### PR TITLE
fix(dsh): 配置路径无效时启动失败

### DIFF
--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -163,7 +163,12 @@ function prompt(): void {
  *  vendored composition is materialized under ~/.botmux/dsh. */
 function resolveConfigPath(): string {
   const fromEnv = process.env.DSH_CORDIS_CONFIG?.trim();
-  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  if (fromEnv) {
+    if (!existsSync(fromEnv)) {
+      throw new Error(`DSH_CORDIS_CONFIG does not exist: ${fromEnv}`);
+    }
+    return fromEnv;
+  }
   const dir = join(homedir(), '.botmux', 'dsh');
   mkdirSync(dir, { recursive: true });
   const path = join(dir, 'cordis.yml');

--- a/test/dsh-runner.test.ts
+++ b/test/dsh-runner.test.ts
@@ -51,7 +51,11 @@ async function waitFor(
   throw new Error(`timed out waiting for ${label}`);
 }
 
-function spawnRunner(scenario: string, extraArgs: string[] = []): Harness {
+function spawnRunner(
+  scenario: string,
+  extraArgs: string[] = [],
+  envOverrides: NodeJS.ProcessEnv = {},
+): Harness {
   const home = mkdtempSync(join(tmpdir(), 'dsh-runner-test-'));
   const logPath = join(home, 'prompts.jsonl');
   const child = spawn(process.execPath, ['--import', 'tsx', RUNNER_PATH,
@@ -67,6 +71,8 @@ function spawnRunner(scenario: string, extraArgs: string[] = []): Harness {
       HOME: home,
       FAKE_DSH_SCENARIO: scenario,
       FAKE_DSH_LOG: logPath,
+      DSH_CORDIS_CONFIG: '',
+      ...envOverrides,
     },
   });
   liveChildren.add(child);
@@ -120,6 +126,29 @@ describe('dsh-runner', () => {
     expect(h.stdout).toContain('✓ bash');
     // The vendored config was materialized under HOME.
     expect(existsSync(join(h.home, '.botmux', 'dsh', 'cordis.yml'))).toBe(true);
+  });
+
+  it('fails fast when DSH_CORDIS_CONFIG points to a missing file', async () => {
+    const missingConfig = join(tmpdir(), `botmux-dsh-missing-config-${process.pid}-${Date.now()}.yml`);
+    h = spawnRunner('happy', [], { DSH_CORDIS_CONFIG: missingConfig });
+    const exitPromise = new Promise<number | null>(resolve => h!.child.on('exit', resolve));
+    const code = await exitPromise;
+
+    expect(code).toBe(1);
+    expect(h.stderr).toContain(`DSH_CORDIS_CONFIG does not exist: ${missingConfig}`);
+    expect(h.stdout).not.toContain('dsh connected');
+    expect(h.stdout).not.toContain('›');
+    expect(existsSync(join(h.home, '.botmux', 'dsh', 'cordis.yml'))).toBe(false);
+  });
+
+  it('uses an existing DSH_CORDIS_CONFIG without materializing the vendored config', async () => {
+    h = spawnRunner('happy', [], { DSH_CORDIS_CONFIG: FAKE_SERVER });
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+
+    h.child.stdin.write(makeFrame('使用显式配置'));
+    await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
+
+    expect(existsSync(join(h.home, '.botmux', 'dsh', 'cordis.yml'))).toBe(false);
   });
 
   it('injects the identity preamble only on the first turn (multi-turn)', async () => {


### PR DESCRIPTION
## 问题

当用户显式设置 `DSH_CORDIS_CONFIG`，但路径拼错、文件被移动或挂载缺失时，dsh runner 过去会静默忽略该配置，转而生成并使用内置 `cordis.yml`。

这会让机器人以一套并非用户指定的插件组合继续启动，表面可用但实际配置已经偏离预期，排查时也没有任何错误提示。

## 改动

- `DSH_CORDIS_CONFIG` 非空但文件不存在时立即启动失败，并在错误中给出无效路径。
- 仅在环境变量未设置或只含空白时使用 vendored 配置。
- 补充缺失路径 fail-fast 和有效显式路径继续可用的集成测试。
- runner 测试显式清空宿主机的 `DSH_CORDIS_CONFIG`，避免开发机环境污染默认配置用例。

## 影响面

- 仅影响 dsh runner 的配置选择，不修改其它 CLI、后端或公共 worker 链路。
- 未配置 `DSH_CORDIS_CONFIG` 的默认行为不变。
- 指向现有文件的显式配置行为不变。
- 唯一行为变化是：原先会静默回退的无效显式配置现在明确失败。

## 验证

- `pnpm vitest run test/dsh-runner.test.ts`：12 passed
- `pnpm vitest run test/worker-dsh-turn.integration.test.ts`：2 passed
- `pnpm build`：通过
