### PR TITLE
fix(dashboard): 修复 Skill 安装候选列表无法滚动

### DIFF
--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -11434,6 +11434,15 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
   max-height: 460px;
 }
 
+.skills-install-selection-body > .skills-candidate-list {
+  min-height: 0;
+  max-height: 100%;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+}
+
 .skills-local-discovery-panel {
   justify-content: space-between;
   padding: 10px;

--- a/test/dashboard-skills-ui.test.ts
+++ b/test/dashboard-skills-ui.test.ts
@@ -206,6 +206,13 @@ describe('dashboard skills install panel', () => {
     expect(root.findAllByProps({ className: 'skills-candidate-row' })).toHaveLength(2);
   });
 
+  it('keeps long install candidate lists scrollable inside the bounded dialog body', () => {
+    const css = readFileSync(new URL('../src/dashboard/web/style.css', import.meta.url), 'utf8');
+
+    expect(css).toMatch(/\.skills-install-selection-body\s*>\s*\.skills-candidate-list\s*\{[^}]*min-height:\s*0;[^}]*max-height:\s*100%;[^}]*overflow-y:\s*auto;/s);
+    expect(css).toMatch(/\.skills-install-selection-body\s*>\s*\.skills-candidate-list\s*\{[^}]*overscroll-behavior:\s*contain;[^}]*-webkit-overflow-scrolling:\s*touch;/s);
+  });
+
   it('echoes the recognized source type and deploy-host requirements before installation', () => {
     const renderer = renderInstallPanel({
       installSource: 'npm_config_registry="https://registry.example.com" npx -y agentbuddy@latest skill add skills.example.com/team/health',


### PR DESCRIPTION
## 改了什么

- 将 Skill 安装确认弹窗中的候选列表变为独立纵向滚动区域
- 补齐 grid 子项的 `min-height: 0` / 高度约束，避免长列表被外层裁切
- 为触控滚动、滚动边界和细滚动条补充样式
- 增加 Dashboard 样式契约测试，防止滚动能力回归

## 为什么

安装来源发现较多 Skill 时，弹窗正文有高度上限且会裁切溢出内容，候选列表自身却没有滚动能力，导致可视区域之外的 Skill 无法单独选择。

修复后，弹窗标题和底部操作按钮保持可见，候选区域可使用鼠标滚轮、触控板或触屏访问完整列表。

Closes #778

## 影响范围

- 模块：Dashboard Skills 安装确认弹窗
- 不改变 Skill 发现、选择或安装逻辑
- 不影响候选项较少时的布局

## 验证

- `pnpm exec vitest run test/dashboard-skills-ui.test.ts`（16 tests passed）
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`
