### PR TITLE
fix(codex-app): 修复斜杠命令卡住会话

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -172,11 +172,25 @@ export function resolveAdapterDefaultPassthroughCommands(larkAppId?: string): st
  * daemon commands must keep their daemon semantics, and passthrough is checked
  * BEFORE DAEMON_COMMANDS in the router, so an un-filtered custom `/status`
  * would hijack the daemon's own.
- * Unknown / no bot → falls back to the builtin set unchanged.
+ * Codex App deliberately resolves to an empty set because its runner speaks
+ * App Server rather than an interactive TUI; slash-looking text must use the
+ * structured turn lane. Unknown / no bot → falls back to the builtin set.
  */
-export function resolvePassthroughCommands(larkAppId?: string): Set<string> {
+export function resolvePassthroughCommands(larkAppId?: string, cliIdOverride?: string): Set<string> {
   const effective = new Set(PASSTHROUGH_COMMANDS);
   if (!larkAppId) return effective;
+  try {
+    const cliId = cliIdOverride ?? getBot(larkAppId).config.cliId;
+    // Codex App speaks the structured app-server protocol: its PTY only hosts
+    // botmux's runner/viewer and is not an interactive Codex TUI. Sending a
+    // slash command through raw_input therefore bypasses the App Server turn
+    // ledger; the model still completes the text as an ordinary turn, but the
+    // worker has no pending dispatch to attribute that final to and the session
+    // remains stuck. Keep these messages on the normal structured turn path.
+    if (cliId === 'codex-app') return new Set();
+  } catch {
+    /* unknown bot — builtin set only */
+  }
   for (const c of resolveAdapterDefaultPassthroughCommands(larkAppId)) {
     effective.add(c);
   }
@@ -3859,7 +3873,7 @@ export async function handleCommand(
           ? sessionCliDisplayName(ds)
           : configuredRuntimeDisplayName(botCfg?.cliRuntime)
             ?? getCliDisplayName(botCfg?.cliId ?? 'claude-code');
-        const passthroughCommands = [...resolvePassthroughCommands(helpAppId)];
+        const passthroughCommands = [...resolvePassthroughCommands(helpAppId, ds?.session.cliId)];
         const help = [
           t('help.heading_session', undefined, loc),
           t('help.close', { cliName }, loc),

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -151,11 +151,25 @@ export function formatSlashGroupName(name: string, prefix = ''): string {
  */
 export const EXISTING_SESSION_ONLY_DAEMON_COMMANDS = new Set(['/rename', '/fork', '/forklist']);
 
-export function resolveAdapterDefaultPassthroughCommands(larkAppId?: string): string[] {
+/**
+ * Adapter-scoped default passthrough commands (e.g. Codex's `/goal`).
+ *
+ * `cliIdOverride` lets a caller resolve against a session's FROZEN CLI instead
+ * of the bot's current config — an existing session keeps the runtime it was
+ * created with, so changing `/botconfig cli` must not silently strip an old
+ * interactive Codex session's adapter-scoped `/goal` (nor grant one to a Codex
+ * App session). `defaultPassthroughCommands` is a static per-adapter list and
+ * does not depend on the resolved binary, so when the override diverges from
+ * the bot's current CLI we intentionally drop `cliPathOverride` (it belongs to
+ * the other CLI) and let the adapter resolve with no path hint.
+ */
+export function resolveAdapterDefaultPassthroughCommands(larkAppId?: string, cliIdOverride?: string): string[] {
   if (!larkAppId) return [];
   try {
     const bot = getBot(larkAppId);
-    const adapter = createCliAdapterSync(bot.config.cliId, bot.config.cliPathOverride);
+    const cliId = (cliIdOverride ?? bot.config.cliId) as CliId;
+    const cliPathOverride = cliId === bot.config.cliId ? bot.config.cliPathOverride : undefined;
+    const adapter = createCliAdapterSync(cliId, cliPathOverride);
     const normalized = (adapter.defaultPassthroughCommands ?? [])
       .map(normalizePassthroughCommand)
       .filter((c): c is string => !!c);
@@ -179,19 +193,26 @@ export function resolveAdapterDefaultPassthroughCommands(larkAppId?: string): st
 export function resolvePassthroughCommands(larkAppId?: string, cliIdOverride?: string): Set<string> {
   const effective = new Set(PASSTHROUGH_COMMANDS);
   if (!larkAppId) return effective;
+  // Resolve the EFFECTIVE CLI once and thread it through every layer below
+  // (early return, adapter defaults). An existing session freezes its CLI, so
+  // the override must reach the adapter-scoped defaults too — otherwise a bot
+  // switched to Codex App would still read the current config there and drop a
+  // frozen interactive Codex session's `/goal` (or vice versa). undefined when
+  // the bot is unknown → builtin set only.
+  let effectiveCliId: string | undefined;
   try {
-    const cliId = cliIdOverride ?? getBot(larkAppId).config.cliId;
-    // Codex App speaks the structured app-server protocol: its PTY only hosts
-    // botmux's runner/viewer and is not an interactive Codex TUI. Sending a
-    // slash command through raw_input therefore bypasses the App Server turn
-    // ledger; the model still completes the text as an ordinary turn, but the
-    // worker has no pending dispatch to attribute that final to and the session
-    // remains stuck. Keep these messages on the normal structured turn path.
-    if (cliId === 'codex-app') return new Set();
+    effectiveCliId = cliIdOverride ?? getBot(larkAppId).config.cliId;
   } catch {
     /* unknown bot — builtin set only */
   }
-  for (const c of resolveAdapterDefaultPassthroughCommands(larkAppId)) {
+  // Codex App speaks the structured app-server protocol: its PTY only hosts
+  // botmux's runner/viewer and is not an interactive Codex TUI. Sending a
+  // slash command through raw_input therefore bypasses the App Server turn
+  // ledger; the model still completes the text as an ordinary turn, but the
+  // worker has no pending dispatch to attribute that final to and the session
+  // remains stuck. Keep these messages on the normal structured turn path.
+  if (effectiveCliId === 'codex-app') return new Set();
+  for (const c of resolveAdapterDefaultPassthroughCommands(larkAppId, effectiveCliId)) {
     effective.add(c);
   }
   try {
@@ -3827,29 +3848,44 @@ export async function handleCommand(
         //   ③ 用户在 bots.json 自定义配置的额外透传命令（customPassthroughCommands）
         //   ④ 文件系统自动发现的 CLI 自定义命令 / skill / 插件
         // MCP 的 /mcp__<server>__<prompt> 需运行时握手才能枚举，这里仅按 .mcp.json 提示 server 名。
+        // 展示口径必须与 resolvePassthroughCommands 的实际路由一致：既有会话按其
+        // 冻结的 CLI（session.cliId）解析，不偷读当前 bot 配置——否则切换默认 CLI 后
+        // 清单会与真正生效的透传集合漂移（Codex App 会话展示伪 passthrough，或旧交互
+        // 式会话丢掉 adapter-scoped 命令）。
         const botCfg = ds
           ? getBot(ds.larkAppId).config
           : (larkAppId ? getBot(larkAppId).config : getAllBots()[0]?.config);
-        const cliId = botCfg?.cliId ?? 'claude-code';
+        const effectiveCliId = (ds?.session.cliId ?? botCfg?.cliId ?? 'claude-code') as CliId;
         const cliName = ds
           ? sessionCliDisplayName(ds)
-          : configuredRuntimeDisplayName(botCfg?.cliRuntime) ?? getCliDisplayName(cliId);
+          : configuredRuntimeDisplayName(botCfg?.cliRuntime) ?? getCliDisplayName(effectiveCliId);
         const workingDir = getSessionWorkingDir(ds);
-        const builtin = [...PASSTHROUGH_COMMANDS];
-        const adapterDefaults = resolveAdapterDefaultPassthroughCommands(larkAppId);
+        // Codex App routes everything through the structured turn lane, so it has
+        // NO passthrough surface at all — mirror resolvePassthroughCommands's
+        // early empty return here and skip filesystem discovery (its PTY is the
+        // App Server runner, not an interactive TUI that would honor those).
+        const isCodexApp = effectiveCliId === 'codex-app';
+        const builtin = isCodexApp ? [] : [...PASSTHROUGH_COMMANDS];
+        const adapterDefaults = isCodexApp ? [] : resolveAdapterDefaultPassthroughCommands(larkAppId, effectiveCliId);
         // 只展示「实际生效」的 custom 命令：用与 resolvePassthroughCommands 同一套
         // normalize 过滤掉手写 bots.json 里遮蔽 daemon 命令 / 非法的项（parser 出于
         // 兼容会保留它们，但路由会丢弃），避免 `/status` 之类被展示成可用却走 daemon。
-        const custom = [...new Set(
+        // Codex App 无透传面，custom 也不生效 → 与路由一致清空。
+        const custom = isCodexApp ? [] : [...new Set(
           (botCfg?.customPassthroughCommands ?? [])
             .map(normalizePassthroughCommand)
             .filter((c): c is string => !!c),
         )];
+        // 文件发现按有效会话 CLI 解析；跨 CLI（冻结 ≠ 当前配置）时不套用当前配置的
+        // cliPathOverride（它属于另一个 CLI）。Codex App 直接跳过发现。
+        const adapterPathOverride = effectiveCliId === botCfg?.cliId ? botCfg?.cliPathOverride : undefined;
         let cliAdapter;
-        try {
-          cliAdapter = createCliAdapterSync(cliId, botCfg?.cliPathOverride);
-        } catch (err) {
-          logger.warn(`[${logTag}] /list-slash-command could not create adapter for ${cliId}: ${err instanceof Error ? err.message : String(err)}`);
+        if (!isCodexApp) {
+          try {
+            cliAdapter = createCliAdapterSync(effectiveCliId, adapterPathOverride);
+          } catch (err) {
+            logger.warn(`[${logTag}] /list-slash-command could not create adapter for ${effectiveCliId}: ${err instanceof Error ? err.message : String(err)}`);
+          }
         }
         const discoverySupported = supportsFilesystemCommandDiscovery(cliAdapter);
         const discovered = cliAdapter && discoverySupported

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -18374,7 +18374,12 @@ async function handleThreadReplyAdmitted(
       });
       return;
     }
-    if (resolvePassthroughCommands(larkAppId).has(cmd)) {
+    // Existing sessions freeze their CLI independently from the bot's current
+    // config. Route passthrough capability from that frozen runtime so changing
+    // `/botconfig cli` cannot make an old Codex App session receive raw_input
+    // (or make an old interactive TUI lose its native slash commands).
+    const passthroughCliId = existingDs?.session.cliId ?? getBot(larkAppId).config.cliId;
+    if (resolvePassthroughCommands(larkAppId, passthroughCliId).has(cmd)) {
       if (!existingDs && threadChatId && isInitialSessionPassthrough(larkAppId, cmd)) {
         await startInitialPassthroughSession({
           larkAppId,

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -1100,6 +1100,21 @@ describe('PASSTHROUGH_COMMANDS set', () => {
     }
   });
 
+  it('keeps raw passthrough off Codex App while honoring a frozen session CLI override', () => {
+    mockCodexAppBot();
+
+    // App Server turns must use the structured message lane; raw_input has no
+    // matching dispatch reservation and would leave the session stuck after
+    // the model final arrives.
+    expect(resolvePassthroughCommands(CODEX_APP_ID).size).toBe(0);
+
+    // Existing sessions freeze their CLI. A pre-switch interactive Codex
+    // session must retain native slash passthrough even if the bot config now
+    // points at Codex App, while the inverse must stay structured.
+    expect(resolvePassthroughCommands(CODEX_APP_ID, 'codex').has('/model')).toBe(true);
+    expect(resolvePassthroughCommands(LARK_APP_ID, 'codex-app').size).toBe(0);
+  });
+
   it('keeps /goal out of the global passthrough list but enables it for Claude and Codex adapters', () => {
     expect(PASSTHROUGH_COMMANDS.has('/goal')).toBe(false);
     expect(resolvePassthroughCommands('app-1').has('/goal')).toBe(true);

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -755,6 +755,35 @@ describe('/list-slash-command discovery', () => {
     }
   });
 
+  it('mirrors the frozen CLI in the listing: Codex App shows NO passthrough, interactive Codex keeps /goal', async () => {
+    mockCodexAppBot(); // bot CURRENT config.cliId = 'codex-app'
+
+    // A session frozen as Codex App: the runner has no passthrough surface, so
+    // builtin + adapter + custom must all render empty (matching the router's
+    // early empty return) — never a fake `/model`/`/compact` passthrough list.
+    const appDs = makeDaemonSession({
+      larkAppId: CODEX_APP_ID,
+      session: makeSession({ cliId: 'codex-app' }),
+    });
+    await handleCommand('/slash', ROOT_ID, makeLarkMessage('/slash'), makeDeps(appDs), CODEX_APP_ID);
+    expect(buildSlashListCard).toHaveBeenLastCalledWith(
+      expect.objectContaining({ builtin: [], adapterDefaults: [], custom: [] }),
+      expect.anything(),
+    );
+
+    // Inverse: bot flipped to Codex App but this session is frozen as
+    // interactive Codex → listing keeps builtin + the adapter-scoped /goal.
+    vi.mocked(buildSlashListCard).mockClear();
+    const tuiDs = makeDaemonSession({
+      larkAppId: CODEX_APP_ID,
+      session: makeSession({ cliId: 'codex' }),
+    });
+    await handleCommand('/slash', ROOT_ID, makeLarkMessage('/slash'), makeDeps(tuiDs), CODEX_APP_ID);
+    const call = vi.mocked(buildSlashListCard).mock.calls.at(-1)?.[0] as any;
+    expect(call.builtin).toContain('/model');
+    expect(call.adapterDefaults).toContain('/goal');
+  });
+
   it('shows only effective custom passthrough commands (drops daemon-shadow + junk, normalizes)', async () => {
     // 手写 bots.json 可能留下 `/status`（遮蔽 daemon 命令，parser 出于兼容会保留但
     // 路由会丢弃）、非法项、大小写不一；展示侧须与 resolvePassthroughCommands 同口径。
@@ -1113,6 +1142,25 @@ describe('PASSTHROUGH_COMMANDS set', () => {
     // points at Codex App, while the inverse must stay structured.
     expect(resolvePassthroughCommands(CODEX_APP_ID, 'codex').has('/model')).toBe(true);
     expect(resolvePassthroughCommands(LARK_APP_ID, 'codex-app').size).toBe(0);
+  });
+
+  it('threads the frozen CLI through the ADAPTER-SCOPED layer, not just the builtin set', () => {
+    // Regression for the earlier miss: the override only guarded the codex-app
+    // early return, so `resolveAdapterDefaultPassthroughCommands` still read the
+    // bot's CURRENT config. When the bot default flips codex→codex-app, a frozen
+    // interactive Codex session then LOST its adapter-scoped `/goal` (it fell
+    // through as a plain message instead of raw_input). Builtin `/model` masked
+    // this because it never touches the adapter layer — so assert `/goal`.
+    mockCodexAppBot(); // bot CURRENT config.cliId = 'codex-app'
+
+    // Frozen interactive Codex session (override='codex'): keeps native /goal.
+    expect(resolvePassthroughCommands(CODEX_APP_ID, 'codex').has('/goal')).toBe(true);
+    expect(resolveAdapterDefaultPassthroughCommands(CODEX_APP_ID, 'codex')).toContain('/goal');
+    // No override → reads current codex-app config → adapter layer is empty.
+    expect(resolveAdapterDefaultPassthroughCommands(CODEX_APP_ID)).not.toContain('/goal');
+    // Inverse: a bot whose current CLI is codex, frozen as codex-app → nothing.
+    expect(resolvePassthroughCommands('app-2', 'codex-app').size).toBe(0);
+    expect(resolveAdapterDefaultPassthroughCommands('app-2', 'codex-app')).not.toContain('/goal');
   });
 
   it('keeps /goal out of the global passthrough list but enables it for Claude and Codex adapters', () => {

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -1672,6 +1672,79 @@ describe('/rename production routing — must not pre-create a session (review P
     });
   });
 
+  it('routes the ADAPTER-SCOPED /goal by frozen CLI too (not just builtin /model)', async () => {
+    // Builtin `/model` lives in PASSTHROUGH_COMMANDS and never touches the
+    // adapter layer, so it can mask a bug where the frozen CLI fails to reach
+    // resolveAdapterDefaultPassthroughCommands. `/goal` IS adapter-scoped
+    // (codex only), so it is the command that actually proves the override is
+    // threaded all the way through. Before the fix, the first leg below sent a
+    // structured `message` instead of `raw_input`.
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'codex-app',
+      allowedUsers: [OWNER],
+      oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
+    });
+    bot.resolvedAllowedUsers = [OWNER];
+
+    // Bot default flipped to Codex App, but this session is frozen as
+    // interactive Codex → its native adapter `/goal` must stay raw_input.
+    const tuiSend = vi.fn();
+    const tuiSession = seedLiveChatSession(tuiSend);
+    tuiSession.session.cliId = 'codex';
+    await handleThreadReply(
+      makeEventData('om_goal_tui', '/goal', 'om_goal_tui_root'),
+      {
+        chatId: CHAT,
+        messageId: 'om_goal_tui',
+        chatType: 'group',
+        scope: 'chat',
+        anchor: CHAT,
+        replyRootId: 'om_goal_tui_root',
+        larkAppId: APP,
+      },
+    );
+    expect(tuiSend).toHaveBeenCalledWith({
+      type: 'raw_input',
+      content: '/goal',
+      turnId: 'om_goal_tui',
+    });
+
+    // Inverse: bot default is interactive Codex, but a frozen Codex App session
+    // has NO passthrough surface → `/goal` must go structured, never raw_input.
+    activeSessions.clear();
+    const codexDefault = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'codex',
+      allowedUsers: [OWNER],
+      oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
+    });
+    codexDefault.resolvedAllowedUsers = [OWNER];
+    const appSend = vi.fn();
+    const appSession = seedLiveChatSession(appSend);
+    appSession.session.cliId = 'codex-app';
+    await handleThreadReply(
+      makeEventData('om_goal_app', '/goal', 'om_goal_app_root'),
+      {
+        chatId: CHAT,
+        messageId: 'om_goal_app',
+        chatType: 'group',
+        scope: 'chat',
+        anchor: CHAT,
+        replyRootId: 'om_goal_app_root',
+        larkAppId: APP,
+      },
+    );
+    expect(appSend).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'raw_input' }));
+    expect(appSend).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'message',
+      turnId: 'om_goal_app',
+      content: expect.stringContaining('/goal'),
+    }));
+  });
+
   it('fails closed on /fast for RPC-input / Riff backends (no raw_input, clear reply)', async () => {
     const bot = registerBot({
       larkAppId: APP,

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -1604,6 +1604,74 @@ describe('/rename production routing — must not pre-create a session (review P
     expect(repliedText()).toMatch(/需要活跃的 CLI 进程|需要在已有会话内使用/);
   });
 
+  it('routes slash text by the frozen session CLI: Codex App structured, interactive Codex raw', async () => {
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'codex',
+      allowedUsers: [OWNER],
+      oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
+    });
+    bot.resolvedAllowedUsers = [OWNER];
+
+    // The bot currently defaults to interactive Codex, but this existing
+    // session was created as Codex App. `/model` must enter the ordinary App
+    // Server turn lane so worker dispatch attribution is reserved.
+    const appSend = vi.fn();
+    const appSession = seedLiveChatSession(appSend);
+    appSession.session.cliId = 'codex-app';
+    await handleThreadReply(
+      makeEventData('om_model_app', '/model', 'om_model_app_root'),
+      {
+        chatId: CHAT,
+        messageId: 'om_model_app',
+        chatType: 'group',
+        scope: 'chat',
+        anchor: CHAT,
+        replyRootId: 'om_model_app_root',
+        larkAppId: APP,
+      },
+    );
+    expect(appSend).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'raw_input' }));
+    expect(appSend).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'message',
+      turnId: 'om_model_app',
+      content: expect.stringContaining('/model'),
+    }));
+
+    // Inverse control: changing the bot default to Codex App must not remove
+    // native slash support from an already-running interactive Codex session.
+    activeSessions.clear();
+    const appDefault = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'codex-app',
+      allowedUsers: [OWNER],
+      oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
+    });
+    appDefault.resolvedAllowedUsers = [OWNER];
+    const tuiSend = vi.fn();
+    const tuiSession = seedLiveChatSession(tuiSend);
+    tuiSession.session.cliId = 'codex';
+    await handleThreadReply(
+      makeEventData('om_model_tui', '/model', 'om_model_tui_root'),
+      {
+        chatId: CHAT,
+        messageId: 'om_model_tui',
+        chatType: 'group',
+        scope: 'chat',
+        anchor: CHAT,
+        replyRootId: 'om_model_tui_root',
+        larkAppId: APP,
+      },
+    );
+    expect(tuiSend).toHaveBeenCalledWith({
+      type: 'raw_input',
+      content: '/model',
+      turnId: 'om_model_tui',
+    });
+  });
+
   it('fails closed on /fast for RPC-input / Riff backends (no raw_input, clear reply)', async () => {
     const bot = registerBot({
       larkAppId: APP,


### PR DESCRIPTION
## 改了什么

- Codex App 不再把 `/model`、`/compact` 等斜杠文本送进 TUI `raw_input`，统一落到有 dispatch 归属的 App Server 结构化消息通道。
- 已存在会话按创建时冻结的 `cliId` 判断路由，避免修改机器人默认 CLI 后旧会话走错输入通道。
- `/help` 同样按冻结的会话 CLI 展示实际生效的 passthrough 命令。
- 增加 Codex App 与交互式 Codex 双向切换的路由回归测试。

## 为什么

Codex App 的 PTY 承载的是 botmux runner/viewer，并不是可接收原生斜杠命令的交互式 Codex TUI。之前 `/model` 被作为 `raw_input` 写入后，App Server 仍会产出模型 final，但 worker 没有对应的 pending dispatch，final 因 `no_pending_turn` 被拒绝，飞书侧最终显示“长时间无进展”，会话也会卡住。

## 影响面

- 改动位于 daemon 共用路由层，但仅对冻结 CLI 为 `codex-app` 的会话关闭 raw passthrough。
- 交互式 Codex、Claude Code 和其他 TUI CLI 的原生 passthrough 行为保持不变。
- 新话题与既有会话均覆盖；配置切换前后的既有会话按各自冻结 CLI 路由。
- 不涉及平台专用路径或 PTY/Tmux backend 实现，macOS/Linux 行为一致。

## 验证

- `corepack pnpm vitest run test/command-handler.test.ts test/daemon-rename-route.test.ts --reporter=verbose`：315/315 通过。
- `corepack pnpm vitest run test/worker-codex-app-turn-routing.integration.test.ts --reporter=verbose`：8/8 通过。
- 固定仓库声明的 pnpm 9.5.0 后执行 `pnpm build`：通过。
- 全量并行 `pnpm test`：14,750 通过、30 失败；失败集中在未改动的高负载超时、Darwin 实时资源采样、已有 `/introduce` 文档同步和并行期间 `dist/cli.js` 缺失，修改涉及的测试均单独复跑全绿。
- PR CI 重跑时依赖安装与 build 通过，`pnpm test` 的 `/introduce` 文档缺失及 Codex App runner 超时与当前 master 的 [CI #31615587151](https://github.com/deepcoldy/botmux/actions/runs/31615587151) 一致。
- 尝试 `pnpm daemon:restart` 时，旧版 live daemon 缺少 `riff-fleet-prepare-persist-commit-managed-sentinel-v3` 关停能力，被安全门拒绝；未绕过保护执行 bootstrap 重启。
