### PR TITLE
fix(zellij): do not gate a live session on an indeterminate probe

### DIFF
--- a/src/adapters/backend/session-backend-selector.ts
+++ b/src/adapters/backend/session-backend-selector.ts
@@ -341,7 +341,15 @@ export function selectSessionBackend(opts: {
 
   if (opts.backendType === 'zellij') {
     const sessionName = ZellijBackend.sessionName(opts.sessionId);
-    const reattach = ZellijBackend.hasSession(sessionName);
+    // Prefer the caller's frozen existence decision when supplied: the worker
+    // resolves a tri-state probe once (biasing an indeterminate answer toward
+    // "reattach", since a live pane is more authoritative than a load-timed-out
+    // probe — the same asymmetry decideBackendGate uses) and refreshes it to
+    // "gone" after any teardown, so a post-kill re-selection cold-spawns rather
+    // than reattaching to what it just removed. A bare live `hasSession()`
+    // cannot tell those two call sites apart, so only fall back to it when no
+    // decision was threaded in (default callers / unit tests).
+    const reattach = opts.hasExistingSession ?? ZellijBackend.hasSession(sessionName);
     return {
       backend: new ZellijBackend(sessionName, { ownsSession: true, isReattach: reattach }),
       isTmuxMode: false,

--- a/src/adapters/backend/session-backend-selector.ts
+++ b/src/adapters/backend/session-backend-selector.ts
@@ -350,8 +350,13 @@ export function selectSessionBackend(opts: {
     // cannot tell those two call sites apart, so only fall back to it when no
     // decision was threaded in (default callers / unit tests).
     const reattach = opts.hasExistingSession ?? ZellijBackend.hasSession(sessionName);
+    // A threaded-in decision is authoritative — tell the backend to honour it
+    // verbatim and skip spawn()'s `|| hasSession()` self-heal, which would
+    // otherwise re-probe and could reattach to a pane a teardown gate just
+    // removed. Default callers (no decision) keep the self-heal via 'auto'.
+    const reattachDecision = opts.hasExistingSession === undefined ? 'auto' : 'frozen';
     return {
-      backend: new ZellijBackend(sessionName, { ownsSession: true, isReattach: reattach }),
+      backend: new ZellijBackend(sessionName, { ownsSession: true, isReattach: reattach, reattachDecision }),
       isTmuxMode: false,
       isPipeMode: false,
       isZellijMode: true,

--- a/src/adapters/backend/session-backend-selector.ts
+++ b/src/adapters/backend/session-backend-selector.ts
@@ -153,14 +153,26 @@ export type BackendGateDecision =
  * abandoning it would spawn a duplicate CLI and orphan the real conversation.
  * tmux/zellij capability probes use disposable sessions; ZMX checks its
  * version and full-list control plane; Herdr uses `herdr --version`.
+ *
+ * `existingSessionUnknown` is the third state of that existence check: the
+ * probe itself got no answer (a timeout under host load), which a
+ * `hasSession()`-style boolean reports as "no session". Gating on that turns a
+ * false negative on the CHEAP check into a hard refusal for a session whose
+ * pane is alive. So an indeterminate existence answer spawns rather than gates
+ * — the reverse asymmetry from a kill-verification, where an unanswered probe
+ * must NOT be read as success. Callers that deliberately gate on an
+ * indeterminate result (ZMX ownership / protocol version, where adopting
+ * someone else's session is the worse outcome) simply leave this unset.
  */
 export function decideBackendGate(opts: {
   requested: BackendType;
   available: boolean;
   hasExistingSession: boolean;
+  existingSessionUnknown?: boolean;
 }): BackendGateDecision {
   if (opts.requested === 'pty') return { action: 'spawn' };
   if (opts.hasExistingSession) return { action: 'spawn' };
+  if (opts.existingSessionUnknown) return { action: 'spawn' };
   if (opts.available) return { action: 'spawn' };
   return { action: 'gate', reason: `${opts.requested} 后端在本机不可用` };
 }

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -98,27 +98,51 @@ export class ZellijBackend implements SessionBackend {
   /** Like liveSessions(), but distinguishes "command failed/timed out" ({ok:false})
    *  from "command succeeded, zero live sessions" ({ok:true, sessions:[]}). The
    *  tri-state probe builds on this so a transient `list-sessions` failure isn't
-   *  read as "session gone". */
+   *  read as "session gone".
+   *
+   *  NOTE zellij exits **1** with stderr `No active zellij sessions found.` when
+   *  there are simply no sessions — an authoritative "zero", not a failure. A
+   *  bare catch would report that clean host as {ok:false} → `unknown`, and any
+   *  caller that biases `unknown` toward reattach would then `zellij attach` a
+   *  name that does not exist (exit 1) on every first start. So classify like
+   *  TmuxBackend.probeSession does: a numeric exit status with no signal is an
+   *  ANSWER from zellij; only a signal/timeout or a spawn failure (ENOENT/EACCES
+   *  — neither carries a numeric status) means we never got one.
+   */
   static probeLiveSessions(): { ok: true; sessions: string[] } | { ok: false } {
+    let out: string;
     try {
-      const out = execFileSync('zellij', ['list-sessions', '--no-formatting'], {
+      out = execFileSync('zellij', ['list-sessions', '--no-formatting'], {
         encoding: 'utf-8',
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         timeout: 3000,
         env: zellijEnv(),
       });
-      return {
-        ok: true,
-        sessions: out
-          .split('\n')
-          .map(l => l.trim())
-          .filter(l => l.length > 0 && !/EXITED/i.test(l))
-          .map(l => l.split(/\s+/)[0]!)
-          .filter(Boolean),
-      };
-    } catch {
+    } catch (e: any) {
+      // Answered, but non-zero: "no active sessions" is the documented exit-1
+      // case, so treat a clean numeric status as an authoritative empty list.
+      // Anything else (timeout → signal, ENOENT/EACCES → no status) is unknown.
+      if (e && typeof e.status === 'number' && !e.signal) {
+        const stderr = (e.stderr?.toString?.() ?? '').trim();
+        const stdout = (e.stdout?.toString?.() ?? '');
+        if (/no active zellij sessions/i.test(stderr) || (!stdout.trim() && !stderr)) {
+          return { ok: true, sessions: [] };
+        }
+        // A different answered failure (bad flag, corrupt cache, …) is not proof
+        // of emptiness — do not let it read as "session gone".
+        return { ok: false };
+      }
       return { ok: false };
     }
+    return {
+      ok: true,
+      sessions: out
+        .split('\n')
+        .map(l => l.trim())
+        .filter(l => l.length > 0 && !/EXITED/i.test(l))
+        .map(l => l.split(/\s+/)[0]!)
+        .filter(Boolean),
+    };
   }
 
   static hasSession(name: string): boolean {
@@ -152,6 +176,23 @@ export class ZellijBackend implements SessionBackend {
     // not-yet-reaped session and wrongly flip us back to attach.
     if (!this.frozenReattach) {
       this.reattaching = this.reattaching || ZellijBackend.hasSession(this.sessionName);
+    }
+    if (this.frozenReattach && this.reattaching) {
+      // A frozen `attach` can still be objectively WRONG: the worker biases an
+      // indeterminate existence probe toward reattach (a live pane is likelier
+      // than a gone one under load), and not every path re-probes before we get
+      // here. `attach` on a session that does not exist exits 1 ("No session
+      // with the name … found!"), which reads as a CLI crash and burns a
+      // restart. So downgrade to a fresh spawn ONLY on an authoritative
+      // 'missing' — an indeterminate answer keeps the reattach bias, and a
+      // frozen `false` is never flipped the other way (that direction is the
+      // teardown guarantee this whole flag exists to protect).
+      if (ZellijBackend.probeSession(this.sessionName) === 'missing') {
+        logger.debug(
+          `[zellij:${this.sessionName}] frozen reattach downgraded to fresh spawn: session is provably absent`,
+        );
+        this.reattaching = false;
+      }
     }
     logger.debug(
       `[zellij:${this.sessionName}] spawn ${this.reattaching ? 'reattach' : 'new'} ` +

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -39,6 +39,15 @@ export class ZellijBackend implements SessionBackend {
   private readonly sessionName: string;
   private readonly ownsSession: boolean;
   private reattaching = false;
+  /** When true, the caller has ALREADY resolved reattach-vs-fresh (the worker's
+   *  frozen tri-state probe, refreshed to 'missing' after any teardown). spawn()
+   *  must then honour `reattaching` verbatim and skip its `|| hasSession()`
+   *  self-heal — that live re-probe would re-run the same load-fragile
+   *  `list-sessions` and, on a post-kill session that has not fully died yet,
+   *  flip a frozen `false` back to attach, reattaching to the very pane the
+   *  teardown gate just removed. 'auto' (default) keeps the self-heal for
+   *  callers that did not freeze a decision. */
+  private readonly frozenReattach: boolean;
   private configPath: string | null = null;
   private tmpConfigDir: string | null = null;
   /** Set by kill()/destroySession() so the pty-client exit they cause (an
@@ -60,10 +69,11 @@ export class ZellijBackend implements SessionBackend {
   cliPid?: number;
   cliCwd?: string;
 
-  constructor(sessionName: string, opts?: { ownsSession?: boolean; isReattach?: boolean; paneId?: string }) {
+  constructor(sessionName: string, opts?: { ownsSession?: boolean; isReattach?: boolean; paneId?: string; reattachDecision?: 'frozen' | 'auto' }) {
     this.sessionName = sessionName;
     this.ownsSession = opts?.ownsSession ?? true;
     this.reattaching = opts?.isReattach ?? false;
+    this.frozenReattach = opts?.reattachDecision === 'frozen';
     this.paneId = opts?.paneId ?? null;
   }
 
@@ -136,7 +146,13 @@ export class ZellijBackend implements SessionBackend {
 
   spawn(bin: string, args: string[], opts: SpawnOpts): void {
     // Reattach if the session is already live (daemon restarted, CLI survived).
-    this.reattaching = this.reattaching || ZellijBackend.hasSession(this.sessionName);
+    // Skip this self-heal when the caller froze the decision: a teardown gate
+    // may have just killed the pane and set reattaching=false, and a live
+    // re-probe here (same load-fragile `list-sessions`) could still see the
+    // not-yet-reaped session and wrongly flip us back to attach.
+    if (!this.frozenReattach) {
+      this.reattaching = this.reattaching || ZellijBackend.hasSession(this.sessionName);
+    }
     logger.debug(
       `[zellij:${this.sessionName}] spawn ${this.reattaching ? 'reattach' : 'new'} ` +
       `bin=${bin} args=${JSON.stringify(args)} cwd=${opts.cwd} ${opts.cols}x${opts.rows}`,

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -6,7 +6,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { zellijEnv, probeZellijFunctional } from '../../setup/ensure-zellij.js';
-import { resolveUserShell, buildBotmuxEnvAssignments, shellWrapperScript, shellCommandArgv, shellKindForPath } from './tmux-backend.js';
+import { resolveUserShell, buildBotmuxEnvAssignments, shellWrapperScript, shellCommandArgv, shellKindForPath, isExecTimeoutError } from './tmux-backend.js';
 import { resolveBotmuxWrapperBinDir } from '../../core/botmux-wrapper.js';
 import { logger } from '../../utils/logger.js';
 
@@ -108,6 +108,16 @@ export class ZellijBackend implements SessionBackend {
    *  TmuxBackend.probeSession does: a numeric exit status with no signal is an
    *  ANSWER from zellij; only a signal/timeout or a spawn failure (ENOENT/EACCES
    *  — neither carries a numeric status) means we never got one.
+   *
+   *  The "answered" case is split by EXIT CODE, not by stderr wording alone:
+   *  zellij uses 1 for "listed fine, nothing live" and clap's 2 for usage errors
+   *  (verified against 0.44.1: a bogus flag/subcommand exits 2). But a numeric
+   *  status is only trusted AFTER ruling out a deadline — Node's timeout can
+   *  race the child's own exit and produce `ETIMEDOUT` alongside a clean status
+   *  (see isExecTimeoutError and the tmux-probe regression that pins it), which
+   *  is still "no answer". And a silent non-zero exit is not proof of emptiness:
+   *  we require zellij's explicit "no active sessions" line (or live rows) to
+   *  call it, so anything ambiguous degrades to `unknown` — the safe direction.
    */
   static probeLiveSessions(): { ok: true; sessions: string[] } | { ok: false } {
     let out: string;
@@ -119,30 +129,44 @@ export class ZellijBackend implements SessionBackend {
         env: zellijEnv(),
       });
     } catch (e: any) {
-      // Answered, but non-zero: "no active sessions" is the documented exit-1
-      // case, so treat a clean numeric status as an authoritative empty list.
-      // Anything else (timeout → signal, ENOENT/EACCES → no status) is unknown.
-      if (e && typeof e.status === 'number' && !e.signal) {
-        const stderr = (e.stderr?.toString?.() ?? '').trim();
-        const stdout = (e.stdout?.toString?.() ?? '');
-        if (/no active zellij sessions/i.test(stderr) || (!stdout.trim() && !stderr)) {
-          return { ok: true, sessions: [] };
-        }
-        // A different answered failure (bad flag, corrupt cache, …) is not proof
-        // of emptiness — do not let it read as "session gone".
-        return { ok: false };
+      // Deadline FIRST, before any numeric-status reasoning: when Node's timeout
+      // races the child's own exit, the error carries `code='ETIMEDOUT'` AND a
+      // clean `status` with no signal (see isExecTimeoutError + the
+      // tmux-probe.test.ts regression pinning that exact shape). Reading that as
+      // an answer would turn the very high-load timeout this PR exists to
+      // tolerate back into an authoritative "gone" — and in the strict post-kill
+      // path it would report an unconfirmed termination as proven.
+      if (isExecTimeoutError(e)) return { ok: false };
+      // Not answered at all (killed by a signal, or a spawn failure like
+      // ENOENT/EACCES which carries no numeric status): stay indeterminate.
+      if (!e || typeof e.status !== 'number' || e.signal) return { ok: false };
+      // Answered non-zero. Only exit 1 can mean "listed fine, nothing live";
+      // clap usage/startup errors are 2+ and prove nothing about liveness.
+      if (e.status !== 1) return { ok: false };
+      // If it printed live rows anyway, those win (never report a live pane gone).
+      const rows = ZellijBackend.parseLiveSessionRows(e.stdout?.toString?.() ?? '');
+      if (rows.length > 0) return { ok: true, sessions: rows };
+      // Require zellij's explicit "no active sessions" answer to call it empty.
+      // A SILENT non-zero exit proves nothing — treating it as zero is how an
+      // unconfirmed kill or a half-broken host would read as "session gone".
+      // (The message is hardcoded in zellij since our 0.44.0 floor; a future
+      // rewording degrades to `unknown`, which is the safe direction here.)
+      if (/no active zellij sessions/i.test((e.stderr?.toString?.() ?? '').trim())) {
+        return { ok: true, sessions: [] };
       }
       return { ok: false };
     }
-    return {
-      ok: true,
-      sessions: out
-        .split('\n')
-        .map(l => l.trim())
-        .filter(l => l.length > 0 && !/EXITED/i.test(l))
-        .map(l => l.split(/\s+/)[0]!)
-        .filter(Boolean),
-    };
+    return { ok: true, sessions: ZellijBackend.parseLiveSessionRows(out) };
+  }
+
+  /** Live (non-EXITED) session names from `list-sessions --no-formatting` output. */
+  private static parseLiveSessionRows(raw: string): string[] {
+    return raw
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l.length > 0 && !/EXITED/i.test(l))
+      .map(l => l.split(/\s+/)[0]!)
+      .filter(Boolean);
   }
 
   static hasSession(name: string): boolean {

--- a/src/utils/executable.ts
+++ b/src/utils/executable.ts
@@ -1,8 +1,13 @@
-import { accessSync, constants } from 'node:fs';
+import { accessSync, constants, statSync } from 'node:fs';
 import { delimiter, isAbsolute, join } from 'node:path';
 
 export function isExecutable(path: string): boolean {
   try {
+    // A directory can carry the `x` bit (it means "traversable"), so an X_OK
+    // check alone would accept a directory that merely shares an executable's
+    // name on PATH. Require a regular file (statSync follows symlinks, so a
+    // symlink → real binary still qualifies) before trusting the mode bit.
+    if (!statSync(path).isFile()) return false;
     accessSync(path, constants.X_OK);
     return true;
   } catch {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12522,6 +12522,7 @@ async function spawnCli(
     let available = true;
     let reason = '';
     let hasExistingSession = false;
+    let existingSessionUnknown = false;
     if (effectiveBackend === 'tmux') {
       hasExistingSession = TmuxBackend.hasSession(TmuxBackend.sessionName(cfg.sessionId));
       if (!hasExistingSession) {
@@ -12533,10 +12534,22 @@ async function spawnCli(
       // Like tmux, zellij's probe is a disposable background session, so a
       // live named session is more authoritative than a transient probe
       // failure (PR#249 semantics) — check it first so we reattach, not gate.
-      hasExistingSession = ZellijBackend.hasSession(ZellijBackend.sessionName(cfg.sessionId));
-      if (!hasExistingSession) {
+      //
+      // Tri-state on purpose: `hasSession()` is `probeSession() === 'exists'`,
+      // so it answers `false` BOTH for "no such session" and for "the probe got
+      // no answer" (`list-sessions` timed out / spawn failed). Under host load
+      // that second case is real — the probe needs a fork+exec before zellij
+      // ever runs — and collapsing it into "no session" then let the functional
+      // probe (which spawns a background session, so it times out under the
+      // same pressure) gate a session whose pane was alive the whole time.
+      const probeState = ZellijBackend.probeSession(ZellijBackend.sessionName(cfg.sessionId));
+      hasExistingSession = probeState === 'exists';
+      existingSessionUnknown = probeState === 'unknown';
+      if (probeState === 'missing') {
         available = ZellijBackend.isAvailable();
         reason = 'zellij 功能性探针失败（需 zellij >= 0.44）';
+      } else if (existingSessionUnknown) {
+        log('zellij list-sessions probe returned no answer (host load); spawning to let reattach decide instead of gating');
       }
     } else if (effectiveBackend === 'zmx') {
       // The local controller version is a protocol requirement even when the
@@ -12570,7 +12583,7 @@ async function spawnCli(
       available = HerdrBackend.isAvailable();
       reason = 'herdr 功能性探针失败';
     }
-    const decision = decideBackendGate({ requested: effectiveBackend, available, hasExistingSession });
+    const decision = decideBackendGate({ requested: effectiveBackend, available, hasExistingSession, existingSessionUnknown });
     if (decision.action === 'gate') {
       const detail = reason || decision.reason;
       log(`${effectiveBackend} backend unavailable and silent PTY fallback is disabled (set BACKEND_TYPE=pty to opt in): ${detail}`);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13280,9 +13280,12 @@ async function spawnCli(
         } else if (effectiveBackendType === 'zellij') {
           // Refresh the frozen zellij probe before re-selecting, or the
           // replacement keeps isReattach for the pane this gate just removed.
-          // Fail closed to 'missing' on an inconclusive post-kill probe: unlike
-          // the pre-spawn bias, an unproven answer here must NOT reattach.
-          resolvedZellijSessionProbe = postKillProbe === 'exists' ? 'exists' : 'missing';
+          // This gate already threw above unless the post-kill probe proved
+          // 'missing' (an inconclusive answer never gets here), so the pane is
+          // known gone: record that so the re-selection cold-spawns. The
+          // mcp-gateway gate is laxer (it only rejects a proven-live pane), so
+          // its own reset still has to fail closed on 'unknown' explicitly.
+          resolvedZellijSessionProbe = 'missing';
         }
       },
       clearProvenanceVerified: () => {
@@ -13360,6 +13363,18 @@ async function spawnCli(
       );
     }
     if (effectiveBackendType === 'zmx' && paneProbe === 'unknown') {
+      throw new Error(
+        `[mcp-gateway] refusing to start session ${cfg.sessionId}: ` +
+        `could not verify existing ${effectiveBackendType} pane`,
+      );
+    }
+    // zellij's pre-spawn bias reattaches on an indeterminate probe (a live pane
+    // is likelier than a gone one under load). That bias is WRONG for an
+    // MCP-gateway pane: reattaching binds the CLI's MCP client to a relay socket
+    // that cannot survive this worker, and the gate below only cold-resumes on a
+    // proven 'exists'. So an unverifiable zellij pane here must fail closed like
+    // zmx rather than silently reattach to a possibly-dead gateway host.
+    if (effectiveBackendType === 'zellij' && paneProbe === 'unknown') {
       throw new Error(
         `[mcp-gateway] refusing to start session ${cfg.sessionId}: ` +
         `could not verify existing ${effectiveBackendType} pane`,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -288,6 +288,7 @@ import {
   backendSupportsWebTerminal,
 } from './adapters/backend/capabilities.js';
 import { zellijEnv } from './setup/ensure-zellij.js';
+import { locateExecutable } from './utils/executable.js';
 import {
   AmbiguousSubmissionBlockedError,
   isObserveBackend,
@@ -12518,6 +12519,12 @@ async function spawnCli(
   }
   let resolvedZmxSessionProbe: SessionProbe | undefined;
   let resolvedZmxSessionPid: number | undefined;
+  // Frozen zellij existence decision, mirroring resolvedZmxSessionProbe: the
+  // gate resolves the tri-state probe ONCE (biasing an indeterminate answer
+  // toward reattach) and every teardown below refreshes it to 'missing', so a
+  // post-kill re-selection cold-spawns instead of reattaching to the pane it
+  // just removed. selectSessionBackend consumes it via hasExistingSession.
+  let resolvedZellijSessionProbe: SessionProbe | undefined;
   {
     let available = true;
     let reason = '';
@@ -12543,13 +12550,30 @@ async function spawnCli(
       // probe (which spawns a background session, so it times out under the
       // same pressure) gate a session whose pane was alive the whole time.
       const probeState = ZellijBackend.probeSession(ZellijBackend.sessionName(cfg.sessionId));
+      resolvedZellijSessionProbe = probeState;
       hasExistingSession = probeState === 'exists';
       existingSessionUnknown = probeState === 'unknown';
       if (probeState === 'missing') {
         available = ZellijBackend.isAvailable();
         reason = 'zellij 功能性探针失败（需 zellij >= 0.44）';
       } else if (existingSessionUnknown) {
-        log('zellij list-sessions probe returned no answer (host load); spawning to let reattach decide instead of gating');
+        // `probeSession` collapses BOTH a load-timeout AND a missing/unrunnable
+        // binary (ENOENT/EACCES) into 'unknown'. Only the first deserves the
+        // spawn-instead-of-gate exemption; a genuinely absent zellij must still
+        // gate to the actionable "install zellij" card, not fall through and
+        // crash node-pty with `execvp failed`. `locateExecutable` is a pure
+        // PATH stat (no fork) so it stays authoritative under the very host
+        // load that made `list-sessions` time out — an absent binary fails it
+        // instantly, a present-but-slow one still resolves.
+        if (locateExecutable('zellij', zellijEnv())) {
+          log('zellij list-sessions probe returned no answer but the binary is on PATH (host load); spawning to let reattach decide instead of gating');
+        } else {
+          existingSessionUnknown = false;
+          resolvedZellijSessionProbe = 'missing';
+          available = false;
+          reason = 'zellij 二进制不在 PATH 上';
+          log('zellij list-sessions probe returned no answer AND the binary is not on PATH; gating to the install card instead of spawning');
+        }
       }
     } else if (effectiveBackend === 'zmx') {
       // The local controller version is a protocol requirement even when the
@@ -12945,11 +12969,19 @@ async function spawnCli(
     // requires an isolation/MCP boundary that only a Botmux-owned session can
     // safely provide. Fresh tasks use distinct agents in one machine-wide host.
     reuseRecordedHerdrTarget,
-    // ZMX reattach vs fresh is frozen here from the probe taken above; the
-    // backend refuses to silently turn a fresh launch into an attach.
+    // ZMX/zellij reattach vs fresh is frozen here from the probe taken above;
+    // the backend refuses to silently turn a fresh launch into an attach. ZMX
+    // reattaches only on a proven 'exists'; zellij also reattaches on 'unknown'
+    // (a load-timed-out probe of a pane that is more likely alive than gone —
+    // the same asymmetry the gate used to spawn instead of gate), and cold-
+    // spawns only on an authoritative 'missing'. Post-kill gates below reset
+    // the frozen probe to 'missing' so a re-selection never reattaches to a
+    // pane they just tore down.
     hasExistingSession: effectiveBackend === 'zmx'
       ? resolvedZmxSessionProbe === 'exists'
-      : undefined,
+      : effectiveBackend === 'zellij'
+        ? resolvedZellijSessionProbe !== undefined && resolvedZellijSessionProbe !== 'missing'
+        : undefined,
     zmxRecoveryStateDir: isolationRuntimeDataDir,
   });
   let selectedBackend = selectBackend();
@@ -13245,6 +13277,12 @@ async function spawnCli(
         if (effectiveBackendType === 'zmx') {
           resolvedZmxSessionProbe = postKillProbe;
           resolvedZmxSessionPid = undefined;
+        } else if (effectiveBackendType === 'zellij') {
+          // Refresh the frozen zellij probe before re-selecting, or the
+          // replacement keeps isReattach for the pane this gate just removed.
+          // Fail closed to 'missing' on an inconclusive post-kill probe: unlike
+          // the pre-spawn bias, an unproven answer here must NOT reattach.
+          resolvedZellijSessionProbe = postKillProbe === 'exists' ? 'exists' : 'missing';
         }
       },
       clearProvenanceVerified: () => {
@@ -13389,6 +13427,11 @@ async function spawnCli(
       if (effectiveBackendType === 'zmx') {
         resolvedZmxSessionProbe = postKillProbe;
         resolvedZmxSessionPid = undefined;
+      } else if (effectiveBackendType === 'zellij') {
+        // Same as the read-isolation gate: refresh the frozen zellij probe so
+        // the re-selection cold-spawns a fresh host instead of reattaching to
+        // the pane we just killed. Fail closed to 'missing' unless proven live.
+        resolvedZellijSessionProbe = postKillProbe === 'exists' ? 'exists' : 'missing';
       }
       selectedBackend = selectBackend();
       isTmuxMode = selectedBackend.isTmuxMode;

--- a/test/backend-gate.test.ts
+++ b/test/backend-gate.test.ts
@@ -169,14 +169,49 @@ describe('decideBackendGate (PTY 退役 hard gate)', () => {
   });
 
   it('resets the frozen zellij probe to missing after every post-kill re-selection', () => {
-    // Both persistent teardown gates (read-isolation, mcp-gateway) must refresh
-    // the frozen zellij probe so a re-selection cold-spawns a fresh pane rather
-    // than reattaching to the one they just killed. Fail closed unless proven
-    // still live.
-    const occurrences = workerSource.split(
-      "resolvedZellijSessionProbe = postKillProbe === 'exists' ? 'exists' : 'missing';",
-    ).length - 1;
-    expect(occurrences).toBe(2);
+    // Both persistent teardown gates must refresh the frozen zellij probe so a
+    // re-selection cold-spawns a fresh pane rather than reattaching to the one
+    // they just killed — but each gate's own strictness differs:
+    //  - read-isolation already throws unless the post-kill probe proved
+    //    'missing', so by then the pane is known gone → assign 'missing'.
+    //  - mcp-gateway only rejects a PROVEN-LIVE pane, so 'unknown' still
+    //    reaches its reset and must fail closed to 'missing' explicitly.
+    // Both post-kill resets are keyed off `postKillProbe`; every one of them
+    // must end at 'missing' so a teardown never leaves a reattachable state.
+    const postKillResets = (workerSource.match(/resolvedZellijSessionProbe = [^;\n]+;/g) ?? [])
+      .filter(r => r.includes('postKillProbe') || r === "resolvedZellijSessionProbe = 'missing';");
+    // 3 = read-isolation confirmPaneGone + mcp-gateway + the not-installed gate
+    // (all three converge on 'missing'); the two teardown ones are the point.
+    expect(postKillResets.length).toBeGreaterThanOrEqual(2);
+    for (const reset of postKillResets) {
+      expect(reset).toContain("'missing'");
+    }
+    // The laxer gate keeps its explicit fail-closed on an unproven answer.
+    expect(workerSource).toContain("resolvedZellijSessionProbe = postKillProbe === 'exists' ? 'exists' : 'missing';");
+    // And the stricter read-isolation gate records the proven-gone pane.
+    const confirmGone = workerSource.indexOf('confirmPaneGone: () => {');
+    const confirmGoneEnd = workerSource.indexOf('clearProvenanceVerified: () => {', confirmGone);
+    expect(confirmGone).toBeGreaterThan(-1);
+    expect(workerSource.slice(confirmGone, confirmGoneEnd))
+      .toContain("resolvedZellijSessionProbe = 'missing';");
+  });
+
+  it('fails closed on an indeterminate zellij pane in the mcp-gateway gate (no silent reattach to a possibly-dead host)', () => {
+    // The pre-spawn bias reattaches zellij on 'unknown', but an MCP-gateway pane
+    // must not: reattaching binds the CLI to a relay socket that cannot survive
+    // this worker, and the gate only cold-resumes on a proven 'exists'. So an
+    // unverifiable zellij pane here must refuse, exactly like zmx.
+    const start = workerSource.indexOf('if (cliAdapter.mcpGateway && mcpRuntimeManifest?.entries.length');
+    const end = workerSource.indexOf('// The plugin set is stable only', start);
+    const gate = workerSource.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(gate).toContain("if (effectiveBackendType === 'zellij' && paneProbe === 'unknown')");
+    // It must throw (refuse), not fall through into a reattach.
+    const zellijUnknown = gate.indexOf("effectiveBackendType === 'zellij' && paneProbe === 'unknown'");
+    const nextThrow = gate.indexOf('throw new Error', zellijUnknown);
+    expect(nextThrow).toBeGreaterThan(zellijUnknown);
   });
 });
 

--- a/test/backend-gate.test.ts
+++ b/test/backend-gate.test.ts
@@ -124,6 +124,60 @@ describe('decideBackendGate (PTY 退役 hard gate)', () => {
     expect(gate).toContain("if (probeState === 'missing')");
     expect(gate).toContain('existingSessionUnknown');
   });
+
+  /**
+   * F2 regression: `probeSession` collapses a load-timeout AND a
+   * missing/unrunnable binary (ENOENT/EACCES) into the same 'unknown'. Only the
+   * load-timeout may take the spawn-instead-of-gate exemption; a genuinely
+   * absent zellij must still gate to the actionable install card rather than
+   * fall through and crash node-pty with `execvp failed`. The split MUST use a
+   * fork-free PATH check (`locateExecutable`), because a fork-based re-probe
+   * (`--version` / `isAvailable()`) would time out under the very host load
+   * that produced the 'unknown' in the first place.
+   */
+  it('splits an indeterminate zellij probe by a fork-free PATH check (ENOENT gates, load-timeout spawns)', () => {
+    const start = workerSource.indexOf("} else if (effectiveBackend === 'zellij') {");
+    const end = workerSource.indexOf("} else if (effectiveBackend === 'zmx')", start);
+    const gate = workerSource.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    // Split happens inside the indeterminate branch, keyed on binary presence.
+    const unknownBranch = gate.indexOf('existingSessionUnknown');
+    const pathCheck = gate.indexOf("locateExecutable('zellij'");
+    expect(pathCheck).toBeGreaterThan(unknownBranch);
+    // Absent binary: revoke the exemption AND fail the availability, so
+    // decideBackendGate reaches its terminal `gate` arm with the install reason.
+    expect(gate).toContain('existingSessionUnknown = false');
+    expect(gate).toContain("reason = 'zellij 二进制不在 PATH 上'");
+  });
+
+  it('freezes the zellij existence probe and threads it into selectSessionBackend for reattach', () => {
+    // F1 wiring: the gate records its tri-state answer once and the selector
+    // consumes it (biasing 'unknown' toward reattach), instead of the selector
+    // re-running a load-fragile live probe that would fresh-spawn into a
+    // collision under sustained load.
+    expect(workerSource).toContain('let resolvedZellijSessionProbe: SessionProbe | undefined;');
+    expect(workerSource).toContain('resolvedZellijSessionProbe = probeState;');
+    // Selector wiring: zellij reattaches on exists OR unknown, cold-spawns only
+    // on an authoritative missing.
+    const selectCall = workerSource.indexOf('const selectBackend = () => selectSessionBackend({');
+    const selectEnd = workerSource.indexOf('let selectedBackend = selectBackend();', selectCall);
+    const selectBlock = workerSource.slice(selectCall, selectEnd);
+    expect(selectBlock).toContain("effectiveBackend === 'zellij'");
+    expect(selectBlock).toContain("resolvedZellijSessionProbe !== undefined && resolvedZellijSessionProbe !== 'missing'");
+  });
+
+  it('resets the frozen zellij probe to missing after every post-kill re-selection', () => {
+    // Both persistent teardown gates (read-isolation, mcp-gateway) must refresh
+    // the frozen zellij probe so a re-selection cold-spawns a fresh pane rather
+    // than reattaching to the one they just killed. Fail closed unless proven
+    // still live.
+    const occurrences = workerSource.split(
+      "resolvedZellijSessionProbe = postKillProbe === 'exists' ? 'exists' : 'missing';",
+    ).length - 1;
+    expect(occurrences).toBe(2);
+  });
 });
 
 describe('backendGateUserMessage', () => {

--- a/test/backend-gate.test.ts
+++ b/test/backend-gate.test.ts
@@ -45,6 +45,56 @@ describe('decideBackendGate (PTY 退役 hard gate)', () => {
     ).toEqual({ action: 'spawn' });
   });
 
+  /**
+   * Regression: `hasSession()` is `probeSession() === 'exists'`, so it answers
+   * `false` both for "no such session" and for "the probe got no answer".
+   * Under host load the zellij existence check (`list-sessions`, needs a
+   * fork+exec) can be killed by its own timeout; the functional probe then
+   * spawns a background session and times out under the same pressure, and a
+   * session whose pane was alive the whole time got gated with
+   * "zellij 不可用".
+   */
+  it('does NOT gate zellij when the existence check itself got no answer', () => {
+    expect(
+      decideBackendGate({
+        requested: 'zellij',
+        available: false,
+        hasExistingSession: false,
+        existingSessionUnknown: true,
+      }),
+    ).toEqual({ action: 'spawn' });
+  });
+
+  it('still gates zellij when the session is PROVABLY absent and the probe failed', () => {
+    // The guard must keep its teeth: an authoritative "no such session" plus a
+    // failed capability probe is the real "zellij is broken" case.
+    expect(
+      decideBackendGate({
+        requested: 'zellij',
+        available: false,
+        hasExistingSession: false,
+        existingSessionUnknown: false,
+      }).action,
+    ).toBe('gate');
+  });
+
+  it('still gates ZMX on an indeterminate ownership probe (opposite asymmetry, unchanged)', () => {
+    // ZMX deliberately gates when ownership/protocol cannot be established —
+    // adopting someone else's session is the worse outcome there. It never sets
+    // existingSessionUnknown, so the zellij/tmux exemption must not reach it.
+    expect(
+      decideBackendGate({ requested: 'zmx', available: false, hasExistingSession: false }).action,
+    ).toBe('gate');
+  });
+
+  it('gates on an indeterminate zellij probe ONLY via the explicit flag, not via available=false', () => {
+    // Sanity: the exemption is opt-in per call site. A caller that never sets
+    // the flag keeps the old fail-closed behaviour.
+    expect(
+      decideBackendGate({ requested: 'zellij', available: false, hasExistingSession: false }).action,
+    ).toBe('gate');
+  });
+
   it('requires the ZMX protocol version before considering a managed live session', () => {
     const start = workerSource.indexOf("} else if (effectiveBackend === 'zmx') {");
     const end = workerSource.indexOf("} else if (effectiveBackend === 'herdr')", start);
@@ -55,6 +105,24 @@ describe('decideBackendGate (PTY 退役 hard gate)', () => {
     expect(gate.indexOf('probeZmxVersion()')).toBeLessThan(gate.indexOf('probeOwnedZmxSession('));
     expect(gate).toContain("resolvedZmxSessionProbe = 'unknown'");
     expect(gate).toContain('hasExistingSession = false');
+    // ZMX must NOT opt into the indeterminate-existence exemption: an unproven
+    // ownership/protocol result has to keep gating.
+    expect(gate).not.toContain('existingSessionUnknown = true');
+  });
+
+  it('wires the zellij gate through the tri-state probe, not the boolean hasSession', () => {
+    const start = workerSource.indexOf("} else if (effectiveBackend === 'zellij') {");
+    const end = workerSource.indexOf("} else if (effectiveBackend === 'zmx')", start);
+    const gate = workerSource.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(gate).toContain('ZellijBackend.probeSession(ZellijBackend.sessionName(cfg.sessionId))');
+    expect(gate).not.toContain('ZellijBackend.hasSession(');
+    // The capability probe runs ONLY on an authoritative 'missing'; an
+    // indeterminate answer must not fall through into it and then gate.
+    expect(gate).toContain("if (probeState === 'missing')");
+    expect(gate).toContain('existingSessionUnknown');
   });
 });
 

--- a/test/executable.test.ts
+++ b/test/executable.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the executable/PATH helpers.
+ *
+ * PR #836 hardening: `accessSync(X_OK)` succeeds on a DIRECTORY (the `x` bit
+ * means "traversable" there), so a directory that merely shares an executable's
+ * name on PATH would be mis-resolved as the binary. isExecutable() must require
+ * a regular file.
+ *
+ * Run:  pnpm vitest run test/executable.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isExecutable, locateExecutable } from '../src/utils/executable.js';
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'exec-test-'));
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('isExecutable', () => {
+  it('accepts a regular file with the executable bit', () => {
+    const f = join(dir, 'realbin');
+    writeFileSync(f, '#!/bin/sh\n');
+    chmodSync(f, 0o755);
+    expect(isExecutable(f)).toBe(true);
+  });
+
+  it('rejects a regular file WITHOUT the executable bit (EACCES)', () => {
+    const f = join(dir, 'notexec');
+    writeFileSync(f, 'plain\n');
+    chmodSync(f, 0o644);
+    expect(isExecutable(f)).toBe(false);
+  });
+
+  it('rejects a DIRECTORY that carries the x (traversable) bit', () => {
+    // The core PR #836 edge: a dir named like a binary is traversable (0755)
+    // and would pass a bare X_OK check.
+    const d = join(dir, 'dirlike');
+    mkdirSync(d, 0o755);
+    expect(isExecutable(d)).toBe(false);
+  });
+
+  it('rejects a missing path (ENOENT)', () => {
+    expect(isExecutable(join(dir, 'nope-does-not-exist'))).toBe(false);
+  });
+
+  it('follows a symlink to a real executable', () => {
+    const target = join(dir, 'symtarget');
+    writeFileSync(target, '#!/bin/sh\n');
+    chmodSync(target, 0o755);
+    const link = join(dir, 'symlink');
+    symlinkSync(target, link);
+    expect(isExecutable(link)).toBe(true);
+  });
+});
+
+describe('locateExecutable (PR #836: directory on PATH must not resolve)', () => {
+  it('does not resolve a same-named directory sitting on PATH', () => {
+    const pathDir = mkdtempSync(join(tmpdir(), 'exec-path-'));
+    mkdirSync(join(pathDir, 'zellij'), 0o755); // a DIRECTORY named zellij
+    try {
+      expect(locateExecutable('zellij', { PATH: pathDir })).toBeNull();
+    } finally {
+      rmSync(pathDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a real binary but skips a shadowing directory earlier on PATH', () => {
+    const dirWithDir = mkdtempSync(join(tmpdir(), 'exec-p1-'));
+    const dirWithBin = mkdtempSync(join(tmpdir(), 'exec-p2-'));
+    mkdirSync(join(dirWithDir, 'zellij'), 0o755); // directory shadow first
+    const bin = join(dirWithBin, 'zellij');
+    writeFileSync(bin, '#!/bin/sh\n');
+    chmodSync(bin, 0o755);
+    try {
+      expect(locateExecutable('zellij', { PATH: `${dirWithDir}:${dirWithBin}` })).toBe(bin);
+    } finally {
+      rmSync(dirWithDir, { recursive: true, force: true });
+      rmSync(dirWithBin, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for an empty PATH', () => {
+    expect(locateExecutable('zellij', { PATH: '' })).toBeNull();
+  });
+});

--- a/test/tmux-reattach-backend.test.ts
+++ b/test/tmux-reattach-backend.test.ts
@@ -330,6 +330,56 @@ describe('selectSessionBackend', () => {
     expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true });
   });
 
+  // F1 regression: the worker resolves zellij existence through a tri-state
+  // probe ONCE and biases an indeterminate answer toward reattach, then threads
+  // that frozen decision in as `hasExistingSession`. The selector must honour
+  // it verbatim — a bare `hasSession()` re-probe here would re-run the same
+  // load-fragile `list-sessions` and, on a sustained-load `false`, do a FRESH
+  // spawn that collides with the still-live named session ("Session already
+  // exists"), which is exactly the crash-loop the gate exemption was meant to
+  // avoid.
+  it('reattaches zellij on a threaded-in existence decision even when a live re-probe would say false', () => {
+    // Simulate the sustained-load case: hasSession() (the re-probe) returns
+    // false, but the frozen decision from the gate is "treat as present".
+    vi.mocked(ZellijBackend.hasSession).mockReturnValue(false);
+
+    const selected = selectSessionBackend({
+      sessionId: '9cfa0024-197d-4781-845b-c541dceb8980',
+      backendType: 'zellij',
+      hasExistingSession: true,
+    });
+
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true });
+    // The threaded decision must WIN — the live re-probe must not be consulted.
+    expect(ZellijBackend.hasSession).not.toHaveBeenCalled();
+  });
+
+  it('cold-spawns zellij on a threaded-in absent decision even if a live re-probe would say true', () => {
+    // Post-kill gates reset the frozen probe to "gone"; a stale live re-probe
+    // saying true must NOT resurrect a reattach to the pane just torn down.
+    vi.mocked(ZellijBackend.hasSession).mockReturnValue(true);
+
+    const selected = selectSessionBackend({
+      sessionId: '9cfa0024-197d-4781-845b-c541dceb8980',
+      backendType: 'zellij',
+      hasExistingSession: false,
+    });
+
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: false });
+    expect(ZellijBackend.hasSession).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a live zellij hasSession probe when no decision is threaded in', () => {
+    // Default callers / tests that do not thread a frozen decision keep the old
+    // behaviour: consult the live probe.
+    vi.mocked(ZellijBackend.hasSession).mockReturnValue(true);
+
+    const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', backendType: 'zellij' });
+
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true });
+    expect(ZellijBackend.hasSession).toHaveBeenCalledTimes(1);
+  });
+
   it('uses zmx tail signals, history snapshots, and send as a managed pipe backend', () => {
     vi.mocked(ZmxBackend.hasSession).mockReturnValue(true);
 

--- a/test/tmux-reattach-backend.test.ts
+++ b/test/tmux-reattach-backend.test.ts
@@ -317,7 +317,7 @@ describe('selectSessionBackend', () => {
     expect(selected.isTmuxMode).toBe(false);
     expect(selected.isPipeMode).toBe(false);
     expect(selected.backend.constructor.name).toBe('MockZellijBackend');
-    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: false });
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: false, reattachDecision: 'auto' });
   });
 
   it('marks an existing zellij session as reattach without making it pipe mode', () => {
@@ -327,7 +327,7 @@ describe('selectSessionBackend', () => {
 
     expect(selected.isZellijMode).toBe(true);
     expect(selected.isPipeMode).toBe(false);
-    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true });
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true, reattachDecision: 'auto' });
   });
 
   // F1 regression: the worker resolves zellij existence through a tri-state
@@ -349,7 +349,7 @@ describe('selectSessionBackend', () => {
       hasExistingSession: true,
     });
 
-    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true });
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true, reattachDecision: 'frozen' });
     // The threaded decision must WIN — the live re-probe must not be consulted.
     expect(ZellijBackend.hasSession).not.toHaveBeenCalled();
   });
@@ -365,18 +365,18 @@ describe('selectSessionBackend', () => {
       hasExistingSession: false,
     });
 
-    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: false });
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: false, reattachDecision: 'frozen' });
     expect(ZellijBackend.hasSession).not.toHaveBeenCalled();
   });
 
-  it('falls back to a live zellij hasSession probe when no decision is threaded in', () => {
+  it('falls back to a live zellij hasSession probe (auto mode) when no decision is threaded in', () => {
     // Default callers / tests that do not thread a frozen decision keep the old
-    // behaviour: consult the live probe.
+    // behaviour: consult the live probe AND let spawn() self-heal (auto).
     vi.mocked(ZellijBackend.hasSession).mockReturnValue(true);
 
     const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', backendType: 'zellij' });
 
-    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true });
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true, reattachDecision: 'auto' });
     expect(ZellijBackend.hasSession).toHaveBeenCalledTimes(1);
   });
 

--- a/test/zellij-frozen-reattach.test.ts
+++ b/test/zellij-frozen-reattach.test.ts
@@ -174,6 +174,78 @@ describe('ZellijBackend.probeLiveSessions exit-code classification', () => {
     expect(ZellijBackend.probeSession('bmx-anything')).toBe('missing');
   });
 
+  it('degrades to unknown (not missing) if zellij ever reworded the no-sessions line', () => {
+    // Deliberate trade-off: emptiness requires zellij's explicit answer, so an
+    // unrecognised message fails SAFE (unknown → keep the reattach bias) rather
+    // than asserting "gone" from a silent non-zero exit. The message is
+    // hardcoded upstream at our 0.44.0 floor, so this is a future-proofing
+    // direction choice, not a live regression.
+    failWith({ status: 1, stderr: Buffer.from('没有活动的 zellij 会话\n') });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: false });
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('unknown');
+  });
+
+  it('treats a DEADLINE that raced a clean exit as unknown (ETIMEDOUT + numeric status, no signal)', () => {
+    // Minimal counter-example from review: Node's timeout can fire while the
+    // child is exiting, so the error carries ETIMEDOUT *and* a clean status=1
+    // with empty output — indistinguishable from "no sessions" by status alone.
+    // Reading it as 'missing' would turn the exact high-load timeout this PR
+    // exists to tolerate back into an authoritative "gone", and would let the
+    // strict post-kill path treat an unconfirmed kill as proven termination.
+    // Mirrors TmuxBackend.probeSession, which checks the deadline FIRST.
+    failWith({
+      code: 'ETIMEDOUT', status: 1, signal: null,
+      stdout: Buffer.alloc(0), stderr: Buffer.alloc(0),
+    });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: false });
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('unknown');
+  });
+
+  it('lets the DEADLINE win even when the no-sessions line is also present', () => {
+    // This is the case that actually isolates the deadline check: with empty
+    // stderr an ETIMEDOUT would return unknown anyway (via the "needs an
+    // explicit answer" path), so removing the deadline guard would go unnoticed.
+    // Here zellij's real message IS present, so only checking the deadline first
+    // keeps it indeterminate — otherwise a timed-out probe that happened to race
+    // an empty listing becomes an authoritative "gone".
+    failWith({
+      code: 'ETIMEDOUT', status: 1, signal: null,
+      stdout: Buffer.alloc(0), stderr: Buffer.from('No active zellij sessions found.\n'),
+    });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: false });
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('unknown');
+  });
+
+  it('does not call a SILENT non-zero exit empty (needs zellij\'s explicit answer)', () => {
+    // A quiet exit 1 with no stderr proves nothing about liveness.
+    failWith({ status: 1, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: false });
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('unknown');
+  });
+
+  it('does NOT treat a usage error (clap exit 2) as emptiness even with empty stderr', () => {
+    // Real zellij 0.44.1 exits 2 for a bogus flag/subcommand. Such an answer
+    // proves nothing about liveness, so it must stay indeterminate — and an
+    // empty stderr must not sneak it through as "no sessions".
+    failWith({ status: 2, stdout: Buffer.from(''), stderr: Buffer.from('') });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: false });
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('unknown');
+  });
+
+  it('still honours live rows printed alongside a non-zero exit 1', () => {
+    // Defensive: if a future zellij lists sessions AND exits 1, the live rows
+    // are authoritative — do not report a live pane as gone.
+    failWith({ status: 1, stdout: Buffer.from('bmx-live [Created 1s ago] \n'), stderr: Buffer.from('') });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: true, sessions: ['bmx-live'] });
+    expect(ZellijBackend.probeSession('bmx-live')).toBe('exists');
+  });
+
   it('treats a spawn failure (binary absent → no numeric status) as unknown', () => {
     failWith({ code: 'ENOENT', status: undefined, signal: undefined });
 

--- a/test/zellij-frozen-reattach.test.ts
+++ b/test/zellij-frozen-reattach.test.ts
@@ -67,12 +67,11 @@ describe('ZellijBackend frozen reattach decision', () => {
     expect(args).not.toContain('attach');
   });
 
-  it('honours a frozen isReattach:true without re-probing', () => {
+  it('honours a frozen isReattach:true when the session is live', () => {
     const be = new ZellijBackend(SESSION, { ownsSession: true, isReattach: true, reattachDecision: 'frozen' });
     be.spawn('claude', [], spawnOpts);
 
     expect(be.isReattach).toBe(true);
-    expect(mockedExecFileSync).not.toHaveBeenCalled();
     const args = mockedPtySpawn.mock.calls[0][1] as string[];
     expect(args).toContain('attach');
     expect(args).not.toContain('--new-session-with-layout');
@@ -99,5 +98,112 @@ describe('ZellijBackend frozen reattach decision', () => {
     expect(be.isReattach).toBe(false);
     const args = mockedPtySpawn.mock.calls[0][1] as string[];
     expect(args).toContain('--new-session-with-layout');
+  });
+
+  /**
+   * The reattach bias is a BET, not a fact: the worker reattaches on an
+   * indeterminate existence probe because a live pane is likelier than a gone
+   * one under load. When the session turns out to be provably absent, `attach`
+   * exits 1 ("No session with the name … found!"), which reads as a CLI crash
+   * and burns a restart — so a frozen `attach` must downgrade to a fresh spawn
+   * on an AUTHORITATIVE 'missing'.
+   */
+  it('downgrades a frozen reattach to a fresh spawn when the session is provably absent', () => {
+    mockedExecFileSync.mockReturnValue('' as unknown as Buffer); // authoritative: no live sessions
+    const be = new ZellijBackend(SESSION, { ownsSession: true, isReattach: true, reattachDecision: 'frozen' });
+    be.spawn('claude', [], spawnOpts);
+
+    expect(be.isReattach).toBe(false);
+    const args = mockedPtySpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('--new-session-with-layout');
+    expect(args).not.toContain('attach');
+  });
+
+  it('keeps a frozen reattach when the probe is INDETERMINATE (bias preserved)', () => {
+    // list-sessions failing (timeout/spawn error) is 'unknown', not 'missing' —
+    // the bias must survive it, otherwise the whole point of the fix is lost.
+    mockedExecFileSync.mockImplementation((() => { throw new Error('ETIMEDOUT'); }) as any);
+    const be = new ZellijBackend(SESSION, { ownsSession: true, isReattach: true, reattachDecision: 'frozen' });
+    be.spawn('claude', [], spawnOpts);
+
+    expect(be.isReattach).toBe(true);
+    const args = mockedPtySpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('attach');
+  });
+
+  it('NEVER flips a frozen fresh decision into an attach, even if the session looks live', () => {
+    // The teardown guarantee: the downgrade above is one-directional. A gate that
+    // killed the pane froze `false`; a lingering not-yet-reaped session must not
+    // resurrect the reattach.
+    listSessionsReportsLive();
+    const be = new ZellijBackend(SESSION, { ownsSession: true, isReattach: false, reattachDecision: 'frozen' });
+    be.spawn('claude', [], spawnOpts);
+
+    expect(be.isReattach).toBe(false);
+    const args = mockedPtySpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('--new-session-with-layout');
+    expect(args).not.toContain('attach');
+  });
+});
+
+/**
+ * Root-cause regression (found in review of the rebased head): zellij exits **1**
+ * with stderr `No active zellij sessions found.` when there are simply no
+ * sessions. The original bare `catch` reported that authoritative "zero" as
+ * {ok:false} → `probeSession() === 'unknown'`, so on a CLEAN HOST (the normal
+ * first-start path) the gate granted its indeterminate-probe exemption and the
+ * frozen decision became `attach` — against a name that does not exist, which
+ * exits 1 every time. Verified against real zellij 0.44.1.
+ */
+describe('ZellijBackend.probeLiveSessions exit-code classification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function failWith(props: Record<string, unknown>) {
+    mockedExecFileSync.mockImplementation((() => {
+      throw Object.assign(new Error('Command failed'), props);
+    }) as any);
+  }
+
+  it('treats the documented "no active sessions" exit 1 as an authoritative EMPTY list', () => {
+    failWith({ status: 1, stderr: Buffer.from('No active zellij sessions found.\n') });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: true, sessions: [] });
+    // The decisive consequence: a clean host reports 'missing', NOT 'unknown'.
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('missing');
+  });
+
+  it('treats a spawn failure (binary absent → no numeric status) as unknown', () => {
+    failWith({ code: 'ENOENT', status: undefined, signal: undefined });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: false });
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('unknown');
+  });
+
+  it('treats a timeout (killed by signal) as unknown', () => {
+    failWith({ code: 'ETIMEDOUT', signal: 'SIGTERM', status: undefined });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: false });
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('unknown');
+  });
+
+  it('does NOT read some other answered failure as emptiness', () => {
+    // A different non-zero exit (bad flag, corrupt cache) is not proof that
+    // zero sessions exist, so it must not become an authoritative 'missing'.
+    failWith({ status: 2, stderr: Buffer.from('error: unexpected argument\n') });
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: false });
+    expect(ZellijBackend.probeSession('bmx-anything')).toBe('unknown');
+  });
+
+  it('still filters EXITED corpses out of a successful listing', () => {
+    mockedExecFileSync.mockReturnValue(
+      'bmx-live [Created 1s ago] \nbmx-dead [Created 2d ago] (EXITED - attach to resurrect)\n' as unknown as Buffer,
+    );
+
+    expect(ZellijBackend.probeLiveSessions()).toEqual({ ok: true, sessions: ['bmx-live'] });
+    expect(ZellijBackend.probeSession('bmx-dead')).toBe('missing');
+    expect(ZellijBackend.probeSession('bmx-live')).toBe('exists');
   });
 });

--- a/test/zellij-frozen-reattach.test.ts
+++ b/test/zellij-frozen-reattach.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression for PR #836 (F1 follow-up): a caller that has already frozen the
+ * reattach-vs-fresh decision (the worker's tri-state probe, reset to 'missing'
+ * after any teardown gate) must have that decision honoured VERBATIM by
+ * ZellijBackend.spawn(). The pre-existing `this.reattaching ||= hasSession()`
+ * self-heal would otherwise re-run the same load-fragile `list-sessions` and,
+ * on a post-kill session that has not fully died yet, flip a frozen `false`
+ * back to attach — reattaching to the very pane the gate just removed.
+ *
+ * Run:  pnpm vitest run test/zellij-frozen-reattach.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock child_process so ZellijBackend.hasSession()/probeSession() are
+// controllable: a 'true'-looking list-sessions output simulates the not-yet-
+// reaped session a live re-probe would still see.
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(() => ({
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    pid: 4242,
+  })),
+}));
+
+import { execFileSync } from 'node:child_process';
+import * as pty from 'node-pty';
+import { ZellijBackend } from '../src/adapters/backend/zellij-backend.js';
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+const mockedPtySpawn = vi.mocked(pty.spawn);
+
+const SESSION = 'bmx-frozen01';
+const spawnOpts = { cwd: '/tmp', cols: 80, rows: 24, env: { PATH: '/usr/bin' } };
+
+// Make list-sessions report the session as LIVE — i.e. hasSession() === true.
+function listSessionsReportsLive() {
+  mockedExecFileSync.mockReturnValue(`${SESSION} [Created 1s ago] \n` as unknown as Buffer);
+}
+
+describe('ZellijBackend frozen reattach decision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listSessionsReportsLive();
+  });
+
+  it('honours a frozen isReattach:false even when a live re-probe would say the session exists', () => {
+    // This is the teardown case: the gate killed the pane and froze the
+    // decision to fresh, but the session lingers in list-sessions.
+    const be = new ZellijBackend(SESSION, { ownsSession: true, isReattach: false, reattachDecision: 'frozen' });
+    be.spawn('claude', [], spawnOpts);
+
+    expect(be.isReattach).toBe(false);
+    // The self-heal probe must NOT have run.
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+    // And the spawn must be a FRESH session (--new-session-with-layout), not an
+    // attach to the pane the teardown removed.
+    const args = mockedPtySpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('--new-session-with-layout');
+    expect(args).not.toContain('attach');
+  });
+
+  it('honours a frozen isReattach:true without re-probing', () => {
+    const be = new ZellijBackend(SESSION, { ownsSession: true, isReattach: true, reattachDecision: 'frozen' });
+    be.spawn('claude', [], spawnOpts);
+
+    expect(be.isReattach).toBe(true);
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+    const args = mockedPtySpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('attach');
+    expect(args).not.toContain('--new-session-with-layout');
+  });
+
+  it('still self-heals in auto mode (default) — a live session flips isReattach true', () => {
+    // Default callers (no frozen decision) keep the PR#249 self-heal: a daemon
+    // restart that left the CLI running must reattach.
+    const be = new ZellijBackend(SESSION, { ownsSession: true, isReattach: false });
+    be.spawn('claude', [], spawnOpts);
+
+    expect(be.isReattach).toBe(true);
+    // The self-heal probe DID run (list-sessions).
+    expect(mockedExecFileSync).toHaveBeenCalled();
+    const args = mockedPtySpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('attach');
+  });
+
+  it('auto mode with a genuinely missing session stays fresh', () => {
+    mockedExecFileSync.mockReturnValue('' as unknown as Buffer); // no live sessions
+    const be = new ZellijBackend(SESSION, { ownsSession: true, isReattach: false });
+    be.spawn('claude', [], spawnOpts);
+
+    expect(be.isReattach).toBe(false);
+    const args = mockedPtySpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('--new-session-with-layout');
+  });
+});


### PR DESCRIPTION
## 问题

与 #833 的 tmux backend gate **逐字同构**的同一个缺陷，只是后端不同。

`ZellijBackend.hasSession()` 是：

```js
return ZellijBackend.probeSession(name) === 'exists';
```

而 `probeSession` 是三态的，第三态 `unknown` 的语义是「**探测没拿到答案**」：

```js
static probeSession(name: string): SessionProbe {
  const probe = ZellijBackend.probeLiveSessions();
  if (!probe.ok) return 'unknown';        // <-- 超时 / spawn 失败
  return probe.sessions.includes(name) ? 'exists' : 'missing';
}
```

塌成 boolean 之后 `unknown` 和 `missing` 都变成 `false`，于是 gate 走成：

1. `list-sessions --no-formatting` 需要 fork+exec，高负载下会被自己的 **3000ms** 预算杀掉 → `unknown` → 被当成「没有会话」
2. 兜底的 `ZellijBackend.isAvailable()` → `probeZellijFunctional()` 会 **spawn 一个后台 session**（`zellij attach --create-background`，5000ms），同样的压力下同样超时
3. → 判定 zellij 不可用，对一个 **pane 一直活着**的会话弹出「zellij 不可用，无法启动会话」

关键点和 tmux 那次一样：**两级探测都需要 fork**，所以主机压力大时它们会一起失败，而「一起失败」正好被读成「zellij 没装好」。

同机实测（同一台机器，同一次故障窗口）：

| 命令 | load ~4 实测 | 预算 |
|---|---|---|
| `tmux -V` | 0.009s（healthy） | 3000ms |
| `tmux new-session -d` | **0.93–4.45s** | 5000ms |

该机 15 分钟均载曾达 **71.56**，那种压力下连 healthy 时 9ms 的 `tmux -V` 都会耗尽 3000ms 预算。zellij 的两个探测是同一类 fork 开销，没有理由免疫。

## 改动

- zellij 分支改用三态 `probeSession()`。只有权威的 `'missing'` 才去跑 capability 探针；`'unknown'` 不再落进 gate。
- `decideBackendGate` 增加可选 `existingSessionUnknown`：存在性判不出来时**放行而不是 gate**。

## 方向是刻意不对称的

同一个 `unknown` 该往哪边倒，取决于**代价不对称**，不能一刀切：

- **判存在性**（本 PR / #833）→ 倒向「**当它在**」。错误 gate 会把一个活着的会话判死，用户看到的是"请安装已经装好的东西"。
- **判是否已杀干净**（另一个 PR）→ 必须倒向「**当它还在**」。未答复读成成功会放过一个应当被杀死的 pane，触发 P0 freeze。

**ZMX 属于后者**：所有权 / 协议版本判不准时就不该接管别人的 session，所以它 `unknown` 时**故意** gate，还显式写 `hasExistingSession = false` 防止豁免绕过。它不设这个新 flag，因此行为完全不变 —— 已加用例钉住（包括断言 zmx 分支里不出现 `existingSessionUnknown = true`）。

## 没改的地方（查过才留下）

`selectSessionBackend` 的 zellij 分支保持原样：`ZellijBackend.spawn()` 自己会做 `this.reattaching || ZellijBackend.hasSession(...)` 复检（`zellij-backend.ts:139`），一个错误的 `false` 会自我纠正，所以那行不是承载判定的位置。这和 tmux 不同 —— tmux 那边选错分支会直接 `duplicate session` 失败，所以 #833 必须处理。

## 验证

- `backend-gate` + `tmux-reattach-backend` + `worker-pipe-initial-screen-order`：**90 个测试全绿**
- 新增用例：zellij 的 `unknown` 不得 gate、权威 `missing` 仍要 gate（守卫保牙）、ZMX 的相反不对称不受影响、worker 接线走三态而非 boolean
- **变异测试证明两处守卫都有牙**：
  - 删掉 gate 的 unknown 豁免 → `does NOT gate zellij when the existence check itself got no answer` FAIL
  - worker 退回 boolean `hasSession`（精确复现原缺陷）→ `wires the zellij gate through the tri-state probe` FAIL

与 #833、#835 是三个独立失效面，可分别 review。
