### PR TITLE
fix(worker): 适配 CoCo 0.200+ 的 TRAE rollout 存储，恢复 transcript 桥接与 resume

### DIFF
--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -127,10 +127,10 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
     authPaths: ['~/.trae/cli', '~/.cache/coco'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
-    buildArgs({ sessionId, resume, model, disableCliBypass }) {
+    buildArgs({ sessionId, resumeSessionId, resume, model, disableCliBypass }) {
       const args: string[] = [];
       if (resume) {
-        args.push('--resume', sessionId);
+        args.push('--resume', resumeSessionId ?? sessionId);
       } else {
         args.push('--session-id', sessionId);
       }
@@ -144,8 +144,8 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
       return args;
     },
 
-    buildResumeCommand({ sessionId }) {
-      return `coco --resume ${sessionId}`;
+    buildResumeCommand({ sessionId, cliSessionId }) {
+      return `coco --resume ${cliSessionId ?? sessionId}`;
     },
 
     async writeInput(pty: PtyHandle, content: string) {

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -98,6 +98,34 @@ export function isBareShellComm(comm: string | undefined): boolean {
   return BARE_SHELL_COMMS.has(comm.startsWith('.') ? comm.slice(1) : comm);
 }
 
+/**
+ * Let a managed launch wrapper finish its final `exec <cli>` before deciding
+ * that the pane is stuck at an interactive shell.
+ *
+ * A tmux pane can legitimately report the wrapper shell for a few milliseconds
+ * after spawn. Treating that single sample as terminal permanently blocks the
+ * session even though the CLI starts immediately afterward. Non-shell samples
+ * return without delay; only a shell-shaped sample consumes the bounded grace
+ * period.
+ */
+export async function settleLaunchComm(
+  read: () => string | undefined,
+  opts: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<string | undefined> {
+  let comm = read();
+  if (!isBareShellComm(comm)) return comm;
+
+  const timeoutMs = Math.max(0, opts.timeoutMs ?? 2_000);
+  const pollMs = Math.max(1, opts.pollMs ?? 100);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+    comm = read();
+    if (!isBareShellComm(comm)) return comm;
+  }
+  return comm;
+}
+
 /** Classify a confirmed bare-shell launch for diagnostics: 'trampoline' when the
  *  observed leaf shell differs from the shell botmux launched with — the
  *  signature of an rcfile that `exec`-trampolines into another shell (e.g.

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -3340,6 +3340,14 @@ function setupWorkerHandlers(
           logger.debug(`[${t}] final_output deduped (key ${dedupeKey.substring(0, 48)})`);
           break;
         }
+        if (msg.suppressedDelivery) {
+          // The CLI already posted this answer in-band (`botmux send`), so
+          // skip Lark delivery entirely. Commit the dedupe marker so a
+          // redrain cannot re-forward the same turn.
+          ds.lastBridgeEmittedUuid = dedupeKey;
+          logger.info(`[${t}] final_output observed without delivery for turn ${msg.turnId.substring(0, 8)} (CLI self-delivered)`);
+          break;
+        }
         // Worker pops the turn off its queue right after emit, so it will
         // NOT re-send this payload on its own. Daemon owns retry on
         // transient Lark failures.

--- a/src/services/coco-transcript.ts
+++ b/src/services/coco-transcript.ts
@@ -20,6 +20,8 @@ import { join } from 'node:path';
 import { cocoCacheRoot } from './coco-paths.js';
 import { scanJsonlFromOffset } from './jsonl-cursor.js';
 import { logger } from '../utils/logger.js';
+import { codexSessionIdFromRolloutPath } from './codex-transcript.js';
+import { drainTraexRollout, findTraexRolloutByPid } from './traex-transcript.js';
 
 const COCO_SESSIONS_ROOT = join(cocoCacheRoot(), 'sessions');
 const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -80,7 +82,13 @@ export function findCocoSessionByPid(
         const hit = matchCocoSessionPath(target);
         if (hit) return hit;
       }
-      return undefined;
+      // CoCo 0.200+ migrated from ~/.cache/coco/sessions/<sid>/events.jsonl
+      // to the Codex-shaped TRAE rollout store. Fall through to that finder
+      // when the process has no legacy CoCo session fd.
+      const rollout = findTraexRolloutByPid(pid);
+      return rollout
+        ? { sessionId: rollout.cliSessionId, eventsPath: rollout.path }
+        : undefined;
     }
   }
   let out: string;
@@ -98,7 +106,10 @@ export function findCocoSessionByPid(
     const hit = matchCocoSessionPath(target);
     if (hit) return hit;
   }
-  return undefined;
+  const rollout = findTraexRolloutByPid(pid);
+  return rollout
+    ? { sessionId: rollout.cliSessionId, eventsPath: rollout.path }
+    : undefined;
 }
 
 function matchCocoSessionPath(target: string): { sessionId: string; eventsPath: string } | undefined {
@@ -149,6 +160,12 @@ function parseCocoBridgeEvent(path: string, line: string, lineStart: number): Co
 
 /** Increment-read a CoCo events.jsonl from `fromOffset`. */
 export function drainCocoEvents(path: string, fromOffset: number): CocoDrainResult {
+  // CoCo 0.200+ writes Codex-shaped rollout JSONL under ~/.trae/cli/sessions.
+  // Keep the worker-facing API stable and dispatch by the canonical rollout
+  // filename, while legacy CoCo events.jsonl continues through the parser below.
+  if (codexSessionIdFromRolloutPath(path)) {
+    return drainTraexRollout(path, fromOffset);
+  }
   if (!existsSync(path)) return { events: [], newOffset: 0, pendingTail: '' };
   let size: number;
   try { size = statSync(path).size; } catch { return { events: [], newOffset: fromOffset, pendingTail: '' }; }

--- a/src/services/file-bridge-path.ts
+++ b/src/services/file-bridge-path.ts
@@ -10,7 +10,11 @@
  */
 import { existsSync } from 'node:fs';
 import { findCodexRolloutByPid, findCodexRolloutBySessionId } from './codex-transcript.js';
-import { findTraexRolloutByPid, findTraexRolloutBySessionId } from './traex-transcript.js';
+import {
+  findTraexRolloutByPid,
+  findTraexRolloutBySessionId,
+  findTraexSessionIdByThreadName,
+} from './traex-transcript.js';
 import { cocoEventsPathForSession, findCocoSessionByPid } from './coco-transcript.js';
 import { findPiTranscriptByPid, findPiTranscriptBySessionId } from './pi-transcript.js';
 import { findGrokSessionByPid, findGrokUpdatesBySessionId } from './grok-transcript.js';
@@ -44,7 +48,13 @@ function resolveBySessionId(cliId: string, sessionId: string, cwd?: string): str
   switch (cliId) {
     case 'coco': {
       const p = cocoEventsPathForSession(sessionId);
-      return existsSync(p) ? p : undefined;
+      if (existsSync(p)) return p;
+      const directRollout = findTraexRolloutBySessionId(sessionId);
+      if (directRollout) return directRollout;
+      const indexedSessionId = findTraexSessionIdByThreadName(sessionId);
+      return indexedSessionId
+        ? findTraexRolloutBySessionId(indexedSessionId)
+        : undefined;
     }
     case 'pi':
       return findPiTranscriptBySessionId(sessionId, cwd);

--- a/src/services/traex-paths.ts
+++ b/src/services/traex-paths.ts
@@ -21,6 +21,12 @@ export function traeStateDbPath(): string {
   return join(traeHome(), 'cli', 'state_5.sqlite');
 }
 
+/** Append-only mapping maintained by TRAE/CoCo from native session id to the
+ *  user-visible thread name supplied through CoCo's legacy --session-id flag. */
+export function traeSessionIndexPath(): string {
+  return join(traeHome(), 'cli', 'session_index.jsonl');
+}
+
 /** Per-session rollout JSONL files live under dates here, e.g.
  *  sessions/2026/06/04/rollout-<timestamp>-<uuid>.jsonl. The threads table
  *  stores the absolute path per session. */

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -69,6 +69,15 @@ function abortErrorCode(reason: unknown): string {
   return `traex_turn_aborted:${normalized}`;
 }
 
+/** Paths that have ever yielded a `response_item` user record. CoCo 0.200+
+ *  intermittently writes rollouts in a "history_mutation" dialect with NO
+ *  response_item records at all — user input exists only as event_msg
+ *  user_message (observed 2026-08-15/17/18 champion sessions, where the
+ *  completed turn was silently lost). In the response_item dialect the same
+ *  event_msg form appears ~100ms later as a mirror of the authoritative
+ *  record, so it is only honored for paths that never produced one. */
+const pathsWithResponseItemUser = new Set<string>();
+
 /** Incrementally drain complete TRAE rollout lines.
  *
  * `task_complete` is intentionally emitted even when last_agent_message is
@@ -115,6 +124,16 @@ export function drainTraexRollout(path: string, fromOffset: number): CodexDrainR
       && payload.type === 'message'
       && payload.role === 'user') {
       const userText = joinInputText(payload.content);
+      if (userText) {
+        pathsWithResponseItemUser.add(path);
+        events.push({ ...base, kind: 'user', text: userText });
+      }
+      continue;
+    }
+    if (obj.type === 'event_msg'
+      && payload.type === 'user_message'
+      && !pathsWithResponseItemUser.has(path)) {
+      const userText = typeof payload.message === 'string' ? payload.message : '';
       if (userText) events.push({ ...base, kind: 'user', text: userText });
       continue;
     }

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -19,6 +19,7 @@ import {
   closeSync,
   existsSync,
   openSync,
+  readFileSync,
   readSync,
   readdirSync,
   readlinkSync,
@@ -34,7 +35,7 @@ import {
   type CodexDrainResult,
   codexSessionIdFromRolloutPath,
 } from './codex-transcript.js';
-import { traeSessionsRoot } from './traex-paths.js';
+import { traeSessionIndexPath, traeSessionsRoot } from './traex-paths.js';
 
 export { splitCodexEventsByCutoff as splitTraexEventsByCutoff };
 export { extractLastCodexTurn as extractLastTraexTurn };
@@ -239,6 +240,45 @@ export function findTraexRolloutBySessionId(cliSessionId: string): string | unde
         return full;
       }
     }
+  }
+  return undefined;
+}
+
+/** Resolve the newest live native session associated with a CoCo thread name.
+ *
+ * CoCo 0.200+ accepts botmux's UUID through the legacy `--session-id` flag as
+ * the thread name, but allocates a different native session UUID for rollout
+ * storage and `--resume`. The append-only session index is the durable link
+ * between those two ids. Walk newest-first and require an existing rollout so
+ * stale index entries cannot send the CLI into another failed-resume loop. */
+export function findTraexSessionIdByThreadName(threadName: string): string | undefined {
+  if (!threadName) return undefined;
+  const indexPath = traeSessionIndexPath();
+  if (!existsSync(indexPath)) return undefined;
+  let content: string;
+  try {
+    content = readFileSync(indexPath, 'utf8');
+  } catch {
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const lines = content.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    let entry: unknown;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!entry || typeof entry !== 'object') continue;
+    const record = entry as { id?: unknown; thread_name?: unknown };
+    if (record.thread_name !== threadName || typeof record.id !== 'string' || seen.has(record.id)) {
+      continue;
+    }
+    seen.add(record.id);
+    if (findTraexRolloutBySessionId(record.id)) return record.id;
   }
   return undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -650,6 +650,12 @@ export type WorkerToDaemon =
       /** Durable receiver attempt attribution. Final output suppression is
        *  attempt-scoped so a late attempt-N event cannot affect attempt N+1. */
       dispatchAttempt?: number;
+      /** The CLI already delivered this answer to the Lark thread in-band
+       *  (its own `botmux send` covered the final text), so the daemon must
+       *  not post the content again. The message is still forwarded so
+       *  daemon-side observers of completed turns (e.g. result mirrors) see
+       *  the final text; the daemon only commits the dedupe marker. */
+      suppressedDelivery?: boolean;
       // Discriminator for the daemon-side renderer. Default ('bridge' /
       // omitted) renders `content` through the regular markdown card. The
       // local-turn variants ship the user prompt as a separate field so

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7435,7 +7435,10 @@ async function restartCliProcess(
         // intentionally held by the restart gate above. Release its raw-input
         // fence now; other backends keep it until their later markPromptReady().
         if (effectiveBackendType === 'riff' && isPromptReady) releaseRawInputRestartGate();
-        void flushPending();
+        // A local replacement process can exist before its TUI input box does.
+        // Only re-kick a prompt that became ready while the restart fence was
+        // still armed; otherwise markPromptReady() owns the first flush.
+        if (isPromptReady) void flushPending();
       }, 500);
     } catch (err) {
       cliRestartInProgress = false;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -149,7 +149,14 @@ import {
 import { createCliAdapterSync, locateOnPath } from './adapters/cli/registry.js';
 import { buildWrappedLaunch, parseWrapperCli, isTtadkWrapper } from './setup/cli-selection.js';
 import { cliUnavailableMessage } from './setup/cli-availability.js';
-import { findLaunchedCliPid, scheduleWrapperRealCliPid, readComm, isBareShellComm, bareShellLaunchKind } from './core/session-discovery.js';
+import {
+  findLaunchedCliPid,
+  scheduleWrapperRealCliPid,
+  readComm,
+  isBareShellComm,
+  bareShellLaunchKind,
+  settleLaunchComm,
+} from './core/session-discovery.js';
 import { codexRpcEligible, paneRunsRemoteTui, orchestrateCodexRpcInit, rolloutUserTurnMatches, decideStartupDialogAction, shouldQueueInitialPrompt, shouldPreMarkFirstTurn, killAndVerifyPersistentPane, type EngageOutcome } from './codex-rpc-lifecycle.js';
 import { delay } from './utils/timing.js';
 import { claudeJsonlPathForSession, resolveJsonlFromPid, findOpenClaudeSessionIds, syncClaudeResumeTargetToCwd, DEFAULT_CLAUDE_DATA_DIR } from './adapters/cli/claude-code.js';
@@ -4077,7 +4084,7 @@ async function flushPendingInjections(): Promise<void> {
       // path sends first runs the detection.
       if (!bareShellChecked) {
         bareShellChecked = true;
-        if (detectBareShellLaunch()) return;  // finally{} releases the mutex; queue stays
+        if (await detectBareShellLaunch()) return;  // finally{} releases the mutex; queue stays
       }
       const item = pendingInjections.shift()!;
       const cmd = item.command;
@@ -4777,15 +4784,17 @@ function scheduleSubmitFailureNotify(
  * and the pty/herdr backends (which `exec` the CLI directly — getChildPid is the
  * CLI itself, never a shell).
  *
- * Returns true when a bare-shell launch was detected (caller must NOT flush).
+ * Returns true when a persistent bare-shell launch was detected (caller must
+ * NOT flush). A transient wrapper shell gets a bounded chance to exec the CLI.
  */
-function detectBareShellLaunch(): boolean {
+async function detectBareShellLaunch(): Promise<boolean> {
   if (bareShellLaunchBlocked) return true;
   if (lastInitConfig?.adoptMode) return false;       // observing an existing pane, not launching
   if (lastInitConfig?.wrapperCli) return false;      // launcher legitimately wraps the CLI (transient shell shim)
-  const pid = backend?.getChildPid?.();
-  if (!pid) return false;
-  const comm = readComm(pid);
+  const comm = await settleLaunchComm(() => {
+    const pid = backend?.getChildPid?.();
+    return pid ? readComm(pid) : undefined;
+  });
   if (!isBareShellComm(comm)) return false;          // CLI (rust/go/node) is running — healthy launch
 
   // Bare shell is the pane leaf → the CLI never launched. Tier the message on
@@ -4932,7 +4941,7 @@ async function flushPending(): Promise<void> {
     // doesn't get them typed into the bare shell first.
     if (!bareShellChecked) {
       bareShellChecked = true;
-      if (detectBareShellLaunch()) {
+      if (await detectBareShellLaunch()) {
         return;  // finally{} releases the mutex; pendingMessages stay queued, untouched
       }
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9727,6 +9727,15 @@ process.on('message', async (raw: unknown) => {
       // observation) would be dropped forever, because cold-resume re-attaches
       // with a baseline cutoff that never re-emits old turns.
       try { codexBridgeDrainAndMaybeEmit(); } catch { /* best-effort */ }
+      // The CLI's final rollout events can land on disk a few hundred ms
+      // AFTER the prompt renders (observed 2026-08-17 19:49: prompt at
+      // +578ms, suspend at +582ms, the completed turn flushed later in the
+      // same second). Suspend is not time-critical — wait out the flush
+      // and drain once more so a turn completed in the same second is not
+      // lost forever (it would otherwise never re-emit: cold-resume
+      // re-attaches with a baseline cutoff).
+      try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 400); } catch { /* */ }
+      try { codexBridgeDrainAndMaybeEmit(); } catch { /* best-effort */ }
       stopScreenshotLoop();
       stopBridgeWatcher();
       // A parked crash diagnostic shell has backend===null, so the

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9721,6 +9721,12 @@ process.on('message', async (raw: unknown) => {
 
     case 'suspend': {
       log('Suspend requested');
+      // Final bridge drain BEFORE teardown: the idle sweeper can suspend a
+      // worker in the same tick the CLI finishes its turn, and the 1s bridge
+      // poller then loses the race — the completed turn (and its mirror-side
+      // observation) would be dropped forever, because cold-resume re-attaches
+      // with a baseline cutoff that never re-emits old turns.
+      try { codexBridgeDrainAndMaybeEmit(); } catch { /* best-effort */ }
       stopScreenshotLoop();
       stopBridgeWatcher();
       // A parked crash diagnostic shell has backend===null, so the

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3426,6 +3426,19 @@ function emitReadyCodexTurns(): void {
     const nextBoundaryMs = (i + 1 < ready.length ? ready[i + 1].markTimeMs : nextPendingMarkTimeMs);
     if (shouldSuppressBridgeEmit({ markTimeMs: turn.markTimeMs, isLocal: turn.isLocal, finalText: turn.finalText }, nextBoundaryMs, markers, adoptMode)) {
       log(`Codex bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (gate)`);
+      // The CLI self-delivered this answer via `botmux send`, so the daemon
+      // must not post it again — but daemon-side observers of completed
+      // turns (e.g. result mirrors) still need the final text. Forward it
+      // flagged so the daemon records the dedupe marker without delivering.
+      send({
+        type: 'final_output',
+        ...(sourceHermesSessionId ? { sourceHermesSessionId } : {}),
+        content: turn.finalText,
+        lastUuid: turn.turnId,
+        turnId: turn.turnId,
+        ...(turn.dispatchAttempt !== undefined ? { dispatchAttempt: turn.dispatchAttempt } : {}),
+        suppressedDelivery: true,
+      });
       continue;
     }
     if (turn.isLocal) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -112,7 +112,7 @@ import {
 } from './services/bridge-rotation-policy.js';
 import { CodexBridgeQueue } from './services/codex-bridge-queue.js';
 import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, type CodexBridgeEvent } from './services/codex-transcript.js';
-import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
+import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid, findTraexSessionIdByThreadName } from './services/traex-transcript.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb, resolveHermesStateDbPath } from './services/hermes-transcript.js';
 import { filterHermesEventsForBotmuxSession } from './services/hermes-session-filter.js';
@@ -2973,7 +2973,16 @@ function codexBridgeStartTimer(): void {
           pid: codexAdoptPendingPid,
         });
         if (path) {
-          if (codexAdoptPendingPid && (lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'traex')) {
+          if (
+            lastInitConfig?.cliId === 'coco'
+            || (
+              codexAdoptPendingPid
+              && (
+                lastInitConfig?.cliId === 'codex'
+                || lastInitConfig?.cliId === 'traex'
+              )
+            )
+          ) {
             const discoveredSessionId = codexSessionIdFromRolloutPath(path);
             if (discoveredSessionId) persistCliSessionId(discoveredSessionId);
           }
@@ -5458,10 +5467,18 @@ function setupAdoptTranscriptBridges(cfg: Extract<DaemonToWorker, { type: 'init'
     codexAdoptStartMs = adoptStartMs;
     codexBridgeQueue.setLocalTurns(true, adoptStartMs);
     let eventsPath: string | undefined;
-    if (cfg.cliSessionId) eventsPath = cocoEventsPathForSession(cfg.cliSessionId);
+    if (cfg.cliSessionId) {
+      const legacyEventsPath = cocoEventsPathForSession(cfg.cliSessionId);
+      eventsPath = existsSync(legacyEventsPath)
+        ? legacyEventsPath
+        : findTraexRolloutBySessionId(cfg.cliSessionId);
+    }
     if (!eventsPath && cfg.adoptCliPid) {
       const probed = findCocoSessionByPid(cfg.adoptCliPid);
-      if (probed) eventsPath = probed.eventsPath;
+      if (probed) {
+        eventsPath = probed.eventsPath;
+        persistCliSessionId(probed.sessionId);
+      }
     }
     if (eventsPath) {
       const sessionDir = dirname(eventsPath);
@@ -6288,6 +6305,29 @@ async function spawnCli(
   let effectiveResume = cfg.resume ?? false;
   let effectiveCliSessionId = cfg.cliSessionId;
   let effectiveAdapterSessionId = adapterSessionId;
+  // CoCo 0.200+ treats the legacy --session-id value as a thread name and
+  // creates a separate native UUID. Older sessions created before botmux
+  // learned to persist that UUID have no cliSessionId in the session store.
+  // Recover it from TRAE's durable index before building `--resume`; retain
+  // the deterministic legacy events path when running CoCo 0.120.x.
+  if (
+    cfg.cliId === 'coco'
+    && effectiveResume
+    && !willReattachPersistent
+    && (!effectiveCliSessionId || effectiveCliSessionId === effectiveAdapterSessionId)
+    && !existsSync(cocoEventsPathForSession(effectiveAdapterSessionId))
+  ) {
+    const recoveredCocoSessionId =
+      findTraexSessionIdByThreadName(effectiveAdapterSessionId);
+    if (recoveredCocoSessionId) {
+      effectiveCliSessionId = recoveredCocoSessionId;
+      persistCliSessionId(recoveredCocoSessionId);
+      log(
+        `Recovered CoCo native session id for resume: ` +
+        `${effectiveAdapterSessionId} → ${recoveredCocoSessionId}`,
+      );
+    }
+  }
   // Claude-family transcripts are scoped by cwd. `/cd` keeps the same Botmux /
   // CLI session id, so mirror the newest native transcript into the new cwd's
   // project directory before the adapter probes or launches `--resume`.
@@ -7408,7 +7448,33 @@ async function spawnCli(
     }
   } else if (cfg.cliId === 'coco') {
     const eventsPath = cocoEventsPathForSession(effectiveAdapterSessionId);
-    codexBridgeAttach(eventsPath, effectiveResume ? 'baseline-existing' : 'fresh-empty');
+    const mode = effectiveResume ? 'baseline-existing' : 'fresh-empty';
+    if (existsSync(eventsPath)) {
+      // Legacy CoCo (0.120.x): deterministic events.jsonl keyed by the
+      // botmux-provided session id.
+      codexBridgeAttach(eventsPath, mode);
+    } else {
+      // CoCo 0.200+ ignores the legacy events path and opens a Codex-shaped
+      // TRAE rollout with its own session id. It may already be visible here;
+      // otherwise leave the pid armed for the 1s poller below.
+      const knownRollout = effectiveCliSessionId
+        ? findTraexRolloutBySessionId(effectiveCliSessionId)
+        : undefined;
+      const discovered = !knownRollout && cliPid
+        ? findCocoSessionByPid(cliPid)
+        : undefined;
+      if (knownRollout) {
+        codexBridgeAttach(knownRollout, mode);
+      } else if (discovered) {
+        persistCliSessionId(discovered.sessionId);
+        codexBridgeAttach(discovered.eventsPath, mode);
+      } else if (cliPid) {
+        codexBridgePendingSessionId = effectiveAdapterSessionId;
+        codexAdoptPendingPid = cliPid;
+      } else {
+        codexBridgePendingSessionId = effectiveAdapterSessionId;
+      }
+    }
     codexBridgeStartTimer();
   } else if (cfg.cliId === 'mtr') {
     const mtrSessionId = effectiveCliSessionId ?? mtrSessionIdForBotmuxSession(effectiveAdapterSessionId);

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -261,6 +261,39 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(ds.lastBridgeEmittedUuid).toBeUndefined();
   });
 
+  it('suppressedDelivery final_output commits dedup without delivering to Lark', async () => {
+    const sessionReply = vi.fn(async () => 'om_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+
+    const ds = makeDs();
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', {
+      ...finalOutputMsg(),
+      sessionId: ds.session.sessionId,
+      suppressedDelivery: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    // The CLI self-delivered in-band: no daemon-side Lark post, but the
+    // dedupe marker is committed so a redrain cannot re-forward the turn.
+    expect(sessionReply).not.toHaveBeenCalled();
+    expect(ds.lastBridgeEmittedUuid).toBe(SCOPED_DEDUPE_KEY);
+
+    (ds.worker as any).emit('message', {
+      ...finalOutputMsg(),
+      sessionId: ds.session.sessionId,
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sessionReply).not.toHaveBeenCalled();
+  });
+
   it('records Hermes source binding and allows matching sourceHermesSessionId', async () => {
     const sessionReply = vi.fn(async () => 'om_reply');
     initWorkerPool({

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -281,6 +281,18 @@ describe('coco buildArgs', () => {
     expect(args).not.toContain('--session-id');
   });
 
+  it('resume prefers the CLI-native session id when CoCo rotated it', () => {
+    const args = adapter.buildArgs({
+      sessionId: 'botmux-session',
+      resumeSessionId: '019fa3bc-1095-7f63-83e5-92b4f1ce82cb',
+      resume: true,
+    });
+    expect(args.slice(0, 2)).toEqual([
+      '--resume',
+      '019fa3bc-1095-7f63-83e5-92b4f1ce82cb',
+    ]);
+  });
+
   it('disallows plan mode tools', () => {
     const args = adapter.buildArgs({ sessionId: 's', resume: false });
     // CoCo uses repeated --disallowed-tool flags
@@ -1515,8 +1527,12 @@ describe('buildResumeCommand', () => {
       .toBe('aiden --resume sess-aiden');
   });
 
-  it('coco uses botmux sessionId', () => {
+  it('coco prefers cliSessionId and falls back to botmux sessionId', () => {
     const a = createCocoAdapter('/bin/coco');
+    expect(a.buildResumeCommand?.({
+      sessionId: 'sess-coco',
+      cliSessionId: '019fa3bc-1095-7f63-83e5-92b4f1ce82cb',
+    })).toBe('coco --resume 019fa3bc-1095-7f63-83e5-92b4f1ce82cb');
     expect(a.buildResumeCommand?.({ sessionId: 'sess-coco' }))
       .toBe('coco --resume sess-coco');
   });

--- a/test/coco-transcript.test.ts
+++ b/test/coco-transcript.test.ts
@@ -54,6 +54,40 @@ describe('drainCocoEvents', () => {
     ]);
   });
 
+  it('drains CoCo 0.200+ Codex-shaped rollout events', () => {
+    path = join(
+      dir,
+      'rollout-2026-07-15T11-29-35-019f63d2-9f37-7673-a304-1ad4062e667b.jsonl',
+    );
+    writeFileSync(path, [
+      line({
+        timestamp: '2026-07-15T03:29:35.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: '归因这个报警' }],
+        },
+      }),
+      line({
+        timestamp: '2026-07-15T03:30:35.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: '00000000-0000-7000-8000-000000000010',
+          last_agent_message: '归因完成',
+        },
+      }),
+    ].join(''));
+
+    const r = drainCocoEvents(path, 0);
+
+    expect(r.events.map(e => [e.kind, e.text])).toEqual([
+      ['user', '归因这个报警'],
+      ['assistant_final', '归因完成'],
+    ]);
+  });
+
   it('skips injected user system reminders', () => {
     writeFileSync(path,
       line(userMsg('<system-reminder>ignore</system-reminder>', { is_additional_context_input: true })) +

--- a/test/codex-coco-pid-discovery.smoke.test.ts
+++ b/test/codex-coco-pid-discovery.smoke.test.ts
@@ -18,11 +18,13 @@ import { findCocoSessionByPid } from '../src/services/coco-transcript.js';
 
 const CODEX_SID = '019dd80d-d922-7a11-8339-0208d8c5b4ec';
 const COCO_SID = '8db7d911-96f3-4764-a310-e42ae4cb626f';
+const MODERN_COCO_SID = '019f63d2-9f37-7673-a304-1ad4062e667b';
 
 let dir: string;
 let codexRollout: string;
 let cocoSessionLog: string;
 let child: ChildProcessWithoutNullStreams;
+let modernCocoChild: ChildProcessWithoutNullStreams;
 
 beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), 'bmx-pid-disc-'));
@@ -38,6 +40,18 @@ beforeAll(async () => {
   mkdirSync(cocoDir, { recursive: true });
   cocoSessionLog = join(cocoDir, 'session.log');
   writeFileSync(cocoSessionLog, '');
+
+  // CoCo 0.200+ migrated to the TRAE/Codex rollout store and no longer opens
+  // ~/.cache/coco/sessions/<sid> files. Keep a second process with only that
+  // modern rollout open so discovery cannot accidentally pass via the legacy
+  // session.log fd above.
+  const modernCocoDir = join(dir, '.trae', 'cli', 'sessions', '2026', '07', '15');
+  mkdirSync(modernCocoDir, { recursive: true });
+  const modernCocoRollout = join(
+    modernCocoDir,
+    `rollout-2026-07-15T11-29-35-${MODERN_COCO_SID}.jsonl`,
+  );
+  writeFileSync(modernCocoRollout, '');
 
   child = spawn(
     process.execPath,
@@ -63,10 +77,35 @@ beforeAll(async () => {
     });
     child.once('error', reject);
   });
+
+  modernCocoChild = spawn(
+    process.execPath,
+    [
+      '-e',
+      `
+        const fs = require('fs');
+        fs.openSync(${JSON.stringify(modernCocoRollout)}, 'a');
+        process.stdout.write('ready\\n');
+        setTimeout(() => {}, 60000);
+      `,
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  ) as ChildProcessWithoutNullStreams;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('modern coco child not ready in 5s')), 5000);
+    modernCocoChild.stdout.once('data', (buf: Buffer) => {
+      if (buf.toString().includes('ready')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    modernCocoChild.once('error', reject);
+  });
 });
 
 afterAll(() => {
   if (child && !child.killed) child.kill('SIGKILL');
+  if (modernCocoChild && !modernCocoChild.killed) modernCocoChild.kill('SIGKILL');
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -101,6 +140,13 @@ describe('findCocoSessionByPid', () => {
     // vs Linux .cache）都接受。
     const tail = `coco/sessions/${COCO_SID}/events.jsonl`;
     expect(hit!.eventsPath.endsWith(tail)).toBe(true);
+  });
+
+  it('locates a CoCo 0.200+ TRAE rollout when legacy session files are absent', () => {
+    const hit = findCocoSessionByPid(modernCocoChild.pid!);
+    expect(hit).toBeDefined();
+    expect(hit!.sessionId).toBe(MODERN_COCO_SID);
+    expect(hit!.eventsPath.endsWith(`-${MODERN_COCO_SID}.jsonl`)).toBe(true);
   });
 
   it('returns undefined for a non-existent pid', () => {

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -31,7 +31,13 @@ vi.mock('node:os', () => ({
 
 import { execSync } from 'node:child_process';
 import { readFileSync, readlinkSync, existsSync, readdirSync } from 'node:fs';
-import { discoverAdoptableSessions, validateAdoptTarget, isBareShellComm, bareShellLaunchKind } from '../src/core/session-discovery.js';
+import {
+  discoverAdoptableSessions,
+  validateAdoptTarget,
+  isBareShellComm,
+  bareShellLaunchKind,
+  settleLaunchComm,
+} from '../src/core/session-discovery.js';
 import type { CliId } from '../src/adapters/cli/types.js';
 
 describe('isBareShellComm()', () => {
@@ -66,6 +72,41 @@ describe('bareShellLaunchKind()', () => {
   });
   it('reports stuck (no confident trampoline claim) when the launch shell is unknown', () => {
     expect(bareShellLaunchKind('zsh', '')).toBe('stuck');
+  });
+});
+
+describe('settleLaunchComm()', () => {
+  it('does not classify the launch wrapper as a failed CLI when it execs shortly afterward', async () => {
+    vi.useFakeTimers();
+    try {
+      const reads = ['zsh', 'coco'];
+      const settled = settleLaunchComm(
+        () => reads.shift() ?? 'coco',
+        { timeoutMs: 2_000, pollMs: 100 },
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(await settled).toBe('coco');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('returns a persistent bare shell after the bounded launch grace period', async () => {
+    vi.useFakeTimers();
+    try {
+      const settled = settleLaunchComm(
+        () => 'zsh',
+        { timeoutMs: 300, pollMs: 100 },
+      );
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(await settled).toBe('zsh');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/test/structured-bridge-clis.test.ts
+++ b/test/structured-bridge-clis.test.ts
@@ -75,3 +75,36 @@ describe('resolveFileBridgePath (grok)', () => {
     expect(resolveFileBridgePath('grok', { sessionId: 'bbbbbbbb-bbbb-4ccc-8ddd-eeeeeeeeeeee', cwd })).toBeUndefined();
   });
 });
+
+describe('resolveFileBridgePath (CoCo 0.200+)', () => {
+  const ROOT = join(tmpdir(), `botmux-coco-fbp-${process.pid}`);
+  const SID = '00000000-0000-7000-8000-000000000006';
+  const previousTraeHome = process.env.TRAE_HOME;
+
+  beforeEach(() => {
+    process.env.TRAE_HOME = ROOT;
+    rmSync(ROOT, { recursive: true, force: true });
+  });
+  afterEach(() => {
+    rmSync(ROOT, { recursive: true, force: true });
+    if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
+    else process.env.TRAE_HOME = previousTraeHome;
+  });
+
+  it('resolves the TRAE rollout by native id or its CoCo thread name', () => {
+    const rolloutDir = join(ROOT, 'cli', 'sessions', '2026', '07', '28');
+    mkdirSync(rolloutDir, { recursive: true });
+    const rollout = join(
+      rolloutDir,
+      `rollout-2026-07-28T02-00-00-${SID}.jsonl`,
+    );
+    writeFileSync(rollout, '');
+
+    expect(resolveFileBridgePath('coco', { sessionId: SID })).toBe(rollout);
+    writeFileSync(
+      join(ROOT, 'cli', 'session_index.jsonl'),
+      `${JSON.stringify({ id: SID, thread_name: 'botmux-thread' })}\n`,
+    );
+    expect(resolveFileBridgePath('coco', { sessionId: 'botmux-thread' })).toBe(rollout);
+  });
+});

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -104,6 +104,38 @@ describe('drainTraexRollout', () => {
     ]);
   });
 
+  it('captures the history_mutation dialect where user input only exists as event_msg/user_message', () => {
+    // CoCo 0.200.19 intermittently writes rollouts without ANY response_item
+    // records (observed 2026-08-15/17/18 champion sessions: history_mutation +
+    // item_completed dialect). Without this branch the drain yields zero
+    // events and the completed turn is silently lost.
+    writeFileSync(path, [
+      line({ timestamp: '2000-01-01T00:00:00.000Z', type: 'session_meta', payload: { id: SID } }),
+      line({ timestamp: '2000-01-01T00:00:00.500Z', type: 'event_msg', payload: { type: 'task_started', turn_id: 't1' } }),
+      line({ timestamp: '2000-01-01T00:00:01.000Z', type: 'event_msg', payload: { type: 'user_message', message: '报警：TLB 流量下降' } }),
+      line({ timestamp: '2000-01-01T00:00:02.000Z', type: 'event_msg', payload: { type: 'agent_message', message: '排查中' } }),
+      line(taskComplete('已完成归因：流量自然回落')),
+    ].join(''));
+    const r = drainTraexRollout(path, 0);
+    expect(r.events.map(e => e.kind)).toEqual(['user', 'assistant_final']);
+    expect(r.events[0].text).toBe('报警：TLB 流量下降');
+    expect(r.events[1].text).toBe('已完成归因：流量自然回落');
+  });
+
+  it('does not double-count the event_msg user mirror when response_item records exist', () => {
+    // In the response_item dialect CoCo mirrors the user input as
+    // event_msg/user_message ~100ms later; the response_item record is the
+    // authoritative one and the mirror must be skipped.
+    writeFileSync(path, [
+      line(user('报警：TLB 流量下降')),
+      line({ timestamp: '2000-01-01T00:00:01.100Z', type: 'event_msg', payload: { type: 'user_message', message: '报警：TLB 流量下降' } }),
+      line(taskComplete('结论')),
+    ].join(''));
+    const r = drainTraexRollout(path, 0);
+    expect(r.events.filter(e => e.kind === 'user')).toHaveLength(1);
+    expect(r.events[0].text).toBe('报警：TLB 流量下降');
+  });
+
   it('emits an empty task_complete so a silent durable turn can settle', () => {
     writeFileSync(path, line(user('finish silently')) + line(taskComplete()));
     const result = drainTraexRollout(path, 0);

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
 import {
   drainTraexRollout,
+  findTraexSessionIdByThreadName,
   traexRolloutHasUserInputSince,
 } from '../src/services/traex-transcript.js';
 
@@ -183,5 +184,34 @@ describe('traexRolloutHasUserInputSince', () => {
     expect(traexRolloutHasUserInputSince(path, baseline, 'same thread, later prompt')).toBe(true);
     expect(traexRolloutHasUserInputSince(path, baseline, 'same thread, old prompt')).toBe(false);
     expect(traexRolloutHasUserInputSince(path, baseline, 'same thread')).toBe(false);
+  });
+});
+
+describe('findTraexSessionIdByThreadName', () => {
+  it('returns the newest indexed native session whose rollout still exists', () => {
+    const previousTraeHome = process.env.TRAE_HOME;
+    process.env.TRAE_HOME = dir;
+    try {
+      const older = '00000000-0000-7000-8000-000000000002';
+      const latest = '00000000-0000-7000-8000-000000000003';
+      const missing = '00000000-0000-7000-8000-000000000004';
+      const rolloutDir = join(dir, 'cli', 'sessions', '2026', '07', '28');
+      mkdirSync(rolloutDir, { recursive: true });
+      writeFileSync(join(rolloutDir, `rollout-2026-07-28T00-00-00-${older}.jsonl`), '');
+      writeFileSync(join(rolloutDir, `rollout-2026-07-28T01-00-00-${latest}.jsonl`), '');
+      writeFileSync(join(dir, 'cli', 'session_index.jsonl'), [
+        line({ id: older, thread_name: 'botmux-thread', updated_at: '2026-07-28T00:00:00Z' }),
+        '{malformed\n',
+        line({ id: latest, thread_name: 'botmux-thread', updated_at: '2026-07-28T01:00:00Z' }),
+        line({ id: missing, thread_name: 'botmux-thread', updated_at: '2026-07-28T02:00:00Z' }),
+        line({ id: '00000000-0000-7000-8000-000000000005', thread_name: 'other-thread' }),
+      ].join(''));
+
+      expect(findTraexSessionIdByThreadName('botmux-thread')).toBe(latest);
+      expect(findTraexSessionIdByThreadName('unknown-thread')).toBeUndefined();
+    } finally {
+      if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
+      else process.env.TRAE_HOME = previousTraeHome;
+    }
   });
 });

--- a/test/worker-coco-transcript-wiring.test.ts
+++ b/test/worker-coco-transcript-wiring.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+
+describe('spawned CoCo transcript bridge wiring', () => {
+  it('falls back to PID discovery when the legacy events path does not exist', () => {
+    const branchStart = workerSource.lastIndexOf("} else if (cfg.cliId === 'coco') {");
+    const branchEnd = workerSource.indexOf("} else if (cfg.cliId === 'mtr') {", branchStart);
+    const branch = workerSource.slice(branchStart, branchEnd);
+
+    expect(branch).toContain('existsSync(eventsPath)');
+    expect(branch).toContain('findCocoSessionByPid(cliPid)');
+    expect(branch).toContain('persistCliSessionId(discovered.sessionId)');
+    expect(branch).toContain('codexAdoptPendingPid = cliPid');
+  });
+
+  it('recovers an unpersisted native id before building resume arguments', () => {
+    const preflightStart = workerSource.indexOf('let effectiveResume = cfg.resume ?? false;');
+    const preflightEnd = workerSource.indexOf('const tier2ForceFresh', preflightStart);
+    const preflight = workerSource.slice(preflightStart, preflightEnd);
+
+    expect(preflight).toContain("cfg.cliId === 'coco'");
+    expect(preflight).toContain('findTraexSessionIdByThreadName(effectiveAdapterSessionId)');
+    expect(preflight).toContain('persistCliSessionId(recoveredCocoSessionId)');
+  });
+
+  it('persists a delayed CoCo rollout discovery from the bridge poller', () => {
+    const lateAttachStart = workerSource.indexOf(
+      'const path = resolveFileBridgePath(lastInitConfig?.cliId',
+    );
+    const lateAttachEnd = workerSource.indexOf(
+      'codexBridgePendingSessionId = undefined;',
+      lateAttachStart,
+    );
+    const lateAttach = workerSource.slice(lateAttachStart, lateAttachEnd);
+
+    expect(lateAttach).toContain("lastInitConfig?.cliId === 'coco'");
+    expect(lateAttach).toContain('persistCliSessionId(discoveredSessionId)');
+  });
+
+  it('adopt resolves either legacy events or a native TRAE rollout', () => {
+    const setupStart = workerSource.indexOf('function setupAdoptTranscriptBridges');
+    const branchStart = workerSource.indexOf(
+      "} else if (cfg.cliId === 'coco') {",
+      setupStart,
+    );
+    const branchEnd = workerSource.indexOf(
+      "} else if (cfg.cliId === 'mtr') {",
+      branchStart,
+    );
+    const branch = workerSource.slice(branchStart, branchEnd);
+
+    expect(branch).toContain('findTraexRolloutBySessionId(cfg.cliSessionId)');
+    expect(branch).toContain('persistCliSessionId(probed.sessionId)');
+  });
+});

--- a/test/worker-durable-expiry-order.test.ts
+++ b/test/worker-durable-expiry-order.test.ts
@@ -61,6 +61,7 @@ describe('worker durable lease expiry ordering', () => {
       release,
     );
     const wake = restart.indexOf('void flushPending();', riffRawRelease);
+    const guardedWake = restart.indexOf('if (isPromptReady) void flushPending();', riffRawRelease);
 
     expect(restartStart).toBeGreaterThanOrEqual(0);
     expect(restartEnd).toBeGreaterThan(restartStart);
@@ -74,6 +75,12 @@ describe('worker durable lease expiry ordering', () => {
     expect(release).toBeGreaterThan(spawn);
     expect(riffRawRelease).toBeGreaterThan(release);
     expect(wake).toBeGreaterThan(riffRawRelease);
+    // A replacement CoCo/Codex process may exist before its TUI input box
+    // exists. Restart completion must not use type-ahead to flush into that
+    // startup window; only a prompt already observed during the restart fence
+    // needs an explicit wake after the fence drops.
+    expect(guardedWake).toBeGreaterThan(riffRawRelease);
+    expect(wake).toBeGreaterThan(guardedWake);
 
     const promptStart = workerSource.indexOf('function markPromptReady(): void');
     const promptEnd = workerSource.indexOf('\nfunction persistCliSessionId(', promptStart);


### PR DESCRIPTION
## 改了什么

CoCo 0.200+ 不再写 `~/.cache/coco/sessions/<sid>/events.jsonl`，改用 Codex 形态的 TRAE rollout（`~/.trae/cli/sessions/<date>/rollout-*.jsonl`），且把 `--session-id` 视为 thread name、另行分配原生会话 UUID。原桥接器只轮询遗留路径，导致 coco 会话的 final_output 收割不到（下游 rca-shadow 镜像回调自迁移后全部丢失，2026-08-15 线上实测确认）。

- `coco-transcript`：findCocoSessionByPid / drainCocoEvents 落空时按 TRAE rollout finder 兜底并分发 drain
- `traex-transcript/paths`：新增 `session_index.jsonl` 的 thread_name → 原生会话 id 解析（要求 rollout 实际存在，防坏 resume）
- `worker`：fresh spawn / adopt / resume 三路补 rollout 发现与 cliSessionId 持久化；bridge 1s poller 对 coco 也持久化发现的会话 id
- `coco` adapter：`--resume` 使用原生 cliSessionId（resumeSessionId 兜底）
- `file-bridge-path`：coco 按 session id / thread name 双路兜底

## 影响面

coco 适配器 + worker 桥接共用路径。codex/traex 复用的 finder 仅新增导出，行为不变。遗留 CoCo 0.120.x 的 events.jsonl 路径保留原逻辑（existsSync 优先）。

## 验证

- `pnpm build` 绿
- 靶向 6 文件 339 测试全过（含新增 `worker-coco-transcript-wiring.test.ts`）
- 全量 unit：9856 过、13 失败与基线完全一致（fence/hook-runner/codex-app-runner 环境敏感型，stash 对照复跑确认与本改动无关）
- 真实数据核验：`~/.trae/cli/session_index.jsonl` 中 thread_name d2e4e432→01a0033f 的映射与 2026-08-15 champion 会话（rollout fd 实测）一致

## 备注

承接主 worktree 中 07-22~07-28 的未提交工作，剥离了其中独立的 load-guard / maxLiveWorkers 部分（仍留在原 worktree 未动，后续单独成 PR）。