### PR TITLE
fix(worker): 隔离 workflow 环境标记避免普通会话假忙

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,7 +96,7 @@ import { hasProtectedSessionMutationOwnership } from './core/session-mutation-gu
 import type { BackendType, PersistentBackendTarget, SessionProbe } from './adapters/backend/types.js';
 import { logger } from './utils/logger.js';
 import { withFileLock, withFileLockSync } from './utils/file-lock.js';
-import { scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv } from './utils/child-env.js';
+import { scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv, scrubWorkflowWorkerEnv } from './utils/child-env.js';
 import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
@@ -364,6 +364,10 @@ function pm2Env(home: string = PM2_HOME): NodeJS.ProcessEnv {
   // they eventually flip transcript saving off fleet-wide once the tmux server
   // respawns from a poisoned daemon (see CLAUDE_SESSION_MARKER_ENV_KEYS).
   scrubClaudeSessionMarkerEnv(env);
+  // Workflow/goal markers identify one short-lived node worker. Persisting
+  // them in PM2 would make every daemon — and then every ordinary chat worker
+  // it forks — run in workflow mode after a restart initiated from that node.
+  scrubWorkflowWorkerEnv(env);
   return env;
 }
 

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -44,6 +44,7 @@ import {
   type GlobalInstallPlan,
 } from '../utils/global-install.js';
 import { withFileLockSync } from '../utils/file-lock.js';
+import { scrubWorkflowWorkerEnv } from '../utils/child-env.js';
 
 export interface MaintenanceState {
   /** Local date the auto-update run was last handled (fired or skipped). */
@@ -245,6 +246,10 @@ export function buildRestartLauncher(
 
 export function detachedRestartEnv(inheritedEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const env = { ...inheritedEnv };
+  // Defense in depth for dashboard/daemon processes resurrected from a stale
+  // PM2 snapshot. `botmux restart` checks workflow mode before pm2Env(), so it
+  // must not inherit node-worker identity even if a host boot scrub regresses.
+  scrubWorkflowWorkerEnv(env);
   // The dashboard/daemon snapshot may outlive a ~/.botmux/.env edit. Let the
   // fresh CLI reload these settings from the file.
   //

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -69,6 +69,7 @@ import { withBotTurnMutation } from './bot-turn-mutation-gate.js';
 import { getBot, getAllBots, loadBotConfigs, resolveBrandLabel, getLoadedConfigPath, resolveUsageDisplay } from '../bot-registry.js';
 import { RestartCoordinator, type RestartObserver } from './restart-coordinator.js';
 import { runtimeBuildIdentity } from '../utils/runtime-build-id.js';
+import { scrubWorkflowWorkerEnv } from '../utils/child-env.js';
 
 /** A random id minted once per daemon process (this lifetime). Stamped onto
  *  isolated persistent panes so a suspend→resume reattach (same id) is
@@ -394,6 +395,10 @@ const WORKER_REDACTED_ENV_KEYS = ['GITHUB_TOKEN', 'GH_TOKEN', 'BOTMUX_PM2_GRACEF
 function workerForkEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...base };
   for (const key of WORKER_REDACTED_ENV_KEYS) delete env[key];
+  // Defense in depth for a daemon started from a contaminated PM2 snapshot.
+  // Genuine workflow workers bypass this pool and receive their markers from
+  // workflows/v3/ephemeral-pool.ts.
+  scrubWorkflowWorkerEnv(env);
   return env;
 }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -239,6 +239,14 @@ import {
   parseDashboardSummaryRows,
 } from './dashboard/dashboard-summary.js';
 import { createDashboardSummaryEndpoint } from './dashboard/dashboard-summary-endpoint.js';
+import { scrubWorkflowWorkerEnv } from './utils/child-env.js';
+
+// The dashboard is an independent long-lived PM2 app and can be resurrected
+// from a stale dump.pm2 without passing through cli.ts pm2Env(). Its start/stop
+// and detached-restart children inherit process.env, so a leaked workflow
+// marker would make those CLI commands fail at the workflow safety gate before
+// they can reach their own cleanup boundary.
+scrubWorkflowWorkerEnv(process.env);
 
 const SECRET_PATH = dashboardSecretPath();
 const TOKEN_PATH = join(homedir(), '.botmux', '.dashboard-token');

--- a/src/index-daemon.ts
+++ b/src/index-daemon.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { existsSync } from 'node:fs';
 import { installStdioEpipeGuard } from './utils/stdio-epipe-guard.js';
-import { scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv } from './utils/child-env.js';
+import { scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv, scrubWorkflowWorkerEnv } from './utils/child-env.js';
 
 // Under pm2 the daemon's stdout/stderr are pipes to the God daemon. A broken
 // pipe (log streaming detaches, God daemon restart) would otherwise emit an
@@ -41,6 +41,11 @@ scrubSessionCliHomeEnv(process.env);
 // as a nested child session (transcript saving OFF → --resume continuity
 // silently lost). See CLAUDE_SESSION_MARKER_ENV_KEYS.
 scrubClaudeSessionMarkerEnv(process.env);
+// A stale PM2 dump can bypass cli.ts pm2Env(). Daemons are workflow hosts,
+// never workflow workers; remove node-scoped identity before importing daemon
+// code or forking ordinary chat workers. The ephemeral pool re-adds the exact
+// markers only to genuine workflow workers.
+scrubWorkflowWorkerEnv(process.env);
 
 async function main() {
   // Resolve global UI locale from ~/.botmux/config.json BEFORE loading

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -26,6 +26,38 @@ export const CLAUDE_SESSION_MARKER_ENV_KEYS = [
   'CLAUDE_PID',
 ] as const;
 
+/**
+ * Runtime markers that belong only to a v3 workflow/goal worker.
+ *
+ * A workflow worker may invoke `botmux restart`; PM2 persists that caller env
+ * into the long-lived daemons. If these keys survive, every ordinary worker
+ * forked by those daemons mistakes itself for a workflow worker: it skips
+ * screen/status updates and goal-only CLI restrictions leak into chat
+ * sessions. Keep the complete file-backed goal contract together with the
+ * workflow identity fields so a partial scrub cannot leave a normal worker in
+ * a hybrid mode.
+ *
+ * Do not apply this scrub at worker.ts boot: real workflow workers share that
+ * entry point and receive these keys explicitly from the ephemeral pool.
+ */
+export const WORKFLOW_WORKER_ENV_KEYS = [
+  'BOTMUX_WORKFLOW',
+  'BOTMUX_WORKFLOW_PTY_LOG_PATH',
+  'BOTMUX_WORKFLOW_RUN_ID',
+  'BOTMUX_WORKFLOW_NODE_ID',
+  'BOTMUX_GOAL_PATH',
+  'BOTMUX_GOAL_INPUTS_PATH',
+  'BOTMUX_GOAL_OUTPUT_DIR',
+  'BOTMUX_GOAL_MANIFEST_PATH',
+  'BOTMUX_GOAL_ATTEMPT_DIR',
+  'BOTMUX_V3_GOAL',
+] as const;
+
+/** Remove workflow-only identity from a non-workflow process boundary. */
+export function scrubWorkflowWorkerEnv(env: NodeJS.ProcessEnv): void {
+  for (const key of WORKFLOW_WORKER_ENV_KEYS) delete env[key];
+}
+
 /** Boundary-only companion to the markers. A CLAUDE_EFFORT inherited THROUGH
  *  pm2 → daemon → worker is indistinguishable from the issuing Claude
  *  session's own override and would silently pin that session's

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -13,6 +13,7 @@ import {
   WORKFLOW_WORKER_ENV_KEYS,
 } from '../src/utils/child-env.js';
 import { PM2_GRACEFUL_EXIT_CODE_ENV } from '../src/pm2-graceful-exit.js';
+import { GOAL_ENV } from '../src/workflows/v3/contract.js';
 
 describe('applySessionOwnerEnv()', () => {
   it('injects both the public contract and legacy owner names', () => {
@@ -225,6 +226,12 @@ describe('scrubWorkflowWorkerEnv()', () => {
     expect(env.BOTMUX_WORKFLOW_RUNS_DIR).toBe('/shared/workflow-runs');
     expect(env.KEEP).toBe('v');
   });
+
+  it('covers the canonical goal contract without drifting', () => {
+    for (const key of Object.values(GOAL_ENV)) {
+      expect(WORKFLOW_WORKER_ENV_KEYS).toContain(key);
+    }
+  });
 });
 
 describe('session CLI home scrub call sites', () => {
@@ -269,11 +276,16 @@ describe('session CLI home scrub call sites', () => {
     expect(worker).toContain('applySessionOwnerEnv(mergedEnv, cfg.ownerOpenId)');
   });
 
-  it('pm2 and daemon boot scrub workflow-worker identity without scrubbing real worker boot', () => {
+  it('pm2, daemon, and dashboard boot scrub workflow identity without scrubbing real worker boot', () => {
     const cli = read('cli.ts');
     const fn = cli.slice(cli.indexOf('function pm2Env('));
     expect(fn.slice(0, fn.indexOf('\n}'))).toContain('scrubWorkflowWorkerEnv(');
     expect(read('index-daemon.ts')).toContain('scrubWorkflowWorkerEnv(process.env)');
+    const dashboard = read('dashboard.ts');
+    const scrubAt = dashboard.indexOf('scrubWorkflowWorkerEnv(process.env)');
+    expect(scrubAt).toBeGreaterThan(-1);
+    expect(scrubAt).toBeLessThan(dashboard.indexOf('function spawnStartBotLive('));
+    expect(scrubAt).toBeLessThan(dashboard.indexOf('function spawnStopBotLive('));
     expect(read('worker.ts')).not.toContain('scrubWorkflowWorkerEnv(process.env)');
   });
 

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -8,7 +8,9 @@ import {
   REDACTED_CHILD_ENV_KEYS,
   scrubClaudeSessionMarkerEnv,
   scrubSessionCliHomeEnv,
+  scrubWorkflowWorkerEnv,
   SESSION_CLI_HOME_ENV_KEYS,
+  WORKFLOW_WORKER_ENV_KEYS,
 } from '../src/utils/child-env.js';
 import { PM2_GRACEFUL_EXIT_CODE_ENV } from '../src/pm2-graceful-exit.js';
 
@@ -206,6 +208,25 @@ describe('scrubClaudeSessionMarkerEnv()', () => {
   });
 });
 
+describe('scrubWorkflowWorkerEnv()', () => {
+  it('removes the complete workflow and goal identity in place', () => {
+    const env: NodeJS.ProcessEnv = {
+      ...Object.fromEntries(WORKFLOW_WORKER_ENV_KEYS.map((key) => [key, 'leaked'])),
+      BOTMUX_WORKFLOW_RUNS_DIR: '/shared/workflow-runs',
+      KEEP: 'v',
+    };
+
+    scrubWorkflowWorkerEnv(env);
+
+    for (const key of WORKFLOW_WORKER_ENV_KEYS) {
+      expect(key in env, key).toBe(false);
+    }
+    // Global workflow storage configuration is not a node-worker identity.
+    expect(env.BOTMUX_WORKFLOW_RUNS_DIR).toBe('/shared/workflow-runs');
+    expect(env.KEEP).toBe('v');
+  });
+});
+
 describe('session CLI home scrub call sites', () => {
   // The scrub only works if every process boundary actually invokes it. These
   // source-level pins keep a refactor from silently dropping a boundary:
@@ -246,6 +267,14 @@ describe('session CLI home scrub call sites', () => {
     expect(worker).toContain('applySessionOwnerEnv(childEnv, cfg.ownerOpenId)');
     expect(worker).toContain('applySessionOwnerEnv(engineEnv, cfg.ownerOpenId)');
     expect(worker).toContain('applySessionOwnerEnv(mergedEnv, cfg.ownerOpenId)');
+  });
+
+  it('pm2 and daemon boot scrub workflow-worker identity without scrubbing real worker boot', () => {
+    const cli = read('cli.ts');
+    const fn = cli.slice(cli.indexOf('function pm2Env('));
+    expect(fn.slice(0, fn.indexOf('\n}'))).toContain('scrubWorkflowWorkerEnv(');
+    expect(read('index-daemon.ts')).toContain('scrubWorkflowWorkerEnv(process.env)');
+    expect(read('worker.ts')).not.toContain('scrubWorkflowWorkerEnv(process.env)');
   });
 
   it('worker-pool strips the PM2 sentinel when forking a worker (source pin)', () => {

--- a/test/maintenance.test.ts
+++ b/test/maintenance.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../src/core/maintenance.js';
 import type { MaintenanceConfig } from '../src/global-config.js';
 import type { RestartIntent } from '../src/services/restart-intent-store.js';
+import { WORKFLOW_WORKER_ENV_KEYS } from '../src/utils/child-env.js';
 
 // 2026-06-07T04:00:00Z === 2026-06-07 12:00 local (Asia/Shanghai)
 const NOON = Date.parse('2026-06-07T04:00:00.000Z');
@@ -205,11 +206,13 @@ describe('detachedRestartEnv', () => {
       // else a detached restart keeps the stale proxy base instead of reloading
       // it from ~/.botmux/.env.
       BOTMUX_PUBLIC_URL: 'http://stale.proxy.example.com',
+      ...Object.fromEntries(WORKFLOW_WORKER_ENV_KEYS.map((key) => [key, 'leaked'])),
       PATH: '/usr/bin',
     };
 
     expect(detachedRestartEnv(inherited)).toEqual({ PATH: '/usr/bin' });
     expect(inherited.WEB_EXTERNAL_HOST).toBe('10.255.64.131');
+    expect(inherited.BOTMUX_WORKFLOW).toBe('leaked');
   });
 });
 

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -1914,6 +1914,25 @@ describe('session.start lifecycle integration', () => {
     vi.unstubAllEnvs();
   });
 
+  it('removes leaked workflow identity from the daemon→worker fork env', () => {
+    vi.stubEnv('BOTMUX_WORKFLOW', '1');
+    vi.stubEnv('BOTMUX_WORKFLOW_RUN_ID', 'run-leaked');
+    vi.stubEnv('BOTMUX_WORKFLOW_NODE_ID', 'node-leaked');
+    vi.stubEnv('BOTMUX_V3_GOAL', '1');
+    vi.stubEnv('BOTMUX_GOAL_ATTEMPT_DIR', '/tmp/leaked-attempt');
+
+    forkWorker(makeDs(), 'hello', false);
+
+    const forkOpts = forkMock.mock.calls.at(-1)?.[2] as { env?: Record<string, string | undefined> } | undefined;
+    expect(forkOpts?.env?.BOTMUX_WORKFLOW).toBeUndefined();
+    expect(forkOpts?.env?.BOTMUX_WORKFLOW_RUN_ID).toBeUndefined();
+    expect(forkOpts?.env?.BOTMUX_WORKFLOW_NODE_ID).toBeUndefined();
+    expect(forkOpts?.env?.BOTMUX_V3_GOAL).toBeUndefined();
+    expect(forkOpts?.env?.BOTMUX_GOAL_ATTEMPT_DIR).toBeUndefined();
+
+    vi.unstubAllEnvs();
+  });
+
   it('re-checks the resident-session cap after spawn and again on an idle edge', async () => {
     const enforceLiveSessionCap = vi.fn();
     initWorkerPool({
@@ -2093,6 +2112,31 @@ describe('session.start lifecycle integration', () => {
     const forkOpts = forkMock.mock.calls.at(-1)?.[2] as { env?: Record<string, string | undefined> } | undefined;
     expect(forkOpts?.env?.GITHUB_TOKEN).toBeUndefined();
     expect(forkOpts?.env?.GH_TOKEN).toBeUndefined();
+
+    vi.unstubAllEnvs();
+  });
+
+  it('removes leaked workflow identity from the daemon→adopt-worker fork env', () => {
+    vi.stubEnv('BOTMUX_WORKFLOW', '1');
+    vi.stubEnv('BOTMUX_WORKFLOW_PTY_LOG_PATH', '/tmp/leaked-pty.log');
+    vi.stubEnv('BOTMUX_V3_GOAL', '1');
+    vi.stubEnv('BOTMUX_GOAL_MANIFEST_PATH', '/tmp/leaked-manifest.json');
+
+    forkAdoptWorker(makeDs({
+      adoptedFrom: {
+        tmuxTarget: 'bmx-deadbeef:0.0',
+        originalCliPid: 23456,
+        sessionId: 'codex-session',
+        cliId: 'codex',
+        cwd: '/repo',
+      },
+    }));
+
+    const forkOpts = forkMock.mock.calls.at(-1)?.[2] as { env?: Record<string, string | undefined> } | undefined;
+    expect(forkOpts?.env?.BOTMUX_WORKFLOW).toBeUndefined();
+    expect(forkOpts?.env?.BOTMUX_WORKFLOW_PTY_LOG_PATH).toBeUndefined();
+    expect(forkOpts?.env?.BOTMUX_V3_GOAL).toBeUndefined();
+    expect(forkOpts?.env?.BOTMUX_GOAL_MANIFEST_PATH).toBeUndefined();
 
     vi.unstubAllEnvs();
   });


### PR DESCRIPTION
## 问题

当 workflow/goal worker 内执行 `botmux restart` 时，PM2 会持久化调用方环境。`BOTMUX_WORKFLOW` 等短生命周期标记可能因此进入 daemon 和独立的 Dashboard PM2 app，并继续传给普通聊天 worker或 Dashboard 启动的管理子命令。

普通 worker 误进入 workflow 模式后会跳过 screen/status 更新：CLI 已恢复到输入提示符，但 daemon 的 `lastScreenStatus` 仍可能停在 `starting`。依赖该状态的 `/relay` 会把实际空闲会话判断为运行中，拒绝迁移。

受污染的 Dashboard 还会把标记传给 `start-bot`、`stop-bot` 和 detached `restart` 子 CLI。这些命令在进入 PM2 环境清理前就会被 workflow 顶层安全门拒绝，导致 Dashboard 无法启动、停止或通过重启自愈。

## 现场复现

同一台主机已在两类普通会话上复现：

- Claude Code 会话已上报 prompt idle，daemon 仍保持 `starting`，`/relay` 显示会话运行中。
- 普通 Codex 会话在日志明确出现 `Prompt detected (idle)` 后，daemon API 仍返回 `status=starting`；对应 PM2 daemon 环境存在 `BOTMUX_WORKFLOW=1`。

主机上的 PM2 app 均观察到同一 workflow 标记，说明污染可跨 daemon 和 Dashboard 扩散，不局限于某个 CLI adapter 或单条会话。

## 修复

- 在 CLI 构造 PM2 环境时剔除 workflow/goal worker 专用标记，阻止新污染写入 PM2。
- daemon 与 Dashboard 启动时再次剔除，兼容已持久化的旧 PM2 快照。
- 普通 worker 与 adopt worker fork 前做防御性剔除。
- detached restart 构造子进程环境时再次剔除，避免 Dashboard/daemon 启动清理发生回归后失去自愈能力。
- 不在共享 `worker.ts` 入口统一清理；真实 ephemeral workflow worker 仍由 ephemeral pool 显式注入这些标记。
- 保留全局配置 `BOTMUX_WORKFLOW_RUNS_DIR`，只清理节点 worker 身份与 goal 文件合约变量。
- 加入与 `GOAL_ENV` 的漂移测试，新增 goal 合约键时会提示同步清理清单。

## 验证

基于最新 `origin/master` rebase 后执行：

- `pnpm vitest run --project unit test/child-env.test.ts test/maintenance.test.ts test/session-lifecycle-start.test.ts test/workflow-v3-ephemeral-pool.test.ts test/relay-picker.test.ts`
  - 5 个文件通过
  - 174 个测试通过
- `pnpm build` 通过
- `git diff --check` 通过

## 存量限制

修复前已经携带污染环境并持续运行的 Herdr CLI 在 daemon reattach 时不会被重新注入环境。更新并重启 daemon 后，worker 状态更新和 `/relay` 主症状会恢复；但该存量 Herdr CLI 内的 `botmux send/ask` 安全门可能持续到会话执行一次 `/restart` 或冷启动。新启动的会话不受此限制。

## 未验证

- 未切换或重启 live daemon，未做安装修复 build 后的真实飞书 `/relay` 端到端验证。
- 早先全量 unit 曾在同机并发运行多个其他 worktree 全量任务时出现 6 个非本改动文件的超时/终端宽度失败，且测试进程未正常收尾；本 PR 直接相关的 focused 回归已在最新 master 上单独稳定通过。
