### PR TITLE
fix(lark): 修复话题内命令回复漂移

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -25,7 +25,7 @@ import { chatAppLink, threadAppLink, normalizeBrand } from '../im/lark/lark-host
 import { claimPairing } from '../services/pairing-store.js';
 import { logger } from '../utils/logger.js';
 import { scheduleTimeZone } from '../utils/timezone.js';
-import { killWorker, teardownAuthoritativePersistentBackingBeforeClose, suspendWorker, forkWorker, forkAdoptWorker, adoptSandboxBlocked, getCurrentCliVersion, postFreshStreamingCard, postPrivateSnapshotCard, resolvePrivateCardAudience, deliverEphemeralOrReply, deliverWritableTerminalCardTo, closeSession as closeWorkerPoolSession, withActiveSessionKeyLock, requestSessionRestart, isSessionTransferring } from './worker-pool.js';
+import { killWorker, teardownAuthoritativePersistentBackingBeforeClose, suspendWorker, forkWorker, forkAdoptWorker, adoptSandboxBlocked, getCurrentCliVersion, postFreshStreamingCard, postPrivateSnapshotCard, resolvePrivateCardAudience, deliverEphemeralOrReply, deliverWritableTerminalCardTo, closeSession as closeWorkerPoolSession, withActiveSessionKeyLock, requestSessionRestart, isSessionTransferring, type WorkerSessionReplyOptions } from './worker-pool.js';
 import {
   expandHome,
   getSessionWorkingDir,
@@ -86,7 +86,7 @@ import {
   readRoleProfileEntry,
   writeRoleProfileEntry,
 } from '../services/role-profile-store.js';
-import type { LarkMessage, DaemonToWorker, CodexAppTurnInput } from '../types.js';
+import type { LarkMessage, DaemonToWorker, CodexAppTurnInput, FrozenSessionReplyTarget } from '../types.js';
 import type { ResolvedSender } from '../im/lark/identity-cache.js';
 import { activeSessionKey, sessionKey, sessionAnchorId, markRepoCardConsumed, claimCurrentRepoCard } from './types.js';
 import type { DaemonSession } from './types.js';
@@ -436,9 +436,12 @@ function invalidConfiguredWorkingDirs(ds: DaemonSession | undefined, larkAppId: 
 
 export interface CommandHandlerDeps {
   activeSessions: Map<string, DaemonSession>;
-  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string, turnId?: string) => Promise<string>;
+  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string, turnId?: string, opts?: WorkerSessionReplyOptions) => Promise<string>;
   getActiveCount: () => number;
   lastRepoScan: Map<string, import('../services/project-scanner.js').ProjectInfo[]>;
+  /** Immutable Lark placement captured by the daemon for this slash-command
+   * invocation. Unlike session state, it remains valid after close/replace. */
+  invocationReplyTarget?: FrozenSessionReplyTarget;
   /** 会前预热文档评论会话：立即启动 CLI、读取文档并进入待命。 */
   prewarmDocCommentSession?: (ds: DaemonSession, sub: DocSubscription) => Promise<void>;
 }
@@ -1362,15 +1365,16 @@ export async function handleCommand(
             );
             break;
           }
-          // 「会话已关闭」卡片优先「仅自己可见」：普通群里走 ephemeral 只发给执行
-          // /close 的本人；话题群不支持 ephemeral(18053) 时回退为正常的群内可见回复
-          // ——与流式卡片上「关闭会话」按钮的送达方式保持一致。
+          // 「会话已关闭」卡片优先「仅自己可见」：普通群顶层走 ephemeral 只发给
+          // 执行 /close 的本人；若本命令从折叠到 chat-scope 的真实话题触发，则
+          // invocationReplyTarget 让 helper 跳过无 thread 锚点的 ephemeral，回原话题。
           await deliverEphemeralOrReply(
             closed.current,
             message.senderId,
             closed.card,
             'interactive',
             () => sessionReply(rootId, closed.card, 'interactive'),
+            deps.invocationReplyTarget,
           );
           logger.info(`[${logTag}] Session closed by /close command`);
         } else {
@@ -1882,6 +1886,7 @@ export async function handleCommand(
               switched.closedCard,
               'interactive',
               () => sessionReply(rootId, switched.closedCard, 'interactive'),
+              deps.invocationReplyTarget,
             );
             await sessionReply(rootId, t('cmd.repo.switched_to', { name: displayName }, loc));
             if (switched.cardToWithdraw) {

--- a/src/core/reply-target.ts
+++ b/src/core/reply-target.ts
@@ -87,6 +87,28 @@ export type SessionReplyTarget =
   | { mode: 'thread'; rootMessageId: string }
   | { mode: 'quote'; rootMessageId: string };
 
+/** Freeze the visible Lark destination for one inbound turn before any
+ * lifecycle mutation can replace or remove its session. `replyRootId` is
+ * supplied only for a real chat-scope thread fold-back; quote-only turns keep
+ * the same root but use ordinary reply semantics instead of reply_in_thread. */
+export function resolveInboundReplyTarget(args: {
+  scope: 'chat' | 'thread';
+  chatId: string;
+  threadRootId: string;
+  replyRootId?: string;
+  quoteOnly?: boolean;
+}): SessionReplyTarget {
+  if (args.scope === 'chat') {
+    if (args.replyRootId) {
+      return args.quoteOnly
+        ? { mode: 'quote', rootMessageId: args.replyRootId }
+        : { mode: 'thread', rootMessageId: args.replyRootId };
+    }
+    return { mode: 'plain', chatId: args.chatId };
+  }
+  return { mode: 'thread', rootMessageId: args.threadRootId };
+}
+
 /** Bound on `Session.replyTargets`: long-lived sessions could otherwise grow
  * without limit. An evicted turn may use a legacy slot only when its turnId
  * still matches exactly; it never borrows a later turn's sender. */
@@ -237,13 +259,13 @@ export function beginReplyTargetTurn(
   // #597: the frozen per-turn dispatch context — the authoritative reply target
   // for THIS turn's Codex App dispatch (steer/queued/opening). Independent of the
   // mention-back participant record below; both are written per turn.
-  const exactTarget: SessionReplyTarget = ds.scope === 'chat'
-    ? replyRootId
-      ? opts?.quoteOnly
-        ? { mode: 'quote', rootMessageId: replyRootId }
-        : { mode: 'thread', rootMessageId: replyRootId }
-      : { mode: 'plain', chatId: ds.chatId }
-    : { mode: 'thread', rootMessageId: ds.session.rootMessageId };
+  const exactTarget = resolveInboundReplyTarget({
+    scope: ds.scope,
+    chatId: ds.chatId,
+    threadRootId: ds.session.rootMessageId,
+    replyRootId,
+    quoteOnly: opts?.quoteOnly,
+  });
   const exactContexts = { ...(ds.session.turnReplyContexts ?? {}) };
   // Re-insertion keeps the newest turn at the end for deterministic bounding.
   delete exactContexts[turnId];

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1870,14 +1870,13 @@ export async function deliverSubstituteControlCard(ds: DaemonSession): Promise<S
  * reply (`reply`). `content` is the card JSON when msgType==='interactive',
  * otherwise the plain text. Topic-group / p2p behavior is unchanged.
  *
- * IMPORTANT: ephemeral is only attempted for flat **chat-scope** sessions. The
+ * IMPORTANT: ephemeral is only attempted for a flat **chat-scope** destination. The
  * ephemeral API (`ephemeral/v1/send`) takes a `chat_id` only — it has no
  * thread/root anchoring — so for a **thread-scope** session (a 话题 inside a
  * 普通群, or a 话题群 topic) an ephemeral card would escape the topic and land at
- * the group top-level. 话题群 happened to reject ephemeral with 18053 and fall
- * back to the in-thread reply, but a 话题 inside a 普通群 succeeds and leaks the
- * card out of the thread. So thread-scope sessions always take the visible
- * `reply()` path, which routes back into the thread (`reply_in_thread`).
+ * the group top-level. The same applies when a chat-scope session is invoked
+ * from a folded thread: callers pass its frozen reply target, and any explicit
+ * thread/quote destination takes the visible `reply()` path.
  */
 export async function deliverEphemeralOrReply(
   ds: DaemonSession,
@@ -1885,8 +1884,16 @@ export async function deliverEphemeralOrReply(
   content: string,
   msgType: 'text' | 'interactive',
   reply: () => Promise<unknown>,
+  replyTarget?: FrozenSessionReplyTarget,
 ): Promise<void> {
-  if (operatorOpenId && ds.chatType !== 'p2p' && ds.scope === 'chat') {
+  // A chat-scope session can still be invoked from a folded thread. The
+  // ephemeral API has no root/thread field, so an explicitly frozen thread or
+  // quote target must take the visible reply path even though the session
+  // itself remains chat-scoped.
+  const allowsEphemeral = replyTarget
+    ? replyTarget.mode === 'plain'
+    : ds.scope === 'chat';
+  if (operatorOpenId && ds.chatType !== 'p2p' && allowsEphemeral) {
     try {
       // The ephemeral API is card-only (msg_type=text → 10003), so wrap a plain
       // confirmation line into a minimal markdown card.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -242,7 +242,7 @@ import {
 import { claimInitialUserTurn, isInitialUserTurnPending, releaseInitialUserTurn } from './core/initial-user-turn.js';
 import { applyQueuedCodexAppLegacyFallback, mergeQueuedCodexAppTurn } from './core/session-create.js';
 import { findOnlineDaemon, listOnlineDaemons } from './utils/daemon-discovery.js';
-import { beginReplyTargetTurn, buildTurnParticipantsFrom, fallbackTurnId, isSubstituteTurn, resolveSessionReplyTarget, syncReplyTargetState } from './core/reply-target.js';
+import { beginReplyTargetTurn, buildTurnParticipantsFrom, fallbackTurnId, isSubstituteTurn, resolveInboundReplyTarget, resolveSessionReplyTarget, syncReplyTargetState } from './core/reply-target.js';
 import { readDeferredTopicBinding } from './core/deferred-topic-binding.js';
 import {
   buildBotmuxLarkNativeSessionTitle,
@@ -4472,6 +4472,39 @@ const commandDeps: CommandHandlerDeps = {
   prewarmDocCommentSession,
 };
 
+/** Bind every reply produced by one slash-command invocation to the routing
+ * decision already made for its inbound Lark message. Commands return before
+ * the normal turn-registration path, and lifecycle commands may remove or
+ * replace their session before replying, so mutable session state cannot be
+ * the authority for placement here. */
+function commandDepsForInvocation(input: {
+  scope: 'chat' | 'thread';
+  chatId: string;
+  anchor: string;
+  messageId: string;
+  replyRootId?: string;
+}): CommandHandlerDeps {
+  const replyTarget = resolveInboundReplyTarget({
+    scope: input.scope,
+    chatId: input.chatId,
+    threadRootId: input.anchor,
+    replyRootId: input.replyRootId,
+  });
+  return {
+    ...commandDeps,
+    invocationReplyTarget: replyTarget,
+    sessionReply: (rootId, content, msgType, larkAppId, turnId, opts) =>
+      sessionReply(
+        rootId,
+        content,
+        msgType,
+        larkAppId,
+        turnId ?? input.messageId,
+        opts?.replyTarget ? opts : { ...opts, replyTarget },
+      ),
+  };
+}
+
 /**
  * Fire a session-less daemon command (`/group`, `/g`) WITHOUT blocking the Lark
  * event ACK on its slow work — the fast-ACK path.
@@ -4497,8 +4530,9 @@ function fireSessionlessCommandDetached(
   anchor: string,
   message: LarkMessage,
   larkAppId: string,
+  deps: CommandHandlerDeps,
 ): void {
-  void handleCommand(cmd, anchor, message, commandDeps, larkAppId).catch((err) =>
+  void handleCommand(cmd, anchor, message, deps, larkAppId).catch((err) =>
     logger.error(`[sessionless ${cmd}] ${anchor.substring(0, 12)} failed: ${err?.message ?? err}`),
   );
 }
@@ -17129,14 +17163,21 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
   const invocation = parseSlashCommandInvocation(cmdContent);
   if (invocation) {
     const { cmd, content: commandContent } = invocation;
+    const invocationDeps = commandDepsForInvocation({
+      scope,
+      chatId,
+      anchor,
+      messageId: parsed.messageId,
+      replyRootId,
+    });
     const restrictedText = grantRestrictedSlashCommandText(larkAppId, chatId, senderOpenId, cmd);
     if (restrictedText) {
-      await sessionReply(anchor, restrictedText, 'text', larkAppId);
+      await invocationDeps.sessionReply(anchor, restrictedText, 'text', larkAppId);
       return;
     }
     if (cmd === '/vc-auth') {
       if (!canOperate(larkAppId, chatId, senderOpenId, teamTrustUnionId)) {
-        await sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
+        await invocationDeps.sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
       await handleVcMeetingTemporaryAuthCommand({
@@ -17157,14 +17198,14 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
     // summon has nothing to show in a brand-new topic. Route here so the generic
     // daemon-command block below does not pre-create a worker=null session.
     if (cmd === '/card') {
-      await handleCardCommand(anchor, larkAppId, chatId, senderOpenId, commandContent, commandDeps);
+      await handleCardCommand(anchor, larkAppId, chatId, senderOpenId, commandContent, invocationDeps);
       return;
     }
     // /term needs a live session's terminal; in a brand-new topic there's none.
     // Route here (own owner-gate inside) so the generic block below doesn't
     // pre-create a worker=null phantom session just to reply "no session".
     if (cmd === '/term') {
-      await handleTermLinkCommand(anchor, larkAppId, chatId, senderOpenId, commandContent, commandDeps);
+      await handleTermLinkCommand(anchor, larkAppId, chatId, senderOpenId, commandContent, invocationDeps);
       return;
     }
     if (resolvePassthroughCommands(larkAppId).has(cmd)) {
@@ -17204,7 +17245,7 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
         });
         return;
       }
-      await sessionReply(anchor, tr('daemon.cmd_requires_session', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
+      await invocationDeps.sessionReply(anchor, tr('daemon.cmd_requires_session', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
       return;
     }
     if (DAEMON_COMMANDS.has(cmd)) {
@@ -17216,7 +17257,7 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
       // canRunDaemonCommand = canOperate ∪（cmd ∈ canTalkDaemonCommands && canTalk）：
       // bot 可通过名单把选定命令（如 /status）降到 canTalk；未配置时与 canOperate 全等。
       if (!canRunDaemonCommand(larkAppId, chatId, senderOpenId, teamTrustUnionId, cmd, senderUnionId, chatType, isBotSenderType, isBotSenderType)) {
-        await sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
+        await invocationDeps.sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
       // `/group` (`/g`) doesn't open a conversation — creating a sessionStore
@@ -17227,7 +17268,13 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
         // Fast-ACK: run detached so the WS event ack isn't blocked on /group's
         // slow Lark API work → no Feishu redelivery → no duplicate group.
         // See fireSessionlessCommandDetached.
-        fireSessionlessCommandDetached(cmd, anchor, { ...parsed, content: commandContent, chatId }, larkAppId);
+        fireSessionlessCommandDetached(
+          cmd,
+          anchor,
+          { ...parsed, content: commandContent, chatId },
+          larkAppId,
+          invocationDeps,
+        );
         return;
       }
       // These commands operate on an EXISTING session; a brand-new topic has none. Route
@@ -17238,7 +17285,7 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
       // permission gates inside their handlers) this branch MUST stay after
       // the canOperate gate above — their handlers do not repeat that gate.
       if (EXISTING_SESSION_ONLY_DAEMON_COMMANDS.has(cmd)) {
-        await handleCommand(cmd, anchor, { ...parsed, content: commandContent }, commandDeps, larkAppId);
+        await handleCommand(cmd, anchor, { ...parsed, content: commandContent }, invocationDeps, larkAppId);
         return;
       }
       // Same rootMessageId reasoning as below in the main spawn path:
@@ -17304,7 +17351,7 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
         });
       }
       // Pass mention-stripped content so /command argument parsing works.
-      await handleCommand(cmd, anchor, { ...parsed, content: commandContent }, commandDeps, larkAppId);
+      await handleCommand(cmd, anchor, { ...parsed, content: commandContent }, invocationDeps, larkAppId);
       return;
     }
   }
@@ -18442,16 +18489,23 @@ async function handleThreadReplyAdmitted(
   const invocation = parseSlashCommandInvocation(cmdContent);
   if (invocation) {
     const { cmd, content: commandContent } = invocation;
+    const invocationDeps = commandDepsForInvocation({
+      scope,
+      chatId: ctxChatId,
+      anchor,
+      messageId: parsed.messageId,
+      replyRootId,
+    });
     const existingDs = activeSessions.get(sessionKey(anchor, larkAppId));
     const effectiveThreadChatId = existingDs?.chatId ?? threadChatId;
     const restrictedText = grantRestrictedSlashCommandText(larkAppId, effectiveThreadChatId, threadSenderOpenId, cmd);
     if (restrictedText) {
-      await sessionReply(anchor, restrictedText, 'text', larkAppId);
+      await invocationDeps.sessionReply(anchor, restrictedText, 'text', larkAppId);
       return;
     }
     if (cmd === '/vc-auth') {
       if (!canOperate(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadTeamTrustUnionId)) {
-        await sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
+        await invocationDeps.sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
       await handleVcMeetingTemporaryAuthCommand({
@@ -18518,7 +18572,7 @@ async function handleThreadReplyAdmitted(
       // 收紧到与 daemon 命令同档；这会同时改变真人 oncall 成员的现有行为，应单独评估。
       const ds = existingDs;
       if (ds?.worker && !ds.worker.killed && hasQueuedActivationAdmissionGate(ds)) {
-        sessionReply(
+        invocationDeps.sessionReply(
           anchor,
           tr('daemon.cmd_activation_pending', { cmd }, localeForBot(larkAppId)),
           'text',
@@ -18536,7 +18590,7 @@ async function handleThreadReplyAdmitted(
         // a clear message rather than deliver a silent no-op (or spawn junk Riff
         // tasks). Other passthrough commands are unaffected.
         if (cmd === '/fast' && fastToggleUnsupportedBackend(ds)) {
-          await sessionReply(anchor, tr('daemon.fast_unsupported_backend', undefined, localeForBot(larkAppId)), 'text', larkAppId);
+          await invocationDeps.sessionReply(anchor, tr('daemon.fast_unsupported_backend', undefined, localeForBot(larkAppId)), 'text', larkAppId);
           return;
         }
         deliverPassthroughToExistingSession(ds, cmd, commandContent, anchor, larkAppId, {
@@ -18548,7 +18602,7 @@ async function handleThreadReplyAdmitted(
           onDelivered: () => markIngressAdmitted(ctx),
         });
       }
-      else void sessionReply(anchor, tr('daemon.cmd_needs_active_cli', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
+      else void invocationDeps.sessionReply(anchor, tr('daemon.cmd_needs_active_cli', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
       return;
     }
     if (DAEMON_COMMANDS.has(cmd)) {
@@ -18559,7 +18613,7 @@ async function handleThreadReplyAdmitted(
       // /term in a thread with no existingDs would spawn a worker:null phantom
       // session and pollute the dashboard before replying not_ready/owner_only.
       if (cmd === '/term') {
-        await handleTermLinkCommand(anchor, larkAppId, threadChatId ?? '', threadSenderOpenId, commandContent, commandDeps);
+        await handleTermLinkCommand(anchor, larkAppId, threadChatId ?? '', threadSenderOpenId, commandContent, invocationDeps);
         return;
       }
       // canOperate gate for thread-reply daemon commands — required in every chat
@@ -18567,7 +18621,7 @@ async function handleThreadReplyAdmitted(
       // canRunDaemonCommand：canTalkDaemonCommands 名单内的命令降到 canTalk，
       // 与 new-topic 路径的统一闸同款（未配置时与 canOperate 全等）。
       if (!canRunDaemonCommand(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadTeamTrustUnionId, cmd, threadSenderUnionId, ctxChatType, isBotSenderType || isForeignBot, isBotSenderType)) {
-        sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
+        invocationDeps.sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
       // First message of a fresh thread carrying a session-needing daemon command
@@ -18635,12 +18689,12 @@ async function handleThreadReplyAdmitted(
       const cmdMessage = { ...parsed, content: commandContent, chatId: threadChatId };
       if (isSessionlessCommandInvocation(cmd, commandContent)) {
         // Fast-ACK for /group invoked mid-thread. See fireSessionlessCommandDetached.
-        fireSessionlessCommandDetached(cmd, anchor, cmdMessage, larkAppId);
+        fireSessionlessCommandDetached(cmd, anchor, cmdMessage, larkAppId, invocationDeps);
         return;
       }
       // 命令路径不打接纳标：handleCommand 内部 catch 吞掉一切异常并记日志
       //（command-handler.ts 收口），异常到不了 ingress catch，标记永远读不到。
-      await handleCommand(cmd, anchor, cmdMessage, commandDeps, larkAppId);
+      await handleCommand(cmd, anchor, cmdMessage, invocationDeps, larkAppId);
       return;
     }
   }

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -84,7 +84,7 @@ import { ttadkConfigModelChoices } from '../../setup/cli-selection.js';
 import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
 import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-store.js';
-import { forkWorker, sendWorkerInput, sendWorkerSessionInput, killWorker, closeSession as closeWorkerPoolSession, teardownAuthoritativePersistentBackingBeforeClose, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, workerHasInitialized, sessionSupportsWebTerminal, readableTerminalUrlFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL, requestSessionRestart, isSessionTransferring, getDaemonStreamingCardUsageSnapshot, withActiveSessionKeyLock } from '../../core/worker-pool.js';
+import { forkWorker, sendWorkerInput, sendWorkerSessionInput, killWorker, closeSession as closeWorkerPoolSession, teardownAuthoritativePersistentBackingBeforeClose, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, workerHasInitialized, sessionSupportsWebTerminal, readableTerminalUrlFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL, requestSessionRestart, isSessionTransferring, getDaemonStreamingCardUsageSnapshot, withActiveSessionKeyLock, type WorkerSessionReplyOptions } from '../../core/worker-pool.js';
 import { getSessionWorkingDir, buildNewTopicCliInput, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput, ensureSessionWhiteboard } from '../../core/session-manager.js';
 import { markInitialUserTurnPending } from '../../core/initial-user-turn.js';
 import { publishAttentionPatch, publishClosedSessionPatch, announcePendingRepoSession } from '../../core/session-activity.js';
@@ -118,7 +118,7 @@ import { runDetachedBotTurnAdmission, withBotTurnAdmission, withBotTurnMutation 
 
 export interface CardHandlerDeps {
   activeSessions: Map<string, DaemonSession>;
-  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string, turnId?: string) => Promise<string>;
+  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string, turnId?: string, opts?: WorkerSessionReplyOptions) => Promise<string>;
   lastRepoScan: Map<string, ProjectInfo[]>;
   /** v3 humanGate 审批卡点击处理（driveRun 由 daemon 接的 v3 gate runner 提供）. */
   v3GateDeps?: V3GateCardHandlerDeps;
@@ -942,6 +942,27 @@ export async function countHostOverload(): Promise<{ stopped: number; idle: numb
     } catch { /* unreachable daemon contributes 0 */ }
   }));
   return { stopped, idle };
+}
+
+/** Resolve a card's actual visible placement from Lark, not action.value
+ * (which is round-tripped client data and therefore untrusted). */
+async function cardReplyOptions(
+  larkAppId: string | undefined,
+  cardMessageId: string | undefined,
+  expectedChatId: string,
+): Promise<WorkerSessionReplyOptions | undefined> {
+  if (!larkAppId || !cardMessageId) return undefined;
+  try {
+    const detail = await getMessageDetail(larkAppId, cardMessageId);
+    const item = detail?.items?.[0];
+    if (!item || item.chat_id !== expectedChatId) return undefined;
+    return item.thread_id
+      ? { replyTarget: { mode: 'thread', rootMessageId: cardMessageId } }
+      : { replyTarget: { mode: 'plain', chatId: item.chat_id } };
+  } catch (err) {
+    logger.debug(`card reply-placement probe failed; preserving legacy route: ${err}`);
+    return undefined;
+  }
 }
 
 export async function handleCardAction(data: CardActionData, deps: CardHandlerDeps, larkAppId?: string): Promise<any> {
@@ -1987,6 +2008,33 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     const sKey = sessionKey(rootId, larkAppId);
     const ds = activeSessions.get(sKey);
     if (!ds) return { toast: { type: 'error', content: t('card.adopt.toast_no_session', undefined, loc) } };
+    // The picker can live in a folded chat-scope topic while rootId remains the
+    // chat session anchor. Freeze the trusted card placement before adoption
+    // mutates the session, so its success/error replies stay beside the picker.
+    const replyOptionsPromise = cardReplyOptions(larkAppId, cardMessageId, ds.chatId);
+    const pickerSessionReply: CardHandlerDeps['sessionReply'] = async (
+      rid,
+      content,
+      msgType,
+      appId,
+      turnId,
+      opts,
+    ) => {
+      const placement = await replyOptionsPromise;
+      return deps.sessionReply(
+        rid,
+        content,
+        msgType,
+        appId,
+        turnId,
+        opts?.replyTarget || !placement
+          ? opts
+          : { ...opts, replyTarget: placement.replyTarget },
+      );
+    };
+    const pickerDeps: CardHandlerDeps = { ...deps, sessionReply: pickerSessionReply };
+    const pickerReply = (content: string, msgType?: string) =>
+      pickerSessionReply(rootId, content, msgType, larkAppId);
     const sourceSession = ds.session;
     if (isSessionTransferring(ds)) {
       return { toast: { type: 'warning', content: t('cmd.session.transfer_in_progress', undefined, localeForBot(ds.larkAppId)) } };
@@ -2015,12 +2063,12 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       }
       const target = resumable.find(r => r.cliSessionId === cliSessionId);
       if (!target) {
-        await sessionReply(rootId, t('cmd.adopt.resume_not_found', { id: cliSessionId }, localeForBot(ds.larkAppId)));
+        await pickerReply(t('cmd.adopt.resume_not_found', { id: cliSessionId }, localeForBot(ds.larkAppId)));
         clearAdoptCandidates(rootId);
         if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
         return;
       }
-      await startResumeImportSession(target, ds, { activeSessions, sessionReply: deps.sessionReply, getActiveCount: () => 0, lastRepoScan }, larkAppId);
+      await startResumeImportSession(target, ds, { ...pickerDeps, getActiveCount: () => 0 }, larkAppId);
       clearAdoptCandidates(rootId);
       if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
       return;
@@ -2077,13 +2125,13 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       return { toast: { type: 'warning', content: t('cmd.session.transfer_in_progress', undefined, localeForBot(ds.larkAppId)) } };
     }
     if (!target) {
-      await sessionReply(rootId, t('cmd.adopt.target_exited', undefined, localeForBot(ds.larkAppId)));
+      await pickerReply(t('cmd.adopt.target_exited', undefined, localeForBot(ds.larkAppId)));
       clearAdoptCandidates(rootId);
       if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
       return;
     }
     const { startAdoptSession } = await import('../../core/command-handler.js');
-    await startAdoptSession(target, ds, { activeSessions, sessionReply: deps.sessionReply, getActiveCount: () => 0, lastRepoScan }, larkAppId);
+    await startAdoptSession(target, ds, { ...pickerDeps, getActiveCount: () => 0 }, larkAppId);
     clearAdoptCandidates(rootId);
     if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
     return;

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -1830,6 +1830,7 @@ describe('handleCommand', () => {
         expect.stringContaining('会话已关闭'),
         'interactive',
         expect.any(Function),
+        undefined,
       );
       // /close now replies with an interactive card carrying a Resume button
       // and a copyable `botmux resume <id>` command — assert on the card shape

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => {
     dataDir,
     replyMessage: vi.fn(async () => 'om_reply'),
     sendMessage: vi.fn(async () => 'om_top'),
+    sendEphemeralCard: vi.fn(async () => 'om_ephemeral'),
     addReaction: vi.fn(async () => 'reaction_received'),
     getChatMode: vi.fn(async () => 'group' as 'group' | 'topic' | 'p2p'),
     getChatNameAndMode: vi.fn(async () => ({ name: null, mode: 'group' as const })),
@@ -73,6 +74,12 @@ const mocks = vi.hoisted(() => {
     forkWorker: vi.fn((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
     }),
+    closeWorkerPoolSession: vi.fn(async () => undefined),
+    discoverAdoptableSessions: vi.fn(() => [] as any[]),
+    discoverAdoptableZellijSessions: vi.fn(() => [] as any[]),
+    discoverClaudeFamilySessions: vi.fn(() => [] as any[]),
+    discoverRolloutSessions: vi.fn(() => [] as any[]),
+    discoverAntigravitySessions: vi.fn(() => [] as any[]),
     scanMultipleProjects: vi.fn(() => [] as any[]),
     getAvailableBots: vi.fn(async () => [] as any[]),
     downloadResources: vi.fn(async () => ({ attachments: [], needLogin: false })),
@@ -100,6 +107,7 @@ vi.mock('../src/im/lark/client.js', async () => {
     ...actual,
     replyMessage: mocks.replyMessage,
     sendMessage: mocks.sendMessage,
+    sendEphemeralCard: mocks.sendEphemeralCard,
     addReaction: mocks.addReaction,
     getChatMode: mocks.getChatMode,
     getChatNameAndMode: mocks.getChatNameAndMode,
@@ -119,7 +127,31 @@ vi.mock('../src/services/session-store.js', async () => {
 
 vi.mock('../src/core/worker-pool.js', async () => {
   const actual = await vi.importActual<any>('../src/core/worker-pool.js');
-  return { ...actual, forkWorker: mocks.forkWorker };
+  return {
+    ...actual,
+    forkWorker: mocks.forkWorker,
+    closeSession: mocks.closeWorkerPoolSession,
+  };
+});
+
+vi.mock('../src/core/session-discovery.js', async () => {
+  const actual = await vi.importActual<any>('../src/core/session-discovery.js');
+  return { ...actual, discoverAdoptableSessions: mocks.discoverAdoptableSessions };
+});
+
+vi.mock('../src/core/zellij-adopt-discovery.js', async () => {
+  const actual = await vi.importActual<any>('../src/core/zellij-adopt-discovery.js');
+  return { ...actual, discoverAdoptableZellijSessions: mocks.discoverAdoptableZellijSessions };
+});
+
+vi.mock('../src/services/resumable-session-discovery.js', async () => {
+  const actual = await vi.importActual<any>('../src/services/resumable-session-discovery.js');
+  return {
+    ...actual,
+    discoverClaudeFamilySessions: mocks.discoverClaudeFamilySessions,
+    discoverRolloutSessions: mocks.discoverRolloutSessions,
+    discoverAntigravitySessions: mocks.discoverAntigravitySessions,
+  };
 });
 
 vi.mock('../src/core/session-manager.js', async () => {
@@ -489,13 +521,28 @@ describe('/rename production routing — must not pre-create a session (review P
     vi.clearAllMocks();
     mocks.replyMessage.mockResolvedValue('om_reply');
     mocks.sendMessage.mockResolvedValue('om_top');
+    mocks.sendEphemeralCard.mockResolvedValue('om_ephemeral');
     mocks.getChatMode.mockResolvedValue('group');
     mocks.getChatNameAndMode.mockResolvedValue({ name: null, mode: 'group' });
     mocks.sessions.clear();
     mocks.forkWorker.mockImplementation((ds: any) => {
       ds.worker = { killed: false, send: vi.fn() };
     });
+    mocks.closeWorkerPoolSession.mockImplementation(async (sessionId: string) => {
+      for (const [key, candidate] of activeSessions) {
+        if (candidate.session.sessionId !== sessionId) continue;
+        candidate.session.status = 'closed';
+        activeSessions.delete(key);
+        mocks.closeSession(sessionId);
+        return;
+      }
+    });
     mocks.scanMultipleProjects.mockReturnValue([]);
+    mocks.discoverAdoptableSessions.mockReturnValue([]);
+    mocks.discoverAdoptableZellijSessions.mockReturnValue([]);
+    mocks.discoverClaudeFamilySessions.mockReturnValue([]);
+    mocks.discoverRolloutSessions.mockReturnValue([]);
+    mocks.discoverAntigravitySessions.mockReturnValue([]);
     mocks.getAvailableBots.mockResolvedValue([]);
     mocks.downloadResources.mockResolvedValue({ attachments: [], needLogin: false });
     activeSessions.clear();
@@ -821,6 +868,317 @@ describe('/rename production routing — must not pre-create a session (review P
     expect(mocks.closeSession).not.toHaveBeenCalled();
     expect(repliedText()).not.toContain('会话已关闭');
     expect(activeSessions.get(sessionKey(rootId, APP))?.workingDir).toBe('/tmp');
+  });
+
+  it('pinned cwd + bare `/t` followed by `/adopt` keeps the picker card inside that thread', async () => {
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: [OWNER],
+      defaultWorkingDir: '/tmp',
+      disableStreamingCard: true,
+    });
+    bot.resolvedAllowedUsers = [OWNER];
+    mocks.discoverAdoptableSessions.mockReturnValue([{
+      tmuxTarget: '0:1.0',
+      panePid: 1000,
+      cliPid: 1001,
+      cliId: 'claude-code',
+      cwd: '/tmp',
+      paneCols: 120,
+      paneRows: 40,
+    }]);
+    const rootId = 'om_bare_force_topic_then_adopt';
+
+    await handleNewTopic(makeEventData(rootId, '/t'), makeCtx(rootId, rootId));
+    mocks.replyMessage.mockClear();
+    mocks.sendMessage.mockClear();
+
+    const adoptReply = makeEventData('om_first_adopt_in_force_topic', '/adopt', rootId);
+    adoptReply.message.thread_id = 'omt_bare_force_topic_then_adopt';
+    await handleNewTopic(
+      adoptReply,
+      makeCtx(rootId, 'om_first_adopt_in_force_topic'),
+    );
+
+    expect(mocks.replyMessage.mock.calls[0]?.slice(0, 5)).toEqual([
+      APP,
+      rootId,
+      expect.any(String),
+      'interactive',
+      true,
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.discoverAdoptableSessions).toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+    expect(JSON.stringify(JSON.parse(String(mocks.replyMessage.mock.calls[0]?.[2])))).toContain('adopt_pick');
+  });
+
+  it('chat-scope `/adopt` picker stays in the invoking group thread', async () => {
+    const ds = seedLiveChatSession();
+    mocks.discoverAdoptableSessions.mockReturnValue([{
+      tmuxTarget: '0:1.0',
+      panePid: 1000,
+      cliPid: 1001,
+      cliId: 'claude-code',
+      cwd: '/tmp',
+      paneCols: 120,
+      paneRows: 40,
+    }]);
+    const topicRoot = 'om_chat_scope_adopt_topic';
+    const messageId = 'om_chat_scope_adopt_command';
+    const event = makeEventData(messageId, '/adopt', topicRoot);
+    event.message.thread_id = 'omt_chat_scope_adopt';
+
+    await handleThreadReply(event, {
+      chatId: CHAT,
+      messageId,
+      chatType: 'group',
+      scope: 'chat',
+      anchor: CHAT,
+      replyRootId: topicRoot,
+      larkAppId: APP,
+    });
+
+    expect(activeSessions.get(sessionKey(CHAT, APP))).toBe(ds);
+    expect(mocks.replyMessage.mock.calls[0]?.slice(0, 5)).toEqual([
+      APP,
+      topicRoot,
+      expect.any(String),
+      'interactive',
+      true,
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.sendEphemeralCard).not.toHaveBeenCalled();
+    expect(mocks.discoverAdoptableSessions).toHaveBeenCalled();
+    expect(JSON.stringify(JSON.parse(String(mocks.replyMessage.mock.calls[0]?.[2])))).toContain('adopt_pick');
+  });
+
+  it('chat-scope command denial stays in the invoking group thread', async () => {
+    const ds = seedLiveChatSession();
+    const topicRoot = 'om_chat_scope_denied_topic';
+    const messageId = 'om_chat_scope_denied_command';
+    const event = makeEventData(messageId, '/rename Hacked', topicRoot);
+    event.message.thread_id = 'omt_chat_scope_denied';
+    event.sender.sender_id.open_id = 'ou_stranger';
+
+    await handleThreadReply(event, {
+      chatId: CHAT,
+      messageId,
+      chatType: 'group',
+      scope: 'chat',
+      anchor: CHAT,
+      replyRootId: topicRoot,
+      larkAppId: APP,
+    });
+
+    expect(ds.session.title).toBe('live chat');
+    expect(mocks.replyMessage.mock.calls[0]?.slice(0, 5)).toEqual([
+      APP,
+      topicRoot,
+      expect.stringContaining('仅 allowedUsers 可执行'),
+      'text',
+      true,
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.sendEphemeralCard).not.toHaveBeenCalled();
+  });
+
+  it('`/t /adopt` opens the picker inside the new thread without starting a CLI', async () => {
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: [OWNER],
+      defaultWorkingDir: '/tmp',
+      disableStreamingCard: true,
+    });
+    bot.resolvedAllowedUsers = [OWNER];
+    mocks.discoverAdoptableSessions.mockReturnValue([{
+      tmuxTarget: '0:1.0',
+      panePid: 1000,
+      cliPid: 1001,
+      cliId: 'claude-code',
+      cwd: '/tmp',
+      paneCols: 120,
+      paneRows: 40,
+    }]);
+    const rootId = 'om_force_topic_adopt_composed';
+
+    await handleNewTopic(
+      makeEventData(rootId, '/t /adopt'),
+      makeCtx(rootId, rootId),
+    );
+
+    expect(mocks.replyMessage.mock.calls[0]?.slice(0, 5)).toEqual([
+      APP,
+      rootId,
+      expect.any(String),
+      'interactive',
+      true,
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.discoverAdoptableSessions).toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+    expect(JSON.stringify(JSON.parse(String(mocks.replyMessage.mock.calls[0]?.[2])))).toContain('adopt_pick');
+  });
+
+  it('chat-scope `/close` confirmation stays in the invoking group thread', async () => {
+    const ds = seedLiveChatSession();
+    const topicRoot = 'om_chat_scope_close_topic';
+    const messageId = 'om_chat_scope_close_command';
+    const event = makeEventData(messageId, '/close', topicRoot);
+    event.message.thread_id = 'omt_chat_scope_close';
+
+    await handleThreadReply(event, {
+      chatId: CHAT,
+      messageId,
+      chatType: 'group',
+      scope: 'chat',
+      anchor: CHAT,
+      replyRootId: topicRoot,
+      larkAppId: APP,
+    });
+
+    expect(mocks.closeWorkerPoolSession).toHaveBeenCalledWith(ds.session.sessionId);
+    expect(activeSessions.has(sessionKey(CHAT, APP))).toBe(false);
+    expect(mocks.replyMessage.mock.calls[0]?.slice(0, 5)).toEqual([
+      APP,
+      topicRoot,
+      expect.any(String),
+      'interactive',
+      true,
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.sendEphemeralCard).not.toHaveBeenCalled();
+  });
+
+  it('chat-scope adopted `/detach` confirmation stays in the invoking group thread', async () => {
+    const ds = seedLiveChatSession();
+    const adoptedFrom = {
+      source: 'tmux' as const,
+      tmuxTarget: '0:1.0',
+      originalCliPid: 1001,
+      cwd: '/tmp',
+    };
+    ds.adoptedFrom = adoptedFrom;
+    ds.session.adoptedFrom = adoptedFrom;
+    const topicRoot = 'om_chat_scope_detach_topic';
+    const messageId = 'om_chat_scope_detach_command';
+    const event = makeEventData(messageId, '/detach', topicRoot);
+    event.message.thread_id = 'omt_chat_scope_detach';
+
+    await handleThreadReply(event, {
+      chatId: CHAT,
+      messageId,
+      chatType: 'group',
+      scope: 'chat',
+      anchor: CHAT,
+      replyRootId: topicRoot,
+      larkAppId: APP,
+    });
+
+    expect(mocks.closeWorkerPoolSession).toHaveBeenCalledWith(ds.session.sessionId);
+    expect(activeSessions.has(sessionKey(CHAT, APP))).toBe(false);
+    expect(mocks.replyMessage.mock.calls[0]?.slice(0, 5)).toEqual([
+      APP,
+      topicRoot,
+      expect.any(String),
+      'text',
+      true,
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.sendEphemeralCard).not.toHaveBeenCalled();
+  });
+
+  it('chat-scope `/close` confirmation stays in the invoking DM thread', async () => {
+    const ds = seedLiveChatSession();
+    ds.chatType = 'p2p';
+    ds.session.chatType = 'p2p';
+    const topicRoot = 'om_dm_close_topic';
+    const messageId = 'om_dm_close_command';
+    const event = makeEventData(messageId, '/close', topicRoot);
+    event.message.thread_id = 'omt_dm_close';
+
+    await handleThreadReply(event, {
+      chatId: CHAT,
+      messageId,
+      chatType: 'p2p',
+      scope: 'chat',
+      anchor: CHAT,
+      replyRootId: topicRoot,
+      larkAppId: APP,
+    });
+
+    expect(mocks.closeWorkerPoolSession).toHaveBeenCalledWith(ds.session.sessionId);
+    expect(activeSessions.has(sessionKey(CHAT, APP))).toBe(false);
+    expect(mocks.replyMessage.mock.calls[0]?.slice(0, 5)).toEqual([
+      APP,
+      topicRoot,
+      expect.any(String),
+      'interactive',
+      true,
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.sendEphemeralCard).not.toHaveBeenCalled();
+  });
+
+  it('thread-scope `/close` keeps its existing in-thread confirmation route', async () => {
+    const topicRoot = 'om_thread_scope_close_topic';
+    const messageId = 'om_thread_scope_close_command';
+    const ds = seedThreadSession(topicRoot, 'live thread close');
+    const event = makeEventData(messageId, '/close', topicRoot);
+    event.message.thread_id = 'omt_thread_scope_close';
+
+    await handleThreadReply(event, {
+      ...makeCtx(topicRoot, messageId),
+      replyRootId: topicRoot,
+    });
+
+    expect(mocks.closeWorkerPoolSession).toHaveBeenCalledWith(ds.session.sessionId);
+    expect(activeSessions.has(sessionKey(topicRoot, APP))).toBe(false);
+    expect(mocks.replyMessage.mock.calls[0]?.slice(0, 5)).toEqual([
+      APP,
+      topicRoot,
+      expect.any(String),
+      'interactive',
+      true,
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.sendEphemeralCard).not.toHaveBeenCalled();
+  });
+
+  it('chat-scope mid-session `/repo <path>` keeps both lifecycle replies in the invoking group thread', async () => {
+    const ds = seedLiveChatSession();
+    const oldSessionId = ds.session.sessionId;
+    const topicRoot = 'om_chat_scope_repo_topic';
+    const messageId = 'om_chat_scope_repo_command';
+    const event = makeEventData(messageId, '/repo /tmp', topicRoot);
+    event.message.thread_id = 'omt_chat_scope_repo';
+
+    await handleThreadReply(event, {
+      chatId: CHAT,
+      messageId,
+      chatType: 'group',
+      scope: 'chat',
+      anchor: CHAT,
+      replyRootId: topicRoot,
+      larkAppId: APP,
+    });
+
+    expect(mocks.closeWorkerPoolSession).toHaveBeenCalledWith(oldSessionId);
+    expect(activeSessions.get(sessionKey(CHAT, APP))).toBe(ds);
+    expect(activeSessions.has(sessionKey(topicRoot, APP))).toBe(false);
+    expect(ds.session.sessionId).not.toBe(oldSessionId);
+    expect(ds.workingDir).toBe('/tmp');
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(mocks.replyMessage.mock.calls.map(call => call.slice(0, 5))).toEqual([
+      [APP, topicRoot, expect.stringContaining('会话已关闭'), 'interactive', true],
+      [APP, topicRoot, expect.stringContaining('已切换到'), 'text', true],
+    ]);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.sendEphemeralCard).not.toHaveBeenCalled();
   });
 
   it('`/t /repo <path>` selects the first Session repository in one message', async () => {

--- a/test/ephemeral-or-reply.test.ts
+++ b/test/ephemeral-or-reply.test.ts
@@ -71,6 +71,26 @@ describe('deliverEphemeralOrReply', () => {
     expect(reply).not.toHaveBeenCalled();
   });
 
+  it('REGRESSION: a chat-scope session with a frozen thread reply target must stay visible in that thread', async () => {
+    const reply = vi.fn().mockResolvedValue('reply_id');
+    await deliverEphemeralOrReply(ds({ scope: 'chat' }), OP, 'restarted', 'text', reply, {
+      mode: 'thread',
+      rootMessageId: 'om_topic',
+    });
+    expect(sendEphemeralCardMock).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps ephemeral delivery for an explicitly frozen flat-chat target', async () => {
+    const reply = vi.fn().mockResolvedValue('reply_id');
+    await deliverEphemeralOrReply(ds({ scope: 'chat' }), OP, 'restarted', 'text', reply, {
+      mode: 'plain',
+      chatId: 'oc_here',
+    });
+    expect(sendEphemeralCardMock).toHaveBeenCalledTimes(1);
+    expect(reply).not.toHaveBeenCalled();
+  });
+
   it('wraps a plain text confirmation into a markdown card before sending ephemeral', async () => {
     await deliverEphemeralOrReply(ds({ scope: 'chat' }), OP, 'restarted', 'text', vi.fn());
     const cardJson = sendEphemeralCardMock.mock.calls[0][3];

--- a/test/initial-passthrough-ownership.test.ts
+++ b/test/initial-passthrough-ownership.test.ts
@@ -99,10 +99,10 @@ describe('registration loser command handoff', () => {
     expect(claimCalls).toBeGreaterThanOrEqual(2);
     expect(src).toContain("if (registration.reason !== 'existing_owner') return;");
     expect(src).toContain(
-      'await handleCommand(cmd, anchor, { ...parsed, content: commandContent }, commandDeps, larkAppId)',
+      'await handleCommand(cmd, anchor, { ...parsed, content: commandContent }, invocationDeps, larkAppId)',
     );
     expect(src).toContain(
-      'await handleCommand(cmd, anchor, cmdMessage, commandDeps, larkAppId)',
+      'await handleCommand(cmd, anchor, cmdMessage, invocationDeps, larkAppId)',
     );
   });
 

--- a/test/reply-target-fallback.test.ts
+++ b/test/reply-target-fallback.test.ts
@@ -21,6 +21,7 @@ import {
   frozenReplyContextForTurn,
   isSubstituteTurn,
   pickTurnReplyTarget,
+  resolveInboundReplyTarget,
   resolveSessionReplyTarget,
 } from '../src/core/reply-target.js';
 import type { DaemonSession } from '../src/core/types.js';
@@ -110,6 +111,44 @@ describe('fallbackTurnId × resolveSessionReplyTarget (the leak fix)', () => {
     });
     const target = resolveSessionReplyTarget(ds, fallbackTurnId(ds as DaemonSession, undefined));
     expect(target).toEqual({ mode: 'quote', rootMessageId: 'om_trigger' });
+  });
+});
+
+describe('resolveInboundReplyTarget', () => {
+  it('anchors a chat-scope thread reply to the inbound reply root', () => {
+    expect(resolveInboundReplyTarget({
+      scope: 'chat',
+      chatId: 'oc_chat',
+      threadRootId: 'om_session_root',
+      replyRootId: 'om_reply_root',
+    })).toEqual({ mode: 'thread', rootMessageId: 'om_reply_root' });
+  });
+
+  it('keeps a chat-scope message without a reply root at chat top level', () => {
+    expect(resolveInboundReplyTarget({
+      scope: 'chat',
+      chatId: 'oc_chat',
+      threadRootId: 'om_session_root',
+    })).toEqual({ mode: 'plain', chatId: 'oc_chat' });
+  });
+
+  it('anchors a thread-scope message to the session thread root', () => {
+    expect(resolveInboundReplyTarget({
+      scope: 'thread',
+      chatId: 'oc_chat',
+      threadRootId: 'om_session_root',
+      replyRootId: 'om_child_reply_root',
+    })).toEqual({ mode: 'thread', rootMessageId: 'om_session_root' });
+  });
+
+  it('uses ordinary quote semantics for a quote-only chat-scope reply', () => {
+    expect(resolveInboundReplyTarget({
+      scope: 'chat',
+      chatId: 'oc_chat',
+      threadRootId: 'om_session_root',
+      replyRootId: 'om_quote_root',
+      quoteOnly: true,
+    })).toEqual({ mode: 'quote', rootMessageId: 'om_quote_root' });
   });
 });
 

--- a/test/session-adopt.test.ts
+++ b/test/session-adopt.test.ts
@@ -18,6 +18,9 @@ vi.mock('../src/im/lark/client.js', () => ({
   updateMessage: vi.fn(async () => {}),
   sendUserMessage: vi.fn(async () => {}),
   deleteMessage: vi.fn(async () => {}),
+  getMessageDetail: vi.fn(async () => ({
+    items: [{ chat_id: 'oc_chat', thread_id: 'omt_adopt_picker' }],
+  })),
   getChatInfo: vi.fn(),
   MessageWithdrawnError: class MessageWithdrawnError extends Error {
     constructor(id: string) { super(`withdrawn: ${id}`); this.name = 'MessageWithdrawnError'; }
@@ -153,7 +156,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 import { handleCardAction, type CardHandlerDeps } from '../src/im/lark/card-handler.js';
 import { killWorker, forkWorker, setActiveSessionsRegistry } from '../src/core/worker-pool.js';
 import * as sessionStore from '../src/services/session-store.js';
-import { deleteMessage } from '../src/im/lark/client.js';
+import { deleteMessage, getMessageDetail } from '../src/im/lark/client.js';
 import { getBot } from '../src/bot-registry.js';
 import { listCodexAppThreads } from '../src/services/codex-app-threads.js';
 import { sessionKey } from '../src/core/types.js';
@@ -251,6 +254,9 @@ describe('Adopt card actions', () => {
       botOpenId: 'ou_bot',
     } as any);
     vi.mocked(listCodexAppThreads).mockResolvedValue([]);
+    vi.mocked(getMessageDetail).mockResolvedValue({
+      items: [{ chat_id: 'oc_chat', thread_id: 'omt_adopt_picker' }],
+    });
   });
 
   // ── Disconnect ──────────────────────────────────────────────────────────
@@ -408,13 +414,62 @@ describe('Adopt card actions', () => {
       await handleCardAction(makeAdoptSelectEvent(ROOT_ID, 'live:tmux:0:1.0:99999'), deps, APP_ID);
       await flush();
 
+      expect(getMessageDetail).toHaveBeenCalledWith(APP_ID, 'om_card_msg');
       expect(deps.sessionReply).toHaveBeenCalledWith(
         ROOT_ID,
         expect.stringContaining('已退出'),
         undefined,
         APP_ID,
+        undefined,
+        { replyTarget: { mode: 'thread', rootMessageId: 'om_card_msg' } },
       );
       expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card_msg');
+
+      vi.doUnmock('../src/core/session-discovery.js');
+    });
+
+    it('falls back to the legacy route when the picker placement probe fails', async () => {
+      vi.doMock('../src/core/session-discovery.js', () => ({
+        discoverAdoptableSessions: vi.fn(() => []),
+        discoverAdoptableSessionByTarget: vi.fn(() => undefined),
+        excludeOwnedHerdrAdoptTargets: vi.fn((sessions: unknown[]) => sessions),
+        adoptTargetKey: vi.fn((s: any) => `tmux:${s.tmuxTarget}:${s.cliPid}`),
+        adoptTargetLabel: vi.fn(() => ''),
+      }));
+      vi.mocked(getMessageDetail).mockRejectedValueOnce(new Error('placement unavailable'));
+      const sessions = new Map<string, DaemonSession>();
+      sessions.set(sessionKey(ROOT_ID, APP_ID), makeDaemonSession());
+      const deps = makeDeps(sessions);
+
+      await handleCardAction(makeAdoptSelectEvent(ROOT_ID, 'live:tmux:0:1.0:99999'), deps, APP_ID);
+      await flush();
+
+      expect(deps.sessionReply).toHaveBeenCalled();
+      expect(vi.mocked(deps.sessionReply).mock.calls[0]?.[5]).toBeUndefined();
+      expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card_msg');
+
+      vi.doUnmock('../src/core/session-discovery.js');
+    });
+
+    it('freezes a top-level picker confirmation to its trusted chat', async () => {
+      vi.doMock('../src/core/session-discovery.js', () => ({
+        discoverAdoptableSessions: vi.fn(() => []),
+        discoverAdoptableSessionByTarget: vi.fn(() => undefined),
+        excludeOwnedHerdrAdoptTargets: vi.fn((sessions: unknown[]) => sessions),
+        adoptTargetKey: vi.fn((s: any) => `tmux:${s.tmuxTarget}:${s.cliPid}`),
+        adoptTargetLabel: vi.fn(() => ''),
+      }));
+      vi.mocked(getMessageDetail).mockResolvedValueOnce({ items: [{ chat_id: 'oc_chat' }] });
+      const sessions = new Map<string, DaemonSession>();
+      sessions.set(sessionKey(ROOT_ID, APP_ID), makeDaemonSession());
+      const deps = makeDeps(sessions);
+
+      await handleCardAction(makeAdoptSelectEvent(ROOT_ID, 'live:tmux:0:1.0:99999'), deps, APP_ID);
+      await flush();
+
+      expect(vi.mocked(deps.sessionReply).mock.calls[0]?.[5]).toEqual({
+        replyTarget: { mode: 'plain', chatId: 'oc_chat' },
+      });
 
       vi.doUnmock('../src/core/session-discovery.js');
     });


### PR DESCRIPTION
## 问题

普通群或私聊中的 chat-scope 会话可以折叠进话题，但 daemon slash command 会在普通 turn 注册前提前返回，因此本次调用没有稳定的话题回复目标。`/close`、`/detach`、mid-session `/repo` 还会先删除或替换 live session；后续再依赖可变 session 状态回复时，就会退化为群/私聊顶层消息。普通群的 ephemeral API 又不支持 thread 锚点，会让关闭卡片直接逃到群顶层。

## 变更

- 从入站 routing context 冻结本次命令的 Lark 回复目标，并通过 invocation-bound command deps 统一传递给通用 daemon command handler、`/card`、`/term` 与 sessionless command 路径。
- lifecycle confirmation 在显式 thread/quote 目标下跳过无话题锚点的 ephemeral；普通群顶层仍保留原有仅自己可见行为。
- `/adopt` 选择卡的后续成功/错误回复通过 `open_message_id` 查询服务端真实卡片位置，校验 chat 后冻结为 thread 或 plain 目标；不信任 action value 中的路由字段。
- 增加生产路由回归，覆盖 `/t` 后 `/adopt`、单消息 `/t /adopt`、chat-scope `/adopt`、群/私聊 `/close`、native thread `/close`、`/detach`、mid-session `/repo` 与权限拒绝回复。

`/t /adopt` 的组合解析在现有实现中已经可用，本 PR 将其作为正式回归契约锁定。

## 影响面

- 影响 Lark 命令回复的可见落点，与 CLI 类型、PTY/Tmux 等后端无关。
- 覆盖普通群话题折叠、私聊话题与原生 thread；普通群顶层回复语义保持不变。
- 不修改 Session 持久化结构、store-first 写入顺序、close/replace 事务或 active session 删除语义；回复位置是与 session 生命周期分离的只读调用上下文，符合 `docs/design/2026-08-12-session-restage-store-first.md` 的边界。
- 本次仅延伸修复 adopt picker 的 card callback；其他 card callback 与 `/vc-auth` 等特殊直发路径不在本 PR 范围。
- 卡片内容与视觉没有变化，仅修正发送位置。

## 验证

- `pnpm build`：通过（已在 rebase 后的 `origin/master@40f31f76` 上复跑）
- `BOTS_CONFIG= pnpm vitest run --project unit test/command-handler.test.ts test/daemon-rename-route.test.ts test/ephemeral-or-reply.test.ts test/initial-passthrough-ownership.test.ts test/reply-target-fallback.test.ts test/session-adopt.test.ts`：6 files / 403 tests passed
- `BOTS_CONFIG= pnpm test -- --reporter=dot --silent=passed-only --hideSkippedTests`：920 files passed、4 skipped；15053 tests passed、37 skipped
- `git diff --check`：通过

按验证约束未执行 `pnpm switch:here`、`pnpm use:here` 或任何 daemon restart，也未切换 live checkout。
