### PR TITLE
fix(bridge): core-only nothing-to-send 回合靠正向 silence 证据 settle 成 completed

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -8478,6 +8478,44 @@ function setupWorkerHandlers(
           // never let a projection/store failure crash the worker IPC loop.
           logger.error(`[${t}] Failed to persist turn_terminal for ${msg.turnId.substring(0, 8)}: ${err.message}`);
         }
+        // Async-HTTP settle-on-terminal (core-only completion bug #70): a turn
+        // the worker's bridge gate suppressed as GENUINE SILENCE (the model
+        // terminated with a bare nothing-to-send sentinel, no `botmux send`)
+        // emits turn_terminal but NO final_output, so the async-trigger result
+        // would stay `pending` and the poller would hang `running` until timeout.
+        // Settle it here with EMPTY content — nothing-to-send is a legitimate
+        // completed-with-empty-output for an HTTP task.
+        //
+        // POSITIVE EVIDENCE ONLY: we settle solely on the worker's explicit
+        // `outputDisposition === 'nothing_to_send'` flag, never on a bare
+        // `completed`. A bare completed terminal is NOT proof of silence — the
+        // RPC-hydration timeout path (worker.ts hydrateCompletedRpcTurn) emits
+        // `completed` with no final_output after fs-lag while the real answer is
+        // still materializing; settling that empty would mask a lost reply.
+        // Guarded further so it never double-settles a final_output-completed
+        // turn (pending-only), never touches a managed VC-meeting receiver, and
+        // only affects this bot's own pending async result. Feishu turns have no
+        // asyncTriggerResults entry, so their silent-turn behavior is unchanged.
+        if (msg.status === 'completed'
+          && msg.outputDisposition === 'nothing_to_send'
+          && !ds.session.vcMeetingReceiver) {
+          const pendingAsync = ds.asyncTriggerResults?.get(msg.turnId);
+          if (pendingAsync && pendingAsync.status === 'pending') {
+            const completedAt = Date.now();
+            pendingAsync.status = 'completed';
+            pendingAsync.content = '';
+            pendingAsync.completedAt = completedAt;
+            try {
+              asyncTriggerStore.recordCompleted(ds.session.sessionId, msg.turnId, '', completedAt, ds.larkAppId);
+            } catch (err: any) {
+              logger.error(`[${t}] Failed to persist async terminal-settle for ${msg.turnId.substring(0, 8)}: ${err.message}`);
+            }
+            // Cleared like the final_output path so worker-exit convergence does
+            // not retro-fail this now-completed turn.
+            if (ds.idempotentAsyncTurn?.triggerId === msg.turnId) ds.idempotentAsyncTurn = undefined;
+            logger.info(`[${t}] Settled async HTTP turn ${msg.turnId.substring(0, 8)} completed (empty output; nothing-to-send)`);
+          }
+        }
         if (msg.turnId.startsWith('mlrp_turn_') && msg.status !== 'completed') {
           markMessageListenerRunPreviewFailed(msg.turnId, {
             sessionId: msg.sessionId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1116,6 +1116,15 @@ export type WorkerToDaemon =
        *  message was posted (silent/suppressed turns also complete). */
       status: 'completed' | 'failed' | 'cancelled' | 'ambiguous';
       errorCode?: string;
+      /** Positive silence evidence. Only set to 'nothing_to_send' when the
+       *  worker's bridge gate deliberately suppressed this turn as genuine
+       *  silence (the model terminated with a bare nothing-to-send sentinel and
+       *  no `botmux send`). It is the ONLY signal a durable/async caller may use
+       *  to settle a turn as completed-with-empty-output. Absent on every other
+       *  `completed` terminal — including the RPC-hydration timeout path, which
+       *  emits `completed` with no final_output after fs-lag and must NOT be
+       *  read as silence (that would mask a real, still-arriving answer). */
+      outputDisposition?: 'nothing_to_send';
     }
   | { type: 'adopt_preamble'; userText: string; assistantText: string; turnId?: string }
   | { type: 'deferred_topic_materialized'; sessionId: string; turnId: string; rootMessageId: string }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,7 +43,7 @@ import { readProcessStartIdentity } from './core/session-marker.js';
 import { roleLibraryRoot, roleLibrarySubtree } from './core/role-library.js';
 import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
-import { bridgePostText, shouldEmitEmptyCompletedBridgeFallback, shouldEmitFailedBridgeFallback, shouldSuppressBridgeEmit, stripTrailingBridgeSentinelLine, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
+import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldEmitFailedBridgeFallback, shouldSuppressBridgeEmit, stripTrailingBridgeSentinelLine, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { buildSubmitMessagePreview } from './services/submit-notification.js';
 import {
   decideHardTimeoutAction,
@@ -5047,6 +5047,10 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
   const remainingPending = bridgeQueue.peek();
   const nextPendingMarkTimeMs = remainingPending.length > 0 ? remainingPending[0].markTimeMs : undefined;
   const cache = new Map<string, ReturnType<typeof drainTranscript>>();
+  // Turns suppressed as GENUINE SILENCE — see emitReadyCodexTurns for the full
+  // rationale. Tracked by object identity across this function's two loops so
+  // the terminal can carry positive silence evidence for a durable/async caller.
+  const nothingToSendTurns = new Set<(typeof ready)[number]>();
   for (let i = 0; i < ready.length; i++) {
     const turn = ready[i];
     const nextBoundaryMs = (i + 1 < ready.length ? ready[i + 1].markTimeMs : nextPendingMarkTimeMs);
@@ -5079,6 +5083,11 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
     if (shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
       const reason = turn.isLocal ? 'local-typed' : 'model called botmux send within window';
       log(`Bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (${reason})`);
+      // Positive silence evidence for the terminal — only a bare nothing-to-send
+      // sentinel (no prose, no send), never "already sent" / local-typed.
+      if (!adoptMode && isBridgeNothingToSendFinal(assistantText)) {
+        nothingToSendTurns.add(turn);
+      }
       notifyExplicitReplyObserved(
         turn.turnId,
         explicitReplyMarkerForTurnWindow(gateInput, nextBoundaryMs, markers, adoptMode),
@@ -5149,7 +5158,7 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
   // after the model used `botmux send`. Completion is not optional. Emit it
   // only after all corresponding final_output IPC messages have been queued so
   // the daemon observes a stable per-turn ordering.
-  for (const turn of ready) emitTurnTerminal(turn.turnId, 'completed', undefined, turn.dispatchAttempt);
+  for (const turn of ready) emitTurnTerminal(turn.turnId, 'completed', undefined, turn.dispatchAttempt, nothingToSendTurns.has(turn) ? 'nothing_to_send' : undefined);
 }
 
 /** Drain `path` from `fromOffset` and feed the events to the bridge queue
@@ -6441,6 +6450,14 @@ function drainReliableTerminalBeforeInterrupt(): void {
 function emitReadyCodexTurns(): void {
   const ready = codexBridgeQueue.drainEmittable();
   if (ready.length === 0) return;
+  // Turns suppressed as GENUINE SILENCE (model terminated with a bare
+  // nothing-to-send sentinel, no `botmux send`). Tracked by object identity —
+  // both the emit loop and the terminal loop below iterate this same `ready`
+  // array — so the terminal for such a turn can carry positive silence evidence
+  // (outputDisposition: 'nothing_to_send'). A durable/async caller uses ONLY
+  // that flag to settle completed-with-empty; a bare `completed` terminal (e.g.
+  // the RPC-hydration timeout path) must never be read as silence.
+  const nothingToSendTurns = new Set<(typeof ready)[number]>();
   const adoptMode = lastInitConfig?.adoptMode === true;
   // Adopt mode: model is the user's external Codex, no botmux send to
   // gate against — every assistant turn (Lark-driven OR locally typed)
@@ -6479,6 +6496,16 @@ function emitReadyCodexTurns(): void {
     if (!content) continue;
     if (shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
       log(`Codex bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (gate)`);
+      // Distinguish DELIBERATE SILENCE (bare nothing-to-send sentinel, no prose,
+      // no send) from other suppression reasons (already `botmux send`-ed this
+      // turn, local-typed). Only the former is positive evidence that the model
+      // chose to produce no output — the terminal below carries it so a durable/
+      // async caller can settle completed-with-empty. "Already sent" is NOT
+      // silence: its content went out via final_output/botmux send and the async
+      // result is captured there, so it must not be stamped.
+      if (!adoptMode && isBridgeNothingToSendFinal(turn.finalText)) {
+        nothingToSendTurns.add(turn);
+      }
       notifyExplicitReplyObserved(
         turn.turnId,
         explicitReplyMarkerForTurnWindow(gateInput, nextBoundaryMs, markers, adoptMode),
@@ -6534,6 +6561,7 @@ function emitReadyCodexTurns(): void {
       turn.terminalStatus ?? 'completed',
       turn.terminalErrorCode,
       turn.dispatchAttempt,
+      nothingToSendTurns.has(turn) ? 'nothing_to_send' : undefined,
     );
   }
 }
@@ -15418,6 +15446,7 @@ function emitTurnTerminal(
   status: TurnTerminalStatus,
   errorCode?: string,
   dispatchAttempt?: number,
+  outputDisposition?: 'nothing_to_send',
 ): void {
   if (!sessionId || !turnId) return;
   if (!emittedTurnTerminals.claim(sessionId, turnId, dispatchAttempt)) return;
@@ -15437,6 +15466,7 @@ function emitTurnTerminal(
     status,
     ...(dispatchAttempt !== undefined ? { dispatchAttempt } : {}),
     ...(errorCode ? { errorCode } : {}),
+    ...(outputDisposition ? { outputDisposition } : {}),
   });
   if (terminalReleasesDurableTurn(
     { turnId: currentBotmuxTurnId, dispatchAttempt: currentBotmuxDispatchAttempt },

--- a/test/async-terminal-settle.test.ts
+++ b/test/async-terminal-settle.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Behavioral coverage for the async-HTTP "settle-on-terminal" fix (core-only
+ * completion bug #70).
+ *
+ * A turn the worker's bridge gate suppressed as GENUINE SILENCE (model
+ * terminated with a bare nothing-to-send sentinel, no `botmux send`) emits
+ * `turn_terminal` but NO `final_output`. Without a settle path the async-trigger
+ * result stays `pending` and the HTTP poller hangs `running` until timeout.
+ *
+ * The fix settles such a turn to completed-with-empty-output — but ONLY on the
+ * worker's explicit positive evidence `outputDisposition: 'nothing_to_send'`,
+ * never on a bare `completed` terminal (the RPC-hydration timeout path emits a
+ * bare `completed` with no final_output while the real answer is still
+ * materializing; settling that empty would mask a lost reply).
+ *
+ * These drive the real worker-pool IPC handler via __testOnly_setupWorkerHandlers
+ * + a fake worker (mirrors bridge-final-output-retry.test.ts) so the guards are
+ * exercised, not just pinned in source.
+ *
+ * Run:  pnpm vitest run test/async-terminal-settle.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../src/im/lark/client.js', () => ({
+  updateMessage: vi.fn(async () => {}),
+  addReaction: vi.fn(async () => 'reaction_id'),
+  removeReaction: vi.fn(async () => {}),
+  sendUserMessage: vi.fn(async () => {}),
+  deleteMessage: vi.fn(async () => {}),
+  getChatInfo: vi.fn(),
+  MessageWithdrawnError: class MessageWithdrawnError extends Error {
+    constructor(id: string) { super(`withdrawn: ${id}`); this.name = 'MessageWithdrawnError'; }
+  },
+}));
+
+vi.mock('../src/im/lark/card-builder.js', () => ({
+  buildStreamingCard: vi.fn(() => '{}'),
+  buildSessionCard: vi.fn(() => '{}'),
+  buildTuiPromptCard: vi.fn(() => '{}'),
+  buildTuiPromptResolvedCard: vi.fn(() => '{}'),
+  getCliDisplayName: vi.fn(() => 'Codex'),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'codex' },
+    resolvedAllowedUsers: [],
+    botOpenId: 'ou_bot',
+    botName: 'TestBot',
+  })),
+  getAllBots: vi.fn(() => []),
+  getBotClient: vi.fn(),
+  getBotBrand: vi.fn(() => undefined),
+  resolveBrandLabel: vi.fn(() => undefined),
+  resolveUsageDisplay: vi.fn(() => 'footer'),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    web: { externalHost: 'localhost' },
+    session: { dataDir: '/tmp/test-sessions' },
+    daemon: { backendType: 'pty', cliId: 'codex' },
+  },
+}));
+
+vi.mock('../src/services/session-store.js', () => ({
+  registerSessionBridgeSendMarkerCleanupFence: vi.fn(),
+  cleanupSessionBridgeSendMarkers: vi.fn(),
+  cleanupSessionBridgeSendMarkersNow: vi.fn(),
+  closeSession: vi.fn(),
+  updateSession: vi.fn(),
+  createSession: vi.fn(),
+  updateSessionPid: vi.fn(),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: class { constructor() {} },
+  WSClient: class { start() {} },
+  EventDispatcher: class { register() {} },
+  LoggerLevel: { info: 2 },
+}));
+
+// Spy the durable store so we assert persistence intent without touching disk.
+const recordCompletedMock = vi.fn();
+vi.mock('../src/services/async-trigger-store.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/services/async-trigger-store.js')>();
+  return { ...actual, recordCompleted: (...args: any[]) => recordCompletedMock(...args) };
+});
+
+import { initWorkerPool, __testOnly_setupWorkerHandlers } from '../src/core/worker-pool.js';
+import type { DaemonSession } from '../src/core/types.js';
+import type { WorkerToDaemon } from '../src/types.js';
+import { EventEmitter } from 'node:events';
+
+function makeDs(): DaemonSession {
+  const fakeWorker = new EventEmitter() as any;
+  fakeWorker.killed = false;
+  fakeWorker.send = vi.fn();
+  fakeWorker.kill = vi.fn();
+  fakeWorker.pid = 99999;
+  fakeWorker.stdout = new EventEmitter();
+  fakeWorker.stderr = new EventEmitter();
+  const ds: DaemonSession = {
+    session: {
+      sessionId: 'sid-async-settle',
+      rootMessageId: 'om_root',
+      chatId: 'oc_chat',
+      title: 'fixture',
+      status: 'active' as any,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      pid: null,
+      chatType: 'group',
+      cliId: 'codex',
+    },
+    worker: fakeWorker,
+    workerPort: 0,
+    workerToken: 'tok',
+    larkAppId: 'app_test',
+    chatId: 'oc_chat',
+    chatType: 'group',
+    spawnedAt: Date.now(),
+    cliVersion: '1',
+    lastMessageAt: Date.now(),
+    hasHistory: false,
+  } as any;
+  return ds;
+}
+
+function terminalMsg(
+  turnId: string,
+  extra: Partial<Extract<WorkerToDaemon, { type: 'turn_terminal' }>> = {},
+): Extract<WorkerToDaemon, { type: 'turn_terminal' }> {
+  return {
+    type: 'turn_terminal',
+    sessionId: 'sid-async-settle',
+    turnId,
+    status: 'completed',
+    ...extra,
+  };
+}
+
+describe('async-HTTP settle-on-terminal (daemon turn_terminal handler)', () => {
+  beforeEach(() => {
+    recordCompletedMock.mockClear();
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    } as any);
+  });
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('settles a pending async result to completed+empty on a nothing_to_send terminal', async () => {
+    const ds = makeDs();
+    ds.asyncTriggerResults = new Map([['turn-silent', { status: 'pending' } as any]]);
+    ds.idempotentAsyncTurn = { triggerId: 'turn-silent' } as any;
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', terminalMsg('turn-silent', { outputDisposition: 'nothing_to_send' }));
+
+    await vi.waitFor(() => {
+      const r = ds.asyncTriggerResults!.get('turn-silent')!;
+      expect(r.status).toBe('completed');
+      expect(r.content).toBe('');
+    });
+    // Durable persistence with EMPTY content.
+    expect(recordCompletedMock).toHaveBeenCalledWith(
+      'sid-async-settle', 'turn-silent', '', expect.any(Number), 'app_test',
+    );
+    // Worker-exit convergence stamp cleared so a later graceful exit can't retro-fail it.
+    expect(ds.idempotentAsyncTurn).toBeUndefined();
+  });
+
+  it('does NOT settle on a bare completed terminal (no disposition) — the RPC-hydration-timeout case', async () => {
+    const ds = makeDs();
+    ds.asyncTriggerResults = new Map([['turn-bare', { status: 'pending' } as any]]);
+    ds.idempotentAsyncTurn = { triggerId: 'turn-bare' } as any;
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    // Bare completed: no outputDisposition. A real answer may still be materializing.
+    (ds.worker as any).emit('message', terminalMsg('turn-bare'));
+
+    // Give the async IPC handler a tick to run.
+    await new Promise(r => setTimeout(r, 20));
+    const r = ds.asyncTriggerResults!.get('turn-bare')!;
+    expect(r.status).toBe('pending');          // untouched — must not fabricate empty output
+    expect(recordCompletedMock).not.toHaveBeenCalled();
+    expect(ds.idempotentAsyncTurn).toEqual({ triggerId: 'turn-bare' });
+  });
+
+  it('does NOT settle on a failed terminal even if flagged (guard is status===completed)', async () => {
+    const ds = makeDs();
+    ds.asyncTriggerResults = new Map([['turn-failed', { status: 'pending' } as any]]);
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', terminalMsg('turn-failed', {
+      status: 'failed', errorCode: 'boom', outputDisposition: 'nothing_to_send',
+    }));
+
+    await new Promise(r => setTimeout(r, 20));
+    expect(ds.asyncTriggerResults!.get('turn-failed')!.status).toBe('pending');
+    expect(recordCompletedMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT clobber a final_output-completed result (pending-only guard)', async () => {
+    const ds = makeDs();
+    ds.asyncTriggerResults = new Map([[
+      'turn-done', { status: 'completed', content: 'real answer' } as any,
+    ]]);
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', terminalMsg('turn-done', { outputDisposition: 'nothing_to_send' }));
+
+    await new Promise(r => setTimeout(r, 20));
+    const r = ds.asyncTriggerResults!.get('turn-done')!;
+    expect(r.status).toBe('completed');
+    expect(r.content).toBe('real answer');       // NOT overwritten with ''
+    expect(recordCompletedMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for a Feishu turn (no asyncTriggerResults entry)', async () => {
+    const ds = makeDs();
+    ds.asyncTriggerResults = new Map();          // Feishu turn: no async entry
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', terminalMsg('turn-feishu', { outputDisposition: 'nothing_to_send' }));
+
+    await new Promise(r => setTimeout(r, 20));
+    expect(ds.asyncTriggerResults!.has('turn-feishu')).toBe(false);
+    expect(recordCompletedMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 问题（#70）
core-only（HTTP async trigger）模式下，模型「本轮无需回复」的沉默回合会以 `BOTMUX_NOTHING_TO_SEND` 哨兵结尾，被 bridge gate 正确抑制——只发 `turn_terminal`、不发 `final_output`。async-trigger 结果因此永远停在 `pending`，HTTP 轮询把这轮一直显示成 `running` 直到超时。codex / claude-code 两种 core-only CLI 都中招。

## 修法：正向 silence 证据，绝不靠「没看到 final_output」推断
- **worker 侧**：仅当 gate 因 **GENUINE SILENCE**（裸哨兵、无 prose、无 `botmux send`，即 `isBridgeNothingToSendFinal` 命中）抑制该轮时，给 `turn_terminal` 带上 `outputDisposition: 'nothing_to_send'` 正向证据。`emitReadyCodexTurns`（结构化 bridge）与 `emitReadyTurns`（transcript/PTY bridge，claude-code 走这条）两条路径都按对象身份跟踪 silence 回合并透传，跨 CLI 一致。「已 `botmux send` / local-typed」的抑制**不算** silence，不打标。
- **daemon 侧**：`turn_terminal` handler 仅凭 `outputDisposition === 'nothing_to_send'` 把仍 `pending` 的 async 结果 settle 成 `completed` + 空正文；**绝不**凭裸 `completed` settle。
  - 关键反例（复审指出）：RPC-hydration 超时路径 `hydrateCompletedRpcTurn`（约 11.6s fs 滞后后）会发一个**无 final_output 的裸 completed**，此时真实答案可能还在途——凭裸 completed settle 会把真答案误判成「空完成」。裸 completed 保持不 settle，交给轮询超时 / worker-exit convergence 处理。
- **守卫**：pending-only（不覆盖 final_output 已完成的真正文）、非 VC-meeting receiver、只动本 bot 自己的 async 结果；飞书回合无 `asyncTriggerResults` 条目，静默行为不变。清 `idempotentAsyncTurn` 戳，避免后续 graceful exit 回溯 fail。

## 撤销首版的 legacy 哨兵移除
首版把「去掉 legacy `BOTMUX_NO_REPLY` 识别」一并落进来，本次**已撤销**、`bridge-fallback-gate` 维持 master 原状。原因：master 故意保留 legacy token 兜底 **restore 的旧会话**——持久后端（tmux/zellij）会话跨二进制升级时，已运行 CLI 的 conversation context **不会**随二进制同步升级，仍是改名前（#769，2026-08-06 才落）的旧哨兵。去掉识别会把字面 token 泄漏到飞书，是回归。哨兵话术收紧/更名是独立议题，不在本 PR。

## 影响面
- **跨 CLI**：两条 bridge 发射路径都改（codex 结构化 + claude-code transcript），共用的 `emitTurnTerminal` 新增一个可选形参，其余 ~16 个调用点行为不变。
- **跨会话类型**：只在 async-trigger（core-only HTTP）回合有新行为；飞书话题会话、adopt、VC-meeting receiver 均被守卫排除，行为不变。

## 验证
- `pnpm build` 绿
- 新增 `test/async-terminal-settle.test.ts`（5 例行为测试，走真 worker-pool IPC handler + fake worker，替换首版源锁测试）：`nothing_to_send` 正常 settle；**裸 completed 不 settle**（RPC-hydration 反例）；`failed` 不 settle；不覆盖 final_output 已完成结果；飞书回合无条目时 no-op。
- 定向回归 `async-terminal-settle` / `bridge-fallback-gate`(52) / `bridge-final-output-retry`(66) / `codex-bridge-queue`(73) 共 **196/196 绿**。
- 注：`worker-argv-reaction-status.integration`（Pi 视口 reaction-status PTY 计时）2 例在本机 CPU 竞争下 flaky——**已核对 clean master 同样 2 失败**，与本改动无关（改动面与 Pi 视口/idle-detector 完全不相交）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
