### PR TITLE
fix(session): mismatch 关闭前复核持久 authority，不再只信进程内镜像

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -997,6 +997,14 @@ function normalizeMessageListeners(raw: unknown, botIndex: number): Record<strin
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+/**
+ * A bots.json row may omit `cliId`. Historically that means claude-code, and such
+ * a row can still carry a legacy `cliPathOverride`. Anything that derives a
+ * selection from a RAW row must apply this same default, otherwise the selection
+ * looks changed and preservation logic is skipped. Exported so there is exactly
+ * one definition of the legacy default.
+ */
+export const LEGACY_DEFAULT_CLI_ID = 'claude-code';
 export interface OncallChat {
   /** Lark chat_id (oc_xxx) the bot was pulled into. */
   chatId: string;
@@ -2495,7 +2503,7 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
     // also persist an exactly-equal path shadow so a rollback to an older
     // BotMux still launches the same distribution. Any unequal pair would make
     // old and new versions disagree, so it fails closed below.
-    const entryCliId = entry.cliId ?? 'claude-code';
+    const entryCliId = entry.cliId ?? LEGACY_DEFAULT_CLI_ID;
     if (entry.cliRuntime !== undefined && entryCliId !== 'codex') {
       throw new Error(`Bot config [${i}]: cliRuntime is currently supported only for cliId "codex"`);
     }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -12,6 +12,7 @@ import * as sessionStore from '../services/session-store.js';
 import * as messageQueue from '../services/message-queue.js';
 import { downloadMessageResource, listChatBotMembers, UserTokenMissingError } from '../im/lark/client.js';
 import { logger } from '../utils/logger.js';
+import { findEntryIndex, readRawConfig, requireConfigPath } from '../services/config-store.js';
 import { forkWorker, sendWorkerInput, promoteQueuedActivationTail, forkAdoptWorker, adoptSandboxBlocked, killStalePids, sweepDeadPidMarkers, getCurrentCliVersion, restoreUsageLimitRuntimeState, setActiveSessionSafe, setActiveSessionIfActive, isDisposableCommandScratch, isRelayableRealSession, closeSession, getActiveSessionsRegistry, suspendWorker, withActiveSessionKeyLock, isSessionTransferring, deferUntilSessionTransferSettled } from './worker-pool.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { buildBotmuxShellHints } from '../adapters/cli/shared-hints.js';
@@ -34,7 +35,7 @@ import {
 } from './persistent-backend.js';
 import type { PersistentBackendTarget } from '../adapters/backend/types.js';
 import { adoptTargetLabel, validateAdoptTargetState } from './session-discovery.js';
-import { getBot, getAllBots, getOwnerOpenId, findOncallChat, effectiveDefaultWorkingDir } from '../bot-registry.js';
+import { getBot, getAllBots, getOwnerOpenId, findOncallChat, effectiveDefaultWorkingDir, LEGACY_DEFAULT_CLI_ID } from '../bot-registry.js';
 import type { BotConfig } from '../bot-registry.js';
 import type { CliId } from '../adapters/cli/types.js';
 import { sameRuntimeIdentity, type CliRuntimeConfig, type CliRuntimeSnapshot } from '../adapters/cli/runtime.js';
@@ -239,13 +240,46 @@ function sameUsageLimit(a: DaemonSession['usageLimit'], b: DaemonSession['usageL
   return usageLimitStateKey(a) === usageLimitStateKey(b) && a.retryReady === b.retryReady;
 }
 
-function sessionBotCliMismatch(ds: DaemonSession): { sessionCli: string; botCli: string } | null {
-  const sessionCliId = ds.session.cliId;
+/** The launch identity a session is compared against. */
+export interface CliMismatchTargetConfig {
+  cliId?: CliId;
+  cliRuntime?: CliRuntimeConfig;
+  cliPathOverride?: string;
+  wrapperCli?: string;
+}
+
+/**
+ * Compare a session's FROZEN launch identity against a target config.
+ *
+ * `target` is explicit so the agent-switch transaction can ask "which sessions
+ * WOULD mismatch if I committed this config" BEFORE writing it. Deriving the
+ * answer from live bot config forces a commit-then-reconcile order, which is
+ * exactly the ordering that let a failed close leave the config switched while
+ * old-agent sessions stayed routable.
+ */
+export function sessionMismatchesTargetCli(
+  ds: DaemonSession,
+  target: CliMismatchTargetConfig,
+): { sessionCli: string; botCli: string } | null {
+  return sessionRowMismatchesTargetCli(ds.session, target);
+}
+
+/**
+ * Same comparison against a DURABLE row.
+ *
+ * The agent switch must also consider rows that are active on disk but absent
+ * from the runtime registry — every field this compares lives on Session, so
+ * there is no need to fabricate a DaemonSession to reach them.
+ */
+export function sessionRowMismatchesTargetCli(
+  row: Session,
+  target: CliMismatchTargetConfig,
+): { sessionCli: string; botCli: string } | null {
+  const sessionCliId = row.cliId;
   if (!sessionCliId) return null;
-  let botCfg: { cliId?: CliId; cliRuntime?: CliRuntimeConfig; cliPathOverride?: string; wrapperCli?: string };
-  try { botCfg = getBot(ds.larkAppId).config; } catch { return null; }
+  const botCfg = target;
   if (!botCfg.cliId) return null;
-  const sessionWrapper = ds.session.wrapperCli?.trim() || undefined;
+  const sessionWrapper = row.wrapperCli?.trim() || undefined;
   const botWrapper = botCfg.wrapperCli?.trim() || undefined;
   const describe = (
     cliId: CliId,
@@ -258,7 +292,7 @@ function sessionBotCliMismatch(ds: DaemonSession): { sessionCli: string; botCli:
   };
   if (sessionCliId !== botCfg.cliId) {
     return {
-      sessionCli: describe(sessionCliId, ds.session.cliRuntime, ds.session.cliPathOverride, sessionWrapper),
+      sessionCli: describe(sessionCliId, row.cliRuntime, row.cliPathOverride, sessionWrapper),
       botCli: describe(botCfg.cliId, botCfg.cliRuntime, botCfg.cliPathOverride, botWrapper),
     };
   }
@@ -266,11 +300,11 @@ function sessionBotCliMismatch(ds: DaemonSession): { sessionCli: string; botCli:
   // 启动选择（selectionKeyForBot 以 cliId+wrapperCli 为键），wrapper 间切换同样不能
   // 复活旧会话。仅 agentFrozen 的会话有可靠的 wrapper 快照——legacy 未冻结会话下次
   // fork 会从 live bot 配置回填 wrapper，天然不会在这条轴上失配。
-  if (ds.session.agentFrozen && !sameRuntimeIdentity(
+  if (row.agentFrozen && !sameRuntimeIdentity(
     {
       cliId: sessionCliId,
-      cliRuntime: ds.session.cliRuntime,
-      cliPathOverride: ds.session.cliPathOverride,
+      cliRuntime: row.cliRuntime,
+      cliPathOverride: row.cliPathOverride,
       wrapperCli: sessionWrapper,
     },
     {
@@ -281,11 +315,106 @@ function sessionBotCliMismatch(ds: DaemonSession): { sessionCli: string; botCli:
     },
   )) {
     return {
-      sessionCli: describe(sessionCliId, ds.session.cliRuntime, ds.session.cliPathOverride, sessionWrapper),
+      sessionCli: describe(sessionCliId, row.cliRuntime, row.cliPathOverride, sessionWrapper),
       botCli: describe(botCfg.cliId, botCfg.cliRuntime, botCfg.cliPathOverride, botWrapper),
     };
   }
   return null;
+}
+
+/** Live-config comparison — the restore / reattach / sweep paths. */
+function sessionBotCliMismatch(ds: DaemonSession): { sessionCli: string; botCli: string } | null {
+  let botCfg: CliMismatchTargetConfig;
+  try { botCfg = getBot(ds.larkAppId).config; } catch { return null; }
+  return sessionMismatchesTargetCli(ds, botCfg);
+}
+
+/**
+ * The bot's launch identity as it exists ON DISK right now.
+ *
+ * `getBot().config` is a per-process mirror: another daemon committing to
+ * bots.json does not update it. Every close in this module is irreversible, so a
+ * close must never be justified by that mirror alone — see
+ * `confirmMismatchAgainstDisk`.
+ *
+ * Returns 'unreadable' rather than a guess, and undefined when the row is gone.
+ */
+async function readPersistedBotIdentity(
+  larkAppId: string,
+): Promise<CliMismatchTargetConfig | undefined | 'unreadable' | 'no_persisted_config'> {
+  let path: string;
+  try {
+    // No persisted config at all (a deployment that never wrote one, or a unit
+    // test): there is no durable authority to consult, so the live config IS the
+    // authority. This is NOT the same as "a config exists but cannot be read",
+    // which is untrustworthy and must fail closed.
+    path = requireConfigPath();
+  } catch {
+    return 'no_persisted_config';
+  }
+  try {
+    const raw = await readRawConfig(path);
+    const idx = findEntryIndex(raw, larkAppId);
+    if (idx < 0) return undefined;
+    const row = raw[idx] as Record<string, unknown>;
+    return {
+      // Same loader default as everywhere else: a legacy row omitting cliId means
+      // claude-code, not "no selection".
+      cliId: (row.cliId ?? LEGACY_DEFAULT_CLI_ID) as CliMismatchTargetConfig['cliId'],
+      wrapperCli: row.wrapperCli as string | undefined,
+      cliRuntime: row.cliRuntime as CliMismatchTargetConfig['cliRuntime'],
+      cliPathOverride: row.cliPathOverride as string | undefined,
+    };
+  } catch {
+    return 'unreadable';
+  }
+}
+
+/**
+ * Re-justify a mismatch against the DURABLE config, immediately before closing.
+ *
+ * This is the single choke point for every mismatch-driven close in this module,
+ * including the deferred ones. That matters because a deferred callback runs an
+ * unbounded time later: `armCliMismatchResweep` waits for a transfer to settle,
+ * and `onCodexAppLedgerDrained` waits for a FIFO to drain. Proving the authority
+ * had not diverged when the retry was ARMED proves nothing about when it RUNS —
+ * another process can commit in between, and this process's mirror would still
+ * show the old value. Closing then destroys a session the durable config
+ * endorses, which nothing downstream can undo.
+ *
+ * Fail-closed: an unreadable authority or a missing row skips the close. Missing
+ * a close is recoverable (the next sweep/restore retries it); mis-closing is not.
+ */
+async function confirmMismatchAgainstDisk(ds: DaemonSession): Promise<boolean> {
+  const disk = await readPersistedBotIdentity(ds.larkAppId);
+  // Nothing durable to check against ⇒ the live decision already made by the
+  // caller stands. Refusing here would disable mismatch convergence entirely for
+  // such deployments.
+  if (disk === 'no_persisted_config') return true;
+  if (disk === 'unreadable') {
+    logger.error(
+      `[${ds.session.sessionId.substring(0, 8)}] CLI mismatch close skipped: the persisted bot `
+      + 'config could not be read, so the close cannot be justified',
+    );
+    return false;
+  }
+  if (!disk) {
+    logger.warn(
+      `[${ds.session.sessionId.substring(0, 8)}] CLI mismatch close skipped: the bot row is gone `
+      + 'from the persisted config',
+    );
+    return false;
+  }
+  if (!sessionMismatchesTargetCli(ds, disk)) {
+    // The durable config now endorses this session (typically another process
+    // committed after our decision, or after this retry was armed).
+    logger.warn(
+      `[${ds.session.sessionId.substring(0, 8)}] CLI mismatch close skipped: the persisted config `
+      + 'no longer marks this session as stale',
+    );
+    return false;
+  }
+  return true;
 }
 
 type CliMismatchCloseResult =
@@ -317,6 +446,12 @@ function armCliMismatchResweep(ds: DaemonSession): void {
 async function closeActiveSessionIfCliMismatch(ds: DaemonSession): Promise<CliMismatchCloseResult> {
   const mismatch = sessionBotCliMismatch(ds);
   if (!mismatch) return 'not_mismatched';
+
+  // The live mirror said "stale"; the DURABLE config has the final word. Placed
+  // here so every caller is covered at once — the bot-level sweep, the deferred
+  // transfer resweep, the ledger-drained resweep and restore — instead of each one
+  // having to remember to consult the authority itself.
+  if (!await confirmMismatchAgainstDisk(ds)) return 'not_mismatched';
 
   // A config mismatch is not an explicit user close. In particular, bots.json
   // may be edited while the daemon is down, leaving a persisted backend-neutral

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -75,6 +75,33 @@ vi.mock('../src/services/frozen-card-store.js', () => ({
 // Map the test passes into restoreActiveSessions — production's closeSession
 // evicts from activeSessionsRegistry, which IS that Map.
 const wp = vi.hoisted(() => ({ registry: null as Map<string, any> | null }));
+/**
+ * The DURABLE bot identity, independently controllable from the in-memory `bot`.
+ *
+ * That split is the whole point: a close must be justified by what is on disk, not
+ * by this process's mirror, and only a fixture that can make them disagree can
+ * prove it.
+ */
+const disk = vi.hoisted(() => ({
+  /** undefined ⇒ no persisted config at all (live config is then the authority). */
+  rows: undefined as any[] | undefined,
+  unreadable: false,
+}));
+
+vi.mock('../src/services/config-store.js', () => ({
+  requireConfigPath: vi.fn(() => {
+    if (!disk.rows && !disk.unreadable) throw new Error('Bot config path unknown');
+    return '/tmp/fixture-bots.json';
+  }),
+  readRawConfig: vi.fn(async () => {
+    if (disk.unreadable) throw new Error('EACCES');
+    return disk.rows ?? [];
+  }),
+  findEntryIndex: vi.fn((rows: any[], id: string) => rows.findIndex(r => r?.larkAppId === id)),
+  rmwBotEntry: vi.fn(),
+  writeRawConfigAtomic: vi.fn(),
+}));
+
 const transferState = vi.hoisted(() => ({
   active: new WeakSet<object>(),
   callbacks: new WeakMap<object, Set<() => void>>(),
@@ -289,6 +316,8 @@ beforeEach(() => {
   zmxSnapshot.unhealthySessions = [];
   herdrProbe.result = 'exists';
   bot.cliId = 'claude-code';
+  disk.rows = undefined;
+  disk.unreadable = false;
   bot.cliRuntime = undefined;
   bot.cliPathOverride = undefined;
   bot.wrapperCli = undefined;
@@ -886,6 +915,99 @@ describe('closeCliMismatchedSessionsForBot — runtime CLI hot-switch sweep', ()
 
   beforeEach(() => {
     wp.registry = new Map<string, DaemonSession>();
+  });
+
+  // The DURABLE config has the final word on every irreversible close.
+  //
+  // getBot().config is a per-process mirror: another daemon committing to
+  // bots.json does not update it. Every entry point into this sweep — including
+  // the deferred ones (a transfer settling, a Codex App ledger draining) — runs an
+  // unbounded time after the decision to retry was made, so the mirror can be
+  // arbitrarily stale by then. Judging a close by it destroys sessions the
+  // persisted config endorses, and nothing downstream can undo that.
+  it('does NOT close when the persisted config exists but cannot be READ', async () => {
+    // "Exists but unreadable" is untrustworthy. That is different from having no
+    // persisted config at all, where the live config legitimately IS the authority
+    // — treating both the same way would disable mismatch convergence outright.
+    const s1 = makeActivePersistentSession('om_auth_unreadable');
+    s1.cliId = 'codex';
+    sessionStore.updateSession(s1);
+    registerDs(s1);
+    disk.unreadable = true;
+
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(0);
+    expect(closeSession).not.toHaveBeenCalledWith(s1.sessionId);
+    expect(sessionStore.getSession(s1.sessionId)!.status).toBe('active');
+  });
+
+  it('does NOT close a session the PERSISTED config still endorses', async () => {
+    // The live mirror says claude-code (so the codex session looks stale), but disk
+    // says codex — another process committed it. The session is correct under the
+    // durable authority and must survive.
+    const s1 = makeActivePersistentSession('om_auth_endorsed');
+    s1.cliId = 'codex';
+    sessionStore.updateSession(s1);
+    registerDs(s1);
+    disk.rows = [{ larkAppId: 'app_test', cliId: 'codex' }];
+
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(0);
+    expect(closeSession).not.toHaveBeenCalledWith(s1.sessionId);
+    expect(sessionStore.getSession(s1.sessionId)!.status).toBe('active');
+  });
+
+  it('DOES close when the persisted config agrees the session is stale', async () => {
+    // The guard must not disable the feature it protects.
+    const s1 = makeActivePersistentSession('om_auth_stale');
+    s1.cliId = 'codex';
+    sessionStore.updateSession(s1);
+    registerDs(s1);
+    disk.rows = [{ larkAppId: 'app_test', cliId: 'claude-code' }];
+
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(1);
+    expect(closeSession).toHaveBeenCalledWith(s1.sessionId);
+  });
+
+  it('skips the close when the bot row is GONE from the persisted config', async () => {
+    const s1 = makeActivePersistentSession('om_auth_rowgone');
+    s1.cliId = 'codex';
+    sessionStore.updateSession(s1);
+    registerDs(s1);
+    disk.rows = [{ larkAppId: 'someone-else', cliId: 'traex' }];
+
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(0);
+    expect(closeSession).not.toHaveBeenCalledWith(s1.sessionId);
+    expect(sessionStore.getSession(s1.sessionId)!.status).toBe('active');
+  });
+
+  it('a DEFERRED retry re-reads disk, so a commit during the wait cannot mis-close', async () => {
+    // The retry runs after the transfer gate settles. Showing the authority had not
+    // diverged when the retry was ARMED proves nothing about when it RUNS.
+    const relaying = makeActivePersistentSession('om_auth_deferred');
+    relaying.cliId = 'codex';
+    sessionStore.updateSession(relaying);
+    const ds = registerDs(relaying);
+    transferState.active.add(ds);
+    disk.rows = [{ larkAppId: 'app_test', cliId: 'claude-code' }];
+
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(0);
+    expect(closeSession).not.toHaveBeenCalledWith(relaying.sessionId);
+
+    // While the transfer settles, another process commits codex back — the session
+    // is frozen on codex, so disk now endorses it. The live mirror is untouched,
+    // because that write happened in a different process.
+    disk.rows = [{ larkAppId: 'app_test', cliId: 'codex' }];
+
+    const callbacks = [...(transferState.callbacks.get(ds) ?? [])];
+    expect(callbacks, 'a deferred retry must have been armed').toHaveLength(1);
+    transferState.active.delete(ds);
+    for (const callback of callbacks) callback();
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(
+      closeSession,
+      'the deferred retry must re-read disk, not inherit the stale live mirror',
+    ).not.toHaveBeenCalledWith(relaying.sessionId);
+    expect(sessionStore.getSession(relaying.sessionId)!.status).toBe('active');
   });
 
   it('closes mismatched sessions of this bot, keeps matching ones', async () => {


### PR DESCRIPTION
## 问题

`closeCliMismatchedSessionsForBot` / `restoreActiveSessions` / `resumeSession` 这些
mismatch 驱动的关闭，判定依据一直是 `getBot(larkAppId).config` —— 一个**进程内镜像**。
另一个 daemon 提交 `bots.json` 不会更新它，因此在多 daemon、或「手工编辑 bots.json」
（仓库明确支持）场景下，本进程可能按已过期的镜像关闭一个持久配置实际认可的会话。
关闭不可逆，无法由任何后续步骤撤销。

更要紧的是**延迟路径**：`armCliMismatchResweep` 等 transfer 结算、
`onCodexAppLedgerDrained` 等 Codex App FIFO 排空，都是**无界延迟**。
「注册重试时镜像还没过期」不能推出「重试执行时仍没过期」。

## 改法

在**所有 mismatch 关闭的共同咽喉点** `closeActiveSessionIfCliMismatch` 插入持久权威复核，
一次覆盖 bot 级 sweep、transfer 延迟 resweep、ledger-drained resweep、restore —— 而不是
让每个入口各自传递 authority（那必然漏）。

- `readPersistedBotIdentity()`：读 bots.json 得该 bot 当前启动身份，返回**四态**
- `confirmMismatchAgainstDisk()`：关闭前复核，不通过则跳过
- 抽出 `CliMismatchTargetConfig` / `sessionRowMismatchesTargetCli`，使「按显式 target 比对」
  与「按 live config 比对」共用同一判定，避免两处漂移
- 从 `bot-registry` 导出 `LEGACY_DEFAULT_CLI_ID` 作为「省略 cliId 即 claude-code」的唯一定义源

### 四态必须区分（不是过度设计）

| 状态 | 含义 | 行为 |
|---|---|---|
| identity | 读到身份 | 正常比对 |
| `no_persisted_config` | 压根没有持久配置（未落盘部署／单测） | **放行**，live 即权威 |
| `unreadable` | 有配置但读不出 | **fail-closed**，不关 |
| `undefined` | 行已消失 | 跳过 |

把 `no_persisted_config` 也 fail-closed 会**彻底禁掉** mismatch 收敛 —— 变异验证时该改动
打断 11 条既有用例。

## 安全保证（精确表述）

✅ 关闭决策在做出的**瞬间**依据的是持久状态，而非可能过期的进程内镜像。

❌ **不保证**「当前 persisted authority 认可的会话永不被误关」。`read → close` 不是原子的：

```
session frozen=C，磁盘 authority=B
→ 复核读到 B，正确判定该会话 stale
→ closeSession() 执行（远端 CLI 可能数秒）
→ 期间另一 writer 提交 C，该会话已被新 authority 重新认可
→ 它仍然被关闭
```

相比现状**只缩小了窗口，没有消除误关**。请勿将其理解为「只会漏关」。

### 彻底消除需二选一（均超出本 PR）

1. 所有 authority writer 与 close **共用 per-bot 跨进程 fence 并跨 close 持有** ——
   在 bots.json 可手工编辑、且旧版 daemon 也会写的前提下**不可达**
2. **不在配置切换请求中主动 close**，改由 turn admission / resume 读取 fresh authority 后
   隔离/拒绝旧 session —— 不可逆动作不再基于任何过期前提

**该边界需要产品明确接受。** 若不接受弱保证，应先做方案 2 再合并本 PR。

## 已知限制：refusal 补偿是一次性 best-effort

`closeSession` 返回 refusal（`mojo_cancel_failed` 等）时会安排**一次**重试；若该重试再次
refuse，bot 级 sweep 只计数并返回，不再安排下一次。失败会上报给调用方因此可见，但**不是
确定性收敛**。

## 验收标准

- [x] `tsc --noEmit` / `pnpm build` 干净
- [x] 全量两轮，失败文件集合与主干基线**差集为空**
- [x] 5 条运行时行为测试（无源码字符串断言），新增可控 disk fixture 与内存 bot 解耦
- [x] 3 个变异全部精确红：M1 删复核→4 条红；M2 unreadable 放行→1 条红；
      M3 `no_persisted_config` 也 fail-closed→11 条红
- [ ] **产品确认**上述「仍可能误关」的边界，或决定改走 turn-admission 方案

## 与 #803 的关系

原先包含在 #803（mojo harness）中，按复审建议拆出：这部分改的是核心并发语义、不是 mojo
必要改动，混在 +2196 行 mojo 主体里 reviewer 无法分开评估。#803 已 rebase 为仅保留 mojo
必需改动（agent-switch 相关 +943/-148 → +224/-19）。
