### PR TITLE
fix(traex): 阻止 adopt 误归因内部消息

### DIFF
--- a/src/features/codex-notifier/internal-turn.ts
+++ b/src/features/codex-notifier/internal-turn.ts
@@ -1,3 +1,5 @@
+export { isInternalCodexSessionMeta } from '../../services/codex-session-meta.js';
+
 const TITLE_GENERATOR_HEADER = /^\s*You\s+are\s+a\s+helpful\s+assistant\.\s+You\s+will\s+be\s+presented\s+with\s+a\s+user\s+prompt,\s+and\s+your\s+job\s+is\s+to\s+provide\s+a\s+short\s+title\s+for\s+a\s+task\b/i;
 const AMBIENT_SUGGESTIONS_WORKER_HEADER = /^\s*Generate\s+\d+\s+to\s+\d+\s+ambient\s+suggestions\b/i;
 const HYPERPERSONALIZED_SUGGESTIONS_WORKER_HEADER = /^\s*#\s*Overview\s+Generate\s+\d+\s+to\s+\d+\s+hyperpersonalized\s+suggestions\b/i;
@@ -26,15 +28,4 @@ export function isInternalCodexPrompt(prompt: unknown): boolean {
     || GUARDIAN_REVIEWER_HEADER.test(prompt)
     || APPROVAL_REVIEW_HEADER.test(prompt)
     || AGENT_BOX_RUNTIME_HEADER.test(prompt);
-}
-
-/** session_meta.source 是协议级来源；出现 internal/subagent 时不属于用户主任务。 */
-export function isInternalCodexSessionMeta(meta: unknown): boolean {
-  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return false;
-  const payload = meta as Record<string, unknown>;
-  if (typeof payload.thread_source === 'string' && payload.thread_source !== 'user') return true;
-  const source = payload.source;
-  if (!source || typeof source !== 'object' || Array.isArray(source)) return false;
-  const sourceRecord = source as Record<string, unknown>;
-  return sourceRecord.internal !== undefined || sourceRecord.subagent !== undefined;
 }

--- a/src/services/codex-session-meta.ts
+++ b/src/services/codex-session-meta.ts
@@ -1,0 +1,11 @@
+/** `session_meta.source` is the protocol-level origin. Internal/subagent
+ * sessions are runtime helpers rather than the user's visible top-level task. */
+export function isInternalCodexSessionMeta(meta: unknown): boolean {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return false;
+  const payload = meta as Record<string, unknown>;
+  if (typeof payload.thread_source === 'string' && payload.thread_source !== 'user') return true;
+  const source = payload.source;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) return false;
+  const sourceRecord = source as Record<string, unknown>;
+  return sourceRecord.internal !== undefined || sourceRecord.subagent !== undefined;
+}

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -3,7 +3,9 @@
  *
  * TRAE is a Codex-family CLI, but its terminal event is NOT byte-identical to
  * upstream Codex:
- *   - user input is a response_item role=user message, like Codex;
+ *   - genuine user input is confirmed by event_msg `user_message`; TRAE also
+ *     writes internal runtime injections as response_item role=user messages,
+ *     so those records alone are not user-attribution evidence;
  *   - assistant response_item messages have no `phase` and are emitted many
  *     times during tool use, so none of them is a safe turn boundary;
  *   - event_msg `task_complete` is the durable end-of-turn marker and carries
@@ -34,6 +36,7 @@ import {
   type CodexDrainResult,
   codexSessionIdFromRolloutPath,
 } from './codex-transcript.js';
+import { isInternalCodexSessionMeta } from './codex-session-meta.js';
 import { baselineJsonlCursor } from './jsonl-cursor.js';
 import { traeSessionsRoot } from './traex-paths.js';
 
@@ -54,24 +57,27 @@ export interface TraexRuntimeSnapshot {
 }
 
 const IS_LINUX = platform() === 'linux';
+const TRAEX_SESSION_META_SCAN_MAX_BYTES = 4 * 1024 * 1024;
+
+type TraexRolloutKind = 'user' | 'internal' | 'legacy' | 'empty' | 'pending';
+
+interface TraexRolloutRef {
+  path: string;
+  cliSessionId: string;
+  kind: TraexRolloutKind;
+  startedAtMs?: number;
+}
+
+const traexRolloutMetaCache = new Map<string, {
+  kind: TraexRolloutKind;
+  startedAtMs?: number;
+}>();
 
 /** Upper bound on how far back readLatestTraexRuntime scans for the newest
  * model/effort. The newest turn_context sits near the tail, so this is only a
  * pathological-file guard (cf. #740): never synchronously parse a multi-GB
  * rollout on attach just to surface advisory runtime identity. */
 const TRAEX_RUNTIME_SCAN_MAX_BYTES = 4 * 1024 * 1024;
-
-function joinInputText(content: unknown): string {
-  if (!Array.isArray(content)) return '';
-  const parts: string[] = [];
-  for (const block of content) {
-    if (block && typeof block === 'object' && (block as any).type === 'input_text') {
-      const text = (block as any).text;
-      if (typeof text === 'string') parts.push(text);
-    }
-  }
-  return parts.join('');
-}
 
 function eventTimestampMs(value: unknown): number {
   const parsed = typeof value === 'string' ? Date.parse(value) : NaN;
@@ -153,10 +159,10 @@ export function drainTraexRollout(path: string, fromOffset: number): TraexDrainR
       timestampMs: eventTimestampMs(obj.timestamp),
       ...(sourceSessionId ? { sourceSessionId } : {}),
     };
-    if (obj.type === 'response_item'
-      && payload.type === 'message'
-      && payload.role === 'user') {
-      const userText = joinInputText(payload.content);
+    if (obj.type === 'event_msg'
+      && payload.type === 'user_message'
+      && typeof payload.message === 'string') {
+      const userText = payload.message;
       if (userText) events.push({ ...base, kind: 'user', text: userText });
       continue;
     }
@@ -280,7 +286,7 @@ function normaliseInputText(text: string): string {
 }
 
 /** Authoritative submit confirmation used by the adapter. Only a complete
- * role=user rollout record appended after `fromOffset` can match. */
+ * event_msg/user_message record appended after `fromOffset` can match. */
 export function traexRolloutHasUserInputSince(
   path: string,
   fromOffset: number,
@@ -382,6 +388,123 @@ function matchTraexRolloutPath(target: string): { path: string; cliSessionId: st
   return { path: target, cliSessionId: sid };
 }
 
+function traexRolloutMeta(path: string): {
+  kind: TraexRolloutKind;
+  startedAtMs?: number;
+} {
+  const cached = traexRolloutMetaCache.get(path);
+  if (cached) return cached;
+
+  let size: number;
+  try { size = statSync(path).size; } catch { return { kind: 'empty' }; }
+  if (size <= 0) return { kind: 'empty' };
+
+  const length = Math.min(size, TRAEX_SESSION_META_SCAN_MAX_BYTES);
+  const buffer = Buffer.alloc(length);
+  let bytesRead = 0;
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, 'r');
+    bytesRead = readSync(fd, buffer, 0, length, 0);
+  } catch {
+    return { kind: 'pending' };
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+
+  const content = buffer.subarray(0, bytesRead);
+  const newline = content.indexOf(0x0a);
+  if (newline < 0) return { kind: 'pending' };
+
+  let entry: any;
+  try { entry = JSON.parse(content.subarray(0, newline).toString('utf8')); } catch {
+    return { kind: 'pending' };
+  }
+  if (entry?.type !== 'session_meta' || !entry.payload || typeof entry.payload !== 'object') {
+    const result = { kind: 'legacy' as const };
+    traexRolloutMetaCache.set(path, result);
+    return result;
+  }
+
+  const payload = entry.payload;
+  const threadSource = payload.thread_source;
+  let kind: TraexRolloutKind = 'legacy';
+  if (isInternalCodexSessionMeta(payload)) {
+    kind = 'internal';
+  } else if (threadSource === 'user') {
+    kind = 'user';
+  }
+  const rawTimestamp = typeof payload.timestamp === 'string'
+    ? payload.timestamp
+    : typeof entry.timestamp === 'string'
+      ? entry.timestamp
+      : undefined;
+  const parsedTimestamp = rawTimestamp ? Date.parse(rawTimestamp) : NaN;
+  const result = {
+    kind,
+    ...(Number.isFinite(parsedTimestamp) ? { startedAtMs: parsedTimestamp } : {}),
+  };
+  if (traexRolloutMetaCache.size >= 512) {
+    const oldest = traexRolloutMetaCache.keys().next().value;
+    if (oldest) traexRolloutMetaCache.delete(oldest);
+  }
+  traexRolloutMetaCache.set(path, result);
+  return result;
+}
+
+function traexRolloutRefs(targets: Iterable<string>): TraexRolloutRef[] {
+  const refs = new Map<string, TraexRolloutRef>();
+  for (const target of targets) {
+    const hit = matchTraexRolloutPath(target);
+    if (!hit || refs.has(hit.path)) continue;
+    refs.set(hit.path, { ...hit, ...traexRolloutMeta(hit.path) });
+  }
+  return [...refs.values()];
+}
+
+function newestTraexRollout(refs: TraexRolloutRef[]): TraexRolloutRef | undefined {
+  const timestamped = refs.filter(
+    (ref): ref is TraexRolloutRef & { startedAtMs: number } => ref.startedAtMs !== undefined,
+  );
+  if (timestamped.length === 0) return undefined;
+  const maxStartedAt = Math.max(...timestamped.map(ref => ref.startedAtMs));
+  const newest = timestamped.filter(ref => ref.startedAtMs === maxStartedAt);
+  return newest.length === 1 ? newest[0] : undefined;
+}
+
+function selectableTraexRollouts(refs: TraexRolloutRef[]): TraexRolloutRef[] {
+  const userRefs = refs.filter(ref => ref.kind === 'user');
+  if (userRefs.length > 0) return userRefs;
+  const legacyRefs = refs.filter(ref => ref.kind === 'legacy');
+  if (legacyRefs.length > 0) return legacyRefs;
+  if (refs.some(ref => ref.kind === 'internal' || ref.kind === 'pending')) return [];
+  const emptyRefs = refs.filter(ref => ref.kind === 'empty');
+  return emptyRefs.length === 1 ? emptyRefs : [];
+}
+
+function selectTraexRollout(
+  refs: TraexRolloutRef[],
+  preferredSessionId?: string,
+): TraexRolloutRef | undefined {
+  const candidates = selectableTraexRollouts(refs);
+  if (candidates.length === 0) return undefined;
+
+  const preferred = preferredSessionId
+    ? candidates.find(ref => ref.cliSessionId.toLowerCase() === preferredSessionId.toLowerCase())
+    : undefined;
+  const newest = newestTraexRollout(candidates);
+  if (preferred) {
+    if (newest?.startedAtMs !== undefined
+      && preferred.startedAtMs !== undefined
+      && newest.startedAtMs > preferred.startedAtMs) {
+      return newest;
+    }
+    return preferred;
+  }
+  if (candidates.length === 1) return candidates[0];
+  return newest;
+}
+
 /** Enumerate the file paths a pid holds open (Linux /proc, else lsof). Shared
  *  by findTraexRolloutByPid (single) and findTraexRolloutSetByPid (ownership
  *  set) so both derive from one source. Returns undefined when enumeration is
@@ -412,17 +535,19 @@ function traexProcessOpenTargets(pid: number): string[] | undefined {
   return targets;
 }
 
-/** Find the rollout file an externally-running TRAE process has open.
- *  Same /proc/<pid>/fd strategy as findCodexRolloutByPid, but with a
- *  TRAE-specific path matcher so we never bind to a sibling Codex pane. */
-export function findTraexRolloutByPid(pid: number): { path: string; cliSessionId: string } | undefined {
+/** Find the visible top-level rollout an externally-running TRAE process owns.
+ *  TRAE can keep the parent rollout and internal guardian/subagent rollouts open
+ *  in the same process. Internal rollouts are never adoptable. When a current
+ *  top-level session is supplied it remains preferred unless a newer top-level
+ *  user rollout proves a real in-process `/new` rotation. */
+export function findTraexRolloutByPid(
+  pid: number,
+  preferredSessionId?: string,
+): { path: string; cliSessionId: string } | undefined {
   const targets = traexProcessOpenTargets(pid);
   if (!targets) return undefined;
-  for (const target of targets) {
-    const hit = matchTraexRolloutPath(target);
-    if (hit) return hit;
-  }
-  return undefined;
+  const selected = selectTraexRollout(traexRolloutRefs(targets), preferredSessionId);
+  return selected ? { path: selected.path, cliSessionId: selected.cliSessionId } : undefined;
 }
 
 /** Lowercased set of TRAE session ids whose rollout the pid holds open. The
@@ -436,9 +561,8 @@ export function findTraexRolloutSetByPid(pid: number): Set<string> | undefined {
   const targets = traexProcessOpenTargets(pid);
   if (!targets) return undefined;
   const set = new Set<string>();
-  for (const target of targets) {
-    const hit = matchTraexRolloutPath(target);
-    if (hit) set.add(hit.cliSessionId.toLowerCase());
+  for (const ref of selectableTraexRollouts(traexRolloutRefs(targets))) {
+    set.add(ref.cliSessionId.toLowerCase());
   }
   return set;
 }

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -477,9 +477,7 @@ function selectableTraexRollouts(refs: TraexRolloutRef[]): TraexRolloutRef[] {
   if (userRefs.length > 0) return userRefs;
   const legacyRefs = refs.filter(ref => ref.kind === 'legacy');
   if (legacyRefs.length > 0) return legacyRefs;
-  if (refs.some(ref => ref.kind === 'internal' || ref.kind === 'pending')) return [];
-  const emptyRefs = refs.filter(ref => ref.kind === 'empty');
-  return emptyRefs.length === 1 ? emptyRefs : [];
+  return [];
 }
 
 function selectTraexRollout(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5952,9 +5952,9 @@ function maybeFollowTraexSessionRotationViaPid(): void {
     ?? backend.getChildPid?.()
     ?? codexAdoptPendingPid;
   if (!pid) return;
-  const observed = findTraexRolloutByPid(pid);
-  if (!observed) return;
   const currentSid = codexSessionIdFromRolloutPath(codexBridgeRolloutPath);
+  const observed = findTraexRolloutByPid(pid, currentSid);
+  if (!observed) return;
   if (currentSid?.toLowerCase() === observed.cliSessionId.toLowerCase()) return;
   persistCliSessionId(observed.cliSessionId);
   codexBridgeNotifyCliSessionId(observed.cliSessionId);

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -14,23 +14,42 @@ vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
 }));
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(() => false),
-  readdirSync: vi.fn(() => []),
-  readFileSync: vi.fn(),
-  readlinkSync: vi.fn(),
-}));
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readdirSync: vi.fn(() => []),
+    readFileSync: vi.fn(),
+    readlinkSync: vi.fn(),
+  };
+});
 
-vi.mock('node:os', () => ({
-  homedir: () => '/home/testuser',
-  // session-discovery 用 platform() 决定 Linux /proc 快路径 vs macOS ps/lsof 兜底。
-  // 既有 mock 数据全部按 Linux 形态准备，所以这里固定为 'linux'。
-  // macOS 兜底路径的覆盖见 test/session-discovery.smoke.test.ts。
-  platform: () => 'linux',
-}));
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {
+    ...actual,
+    homedir: () => '/home/testuser',
+    // session-discovery 用 platform() 决定 Linux /proc 快路径 vs macOS ps/lsof 兜底。
+    // 既有 mock 数据全部按 Linux 形态准备，所以这里固定为 'linux'。
+    // macOS 兜底路径的覆盖见 test/session-discovery.smoke.test.ts。
+    platform: () => 'linux',
+  };
+});
 
 import { execSync } from 'node:child_process';
-import { readFileSync, readlinkSync, existsSync, readdirSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   discoverAdoptableSessions,
   discoverAdoptableSessionByTarget,
@@ -919,26 +938,47 @@ describe('discoverAdoptableSessions', () => {
   // the ~/.trae/cli/sessions layout.
 
   it('detects a TRAE (traex) CLI process and captures sessionId from the open rollout fd', () => {
-    setupMocks({
-      paneLines: 'work:0.0 9000\n',
-      commMap: { 9000: 'bash', 9001: 'traex' },
-      childMap: { 9000: [9001] },
-      cwdMap: { 9001: '/workspace/proj' },
-      dimsMap: { 'work:0.0': '120 30' },
-      procFdMap: {
-        9001: [
-          '/dev/null',
-          '/home/testuser/.trae/cli/sessions/2026/06/11/rollout-2026-06-11T10-00-00-8db7d911-96f3-4764-a310-e42ae4cb626f.jsonl',
-        ],
+    const sessionId = '8db7d911-96f3-4764-a310-e42ae4cb626f';
+    const root = mkdtempSync(join(tmpdir(), 'botmux-traex-discovery-'));
+    const rolloutDir = join(root, '.trae', 'cli', 'sessions', '2026', '06', '11');
+    const rolloutPath = join(
+      rolloutDir,
+      `rollout-2026-06-11T10-00-00-${sessionId}.jsonl`,
+    );
+    mkdirSync(rolloutDir, { recursive: true });
+    writeFileSync(rolloutPath, `${JSON.stringify({
+      timestamp: '2026-06-11T10:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        id: sessionId,
+        timestamp: '2026-06-11T10:00:00.000Z',
+        cwd: '/workspace/proj',
+        source: 'cli',
+        thread_source: 'user',
       },
-    });
+    })}\n`);
 
-    const results = discoverAdoptableSessions();
+    try {
+      setupMocks({
+        paneLines: 'work:0.0 9000\n',
+        commMap: { 9000: 'bash', 9001: 'traex' },
+        childMap: { 9000: [9001] },
+        cwdMap: { 9001: '/workspace/proj' },
+        dimsMap: { 'work:0.0': '120 30' },
+        procFdMap: {
+          9001: ['/dev/null', rolloutPath],
+        },
+      });
 
-    expect(results).toHaveLength(1);
-    expect(results[0]!.cliId).toBe('traex');
-    expect(results[0]!.cwd).toBe('/workspace/proj');
-    expect(results[0]!.sessionId).toBe('8db7d911-96f3-4764-a310-e42ae4cb626f');
+      const results = discoverAdoptableSessions();
+
+      expect(results).toHaveLength(1);
+      expect(results[0]!.cliId).toBe('traex');
+      expect(results[0]!.cwd).toBe('/workspace/proj');
+      expect(results[0]!.sessionId).toBe(sessionId);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('returns traex discovery without sessionId when no rollout fd is open', () => {

--- a/test/traex-pid-discovery.smoke.test.ts
+++ b/test/traex-pid-discovery.smoke.test.ts
@@ -16,6 +16,8 @@ const AMBIGUOUS_B_SID = '019fea00-0000-7000-8000-000000000003';
 const LEGACY_SID = '019fea00-0000-7000-8000-000000000004';
 const LEGACY_SECOND_SID = '019fea00-0000-7000-8000-000000000005';
 const PARTIAL_SID = '019fea00-0000-7000-8000-000000000006';
+const EMPTY_SID = '019fea00-0000-7000-8000-000000000007';
+const EMPTY_THEN_USER_SID = '019fea00-0000-7000-8000-000000000008';
 
 let dir: string;
 const children: ChildProcessWithoutNullStreams[] = [];
@@ -29,6 +31,9 @@ let mainPartialChild: ChildProcessWithoutNullStreams;
 let guardianPartialChild: ChildProcessWithoutNullStreams;
 let partialChild: ChildProcessWithoutNullStreams;
 let legacyGuardianChild: ChildProcessWithoutNullStreams;
+let emptyChild: ChildProcessWithoutNullStreams;
+let emptyThenUserChild: ChildProcessWithoutNullStreams;
+let emptyThenUserPath: string;
 
 function rolloutPath(sid: string, label: string): string {
   const sessions = join(dir, 'custom-trae-home', 'cli', 'sessions', '2026', '08', '10');
@@ -119,12 +124,16 @@ beforeAll(async () => {
   const legacy = rolloutPath(LEGACY_SID, 'legacy');
   const legacySecond = rolloutPath(LEGACY_SECOND_SID, 'legacy-second');
   const partial = rolloutPath(PARTIAL_SID, 'partial');
+  const empty = rolloutPath(EMPTY_SID, 'empty');
+  emptyThenUserPath = rolloutPath(EMPTY_THEN_USER_SID, 'empty-then-user');
   writeFileSync(legacy, `${JSON.stringify({ type: 'turn_context', payload: { model: 'legacy' } })}\n`);
   writeFileSync(
     legacySecond,
     `${JSON.stringify({ type: 'turn_context', payload: { model: 'legacy-second' } })}\n`,
   );
   writeFileSync(partial, '{"type":"session_meta","payload":{"thread_source":"subagent"');
+  writeFileSync(empty, '');
+  writeFileSync(emptyThenUserPath, '');
 
   mainGuardianChild = await spawnHolder([guardian, main]);
   mainNewChild = await spawnHolder([main, guardian, newMain]);
@@ -136,6 +145,8 @@ beforeAll(async () => {
   guardianPartialChild = await spawnHolder([partial, guardian]);
   partialChild = await spawnHolder([partial]);
   legacyGuardianChild = await spawnHolder([legacy, guardian]);
+  emptyChild = await spawnHolder([empty]);
+  emptyThenUserChild = await spawnHolder([emptyThenUserPath]);
 });
 
 afterAll(() => {
@@ -192,6 +203,30 @@ describe('findTraexRolloutByPid', () => {
   it('keeps a complete legacy rollout selectable when guardian is also open', () => {
     expect(findTraexRolloutByPid(legacyGuardianChild.pid!)?.cliSessionId).toBe(LEGACY_SID);
   });
+
+  it('fails closed while the only rollout is empty and has no session_meta evidence', () => {
+    expect(findTraexRolloutByPid(emptyChild.pid!)).toBeUndefined();
+  });
+
+  it('selects an initially empty rollout after a later probe sees complete user session_meta', () => {
+    expect(findTraexRolloutByPid(emptyThenUserChild.pid!)).toBeUndefined();
+
+    writeFileSync(emptyThenUserPath, `${JSON.stringify({
+      timestamp: '2026-08-10T06:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        id: EMPTY_THEN_USER_SID,
+        timestamp: '2026-08-10T06:00:00.000Z',
+        cwd: '/workspace',
+        source: 'cli',
+        thread_source: 'user',
+      },
+    })}\n`);
+
+    expect(findTraexRolloutByPid(emptyThenUserChild.pid!)?.cliSessionId).toBe(
+      EMPTY_THEN_USER_SID,
+    );
+  });
 });
 
 describe('findTraexRolloutSetByPid', () => {
@@ -205,5 +240,9 @@ describe('findTraexRolloutSetByPid', () => {
     expect(findTraexRolloutSetByPid(mainPartialChild.pid!)).toEqual(
       new Set([MAIN_SID.toLowerCase()]),
     );
+  });
+
+  it('does not treat an empty rollout as owned before session_meta is complete', () => {
+    expect(findTraexRolloutSetByPid(emptyChild.pid!)).toEqual(new Set());
   });
 });

--- a/test/traex-pid-discovery.smoke.test.ts
+++ b/test/traex-pid-discovery.smoke.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  findTraexRolloutByPid,
+  findTraexRolloutSetByPid,
+} from '../src/services/traex-transcript.js';
+
+const MAIN_SID = '019fe206-29ee-7a62-8da7-67d37a4fa70c';
+const GUARDIAN_SID = '019fe9cf-5c4e-7231-9b5d-799f294fd57d';
+const NEW_MAIN_SID = '019fea00-0000-7000-8000-000000000001';
+const AMBIGUOUS_A_SID = '019fea00-0000-7000-8000-000000000002';
+const AMBIGUOUS_B_SID = '019fea00-0000-7000-8000-000000000003';
+const LEGACY_SID = '019fea00-0000-7000-8000-000000000004';
+const LEGACY_SECOND_SID = '019fea00-0000-7000-8000-000000000005';
+const PARTIAL_SID = '019fea00-0000-7000-8000-000000000006';
+
+let dir: string;
+const children: ChildProcessWithoutNullStreams[] = [];
+let mainGuardianChild: ChildProcessWithoutNullStreams;
+let mainNewChild: ChildProcessWithoutNullStreams;
+let ambiguousChild: ChildProcessWithoutNullStreams;
+let guardianOnlyChild: ChildProcessWithoutNullStreams;
+let legacyChild: ChildProcessWithoutNullStreams;
+let legacyAmbiguousChild: ChildProcessWithoutNullStreams;
+let mainPartialChild: ChildProcessWithoutNullStreams;
+let guardianPartialChild: ChildProcessWithoutNullStreams;
+let partialChild: ChildProcessWithoutNullStreams;
+let legacyGuardianChild: ChildProcessWithoutNullStreams;
+
+function rolloutPath(sid: string, label: string): string {
+  const sessions = join(dir, 'custom-trae-home', 'cli', 'sessions', '2026', '08', '10');
+  mkdirSync(sessions, { recursive: true });
+  return join(sessions, `rollout-2026-08-10T00-00-00-${label}-${sid}.jsonl`);
+}
+
+function writeRollout(
+  sid: string,
+  label: string,
+  timestamp: string,
+  threadSource: string,
+  source: unknown,
+): string {
+  const path = rolloutPath(sid, label);
+  writeFileSync(path, `${JSON.stringify({
+    timestamp,
+    type: 'session_meta',
+    payload: {
+      id: sid,
+      timestamp,
+      cwd: '/workspace',
+      source,
+      thread_source: threadSource,
+    },
+  })}\n`);
+  return path;
+}
+
+async function spawnHolder(paths: string[]): Promise<ChildProcessWithoutNullStreams> {
+  const child = spawn(
+    process.execPath,
+    [
+      '-e',
+      `
+        const fs = require('fs');
+        for (const path of ${JSON.stringify(paths)}) fs.openSync(path, 'a');
+        process.stdout.write('ready\\n');
+        setTimeout(() => {}, 60000);
+      `,
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  ) as ChildProcessWithoutNullStreams;
+  children.push(child);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('rollout holder not ready in 5s')), 5000);
+    child.stdout.once('data', (buffer: Buffer) => {
+      if (!buffer.toString().includes('ready')) return;
+      clearTimeout(timer);
+      resolve();
+    });
+    child.once('error', reject);
+  });
+  return child;
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'bmx-traex-pid-'));
+  const main = writeRollout(MAIN_SID, 'main', '2026-08-08T15:38:02.000Z', 'user', 'cli');
+  const guardian = writeRollout(
+    GUARDIAN_SID,
+    'guardian',
+    '2026-08-10T03:55:08.000Z',
+    'subagent',
+    { subagent: { other: 'guardian' } },
+  );
+  const newMain = writeRollout(
+    NEW_MAIN_SID,
+    'new-main',
+    '2026-08-10T04:00:00.000Z',
+    'user',
+    'cli',
+  );
+  const ambiguousA = writeRollout(
+    AMBIGUOUS_A_SID,
+    'ambiguous-a',
+    '2026-08-10T05:00:00.000Z',
+    'user',
+    'cli',
+  );
+  const ambiguousB = writeRollout(
+    AMBIGUOUS_B_SID,
+    'ambiguous-b',
+    '2026-08-10T05:00:00.000Z',
+    'user',
+    'cli',
+  );
+  const legacy = rolloutPath(LEGACY_SID, 'legacy');
+  const legacySecond = rolloutPath(LEGACY_SECOND_SID, 'legacy-second');
+  const partial = rolloutPath(PARTIAL_SID, 'partial');
+  writeFileSync(legacy, `${JSON.stringify({ type: 'turn_context', payload: { model: 'legacy' } })}\n`);
+  writeFileSync(
+    legacySecond,
+    `${JSON.stringify({ type: 'turn_context', payload: { model: 'legacy-second' } })}\n`,
+  );
+  writeFileSync(partial, '{"type":"session_meta","payload":{"thread_source":"subagent"');
+
+  mainGuardianChild = await spawnHolder([guardian, main]);
+  mainNewChild = await spawnHolder([main, guardian, newMain]);
+  ambiguousChild = await spawnHolder([ambiguousA, ambiguousB]);
+  guardianOnlyChild = await spawnHolder([guardian]);
+  legacyChild = await spawnHolder([legacy]);
+  legacyAmbiguousChild = await spawnHolder([legacy, legacySecond]);
+  mainPartialChild = await spawnHolder([partial, main]);
+  guardianPartialChild = await spawnHolder([partial, guardian]);
+  partialChild = await spawnHolder([partial]);
+  legacyGuardianChild = await spawnHolder([legacy, guardian]);
+});
+
+afterAll(() => {
+  for (const child of children) {
+    if (!child.killed) child.kill('SIGKILL');
+  }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('findTraexRolloutByPid', () => {
+  it('filters a newer guardian rollout and keeps the visible user session', () => {
+    const hit = findTraexRolloutByPid(mainGuardianChild.pid!);
+    expect(hit?.cliSessionId).toBe(MAIN_SID);
+  });
+
+  it('keeps the preferred visible session when the only newer rollout is guardian', () => {
+    const hit = findTraexRolloutByPid(mainGuardianChild.pid!, MAIN_SID);
+    expect(hit?.cliSessionId).toBe(MAIN_SID);
+  });
+
+  it('follows a newer top-level user rollout as a legitimate in-process /new', () => {
+    const hit = findTraexRolloutByPid(mainNewChild.pid!, MAIN_SID);
+    expect(hit?.cliSessionId).toBe(NEW_MAIN_SID);
+  });
+
+  it('fails closed when two top-level candidates are equally new', () => {
+    expect(findTraexRolloutByPid(ambiguousChild.pid!)).toBeUndefined();
+  });
+
+  it('fails closed when the process exposes only internal rollouts', () => {
+    expect(findTraexRolloutByPid(guardianOnlyChild.pid!)).toBeUndefined();
+  });
+
+  it('keeps one legacy rollout without session_meta compatible', () => {
+    expect(findTraexRolloutByPid(legacyChild.pid!)?.cliSessionId).toBe(LEGACY_SID);
+  });
+
+  it('does not guess between multiple legacy rollouts without session_meta', () => {
+    expect(findTraexRolloutByPid(legacyAmbiguousChild.pid!)).toBeUndefined();
+  });
+
+  it('does not let a partially-written helper rollout displace a visible user rollout', () => {
+    expect(findTraexRolloutByPid(mainPartialChild.pid!)?.cliSessionId).toBe(MAIN_SID);
+  });
+
+  it('fails closed when internal and partially-written rollouts are the only candidates', () => {
+    expect(findTraexRolloutByPid(guardianPartialChild.pid!)).toBeUndefined();
+  });
+
+  it('does not bind a non-empty rollout whose session_meta line is incomplete', () => {
+    expect(findTraexRolloutByPid(partialChild.pid!)).toBeUndefined();
+  });
+
+  it('keeps a complete legacy rollout selectable when guardian is also open', () => {
+    expect(findTraexRolloutByPid(legacyGuardianChild.pid!)?.cliSessionId).toBe(LEGACY_SID);
+  });
+});
+
+describe('findTraexRolloutSetByPid', () => {
+  it('excludes guardian session ids from ownership decisions', () => {
+    const set = findTraexRolloutSetByPid(mainGuardianChild.pid!);
+    expect(set).toEqual(new Set([MAIN_SID.toLowerCase()]));
+    expect(set?.has(GUARDIAN_SID.toLowerCase())).toBe(false);
+  });
+
+  it('excludes a partially-written helper while a visible user rollout is owned', () => {
+    expect(findTraexRolloutSetByPid(mainPartialChild.pid!)).toEqual(
+      new Set([MAIN_SID.toLowerCase()]),
+    );
+  });
+});

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -23,6 +23,20 @@ function line(value: unknown): string {
 function user(text: string, timestamp = '2000-01-01T00:00:01.000Z') {
   return {
     timestamp,
+    type: 'event_msg',
+    payload: {
+      type: 'user_message',
+      message: text,
+      images: [],
+      local_images: [],
+      text_elements: [],
+    },
+  };
+}
+
+function userResponseItem(text: string, timestamp = '2000-01-01T00:00:01.000Z') {
+  return {
+    timestamp,
     type: 'response_item',
     payload: {
       type: 'message',
@@ -184,6 +198,27 @@ describe('drainTraexRollout', () => {
         kind: 'assistant_final',
         text: 'durable final answer',
         sourceSessionId: SID,
+      }),
+    ]);
+  });
+
+  it('ignores internal role=user injections without a user_message event', () => {
+    writeFileSync(path, [
+      line(userResponseItem('<environment_context>runtime context</environment_context>')),
+      line(userResponseItem('Warning: runtime-generated process limit notice')),
+      line(userResponseItem('real terminal input')),
+      line(user('real terminal input')),
+      line(taskComplete('done')),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events).toEqual([
+      expect.objectContaining({
+        kind: 'user',
+        text: 'real terminal input',
+      }),
+      expect.objectContaining({
+        kind: 'assistant_final',
+        text: 'done',
       }),
     ]);
   });

--- a/test/traex-worker-bridge-wiring.test.ts
+++ b/test/traex-worker-bridge-wiring.test.ts
@@ -174,7 +174,7 @@ describe('TRAE worker structured-bridge wiring', () => {
     const end = workerSource.indexOf('\n}\n', start);
     const follower = workerSource.slice(start, end);
 
-    expect(follower).toContain('findTraexRolloutByPid(pid)');
+    expect(follower).toContain('findTraexRolloutByPid(pid, currentSid)');
     expect(follower).toContain('persistCliSessionId(observed.cliSessionId);');
     expect(follower).toContain('codexBridgeNotifyCliSessionId(observed.cliSessionId);');
   });


### PR DESCRIPTION
## 背景

`/adopt` 通过 TRAE 进程 PID 发现 rollout 时，同一进程可能同时持有用户主会话与 guardian/subagent rollout。旧逻辑直接选择首个匹配文件，可能把内部审批会话当成合法 `/new` 轮转；此外，TRAE 主 rollout 也会将运行时 warning、环境上下文等内部注入记录为 `response_item role=user`，从而被错误渲染成真人输入。

## 修改

- 提取协议级 `session_meta` 内部会话判定，过滤 guardian/subagent rollout。
- 已绑定的顶层用户会话保持稳定；只有唯一更新的顶层用户 rollout 才允许合法 `/new` 轮转。
- 多个同级候选、仅内部候选或部分写入的元数据均 fail closed。
- TRAE transcript 仅将结构化 `event_msg/user_message` 视为真实用户输入，忽略孤立的内部 `role=user` 注入。
- 补充真实多 FD 子进程和 transcript 双记录回归测试。

## 影响面

- 仅影响 TRAE 的 structured transcript reader 与 adopt PID 轮转发现。
- 不修改 Codex、Claude 等其他 CLI 的 transcript 解析。
- 保留单 rollout、旧版无 `session_meta`、真实本地输入和合法 `/new` 的兼容行为。

## 验证

```bash
pnpm vitest run --project unit \
  test/traex-adapter-submit.test.ts \
  test/traex-pid-discovery.smoke.test.ts \
  test/traex-transcript.test.ts \
  test/traex-user-input.test.ts \
  test/traex-worker-bridge-wiring.test.ts \
  test/codex-bridge-queue.test.ts \
  test/write-input.test.ts
# 7 files, 272 tests passed

pnpm exec tsc --noEmit
pnpm build
```

Linux canary 实测：

- 主会话与 guardian 同 PID 共存时不发生错误轮转，内部审批 transcript 不再同步。
- 主 rollout 的运行时 warning 产生 0 个 user event。
- 飞书输入仍按普通 bridge 交付，adopted pane 的真实本地输入仍生成一条 local-turn。
- daemon 重启后静默恢复原 adopt 会话，不重放历史内容。
