### PR TITLE
feat(send): botmux send --slash 发原生斜杠命令给 bot 消费 + acceptSlashFromBots 开关

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -851,7 +851,7 @@ export interface RelayRequest {
 // (--chat-id/--into/--top-level), and --session-id are NOT allowlisted:
 // content/attachments come from validated outbox files, and session-id is
 // forced by the worker.
-const RELAY_FLAGS_NOVAL = new Set(['--mention-back', '--no-mention', '--no-quote', '--voice']);
+const RELAY_FLAGS_NOVAL = new Set(['--mention-back', '--no-mention', '--no-quote', '--voice', '--slash']);
 const RELAY_FLAGS_VAL = new Set(['--mention', '--quote', '--response-kind']);
 
 export interface ValidatedRelay {

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1362,6 +1362,20 @@ export interface BotConfig {
    */
   p2pOpen?: boolean;
   /**
+   * 是否接受**其他 bot** 通过 `botmux send --slash` 发来的原生斜杠命令
+   * （/clear、/model、/close…）。默认开（undefined = 开）；只有显式 false 才关。
+   *
+   * 关掉后，来自 bot 发送方的 slash 命令不进 passthrough / daemon-command 路由，
+   * 退化为普通消息（与任何非 bot-slash 消息一样按 talk 门处理）——给 owner 一个
+   * 「不让别的 bot 清我上下文 / 敲我 CLI」的逃生阀。对**真人**发送方无影响
+   * （真人在飞书直接打字发 /clear 仍照常）。
+   *
+   * 安全边界不变：daemon 管理命令（/close /restart 等）从 bot 来**仍只认
+   * allowedUsers**（canOperate），本开关只控制「是否接受 bot 的 slash 进入路由」，
+   * 不放宽任何 operate 权限。
+   */
+  acceptSlashFromBots?: boolean;
+  /**
    * 消息额度覆盖配置：
    *   • 未配置（undefined）→ 卡片使用产品默认 3 条；oncall 不自动计数。
    *   • 配置正整数 D    → 卡片默认 D 条，同时作为 oncall 默认额度。
@@ -2178,6 +2192,15 @@ export function getBotTuiSlashAllow(larkAppId: string): string[] | undefined {
 }
 
 /**
+ * 该 bot 是否接受**其他 bot** 发来的原生斜杠命令（--slash）。默认开：只有
+ * 配置里显式 `acceptSlashFromBots: false` 才关。未知 bot（无注册项）→ 默认开
+ * （与其它 default-on 开关一致，缺配置不 fail-closed 成"全拒"）。
+ */
+export function botAcceptsSlashFromBots(larkAppId: string): boolean {
+  return bots.get(larkAppId)?.config.acceptSlashFromBots !== false;
+}
+
+/**
  * Load bot configurations from one of (in priority order):
  * 1. BOTS_CONFIG env var — path to a JSON file
  * 2. ~/.botmux/bots.json — default config path
@@ -2797,6 +2820,8 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       restrictGrantCommands: entry.restrictGrantCommands === true || undefined,
       // Default is ON, so only explicit false is meaningful/persisted.
       autoGrantRequestCards: entry.autoGrantRequestCards === false ? false : undefined,
+      // Default is ON (accept bot-sent slash), so only explicit false persists.
+      acceptSlashFromBots: entry.acceptSlashFromBots === false ? false : undefined,
       customPassthroughCommands,
       canTalkDaemonCommands,
       tuiSlashAllow,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,7 +127,7 @@ import {
   startExactPm2ProcessIds,
   type Pm2ExactStartClient,
 } from './cli/pm2-exact-start.js';
-import { dispatchPrimaryMessage, findStdinAliasAttachment, normalizeInteractiveCardInput, sendFileAttachments, sendVideoAttachments, shouldSendAsPureVideo, validateVideoAttachments } from './cli/send-dispatch.js';
+import { dispatchPrimaryMessage, findStdinAliasAttachment, normalizeInteractiveCardInput, sendFileAttachments, sendVideoAttachments, shouldSendAsPureVideo, validateSlashSend, validateVideoAttachments } from './cli/send-dispatch.js';
 import { dispatchDeferredTopicSend, reusableDeferredTopicRoot, type DeferredScheduleRunData } from './cli/deferred-topic-send.js';
 import { readDeferredTopicBinding } from './core/deferred-topic-binding.js';
 import { resolveDaemonEnv } from './cli/daemon-lifecycle-env.js';
@@ -7910,7 +7910,7 @@ async function relaySend(
     // the dashboard hand anyway; excluding it would silently send the reason as a
     // bare message instead of the original loud "no content" failure. Plumbing
     // `--attention` through the relay is a separate change, out of this scope.
-    const pos = positionals(rest, ['--card', '--text', '--top-level', '--no-quote', '--mention-back', '--no-mention', '--anyway', '--voice']);
+    const pos = positionals(rest, ['--card', '--text', '--top-level', '--no-quote', '--mention-back', '--no-mention', '--anyway', '--voice', '--slash']);
     content = pos.length > 0 ? pos.join(' ') : await readStdin();
   }
   const preparedCardContent = cardJsonArg === undefined && cardFile === undefined && !rest.includes('--voice')
@@ -7969,7 +7969,7 @@ async function relaySend(
   // Forward only presentation flags (must match the watcher's allowlist); path,
   // routing (--chat-id/--into/--top-level) and --session-id flags are dropped —
   // content/attachments come from the outbox and session-id is forced host-side.
-  const FLAGS_NOVAL = new Set(['--mention-back', '--no-mention', '--no-quote', '--voice']);
+  const FLAGS_NOVAL = new Set(['--mention-back', '--no-mention', '--no-quote', '--voice', '--slash']);
   const FLAGS_VAL = new Set(['--mention', '--quote', '--response-kind']);
   const flags: string[] = [];
   for (let i = 0; i < rest.length; i++) {
@@ -8738,6 +8738,29 @@ async function cmdSend(rest: string[]): Promise<void> {
     console.error('botmux send: --card-file/--card-json 不能与 --voice 混用');
     process.exit(2);
   }
+  // --slash: send a NATIVE slash command (e.g. /clear /model /close) as a
+  // single-line plain-`text` message instead of the usual interactive card.
+  // The card path appends a `[🔊 语音总结]` footer, turning the body multi-line
+  // so the receiving daemon's parseSlashCommandInvocation drops it to an
+  // ordinary prompt (never reaching the passthrough / daemon-command router).
+  // A --slash send skips the card so a peer bot (or self) can consume it. It is
+  // deliberately exclusive with every richer payload — a slash command is one
+  // line of text, nothing else.
+  const isSlashSend = rest.includes('--slash');
+  if (isSlashSend) {
+    if (customCardRequested || asVoice) {
+      console.error('botmux send: --slash 不能与 --card-file/--card-json/--voice 混用（斜杠命令只发单行纯文本）');
+      process.exit(2);
+    }
+    if (images.length > 0 || files.length > 0 || videos.length > 0 || videoCovers.length > 0) {
+      console.error('botmux send: --slash 不能带附件（--images/--files/--videos）；斜杠命令只发单行纯文本');
+      process.exit(2);
+    }
+    if (attention.requested) {
+      console.error('botmux send: --slash 不能与 --attention 混用');
+      process.exit(2);
+    }
+  }
 
   const sid = sessionIdArg ?? ancestorCtx?.sessionId ?? process.env.BOTMUX_SESSION_ID ?? null;
   if (!sid) {
@@ -8964,7 +8987,7 @@ async function cmdSend(rest: string[]): Promise<void> {
     if (!existsSync(contentFile)) { console.error(`文件不存在: ${contentFile}`); process.exit(1); }
     content = readFileSync(contentFile, 'utf-8');
   } else {
-    const pos = positionals(rest, ['--card', '--text', '--top-level', '--no-quote', '--mention-back', '--no-mention', '--anyway', '--voice', '--attention']);
+    const pos = positionals(rest, ['--card', '--text', '--top-level', '--no-quote', '--mention-back', '--no-mention', '--anyway', '--voice', '--attention', '--slash']);
     if (pos.length > 0) {
       content = pos.join(' ');
     } else {
@@ -9755,7 +9778,9 @@ async function cmdSend(rest: string[]): Promise<void> {
       // --no-mention 显式不 @ 任何人：跳过正文 @BotName 的自动注入，否则正文里
       // 出现的 @名字 仍会被注入成 <at>，破坏 --no-mention 语义、还可能误触发对方
       // bot（正是要避免的循环 @）。botEntries/crossRef 仍需加载供 footer 寻址用。
-      if (!noMention && !vcMeetingManagedSendOrigin) {
+      // --slash 同理跳过：斜杠命令正文（如 `/clear`）不该被扫成 @，收件人只认
+      // 显式 --mention（下面的 slash 分支只用 explicit mentions 拼 <at> 前缀）。
+      if (!noMention && !isSlashSend && !vcMeetingManagedSendOrigin) {
       const alreadyMentioned = new Set(mentions.map(m => m.open_id));
       // Scan a code-span-stripped copy so a bot name quoted inside backticks or a
       // fenced block (e.g. an example `botmux send --mention @Bot …` or an
@@ -9888,6 +9913,19 @@ async function cmdSend(rest: string[]): Promise<void> {
         });
     if (customCard) {
       messageId = await dispatchPrimary(JSON.stringify(customCard), 'interactive');
+    } else if (isSlashSend) {
+      // --slash: deliver the command as a single-line plain-`text` message so the
+      // receiving daemon's parseSlashCommandInvocation sees a bare `/cmd` (the
+      // card path's `[🔊 语音总结]` footer would make it multi-line and demote it
+      // to an ordinary prompt). Inline an `<at>` for each --mention so a peer
+      // bot in a group is actually triggered AND the receiver can strip the
+      // mention back to a clean command (Feishu keys the <at>, the receiver's
+      // resolveMentions→stripLeadingMentions removes the leading `@Name`).
+      const slash = validateSlashSend(content);
+      if (!slash.ok) { console.error(`botmux send: ${slash.error}`); process.exit(2); }
+      const atPrefix = mentions.map(m => `<at user_id="${m.open_id}"></at>`).join(' ');
+      const slashText = atPrefix ? `${atPrefix} ${slash.command}` : slash.command;
+      messageId = await dispatchPrimary(slashText, 'text');
     } else if (pureVideoSend) {
       // Pure-video fast path: send the preview as a standalone media message.
       // A send that also carries mentions is deliberately excluded (media messages

--- a/src/cli/send-dispatch.ts
+++ b/src/cli/send-dispatch.ts
@@ -46,6 +46,40 @@ export function findStdinAliasAttachment(paths: readonly string[]): string | nul
   return null;
 }
 
+export type SlashSendValidation =
+  | { ok: true; command: string }
+  | { ok: false; error: string };
+
+/**
+ * Validate the body of a `botmux send --slash "<cmd>"`.
+ *
+ * `--slash` exists so one bot can hand another a NATIVE slash command that the
+ * receiving daemon relays into the CLI verbatim (passthrough: /clear, /model,
+ * …) or routes as a daemon command (/close, …). The ordinary `send` path wraps
+ * every message in an interactive card whose body picks up a `[🔊 语音总结]`
+ * footer line, so the receiver sees a MULTI-LINE message and
+ * `parseSlashCommandInvocation` (which only treats /schedule|/role|/fork as
+ * multi-line commands) drops it to an ordinary prompt — the command never
+ * reaches the passthrough/daemon router. A `--slash` send therefore MUST go out
+ * as a single-line plain-`text` message.
+ *
+ * Fail LOUD rather than silently sending junk: the content has to be exactly one
+ * line and start with `/`. Leading/trailing whitespace is trimmed (a trailing
+ * newline from a heredoc is the common case); an interior newline is rejected so
+ * the caller notices instead of the daemon quietly treating it as prose.
+ */
+export function validateSlashSend(raw: string): SlashSendValidation {
+  const command = raw.trim();
+  if (!command) return { ok: false, error: '--slash 需要一条斜杠命令，例如 --slash "/clear"' };
+  if (/[\r\n]/.test(command)) {
+    return { ok: false, error: '--slash 只能发送单行斜杠命令（收到含换行的多行内容）' };
+  }
+  if (!command.startsWith('/')) {
+    return { ok: false, error: `--slash 内容必须以 / 开头（收到 ${JSON.stringify(command.slice(0, 24))}）` };
+  }
+  return { ok: true, command };
+}
+
 export type SendFileAttachmentsDeps = {
   uploadFile: (appId: string, path: string) => Promise<string>;
   dispatch: (content: string, msgType: string) => Promise<string>;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -66,6 +66,7 @@ import {
   setResolvedAllowedUsersRepublishHook,
   setAllowedUsersResolveRetryHook,
   vcMeetingAgentConfigActive,
+  botAcceptsSlashFromBots,
   type BotConfig,
   type BotState,
   type OncallChat,
@@ -17183,7 +17184,14 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
   }
 
   // Intercept daemon commands in new topics (no session needed for some commands)
-  const invocation = parseSlashCommandInvocation(cmdContent);
+  // acceptSlashFromBots gate: a bot sender's slash command is only routed as a
+  // command when this bot opts in (default on). When off, fall through to
+  // ordinary message handling — the peer bot can still talk, it just can't drive
+  // /clear /model /close … into this bot. Human senders are never gated here.
+  const senderIsBotForSlashGate = isBotSenderType || isForeignBotSender;
+  const invocation = (senderIsBotForSlashGate && !botAcceptsSlashFromBots(larkAppId))
+    ? null
+    : parseSlashCommandInvocation(cmdContent);
   if (invocation) {
     const { cmd, content: commandContent } = invocation;
     const restrictedText = grantRestrictedSlashCommandText(larkAppId, chatId, senderOpenId, cmd);
@@ -18496,7 +18504,12 @@ async function handleThreadReplyAdmitted(
   }
 
   // Intercept daemon commands
-  const invocation = parseSlashCommandInvocation(cmdContent);
+  // acceptSlashFromBots gate (mirror of the new-topic path): a bot sender's
+  // slash is only routed as a command when this bot opts in (default on); when
+  // off it falls through to ordinary message handling. Human senders unaffected.
+  const invocation = ((isBotSenderType || isForeignBot) && !botAcceptsSlashFromBots(larkAppId))
+    ? null
+    : parseSlashCommandInvocation(cmdContent);
   if (invocation) {
     const { cmd, content: commandContent } = invocation;
     const existingDs = activeSessions.get(sessionKey(anchor, larkAppId));

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -913,7 +913,7 @@ export const messages: Record<string, string> = {
   'daemon.auto_start_join_title': 'Proactive start (joined chat)',
   'daemon.auto_start_join_seed': '🚀 Joined this chat — getting to work…',
   'daemon.cmd_requires_session': '{cmd} requires an existing session (send a normal message first to start the CLI).',
-  'daemon.cmd_allowed_users_only': '⚠️ {cmd} is restricted to `allowedUsers`.',
+  'daemon.cmd_allowed_users_only': '⚠️ {cmd} is a management command, restricted to `allowedUsers`. To authorize, ask the owner to add you to this bot\'s `allowedUsers` (Dashboard or bots.json).',
   'daemon.download_failed_need_login': '⚠️ Some images/files failed to download (missing User Token). Send `/login` in this topic to authorize, then resend.',
   'daemon.foreign_bot_mention_prefix': '[@mention from {botName}]',
   'daemon.ordinary_ingress_failed': '⚠️ This message did not reach the CLI. Please resend; if it keeps failing, `/close` and reopen the topic.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -914,7 +914,7 @@ export const messages: Record<string, string> = {
   'daemon.auto_start_join_title': '主动开工（入群）',
   'daemon.auto_start_join_seed': '🚀 已加入本群，开始工作…',
   'daemon.cmd_requires_session': '{cmd} 需要在已有会话内使用（先发一条普通消息启动 CLI）。',
-  'daemon.cmd_allowed_users_only': '⚠️ {cmd} 仅 allowedUsers 可执行。',
+  'daemon.cmd_allowed_users_only': '⚠️ {cmd} 是管理命令，仅 allowedUsers 可执行。需要授权请让 owner 把你加入该 Bot 的 allowedUsers（Dashboard 或 bots.json）。',
   'daemon.download_failed_need_login': '⚠️ 部分图片/文件下载失败（缺少 User Token）。请在话题中发送 /login 授权后重新发送。',
   'daemon.foreign_bot_mention_prefix': '[来自 {botName} 的 @mention]',
   'daemon.ordinary_ingress_failed': '⚠️ 这条消息没有送达 CLI，请重发一次；若持续失败，可 /close 后重开话题。',

--- a/test/accept-slash-from-bots.test.ts
+++ b/test/accept-slash-from-bots.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the `acceptSlashFromBots` per-bot switch (default ON):
+ *   - parse round-trip through parseBotConfigsFromText (only explicit false persists)
+ *   - botAcceptsSlashFromBots accessor (default on; explicit false off; unknown bot on)
+ *
+ * The switch gates whether a bot-sent native slash command (botmux send --slash)
+ * is routed as a command; human senders are never gated by it. See daemon.ts's
+ * two invocation-parse sites.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('node:fs')>();
+  return { ...orig, existsSync: vi.fn(() => false), readFileSync: vi.fn(() => ''), statSync: vi.fn(() => ({ mtimeMs: 0 })) };
+});
+
+async function freshImport() {
+  vi.resetModules();
+  return await import('../src/bot-registry.js');
+}
+
+function baseEntry(overrides: Record<string, unknown> = {}) {
+  return { larkAppId: 'app_slash_001', larkAppSecret: 'secret', cliId: 'claude-code', ...overrides };
+}
+
+describe('acceptSlashFromBots parse', () => {
+  it('defaults to undefined (= ON) when unset', async () => {
+    const mod = await freshImport();
+    const [cfg] = mod.parseBotConfigsFromText(JSON.stringify([baseEntry()]));
+    expect(cfg.acceptSlashFromBots).toBeUndefined();
+  });
+
+  it('persists only explicit false (bots.json stays clean)', async () => {
+    const mod = await freshImport();
+    const [off] = mod.parseBotConfigsFromText(JSON.stringify([baseEntry({ acceptSlashFromBots: false })]));
+    expect(off.acceptSlashFromBots).toBe(false);
+    // explicit true is the default → normalized away (undefined), like autoGrantRequestCards
+    const [on] = mod.parseBotConfigsFromText(JSON.stringify([baseEntry({ acceptSlashFromBots: true })]));
+    expect(on.acceptSlashFromBots).toBeUndefined();
+  });
+});
+
+describe('botAcceptsSlashFromBots accessor', () => {
+  it('returns true by default (unset)', async () => {
+    const mod = await freshImport();
+    mod.registerBot(baseEntry() as any);
+    expect(mod.botAcceptsSlashFromBots('app_slash_001')).toBe(true);
+  });
+
+  it('returns false only when explicitly disabled', async () => {
+    const mod = await freshImport();
+    mod.registerBot(baseEntry({ acceptSlashFromBots: false }) as any);
+    expect(mod.botAcceptsSlashFromBots('app_slash_001')).toBe(false);
+  });
+
+  it('returns true for an unknown bot (default-on, never fail-closed to all-reject)', async () => {
+    const mod = await freshImport();
+    expect(mod.botAcceptsSlashFromBots('app_never_registered')).toBe(true);
+  });
+});

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -492,7 +492,7 @@ describe('cmdSend hook context wiring', () => {
     expect(cmdSend).toContain('containsNativeAtTag: containsLarkAtTag(content)');
     expect(cmdSend).toContain('const managedRenderedPayloadError = managedVcSendPayloadError({');
     expect(cmdSend).toContain('containsNativeAtTag: containsLarkAtTag(text)');
-    expect(cmdSend).toContain('if (!noMention && !vcMeetingManagedSendOrigin)');
+    expect(cmdSend).toContain('if (!noMention && !isSlashSend && !vcMeetingManagedSendOrigin)');
     expect(cmdSend).toContain('if (!sendTopLevel && !vcMeetingManagedSendOrigin)');
     expect(cmdSend.indexOf('const managedPayloadError = managedVcSendPayloadError({'))
       .toBeLessThan(cmdSend.indexOf("const { sendMessage, replyMessage, uploadImage, uploadFile"));

--- a/test/cli-send-slash.test.ts
+++ b/test/cli-send-slash.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateSlashSend } from '../src/cli/send-dispatch.js';
+
+describe('validateSlashSend', () => {
+  it('accepts a bare single-line slash command', () => {
+    expect(validateSlashSend('/clear')).toEqual({ ok: true, command: '/clear' });
+  });
+
+  it('accepts a slash command with arguments', () => {
+    expect(validateSlashSend('/model opus')).toEqual({ ok: true, command: '/model opus' });
+  });
+
+  it('trims surrounding whitespace (heredoc trailing newline is the common case)', () => {
+    expect(validateSlashSend('  /compact \n')).toEqual({ ok: true, command: '/compact' });
+    expect(validateSlashSend('/clear\n')).toEqual({ ok: true, command: '/clear' });
+  });
+
+  it('rejects empty / whitespace-only input', () => {
+    expect(validateSlashSend('')).toMatchObject({ ok: false });
+    expect(validateSlashSend('   ')).toMatchObject({ ok: false });
+    expect(validateSlashSend('\n\n')).toMatchObject({ ok: false });
+  });
+
+  it('rejects content that does not start with a slash', () => {
+    const r = validateSlashSend('clear');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('/');
+  });
+
+  it('rejects a leading @mention before the slash (would break command detection)', () => {
+    // A user pasting "@Bot /clear" as the --slash body is a mistake: the daemon
+    // strips leading mentions by NAME from its own mentions[] list, not from raw
+    // text a peer typed, so an inline "@Bot" here would not be stripped. Reject.
+    expect(validateSlashSend('@Bot /clear')).toMatchObject({ ok: false });
+  });
+
+  it('rejects multi-line content (the exact regression --slash exists to prevent)', () => {
+    // A multi-line body is what the card-footer path produced, demoting the
+    // command to an ordinary prompt on the receiver. Fail loud instead.
+    expect(validateSlashSend('/clear\nextra line')).toMatchObject({ ok: false });
+    expect(validateSlashSend('/clear\r\nextra')).toMatchObject({ ok: false });
+  });
+});


### PR DESCRIPTION
## 背景

一个 bot 用 `botmux send` 发单行斜杠命令（如 `/clear`）给另一个 bot 时，`send` 当前只能发 interactive 卡片；卡片带「🔊 语音总结」footer 使正文变多行，接收方 daemon 的 `parseSlashCommandInvocation` 只把 `/schedule|/role|/fork` 当多行命令，其余多行一律降级为普通 prompt——命令到不了 passthrough / daemon 命令路由，被当对话喂给对端模型。因此 bot→bot 发 `/clear` 等命令此前无法被真正消费。

## 改了什么

- **发送端 `--slash`**：`botmux send --slash "/xxx"` 强校验（单行、以 `/` 开头、trim 尾部空白、拒多行/拒 @前缀），走纯 `text` 消息而非卡片；显式 `--mention` 拼成 `<at>` 前缀，既能触发对端 bot 又能被接收方 `stripLeadingMentions` 剥回干净命令。与 `--voice` / `--card-file` / `--card-json` / `--content-file` / 附件 / `--attention` 互斥；跳过正文 `@BotName` 自动注入（只认显式 `--mention`）。
- **沙盒**：`send` 走 outbox relay，host watcher 按 flag allowlist 重建 argv，故 `--slash` 同步加入 `cli.ts` relaySend 的 `FLAGS_NOVAL` 与 `sandbox.ts` 的 `RELAY_FLAGS_NOVAL`，否则沙盒内的 bot 用不了。
- **消费端 opt-in 开关**：新增 per-bot `acceptSlashFromBots`（默认开，仅显式 `false` 持久化）。关掉后来自 bot 发送方的斜杠命令不进 passthrough / daemon 命令路由，退化为普通消息；真人发送方不受影响。daemon 两处 `parseSlashCommandInvocation` 前加闸。
- **管理命令边界（最小方案）**：daemon 管理命令（`/close` `/restart` 等）从 bot 来仍只认 `allowedUsers`（`canOperate` 不变），把「仅 allowedUsers 可执行」死文案改成可操作提示（引导 owner 把该 bot 加入 `allowedUsers`）。**刻意不做「授权卡授 operate」**——现有 grant 卡只授 `canTalk`，`canOperate` 恒不读 grant 存储，卡片授 operate 会误导且破坏既有安全边界。

## 为什么

passthrough 消费端其实早就就绪（`deliverPassthroughToExistingSession` 对 bot 发送方无排除、passthrough 不过 canOperate 闸），唯一断点是发送端只能发多行卡片。补一个发纯 text 的通道即可打通，opt-in 开关给 owner 留「不让别的 bot 敲我 CLI」的逃生阀。

## 影响面

- **跨平台**：纯 IM 层 + 配置层，无路径/PTY/shell 改动，Linux/macOS 一致。
- **跨 CLI**：`--slash` 发 text 与消费端归类均与具体 CLI 无关，未动任何 adapter；passthrough 归类沿用既有 per-adapter 集合。
- **跨后端**：`send` 在 IM 层，PtyBackend/TmuxBackend 无差异；沙盒 on/off 双 allowlist 均已放行。
- **会话类型**：新话题（chat-scope 冷启动）与话题内回复（thread-scope）两条路由都加了 opt-in 闸。

## 测试验证

- **新增单测**：`test/cli-send-slash.test.ts`（7）验 `validateSlashSend`（含拒多行/拒 @前缀/trim）；`test/accept-slash-from-bots.test.ts`（5）验默认开/显式关/未知 bot 默认开 + parse 只持久化 false。更新 `test/cli-send-hook-context.test.ts` 的 auto-mention 守卫断言（加入 `!isSlashSend`）。
- `pnpm build` 绿；`pnpm tsc` 绿；全量非 e2e 用例 **14822 passed**（4 个失败经 stash 后在 clean master 上复现，确认为仓库既有/偶发，与本改动无关：slash-commands 文档同步缺 `/introduce`、codex-app-runner 集成、group-join-shared-routing）。
- **端到端实测**：向已记住暗号的目标会话发 `--slash /clear`，目标 daemon 日志出现 `Passthrough /clear → worker`（未加 flag 时同操作仅 `Ordinary IM input`），目标会话上下文由 300.7K 骤降到 36.6K、暗号丢失——坐实命令被真正当 passthrough 敲进对端 CLI 而非当 prompt。发送出的消息实测为 `msgType=text, content="/clear"`（不再是卡片）。

## 后续（不在本 PR）

`/botconfig set acceptSlashFromBots` 与 dashboard 开关：`botconfig` 的 boolean 持久化按 default-off 设计（`true` 写、`false` 删 key），default-on 开关需改共享 store，另开 PR；当前经 bots.json 字段已完全可用。
