### PR TITLE
fix(lark): 复用话题状态卡片并完善执行反馈

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -221,6 +221,9 @@ export interface DaemonSession {
   streamCardTurnGeneration?: number;
   /** Exact newest turn awaiting its own streaming card. In-memory only. */
   streamCardPendingTurnId?: string;
+  /** Exact accepted turn whose visual events may mutate the stable thread card.
+   * Older worker screen/screenshot events are ignored after type-ahead. */
+  streamCardVisualTurnId?: string;
   pendingLocalCliButtonRefresh?: boolean; // true when cli_session_id arrived while the streaming card POST was in flight
   pendingRiffUrlCardRefresh?: boolean; // true when riff_access_url arrived while the streaming card POST was in flight
   /** Set on sessions restored after a daemon restart: suppresses the automatic

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -335,8 +335,9 @@ export interface DaemonSession {
   pendingCardJson?: string;       // queued card JSON — flushed when in-flight PATCH completes (latest wins)
   pendingCardId?: string;         // card message_id captured at schedule time — prevents stale reads when streamCardId changes between schedule and flush
   pendingCardTurnId?: string;     // exact turn that produced pendingCardJson; undefined for predecessor/auxiliary snapshots
-  /** Exact reused-card turn that should fall back to POST if this queued PATCH
-   *  discovers the persisted message was withdrawn. In-memory only. */
+  /** Exact reused-card turn that should fall back to POST if any same-turn
+   *  PATCH fails. Kept across successful PATCHes for the active generation;
+   *  in-memory only. */
   pendingCardWithdrawFallback?: { turnId: string; generation: number };
   frozenCards?: Map<string, FrozenCard>;  // nonce → FrozenCard (historical cards' cached state for toggle)
   /** Wait Mode / HTTP Sync integration: pending Promise handlers for synchronous

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -334,6 +334,7 @@ export interface DaemonSession {
   cardPatchInFlight?: boolean;    // true while a card PATCH is in-flight
   pendingCardJson?: string;       // queued card JSON — flushed when in-flight PATCH completes (latest wins)
   pendingCardId?: string;         // card message_id captured at schedule time — prevents stale reads when streamCardId changes between schedule and flush
+  pendingCardTurnId?: string;     // exact turn that produced pendingCardJson; undefined for predecessor/auxiliary snapshots
   /** Exact reused-card turn that should fall back to POST if this queued PATCH
    *  discovers the persisted message was withdrawn. In-memory only. */
   pendingCardWithdrawFallback?: { turnId: string; generation: number };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -331,6 +331,9 @@ export interface DaemonSession {
   cardPatchInFlight?: boolean;    // true while a card PATCH is in-flight
   pendingCardJson?: string;       // queued card JSON — flushed when in-flight PATCH completes (latest wins)
   pendingCardId?: string;         // card message_id captured at schedule time — prevents stale reads when streamCardId changes between schedule and flush
+  /** Exact reused-card turn that should fall back to POST if this queued PATCH
+   *  discovers the persisted message was withdrawn. In-memory only. */
+  pendingCardWithdrawFallback?: { turnId: string; generation: number };
   frozenCards?: Map<string, FrozenCard>;  // nonce → FrozenCard (historical cards' cached state for toggle)
   /** Wait Mode / HTTP Sync integration: pending Promise handlers for synchronous
    *  webhook triggers waiting for a response in this session. Key is turnId. */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -246,13 +246,16 @@ export interface DaemonSession {
    *  command so a user can manually summon a live card in an otherwise-quiet
    *  session. In-memory only (resets on daemon restart). */
   streamingCardForced?: boolean;
-  /** Two-phase turn reactions (auto-on for card-off sessions, i.e. streaming
-   *  card disabled). The bot reacts 冲! on each user message the moment it's accepted for the session
-   *  (bound to the message, NOT a worker status edge — so type-ahead / busy-
-   *  batched messages each get their own reaction). Every pending ✋ here is
-   *  flipped to ✅ when the turn returns to idle. In-memory only (a daemon
-   *  restart mid-turn just leaves a stale ✋ — purely cosmetic). */
-  pendingAckReactions?: Array<{ messageId: string; reactionId?: string }>;
+  /** Turn progress reactions bound to the triggering user message. Card-off
+   *  turns flip the received reaction to DONE at idle; thread turns with a
+   *  live status card remove it only once the reply is delivered. In-memory
+   *  only. */
+  pendingAckReactions?: Array<{
+    messageId: string;
+    reactionId?: string;
+    turnId?: string;
+    clearOnReply?: boolean;
+  }>;
   /** Card body display mode. Default 'hidden'. When user clicks 显示输出, defaults to 'screenshot'. */
   displayMode?: DisplayMode;
   /** Latest uploaded screenshot image_key for the streaming card. */

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -8089,14 +8089,36 @@ function setupWorkerHandlers(
           && msg.turnId
           && msg.turnId !== ds.streamCardVisualTurnId
         );
-        const preservedCardContent = ds.lastScreenContent;
-        const preservedCardStatus = ds.lastScreenStatus;
+        if (supersededCardVisual) {
+          const supersededTurnId = msg.turnId!;
+          const settledStatus = msg.usageLimit ? 'limited' : msg.status;
+          // This event still closes the older turn's accounting boundary, but
+          // it no longer represents the current session projection. In
+          // particular, do not borrow N+1's lastScreenStatus to manufacture a
+          // dashboard/lifecycle edge, clear its usage timer, or satisfy its
+          // deferred suspend claim.
+          if (settledStatus === 'idle' || settledStatus === 'limited') {
+            recordUsageForDaemonSession(ds, { turnId: supersededTurnId });
+          }
+          if (
+            settledStatus === 'idle'
+            && ds.session.deferredScheduleRun?.turnId === supersededTurnId
+          ) {
+            void cb.onDeferredScheduleTurnSettled?.(ds, { turnId: supersededTurnId, source: 'idle' });
+          }
+          if (settledStatus === 'idle' && cb.enforceLiveSessionCap) {
+            queueMicrotask(cb.enforceLiveSessionCap);
+          }
+          logger.debug(
+            `[${t}] Settled bookkeeping but ignored card/session projection for superseded turn ${supersededTurnId.substring(0, 12)} `
+            + `(card owner ${ds.streamCardVisualTurnId!.substring(0, 12)})`,
+          );
+          break;
+        }
         const prevStatus = ds.lastScreenStatus;
-        if (!supersededCardVisual) updateUsageLimitState(ds, msg.usageLimit);
+        updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenContent = msg.content;
-        ds.lastScreenStatus = (msg.usageLimit ?? (supersededCardVisual ? undefined : ds.usageLimit))
-          ? 'limited'
-          : msg.status;
+        ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
         // A suspend that arrived mid-turn parked itself here. Defer until this
         // screen_update has finished using process state — suspendWorker nulls
         // `worker` + `lastScreenStatus`, which everything below still reads
@@ -8174,16 +8196,6 @@ function setupWorkerHandlers(
             // The newly-idle session itself may be the oldest eviction target.
             queueMicrotask(cb.enforceLiveSessionCap);
           }
-        }
-
-        if (supersededCardVisual) {
-          ds.lastScreenContent = preservedCardContent;
-          ds.lastScreenStatus = preservedCardStatus;
-          logger.debug(
-            `[${t}] Kept bookkeeping but ignored card update for superseded turn ${msg.turnId!.substring(0, 12)} `
-            + `(card owner ${ds.streamCardVisualTurnId!.substring(0, 12)})`,
-          );
-          break;
         }
 
         if (managedAuxUiSuppressed(msg.turnId, msg.dispatchAttempt)) { clearUsageRefreshTimer(ds); break; }
@@ -8332,17 +8344,20 @@ function setupWorkerHandlers(
           && msg.turnId
           && msg.turnId !== ds.streamCardVisualTurnId
         );
-        const preservedCardImageKey = ds.currentImageKey;
-        const preservedCardStatus = ds.lastScreenStatus;
+        if (supersededCardVisual) {
+          logger.debug(
+            `[${t}] Ignored screenshot/session projection for superseded turn ${msg.turnId!.substring(0, 12)} `
+            + `(card owner ${ds.streamCardVisualTurnId!.substring(0, 12)})`,
+          );
+          break;
+        }
         // Drop uploads that arrived during a new-turn handoff — the image_key may
         // reflect previous turn's content. Next 10s cycle picks up fresh content.
         if (ds.streamCardPending) break;
         ds.currentImageKey = msg.imageKey;
         const prevStatus = ds.lastScreenStatus;
-        if (!supersededCardVisual) updateUsageLimitState(ds, msg.usageLimit);
-        ds.lastScreenStatus = (msg.usageLimit ?? (supersededCardVisual ? undefined : ds.usageLimit))
-          ? 'limited'
-          : msg.status;
+        updateUsageLimitState(ds, msg.usageLimit);
+        ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
         // Same deferred-suspend checkpoint as the screen_update branch, and
         // deferred for the same reason (see runPendingSuspendIfSettled).
         // The predicate is defense-in-depth here: the handler's fence already
@@ -8356,15 +8371,6 @@ function setupWorkerHandlers(
           imageKey: msg.imageKey,
           content: ds.lastScreenContent ?? '',
         });
-        if (supersededCardVisual) {
-          ds.currentImageKey = preservedCardImageKey;
-          ds.lastScreenStatus = preservedCardStatus;
-          logger.debug(
-            `[${t}] Kept bookkeeping but ignored screenshot for superseded turn ${msg.turnId!.substring(0, 12)} `
-            + `(card owner ${ds.streamCardVisualTurnId!.substring(0, 12)})`,
-          );
-          break;
-        }
         persistStreamCardState(ds);
         // screenshot_uploaded never ARMS the usage refresh — screen_update owns
         // the authorized arm. Here we only tear it down: unconditionally on

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2080,6 +2080,7 @@ export function scheduleCardPatch(
 function flushCardPatch(ds: DaemonSession): void {
   const json = ds.pendingCardJson;
   const cardId = ds.pendingCardId;
+  const cardTurnId = ds.pendingCardTurnId;
   const withdrawnFallback = ds.pendingCardWithdrawFallback;
   if (!json || !cardId) {
     ds.pendingCardJson = undefined;
@@ -2102,6 +2103,23 @@ function flushCardPatch(ds: DaemonSession): void {
         && withdrawnFallback.generation === (ds.streamCardTurnGeneration ?? 0)
         && (ds.streamCardId === undefined || ds.streamCardId === cardId)
       );
+      const postReplacement = (clearWithdrawnCard: boolean): void => {
+        const fallback = withdrawnFallback!;
+        if (clearWithdrawnCard) ds.streamCardId = undefined;
+        ds.streamCardPending = true;
+        ds.streamCardPendingTurnId = fallback.turnId;
+        if (ds.pendingCardJson) {
+          if (ds.pendingCardId === cardId) ds.pendingCardId = CARD_POSTING_SENTINEL;
+        } else {
+          // No newer latest-wins payload exists, so replay this failed state
+          // after the replacement POST instead of leaving it at "starting".
+          ds.pendingCardJson = json;
+          ds.pendingCardId = CARD_POSTING_SENTINEL;
+          ds.pendingCardTurnId = cardTurnId ?? fallback.turnId;
+        }
+        persistStreamCardState(ds);
+        void postTurnStartingCard(ds, requireCallbacks().sessionReply, fallback.turnId);
+      };
       if (err instanceof MessageWithdrawnError) {
         // Only clear streamCardId when the withdrawn message is still the
         // active one. With auto-recall a new turn may have advanced
@@ -2123,14 +2141,7 @@ function flushCardPatch(ds: DaemonSession): void {
         // for a newer type-ahead turn. `streamCardId` may already be undefined
         // because an earlier queued PATCH discovered the same withdrawal.
         if (fallbackMatches) {
-          ds.streamCardId = undefined;
-          ds.streamCardPending = true;
-          ds.streamCardPendingTurnId = withdrawnFallback.turnId;
-          if (ds.pendingCardJson && ds.pendingCardId === cardId) {
-            ds.pendingCardId = CARD_POSTING_SENTINEL;
-          }
-          persistStreamCardState(ds);
-          void postTurnStartingCard(ds, requireCallbacks().sessionReply, withdrawnFallback.turnId);
+          postReplacement(true);
         }
         return;
       }
@@ -2139,13 +2150,7 @@ function flushCardPatch(ds: DaemonSession): void {
       // the same fresh-card path as an explicit withdrawal. Keep the old card
       // identity until the POST succeeds so it can be recalled afterwards.
       if (fallbackMatches) {
-        ds.streamCardPending = true;
-        ds.streamCardPendingTurnId = withdrawnFallback.turnId;
-        if (ds.pendingCardJson && ds.pendingCardId === cardId) {
-          ds.pendingCardId = CARD_POSTING_SENTINEL;
-        }
-        persistStreamCardState(ds);
-        void postTurnStartingCard(ds, requireCallbacks().sessionReply, withdrawnFallback.turnId);
+        postReplacement(false);
         return;
       }
       logger.debug(`[${tag(ds)}] Failed to update streaming card: ${err}`);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1426,6 +1426,36 @@ export function reuseThreadStreamingCardForTurn(
   return true;
 }
 
+function buildTurnStartingCardJson(
+  ds: DaemonSession,
+  botCfg: ReturnType<typeof getBot>['config'],
+  nonce: string,
+): string {
+  const effectiveCliId = sessionCliId(ds, botCfg);
+  const status = ds.usageLimit ? 'limited' : 'starting';
+  return buildStreamingCard(
+    ds.session.sessionId,
+    sessionAnchorId(ds),
+    readableTerminalUrlFor(ds),
+    ds.currentTurnTitle || ds.session.title || sessionCliDisplayName(ds, botCfg),
+    '',
+    status,
+    effectiveCliId,
+    ds.displayMode ?? 'hidden',
+    nonce,
+    undefined,
+    !!ds.adoptedFrom,
+    false,
+    localeForBot(ds.larkAppId),
+    ds.usageLimit,
+    writableTerminalLinkFor(ds),
+    isLocalCliOpenReady(ds, { cliId: effectiveCliId }),
+    getDaemonStreamingCardUsageSnapshot(ds, effectiveCliId),
+    sessionRuntimeDisplayName(ds, botCfg),
+    codexServiceTierBadge(effectiveCliId, ds.codexServiceTier),
+  );
+}
+
 /**
  * Post the current turn's starting card as soon as the daemon accepts the
  * inbound message. Terminal redraw is deliberately not part of this trigger:
@@ -1454,7 +1484,6 @@ export async function postTurnStartingCard(
   const anchorAtPost = sessionAnchorId(ds);
   const registryKeyAtPost = sessionKey(anchorAtPost, larkAppIdAtPost);
   const botCfg = getBot(ds.larkAppId).config;
-  const effectiveCliId = sessionCliId(ds, botCfg);
   const previousCardId = ds.streamCardId;
   const previousNonce = ds.streamCardNonce;
   // A newer turn may have arrived while the previous turn's POST was still in
@@ -1462,28 +1491,7 @@ export async function postTurnStartingCard(
   // predecessor here before replacing its identity.
   parkStreamCard(ds);
   const nonce = randomBytes(4).toString('hex');
-  const status = ds.usageLimit ? 'limited' : 'starting';
-  const cardJson = buildStreamingCard(
-    ds.session.sessionId,
-    sessionAnchorId(ds),
-    readableTerminalUrlFor(ds),
-    ds.currentTurnTitle || ds.session.title || sessionCliDisplayName(ds, botCfg),
-    '',
-    status,
-    effectiveCliId,
-    ds.displayMode ?? 'hidden',
-    nonce,
-    undefined,
-    !!ds.adoptedFrom,
-    false,
-    localeForBot(ds.larkAppId),
-    ds.usageLimit,
-    writableTerminalLinkFor(ds),
-    isLocalCliOpenReady(ds, { cliId: effectiveCliId }),
-    getDaemonStreamingCardUsageSnapshot(ds, effectiveCliId),
-    sessionRuntimeDisplayName(ds, botCfg),
-    codexServiceTierBadge(effectiveCliId, ds.codexServiceTier),
-  );
+  const cardJson = buildTurnStartingCardJson(ds, botCfg, nonce);
 
   ds.streamCardNonce = nonce;
   ds.streamCardId = CARD_POSTING_SENTINEL;
@@ -1524,7 +1532,34 @@ export async function postTurnStartingCard(
     }
     ds.parkedStreamCardNonce = undefined;
     const superseded = (ds.streamCardTurnGeneration ?? 0) !== generation;
-    if (!superseded) {
+    const latestPendingTurnId = superseded && ds.scope === 'thread'
+      ? ds.streamCardPendingTurnId
+      : undefined;
+    if (latestPendingTurnId) {
+      // The POST was admitted before the stable thread card had a real message
+      // id. If a newer turn arrived while it was in flight, this newly-landed
+      // card is the stable card: retarget it to the latest turn instead of
+      // posting a second card and withdrawing this one.
+      ds.streamCardVisualTurnId = latestPendingTurnId;
+      ds.streamCardPending = false;
+      ds.streamCardPendingTurnId = undefined;
+      const withdrawnFallback = {
+        turnId: latestPendingTurnId,
+        generation: ds.streamCardTurnGeneration ?? 0,
+      };
+      if (ds.pendingCardJson) {
+        // Preserve a newer working/idle payload that raced the POST; it is more
+        // current than another synthetic "starting" card.
+        ds.pendingCardWithdrawFallback = withdrawnFallback;
+      } else {
+        scheduleCardPatch(
+          ds,
+          buildTurnStartingCardJson(ds, botCfg, nonce),
+          latestPendingTurnId,
+          { withdrawnFallback },
+        );
+      }
+    } else if (!superseded) {
       ds.streamCardPending = false;
       ds.streamCardPendingTurnId = undefined;
     }
@@ -3469,6 +3504,12 @@ export async function closeSession(
   const preparedRiffRequestId = ds?.riffCloseState?.phase === 'prepared'
     ? ds.riffCloseState.requestId
     : undefined;
+  // A closed session has no later reply/idle edge that could settle progress
+  // reactions. Detach them inside the close critical section so concurrent
+  // terminal paths cannot remove the same reaction twice; the remote cleanup
+  // below remains best-effort.
+  const closeAckReactions = ds?.pendingAckReactions ?? [];
+  if (ds) ds.pendingAckReactions = [];
 
   // 会话关闭即可回收其崩溃重启计数；否则每个曾崩溃过的 session 会在 daemon
   // 生命周期内永久占位（restartCounts 此前无任何 delete）。
@@ -3568,6 +3609,17 @@ export async function closeSession(
   // best-effort and can be slow; it must not leave a resurrection window.
   const cleanupAppId = ds?.larkAppId ?? stored?.larkAppId;
   if (cleanupAppId) {
+    for (const ack of closeAckReactions) {
+      if (!ack.reactionId) continue;
+      try {
+        await removeReaction(cleanupAppId, ack.messageId, ack.reactionId);
+      } catch (err: any) {
+        logger.debug(
+          `[reaction] close cleanup could not remove reaction ${ack.reactionId}: ${err?.message ?? err}`,
+        );
+      }
+    }
+
     for (const target of docReactionTargets) {
       try {
         await removeCommentReaction(

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1547,7 +1547,7 @@ export async function postTurnStartingCard(
         turnId: latestPendingTurnId,
         generation: ds.streamCardTurnGeneration ?? 0,
       };
-      if (ds.pendingCardJson) {
+      if (ds.pendingCardJson && ds.pendingCardTurnId === latestPendingTurnId) {
         // Preserve a newer working/idle payload that raced the POST; it is more
         // current than another synthetic "starting" card.
         ds.pendingCardWithdrawFallback = withdrawnFallback;
@@ -2054,6 +2054,7 @@ export function scheduleCardPatch(
   // versa) just because it overwrote the latest-turn slot.
   if (streamingCardDisabled(ds, turnId)) return;
   ds.pendingCardJson = cardJson;
+  ds.pendingCardTurnId = turnId;
   // Capture the card ID now — by the time flushCardPatch runs, ds.streamCardId
   // may have been overwritten by a new turn's card (CARD_POSTING_SENTINEL).
   const pendingCardId = ds.streamCardId;
@@ -2076,6 +2077,7 @@ function flushCardPatch(ds: DaemonSession): void {
   if (!json || !cardId) {
     ds.pendingCardJson = undefined;
     ds.pendingCardId = undefined;
+    ds.pendingCardTurnId = undefined;
     ds.pendingCardWithdrawFallback = undefined;
     return;
   }
@@ -2085,6 +2087,7 @@ function flushCardPatch(ds: DaemonSession): void {
   if (cardId === CARD_POSTING_SENTINEL) return;
   ds.pendingCardJson = undefined;
   ds.pendingCardId = undefined;
+  ds.pendingCardTurnId = undefined;
   ds.pendingCardWithdrawFallback = undefined;
   ds.cardPatchInFlight = true;
   updateMessage(ds.larkAppId, cardId, json)

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -10515,13 +10515,15 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
       reason: 'worker_fork_error',
       message: reason,
     });
+    const replyTurnId = fallbackTurnId(ds, opts?.turnId);
     void cb.sessionReply(
       sessionAnchorId(ds),
       message,
       'text',
       ds.larkAppId,
-      fallbackTurnId(ds, undefined),
-    ).catch(replyErr => logger.error(`[${t}] Failed to deliver adopt worker fork error to Lark: ${replyErr}`));
+      replyTurnId,
+    ).then(() => finishDeliveredTurnReactions(ds, replyTurnId))
+      .catch(replyErr => logger.error(`[${t}] Failed to deliver adopt worker fork error to Lark: ${replyErr}`));
   });
 
   // Pipe worker stdout/stderr — both go through logger.info (→ daemon.log,

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -3504,13 +3504,6 @@ export async function closeSession(
   const preparedRiffRequestId = ds?.riffCloseState?.phase === 'prepared'
     ? ds.riffCloseState.requestId
     : undefined;
-  // A closed session has no later reply/idle edge that could settle progress
-  // reactions. Detach them inside the close critical section so concurrent
-  // terminal paths cannot remove the same reaction twice; the remote cleanup
-  // below remains best-effort.
-  const closeAckReactions = ds?.pendingAckReactions ?? [];
-  if (ds) ds.pendingAckReactions = [];
-
   // 会话关闭即可回收其崩溃重启计数；否则每个曾崩溃过的 session 会在 daemon
   // 生命周期内永久占位（restartCounts 此前无任何 delete）。
   restartCounts.delete(sessionId);
@@ -3556,6 +3549,13 @@ export async function closeSession(
       ds.session.closedAt = after?.closedAt ?? ds.session.closedAt;
     }
   }
+
+  // A closed session has no later reply/idle edge that could settle progress
+  // reactions. Detach only after the durable transition succeeds: failed Riff
+  // commit and non-Riff store exceptions leave the session live and must retain
+  // their reaction ownership for a later reply or close retry.
+  const closeAckReactions = ds?.pendingAckReactions ?? [];
+  if (ds) ds.pendingAckReactions = [];
 
   if (ds) {
     killWorker(ds, {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -6862,16 +6862,18 @@ export function forkWorker(
     }
     const cliName = sessionCliDisplayName(ds, botCfg);
     const message = tr('worker.start_failed', { cliName, reason }, botLocale(botCfg));
+    const replyTurnId = fallbackTurnId(ds, initAttributionTurnId);
     void cb.sessionReply(
       sessionAnchorId(ds),
       message,
       'text',
       ds.larkAppId,
-      fallbackTurnId(ds, initAttributionTurnId),
+      replyTurnId,
       ds.session.vcMeetingReceiver
         ? { sourceSessionId: ds.session.sessionId }
         : undefined,
-    ).catch(replyErr => logger.error(`[${t}] Failed to deliver worker fork error to Lark: ${replyErr}`));
+    ).then(() => finishDeliveredTurnReactions(ds, replyTurnId))
+      .catch(replyErr => logger.error(`[${t}] Failed to deliver worker fork error to Lark: ${replyErr}`));
   });
 
   // Pipe worker stdout/stderr to daemon logger.
@@ -7409,6 +7411,7 @@ function setupWorkerHandlers(
     const message = tr('worker.start_failed', { cliName, reason }, loc);
     try {
       await scopedReply(message, 'text', turnId);
+      if (turnId) await finishDeliveredTurnReactions(ds, turnId);
     } catch (err: any) {
       logger.error(`[${t}] Failed to deliver worker startup failure to Lark: ${err?.message ?? err}`);
     }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -8083,22 +8083,20 @@ function setupWorkerHandlers(
         // ZMX intentionally reports ready with port=0, but its plain-history
         // screenshots and idle/status transitions must keep flowing.
         if (!startupState.ready && !workerHasInitialized(ds)) break;
-        if (
+        const supersededCardVisual = (
           ds.scope === 'thread'
           && ds.streamCardVisualTurnId
           && msg.turnId
           && msg.turnId !== ds.streamCardVisualTurnId
-        ) {
-          logger.debug(
-            `[${t}] Ignored visual update for superseded turn ${msg.turnId.substring(0, 12)} `
-            + `(card owner ${ds.streamCardVisualTurnId.substring(0, 12)})`,
-          );
-          break;
-        }
+        );
+        const preservedCardContent = ds.lastScreenContent;
+        const preservedCardStatus = ds.lastScreenStatus;
         const prevStatus = ds.lastScreenStatus;
-        updateUsageLimitState(ds, msg.usageLimit);
+        if (!supersededCardVisual) updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenContent = msg.content;
-        ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
+        ds.lastScreenStatus = (msg.usageLimit ?? (supersededCardVisual ? undefined : ds.usageLimit))
+          ? 'limited'
+          : msg.status;
         // A suspend that arrived mid-turn parked itself here. Defer until this
         // screen_update has finished using process state — suspendWorker nulls
         // `worker` + `lastScreenStatus`, which everything below still reads
@@ -8176,6 +8174,16 @@ function setupWorkerHandlers(
             // The newly-idle session itself may be the oldest eviction target.
             queueMicrotask(cb.enforceLiveSessionCap);
           }
+        }
+
+        if (supersededCardVisual) {
+          ds.lastScreenContent = preservedCardContent;
+          ds.lastScreenStatus = preservedCardStatus;
+          logger.debug(
+            `[${t}] Kept bookkeeping but ignored card update for superseded turn ${msg.turnId!.substring(0, 12)} `
+            + `(card owner ${ds.streamCardVisualTurnId!.substring(0, 12)})`,
+          );
+          break;
         }
 
         if (managedAuxUiSuppressed(msg.turnId, msg.dispatchAttempt)) { clearUsageRefreshTimer(ds); break; }
@@ -8318,25 +8326,23 @@ function setupWorkerHandlers(
       }
 
       case 'screenshot_uploaded': {
-        if (
+        const supersededCardVisual = (
           ds.scope === 'thread'
           && ds.streamCardVisualTurnId
           && msg.turnId
           && msg.turnId !== ds.streamCardVisualTurnId
-        ) {
-          logger.debug(
-            `[${t}] Ignored screenshot for superseded turn ${msg.turnId.substring(0, 12)} `
-            + `(card owner ${ds.streamCardVisualTurnId.substring(0, 12)})`,
-          );
-          break;
-        }
+        );
+        const preservedCardImageKey = ds.currentImageKey;
+        const preservedCardStatus = ds.lastScreenStatus;
         // Drop uploads that arrived during a new-turn handoff — the image_key may
         // reflect previous turn's content. Next 10s cycle picks up fresh content.
         if (ds.streamCardPending) break;
         ds.currentImageKey = msg.imageKey;
         const prevStatus = ds.lastScreenStatus;
-        updateUsageLimitState(ds, msg.usageLimit);
-        ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
+        if (!supersededCardVisual) updateUsageLimitState(ds, msg.usageLimit);
+        ds.lastScreenStatus = (msg.usageLimit ?? (supersededCardVisual ? undefined : ds.usageLimit))
+          ? 'limited'
+          : msg.status;
         // Same deferred-suspend checkpoint as the screen_update branch, and
         // deferred for the same reason (see runPendingSuspendIfSettled).
         // The predicate is defense-in-depth here: the handler's fence already
@@ -8350,6 +8356,15 @@ function setupWorkerHandlers(
           imageKey: msg.imageKey,
           content: ds.lastScreenContent ?? '',
         });
+        if (supersededCardVisual) {
+          ds.currentImageKey = preservedCardImageKey;
+          ds.lastScreenStatus = preservedCardStatus;
+          logger.debug(
+            `[${t}] Kept bookkeeping but ignored screenshot for superseded turn ${msg.turnId!.substring(0, 12)} `
+            + `(card owner ${ds.streamCardVisualTurnId!.substring(0, 12)})`,
+          );
+          break;
+        }
         persistStreamCardState(ds);
         // screenshot_uploaded never ARMS the usage refresh — screen_update owns
         // the authorized arm. Here we only tear it down: unconditionally on

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1515,6 +1515,12 @@ export async function postTurnStartingCard(
       return false;
     }
     ds.streamCardId = messageId;
+    // Screen/status updates can arrive while the starting-card POST owns the
+    // sentinel. Keep their latest-wins payload queued, then retarget it to the
+    // real message id once the POST lands.
+    if (ds.pendingCardJson && ds.pendingCardId === CARD_POSTING_SENTINEL) {
+      ds.pendingCardId = messageId;
+    }
     ds.parkedStreamCardNonce = undefined;
     const superseded = (ds.streamCardTurnGeneration ?? 0) !== generation;
     if (!superseded) {
@@ -1528,6 +1534,7 @@ export async function postTurnStartingCard(
     flushPendingActiveRuntimePatch(ds);
     flushPendingCodexServiceTierPatch(ds);
     syncUsageRefreshTimer(ds);
+    if (ds.pendingCardJson && !ds.cardPatchInFlight) flushCardPatch(ds);
     logger.info(`[${tag(ds)}] Posted starting card for turn ${turnId.substring(0, 12)}`);
     if (superseded && ds.streamCardPendingTurnId) {
       void postTurnStartingCard(ds, sessionReply, ds.streamCardPendingTurnId);
@@ -2030,12 +2037,16 @@ function flushCardPatch(ds: DaemonSession): void {
   const json = ds.pendingCardJson;
   const cardId = ds.pendingCardId;
   const withdrawnFallback = ds.pendingCardWithdrawFallback;
-  if (!json || !cardId || cardId === CARD_POSTING_SENTINEL) {
+  if (!json || !cardId) {
     ds.pendingCardJson = undefined;
     ds.pendingCardId = undefined;
     ds.pendingCardWithdrawFallback = undefined;
     return;
   }
+  // A starting-card POST will replace the sentinel with its real message id
+  // and flush this latest payload. Clearing here loses working/idle updates
+  // that raced the POST and can leave the visible replacement at "starting".
+  if (cardId === CARD_POSTING_SENTINEL) return;
   ds.pendingCardJson = undefined;
   ds.pendingCardId = undefined;
   ds.pendingCardWithdrawFallback = undefined;
@@ -2070,6 +2081,9 @@ function flushCardPatch(ds: DaemonSession): void {
           ds.streamCardId = undefined;
           ds.streamCardPending = true;
           ds.streamCardPendingTurnId = withdrawnFallback.turnId;
+          if (ds.pendingCardJson && ds.pendingCardId === cardId) {
+            ds.pendingCardId = CARD_POSTING_SENTINEL;
+          }
           persistStreamCardState(ds);
           void postTurnStartingCard(ds, requireCallbacks().sessionReply, withdrawnFallback.turnId);
         }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2060,9 +2060,16 @@ export function scheduleCardPatch(
   const pendingCardId = ds.streamCardId;
   if (options?.withdrawnFallback) {
     ds.pendingCardWithdrawFallback = options.withdrawnFallback;
-  } else if (ds.pendingCardId !== pendingCardId) {
-    // A same-card status refresh must not erase a queued reuse fallback. A
-    // different card identity owns a different lifecycle and must not inherit it.
+  } else if (
+    ds.pendingCardWithdrawFallback
+    && (
+      ds.pendingCardWithdrawFallback.generation !== (ds.streamCardTurnGeneration ?? 0)
+      || (turnId !== undefined && turnId !== ds.pendingCardWithdrawFallback.turnId)
+    )
+  ) {
+    // Keep the fallback for every same-turn update, including updates queued
+    // after the initial reuse PATCH has completed. A new generation or an
+    // explicitly different turn owns a different card lifecycle.
     ds.pendingCardWithdrawFallback = undefined;
   }
   ds.pendingCardId = pendingCardId;
@@ -2078,7 +2085,6 @@ function flushCardPatch(ds: DaemonSession): void {
     ds.pendingCardJson = undefined;
     ds.pendingCardId = undefined;
     ds.pendingCardTurnId = undefined;
-    ds.pendingCardWithdrawFallback = undefined;
     return;
   }
   // A starting-card POST will replace the sentinel with its real message id
@@ -2088,10 +2094,14 @@ function flushCardPatch(ds: DaemonSession): void {
   ds.pendingCardJson = undefined;
   ds.pendingCardId = undefined;
   ds.pendingCardTurnId = undefined;
-  ds.pendingCardWithdrawFallback = undefined;
   ds.cardPatchInFlight = true;
   updateMessage(ds.larkAppId, cardId, json)
     .catch(err => {
+      const fallbackMatches = (
+        withdrawnFallback
+        && withdrawnFallback.generation === (ds.streamCardTurnGeneration ?? 0)
+        && (ds.streamCardId === undefined || ds.streamCardId === cardId)
+      );
       if (err instanceof MessageWithdrawnError) {
         // Only clear streamCardId when the withdrawn message is still the
         // active one. With auto-recall a new turn may have advanced
@@ -2112,11 +2122,7 @@ function flushCardPatch(ds: DaemonSession): void {
         // Generation matching prevents an older in-flight PATCH from posting
         // for a newer type-ahead turn. `streamCardId` may already be undefined
         // because an earlier queued PATCH discovered the same withdrawal.
-        if (
-          withdrawnFallback
-          && withdrawnFallback.generation === (ds.streamCardTurnGeneration ?? 0)
-          && (ds.streamCardId === undefined || ds.streamCardId === cardId)
-        ) {
+        if (fallbackMatches) {
           ds.streamCardId = undefined;
           ds.streamCardPending = true;
           ds.streamCardPendingTurnId = withdrawnFallback.turnId;
@@ -2126,6 +2132,20 @@ function flushCardPatch(ds: DaemonSession): void {
           persistStreamCardState(ds);
           void postTurnStartingCard(ds, requireCallbacks().sessionReply, withdrawnFallback.turnId);
         }
+        return;
+      }
+      // A queued worker-ready PATCH cannot throw back into its caller. For an
+      // accepted reused-card turn, converge ordinary transport/API failures to
+      // the same fresh-card path as an explicit withdrawal. Keep the old card
+      // identity until the POST succeeds so it can be recalled afterwards.
+      if (fallbackMatches) {
+        ds.streamCardPending = true;
+        ds.streamCardPendingTurnId = withdrawnFallback.turnId;
+        if (ds.pendingCardJson && ds.pendingCardId === cardId) {
+          ds.pendingCardId = CARD_POSTING_SENTINEL;
+        }
+        persistStreamCardState(ds);
+        void postTurnStartingCard(ds, requireCallbacks().sessionReply, withdrawnFallback.turnId);
         return;
       }
       logger.debug(`[${tag(ds)}] Failed to update streaming card: ${err}`);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -9056,6 +9056,14 @@ function setupWorkerHandlers(
           // never let a projection/store failure crash the worker IPC loop.
           logger.error(`[${t}] Failed to persist turn_terminal for ${msg.turnId.substring(0, 8)}: ${err.message}`);
         }
+        // A stable-card thread normally clears its progress reaction when the
+        // reply lands. Genuine nothing-to-send has no reply event, so its
+        // positive terminal evidence is the only safe point to clear the exact
+        // turn. Bare completed is intentionally insufficient: a trailing reply
+        // may still be materializing after the terminal edge.
+        if (msg.status === 'completed' && msg.outputDisposition === 'nothing_to_send') {
+          await finishDeliveredTurnReactions(ds, msg.turnId);
+        }
         // Async-HTTP settle-on-terminal (core-only completion bug #70): a turn
         // the worker's bridge gate suppressed as GENUINE SILENCE (the model
         // terminated with a bare nothing-to-send sentinel, no `botmux send`)
@@ -9793,7 +9801,8 @@ async function finishTurnReactions(ds: DaemonSession): Promise<void> {
 }
 
 /** Remove the exact thread turn's progress reaction after its reply has been
- * delivered. Card-off entries keep their existing received→DONE idle flow. */
+ * delivered, or after positive terminal evidence says no reply will be sent.
+ * Card-off entries keep their existing received→DONE idle flow. */
 async function finishDeliveredTurnReactions(ds: DaemonSession, turnId: string): Promise<void> {
   const list = ds.pendingAckReactions;
   if (!list || list.length === 0) return;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1416,7 +1416,11 @@ export function reuseThreadStreamingCardForTurn(
   // A stopped worker's ready handler owns the first PATCH because it adds the
   // newly-established terminal/readiness state. Queuing this older starting
   // card now could resolve after ready's direct update and overwrite it.
-  if (workerHasInitialized(ds)) scheduleCardPatch(ds, cardJson, turnId);
+  if (workerHasInitialized(ds)) {
+    scheduleCardPatch(ds, cardJson, turnId, {
+      withdrawnFallback: { turnId, generation: ds.streamCardTurnGeneration },
+    });
+  }
   logger.info(`[${tag(ds)}] Reused streaming card for turn ${turnId.substring(0, 12)}`);
   return true;
 }
@@ -1990,7 +1994,12 @@ export async function deliverEphemeralOrReply(
  * Otherwise stores the card JSON on `ds.pendingCardJson` (overwriting
  * any previously queued value — only the latest state matters).
  */
-export function scheduleCardPatch(ds: DaemonSession, cardJson: string, turnId?: string): void {
+export function scheduleCardPatch(
+  ds: DaemonSession,
+  cardJson: string,
+  turnId?: string,
+  options?: { withdrawnFallback?: { turnId: string; generation: number } },
+): void {
   // Defense-in-depth transport gate: a no-transport session (apiOnly bot or HTTP
   // virtual chat) has no real Feishu card to PATCH. Callers already suppress via
   // managedAuxUiSuppressed, but guarding the flush entry too means a stray direct
@@ -2004,7 +2013,15 @@ export function scheduleCardPatch(ds: DaemonSession, cardJson: string, turnId?: 
   ds.pendingCardJson = cardJson;
   // Capture the card ID now — by the time flushCardPatch runs, ds.streamCardId
   // may have been overwritten by a new turn's card (CARD_POSTING_SENTINEL).
-  ds.pendingCardId = ds.streamCardId;
+  const pendingCardId = ds.streamCardId;
+  if (options?.withdrawnFallback) {
+    ds.pendingCardWithdrawFallback = options.withdrawnFallback;
+  } else if (ds.pendingCardId !== pendingCardId) {
+    // A same-card status refresh must not erase a queued reuse fallback. A
+    // different card identity owns a different lifecycle and must not inherit it.
+    ds.pendingCardWithdrawFallback = undefined;
+  }
+  ds.pendingCardId = pendingCardId;
   if (ds.cardPatchInFlight) return;
   flushCardPatch(ds);
 }
@@ -2012,13 +2029,16 @@ export function scheduleCardPatch(ds: DaemonSession, cardJson: string, turnId?: 
 function flushCardPatch(ds: DaemonSession): void {
   const json = ds.pendingCardJson;
   const cardId = ds.pendingCardId;
+  const withdrawnFallback = ds.pendingCardWithdrawFallback;
   if (!json || !cardId || cardId === CARD_POSTING_SENTINEL) {
     ds.pendingCardJson = undefined;
     ds.pendingCardId = undefined;
+    ds.pendingCardWithdrawFallback = undefined;
     return;
   }
   ds.pendingCardJson = undefined;
   ds.pendingCardId = undefined;
+  ds.pendingCardWithdrawFallback = undefined;
   ds.cardPatchInFlight = true;
   updateMessage(ds.larkAppId, cardId, json)
     .catch(err => {
@@ -2036,6 +2056,22 @@ function flushCardPatch(ds: DaemonSession): void {
           persistStreamCardState(ds);
         } else {
           logger.debug(`[${tag(ds)}] Stale card ${cardId.substring(0, 12)} withdrawn (current: ${ds.streamCardId?.substring(0, 12) ?? 'none'})`);
+        }
+        // A turn that intentionally reused a stable thread card must still
+        // surface a status card when that persisted message was withdrawn.
+        // Generation matching prevents an older in-flight PATCH from posting
+        // for a newer type-ahead turn. `streamCardId` may already be undefined
+        // because an earlier queued PATCH discovered the same withdrawal.
+        if (
+          withdrawnFallback
+          && withdrawnFallback.generation === (ds.streamCardTurnGeneration ?? 0)
+          && (ds.streamCardId === undefined || ds.streamCardId === cardId)
+        ) {
+          ds.streamCardId = undefined;
+          ds.streamCardPending = true;
+          ds.streamCardPendingTurnId = withdrawnFallback.turnId;
+          persistStreamCardState(ds);
+          void postTurnStartingCard(ds, requireCallbacks().sessionReply, withdrawnFallback.turnId);
         }
         return;
       }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -9001,6 +9001,9 @@ function setupWorkerHandlers(
         if (managedAuxUiSuppressed(msg.turnId, msg.dispatchAttempt)) break;
         try {
           await scopedReply(msg.message, 'text', msg.turnId);
+          if (msg.settlesTurn === true && msg.turnId) {
+            await finishDeliveredTurnReactions(ds, msg.turnId);
+          }
         } catch (err: any) {
           logger.error(`[${t}] Failed to deliver user_notify to Lark: ${err.message}`);
         }
@@ -9800,8 +9803,8 @@ async function finishTurnReactions(ds: DaemonSession): Promise<void> {
   }
 }
 
-/** Remove the exact thread turn's progress reaction after its reply has been
- * delivered, or after positive terminal evidence says no reply will be sent.
+/** Remove the exact thread turn's progress reaction after its reply or terminal
+ * notice has been delivered, or after positive evidence says no reply will be sent.
  * Card-off entries keep their existing received→DONE idle flow. */
 async function finishDeliveredTurnReactions(ds: DaemonSession, turnId: string): Promise<void> {
   const list = ds.pendingAckReactions;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1355,6 +1355,73 @@ export function recallFrozenCards(ds: DaemonSession): void {
 }
 
 /**
+ * Start a new turn by PATCHing the existing card in a thread-scoped session.
+ * Final answers are delivered as fresh messages, so keeping one stable status
+ * card avoids a withdraw/repost cycle without hiding conversation history.
+ */
+export function reuseThreadStreamingCardForTurn(
+  ds: DaemonSession,
+  title: string,
+  turnId: string,
+): boolean {
+  if (ds.scope !== 'thread') return false;
+  if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL) return false;
+  if (ds.session.vcMeetingReceiver || streamingCardDisabled(ds, turnId)) return false;
+  if (riffRetirementAdmissionPhase(ds)) return false;
+  if (!larkTransportEnabled({ chatId: ds.chatId, apiOnly: getBot(ds.larkAppId).config.apiOnly })) return false;
+
+  if (ds.usageLimitRetryTimer) {
+    clearTimeout(ds.usageLimitRetryTimer);
+    ds.usageLimitRetryTimer = undefined;
+  }
+  clearUsageRefreshTimer(ds);
+  ds.usageLimit = undefined;
+  ds.streamCardPending = false;
+  ds.streamCardPendingTurnId = undefined;
+  ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
+  ds.currentTurnTitle = title.substring(0, 50);
+  ds.currentImageKey = undefined;
+  // Force the next real worker update to cross a status edge even when the
+  // previous turn was still `working` (type-ahead). Otherwise working→working
+  // would be coalesced and leave this card stuck at "starting" with no usage
+  // refresh timer.
+  ds.lastScreenStatus = 'starting';
+  ds.parkedStreamCardNonce = undefined;
+  if (!ds.streamCardNonce) ds.streamCardNonce = randomBytes(4).toString('hex');
+
+  const botCfg = getBot(ds.larkAppId).config;
+  const effectiveCliId = sessionCliId(ds, botCfg);
+  const cardJson = buildStreamingCard(
+    ds.session.sessionId,
+    sessionAnchorId(ds),
+    readableTerminalUrlFor(ds),
+    ds.currentTurnTitle,
+    '',
+    'starting',
+    effectiveCliId,
+    ds.displayMode ?? 'hidden',
+    ds.streamCardNonce,
+    undefined,
+    !!ds.adoptedFrom,
+    false,
+    localeForBot(ds.larkAppId),
+    undefined,
+    writableTerminalLinkFor(ds),
+    isLocalCliOpenReady(ds, { cliId: effectiveCliId }),
+    getDaemonStreamingCardUsageSnapshot(ds, effectiveCliId),
+    sessionRuntimeDisplayName(ds, botCfg),
+    codexServiceTierBadge(effectiveCliId, ds.codexServiceTier),
+  );
+  persistStreamCardState(ds);
+  // A stopped worker's ready handler owns the first PATCH because it adds the
+  // newly-established terminal/readiness state. Queuing this older starting
+  // card now could resolve after ready's direct update and overwrite it.
+  if (workerHasInitialized(ds)) scheduleCardPatch(ds, cardJson, turnId);
+  logger.info(`[${tag(ds)}] Reused streaming card for turn ${turnId.substring(0, 12)}`);
+  return true;
+}
+
+/**
  * Post the current turn's starting card as soon as the daemon accepts the
  * inbound message. Terminal redraw is deliberately not part of this trigger:
  * some CLIs consume a turn without emitting another screen_update, which used
@@ -8879,6 +8946,7 @@ function setupWorkerHandlers(
       }
 
       case 'explicit_reply_observed': {
+        void finishDeliveredTurnReactions(ds, msg.turnId);
         if (msg.turnId.startsWith('mlrp_turn_')) {
           markMessageListenerRunPreviewReplied(msg.turnId, {
             sessionId: ds.session.sessionId,
@@ -9645,15 +9713,11 @@ function shouldDropMismatchedHermesFinalOutput(
 }
 
 /**
- * Turn-end half of the two-phase turn reactions (auto-on for card-off sessions,
- * i.e. streaming card disabled). The 冲! "received" reactions are added per-message at the daemon
- * acceptance point (`noteTurnReceived`); the screen_update handler calls this
- * only on working|analyzing → idle|limited (not cold-start starting→idle), to
- * flip every pending ✋ on this session to ✅ DONE and clear the list. When
- * silentTurnReactions is enabled after a ✋ has already landed, we only remove
- * that received reaction and do not add DONE. Binding the start to the message
- * (not a status edge) means type-ahead / busy-batched messages each get their
- * own reaction and all settle together here.
+ * Turn-end handler for card-off progress reactions. Stable-card thread turns
+ * keep their reaction until a reply delivery signal arrives; an idle edge by
+ * itself must not tell the user the reply has landed. The screen_update handler
+ * calls this only on working|analyzing → idle|limited (not cold-start
+ * starting→idle).
  *
  * Every Feishu call is best-effort — a failure only means a missing emoji, so it
  * must never throw into the status pipeline (callers invoke as `void`).
@@ -9661,14 +9725,21 @@ function shouldDropMismatchedHermesFinalOutput(
 async function finishTurnReactions(ds: DaemonSession): Promise<void> {
   const list = ds.pendingAckReactions;
   if (!list || list.length === 0) return;
-  // Detach the batch first so a second idle edge can't double-flip it.
-  ds.pendingAckReactions = [];
   // A dedicated receiver has no progress-reaction channel. Clear any stale
   // in-memory entries restored from an older build without touching Lark.
-  if (ds.session.vcMeetingReceiver) return;
+  if (ds.session.vcMeetingReceiver) {
+    ds.pendingAckReactions = [];
+    return;
+  }
+  // Thread entries are settled by finishDeliveredTurnReactions after an
+  // outbound reply succeeds. Detach only card-off entries here so a second
+  // idle edge cannot double-flip them and concurrent reply delivery can still
+  // find its exact turn.
+  const cardOff = list.filter(ack => ack.clearOnReply !== true);
+  ds.pendingAckReactions = list.filter(ack => ack.clearOnReply === true);
   const silent = silentTurnReactions(ds);
   const doneEmoji = doneReactionEmojiFor(ds);
-  for (const ack of list) {
+  for (const ack of cardOff) {
     if (ack.reactionId) {
       try {
         await removeReaction(ds.larkAppId, ack.messageId, ack.reactionId);
@@ -9681,6 +9752,25 @@ async function finishTurnReactions(ds: DaemonSession): Promise<void> {
       await addReaction(ds.larkAppId, ack.messageId, doneEmoji);
     } catch (err: any) {
       logger.debug(`[reaction] failed to add done reaction to ${ack.messageId}: ${err?.message ?? err}`);
+    }
+  }
+}
+
+/** Remove the exact thread turn's progress reaction after its reply has been
+ * delivered. Card-off entries keep their existing received→DONE idle flow. */
+async function finishDeliveredTurnReactions(ds: DaemonSession, turnId: string): Promise<void> {
+  const list = ds.pendingAckReactions;
+  if (!list || list.length === 0) return;
+  const delivered = list.filter(ack =>
+    ack.clearOnReply === true && (ack.turnId ?? ack.messageId) === turnId);
+  if (delivered.length === 0) return;
+  ds.pendingAckReactions = list.filter(ack => !delivered.includes(ack));
+  for (const ack of delivered) {
+    if (!ack.reactionId) continue;
+    try {
+      await removeReaction(ds.larkAppId, ack.messageId, ack.reactionId);
+    } catch (err: any) {
+      logger.debug(`[reaction] failed to clear delivered reaction ${ack.reactionId}: ${err?.message ?? err}`);
     }
   }
 }
@@ -10145,6 +10235,7 @@ function deliverFinalOutput(
           ? { ...deliveryReplyOptions, replyTarget: frozenReplyTarget }
           : deliveryReplyOptions,
       );
+      await finishDeliveredTurnReactions(ds, msg.turnId);
       if (!isStillOwned()) { onComplete?.(true); return; }
       recordPrimaryOutput(messageId);
       if (msg.turnId.startsWith('mlrp_turn_')) {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -7732,12 +7732,30 @@ function setupWorkerHandlers(
               sessionRuntimeDisplayName(ds, botCfg),
               codexServiceTierBadge(effectiveCliId, ds.codexServiceTier),
             );
-            await updateMessage(ds.larkAppId, restoredCardId, streamCardJson);
+            // A previous worker generation may still own an in-flight PATCH
+            // for this same stable card. Queue readiness behind it so the old
+            // payload cannot finish after ready and overwrite the new turn.
+            // The exact fallback also makes a withdrawal discovered by either
+            // serialized request converge to a replacement for this turn.
+            const readyTurnId = msg.turnId ?? ds.streamCardVisualTurnId;
+            scheduleCardPatch(
+              ds,
+              streamCardJson,
+              readyTurnId,
+              readyTurnId && ds.scope === 'thread'
+                ? {
+                    withdrawnFallback: {
+                      turnId: readyTurnId,
+                      generation: ds.streamCardTurnGeneration ?? 0,
+                    },
+                  }
+                : undefined,
+            );
             if (!ownsLifecycleMutation()) break;
             ds.parkedStreamCardNonce = undefined;
-            // Worker IPC handlers may run while the direct restore PATCH is in
-            // flight. Re-queue readiness after it completes so an older
-            // not-ready payload can never overwrite the cli_session_id PATCH.
+            // Worker IPC handlers may run while the queued restore PATCH is in
+            // flight. Re-queue readiness so the serialized latest-wins payload
+            // includes any newly available local CLI capability.
             if (!localCliReadyAtBuild && isLocalCliOpenReady(ds, { cliId: effectiveCliId })) {
               scheduleLocalCliOpenReadinessPatch(ds);
             }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1370,6 +1370,7 @@ export function reuseThreadStreamingCardForTurn(
   if (riffRetirementAdmissionPhase(ds)) return false;
   if (!larkTransportEnabled({ chatId: ds.chatId, apiOnly: getBot(ds.larkAppId).config.apiOnly })) return false;
 
+  ds.streamCardVisualTurnId = turnId;
   if (ds.usageLimitRetryTimer) {
     clearTimeout(ds.usageLimitRetryTimer);
     ds.usageLimitRetryTimer = undefined;
@@ -8082,6 +8083,18 @@ function setupWorkerHandlers(
         // ZMX intentionally reports ready with port=0, but its plain-history
         // screenshots and idle/status transitions must keep flowing.
         if (!startupState.ready && !workerHasInitialized(ds)) break;
+        if (
+          ds.scope === 'thread'
+          && ds.streamCardVisualTurnId
+          && msg.turnId
+          && msg.turnId !== ds.streamCardVisualTurnId
+        ) {
+          logger.debug(
+            `[${t}] Ignored visual update for superseded turn ${msg.turnId.substring(0, 12)} `
+            + `(card owner ${ds.streamCardVisualTurnId.substring(0, 12)})`,
+          );
+          break;
+        }
         const prevStatus = ds.lastScreenStatus;
         updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenContent = msg.content;
@@ -8305,6 +8318,18 @@ function setupWorkerHandlers(
       }
 
       case 'screenshot_uploaded': {
+        if (
+          ds.scope === 'thread'
+          && ds.streamCardVisualTurnId
+          && msg.turnId
+          && msg.turnId !== ds.streamCardVisualTurnId
+        ) {
+          logger.debug(
+            `[${t}] Ignored screenshot for superseded turn ${msg.turnId.substring(0, 12)} `
+            + `(card owner ${ds.streamCardVisualTurnId.substring(0, 12)})`,
+          );
+          break;
+        }
         // Drop uploads that arrived during a new-turn handoff — the image_key may
         // reflect previous turn's content. Next 10s cycle picks up fresh content.
         if (ds.streamCardPending) break;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -6873,7 +6873,7 @@ export function forkWorker(
       ds.session.vcMeetingReceiver
         ? { sourceSessionId: ds.session.sessionId }
         : undefined,
-    ).then(() => finishDeliveredTurnReactions(ds, replyTurnId))
+    ).then(() => replyTurnId ? finishDeliveredTurnReactions(ds, replyTurnId) : undefined)
       .catch(replyErr => logger.error(`[${t}] Failed to deliver worker fork error to Lark: ${replyErr}`));
   });
 
@@ -8698,6 +8698,7 @@ function setupWorkerHandlers(
           break;
         }
         const suppressExitUi = managedAuxUiSuppressed(msg.turnId, msg.dispatchAttempt);
+        const exitTurnId = fallbackTurnId(ds, msg.turnId);
 
         // Do NOT auto-restart in adopt mode — there's nothing to restart
         if (ds.adoptedFrom) {
@@ -8726,7 +8727,8 @@ function setupWorkerHandlers(
           // leave status='active' and still get the notice.
           if (!suppressExitUi && ds.session.status !== 'closed') {
             try {
-              await scopedReply(tr('worker.adopted_session_exited', undefined, loc), 'text', undefined);
+              await scopedReply(tr('worker.adopted_session_exited', undefined, loc), 'text', exitTurnId);
+              if (exitTurnId) await finishDeliveredTurnReactions(ds, exitTurnId);
             } catch { /* best effort */ }
           }
           break;
@@ -8747,7 +8749,8 @@ function setupWorkerHandlers(
           // lifecycle. Only an unexpected backend exit needs recovery guidance.
           if (!retirementPhase && !suppressExitUi) {
             try {
-              await scopedReply(tr('cmd.restart.riff_unsupported', undefined, loc), 'text', undefined);
+              await scopedReply(tr('cmd.restart.riff_unsupported', undefined, loc), 'text', exitTurnId);
+              if (exitTurnId) await finishDeliveredTurnReactions(ds, exitTurnId);
             } catch (replyErr) {
               if (replyErr instanceof MessageWithdrawnError) {
                 logger.warn(`[${t}] Root message withdrawn, closing stale session`);
@@ -8826,7 +8829,8 @@ function setupWorkerHandlers(
           }
           if (!suppressExitUi) {
             try {
-              await scopedReply(parts.join('\n\n'), 'text', undefined);
+              await scopedReply(parts.join('\n\n'), 'text', exitTurnId);
+              if (exitTurnId) await finishDeliveredTurnReactions(ds, exitTurnId);
             } catch (replyErr) {
               if (replyErr instanceof MessageWithdrawnError && ownsLifecycleMutation()) {
                 await closeWithdrawnSessionIfLedgerEmpty(ds, 'Root message withdrawn while sending crash diagnostic');
@@ -10529,7 +10533,7 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
       'text',
       ds.larkAppId,
       replyTurnId,
-    ).then(() => finishDeliveredTurnReactions(ds, replyTurnId))
+    ).then(() => replyTurnId ? finishDeliveredTurnReactions(ds, replyTurnId) : undefined)
       .catch(replyErr => logger.error(`[${t}] Failed to deliver adopt worker fork error to Lark: ${replyErr}`));
   });
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -4111,10 +4111,11 @@ function failOrdinaryImDelivery(record: OrdinaryImDelivery, reason: string): voi
     'text',
     record.ds.larkAppId,
     record.turnId,
-  ).catch(err => logger.error(
-    `[${tag(record.ds)}] Failed to report ordinary IM worker delivery failure: `
-    + `${err instanceof Error ? err.message : String(err)}`,
-  ));
+  ).then(() => finishDeliveredTurnReactions(record.ds, record.turnId))
+    .catch(err => logger.error(
+      `[${tag(record.ds)}] Failed to report ordinary IM worker delivery failure: `
+      + `${err instanceof Error ? err.message : String(err)}`,
+    ));
 }
 
 function retryOrFailOrdinaryImDelivery(record: OrdinaryImDelivery, reason: string): void {
@@ -9353,6 +9354,9 @@ function setupWorkerHandlers(
             settlement.generation,
             settlement.seq,
           )) {
+            if (msg.disposition === 'steer_superseded') {
+              await finishDeliveredTurnReactions(ds, msg.turnId);
+            }
             acknowledge(true);
             if (!hasUnsettledCodexAppDispatch(ds.session.codexAppDispatchLedger)) {
               try { await cb.onCodexAppLedgerDrained?.(ds); }
@@ -9499,6 +9503,9 @@ function setupWorkerHandlers(
             codexAppFinalSettlementInFlight.set(key, inFlight);
           }
           const persisted = await inFlight;
+          if (persisted && msg.disposition === 'steer_superseded') {
+            await finishDeliveredTurnReactions(ds, msg.turnId);
+          }
           acknowledge(persisted, persisted ? undefined : 'final_settlement_failed');
           if (persisted && !hasUnsettledCodexAppDispatch(ds.session.codexAppDispatchLedger)) {
             try { await cb.onCodexAppLedgerDrained?.(ds); }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2106,6 +2106,10 @@ function flushCardPatch(ds: DaemonSession): void {
       const postReplacement = (clearWithdrawnCard: boolean): void => {
         const fallback = withdrawnFallback!;
         if (clearWithdrawnCard) ds.streamCardId = undefined;
+        // One accepted turn gets at most one replacement. Consume the fallback
+        // before replaying the failed payload so a persistently failing PATCH
+        // cannot recurse into an unbounded POST → PATCH → POST loop.
+        ds.pendingCardWithdrawFallback = undefined;
         ds.streamCardPending = true;
         ds.streamCardPendingTurnId = fallback.turnId;
         if (ds.pendingCardJson) {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -8165,6 +8165,10 @@ function setupWorkerHandlers(
         if (supersededCardVisual) {
           const supersededTurnId = msg.turnId!;
           const settledStatus = msg.usageLimit ? 'limited' : msg.status;
+          // Usage limits are session-wide even when this turn no longer owns
+          // the card. Preserve the limit + retry timer while fencing every
+          // visual/dashboard field below to N+1.
+          updateUsageLimitState(ds, msg.usageLimit);
           // This event still closes the older turn's accounting boundary, but
           // it no longer represents the current session projection. In
           // particular, do not borrow N+1's lastScreenStatus to manufacture a
@@ -8418,6 +8422,9 @@ function setupWorkerHandlers(
           && msg.turnId !== ds.streamCardVisualTurnId
         );
         if (supersededCardVisual) {
+          // The screenshot belongs to the old visual turn, but a structured
+          // usage limit still applies to the whole session.
+          updateUsageLimitState(ds, msg.usageLimit);
           logger.debug(
             `[${t}] Ignored screenshot/session projection for superseded turn ${msg.turnId!.substring(0, 12)} `
             + `(card owner ${ds.streamCardVisualTurnId!.substring(0, 12)})`,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4354,7 +4354,12 @@ function beginNewTurn(ds: DaemonSession, title: string, turnId: string): void {
   // Use `/card on` to persistently restore cards for the chat.
   ds.streamingCardForced = undefined;
   if (reuseThreadStreamingCardForTurn(ds, title, turnId)) return;
-  if (ds.scope === 'thread') ds.streamCardVisualTurnId = turnId;
+  if (ds.scope === 'thread') {
+    // Card-off turns have no visual surface to own. Leaving an exact turn fence
+    // here would make an older turn's idle look visually superseded and skip
+    // its dashboard/reaction settlement.
+    ds.streamCardVisualTurnId = streamingCardDisabledFor(ds, turnId) ? undefined : turnId;
+  }
   const previousUsageLimit = ds.usageLimit;
   const previousStatus = ds.lastScreenStatus === 'limited' && previousUsageLimit ? 'limited' : 'idle';
   if (ds.streamCardId && workerHasInitialized(ds)) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -157,7 +157,6 @@ import {
   setCurrentCliVersion,
   getCurrentCliVersion,
   CARD_POSTING_SENTINEL,
-  parkStreamCard,
   closeSession as closeSessionHelper,
   setActiveSessionIfActive,
   rollbackRejectedSessionAndGetWinner,
@@ -19631,24 +19630,6 @@ async function handleThreadReplyAdmitted(
     logger.info(`[${tag(ds)}] Worker not running, re-forking...`);
     // 飞书消息轮（非文档评论轮）：docCommentTargets 是 per-turn map，本轮 turnId
     // 不会命中文档评论的 key，无需显式清盘。
-    if (!reuseThreadStreamingCardForTurn(ds, parsed.content, parsed.messageId)) {
-      if (ds.usageLimitRetryTimer) {
-        clearTimeout(ds.usageLimitRetryTimer);
-        ds.usageLimitRetryTimer = undefined;
-      }
-      ds.usageLimit = undefined;
-      ds.currentTurnTitle = parsed.content.substring(0, 50);
-      // With no worker, park the current card until its flat-chat successor is
-      // visible. If fork / worker_ready / POST fails, the old card remains.
-      parkStreamCard(ds);
-      ds.streamCardId = undefined;
-      ds.streamCardNonce = undefined;
-      ds.streamCardPending = true;
-      ds.streamCardPendingTurnId = parsed.messageId;
-      ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
-      ds.currentImageKey = undefined;
-      persistStreamCardState(ds);
-    }
     // Wrap the user message in the same `<user_message>` / `<session_id>` /
     // `<botmux_reminder>` envelope as live-worker turns. Without this, the
     // initial prompt that worker queues for the freshly-spawned CLI is the
@@ -19715,7 +19696,7 @@ async function handleThreadReplyAdmitted(
       await stageCurrentBehindQueuedActivation();
       try {
         const recoverThroughCodexLedger = (ds.session.cliId ?? dsBotCfgForFork.cliId) === 'codex-app';
-        forkWorker(
+        const recoveryAccepted = forkWorker(
           ds,
           recoverThroughCodexLedger ? '' : (ds.session.queuedActivationInput ?? ''),
           {
@@ -19724,6 +19705,7 @@ async function handleThreadReplyAdmitted(
             dispatchAttempt: ds.session.queuedActivationDispatchAttempt,
           },
         );
+        if (recoveryAccepted) beginNewTurn(ds, parsed.content, parsed.messageId);
         if (ownsInitialStartClaim()) retainInitialStartClaim = true;
       } catch (err) {
         ds.initialStartPending = false;
@@ -19742,11 +19724,12 @@ async function handleThreadReplyAdmitted(
     if (retainedQueuedActivation) {
       await stageCurrentBehindQueuedActivation();
       try {
-        forkWorker(ds, retainedQueuedActivation, {
+        const recoveryAccepted = forkWorker(ds, retainedQueuedActivation, {
           resume: ds.hasHistory,
           turnId: ds.session.queuedActivationTurnId,
           dispatchAttempt: ds.session.queuedActivationDispatchAttempt,
         });
+        if (recoveryAccepted) beginNewTurn(ds, parsed.content, parsed.messageId);
         if (ownsInitialStartClaim()) retainInitialStartClaim = true;
       } catch (err) {
         // Keep the staged tail for a later activation attempt, but release the
@@ -19891,8 +19874,16 @@ async function handleThreadReplyAdmitted(
     // refork 成功才算本轮已交给 CLI。fork 抛错（rethrow）或返回 false（quarantine /
     // 会话已非 active 的不抛错拒绝腿）时，本轮只存在于内存、无 durable 兜底，
     // 必须保持「请重发」提示——与 live 分支按 accepted 打标对称。
-    if (reforkAccepted) markIngressAdmitted(ctx);
-    else if (!queuedHasDurableTail) await discardTurnReceivedReaction(ds, parsed.messageId);
+    if (reforkAccepted) {
+      markIngressAdmitted(ctx);
+      // The stable card changes owner only after the replacement worker has
+      // accepted this turn. beginNewTurn also binds fresh-card reforks where no
+      // reusable message id exists, so their worker events cannot inherit the
+      // previous turn's visual fence.
+      beginNewTurn(ds, parsed.content, parsed.messageId);
+    } else if (!queuedHasDurableTail) {
+      await discardTurnReceivedReaction(ds, parsed.messageId);
+    }
     // Record the input as the session's last real CLI turn ONLY after the fork
     // succeeded. Recording before the fork (the old order) persisted lastCliInput
     // for a turn that never launched when forkWorker threw; the retry then read
@@ -20262,19 +20253,6 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
 
       // Worker 挂起 / 已退出 —— resume 重 fork（与 handleThreadReply 同路）。
       logger.info(`[${tag(ds)}] Worker not running for doc-comment, re-forking...`);
-      if (!reuseThreadStreamingCardForTurn(ds, text, turnId)) {
-        if (ds.usageLimitRetryTimer) { clearTimeout(ds.usageLimitRetryTimer); ds.usageLimitRetryTimer = undefined; }
-        ds.usageLimit = undefined;
-        ds.currentTurnTitle = text.substring(0, 50);
-        parkStreamCard(ds);
-        ds.streamCardId = undefined;
-        ds.streamCardNonce = undefined;
-        ds.streamCardPending = true;
-        ds.streamCardPendingTurnId = turnId;
-        ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
-        ds.currentImageKey = undefined;
-        persistStreamCardState(ds);
-      }
       // Skip whiteboard ensure for adopted (bridge) sessions on re-fork — mirrors
       // the live-worker branch above (if (!isBridge) ensure…).
       if (!ds.adoptedFrom) ensureSessionWhiteboard(ds);
@@ -20298,8 +20276,11 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
       if (ds.adoptedFrom) {
         forkAdoptWorker(ds, { prompt: wrappedInput.content, turnId });
       } else {
-        forkWorker(ds, wrappedInput, { resume: ds.hasHistory, turnId });
+        if (!forkWorker(ds, wrappedInput, { resume: ds.hasHistory, turnId })) {
+          throw new Error('doc-comment refork was not accepted');
+        }
       }
+      beginNewTurn(ds, text, turnId);
     }, cleanupFailedDelivery);
   } catch (err) {
     if (err instanceof DocCommentDeferredError) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -172,6 +172,7 @@ import {
   getDaemonBootId,
   getDaemonStreamingCardUsageSnapshot,
   postTurnStartingCard,
+  reuseThreadStreamingCardForTurn,
   isSessionTransferring,
   snapshotCodexAppFinalSettlements,
   codexAppFinalSettlementCount,
@@ -3135,7 +3136,7 @@ export async function noteTurnReceived(
   triggerMessageId: string,
   _prompt?: string,
   _sender?: { name?: string },
-  _turnId?: string,
+  turnId?: string,
   receivedReactionEmoji?: string,
 ): Promise<void> {
   // Replaces the old 「处理中」 placeholder card. That card existed only to be
@@ -3145,10 +3146,10 @@ export async function noteTurnReceived(
   // fresh message (deliverFinalOutput / `botmux send`).
   //
   // This call site is the per-message acceptance point, so it also drives the
-  // two-phase turn reaction. It's auto-enabled exactly for card-off sessions
-  // (streaming card disabled): those have no live status card, so the ✋→✅ on
-  // the user's message is the only lightweight progress signal. Bots can opt
-  // out via silentTurnReactions for low-noise observer scenarios.
+  // turn reaction. Card-off sessions retain the existing received→DONE flow.
+  // Thread sessions also react while their stable status card is running, then
+  // remove that reaction after the reply lands so a reused card never makes a
+  // newly accepted turn feel silent. Bots can opt out via silentTurnReactions.
   // React 冲! on the triggering message the instant it's accepted. Binding to the
   // message — not a worker status edge — means type-ahead / busy-batched messages
   // each get their own ✋. `finishTurnReactions` flips every pending ✋ to ✅ when
@@ -3156,7 +3157,9 @@ export async function noteTurnReceived(
   if (ds.session.vcMeetingReceiver) return;
   // Turn-exact card-off check: the reaction ack belongs to THIS message's turn,
   // not to whichever turn most recently overwrote currentReplyTarget.
-  if (!streamingCardDisabledFor(ds, triggerMessageId)) return;
+  const cardDisabled = streamingCardDisabledFor(ds, turnId ?? triggerMessageId);
+  const clearOnReply = ds.scope === 'thread' && !cardDisabled;
+  if (!cardDisabled && !clearOnReply) return;
   if (silentTurnReactionsFor(ds)) return;
   // Only Lark messages carry reactions — doc-comment ids / chat anchors can't.
   if (!triggerMessageId.startsWith('om_')) return;
@@ -3174,7 +3177,12 @@ export async function noteTurnReceived(
     logger.debug(`[reaction] received add failed for ${triggerMessageId}: ${err instanceof Error ? err.message : String(err)}`);
     return;
   }
-  (ds.pendingAckReactions ??= []).push({ messageId: triggerMessageId, reactionId });
+  (ds.pendingAckReactions ??= []).push({
+    messageId: triggerMessageId,
+    reactionId,
+    turnId: turnId ?? triggerMessageId,
+    ...(clearOnReply ? { clearOnReply: true } : {}),
+  });
 }
 
 async function sessionReply(
@@ -4314,12 +4322,10 @@ function getActiveCount(): number {
 }
 
 /**
- * Freeze the previous turn's streaming card at "idle" and mark a new turn so the
- * next screen_update from the worker POSTs a fresh streaming card instead of
- * PATCH-ing the previous one. Shared by the normal-message path and the
- * passthrough slash-command path (/model, /clear, /compact, etc.) — without
- * this, passthrough commands silently PATCH the previous card and the user
- * sees no visible response.
+ * Start a new streaming-card turn. Thread sessions PATCH their existing status
+ * card in place; flat chat sessions freeze the previous card and POST a fresh
+ * one so the new activity remains visible in the main timeline. Shared by the
+ * normal-message and passthrough slash-command paths.
  */
 function beginNewTurn(ds: DaemonSession, title: string, turnId: string): void {
   // docCommentTargets 改为 per-turn map（按 turnId 索引），不再需要每轮清空：
@@ -4329,6 +4335,7 @@ function beginNewTurn(ds: DaemonSession, title: string, turnId: string): void {
   // in. A new turn returns to the config default (noCardChats / disableStreamingCard).
   // Use `/card on` to persistently restore cards for the chat.
   ds.streamingCardForced = undefined;
+  if (reuseThreadStreamingCardForTurn(ds, title, turnId)) return;
   const previousUsageLimit = ds.usageLimit;
   const previousStatus = ds.lastScreenStatus === 'limited' && previousUsageLimit ? 'limited' : 'idle';
   if (ds.streamCardId && workerHasInitialized(ds)) {
@@ -19566,37 +19573,30 @@ async function handleThreadReplyAdmitted(
       if (openingTurn && !accepted) releaseInitialUserTurn(ds);
     }
   } else {
-    // Worker not running — re-fork with resume. This is a NEW turn, so drop
-    // any restored streaming-card reference; worker_ready will POST a fresh
-    // card instead of PATCHing the previous turn's card in place.
+    // Worker not running — re-fork with resume. Thread sessions keep their
+    // stable status card for worker_ready to PATCH; flat chats retain the
+    // fresh-card handoff so new activity appears in the main timeline.
     logger.info(`[${tag(ds)}] Worker not running, re-forking...`);
     // 飞书消息轮（非文档评论轮）：docCommentTargets 是 per-turn map，本轮 turnId
     // 不会命中文档评论的 key，无需显式清盘。
-    if (ds.usageLimitRetryTimer) {
-      clearTimeout(ds.usageLimitRetryTimer);
-      ds.usageLimitRetryTimer = undefined;
+    if (!reuseThreadStreamingCardForTurn(ds, parsed.content, parsed.messageId)) {
+      if (ds.usageLimitRetryTimer) {
+        clearTimeout(ds.usageLimitRetryTimer);
+        ds.usageLimitRetryTimer = undefined;
+      }
+      ds.usageLimit = undefined;
+      ds.currentTurnTitle = parsed.content.substring(0, 50);
+      // With no worker, park the current card until its flat-chat successor is
+      // visible. If fork / worker_ready / POST fails, the old card remains.
+      parkStreamCard(ds);
+      ds.streamCardId = undefined;
+      ds.streamCardNonce = undefined;
+      ds.streamCardPending = true;
+      ds.streamCardPendingTurnId = parsed.messageId;
+      ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
+      ds.currentImageKey = undefined;
+      persistStreamCardState(ds);
     }
-    ds.usageLimit = undefined;
-    ds.currentTurnTitle = parsed.content.substring(0, 50);
-    // The cosmetic freeze step (above) is gated on a live worker. With no
-    // worker we just park the current card in frozenCards — the upcoming
-    // new POST will recall it. Parking instead of deleting preserves the
-    // "old card stays until a new one is live" invariant: if fork /
-    // worker_ready / POST fails, the user still sees the previous card.
-    parkStreamCard(ds);
-    ds.streamCardId = undefined;
-    ds.streamCardNonce = undefined;
-    // This is a new turn even though the worker is currently down. Force the
-    // first screen_update from the re-forked worker to POST a fresh card and
-    // drop any persisted screenshot from the previous turn. Otherwise a stale
-    // image_key (for example an old Claude Code frame) can be reused on the
-    // new Worker card until the next screenshot upload, which makes a fresh
-    // @mention appear to resurrect the wrong CLI UI.
-    ds.streamCardPending = true;
-    ds.streamCardPendingTurnId = parsed.messageId;
-    ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
-    ds.currentImageKey = undefined;
-    persistStreamCardState(ds);
     // Wrap the user message in the same `<user_message>` / `<session_id>` /
     // `<botmux_reminder>` envelope as live-worker turns. Without this, the
     // initial prompt that worker queues for the freshly-spawned CLI is the
@@ -20208,17 +20208,19 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
 
       // Worker 挂起 / 已退出 —— resume 重 fork（与 handleThreadReply 同路）。
       logger.info(`[${tag(ds)}] Worker not running for doc-comment, re-forking...`);
-      if (ds.usageLimitRetryTimer) { clearTimeout(ds.usageLimitRetryTimer); ds.usageLimitRetryTimer = undefined; }
-      ds.usageLimit = undefined;
-      ds.currentTurnTitle = text.substring(0, 50);
-      parkStreamCard(ds);
-      ds.streamCardId = undefined;
-      ds.streamCardNonce = undefined;
-      ds.streamCardPending = true;
-      ds.streamCardPendingTurnId = turnId;
-      ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
-      ds.currentImageKey = undefined;
-      persistStreamCardState(ds);
+      if (!reuseThreadStreamingCardForTurn(ds, text, turnId)) {
+        if (ds.usageLimitRetryTimer) { clearTimeout(ds.usageLimitRetryTimer); ds.usageLimitRetryTimer = undefined; }
+        ds.usageLimit = undefined;
+        ds.currentTurnTitle = text.substring(0, 50);
+        parkStreamCard(ds);
+        ds.streamCardId = undefined;
+        ds.streamCardNonce = undefined;
+        ds.streamCardPending = true;
+        ds.streamCardPendingTurnId = turnId;
+        ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
+        ds.currentImageKey = undefined;
+        persistStreamCardState(ds);
+      }
       // Skip whiteboard ensure for adopted (bridge) sessions on re-fork — mirrors
       // the live-worker branch above (if (!isBridge) ensure…).
       if (!ds.adoptedFrom) ensureSessionWhiteboard(ds);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4443,7 +4443,6 @@ async function prewarmDocCommentSession(ds: DaemonSession, sub: DocSubscription)
     );
   }
 
-  beginNewTurn(ds, title, turnId);
   ds.lastMessageAt = Date.now();
   ds.session.lastMessageAt = new Date(ds.lastMessageAt).toISOString();
   if (sub.workingDir && (!ds.worker || ds.worker.killed)) {
@@ -4464,11 +4463,12 @@ async function prewarmDocCommentSession(ds: DaemonSession, sub: DocSubscription)
       sender,
       mode: 'live',
     });
-    rememberLastCliInput(ds, promptContent, cliInput);
-    sessionStore.updateSession(ds.session);
     if (!sendWorkerInput(ds, cliInput, turnId)) {
       throw new Error('doc-watch warmup worker input was not accepted');
     }
+    beginNewTurn(ds, title, turnId);
+    rememberLastCliInput(ds, promptContent, cliInput);
+    sessionStore.updateSession(ds.session);
     markSessionActivity(ds);
   } else {
     ensureSessionWhiteboard(ds);
@@ -4481,9 +4481,12 @@ async function prewarmDocCommentSession(ds: DaemonSession, sub: DocSubscription)
       sender,
       mode: 'refork',
     });
+    if (!forkWorker(ds, wrappedInput, ds.hasHistory)) {
+      throw new Error('doc-watch warmup worker fork was not accepted');
+    }
+    beginNewTurn(ds, title, turnId);
     rememberLastCliInput(ds, promptContent, wrappedInput);
     sessionStore.updateSession(ds.session);
-    forkWorker(ds, wrappedInput, ds.hasHistory);
   }
   logger.info(`[${tag(ds)}] doc-comment watch prewarm injected file=${sub.fileToken.slice(0, 12)}`);
 }
@@ -20230,7 +20233,6 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
           sender,
           mode: 'live',
         });
-        beginNewTurn(ds, text, turnId);
         (ds.session.docCommentTargets ??= {})[turnId] = docTarget; // per-turn map，不覆盖其他并发轮
         // rememberLastCliInput persists both the exact comment target and the
         // structured sidecar before any worker-visible delivery can occur.
@@ -20243,6 +20245,7 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
         if (!sendWorkerInput(ds, cliInput, turnId)) {
           throw new Error('worker became unavailable during comment:live-send');
         }
+        beginNewTurn(ds, text, turnId);
         logger.info(`[${tag(ds)}] doc-comment turn injected (turn ${turnId.slice(0, 8)})`);
         return;
       }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16517,6 +16517,21 @@ function forkReservedInitialSession(ds: DaemonSession, availableBots: AvailableB
   }
 }
 
+/** A pinned initial session has no durable pending-repo journal. If its fork
+ * fails, undo the reaction registered immediately before admission. */
+async function forkPinnedInitialSession(
+  ds: DaemonSession,
+  availableBots: AvailableBot[],
+  turnId: string,
+): Promise<void> {
+  try {
+    forkReservedInitialSession(ds, availableBots);
+  } catch (err) {
+    await discardTurnReceivedReaction(ds, turnId);
+    throw err;
+  }
+}
+
 /** Raw slash-command cold starts type the raw command only after prompt_ready.
  * Buffer later same-anchor messages into the ordered follow-up payload carried
  * on that same raw_input IPC; a separate worker message could overtake the
@@ -17753,7 +17768,7 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
     });
     const availableBots = await getAvailableBots(larkAppId, chatId);
     await noteTurnReceived(ds, messageId, content, newTopicSender, messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
-    forkReservedInitialSession(ds, availableBots);
+    await forkPinnedInitialSession(ds, availableBots, messageId);
     // fork 成功即开场已交给 CLI；fork 抛错则开场只存在于内存，保持重发提示。
     markIngressAdmitted(ctx);
     const reason = oncallEntry
@@ -18226,11 +18241,12 @@ async function handleBotAdded(
       }
       await noteTurnReceived(ds, anchor, promptBody);
       if (joinBootstrapWasTakenOver()) {
+        await discardTurnReceivedReaction(ds, anchor);
         withdrawSharedReplySeed();
         return;
       }
       armSharedReplyTarget();
-      forkReservedInitialSession(ds, availableBots);
+      await forkPinnedInitialSession(ds, availableBots, anchor);
       ds.pendingTurnId = undefined;
       ds.pendingChatContext = undefined;
       logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 自动开工（${mode}/${scope}），workingDir=${pinnedWorkingDir}`);
@@ -19441,7 +19457,7 @@ async function handleThreadReplyAdmitted(
       ensureSessionWhiteboard(newDs);
       const availableBots = await getAvailableBots(larkAppId, autoCreateChatId);
       await noteTurnReceived(newDs, parsed.messageId, parsed.content, autoCreateSender, parsed.messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
-      forkReservedInitialSession(newDs, availableBots);
+      await forkPinnedInitialSession(newDs, availableBots, parsed.messageId);
       // fork 成功即开场已交给 CLI；fork 抛错则开场只存在于内存，保持重发提示。
       markIngressAdmitted(ctx);
       const reason = oncallEntry

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -49,7 +49,7 @@ import {
 } from './core/supervisor-shutdown-protocol.js';
 import { readSupervisorProcessStartIdentity } from './core/process-start-identity.js';
 import { statSync } from 'node:fs';
-import { addReaction, deleteMessage, getChatContext, getChatMode, getChatNameAndMode, getMessageChatId, listChatMemberOpenIds, MessageWithdrawnError, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage, type EntryResolveStatus } from './im/lark/client.js';
+import { addReaction, deleteMessage, getChatContext, getChatMode, getChatNameAndMode, getMessageChatId, listChatMemberOpenIds, MessageWithdrawnError, removeReaction, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage, type EntryResolveStatus } from './im/lark/client.js';
 import { resolveGroupJoinPrompt, waitForAllowedUserInChat } from './core/auto-start.js';
 import {
   loadBotConfigAtIndex,
@@ -3183,6 +3183,25 @@ export async function noteTurnReceived(
     turnId: turnId ?? triggerMessageId,
     ...(clearOnReply ? { clearOnReply: true } : {}),
   });
+}
+
+/** Undo the progress reaction when a turn never reaches durable worker
+ * ownership. Detach the exact turn before awaiting Lark so a concurrent reply
+ * signal cannot remove the same reaction twice. */
+async function discardTurnReceivedReaction(ds: DaemonSession, turnId: string): Promise<void> {
+  const list = ds.pendingAckReactions;
+  if (!list || list.length === 0) return;
+  const discarded = list.filter(ack => (ack.turnId ?? ack.messageId) === turnId);
+  if (discarded.length === 0) return;
+  ds.pendingAckReactions = list.filter(ack => !discarded.includes(ack));
+  for (const ack of discarded) {
+    if (!ack.reactionId) continue;
+    try {
+      await removeReaction(ds.larkAppId, ack.messageId, ack.reactionId);
+    } catch (err) {
+      logger.debug(`[reaction] failed to clear unaccepted reaction ${ack.reactionId}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 }
 
 async function sessionReply(
@@ -19571,6 +19590,7 @@ async function handleThreadReplyAdmitted(
       // The opening is one-shot: give it back when the worker died / refused,
       // so the next message re-opens instead of silently losing the context.
       if (openingTurn && !accepted) releaseInitialUserTurn(ds);
+      if (!accepted) await discardTurnReceivedReaction(ds, parsed.messageId);
     }
   } else {
     // Worker not running — re-fork with resume. Thread sessions keep their
@@ -19833,12 +19853,14 @@ async function handleThreadReplyAdmitted(
       }
     } catch (e) {
       if (openingTurn) releaseInitialUserTurn(ds);
+      if (!queuedHasDurableTail) await discardTurnReceivedReaction(ds, parsed.messageId);
       throw e;
     }
     // refork 成功才算本轮已交给 CLI。fork 抛错（rethrow）或返回 false（quarantine /
     // 会话已非 active 的不抛错拒绝腿）时，本轮只存在于内存、无 durable 兜底，
     // 必须保持「请重发」提示——与 live 分支按 accepted 打标对称。
     if (reforkAccepted) markIngressAdmitted(ctx);
+    else if (!queuedHasDurableTail) await discardTurnReceivedReaction(ds, parsed.messageId);
     // Record the input as the session's last real CLI turn ONLY after the fork
     // succeeded. Recording before the fork (the old order) persisted lastCliInput
     // for a turn that never launched when forkWorker threw; the retry then read

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16743,13 +16743,22 @@ function deliverPassthroughToExistingSession(
     // clearing the marker would lose the opening for the next real turn.
     // `/model` on an empty-started session therefore stays literal and the
     // FOLLOWING business message still opens as a new topic.
-    beginNewTurn(ds, commandContent, turn.messageId);
-    sendWorkerSessionInput(ds, {
+    const accepted = sendWorkerSessionInput(ds, {
       type: 'raw_input',
       content: commandContent,
       turnId: turn.messageId,
     });
+    if (!accepted) {
+      void sessionReply(
+        anchor,
+        tr('daemon.cmd_needs_active_cli', { cmd }, localeForBot(larkAppId)),
+        'text',
+        larkAppId,
+      );
+      return;
+    }
     turn.onDelivered?.();
+    beginNewTurn(ds, commandContent, turn.messageId);
     markSessionActivity(ds);
     logger.info(`[${anchor.substring(0, 12)}] Passthrough ${cmd} → worker`);
     return;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4355,6 +4355,7 @@ function beginNewTurn(ds: DaemonSession, title: string, turnId: string): void {
   // Use `/card on` to persistently restore cards for the chat.
   ds.streamingCardForced = undefined;
   if (reuseThreadStreamingCardForTurn(ds, title, turnId)) return;
+  if (ds.scope === 'thread') ds.streamCardVisualTurnId = turnId;
   const previousUsageLimit = ds.usageLimit;
   const previousStatus = ds.lastScreenStatus === 'limited' && previousUsageLimit ? 'limited' : 'idle';
   if (ds.streamCardId && workerHasInitialized(ds)) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16497,12 +16497,12 @@ export const __testOnly_onQueuedActivationSubmitted = onQueuedActivationSubmitte
  * deliberately no await between the final buffered-input snapshot, fork, and
  * release: a later handler either buffers before this block or observes the
  * live worker after it. */
-function forkReservedInitialSession(ds: DaemonSession, availableBots: AvailableBot[]): void {
+function forkReservedInitialSession(ds: DaemonSession, availableBots: AvailableBot[]): boolean {
   const userPrompt = ds.pendingPrompt ?? '';
   const input = buildReservedInitialInput(ds, availableBots);
   rememberLastCliInput(ds, userPrompt, input);
   const turnId = ds.pendingTurnId ?? ds.session.pendingRepoSetup?.turnId;
-  forkWorker(ds, input, turnId ? { turnId } : false);
+  if (!forkWorker(ds, input, turnId ? { turnId } : false)) return false;
   ds.pendingTurnId = undefined;
   // A no-project pendingRepo fallback enters forkWorker with `session.queued`
   // still set. forkWorker materializes the exact opening as a tokened
@@ -16518,6 +16518,7 @@ function forkReservedInitialSession(ds: DaemonSession, availableBots: AvailableB
     // still being built. Hand off now, or defer until its reservation settles.
     void releaseQueuedActivationReservation(ds);
   }
+  return true;
 }
 
 /** A pinned initial session has no durable pending-repo journal. If its fork
@@ -16528,7 +16529,9 @@ async function forkPinnedInitialSession(
   turnId: string,
 ): Promise<void> {
   try {
-    forkReservedInitialSession(ds, availableBots);
+    if (!forkReservedInitialSession(ds, availableBots)) {
+      throw new Error(`Worker refused pinned initial turn ${turnId}`);
+    }
   } catch (err) {
     await discardTurnReceivedReaction(ds, turnId);
     throw err;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -19582,7 +19582,6 @@ async function handleThreadReplyAdmitted(
           codexAppApplicationContext,
           codexAppMessageContext,
         });
-    beginNewTurn(ds, parsed.content, parsed.messageId);
     await noteTurnReceived(ds, parsed.messageId, parsed.content, turnSender, parsed.messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
     // Codex App steer authorization was computed ONCE before the branch split
     // above (R4-B1); reuse the same frozen value here for the live-worker path.
@@ -19600,6 +19599,10 @@ async function handleThreadReplyAdmitted(
         // 消息已实际送入 live worker——之后的收尾失败不得再诱导重发。
         markIngressAdmitted(ctx);
         rememberLastCliInput(ds, promptContent, cliInput);
+        // A stable thread card represents work that the CLI actually accepted.
+        // Keep the previous completed card intact when the live worker refuses
+        // or throws before admission.
+        beginNewTurn(ds, parsed.content, parsed.messageId);
       }
       else logger.warn(`[${tag(ds)}] Inbound ${parsed.messageId} was not accepted by the live worker`);
     } finally {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4466,9 +4466,8 @@ async function prewarmDocCommentSession(ds: DaemonSession, sub: DocSubscription)
     if (!sendWorkerInput(ds, cliInput, turnId)) {
       throw new Error('doc-watch warmup worker input was not accepted');
     }
-    beginNewTurn(ds, title, turnId);
     rememberLastCliInput(ds, promptContent, cliInput);
-    sessionStore.updateSession(ds.session);
+    beginNewTurn(ds, title, turnId);
     markSessionActivity(ds);
   } else {
     ensureSessionWhiteboard(ds);
@@ -4484,9 +4483,8 @@ async function prewarmDocCommentSession(ds: DaemonSession, sub: DocSubscription)
     if (!forkWorker(ds, wrappedInput, ds.hasHistory)) {
       throw new Error('doc-watch warmup worker fork was not accepted');
     }
-    beginNewTurn(ds, title, turnId);
     rememberLastCliInput(ds, promptContent, wrappedInput);
-    sessionStore.updateSession(ds.session);
+    beginNewTurn(ds, title, turnId);
   }
   logger.info(`[${tag(ds)}] doc-comment watch prewarm injected file=${sub.fileToken.slice(0, 12)}`);
 }
@@ -18306,6 +18304,7 @@ async function handleBotAdded(
       }
       await noteTurnReceived(ds, anchor, promptBody);
       if (joinBootstrapWasTakenOver()) {
+        await discardTurnReceivedReaction(ds, anchor);
         withdrawSharedReplySeed();
         return;
       }

--- a/src/services/usage-ledger.ts
+++ b/src/services/usage-ledger.ts
@@ -429,6 +429,12 @@ interface DaemonSessionLedgerOpts {
   ledgerDir?: string;
 }
 
+interface DaemonSessionUsageRecordOpts extends DaemonSessionLedgerOpts {
+  /** Exact settled turn. Used only by recordUsageForDaemonSession so a late
+   *  turn boundary cannot borrow a newer turn's caller attribution. */
+  turnId?: string;
+}
+
 /** The CLI-native session id a ledger record should carry. coco is spawned
  *  with `--session-id <botmux sessionId>` and the worker never sets a separate
  *  cliSessionId (there is nothing to adopt) — but the botmux session id IS
@@ -441,9 +447,16 @@ function ledgerCliSessionId(s: { cliId?: string; sessionId: string; cliSessionId
   return s.cliId === 'coco' ? s.sessionId : undefined;
 }
 
-function ledgerArgsForDaemonSession(ds: DaemonSession): Omit<RecordSessionUsageArgs, 'usage'> & { usage: SessionTokenUsage | null } {
+function ledgerArgsForDaemonSession(
+  ds: DaemonSession,
+  turnId?: string,
+): Omit<RecordSessionUsageArgs, 'usage'> & { usage: SessionTokenUsage | null } {
   const s = ds.session;
   const workingDir = ds.workingDir ?? s.workingDir;
+  const exactCallerOpenId = turnId
+    ? (s.replyTargets?.[turnId]?.senderOpenId
+      ?? (s.quoteTargetId === turnId ? s.quoteTargetSenderOpenId : undefined))
+    : undefined;
   // fresh: ledger snapshots are turn-boundary exact — bypass the dashboard
   // read throttle (incremental folding keeps this cheap).
   const usage = getSessionTokenUsage({
@@ -463,16 +476,19 @@ function ledgerArgsForDaemonSession(ds: DaemonSession): Omit<RecordSessionUsageA
     chatId: s.chatId,
     title: s.title,
     workingDir,
-    callerOpenId: s.lastCallerOpenId ?? s.creatorOpenId ?? s.ownerOpenId,
+    callerOpenId: turnId
+      ? (exactCallerOpenId ?? s.creatorOpenId ?? s.ownerOpenId)
+      : (s.lastCallerOpenId ?? s.creatorOpenId ?? s.ownerOpenId),
   };
 }
 
 /** Turn boundary (idle/limited edge, session close): append the delta. */
-export function recordUsageForDaemonSession(ds: DaemonSession, opts?: DaemonSessionLedgerOpts): UsageLedgerRecord | null {
+export function recordUsageForDaemonSession(ds: DaemonSession, opts?: DaemonSessionUsageRecordOpts): UsageLedgerRecord | null {
   try {
-    const args = ledgerArgsForDaemonSession(ds);
+    const { turnId, ...recordOpts } = opts ?? {};
+    const args = ledgerArgsForDaemonSession(ds, turnId);
     if (!args.usage) return null;
-    return recordSessionUsage({ ...args, usage: args.usage, ...opts });
+    return recordSessionUsage({ ...args, usage: args.usage, ...recordOpts });
   } catch (err: any) {
     logger.error(`usage-ledger: failed to record daemon session usage: ${err?.message ?? err}`);
     return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1024,7 +1024,7 @@ export type WorkerToDaemon =
   | { type: 'stuck_warning_expired'; nonce: number; turnId?: string; dispatchAttempt?: number }
   | { type: 'tui_keys_delivered'; nonce: number; turnId?: string; dispatchAttempt?: number }
   | { type: 'screenshot_uploaded'; imageKey: string; status: ScreenStatus; usageLimit?: CliUsageLimitState; turnId?: string; dispatchAttempt?: number }
-  | { type: 'user_notify'; message: string; turnId?: string; dispatchAttempt?: number }
+  | { type: 'user_notify'; message: string; turnId?: string; dispatchAttempt?: number; settlesTurn?: true }
   /** A normal success acknowledgement for one app-server accepted steer.
    * `appTurnId` is diagnostic/protocol identity; `turnId` is the immutable
    * botmux/Lark reply route. This must never enter the attention path. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9611,6 +9611,7 @@ function scheduleSubmitFailureNotify(
       send({
         type: 'user_notify',
         turnId: turnIdentity?.turnId ?? currentBotmuxTurnId,
+        settlesTurn: true,
         message: t('worker.submit_impossible', { cliName: cliName(), reason, preview }),
       });
     }
@@ -9700,6 +9701,7 @@ function scheduleSubmitFailureNotify(
       send({
         type: 'user_notify',
         turnId: turnIdentity?.turnId ?? currentBotmuxTurnId,
+        settlesTurn: true,
         message: t(
           effectiveBackendType === 'zmx'
             ? 'worker.submit_unconfirmed_zmx'

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -601,6 +601,7 @@ function notifyRpcTeardownBeforeActivation(
   const completedBeforeActivation = terminalStatus === 'completed';
   send({
     type: 'user_notify',
+    settlesTurn: true,
     message: completedBeforeActivation
       ? 'Codex RPC 消息已执行完成，但会话在本地完成生命周期登记前重启，兜底输出可能未被捕获；原消息未自动重发，如未看到回复请先查看终端结果再人工跟进。'
       : 'Codex RPC 消息已写出，但会话在取得 turn/start 归属前重启；为避免重复执行未自动重发，请按需人工确认结果。',
@@ -7069,6 +7070,7 @@ async function writeAdoptMessage(
       send({
         type: 'user_notify',
         turnId,
+        settlesTurn: true,
         message: 'Adopt input could not be reconciled because the CLI backend changed while it was being written. Please verify the terminal before retrying.',
       });
     }

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -15,13 +15,14 @@ import { normalizeFeedbackPolicy } from '../src/services/feedback-policy.js';
 
 const updateMessageMock = vi.fn(async () => {});
 const addReactionMock = vi.fn(async () => 'reaction_id');
+const removeReactionMock = vi.fn(async () => {});
 const replyToDocCommentMock = vi.fn(async () => {});
 const removeCommentReactionMock = vi.fn(async () => {});
 const updateSessionMock = vi.fn();
 vi.mock('../src/im/lark/client.js', () => ({
   updateMessage: (...args: any[]) => updateMessageMock(...args),
   addReaction: (...args: any[]) => addReactionMock(...args),
-  removeReaction: vi.fn(async () => {}),
+  removeReaction: (...args: any[]) => removeReactionMock(...args),
   sendUserMessage: vi.fn(async () => {}),
   deleteMessage: vi.fn(async () => {}),
   getChatInfo: vi.fn(),
@@ -1470,6 +1471,9 @@ describe('Bridge final_output delivery (P2 retry)', () => {
 
     const ds = makeDs();
     ds.session.quoteTargetId = 'om_user';
+    ds.pendingAckReactions = [{
+      messageId: 'om_user', reactionId: 'reaction_progress', turnId: 'turn-1', clearOnReply: true,
+    }];
 
     const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
     __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
@@ -1478,9 +1482,9 @@ describe('Bridge final_output delivery (P2 retry)', () => {
 
     expect(sessionReply).toHaveBeenCalledTimes(1);
     expect(updateMessageMock).not.toHaveBeenCalled();
-    // Turn reactions are driven off message acceptance (noteTurnReceived) and
-    // the idle edge (finishTurnReactions), not the bridge final-output path.
+    expect(removeReactionMock).toHaveBeenCalledWith('app_test', 'om_user', 'reaction_progress');
     expect(addReactionMock).not.toHaveBeenCalled();
+    expect(ds.pendingAckReactions).toEqual([]);
     expect(ds.lastBridgeEmittedUuid).toBe(SCOPED_DEDUPE_KEY);
   });
 

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -637,6 +637,10 @@ describe('Bridge final_output delivery (P2 retry)', () => {
       { dispatchId: 'dispatch-ok-head', turnId: 'turn-ok-head', state: 'prepared', content: 'superseded', deliverySink: 'lark', codexAppSteerable: true },
       { dispatchId: 'dispatch-ok-next', turnId: 'turn-ok-next', state: 'accepted', content: 'real', deliverySink: 'lark', codexAppSteerable: true },
     ];
+    ds.pendingAckReactions = [
+      { messageId: 'om_superseded', reactionId: 'reaction_superseded', turnId: 'turn-ok-head', clearOnReply: true },
+      { messageId: 'om_next', reactionId: 'reaction_next', turnId: 'turn-ok-next', clearOnReply: true },
+    ];
     __testOnly_setupWorkerHandlers(ds, ds.worker as any);
 
     (ds.worker as any).emit('message', {
@@ -658,6 +662,12 @@ describe('Bridge final_output delivery (P2 retry)', () => {
       }),
     ));
     expect(sessionReply).not.toHaveBeenCalled();
+    expect(removeReactionMock).toHaveBeenCalledWith(
+      'app_test', 'om_superseded', 'reaction_superseded',
+    );
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_next', reactionId: 'reaction_next', turnId: 'turn-ok-next', clearOnReply: true,
+    }]);
     await vi.waitFor(() => expect(ds.session.codexAppDispatchLedger?.length).toBe(1));
     expect(ds.session.codexAppDispatchLedger?.[0]?.dispatchId).toBe('dispatch-ok-next');
   });

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -2604,8 +2604,12 @@ describe('Worker turn_terminal routing', () => {
   it('reports a managed CLI exit even when the Node worker stays alive', async () => {
     const ds = makeDs();
     const onCliExit = vi.fn(async () => {});
+    const sessionReply = vi.fn(async () => 'om_reply');
+    ds.pendingAckReactions = [{
+      messageId: 'om_live', reactionId: 'reaction_live', turnId: 'om_live', clearOnReply: true,
+    }];
     initWorkerPool({
-      sessionReply: vi.fn(async () => 'om_reply'),
+      sessionReply,
       getSessionWorkingDir: () => '/tmp',
       getActiveCount: () => 1,
       closeSession: vi.fn(),
@@ -2625,9 +2629,11 @@ describe('Worker turn_terminal routing', () => {
     });
 
     (ds.worker as any).emit('message', {
-      type: 'claude_exit', code: 9, signal: 'SIGKILL',
+      type: 'claude_exit', code: 9, signal: 'SIGKILL', turnId: 'om_live',
     } satisfies Extract<WorkerToDaemon, { type: 'claude_exit' }>);
-    await Promise.resolve();
+    await vi.waitFor(() => expect(removeReactionMock).toHaveBeenCalledWith(
+      'app_test', 'om_live', 'reaction_live',
+    ));
 
     expect(onCliExit).toHaveBeenCalledWith(ds, {
       sessionId: ds.session.sessionId,
@@ -2636,6 +2642,7 @@ describe('Worker turn_terminal routing', () => {
       signal: 'SIGKILL',
     });
     expect(ds.managedTurnOrigin).toBeUndefined();
+    expect(ds.pendingAckReactions).toEqual([]);
   });
 
   it('ignores stale-worker CLI exit authority changes after replacement', async () => {

--- a/test/claude-turn-terminal-contract.test.ts
+++ b/test/claude-turn-terminal-contract.test.ts
@@ -212,9 +212,11 @@ describe('Claude durable turn terminal contract', () => {
     expect(source).toContain("emitDurableTerminal(`submit_impossible:${reason}`)");
     expect(source).toContain("emitDurableTerminal('submit_usage_limit')");
     expect(source).toContain("emitDurableTerminal('submit_unconfirmed')");
-    expect(source.match(/settlesTurn: true/g)).toHaveLength(2);
+    expect(source.match(/settlesTurn: true/g)).toHaveLength(4);
     expect(source).toMatch(/type: 'user_notify',[\s\S]*?settlesTurn: true,[\s\S]*?worker\.submit_impossible/);
     expect(source).toMatch(/type: 'user_notify',[\s\S]*?settlesTurn: true,[\s\S]*?worker\.submit_unconfirmed/);
+    expect(source).toMatch(/function notifyRpcTeardownBeforeActivation[\s\S]*?type: 'user_notify',[\s\S]*?settlesTurn: true/);
+    expect(source).toMatch(/const settleStaleAfterWrite[\s\S]*?type: 'user_notify',[\s\S]*?settlesTurn: true/);
     expect(source).toContain('dropFailedBridgeMark(bridgeTurnId, turnIdentity?.dispatchAttempt)');
     expect(source).toContain("'terminal_bridge_unavailable'");
     expect(source).toMatch(/emitTurnTerminal\([\s\S]*?'ambiguous',[\s\S]*?'cli_exit'/);

--- a/test/claude-turn-terminal-contract.test.ts
+++ b/test/claude-turn-terminal-contract.test.ts
@@ -212,6 +212,9 @@ describe('Claude durable turn terminal contract', () => {
     expect(source).toContain("emitDurableTerminal(`submit_impossible:${reason}`)");
     expect(source).toContain("emitDurableTerminal('submit_usage_limit')");
     expect(source).toContain("emitDurableTerminal('submit_unconfirmed')");
+    expect(source.match(/settlesTurn: true/g)).toHaveLength(2);
+    expect(source).toMatch(/type: 'user_notify',[\s\S]*?settlesTurn: true,[\s\S]*?worker\.submit_impossible/);
+    expect(source).toMatch(/type: 'user_notify',[\s\S]*?settlesTurn: true,[\s\S]*?worker\.submit_unconfirmed/);
     expect(source).toContain('dropFailedBridgeMark(bridgeTurnId, turnIdentity?.dispatchAttempt)');
     expect(source).toContain("'terminal_bridge_unavailable'");
     expect(source).toMatch(/emitTurnTerminal\([\s\S]*?'ambiguous',[\s\S]*?'cli_exit'/);

--- a/test/cli-runtime-display.test.ts
+++ b/test/cli-runtime-display.test.ts
@@ -82,10 +82,10 @@ describe('CLI runtime display identity', () => {
     expect(body).toContain('ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1');
   });
 
-  it('keeps the stable thread card across normal and doc-comment re-forks', () => {
+  it('routes normal and doc-comment reforks through the post-admission turn handoff', () => {
     const source = readFileSync(new URL('../src/daemon.ts', import.meta.url), 'utf8');
 
-    expect(source).toContain('reuseThreadStreamingCardForTurn(ds, parsed.content, parsed.messageId)');
-    expect(source).toContain('reuseThreadStreamingCardForTurn(ds, text, turnId)');
+    expect(source).toMatch(/reforkAccepted = forkWorker[\s\S]*if \(reforkAccepted\) \{[\s\S]*beginNewTurn\(ds, parsed\.content, parsed\.messageId\)/);
+    expect(source).toMatch(/forkWorker\(ds, wrappedInput, \{ resume: ds\.hasHistory, turnId \}\)[\s\S]*beginNewTurn\(ds, text, turnId\)/);
   });
 });

--- a/test/cli-runtime-display.test.ts
+++ b/test/cli-runtime-display.test.ts
@@ -67,14 +67,25 @@ describe('CLI runtime display identity', () => {
     expect(body).toMatch(/getDaemonStreamingCardUsageSnapshot[\s\S]*runtimeDisplayName,/);
   });
 
-  it('starts the current turn card at message acceptance instead of waiting for terminal redraw', () => {
+  it('reuses a thread card at acceptance and keeps the fresh-card fallback', () => {
     const source = readFileSync(new URL('../src/daemon.ts', import.meta.url), 'utf8');
     const begin = source.indexOf('function beginNewTurn(');
     const end = source.indexOf('\nfunction ', begin + 1);
     const body = source.slice(begin, end);
 
+    const reuse = body.indexOf('reuseThreadStreamingCardForTurn(ds, title, turnId)');
+    const freeze = body.indexOf('const previousUsageLimit = ds.usageLimit');
+    expect(reuse).toBeGreaterThan(-1);
+    expect(freeze).toBeGreaterThan(reuse);
     expect(body).toContain('postTurnStartingCard(ds, sessionReply, turnId)');
     expect(body).toContain('ds.streamCardPendingTurnId = turnId');
     expect(body).toContain('ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1');
+  });
+
+  it('keeps the stable thread card across normal and doc-comment re-forks', () => {
+    const source = readFileSync(new URL('../src/daemon.ts', import.meta.url), 'utf8');
+
+    expect(source).toContain('reuseThreadStreamingCardForTurn(ds, parsed.content, parsed.messageId)');
+    expect(source).toContain('reuseThreadStreamingCardForTurn(ds, text, turnId)');
   });
 });

--- a/test/daemon-ordinary-ingress-failure-notice.test.ts
+++ b/test/daemon-ordinary-ingress-failure-notice.test.ts
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
     replyMessage: vi.fn(async () => 'om_reply'),
     sendMessage: vi.fn(async () => 'om_top'),
     addReaction: vi.fn(async () => 'reaction_received'),
+    removeReaction: vi.fn(async () => undefined),
     getChatMode: vi.fn(async () => 'group' as 'group' | 'topic' | 'p2p'),
     getChatNameAndMode: vi.fn(async () => ({ name: null, mode: 'group' as const })),
     resolveSender: vi.fn(async (_appId: string, openId: string | undefined, senderType: string | undefined) => (
@@ -63,7 +64,9 @@ const mocks = vi.hoisted(() => {
     }),
     forkWorker: vi.fn((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     }),
+    sendWorkerInput: vi.fn(() => true),
     scanMultipleProjects: vi.fn(() => [] as any[]),
     getAvailableBots: vi.fn(async () => [] as any[]),
     downloadResources: vi.fn(async () => ({ attachments: [], needLogin: false })),
@@ -92,6 +95,7 @@ vi.mock('../src/im/lark/client.js', async () => {
     replyMessage: mocks.replyMessage,
     sendMessage: mocks.sendMessage,
     addReaction: mocks.addReaction,
+    removeReaction: mocks.removeReaction,
     getChatMode: mocks.getChatMode,
     getChatNameAndMode: mocks.getChatNameAndMode,
   };
@@ -110,7 +114,11 @@ vi.mock('../src/services/session-store.js', async () => {
 
 vi.mock('../src/core/worker-pool.js', async () => {
   const actual = await vi.importActual<any>('../src/core/worker-pool.js');
-  return { ...actual, forkWorker: mocks.forkWorker };
+  return {
+    ...actual,
+    forkWorker: mocks.forkWorker,
+    sendWorkerInput: mocks.sendWorkerInput,
+  };
 });
 
 vi.mock('../src/core/session-manager.js', async () => {
@@ -224,7 +232,9 @@ describe('ordinary ingress terminal failure → actionable notice', () => {
     mocks.sessions.clear();
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
+    mocks.sendWorkerInput.mockReturnValue(true);
     mocks.scanMultipleProjects.mockReturnValue([]);
     mocks.getAvailableBots.mockResolvedValue([]);
     mocks.downloadResources.mockResolvedValue({ attachments: [], needLogin: false });
@@ -281,6 +291,25 @@ describe('ordinary ingress terminal failure → actionable notice', () => {
 
     expect(repliedText()).not.toContain(expectedNotice());
   });
+
+  it('live worker rejection removes the exact thread progress reaction', async () => {
+    const anchor = 'om_thread_live_reject';
+    const ds = seedThreadSession(anchor, 'seeded');
+    (ds as any).worker = { killed: false, send: vi.fn() };
+    mocks.sendWorkerInput.mockReturnValueOnce(false);
+
+    await handleThreadReply(
+      makeEventData('om_msg_live_reject', 'please retry', anchor),
+      makeCtx(anchor, 'om_msg_live_reject'),
+    );
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(
+      APP,
+      'om_msg_live_reject',
+      'reaction_received',
+    );
+    expect(ds.pendingAckReactions ?? []).toEqual([]);
+  });
 });
 
 /** 让匹配 predicate 的回复失败，其余照常成功（模拟 Lark 瞬时发送故障只打中某一条）。 */
@@ -310,7 +339,9 @@ describe('durable admission then failing status reply → no resend advice (PR #
     mocks.sessions.clear();
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
+    mocks.sendWorkerInput.mockReturnValue(true);
     mocks.scanMultipleProjects.mockReturnValue([]);
     mocks.getAvailableBots.mockResolvedValue([]);
     mocks.downloadResources.mockResolvedValue({ attachments: [], needLogin: false });
@@ -426,6 +457,12 @@ describe('durable admission then failing status reply → no resend advice (PR #
 
     expect(repliedText()).toContain(resendNotice());
     expect(repliedText()).not.toContain(admittedNotice());
+    expect(mocks.removeReaction).toHaveBeenCalledWith(
+      APP,
+      'om_msg_refork',
+      'reaction_received',
+    );
+    expect(ds.pendingAckReactions ?? []).toEqual([]);
   });
 
   it('a rejected /vc-auth (pure-reply branch, no side effect) still advises a resend', async () => {

--- a/test/daemon-ordinary-ingress-failure-notice.test.ts
+++ b/test/daemon-ordinary-ingress-failure-notice.test.ts
@@ -509,6 +509,13 @@ describe('durable admission then failing status reply → no resend advice (PR #
     const anchor = 'om_thread_refork_fail';
     const ds = seedThreadSession(anchor, 'seeded') as any;
     ds.hasHistory = true;
+    ds.streamCardId = 'om_stable_status';
+    ds.streamCardNonce = 'stable-nonce';
+    ds.streamCardVisualTurnId = 'om_previous_turn';
+    ds.streamCardTurnGeneration = 7;
+    ds.currentTurnTitle = 'previous completed turn';
+    ds.currentImageKey = 'img_previous';
+    ds.lastScreenStatus = 'idle';
     mocks.forkWorker.mockImplementation(() => {
       throw new Error('fork failed: EAGAIN');
     });
@@ -525,6 +532,27 @@ describe('durable admission then failing status reply → no resend advice (PR #
       'reaction_received',
     );
     expect(ds.pendingAckReactions ?? []).toEqual([]);
+    expect(ds.streamCardId).toBe('om_stable_status');
+    expect(ds.streamCardVisualTurnId).toBe('om_previous_turn');
+    expect(ds.streamCardTurnGeneration).toBe(7);
+    expect(ds.currentTurnTitle).toBe('previous completed turn');
+    expect(ds.currentImageKey).toBe('img_previous');
+    expect(ds.lastScreenStatus).toBe('idle');
+  });
+
+  it('binds a successful fresh-card refork to the accepted turn', async () => {
+    const anchor = 'om_thread_refork_fresh';
+    const ds = seedThreadSession(anchor, 'seeded') as any;
+    ds.hasHistory = true;
+    ds.streamCardVisualTurnId = 'om_previous_turn';
+
+    await handleThreadReply(
+      makeEventData('om_msg_refork_fresh', 'run the fresh task', anchor),
+      makeCtx(anchor, 'om_msg_refork_fresh'),
+    );
+
+    expect(ds.streamCardVisualTurnId).toBe('om_msg_refork_fresh');
+    expect(ds.streamCardPendingTurnId).toBe('om_msg_refork_fresh');
   });
 
   it('a rejected /vc-auth (pure-reply branch, no side effect) still advises a resend', async () => {

--- a/test/daemon-ordinary-ingress-failure-notice.test.ts
+++ b/test/daemon-ordinary-ingress-failure-notice.test.ts
@@ -352,6 +352,9 @@ describe('ordinary ingress terminal failure → actionable notice', () => {
     const anchor = 'om_thread_live_reject';
     const ds = seedThreadSession(anchor, 'seeded');
     (ds as any).worker = { killed: false, send: vi.fn() };
+    ds.streamCardId = 'om_stable_status';
+    ds.currentTurnTitle = 'previous completed turn';
+    ds.lastScreenStatus = 'idle';
     mocks.sendWorkerInput.mockReturnValueOnce(false);
 
     await handleThreadReply(
@@ -365,6 +368,9 @@ describe('ordinary ingress terminal failure → actionable notice', () => {
       'reaction_received',
     );
     expect(ds.pendingAckReactions ?? []).toEqual([]);
+    expect(ds.streamCardId).toBe('om_stable_status');
+    expect(ds.currentTurnTitle).toBe('previous completed turn');
+    expect(ds.lastScreenStatus).toBe('idle');
   });
 });
 

--- a/test/daemon-ordinary-ingress-failure-notice.test.ts
+++ b/test/daemon-ordinary-ingress-failure-notice.test.ts
@@ -282,6 +282,62 @@ describe('ordinary ingress terminal failure → actionable notice', () => {
     expect(repliedText()).toContain(expectedNotice());
   });
 
+  it('pinned new-topic fork failure removes its thread progress reaction', async () => {
+    mkdirSync(mocks.dataDir, { recursive: true });
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: [OWNER],
+      defaultWorkingDir: mocks.dataDir,
+    });
+    bot.resolvedAllowedUsers = [OWNER];
+    mocks.forkWorker.mockImplementation(() => {
+      throw new Error('new topic fork failed: EAGAIN');
+    });
+
+    await expect(
+      handleNewTopic(
+        makeEventData('om_msg_new_pinned', 'start pinned task'),
+        makeCtx('om_msg_new_pinned', 'om_msg_new_pinned'),
+      ),
+    ).rejects.toThrow('new topic fork failed: EAGAIN');
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(
+      APP,
+      'om_msg_new_pinned',
+      'reaction_received',
+    );
+  });
+
+  it('pinned thread auto-create fork failure removes its progress reaction', async () => {
+    mkdirSync(mocks.dataDir, { recursive: true });
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: [OWNER],
+      defaultWorkingDir: mocks.dataDir,
+    });
+    bot.resolvedAllowedUsers = [OWNER];
+    mocks.forkWorker.mockImplementation(() => {
+      throw new Error('auto-create fork failed: EAGAIN');
+    });
+
+    await expect(
+      handleThreadReply(
+        makeEventData('om_msg_auto_pinned', 'continue pinned task', 'om_auto_root'),
+        makeCtx('om_auto_root', 'om_msg_auto_pinned'),
+      ),
+    ).rejects.toThrow('auto-create fork failed: EAGAIN');
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(
+      APP,
+      'om_msg_auto_pinned',
+      'reaction_received',
+    );
+  });
+
   it('successful delivery sends no failure notice', async () => {
     const anchor = 'om_thread_root_3';
     const ds = seedThreadSession(anchor, 'seeded');

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -725,6 +725,32 @@ describe('/rename production routing — must not pre-create a session (review P
     expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
   });
 
+  it('does not establish a visual turn fence for a card-off thread turn', async () => {
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'codex',
+      allowedUsers: [OWNER],
+      disableStreamingCard: true,
+    });
+    bot.resolvedAllowedUsers = [OWNER];
+    const ds = seedThreadSession('om_card_off_root', 'card off');
+    ds.streamCardVisualTurnId = 'om_previous_turn';
+    const send = vi.fn();
+    ds.worker = { killed: false, send } as any;
+
+    await handleThreadReply(
+      makeEventData('om_card_off_next', 'next task', 'om_card_off_root'),
+      makeCtx('om_card_off_root', 'om_card_off_next'),
+    );
+
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'message',
+      turnId: 'om_card_off_next',
+    }));
+    expect(ds.streamCardVisualTurnId).toBeUndefined();
+  });
+
   it('`/t <content>` preserves a paired forward seed in the first worker input', async () => {
     const bot = registerBot({
       larkAppId: APP,

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -44,6 +44,7 @@ const mocks = vi.hoisted(() => {
     sendMessage: vi.fn(async () => 'om_top'),
     sendEphemeralCard: vi.fn(async () => 'om_ephemeral'),
     addReaction: vi.fn(async () => 'reaction_received'),
+    removeReaction: vi.fn(async () => undefined),
     getChatMode: vi.fn(async () => 'group' as 'group' | 'topic' | 'p2p'),
     getChatNameAndMode: vi.fn(async () => ({ name: null, mode: 'group' as const })),
     resolveSender: vi.fn(async (_appId: string, openId: string | undefined, senderType: string | undefined) => (
@@ -73,6 +74,7 @@ const mocks = vi.hoisted(() => {
     }),
     forkWorker: vi.fn((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     }),
     closeWorkerPoolSession: vi.fn(async () => undefined),
     discoverAdoptableSessions: vi.fn(() => [] as any[]),
@@ -109,6 +111,7 @@ vi.mock('../src/im/lark/client.js', async () => {
     sendMessage: mocks.sendMessage,
     sendEphemeralCard: mocks.sendEphemeralCard,
     addReaction: mocks.addReaction,
+    removeReaction: mocks.removeReaction,
     getChatMode: mocks.getChatMode,
     getChatNameAndMode: mocks.getChatNameAndMode,
   };
@@ -527,6 +530,7 @@ describe('/rename production routing — must not pre-create a session (review P
     mocks.sessions.clear();
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
     mocks.closeWorkerPoolSession.mockImplementation(async (sessionId: string) => {
       for (const [key, candidate] of activeSessions) {
@@ -1308,6 +1312,34 @@ describe('/rename production routing — must not pre-create a session (review P
       'om_force_topic_with_content',
       expect.any(String),
     );
+  });
+
+  it('treats a refused pinned initial fork as unaccepted and removes its reaction', async () => {
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'codex',
+      allowedUsers: [OWNER],
+      defaultWorkingDir: '/tmp',
+    });
+    bot.resolvedAllowedUsers = [OWNER];
+    mocks.forkWorker.mockReturnValueOnce(false);
+    const ctx = makeCtx('om_refused_pinned', 'om_refused_pinned');
+
+    await expect(handleNewTopic(
+      makeEventData('om_refused_pinned', 'start work'),
+      ctx,
+    )).rejects.toThrow('Worker refused pinned initial turn');
+
+    expect(ctx.ingressAdmission).toEqual({ admitted: false });
+    expect(mocks.removeReaction).toHaveBeenCalledWith(
+      APP,
+      'om_refused_pinned',
+      'reaction_received',
+    );
+    const ds = activeSessions.get(sessionKey('om_refused_pinned', APP));
+    expect(ds?.worker).toBeNull();
+    expect(ds?.pendingAckReactions).toEqual([]);
   });
 
   it('routes a colliding daemon command to the canonical pending owner and closes only the loser', async () => {

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -2636,6 +2636,7 @@ describe('document comment canonical ownership and single-flight delivery', () =
     mocks.sessions.clear();
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
     mocks.getAvailableBots.mockResolvedValue([]);
     activeSessions.clear();
@@ -2824,6 +2825,7 @@ describe('document comment canonical ownership and single-flight delivery', () =
     // Failure was not recorded as completed: a later poll retry can deliver.
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
     await expect(handleDocComment(ctx)).resolves.toBe(true);
     expect(mocks.forkWorker).toHaveBeenCalledTimes(2);

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -2796,6 +2796,30 @@ describe('document comment canonical ownership and single-flight delivery', () =
     removeDocSubscription(config.session.dataDir, APP, sub.fileToken);
   });
 
+  it.each(['live', 'refork'] as const)(
+    'persists accepted %s doc-watch input before card-state persistence fails',
+    async (mode) => {
+      const sub = docSub(`doc-prewarm-${mode}-persist-${Date.now()}`);
+      const ds = seedThreadSession(sub.sessionAnchor, `prewarm ${mode} persist`);
+      const liveSend = vi.fn();
+      if (mode === 'live') ds.worker = { killed: false, send: liveSend } as any;
+      mocks.updateSession
+        .mockImplementationOnce((session: any) => { mocks.sessions.set(session.sessionId, session); })
+        .mockImplementationOnce(() => { throw new Error('card state persistence failed'); });
+
+      await expect(prewarmDocCommentSession(ds, sub)).rejects.toThrow('card state persistence failed');
+
+      if (mode === 'live') expect(liveSend).toHaveBeenCalledTimes(1);
+      else expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+      expect(ds.lastUserPrompt).toContain(sub.fileToken);
+      expect(ds.lastCliInput).toContain(sub.fileToken);
+      expect(ds.session.lastUserPrompt).toContain(sub.fileToken);
+      expect(ds.session.lastCliInput).toContain(sub.fileToken);
+      expect(mocks.updateSession).toHaveBeenCalledTimes(2);
+      removeDocSubscription(config.session.dataDir, APP, sub.fileToken);
+    },
+  );
+
   it('serializes concurrent get-or-create, merges targets, and reuses canonical state after restart', async () => {
     const fileToken = `doc-concurrent-${Date.now()}`;
     const sub = docSub(fileToken);

--- a/test/doc-comment-daemon-concurrency.test.ts
+++ b/test/doc-comment-daemon-concurrency.test.ts
@@ -423,6 +423,7 @@ describe('document-comment routing integration', () => {
     expect(region).toMatch(/await noteTurnReceived[\s\S]*ensureCurrentRoutingGeneration\(generation, 'comment:live-note'\)[\s\S]*sendWorkerInput/);
     expect(region).toMatch(/sendWorkerInput\(ds, cliInput, turnId\)[\s\S]*beginNewTurn\(ds, text, turnId\)/);
     expect(region).toMatch(/await noteTurnReceived[\s\S]*ensureCurrentRoutingGeneration\(generation, 'comment:refork-note'\)[\s\S]*forkWorker/);
+    expect(region).toMatch(/forkWorker\(ds, wrappedInput, \{ resume: ds\.hasHistory, turnId \}\)[\s\S]*beginNewTurn\(ds, text, turnId\)/);
   });
 
   it('rolls back only this turn target and an already-landed Typing reaction before releasing the claim', () => {

--- a/test/doc-comment-daemon-concurrency.test.ts
+++ b/test/doc-comment-daemon-concurrency.test.ts
@@ -409,8 +409,9 @@ describe('document-comment routing integration', () => {
     expect(region).toMatch(/const generation = captureRoutingGeneration\(ds\);[\s\S]*await resolveSender[\s\S]*ensureCurrentRoutingGeneration\(generation, 'prewarm:sender'\)/);
     const guard = region.indexOf("ensureCurrentRoutingGeneration(generation, 'prewarm:sender')");
     expect(guard).toBeGreaterThanOrEqual(0);
-    expect(region.indexOf('beginNewTurn(ds, title, turnId)')).toBeGreaterThan(guard);
-    expect(region.indexOf('sendWorkerInput(ds, cliInput', guard)).toBeGreaterThan(guard);
+    const liveSend = region.indexOf('sendWorkerInput(ds, cliInput', guard);
+    expect(liveSend).toBeGreaterThan(guard);
+    expect(region.indexOf('beginNewTurn(ds, title, turnId)')).toBeGreaterThan(liveSend);
     expect(region.indexOf('forkWorker(ds, wrappedInput', guard)).toBeGreaterThan(guard);
   });
 
@@ -420,6 +421,7 @@ describe('document-comment routing integration', () => {
     expect(region).toMatch(/await addCommentReaction[\s\S]*ensureCurrentRoutingGeneration\(generation, 'comment:reaction'\)/);
     expect(region).toMatch(/await resolveSender[\s\S]*ensureCurrentRoutingGeneration\(generation, 'comment:sender'\)/);
     expect(region).toMatch(/await noteTurnReceived[\s\S]*ensureCurrentRoutingGeneration\(generation, 'comment:live-note'\)[\s\S]*sendWorkerInput/);
+    expect(region).toMatch(/sendWorkerInput\(ds, cliInput, turnId\)[\s\S]*beginNewTurn\(ds, text, turnId\)/);
     expect(region).toMatch(/await noteTurnReceived[\s\S]*ensureCurrentRoutingGeneration\(generation, 'comment:refork-note'\)[\s\S]*forkWorker/);
   });
 

--- a/test/doc-comment-daemon-concurrency.test.ts
+++ b/test/doc-comment-daemon-concurrency.test.ts
@@ -411,7 +411,10 @@ describe('document-comment routing integration', () => {
     expect(guard).toBeGreaterThanOrEqual(0);
     const liveSend = region.indexOf('sendWorkerInput(ds, cliInput', guard);
     expect(liveSend).toBeGreaterThan(guard);
-    expect(region.indexOf('beginNewTurn(ds, title, turnId)')).toBeGreaterThan(liveSend);
+    const remember = region.indexOf('rememberLastCliInput(ds, promptContent, cliInput)');
+    const begin = region.indexOf('beginNewTurn(ds, title, turnId)');
+    expect(remember).toBeGreaterThan(liveSend);
+    expect(begin).toBeGreaterThan(remember);
     expect(region.indexOf('forkWorker(ds, wrappedInput', guard)).toBeGreaterThan(guard);
   });
 

--- a/test/group-join-shared-routing.test.ts
+++ b/test/group-join-shared-routing.test.ts
@@ -116,6 +116,7 @@ beforeEach(() => {
   modules.daemon.__testOnly_setAutoStartJoinReadyMaxWaitMs();
   vi.clearAllMocks();
   mocks.forkWorker.mockReset();
+  mocks.forkWorker.mockReturnValue(true);
   mocks.getChatContext.mockImplementation(async (_appId: string, chatId: string) => ({
     chatId,
     name: '【Pippit】【BUG】测试群',
@@ -431,6 +432,7 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     });
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
     registry.registerBot({
       larkAppId: appId,
@@ -509,6 +511,7 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     });
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
     registry.registerBot({
       larkAppId: appId,
@@ -624,6 +627,7 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     });
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
     registry.registerBot({
       larkAppId: appId,
@@ -703,6 +707,7 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     });
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
     registry.registerBot({
       larkAppId: appId,
@@ -869,6 +874,7 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     });
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      return true;
     });
     registry.registerBot({
       larkAppId: appId,

--- a/test/group-join-shared-routing.test.ts
+++ b/test/group-join-shared-routing.test.ts
@@ -27,6 +27,8 @@ const mocks = vi.hoisted(() => ({
   )),
   listChatMemberOpenIds: vi.fn(async () => ['ou_owner']),
   replyMessage: vi.fn(async () => 'om_reply'),
+  addReaction: vi.fn(async () => 'reaction_received'),
+  removeReaction: vi.fn(async () => undefined),
   scanMultipleProjects: vi.fn(() => [] as Array<{ name: string; path: string; type: 'repo' | 'worktree'; branch: string }>),
   sendMessage: vi.fn(async () => 'om_join_seed'),
 }));
@@ -51,6 +53,8 @@ vi.mock('../src/im/lark/client.js', async () => {
     getChatContext: mocks.getChatContext,
     listChatMemberOpenIds: mocks.listChatMemberOpenIds,
     replyMessage: mocks.replyMessage,
+    addReaction: mocks.addReaction,
+    removeReaction: mocks.removeReaction,
     sendMessage: mocks.sendMessage,
   };
 });
@@ -133,6 +137,8 @@ beforeEach(() => {
   ));
   mocks.listChatMemberOpenIds.mockResolvedValue(['ou_owner']);
   mocks.replyMessage.mockResolvedValue('om_reply');
+  mocks.addReaction.mockResolvedValue('reaction_received');
+  mocks.removeReaction.mockResolvedValue(undefined);
   mocks.scanMultipleProjects.mockReturnValue([]);
   mocks.sendMessage.mockResolvedValue('om_join_seed');
 });
@@ -562,6 +568,50 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
       type: 'message',
       turnId: userMessageId,
     }));
+  });
+
+  it('clears the topic seed reaction when no-project startup is taken over after reaction creation', async () => {
+    const { daemon, registry, types } = modules;
+    const appId = 'app_join_topic_reaction_takeover';
+    const chatId = 'oc_join_topic_reaction_takeover';
+    const seedId = 'om_join_seed';
+    const key = types.sessionKey(seedId, appId);
+    mocks.getChatContext.mockResolvedValueOnce({
+      chatId,
+      name: '话题群',
+      description: null,
+      mode: 'topic',
+      fetchStatus: 'ok',
+    });
+    let releaseReaction!: (reactionId: string) => void;
+    const reactionPending = new Promise<string>((resolve) => { releaseReaction = resolve; });
+    let reactionStarted!: () => void;
+    const reactionStartedPromise = new Promise<void>((resolve) => { reactionStarted = resolve; });
+    mocks.addReaction.mockImplementationOnce(async () => {
+      reactionStarted();
+      return reactionPending;
+    });
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      regularGroupReplyMode: 'shared',
+    });
+
+    const joinPromise = daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+    await reactionStartedPromise;
+    const ds = daemon.__testOnly_activeSessions.get(key)!;
+    ds.worker = { killed: false, send: vi.fn(), pid: 4321 } as any;
+
+    releaseReaction('reaction_seed');
+    await joinPromise;
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(appId, seedId, 'reaction_seed');
+    expect(ds.pendingAckReactions).toEqual([]);
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
   });
 
   it('yields without re-forking when a non-message entry starts the registered session', async () => {

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -19,6 +19,7 @@ const updateMessageMock = vi.fn(async (_appId: string, _messageId: string, _json
 const saveFrozenCardsMock = vi.fn();
 const loadFrozenCardsMock = vi.fn(() => new Map<string, FrozenCard>());
 const persistStreamCardStateMock = vi.fn();
+const sessionReplyMock = vi.fn(async () => 'om_replacement');
 
 vi.mock('../src/im/lark/client.js', () => {
   class MessageWithdrawnError extends Error {
@@ -116,6 +117,7 @@ import {
   postFreshStreamingCard,
   postTurnStartingCard,
   reuseThreadStreamingCardForTurn,
+  initWorkerPool,
   setActiveSessionsRegistry,
   restoreUsageLimitRuntimeState,
   scheduleCardPatch,
@@ -179,6 +181,14 @@ beforeEach(() => {
   loadFrozenCardsMock.mockReset();
   loadFrozenCardsMock.mockReturnValue(new Map());
   persistStreamCardStateMock.mockClear();
+  sessionReplyMock.mockReset();
+  sessionReplyMock.mockResolvedValue('om_replacement');
+  initWorkerPool({
+    sessionReply: sessionReplyMock,
+    getSessionWorkingDir: () => '/repo',
+    getActiveCount: () => 1,
+    closeSession: vi.fn(),
+  });
   vi.mocked(buildStreamingCard).mockClear();
   setTerminalProxyPort(8800);
 });
@@ -483,6 +493,48 @@ describe('reuseThreadStreamingCardForTurn', () => {
     expect(ds.streamCardPending).toBe(false);
     expect(updateMessageMock).not.toHaveBeenCalled();
     expect(deleteMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('POSTs a replacement when the reused thread card was withdrawn', async () => {
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_withdrawn';
+    ds.streamCardNonce = 'nonce_withdrawn';
+    updateMessageMock.mockRejectedValueOnce(new MessageWithdrawnError('om_withdrawn'));
+
+    expect(reuseThreadStreamingCardForTurn(ds, 'next question', 'om_next_turn')).toBe(true);
+    await flush();
+    await flush();
+
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock.mock.calls[0][4]).toBe('om_next_turn');
+    expect(ds.streamCardId).toBe('om_replacement');
+    expect(ds.streamCardPending).toBe(false);
+    expect(ds.streamCardPendingTurnId).toBeUndefined();
+  });
+
+  it('keeps the withdrawal fallback when a same-card PATCH supersedes the queued payload', async () => {
+    let rejectFirstPatch!: (error: Error) => void;
+    updateMessageMock
+      .mockImplementationOnce(() => new Promise<void>((_resolve, reject) => { rejectFirstPatch = reject; }))
+      .mockRejectedValueOnce(new MessageWithdrawnError('om_withdrawn'));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_withdrawn';
+    ds.streamCardNonce = 'nonce_withdrawn';
+
+    scheduleCardPatch(ds, 'older payload');
+    expect(reuseThreadStreamingCardForTurn(ds, 'next question', 'om_next_turn')).toBe(true);
+    scheduleCardPatch(ds, 'latest payload', 'om_next_turn');
+    rejectFirstPatch(new MessageWithdrawnError('om_withdrawn'));
+    await flush();
+    await flush();
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenNthCalledWith(2, APP_ID, 'om_withdrawn', 'latest payload');
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock.mock.calls[0][4]).toBe('om_next_turn');
+    expect(ds.streamCardId).toBe('om_replacement');
   });
 
   it('keeps the fresh-card flow for flat chat sessions', () => {

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -469,6 +469,7 @@ describe('reuseThreadStreamingCardForTurn', () => {
     expect(ds.streamCardPending).toBe(false);
     expect(ds.streamCardPendingTurnId).toBeUndefined();
     expect(ds.streamCardTurnGeneration).toBe(4);
+    expect(ds.streamCardVisualTurnId).toBe('om_next_turn');
     expect(ds.currentTurnTitle).toBe('next question');
     expect(ds.currentImageKey).toBeUndefined();
     expect(ds.lastScreenStatus).toBe('starting');

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -537,6 +537,40 @@ describe('reuseThreadStreamingCardForTurn', () => {
     expect(ds.streamCardId).toBe('om_replacement');
   });
 
+  it('replays the latest queued status onto the withdrawn-card replacement', async () => {
+    let rejectReusePatch!: (error: Error) => void;
+    updateMessageMock.mockImplementationOnce(
+      () => new Promise<void>((_resolve, reject) => { rejectReusePatch = reject; }),
+    );
+    let resolveReplacementPost!: (messageId: string) => void;
+    sessionReplyMock.mockImplementationOnce(
+      () => new Promise<string>((resolve) => { resolveReplacementPost = resolve; }),
+    );
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_withdrawn';
+    ds.streamCardNonce = 'nonce_withdrawn';
+
+    expect(reuseThreadStreamingCardForTurn(ds, 'next question', 'om_next_turn')).toBe(true);
+    scheduleCardPatch(ds, 'completed payload', 'om_next_turn');
+    rejectReusePatch(new MessageWithdrawnError('om_withdrawn'));
+    await flush();
+    await flush();
+
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+    expect(ds.pendingCardJson).toBe('completed payload');
+
+    resolveReplacementPost('om_replacement');
+    await flush();
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenNthCalledWith(
+      2, APP_ID, 'om_replacement', 'completed payload',
+    );
+    expect(ds.pendingCardJson).toBeUndefined();
+  });
+
   it('keeps the fresh-card flow for flat chat sessions', () => {
     const ds = makeDs();
     ds.scope = 'chat';

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -555,6 +555,7 @@ describe('reuseThreadStreamingCardForTurn', () => {
     scheduleCardPatch(ds, 'working payload', 'om_next_turn');
     await flush();
     await flush();
+    await flush();
 
     expect(updateMessageMock).toHaveBeenNthCalledWith(
       2, APP_ID, 'om_withdrawn', 'working payload',
@@ -562,6 +563,10 @@ describe('reuseThreadStreamingCardForTurn', () => {
     expect(sessionReplyMock).toHaveBeenCalledTimes(1);
     expect(sessionReplyMock.mock.calls[0][4]).toBe('om_next_turn');
     expect(ds.streamCardId).toBe('om_replacement');
+    expect(updateMessageMock).toHaveBeenNthCalledWith(
+      3, APP_ID, 'om_replacement', 'working payload',
+    );
+    expect(ds.pendingCardJson).toBeUndefined();
   });
 
   it('replays the latest queued status onto the withdrawn-card replacement', async () => {

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -125,6 +125,7 @@ import {
   refreshStreamingCardUsage,
   syncUsageRefreshTimer,
   USAGE_REFRESH_INTERVAL_MS,
+  CARD_POSTING_SENTINEL,
 } from '../src/core/worker-pool.js';
 import { MessageWithdrawnError } from '../src/im/lark/client.js';
 import { buildStreamingCard } from '../src/im/lark/card-builder.js';
@@ -657,11 +658,10 @@ describe('postTurnStartingCard', () => {
     expect(ds.frozenCards?.size).toBe(0);
   });
 
-  it('posts the newest queued turn after an older card POST finishes', async () => {
+  it('retargets a newly-landed thread card when a newer turn supersedes its POST', async () => {
     let resolveFirst!: (messageId: string) => void;
     const sessionReply = vi.fn()
-      .mockImplementationOnce(() => new Promise<string>(resolve => { resolveFirst = resolve; }))
-      .mockResolvedValueOnce('om_turn_card_2');
+      .mockImplementationOnce(() => new Promise<string>(resolve => { resolveFirst = resolve; }));
     const ds = makeDs();
     ds.workerReady = true;
     ds.streamCardId = 'om_previous';
@@ -678,18 +678,28 @@ describe('postTurnStartingCard', () => {
     ds.streamCardPendingTurnId = 'om_turn_2';
     ds.currentTurnTitle = 'second turn';
     await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_2')).resolves.toBe(false);
+    // Simulate the newest turn reaching working while the original POST still
+    // owns the sentinel. Retargeting must not overwrite this fresher payload
+    // with another synthetic starting state.
+    ds.pendingCardJson = '{"status":"working"}';
+    ds.pendingCardId = CARD_POSTING_SENTINEL;
 
     resolveFirst('om_turn_card_1');
     await firstPost;
     await flush();
     await flush();
 
-    expect(sessionReply).toHaveBeenCalledTimes(2);
-    expect(sessionReply.mock.calls[1][4]).toBe('om_turn_2');
-    expect(ds.streamCardId).toBe('om_turn_card_2');
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    expect(updateMessageMock).toHaveBeenCalledWith(
+      APP_ID,
+      'om_turn_card_1',
+      '{"status":"working"}',
+    );
+    expect(ds.streamCardId).toBe('om_turn_card_1');
     expect(ds.streamCardPending).toBe(false);
     expect(ds.streamCardPendingTurnId).toBeUndefined();
-    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_turn_card_1');
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_previous');
+    expect(deleteMessageMock).not.toHaveBeenCalledWith(APP_ID, 'om_turn_card_1');
   });
 
   it('restores the previous live card when the starting-card POST fails', async () => {

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -115,6 +115,7 @@ import {
   parkStreamCard,
   postFreshStreamingCard,
   postTurnStartingCard,
+  reuseThreadStreamingCardForTurn,
   setActiveSessionsRegistry,
   restoreUsageLimitRuntimeState,
   scheduleCardPatch,
@@ -161,6 +162,7 @@ function makeDs(frozenCards?: Map<string, FrozenCard>): DaemonSession {
     larkAppId: APP_ID,
     chatId: 'oc_chat',
     chatType: 'group',
+    scope: 'thread',
     spawnedAt: Date.now(),
     cliVersion: '1.0',
     lastMessageAt: Date.now(),
@@ -434,6 +436,70 @@ describe('restoreUsageLimitRuntimeState', () => {
   });
 });
 
+describe('reuseThreadStreamingCardForTurn', () => {
+  it('PATCHes the existing thread card instead of withdrawing and posting another', async () => {
+    vi.useFakeTimers();
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_stable';
+    ds.streamCardNonce = 'nonce_stable';
+    ds.streamCardPending = true;
+    ds.streamCardPendingTurnId = 'om_old_turn';
+    ds.streamCardTurnGeneration = 3;
+    ds.currentImageKey = 'img_previous';
+    ds.lastScreenStatus = 'working';
+    ds.usageLimit = { limited: true, kind: 'usage', retryReady: false };
+    ds.usageLimitRetryTimer = setTimeout(() => {}, 60_000);
+    ds.usageRefreshTimer = setInterval(() => {}, 60_000);
+
+    expect(reuseThreadStreamingCardForTurn(ds, 'next question', 'om_next_turn')).toBe(true);
+
+    expect(ds.streamCardId).toBe('om_stable');
+    expect(ds.streamCardNonce).toBe('nonce_stable');
+    expect(ds.streamCardPending).toBe(false);
+    expect(ds.streamCardPendingTurnId).toBeUndefined();
+    expect(ds.streamCardTurnGeneration).toBe(4);
+    expect(ds.currentTurnTitle).toBe('next question');
+    expect(ds.currentImageKey).toBeUndefined();
+    expect(ds.lastScreenStatus).toBe('starting');
+    expect(ds.usageLimit).toBeUndefined();
+    expect(ds.usageLimitRetryTimer).toBeUndefined();
+    expect(ds.usageRefreshTimer).toBeUndefined();
+    expect(updateMessageMock).toHaveBeenCalledWith(APP_ID, 'om_stable', '{}');
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+    expect(saveFrozenCardsMock).not.toHaveBeenCalled();
+  });
+
+  it('also preserves the stable thread card while a stopped worker is re-forked', () => {
+    const ds = makeDs();
+    ds.worker = null;
+    ds.workerReady = false;
+    ds.streamCardId = 'om_stable';
+    ds.streamCardNonce = 'nonce_stable';
+
+    expect(reuseThreadStreamingCardForTurn(ds, 'resume question', 'om_resume_turn')).toBe(true);
+
+    expect(ds.streamCardId).toBe('om_stable');
+    expect(ds.streamCardPending).toBe(false);
+    expect(updateMessageMock).not.toHaveBeenCalled();
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the fresh-card flow for flat chat sessions', () => {
+    const ds = makeDs();
+    ds.scope = 'chat';
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+
+    expect(reuseThreadStreamingCardForTurn(ds, 'next question', 'om_next_turn')).toBe(false);
+
+    expect(ds.streamCardId).toBe('om_previous');
+    expect(ds.streamCardTurnGeneration).toBeUndefined();
+    expect(updateMessageMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('receiver streaming card boundary', () => {
   it('refuses a fresh group-visible streaming card for a dedicated receiver', async () => {
     const ds = makeDs();
@@ -485,6 +551,23 @@ describe('postTurnStartingCard', () => {
     expect(ds.streamCardId).toBe('om_turn_card_1');
     expect(ds.streamCardPending).toBe(false);
     expect(ds.streamCardPendingTurnId).toBeUndefined();
+  });
+
+  it('still recalls the previous card after posting in a chat-scoped session', async () => {
+    const ds = makeDs();
+    ds.scope = 'chat';
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+    const sessionReply = vi.fn(async () => 'om_turn_card_1');
+
+    await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_1')).resolves.toBe(true);
+
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_previous');
+    expect(ds.frozenCards?.size).toBe(0);
   });
 
   it('posts the newest queued turn after an older card POST finishes', async () => {

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -683,6 +683,7 @@ describe('postTurnStartingCard', () => {
     // with another synthetic starting state.
     ds.pendingCardJson = '{"status":"working"}';
     ds.pendingCardId = CARD_POSTING_SENTINEL;
+    ds.pendingCardTurnId = 'om_turn_2';
 
     resolveFirst('om_turn_card_1');
     await firstPost;
@@ -700,6 +701,39 @@ describe('postTurnStartingCard', () => {
     expect(ds.streamCardPendingTurnId).toBeUndefined();
     expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_previous');
     expect(deleteMessageMock).not.toHaveBeenCalledWith(APP_ID, 'om_turn_card_1');
+  });
+
+  it('replaces a predecessor snapshot queued during a superseded thread POST', async () => {
+    let resolveFirst!: (messageId: string) => void;
+    const sessionReply = vi.fn()
+      .mockImplementationOnce(() => new Promise<string>(resolve => { resolveFirst = resolve; }));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+    ds.currentTurnTitle = 'first turn';
+
+    const firstPost = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    ds.streamCardTurnGeneration = 2;
+    ds.streamCardPendingTurnId = 'om_turn_2';
+    ds.currentTurnTitle = 'second turn';
+    // beginNewTurn freezes N without assigning N+1 as the payload owner.
+    ds.pendingCardJson = '{"status":"idle","title":"first turn"}';
+    ds.pendingCardId = CARD_POSTING_SENTINEL;
+
+    resolveFirst('om_turn_card_1');
+    await firstPost;
+    await flush();
+
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    expect(updateMessageMock).toHaveBeenCalledWith(APP_ID, 'om_turn_card_1', '{}');
+    expect(updateMessageMock).not.toHaveBeenCalledWith(
+      APP_ID,
+      'om_turn_card_1',
+      '{"status":"idle","title":"first turn"}',
+    );
+    expect(ds.streamCardVisualTurnId).toBe('om_turn_2');
   });
 
   it('restores the previous live card when the starting-card POST fails', async () => {

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -539,6 +539,31 @@ describe('reuseThreadStreamingCardForTurn', () => {
     expect(ds.streamCardId).toBe('om_replacement');
   });
 
+  it('keeps the withdrawal fallback after the initial reuse PATCH succeeds', async () => {
+    updateMessageMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new MessageWithdrawnError('om_withdrawn'));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_withdrawn';
+    ds.streamCardNonce = 'nonce_withdrawn';
+
+    expect(reuseThreadStreamingCardForTurn(ds, 'next question', 'om_next_turn')).toBe(true);
+    await flush();
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+
+    scheduleCardPatch(ds, 'working payload', 'om_next_turn');
+    await flush();
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenNthCalledWith(
+      2, APP_ID, 'om_withdrawn', 'working payload',
+    );
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock.mock.calls[0][4]).toBe('om_next_turn');
+    expect(ds.streamCardId).toBe('om_replacement');
+  });
+
   it('replays the latest queued status onto the withdrawn-card replacement', async () => {
     let rejectReusePatch!: (error: Error) => void;
     updateMessageMock.mockImplementationOnce(

--- a/test/riff-explicit-close.test.ts
+++ b/test/riff-explicit-close.test.ts
@@ -5,9 +5,10 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { activeSessionKey, type DaemonSession } from '../src/core/types.js';
 
-const { getBotMock, cancelRiffTaskMock } = vi.hoisted(() => ({
+const { getBotMock, cancelRiffTaskMock, removeReactionMock } = vi.hoisted(() => ({
   getBotMock: vi.fn(),
   cancelRiffTaskMock: vi.fn(async () => true),
+  removeReactionMock: vi.fn(async () => undefined),
 }));
 
 vi.mock('../src/bot-registry.js', () => ({
@@ -29,7 +30,7 @@ vi.mock('../src/im/lark/client.js', () => ({
   sendEphemeralCard: vi.fn(),
   sendUserMessage: vi.fn(),
   addReaction: vi.fn(),
-  removeReaction: vi.fn(),
+  removeReaction: removeReactionMock,
   getMessageChatId: vi.fn(),
   MessageWithdrawnError: class extends Error {},
 }));
@@ -221,6 +222,33 @@ describe('Riff explicit close', () => {
       riffParentTaskId: 'task-riff-123',
     });
     expect(fixture.ds.riffCloseState).toBeUndefined();
+  });
+
+  it('retains pending reactions when the durable close fails after prepare', async () => {
+    const fixture = createFixture({ liveWorker: true });
+    const pendingReaction = {
+      messageId: 'om_riff_turn',
+      reactionId: 'reaction_riff_turn',
+      turnId: 'om_riff_turn',
+      clearOnReply: true,
+    };
+    fixture.ds.pendingAckReactions = [pendingReaction];
+    vi.spyOn(sessionStore, 'closeSession').mockImplementationOnce(() => {
+      throw new Error('disk full');
+    });
+
+    expect(await closeSession(fixture.session.sessionId)).toEqual({
+      ok: false,
+      alreadyClosed: false,
+      error: 'riff_durable_close_failed',
+      retryable: true,
+      taskId: 'task-riff-123',
+    });
+
+    expect(fixture.ds.pendingAckReactions).toEqual([pendingReaction]);
+    expect(removeReactionMock).not.toHaveBeenCalled();
+    expect(fixture.registry.get(activeSessionKey(fixture.ds))).toBe(fixture.ds);
+    expect(fixture.session.status).toBe('active');
   });
 
   it('refuses an unprepared generic retirement of a live Riff worker', () => {

--- a/test/session-delete-close-barrier.test.ts
+++ b/test/session-delete-close-barrier.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { config } from '../src/config.js';
 import { dashboardEventBus, type DashboardEvent } from '../src/core/dashboard-events.js';
 import * as docComment from '../src/im/lark/doc-comment.js';
+import * as larkClient from '../src/im/lark/client.js';
 import * as workerPool from '../src/core/worker-pool.js';
 import { activeSessionKey } from '../src/core/types.js';
 import * as docSubsStore from '../src/services/doc-subs-store.js';
@@ -23,6 +24,64 @@ afterEach(() => {
 });
 
 describe('daemon close barrier used by botmux delete', () => {
+  it('removes pending progress reactions when the session closes', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-close-reaction-'));
+    tempDirs.push(dataDir);
+    const previousDataDir = config.session.dataDir;
+    config.session.dataDir = dataDir;
+    sessionStore.init('app-close-reaction');
+    const removeReaction = vi.spyOn(larkClient, 'removeReaction').mockResolvedValue(undefined);
+
+    try {
+      const session = sessionStore.createSession(
+        'oc_close_reaction',
+        'om_close_reaction',
+        'close reaction',
+        'group',
+      );
+      session.larkAppId = 'app-close-reaction';
+      sessionStore.updateSession(session);
+      const ds = {
+        session,
+        worker: null,
+        workerPort: null,
+        workerToken: null,
+        workerViewToken: null,
+        larkAppId: 'app-close-reaction',
+        chatId: session.chatId,
+        chatType: 'group',
+        scope: 'thread',
+        spawnedAt: Date.now(),
+        cliVersion: 'test',
+        lastMessageAt: Date.now(),
+        hasHistory: true,
+        adoptedFrom: { source: 'tmux', tmuxTarget: 'user:1.0', cwd: '/repo' },
+        pendingAckReactions: [{
+          messageId: 'om_turn_in_progress',
+          reactionId: 'reaction_in_progress',
+          turnId: 'om_turn_in_progress',
+          clearOnReply: true,
+        }],
+      } as any;
+      workerPool.setActiveSessionsRegistry(new Map([[activeSessionKey(ds), ds]]));
+
+      await expect(workerPool.closeSession(session.sessionId)).resolves.toEqual({
+        ok: true,
+        alreadyClosed: false,
+        known: true,
+      });
+
+      expect(ds.pendingAckReactions).toEqual([]);
+      expect(removeReaction).toHaveBeenCalledWith(
+        'app-close-reaction',
+        'om_turn_in_progress',
+        'reaction_in_progress',
+      );
+    } finally {
+      config.session.dataDir = previousDataDir;
+    }
+  });
+
   it('evicts activeSessions and persists closed before awaited doc cleanup', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-barrier-'));
     tempDirs.push(dataDir);

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -266,7 +266,14 @@ describe('ordinary IM worker receipt acknowledgement', () => {
       getActiveCount: () => 1,
       closeSession: vi.fn(),
     });
-    const ds = makeDs();
+    const ds = makeDs({
+      pendingAckReactions: [{
+        messageId: 'om_business',
+        reactionId: 'reaction_business',
+        turnId: 'om_business',
+        clearOnReply: true,
+      }],
+    });
     forkWorker(ds, 'hello', false);
     const worker = forkMock.mock.results.at(-1)!.value;
 
@@ -286,6 +293,10 @@ describe('ordinary IM worker receipt acknowledgement', () => {
       'app_test',
       'om_business',
     );
+    expect(removeReactionMock).toHaveBeenCalledWith(
+      'app_test', 'om_business', 'reaction_business',
+    );
+    expect(ds.pendingAckReactions).toEqual([]);
     businessSends = vi.mocked(worker.send).mock.calls
       .map(call => call[0])
       .filter(message => message?.type === 'message' && message?.turnId === 'om_business');

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -2,10 +2,11 @@ import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { applyQueuedCodexAppLegacyFallback } from '../src/core/session-create.js';
 
-const { emitHookEventMock, forkMock, execSyncMock } = vi.hoisted(() => ({
+const { emitHookEventMock, forkMock, execSyncMock, removeReactionMock } = vi.hoisted(() => ({
   emitHookEventMock: vi.fn(),
   forkMock: vi.fn(),
   execSyncMock: vi.fn(),
+  removeReactionMock: vi.fn(async () => undefined),
 }));
 
 vi.mock('node:child_process', async (importOriginal) => {
@@ -28,6 +29,7 @@ vi.mock('../src/im/lark/client.js', () => {
   return {
     updateMessage: vi.fn(async () => {}),
     deleteMessage: vi.fn(async () => {}),
+    removeReaction: removeReactionMock,
     MessageWithdrawnError,
   };
 });
@@ -2921,8 +2923,14 @@ describe('worker startup failure delivery', () => {
         cliId: 'codex',
         cwd: '/repo',
       },
+      pendingAckReactions: [{
+        messageId: 'om_adopt_turn',
+        reactionId: 'reaction_adopt_turn',
+        turnId: 'om_adopt_turn',
+        clearOnReply: true,
+      }],
     });
-    forkAdoptWorker(ds);
+    forkAdoptWorker(ds, { turnId: 'om_adopt_turn' });
     const worker = forkMock.mock.results.at(-1)!.value;
 
     worker.emit('error', new Error('adopt fork ENOENT'));
@@ -2931,11 +2939,54 @@ describe('worker startup failure delivery', () => {
 
     expect(sessionReply).toHaveBeenCalledTimes(1);
     expect(sessionReply.mock.calls[0]?.[1]).toContain('adopt fork ENOENT');
+    expect(removeReactionMock).toHaveBeenCalledWith(
+      'app_test', 'om_adopt_turn', 'reaction_adopt_turn',
+    );
+    expect(ds.pendingAckReactions).toEqual([]);
     expect(emitHookEventMock).toHaveBeenCalledWith('session.requires_attention', expect.objectContaining({
       sessionId: 'sid-start-test',
       reason: 'worker_fork_error',
       message: 'adopt fork ENOENT',
     }));
+  });
+
+  it('keeps the adopted turn reaction when its fork-error reply fails', async () => {
+    const sessionReply = vi.fn(async () => { throw new Error('Lark unavailable'); });
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs({
+      adoptedFrom: {
+        tmuxTarget: 'bmx-deadbeef:0.0',
+        originalCliPid: 23456,
+        sessionId: 'codex-session',
+        cliId: 'codex',
+        cwd: '/repo',
+      },
+      pendingAckReactions: [{
+        messageId: 'om_adopt_turn',
+        reactionId: 'reaction_adopt_turn',
+        turnId: 'om_adopt_turn',
+        clearOnReply: true,
+      }],
+    });
+    forkAdoptWorker(ds, { turnId: 'om_adopt_turn' });
+    const worker = forkMock.mock.results.at(-1)!.value;
+
+    worker.emit('error', new Error('adopt fork ENOENT'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(removeReactionMock).not.toHaveBeenCalled();
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_adopt_turn',
+      reactionId: 'reaction_adopt_turn',
+      turnId: 'om_adopt_turn',
+      clearOnReply: true,
+    }]);
   });
 });
 

--- a/test/transfer-input-gate-wiring.test.ts
+++ b/test/transfer-input-gate-wiring.test.ts
@@ -19,6 +19,8 @@ describe('transfer input gate wiring', () => {
     const passthrough = daemonSource.slice(passthroughStart, passthroughEnd);
     expect(passthrough).toContain('sendWorkerSessionInput(ds, {');
     expect(passthrough).toContain("type: 'raw_input'");
+    expect(passthrough.indexOf('beginNewTurn(ds, commandContent, turn.messageId)'))
+      .toBeGreaterThan(passthrough.indexOf('sendWorkerSessionInput(ds, {'));
     expect(passthrough).not.toContain("ds.worker.send({\n      type: 'raw_input'");
 
     const promptReadyStart = workerPoolSource.indexOf("case 'prompt_ready':");

--- a/test/transfer-passthrough-gate.test.ts
+++ b/test/transfer-passthrough-gate.test.ts
@@ -56,6 +56,70 @@ import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
 
 describe('mid-transfer literal passthrough', () => {
+  it('does not mutate the reused card when raw IPC rejects before acceptance', () => {
+    const ds = {
+      session: {
+        sessionId: 'session-disconnected-passthrough',
+        chatId: 'oc_source',
+        rootMessageId: 'om_source',
+        title: 'disconnected passthrough',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        scope: 'thread',
+        chatType: 'group',
+        larkAppId: 'app-transfer-passthrough',
+        ownerOpenId: 'ou_owner',
+        workingDir: '/tmp',
+        cliId: 'claude-code',
+      },
+      worker: Object.assign(new EventEmitter(), {
+        killed: false,
+        connected: false,
+        send: vi.fn(() => { throw new Error('IPC channel is closed'); }),
+      }),
+      workerPort: null,
+      workerToken: null,
+      larkAppId: 'app-transfer-passthrough',
+      chatId: 'oc_source',
+      chatType: 'group',
+      scope: 'thread',
+      spawnedAt: Date.now(),
+      cliVersion: '1.0.0',
+      lastMessageAt: Date.now(),
+      hasHistory: true,
+      workingDir: '/tmp',
+      lastScreenStatus: 'idle',
+      streamingCardForced: true,
+      streamCardId: 'om_stable_card',
+      streamCardNonce: 'stable-nonce',
+      streamCardTurnGeneration: 7,
+      currentTurnTitle: 'previous completed turn',
+    } as unknown as DaemonSession;
+    const onDelivered = vi.fn();
+
+    expect(() => deliverPassthrough(
+      ds,
+      '/model',
+      '/model opus',
+      'om_source',
+      ds.larkAppId,
+      {
+        messageId: 'om_rejected_passthrough',
+        senderOpenId: 'ou_owner',
+        senderIsBot: false,
+        substitute: false,
+        onDelivered,
+      },
+    )).toThrow('IPC channel is closed');
+
+    expect(onDelivered).not.toHaveBeenCalled();
+    expect(ds.streamingCardForced).toBe(true);
+    expect(ds.streamCardId).toBe('om_stable_card');
+    expect(ds.streamCardTurnGeneration).toBe(7);
+    expect(ds.currentTurnTitle).toBe('previous completed turn');
+    expect(ds.streamCardPendingTurnId).toBeUndefined();
+  });
+
   it('buffers raw input while worker=null and replays it on the target replacement', async () => {
     const ds = {
       session: {

--- a/test/turn-reactions.test.ts
+++ b/test/turn-reactions.test.ts
@@ -622,6 +622,62 @@ describe('turn reaction screen_update behavioral gate', () => {
     }]);
   });
 
+  it('startup-failure reply clears the exact thread reaction after delivery', async () => {
+    registerWith(false);
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [
+        { messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true },
+        { messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true },
+      ],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'error', turnId: 'om_a', message: 'CLI startup failed.',
+    });
+    await flush();
+
+    expect(mocks.sessionReply).toHaveBeenCalledWith(
+      'om_root', expect.stringContaining('CLI startup failed.'), 'text', APP, 'om_a', undefined,
+    );
+    expect(mocks.removeReaction).toHaveBeenCalledWith(APP, 'om_a', 'rid_om_a');
+    expect(mocks.sessionReply.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.removeReaction.mock.invocationCallOrder[0],
+    );
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true,
+    }]);
+  });
+
+  it('failed startup-failure reply keeps the reaction pending', async () => {
+    registerWith(false);
+    mocks.sessionReply.mockRejectedValueOnce(new Error('Lark unavailable'));
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [{
+        messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+      }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'error', turnId: 'om_a', message: 'CLI startup failed.',
+    });
+    await flush();
+
+    expect(mocks.removeReaction).not.toHaveBeenCalled();
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+    }]);
+  });
+
   it('bare completed terminal does not clear a thread reaction before a trailing reply', async () => {
     registerWith(false);
     const worker = makeFakeWorker();

--- a/test/turn-reactions.test.ts
+++ b/test/turn-reactions.test.ts
@@ -20,6 +20,7 @@ import { join } from 'path';
 const mocks = vi.hoisted(() => ({
   addReaction: vi.fn(),
   removeReaction: vi.fn(),
+  sessionReply: vi.fn(),
 }));
 
 vi.mock('@larksuiteoapi/node-sdk', () => {
@@ -407,9 +408,10 @@ describe('turn reaction screen_update behavioral gate', () => {
     process.env.SESSION_DATA_DIR = mkdtempSync(join(tmpdir(), 'botmux-react-behav-'));
     mocks.addReaction.mockImplementation(async (_app: string, msgId: string) => `rid_${msgId}`);
     mocks.removeReaction.mockResolvedValue(undefined);
+    mocks.sessionReply.mockResolvedValue('om_reply');
     registerWith(true);
     initWorkerPool({
-      sessionReply: vi.fn(async () => 'om_reply'),
+      sessionReply: mocks.sessionReply,
       getSessionWorkingDir: () => '/repo',
       getActiveCount: () => 1,
       closeSession: vi.fn(),
@@ -531,6 +533,92 @@ describe('turn reaction screen_update behavioral gate', () => {
     expect(mocks.removeReaction).not.toHaveBeenCalledWith(APP, 'om_b', 'rid_om_b');
     expect(ds.pendingAckReactions).toEqual([{
       messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true,
+    }]);
+  });
+
+  it('terminal worker notice clears the exact reaction only after its reply is delivered', async () => {
+    registerWith(false);
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [
+        { messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true },
+        { messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true },
+      ],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'user_notify',
+      turnId: 'om_a',
+      settlesTurn: true,
+      message: 'CLI did not accept this message.',
+    });
+    await flush();
+
+    expect(mocks.sessionReply).toHaveBeenCalledWith(
+      'om_root', 'CLI did not accept this message.', 'text', APP, 'om_a', undefined,
+    );
+    expect(mocks.removeReaction).toHaveBeenCalledWith(APP, 'om_a', 'rid_om_a');
+    expect(mocks.sessionReply.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.removeReaction.mock.invocationCallOrder[0],
+    );
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true,
+    }]);
+  });
+
+  it('informational worker notice does not settle a pending thread reaction', async () => {
+    registerWith(false);
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [{
+        messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+      }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'user_notify', turnId: 'om_a', message: 'Informational notice.',
+    });
+    await flush();
+
+    expect(mocks.sessionReply).toHaveBeenCalledWith(
+      'om_root', 'Informational notice.', 'text', APP, 'om_a', undefined,
+    );
+    expect(mocks.removeReaction).not.toHaveBeenCalled();
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+    }]);
+  });
+
+  it('failed terminal-notice delivery keeps the reaction pending', async () => {
+    registerWith(false);
+    mocks.sessionReply.mockRejectedValueOnce(new Error('Lark unavailable'));
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [{
+        messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+      }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'user_notify', turnId: 'om_a', settlesTurn: true, message: 'Submit failed.',
+    });
+    await flush();
+
+    expect(mocks.removeReaction).not.toHaveBeenCalled();
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
     }]);
   });
 

--- a/test/turn-reactions.test.ts
+++ b/test/turn-reactions.test.ts
@@ -1,9 +1,9 @@
 /**
- * Two-phase turn reactions (auto-on for card-off sessions, i.e. streaming card disabled):
+ * Turn progress reactions:
  *   - noteTurnReceived(ds, msgId): react 冲! (GoGoGo) the instant a user message
  *     is accepted for the session, tracked per-message in ds.pendingAckReactions.
- *   - finishTurnReactions(ds): when the worker next goes idle, flip every pending
- *     ✋ to ✅ (DONE) and clear the list.
+ *   - card-off turns flip pending reactions to DONE at idle.
+ *   - stable-card thread turns clear the reaction after reply delivery.
  *
  * Binding the "received" reaction to the message (not a worker status edge) is
  * what makes type-ahead / busy-batched messages each get their own reaction —
@@ -91,6 +91,21 @@ describe('two-phase turn reactions', () => {
     await noteTurnReceived(ds, 'om_a');
     expect(mocks.addReaction).not.toHaveBeenCalled();
     expect(ds.pendingAckReactions ?? []).toEqual([]);
+  });
+
+  it('stable-card thread turns react on receipt and mark the reaction clear-on-reply', async () => {
+    registerWith(false);
+    const ds = makeDs({ scope: 'thread' });
+
+    await noteTurnReceived(ds, 'om_a', undefined, undefined, 'om_a');
+
+    expect(mocks.addReaction).toHaveBeenCalledWith(APP, 'om_a', 'GoGoGo');
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_a',
+      reactionId: 'rid_om_a',
+      turnId: 'om_a',
+      clearOnReply: true,
+    }]);
   });
 
   it('dedicated VC receivers never add or finish progress reactions', async () => {
@@ -440,6 +455,73 @@ describe('turn reaction screen_update behavioral gate', () => {
     expect(ds.pendingAckReactions).toEqual([]);
   });
 
+  it('explicit reply delivery removes the exact thread reaction without adding DONE', async () => {
+    registerWith(false);
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [{
+        messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+      }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'explicit_reply_observed', turnId: 'om_a', messageId: 'om_reply',
+    });
+    await flush();
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(APP, 'om_a', 'rid_om_a');
+    expect(mocks.addReaction).not.toHaveBeenCalledWith(APP, 'om_a', 'DONE');
+    expect(ds.pendingAckReactions).toEqual([]);
+  });
+
+  it('reply delivery clears only its exact turn and leaves a newer turn pending', async () => {
+    registerWith(false);
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [
+        { messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true },
+        { messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true },
+      ],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'explicit_reply_observed', turnId: 'om_a', messageId: 'om_reply_a',
+    });
+    await flush();
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(APP, 'om_a', 'rid_om_a');
+    expect(mocks.removeReaction).not.toHaveBeenCalledWith(APP, 'om_b', 'rid_om_b');
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true,
+    }]);
+  });
+
+  it('idle does not clear a stable-card thread reaction before reply delivery', async () => {
+    registerWith(false);
+    const ds = makeDs({
+      scope: 'thread',
+      pendingAckReactions: [{
+        messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+      }],
+    });
+
+    await finishTurnReactions(ds);
+
+    expect(mocks.removeReaction).not.toHaveBeenCalled();
+    expect(mocks.addReaction).not.toHaveBeenCalledWith(APP, 'om_a', 'DONE');
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+    }]);
+  });
+
   it('working→limited flips DONE (rate-limit banner on settle; synthetic working must not be rewritten)', async () => {
     // Review third round: if both seeds classify to limited, gate never sees
     // working. Forced synthetic working + limited settle must still DONE.
@@ -508,5 +590,3 @@ describe('turn reaction screen_update behavioral gate', () => {
     expect(ds.pendingAckReactions?.map(a => a.messageId)).toEqual(['om_a']);
   });
 });
-
-

--- a/test/turn-reactions.test.ts
+++ b/test/turn-reactions.test.ts
@@ -504,6 +504,63 @@ describe('turn reaction screen_update behavioral gate', () => {
     }]);
   });
 
+  it('nothing-to-send terminal clears the exact thread reaction without a reply event', async () => {
+    registerWith(false);
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [
+        { messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true },
+        { messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true },
+      ],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_a',
+      status: 'completed',
+      outputDisposition: 'nothing_to_send',
+    });
+    await flush();
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(APP, 'om_a', 'rid_om_a');
+    expect(mocks.removeReaction).not.toHaveBeenCalledWith(APP, 'om_b', 'rid_om_b');
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_b', reactionId: 'rid_om_b', turnId: 'om_b', clearOnReply: true,
+    }]);
+  });
+
+  it('bare completed terminal does not clear a thread reaction before a trailing reply', async () => {
+    registerWith(false);
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker,
+      workerPort: 9999,
+      pendingAckReactions: [{
+        messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+      }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_a',
+      status: 'completed',
+    });
+    await flush();
+
+    expect(mocks.removeReaction).not.toHaveBeenCalled();
+    expect(ds.pendingAckReactions).toEqual([{
+      messageId: 'om_a', reactionId: 'rid_om_a', turnId: 'om_a', clearOnReply: true,
+    }]);
+  });
+
   it('idle does not clear a stable-card thread reaction before reply delivery', async () => {
     registerWith(false);
     const ds = makeDs({

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -615,6 +615,31 @@ describe('daemon-session wrappers', () => {
     });
   });
 
+  it('attributes a late settlement to its exact turn caller', () => {
+    vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(100, 10));
+    const exactDs = {
+      ...ds,
+      session: {
+        ...ds.session,
+        lastCallerOpenId: 'ou_newer_turn',
+        replyTargets: {
+          om_older_turn: {
+            updatedAt: '2026-06-10T11:59:00Z',
+            senderOpenId: 'ou_older_turn',
+          },
+        },
+      },
+    } as any;
+
+    const rec = recordUsageForDaemonSession(exactDs, {
+      ledgerDir: dir,
+      now: new Date('2026-06-10T12:00:00Z'),
+      turnId: 'om_older_turn',
+    });
+
+    expect(rec?.callerOpenId).toBe('ou_older_turn');
+  });
+
   it('does nothing when the transcript has no usage', () => {
     vi.mocked(getSessionTokenUsage).mockReturnValue(null);
 

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -732,6 +732,35 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(ds.streamCardId).toBe('om_new_card');
   });
 
+  it('posts a replacement when a reused-card ready PATCH fails', async () => {
+    updateMessageMock.mockRejectedValueOnce(new Error('temporary Lark failure'));
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker: fakeWorker,
+      workerReady: false,
+      streamCardPending: false,
+      streamCardId: 'om_existing_card',
+      streamCardNonce: 'stable-nonce',
+      streamCardTurnGeneration: 4,
+      streamCardVisualTurnId: 'om_previous_turn',
+    });
+
+    expect(reuseThreadStreamingCardForTurn(ds, 'new turn', 'om_new_turn')).toBe(true);
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', {
+      type: 'ready', port: 9999, token: 'tok_abc', turnId: 'om_new_turn',
+    });
+    await flush();
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock.mock.calls[0][4]).toBe('om_new_turn');
+    expect(ds.streamCardId).toBe('om_new_card');
+    expect(ds.streamCardPending).toBe(false);
+  });
+
   it('silent recovery restores screenshot mode without touching the streaming card', async () => {
     const fakeWorker = makeFakeWorker();
     const ds = makeDs({

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -19,7 +19,10 @@ import { EventEmitter } from 'node:events';
 // ─── Mocks ─────────────────────────────────────────────────────────────────
 
 const updateMessageMock = vi.fn(async () => {});
-const { loggerInfoMock } = vi.hoisted(() => ({ loggerInfoMock: vi.fn() }));
+const { loggerInfoMock, recordUsageMock } = vi.hoisted(() => ({
+  loggerInfoMock: vi.fn(),
+  recordUsageMock: vi.fn(),
+}));
 
 vi.mock('../src/im/lark/client.js', () => {
   class MessageWithdrawnError extends Error {
@@ -90,6 +93,11 @@ vi.mock('../src/core/dashboard-events.js', () => ({
 
 vi.mock('../src/core/dashboard-rows.js', () => ({
   composeRowFromActive: vi.fn(() => ({ tokenUsage: undefined })),
+}));
+
+vi.mock('../src/services/usage-ledger.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/services/usage-ledger.js')>()),
+  recordUsageForDaemonSession: (...args: any[]) => recordUsageMock(...args),
 }));
 
 vi.mock('../src/skills/installer.js', () => ({
@@ -424,6 +432,7 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(ds.lastScreenContent).toBe('');
     expect(ds.lastScreenStatus).toBe('starting');
     expect(ds.currentImageKey).toBeUndefined();
+    expect(recordUsageMock).toHaveBeenCalledWith(ds);
 
     fakeWorker.emit('message', {
       type: 'screen_update',

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -726,7 +726,8 @@ describe('Worker ready: set_display_mode re-sync', () => {
     await flush();
     await flush();
 
-    expect(updateMessageMock).toHaveBeenCalledTimes(2);
+    expect(updateMessageMock).toHaveBeenCalledTimes(3);
+    expect(updateMessageMock.mock.calls[2][1]).toBe('om_new_card');
     expect(sessionReplyMock).toHaveBeenCalledTimes(1);
     expect(sessionReplyMock.mock.calls[0][4]).toBe('om_new_turn');
     expect(ds.streamCardId).toBe('om_new_card');
@@ -754,11 +755,12 @@ describe('Worker ready: set_display_mode re-sync', () => {
     await flush();
     await flush();
 
-    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+    expect(updateMessageMock).toHaveBeenCalledTimes(2);
     expect(sessionReplyMock).toHaveBeenCalledTimes(1);
     expect(sessionReplyMock.mock.calls[0][4]).toBe('om_new_turn');
     expect(ds.streamCardId).toBe('om_new_card');
     expect(ds.streamCardPending).toBe(false);
+    expect(ds.pendingCardJson).toBeUndefined();
   });
 
   it('silent recovery restores screenshot mode without touching the streaming card', async () => {

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -148,7 +148,13 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 
 // ─── Imports under test ────────────────────────────────────────────────────
 
-import { CARD_POSTING_SENTINEL, initWorkerPool, __testOnly_setupWorkerHandlers } from '../src/core/worker-pool.js';
+import {
+  CARD_POSTING_SENTINEL,
+  initWorkerPool,
+  reuseThreadStreamingCardForTurn,
+  scheduleCardPatch,
+  __testOnly_setupWorkerHandlers,
+} from '../src/core/worker-pool.js';
 import { MessageWithdrawnError } from '../src/im/lark/client.js';
 import type { DaemonSession } from '../src/core/types.js';
 import { getBot } from '../src/bot-registry.js';
@@ -636,6 +642,48 @@ describe('Worker ready: set_display_mode re-sync', () => {
     );
   });
 
+  it('serializes refork readiness behind an older PATCH and recovers withdrawal for the new turn', async () => {
+    let rejectOldPatch!: (error: Error) => void;
+    updateMessageMock
+      .mockImplementationOnce(() => new Promise<void>((_resolve, reject) => {
+        rejectOldPatch = reject;
+      }))
+      .mockRejectedValueOnce(new MessageWithdrawnError('om_existing_card'));
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker: fakeWorker,
+      workerReady: false,
+      streamCardPending: false,
+      streamCardId: 'om_existing_card',
+      streamCardNonce: 'stable-nonce',
+      streamCardTurnGeneration: 4,
+      streamCardVisualTurnId: 'om_previous_turn',
+    });
+
+    scheduleCardPatch(ds, 'previous-generation payload');
+    expect(reuseThreadStreamingCardForTurn(ds, 'new turn', 'om_new_turn')).toBe(true);
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', {
+      type: 'ready', port: 9999, token: 'tok_abc', turnId: 'om_new_turn',
+    });
+    await flush();
+
+    // ready must queue behind the prior generation instead of issuing a
+    // concurrent direct PATCH that the old request could overwrite later.
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+
+    rejectOldPatch(new MessageWithdrawnError('om_existing_card'));
+    await flush();
+    await flush();
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenCalledTimes(2);
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock.mock.calls[0][4]).toBe('om_new_turn');
+    expect(ds.streamCardId).toBe('om_new_card');
+  });
+
   it('silent recovery restores screenshot mode without touching the streaming card', async () => {
     const fakeWorker = makeFakeWorker();
     const ds = makeDs({
@@ -682,14 +730,13 @@ describe('Worker ready: set_display_mode re-sync', () => {
 
     fakeWorker.emit('message', { type: 'cli_session_id', cliSessionId: 'trae-native-ready' });
     await flush();
-    expect(updateMessageMock).toHaveBeenCalledTimes(2);
-    expect(JSON.parse(updateMessageMock.mock.calls[1][2])).toMatchObject({ localCliReady: true });
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
 
     resolveRestorePatch();
     await flush();
     await flush();
 
-    expect(updateMessageMock).toHaveBeenCalledTimes(3);
+    expect(updateMessageMock).toHaveBeenCalledTimes(2);
     expect(JSON.parse(updateMessageMock.mock.calls.at(-1)![2])).toMatchObject({ localCliReady: true });
   });
 

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -468,6 +468,54 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(ds.currentImageKey).toBe('img_turn_n_plus_1');
   });
 
+  it('preserves a prior-turn usage limit after the thread card changes owner', async () => {
+    const fakeWorker = makeFakeWorker();
+    const retryAtMs = Date.now() + 60_000;
+    const ds = makeDs({
+      scope: 'thread',
+      worker: fakeWorker,
+      workerReady: true,
+      workerPort: 9999,
+      streamCardId: 'om_stable_card',
+      streamCardNonce: 'stable-nonce',
+      streamCardVisualTurnId: 'om_turn_n_plus_1',
+      currentTurnTitle: 'turn n+1',
+      lastScreenContent: 'turn n+1 starting',
+      lastScreenStatus: 'starting',
+      currentImageKey: undefined,
+      displayMode: 'screenshot',
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', {
+      type: 'screen_update',
+      content: 'turn n reached its usage limit',
+      status: 'limited',
+      turnId: 'om_turn_n',
+      usageLimit: {
+        limited: true,
+        kind: 'usage',
+        retryAtMs,
+        retryLabel: '10:36 PM',
+        retryReady: false,
+      },
+    });
+    await flush();
+
+    expect(ds.usageLimit).toMatchObject({ retryAtMs, retryReady: false });
+    expect(ds.usageLimitRetryTimer).toBeDefined();
+    expect(ds.lastScreenContent).toBe('turn n+1 starting');
+    expect(ds.lastScreenStatus).toBe('starting');
+    expect(ds.currentImageKey).toBeUndefined();
+    expect(recordUsageMock).toHaveBeenCalledWith(ds, { turnId: 'om_turn_n' });
+    expect(dashboardPublishMock).not.toHaveBeenCalled();
+    expect(transitionHookMock).not.toHaveBeenCalled();
+    expect(updateMessageMock).not.toHaveBeenCalled();
+
+    clearTimeout(ds.usageLimitRetryTimer);
+    ds.usageLimitRetryTimer = undefined;
+  });
+
   it('ignores every message from a replaced worker generation', async () => {
     const staleWorker = makeFakeWorker();
     const currentWorker = makeFakeWorker();

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -389,6 +389,61 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(ds.currentImageKey).toBe('img_zmx_history');
   });
 
+  it('ignores prior-turn visual events after a stable thread card changes owner', async () => {
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker: fakeWorker,
+      workerReady: true,
+      workerPort: 9999,
+      streamCardId: 'om_stable_card',
+      streamCardNonce: 'stable-nonce',
+      streamCardVisualTurnId: 'om_turn_n_plus_1',
+      currentTurnTitle: 'turn n+1',
+      lastScreenContent: '',
+      lastScreenStatus: 'starting',
+      currentImageKey: undefined,
+      displayMode: 'screenshot',
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', {
+      type: 'screen_update',
+      content: 'turn n completed',
+      status: 'idle',
+      turnId: 'om_turn_n',
+    });
+    fakeWorker.emit('message', {
+      type: 'screenshot_uploaded',
+      imageKey: 'img_turn_n',
+      status: 'idle',
+      turnId: 'om_turn_n',
+    });
+    await flush();
+
+    expect(ds.lastScreenContent).toBe('');
+    expect(ds.lastScreenStatus).toBe('starting');
+    expect(ds.currentImageKey).toBeUndefined();
+
+    fakeWorker.emit('message', {
+      type: 'screen_update',
+      content: 'turn n+1 running',
+      status: 'working',
+      turnId: 'om_turn_n_plus_1',
+    });
+    fakeWorker.emit('message', {
+      type: 'screenshot_uploaded',
+      imageKey: 'img_turn_n_plus_1',
+      status: 'working',
+      turnId: 'om_turn_n_plus_1',
+    });
+    await flush();
+
+    expect(ds.lastScreenContent).toBe('turn n+1 running');
+    expect(ds.lastScreenStatus).toBe('working');
+    expect(ds.currentImageKey).toBe('img_turn_n_plus_1');
+  });
+
   it('ignores every message from a replaced worker generation', async () => {
     const staleWorker = makeFakeWorker();
     const currentWorker = makeFakeWorker();

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -19,9 +19,11 @@ import { EventEmitter } from 'node:events';
 // ─── Mocks ─────────────────────────────────────────────────────────────────
 
 const updateMessageMock = vi.fn(async () => {});
-const { loggerInfoMock, recordUsageMock } = vi.hoisted(() => ({
+const { loggerInfoMock, recordUsageMock, dashboardPublishMock, transitionHookMock } = vi.hoisted(() => ({
   loggerInfoMock: vi.fn(),
   recordUsageMock: vi.fn(),
+  dashboardPublishMock: vi.fn(),
+  transitionHookMock: vi.fn(),
 }));
 
 vi.mock('../src/im/lark/client.js', () => {
@@ -88,7 +90,7 @@ vi.mock('../src/core/session-manager.js', () => ({
 }));
 
 vi.mock('../src/core/dashboard-events.js', () => ({
-  dashboardEventBus: { publish: vi.fn() },
+  dashboardEventBus: { publish: (...args: any[]) => dashboardPublishMock(...args) },
 }));
 
 vi.mock('../src/core/dashboard-rows.js', () => ({
@@ -98,6 +100,11 @@ vi.mock('../src/core/dashboard-rows.js', () => ({
 vi.mock('../src/services/usage-ledger.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../src/services/usage-ledger.js')>()),
   recordUsageForDaemonSession: (...args: any[]) => recordUsageMock(...args),
+}));
+
+vi.mock('../src/services/session-lifecycle-hooks.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/services/session-lifecycle-hooks.js')>()),
+  emitSessionStateTransitionHook: (...args: any[]) => transitionHookMock(...args),
 }));
 
 vi.mock('../src/skills/installer.js', () => ({
@@ -408,8 +415,8 @@ describe('Worker ready: set_display_mode re-sync', () => {
       streamCardNonce: 'stable-nonce',
       streamCardVisualTurnId: 'om_turn_n_plus_1',
       currentTurnTitle: 'turn n+1',
-      lastScreenContent: '',
-      lastScreenStatus: 'starting',
+      lastScreenContent: 'turn n+1 running',
+      lastScreenStatus: 'working',
       currentImageKey: undefined,
       displayMode: 'screenshot',
     });
@@ -429,27 +436,29 @@ describe('Worker ready: set_display_mode re-sync', () => {
     });
     await flush();
 
-    expect(ds.lastScreenContent).toBe('');
-    expect(ds.lastScreenStatus).toBe('starting');
+    expect(ds.lastScreenContent).toBe('turn n+1 running');
+    expect(ds.lastScreenStatus).toBe('working');
     expect(ds.currentImageKey).toBeUndefined();
-    expect(recordUsageMock).toHaveBeenCalledWith(ds);
+    expect(recordUsageMock).toHaveBeenCalledWith(ds, { turnId: 'om_turn_n' });
+    expect(dashboardPublishMock).not.toHaveBeenCalled();
+    expect(transitionHookMock).not.toHaveBeenCalled();
 
     fakeWorker.emit('message', {
       type: 'screen_update',
-      content: 'turn n+1 running',
-      status: 'working',
+      content: 'turn n+1 completed',
+      status: 'idle',
       turnId: 'om_turn_n_plus_1',
     });
     fakeWorker.emit('message', {
       type: 'screenshot_uploaded',
       imageKey: 'img_turn_n_plus_1',
-      status: 'working',
+      status: 'idle',
       turnId: 'om_turn_n_plus_1',
     });
     await flush();
 
-    expect(ds.lastScreenContent).toBe('turn n+1 running');
-    expect(ds.lastScreenStatus).toBe('working');
+    expect(ds.lastScreenContent).toBe('turn n+1 completed');
+    expect(ds.lastScreenStatus).toBe('idle');
     expect(ds.currentImageKey).toBe('img_turn_n_plus_1');
   });
 

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -763,6 +763,37 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(ds.pendingCardJson).toBeUndefined();
   });
 
+  it('bounds replacement to one POST when reused-card PATCHes keep failing', async () => {
+    updateMessageMock.mockRejectedValue(new Error('persistent Lark failure'));
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'thread',
+      worker: fakeWorker,
+      workerReady: false,
+      streamCardPending: false,
+      streamCardId: 'om_existing_card',
+      streamCardNonce: 'stable-nonce',
+      streamCardTurnGeneration: 4,
+      streamCardVisualTurnId: 'om_previous_turn',
+    });
+
+    expect(reuseThreadStreamingCardForTurn(ds, 'new turn', 'om_new_turn')).toBe(true);
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', {
+      type: 'ready', port: 9999, token: 'tok_abc', turnId: 'om_new_turn',
+    });
+    await flush();
+    await flush();
+    await flush();
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenCalledTimes(2);
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(ds.streamCardId).toBe('om_new_card');
+    expect(ds.pendingCardWithdrawFallback).toBeUndefined();
+    expect(ds.pendingCardJson).toBeUndefined();
+  });
+
   it('silent recovery restores screenshot mode without touching the streaming card', async () => {
     const fakeWorker = makeFakeWorker();
     const ds = makeDs({

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -421,6 +421,7 @@ describe('worker structured-turn status wiring', () => {
     expect(stop).toContain('for (const [ownerKey, identity] of [...rpcTurnsAwaitingActivationIdentities])');
     expect(stop).toContain("'rpc_engine_teardown_before_turn_start_ack'");
     const notify = functionSlice('notifyRpcTeardownBeforeActivation', 'stopCodexRpcEngine');
+    expect(notify).toContain('settlesTurn: true');
     expect(notify).toContain('为避免重复执行未自动重发');
     expect(notify).toContain('兜底输出可能未被捕获');
     expect(stop).toContain('turn.finalText === undefined');


### PR DESCRIPTION
## 改了什么

- 同一飞书话题的后续 turn 复用现有状态卡片，通过 PATCH 更新执行状态，不再撤回旧卡片后重发。
- 若持久化的旧卡片已被撤回或复用 PATCH 遇到普通 API/网络失败，会按 turn + generation 精确回退为 POST 新卡；该 fallback 跨同轮次成功 PATCH 持续保留，失败的 working/idle payload 会在 replacement 落地后重放，避免新卡停在 starting。补发资格进入 replacement 时一次性消费，持续 PATCH 故障不会形成 POST/PATCH 循环。
- replacement POST 期间到达的最新 working/idle 状态会在新 messageId 落地后重放，避免并发完成时新卡停留在 starting。
- 首张状态卡 POST 尚未返回时若新 turn 已接纳，落地后的同一张卡会直接转交给最新 turn，保留期间到达的 working/idle 状态，不再为新 turn 额外 POST 后撤回。
- queued card payload 记录 exact turn owner；并发 POST 落地时仅保留确属最新 turn 的 working/idle，旧 turn 的冻结快照会被最新 turn starting 覆盖，避免稳定卡显示 predecessor 状态。
- refork 的 worker-ready 卡片更新进入同一串行 PATCH 队列；上一代尚未完成的请求不能在新 turn ready 后反向覆盖，旧卡撤回时按新 turn + generation 补发 replacement。
- 稳定 thread 卡片按 exact turn 绑定视觉 owner；type-ahead 后旧轮次的 idle 仍按冻结 sender 完成 usage 等 accounting，旧轮次发现的会话级 usage limit 也会持久化并启动重试计时器，但不会覆盖新轮次标题、状态、图片或 dashboard/lifecycle 投影。
- card-off / `noCardChats` 话题不建立视觉 turn fence；没有稳定卡片可接管时，旧轮次 idle 仍会正常结算 dashboard 与执行 reaction。
- 覆盖活跃 worker、worker 退出后 resume/re-fork，以及文档评论触发的 thread 会话。
- 收到 thread 消息后添加执行中 reaction；对应回复、终止型提交失败通知或 worker 启动失败提示成功送达，或明确进入 `nothing_to_send` 终态后再精确移除，并发 turn 不会相互误删；普通与 adopted session 的启动失败分支均覆盖，通知发送失败时 reaction 保持可见。
- 显式关闭 session 时同步摘除所有待结算 reaction，并在关闭获准后 best-effort 调用飞书删除，避免关闭后永久残留执行中标记。
- reaction 仅在 durable close 成功后摘除；Riff prepare 后落盘失败或非 Riff store 异常时保留原 reaction 所有权，供仍存活的 session 后续回复或重试关闭。
- worker 未接纳、普通 refork 或非持久化初次启动失败时立即撤销 reaction；live worker 接纳消息后才更新稳定卡片，拒绝或抛错时保留上一轮已完成状态。
- pinned 初始 session 的 fork 明确检查 boolean 接纳结果；session 已关闭或被替换导致 fork 返回 false 时，按未接纳失败处理、撤销 reaction，且不误标 ingress admitted。
- 话题群入群无项目路径在 reaction 创建后若被其它入口接管，会精确撤销 seed reaction；不会让已撤回 seed 永久残留执行中标记。
- Codex App 合并 steer 的被替代轮次在持久化结算后清理各自 reaction；worker 接收 ACK 超时、RPC 激活前 teardown、adopted backend 写入后确认失效，以及 adopted session、非重启 Riff、crash-loop 停止等终止型提示，同样在明确回复送达后清理对应轮次。
- 普通、queued recovery 与文档评论 refork 均只在 replacement worker 接纳后切换稳定卡片；没有可复用 card id 时也会把 fresh-card 视觉 owner 绑定到新 turn，拒绝时保留上一轮已完成状态。文档评论与 doc-watch 的 live worker 路径同样只在接纳后更新卡片。
- doc-watch 预热在 live worker / refork 接纳后先持久化最后输入，再更新卡片视觉状态；卡片持久化失败不会留下过期恢复元数据或导致预热被重复提交。
- `/model`、`/clear` 等 raw passthrough 命令同样只在 transfer fence / worker IPC 接纳后更新稳定卡片；断连拒绝不会留下虚假的执行中状态。
- 保持普通群聊、关闭卡片会话和 VC receiver 的原有行为不变。

## 为什么改

同一话题内每轮都撤回旧状态卡片再发送新卡片，会造成消息闪动、时间线噪音，也会让用户难以判断新消息是否已开始处理。复用稳定状态卡片，并在触发消息上保留短暂 reaction，可以同时表达“已接收”和“仍在执行”，且不会污染话题历史。

## 影响面

- 改动位于飞书消息和 worker 共用路径，对所有 CLI / PTY 与 tmux 后端采用一致逻辑。
- 仅 thread scope 复用状态卡片；chat scope 仍保留每轮新卡片与旧卡片回收流程。
- card-off 会话继续沿用执行中 reaction 转 DONE 的流程；VC receiver 不产生 reaction。
- 不涉及平台相关路径、进程或编码逻辑。

## 验证

- `pnpm vitest run test/turn-reactions.test.ts test/bridge-final-output-retry.test.ts test/recall-frozen-cards.test.ts test/card-integration.test.ts test/worker-ready-display-mode.test.ts test/session-lifecycle-hooks.test.ts test/cli-runtime-display.test.ts test/session-reply-thread-anchor.test.ts test/reply-target-fallback.test.ts test/daemon-ordinary-ingress-failure-notice.test.ts test/group-join-shared-routing.test.ts test/async-terminal-settle.test.ts test/claude-turn-terminal-contract.test.ts test/worker-structured-lifecycle-status.test.ts test/session-lifecycle-start.test.ts test/doc-comment-daemon-concurrency.test.ts test/daemon-rename-route.test.ts test/transfer-passthrough-gate.test.ts test/transfer-input-gate-wiring.test.ts test/usage-ledger.test.ts test/session-delete-close-barrier.test.ts test/riff-explicit-close.test.ts`
  - 22 个测试文件、655 条用例全部通过。
- `pnpm build`
  - TypeScript 编译、domain audit、dashboard bundle 和 dist audit 通过。
- `git diff --check`
  - 通过。

全量 `pnpm test`：15,144 条通过，剩余 3 个文件受并行资源/基线环境影响。两个 daemon 动态导入 hook 超时用例单文件复跑均通过；adopted-Pi tmux 用例在本分支及最新 `origin/master` 快照中均以相同的 `tmux pipe-pane` 错误失败，确认不是本 PR 引入。

## 截图

飞书 live daemon 尚未切换到此分支，待安全切换并完成群内手动验证后补充截图。
