### PR TITLE
fix(adopt): 优先展示 Claude customTitle

### DIFF
--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -6,16 +6,14 @@
  * runs `<cli> --resume <id>` in the recorded cwd.
  *
  * Three storage shapes are covered (one parser each, shared across CLIs):
- *   - Claude-family JSONL  (`claude-code`, `seed`, `relay`): <dataDir>/projects/<hash>/<id>.jsonl
+ *   - Claude-family JSONL  (`claude-code`, `seed`, `relay`, `genius`): <dataDir>/projects/<hash>/<id>.jsonl
  *   - Codex/TRAE rollout   (`codex`, `traex`):       <sessionsRoot>/YYYY/MM/DD/rollout-*.jsonl
  *   - Antigravity history  (`antigravity`):          <home>/history.jsonl (flat submit log)
  *
  * All scans are daemon-side, pure filesystem (no PTY / subprocess), and run
- * only on an explicit `/adopt` — so we favour correctness over cleverness: take
- * the most-recent files by mtime, then stream each line by line (NOT a bounded
- * byte prefix, which truncates oversized records and hides an append-only log's
- * fresh tail). Parsers stop early once the needed metadata is in hand where
- * possible; Claude scans the bounded transcript so a later `/rename` wins.
+ * only on an explicit `/adopt`: take the most-recent files by mtime, stream
+ * metadata records line by line, and use a bounded tail window for Claude
+ * `/rename` records. Parsers stop early once metadata is in hand where possible.
  */
 import { promises as fs, createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
@@ -24,16 +22,24 @@ import type { ResumableSession } from '../adapters/cli/types.js';
 
 const TITLE_MAX = 80;
 
-/** Safety cap on lines scanned per transcript when searching for metadata.
- *  Session id / cwd / first prompt live near the top, but Claude custom titles
- *  may appear later after `/rename`, so its parser intentionally scans up to
- *  this bound. The cap only bounds pathological / corrupt files. Antigravity's
- *  flat submit log is read in full (see its own higher cap) so tail entries are
- *  never missed. */
-const MAX_LINES_PER_FILE = 5_000;
+/** Forward/head cap for transcript metadata; Claude custom titles use the
+ *  separate bounded tail read below. Antigravity has its own higher cap. */
+const MAX_HEAD_LINES_PER_FILE = 5_000;
+/** Maximum bytes inspected from the end for the latest valid customTitle. */
+const CLAUDE_CUSTOM_TITLE_TAIL_BYTES = 4 * 1024 * 1024;
 
 function asRecord(v: unknown): Record<string, unknown> | null {
   return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+function parseJsonRecord(raw: string): Record<string, unknown> | null {
+  const line = raw.trim();
+  if (!line) return null;
+  try {
+    return asRecord(JSON.parse(line));
+  } catch {
+    return null;
+  }
 }
 
 /** Stream a JSONL file line by line, invoking `onLine` for each parsed object.
@@ -46,7 +52,7 @@ function asRecord(v: unknown): Record<string, unknown> | null {
 async function forEachJsonLine(
   path: string,
   onLine: (rec: Record<string, unknown>) => boolean | void,
-  maxLines = MAX_LINES_PER_FILE,
+  maxLines = MAX_HEAD_LINES_PER_FILE,
 ): Promise<void> {
   const stream = createReadStream(path, { encoding: 'utf8' });
   // A missing/unreadable file emits 'error' asynchronously; without a listener
@@ -57,13 +63,8 @@ async function forEachJsonLine(
   let n = 0;
   try {
     for await (const raw of rl) {
-      const line = raw.trim();
-      if (line) {
-        let parsed: unknown = null;
-        try { parsed = JSON.parse(line); } catch { /* corrupt line — skip */ }
-        const rec = asRecord(parsed);
-        if (rec && onLine(rec) === true) break;
-      }
+      const rec = parseJsonRecord(raw);
+      if (rec && onLine(rec) === true) break;
       if (++n >= maxLines) break;
     }
   } catch {
@@ -191,21 +192,63 @@ async function collectRecentJsonl(
   return out.sort((a, b) => b.mtimeMs - a.mtimeMs).slice(0, limit);
 }
 
-// ─── Claude-family JSONL (claude-code, seed, relay) ──────────────────────────
+// ─── Claude-family JSONL (claude-code, seed, relay, genius) ──────────────────
+
+/** Scan a bounded tail for the latest valid customTitle. The first line may be
+ *  truncated at the byte boundary, so it is skipped. */
+async function findLatestClaudeCustomTitle(path: string): Promise<string> {
+  let stat;
+  try {
+    stat = await fs.stat(path);
+  } catch {
+    return '';
+  }
+  if (stat.size <= 0) return '';
+
+  const start = Math.max(0, stat.size - CLAUDE_CUSTOM_TITLE_TAIL_BYTES);
+  const stream = createReadStream(path, {
+    encoding: 'utf8',
+    start,
+    end: stat.size - 1,
+  });
+  stream.on('error', () => { /* handled via try/catch */ });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  let latest = '';
+  let first = start > 0;
+  try {
+    for await (const raw of rl) {
+      if (first) {
+        first = false;
+        continue;
+      }
+      const rec = parseJsonRecord(raw);
+      if (!rec || rec.isSidechain === true || typeof rec.customTitle !== 'string') continue;
+      const title = truncateTitle(rec.customTitle);
+      if (title) latest = title;
+    }
+  } catch {
+    // Missing, unreadable, or concurrently rotated transcripts return what we have.
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+  return latest;
+}
 
 /** Parse one Claude JSONL transcript. The session id is the filename; cwd,
  *  first user prompt, and the latest valid customTitle come from the content.
- *  Sidechain / synthetic / slash-command entries are skipped. A custom title
- *  wins when present; otherwise the user's real first turn is the fallback. */
+ *  Sidechain / synthetic / slash-command entries are skipped. The head pass
+ *  finds the identity/origin metadata, then a bounded tail pass finds the
+ *  latest valid custom title. A custom title wins when present; otherwise the
+ *  user's real first turn is the fallback. */
 async function parseClaudeTranscript(path: string, mtimeMs: number): Promise<ResumableSession | null> {
   const cliSessionId = basename(path, '.jsonl');
   if (!cliSessionId) return null;
   // Accumulate into an object (see parseRolloutTranscript) so the post-loop
   // guard narrows correctly despite closure mutation.
-  const acc: { cwd: string | null; fallbackTitle: string; customTitle: string; botmux: boolean } = {
+  const acc: { cwd: string | null; fallbackTitle: string; botmux: boolean } = {
     cwd: null,
     fallbackTitle: '',
-    customTitle: '',
     botmux: false,
   };
   await forEachJsonLine(path, (rec) => {
@@ -222,18 +265,16 @@ async function parseClaudeTranscript(path: string, mtimeMs: number): Promise<Res
         if (clean) acc.fallbackTitle = truncateTitle(clean);
       }
     }
-    if (typeof rec.customTitle === 'string') {
-      const title = truncateTitle(rec.customTitle);
-      if (title) acc.customTitle = title;
-    }
+    return Boolean(acc.cwd && acc.fallbackTitle);
   });
   // Drop botmux-origin sessions and empties (no real user prompt → command-only
   // / aborted — not worth importing).
   if (acc.botmux || !acc.cwd || !acc.fallbackTitle) return null;
+  const tailTitle = await findLatestClaudeCustomTitle(path);
   return {
     cliSessionId,
     cwd: acc.cwd,
-    title: acc.customTitle || acc.fallbackTitle,
+    title: tailTitle || acc.fallbackTitle,
     lastActivityAt: mtimeMs,
   };
 }

--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -194,8 +194,8 @@ async function collectRecentJsonl(
 
 // ─── Claude-family JSONL (claude-code, seed, relay, genius) ──────────────────
 
-/** Scan a bounded tail for the latest valid customTitle. The first line may be
- *  truncated at the byte boundary, so it is skipped. */
+/** Scan a bounded tail for the latest valid customTitle. Skip the first line
+ *  only when the byte boundary cuts through it. */
 async function findLatestClaudeCustomTitle(path: string): Promise<string> {
   let stat;
   try {
@@ -206,6 +206,24 @@ async function findLatestClaudeCustomTitle(path: string): Promise<string> {
   if (stat.size <= 0) return '';
 
   const start = Math.max(0, stat.size - CLAUDE_CUSTOM_TITLE_TAIL_BYTES);
+  let skipFirstLine = false;
+  if (start > 0) {
+    let handle;
+    try {
+      handle = await fs.open(path, 'r');
+      const previous = Buffer.alloc(1);
+      const { bytesRead } = await handle.read(previous, 0, 1, start - 1);
+      // If the tail starts immediately after a newline, its first line is
+      // complete. Otherwise it is the residual of a line cut by the byte cap.
+      skipFirstLine = bytesRead !== 1 || previous[0] !== 0x0a;
+    } catch {
+      // Prefer dropping a possibly partial first line if the probe races with
+      // a rotated/unreadable transcript.
+      skipFirstLine = true;
+    } finally {
+      await handle?.close().catch(() => {});
+    }
+  }
   const stream = createReadStream(path, {
     encoding: 'utf8',
     start,
@@ -214,13 +232,14 @@ async function findLatestClaudeCustomTitle(path: string): Promise<string> {
   stream.on('error', () => { /* handled via try/catch */ });
   const rl = createInterface({ input: stream, crlfDelay: Infinity });
   let latest = '';
-  let first = start > 0;
+  let first = true;
   try {
     for await (const raw of rl) {
-      if (first) {
+      if (first && skipFirstLine) {
         first = false;
         continue;
       }
+      first = false;
       const rec = parseJsonRecord(raw);
       if (!rec || rec.isSidechain === true || typeof rec.customTitle !== 'string') continue;
       const title = truncateTitle(rec.customTitle);

--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -14,7 +14,8 @@
  * only on an explicit `/adopt` — so we favour correctness over cleverness: take
  * the most-recent files by mtime, then stream each line by line (NOT a bounded
  * byte prefix, which truncates oversized records and hides an append-only log's
- * fresh tail), stopping early once the needed metadata is in hand.
+ * fresh tail). Parsers stop early once the needed metadata is in hand where
+ * possible; Claude scans the bounded transcript so a later `/rename` wins.
  */
 import { promises as fs, createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
@@ -23,11 +24,12 @@ import type { ResumableSession } from '../adapters/cli/types.js';
 
 const TITLE_MAX = 80;
 
-/** Safety cap on lines scanned per transcript when searching for the metadata
- *  we need (session id / cwd / first prompt). All three live near the top of
- *  claude/rollout transcripts, so the early-stop almost always fires first;
- *  this only bounds pathological / corrupt files. Antigravity's flat submit log
- *  is read in full (see its own higher cap) so tail entries are never missed. */
+/** Safety cap on lines scanned per transcript when searching for metadata.
+ *  Session id / cwd / first prompt live near the top, but Claude custom titles
+ *  may appear later after `/rename`, so its parser intentionally scans up to
+ *  this bound. The cap only bounds pathological / corrupt files. Antigravity's
+ *  flat submit log is read in full (see its own higher cap) so tail entries are
+ *  never missed. */
 const MAX_LINES_PER_FILE = 5_000;
 
 function asRecord(v: unknown): Record<string, unknown> | null {
@@ -191,33 +193,49 @@ async function collectRecentJsonl(
 
 // ─── Claude-family JSONL (claude-code, seed, relay) ──────────────────────────
 
-/** Parse one Claude JSONL transcript. The session id is the filename; cwd +
- *  first user prompt come from the content (streamed line by line, stopping
- *  once both are found). Sidechain / synthetic / slash-command entries are
- *  skipped so the title is the user's real first turn. */
+/** Parse one Claude JSONL transcript. The session id is the filename; cwd,
+ *  first user prompt, and the latest valid customTitle come from the content.
+ *  Sidechain / synthetic / slash-command entries are skipped. A custom title
+ *  wins when present; otherwise the user's real first turn is the fallback. */
 async function parseClaudeTranscript(path: string, mtimeMs: number): Promise<ResumableSession | null> {
   const cliSessionId = basename(path, '.jsonl');
   if (!cliSessionId) return null;
   // Accumulate into an object (see parseRolloutTranscript) so the post-loop
   // guard narrows correctly despite closure mutation.
-  const acc: { cwd: string | null; title: string; botmux: boolean } = { cwd: null, title: '', botmux: false };
+  const acc: { cwd: string | null; fallbackTitle: string; customTitle: string; botmux: boolean } = {
+    cwd: null,
+    fallbackTitle: '',
+    customTitle: '',
+    botmux: false,
+  };
   await forEachJsonLine(path, (rec) => {
     if (rec.isSidechain === true) return;
     if (!acc.cwd && typeof rec.cwd === 'string') acc.cwd = rec.cwd;
-    if (rec.type === 'user') {
+    // Origin and fallback title are both determined by the first meaningful
+    // user turn. Do not reclassify an external session if it is later resumed
+    // through botmux while we continue scanning for a rename.
+    if (!acc.fallbackTitle && rec.type === 'user') {
       const raw = rawClaudeUserText(rec.message);
       if (raw && isBotmuxInjected(raw)) { acc.botmux = true; return true; } // botmux-origin → drop
-      if (!acc.title && raw) {
+      if (raw) {
         const clean = cleanUserPromptForTitle(raw);
-        if (clean) acc.title = truncateTitle(clean);
+        if (clean) acc.fallbackTitle = truncateTitle(clean);
       }
     }
-    return Boolean(acc.cwd && acc.title); // stop once we have everything
+    if (typeof rec.customTitle === 'string') {
+      const title = truncateTitle(rec.customTitle);
+      if (title) acc.customTitle = title;
+    }
   });
   // Drop botmux-origin sessions and empties (no real user prompt → command-only
   // / aborted — not worth importing).
-  if (acc.botmux || !acc.cwd || !acc.title) return null;
-  return { cliSessionId, cwd: acc.cwd, title: acc.title, lastActivityAt: mtimeMs };
+  if (acc.botmux || !acc.cwd || !acc.fallbackTitle) return null;
+  return {
+    cliSessionId,
+    cwd: acc.cwd,
+    title: acc.customTitle || acc.fallbackTitle,
+    lastActivityAt: mtimeMs,
+  };
 }
 
 /** Pull plain user text out of a Claude `message` field (string content or the

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -46,6 +46,38 @@ describe('discoverClaudeFamilySessions', () => {
     });
   });
 
+  it('prefers a customTitle that appears after the first user prompt', async () => {
+    writeSession('-root-proj', 'rename-after-prompt', [
+      { type: 'user', cwd: '/root/proj', message: { role: 'user', content: 'fix the parser bug' } },
+      { type: 'assistant', message: { role: 'assistant', content: 'ok' } },
+      { type: 'custom-title', customTitle: '  Parser reliability  ' },
+    ]);
+    const out = await discoverClaudeFamilySessions(dataDir, 10);
+    expect(out[0]?.title).toBe('Parser reliability');
+  });
+
+  it('uses the latest valid customTitle across multiple renames', async () => {
+    writeSession('-root-proj', 'multiple-renames', [
+      { type: 'user', cwd: '/root/proj', message: { role: 'user', content: 'initial prompt' } },
+      { type: 'custom-title', customTitle: 'First name' },
+      { type: 'custom-title', customTitle: 'Latest name' },
+      { type: 'custom-title', customTitle: '   ' },
+      { type: 'custom-title', customTitle: null },
+    ]);
+    const out = await discoverClaudeFamilySessions(dataDir, 10);
+    expect(out[0]?.title).toBe('Latest name');
+  });
+
+  it('falls back to the first real user prompt when customTitle is absent or invalid', async () => {
+    writeSession('-root-proj', 'rename-fallback', [
+      { type: 'user', cwd: '/root/proj', message: { role: 'user', content: 'the fallback prompt' } },
+      { type: 'custom-title', customTitle: '' },
+      { type: 'custom-title', customTitle: 123 },
+    ]);
+    const out = await discoverClaudeFamilySessions(dataDir, 10);
+    expect(out[0]?.title).toBe('the fallback prompt');
+  });
+
   it('skips sidechain entries and slash-command meta lines when picking a title', async () => {
     writeSession('-root-proj', 'bbbb2222-0000-0000-0000-000000000002', [
       { type: 'user', cwd: '/root/proj', isSidechain: true, message: { role: 'user', content: 'subagent noise' } },

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -21,7 +21,7 @@ function tmp(prefix: string): string {
 
 const jsonl = (...lines: unknown[]): string => lines.map((l) => JSON.stringify(l)).join('\n') + '\n';
 
-describe('discoverClaudeFamilySessions', () => {
+describe('discoverClaudeFamilySessions (Claude-family / Genius)', () => {
   let dataDir: string;
   beforeEach(() => { dataDir = tmp('bmx-claude-'); });
 
@@ -68,6 +68,23 @@ describe('discoverClaudeFamilySessions', () => {
     expect(out[0]?.title).toBe('Latest name');
   });
 
+  // Regression: Claude-family / Genius append `custom-title` records after
+  // the transcript's initial metadata. The bounded head scan must not hide a
+  // valid rename that lands beyond its 5,000-line safety window.
+  it('finds a customTitle appended after line 5000', async () => {
+    const lines: unknown[] = [
+      { type: 'user', cwd: '/root/proj', message: { role: 'user', content: 'initial prompt' } },
+    ];
+    for (let i = 0; i < 5_001; i++) {
+      lines.push({ type: 'assistant', message: { role: 'assistant', content: `filler ${i}` } });
+    }
+    lines.push({ type: 'custom-title', customTitle: 'Late parser title' });
+    writeSession('-root-proj', 'rename-after-head-cap', lines);
+
+    const out = await discoverClaudeFamilySessions(dataDir, 10);
+    expect(out[0]?.title).toBe('Late parser title');
+  });
+
   it('falls back to the first real user prompt when customTitle is absent or invalid', async () => {
     writeSession('-root-proj', 'rename-fallback', [
       { type: 'user', cwd: '/root/proj', message: { role: 'user', content: 'the fallback prompt' } },
@@ -83,6 +100,7 @@ describe('discoverClaudeFamilySessions', () => {
       { type: 'user', cwd: '/root/proj', isSidechain: true, message: { role: 'user', content: 'subagent noise' } },
       { type: 'user', cwd: '/root/proj', message: { role: 'user', content: '<command-name>/clear</command-name>' } },
       { type: 'user', cwd: '/root/proj', message: { role: 'user', content: 'the real first question' } },
+      { type: 'custom-title', isSidechain: true, customTitle: 'subagent title noise' },
     ]);
     const out = await discoverClaudeFamilySessions(dataDir, 10);
     expect(out[0]?.title).toBe('the real first question');
@@ -116,7 +134,7 @@ describe('discoverClaudeFamilySessions', () => {
     expect(out.map((s) => s.cliSessionId).sort()).toEqual(['ext-discuss-1', 'ext-discuss-2']);
   });
 
-  // Regression (whiteboard /adopt leak): Claude-family CLIs with
+  // Regression (whiteboard /adopt leak): Claude-family / Genius CLIs with
   // injectsSessionContext=true get routing/identity/session_id via system
   // prompt, so when no team/group role is configured the botmux prompt STARTS
   // with the <whiteboard> block directly. No ^-anchored pattern matched that
@@ -136,7 +154,7 @@ describe('discoverClaudeFamilySessions', () => {
 
   // The ^<whiteboard>-opening pattern matches ANY board id (id="[^"]+"), not
   // just the default `wb_` prefix — a user-created board (`create --id
-  // <custom>`) bound to a Claude-family + role-less session also opens with
+  // <custom>`) bound to a Claude-family / Genius + role-less session also opens with
   // <whiteboard id="<custom>"> and must be dropped from /adopt.
   it('drops botmux-origin Claude sessions opening with a custom-id <whiteboard>', async () => {
     writeSession('-root-wb', 'wb-custom-1', [

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -85,6 +85,53 @@ describe('discoverClaudeFamilySessions (Claude-family / Genius)', () => {
     expect(out[0]?.title).toBe('Late parser title');
   });
 
+  it('does not skip a customTitle that starts exactly at the tail boundary', async () => {
+    const tailBytes = 4 * 1024 * 1024;
+    const assistantLine = (content: string): string => JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content },
+    }) + '\n';
+    const prefix = JSON.stringify({
+      type: 'user',
+      cwd: '/root/boundary',
+      message: { role: 'user', content: 'initial prompt' },
+    }) + '\n';
+    const customTitleLine = JSON.stringify({
+      type: 'custom-title',
+      customTitle: 'Boundary title',
+    }) + '\n';
+    const fillerBytes = tailBytes - Buffer.byteLength(customTitleLine);
+    const emptyAssistantBytes = Buffer.byteLength(assistantLine(''));
+    expect(fillerBytes).toBeGreaterThanOrEqual(emptyAssistantBytes);
+    const fillerLine = assistantLine('x'.repeat(fillerBytes - emptyAssistantBytes));
+    expect(Buffer.byteLength(customTitleLine + fillerLine)).toBe(tailBytes);
+
+    const dir = join(dataDir, 'projects', '-root-boundary');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'tail-boundary.jsonl'), prefix + customTitleLine + fillerLine);
+
+    const out = await discoverClaudeFamilySessions(dataDir, 10);
+    expect(out[0]?.title).toBe('Boundary title');
+  });
+
+  it('skips a genuinely truncated tail line before reading the next title', async () => {
+    const dir = join(dataDir, 'projects', '-root-truncated');
+    mkdirSync(dir, { recursive: true });
+    const oversizedAssistant = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: 'x'.repeat(4 * 1024 * 1024) },
+    });
+    writeFileSync(join(dir, 'truncated-tail.jsonl'), [
+      JSON.stringify({ type: 'user', cwd: '/root/truncated', message: { role: 'user', content: 'prompt' } }),
+      oversizedAssistant,
+      JSON.stringify({ type: 'custom-title', customTitle: 'After truncated line' }),
+      '',
+    ].join('\n'));
+
+    const out = await discoverClaudeFamilySessions(dataDir, 10);
+    expect(out[0]?.title).toBe('After truncated line');
+  });
+
   it('falls back to the first real user prompt when customTitle is absent or invalid', async () => {
     writeSession('-root-proj', 'rename-fallback', [
       { type: 'user', cwd: '/root/proj', message: { role: 'user', content: 'the fallback prompt' } },


### PR DESCRIPTION
## 变更内容

- Claude-family 会话发现把头部元数据解析和尾部重命名查找拆开
- 头部只负责 `cwd`、首条真实用户消息和 botmux 来源判定
- 尾部使用有界 4 MiB 流式窗口查找最新有效 `customTitle`，不会无界扫描超长 transcript
- 多次 rename 时采用最后一个有效标题；空白、非字符串和 sidechain 标题不会覆盖结果
- 没有有效 `customTitle` 时，保持首条真实用户消息作为 fallback

## 原因

原实现最多顺序读取前 5000 行。Claude 的 `/rename` 会把 `custom-title` 记录追加到 transcript 尾部，因此长会话的重命名可能位于第 5001 行以后并被静默忽略。

## 影响范围

改动仅涉及 Claude-family 共用的 resumable session discovery 路径（Claude Code、Seed、Relay、Genius）。Codex/TRAE rollout、Antigravity、backend 和 IM 渲染逻辑不受影响。botmux-origin、sidechain、slash/local command 与 command-only 会话过滤行为保持不变。

## 验证

- `pnpm exec vitest run --project unit test/resumable-session-discovery.test.ts`（30/30 通过，包含 `customTitle` 位于第 5000 行之后的回归用例）
- `pnpm build`（通过）
- `git diff --check`（通过）

Closes #523