### PR TITLE
docs(adapter): 新增 dsh 接入指南

### DIFF
--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -1,62 +1,58 @@
-# DeepSeek Harness（dsh）接入指南
+# 接入 DeepSeek Harness（dsh）
 
-这份文档面向要把 **dsh（deepseek-harness）** 接入 botmux 的使用者：从零配好一个能用的 dsh 机器人、搞清凭据为什么总是配不上、需要自定义模型路由时知道改哪里。
+botmux 的 dsh 适配器把飞书机器人接到 deepseek-harness：会话由 dsh 的 agent 组合驱动，模型调用走组合里的 `llm-deepseek`。适配器在 PR #858 加入，先用 dashboard 确认 CLI 下拉里有 **DeepSeek Harness**——没有就是 botmux 版本太旧，升级再说。
 
-dsh 适配器由 PR #858 引入。使用前先确认 botmux 包含 dsh 适配器——dashboard 的 CLI 下拉里能看到 **DeepSeek Harness** 选项即说明版本满足。
+> 最反直觉的一点先放前面：**dsh 的凭据不读 `~/.dsh`**。`settings.yaml`、`.credentials.yaml` 里配了也不生效，key 只能靠环境变量进进程。第一次接入基本都卡在这，详见[配置凭据](#配置凭据)。
 
-## 快速接入
+## 跑起来
 
-### 1. 安装 dsh 运行时
+要装的东西只有一样：dsh 运行时本体。
 
-botmux 自带的 dsh 桥接层（`dsh-runner.js`）随构建分发，但底层的 `dsh-jsonrpc-agent` 需要单独安装：
+botmux 自带的桥接层 `dsh-runner.js` 随构建分发，不用管；要装的是 `dsh-jsonrpc-agent`，deepseek-harness 的单文件运行时：
 
-- 安装 pip 包 `deepseek-harness-sdk`（依赖 `deepseek-harness-runtime-bin` 平台 wheel，提供单文件可执行程序 `dsh-jsonrpc-agent`）。
-- 确认 `dsh-jsonrpc-agent` 在 daemon 的 PATH 上；不在的话为机器人配置 `pathOverride` 指定绝对路径。
+```bash
+pip install deepseek-harness-sdk   # 会带上 deepseek-harness-runtime-bin 平台 wheel，提供 dsh-jsonrpc-agent
+```
 
-### 2. 配置机器人
+装完确认 `dsh-jsonrpc-agent` 在 daemon 的 PATH 上；不在就给机器人配 `pathOverride` 指绝对路径。运行时内部捆绑了组合要用的 8 个插件，不需要再装任何插件。
 
-dashboard → 选中机器人 →「Agent 配置」→ CLI 下拉选择 **DeepSeek Harness**（`cliId: "dsh"`），并按需配置：
+然后 dashboard → 机器人 →「Agent 配置」→ CLI 选 **DeepSeek Harness**（`cliId: "dsh"`），填这几个：
 
-| 字段 | 说明 |
-|------|------|
-| `cliId` | `"dsh"` |
-| `model` | 默认 `deepseek-v4-flash`，可选 `deepseek-v4-pro` |
-| `workingDir` | 会话工作目录 |
-| `provider` | **不用配置**：runner 固定走 `provider: 'deepseek-official'`，只能通过环境变量 / 组合配置改这条路由的 key 与 baseURL，不能换其它 provider 路由 |
+- `model`：默认 `deepseek-v4-flash`，想要更强就选 `deepseek-v4-pro`
+- `workingDir`：会话工作目录
+- `provider`：别动。runner 固定走 `deepseek-official` 路由；想改这条路由的 key / baseURL，只能通过环境变量和组合配置（见下），换不了其它路由
 
-### 3. 配置凭据
+key 配好（下一节）就能 @机器人 开聊。报错先翻文末[排错速查](#排错速查)。
 
-dsh 的凭据只认环境变量（见下一节），先把 key 配好再发消息，否则第一轮就会报 `no API key for provider route "deepseek-official"`。
+## 配置凭据
 
-### 4. 验证
+dsh 在 botmux 里的凭据链路和单独用 dsh 时不一样。botmux 的组合里没有 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai` 这几个插件，所以 `~/.dsh/settings.yaml`（默认模型、路由那些）和 `~/.dsh/.credentials.yaml`（key）**全部不生效**——报错提示 "export DEEPSEEK_API_KEY in the launching environment" 就是这个原因。
 
-群里 @机器人 发条消息。连不上或报 key 相关错误时，对照文末「排错速查」逐条排查。
+想复刻 `~/.dsh` 里的配置，把它拆成三处：环境变量（key）、组合配置（路由的 key 引用和 baseURL）、bot 的 `model` 字段（模型）。
 
-## 配置凭据（最容易踩坑的地方）
+### 环境变量
 
-dsh 适配器**不读 `~/.dsh` 全局配置**：botmux 的组合里没有挂 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai`，所以 `~/.dsh/settings.yaml` 和 `~/.dsh/.credentials.yaml` **都不会生效**。凭据只能靠**环境变量**进到进程里——这也是报错会提示 “export DEEPSEEK_API_KEY in the launching environment” 的原因。
+| 变量 | 什么时候要 | 作用 |
+|------|-----------|------|
+| `DEEPSEEK_API_KEY` | 走官方 API | `llm-deepseek` 默认读的 key |
+| `OPENCODE_GO_API_KEY` | 走 zen/go 网关 | 自定义组合里把 `apiKeyEnv` 指到它 |
+| `DSH_CORDIS_CONFIG` | 用了自定义组合 | 指向自定义 cordis.yml 的绝对路径 |
+| `DEEPSEEK_BASE_URL` | 可选 | 组合里没写 `baseURL` 时用这个兜底 |
 
-要复刻 `~/.dsh` 全局配置的效果，把 settings.yaml 里的信息翻译成三处：**自定义组合（路由的 key / baseURL）+ 环境变量 + bot 的 `model` 字段**。
+### 怎么把变量送进进程
 
-### 需要哪些环境变量
+两种方式，推荐第一种：
 
-| 变量 | 何时必填 | 作用 |
-|------|----------|------|
-| `DEEPSEEK_API_KEY` | 走官方 API 时 | llm-deepseek 默认读取的凭据（`apiKeyEnv` 的默认引用） |
-| `OPENCODE_GO_API_KEY` | 走 zen/go 网关时 | 自定义组合里把 `apiKeyEnv` 改指它 |
-| `DSH_CORDIS_CONFIG` | 使用自定义组合时 | 指向自定义 cordis.yml 的绝对路径 |
-| `DEEPSEEK_BASE_URL` | 可选 | 组合里没写 `baseURL` 时的兜底端点 |
+- **per-bot env**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页的「运行时环境变量」。按会话注入，新会话生效，不影响别的机器人。
+- **daemon 环境**：export 之后重启 daemon。注意 pm2 只保留首次启动时捕获的环境，改过之后要 `pm2 restart --update-env`（或者 delete + start）才生效，只 `botmux restart` 不行。
 
-### 注入方式（二选一）
+per-bot env 在沙箱模式下偶尔透传不进去（这块实现上比较保守），遇到就退回 daemon 环境。
 
-- **per-bot env（推荐）**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页「运行时环境变量」。按会话注入，**新会话即生效**，不影响其它机器人。
-- **daemon 环境**：在 daemon 启动环境里 export 后重启。pm2 保留首次捕获的环境变量，改环境后需要 `pm2 restart --update-env`（或 delete + start）才可靠。
+### 自定义组合（可选）
 
-## 自定义组合（可选）
+runner 每次启动会把内置的默认组合**覆写**到 `~/.botmux/dsh/cordis.yml`——直接改这个文件没用，改完下次启动就被覆盖。要自定义，设置 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 优先读这个文件。
 
-runner 每次启动都会把内置的默认组合**覆写**到 `~/.botmux/dsh/cordis.yml`，所以直接改这个文件没有用。要自定义时设置环境变量 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 会优先使用该文件。
-
-自定义组合 = 默认组合 + 按需覆盖 `llm-deepseek` 路由。走 zen/go 网关的示例：
+默认组合长这样，需要改路由时照着抄、改 `llm-deepseek` 那一段就行。下面是走 zen/go 网关的完整示例：
 
 ```yaml
 - id: sdk-jsonrpc-server
@@ -80,44 +76,23 @@ runner 每次启动都会把内置的默认组合**覆写**到 `~/.botmux/dsh/co
   name: '@deepseek-ai/dsh-fs-local'
 ```
 
-组合里用到的插件都由单文件运行时**内部捆绑**，配置里只写 `name` 即可，不需要单独安装。
+## 原理速览
 
-## 工作原理
+一条链：飞书消息 → botmux daemon → worker → `dsh-runner.js`（botmux 的桥接层）→ `dsh-jsonrpc-agent`（你装的运行时）→ 组合里的 `llm-deepseek` → HTTP 调模型。
 
-### 进程链
+两个容易忽略的点：
 
-```
-飞书消息 → botmux daemon
- → worker → spawn node dsh-runner.js            [botmux 构建内置，无需单独安装]
- → spawn dsh-jsonrpc-agent <config>             [PATH 上的可执行文件，需自行安装]
- → 加载 cordis 组合 → llm-deepseek 适配器 → HTTP 调用模型
-```
-
-- `dsh-runner.js`：botmux 自带的桥接层（JSON-RPC stdio ↔ botmux 控制帧），随 botmux 构建分发。
-- `dsh-jsonrpc-agent`：deepseek-harness 的**单文件运行时**，必须存在且可执行；botmux 通过 `resolveCommand('dsh-jsonrpc-agent')` 在 PATH 上查找（或机器人的 `pathOverride`）。
-
-### 依赖与版本
-
-| 依赖 | 来源 | 说明 |
-|------|------|------|
-| botmux（含 dsh 适配器） | 源码构建 / 发布版（PR #858 之后） | 旧版本没有 dsh 适配器，dashboard 不会出现 DeepSeek Harness 选项 |
-| `dsh-jsonrpc-agent` | pip 包 `deepseek-harness-sdk` → `deepseek-harness-runtime-bin`（平台 wheel 内的单文件可执行程序） | 安装后确认在 daemon 的 PATH 上 |
-| 组合里的 8 个插件（sdk-jsonrpc-server / agent-spine-demo / llm-deepseek / session-persistence-jsonl / session-checkpoint-policy / subprocess-local / bash-local / fs-local） | **捆绑在单文件运行时内部** | 配置里只写 `name`，由运行时解析，无需单独安装 |
-
-版本耦合：botmux 内置的默认组合与 dsh 运行时的协议版本绑定，**升级 dsh 运行时要注意与 botmux runner 的协议兼容**。
-
-### 会话目录
-
-`~/.botmux/dsh/`：会话持久化目录，runner 自动创建；适配器的 `authPaths` 保证文件沙箱内可写。
+- **升级 dsh 运行时要谨慎**：botmux 内置的默认组合和 dsh 的协议版本绑定，运行时大版本升级前先确认和当前 botmux 的 runner 兼容。
+- **会话落在哪**：`~/.botmux/dsh/`，runner 自动创建，适配器把它声明为 `authPaths`，文件沙箱里也可写。
 
 ## 排错速查
 
 | 现象 | 原因 | 处理 |
 |------|------|------|
-| dashboard 无 DeepSeek Harness 选项 | botmux 版本旧（无 dsh 适配器） | 升级 botmux 到包含 dsh 适配器的版本 |
-| 选项在但报「找不到 dsh-jsonrpc-agent」 | 运行时没装 / 不在 PATH | 安装 `deepseek-harness-sdk`，把 `dsh-jsonrpc-agent` 放进 PATH（或配置 `pathOverride`） |
-| `no API key for provider route "deepseek-official"` | key 没进进程环境（`~/.dsh/.credentials.yaml` 不算数） | 用 per-bot env 或 daemon 环境配置 key |
-| 配了 per-bot env 仍报缺 key | 文件沙箱可能未透传环境变量 | 兜底：export 到 daemon 环境后重启（`pm2 restart --update-env`） |
-| `UNKNOWN_MODEL` / 401 | bot 的 model 不在该路由模型列表 / key 错误 | 检查 model 字段、key、baseURL 是否匹配 |
+| dashboard 里没有 DeepSeek Harness 选项 | botmux 版本旧，没有 dsh 适配器 | 升级 botmux |
+| 有选项，但报找不到 dsh-jsonrpc-agent | 运行时没装，或不在 PATH | `pip install deepseek-harness-sdk`，把 `dsh-jsonrpc-agent` 放进 PATH（或配 `pathOverride`） |
+| `no API key for provider route "deepseek-official"` | key 没进进程环境，`~/.dsh/.credentials.yaml` 不算数 | 用 per-bot env 或 daemon 环境配 key |
+| per-bot env 配了还是报缺 key | 沙箱可能没透传这个变量 | 退回 daemon 环境：export 后 `pm2 restart --update-env` |
+| `UNKNOWN_MODEL` 或 401 | model 不在该路由的模型列表里，或 key 不对 | 核对 model 字段、key、baseURL 三者 |
 
-> 诊断：`GET /api/cli-options` 返回 `dsh: available: true/false`，可确认适配器是否可用。
+`GET /api/cli-options` 返回 `dsh: available: true/false`，可以快速确认适配器本身是否可用。

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -19,7 +19,7 @@
 
 ## 安装 dsh 运行时
 
-`dsh-runner.js` 随 botmux 构建分发，无需安装；需要安装的是 `dsh-jsonrpc-agent`，deepseek-harness 的单文件运行时：
+`dsh-runner.js` 随 botmux 构建分发，无需安装；需要安装的是 `dsh-jsonrpc-agent`，deepseek-harness 的单文件运行时（要求 Python >= 3.10）：
 
 ```bash
 pip install deepseek-harness-sdk   # 依赖 deepseek-harness-runtime-bin，提供 dsh-jsonrpc-agent
@@ -44,36 +44,57 @@ dsh 适配器**不读取 `~/.dsh` 全局配置**：botmux 的组合里没有挂�
 
 ### 注入方式
 
-- **per-bot env（推荐）**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页「运行时环境变量」。按会话注入，新会话生效，不影响其它机器人。沙箱模式下该变量可能不会传递，遇到时改用 daemon 环境。
-- **daemon 环境**：export 后重启 daemon。pm2 保留首次启动时捕获的环境，修改后需 `pm2 restart --update-env`（或 delete + start）才会更新。
+- **per-bot env（推荐）**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页「运行时环境变量」。按会话注入，新会话生效，不影响其它机器人。沙箱模式下同样生效：worker 把 `env` 作为 `injectEnv` 传给后端（PTY 并入子进程环境，tmux 通过 pane 内 `/usr/bin/env KEY=VAL` 注入），bwrap 不清理环境，key 会被一路继承。
+- **daemon 环境**：export 后重启 daemon 生效。用 `botmux restart`（在仓库 checkout 内也可用 `pnpm daemon:restart`）；不要直接用 `pm2 restart --update-env`，会绕过 botmux 的安全重启与会话恢复。
 
 ## 自定义组合（可选）
 
 runner 每次启动会把内置的默认组合覆写到 `~/.botmux/dsh/cordis.yml`，直接修改该文件无效。需要自定义时设置 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 优先读取该文件。
 
-默认组合如下；需要改路由时复制一份，仅调整 `llm-deepseek` 段。以下为走 zen/go 网关的示例：
+内置默认组合如下（与 `src/dsh-runner.ts` 的 `VENDORED_CONFIG` 一致）：
 
 ```yaml
+# Vendored by botmux dsh-runner. Source: deepseek-harness python/sdk-runtime cordis.yml.
 - id: sdk-jsonrpc-server
   name: '@deepseek-ai/dsh-sdk-jsonrpc-server'
 - id: agent-core
   name: '@deepseek-ai/dsh-agent-spine-demo'
+  config:
+    workspaceContext:
+      maxBytes: 65536
 - id: llm-deepseek
   name: '@deepseek-ai/dsh-llm-deepseek'
-  config:
-    apiKeyEnv: OPENCODE_GO_API_KEY
-    baseURL: https://opencode.ai/zen/go/v1
 - id: sessions
   name: '@deepseek-ai/dsh-session-persistence-jsonl'
+  config:
+    root: !!js process.env.DSH_SESSION_ROOT ?? './.sessions'
 - id: session-checkpoints
   name: '@deepseek-ai/dsh-session-checkpoint-policy'
 - id: subprocess
   name: '@deepseek-ai/dsh-subprocess-local'
 - id: bash
   name: '@deepseek-ai/dsh-bash-local'
+  config:
+    cwd: !!js process.env.DSH_CWD ?? process.cwd()
 - id: fs-local
   name: '@deepseek-ai/dsh-fs-local'
+  config:
+    cwd: !!js process.env.DSH_CWD ?? process.cwd()
 ```
+
+改路由时复制一份，只调整 `llm-deepseek` 段。例如走 zen/go 网关，把该段改为：
+
+```yaml
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+  config:
+    apiKeyEnv: OPENCODE_GO_API_KEY
+    baseURL: https://opencode.ai/zen/go/v1
+```
+
+其余段保持默认即可——尤其不要删掉 `sessions.config.root` 与 `bash` / `fs-local` 的 `config.cwd`，否则会话落盘位置会退回 workingDir 下的 `./.sessions`，与下文「会话目录」冲突。
+
+> 沙箱注意：`DSH_CORDIS_CONFIG` 指向的文件必须在文件沙箱可见范围内，否则沙箱内 `existsSync` 判空会**静默回退到内置组合**。最稳妥是放在 `~/.botmux/dsh/`（适配器已把该目录声明为 `authPaths`，例如 `~/.botmux/dsh/custom.yml`），或放在 workingDir 内。
 
 ## 会话与版本
 
@@ -87,7 +108,7 @@ runner 每次启动会把内置的默认组合覆写到 `~/.botmux/dsh/cordis.ym
 | dashboard 无 DeepSeek Harness 选项 | botmux 版本过旧，无 dsh 适配器。升级 botmux |
 | 报找不到 dsh-jsonrpc-agent | 运行时未安装或不在 PATH。安装 `deepseek-harness-sdk` 并将 `dsh-jsonrpc-agent` 加入 PATH（或配置 `pathOverride`） |
 | `no API key for provider route "deepseek-official"` | key 未进入进程环境（`~/.dsh/.credentials.yaml` 不生效）。通过 per-bot env 或 daemon 环境配置 key |
-| per-bot env 已配置仍报缺 key | 沙箱未传递该环境变量。改用 daemon 环境（export 后 `pm2 restart --update-env`） |
+| 自定义组合不生效（仍走默认路由 / 模型） | `DSH_CORDIS_CONFIG` 指向的文件在沙箱内不可见，`existsSync` 判空后静默回退内置组合。把文件放到 `~/.botmux/dsh/` 或 workingDir 内 |
 | `UNKNOWN_MODEL` 或 401 | model 不在该路由的模型列表，或 key 有误。核对 model 字段、key、baseURL |
 
-`GET /api/cli-options` 返回 `dsh: available: true/false`，可确认适配器是否可用。
+`GET /api/cli-options` 返回的 `options` 数组中，`id: "dsh"` 条目的 `available` 为 true/false，可确认适配器是否可用。

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -1,6 +1,6 @@
 # DeepSeek Harness（dsh）机器人接入指南
 
-> dsh 适配器把飞书机器人接到 deepseek-harness 运行时：botmux 内置的 `dsh-runner.js` 启动 `dsh-jsonrpc-agent`（需单独安装），后者加载 cordis 组合，模型调用走组合里的 `llm-deepseek`。要求 botmux 包含 dsh 适配器——dashboard 的 CLI 下拉里能看到 **DeepSeek Harness** 即满足要求。
+> dsh 适配器把飞书机器人接到 deepseek-harness 运行时：botmux 内置的 `dsh-runner.js` 启动 `dsh-jsonrpc-agent`（需单独安装），后者加载 cordis 组合（一份插件清单，声明加载哪些插件及各自配置），模型调用走组合里的 `llm-deepseek`。要求 botmux 包含 dsh 适配器——dashboard 的 CLI 下拉里能看到 **DeepSeek Harness** 即满足要求。
 
 ## 快速接入
 
@@ -12,7 +12,7 @@
    |------|------|
    | `model` | 默认 `deepseek-v4-flash`，可选 `deepseek-v4-pro` |
    | `workingDir` | 会话工作目录 |
-   | `provider` | 无需配置。runner 固定使用 `deepseek-official` 路由；该路由的 key / baseURL 只能通过环境变量与组合配置调整（见下），不支持更换其它 provider 路由 |
+   | `provider` | 无需配置。默认组合固定走 `deepseek-official` 路由，该路由的 key / baseURL 通过环境变量与组合配置调整（见「凭据配置」）；需要多 provider 见「走 pi 插件配置多 provider」 |
 
 4. 配置凭据（见「凭据配置」）。
 5. 群里 @机器人 发消息即可。报错对照文末「常见问题」逐条排查。
@@ -29,18 +29,24 @@ pip install deepseek-harness-sdk   # 依赖 deepseek-harness-runtime-bin，提�
 
 ## 凭据配置
 
-dsh 适配器**不读取 `~/.dsh` 全局配置**：botmux 的组合里没有挂载 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai`，`~/.dsh/settings.yaml` 与 `~/.dsh/.credentials.yaml` 均不生效，凭据只能通过环境变量传入进程（报错 "export DEEPSEEK_API_KEY in the launching environment" 即由此而来）。
+dsh 的配置分两层：
 
-要复刻 `~/.dsh` 的配置效果，将其拆成三处：环境变量（key）、组合配置（key 引用与 baseURL）、bot 的 `model` 字段（模型）。
+- **组合（cordis.yml）**：声明挂哪些插件、各自的 `config`。botmux 默认组合只挂 `llm-deepseek`（官方路由 `deepseek-official`），没有挂 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai`，所以 `~/.dsh/settings.yaml` 与 `~/.dsh/.credentials.yaml` 默认都不生效，凭据只能通过环境变量传入进程（报错 "export DEEPSEEK_API_KEY in the launching environment" 就是这个原因）。
+- **settings（`~/.dsh/settings.yaml`）**：只有自定义组合里挂了 settings / credentials / pi 插件后才生效（见「走 pi 插件配置多 provider」）。
+
+key 的传递规则：组合里的 `apiKeyEnv` 是**环境变量名引用**，不是 key 本身——插件按这个名字去进程环境里读。默认组合的 `llm-deepseek` 默认读 `DEEPSEEK_API_KEY`；自定义组合里把 `apiKeyEnv` 改成什么名字，就配什么环境变量。
+
+所以要复刻 `~/.dsh` 的配置效果，拆成三处即可：环境变量（key）、组合配置（key 引用与 baseURL）、bot 的 `model` 字段（模型）。
 
 ### 环境变量
 
 | 变量 | 何时需要 | 作用 |
 |------|---------|------|
-| `DEEPSEEK_API_KEY` | 走官方 API | `llm-deepseek` 默认读取的 key |
-| `OPENCODE_GO_API_KEY` | 走 zen/go 网关 | 自定义组合中把 `apiKeyEnv` 指向它 |
+| `DEEPSEEK_API_KEY` | 走官方 API | 默认组合 `llm-deepseek` 的 `apiKeyEnv` 默认值 |
+| `DEEPSEEK_BASE_URL` | 可选 | `llm-deepseek` 的 `baseURL` 兜底：组合未配置时读它，再缺省用官方端点 |
 | `DSH_CORDIS_CONFIG` | 使用自定义组合 | 自定义 cordis.yml 的绝对路径 |
-| `DEEPSEEK_BASE_URL` | 可选 | 组合未配置 `baseURL` 时的兜底端点 |
+
+> 自定义组合里 `apiKeyEnv` 填的变量名由你定义（例如填 `MY_GATEWAY_KEY`，就往进程环境里配 `MY_GATEWAY_KEY`），不是固定的几个名字。
 
 ### 注入方式
 
@@ -49,7 +55,7 @@ dsh 适配器**不读取 `~/.dsh` 全局配置**：botmux 的组合里没有挂�
 
 ## 自定义组合（可选）
 
-runner 每次启动会把内置的默认组合覆写到 `~/.botmux/dsh/cordis.yml`，直接修改该文件无效。需要自定义时设置 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 优先读取该文件。
+runner 每次启动都会把内置的默认组合覆写到 `~/.botmux/dsh/cordis.yml`，直接改这个文件无效。需要自定义时，把默认组合复制一份存成自己的文件，设置 `DSH_CORDIS_CONFIG=<绝对路径>` 指向它——runner 优先读这个文件。
 
 内置默认组合如下（与 `src/dsh-runner.ts` 的 `VENDORED_CONFIG` 一致）：
 
@@ -82,19 +88,42 @@ runner 每次启动会把内置的默认组合覆写到 `~/.botmux/dsh/cordis.ym
     cwd: !!js process.env.DSH_CWD ?? process.cwd()
 ```
 
-改路由时复制一份，只调整 `llm-deepseek` 段。例如走 zen/go 网关，把该段改为：
+改路由时只调整 `llm-deepseek` 段的 `config`——`apiKeyEnv` 填你的环境变量名，`baseURL` 填你的网关端点（下为占位示例，不要照抄具体值）：
 
 ```yaml
 - id: llm-deepseek
   name: '@deepseek-ai/dsh-llm-deepseek'
   config:
-    apiKeyEnv: OPENCODE_GO_API_KEY
-    baseURL: https://opencode.ai/zen/go/v1
+    apiKeyEnv: MY_GATEWAY_KEY
+    baseURL: https://your-gateway.example/v1
 ```
 
 其余段保持默认即可——尤其不要删掉 `sessions.config.root` 与 `bash` / `fs-local` 的 `config.cwd`，否则会话落盘位置会退回 workingDir 下的 `./.sessions`，与下文「会话目录」冲突。
 
 > 沙箱注意：`DSH_CORDIS_CONFIG` 指向的文件必须在文件沙箱可见范围内，否则沙箱内 `existsSync` 判空会**静默回退到内置组合**。最稳妥是放在 `~/.botmux/dsh/`（适配器已把该目录声明为 `authPaths`，例如 `~/.botmux/dsh/custom.yml`），或放在 workingDir 内。
+
+## 走 pi 插件配置多 provider
+
+默认组合只挂 `llm-deepseek`（官方路由）。需要多 provider 时，在自定义组合里追加三个插件：
+
+```yaml
+- id: settings
+  name: '@deepseek-ai/dsh-settings-file'
+- id: credentials
+  name: '@deepseek-ai/dsh-credentials-local'
+- id: llm-pi-ai
+  name: '@deepseek-ai/dsh-llm-pi-ai'
+```
+
+然后在 `~/.dsh/settings.yaml` 的 `llm-pi-ai:` 段配置 provider 列表：每个 provider 一个路由项，`apiKeyEnv` 填**环境变量名**（引用而非值——key 本身通过 per-bot env / daemon 环境注入，或写在 `~/.dsh/.credentials.yaml`），该路由可用的模型在 `models` 里声明。`llm-pi-ai` 挂载后默认休眠：settings 里没有该段时不注册任何路由，段存在后实时生效、清空后摘除。
+
+会话默认走哪个 provider/model 在 `~/.dsh/settings.yaml` 的 `agent-default-model:` 段选择；bot 配置的 `model` 字段必须是该路由模型列表里的 id。
+
+注意：
+
+- provider 名称、baseURL、模型 id、key 都属于你的本地配置，只写在 `~/.dsh/settings.yaml` 或 `~/.dsh/.credentials.yaml`，不要写进组合文件、更不要提交到仓库。
+- 沙箱模式下 `~/.dsh` 默认不在文件沙箱可见范围（适配器只声明了 `~/.botmux/dsh`）：在 bot 配置的 `sandboxPaths.readOnly` 里加上 `~/.dsh`，否则 settings 读不到、pi 路由保持休眠。
+- `settings.yaml` 热加载，改 provider 配置不用重启。
 
 ## 会话与版本
 

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -1,69 +1,62 @@
 # DeepSeek Harness（dsh）接入指南
 
-> botmux 通过 `dsh` 适配器把飞书话题群接到 **deepseek-harness（dsh）** 运行时：会话由 dsh 的 agent 组合驱动（subprocess / bash / fs 等本地能力插件 + llm-deepseek 模型适配器）。要求 botmux 为**包含 dsh 适配器的版本**（`cliId: "dsh"` 由 PR #858 引入）。
+这份文档面向要把 **dsh（deepseek-harness）** 接入 botmux 的使用者：从零配好一个能用的 dsh 机器人、搞清凭据为什么总是配不上、需要自定义模型路由时知道改哪里。
 
-## 一、进程链（谁依赖谁）
+dsh 适配器由 PR #858 引入。使用前先确认 botmux 包含 dsh 适配器——dashboard 的 CLI 下拉里能看到 **DeepSeek Harness** 选项即说明版本满足。
 
-```
-飞书消息 → botmux daemon
- → worker → spawn node dsh-runner.js            [botmux 构建内置，无需单独安装]
- → spawn dsh-jsonrpc-agent <config>             [PATH 上的可执行文件，需自行安装]
- → 加载 cordis 组合 → llm-deepseek 适配器 → HTTP 调用模型
-```
+## 快速接入
 
-- `dsh-runner.js` 是 botmux 自己的桥接层（JSON-RPC stdio ↔ botmux 控制帧），随 botmux 构建分发，**无需单独安装**。
-- `dsh-jsonrpc-agent` 是 deepseek-harness 的**单文件运行时**，**必须存在且可执行**；botmux 通过 `resolveCommand('dsh-jsonrpc-agent')` 在 PATH 上查找（或机器人配置的 `pathOverride`）。
+### 1. 安装 dsh 运行时
 
-## 二、依赖清单
+botmux 自带的 dsh 桥接层（`dsh-runner.js`）随构建分发，但底层的 `dsh-jsonrpc-agent` 需要单独安装：
 
-| 依赖 | 来源 | 说明 |
-|---|---|---|
-| botmux（含 dsh 适配器） | 源码构建 / 发布版（PR #858 之后） | 旧版本没有 dsh 适配器，dashboard 不会出现 DeepSeek Harness 选项 |
-| `dsh-jsonrpc-agent` | pip 包 `deepseek-harness-sdk` → `deepseek-harness-runtime-bin`（平台 wheel 内的单文件可执行程序） | 安装后确认其在 daemon 的 PATH 上 |
-| 运行时组合里的 8 个插件（sdk-jsonrpc-server / agent-spine-demo / llm-deepseek / session-persistence-jsonl / session-checkpoint-policy / subprocess-local / bash-local / fs-local） | **捆绑在单文件运行时内部** | 组合配置里只写 `name`，由运行时解析，**无需单独安装** |
-| 版本耦合 | — | botmux 内置的 vendored 组合与 dsh 运行时协议版本绑定：**升级 dsh 运行时要注意与 botmux runner 的协议兼容** |
+- 安装 pip 包 `deepseek-harness-sdk`（依赖 `deepseek-harness-runtime-bin` 平台 wheel，提供单文件可执行程序 `dsh-jsonrpc-agent`）。
+- 确认 `dsh-jsonrpc-agent` 在 daemon 的 PATH 上；不在的话为机器人配置 `pathOverride` 指定绝对路径。
 
-## 三、快速接入
+### 2. 配置机器人
 
-1. 前提：botmux daemon 正常运行；已安装 `dsh-jsonrpc-agent` 并在 PATH；有一个飞书机器人。
-2. dashboard → 选中机器人 →「Agent 配置」→ CLI 下拉选择 **DeepSeek Harness**（`cliId: "dsh"`）。
-3. 配置机器人字段：
+dashboard → 选中机器人 →「Agent 配置」→ CLI 下拉选择 **DeepSeek Harness**（`cliId: "dsh"`），并按需配置：
 
-   | 字段 | 说明 |
-   |------|------|
-   | `cliId` | `"dsh"` |
-   | `model` | 默认 `deepseek-v4-flash`，可选 `deepseek-v4-pro`（来自 runner 的 initialize 请求的 model 字段） |
-   | `workingDir` | 会话工作目录 |
-   | provider | **不要配置**：runner 硬编码 `provider: 'deepseek-official'`——只能改这条路由的 key/baseURL，不能切换到其它 provider 路由 |
+| 字段 | 说明 |
+|------|------|
+| `cliId` | `"dsh"` |
+| `model` | 默认 `deepseek-v4-flash`，可选 `deepseek-v4-pro` |
+| `workingDir` | 会话工作目录 |
+| `provider` | **不用配置**：runner 固定走 `provider: 'deepseek-official'`，只能通过环境变量 / 组合配置改这条路由的 key 与 baseURL，不能换其它 provider 路由 |
 
-4. 配置凭据（见下一节），然后群里 @机器人 发消息。
+### 3. 配置凭据
 
-## 四、凭据配置（重点）
+dsh 的凭据只认环境变量（见下一节），先把 key 配好再发消息，否则第一轮就会报 `no API key for provider route "deepseek-official"`。
 
-**dsh 适配器完全不读 `~/.dsh` 全局配置**：botmux 的组合里没有挂 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai`，所以 `~/.dsh/settings.yaml` 与 `~/.dsh/.credentials.yaml` **都不生效**。凭据只能靠**环境变量**进入进程。
+### 4. 验证
 
-要复刻全局配置的效果，就是把 settings.yaml 里的信息翻译成：**自定义组合（provider 路由的 key/baseURL）+ 环境变量 + bot 的 model 字段**。
+群里 @机器人 发条消息。连不上或报 key 相关错误时，对照文末「排错速查」逐条排查。
 
-### 环境变量（必须到达 runner 进程）
+## 配置凭据（最容易踩坑的地方）
 
-| 变量 | 必填 | 作用 |
-|---|---|---|
-| `DEEPSEEK_API_KEY` | 走官方 API 时必填 | llm-deepseek 的默认凭据引用（`apiKeyEnv`） |
-| `OPENCODE_GO_API_KEY` | 走 zen/go 网关时必填 | 自定义组合里把 `apiKeyEnv` 改指它 |
-| `DSH_CORDIS_CONFIG` | 使用自定义组合时必填 | 指向自定义 cordis.yml 的绝对路径 |
-| `DEEPSEEK_BASE_URL` | 可选 | 组合里不写 `baseURL` 时的兜底端点 |
+dsh 适配器**不读 `~/.dsh` 全局配置**：botmux 的组合里没有挂 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai`，所以 `~/.dsh/settings.yaml` 和 `~/.dsh/.credentials.yaml` **都不会生效**。凭据只能靠**环境变量**进到进程里——这也是报错会提示 “export DEEPSEEK_API_KEY in the launching environment” 的原因。
+
+要复刻 `~/.dsh` 全局配置的效果，把 settings.yaml 里的信息翻译成三处：**自定义组合（路由的 key / baseURL）+ 环境变量 + bot 的 `model` 字段**。
+
+### 需要哪些环境变量
+
+| 变量 | 何时必填 | 作用 |
+|------|----------|------|
+| `DEEPSEEK_API_KEY` | 走官方 API 时 | llm-deepseek 默认读取的凭据（`apiKeyEnv` 的默认引用） |
+| `OPENCODE_GO_API_KEY` | 走 zen/go 网关时 | 自定义组合里把 `apiKeyEnv` 改指它 |
+| `DSH_CORDIS_CONFIG` | 使用自定义组合时 | 指向自定义 cordis.yml 的绝对路径 |
+| `DEEPSEEK_BASE_URL` | 可选 | 组合里没写 `baseURL` 时的兜底端点 |
 
 ### 注入方式（二选一）
 
 - **per-bot env（推荐）**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页「运行时环境变量」。按会话注入，**新会话即生效**，不影响其它机器人。
-- **daemon 环境**：在 daemon 启动环境里 export 后重启。注意：pm2 保留首次捕获的环境变量，改环境后需要 `pm2 restart --update-env`（或 delete + start）才可靠。
+- **daemon 环境**：在 daemon 启动环境里 export 后重启。pm2 保留首次捕获的环境变量，改环境后需要 `pm2 restart --update-env`（或 delete + start）才可靠。
 
-## 五、组合配置（cordis.yml）——runner 决定用哪份
+## 自定义组合（可选）
 
-- **默认**：runner 每次启动把内置的 vendored 组合**覆写**到 `~/.botmux/dsh/cordis.yml`，所以**直接改这个文件没有用**。
-- **自定义**：设置环境变量 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 优先使用该文件（文件存在时）。
+runner 每次启动都会把内置的默认组合**覆写**到 `~/.botmux/dsh/cordis.yml`，所以直接改这个文件没有用。要自定义时设置环境变量 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 会优先使用该文件。
 
-自定义组合 = 默认组合 + 按需覆盖 llm-deepseek 路由。示例（走 zen/go 网关）：
+自定义组合 = 默认组合 + 按需覆盖 `llm-deepseek` 路由。走 zen/go 网关的示例：
 
 ```yaml
 - id: sdk-jsonrpc-server
@@ -87,18 +80,44 @@
   name: '@deepseek-ai/dsh-fs-local'
 ```
 
-## 六、会话目录
+组合里用到的插件都由单文件运行时**内部捆绑**，配置里只写 `name` 即可，不需要单独安装。
 
-`~/.botmux/dsh/`：会话持久化目录（runner 自动创建；适配器的 `authPaths` 保证文件沙箱内可写）。
+## 工作原理
 
-## 七、排错速查
+### 进程链
+
+```
+飞书消息 → botmux daemon
+ → worker → spawn node dsh-runner.js            [botmux 构建内置，无需单独安装]
+ → spawn dsh-jsonrpc-agent <config>             [PATH 上的可执行文件，需自行安装]
+ → 加载 cordis 组合 → llm-deepseek 适配器 → HTTP 调用模型
+```
+
+- `dsh-runner.js`：botmux 自带的桥接层（JSON-RPC stdio ↔ botmux 控制帧），随 botmux 构建分发。
+- `dsh-jsonrpc-agent`：deepseek-harness 的**单文件运行时**，必须存在且可执行；botmux 通过 `resolveCommand('dsh-jsonrpc-agent')` 在 PATH 上查找（或机器人的 `pathOverride`）。
+
+### 依赖与版本
+
+| 依赖 | 来源 | 说明 |
+|------|------|------|
+| botmux（含 dsh 适配器） | 源码构建 / 发布版（PR #858 之后） | 旧版本没有 dsh 适配器，dashboard 不会出现 DeepSeek Harness 选项 |
+| `dsh-jsonrpc-agent` | pip 包 `deepseek-harness-sdk` → `deepseek-harness-runtime-bin`（平台 wheel 内的单文件可执行程序） | 安装后确认在 daemon 的 PATH 上 |
+| 组合里的 8 个插件（sdk-jsonrpc-server / agent-spine-demo / llm-deepseek / session-persistence-jsonl / session-checkpoint-policy / subprocess-local / bash-local / fs-local） | **捆绑在单文件运行时内部** | 配置里只写 `name`，由运行时解析，无需单独安装 |
+
+版本耦合：botmux 内置的默认组合与 dsh 运行时的协议版本绑定，**升级 dsh 运行时要注意与 botmux runner 的协议兼容**。
+
+### 会话目录
+
+`~/.botmux/dsh/`：会话持久化目录，runner 自动创建；适配器的 `authPaths` 保证文件沙箱内可写。
+
+## 排错速查
 
 | 现象 | 原因 | 处理 |
-|---|---|---|
+|------|------|------|
 | dashboard 无 DeepSeek Harness 选项 | botmux 版本旧（无 dsh 适配器） | 升级 botmux 到包含 dsh 适配器的版本 |
-| 选项在但报「找不到 dsh-jsonrpc-agent」 | 运行时没装 / 不在 PATH | 安装 `deepseek-harness-sdk` 并把 `dsh-jsonrpc-agent` 放进 PATH（或配置 `pathOverride`） |
+| 选项在但报「找不到 dsh-jsonrpc-agent」 | 运行时没装 / 不在 PATH | 安装 `deepseek-harness-sdk`，把 `dsh-jsonrpc-agent` 放进 PATH（或配置 `pathOverride`） |
 | `no API key for provider route "deepseek-official"` | key 没进进程环境（`~/.dsh/.credentials.yaml` 不算数） | 用 per-bot env 或 daemon 环境配置 key |
 | 配了 per-bot env 仍报缺 key | 文件沙箱可能未透传环境变量 | 兜底：export 到 daemon 环境后重启（`pm2 restart --update-env`） |
 | `UNKNOWN_MODEL` / 401 | bot 的 model 不在该路由模型列表 / key 错误 | 检查 model 字段、key、baseURL 是否匹配 |
 
-> 诊断：dsh 适配器可用性可通过 `GET /api/cli-options` 返回的 `dsh: available: true/false` 确认。
+> 诊断：`GET /api/cli-options` 返回 `dsh: available: true/false`，可确认适配器是否可用。

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -1,0 +1,104 @@
+# DeepSeek Harness（dsh）接入指南
+
+> botmux 通过 `dsh` 适配器把飞书话题群接到 **deepseek-harness（dsh）** 运行时：会话由 dsh 的 agent 组合驱动（subprocess / bash / fs 等本地能力插件 + llm-deepseek 模型适配器）。要求 botmux 为**包含 dsh 适配器的版本**（`cliId: "dsh"` 由 PR #858 引入）。
+
+## 一、进程链（谁依赖谁）
+
+```
+飞书消息 → botmux daemon
+ → worker → spawn node dsh-runner.js            [botmux 构建内置，无需单独安装]
+ → spawn dsh-jsonrpc-agent <config>             [PATH 上的可执行文件，需自行安装]
+ → 加载 cordis 组合 → llm-deepseek 适配器 → HTTP 调用模型
+```
+
+- `dsh-runner.js` 是 botmux 自己的桥接层（JSON-RPC stdio ↔ botmux 控制帧），随 botmux 构建分发，**无需单独安装**。
+- `dsh-jsonrpc-agent` 是 deepseek-harness 的**单文件运行时**，**必须存在且可执行**；botmux 通过 `resolveCommand('dsh-jsonrpc-agent')` 在 PATH 上查找（或机器人配置的 `pathOverride`）。
+
+## 二、依赖清单
+
+| 依赖 | 来源 | 说明 |
+|---|---|---|
+| botmux（含 dsh 适配器） | 源码构建 / 发布版（PR #858 之后） | 旧版本没有 dsh 适配器，dashboard 不会出现 DeepSeek Harness 选项 |
+| `dsh-jsonrpc-agent` | pip 包 `deepseek-harness-sdk` → `deepseek-harness-runtime-bin`（平台 wheel 内的单文件可执行程序） | 安装后确认其在 daemon 的 PATH 上 |
+| 运行时组合里的 8 个插件（sdk-jsonrpc-server / agent-spine-demo / llm-deepseek / session-persistence-jsonl / session-checkpoint-policy / subprocess-local / bash-local / fs-local） | **捆绑在单文件运行时内部** | 组合配置里只写 `name`，由运行时解析，**无需单独安装** |
+| 版本耦合 | — | botmux 内置的 vendored 组合与 dsh 运行时协议版本绑定：**升级 dsh 运行时要注意与 botmux runner 的协议兼容** |
+
+## 三、快速接入
+
+1. 前提：botmux daemon 正常运行；已安装 `dsh-jsonrpc-agent` 并在 PATH；有一个飞书机器人。
+2. dashboard → 选中机器人 →「Agent 配置」→ CLI 下拉选择 **DeepSeek Harness**（`cliId: "dsh"`）。
+3. 配置机器人字段：
+
+   | 字段 | 说明 |
+   |------|------|
+   | `cliId` | `"dsh"` |
+   | `model` | 默认 `deepseek-v4-flash`，可选 `deepseek-v4-pro`（来自 runner 的 initialize 请求的 model 字段） |
+   | `workingDir` | 会话工作目录 |
+   | provider | **不要配置**：runner 硬编码 `provider: 'deepseek-official'`——只能改这条路由的 key/baseURL，不能切换到其它 provider 路由 |
+
+4. 配置凭据（见下一节），然后群里 @机器人 发消息。
+
+## 四、凭据配置（重点）
+
+**dsh 适配器完全不读 `~/.dsh` 全局配置**：botmux 的组合里没有挂 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai`，所以 `~/.dsh/settings.yaml` 与 `~/.dsh/.credentials.yaml` **都不生效**。凭据只能靠**环境变量**进入进程。
+
+要复刻全局配置的效果，就是把 settings.yaml 里的信息翻译成：**自定义组合（provider 路由的 key/baseURL）+ 环境变量 + bot 的 model 字段**。
+
+### 环境变量（必须到达 runner 进程）
+
+| 变量 | 必填 | 作用 |
+|---|---|---|
+| `DEEPSEEK_API_KEY` | 走官方 API 时必填 | llm-deepseek 的默认凭据引用（`apiKeyEnv`） |
+| `OPENCODE_GO_API_KEY` | 走 zen/go 网关时必填 | 自定义组合里把 `apiKeyEnv` 改指它 |
+| `DSH_CORDIS_CONFIG` | 使用自定义组合时必填 | 指向自定义 cordis.yml 的绝对路径 |
+| `DEEPSEEK_BASE_URL` | 可选 | 组合里不写 `baseURL` 时的兜底端点 |
+
+### 注入方式（二选一）
+
+- **per-bot env（推荐）**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页「运行时环境变量」。按会话注入，**新会话即生效**，不影响其它机器人。
+- **daemon 环境**：在 daemon 启动环境里 export 后重启。注意：pm2 保留首次捕获的环境变量，改环境后需要 `pm2 restart --update-env`（或 delete + start）才可靠。
+
+## 五、组合配置（cordis.yml）——runner 决定用哪份
+
+- **默认**：runner 每次启动把内置的 vendored 组合**覆写**到 `~/.botmux/dsh/cordis.yml`，所以**直接改这个文件没有用**。
+- **自定义**：设置环境变量 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 优先使用该文件（文件存在时）。
+
+自定义组合 = 默认组合 + 按需覆盖 llm-deepseek 路由。示例（走 zen/go 网关）：
+
+```yaml
+- id: sdk-jsonrpc-server
+  name: '@deepseek-ai/dsh-sdk-jsonrpc-server'
+- id: agent-core
+  name: '@deepseek-ai/dsh-agent-spine-demo'
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+  config:
+    apiKeyEnv: OPENCODE_GO_API_KEY
+    baseURL: https://opencode.ai/zen/go/v1
+- id: sessions
+  name: '@deepseek-ai/dsh-session-persistence-jsonl'
+- id: session-checkpoints
+  name: '@deepseek-ai/dsh-session-checkpoint-policy'
+- id: subprocess
+  name: '@deepseek-ai/dsh-subprocess-local'
+- id: bash
+  name: '@deepseek-ai/dsh-bash-local'
+- id: fs-local
+  name: '@deepseek-ai/dsh-fs-local'
+```
+
+## 六、会话目录
+
+`~/.botmux/dsh/`：会话持久化目录（runner 自动创建；适配器的 `authPaths` 保证文件沙箱内可写）。
+
+## 七、排错速查
+
+| 现象 | 原因 | 处理 |
+|---|---|---|
+| dashboard 无 DeepSeek Harness 选项 | botmux 版本旧（无 dsh 适配器） | 升级 botmux 到包含 dsh 适配器的版本 |
+| 选项在但报「找不到 dsh-jsonrpc-agent」 | 运行时没装 / 不在 PATH | 安装 `deepseek-harness-sdk` 并把 `dsh-jsonrpc-agent` 放进 PATH（或配置 `pathOverride`） |
+| `no API key for provider route "deepseek-official"` | key 没进进程环境（`~/.dsh/.credentials.yaml` 不算数） | 用 per-bot env 或 daemon 环境配置 key |
+| 配了 per-bot env 仍报缺 key | 文件沙箱可能未透传环境变量 | 兜底：export 到 daemon 环境后重启（`pm2 restart --update-env`） |
+| `UNKNOWN_MODEL` / 401 | bot 的 model 不在该路由模型列表 / key 错误 | 检查 model 字段、key、baseURL 是否匹配 |
+
+> 诊断：dsh 适配器可用性可通过 `GET /api/cli-options` 返回的 `dsh: available: true/false` 确认。

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -1,8 +1,8 @@
 # 接入 DeepSeek Harness（dsh）
 
-botmux 的 dsh 适配器把飞书机器人接到 deepseek-harness：会话由 dsh 的 agent 组合驱动，模型调用走组合里的 `llm-deepseek`。适配器在 PR #858 加入，先用 dashboard 确认 CLI 下拉里有 **DeepSeek Harness**——没有就是 botmux 版本太旧，升级再说。
+botmux 的 dsh 适配器把飞书机器人接到 deepseek-harness：会话由 dsh 的 agent 组合驱动，模型调用走组合里的 `llm-deepseek`。需要包含 dsh 适配器的 botmux 版本——dashboard 的 CLI 下拉里能看到 **DeepSeek Harness** 即说明版本满足；看不到说明版本过旧，先升级。
 
-> 最反直觉的一点先放前面：**dsh 的凭据不读 `~/.dsh`**。`settings.yaml`、`.credentials.yaml` 里配了也不生效，key 只能靠环境变量进进程。第一次接入基本都卡在这，详见[配置凭据](#配置凭据)。
+> 最反直觉的一点先放前面：**dsh 的凭据不读 `~/.dsh`**。`settings.yaml`、`.credentials.yaml` 里配了也不生效，key 只能靠环境变量进进程。第一次接入最容易在这里卡住，详见[配置凭据](#配置凭据)。
 
 ## 跑起来
 
@@ -18,11 +18,11 @@ pip install deepseek-harness-sdk   # 会带上 deepseek-harness-runtime-bin 平�
 
 然后 dashboard → 机器人 →「Agent 配置」→ CLI 选 **DeepSeek Harness**（`cliId: "dsh"`），填这几个：
 
-- `model`：默认 `deepseek-v4-flash`，想要更强就选 `deepseek-v4-pro`
+- `model`：默认 `deepseek-v4-flash`，需要更强可选 `deepseek-v4-pro`
 - `workingDir`：会话工作目录
-- `provider`：别动。runner 固定走 `deepseek-official` 路由；想改这条路由的 key / baseURL，只能通过环境变量和组合配置（见下），换不了其它路由
+- `provider`：无需配置。runner 固定走 `deepseek-official` 路由；想改这条路由的 key / baseURL，只能通过环境变量和组合配置（见下），换不了其它路由
 
-key 配好（下一节）就能 @机器人 开聊。报错先翻文末[排错速查](#排错速查)。
+key 按下一节配好后，@机器人 发消息即可。报错对照文末[排错速查](#排错速查)。
 
 ## 配置凭据
 
@@ -46,13 +46,13 @@ dsh 在 botmux 里的凭据链路和单独用 dsh 时不一样。botmux 的组�
 - **per-bot env**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页的「运行时环境变量」。按会话注入，新会话生效，不影响别的机器人。
 - **daemon 环境**：export 之后重启 daemon。注意 pm2 只保留首次启动时捕获的环境，改过之后要 `pm2 restart --update-env`（或者 delete + start）才生效，只 `botmux restart` 不行。
 
-per-bot env 在沙箱模式下偶尔透传不进去（这块实现上比较保守），遇到就退回 daemon 环境。
+per-bot env 在沙箱模式下偶尔透传不进去，遇到这种情况退回 daemon 环境即可。
 
 ### 自定义组合（可选）
 
 runner 每次启动会把内置的默认组合**覆写**到 `~/.botmux/dsh/cordis.yml`——直接改这个文件没用，改完下次启动就被覆盖。要自定义，设置 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 优先读这个文件。
 
-默认组合长这样，需要改路由时照着抄、改 `llm-deepseek` 那一段就行。下面是走 zen/go 网关的完整示例：
+默认组合的完整内容如下；需要改路由时复制一份，只调整 `llm-deepseek` 那一段即可。下面是走 zen/go 网关的示例：
 
 ```yaml
 - id: sdk-jsonrpc-server

--- a/docs/dsh.md
+++ b/docs/dsh.md
@@ -1,58 +1,57 @@
-# 接入 DeepSeek Harness（dsh）
+# DeepSeek Harness（dsh）机器人接入指南
 
-botmux 的 dsh 适配器把飞书机器人接到 deepseek-harness：会话由 dsh 的 agent 组合驱动，模型调用走组合里的 `llm-deepseek`。需要包含 dsh 适配器的 botmux 版本——dashboard 的 CLI 下拉里能看到 **DeepSeek Harness** 即说明版本满足；看不到说明版本过旧，先升级。
+> dsh 适配器把飞书机器人接到 deepseek-harness 运行时：botmux 内置的 `dsh-runner.js` 启动 `dsh-jsonrpc-agent`（需单独安装），后者加载 cordis 组合，模型调用走组合里的 `llm-deepseek`。要求 botmux 包含 dsh 适配器——dashboard 的 CLI 下拉里能看到 **DeepSeek Harness** 即满足要求。
 
-> 最反直觉的一点先放前面：**dsh 的凭据不读 `~/.dsh`**。`settings.yaml`、`.credentials.yaml` 里配了也不生效，key 只能靠环境变量进进程。第一次接入最容易在这里卡住，详见[配置凭据](#配置凭据)。
+## 快速接入
 
-## 跑起来
+1. 前提：botmux daemon 正常运行；已安装 `dsh-jsonrpc-agent`（见「安装 dsh 运行时」）；有一个飞书机器人。
+2. 打开 dashboard → 选中机器人 →「Agent 配置」→ CLI 下拉选择 **DeepSeek Harness**（`cliId: "dsh"`）。
+3. 配置项：
 
-要装的东西只有一样：dsh 运行时本体。
+   | 字段 | 说明 |
+   |------|------|
+   | `model` | 默认 `deepseek-v4-flash`，可选 `deepseek-v4-pro` |
+   | `workingDir` | 会话工作目录 |
+   | `provider` | 无需配置。runner 固定使用 `deepseek-official` 路由；该路由的 key / baseURL 只能通过环境变量与组合配置调整（见下），不支持更换其它 provider 路由 |
 
-botmux 自带的桥接层 `dsh-runner.js` 随构建分发，不用管；要装的是 `dsh-jsonrpc-agent`，deepseek-harness 的单文件运行时：
+4. 配置凭据（见「凭据配置」）。
+5. 群里 @机器人 发消息即可。报错对照文末「常见问题」逐条排查。
+
+## 安装 dsh 运行时
+
+`dsh-runner.js` 随 botmux 构建分发，无需安装；需要安装的是 `dsh-jsonrpc-agent`，deepseek-harness 的单文件运行时：
 
 ```bash
-pip install deepseek-harness-sdk   # 会带上 deepseek-harness-runtime-bin 平台 wheel，提供 dsh-jsonrpc-agent
+pip install deepseek-harness-sdk   # 依赖 deepseek-harness-runtime-bin，提供 dsh-jsonrpc-agent
 ```
 
-装完确认 `dsh-jsonrpc-agent` 在 daemon 的 PATH 上；不在就给机器人配 `pathOverride` 指绝对路径。运行时内部捆绑了组合要用的 8 个插件，不需要再装任何插件。
+安装后确认 `dsh-jsonrpc-agent` 在 daemon 的 PATH 上；不在则给机器人配置 `pathOverride` 指定绝对路径。组合所需插件（sdk-jsonrpc-server / agent-spine-demo / llm-deepseek / session-persistence-jsonl / session-checkpoint-policy / subprocess-local / bash-local / fs-local）捆绑在运行时内部，配置里只写 `name`，无需单独安装。
 
-然后 dashboard → 机器人 →「Agent 配置」→ CLI 选 **DeepSeek Harness**（`cliId: "dsh"`），填这几个：
+## 凭据配置
 
-- `model`：默认 `deepseek-v4-flash`，需要更强可选 `deepseek-v4-pro`
-- `workingDir`：会话工作目录
-- `provider`：无需配置。runner 固定走 `deepseek-official` 路由；想改这条路由的 key / baseURL，只能通过环境变量和组合配置（见下），换不了其它路由
+dsh 适配器**不读取 `~/.dsh` 全局配置**：botmux 的组合里没有挂载 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai`，`~/.dsh/settings.yaml` 与 `~/.dsh/.credentials.yaml` 均不生效，凭据只能通过环境变量传入进程（报错 "export DEEPSEEK_API_KEY in the launching environment" 即由此而来）。
 
-key 按下一节配好后，@机器人 发消息即可。报错对照文末[排错速查](#排错速查)。
-
-## 配置凭据
-
-dsh 在 botmux 里的凭据链路和单独用 dsh 时不一样。botmux 的组合里没有 `dsh-settings-file` / `dsh-credentials-local` / `llm-pi-ai` 这几个插件，所以 `~/.dsh/settings.yaml`（默认模型、路由那些）和 `~/.dsh/.credentials.yaml`（key）**全部不生效**——报错提示 "export DEEPSEEK_API_KEY in the launching environment" 就是这个原因。
-
-想复刻 `~/.dsh` 里的配置，把它拆成三处：环境变量（key）、组合配置（路由的 key 引用和 baseURL）、bot 的 `model` 字段（模型）。
+要复刻 `~/.dsh` 的配置效果，将其拆成三处：环境变量（key）、组合配置（key 引用与 baseURL）、bot 的 `model` 字段（模型）。
 
 ### 环境变量
 
-| 变量 | 什么时候要 | 作用 |
-|------|-----------|------|
-| `DEEPSEEK_API_KEY` | 走官方 API | `llm-deepseek` 默认读的 key |
-| `OPENCODE_GO_API_KEY` | 走 zen/go 网关 | 自定义组合里把 `apiKeyEnv` 指到它 |
-| `DSH_CORDIS_CONFIG` | 用了自定义组合 | 指向自定义 cordis.yml 的绝对路径 |
-| `DEEPSEEK_BASE_URL` | 可选 | 组合里没写 `baseURL` 时用这个兜底 |
+| 变量 | 何时需要 | 作用 |
+|------|---------|------|
+| `DEEPSEEK_API_KEY` | 走官方 API | `llm-deepseek` 默认读取的 key |
+| `OPENCODE_GO_API_KEY` | 走 zen/go 网关 | 自定义组合中把 `apiKeyEnv` 指向它 |
+| `DSH_CORDIS_CONFIG` | 使用自定义组合 | 自定义 cordis.yml 的绝对路径 |
+| `DEEPSEEK_BASE_URL` | 可选 | 组合未配置 `baseURL` 时的兜底端点 |
 
-### 怎么把变量送进进程
+### 注入方式
 
-两种方式，推荐第一种：
+- **per-bot env（推荐）**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页「运行时环境变量」。按会话注入，新会话生效，不影响其它机器人。沙箱模式下该变量可能不会传递，遇到时改用 daemon 环境。
+- **daemon 环境**：export 后重启 daemon。pm2 保留首次启动时捕获的环境，修改后需 `pm2 restart --update-env`（或 delete + start）才会更新。
 
-- **per-bot env**：`bots.json` 的 `env` 字段，或 dashboard 机器人配置页的「运行时环境变量」。按会话注入，新会话生效，不影响别的机器人。
-- **daemon 环境**：export 之后重启 daemon。注意 pm2 只保留首次启动时捕获的环境，改过之后要 `pm2 restart --update-env`（或者 delete + start）才生效，只 `botmux restart` 不行。
+## 自定义组合（可选）
 
-per-bot env 在沙箱模式下偶尔透传不进去，遇到这种情况退回 daemon 环境即可。
+runner 每次启动会把内置的默认组合覆写到 `~/.botmux/dsh/cordis.yml`，直接修改该文件无效。需要自定义时设置 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 优先读取该文件。
 
-### 自定义组合（可选）
-
-runner 每次启动会把内置的默认组合**覆写**到 `~/.botmux/dsh/cordis.yml`——直接改这个文件没用，改完下次启动就被覆盖。要自定义，设置 `DSH_CORDIS_CONFIG=<绝对路径>`，runner 优先读这个文件。
-
-默认组合的完整内容如下；需要改路由时复制一份，只调整 `llm-deepseek` 那一段即可。下面是走 zen/go 网关的示例：
+默认组合如下；需要改路由时复制一份，仅调整 `llm-deepseek` 段。以下为走 zen/go 网关的示例：
 
 ```yaml
 - id: sdk-jsonrpc-server
@@ -76,23 +75,19 @@ runner 每次启动会把内置的默认组合**覆写**到 `~/.botmux/dsh/cordi
   name: '@deepseek-ai/dsh-fs-local'
 ```
 
-## 原理速览
+## 会话与版本
 
-一条链：飞书消息 → botmux daemon → worker → `dsh-runner.js`（botmux 的桥接层）→ `dsh-jsonrpc-agent`（你装的运行时）→ 组合里的 `llm-deepseek` → HTTP 调模型。
+- **会话目录**：`~/.botmux/dsh/`，runner 自动创建，适配器将其声明为 `authPaths`，文件沙箱内可写。
+- **版本兼容**：botmux 内置默认组合与 dsh 运行时的协议版本绑定，升级 dsh 运行时前需确认与当前 botmux runner 的协议兼容。
 
-两个容易忽略的点：
+## 常见问题
 
-- **升级 dsh 运行时要谨慎**：botmux 内置的默认组合和 dsh 的协议版本绑定，运行时大版本升级前先确认和当前 botmux 的 runner 兼容。
-- **会话落在哪**：`~/.botmux/dsh/`，runner 自动创建，适配器把它声明为 `authPaths`，文件沙箱里也可写。
+| 现象 | 原因与处理 |
+|------|-----------|
+| dashboard 无 DeepSeek Harness 选项 | botmux 版本过旧，无 dsh 适配器。升级 botmux |
+| 报找不到 dsh-jsonrpc-agent | 运行时未安装或不在 PATH。安装 `deepseek-harness-sdk` 并将 `dsh-jsonrpc-agent` 加入 PATH（或配置 `pathOverride`） |
+| `no API key for provider route "deepseek-official"` | key 未进入进程环境（`~/.dsh/.credentials.yaml` 不生效）。通过 per-bot env 或 daemon 环境配置 key |
+| per-bot env 已配置仍报缺 key | 沙箱未传递该环境变量。改用 daemon 环境（export 后 `pm2 restart --update-env`） |
+| `UNKNOWN_MODEL` 或 401 | model 不在该路由的模型列表，或 key 有误。核对 model 字段、key、baseURL |
 
-## 排错速查
-
-| 现象 | 原因 | 处理 |
-|------|------|------|
-| dashboard 里没有 DeepSeek Harness 选项 | botmux 版本旧，没有 dsh 适配器 | 升级 botmux |
-| 有选项，但报找不到 dsh-jsonrpc-agent | 运行时没装，或不在 PATH | `pip install deepseek-harness-sdk`，把 `dsh-jsonrpc-agent` 放进 PATH（或配 `pathOverride`） |
-| `no API key for provider route "deepseek-official"` | key 没进进程环境，`~/.dsh/.credentials.yaml` 不算数 | 用 per-bot env 或 daemon 环境配 key |
-| per-bot env 配了还是报缺 key | 沙箱可能没透传这个变量 | 退回 daemon 环境：export 后 `pm2 restart --update-env` |
-| `UNKNOWN_MODEL` 或 401 | model 不在该路由的模型列表里，或 key 不对 | 核对 model 字段、key、baseURL 三者 |
-
-`GET /api/cli-options` 返回 `dsh: available: true/false`，可以快速确认适配器本身是否可用。
+`GET /api/cli-options` 返回 `dsh: available: true/false`，可确认适配器是否可用。


### PR DESCRIPTION
## 改动

新增 `docs/dsh.md`：DeepSeek Harness（dsh）适配器的接入指南，覆盖：

- 快速接入：安装运行时、机器人配置项、验证
- 凭据配置：`~/.dsh` 全局配置不生效，凭据只能通过环境变量注入；两种注入方式及沙箱注意事项
- 自定义组合：`DSH_CORDIS_CONFIG` 覆写行为、默认组合内容与 zen/go 网关示例
- 原理速览：进程链、版本兼容、会话目录
- 常见问题：5 类现象的原因与处理

## 为什么

dsh 适配器（#858）引入后缺少面向用户的接入文档。dsh 在 botmux 里的凭据链路（不读 `~/.dsh`）和默认组合覆写行为与单独使用 dsh 时差异较大，实际接入容易踩坑，整理成文档便于按步骤接入与排错。

## 影响面

纯文档新增，无代码变更，不影响任何运行时行为。

## 验证

- 内容与 `src/adapters/cli/dsh.ts`、`src/dsh-runner.ts` 实现逐项核对（环境变量名、默认组合、provider 路由、model 选项、会话目录）
- 结构与语气对齐仓库既有接入指南 `docs/riff.md`
