### PR TITLE
fix(worker): 修复首轮启动期卡片跳过工作中状态

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10727,7 +10727,47 @@ function startScreenUpdates(): void {
   // watermark — there we must capture every tick (see shouldCaptureScreen).
   let lastSnapshotPtyActivity = -1;
   screenUpdateTimer = setInterval(() => {
-    if (awaitingFirstPrompt) return;
+    if (awaitingFirstPrompt) {
+      // First-turn 「工作中」 narrow channel. The async sampler below is fully
+      // gated until the first turn ends (markPromptReady flips awaitingFirstPrompt)
+      // or the 15s soft timeout, so an argv-baked first prompt (Pi et al., which
+      // never goes through flushPending) emits NO screen_update for the whole
+      // turn — the daemon card sits at 'starting' and jumps straight to
+      // 「等待输入」 when the first idle lands, skipping 「工作中」 entirely.
+      // Publish a single 'working' edge when the authoritative viewport actually
+      // shows the CLI's busy marker, so the live card reflects real work mid-turn.
+      //
+      // Pure publisher: it only send()s a status and updates the local
+      // lastSentStatus dedup — it never touches isPromptReady, the idle detector,
+      // or the argv seed flags (spawnArgvInitialPromptBusy / -NeedsWorkingSeed),
+      // so the first-prompt evidence machinery and the end-of-turn working→idle
+      // seed are unchanged. Fail-open on non-authoritative screens (ZMX check
+      // first, before any capture) and a no-op without a busyPattern, so CLIs
+      // that render no detectable marker keep the original bare-return behavior.
+      if (lastSentStatus !== 'working'
+        && backendScreenEvidenceIsAuthoritativeForMutation()
+        && cliAdapter?.busyPattern
+        && backend
+        && canCaptureBusyPatternScreen(backend)) {
+        try {
+          const content = captureBackendScreen(backend);
+          if (content && cliAdapter.busyPattern.test(busyProbeRegion(content))) {
+            lastSentStatus = 'working';
+            send({
+              type: 'screen_update',
+              content,
+              status: 'working',
+              turnId: currentBotmuxTurnId,
+              dispatchAttempt: currentBotmuxDispatchAttempt,
+            });
+            log('First-turn busy marker on authoritative viewport — publishing working before first prompt');
+          }
+        } catch {
+          // Capture failed — preserve the original gate behavior (stay silent).
+        }
+      }
+      return;
+    }
 
     void (async () => {
       const { snapshot, status } = await snapshotWithLatestRuntimeStatus(async () => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9333,7 +9333,17 @@ function markPromptReady(): void {
   // make the CLI busy, so the idle state is transient and shouldn't appear
   // in the card.  This avoids a false "就绪" flash on daemon restart
   // (where the initial prompt is queued before the CLI becomes idle).
-  if (renderer && pendingMessages.length === 0 && pendingAdoptMessages.length === 0 && pendingRawInputs.length === 0 && pendingSessionRename === null && !isFlushing) {
+  //
+  // ALSO skip when the Grok-class busy arm is pending (spawnArgvInitialPromptBusy):
+  // for these adapters the FIRST ready is a pre-execution SessionStart edge, not a
+  // turn boundary — the argv-baked first prompt is still running. isPromptReady was
+  // just set true above, so this generic snapshot would project 'idle' and reach the
+  // daemon BEFORE the busy arm below re-publishes 'working'. Combined with the
+  // first-turn working already sent by startScreenUpdates, the daemon would then see
+  // working→idle and fire finishTurnReactions() — a premature ✅ DONE mid-turn (and a
+  // 「工作中→等待输入→工作中」 flicker on the open card). The busy arm below owns the
+  // correct 'working' publish for this path, so this idle must not escape first.
+  if (renderer && !spawnArgvInitialPromptBusy && pendingMessages.length === 0 && pendingAdoptMessages.length === 0 && pendingRawInputs.length === 0 && pendingSessionRename === null && !isFlushing) {
     const { content } = renderer.snapshot();
     send({
       type: 'screen_update',
@@ -10728,42 +10738,43 @@ function startScreenUpdates(): void {
   let lastSnapshotPtyActivity = -1;
   screenUpdateTimer = setInterval(() => {
     if (awaitingFirstPrompt) {
-      // First-turn 「工作中」 narrow channel. The async sampler below is fully
-      // gated until the first turn ends (markPromptReady flips awaitingFirstPrompt)
-      // or the 15s soft timeout, so an argv-baked first prompt (Pi et al., which
-      // never goes through flushPending) emits NO screen_update for the whole
-      // turn — the daemon card sits at 'starting' and jumps straight to
-      // 「等待输入」 when the first idle lands, skipping 「工作中」 entirely.
-      // Publish a single 'working' edge when the authoritative viewport actually
-      // shows the CLI's busy marker, so the live card reflects real work mid-turn.
+      // First-turn 「工作中」 publisher. The async sampler below is fully gated
+      // until the first turn ends (markPromptReady flips awaitingFirstPrompt) or
+      // the 15s soft timeout, so an argv-baked first prompt (Pi/Grok/…, delivered
+      // via the launch command — it never goes through flushPending) would emit
+      // NO screen_update for the whole turn: the daemon card sits at 'starting'
+      // and jumps straight to 「等待输入」 on the first idle, skipping 「工作中」.
       //
-      // Pure publisher: it only send()s a status and updates the local
-      // lastSentStatus dedup — it never touches isPromptReady, the idle detector,
-      // or the argv seed flags (spawnArgvInitialPromptBusy / -NeedsWorkingSeed),
-      // so the first-prompt evidence machinery and the end-of-turn working→idle
-      // seed are unchanged. Fail-open on non-authoritative screens (ZMX check
-      // first, before any capture) and a no-op without a busyPattern, so CLIs
-      // that render no detectable marker keep the original bare-return behavior.
-      if (lastSentStatus !== 'working'
-        && backendScreenEvidenceIsAuthoritativeForMutation()
-        && cliAdapter?.busyPattern
-        && backend
-        && canCaptureBusyPatternScreen(backend)) {
-        try {
-          const content = captureBackendScreen(backend);
-          if (content && cliAdapter.busyPattern.test(busyProbeRegion(content))) {
-            lastSentStatus = 'working';
-            send({
-              type: 'screen_update',
-              content,
-              status: 'working',
-              turnId: currentBotmuxTurnId,
-              dispatchAttempt: currentBotmuxDispatchAttempt,
-            });
-            log('First-turn busy marker on authoritative viewport — publishing working before first prompt');
-          }
-        } catch {
-          // Capture failed — preserve the original gate behavior (stay silent).
+      // The status projection already reads 'working' during turn one (isPromptReady
+      // is still false — same rule that makes every post-submit turn working), so we
+      // simply PUBLISH that projection once instead of scraping the screen for a busy
+      // marker. This is the general "sent to the CLI ⇒ working" model: it fires for
+      // every argv-baked first prompt (spawnArgvNeedsWorkingSeed), not just CLIs that
+      // happen to render a detectable busyPattern.
+      //
+      // Gate on spawnArgvNeedsWorkingSeed so it stays a no-op for a NON-argv first
+      // turn (Claude/Codex/type-ahead): there the prompt is still queued and the CLI
+      // is genuinely booting — not working — until flushPending() submits it after
+      // the ready edge. Empty-prompt adopt sessions also don't arm the flag, so an
+      // attach never falsely claims working.
+      //
+      // Pure publisher: it only send()s a status and updates the local lastSentStatus
+      // dedup — it never touches isPromptReady, the idle detector, or the argv seed
+      // flags (spawnArgvInitialPromptBusy / -NeedsWorkingSeed), so the first-prompt
+      // evidence machinery and the end-of-turn seed are unchanged.
+      if (spawnArgvNeedsWorkingSeed && lastSentStatus !== 'working' && renderer) {
+        const projected = projectedRuntimeScreenStatus();
+        if (projected === 'working') {
+          const { content } = renderer.snapshot();
+          lastSentStatus = 'working';
+          send({
+            type: 'screen_update',
+            content,
+            status: 'working',
+            turnId: currentBotmuxTurnId,
+            dispatchAttempt: currentBotmuxDispatchAttempt,
+          });
+          log('Argv-baked first prompt in flight — publishing projected working before first prompt');
         }
       }
       return;

--- a/test/worker-argv-reaction-status.integration.test.ts
+++ b/test/worker-argv-reaction-status.integration.test.ts
@@ -256,10 +256,10 @@ setInterval(() => {}, 1_000);
     const dataDir = join(root, 'session');
     mkdirSync(dataDir, { recursive: true });
 
-    // Argv-baked first prompt (no flushPending). The fake stays on Working...
-    // for the whole first turn, then clears the marker so the turn settles idle.
-    // The window must span at least a couple of SCREEN_UPDATE_INTERVAL_MS ticks
-    // so the first-turn narrow channel gets a chance to sample the busy marker.
+    // Argv-baked first prompt (no flushPending). The fake stays running for the
+    // whole first turn, then clears the screen so the turn settles idle. The
+    // window must span at least a couple of SCREEN_UPDATE_INTERVAL_MS ticks so the
+    // first-turn publisher gets a chance to emit the projected working.
     const fakePi = join(root, 'fake-pi');
     writeFileSync(fakePi, `#!/usr/bin/env node
 process.stdout.write('Working...\\n');
@@ -302,10 +302,12 @@ setInterval(() => {}, 1_000);
       turnId: 'om_turn',
     } satisfies DaemonToWorker);
 
-    // The narrow channel must publish `working` WHILE the first turn is still
-    // running — i.e. before prompt_ready. This log line is the proof it fired
-    // through the first-turn gate (the async sampler stays gated until then).
-    await waitForLog(child, logs, 'First-turn busy marker on authoritative viewport');
+    // The publisher must emit `working` WHILE the first turn is still running —
+    // i.e. before prompt_ready. This log line is the proof it fired through the
+    // first-turn gate (the async sampler stays gated until then). It publishes the
+    // projected status ('working' because isPromptReady is still false), not a
+    // scraped busy marker.
+    await waitForLog(child, logs, 'Argv-baked first prompt in flight — publishing projected working');
 
     // A working screen_update reached the daemon before the turn ended, and no
     // prompt_ready has escaped yet. (Without the fix the whole first turn is
@@ -316,8 +318,8 @@ setInterval(() => {}, 1_000);
     );
     expect(preReady.some(message => message.status === 'working'), JSON.stringify(messages)).toBe(true);
     expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
-    // Dedup: the narrow channel sends `working` at most once per first turn even
-    // though it samples every tick (lastSentStatus guard). Count the working
+    // Dedup: the publisher sends `working` at most once per first turn even
+    // though it runs every tick (lastSentStatus guard). Count the working
     // updates emitted before the first prompt_ready lands.
     await waitForPromptReady(child, messages, logs);
     const readyIdx = messages.findIndex(message => message.type === 'prompt_ready');
@@ -329,6 +331,93 @@ setInterval(() => {}, 1_000);
     // Once the fake clears Working..., the turn settles idle as usual.
     const updates = await waitForScreenUpdates(child, messages, 1, logs);
     expect(updates.at(-1)?.status).toBe('idle');
+  }, 25_000);
+
+  it('never lets an idle escape between the two working edges on a Grok-class first turn', async () => {
+    // Grok arms spawnArgvInitialPromptBusy (argv-baked prompt + injectsReadyHook +
+    // reliableTurnTerminal): its FIRST ready edge is pre-execution — the argv-baked
+    // first prompt is still running. markPromptReady() would otherwise publish a
+    // generic snapshot (projected idle, since isPromptReady was just set true)
+    // BEFORE the busy arm re-publishes working. Combined with the first-turn
+    // publisher's working, the daemon would see working→idle and fire
+    // finishTurnReactions() — a premature DONE mid-turn. This regression asserts the
+    // fix: after the first working, no idle may reach the daemon before the busy arm.
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-grok-first-turn-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+
+    // Fake Grok: emit output for ~4s (so the 2s first-turn publisher tick fires and
+    // sends the projected working while awaitingFirstPrompt), WITHOUT ever rendering
+    // Grok's busy marker (`Waiting for response…` / `Ctrl+c:cancel`) — otherwise the
+    // screen-idle busy guard would defer readiness and markPromptReady()'s seed
+    // (the code under test) would never run. Then go quiet so the idle detector
+    // drives markPromptReady() (the ready-gate preflight fails without an installed
+    // SessionStart hook, so readiness falls to the idle path — no session_ready IPC
+    // needed). The composer `❯` renders idle-looking; the busy arm is what keeps the
+    // turn `working`, exactly the pre-execution SessionStart shape.
+    const fakeGrok = join(root, 'fake-grok');
+    writeFileSync(fakeGrok, `#!/usr/bin/env node
+process.stdout.write('❯ booting\\n');
+let n = 0;
+const iv = setInterval(() => { process.stdout.write('.'); if (++n >= 8) clearInterval(iv); }, 500);
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakeGrok, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-grok-first-turn',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-grok-first-turn',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'grok',
+      cliPathOverride: fakeGrok,
+      backendType: 'pty',
+      prompt: 'hello from argv',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_turn',
+    } satisfies DaemonToWorker);
+
+    // The first-turn publisher emits the projected working before any ready edge.
+    await waitForLog(child, logs, 'Argv-baked first prompt in flight — publishing projected working');
+    // Then the Grok-class busy arm runs inside markPromptReady() and re-publishes
+    // working. Reaching this log proves we passed the generic-snapshot point (9337)
+    // that the fix must keep from emitting idle.
+    await waitForLog(child, logs, 'reporting working (not idle) so turn reactions can settle later');
+    // Let any stray snapshot land.
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 500));
+
+    // The daemon-visible sequence up to the busy arm must be all-working, no idle:
+    // the publisher's working, then the arm's working — and crucially NO idle in
+    // between (that idle is what fired the premature DONE / the 工作中→等待输入→工作中
+    // flicker).
+    const statuses = messages
+      .filter((m): m is Extract<WorkerToDaemon, { type: 'screen_update' }> => m.type === 'screen_update')
+      .map(m => m.status);
+    expect(statuses.length, JSON.stringify(messages)).toBeGreaterThanOrEqual(1);
+    expect(statuses.includes('working'), JSON.stringify(messages)).toBe(true);
+    expect(statuses.includes('idle'), JSON.stringify(messages)).toBe(false);
   }, 25_000);
 
   it.skipIf(!tmuxAvailable)('keeps an adopted Pi pane working until its viewport loses Working...', async () => {

--- a/test/worker-argv-reaction-status.integration.test.ts
+++ b/test/worker-argv-reaction-status.integration.test.ts
@@ -250,6 +250,87 @@ setInterval(() => {}, 1_000);
     expect(updates.at(-1)?.status).toBe('idle');
   }, 25_000);
 
+  it('publishes a working card during an argv-baked first turn before it completes', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-first-turn-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+
+    // Argv-baked first prompt (no flushPending). The fake stays on Working...
+    // for the whole first turn, then clears the marker so the turn settles idle.
+    // The window must span at least a couple of SCREEN_UPDATE_INTERVAL_MS ticks
+    // so the first-turn narrow channel gets a chance to sample the busy marker.
+    const fakePi = join(root, 'fake-pi');
+    writeFileSync(fakePi, `#!/usr/bin/env node
+process.stdout.write('Working...\\n');
+setTimeout(() => process.stdout.write('\\x1b[2J\\x1b[HDone without transcript final\\n'), 6_000);
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakePi, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-pi-first-turn',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-pi-first-turn',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'pi',
+      cliPathOverride: fakePi,
+      backendType: 'pty',
+      prompt: 'hello from argv',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_turn',
+    } satisfies DaemonToWorker);
+
+    // The narrow channel must publish `working` WHILE the first turn is still
+    // running — i.e. before prompt_ready. This log line is the proof it fired
+    // through the first-turn gate (the async sampler stays gated until then).
+    await waitForLog(child, logs, 'First-turn busy marker on authoritative viewport');
+
+    // A working screen_update reached the daemon before the turn ended, and no
+    // prompt_ready has escaped yet. (Without the fix the whole first turn is
+    // silent — the card would sit at `starting` until the terminal idle.)
+    const preReady = messages.filter(
+      (message): message is Extract<WorkerToDaemon, { type: 'screen_update' }> =>
+        message.type === 'screen_update',
+    );
+    expect(preReady.some(message => message.status === 'working'), JSON.stringify(messages)).toBe(true);
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+    // Dedup: the narrow channel sends `working` at most once per first turn even
+    // though it samples every tick (lastSentStatus guard). Count the working
+    // updates emitted before the first prompt_ready lands.
+    await waitForPromptReady(child, messages, logs);
+    const readyIdx = messages.findIndex(message => message.type === 'prompt_ready');
+    const workingBeforeReady = messages
+      .slice(0, readyIdx)
+      .filter(message => message.type === 'screen_update' && message.status === 'working');
+    expect(workingBeforeReady.length, JSON.stringify(messages)).toBe(1);
+
+    // Once the fake clears Working..., the turn settles idle as usual.
+    const updates = await waitForScreenUpdates(child, messages, 1, logs);
+    expect(updates.at(-1)?.status).toBe('idle');
+  }, 25_000);
+
   it.skipIf(!tmuxAvailable)('keeps an adopted Pi pane working until its viewport loses Working...', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-adopt-busy-'));
     tempDirs.add(root);

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -511,6 +511,43 @@ describe('worker structured-turn status wiring', () => {
     expect(probe).toContain('if (!backendScreenEvidenceIsAuthoritativeForMutation()) return;');
   });
 
+  it('publishes first-turn working only on an authoritative viewport with a busy marker, as a pure publisher', () => {
+    const startScreen = functionSlice('startScreenUpdates', 'stopScreenUpdates');
+    const gate = startScreen.indexOf('if (awaitingFirstPrompt) {');
+    const gateEnd = startScreen.indexOf('void (async () => {', gate);
+    expect(gate).toBeGreaterThanOrEqual(0);
+    expect(gateEnd).toBeGreaterThan(gate);
+    const channel = startScreen.slice(gate, gateEnd);
+
+    // B: the authoritative-screen check (ZMX fail-open) must precede any capture,
+    // and a busyPattern is required — a CLI without a marker keeps the bare
+    // return and never captures. Ordering: authoritative gate < capture call.
+    const authGate = channel.indexOf('backendScreenEvidenceIsAuthoritativeForMutation()');
+    const busyRequired = channel.indexOf('cliAdapter?.busyPattern');
+    const capture = channel.indexOf('captureBackendScreen(backend)');
+    expect(authGate).toBeGreaterThanOrEqual(0);
+    expect(busyRequired).toBeGreaterThan(authGate);
+    expect(capture).toBeGreaterThan(busyRequired);
+    // The busy marker itself gates the send, and the channel still ends in the
+    // original bare `return` so the async sampler stays gated during turn one.
+    expect(channel).toContain('cliAdapter.busyPattern.test(busyProbeRegion(content))');
+    expect(channel).toContain("status: 'working'");
+    // The channel still ends in the original bare `return;` (last statement
+    // before the gate block closes) so the async sampler stays gated during
+    // turn one exactly as before.
+    expect(/return;\s*}\s*$/.test(channel.trimEnd())).toBe(true);
+
+    // Pure publisher: dedup via the local lastSentStatus only; it must NOT touch
+    // isPromptReady, the idle detector, or the argv seed flags — otherwise it
+    // would perturb the first-prompt evidence machinery / end-of-turn seed.
+    expect(channel).toContain("lastSentStatus !== 'working'");
+    expect(channel).toContain("lastSentStatus = 'working'");
+    expect(channel).not.toContain('isPromptReady =');
+    expect(channel).not.toContain('idleDetector');
+    expect(channel).not.toContain('spawnArgvInitialPromptBusy =');
+    expect(channel).not.toContain('spawnArgvNeedsWorkingSeed =');
+  });
+
   it('carries the structured mark through adopt submit confirmation and exception cleanup', () => {
     const adopt = functionSlice('writeAdoptMessage', 'isWorkflowWorker');
     const handler = source.slice(source.indexOf("case 'message':"), source.indexOf("case 'raw_input':"));

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -511,7 +511,7 @@ describe('worker structured-turn status wiring', () => {
     expect(probe).toContain('if (!backendScreenEvidenceIsAuthoritativeForMutation()) return;');
   });
 
-  it('publishes first-turn working only on an authoritative viewport with a busy marker, as a pure publisher', () => {
+  it('publishes first-turn working from the projected status for argv-baked prompts, as a pure publisher', () => {
     const startScreen = functionSlice('startScreenUpdates', 'stopScreenUpdates');
     const gate = startScreen.indexOf('if (awaitingFirstPrompt) {');
     const gateEnd = startScreen.indexOf('void (async () => {', gate);
@@ -519,22 +519,23 @@ describe('worker structured-turn status wiring', () => {
     expect(gateEnd).toBeGreaterThan(gate);
     const channel = startScreen.slice(gate, gateEnd);
 
-    // B: the authoritative-screen check (ZMX fail-open) must precede any capture,
-    // and a busyPattern is required — a CLI without a marker keeps the bare
-    // return and never captures. Ordering: authoritative gate < capture call.
-    const authGate = channel.indexOf('backendScreenEvidenceIsAuthoritativeForMutation()');
-    const busyRequired = channel.indexOf('cliAdapter?.busyPattern');
-    const capture = channel.indexOf('captureBackendScreen(backend)');
-    expect(authGate).toBeGreaterThanOrEqual(0);
-    expect(busyRequired).toBeGreaterThan(authGate);
-    expect(capture).toBeGreaterThan(busyRequired);
-    // The busy marker itself gates the send, and the channel still ends in the
-    // original bare `return` so the async sampler stays gated during turn one.
-    expect(channel).toContain('cliAdapter.busyPattern.test(busyProbeRegion(content))');
+    // Gated on spawnArgvNeedsWorkingSeed (argv-baked first prompt), NOT on
+    // busyPattern: a non-argv first turn (Claude/Codex/type-ahead) is still booting,
+    // so the publisher must be a no-op there and let the queued prompt flush after
+    // the ready edge.
+    expect(channel).toContain('spawnArgvNeedsWorkingSeed');
+    // It publishes the PROJECTED status ('working' during turn one because
+    // isPromptReady is still false) rather than scraping the screen for a busy
+    // marker — this is the general "sent to the CLI ⇒ working" model.
+    expect(channel).toContain('projectedRuntimeScreenStatus()');
+    expect(channel).toContain("projected === 'working'");
     expect(channel).toContain("status: 'working'");
-    // The channel still ends in the original bare `return;` (last statement
-    // before the gate block closes) so the async sampler stays gated during
-    // turn one exactly as before.
+    // No screen-scraping: the old busyPattern/capture path is gone from this gate.
+    expect(channel).not.toContain('cliAdapter?.busyPattern');
+    expect(channel).not.toContain('busyProbeRegion(content)');
+    expect(channel).not.toContain('captureBackendScreen(');
+    // The channel still ends in the original bare `return;` so the async sampler
+    // stays gated during turn one exactly as before.
     expect(/return;\s*}\s*$/.test(channel.trimEnd())).toBe(true);
 
     // Pure publisher: dedup via the local lastSentStatus only; it must NOT touch
@@ -547,6 +548,26 @@ describe('worker structured-turn status wiring', () => {
     expect(channel).not.toContain('spawnArgvInitialPromptBusy =');
     expect(channel).not.toContain('spawnArgvNeedsWorkingSeed =');
   });
+
+  it('suppresses the markPromptReady generic idle snapshot while the Grok-class busy arm is pending', () => {
+    const body = functionSlice('markPromptReady', 'persistCliSessionId');
+    // The "immediate idle snapshot" fires before the seed consumes
+    // spawnArgvInitialPromptBusy. For a Grok-class pre-execution ready edge that
+    // generic snapshot projects idle (isPromptReady just went true) and would reach
+    // the daemon BEFORE the busy arm re-publishes working — combined with the
+    // first-turn publisher's working, that working→idle fires a premature DONE. The
+    // snapshot must be gated on !spawnArgvInitialPromptBusy so no idle escapes.
+    const idleSnapshot = body.indexOf('Send immediate idle snapshot');
+    const guardedSend = body.indexOf('renderer && !spawnArgvInitialPromptBusy && pendingMessages.length === 0', idleSnapshot);
+    expect(idleSnapshot).toBeGreaterThanOrEqual(0);
+    expect(guardedSend).toBeGreaterThan(idleSnapshot);
+    // The busy arm below still owns the working publish for this path.
+    const busyArm = body.indexOf('if (spawnArgvInitialPromptBusy) {', guardedSend);
+    const armWorking = body.indexOf("publishScreenStatus('working', { force: true })", busyArm);
+    expect(busyArm).toBeGreaterThan(guardedSend);
+    expect(armWorking).toBeGreaterThan(busyArm);
+  });
+
 
   it('carries the structured mark through adopt submit confirmation and exception cleanup', () => {
     const adopt = functionSlice('writeAdoptMessage', 'isWorkflowWorker');


### PR DESCRIPTION
## 改了什么、为什么

用户给 Pi 发第一句话时，飞书卡片从「启动中」直接跳「等待输入」，缺「工作中」状态。修复遵循「消息成功发给 CLI 即 working」的既有投影模型，并收敛触发范围，避免波及其它 CLI。

**根因（已实证）**
- 首条消息走 argv 烘焙（`passesInitialPromptViaArgs`），不经 `flushPending`。
- `worker.ts` `startScreenUpdates()` 的 2s 采样器被 `if (awaitingFirstPrompt) return;` 整个 gate 掉，要等首轮结束的 `markPromptReady` 或 15s 软超时才解除，期间 daemon 收不到任何 `screen_update`。
- 关键：首轮的状态**投影本就是 `working`**（`isPromptReady` 初始为 false，投影规则 `isPromptReady ? idle : working` 与提交后每一轮一致）——问题不是缺 working 态，而是这条投影在首轮被上面那句裸 `return` **静音**了，没往 daemon 发。
- daemon 侧卡片状态 = `lastScreenStatus ?? 'starting'`，首轮结束收到第一条 `screen_update(idle)` 时直接跳「等待输入」。

## 怎么改

**改动一 · 首轮通道（`startScreenUpdates`）**：把裸 `if (awaitingFirstPrompt) return;` 换成一条**投影发布者**（不再截屏找 busyPattern）：
1. 闸门 `spawnArgvNeedsWorkingSeed`——即「argv 烘焙了首条 prompt」。对非 argv 首轮（Claude/Codex/type-ahead，prompt 还在队列、CLI 真在启动）保持 no-op；空 prompt 的 adopt 会话也不 arm 该 flag，不误报 working。
2. 读 `projectedRuntimeScreenStatus()`；仅当投影为 `working`（首轮 `isPromptReady=false` 即成立）时发一次 `working` 的 `screen_update`（当前快照 + `turnId`/`dispatchAttempt`）。
3. `lastSentStatus !== 'working'` 去重，发后置 `lastSentStatus = 'working'`。
4. 末尾仍是原来的裸 `return`，async 采样器主体在首轮期间照旧不跑。

**纯 publisher**：只 `send` 状态 + 更新本地 `lastSentStatus`，不改 `isPromptReady` / idle detector / `spawnArgvInitialPromptBusy` / `spawnArgvNeedsWorkingSeed` 任一状态。首轮就绪证据机制、首轮结束的 seed 均不变。

**改动二 · `markPromptReady` 的通用 idle 快照（worker.ts:9337）**：加 `!spawnArgvInitialPromptBusy` 闸。
- Grok 类（argv + `injectsReadyHook` + `reliableTurnTerminal`）的**首个 ready 是执行前的 SessionStart 边沿，不是收尾**——`spawnArgvInitialPromptBusy` 存在正是为此。
- `markPromptReady` 在消费该 busy arm **之前**会先发一条通用 idle 快照：此刻 `isPromptReady` 刚置 true → 投影成 `idle`，抢在下方 arm 补 `working` 之前到达 daemon。它与改动一在首轮已发的 `working` 组成 `working→idle`，触发 daemon `finishTurnReactions()` → **过早 ✅ DONE**（并在实时卡片上表现为「工作中→等待输入→工作中」闪变）。
- 加闸后，Grok 类跳过这条 idle 快照；`working` 由下方 busy arm 负责发布，`idle` 不再抢跑。真正的收尾 idle（`assistant_final`/`fireIdle`）仍照常形成 daemon 所需的 `working→idle` 边。

## 影响面

- **落点**：`worker.ts` 两处——`startScreenUpdates()` 首轮 gate 分支、`markPromptReady()` 的立即 idle 快照守卫。async 采样器主体、busy arm、seed 逻辑逐字未动。
- **跨 CLI**：
  - 改动一惠及**所有 argv 烘焙首轮**（`spawnArgvNeedsWorkingSeed`：Pi/Gemini/MTR/OpenCode/Grok），不再挑「是否有 busyPattern」。已逐个核对：Claude/Codex/traex/coco/kimi/hermes 均 `passesInitialPromptViaArgs=false` → flag 为 false → 该分支 no-op（它们经正常 `flushPending` 提交后自然显示 working）。
  - 改动二只影响 arm 了 `spawnArgvInitialPromptBusy` 的 **Grok 类**（需 argv + `injectsReadyHook` + `reliableTurnTerminal` 三者全真，当前仅 Grok 满足）。Pi 走 `spawnArgvNeedsWorkingSeed` seed 路径、其 `working→idle` 是真收尾，不受改动二影响。
  - `shouldTrackArgvBakedFirstPrompt` 要求 `preparedInitialPrompt` 非空且未 defer → adopt 空 prompt、defer/queued prompt 均返回 false，不误报。
- **跨后端**：改动一读 `renderer.snapshot()` + 投影，不依赖后端截屏能力；PtyBackend / TmuxBackend 一致。
- **公共层**：未改。

## 测试验证

- **新增 Pi 首轮集成回归** `test/worker-argv-reaction-status.integration.test.ts`「publishes a working card during an argv-baked first turn before it completes」：fake Pi argv 首轮，断言 `prompt_ready` **之前**已收到 `status: working` 且**只发一次**（`lastSentStatus` 去重），随后正常 `idle`。**撤掉改动一后该用例转红**（首轮全程静默）。
- **新增 Grok 状态序列回归** 同文件「never lets an idle escape between the two working edges on a Grok-class first turn」：驱动真实 worker + fake Grok 走首个 ready 边沿，断言首轮发过 `working` 后、terminal 前**不得出现 `idle`**。**撤掉改动二后该用例转红**（idle 泄漏、`includes('idle')` 变 true，复现过早 DONE 序列）。
- **新增/更新源码级回归** `test/worker-structured-lifecycle-status.test.ts`：钉住首轮通道按 `spawnArgvNeedsWorkingSeed` + 投影发布、不再截屏、纯 publisher 不碰就绪/idle/seed；并钉住 `markPromptReady` 的 idle 快照带 `!spawnArgvInitialPromptBusy` 闸、working 由下方 arm 发。
- `pnpm build` 通过；`tsc --noEmit` 通过（exit 0）。
- 两个 PR 测试文件 34 项全绿（含既有 Pi 三例 + gemini seed 例 + 新增 Pi/Grok 首轮例）。
- 说明：CI 若见 `slash-commands-doc-sync`（缺 `/introduce`）与 gemini seed 顺序失败，均在 PR base `426b8f7a0` 原样复现，PR 未改相关文件，与本改动无关。
- 未切 live daemon。worker 热路径，合并后需 `pnpm switch:here && pnpm daemon:restart`（canonical checkout）方在飞书生效；如需飞书内手动验证 Pi/Grok 首轮卡片请先告知。
