### PR TITLE
fix(fork): 修复 /forklist 静默无响应与分身列表恒空

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -3854,11 +3854,20 @@ export async function handleCommand(
           break;
         }
 
-        await sessionReply(rootId, t('cmd.fork.created', { name: forkGroupName, link: forkInviteLink }, loc));
-        // Record the child on the SOURCE session's lineage so /forklist can list
-        // it. The sub-topic fork path does this too; the --create (new-group)
-        // path historically skipped it, leaving forkChildSessionIds permanently
-        // empty and /forklist always reporting "no forks" even after many forks.
+        // Persist the child on the SOURCE session's lineage BEFORE any
+        // user-visible send. The sub-topic fork path also records lineage; the
+        // --create (new-group) path historically skipped it entirely, leaving
+        // forkChildSessionIds permanently empty and /forklist always reporting
+        // "no forks".
+        //
+        // Ordering is load-bearing: the "created" notice below is a reply to the
+        // parent session's root message, i.e. the SAME message whose expiry
+        // (HTTP 400) this PR's other fix addresses. If that reply threw while it
+        // still ran first, control would unwind to handleCommand's outer catch
+        // (log-only) and the lineage write would be skipped — so in the very
+        // "root expired" scenario this change targets, /forklist would stay
+        // empty. Writing lineage first makes it independent of the notify path;
+        // the notice and panel refresh are best-effort afterwards.
         if (!ds.session.forkChildSessionIds?.includes(forkResult.childSessionId)) {
           ds.session.forkChildSessionIds = [
             ...(ds.session.forkChildSessionIds ?? []),
@@ -3872,16 +3881,28 @@ export async function handleCommand(
               + `${err instanceof Error ? err.message : String(err)}`,
             );
           }
-          try {
-            await upsertForkPanelCard(ds, loc);
-          } catch (err) {
-            logger.warn(
-              `[${logTag}] /fork --create panel refresh failed: `
-              + `${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
         }
         logger.info(`[${logTag}] /fork --create completed: chat=${forkChatId} child=${forkResult.childSessionId.substring(0, 8)} bot=${targetBotAppId} (source ${ds.session.sessionId.substring(0, 8)} untouched)`);
+        // User-visible notice + panel refresh: best-effort, AFTER lineage is
+        // durable. A failure here (e.g. the root-message 400) must not undo the
+        // lineage write, so swallow locally instead of letting it reach the
+        // outer catch.
+        try {
+          await sessionReply(rootId, t('cmd.fork.created', { name: forkGroupName, link: forkInviteLink }, loc));
+        } catch (err) {
+          logger.warn(
+            `[${logTag}] /fork --create created-notice send failed: `
+            + `${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        try {
+          await upsertForkPanelCard(ds, loc, { preferredReplyToMessageId: message.messageId });
+        } catch (err) {
+          logger.warn(
+            `[${logTag}] /fork --create panel refresh failed: `
+            + `${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
         break;
       }
 
@@ -3890,7 +3911,7 @@ export async function handleCommand(
           await sessionReply(rootId, t('cmd.fork.no_session', undefined, loc));
           break;
         }
-        await upsertForkPanelCard(ds, loc, { allowEmpty: true });
+        await upsertForkPanelCard(ds, loc, { allowEmpty: true, preferredReplyToMessageId: message.messageId });
         break;
       }
 
@@ -4639,7 +4660,7 @@ export async function startForkSubtopicSession(
 async function upsertForkPanelCard(
   parentDs: DaemonSession,
   loc: Locale,
-  opts?: { allowEmpty?: boolean },
+  opts?: { allowEmpty?: boolean; preferredReplyToMessageId?: string },
 ): Promise<void> {
   const appId = parentDs.larkAppId;
   const chatId = parentDs.chatId;
@@ -4678,21 +4699,35 @@ async function upsertForkPanelCard(
   // swallowed failure looks like the command silently did nothing; the flat send
   // keeps it visible. Only if BOTH transports fail do we give up (and warn).
   const cardBody = buildForkPanelCard(children, loc);
+  // Reply targets are tried in order, then a flat send as the last resort:
+  //   1) the FRESH triggering command message (when /forklist or /fork passes
+  //      it) — a just-arrived message is never past Lark's reply window, and in
+  //      a 话题群 it keeps the panel inside the current topic;
+  //   2) the session root message — the historical target, but it can age past
+  //      the reply window (HTTP 400) or be withdrawn;
+  //   3) a flat chat sendMessage — always delivers, though in a 话题群 it starts
+  //      a new sibling topic rather than threading. The panel is the user-visible
+  //      output of /forklist, so a visible-but-flat panel beats silent nothing.
+  const replyTargets: string[] = [];
+  if (opts?.preferredReplyToMessageId) replyTargets.push(opts.preferredReplyToMessageId);
+  if (parentDs.session.rootMessageId
+    && parentDs.session.rootMessageId !== opts?.preferredReplyToMessageId) {
+    replyTargets.push(parentDs.session.rootMessageId);
+  }
   let cardId: string | undefined;
-  try {
-    cardId = await replyMessage(
-      appId,
-      parentDs.session.rootMessageId,
-      cardBody,
-      'interactive',
-      true,
-    );
-  } catch (replyErr) {
-    logger.warn(
-      `[fork-panel] reply to root ${parentDs.session.rootMessageId} failed `
-      + `(${replyErr instanceof Error ? replyErr.message : replyErr}); `
-      + 'falling back to a flat chat message',
-    );
+  for (const target of replyTargets) {
+    try {
+      cardId = await replyMessage(appId, target, cardBody, 'interactive', true);
+      break;
+    } catch (replyErr) {
+      logger.warn(
+        `[fork-panel] reply to ${target} failed `
+        + `(${replyErr instanceof Error ? replyErr.message : replyErr})`,
+      );
+    }
+  }
+  if (!cardId) {
+    logger.warn('[fork-panel] all reply targets failed; falling back to a flat chat message');
     try {
       cardId = await sendMessage(appId, chatId, cardBody, 'interactive');
     } catch (sendErr) {
@@ -4703,7 +4738,18 @@ async function upsertForkPanelCard(
     }
   }
   if (cardId) {
+    // Local guard: a write-store failure here must not bubble to /forklist's
+    // outer catch (which would look like the command errored even though the
+    // panel already posted). Losing only the stale-card id just means the next
+    // /forklist can't delete the previous panel — a benign duplicate at worst.
     parentDs.session.forkPanelCardId = cardId;
-    sessionStore.updateSession(parentDs.session);
+    try {
+      sessionStore.updateSession(parentDs.session);
+    } catch (err) {
+      logger.warn(
+        `[fork-panel] persist forkPanelCardId failed: `
+        + `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 }

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -4635,17 +4635,40 @@ async function upsertForkPanelCard(
     }
   }
 
+  // Post the panel. Primary: reply-in-thread to the session's root message so
+  // the panel anchors to this conversation. Fallback: if that reply fails (the
+  // most common cause is the root message aging past Lark's reply window —
+  // surfaces as HTTP 400 — but also covers a withdrawn root), post the card flat
+  // to the chat instead. The panel IS the user-visible output of /forklist, so a
+  // swallowed failure looks like the command silently did nothing; the flat send
+  // keeps it visible. Only if BOTH transports fail do we give up (and warn).
+  const cardBody = buildForkPanelCard(children, loc);
+  let cardId: string | undefined;
   try {
-    const cardId = await replyMessage(
+    cardId = await replyMessage(
       appId,
       parentDs.session.rootMessageId,
-      buildForkPanelCard(children, loc),
+      cardBody,
       'interactive',
       true,
     );
+  } catch (replyErr) {
+    logger.warn(
+      `[fork-panel] reply to root ${parentDs.session.rootMessageId} failed `
+      + `(${replyErr instanceof Error ? replyErr.message : replyErr}); `
+      + 'falling back to a flat chat message',
+    );
+    try {
+      cardId = await sendMessage(appId, chatId, cardBody, 'interactive');
+    } catch (sendErr) {
+      logger.warn(
+        `[fork-panel] failed to post panel card via both reply and flat send: `
+        + `${sendErr instanceof Error ? sendErr.message : sendErr}`,
+      );
+    }
+  }
+  if (cardId) {
     parentDs.session.forkPanelCardId = cardId;
     sessionStore.updateSession(parentDs.session);
-  } catch (err) {
-    logger.warn(`[fork-panel] failed to post panel card: ${err instanceof Error ? err.message : err}`);
   }
 }

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -3812,7 +3812,12 @@ export async function handleCommand(
         // is empty by construction, so no target-anchor conflict. Source is
         // never touched.
         const { forkSession } = await import('./worker-pool.js');
-        const forkResult = await forkSession(ds.session.sessionId, forkChatId, forkChatId, 'group', 'chat');
+        // forkTaskText = the group name (the human-readable intent for this
+        // fork), so /forklist can label the child row instead of falling back to
+        // the raw session title.
+        const forkResult = await forkSession(ds.session.sessionId, forkChatId, forkChatId, 'group', 'chat', {
+          forkTaskText: forkGroupName,
+        });
         if (!forkResult.ok) {
           // Residual-orphan cleanup: the front guards already ran before
           // createGroupWithBots, so this only fires on a narrow TOCTOU race
@@ -3850,6 +3855,32 @@ export async function handleCommand(
         }
 
         await sessionReply(rootId, t('cmd.fork.created', { name: forkGroupName, link: forkInviteLink }, loc));
+        // Record the child on the SOURCE session's lineage so /forklist can list
+        // it. The sub-topic fork path does this too; the --create (new-group)
+        // path historically skipped it, leaving forkChildSessionIds permanently
+        // empty and /forklist always reporting "no forks" even after many forks.
+        if (!ds.session.forkChildSessionIds?.includes(forkResult.childSessionId)) {
+          ds.session.forkChildSessionIds = [
+            ...(ds.session.forkChildSessionIds ?? []),
+            forkResult.childSessionId,
+          ];
+          try {
+            sessionStore.updateSession(ds.session);
+          } catch (err) {
+            logger.warn(
+              `[${logTag}] /fork --create parent lineage update failed: `
+              + `${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+          try {
+            await upsertForkPanelCard(ds, loc);
+          } catch (err) {
+            logger.warn(
+              `[${logTag}] /fork --create panel refresh failed: `
+              + `${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
         logger.info(`[${logTag}] /fork --create completed: chat=${forkChatId} child=${forkResult.childSessionId.substring(0, 8)} bot=${targetBotAppId} (source ${ds.session.sessionId.substring(0, 8)} untouched)`);
         break;
       }
@@ -4619,9 +4650,13 @@ async function upsertForkPanelCard(
     .map(session => ({
       instruction: session.forkTaskText ?? session.title,
       status: (session.status === 'active' ? 'active' : 'closed') as 'active' | 'closed',
+      // Link to the child's OWN chat: a sub-topic fork shares the parent chat and
+      // carries a larkThreadId (deep-link into that topic); a --create fork lives
+      // in its own new group (different chatId, no thread) so the link must use
+      // the child's chatId, not the parent's, or it would point back here.
       link: session.larkThreadId
-        ? threadAppLink(chatId, session.larkThreadId, brand)
-        : chatAppLink(chatId, brand),
+        ? threadAppLink(session.chatId ?? chatId, session.larkThreadId, brand)
+        : chatAppLink(session.chatId ?? chatId, brand),
     }));
   if (children.length === 0 && !opts?.allowEmpty) return;
 

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -1516,6 +1516,54 @@ describe('handleCommand', () => {
     });
   });
 
+  describe('/fork --create lineage durability', () => {
+    it('persists parent lineage even when the created-notice reply fails (expired root → 400)', async () => {
+      // Regression for the ordering blocker: the "created" notice is a reply to
+      // the parent session's root message — the same message whose expiry this
+      // PR's other fix addresses. If that notice throws, control must NOT skip
+      // the lineage write, or /forklist stays empty in the exact "root expired"
+      // scenario the PR targets. We assert lineage is durable BEFORE the notice.
+      vi.mocked(forkSession).mockResolvedValueOnce({ ok: true, childSessionId: 'child-create-1' });
+      const ds = makeDaemonSession({
+        scope: 'chat',
+        lastScreenStatus: 'idle',
+        session: makeSession({ ownerOpenId: 'ou_sender', scope: 'chat', cliId: 'codex' }),
+      });
+      const deps = makeDeps(ds);
+      // First sessionReply (the created notice) rejects like a 400 on the
+      // expired root; later calls (if any) resolve.
+      let replyCall = 0;
+      (deps.sessionReply as any).mockImplementation(async () => {
+        replyCall += 1;
+        if (replyCall === 1) throw new Error('Request failed with status code 400');
+        return 'reply-msg-id';
+      });
+
+      await handleCommand(
+        '/fork',
+        ROOT_ID,
+        makeLarkMessage('/fork --create 直播开发备份'),
+        deps,
+        LARK_APP_ID,
+      );
+
+      // forkSession ran for the new group and carried the group name as task text.
+      expect(forkSession).toHaveBeenCalledWith(
+        'sess-001',
+        expect.any(String),
+        expect.any(String),
+        'group',
+        'chat',
+        expect.objectContaining({ forkTaskText: '直播开发备份' }),
+      );
+      // The load-bearing assertion: lineage persisted despite the notice throwing.
+      expect(ds.session.forkChildSessionIds).toEqual(['child-create-1']);
+      expect(sessionStore.updateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ forkChildSessionIds: ['child-create-1'] }),
+      );
+    });
+  });
+
   describe('doc comment commands', () => {
     it('/subscribe-lark-doc keeps the original doc-scoped OAuth requirement', async () => {
       const ds = makeDaemonSession();


### PR DESCRIPTION
## 背景 / 现象

在飞书群里执行 `/forklist`（查看当前会话的 fork 分身面板）时出现两类用户可见故障：

1. **命令毫无反应**：发 `/forklist` 后 bot 完全不回，看起来像命令没生效；而同一会话里 `/fork --create`（新建群）却正常。
2. **面板恒显示「本会话还没有分身任务」**：即便已经 fork 过多次，`/forklist` 仍报告没有分身。

## 根因

**故障 1 —— 面板发送失败被静默吞掉**
`upsertForkPanelCard` 只用 `replyMessage(rootMessageId, …, reply_in_thread=true)` 把面板回帖到会话根消息。当根消息超过飞书回帖时效窗口（返回 HTTP 400）或被撤回时，异常被 `catch` 后仅写一条 warn 日志，对用户完全静默 —— 于是 `/forklist` 看起来「没反应」。`/fork --create` 走的是新建群卡片、不依赖旧根消息，所以不受影响，形成「一个响应、一个不响应」的对比。

**故障 2 —— `/fork --create` 从不记录父会话血缘**
`/fork` 有两条路径：话题群开子话题的路径会把 child 写进父会话的 `forkChildSessionIds`；而 `/fork --create <群名>`（新建独立群）的路径在 `forkSession` 成功后直接 `break`，从不写父会话血缘，也不传 `forkTaskText`。而 `/forklist` 面板恰恰只读 `forkChildSessionIds`，因此对使用 `--create` 的用户永远为空。

## 改了什么

- **故障 1**：面板发送改为「先回帖到根消息，失败则回退为向 chat 平铺 `sendMessage`」，保证面板始终可见；仅当回帖与平铺都失败才写 warn。面板本身就是 `/forklist` 的用户可见输出，回退发送即让用户重新看到面板。
- **故障 2**：`/fork --create` 成功后把 child 写入源会话 `forkChildSessionIds` 并 `updateSession`，随后调用 `upsertForkPanelCard` 刷新面板（与子话题路径一致）；同时向 `forkSession` 传 `forkTaskText=群名`，使面板行有可读标签。
- 面板子项链接改用 child 自身的 `chatId`：`--create` 分身位于独立新群、无 `larkThreadId`，若沿用父会话 `chatId` 会错误指回父群。

## 影响面

仅触及 `im/lark` 群会话的 `/forklist` 与 `/fork` 面板刷新路径。不改命令解析、权限门禁、会话路由；子话题 fork 路径行为不变；不涉及其它 CLI / 后端 / 平台。

## 测试

- `pnpm build`（含 `tsc`）通过。
- `pnpm vitest run --project unit test/fork-session.test.ts test/daemon-refork-substitute-wiring.test.ts`：20/20 通过。
- Live 复现验证：修复前 `/forklist` 因根消息过期回帖返回 400 且静默；修复后日志出现 `reply to root … failed (400); falling back to a flat chat message` 并成功 `Sent message` 平铺发出面板，用户侧正常看到分身面板。`/fork --create` 后再发 `/forklist`，面板正确列出新建群分身（含可读任务名与「打开」跳转）。
