### PR TITLE
fix(setup): 字体下载遵循代理环境变量

### DIFF
--- a/src/setup/ensure-fonts.ts
+++ b/src/setup/ensure-fonts.ts
@@ -15,6 +15,7 @@ import { existsSync, mkdirSync, createWriteStream, statSync, unlinkSync, renameS
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { get as httpsGet } from 'node:https';
+import { ProxyAgent } from 'proxy-agent';
 import { detectPlatform, type PlatformInfo } from './detect-platform.js';
 
 export interface FontResult {
@@ -27,6 +28,25 @@ export interface FontResult {
 }
 
 const FONT_DIR = join(homedir(), '.botmux', 'fonts');
+
+const FONT_PROXY_ENV_KEYS = [
+  'npm_config_https_proxy',
+  'NPM_CONFIG_HTTPS_PROXY',
+  'https_proxy',
+  'HTTPS_PROXY',
+  'npm_config_proxy',
+  'NPM_CONFIG_PROXY',
+  'all_proxy',
+  'ALL_PROXY',
+] as const;
+
+/** Build an env-aware agent only when a proxy is configured. ProxyAgent also
+ * applies NO_PROXY per redirect target, so GitHub and its CDN can make the
+ * proxy/direct decision independently. Exported for the env contract test. */
+export function createFontDownloadAgent(): ProxyAgent | undefined {
+  if (!FONT_PROXY_ENV_KEYS.some(key => process.env[key]?.trim())) return undefined;
+  return new ProxyAgent();
+}
 
 interface FontSpec {
   /** Friendly category label for log lines. */
@@ -135,6 +155,7 @@ function downloadFile(url: string, destPath: string, timeoutMs = 60_000): Promis
     const tmp = destPath + '.part';
     let settled = false;
     let activeReq: ReturnType<typeof httpsGet> | null = null;
+    const agent = createFontDownloadAgent();
 
     const cleanup = () => {
       try { unlinkSync(tmp); } catch { /* may not exist */ }
@@ -144,6 +165,7 @@ function downloadFile(url: string, destPath: string, timeoutMs = 60_000): Promis
       settled = true;
       clearTimeout(timer);
       if (activeReq) try { activeReq.destroy(); } catch { /* ignore */ }
+      if (agent) try { agent.destroy(); } catch { /* ignore */ }
       if (err) { cleanup(); reject(err); }
       else resolve();
     };
@@ -154,7 +176,7 @@ function downloadFile(url: string, destPath: string, timeoutMs = 60_000): Promis
       const u = new URL(current);
       if (u.protocol !== 'https:') return finish(new Error(`仅支持 https://, got ${u.protocol} for ${current}`));
 
-      activeReq = httpsGet(u, { headers: { 'user-agent': 'botmux-font-installer' } }, (res) => {
+      activeReq = httpsGet(u, { agent, headers: { 'user-agent': 'botmux-font-installer' } }, (res) => {
         if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           res.resume();
           followRedirect(new URL(res.headers.location, u).toString(), hops + 1);

--- a/test/ensure-fonts.test.ts
+++ b/test/ensure-fonts.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createFontDownloadAgent } from '../src/setup/ensure-fonts.js';
+
+const PROXY_ENV_KEYS = [
+  'npm_config_https_proxy',
+  'NPM_CONFIG_HTTPS_PROXY',
+  'https_proxy',
+  'HTTPS_PROXY',
+  'npm_config_proxy',
+  'NPM_CONFIG_PROXY',
+  'all_proxy',
+  'ALL_PROXY',
+  'npm_config_no_proxy',
+  'NPM_CONFIG_NO_PROXY',
+  'no_proxy',
+  'NO_PROXY',
+] as const;
+
+const originalProxyEnv = Object.fromEntries(PROXY_ENV_KEYS.map(key => [key, process.env[key]]));
+
+function setProxyEnv(values: Partial<Record<(typeof PROXY_ENV_KEYS)[number], string>>): void {
+  for (const key of PROXY_ENV_KEYS) delete process.env[key];
+  Object.assign(process.env, values);
+}
+
+afterEach(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    const value = originalProxyEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('font download proxy', () => {
+  it('uses the configured HTTPS proxy for GitHub font downloads', () => {
+    setProxyEnv({
+      HTTPS_PROXY: 'http://upper-proxy:8118',
+      https_proxy: 'http://lower-proxy:8118',
+    });
+
+    const agent = createFontDownloadAgent();
+    expect(agent?.getProxyForUrl('https://github.com/notofonts/noto-cjk/raw/font.otf', {}))
+      .toBe('http://lower-proxy:8118');
+    agent?.destroy();
+  });
+
+  it('honors NO_PROXY independently for redirect destinations', () => {
+    setProxyEnv({
+      HTTPS_PROXY: 'http://proxy.example:8118',
+      NO_PROXY: 'github.com',
+    });
+
+    const agent = createFontDownloadAgent();
+    expect(agent?.getProxyForUrl('https://github.com/notofonts/noto-cjk/raw/font.otf', {})).toBe('');
+    expect(agent?.getProxyForUrl('https://objects.githubusercontent.com/font.otf', {}))
+      .toBe('http://proxy.example:8118');
+    agent?.destroy();
+  });
+
+  it('keeps the native HTTPS agent when no proxy is configured', () => {
+    setProxyEnv({});
+    expect(createFontDownloadAgent()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 改了什么

- 字体下载请求在存在代理配置时使用项目已有的 `ProxyAgent`
- 支持 `HTTPS_PROXY`、`ALL_PROXY` 及 npm 对应的 proxy 环境变量
- 每次 GitHub 重定向都会按新目标重新应用 `NO_PROXY` 判断
- 请求结束、失败或超时后主动销毁代理 agent
- 增加代理优先级、`NO_PROXY` 和无代理回退测试

## 为什么

字体安装器此前直接调用 Node.js `https.get`，不会自动读取代理环境变量。在需要代理访问 GitHub 的环境中，首次启动会一直等待字体下载超时，尽管系统已正确配置 `https_proxy`。

本改动复用项目现有的 `proxy-agent` 依赖；未配置代理时仍使用 Node 原生 HTTPS agent，不改变直连行为。

Closes #618

## 影响范围

- 模块：setup 阶段的字体下载器
- 仅在检测到代理环境变量时启用代理 agent
- 不改变字体来源、校验规则、落盘路径或失败降级行为

## 验证

- `pnpm exec vitest run test/ensure-fonts.test.ts`（3 tests passed）
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`
