### PR TITLE
fix(web-terminal): 支持 OpenCode 只读终端滚轮翻页

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ src/desktop/assets/*.png
 # 静默忽略，`git add` 只报一行提示，很容易漏提交。
 /platform/
 /mcp-gateway/
+
+# OMO 计划产物（.omo/ 计划、草稿、证据），绝不提交
+.omo/

--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -362,6 +362,7 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
     readyPattern: undefined,        // Bubble Tea TUI — no reliable prompt indicator; rely on quiescence + spinner guard
     systemHints: BOTMUX_SHELL_HINTS,
     altScreen: true,                // Bubble Tea renders in alternate screen buffer
+    readOnlyRemoteScroll: true,
     skillsDir: '~/.config/opencode/skills',
     // botmux hook 安装：spawn 时写入 OpenCode 插件文件，
     // 使 question.asked 事件自动转发到 `botmux hook opencode`。

--- a/src/adapters/cli/opencode2.ts
+++ b/src/adapters/cli/opencode2.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs';
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import type { CliAdapter, PtyHandle, ResumableSession } from './types.js';
@@ -135,6 +134,7 @@ export function createOpenCode2Adapter(pathOverride?: string): CliAdapter {
     readyPattern: undefined,
     systemHints: BOTMUX_SHELL_HINTS,
     altScreen: true,                // V2 TUI 仍渲染在 alternate screen buffer（实测 \x1b[?1049h）
+    readOnlyRemoteScroll: true,
     skillsDir: '~/.config/opencode/skills',
     // botmux ask-hook：V2 插件（新插件 API），写入 V2 全局插件发现目录。
     // ⚠️ beta 已知上游问题（next-17082）：HOME 是符号链接（如 /home→/data00/home）的

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -406,6 +406,12 @@ export interface CliAdapter {
   /** Whether CLI uses alternate screen buffer */
   readonly altScreen: boolean;
 
+  /** Whether read-only Web Terminal viewers may forward SGR wheel events.
+   *  This is narrower than write access: the worker accepts only validated
+   *  mouse-wheel escape sequences, for TUIs whose transcript can only scroll
+   *  inside the alternate-screen app viewport. */
+  readonly readOnlyRemoteScroll?: boolean;
+
   /** Curated model candidates surfaced in `botmux setup`. When undefined the
    *  setup flow skips the model prompt for this CLI entirely (e.g. CLIs whose
    *  model is fixed or set via a config file we don't manage). The order is

--- a/src/utils/web-terminal-scroll.ts
+++ b/src/utils/web-terminal-scroll.ts
@@ -31,3 +31,41 @@ export function parseReadOnlyRemoteScrollPayload(data: string): ReadOnlyRemoteSc
   if (offset !== data.length || eventCount === 0 || direction === undefined) return null;
   return { direction, eventCount };
 }
+
+export const READ_ONLY_REMOTE_SCROLL_SESSION_BUDGET = 12;
+export const READ_ONLY_REMOTE_SCROLL_WINDOW_MS = 1_000;
+
+export interface ReadOnlyRemoteScrollLimiterOptions {
+  readonly budget: number;
+  readonly windowMs: number;
+}
+
+/**
+ * Session-scoped fixed-window limiter for read-only remote scroll events.
+ * One instance is shared by every read-only WebSocket client of a session,
+ * so the budget aggregates across sockets. The window resets on the first
+ * consumption after it expires; excess events are dropped, never queued.
+ */
+export class ReadOnlyRemoteScrollLimiter {
+  private usedEvents = 0;
+  private windowStartMs: number | undefined;
+
+  constructor(
+    private readonly options: ReadOnlyRemoteScrollLimiterOptions,
+    private readonly nowMs: () => number = Date.now,
+  ) {
+    if (options.budget <= 0) throw new Error('ReadOnlyRemoteScrollLimiter: budget must be positive');
+    if (options.windowMs <= 0) throw new Error('ReadOnlyRemoteScrollLimiter: windowMs must be positive');
+  }
+
+  tryConsume(eventCount: number): boolean {
+    const now = this.nowMs();
+    if (this.windowStartMs === undefined || now - this.windowStartMs >= this.options.windowMs) {
+      this.windowStartMs = now;
+      this.usedEvents = 0;
+    }
+    if (this.usedEvents + eventCount > this.options.budget) return false;
+    this.usedEvents += eventCount;
+    return true;
+  }
+}

--- a/src/utils/web-terminal-scroll.ts
+++ b/src/utils/web-terminal-scroll.ts
@@ -1,0 +1,33 @@
+export type ReadOnlyRemoteScrollDirection = 'up' | 'down';
+
+export interface ReadOnlyRemoteScrollPayload {
+  readonly direction: ReadOnlyRemoteScrollDirection;
+  readonly eventCount: number;
+}
+
+const READ_ONLY_REMOTE_SCROLL_MAX_EVENTS = 6;
+
+export function parseReadOnlyRemoteScrollPayload(data: string): ReadOnlyRemoteScrollPayload | null {
+  if (!data) return null;
+
+  const eventPattern = /\x1b\[<(64|65);[1-9]\d{0,3};[1-9]\d{0,3}M/g;
+  let offset = 0;
+  let eventCount = 0;
+  let direction: ReadOnlyRemoteScrollDirection | undefined;
+
+  for (let match = eventPattern.exec(data); match; match = eventPattern.exec(data)) {
+    const fullMatch = match[0];
+    const button = match[1];
+    if (match.index !== offset) return null;
+    offset += fullMatch.length;
+    eventCount += 1;
+    if (eventCount > READ_ONLY_REMOTE_SCROLL_MAX_EVENTS) return null;
+
+    const nextDirection: ReadOnlyRemoteScrollDirection = button === '64' ? 'up' : 'down';
+    if (direction !== undefined && direction !== nextDirection) return null;
+    direction = nextDirection;
+  }
+
+  if (offset !== data.length || eventCount === 0 || direction === undefined) return null;
+  return { direction, eventCount };
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -66,6 +66,7 @@ import {
 import { canStartInjectionFlush, shouldDeferUserFlush, shouldFlushInjectionsFirst, type PendingInjection } from './core/inject-queue-policy.js';
 import { decideRestartFollowup, settleDurableTurnForRestart } from './core/restart-followup-policy.js';
 import { stripAnsiForLog, tailChars } from './utils/crash-log.js';
+import { parseReadOnlyRemoteScrollPayload } from './utils/web-terminal-scroll.js';
 import { CodexUpdateDialogGuard } from './utils/codex-update-dialog.js';
 import { EffortConfirmDialogGuard, isEffortLevelCommand } from './utils/effort-confirm-dialog.js';
 import { installStdioEpipeGuard, isIgnorableStreamError } from './utils/stdio-epipe-guard.js';
@@ -6805,6 +6806,11 @@ function restoreHerdrWebBindings(): void {
     }
     applyHerdrWebBindingResult(ws, binding.restore());
   }
+}
+
+function canHandleReadOnlyRemoteScroll(): boolean {
+  return cliAdapter?.readOnlyRemoteScroll === true
+    && !(lastInitConfig?.adoptMode && lastInitConfig.adoptZellijPaneId);
 }
 
 function wireHerdrWebTerminalRelays(be: HerdrBackend): void {
@@ -14449,6 +14455,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
       // normal buffer until resize causes a redraw. Preserve that mode so
       // scroll gestures continue to target the CLI's own transcript.
       const forceRemoteScroll = effectiveBackendType === 'herdr' && cliAdapter?.altScreen === true;
+      const allowReadOnlyRemoteScroll = canHandleReadOnlyRemoteScroll();
       // The wheel burst cap throttles backends where a forwarded wheel is
       // EXPENSIVE or has no local terminal to drive:
       //   • Herdr — each forwarded wheel → pane send-text + snapshot re-render.
@@ -14466,7 +14473,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         || effectiveBackendType === 'tmux'
         || effectiveBackendType === 'zellij';
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend));
+      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend, allowReadOnlyRemoteScroll));
     });
 
     wss = new WebSocketServer({
@@ -14501,6 +14508,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         return;
       }
       const { hasWrite } = resolveTerminalAccessForReq(req, url);
+      const allowReadOnlyRemoteScroll = canHandleReadOnlyRemoteScroll();
       if (hasWrite) authedClients.add(ws);
       log(`WS client connected (total: ${wsClients.size}, write: ${hasWrite})`);
 
@@ -14725,6 +14733,12 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
                 else if (msg.data.includes('\x1b[<65;')) herdrWebScrollDirection = 'down';
               }
               backend?.write(msg.data);
+            } else if (msg.type === 'scroll' && typeof msg.data === 'string') {
+              if (!allowReadOnlyRemoteScroll || authedClients.has(ws)) return;
+              const parsed = parseReadOnlyRemoteScrollPayload(msg.data);
+              if (!parsed) return;
+              if (usesHerdrSnapshotWebHistory()) herdrWebScrollDirection = parsed.direction;
+              backend?.write(msg.data);
             }
           } catch { /* ignore non-JSON or bad messages */ }
         });
@@ -14756,6 +14770,7 @@ function getTerminalHtml(
   loginUrl = '',
   forceRemoteScroll = false,
   localTerminalBackend = false,
+  allowReadOnlyRemoteScroll = false,
 ): string {
   const label = sessionId.substring(0, 8);
   return `<!DOCTYPE html>
@@ -14894,6 +14909,7 @@ var hasToken=${hasWrite};
 var platformReadonly=${platformReadonly};
 var remoteScroll=${forceRemoteScroll};
 var localTerminalBackend=${localTerminalBackend};
+var readOnlyRemoteScroll=${allowReadOnlyRemoteScroll};
 if(!hasToken){
   if(platformReadonly){var _lb=document.getElementById('login-banner');_lb.classList.add('show');}
   else{var _rb=document.getElementById('readonly-banner');_rb.classList.add('show');_rb.addEventListener('click',function(){_rb.classList.remove('show')});}
@@ -15190,8 +15206,9 @@ window.addEventListener('resize',onViewportResize);
 // Alt-screen + mouse-mode CLIs (e.g. Claude Code) keep NO scrollback in xterm OR
 // tmux — their whole transcript is redrawn by the app inside the fixed alt-screen
 // grid, so term.scrollLines() reveals nothing. In the alternate buffer we forward
-// scrolling as SGR mouse-wheel events so the CLI scrolls its own transcript and
-// repaints. This is write-capability only; view links stay locally scrollable.
+// scrolling as SGR mouse-wheel events so the CLI scrolls its own transcript.
+// Read-only viewers get this remote path only for adapters that explicitly opt
+// in; the server then accepts only validated wheel events, never general input.
 // Normal-buffer CLIs keep xterm's native scrollback scroll. Capture-phase +
 // stopPropagation pre-empts xterm's own handler. Skipped for pure tmux/zellij
 // ATTACH (gate), where the attach client owns scrolling via copy-mode.
@@ -15251,7 +15268,7 @@ function _cellAt(clientX,clientY){
   return col+';'+row;
 }
 function _fwdScroll(px,coord){
-  if(!hasToken||!ws_||ws_.readyState!==1||!px)return;
+  if((!hasToken&&!readOnlyRemoteScroll)||!ws_||ws_.readyState!==1||!px)return;
   coord=coord||(((term.cols>>1)+1)+';'+((term.rows>>1)+1)); // never (1,1)
   var dir=px<0?-1:1;
   if(_scrollBurstDir&&dir!==_scrollBurstDir){_scrollAccum=0;_scrollBurstTicks=0;}
@@ -15265,7 +15282,7 @@ function _fwdScroll(px,coord){
     _scrollAccum+=up?_SCROLL_STEP:-_SCROLL_STEP;n++;_scrollBurstTicks++;
   }
   if(_scrollBurstTicks>=_SCROLL_BURST_MAX)_scrollAccum=0;
-  if(data)ws_.send(JSON.stringify({type:'input',data:data}));
+  if(data)ws_.send(JSON.stringify({type:hasToken?'input':'scroll',data:data}));
 }
 if(!${isTmuxMode && !isPipeMode}){
   document.getElementById('terminal').addEventListener('wheel',function(e){
@@ -15278,7 +15295,9 @@ if(!${isTmuxMode && !isPipeMode}){
       return;
     }
     if(!hasToken){
-      e.preventDefault();e.stopPropagation();term.scrollLines(e.deltaY>0?3:-3);return;
+      e.preventDefault();e.stopPropagation();
+      if(readOnlyRemoteScroll)_fwdScroll(px,_cellAt(e.clientX,e.clientY));
+      else term.scrollLines(e.deltaY>0?3:-3);return;
     }
     e.preventDefault();e.stopPropagation();
     _fwdScroll(px,_cellAt(e.clientX,e.clientY)); // report the cell under the pointer
@@ -15599,8 +15618,7 @@ if(!${isTmuxMode && !isPipeMode}){
     if(e.touches.length===1)_tLastY=e.touches[0].clientY;
   },{capture:true,passive:true});
   _tTerm.addEventListener('touchmove',function(e){
-    // View links never forward input; let xterm/browser handle local scrolling.
-    if(!hasToken||_tLastY===null||e.touches.length!==1)return;
+    if((!hasToken&&!readOnlyRemoteScroll)||_tLastY===null||e.touches.length!==1)return;
     e.preventDefault();e.stopPropagation();
     var y=e.touches[0].clientY;
     var px=_tLastY-y;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -66,7 +66,12 @@ import {
 import { canStartInjectionFlush, shouldDeferUserFlush, shouldFlushInjectionsFirst, type PendingInjection } from './core/inject-queue-policy.js';
 import { decideRestartFollowup, settleDurableTurnForRestart } from './core/restart-followup-policy.js';
 import { stripAnsiForLog, tailChars } from './utils/crash-log.js';
-import { parseReadOnlyRemoteScrollPayload } from './utils/web-terminal-scroll.js';
+import {
+  parseReadOnlyRemoteScrollPayload,
+  READ_ONLY_REMOTE_SCROLL_SESSION_BUDGET,
+  READ_ONLY_REMOTE_SCROLL_WINDOW_MS,
+  ReadOnlyRemoteScrollLimiter,
+} from './utils/web-terminal-scroll.js';
 import { CodexUpdateDialogGuard } from './utils/codex-update-dialog.js';
 import { EffortConfirmDialogGuard, isEffortLevelCommand } from './utils/effort-confirm-dialog.js';
 import { installStdioEpipeGuard, isIgnorableStreamError } from './utils/stdio-epipe-guard.js';
@@ -1781,6 +1786,10 @@ const authedClients = new WeakSet<WebSocket>();
 const clientPtys = new Map<WebSocket, pty.IPty>();
 /** Managed-Herdr viewers survive an in-worker /restart while backend changes. */
 const herdrWebBindings = new Map<WebSocket, HerdrWebTerminalBinding>();
+const readOnlyRemoteScrollLimiter = new ReadOnlyRemoteScrollLimiter({
+  budget: READ_ONLY_REMOTE_SCROLL_SESSION_BUDGET,
+  windowMs: READ_ONLY_REMOTE_SCROLL_WINDOW_MS,
+});
 // Standalone/test fallback. Production replaces this after init with a stable
 // per-session HMAC derived from the host-only dashboard secret, so an
 // already-issued 「操作链接」/write link survives a worker restart (a silent
@@ -14737,6 +14746,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
               if (!allowReadOnlyRemoteScroll || authedClients.has(ws)) return;
               const parsed = parseReadOnlyRemoteScrollPayload(msg.data);
               if (!parsed) return;
+              if (!readOnlyRemoteScrollLimiter.tryConsume(parsed.eventCount)) return;
               if (usesHerdrSnapshotWebHistory()) herdrWebScrollDirection = parsed.direction;
               backend?.write(msg.data);
             }

--- a/test/helpers/worker-terminal-scroll-harness.ts
+++ b/test/helpers/worker-terminal-scroll-harness.ts
@@ -1,0 +1,229 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach } from 'vitest';
+import { WebSocket } from 'ws';
+import type { DaemonToWorker, WorkerToDaemon } from '../../src/types.js';
+
+const children = new Set<ChildProcess>();
+const tempDirs = new Set<string>();
+
+export const READ_ONLY_SCROLL_SESSION_BUDGET = 12;
+export const WHEEL_UP = '\x1b[<64;12;8M';
+export const WHEEL_UP_HEX = Buffer.from(WHEEL_UP).toString('hex');
+export const FORGED_INPUT = 'FORGED_INPUT\n';
+export const FORGED_INPUT_HEX = Buffer.from(FORGED_INPUT).toString('hex');
+
+type ReadyMessage = Extract<WorkerToDaemon, { type: 'ready' }>;
+type ErrorMessage = Extract<WorkerToDaemon, { type: 'error' }>;
+type TestCliId = 'opencode' | 'opencode2';
+
+type WorkerHarness = {
+  readonly child: ChildProcess;
+  readonly inputLog: string;
+  readonly ready: ReadyMessage;
+};
+
+type StableCountOptions = {
+  readonly timeoutMs: number;
+  readonly pollMs: number;
+  readonly stablePolls: number;
+  readonly minimumCount: number;
+};
+
+const DEFAULT_STABLE_COUNT_OPTIONS = {
+  timeoutMs: 5_000,
+  pollMs: 25,
+  stablePolls: 8,
+  minimumCount: 0,
+} satisfies StableCountOptions;
+
+class HarnessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HarnessError';
+  }
+}
+
+afterEach(() => {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  }
+  children.clear();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+function hasMessageType(raw: unknown, type: WorkerToDaemon['type']): raw is { readonly type: WorkerToDaemon['type'] } {
+  return typeof raw === 'object' && raw !== null && 'type' in raw && raw.type === type;
+}
+
+function isReadyMessage(raw: unknown): raw is ReadyMessage {
+  return hasMessageType(raw, 'ready');
+}
+
+function isErrorMessage(raw: unknown): raw is ErrorMessage {
+  return hasMessageType(raw, 'error') && 'message' in raw && typeof raw.message === 'string';
+}
+
+function waitForReady(child: ChildProcess, logs: readonly string[]): Promise<ReadyMessage> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      rejectPromise(new HarnessError(`worker ready timeout\n${logs.join('')}`));
+    }, 15_000);
+    child.on('message', (raw: unknown) => {
+      if (isReadyMessage(raw)) {
+        clearTimeout(timer);
+        resolvePromise(raw);
+      } else if (isErrorMessage(raw)) {
+        clearTimeout(timer);
+        rejectPromise(new HarnessError(`worker error: ${raw.message}\n${logs.join('')}`));
+      }
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      rejectPromise(new HarnessError(`worker exited before ready (${code ?? signal})\n${logs.join('')}`));
+    });
+  });
+}
+
+export async function startOpenCodeWorker(cliId: TestCliId = 'opencode'): Promise<WorkerHarness> {
+  const root = mkdtempSync(join(tmpdir(), 'botmux-readonly-scroll-'));
+  tempDirs.add(root);
+  const dataDir = join(root, 'session');
+  mkdirSync(dataDir, { recursive: true });
+
+  const botmuxDir = join(root, '.botmux');
+  mkdirSync(botmuxDir, { recursive: true });
+  writeFileSync(join(botmuxDir, '.dashboard-secret'), 'integration-host-dashboard-secret', { mode: 0o600 });
+
+  const fakeCli = join(root, 'fake-opencode');
+  const inputLog = join(root, 'terminal-input.hex');
+  writeFileSync(fakeCli, `#!/usr/bin/env node
+const { appendFileSync } = require('node:fs');
+process.stdin.setRawMode?.(true);
+process.stdin.resume();
+process.stdin.on('data', chunk => appendFileSync(${JSON.stringify(inputLog)}, chunk.toString('hex') + '\\n'));
+setInterval(() => {}, 1_000);
+`);
+  chmodSync(fakeCli, 0o755);
+
+  const logs: string[] = [];
+  const sessionId = `readonly-scroll-${cliId}`;
+  const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+    cwd: resolve('.'),
+    env: {
+      ...process.env,
+      HOME: root,
+      SESSION_DATA_DIR: dataDir,
+      BOTMUX_SESSION_ID: sessionId,
+      LARK_APP_ID: 'app_readonly_scroll',
+      LARK_APP_SECRET: 'secret',
+    },
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+  });
+  children.add(child);
+  child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+  child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+  child.send({
+    type: 'init',
+    sessionId,
+    chatId: `oc_${sessionId}`,
+    rootMessageId: `om_${sessionId}`,
+    workingDir: dataDir,
+    cliId,
+    cliPathOverride: fakeCli,
+    backendType: 'pty',
+    prompt: '',
+    larkAppId: 'app_readonly_scroll',
+    larkAppSecret: 'secret',
+  } satisfies DaemonToWorker);
+
+  const ready = await waitForReady(child, logs);
+  return { child, inputLog, ready };
+}
+
+function viewWebSocketUrl(harness: WorkerHarness): string {
+  if (!harness.ready.viewToken) throw new HarnessError('worker ready message did not include a view token');
+  return `ws://127.0.0.1:${harness.ready.port}/?viewToken=${encodeURIComponent(harness.ready.viewToken)}`;
+}
+
+function openWebSocket(url: string): Promise<WebSocket> {
+  const ws = new WebSocket(url);
+  return new Promise((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      ws.terminate();
+      rejectPromise(new HarnessError('websocket open timeout'));
+    }, 5_000);
+    ws.once('open', () => {
+      clearTimeout(timer);
+      resolvePromise(ws);
+    });
+    ws.once('error', err => {
+      clearTimeout(timer);
+      rejectPromise(err);
+    });
+  });
+}
+
+export async function openViewSocket(harness: WorkerHarness): Promise<WebSocket> {
+  return openWebSocket(viewWebSocketUrl(harness));
+}
+
+export function closeWorker(child: ChildProcess): void {
+  if (child.connected && child.exitCode === null && child.signalCode === null) {
+    child.send({ type: 'close' } satisfies DaemonToWorker);
+  }
+}
+
+export function closeSocket(ws: WebSocket): void {
+  if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) ws.close();
+}
+
+function countOccurrences(text: string, needle: string): number {
+  let count = 0;
+  let offset = 0;
+  while (offset < text.length) {
+    const found = text.indexOf(needle, offset);
+    if (found === -1) return count;
+    count += 1;
+    offset = found + needle.length;
+  }
+  return count;
+}
+
+export function readTextIfPresent(path: string): string {
+  return existsSync(path) ? readFileSync(path, 'utf8') : '';
+}
+
+export async function waitForStableOccurrenceCount(
+  path: string,
+  needle: string,
+  overrides: Partial<StableCountOptions> = {},
+): Promise<number> {
+  const options = { ...DEFAULT_STABLE_COUNT_OPTIONS, ...overrides };
+  const deadline = Date.now() + options.timeoutMs;
+  let lastCount = -1;
+  let stablePolls = 0;
+
+  while (Date.now() < deadline) {
+    const count = countOccurrences(readTextIfPresent(path), needle);
+    if (count === lastCount) {
+      stablePolls += 1;
+      if (count >= options.minimumCount && stablePolls >= options.stablePolls) return count;
+    } else {
+      lastCount = count;
+      stablePolls = 0;
+    }
+    await new Promise(resolvePromise => setTimeout(resolvePromise, options.pollMs));
+  }
+
+  return Math.max(lastCount, 0);
+}
+
+export function sendScroll(ws: WebSocket): void {
+  ws.send(JSON.stringify({ type: 'scroll', data: WHEEL_UP }));
+}

--- a/test/opencode-raw-passthrough.test.ts
+++ b/test/opencode-raw-passthrough.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
+import { createOpenCode2Adapter } from '../src/adapters/cli/opencode2.js';
 import { rawCommandWriteOptionsFor } from '../src/core/raw-command-write-options.js';
 import { writeRawCommandLine } from '../src/core/raw-command-writer.js';
 
@@ -52,5 +53,10 @@ describe('OpenCode raw slash command passthrough', () => {
       'delay:300',
       'sendSpecialKeys:Enter',
     ]);
+  });
+
+  it('declares read-only remote wheel scroll for OpenCode alternate-screen transcript panes', () => {
+    expect(createOpenCodeAdapter('/bin/opencode').readOnlyRemoteScroll).toBe(true);
+    expect(createOpenCode2Adapter('/bin/opencode2').readOnlyRemoteScroll).toBe(true);
   });
 });

--- a/test/web-terminal-scroll-rate-limit.test.ts
+++ b/test/web-terminal-scroll-rate-limit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { ReadOnlyRemoteScrollLimiter } from '../src/utils/web-terminal-scroll.js';
+import type { ReadOnlyRemoteScrollPayload } from '../src/utils/web-terminal-scroll.js';
+
+const WINDOW_MS = 1_000;
+
+function payload(direction: ReadOnlyRemoteScrollPayload['direction'], eventCount: number): ReadOnlyRemoteScrollPayload {
+  return { direction, eventCount };
+}
+
+describe('ReadOnlyRemoteScrollLimiter', () => {
+  it('allows up to the configured budget of events within one window', () => {
+    let now = 0;
+    const limiter = new ReadOnlyRemoteScrollLimiter({ budget: 3, windowMs: WINDOW_MS }, () => now);
+
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(true);
+  });
+
+  it('denies events that would exceed the budget within one window', () => {
+    let now = 0;
+    const limiter = new ReadOnlyRemoteScrollLimiter({ budget: 3, windowMs: WINDOW_MS }, () => now);
+
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(false);
+    expect(limiter.tryConsume(2)).toBe(false);
+  });
+
+  it('drops a single over-budget payload without consuming the window budget', () => {
+    let now = 0;
+    const limiter = new ReadOnlyRemoteScrollLimiter({ budget: 2, windowMs: WINDOW_MS }, () => now);
+
+    expect(limiter.tryConsume(6)).toBe(false);
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(false);
+  });
+
+  it('shares one budget across multiple callers of the same limiter instance', () => {
+    let now = 0;
+    const limiter = new ReadOnlyRemoteScrollLimiter({ budget: 2, windowMs: WINDOW_MS }, () => now);
+
+    const callerA: boolean[] = [];
+    const callerB: boolean[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      callerA.push(limiter.tryConsume(1));
+      callerB.push(limiter.tryConsume(1));
+    }
+
+    const allowedCount = [...callerA, ...callerB].filter(allowed => allowed).length;
+    expect(allowedCount).toBe(2);
+    expect(callerA[0]).toBe(true);
+    expect(callerB[0]).toBe(true);
+    expect(callerA[1]).toBe(false);
+    expect(callerB[1]).toBe(false);
+  });
+
+  it('reopens the budget when a later window begins', () => {
+    let now = 0;
+    const limiter = new ReadOnlyRemoteScrollLimiter({ budget: 2, windowMs: WINDOW_MS }, () => now);
+
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(false);
+
+    now = WINDOW_MS - 1;
+    expect(limiter.tryConsume(1)).toBe(false);
+
+    now = WINDOW_MS;
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(true);
+    expect(limiter.tryConsume(1)).toBe(false);
+  });
+
+  it('shares the budget across directions so mixed scroll cannot bypass the limit', () => {
+    let now = 0;
+    const limiter = new ReadOnlyRemoteScrollLimiter({ budget: 2, windowMs: WINDOW_MS }, () => now);
+
+    const bursts: readonly ReadOnlyRemoteScrollPayload[] = [
+      payload('up', 1),
+      payload('down', 1),
+      payload('up', 1),
+      payload('down', 1),
+    ];
+
+    const allowed: ReadOnlyRemoteScrollPayload[] = [];
+    for (const burst of bursts) {
+      if (limiter.tryConsume(burst.eventCount)) allowed.push(burst);
+    }
+
+    expect(allowed).toEqual([bursts[0], bursts[1]]);
+  });
+
+  it('works with the default wall-clock nowMs when no clock is injected', () => {
+    const limiter = new ReadOnlyRemoteScrollLimiter({ budget: 1, windowMs: WINDOW_MS });
+
+    expect(limiter.tryConsume(1)).toBe(true);
+  });
+
+  it('rejects non-positive budget or window configuration', () => {
+    expect(() => new ReadOnlyRemoteScrollLimiter({ budget: 0, windowMs: WINDOW_MS })).toThrow();
+    expect(() => new ReadOnlyRemoteScrollLimiter({ budget: 1, windowMs: 0 })).toThrow();
+  });
+});

--- a/test/web-terminal-scroll.test.ts
+++ b/test/web-terminal-scroll.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseReadOnlyRemoteScrollPayload } from '../src/utils/web-terminal-scroll.js';
+
+describe('read-only web terminal remote scroll payloads', () => {
+  it('parses one SGR wheel-up event', () => {
+    expect(parseReadOnlyRemoteScrollPayload('\x1b[<64;12;8M')).toEqual({
+      direction: 'up',
+      eventCount: 1,
+    });
+  });
+
+  it('parses a capped same-direction wheel burst', () => {
+    const payload = '\x1b[<65;12;8M'.repeat(6);
+
+    expect(parseReadOnlyRemoteScrollPayload(payload)).toEqual({
+      direction: 'down',
+      eventCount: 6,
+    });
+  });
+
+  it('rejects unbounded or non-wheel payloads', () => {
+    expect(parseReadOnlyRemoteScrollPayload('\x1b[<64;12;8M'.repeat(7))).toBeNull();
+    expect(parseReadOnlyRemoteScrollPayload('\x1b[<64;12;8M\x1b[<65;12;8M')).toBeNull();
+    expect(parseReadOnlyRemoteScrollPayload('\x1b[<0;12;8M')).toBeNull();
+    expect(parseReadOnlyRemoteScrollPayload('x\x1b[<64;12;8M')).toBeNull();
+    expect(parseReadOnlyRemoteScrollPayload('\x1b[<64;12;8Mx')).toBeNull();
+    expect(parseReadOnlyRemoteScrollPayload('\x1b[<64;0;8M')).toBeNull();
+    expect(parseReadOnlyRemoteScrollPayload('\x1b[<64;10000;8M')).toBeNull();
+  });
+});

--- a/test/web-terminal-touch-scroll.test.ts
+++ b/test/web-terminal-touch-scroll.test.ts
@@ -66,7 +66,7 @@ describe('web terminal touch scrolling', () => {
       + "        || effectiveBackendType === 'zellij';",
     );
     expect(workerSource).toContain(
-      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend)',
+      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend, allowReadOnlyRemoteScroll)',
     );
     expect(workerSource).toContain('var localTerminalBackend=${localTerminalBackend};');
     // Guard the exclusion explicitly: neither Herdr nor Riff may appear in the gate.
@@ -145,6 +145,35 @@ describe('web terminal touch scrolling', () => {
     expect(wheelBlock).toContain('return px>0||b.viewportY>0');
     expect(wheelBlock).toContain('if(_canScrollLocal(px)){');
     expect(touchBlock).toContain('if(_canScrollLocal(px)){');
+  });
+
+  it('allows declared read-only remote wheel scroll without opening general input', () => {
+    const wheelBlock = scriptBlock('// ── Wheel / touch scroll handling ──');
+
+    expect(workerSource).toContain('function canHandleReadOnlyRemoteScroll(): boolean {');
+    expect(workerSource).toContain('const allowReadOnlyRemoteScroll = canHandleReadOnlyRemoteScroll();');
+    expect(workerSource).toContain('var readOnlyRemoteScroll=${allowReadOnlyRemoteScroll};');
+    expect(workerSource).toContain("} else if (msg.type === 'scroll' && typeof msg.data === 'string') {");
+    expect(workerSource).toContain('if (!allowReadOnlyRemoteScroll || authedClients.has(ws)) return;');
+    expect(workerSource).toContain('const parsed = parseReadOnlyRemoteScrollPayload(msg.data);');
+    expect(workerSource).toContain('if (usesHerdrSnapshotWebHistory()) herdrWebScrollDirection = parsed.direction;');
+    expect(wheelBlock).toContain("ws_.send(JSON.stringify({type:hasToken?'input':'scroll',data:data}))");
+    expect(wheelBlock).toContain(
+      'if(!hasToken){\n'
+      + '      e.preventDefault();e.stopPropagation();\n'
+      + '      if(readOnlyRemoteScroll)_fwdScroll(px,_cellAt(e.clientX,e.clientY));\n'
+      + '      else term.scrollLines(e.deltaY>0?3:-3);return;\n'
+      + '    }',
+    );
+  });
+
+  it('does not advertise read-only remote scroll for zellij per-client attach', () => {
+    const helperStart = workerSource.indexOf('function canHandleReadOnlyRemoteScroll(): boolean {');
+    const helperEnd = workerSource.indexOf('\n}\n\nfunction wireHerdrWebTerminalRelays', helperStart) + 2;
+    const helperBlock = workerSource.slice(helperStart, helperEnd);
+
+    expect(helperBlock).toContain("cliAdapter?.readOnlyRemoteScroll === true");
+    expect(helperBlock).toContain("!(lastInitConfig?.adoptMode && lastInitConfig.adoptZellijPaneId)");
   });
 
   it('replaces merged Herdr history and preserves the reader anchor', () => {

--- a/test/worker-terminal-readonly-scroll.integration.test.ts
+++ b/test/worker-terminal-readonly-scroll.integration.test.ts
@@ -1,0 +1,87 @@
+import { writeFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  closeSocket,
+  closeWorker,
+  FORGED_INPUT,
+  FORGED_INPUT_HEX,
+  openViewSocket,
+  READ_ONLY_SCROLL_SESSION_BUDGET,
+  readTextIfPresent,
+  sendScroll,
+  startOpenCodeWorker,
+  waitForStableOccurrenceCount,
+  WHEEL_UP,
+  WHEEL_UP_HEX,
+} from './helpers/worker-terminal-scroll-harness.js';
+
+describe('worker read-only terminal remote scroll', () => {
+  it('forwards one legal read-only scroll frame for an OpenCode opt-in view socket', async () => {
+    const harness = await startOpenCodeWorker('opencode');
+    const ws = await openViewSocket(harness);
+
+    writeFileSync(harness.inputLog, '');
+    sendScroll(ws);
+
+    const count = await waitForStableOccurrenceCount(harness.inputLog, WHEEL_UP_HEX, { minimumCount: 1 });
+    expect(count).toBe(1);
+
+    closeSocket(ws);
+    closeWorker(harness.child);
+  }, 25_000);
+
+  it('bounds repeated read-only scroll frames from one view socket by the session budget', async () => {
+    const harness = await startOpenCodeWorker('opencode');
+    const ws = await openViewSocket(harness);
+
+    writeFileSync(harness.inputLog, '');
+    for (let i = 0; i < READ_ONLY_SCROLL_SESSION_BUDGET + 8; i += 1) sendScroll(ws);
+
+    const count = await waitForStableOccurrenceCount(harness.inputLog, WHEEL_UP_HEX, {
+      minimumCount: READ_ONLY_SCROLL_SESSION_BUDGET,
+    });
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThanOrEqual(READ_ONLY_SCROLL_SESSION_BUDGET);
+
+    closeSocket(ws);
+    closeWorker(harness.child);
+  }, 25_000);
+
+  it('shares the read-only scroll budget across multiple view sockets in one session', async () => {
+    const harness = await startOpenCodeWorker('opencode');
+    const firstWs = await openViewSocket(harness);
+    const secondWs = await openViewSocket(harness);
+
+    writeFileSync(harness.inputLog, '');
+    for (let i = 0; i < READ_ONLY_SCROLL_SESSION_BUDGET + 4; i += 1) {
+      sendScroll(firstWs);
+      sendScroll(secondWs);
+    }
+
+    const count = await waitForStableOccurrenceCount(harness.inputLog, WHEEL_UP_HEX, {
+      minimumCount: READ_ONLY_SCROLL_SESSION_BUDGET,
+    });
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThanOrEqual(READ_ONLY_SCROLL_SESSION_BUDGET);
+
+    closeSocket(firstWs);
+    closeSocket(secondWs);
+    closeWorker(harness.child);
+  }, 25_000);
+
+  it('keeps rejecting forged read-only input frames on a view socket', async () => {
+    const harness = await startOpenCodeWorker('opencode');
+    const ws = await openViewSocket(harness);
+
+    writeFileSync(harness.inputLog, '');
+    ws.send(JSON.stringify({ type: 'input', data: WHEEL_UP }));
+    ws.send(JSON.stringify({ type: 'input', data: FORGED_INPUT }));
+
+    const scrollCount = await waitForStableOccurrenceCount(harness.inputLog, WHEEL_UP_HEX);
+    expect(scrollCount).toBe(0);
+    expect(readTextIfPresent(harness.inputLog)).not.toContain(FORGED_INPUT_HEX);
+
+    closeSocket(ws);
+    closeWorker(harness.child);
+  }, 25_000);
+});


### PR DESCRIPTION
## 改动说明



- 为 OpenCode / OpenCode2 声明只读 Web Terminal 远端滚轮能力；其它 CLI 保持原行为。

- 只读端滚轮/触摸滚动改走专用 `scroll` 消息，不复用写权限 `input` 通道。

- 服务端新增只读滚轮载荷校验：只允许完整、连续、同方向、坐标合法、最多 6 个 SGR wheel 事件；非法包直接丢弃。

- 在服务端 `scroll` 分支接入会话级 `ReadOnlyRemoteScrollLimiter`：每个会话每秒最多放行 12 个只读滚轮事件，超额直接丢弃、不排队；额度跨多个 view-link WebSocket 共享。

- Herdr 只在限流放行并即将写入后端时同步滚动方向，避免被丢弃事件影响下一次历史合并；zellij adopt 继续不暴露未处理的只读远端滚动能力。

- 根目录 `.gitignore` 忽略 `.omo/` 计划/证据产物，避免误提交。



## 为什么这样改



只读 view link 原本承诺不产生终端输入。第一批改动用严格白名单只放开“滚轮”这一个受限动作，避免点击/拖拽/命令字节进入后端；复审发现仅校验 payload 不限制频率时，view-link 持有者仍可高速发送合法滚轮包，反复触发 tmux-pipe / Herdr 的同步后端写入，拖慢或卡死当前 worker。因此第二批补上服务端、会话级限流，避免 per-WebSocket 限流被多开标签页绕过。



## 影响范围



- 影响 Web Terminal 的只读远端滚轮路径，仅 OpenCode / OpenCode2 opt-in。

- 写权限终端仍走原有 `input` 消息，不受只读 `scroll` 限流影响。

- 只读 `input` 仍被拒绝；只读 `scroll` 只有通过服务端校验与会话预算后才写入后端。

- 其它未 opt-in CLI、tmux/zellij attach input、token derivation、adapter 选择逻辑保持原行为。



## 测试验证



- RED 证据：新增真实 Worker WebSocket 测试在实现限流前失败：单连接洪泛写入 20 个合法滚轮事件、双连接合计写入 32 个，均超过会话预算 12。

- Targeted tests：`pnpm vitest run test/worker-terminal-read-auth.integration.test.ts test/worker-terminal-readonly-scroll.integration.test.ts test/web-terminal-scroll.test.ts test/web-terminal-scroll-rate-limit.test.ts test/web-terminal-touch-scroll.test.ts`，5 files / 28 tests passed。

- Typecheck：`tsc --noEmit --pretty false`，No errors found。

- Build：`pnpm build`，exit 0；domain audit clean，dashboard bundle 成功，build audit 通过。
