### PR TITLE
fix(dashboard): token 500 透传具体原因+修复建议，不再只给不透明 code

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -17,7 +17,7 @@ import { listenWithProbe } from './utils/listen-with-probe.js';
 import {
   parseCookie, buildSetCookie, verifyHmac, cliAuthBind, decideDashboardAuth,
   loadPersistedToken, loadOrCreatePersistedToken, rotatePersistedToken,
-  loadDashboardSecret, loadOrCreateDashboardSecret,
+  loadDashboardSecret, loadOrCreateDashboardSecret, describeDashboardTokenError,
 } from './dashboard/auth.js';
 import { DaemonRegistry, botsRosterSignature } from './dashboard/registry.js';
 import { Aggregator, subscribeDaemon } from './dashboard/aggregator.js';
@@ -2866,7 +2866,7 @@ const server = createServer(async (req, res) => {
         return jsonRes(res, 200, dashboardUrlsFor(token));
       } catch (e) {
         logger.warn(`[dashboard] Failed to persist token to ${TOKEN_PATH}: ${(e as Error).message}`);
-        return jsonRes(res, 500, { error: 'token_persist_failed' });
+        return jsonRes(res, 500, describeDashboardTokenError('token_persist_failed', e, TOKEN_PATH));
       }
     }
 
@@ -2880,7 +2880,7 @@ const server = createServer(async (req, res) => {
         return jsonRes(res, 200, dashboardUrlsFor(token));
       } catch (e) {
         logger.warn(`[dashboard] Failed to ensure token at ${TOKEN_PATH}: ${(e as Error).message}`);
-        return jsonRes(res, 500, { error: 'token_persist_failed' });
+        return jsonRes(res, 500, describeDashboardTokenError('token_persist_failed', e, TOKEN_PATH));
       }
     }
 
@@ -2894,7 +2894,7 @@ const server = createServer(async (req, res) => {
         token = loadPersistedToken(TOKEN_PATH);
       } catch (e) {
         logger.warn(`[dashboard] Failed to read token from ${TOKEN_PATH}: ${(e as Error).message}`);
-        return jsonRes(res, 500, { error: 'token_unavailable' });
+        return jsonRes(res, 500, describeDashboardTokenError('token_unavailable', e, TOKEN_PATH));
       }
       if (!token) return jsonRes(res, 404, { error: 'no_active_token' });
       return jsonRes(res, 200, dashboardUrlsFor(token));

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -6,6 +6,7 @@ import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { dirname } from 'node:path';
 import {
   readSecureHostFileSync,
+  UnsafeHostAuthorityFileError,
   withSecureHostParentSync,
   writeSecureHostFileSync,
 } from '../platform/secure-host-file.js';
@@ -208,6 +209,46 @@ export function rotatePersistedToken(tokenPath: string): string {
       return token;
     }),
   );
+}
+
+/**
+ * Diagnostic body for a dashboard token 500. The `/__cli/*` HTTP layer used to
+ * return a bare `{ error: 'token_persist_failed' | 'token_unavailable' }`, which
+ * the CLI printed verbatim — so a user whose `~/.botmux` (or `.dashboard-token`)
+ * has loose perms only saw an opaque code and had to be diagnosed remotely. The
+ * real, actionable cause is already on the thrown {@link
+ * UnsafeHostAuthorityFileError} (`message` is a precise reason like
+ * "宿主凭证目录可被组内或其它用户写入" / "宿主凭证文件权限必须严格为 0600" /
+ * "宿主凭证拒绝符号链接"). This surfaces that reason plus a one-line remediation
+ * hint WITHOUT changing any validation — every fail-closed check still fails
+ * closed; we only make the failure legible.
+ *
+ * `error` keeps the stable machine code (unchanged for programmatic callers);
+ * `reason`/`hint` are additive human-facing fields.
+ */
+export function describeDashboardTokenError(
+  code: 'token_persist_failed' | 'token_unavailable',
+  err: unknown,
+  tokenPath: string,
+): { error: string; reason?: string; hint?: string } {
+  if (!(err instanceof UnsafeHostAuthorityFileError)) return { error: code };
+  const reason = err.message;
+  // Map the credential-shape reason to a concrete, copy-pasteable fix. The dir
+  // and file remediations are intentionally NOT auto-applied: a group/other-
+  // writable credential dir may already be compromised, so tightening it is the
+  // user's explicit decision, not a silent self-heal.
+  const dir = tokenPath.replace(/\/[^/]*$/, '') || '~/.botmux';
+  let hint: string | undefined;
+  if (reason.includes('组内或其它用户写入') || reason.includes('不属于当前用户')) {
+    hint = `凭证目录权限过松或属主不对。请确认 ${dir} 属当前用户并执行 chmod 700 ${dir} 后重试。`;
+  } else if (reason.includes('权限必须严格为 0600')) {
+    hint = `凭证文件权限过松。请执行 chmod 600 ${tokenPath} 后重试。`;
+  } else if (reason.includes('拒绝符号链接') || reason.includes('必须是普通文件')) {
+    hint = `凭证文件是软链或非普通文件。请 rm -f ${tokenPath} 让其重新生成后重试。`;
+  } else if (reason.includes('祖先目录') || reason.includes('句柄')) {
+    hint = `凭证目录的某级祖先不安全或运行期被改动。请确认 ${dir} 及其上级目录属可信用户后重试。`;
+  }
+  return { error: code, reason, ...(hint ? { hint } : {}) };
 }
 
 /** Extract `botmux_dashboard_token` value from a Cookie header. */

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -212,6 +212,17 @@ export function rotatePersistedToken(tokenPath: string): string {
 }
 
 /**
+ * POSIX-single-quote a path for safe copy-paste into a shell, but only when it
+ * contains characters a shell treats specially — a clean path stays unquoted so
+ * the common-case hint reads naturally. Only ever used to build a POSIX command
+ * (never on win32, where we emit prose, not a command).
+ */
+function shellQuoteIfNeeded(p: string): string {
+  if (/^[A-Za-z0-9_./-]+$/.test(p)) return p;
+  return `'${p.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * Diagnostic body for a dashboard token 500. The `/__cli/*` HTTP layer used to
  * return a bare `{ error: 'token_persist_failed' | 'token_unavailable' }`, which
  * the CLI printed verbatim — so a user whose `~/.botmux` (or `.dashboard-token`)
@@ -233,19 +244,52 @@ export function describeDashboardTokenError(
 ): { error: string; reason?: string; hint?: string } {
   if (!(err instanceof UnsafeHostAuthorityFileError)) return { error: code };
   const reason = err.message;
-  // Map the credential-shape reason to a concrete, copy-pasteable fix. The dir
-  // and file remediations are intentionally NOT auto-applied: a group/other-
-  // writable credential dir may already be compromised, so tightening it is the
-  // user's explicit decision, not a silent self-heal.
-  const dir = tokenPath.replace(/\/[^/]*$/, '') || '~/.botmux';
+  // Map the credential-shape reason to a concrete fix. Remediations are
+  // intentionally NOT auto-applied: a group/other-writable (or wrongly-owned)
+  // credential dir may already be compromised, so tightening it is the user's
+  // explicit decision, not a silent self-heal — we only make the failure
+  // legible. Guard rails for the hint (the reason itself is always surfaced):
+  //   - Owner errors carry the failing node in their label ("宿主凭证目录" vs
+  //     "宿主凭证文件"); branch on it so we never tell someone to chmod the dir
+  //     when the *file* is the wrong owner (chmod can't fix ownership anyway).
+  //   - Never hand a single destructive command when the node kind is unknown:
+  //     a directory leaf makes a blind `rm -f` fail with "Is a directory", so
+  //     the generic non-regular-file case degrades to an inspection step.
+  //   - On non-POSIX hosts a chmod/rm one-liner is unusable, so degrade to prose
+  //     and quote paths (spaces / shell metacharacters) on POSIX.
+  const dir = dirname(tokenPath);
+  const posix = process.platform !== 'win32';
+  const qDir = shellQuoteIfNeeded(dir);
+  const qFile = shellQuoteIfNeeded(tokenPath);
+  const ownerErr = reason.includes('不属于当前用户');
   let hint: string | undefined;
-  if (reason.includes('组内或其它用户写入') || reason.includes('不属于当前用户')) {
-    hint = `凭证目录权限过松或属主不对。请确认 ${dir} 属当前用户并执行 chmod 700 ${dir} 后重试。`;
+  if (reason.includes('组内或其它用户写入') || (ownerErr && reason.includes('宿主凭证目录'))) {
+    hint = posix
+      ? `凭证目录权限过松或属主不对。请确认 ${dir} 归当前用户所有,并执行 chmod 700 ${qDir} 后重试。`
+      : `凭证目录权限过松或属主不对。请确认 ${dir} 归当前用户所有、且未对其他用户开放写权限后重试。`;
+  } else if (ownerErr && reason.includes('宿主凭证文件')) {
+    // Wrong-owner file: chmod can't change ownership; removing it lets ensure/
+    // rotate regenerate it as the current user (the dir is 0700-owned, so the
+    // unlink is permitted).
+    hint = posix
+      ? `凭证文件不属于当前用户。请执行 rm -f ${qFile} 让其以当前用户身份重新生成后重试。`
+      : `凭证文件不属于当前用户。请删除 ${tokenPath} 让其以当前用户身份重新生成后重试。`;
   } else if (reason.includes('权限必须严格为 0600')) {
-    hint = `凭证文件权限过松。请执行 chmod 600 ${tokenPath} 后重试。`;
-  } else if (reason.includes('拒绝符号链接') || reason.includes('必须是普通文件')) {
-    hint = `凭证文件是软链或非普通文件。请 rm -f ${tokenPath} 让其重新生成后重试。`;
-  } else if (reason.includes('祖先目录') || reason.includes('句柄')) {
+    hint = posix
+      ? `凭证文件权限过松。请执行 chmod 600 ${qFile} 后重试。`
+      : `凭证文件权限过松。请将 ${tokenPath} 收紧为仅当前用户可读写后重试。`;
+  } else if (reason.includes('拒绝符号链接')) {
+    // ELOOP — definitely a symlink; `rm -f` removes a symlink safely.
+    hint = posix
+      ? `凭证文件是符号链接。请执行 rm -f ${qFile} 让其重新生成后重试。`
+      : `凭证文件是符号链接。请删除 ${tokenPath} 让其重新生成后重试。`;
+  } else if (reason.includes('必须是普通文件')) {
+    // Non-regular file of unknown kind (possibly a directory): give an
+    // inspection step, not a blind `rm -f` that could fail or over-delete.
+    hint = posix
+      ? `凭证路径不是普通文件(可能是目录/管道/设备等)。请先 ls -ld ${qFile} 查看,再手动移除该节点后重试。`
+      : `凭证路径不是普通文件(可能是目录等)。请检查并手动移除 ${tokenPath} 后重试。`;
+  } else if (reason.includes('祖先') || reason.includes('句柄')) {
     hint = `凭证目录的某级祖先不安全或运行期被改动。请确认 ${dir} 及其上级目录属可信用户后重试。`;
   }
   return { error: code, reason, ...(hint ? { hint } : {}) };

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -69,6 +69,17 @@ describe('generateToken', () => {
 describe('describeDashboardTokenError', () => {
   const TP = '/home/u/.botmux/.dashboard-token';
 
+  // The function branches on process.platform (POSIX command vs prose). Default
+  // the whole block to a POSIX view so the common-case assertions are stable on
+  // any host; the win32 cases override it explicitly and restore after.
+  let platformSpy: ReturnType<typeof vi.spyOn> | undefined;
+  const asPlatform = (p: NodeJS.Platform) => {
+    platformSpy?.mockRestore();
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue(p);
+  };
+  beforeEach(() => asPlatform('linux'));
+  afterEach(() => { platformSpy?.mockRestore(); platformSpy = undefined; });
+
   it('keeps the bare stable code for non-credential errors', () => {
     expect(describeDashboardTokenError('token_unavailable', new Error('boom'), TP))
       .toEqual({ error: 'token_unavailable' });
@@ -77,7 +88,7 @@ describe('describeDashboardTokenError', () => {
       .toEqual({ error: 'token_persist_failed' });
   });
 
-  it('surfaces a group/other-writable dir reason with a chmod 700 hint', () => {
+  it('surfaces a group/other-writable dir reason with a chmod 700 (dir) hint', () => {
     const out = describeDashboardTokenError(
       'token_unavailable',
       new UnsafeHostAuthorityFileError('宿主凭证目录可被组内或其它用户写入'),
@@ -86,6 +97,27 @@ describe('describeDashboardTokenError', () => {
     expect(out.error).toBe('token_unavailable'); // stable code preserved
     expect(out.reason).toBe('宿主凭证目录可被组内或其它用户写入');
     expect(out.hint).toContain('chmod 700 /home/u/.botmux');
+  });
+
+  it('a wrong-owner DIRECTORY gets the chmod 700 dir hint', () => {
+    const out = describeDashboardTokenError(
+      'token_unavailable',
+      new UnsafeHostAuthorityFileError('宿主凭证目录 不属于当前用户'),
+      TP,
+    );
+    expect(out.hint).toContain('chmod 700 /home/u/.botmux');
+  });
+
+  it('a wrong-owner FILE does NOT get a chmod hint (chmod cannot fix ownership) but an rm-to-regenerate hint', () => {
+    const out = describeDashboardTokenError(
+      'token_persist_failed',
+      // secure-host-file throws `${label} 不属于当前用户` with label 宿主凭证文件.
+      new UnsafeHostAuthorityFileError('宿主凭证文件 不属于当前用户'),
+      TP,
+    );
+    expect(out.reason).toBe('宿主凭证文件 不属于当前用户');
+    expect(out.hint).not.toContain('chmod'); // the pre-fix bug: told user to chmod the dir
+    expect(out.hint).toContain(`rm -f ${TP}`);
   });
 
   it('surfaces a wrong-mode token reason with a chmod 600 hint', () => {
@@ -98,13 +130,24 @@ describe('describeDashboardTokenError', () => {
     expect(out.hint).toContain(`chmod 600 ${TP}`);
   });
 
-  it('surfaces a symlink/non-regular token reason with an rm hint', () => {
+  it('a symlink (ELOOP) gets a definite rm -f hint', () => {
     const out = describeDashboardTokenError(
       'token_persist_failed',
       new UnsafeHostAuthorityFileError('宿主凭证拒绝符号链接'),
       TP,
     );
     expect(out.hint).toContain(`rm -f ${TP}`);
+  });
+
+  it('a non-regular file of unknown kind degrades to an inspection step, NOT a blind rm -f (a dir leaf would fail "Is a directory")', () => {
+    const out = describeDashboardTokenError(
+      'token_persist_failed',
+      new UnsafeHostAuthorityFileError('宿主凭证必须是普通文件'),
+      TP,
+    );
+    expect(out.reason).toBe('宿主凭证必须是普通文件');
+    expect(out.hint).not.toContain('rm -f'); // the pre-fix bug: `rm -f` on a dir leaf
+    expect(out.hint).toContain(`ls -ld ${TP}`);
   });
 
   it('surfaces an unsafe-ancestor reason without inventing a chmod on the leaf', () => {
@@ -115,6 +158,46 @@ describe('describeDashboardTokenError', () => {
     );
     expect(out.reason).toBe('宿主凭证目录可被不可信祖先目录替换');
     expect(out.hint).toContain('祖先');
+  });
+
+  it('shell-quotes paths with spaces/metacharacters in the copy-paste command', () => {
+    const spaced = '/home/u/My Botmux/.dashboard-token';
+    const out = describeDashboardTokenError(
+      'token_persist_failed',
+      new UnsafeHostAuthorityFileError('宿主凭证文件权限必须严格为 0600'),
+      spaced,
+    );
+    // Quoted so the command survives a copy-paste; the raw path may still appear
+    // in prose, but the command token itself must be the quoted form.
+    expect(out.hint).toContain(`chmod 600 '${spaced}'`);
+  });
+
+  it('on win32 emits prose, never an unusable chmod/rm one-liner', () => {
+    asPlatform('win32');
+    const chmodCase = describeDashboardTokenError(
+      'token_unavailable',
+      new UnsafeHostAuthorityFileError('宿主凭证目录可被组内或其它用户写入'),
+      'C:\\Users\\u\\.botmux\\.dashboard-token',
+    );
+    expect(chmodCase.hint).toBeTruthy();
+    expect(chmodCase.hint).not.toMatch(/chmod|rm -f/);
+    const rmCase = describeDashboardTokenError(
+      'token_persist_failed',
+      new UnsafeHostAuthorityFileError('宿主凭证拒绝符号链接'),
+      'C:\\Users\\u\\.botmux\\.dashboard-token',
+    );
+    expect(rmCase.hint).toBeTruthy();
+    expect(rmCase.hint).not.toMatch(/chmod|rm -f/);
+  });
+
+  it('an unmapped credential reason still surfaces the reason verbatim with no hint', () => {
+    const out = describeDashboardTokenError(
+      'token_persist_failed',
+      new UnsafeHostAuthorityFileError('宿主凭证文件大小异常'),
+      TP,
+    );
+    expect(out.reason).toBe('宿主凭证文件大小异常');
+    expect(out.hint).toBeUndefined();
   });
 });
 

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -11,8 +11,9 @@ import { join } from 'node:path';
 import {
   verifyHmac, generateToken, parseCookie, decideDashboardAuth,
   loadPersistedToken, loadOrCreatePersistedToken, persistToken, rotatePersistedToken,
-  loadDashboardSecret, loadOrCreateDashboardSecret,
+  loadDashboardSecret, loadOrCreateDashboardSecret, describeDashboardTokenError,
 } from '../src/dashboard/auth.js';
+import { UnsafeHostAuthorityFileError } from '../src/platform/secure-host-file.js';
 
 const SECRET = 'a'.repeat(43); // base64url 32 bytes
 
@@ -62,6 +63,58 @@ describe('generateToken', () => {
   it('returns 43-char base64url (32 bytes)', () => {
     const t = generateToken();
     expect(t).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+});
+
+describe('describeDashboardTokenError', () => {
+  const TP = '/home/u/.botmux/.dashboard-token';
+
+  it('keeps the bare stable code for non-credential errors', () => {
+    expect(describeDashboardTokenError('token_unavailable', new Error('boom'), TP))
+      .toEqual({ error: 'token_unavailable' });
+    // Preserve the machine code so programmatic callers are unaffected.
+    expect(describeDashboardTokenError('token_persist_failed', undefined, TP))
+      .toEqual({ error: 'token_persist_failed' });
+  });
+
+  it('surfaces a group/other-writable dir reason with a chmod 700 hint', () => {
+    const out = describeDashboardTokenError(
+      'token_unavailable',
+      new UnsafeHostAuthorityFileError('宿主凭证目录可被组内或其它用户写入'),
+      TP,
+    );
+    expect(out.error).toBe('token_unavailable'); // stable code preserved
+    expect(out.reason).toBe('宿主凭证目录可被组内或其它用户写入');
+    expect(out.hint).toContain('chmod 700 /home/u/.botmux');
+  });
+
+  it('surfaces a wrong-mode token reason with a chmod 600 hint', () => {
+    const out = describeDashboardTokenError(
+      'token_persist_failed',
+      new UnsafeHostAuthorityFileError('宿主凭证文件权限必须严格为 0600'),
+      TP,
+    );
+    expect(out.reason).toBe('宿主凭证文件权限必须严格为 0600');
+    expect(out.hint).toContain(`chmod 600 ${TP}`);
+  });
+
+  it('surfaces a symlink/non-regular token reason with an rm hint', () => {
+    const out = describeDashboardTokenError(
+      'token_persist_failed',
+      new UnsafeHostAuthorityFileError('宿主凭证拒绝符号链接'),
+      TP,
+    );
+    expect(out.hint).toContain(`rm -f ${TP}`);
+  });
+
+  it('surfaces an unsafe-ancestor reason without inventing a chmod on the leaf', () => {
+    const out = describeDashboardTokenError(
+      'token_persist_failed',
+      new UnsafeHostAuthorityFileError('宿主凭证目录可被不可信祖先目录替换'),
+      TP,
+    );
+    expect(out.reason).toBe('宿主凭证目录可被不可信祖先目录替换');
+    expect(out.hint).toContain('祖先');
   });
 });
 


### PR DESCRIPTION
## 背景

3.13.0 修好了「软链/共享盘/异主祖先 HOME」下 token ensure/rotate 报 500 的问题（放松祖先目录链断言、改走 FD-pinning）。但用户反馈仍有机器报 500——经实测复核，那是**另一类**原因：`~/.botmux` 目录自身或 `.dashboard-token` 文件的权限/形态不安全（这些校验 3.13.0 一条都没动、也不该动）。

问题在于报错**不可诊断**：`/__cli/current` 返回 `500 {"error":"token_unavailable"}`、`/__cli/ensure|rotate` 返回 `500 {"error":"token_persist_failed"}`，CLI 原样打印，用户只看到不透明 code，只能逐台远程诊断。而真实原因其实已经在抛出的 `UnsafeHostAuthorityFileError.message` 里（如「宿主凭证目录可被组内或其它用户写入」「宿主凭证文件权限必须严格为 0600」「宿主凭证拒绝符号链接」），只是没透传到 HTTP body。

## 改动（纯可诊断性，不动任何 fail-closed 校验）

- `dashboard/auth.ts` 新增纯函数 `describeDashboardTokenError(code, err, tokenPath)`：仅当 `err instanceof UnsafeHostAuthorityFileError` 时，在响应体附上 `reason`（底层真实原因）+ `hint`（一句可执行的修复/排查建议，按错误里的**节点类型**和**运行平台**分档）：
  - 目录 group/other 可写 / **目录**属主不对 → `chmod 700 <目录>`
  - **文件**属主不对 → `rm -f <文件>` 让其以当前用户身份重建（chmod 改不了属主；父目录已被校验为 0700 且属当前用户，unlink 由父目录写权限决定，故可成功）
  - 文件权限非 0600 → `chmod 600 <文件>`
  - 符号链接（ELOOP，确定是软链）→ `rm -f <文件>` 让其重建
  - 非普通文件（可能是目录/管道/设备等未知形态）→ 降级为 `ls -ld <文件>` 排查说明，**不**盲发 `rm -f`（leaf 是目录时 `rm -f` 会报 `Is a directory`）
  - 祖先不安全 / 运行期句柄变动 → 提示检查上级目录
  - 跨平台：非 POSIX 平台（Windows）只给中文排查说明，不输出不可用的 chmod/rm；含空格或 shell 元字符的路径在 POSIX 命令里做单引号引用，保证「可复制命令」可靠。
  - 未映射到具体建议的原因（大小异常 / 读取期 TOCTOU / 不是普通目录等）退化为「仅 `reason` 无 `hint`」，绝不误命中错误 hint。
  - `error` 机器码保持不变（程序化调用者不受影响），`reason`/`hint` 为附加字段。
- `dashboard.ts` 三处 500 改用它。

### 关键取舍：权限问题**故意不自动 chmod**

有人建议「检测到 `~/.botmux` 过松就自动 chmod 回 0700 自愈」。**本 PR 明确不这么做**：
- 这是真安全不变量，不是过严校验——目录能被 group/other 写，意味着别人可换掉 `.dashboard-token` → 劫持 dashboard（dashboard 能操作所有会话）。
- 该校验被 7 个凭证使用方共用（device 注册、platform binding、隔离标记等），悄悄放松/自愈会削弱整台机器的凭证边界。
- 更关键：目录已 group-writable 时，里面的东西**可能已被动过**；自动 chmod 是掩盖入侵痕迹而非修复。继续 fail closed、把原因讲清楚，让用户显式决定，才是对的。

## 影响面

- 仅改 dashboard token 三个 500 分支的**响应体内容**；不改状态码、不改任何校验、不改成功路径。`secure-host-file.ts` 的校验一条未动。
- `error` 稳定码保留，`/__cli/*` 的程序化消费者（CLI 的 `callDashboard`/`classifyDashboard*`）行为不变——它们只依据 `reason`/`error`，多出的字段只是让 CLI 打印的 `detail` 更可读。
- 其它平台/CLI/会话类型不经过此路径，不受影响。

## 测试验证

- `pnpm exec tsc --noEmit` 干净；`pnpm build` 通过。
- `dashboard-auth.test.ts` 全文件 75 例通过，其中 `describeDashboardTokenError` 覆盖 11 例：非凭证错误保留裸 code；group/other 可写 → chmod 700；**目录**属主错 → chmod 700；**文件**属主错 → `rm -f` 重建且不含 chmod；0600 → chmod 600；符号链接 → `rm -f`；非普通文件 → `ls -ld` 排查（不含 `rm -f`）；祖先不安全 → 查上级目录；含空格/元字符路径 → 单引号引用；Windows → 只给说明不给命令；未映射原因 → 仅透传 `reason`。
- 枚举 `secure-host-file.ts` 全部 13 条抛出 message，逐条跑 `describeDashboardTokenError` 核对分档，0 误投。
- 实测 before/after（模拟真实故障路径）：
  - `~/.botmux` 0770：`500 {"error":"token_unavailable"}` → `500 {"error":"token_unavailable","reason":"宿主凭证目录可被组内或其它用户写入","hint":"…chmod 700 …"}`
  - `.dashboard-token` 0644：同样从裸 code → 带 `reason`+`chmod 600` hint。
  - 异主 leaf（真实非 root 用户、父目录 0700 属当前用户）：生成的 `rm -f` 成功删除 leaf，token 随后以当前用户 0600 重建。

## 已知非阻断 follow-up（非本 PR 回归）

- 异主且 0600 不可读的 leaf 在普通用户下会在进入本 helper 前就得到原生 `EACCES`（`fstat` 阶段即失败），因此仍走裸稳定码而拿不到 `reason`/`hint`。这是 `secure-host-file.ts` 既有的错误归类盲点，非本提交引入，留作后续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
