### PR TITLE
fix(lark): 替身触发按消息类型收口，转发卡片不再误触发

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1278,12 +1278,21 @@ function substituteTargetMatchesMention(target: {
   );
 }
 
+// 替身触发只认「发送者本人当场亲手 @」的消息类型：text（纯文本）/ post（富文本）。
+// 转发一张卡片（interactive）或合并转发（merge_forward）时，飞书会把被转发内容
+// 里原本的接收人 / at-node 继承进这条消息的顶层 mentions —— 那不是发送者真的
+// @ 了替身对象（用户实测：卡片里灰色的「发送给:@某某」被当成了真 @，凭空触发替身
+// 在话题外回复）。这类消息一律不触发替身，避免转发误触发。
+const SUBSTITUTE_TRIGGER_MESSAGE_TYPES = new Set(['text', 'post']);
+
 export function resolveSubstituteTrigger(
   larkAppId: string,
   message: any,
 ): import('../../types.js').SubstituteTrigger | undefined {
   const cfg = getBot(larkAppId).config.substituteMode;
   if (!cfg?.enabled || !cfg.targets?.length) return undefined;
+  const messageType = message?.message_type ?? message?.msg_type;
+  if (!SUBSTITUTE_TRIGGER_MESSAGE_TYPES.has(messageType)) return undefined;
   const mentions = extractMentionIdentities(message);
   for (const mention of mentions) {
     const target = cfg.targets.find(t => substituteTargetMatchesMention(t, mention));

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -932,6 +932,10 @@ function makeUserMessageEvent(opts: {
   chatType?: string;
   messageId?: string;
   mentions?: TestMention[];
+  /** Lark message_type. Defaults to 'text' — the substitute trigger only fires
+   *  on hand-typed text/post, so tests exercising a trigger must carry a real
+   *  type (real WS events always do; the field is only optional here). */
+  messageType?: string;
 }) {
   const threadId = opts.threadId === null
     ? undefined
@@ -943,6 +947,7 @@ function makeUserMessageEvent(opts: {
       thread_id: threadId,
       chat_id: opts.chatId ?? 'chat-001',
       chat_type: opts.chatType ?? 'group',
+      message_type: opts.messageType ?? 'text',
       content: opts.content,
       mentions: opts.mentions,
     },
@@ -3546,6 +3551,75 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
   });
 
+  // Regression for the msg-type gate: a forwarded interactive card / merge_forward
+  // inherits the forwarded content's original recipients into the event's top-level
+  // mentions. Those are NOT a hand-typed @ by the sender, so they must never trigger
+  // the substitute. Only text/post (typed by the sender in the composer) may.
+  for (const badType of ['interactive', 'merge_forward', 'file', 'image']) {
+    it(`substituteMode: ${badType} carrying an inherited @substitute in top-level mentions does NOT trigger`, async () => {
+      setupBotState({
+        allowedUsers: [USER_OPEN_ID],
+        regularGroupReplyMode: 'new-topic',
+        substituteMode: {
+          enabled: true,
+          targets: [{ userId: 'u_sub', name: 'Sub Person' }],
+          disclosure: 'prefix',
+        },
+      });
+      mockGetChatMode.mockResolvedValue('group');
+      handlers.isSessionOwner.mockReturnValue(false);
+      const event = makeUserMessageEvent({
+        senderOpenId: USER_OPEN_ID,
+        content: JSON.stringify({ text: '发送给:@Sub Person' }),
+        messageId: `msg-substitute-${badType}`,
+        chatId: 'chat-substitute',
+        chatType: 'group',
+        messageType: badType,
+        // Same mention shape a genuine text @ would carry — proving the gate keys
+        // off message_type, not off whether the mention "looks" real.
+        mentions: [{ key: '@_sub', name: 'Sub Person', id: { user_id: 'u_sub' } }],
+      });
+
+      await capturedHandlers['im.message.receive_v1'](event);
+      await flushEventWork();
+
+      expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+      expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    });
+  }
+
+  it('substituteMode: a message with no message_type does NOT trigger (fail-closed contract)', async () => {
+    setupBotState({
+      allowedUsers: [USER_OPEN_ID],
+      regularGroupReplyMode: 'new-topic',
+      substituteMode: {
+        enabled: true,
+        targets: [{ userId: 'u_sub', name: 'Sub Person' }],
+        disclosure: 'prefix',
+      },
+    });
+    mockGetChatMode.mockResolvedValue('group');
+    handlers.isSessionOwner.mockReturnValue(false);
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '@Sub Person help with this' }),
+      messageId: 'msg-substitute-notype',
+      chatId: 'chat-substitute',
+      chatType: 'group',
+      mentions: [{ key: '@_sub', name: 'Sub Person', id: { user_id: 'u_sub' } }],
+    });
+    // Model an event that reached the resolver without a resolved type: neither
+    // WS (always sets message_type) nor the polled path (coalesces msg_type)
+    // should do this, so the gate must fail closed rather than trigger.
+    delete (event.message as any).message_type;
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+
   it('substituteMode: top-level @substitute carries replyRootId=messageId so each trigger has its own reply anchor', async () => {
     // Regression: without replyRootId, multiple substitute triggers in the same
     // chat-scope session share/clear the currentReplyTarget, causing replies to
@@ -3714,6 +3788,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
       messageId: 'msg-substitute-post',
       chatId: 'chat-substitute-post',
       chatType: 'group',
+      messageType: 'post',
     });
 
     await capturedHandlers['im.message.receive_v1'](event);


### PR DESCRIPTION
## 问题

替身模式（substituteMode）下，转发一张 botmux 卡片（如 DONE 卡片，正文里写着「发送给:@某某 @某某」）到群里，机器人会凭空在话题外触发替身回复——即使没有任何人真的蓝色 @ 替身对象。

## 根因

`resolveSubstituteTrigger` 只判断消息**顶层 mentions** 是否命中替身对象。但飞书在转发 `interactive`（卡片）/ `merge_forward`（合并转发）消息时，会把**被转发内容里原本的接收人 / at-node**（包括卡片正文里灰色的、非真 @ 的「发送给:@某某」）继承进这条消息的顶层 mentions 字段。于是「转发一张里面写着替身对象名字的卡片」被误判成「有人真的 @ 了替身对象」。

用真实线上消息核对确认：
- `msg_type=text` 且 content 里有蓝色 @ → mentions 命中，是真实 @（应触发）
- `msg_type=interactive` 转发卡片 → mentions 里带了卡片原接收人（误触发）

## 修复

替身触发加一道消息类型白名单：只认发送者本人当场亲手 @ 的 `text`（纯文本）/ `post`（富文本）消息；`interactive` / `merge_forward` 这类 mentions 从被转发内容继承而来的消息一律不触发。

## 影响面

改动仅在 `im/lark/event-dispatcher.ts` 的 `resolveSubstituteTrigger` 内新增一道消息类型判断，属飞书事件路由层，不涉及跨 CLI / 跨后端 / 跨平台逻辑。替身功能默认关闭；开启时行为变化仅为「转发卡片/合并转发不再误触发」，真实文本/富文本 @ 触发路径不变。

## 验证

用真实 bot 配置模拟各消息类型：

| 消息类型 | mentions 命中替身 | 结果 |
|---|---|---|
| text 真实@ | 是 | TRIGGER |
| post 富文本@ | 是 | TRIGGER |
| interactive 转发卡片 | 是（继承） | skip |
| merge_forward 合并转发 | 是（继承） | skip |

`pnpm build` 通过；substitute 相关单测 48 项全绿（bot-routing / substitute-mode-store / substitute-chat-toggle-store）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
