### PR TITLE
feat(adapter): 新增 dsh 适配器（DeepSeek Harness，ACP 通道）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -62,7 +62,7 @@ More: [Roles & teams](https://deepcoldy.github.io/botmux/en/roles) · [File sand
 
 Switch with `cliId` in `bots.json`. **20+ adapters**, spanning local CLIs (process-isolated, reachable via `tmux attach`) and API / cloud agents (e.g. Mira, riff — reached over API / remote, not a local process). Representative ones:
 
-`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `opencode2` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `reasonix` · `aiden` · `coco` (TRAE) · `hermes` · `mira` · `riff` (cloud agent) …
+`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `opencode2` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `reasonix` · `dsh` (DeepSeek Harness) · `aiden` · `coco` (TRAE) · `hermes` · `mira` · `riff` (cloud agent) …
 
 The current full set of `cliId`s is authoritative in [`src/adapters/cli/registry.ts`](https://github.com/deepcoldy/botmux/blob/master/src/adapters/cli/registry.ts); per-CLI config and wrapper / gateway setups are in [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ botmux start                 # 启动 daemon（botmux autostart enable 设开机
 
 `bots.json` 里用 `cliId` 一键切换。**20+ 适配器**，覆盖本地 CLI（进程隔离，`tmux attach` 可直连）和 API / 云 Agent（如 Mira、riff——通过 API / 远端接入，非本地进程）。代表项：
 
-`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `opencode2` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `reasonix` · `aiden` · `coco`(TRAE) · `hermes` · `mira` · `riff`(云 Agent) …
+`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `opencode2` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `reasonix` · `dsh`(DeepSeek Harness) · `aiden` · `coco`(TRAE) · `hermes` · `mira` · `riff`(云 Agent) …
 
 当前完整 `cliId` 以 [`src/adapters/cli/registry.ts`](https://github.com/deepcoldy/botmux/blob/master/src/adapters/cli/registry.ts) 为准；各 CLI 的配置与套 wrapper / 网关方法见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
 

--- a/docs-site/docs/en/adapters.md
+++ b/docs-site/docs/en/adapters.md
@@ -36,6 +36,7 @@ The table lists the current built-in adapters (the **authoritative source** for 
 | `mira` | Mira APP | API / remote | |
 | `mir` | Mir CLI (local mircli + MCP bridge) | local process | |
 | `riff` | riff | cloud agent (API) | |
+| `dsh` | DeepSeek Harness (dsh, ACP channel) | local process | ✅ |
 
 > The `model` field only takes effect for adapters that support a model parameter; others ignore it. Mir CLI's extra prerequisites (login / miramcp) are in the section below.
 

--- a/docs-site/docs/zh/adapters.md
+++ b/docs-site/docs/zh/adapters.md
@@ -36,6 +36,7 @@ botmux 通过适配器桥接不同 CLI / Agent，`bots.json` 里用 `cliId` 选�
 | `mira` | Mira APP | API / 远端 | |
 | `mir` | Mir CLI（本地 mircli + MCP bridge） | 本地进程 | |
 | `riff` | riff | 云 Agent（API） | |
+| `dsh` | DeepSeek Harness（dsh，ACP 通道） | 本地进程 | ✅ |
 
 > `model` 字段只对支持模型参数的适配器生效，其它忽略。Mir CLI 的额外前置（登录 / miramcp）见下方专节。
 

--- a/src/adapters/cli/dsh.ts
+++ b/src/adapters/cli/dsh.ts
@@ -1,0 +1,130 @@
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type { CliAdapter, PtyHandle } from './types.js';
+import { writeRunnerInput } from './runner-input.js';
+import { resolveCommand } from './registry.js';
+
+/**
+ * DeepSeek Harness (dsh) adapter — drives the harness through its
+ * automation-only ACP transport (`@deepseek-ai/dsh-acp`, Agent Client Protocol
+ * over JSON-RPC stdio) via a small Node runner (src/dsh-runner.ts), mirroring
+ * the `mir` adapter's runner shape.
+ *
+ * Why ACP instead of the other dsh entry points:
+ *   - `--profile headless` is one-shot: every run creates a fresh session, so
+ *     multi-turn chat would lose all context;
+ *   - the TUI profile has no published app plugin yet (v0.1-rc);
+ *   - `dsh web` serves the browser UI over an undocumented client API;
+ *   - ACP is the officially designated programmatic channel: one long-lived
+ *     process per botmux session, `session/new` once, `session/prompt` per
+ *     turn, committed assistant text back — exactly botmux's session model.
+ *
+ * The runner boots `dsh --profile <name>` (default `acp`; the profile stacks
+ * dsh-base + the dsh-acp transport and is auto-provisioned on first use) and
+ * ships each turn's final text back over stdout OSC `final` markers (`dsh` is
+ * in APP_RUNNER_OSC_CLI_IDS), so delivery needs neither `botmux send` nor a
+ * BOTMUX_SESSION_ID.
+ *
+ * Limitation: the rc-stage ACP server creates fresh sessions only (resume
+ * belongs to other dsh entry points). checkResumeTargetExists therefore
+ * reports "no resume target" so a daemon restart falls back to a FRESH
+ * session with the worker's one-time user notice instead of silently losing
+ * context mid-conversation.
+ */
+
+function runnerPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const compiledSibling = resolve(here, '..', '..', 'dsh-runner.js');
+  if (existsSync(compiledSibling)) return compiledSibling;
+  const builtFromSourceTree = resolve(here, '..', '..', '..', 'dist', 'dsh-runner.js');
+  if (existsSync(builtFromSourceTree)) return builtFromSourceTree;
+  return compiledSibling;
+}
+
+function pushOpt(args: string[], key: string, value: string | undefined): void {
+  if (value === undefined || value.length === 0) return;
+  args.push(key, value);
+}
+
+export function createDshAdapter(pathOverride?: string): CliAdapter {
+  // A configured cliPathOverride is the dsh binary the runner should spawn
+  // (resolvedBin is the node runner itself). Resolve a bare name to an
+  // absolute path and hand it to the runner via --dsh-bin; the runner falls
+  // back to DSH_BIN / `dsh` on PATH when unset.
+  let cachedDshBin: string | undefined;
+  const dshBin = (): string | undefined => {
+    if (!pathOverride || !pathOverride.trim()) return undefined;
+    return (cachedDshBin ??= resolveCommand(pathOverride.trim()));
+  };
+  return {
+    id: 'dsh',
+    resolvedBin: process.execPath,
+
+    buildArgs({ sessionId, model, botName, disableCliBypass }) {
+      const args = [runnerPath(), '--session-id', sessionId];
+      pushOpt(args, '--dsh-bin', dshBin());
+      pushOpt(args, '--model', model);
+      pushOpt(args, '--bot-name', botName);
+      // The ACP bridge surfaces one-shot permission requests; the runner
+      // auto-allows them by default (matching the other adapters' bypass
+      // norm). A bot with disableCliBypass set must not silently approve, so
+      // the runner fails those requests closed instead.
+      if (disableCliBypass) args.push('--reject-permissions');
+      return args;
+    },
+
+    // The conversation lives in the harness's own session store
+    // (~/.dsh/sessions), but the rc-stage dsh CLI has no per-session resume
+    // entry point, so there is no copy-paste command for the user's terminal.
+    buildResumeCommand() {
+      return null;
+    },
+
+    // ACP sessions cannot be resumed (fresh `session/new` only), so every
+    // resume attempt provably has no target: the worker spawns FRESH and
+    // notifies the topic once instead of silently dropping context.
+    checkResumeTargetExists() {
+      return false;
+    },
+
+    async writeInput(pty: PtyHandle, content: string) {
+      // Chunked + throttled stdin injection (see runner-input.ts) — same path
+      // the mira / mir / codex-app runners use.
+      return writeRunnerInput(pty, '::botmux-dsh:', content);
+    },
+
+    completionPattern: undefined,
+    // The runner prints `› ` as its ready prompt between turns.
+    readyPattern: /›/,
+    systemHints: [],
+    // Delivery is the runner's stdout (`final` markers), like mir/mira — so
+    // the standard <botmux_routing> block, which would instruct the model to
+    // deliver via `botmux send`, must NOT be injected (it would double-deliver
+    // every reply). The runner flattens the remaining envelope and prepends
+    // its own minimal first-turn context instead.
+    injectsSessionContext: true,
+    altScreen: false,
+
+    modelChoices: ['deepseek-v4-flash', 'deepseek-v4-pro'],
+
+    // The whole harness home must stay REAL + writable inside the file
+    // sandbox: it holds the credential store (.credentials.yaml), the
+    // auto-provisioned ACP profile (profiles/acp — package.json + pnpm
+    // node_modules + cordis.patch.yml), and the JSONL session store. A narrow
+    // carve-out would leave the credential file and profile tree in the
+    // short-lived tmpfs, breaking auth on every spawn (see CLAUDE.md sandbox
+    // checklist items 1 and 3).
+    authPaths: ['~/.dsh'],
+
+    // resolvedBin is the node runner; the real dsh launcher is spawned as a
+    // second stage inside the sandbox and must survive the fresh `/run` tmpfs
+    // (version-manager shim farms live there on some hosts).
+    sandboxExtraExecPaths() {
+      const bin = dshBin() ?? resolveCommand('dsh');
+      return bin && bin !== 'dsh' ? [bin] : [];
+    },
+  };
+}
+
+export const create = createDshAdapter;

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -30,6 +30,7 @@ import { createGrokAdapter } from './grok.js';
 import { createKiroCliAdapter } from './kiro-cli.js';
 import { createRiffAdapter } from './riff.js';
 import { createReasonixAdapter } from './reasonix.js';
+import { createDshAdapter } from './dsh.js';
 
 /**
  * The first CLI executable (or nested runner dependency) before shell
@@ -70,6 +71,9 @@ const RAW_CLI_EXECUTABLES: Readonly<Record<CliId, string | undefined>> = {
   // API-backed; no local executable is required.
   riff: undefined,
   reasonix: 'reasonix',
+  // The adapter itself launches a bundled Node runner; dsh is its real
+  // second-stage dependency.
+  dsh: 'dsh',
 };
 
 /** Return the unresolved command without constructing an adapter or spawning a
@@ -169,7 +173,7 @@ export async function createCliAdapter(id: CliId, pathOverride?: string): Promis
   return adapter;
 }
 
-export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createGeniusAdapter, createOpenCodeAdapter, createOpenCode2Adapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createMirAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter, createKimiAdapter, createGrokAdapter, createKiroCliAdapter, createRiffAdapter, createReasonixAdapter };
+export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createGeniusAdapter, createOpenCodeAdapter, createOpenCode2Adapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createMirAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter, createKimiAdapter, createGrokAdapter, createKiroCliAdapter, createRiffAdapter, createReasonixAdapter, createDshAdapter };
 
 /** Synchronous version for use in worker process. */
 export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapter {
@@ -200,6 +204,7 @@ export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapt
     case 'kiro-cli': return createKiroCliAdapter(pathOverride);
     case 'riff': return createRiffAdapter(pathOverride);
     case 'reasonix': return createReasonixAdapter(pathOverride);
+    case 'dsh': return createDshAdapter(pathOverride);
     default: throw new Error(`Unknown CLI adapter: ${id}`);
   }
 }

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -535,4 +535,4 @@ export interface CliAdapter {
   buildSessionRenameCommand?(title: string): string;
 }
 
-export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'genius' | 'opencode' | 'opencode2' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'mir' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi' | 'kimi' | 'grok' | 'kiro-cli' | 'riff' | 'reasonix';
+export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'genius' | 'opencode' | 'opencode2' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'mir' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi' | 'kimi' | 'grok' | 'kiro-cli' | 'riff' | 'reasonix' | 'dsh';

--- a/src/core/local-terminal-opener.ts
+++ b/src/core/local-terminal-opener.ts
@@ -70,6 +70,9 @@ function defaultLocalExecutable(cliId: CliId, adapterResolvedBin: string, cliPat
   if (cliId === 'codex-app') return 'codex';
   if (cliId === 'mira') return null;
   if (cliId === 'mir') return 'mircli';
+  // dsh ACP sessions live inside the runner's harness process; there is no
+  // terminal command that reattaches to one.
+  if (cliId === 'dsh') return null;
   return adapterResolvedBin;
 }
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1132,11 +1132,12 @@ function loadKnownBotOpenIdsForApp(larkAppId: string): Set<string> {
 }
 
 /** CLIs whose model→Lark delivery is the daemon's stdout-runner fallback card
- *  (NOT the model calling `botmux send`): mira (Web API runner) and mir (local
- *  mircli runner). They can't @-trigger a peer bot themselves, so for bot-to-bot
- *  handoffs the fallback card must carry the real <at> back to the dispatcher. */
+ *  (NOT the model calling `botmux send`): mira (Web API runner), mir (local
+ *  mircli runner) and dsh (DeepSeek Harness ACP runner). They can't @-trigger a
+ *  peer bot themselves, so for bot-to-bot handoffs the fallback card must carry
+ *  the real <at> back to the dispatcher. */
 function isRunnerDeliveryCli(cliId?: string): boolean {
-  return cliId === 'mira' || cliId === 'mir';
+  return cliId === 'mira' || cliId === 'mir' || cliId === 'dsh';
 }
 
 function daemonCardFooterRecipientOpenId(ds: DaemonSession, effectiveCliId?: string): string | undefined {

--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -1,0 +1,483 @@
+#!/usr/bin/env node
+/**
+ * DeepSeek Harness (dsh) runner — the `dsh` adapter's backend.
+ *
+ * Boots ONE long-lived `dsh --profile <name>` process (default profile `acp`:
+ * dsh-base + the automation-only `@deepseek-ai/dsh-acp` transport) and speaks
+ * the Agent Client Protocol over its stdio: JSON-RPC 2.0, one JSON frame per
+ * line (ndjson).
+ *
+ *     initialize → session/new (cwd = botmux workspace) → per botmux turn:
+ *     session/prompt → collect committed `agent_message_chunk` text →
+ *     OSC `final` marker (parsed by the worker, see APP_RUNNER_OSC_CLI_IDS).
+ *
+ * Why ACP instead of `--profile headless` / the TUI / `dsh web`: headless is
+ * one-shot (fresh session per run — no multi-turn context), the TUI app plugin
+ * is unpublished at v0.1-rc, and the web profile serves a browser UI over an
+ * undocumented client API. ACP is dsh's designated programmatic channel and
+ * matches botmux's session model one-to-one.
+ *
+ * The ACP profile is auto-provisioned on first use (`dsh plugin --profile acp
+ * add @deepseek-ai/dsh-acp` + a cordis.patch.yml mounting the transport); the
+ * DeepSeek API key comes from the harness's own credential store
+ * (`~/.dsh/.credentials.yaml`, written by the web Models page) or a
+ * DEEPSEEK_API_KEY environment variable.
+ *
+ * Limitation: the rc-stage ACP server creates fresh sessions only, so a
+ * runner restart starts a new conversation (the adapter reports "no resume
+ * target" and the worker notifies the topic once).
+ */
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Buffer } from 'node:buffer';
+import { RunnerControlWriter } from './adapters/cli/runner-control-channel.js';
+// Generic, side-effect-free botmux-envelope flattener (unwraps <user_message>,
+// summarizes sender/mentions/attachments into prose). Shared with the mir
+// runner — both consume the same envelope through a stdout-delivery bridge.
+import { normalizeMircliPrompt } from './mir-prompt.js';
+
+interface Args {
+  sessionId: string;
+  dshBin?: string;
+  model?: string;
+  botName?: string;
+  rejectPermissions?: boolean;
+}
+
+const output = new RunnerControlWriter();
+const MARKER_PREFIX = '::botmux-dsh:';
+const DEFAULT_TURN_TIMEOUT_MS = 12 * 60 * 1000;
+const ACP_PLUGIN_PACKAGE = '@deepseek-ai/dsh-acp';
+const DEFAULT_PROVIDER = 'deepseek-official';
+const DEFAULT_MODEL = 'deepseek-v4-flash';
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { sessionId: '' };
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const val = argv[i + 1];
+    if (key === '--session-id' && val !== undefined) { out.sessionId = val; i++; }
+    else if (key === '--dsh-bin' && val !== undefined) { out.dshBin = val; i++; }
+    else if (key === '--model' && val !== undefined) { out.model = val; i++; }
+    else if (key === '--bot-name' && val !== undefined) { out.botName = val; i++; }
+    else if (key === '--reject-permissions') { out.rejectPermissions = true; }
+  }
+  if (!out.sessionId) throw new Error('--session-id is required');
+  return out;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function writeLine(text = ''): void {
+  output.line(text);
+}
+
+function prompt(): void {
+  output.display('› ');
+}
+
+/** Ensure the version-manager shim dirs dsh installs under are on PATH. */
+function localPathEnv(): string {
+  const existing = process.env.PATH || '';
+  const parts = existing.split(':');
+  const extra = [
+    join(homedir(), '.local', 'share', 'mise', 'shims'),
+    join(homedir(), '.local', 'bin'),
+  ].filter(dir => !parts.includes(dir));
+  return extra.length > 0 ? `${extra.join(':')}:${existing}` : existing;
+}
+
+function dshHome(): string {
+  return process.env.DSH_HOME || join(homedir(), '.dsh');
+}
+
+function profileName(): string {
+  return process.env.DSH_ACP_PROFILE || 'acp';
+}
+
+/** The patch layer that mounts the ACP transport over dsh-base. */
+function acpMountPatch(): string {
+  return [
+    '# botmux: mount the automation-only ACP transport over dsh-base.',
+    '# stdout is reserved for JSON-RPC frames; keep stdout-writing plugins out.',
+    '- id: hmr',
+    '  disabled: true',
+    '',
+    '- insert:',
+    `    - id: acp`,
+    `      name: '${ACP_PLUGIN_PACKAGE}'`,
+    '      config:',
+    `        provider: ${process.env.DSH_ACP_PROVIDER || DEFAULT_PROVIDER}`,
+    `        model: ${DEFAULT_MODEL}`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Provision the ACP profile on first use. `dsh plugin --profile <p> add`
+ * scaffolds the profile (dsh-base bundle) and pnpm-installs the transport;
+ * the patch layer then mounts it. Existing profiles are trusted as-is —
+ * except a missing ACP mount in the patch file, which is appended (top-level
+ * YAML array entries compose).
+ */
+function ensureAcpProfile(dshBin: string): void {
+  const profileDir = join(dshHome(), 'profiles', profileName());
+  const patchPath = join(profileDir, 'cordis.patch.yml');
+  if (!existsSync(join(profileDir, 'package.json'))) {
+    output.error(`[dsh] provisioning ACP profile "${profileName()}" (first use)...\n`);
+    const result = spawnSync(dshBin, ['plugin', '--profile', profileName(), 'add', ACP_PLUGIN_PACKAGE], {
+      encoding: 'utf-8',
+      timeout: 180_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, PATH: localPathEnv() },
+    });
+    if (result.status !== 0) {
+      const detail = `${result.stderr ?? ''}${result.stdout ?? ''}`.trim().slice(0, 800);
+      throw new Error(
+        `failed to provision the dsh ACP profile (dsh plugin --profile ${profileName()} add ${ACP_PLUGIN_PACKAGE}): `
+        + `${detail || `exit ${result.status}`}. Run that command manually, then retry.`,
+      );
+    }
+  }
+  const existingPatch = existsSync(patchPath) ? readFileSync(patchPath, 'utf-8') : '';
+  if (existingPatch.includes(ACP_PLUGIN_PACKAGE)) return;
+  // Scaffolded patch files carry only comments and `[]`; replace those, but
+  // append to a user-authored layer so their entries survive.
+  const scaffoldOnly = existingPatch.split('\n').every(line => {
+    const t = line.trim();
+    return t === '' || t.startsWith('#') || t === '[]';
+  });
+  if (scaffoldOnly) {
+    writeFileSync(patchPath, acpMountPatch());
+  } else {
+    appendFileSync(patchPath, `\n${acpMountPatch()}`);
+  }
+}
+
+interface PendingRequest {
+  resolve: (result: any) => void;
+  reject: (err: Error) => void;
+}
+
+class DshAcpClient {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private nextId = 0;
+  private readonly pending = new Map<number, PendingRequest>();
+  private chunks: string[] = [];
+  private acpSessionId = '';
+  private exited = false;
+
+  constructor(private readonly args: Args) {}
+
+  private dshBin(): string {
+    return this.args.dshBin || process.env.DSH_BIN || 'dsh';
+  }
+
+  /** Boot args: the profile, plus a --patch overlay when a per-bot model
+   *  override must replace the profile's acp config (patch layers replace the
+   *  whole config object, so the overlay always carries provider AND model). */
+  private bootArgs(): string[] {
+    const args = ['--profile', profileName()];
+    if (this.args.model) {
+      const overlay = join(mkdtempSync(join(tmpdir(), 'botmux-dsh-')), 'model-patch.yml');
+      writeFileSync(overlay, [
+        '- id: acp',
+        '  config:',
+        `    provider: ${process.env.DSH_ACP_PROVIDER || DEFAULT_PROVIDER}`,
+        `    model: ${this.args.model}`,
+        '',
+      ].join('\n'));
+      args.push('--patch', overlay);
+    }
+    return args;
+  }
+
+  async start(): Promise<string> {
+    ensureAcpProfile(this.dshBin());
+    const child = spawn(this.dshBin(), this.bootArgs(), {
+      cwd: process.cwd(),
+      env: { ...process.env, PATH: localPathEnv() },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.child = child;
+    child.stderr.on('data', (chunk: Buffer) => {
+      output.error(chunk.toString('utf8'));
+    });
+    const rl = createInterface({ input: child.stdout });
+    rl.on('line', line => { this.handleFrame(line); });
+    child.on('error', err => {
+      this.failAll(new Error(`failed to start dsh (${this.dshBin()}): ${errorMessage(err)}`));
+    });
+    child.on('close', (code, signal) => {
+      this.exited = true;
+      this.failAll(new Error(`dsh exited (${code ?? `signal ${signal ?? 'unknown'}`})`));
+      // Let an in-flight turn settle its error `final` first, then exit so the
+      // worker's crash handling respawns a fresh runner instead of keeping a
+      // zombie bridge whose every turn would fail.
+      const timer = setTimeout(() => process.exit(code === 0 ? 0 : 1), 250);
+      timer.unref();
+    });
+
+    await this.request('initialize', { protocolVersion: 1, clientCapabilities: {} });
+    const session = await this.request('session/new', { cwd: process.cwd(), mcpServers: [] });
+    if (typeof session?.sessionId !== 'string' || session.sessionId === '') {
+      throw new Error('dsh ACP session/new returned no sessionId');
+    }
+    this.acpSessionId = session.sessionId;
+    return this.acpSessionId;
+  }
+
+  async complete(content: string): Promise<{ finalText: string; turnId: string }> {
+    if (this.exited || !this.child) throw new Error('dsh process is not running');
+    this.chunks = [];
+    const timeoutMs = Number(process.env.DSH_RUNNER_TIMEOUT_MS || DEFAULT_TURN_TIMEOUT_MS);
+    let timer: NodeJS.Timeout | undefined;
+    if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        // Cancellation settles the pending prompt with stopReason `cancelled`;
+        // the collected chunks (if any) still ship back below.
+        this.notify('session/cancel', { sessionId: this.acpSessionId });
+      }, timeoutMs);
+      timer.unref();
+    }
+    try {
+      const result = await this.request('session/prompt', {
+        sessionId: this.acpSessionId,
+        prompt: [{ type: 'text', text: content }],
+      });
+      let finalText = this.chunks.filter(Boolean).join('\n\n').trim();
+      if (result?.stopReason && result.stopReason !== 'end_turn') {
+        finalText = finalText === ''
+          ? `[dsh] turn ended without text output (stopReason: ${result.stopReason})`
+          : `${finalText}\n\n[dsh] stopReason: ${result.stopReason}`;
+      }
+      return { finalText, turnId: `${this.acpSessionId}:${Date.now()}` };
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  shutdown(): void {
+    this.child?.kill('SIGTERM');
+  }
+
+  private request(method: string, params: unknown): Promise<any> {
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      if (this.exited || !this.child) {
+        reject(new Error('dsh process is not running'));
+        return;
+      }
+      this.pending.set(id, { resolve, reject });
+      this.child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    });
+  }
+
+  private notify(method: string, params: unknown): void {
+    if (this.exited || !this.child) return;
+    this.child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+  }
+
+  private respond(id: unknown, result: unknown): void {
+    if (this.exited || !this.child) return;
+    this.child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
+  }
+
+  private failAll(err: Error): void {
+    for (const [, request] of this.pending) request.reject(err);
+    this.pending.clear();
+  }
+
+  private handleFrame(line: string): void {
+    let msg: any;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // not a protocol frame; ignore
+    }
+    if (msg.id !== undefined && this.pending.has(msg.id)) {
+      const request = this.pending.get(msg.id)!;
+      this.pending.delete(msg.id);
+      if (msg.error) {
+        let detail = typeof msg.error.message === 'string' ? msg.error.message : JSON.stringify(msg.error);
+        if (detail.includes('MISSING_CREDENTIAL')) {
+          detail += ' — store the DeepSeek API key through the dsh credentials service'
+            + ' (~/.dsh/.credentials.yaml, written by the web Models page) or export DEEPSEEK_API_KEY.';
+        }
+        request.reject(new Error(detail));
+      } else {
+        request.resolve(msg.result);
+      }
+      return;
+    }
+    if (msg.method === 'session/update') {
+      const update = msg.params?.update;
+      if (update?.sessionUpdate === 'agent_message_chunk' && update.content?.type === 'text'
+        && typeof update.content.text === 'string') {
+        this.chunks.push(update.content.text);
+      }
+      return;
+    }
+    if (msg.method === 'session/request_permission' && msg.id !== undefined) {
+      const options: Array<{ optionId: string; kind?: string }> = msg.params?.options ?? [];
+      const wanted = this.args.rejectPermissions ? 'reject_once' : 'allow_once';
+      const choice = options.find(option => option.kind === wanted) ?? options[0];
+      if (!choice) {
+        this.respond(msg.id, { outcome: { outcome: 'cancelled' } });
+        return;
+      }
+      if (this.args.rejectPermissions) {
+        output.error('[dsh] permission request rejected (disableCliBypass is set for this bot)\n');
+      }
+      this.respond(msg.id, { outcome: { outcome: 'selected', optionId: choice.optionId } });
+    }
+  }
+}
+
+let args: Args;
+try {
+  args = parseArgs(process.argv.slice(2));
+} catch (err) {
+  output.error(`dsh runner: ${errorMessage(err)}\n`);
+  process.exit(2);
+}
+
+const client = new DshAcpClient(args);
+const queue: string[] = [];
+let inputBuffer = '';
+let processing = false;
+let firstTurn = true;
+
+/** Minimal session context for the first prompt. The ACP transport has no
+ *  per-session system-prompt surface, and the standard <botmux_routing>
+ *  envelope is suppressed (delivery is this runner's stdout, not `botmux
+ *  send`), so the model learns its situation here. */
+function firstTurnContext(): string {
+  return [
+    args.botName ? `You are the agent behind the bot "${args.botName}", bridged into a Lark (Feishu) topic by botmux.` : 'You are bridged into a Lark (Feishu) topic by botmux.',
+    'Your final reply text is delivered to the user automatically — do NOT try to send messages through other channels.',
+    'Attachments arrive as local file paths; read them with your file tools.',
+    '',
+  ].join('\n');
+}
+
+async function runTurn(content: string): Promise<void> {
+  const startedAtMs = Date.now();
+  writeLine();
+  writeLine('[user]');
+  writeLine(content);
+  writeLine();
+  writeLine('[dsh] thinking...');
+
+  // Flatten botmux's XML envelope (sender/mentions/attachments → prose) —
+  // the ACP prompt is one plain user message.
+  let promptText = normalizeMircliPrompt(content);
+  if (firstTurn) {
+    promptText = `${firstTurnContext()}\n${promptText}`;
+    firstTurn = false;
+  }
+  const result = await client.complete(promptText);
+  const completedAtMs = Date.now();
+  if (result.finalText) {
+    writeLine();
+    writeLine(result.finalText);
+    output.marker('final', {
+      nativeTurnId: result.turnId,
+      content: result.finalText,
+      startedAtMs,
+      completedAtMs,
+    });
+  } else {
+    writeLine('[dsh] completed without text output.');
+  }
+}
+
+async function drainQueue(): Promise<void> {
+  if (processing) return;
+  processing = true;
+  try {
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      try {
+        await runTurn(next);
+      } catch (err) {
+        const now = Date.now();
+        const message = `dsh runner error: ${errorMessage(err)}`;
+        writeLine(message);
+        output.marker('final', {
+          content: message,
+          startedAtMs: now,
+          completedAtMs: now,
+        });
+      }
+      prompt();
+    }
+  } finally {
+    processing = false;
+  }
+}
+
+function enqueueLine(line: string): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  if (trimmed.startsWith(MARKER_PREFIX)) {
+    const encoded = trimmed.slice(MARKER_PREFIX.length);
+    try {
+      const decoded = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+      if (decoded?.type === 'message' && typeof decoded.content === 'string') {
+        queue.push(decoded.content);
+        void drainQueue();
+      }
+    } catch (err) {
+      writeLine(`[dsh] bad botmux input: ${errorMessage(err)}`);
+    }
+    return;
+  }
+  queue.push(line);
+  void drainQueue();
+}
+
+function handleInput(data: Buffer): void {
+  const text = data.toString('utf8');
+  for (const ch of text) {
+    const code = ch.charCodeAt(0);
+    if (code === 3) {           // Ctrl-C
+      client.shutdown();
+      process.exit(130);
+    } else if (ch === '\r' || ch === '\n') {
+      const line = inputBuffer;
+      inputBuffer = '';
+      enqueueLine(line);
+    } else if (code === 127 || code === 8) {  // DEL / Backspace
+      inputBuffer = inputBuffer.slice(0, -1);
+    } else {
+      inputBuffer += ch;
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const acpSessionId = await client.start();
+  output.marker('thread', { threadId: acpSessionId });
+  writeLine('DeepSeek Harness ACP runner ready.');
+  if (process.stdin.isTTY) process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.on('data', handleInput);
+  prompt();
+}
+
+process.on('SIGTERM', () => {
+  client.shutdown();
+  process.exit(0);
+});
+
+main().catch(err => {
+  output.error(`dsh runner failed: ${errorMessage(err)}\n`);
+  process.exit(1);
+});

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -282,6 +282,7 @@ const cliDisplayNames: Record<CliId, string> = {
   'kiro-cli': 'Kiro',
   'riff': 'Riff',
   'reasonix': 'Reasonix',
+  'dsh': 'DeepSeek Harness',
 };
 
 export function getCliDisplayName(cliId: CliId): string {

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -34,6 +34,7 @@ export const CLI_ID_CHOICES: Record<string, CliId> = {
   '24': 'riff',
   '25': 'reasonix',
   '26': 'opencode2',
+  '27': 'dsh',
 };
 
 const VALID_CLI_IDS: ReadonlySet<string> = new Set(Object.values(CLI_ID_CHOICES));
@@ -70,6 +71,7 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'kiro-cli': 'Kiro',
   'riff': 'Riff',
   'reasonix': 'Reasonix',
+  'dsh': 'DeepSeek Harness',
 };
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1857,7 +1857,7 @@ let closeRequested = false;
 let capturedSpawnCommand: string | null = null;
 let deferredTopicOutputTail = '';
 const reportedDeferredTopicRoots = new Set<string>();
-const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', genius: 'Genius', opencode: 'OpenCode', opencode2: 'OpenCode 2', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', mir: 'Mir CLI', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi', kimi: 'Kimi', grok: 'Grok Build', 'kiro-cli': 'Kiro', riff: 'Riff', reasonix: 'Reasonix' };
+const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', genius: 'Genius', opencode: 'OpenCode', opencode2: 'OpenCode 2', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', mir: 'Mir CLI', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi', kimi: 'Kimi', grok: 'Grok Build', 'kiro-cli': 'Kiro', riff: 'Riff', reasonix: 'Reasonix', dsh: 'DeepSeek Harness' };
 function cliName(): string {
   return (lastInitConfig?.cliRuntime?.source === 'configured'
     ? (lastInitConfig.cliRuntime.displayName?.trim() || lastInitConfig.cliRuntime.id)
@@ -8105,7 +8105,7 @@ function handleVisibleStartupInteraction(data: string): boolean {
 // does not (PR #597): its signed Unix-socket channel is independent of the
 // terminal/backend rendering (including Herdr and Zellij), so it is no longer
 // in the terminal-OSC decode set.
-const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir']);
+const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir', 'dsh']);
 const appRunnerControlDecoder = new RunnerControlDecoder();
 let kiroSessionIdCaptureArmed = false;
 let kiroSessionIdCaptureBuffer = '';

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -41,6 +41,7 @@ import { GOAL_ENV } from '../src/workflows/v3/contract.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
 import { createMirAdapter } from '../src/adapters/cli/mir.js';
+import { createDshAdapter } from '../src/adapters/cli/dsh.js';
 import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
@@ -56,7 +57,7 @@ import type { CliAdapter, CliId, PtyHandle } from '../src/adapters/cli/types.js'
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'genius', 'opencode', 'opencode2', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi', 'kimi', 'grok', 'kiro-cli', 'reasonix'];
+const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'genius', 'opencode', 'opencode2', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi', 'kimi', 'grok', 'kiro-cli', 'reasonix', 'dsh'];
 
 // ---------------------------------------------------------------------------
 // 1. Factory: createCliAdapterSync
@@ -80,7 +81,7 @@ describe('createCliAdapterSync factory', () => {
 
   it.each(ALL_CLI_IDS)('adapter for "%s" has resolvedBin set', (id) => {
     const adapter = createCliAdapterSync(id, `/opt/${id}`);
-    if (id === 'codex-app' || id === 'mira' || id === 'mir') expect(adapter.resolvedBin).toBe(process.execPath);
+    if (id === 'codex-app' || id === 'mira' || id === 'mir' || id === 'dsh') expect(adapter.resolvedBin).toBe(process.execPath);
     else expect(adapter.resolvedBin).toBe(`/opt/${id}`);
   });
 });
@@ -604,6 +605,64 @@ describe('mir buildArgs (runner model)', () => {
   it('injectsSessionContext (runner injects its own context) + empty systemHints', () => {
     expect(adapter.injectsSessionContext).toBe(true);
     expect(adapter.systemHints).toEqual([]);
+  });
+});
+
+describe('dsh buildArgs (runner model)', () => {
+  const adapter = createDshAdapter();
+
+  it('spawns the dsh-runner via node with --session-id', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-dsh', resume: false });
+    expect(adapter.resolvedBin).toBe(process.execPath);
+    expect(args[0]).toMatch(/dsh-runner\.js$/);
+    expect(args).toContain('--session-id');
+    expect(args).toContain('sess-dsh');
+  });
+
+  it('forwards model + bot name to the runner', () => {
+    const args = adapter.buildArgs({
+      sessionId: 's', resume: false, model: 'deepseek-v4-pro', botName: 'DS',
+    });
+    expect(args).toContain('--model');
+    expect(args).toContain('deepseek-v4-pro');
+    expect(args).toContain('--bot-name');
+    expect(args).toContain('DS');
+  });
+
+  it('passes --reject-permissions only when disableCliBypass is set', () => {
+    expect(adapter.buildArgs({ sessionId: 's', resume: false })).not.toContain('--reject-permissions');
+    expect(adapter.buildArgs({ sessionId: 's', resume: false, disableCliBypass: true })).toContain('--reject-permissions');
+  });
+
+  it('passes a cliPathOverride to the runner via --dsh-bin (absolute kept as-is)', () => {
+    const overridden = createDshAdapter('/opt/dsh/bin/dsh');
+    const args = overridden.buildArgs({ sessionId: 's', resume: false });
+    const idx = args.indexOf('--dsh-bin');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('/opt/dsh/bin/dsh');
+  });
+
+  it('omits --dsh-bin when no cliPathOverride is configured', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false });
+    expect(args).not.toContain('--dsh-bin');
+  });
+
+  it('always reports "no resume target" (rc-stage ACP is fresh-session only)', () => {
+    expect(adapter.checkResumeTargetExists?.({ sessionId: 'bm-1', cliSessionId: 'acp-9' })).toBe(false);
+    expect(adapter.buildResumeCommand?.({ sessionId: 'bm-1', cliSessionId: 'acp-9' })).toBeNull();
+  });
+
+  it('readyPattern matches the runner prompt indicator', () => {
+    expect(adapter.readyPattern?.test('› ')).toBe(true);
+  });
+
+  it('injectsSessionContext (stdout delivery — no botmux send routing block) + empty systemHints', () => {
+    expect(adapter.injectsSessionContext).toBe(true);
+    expect(adapter.systemHints).toEqual([]);
+  });
+
+  it('binds the whole harness home rw in the file sandbox (credentials + profile + sessions)', () => {
+    expect(adapter.authPaths).toEqual(['~/.dsh']);
   });
 });
 
@@ -1606,6 +1665,7 @@ describe('id property', () => {
     ['copilot', () => createCopilotAdapter('/bin/copilot')],
     ['kiro-cli', () => createKiroCliAdapter('/bin/kiro-cli')],
     ['reasonix', () => createReasonixAdapter('/bin/reasonix')],
+    ['dsh', () => createDshAdapter()],
   ];
 
   it.each(expected)('adapter id is "%s"', (expectedId, factory) => {

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -412,7 +412,7 @@ describe('worker pipe initial screen ordering', () => {
     expect(finalizeIdx).toBeGreaterThan(spawnIdx);
     expect(onDataIdx).toBeGreaterThan(finalizeIdx);
     expect(finalize).toContain("codexAppControlProven && codexAppControlStateValue?.status === 'active'");
-    expect(source).toContain("const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir']);");
+    expect(source).toContain("const APP_RUNNER_OSC_CLI_IDS = new Set(['mira', 'mir', 'dsh']);");
     expect(source).not.toContain('CODEX_APP_CONTROL_NONCE_ENV');
     expect(source).not.toContain('codexAppControlNonceForSpawn');
   });


### PR DESCRIPTION
## 改了什么

新增 **DeepSeek Harness**（`@deepseek-ai/dsh`，2026-08-13 开源的 v0.1-rc）CLI 适配器，cliId `dsh`。

### 接入形态选型（多形态对比）

dsh 提供 web / headless / TUI（未发布）/ ACP 四种形态，逐一评估后选 **ACP**（Agent Client Protocol，JSON-RPC over stdio）：

| 形态 | 结论 |
|---|---|
| `--profile headless` | 一次性进程，每次全新 session，多轮对话无上下文 |
| TUI | 官方 app 插件在 v0.1-rc 尚未发布 |
| `dsh web` | 面向浏览器 UI，客户端 API 未文档化 |
| **ACP**（`@deepseek-ai/dsh-acp`）| 官方“automation-only”程序化通道，session/new → 每回合 session/prompt → 返回 committed 文本 + stopReason，与 botmux 会话模型一一对应 |

复用仓库已有的 **runner 形态先例（mir/mira）**：适配器 spawn 一个 Node runner（`src/dsh-runner.ts`），runner 内部长驻一个 `dsh --profile acp` 子进程，回合结果经 stdout OSC `final` 标记回传（`dsh` 加入 `APP_RUNNER_OSC_CLI_IDS`），无需 `botmux send`。

### 主要文件

- `src/dsh-runner.ts`（新）：ACP 客户端 runner——ndjson JSON-RPC；acp profile 首用自动预置（`dsh plugin --profile acp add @deepseek-ai/dsh-acp` + patch 挂载，已有 profile 不覆盖）；`--model` 通过 `--patch` overlay 覆盖（patch 是整块替换，overlay 恒带 provider+model 两键）；`session/request_permission` 默认自动允许、`--reject-permissions`（disableCliBypass）时拒绝；回合超时发 `session/cancel`；dsh 子进程死亡时先落错误 final 再退出，交给 worker 崩溃重启
- `src/adapters/cli/dsh.ts`（新）：runner 模型适配器。`injectsSessionContext: true`——投递走 stdout，标准 `<botmux_routing>`（指示模型跑 `botmux send`）注入会造成双投递，必须跳过；runner 复用 `mir-prompt.ts` 的 envelope 扁平化并在首轮注入最小身份上下文
- 接线：`CliId` 联合类型、registry、worker 显示名 + OSC 集合、card-builder 显示名、setup 序号（**尾部追加 `27`**）+ 展示名、`local-terminal-opener`（dsh 无可接续的本地命令 → null）、`worker-pool.isRunnerDeliveryCli`（dsh 同 mir/mira 不能 @ 其它 bot，bot-to-bot 交接回落卡需 @ 回派发方）、README 双语、docs-site 适配器表双语

## 为什么

DeepSeek Harness 刚开源即有接入需求；ACP 是其官方给程序化客户端的通道，升级面最平滑，且 botmux 已有同拓扑基建（runner + OSC final），worker 协议零新增。

## 已知限制（诚实声明）

rc 版 ACP 仅支持新建会话（无 session/load）。适配器 `checkResumeTargetExists` 恒返回 false：daemon 重启后走 worker 既有的 fresh 回退路径并向话题提示一次，而不是静默丢上下文；dsh 后续补 resume 后可经 `resumeSessionId` 无缝升级。

## 影响面评估

- **共用路径改动**：`worker.ts` 仅加显示名 + OSC 集合成员（该集合原值 `['mira','mir']` 不变语义）；`worker-pool.isRunnerDeliveryCli` 加一个 id；`local-terminal-opener` 加一个早退分支；其余为各展示名/序号表尾部追加。未动 `shared-hints`、`runner-input`、session-manager 与任何后端
- **跨 CLI**：`runner-input`/`runner-control-channel`/`mir-prompt` 均为只读复用，未改；mir/mira/codex-app 行为不变（cli-adapters 全量 350 用例绿）
- **跨平台**：runner 只用 node:child_process/fs/readline，无平台特定逻辑；PATH 兜底补 mise shims 与 ~/.local/bin 两个目录
- **沙盒**：`authPaths: ['~/.dsh']` 目录级绑定（credentials + profile + sessions 按清单三项必查设计），`sandboxExtraExecPaths` 暴露二段 dsh 可执行；bwrap 为 Linux 侧机制，本机（macOS）未实测沙盒开启组合，声明为待 Linux 验证项

## 实际测试验证

- `pnpm build` 通过；`pnpm test` 15134 通过 / 2 失败——失败的 `skill-doctor-command.test.ts` 两例已在干净 master 上复现（环境性既有失败，与本 PR 无关）
- ACP 通道手工探针（真 API）：initialize / session/new / 两轮 session/prompt 往返 3.3s，同 session 上下文连续性验证通过；工具调用真实执行（bash `expr 6 \* 7` → 42）
- 编译产物 `dist/dsh-runner.js` 端到端（真 API）：thread 标记（ACP session id）、两轮 final 标记内容与时间戳正确、第二轮召回第一轮内容（上下文连续）、`›` ready 提示符正常
- `--model deepseek-v4-pro` overlay 启动 + 回合冒烟通过；删除 profile 后首用自动预置全流程通过（scaffold + pnpm 安装 + patch 挂载 + 直接可用）
- **Live daemon 实测**（`switch:here` + daemon 重启后）：
  - dashboard `/api/trigger` 同步触发 dsh bot：完整链路 daemon → worker → dsh-runner → ACP → DeepSeek API，精确返回指令要求的单行文本
  - 飞书群内真机实测：新建 dsh bot 入群，@ 后正常出会话卡并回复（截图见下）

## 实测截图（飞书群内，已打码）

![dsh bot 在飞书话题中工作：会话卡 + 问候回复](https://raw.githubusercontent.com/deepcoldy/botmux/pr859-assets/.pr-assets/859/dsh-live-test.png)
