### PR TITLE
fix(test): dsh 沙盒集成用例按 bwrap 运行时可用性 gate，CI 放开 userns 限制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,22 @@ jobs:
         with:
           node-version: 22
 
+      # dsh 沙盒集成用例要在 runner 上真跑 bwrap:ubuntu-24.04 默认
+      # kernel.apparmor_restrict_unprivileged_userns=1 且 bubblewrap 包不带
+      # AppArmor profile,bwrap 一起 userns 就秒退("setting up uid map:
+      # Permission denied",exit 1)。这里放开限制并预装 bubblewrap,让沙盒
+      # 用例在 CI 上真正执行。整步 best-effort:哪一步失败都不阻塞——测试侧
+      # 有 bwrap 运行时探测 gate,跑不了会 loud skip 而不是超时挂掉。
+      - name: Enable bwrap sandbox for integration tests (best-effort)
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          command -v bwrap >/dev/null || sudo apt-get install -y bubblewrap || true
+          if bwrap --bind / / --unshare-user -- /bin/true 2>/dev/null; then
+            echo "bwrap userns OK — sandbox integration tests will run for real"
+          else
+            echo "bwrap still unavailable — sandbox integration tests will skip (see test-side gate)"
+          fi
+
       - run: npm install -g pnpm@9.5.0
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/test/worker-dsh-turn.integration.test.ts
+++ b/test/worker-dsh-turn.integration.test.ts
@@ -12,7 +12,23 @@ import { chmodSync, copyFileSync, existsSync, mkdtempSync, rmSync } from 'node:f
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { probeHostCredentialIsolationMechanism } from '../src/adapters/backend/sandbox.js';
 import type { DaemonToWorker, WorkerToDaemon } from '../src/types.js';
+
+// Dep gate for the sandbox case (same shape as sandbox.test.ts): the direct
+// sandbox must actually ESTABLISH bwrap's namespaces (--unshare-user & co.),
+// not merely find bwrap on PATH. Stock Ubuntu 23.10+ (incl. GitHub's
+// ubuntu-24.04 runners and colima VMs) sets
+// kernel.apparmor_restrict_unprivileged_userns=1 and the 24.04 bubblewrap
+// package ships no AppArmor profile, so bwrap dies instantly with
+// "bwrap: setting up uid map: Permission denied" (exit 1) — an environment
+// limitation, not a code bug. Probe the product's own namespace set and skip
+// loudly when the host can't do it; ci.yml lifts the restriction so the case
+// still truly runs on CI runners.
+const sandboxHost = probeHostCredentialIsolationMechanism();
+if (!sandboxHost.supported) {
+  console.warn(`[worker-dsh-turn] sandbox case will SKIP — host cannot establish the file sandbox: ${sandboxHost.reason}`);
+}
 
 const children = new Set<ChildProcess>();
 const tempDirs = new Set<string>();
@@ -147,7 +163,7 @@ describe('dsh worker final_output integration', () => {
     }
   }, 60_000);
 
-  it('survives the file sandbox and persists config/sessions to the real HOME', async () => {
+  it.skipIf(!sandboxHost.supported)('survives the file sandbox and persists config/sessions to the real HOME', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-worker-dsh-sb-'));
     tempDirs.add(root);
     const fakeDsh = join(root, 'fake-dsh-server');


### PR DESCRIPTION
## 问题

master 自 #858 合入起 CI 持续红：`worker-dsh-turn.integration.test.ts` 的「survives the file sandbox…」用例在 GitHub ubuntu-24.04 runner 上必挂。#858 合入前其 PR 分支上没有任何跑完的 CI（run 停在待审批），第一次真跑就是 merge push，当场即挂——该用例在 GitHub runner 上从未绿过。此后 master 每个 push 与所有 open PR 全部继承同一条红。

## 根因（环境限制，非代码 bug）

沙盒用例走 Linux bwrap DIRECT 模式，必带 `--unshare-user`。ubuntu-24.04（GitHub runner 与 stock 24.04 一致）默认 `kernel.apparmor_restrict_unprivileged_userns=1`，且 24.04 的 bubblewrap 包不带 AppArmor profile，bwrap 一建 userns 就秒退：

```
bwrap: setting up uid map: Permission denied   (exit 1)
```

与 CI 日志形态完全吻合（`Sandbox ON` 后 8ms `DeepSeek Harness exited (code: 1)` → 用例 30s 超时）。在 Ubuntu 24.04.4 VM 复现同样报错；同一 VM `sysctl` 放开限制后用例真跑即绿，证明用例本身健康。

## 修复

- **测试侧 gate**（学 `sandbox.test.ts` 的 dep gate 形态）：沙盒用例改 `it.skipIf`，复用产品自己的 `probeHostCredentialIsolationMechanism()` 做运行时探测——bwrap 在场且能真建 user/pid/ipc/uts namespace 才跑；跑不了 loud skip（`console.warn` 带原因），不再超时挂整个 suite。顺带覆盖「Linux 开发机没装 bwrap」场景（此前同样会挂）。
- **CI 侧环境修复**：`ci.yml` 在 `pnpm test` 前 best-effort 放开 `kernel.apparmor_restrict_unprivileged_userns` 并预装 bubblewrap，让该用例在 CI 上**真正执行**而不是永久 skip；任一步失败都不阻塞，gate 兜底，并打一行冒烟结果便于在日志里确认走了哪条路。

## 影响面

- 产品代码零改动；只动 1 个测试文件 + ci.yml。
- macOS Seatbelt 路径不受影响：探测返回 supported，用例照常真跑（本地实测绿）。
- Linux bwrap 可用时照常真跑；不可用时由超时失败变为带原因的 skip。
- 其它平台/CLI/会话类型不涉及（未动 `adapters/`、`core/` 共用路径）。

## 实测验证

- macOS（本机）：`pnpm vitest run test/worker-dsh-turn.integration.test.ts` → 2 passed（沙盒用例经 Seatbelt 真跑，3.2s）。
- Ubuntu 24.04.4 VM（arm64，`apparmor_restrict_unprivileged_userns=1`，与 runner 同态）：
  - 修复前：复现 CI 失败——`DeepSeek Harness exited (code: 1)` → `worker dsh timeout`；
  - 修复后：沙盒用例 skip 并输出 `[worker-dsh-turn] sandbox case will SKIP — … bubblewrap cannot establish the required user/mount/PID namespaces`，另一用例照常绿；
  - `sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` 放开后：沙盒用例**真跑通过**（含 cordis.yml / sessions 落真 HOME 的断言）。
- 本 PR 的 CI run：见 checks（预期步骤日志出现 `bwrap userns OK — sandbox integration tests will run for real` 且用例真跑）。
