### PR TITLE
fix(herdr): adopt 复核回退进程 comm，修版本号命名的 CLI 被误判已退出

### DIFF
--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -759,14 +759,30 @@ function herdrPaneCliProcess(
     // reporting a live Pi pane as exited.
     const argv0 = typeof proc?.argv0 === 'string' ? proc.argv0 : undefined;
     const effectiveArgv = argv.length > 0 ? argv : argv0 ? [argv0] : [];
-    const cliId = cliIdFromCommArgv(
+    const pid = Number(proc?.pid);
+    const pidMatches = Number.isInteger(pid) && pid > 0 && (!expectedPid || pid === expectedPid);
+    let cliId = cliIdFromCommArgv(
       typeof proc?.name === 'string' ? proc.name : undefined,
       effectiveArgv,
       filterCliId,
       filterExecutable,
     );
-    const pid = Number(proc?.pid);
-    if (cliId && Number.isInteger(pid) && pid > 0 && (!expectedPid || pid === expectedPid)) {
+    // Herdr's `name` is the basename of the RESOLVED executable, so a CLI shipped
+    // as a version-named binary behind a stable symlink reports the version, not
+    // the CLI name — Claude Code 2.x installs `~/.local/bin/claude` as a symlink
+    // to `~/.local/share/claude/versions/2.1.224`, and herdr reports
+    // `name:"2.1.224"` for it. No CLI_COMM_MAP entry matches that, and the argv
+    // fallback only fires for COMM_ARGV_LAUNCHERS (node/python/…), so the
+    // `argv:["claude"]` sitting right beside it is never consulted. Discovery
+    // still lists the pane (agent-list reports `agent:"claude"`) while adopt
+    // revalidation resolves nothing → the pane is wrongly reported as exited.
+    // Our own readComm goes through /proc/<pid>/comm (Linux) or `ps -o comm=`
+    // (macOS), both of which keep the symlink name, so retry with it.
+    if (!cliId && pidMatches) {
+      const comm = readComm(pid);
+      if (comm) cliId = cliIdFromCommArgv(comm, effectiveArgv, filterCliId, filterExecutable);
+    }
+    if (cliId && pidMatches) {
       return { pid, cliId, cwd: typeof proc?.cwd === 'string' ? proc.cwd : undefined };
     }
   }

--- a/test/herdr-discovery.test.ts
+++ b/test/herdr-discovery.test.ts
@@ -100,6 +100,56 @@ describe('validateHerdrAdoptTarget', () => {
     expect(validateHerdrAdoptTarget('sess', 'pane-1', 3333, 'claude-code')).toBe('missing');
   });
 
+  it('falls back to the pane process comm when herdr reports a version-named binary', () => {
+    // Claude Code 2.x installs `~/.local/bin/claude` as a symlink to
+    // `~/.local/share/claude/versions/<version>`, and herdr's `name` is the
+    // basename of the RESOLVED executable — so it reports `2.1.224`, which no
+    // CLI_COMM_MAP entry matches. The argv fallback in cliIdFromCommArgv only
+    // fires for COMM_ARGV_LAUNCHERS (node/python/…), so `argv:["claude"]` is
+    // never consulted either. agent-list discovery still lists the pane, so
+    // without the comm fallback revalidation wrongly reports "exited".
+    mockExecFileSync
+      .mockReturnValueOnce(
+        JSON.stringify({ result: { agents: [{ pane_id: 'pane-1', agent: '/usr/bin/claude' }] } }) as any,
+      )
+      .mockReturnValueOnce(JSON.stringify({
+        result: {
+          process_info: {
+            foreground_processes: [{ pid: 4242, name: '2.1.224', argv: ['claude'] }],
+          },
+        },
+      }) as any);
+    // readComm on Linux reads /proc/<pid>/comm, which keeps the symlink name.
+    mockReadFileSync.mockImplementation(((path: unknown) => {
+      if (String(path) === '/proc/4242/comm') return 'claude\n';
+      throw new Error('ENOENT');
+    }) as any);
+
+    expect(validateHerdrAdoptTarget('sess', 'pane-1', 4242, 'claude-code')).toBe('alive');
+  });
+
+  it('keeps the cliId filter honoured on the comm fallback path', () => {
+    // The fallback must not become a hole in the filter: a codex pane stays
+    // unadoptable for a claude-code bot even when herdr's name is unrecognisable.
+    mockExecFileSync
+      .mockReturnValueOnce(
+        JSON.stringify({ result: { agents: [{ pane_id: 'pane-1', agent: '/usr/bin/codex' }] } }) as any,
+      )
+      .mockReturnValueOnce(JSON.stringify({
+        result: {
+          process_info: {
+            foreground_processes: [{ pid: 4242, name: '0.9.1', argv: ['codex'] }],
+          },
+        },
+      }) as any);
+    mockReadFileSync.mockImplementation(((path: unknown) => {
+      if (String(path) === '/proc/4242/comm') return 'codex\n';
+      throw new Error('ENOENT');
+    }) as any);
+
+    expect(validateHerdrAdoptTarget('sess', 'pane-1', 4242, 'claude-code')).toBe('missing');
+  });
+
   it('returns "missing" when herdr returns ok but pane is not in list', () => {
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify({ result: { agents: [{ pane_id: 'pane-other' }] } }) as any)


### PR DESCRIPTION
## 问题

在 herdr 里跑 Claude Code 时，`/adopt` 的卡片能正常列出 pane，但一点选就提示：

> ⚠️ 目标 CLI 会话已退出

而那个 CLI 进程其实活得好好的。

## 根因

herdr `pane process-info` 返回的 `name` 是**解析后**可执行文件的 basename。当 CLI 以「版本号命名的二进制 + 稳定软链」方式安装时，这个字段拿到的是版本号而不是 CLI 名。Claude Code 2.x 正是如此：

```
~/.local/bin/claude → ~/.local/share/claude/versions/2.1.224
```

同一台机器上实测，同一个进程两个来源报出的名字不一致：

| 来源 | 报告的进程名 |
|---|---|
| herdr `pane process-info` 的 `name` | `2.1.224` |
| 本仓库 `readComm`（`ps -o comm=`） | `claude` |

herdr 实际返回（已脱敏）：

```json
{"pid":56136,"name":"2.1.224","argv":["claude"],"argv0":"claude","cwd":"..."}
```

`2.1.224` 匹配不到任何 `CLI_COMM_MAP` 条目；而 `cliIdFromCommArgv` 的 argv 兜底只对 `COMM_ARGV_LAUNCHERS`（node/python/…）生效，所以紧挨着的 `argv:["claude"]` 根本没被看一眼，`herdrPaneCliProcess` 直接返回 `undefined`。

于是 discovery 与 validation 出现不对称：

| 阶段 | 代码路径 | 读什么 | 结果 |
|---|---|---|---|
| discovery（列卡片） | `herdrAgentCliId` | herdr 的 `agent:"claude"` | ✅ 认得出，pane 正常上卡片 |
| validation（点选复核） | `herdrPaneCliProcess` | 进程 `name:"2.1.224"` | ❌ 认不出 → `'missing'` |

链路：`herdrPaneCliProcess` → `undefined` → `validateHerdrAdoptTarget` → `'missing'` → `validateAdoptTarget` → `false` → `cmd.adopt.target_exited`。

这正是 `validateTmuxAdoptTarget` 上方注释早就预警过的那类不对称：

> discovery surfaces the session but validation re-identifies nothing and wrongly reports it exited

## 改动

herdr 报的 `name` 认不出时，回退到本仓库自己的 `readComm(pid)` 再判一次。`readComm` 走 `/proc/<pid>/comm`（Linux）或 `ps -o comm=`（macOS），两者拿到的都是软链名 `claude`，正好补上 herdr 这一路的盲区。

约束保持不变：

- 回退只在 pid 已满足 `expectedPid` 约束时触发（顺带避免给不相干进程白跑一次 comm 读取）
- `filterCliId` / `filterExecutable` 全程生效，不放宽 adopt 的目标范围

## 影响面

- 只动 herdr 一条 adopt 路径（`herdrPaneCliProcess`），tmux / zellij 的 discovery 与 validation 均未触碰
- 同一函数被 discovery（`cliPid` 解析）与 validation（adopt 复核）共用，两处一并受益 —— 此前 `cliPid` 解析不到还会连带影响 `sessionId` 探测
- 跨平台：Linux 走 `/proc`，macOS 走 `ps`，`readComm` 内部已分别处理；单测在 mock 成 linux 的环境下覆盖
- 额外开销仅在识别失败时多一次 comm 读取，`foreground_processes` 通常 1-3 个

## 测试验证

新增 2 个用例（`test/herdr-discovery.test.ts`）：

- `falls back to the pane process comm when herdr reports a version-named binary` —— 正向覆盖本 bug
- `keeps the cliId filter honoured on the comm fallback path` —— 确认回退没有变成 filter 的洞（codex pane 对 claude-code bot 仍不可 adopt）

```
$ npx vitest run --project unit test/herdr-discovery.test.ts
 ✓ unit  test/herdr-discovery.test.ts (16 tests) 3ms
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

**验证新用例确实能抓到这个 bug** —— 临时 stash 掉 `src/core/session-discovery.ts` 的改动后重跑：

```
 × falls back to the pane process comm when herdr reports a version-named binary
 Tests  1 failed | 15 passed (16)
```

即：不带修复时新用例失败，带修复时通过。

`pnpm build`：通过（`tsc` + dashboard bundle + `audit-dist` 均无报错）。

全量单测 `npx vitest run --project unit`：

| | Test Files | Tests |
|---|---|---|
| 干净 master（baseline） | 11 failed / 876 passed | 22 failed / 14530 passed |
| 本 PR | 9 failed / 878 passed | 20 failed / 14534 passed |

本 PR 未引入新失败。baseline 上就存在的失败集中在 `codex-app-*`、`workflow-cli`、`preset-export-cli`、`whiteboard-cli`、`slash-commands-doc-sync`、`worker-*` 等与本改动无关的模块，本机环境下表现为 flaky（例如 `git-worktree.test.ts` 在干净 master 上单独重跑同样失败，且每次失败的用例名都不同）。
