### PR TITLE
fix(cli): 支持发现当前 ChatGPT 桌面端内置 Codex

### DIFF
--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -80,6 +80,16 @@ export function rawCliExecutable(id: CliId, pathOverride?: string): string | und
 
 const RESOLVE_COMMAND_SCRIPT = 'command -v -- "$1"';
 
+/** macOS desktop apps bundle a standalone Codex binary even when `codex` is
+ * not installed on PATH. ChatGPT is the current app name; keep the legacy
+ * Codex.app locations so existing installations continue to work. */
+export function macOSBundledCodexCandidates(userHome = homedir()): string[] {
+  return ['ChatGPT.app', 'Codex.app'].flatMap(appName => [
+    join('/Applications', appName, 'Contents', 'Resources', 'codex'),
+    join(userHome, 'Applications', appName, 'Contents', 'Resources', 'codex'),
+  ]);
+}
+
 /** Resolve a command name to its absolute path via a login/interactive shell.
  *  Tries login shell first (-lc), then interactive shell (-ic) for tools
  *  whose installers add PATH entries to .bashrc/.zshrc only. The command is
@@ -125,11 +135,7 @@ export function resolveCommand(cmd: string): string {
     }
   }
   if (process.platform === 'darwin' && cmd === 'codex') {
-    const bundledCodexCandidates = [
-      '/Applications/Codex.app/Contents/Resources/codex',
-      join(homedir(), 'Applications', 'Codex.app', 'Contents', 'Resources', 'codex'),
-    ];
-    for (const candidate of bundledCodexCandidates) {
+    for (const candidate of macOSBundledCodexCandidates()) {
       if (existsSync(candidate)) return candidate;
     }
   }

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -275,7 +275,7 @@ class AppServerClient {
     });
     this.child.on('error', err => {
       const hint = (err as NodeJS.ErrnoException).code === 'ENOENT'
-        ? '\nHint: install the Codex CLI, or set cliPathOverride to the Codex App bundled binary, for example /Applications/Codex.app/Contents/Resources/codex.'
+        ? '\nHint: install the Codex CLI, or set cliPathOverride to the desktop app bundled binary, for example /Applications/ChatGPT.app/Contents/Resources/codex (current) or /Applications/Codex.app/Contents/Resources/codex (legacy).'
         : '';
       this.failAll(new Error(`Failed to start Codex app-server with "${codexBin}": ${err.message}${hint}`));
     });

--- a/src/setup/cli-availability.ts
+++ b/src/setup/cli-availability.ts
@@ -55,7 +55,8 @@ function requiredCommand(input: CliAvailabilityInput): string | undefined {
 /**
  * Check launch availability with the same shell-aware resolution used by the
  * worker.  The fast PATH check avoids shell startup in the common case; the
- * fallback still finds nvm/fnm/rc-only installs and the macOS Codex.app binary.
+ * fallback still finds nvm/fnm/rc-only installs and the macOS ChatGPT/Codex
+ * desktop app binary.
  */
 export function checkCliAvailability(
   input: CliAvailabilityInput,

--- a/test/resolve-command-shell-parse.test.ts
+++ b/test/resolve-command-shell-parse.test.ts
@@ -2,7 +2,10 @@ import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { resolveCommand } from '../src/adapters/cli/registry.js';
+import {
+  macOSBundledCodexCandidates,
+  resolveCommand,
+} from '../src/adapters/cli/registry.js';
 import { shellPathProbes } from '../src/desktop/shared/shell-path-probes.js';
 
 describe('shellPathProbes ladder', () => {
@@ -104,5 +107,16 @@ describe('resolveCommand shell output parsing', () => {
     const command = `botmux-test-missing$(touch ${marker})`;
     expect(resolveCommand(command)).toBe(command);
     expect(existsSync(marker)).toBe(false);
+  });
+});
+
+describe('macOS bundled Codex CLI discovery', () => {
+  it('prefers the current ChatGPT app and retains legacy Codex.app paths', () => {
+    expect(macOSBundledCodexCandidates('/Users/example')).toEqual([
+      '/Applications/ChatGPT.app/Contents/Resources/codex',
+      '/Users/example/Applications/ChatGPT.app/Contents/Resources/codex',
+      '/Applications/Codex.app/Contents/Resources/codex',
+      '/Users/example/Applications/Codex.app/Contents/Resources/codex',
+    ]);
   });
 });


### PR DESCRIPTION
## 改动

- macOS 解析 `codex` 可执行文件时，优先发现当前 `ChatGPT.app` 在系统级和用户级 Applications 目录中的内置二进制
- 保留旧 `Codex.app` 的兼容路径，并更新 app-server 启动失败提示
- 提取候选路径生成函数，补充当前应用与旧应用路径优先级的回归测试

## 原因

当前 ChatGPT 桌面端会捆绑独立的 Codex 二进制；当 `codex` 不在 PATH 上时，原有回退只识别旧 `Codex.app`，导致 setup 可用性检查和 worker 启动无法发现当前安装。

## 影响面

- 改动位于共用的 `resolveCommand` 路径，setup 可用性检查和 worker 启动会复用同一解析结果
- 新逻辑仅在 `process.platform === 'darwin' && cmd === 'codex'` 时生效；Linux 和其它 CLI 不受影响
- PATH 与 `cliPathOverride` 的优先级保持不变；PTY/Tmux、话题/群会话、adopt/restore 和 sandbox 路径均无行为变化

## 验证

- `npm exec --yes --package=pnpm@9.5.0 -- pnpm run build`：通过
- `./node_modules/.bin/vitest run --project unit test/resolve-command-shell-parse.test.ts test/cli-availability.test.ts`：2 个测试文件、17 个用例全部通过
- 尝试运行全量 unit；当前受限环境中的 localhost 监听和部分进程探测用例批量失败/超时，因此未作为通过项，相关测试文件已单独验证通过
