### PR TITLE
feat(session): session-store 引擎替换为 per-bot SQLite（导入 + 混合窗口 + sqlite-compat）

### DIFF
--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -2,14 +2,15 @@
 title: Session 架构拆解回收与 store-first 重新分步
 type: design
 date: 2026-08-12
-updated: 2026-08-13（Step 1 执行完毕后，以 master 为基线对全计划做证据复核并修订）
+updated: 2026-08-19（Step 3 第一 PR rebase 到 origin/master@47b2c11a 后，按现行基线修订口径与收益判定）
 topic: session-restage-store-first
 status: proposed
-baseline: origin/master@16fde8a27（复核基线；原始基线 723c79ade）
+baseline: origin/master@47b2c11a（0819 复核基线；0813 复核基线 16fde8a27；原始基线 723c79ade）
 references:
   - feat/virtual_actor_stage2@b6a4982ea（不合入；仅作参考实现、竞态清单与写点地图）
   - docs/design/2026-08-08-virtual-actor-session-runtime.md（原始提案；本目录保留未跟踪副本）
-  - PR #846（Step 1 产出）
+  - PR #846（Step 1+2 产出）
+  - PR #852（Step 3 第一 PR：引擎替换 + 导入 + 混合窗口；JSON 净删除另立第二 PR）
 ---
 
 # Session 架构拆解回收与 store-first 重新分步
@@ -25,6 +26,15 @@ references:
 > ① 记录 Step 1 实际产出与逐项处置；② **以 master 为唯一证据源重新核实
 > Step 2/3/4 的全部前提**——核实结论是三步全部成立，且 Step 3 的收益比原文
 > 写的更大，但两处前提表述需要修正（见各节【master 复核】）。
+>
+> **2026-08-19 修订**：#831 / virtual-actor 仍不合入；现行范式是 store-first，
+> 不是把 actor 缝隙再包一层。Step 3 第一 PR（#852）rebase 到
+> `origin/master@47b2c11a` 后复核：引擎替换与行级写的收益成立，但原文收益
+> 第 1 条（「仲裁不再依赖 findDaemon-TOCTOU」）过满——SQLite 只排序写者，
+> daemon 在位探测仍必须保留；净删除未在本 PR 兑现（JSON 机器仍在，留给灰度
+> 稳定后的第二 PR）。0813 之后 master 还叠了 Remote lineage 改名、Mojo close
+> journal、`SessionStoreUnavailableError` 写门，Step 3 必须带着这些 API 一起
+> 换引擎，不能只按 0813 的 JSON store 形状施工。
 
 ## 0. 背景与决策
 
@@ -131,8 +141,9 @@ idempotency-store、vc-meeting-* 系列）不动——它们各自有独立文�
 
 ### Step 3 — SQLite 引擎替换（1~2 个 PR）
 
-在 Step 2 的门后把 JSON 换成 per-bot SQLite（`node:sqlite`：engines 已是
-`>=22`，仓库已有先例 `adapters/cli/opencode.ts:65`）。
+在 Step 2 的门后把 JSON 换成 per-bot SQLite（`node:sqlite`：免 flag 线
+v22.13.0 / v23.4.0；仓库先例 `adapters/cli/opencode.ts`，但现行门是 daemon
+`assertSqliteSupported()`，不是 opencode 注释里的 experimental）。
 
 【master 复核 ⚠️ 前提表述需修正，但修正后收益更大】
 
@@ -148,37 +159,70 @@ idempotency-store、vc-meeting-* 系列）不动——它们各自有独立文�
 
 这个修正不削弱反而加强 Step 3 的立项理由——SQLite 在 master 上可核实的收益：
 
-1. **跨进程互斥从「探测式纪律」变成引擎保证**：WAL 下单写者多读者天然成立，
-   CLI 离线写与 daemon 在线写的仲裁不再依赖 findDaemon-TOCTOU。
+1. **写者互斥从文件锁换成引擎锁**：WAL 下多读者成立；离线 CLI 与 daemon 的
+   **写排序**由 `BEGIN IMMEDIATE` 承担。**不是**「findDaemon 探测可以删」——
+   SQLite 锁只排序写者，防的是写写交错；探测防的是「daemon 内存缓存与磁盘
+   分叉」，二者不可互替。残余 probe-vs-publish TOCTOU 与 JSON 时代等宽，仍
+   是 Step 4 的事务化候选，不是本步验收项。
 2. **消灭整图覆盖丢失更新这一整类问题**：今天 daemon 进程终身持有一份
    `Map<string, Session>` 缓存（`load()` 仅一次），每次 `save()` 把**整个 map**
    序列化重写文件——任何外部进程在窗口内写入的行都会被陈旧整图覆盖。改成
-   行级 upsert 后该类问题结构性消失。
-3. **热路径成本**：`updateSession` 全仓 119 个调用点、每条入站消息触发多次，
+   行级 upsert 后该类问题在 SQLite 路径上结构性消失。首次 load 必须与离线
+   写者走同一排他协议（`BEGIN IMMEDIATE` 快照读），否则仍会把提交前旧行读进
+   终身缓存。
+3. **热路径成本**：`updateSession` 全仓约 125 个 src 调用点（0813 计 119；
+   0819 基线因 Mojo/dashboard 等新增约 +6）、每条入站消息触发多次，
    每次 `JSON.stringify` 全部会话行（live 数据实测：单 bot 文件 228KB/40 行、
    closed 行从不回收、只增不减）再做 byte-identical 跳写。行级写把 O(全部行)
    变 O(1)。
-4. **净删除**（本步的删除项，兑现原则 1）：store 内 JSON 机器全部私有报废——
-   `withFileLockSync` 编排、tmp+rename 原子替换、byte-identical 跳写、legacy
-   `sessions.json` 迁移分支、`repairMissingChatScopes`（转为导入期一次性步骤）；
-   以及 **Riff lineage CAS + readback 验证机器 ~370 行**（session-store.ts
-   229-395、665-721）——这是手写的事务，`BEGIN IMMEDIATE` 直接替代。
+4. **净删除**（本步的删除项，兑现原则 1；**第一 PR 不兑现，灰度稳定后的
+   第二 PR 才删**）：store 内 JSON 机器全部私有报废——`withFileLockSync`
+   编排、tmp+rename 原子替换、byte-identical 跳写、legacy `sessions.json`
+   迁移分支、`repairMissingChatScopes`（转为导入期一次性步骤）；以及
+   **Remote lineage CAS + readback 的 JSON 实现**（0813 时名为 Riff；0819
+   基线已改名为 Remote，含 Mojo 共用）。第一 PR 只在 SQLite 上等价重写，
+   JSON 实现与 db-else-json 分流逻辑必须留到回滚窗口关闭。因此第一 PR
+   **暂时违反原则 1 的「合入即更简单」**——这是设计允许的 1~2 PR 切分，
+   不是另起 actor 层；验收以第二 PR 的净删除为准。
 5. durability 口径修正：今天的语义是 **tmp+rename、无 fsync**；SQLite WAL +
    `synchronous=NORMAL` 首版即不弱于现状，不顺带升级（维持原验收）。
 
-实施要点（维持原文，补充两条）：
+实施要点（0819 按现行基线补齐，不改目标）：
 
 - 首启从既有 JSON **确定性自动导入**（per-bot 文件 + legacy `sessions.json`
   中属于本 bot 的行；`repairMissingChatScope` 在导入时执行一次）：无操作员
-  仪式、无 promotion、无 HIL；
-- **保持 `updateSession(session)` 等既有签名不变**（内部变行级 upsert），
-  119 个调用点零改动——Step 2 收口后的门就是兼容层本身；
-- 跨 bot 发现类读者（`findActiveSessionsByRoot` 等）改为只读打开兄弟 bot 的
-  `.db`；`countActiveSessionsOnDisk`/`collectBotmuxSessionIdentities` 改扫
-  `.db` 文件。远程 sandbox 无本地 store 的路径（cli.ts:7743 等）语义不变；
-- 经 npm canary 渠道灰度；稳定后删除 JSON 会话持久化路径。
+  仪式、无 promotion、无 HIL。JSON 不可读则 **fail-closed**（`loadFailure` +
+  `SessionStoreUnavailableError`），禁止导入出空库把唯一副本毁掉。
+- **保持 `updateSession(session)` 等既有签名不变**（内部变行级 upsert）。
+  0819 基线门面已比 0813 宽：`listSessionsStrict` / `loadForWrite` /
+  `persistActiveRemoteLineage*`（原 Riff）/ Mojo close journal 必须走同一
+  引擎，不能只换 `updateSession`。
+- 跨 bot 发现类读者改为只读打开兄弟 bot 的 `.db`；扫描函数按 db-else-json
+  解析每个 store。远程 sandbox 无本地 store 的路径（cli.ts `loadSessions`
+  走 `loadAllSessionsSnapshot` + sandbox fallback）语义不变。
+- per-bot 库放 `session-stores/<appId>/sessions.db`（目录 bind，避免 bwrap
+  单文件 inode 钉死 WAL sidecar）；legacy 无 appId 库保持平铺、不进沙盒。
+- worker `owner: false`：混合窗口内旧 daemon 从新 dist spawn 的 worker 不得
+  首启导入。
+- Node 门：`node:sqlite` 免 flag 线为 v22.13.0 / v23.4.0；`engines` 收紧为
+  `^22.13.0 || >=23.4.0`，daemon 启动 `assertSqliteSupported()` 才是真门
+  （opencode.ts 仍标注 experimental，那是先例不是现行能力边界）。
+- 经 npm canary 渠道灰度；稳定后删除 JSON 会话持久化路径（第二 PR）。
 
-验收：引擎互换 + 上述净删除；durability 首版与今日等价。
+验收：第一 PR = 引擎互换 + 混合窗口 + 行为等价（含 0819 基线新增 API）；
+第二 PR = 上述净删除。durability 首版与今日等价。
+
+**执行结果（2026-08-19，#852 rebase onto origin/master@47b2c11a）**：
+
+- store 公共签名保持；内部 SQLite 单表 + 整行 JSON 列 + VIRTUAL 生成列索引。
+- 混合窗口统一 db-else-json；abortIf 双探测保留；首次 load 走 BEGIN IMMEDIATE。
+- 0819 基线新增面已接上：Remote lineage CAS、Mojo journal 经 `persistRow`、
+  损坏 store 的写门对 .db 同样 fail-closed。`BEGIN IMMEDIATE` 超时
+  （SQLITE_BUSY）**不得**收成空投影：daemon restore 走 `listSessions()`，
+  锁等待必须抛错而不能当成「没有会话」。
+- 体量：master `session-store.ts` 1390 行 → 本 PR ~2135 行。这是「JSON 机器
+  + SQLite 机器」共存的中间态，印证原则 1 的兑现点在第二 PR，不在本 PR。
+- src 无 SessionRuntime / virtual-actor 缝隙回流。
 
 ### Step 4 — 按痛点上事务（N 个独立小 PR，ROI gate）
 
@@ -191,16 +235,19 @@ idempotency-store、vc-meeting-* 系列）不动——它们各自有独立文�
 仅为「去哪里看」清单）】
 
 - (a) `closeSession`/`reactivateClosedSession` 的手工回滚（session-store.ts
-  554-563、637-642）——save 抛错时逐字段还原。Step 3 落地后事务化即天然替代，
-  可能不需要独立 PR。
-- (b) `reserveWorkerGeneration` 回滚重抛（worker-pool.ts:10119）与 worker exit
-  fence 的**无保护** `updateSession`（worker-pool.ts:9528，在 `worker.on('exit')`
-  处理器内直接抛出）——后者是 Step 1 分析中发现的疑似真实脆弱点。
-- (c) `admitQueuedActivationTail` 的 priorTail 回滚舞蹈（worker-pool.ts ~6040）。
-- (d) **async tail-admission 整套**（daemon.ts:16147-16226 的 reserve/settle/
-  retry-timer 三件套 + DaemonSession 三字段 + gate 分支）——Step 1 候选 5 的
-  降级素材归位处：若队首激活的 FIFO 语义由事务表达，这套进程内计数器机器
-  就是它替代并删除的 ad-hoc 防御。
+  `closeSession` / `reactivateClosedSession` / `mutateMojoCloseJournal` 的
+  persistRow 失败还原）——save 抛错时逐字段还原。Step 3 落地后事务化即天然
+  替代，可能不需要独立 PR。行号随 master 漂移，以符号名为准。
+- (b) `reserveWorkerGeneration` 回滚重抛（0819：worker-pool.ts `reserveWorkerGeneration`）
+  与 worker exit fence 的**无保护** `updateSession`——后者是 Step 1 分析中发现
+  的疑似真实脆弱点。立项前必须在现行 master 重新定位行号并写出能红的测试。
+- (c) `admitQueuedActivationTail` 的 priorTail 回滚舞蹈（0819：worker-pool.ts
+  `admitQueuedActivationTail`）。
+- (d) **async tail-admission 整套**（0819：daemon.ts
+  `queuedActivationTailAdmissionsOutstanding` / ReleasePending / RetryTimer
+  三件套 + DaemonSession 三字段 + gate 分支）——Step 1 候选 5 的降级素材归位处：
+  若队首激活的 FIFO 语义由事务表达，这套进程内计数器机器就是它替代并删除的
+  ad-hoc 防御。
 - (e) `initial-user-turn` 的 best-effort persist（落盘失败退化为进程内生效）。
 
 stage2 的 receipts / per-session lane 语义仍作设计参考，代码不搬。
@@ -214,6 +261,8 @@ stage2 的 receipts / per-session lane 语义仍作设计参考，代码不搬�
 ## 3. 非目标
 
 - 不迁移调用方群组，不建 actor 抽象层，不引入 SessionRuntime/SessionProjection 缝隙；
+  virtual-actor（#831 / feat/virtual_actor_stage2）维持不合入，不在 Step 3/4
+  「顺便固化」。store-first 就是对它的替代，不是前置。
 - 不引入分配式身份或任何注册表（BotId 保持地址纯推导）；
 - 不动内存 DaemonSession 的共享可变语义——它在单 daemon 进程内工作正常，
   重构它需要独立的实测理由；

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -2,10 +2,10 @@
 title: Session 架构拆解回收与 store-first 重新分步
 type: design
 date: 2026-08-12
-updated: 2026-08-19（Step 3 第一 PR rebase 到 origin/master@47b2c11a 后，按现行基线修订口径与收益判定）
+updated: 2026-08-20（Step 3 第一 PR rebase 到 origin/master@3d84aaad 后，按现行基线修订口径与收益判定）
 topic: session-restage-store-first
 status: proposed
-baseline: origin/master@47b2c11a（0819 复核基线；0813 复核基线 16fde8a27；原始基线 723c79ade）
+baseline: origin/master@3d84aaad（0820 复核基线；0819 复核基线 47b2c11a；0813 复核基线 16fde8a27；原始基线 723c79ade）
 references:
   - feat/virtual_actor_stage2@b6a4982ea（不合入；仅作参考实现、竞态清单与写点地图）
   - docs/design/2026-08-08-virtual-actor-session-runtime.md（原始提案；本目录保留未跟踪副本）
@@ -35,6 +35,12 @@ references:
 > 稳定后的第二 PR）。0813 之后 master 还叠了 Remote lineage 改名、Mojo close
 > journal、`SessionStoreUnavailableError` 写门，Step 3 必须带着这些 API 一起
 > 换引擎，不能只按 0813 的 JSON store 形状施工。
+>
+> **2026-08-20 修订**：#852 再 rebase 到 `origin/master@3d84aaad`。#846 的
+> 唯一门仍然健壮：src 无会话行直写绕过，CLI 只委托 `loadAllSessionsSnapshot` /
+> `mutateSessionRowOffline`，provenance 仍走 `readSessionRowCopiesAcrossStores`。
+> 0819 之后 master 新增的 Workbench `previewTarget` 在 close/resume 路径上清除，
+> 已语义化并进本 PR 的 `persistRow`。收益判定不变；原则 1 仍待第二 PR 净删除。
 
 ## 0. 背景与决策
 
@@ -212,7 +218,7 @@ v22.13.0 / v23.4.0；仓库先例 `adapters/cli/opencode.ts`，但现行门是 d
 验收：第一 PR = 引擎互换 + 混合窗口 + 行为等价（含 0819 基线新增 API）；
 第二 PR = 上述净删除。durability 首版与今日等价。
 
-**执行结果（2026-08-19，#852 rebase onto origin/master@47b2c11a）**：
+**执行结果（2026-08-20，#852 rebase onto origin/master@3d84aaad）**：
 
 - store 公共签名保持；内部 SQLite 单表 + 整行 JSON 列 + VIRTUAL 生成列索引。
 - 混合窗口统一 db-else-json；abortIf 双探测保留；首次 load 走 BEGIN IMMEDIATE。
@@ -220,7 +226,9 @@ v22.13.0 / v23.4.0；仓库先例 `adapters/cli/opencode.ts`，但现行门是 d
   损坏 store 的写门对 .db 同样 fail-closed。`BEGIN IMMEDIATE` 超时
   （SQLITE_BUSY）**不得**收成空投影：daemon restore 走 `listSessions()`，
   锁等待必须抛错而不能当成「没有会话」。
-- 体量：master `session-store.ts` 1390 行 → 本 PR ~2135 行。这是「JSON 机器
+- 0820 基线新增面：Workbench `previewTarget` 在 `closeSession` / `reactivateClosedSession`
+  清除并随 `persistRow` 回滚；#846 四导出在 SQLite + 混合窗口下仍是唯一门。
+- 体量：0813 master `session-store.ts` 1390 行 → 本 PR ~2161 行。这是「JSON 机器
   + SQLite 机器」共存的中间态，印证原则 1 的兑现点在第二 PR，不在本 PR。
 - src 无 SessionRuntime / virtual-actor 缝隙回流。
 

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -41,6 +41,9 @@ references:
 > `mutateSessionRowOffline`，provenance 仍走 `readSessionRowCopiesAcrossStores`。
 > 0819 之后 master 新增的 Workbench `previewTarget` 在 close/resume 路径上清除，
 > 已语义化并进本 PR 的 `persistRow`。收益判定不变；原则 1 仍待第二 PR 净删除。
+> 同日补记：残余 `findDaemon` probe-vs-publish TOCTOU 的消法是 **store 内占位
+> 租约**（与行写同一 `BEGIN IMMEDIATE`），不是 virtual actor / SessionRuntime；
+> 见 Step 4 候选 (f)。本 PR 不实施。
 
 ## 0. 背景与决策
 
@@ -169,7 +172,8 @@ v22.13.0 / v23.4.0；仓库先例 `adapters/cli/opencode.ts`，但现行门是 d
    **写排序**由 `BEGIN IMMEDIATE` 承担。**不是**「findDaemon 探测可以删」——
    SQLite 锁只排序写者，防的是写写交错；探测防的是「daemon 内存缓存与磁盘
    分叉」，二者不可互替。残余 probe-vs-publish TOCTOU 与 JSON 时代等宽，仍
-   是 Step 4 的事务化候选，不是本步验收项。
+   是 Step 4 候选 (f)，不是本步验收项。消法见该候选：占位进 store，不是再包
+   actor。
 2. **消灭整图覆盖丢失更新这一整类问题**：今天 daemon 进程终身持有一份
    `Map<string, Session>` 缓存（`load()` 仅一次），每次 `save()` 把**整个 map**
    序列化重写文件——任何外部进程在窗口内写入的行都会被陈旧整图覆盖。改成
@@ -257,8 +261,46 @@ v22.13.0 / v23.4.0；仓库先例 `adapters/cli/opencode.ts`，但现行门是 d
   若队首激活的 FIFO 语义由事务表达，这套进程内计数器机器就是它替代并删除的
   ad-hoc 防御。
 - (e) `initial-user-turn` 的 best-effort persist（落盘失败退化为进程内生效）。
+- (f) **离线写 `findDaemon` probe-vs-publish TOCTOU**（0820 口径备忘，未立项）。
+  Step 3 收益第 1 条已写明：SQLite 只排序写者，`abortIf` + `findDaemon` 必须留；
+  残余窗口与 JSON 时代等宽。下面「占位租约」是这条候选若立项时的**消法**，
+  不是本步或 Step 3 的验收项。
 
 stage2 的 receipts / per-session lane 语义仍作设计参考，代码不搬。
+
+#### 候选 (f) 消法：占位进 store，不必叫 actor
+
+这段窗口**不是**「daemon 进程内少了一个 mailbox」。产品规定了两种权威——
+daemon 活着时内存 `Map` 是权威；daemon 不在时 CLI 必须能改盘（离线 close /
+abandon）。第二种权威不会消失。TOCTOU 来自实现选择：`findDaemon` 读的是旁路
+descriptor（`dashboard-daemons/*.json` 心跳），写的是会话库——检查 A、动手 B。
+
+因此：
+
+- **必然存在的**：daemon 挂了仍要有人能写盘。
+- **不是必然的**：探 descriptor 和写会话行之间的缝。那是占位放在旁路文件上。
+- **与 virtual actor 无关的**：stage2 的 `SessionRuntime` 管进程内怎么改字段；
+  窗口发生在 CLI 进程 vs daemon 进程之间。进程内单线程化消不掉它。stage2 也
+  没消：CLI 仍是第二写者，descriptor 仍在库外。用缝隙层消这条是用错工具。
+- **相关的只是 occupancy 协议**（Orleans grain directory / Durable Object 的
+  瘦身版）：同一时刻一个 activation；没有 activation 才允许 failover 写存储；
+  **占位和数据在同一个原子里**。落到本仓库就是 store 元数据，不是 actor 框架，
+  也不是 §3 禁止的 BotId 注册表。
+
+若立项（仍要 test-first 复现 + 合入即删旧探测），形态是：
+
+1. 会话库持有占位：`owner_pid` / `boot_id` / `lease_until`（或 SQLite 锁会话）。
+2. daemon 启动：与首次 load **同一事务**占位（现协议是先写 descriptor 再 load，
+   占位与行不在同一原子）。
+3. CLI 离线写：`BEGIN IMMEDIATE` → 读占位 → 租约有效则 abort 去 IPC，否则改行
+   并 COMMIT。检查和动手一次事务。
+4. 租约靠心跳续期；过期才允许 CLI 当 failover 写者（90s 心跳过期已有，只是
+   和行不在同一原子）。
+
+验收必须**删掉或降级**旁路 `findDaemon` 探路（发现仍可读 descriptor，所有权
+不得再靠它 abort），不能两套探测并存——否则违反「上新必须删旧」。
+`BEGIN IMMEDIATE` 单独代替 `findDaemon` 不构成验收：锁看不见「对面有一份会
+写回的缓存」。禁止 CLI 写盘也不构成验收：离线收尸没了。
 
 ### Step 5 — 资产归档（无代码）
 
@@ -271,9 +313,11 @@ stage2 的 receipts / per-session lane 语义仍作设计参考，代码不搬�
 - 不迁移调用方群组，不建 actor 抽象层，不引入 SessionRuntime/SessionProjection 缝隙；
   virtual-actor（#831 / feat/virtual_actor_stage2）维持不合入，不在 Step 3/4
   「顺便固化」。store-first 就是对它的替代，不是前置。
-- 不引入分配式身份或任何注册表（BotId 保持地址纯推导）；
+- 不引入分配式身份或任何注册表（BotId 保持地址纯推导）。会话库内的**占位租约**
+  （Step 4 候选 f：哪个 daemon 此刻拥有本 bot 的行）是 store 元数据，不是身份
+  注册表，立项时不得借此引入 BotId 分配。
 - 不动内存 DaemonSession 的共享可变语义——它在单 daemon 进程内工作正常，
-  重构它需要独立的实测理由；
+  重构它需要独立的实测理由；也**消不掉**跨进程离线写 TOCTOU（见候选 f）。
 - （0813 明确）不把 sessionId 旁路存储（turn-sends、frozen-card、whiteboard、
   usage-ledger、idempotency、vc-meeting-*）卷进 Step 2/3 的范围。
 

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -2,10 +2,10 @@
 title: Session 架构拆解回收与 store-first 重新分步
 type: design
 date: 2026-08-12
-updated: 2026-08-20（Step 3 第一 PR rebase 到 origin/master@3d84aaad 后，按现行基线修订口径与收益判定）
+updated: 2026-08-27（Step 3 第一 PR rebase 到 origin/master@06db2b48；会话库改走 sqlite-compat，engines 跟 master）
 topic: session-restage-store-first
 status: proposed
-baseline: origin/master@3d84aaad（0820 复核基线；0819 复核基线 47b2c11a；0813 复核基线 16fde8a27；原始基线 723c79ade）
+baseline: origin/master@06db2b48（0827 复核基线；0820 复核基线 3d84aaad；0819 复核基线 47b2c11a；0813 复核基线 16fde8a27；原始基线 723c79ade）
 references:
   - feat/virtual_actor_stage2@b6a4982ea（不合入；仅作参考实现、竞态清单与写点地图）
   - docs/design/2026-08-08-virtual-actor-session-runtime.md（原始提案；本目录保留未跟踪副本）
@@ -44,6 +44,18 @@ references:
 > 同日补记：残余 `findDaemon` probe-vs-publish TOCTOU 的消法是 **store 内占位
 > 租约**（与行写同一 `BEGIN IMMEDIATE`），不是 virtual actor / SessionRuntime；
 > 见 Step 4 候选 (f)。本 PR 不实施。
+>
+> **2026-08-27 修订**：#852 再 rebase 到 `origin/master@06db2b48`。master 在
+> 0820 之后把运行时切到 bun 单二进制，并把所有 SQLite 打开收进
+> `sqlite-compat`（Node: `node:sqlite` / Bun: `bun:sqlite`，见 `005ce0ae`）。
+> 会话库若仍 `createRequire('node:sqlite')`，会在编译态把 Step 3 硬门打成假
+> 失败——这是「干净 rebase 不是正确 rebase」（traex-transcript 已写过的
+> 同一类合并坑）。本 PR 改走 compat：引擎缺失抛 `SessionStoreSqliteUnavailableError`；
+> 损坏 `.db` 仍是普通打开失败，扫描可 skip。`engines` 跟 master 的 `node: >=22`，
+> 真门仍是 daemon `assertSqliteSupported()`。原则 1–5 与 Step 2 唯一门、混合窗口
+> `owner: false`、`abortIf`+`findDaemon`、非目标（不回流 actor / 不卷旁路 store）
+> 均未被后续 master 提交破坏；#889 `/cli`、#1017 发信人、#1008 schedule、#946
+> pending-turn journal 要么走 store 字段、要么是设计允许的旁路文件。
 
 ## 0. 背景与决策
 
@@ -150,9 +162,10 @@ idempotency-store、vc-meeting-* 系列）不动——它们各自有独立文�
 
 ### Step 3 — SQLite 引擎替换（1~2 个 PR）
 
-在 Step 2 的门后把 JSON 换成 per-bot SQLite（`node:sqlite`：免 flag 线
-v22.13.0 / v23.4.0；仓库先例 `adapters/cli/opencode.ts`，但现行门是 daemon
-`assertSqliteSupported()`，不是 opencode 注释里的 experimental）。
+在 Step 2 的门后把 JSON 换成 per-bot SQLite。打开库必须走 `sqlite-compat`
+（Node 的 `node:sqlite` / Bun 的 `bun:sqlite`），禁止再直连 `node:sqlite`。
+Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
+`>=22`（bun 分发）；现行门是 daemon `assertSqliteSupported()` 经 compat 探测。
 
 【master 复核 ⚠️ 前提表述需修正，但修正后收益更大】
 
@@ -214,9 +227,12 @@ v22.13.0 / v23.4.0；仓库先例 `adapters/cli/opencode.ts`，但现行门是 d
   单文件 inode 钉死 WAL sidecar）；legacy 无 appId 库保持平铺、不进沙盒。
 - worker `owner: false`：混合窗口内旧 daemon 从新 dist spawn 的 worker 不得
   首启导入。
-- Node 门：`node:sqlite` 免 flag 线为 v22.13.0 / v23.4.0；`engines` 收紧为
-  `^22.13.0 || >=23.4.0`，daemon 启动 `assertSqliteSupported()` 才是真门
-  （opencode.ts 仍标注 experimental，那是先例不是现行能力边界）。
+- 运行时门：打开库走 `src/services/sqlite-compat.ts`（与 feedback / opencode /
+  traex 同一入口）。Node 免 flag 线仍是 v22.13.0 / v23.4.0，但 `package.json`
+  `engines` **不收紧**——跟 master `node: >=22`（bun 单二进制用 `bun:sqlite`）。
+  真门是 daemon 启动 `assertSqliteSupported()`：模块加载失败才算引擎不可用；
+  损坏 `.db` 不得收成 Unavailable（否则身份扫描会把坏库误判成整机无 SQLite）。
+  opencode.ts 仍标注 experimental，那是先例不是现行能力边界。
 - 经 npm canary 渠道灰度；稳定后删除 JSON 会话持久化路径（第二 PR）。
 
 验收：第一 PR = 引擎互换 + 混合窗口 + 行为等价（含 0819 基线新增 API）；
@@ -235,6 +251,20 @@ v22.13.0 / v23.4.0；仓库先例 `adapters/cli/opencode.ts`，但现行门是 d
 - 体量：0813 master `session-store.ts` 1390 行 → 本 PR ~2161 行。这是「JSON 机器
   + SQLite 机器」共存的中间态，印证原则 1 的兑现点在第二 PR，不在本 PR。
 - src 无 SessionRuntime / virtual-actor 缝隙回流。
+
+**执行结果（2026-08-27，#852 rebase onto origin/master@06db2b48）**：
+
+- 会话库不再直连 `node:sqlite`，经 `sqliteEngineAvailable` +
+  `openDatabaseSyncOrThrow` 打开；与 master bun 分发同一运行时原则。
+- `engines` 恢复 master 的 `>=22`；硬门文案同时覆盖 Node 升级线与 Bun
+  `bun:sqlite`。损坏库与引擎缺失分型：扫描 skip vs 穿透抛错。
+- 原则自检（对照 3d84aaad..06db2b48）：唯一门仍在（src 无 `sessions*.json`
+  直写绕过；CLI 只委托 store）；worker `owner: false`、fs-policy 授
+  `session-stores/<appId>` 目录、descriptor 后再 `listSessions()` +
+  `BEGIN IMMEDIATE`、`abortIf`+`findDaemon` 均保住。#889 会话级 `/cli` 写的是
+  Session 字段经 `updateSession`；#1017 发信人仍走
+  `readSessionRowCopiesAcrossStores`；#946 journal / #1008 schedule 仍是旁路
+  文件，符合非目标。无 SessionRuntime 回流，Step 4(f) 占位租约仍未实施。
 
 ### Step 4 — 按痛点上事务（N 个独立小 PR，ROI gate）
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "vitest": "^4.0.18"
   },
   "engines": {
-    "node": "^22.13.0 || >=23.4.0"
+    "node": ">=22"
   },
   "packageManager": "bun@1.4.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "vitest": "^4.0.18"
   },
   "engines": {
-    "node": ">=22"
+    "node": "^22.13.0 || >=23.4.0"
   },
   "packageManager": "bun@1.4.0",
   "repository": {

--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -763,13 +763,15 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
   push(dropAuthority(ctx.extraWritePaths), 'readWrite', 'internal');
   push(dropAuthority(ctx.readonlyRoots), 'readOnly', 'internal');
   // Own routing metadata (`botmux send` reply routing) — read-only. The store
-  // is SQLite (db-else-json mixed window keeps the .json grant); WAL readers
-  // additionally need the -wal/-shm sidecars a live daemon maintains.
+  // is SQLite in its own per-bot DIRECTORY (db-else-json mixed window keeps
+  // the .json grant): the dir grant is deliberate — a single-file bwrap bind
+  // pins the inode, and SQLite deletes/recreates -wal/-shm across daemon
+  // restarts, so a persistent pane with file binds would keep reading the dead
+  // WAL forever. A directory bind resolves names live. Sibling bots' store
+  // dirs stay uncovered (deny-by-default).
   push([
     `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`,
-    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db`,
-    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db-wal`,
-    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db-shm`,
+    `${ctx.sessionDataDir}/session-stores/${ctx.currentAppId}`,
   ], 'readOnly', 'internal');
   // Own upload bucket — readWRITE: `botmux quoted` / downloadResources writes the
   // downloaded attachment under attachments/<self>/<messageId>/… (not just reads
@@ -908,9 +910,9 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
     push([
       `${ctx.sessionDataDir}/bots-info.json`,               // display names for <available_bots> (public-ish)
       `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`,
-      `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db`,
-      `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db-wal`,
-      `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db-shm`,
+      // Own SQLite store DIRECTORY (see the larkTransport grant above for why
+      // a dir, not the three files).
+      `${ctx.sessionDataDir}/session-stores/${ctx.currentAppId}`,
       `${ctx.sessionDataDir}/bot-openids-${ctx.currentAppId}.json`,
       // Core-only writes its `botmux` wrapper into <dataDir>/bin (dedicated, NOT
       // the shared ~/.botmux/bin) and prepends it to the worker PATH — read-only

--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -762,8 +762,15 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
   push(ctx.outbox ? [ctx.outbox] : [], 'readWrite', 'internal');
   push(dropAuthority(ctx.extraWritePaths), 'readWrite', 'internal');
   push(dropAuthority(ctx.readonlyRoots), 'readOnly', 'internal');
-  // Own routing metadata (`botmux send` reply routing) — read-only.
-  push([`${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`], 'readOnly', 'internal');
+  // Own routing metadata (`botmux send` reply routing) — read-only. The store
+  // is SQLite (db-else-json mixed window keeps the .json grant); WAL readers
+  // additionally need the -wal/-shm sidecars a live daemon maintains.
+  push([
+    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`,
+    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db`,
+    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db-wal`,
+    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db-shm`,
+  ], 'readOnly', 'internal');
   // Own upload bucket — readWRITE: `botmux quoted` / downloadResources writes the
   // downloaded attachment under attachments/<self>/<messageId>/… (not just reads
   // pre-uploaded files). The worker mkdirs it pre-spawn so it survives the
@@ -901,6 +908,9 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
     push([
       `${ctx.sessionDataDir}/bots-info.json`,               // display names for <available_bots> (public-ish)
       `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`,
+      `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db`,
+      `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db-wal`,
+      `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.db-shm`,
       `${ctx.sessionDataDir}/bot-openids-${ctx.currentAppId}.json`,
       // Core-only writes its `botmux` wrapper into <dataDir>/bin (dedicated, NOT
       // the shared ~/.botmux/bin) and prepends it to the worker PATH — read-only

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -21332,8 +21332,9 @@ async function waitForManagedActivationCommit(index: number, appId: string): Pro
 }
 
 export async function startDaemon(botIndex?: number): Promise<void> {
-  // 会话存储 SQLite 能力硬门：npm 对 engines 不匹配只告警，这里是真正的门。
-  // 放在启动最前，失败信息可行动（升级 Node），避免拖到首次落盘才炸。
+  // 会话存储 SQLite 能力硬门：package.json engines 只要求 node>=22（npm 对
+  // 不匹配只告警；编译版走 bun:sqlite）。这里经 sqlite-compat 探测，失败
+  // 信息可行动，避免拖到首次落盘才炸。
   sessionStore.assertSqliteSupported();
 
   // Survive a fire-and-forget rejection instead of dying from it. Installed here

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22012,9 +22012,11 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // so riff never triggers into a racing durable restore (codex P1).
 
   // Publish daemon ownership immediately after IPC binds, then perform the
-  // first session-file load under SessionStore's cross-process lock. An
-  // offline CLI either observes this descriptor and delegates, or it already
-  // holds the file lock; in the latter case this load waits and sees its atomic
+  // first session-store load under the store's cross-process write exclusion
+  // (the shared file lock on JSON, a BEGIN IMMEDIATE read on SQLite — a plain
+  // SELECT would NOT wait for an in-flight offline writer). An offline CLI
+  // either observes this descriptor and delegates, or it already holds the
+  // write exclusion; in the latter case this load waits and sees its atomic
   // mutation. Never load a stale cache in an unadvertised startup window.
   desc.lastHeartbeat = Date.now();
   writeDaemonDescriptor(desc);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -21332,6 +21332,10 @@ async function waitForManagedActivationCommit(index: number, appId: string): Pro
 }
 
 export async function startDaemon(botIndex?: number): Promise<void> {
+  // 会话存储 SQLite 能力硬门：npm 对 engines 不匹配只告警，这里是真正的门。
+  // 放在启动最前，失败信息可行动（升级 Node），避免拖到首次落盘才炸。
+  sessionStore.assertSqliteSupported();
+
   // Survive a fire-and-forget rejection instead of dying from it. Installed here
   // rather than in index-daemon.ts on purpose: startDaemon has TWO entry points
   // (index-daemon.ts and index-core-only.ts), so guarding the entry file would
@@ -21344,6 +21348,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // live Lark session too. The rejection is logged loudly at error level — this
   // is a backstop for the next missed `.catch`, not permission to omit them.
   installDaemonRejectionGuard(logger);
+
   // Repair a shared tmux server polluted by an older botmux immediately on
   // daemon startup. This must not depend on restoring/spawning a bmx-* session:
   // a user-held tmux server can outlive every botmux pane and still leak stale

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -44,8 +44,8 @@ export function stripLegacyPendingCardFields(session: Record<string, unknown>): 
 }
 
 // ─── SQLite engine plumbing ──────────────────────────────────────────────────
-// Per-bot session rows live in `sessions-<appId>.db` (legacy no-appId store:
-// `sessions.db`), one table, whole-row JSON column. The TS `Session` type stays
+// Per-bot session rows live in `session-stores/<appId>/sessions.db` (legacy
+// no-appId store: `sessions.db`), one table, whole-row JSON column. The TS `Session` type stays
 // the schema authority; the generated columns below only serve hot lookups.
 // The pre-SQLite JSON files are frozen in place on first import and never
 // written again — reinstalling an older botmux and restarting reads them as of
@@ -164,6 +164,13 @@ interface OwnSqliteStore {
   upsert: SqliteStatementLike;
 }
 let ownStore: OwnSqliteStore | undefined;
+
+/** Lock/busy contention is retryable. Swallowing it into loadFailure would let
+ *  the daemon start with an empty cache while the durable store is healthy. */
+function isTransientStoreContentionError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /database is locked|SQLITE_BUSY|SQLITE_LOCKED|file-lock timeout/i.test(message);
+}
 
 function attachOwnStore(path: string): OwnSqliteStore {
   const db = openDbForOwnStore(path);
@@ -406,7 +413,7 @@ export function __testOnly_setAfterRemoteBatchRename(hook: (() => void) | undefi
 
 /**
  * Initialise session store for a specific bot (multi-daemon mode).
- * When appId is set, sessions are stored in `sessions-{appId}.db`.
+ * When appId is set, sessions are stored in `session-stores/{appId}/sessions.db`.
  * When unset, uses the legacy no-appId store (`sessions.db`).
  *
  * `owner: false` marks a non-owning process (worker): it reads whichever
@@ -562,6 +569,7 @@ function load(): void {
         }
       });
     } catch (err) {
+      if (isTransientStoreContentionError(err)) throw err;
       logger.error(`Failed to import sessions into SQLite: ${err}`);
       loadFailure = err instanceof Error ? err : new Error(String(err));
       sessions = new Map();
@@ -571,7 +579,17 @@ function load(): void {
   }
 
   if (existsSync(dbFp)) {
-    const store = attachOwnStore(dbFp);
+    let store: OwnSqliteStore;
+    try {
+      store = attachOwnStore(dbFp);
+    } catch (err) {
+      // Unreadable/corrupt .db: same fail-closed gate as a malformed JSON file.
+      logger.error(`Failed to load sessions: ${err}`);
+      loadFailure = err instanceof Error ? err : new Error(String(err));
+      sessions = new Map();
+      loaded = true;
+      return;
+    }
     sessions = new Map();
     // 排他读：BEGIN IMMEDIATE 与离线 CLI 写者互斥后再取快照。纯 SELECT 不被
     // 写事务排斥——若一个已通过双 abortIf 探测、正持有 IMMEDIATE 的离线 CLI
@@ -579,28 +597,40 @@ function load(): void {
     // 覆盖掉 CLI 的提交（JSON 时代由同一把文件锁保证的 load/离线写串行化）。
     // daemon 先发布 descriptor 再首次 load：新来的写者在探测处让位，已持锁
     // 的写者让本读取等到它 commit 之后。
-    store.db.exec('BEGIN IMMEDIATE');
-    let committed = false;
     try {
-      for (const [key, value] of readOwnStoreAllRows(store)) sessions.set(key, value);
-      const repaired = repairMissingChatScopes();
+      store.db.exec('BEGIN IMMEDIATE');
+      let committed = false;
       try {
-        for (const session of repaired) {
-          store.upsert.run(session.sessionId, sessionStatusText(session), JSON.stringify(session));
+        for (const [key, value] of readOwnStoreAllRows(store)) sessions.set(key, value);
+        const repaired = repairMissingChatScopes();
+        try {
+          for (const session of repaired) {
+            store.upsert.run(session.sessionId, sessionStatusText(session), JSON.stringify(session));
+          }
+          store.db.exec('COMMIT');
+          committed = true;
+          if (repaired.length > 0) {
+            logger.info(`Repaired ${repaired.length} scope-less chat session(s) in ${dbFp}`);
+          }
+        } catch (err) {
+          // Loading succeeded, so keep the in-memory sessions available (with
+          // the in-memory repairs) even if the best-effort repair cannot be
+          // persisted yet.
+          logger.error(`Failed to persist repaired chat session scopes: ${err}`);
         }
-        store.db.exec('COMMIT');
-        committed = true;
-        if (repaired.length > 0) {
-          logger.info(`Repaired ${repaired.length} scope-less chat session(s) in ${dbFp}`);
-        }
-      } catch (err) {
-        // Loading succeeded, so keep the in-memory sessions available (with
-        // the in-memory repairs) even if the best-effort repair cannot be
-        // persisted yet.
-        logger.error(`Failed to persist repaired chat session scopes: ${err}`);
+      } finally {
+        if (!committed) { try { store.db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
       }
-    } finally {
-      if (!committed) { try { store.db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
+    } catch (err) {
+      // Lock contention (SQLITE_BUSY after busy_timeout) must NOT become
+      // loadFailure + empty cache: daemon startup uses listSessions(), which
+      // would then restore nothing while the durable store is healthy.
+      if (ownStore) {
+        try { ownStore.db.close(); } catch { /* already closed */ }
+        ownStore = undefined;
+      }
+      sessions = new Map();
+      throw err;
     }
     logger.info(`Loaded ${sessions.size} sessions from ${dbFp}`);
     loaded = true;

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
 import { withFileLockSync } from '../utils/file-lock.js';
@@ -12,6 +13,11 @@ import type { Session } from '../types.js';
 let sessions: Map<string, Session> = new Map();
 let loaded = false;
 let currentAppId: string | undefined;
+// Only the store-owning daemon process may create/import the SQLite store.
+// Workers spawned from a NEWER dist by a still-running OLDER daemon must not
+// bootstrap a .db while that daemon keeps writing JSON — the mixed upgrade
+// window would fork the two representations.
+let sqliteBootstrapAllowed = true;
 let loadFailure: Error | undefined;
 
 /**
@@ -27,13 +33,317 @@ export class SessionStoreUnavailableError extends Error {
   }
 }
 
+
 // Legacy fields from the removed「处理中」placeholder-card PATCH delivery. They
 // no longer exist on Session and nothing reads them, but sessions persisted
-// before the removal still carry them on disk. Strip on write so the file
+// before the removal still carry them on disk. Strip on write so the store
 // converges to clean on the first save (daemon + CLI both call this).
 const LEGACY_PENDING_CARD_FIELDS = ['pendingResponseCardId', 'pendingResponseCardState', 'lastPatchedResponseCardId'] as const;
 export function stripLegacyPendingCardFields(session: Record<string, unknown>): void {
   for (const f of LEGACY_PENDING_CARD_FIELDS) delete session[f];
+}
+
+// ─── SQLite engine plumbing ──────────────────────────────────────────────────
+// Per-bot session rows live in `sessions-<appId>.db` (legacy no-appId store:
+// `sessions.db`), one table, whole-row JSON column. The TS `Session` type stays
+// the schema authority; the generated columns below only serve hot lookups.
+// The pre-SQLite JSON files are frozen in place on first import and never
+// written again — reinstalling an older botmux and restarting reads them as of
+// the freeze instant (the rollback story for the migration window).
+//
+// Mixed upgrade window (npm upgraded, daemon not yet restarted): every
+// cross-process reader and CLI offline write path resolves each store as
+// "use the .db when it exists, else the .json".
+
+interface SqliteStatementLike {
+  get(...params: unknown[]): unknown;
+  all(...params: unknown[]): unknown[];
+  run(...params: unknown[]): unknown;
+}
+interface SqliteDatabaseLike {
+  exec(sql: string): void;
+  prepare(sql: string): SqliteStatementLike;
+  close(): void;
+}
+type SqliteModuleLike = {
+  DatabaseSync: new (path: string, opts?: { readOnly?: boolean }) => SqliteDatabaseLike;
+};
+
+const SQLITE_BUSY_TIMEOUT_MS = 3000;
+const SQLITE_NODE_VERSION_HINT = 'Node ≥ 22.13.0（23.x 需 ≥ 23.4.0）';
+
+const SESSIONS_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  row TEXT NOT NULL,
+  chat_id TEXT GENERATED ALWAYS AS (json_extract(row, '$.chatId')) VIRTUAL,
+  root_message_id TEXT GENERATED ALWAYS AS (json_extract(row, '$.rootMessageId')) VIRTUAL,
+  scope TEXT GENERATED ALWAYS AS (json_extract(row, '$.scope')) VIRTUAL
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_root_message_id ON sessions(root_message_id, status);
+CREATE INDEX IF NOT EXISTS idx_sessions_chat_scope ON sessions(chat_id, scope, status);
+`;
+
+let sqliteModule: SqliteModuleLike | null | undefined;
+/** Simulate a Node runtime without node:sqlite (createRequire bypasses the
+ *  vitest module graph, so a mock cannot intercept it). */
+export function __testOnly_setSqliteUnavailable(unavailable: boolean): void {
+  sqliteModule = unavailable ? null : undefined;
+}
+function loadSqliteModule(): SqliteModuleLike | null {
+  if (sqliteModule !== undefined) return sqliteModule;
+  // ESM 下没有裸 require，必须走 createRequire（同 adapters/cli/opencode.ts 的教训）。
+  try {
+    const req = createRequire(import.meta.url);
+    sqliteModule = req('node:sqlite') as SqliteModuleLike;
+  } catch {
+    sqliteModule = null;
+  }
+  return sqliteModule;
+}
+
+/** node:sqlite is unavailable on this Node runtime but a SQLite store exists
+ *  (or must be created). Distinct class so best-effort scan loops can rethrow
+ *  it instead of degrading a capability failure into "file skipped". */
+export class SessionStoreSqliteUnavailableError extends Error {
+  override readonly name = 'SessionStoreSqliteUnavailableError';
+}
+
+function requireSqliteModule(context: string): SqliteModuleLike {
+  const mod = loadSqliteModule();
+  if (!mod) {
+    throw new SessionStoreSqliteUnavailableError(
+      `${context}需要 node:sqlite，但当前 Node ${process.version} 不提供。请升级 ${SQLITE_NODE_VERSION_HINT} 后重试。`,
+    );
+  }
+  return mod;
+}
+
+/** Startup capability gate for the daemon. npm only WARNS on an engines
+ *  mismatch, so this probe is the real gate: fail fast with an actionable
+ *  message instead of failing later on the first store touch. */
+export function assertSqliteSupported(): void {
+  requireSqliteModule('botmux 会话存储（SQLite 引擎）');
+}
+
+/** Open the store the daemon/worker owns for read-write use (WAL + NORMAL +
+ *  busy_timeout, schema ensured). Durability matches the previous JSON
+ *  tmp+rename (no fsync) — deliberately not upgraded in this step. */
+function openDbForOwnStore(path: string): SqliteDatabaseLike {
+  const mod = requireSqliteModule(`会话存储 ${basename(path)} `);
+  const db = new mod.DatabaseSync(path);
+  db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+  db.exec('PRAGMA journal_mode = WAL;');
+  db.exec('PRAGMA synchronous = NORMAL;');
+  db.exec(SESSIONS_SCHEMA_SQL);
+  return db;
+}
+
+/** Open somebody's store for reading. Read-write first so a stale WAL left by
+ *  a crashed daemon can be recovered; fall back to read-only for sandboxed
+ *  readers whose grant on the .db is read-only (a live daemon maintains the
+ *  -shm they piggyback on). Callers must only SELECT. */
+function openDbForRead(path: string): SqliteDatabaseLike {
+  const mod = requireSqliteModule(`会话存储 ${basename(path)} `);
+  let db: SqliteDatabaseLike;
+  try {
+    db = new mod.DatabaseSync(path);
+  } catch {
+    db = new mod.DatabaseSync(path, { readOnly: true });
+  }
+  db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+  return db;
+}
+
+interface OwnSqliteStore {
+  db: SqliteDatabaseLike;
+  selectRow: SqliteStatementLike;
+  selectAll: SqliteStatementLike;
+  upsert: SqliteStatementLike;
+}
+let ownStore: OwnSqliteStore | undefined;
+
+function attachOwnStore(path: string): OwnSqliteStore {
+  const db = openDbForOwnStore(path);
+  ownStore = {
+    db,
+    selectRow: db.prepare('SELECT row FROM sessions WHERE session_id = ?'),
+    selectAll: db.prepare('SELECT session_id, row FROM sessions'),
+    upsert: db.prepare(
+      'INSERT INTO sessions (session_id, status, row) VALUES (?, ?, ?) '
+      + 'ON CONFLICT(session_id) DO UPDATE SET status = excluded.status, row = excluded.row',
+    ),
+  };
+  return ownStore;
+}
+
+function sessionStatusText(value: unknown): string {
+  const status = (value as { status?: unknown } | null | undefined)?.status;
+  return typeof status === 'string' ? status : '';
+}
+
+let testOnlyBeforeRowPersist: ((sessionId: string) => void) | undefined;
+/** Failure injection for the SQLite row write (the JSON engine was injectable
+ *  through a node:fs mock; node:sqlite bypasses node:fs). */
+export function __testOnly_setBeforeRowPersist(hook: ((sessionId: string) => void) | undefined): void {
+  testOnlyBeforeRowPersist = hook;
+}
+
+// ─── Store file resolution (db-else-json) ────────────────────────────────────
+
+type StoreFileRef = {
+  /** undefined = the legacy no-appId store. */
+  appId?: string;
+  kind: 'sqlite' | 'json';
+  path: string;
+};
+
+/** Per-bot SQLite stores live in their OWN directory
+ *  (`session-stores/<appId>/sessions.db`), not as flat sibling files: the CLI
+ *  file sandbox must bind the store as a DIRECTORY. A single-file bwrap bind
+ *  pins the inode mounted at spawn, and SQLite deletes/recreates -wal/-shm
+ *  when the last connection closes — a persistent pane surviving a daemon
+ *  restart would keep reading the dead WAL forever (or a corrupt hybrid once
+ *  checkpoints recycle it). Directory binds resolve names live, so the pane
+ *  always sees the current sidecars. The legacy no-appId store (tests /
+ *  single-bot dev) stays flat `sessions.db` — it is never sandbox-granted. */
+const PER_BOT_STORE_DIRNAME = 'session-stores';
+
+export function sessionStoreSqliteDir(appId: string, dataDir: string = config.session.dataDir): string {
+  return join(dataDir, PER_BOT_STORE_DIRNAME, appId);
+}
+
+function storeDbPath(appId: string | undefined, dataDir: string): string {
+  return appId ? join(sessionStoreSqliteDir(appId, dataDir), 'sessions.db') : join(dataDir, 'sessions.db');
+}
+function storeJsonFileName(appId: string | undefined): string {
+  return appId ? `sessions-${appId}.json` : 'sessions.json';
+}
+
+/** Per-store rule for every cross-process reader and CLI offline writer:
+ *  use the .db when it exists, else the .json. */
+function resolveStoreFile(appId: string | undefined, dataDir: string): StoreFileRef {
+  const dbPath = storeDbPath(appId, dataDir);
+  if (existsSync(dbPath)) return { appId, kind: 'sqlite', path: dbPath };
+  return { appId, kind: 'json', path: join(dataDir, storeJsonFileName(appId)) };
+}
+
+/** One ref per store identity across the whole data dir, .db winning: flat
+ *  legacy files + per-bot JSON files + per-bot SQLite store directories.
+ *  `strict` propagates an unlistable `session-stores/` dir (fail-closed
+ *  callers must not mistake an unreadable store set for an empty one);
+ *  otherwise it degrades to the JSON view. */
+function listStoreRefs(dataDir: string, opts: { strict?: boolean } = {}): StoreFileRef[] {
+  const names = readdirSync(dataDir);
+  const dbPaths = new Map<string, string>();
+  const jsonPaths = new Map<string, string>();
+  for (const name of names) {
+    if (name === 'sessions.db') dbPaths.set('', join(dataDir, name));
+    else if (name === 'sessions.json') jsonPaths.set('', join(dataDir, name));
+    else if (name.startsWith('sessions-') && name.endsWith('.json')) {
+      jsonPaths.set(name.slice('sessions-'.length, -'.json'.length), join(dataDir, name));
+    }
+  }
+  if (names.includes(PER_BOT_STORE_DIRNAME)) {
+    let appIds: string[] = [];
+    try {
+      appIds = readdirSync(join(dataDir, PER_BOT_STORE_DIRNAME));
+    } catch (err) {
+      if (opts.strict) throw err;
+    }
+    for (const appId of appIds) {
+      const dbPath = storeDbPath(appId, dataDir);
+      if (existsSync(dbPath)) dbPaths.set(appId, dbPath);
+    }
+  }
+  const refs: StoreFileRef[] = [];
+  for (const key of new Set([...dbPaths.keys(), ...jsonPaths.keys()])) {
+    const dbPath = dbPaths.get(key);
+    refs.push({
+      appId: key === '' ? undefined : key,
+      kind: dbPath ? 'sqlite' : 'json',
+      path: dbPath ?? jsonPaths.get(key)!,
+    });
+  }
+  return refs;
+}
+
+/** All [key, value] entries of one store file. Throws on an unreadable store;
+ *  callers decide skip-vs-propagate (capability errors always propagate). */
+function readStoreEntries(ref: StoreFileRef): [string, Session][] {
+  if (ref.kind === 'json') {
+    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') return [];
+    return Object.entries(parsed as Record<string, Session>);
+  }
+  const db = openDbForRead(ref.path);
+  try {
+    const rows = db.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
+    const entries: [string, Session][] = [];
+    for (const r of rows) {
+      try { entries.push([r.session_id, JSON.parse(r.row) as Session]); } catch { /* skip unparseable row */ }
+    }
+    return entries;
+  } finally {
+    db.close();
+  }
+}
+
+/** Point-read one key from one store file. Throws on an unreadable store. */
+function readStoreRowByKey(ref: StoreFileRef, sessionId: string): Session | undefined {
+  if (ref.kind === 'json') {
+    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    return (parsed as Record<string, Session>)[sessionId];
+  }
+  // The daemon's hot freshness reads hit its own store — reuse the attached
+  // connection instead of opening one per call.
+  if (ownStore && loaded && ref.appId === currentAppId && ref.path === getDbPath()) {
+    const hit = ownStore.selectRow.get(sessionId) as { row: string } | undefined;
+    return hit ? JSON.parse(hit.row) as Session : undefined;
+  }
+  const db = openDbForRead(ref.path);
+  try {
+    const hit = db.prepare('SELECT row FROM sessions WHERE session_id = ?').get(sessionId) as { row: string } | undefined;
+    return hit ? JSON.parse(hit.row) as Session : undefined;
+  } finally {
+    db.close();
+  }
+}
+
+/** The active rows of one store file, optionally narrowed by an indexed hint. */
+function readStoreActiveRows(
+  ref: StoreFileRef,
+  hint?: { rootMessageId?: string; chatScopeChatId?: string },
+): Session[] {
+  if (ref.kind === 'json') {
+    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') return [];
+    return Object.values(parsed as Record<string, Session>).filter(s => s?.status === 'active');
+  }
+  const db = openDbForRead(ref.path);
+  try {
+    let sql = "SELECT row FROM sessions WHERE status = 'active'";
+    const params: unknown[] = [];
+    if (hint?.rootMessageId !== undefined) {
+      sql += ' AND root_message_id = ?';
+      params.push(hint.rootMessageId);
+    }
+    if (hint?.chatScopeChatId !== undefined) {
+      sql += " AND chat_id = ? AND scope = 'chat'";
+      params.push(hint.chatScopeChatId);
+    }
+    const rows = db.prepare(sql).all(...params) as { row: string }[];
+    const out: Session[] = [];
+    for (const r of rows) {
+      try { out.push(JSON.parse(r.row) as Session); } catch { /* skip unparseable row */ }
+    }
+    return out;
+  } finally {
+    db.close();
+  }
 }
 
 /** The active row no longer has the lineage/ownership sampled by the caller. */
@@ -96,19 +406,32 @@ export function __testOnly_setAfterRemoteBatchRename(hook: (() => void) | undefi
 
 /**
  * Initialise session store for a specific bot (multi-daemon mode).
- * When appId is set, sessions are stored in `sessions-{appId}.json`.
- * When unset, uses the legacy `sessions.json`.
+ * When appId is set, sessions are stored in `sessions-{appId}.db`.
+ * When unset, uses the legacy no-appId store (`sessions.db`).
+ *
+ * `owner: false` marks a non-owning process (worker): it reads whichever
+ * engine exists (db-else-json) but never bootstraps/imports the SQLite store —
+ * an old daemon can spawn workers from a newer dist during the upgrade window,
+ * and only the daemon itself may flip the on-disk engine.
  */
-export function init(appId?: string): void {
+export function init(appId?: string, opts: { owner?: boolean } = {}): void {
   currentAppId = appId;
+  sqliteBootstrapAllowed = opts.owner !== false;
   loaded = false;
   sessions = new Map();
   loadFailure = undefined;
+  if (ownStore) {
+    try { ownStore.db.close(); } catch { /* already closed */ }
+    ownStore = undefined;
+  }
 }
 
 function getFilePath(): string {
-  const fileName = currentAppId ? `sessions-${currentAppId}.json` : 'sessions.json';
-  return join(config.session.dataDir, fileName);
+  return join(config.session.dataDir, storeJsonFileName(currentAppId));
+}
+
+function getDbPath(): string {
+  return storeDbPath(currentAppId, config.session.dataDir);
 }
 
 function ensureDir(): void {
@@ -140,10 +463,10 @@ export function repairMissingChatScope(session: unknown): boolean {
   return false;
 }
 
-function repairMissingChatScopes(): number {
-  let repaired = 0;
+function repairMissingChatScopes(): Session[] {
+  const repaired: Session[] = [];
   for (const session of sessions.values()) {
-    if (repairMissingChatScope(session)) repaired += 1;
+    if (repairMissingChatScope(session)) repaired.push(session);
   }
   return repaired;
 }
@@ -156,30 +479,155 @@ function parseSessionsProjectionStrict(raw: string, fp: string): Record<string, 
   return value as Record<string, Session>;
 }
 
+/** The JSON rows today's load()/migration would have produced for this store:
+ *  the per-bot file's entries when it exists, else the legacy `sessions.json`
+ *  rows belonging to this bot; scope repair applied, legacy card fields
+ *  stripped, closed rows included. Parse failures degrade to an empty store —
+ *  exactly like the previous loader. */
+function readJsonEntriesForImport(jsonFp: string): [string, Session][] {
+  let entries: [string, Session][] = [];
+  if (existsSync(jsonFp)) {
+    const data = parseSessionsProjectionStrict(readFileSync(jsonFp, 'utf-8'), jsonFp);
+    entries = Object.entries(data);
+  } else if (currentAppId) {
+    const legacyFp = join(config.session.dataDir, 'sessions.json');
+    if (!existsSync(legacyFp)) return [];
+    const data = parseSessionsProjectionStrict(readFileSync(legacyFp, 'utf-8'), legacyFp);
+    entries = Object.entries(data).filter(([, v]) => v?.larkAppId === currentAppId);
+  } else {
+    return [];
+  }
+  for (const [, value] of entries) {
+    if (value && typeof value === 'object') {
+      repairMissingChatScope(value);
+      stripLegacyPendingCardFields(value as unknown as Record<string, unknown>);
+    }
+  }
+  return entries;
+}
+
+/** One-shot deterministic import: build the store at `<db>.tmp`, commit, then
+ *  rename into place so readers only ever see a complete database. The caller
+ *  holds the same JSON file lock daemon saves and offline CLI mutations use,
+ *  so the imported snapshot cannot race a concurrent JSON writer. The source
+ *  JSON is left frozen in place (the rollback path for the upgrade window). */
+function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
+  const mod = requireSqliteModule(`会话存储 ${basename(dbFp)} 首次导入`);
+  const tmpFp = `${dbFp}.tmp`;
+  for (const suffix of ['', '-wal', '-shm']) {
+    try { unlinkSync(`${tmpFp}${suffix}`); } catch { /* no leftover from a crashed import */ }
+  }
+  const entries = readJsonEntriesForImport(jsonFp);
+  const tmp = new mod.DatabaseSync(tmpFp);
+  try {
+    tmp.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+    tmp.exec('PRAGMA journal_mode = WAL;');
+    tmp.exec('PRAGMA synchronous = NORMAL;');
+    tmp.exec(SESSIONS_SCHEMA_SQL);
+    tmp.exec('BEGIN');
+    const insert = tmp.prepare('INSERT OR REPLACE INTO sessions (session_id, status, row) VALUES (?, ?, ?)');
+    for (const [key, value] of entries) {
+      insert.run(key, sessionStatusText(value), JSON.stringify(value));
+    }
+    tmp.exec('COMMIT');
+    tmp.close();
+    renameSync(tmpFp, dbFp);
+    return entries.length;
+  } catch (err) {
+    try { tmp.close(); } catch { /* already closed */ }
+    for (const suffix of ['', '-wal', '-shm']) {
+      try { unlinkSync(`${tmpFp}${suffix}`); } catch { /* best-effort orphan cleanup */ }
+    }
+    throw err;
+  }
+}
+
 // Sessions persisted before 2026-04-29 lack `cliId`; consumers must fall back to 'unknown' at the render boundary.
 function load(): void {
   if (loaded) return;
   ensureDir();
-  const fp = getFilePath();
-  withFileLockSync(fp, () => {
-    if (existsSync(fp)) {
+  const dbFp = getDbPath();
+  const jsonFp = getFilePath();
+
+  if (!existsSync(dbFp) && sqliteBootstrapAllowed) {
+    // First start on the SQLite engine: import this store's JSON rows (or
+    // create an empty store) under the same lock every JSON writer uses.
+    mkdirSync(dirname(dbFp), { recursive: true });
+    try {
+      withFileLockSync(jsonFp, () => {
+        if (existsSync(dbFp)) return; // another owning process won the import
+        const imported = importJsonStoreToSqlite(dbFp, jsonFp);
+        if (imported > 0) {
+          logger.info(`Imported ${imported} session row(s) from JSON into ${dbFp}; JSON files stay frozen for rollback`);
+        }
+      });
+    } catch (err) {
+      logger.error(`Failed to import sessions into SQLite: ${err}`);
+      loadFailure = err instanceof Error ? err : new Error(String(err));
+      sessions = new Map();
+      loaded = true;
+      return;
+    }
+  }
+
+  if (existsSync(dbFp)) {
+    const store = attachOwnStore(dbFp);
+    sessions = new Map();
+    // 排他读：BEGIN IMMEDIATE 与离线 CLI 写者互斥后再取快照。纯 SELECT 不被
+    // 写事务排斥——若一个已通过双 abortIf 探测、正持有 IMMEDIATE 的离线 CLI
+    // 尚未 commit，普通读会把它提交前的旧行读进终身缓存，随后的行写回就会
+    // 覆盖掉 CLI 的提交（JSON 时代由同一把文件锁保证的 load/离线写串行化）。
+    // daemon 先发布 descriptor 再首次 load：新来的写者在探测处让位，已持锁
+    // 的写者让本读取等到它 commit 之后。
+    store.db.exec('BEGIN IMMEDIATE');
+    let committed = false;
+    try {
+      for (const [key, value] of readOwnStoreAllRows(store)) sessions.set(key, value);
+      const repaired = repairMissingChatScopes();
       try {
-        const data = parseSessionsProjectionStrict(readFileSync(fp, 'utf-8'), fp);
+        for (const session of repaired) {
+          store.upsert.run(session.sessionId, sessionStatusText(session), JSON.stringify(session));
+        }
+        store.db.exec('COMMIT');
+        committed = true;
+        if (repaired.length > 0) {
+          logger.info(`Repaired ${repaired.length} scope-less chat session(s) in ${dbFp}`);
+        }
+      } catch (err) {
+        // Loading succeeded, so keep the in-memory sessions available (with
+        // the in-memory repairs) even if the best-effort repair cannot be
+        // persisted yet.
+        logger.error(`Failed to persist repaired chat session scopes: ${err}`);
+      }
+    } finally {
+      if (!committed) { try { store.db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
+    }
+    logger.info(`Loaded ${sessions.size} sessions from ${dbFp}`);
+    loaded = true;
+    return;
+  }
+
+  // JSON engine (non-owning process before the daemon has imported, or a
+  // pre-SQLite store this process may not bootstrap). Behaviour unchanged.
+  withFileLockSync(jsonFp, () => {
+    if (existsSync(jsonFp)) {
+      try {
+        const data = parseSessionsProjectionStrict(readFileSync(jsonFp, 'utf-8'), jsonFp);
         sessions = new Map(Object.entries(data));
         const repaired = repairMissingChatScopes();
-        if (repaired > 0) {
+        if (repaired.length > 0) {
           try {
-            const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
+            const tmpFp = `${jsonFp}.${process.pid}.${randomUUID()}.tmp`;
             writeFileSync(tmpFp, JSON.stringify(Object.fromEntries(sessions), null, 2), 'utf-8');
-            renameSync(tmpFp, fp);
-            logger.info(`Repaired ${repaired} scope-less chat session(s) in ${fp}`);
+            renameSync(tmpFp, jsonFp);
+            logger.info(`Repaired ${repaired.length} scope-less chat session(s) in ${jsonFp}`);
           } catch (err) {
             // Loading succeeded, so keep the in-memory sessions available even
             // if the best-effort repair cannot be persisted yet.
             logger.error(`Failed to persist repaired chat session scopes: ${err}`);
           }
         }
-        logger.info(`Loaded ${sessions.size} sessions from ${fp}`);
+        logger.info(`Loaded ${sessions.size} sessions from ${jsonFp}`);
       } catch (err) {
         logger.error(`Failed to load sessions: ${err}`);
         loadFailure = err instanceof Error ? err : new Error(String(err));
@@ -199,12 +647,12 @@ function load(): void {
           if (sessions.size > 0) {
             const repaired = repairMissingChatScopes();
             const obj = Object.fromEntries(sessions);
-            const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
+            const tmpFp = `${jsonFp}.${process.pid}.${randomUUID()}.tmp`;
             writeFileSync(tmpFp, JSON.stringify(obj, null, 2), 'utf-8');
-            renameSync(tmpFp, fp);
-            logger.info(`Migrated ${sessions.size} sessions from sessions.json to ${fp}`);
-            if (repaired > 0) {
-              logger.info(`Repaired ${repaired} scope-less chat session(s) during migration`);
+            renameSync(tmpFp, jsonFp);
+            logger.info(`Migrated ${sessions.size} sessions from sessions.json to ${jsonFp}`);
+            if (repaired.length > 0) {
+              logger.info(`Repaired ${repaired.length} scope-less chat session(s) during migration`);
             }
           }
         } catch (err) {
@@ -228,6 +676,15 @@ function load(): void {
 function loadForWrite(): void {
   load();
   if (loadFailure) throw new SessionStoreUnavailableError(loadFailure);
+}
+
+function readOwnStoreAllRows(store: OwnSqliteStore): [string, Session][] {
+  const rows = store.selectAll.all() as { session_id: string; row: string }[];
+  const entries: [string, Session][] = [];
+  for (const r of rows) {
+    try { entries.push([r.session_id, JSON.parse(r.row) as Session]); } catch { /* skip unparseable row */ }
+  }
+  return entries;
 }
 
 function readExistingSessionsFromDisk(fp: string): { raw: string; parsed: Record<string, Session> } {
@@ -256,8 +713,23 @@ function duplicateIds(ids: readonly string[]): string[] {
   return [...duplicates];
 }
 
+/** Read-write connection to this process's own store for remote/offline-style
+ *  fresh access: the attached connection when loaded, else a short-lived one.
+ *  Returns undefined when the store is still on the JSON engine. */
+function withOwnStoreDbIfSqlite<T>(fn: (db: SqliteDatabaseLike) => T): T | undefined {
+  if (ownStore) return fn(ownStore.db);
+  const dbFp = getDbPath();
+  if (!existsSync(dbFp)) return undefined;
+  const db = openDbForOwnStore(dbFp);
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
 /**
- * Sample every active remote participant from one fresh sessions projection.
+ * Sample every active Riff participant from one fresh sessions projection.
  * Fleet shutdown takes this snapshot before fencing any worker.
  */
 export function getActiveRemoteShutdownSnapshotsBatch(
@@ -275,8 +747,44 @@ export function getActiveRemoteShutdownSnapshotsBatch(
   }
 
   ensureDir();
-  const fp = getFilePath();
   try {
+    const sqliteResult = withOwnStoreDbIfSqlite((db): ActiveRemoteShutdownSnapshot[] => {
+      db.exec('BEGIN');
+      try {
+        const select = db.prepare('SELECT row FROM sessions WHERE session_id = ?');
+        const fresh = new Map<string, Session | undefined>();
+        for (const sessionId of sessionIds) {
+          const hit = select.get(sessionId) as { row: string } | undefined;
+          fresh.set(sessionId, hit ? JSON.parse(hit.row) as Session : undefined);
+        }
+        const invalid = sessionIds.filter((sessionId) => {
+          const session = fresh.get(sessionId);
+          return !session || session.status !== 'active';
+        });
+        if (invalid.length > 0) {
+          throw new RemoteLineageBatchError(
+            'prewrite_ownership',
+            invalid,
+            `cannot snapshot non-active remote sessions: ${invalid.join(', ')}`,
+          );
+        }
+        return sessionIds.map((sessionId) => {
+          const session = fresh.get(sessionId)!;
+          return {
+            sessionId,
+            taskId: session.riffParentTaskId ?? null,
+            owner: remoteDurableOwner(session),
+          };
+        });
+      } finally {
+        // 读事务收尾：COMMIT 失败（事务已 abort）时必须 ROLLBACK，
+        // 长驻连接绝不能滞留在事务里。
+        try { db.exec('COMMIT'); } catch { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
+      }
+    });
+    if (sqliteResult !== undefined) return sqliteResult;
+
+    const fp = getFilePath();
     return withFileLockSync(fp, () => {
       const { parsed } = readSessionsProjectionStrict(fp);
       const invalid = sessionIds.filter((sessionId) => {
@@ -311,8 +819,7 @@ export function getActiveRemoteShutdownSnapshotsBatch(
 
 /**
  * Commit every prepared remote lineage as one compare-and-set transaction.
- * The published projection is read back under the same lock before workers
- * are allowed to exit.
+ * The published rows are read back before workers are allowed to exit.
  */
 export function persistActiveRemoteLineagesExactBatch(
   updates: readonly ActiveRemoteLineageBatchUpdate[],
@@ -331,69 +838,76 @@ export function persistActiveRemoteLineagesExactBatch(
 
   loadForWrite();
   ensureDir();
-  const fp = getFilePath();
   let published = false;
-  let tmpFp: string | undefined;
   try {
-    return withFileLockSync(fp, () => {
-      const { raw, parsed } = readSessionsProjectionStrict(fp);
-      const conflicts: string[] = [];
-      for (const update of updates) {
-        const durable = parsed[update.sessionId];
-        const durableTaskId = durable?.riffParentTaskId ?? null;
-        if (!durable
-            || durable.status !== 'active'
-            || !update.expectedCurrentTaskIds.some(candidate => candidate === durableTaskId)
-            || !remoteOwnersEqual(remoteDurableOwner(durable), update.owner)) {
-          conflicts.push(update.sessionId);
+    const sqliteResult = withOwnStoreDbIfSqlite((db): ActiveRemoteShutdownSnapshot[] => {
+      const select = db.prepare('SELECT row FROM sessions WHERE session_id = ?');
+      const update = db.prepare("UPDATE sessions SET status = ?, row = ? WHERE session_id = ?");
+      let inTxn = false;
+      let changed = false;
+      try {
+        db.exec('BEGIN IMMEDIATE');
+        inTxn = true;
+        const freshRows = new Map<string, { session: Session; raw: string } | undefined>();
+        for (const sessionId of sessionIds) {
+          const hit = select.get(sessionId) as { row: string } | undefined;
+          freshRows.set(sessionId, hit ? { session: JSON.parse(hit.row) as Session, raw: hit.row } : undefined);
         }
+        const conflicts: string[] = [];
+        for (const u of updates) {
+          const durable = freshRows.get(u.sessionId)?.session;
+          const durableTaskId = durable?.riffParentTaskId ?? null;
+          if (!durable
+              || durable.status !== 'active'
+              || !u.expectedCurrentTaskIds.some(candidate => candidate === durableTaskId)
+              || !remoteOwnersEqual(remoteDurableOwner(durable), u.owner)) {
+            conflicts.push(u.sessionId);
+          }
+        }
+        if (conflicts.length > 0) {
+          throw new RemoteLineageBatchError(
+            'prewrite_ownership',
+            conflicts,
+            `Remote lineage batch compare-and-set failed for: ${conflicts.join(', ')}`,
+          );
+        }
+        for (const u of updates) {
+          const fresh = freshRows.get(u.sessionId)!;
+          const next: Session = {
+            ...fresh.session,
+            riffParentTaskId: u.targetTaskId ?? undefined,
+          };
+          stripLegacyPendingCardFields(next as unknown as Record<string, unknown>);
+          const json = JSON.stringify(next);
+          if (json !== fresh.raw) {
+            update.run(sessionStatusText(next), json, u.sessionId);
+            changed = true;
+          }
+        }
+        db.exec('COMMIT');
+        inTxn = false;
+      } catch (err) {
+        if (inTxn) { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
+        throw err;
       }
-      if (conflicts.length > 0) {
-        throw new RemoteLineageBatchError(
-          'prewrite_ownership',
-          conflicts,
-          `Remote lineage batch compare-and-set failed for: ${conflicts.join(', ')}`,
-        );
-      }
-
-      for (const update of updates) {
-        const durable = parsed[update.sessionId]!;
-        const next: Session = {
-          ...durable,
-          riffParentTaskId: update.targetTaskId ?? undefined,
-        };
-        stripLegacyPendingCardFields(next as unknown as Record<string, unknown>);
-        parsed[update.sessionId] = next;
-      }
-
-      const json = JSON.stringify(parsed, null, 2);
-      if (json !== raw) {
-        tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
-        writeFileSync(tmpFp, json, 'utf-8');
-        renameSync(tmpFp, fp);
-        tmpFp = undefined;
+      if (changed) {
         published = true;
         testOnlyAfterRemoteBatchRename?.();
       }
 
-      let verifiedProjection: Record<string, Session>;
-      try {
-        verifiedProjection = readSessionsProjectionStrict(fp).parsed;
-      } catch (error) {
-        throw new RemoteLineageBatchError(
-          published ? 'postrename_ambiguity' : 'prewrite_io',
-          [...sessionIds],
-          `failed to read back Remote lineage batch: ${String(error)}`,
-        );
+      // Read back the committed rows before any worker may exit.
+      const verifiedRows = new Map<string, Session | undefined>();
+      for (const sessionId of sessionIds) {
+        const hit = select.get(sessionId) as { row: string } | undefined;
+        verifiedRows.set(sessionId, hit ? JSON.parse(hit.row) as Session : undefined);
       }
-
-      const ambiguous = updates.filter((update) => {
-        const durable = verifiedProjection[update.sessionId];
+      const ambiguous = updates.filter((u) => {
+        const durable = verifiedRows.get(u.sessionId);
         return !durable
           || durable.status !== 'active'
-          || (durable.riffParentTaskId ?? null) !== update.targetTaskId
-          || !remoteOwnersEqual(remoteDurableOwner(durable), update.owner);
-      }).map(update => update.sessionId);
+          || (durable.riffParentTaskId ?? null) !== u.targetTaskId
+          || !remoteOwnersEqual(remoteDurableOwner(durable), u.owner);
+      }).map(u => u.sessionId);
       if (ambiguous.length > 0) {
         throw new RemoteLineageBatchError(
           published ? 'postrename_ambiguity' : 'prewrite_ownership',
@@ -402,19 +916,109 @@ export function persistActiveRemoteLineagesExactBatch(
         );
       }
 
-      const verified = updates.map((update) => ({
-        sessionId: update.sessionId,
-        taskId: update.targetTaskId,
-        owner: remoteDurableOwner(verifiedProjection[update.sessionId]!),
+      const verified = updates.map((u) => ({
+        sessionId: u.sessionId,
+        taskId: u.targetTaskId,
+        owner: remoteDurableOwner(verifiedRows.get(u.sessionId)!),
       }));
       if (loaded) {
-        for (const update of updates) {
-          const cached = sessions.get(update.sessionId);
-          if (cached) cached.riffParentTaskId = update.targetTaskId ?? undefined;
+        for (const u of updates) {
+          const cached = sessions.get(u.sessionId);
+          if (cached) cached.riffParentTaskId = u.targetTaskId ?? undefined;
         }
       }
       return verified;
-    }, { maxWaitMs: options.maxWaitMs });
+    });
+    if (sqliteResult !== undefined) return sqliteResult;
+
+    const fp = getFilePath();
+    let tmpFp: string | undefined;
+    try {
+      return withFileLockSync(fp, () => {
+        const { raw, parsed } = readSessionsProjectionStrict(fp);
+        const conflicts: string[] = [];
+        for (const update of updates) {
+          const durable = parsed[update.sessionId];
+          const durableTaskId = durable?.riffParentTaskId ?? null;
+          if (!durable
+              || durable.status !== 'active'
+              || !update.expectedCurrentTaskIds.some(candidate => candidate === durableTaskId)
+              || !remoteOwnersEqual(remoteDurableOwner(durable), update.owner)) {
+            conflicts.push(update.sessionId);
+          }
+        }
+        if (conflicts.length > 0) {
+          throw new RemoteLineageBatchError(
+            'prewrite_ownership',
+            conflicts,
+            `Remote lineage batch compare-and-set failed for: ${conflicts.join(', ')}`,
+          );
+        }
+
+        for (const update of updates) {
+          const durable = parsed[update.sessionId]!;
+          const next: Session = {
+            ...durable,
+            riffParentTaskId: update.targetTaskId ?? undefined,
+          };
+          stripLegacyPendingCardFields(next as unknown as Record<string, unknown>);
+          parsed[update.sessionId] = next;
+        }
+
+        const json = JSON.stringify(parsed, null, 2);
+        if (json !== raw) {
+          tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
+          writeFileSync(tmpFp, json, 'utf-8');
+          renameSync(tmpFp, fp);
+          tmpFp = undefined;
+          published = true;
+          testOnlyAfterRemoteBatchRename?.();
+        }
+
+        let verifiedProjection: Record<string, Session>;
+        try {
+          verifiedProjection = readSessionsProjectionStrict(fp).parsed;
+        } catch (error) {
+          throw new RemoteLineageBatchError(
+            published ? 'postrename_ambiguity' : 'prewrite_io',
+            [...sessionIds],
+            `failed to read back Remote lineage batch: ${String(error)}`,
+          );
+        }
+
+        const ambiguous = updates.filter((update) => {
+          const durable = verifiedProjection[update.sessionId];
+          return !durable
+            || durable.status !== 'active'
+            || (durable.riffParentTaskId ?? null) !== update.targetTaskId
+            || !remoteOwnersEqual(remoteDurableOwner(durable), update.owner);
+        }).map(update => update.sessionId);
+        if (ambiguous.length > 0) {
+          throw new RemoteLineageBatchError(
+            published ? 'postrename_ambiguity' : 'prewrite_ownership',
+            ambiguous,
+            `Remote lineage batch readback mismatch for: ${ambiguous.join(', ')}`,
+          );
+        }
+
+        const verified = updates.map((update) => ({
+          sessionId: update.sessionId,
+          taskId: update.targetTaskId,
+          owner: remoteDurableOwner(verifiedProjection[update.sessionId]!),
+        }));
+        if (loaded) {
+          for (const update of updates) {
+            const cached = sessions.get(update.sessionId);
+            if (cached) cached.riffParentTaskId = update.targetTaskId ?? undefined;
+          }
+        }
+        return verified;
+      }, { maxWaitMs: options.maxWaitMs });
+    } finally {
+      if (tmpFp) {
+        try { unlinkSync(tmpFp); } catch { /* best-effort orphan cleanup */ }
+      }
+    }
   } catch (error) {
     if (error instanceof RemoteLineageBatchError) throw error;
     throw new RemoteLineageBatchError(
@@ -422,13 +1026,10 @@ export function persistActiveRemoteLineagesExactBatch(
       [...sessionIds],
       `failed to persist Remote lineage batch: ${String(error)}`,
     );
-  } finally {
-    if (tmpFp) {
-      try { unlinkSync(tmpFp); } catch { /* best-effort orphan cleanup */ }
-    }
   }
 }
 
+/** Whole-map JSON save — only for a store still on the JSON engine. */
 function save(): void {
   if (loadFailure) throw new SessionStoreUnavailableError(loadFailure);
   ensureDir();
@@ -452,6 +1053,24 @@ function save(): void {
   });
 }
 
+/** Persist ONE changed row. SQLite engine: dirty-row upsert (a redundant
+ *  update that leaves the serialized row identical skips the write, the
+ *  row-level analogue of the old byte-identical whole-file skip). JSON
+ *  engine: the legacy whole-map save. */
+function persistRow(session: Session): void {
+  if (loadFailure) throw new SessionStoreUnavailableError(loadFailure);
+  if (!ownStore) {
+    save();
+    return;
+  }
+  stripLegacyPendingCardFields(session as unknown as Record<string, unknown>);
+  testOnlyBeforeRowPersist?.(session.sessionId);
+  const json = JSON.stringify(session);
+  const existing = ownStore.selectRow.get(session.sessionId) as { row: string } | undefined;
+  if (existing?.row === json) return;
+  ownStore.upsert.run(session.sessionId, sessionStatusText(session), json);
+}
+
 export function createSession(
   chatId: string,
   rootMessageId: string,
@@ -471,7 +1090,7 @@ export function createSession(
     createdAt: new Date().toISOString(),
   };
   sessions.set(session.sessionId, session);
-  save();
+  persistRow(session);
   logger.info(`Created session ${session.sessionId} (thread: ${rootMessageId})`);
   return session;
 }
@@ -512,9 +1131,20 @@ export function getOwnedSession(sessionId: string): Session | undefined {
   return sessions.get(sessionId);
 }
 
-/** Cross-process fresh read ordered after daemon/CLI writes by the shared lock. */
+/** Cross-process fresh read. SQLite engine: a point SELECT observes the last
+ *  committed write (WAL orders daemon/CLI writers). JSON engine: ordered
+ *  after writers by the shared file lock, as before. */
 export function getSessionFresh(sessionId: string): Session | undefined {
   ensureDir();
+  const dbFp = getDbPath();
+  if (existsSync(dbFp)) {
+    try {
+      return readStoreRowByKey({ appId: currentAppId, kind: 'sqlite', path: dbFp }, sessionId);
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      return undefined;
+    }
+  }
   const fp = getFilePath();
   return withFileLockSync(fp, () => {
     if (!existsSync(fp)) return undefined;
@@ -528,27 +1158,29 @@ export function getSessionFresh(sessionId: string): Session | undefined {
 }
 
 /**
- * Search all session files for a session not found in the current file.
+ * Search all session stores for a session not found in the current store.
  *
- * Sessions are partitioned per-bot (sessions-<larkAppId>.json), but agent-
- * facing CLI subcommands (`botmux send`, etc.) may be invoked in contexts
- * where LARK_APP_ID isn't set, so they can't pick the right file directly.
- * Scanning all files is safe — these callers only read sessions.
+ * Sessions are partitioned per-bot, but agent-facing CLI subcommands
+ * (`botmux send`, etc.) may be invoked in contexts where LARK_APP_ID isn't
+ * set, so they can't pick the right store directly. Scanning all stores is
+ * safe — these callers only read sessions.
  */
 function findInOtherFiles(sessionId: string): Session | undefined {
   const dataDir = config.session.dataDir;
-  const currentFp = getFilePath();
+  let refs: StoreFileRef[];
   try {
-    for (const file of readdirSync(dataDir)) {
-      if (!file.startsWith('sessions') || !file.endsWith('.json')) continue;
-      const fp = join(dataDir, file);
-      if (fp === currentFp) continue;
-      try {
-        const data: Record<string, Session> = JSON.parse(readFileSync(fp, 'utf-8'));
-        if (data[sessionId]) return data[sessionId];
-      } catch { continue; }
+    refs = listStoreRefs(dataDir);
+  } catch { return undefined; }
+  for (const ref of refs) {
+    if (ref.appId === currentAppId) continue;
+    try {
+      const hit = readStoreRowByKey(ref, sessionId);
+      if (hit) return hit;
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      continue;
     }
-  } catch { /* ignore */ }
+  }
   return undefined;
 }
 
@@ -622,7 +1254,7 @@ function mutateMojoCloseJournal(
   }
   mutate(session);
   try {
-    save();
+    persistRow(session);
   } catch (error) {
     session.mojoCloseJournal = priorJournal;
     session.riffParentTaskId = priorTaskId;
@@ -925,7 +1557,7 @@ export function closeSession(
     // Clear its retry handle in the same atomic save as status='closed'.
     if (opts.clearRiffParentTaskId) session.riffParentTaskId = undefined;
     try {
-      save();
+      persistRow(session);
     } catch (err) {
       session.status = priorStatus;
       session.closedAt = priorClosedAt;
@@ -964,7 +1596,7 @@ export function closeSession(
 
 /**
  * Reactivate one explicitly closed row and discard every queued/setup owner in
- * the same durable file replacement.  The close path has cleared these fields
+ * the same durable write.  The close path has cleared these fields
  * since 2026-07, but older closed rows can still contain prepared input.  A
  * generic resume is an explicit new lifecycle and must never revive that
  * abandoned FIFO.
@@ -1027,7 +1659,7 @@ export function reactivateClosedSession(
   session.mojoCloseJournal = undefined;
 
   try {
-    save();
+    persistRow(session);
   } catch (err) {
     Object.assign(session, prior);
     throw err;
@@ -1040,19 +1672,19 @@ export function updateSessionPid(sessionId: string, pid: number | null): void {
   const session = sessions.get(sessionId);
   if (session) {
     session.pid = pid ?? undefined;
-    save();
+    persistRow(session);
   }
 }
 
 export function updateSession(session: Session): void {
   loadForWrite();
   sessions.set(session.sessionId, session);
-  save();
+  persistRow(session);
 }
 
 /**
  * Persist one exact remote follow-up lineage for an active durable owner.
- * The process cache changes only after the atomic file replacement succeeds.
+ * The process cache changes only after the durable write succeeds.
  */
 export function persistActiveRemoteLineageExact(
   sessionId: string,
@@ -1064,10 +1696,8 @@ export function persistActiveRemoteLineageExact(
 ): Session {
   loadForWrite();
   ensureDir();
-  const fp = getFilePath();
-  return withFileLockSync(fp, () => {
-    const { raw, parsed } = readExistingSessionsFromDisk(fp);
-    const durable = parsed[sessionId];
+
+  const applyChecksAndBuildNext = (durable: Session | undefined): Session => {
     if (!durable || durable.status !== 'active') {
       throw new RemoteLineageOwnershipError(
         `cannot persist remote lineage for non-active session ${sessionId}`,
@@ -1088,20 +1718,15 @@ export function persistActiveRemoteLineageExact(
         + `expected=${JSON.stringify(options.expectedOwner)})`,
       );
     }
-
     const next: Session = {
       ...durable,
       riffParentTaskId: taskId ?? undefined,
     };
     stripLegacyPendingCardFields(next as unknown as Record<string, unknown>);
-    parsed[sessionId] = next;
-    const json = JSON.stringify(parsed, null, 2);
-    if (json !== raw) {
-      const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
-      writeFileSync(tmpFp, json, 'utf-8');
-      renameSync(tmpFp, fp);
-    }
+    return next;
+  };
 
+  const publishToCache = (next: Session): Session => {
     const cached = sessions.get(sessionId);
     if (cached) {
       cached.riffParentTaskId = taskId ?? undefined;
@@ -1109,6 +1734,44 @@ export function persistActiveRemoteLineageExact(
     }
     sessions.set(sessionId, next);
     return next;
+  };
+
+  const sqliteResult = withOwnStoreDbIfSqlite((db): Session => {
+    const select = db.prepare('SELECT row FROM sessions WHERE session_id = ?');
+    let inTxn = false;
+    try {
+      db.exec('BEGIN IMMEDIATE');
+      inTxn = true;
+      const hit = select.get(sessionId) as { row: string } | undefined;
+      const next = applyChecksAndBuildNext(hit ? JSON.parse(hit.row) as Session : undefined);
+      const json = JSON.stringify(next);
+      if (json !== hit!.row) {
+        testOnlyBeforeRowPersist?.(sessionId);
+        db.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
+          .run(sessionStatusText(next), json, sessionId);
+      }
+      db.exec('COMMIT');
+      inTxn = false;
+      return publishToCache(next);
+    } catch (err) {
+      if (inTxn) { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
+      throw err;
+    }
+  });
+  if (sqliteResult !== undefined) return sqliteResult;
+
+  const fp = getFilePath();
+  return withFileLockSync(fp, () => {
+    const { raw, parsed } = readExistingSessionsFromDisk(fp);
+    const next = applyChecksAndBuildNext(parsed[sessionId]);
+    parsed[sessionId] = next;
+    const json = JSON.stringify(parsed, null, 2);
+    if (json !== raw) {
+      const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
+      writeFileSync(tmpFp, json, 'utf-8');
+      renameSync(tmpFp, fp);
+    }
+    return publishToCache(next);
   });
 }
 
@@ -1118,7 +1781,7 @@ export function listSessions(): Session[] {
 }
 
 /**
- * Return the current projection only when its backing file was loaded safely.
+ * Return the current projection only when its backing store was loaded safely.
  * Use this for decisions that delete, retire, or reconfigure resources: the
  * legacy empty-on-error behaviour of listSessions() is unsafe at those gates.
  * A failed load remains unhealthy until init() explicitly selects/reloads a
@@ -1136,11 +1799,14 @@ export function listSessionsStrict(): Session[] {
  * another bot has already pinned to a working directory — the new bot inherits
  * the pinned dir instead of re-prompting the user for repo selection.
  *
- * Reads other bots' session files directly (best-effort) instead of relying on
- * any in-memory state, since each daemon process only owns its own bot.
+ * Reads other bots' session stores directly (best-effort) instead of relying
+ * on any in-memory state, since each daemon process only owns its own bot.
  */
 export function findActiveSessionsByRoot(rootMessageId: string): Session[] {
-  return findActiveSessionsMatching(s => s.rootMessageId === rootMessageId);
+  return findActiveSessionsMatching(
+    s => s.rootMessageId === rootMessageId,
+    { rootMessageId },
+  );
 }
 
 /**
@@ -1155,33 +1821,50 @@ export function findActiveSessionsByRoot(rootMessageId: string): Session[] {
  * are routed by rootMessageId and not eligible for chat-scope inheritance.
  */
 export function findActiveChatScopeSessionsByChat(chatId: string): Session[] {
-  return findActiveSessionsMatching(s => s.chatId === chatId && s.scope === 'chat');
+  return findActiveSessionsMatching(
+    s => s.chatId === chatId && s.scope === 'chat',
+    { chatScopeChatId: chatId },
+  );
 }
 
 /**
- * Count active sessions across every bot's on-disk session file. A pure disk
+ * Count active sessions across every bot's on-disk session store. A pure disk
  * read (no in-memory state) so it's correct at daemon startup regardless of
  * which bot owns this process — used by the restart-report DM after a restart.
  */
 export function countActiveSessionsOnDisk(dataDir: string = config.session.dataDir): number {
-  let n = 0;
+  let refs: StoreFileRef[];
   try {
-    for (const file of readdirSync(dataDir)) {
-      if (!file.startsWith('sessions') || !file.endsWith('.json')) continue;
-      try {
-        const data: Record<string, Session> = JSON.parse(readFileSync(join(dataDir, file), 'utf-8'));
+    refs = listStoreRefs(dataDir);
+  } catch { return 0; /* missing dir → 0 */ }
+  let n = 0;
+  for (const ref of refs) {
+    try {
+      if (ref.kind === 'sqlite') {
+        const db = openDbForRead(ref.path);
+        try {
+          const hit = db.prepare("SELECT COUNT(*) AS n FROM sessions WHERE status = 'active'").get() as { n: number };
+          n += hit.n;
+        } finally {
+          db.close();
+        }
+      } else {
+        const data: Record<string, Session> = JSON.parse(readFileSync(ref.path, 'utf-8'));
         for (const s of Object.values(data)) if (s?.status === 'active') n++;
-      } catch { continue; }
+      }
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      continue;
     }
-  } catch { /* missing dir → 0 */ }
+  }
   return n;
 }
 
 /**
  * Collect every CLI session identity botmux has ever recorded — across ALL bot
- * store files, ANY status (active or closed). Returns both each session's
- * botmux `sessionId` (which, for claude-family, IS the on-disk jsonl filename
- * since botmux spawns with `--session-id <id>`) and its `cliSessionId` (the
+ * stores, ANY status (active or closed). Returns both each session's botmux
+ * `sessionId` (which, for claude-family, IS the on-disk jsonl filename since
+ * botmux spawns with `--session-id <id>`) and its `cliSessionId` (the
  * CLI-native id after any resume/rotation, e.g. a codex/traex rollout id).
  *
  * Used by `/adopt`'s resume-import discovery to hide sessions botmux already
@@ -1199,16 +1882,19 @@ export function collectBotmuxSessionIdentities(dataDir: string = config.session.
   // In-memory first (freshest — covers ids not yet flushed to disk).
   load();
   for (const s of sessions.values()) add(s);
-  // Then every bot's persisted store file (other daemons own their own files).
+  // Then every bot's persisted store (other daemons own their own stores).
+  let refs: StoreFileRef[];
   try {
-    for (const file of readdirSync(dataDir)) {
-      if (!file.startsWith('sessions') || !file.endsWith('.json')) continue;
-      try {
-        const data: Record<string, Session> = JSON.parse(readFileSync(join(dataDir, file), 'utf-8'));
-        for (const s of Object.values(data)) add(s);
-      } catch { continue; }
+    refs = listStoreRefs(dataDir);
+  } catch { return ids; /* missing dir → in-memory only */ }
+  for (const ref of refs) {
+    try {
+      for (const [, s] of readStoreEntries(ref)) add(s);
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      continue;
     }
-  } catch { /* missing dir → in-memory only */ }
+  }
   return ids;
 }
 
@@ -1218,15 +1904,16 @@ export function collectBotmuxSessionIdentities(dataDir: string = config.session.
 // 2026-08 the CLI kept its own parallel copies of these (loadSessions /
 // saveSession / mutateSessionOffline in cli.ts) — one of which wrote the whole
 // file WITHOUT the lock; they were absorbed here so persistence mechanics
-// (file layout, lock, tmp+rename, legacy-field strip) stay private to this
-// module.
+// (store layout, lock/transaction, legacy-field strip) stay private to this
+// module. Every entry point resolves each store as db-else-json (mixed
+// upgrade window: npm already replaced dist, daemon still running old code).
 
 /**
- * Read-only snapshot of every session row across the legacy `sessions.json`
- * and all per-bot `sessions-<appId>.json` files. Per-bot rows win duplicate
- * sessionIds and get `larkAppId` stamped from their filename so a later
- * offline mutation resolves the owning file. Deliberately lock-free: atomic
- * tmp+rename publication keeps each file self-consistent, and snapshot
+ * Read-only snapshot of every session row across the legacy store and all
+ * per-bot stores. Per-bot rows win duplicate sessionIds and get `larkAppId`
+ * stamped from their filename so a later offline mutation resolves the owning
+ * store. Deliberately lock-free: atomic publication (tmp+rename for JSON,
+ * WAL transactions for SQLite) keeps each store self-consistent, and snapshot
  * composition must stay a pure reader (an older CLI opportunistically migrated
  * legacy rows here, which made even `botmux list` a whole-file writer able to
  * race a daemon save).
@@ -1234,96 +1921,99 @@ export function collectBotmuxSessionIdentities(dataDir: string = config.session.
 export function loadAllSessionsSnapshot(options: {
   dataDir?: string;
   /** Per-bot fallback when the data dir cannot be enumerated (the CLI file
-   *  sandbox exposes sessions-<self>.json but NOT a listing of data/). */
+   *  sandbox exposes this bot's own store but NOT a listing of data/). */
   fallbackAppId?: string;
 } = {}): Map<string, Session> {
   const dataDir = options.dataDir ?? config.session.dataDir;
   const out = new Map<string, Session>();
-  const readInto = (file: string, stampAppId?: string): void => {
-    let parsed: unknown;
+  const readInto = (ref: StoreFileRef): void => {
+    let entries: [string, Session][];
     try {
-      parsed = JSON.parse(readFileSync(join(dataDir, file), 'utf-8'));
-    } catch { return; /* missing or corrupt file → skip */ }
-    // Arrays are deliberately tolerated (Object.values yields their rows):
-    // the historical CLI loader accepted array-shaped files and existing
-    // fixtures/tools rely on that.
-    if (!parsed || typeof parsed !== 'object') return;
-    for (const value of Object.values(parsed as Record<string, unknown>)) {
+      entries = readStoreEntries(ref);
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      return; /* missing or corrupt store → skip */
+    }
+    // Arrays are deliberately tolerated on the JSON side (Object.entries
+    // yields their rows): the historical CLI loader accepted array-shaped
+    // files and existing fixtures/tools rely on that.
+    for (const [, value] of entries) {
       const session = value as Session;
       if (!session || typeof session !== 'object' || !session.sessionId) continue;
       repairMissingChatScope(session);
-      if (stampAppId && !session.larkAppId) session.larkAppId = stampAppId;
+      if (ref.appId && !session.larkAppId) session.larkAppId = ref.appId;
       out.set(session.sessionId, session);
     }
   };
-  readInto('sessions.json');
+  readInto(resolveStoreFile(undefined, dataDir));
+  let refs: StoreFileRef[];
   try {
-    for (const file of readdirSync(dataDir)) {
-      if (file.startsWith('sessions-') && file.endsWith('.json')) {
-        readInto(file, file.slice('sessions-'.length, -'.json'.length));
-      }
-    }
+    refs = listStoreRefs(dataDir);
   } catch {
     if (options.fallbackAppId) {
-      readInto(`sessions-${options.fallbackAppId}.json`, options.fallbackAppId);
+      readInto(resolveStoreFile(options.fallbackAppId, dataDir));
     }
+    return out;
+  }
+  for (const ref of refs) {
+    if (ref.appId) readInto(ref);
   }
   return out;
 }
 
 /**
  * Unlocked point-read of one row straight from disk, bypassing this process's
- * in-memory cache: the owning per-bot file first, then the legacy
- * `sessions.json`. Atomic tmp+rename publication keeps each file
- * self-consistent, so this never blocks on (or throws from) the store lock —
- * safe on hot paths that only need a freshness hint.
+ * in-memory cache: the owning per-bot store first, then the legacy store.
+ * Atomic publication keeps each store self-consistent, so this never blocks
+ * on (or throws from) the store lock — safe on hot paths that only need a
+ * freshness hint.
  */
 export function readSessionRowFromDisk(
   sessionId: string,
   larkAppId?: string,
   dataDir: string = config.session.dataDir,
 ): Session | undefined {
-  const files = larkAppId
-    ? [`sessions-${larkAppId}.json`, 'sessions.json']
-    : ['sessions.json'];
-  for (const file of files) {
-    const fp = join(dataDir, file);
-    if (!existsSync(fp)) continue;
+  const stores = larkAppId
+    ? [resolveStoreFile(larkAppId, dataDir), resolveStoreFile(undefined, dataDir)]
+    : [resolveStoreFile(undefined, dataDir)];
+  for (const ref of stores) {
+    if (!existsSync(ref.path)) continue;
     try {
-      const data = JSON.parse(readFileSync(fp, 'utf-8')) as Record<string, Session>;
-      if (data[sessionId]) return data[sessionId];
-    } catch { /* ignore corrupt/racing session file */ }
+      const hit = readStoreRowByKey(ref, sessionId);
+      if (hit) return hit;
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      /* ignore corrupt/racing session store */
+    }
   }
   return undefined;
 }
 
 /**
- * Fail-closed identity scan: every file's copy of one session row across the
- * legacy and all per-bot files — one entry per file that holds the id. An
- * unlistable data dir THROWS: a caller proving "this row resolves exactly
- * once" must not mistake an unreadable store for an empty one. A corrupt
- * individual file is skipped: an unrelated bot's bad file must neither block
- * nor impersonate a valid record; the target row still has to resolve from a
- * readable file.
+ * Fail-closed identity scan: every store's copy of one session row across the
+ * legacy and all per-bot stores — one entry per store that holds the id (a
+ * per-bot store is its .db when that exists, else its .json; a frozen
+ * pre-import JSON file is superseded, not a second copy). An unlistable data
+ * dir THROWS: a caller proving "this row resolves exactly once" must not
+ * mistake an unreadable store for an empty one. A corrupt individual store is
+ * skipped: an unrelated bot's bad file must neither block nor impersonate a
+ * valid record; the target row still has to resolve from a readable store.
  */
 export function readSessionRowCopiesAcrossStores(
   sessionId: string,
   dataDir: string = config.session.dataDir,
 ): Session[] {
-  const files = readdirSync(dataDir).filter((name) => (
-    name === 'sessions.json'
-    || (name.startsWith('sessions-') && name.endsWith('.json'))
-  ));
+  const refs = listStoreRefs(dataDir, { strict: true });
   const matches: Session[] = [];
-  for (const file of files) {
-    let parsed: unknown;
+  for (const ref of refs) {
+    let session: Session | undefined;
     try {
-      parsed = JSON.parse(readFileSync(join(dataDir, file), 'utf-8')) as unknown;
-    } catch { continue; }
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
-    const keyed = (parsed as Record<string, unknown>)[sessionId];
-    if (!keyed || typeof keyed !== 'object' || Array.isArray(keyed)) continue;
-    const session = keyed as Session;
+      session = readStoreRowByKey(ref, sessionId);
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      continue;
+    }
+    if (!session || typeof session !== 'object' || Array.isArray(session)) continue;
     if (session.sessionId !== sessionId) continue;
     matches.push(session);
   }
@@ -1331,21 +2021,23 @@ export function readSessionRowCopiesAcrossStores(
 }
 
 /**
- * Locked offline mutation of one exact row in its owning file (per-bot when
- * the caller-observed row carries `larkAppId`, legacy `sessions.json`
- * otherwise). Re-reads the row under the SAME lock the owning daemon uses for
- * every save and hands the FRESH copy to `mutate` — never publishing the
- * caller's possibly-stale snapshot — then republishes with the daemon's own
- * tmp+rename / mismatched-key cleanup / legacy-field strip.
+ * Locked offline mutation of one exact row in its owning store (per-bot when
+ * the caller-observed row carries `larkAppId`, the legacy store otherwise).
+ * Re-reads the row under the owning store's write exclusion — the SQLite
+ * store's `BEGIN IMMEDIATE` transaction, or the shared file lock for a store
+ * still on JSON — and hands the FRESH copy to `mutate`, never publishing the
+ * caller's possibly-stale snapshot.
  *
- * `abortIf` is evaluated under the lock at entry and re-evaluated immediately
- * before publication; returning true abandons the mutation with `undefined`
- * (callers pass a daemon-liveness probe so an owning daemon that appears
- * mid-flight stays authoritative and the file is left untouched).
+ * `abortIf` is evaluated at entry (inside the exclusion) and re-evaluated
+ * immediately before publication; returning true abandons the mutation with
+ * `undefined` (callers pass a daemon-liveness probe so an owning daemon that
+ * appears mid-flight stays authoritative and the store is left untouched).
+ * SQLite's own locking does NOT replace this probe: it orders writers, but
+ * cannot detect that a daemon holding a stale in-memory cache has come alive.
  *
  * Returns the fresh row — mutated when `mutate` returned true, otherwise
- * unmodified (so `() => false` is a locked fresh read) — or undefined when
- * the row is absent or `abortIf` aborted.
+ * unmodified (so `() => false` is an exclusion-ordered fresh read) — or
+ * undefined when the row is absent or `abortIf` aborted.
  */
 export function mutateSessionRowOffline(
   target: { sessionId: string; larkAppId?: string },
@@ -1353,8 +2045,34 @@ export function mutateSessionRowOffline(
   options: { dataDir?: string; abortIf?: () => boolean } = {},
 ): Session | undefined {
   const dataDir = options.dataDir ?? config.session.dataDir;
-  const fileName = target.larkAppId ? `sessions-${target.larkAppId}.json` : 'sessions.json';
-  const fp = join(dataDir, fileName);
+  const ref = resolveStoreFile(target.larkAppId, dataDir);
+
+  if (ref.kind === 'sqlite') {
+    const db = openDbForOwnStore(ref.path);
+    let inTxn = false;
+    try {
+      db.exec('BEGIN IMMEDIATE');
+      inTxn = true;
+      if (options.abortIf?.()) return undefined;
+      const hit = db.prepare('SELECT row FROM sessions WHERE session_id = ?')
+        .get(target.sessionId) as { row: string } | undefined;
+      if (!hit) return undefined;
+      const current = JSON.parse(hit.row) as Session;
+      if (!mutate(current)) return current;
+      stripLegacyPendingCardFields(current as unknown as Record<string, unknown>);
+      if (options.abortIf?.()) return undefined;
+      db.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
+        .run(sessionStatusText(current), JSON.stringify(current), target.sessionId);
+      db.exec('COMMIT');
+      inTxn = false;
+      return current;
+    } finally {
+      if (inTxn) { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
+      db.close();
+    }
+  }
+
+  const fp = ref.path;
   return withFileLockSync(fp, () => {
     if (options.abortIf?.()) return undefined;
     let data: Record<string, Session> = {};
@@ -1384,26 +2102,30 @@ export function mutateSessionRowOffline(
   });
 }
 
-function findActiveSessionsMatching(predicate: (s: Session) => boolean): Session[] {
+function findActiveSessionsMatching(
+  predicate: (s: Session) => boolean,
+  hint?: { rootMessageId?: string; chatScopeChatId?: string },
+): Session[] {
   load();
   const matches: Session[] = [];
   for (const s of sessions.values()) {
     if (predicate(s) && s.status === 'active') matches.push(s);
   }
   const dataDir = config.session.dataDir;
-  const currentFp = getFilePath();
+  let refs: StoreFileRef[];
   try {
-    for (const file of readdirSync(dataDir)) {
-      if (!file.startsWith('sessions') || !file.endsWith('.json')) continue;
-      const fp = join(dataDir, file);
-      if (fp === currentFp) continue;
-      try {
-        const data: Record<string, Session> = JSON.parse(readFileSync(fp, 'utf-8'));
-        for (const s of Object.values(data)) {
-          if (predicate(s) && s.status === 'active') matches.push(s);
-        }
-      } catch { continue; }
+    refs = listStoreRefs(dataDir);
+  } catch { return matches; }
+  for (const ref of refs) {
+    if (ref.appId === currentAppId) continue;
+    try {
+      for (const s of readStoreActiveRows(ref, hint)) {
+        if (predicate(s) && s.status === 'active') matches.push(s);
+      }
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      continue;
     }
-  } catch { /* ignore */ }
+  }
   return matches;
 }

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -120,6 +120,7 @@ export function assertSqliteSupported(): void {
 function openDbForOwnStore(path: string): SqliteDatabaseLike {
   requireSqliteEngine(`会话存储 ${basename(path)} `);
   const db = openDatabaseSyncOrThrow(path);
+  // Both engines validate the file at first use, not in the constructor.
   db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
   db.exec('PRAGMA journal_mode = WAL;');
   db.exec('PRAGMA synchronous = NORMAL;');
@@ -139,6 +140,7 @@ function openDbForRead(path: string): SqliteDatabaseLike {
   } catch {
     db = openDatabaseSyncOrThrow(path, { readOnly: true });
   }
+  // First use: file validation (corrupt → throw here, skippable by scan).
   db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
   return db;
 }

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -1,13 +1,18 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { createRequire } from 'node:module';
 import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
 import { withFileLockSync } from '../utils/file-lock.js';
 import { cleanupMaterializedDashboardImages } from '../core/dashboard-images.js';
 import { deleteFrozenCards } from './frozen-card-store.js';
 import { removePromptContextDir } from './prompt-context-store.js';
+import {
+  openDatabaseSyncOrThrow,
+  sqliteEngineAvailable,
+  type DatabaseSyncLike,
+  type StatementLike,
+} from './sqlite-compat.js';
 import type { Session } from '../types.js';
 
 let sessions: Map<string, Session> = new Map();
@@ -55,19 +60,8 @@ export function stripLegacyPendingCardFields(session: Record<string, unknown>): 
 // cross-process reader and CLI offline write path resolves each store as
 // "use the .db when it exists, else the .json".
 
-interface SqliteStatementLike {
-  get(...params: unknown[]): unknown;
-  all(...params: unknown[]): unknown[];
-  run(...params: unknown[]): unknown;
-}
-interface SqliteDatabaseLike {
-  exec(sql: string): void;
-  prepare(sql: string): SqliteStatementLike;
-  close(): void;
-}
-type SqliteModuleLike = {
-  DatabaseSync: new (path: string, opts?: { readOnly?: boolean }) => SqliteDatabaseLike;
-};
+type SqliteStatementLike = StatementLike;
+type SqliteDatabaseLike = DatabaseSyncLike;
 
 const SQLITE_BUSY_TIMEOUT_MS = 3000;
 const SQLITE_NODE_VERSION_HINT = 'Node ≥ 22.13.0（23.x 需 ≥ 23.4.0）';
@@ -86,54 +80,46 @@ CREATE INDEX IF NOT EXISTS idx_sessions_root_message_id ON sessions(root_message
 CREATE INDEX IF NOT EXISTS idx_sessions_chat_scope ON sessions(chat_id, scope, status);
 `;
 
-let sqliteModule: SqliteModuleLike | null | undefined;
-/** Simulate a Node runtime without node:sqlite (createRequire bypasses the
- *  vitest module graph, so a mock cannot intercept it). */
+let sqliteForcedUnavailable = false;
+/** Simulate a runtime without a SQLite engine. The real probe lives in
+ *  sqlite-compat (Node: node:sqlite / Bun: bun:sqlite); tests flip this
+ *  because createRequire bypasses the vitest module graph. */
 export function __testOnly_setSqliteUnavailable(unavailable: boolean): void {
-  sqliteModule = unavailable ? null : undefined;
-}
-function loadSqliteModule(): SqliteModuleLike | null {
-  if (sqliteModule !== undefined) return sqliteModule;
-  // ESM 下没有裸 require，必须走 createRequire（同 adapters/cli/opencode.ts 的教训）。
-  try {
-    const req = createRequire(import.meta.url);
-    sqliteModule = req('node:sqlite') as SqliteModuleLike;
-  } catch {
-    sqliteModule = null;
-  }
-  return sqliteModule;
+  sqliteForcedUnavailable = unavailable;
 }
 
-/** node:sqlite is unavailable on this Node runtime but a SQLite store exists
- *  (or must be created). Distinct class so best-effort scan loops can rethrow
- *  it instead of degrading a capability failure into "file skipped". */
+/** SQLite engine cannot be loaded but a SQLite store exists (or must be
+ *  created). Distinct class so best-effort scan loops can rethrow it instead
+ *  of degrading a capability failure into "file skipped". A corrupt .db is
+ *  NOT this error — that is a regular open failure the scan may skip. */
 export class SessionStoreSqliteUnavailableError extends Error {
   override readonly name = 'SessionStoreSqliteUnavailableError';
 }
 
-function requireSqliteModule(context: string): SqliteModuleLike {
-  const mod = loadSqliteModule();
-  if (!mod) {
-    throw new SessionStoreSqliteUnavailableError(
-      `${context}需要 node:sqlite，但当前 Node ${process.version} 不提供。请升级 ${SQLITE_NODE_VERSION_HINT} 后重试。`,
-    );
-  }
-  return mod;
+function sqliteUnavailableMessage(context: string): string {
+  return `${context}需要 SQLite 引擎（Node 的 node:sqlite 或 Bun 的 bun:sqlite），但当前运行时不可用。Node 请升级到 ${SQLITE_NODE_VERSION_HINT}；编译版请使用支持 bun:sqlite 的 Bun。当前 runtime: ${process.version}。`;
 }
 
-/** Startup capability gate for the daemon. npm only WARNS on an engines
- *  mismatch, so this probe is the real gate: fail fast with an actionable
- *  message instead of failing later on the first store touch. */
+function requireSqliteEngine(context: string): void {
+  if (sqliteForcedUnavailable || !sqliteEngineAvailable()) {
+    throw new SessionStoreSqliteUnavailableError(sqliteUnavailableMessage(context));
+  }
+}
+
+/** Startup capability gate for the daemon. package.json engines is only
+ *  `node: >=22` (npm WARNS on mismatch; bun binaries use bun:sqlite). This
+ *  probe is the real gate: fail fast with an actionable message instead of
+ *  failing later on the first store touch. */
 export function assertSqliteSupported(): void {
-  requireSqliteModule('botmux 会话存储（SQLite 引擎）');
+  requireSqliteEngine('botmux 会话存储（SQLite 引擎）');
 }
 
 /** Open the store the daemon/worker owns for read-write use (WAL + NORMAL +
  *  busy_timeout, schema ensured). Durability matches the previous JSON
  *  tmp+rename (no fsync) — deliberately not upgraded in this step. */
 function openDbForOwnStore(path: string): SqliteDatabaseLike {
-  const mod = requireSqliteModule(`会话存储 ${basename(path)} `);
-  const db = new mod.DatabaseSync(path);
+  requireSqliteEngine(`会话存储 ${basename(path)} `);
+  const db = openDatabaseSyncOrThrow(path);
   db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
   db.exec('PRAGMA journal_mode = WAL;');
   db.exec('PRAGMA synchronous = NORMAL;');
@@ -146,12 +132,12 @@ function openDbForOwnStore(path: string): SqliteDatabaseLike {
  *  readers whose grant on the .db is read-only (a live daemon maintains the
  *  -shm they piggyback on). Callers must only SELECT. */
 function openDbForRead(path: string): SqliteDatabaseLike {
-  const mod = requireSqliteModule(`会话存储 ${basename(path)} `);
+  requireSqliteEngine(`会话存储 ${basename(path)} `);
   let db: SqliteDatabaseLike;
   try {
-    db = new mod.DatabaseSync(path);
+    db = openDatabaseSyncOrThrow(path);
   } catch {
-    db = new mod.DatabaseSync(path, { readOnly: true });
+    db = openDatabaseSyncOrThrow(path, { readOnly: true });
   }
   db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
   return db;
@@ -193,7 +179,7 @@ function sessionStatusText(value: unknown): string {
 
 let testOnlyBeforeRowPersist: ((sessionId: string) => void) | undefined;
 /** Failure injection for the SQLite row write (the JSON engine was injectable
- *  through a node:fs mock; node:sqlite bypasses node:fs). */
+ *  through a node:fs mock; the sqlite-compat handle bypasses node:fs). */
 export function __testOnly_setBeforeRowPersist(hook: ((sessionId: string) => void) | undefined): void {
   testOnlyBeforeRowPersist = hook;
 }
@@ -519,13 +505,13 @@ function readJsonEntriesForImport(jsonFp: string): [string, Session][] {
  *  so the imported snapshot cannot race a concurrent JSON writer. The source
  *  JSON is left frozen in place (the rollback path for the upgrade window). */
 function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
-  const mod = requireSqliteModule(`会话存储 ${basename(dbFp)} 首次导入`);
+  requireSqliteEngine(`会话存储 ${basename(dbFp)} 首次导入`);
   const tmpFp = `${dbFp}.tmp`;
   for (const suffix of ['', '-wal', '-shm']) {
     try { unlinkSync(`${tmpFp}${suffix}`); } catch { /* no leftover from a crashed import */ }
   }
   const entries = readJsonEntriesForImport(jsonFp);
-  const tmp = new mod.DatabaseSync(tmpFp);
+  const tmp = openDatabaseSyncOrThrow(tmpFp);
   try {
     tmp.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
     tmp.exec('PRAGMA journal_mode = WAL;');

--- a/src/services/sqlite-compat.ts
+++ b/src/services/sqlite-compat.ts
@@ -9,8 +9,16 @@
  *
  * Both back the same tiny synchronous API botmux uses (open, exec, prepare→
  * get/run/all, close), so we expose one `DatabaseSyncLike` interface and pick
- * the backing engine by runtime. Callers import `openDatabaseSync` here instead
- * of importing `node:sqlite` directly.
+ * the backing engine by runtime. Callers import from here instead of
+ * importing `node:sqlite` directly.
+ *
+ * Two open contracts:
+ *   • `openDatabaseSyncNow` — best-effort (adapters / feedback): any failure
+ *     returns null, including a missing module AND a corrupt file.
+ *   • `sqliteEngineAvailable` + `openDatabaseSyncOrThrow` — fail-closed
+ *     stores (session-store): module-load failure is "no engine"; a
+ *     constructor error after the engine loaded is a bad file, not a
+ *     missing runtime. Do not collapse the two.
  *
  * Kept deliberately synchronous to match the existing feedback store's contract
  * (a synchronous write under a busy_timeout serializes concurrent opens without
@@ -75,6 +83,34 @@ function wrapBunDatabase(db: {
   };
 }
 
+function openWithLoadedEngine(path: string, opts: OpenOptions = {}): DatabaseSyncLike {
+  const require = createRequire(import.meta.url);
+  if (isBunRuntime()) {
+    const { Database } = require('bun:sqlite');
+    const db = opts.readOnly ? new Database(path, { readonly: true }) : new Database(path);
+    return wrapBunDatabase(db as never);
+  }
+  const { DatabaseSync } = require('node:sqlite');
+  const db = opts.readOnly ? new DatabaseSync(path, { readOnly: true }) : new DatabaseSync(path);
+  return db as unknown as DatabaseSyncLike;
+}
+
+/** Probe whether a SQLite engine can be loaded. Does not open a file, so a
+ *  corrupt database is not mistaken for a missing runtime. */
+export function sqliteEngineAvailable(): boolean {
+  try {
+    const require = createRequire(import.meta.url);
+    if (isBunRuntime()) {
+      require('bun:sqlite');
+      return true;
+    }
+    require('node:sqlite');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Open a SQLite database with the right engine for the current runtime, returning
  * a unified synchronous handle. Async because Node's binding is imported lazily
@@ -101,21 +137,24 @@ export async function openDatabaseSync(path: string, opts: OpenOptions = {}): Pr
  * Synchronous open, for call sites that must stay sync (e.g. the opencode/traex
  * adapters' `withDb`, which run inside synchronous input-delivery paths). Uses
  * `createRequire` so the runtime-specific specifier stays out of the bundler's
- * static graph. Returns null if the engine can't be loaded (caller degrades),
- * matching the adapters' existing best-effort contract.
+ * static graph. Returns null if the engine can't be loaded OR the open fails
+ * (caller degrades), matching the adapters' existing best-effort contract.
  */
 export function openDatabaseSyncNow(path: string, opts: OpenOptions = {}): DatabaseSyncLike | null {
   try {
-    const require = createRequire(import.meta.url);
-    if (isBunRuntime()) {
-      const { Database } = require('bun:sqlite');
-      const db = opts.readOnly ? new Database(path, { readonly: true }) : new Database(path);
-      return wrapBunDatabase(db as never);
-    }
-    const { DatabaseSync } = require('node:sqlite');
-    const db = opts.readOnly ? new DatabaseSync(path, { readOnly: true }) : new DatabaseSync(path);
-    return db as unknown as DatabaseSyncLike;
+    return openWithLoadedEngine(path, opts);
   } catch {
     return null;
   }
+}
+
+/**
+ * Synchronous open that distinguishes "no engine" from "engine loaded, open
+ * failed". Module-load errors propagate as thrown exceptions from `require`;
+ * a corrupt / locked file also throws from the constructor. Fail-closed
+ * stores (session-store) use this so SQLITE_NOTADB is not collapsed into
+ * "runtime has no SQLite".
+ */
+export function openDatabaseSyncOrThrow(path: string, opts: OpenOptions = {}): DatabaseSyncLike {
+  return openWithLoadedEngine(path, opts);
 }

--- a/src/services/sqlite-compat.ts
+++ b/src/services/sqlite-compat.ts
@@ -17,8 +17,8 @@
  *     returns null, including a missing module AND a corrupt file.
  *   • `sqliteEngineAvailable` + `openDatabaseSyncOrThrow` — fail-closed
  *     stores (session-store): module-load failure is "no engine"; a
- *     constructor error after the engine loaded is a bad file, not a
- *     missing runtime. Do not collapse the two.
+ *     corrupt/locked file surfaces at first exec/query after the engine
+ *     loaded (not a missing runtime). Do not collapse the two.
  *
  * Kept deliberately synchronous to match the existing feedback store's contract
  * (a synchronous write under a busy_timeout serializes concurrent opens without
@@ -149,11 +149,14 @@ export function openDatabaseSyncNow(path: string, opts: OpenOptions = {}): Datab
 }
 
 /**
- * Synchronous open that distinguishes "no engine" from "engine loaded, open
- * failed". Module-load errors propagate as thrown exceptions from `require`;
- * a corrupt / locked file also throws from the constructor. Fail-closed
- * stores (session-store) use this so SQLITE_NOTADB is not collapsed into
- * "runtime has no SQLite".
+ * Synchronous open that distinguishes "no engine" from "engine loaded, file
+ * unusable". Module-load errors throw from `require`. Both runtimes defer
+ * file validation to first use — a corrupt / locked file does **not** throw
+ * from the constructor; it surfaces at the first `exec` / query
+ * (`file is not a database`). Fail-closed stores (session-store) call this
+ * then immediately `PRAGMA busy_timeout`, so SQLITE_NOTADB still throws
+ * inside the open helper's caller and is not collapsed into "runtime has
+ * no SQLite".
  */
 export function openDatabaseSyncOrThrow(path: string, opts: OpenOptions = {}): DatabaseSyncLike {
   return openWithLoadedEngine(path, opts);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18028,7 +18028,9 @@ process.on('message', async (raw: unknown) => {
       // must not be appended to the bot's chat-session registry.  The
       // workflow's own event log is the source of truth for run state.
       if (msg.larkAppId && process.env.BOTMUX_WORKFLOW !== '1') {
-        sessionStore.init(msg.larkAppId);
+        // owner:false —— worker 可能由仍在跑旧代码的 daemon 从新 dist spawn 出来，
+        // 不许它首启导入/建 .db（引擎切换只能由 daemon 自己做），只按 db-else-json 读。
+        sessionStore.init(msg.larkAppId, { owner: false });
       }
       if (msg.cliId === 'codex-app') {
         codexAppRecoveredDispatches = (msg.codexAppRecoveredDispatches ?? []).map(entry => ({

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -239,6 +239,8 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/bots-info.json').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/bot-openids-cli_self.json').access).toBe('readOnly'); // own
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');     // own
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/turn-sends/s.jsonl').access).toBe('readWrite');        // OWN session marker only
     // blocker #4: turn-sends is granted per-session-FILE, not the whole dir —
     // another session's marker is NOT writable (can't corrupt its send-dedup).
@@ -259,6 +261,7 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/schedules.json').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots/cli_other/schedules.json').access).toBe('none'); // sibling store
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_other.json').access).toBe('none');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other/sessions.db').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/bot-openids-cli_other.json').access).toBe('none'); // sibling
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots.json').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots/cli_other/send-cred.json').access).toBe('none');
@@ -419,8 +422,10 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, '/Users/u/proj/src/x.ts').access).toBe('readWrite');
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots/cli_self/claude/x.jsonl').access).toBe('readWrite');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db').access).toBe('readOnly');
     // siblings simply not covered under the allow-list → inaccessible
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_other.json').access).toBe('none');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other/sessions.db').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/attachments/cli_self/m1/f.pdf').access).toBe('readWrite');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/attachments/cli_other/m1/f.pdf').access).toBe('none');
   });
@@ -1500,6 +1505,8 @@ describe('no-Lark-transport credential profile (larkTransportEnabled=false)', ()
     expect(accessForPath(p.rules, '/Users/u/.botmux/.data-dir').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/bin/botmux').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/bots-info.json').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/opt/botmux/dist/cli.js').access).toBe('readOnly');
   });
 

--- a/test/helpers/session-store-disk.ts
+++ b/test/helpers/session-store-disk.ts
@@ -1,0 +1,59 @@
+/**
+ * 直接读/改会话行持久层的测试夹具，按运行时的混合窗口规则解析引擎：
+ * 「有 .db 用 .db，否则用 .json」。引擎替换后 daemon store 落在 sessions*.db
+ * （既有 JSON 冻结），但夹具保持两种引擎都可用，方便混合窗口场景直接播种 JSON。
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+function storePaths(dataDir: string, appId?: string): { db: string; json: string } {
+  return {
+    db: join(dataDir, appId ? `sessions-${appId}.db` : 'sessions.db'),
+    json: join(dataDir, appId ? `sessions-${appId}.json` : 'sessions.json'),
+  };
+}
+
+/** db-else-json 读某个 store 的全部行（键 → 行对象）。 */
+export function readPersistedSessionRows(dataDir: string, appId?: string): Record<string, any> {
+  const { db, json } = storePaths(dataDir, appId);
+  if (existsSync(db)) {
+    const conn = new DatabaseSync(db);
+    try {
+      conn.exec('PRAGMA busy_timeout = 3000');
+      const rows = conn.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
+      return Object.fromEntries(rows.map(r => [r.session_id, JSON.parse(r.row)]));
+    } finally {
+      conn.close();
+    }
+  }
+  return JSON.parse(readFileSync(json, 'utf8'));
+}
+
+/** 模拟「另一个进程」直改持久层里的一行（旧夹具直接改 JSON 文件的等价物）。 */
+export function mutatePersistedSessionRow(
+  dataDir: string,
+  appId: string | undefined,
+  sessionId: string,
+  mutate: (row: any) => void,
+): void {
+  const { db, json } = storePaths(dataDir, appId);
+  if (existsSync(db)) {
+    const conn = new DatabaseSync(db);
+    try {
+      conn.exec('PRAGMA busy_timeout = 3000');
+      const hit = conn.prepare('SELECT row FROM sessions WHERE session_id = ?').get(sessionId) as { row: string } | undefined;
+      if (!hit) throw new Error(`no session row ${sessionId} in ${db}`);
+      const row = JSON.parse(hit.row);
+      mutate(row);
+      conn.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
+        .run(typeof row?.status === 'string' ? row.status : '', JSON.stringify(row), sessionId);
+    } finally {
+      conn.close();
+    }
+    return;
+  }
+  const projection = JSON.parse(readFileSync(json, 'utf8')) as Record<string, any>;
+  mutate(projection[sessionId]);
+  writeFileSync(json, JSON.stringify(projection, null, 2));
+}

--- a/test/helpers/session-store-disk.ts
+++ b/test/helpers/session-store-disk.ts
@@ -9,7 +9,7 @@ import { DatabaseSync } from 'node:sqlite';
 
 function storePaths(dataDir: string, appId?: string): { db: string; json: string } {
   return {
-    db: join(dataDir, appId ? `sessions-${appId}.db` : 'sessions.db'),
+    db: appId ? join(dataDir, 'session-stores', appId, 'sessions.db') : join(dataDir, 'sessions.db'),
     json: join(dataDir, appId ? `sessions-${appId}.json` : 'sessions.json'),
   };
 }

--- a/test/mojo-close-journal.test.ts
+++ b/test/mojo-close-journal.test.ts
@@ -19,11 +19,12 @@
  * Run:  pnpm vitest run test/mojo-close-journal.test.ts
  */
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { activeSessionKey, type DaemonSession } from '../src/core/types.js';
+import { readPersistedSessionRows } from './helpers/session-store-disk.js';
 
 const { getBotMock, cancelMojoMock } = vi.hoisted(() => ({
   getBotMock: vi.fn(),
@@ -390,9 +391,7 @@ describe('the journal is actually DURABLE, not just in-memory', () => {
    * feature: the journal exists to survive a daemon crash.
    */
   function journalOnDisk(sessionId: string): Record<string, unknown> | undefined {
-    const raw = JSON.parse(readFileSync(join(dataDir, 'sessions-app.json'), 'utf-8')) as
-      Record<string, { mojoCloseJournal?: Record<string, unknown> }>;
-    return raw[sessionId]?.mojoCloseJournal;
+    return readPersistedSessionRows(dataDir, 'app')[sessionId]?.mojoCloseJournal;
   }
 
   function seedActiveMojoRow(hint: string) {

--- a/test/remote-shutdown-detach.test.ts
+++ b/test/remote-shutdown-detach.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../src/core/remote-shutdown-detach.js';
 import { sendWorkerInput } from '../src/core/worker-pool.js';
 import * as sessionStore from '../src/services/session-store.js';
+import { mutatePersistedSessionRow } from './helpers/session-store-disk.js';
 
 vi.mock('../src/utils/logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -107,14 +108,15 @@ describe('Remote graceful daemon-shutdown detach coordinator', () => {
     session.backendType = 'riff';
     session.riffParentTaskId = 'task-before';
     sessionStore.updateSession(session);
-    const blockedDataDir = join(dataDir, 'not-a-directory');
-    writeFileSync(blockedDataDir, 'block');
-    config.session.dataDir = blockedDataDir;
+    // SQLite 行写不经过文件路径拼装，失败注入改走 store 的 test-only 钩子。
+    sessionStore.__testOnly_setBeforeRowPersist(() => { throw new Error('simulated durable lineage write failure'); });
 
-    expect(() => sessionStore.persistActiveRemoteLineageExact(session.sessionId, 'task-after')).toThrow();
-    expect(session.riffParentTaskId).toBe('task-before');
-
-    config.session.dataDir = dataDir;
+    try {
+      expect(() => sessionStore.persistActiveRemoteLineageExact(session.sessionId, 'task-after')).toThrow();
+      expect(session.riffParentTaskId).toBe('task-before');
+    } finally {
+      sessionStore.__testOnly_setBeforeRowPersist(undefined);
+    }
     expect(sessionStore.getSessionFresh(session.sessionId)?.riffParentTaskId).toBe('task-before');
   });
 
@@ -836,10 +838,9 @@ describe('Remote graceful daemon-shutdown detach coordinator', () => {
         queueMicrotask(() => {
           // Simulate a different process advancing the durable owner after
           // prepare, without changing this daemon's runtime generation.
-          const sessionsPath = join(dataDir, 'sessions-app.json');
-          const projection = JSON.parse(readFileSync(sessionsPath, 'utf8')) as Record<string, any>;
-          projection[f.ds.session.sessionId]!.riffParentTaskId = 'task-external-owner';
-          writeFileSync(sessionsPath, JSON.stringify(projection, null, 2));
+          mutatePersistedSessionRow(dataDir, 'app', f.ds.session.sessionId, (row) => {
+            row.riffParentTaskId = 'task-external-owner';
+          });
           worker.emit('message', {
             type: 'remote_shutdown_result', requestId: message.requestId,
             phase: 'prepare', ok: true, taskId: 'task-prepared-child',
@@ -865,10 +866,9 @@ describe('Remote graceful daemon-shutdown detach coordinator', () => {
     const f = fixture('task-parent', (worker, message) => {
       if (message.type === 'remote_shutdown_prepare') {
         queueMicrotask(() => {
-          const sessionsPath = join(dataDir, 'sessions-app.json');
-          const projection = JSON.parse(readFileSync(sessionsPath, 'utf8')) as Record<string, any>;
-          projection[f.ds.session.sessionId]!.pid = 999_999;
-          writeFileSync(sessionsPath, JSON.stringify(projection, null, 2));
+          mutatePersistedSessionRow(dataDir, 'app', f.ds.session.sessionId, (row) => {
+            row.pid = 999_999;
+          });
           worker.emit('message', {
             type: 'remote_shutdown_result', requestId: message.requestId,
             phase: 'prepare', ok: true, taskId: 'task-prepared-child',
@@ -897,10 +897,9 @@ describe('Remote graceful daemon-shutdown detach coordinator', () => {
         const result = originalPersist(sessionId, taskId, options);
         // Exact replacement race: CAS wrote the expected task, then a new
         // durable owner published the same task before the separate readback.
-        const sessionsPath = join(dataDir, 'sessions-app.json');
-        const projection = JSON.parse(readFileSync(sessionsPath, 'utf8')) as Record<string, any>;
-        projection[sessionId]!.pid = 888_888;
-        writeFileSync(sessionsPath, JSON.stringify(projection, null, 2));
+        mutatePersistedSessionRow(dataDir, 'app', sessionId, (row) => {
+          row.pid = 888_888;
+        });
         return result;
       },
     );

--- a/test/riff-explicit-close.test.ts
+++ b/test/riff-explicit-close.test.ts
@@ -54,6 +54,7 @@ import {
   setActiveSessionsRegistry,
 } from '../src/core/worker-pool.js';
 import * as sessionStore from '../src/services/session-store.js';
+import { readPersistedSessionRows } from './helpers/session-store-disk.js';
 
 let dataDir: string;
 let previousDataDir: string;
@@ -301,7 +302,7 @@ describe('Riff explicit close', () => {
     await new Promise(resolve => setImmediate(resolve));
 
     expect(fixture.session.riffParentTaskId).toBe('task-riff-child');
-    const durable = JSON.parse(readFileSync(join(dataDir, 'sessions-app.json'), 'utf8'));
+    const durable = readPersistedSessionRows(dataDir, 'app');
     expect(durable[fixture.session.sessionId].riffParentTaskId).toBe('task-riff-123');
   });
 
@@ -318,7 +319,7 @@ describe('Riff explicit close', () => {
     await new Promise(resolve => setImmediate(resolve));
 
     expect(fixture.session.riffParentTaskId).toBe('task-riff-123');
-    const durable = JSON.parse(readFileSync(join(dataDir, 'sessions-app.json'), 'utf8'));
+    const durable = readPersistedSessionRows(dataDir, 'app');
     expect(durable[fixture.session.sessionId].riffParentTaskId).toBe('task-riff-123');
   });
 });

--- a/test/session-store-bwrap.test.ts
+++ b/test/session-store-bwrap.test.ts
@@ -1,0 +1,127 @@
+/**
+ * 真实 bubblewrap 回归：persistent pane（长命 mount 命名空间）必须在会话存储
+ * 「关闭 → 重开」（daemon 重启）之后读到新 commit。
+ *
+ * 背景：SQLite 最后一个连接关闭时删除 -wal/-shm，重开时重建为新 inode。旧方案
+ * 对 .db/-wal/-shm 做单文件 ro-bind——bind 钉住的是 spawn 时刻的 inode，重启后
+ * 旧 pane 永久读死 WAL（甚至在 checkpoint 复用后读出错乱视图）。修复为绑定
+ * per-bot store 目录（fs-policy 授 `session-stores/<appId>`），目录 bind 按名字
+ * 解析，重启后的新 sidecar 自动可见。本测试用与生产 compileToBwrap 相同形状的
+ * 参数（tmpfs 根 + 逐条 ro-bind + 目录级 store 授权）复现「writer 关闭重开写
+ * v2 → 既有 sandbox 查询」时序，断言读到 v2。
+ *
+ * 仅在 linux 且 bwrap 可用（含 unprivileged userns）时运行，否则 skip。
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+function bwrapUsable(): boolean {
+  if (process.platform !== 'linux') return false;
+  try {
+    const probe = spawnSync('bwrap', [
+      '--unshare-user', '--die-with-parent',
+      '--tmpfs', '/', '--proc', '/proc', '--dev', '/dev',
+      '--ro-bind', '/usr', '/usr',
+      '/usr/bin/true',
+    ], { timeout: 10_000 });
+    return probe.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+async function pollFor(predicate: () => boolean, what: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+describe.skipIf(!bwrapUsable())('bwrap persistent pane × SQLite store reopen', () => {
+  it('a dir-bound sandbox that outlives the writer reads commits made by the REOPENED store', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'bwrap-session-store-'));
+    const ctlDir = mkdtempSync(join(tmpdir(), 'bwrap-session-ctl-'));
+    const storeDir = join(dataDir, 'session-stores', 'appA');
+    mkdirSync(storeDir, { recursive: true });
+    const dbPath = join(storeDir, 'sessions.db');
+    const openStore = () => {
+      const db = new DatabaseSync(dbPath);
+      db.exec('PRAGMA busy_timeout = 3000');
+      db.exec('PRAGMA journal_mode = WAL');
+      db.exec('PRAGMA synchronous = NORMAL');
+      db.exec('CREATE TABLE IF NOT EXISTS sessions (session_id TEXT PRIMARY KEY, status TEXT NOT NULL, row TEXT NOT NULL)');
+      return db;
+    };
+
+    // writer-1 = 升级前的 daemon：写入 v1，保持连接（-wal/-shm 存活）。
+    const writer1 = openStore();
+    writer1.prepare('INSERT OR REPLACE INTO sessions (session_id, status, row) VALUES (?, ?, ?)')
+      .run('s1', 'active', JSON.stringify({ v: 'v1' }));
+
+    // persistent pane：长命 bwrap，目录级 store 授权（与生产 fs-policy 同形）。
+    // 内部脚本等 go 信号后才查询——模拟 pane 存活跨越 daemon 重启的真实时序。
+    const readerScript = `
+      const fs = require('node:fs');
+      const ctl = ${JSON.stringify(ctlDir)};
+      fs.writeFileSync(ctl + '/ready', '1');
+      const tick = () => {
+        if (!fs.existsSync(ctl + '/go')) return setTimeout(tick, 100);
+        try {
+          const { DatabaseSync } = require('node:sqlite');
+          let db;
+          try { db = new DatabaseSync(${JSON.stringify(dbPath)}); }
+          catch { db = new DatabaseSync(${JSON.stringify(dbPath)}, { readOnly: true }); }
+          db.exec('PRAGMA busy_timeout = 3000');
+          const hit = db.prepare("SELECT row FROM sessions WHERE session_id = 's1'").get();
+          fs.writeFileSync(ctl + '/out', JSON.parse(hit.row).v);
+        } catch (err) {
+          fs.writeFileSync(ctl + '/out', 'ERR:' + (err && err.message));
+        }
+      };
+      tick();
+    `;
+    const nodeDir = dirname(process.execPath);
+    const pane = spawn('bwrap', [
+      '--unshare-user', '--die-with-parent',
+      '--tmpfs', '/', '--proc', '/proc', '--dev', '/dev', '--tmpfs', '/tmp',
+      '--ro-bind', '/usr', '/usr',
+      '--ro-bind-try', '/lib', '/lib',
+      '--ro-bind-try', '/lib64', '/lib64',
+      '--ro-bind-try', '/etc', '/etc',
+      '--ro-bind', nodeDir, nodeDir,
+      '--ro-bind', storeDir, storeDir, // ← 被测形状：目录级只读授权
+      '--bind', ctlDir, ctlDir,
+      process.execPath, '-e', readerScript,
+    ], { stdio: ['ignore', 'inherit', 'inherit'] });
+
+    try {
+      await pollFor(() => existsSync(join(ctlDir, 'ready')), 'sandbox reader ready');
+
+      // daemon 重启：关闭 writer-1（SQLite 删除 -wal/-shm）……
+      writer1.close();
+      expect(existsSync(`${dbPath}-wal`)).toBe(false);
+      // ……新 daemon 重开 store 并提交 v2（sidecar 为全新 inode，且 v2 只在 WAL 里）。
+      const writer2 = openStore();
+      writer2.prepare('UPDATE sessions SET row = ? WHERE session_id = ?')
+        .run(JSON.stringify({ v: 'v2' }), 's1');
+      try {
+        writeFileSync(join(ctlDir, 'go'), '1');
+        await pollFor(() => existsSync(join(ctlDir, 'out')), 'sandbox query result');
+        // 单文件 bind 的旧形状在这里永远读到 v1（钉死的旧 WAL inode）。
+        expect(readFileSync(join(ctlDir, 'out'), 'utf-8')).toBe('v2');
+      } finally {
+        writer2.close();
+      }
+    } finally {
+      try { pane.kill('SIGKILL'); } catch { /* already gone */ }
+      for (const dir of [dataDir, ctlDir]) {
+        try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+    }
+  }, 30_000);
+});

--- a/test/session-store-bwrap.test.ts
+++ b/test/session-store-bwrap.test.ts
@@ -26,6 +26,8 @@ function bwrapUsable(): boolean {
       '--unshare-user', '--die-with-parent',
       '--tmpfs', '/', '--proc', '/proc', '--dev', '/dev',
       '--ro-bind', '/usr', '/usr',
+      '--ro-bind-try', '/lib', '/lib',
+      '--ro-bind-try', '/lib64', '/lib64',
       '/usr/bin/true',
     ], { timeout: 10_000 });
     return probe.status === 0;

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
+import { spawn } from 'node:child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -104,7 +105,7 @@ describe('first-start JSON import', () => {
     // repairMissingChatScope 发生在导入期
     expect(imported.broken.scope).toBe('chat');
     // .db 落位，JSON 原地冻结（一个字节都不动）
-    expect(existsSync(join(tempDir, 'sessions-appA.db'))).toBe(true);
+    expect(existsSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'))).toBe(true);
     expect(readFileSync(jsonFp, 'utf-8')).toBe(jsonBefore);
   });
 
@@ -117,7 +118,7 @@ describe('first-start JSON import', () => {
 
     init('app-A');
     expect(listSessions().map(s => s.sessionId)).toEqual(['a1']);
-    expect(existsSync(join(tempDir, 'sessions-app-A.db'))).toBe(true);
+    expect(existsSync(join(tempDir, 'session-stores', 'app-A', 'sessions.db'))).toBe(true);
     // 旧行为会把行迁移写进 sessions-app-A.json；现在 JSON 全部冻结
     expect(existsSync(join(tempDir, 'sessions-app-A.json'))).toBe(false);
     expect(readFileSync(legacyFp, 'utf-8')).toBe(legacyBefore);
@@ -137,14 +138,15 @@ describe('first-start JSON import', () => {
 
   it('publishes the store atomically: no .db.tmp survives, and stale tmp leftovers are replaced', () => {
     // 上次导入中途崩溃的残留 tmp（垃圾内容）不得阻塞、也不得泄漏进结果
-    mkdirSync(tempDir, { recursive: true });
-    writeFileSync(join(tempDir, 'sessions-appA.db.tmp'), 'garbage from a crashed import');
+    const storeDir = join(tempDir, 'session-stores', 'appA');
+    mkdirSync(storeDir, { recursive: true });
+    writeFileSync(join(storeDir, 'sessions.db.tmp'), 'garbage from a crashed import');
     seedJson('sessions-appA.json', { s1: row('s1') });
 
     init('appA');
     expect(getSession('s1')?.title).toBe('s1');
-    expect(existsSync(join(tempDir, 'sessions-appA.db'))).toBe(true);
-    expect(existsSync(join(tempDir, 'sessions-appA.db.tmp'))).toBe(false);
+    expect(existsSync(join(storeDir, 'sessions.db'))).toBe(true);
+    expect(existsSync(join(storeDir, 'sessions.db.tmp'))).toBe(false);
   });
 
   it('daemon writes after import go to the .db only — the frozen JSON never changes again', () => {
@@ -168,12 +170,12 @@ describe('first-start JSON import', () => {
 
     init('appA', { owner: false });
     expect(getSession('s1')?.title).toBe('s1'); // 读 JSON 照常
-    expect(existsSync(join(tempDir, 'sessions-appA.db'))).toBe(false);
+    expect(existsSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'))).toBe(false);
 
     // daemon（owner）随后启动才导入
     init('appA');
     expect(getSession('s1')?.title).toBe('s1');
-    expect(existsSync(join(tempDir, 'sessions-appA.db'))).toBe(true);
+    expect(existsSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'))).toBe(true);
   });
 });
 
@@ -288,6 +290,51 @@ describe('mixed-window db-else-json resolution', () => {
     );
     expect(published?.status).toBe('closed');
     expect(published?.workerGeneration).toBe(7);
+  });
+});
+
+// ─── cutover 竞态：daemon 首次 load × 在途离线写者 ───────────────────────────
+
+describe('first-load serialization against an in-flight offline writer', () => {
+  it('load blocks on a held BEGIN IMMEDIATE and reads the post-commit row (lost-update regression)', async () => {
+    // 复现评审时序：离线 CLI 已通过双 abortIf 探测、持有 BEGIN IMMEDIATE 且改了
+    // 行但未 commit；daemon 此刻首次 load。纯 SELECT 不被写事务排斥——若 load
+    // 不进排他事务，会把 commit 前的旧行读进终身缓存，稍后的行写回覆盖 CLI 的
+    // 提交。修复后 load 的排他读必须等 CLI commit，读到新值。
+    seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
+    init('appA');
+    listSessions(); // 触发导入 → .db
+    init();         // 释放连接，模拟 daemon 尚未启动
+    const dbPath = join(tempDir, 'session-stores', 'appA', 'sessions.db');
+
+    const child = spawn(process.execPath, ['-e', `
+      const { DatabaseSync } = require('node:sqlite');
+      const db = new DatabaseSync(${JSON.stringify(dbPath)});
+      db.exec('PRAGMA busy_timeout = 3000');
+      db.exec('BEGIN IMMEDIATE');
+      const current = JSON.parse(db.prepare('SELECT row FROM sessions WHERE session_id = ?').get('s1').row);
+      current.title = 'offline-cli-write';
+      db.prepare('UPDATE sessions SET row = ? WHERE session_id = ?').run(JSON.stringify(current), 's1');
+      process.stdout.write('HELD\\n'); // 已持写锁 + 已过双探测的时刻
+      setTimeout(() => { db.exec('COMMIT'); db.close(); }, 600);
+    `], { stdio: ['ignore', 'pipe', 'inherit'] });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('offline writer never signalled HELD')), 5000);
+        child.stdout!.on('data', (chunk: Buffer) => {
+          if (chunk.toString().includes('HELD')) { clearTimeout(timer); resolve(); }
+        });
+        child.once('exit', (code) => { clearTimeout(timer); reject(new Error(`writer exited early (${code})`)); });
+      });
+
+      init('appA');
+      const t0 = Date.now();
+      const loaded = getSession('s1'); // 首次 load：排他读必须等 COMMIT
+      expect(loaded?.title).toBe('offline-cli-write');
+      expect(Date.now() - t0).toBeGreaterThanOrEqual(300); // 确实等待了，而非读旧行
+    } finally {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+    }
   });
 });
 

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -1,0 +1,334 @@
+/**
+ * SQLite 引擎替换（Step 3 第一个 PR）的专项回归：
+ *  - 首启确定性自动导入（含 closed 行、legacy sessions.json、幂等/重启不重复导入）
+ *  - .db.tmp 原子出现（读者绝不见半成品；残留 tmp 被清理）
+ *  - JSON 原地冻结（导入后 daemon 写不再碰 JSON —— 回滚方案的前提）
+ *  - 混合窗口 db-else-json（跨进程读 + CLI 离线写，含「冻结 JSON 不算第二份拷贝」）
+ *  - Node 能力探测报错路径（daemon 硬门；CLI 有 .db 硬报错 / 无 .db 走 JSON）
+ *  - worker（owner:false）不触发导入
+ *
+ * Run:  pnpm vitest run test/session-store-sqlite.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let tempDir: string;
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    session: {
+      get dataDir() { return tempDir; },
+    },
+  },
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const mockDeleteFrozenCards = vi.fn();
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  deleteFrozenCards: (...args: any[]) => mockDeleteFrozenCards(...args),
+}));
+
+import {
+  __testOnly_setSqliteUnavailable,
+  assertSqliteSupported,
+  init,
+  createSession,
+  getSession,
+  getSessionFresh,
+  listSessions,
+  closeSession,
+  updateSession,
+  findActiveSessionsByRoot,
+  countActiveSessionsOnDisk,
+  collectBotmuxSessionIdentities,
+  loadAllSessionsSnapshot,
+  mutateSessionRowOffline,
+  readSessionRowFromDisk,
+  readSessionRowCopiesAcrossStores,
+  SessionStoreSqliteUnavailableError,
+} from '../src/services/session-store.js';
+import { readPersistedSessionRows, mutatePersistedSessionRow } from './helpers/session-store-disk.js';
+
+function seedJson(name: string, rows: Record<string, unknown>): string {
+  mkdirSync(tempDir, { recursive: true });
+  const fp = join(tempDir, name);
+  writeFileSync(fp, JSON.stringify(rows, null, 2));
+  return fp;
+}
+
+function row(sessionId: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    sessionId, chatId: 'oc_chat', rootMessageId: `om_${sessionId}`, title: sessionId,
+    status: 'active', createdAt: '2026-01-01T00:00:00.000Z', ...extra,
+  };
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'session-store-sqlite-test-'));
+  __testOnly_setSqliteUnavailable(false);
+  mockDeleteFrozenCards.mockReset();
+  init();
+});
+
+afterEach(() => {
+  __testOnly_setSqliteUnavailable(false);
+  try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── 首启确定性自动导入 ──────────────────────────────────────────────────────
+
+describe('first-start JSON import', () => {
+  it('imports per-bot JSON rows — closed rows included — and freezes the JSON in place', () => {
+    const jsonFp = seedJson('sessions-appA.json', {
+      live: row('live'),
+      done: row('done', { status: 'closed', closedAt: '2026-02-01T00:00:00.000Z' }),
+      legacyCard: row('legacyCard', { pendingResponseCardId: 'om_old', pendingResponseCardState: 'open' }),
+      broken: { ...row('broken'), chatId: 'oc_x', rootMessageId: 'oc_x' },
+    });
+    const jsonBefore = readFileSync(jsonFp, 'utf-8');
+
+    init('appA');
+    expect(getSession('live')?.status).toBe('active');
+    // closed 行全量导入
+    expect(getSession('done')?.status).toBe('closed');
+    expect(getSession('done')?.closedAt).toBe('2026-02-01T00:00:00.000Z');
+    // strip legacy 字段发生在导入期
+    const imported = readPersistedSessionRows(tempDir, 'appA');
+    expect(imported.legacyCard).not.toHaveProperty('pendingResponseCardId');
+    expect(imported.legacyCard).not.toHaveProperty('pendingResponseCardState');
+    // repairMissingChatScope 发生在导入期
+    expect(imported.broken.scope).toBe('chat');
+    // .db 落位，JSON 原地冻结（一个字节都不动）
+    expect(existsSync(join(tempDir, 'sessions-appA.db'))).toBe(true);
+    expect(readFileSync(jsonFp, 'utf-8')).toBe(jsonBefore);
+  });
+
+  it('imports only this bot\'s rows from legacy sessions.json and leaves it frozen', () => {
+    const legacyFp = seedJson('sessions.json', {
+      a1: row('a1', { larkAppId: 'app-A' }),
+      b1: row('b1', { larkAppId: 'app-B' }),
+    });
+    const legacyBefore = readFileSync(legacyFp, 'utf-8');
+
+    init('app-A');
+    expect(listSessions().map(s => s.sessionId)).toEqual(['a1']);
+    expect(existsSync(join(tempDir, 'sessions-app-A.db'))).toBe(true);
+    // 旧行为会把行迁移写进 sessions-app-A.json；现在 JSON 全部冻结
+    expect(existsSync(join(tempDir, 'sessions-app-A.json'))).toBe(false);
+    expect(readFileSync(legacyFp, 'utf-8')).toBe(legacyBefore);
+  });
+
+  it('is idempotent: a restart with the frozen JSON still present must not re-import', () => {
+    const jsonFp = seedJson('sessions-appA.json', { s1: row('s1') });
+    init('appA');
+    closeSession('s1');
+    expect(getSession('s1')?.status).toBe('closed');
+
+    // daemon 重启：.db 已存在，冻结 JSON 里的旧 active 行不得覆盖回来
+    init('appA');
+    expect(getSession('s1')?.status).toBe('closed');
+    expect(JSON.parse(readFileSync(jsonFp, 'utf-8')).s1.status).toBe('active');
+  });
+
+  it('publishes the store atomically: no .db.tmp survives, and stale tmp leftovers are replaced', () => {
+    // 上次导入中途崩溃的残留 tmp（垃圾内容）不得阻塞、也不得泄漏进结果
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, 'sessions-appA.db.tmp'), 'garbage from a crashed import');
+    seedJson('sessions-appA.json', { s1: row('s1') });
+
+    init('appA');
+    expect(getSession('s1')?.title).toBe('s1');
+    expect(existsSync(join(tempDir, 'sessions-appA.db'))).toBe(true);
+    expect(existsSync(join(tempDir, 'sessions-appA.db.tmp'))).toBe(false);
+  });
+
+  it('daemon writes after import go to the .db only — the frozen JSON never changes again', () => {
+    const jsonFp = seedJson('sessions-appA.json', { s1: row('s1') });
+    const jsonBefore = readFileSync(jsonFp, 'utf-8');
+    init('appA');
+
+    const s1 = getSession('s1')!;
+    s1.title = 'renamed';
+    updateSession(s1);
+    createSession('oc_new', 'om_new', 'brand new');
+
+    expect(readFileSync(jsonFp, 'utf-8')).toBe(jsonBefore);
+    const rows = readPersistedSessionRows(tempDir, 'appA');
+    expect(rows.s1.title).toBe('renamed');
+    expect(Object.keys(rows)).toHaveLength(2);
+  });
+
+  it('a non-owning process (worker under an old daemon) never bootstraps the .db', () => {
+    seedJson('sessions-appA.json', { s1: row('s1') });
+
+    init('appA', { owner: false });
+    expect(getSession('s1')?.title).toBe('s1'); // 读 JSON 照常
+    expect(existsSync(join(tempDir, 'sessions-appA.db'))).toBe(false);
+
+    // daemon（owner）随后启动才导入
+    init('appA');
+    expect(getSession('s1')?.title).toBe('s1');
+    expect(existsSync(join(tempDir, 'sessions-appA.db'))).toBe(true);
+  });
+});
+
+// ─── 混合窗口 db-else-json ───────────────────────────────────────────────────
+
+describe('mixed-window db-else-json resolution', () => {
+  it('readers prefer the .db and treat the frozen JSON as superseded, not a second copy', () => {
+    // appA 已切 SQLite（daemon 已重启），冻结 JSON 里留着一份陈旧拷贝
+    const jsonFp = seedJson('sessions-appA.json', {
+      s1: row('s1', { title: 'stale json copy', larkAppId: 'appA' }),
+    });
+    init('appA');
+    const fresh = getSession('s1')!;
+    fresh.title = 'live db copy';
+    updateSession(fresh);
+    // 冻结 JSON 又多出一行只存在于 JSON 的行（导入后读者不再看 JSON）
+    writeFileSync(jsonFp, JSON.stringify({
+      s1: row('s1', { title: 'stale json copy', larkAppId: 'appA' }),
+      ghost: row('ghost', { larkAppId: 'appA' }),
+    }, null, 2));
+
+    expect(readSessionRowFromDisk('s1', 'appA', tempDir)?.title).toBe('live db copy');
+    expect(loadAllSessionsSnapshot({ dataDir: tempDir }).get('s1')?.title).toBe('live db copy');
+    // 身份扫描：同一 store 的冻结 JSON 不算第二份拷贝（exactly-once 证明不被打破）
+    expect(readSessionRowCopiesAcrossStores('s1', tempDir)).toHaveLength(1);
+    // 冻结 JSON 独有的行不可见——读者一律以 .db 为准
+    expect(loadAllSessionsSnapshot({ dataDir: tempDir }).has('ghost')).toBe(false);
+    expect(countActiveSessionsOnDisk(tempDir)).toBe(1);
+  });
+
+  it('stores still on JSON keep full read behaviour, and mixed stores compose', () => {
+    // appOld 还没重启（只有 JSON）；appNew 已切 SQLite
+    seedJson('sessions-appOld.json', { o1: row('o1', { larkAppId: 'appOld' }) });
+    init('appNew');
+    const n1 = createSession('oc_chat', 'om_shared_root', 'new bot session');
+    n1.larkAppId = 'appNew';
+    updateSession(n1);
+    mutatePersistedSessionRow(tempDir, 'appNew', n1.sessionId, (r) => { r.rootMessageId = 'om_o1'; });
+
+    const snapshot = loadAllSessionsSnapshot({ dataDir: tempDir });
+    expect(snapshot.get('o1')?.larkAppId).toBe('appOld');
+    expect(snapshot.get(n1.sessionId)?.larkAppId).toBe('appNew');
+
+    // 跨 bot 发现类读者对两种引擎同时可见（sibling json + sibling db）
+    init('appThird');
+    const found = findActiveSessionsByRoot('om_o1');
+    expect(found.map(s => s.sessionId).sort()).toEqual(['o1', n1.sessionId].sort());
+    expect(countActiveSessionsOnDisk(tempDir)).toBe(2);
+    const ids = collectBotmuxSessionIdentities(tempDir);
+    expect(ids.has('o1')).toBe(true);
+    expect(ids.has(n1.sessionId)).toBe(true);
+  });
+
+  it('getSessionFresh reads the committed .db state, not the process cache', () => {
+    init('appA');
+    const s = createSession('oc_chat', 'om_root', 'fresh probe');
+    mutatePersistedSessionRow(tempDir, 'appA', s.sessionId, (r) => { r.title = 'external change'; });
+    expect(getSessionFresh(s.sessionId)?.title).toBe('external change');
+    expect(getSession(s.sessionId)?.title).toBe('fresh probe'); // 缓存语义不变
+  });
+
+  it('offline mutation targets the .db when it exists and leaves the frozen JSON untouched', () => {
+    const jsonFp = seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
+    init('appA');
+    expect(getSession('s1')?.status).toBe('active'); // 首次访问触发导入 → .db
+    const jsonAfterImport = readFileSync(jsonFp, 'utf-8');
+
+    const published = mutateSessionRowOffline(
+      { sessionId: 's1', larkAppId: 'appA' },
+      (current) => { current.status = 'closed'; current.closedAt = '2026-08-13T00:00:00.000Z'; return true; },
+      { dataDir: tempDir },
+    );
+    expect(published?.status).toBe('closed');
+    expect(readPersistedSessionRows(tempDir, 'appA').s1.status).toBe('closed');
+    expect(readFileSync(jsonFp, 'utf-8')).toBe(jsonAfterImport);
+    expect(JSON.parse(jsonAfterImport).s1.status).toBe('active');
+  });
+
+  it('offline mutation on the .db keeps the abortIf entry + pre-publication probes', () => {
+    seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
+    init('appA');
+    const before = readPersistedSessionRows(tempDir, 'appA');
+
+    let probes = 0;
+    const aborted = mutateSessionRowOffline(
+      { sessionId: 's1', larkAppId: 'appA' },
+      (current) => { current.status = 'closed'; return true; },
+      { dataDir: tempDir, abortIf: () => ++probes > 1 },
+    );
+    expect(aborted).toBeUndefined();
+    expect(probes).toBe(2);
+    expect(readPersistedSessionRows(tempDir, 'appA')).toEqual(before);
+
+    const abortedAtEntry = mutateSessionRowOffline(
+      { sessionId: 's1', larkAppId: 'appA' },
+      (current) => { current.status = 'closed'; return true; },
+      { dataDir: tempDir, abortIf: () => true },
+    );
+    expect(abortedAtEntry).toBeUndefined();
+    expect(readPersistedSessionRows(tempDir, 'appA')).toEqual(before);
+  });
+
+  it('offline mutation hands mutate the FRESH .db row, never the caller snapshot', () => {
+    seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
+    init('appA');
+    mutatePersistedSessionRow(tempDir, 'appA', 's1', (r) => { r.workerGeneration = 7; });
+
+    const published = mutateSessionRowOffline(
+      { sessionId: 's1', larkAppId: 'appA' },
+      (current) => { current.status = 'closed'; return true; },
+      { dataDir: tempDir },
+    );
+    expect(published?.status).toBe('closed');
+    expect(published?.workerGeneration).toBe(7);
+  });
+});
+
+// ─── Node 能力探测 ───────────────────────────────────────────────────────────
+
+describe('node:sqlite capability gate', () => {
+  it('daemon startup probe fails with an actionable upgrade message', () => {
+    __testOnly_setSqliteUnavailable(true);
+    expect(() => assertSqliteSupported()).toThrow(SessionStoreSqliteUnavailableError);
+    expect(() => assertSqliteSupported()).toThrow(/22\.13/);
+  });
+
+  it('CLI paths fail hard when a .db exists but node:sqlite is missing', () => {
+    seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
+    init('appA');
+    listSessions(); // 首次访问触发导入 → .db
+    init(); // 释放已 attach 的连接，模拟独立 CLI 进程
+    __testOnly_setSqliteUnavailable(true);
+
+    expect(() => readSessionRowFromDisk('s1', 'appA', tempDir)).toThrow(SessionStoreSqliteUnavailableError);
+    expect(() => loadAllSessionsSnapshot({ dataDir: tempDir })).toThrow(SessionStoreSqliteUnavailableError);
+    expect(() => readSessionRowCopiesAcrossStores('s1', tempDir)).toThrow(SessionStoreSqliteUnavailableError);
+    expect(() => mutateSessionRowOffline(
+      { sessionId: 's1', larkAppId: 'appA' },
+      () => true,
+      { dataDir: tempDir },
+    )).toThrow(SessionStoreSqliteUnavailableError);
+  });
+
+  it('CLI paths keep working on plain JSON stores when node:sqlite is missing (no .db yet)', () => {
+    seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
+    __testOnly_setSqliteUnavailable(true);
+
+    expect(readSessionRowFromDisk('s1', 'appA', tempDir)?.sessionId).toBe('s1');
+    expect(loadAllSessionsSnapshot({ dataDir: tempDir }).get('s1')?.larkAppId).toBe('appA');
+    expect(readSessionRowCopiesAcrossStores('s1', tempDir)).toHaveLength(1);
+    const published = mutateSessionRowOffline(
+      { sessionId: 's1', larkAppId: 'appA' },
+      (current) => { current.status = 'closed'; return true; },
+      { dataDir: tempDir },
+    );
+    expect(published?.status).toBe('closed');
+  });
+});

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -346,6 +346,58 @@ describe('first-load serialization against an in-flight offline writer', () => {
       try { child.kill('SIGKILL'); } catch { /* already gone */ }
     }
   });
+
+  it('load does not swallow SQLITE_BUSY into an empty cache', async () => {
+    // busy_timeout 耗尽后若收成 loadFailure + 空 Map，daemon 启动会走
+    // listSessions() 把「锁等待超时」当成「没有会话」并跳过 restore。
+    seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA', title: 'must-survive-busy' }) });
+    init('appA');
+    listSessions();
+    init();
+    const dbPath = join(tempDir, 'session-stores', 'appA', 'sessions.db');
+    const releaseMarker = join(tempDir, 'busy-release');
+    const child = spawn(process.execPath, ['-e', `
+      const fs = require('node:fs');
+      const { DatabaseSync } = require('node:sqlite');
+      const db = new DatabaseSync(${JSON.stringify(dbPath)});
+      db.exec('PRAGMA busy_timeout = 3000');
+      db.exec('BEGIN IMMEDIATE');
+      process.stdout.write('HELD\\n');
+      const tick = () => {
+        if (!fs.existsSync(${JSON.stringify(releaseMarker)})) return setTimeout(tick, 50);
+        db.exec('COMMIT');
+        db.close();
+      };
+      tick();
+    `], { stdio: ['ignore', 'pipe', 'inherit'] });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('writer never signalled HELD')), 5000);
+        child.stdout!.on('data', (chunk: Buffer) => {
+          if (chunk.toString().includes('HELD')) { clearTimeout(timer); resolve(); }
+        });
+        child.once('exit', (code) => { clearTimeout(timer); reject(new Error(`writer exited early (${code})`)); });
+      });
+
+      init('appA');
+      const t0 = Date.now();
+      expect(() => listSessions()).toThrow(/database is locked|SQLITE_BUSY|SQLITE_LOCKED/i);
+      expect(Date.now() - t0).toBeGreaterThanOrEqual(2500);
+
+      writeFileSync(releaseMarker, '1');
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('writer did not exit after release')), 5000);
+        child.once('exit', () => { clearTimeout(timer); resolve(); });
+      });
+
+      const loaded = listSessions();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0]?.title).toBe('must-survive-busy');
+    } finally {
+      try { writeFileSync(releaseMarker, '1'); } catch { /* already written */ }
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+    }
+  }, 20_000);
 });
 
 // ─── Node 能力探测 ───────────────────────────────────────────────────────────

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -307,7 +307,12 @@ describe('first-load serialization against an in-flight offline writer', () => {
     init();         // 释放连接，模拟 daemon 尚未启动
     const dbPath = join(tempDir, 'session-stores', 'appA', 'sessions.db');
 
+    // 握手协议保证确定性：子进程持锁改行后发 HELD；父进程落下 loading 标记后
+    // 立刻进入 load；子进程看到标记再等 300ms 才 COMMIT——父进程无论多慢都
+    // 一定在锁被持有期间发起排他读。
+    const loadingMarker = join(tempDir, 'race-parent-loading');
     const child = spawn(process.execPath, ['-e', `
+      const fs = require('node:fs');
       const { DatabaseSync } = require('node:sqlite');
       const db = new DatabaseSync(${JSON.stringify(dbPath)});
       db.exec('PRAGMA busy_timeout = 3000');
@@ -316,7 +321,11 @@ describe('first-load serialization against an in-flight offline writer', () => {
       current.title = 'offline-cli-write';
       db.prepare('UPDATE sessions SET row = ? WHERE session_id = ?').run(JSON.stringify(current), 's1');
       process.stdout.write('HELD\\n'); // 已持写锁 + 已过双探测的时刻
-      setTimeout(() => { db.exec('COMMIT'); db.close(); }, 600);
+      const tick = () => {
+        if (!fs.existsSync(${JSON.stringify(loadingMarker)})) return setTimeout(tick, 50);
+        setTimeout(() => { db.exec('COMMIT'); db.close(); }, 300);
+      };
+      tick();
     `], { stdio: ['ignore', 'pipe', 'inherit'] });
     try {
       await new Promise<void>((resolve, reject) => {
@@ -328,10 +337,11 @@ describe('first-load serialization against an in-flight offline writer', () => {
       });
 
       init('appA');
+      writeFileSync(loadingMarker, '1');
       const t0 = Date.now();
       const loaded = getSession('s1'); // 首次 load：排他读必须等 COMMIT
       expect(loaded?.title).toBe('offline-cli-write');
-      expect(Date.now() - t0).toBeGreaterThanOrEqual(300); // 确实等待了，而非读旧行
+      expect(Date.now() - t0).toBeGreaterThanOrEqual(200); // 确实等待了，而非读旧行
     } finally {
       try { child.kill('SIGKILL'); } catch { /* already gone */ }
     }

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -4,10 +4,11 @@
  *  - .db.tmp 原子出现（读者绝不见半成品；残留 tmp 被清理）
  *  - JSON 原地冻结（导入后 daemon 写不再碰 JSON —— 回滚方案的前提）
  *  - 混合窗口 db-else-json（跨进程读 + CLI 离线写，含「冻结 JSON 不算第二份拷贝」）
- *  - Node 能力探测报错路径（daemon 硬门；CLI 有 .db 硬报错 / 无 .db 走 JSON）
+ *  - SQLite 能力探测报错路径（daemon 硬门；CLI 有 .db 硬报错 / 无 .db 走 JSON；
+ *    损坏 .db 不得收成「引擎不可用」）
  *  - worker（owner:false）不触发导入
  *
- * Run:  pnpm vitest run test/session-store-sqlite.test.ts
+ * Run:  bunx vitest run test/session-store-sqlite.test.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
@@ -402,14 +403,15 @@ describe('first-load serialization against an in-flight offline writer', () => {
 
 // ─── Node 能力探测 ───────────────────────────────────────────────────────────
 
-describe('node:sqlite capability gate', () => {
+describe('SQLite capability gate', () => {
   it('daemon startup probe fails with an actionable upgrade message', () => {
     __testOnly_setSqliteUnavailable(true);
     expect(() => assertSqliteSupported()).toThrow(SessionStoreSqliteUnavailableError);
     expect(() => assertSqliteSupported()).toThrow(/22\.13/);
+    expect(() => assertSqliteSupported()).toThrow(/bun:sqlite/);
   });
 
-  it('CLI paths fail hard when a .db exists but node:sqlite is missing', () => {
+  it('CLI paths fail hard when a .db exists but the SQLite engine is missing', () => {
     seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
     init('appA');
     listSessions(); // 首次访问触发导入 → .db
@@ -426,7 +428,7 @@ describe('node:sqlite capability gate', () => {
     )).toThrow(SessionStoreSqliteUnavailableError);
   });
 
-  it('CLI paths keep working on plain JSON stores when node:sqlite is missing (no .db yet)', () => {
+  it('CLI paths keep working on plain JSON stores when the SQLite engine is missing (no .db yet)', () => {
     seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
     __testOnly_setSqliteUnavailable(true);
 
@@ -439,5 +441,18 @@ describe('node:sqlite capability gate', () => {
       { dataDir: tempDir },
     );
     expect(published?.status).toBe('closed');
+  });
+
+  it('a corrupt .db is a skippable store, not a missing-engine error', () => {
+    mkdirSync(join(tempDir, 'session-stores', 'appA'), { recursive: true });
+    writeFileSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'), 'this is not a database');
+    // A sibling JSON store (no .db) is the readable copy. The empty legacy
+    // sessions.db that beforeEach init() may have created does not hold s1.
+    seedJson('sessions-appB.json', { s1: row('s1', { title: 'other-bot' }) });
+
+    expect(() => assertSqliteSupported()).not.toThrow();
+    const copies = readSessionRowCopiesAcrossStores('s1', tempDir);
+    expect(copies).toHaveLength(1);
+    expect(copies[0]?.title).toBe('other-bot');
   });
 });

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -623,7 +623,9 @@ describe('closeSession()', () => {
     // (read by offline/cross-store row readers) may still carry the target.
     init();
     expect(getSession(session.sessionId)?.previewTarget).toBeUndefined();
-    const raw = readFileSync(join(tempDir, 'sessions.json'), 'utf-8');
+    const persisted = readPersistedRows(tempDir)[session.sessionId];
+    expect(persisted.previewTarget).toBeUndefined();
+    const raw = JSON.stringify(persisted);
     expect(raw).not.toContain('previewTarget');
     expect(raw).not.toContain('4173');
   });
@@ -636,7 +638,7 @@ describe('closeSession()', () => {
       registeredAt: '2026-08-11T12:00:00.000Z',
     };
     updateSession(session);
-    fsControl.failSessionWrite = true;
+    __testOnly_setBeforeRowPersist(() => { throw new Error('simulated session repair write failure'); });
 
     expect(() => closeSession(session.sessionId))
       .toThrow(/simulated session repair write failure/);

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -447,7 +447,11 @@ describe('write health gate', () => {
     const session = createSession('chat-write-gate', 'root-write-gate', 'Write Gate');
     session.backendType = 'mojo';
     updateSession(session);
-    const fp = join(tempDir, 'sessions.json');
+    // Close the live SQLite connection before overwriting the active store;
+    // corrupting the frozen JSON would not trip the engine now in use.
+    init();
+    const fp = persistedStorePath(tempDir);
+    if (!fp) throw new Error('expected a persisted store after createSession');
     writeFileSync(fp, '{not-json');
     init();
     return { session, fp };
@@ -498,11 +502,12 @@ describe('write health gate', () => {
       SessionStoreUnavailableError,
     );
 
-    writeFileSync(fp, '{}');
+    rmSync(fp, { force: true });
+    new DatabaseSync(fp).close();
     expect(() => createSession('chat-still-blocked', 'root-still-blocked', 'Still Blocked')).toThrow(
       SessionStoreUnavailableError,
     );
-    expect(readFileSync(fp, 'utf-8')).toBe('{}');
+    expect(existsSync(fp)).toBe(true);
 
     init();
     expect(createSession('chat-reloaded', 'root-reloaded', 'Reloaded').status).toBe('active');
@@ -523,7 +528,9 @@ describe('write health gate', () => {
 
   it('rejects writes after a valid JSON value that is not a session projection', () => {
     const session = createSession('chat-array', 'root-array', 'Array Projection');
-    const fp = join(tempDir, 'sessions.json');
+    init();
+    const fp = persistedStorePath(tempDir);
+    if (!fp) throw new Error('expected a persisted store after createSession');
     writeFileSync(fp, '[]');
     init();
 
@@ -689,7 +696,7 @@ describe('closeSession()', () => {
     session.backendType = 'mojo';
     session.riffParentTaskId = 'mojo-sid-retry';
     updateSession(session);
-    fsControl.failSessionWrite = true;
+    __testOnly_setBeforeRowPersist(() => { throw new Error('simulated session repair write failure'); });
 
     expect(() => closeSession(
       session.sessionId,
@@ -702,7 +709,7 @@ describe('closeSession()', () => {
     expect(inMemory?.mojoQuarantineNoticePending).toBeUndefined();
 
     // ...and the same must be true of what is actually on disk.
-    fsControl.failSessionWrite = false;
+    __testOnly_setBeforeRowPersist(undefined);
     init();
     const reloaded = getSession(session.sessionId);
     expect(reloaded).toMatchObject({ status: 'active', riffParentTaskId: 'mojo-sid-retry' });
@@ -760,7 +767,7 @@ describe('closeSession()', () => {
     updateSession(session);
     beginMojoCloseJournal(session.sessionId, 'request-1', 'mojo-sid-journal');
     markMojoClosePrepared(session.sessionId, 'request-1', 'mojo-sid-journal');
-    fsControl.failSessionWrite = true;
+    __testOnly_setBeforeRowPersist(() => { throw new Error('simulated session repair write failure'); });
 
     expect(() => closeSession(
       session.sessionId,
@@ -772,7 +779,7 @@ describe('closeSession()', () => {
       mojoCloseJournal: { phase: 'prepared', requestId: 'request-1' },
     });
 
-    fsControl.failSessionWrite = false;
+    __testOnly_setBeforeRowPersist(undefined);
     init();
     expect(getSession(session.sessionId)).toMatchObject({
       status: 'active',
@@ -787,7 +794,7 @@ describe('closeSession()', () => {
     session.riffParentTaskId = 'mojo-sid-journal';
     updateSession(session);
     beginMojoCloseJournal(session.sessionId, 'request-1', 'mojo-sid-journal');
-    fsControl.failSessionWrite = true;
+    __testOnly_setBeforeRowPersist(() => { throw new Error('simulated session repair write failure'); });
 
     expect(() => markMojoClosePrepared(
       session.sessionId,
@@ -799,7 +806,7 @@ describe('closeSession()', () => {
       requestId: 'request-1',
     });
 
-    fsControl.failSessionWrite = false;
+    __testOnly_setBeforeRowPersist(undefined);
     init();
     expect(getSession(session.sessionId)?.mojoCloseJournal).toMatchObject({
       phase: 'preparing',

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -98,7 +98,7 @@ function makeTempDir(): string {
 import { DatabaseSync } from 'node:sqlite';
 
 function persistedStorePath(dir: string, appId?: string): string | undefined {
-  const dbPath = join(dir, appId ? `sessions-${appId}.db` : 'sessions.db');
+  const dbPath = appId ? join(dir, 'session-stores', appId, 'sessions.db') : join(dir, 'sessions.db');
   if (existsSync(dbPath)) return dbPath;
   const jsonPath = join(dir, appId ? `sessions-${appId}.json` : 'sessions.json');
   return existsSync(jsonPath) ? jsonPath : undefined;

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -62,6 +62,7 @@ vi.mock('../src/services/frozen-card-store.js', () => ({
 
 // Import the module under test after mocks are set up
 import {
+  __testOnly_setBeforeRowPersist,
   init,
   createSession,
   getSession,
@@ -92,11 +93,42 @@ function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), 'session-store-test-'));
 }
 
+// db-else-json 读盘夹具：引擎替换后，daemon store 的持久化状态落在 sessions*.db
+// （既有 JSON 冻结不再更新）；混合窗口场景仍可能只有 .json。读断言统一走这里。
+import { DatabaseSync } from 'node:sqlite';
+
+function persistedStorePath(dir: string, appId?: string): string | undefined {
+  const dbPath = join(dir, appId ? `sessions-${appId}.db` : 'sessions.db');
+  if (existsSync(dbPath)) return dbPath;
+  const jsonPath = join(dir, appId ? `sessions-${appId}.json` : 'sessions.json');
+  return existsSync(jsonPath) ? jsonPath : undefined;
+}
+
+function persistedStoreExists(dir: string, appId?: string): boolean {
+  return persistedStorePath(dir, appId) !== undefined;
+}
+
+function readPersistedRows(dir: string, appId?: string): Record<string, any> {
+  const path = persistedStorePath(dir, appId);
+  if (!path) throw new Error(`no persisted session store in ${dir} (appId=${appId ?? 'legacy'})`);
+  if (path.endsWith('.db')) {
+    const db = new DatabaseSync(path);
+    try {
+      const rows = db.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
+      return Object.fromEntries(rows.map(r => [r.session_id, JSON.parse(r.row)]));
+    } finally {
+      db.close();
+    }
+  }
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
 // ─── Setup / Teardown ─────────────────────────────────────────────────────
 
 beforeEach(() => {
   tempDir = makeTempDir();
   fsControl.failSessionWrite = false;
+  __testOnly_setBeforeRowPersist(undefined);
   mockDeleteFrozenCards.mockReset();
   // Reset module state for each test
   init();
@@ -177,7 +209,7 @@ describe('init()', () => {
 
     expect(getSession('broken')?.scope).toBe('chat');
     expect(getSession('legacyThread')?.scope).toBeUndefined();
-    const persisted = JSON.parse(readFileSync(fp, 'utf-8'));
+    const persisted = readPersistedRows(tempDir);
     expect(persisted.broken.scope).toBe('chat');
     expect(persisted.legacyThread.scope).toBeUndefined();
   });
@@ -294,9 +326,8 @@ describe('createSession()', () => {
 
   it('should persist session to disk', () => {
     const session = createSession('chat1', 'root1', 'Persisted');
-    const fp = join(tempDir, 'sessions.json');
-    expect(existsSync(fp)).toBe(true);
-    const data = JSON.parse(readFileSync(fp, 'utf-8'));
+    expect(persistedStoreExists(tempDir)).toBe(true);
+    const data = readPersistedRows(tempDir);
     expect(data[session.sessionId]).toBeDefined();
     expect(data[session.sessionId].title).toBe('Persisted');
   });
@@ -542,7 +573,8 @@ describe('closeSession()', () => {
     session.backendType = 'riff';
     session.riffParentTaskId = 'riff-task-retry';
     updateSession(session);
-    fsControl.failSessionWrite = true;
+    // SQLite 行写不经过 node:fs，失败注入改走 store 的 test-only 钩子。
+    __testOnly_setBeforeRowPersist(() => { throw new Error('simulated session repair write failure'); });
 
     expect(() => closeSession(
       session.sessionId,
@@ -554,7 +586,7 @@ describe('closeSession()', () => {
     });
     expect(mockDeleteFrozenCards).not.toHaveBeenCalled();
 
-    fsControl.failSessionWrite = false;
+    __testOnly_setBeforeRowPersist(undefined);
     init();
     expect(getSession(session.sessionId)).toMatchObject({
       status: 'active',
@@ -946,22 +978,22 @@ describe('updateSession()', () => {
   });
 
   it('skips the disk write when an update produces byte-identical content', () => {
-    // save() does writeFile(tmp) + rename(tmp → fp), so every REAL write
-    // replaces the file's inode. A skipped write leaves the inode untouched.
-    const fp = join(tempDir, 'sessions.json');
+    // 行级写落在 WAL（append-only），每次 REAL write 都让 sessions.db-wal 变长；
+    // 被跳过的冗余写不开事务，WAL 长度保持不变。
+    const walFp = join(tempDir, 'sessions.db-wal');
     const session = createSession('chat1', 'root1', 'NoChange');
-    const inodeAfterCreate = statSync(fp).ino;
+    const walAfterCreate = statSync(walFp).size;
 
-    // A redundant update with no field change → must be skipped (inode stable).
+    // A redundant update with no field change → must be skipped (WAL stable).
     updateSession(session);
-    expect(statSync(fp).ino).toBe(inodeAfterCreate);
+    expect(statSync(walFp).size).toBe(walAfterCreate);
     updateSession(session); // and again — still no write
-    expect(statSync(fp).ino).toBe(inodeAfterCreate);
+    expect(statSync(walFp).size).toBe(walAfterCreate);
 
-    // A real change → the file is rewritten (inode changes).
+    // A real change → the row is rewritten (WAL grows).
     session.title = 'Changed';
     updateSession(session);
-    expect(statSync(fp).ino).not.toBe(inodeAfterCreate);
+    expect(statSync(walFp).size).toBeGreaterThan(walAfterCreate);
 
     // Content is still correct after the skip/write sequence.
     init();
@@ -1021,8 +1053,8 @@ describe('Multi-bot isolation', () => {
     init('app-beta');
     createSession('c2', 'r2', 'Beta Session');
 
-    expect(existsSync(join(tempDir, 'sessions-app-alpha.json'))).toBe(true);
-    expect(existsSync(join(tempDir, 'sessions-app-beta.json'))).toBe(true);
+    expect(persistedStoreExists(tempDir, 'app-alpha')).toBe(true);
+    expect(persistedStoreExists(tempDir, 'app-beta')).toBe(true);
   });
 
   it('should only list sessions belonging to the current appId', () => {
@@ -1045,7 +1077,8 @@ describe('Multi-bot isolation', () => {
   it('should use legacy sessions.json when no appId is set', () => {
     init();
     createSession('c1', 'r1', 'Legacy');
-    expect(existsSync(join(tempDir, 'sessions.json'))).toBe(true);
+    expect(persistedStoreExists(tempDir)).toBe(true);
+    expect(readPersistedRows(tempDir)).not.toEqual({});
   });
 
   it('should migrate matching sessions from legacy file to per-bot file', () => {
@@ -1078,7 +1111,7 @@ describe('Multi-bot isolation', () => {
     const sessions = listSessions();
     expect(sessions).toHaveLength(1);
     expect(sessions[0].title).toBe('App A Session');
-    expect(existsSync(join(tempDir, 'sessions-app-A.json'))).toBe(true);
+    expect(persistedStoreExists(tempDir, 'app-A')).toBe(true);
   });
 });
 
@@ -1197,7 +1230,7 @@ describe('legacy placeholder-card field stripping', () => {
     const loaded = getSession('s1')!;
     updateSession({ ...loaded, title: 'Touched' });
 
-    const onDisk = JSON.parse(readFileSync(join(tempDir, 'sessions.json'), 'utf-8'));
+    const onDisk = readPersistedRows(tempDir);
     expect(onDisk.s1.title).toBe('Touched');
     expect(onDisk.s1).not.toHaveProperty('pendingResponseCardId');
     expect(onDisk.s1).not.toHaveProperty('pendingResponseCardState');

--- a/test/unit-data-dir-isolation.test.ts
+++ b/test/unit-data-dir-isolation.test.ts
@@ -21,7 +21,7 @@ describe.sequential('unit-test session persistence', () => {
     sessionStore.init('unit_isolation_probe');
     sessionStore.createSession('oc_probe', 'om_probe', 'unit isolation probe');
 
-    expect(existsSync(join(isolatedDataDir, 'sessions-unit_isolation_probe.db'))).toBe(true);
+    expect(existsSync(join(isolatedDataDir, 'session-stores', 'unit_isolation_probe', 'sessions.db'))).toBe(true);
 
     process.env.SESSION_DATA_DIR = join(unitRoot, 'leaked-test-override');
   });

--- a/test/unit-data-dir-isolation.test.ts
+++ b/test/unit-data-dir-isolation.test.ts
@@ -21,7 +21,7 @@ describe.sequential('unit-test session persistence', () => {
     sessionStore.init('unit_isolation_probe');
     sessionStore.createSession('oc_probe', 'om_probe', 'unit isolation probe');
 
-    expect(existsSync(join(isolatedDataDir, 'sessions-unit_isolation_probe.json'))).toBe(true);
+    expect(existsSync(join(isolatedDataDir, 'sessions-unit_isolation_probe.db'))).toBe(true);
 
     process.env.SESSION_DATA_DIR = join(unitRoot, 'leaked-test-override');
   });


### PR DESCRIPTION
## 背景

「Session 架构拆解回收」计划 Step 3 的**第一个 PR**（引擎替换 + 导入 + 灰度准备）。唯一口径：`docs/design/2026-08-12-session-restage-store-first.md` Step 3。前提是 #846：会话行持久化已收敛为 `services/session-store.ts` 唯一门——本 PR 在门后把 JSON 整文件引擎换成 per-bot SQLite，**公共 API 签名与行为不变**。

virtual-actor / SessionRuntime（#831）**不合入**；本 PR 也不把它缝回去。store-first 就是替代方案。

已 rebase 到 `origin/master@06db2b48`（bun 包管理器 + 单二进制）。0813 之后 master 新增的 Remote lineage CAS、Mojo close journal、`SessionStoreUnavailableError` / `listSessionsStrict` / `loadForWrite`，0820 基线的 Workbench `previewTarget` close/resume 清理，以及 0820 之后的 bun `sqlite-compat`、#889 会话级 `/cli`、#1017 发信人身份，都接到同一套 SQLite 引擎上。

## 改了什么

### 引擎（`src/services/session-store.ts`）

- **Schema**：单表 + 整行 JSON 列——`sessions(session_id TEXT PRIMARY KEY, status TEXT NOT NULL, row TEXT NOT NULL)`，另加 `chatId` / `rootMessageId` / `scope` 三个 VIRTUAL 生成列与 status/root/chat 索引服务热查询。`Session` 的 TS 类型仍是 schema 权威。
- **存储位置**：per-bot 库在自有目录 `session-stores/<appId>/sessions.db`（legacy 无 appId 库保持平铺 `sessions.db`，从不进沙盒授权）。Linux 沙盒的单文件 bind 钉住 spawn 时刻 inode，而 SQLite 在最后连接关闭时删建 `-wal/-shm`——persistent pane 跨 daemon 重启会读死 WAL；目录 bind 按名字解析，重启后的新 sidecar 自动可见。
- **打开库走 `sqlite-compat`**：Node 用 `node:sqlite`，Bun 编译态用 `bun:sqlite`。禁止再 `createRequire('node:sqlite')`（否则编译版 daemon 硬门假失败）。`sqliteEngineAvailable()` 只探测模块能否加载；`openDatabaseSyncOrThrow()` 打开失败（损坏库）不得收成「引擎不可用」。
- **首启确定性自动导入**：无 `.db` 且本进程允许 bootstrap（daemon）时，在与 JSON 写者相同的文件锁下把本 bot 的 JSON 行导入 `.db.tmp`，commit 后 `rename` 落位。语义覆盖今天 `load()` 的兼容处理：per-bot 文件 else legacy `sessions.json` 中属于本 bot 的行、`repairMissingChatScope`、strip legacy card 字段、**closed 行全量导入**。JSON 不可读则 fail-closed（`loadFailure`），禁止导入出空库把唯一副本毁掉。
- **公共 API 签名不变**：`updateSession(session)` 等调用点不改签名；内部从整份 `JSON.stringify` + tmp+rename 改为**只把变化的那一行 upsert**；序列化结果相同则跳写。进程内 `Map` 缓存与内存 `DaemonSession` 语义不动。
- **首次 load 排他读**：`BEGIN IMMEDIATE` 只排斥写者、不阻塞普通 SELECT。已过双 `abortIf`、持写锁未 commit 的离线 CLI，会让普通读把提交前旧行读进终身缓存，随后行写回覆盖 CLI 提交。load 的快照读（含 scope repair 写回）整体在 `BEGIN IMMEDIATE` 内完成；配合 daemon「先发布 descriptor 再首次 load」：已持锁写者让 load 等到 commit，新来写者在探测处让位。
- **锁等待 ≠ 空库**：损坏 / 非数据库文件走 `loadFailure`（`listSessions()` 仍兼容空投影，写路径 `listSessionsStrict` / `loadForWrite` 拒绝）。`BEGIN IMMEDIATE` 耗尽 `busy_timeout`（SQLITE_BUSY）以及导入期文件锁超时**必须抛错**——daemon restore 走 `listSessions()`，把健康库的锁等待收成空 Map 会跳过全部会话恢复。
- **Remote lineage CAS + readback** 在 SQLite 上等价重写（`BEGIN IMMEDIATE` 内 compare-and-set，提交后回读；`prewrite_ownership` / `prewrite_io` / `postrename_ambiguity` 分级与 JSON 路径一致）。JSON 实现净删除留给第二 PR。
- **Mojo close journal** 经同一套 `persistRow` / 写失败回滚；损坏库的写门对 `.db` 同样 fail-closed。
- **运行参数**：WAL、`synchronous=NORMAL`、`busy_timeout=3s`。durability 首版与今日等价（tmp+rename、无 fsync），不顺带升级。

### 混合窗口（npm 已升级、daemon 未重启）

跨进程读者和 CLI 离线写统一 **per store「有 `.db` 用 `.db`，否则 `.json`」**。要点：

- `mutateSessionRowOffline` 的 **`abortIf` daemon 在位探测原样保留**（锁内入口 + 发布前各一次）。SQLite 只排序写者，不能代替「daemon 内存缓存与磁盘分叉」探测。
- `readSessionRowCopiesAcrossStores` 把「.db + 冻结 .json」视为**同一个 store 的一份拷贝**（以 .db 为准）。
- **worker `owner: false`**：旧 daemon 从新 dist spawn 的 worker 不得首启导入，避免「旧 daemon 仍写 JSON」期间造出 `.db` 分叉。

### 运行时门

- `engines` 跟 master：`node: >=22`（bun 单二进制用 `bun:sqlite`，不把仓库 engines 收紧到 22.13）。
- daemon 启动最前 `assertSqliteSupported()` 才是真门；失败信息同时给出 Node 升级线与 Bun `bun:sqlite`。
- CLI：已有 `.db` 但运行时没有 SQLite 引擎 → `SessionStoreSqliteUnavailableError` 硬报错（穿透 best-effort 扫描）；尚无 `.db` → JSON 路径照常；**损坏 `.db` 是 skippable store，不是引擎缺失**。

### 沙盒（`src/adapters/cli/fs-policy.ts`）

常规 + no-transport 两处 readOnly 授权授 **store 目录** `session-stores/<appId>`（混合窗口仍保留冻结 `.json` 授权）。兄弟 bot 的 store 目录 deny-by-default。macOS Seatbelt 同步改目录授权，两平台同形。

## 回滚

导入后 **JSON 原地冻结，不删不改名**：装回旧版重启即读冻结时刻的 JSON。代价：丢弃灰度窗口内发生的会话行变更。第二 PR 前 JSON 路径全程在库。

## 影响面

- **主要动公共层 `session-store`**，以及 daemon 启动硬门、worker `owner:false`、fs-policy 沙盒授权、`sqlite-compat` 的 fail-closed 打开 API。turn-sends / frozen-card / whiteboard / usage-ledger / idempotency / vc-meeting-* / schedule / pending-turn journal 等旁路存储未卷进会话行；`utils/file-lock.ts` 本体未动（JSON 路径仍用它）。
- **跨进程**：daemon 唯一在线写者 → SQLite 行写；worker 读者 → db-else-json；CLI 离线写 → db-else-json + `BEGIN IMMEDIATE` + abortIf；sibling 跨 bot 发现 → db-else-json。
- **跨平台 / 跨运行时**：开发态 Node 走 `node:sqlite`；编译版 Bun 走 `bun:sqlite`。Linux bwrap 依赖目录 bind（见上）；macOS Seatbelt 为路径规则。真实 bwrap 回归仅 linux+bwrap 可用时运行，本机 macOS skip。
- **跨 CLI / 后端 / 会话类型**：调用点签名不变；Pty/Tmux、话题/群、adopt/restore、sandbox on/off 仍走同一 store 门面。

原则 1「合入即更简单」**本 PR 不兑现**：`session-store.ts` 从 master ~1390 行增至 ~2160 行（JSON 机器 + SQLite 机器共存）。这是设计允许的 1~2 PR 切分；净删除验收在第二 PR。收益里「仲裁不再依赖 findDaemon-TOCTOU」过满——SQLite 只排序写者，`abortIf` + `findDaemon` 必须留。

## 0827 原则自检（对照 `3d84aaad..06db2b48`）

后续 master **没有**破坏 store-first 原则，但有一处必须跟进的运行时原则：

| 原则 / 不变量 | 结论 |
|---|---|
| 1 合入即更简单 | 仍待第二 PR 净删除；master 未要求本 PR 提前删 JSON 机器 |
| 2 唯一门 | src 无 `sessions*.json` 直写绕过；CLI 只委托 `loadAllSessionsSnapshot` / `mutateSessionRowOffline`；provenance 仍走 `readSessionRowCopiesAcrossStores` |
| 3 收益不递延铺路 | 无 SessionRuntime / virtual-actor 回流；Step 4(f) 占位租约未实施 |
| 5 证据只认 master | master `005ce0ae` 已规定 SQLite 必须经 `sqlite-compat`；本 PR 直连 `node:sqlite` 会与 bun 分发冲突，已改走 compat |
| 混合窗口 `owner: false` | worker 启动仍 `sessionStore.init(..., { owner: false })` |
| fs-policy 目录授权 | 仍授 `session-stores/<appId>`，兄弟 bot deny-by-default |
| `abortIf` + `findDaemon` | 离线写双探测仍在；SQLite 锁不替代 |
| 非目标旁路 store | #946 pending-turn journal、#1008 schedule 仍是独立文件；#889 `/cli` 写 Session 字段经 `updateSession` |

唯一被后续提交「打穿」的是 **Node-only `node:sqlite` 假设**（不是设计文档原则 1–5 本身）。已修好。

## 测试与验证

未跑 `switch:here` / 桌面端打包。本轮相关单测（本机无 bun，走 `./node_modules/.bin/vitest`）：

```bash
./node_modules/.bin/vitest run --project unit \
  test/session-store.test.ts \
  test/session-store-sqlite.test.ts \
  test/mojo-close-journal.test.ts \
  test/remote-shutdown-detach.test.ts \
  test/fs-policy.test.ts \
  test/unit-data-dir-isolation.test.ts \
  test/riff-explicit-close.test.ts \
  test/cli-send-hook-context.test.ts \
  test/current-turn-provenance.test.ts \
  test/skill-feedback-store.test.ts \
  test/feedback-store-v3-migration.test.ts
```

结果：**11 files / 318 passed**（`session-store-bwrap` 本机 macOS 未跑，linux+bwrap 才跑真实目录 bind 回归）。新增回归：损坏 `.db` 不得收成 `SessionStoreSqliteUnavailableError`。

既有 `session-store.test.ts` 作为行为等价 parity（含 master 新增的 strict 读 / 写门 / Remote / Mojo）；写失败注入改走 `__testOnly_setBeforeRowPersist`。新增共享夹具 `test/helpers/session-store-disk.ts`。

rebase 后请再看 CI（含 linux bwrap 与 bun 编译态是否仍能打开会话库）。

## 第二 PR（灰度稳定后）净删除清单

1. store 内 JSON 机器：`load()` JSON/legacy 分支、`save()` 整份序列化、tmp+rename、byte-identical 跳写、`readExistingSessionsFromDisk` / `readSessionsProjectionStrict`；
2. store 内 `withFileLockSync` 编排（`file-lock.ts` 本体不动）；
3. `repairMissingChatScopes` 收敛为仅导入期一次性步骤；
4. Remote lineage CAS + readback 的 JSON 实现（SQLite 版已在本 PR）；
5. `mutateSessionRowOffline` / 各扫描函数的 JSON 分支与 db-else-json 分流（收敛为 db-only）；
6. 冻结 JSON 文件的清理策略届时一并决策。

## 已知边界

- Remote 批量 API 的 `maxWaitMs` 原本约束文件锁；SQLite 路径等待上限由 `busy_timeout`（3s）决定。
- 离线写 `findDaemon` probe-vs-publish TOCTOU 与 JSON 时代等宽：SQLite 只排序写者。消法（store 内占位租约，与行写同一事务；不是 virtual actor）已记入设计文档 Step 4 候选 (f)，**本 PR 不实施**。
- `restoreActiveSessions` 仍走兼容读 `listSessions()`：损坏库与 JSON 时代一样会当成空投影启动（写路径已有 `listSessionsStrict`）。健康库的锁等待已改为抛错，不再走这条兼容空投影。
- 沙盒 readOnly 读 WAL 库依赖 live daemon 维持 `-shm`；daemon 崩溃遗留 stale WAL 时，非沙盒读者先尝试读写打开做恢复，失败再只读。