### PR TITLE
feat(dashboard): 版本升级弹窗加进度环，收敛三处转圈为唯一指示

### DIFF
--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -565,6 +565,7 @@ function TopbarVersionControl(props: {
   const { status } = props;
   const [open, setOpen] = useState(false);
   const [phase, setPhase] = useState<TopbarUpdatePhase>('idle');
+  const [progress, setProgress] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
   const [refreshFailed, setRefreshFailed] = useState(false);
   const [errorDetail, setErrorDetail] = useState('');
@@ -577,6 +578,7 @@ function TopbarVersionControl(props: {
   const [activeRollback, setActiveRollback] = useState<string | null>(null);
   const actionInFlightRef = useRef(false);
   const reconnectTimerRef = useRef<number | null>(null);
+  const progressTimerRef = useRef<number | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLElement>(null);
@@ -588,9 +590,16 @@ function TopbarVersionControl(props: {
     reconnectTimerRef.current = null;
   };
 
+  const clearProgressTimer = () => {
+    if (progressTimerRef.current === null) return;
+    window.clearInterval(progressTimerRef.current);
+    progressTimerRef.current = null;
+  };
+
   useEffect(() => {
     actionInFlightRef.current = false;
     setPhase('idle');
+    setProgress(0);
     setRefreshing(false);
     setRefreshFailed(false);
     setErrorDetail('');
@@ -602,6 +611,25 @@ function TopbarVersionControl(props: {
     setSelectedRollback(null);
     setActiveRollback(null);
   }, [status?.current, status?.latest]);
+
+  // Faux progress bar. npm install gives no reliable percentage, so we creep a
+  // deliberately-capped bar per phase: install climbs toward 50% (the real
+  // install ends there), restart+reconnect climbs toward ~95%; the actual
+  // reconnect reload finishes the job, so we never fake a 100%. Reset to 0 on
+  // idle/error clears it.
+  useEffect(() => {
+    clearProgressTimer();
+    if (phase === 'idle' || phase === 'error') {
+      setProgress(0);
+      return;
+    }
+    const cap = phase === 'updating' ? 50 : 95;
+    if (phase === 'restarting') setProgress(value => Math.max(value, 50));
+    progressTimerRef.current = window.setInterval(() => {
+      setProgress(value => (value >= cap ? cap : value + Math.max(0.5, (cap - value) * 0.08)));
+    }, 400);
+    return () => clearProgressTimer();
+  }, [phase]);
 
   useEffect(() => {
     if (status) setRefreshFailed(status.versionLookupOk === false);
@@ -651,7 +679,7 @@ function TopbarVersionControl(props: {
     };
   }, [open]);
 
-  useEffect(() => () => clearReconnectTimer(), []);
+  useEffect(() => () => { clearReconnectTimer(); clearProgressTimer(); }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -680,6 +708,11 @@ function TopbarVersionControl(props: {
   const automatic = behind && status.updateSupported && !status.localDevInstall && status.node.ok;
   const rollbackSupported = status.updateSupported && !status.localDevInstall && status.node.ok;
   const busy = phase === 'updating' || phase === 'restarting';
+  // Progress-ring geometry. R=20 → circumference C; the arc fills clockwise
+  // from 12 o'clock for `progress`%.
+  const RING_R = 20;
+  const RING_C = 2 * Math.PI * RING_R;
+  const ringDashoffset = RING_C * (1 - Math.max(2, Math.round(progress)) / 100);
   const command = status.updateCommand ?? 'botmux update';
   const currentVersion = `v${status.current}`;
   const latestVersion = status.latest ? `v${status.latest}` : '';
@@ -899,9 +932,35 @@ function TopbarVersionControl(props: {
           <div className="dashboard-version-popover-body">
             <div className="dashboard-version-current">
               <strong>{currentVersion}</strong>
-              <span className={versionSignal.className} aria-hidden="true">
-                {busy ? <span className="dashboard-update-spinner" /> : versionSignal.symbol}
-              </span>
+              {busy ? (
+                <span
+                  className="dashboard-version-ring"
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={Math.round(progress)}
+                  aria-label={message}
+                >
+                  <svg viewBox="0 0 44 44" width="44" height="44" aria-hidden="true">
+                    <defs>
+                      <linearGradient id="dvr-grad" x1="0%" y1="100%" x2="100%" y2="0%">
+                        <stop offset="0%" stopColor="var(--brand-accent-cyan)" />
+                        <stop offset="55%" stopColor="var(--accent)" />
+                        <stop offset="100%" stopColor="var(--brand-accent-pink)" />
+                      </linearGradient>
+                    </defs>
+                    <circle className="dvr-track" cx="22" cy="22" r="20" />
+                    <circle
+                      className="dvr-arc"
+                      cx="22" cy="22" r="20"
+                      style={{ strokeDasharray: RING_C, strokeDashoffset: ringDashoffset }}
+                    />
+                  </svg>
+                  <span className="dvr-pct">{Math.round(progress)}%</span>
+                </span>
+              ) : (
+                <span className={versionSignal.className} aria-hidden="true">{versionSignal.symbol}</span>
+              )}
             </div>
             <p
               className={`dashboard-version-message${phase === 'error' || refreshFailed ? ' is-error' : ''}`}
@@ -1035,7 +1094,6 @@ function TopbarVersionControl(props: {
                 disabled={busy}
                 onClick={() => void run()}
               >
-                {busy ? <span className="dashboard-update-spinner" aria-hidden="true" /> : null}
                 {action}
               </button>
             </footer>

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -889,12 +889,10 @@ function TopbarVersionControl(props: {
         onClick={() => setOpen(value => !value)}
       >
         <span>{currentVersion}</span>
-        {busy
-          ? <span className="dashboard-update-spinner" aria-hidden="true" />
-          : <span
-              className={`dashboard-version-state ${versionSignal.className}`}
-              aria-hidden="true"
-            >{versionSignal.symbol}</span>}
+        <span
+          className={`dashboard-version-state ${versionSignal.className}`}
+          aria-hidden="true"
+        >{versionSignal.symbol}</span>
       </button>
       {open && popoverPosition && typeof document !== 'undefined' ? createPortal((
         <section

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -8601,14 +8601,12 @@ button.dashboard-version-refresh.is-refreshing svg {
   color: var(--danger);
   overflow-wrap: anywhere;
 }
-.dashboard-version-ring { position: relative; display: inline-flex; flex: none; width: 44px; height: 44px; }
+.dashboard-version-current > span.dashboard-version-ring { position: relative; display: inline-flex; place-items: unset; flex: none; width: 44px; height: 44px; border-radius: 0; }
 .dashboard-version-ring svg { display: block; width: 44px; height: 44px; }
 .dvr-track { fill: none; stroke: color-mix(in srgb, var(--muted) 26%, transparent); stroke-width: 4; }
 .dvr-arc { fill: none; stroke: url(#dvr-grad); stroke-width: 4; stroke-linecap: round; transform: rotate(-90deg); transform-origin: 50% 50%; transition: stroke-dashoffset 0.4s ease; animation: dvr-breathe 1.8s ease-in-out infinite; }
 @keyframes dvr-breathe { 0%, 100% { opacity: 1; } 50% { opacity: 0.55; } }
 .dvr-pct { position: absolute; inset: 0; display: grid; place-items: center; font-family: "Geist Mono", var(--mono); font-size: 11px; font-weight: 700; line-height: 1; text-align: center; font-variant-numeric: tabular-nums; color: var(--accent-strong); }
-.dashboard-version-ring.is-error .dvr-arc { stroke: var(--danger); animation: none; opacity: 1; }
-.dashboard-version-ring.is-error .dvr-pct { color: var(--danger); }
 @media (prefers-reduced-motion: reduce) { .dvr-arc { transition: none; animation: none; opacity: 1; } }
 .dashboard-version-release-link {
   display: inline-flex;
@@ -10179,36 +10177,6 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
   grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
   gap: 14px;
   align-items: start;
-}
-.overview-layout.schedules-collapsed {
-  grid-template-columns: minmax(0, 1fr);
-}
-.overview-layout.schedules-collapsed .overview-side {
-  grid-column: 1 / -1;
-}
-.schedules-collapse-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm, 6px);
-  background: transparent;
-  color: var(--fg-muted, var(--fg));
-  cursor: pointer;
-  transition: color 0.15s, border-color 0.15s, transform 0.15s;
-}
-.schedules-collapse-toggle:hover {
-  color: var(--fg);
-  border-color: var(--accent);
-}
-.schedules-collapse-toggle svg {
-  transition: transform 0.15s;
-}
-.schedules-collapse-toggle[aria-expanded="false"] svg {
-  transform: rotate(-90deg);
 }
 .overview-main {
   display: grid;

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -8601,6 +8601,15 @@ button.dashboard-version-refresh.is-refreshing svg {
   color: var(--danger);
   overflow-wrap: anywhere;
 }
+.dashboard-version-ring { position: relative; display: inline-flex; flex: none; width: 44px; height: 44px; }
+.dashboard-version-ring svg { display: block; width: 44px; height: 44px; }
+.dvr-track { fill: none; stroke: color-mix(in srgb, var(--muted) 26%, transparent); stroke-width: 4; }
+.dvr-arc { fill: none; stroke: url(#dvr-grad); stroke-width: 4; stroke-linecap: round; transform: rotate(-90deg); transform-origin: 50% 50%; transition: stroke-dashoffset 0.4s ease; animation: dvr-breathe 1.8s ease-in-out infinite; }
+@keyframes dvr-breathe { 0%, 100% { opacity: 1; } 50% { opacity: 0.55; } }
+.dvr-pct { position: absolute; inset: 0; display: grid; place-items: center; font-family: "Geist Mono", var(--mono); font-size: 11px; font-weight: 700; line-height: 1; text-align: center; font-variant-numeric: tabular-nums; color: var(--accent-strong); }
+.dashboard-version-ring.is-error .dvr-arc { stroke: var(--danger); animation: none; opacity: 1; }
+.dashboard-version-ring.is-error .dvr-pct { color: var(--danger); }
+@media (prefers-reduced-motion: reduce) { .dvr-arc { transition: none; animation: none; opacity: 1; } }
 .dashboard-version-release-link {
   display: inline-flex;
   align-items: center;
@@ -10170,6 +10179,36 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
   grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
   gap: 14px;
   align-items: start;
+}
+.overview-layout.schedules-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+}
+.overview-layout.schedules-collapsed .overview-side {
+  grid-column: 1 / -1;
+}
+.schedules-collapse-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--fg-muted, var(--fg));
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, transform 0.15s;
+}
+.schedules-collapse-toggle:hover {
+  color: var(--fg);
+  border-color: var(--accent);
+}
+.schedules-collapse-toggle svg {
+  transition: transform 0.15s;
+}
+.schedules-collapse-toggle[aria-expanded="false"] svg {
+  transform: rotate(-90deg);
 }
 .overview-main {
   display: grid;


### PR DESCRIPTION
## 改了什么

版本升级弹窗「升级进行中」态原本有三处各自转圈的 spinner——版本号旁一个、主按钮里一个、顶栏 chip 上一个——重复且视觉杂乱、冷暖配色不协调。本 PR 把它们收敛为**版本号旁一个环形进度环**，作为唯一的进度 + 活动指示。

- 环心显示实时百分比；渐变弧（品牌 cyan→indigo→pink，复用现有 token）按 `progress` 填充。新增一个按相位爬升的假进度定时器：install 阶段爬到 50% 封顶，restart/reconnect 爬到 95%，最后真实 reconnect reload 完成整个升级，不伪造 100%（npm install 拿不到真实百分比，故用封顶假进度）。
- 平台期（卡在 50%/95%）靠渐变弧透明度轻微呼吸（1.8s）表达"仍在处理"。
- 删除上述三处 spinner 中的两处（版本号旁、主按钮里）并把顶栏 chip 的 busy spinner 也去掉，busy 时 chip 只显静态状态符号。`.dashboard-update-spinner` 保留（回退版本列表加载态两处仍在用）。
- 明暗主题自适应；尊重 `prefers-reduced-motion`（关呼吸、保留静态渐变弧）。错误态仍沿用既有 chip 上的 `!` 徽标（本 PR 不新增错误态环）。

## 为什么

原升级态多个"在转"的 spinner 堆叠，重复且不协调。用一个能同时表达进度与活动的进度环替代，视觉更聚焦、信息更明确。

## 影响面

仅前端两文件：`src/dashboard/web/app.tsx`（进度环 SVG 渲染 + 几何计算，去三处 spinner）、`src/dashboard/web/style.css`（进度环样式 + 呼吸动画）。不涉及后端、其它 CLI、其它会话类型；升级/回退的接口契约未变。

## 验证

- `pnpm build` 通过；`tsc --noEmit` 对全仓无报错。
- 进度环容器特异度已修：`.dashboard-version-current > span.dashboard-version-ring` 覆盖既有 `.dashboard-version-current > span` 的 24×24 grid 约束，环恢复 44×44、百分比与 SVG 同心。
- 顶栏 chip 的重复 spinner、以及一处不可达的 error-ring 死 CSS 均已删除，不再有重复活动指示器。
- `git diff --check` 干净；对当前 master `merge-tree` 无冲突；净改动收敛回上述两文件。

> 后续补：升级进行中态的真机截图（需在低版本实例上触发升级态截取进度环）。
