### PR TITLE
feat(riff-backend): render route-B display projection in the web terminal

### DIFF
--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -292,6 +292,48 @@ interface RiffAttachment {
   type: 'image' | 'file';
 }
 
+/**
+ * riff route-B `display` projection carried on stdout `log` SSE events
+ * (feat/riff-agent-log-display, TaskLogDisplay = DerivedExecuteLogEvent minus
+ * commandId/payload). A per-line, stateless distillation of a codex app-server
+ * event; `kind` drives our timeline prefix + colour, `title` is riff-localized.
+ */
+interface RiffLogDisplay {
+  kind: string;
+  actor?: string;
+  title?: string;
+  text?: string;
+  summary?: string;
+  command?: string;
+  status?: 'running' | 'completed' | 'failed';
+  stream?: 'stdout' | 'stderr';
+  exitCode?: number;
+}
+
+// Defensive backstop only: riff already downgrades codex lifecycle "noise" lines
+// (thread.started / item.started / usage-only turns) to channel:'raw' so a default
+// subscription never receives them. If an un-projected bare codex event still slips
+// through, this recognizes it so we suppress rather than render a wall of JSON.
+// Deliberately narrow: only a single-line JSON object whose `type` is a known
+// no-content lifecycle marker — never plain shell output.
+const CODEX_NOISE_TYPES = new Set([
+  'thread.started',
+  'turn.started',
+  'item.started',
+  'item.updated',
+  'turn.completed',
+]);
+function isBareCodexNoiseLine(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return false;
+  try {
+    const parsed = JSON.parse(trimmed) as { type?: unknown };
+    return typeof parsed.type === 'string' && CODEX_NOISE_TYPES.has(parsed.type);
+  } catch {
+    return false;
+  }
+}
+
 interface RiffTaskResponse {
   success: boolean;
   data: {
@@ -802,6 +844,68 @@ export class RiffBackend implements SessionBackend {
     this.dataCb?.(normalized);
   }
 
+  /**
+   * Render a riff route-B `display` projection (a codex app-server event distilled
+   * to {kind,title,text,command,exitCode,status}) as one human-readable timeline
+   * row: `[思路] …` / `[命令] <cmd> (exit N)` / `[回答] …`. The Chinese label comes
+   * from riff's already-localized `title` when present (i18n follows riff); we only
+   * fall back to a kind→label table when it is absent. Colour follows the kind
+   * (command exit!=0 / error → red, completion → green, reasoning/usage dimmed).
+   */
+  private emitDisplay(display: RiffLogDisplay): void {
+    const kind = display.kind;
+    // Kind → default label + emitLine style. `title` (localized by riff) wins over
+    // the label when present.
+    const LABEL: Record<string, string> = {
+      message: '回答',
+      reasoning: '思路',
+      command: '命令',
+      tool: '工具',
+      error: '错误',
+      system: '系统',
+      usage: '用量',
+      stdout: '',
+      stderr: '',
+    };
+    const label = display.title || LABEL[kind] || kind;
+    const body = (display.text ?? display.summary ?? '').trimEnd();
+
+    if (kind === 'command') {
+      const cmd = display.command || body || '已执行命令';
+      const failed = display.status === 'failed' || (display.exitCode != null && display.exitCode !== 0);
+      const exit = display.exitCode != null ? ` (exit ${display.exitCode})` : '';
+      this.emitLine(`[${label}] ${cmd}${exit}`, failed ? 'err' : 'ok');
+      // Surface any captured command output beneath the header, verbatim.
+      if (body && body !== cmd) this.emitText(`${body}\n`);
+      return;
+    }
+    switch (kind) {
+      case 'reasoning':
+      case 'usage':
+        // Low-signal in a live terminal — keep but dim (plain, no color).
+        this.emitLine(`[${label}] ${body}`, 'plain');
+        return;
+      case 'error':
+        this.emitLine(`[${label}] ${body}`, 'err');
+        return;
+      case 'stderr':
+        this.emitLine(body, 'warn');
+        return;
+      case 'stdout':
+        // Plain shell output projected as-is.
+        if (body) this.emitText(`${body}\n`);
+        return;
+      case 'message':
+        this.emitLine(`[${label}] ${body}`, 'title');
+        return;
+      case 'tool':
+      case 'system':
+      default:
+        this.emitLine(`[${label}] ${body}`, 'info');
+        return;
+    }
+  }
+
   private extractAttachments(content: string): { text: string; attachments: RiffAttachment[] } {
     const attachments: RiffAttachment[] = [];
     const attachRegex = /<attachments[^>]*>([\s\S]*?)<\/attachments>/g;
@@ -1263,6 +1367,15 @@ export class RiffBackend implements SessionBackend {
           const kind = data['kind'] as string | undefined;
           const group = (data['group'] as string | undefined)
             ?? (data['payload'] as Record<string, unknown> | undefined)?.['group'] as string | undefined;
+          // riff's route-B projection (feat/riff-agent-log-display): stdout log
+          // events may carry a `display: TaskLogDisplay` — a per-line, human-readable
+          // projection of a codex app-server event (回答 / 思路 / 命令 … ). When present,
+          // render the timeline row from it instead of the raw JSON line.
+          const display = data['display'] as RiffLogDisplay | undefined;
+          if (group === 'stdout' && display && typeof display.kind === 'string') {
+            this.emitDisplay(display);
+            break;
+          }
           // stdout logs are the real output stream — emit as data regardless of logLevel.
           // riff stores each stdout log line BARE (no trailing newline): the runner's
           // logger persists `message` verbatim (Logger.createRootLog) and the SSE `log`
@@ -1274,6 +1387,13 @@ export class RiffBackend implements SessionBackend {
           // stored line has no trailing newline). NOTE: the `output`/chunk path stays raw —
           // those chunks may be partial lines, so they must NOT get a synthetic newline.
           if (group === 'stdout' && text) {
+            // Defensive backstop: riff downgrades codex lifecycle "noise" lines
+            // (thread.started / item.started / usage-only turns) to channel:'raw',
+            // so a default subscription never receives them. But if an un-projected
+            // bare codex event ever slips through, suppress it rather than re-wall.
+            if (isBareCodexNoiseLine(text)) {
+              break;
+            }
             this.emitText(`${text}\n`);
           } else if (this.config.logLevel === 'verbose' && text) {
             this.emitLine(`[riff:${kind ?? 'log'}] ${text}`);

--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -316,12 +316,16 @@ interface RiffLogDisplay {
 // through, this recognizes it so we suppress rather than render a wall of JSON.
 // Deliberately narrow: only a single-line JSON object whose `type` is a known
 // no-content lifecycle marker — never plain shell output.
+// Kept in sync with riff's CODEX_NOISE_EVENT_TYPES (agentExecuteLogParser.ts) — the
+// authoritative classifier. Mirror it exactly so our fallback matches riff's filter.
 const CODEX_NOISE_TYPES = new Set([
   'thread.started',
   'turn.started',
   'item.started',
   'item.updated',
   'turn.completed',
+  'response.completed',
+  'response.done',
 ]);
 function isBareCodexNoiseLine(text: string): boolean {
   const trimmed = text.trim();
@@ -821,13 +825,14 @@ export class RiffBackend implements SessionBackend {
    * lines stair-step to the right, which is the main reason the raw log view
    * was hard to read. Always emit `\r\n` and reset ANSI styling per line.
    */
-  private emitLine(text: string, style: 'info' | 'warn' | 'ok' | 'err' | 'title' | 'plain' = 'info'): void {
+  private emitLine(text: string, style: 'info' | 'warn' | 'ok' | 'err' | 'title' | 'dim' | 'plain' = 'info'): void {
     const codes: Record<string, string> = {
       info: '\x1b[36m',   // cyan — routine status
       warn: '\x1b[33m',   // yellow — degraded/attention
       ok: '\x1b[32m',     // green — completion
       err: '\x1b[31m',    // red — failure
       title: '\x1b[1m',   // bold — section separators
+      dim: '\x1b[2m',     // faint — low-signal (reasoning / usage)
       plain: '',
     };
     const open = codes[style] ?? '';
@@ -845,66 +850,98 @@ export class RiffBackend implements SessionBackend {
   }
 
   /**
+   * Emit ONE timeline row for a route-B display projection. Unlike {@link emitLine}
+   * (which brackets every call with a leading + trailing CRLF → blank lines between
+   * consecutive rows, and leaves internal `\n` un-normalized → xterm stair-stepping),
+   * this normalizes ALL internal newlines to CRLF and appends exactly ONE trailing
+   * CRLF, with NO leading CRLF. Consecutive rows therefore sit on adjacent lines and
+   * multi-line bodies render flush-left.
+   */
+  private emitTimelineRow(text: string, style: 'info' | 'warn' | 'ok' | 'err' | 'title' | 'dim' | 'plain' = 'info'): void {
+    const codes: Record<string, string> = {
+      info: '\x1b[36m', warn: '\x1b[33m', ok: '\x1b[32m',
+      err: '\x1b[31m', title: '\x1b[1m', dim: '\x1b[2m', plain: '',
+    };
+    const open = codes[style] ?? '';
+    const close = open ? '\x1b[0m' : '';
+    // Color the whole (possibly multi-line) row, then normalize every newline —
+    // including the internal ones — to CRLF, and terminate with exactly one CRLF.
+    const body = `${open}${text}${close}`.replace(/\r?\n/g, '\r\n');
+    const line = `${body}\r\n`;
+    this.outputBuffer += line;
+    this.dataCb?.(line);
+  }
+
+  /**
    * Render a riff route-B `display` projection (a codex app-server event distilled
    * to {kind,title,text,command,exitCode,status}) as one human-readable timeline
    * row: `[思路] …` / `[命令] <cmd> (exit N)` / `[回答] …`. The Chinese label comes
    * from riff's already-localized `title` when present (i18n follows riff); we only
    * fall back to a kind→label table when it is absent. Colour follows the kind
-   * (command exit!=0 / error → red, completion → green, reasoning/usage dimmed).
+   * (failed command / error → red, completed command → green, reasoning/usage dim).
    */
   private emitDisplay(display: RiffLogDisplay): void {
     const kind = display.kind;
-    // Kind → default label + emitLine style. `title` (localized by riff) wins over
-    // the label when present.
+    // Kind → default label. `title` (localized by riff) wins when present.
     const LABEL: Record<string, string> = {
       message: '回答',
       reasoning: '思路',
       command: '命令',
       tool: '工具',
-      error: '错误',
       system: '系统',
       usage: '用量',
+      error: '错误',
+      stage: '阶段',
+      trace: '追踪',
       stdout: '',
       stderr: '',
     };
     const label = display.title || LABEL[kind] || kind;
-    const body = (display.text ?? display.summary ?? '').trimEnd();
+    // NOTE: for a codex `command` projection riff sets {command,status,exitCode,
+    // summary:'命令执行完成'} and NO `text` — the real captured stdout rides a
+    // SEPARATE stdout event on the verbatim `text`/passthrough path, not here. So
+    // the command branch renders ONLY its header (never `summary` as fake output).
+    const body = (display.text ?? '').trimEnd();
 
     if (kind === 'command') {
-      const cmd = display.command || body || '已执行命令';
+      const cmd = display.command || '已执行命令';
+      const completed = display.status === 'completed' || display.exitCode === 0;
       const failed = display.status === 'failed' || (display.exitCode != null && display.exitCode !== 0);
       const exit = display.exitCode != null ? ` (exit ${display.exitCode})` : '';
-      this.emitLine(`[${label}] ${cmd}${exit}`, failed ? 'err' : 'ok');
-      // Surface any captured command output beneath the header, verbatim.
-      if (body && body !== cmd) this.emitText(`${body}\n`);
+      // Green ONLY for a confirmed-completed/exit-0 command; red for failure;
+      // neutral (info) for a still-running command (no exit code yet).
+      const style = failed ? 'err' : completed ? 'ok' : 'info';
+      this.emitTimelineRow(`[${label}] ${cmd}${exit}`, style);
       return;
     }
     switch (kind) {
       case 'reasoning':
       case 'usage':
-        // Low-signal in a live terminal — keep but dim (plain, no color).
-        this.emitLine(`[${label}] ${body}`, 'plain');
+        this.emitTimelineRow(`[${label}] ${body}`, 'dim');
         return;
       case 'error':
-        this.emitLine(`[${label}] ${body}`, 'err');
+        this.emitTimelineRow(`[${label}] ${body}`, 'err');
         return;
       case 'stderr':
-        this.emitLine(body, 'warn');
+        this.emitTimelineRow(body, 'warn');
         return;
       case 'stdout':
-        // Plain shell output projected as-is.
-        if (body) this.emitText(`${body}\n`);
+        // Plain shell output projected as-is (no label prefix).
+        if (body) this.emitTimelineRow(body, 'plain');
         return;
       case 'message':
-        this.emitLine(`[${label}] ${body}`, 'title');
+        this.emitTimelineRow(`[${label}] ${body}`, 'title');
         return;
       case 'tool':
       case 'system':
+      case 'stage':
+      case 'trace':
       default:
-        this.emitLine(`[${label}] ${body}`, 'info');
+        this.emitTimelineRow(`[${label}] ${body}`, 'info');
         return;
     }
   }
+
 
   private extractAttachments(content: string): { text: string; attachments: RiffAttachment[] } {
     const attachments: RiffAttachment[] = [];

--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -897,10 +897,11 @@ export class RiffBackend implements SessionBackend {
       stderr: '',
     };
     const label = display.title || LABEL[kind] || kind;
-    // NOTE: for a codex `command` projection riff sets {command,status,exitCode,
-    // summary:'命令执行完成'} and NO `text` — the real captured stdout rides a
-    // SEPARATE stdout event on the verbatim `text`/passthrough path, not here. So
-    // the command branch renders ONLY its header (never `summary` as fake output).
+    // For a codex `command` projection riff sets {command,status,exitCode,
+    // summary:'命令执行完成'} PLUS `text` = the captured command output (stdout/
+    // stderr, already truncated to 32KB by riff's collapseCommandOutputIntoPrimary).
+    // `summary` is a status blurb we never render; `text` is the real output we DO
+    // render beneath the header. For non-command kinds `text` is the content itself.
     const body = (display.text ?? '').trimEnd();
 
     if (kind === 'command') {
@@ -912,6 +913,10 @@ export class RiffBackend implements SessionBackend {
       // neutral (info) for a still-running command (no exit code yet).
       const style = failed ? 'err' : completed ? 'ok' : 'info';
       this.emitTimelineRow(`[${label}] ${cmd}${exit}`, style);
+      // Render the captured command output (riff folds it into `text`) beneath the
+      // header, verbatim/uncolored. `summary` ('命令执行完成') is NOT this — it never
+      // reaches `body` (we read `text` only), so no fake output line.
+      if (body) this.emitTimelineRow(body, 'plain');
       return;
     }
     switch (kind) {

--- a/test/riff-backend.test.ts
+++ b/test/riff-backend.test.ts
@@ -390,14 +390,18 @@ describe('RiffBackend', () => {
       const lines: string[] = [];
       be.onData(d => lines.push(d));
       (be as any).currentTaskId = 'task-1';
-      (be as any).handleSseEvent('event:log\ndata:{"group":"stdout","text":"{\\"type\\":\\"thread.started\\"}"}', 'task-1');
-      (be as any).handleSseEvent('event:log\ndata:{"group":"stdout","text":"{\\"type\\":\\"turn.started\\"}"}', 'task-1');
+      // Use content-bearing lines (not thread.started/turn.started lifecycle
+      // markers — those are now suppressed by the route-B noise backstop). The
+      // char-wall invariant under test is: consecutive bare stdout lines get a
+      // separator, never butt together into `}{`.
+      (be as any).handleSseEvent('event:log\ndata:{"group":"stdout","text":"{\\"type\\":\\"item.completed\\",\\"n\\":1}"}', 'task-1');
+      (be as any).handleSseEvent('event:log\ndata:{"group":"stdout","text":"{\\"type\\":\\"item.completed\\",\\"n\\":2}"}', 'task-1');
       const out = lines.join('');
       // The two events must not butt together (…}{… would be the wall).
       expect(out).not.toContain('}{');
       // Each event renders on its own line (emitText normalizes \n → \r\n).
-      expect(out).toContain('{"type":"thread.started"}\r\n');
-      expect(out).toContain('{"type":"turn.started"}\r\n');
+      expect(out).toContain('{"type":"item.completed","n":1}\r\n');
+      expect(out).toContain('{"type":"item.completed","n":2}\r\n');
     });
 
     it('does not double-space a stdout log (bare line + exactly one separator)', () => {
@@ -418,6 +422,73 @@ describe('RiffBackend', () => {
       (be as any).handleSseEvent('event:output\ndata:{"chunk":"tial"}', 'task-1');
       // No synthetic newline injected between chunks — they join seamlessly.
       expect(lines.join('')).toBe('partial');
+    });
+  });
+
+  describe('route-B display projection (feat/riff-agent-log-display)', () => {
+    // riff attaches a per-line `display: TaskLogDisplay` on stdout log events —
+    // a human-readable projection of a codex app-server event. We render a
+    // timeline row from it instead of the raw JSON line.
+    const logEvt = (payload: Record<string, unknown>) =>
+      `event:log\ndata:${JSON.stringify(payload)}`;
+
+    it('renders an agent_message display as a [回答] row, not raw JSON', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(
+        logEvt({ group: 'stdout', text: '{"type":"item.completed",...}', display: { kind: 'message', title: '回答', text: 'Hello there' } }),
+        'task-1',
+      );
+      const out = lines.join('');
+      expect(out).toContain('[回答] Hello there');
+      // The raw JSON `text` is NOT emitted when a display projection exists.
+      expect(out).not.toContain('item.completed');
+    });
+
+    it('renders a command display with exit code + failure color', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(
+        logEvt({ group: 'stdout', text: '{}', display: { kind: 'command', title: '命令', command: 'ls -la', status: 'failed', exitCode: 2 } }),
+        'task-1',
+      );
+      const out = lines.join('');
+      expect(out).toContain('[命令] ls -la (exit 2)');
+      expect(out).toContain('\x1b[31m'); // red for the failed command
+    });
+
+    it('falls back to raw line (with separator) when display is absent (#805)', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(logEvt({ group: 'stdout', text: 'plain shell output' }), 'task-1');
+      expect(lines.join('')).toBe('plain shell output\r\n');
+    });
+
+    it('defensively suppresses a bare codex noise line that slipped through un-projected', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      // No display + a bare lifecycle event = riff would normally have downgraded
+      // it to channel:'raw'; if it slips through, we must not re-wall.
+      (be as any).handleSseEvent(logEvt({ group: 'stdout', text: '{"type":"thread.started","thread_id":"t1"}' }), 'task-1');
+      expect(lines.join('')).toBe('');
+    });
+
+    it('does NOT suppress plain output that merely contains braces', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(logEvt({ group: 'stdout', text: '{"result": 42} done' }), 'task-1');
+      // Not a bare codex lifecycle event → passes through as normal output.
+      expect(lines.join('')).toBe('{"result": 42} done\r\n');
     });
   });
 

--- a/test/riff-backend.test.ts
+++ b/test/riff-backend.test.ts
@@ -447,12 +447,12 @@ describe('RiffBackend', () => {
       expect(out).not.toContain('item.completed');
     });
 
-    it('renders a completed command as [命令] <cmd> (exit 0) in green', () => {
+    it('renders a completed command as [命令] <cmd> (exit 0) in green (no output case)', () => {
       const be = makeBackend({ injectStatusLines: false });
       const lines: string[] = [];
       be.onData(d => lines.push(d));
       (be as any).currentTaskId = 'task-1';
-      // riff's real command projection: {command,status,exitCode,summary} + NO text.
+      // A command with no captured output: riff omits `text`, so header only.
       (be as any).handleSseEvent(
         logEvt({ group: 'stdout', text: '{}', display: { kind: 'command', title: '命令执行', command: 'ls -la', status: 'completed', exitCode: 0, summary: '命令执行完成' } }),
         'task-1',
@@ -462,6 +462,36 @@ describe('RiffBackend', () => {
       expect(out).toContain('\x1b[32m'); // green for exit 0
       // MUST NOT print `summary` ('命令执行完成') as a fake output line.
       expect(out).not.toContain('命令执行完成');
+    });
+
+    it('renders captured command output (riff folds stdout into display.text) below the header', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      // riff's collapseCommandOutputIntoPrimary puts the real stdout in `text`.
+      (be as any).handleSseEvent(
+        logEvt({ group: 'stdout', text: '{}', display: { kind: 'command', title: '命令执行', command: 'echo hello', status: 'completed', exitCode: 0, summary: '命令执行完成', text: 'hello' } }),
+        'task-1',
+      );
+      const out = lines.join('');
+      expect(out).toContain('[命令执行] echo hello (exit 0)');
+      expect(out).toContain('hello'); // the real output IS rendered
+      expect(out).not.toContain('命令执行完成'); // summary still never rendered
+    });
+
+    it('renders multi-line command output verbatim with CRLF normalization', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(
+        logEvt({ group: 'stdout', text: '{}', display: { kind: 'command', title: '命令', command: 'ls', status: 'completed', exitCode: 0, text: 'file1\nfile2' } }),
+        'task-1',
+      );
+      const out = lines.join('');
+      expect(out).toContain('file1\r\nfile2');
+      expect(out).not.toMatch(/[^\r]\n/); // no bare LF (would stair-step)
     });
 
     it('renders a failed command in red with its exit code', () => {

--- a/test/riff-backend.test.ts
+++ b/test/riff-backend.test.ts
@@ -447,18 +447,92 @@ describe('RiffBackend', () => {
       expect(out).not.toContain('item.completed');
     });
 
-    it('renders a command display with exit code + failure color', () => {
+    it('renders a completed command as [命令] <cmd> (exit 0) in green', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      // riff's real command projection: {command,status,exitCode,summary} + NO text.
+      (be as any).handleSseEvent(
+        logEvt({ group: 'stdout', text: '{}', display: { kind: 'command', title: '命令执行', command: 'ls -la', status: 'completed', exitCode: 0, summary: '命令执行完成' } }),
+        'task-1',
+      );
+      const out = lines.join('');
+      expect(out).toContain('[命令执行] ls -la (exit 0)');
+      expect(out).toContain('\x1b[32m'); // green for exit 0
+      // MUST NOT print `summary` ('命令执行完成') as a fake output line.
+      expect(out).not.toContain('命令执行完成');
+    });
+
+    it('renders a failed command in red with its exit code', () => {
       const be = makeBackend({ injectStatusLines: false });
       const lines: string[] = [];
       be.onData(d => lines.push(d));
       (be as any).currentTaskId = 'task-1';
       (be as any).handleSseEvent(
-        logEvt({ group: 'stdout', text: '{}', display: { kind: 'command', title: '命令', command: 'ls -la', status: 'failed', exitCode: 2 } }),
+        logEvt({ group: 'stdout', text: '{}', display: { kind: 'command', title: '命令', command: 'false', status: 'failed', exitCode: 2, summary: '命令执行失败' } }),
         'task-1',
       );
       const out = lines.join('');
-      expect(out).toContain('[命令] ls -la (exit 2)');
-      expect(out).toContain('\x1b[31m'); // red for the failed command
+      expect(out).toContain('[命令] false (exit 2)');
+      expect(out).toContain('\x1b[31m'); // red
+      expect(out).not.toContain('命令执行失败'); // summary not printed as output
+    });
+
+    it('does NOT color a still-running command green (no exit code yet)', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(
+        logEvt({ group: 'stdout', text: '{}', display: { kind: 'command', title: '命令', command: 'sleep 5', status: 'running' } }),
+        'task-1',
+      );
+      const out = lines.join('');
+      expect(out).toContain('[命令] sleep 5');
+      expect(out).not.toContain('(exit'); // no exit code segment while running
+      expect(out).not.toContain('\x1b[32m'); // NOT green while running
+    });
+
+    it('dims reasoning/usage rows (actual ANSI dim, not a no-op)', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(
+        logEvt({ group: 'stdout', text: '{}', display: { kind: 'reasoning', title: '思路', text: 'thinking...' } }),
+        'task-1',
+      );
+      const out = lines.join('');
+      expect(out).toContain('[思路] thinking...');
+      expect(out).toContain('\x1b[2m'); // faint
+    });
+
+    it('does not double-space consecutive display rows', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(logEvt({ group: 'stdout', text: '{}', display: { kind: 'message', title: '回答', text: 'A' } }), 'task-1');
+      (be as any).handleSseEvent(logEvt({ group: 'stdout', text: '{}', display: { kind: 'message', title: '回答', text: 'B' } }), 'task-1');
+      const out = lines.join('');
+      // No blank line between the two rows: no CRLFCRLF anywhere in the stream.
+      expect(out).not.toContain('\r\n\r\n');
+    });
+
+    it('normalizes internal newlines in a multi-line display body (no stair-step)', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(
+        logEvt({ group: 'stdout', text: '{}', display: { kind: 'tool', title: '工具调用', text: 'line1\nline2' } }),
+        'task-1',
+      );
+      const out = lines.join('');
+      // Every newline in the emitted row is a CRLF — no bare \n left to stair-step.
+      expect(out).not.toMatch(/[^\r]\n/);
+      expect(out).toContain('line1\r\nline2');
     });
 
     it('falls back to raw line (with separator) when display is absent (#805)', () => {
@@ -478,6 +552,16 @@ describe('RiffBackend', () => {
       // No display + a bare lifecycle event = riff would normally have downgraded
       // it to channel:'raw'; if it slips through, we must not re-wall.
       (be as any).handleSseEvent(logEvt({ group: 'stdout', text: '{"type":"thread.started","thread_id":"t1"}' }), 'task-1');
+      expect(lines.join('')).toBe('');
+    });
+
+    it('suppresses response.completed / response.done noise (kept in sync with riff)', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent(logEvt({ group: 'stdout', text: '{"type":"response.completed"}' }), 'task-1');
+      (be as any).handleSseEvent(logEvt({ group: 'stdout', text: '{"type":"response.done"}' }), 'task-1');
       expect(lines.join('')).toBe('');
     });
 


### PR DESCRIPTION
## 背景

route B(web 终端人可读时间线)的 botmux 消费端。前置:#805 已让 codex_app_server 的 stdout 每行一个规整 JSON;riff 侧 `feat/riff-agent-log-display` 在 stdout `log` SSE 事件上加了一个逐行、无状态的 `display: TaskLogDisplay` 投影(codex 事件蒸馏成 kind/title/text/command/exitCode/status)。本 PR 消费它,把裸 JSON 渲成 `[回答]/[思路]/[命令 exitN]` 时间线。

## 改了什么(`src/adapters/backend/riff-backend.ts`,+120)

`case 'log'` 的 stdout 分支三态处理:
1. **有 `display`** → `emitDisplay()` 渲一行时间线:
   - `message`→`[回答]`(bold)、`reasoning`→`[思路]`(dim)、`command`→`[命令] <cmd> (exit N)`(exit0/completed 绿、非0/failed 红)、`tool`→`[工具]`、`error`→`[错误]`(红)、`system`→`[系统]`、`usage`→dim、`stdout/stderr`→原样(stderr 黄)。
   - 前缀优先用 riff 已本地化的 `title`(i18n 跟着 riff 走),缺省才回落 kind→label 表。
2. **无 `display`** → 保持 #805 的原样兜底 `emitText(text + '\n')`(非 codex 输出 / 解析未命中)。
3. **防御兜底** → 若某条裸 codex 生命周期事件(thread.started/item.started/…)漏过来未被投影(riff 正常会把这些降 `channel:'raw'`,default 订阅收不到),`isBareCodexNoiseLine` 识别并抑制,而不是重新糊墙。刻意收窄:仅单行 JSON 且 `type` 是已知无内容标记 —— 绝不误伤含花括号的普通 shell 输出。

`event:output`(chunk)路径不动。

## 消费契约

SSE `log`(group=stdout)携带 `display?: TaskLogDisplay`(= riff DerivedExecuteLogEvent 去掉 commandId/payload)。字段与 riff MR `feat/riff-agent-log-display` 对齐。

## 测试

`test/riff-backend.test.ts` +5:display→时间线行 / command+exit+失败色 / display 缺省→#805 兜底 / 裸 noise 行被抑制 / 含花括号的普通输出不被误抑制。并更新了 #805 那条"分行不糊"测试改用 content-bearing 行(生命周期标记现已被 noise 兜底抑制)。**riff-backend 55/55 绿**,tsc 改动文件零新增错误。

## 上线

同 #805:随 botmux 发布 → 沙箱 pin(`RIFF_BOTMUX_CORE_ONLY_VERSION`)指到含本改动的版本才生效。属体验增强,非阻塞。
