### PR TITLE
fix(dsh): 校验运行时协议响应

### DIFF
--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -147,6 +147,29 @@ function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Keep the wire checks aligned with the official dsh SDK client. A successful
+ *  JSON-RPC envelope with a malformed result is still a protocol failure. */
+function parseInitializeResult(result: unknown): { serverInfo: { name: string; version: string } } {
+  if (!isRecord(result)
+    || !isRecord(result.serverInfo)
+    || typeof result.serverInfo.name !== 'string'
+    || typeof result.serverInfo.version !== 'string') {
+    throw new Error(`dsh protocol error: initialize returned no server identity: ${JSON.stringify(result)}`);
+  }
+  return { serverInfo: { name: result.serverInfo.name, version: result.serverInfo.version } };
+}
+
+function parsePromptMessageId(result: unknown): string {
+  if (!isRecord(result) || typeof result.messageId !== 'string') {
+    throw new Error(`dsh protocol error: session/prompt returned no message id: ${JSON.stringify(result)}`);
+  }
+  return result.messageId;
+}
+
 function emitMarker(kind: string, payload: unknown): void {
   output.marker(kind, payload);
 }
@@ -507,15 +530,16 @@ async function runTurn(content: string): Promise<void> {
   });
 
   try {
-    const ack = await client.request<{ messageId?: string }>('session/prompt', {
+    const ack = await client.request<unknown>('session/prompt', {
       sessionId: dshSessionId,
       contentBlocks: [{ type: 'text', text: promptContent }],
     }, PROMPT_ACK_TIMEOUT_MS);
+    const messageId = parsePromptMessageId(ack);
     // The ACK's messageId correlates this turn's events: notifications may
     // already be buffered (they can precede the response), and a late idle
     // from the previous turn must not settle this one.
-    if (activeTurn && typeof ack.messageId === 'string') {
-      activeTurn.messageId = ack.messageId;
+    if (activeTurn) {
+      activeTurn.messageId = messageId;
       tryClaimReceipt(activeTurn);
     }
     // Commit firstTurn only after the prompt was accepted: a rejected first
@@ -645,12 +669,13 @@ async function main(): Promise<void> {
   client.start();
 
   const model = args.model?.trim() || DEFAULT_MODEL;
-  const serverInfo = await client.request<{ serverInfo?: { name?: string; version?: string } }>(
+  const initializeResult = await client.request<unknown>(
     'initialize',
     { cwd, provider: 'deepseek-official', model, maxTokens: DEFAULT_MAX_TOKENS },
     HANDSHAKE_TIMEOUT_MS,
   );
-  writeLine(`dsh connected (${serverInfo?.serverInfo?.name ?? 'unknown'} ${serverInfo?.serverInfo?.version ?? ''}).`);
+  const { serverInfo } = parseInitializeResult(initializeResult);
+  writeLine(`dsh connected (${serverInfo.name} ${serverInfo.version}).`);
 
   if (process.stdin.isTTY) process.stdin.setRawMode(true);
   process.stdin.resume();

--- a/test/dsh-runner.test.ts
+++ b/test/dsh-runner.test.ts
@@ -244,6 +244,38 @@ describe('dsh-runner', () => {
     expect(prompts[1].prompt.contentBlocks[0].text).toContain('第二次');
   });
 
+  it('rejects a prompt ACK without a message id instead of waiting for the turn watchdog', async () => {
+    h = spawnRunner('bad-prompt-ack', ['--turn-timeout-ms', '10000']);
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('第一次'));
+    await waitFor(() => parseMarkers(h.stdout).filter(m => m.kind === 'final').length >= 1, {
+      timeout: 3000,
+      label: 'protocol error final',
+    });
+    const errorFinal = parseMarkers(h.stdout).find(m => m.kind === 'final')!;
+    expect(errorFinal.payload.content).toContain('session/prompt returned no message id');
+
+    h.child.stdin.write(makeFrame('第二次'));
+    await waitFor(() => parseMarkers(h.stdout).filter(m => m.kind === 'final').length >= 2, { label: 'success final' });
+
+    const prompts = readPrompts(h);
+    expect(prompts).toHaveLength(2);
+    expect(prompts[1].prompt.contentBlocks[0].text).toContain('<botmux_identity>');
+    expect(prompts[1].prompt.contentBlocks[0].text).toContain('第二次');
+  });
+
+  it('rejects an initialize response without a server identity', async () => {
+    h = spawnRunner('bad-initialize');
+    const exitPromise = new Promise<number | null>(resolve => h!.child.on('exit', resolve));
+    const code = await exitPromise;
+
+    expect(code).toBe(1);
+    expect(h.stderr).toContain('initialize returned no server identity');
+    expect(h.stdout).not.toContain('dsh connected');
+    expect(h.stdout).not.toContain('›');
+  });
+
   it('reaps a wedged turn with the watchdog and exits for restart', async () => {
     h = spawnRunner('hang', ['--turn-timeout-ms', '500']);
     await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });

--- a/test/fixtures/fake-dsh-server.mjs
+++ b/test/fixtures/fake-dsh-server.mjs
@@ -22,6 +22,9 @@ import { appendFileSync } from 'node:fs';
  *                     response (real async ordering)
  *   retry           - first session/prompt fails with a JSON-RPC error, the
  *                     second runs the happy path (preamble must survive)
+ *   bad-prompt-ack  - first session/prompt returns no messageId, the second
+ *                     runs the happy path (preamble must survive)
+ *   bad-initialize  - initialize returns no server identity
  *   error           - session/prompt fails with a JSON-RPC error
  *   turn-error      - prompt accepted, but the turn ends with an LLM error
  *                     (like the real 401 path): no assistant/message, a
@@ -182,6 +185,10 @@ function handleLine(line) {
     return;
   }
   if (msg.method === 'initialize') {
+    if (scenario === 'bad-initialize') {
+      send({ jsonrpc: '2.0', id: msg.id, result: {} });
+      return;
+    }
     send({
       jsonrpc: '2.0',
       id: msg.id,
@@ -191,6 +198,11 @@ function handleLine(line) {
   }
   if (msg.method === 'session/prompt') {
     if (logPath) appendFileSync(logPath, JSON.stringify({ prompt: msg.params }) + '\n');
+    if (scenario === 'bad-prompt-ack' && promptCount === 0) {
+      promptCount++;
+      send({ jsonrpc: '2.0', id: msg.id, result: {} });
+      return;
+    }
     if (scenario === 'error' || (scenario === 'retry' && promptCount === 0)) {
       promptCount++;
       send({


### PR DESCRIPTION
## 问题

dsh runner 过去把 JSON-RPC 成功响应直接当作类型正确的协议结果：

- `session/prompt` 若返回对象但缺少 `messageId`，本轮无法认领对应的 inbox receipt，却仍会等待事件，最终卡满默认 10 分钟看门狗。
- `initialize` 若缺少 `serverInfo.name/version`，仍会显示 `dsh connected (unknown)` 并进入 ready，掩盖运行时协议不兼容。

DeepSeek Harness 官方 SDK 会在这两种响应上立即抛出协议错误，botmux runner 应保持相同边界。

## 改动

- 在 dsh JSON-RPC 边界校验 `initialize` 的服务端身份和 `session/prompt` 的消息 ID。
- 非法 prompt ACK 立即结束当前请求并返回明确错误，不再等待 turn watchdog；首轮身份前缀保留给下一次有效重试。
- 非法 initialize 响应在 runner 输出 ready 前直接启动失败。
- 扩展 fake dsh runtime，覆盖两种畸形成功响应及重试行为。

## 影响面

- 仅修改 dsh runner 及其测试 fixture。
- 不涉及其它 CLI、PTY/Tmux 后端、IM 路由或公共 worker 链路。
- 合法 DSH 协议响应的正常多轮、事件乱序、沙盒持久化行为保持不变。

## 验证

- `pnpm vitest run test/dsh-runner.test.ts test/worker-dsh-turn.integration.test.ts`：14 passed
- `pnpm build`：通过
- `pnpm test`：当前机器未全绿；失败集中在无关的 bwrap/MCP 沙盒清理权限、进程名假设以及 Codex App tmux 时序用例，本 PR 的 dsh 定向测试均通过。
