### PR TITLE
fix(trigger): turnIdempotencyKey/idempotencyKey 互斥校验前置，精确报文可达

### DIFF
--- a/src/services/trigger-types.ts
+++ b/src/services/trigger-types.ts
@@ -250,6 +250,16 @@ export function validateTriggerRequest(raw: unknown): { ok: true; request: Trigg
   if (options.reasoningEffort !== undefined && !['low', 'medium', 'high', 'xhigh'].includes(options.reasoningEffort as string)) {
     return { ok: false, status: 400, body: { ok: false, errorCode: 'bad_request', error: 'options.reasoningEffort must be one of low|medium|high|xhigh' } };
   }
+  // Mutual exclusion FIRST, before either key's scope-lock: the two keys have
+  // different scopes (fresh-session vs follow-up) with opposite target shapes, so
+  // whichever scope check ran first would otherwise mask the "both present" case
+  // with its own scope message (e.g. a request carrying BOTH + target.sessionId
+  // trips idempotencyKey's no-sessionId scope-lock before reaching this check).
+  // Hoisting it makes the precise mutual-exclusion 400 always reachable when both
+  // are supplied, regardless of target shape (riff #818 canary validation).
+  if (options.idempotencyKey !== undefined && options.turnIdempotencyKey !== undefined) {
+    return { ok: false, status: 400, body: { ok: false, errorCode: 'bad_request', error: 'options.turnIdempotencyKey and options.idempotencyKey are mutually exclusive' } };
+  }
   if (options.idempotencyKey !== undefined) {
     if (typeof options.idempotencyKey !== 'string' || options.idempotencyKey.trim().length === 0 || options.idempotencyKey.length > 200) {
       return { ok: false, status: 400, body: { ok: false, errorCode: 'bad_request', error: 'options.idempotencyKey must be a non-empty string (<=200 chars)' } };
@@ -284,13 +294,7 @@ export function validateTriggerRequest(raw: unknown): { ok: true; request: Trigg
     if (typeof options.turnIdempotencyKey !== 'string' || options.turnIdempotencyKey.trim().length === 0 || options.turnIdempotencyKey.length > 200) {
       return { ok: false, status: 400, body: { ok: false, errorCode: 'bad_request', error: 'options.turnIdempotencyKey must be a non-empty string (<=200 chars)' } };
     }
-    // Mutually exclusive with the fresh-session `idempotencyKey`: the two key
-    // spaces have different scopes (per-bot fresh dispatch vs per-session turn)
-    // and different validity gates. Allowing both would be ambiguous about which
-    // lease governs the dispatch, so reject up-front rather than pick one.
-    if (options.idempotencyKey !== undefined) {
-      return { ok: false, status: 400, body: { ok: false, errorCode: 'bad_request', error: 'options.turnIdempotencyKey and options.idempotencyKey are mutually exclusive' } };
-    }
+    // (Mutual exclusion with idempotencyKey is checked up-front, above.)
     // Scope lock (follow-up turn only): the turn-level lease is implemented solely
     // on the existing-session async-return append seam. It REQUIRES target.sessionId
     // (that is the session whose turn is keyed) and asyncReturnSessionId, and must

--- a/test/trigger-api.test.ts
+++ b/test/trigger-api.test.ts
@@ -228,7 +228,21 @@ describe('trigger request contract', () => {
     req.options = { asyncReturnSessionId: true, turnIdempotencyKey: 'tk', idempotencyKey: 'k' } as any;
     const v = validateTriggerRequest(req);
     expect(v.ok).toBe(false);
-    if (!v.ok) expect(v.body.errorCode).toBe('bad_request');
+    if (!v.ok) {
+      expect(v.body.errorCode).toBe('bad_request');
+      // The PRECISE mutual-exclusion message must be reachable even WITH sessionId
+      // present — the check is hoisted above idempotencyKey's fresh-scope-lock so
+      // the latter can't mask it (riff #818 canary validation).
+      expect(v.body.error).toContain('mutually exclusive');
+    }
+    // Also holds with NO sessionId (idempotencyKey's shape is fine there, so only
+    // the mutual-exclusion check can reject).
+    const req2 = request();
+    req2.target = { kind: 'turn', botId: 'app1' };
+    req2.options = { asyncReturnSessionId: true, turnIdempotencyKey: 'tk', idempotencyKey: 'k' } as any;
+    const v2 = validateTriggerRequest(req2);
+    expect(v2.ok).toBe(false);
+    if (!v2.ok) expect(v2.body.error).toContain('mutually exclusive');
   });
 
   it('rejects turnIdempotencyKey WITHOUT target.sessionId (follow-up scope requires an existing session)', () => {


### PR DESCRIPTION
## 背景（riff #818 canary 灰度验证发现）
riff 验 `botmux@3.13.0-canary.1` 时发现一个 cosmetic 校验报文问题：同时传 `turnIdempotencyKey` + `idempotencyKey` + `target.sessionId` 时，返回的是 `idempotencyKey` 的 fresh-only scope-lock 报文（它的 scope 检查排在 turnKey 互斥块之前，带 sessionId 先被它 400 拦），而不是那句专门的 `options.turnIdempotencyKey and options.idempotencyKey are mutually exclusive`。**功能没问题**（两种都是 400 bad_request），纯 cosmetic——专门的互斥报文在「同带 sessionId」时走不到。

## 修法
把「两个 key 同时存在」的互斥检查**前置**到两个 scope-lock 之前，任何 target 形态下都先返回精确的互斥报文。`turnIdempotencyKey` 块里原来的互斥检查随之删掉（已被上移覆盖）。

## 验证
- `pnpm build` 绿
- `trigger-api.test.ts` 加断言：同带两 key（有 sessionId / 无 sessionId 两种）报文都命中 `mutually exclusive`；37/37 绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)