### PR TITLE
fix(grok): 避免把排队输入重试成 send_now

### DIFF
--- a/src/adapters/cli/grok.ts
+++ b/src/adapters/cli/grok.ts
@@ -251,10 +251,13 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
       const historyPath = grokPromptHistoryPath(cwd);
       const baseByte = grokFileSize(historyPath);
 
-      // Paste text once; retries only re-send Enter (codex/coco parity).
-      // Re-pasting the full body on retry double-submits when the first Enter
-      // actually landed but prompt_history was slow, or doubles composer text
-      // when Enter was dropped but the paste stuck.
+      // Paste text once, then a single Enter. Do not retry Enter: while a
+      // turn is running, an empty composer plus a queued follow-up makes
+      // Grok treat the next Enter as send-now (cancel-and-send). Slow
+      // prompt_history is not proof the first Enter dropped.
+      // Re-pasting the full body would double-submit when the first Enter
+      // landed but prompt_history was slow, or double composer text when
+      // Enter was dropped but the paste stuck.
       // TmuxPipeBackend (adopt) returns false on failed writes instead of
       // throwing — treat false as definite failure.
       const trySendEnter = (): boolean => {
@@ -294,20 +297,17 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
         return matchGrokPromptAppend(historyPath, base, content, { preferSessionId });
       };
 
+      // Keep polling for a late history append. A dropped first Enter is
+      // recovered by the worker's deferred recheck, not by a second Enter.
       const deadline = Date.now() + scaleMs(4_000);
-      for (let attempt = 0; attempt < 3; attempt++) {
-        const waitUntil = Math.min(deadline, Date.now() + scaleMs(800));
-        while (Date.now() < waitUntil) {
-          const hit = probe();
-          if (hit.found) {
-            return hit.cliSessionId
-              ? { submitted: true, cliSessionId: hit.cliSessionId }
-              : { submitted: true };
-          }
-          await delay(scaleMs(100));
+      while (Date.now() < deadline) {
+        const hit = probe();
+        if (hit.found) {
+          return hit.cliSessionId
+            ? { submitted: true, cliSessionId: hit.cliSessionId }
+            : { submitted: true };
         }
-        if (Date.now() >= deadline) break;
-        if (!trySendEnter()) return { submitted: false };
+        await delay(scaleMs(100));
       }
 
       const late = probe();

--- a/src/services/grok-transcript.ts
+++ b/src/services/grok-transcript.ts
@@ -235,28 +235,56 @@ function eventUuid(path: string, lineStart: number, update: any, obj: any): stri
   return `${path}:${lineStart}`;
 }
 
+/** Read `cancelTrigger` from the first `_meta` that actually carries it.
+ *  Production `turn_completed` lines put it on `params._meta`; fixtures may
+ *  hang it on `update._meta`. Do not stop at an inner `_meta` that only has
+ *  eventId / timestamps. */
+function grokCancelTrigger(update: any, obj: any): string {
+  for (const meta of [update?._meta, obj?.params?._meta, obj?._meta]) {
+    if (!meta || typeof meta !== 'object') continue;
+    const trigger = (meta as { cancelTrigger?: unknown }).cancelTrigger;
+    if (typeof trigger === 'string' && trigger.trim()) return trigger.trim().toLowerCase();
+  }
+  return '';
+}
+
 /** Map Grok's authoritative turn boundary to the durable terminal contract.
  * `end_turn` means the submitted turn finished, even when its visible final is
- * empty (for example a tool-only turn). Explicit errors are retryable; an
- * explicit cancellation is a retryable failure after the receiver fences the
- * old attempt. Unknown reasons fail closed instead of being
- * reported as a successful delivery. */
-function grokTerminalOutcome(stopReason: unknown): Pick<
-  GrokBridgeEvent,
-  'terminalStatus' | 'terminalErrorCode'
-> {
+ * empty (for example a tool-only turn). Explicit errors are retryable.
+ * `cancelled` + `cancelTrigger=send_now` means a newer prompt aborted the
+ * previous active turn: the new turn already owns delivery, so this maps to
+ * `ambiguous` like Codex `turn_aborted` instead of a user-visible failed card.
+ * Other cancellations stay retryable failures after the receiver fences the
+ * old attempt. Unknown reasons fail closed instead of being reported as a
+ * successful delivery. */
+function grokTerminalOutcome(
+  stopReason: unknown,
+  cancelTrigger = '',
+): Pick<GrokBridgeEvent, 'terminalStatus' | 'terminalErrorCode' | 'terminalErrorSummary'> {
   const raw = typeof stopReason === 'string' ? stopReason.trim().toLowerCase() : '';
   if (raw === 'end_turn') return { terminalStatus: 'completed' };
   if (raw === 'cancelled' || raw === 'canceled') {
-    return { terminalStatus: 'failed', terminalErrorCode: 'grok_turn_cancelled' };
+    if (cancelTrigger === 'send_now') {
+      return { terminalStatus: 'ambiguous', terminalErrorCode: 'grok_turn_cancelled' };
+    }
+    return {
+      terminalStatus: 'failed',
+      terminalErrorCode: 'grok_turn_cancelled',
+      terminalErrorSummary: 'turn cancelled',
+    };
   }
   if (raw === 'error') {
-    return { terminalStatus: 'failed', terminalErrorCode: 'grok_turn_error' };
+    return {
+      terminalStatus: 'failed',
+      terminalErrorCode: 'grok_turn_error',
+      terminalErrorSummary: 'turn error',
+    };
   }
   const normalized = raw.replace(/[^a-z0-9_.-]+/g, '_').slice(0, 80) || 'missing';
   return {
     terminalStatus: 'failed',
     terminalErrorCode: `grok_stop_reason:${normalized}`,
+    terminalErrorSummary: `stop reason: ${normalized}`,
   };
 }
 
@@ -368,7 +396,16 @@ export function drainGrokUpdates(path: string, fromOffset: number): GrokDrainRes
       // that followed them. The terminal boundary itself is NOT conditional on
       // text: an empty/error/cancelled turn must still release (or fail) an
       // exact durable delivery attempt.
-      const finalText = agentParts.join('').trim();
+      const cancelTrigger = grokCancelTrigger(update, obj);
+      const outcome = grokTerminalOutcome(
+        update.stop_reason ?? update.stopReason,
+        cancelTrigger,
+      );
+      // send_now abort: drop buffered partial so worker cannot post it as a
+      // normal final_output while the newer prompt is already in flight.
+      const dropSupersededText = outcome.terminalStatus === 'ambiguous'
+        && outcome.terminalErrorCode === 'grok_turn_cancelled';
+      const finalText = dropSupersededText ? '' : agentParts.join('').trim();
       agentParts = [];
       openTurnStartOffset = null;
       events.push({
@@ -377,7 +414,7 @@ export function drainGrokUpdates(path: string, fromOffset: number): GrokDrainRes
         kind: 'assistant_final',
         text: finalText,
         sourceSessionId: sessionId ?? openTurnSessionId,
-        ...grokTerminalOutcome(update.stop_reason ?? update.stopReason),
+        ...outcome,
       });
       openTurnSessionId = undefined;
       lastFullyConsumedOffset = cursor;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10383,21 +10383,19 @@ function scheduleSubmitFailureNotify(
       case 'suppress-active':
         redriveRejectedStructuredReady();
         log(`Deferred recheck missing but later ${action.evidence} shows ${cliName()} is active — suppressing submit warning. preview="${preview}"`);
-        // For a durable turn, activity is evidence of possible submission, not
-        // a terminal result. Keep the arbiter closed and re-check until either
-        // the transcript confirms it or a quiet interval proves it stuck.
-        if (turnIdentity?.dispatchAttempt !== undefined) {
-          scheduleSubmitFailureNotify(
-            msg,
-            recheck,
-            transcriptLabel,
-            bridgeTurnId,
-            undefined,
-            turnSeq,
-            turnIdentity,
-            durableTerminalStatus,
-          );
-        }
+        // activity 证据只能说明 CLI 仍在动，不能证明本次输入已提交
+        // 普通 IM 和 durable turn 都继续重查，直到 transcript 命中或安静窗口落到 submit_unconfirmed
+        scheduleSubmitFailureNotify(
+          msg,
+          recheck,
+          transcriptLabel,
+          bridgeTurnId,
+          undefined,
+          turnSeq,
+          turnIdentity,
+          durableTerminalStatus,
+          structuredTarget,
+        );
         return;
       case 'notify-hard-failure':
         // failureReason is handled synchronously above.

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
+import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
 import {
   BRIDGE_NOTHING_TO_SEND_SENTINEL,
   BRIDGE_NO_REPLY_SENTINEL_LEGACY,
@@ -18,6 +20,10 @@ import {
   CODEX_CONNECTION_ERROR_CODE,
   CODEX_RATE_LIMIT_ERROR_CODE,
 } from '../src/services/codex-transcript.js';
+import {
+  settleDeferredSubmitConfirmation,
+  type SubmitActivityEvidence,
+} from '../src/services/submit-confirmation.js';
 
 const turn = (markTimeMs: number | undefined, isLocal: boolean | undefined = false) =>
   ({ markTimeMs, isLocal });
@@ -99,6 +105,100 @@ describe('stripTrailingOaiMemoryCitation', () => {
     const malformed = `<oai-mem-citation><citation_entries>${repeatedCandidates}`
       + '<rollout_ids>missing final envelope';
     expect(stripTrailingOaiMemoryCitation(malformed)).toBe(malformed);
+  });
+});
+
+function workerFunctionSlice(name: string, nextName: string): string {
+  const source = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+  const start = source.indexOf(`function ${name}`);
+  const end = source.indexOf(`function ${nextName}`, start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('worker submit-failure retry wiring', () => {
+  it('reschedules ordinary IM turns after active evidence and keeps structured-target state', () => {
+    const schedule = workerFunctionSlice('scheduleSubmitFailureNotify', 'detectBareShellLaunch');
+    const activeStart = schedule.indexOf("case 'suppress-active':");
+    const activeEnd = schedule.indexOf("case 'notify-hard-failure':", activeStart);
+    expect(activeStart).toBeGreaterThanOrEqual(0);
+    expect(activeEnd).toBeGreaterThan(activeStart);
+
+    const active = schedule.slice(activeStart, activeEnd);
+    const recursiveCall = active.indexOf('scheduleSubmitFailureNotify(');
+    expect(recursiveCall).toBeGreaterThanOrEqual(0);
+    expect(active.slice(0, recursiveCall)).not.toContain('dispatchAttempt !== undefined');
+    expect(active.slice(recursiveCall, active.indexOf(');', recursiveCall) + 2)).toContain('structuredTarget');
+
+    const notifyStuck = schedule.slice(schedule.indexOf("case 'notify-stuck':"));
+    expect(notifyStuck).toContain('if (turnIdentity?.dispatchAttempt === undefined)');
+    expect(notifyStuck).toContain("type: 'user_notify'");
+    expect(notifyStuck).toContain('worker.submit_unconfirmed');
+  });
+});
+
+describe('deferred submit confirmation behavior', () => {
+  it('keeps ordinary IM unconfirmed while active evidence continues, then notifies after a quiet window', async () => {
+    const queue = new CodexBridgeQueue();
+    const evidence: Array<SubmitActivityEvidence | undefined> = [
+      'pty-output',
+      'botmux-send',
+      undefined,
+    ];
+
+    const actions = [];
+    for (const activityEvidence of evidence) {
+      const settlement = await settleDeferredSubmitConfirmation(queue, {
+        turnId: 'ordinary-im-turn',
+        recheck: async () => false,
+        usageLimitDetected: () => false,
+        activityEvidence: () => activityEvidence,
+        isCurrent: () => true,
+      });
+      expect(settlement.stale).toBe(false);
+      if (!settlement.stale) actions.push(settlement.action);
+    }
+
+    expect(actions).toEqual([
+      { kind: 'suppress-active', evidence: 'pty-output' },
+      { kind: 'suppress-active', evidence: 'botmux-send' },
+      { kind: 'notify-stuck' },
+    ]);
+  });
+
+  it('confirms an ordinary IM retry once the deferred history recheck sees the prompt', async () => {
+    const queue = new CodexBridgeQueue();
+    let recheckCalls = 0;
+    const actions = [];
+
+    for (let round = 0; round < 3; round += 1) {
+      const settlement = await settleDeferredSubmitConfirmation(queue, {
+        turnId: 'ordinary-im-turn',
+        recheck: async () => {
+          recheckCalls += 1;
+          return recheckCalls === 3
+            ? { submitted: true, cliSessionId: 'grok-session-id' }
+            : false;
+        },
+        usageLimitDetected: () => false,
+        activityEvidence: () => 'structured-transcript',
+        isCurrent: () => true,
+      });
+      expect(settlement.stale).toBe(false);
+      if (!settlement.stale) actions.push(settlement.action);
+      if (!settlement.stale && settlement.action.kind === 'suppress-confirmed') {
+        expect(settlement.cliSessionId).toBe('grok-session-id');
+        expect(settlement.lifecycle).toBe('unchanged');
+        break;
+      }
+    }
+
+    expect(actions).toEqual([
+      { kind: 'suppress-active', evidence: 'structured-transcript' },
+      { kind: 'suppress-active', evidence: 'structured-transcript' },
+      { kind: 'suppress-confirmed' },
+    ]);
   });
 });
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -2161,7 +2161,7 @@ describe('grok buildArgs', () => {
     expect(events).toEqual(['text:line1\nline2', 'keys:Enter']);
   });
 
-  it('writeInput retries only Enter (does not re-paste full text)', async () => {
+  it('writeInput does not send a second Enter when history is delayed', async () => {
     process.env.BOTMUX_TIME_SCALE = '0.01';
     const cwd = '/tmp/proj';
     const historyDir = join(GROK_TEST_HOME, 'sessions', encodeURIComponent(cwd));
@@ -2170,28 +2170,31 @@ describe('grok buildArgs', () => {
     const grokMintedSid = '019f55e6-10a3-7f31-bc07-2fb370ae8239';
 
     const events: string[] = [];
-    let enterCount = 0;
     const pty = {
       write() {},
       cliCwd: cwd,
       sendText(text: string) { events.push(`text:${text}`); },
       sendSpecialKeys(...keys: string[]) {
         events.push(`keys:${keys.join(',')}`);
-        enterCount++;
-        // First Enter is swallowed (slow history); second lands the submit.
-        if (enterCount >= 2) {
-          appendFileSync(historyPath, JSON.stringify({
-            timestamp: '2026-07-12T10:00:00Z', session_id: grokMintedSid, prompt: 'once only', is_bash: false,
-          }) + '\n');
-        }
       },
     } satisfies PtyHandle;
 
-    const result = await adapter.writeInput(pty, 'once only');
-    expect(result).toEqual({ submitted: true, cliSessionId: grokMintedSid });
-    // Text pasted exactly once; Enter retried.
+    // First Enter already accepted; history shows up after the old 800ms
+    // retry window (8ms scaled) but inside the 4s poll budget (40ms scaled).
+    const late = setTimeout(() => {
+      appendFileSync(historyPath, JSON.stringify({
+        timestamp: '2026-07-12T10:00:00Z', session_id: grokMintedSid, prompt: 'once only', is_bash: false,
+      }) + '\n');
+    }, 20);
+
+    try {
+      const result = await adapter.writeInput(pty, 'once only');
+      expect(result).toEqual({ submitted: true, cliSessionId: grokMintedSid });
+    } finally {
+      clearTimeout(late);
+    }
     expect(events.filter((e) => e.startsWith('text:'))).toEqual(['text:once only']);
-    expect(events.filter((e) => e === 'keys:Enter').length).toBeGreaterThanOrEqual(2);
+    expect(events.filter((e) => e === 'keys:Enter')).toEqual(['keys:Enter']);
   });
 
   it('writeInput treats sendText/sendSpecialKeys false as definite failure (adopt pipe path)', async () => {
@@ -2230,15 +2233,17 @@ describe('grok buildArgs', () => {
     mkdirSync(historyDir, { recursive: true });
     const historyPath = join(historyDir, 'prompt_history.jsonl');
 
+    const events: string[] = [];
     const pty = {
       write() {},
       cliCwd: cwd,
-      sendText() {},
-      sendSpecialKeys() {},
+      sendText() { events.push('text'); },
+      sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); },
     } satisfies PtyHandle;
 
     const result = await adapter.writeInput(pty, 'never lands');
     expect(result).toMatchObject({ submitted: false });
+    expect(events.filter((e) => e === 'keys:Enter')).toEqual(['keys:Enter']);
     const recheck = (result as { recheck?: () => unknown }).recheck!;
     expect(recheck()).toBe(false);
     // Late append (slow submit) — the deferred recheck must pick it up.

--- a/test/grok-transcript.test.ts
+++ b/test/grok-transcript.test.ts
@@ -68,18 +68,32 @@ function agentChunk(sessionId: string, text: string, eventId: string, ts = 1_000
   };
 }
 
-function turnDone(sessionId: string, eventId: string, ts = 1_000_200, stopReason = 'end_turn') {
+function turnDone(
+  sessionId: string,
+  eventId: string,
+  ts = 1_000_200,
+  stopReason = 'end_turn',
+  opts?: { cancelTrigger?: string; metaOn?: 'update' | 'params' | 'split' },
+) {
+  const update: Record<string, unknown> = {
+    sessionUpdate: 'turn_completed',
+    stop_reason: stopReason,
+  };
+  const params: Record<string, unknown> = { sessionId, update };
+  const metaOn = opts?.metaOn ?? 'update';
+  if (metaOn === 'split') {
+    update._meta = { eventId, agentTimestampMs: ts };
+    params._meta = opts?.cancelTrigger ? { cancelTrigger: opts.cancelTrigger } : {};
+  } else {
+    const meta: Record<string, unknown> = { eventId, agentTimestampMs: ts };
+    if (opts?.cancelTrigger) meta.cancelTrigger = opts.cancelTrigger;
+    if (metaOn === 'params') params._meta = meta;
+    else update._meta = meta;
+  }
   return {
     timestamp: ts,
-    method: 'session/update',
-    params: {
-      sessionId,
-      update: {
-        sessionUpdate: 'turn_completed',
-        stop_reason: stopReason,
-        _meta: { eventId, agentTimestampMs: ts },
-      },
-    },
+    method: metaOn === 'update' ? 'session/update' : '_x.ai/session/update',
+    params,
   };
 }
 
@@ -212,10 +226,10 @@ describe('drainGrokUpdates', () => {
   });
 
   it.each([
-    ['error', 'failed', 'grok_turn_error'],
-    ['cancelled', 'failed', 'grok_turn_cancelled'],
-    ['future reason', 'failed', 'grok_stop_reason:future_reason'],
-  ] as const)('maps %s turn_completed to %s even with an empty final', (reason, status, errorCode) => {
+    ['error', 'failed', 'grok_turn_error', 'turn error'],
+    ['cancelled', 'failed', 'grok_turn_cancelled', 'turn cancelled'],
+    ['future reason', 'failed', 'grok_stop_reason:future_reason', 'stop reason: future_reason'],
+  ] as const)('maps %s turn_completed to %s even with an empty final', (reason, status, errorCode, summary) => {
     const sid = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
     const path = writeUpdates(sid, '/tmp/proj', [
       userChunk(sid, 'q', 'e1'),
@@ -232,6 +246,70 @@ describe('drainGrokUpdates', () => {
         sourceSessionId: sid,
         terminalStatus: status,
         terminalErrorCode: errorCode,
+        terminalErrorSummary: summary,
+      }),
+    ]);
+  });
+
+  it.each([
+    ['params'] as const,
+    ['update'] as const,
+  ])('maps cancelled + send_now on %s._meta to ambiguous', (metaOn) => {
+    const sid = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    const path = writeUpdates(sid, '/tmp/proj', [
+      userChunk(sid, 'q', 'e1'),
+      turnDone(sid, 'e2', 1_000_200, 'cancelled', { cancelTrigger: 'send_now', metaOn }),
+    ]);
+
+    const r = drainGrokUpdates(path, 0);
+    const finals = r.events.filter((e) => e.kind === 'assistant_final');
+
+    expect(finals).toEqual([
+      expect.objectContaining({
+        kind: 'assistant_final',
+        text: '',
+        sourceSessionId: sid,
+        terminalStatus: 'ambiguous',
+        terminalErrorCode: 'grok_turn_cancelled',
+      }),
+    ]);
+    expect(finals[0]).not.toHaveProperty('terminalErrorSummary');
+  });
+
+  it('drops buffered agent text when cancelled by send_now', () => {
+    const sid = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    const path = writeUpdates(sid, '/tmp/proj', [
+      userChunk(sid, 'q', 'e1'),
+      agentChunk(sid, 'partial answer already streamed', 'e2'),
+      turnDone(sid, 'e3', 1_000_200, 'cancelled', { cancelTrigger: 'send_now', metaOn: 'params' }),
+    ]);
+
+    const r = drainGrokUpdates(path, 0);
+    expect(r.events.filter((e) => e.kind === 'assistant_final')).toEqual([
+      expect.objectContaining({
+        kind: 'assistant_final',
+        text: '',
+        sourceSessionId: sid,
+        terminalStatus: 'ambiguous',
+        terminalErrorCode: 'grok_turn_cancelled',
+      }),
+    ]);
+  });
+
+  it('reads cancelTrigger from params._meta when update._meta has no trigger', () => {
+    const sid = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    const path = writeUpdates(sid, '/tmp/proj', [
+      userChunk(sid, 'q', 'e1'),
+      turnDone(sid, 'e2', 1_000_200, 'cancelled', { cancelTrigger: 'send_now', metaOn: 'split' }),
+    ]);
+
+    const r = drainGrokUpdates(path, 0);
+    expect(r.events.filter((e) => e.kind === 'assistant_final')).toEqual([
+      expect.objectContaining({
+        kind: 'assistant_final',
+        text: '',
+        terminalStatus: 'ambiguous',
+        terminalErrorCode: 'grok_turn_cancelled',
       }),
     ]);
   });


### PR DESCRIPTION
## 问题

Grok 会话里新飞书消息打断上一轮时，用户会看到「Grok Build 本轮执行失败：未提供可安全展示的错误摘要」。这不是模型调用失败，而是 `send_now` 取消被当成普通失败，且没有可展示摘要。

## 根因

`turn_completed` 的 `stop_reason=cancelled` 原先一律映射成 `failed` + `grok_turn_cancelled`，不读 `_meta.cancelTrigger`，也不填 `terminalErrorSummary`。worker 因此弹出兜底失败卡。

另一条路径会把普通排队输入误造成 `send_now`：`writeInput` 在 800ms 内看不到 `prompt_history.jsonl` 时会再按 Enter。Grok 在轮次进行中、composer 已空、已有排队 follow-up 时，下一次 Enter 会 force-send 队首并取消旧轮。

普通飞书 IM turn 的 deferred submit recheck 还有一条静默路径：`suppress-active` 只给 durable turn 续排。普通 IM turn 撞上旧轮 activity 证据时会直接返回，既不继续重查 history，也不在安静窗口后发 `submit_unconfirmed`。

## 修复

- `cancelled` + `send_now` 标成 `ambiguous`，对齐 Codex `turn_aborted`，不再走失败兜底卡
- 同时清空该轮缓存的 `agent_message_chunk`，避免旧轮次 partial 被当成普通回复发出
- `cancelTrigger` 按字段逐层查 `update._meta` / `params._meta` / `obj._meta`，内层只有 eventId 时不会挡住 production 的 `params._meta`
- Grok `writeInput` 只按一次 Enter，之后只轮询 `prompt_history`；真正丢键走 worker 的 deferred recheck
- 普通 IM turn 在 `suppress-active` 后也持续重查，直到 `prompt_history` 命中或安静窗口落到 `submit_unconfirmed`
- 递归重查继续透传 `structuredTarget`，避免 structured submit lifecycle 轮次退化
- 其余 `cancelled` / `error` / 未知 stop_reason 补英文 `terminalErrorSummary`，避免再落到「未提供可安全展示的错误摘要」

## 影响面

改 Grok `updates.jsonl` 终态映射、Grok 适配器的 Enter 提交，以及 worker 的 deferred submit 确认重查。Codex / Claude 等其它 CLI 不变。`end_turn` 与非 `send_now` 的取消语义不变。明确由 Grok TUI 发起的真实 `send_now` 仍映射为 `ambiguous`。

## 验证

- `BOTS_CONFIG= pnpm vitest run --project unit test/grok-transcript.test.ts test/cli-adapters.test.ts test/bridge-fallback-gate.test.ts`：428 passed / 1 skipped
- `pnpm build`：passed
- 覆盖 production 的 `params._meta`、fixture 的 `update._meta`、双 `_meta` 分层、agent chunk 后 `send_now` 文本被清空、history 晚到时不再发送第二次 Enter、普通 IM 在旧轮持续 activity 后不会永久静默
