### PR TITLE
feat(overload): 过载告警卡加可配置的按浏览器重启按钮

### DIFF
--- a/src/core/browser-restart.ts
+++ b/src/core/browser-restart.ts
@@ -1,0 +1,277 @@
+/**
+ * Browser-restart降压 for the host-overload alert.
+ *
+ * Motivation: on a dev Mac the real memory hog is almost always a browser
+ * (Arc / Chrome / Edge each routinely hold multiple GB), NOT botmux sessions.
+ * The overload card's original two buttons (clean zombie / suspend idle) free
+ * almost nothing when 僵尸/闲置 are both 0 — the machine is red because a
+ * browser is sitting on 6 GB. This module lets the owner bounce a specific
+ * browser straight from the alert card, which reliably reclaims that memory
+ * (the browser reopens and restores its tabs).
+ *
+ * Design:
+ *  - Targets are DATA, never hard-coded control flow. {@link DEFAULT_BROWSER_TARGETS}
+ *    ships Arc / Chrome / Edge; a global-config `browserRestartTargets` list can
+ *    override any field by bundleId, disable one (`enabled:false`), or append a
+ *    brand-new browser (Safari/Brave/Firefox…) with ZERO code change.
+ *  - Pure helpers ({@link resolveBrowserTargets}, {@link formatBrowserLabel},
+ *    the action-value codec) have no I/O and are unit-tested. The host probes +
+ *    the actual quit/relaunch live in {@link detectRunningBrowsers} /
+ *    {@link restartBrowser}, which shell out via bundle id (precise — never a
+ *    fuzzy process-name kill).
+ *  - The card only renders browsers that are BOTH installed AND currently
+ *    holding memory on THIS host, so the owner never taps a dead button.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const pExecFile = promisify(execFile);
+
+/** A restartable browser target. `bundleId` is the macOS CFBundleIdentifier —
+ *  the single source of truth we quit + relaunch by (no process-name guessing).
+ *  `openArgs` are passed to `open -b <id> --args …` on relaunch (e.g. Chromium's
+ *  `--restore-last-session` to force tab restore). */
+export interface BrowserTarget {
+  bundleId: string;
+  label: string;
+  /** Extra argv forwarded on relaunch (Chromium restore flag, etc.). */
+  openArgs?: string[];
+  /** false ⇒ never offered on the card (config can disable a default). */
+  enabled?: boolean;
+}
+
+/** Config entry shape (all optional except bundleId) — merged over the defaults
+ *  by bundleId. Kept separate from {@link BrowserTarget} so config validation is
+ *  explicit and forgiving of missing fields. */
+export interface BrowserTargetConfig {
+  bundleId?: unknown;
+  label?: unknown;
+  openArgs?: unknown;
+  enabled?: unknown;
+}
+
+/** Built-in defaults. Chromium browsers get `--restore-last-session` so a bounce
+ *  reopens the exact tabs; Arc restores its own state on launch. Order here is
+ *  the display order on the card. NOT exhaustive by design — extend via config. */
+export const DEFAULT_BROWSER_TARGETS: readonly BrowserTarget[] = [
+  { bundleId: 'company.thebrowser.Browser', label: 'Arc' },
+  { bundleId: 'com.google.Chrome', label: 'Chrome', openArgs: ['--restore-last-session'] },
+  { bundleId: 'com.microsoft.edgemac', label: 'Edge', openArgs: ['--restore-last-session'] },
+];
+
+/**
+ * Merge a config `browserRestartTargets` list over {@link DEFAULT_BROWSER_TARGETS}:
+ *  - a config entry whose bundleId matches a default OVERRIDES its label/openArgs/
+ *    enabled (only the fields actually present);
+ *  - a config entry with a new bundleId is APPENDED (so new browsers need no code);
+ *  - the result drops anything with `enabled === false`.
+ * Pure: no I/O. Invalid/garbage entries (missing/blank bundleId) are ignored so a
+ * hand-edited config can't crash the resolver. When `raw` is undefined/empty the
+ * built-in defaults are returned unchanged.
+ */
+export function resolveBrowserTargets(raw: unknown): BrowserTarget[] {
+  const byId = new Map<string, BrowserTarget>();
+  for (const d of DEFAULT_BROWSER_TARGETS) byId.set(d.bundleId, { ...d });
+
+  if (Array.isArray(raw)) {
+    for (const item of raw) {
+      if (!item || typeof item !== 'object') continue;
+      const c = item as BrowserTargetConfig;
+      const bundleId = typeof c.bundleId === 'string' ? c.bundleId.trim() : '';
+      if (!bundleId) continue;
+      const prev = byId.get(bundleId);
+      const merged: BrowserTarget = prev
+        ? { ...prev }
+        : { bundleId, label: bundleId };
+      if (typeof c.label === 'string' && c.label.trim()) merged.label = c.label.trim();
+      if (Array.isArray(c.openArgs) && c.openArgs.every(a => typeof a === 'string')) {
+        merged.openArgs = c.openArgs as string[];
+      }
+      if (typeof c.enabled === 'boolean') merged.enabled = c.enabled;
+      byId.set(bundleId, merged);
+    }
+  }
+
+  return [...byId.values()].filter(t => t.enabled !== false);
+}
+
+/** Card button label, e.g. `♻️ 重启 Arc · 6.2 GB`. Memory is optional (unknown
+ *  ⇒ omit the suffix). Pure. */
+export function formatBrowserLabel(label: string, memMB?: number): string {
+  if (memMB === undefined || !Number.isFinite(memMB) || memMB <= 0) return `♻️ 重启 ${label}`;
+  const mem = memMB >= 1024 ? `${(memMB / 1024).toFixed(1)} GB` : `${Math.round(memMB)} MB`;
+  return `♻️ 重启 ${label} · ${mem}`;
+}
+
+/** A running browser found on the host, with its aggregate RSS in MB. */
+export interface RunningBrowser {
+  bundleId: string;
+  label: string;
+  memMB: number;
+  openArgs?: string[];
+}
+
+/** Resolve a bundle id to its .app path via Spotlight. Returns '' when the app
+ *  isn't installed (or Spotlight can't answer). Impure (mdfind). */
+async function appPathForBundleId(bundleId: string): Promise<string> {
+  try {
+    const { stdout } = await pExecFile('mdfind', [`kMDItemCFBundleIdentifier == '${bundleId}'`], { timeout: 5_000 });
+    const line = stdout.split('\n').map(s => s.trim()).find(s => s.endsWith('.app'));
+    return line ?? '';
+  } catch { return ''; }
+}
+
+/**
+ * Probe the host for which of `targets` are installed AND currently holding
+ * memory, returning them (in `targets` order) with aggregate RSS in MB. A
+ * browser that's installed but not running contributes nothing (no button).
+ *
+ * Memory is summed over every process whose command line lives under the app's
+ * bundle path (helper renderers, GPU process, …) — matched by RESOLVED app path,
+ * not a fuzzy name, so "Google Chrome" can't accidentally match "Chrome" text
+ * elsewhere. Impure (mdfind + ps). Best-effort: a probe failure yields [].
+ */
+export async function detectRunningBrowsers(
+  targets: BrowserTarget[],
+  deps: {
+    /** injectable for tests; defaults to the real ps. */
+    psList?: () => Promise<string>;
+    /** injectable for tests; defaults to the real Spotlight lookup. */
+    appPathFor?: (bundleId: string) => Promise<string>;
+    /** override the platform gate in tests. */
+    platform?: NodeJS.Platform;
+  } = {},
+): Promise<RunningBrowser[]> {
+  // The quit/relaunch path is macOS-only (osascript + `open -b <bundleId>`);
+  // on any other platform there's nothing to offer, so skip the probe entirely
+  // instead of spawning mdfind/ps for no reason.
+  if ((deps.platform ?? process.platform) !== 'darwin') return [];
+  const psList = deps.psList ?? (async () => (await pExecFile('ps', ['-Axo', 'rss=,command='], { timeout: 8_000, maxBuffer: 32 * 1024 * 1024 })).stdout);
+  const appPathFor = deps.appPathFor ?? appPathForBundleId;
+  let psOut = '';
+  try { psOut = await psList(); } catch { return []; }
+  const lines = psOut.split('\n');
+
+  const out: RunningBrowser[] = [];
+  for (const t of targets) {
+    const appPath = await appPathFor(t.bundleId);
+    if (!appPath) continue; // not installed → no button
+    let kb = 0;
+    for (const ln of lines) {
+      const m = ln.match(/^\s*(\d+)\s+(.*)$/);
+      if (!m) continue;
+      if (commandInApp(m[2], appPath)) kb += Number(m[1]) || 0;
+    }
+    const memMB = Math.round(kb / 1024);
+    if (memMB <= 0) continue; // installed but not running → no button
+    out.push({ bundleId: t.bundleId, label: t.label, memMB, ...(t.openArgs ? { openArgs: t.openArgs } : {}) });
+  }
+  return out;
+}
+
+/** Result of a restart attempt. `relaunched` is best-effort — a failure to
+ *  reopen still counts the quit as done (memory was freed) but is reported. */
+export interface RestartResult {
+  ok: boolean;
+  quit: boolean;
+  relaunched: boolean;
+  error?: string;
+}
+
+/**
+ * Restart a browser by bundle id: graceful `quit` via AppleScript, poll until
+ * its processes are gone, then relaunch with `open -b <id>` (+ openArgs). Never
+ * SIGKILLs — a browser refusing to quit (unsaved prompt) is left alone and
+ * reported rather than force-killed under the user. Impure. `sleep`/`now`/`run`
+ * are injectable so the polling loop is unit-testable without real timers.
+ */
+export async function restartBrowser(
+  target: { bundleId: string; openArgs?: string[] },
+  opts: {
+    run?: (file: string, args: string[]) => Promise<{ stdout: string }>;
+    isRunning?: (bundleId: string) => Promise<boolean>;
+    sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
+    quitTimeoutMs?: number;
+    /** inject the resolved bundle path (tests); defaults to a Spotlight lookup. */
+    appPath?: string;
+    appPathFor?: (bundleId: string) => Promise<string>;
+  } = {},
+): Promise<RestartResult> {
+  const run = opts.run ?? (async (file, args) => pExecFile(file, args, { timeout: 15_000 }));
+  const sleep = opts.sleep ?? ((ms) => new Promise<void>(r => setTimeout(r, ms)));
+  const now = opts.now ?? (() => Date.now());
+  const quitTimeoutMs = opts.quitTimeoutMs ?? 12_000;
+  // Resolve the app's bundle path ONCE, up front, and let the liveness probe run
+  // `ps` against THAT path for the whole poll loop. This is the fail-safe the
+  // review flagged: the previous default was `appPathForBundleId(id) !== '' &&
+  // bundleHasProcess(...)`, so a missing/failed mdfind returned '' and the `&&`
+  // short-circuited to "not running" — we'd `open` and report ok WITHOUT ever
+  // checking ps. Now an unresolvable path or a ps error is treated as "still
+  // running" (never gone), so we never blindly relaunch on unknown state.
+  const appPath = opts.appPath ?? await (opts.appPathFor ?? appPathForBundleId)(target.bundleId);
+  const isRunning = opts.isRunning ?? (async () => {
+    if (!appPath) return true; // unknown bundle path ⇒ assume running (don't relaunch)
+    try {
+      const { stdout } = await run('ps', ['-Axo', 'command=']);
+      return stdout.split('\n').some(ln => commandInApp(ln, appPath));
+    } catch { return true; } // ps error ⇒ assume running (conservative)
+  });
+
+  // 1) graceful quit
+  try {
+    await run('osascript', ['-e', `tell application id "${target.bundleId}" to quit`]);
+  } catch (err) {
+    return { ok: false, quit: false, relaunched: false, error: `quit failed: ${errMsg(err)}` };
+  }
+
+  // 2) wait for the app's processes to actually exit before relaunching, or a
+  //    fast `open` races the still-shutting-down instance and no-ops.
+  const deadline = now() + quitTimeoutMs;
+  let gone = false;
+  while (now() < deadline) {
+    await sleep(500);
+    if (!(await isRunning(target.bundleId))) { gone = true; break; }
+  }
+  if (!gone) {
+    // Still alive after the grace window — likely an unsaved-changes dialog.
+    // Do NOT force-kill: report so the owner can handle it.
+    return { ok: false, quit: false, relaunched: false, error: '浏览器未在超时内退出（可能有未保存的弹窗，或进程状态无法确认），已放弃，未强杀' };
+  }
+
+  // 3) relaunch
+  try {
+    const args = ['-b', target.bundleId, ...(target.openArgs && target.openArgs.length ? ['--args', ...target.openArgs] : [])];
+    await run('open', args);
+    return { ok: true, quit: true, relaunched: true };
+  } catch (err) {
+    return { ok: true, quit: true, relaunched: false, error: `relaunch failed: ${errMsg(err)}` };
+  }
+}
+
+/**
+ * True when a `ps` command line's EXECUTABLE belongs to the app at `appPath`.
+ *
+ * A `ps` line is `<argv0> <args...>`; the executable is argv0 at the very start.
+ * We anchor on that left boundary — the command (after trimming leading spaces)
+ * must BEGIN with `appPath` — instead of scanning for the path anywhere in the
+ * line. This is deliberately stricter than a substring/right-boundary match:
+ *   - a backup copy launched from elsewhere, e.g. `/Volumes/Backup/…/Arc.app/…`,
+ *     does NOT start with `/Applications/Arc.app` → excluded;
+ *   - `/Applications/Arc.app-copy/…` is not under `/Applications/Arc.app/` → excluded;
+ *   - the path appearing as an unrelated ARGUMENT, e.g.
+ *     `/usr/bin/open -b x /Applications/Arc.app`, is not argv0 → excluded.
+ * Bundle-internal helpers (`<app>/Contents/Frameworks/…`) start with `<app>/`, so
+ * they match. Prefix-matching (not whitespace-splitting) also tolerates spaces in
+ * the app path itself (e.g. `/Applications/Google Chrome.app`). Pure.
+ */
+export function commandInApp(command: string, appPath: string): boolean {
+  if (!appPath) return false;
+  const cmd = command.replace(/^\s+/, ''); // argv0 sits at the start of the line
+  if (cmd === appPath) return true;               // executable is exactly the path
+  if (cmd.startsWith(appPath + '/')) return true; // helper/binary under the bundle
+  if (cmd.startsWith(appPath + ' ')) return true; // path is argv0, followed by args
+  return false;
+}
+
+function errMsg(err: unknown): string { return err instanceof Error ? err.message : String(err); }

--- a/src/core/host-overload-alert.ts
+++ b/src/core/host-overload-alert.ts
@@ -363,6 +363,9 @@ export function formatOverloadAlert(action: OverloadAlertAction, hostLabel?: str
  *  exact literals (typo-proof). */
 export const OVERLOAD_ACTION_CLEAN_STOPPED = 'overload_clean_stopped';
 export const OVERLOAD_ACTION_SUSPEND_IDLE = 'overload_suspend_idle';
+/** Restart a specific browser (bundleId carried on the button value). One action
+ *  literal for all browsers; the per-browser one-shot claim keys on bundleId. */
+export const OVERLOAD_ACTION_RESTART_BROWSER = 'overload_restart_browser';
 /** Fail-safe action on a disabled (already-run) button — clients that don't
  *  suppress disabled callbacks just get a harmless toast, no side effect. */
 export const OVERLOAD_ACTION_NOOP = 'overload_noop';
@@ -395,6 +398,18 @@ export interface OverloadCardState {
   /** result of each action once run; -1 = not run yet. */
   cleanedN: number;
   suspendedN: number;
+  /** Browsers currently running + holding memory on this host, in display order.
+   *  Empty ⇒ no browser buttons (nothing to reclaim). */
+  browsers?: OverloadCardBrowser[];
+  /** bundleIds whose restart button has already been clicked (✓ done). */
+  restartedBrowsers?: string[];
+}
+
+/** A per-browser restart button descriptor carried on the card. */
+export interface OverloadCardBrowser {
+  bundleId: string;
+  label: string;
+  memMB: number;
 }
 
 /** Build the machine-wide summary/metrics line from card state. */
@@ -410,6 +425,7 @@ export function initialOverloadCardState(
   action: OverloadAlertAction,
   counts: { stopped: number; idle: number },
   nonce: string,
+  browsers: OverloadCardBrowser[] = [],
 ): OverloadCardState {
   return {
     nonce,
@@ -422,7 +438,17 @@ export function initialOverloadCardState(
     idle: counts.idle,
     cleanedN: -1,
     suspendedN: -1,
+    ...(browsers.length ? { browsers, restartedBrowsers: [] } : {}),
   };
+}
+
+/** Card button label for a browser restart, e.g. `♻️ 重启 Arc · 6.2 GB`. Inlined
+ *  here (rather than imported from core/browser-restart) so this card module
+ *  stays free of node:child_process and trivially unit-testable. Pure. */
+function browserButtonLabel(label: string, memMB: number): string {
+  if (!Number.isFinite(memMB) || memMB <= 0) return `♻️ 重启 ${label}`;
+  const mem = memMB >= 1024 ? `${(memMB / 1024).toFixed(1)} GB` : `${Math.round(memMB)} MB`;
+  return `♻️ 重启 ${label} · ${mem}`;
 }
 
 /**
@@ -458,16 +484,50 @@ export function buildOverloadAlertCard(st: OverloadCardState, hostLabel?: string
         text: { tag: 'plain_text', content: `💤 挂起闲置会话 (${st.idle})` },
         value: { action: OVERLOAD_ACTION_SUSPEND_IDLE, st: JSON.stringify(st) } };
 
+  // Per-browser restart buttons: one per browser that's running + holding memory
+  // on this host. Each carries its own bundleId so the one-shot claim keys on it
+  // (the owner can bounce Arc AND Chrome on one card, but neither twice). A
+  // clicked browser → disabled ✓; the memory tag reflects what was reclaimed.
+  const browsers = st.browsers ?? [];
+  const restarted = new Set(st.restartedBrowsers ?? []);
+  const browserBtns = browsers.map((b) => restarted.has(b.bundleId)
+    ? { tag: 'button', type: 'default', disabled: true,
+        text: { tag: 'plain_text', content: `✓ 已重启 ${b.label}` },
+        value: { action: OVERLOAD_ACTION_NOOP } }
+    : { tag: 'button', type: 'danger',
+        text: { tag: 'plain_text', content: browserButtonLabel(b.label, b.memMB) },
+        value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: b.bundleId, st: JSON.stringify(st) } });
+
+  const memList = browsers.length
+    ? '内存占用：' + browsers.map(b => `**${b.label} ${b.memMB >= 1024 ? (b.memMB / 1024).toFixed(1) + 'G' : b.memMB + 'M'}**`).join(' · ')
+    : '';
+
+  const actionRows: unknown[] = [{ tag: 'action', actions: [cleanBtn, suspendBtn] }];
+  // Repo convention: <= 4 buttons per `action` row. With 5+ custom browser
+  // targets we'd otherwise cram them all into one row; chunk into rows of 4.
+  for (let i = 0; i < browserBtns.length; i += 4) {
+    actionRows.push({ tag: 'action', actions: browserBtns.slice(i, i + 4) });
+  }
+
+  const noteLines = [
+    '清僵尸=关闭进程已退出的僵尸会话；挂起闲置=挂起空闲可恢复会话（下条消息冷恢复）。',
+  ];
+  if (browsers.length) noteLines.push('重启浏览器=优雅退出并重开该浏览器（会恢复标签页），用于释放浏览器占用的大块内存。');
+  noteLines.push('仅管理员可操作，每个按钮可点一次。');
+
+  const elements: unknown[] = [
+    { tag: 'div', text: { tag: 'lark_md', content: `**触发维度：**${why}\n${stateMetricsLine(st)}` } },
+    { tag: 'div', text: { tag: 'lark_md', content: `当前可降压：**僵尸会话 ${st.stopped} 个** · **闲置会话 ${st.idle} 个**` } },
+  ];
+  if (memList) elements.push({ tag: 'div', text: { tag: 'lark_md', content: memList } });
+  elements.push({ tag: 'hr' });
+  elements.push(...actionRows);
+  elements.push({ tag: 'note', elements: [{ tag: 'lark_md', content: noteLines.join('') }] });
+
   return JSON.stringify({
     config: { wide_screen_mode: true },
     header: { template: 'red', title: { tag: 'plain_text', content: `⚠️ 机器过载告警${host}` } },
-    elements: [
-      { tag: 'div', text: { tag: 'lark_md', content: `**触发维度：**${why}\n${stateMetricsLine(st)}` } },
-      { tag: 'div', text: { tag: 'lark_md', content: `当前可降压：**僵尸会话 ${st.stopped} 个** · **闲置会话 ${st.idle} 个**` } },
-      { tag: 'hr' },
-      { tag: 'action', actions: [cleanBtn, suspendBtn] },
-      { tag: 'note', elements: [{ tag: 'lark_md', content: '清僵尸=关闭进程已退出的僵尸会话；挂起闲置=挂起空闲可恢复会话（下条消息冷恢复）。仅管理员可操作，每个按钮可点一次。' }] },
-    ],
+    elements,
   });
 }
 
@@ -491,4 +551,22 @@ export function buildOverloadExpiredCard(detail = ''): string {
     header: { template: 'grey', title: { tag: 'plain_text', content: '⏳ 操作已失效' } },
     elements: [{ tag: 'div', text: { tag: 'lark_md', content: detail || '这张告警卡已过期（daemon 重启或超时）。等待下一次告警即可。' } }],
   });
+}
+
+/**
+ * Failure card for a browser-restart click that could not complete (quit failed,
+ * refused to quit within the window, or quit-but-relaunch-failed). Rendered as a
+ * FULL patchable alert card (not a toast): the browser-restart handler can run up
+ * to ~12s, past the 2.5s card-ACK window, after which a toast-only result is
+ * dropped by the dispatcher — so the failure must ride a card the dispatcher can
+ * patch in. Carries the rebuilt alert `st` so every still-live button (including
+ * this browser's, whose claim was released for retry) stays clickable.
+ */
+export function buildOverloadBrowserFailureCard(st: OverloadCardState, label: string, detail: string, hostLabel?: string): string {
+  const base = JSON.parse(buildOverloadAlertCard(st, hostLabel)) as { elements: unknown[] };
+  base.elements.push({
+    tag: 'note',
+    elements: [{ tag: 'lark_md', content: `⚠️ **${label}**：${detail}` }],
+  });
+  return JSON.stringify(base);
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -33,8 +33,10 @@ import {
   isOverloadAlertTarget,
   type OverloadState,
   type OverloadThresholds,
+  type OverloadCardBrowser,
 } from './core/host-overload-alert.js';
 import { registerOverloadNonce } from './im/lark/overload-nonce.js';
+import { resolveBrowserTargets, detectRunningBrowsers } from './core/browser-restart.js';
 import { countHostOverload } from './im/lark/card-handler.js';
 import { startMaintenance, stopMaintenance } from './core/maintenance.js';
 import {
@@ -21808,7 +21810,17 @@ export async function startDaemon(botIndex?: number): Promise<void> {
           let counts = { stopped: 0, idle: 0 };
           try { counts = await countHostOverload(); }
           catch (err) { logger.warn(`[overload] count failed, showing 0: ${err instanceof Error ? err.message : String(err)}`); }
-          cardJson = buildOverloadAlertCard(initialOverloadCardState(action, counts, nonce));
+          // Probe which configured browsers are running + holding memory so the
+          // card can offer a per-browser「♻️ 重启」button (the real memory hog on
+          // a dev Mac is usually a browser, not botmux sessions). Best-effort:
+          // any probe failure just yields no browser buttons.
+          let browsers: OverloadCardBrowser[] = [];
+          try {
+            const targets = resolveBrowserTargets((alertCfg as { browserRestartTargets?: unknown }).browserRestartTargets);
+            const running = await detectRunningBrowsers(targets);
+            browsers = running.map(b => ({ bundleId: b.bundleId, label: b.label, memMB: b.memMB }));
+          } catch (err) { logger.warn(`[overload] browser probe failed, no restart buttons: ${err instanceof Error ? err.message : String(err)}`); }
+          cardJson = buildOverloadAlertCard(initialOverloadCardState(action, counts, nonce, browsers));
         } else {
           cardJson = buildOverloadRecoveredCard(action);
         }

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -68,6 +68,24 @@ export interface HostOverloadAlertGlobalConfig {
   enterLoadRatio?: number;
   /** 进入过载的已用内存占比阈值(0..1)。缺省 0.92。退出线同样按 95% 派生。 */
   enterMemUsedFrac?: number;
+  /** 过载卡上「重启浏览器」按钮的可配置目标清单。缺省内置 Arc / Chrome / Edge
+   *  （见 core/browser-restart.ts 的 DEFAULT_BROWSER_TARGETS）。此处按 bundleId
+   *  合并覆盖：同 bundleId 覆盖 label/openArgs/enabled；新 bundleId 追加；
+   *  enabled:false 关闭某个默认项。绝不写死浏览器，加新浏览器只改配置。 */
+  browserRestartTargets?: HostOverloadBrowserTargetConfig[];
+}
+
+/** 单个可重启浏览器目标的配置项（全部可选，仅 bundleId 必填才生效）。 */
+export interface HostOverloadBrowserTargetConfig {
+  /** macOS CFBundleIdentifier，如 company.thebrowser.Browser。唯一定位键。 */
+  bundleId: string;
+  /** 卡片显示名，如 Arc / Chrome / Edge。缺省回退为 bundleId。 */
+  label?: string;
+  /** 重启时透传给 `open -b <id> --args …` 的额外参数（如 Chromium 的
+   *  --restore-last-session 强制恢复标签）。 */
+  openArgs?: string[];
+  /** 置 false 则该浏览器永不出现在卡片上（用于关掉某个默认项）。 */
+  enabled?: boolean;
 }
 
 export interface VcMeetingAgentGlobalConfig {
@@ -435,7 +453,33 @@ function readHostOverloadAlert(raw: unknown): HostOverloadAlertGlobalConfig | un
   ) {
     out.enterMemUsedFrac = value.enterMemUsedFrac;
   }
+  const browserTargets = readBrowserRestartTargets(value.browserRestartTargets);
+  if (browserTargets) out.browserRestartTargets = browserTargets;
   return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Parse the `browserRestartTargets` array from config. Keep only entries with a
+ *  non-blank string bundleId; coerce the optional fields defensively so a
+ *  hand-edited config can't inject non-strings. Returns undefined when there's
+ *  nothing usable (so the default set applies). The daemon-side resolver
+ *  (core/browser-restart.ts) does the actual merge-over-defaults. */
+function readBrowserRestartTargets(raw: unknown): HostOverloadBrowserTargetConfig[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: HostOverloadBrowserTargetConfig[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const v = item as Record<string, unknown>;
+    const bundleId = typeof v.bundleId === 'string' ? v.bundleId.trim() : '';
+    if (!bundleId) continue;
+    const entry: HostOverloadBrowserTargetConfig = { bundleId };
+    if (typeof v.label === 'string' && v.label.trim()) entry.label = v.label.trim();
+    if (Array.isArray(v.openArgs) && v.openArgs.every(a => typeof a === 'string')) {
+      entry.openArgs = v.openArgs as string[];
+    }
+    if (typeof v.enabled === 'boolean') entry.enabled = v.enabled;
+    out.push(entry);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 function readVcMeetingAgent(raw: unknown): VcMeetingAgentGlobalConfig | undefined {

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -36,9 +36,13 @@ import {
   buildOverloadExpiredCard,
   OVERLOAD_ACTION_CLEAN_STOPPED,
   OVERLOAD_ACTION_SUSPEND_IDLE,
+  OVERLOAD_ACTION_RESTART_BROWSER,
   OVERLOAD_ACTION_NOOP,
+  buildOverloadBrowserFailureCard,
   type OverloadCardState,
 } from '../../core/host-overload-alert.js';
+import { restartBrowser, resolveBrowserTargets } from '../../core/browser-restart.js';
+import { readGlobalConfig } from '../../global-config.js';
 import { listOnlineDaemons } from '../../utils/daemon-discovery.js';
 import { fetchDaemonIpc } from '../../core/daemon-ipc-auth.js';
 import { recordObservedBots } from '../../services/observed-bots-store.js';
@@ -1038,6 +1042,83 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     }
     logger.info(`[overload] ${value.action} by owner ${operatorOpenId}: affected=${affected}, remaining stopped=${st.stopped} idle=${st.idle}`);
     // Rebuild the SAME card: clicked button → ✓done+disabled, other → still live.
+    return JSON.parse(buildOverloadAlertCard(st));
+  }
+  // ─── 过载告警卡：重启浏览器（overload_restart_browser）────────────────────
+  // owner 强闸门 + 按 bundleId 分开的一次性 nonce 核销（可分别重启 Arc/Chrome/Edge，
+  // 各一次）。重启在本机 daemon 直接执行（浏览器就跑在本机），不跨 daemon 扇出。
+  if (value?.action === OVERLOAD_ACTION_RESTART_BROWSER && larkAppId) {
+    const owner = getOwnerOpenId(larkAppId);
+    if (!operatorOpenId || operatorOpenId !== owner) {
+      logger.info(`Overload browser-restart blocked for non-owner: ${operatorOpenId}`);
+      return { toast: { type: 'error', content: '仅管理员可操作' } };
+    }
+    const bundleId = typeof value.bundleId === 'string' ? value.bundleId : '';
+    if (!bundleId) return { toast: { type: 'error', content: '按钮缺少 bundleId' } };
+    let st: OverloadCardState;
+    try { st = JSON.parse(value.st ?? ''); } catch { return JSON.parse(buildOverloadExpiredCard()); }
+    if (!st?.nonce) return JSON.parse(buildOverloadExpiredCard());
+    // Fail-closed against config drift: the button lives
+    // on a card that stays clickable for the nonce's 1h TTL, but the config's
+    // enabled targets can change underneath it (a target disabled via
+    // `enabled:false` or removed entirely). Before we quit a real host browser,
+    // require the bundleId to be present BOTH on this card's `st.browsers` (it
+    // was a rendered button, not a forged value) AND in the live resolved
+    // enabled targets (it's still an allowed target right now). Either miss →
+    // refuse without touching the browser, so a stale card can't kill a browser
+    // the operator has since taken off the allow-list.
+    const target = (st.browsers ?? []).find(b => b.bundleId === bundleId);
+    let liveTargets: ReturnType<typeof resolveBrowserTargets> = [];
+    try {
+      const alertCfg = (readGlobalConfig().hostOverloadAlert ?? {}) as { browserRestartTargets?: unknown };
+      liveTargets = resolveBrowserTargets(alertCfg.browserRestartTargets);
+    } catch { /* resolver is pure over config; treat a throw as "no live targets" → fail-closed below */ }
+    const liveTarget = liveTargets.find(t => t.bundleId === bundleId);
+    if (!target || !liveTarget) {
+      logger.info(`[overload] restart browser refused (config drift): bundleId=${bundleId} onCard=${!!target} liveEnabled=${!!liveTarget}`);
+      return JSON.parse(buildOverloadExpiredCard('该浏览器的重启配置已变更或卡片已过期，未执行。'));
+    }
+    const label = target.label ?? liveTarget.label ?? bundleId;
+    // One-shot per (nonce, bundleId): each browser button burns its own claim so
+    // the owner can bounce several browsers on one card, but none twice.
+    const claimKey = `${OVERLOAD_ACTION_RESTART_BROWSER}:${bundleId}`;
+    if (!claimOverloadNonce(st.nonce, claimKey)) {
+      return JSON.parse(buildOverloadExpiredCard('这个按钮已点过，或该告警卡已过期。'));
+    }
+    const openArgs = liveTarget.openArgs;
+    let result;
+    try {
+      result = await restartBrowser({ bundleId, ...(openArgs ? { openArgs } : {}) });
+    } catch (err) {
+      logger.warn(`[overload] restart browser ${label} threw: ${err instanceof Error ? err.message : String(err)}`);
+      releaseOverloadNonce(st.nonce, claimKey);
+      // Return a VISIBLE card, not a toast: the handler can
+      // run up to ~12s (quit-wait), which exceeds the 2.5s card-ACK window — a
+      // toast-only result after that ACK is silently dropped by the dispatcher.
+      // buildOverloadBrowserFailureCard renders a patchable card carrying the
+      // rebuilt alert `st`, so the owner actually sees the failure + can retry.
+      return JSON.parse(buildOverloadBrowserFailureCard(st, label, '重启失败，请稍后重试'));
+    }
+    if (!result.ok) {
+      // Quit never happened (e.g. unsaved-changes dialog) — nothing was killed;
+      // release the claim so the owner can retry after handling the dialog. Same
+      // reasoning as above: deliver via a patchable card, never a toast.
+      logger.warn(`[overload] restart browser ${label} not ok: ${result.error ?? 'unknown'}`);
+      releaseOverloadNonce(st.nonce, claimKey);
+      return JSON.parse(buildOverloadBrowserFailureCard(st, label, result.error ?? '重启失败'));
+    }
+    if (!result.relaunched) {
+      // Quit succeeded but relaunch failed: the browser is
+      // now DOWN, not restarted. Do NOT mark it「✓已重启」and do NOT burn the
+      // claim — release it so the owner can retry the reopen. Report the true
+      // state (已退出未重开) on a patchable card.
+      logger.warn(`[overload] browser ${label} quit but relaunch failed: ${result.error ?? 'unknown'}`);
+      releaseOverloadNonce(st.nonce, claimKey);
+      return JSON.parse(buildOverloadBrowserFailureCard(st, label, `已退出但重开失败：${result.error ?? '未知错误'}。可再点一次重试重开`));
+    }
+    // Mark this browser done on the card (button → ✓已重启, disabled).
+    st.restartedBrowsers = [...new Set([...(st.restartedBrowsers ?? []), bundleId])];
+    logger.info(`[overload] browser ${label} restarted by owner ${operatorOpenId} (relaunched=${result.relaunched})`);
     return JSON.parse(buildOverloadAlertCard(st));
   }
   // ─── 群内授权卡片动作（限制提交 + grant/revoke，talk-only）──────────────────

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -719,6 +719,11 @@ function cardActionKey(larkAppId: string, data: any): string {
     // managing bot A in group X doesn't dedupe bot B in group Y.
     chatId: value?.chat_id,
     appId: value?.app_id,
+    // Overload browser-restart buttons all share one action label
+    // (`overload_restart_browser`) but target different browsers; include the
+    // bundleId so rapidly clicking Arc then Chrome isn't collapsed into one
+    // in-flight dedupe key that drops the second click.
+    bundleId: value?.bundleId,
   })}`;
 }
 

--- a/test/browser-restart.test.ts
+++ b/test/browser-restart.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_BROWSER_TARGETS,
+  resolveBrowserTargets,
+  formatBrowserLabel,
+  restartBrowser,
+} from '../src/core/browser-restart.js';
+
+describe('resolveBrowserTargets — configurable, never hard-coded', () => {
+  it('returns the built-in Arc/Chrome/Edge defaults when config is empty/undefined', () => {
+    const ids = resolveBrowserTargets(undefined).map(t => t.bundleId);
+    expect(ids).toEqual(DEFAULT_BROWSER_TARGETS.map(t => t.bundleId));
+    expect(resolveBrowserTargets([]).map(t => t.label)).toEqual(['Arc', 'Chrome', 'Edge']);
+  });
+
+  it('overrides an existing default by bundleId (label/openArgs) without dropping others', () => {
+    const out = resolveBrowserTargets([
+      { bundleId: 'company.thebrowser.Browser', label: 'Arc 浏览器', openArgs: ['--foo'] },
+    ]);
+    const arc = out.find(t => t.bundleId === 'company.thebrowser.Browser')!;
+    expect(arc.label).toBe('Arc 浏览器');
+    expect(arc.openArgs).toEqual(['--foo']);
+    // Chrome + Edge still present + unchanged.
+    expect(out.map(t => t.bundleId)).toContain('com.google.Chrome');
+    expect(out.map(t => t.bundleId)).toContain('com.microsoft.edgemac');
+  });
+
+  it('appends a brand-new browser with no code change', () => {
+    const out = resolveBrowserTargets([
+      { bundleId: 'com.brave.Browser', label: 'Brave' },
+    ]);
+    expect(out.find(t => t.bundleId === 'com.brave.Browser')?.label).toBe('Brave');
+    expect(out).toHaveLength(4);
+  });
+
+  it('drops a default when config disables it (enabled:false)', () => {
+    const out = resolveBrowserTargets([{ bundleId: 'com.microsoft.edgemac', enabled: false }]);
+    expect(out.map(t => t.bundleId)).not.toContain('com.microsoft.edgemac');
+    expect(out.map(t => t.bundleId)).toContain('company.thebrowser.Browser');
+  });
+
+  it('ignores garbage entries (missing/blank bundleId, non-objects)', () => {
+    const out = resolveBrowserTargets(['nope', 42, {}, { bundleId: '   ' }, null]);
+    expect(out.map(t => t.bundleId)).toEqual(DEFAULT_BROWSER_TARGETS.map(t => t.bundleId));
+  });
+});
+
+describe('formatBrowserLabel', () => {
+  it('renders GB for >= 1024 MB and MB otherwise', () => {
+    expect(formatBrowserLabel('Arc', 6202)).toBe('♻️ 重启 Arc · 6.1 GB');
+    expect(formatBrowserLabel('Chrome', 512)).toBe('♻️ 重启 Chrome · 512 MB');
+  });
+  it('omits the memory suffix when unknown/zero', () => {
+    expect(formatBrowserLabel('Edge')).toBe('♻️ 重启 Edge');
+    expect(formatBrowserLabel('Edge', 0)).toBe('♻️ 重启 Edge');
+  });
+});
+
+describe('restartBrowser — bundleId quit + relaunch, never force-kill', () => {
+  it('quits, waits for exit, then relaunches with openArgs', async () => {
+    const calls: Array<[string, string[]]> = [];
+    let alive = true;
+    const result = await restartBrowser(
+      { bundleId: 'com.google.Chrome', openArgs: ['--restore-last-session'] },
+      {
+        run: async (file, args) => { calls.push([file, args]); return { stdout: '' }; },
+        isRunning: async () => alive,
+        sleep: async () => { alive = false; }, // process exits after first poll
+        now: (() => { let t = 0; return () => (t += 100); })(),
+      },
+    );
+    expect(result).toEqual({ ok: true, quit: true, relaunched: true });
+    expect(calls[0][0]).toBe('osascript');
+    expect(calls[0][1].join(' ')).toContain('id "com.google.Chrome" to quit');
+    const open = calls.find(c => c[0] === 'open')!;
+    expect(open[1]).toEqual(['-b', 'com.google.Chrome', '--args', '--restore-last-session']);
+  });
+
+  it('does NOT relaunch (and reports) when the browser refuses to quit within the window', async () => {
+    const calls: Array<[string, string[]]> = [];
+    const result = await restartBrowser(
+      { bundleId: 'company.thebrowser.Browser' },
+      {
+        run: async (file, args) => { calls.push([file, args]); return { stdout: '' }; },
+        isRunning: async () => true, // never exits (unsaved dialog)
+        sleep: async () => {},
+        now: (() => { let t = 0; return () => (t += 5_000); })(),
+        quitTimeoutMs: 12_000,
+      },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.relaunched).toBe(false);
+    expect(calls.some(c => c[0] === 'open')).toBe(false); // never relaunched
+    expect(calls.some(c => c[1].includes('-9') || c[1].includes('kill'))).toBe(false); // never force-killed
+  });
+
+  it('reports quit-failure without relaunching', async () => {
+    const result = await restartBrowser(
+      { bundleId: 'x.y.z' },
+      { run: async () => { throw new Error('no such app'); }, isRunning: async () => false, sleep: async () => {} },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.quit).toBe(false);
+    expect(result.error).toContain('quit failed');
+  });
+});
+
+import { detectRunningBrowsers, commandInApp } from '../src/core/browser-restart.js';
+
+describe('commandInApp — executable left-boundary match', () => {
+  const app = '/Applications/Arc.app';
+  it('matches when the executable (argv0) is under the bundle', () => {
+    expect(commandInApp(`${app}/Contents/MacOS/Arc`, app)).toBe(true);
+    expect(commandInApp(`  ${app}/Contents/Frameworks/Helper --type=gpu`, app)).toBe(true);
+  });
+  it('matches when argv0 is exactly the app path (with or without following args)', () => {
+    expect(commandInApp(app, app)).toBe(true);
+    expect(commandInApp(`${app} --new-window`, app)).toBe(true);
+  });
+  it('does NOT match when the path is an unrelated ARGUMENT (not argv0)', () => {
+    // e.g. `open -b x /Applications/Arc.app` launches via LaunchServices; the
+    // executable is /usr/bin/open, not Arc — must not be counted as Arc running.
+    expect(commandInApp(`/usr/bin/open -b x ${app}`, app)).toBe(false);
+  });
+  it('does NOT match a "-copy" sibling or a substring inside an arg', () => {
+    expect(commandInApp(`${app}-copy/Contents/MacOS/Arc`, app)).toBe(false);
+    expect(commandInApp(`/usr/bin/foo --flag=${app}bar`, app)).toBe(false);
+  });
+  it('does NOT match a backup copy launched from another root (left-prefix)', () => {
+    expect(commandInApp(`/Volumes/Backup/Applications/Arc.app/Contents/MacOS/Arc`, app)).toBe(false);
+    expect(commandInApp(`/Users/x/Backups${app}/Contents/MacOS/Arc`, app)).toBe(false);
+  });
+});
+
+describe('detectRunningBrowsers — DI probe, boundary aware + non-darwin', () => {
+  const appPath = '/Applications/Arc.app';
+  const psText = [
+    `  100000 ${appPath}/Contents/MacOS/Arc`,
+    `  200000 ${appPath}/Contents/Frameworks/Helper`,
+    `  999999 ${appPath}-copy/Contents/MacOS/Arc`,
+    `  888888 /usr/bin/foo --flag=${appPath}bar`,
+  ].join('\n');
+
+  it('sums only processes under the exact bundle path', async () => {
+    const out = await detectRunningBrowsers(
+      [{ bundleId: 'company.thebrowser.Browser', label: 'Arc' }],
+      { platform: 'darwin', psList: async () => psText, appPathFor: async () => appPath },
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].memMB).toBe(Math.round(300000 / 1024)); // -copy + substring excluded
+  });
+
+  it('omits a browser that is installed but not running (0 MB)', async () => {
+    const out = await detectRunningBrowsers(
+      [{ bundleId: 'x', label: 'X' }],
+      { platform: 'darwin', psList: async () => '  1234 /usr/bin/other', appPathFor: async () => '/Applications/X.app' },
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] on non-darwin without probing', async () => {
+    let probed = false;
+    const out = await detectRunningBrowsers(
+      [{ bundleId: 'x', label: 'X' }],
+      { platform: 'linux', psList: async () => { probed = true; return ''; }, appPathFor: async () => { probed = true; return ''; } },
+    );
+    expect(out).toEqual([]);
+    expect(probed).toBe(false);
+  });
+});
+
+describe('restartBrowser — default liveness probe is fail-safe (never blind relaunch)', () => {
+  it('treats an unresolvable bundle path as "still running": no relaunch, reports not-gone', async () => {
+    const calls: Array<[string, string[]]> = [];
+    const result = await restartBrowser(
+      { bundleId: 'x.y.z' },
+      {
+        run: async (file, args) => { calls.push([file, args]); return { stdout: '' }; },
+        appPathFor: async () => '',            // mdfind found nothing
+        sleep: async () => {},
+        now: (() => { let t = 0; return () => (t += 5_000); })(),
+        quitTimeoutMs: 12_000,
+        // NOTE: no isRunning override → exercises the real default probe.
+      },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.relaunched).toBe(false);
+    expect(calls.some(c => c[0] === 'open')).toBe(false); // never relaunched on unknown
+  });
+
+  it('treats a ps error as "still running": no relaunch', async () => {
+    const calls: Array<[string, string[]]> = [];
+    const result = await restartBrowser(
+      { bundleId: 'company.thebrowser.Browser' },
+      {
+        run: async (file, args) => {
+          calls.push([file, args]);
+          if (file === 'ps') throw new Error('ps boom');
+          return { stdout: '' };
+        },
+        appPath: '/Applications/Arc.app',
+        sleep: async () => {},
+        now: (() => { let t = 0; return () => (t += 5_000); })(),
+        quitTimeoutMs: 12_000,
+      },
+    );
+    expect(result.ok).toBe(false);
+    expect(calls.some(c => c[0] === 'open')).toBe(false);
+  });
+
+  it('relaunches once ps shows the app gone', async () => {
+    let psCall = 0;
+    const calls: Array<[string, string[]]> = [];
+    const result = await restartBrowser(
+      { bundleId: 'company.thebrowser.Browser', openArgs: ['--restore-last-session'] },
+      {
+        run: async (file, args) => {
+          calls.push([file, args]);
+          if (file === 'ps') {
+            psCall++;
+            // first poll: still running; second: gone.
+            return { stdout: psCall === 1 ? '/Applications/Arc.app/Contents/MacOS/Arc' : '/usr/bin/other' };
+          }
+          return { stdout: '' };
+        },
+        appPath: '/Applications/Arc.app',
+        sleep: async () => {},
+        now: (() => { let t = 0; return () => (t += 100); })(),
+      },
+    );
+    expect(result).toEqual({ ok: true, quit: true, relaunched: true });
+    const open = calls.find(c => c[0] === 'open')!;
+    expect(open[1]).toEqual(['-b', 'company.thebrowser.Browser', '--args', '--restore-last-session']);
+  });
+});

--- a/test/card-handler-browser-restart.test.ts
+++ b/test/card-handler-browser-restart.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { restartBrowserMock } = vi.hoisted(() => ({ restartBrowserMock: vi.fn() }));
+
+vi.mock('../src/core/browser-restart.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/core/browser-restart.js')>('../src/core/browser-restart.js');
+  return { ...actual, restartBrowser: (...a: any[]) => restartBrowserMock(...a) };
+});
+
+vi.mock('../src/bot-registry.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/bot-registry.js')>('../src/bot-registry.js');
+  return { ...actual, getOwnerOpenId: vi.fn(() => 'ou_owner') };
+});
+
+import { handleCardAction } from '../src/im/lark/card-handler.js';
+import {
+  OVERLOAD_ACTION_RESTART_BROWSER,
+  type OverloadCardState,
+} from '../src/core/host-overload-alert.js';
+import {
+  _resetOverloadNoncesForTest,
+  registerOverloadNonce,
+} from '../src/im/lark/overload-nonce.js';
+
+function stateWithBrowsers(nonce: string): OverloadCardState {
+  return {
+    nonce, load15: 6.9, cpu: 12, mem: 0.99, reasons: ['memory'],
+    stopped: 0, idle: 0, cleanedN: -1, suspendedN: -1,
+    browsers: [
+      { bundleId: 'company.thebrowser.Browser', label: 'Arc', memMB: 6202 },
+      { bundleId: 'com.google.Chrome', label: 'Chrome', memMB: 1659 },
+    ],
+    restartedBrowsers: [],
+  };
+}
+
+const deps = {
+  activeSessions: new Map(),
+  sessionReply: vi.fn(async () => 'om_reply'),
+  lastRepoScan: new Map(),
+} as any;
+
+beforeEach(() => {
+  _resetOverloadNoncesForTest();
+  restartBrowserMock.mockReset();
+});
+
+describe('overload card — restart browser action', () => {
+  it('restarts the chosen browser (owner) and marks only it done', async () => {
+    restartBrowserMock.mockResolvedValue({ ok: true, quit: true, relaunched: true });
+    const st = stateWithBrowsers('nb1');
+    registerOverloadNonce(st.nonce);
+
+    const result = await handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'company.thebrowser.Browser', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+
+    expect(restartBrowserMock).toHaveBeenCalledTimes(1);
+    expect(restartBrowserMock.mock.calls[0][0].bundleId).toBe('company.thebrowser.Browser');
+    const s = JSON.stringify(result);
+    expect(s).toContain('✓ 已重启 Arc');
+    expect(s).toContain('♻️ 重启 Chrome'); // Chrome still clickable
+  });
+
+  it('blocks a non-owner', async () => {
+    const st = stateWithBrowsers('nb2');
+    registerOverloadNonce(st.nonce);
+    const result = await handleCardAction({
+      operator: { open_id: 'ou_intruder' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'com.google.Chrome', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+    expect(restartBrowserMock).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).toContain('仅管理员可操作');
+  });
+
+  it('is one-shot per (nonce, bundleId): a second Arc click is rejected, but Chrome still works', async () => {
+    restartBrowserMock.mockResolvedValue({ ok: true, quit: true, relaunched: true });
+    const st = stateWithBrowsers('nb3');
+    registerOverloadNonce(st.nonce);
+    const arcClick = () => handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'company.thebrowser.Browser', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+
+    await arcClick();
+    const second = await arcClick();
+    expect(JSON.stringify(second)).toContain('已点过');
+    expect(restartBrowserMock).toHaveBeenCalledTimes(1);
+
+    const chrome = await handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'com.google.Chrome', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+    expect(JSON.stringify(chrome)).toContain('✓ 已重启 Chrome');
+    expect(restartBrowserMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases the claim on a failed restart so the owner can retry', async () => {
+    restartBrowserMock.mockResolvedValueOnce({ ok: false, quit: false, relaunched: false, error: '浏览器未在超时内退出' });
+    const st = stateWithBrowsers('nb4');
+    registerOverloadNonce(st.nonce);
+    const click = () => handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'company.thebrowser.Browser', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+
+    const first = await click();
+    expect(JSON.stringify(first)).toContain('未在超时内退出');
+    restartBrowserMock.mockResolvedValueOnce({ ok: true, quit: true, relaunched: true });
+    const retry = await click();
+    expect(JSON.stringify(retry)).toContain('✓ 已重启 Arc');
+    expect(restartBrowserMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('overload card — browser restart config-drift & failure handling', () => {
+  it('fail-closed: refuses (no restart) when the bundleId is no longer a live enabled target', async () => {
+    // A card button for a browser that config has since disabled/removed. Its
+    // bundleId is on st.browsers (it was rendered) but NOT in live targets.
+    const st = stateWithBrowsers('nb-drift');
+    st.browsers = [{ bundleId: 'com.disabled.Browser', label: 'Gone', memMB: 3000 }];
+    registerOverloadNonce(st.nonce);
+    const result = await handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'com.disabled.Browser', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+    expect(restartBrowserMock).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).toContain('配置已变更');
+  });
+
+  it('fail-closed: refuses when the bundleId is not on the card (forged value)', async () => {
+    const st = stateWithBrowsers('nb-forge');
+    registerOverloadNonce(st.nonce);
+    const result = await handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'com.google.Chrome-forged', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+    expect(restartBrowserMock).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).toContain('配置已变更');
+  });
+
+  it('quit-but-relaunch-failed: NOT marked ✓已重启, claim released for retry, failure visible as a card', async () => {
+    restartBrowserMock.mockResolvedValueOnce({ ok: true, quit: true, relaunched: false, error: 'open failed' });
+    const st = stateWithBrowsers('nb-relaunch');
+    registerOverloadNonce(st.nonce);
+    const click = () => handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'company.thebrowser.Browser', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+
+    const first = await click();
+    const s1 = JSON.stringify(first);
+    expect(s1).not.toContain('✓ 已重启 Arc');   // never falsely marked done
+    expect(s1).toContain('已退出但重开失败');
+    expect(s1).toContain('♻️ 重启 Arc');          // button still live (retry)
+
+    // retry succeeds → now marked done
+    restartBrowserMock.mockResolvedValueOnce({ ok: true, quit: true, relaunched: true });
+    const retry = await click();
+    expect(JSON.stringify(retry)).toContain('✓ 已重启 Arc');
+    expect(restartBrowserMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('slow failure returns a patchable CARD (has elements), not a toast-only result', async () => {
+    restartBrowserMock.mockResolvedValueOnce({ ok: false, quit: false, relaunched: false, error: '浏览器未在超时内退出' });
+    const st = stateWithBrowsers('nb-slowfail');
+    registerOverloadNonce(st.nonce);
+    const result = await handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'company.thebrowser.Browser', st: JSON.stringify(st) } },
+    }, deps, 'cli_alert');
+    // A card body (has `elements`), which the dispatcher can patch in after the
+    // 2.5s ACK — a toast-only result would be dropped.
+    expect(result).toHaveProperty('elements');
+    expect(JSON.stringify(result)).toContain('未在超时内退出');
+  });
+});

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -6865,6 +6865,56 @@ describe('card.action.trigger — ack-safe slow handlers', () => {
     expect(mockUpdateMessage).toHaveBeenCalledWith(MY_APP_ID, 'om_slow_card', JSON.stringify({ type: 'late-card' }));
   });
 
+  // Regression: browser-restart slow-fail visibility.
+  // the browser-restart handler can run up to ~12s (quit-wait), well past the
+  // 2.5s ACK window. A slow handler that resolves to a CARD body must be patched
+  // into the message in the background (owner sees the failure). Contrast with
+  // the very next test: a slow TOAST-only result is dropped, which is exactly
+  // why the handler now returns a failure CARD instead of a toast.
+  it('patches a slow browser-restart FAILURE card in after ACK (visible failure)', async () => {
+    let release!: () => void;
+    const failureCard = { elements: [{ tag: 'note', elements: [{ tag: 'lark_md', content: '⚠️ **Arc**：已退出但重开失败' }] }] };
+    handlers.handleCardAction.mockReturnValue(new Promise(resolve => { release = () => resolve(failureCard); }) as any);
+
+    vi.useFakeTimers();
+    const call = capturedHandlers['card.action.trigger']({
+      action: { value: { action: 'overload_restart_browser', bundleId: 'company.thebrowser.Browser' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_browser_fail' },
+    });
+    await vi.advanceTimersByTimeAsync(2500);
+    await expect(call).resolves.toEqual({ toast: { type: 'info', content: '操作已收到，后台处理中' } });
+
+    release();
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+
+    // The failure card is wrapped as a raw patch and applied to the message.
+    expect(mockUpdateMessage).toHaveBeenCalledWith(MY_APP_ID, 'om_browser_fail', JSON.stringify(failureCard));
+  });
+
+  it('drops a slow TOAST-only result after ACK (proves why failures must be cards)', async () => {
+    let release!: () => void;
+    handlers.handleCardAction.mockReturnValue(new Promise(resolve => { release = () => resolve({ toast: { type: 'error', content: 'too late' } }); }) as any);
+
+    vi.useFakeTimers();
+    const call = capturedHandlers['card.action.trigger']({
+      action: { value: { action: 'overload_restart_browser', bundleId: 'com.google.Chrome' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_toast_dropped' },
+    });
+    await vi.advanceTimersByTimeAsync(2500);
+    await expect(call).resolves.toEqual({ toast: { type: 'info', content: '操作已收到，后台处理中' } });
+
+    release();
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+
+    // Toast-only slow result is NOT patched (dropped) — logged instead.
+    expect(mockUpdateMessage).not.toHaveBeenCalledWith(MY_APP_ID, 'om_toast_dropped', expect.anything());
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('slow handler resolved to a toast-only result'));
+  });
+
   it('dedupes a repeated card action while the first copy is still running', async () => {
     let release!: () => void;
     handlers.handleCardAction.mockReturnValue(new Promise(resolve => { release = () => resolve(undefined); }) as any);

--- a/test/overload-card-browser-buttons.test.ts
+++ b/test/overload-card-browser-buttons.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOverloadAlertCard,
+  initialOverloadCardState,
+  OVERLOAD_ACTION_RESTART_BROWSER,
+  OVERLOAD_ACTION_NOOP,
+  type OverloadAlertAction,
+  type OverloadCardBrowser,
+} from '../src/core/host-overload-alert.js';
+
+const action: OverloadAlertAction = {
+  kind: 'entered',
+  reasons: ['memory'],
+  reading: { load15: 6.9, memTotalBytes: 32e9, memFreeBytes: 0.3e9 },
+  metrics: { load15: 6.9, loadPerCpu: 0.57, cpuCount: 12, memUsedFrac: 0.99 },
+};
+
+const browsers: OverloadCardBrowser[] = [
+  { bundleId: 'company.thebrowser.Browser', label: 'Arc', memMB: 6202 },
+  { bundleId: 'com.google.Chrome', label: 'Chrome', memMB: 1659 },
+];
+
+describe('overload card browser buttons', () => {
+  it('renders one restart button per running browser, each with its own bundleId', () => {
+    const st = initialOverloadCardState(action, { stopped: 0, idle: 0 }, 'n1', browsers);
+    const card = JSON.parse(buildOverloadAlertCard(st));
+    const btns = card.elements.flatMap((e: any) => e.tag === 'action' ? e.actions : []);
+    const restartBtns = btns.filter((b: any) => b.value?.action === OVERLOAD_ACTION_RESTART_BROWSER);
+    expect(restartBtns.map((b: any) => b.value.bundleId)).toEqual([
+      'company.thebrowser.Browser', 'com.google.Chrome',
+    ]);
+    expect(restartBtns[0].text.content).toBe('♻️ 重启 Arc · 6.1 GB');
+    expect(restartBtns[1].text.content).toBe('♻️ 重启 Chrome · 1.6 GB');
+  });
+
+  it('shows NO browser buttons when nothing is running', () => {
+    const st = initialOverloadCardState(action, { stopped: 1, idle: 2 }, 'n2', []);
+    const card = JSON.parse(buildOverloadAlertCard(st));
+    const btns = card.elements.flatMap((e: any) => e.tag === 'action' ? e.actions : []);
+    expect(btns.some((b: any) => b.value?.action === OVERLOAD_ACTION_RESTART_BROWSER)).toBe(false);
+  });
+
+  it('marks a restarted browser done (disabled ✓) while the other stays clickable', () => {
+    const st = initialOverloadCardState(action, { stopped: 0, idle: 0 }, 'n3', browsers);
+    st.restartedBrowsers = ['company.thebrowser.Browser'];
+    const card = JSON.parse(buildOverloadAlertCard(st));
+    const btns = card.elements.flatMap((e: any) => e.tag === 'action' ? e.actions : []);
+    const arc = btns.find((b: any) => b.text.content.includes('Arc'));
+    const chrome = btns.find((b: any) => b.text.content.includes('Chrome'));
+    expect(arc.disabled).toBe(true);
+    expect(arc.text.content).toBe('✓ 已重启 Arc');
+    expect(arc.value.action).toBe(OVERLOAD_ACTION_NOOP);
+    expect(chrome.disabled).toBeUndefined();
+    expect(chrome.value.action).toBe(OVERLOAD_ACTION_RESTART_BROWSER);
+  });
+});
+
+describe('overload card — >4 browser buttons split into rows of 4', () => {
+  it('chunks 5 browser targets into two action rows (4 + 1)', () => {
+    const many: OverloadCardBrowser[] = Array.from({ length: 5 }, (_, i) => ({
+      bundleId: `com.b${i}.Browser`, label: `B${i}`, memMB: 1000 + i,
+    }));
+    const st = initialOverloadCardState(action, { stopped: 0, idle: 0 }, 'n-many', many);
+    const card = JSON.parse(buildOverloadAlertCard(st));
+    const actionRows = card.elements.filter((e: any) => e.tag === 'action');
+    // row 0 = clean+suspend, rows 1..N = browser buttons chunked by 4.
+    const browserRows = actionRows.filter((r: any) =>
+      r.actions.some((b: any) => b.value?.action === OVERLOAD_ACTION_RESTART_BROWSER || String(b.text.content).includes('重启 B')));
+    expect(browserRows).toHaveLength(2);
+    expect(browserRows[0].actions).toHaveLength(4);
+    expect(browserRows[1].actions).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 背景

机器过载告警卡原本的两个降压按钮（清僵尸会话 / 挂起闲置会话），在僵尸和闲置都为 0 时几乎释放不了内存——开发机上真正的内存大头通常是浏览器（Arc / Chrome / Edge 各自动辄几个 GB），而不是 botmux 会话。

## 改了什么

给过载告警卡加了「按浏览器」的独立重启按钮：点某个浏览器 → 优雅退出并重开（标签页会恢复），从而释放该浏览器占用的大块内存。

- `core/browser-restart.ts`：可配置目标清单，默认内置 Arc / Chrome / Edge，**绝不写死**。全局配置 `hostOverloadAlert.browserRestartTargets` 可按 bundleId 覆盖 label/openArgs/enabled、追加新浏览器（Safari/Brave…）、或关掉某个默认项，全部零代码改动。纯函数 resolver + label 格式化 + 按 bundleId 的 quit/relaunch（不强杀）。
- 卡片只渲染「本机此刻在跑且占内存」的浏览器，各自一个独立按钮，标注实时内存（如 `♻️ 重启 Arc · 6.1 GB`）；Chrome/Edge 重启带 `--restore-last-session` 恢复标签。
- 处理器：owner 强闸门 + 按 `(nonce, bundleId)` 分开的一次性核销——同一张卡可分别重启多个浏览器，但每个仅一次；重启失败会释放核销以便重试；有未保存弹窗退不掉则放弃并提示，不强杀。

## 安全与准确性

- **配置漂移 fail-closed**：执行前校验 bundleId 同时在卡片 `st.browsers` 和 live 的 enabled targets 里，缺一即拒绝，旧卡杀不掉已下架的浏览器。
- **慢失败可见**：失败返回可 patch 的整卡（非 toast）——处理最长 ~12s 超过 2.5s ACK 窗口，toast-only 会被 dispatcher 丢弃。
- **重开失败不标成功**：quit 成功但 relaunch 失败时不标「✓已重启」、不烧核销，保留可重试。
- **存活探测 fail-safe**：quit 前解析一次稳定 appPath，轮询仅用该路径跑 ps；appPath 解析不到或 ps 出错时按「仍在跑」处理，绝不盲目 relaunch。
- **进程归属左边界匹配**：命令 argv0 须以 appPath 起始，排除 `/Volumes/Backup/.../Arc.app`、`.app-copy` 兄弟目录、以及路径仅作为无关参数的情况。
- 其余：去重 key 纳入 bundleId；按钮每行最多 4 个分行；非 darwin 快速返回；探测/重启函数可注入依赖便于测试。

## 测试

- 新增浏览器相关测试 35 个：`browser-restart` 21、`overload-card-browser-buttons` 4、`card-handler-browser-restart` 8，外加 `event-dispatcher` 慢失败可见性 2 个。
- 覆盖：目标解析（默认/覆盖/追加/禁用/垃圾输入）、label 格式化、存活探测 fail-safe（unknown 路径 / ps 出错不盲目 relaunch）、左边界进程归属（备份根 / -copy / 参数误计反例）、卡片按钮渲染与超 4 分行、配置漂移 fail-closed、慢失败走可 patch 卡片、重开失败保留重试。
- 相关 overload / card-handler / dispatcher 共 426 测全绿，既有测试零回归；`pnpm build` + `tsc --noEmit` 均绿。
- 本机实测探测：Arc / Chrome 正常识别并计内存，Edge 未运行不出按钮。
