### PR TITLE
feat(codex): 补齐 V3 与群内思考强度配置

### DIFF
--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -27,6 +27,12 @@ import { parseStartupCommandsInput } from '../core/startup-commands.js';
 import { isReservedPerBotEnvKey, sanitizePerBotEnv } from '../core/per-bot-env.js';
 import { normalizeFeedbackPolicy } from './feedback-policy.js';
 import { normalizeFeedbackPolicyLayer, type FeedbackPolicyLayer } from './feedback-policy-resolver.js';
+import {
+  CODEX_REASONING_EFFORTS,
+  codexModelSupportsReasoningEffort,
+  isCodexReasoningCliId,
+  isCodexReasoningEffort,
+} from './codex-reasoning-effort.js';
 
 /**
  * 生效时机：
@@ -67,6 +73,7 @@ export interface ConfigFieldSpec {
 export const CONFIG_FIELDS: readonly ConfigFieldSpec[] = [
   { key: 'displayName', configKey: 'displayName', kind: 'string', effect: 'immediate', clearable: true, maxLen: 64, hint: '自定义展示名（dashboard 名册/会话列表用，≤64 字符）；不改飞书群内应用名；unset 回飞书名称' },
   { key: 'model', configKey: 'model', kind: 'string', effect: 'next-session', clearable: true, hint: 'CLI 模型名（如 opus）；unset 回 CLI 默认' },
+  { key: 'reasoningEffort', configKey: 'reasoningEffort', kind: 'enum', effect: 'next-session', clearable: true, enumValues: CODEX_REASONING_EFFORTS, hint: 'Codex 思考强度 low|medium|high|xhigh|max|ultra；可用档位取决于模型，unset 回 CLI/模型默认' },
   { key: 'cli', configKey: 'cliId', kind: 'cli', effect: 'next-session', clearable: false, hint: 'CLI 适配器（序号 1-16 或 id，如 claude-code）' },
   { key: 'launchShell', configKey: 'launchShell', kind: 'string', effect: 'next-session', clearable: true, hint: '启动 CLI 用的 shell（zsh|bash|fish|sh 或绝对路径），覆盖 $SHELL；用于 .bashrc/.zshrc 里 exec 切到别的 shell 导致会话起不来的场景；fish 用户把 PATH/nvm 放进 ~/.config/fish/config.fish，无需回填 bash/zsh；unset 回 $SHELL' },
   { key: 'lang', configKey: 'lang', kind: 'enum', effect: 'immediate', clearable: true, enumValues: ['zh', 'en'], hint: '机器人 UI 语言 zh|en；unset 回全局默认' },
@@ -218,6 +225,14 @@ export async function applyConfigField(
 
   // 空数组（stringList 全被过滤）等价清除，bots.json 保持干净。
   const effective = spec.kind === 'stringList' && Array.isArray(value) && value.length === 0 ? null : value;
+  if (spec.configKey === 'reasoningEffort' && effective !== null) {
+    if (!isCodexReasoningCliId(bot.config.cliId) || !isCodexReasoningEffort(effective)) {
+      return { ok: false, reason: 'reasoning_effort_requires_codex' };
+    }
+    if (!codexModelSupportsReasoningEffort(bot.config.model, effective)) {
+      return { ok: false, reason: 'reasoning_effort_not_supported_by_model' };
+    }
+  }
 
   const r = await rmwBotEntry<null>(larkAppId, (entry) => {
     if (effective === null) {
@@ -230,6 +245,14 @@ export async function applyConfigField(
       entry[spec.configKey] = effective as any;
     } else {
       entry[spec.configKey] = effective;
+    }
+    if (spec.configKey === 'cliId' && !isCodexReasoningCliId(String(effective))) {
+      delete entry.reasoningEffort;
+    }
+    if (spec.configKey === 'model'
+        && isCodexReasoningEffort(entry.reasoningEffort)
+        && !codexModelSupportsReasoningEffort(typeof effective === 'string' ? effective : undefined, entry.reasoningEffort)) {
+      delete entry.reasoningEffort;
     }
     return { write: true, result: null };
   });
@@ -244,6 +267,14 @@ export async function applyConfigField(
     (bot.config as any)[spec.configKey] = effective;
   } else {
     (bot.config as any)[spec.configKey] = effective;
+  }
+  if (spec.configKey === 'cliId' && !isCodexReasoningCliId(String(effective))) {
+    bot.config.reasoningEffort = undefined;
+  }
+  if (spec.configKey === 'model'
+      && bot.config.reasoningEffort
+      && !codexModelSupportsReasoningEffort(typeof effective === 'string' ? effective : undefined, bot.config.reasoningEffort)) {
+    bot.config.reasoningEffort = undefined;
   }
   const newText = formatFieldValue(spec, (bot.config as any)[spec.configKey]);
   if (spec.configKey === 'feedback') {

--- a/src/workflows/v3/bot-resolve.ts
+++ b/src/workflows/v3/bot-resolve.ts
@@ -18,6 +18,11 @@ import {
   isV3SupportedCli,
   type BotSnapshot,
 } from './contract.js';
+import {
+  codexModelSupportsReasoningEffort,
+  isCodexReasoningCliId,
+  isCodexReasoningEffort,
+} from '../../services/codex-reasoning-effort.js';
 
 export function resolveBotConfig(selector: string | undefined, bots: BotConfig[]): BotConfig {
   if (!selector) {
@@ -73,6 +78,7 @@ export function botToSnapshot(bot: BotConfig, workingDirOverride?: string): BotS
     cliId: bot.cliId,
     ...(bot.cliPathOverride ? { cliPathOverride: bot.cliPathOverride } : {}),
     ...(bot.model ? { model: bot.model } : {}),
+    ...(bot.reasoningEffort ? { reasoningEffort: bot.reasoningEffort } : {}),
     ...(bot.sandbox === true ? { sandbox: true } : {}),
     ...(sandboxPathsSnapshot(bot.sandboxPaths) ? { sandboxPaths: sandboxPathsSnapshot(bot.sandboxPaths)! } : {}),
     ...(bot.sandboxHidePaths?.length ? { sandboxHidePaths: [...bot.sandboxHidePaths] } : {}),
@@ -137,6 +143,7 @@ export function parseFrozenBotSnapshots(raw: unknown, dag?: V3Dag): Map<string, 
     'cliId',
     'cliPathOverride',
     'model',
+    'reasoningEffort',
     'sandbox',
     'sandboxPaths',
     'sandboxHidePaths',
@@ -169,6 +176,16 @@ export function parseFrozenBotSnapshots(raw: unknown, dag?: V3Dag): Map<string, 
       if (obj[field] !== undefined && typeof obj[field] !== 'string') {
         throw new Error(`bots.snapshot.json[${JSON.stringify(key)}].${field} must be a string`);
       }
+    }
+    const snapshotModel = typeof obj.model === 'string' ? obj.model : undefined;
+    if (obj.reasoningEffort !== undefined && (
+      !isCodexReasoningCliId(obj.cliId as string)
+      || !isCodexReasoningEffort(obj.reasoningEffort)
+      || !codexModelSupportsReasoningEffort(snapshotModel, obj.reasoningEffort)
+    )) {
+      throw new Error(
+        `bots.snapshot.json[${JSON.stringify(key)}].reasoningEffort is not supported by its Codex CLI/model`,
+      );
     }
     for (const field of ['sandbox', 'sandboxNetwork'] as const) {
       if (obj[field] !== undefined && typeof obj[field] !== 'boolean') {
@@ -208,6 +225,7 @@ export function parseFrozenBotSnapshots(raw: unknown, dag?: V3Dag): Map<string, 
       cliId: obj.cliId as BotSnapshot['cliId'],
       ...(obj.cliPathOverride !== undefined ? { cliPathOverride: obj.cliPathOverride as string } : {}),
       ...(obj.model !== undefined ? { model: obj.model as string } : {}),
+      ...(obj.reasoningEffort !== undefined ? { reasoningEffort: obj.reasoningEffort as BotSnapshot['reasoningEffort'] } : {}),
       ...(obj.sandbox !== undefined ? { sandbox: obj.sandbox as boolean } : {}),
       ...(parsedSandboxPaths ? { sandboxPaths: parsedSandboxPaths } : {}),
       ...(obj.sandboxHidePaths !== undefined ? { sandboxHidePaths: [...obj.sandboxHidePaths as string[]] } : {}),

--- a/src/workflows/v3/contract.ts
+++ b/src/workflows/v3/contract.ts
@@ -15,6 +15,7 @@
  */
 
 import type { CliId } from '../../adapters/cli/types.js';
+import type { CodexReasoningEffort } from '../../services/codex-reasoning-effort.js';
 import type { V3GoalNode } from './dag.js';
 import type { RunChatBinding } from './grill-state.js';
 import type { V3ArmedAttemptWorkerFence } from './worker-fence.js';
@@ -144,8 +145,8 @@ export function isV3SupportedCli(cliId: CliId): boolean {
  * The spawn-relevant bot config, FROZEN when the run starts and persisted in
  * the runDir.  The pool spawns ephemeral workers from this snapshot rather
  * than re-reading `bots.json` at execution time, so a retry / daemon-restart
- * reproduces the original cliId / model / workingDir even if the live bot
- * config drifted (codex point 1).
+ * reproduces the original cliId / model / reasoning effort / workingDir even
+ * if the live bot config drifted (codex point 1).
  *
  * Deliberately omits `larkAppSecret`: secrets are not written into the runDir.
  * The pool re-reads the secret by `larkAppId` from the live registry at spawn
@@ -157,6 +158,7 @@ export interface BotSnapshot {
   cliId: CliId;
   cliPathOverride?: string;
   model?: string;
+  reasoningEffort?: CodexReasoningEffort;
   /** Frozen per-bot sandbox policy. Workflow workers must not silently lose
    *  these fields when spawning outside the main forkWorker path. */
   sandbox?: boolean;

--- a/src/workflows/v3/ephemeral-pool.ts
+++ b/src/workflows/v3/ephemeral-pool.ts
@@ -241,6 +241,7 @@ async function runNodeImpl(
     cliId: req.botSnapshot.cliId,
     cliPathOverride: req.botSnapshot.cliPathOverride,
     model: req.botSnapshot.model,
+    reasoningEffort: req.botSnapshot.reasoningEffort,
     // Workflow workers require CLI bypass permissions by product contract.
     // Restricted bots are rejected before a BotSnapshot is created.
     disableCliBypass: false,

--- a/test/bot-config-store.test.ts
+++ b/test/bot-config-store.test.ts
@@ -83,6 +83,7 @@ describe('bot-config store', () => {
     expect(new Set(keys).size).toBe(keys.length);
     expect(keys).toContain('allowedUsers');
     expect(keys).toContain('model');
+    expect(keys).toContain('reasoningEffort');
     expect(keys).not.toContain('repoPickerMode');
     expect(keys).toContain('skills');
     expect(keys).toContain('silentTurnReactions');
@@ -152,6 +153,51 @@ describe('bot-config store', () => {
     expect(r2.ok).toBe(true);
     expect(readConfig().model).toBeUndefined();
     expect(registry.getBot('app_default').config.model).toBeUndefined();
+  });
+
+  it('persists a model-compatible Codex reasoning effort and rejects invalid combinations', async () => {
+    const { registry, store } = await loaded({ cliId: 'codex', model: 'gpt-5.6-luna' });
+    const spec = store.findConfigField('reasoningEffort')!;
+
+    expect(store.coerceConfigValue(spec, 'MAX')).toEqual({ ok: true, value: 'max' });
+    expect(store.coerceConfigValue(spec, 'extreme')).toEqual({ ok: false, reason: 'invalid_enum' });
+    expect(await store.applyConfigField('app_default', spec, 'max')).toMatchObject({ ok: true });
+    expect(readConfig().reasoningEffort).toBe('max');
+    expect(registry.getBot('app_default').config.reasoningEffort).toBe('max');
+
+    expect(await store.applyConfigField('app_default', spec, 'ultra')).toEqual({
+      ok: false,
+      reason: 'reasoning_effort_not_supported_by_model',
+    });
+    expect(readConfig().reasoningEffort).toBe('max');
+
+    expect(await store.applyConfigField('app_default', spec, null)).toMatchObject({ ok: true });
+    expect(readConfig().reasoningEffort).toBeUndefined();
+    expect(registry.getBot('app_default').config.reasoningEffort).toBeUndefined();
+  });
+
+  it('rejects reasoning effort for non-Codex bots and clears it when CLI/model becomes incompatible', async () => {
+    const nonCodex = await loaded({ cliId: 'claude-code' });
+    const effortSpec = nonCodex.store.findConfigField('reasoningEffort')!;
+    expect(await nonCodex.store.applyConfigField('app_default', effortSpec, 'high')).toEqual({
+      ok: false,
+      reason: 'reasoning_effort_requires_codex',
+    });
+
+    const { registry, store } = await loaded({
+      cliId: 'codex',
+      model: 'gpt-5.6-luna',
+      reasoningEffort: 'max',
+    });
+    expect(await store.applyConfigField('app_default', store.findConfigField('model')!, 'gpt-5.4')).toMatchObject({ ok: true });
+    expect(readConfig().reasoningEffort).toBeUndefined();
+    expect(registry.getBot('app_default').config.reasoningEffort).toBeUndefined();
+
+    await store.applyConfigField('app_default', store.findConfigField('model')!, 'gpt-5.6-luna');
+    await store.applyConfigField('app_default', effortSpec, 'max');
+    expect(await store.applyConfigField('app_default', store.findConfigField('cli')!, 'claude-code')).toMatchObject({ ok: true });
+    expect(readConfig().reasoningEffort).toBeUndefined();
+    expect(registry.getBot('app_default').config.reasoningEffort).toBeUndefined();
   });
 
   it('displayName round-trips, fires the refresher hook, and clears on null', async () => {

--- a/test/codex-effort-wiring.test.ts
+++ b/test/codex-effort-wiring.test.ts
@@ -19,6 +19,11 @@ vi.mock('../src/adapters/cli/registry.js', async (orig) => {
 
 import { createCodexAdapter } from '../src/adapters/cli/codex.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
+import {
+  botToSnapshot,
+  parseFrozenBotSnapshots,
+  serializeFrozenBotSnapshots,
+} from '../src/workflows/v3/bot-resolve.js';
 
 const BASE = { sessionId: 's1', resume: false, workingDir: '/tmp' } as const;
 
@@ -101,5 +106,32 @@ describe('worker → CodexRpcEngine effort wiring (source lock)', () => {
     const returnConfig = source.indexOf('return {', frozenBranch);
     expect(compatibilityGuard).toBeGreaterThan(frozenBranch);
     expect(compatibilityGuard).toBeLessThan(returnConfig);
+  });
+});
+
+describe('v3 frozen BotSnapshot reasoning effort', () => {
+  it('round-trips a compatible effort and rejects tampered CLI/model combinations', () => {
+    const snapshot = botToSnapshot({
+      larkAppId: 'app-codex',
+      larkAppSecret: 'secret',
+      cliId: 'codex',
+      model: 'gpt-5.6-luna',
+      reasoningEffort: 'max',
+    });
+    expect(snapshot.reasoningEffort).toBe('max');
+    expect(parseFrozenBotSnapshots(serializeFrozenBotSnapshots(new Map([['', snapshot]]))).get(''))
+      .toMatchObject({ model: 'gpt-5.6-luna', reasoningEffort: 'max' });
+
+    expect(() => parseFrozenBotSnapshots({
+      '': { ...snapshot, cliId: 'claude-code' },
+    })).toThrow('reasoningEffort is not supported by its Codex CLI/model');
+    expect(() => parseFrozenBotSnapshots({
+      '': { ...snapshot, reasoningEffort: 'ultra' },
+    })).toThrow('reasoningEffort is not supported by its Codex CLI/model');
+  });
+
+  it('passes the frozen effort into the v3 worker init message', () => {
+    const source = readFileSync(new URL('../src/workflows/v3/ephemeral-pool.ts', import.meta.url), 'utf8');
+    expect(source).toContain('reasoningEffort: req.botSnapshot.reasoningEffort');
   });
 });


### PR DESCRIPTION
## 改了什么

- 在 #838 的每 Bot Codex 默认思考强度基础上，补齐群内 `/config reasoningEffort <level>` 与 `unset` 管理入口。
- `/config` 复用统一的模型能力表：只允许 Codex / Codex App，拒绝模型不支持的档位；切换到非 Codex CLI 或不兼容模型时清理旧值。
- 将 `reasoningEffort` 纳入 V3 `BotSnapshot`，随 run 持久化并传入 ephemeral worker，保证重试、恢复不会重新读取已经漂移的 Bot 配置。
- V3 快照读取对 CLI、模型和 effort 组合做 fail-closed 校验，拒绝篡改或不兼容的 artifact。

## 为什么

#838 已覆盖 Dashboard 和普通会话，但 V3 走独立的 BotSnapshot / ephemeral worker 路径；若不显式加入快照，工作流会丢失 Bot 默认思考强度。群内 `/config` 也尚未暴露该字段，无法与现有 `model` 配置一起远程管理。

## 影响面

- 普通会话与 Dashboard：继续使用 #838 的实现，本 MR 不重复修改。
- V3 workflow：Codex / Codex App 的新 run 冻结并传递思考强度；旧快照无该字段时保持兼容。
- `/config`：新增 next-session 字段；当前活跃会话不漂移。
- 其它 CLI、后端和平台路径保持原行为。

## 验证

- `pnpm vitest run test/bot-config-store.test.ts test/codex-effort-wiring.test.ts test/codex-default-reasoning.test.ts test/codex-reasoning-effort.test.ts`：4 个文件、54 条测试通过。
- `pnpm vitest run test/workflow-v3-ephemeral-pool.test.ts`（沙箱外，测试需读取真实进程启动身份）：22 条测试通过。
- `pnpm build`：domain audit、TypeScript 编译、Dashboard bundle、dist audit 全部通过。
