### PR TITLE
fix(codex-rpc): 未应答的存活探测不能证明面板已终止

### DIFF
--- a/src/codex-rpc-lifecycle.ts
+++ b/src/codex-rpc-lifecycle.ts
@@ -326,14 +326,26 @@ export async function orchestrateCodexRpcInit(
 
 export interface PersistentPaneKillEffects {
   kill: (sessionName: string) => void;
-  isLive: (sessionName: string) => boolean;
+  /** Tri-state on purpose. A boolean cannot distinguish "the pane is gone" from
+   *  "the liveness probe got no answer", and this function's return value is
+   *  read as PROOF of absence. `hasSession()`-style helpers collapse a probe
+   *  timeout into `false`, which is exactly the wrong direction here. */
+  probeLive: (sessionName: string) => 'live' | 'gone' | 'unknown';
   wait: (ms: number) => Promise<void>;
 }
 
 /** Kill a resolved persistent-session name and verify that exact name is gone.
  *  Keeping the resolved name opaque avoids accidentally applying sessionName()
  *  twice (`bmx-1234` -> `bmx-bmx-`), which would turn every failed kill into a
- *  false success and reattach the stale RPC pane. */
+ *  false success and reattach the stale RPC pane.
+ *
+ *  Returns true ONLY on an authoritative 'gone'. An indeterminate probe is not
+ *  proof: under host load even a cheap `has-session` (~20ms healthy) can be
+ *  killed by its own timeout, and reporting that as a verified kill lets a
+ *  surviving dead-`--remote` pane be reattached to the fresh-port engine — the
+ *  exact P0 freeze this verification layer exists to prevent. When every
+ *  attempt comes back 'unknown' we fail closed: the caller then aborts init
+ *  and tells the user, instead of silently proceeding on an unproven kill. */
 export async function killAndVerifyPersistentPane(
   sessionName: string,
   fx: PersistentPaneKillEffects,
@@ -342,10 +354,12 @@ export async function killAndVerifyPersistentPane(
 ): Promise<boolean> {
   for (let attempt = 0; attempt < attempts; attempt++) {
     try { fx.kill(sessionName); } catch { /* verify below */ }
-    if (!fx.isLive(sessionName)) return true;
+    // Retry on 'unknown' as well as 'live': an unanswered probe is a reason to
+    // look again, never a reason to declare success.
+    if (fx.probeLive(sessionName) === 'gone') return true;
     if (attempt + 1 < attempts) await fx.wait(retryMs);
   }
-  return !fx.isLive(sessionName);
+  return fx.probeLive(sessionName) === 'gone';
 }
 
 function tmuxPanePid(sessionName: string): number | undefined {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -732,11 +732,23 @@ function persistentPaneInfo(backendType: string, sessionId: string): { name: str
   return { name, live };
 }
 
-function persistentPaneLive(backendType: PersistentBackendType, name: string): boolean {
-  if (backendType === 'tmux') return TmuxBackend.hasSession(name);
-  if (backendType === 'zellij') return ZellijBackend.hasSession(name);
-  if (backendType === 'herdr') return HerdrBackend.hasSession(name);
-  return ZmxBackend.hasSession(name);
+/** Tri-state pane liveness, for callers that must not read "no answer" as an
+ *  answer. The `hasSession()` helpers collapse an unanswered probe into
+ *  `false`, which is safe where a wrong guess just means "treat as fresh" but
+ *  NOT where the boolean is consumed as proof that a kill succeeded. Every
+ *  backend already classifies this correctly; only the boolean wrapper threw
+ *  the distinction away. */
+function persistentPaneProbe(
+  backendType: PersistentBackendType,
+  name: string,
+): 'live' | 'gone' | 'unknown' {
+  const probe: SessionProbe = backendType === 'tmux' ? TmuxBackend.probeSession(name)
+    : backendType === 'zellij' ? ZellijBackend.probeSession(name)
+      : backendType === 'herdr' ? HerdrBackend.probeSession(name)
+        : ZmxBackend.probeSession(name);
+  if (probe === 'exists') return 'live';
+  if (probe === 'missing') return 'gone';
+  return 'unknown';
 }
 
 function probeOwnedZmxSession(
@@ -774,7 +786,7 @@ async function killPersistentSessionVerified(
 ): Promise<boolean> {
   return killAndVerifyPersistentPane(name, {
     kill: (resolvedName) => killPersistentSession(backendType, resolvedName, sessionId),
-    isLive: (resolvedName) => persistentPaneLive(backendType, resolvedName),
+    probeLive: (resolvedName) => persistentPaneProbe(backendType, resolvedName),
     wait: delay,
   });
 }

--- a/test/codex-rpc-lifecycle.test.ts
+++ b/test/codex-rpc-lifecycle.test.ts
@@ -394,7 +394,7 @@ describe('killAndVerifyPersistentPane — verifies the resolved name without re-
     const probed: string[] = [];
     const gone = await killAndVerifyPersistentPane('bmx-12345678', {
       kill: (name) => { killed.push(name); },
-      isLive: (name) => { probed.push(name); return true; },
+      probeLive: (name) => { probed.push(name); return 'live'; },
       wait: async () => {},
     }, 2, 0);
     expect(gone).toBe(false);
@@ -407,11 +407,43 @@ describe('killAndVerifyPersistentPane — verifies the resolved name without re-
     let kills = 0;
     const gone = await killAndVerifyPersistentPane('bmx-abcdef12', {
       kill: () => { kills += 1; if (kills === 2) live = false; },
-      isLive: () => live,
+      probeLive: () => (live ? 'live' : 'gone'),
       wait: async () => {},
     }, 4, 0);
     expect(gone).toBe(true);
     expect(kills).toBe(2);
+  });
+
+  /**
+   * Regression: an unanswered liveness probe must never be reported as a
+   * verified kill. `TmuxBackend.hasSession()` (and its zellij/herdr/zmx peers)
+   * return `false` for BOTH "session absent" and "probe timed out", because
+   * they collapse the tri-state `probeSession()` to `=== 'exists'`. Feeding
+   * that boolean into this function turned a load-induced timeout into proof of
+   * absence, letting a surviving dead-`--remote` pane be reattached to the
+   * fresh-port engine — the P0 freeze this layer exists to prevent.
+   */
+  it('does NOT report a verified kill when every probe is indeterminate', async () => {
+    let kills = 0;
+    const gone = await killAndVerifyPersistentPane('bmx-deadbeef', {
+      kill: () => { kills += 1; },
+      probeLive: () => 'unknown',
+      wait: async () => {},
+    }, 3, 0);
+    expect(gone).toBe(false);
+    // 'unknown' is a reason to look again, so the retries are still spent.
+    expect(kills).toBe(3);
+  });
+
+  it('accepts a later authoritative "gone" after earlier indeterminate probes', async () => {
+    const answers: Array<'unknown' | 'gone'> = ['unknown', 'unknown', 'gone'];
+    let i = 0;
+    const gone = await killAndVerifyPersistentPane('bmx-cafe1234', {
+      kill: () => {},
+      probeLive: () => answers[Math.min(i++, answers.length - 1)],
+      wait: async () => {},
+    }, 4, 0);
+    expect(gone).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 问题（P0）

`killAndVerifyPersistentPane` 存在的理由写在它自己的注释里 —— `killPersistentSession` 吞异常且返回 `void`，所以 `try/catch` 永远观察不到一次失败的 kill，因此需要一层**验证**来证明 pane 真的没了。

但它拿到的谓词把这个证据变成了猜测：

```js
if (!fx.isLive(sessionName)) return true;   // true = "CONFIRMED ABSENT"
```

`isLive` 最终是 `TmuxBackend.hasSession()`（zellij/herdr/zmx 同构），而它是：

```js
return TmuxBackend.probeSession(name) === 'exists';
```

`probeSession` 是**三态**的，第三态 `unknown` 的语义就是「**没拿到答案**」（超时被 SIGTERM、ENOENT、EACCES）—— 这一点在 `probeSession` 的 jsdoc 里写得很明确。塌成 boolean 之后 `unknown` 和 `missing` 都变成 `false`，于是**一次探测超时就被读成「已确认杀掉」**。

实跑分类器验证（不是只读代码）：

```
probeSession(timeout) = unknown
isLive                = false
killAndVerify         = true    <-- "CONFIRMED ABSENT"
```

## 后果正是这一层自己警告的那个 P0

`codex-rpc-lifecycle.ts` 在 `gone === true` 时直接继续，于是一个**可能仍然活着**的旧 `--remote` pane 被留在原地，随后被 reattach 到新 app-server 的 fresh port。引用同文件的注释：

> a surviving (dead-`--remote`) pane would then be reattached against the NEW app-server's fresh port, re-triggering the exact P0 freeze

反过来说：**验证层是有的，但它的谓词在超时时给出「成功」**，所以这层保护在最需要它的时候（主机压力大、探测最容易超时）正好失效。

高负载下这不是理论值。同机实测：

| 命令 | load ~4 实测 | 预算 |
|---|---|---|
| `tmux -V` | 0.009s（healthy） | 3000ms |
| `has-session` | 0.02s（healthy） | 3000ms |
| `tmux new-session -d` | **0.93–4.45s** | 5000ms |

而该机 15 分钟均载曾达 **71.56**，那种压力下连 `tmux -V` 都会耗尽 3000ms 预算。

## 改动

- `PersistentPaneKillEffects.isLive: () => boolean` → `probeLive: () => 'live' | 'gone' | 'unknown'`。**四个后端本来就已经正确分类**，只有 boolean 包装层把区别丢掉了 —— 信息一直都在。
- 只有权威的 `'gone'` 才返回 `true`。`'unknown'` 与 `'live'` 一样触发重试（未答复是「再看一次」的理由，不是宣布成功的理由）；全程 `unknown` 则 **fail closed** —— 调用方 abort init 并通知用户，而不是在一个未经证明的 kill 上静默前进。
- worker 侧新增 `persistentPaneProbe()` 透传三态；随之失去调用者的 `persistentPaneLive()` 一并移除。

## 验证

- `codex-rpc-lifecycle` + `worker-structured-lifecycle-status`：**93 个测试全绿**
- 新增 2 个用例：全程 `unknown` 不得报成已杀（且重试次数照常耗尽）、先 `unknown` 后权威 `gone` 应接受
- **变异测试证明守卫有牙**：把 `=== 'gone'` 改回 `!== 'live'`（即精确复现旧语义）后，`does NOT report a verified kill when every probe is indeterminate` 立即 FAIL

## 范围

本 PR 只改「**是否已杀干净**」这一个消费点。同一个 `unknown → false` 塌陷在 zellij 的 backend gate 上还有一处，另提一个 PR —— 那里正确方向**相反**：判存在性应倒向「当它在」（错杀活会话很贵），判是否已消失必须倒向「当它还在」（漏杀触发本 P0）。所以我没有去改 `hasSession` 本身的语义，而是在这两个消费点分别用三态。

与 #833 是不同失效面，可独立 review / 合并。
