### PR TITLE
fix(update): 补全 pnpm 11 store 实路径识别

### DIFF
--- a/src/utils/global-install.ts
+++ b/src/utils/global-install.ts
@@ -40,6 +40,13 @@ function normalized(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+$/, '');
 }
 
+/** Node resolves pnpm 11's global botmux symlink to this store realpath. */
+function pnpmV11StoreMatch(root: string): RegExpMatchArray | null {
+  return root.match(
+    /^(.*\/pnpm)\/store\/(v\d+)\/links\/@\/botmux\/[^/]+\/[^/]+\/node_modules\/botmux$/i,
+  );
+}
+
 /**
  * pnpm 11 installs a global project in a versioned directory and points a
  * stable content-addressed symlink at that directory:
@@ -87,6 +94,7 @@ export function detectGlobalInstallManager(
   // Node normally resolves pnpm's stable symlink to this versioned virtual-store
   // path. Match it before the generic node_modules layouts below.
   if (root.includes('/.pnpm/')) return 'pnpm';
+  if (pnpmV11StoreMatch(root)) return 'pnpm';
 
   // Known non-npm managers must never fall through to npm, especially on
   // Windows where all three can end in <prefix>/node_modules/botmux.
@@ -135,14 +143,18 @@ export function resolveGlobalInstallPlan(
     const marker = '/.pnpm/';
     const markerIndex = root.toLowerCase().indexOf(marker);
     const pnpmV11Match = root.match(/^(.*\/pnpm\/global)\/(v\d+)\/[^/]+\/node_modules\/botmux$/i);
+    const pnpmV11Store = pnpmV11StoreMatch(root);
     // Use the capture from the normalized path. Besides avoiding a fragile
     // separator search, this preserves Windows drive letters while converting
     // backslashes to the separator expected by pnpm's command arguments.
-    const globalDir = pnpmV11Match?.[1];
+    const globalDir = pnpmV11Match?.[1]
+      ?? (pnpmV11Store ? path.join(pnpmV11Store[1], 'global') : undefined);
     const globalInstallDir = pnpmV11Match
       ? path.join(globalDir!, pnpmV11Match[2])
+      : pnpmV11Store
+        ? path.join(globalDir!, pnpmV11Store[2])
       : markerIndex >= 0
-        ? root.slice(0, markerIndex)
+      ? root.slice(0, markerIndex)
       : path.dirname(path.dirname(packageRoot));
     // pnpm appends its global layout version (currently "5", or "v11") to
     // --global-dir. The pnpm 11 runtime adds another temporary directory below
@@ -150,6 +162,8 @@ export function resolveGlobalInstallPlan(
     const resolvedGlobalDir = globalDir ?? path.dirname(globalInstallDir);
     const activePackageRoot = pnpmV11Match
       ? pnpmV11StablePackageRoot(packageRoot, resolvedGlobalDir, pnpmV11Match[2], path)
+      : pnpmV11Store
+        ? pnpmV11StablePackageRoot(packageRoot, resolvedGlobalDir, pnpmV11Store[2], path)
       : path.join(globalInstallDir, 'node_modules', 'botmux');
     return {
       manager,

--- a/src/utils/global-install.ts
+++ b/src/utils/global-install.ts
@@ -7,7 +7,9 @@
  * supported; known Yarn layouts are identified for diagnostics but rejected
  * until their global-dir/bin-dir semantics are handled explicitly.
  */
+import { spawnSync } from 'node:child_process';
 import { readdirSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { posix, win32 } from 'node:path';
 import { botmuxInstallRoot } from './install-info.js';
 
@@ -45,6 +47,31 @@ function pnpmV11StoreMatch(root: string): RegExpMatchArray | null {
   return root.match(
     /^(.*\/pnpm)\/store\/(v\d+)\/links\/@\/botmux\/[^/]+\/[^/]+\/node_modules\/botmux$/i,
   );
+}
+
+function pnpmGlobalDir(
+  pathImpl: typeof posix,
+  layout: string,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  const command = platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  const result = spawnSync(command, ['list', '-g', '--depth', '0', '--json'], {
+    cwd: homedir(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0 || typeof result.stdout !== 'string') return undefined;
+  let globalRoot: string | undefined;
+  try {
+    const listing = JSON.parse(result.stdout);
+    globalRoot = Array.isArray(listing) && typeof listing[0]?.path === 'string'
+      ? normalized(listing[0].path)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+  if (!globalRoot) return undefined;
+  return globalRoot.endsWith(`/${layout}`) ? pathImpl.dirname(globalRoot) : undefined;
 }
 
 /**
@@ -148,7 +175,10 @@ export function resolveGlobalInstallPlan(
     // separator search, this preserves Windows drive letters while converting
     // backslashes to the separator expected by pnpm's command arguments.
     const globalDir = pnpmV11Match?.[1]
-      ?? (pnpmV11Store ? path.join(pnpmV11Store[1], 'global') : undefined);
+      ?? (pnpmV11Store ? pnpmGlobalDir(path, pnpmV11Store[2], platform) : undefined);
+    if (pnpmV11Store && !globalDir) {
+      throw new UnsupportedGlobalInstallError('pnpm', packageRoot);
+    }
     const globalInstallDir = pnpmV11Match
       ? path.join(globalDir!, pnpmV11Match[2])
       : pnpmV11Store
@@ -165,6 +195,9 @@ export function resolveGlobalInstallPlan(
       : pnpmV11Store
         ? pnpmV11StablePackageRoot(packageRoot, resolvedGlobalDir, pnpmV11Store[2], path)
       : path.join(globalInstallDir, 'node_modules', 'botmux');
+    if (pnpmV11Store && activePackageRoot === packageRoot) {
+      throw new UnsupportedGlobalInstallError('pnpm', packageRoot);
+    }
     return {
       manager,
       command: 'pnpm',

--- a/src/utils/global-install.ts
+++ b/src/utils/global-install.ts
@@ -59,6 +59,19 @@ function pnpmGlobalDir(
     cwd: homedir(),
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'ignore'],
+    // .cmd shims are not directly executable: without cmd.exe the Windows
+    // install path fails with ENOENT/EINVAL. Mirror the update execution
+    // strategy (installLatestBotmuxSync / runGlobalInstall). Args are fixed
+    // literals, so the shell cannot reinterpret anything.
+    shell: platform === 'win32',
+    // This probe runs on request-serving paths (dashboard settings, update
+    // status, scheduled maintenance) with no plan cache before the first
+    // successful update, so a hung pnpm or wedged disk must never freeze the
+    // event loop. Any timeout/error keeps callers on the fail-closed path
+    // (status !== 0 -> undefined). SIGKILL cannot be trapped by the child.
+    timeout: 5_000,
+    killSignal: 'SIGKILL',
+    maxBuffer: 256 * 1024,
   });
   if (result.status !== 0 || typeof result.stdout !== 'string') return undefined;
   let globalRoot: string | undefined;

--- a/test/global-install-probe.test.ts
+++ b/test/global-install-probe.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The Windows probe behaviour cannot be proven on Linux CI with a fake
+// executable: a shebang script named pnpm.cmd runs without a shell, so even
+// removing `shell` keeps such tests green. Assert the spawnSync contract
+// directly instead. Mocked before importing the module under test.
+const spawnSync = vi.fn(() => ({ status: 1, stdout: '' }));
+vi.mock('node:child_process', () => ({ spawnSync }));
+
+const { tryResolveGlobalInstallPlan } = await import('../src/utils/global-install.js');
+
+const STORE_REALPATH
+  = String.raw`C:\pnpm\store\v11\links\@\botmux\3.11.0\hash\node_modules\botmux`;
+
+describe('pnpm global probe spawn contract', () => {
+  it('spawns pnpm.cmd through a shell with a hard SIGKILL timeout on win32', () => {
+    expect(tryResolveGlobalInstallPlan(STORE_REALPATH, 'win32')).toBeNull();
+    expect(spawnSync).toHaveBeenCalledExactlyOnceWith(
+      'pnpm.cmd',
+      ['list', '-g', '--depth', '0', '--json'],
+      expect.objectContaining({
+        shell: true,
+        timeout: 5_000,
+        killSignal: 'SIGKILL',
+      }),
+    );
+  });
+
+  it('spawns plain pnpm without a shell but with the hard timeout on POSIX', () => {
+    spawnSync.mockClear();
+    const root = '/home/bot/.local/share/pnpm/store/v11/links/@/botmux/3.11.0/hash/node_modules/botmux';
+    expect(tryResolveGlobalInstallPlan(root, 'linux')).toBeNull();
+    expect(spawnSync).toHaveBeenCalledExactlyOnceWith(
+      'pnpm',
+      ['list', '-g', '--depth', '0', '--json'],
+      expect.objectContaining({
+        shell: false,
+        timeout: 5_000,
+        killSignal: 'SIGKILL',
+      }),
+    );
+  });
+});

--- a/test/global-install.test.ts
+++ b/test/global-install.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
@@ -122,6 +122,62 @@ describe('resolveGlobalInstallPlan', () => {
         'add', '-g', '--global-dir', customGlobal, 'botmux@latest',
       ]);
       expect(plan.activePackageRoot).toBe(join(stableDir, 'node_modules', 'botmux'));
+    } finally {
+      process.env.PATH = previousPath;
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when the pnpm global probe hangs', { timeout: 20_000 }, () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'botmux-pnpm11-hang-'));
+    const previousPath = process.env.PATH;
+    try {
+      const storeRoot = join(tempRoot, 'pnpm', 'store', 'v11', 'links', '@', 'botmux', '3.11.0', 'hash');
+      const packageRoot = join(storeRoot, 'node_modules', 'botmux');
+      const fakePnpm = join(tempRoot, 'bin', 'pnpm');
+      mkdirSync(packageRoot, { recursive: true });
+      mkdirSync(join(tempRoot, 'bin'), { recursive: true });
+      writeFileSync(fakePnpm, '#!/bin/sh\nsleep 60\n');
+      chmodSync(fakePnpm, 0o755);
+      process.env.PATH = `${join(tempRoot, 'bin')}:${previousPath ?? ''}`;
+
+      const startedAt = Date.now();
+      expect(tryResolveGlobalInstallPlan(packageRoot, 'linux')).toBeNull();
+      // The probe must have been killed by its hard timeout, not waited out.
+      expect(Date.now() - startedAt).toBeLessThan(30_000);
+    } finally {
+      process.env.PATH = previousPath;
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('runs the pnpm global probe through the shell for a Windows store realpath', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'botmux-pnpm11-win32-'));
+    const previousPath = process.env.PATH;
+    try {
+      const pnpmHome = join(tempRoot, 'pnpm');
+      const storeRoot = join(pnpmHome, 'store', 'v11', 'links', '@', 'botmux', '3.11.0', 'hash');
+      const packageRoot = join(storeRoot, 'node_modules', 'botmux');
+      const customGlobal = join(tempRoot, 'custom-global');
+      const globalRoot = join(customGlobal, 'v11');
+      // On win32 the probe spawns `pnpm.cmd` via the shell; a shebang script
+      // named pnpm.cmd is executable by sh, so the same spawn path is covered.
+      // The marker proves the probe actually ran (a failed spawn would also
+      // fail closed, but without executing pnpm).
+      const probeMarker = join(tempRoot, 'probe-ran');
+      const fakePnpm = join(tempRoot, 'bin', 'pnpm.cmd');
+      mkdirSync(packageRoot, { recursive: true });
+      mkdirSync(join(tempRoot, 'bin'), { recursive: true });
+      writeFileSync(
+        fakePnpm,
+        `#!/bin/sh\ntouch '${probeMarker}'\nprintf '%s\\n' '[{"path":"${globalRoot}"}]'\n`,
+      );
+      chmodSync(fakePnpm, 0o755);
+      process.env.PATH = `${join(tempRoot, 'bin')}:${previousPath ?? ''}`;
+
+      // Probe runs but no stable link resolves: must fail closed, not throw.
+      expect(tryResolveGlobalInstallPlan(packageRoot, 'win32')).toBeNull();
+      expect(existsSync(probeMarker)).toBe(true);
     } finally {
       process.env.PATH = previousPath;
       rmSync(tempRoot, { recursive: true, force: true });

--- a/test/global-install.test.ts
+++ b/test/global-install.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
@@ -143,8 +143,12 @@ describe('resolveGlobalInstallPlan', () => {
 
       const startedAt = Date.now();
       expect(tryResolveGlobalInstallPlan(packageRoot, 'linux')).toBeNull();
-      // The probe must have been killed by its hard timeout, not waited out.
-      expect(Date.now() - startedAt).toBeLessThan(30_000);
+      const elapsed = Date.now() - startedAt;
+      // The probe must have been killed by its 5s hard timeout, not waited
+      // out (sleep 60) and not failed instantly for an unrelated reason
+      // (e.g. ENOENT would return in ~0s and pass the upper bound vacuously).
+      expect(elapsed).toBeGreaterThanOrEqual(4_000);
+      expect(elapsed).toBeLessThan(15_000);
     } finally {
       process.env.PATH = previousPath;
       rmSync(tempRoot, { recursive: true, force: true });
@@ -162,22 +166,25 @@ describe('resolveGlobalInstallPlan', () => {
       const globalRoot = join(customGlobal, 'v11');
       // On win32 the probe spawns `pnpm.cmd` via the shell; a shebang script
       // named pnpm.cmd is executable by sh, so the same spawn path is covered.
-      // The marker proves the probe actually ran (a failed spawn would also
-      // fail closed, but without executing pnpm).
-      const probeMarker = join(tempRoot, 'probe-ran');
+      // The marker records the exact argv the probe passed, proving it ran
+      // AND with the expected arguments (a spawn failure or wrong args would
+      // leave the marker absent and fail closed for the wrong reason).
+      const probeMarker = join(tempRoot, 'probe-argv');
       const fakePnpm = join(tempRoot, 'bin', 'pnpm.cmd');
       mkdirSync(packageRoot, { recursive: true });
       mkdirSync(join(tempRoot, 'bin'), { recursive: true });
       writeFileSync(
         fakePnpm,
-        `#!/bin/sh\ntouch '${probeMarker}'\nprintf '%s\\n' '[{"path":"${globalRoot}"}]'\n`,
+        `#!/bin/sh\nprintf '%s\\n' "$@" > '${probeMarker}'\nprintf '%s\\n' '[{"path":"${globalRoot}"}]'\n`,
       );
       chmodSync(fakePnpm, 0o755);
       process.env.PATH = `${join(tempRoot, 'bin')}:${previousPath ?? ''}`;
 
       // Probe runs but no stable link resolves: must fail closed, not throw.
       expect(tryResolveGlobalInstallPlan(packageRoot, 'win32')).toBeNull();
-      expect(existsSync(probeMarker)).toBe(true);
+      expect(readFileSync(probeMarker, 'utf8').split('\n').filter(Boolean)).toEqual([
+        'list', '-g', '--depth', '0', '--json',
+      ]);
     } finally {
       process.env.PATH = previousPath;
       rmSync(tempRoot, { recursive: true, force: true });

--- a/test/global-install.test.ts
+++ b/test/global-install.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
@@ -90,31 +90,40 @@ describe('resolveGlobalInstallPlan', () => {
 
   it('recognises the pnpm 11 store realpath behind a global symlink', () => {
     const root = '/home/bot/.local/share/pnpm/store/v11/links/@/botmux/3.11.0/hash/node_modules/botmux';
-    const plan = resolveGlobalInstallPlan(root, 'linux');
-    expect(plan).toMatchObject({
-      manager: 'pnpm',
-      command: 'pnpm',
-      args: ['add', '-g', '--global-dir', '/home/bot/.local/share/pnpm/global', 'botmux@latest'],
-    });
     expect(detectGlobalInstallManager(root, 'linux')).toBe('pnpm');
   });
 
-  it('uses the stable pnpm 11 global symlink for a store realpath', () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'botmux-pnpm11-store-'));
+  it('uses pnpm root -g for a custom global-dir and fails closed without its stable link', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'botmux-pnpm11-custom-global-'));
+    const previousPath = process.env.PATH;
     try {
       const pnpmHome = join(tempRoot, 'pnpm');
       const storeRoot = join(pnpmHome, 'store', 'v11', 'links', '@', 'botmux', '3.11.0', 'hash');
       const packageRoot = join(storeRoot, 'node_modules', 'botmux');
-      const globalRoot = join(pnpmHome, 'global', 'v11');
-      const stableDir = join(globalRoot, 'stable-hash');
+      const customGlobal = join(tempRoot, 'custom-global');
+      const globalRoot = join(customGlobal, 'v11');
+      const fakePnpm = join(tempRoot, 'bin', 'pnpm');
       mkdirSync(packageRoot, { recursive: true });
-      mkdirSync(globalRoot, { recursive: true });
-      symlinkSync(storeRoot, stableDir, 'dir');
+      mkdirSync(join(tempRoot, 'bin'), { recursive: true });
+      writeFileSync(fakePnpm, `#!/bin/sh\nprintf '%s\\n' '[{"path":"${globalRoot}"}]'\n`);
+      chmodSync(fakePnpm, 0o755);
+      process.env.PATH = `${join(tempRoot, 'bin')}:${previousPath ?? ''}`;
+
+      expect(tryResolveGlobalInstallPlan(packageRoot, 'linux')).toBeNull();
+
+      const runtimeRoot = join(globalRoot, 'runtime');
+      const stableDir = join(globalRoot, 'stable-hash');
+      mkdirSync(join(runtimeRoot, 'node_modules'), { recursive: true });
+      symlinkSync(packageRoot, join(runtimeRoot, 'node_modules', 'botmux'), 'dir');
+      symlinkSync(runtimeRoot, stableDir, 'dir');
 
       const plan = resolveGlobalInstallPlan(packageRoot, 'linux');
-
+      expect(plan.args).toEqual([
+        'add', '-g', '--global-dir', customGlobal, 'botmux@latest',
+      ]);
       expect(plan.activePackageRoot).toBe(join(stableDir, 'node_modules', 'botmux'));
     } finally {
+      process.env.PATH = previousPath;
       rmSync(tempRoot, { recursive: true, force: true });
     }
   });

--- a/test/global-install.test.ts
+++ b/test/global-install.test.ts
@@ -88,6 +88,37 @@ describe('resolveGlobalInstallPlan', () => {
     }
   });
 
+  it('recognises the pnpm 11 store realpath behind a global symlink', () => {
+    const root = '/home/bot/.local/share/pnpm/store/v11/links/@/botmux/3.11.0/hash/node_modules/botmux';
+    const plan = resolveGlobalInstallPlan(root, 'linux');
+    expect(plan).toMatchObject({
+      manager: 'pnpm',
+      command: 'pnpm',
+      args: ['add', '-g', '--global-dir', '/home/bot/.local/share/pnpm/global', 'botmux@latest'],
+    });
+    expect(detectGlobalInstallManager(root, 'linux')).toBe('pnpm');
+  });
+
+  it('uses the stable pnpm 11 global symlink for a store realpath', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'botmux-pnpm11-store-'));
+    try {
+      const pnpmHome = join(tempRoot, 'pnpm');
+      const storeRoot = join(pnpmHome, 'store', 'v11', 'links', '@', 'botmux', '3.11.0', 'hash');
+      const packageRoot = join(storeRoot, 'node_modules', 'botmux');
+      const globalRoot = join(pnpmHome, 'global', 'v11');
+      const stableDir = join(globalRoot, 'stable-hash');
+      mkdirSync(packageRoot, { recursive: true });
+      mkdirSync(globalRoot, { recursive: true });
+      symlinkSync(storeRoot, stableDir, 'dir');
+
+      const plan = resolveGlobalInstallPlan(packageRoot, 'linux');
+
+      expect(plan.activePackageRoot).toBe(join(stableDir, 'node_modules', 'botmux'));
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('preserves the Windows pnpm 11 global-dir path', () => {
     const root = String.raw`D:\pnpm\global\v11\2bd754-19fd4ccaab4-b6f57fa0272de3b8\node_modules\botmux`;
     const plan = resolveGlobalInstallPlan(root, 'win32');


### PR DESCRIPTION
## 变更

补全 pnpm 11 全局安装的自动更新检测，兼容 Node 通过 `import.meta.url` 暴露的 pnpm store 实路径：

```text
<pnpm-home>/store/v11/links/@/botmux/<version>/<hash>/node_modules/botmux
```

检测到该路径后，会反查对应的 `global/v11` 稳定入口，继续使用同一个 `--global-dir` 生成 pnpm 更新计划，并保留更新后的稳定包路径。

## 运行时传递链路

pnpm 11 全局安装时，实际链路是：

```text
pnpm bin/botmux
  -> global/v11/<runtime>/node_modules/botmux/dist/cli.js
  -> global/v11/<runtime>/node_modules/botmux（软链接）
  -> store/v11/links/@/botmux/<version>/<hash>/node_modules/botmux
  -> Node 加载模块
  -> import.meta.url
  -> botmuxInstallRoot()
  -> detectGlobalInstallManager()
  -> tryResolveGlobalInstallPlan()
  -> Dashboard 的 autoUpdateSupported
```

`global/v11/<runtime>` 是 pnpm 的逻辑入口，`store/v11/links` 是实际包目录。Node 默认解析软链接，因此 `import.meta.url` 通常最终暴露的是第二种路径。

## 背景与此前 PR 未覆盖的原因

此前的 pnpm 11 支持 PR #758 识别了：

```text
<pnpm-home>/global/v11/<runtime>/node_modules/botmux
```

并补充了该布局下的稳定入口查找。但它没有覆盖 Node 解析软链接后的：

```text
<pnpm-home>/store/v11/links/@/botmux/<version>/<hash>/node_modules/botmux
```

原因是之前的测试验证了 pnpm 全局项目的逻辑路径和构造出的 runtime 布局，却没有模拟“global 入口软链接到 store、再由 `import.meta.url` 取得 realpath”的完整链路。于是实际运行时会在 `detectGlobalInstallManager()` 阶段返回 `unknown`，根本不会进入后续的 pnpm 更新计划和稳定入口逻辑，Dashboard 最终显示不支持自动更新。

本次以 store realpath 为主要运行时路径，同时保留对未解析软链接时 global runtime 路径的兼容。

## 验证

- `pnpm exec vitest run --project unit test/global-install.test.ts`：22/22 通过
- `pnpm build`：通过
- 临时构造真实的 `global/v11/<runtime> -> store/v11/links` 软链接布局：
  - `manager = pnpm`
  - `autoUpdateSupported = true`
  - 更新目录正确解析为 `pnpm/global`
  - `activePackageRoot` 正确回到 `global/v11` 稳定入口
- 所有临时 fixture 均在测试结束后清理，未修改现有 pnpm 安装或 daemon


## 本机验证截图

截图中的本机用户名路径已脱敏，仅保留 pnpm 运行时路径结构：

![pnpm 11 自动更新检测验证](https://gist.githubusercontent.com/emosheeep/f9c7fc8648476eabfb9827250abdbea4/raw/botmux-pnpm11-update-redacted.svg)
