### PR TITLE
fix(tmux): do not gate live sessions on an indeterminate probe

### DIFF
--- a/src/adapters/backend/session-backend-selector.ts
+++ b/src/adapters/backend/session-backend-selector.ts
@@ -149,14 +149,24 @@ export type BackendGateDecision =
  * abandoning it would spawn a duplicate CLI and orphan the real conversation.
  * tmux/zellij capability probes use disposable sessions; ZMX checks its
  * version and full-list control plane; Herdr uses `herdr --version`.
+ *
+ * `existingSessionUnknown` covers the third state: the existence check itself
+ * got no answer (timeout under host load). Gating on that is what produced
+ * "本机 tmux 不可用" cards for sessions whose tmux panes were alive the whole
+ * time — a false negative on the *cheap* check overrode a live session. When
+ * existence is indeterminate we spawn rather than gate: selectSessionBackend
+ * re-probes and takes the create branch, which absorbs a "duplicate session"
+ * error as a reattach, whereas a wrong gate strands a working conversation.
  */
 export function decideBackendGate(opts: {
   requested: BackendType;
   available: boolean;
   hasExistingSession: boolean;
+  existingSessionUnknown?: boolean;
 }): BackendGateDecision {
   if (opts.requested === 'pty') return { action: 'spawn' };
   if (opts.hasExistingSession) return { action: 'spawn' };
+  if (opts.existingSessionUnknown) return { action: 'spawn' };
   if (opts.available) return { action: 'spawn' };
   return { action: 'gate', reason: `${opts.requested} 后端在本机不可用` };
 }
@@ -401,7 +411,13 @@ export function selectSessionBackend(opts: {
   }
 
   const sessionName = TmuxBackend.sessionName(opts.sessionId);
-  if (TmuxBackend.hasSession(sessionName)) {
+  // Retry first so a load-induced timeout doesn't decide this at all. Only an
+  // authoritative 'exists' takes the reattach branch; a residual 'unknown'
+  // falls through to create, which absorbs a wrong guess (see
+  // createDetachedSession: a "duplicate session" error is treated as reattach).
+  // The reverse bet is NOT safe — reattaching a session that is really gone
+  // leaves pipe-pane with no pane and no way to recover.
+  if (TmuxBackend.probeSessionWithRetry(sessionName) === 'exists') {
     return {
       backend: new TmuxPipeBackend(sessionName, { ownsSession: true, isReattach: true }),
       isTmuxMode: true,

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -115,12 +115,41 @@ export class TmuxBackend implements SessionBackend {
    */
   static probeSession(name: string): SessionProbe {
     try {
-      execFileSync('tmux', ['has-session', '-t', name], { stdio: 'ignore', env: tmuxEnv(), timeout: 3000 });
+      execFileSync('tmux', ['has-session', '-t', name], { stdio: 'ignore', env: tmuxEnv(), timeout: 10_000 });
       return 'exists';
     } catch (e: any) {
       if (e && typeof e.status === 'number' && !e.signal) return 'missing';
       return 'unknown';
     }
+  }
+
+  /**
+   * Existence probe with a short retry on 'unknown'.
+   *
+   * `has-session` is cheap (~20ms on a healthy host) but it still needs a
+   * fork+exec, so under heavy host load the timeout can expire before tmux is
+   * ever scheduled — signal=SIGTERM, no numeric status → 'unknown'.
+   * A single timeout must not be reported as a verdict, because callers that
+   * collapse 'unknown' into 'missing' then act as if a live session were gone.
+   *
+   * Only 'unknown' is retried: 'exists' and 'missing' are authoritative
+   * answers from tmux and are returned immediately.
+   */
+  static probeSessionWithRetry(name: string, opts: { attempts?: number; baseDelayMs?: number } = {}): SessionProbe {
+    const attempts = Math.max(1, Math.floor(opts.attempts ?? 3));
+    const baseDelayMs = Math.max(0, Math.floor(opts.baseDelayMs ?? 150));
+    let result = TmuxBackend.probeSession(name);
+
+    for (let completed = 1; result === 'unknown' && completed < attempts; completed += 1) {
+      const backoff = baseDelayMs * (2 ** (completed - 1));
+      const jitter = baseDelayMs > 0 ? Math.floor(Math.random() * baseDelayMs) : 0;
+      try {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, backoff + jitter);
+      } catch { /* SharedArrayBuffer unavailable: retry immediately */ }
+      result = TmuxBackend.probeSession(name);
+    }
+
+    return result;
   }
 
   /** Kill a named tmux session (no-op if it doesn't exist). */

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -617,23 +617,37 @@ export class TmuxPipeBackend implements SessionBackend {
   private createDetachedSession(bin: string, args: string[], opts: SpawnOpts): void {
     const shellSpec = resolveUserShell(process.env, opts.launchShell);
     const envAssignments = buildBotmuxEnvAssignments(opts.env, opts.injectEnv);
-    execFileSync('tmux', [
-      'new-session',
-      '-d',
-      '-s', this.paneTarget,
-      '-x', String(opts.cols),
-      '-y', String(opts.rows),
-      '--',
-      ...shellLaunchArgv(shellSpec.shell, shellSpec.flags), '-c', shellWrapperScript(resolveBotmuxWrapperBinDir(opts.env ?? process.env)), '_',
-      opts.cwd,
-      ...envAssignments,
-      bin, ...args,
-    ], {
-      cwd: opts.cwd,
-      stdio: 'ignore',
-      timeout: 5000,
-      env: tmuxEnv(opts.env),
-    });
+    try {
+      execFileSync('tmux', [
+        'new-session',
+        '-d',
+        '-s', this.paneTarget,
+        '-x', String(opts.cols),
+        '-y', String(opts.rows),
+        '--',
+        ...shellLaunchArgv(shellSpec.shell, shellSpec.flags), '-c', shellWrapperScript(resolveBotmuxWrapperBinDir(opts.env ?? process.env)), '_',
+        opts.cwd,
+        ...envAssignments,
+        bin, ...args,
+      ], {
+        cwd: opts.cwd,
+        stdio: ['ignore', 'ignore', 'pipe'],
+        timeout: 5000,
+        env: tmuxEnv(opts.env),
+      });
+    } catch (e: any) {
+      // "duplicate session" means the session we were about to create already
+      // exists, so the create branch was chosen on a stale/indeterminate
+      // existence check (e.g. `has-session` timed out under host load). That is
+      // recoverable and MUST NOT kill the spawn: the pane is alive, so fall
+      // through to reattach — pipe-pane below subscribes to it either way.
+      // Any other failure is a real spawn error and still propagates.
+      const stderr = (e?.stderr?.toString?.() ?? '').trim();
+      if (!/duplicate session/i.test(stderr)) throw e;
+      // stderr, not a logger: this backend deliberately avoids importing the
+      // logger (circular import), same as the read-error path above.
+      process.stderr.write(`[tmux-pipe-backend] session ${this.paneTarget} already existed; reattaching instead of creating\n`);
+    }
     this.applySessionOptions();
   }
 

--- a/src/setup/ensure-tmux.ts
+++ b/src/setup/ensure-tmux.ts
@@ -77,12 +77,33 @@ function childFailureReason(command: string, failure: any, timeoutMs: number): s
   return `${command} 启动/探测失败${message ? `：${message}` : ''}`;
 }
 
+/**
+ * Child-process budgets for tmux probes.
+ *
+ * These are fork+exec budgets, not tmux-work budgets: `tmux -V` answers in
+ * ~10ms and `new-session -d` in well under a second on an idle host. What
+ * actually consumes the budget is waiting to be scheduled. Measured on a dev
+ * Mac running dozens of CLI sessions, `new-session` took 0.93–4.45s at load
+ * ~4, and `tmux -V` blew a 3000ms budget entirely at load ~70 — producing
+ * "tmux 不可用" cards on a host where tmux was perfectly healthy.
+ *
+ * So these are deliberately generous: a probe that takes 10s and answers
+ * correctly is strictly better than one that gives up at 3s and reports a
+ * false negative, because the false negative surfaces to the user as a hard
+ * refusal to start their session. Timeouts still exist to bound a genuinely
+ * hung tmux (restricted /tmp, corrupt install), which is the case they were
+ * added for.
+ */
+const TMUX_VERSION_PROBE_TIMEOUT_MS = 10_000;
+const TMUX_SESSION_PROBE_TIMEOUT_MS = 15_000;
+const TMUX_CLEANUP_TIMEOUT_MS = 5_000;
+
 function probeTmuxVersion(): TmuxVersionProbe {
   try {
     const out = execFileSync('tmux', ['-V'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 3000,
+      timeout: TMUX_VERSION_PROBE_TIMEOUT_MS,
       env: tmuxEnv(),
     });
     return { ok: true, version: out.trim() };
@@ -90,7 +111,7 @@ function probeTmuxVersion(): TmuxVersionProbe {
     const code = err?.code;
     return {
       ok: false,
-      reason: childFailureReason('tmux -V', err, 3000),
+      reason: childFailureReason('tmux -V', err, TMUX_VERSION_PROBE_TIMEOUT_MS),
       // Only ENOENT proves absence. Timeout/EMFILE/EACCES must not be turned
       // into the old, misleading "not on PATH" diagnosis or a startup hard
       // gate; they prove only that this particular probe got no answer.
@@ -264,15 +285,15 @@ export function probeTmuxFunctional(): TmuxFunctionalProbe {
   // startup) and report "ok: false" even on a perfectly healthy install.
   const run = spawnSync('tmux', ['-L', sockName, 'new-session', '-d', '-s', 'probe', 'true'], {
     stdio: ['ignore', 'ignore', 'pipe'],
-    timeout: 5000,
+    timeout: TMUX_SESSION_PROBE_TIMEOUT_MS,
     env: tmuxEnv(),
   });
   if (run.status !== 0) {
-    spawnSync('tmux', ['-L', sockName, 'kill-server'], { stdio: 'ignore', timeout: 3000, env: tmuxEnv() });
+    spawnSync('tmux', ['-L', sockName, 'kill-server'], { stdio: 'ignore', timeout: TMUX_CLEANUP_TIMEOUT_MS, env: tmuxEnv() });
     cleanupTmuxProbeSocket(sockName);
     return {
       ok: false,
-      reason: childFailureReason('tmux new-session', run, 5000),
+      reason: childFailureReason('tmux new-session', run, TMUX_SESSION_PROBE_TIMEOUT_MS),
       binaryPresent: true,
       retryable: (run.error as NodeJS.ErrnoException | undefined)?.code !== 'EACCES',
       version,
@@ -281,7 +302,7 @@ export function probeTmuxFunctional(): TmuxFunctionalProbe {
   // Tear down the probe server and remove the socket file. Some platforms leave
   // bmx-probe-* sockets behind after the server exits; thousands of stale
   // entries make later probe storms slower and easier to time out.
-  spawnSync('tmux', ['-L', sockName, 'kill-server'], { stdio: 'ignore', timeout: 3000, env: tmuxEnv() });
+  spawnSync('tmux', ['-L', sockName, 'kill-server'], { stdio: 'ignore', timeout: TMUX_CLEANUP_TIMEOUT_MS, env: tmuxEnv() });
   cleanupTmuxProbeSocket(sockName);
   return { ok: true, version };
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11365,12 +11365,20 @@ async function spawnCli(
     let available = true;
     let reason = '';
     let hasExistingSession = false;
+    let existingSessionUnknown = false;
     if (effectiveBackend === 'tmux') {
-      hasExistingSession = TmuxBackend.hasSession(TmuxBackend.sessionName(cfg.sessionId));
-      if (!hasExistingSession) {
+      // Tri-state on purpose: under heavy host load even `has-session` (~20ms
+      // healthy) can time out, and collapsing that 'unknown' into "no session"
+      // used to gate sessions whose tmux panes were alive the whole time.
+      const probeState = TmuxBackend.probeSessionWithRetry(TmuxBackend.sessionName(cfg.sessionId));
+      hasExistingSession = probeState === 'exists';
+      existingSessionUnknown = probeState === 'unknown';
+      if (probeState === 'missing') {
         const probe = probeTmuxFunctionalWithRetry();
         available = probe.ok;
         if (!probe.ok) reason = probe.reason;
+      } else if (existingSessionUnknown) {
+        log('tmux has-session probe returned no answer (host load); spawning to let reattach decide instead of gating');
       }
     } else if (effectiveBackend === 'zellij') {
       // Like tmux, zellij's probe is a disposable background session, so a
@@ -11413,7 +11421,7 @@ async function spawnCli(
       available = HerdrBackend.isAvailable();
       reason = 'herdr 功能性探针失败';
     }
-    const decision = decideBackendGate({ requested: effectiveBackend, available, hasExistingSession });
+    const decision = decideBackendGate({ requested: effectiveBackend, available, hasExistingSession, existingSessionUnknown });
     if (decision.action === 'gate') {
       const detail = reason || decision.reason;
       log(`${effectiveBackend} backend unavailable and silent PTY fallback is disabled (set BACKEND_TYPE=pty to opt in): ${detail}`);

--- a/test/backend-gate.test.ts
+++ b/test/backend-gate.test.ts
@@ -33,6 +33,39 @@ describe('decideBackendGate (PTY 退役 hard gate)', () => {
     ).toEqual({ action: 'spawn' });
   });
 
+  /**
+   * Regression: 2026-08-12. Under host load ~70 the cheap `has-session` probe
+   * timed out (signal=SIGTERM, no exit status). That 'unknown' was collapsed
+   * into hasExistingSession:false, the disposable functional probe then also
+   * timed out, and five sessions whose tmux panes were alive the whole time
+   * got "本机 tmux 不可用，无法启动会话" cards telling the user to
+   * `brew install tmux` — which was already installed and healthy.
+   */
+  it('does NOT gate when the existence check itself got no answer (timeout, not absence)', () => {
+    expect(
+      decideBackendGate({
+        requested: 'tmux',
+        available: false,
+        hasExistingSession: false,
+        existingSessionUnknown: true,
+      }),
+    ).toEqual({ action: 'spawn' });
+  });
+
+  it('still gates when the session is PROVABLY absent and the backend is unavailable', () => {
+    // The guard must keep its teeth: an authoritative "no such session" plus a
+    // failed functional probe is the real "tmux is broken" case the gate exists
+    // for, and must not be softened by the unknown-state exemption above.
+    expect(
+      decideBackendGate({
+        requested: 'tmux',
+        available: false,
+        hasExistingSession: false,
+        existingSessionUnknown: false,
+      }).action,
+    ).toBe('gate');
+  });
+
   it('gates herdr / zellij / zmx when unavailable instead of degrading to PTY', () => {
     expect(decideBackendGate({ requested: 'herdr', available: false, hasExistingSession: false }).action).toBe('gate');
     expect(decideBackendGate({ requested: 'zellij', available: false, hasExistingSession: false }).action).toBe('gate');

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -388,6 +388,51 @@ describe('normaliseCaptureLineEndings', () => {
 });
 
 describe('TmuxPipeBackend managed session', () => {
+  /**
+   * Regression: 2026-08-12. When the existence probe can't get an answer
+   * (has-session timed out under host load) the selector picks the create
+   * branch. If the session actually exists, tmux refuses with
+   * "duplicate session" — verified against real tmux as exit 1 on stderr,
+   * with the live session left intact. That must degrade to reattach rather
+   * than throwing away a working conversation.
+   */
+  it('absorbs "duplicate session" and still subscribes to the existing pane', () => {
+    mockedExecFileSync.mockImplementation(((_bin: string, args: string[]) => {
+      if (args.includes('new-session')) {
+        throw Object.assign(new Error('Command failed'), {
+          status: 1,
+          stderr: Buffer.from('duplicate session: bmx-owned\n'),
+        });
+      }
+      return Buffer.from('') as any;
+    }) as any);
+
+    const be = new TmuxPipeBackend('bmx-owned', { createSession: true, ownsSession: true });
+    expect(() => be.spawn('/bin/echo', ['hello'], spawnOpts())).not.toThrow();
+
+    // The whole point: the pane stream is still wired up after the failed create.
+    const pipeCalls = mockedExecSync.mock.calls
+      .map(c => String(c[0]))
+      .filter(c => c.includes('pipe-pane'));
+    expect(pipeCalls.length).toBe(1);
+    expect(pipeCalls[0]).toContain("'bmx-owned'");
+  });
+
+  it('still propagates a NON-duplicate new-session failure (guard keeps its teeth)', () => {
+    mockedExecFileSync.mockImplementation(((_bin: string, args: string[]) => {
+      if (args.includes('new-session')) {
+        throw Object.assign(new Error('Command failed'), {
+          status: 1,
+          stderr: Buffer.from('no space left on device\n'),
+        });
+      }
+      return Buffer.from('') as any;
+    }) as any);
+
+    const be = new TmuxPipeBackend('bmx-owned', { createSession: true, ownsSession: true });
+    expect(() => be.spawn('/bin/echo', ['hello'], spawnOpts())).toThrow();
+  });
+
   it('creates detached session and applies botmux tmux options', () => {
     const be = new TmuxPipeBackend('bmx-owned', { createSession: true, ownsSession: true });
     be.spawn('/bin/echo', ['hello'], spawnOpts());

--- a/test/tmux-probe.test.ts
+++ b/test/tmux-probe.test.ts
@@ -95,3 +95,47 @@ describe('TmuxBackend.killSession', () => {
     );
   });
 });
+
+/**
+ * Regression: 2026-08-12. `has-session` is cheap (~20ms) but still needs a
+ * fork+exec, so at load ~70 it was killed by its own timeout before tmux ran.
+ * One such timeout was reported as a verdict, and the caller treated a live
+ * session as gone — gating five healthy sessions with "本机 tmux 不可用".
+ */
+describe('TmuxBackend.probeSessionWithRetry', () => {
+  it('retries a timeout and returns "exists" when a later attempt gets through', () => {
+    let calls = 0;
+    mockedExecFileSync.mockImplementation((() => {
+      calls += 1;
+      if (calls === 1) throw err({ signal: 'SIGTERM', status: null, killed: true });
+      return '';
+    }) as any);
+
+    expect(TmuxBackend.probeSessionWithRetry(NAME, { baseDelayMs: 0 })).toBe('exists');
+    expect(calls).toBe(2);
+  });
+
+  it('does NOT retry an authoritative answer — "missing" costs exactly one call', () => {
+    // Retrying a clean exit 1 would add latency to the common cold-start path
+    // and could mask a genuine absence, so authoritative answers return at once.
+    let calls = 0;
+    mockedExecFileSync.mockImplementation((() => {
+      calls += 1;
+      throw err({ status: 1, signal: null });
+    }) as any);
+
+    expect(TmuxBackend.probeSessionWithRetry(NAME, { baseDelayMs: 0 })).toBe('missing');
+    expect(calls).toBe(1);
+  });
+
+  it('still reports "unknown" when every attempt times out (no false verdict)', () => {
+    let calls = 0;
+    mockedExecFileSync.mockImplementation((() => {
+      calls += 1;
+      throw err({ signal: 'SIGTERM', status: null, killed: true });
+    }) as any);
+
+    expect(TmuxBackend.probeSessionWithRetry(NAME, { attempts: 3, baseDelayMs: 0 })).toBe('unknown');
+    expect(calls).toBe(3);
+  });
+});

--- a/test/tmux-reattach-backend.test.ts
+++ b/test/tmux-reattach-backend.test.ts
@@ -8,6 +8,7 @@ vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
   TmuxBackend: class MockTmuxBackend {
     static sessionName = vi.fn((id: string) => `bmx-${id.slice(0, 8)}`);
     static hasSession = vi.fn();
+    static probeSessionWithRetry = vi.fn();
     constructor(public sessionName: string) {}
   },
 }));
@@ -63,6 +64,7 @@ describe('selectSessionBackend', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(TmuxBackend.hasSession).mockReset();
+    vi.mocked(TmuxBackend.probeSessionWithRetry).mockReset();
     vi.mocked(TmuxBackend.sessionName).mockClear();
     vi.mocked(HerdrBackend.hasSession).mockReturnValue(false);
     vi.mocked(HerdrBackend.probeSession).mockReturnValue('missing');
@@ -72,7 +74,7 @@ describe('selectSessionBackend', () => {
   });
 
   it('uses owned pipe backend when reattaching to an existing tmux session', () => {
-    vi.mocked(TmuxBackend.hasSession).mockReturnValue(true);
+    vi.mocked(TmuxBackend.probeSessionWithRetry).mockReturnValue('exists');
 
     const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', backendType: 'tmux' });
 
@@ -88,7 +90,7 @@ describe('selectSessionBackend', () => {
   });
 
   it('uses managed pipe backend for a new tmux session', () => {
-    vi.mocked(TmuxBackend.hasSession).mockReturnValue(false);
+    vi.mocked(TmuxBackend.probeSessionWithRetry).mockReturnValue('missing');
 
     const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', backendType: 'tmux' });
 
@@ -96,6 +98,21 @@ describe('selectSessionBackend', () => {
     expect(selected.isPipeMode).toBe(true);
     expect(selected.backend.constructor.name).toBe('MockTmuxPipeBackend');
     expect((selected.backend as any).paneTarget).toBe('bmx-9cfa0024');
+    expect((selected.backend as any).opts).toEqual({ createSession: true, ownsSession: true });
+  });
+
+  /**
+   * Regression: 2026-08-12. An indeterminate probe (has-session timed out under
+   * host load) must take the create branch, because createDetachedSession
+   * absorbs a "duplicate session" error as a reattach. Choosing reattach here
+   * would be unrecoverable if the session were genuinely gone: pipe-pane would
+   * have no pane to subscribe to.
+   */
+  it('takes the create branch when existence is indeterminate (unknown, not missing)', () => {
+    vi.mocked(TmuxBackend.probeSessionWithRetry).mockReturnValue('unknown');
+
+    const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', backendType: 'tmux' });
+
     expect((selected.backend as any).opts).toEqual({ createSession: true, ownsSession: true });
   });
 

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -738,8 +738,14 @@ describe('worker pipe initial screen ordering', () => {
     expect(guardStart).toBeGreaterThan(-1);
     expect(guardEnd).toBeGreaterThan(guardStart);
     // A live tmux session is checked before probing so it can reattach (PR#249).
-    expect(guard).toContain('TmuxBackend.hasSession(TmuxBackend.sessionName(cfg.sessionId))');
-    expect(guard.indexOf('TmuxBackend.hasSession')).toBeLessThan(guard.indexOf('probeTmuxFunctional'));
+    // Uses the retrying tri-state probe: a load-induced `has-session` timeout
+    // must not be read as "no session" and gate a live pane (2026-08-12).
+    expect(guard).toContain('TmuxBackend.probeSessionWithRetry(TmuxBackend.sessionName(cfg.sessionId))');
+    expect(guard.indexOf('TmuxBackend.probeSessionWithRetry')).toBeLessThan(guard.indexOf('probeTmuxFunctional'));
+    // The functional probe runs ONLY on an authoritative 'missing' — an
+    // indeterminate answer must not fall through into the gate.
+    expect(guard).toContain("if (probeState === 'missing')");
+    expect(guard).toContain('existingSessionUnknown');
     // The decision is made by the pure gate helper, and a gate posts an
     // actionable error IPC + throws — it must NOT silently downgrade to pty.
     // The daemon renders WorkerToDaemon.error to Lark, avoiding the old


### PR DESCRIPTION
## 问题

用户在飞书连续收到十余条 `⚠️ 本机 tmux 不可用，无法启动会话`，卡片建议 `brew install tmux` —— 但 tmux 3.7b 装着且健康（`tmux -V` 9ms 返回，当时 11 个 `bmx-*` session 正在跑）。这条提示把用户引向了错误的方向。

## 根因：把「没问到答案」当成了「东西不存在」

`TmuxBackend.probeSession` 是三态的（`exists` / `missing` / `unknown`），注释也明确写了 unknown 的意义。但 `hasSession` 把 `unknown` 塌成 `false`，而 worker 的 backend gate 用的正是 `hasSession`。

主机负载高时（法证窗口 15 分钟均载 **71.56**），连 fork+exec 都排不上队：

- `has-session` 超时（healthy 时约 20ms）→ `unknown` → 被当成「没有会话」
- 兜底的功能探针 `new-session` 同样超时 → `available: false`
- → 判定 tmux 不可用并硬 gate

日志里全部是 `探测超时（3000ms，signal=SIGTERM）`，**从来没有一条 ENOENT**（只有 ENOENT 才证明真的没装）。

被 gate 的 5 个 session（`69e91edd` / `6a4a25c7` / `ea3bb807` / `0e08785f` / `f7dab4c3`）当时 tmux pane 全部活着；其中 `f7dab4c3` 的 session 建于 8/10，比 8/12 那次 gate 早两天。

实测延迟（本机，load ~4，远低于故障时的 71）：

| 命令 | 耗时 | 原预算 |
|---|---|---|
| `tmux -V` | 0.009s | 3000ms |
| `has-session` | 0.02s | 3000ms |
| `new-session -d` | **0.93–4.45s** | 5000ms |

`new-session` 已经在正常负载下逼近甚至超过原预算。

## 改动

1. **`probeSessionWithRetry`**：只对 `unknown` 退避重试；`exists` / `missing` 是 tmux 的权威回答，立即返回，不给冷启动路径加延迟。
2. **gate 增加 `existingSessionUnknown`**：存在性判不出来时放行而不是 gate。可逆性不对称 —— 错误的 gate 会把一个活着的会话直接判死，而多余的一次 spawn 尝试是可恢复的。
3. **`selectSessionBackend` 只在权威 `exists` 时 reattach**；残留的 `unknown` 落到 create 分支，并让 `createDetachedSession` 把 `duplicate session` 吸收为 reattach。

   反向下注不安全：会话真的没了时，reattach 会让 `pipe-pane` 找不到 pane 且无从恢复。`duplicate session` 的行为是实测确认的 —— exit 1、stderr 带该字样、原 session 完好无损、同名 session 仍只有 1 个。

4. **探测超时按实测放宽**并抽成命名常量：版本探测 10s、功能探测 15s、清理 5s。超时仍然存在，用于兜住真正卡死的 tmux（受限 `/tmp`、损坏安装）—— 那才是它当初被加进来的场景。

## 验证

- tmux 相关 **147 个测试**全绿（`backend-gate` / `tmux-probe` / `tmux-pipe-backend` / `tmux-reattach-backend` / `worker-pipe-initial-screen-order` / `startup-tmux-gate`）
- **变异测试**证明三个守卫都有牙，逐条注入后对应用例立即 FAIL：
  - 删掉 gate 的 unknown 豁免 → `does NOT gate when the existence check itself got no answer` FAIL
  - 把 retry 改成直通 → `retries a timeout…` + `still reports "unknown"…` FAIL
  - 把 duplicate 判断改成吞掉所有错误 → `still propagates a NON-duplicate new-session failure` FAIL
- `duplicate session` 的 stderr 捕获与正则匹配是对真 tmux 实测的，不是推断
- 已在本机部署验证：daemon 重启后 **8 个活跃 session 一个没丢**（重启前后清单逐字节一致），无新 gate 报错

## 说明

- 未复活 `serverState()`：cherry-pick 时发现 upstream 已有意移除它（`session-manager.ts` 称其为 "an earlier version"），解冲突时保留了 upstream 的删除。
- 解冲突时保留了 upstream 的 `shellWrapperScript(resolveBotmuxWrapperBinDir(...))` 与 ZMX 相关文案／用例，只叠加本次改动。
- 本 PR 只修「高负载时不再误判」，不解决负载本身。
