### PR TITLE
fix(adopt): 兼容 Codex Desktop 新版会话记录

### DIFF
--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -246,6 +246,35 @@ function cleanUserPromptForTitle(raw: string): string | null {
   return raw;
 }
 
+/** Extract text inputs from a Codex/TRAE persisted user response item. */
+function rawRolloutUserTexts(content: unknown): string[] {
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((part) => {
+    const rec = asRecord(part);
+    const text = rec?.type === 'input_text' && typeof rec.text === 'string'
+      ? rec.text.trim()
+      : '';
+    return text ? [text] : [];
+  });
+}
+
+/** Codex persists startup context as role:user response items. These are not
+ *  human prompts and must not become /adopt titles. */
+const ROLLOUT_SYNTHETIC_USER_PATTERNS: readonly RegExp[] = [
+  /^# AGENTS\.md instructions(?:\s+for\b)?/,
+  /^<environment_context\b/,
+  /^<skills_instructions\b/,
+  /^<permissions instructions\b/,
+  /^<collaboration_mode\b/,
+  /^<apps_instructions\b/,
+  /^<plugins_instructions\b/,
+];
+
+function cleanRolloutUserPromptForTitle(raw: string): string | null {
+  if (ROLLOUT_SYNTHETIC_USER_PATTERNS.some((re) => re.test(raw))) return null;
+  return raw;
+}
+
 export async function discoverClaudeFamilySessions(
   dataDir: string,
   limit: number,
@@ -262,10 +291,10 @@ export async function discoverClaudeFamilySessions(
 // ─── Codex / TRAE rollout (codex, traex) ─────────────────────────────────────
 
 /** Parse one Codex/TRAE rollout. `session_meta` carries the resume id + cwd;
- *  the first `event_msg`/`user_message` carries the user's first prompt (the
- *  `response_item` role:user entries include the synthetic
- *  <environment_context>/<permissions> preamble, so we prefer user_message).
- *  Streamed line by line, stopping once id + cwd + title are found. */
+ *  `event_msg`/`user_message` is the preferred title source. Codex Desktop may
+ *  persist user input only as `response_item` messages, so those are accepted
+ *  as an EOF fallback after filtering the synthetic startup context. Streamed
+ *  line by line; a legacy user_message can stop the scan early. */
 async function parseRolloutTranscript(
   path: string,
   mtimeMs: number,
@@ -274,7 +303,13 @@ async function parseRolloutTranscript(
   // Accumulate into an object — closure mutation of plain `let` defeats TS's
   // control-flow narrowing at the post-loop guard; object properties keep their
   // declared type.
-  const acc: { id: string | null; cwd: string | null; title: string; botmux: boolean } = { id: null, cwd: null, title: '', botmux: false };
+  const acc: { id: string | null; cwd: string | null; title: string; fallbackTitle: string; botmux: boolean } = {
+    id: null,
+    cwd: null,
+    title: '',
+    fallbackTitle: '',
+    botmux: false,
+  };
   let excluded = false;
   await forEachJsonLine(path, (rec) => {
     const payload = asRecord(rec.payload);
@@ -289,11 +324,18 @@ async function parseRolloutTranscript(
     } else if (rec.type === 'event_msg' && payload?.type === 'user_message' && typeof payload.message === 'string') {
       if (isBotmuxInjected(payload.message)) { acc.botmux = true; return true; } // botmux-origin → drop
       if (!acc.title) acc.title = truncateTitle(payload.message);
+    } else if (rec.type === 'response_item' && payload?.type === 'message' && payload.role === 'user') {
+      for (const raw of rawRolloutUserTexts(payload.content)) {
+        if (isBotmuxInjected(raw)) { acc.botmux = true; return true; }
+        const clean = cleanRolloutUserPromptForTitle(raw);
+        if (!acc.fallbackTitle && clean) acc.fallbackTitle = truncateTitle(clean);
+      }
     }
     return Boolean(acc.id && acc.cwd && acc.title);
   });
-  if (excluded || acc.botmux || !acc.id || !acc.cwd || !acc.title) return null;
-  return { cliSessionId: acc.id, cwd: acc.cwd, title: acc.title, lastActivityAt: mtimeMs };
+  const title = acc.title || acc.fallbackTitle;
+  if (excluded || acc.botmux || !acc.id || !acc.cwd || !title) return null;
+  return { cliSessionId: acc.id, cwd: acc.cwd, title, lastActivityAt: mtimeMs };
 }
 
 export async function discoverRolloutSessions(

--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -102,11 +102,14 @@ const BOTMUX_INJECTION_PATTERNS: readonly RegExp[] = [
   // blocks first, then the wrapper. External prompts may discuss these tags
   // mid-text, but they don't start with this structural envelope.
   /^<user_message>[\s\S]*?<\/user_message>/,
+  // Routing is the stable first block, but the context blocks between it and
+  // the user envelope evolve over time. Match their ordering boundary instead
+  // of maintaining a whitelist that breaks whenever a new block is inserted.
+  /^<botmux_routing>[\s\S]*?<\/botmux_routing>[\s\S]*?<user_message>[\s\S]*?<\/user_message>/,
   // The optional <whiteboard> block sits between <botmux_reminder> and
   // <user_message> (new-topic prompts place it before <user_message> too), so
   // each reminder-bearing envelope makes it optional there to stay structural —
   // a botmux-generated prompt with <whiteboard> must still drop, not get adopted.
-  /^<botmux_routing>[\s\S]*?<\/botmux_routing>\s*(?:<identity>[\s\S]*?<\/identity>\s*)?<session_id>[^<]+<\/session_id>\s*(?:<role\b[\s\S]*?<\/role>\s*)?(?:<botmux_reminder>[\s\S]*?<\/botmux_reminder>\s*)?(?:<whiteboard\b[\s\S]*?<\/whiteboard>\s*)?<user_message>[\s\S]*?<\/user_message>/,
   /^<role\s+context="(?:team|group)"\s+chat_id="[^"]+">[\s\S]*?<\/role>\s*(?:<session_id>[^<]+<\/session_id>\s*)?(?:<botmux_reminder>[\s\S]*?<\/botmux_reminder>\s*)?(?:<whiteboard\b[\s\S]*?<\/whiteboard>\s*)?<user_message>[\s\S]*?<\/user_message>/,
   /^<session_id>[^<]+<\/session_id>\s*(?:<role\b[\s\S]*?<\/role>\s*)?(?:<botmux_reminder>[\s\S]*?<\/botmux_reminder>\s*)?(?:<whiteboard\b[\s\S]*?<\/whiteboard>\s*)?<user_message>[\s\S]*?<\/user_message>/,
   /^<botmux_reminder>[\s\S]*?<\/botmux_reminder>\s*(?:<whiteboard\b[\s\S]*?<\/whiteboard>\s*)?<user_message>[\s\S]*?<\/user_message>/,
@@ -268,6 +271,8 @@ const ROLLOUT_SYNTHETIC_USER_PATTERNS: readonly RegExp[] = [
   /^<collaboration_mode\b/,
   /^<apps_instructions\b/,
   /^<plugins_instructions\b/,
+  /^<codex_internal_context\b/,
+  /^<turn_aborted\b/,
 ];
 
 function cleanRolloutUserPromptForTitle(raw: string): string | null {

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -205,6 +205,155 @@ describe('discoverRolloutSessions (codex / traex)', () => {
     });
   });
 
+  it('discovers Codex Desktop rollouts whose real user input exists only as a response_item', async () => {
+    writeRollout('2026/08/14', 'rollout-codex-desktop-response-item.jsonl', [
+      {
+        type: 'session_meta',
+        payload: {
+          id: 'sid-codex-desktop-response-item',
+          cwd: '/root/desktop-project',
+          originator: 'Codex Desktop',
+          source: 'vscode',
+        },
+      },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: '# AGENTS.md instructions for /root/desktop-project\n\n<INSTRUCTIONS>...</INSTRUCTIONS>' },
+            { type: 'input_text', text: '<environment_context>\n  <cwd>/root/desktop-project</cwd>\n</environment_context>' },
+          ],
+        },
+      },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'index the uploaded knowledge bundle' }],
+        },
+      },
+    ]);
+
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      cliSessionId: 'sid-codex-desktop-response-item',
+      cwd: '/root/desktop-project',
+      title: 'index the uploaded knowledge bundle',
+    });
+  });
+
+  it('prefers the legacy user_message title when a rollout contains both formats', async () => {
+    writeRollout('2026/08/14', 'rollout-codex-mixed-user-formats.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-codex-mixed-user-formats', cwd: '/root/mixed-project' } },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'response-item fallback title' }],
+        },
+      },
+      { type: 'event_msg', payload: { type: 'user_message', message: 'legacy event title' } },
+    ]);
+
+    expect((await discoverRolloutSessions(sessionsRoot, 10))[0]?.title).toBe('legacy event title');
+  });
+
+  it('keeps TRAE response_item rollouts discoverable through the shared parser', async () => {
+    writeRollout('2026/08/14', 'rollout-traex-response-item.jsonl', [
+      {
+        type: 'session_meta',
+        payload: {
+          id: 'sid-traex-response-item',
+          cwd: '/root/traex-project',
+          originator: 'TRAE',
+          source: 'traex',
+        },
+      },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'review the shared rollout parser' }],
+        },
+      },
+    ]);
+
+    expect(await discoverRolloutSessions(sessionsRoot, 10)).toEqual([
+      expect.objectContaining({
+        cliSessionId: 'sid-traex-response-item',
+        cwd: '/root/traex-project',
+        title: 'review the shared rollout parser',
+      }),
+    ]);
+  });
+
+  it('skips persisted Codex runtime instructions before choosing a response_item title', async () => {
+    writeRollout('2026/08/15', 'rollout-codex-desktop-runtime-context.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-codex-runtime-context', cwd: '/root/context-project' } },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: '# AGENTS.md instructions\n\n<INSTRUCTIONS>...</INSTRUCTIONS>' },
+            { type: 'input_text', text: '<skills_instructions>...</skills_instructions>' },
+            { type: 'input_text', text: '<permissions instructions>...</permissions instructions>' },
+            { type: 'input_text', text: '<collaboration_mode>...</collaboration_mode>' },
+            { type: 'input_text', text: '<apps_instructions>...</apps_instructions>' },
+            { type: 'input_text', text: '<plugins_instructions>...</plugins_instructions>' },
+          ],
+        },
+      },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'the first prompt typed by the user' }],
+        },
+      },
+    ]);
+
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+
+    expect(out[0]?.title).toBe('the first prompt typed by the user');
+  });
+
+  it('drops botmux-origin rollouts when the injected prompt exists only as a response_item', async () => {
+    writeRollout('2026/08/16', 'rollout-codex-botmux-response-item.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-codex-botmux-response-item', cwd: '/root/botmux-project' } },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: '<environment_context>...</environment_context>' }],
+        },
+      },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{
+            type: 'input_text',
+            text: '<botmux_routing>\nreply with botmux send\n</botmux_routing>\n\n<session_id>session-123</session_id>\n\n<role context="team" chat_id="oc_team">\nreviewer\n</role>\n\n<user_message>\nfix the parser\n</user_message>',
+          }],
+        },
+      },
+    ]);
+
+    expect(await discoverRolloutSessions(sessionsRoot, 10)).toEqual([]);
+  });
+
   it('drops botmux-origin rollouts (user_message carries the injected wrapper)', async () => {
     writeRollout('2026/06/12', 'rollout-bmx.jsonl', [
       { type: 'session_meta', payload: { id: 'sid-bmx', cwd: '/root/x' } },

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -327,6 +327,44 @@ describe('discoverRolloutSessions (codex / traex)', () => {
     expect(out[0]?.title).toBe('the first prompt typed by the user');
   });
 
+  it('does not discover a rollout whose only user item is Codex goal context', async () => {
+    writeRollout('2026/08/15', 'rollout-codex-goal-context-only.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-codex-goal-context-only', cwd: '/root/goal-project' } },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{
+            type: 'input_text',
+            text: '<codex_internal_context source="goal">\nContinue pursuing the active goal.\n</codex_internal_context>',
+          }],
+        },
+      },
+    ]);
+
+    expect(await discoverRolloutSessions(sessionsRoot, 10)).toEqual([]);
+  });
+
+  it('does not discover a rollout whose only user item is an aborted-turn marker', async () => {
+    writeRollout('2026/08/15', 'rollout-codex-turn-aborted-only.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-codex-turn-aborted-only', cwd: '/root/aborted-project' } },
+      {
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{
+            type: 'input_text',
+            text: '<turn_aborted>\nThe previous turn was interrupted by the user.\n</turn_aborted>',
+          }],
+        },
+      },
+    ]);
+
+    expect(await discoverRolloutSessions(sessionsRoot, 10)).toEqual([]);
+  });
+
   it('drops botmux-origin rollouts when the injected prompt exists only as a response_item', async () => {
     writeRollout('2026/08/16', 'rollout-codex-botmux-response-item.jsonl', [
       { type: 'session_meta', payload: { id: 'sid-codex-botmux-response-item', cwd: '/root/botmux-project' } },
@@ -345,7 +383,7 @@ describe('discoverRolloutSessions (codex / traex)', () => {
           role: 'user',
           content: [{
             type: 'input_text',
-            text: '<botmux_routing>\nreply with botmux send\n</botmux_routing>\n\n<session_id>session-123</session_id>\n\n<role context="team" chat_id="oc_team">\nreviewer\n</role>\n\n<user_message>\nfix the parser\n</user_message>',
+            text: '<botmux_routing>\nreply with botmux send\n</botmux_routing>\n\n<botmux_builtin_skills>\nuse the built-in skills\n</botmux_builtin_skills>\n\n<identity>\n  <name>Codex Bot</name>\n  <open_id>ou_bot</open_id>\n</identity>\n\n<session_id>session-123</session_id>\n\n<user_message>\nfix the parser\n</user_message>',
           }],
         },
       },


### PR DESCRIPTION
## 背景

Fixes #878.

Codex Desktop / CLI 0.147 的部分 rollout 不再写入 `event_msg/user_message`，真实用户输入只存在于 `response_item/message(role=user)`。现有磁盘恢复扫描器因此无法生成标题，导致 `/adopt` 找不到 Codex 自身仍可恢复的 session。

## 改动

- 保留并继续优先旧版 `event_msg/user_message` 标题路径。
- 将 `response_item` 的 `input_text` 作为文件结束时的 fallback。
- 过滤 AGENTS、environment、permissions、skills、collaboration、apps、plugins 等 Codex 合成上下文。
- 在新版记录结构下继续识别并排除 botmux 自身注入的 session。
- 为 Codex Desktop、TRAE 共用解析路径、混合格式优先级和 botmux envelope 增加回归测试。

## 影响范围

仅修改 Codex/TRAE 磁盘 resumable session discovery；未改动 live backend、Claude-family、Antigravity、worker 或 IM 路径。现有 exclude、limit 与旧格式行为保持不变。

## 验证

- `pnpm build`：通过
- `pnpm exec vitest run --project unit test/resumable-session-discovery.test.ts`：31/31 通过
- `pnpm workflow-core:test`：通过
- 使用脱敏前真实 rollout 只读验证：目标 session 可发现并生成标题；已知 botmux-origin session 仍被隐藏
- 本机完整 `pnpm test`：15,195 通过；31 项为无关环境依赖失败（系统 Git 2.20 不支持测试使用的 `git init -b`、缺少 bwrap，以及 host/runtime 相关用例），相关 discovery 套件无失败
