### PR TITLE
fix(schedule): 为跨目标触发通知添加跳转链接

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -81,6 +81,7 @@ import { resolveRegularGroupMode } from '../services/chat-reply-mode-store.js';
 import { beginReplyTargetTurn } from './reply-target.js';
 import { readDeferredTopicBinding, removeDeferredTopicBinding } from './deferred-topic-binding.js';
 import { escapeXmlTagLikeTokens } from '../utils/xml.js';
+import { chatAppLink, threadAppLink, normalizeBrand } from '../im/lark/lark-hosts.js';
 
 export { getAttachmentsDir } from './attachment-path.js';
 
@@ -2640,6 +2641,37 @@ export function resolveScheduledTaskExecutionPosition(
   return task.scope !== 'chat' && task.rootMessageId ? 'topic' : 'top-level';
 }
 
+async function buildScheduledTargetNotice(params: {
+  kind: 'chat' | 'thread';
+  taskName: string;
+  targetAppId: string;
+  targetChatId: string;
+  targetRootMessageId?: string;
+  targetBrand?: unknown;
+  locale?: Locale;
+}): Promise<string> {
+  const { getMessageThreadId } = await import('../im/lark/client.js');
+  const brand = normalizeBrand(params.targetBrand);
+  let link = chatAppLink(params.targetChatId, brand);
+  if (params.kind === 'thread' && params.targetRootMessageId) {
+    try {
+      const threadId = await getMessageThreadId(params.targetAppId, params.targetRootMessageId);
+      if (threadId) link = threadAppLink(params.targetChatId, threadId, brand);
+    } catch (err: any) {
+      logger.warn(
+        `[scheduler] Failed to resolve target topic ${params.targetRootMessageId}; falling back to chat link (${err.message})`,
+      );
+    }
+  }
+  return t(
+    params.kind === 'thread'
+      ? 'scheduler.task_triggered_target_thread'
+      : 'scheduler.task_triggered_target_chat',
+    { name: params.taskName, link },
+    params.locale,
+  );
+}
+
 export async function executeScheduledTask(
   task: ScheduledTask,
   activeSessions: Map<string, DaemonSession>,
@@ -2709,13 +2741,20 @@ export async function executeScheduledTask(
     } else {
       if (task.creatorRootMessageId && task.creatorChatId !== task.chatId) {
         const creatorAppId = task.creatorLarkAppId ?? larkAppId;
-        replyMessage(
+        buildScheduledTargetNotice({
+          kind: 'chat',
+          taskName: task.name,
+          targetAppId: larkAppId,
+          targetChatId: task.chatId,
+          targetBrand: bot.config.brand,
+          locale: localeForBot(creatorAppId),
+        }).then(content => replyMessage(
           creatorAppId,
-          task.creatorRootMessageId,
-          t('scheduler.task_triggered_target_chat', { name: task.name }, localeForBot(creatorAppId)),
+          task.creatorRootMessageId!,
+          content,
           'text',
           true,
-        ).catch((err: any) => {
+        )).catch((err: any) => {
           logger.warn(`[scheduler] Failed to notify creator thread ${task.creatorRootMessageId} (${err.message})`);
         });
       }
@@ -2739,13 +2778,20 @@ export async function executeScheduledTask(
       // target bot/chat's shared or independent-topic regular-group mode.
       if (task.creatorRootMessageId && task.creatorChatId !== task.chatId) {
         const creatorAppId = task.creatorLarkAppId ?? larkAppId;
-        replyMessage(
+        buildScheduledTargetNotice({
+          kind: 'chat',
+          taskName: task.name,
+          targetAppId: larkAppId,
+          targetChatId: task.chatId,
+          targetBrand: bot.config.brand,
+          locale: localeForBot(creatorAppId),
+        }).then(content => replyMessage(
           creatorAppId,
-          task.creatorRootMessageId,
-          t('scheduler.task_triggered_target_chat', { name: task.name }, localeForBot(creatorAppId)),
+          task.creatorRootMessageId!,
+          content,
           'text',
           true,
-        ).catch((err: any) => {
+        )).catch((err: any) => {
           logger.warn(`[scheduler] Failed to notify creator thread ${task.creatorRootMessageId} (${err.message})`);
         });
       }
@@ -2786,13 +2832,21 @@ export async function executeScheduledTask(
     if (isCrossThread) {
       if (!silent) {
         const creatorAppId = task.creatorLarkAppId ?? larkAppId;
-        replyMessage(
+        buildScheduledTargetNotice({
+          kind: 'thread',
+          taskName: task.name,
+          targetAppId: larkAppId,
+          targetChatId: task.chatId,
+          targetRootMessageId: task.rootMessageId,
+          targetBrand: bot.config.brand,
+          locale: localeForBot(creatorAppId),
+        }).then(content => replyMessage(
           creatorAppId,
           task.creatorRootMessageId!,
-          t('scheduler.task_triggered_target_thread', { name: task.name }, localeForBot(creatorAppId)),
+          content,
           'text',
           true,
-        ).catch((err: any) => {
+        )).catch((err: any) => {
           logger.warn(`[scheduler] Failed to notify creator thread ${task.creatorRootMessageId} (${err.message})`);
         });
       }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1233,8 +1233,8 @@ export const messages: Record<string, string> = {
 
   // Scheduler announcements
   'scheduler.task_started': '🕐 Scheduled task “{name}” started',
-  'scheduler.task_triggered_target_chat': '🕐 Scheduled task “{name}” triggered in the target chat',
-  'scheduler.task_triggered_target_thread': '🕐 Scheduled task “{name}” triggered in the target topic',
+  'scheduler.task_triggered_target_chat': '🕐 Scheduled task “{name}” triggered in the target chat\nOpen target chat: {link}',
+  'scheduler.task_triggered_target_thread': '🕐 Scheduled task “{name}” triggered in the target topic\nOpen target topic: {link}',
 
   // External event trigger seed
   'trigger.external_event': 'External event: {source}',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1234,8 +1234,8 @@ export const messages: Record<string, string> = {
 
   // Scheduler announcements
   'scheduler.task_started': '🕐 定时任务「{name}」开始执行',
-  'scheduler.task_triggered_target_chat': '🕐 定时任务「{name}」已在目标群聊触发',
-  'scheduler.task_triggered_target_thread': '🕐 定时任务「{name}」已在目标话题触发',
+  'scheduler.task_triggered_target_chat': '🕐 定时任务「{name}」已在目标群聊触发\n打开目标群聊：{link}',
+  'scheduler.task_triggered_target_thread': '🕐 定时任务「{name}」已在目标话题触发\n打开目标话题：{link}',
 
   // External event trigger seed
   'trigger.external_event': '外部事件触发：{source}',

--- a/test/scheduler-silent-execute.test.ts
+++ b/test/scheduler-silent-execute.test.ts
@@ -51,10 +51,12 @@ vi.mock('../src/services/message-queue.js', () => ({ ensureQueue: vi.fn() }));
 const sendMessageMock = vi.fn(async () => 'om_banner_123');
 const replyMessageMock = vi.fn(async () => 'om_reply_456');
 const getChatModeMock = vi.fn(async () => 'group');
+const getMessageThreadIdMock = vi.fn(async () => 'omt_target_thread');
 vi.mock('../src/im/lark/client.js', () => ({
   sendMessage: (...a: any[]) => sendMessageMock(...a),
   replyMessage: (...a: any[]) => replyMessageMock(...a),
   getChatMode: (...a: any[]) => getChatModeMock(...a),
+  getMessageThreadId: (...a: any[]) => getMessageThreadIdMock(...a),
   downloadMessageResource: vi.fn(),
   listChatBotMembers: vi.fn(async () => []),
   UserTokenMissingError: class extends Error {},
@@ -183,6 +185,8 @@ beforeEach(() => {
   replyMessageMock.mockClear();
   getChatModeMock.mockClear();
   getChatModeMock.mockResolvedValue('group');
+  getMessageThreadIdMock.mockClear();
+  getMessageThreadIdMock.mockResolvedValue('omt_target_thread');
   delete (BOT.config as typeof BOT.config & { regularGroupReplyMode?: string }).regularGroupReplyMode;
 });
 
@@ -333,13 +337,15 @@ describe('executeScheduledTask — chat-scope regular-group mode', () => {
       creatorRootMessageId: 'om_creator_root',
     }), active, refreshCliVersion);
 
-    expect(replyMessageMock).toHaveBeenCalledWith(
-      APP,
-      'om_creator_root',
-      expect.any(String),
-      'text',
-      true,
-    );
+    await vi.waitFor(() => {
+      expect(replyMessageMock).toHaveBeenCalledWith(
+        APP,
+        'om_creator_root',
+        expect.any(String),
+        'text',
+        true,
+      );
+    });
     expect(sendMessageMock).toHaveBeenCalledWith(APP, CHAT, expect.any(String));
     expect(active.get(sessionKey(CHAT, APP))).toBeUndefined();
     expect(active.get(sessionKey('om_banner_123', APP))?.scope).toBe('thread');
@@ -393,6 +399,77 @@ describe('executeScheduledTask — chat-scope regular-group mode', () => {
     const ds = active.get(sessionKey(CHAT, APP))!;
     expect(ds.scope).toBe('chat');
     expect(ds.silentScheduledTurns?.has(forkedTurnId())).toBe(true);
+  });
+});
+
+describe('executeScheduledTask — cross-target notice', () => {
+  it('links a cross-thread creator notice to the exact target topic', async () => {
+    const active = new Map<string, DaemonSession>();
+
+    await executeScheduledTask(baseTask({
+      rootMessageId: ROOT,
+      scope: 'thread',
+      creatorChatId: CHAT,
+      creatorRootMessageId: 'om_creator_root',
+    }), active, refreshCliVersion);
+
+    await vi.waitFor(() => {
+      expect(getMessageThreadIdMock).toHaveBeenCalledWith(APP, ROOT);
+      expect(replyMessageMock).toHaveBeenCalledWith(
+        APP,
+        'om_creator_root',
+        expect.stringContaining(
+          'https://applink.feishu.cn/client/thread/open?open_chat_id=oc_chat&open_thread_id=omt_target_thread',
+        ),
+        'text',
+        true,
+      );
+    });
+    expect(active.get(sessionKey(ROOT, APP))).toBeTruthy();
+  });
+
+  it('links a cross-chat creator notice to the target chat', async () => {
+    (BOT.config as typeof BOT.config & { regularGroupReplyMode?: string }).regularGroupReplyMode = 'new-topic';
+    const active = new Map<string, DaemonSession>();
+
+    await executeScheduledTask(baseTask({
+      scope: 'chat',
+      chatType: 'group',
+      creatorChatId: 'oc_creator_chat',
+      creatorRootMessageId: 'om_creator_root',
+    }), active, refreshCliVersion);
+
+    await vi.waitFor(() => {
+      expect(replyMessageMock).toHaveBeenCalledWith(
+        APP,
+        'om_creator_root',
+        expect.stringContaining('https://applink.feishu.cn/client/chat/open?openChatId=oc_chat'),
+        'text',
+        true,
+      );
+    });
+  });
+
+  it('falls back to the target chat link when topic resolution fails', async () => {
+    getMessageThreadIdMock.mockRejectedValueOnce(new Error('lookup failed'));
+    const active = new Map<string, DaemonSession>();
+
+    await executeScheduledTask(baseTask({
+      rootMessageId: ROOT,
+      scope: 'thread',
+      creatorChatId: CHAT,
+      creatorRootMessageId: 'om_creator_root',
+    }), active, refreshCliVersion);
+
+    await vi.waitFor(() => {
+      expect(replyMessageMock).toHaveBeenCalledWith(
+        APP,
+        'om_creator_root',
+        expect.stringContaining('https://applink.feishu.cn/client/chat/open?openChatId=oc_chat'),
+        'text',
+        true,
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## 概述

跨目标定时任务当前会告诉创建者「任务已在另一个群聊/话题触发」,但没有说明目标在哪里。本次改动在通知中补充一条指向目标群聊或目标话题的飞书 AppLink。

## 用户可见问题

当定时任务在话题 A 创建、投递到话题 B 时,话题 A 只会收到:

> 定时任务「…」已在目标话题触发

任务可以在话题 B 成功执行完,但用户没有从通知跳转到输出的路径。

## 根因

调度器保留了目标 `chatId` 和根消息,但创建者通知只渲染了任务名,从未解析目标话题或构造 AppLink。

## 改动

- 跨群聊通知链接到目标群聊。
- 解析目标根消息,把跨话题通知链接到具体话题。
- 话题解析失败时回退为目标群聊链接。
- 用单元测试覆盖目标话题、目标群聊、回退三种行为。

## 验证

- 定向:2 个文件,38 个测试通过。
- 调度器回归:8 个文件,226 个测试通过。
- 构建:通过(`tsc`、dashboard bundle、dist audit)。
- 完整单测中与调度器无关的失败(终端宽度超时、worker argv/reaction 集成)为既有基线,与本改动无关。
