### PR TITLE
fix(dashboard): 会话筛选优先展示已解析的聊天名，不再被原始 chatId 覆盖

### DIFF
--- a/src/dashboard/web/sessions-page.tsx
+++ b/src/dashboard/web/sessions-page.tsx
@@ -66,6 +66,7 @@ import {
   repoBasename,
   restartConfirmMessage,
   sessionLocationText,
+  preferChatFilterLabel,
   sessionLocationTitle,
   sessionExchangePreview,
   sessionRuntimeCounts,
@@ -2472,8 +2473,7 @@ function SessionsPage(): React.JSX.Element {
       if (!chatId) continue;
       if (!filters.showUnknownChats && isUnknownChatSession(row)) continue;
       const label = sessionLocationText(row);
-      const existing = options.get(chatId);
-      if (!existing || label < existing) options.set(chatId, label);
+      options.set(chatId, preferChatFilterLabel(options.get(chatId), label, chatId));
     }
     return [...options.entries()]
       .sort((a, b) => a[1].localeCompare(b[1]))

--- a/src/dashboard/web/sessions.ts
+++ b/src/dashboard/web/sessions.ts
@@ -199,6 +199,32 @@ export function isUnknownChatSession(
   return !!chatId && !resolveTitle(s);
 }
 
+/** True when a chat-filter label still falls back to the raw `chatId` (no
+ * human-readable name resolved). Used to demote unresolved labels during
+ * option dedup so a named session always wins over an id-only one. */
+export function chatFilterLabelIsUnresolved(label: string, chatId: string): boolean {
+  const id = String(chatId ?? '').trim();
+  return !!id && String(label ?? '').includes(id);
+}
+
+/** Pick the better of two chat-filter labels for the same `chatId`. A label
+ * that resolved to a real name beats one that still shows the raw id; when both
+ * are equally (un)resolved, fall back to a deterministic lexicographic pick so
+ * option ordering stays stable across renders.
+ *
+ * Fixes the dedup bug where `label < existing` alone let a raw-id label
+ * (ASCII `oc_…`, which sorts before CJK names) mask an already-resolved name
+ * such as `单聊 · 韩毅 - Nil-RD`. */
+export function preferChatFilterLabel(existing: string | undefined, candidate: string, chatId: string): string {
+  if (existing === undefined) return candidate;
+  const existingUnresolved = chatFilterLabelIsUnresolved(existing, chatId);
+  const candidateUnresolved = chatFilterLabelIsUnresolved(candidate, chatId);
+  if (existingUnresolved !== candidateUnresolved) {
+    return existingUnresolved ? candidate : existing;
+  }
+  return candidate < existing ? candidate : existing;
+}
+
 export function sessionLocationTitle(s: any): string {
   const label = sessionLocationText(s);
   const chatId = String(s?.chatId ?? '').trim();

--- a/test/dashboard-sessions-ui.test.ts
+++ b/test/dashboard-sessions-ui.test.ts
@@ -9,6 +9,8 @@ import {
   CLI_FILTER_OPTIONS,
   groupSessionsByTopic,
   isUnknownChatSession,
+  preferChatFilterLabel,
+  chatFilterLabelIsUnresolved,
   restartConfirmMessage,
   historySenderKey,
   sessionLocationText,
@@ -549,6 +551,31 @@ describe('dashboard sessions filters', () => {
     expect(isUnknownChatSession(row, () => 'SellerIM Agent 集中营')).toBe(false);
     expect(isUnknownChatSession(namedDirect)).toBe(false);
     expect(isUnknownChatSession({}, () => null)).toBe(false);
+  });
+
+  it('detects chat-filter labels that still fall back to the raw chatId', () => {
+    expect(chatFilterLabelIsUnresolved('单聊 · oc_dm - Nil-RD', 'oc_dm')).toBe(true);
+    expect(chatFilterLabelIsUnresolved('单聊 · 韩毅 - Nil-RD', 'oc_dm')).toBe(false);
+    expect(chatFilterLabelIsUnresolved('群聊 · oc_group', 'oc_group')).toBe(true);
+    expect(chatFilterLabelIsUnresolved('anything', '')).toBe(false);
+  });
+
+  it('prefers a resolved chat-filter label over a raw-id one during dedup', () => {
+    // Same p2p chatId: one row resolved the human name, another (a scheduled
+    // task with no user sender) fell back to the raw id. The resolved name must
+    // win regardless of arrival order, even though ASCII `oc_…` sorts before CJK.
+    const resolved = '单聊 · 韩毅 - 韩毅';
+    const rawId = '单聊 · oc_cfa427 - 韩毅';
+    expect(preferChatFilterLabel(undefined, rawId, 'oc_cfa427')).toBe(rawId);
+    expect(preferChatFilterLabel(rawId, resolved, 'oc_cfa427')).toBe(resolved);
+    expect(preferChatFilterLabel(resolved, rawId, 'oc_cfa427')).toBe(resolved);
+  });
+
+  it('falls back to a deterministic lexicographic pick when both labels are equally resolved', () => {
+    expect(preferChatFilterLabel('群聊 · B', '群聊 · A', 'oc_x')).toBe('群聊 · A');
+    expect(preferChatFilterLabel('群聊 · A', '群聊 · B', 'oc_x')).toBe('群聊 · A');
+    // Both unresolved (raw id) → still deterministic, no crash.
+    expect(preferChatFilterLabel('群聊 · oc_x', '群聊 · oc_x', 'oc_x')).toBe('群聊 · oc_x');
   });
 
   it('groups consecutive app/bot history records by sender identity', () => {


### PR DESCRIPTION
## 问题

会话管理 (Sessions) 页面「所在聊天」筛选下拉里，部分明明是已知的单聊/群聊，选项却显示成一长串原始 `oc_...` chatId，而不是人类可读的名字。

## 根因

筛选项文案来自 `sessionLocationText()`，它解析聊天名只有两个数据源：

1. 会话行上持久化的 `chatDisplayName`
2. 群聊：`/api/groups` 拉回来的群名表

同一个 `chatId` 下常常混着「有名字」和「无名字」两类会话行。典型是定时任务、`/login` 这类**没有真人 sender** 的单聊会话——`setDirectChatDisplayNameFromSender` 只在 `sender.type === 'user'` 时才写 `chatDisplayName`，于是这些行退化成 `单聊 · oc_xxx - <bot>`。

`chatOptions` 去重时原本按「字典序最小」选 label（`if (!existing || label < existing)`）。原始 `oc_` 串是 ASCII `'o'`，排在 CJK 人名之前，导致**含原始 id 的 label 永远压过已解析出的名字**（如 `单聊 · 韩毅 - Nil-RD`），筛选框最终就显示了一长串 id。

## 改动

- `src/dashboard/web/sessions.ts`：新增两个纯函数
  - `chatFilterLabelIsUnresolved(label, chatId)` — 判断 label 是否仍回退到原始 chatId
  - `preferChatFilterLabel(existing, candidate, chatId)` — 去重时优先保留「已解析出名字」的 label；两者同等 (un)resolved 时再退回字典序，保证渲染顺序稳定
- `src/dashboard/web/sessions-page.tsx`：`chatOptions` 去重改用 `preferChatFilterLabel`
- `test/dashboard-sessions-ui.test.ts`：新增 3 个用例覆盖解析优先级 / 未解析检测 / 同等时的确定性排序

## 影响范围

纯前端 Dashboard 展示层改动，只影响「所在聊天」筛选项的 label 选择，不改数据、不改后端、不影响其它 CLI / 后端 / 会话类型。据一份线上会话快照验证，原本 4 个显示 id 的单聊已恢复显示人名。

## 已知未覆盖（另一类根因，非本 PR 范围）

仍显示原始 id 的**群聊**是另一类问题：对应 bot 已退群 → 飞书侧查不到群名，且这些会话的 `chatDisplayName` 建会话时从未落库（群名兜底 `resolveGroupChatNameForNativeTitle` 限定 `cliId==='codex'` + 800ms 超时）。治本需在建会话时更积极持久化群名 + 增加历史群名缓存，后续单独提 PR。

## 测试

`pnpm build` 通过；`pnpm exec vitest run test/dashboard-sessions-ui.test.ts` → 34 passed。