### PR TITLE
feat(adapter): 新增 dsh 适配器（deepseek-harness SDK JSON-RPC）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -62,7 +62,7 @@ More: [Roles & teams](https://deepcoldy.github.io/botmux/en/roles) · [File sand
 
 Switch with `cliId` in `bots.json`. **20+ adapters**, spanning local CLIs (process-isolated, reachable via `tmux attach`) and API / cloud agents (e.g. Mira, riff — reached over API / remote, not a local process). Representative ones:
 
-`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `opencode2` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `reasonix` · `aiden` · `coco` (TRAE) · `hermes` · `mira` · `riff` (cloud agent) …
+`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `opencode2` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `reasonix` · `dsh` · `aiden` · `coco` (TRAE) · `hermes` · `mira` · `riff` (cloud agent) …
 
 The current full set of `cliId`s is authoritative in [`src/adapters/cli/registry.ts`](https://github.com/deepcoldy/botmux/blob/master/src/adapters/cli/registry.ts); per-CLI config and wrapper / gateway setups are in [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ botmux start                 # 启动 daemon（botmux autostart enable 设开机
 
 `bots.json` 里用 `cliId` 一键切换。**20+ 适配器**，覆盖本地 CLI（进程隔离，`tmux attach` 可直连）和 API / 云 Agent（如 Mira、riff——通过 API / 远端接入，非本地进程）。代表项：
 
-`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `opencode2` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `reasonix` · `aiden` · `coco`(TRAE) · `hermes` · `mira` · `riff`(云 Agent) …
+`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `opencode2` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `reasonix` · `dsh` · `aiden` · `coco`(TRAE) · `hermes` · `mira` · `riff`(云 Agent) …
 
 当前完整 `cliId` 以 [`src/adapters/cli/registry.ts`](https://github.com/deepcoldy/botmux/blob/master/src/adapters/cli/registry.ts) 为准；各 CLI 的配置与套 wrapper / 网关方法见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
 

--- a/docs-site/docs/en/adapters.md
+++ b/docs-site/docs/en/adapters.md
@@ -47,7 +47,7 @@ The table lists the current built-in adapters (the **authoritative source** for 
 1. `dsh-jsonrpc-agent` on PATH (or point `cliPathOverride` at it).
 2. Set `DEEPSEEK_API_KEY` in the bot's `env`.
 
-Session JSONL lives under `~/.botmux/dsh-sessions/`. Turns are multi-turn within one runner connection; a daemon restart starts a fresh session (no context resume).
+Session JSONL lives under `~/.botmux/dsh/sessions/`. Turns are multi-turn within one runner connection; a daemon restart starts a fresh session (no context resume).
 
 ## Mir CLI and MCP Bridge
 

--- a/docs-site/docs/en/adapters.md
+++ b/docs-site/docs/en/adapters.md
@@ -36,8 +36,18 @@ The table lists the current built-in adapters (the **authoritative source** for 
 | `mira` | Mira APP | API / remote | |
 | `mir` | Mir CLI (local mircli + MCP bridge) | local process | |
 | `riff` | riff | cloud agent (API) | |
+| `dsh` | DeepSeek Harness (dsh-jsonrpc-agent) | local process (SDK JSON-RPC) | ✅ |
 
 > The `model` field only takes effect for adapters that support a model parameter; others ignore it. Mir CLI's extra prerequisites (login / miramcp) are in the section below.
+
+## DeepSeek Harness (dsh)
+
+`cliId: "dsh"` drives a local `dsh-jsonrpc-agent` (the packaged runtime of [deepseek-harness](https://github.com/deepseekai/deepseek-harness)) through the bundled runner over the SDK JSON-RPC protocol. Prerequisites:
+
+1. `dsh-jsonrpc-agent` on PATH (or point `cliPathOverride` at it).
+2. Set `DEEPSEEK_API_KEY` in the bot's `env`.
+
+Session JSONL lives under `~/.botmux/dsh-sessions/`. Turns are multi-turn within one runner connection; a daemon restart starts a fresh session (no context resume).
 
 ## Mir CLI and MCP Bridge
 

--- a/docs-site/docs/zh/adapters.md
+++ b/docs-site/docs/zh/adapters.md
@@ -36,8 +36,18 @@ botmux 通过适配器桥接不同 CLI / Agent，`bots.json` 里用 `cliId` 选�
 | `mira` | Mira APP | API / 远端 | |
 | `mir` | Mir CLI（本地 mircli + MCP bridge） | 本地进程 | |
 | `riff` | riff | 云 Agent（API） | |
+| `dsh` | DeepSeek Harness（dsh-jsonrpc-agent） | 本地进程（SDK JSON-RPC） | ✅ |
 
 > `model` 字段只对支持模型参数的适配器生效，其它忽略。Mir CLI 的额外前置（登录 / miramcp）见下方专节。
+
+## DeepSeek Harness（dsh）
+
+`cliId: "dsh"` 通过内置 runner 驱动本机的 `dsh-jsonrpc-agent`（[deepseek-harness](https://github.com/deepseekai/deepseek-harness) 的打包 runtime），走 SDK JSON-RPC 协议。前置条件：
+
+1. `dsh-jsonrpc-agent` 在 PATH 上（或用 `cliPathOverride` 指定路径）。
+2. `bots.json` 的 `env` 里配置 `DEEPSEEK_API_KEY`。
+
+会话 JSONL 落在 `~/.botmux/dsh-sessions/`；同一 runner 连接内多轮，daemon 重启后开新会话（不续上下文）。
 
 ## Mir CLI 与 MCP Bridge
 

--- a/docs-site/docs/zh/adapters.md
+++ b/docs-site/docs/zh/adapters.md
@@ -47,7 +47,7 @@ botmux 通过适配器桥接不同 CLI / Agent，`bots.json` 里用 `cliId` 选�
 1. `dsh-jsonrpc-agent` 在 PATH 上（或用 `cliPathOverride` 指定路径）。
 2. `bots.json` 的 `env` 里配置 `DEEPSEEK_API_KEY`。
 
-会话 JSONL 落在 `~/.botmux/dsh-sessions/`；同一 runner 连接内多轮，daemon 重启后开新会话（不续上下文）。
+会话 JSONL 落在 `~/.botmux/dsh/sessions/`；同一 runner 连接内多轮，daemon 重启后开新会话（不续上下文）。
 
 ## Mir CLI 与 MCP Bridge
 

--- a/docs/design/2026-08-13-dsh-adapter.md
+++ b/docs/design/2026-08-13-dsh-adapter.md
@@ -4,6 +4,10 @@
 状态：已实现（v1）
 作者：Monday（AI）
 
+> 2026-08-14 更新：v2 的跨重启 resume/取消经评审回退。dsh SDK server 的 `createSession` 走 `agents.create`，
+> 不调用 `agents.resume`；持久化层拒绝用同 ID 覆盖已有日志。稳定 sessionId 会导致重启后首个 prompt 永久失败。
+> 跨重启 resume 需要 dsh 上游提供 create-or-resume 能力，列为已知限制。
+
 ## 1. 背景与目标
 
 让 botmux 支持把 [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness)（下称 dsh）作为群机器人的 agent 后端：飞书群 @ 机器人 → dsh 执行 → 结果回群，支持同会话多轮。
@@ -203,11 +207,11 @@ runner 在首轮用户消息前插入（后续轮不插）：
 4. **双重沙箱**：默认 cordis.yml 不含 landlock 沙箱插件，v1 靠 botmux 沙箱兜底，无冲突。
 5. **密钥**：DEEPSEEK_API_KEY 走 bots.json env 注入，不进配置文件、不落盘。
 
-## 11. v2 backlog
+## 11. 已知限制（v2 backlog）
 
-- 跨重启 resume（依赖风险 2 的结论）
-- 中断/取消（ACP 或协议扩展）
-- 工具调用卡片化展示（替代纯文本进度行）
-- 权限请求桥接群内人工确认（若走 ACP）
-- 图片消息（resource_link 或多模态块，视 dsh 协议演进）
-- 多 session 并发（一个 runner 多群/多话题）
+- **跨重启 resume**：dsh SDK server 无 create-or-resume；`agents.create` 不 resume，持久化层拒绝同 ID 覆盖。runner 重启后开新会话（随机 sessionId）。需要 dsh 上游支持。
+- **中断/取消**：SDK 协议无 cancel；worker 杀 runner 重拉即取消，但会丢当前会话上下文（配合上一条，无法 resume）。
+- 工具调用卡片化展示（替代纯文本进度行）：worker/渲染层工作，另开。
+- 权限请求桥接群内人工确认：SDK 协议无权限请求语义。
+- 图片消息：协议只收 text；botmux 已有的附件提示会把文件路径写进 prompt，dsh 工具可读取。
+- 多 session 并发：botmux 本来就是一个 bot 会话一个 runner，无实际场景。

--- a/docs/design/2026-08-13-dsh-adapter.md
+++ b/docs/design/2026-08-13-dsh-adapter.md
@@ -1,0 +1,213 @@
+# dsh (deepseek-harness) Adapter 实施方案
+
+日期：2026-08-13
+状态：已实现（v1）
+作者：Monday（AI）
+
+## 1. 背景与目标
+
+让 botmux 支持把 [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness)（下称 dsh）作为群机器人的 agent 后端：飞书群 @ 机器人 → dsh 执行 → 结果回群，支持同会话多轮。
+
+dsh 是 DeepSeek 开源的 agent harness（cordis 插件架构，opencode 血统），当前版本 `0.1.0-rc.5`。它**没有 TUI**，shipped 的只有 web/headless 两个 profile，但天生为"被程序驱动"设计，提供 stdio JSON-RPC 接口。
+
+## 2. 调研结论（关键事实）
+
+### 2.1 botmux 侧
+
+- 主流 adapter（kimi/gemini/…）是 PTY 驱动 TUI：打字进 stdin、静默检测判 turn 结束、agent 自己执行 `botmux send` 回消息。**dsh 没有 TUI，这条路不适用。**
+- botmux 已有 **runner 型 adapter** 模式（codex-app/mira/mir）：spawn 一个小 Node runner，runner 对 botmux 说输入帧协议 + OSC 控制帧，对真实 agent 说原生协议。thin adapter 仅 ~120 行（`src/adapters/cli/codex-app.ts`），重活在 runner。
+- 输入帧协议（`src/adapters/cli/runner-input.ts`）：botmux 写 `::botmux-<id>:<base64(JSON)>\n`，`writeRunnerInput` 负责分块（1024B/块、20ms 节流）、pre-flush、提交重试，返回 `{submitted, submissionDisposition}`。
+- 回包通道（`src/adapters/cli/runner-control-channel.ts`）：runner 在 stdout 混 OSC 帧 `\x1b]777;botmux:<kind>:<base64>\x07`。worker 对 `final` 帧有通用投递路径（`src/worker.ts:8401`，mira/mir 走 8483 的 else 分支），`final` 的 `content` 即投递到飞书的最终文本。
+- 新 adapter 注册点：`types.ts` CliId、`registry.ts` 三处、`worker.ts` CLI_DISPLAY_NAMES、`card-builder.ts` cliDisplayNames、`bot-config-editor.ts` CLI_ID_CHOICES（只能尾部追加）、`test/cli-adapters.test.ts` ALL_CLI_IDS、README/docs。
+
+### 2.2 dsh 侧
+
+- 有打包好的单文件 runtime **`dsh-jsonrpc-agent`**（`python/sdk-runtime`，wheel 自带，目标机无需 Node），说 **SDK JSON-RPC 协议**（`packages/sdk/protocol/src/types.ts`）：
+  - 请求 3 个：`initialize {cwd, provider, model, maxTokens?}` → `{serverInfo}`；`session/prompt {sessionId, contentBlocks}` → `{messageId}`（入队回执，**不是最终结果**）；`shutdown`。
+  - 通知 4 个：`session.event {sessionId, event}`（完整事件流）、`session.status {sessionId, status: 'idle'|'running'}`、`subagent.started`、`subagent.finished`。
+  - session 语义：`sessionId` 由客户端指定，未知 id 懒创建；**同一连接内**复用 id 即多轮（server 内存 Map 持有 agent）。
+- runtime 启动**必须显式给配置**（`$DSH_CORDIS_CONFIG` 或 argv 位置参数）。wheel 默认 `cordis.yml` 含：jsonrpc-server + agent-spine + llm-deepseek + JSONL 持久化 + checkpoint 策略 + 本地 bash + 本地 fs。会话根目录 `$DSH_SESSION_ROOT`（默认进程 cwd 下 `./.sessions`），工作目录 `$DSH_CWD`。
+- 模型鉴权：`DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL` 环境变量。
+- 事件信封（session.event 的 event）：`{type, seq, time, data}`，type 包括 `turn/start`、`turn/end`（data.reason.kind）、`assistant/message`（data.message.content 块：text/reasoning/tool-call，data.usage）、`tool/call`、`tool/result`、`assistant/chunk` 等。
+- **SDK 协议没有 cancel**；没有权限请求（权限由配置侧决定）；不支持图片（只收 text 块）。
+- ACP server 也存在（`packages/acp`），有 `session/cancel` 和权限请求，但只有 repo 内示例组合、无现成可执行文件，且只给 committed text（无工具可见性）。
+
+## 3. 方案选型
+
+| 方案 | 结论 | 理由 |
+|---|---|---|
+| TUI adapter（kimi 式） | ❌ | dsh 无 TUI |
+| headless 一次性 | ❌ | 无多轮、无流式、无事件 |
+| ACP + runner | 备选 | 标准化、有 cancel/权限；但无现成二进制、无工具可见性 |
+| **SDK JSON-RPC + runner** | ✅ 采用 | 有打包 runtime、事件流完整（工具可见）、协议面极小（3+4） |
+
+## 4. 总体架构
+
+```
+飞书消息 → worker → dsh.ts (thin adapter)
+  buildArgs: node dsh-runner.js --session-id <id> --dsh-bin dsh-jsonrpc-agent --cwd <dir> ...
+  writeInput: ::botmux-dsh:<base64> 帧（writeRunnerInput）
+      │
+      ▼
+dsh-runner.js（长驻 Node 进程）
+  ├─ spawn: dsh-jsonrpc-agent --config <cordis.yml>
+  │    env: DSH_SESSION_ROOT=~/.botmux/dsh-sessions/<id>, DSH_CWD, DEEPSEEK_API_KEY
+  ├─ initialize（握手，provider=deepseek-official, model）
+  ├─ 每 turn：session/prompt（固定 sessionId，连接内多轮）
+  ├─ session.event → 工具调用渲染成进度行写 stdout（worker 当卡片渲染）
+│                → 累积 assistant 文本块
+  ├─ session.status=idle → OSC final 帧 {content, usage, replyTurnId}
+  └─ 致命错误 → OSC lifecycle {event:'fatal'} 后退出
+      │
+      ▼
+worker 解码 final → 投递飞书
+```
+
+## 5. 详细设计
+
+### 5.1 `src/adapters/cli/dsh.ts`（新增，~130 行，照抄 codex-app.ts 形状）
+
+| 成员 | 值/行为 |
+|---|---|
+| `id` | `'dsh'` |
+| `resolvedBin` | `process.execPath`（node 跑 runner） |
+| `sandboxExtraExecPaths` | lazy `resolveCommand(pathOverride ?? 'dsh-jsonrpc-agent')` |
+| `buildArgs` | `[runnerPath(), '--session-id', sessionId, '--dsh-bin', <resolved>, '--cwd', workingDir, '--bot-name', botName, '--locale', locale, '--model', model?]` |
+| `writeInput` | `writeRunnerInput(pty, '::botmux-dsh:', content, undefined, context?.turnId)` |
+| `systemHints` | `[]`（runner 模式不走 botmux send 约定） |
+| `injectsSessionContext` | `true`（runner 把 bot 身份注入首轮 prompt） |
+| `altScreen` | `false` |
+| `supportsTypeAhead` | `false`（v1 串行 turn） |
+| `readyPattern` | `/›/`（runner 握手完成后打印 `›`） |
+| `deferFirstPromptTimeoutUntilReady` | `true` |
+| `modelChoices` | `['deepseek-v4-flash', 'deepseek-v4-pro']` |
+| `authPaths` | `['~/.botmux/dsh-sessions']` |
+| `buildResumeCommand` | `() => null`（v1 不支持） |
+
+### 5.2 `src/dsh-runner.ts`（新增，~450 行）
+
+**argv**：`--session-id`（必填）、`--dsh-bin`（必填）、`--dsh-config`（可选）、`--cwd`、`--bot-name`、`--bot-open-id`、`--locale`、`--model`、`--turn-timeout`（默认 600s）。
+
+**boot**：
+1. 解析 config 路径：`--dsh-config` > `$DSH_CORDIS_CONFIG` > botmux 内置 `assets/dsh/cordis.yml`（vendored，见 5.4）。
+2. `spawn(dshBin, [configPath], {env: {...process.env, DSH_SESSION_ROOT: ~/.botmux/dsh-sessions/<session-id>, DSH_CWD: cwd}})`。
+3. NDJSON 握手：发 `initialize {cwd, provider: 'deepseek-official', model, maxTokens: 49152}`，等 result；超时 30s → lifecycle fatal 退出。
+4. 成功后 stdout 打印 `›`（ready 标记）。
+
+**输入循环**：逐字节读 stdin，遇换行解析 `::botmux-dsh:<base64>` → JSON `{type:'message', content, replyTurnId}`：
+- 首轮 content 前插身份 preamble（见 5.5）。
+- 发 `session/prompt {sessionId: 固定值（runner 启动时生成）, contentBlocks: [{type:'text', text: content}]}`，得 `{messageId}`。
+- v1 同一时刻只允许一个 in-flight prompt（worker 侧 `supportsTypeAhead: false` 已保证；runner 再 assert 一层，冲突时 fatal）。
+
+**事件循环**（解析 dsh stdout 的 NDJSON）：
+- `session.event`：按 sessionId 过滤；
+  - `tool/call` → stdout 进度行 `🔧 ${name} ${truncate(args, 200)}`
+  - `tool/result` → `✓ ${name}`（isError 时 `✗`）
+  - `assistant/message` → 把 content 中 `type:'text'` 块追加到本轮缓冲；记录 usage
+  - `subagent.started/finished` → `↳ 子任务 ${status}`
+- `session.status`：`running` 置忙、`idle` 且有 in-flight → 发 `final` marker `{content: 缓冲文本, usage, startedAtMs, completedAtMs, replyTurnId}`，清空缓冲。缓冲为空则 content 给 `''`（worker 有 pure-silence 抑制逻辑）。
+- JSON-RPC error response → `final` 带错误文本。
+
+**看门狗**：turn 超过 `--turn-timeout` → 杀 dsh 子进程、发 lifecycle fatal、退出非零（worker 重拉 runner；会话上下文丢失，日志明示）。
+
+**子进程崩溃**：exit 事件先于 final → lifecycle fatal 退出。
+
+**关闭**：stdin EOF → 发 `shutdown` → 2s grace 后 kill。
+
+### 5.3 协议规格
+
+botmux→runner 输入帧（复用 runner-input.ts，不改）：
+```
+::botmux-dsh:<base64({"type":"message","content":"...","replyTurnId":"..."})>\n
+```
+
+runner→botmux OSC 帧（复用 RunnerControlWriter）：
+```
+\x1b]777;botmux:final:<base64({"content":"...","usage":{...},"startedAtMs":..,"completedAtMs":..,"replyTurnId":"..."})>\x07
+\x1b]777;botmux:lifecycle:<base64({"event":"fatal","reason":"..."})>\x07
+```
+
+runner→dsh（SDK JSON-RPC，NDJSON over stdio）：见 2.2。
+
+### 5.4 配置与注册点
+
+- **vendored 配置**：`assets/dsh/cordis.yml`，内容取自 dsh `python/sdk-runtime/src/deepseek_harness_runtime/runtime/cordis.yml`（含 jsonrpc-server/agent-spine/llm-deepseek/jsonl/checkpoint/bash/fs），随 botmux 版本 pin dsh 协议版本。
+- **bots.json**：`"cliId": "dsh"`，`"env": {"DEEPSEEK_API_KEY": "..."}`，可选 `"model": "deepseek-v4-pro"`、`"workingDir"`。
+- **注册点**（照 `src/adapters/cli/CLAUDE.md`）：
+  1. `src/adapters/cli/types.ts` CliId 加 `'dsh'`
+  2. `src/adapters/cli/registry.ts`：import + `RAW_CLI_EXECUTABLES['dsh-jsonrpc-agent']` + switch case
+  3. `src/worker.ts` CLI_DISPLAY_NAMES、`src/im/lark/card-builder.ts` cliDisplayNames
+  4. `src/setup/bot-config-editor.ts`：CLI_ID_CHOICES **尾部追加** + labels
+  5. `test/cli-adapters.test.ts`：ALL_CLI_IDS + dsh describe 段
+  6. README.md / README.en.md / docs-site/docs/{zh,en}/adapters.md
+
+### 5.5 身份 preamble（首轮注入）
+
+runner 在首轮用户消息前插入（后续轮不插）：
+
+```
+<botmux_identity>
+你是飞书群机器人「<botName>」，通过 deepseek-harness 运行。
+- 你的最终回复文本会被自动捕获并发送到群里，**不要**执行 botmux send 或任何发消息命令。
+- 工作目录：<cwd>。语言：<locale>。
+</botmux_identity>
+```
+
+必须显式禁止 `botmux send`：dsh 的 bash 工具是 runner 的子进程，能看到 botmux 的 pid marker，不禁止会双发。
+
+## 6. Turn 端到端生命周期
+
+1. worker spawn runner → runner spawn dsh → initialize 完成 → 打印 `›`
+2. worker 见 readyPattern → 把群消息组成 `::botmux-dsh:` 帧写入（首轮带 preamble）
+3. runner 发 session/prompt → dsh 执行（工具调用实时以进度行上屏）
+4. `session.status=idle` → runner 发 final 帧 → worker 投递飞书，turn 结束
+5. 下一条群消息 → 同 sessionId 再 prompt（多轮）
+6. worker 重启 → runner 重拉 → 新 sessionId（v1 不续上下文）
+
+## 7. 错误处理与边界
+
+| 场景 | 行为 |
+|---|---|
+| dsh 二进制不存在 | resolveCommand 失败，setup/启动期报错（同其他 adapter） |
+| initialize 超时/失败 | lifecycle fatal，runner 退出非零，worker 展示失败 |
+| prompt JSON-RPC error | final 带错误文本，turn 正常收尾 |
+| turn 超时（默认 10min） | 杀 dsh + fatal 退出，worker 重拉（丢上下文，明示） |
+| dsh 中途崩溃 | lifecycle fatal 退出 |
+| 空回复（只调工具无文本） | final content='' → worker 抑制投递（已有逻辑） |
+| 图片消息 | v1 转文本提示"暂不支持图片" |
+| stdout 纯净 | runner 的 display 行不含 ESC；OSC 帧由 RunnerControlWriter 统一转义 |
+
+## 8. 测试计划
+
+- **单测** `test/cli-adapters.test.ts`：buildArgs 各 flag 组合、lazy bin、readyPattern、writeInput（fake PtyHandle 断言帧内容）。
+- **runner 单测** `test/dsh-runner.test.ts`（新增）：fixture 假 dsh server（Node 脚本说 SDK 协议）覆盖：握手成功/超时、prompt→事件→final 帧内容、错误响应、超时看门狗、stdin EOF 关闭。
+- **e2e**（手动，不进 CI）：真 dsh binary + DEEPSEEK_API_KEY，群里 @ 验证多轮。
+- 运行：`pnpm vitest run test/cli-adapters.test.ts test/dsh-runner.test.ts`
+
+## 9. 任务拆解
+
+| # | 任务 | 估时 |
+|---|---|---|
+| T0 | spike：假 server 打通 worker↔runner↔dsh 帧通路（throwaway 脚本验证假设） | 0.25d |
+| T1 | dsh.ts + 全部注册点 + bots.json 配置 | 0.5d |
+| T2 | dsh-runner.ts 主体（boot/输入/事件/final/看门狗/关闭） | 1d |
+| T3 | 单测（adapter + runner + 假 server fixture） | 0.5d |
+| T4 | 文档（README、adapters.md、本设计文档定稿） | 0.25d |
+| | **合计** | **~2.5d** |
+
+## 10. 风险与未决项
+
+1. **无 cancel**：SDK 协议没有中断。v1"停止生成"= 杀进程重开（丢上下文）。硬需求则 v2 评估 ACP（有 session/cancel，但要自己 bundle 且丢工具可见性）。
+2. **跨重启 resume 未验证**：server session 是内存 Map；同 sessionId 新连接是否从 JSONL load 历史待验证（大概率不支持）。v2 调研 `session-persistence-jsonl` 的 load 能力。
+3. **协议漂移**：dsh 还是 rc（0.1.0-rc.5），协议可能变。对策：pin 版本 + fixture 测试锁定 wire 格式。
+4. **双重沙箱**：默认 cordis.yml 不含 landlock 沙箱插件，v1 靠 botmux 沙箱兜底，无冲突。
+5. **密钥**：DEEPSEEK_API_KEY 走 bots.json env 注入，不进配置文件、不落盘。
+
+## 11. v2 backlog
+
+- 跨重启 resume（依赖风险 2 的结论）
+- 中断/取消（ACP 或协议扩展）
+- 工具调用卡片化展示（替代纯文本进度行）
+- 权限请求桥接群内人工确认（若走 ACP）
+- 图片消息（resource_link 或多模态块，视 dsh 协议演进）
+- 多 session 并发（一个 runner 多群/多话题）

--- a/docs/design/2026-08-13-dsh-adapter.md
+++ b/docs/design/2026-08-13-dsh-adapter.md
@@ -55,7 +55,7 @@ dsh 是 DeepSeek 开源的 agent harness（cordis 插件架构，opencode 血统
       ▼
 dsh-runner.js（长驻 Node 进程）
   ├─ spawn: dsh-jsonrpc-agent --config <cordis.yml>
-  │    env: DSH_SESSION_ROOT=~/.botmux/dsh-sessions/<id>, DSH_CWD, DEEPSEEK_API_KEY
+  │    env: DSH_SESSION_ROOT=~/.botmux/dsh/sessions/<id>, DSH_CWD, DEEPSEEK_API_KEY
   ├─ initialize（握手，provider=deepseek-official, model）
   ├─ 每 turn：session/prompt（固定 sessionId，连接内多轮）
   ├─ session.event → 工具调用渲染成进度行写 stdout（worker 当卡片渲染）
@@ -85,7 +85,7 @@ worker 解码 final → 投递飞书
 | `readyPattern` | `/›/`（runner 握手完成后打印 `›`） |
 | `deferFirstPromptTimeoutUntilReady` | `true` |
 | `modelChoices` | `['deepseek-v4-flash', 'deepseek-v4-pro']` |
-| `authPaths` | `['~/.botmux/dsh-sessions']` |
+| `authPaths` | `['~/.botmux/dsh']`（adapter 在进沙盒前预创建） |
 | `buildResumeCommand` | `() => null`（v1 不支持） |
 
 ### 5.2 `src/dsh-runner.ts`（新增，~450 行）
@@ -94,7 +94,7 @@ worker 解码 final → 投递飞书
 
 **boot**：
 1. 解析 config 路径：`--dsh-config` > `$DSH_CORDIS_CONFIG` > botmux 内置 `assets/dsh/cordis.yml`（vendored，见 5.4）。
-2. `spawn(dshBin, [configPath], {env: {...process.env, DSH_SESSION_ROOT: ~/.botmux/dsh-sessions/<session-id>, DSH_CWD: cwd}})`。
+2. `spawn(dshBin, [configPath], {env: {...process.env, DSH_SESSION_ROOT: ~/.botmux/dsh/sessions/<session-id>, DSH_CWD: cwd}})`。
 3. NDJSON 握手：发 `initialize {cwd, provider: 'deepseek-official', model, maxTokens: 49152}`，等 result；超时 30s → lifecycle fatal 退出。
 4. 成功后 stdout 打印 `›`（ready 标记）。
 

--- a/src/adapters/backend/capabilities.ts
+++ b/src/adapters/backend/capabilities.ts
@@ -21,7 +21,7 @@ export function backendCliCompatibilityError(
   backendType: BackendType,
   cliId: CliId,
 ): string | undefined {
-  if (backendType === 'zmx' && ['codex-app', 'mira', 'mir'].includes(cliId)) {
+  if (backendType === 'zmx' && ['codex-app', 'mira', 'mir', 'dsh'].includes(cliId)) {
     return `backend "zmx" cannot carry ${cliId}'s hidden OSC final/thread events; use tmux/pty`;
   }
   return undefined;

--- a/src/adapters/cli/dsh.ts
+++ b/src/adapters/cli/dsh.ts
@@ -80,6 +80,10 @@ export function createDshAdapter(pathOverride?: string): CliAdapter {
     supportsTypeAhead: false,
     completionPattern: undefined,
     readyPattern: /›/,
+    // The runner only attaches its stdin listener after the JSON-RPC handshake
+    // (up to 30s). Without this, the worker's 15s soft timeout would flush the
+    // first prompt into an un-drained PTY and risk a dirty_unknown generation.
+    deferFirstPromptTimeoutUntilReady: true,
     systemHints: [],
     injectsSessionContext: true,
     altScreen: false,

--- a/src/adapters/cli/dsh.ts
+++ b/src/adapters/cli/dsh.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url';
-import { existsSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { resolveCommand } from './registry.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
@@ -36,9 +37,11 @@ export function createDshAdapter(pathOverride?: string): CliAdapter {
   let cachedDshBin: string | undefined;
   return {
     id: 'dsh',
-    // Session JSONL lives here; keep it REAL under the file sandbox so
-    // history persists across sessions (see adapters CLAUDE.md sandbox notes).
-    authPaths: ['~/.botmux/dsh-sessions'],
+    // The runner writes its vendored cordis.yml and session JSONL under
+    // ~/.botmux/dsh/. Keep the whole dir REAL under the file sandbox so
+    // both survive (see adapters CLAUDE.md sandbox notes). Pre-created in
+    // buildArgs so the sandbox's keepExisting filter doesn't drop it.
+    authPaths: ['~/.botmux/dsh'],
     resolvedBin: process.execPath,
 
     // resolvedBin is node-running-the-runner; the real dsh runtime is spawned
@@ -51,6 +54,10 @@ export function createDshAdapter(pathOverride?: string): CliAdapter {
     },
 
     buildArgs({ sessionId, workingDir, botName, botOpenId, locale, model }) {
+      // Pre-create the persistent dsh dir in the real HOME before the worker
+      // enters the sandbox: the sandbox's keepExisting filter drops authPaths
+      // that don't exist yet, and the runner can't create them from inside.
+      mkdirSync(join(homedir(), '.botmux', 'dsh'), { recursive: true });
       const args = [
         runnerPath(),
         '--session-id', sessionId,

--- a/src/adapters/cli/dsh.ts
+++ b/src/adapters/cli/dsh.ts
@@ -1,0 +1,90 @@
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { resolveCommand } from './registry.js';
+import type { CliAdapter, PtyHandle } from './types.js';
+import { writeRunnerInput } from './runner-input.js';
+
+function runnerPath(): string {
+  // Source-level worker integration tests execute through tsx and need the
+  // matching source runner rather than a possibly absent/stale ignored dist
+  // tree. Keep the override strictly test-scoped so production launch
+  // resolution remains canonical and cannot be redirected by ambient env.
+  const testOverride = process.env.NODE_ENV === 'test'
+    ? process.env.BOTMUX_TEST_DSH_RUNNER_PATH
+    : undefined;
+  if (testOverride) return resolve(testOverride);
+  const here = dirname(fileURLToPath(import.meta.url));
+  const compiledSibling = resolve(here, '..', '..', 'dsh-runner.js');
+  if (existsSync(compiledSibling)) return compiledSibling;
+  const builtFromSourceTree = resolve(here, '..', '..', '..', 'dist', 'dsh-runner.js');
+  if (existsSync(builtFromSourceTree)) return builtFromSourceTree;
+  return compiledSibling;
+}
+
+function pushOpt(args: string[], key: string, value: string | undefined): void {
+  if (value === undefined || value.length === 0) return;
+  args.push(key, value);
+}
+
+export function createDshAdapter(pathOverride?: string): CliAdapter {
+  // Resolve the wrapped `dsh-jsonrpc-agent` binary lazily, on first buildArgs
+  // (spawn time), so constructing the adapter during `botmux setup` doesn't
+  // shell out via resolveCommand. resolvedBin is the node runner, not dsh
+  // itself.
+  const rawDshBin = pathOverride ?? 'dsh-jsonrpc-agent';
+  let cachedDshBin: string | undefined;
+  return {
+    id: 'dsh',
+    // Session JSONL lives here; keep it REAL under the file sandbox so
+    // history persists across sessions (see adapters CLAUDE.md sandbox notes).
+    authPaths: ['~/.botmux/dsh-sessions'],
+    resolvedBin: process.execPath,
+
+    // resolvedBin is node-running-the-runner; the real dsh runtime is spawned
+    // by the runner. Declare it so the file sandbox can re-expose its bin dir
+    // when it lives under /run (fnm/nvm) — else --tmpfs /run masks it and the
+    // in-sandbox spawn ENOENTs into a crash-loop. Same lazy resolve+cache as
+    // buildArgs; only an executable path, never the cwd.
+    sandboxExtraExecPaths() {
+      return [(cachedDshBin ??= resolveCommand(rawDshBin))];
+    },
+
+    buildArgs({ sessionId, workingDir, botName, botOpenId, locale, model }) {
+      const args = [
+        runnerPath(),
+        '--session-id', sessionId,
+        '--dsh-bin', (cachedDshBin ??= resolveCommand(rawDshBin)),
+      ];
+      pushOpt(args, '--cwd', workingDir);
+      pushOpt(args, '--bot-name', botName);
+      pushOpt(args, '--bot-open-id', botOpenId);
+      pushOpt(args, '--locale', locale);
+      pushOpt(args, '--model', model && model.trim() ? model.trim() : undefined);
+      return args;
+    },
+
+    buildResumeCommand() {
+      // dsh sessions live inside the runner's JSON-RPC connection; there is no
+      // stable user-facing CLI deeplink to resume one.
+      return null;
+    },
+
+    async writeInput(pty: PtyHandle, content: string, context) {
+      // Chunked + throttled stdin injection — a single send-keys of the whole
+      // (potentially large) control line overruns the pane pty input buffer.
+      // See runner-input.ts.
+      return writeRunnerInput(pty, '::botmux-dsh:', content, undefined, context?.turnId);
+    },
+
+    supportsTypeAhead: false,
+    completionPattern: undefined,
+    readyPattern: /›/,
+    systemHints: [],
+    injectsSessionContext: true,
+    altScreen: false,
+    modelChoices: ['deepseek-v4-flash', 'deepseek-v4-pro'],
+  };
+}
+
+export const create = createDshAdapter;

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -30,6 +30,7 @@ import { createGrokAdapter } from './grok.js';
 import { createKiroCliAdapter } from './kiro-cli.js';
 import { createRiffAdapter } from './riff.js';
 import { createReasonixAdapter } from './reasonix.js';
+import { createDshAdapter } from './dsh.js';
 
 /**
  * The first CLI executable (or nested runner dependency) before shell
@@ -70,6 +71,9 @@ const RAW_CLI_EXECUTABLES: Readonly<Record<CliId, string | undefined>> = {
   // API-backed; no local executable is required.
   riff: undefined,
   reasonix: 'reasonix',
+  // The adapter itself launches a bundled Node runner; dsh-jsonrpc-agent is
+  // its real second-stage dependency.
+  dsh: 'dsh-jsonrpc-agent',
 };
 
 /** Return the unresolved command without constructing an adapter or spawning a
@@ -169,7 +173,7 @@ export async function createCliAdapter(id: CliId, pathOverride?: string): Promis
   return adapter;
 }
 
-export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createGeniusAdapter, createOpenCodeAdapter, createOpenCode2Adapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createMirAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter, createKimiAdapter, createGrokAdapter, createKiroCliAdapter, createRiffAdapter, createReasonixAdapter };
+export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createGeniusAdapter, createOpenCodeAdapter, createOpenCode2Adapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createMirAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter, createKimiAdapter, createGrokAdapter, createKiroCliAdapter, createRiffAdapter, createReasonixAdapter, createDshAdapter };
 
 /** Synchronous version for use in worker process. */
 export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapter {
@@ -200,6 +204,7 @@ export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapt
     case 'kiro-cli': return createKiroCliAdapter(pathOverride);
     case 'riff': return createRiffAdapter(pathOverride);
     case 'reasonix': return createReasonixAdapter(pathOverride);
+    case 'dsh': return createDshAdapter(pathOverride);
     default: throw new Error(`Unknown CLI adapter: ${id}`);
   }
 }

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -535,4 +535,4 @@ export interface CliAdapter {
   buildSessionRenameCommand?(title: string): string;
 }
 
-export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'genius' | 'opencode' | 'opencode2' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'mir' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi' | 'kimi' | 'grok' | 'kiro-cli' | 'riff' | 'reasonix';
+export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'genius' | 'opencode' | 'opencode2' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'mir' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi' | 'kimi' | 'grok' | 'kiro-cli' | 'riff' | 'reasonix' | 'dsh';

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -211,7 +211,14 @@ export function resolvePassthroughCommands(larkAppId?: string, cliIdOverride?: s
   // ledger; the model still completes the text as an ordinary turn, but the
   // worker has no pending dispatch to attribute that final to and the session
   // remains stuck. Keep these messages on the normal structured turn path.
-  if (effectiveCliId === 'codex-app') return new Set();
+  // Runner adapters (codex-app/mira/mir/dsh) speak a framed stdin protocol,
+  // not an interactive TUI: a slash command through raw_input bypasses the
+  // turn ledger and the runner rejects non-frame input, wedging the session.
+  // Keep these messages on the normal structured turn path.
+  if (effectiveCliId === 'codex-app'
+    || effectiveCliId === 'mira'
+    || effectiveCliId === 'mir'
+    || effectiveCliId === 'dsh') return new Set();
   for (const c of resolveAdapterDefaultPassthroughCommands(larkAppId, effectiveCliId)) {
     effective.add(c);
   }

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -190,6 +190,16 @@ export function resolveAdapterDefaultPassthroughCommands(larkAppId?: string, cli
  * App Server rather than an interactive TUI; slash-looking text must use the
  * structured turn lane. Unknown / no bot → falls back to the builtin set.
  */
+/** Runner adapters speak a framed stdin protocol, not an interactive TUI:
+ * raw slash passthrough would bypass the turn ledger and the runner rejects
+ * non-frame input. Both the routing and the /list-slash-command display must
+ * agree on this set. */
+const NO_RAW_PASSTHROUGH_CLI_IDS = new Set(['codex-app', 'mira', 'mir', 'dsh']);
+
+export function cliHasNoRawPassthroughSurface(cliId: string | undefined): boolean {
+  return !!cliId && NO_RAW_PASSTHROUGH_CLI_IDS.has(cliId);
+}
+
 export function resolvePassthroughCommands(larkAppId?: string, cliIdOverride?: string): Set<string> {
   const effective = new Set(PASSTHROUGH_COMMANDS);
   if (!larkAppId) return effective;
@@ -215,10 +225,7 @@ export function resolvePassthroughCommands(larkAppId?: string, cliIdOverride?: s
   // not an interactive TUI: a slash command through raw_input bypasses the
   // turn ledger and the runner rejects non-frame input, wedging the session.
   // Keep these messages on the normal structured turn path.
-  if (effectiveCliId === 'codex-app'
-    || effectiveCliId === 'mira'
-    || effectiveCliId === 'mir'
-    || effectiveCliId === 'dsh') return new Set();
+  if (cliHasNoRawPassthroughSurface(effectiveCliId)) return new Set();
   for (const c of resolveAdapterDefaultPassthroughCommands(larkAppId, effectiveCliId)) {
     effective.add(c);
   }
@@ -3872,18 +3879,19 @@ export async function handleCommand(
           ? sessionCliDisplayName(ds)
           : configuredRuntimeDisplayName(botCfg?.cliRuntime) ?? getCliDisplayName(effectiveCliId);
         const workingDir = getSessionWorkingDir(ds);
-        // Codex App routes everything through the structured turn lane, so it has
-        // NO passthrough surface at all — mirror resolvePassthroughCommands's
-        // early empty return here and skip filesystem discovery (its PTY is the
-        // App Server runner, not an interactive TUI that would honor those).
-        const isCodexApp = effectiveCliId === 'codex-app';
-        const builtin = isCodexApp ? [] : [...PASSTHROUGH_COMMANDS];
-        const adapterDefaults = isCodexApp ? [] : resolveAdapterDefaultPassthroughCommands(larkAppId, effectiveCliId);
+        // Runner adapters route everything through the structured turn lane,
+        // so they have NO passthrough surface at all — mirror
+        // resolvePassthroughCommands's early empty return here and skip
+        // filesystem discovery (their PTY is the runner, not an interactive
+        // TUI that would honor those).
+        const noPassthrough = cliHasNoRawPassthroughSurface(effectiveCliId);
+        const builtin = noPassthrough ? [] : [...PASSTHROUGH_COMMANDS];
+        const adapterDefaults = noPassthrough ? [] : resolveAdapterDefaultPassthroughCommands(larkAppId, effectiveCliId);
         // 只展示「实际生效」的 custom 命令：用与 resolvePassthroughCommands 同一套
         // normalize 过滤掉手写 bots.json 里遮蔽 daemon 命令 / 非法的项（parser 出于
         // 兼容会保留它们，但路由会丢弃），避免 `/status` 之类被展示成可用却走 daemon。
         // Codex App 无透传面，custom 也不生效 → 与路由一致清空。
-        const custom = isCodexApp ? [] : [...new Set(
+        const custom = noPassthrough ? [] : [...new Set(
           (botCfg?.customPassthroughCommands ?? [])
             .map(normalizePassthroughCommand)
             .filter((c): c is string => !!c),
@@ -3892,7 +3900,7 @@ export async function handleCommand(
         // cliPathOverride（它属于另一个 CLI）。Codex App 直接跳过发现。
         const adapterPathOverride = effectiveCliId === botCfg?.cliId ? botCfg?.cliPathOverride : undefined;
         let cliAdapter;
-        if (!isCodexApp) {
+        if (!noPassthrough) {
           try {
             cliAdapter = createCliAdapterSync(effectiveCliId, adapterPathOverride);
           } catch (err) {

--- a/src/core/local-terminal-opener.ts
+++ b/src/core/local-terminal-opener.ts
@@ -68,7 +68,7 @@ function isCodexFamily(cliId: string): boolean {
 function defaultLocalExecutable(cliId: CliId, adapterResolvedBin: string, cliPathOverride?: string): string | null {
   if (cliPathOverride?.trim()) return cliPathOverride.trim();
   if (cliId === 'codex-app') return 'codex';
-  if (cliId === 'mira') return null;
+  if (cliId === 'mira' || cliId === 'dsh') return null;
   if (cliId === 'mir') return 'mircli';
   return adapterResolvedBin;
 }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1136,7 +1136,7 @@ function loadKnownBotOpenIdsForApp(larkAppId: string): Set<string> {
  *  mircli runner). They can't @-trigger a peer bot themselves, so for bot-to-bot
  *  handoffs the fallback card must carry the real <at> back to the dispatcher. */
 function isRunnerDeliveryCli(cliId?: string): boolean {
-  return cliId === 'mira' || cliId === 'mir';
+  return cliId === 'mira' || cliId === 'mir' || cliId === 'dsh';
 }
 
 function daemonCardFooterRecipientOpenId(ds: DaemonSession, effectiveCliId?: string): string | undefined {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2563,7 +2563,7 @@ function dashboardSkillCliIds(): CliId[] {
   const ids = new Set<CliId>();
   // Always scan all known CLI skill dirs, not just configured bots — users may
   // want to discover codex/trae/... skills even before creating a bot for them.
-  const allCliIds: CliId[] = ['claude-code', 'seed', 'relay', 'aiden', 'coco', 'codex', 'codex-app', 'cursor', 'gemini', 'genius', 'opencode', 'opencode2', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi', 'kimi', 'grok', 'kiro-cli', 'riff'];
+  const allCliIds: CliId[] = ['claude-code', 'seed', 'relay', 'aiden', 'coco', 'codex', 'codex-app', 'cursor', 'gemini', 'genius', 'opencode', 'opencode2', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi', 'kimi', 'grok', 'kiro-cli', 'riff', 'reasonix', 'dsh'];
   for (const cliId of allCliIds) ids.add(cliId);
   try {
     for (const cliId of configuredCliIds().values()) ids.add(cliId as CliId);

--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -31,6 +31,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { RunnerControlWriter } from './adapters/cli/runner-control-channel.js';
 
 const DSH_MARKER = '::botmux-dsh:';
@@ -326,10 +327,11 @@ try {
 }
 
 const cwd = args.cwd ? resolve(args.cwd) : process.cwd();
-// Stable across runner restarts so a respawned runner resumes the same dsh
-// session (the worker's stop/cancel path kills and restarts the runner).
-// dsh SessionId is opaque but constrained to a slug charset.
-const dshSessionId = `session-${args.sessionId.replace(/[^a-zA-Z0-9-]/g, '-')}`;
+// One runner process owns one dsh session. The id is random per runner: the
+// dsh SDK server has no create-or-resume, and its persistence layer rejects
+// creating a session whose id already has a log on disk. Cross-restart resume
+// therefore stays a limitation (a restarted runner starts a fresh session).
+const dshSessionId = `session-${randomUUID()}`;
 let client: DshJsonRpcClient;
 let activeTurn: PendingTurn | undefined;
 let shuttingDown = false;

--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -31,7 +31,6 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { randomUUID } from 'node:crypto';
 import { RunnerControlWriter } from './adapters/cli/runner-control-channel.js';
 
 const DSH_MARKER = '::botmux-dsh:';
@@ -95,6 +94,15 @@ interface PendingTurn {
   usage?: DshUsage;
   toolNames: Map<string, string>;
   timer: NodeJS.Timeout;
+  /** Set from the session/prompt ACK; the turn only owns events at/after
+   *  the matching agent/inbox/spliced receipt. */
+  messageId?: string;
+  /** Notifications buffered until the spliced receipt for messageId arrives. */
+  pending: Array<{ method: string; params: Record<string, unknown> }>;
+  receiptReceived: boolean;
+  /** Set from a turn/end event whose reason is an error, so a failed turn
+   *  surfaces in the reply instead of completing with an empty final. */
+  turnError?: string;
 }
 
 interface DshUsage {
@@ -318,7 +326,10 @@ try {
 }
 
 const cwd = args.cwd ? resolve(args.cwd) : process.cwd();
-const dshSessionId = `session-${randomUUID()}`;
+// Stable across runner restarts so a respawned runner resumes the same dsh
+// session (the worker's stop/cancel path kills and restarts the runner).
+// dsh SessionId is opaque but constrained to a slug charset.
+const dshSessionId = `session-${args.sessionId.replace(/[^a-zA-Z0-9-]/g, '-')}`;
 let client: DshJsonRpcClient;
 let activeTurn: PendingTurn | undefined;
 let shuttingDown = false;
@@ -341,9 +352,32 @@ function buildPreamble(): string {
   ].join('\n');
 }
 
-function handleSessionEvent(event: unknown): void {
-  const turn = activeTurn;
-  if (!turn || !event || typeof event !== 'object') return;
+/** Whether a session event is the durable enqueue receipt for `messageId`
+ *  (same correlation as the official SDK client's isInboxReceipt). */
+function isInboxReceipt(event: unknown, messageId: string): boolean {
+  if (!event || typeof event !== 'object') return false;
+  const ev = event as { type?: string; data?: { inserted?: unknown } };
+  if (ev.type !== 'agent/inbox/spliced' || !ev.data || !Array.isArray(ev.data.inserted)) return false;
+  return ev.data.inserted.some(m =>
+    m && typeof m === 'object' && (m as { id?: unknown }).id === messageId);
+}
+
+/** Claim the turn's receipt boundary: once messageId is known, scan buffered
+ *  notifications for its agent/inbox/spliced and replay only what follows.
+ *  Notifications before the receipt belong to a previous turn and are dropped. */
+function tryClaimReceipt(turn: PendingTurn): void {
+  if (turn.receiptReceived || !turn.messageId) return;
+  const idx = turn.pending.findIndex(item =>
+    item.method === 'session.event' && isInboxReceipt(item.params.event, turn.messageId!));
+  if (idx < 0) return;
+  turn.receiptReceived = true;
+  const queued = turn.pending.splice(idx + 1);
+  turn.pending.length = 0;
+  for (const item of queued) processTurnNotification(turn, item.method, item.params);
+}
+
+function handleSessionEvent(turn: PendingTurn, event: unknown): void {
+  if (!event || typeof event !== 'object') return;
   const ev = event as { type?: string; data?: Record<string, unknown> };
   switch (ev.type) {
     case 'tool/call': {
@@ -362,6 +396,13 @@ function handleSessionEvent(event: unknown): void {
       writeLine(`${isError ? '✗' : '✓'} ${name}`);
       break;
     }
+    case 'turn/end': {
+      const reason = ev.data?.reason as { kind?: string; error?: { message?: string } } | undefined;
+      if (reason?.kind === 'error') {
+        turn.turnError = reason.error?.message || `turn failed (${reason.kind})`;
+      }
+      break;
+    }
     case 'assistant/message': {
       const message = ev.data?.message as { content?: Array<{ type?: string; text?: string }> } | undefined;
       const blocks = message?.content;
@@ -369,11 +410,12 @@ function handleSessionEvent(event: unknown): void {
         // dsh emits one assistant/message per step. The turn's final response
         // is the LAST assistant message's text (same semantics as the SDK's
         // finalResponse): replace, don't append, so intermediate step chatter
-        // never leaks into the reply.
+        // never leaks into the reply. Multiple text blocks in one message
+        // concatenate with no separator (official SDK behavior).
         const parts = blocks
           .filter((b): b is { type: 'text'; text: string } => b?.type === 'text' && typeof b.text === 'string')
           .map(b => b.text);
-        turn.textBuffer = parts.join('\n');
+        turn.textBuffer = parts.join('');
       }
       // usage is per model call; accumulate across steps for a turn total.
       const usage = normalizeUsage(ev.data?.usage);
@@ -385,27 +427,39 @@ function handleSessionEvent(event: unknown): void {
   }
 }
 
+function processTurnNotification(turn: PendingTurn, method: string, p: Record<string, unknown>): void {
+  if (method === 'session.event') {
+    handleSessionEvent(turn, p.event);
+    return;
+  }
+  if (method === 'session.status' && p.status === 'idle' && activeTurn === turn) {
+    activeTurn = undefined;
+    clearTimeout(turn.timer);
+    lastTurnText = turn.textBuffer;
+    lastTurnUsage = turn.usage;
+    lastTurnError = turn.turnError;
+    turn.resolve();
+  }
+}
+
 function handleNotification(method: string, params: unknown): void {
   if (!params || typeof params !== 'object') return;
   const p = params as Record<string, unknown>;
+  if (method === 'session.event' || method === 'session.status') {
+    if (p.sessionId !== dshSessionId) return;
+    const turn = activeTurn;
+    if (!turn) return;
+    // Buffer until the spliced receipt for our messageId: stale notifications
+    // from a previous turn (notably a late idle) must not settle this one.
+    if (!turn.receiptReceived) {
+      turn.pending.push({ method, params: p });
+      tryClaimReceipt(turn);
+      return;
+    }
+    processTurnNotification(turn, method, p);
+    return;
+  }
   switch (method) {
-    case 'session.event': {
-      if (p.sessionId !== dshSessionId) return;
-      handleSessionEvent(p.event);
-      break;
-    }
-    case 'session.status': {
-      if (p.sessionId !== dshSessionId) return;
-      if (p.status === 'idle' && activeTurn) {
-        const turn = activeTurn;
-        activeTurn = undefined;
-        clearTimeout(turn.timer);
-        lastTurnText = turn.textBuffer;
-        lastTurnUsage = turn.usage;
-        turn.resolve();
-      }
-      break;
-    }
     case 'subagent.started':
       writeLine('↳ 子任务开始');
       break;
@@ -421,6 +475,7 @@ function handleNotification(method: string, params: unknown): void {
 // so runTurn can build the final marker after the promise resolves.
 let lastTurnText = '';
 let lastTurnUsage: DshUsage | undefined;
+let lastTurnError: string | undefined;
 
 async function runTurn(content: string): Promise<void> {
   const startedAtMs = Date.now();
@@ -443,15 +498,24 @@ async function runTurn(content: string): Promise<void> {
       startedAtMs,
       textBuffer: '',
       toolNames: new Map(),
+      pending: [],
+      receiptReceived: false,
       timer,
     };
   });
 
   try {
-    await client.request('session/prompt', {
+    const ack = await client.request<{ messageId?: string }>('session/prompt', {
       sessionId: dshSessionId,
       contentBlocks: [{ type: 'text', text: promptContent }],
     }, PROMPT_ACK_TIMEOUT_MS);
+    // The ACK's messageId correlates this turn's events: notifications may
+    // already be buffered (they can precede the response), and a late idle
+    // from the previous turn must not settle this one.
+    if (activeTurn && typeof ack.messageId === 'string') {
+      activeTurn.messageId = ack.messageId;
+      tryClaimReceipt(activeTurn);
+    }
     // Commit firstTurn only after the prompt was accepted: a rejected first
     // prompt must keep the identity preamble for the retry (double-send guard).
     firstTurn = false;
@@ -466,7 +530,8 @@ async function runTurn(content: string): Promise<void> {
   await turnPromise;
 
   const completedAtMs = Date.now();
-  const finalText = lastTurnText;
+  const finalText = lastTurnText
+    || (lastTurnError ? `dsh 执行出错：${lastTurnError}` : '');
   const finalUsage = lastTurnUsage;
   emitMarker('final', {
     content: finalText,

--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -162,9 +162,10 @@ function resolveConfigPath(): string {
   return path;
 }
 
-/** Map dsh's usage shape onto botmux's four-bucket final usage. The worker
- *  drops the whole usage unless every bucket is a non-negative integer, so
- *  missing buckets default to 0. */
+/** Map dsh's per-model-call usage onto botmux's four-bucket final usage.
+ *  dsh reports cacheWriteTokens where botmux says cacheCreateTokens. The
+ *  worker drops the whole usage unless every bucket is a non-negative
+ *  integer, so missing buckets default to 0. */
 function normalizeUsage(raw: unknown): DshUsage | undefined {
   if (!raw || typeof raw !== 'object') return undefined;
   const r = raw as Record<string, unknown>;
@@ -177,7 +178,18 @@ function normalizeUsage(raw: unknown): DshUsage | undefined {
     inputTokens,
     outputTokens,
     cacheReadTokens: num(r.cacheReadTokens) ?? 0,
-    cacheCreateTokens: 0,
+    cacheCreateTokens: num(r.cacheWriteTokens) ?? 0,
+  };
+}
+
+/** Accumulate per-step usage into a turn total (dsh meters each model call,
+ *  not the whole turn). */
+function addUsage(a: DshUsage, b: DshUsage): DshUsage {
+  return {
+    inputTokens: a.inputTokens + b.inputTokens,
+    outputTokens: a.outputTokens + b.outputTokens,
+    cacheReadTokens: a.cacheReadTokens + b.cacheReadTokens,
+    cacheCreateTokens: a.cacheCreateTokens + b.cacheCreateTokens,
   };
 }
 
@@ -354,14 +366,18 @@ function handleSessionEvent(event: unknown): void {
       const message = ev.data?.message as { content?: Array<{ type?: string; text?: string }> } | undefined;
       const blocks = message?.content;
       if (Array.isArray(blocks)) {
-        for (const block of blocks) {
-          if (block?.type === 'text' && typeof block.text === 'string') {
-            turn.textBuffer += turn.textBuffer ? `\n${block.text}` : block.text;
-          }
-        }
+        // dsh emits one assistant/message per step. The turn's final response
+        // is the LAST assistant message's text (same semantics as the SDK's
+        // finalResponse): replace, don't append, so intermediate step chatter
+        // never leaks into the reply.
+        const parts = blocks
+          .filter((b): b is { type: 'text'; text: string } => b?.type === 'text' && typeof b.text === 'string')
+          .map(b => b.text);
+        turn.textBuffer = parts.join('\n');
       }
+      // usage is per model call; accumulate across steps for a turn total.
       const usage = normalizeUsage(ev.data?.usage);
-      if (usage) turn.usage = usage;
+      if (usage) turn.usage = turn.usage ? addUsage(turn.usage, usage) : usage;
       break;
     }
     default:
@@ -415,7 +431,6 @@ async function runTurn(content: string): Promise<void> {
   writeLine('[dsh] thinking...');
 
   const promptContent = firstTurn ? `${buildPreamble()}${content}` : content;
-  firstTurn = false;
 
   const turnPromise = new Promise<void>((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -437,6 +452,9 @@ async function runTurn(content: string): Promise<void> {
       sessionId: dshSessionId,
       contentBlocks: [{ type: 'text', text: promptContent }],
     }, PROMPT_ACK_TIMEOUT_MS);
+    // Commit firstTurn only after the prompt was accepted: a rejected first
+    // prompt must keep the identity preamble for the retry (double-send guard).
+    firstTurn = false;
   } catch (err) {
     if (activeTurn) {
       clearTimeout(activeTurn.timer);

--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -1,0 +1,585 @@
+#!/usr/bin/env node
+/**
+ * dsh-runner: botmux runner for deepseek-harness (dsh).
+ *
+ * botmux spawns this with node (see adapters/cli/dsh.ts). It bridges two
+ * protocols:
+ *
+ *   botmux side (stdin/stdout):
+ *     - input frames:  `::botmux-dsh:<base64(JSON)>\n` one per user message
+ *     - output:        display lines + OSC control frames
+ *                      (`\x1b]777;botmux:<kind>:<base64>\x07`, see
+ *                      adapters/cli/runner-control-channel.ts)
+ *
+ *   dsh side (child `dsh-jsonrpc-agent` process, newline-delimited JSON-RPC):
+ *     - requests:  initialize / session/prompt / shutdown
+ *     - notifications: session.event (full event stream), session.status,
+ *                      subagent.started, subagent.finished
+ *
+ * One runner process owns one dsh session (a fixed sessionId reused across
+ * prompts, so the connection stays multi-turn). Turn completion is driven by
+ * `session.status: idle`. The agent's final text is accumulated from
+ * assistant/message events and delivered to botmux as a `final` control
+ * frame; tool calls render as progress lines.
+ *
+ * The SDK protocol has no cancel: a wedged turn is reaped by the turn
+ * watchdog, which kills the child and exits so botmux restarts the runner
+ * (the in-memory session is lost; sessions persist on disk under
+ * DSH_SESSION_ROOT but cross-process resume is not wired up yet).
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { RunnerControlWriter } from './adapters/cli/runner-control-channel.js';
+
+const DSH_MARKER = '::botmux-dsh:';
+const DEFAULT_TURN_TIMEOUT_MS = 10 * 60 * 1000;
+const HANDSHAKE_TIMEOUT_MS = 30_000;
+const PROMPT_ACK_TIMEOUT_MS = 30_000;
+const SHUTDOWN_GRACE_MS = 2_000;
+const DEFAULT_MODEL = 'deepseek-v4-flash';
+const DEFAULT_MAX_TOKENS = 49152;
+
+/**
+ * Vendored default composition, pinned to the dsh protocol version this
+ * runner speaks. Mirrors the wheel's runtime/cordis.yml; bump together with
+ * the dsh release. Written once per boot so the runtime always gets an
+ * explicit config (it refuses to start without one).
+ */
+const VENDORED_CONFIG = `# Vendored by botmux dsh-runner. Source: deepseek-harness python/sdk-runtime cordis.yml.
+- id: sdk-jsonrpc-server
+  name: '@deepseek-ai/dsh-sdk-jsonrpc-server'
+- id: agent-core
+  name: '@deepseek-ai/dsh-agent-spine-demo'
+  config:
+    workspaceContext:
+      maxBytes: 65536
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+- id: sessions
+  name: '@deepseek-ai/dsh-session-persistence-jsonl'
+  config:
+    root: !!js process.env.DSH_SESSION_ROOT ?? './.sessions'
+- id: session-checkpoints
+  name: '@deepseek-ai/dsh-session-checkpoint-policy'
+- id: subprocess
+  name: '@deepseek-ai/dsh-subprocess-local'
+- id: bash
+  name: '@deepseek-ai/dsh-bash-local'
+  config:
+    cwd: !!js process.env.DSH_CWD ?? process.cwd()
+- id: fs-local
+  name: '@deepseek-ai/dsh-fs-local'
+  config:
+    cwd: !!js process.env.DSH_CWD ?? process.cwd()
+`;
+
+interface Args {
+  sessionId: string;
+  dshBin: string;
+  cwd?: string;
+  botName?: string;
+  botOpenId?: string;
+  locale?: string;
+  model?: string;
+  turnTimeoutMs: number;
+}
+
+interface PendingTurn {
+  resolve: () => void;
+  reject: (err: Error) => void;
+  startedAtMs: number;
+  textBuffer: string;
+  usage?: DshUsage;
+  toolNames: Map<string, string>;
+  timer: NodeJS.Timeout;
+}
+
+interface DshUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+}
+
+const output = new RunnerControlWriter();
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { sessionId: '', dshBin: '', turnTimeoutMs: DEFAULT_TURN_TIMEOUT_MS };
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const val = argv[i + 1];
+    if (key === '--session-id' && val !== undefined) { out.sessionId = val; i++; }
+    else if (key === '--dsh-bin' && val !== undefined) { out.dshBin = val; i++; }
+    else if (key === '--cwd' && val !== undefined) { out.cwd = val; i++; }
+    else if (key === '--bot-name' && val !== undefined) { out.botName = val; i++; }
+    else if (key === '--bot-open-id' && val !== undefined) { out.botOpenId = val; i++; }
+    else if (key === '--locale' && val !== undefined) { out.locale = val; i++; }
+    else if (key === '--model' && val !== undefined) { out.model = val; i++; }
+    else if (key === '--turn-timeout-ms' && val !== undefined) {
+      const n = Number(val);
+      if (Number.isFinite(n) && n > 0) out.turnTimeoutMs = n;
+      i++;
+    }
+  }
+  if (!out.sessionId) throw new Error('--session-id is required');
+  if (!out.dshBin) throw new Error('--dsh-bin is required');
+  return out;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function emitMarker(kind: string, payload: unknown): void {
+  output.marker(kind, payload);
+}
+
+function writeLine(text = ''): void {
+  output.line(text);
+}
+
+function prompt(): void {
+  output.display('› ');
+}
+
+/** Resolve the dsh config: an explicit DSH_CORDIS_CONFIG wins, otherwise the
+ *  vendored composition is materialized under ~/.botmux/dsh. */
+function resolveConfigPath(): string {
+  const fromEnv = process.env.DSH_CORDIS_CONFIG?.trim();
+  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  const dir = join(homedir(), '.botmux', 'dsh');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, 'cordis.yml');
+  writeFileSync(path, VENDORED_CONFIG, 'utf8');
+  return path;
+}
+
+/** Map dsh's usage shape onto botmux's four-bucket final usage. The worker
+ *  drops the whole usage unless every bucket is a non-negative integer, so
+ *  missing buckets default to 0. */
+function normalizeUsage(raw: unknown): DshUsage | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const r = raw as Record<string, unknown>;
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isInteger(v) && v >= 0 ? v : undefined;
+  const inputTokens = num(r.inputTokens);
+  const outputTokens = num(r.outputTokens);
+  if (inputTokens === undefined || outputTokens === undefined) return undefined;
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens: num(r.cacheReadTokens) ?? 0,
+    cacheCreateTokens: 0,
+  };
+}
+
+/** Minimal JSON-RPC client over the dsh runtime's stdio transport. */
+class DshJsonRpcClient {
+  private child?: ChildProcessWithoutNullStreams;
+  private nextId = 1;
+  private readonly pending = new Map<number, {
+    resolve: (result: unknown) => void;
+    reject: (err: Error) => void;
+    timer: NodeJS.Timeout;
+  }>();
+  private stdoutBuffer = '';
+  private exited = false;
+  onNotification?: (method: string, params: unknown) => void;
+  onExit?: (code: number | null, signal: string | null) => void;
+
+  constructor(
+    private readonly dshBin: string,
+    private readonly configPath: string,
+    private readonly env: NodeJS.ProcessEnv,
+    private readonly cwd: string,
+  ) {}
+
+  start(): void {
+    this.child = spawn(this.dshBin, [this.configPath], {
+      env: this.env,
+      cwd: this.cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.child.stdout.setEncoding('utf8');
+    this.child.stdout.on('data', chunk => this.handleStdout(String(chunk)));
+    this.child.stderr.setEncoding('utf8');
+    this.child.stderr.on('data', chunk => output.error(`[dsh] ${String(chunk)}`));
+    this.child.on('error', err => this.failAll(err));
+    this.child.on('exit', (code, signal) => {
+      this.exited = true;
+      this.failAll(new Error(`dsh process exited (code=${code}, signal=${signal})`));
+      this.onExit?.(code, signal);
+    });
+  }
+
+  request<T>(method: string, params: unknown, timeoutMs: number): Promise<T> {
+    if (!this.child || this.exited) {
+      return Promise.reject(new Error('dsh child is not running'));
+    }
+    const id = this.nextId++;
+    const payload = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n';
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`dsh request '${method}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: result => resolve(result as T),
+        reject,
+        timer,
+      });
+      this.child!.stdin.write(payload);
+    });
+  }
+
+  kill(): void {
+    try { this.child?.kill('SIGTERM'); } catch { /* already gone */ }
+  }
+
+  /** Best-effort shutdown: ask nicely, then kill after the grace period. */
+  async shutdown(): Promise<void> {
+    if (!this.child || this.exited) return;
+    try {
+      await this.request('shutdown', {}, SHUTDOWN_GRACE_MS);
+    } catch { /* runtime may exit on its own; SIGTERM below is the backstop */ }
+    this.kill();
+  }
+
+  private handleStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    for (;;) {
+      const idx = this.stdoutBuffer.indexOf('\n');
+      if (idx < 0) break;
+      const line = this.stdoutBuffer.slice(0, idx).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(idx + 1);
+      if (!line) continue;
+      let msg: { id?: number; result?: unknown; error?: { message?: string }; method?: string; params?: unknown };
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        output.error(`[dsh] non-JSON stdout line: ${truncate(line, 200)}`);
+        continue;
+      }
+      if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+        const entry = this.pending.get(msg.id);
+        if (!entry) continue;
+        this.pending.delete(msg.id);
+        clearTimeout(entry.timer);
+        if (msg.error) {
+          entry.reject(new Error(`dsh error: ${msg.error.message ?? JSON.stringify(msg.error)}`));
+        } else {
+          entry.resolve(msg.result);
+        }
+      } else if (msg.method) {
+        this.onNotification?.(msg.method, msg.params);
+      }
+    }
+  }
+
+  private failAll(err: Error): void {
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(err);
+    }
+    this.pending.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runner state
+// ---------------------------------------------------------------------------
+
+let args: Args;
+try {
+  args = parseArgs(process.argv.slice(2));
+} catch (err) {
+  output.error(`${errorMessage(err)}\n`);
+  process.exit(2);
+}
+
+const cwd = args.cwd ? resolve(args.cwd) : process.cwd();
+const dshSessionId = `session-${randomUUID()}`;
+let client: DshJsonRpcClient;
+let activeTurn: PendingTurn | undefined;
+let shuttingDown = false;
+let firstTurn = true;
+
+const queue: string[] = [];
+let inputBuffer = '';
+let processing = false;
+
+function buildPreamble(): string {
+  const name = args.botName?.trim() || 'bot';
+  const locale = args.locale?.trim() || 'zh';
+  return [
+    '<botmux_identity>',
+    `你是飞书群机器人「${name}」，通过 deepseek-harness 运行。`,
+    '- 你的最终回复文本会被自动捕获并发送到群里，不要执行 botmux send 或任何发消息命令。',
+    `- 工作目录：${cwd}。语言：${locale}。`,
+    '</botmux_identity>',
+    '',
+  ].join('\n');
+}
+
+function handleSessionEvent(event: unknown): void {
+  const turn = activeTurn;
+  if (!turn || !event || typeof event !== 'object') return;
+  const ev = event as { type?: string; data?: Record<string, unknown> };
+  switch (ev.type) {
+    case 'tool/call': {
+      const name = String(ev.data?.name ?? 'tool');
+      const callId = String(ev.data?.callId ?? '');
+      if (callId) turn.toolNames.set(callId, name);
+      const argsText = typeof ev.data?.arguments === 'string' ? ev.data.arguments : '';
+      writeLine(`🔧 ${name} ${truncate(argsText, 200)}`);
+      break;
+    }
+    case 'tool/result': {
+      const message = ev.data?.message as { source?: { callId?: string }; content?: Array<{ isError?: boolean }> } | undefined;
+      const callId = String(message?.source?.callId ?? '');
+      const name = turn.toolNames.get(callId) ?? 'tool';
+      const isError = Array.isArray(message?.content) && message.content.some(c => c?.isError === true);
+      writeLine(`${isError ? '✗' : '✓'} ${name}`);
+      break;
+    }
+    case 'assistant/message': {
+      const message = ev.data?.message as { content?: Array<{ type?: string; text?: string }> } | undefined;
+      const blocks = message?.content;
+      if (Array.isArray(blocks)) {
+        for (const block of blocks) {
+          if (block?.type === 'text' && typeof block.text === 'string') {
+            turn.textBuffer += turn.textBuffer ? `\n${block.text}` : block.text;
+          }
+        }
+      }
+      const usage = normalizeUsage(ev.data?.usage);
+      if (usage) turn.usage = usage;
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function handleNotification(method: string, params: unknown): void {
+  if (!params || typeof params !== 'object') return;
+  const p = params as Record<string, unknown>;
+  switch (method) {
+    case 'session.event': {
+      if (p.sessionId !== dshSessionId) return;
+      handleSessionEvent(p.event);
+      break;
+    }
+    case 'session.status': {
+      if (p.sessionId !== dshSessionId) return;
+      if (p.status === 'idle' && activeTurn) {
+        const turn = activeTurn;
+        activeTurn = undefined;
+        clearTimeout(turn.timer);
+        lastTurnText = turn.textBuffer;
+        lastTurnUsage = turn.usage;
+        turn.resolve();
+      }
+      break;
+    }
+    case 'subagent.started':
+      writeLine('↳ 子任务开始');
+      break;
+    case 'subagent.finished':
+      writeLine(`↳ 子任务${p.status === 'ok' ? '完成' : '失败'}`);
+      break;
+    default:
+      break;
+  }
+}
+
+// The idle handler clears activeTurn; stash the completed turn's payload here
+// so runTurn can build the final marker after the promise resolves.
+let lastTurnText = '';
+let lastTurnUsage: DshUsage | undefined;
+
+async function runTurn(content: string): Promise<void> {
+  const startedAtMs = Date.now();
+  writeLine();
+  writeLine('[user]');
+  writeLine(content);
+  writeLine();
+  writeLine('[dsh] thinking...');
+
+  const promptContent = firstTurn ? `${buildPreamble()}${content}` : content;
+  firstTurn = false;
+
+  const turnPromise = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (activeTurn?.timer === timer) activeTurn = undefined;
+      reject(new Error(`dsh turn timed out after ${args.turnTimeoutMs}ms`));
+    }, args.turnTimeoutMs);
+    activeTurn = {
+      resolve,
+      reject,
+      startedAtMs,
+      textBuffer: '',
+      toolNames: new Map(),
+      timer,
+    };
+  });
+
+  try {
+    await client.request('session/prompt', {
+      sessionId: dshSessionId,
+      contentBlocks: [{ type: 'text', text: promptContent }],
+    }, PROMPT_ACK_TIMEOUT_MS);
+  } catch (err) {
+    if (activeTurn) {
+      clearTimeout(activeTurn.timer);
+      activeTurn = undefined;
+    }
+    throw err;
+  }
+
+  await turnPromise;
+
+  const completedAtMs = Date.now();
+  const finalText = lastTurnText;
+  const finalUsage = lastTurnUsage;
+  emitMarker('final', {
+    content: finalText,
+    ...(finalUsage ? { usage: finalUsage } : {}),
+    startedAtMs,
+    completedAtMs,
+  });
+  if (!finalText.trim()) writeLine('[dsh] completed without text output.');
+}
+
+function isFatalRunnerError(err: unknown): boolean {
+  const msg = errorMessage(err);
+  return msg.includes('timed out')
+    || msg.includes('exited')
+    || msg.includes('not running');
+}
+
+async function drainQueue(): Promise<void> {
+  if (processing) return;
+  processing = true;
+  try {
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      try {
+        await runTurn(next);
+      } catch (err) {
+        const now = Date.now();
+        const message = `dsh runner error: ${errorMessage(err)}`;
+        writeLine(message);
+        emitMarker('final', { content: message, startedAtMs: now, completedAtMs: now });
+        if (isFatalRunnerError(err)) {
+          // The child is wedged or gone: recycle the runner so botmux starts a
+          // fresh one (and a fresh dsh session) for the next turn.
+          client.kill();
+          setTimeout(() => process.exit(1), 100);
+          return;
+        }
+      }
+      prompt();
+    }
+  } finally {
+    processing = false;
+  }
+}
+
+function enqueueLine(line: string): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  if (!trimmed.startsWith(DSH_MARKER)) {
+    writeLine('[dsh] ignoring non-frame input');
+    return;
+  }
+  const encoded = trimmed.slice(DSH_MARKER.length);
+  try {
+    const decoded = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8')) as {
+      type?: string;
+      content?: unknown;
+      replyTurnId?: unknown;
+    };
+    if (decoded?.type === 'message' && typeof decoded.content === 'string') {
+      queue.push(decoded.content);
+      void drainQueue();
+    }
+  } catch (err) {
+    writeLine(`[dsh] bad botmux input: ${errorMessage(err)}`);
+  }
+}
+
+function handleInput(data: Buffer): void {
+  const text = data.toString('utf8');
+  for (const ch of text) {
+    if (ch === '\u0003') {
+      process.exit(130);
+    } else if (ch === '\r' || ch === '\n') {
+      const line = inputBuffer;
+      inputBuffer = '';
+      enqueueLine(line);
+    } else if (ch === '\u007f' || ch === '\b') {
+      inputBuffer = inputBuffer.slice(0, -1);
+    } else {
+      inputBuffer += ch;
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const configPath = resolveConfigPath();
+  const sessionRoot = join(homedir(), '.botmux', 'dsh-sessions', args.sessionId);
+  mkdirSync(sessionRoot, { recursive: true });
+
+  client = new DshJsonRpcClient(args.dshBin, configPath, {
+    ...process.env,
+    DSH_SESSION_ROOT: sessionRoot,
+    DSH_CWD: cwd,
+  }, cwd);
+  client.onNotification = handleNotification;
+  client.onExit = (code, signal) => {
+    if (shuttingDown) return;
+    const message = `dsh process exited unexpectedly (code=${code}, signal=${signal})`;
+    writeLine(message);
+    if (activeTurn) {
+      const turn = activeTurn;
+      activeTurn = undefined;
+      clearTimeout(turn.timer);
+      turn.reject(new Error(message));
+    }
+    setTimeout(() => process.exit(1), 100);
+  };
+  client.start();
+
+  const model = args.model?.trim() || DEFAULT_MODEL;
+  const serverInfo = await client.request<{ serverInfo?: { name?: string; version?: string } }>(
+    'initialize',
+    { cwd, provider: 'deepseek-official', model, maxTokens: DEFAULT_MAX_TOKENS },
+    HANDSHAKE_TIMEOUT_MS,
+  );
+  writeLine(`dsh connected (${serverInfo?.serverInfo?.name ?? 'unknown'} ${serverInfo?.serverInfo?.version ?? ''}).`);
+
+  if (process.stdin.isTTY) process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.on('data', handleInput);
+  process.stdin.on('end', () => {
+    shuttingDown = true;
+    void client.shutdown().finally(() => process.exit(0));
+  });
+  prompt();
+}
+
+process.on('SIGTERM', () => process.exit(0));
+
+main().catch(err => {
+  output.error(`dsh runner failed: ${errorMessage(err)}\n`);
+  process.exit(1);
+});

--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -621,7 +621,7 @@ function handleInput(data: Buffer): void {
 
 async function main(): Promise<void> {
   const configPath = resolveConfigPath();
-  const sessionRoot = join(homedir(), '.botmux', 'dsh-sessions', args.sessionId);
+  const sessionRoot = join(homedir(), '.botmux', 'dsh', 'sessions', args.sessionId);
   mkdirSync(sessionRoot, { recursive: true });
 
   client = new DshJsonRpcClient(args.dshBin, configPath, {

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -282,6 +282,7 @@ const cliDisplayNames: Record<CliId, string> = {
   'kiro-cli': 'Kiro',
   'riff': 'Riff',
   'reasonix': 'Reasonix',
+  'dsh': 'DeepSeek Harness',
 };
 
 export function getCliDisplayName(cliId: CliId): string {

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -34,6 +34,9 @@ export const CLI_ID_CHOICES: Record<string, CliId> = {
   '24': 'riff',
   '25': 'reasonix',
   '26': 'opencode2',
+  // 新增 CLI 一律追加到尾部：序号是脚本化 setup（非 TTY 管道喂数字）的稳定接口，
+  // 插位会让老脚本静默选错 CLI。
+  '27': 'dsh',
 };
 
 const VALID_CLI_IDS: ReadonlySet<string> = new Set(Object.values(CLI_ID_CHOICES));
@@ -70,6 +73,7 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'kiro-cli': 'Kiro',
   'riff': 'Riff',
   'reasonix': 'Reasonix',
+  'dsh': 'DeepSeek Harness',
 };
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1857,7 +1857,7 @@ let closeRequested = false;
 let capturedSpawnCommand: string | null = null;
 let deferredTopicOutputTail = '';
 const reportedDeferredTopicRoots = new Set<string>();
-const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', genius: 'Genius', opencode: 'OpenCode', opencode2: 'OpenCode 2', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', mir: 'Mir CLI', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi', kimi: 'Kimi', grok: 'Grok Build', 'kiro-cli': 'Kiro', riff: 'Riff', reasonix: 'Reasonix' };
+const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', genius: 'Genius', opencode: 'OpenCode', opencode2: 'OpenCode 2', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', mir: 'Mir CLI', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi', kimi: 'Kimi', grok: 'Grok Build', 'kiro-cli': 'Kiro', riff: 'Riff', reasonix: 'Reasonix', dsh: 'DeepSeek Harness' };
 function cliName(): string {
   return (lastInitConfig?.cliRuntime?.source === 'configured'
     ? (lastInitConfig.cliRuntime.displayName?.trim() || lastInitConfig.cliRuntime.id)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8101,11 +8101,11 @@ function handleVisibleStartupInteraction(data: string): boolean {
   return true;
 }
 
-// Mira/Mir still send terminal OSC control messages. Codex App deliberately
+// Mira/Mir/dsh send terminal OSC control messages. Codex App deliberately
 // does not (PR #597): its signed Unix-socket channel is independent of the
 // terminal/backend rendering (including Herdr and Zellij), so it is no longer
 // in the terminal-OSC decode set.
-const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir']);
+const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir', 'dsh']);
 const appRunnerControlDecoder = new RunnerControlDecoder();
 let kiroSessionIdCaptureArmed = false;
 let kiroSessionIdCaptureBuffer = '';

--- a/test/backend-capabilities.test.ts
+++ b/test/backend-capabilities.test.ts
@@ -17,7 +17,7 @@ describe('backendSupportsWebTerminal', () => {
 
 describe('backendCliCompatibilityError', () => {
   it('fails closed for runner CLIs whose final/thread events require hidden OSC on zmx', () => {
-    for (const cliId of ['codex-app', 'mira', 'mir'] as const) {
+    for (const cliId of ['codex-app', 'mira', 'mir', 'dsh'] as const) {
       expect(backendCliCompatibilityError('zmx', cliId)).toContain('hidden OSC');
       expect(backendCliCompatibilityError('tmux', cliId)).toBeUndefined();
     }

--- a/test/backend-gate.test.ts
+++ b/test/backend-gate.test.ts
@@ -305,9 +305,9 @@ describe('live-only observer screen rebase', () => {
 
   it('shares update and trust dialog handling with incremental PTY output', () => {
     const helperStart = workerSource.indexOf('function handleVisibleStartupInteraction(');
-    // PR #597 moved codex-app OFF terminal OSC; the comment after this helper now
-    // reads "// Mira/Mir still send terminal OSC" (was "// Codex App runner sends").
-    const helperEnd = workerSource.indexOf('// Mira/Mir still send terminal OSC', helperStart);
+    // Use the next stable declaration as the end delimiter (not a comment,
+    // which changes when runner CLIs are added to the OSC set).
+    const helperEnd = workerSource.indexOf('const APP_RUNNER_OSC_CLI_IDS', helperStart);
     const helper = workerSource.slice(helperStart, helperEnd);
     const ptyStart = workerSource.indexOf('function onPtyData(');
     const ptyEnd = workerSource.indexOf('function onBackendScreenResync(', ptyStart);

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -1217,6 +1217,32 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(cardJson).toContain('<at id=ou_dispatcher_bot></at>');
   });
 
+  it.each(['mira', 'mir', 'dsh'] as const)('addresses %s daemon fallback output back to the bot dispatcher', async (cliId) => {
+    const sessionReply = vi.fn(async () => 'om_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+
+    const ds = makeDs();
+    ds.session.cliId = cliId;
+    ds.session.ownerOpenId = undefined;
+    ds.ownerOpenId = undefined;
+    ds.session.creatorOpenId = 'ou_dispatcher_bot';
+    ds.session.quoteTargetSenderIsBot = true;
+
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    const cardJson = sessionReply.mock.calls[0][1] as string;
+    expect(cardJson).toContain('<at id=ou_dispatcher_bot></at>');
+  });
+
   it('addresses Mira fallback output to a known-bot owner (/repo-primed dispatch)', async () => {
     // `botmux dispatch --repo` primes the thread with "@bot /repo <path>",
     // which records the dispatching bot as ownerOpenId (daemon /repo

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -49,6 +49,7 @@ import { createKimiAdapter } from '../src/adapters/cli/kimi.js';
 import { createGrokAdapter } from '../src/adapters/cli/grok.js';
 import { createKiroCliAdapter } from '../src/adapters/cli/kiro-cli.js';
 import { createReasonixAdapter } from '../src/adapters/cli/reasonix.js';
+import { createDshAdapter } from '../src/adapters/cli/dsh.js';
 import { buildBotmuxShellHints, buildBotmuxSystemPromptText } from '../src/adapters/cli/shared-hints.js';
 import type { CliAdapter, CliId, PtyHandle } from '../src/adapters/cli/types.js';
 
@@ -56,7 +57,7 @@ import type { CliAdapter, CliId, PtyHandle } from '../src/adapters/cli/types.js'
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'genius', 'opencode', 'opencode2', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi', 'kimi', 'grok', 'kiro-cli', 'reasonix'];
+const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'genius', 'opencode', 'opencode2', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi', 'kimi', 'grok', 'kiro-cli', 'reasonix', 'dsh'];
 
 // ---------------------------------------------------------------------------
 // 1. Factory: createCliAdapterSync
@@ -80,7 +81,7 @@ describe('createCliAdapterSync factory', () => {
 
   it.each(ALL_CLI_IDS)('adapter for "%s" has resolvedBin set', (id) => {
     const adapter = createCliAdapterSync(id, `/opt/${id}`);
-    if (id === 'codex-app' || id === 'mira' || id === 'mir') expect(adapter.resolvedBin).toBe(process.execPath);
+    if (id === 'codex-app' || id === 'mira' || id === 'mir' || id === 'dsh') expect(adapter.resolvedBin).toBe(process.execPath);
     else expect(adapter.resolvedBin).toBe(`/opt/${id}`);
   });
 });
@@ -548,6 +549,71 @@ describe('mira buildArgs', () => {
     });
     expect(args).toContain('--mira-session-id');
     expect(args).toContain('mira-session-123');
+  });
+});
+
+describe('dsh buildArgs (runner model)', () => {
+  const adapter = createDshAdapter('/opt/dsh/bin/dsh-jsonrpc-agent');
+
+  it('spawns the node runner and passes the dsh runtime binary', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-dsh', resume: false, workingDir: '/repo/root' });
+    expect(adapter.resolvedBin).toBe(process.execPath);
+    expect(args[0]).toMatch(/dsh-runner\.js$/);
+    expect(args).toContain('--session-id');
+    expect(args).toContain('sess-dsh');
+    expect(args).toContain('--dsh-bin');
+    expect(args).toContain('/opt/dsh/bin/dsh-jsonrpc-agent');
+    expect(args).toContain('--cwd');
+    expect(args).toContain('/repo/root');
+  });
+
+  it('forwards bot identity, locale and model to the runner', () => {
+    const args = adapter.buildArgs({
+      sessionId: 's', resume: false, botName: 'Monday', botOpenId: 'ou_x', locale: 'zh', model: 'deepseek-v4-pro',
+    });
+    expect(args).toContain('--bot-name');
+    expect(args).toContain('Monday');
+    expect(args).toContain('--bot-open-id');
+    expect(args).toContain('ou_x');
+    expect(args).toContain('--locale');
+    expect(args).toContain('zh');
+    expect(args).toContain('--model');
+    expect(args).toContain('deepseek-v4-pro');
+  });
+
+  it('omits --model when no model is configured', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false });
+    expect(args).not.toContain('--model');
+  });
+
+  it('has no portable copy-paste resume command', () => {
+    expect(adapter.buildResumeCommand?.({ sessionId: 'sess-dsh', cliSessionId: 'session-abc' })).toBeNull();
+  });
+
+  it('readyPattern matches the runner prompt indicator', () => {
+    expect(adapter.readyPattern?.test('› ')).toBe(true);
+  });
+
+  it('does not type ahead (serial turns)', () => {
+    expect(adapter.supportsTypeAhead).not.toBe(true);
+  });
+
+  it('advertises the deepseek model choices', () => {
+    expect(adapter.modelChoices).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro']);
+  });
+
+  it('writeInput frames content with the dsh marker', async () => {
+    const written: string[] = [];
+    const pty = {
+      write: (data: string) => { written.push(data); return true; },
+    } as unknown as PtyHandle;
+    const result = await adapter.writeInput!(pty, 'hello dsh', { turnId: 'turn-1' });
+    expect(result).toEqual({ submitted: true, submissionDisposition: 'submitted' });
+    const line = written.join('');
+    expect(line.startsWith('::botmux-dsh:')).toBe(true);
+    const decoded = JSON.parse(Buffer.from(line.slice('::botmux-dsh:'.length).trim(), 'base64').toString('utf8'));
+    expect(decoded.content).toBe('hello dsh');
+    expect(decoded.replyTurnId).toBe('turn-1');
   });
 });
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -594,6 +594,10 @@ describe('dsh buildArgs (runner model)', () => {
     expect(adapter.readyPattern?.test('› ')).toBe(true);
   });
 
+  it('defers the first prompt until the runner is ready (slow handshake)', () => {
+    expect(adapter.deferFirstPromptTimeoutUntilReady).toBe(true);
+  });
+
   it('does not type ahead (serial turns)', () => {
     expect(adapter.supportsTypeAhead).not.toBe(true);
   });

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -1142,6 +1142,11 @@ describe('PASSTHROUGH_COMMANDS set', () => {
     // points at Codex App, while the inverse must stay structured.
     expect(resolvePassthroughCommands(CODEX_APP_ID, 'codex').has('/model')).toBe(true);
     expect(resolvePassthroughCommands(LARK_APP_ID, 'codex-app').size).toBe(0);
+    // Runner adapters (mira/mir/dsh) only accept framed input; raw slash
+    // passthrough would be rejected by the runner and wedge the session.
+    expect(resolvePassthroughCommands(LARK_APP_ID, 'mira').size).toBe(0);
+    expect(resolvePassthroughCommands(LARK_APP_ID, 'mir').size).toBe(0);
+    expect(resolvePassthroughCommands(LARK_APP_ID, 'dsh').size).toBe(0);
   });
 
   it('threads the frozen CLI through the ADAPTER-SCOPED layer, not just the builtin set', () => {

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -784,6 +784,18 @@ describe('/list-slash-command discovery', () => {
     expect(call.adapterDefaults).toContain('/goal');
   });
 
+  it.each(['codex-app', 'mira', 'mir', 'dsh'] as const)('shows NO passthrough for runner CLI %s', async (cliId) => {
+    const ds = makeDaemonSession({
+      larkAppId: LARK_APP_ID,
+      session: makeSession({ cliId }),
+    });
+    await handleCommand('/slash', ROOT_ID, makeLarkMessage('/slash'), makeDeps(ds), LARK_APP_ID);
+    expect(buildSlashListCard).toHaveBeenLastCalledWith(
+      expect.objectContaining({ builtin: [], adapterDefaults: [], custom: [] }),
+      expect.anything(),
+    );
+  });
+
   it('shows only effective custom passthrough commands (drops daemon-shadow + junk, normalizes)', async () => {
     // 手写 bots.json 可能留下 `/status`（遮蔽 daemon 命令，parser 出于兼容会保留但
     // 路由会丢弃）、非法项、大小写不一；展示侧须与 resolvePassthroughCommands 同口径。

--- a/test/dsh-runner.test.ts
+++ b/test/dsh-runner.test.ts
@@ -1,0 +1,180 @@
+/**
+ * dsh-runner integration tests: spawn the real runner against the fake dsh
+ * SDK JSON-RPC server (test/fixtures/fake-dsh-server.mjs).
+ *
+ * Run: pnpm vitest run test/dsh-runner.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const RUNNER_PATH = resolve('src/dsh-runner.ts');
+const FAKE_SERVER = resolve('test/fixtures/fake-dsh-server.mjs');
+const CONTROL_PREFIX = '::botmux-dsh:';
+
+interface Harness {
+  child: ChildProcessWithoutNullStreams;
+  home: string;
+  logPath: string;
+  stdout: string;
+  stderr: string;
+}
+
+const liveChildren = new Set<ChildProcessWithoutNullStreams>();
+
+function makeFrame(content: string): string {
+  return `${CONTROL_PREFIX}${Buffer.from(JSON.stringify({ type: 'message', content }), 'utf8').toString('base64')}\n`;
+}
+
+function parseMarkers(stdout: string): Array<{ kind: string; payload: any }> {
+  const markers: Array<{ kind: string; payload: any }> = [];
+  const re = /\x1b\]777;botmux:([a-z][a-z0-9_-]*):([A-Za-z0-9+/=]+)\x07/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(stdout))) {
+    markers.push({ kind: m[1], payload: JSON.parse(Buffer.from(m[2], 'base64').toString('utf8')) });
+  }
+  return markers;
+}
+
+async function waitFor(
+  get: () => boolean,
+  { timeout = 15_000, interval = 50, label = 'condition' }: { timeout?: number; interval?: number; label?: string } = {},
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (get()) return;
+    await new Promise(r => setTimeout(r, interval));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+function spawnRunner(scenario: string, extraArgs: string[] = []): Harness {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-runner-test-'));
+  const logPath = join(home, 'prompts.jsonl');
+  const child = spawn(process.execPath, ['--import', 'tsx', RUNNER_PATH,
+    '--session-id', 'test-session',
+    '--dsh-bin', FAKE_SERVER,
+    '--cwd', home,
+    '--bot-name', 'TestBot',
+    ...extraArgs,
+  ], {
+    cwd: resolve('.'),
+    env: {
+      ...process.env,
+      HOME: home,
+      FAKE_DSH_SCENARIO: scenario,
+      FAKE_DSH_LOG: logPath,
+    },
+  });
+  liveChildren.add(child);
+  const h: Harness = { child, home, logPath, stdout: '', stderr: '' };
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (d: string) => { h.stdout += d; });
+  child.stderr.on('data', (d: string) => { h.stderr += d; });
+  child.on('exit', () => liveChildren.delete(child));
+  return h;
+}
+
+function readPrompts(h: Harness): any[] {
+  if (!existsSync(h.logPath)) return [];
+  return readFileSync(h.logPath, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse);
+}
+
+describe('dsh-runner', () => {
+  let h: Harness | undefined;
+
+  beforeEach(() => { h = undefined; });
+  afterEach(() => {
+    if (h && !h.child.killed) {
+      try { h.child.kill('SIGKILL'); } catch { /* already gone */ }
+    }
+  });
+  afterEach(() => {
+    for (const child of liveChildren) {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+    }
+    liveChildren.clear();
+  });
+
+  it('boots, runs a turn, and delivers the final text with usage', async () => {
+    h = spawnRunner('happy');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('你好'));
+    await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
+
+    const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    expect(final.payload.content).toContain('你好，我是 dsh。');
+    expect(final.payload.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 42,
+      cacheReadTokens: 10,
+      cacheCreateTokens: 0,
+    });
+    // Tool calls render as progress lines.
+    expect(h.stdout).toContain('🔧 bash');
+    expect(h.stdout).toContain('✓ bash');
+    // The vendored config was materialized under HOME.
+    expect(existsSync(join(h.home, '.botmux', 'dsh', 'cordis.yml'))).toBe(true);
+  });
+
+  it('injects the identity preamble only on the first turn (multi-turn)', async () => {
+    h = spawnRunner('happy');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('第一句'));
+    await waitFor(() => parseMarkers(h.stdout).filter(m => m.kind === 'final').length >= 1, { label: 'first final' });
+    h.child.stdin.write(makeFrame('第二句'));
+    await waitFor(() => parseMarkers(h.stdout).filter(m => m.kind === 'final').length >= 2, { label: 'second final' });
+
+    const prompts = readPrompts(h);
+    expect(prompts).toHaveLength(2);
+    const firstText = prompts[0].prompt.contentBlocks[0].text;
+    const secondText = prompts[1].prompt.contentBlocks[0].text;
+    expect(firstText).toContain('<botmux_identity>');
+    expect(firstText).toContain('TestBot');
+    expect(firstText).toContain('第一句');
+    expect(secondText).not.toContain('<botmux_identity>');
+    expect(secondText).toBe('第二句');
+  });
+
+  it('delivers a JSON-RPC error as a final message', async () => {
+    h = spawnRunner('error');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('触发错误'));
+    await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
+
+    const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    expect(final.payload.content).toContain('boom');
+  });
+
+  it('emits an empty final when the agent produces no text', async () => {
+    h = spawnRunner('empty');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('只调工具'));
+    await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
+
+    const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    expect(final.payload.content).toBe('');
+    expect(h.stdout).toContain('completed without text output');
+  });
+
+  it('reaps a wedged turn with the watchdog and exits for restart', async () => {
+    h = spawnRunner('hang', ['--turn-timeout-ms', '500']);
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    const exitPromise = new Promise<number | null>(resolve => h!.child.on('exit', resolve));
+    h.child.stdin.write(makeFrame('卡住了'));
+    const code = await exitPromise;
+    expect(code).toBe(1);
+
+    const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    expect(final.payload.content).toContain('timed out');
+  }, 30_000);
+});

--- a/test/dsh-runner.test.ts
+++ b/test/dsh-runner.test.ts
@@ -165,6 +165,46 @@ describe('dsh-runner', () => {
     expect(h.stdout).toContain('completed without text output');
   });
 
+  it('takes only the last assistant message as the final text and accumulates usage', async () => {
+    h = spawnRunner('multi-step');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('多步任务'));
+    await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
+
+    const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    // The intermediate step text must not leak into the reply.
+    expect(final.payload.content).toBe('你好，我是 dsh。');
+    expect(final.payload.content).not.toContain('中间步骤');
+    // Per-model-call usage accumulates into a turn total.
+    expect(final.payload.usage).toEqual({
+      inputTokens: 150,
+      outputTokens: 50,
+      cacheReadTokens: 7,
+      cacheCreateTokens: 4,
+    });
+  });
+
+  it('keeps the identity preamble for the retry after a rejected first prompt', async () => {
+    h = spawnRunner('retry');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('第一次'));
+    await waitFor(() => parseMarkers(h.stdout).filter(m => m.kind === 'final').length >= 1, { label: 'error final' });
+    const errorFinal = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    expect(errorFinal.payload.content).toContain('boom');
+
+    h.child.stdin.write(makeFrame('第二次'));
+    await waitFor(() => parseMarkers(h.stdout).filter(m => m.kind === 'final').length >= 2, { label: 'success final' });
+
+    const prompts = readPrompts(h);
+    expect(prompts).toHaveLength(2);
+    // The first prompt was rejected, so the second one is still the first
+    // EXECUTED turn and must carry the identity preamble.
+    expect(prompts[1].prompt.contentBlocks[0].text).toContain('<botmux_identity>');
+    expect(prompts[1].prompt.contentBlocks[0].text).toContain('第二次');
+  });
+
   it('reaps a wedged turn with the watchdog and exits for restart', async () => {
     h = spawnRunner('hang', ['--turn-timeout-ms', '500']);
     await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });

--- a/test/dsh-runner.test.ts
+++ b/test/dsh-runner.test.ts
@@ -219,6 +219,9 @@ describe('dsh-runner', () => {
 
     const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
     expect(final.payload.content).toContain('你好，我是 dsh。');
+    // The fixture logs phase markers: notifications must precede the response.
+    const phases = readPrompts(h).filter((r: any) => r.phase).map((r: any) => r.phase);
+    expect(phases).toEqual(['notifications', 'response']);
   });
 
   it('keeps the identity preamble for the retry after a rejected first prompt', async () => {

--- a/test/dsh-runner.test.ts
+++ b/test/dsh-runner.test.ts
@@ -185,6 +185,42 @@ describe('dsh-runner', () => {
     });
   });
 
+  it('surfaces a turn-level error in the final instead of an empty reply', async () => {
+    h = spawnRunner('turn-error');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('触发 turn 错误'));
+    await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
+
+    const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    expect(final.payload.content).toContain('Authentication Fails');
+  });
+
+  it('drops stale notifications that arrive before the inbox receipt', async () => {
+    h = spawnRunner('stale');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('有旧通知'));
+    await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
+
+    const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    // The stale assistant/message and idle must not settle or pollute this turn.
+    expect(final.payload.content).toBe('你好，我是 dsh。');
+    expect(final.payload.content).not.toContain('STALE');
+    expect(final.payload.usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheCreateTokens: 0 });
+  });
+
+  it('claims the receipt when notifications arrive before the JSON-RPC response', async () => {
+    h = spawnRunner('early-receipt');
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('通知先到'));
+    await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
+
+    const final = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    expect(final.payload.content).toContain('你好，我是 dsh。');
+  });
+
   it('keeps the identity preamble for the retry after a rejected first prompt', async () => {
     h = spawnRunner('retry');
     await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });

--- a/test/fixtures/fake-dsh-server.mjs
+++ b/test/fixtures/fake-dsh-server.mjs
@@ -13,6 +13,10 @@ import { appendFileSync } from 'node:fs';
  *
  * Scenarios via FAKE_DSH_SCENARIO:
  *   happy (default) - full event stream with assistant text + usage
+ *   multi-step      - two assistant/message events; only the last is the final
+ *                     answer, and usage must accumulate across both
+ *   retry           - first session/prompt fails with a JSON-RPC error, the
+ *                     second runs the happy path (preamble must survive)
  *   error           - session/prompt fails with a JSON-RPC error
  *   empty           - tool calls only, no assistant text (empty final)
  *   hang            - never goes idle (exercises the turn watchdog)
@@ -23,6 +27,7 @@ const finalText = process.env.FAKE_DSH_FINAL_TEXT ?? '你好，我是 dsh。';
 const logPath = process.env.FAKE_DSH_LOG;
 
 let inputBuffer = '';
+let promptCount = 0;
 
 function send(obj) {
   process.stdout.write(JSON.stringify(obj) + '\n');
@@ -67,6 +72,38 @@ function runHappyTurn(sessionId) {
   notify('session.status', { sessionId, status: 'idle' });
 }
 
+function runMultiStepTurn(sessionId) {
+  const callId = 'call_multi_1';
+  sessionEvent(sessionId, {
+    type: 'tool/call',
+    data: { callId, name: 'bash', arguments: '{"command":"ls"}' },
+  });
+  sessionEvent(sessionId, {
+    type: 'assistant/message',
+    data: {
+      message: { role: 'assistant', content: [{ type: 'text', text: '中间步骤的阶段性文本' }] },
+      usage: { inputTokens: 100, outputTokens: 20, cacheReadTokens: 5, cacheWriteTokens: 3 },
+    },
+  });
+  sessionEvent(sessionId, {
+    type: 'tool/result',
+    data: {
+      message: {
+        source: { callId },
+        content: [{ type: 'tool-result', content: [], isError: false }],
+      },
+    },
+  });
+  sessionEvent(sessionId, {
+    type: 'assistant/message',
+    data: {
+      message: { role: 'assistant', content: [{ type: 'text', text: finalText }] },
+      usage: { inputTokens: 50, outputTokens: 30, cacheReadTokens: 2, cacheWriteTokens: 1 },
+    },
+  });
+  notify('session.status', { sessionId, status: 'idle' });
+}
+
 function runEmptyTurn(sessionId) {
   sessionEvent(sessionId, {
     type: 'tool/call',
@@ -100,7 +137,9 @@ function handleLine(line) {
     return;
   }
   if (msg.method === 'session/prompt') {
-    if (scenario === 'error') {
+    if (logPath) appendFileSync(logPath, JSON.stringify({ prompt: msg.params }) + '\n');
+    if (scenario === 'error' || (scenario === 'retry' && promptCount === 0)) {
+      promptCount++;
       send({
         jsonrpc: '2.0',
         id: msg.id,
@@ -108,13 +147,14 @@ function handleLine(line) {
       });
       return;
     }
+    promptCount++;
     send({ jsonrpc: '2.0', id: msg.id, result: { messageId: `msg-${msg.id}` } });
     const sessionId = msg.params?.sessionId ?? 'unknown';
-    if (logPath) appendFileSync(logPath, JSON.stringify({ prompt: msg.params }) + '\n');
     if (scenario === 'hang') return;
     // Notifications land after the enqueue receipt, like the real server.
     setImmediate(() => {
       if (scenario === 'empty') runEmptyTurn(sessionId);
+      else if (scenario === 'multi-step') runMultiStepTurn(sessionId);
       else runHappyTurn(sessionId);
     });
     return;

--- a/test/fixtures/fake-dsh-server.mjs
+++ b/test/fixtures/fake-dsh-server.mjs
@@ -14,10 +14,18 @@ import { appendFileSync } from 'node:fs';
  * Scenarios via FAKE_DSH_SCENARIO:
  *   happy (default) - full event stream with assistant text + usage
  *   multi-step      - two assistant/message events; only the last is the final
- *                     answer, and usage must accumulate across both
+ *                     answer, usage accumulates, and its two text blocks join
+ *                     with no separator
+ *   stale           - stale assistant/message + idle BEFORE this turn's
+ *                     inbox receipt; the runner must drop them
+ *   early-receipt   - receipt + events + idle are sent BEFORE the JSON-RPC
+ *                     response (real async ordering)
  *   retry           - first session/prompt fails with a JSON-RPC error, the
  *                     second runs the happy path (preamble must survive)
  *   error           - session/prompt fails with a JSON-RPC error
+ *   turn-error      - prompt accepted, but the turn ends with an LLM error
+ *                     (like the real 401 path): no assistant/message, a
+ *                     turn/end with reason.error — the runner must surface it
  *   empty           - tool calls only, no assistant text (empty final)
  *   hang            - never goes idle (exercises the turn watchdog)
  */
@@ -41,7 +49,15 @@ function sessionEvent(sessionId, event) {
   notify('session.event', { sessionId, event });
 }
 
-function runHappyTurn(sessionId) {
+function sendInboxReceipt(sessionId, messageId) {
+  sessionEvent(sessionId, {
+    type: 'agent/inbox/spliced',
+    data: { inserted: [{ id: messageId, role: 'user' }] },
+  });
+}
+
+function runHappyTurn(sessionId, messageId) {
+  sendInboxReceipt(sessionId, messageId);
   const callId = 'call_test_1';
   sessionEvent(sessionId, {
     type: 'tool/call',
@@ -72,7 +88,8 @@ function runHappyTurn(sessionId) {
   notify('session.status', { sessionId, status: 'idle' });
 }
 
-function runMultiStepTurn(sessionId) {
+function runMultiStepTurn(sessionId, messageId) {
+  sendInboxReceipt(sessionId, messageId);
   const callId = 'call_multi_1';
   sessionEvent(sessionId, {
     type: 'tool/call',
@@ -97,14 +114,50 @@ function runMultiStepTurn(sessionId) {
   sessionEvent(sessionId, {
     type: 'assistant/message',
     data: {
-      message: { role: 'assistant', content: [{ type: 'text', text: finalText }] },
+      // Two text blocks in one message concatenate with no separator.
+      message: { role: 'assistant', content: [{ type: 'text', text: '你好，' }, { type: 'text', text: '我是 dsh。' }] },
       usage: { inputTokens: 50, outputTokens: 30, cacheReadTokens: 2, cacheWriteTokens: 1 },
     },
   });
   notify('session.status', { sessionId, status: 'idle' });
 }
 
-function runEmptyTurn(sessionId) {
+/** Stale notifications from a previous turn arrive BEFORE this turn's
+ *  receipt; the runner must drop them and only own what follows the receipt. */
+function runStaleTurn(sessionId, messageId) {
+  sessionEvent(sessionId, {
+    type: 'assistant/message',
+    data: {
+      message: { role: 'assistant', content: [{ type: 'text', text: 'STALE' }] },
+      usage: { inputTokens: 999, outputTokens: 999 },
+    },
+  });
+  notify('session.status', { sessionId, status: 'idle' });
+  sendInboxReceipt(sessionId, messageId);
+  sessionEvent(sessionId, {
+    type: 'assistant/message',
+    data: {
+      message: { role: 'assistant', content: [{ type: 'text', text: finalText }] },
+      usage: { inputTokens: 10, outputTokens: 5 },
+    },
+  });
+  notify('session.status', { sessionId, status: 'idle' });
+}
+
+/** A turn that fails at the LLM call (mirrors the real 401 path): no
+ *  assistant/message, just a turn/end with an error reason. */
+function runTurnErrorTurn(sessionId, messageId) {
+  sendInboxReceipt(sessionId, messageId);
+  sessionEvent(sessionId, { type: 'turn/start', data: { turn: 1 } });
+  sessionEvent(sessionId, {
+    type: 'turn/end',
+    data: { turn: 1, reason: { kind: 'error', error: { message: 'Authentication Fails', code: 'AUTH', status: 401 } } },
+  });
+  notify('session.status', { sessionId, status: 'idle' });
+}
+
+function runEmptyTurn(sessionId, messageId) {
+  sendInboxReceipt(sessionId, messageId);
   sessionEvent(sessionId, {
     type: 'tool/call',
     data: { callId: 'call_empty', name: 'bash', arguments: '{}' },
@@ -148,14 +201,23 @@ function handleLine(line) {
       return;
     }
     promptCount++;
-    send({ jsonrpc: '2.0', id: msg.id, result: { messageId: `msg-${msg.id}` } });
+    const messageId = `msg-${msg.id}`;
     const sessionId = msg.params?.sessionId ?? 'unknown';
+    if (scenario === 'early-receipt') {
+      // Notifications before the JSON-RPC response.
+      setImmediate(() => runHappyTurn(sessionId, messageId));
+      send({ jsonrpc: '2.0', id: msg.id, result: { messageId } });
+      return;
+    }
+    send({ jsonrpc: '2.0', id: msg.id, result: { messageId } });
     if (scenario === 'hang') return;
     // Notifications land after the enqueue receipt, like the real server.
     setImmediate(() => {
-      if (scenario === 'empty') runEmptyTurn(sessionId);
-      else if (scenario === 'multi-step') runMultiStepTurn(sessionId);
-      else runHappyTurn(sessionId);
+      if (scenario === 'empty') runEmptyTurn(sessionId, messageId);
+      else if (scenario === 'multi-step') runMultiStepTurn(sessionId, messageId);
+      else if (scenario === 'stale') runStaleTurn(sessionId, messageId);
+      else if (scenario === 'turn-error') runTurnErrorTurn(sessionId, messageId);
+      else runHappyTurn(sessionId, messageId);
     });
     return;
   }

--- a/test/fixtures/fake-dsh-server.mjs
+++ b/test/fixtures/fake-dsh-server.mjs
@@ -204,9 +204,12 @@ function handleLine(line) {
     const messageId = `msg-${msg.id}`;
     const sessionId = msg.params?.sessionId ?? 'unknown';
     if (scenario === 'early-receipt') {
-      // Notifications before the JSON-RPC response.
-      setImmediate(() => runHappyTurn(sessionId, messageId));
+      // Notifications BEFORE the JSON-RPC response (real async ordering:
+      // the real server emits the spliced receipt before returning the ACK).
+      if (logPath) appendFileSync(logPath, JSON.stringify({ phase: 'notifications' }) + '\n');
+      runHappyTurn(sessionId, messageId);
       send({ jsonrpc: '2.0', id: msg.id, result: { messageId } });
+      if (logPath) appendFileSync(logPath, JSON.stringify({ phase: 'response' }) + '\n');
       return;
     }
     send({ jsonrpc: '2.0', id: msg.id, result: { messageId } });

--- a/test/fixtures/fake-dsh-server.mjs
+++ b/test/fixtures/fake-dsh-server.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+/**
+ * Fake dsh SDK JSON-RPC server for dsh-runner tests.
+ *
+ * Speaks the deepseek-harness SDK runtime protocol over stdio
+ * (newline-delimited JSON-RPC):
+ *   - initialize  -> {serverInfo}
+ *   - session/prompt -> {messageId}, then async notifications:
+ *       session.event (tool/call, assistant/message, tool/result),
+ *       session.status idle
+ *   - shutdown -> {}
+ *
+ * Scenarios via FAKE_DSH_SCENARIO:
+ *   happy (default) - full event stream with assistant text + usage
+ *   error           - session/prompt fails with a JSON-RPC error
+ *   empty           - tool calls only, no assistant text (empty final)
+ *   hang            - never goes idle (exercises the turn watchdog)
+ */
+
+const scenario = process.env.FAKE_DSH_SCENARIO ?? 'happy';
+const finalText = process.env.FAKE_DSH_FINAL_TEXT ?? '你好，我是 dsh。';
+const logPath = process.env.FAKE_DSH_LOG;
+
+let inputBuffer = '';
+
+function send(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+function notify(method, params) {
+  send({ jsonrpc: '2.0', method, params });
+}
+
+function sessionEvent(sessionId, event) {
+  notify('session.event', { sessionId, event });
+}
+
+function runHappyTurn(sessionId) {
+  const callId = 'call_test_1';
+  sessionEvent(sessionId, {
+    type: 'tool/call',
+    data: { callId, name: 'bash', arguments: '{"command":"echo hi"}' },
+  });
+  sessionEvent(sessionId, {
+    type: 'assistant/message',
+    data: {
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'thinking...' },
+          { type: 'text', text: finalText },
+        ],
+      },
+      usage: { inputTokens: 100, outputTokens: 42, cacheReadTokens: 10, reasoningTokens: 8 },
+    },
+  });
+  sessionEvent(sessionId, {
+    type: 'tool/result',
+    data: {
+      message: {
+        source: { callId },
+        content: [{ type: 'tool-result', content: [{ type: 'text', text: 'hi\n' }], isError: false }],
+      },
+    },
+  });
+  notify('session.status', { sessionId, status: 'idle' });
+}
+
+function runEmptyTurn(sessionId) {
+  sessionEvent(sessionId, {
+    type: 'tool/call',
+    data: { callId: 'call_empty', name: 'bash', arguments: '{}' },
+  });
+  sessionEvent(sessionId, {
+    type: 'tool/result',
+    data: {
+      message: {
+        source: { callId: 'call_empty' },
+        content: [{ type: 'tool-result', content: [], isError: false }],
+      },
+    },
+  });
+  notify('session.status', { sessionId, status: 'idle' });
+}
+
+function handleLine(line) {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (msg.method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id: msg.id,
+      result: { serverInfo: { name: 'fake-dsh', version: '0.0.1' } },
+    });
+    return;
+  }
+  if (msg.method === 'session/prompt') {
+    if (scenario === 'error') {
+      send({
+        jsonrpc: '2.0',
+        id: msg.id,
+        error: { code: -32000, message: 'boom' },
+      });
+      return;
+    }
+    send({ jsonrpc: '2.0', id: msg.id, result: { messageId: `msg-${msg.id}` } });
+    const sessionId = msg.params?.sessionId ?? 'unknown';
+    if (logPath) appendFileSync(logPath, JSON.stringify({ prompt: msg.params }) + '\n');
+    if (scenario === 'hang') return;
+    // Notifications land after the enqueue receipt, like the real server.
+    setImmediate(() => {
+      if (scenario === 'empty') runEmptyTurn(sessionId);
+      else runHappyTurn(sessionId);
+    });
+    return;
+  }
+  if (msg.method === 'shutdown') {
+    send({ jsonrpc: '2.0', id: msg.id, result: {} });
+    setTimeout(() => process.exit(0), 50);
+  }
+}
+
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => {
+  inputBuffer += chunk;
+  for (;;) {
+    const idx = inputBuffer.indexOf('\n');
+    if (idx < 0) break;
+    const line = inputBuffer.slice(0, idx).trim();
+    inputBuffer = inputBuffer.slice(idx + 1);
+    if (line) handleLine(line);
+  }
+});
+process.stdin.on('end', () => process.exit(0));

--- a/test/worker-app-runner-control-wiring.test.ts
+++ b/test/worker-app-runner-control-wiring.test.ts
@@ -8,6 +8,7 @@ import {
   CodexRunnerFreshnessInputQueue,
   type CodexRunnerFreshnessState,
 } from '../src/services/codex-runner-freshness.js';
+import { RunnerControlDecoder, RUNNER_CONTROL_PREFIX, RUNNER_CONTROL_END } from '../src/adapters/cli/runner-control-channel.js';
 
 const workerSource = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
 
@@ -374,5 +375,33 @@ describe('worker app-runner control-channel wiring', () => {
     expect(marker).not.toContain('finalText: deliverableContent');
     // The send payload still posts the stripped deliverable, not the raw final.
     expect(marker).toContain('content: (suppressDelivery || isSuperseded) ? \'\' : deliverableContent,');
+  });
+
+  it('enables OSC decoding for dsh and routes final frames to the generic path', () => {
+    // The worker only decodes runner OSC frames for cliIds in this set.
+    expect(workerSource).toContain("const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir', 'dsh']);");
+    // dsh finals go through the generic (non-codex-app) settlement path.
+    const markerStart = workerSource.indexOf('if (kind === \'final\' && typeof payload.content === \'string\')');
+    expect(markerStart).toBeGreaterThan(-1);
+    const genericPath = workerSource.indexOf('// Mira/Mir retain their terminal OSC control path', markerStart);
+    expect(genericPath).toBeGreaterThan(markerStart);
+  });
+
+  it('decodes a dsh final OSC frame without leaking control bytes to display', () => {
+    // Behavioral mirror of the worker's splitCodexAppControl: when the cliId
+    // is in the decode set, a `final` frame is stripped from the display
+    // stream and handed to the marker callback.
+    const decoder = new RunnerControlDecoder();
+    const markers: Array<{ kind: string; payload: unknown }> = [];
+    const content = '你好，我是 dsh。';
+    const frame = `${RUNNER_CONTROL_PREFIX}final:${Buffer.from(JSON.stringify({ content })).toString('base64')}${RUNNER_CONTROL_END}`;
+    const display = decoder.push(frame, true, body => {
+      const colon = body.indexOf(':');
+      markers.push({ kind: body.slice(0, colon), payload: JSON.parse(Buffer.from(body.slice(colon + 1), 'base64').toString('utf8')) });
+    });
+    expect(display).toBe('');
+    expect(markers).toHaveLength(1);
+    expect(markers[0].kind).toBe('final');
+    expect((markers[0].payload as { content: string }).content).toBe(content);
   });
 });

--- a/test/worker-dsh-turn.integration.test.ts
+++ b/test/worker-dsh-turn.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Worker-level integration test for the dsh adapter: spawns a real worker
+ * with cliId 'dsh', drives one turn through the fake dsh server, and asserts
+ * the final_output IPC contract (content, turnId, usage) and that OSC control
+ * bytes never leak into the display stream.
+ *
+ * Run: pnpm vitest run test/worker-dsh-turn.integration.test.ts
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { chmodSync, copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { DaemonToWorker, WorkerToDaemon } from '../src/types.js';
+
+const children = new Set<ChildProcess>();
+const tempDirs = new Set<string>();
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>(resolvePromise => {
+    const timer = setTimeout(() => child.kill('SIGKILL'), 3_000);
+    child.once('exit', () => { clearTimeout(timer); resolvePromise(); });
+    if (child.connected) child.send({ type: 'close' } satisfies DaemonToWorker);
+    else child.kill('SIGTERM');
+  });
+}
+
+afterEach(async () => {
+  await Promise.all([...children].map(stopChild));
+  children.clear();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+function waitFor(
+  child: ChildProcess,
+  logs: string[],
+  predicate: () => boolean,
+  timeoutMs = 30_000,
+): Promise<void> {
+  if (predicate()) return Promise.resolve();
+  return new Promise((resolvePromise, rejectPromise) => {
+    const poll = setInterval(() => {
+      if (!predicate()) return;
+      cleanup();
+      resolvePromise();
+    }, 50);
+    const timer = setTimeout(() => {
+      cleanup();
+      rejectPromise(new Error(`worker dsh timeout\n${logs.join('')}`));
+    }, timeoutMs);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      rejectPromise(new Error(`worker exited early (${code ?? signal})\n${logs.join('')}`));
+    };
+    const cleanup = () => {
+      clearInterval(poll);
+      clearTimeout(timer);
+      child.off('exit', onExit);
+    };
+    child.once('exit', onExit);
+  });
+}
+
+describe('dsh worker final_output integration', () => {
+  it('delivers one final_output with correct content/turnId/usage and no OSC leak', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-dsh-'));
+    tempDirs.add(root);
+    const fakeDsh = join(root, 'fake-dsh-server');
+    copyFileSync(resolve('test/fixtures/fake-dsh-server.mjs'), fakeDsh);
+    chmodSync(fakeDsh, 0o755);
+
+    const sessionId = `dsh-it-${randomBytes(4).toString('hex')}-${process.pid}`;
+    const logs: string[] = [];
+    const messages: WorkerToDaemon[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        NODE_ENV: 'test',
+        NODE_OPTIONS: [process.env.NODE_OPTIONS, '--import=tsx'].filter(Boolean).join(' '),
+        BOTMUX_TEST_DSH_RUNNER_PATH: resolve('src/dsh-runner.ts'),
+        SESSION_DATA_DIR: root,
+        BOTMUX_SESSION_ID: sessionId,
+        LARK_APP_ID: 'app_dsh_it',
+        LARK_APP_SECRET: 'secret',
+        FAKE_DSH_SCENARIO: 'happy',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+    child.on('message', raw => {
+      const message = raw as WorkerToDaemon;
+      messages.push(message);
+      if (message.type === 'error') logs.push(`[worker-ipc-error] ${message.message}\n`);
+    });
+
+    const init: DaemonToWorker = {
+      type: 'init',
+      sessionId,
+      chatId: 'oc_dsh_it',
+      rootMessageId: 'om_dsh_it_root',
+      workingDir: resolve('.'),
+      cliId: 'dsh',
+      cliPathOverride: fakeDsh,
+      backendType: 'pty',
+      prompt: '<user_message>你好 dsh</user_message>',
+      larkAppId: 'app_dsh_it',
+      larkAppSecret: 'secret',
+      turnId: 'om_dsh_it_turn_1',
+    };
+
+    try {
+      child.send(init);
+      await waitFor(child, logs, () =>
+        messages.some(m => m.type === 'final_output'));
+
+      const finals = messages.filter(
+        (m): m is Extract<WorkerToDaemon, { type: 'final_output' }> => m.type === 'final_output',
+      );
+      expect(finals).toHaveLength(1);
+      expect(finals[0].content).toContain('你好，我是 dsh。');
+      expect(finals[0].turnId).toBe('om_dsh_it_turn_1');
+      // Usage comes through the four-bucket shape.
+      expect(finals[0].usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 42,
+        cacheReadTokens: 10,
+        cacheCreateTokens: 0,
+      });
+
+      // OSC control bytes must not appear in any screen/display payload.
+      const screenLeaks = messages
+        .filter(m => m.type === 'screen_update' || m.type === 'display')
+        .filter(m => JSON.stringify(m).includes('\x1b]777;botmux:'));
+      expect(screenLeaks).toHaveLength(0);
+    } finally {
+      await stopChild(child);
+    }
+  }, 60_000);
+});

--- a/test/worker-dsh-turn.integration.test.ts
+++ b/test/worker-dsh-turn.integration.test.ts
@@ -8,7 +8,7 @@
  */
 import { spawn, type ChildProcess } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { chmodSync, copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -30,7 +30,10 @@ async function stopChild(child: ChildProcess): Promise<void> {
 afterEach(async () => {
   await Promise.all([...children].map(stopChild));
   children.clear();
-  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  for (const dir of tempDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); }
+    catch { /* sandbox may leave root-owned mount points; best effort */ }
+  }
   tempDirs.clear();
 });
 
@@ -139,6 +142,77 @@ describe('dsh worker final_output integration', () => {
         .filter(m => m.type === 'screen_update' || m.type === 'display')
         .filter(m => JSON.stringify(m).includes('\x1b]777;botmux:'));
       expect(screenLeaks).toHaveLength(0);
+    } finally {
+      await stopChild(child);
+    }
+  }, 60_000);
+
+  it('survives the file sandbox and persists config/sessions to the real HOME', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-dsh-sb-'));
+    tempDirs.add(root);
+    const fakeDsh = join(root, 'fake-dsh-server');
+    copyFileSync(resolve('test/fixtures/fake-dsh-server.mjs'), fakeDsh);
+    chmodSync(fakeDsh, 0o755);
+
+    const sessionId = `dsh-sb-${randomBytes(4).toString('hex')}-${process.pid}`;
+    const logs: string[] = [];
+    const messages: WorkerToDaemon[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        NODE_ENV: 'test',
+        NODE_OPTIONS: [process.env.NODE_OPTIONS, '--import=tsx'].filter(Boolean).join(' '),
+        BOTMUX_TEST_DSH_RUNNER_PATH: resolve('src/dsh-runner.ts'),
+        SESSION_DATA_DIR: root,
+        BOTMUX_SESSION_ID: sessionId,
+        LARK_APP_ID: 'app_dsh_sb',
+        LARK_APP_SECRET: 'secret',
+        FAKE_DSH_SCENARIO: 'happy',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+    child.on('message', raw => {
+      const message = raw as WorkerToDaemon;
+      messages.push(message);
+      if (message.type === 'error') logs.push(`[worker-ipc-error] ${message.message}\n`);
+    });
+
+    const init: DaemonToWorker = {
+      type: 'init',
+      sessionId,
+      chatId: 'oc_dsh_sb',
+      rootMessageId: 'om_dsh_sb_root',
+      workingDir: resolve('.'),
+      cliId: 'dsh',
+      cliPathOverride: fakeDsh,
+      backendType: 'pty',
+      sandbox: true,
+      prompt: '<user_message>沙盒测试</user_message>',
+      larkAppId: 'app_dsh_sb',
+      larkAppSecret: 'secret',
+      turnId: 'om_dsh_sb_turn_1',
+    };
+
+    try {
+      child.send(init);
+      await waitFor(child, logs, () =>
+        messages.some(m => m.type === 'final_output'));
+
+      const finals = messages.filter(
+        (m): m is Extract<WorkerToDaemon, { type: 'final_output' }> => m.type === 'final_output',
+      );
+      expect(finals).toHaveLength(1);
+      expect(finals[0].content).toContain('你好，我是 dsh。');
+
+      // The vendored config and session JSONL must land in the REAL HOME,
+      // not in a throwaway tmpfs that dies with the sandbox.
+      expect(existsSync(join(root, '.botmux', 'dsh', 'cordis.yml'))).toBe(true);
+      expect(existsSync(join(root, '.botmux', 'dsh', 'sessions', sessionId))).toBe(true);
     } finally {
       await stopChild(child);
     }

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -412,7 +412,7 @@ describe('worker pipe initial screen ordering', () => {
     expect(finalizeIdx).toBeGreaterThan(spawnIdx);
     expect(onDataIdx).toBeGreaterThan(finalizeIdx);
     expect(finalize).toContain("codexAppControlProven && codexAppControlStateValue?.status === 'active'");
-    expect(source).toContain("const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir']);");
+    expect(source).toContain("const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir', 'dsh']);");
     expect(source).not.toContain('CODEX_APP_CONTROL_NONCE_ENV');
     expect(source).not.toContain('codexAppControlNonceForSpawn');
   });


### PR DESCRIPTION
## 背景

deepseek-harness（dsh）是 DeepSeek 开源的 agent harness，没有 TUI，但提供 stdio JSON-RPC 接口。本 PR 让 botmux 能把 dsh 作为群机器人的 agent 后端。

方案与选型详见 `docs/design/2026-08-13-dsh-adapter.md`：走 runner 型 adapter（codex-app/mira 模式），runner 对 dsh 说 SDK JSON-RPC 协议（3 请求 + 4 通知），而非 ACP——因为打包的 `dsh-jsonrpc-agent` 说的就是 SDK 协议，且事件流更完整（工具调用可见）。

## 实现

- `src/dsh-runner.ts`（新增）：spawn `dsh-jsonrpc-agent`，NDJSON 握手（initialize），每 turn 一个 `session/prompt`，`session.status=idle` 收尾发 OSC `final` 帧；工具调用渲染为进度行；10 分钟看门狗；子进程异常退出由 worker 重拉
- `src/adapters/cli/dsh.ts`（新增）：thin adapter，照 codex-app/mira 模式，`writeInput` 复用 `writeRunnerInput`
- 注册：`CliId`、`registry.ts`、显示名（worker/card-builder/setup），setup 选项尾部追加（`'27': 'dsh'`）
- 首轮注入身份 preamble，明确禁止 agent 自行 `botmux send`（dsh 的 bash 是 runner 子进程，能看到 pid marker，不禁止会双发）
- dsh 配置（cordis.yml）内嵌 runner，启动时落到 `~/.botmux/dsh/cordis.yml`，支持 `DSH_CORDIS_CONFIG` 覆盖
- 会话 JSONL 落 `~/.botmux/dsh-sessions/`，已加 `authPaths` 保证沙箱内持久

## 测试

- `test/dsh-runner.test.ts`（新增 5 例）+ `test/fixtures/fake-dsh-server.mjs`（假 dsh 服务器）：正常多轮（含 preamble 只在首轮）、JSON-RPC 错误、空回复、看门狗回收
- `test/cli-adapters.test.ts`：dsh 段（buildArgs / writeInput 帧 / modelChoices / readyPattern）
- `tsc --noEmit` 干净；cli-adapters 348 + dsh-runner 5 + runner-input/control + bot-config-editor 等全过

## 已知限制（v2 backlog）

- SDK 协议无 cancel：中断 = 杀进程重开，丢当前会话上下文
- daemon 重启后不续聊（dsh 跨进程 resume 未接）
- 图片消息不支持
- 未做真机冒烟（本机无 `dsh-jsonrpc-agent` 二进制和 `DEEPSEEK_API_KEY`）；接入方配好后 bots.json 加 `cliId: "dsh"` + env `DEEPSEEK_API_KEY` 即可

🤖 Generated with [Claude Code](https://claude.com/claude-code)