### PR TITLE
fix(dashboard): 软链/共享盘 HOME 下 token ensure/rotate 不再报 token_persist_failed

### DIFF
--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -9,7 +9,6 @@ import {
   withSecureHostParentSync,
   writeSecureHostFileSync,
 } from '../platform/secure-host-file.js';
-import { withFileLockSync } from '../utils/file-lock.js';
 
 const NONCE_TTL_MS = 60_000;
 const TS_WINDOW_S = 30;
@@ -190,7 +189,7 @@ export function persistToken(tokenPath: string, token: string): void {
  */
 export function loadOrCreatePersistedToken(tokenPath: string): string {
   return withSecureHostParentSync(tokenPath, (parent) =>
-    withFileLockSync(parent.leafPath, () => {
+    parent.withLeafLock(() => {
       const existing = parent.readLeaf(256)?.trim() || null;
       if (existing) return existing;
       const token = generateToken();
@@ -203,7 +202,7 @@ export function loadOrCreatePersistedToken(tokenPath: string): string {
 /** Generate and durably replace the token while serialized with first creation. */
 export function rotatePersistedToken(tokenPath: string): string {
   return withSecureHostParentSync(tokenPath, (parent) =>
-    withFileLockSync(parent.leafPath, () => {
+    parent.withLeafLock(() => {
       const token = generateToken();
       parent.writeLeaf(token);
       return token;

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -6,7 +6,7 @@ import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { dirname } from 'node:path';
 import {
   readSecureHostFileSync,
-  secureHostFilePath,
+  withSecureHostParent,
   writeSecureHostFileSync,
 } from '../platform/secure-host-file.js';
 import { withFileLockSync } from '../utils/file-lock.js';
@@ -179,26 +179,36 @@ export function persistToken(tokenPath: string, token: string): void {
  * Load the active token, creating and persisting the first one when absent.
  * The file lock makes get-or-create linearizable across dashboard processes:
  * every concurrent caller returns the same durable token.
+ *
+ * The credential directory is pinned once (Linux: via an open directory
+ * descriptor) and the lock, the read, and the write all resolve through that
+ * same anchor. This keeps the whole critical section on one directory inode —
+ * so a symlinked HOME whose target sits under a shared-drive / 0777 ancestor
+ * still succeeds, while an ancestor rename mid-section cannot redirect the lock
+ * or the token write into a substituted directory. `~/.botmux` itself must
+ * still be 0700 and owned by the current user; a leaf symlink is still refused.
  */
 export function loadOrCreatePersistedToken(tokenPath: string): string {
-  const securePath = secureHostFilePath(tokenPath);
-  return withFileLockSync(securePath, () => {
-    const existing = loadPersistedToken(securePath);
-    if (existing) return existing;
-    const token = generateToken();
-    persistToken(securePath, token);
-    return token;
-  });
+  return withSecureHostParent(tokenPath, (parent) =>
+    withFileLockSync(parent.leafPath, () => {
+      const existing = parent.readLeaf(256)?.trim() || null;
+      if (existing) return existing;
+      const token = generateToken();
+      parent.writeLeaf(token);
+      return token;
+    }),
+  );
 }
 
 /** Generate and durably replace the token while serialized with first creation. */
 export function rotatePersistedToken(tokenPath: string): string {
-  const securePath = secureHostFilePath(tokenPath);
-  return withFileLockSync(securePath, () => {
-    const token = generateToken();
-    persistToken(securePath, token);
-    return token;
-  });
+  return withSecureHostParent(tokenPath, (parent) =>
+    withFileLockSync(parent.leafPath, () => {
+      const token = generateToken();
+      parent.writeLeaf(token);
+      return token;
+    }),
+  );
 }
 
 /** Extract `botmux_dashboard_token` value from a Cookie header. */

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -6,7 +6,7 @@ import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { dirname } from 'node:path';
 import {
   readSecureHostFileSync,
-  withSecureHostParent,
+  withSecureHostParentSync,
   writeSecureHostFileSync,
 } from '../platform/secure-host-file.js';
 import { withFileLockSync } from '../utils/file-lock.js';
@@ -189,7 +189,7 @@ export function persistToken(tokenPath: string, token: string): void {
  * still be 0700 and owned by the current user; a leaf symlink is still refused.
  */
 export function loadOrCreatePersistedToken(tokenPath: string): string {
-  return withSecureHostParent(tokenPath, (parent) =>
+  return withSecureHostParentSync(tokenPath, (parent) =>
     withFileLockSync(parent.leafPath, () => {
       const existing = parent.readLeaf(256)?.trim() || null;
       if (existing) return existing;
@@ -202,7 +202,7 @@ export function loadOrCreatePersistedToken(tokenPath: string): string {
 
 /** Generate and durably replace the token while serialized with first creation. */
 export function rotatePersistedToken(tokenPath: string): string {
-  return withSecureHostParent(tokenPath, (parent) =>
+  return withSecureHostParentSync(tokenPath, (parent) =>
     withFileLockSync(parent.leafPath, () => {
       const token = generateToken();
       parent.writeLeaf(token);

--- a/src/platform/secure-host-file.ts
+++ b/src/platform/secure-host-file.ts
@@ -26,6 +26,7 @@ import {
 } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { withFileLockSync } from '../utils/file-lock.js';
 
 export class UnsafeHostAuthorityFileError extends Error {
   constructor(message: string) {
@@ -322,33 +323,37 @@ export function writeSecureHostFileSync(filePath: string, data: string): void {
 
 /**
  * A pinned view of the credential directory that stays valid ONLY for the
- * synchronous duration of the callback. On Linux `leafPath` (and anything a
- * caller derives from it, e.g. a sibling `.lock`) resolves through the opened
- * directory descriptor, so an ancestor rename/replacement after acquisition
- * cannot redirect subsequent lock/read/write operations into an attacker-
- * substituted directory. On other platforms (and Linux without procfs) the
- * parent is the canonical real path and the strict ancestor-chain check has
- * already run.
+ * synchronous duration of the callback. On Linux every operation resolves
+ * through the opened directory descriptor (`/proc/self/fd/<fd>`), so an
+ * ancestor rename/replacement after acquisition cannot redirect subsequent
+ * lock/read/write operations into an attacker-substituted directory. On other
+ * platforms (and Linux without procfs) the parent is the canonical real path
+ * and the strict ancestor-chain check has already run.
  *
- * The handle is single-use and fail-closed: once the owning
- * {@link withSecureHostParentSync} call returns and releases the descriptor,
- * `readLeaf`/`writeLeaf` throw {@link UnsafeHostAuthorityFileError}. This
- * matters because the anchor is `/proc/self/fd/<fd>`: after the fd is closed
- * the kernel may recycle that number for an unrelated directory that never
- * passed the 0700/owner checks, so a leaked or post-release handle must never
- * be allowed to operate on it.
+ * The handle is single-use and fail-closed. It deliberately exposes NO raw
+ * filesystem path: the `/proc/self/fd/<fd>` anchor is a live capability that
+ * cannot be revoked once handed out as a string, so a caller could stash it,
+ * let the fd be recycled after release, and hand the stale string to `fs` or a
+ * lock — landing on a directory that never passed the 0700/owner checks. Every
+ * capability is therefore a method that re-checks `active` at call time: once
+ * the owning {@link withSecureHostParentSync} call returns and releases the
+ * descriptor, `readLeaf`/`writeLeaf`/`withLeafLock` throw
+ * {@link UnsafeHostAuthorityFileError} instead of touching the recycled fd.
  */
 export interface SecureHostParentHandle {
-  /** Directory anchor to build the leaf and any sibling paths from. */
-  readonly parentPath: string;
-  /** Basename of the credential leaf. */
+  /** Basename of the credential leaf (informational; carries no path capability). */
   readonly leafName: string;
-  /** Anchored leaf path (`join(parentPath, leafName)`). */
-  readonly leafPath: string;
   /** Read the pinned leaf (fail-closed on unsafe shapes); null if absent. */
   readLeaf(maxBytes?: number): string | null;
   /** Durably, atomically replace the pinned leaf without following a symlink. */
   writeLeaf(data: string): void;
+  /**
+   * Run `fn` while holding a cross-process advisory lock on the pinned leaf,
+   * serialized against other processes doing the same get-or-create. The lock
+   * path is derived from the internal anchor and never exposed, so it cannot be
+   * reused after release. `fn` must be synchronous (see {@link NonThenable}).
+   */
+  withLeafLock<R>(fn: () => NonThenable<R>): R;
 }
 
 /**
@@ -374,10 +379,10 @@ type NonThenable<T> = T extends PromiseLike<unknown> ? never : T;
  * owned by the current user.
  *
  * Fail-closed lifetime: `fn` MUST be synchronous. The `NonThenable` return
- * bound rejects `async`/Promise-returning callbacks at compile time, and the
- * handle additionally traps at runtime — after this function returns, any
- * escaped handle's `readLeaf`/`writeLeaf` throws instead of touching the
- * released (and possibly fd-recycled) `/proc/self/fd/<fd>` anchor.
+ * bound rejects `async`/Promise-returning callbacks at compile time; the handle
+ * exposes no raw path (only guarded methods); and every method re-checks
+ * `active` at runtime — after this function returns, any escaped handle traps
+ * instead of touching the released (and possibly fd-recycled) anchor.
  */
 export function withSecureHostParentSync<T>(
   filePath: string,
@@ -385,6 +390,8 @@ export function withSecureHostParentSync<T>(
 ): T {
   const parent = acquireSecureHostParent(filePath);
   const leafName = basename(filePath);
+  // Kept in the closure only — never exposed as a string on the handle.
+  const anchoredLeafPath = join(parent.path, leafName);
   let released = false;
   const assertActive = (): void => {
     if (released) {
@@ -393,9 +400,7 @@ export function withSecureHostParentSync<T>(
   };
   try {
     const handle: SecureHostParentHandle = {
-      parentPath: parent.path,
       leafName,
-      leafPath: join(parent.path, leafName),
       readLeaf: (maxBytes = 64 * 1024) => {
         assertActive();
         return readSecureHostFileFromParentSync(parent, leafName, maxBytes);
@@ -403,6 +408,10 @@ export function withSecureHostParentSync<T>(
       writeLeaf: (data: string) => {
         assertActive();
         writeSecureLeafFromParentSync(parent, leafName, data);
+      },
+      withLeafLock: <R>(inner: () => NonThenable<R>): R => {
+        assertActive();
+        return withFileLockSync(anchoredLeafPath, inner);
       },
     };
     return fn(handle);

--- a/src/platform/secure-host-file.ts
+++ b/src/platform/secure-host-file.ts
@@ -275,38 +275,101 @@ function writePinnedSecureHostFileSync(
   }
 }
 
+/**
+ * Strict, durable atomic replace of a leaf under an already-acquired parent.
+ * Every path is resolved through `parent.path` (the pinned /proc/self/fd anchor
+ * on Linux), so a caller that holds the parent across several operations never
+ * re-resolves the swappable directory name between them.
+ */
+function writeSecureLeafFromParentSync(
+  parent: SecureHostParent,
+  leafName: string,
+  data: string,
+): void {
+  const resolved = join(parent.path, leafName);
+  let leafExists = false;
+  try {
+    lstatSync(resolved);
+    leafExists = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  if (leafExists) {
+    // Pin and validate the existing leaf before replacement. The final
+    // rename never follows a leaf symlink.
+    readSecureHostFileFromParentSync(parent, leafName, 64 * 1024);
+  }
+  if (parent.fd !== undefined) {
+    writePinnedSecureHostFileSync(parent, parent.fd, leafName, data);
+  } else {
+    atomicWriteFileSync(resolved, data, {
+      mode: 0o600,
+      durable: true,
+      followTargetSymlink: false,
+    });
+  }
+}
+
 /** Strict, durable atomic replace that never follows a leaf symlink. */
 export function writeSecureHostFileSync(filePath: string, data: string): void {
   const parent = acquireSecureHostParent(filePath);
-  const leafName = basename(filePath);
-  const resolved = join(parent.path, leafName);
   try {
-    let leafExists = false;
-    try {
-      lstatSync(resolved);
-      leafExists = true;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-    }
-    if (leafExists) {
-      // Pin and validate the existing leaf before replacement. The final
-      // rename never follows a leaf symlink.
-      readSecureHostFileFromParentSync(parent, leafName, 64 * 1024);
-    }
-    if (parent.fd !== undefined) {
-      writePinnedSecureHostFileSync(
-        parent,
-        parent.fd,
-        leafName,
-        data,
-      );
-    } else {
-      atomicWriteFileSync(resolved, data, {
-        mode: 0o600,
-        durable: true,
-        followTargetSymlink: false,
-      });
-    }
+    writeSecureLeafFromParentSync(parent, basename(filePath), data);
+  } finally {
+    releaseSecureHostParent(parent);
+  }
+}
+
+/**
+ * A pinned view of the credential directory that stays valid for the whole
+ * callback. On Linux `leafPath` (and anything a caller derives from it, e.g. a
+ * sibling `.lock`) resolves through the opened directory descriptor, so an
+ * ancestor rename/replacement after acquisition cannot redirect subsequent
+ * lock/read/write operations into an attacker-substituted directory. On other
+ * platforms (and Linux without procfs) the parent is the canonical real path
+ * and the strict ancestor-chain check has already run.
+ */
+export interface SecureHostParentHandle {
+  /** Directory anchor to build the leaf and any sibling paths from. */
+  readonly parentPath: string;
+  /** Basename of the credential leaf. */
+  readonly leafName: string;
+  /** Anchored leaf path (`join(parentPath, leafName)`). */
+  readonly leafPath: string;
+  /** Read the pinned leaf (fail-closed on unsafe shapes); null if absent. */
+  readLeaf(maxBytes?: number): string | null;
+  /** Durably, atomically replace the pinned leaf without following a symlink. */
+  writeLeaf(data: string): void;
+}
+
+/**
+ * Acquire the secure parent directory once and expose it to `fn` as a pinned
+ * handle, releasing the descriptor afterwards. Use this instead of chaining
+ * {@link secureHostFilePath} + independent read/write calls when a credential
+ * needs a serialized get-or-create (lock → read → write): resolving the lock
+ * and the leaf through the same descriptor keeps the whole critical section on
+ * one directory inode. Unlike {@link secureHostFilePath}, this does not force
+ * the strict ancestor-chain assertion on Linux — the pinned descriptor already
+ * makes later operations independent of ancestor renames — so it works under a
+ * symlinked HOME or a shared-drive/0777 ancestor while `~/.botmux` itself stays
+ * 0700 and owned by the current user.
+ */
+export function withSecureHostParent<T>(
+  filePath: string,
+  fn: (handle: SecureHostParentHandle) => T,
+): T {
+  const parent = acquireSecureHostParent(filePath);
+  const leafName = basename(filePath);
+  try {
+    const handle: SecureHostParentHandle = {
+      parentPath: parent.path,
+      leafName,
+      leafPath: join(parent.path, leafName),
+      readLeaf: (maxBytes = 64 * 1024) =>
+        readSecureHostFileFromParentSync(parent, leafName, maxBytes),
+      writeLeaf: (data: string) => writeSecureLeafFromParentSync(parent, leafName, data),
+    };
+    return fn(handle);
   } finally {
     releaseSecureHostParent(parent);
   }

--- a/src/platform/secure-host-file.ts
+++ b/src/platform/secure-host-file.ts
@@ -321,13 +321,22 @@ export function writeSecureHostFileSync(filePath: string, data: string): void {
 }
 
 /**
- * A pinned view of the credential directory that stays valid for the whole
- * callback. On Linux `leafPath` (and anything a caller derives from it, e.g. a
- * sibling `.lock`) resolves through the opened directory descriptor, so an
- * ancestor rename/replacement after acquisition cannot redirect subsequent
- * lock/read/write operations into an attacker-substituted directory. On other
- * platforms (and Linux without procfs) the parent is the canonical real path
- * and the strict ancestor-chain check has already run.
+ * A pinned view of the credential directory that stays valid ONLY for the
+ * synchronous duration of the callback. On Linux `leafPath` (and anything a
+ * caller derives from it, e.g. a sibling `.lock`) resolves through the opened
+ * directory descriptor, so an ancestor rename/replacement after acquisition
+ * cannot redirect subsequent lock/read/write operations into an attacker-
+ * substituted directory. On other platforms (and Linux without procfs) the
+ * parent is the canonical real path and the strict ancestor-chain check has
+ * already run.
+ *
+ * The handle is single-use and fail-closed: once the owning
+ * {@link withSecureHostParentSync} call returns and releases the descriptor,
+ * `readLeaf`/`writeLeaf` throw {@link UnsafeHostAuthorityFileError}. This
+ * matters because the anchor is `/proc/self/fd/<fd>`: after the fd is closed
+ * the kernel may recycle that number for an unrelated directory that never
+ * passed the 0700/owner checks, so a leaked or post-release handle must never
+ * be allowed to operate on it.
  */
 export interface SecureHostParentHandle {
   /** Directory anchor to build the leaf and any sibling paths from. */
@@ -343,34 +352,65 @@ export interface SecureHostParentHandle {
 }
 
 /**
- * Acquire the secure parent directory once and expose it to `fn` as a pinned
- * handle, releasing the descriptor afterwards. Use this instead of chaining
- * {@link secureHostFilePath} + independent read/write calls when a credential
- * needs a serialized get-or-create (lock → read → write): resolving the lock
- * and the leaf through the same descriptor keeps the whole critical section on
- * one directory inode. Unlike {@link secureHostFilePath}, this does not force
- * the strict ancestor-chain assertion on Linux — the pinned descriptor already
- * makes later operations independent of ancestor renames — so it works under a
- * symlinked HOME or a shared-drive/0777 ancestor while `~/.botmux` itself stays
- * 0700 and owned by the current user.
+ * `T` constrained to a non-thenable so an `async` callback (or any callback
+ * returning a Promise) is a compile-time error. The pinned descriptor is
+ * released synchronously when the callback returns; an awaited continuation
+ * would run after release, on a possibly-recycled fd. See
+ * {@link withSecureHostParentSync}.
  */
-export function withSecureHostParent<T>(
+type NonThenable<T> = T extends PromiseLike<unknown> ? never : T;
+
+/**
+ * Acquire the secure parent directory once and expose it to `fn` as a pinned
+ * handle for the SYNCHRONOUS duration of the call, releasing the descriptor
+ * afterwards. Use this instead of chaining {@link secureHostFilePath} +
+ * independent read/write calls when a credential needs a serialized
+ * get-or-create (lock → read → write): resolving the lock and the leaf through
+ * the same descriptor keeps the whole critical section on one directory inode.
+ * Unlike {@link secureHostFilePath}, this does not force the strict
+ * ancestor-chain assertion on Linux — the pinned descriptor already makes later
+ * operations independent of ancestor renames — so it works under a symlinked
+ * HOME or a shared-drive/0777 ancestor while `~/.botmux` itself stays 0700 and
+ * owned by the current user.
+ *
+ * Fail-closed lifetime: `fn` MUST be synchronous. The `NonThenable` return
+ * bound rejects `async`/Promise-returning callbacks at compile time, and the
+ * handle additionally traps at runtime — after this function returns, any
+ * escaped handle's `readLeaf`/`writeLeaf` throws instead of touching the
+ * released (and possibly fd-recycled) `/proc/self/fd/<fd>` anchor.
+ */
+export function withSecureHostParentSync<T>(
   filePath: string,
-  fn: (handle: SecureHostParentHandle) => T,
+  fn: (handle: SecureHostParentHandle) => NonThenable<T>,
 ): T {
   const parent = acquireSecureHostParent(filePath);
   const leafName = basename(filePath);
+  let released = false;
+  const assertActive = (): void => {
+    if (released) {
+      throw new UnsafeHostAuthorityFileError('宿主凭证目录句柄已释放，禁止在回调返回后继续使用');
+    }
+  };
   try {
     const handle: SecureHostParentHandle = {
       parentPath: parent.path,
       leafName,
       leafPath: join(parent.path, leafName),
-      readLeaf: (maxBytes = 64 * 1024) =>
-        readSecureHostFileFromParentSync(parent, leafName, maxBytes),
-      writeLeaf: (data: string) => writeSecureLeafFromParentSync(parent, leafName, data),
+      readLeaf: (maxBytes = 64 * 1024) => {
+        assertActive();
+        return readSecureHostFileFromParentSync(parent, leafName, maxBytes);
+      },
+      writeLeaf: (data: string) => {
+        assertActive();
+        writeSecureLeafFromParentSync(parent, leafName, data);
+      },
     };
     return fn(handle);
   } finally {
+    // Invalidate the handle BEFORE closing the fd so a post-return caller
+    // (leaked closure, or an async continuation that slipped past the type
+    // bound) can never act on a recycled descriptor.
+    released = true;
     releaseSecureHostParent(parent);
   }
 }

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -3,7 +3,8 @@ import { createHmac } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import {
-  mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync, existsSync, statSync,
+  chmodSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync,
+  symlinkSync, writeFileSync, existsSync, statSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -192,6 +193,168 @@ describe('token persistence (survives restart, rotates only on `botmux dashboard
   it('loadPersistedToken fails closed when the credential path is not a regular file', () => {
     expect(() => loadPersistedToken(dir)).toThrow();
   });
+});
+
+/**
+ * Regression: dashboard token ensure/rotate on a Linux dev box whose HOME is a
+ * symlink resolving onto a shared drive / 0777 ancestor. Before the FD-anchored
+ * fix, loadOrCreatePersistedToken()/rotatePersistedToken() ran the strict
+ * ancestor-chain assertion (via secureHostFilePath) before reaching the Linux
+ * FD-pinning path, so a single writable ancestor made `botmux dashboard` fail
+ * with `500 token_persist_failed` even though the direct write path succeeded.
+ */
+describe('token persistence under a symlinked HOME on a shared drive (Linux FD-pinning)', () => {
+  let base: string;
+
+  beforeEach(() => { base = mkdtempSync(join(tmpdir(), 'botmux-token-shared-')); });
+  afterEach(() => { rmSync(base, { recursive: true, force: true }); });
+
+  /**
+   * Build `<shared 0777>/real-home/.botmux` (0700, current user) and a HOME
+   * symlink pointing at real-home. Returns the token path as seen through the
+   * symlinked HOME plus the canonical (post-realpath) leaf path.
+   */
+  function sharedDriveHome(): { tokenPath: string; canonicalLeaf: string; botmux: string } {
+    const shared = join(base, 'shared');
+    mkdirSync(shared, { recursive: true });
+    chmodSync(shared, 0o777); // shared drive / group+other-writable ancestor
+    const realHome = join(shared, 'real-home');
+    mkdirSync(realHome, { recursive: true });
+    const botmux = join(realHome, '.botmux');
+    mkdirSync(botmux, { mode: 0o700 });
+    chmodSync(botmux, 0o700); // defeat umask so the dir is exactly 0700
+    const homeLink = join(base, 'home-link');
+    symlinkSync(realHome, homeLink);
+    return {
+      tokenPath: join(homeLink, '.botmux', '.dashboard-token'),
+      canonicalLeaf: join(realHome, '.botmux', '.dashboard-token'),
+      botmux,
+    };
+  }
+
+  it('ensures a token under a 0777 ancestor; leaf lands in the real dir at 0600', () => {
+    if (process.platform !== 'linux') return;
+    const { tokenPath, canonicalLeaf } = sharedDriveHome();
+
+    const token = loadOrCreatePersistedToken(tokenPath);
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    // Persisted through the symlink into the real (canonical) directory.
+    expect(readFileSync(canonicalLeaf, 'utf8').trim()).toBe(token);
+    expect(lstatSync(canonicalLeaf).mode & 0o777).toBe(0o600);
+    // Re-ensure reuses the same durable token instead of minting a new one.
+    expect(loadOrCreatePersistedToken(tokenPath)).toBe(token);
+    expect(loadPersistedToken(tokenPath)).toBe(token);
+  });
+
+  it('rotates the token under the same shared-drive path', () => {
+    if (process.platform !== 'linux') return;
+    const { tokenPath, canonicalLeaf } = sharedDriveHome();
+
+    const first = loadOrCreatePersistedToken(tokenPath);
+    const rotated = rotatePersistedToken(tokenPath);
+    expect(rotated).not.toBe(first);
+    expect(rotated).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(readFileSync(canonicalLeaf, 'utf8').trim()).toBe(rotated);
+    expect(lstatSync(canonicalLeaf).mode & 0o777).toBe(0o600);
+    expect(loadPersistedToken(tokenPath)).toBe(rotated);
+  });
+
+  it('ensures a token through a HOME symlink to a permission-safe plain dir', () => {
+    if (process.platform === 'win32') return;
+    // Safe layout: no writable ancestor, HOME is just a symlink indirection.
+    const realHome = join(base, 'real-home');
+    mkdirSync(join(realHome, '.botmux'), { recursive: true, mode: 0o700 });
+    chmodSync(join(realHome, '.botmux'), 0o700);
+    const homeLink = join(base, 'home-link');
+    symlinkSync(realHome, homeLink);
+    const tokenPath = join(homeLink, '.botmux', '.dashboard-token');
+
+    const token = loadOrCreatePersistedToken(tokenPath);
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(readFileSync(join(realHome, '.botmux', '.dashboard-token'), 'utf8').trim()).toBe(token);
+    expect(rotatePersistedToken(tokenPath)).not.toBe(token);
+  });
+
+  it('still refuses a token leaf symlink under a shared-drive HOME (target untouched)', () => {
+    if (process.platform === 'win32') return;
+    const { tokenPath, botmux } = sharedDriveHome();
+    const victim = join(botmux, 'victim');
+    writeFileSync(victim, 'keep-me', { mode: 0o600 });
+    symlinkSync(victim, realpathSync(botmux) + '/.dashboard-token');
+
+    expect(() => rotatePersistedToken(tokenPath)).toThrow();
+    expect(() => loadOrCreatePersistedToken(tokenPath)).toThrow();
+    expect(readFileSync(victim, 'utf8')).toBe('keep-me');
+  });
+
+  it('still refuses when ~/.botmux itself is group/other-writable', () => {
+    if (process.platform === 'win32') return;
+    const shared = join(base, 'shared');
+    mkdirSync(shared, { recursive: true });
+    chmodSync(shared, 0o777);
+    const realHome = join(shared, 'real-home');
+    const botmux = join(realHome, '.botmux');
+    mkdirSync(botmux, { recursive: true });
+    chmodSync(botmux, 0o770); // the credential dir itself is group-writable → unsafe
+    const homeLink = join(base, 'home-link');
+    symlinkSync(realHome, homeLink);
+    const tokenPath = join(homeLink, '.botmux', '.dashboard-token');
+
+    expect(() => loadOrCreatePersistedToken(tokenPath)).toThrow(/组内|其它用户写入/);
+    expect(() => rotatePersistedToken(tokenPath)).toThrow(/组内|其它用户写入/);
+  });
+
+  it('concurrent processes under a shared-drive symlinked HOME all return one token', async () => {
+    if (process.platform !== 'linux') return;
+    const { tokenPath, canonicalLeaf } = sharedDriveHome();
+    const goPath = join(base, 'go');
+    const authModuleUrl = new URL('../src/dashboard/auth.ts', import.meta.url).href;
+    const childSource = `
+      import { existsSync, writeFileSync } from 'node:fs';
+      const [tokenPath, readyPath, goPath] = process.argv.slice(1);
+      const { loadOrCreatePersistedToken } = await import(${JSON.stringify(authModuleUrl)});
+      writeFileSync(readyPath, 'ready');
+      while (!existsSync(goPath)) await new Promise(resolve => setTimeout(resolve, 5));
+      process.stdout.write(loadOrCreatePersistedToken(tokenPath));
+    `;
+    const children = Array.from({ length: 12 }, (_, index) => {
+      const readyPath = join(base, `ready-${index}`);
+      const child = spawn(process.execPath, [
+        '--import', 'tsx', '--input-type=module', '-e', childSource,
+        tokenPath, readyPath, goPath,
+      ], { stdio: ['ignore', 'pipe', 'pipe'] });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', chunk => { stdout += String(chunk); });
+      child.stderr.on('data', chunk => { stderr += String(chunk); });
+      return { child, readyPath, stdout: () => stdout, stderr: () => stderr };
+    });
+
+    try {
+      const deadline = Date.now() + 10_000;
+      while (!children.every(entry => existsSync(entry.readyPath))) {
+        if (Date.now() >= deadline) throw new Error('token children did not reach barrier');
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+      writeFileSync(goPath, 'go');
+      const exits = await Promise.all(children.map(async entry => {
+        const [code, signal] = await once(entry.child, 'close');
+        return { code, signal, stdout: entry.stdout(), stderr: entry.stderr() };
+      }));
+      for (const result of exits) {
+        expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
+      }
+      const tokens = exits.map(result => result.stdout);
+      expect(new Set(tokens).size).toBe(1);
+      expect(tokens[0]).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      // The single durable winner is what the real (canonical) leaf holds.
+      expect(readFileSync(canonicalLeaf, 'utf8').trim()).toBe(tokens[0]);
+    } finally {
+      for (const { child } of children) {
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      }
+    }
+  }, 20_000);
 });
 
 describe('dashboard secret persistence', () => {

--- a/test/secure-host-file-race.test.ts
+++ b/test/secure-host-file-race.test.ts
@@ -1,6 +1,7 @@
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -41,6 +42,7 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 import { writeSecureHostFileSync } from '../src/platform/secure-host-file.js';
+import { loadOrCreatePersistedToken } from '../src/dashboard/auth.js';
 
 const roots: string[] = [];
 
@@ -72,5 +74,36 @@ describe('secure host authority directory pinning', () => {
 
     expect(readFileSync(movedFile, 'utf8')).toBe('secret');
     expect(existsSync(trapFile)).toBe(false);
+  });
+
+  it('keeps the dashboard token lock+write on the pinned dir when an ancestor is swapped', () => {
+    if (process.platform !== 'linux') return;
+    const root = mkdtempSync(join(tmpdir(), 'botmux-token-race-'));
+    roots.push(root);
+    chmodSync(root, 0o777);
+    const visibleRoot = join(root, 'visible');
+    const movedRoot = join(root, 'moved');
+    const visibleBotmux = join(visibleRoot, '.botmux');
+    const tokenPath = join(visibleBotmux, '.dashboard-token');
+    const movedLeaf = join(movedRoot, '.botmux', '.dashboard-token');
+    mkdirSync(visibleBotmux, { recursive: true, mode: 0o700 });
+
+    // Right after the credential parent fd is pinned, rename the whole ancestor
+    // aside and drop a 0777 trap directory back into the old path. If the lock
+    // or the token write re-resolved the pathname instead of the pinned fd,
+    // they would land in (or be redirected through) the attacker-writable trap.
+    fsRace.afterDirectoryOpen = () => {
+      renameSync(visibleRoot, movedRoot);
+      mkdirSync(visibleBotmux, { recursive: true, mode: 0o777 });
+      chmodSync(visibleBotmux, 0o777);
+    };
+
+    const token = loadOrCreatePersistedToken(tokenPath);
+
+    // Token + its lock landed in the pinned (moved) directory, never the trap.
+    expect(readFileSync(movedLeaf, 'utf8').trim()).toBe(token);
+    expect(lstatSync(movedLeaf).mode & 0o777).toBe(0o600);
+    expect(existsSync(tokenPath)).toBe(false);
+    expect(existsSync(`${tokenPath}.lock`)).toBe(false);
   });
 });

--- a/test/secure-host-file.test.ts
+++ b/test/secure-host-file.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   readSecureHostFileSync,
   unlinkSecureHostFileSync,
+  withSecureHostParent,
   writeSecureHostFileSync,
 } from '../src/platform/secure-host-file.js';
 
@@ -95,5 +96,58 @@ describe('secure host authority files', () => {
 
     writeSecureHostFileSync(file, 'secret');
     expect(readSecureHostFileSync(file)).toBe('secret');
+  });
+});
+
+describe('withSecureHostParent', () => {
+  it('pins the parent for read+write and returns anchored paths', () => {
+    const root = tempRoot();
+    const file = join(root, '.botmux', '.dashboard-token');
+    const result = withSecureHostParent(file, (parent) => {
+      expect(parent.leafName).toBe('.dashboard-token');
+      expect(parent.leafPath).toBe(join(parent.parentPath, '.dashboard-token'));
+      expect(parent.readLeaf()).toBeNull(); // absent leaf reads as null, not a throw
+      parent.writeLeaf('tok-value');
+      return parent.readLeaf();
+    });
+    expect(result).toBe('tok-value');
+    expect(lstatSync(file).mode & 0o777).toBe(process.platform === 'win32' ? lstatSync(file).mode & 0o777 : 0o600);
+    expect(readSecureHostFileSync(file)).toBe('tok-value');
+  });
+
+  it('pins a safe credential dir under a 0777 ancestor on Linux; strict elsewhere', () => {
+    if (process.platform === 'win32') return;
+    const root = tempRoot();
+    chmodSync(root, 0o777);
+    const dir = join(root, '.botmux');
+    mkdirSync(dir, { mode: 0o700 });
+    const file = join(dir, '.dashboard-token');
+
+    if (process.platform === 'linux') {
+      const token = withSecureHostParent(file, (parent) => {
+        parent.writeLeaf('anchored-token');
+        return parent.readLeaf();
+      });
+      expect(token).toBe('anchored-token');
+      expect(readSecureHostFileSync(file)).toBe('anchored-token');
+    } else {
+      // Non-Linux keeps the conservative ancestor-chain requirement.
+      expect(() => withSecureHostParent(file, (parent) => parent.writeLeaf('x')))
+        .toThrow(/祖先目录替换/);
+    }
+  });
+
+  it('refuses a leaf symlink through the pinned handle without touching its target', () => {
+    if (process.platform === 'win32') return;
+    const root = tempRoot();
+    const dir = join(root, '.botmux');
+    mkdirSync(dir, { mode: 0o700 });
+    const victim = join(root, 'victim');
+    writeFileSync(victim, 'keep-me', { mode: 0o600 });
+    const file = join(dir, '.dashboard-token');
+    symlinkSync(victim, file);
+
+    expect(() => withSecureHostParent(file, (parent) => parent.writeLeaf('replace'))).toThrow();
+    expect(readFileSync(victim, 'utf8')).toBe('keep-me');
   });
 });

--- a/test/secure-host-file.test.ts
+++ b/test/secure-host-file.test.ts
@@ -101,12 +101,14 @@ describe('secure host authority files', () => {
 });
 
 describe('withSecureHostParentSync', () => {
-  it('pins the parent for read+write and returns anchored paths', () => {
+  it('pins the parent for read+write and exposes no raw path capability', () => {
     const root = tempRoot();
     const file = join(root, '.botmux', '.dashboard-token');
     const result = withSecureHostParentSync(file, (parent) => {
       expect(parent.leafName).toBe('.dashboard-token');
-      expect(parent.leafPath).toBe(join(parent.parentPath, '.dashboard-token'));
+      // The handle must NOT hand out a raw /proc/self/fd path capability.
+      expect((parent as Record<string, unknown>).leafPath).toBeUndefined();
+      expect((parent as Record<string, unknown>).parentPath).toBeUndefined();
       expect(parent.readLeaf()).toBeNull(); // absent leaf reads as null, not a throw
       parent.writeLeaf('tok-value');
       return parent.readLeaf();
@@ -114,6 +116,21 @@ describe('withSecureHostParentSync', () => {
     expect(result).toBe('tok-value');
     expect(lstatSync(file).mode & 0o777).toBe(process.platform === 'win32' ? lstatSync(file).mode & 0o777 : 0o600);
     expect(readSecureHostFileSync(file)).toBe('tok-value');
+  });
+
+  it('serializes a get-or-create through withLeafLock', () => {
+    const root = tempRoot();
+    const file = join(root, '.botmux', '.dashboard-token');
+    const token = withSecureHostParentSync(file, (parent) =>
+      parent.withLeafLock(() => {
+        const existing = parent.readLeaf()?.trim() || null;
+        if (existing) return existing;
+        parent.writeLeaf('locked-token');
+        return 'locked-token';
+      }),
+    );
+    expect(token).toBe('locked-token');
+    expect(readSecureHostFileSync(file)).toBe('locked-token');
   });
 
   it('pins a safe credential dir under a 0777 ancestor on Linux; strict elsewhere', () => {
@@ -125,10 +142,12 @@ describe('withSecureHostParentSync', () => {
     const file = join(dir, '.dashboard-token');
 
     if (process.platform === 'linux') {
-      const token = withSecureHostParentSync(file, (parent) => {
-        parent.writeLeaf('anchored-token');
-        return parent.readLeaf();
-      });
+      const token = withSecureHostParentSync(file, (parent) =>
+        parent.withLeafLock(() => {
+          parent.writeLeaf('anchored-token');
+          return parent.readLeaf();
+        }),
+      );
       expect(token).toBe('anchored-token');
       expect(readSecureHostFileSync(file)).toBe('anchored-token');
     } else {
@@ -164,9 +183,10 @@ describe('withSecureHostParentSync', () => {
       return 0;
     });
     // After release the descriptor may be recycled to an unchecked directory,
-    // so both accessors must throw rather than touch /proc/self/fd/<fd>.
+    // so every capability must throw rather than touch /proc/self/fd/<fd>.
     expect(() => leaked.readLeaf()).toThrow(/句柄已释放/);
     expect(() => leaked.writeLeaf('after-release')).toThrow(/句柄已释放/);
+    expect(() => leaked.withLeafLock(() => 0)).toThrow(/句柄已释放/);
     // The one legitimate in-callback write is the only mutation that landed.
     expect(readSecureHostFileSync(file)).toBe('inside-token');
   });
@@ -180,5 +200,6 @@ describe('withSecureHostParentSync', () => {
       throw new Error('boom');
     })).toThrow('boom');
     expect(() => leaked.writeLeaf('after-throw')).toThrow(/句柄已释放/);
+    expect(() => leaked.withLeafLock(() => 0)).toThrow(/句柄已释放/);
   });
 });

--- a/test/secure-host-file.test.ts
+++ b/test/secure-host-file.test.ts
@@ -13,8 +13,9 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   readSecureHostFileSync,
+  type SecureHostParentHandle,
   unlinkSecureHostFileSync,
-  withSecureHostParent,
+  withSecureHostParentSync,
   writeSecureHostFileSync,
 } from '../src/platform/secure-host-file.js';
 
@@ -99,11 +100,11 @@ describe('secure host authority files', () => {
   });
 });
 
-describe('withSecureHostParent', () => {
+describe('withSecureHostParentSync', () => {
   it('pins the parent for read+write and returns anchored paths', () => {
     const root = tempRoot();
     const file = join(root, '.botmux', '.dashboard-token');
-    const result = withSecureHostParent(file, (parent) => {
+    const result = withSecureHostParentSync(file, (parent) => {
       expect(parent.leafName).toBe('.dashboard-token');
       expect(parent.leafPath).toBe(join(parent.parentPath, '.dashboard-token'));
       expect(parent.readLeaf()).toBeNull(); // absent leaf reads as null, not a throw
@@ -124,7 +125,7 @@ describe('withSecureHostParent', () => {
     const file = join(dir, '.dashboard-token');
 
     if (process.platform === 'linux') {
-      const token = withSecureHostParent(file, (parent) => {
+      const token = withSecureHostParentSync(file, (parent) => {
         parent.writeLeaf('anchored-token');
         return parent.readLeaf();
       });
@@ -132,7 +133,7 @@ describe('withSecureHostParent', () => {
       expect(readSecureHostFileSync(file)).toBe('anchored-token');
     } else {
       // Non-Linux keeps the conservative ancestor-chain requirement.
-      expect(() => withSecureHostParent(file, (parent) => parent.writeLeaf('x')))
+      expect(() => withSecureHostParentSync(file, (parent) => parent.writeLeaf('x')))
         .toThrow(/祖先目录替换/);
     }
   });
@@ -147,7 +148,37 @@ describe('withSecureHostParent', () => {
     const file = join(dir, '.dashboard-token');
     symlinkSync(victim, file);
 
-    expect(() => withSecureHostParent(file, (parent) => parent.writeLeaf('replace'))).toThrow();
+    expect(() => withSecureHostParentSync(file, (parent) => parent.writeLeaf('replace'))).toThrow();
     expect(readFileSync(victim, 'utf8')).toBe('keep-me');
+  });
+
+  it('fails closed when a leaked handle is used after the call returns', () => {
+    const root = tempRoot();
+    const file = join(root, '.botmux', '.dashboard-token');
+    // Escape the handle out of the callback (models a sync closure leak or an
+    // async continuation that slipped past the compile-time NonThenable bound).
+    let leaked!: SecureHostParentHandle;
+    withSecureHostParentSync(file, (parent) => {
+      leaked = parent;
+      parent.writeLeaf('inside-token');
+      return 0;
+    });
+    // After release the descriptor may be recycled to an unchecked directory,
+    // so both accessors must throw rather than touch /proc/self/fd/<fd>.
+    expect(() => leaked.readLeaf()).toThrow(/句柄已释放/);
+    expect(() => leaked.writeLeaf('after-release')).toThrow(/句柄已释放/);
+    // The one legitimate in-callback write is the only mutation that landed.
+    expect(readSecureHostFileSync(file)).toBe('inside-token');
+  });
+
+  it('invalidates the handle even when the callback throws', () => {
+    const root = tempRoot();
+    const file = join(root, '.botmux', '.dashboard-token');
+    let leaked!: SecureHostParentHandle;
+    expect(() => withSecureHostParentSync(file, (parent) => {
+      leaked = parent;
+      throw new Error('boom');
+    })).toThrow('boom');
+    expect(() => leaked.writeLeaf('after-throw')).toThrow(/句柄已释放/);
   });
 });


### PR DESCRIPTION
## 问题

Linux 开发机 HOME 为软链、且 `realpath` 落到共享盘或存在异主/可写祖先目录时，`botmux dashboard` 报：

```
Dashboard lookup failed: 500 {"error":"token_persist_failed"}
```

## 根因

`src/dashboard/auth.ts` 的 `loadOrCreatePersistedToken()` / `rotatePersistedToken()` 先调用 `secureHostFilePath()`，后者**无条件**执行 `assertAncestorChainCannotReplace()`；而 Linux 的 `readSecureHostFileSync()` / `writeSecureHostFileSync()` 走的是 FD-pinning 安全路径（打开父目录 FD、用 `/proc/self/fd/<fd>` 锚定目录），**根本不跑**那条祖先断言。

于是 token 在进入 FD-pinning 路径前，就因某级祖先目录 group/other 可写（0777 共享盘）或被异主用户拥有而失败——同一路径 `persistToken()` 成功、`ensure`/`rotate` 却失败，是新增的 token 文件锁路径预处理重新引入的共享盘兼容性回归。

祖先断言有两支会触发（同一文案「宿主凭证目录可被不可信祖先目录替换」）：
- **group/other 可写**：祖先目录 0777（共享盘典型）。
- **异主 owner 可写**：祖先目录被 uid≠当前用户且≠root 的用户拥有、且 owner 有写位（如软链 HOME 的真实父路径落在服务账号拥有的挂载点下）。

## 改动

- `src/platform/secure-host-file.ts`
  - 抽出 `writeSecureLeafFromParentSync()`（`writeSecureHostFileSync` 复用，行为等价）。
  - 新增 `withSecureHostParent(filePath, fn)`：**acquire 一次 pinned parent** 后，把 lock / read / write 全部锚定到同一 `parent.leafPath`。Linux 走 procfs FD anchor（跳过祖先断言——pinned FD 已让后续 open/rename/link 免疫祖先 rename）；非 Linux 及无 procfs 的 Linux 仍执行严格祖先校验，行为不变。
- `src/dashboard/auth.ts`
  - `loadOrCreatePersistedToken` / `rotatePersistedToken` 改用 `withSecureHostParent`，删除 `secureHostFilePath` 预处理。锁与 token 读写在同一目录 inode 上完成，整段临界区不再重解析可被替换的目录名。

不变量保持：`~/.botmux` 自身仍须 0700 且属当前用户；`.dashboard-token` 叶子软链仍被拒；写仍是严格 0600 原子替换。

## 影响范围评估

- **Dashboard ensure/current/rotate**：`ensure`/`rotate` 修复；`current`（`loadPersistedToken`）本就走 FD-pinning 读，未改。
- **其它 `secure-host-file` 使用方**（`platform/device`、`binding`、`device-isolation`、`device-enroll`、`device-isolation-activation-client`）：仅 `writeSecureHostFileSync` 内部抽了函数、语义等价，相关 10 个测试文件全通过。
- **Linux vs macOS 差异**：macOS / 非 Linux 严格祖先校验路径保持不变（新增用例断言在非 Linux 仍 `throw /祖先目录替换/`）。
- **多 Dashboard 进程并发 / stale lock**：跨进程 `O_EXCL` 仍在同一 `.lock` inode 上互斥（两个不同 dir fd 指向同一 `.botmux`，实测第二个 `EEXIST`）；stale-break 逻辑未改。
- **普通 daemon / 不同 CLI / PTY·Tmux 会话**：不经过 dashboard token 路径，不受影响。

## 测试验证

先写失败测试证明回归，再实现修复：

- **负向对照**：stash 掉 `src` 修复（保留新测试）跑，新增用例 **6 例红**（ensure/rotate/并发 under 0777、`withSecureHostParent` Linux/0777、token lock+write ancestor-swap race）；恢复修复后全绿——证明是真回归测试而非空测试。
- **四个核心测试文件 106 例全绿**：`secure-host-file` / `secure-host-file-race` / `dashboard-auth` / `file-lock`。
- **其它使用方 63 例全绿**：device / binding / isolation / enroll / activation。
- `pnpm build`（含 `tsc`）通过；`tsc --noEmit` 干净。
- 全量单测中另有 3 文件 / 6 例 **PTY 集成用例**失败，经在**干净 master 同 commit** 复跑确认**同样失败、集合随机漂移**，与本改无关（不引用本改动模块）。
- 在**真实失败路径** `~/.botmux/.dashboard-token`（其祖先 `/data00` 属异主账号）实测：修复后 `ensure` 成功且**不改动既有 token**（内容与 mtime 均未变），未污染用户配置。

新增回归测试对应需求清单：软链/共享盘 ensure(1)、rotate(2)、安全软链目录(3)、多进程并发同 token(4)、叶子软链仍拒(5)、`~/.botmux` group/other 可写仍拒(6)、Linux ancestor-rename race 不被重定向到 trap(7)、非 Linux 平台 guard(8)、既有 `dashboard-auth`/`secure-host-file`/`file-lock` 全通过(9)。

> ⚠️ 本改动需要在飞书里手动验证 `botmux dashboard` 端到端。因 live daemon 为**多 bot 共享**且承载着当前会话，`pnpm switch:here && pnpm daemon:restart` 会重指全局 shim 并重启所有会话，属破坏性操作，未擅自执行——已在函数层于真实失败路径自证修复。合并前如需 live 验证请告知。
