### PR TITLE
fix(riff-backend): 长任务误报「SSE 连接中断，重连失败」——消费 init 重放终态 + 重连预算按连接寿命判据

### DIFF
--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -349,6 +349,12 @@ interface RiffTaskResponse {
   };
 }
 
+/** Terminal riff task statuses (riff openApiDocs task contract). Once a task
+ *  reaches one of these it will emit no further progress — an `init` replay or
+ *  a `done` event carrying one of these IS the task's completion. Non-terminal:
+ *  pending / creating_session / running. */
+const TERMINAL_RIFF_STATUSES = new Set(['completed', 'failed', 'cancelled', 'timeout']);
+
 /**
  * RiffBackend — bridges botmux's SessionBackend interface to riff's HTTP API.
  *
@@ -387,11 +393,41 @@ export class RiffBackend implements SessionBackend {
    *  cleared past 64 entries (a session rarely exceeds a few dozen turns). */
   private completedTaskIds = new Set<string>();
   private reconnectAttempts = 0;
-  private maxReconnectAttempts = 3;
+  private maxReconnectAttempts = 6;
+  /** Wall-clock ms when the CURRENT SSE connection was established, or `null`
+   *  when none is open / the last fetch never connected. Typed `number | null`
+   *  (not a 0 sentinel) on purpose: 0 is both "not connected" AND a valid number
+   *  you could subtract, so a future edit dropping the guard would compute a
+   *  bogus multi-decade lifetime from `Date.now() - 0` and refund forever. `null`
+   *  makes "never connected" un-subtractable and forces the guard at the type
+   *  level. The reconnect budget is refunded only when a broken connection had
+   *  LIVED long enough to be a healthy long connection merely severed by the
+   *  upstream proxy's fixed ~183s lifetime cap — NOT merely because a connection
+   *  opened. Keying on "connection lived ≥ reconnectHealthyConnMs" (not on
+   *  receiving init, and not on any data event — both were falsified/
+   *  insufficient) is what separates the two cases that look identical from the
+   *  client:
+   *    • healthy cap:   connection lives ~183s, EOFs → refund → task streams on
+   *    • dead/hot-loop: connection opens then EOFs within ~1s, repeatedly →
+   *      NO refund → budget exhausts and bails. Covers BOTH a fetch that never
+   *      connects (stays null) AND a "connect→init→instant-EOF" loop against a
+   *      stale-running orphan (lives <threshold) — the latter is exactly the
+   *      infinite-retry hole a naive "reset on connect/init" would reopen. */
+  private connectionStartedAtMs: number | null = null;
   /** 预算层级（单调覆盖，见 destroySession 注释）；字段化以便测试注入边界。 */
   private cancelTimeoutMs = 4_000;
   private createTimeoutMs = 10_000;
   private destroyDeadlineMs = 20_000;
+  /** SSE 重连退避基数（指数退避的第一档）；字段化以便测试把重连间隔压到 0。 */
+  private reconnectBaseDelayMs = 1_000;
+  private reconnectMaxDelayMs = 30_000;
+  /** A broken SSE connection that lived at least this long is treated as a
+   *  healthy long connection severed by the ~183s proxy cap → refund the
+   *  reconnect budget. Shorter-lived breaks (dead endpoint / instant-EOF hot
+   *  loop) do NOT refund. 30s: the cap is metronomic at ~181-183s (6× margin)
+   *  while pathological EOFs are sub-second, so the two separate cleanly.
+   *  Field-ized for test injection. */
+  private reconnectHealthyConnMs = 30_000;
   /** Exact late/current task whose close cancellation failed. Retained across
    * the prepare-close handshake so the daemon can persist a retry handle. */
   private closeFailureTaskId: string | null = null;
@@ -1236,16 +1272,27 @@ export class RiffBackend implements SessionBackend {
     if (jwt) headers['x-jwt-token'] = jwt;
 
     this.abortController = new AbortController();
+    // Per-connection lifetime clock (see field doc): null until this connection
+    // is confirmed established below. Reset PER streamTask invocation so a fetch
+    // that never connects can't inherit the previous connection's start time.
+    this.connectionStartedAtMs = null;
 
     try {
       const resp = await fetch(url, { headers, signal: this.abortController.signal });
       if (!resp.ok || !resp.body) {
         throw new Error(`SSE HTTP ${resp.status}`);
       }
+      // Connection established — start its lifetime clock. On break, catch
+      // compares elapsed against reconnectHealthyConnMs to decide whether this
+      // was a healthy ~183s-capped connection (refund budget) or a short-lived
+      // dead/hot-loop break (do not refund).
+      this.connectionStartedAtMs = Date.now();
 
-      // NOTE: reconnectAttempts is reset per TASK (createTask/followUp), not
-      // here — resetting on every 200 would let a "connect OK → immediate
-      // clean EOF" loop retry forever.
+      // NOTE: reconnectAttempts is reset per TASK (createTask/followUp) AND
+      // whenever a broken connection had LIVED ≥ reconnectHealthyConnMs (see the
+      // catch) — NOT unconditionally on every 200, which would let a "connect OK
+      // → instant EOF" loop retry forever (the hole the per-task-only reset
+      // originally guarded, which a naive "reset on connect/init" reopens).
       const reader = resp.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
@@ -1288,10 +1335,29 @@ export class RiffBackend implements SessionBackend {
       if (taskId !== this.currentTaskId || this.completedTaskIds.has(taskId)) return;
       logger.warn(`[riff] SSE stream error: ${err}`);
 
+      // Core fix: an upstream proxy caps each task-stream connection at a fixed
+      // ~183s lifetime and closes it with a clean EOF (no done event) — verified
+      // against live data: tasks that "重连失败" had actually COMPLETED server-
+      // side; botmux gave up ~22s early on one, 16min early on another. A healthy
+      // long runner task thus breaks every ~183s. If this just-broken connection
+      // had LIVED long enough (≥ reconnectHealthyConnMs), it was such a healthy
+      // capped connection — refund the reconnect budget so those periodic caps
+      // never accumulate into a false failure, letting the task stream until it
+      // truly finishes. A short-lived break (dead endpoint that never connected,
+      // or a connect→instant-EOF hot loop against a stale-running orphan) does
+      // NOT refund, so it still exhausts the budget and bails (no infinite
+      // retry). Keyed on connection LIFETIME — not on connect/init receipt,
+      // which would refund every attempt and reopen the infinite-retry hole.
+      const connLivedMs = this.connectionStartedAtMs !== null ? Date.now() - this.connectionStartedAtMs : 0;
+      if (connLivedMs >= this.reconnectHealthyConnMs) this.reconnectAttempts = 0;
+
       // Attempt reconnect if task is still running
       if (!this.killed && !this.taskDone && this.reconnectAttempts < this.maxReconnectAttempts) {
         this.reconnectAttempts++;
-        const delay = 1000 * this.reconnectAttempts;
+        // Exponential backoff with a cap: 1s,2s,4s,8s,16s,30s(cap). Linear 1s/2s/3s
+        // was negligible against a ~180s connection lifetime anyway; the cap keeps
+        // a truly-unreachable gateway from stalling teardown for minutes.
+        const delay = Math.min(this.reconnectMaxDelayMs, this.reconnectBaseDelayMs * 2 ** (this.reconnectAttempts - 1));
         logger.info(`[riff] SSE reconnect attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts} in ${delay}ms`);
         this.emitLine(`[riff] 连接中断，正在重连 (${this.reconnectAttempts}/${this.maxReconnectAttempts})`, 'warn');
         await new Promise((r) => setTimeout(r, delay));
@@ -1302,6 +1368,47 @@ export class RiffBackend implements SessionBackend {
       } else if (!this.killed && !this.taskDone) {
         this.emitError(`SSE 连接中断，重连失败`);
       }
+    }
+  }
+
+  /**
+   * Fire a task's completion exactly once — the turn boundary + final-output
+   * fetch. Called from BOTH the `done` SSE event AND an `init` replay carrying a
+   * terminal status (the task finished while a prior connection was dead and its
+   * `done` was lost with the closed stream). Idempotency & staleness — per TASK,
+   * not per backend: streams can deliver done more than once (observed ~500ms
+   * apart live), and by the time a duplicate (or a reconnect's init replay)
+   * arrives, a queued follow-up may already be running as the NEXT task (write()
+   * reset the global taskDone). A plain boolean guard would re-fire the boundary
+   * mid-way through that next task and falsely mark it done, so gate on:
+   *   1) the completion must belong to the CURRENT task (stale streams no-op)
+   *   2) each task fires the boundary at most once (completedTaskIds)
+   */
+  private completeTask(taskId: string, status: string | undefined, exitCode: number | undefined): void {
+    if (taskId !== this.currentTaskId) return;
+    if (this.completedTaskIds.has(taskId)) return;
+    this.completedTaskIds.add(taskId);
+    // Bounded FIFO eviction — never a blanket clear(), which would drop the id
+    // just added and let its ~500ms duplicate done re-fire.
+    while (this.completedTaskIds.size > 64) {
+      const oldest = this.completedTaskIds.values().next().value!;
+      if (oldest === taskId) break;
+      this.completedTaskIds.delete(oldest);
+    }
+    this.taskDone = true;
+    if (this.config.injectStatusLines !== false) {
+      this.emitLine(`[riff] 任务完成${status ? ` (${status}${exitCode != null ? `, exit=${exitCode}` : ''})` : ''}`, status === 'failed' ? 'warn' : 'ok');
+    }
+    // Fetch final output from task-detail API (SSE has no output events for
+    // runner tasks) BEFORE firing the turn boundary: the boundary flushes queued
+    // follow-ups → currentTaskId flips to the next task → the stale guard would
+    // (correctly) drop THIS task's only report.
+    if (status === 'completed' || status === 'failed') {
+      void this.fetchAndEmitOutput(taskId)
+        .catch(() => { /* logged inside */ })
+        .finally(() => { this.taskDoneCb?.(); });
+    } else {
+      this.taskDoneCb?.();
     }
   }
 
@@ -1362,44 +1469,27 @@ export class RiffBackend implements SessionBackend {
           if (changed && !this.accessUrlIsDirect) {
             void this.fetchDirectAccessUrl(taskId);
           }
+          // init REPLAYS the full accumulated task state, including a terminal
+          // `status` when the task finished while our previous connection was
+          // dead (the ~183s cap closes mid-flight and the `done` event is lost
+          // with it). Consume that replay: a terminal status here IS the missed
+          // completion — route it through the same completion path so the turn
+          // ends cleanly instead of the budget eventually exhausting into a
+          // false "重连失败". Non-terminal (running/pending/…) just means the
+          // reconnect resumed a still-live task — no completion, keep streaming.
+          if (eventType === 'init') {
+            const initStatus = data['status'] as string | undefined;
+            if (initStatus && TERMINAL_RIFF_STATUSES.has(initStatus)) {
+              const exitCode = data['exitCode'] as number | undefined;
+              this.completeTask(taskId, initStatus, exitCode);
+            }
+          }
           break;
         }
         case 'done': {
-          // Idempotency & staleness — per TASK, not per backend: streams can
-          // deliver done more than once (observed ~500ms apart live), and by
-          // the time the duplicate arrives a queued follow-up may already be
-          // running as the NEXT task (write() reset the global taskDone). A
-          // plain boolean guard would re-fire the turn-boundary callback mid-
-          // way through that next task and falsely mark it done, so gate on:
-          //   1) the done must belong to the CURRENT task (stale streams no-op)
-          //   2) each task fires the boundary at most once (completedTaskIds)
-          if (taskId !== this.currentTaskId) break;
-          if (this.completedTaskIds.has(taskId)) break;
-          this.completedTaskIds.add(taskId);
-          // Bounded FIFO eviction — never a blanket clear(), which would drop
-          // the id just added and let its ~500ms duplicate done re-fire.
-          while (this.completedTaskIds.size > 64) {
-            const oldest = this.completedTaskIds.values().next().value!;
-            if (oldest === taskId) break;
-            this.completedTaskIds.delete(oldest);
-          }
-          this.taskDone = true;
           const status = data['status'] as string | undefined;
           const exitCode = data['exitCode'] as number | undefined;
-          if (this.config.injectStatusLines !== false) {
-            this.emitLine(`[riff] 任务完成${status ? ` (${status}${exitCode != null ? `, exit=${exitCode}` : ''})` : ''}`, status === 'failed' ? 'warn' : 'ok');
-          }
-          // Fetch final output from task-detail API (SSE has no output events
-          // for runner tasks) BEFORE firing the turn boundary: the boundary
-          // flushes queued follow-ups → currentTaskId flips to the next task →
-          // the stale guard would (correctly) drop THIS task's only report.
-          if (status === 'completed' || status === 'failed') {
-            void this.fetchAndEmitOutput(taskId)
-              .catch(() => { /* logged inside */ })
-              .finally(() => { this.taskDoneCb?.(); });
-          } else {
-            this.taskDoneCb?.();
-          }
+          this.completeTask(taskId, status, exitCode);
           // NOTE: task done does NOT trigger onExit — session stays alive
           // for follow-up messages. Only /close or unrecoverable errors exit.
           break;

--- a/test/riff-backend.test.ts
+++ b/test/riff-backend.test.ts
@@ -361,6 +361,254 @@ describe('RiffBackend', () => {
     });
   });
 
+  describe('SSE reconnect budget refund keyed on connection lifetime (~183s connection cap)', () => {
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    // These tests intentionally leave reconnect loops in flight (pending/looping
+    // streams). Track every backend and kill() it after each test so a leaked
+    // loop can't keep incrementing the NEXT test's shared fetchMock counter
+    // (kill sets `killed`, which makes the streamTask catch bail).
+    let liveBackends: RiffBackend[] = [];
+    const track = (be: RiffBackend) => { liveBackends.push(be); return be; };
+    afterEach(() => { liveBackends.forEach(b => b.kill()); liveBackends = []; });
+    // Healthy long connection: emits init(running), STAYS OPEN past the health
+    // threshold, then cleanly EOFs — models a task-stream connection severed by
+    // the ~183s proxy cap. The delay before close is what makes it "healthy".
+    const healthyThenEof = (openMs: number, status = 'running') =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          async start(c) {
+            c.enqueue(new TextEncoder().encode(`event:init\ndata:{"status":"${status}"}\n\n`));
+            await sleep(openMs);
+            c.close();
+          },
+        }),
+        { status: 200 },
+      );
+    // Pathological: connects, emits init(running), then EOFs INSTANTLY (sub-
+    // threshold lifetime) — the stale-running-orphan hot loop. Must NOT refund.
+    const initThenInstantEof = () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(c) {
+            c.enqueue(new TextEncoder().encode('event:init\ndata:{"status":"running"}\n\n'));
+            c.close();
+          },
+        }),
+        { status: 200 },
+      );
+    // Dead endpoint: connects 200 then EOFs immediately with nothing.
+    const bareEof = () =>
+      new Response(new ReadableStream<Uint8Array>({ start(c) { c.close(); } }), { status: 200 });
+    // init replaying a TERMINAL status (task finished while a prior connection
+    // was dead — its `done` was lost with the closed stream).
+    const initTerminalThenEof = (status = 'completed') =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(c) {
+            c.enqueue(new TextEncoder().encode(`event:init\ndata:{"status":"${status}"}\n\n`));
+            c.close();
+          },
+        }),
+        { status: 200 },
+      );
+
+    it('a connection that lived past the health threshold refunds the budget → many ~183s caps never falsely fail', async () => {
+      const be = track(makeBackend({ injectStatusLines: false }));
+      (be as any).reconnectBaseDelayMs = 0; // collapse backoff for a fast test
+      (be as any).reconnectMaxDelayMs = 0;
+      (be as any).reconnectHealthyConnMs = 15; // healthy = lived ≥15ms (test scale)
+      const done = vi.fn();
+      const errored = vi.fn();
+      be.onTaskDone(done);
+      be.onData((d: string) => { if (d.includes('重连失败')) errored(); });
+
+      // 12 consecutive healthy caps — WAY past the 6-attempt budget. If a
+      // healthy-lived break did not refund, this would emitError long before 12.
+      let streamHits = 0;
+      fetchMock.mockImplementation(async (url: string | URL) => {
+        const u = String(url);
+        calls.push({ url: u });
+        if (u.includes('/api2/task-stream')) {
+          streamHits++;
+          return streamHits <= 12 ? healthyThenEof(80) : pendingSseResponse();
+        }
+        if (u.includes('/api/task-detail')) return Response.json({ success: true, data: { task: {} } });
+        return taskResponse('task-1');
+      });
+      be.spawn('', [], {} as any);
+      be.write('long runner task');
+      // Real time must elapse for the 80ms-open connections — poll on progress.
+      for (let i = 0; i < 400 && streamHits <= 8; i++) await sleep(10);
+      for (let i = 0; i < 20; i++) await flush();
+
+      expect(streamHits).toBeGreaterThan(6);       // survived past the raw budget
+      expect(errored).not.toHaveBeenCalled();       // never surfaced 重连失败
+      expect(done).not.toHaveBeenCalled();          // still running
+      // Healthy break refunds to 0 then increments to 1 — settles at 1, never
+      // accumulates toward 6 however many caps occur. That is the fix.
+      expect((be as any).reconnectAttempts).toBeLessThanOrEqual(1);
+    });
+
+    it('a stale-running-orphan hot loop (init then INSTANT EOF, sub-threshold) exhausts the budget — the reopened-infinite-retry-hole guard', async () => {
+      const be = track(makeBackend({ injectStatusLines: false }));
+      (be as any).reconnectBaseDelayMs = 0;
+      (be as any).reconnectMaxDelayMs = 0;
+      (be as any).reconnectHealthyConnMs = 10_000; // instant EOF (few ms) << 10s → never refunds
+      const done = vi.fn();
+      const errored = vi.fn();
+      be.onTaskDone(done);
+      be.onData((d: string) => { if (d.includes('重连失败')) errored(); });
+
+      // The critical regression case: task is running (init=running) so the
+      // terminal-status completion path never fires, but the connection EOFs
+      // instantly every time. Keying refund on init-receipt would loop forever;
+      // keying on lifetime lets the budget exhaust and bail.
+      let streamHits = 0;
+      fetchMock.mockImplementation(async (url: string | URL) => {
+        const u = String(url);
+        calls.push({ url: u });
+        if (u.includes('/api2/task-stream')) { streamHits++; return initThenInstantEof(); }
+        if (u.includes('/api/task-detail')) return Response.json({ success: true, data: { task: {} } });
+        return taskResponse('task-1');
+      });
+      be.spawn('', [], {} as any);
+      be.write('stale-running orphan');
+      for (let i = 0; i < 60; i++) await flush();
+
+      // 1 initial + 6 reconnects = 7, then bail. BOUNDED — no infinite hot loop.
+      expect(streamHits).toBe(7);
+      expect(errored).toHaveBeenCalledTimes(1);
+      expect(done).toHaveBeenCalledTimes(1); // emitError fires the turn boundary
+    });
+
+    it('a reconnect whose init replays a TERMINAL status completes the turn cleanly — no error (the false-positive being fixed)', async () => {
+      const be = track(makeBackend({ injectStatusLines: false }));
+      (be as any).reconnectBaseDelayMs = 0;
+      (be as any).reconnectMaxDelayMs = 0;
+      (be as any).reconnectHealthyConnMs = 20;
+      const done = vi.fn();
+      const errored = vi.fn();
+      be.onTaskDone(done);
+      be.onData((d: string) => { if (d.includes('重连失败')) errored(); });
+
+      // First connection: healthy-lived running then EOF (the ~183s cap).
+      // Reconnect: init replays completed (task finished during the dead window).
+      // Terminal completion must fire even though the reconnect's own connection
+      // is short-lived — completion does NOT depend on the lifetime gate.
+      let streamHits = 0;
+      fetchMock.mockImplementation(async (url: string | URL) => {
+        const u = String(url);
+        calls.push({ url: u });
+        if (u.includes('/api2/task-stream')) {
+          streamHits++;
+          return streamHits === 1 ? healthyThenEof(40) : initTerminalThenEof('completed');
+        }
+        if (u.includes('/api/task-detail')) return Response.json({ success: true, data: { task: { output: 'final result' } } });
+        return taskResponse('task-1');
+      });
+      be.spawn('', [], {} as any);
+      be.write('task that completes during the dead window');
+      for (let i = 0; i < 200 && streamHits < 2; i++) await sleep(10);
+      for (let i = 0; i < 20; i++) await flush();
+
+      expect(errored).not.toHaveBeenCalled();      // the whole point: no false 重连失败
+      expect(done).toHaveBeenCalledTimes(1);        // completion fired exactly once
+      expect((be as any).taskDone).toBe(true);
+    });
+
+    it('a dead endpoint (connect→instant EOF, sub-threshold) still exhausts the budget and fails — no infinite retry', async () => {
+      const be = track(makeBackend({ injectStatusLines: false }));
+      (be as any).reconnectBaseDelayMs = 0;
+      (be as any).reconnectMaxDelayMs = 0;
+      (be as any).reconnectHealthyConnMs = 10_000; // instant EOF (few ms) << 10s → never refunds
+      const done = vi.fn();
+      const errored = vi.fn();
+      be.onTaskDone(done);
+      be.onData((d: string) => { if (d.includes('重连失败')) errored(); });
+
+      let streamHits = 0;
+      fetchMock.mockImplementation(async (url: string | URL) => {
+        const u = String(url);
+        calls.push({ url: u });
+        if (u.includes('/api2/task-stream')) { streamHits++; return bareEof(); }
+        if (u.includes('/api/task-detail')) return Response.json({ success: true, data: { task: {} } });
+        return taskResponse('task-1');
+      });
+      be.spawn('', [], {} as any);
+      be.write('doomed task');
+      for (let i = 0; i < 40; i++) await flush();
+
+      // 1 initial + 6 reconnects = 7 stream attempts, then bail. Crucially BOUNDED.
+      expect(streamHits).toBe(7);
+      expect(errored).toHaveBeenCalledTimes(1);
+      expect(done).toHaveBeenCalledTimes(1); // emitError fires the turn boundary
+    });
+
+    // The connection-never-established path is DISTINCT from "connect then EOF":
+    // fetch throws / !resp.ok bail BEFORE connectionStartedAtMs is stamped, so it
+    // stays at its sentinel. The lifetime gate must treat "never stamped" as
+    // NOT-healthy (no refund), else a permanent 404 (task GC'd) or 401 (jwt dead)
+    // would compute a bogus huge lifetime, refund forever, and hot-loop a request
+    // storm with no idle backstop. These lock that path to bounded early-stop.
+    it('a permanent !resp.ok (404 task-gone / 401) never refunds → bounded early-stop, no request storm', async () => {
+      const be = track(makeBackend({ injectStatusLines: false }));
+      (be as any).reconnectBaseDelayMs = 0;
+      (be as any).reconnectMaxDelayMs = 0;
+      (be as any).reconnectHealthyConnMs = 10_000;
+      const done = vi.fn();
+      const errored = vi.fn();
+      be.onTaskDone(done);
+      be.onData((d: string) => { if (d.includes('重连失败')) errored(); });
+
+      let streamHits = 0;
+      fetchMock.mockImplementation(async (url: string | URL) => {
+        const u = String(url);
+        calls.push({ url: u });
+        // task-stream returns 404 → !resp.ok → throws before the connection is
+        // ever stamped (connectionStartedAtMs stays at its never-connected value).
+        if (u.includes('/api2/task-stream')) { streamHits++; return new Response('gone', { status: 404 }); }
+        if (u.includes('/api/task-detail')) return Response.json({ success: true, data: { task: {} } });
+        return taskResponse('task-1');
+      });
+      be.spawn('', [], {} as any);
+      be.write('task that was GC-ed');
+      for (let i = 0; i < 40; i++) await flush();
+
+      // Must be BOUNDED: 1 initial + 6 reconnects = 7, then emitError. A bogus
+      // "healthy lifetime" from an unstamped clock would loop unbounded here.
+      expect(streamHits).toBe(7);
+      expect(errored).toHaveBeenCalledTimes(1);
+      expect(done).toHaveBeenCalledTimes(1);
+    });
+
+    it('a fetch that throws (network error) before connecting never refunds → bounded early-stop', async () => {
+      const be = track(makeBackend({ injectStatusLines: false }));
+      (be as any).reconnectBaseDelayMs = 0;
+      (be as any).reconnectMaxDelayMs = 0;
+      (be as any).reconnectHealthyConnMs = 10_000;
+      const done = vi.fn();
+      const errored = vi.fn();
+      be.onTaskDone(done);
+      be.onData((d: string) => { if (d.includes('重连失败')) errored(); });
+
+      let streamHits = 0;
+      fetchMock.mockImplementation(async (url: string | URL) => {
+        const u = String(url);
+        calls.push({ url: u });
+        if (u.includes('/api2/task-stream')) { streamHits++; throw new Error('ECONNREFUSED'); }
+        if (u.includes('/api/task-detail')) return Response.json({ success: true, data: { task: {} } });
+        return taskResponse('task-1');
+      });
+      be.spawn('', [], {} as any);
+      be.write('unreachable endpoint');
+      for (let i = 0; i < 40; i++) await flush();
+
+      expect(streamHits).toBe(7);       // bounded — no infinite reconnect
+      expect(errored).toHaveBeenCalledTimes(1);
+      expect(done).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('restart lineage resume (finding D)', () => {
     it('resumeParentTaskId makes the first write a follow-up on the persisted parent', async () => {
       const be = makeBackend({ resumeParentTaskId: 'task-old', injectStatusLines: false });


### PR DESCRIPTION
## 问题

riff runner 长任务（运行超过 ~12 分钟）会被误报：

```
[riff] 错误：SSE 连接中断，重连失败
```

但任务实际在服务端**已成功完成**——这是假阳性：用户任务成功了，botmux 却告诉用户失败。据 live 数据核实，两个复现任务在客户端报错时服务端 status 均为 completed（一个在 botmux 放弃后 22 秒完成，另一个当时还要跑 16 分钟）。

## 根因（两层）

1. **上游代理对每条 `/api2/task-stream` SSE 连接有固定 ~183s 寿命上限**：到点用「干净 EOF（无 `done` 事件）」关流，与内容无关（实测断流间隔规整在 181/183s，是定时器而非抖动）。健康长任务因此每 ~183s 断一次。
2. **重连时 init 重放的终态被丢弃**：重连的第一帧 `init` 会重放完整累积状态（status/logEvents/output/resultOutput），但原 `init` 处理分支只读 `accessUrl`，丢弃了其中的终态 `status`。于是「任务在死连接窗口内完成、`done` 随死连接一起丢失」这种情况，完成信号被丢 → 重连预算最终耗尽 → 误报「重连失败」。

> 说明：runner 任务的最终输出走 `done` 时的 task-detail 拉取（SSE 对 runner 任务没有 output 事件），所以重连间隙不丢最终结果。

## 改动（`src/adapters/backend/riff-backend.ts`）

- **消费 init 重放的终态**：`init`/`session_info` 分支现在读 `status`，若为终态（`completed`/`failed`/`cancelled`/`timeout`，抽成 `TERMINAL_RIFF_STATUSES` 常量）→ 走完成路径。重连一上来即可凭 init 正常收尾，不再误报。
- **完成逻辑抽成 `completeTask()`**：`done` 事件与 init 终态两条入口复用同一份「`completedTaskIds` 去重 + `taskDone` + `fetchAndEmitOutput` + turn 边界」，保证恰好一次（`done` 的幂等 / staleness 语义原样保留，仅搬迁）。
- **重连预算判据改为「连接寿命」**：新增 `connectionStartedAtMs`（`number | null`，连接确认建立后 stamp），仅当断开的连接**存活 ≥ `reconnectHealthyConnMs`（30s）**才 reset 预算。
  - 健康 ~183s cap（存活 ≥30s）→ reset → 真运行任务可无限承受周期性 cap，撑到自己完成；
  - 秒级 EOF 热循环（stale-running 孤儿）/ 建连失败（4xx、网络异常，从未 stamp）→ 不 reset → 仍有界早停，**不无限重连**；
  - 判据不解析 init 内容、不依赖任何字段契约；类型用 `null` 而非 `0` 哨兵，从类型层杜绝「未连接却被 `Date.now() - 0` 算成健康长连」。
- **退避加厚**：上限 3→6、退避从线性（1/2/3s）改指数带上限（1/2/4/8/16/30s）；相关阈值字段化便于测试注入。

## 影响范围

仅 `RiffBackend` 单个 CLI 适配器，**未触碰** `adapters/cli/` 共用基类或 worker 侧共用逻辑，无跨 CLI / 跨后端连带影响；`done` 幂等语义未变（仅搬进 `completeTask`）。daemon 实际跑在 Linux，本改动纯 TS 逻辑、不涉及平台相关路径/进程/PTY。

## 测试

`test/riff-backend.test.ts` 新增回归用例：

- 健康连接（存活过阈值）跨多次 ~183s cap → 远超预算仍不误报、计数不累积；
- 重连 init 重放**终态** → 干净收尾、完成恰好一次、零「重连失败」（假阳性本体）；
- stale-running 孤儿**秒级 EOF 热循环**（init=running，连接秒断）→ 有界早停 + 报错（锁死「reset 判据不能只看是否连上/收到 init」这个回归）；
- 建连失败 **404（task 已 GC）/ 网络异常 throw**（从未 stamp）→ 有界早停，无请求风暴；
- 并修复测试遗留「在途重连循环污染下一个用例共享 fetchMock 计数」的卫生问题（`afterEach` 中 `kill()` 各 backend）。

验证结果：

- `test/riff-backend.test.ts` 69 项多次运行全绿（含计时 / 热循环 / 404 / throw / null 分支用例，稳定不 flaky）；
- 相关 backend/worker 套件（`riff-explicit-close` / `restart-worker-null-reattach` / `worker-riff-retirement-protocol` / `persistent-backend-type`）60 项全绿；
- `pnpm build` 绿。

## 后续

live 验证需部署本 checkout 到运行 riff bot 的 daemon，跑一个 >13 分钟的 runner 任务确认不再误报失败（另行择时进行，避免影响在用会话）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)