### PR TITLE
fix(lark): 自动进群主动开工延续 new-topic 配置开话题

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -226,7 +226,7 @@ import {
   ensureSessionWhiteboard,
   closeCliMismatchedSessionsForBot,
 } from './core/session-manager.js';
-import { triggerSessionTurn, reconcileIdempotencyLeasesOnBoot, convergeIdempotentAsyncTurnOnWorkerExit } from './core/trigger-session.js';
+import { triggerSessionTurn, reconcileIdempotencyLeasesOnBoot, convergeIdempotentAsyncTurnOnWorkerExit, externalEventOpensOwnTopic } from './core/trigger-session.js';
 import {
   runDetachedBotTurnMutation,
   tryWithBotTurnMutation,
@@ -17796,11 +17796,16 @@ async function handleBotAdded(
     // UserMessage; reuse the localized session title only in its clean sidecar.
     const codexAppText = promptBody || title;
 
-    // Pick scope + anchor. 话题群 → seed a topic and anchor thread-scope there;
-    // 普通群 → chat-scope anchored at chatId.
+    // Pick scope + anchor. 话题群 或 普通群 new-topic 模式 → seed a topic and
+    // anchor thread-scope there；其余普通群 → chat-scope anchored at chatId。
+    // 复用入站 @ 的路由判据（externalEventOpensOwnTopic）：否则「自动进群主动开工」
+    // 会无视群配的 new-topic，把首轮平铺进群顶层 chat-scope，而不是像用户手动 @
+    // 那样开一个独立话题。
+    const regularGroupMode = resolveRegularGroupMode(larkAppId, chatId);
+    const opensOwnTopic = externalEventOpensOwnTopic(mode, regularGroupMode);
     let scope: 'thread' | 'chat';
     let anchor: string;
-    if (mode === 'topic') {
+    if (opensOwnTopic) {
       const seedText = tr('daemon.auto_start_join_seed', undefined, localeForBot(larkAppId));
       anchor = await sendMessage(larkAppId, chatId, seedText, 'text');
       scope = 'thread';
@@ -17814,7 +17819,7 @@ async function handleBotAdded(
       return;
     }
     const needsSharedReply = mode === 'group'
-      && resolveRegularGroupMode(larkAppId, chatId) === 'shared';
+      && regularGroupMode === 'shared';
 
     const { pinnedWorkingDir, pinnedFromBotDefault } = await resolvePinnedWorkingDir({ scope, anchor, chatId, chatType, larkAppId });
     const autoWt = willAutoWorktree(larkAppId, pinnedWorkingDir, pinnedFromBotDefault);

--- a/test/group-join-shared-routing.test.ts
+++ b/test/group-join-shared-routing.test.ts
@@ -954,4 +954,32 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     expect(ds?.session.currentReplyTarget).toBeUndefined();
     expect(mocks.forkWorker).toHaveBeenCalledWith(ds, expect.anything(), false);
   });
+
+  it('普通群 new-topic 模式开话题并锚定独立 thread-scope session', async () => {
+    const { daemon, registry, types } = modules;
+    const appId = 'app_join_new_topic';
+    const chatId = 'oc_join_new_topic';
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      defaultWorkingDir: tempDir('repo-new-topic'),
+      regularGroupReplyMode: 'new-topic',
+    });
+
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+
+    // 普通群（mode='group'）但 reply mode 是 new-topic：应像话题群一样开一个
+    // 独立话题（seed + thread-scope），而不是平铺进群顶层 chat-scope。
+    const ds = daemon.__testOnly_activeSessions.get(types.sessionKey('om_join_seed', appId));
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(ds?.scope).toBe('thread');
+    expect(ds?.session.rootMessageId).toBe('om_join_seed');
+    // new-topic 是独立会话（非 shared 复用），不 arm shared reply target。
+    expect(ds?.session.currentReplyTarget).toBeUndefined();
+    expect(mocks.forkWorker).toHaveBeenCalledWith(ds, expect.anything(), false);
+  });
 });


### PR DESCRIPTION
## 问题

配置了「自动进群」后，机器人主动开工没有延续群配的 `new-topic`，而是把首轮平铺进群顶层 chat。

## 根因

`handleBotAdded`（自动进群主动开工）挑选会话 scope 时只看群「类型」：话题群才开话题、普通群一律 chat-scope，完全没读群配的 reply mode。所以普通群设成 `new-topic` 后：
- 用户**手动 @** → 走 `event-dispatcher` 的 `regularGroupRouting`，正确开话题；
- 机器人**自动进群**首轮 → 绕过该判据，直接平铺进群顶层 chat-scope。

两条路径不一致。

## 修复

自动进群改用与入站 @ **完全同一套判据** `externalEventOpensOwnTopic(mode, regularGroupMode)`：
- 话题群 **或** 普通群 `new-topic` 模式 → seed 一个话题根并锚定独立 thread-scope 会话；
- 其余普通群（`chat` / `shared` / `chat-topic`）保持原行为不变。

`needsSharedReply` 复用同一个已解析的 `regularGroupMode`，避免重复读取。

## 影响面

仅 `daemon.ts` `handleBotAdded`（自动进群路径）。话题群、shared、chat、chat-topic 行为均不变；入站 @ 路由不受影响。

## 验证

- `pnpm build` 通过
- `test/group-join-shared-routing.test.ts` 16 例全绿，含新增用例「普通群 new-topic 模式开话题并锚定独立 thread-scope session」

（注：本 PR 重提自 #844 —— 该 PR 网页端返回 500 疑似 GitHub 侧对象损坏，改用新分支重开。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
