### PR TITLE
fix(ci): 消除测试夹具时序竞态

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,10 +189,12 @@ pnpm test:bench --compare   # serial vs parallel vs parallel+time-scale table
 
 ### Timing-Sensitive Test Contract
 
-- Treat `ready` as a happens-before barrier, not a progress log: publish it only
-  after every handler, listener, resource, and durable state needed by the
-  parent's next action is installed.
-- Establish preconditions through observable events or state. Fixed sleeps may
+- Treat a test fixture's `ready` handshake as a happens-before barrier, not a
+  progress log: publish it only after every handler, listener, resource, and
+  durable state needed by the parent's next action is installed.
+- Establish preconditions and postconditions through the exact observable event
+  or state under assertion. Do not infer sibling or downstream telemetry from a
+  lifecycle event unless its contract explicitly orders them. Fixed sleeps may
   model intentional timing or bound a hang, but must not stand in for readiness.
 - Make scheduler-sensitive ordering deterministic in the fixture. Widen a
   timeout only for proven slow-but-progressing work, and never use retries to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,3 +186,15 @@ pnpm test:bench --compare   # serial vs parallel vs parallel+time-scale table
 > `src/utils/timing.ts`, default `1` = unchanged in production) multiplies every
 > such delay. Filesystem-mocked unit tests set it small to collapse those waits.
 > See [`docs/test-benchmark.md`](docs/test-benchmark.md).
+
+### Timing-Sensitive Test Contract
+
+- Treat `ready` as a happens-before barrier, not a progress log: publish it only
+  after every handler, listener, resource, and durable state needed by the
+  parent's next action is installed.
+- Establish preconditions through observable events or state. Fixed sleeps may
+  model intentional timing or bound a hang, but must not stand in for readiness.
+- Make scheduler-sensitive ordering deterministic in the fixture. Widen a
+  timeout only for proven slow-but-progressing work, and never use retries to
+  mask a missing barrier or known race.
+- Keep every wait bounded and make timeout errors identify the unmet condition.

--- a/test/producer-quiescence.test.ts
+++ b/test/producer-quiescence.test.ts
@@ -28,8 +28,8 @@ async function spawnChild(opts: { holdStdoutMs?: number } = {}): Promise<ChildPr
     // (but not our IPC 'disconnect') — the fd-inheritance scenario.
     cp.spawn(process.execPath, ['-e', 'setTimeout(()=>{}, ${opts.holdStdoutMs})'], { stdio: ['ignore', 'inherit', 'ignore'] });
     ` : ''}
-    process.send && process.send({ ready: true });
     setInterval(() => {}, 100000);
+    process.send && process.send({ ready: true });
   `;
   const child = spawn(process.execPath, ['-e', src], { stdio: ['ignore', 'pipe', 'pipe', 'ipc'] });
   kids.push(child);

--- a/test/shutdown-quiescence-orchestration.test.ts
+++ b/test/shutdown-quiescence-orchestration.test.ts
@@ -146,8 +146,10 @@ describe('shutdown reaping / producer-fence separation (real ChildProcess)', () 
   const kids: ChildProcess[] = [];
   afterEach(() => { for (const k of kids.splice(0)) { try { k.kill('SIGKILL'); } catch { /* */ } } });
 
-  async function spawnIpcChild(body: string): Promise<ChildProcess> {
-    const child = spawn(process.execPath, ['-e', `process.send && process.send({ready:true}); ${body}`], { stdio: ['ignore', 'pipe', 'pipe', 'ipc'] });
+  async function spawnIpcChild(setup: string): Promise<ChildProcess> {
+    // `ready` is a happens-before barrier: the parent signals immediately after
+    // it, so every handler needed by that signal must already be installed.
+    const child = spawn(process.execPath, ['-e', `${setup}\nprocess.send?.({ ready: true });`], { stdio: ['ignore', 'pipe', 'pipe', 'ipc'] });
     kids.push(child);
     await new Promise<void>((res, rej) => { const t = setTimeout(() => rej(new Error('no ready')), 5000); child.once('message', (m: any) => { if (m?.ready) { clearTimeout(t); res(); } }); });
     return child;

--- a/test/worker-argv-reaction-status.integration.test.ts
+++ b/test/worker-argv-reaction-status.integration.test.ts
@@ -38,21 +38,25 @@ async function waitForScreenUpdates(
   messages: WorkerToDaemon[],
   count: number,
   logs: string[],
+  predicate: (
+    message: Extract<WorkerToDaemon, { type: 'screen_update' }>,
+  ) => boolean = () => true,
+  description = 'screen updates',
 ): Promise<Array<Extract<WorkerToDaemon, { type: 'screen_update' }>>> {
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     const updates = messages.filter(
       (message): message is Extract<WorkerToDaemon, { type: 'screen_update' }> =>
-        message.type === 'screen_update',
+        message.type === 'screen_update' && predicate(message),
     );
     if (updates.length >= count) return updates;
     if (child.exitCode !== null || child.signalCode !== null) {
-      throw new Error(`worker exited before ${count} screen updates\n${logs.join('')}`);
+      throw new Error(`worker exited before ${count} ${description}\n${logs.join('')}`);
     }
     await new Promise(resolvePromise => setTimeout(resolvePromise, 25));
   }
   throw new Error(
-    `timed out waiting for ${count} screen updates: ${JSON.stringify(messages)}\n${logs.join('')}`,
+    `timed out waiting for ${count} ${description}: ${JSON.stringify(messages)}\n${logs.join('')}`,
   );
 }
 
@@ -246,7 +250,14 @@ setInterval(() => {}, 1_000);
     // clear redraw's quiescence, whichever matures first).
     await waitForPromptReady(child, messages, logs);
 
-    const updates = await waitForScreenUpdates(child, messages, 1, logs);
+    const updates = await waitForScreenUpdates(
+      child,
+      messages,
+      1,
+      logs,
+      update => update.status === 'idle',
+      'idle screen update',
+    );
     expect(updates.at(-1)?.status).toBe('idle');
   }, 25_000);
 
@@ -329,7 +340,14 @@ setInterval(() => {}, 1_000);
     expect(workingBeforeReady.length, JSON.stringify(messages)).toBe(1);
 
     // Once the fake clears Working..., the turn settles idle as usual.
-    const updates = await waitForScreenUpdates(child, messages, 1, logs);
+    const updates = await waitForScreenUpdates(
+      child,
+      messages,
+      1,
+      logs,
+      update => update.status === 'idle',
+      'idle screen update',
+    );
     expect(updates.at(-1)?.status).toBe('idle');
   }, 25_000);
 

--- a/test/zmx-backend-helpers.test.ts
+++ b/test/zmx-backend-helpers.test.ts
@@ -616,7 +616,9 @@ describe('zmx backend pure helpers', () => {
       env: { PATH: '/usr/bin:/bin', HOME: root },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    const exitPromise = waitForExit(child, 8000);
+    // Starts at spawn: 5s readiness + 3s history grace + 2s execution/scheduler slack.
+    // The outer 12s test deadline leaves roughly 2s for assertions and cleanup.
+    const exitPromise = waitForExit(child, 10_000);
     try {
       await waitForFileContent(readyPath, `${readyNonce}\n`, 5000);
       writeFileSync(releaseTempPath, `${releaseToken}\n`, { mode: 0o600, flag: 'wx' });
@@ -630,5 +632,5 @@ describe('zmx backend pure helpers', () => {
     } finally {
       if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
     }
-  }, 10_000);
+  }, 12_000);
 });

--- a/test/zmx-backend-helpers.test.ts
+++ b/test/zmx-backend-helpers.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, renameSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -54,16 +54,27 @@ function makeExecutableShell(name: 'fish' | 'sh'): string {
   return shellPath;
 }
 
-function waitForPath(path: string, timeoutMs: number): Promise<void> {
+function waitForFileContent(path: string, expected: string, timeoutMs: number): Promise<void> {
   const startedAt = Date.now();
+  let lastObserved = '<missing>';
   return new Promise((resolve, reject) => {
     const poll = () => {
-      if (existsSync(path)) {
-        resolve();
-        return;
+      try {
+        const value = readFileSync(path, 'utf8');
+        lastObserved = JSON.stringify(value);
+        if (value === expected) {
+          resolve();
+          return;
+        }
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          lastObserved = `<read error: ${err instanceof Error ? err.message : String(err)}>`;
+        }
       }
       if (Date.now() - startedAt >= timeoutMs) {
-        reject(new Error(`Timed out waiting for ${path}`));
+        reject(new Error(
+          `Timed out waiting for ${path} to contain ${JSON.stringify(expected)}; last observed ${lastObserved}`,
+        ));
         return;
       }
       setTimeout(poll, 10);
@@ -72,15 +83,30 @@ function waitForPath(path: string, timeoutMs: number): Promise<void> {
   });
 }
 
-function waitForExit(child: ReturnType<typeof spawn>): Promise<{ readonly code: number | null; readonly stdout: string; readonly stderr: string }> {
+function waitForExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number,
+): Promise<{ readonly code: number | null; readonly stdout: string; readonly stderr: string }> {
   let stdout = '';
   let stderr = '';
   child.stdout?.setEncoding('utf8');
   child.stderr?.setEncoding('utf8');
   child.stdout?.on('data', chunk => { stdout += chunk; });
   child.stderr?.on('data', chunk => { stderr += chunk; });
-  return new Promise((resolve) => {
-    child.on('close', code => {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(
+        `Timed out after ${timeoutMs}ms waiting for generated ZMX launch to exit; ` +
+        `stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`,
+      ));
+    }, timeoutMs);
+    child.once('error', err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.once('close', code => {
+      clearTimeout(timeout);
       resolve({ code, stdout, stderr });
     });
   });
@@ -556,6 +582,7 @@ describe('zmx backend pure helpers', () => {
     const payloadPath = join(launchDir, 'payload.fish');
     const readyPath = join(launchDir, 'ready');
     const releasePath = join(launchDir, 'release');
+    const releaseTempPath = join(launchDir, 'release.tmp');
     const outputPath = join(root, 'cli-output.txt');
     const readyNonce = '0123456789abcdef0123456789abcdef';
     const releaseToken = 'fedcba9876543210fedcba9876543210';
@@ -589,15 +616,19 @@ describe('zmx backend pure helpers', () => {
       env: { PATH: '/usr/bin:/bin', HOME: root },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    const exitPromise = waitForExit(child);
-    await waitForPath(readyPath, 1000);
-    expect(readFileSync(readyPath, 'utf8')).toBe(`${readyNonce}\n`);
-    writeFileSync(releasePath, `${releaseToken}\n`);
-    const result = await exitPromise;
+    const exitPromise = waitForExit(child, 8000);
+    try {
+      await waitForFileContent(readyPath, `${readyNonce}\n`, 5000);
+      writeFileSync(releaseTempPath, `${releaseToken}\n`, { mode: 0o600, flag: 'wx' });
+      renameSync(releaseTempPath, releasePath);
+      const result = await exitPromise;
 
-    expect(result).toMatchObject({ code: 0 });
-    expect(result.stderr).not.toContain(payloadPath);
-    expect(readFileSync(outputPath, 'utf8')).toBe(`PWD:${workDir}\nSAFE:fish-safe\nARG:fish-arg\n`);
-    expect(existsSync(payloadPath)).toBe(false);
+      expect(result).toMatchObject({ code: 0 });
+      expect(result.stderr).not.toContain(payloadPath);
+      expect(readFileSync(outputPath, 'utf8')).toBe(`PWD:${workDir}\nSAFE:fish-safe\nARG:fish-arg\n`);
+      expect(existsSync(payloadPath)).toBe(false);
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    }
   }, 10_000);
 });


### PR DESCRIPTION
## 背景

PR #852 的两次 CI 均只有同一条关机时序用例失败：前置的“未发送 SIGKILL”断言已经通过，最终却得到 `exitCode=null`。这说明子进程是在宽限窗内被信号终止，并非 runner 太慢导致窗口耗尽。

根因是测试夹具先发送 `ready`，之后才安装 SIGTERM handler。父进程收到 `ready` 后立即发 SIGTERM；负载较高时，信号会落在这个空窗中，触发 Node 默认退出。原顺序压力复现能观察到 `signalCode=SIGTERM`，调整顺序后 200/200 均以 code 0 退出。

首轮 CI 还暴露了一处既有的等待条件竞态：worker 依次发送 `prompt_ready` 和 idle `screen_update`，测试看到前者后却只等待“累计至少一条 screen_update”。此前的 working 更新已经满足该条件，因此父进程可合法观察到消息前缀并立即拿旧 working 做 idle 断言。相同签名在本 PR 之前已有多次 CI 记录。

## 改了什么

- `shutdown-quiescence-orchestration`：先完成子进程 setup、安装信号 handler，再发布 `ready`。
- `producer-quiescence`：keepalive 也是 ready 后场景成立的必要条件，调整为建立后再发布 `ready`。
- `worker-argv-reaction-status`：等待 helper 支持目标状态谓词；两处同形调用显式等待 idle `screen_update`，不再由历史 working 误满足。
- `zmx-backend-helpers`：latest master 扫描发现文件握手夹具只等路径存在、并直接写最终 release 路径；改为等待完整 nonce、用同目录 temp + rename 原子发布 release，并为 exit wait 加入有诊断的界限与清理。
- ZMX exit timer 从 spawn 起算；预算调整为 5 秒 readiness + 3 秒固定 history grace + 2 秒执行/调度余量（内部 10 秒），Vitest 外层 12 秒再为断言与清理保留约 2 秒。
- `CONTRIBUTING.md`：增加 timing-sensitive test contract，明确 fixture ready 的 happens-before 语义、目标可观察状态等待，以及 timeout/retry 的使用边界。
- 不增加 retry，不改生产代码。

## latest master 扫描

分支按前轮要求 rebase 到 `d66ae1093`，并扫描该基线新增/修改的 24 个测试文件及 CI 配置。当前 master 已前进到 `ade903aca`；其后续提交未触碰本 PR 的 5 个文件，merge-tree 无冲突，最终 head 的 GitHub merge-ref 全量 CI 通过。

- CI workflow、Vitest、package/lockfile、tsconfig 均未变化。
- latest master 的红灯仍是本 PR 已修的 shutdown A/B 同一竞态，不是 fish、slash、route 或 opencode2 新测试失败。
- 历史 Actions 中，新增的 adopt-route、opencode2、slash、thread/adopt、fish/zmx 测试未发现重复 flake；唯一早期 source-lock 失败为确定性遗漏，已在合入 master 前修正。
- 修复了 ZMX 文件握手的真实竞态。另有 fish 条件测试的同步进程缺少独立 timeout、adopt-route 的低风险真实墙钟断言，均未在现有 Actions 历史中失败；不扩入本次修复。

## 影响面

仅修改真实子进程测试夹具、集成测试等待 helper 和贡献者文档。生产关机/worker 状态逻辑、CLI 适配器、Pty/Tmux/ZMX 后端、话题/群/adopt/restore/sandbox 等会话路径均不变。修复消除 macOS/Linux Node 子进程调度、IPC 消费与文件发布时机差异。

## 验证

- `pnpm exec vitest run --project unit test/zmx-backend-helpers.test.ts test/shutdown-quiescence-orchestration.test.ts test/producer-quiescence.test.ts`：41 passed / 1 条无 fish 环境条件跳过。
- fish 3.6.0 补充环境验证：`zmx-backend-helpers` 全文件 25/25 通过，live 用例连续 6/6 通过。
- 原关机相关两文件 17/17、worker argv 6/6 通过；`pnpm exec tsc --noEmit`、`pnpm build` 通过。
- [GitHub CI run 31730864500](https://github.com/deepcoldy/botmux/actions/runs/31730864500) 在修正前 HEAD `5c321b7fc` 上串行完成 3 轮 `CI / build`（attempt 1–3）：每轮 925 个测试文件 / 15157 个测试与 `workflow-core:test` 均通过；31 个测试按条件跳过。
- [GitHub CI run 31764076344](https://github.com/deepcoldy/botmux/actions/runs/31764076344) 在最终 HEAD `b49464631` 上通过：927 个测试文件 / 15167 个测试、`workflow-core:test` 全绿；31 个测试按条件跳过。
- 最终 head 的目标文件均通过：`shutdown-quiescence-orchestration` 5/5、`producer-quiescence` 12/12、`worker-argv-reaction-status.integration` 6/6、`zmx-backend-helpers` 24/24（另 1 条 runner 无 fish 时按条件跳过）。
- 最终 push 自动触发的 CodeQL actions / JavaScript-TypeScript / Python / 汇总检查全部通过；没有手动重复运行 CodeQL。
