### PR TITLE
fix(adapter): 禁止 dsh 使用 ZMX 后端

### DIFF
--- a/src/adapters/backend/capabilities.ts
+++ b/src/adapters/backend/capabilities.ts
@@ -21,7 +21,7 @@ export function backendCliCompatibilityError(
   backendType: BackendType,
   cliId: CliId,
 ): string | undefined {
-  if (backendType === 'zmx' && ['codex-app', 'mira', 'mir'].includes(cliId)) {
+  if (backendType === 'zmx' && ['codex-app', 'mira', 'mir', 'dsh'].includes(cliId)) {
     return `backend "zmx" cannot carry ${cliId}'s hidden OSC final/thread events; use tmux/pty`;
   }
   return undefined;

--- a/test/backend-capabilities.test.ts
+++ b/test/backend-capabilities.test.ts
@@ -17,7 +17,7 @@ describe('backendSupportsWebTerminal', () => {
 
 describe('backendCliCompatibilityError', () => {
   it('fails closed for runner CLIs whose final/thread events require hidden OSC on zmx', () => {
-    for (const cliId of ['codex-app', 'mira', 'mir'] as const) {
+    for (const cliId of ['codex-app', 'mira', 'mir', 'dsh'] as const) {
       expect(backendCliCompatibilityError('zmx', cliId)).toContain('hidden OSC');
       expect(backendCliCompatibilityError('tmux', cliId)).toBeUndefined();
     }


### PR DESCRIPTION
## 改了什么

- 将 `dsh` 纳入 ZMX 后端的 runner CLI 兼容性拦截
- 补充后端能力单元测试，覆盖 `dsh + zmx` 组合

## 为什么

#859 中的 DSH runner 通过隐藏 OSC 事件向 botmux 交付最终回复；ZMX 只暴露消费控制序列后的纯文本 history，无法恢复这些事件。若不提前拦截，`dsh + zmx` 会启动成功但无法可靠交付最终回复。

本改动沿用 `codex-app`、`mira`、`mir` 已有的 fail-closed 行为，引导用户改用 tmux/pty。

## 影响范围

- 模块：backend capability gate、对应单元测试
- 会话类型：仅 `cliId=dsh` 且 `backend=zmx`
- 其他 CLI 和后端行为不变

## 验证

- `pnpm exec vitest run test/backend-capabilities.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`
