### PR TITLE
fix(pi): 修复结构化终态早于屏幕收尾时卡片误显空闲

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13635,8 +13635,19 @@ async function spawnCli(
           log('Screen settle barrier degraded after bounded retries; finalizing from the last successful snapshot');
         }
       }
-      if (evidenceSource === 'screen' && idleBackend
-        && deferPromptReadyWhileBusy(`${cliName()} screen-idle`, idleBackend)) return;
+      // Pi's transcript final (assistant_final) is persisted asynchronously
+      // from the TUI clearing its `Working...` busy marker — either order
+      // occurs. An external idle landing while the authoritative viewport
+      // still shows busy must defer exactly like a screen idle, or the card
+      // flips to 等待输入 mid-turn. Scoped to Pi: Grok/Codex own their idle
+      // via reliableTurnTerminal / lifecycle blocking, and their busy markers
+      // legitimately lag behind the transcript final. deferPromptReadyWhileBusy
+      // itself fail-opens on non-authoritative screens (ZMX), so a stale
+      // `Working...` in ZMX history can never block a structured terminal.
+      const busyGuardedIdle = evidenceSource === 'screen'
+        || (evidenceSource === 'external' && structuredBridgeIsPi());
+      if (busyGuardedIdle && idleBackend
+        && deferPromptReadyWhileBusy(`${cliName()} ${evidenceSource}-idle`, idleBackend)) return;
       drainBridgesThenMarkReady(evidenceSource);
     });
   }

--- a/test/raw-input-followup-atomicity.test.ts
+++ b/test/raw-input-followup-atomicity.test.ts
@@ -483,7 +483,7 @@ describe('late bare-shell launch recovery', () => {
   });
 
   it('generation-fences PTY data before it can feed the active idle detector', () => {
-    const wiring = caseRegion(workerSrc, 'const observedBackend = backend;', 2300);
+    const wiring = caseRegion(workerSrc, 'const observedBackend = backend;', 3400);
     const onData = wiring.indexOf('observedBackend.onData((data) =>');
     const fence = wiring.indexOf('if (backend !== observedBackend) return;', onData);
     const feed = wiring.indexOf('onPtyData(data)', fence);

--- a/test/worker-argv-reaction-status.integration.test.ts
+++ b/test/worker-argv-reaction-status.integration.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -54,6 +54,34 @@ async function waitForScreenUpdates(
   throw new Error(
     `timed out waiting for ${count} screen updates: ${JSON.stringify(messages)}\n${logs.join('')}`,
   );
+}
+
+async function waitForLog(child: ChildProcess, logs: string[], needle: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (logs.some(entry => entry.includes(needle))) return;
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`worker exited before log "${needle}"\n${logs.join('')}`);
+    }
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 25));
+  }
+  throw new Error(`timed out waiting for log "${needle}"\n${logs.join('')}`);
+}
+
+async function waitForPromptReady(
+  child: ChildProcess,
+  messages: WorkerToDaemon[],
+  logs: string[],
+): Promise<void> {
+  const deadline = Date.now() + 12_000;
+  while (Date.now() < deadline) {
+    if (messages.some(message => message.type === 'prompt_ready')) return;
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`worker exited before prompt_ready\n${logs.join('')}`);
+    }
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 25));
+  }
+  throw new Error(`timed out waiting for prompt_ready: ${JSON.stringify(messages)}\n${logs.join('')}`);
 }
 
 describe('worker argv reaction status', () => {
@@ -115,6 +143,112 @@ setInterval(() => {}, 1_000);
     expect(updates[0]?.status).toBe('working');
     expect(updates.at(-1)?.status).toBe('idle');
   }, 15_000);
+
+  it('defers a Pi transcript final that lands while the viewport still shows Working...', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-external-busy-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+
+    // Pre-create the Pi session transcript so the bridge attaches (fresh-empty)
+    // during spawn; the terminal assistant record is appended mid-turn below.
+    const cliSessionId = 'deadbeef-1234-4678-9abc-def012345678';
+    const piSessionsDir = join(root, '.pi', 'agent', 'sessions', dataDir.replace(/\//g, '--'));
+    mkdirSync(piSessionsDir, { recursive: true });
+    const transcriptPath = join(piSessionsDir, `20260810120000_${cliSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '');
+
+    const fakePi = join(root, 'fake-pi');
+    // The marker stays up long enough for the worst-case ingest path: even if
+    // fs.watch drops the append (documented macOS FSEvents gap) and the 1s
+    // bridge poller has to pick it up, the external idle still lands while
+    // the viewport is busy.
+    writeFileSync(fakePi, `#!/usr/bin/env node
+process.stdout.write('Working...\\n');
+setTimeout(() => process.stdout.write('\\x1b[2J\\x1b[HDone after transcript final\\n'), 6_000);
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakePi, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-pi-external-busy',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-pi-external-busy',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'pi',
+      cliPathOverride: fakePi,
+      cliSessionId,
+      backendType: 'pty',
+      prompt: 'hello from argv',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_turn',
+    } satisfies DaemonToWorker);
+
+    // The bridge must be attached before the terminal record lands, otherwise
+    // the append below is never ingested and no external idle fires at all.
+    await waitForLog(child, logs, 'Codex bridge fresh-empty:');
+    // Wait until the authoritative viewport provably shows Working... — the
+    // first quiescence screen-idle deferral is that proof. Appending earlier
+    // would race the fake's first write into the backend capture and the
+    // external idle would correctly fall through instead of being deferred.
+    await waitForLog(child, logs, 'screen-idle: authoritative viewport still shows busy marker');
+
+    // assistant_final while the TUI still shows Working... — the race this
+    // regression covers. drainPiTranscript maps a stopReason:"stop" record
+    // without tool calls to a terminal assistant_final, and codexBridgeIngest
+    // fireIdle()s on it (source=external).
+    appendFileSync(transcriptPath, JSON.stringify({
+      type: 'message',
+      timestamp: new Date().toISOString(),
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'final answer' }],
+        stopReason: 'stop',
+      },
+    }) + '\n');
+
+    // The external idle MUST reach the busy-viewport guard (this log line is
+    // the proof the transcript final was ingested and deferred — without it
+    // the ready assertions below could pass vacuously)...
+    await waitForLog(child, logs, 'external-idle: authoritative viewport still shows busy marker');
+    // ...and no prompt_ready may escape while the marker remains on screen.
+    // (Without the guard this fireIdle marks ready immediately, so the 1.5s
+    // window is ample for the bug to surface.)
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 1_500));
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+    expect(
+      messages.some(message => message.type === 'screen_update' && message.status === 'idle'),
+      JSON.stringify(messages),
+    ).toBe(false);
+
+    // Once the fake clears Working..., readiness follows (busy probe or the
+    // clear redraw's quiescence, whichever matures first).
+    await waitForPromptReady(child, messages, logs);
+
+    const updates = await waitForScreenUpdates(child, messages, 1, logs);
+    expect(updates.at(-1)?.status).toBe('idle');
+  }, 25_000);
 
   it.skipIf(!tmuxAvailable)('keeps an adopted Pi pane working until its viewport loses Working...', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-adopt-busy-'));

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -186,7 +186,10 @@ describe('worker pipe initial screen ordering', () => {
     const idleStart = source.search(/idleDetector\.onIdle\(async \(/);
     const idleEnd = source.indexOf('observedBackend.onData((data) =>', idleStart);
     const idle = source.slice(idleStart, idleEnd);
-    const deferIdx = idle.indexOf("deferPromptReadyWhileBusy(`${cliName()} screen-idle`, idleBackend)");
+    // The defer label is templated by evidence source (`screen-idle` /
+    // `external-idle`) since Pi's transcript final is guarded by the same
+    // helper; pin the call itself and its ordering before the ready drain.
+    const deferIdx = idle.indexOf("deferPromptReadyWhileBusy(`${cliName()} ${evidenceSource}-idle`, idleBackend)");
     const drainIdx = idle.indexOf('drainBridgesThenMarkReady(evidenceSource);');
     const adoptStart = source.indexOf('function setupAdoptIdleDetection');
     const adoptEnd = source.indexOf('function seedBackendScreen', adoptStart);

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -481,6 +481,36 @@ describe('worker structured-turn status wiring', () => {
     expect(tickPrune).toBeGreaterThan(finallyBlock);
   });
 
+  it('routes Pi external idle through the busy-viewport guard; ZMX stays fail-open', () => {
+    const callback = source.slice(
+      source.indexOf('idleDetector.onIdle(async (evidenceSource)'),
+      source.indexOf('drainBridgesThenMarkReady(evidenceSource);'),
+    );
+    // Pi's assistant_final is persisted asynchronously from the TUI clearing
+    // Working... — an external idle landing while the authoritative viewport
+    // still shows busy must defer exactly like a screen idle.
+    expect(callback).toContain("evidenceSource === 'screen'");
+    expect(callback).toContain("evidenceSource === 'external' && structuredBridgeIsPi()");
+    expect(callback).toContain('deferPromptReadyWhileBusy(`${cliName()} ${evidenceSource}-idle`, idleBackend)');
+
+    // The guard fail-opens on non-authoritative screens (ZMX) BEFORE testing
+    // the busy pattern, so a stale Working... in ZMX history can never block
+    // a structured terminal; on a busy authoritative viewport it re-arms the
+    // detector and reuses the busy-pattern probe until the marker clears.
+    const defer = functionSlice('deferPromptReadyWhileBusy', 'probeBusyPatternIdle');
+    const authoritativeGate = defer.indexOf('!backendScreenEvidenceIsAuthoritativeForMutation()');
+    const busyTest = defer.indexOf('cliAdapter.busyPattern.test(');
+    expect(authoritativeGate).toBeGreaterThanOrEqual(0);
+    expect(busyTest).toBeGreaterThan(authoritativeGate);
+    expect(defer.indexOf('idleDetector?.reset()')).toBeGreaterThan(busyTest);
+    expect(defer.indexOf('scheduleBusyPatternIdleProbe(source)')).toBeGreaterThan(busyTest);
+
+    // The re-armed probe itself refuses to arm on non-authoritative backends,
+    // so a deferred ZMX turn can never be pinned by the probe loop.
+    const probe = functionSlice('scheduleBusyPatternIdleProbe', 'spawnCli');
+    expect(probe).toContain('if (!backendScreenEvidenceIsAuthoritativeForMutation()) return;');
+  });
+
   it('carries the structured mark through adopt submit confirmation and exception cleanup', () => {
     const adopt = functionSlice('writeAdoptMessage', 'isWorkflowWorker');
     const handler = source.slice(source.indexOf("case 'message':"), source.indexOf("case 'raw_input':"));


### PR DESCRIPTION
## 改了什么、为什么

Pi 工作时 TUI 底部显示 `Working...`。Pi 的 JSONL transcript 落盘（`assistant_final`）与 TUI 清除 `Working...` 是异步的，顺序不固定。#732 已让 screen-idle 路径在权威 viewport 仍含 busy marker 时 defer（`deferPromptReadyWhileBusy()`），但 transcript 驱动的 external idle（`codexBridgeIngest()` → `idleDetector.fireIdle()`，`source=external`）在 `spawnCli` 的 idle callback 里绕过该守卫直接 `markPromptReady()`，导致 assistant_final 先到时卡片在 Pi 仍在工作时偶发提前变绿「等待输入」。

修复：`idleDetector.onIdle` 的 busy viewport 守卫从仅 `screen` 扩展为 `screen || (external && structuredBridgeIsPi())`，完全复用 `deferPromptReadyWhileBusy()`——viewport 仍忙时不 ready、`idleDetector.reset()` 重新武装、复用 `scheduleBusyPatternIdleProbe()` 轮询至 marker 消失后再 ready。defer 期间桥接 final_output 由既有 1s tick 在 ready 后 emit，不丢回复。

守卫范围仅 Pi：Grok/Codex 的 busy marker 合法滞后于 transcript final（终态由 `reliableTurnTerminal` / lifecycle blocking 承担），通用化会引入「卡片卡在 working」类回归；Pi 也未加入永久强门控（`terminate:true` custom tool 不落完整 terminal record，可能永久 working）。ZMX 沿用 `backendScreenEvidenceIsAuthoritativeForMutation()` 的 fail-open，history 中残留 `Working...` 不会阻塞结构化终态。

## 影响面

- 跨 CLI：仅 Pi external-idle；其它 CLI 的 screen/external idle 逐字未动
- 跨后端：PTY/tmux 与 #732 screen 路径一致；ZMX fail-open，probe 对非权威 backend 不 arm
- 会话类型：adopt 路径（`setupAdoptIdleDetection`）本就无条件过该守卫，未变；话题/群会话共用同一 callback
- 公共层未动；`src/worker.ts` 单点 +11 行
- 既有源码断言测试两处适配：`worker-pipe-initial-screen-order`（守卫 label 模板化）与 `raw-input-followup-atomicity`（插入代码顶出 2300 字符窗口，放宽至 3400，断言本身不弱化）

## 测试验证

- 新增集成回归 `worker-argv-reaction-status.integration`「defers a Pi transcript final that lands while the viewport still shows Working...」：fake Pi busy 时向 session JSONL append 终态 record → 断言守卫 defer 日志出现、busy 期间无 prompt_ready、无 idle 卡片；marker 清除后 prompt_ready 到达、最终 update 为 idle。**撤掉 src 修复后该测试必失败（bug 可复现）**，带修复连跑 2 次稳定通过
- 新增源码级回归 `worker-structured-lifecycle-status`：钉住 external 守卫的 Pi-only 门控与 ZMX fail-open 顺序
- `pnpm build` 绿
- 定向：`pnpm vitest run test/idle-detector.test.ts test/worker-argv-reaction-status.integration.test.ts test/worker-pipe-initial-screen-order.test.ts test/worker-structured-lifecycle-status.test.ts test/pi-transcript.test.ts test/worker-zmx-submit-recovery.test.ts test/raw-input-followup-atomicity.test.ts` → 166 通过 / 2 失败
- 全量 `pnpm test` → 14317 通过 / 7 失败，失败项均为本机（macOS）既有基线/flaky，与本改动无关（干净 master 同失败，逐条隔离复核）：
  - worker-argv-reaction ×2：synthetic working seed 顺序（master 全量+隔离共 3 次同失败；busy 守卫核心断言通过）
  - codex-app-runner.integration ×2：两次全量失败用例交替（R3-B3/R4-B3），master 基线同失败
  - v2-run-archive、v3-host-execution：symlink/quarantine 用例，master 基线同失败
  - cost-calculator-cache：仅全量负载下失败，隔离（含本改动/干净 master）均通过

Made with [Cursor](https://cursor.com)