### PR TITLE
fix(cli-runtime-update): 用 canonical realpath 作持久化身份，修复 FNM 旋转路径下 Codex 更新每小时重复提醒

### DIFF
--- a/src/core/cli-runtime-update.ts
+++ b/src/core/cli-runtime-update.ts
@@ -58,7 +58,15 @@ export interface CliRuntimeUpdateEntry {
   cliId: 'codex';
   runtimeId: string;
   displayName: string;
+  /** Executable path as discovered at probe time. Display-only: it may be a
+   * short-lived launcher symlink (e.g. FNM's per-shell `fnm_multishells`), so
+   * it must never be part of the persisted identity. */
   binPath: string;
+  /** Canonical realpath of the installation this entry tracks, captured when
+   * the entry was written. This is the stable persistence identity: a rotating
+   * `binPath` that resolves here must reuse the same TTL/notification state
+   * instead of minting a fresh row every tick. */
+  installationPath: string;
   provider: CliRuntimeUpdateProvider;
   /** Explicit npm source, when configured. Persisted so source changes can
    * invalidate the TTL/status cache instead of inheriting another package. */
@@ -165,6 +173,13 @@ function validEntry(raw: unknown): ValidatedStoreEntry | null {
   const v = raw as Record<string, unknown>;
   if (v.cliId !== 'codex' || typeof v.binPath !== 'string' || !v.binPath) return null;
   if (typeof v.lastCheckedAt !== 'number' || !Number.isFinite(v.lastCheckedAt)) return null;
+  // Entries written before stable-identity keying lack installationPath. Derive
+  // it once from the persisted binPath: for a still-present install that is its
+  // realpath; for a dead rotating symlink it degrades to the raw path, which is
+  // exactly what the old key already used, so nothing regresses.
+  const installationPath = typeof v.installationPath === 'string' && v.installationPath
+    ? v.installationPath
+    : canonicalInstallationPath(v.binPath);
   const current = typeof v.current === 'string' && parseVersion(v.current) ? v.current : null;
   const runtimeId = typeof v.runtimeId === 'string' && v.runtimeId ? v.runtimeId : 'codex';
   const displayName = typeof v.displayName === 'string' && v.displayName ? v.displayName : 'Codex';
@@ -204,6 +219,7 @@ function validEntry(raw: unknown): ValidatedStoreEntry | null {
       runtimeId,
       displayName,
       binPath: v.binPath,
+      installationPath,
       provider,
       ...(packageName ? { packageName } : {}),
       // Recompute instead of trusting persisted input. Besides hardening corrupted
@@ -533,13 +549,32 @@ export async function probeCodexRuntimeUpdate(
   return probeCliRuntimeUpdate(target, deps);
 }
 
-function targetKey(target: Pick<CliRuntimeUpdateTarget, 'runtimeId' | 'binPath'>): string {
-  return `${target.runtimeId}:${target.binPath}`;
+/** Canonicalize an executable path to a stable filesystem identity. A present
+ * install resolves through every launcher symlink to its real file; a dead or
+ * rotated symlink (e.g. an expired `fnm_multishells` entry) has no realpath, so
+ * we fall back to a normalized absolute path. */
+function canonicalInstallationPath(binPath: string): string {
+  try { return realpathSync(binPath); }
+  catch { return resolve(binPath); }
 }
 
-function targetInstallationKey(target: Pick<CliRuntimeUpdateTarget, 'binPath'>): string {
-  try { return realpathSync(target.binPath); }
-  catch { return resolve(target.binPath); }
+/** Persisted identity of a tracked runtime. Keyed by the canonical installation
+ * path, not the raw `binPath`: FNM hands each new shell a fresh
+ * `/run/user/.../fnm_multishells/<pid>_.../bin/codex` symlink that all resolve
+ * to one npm install, so keying by raw path would mint a new row (losing the
+ * 24h TTL and per-version notification watermark) on every hourly tick. */
+function targetKey(target: Pick<CliRuntimeUpdateTarget, 'runtimeId' | 'binPath'>): string {
+  return `${target.runtimeId}:${canonicalInstallationPath(target.binPath)}`;
+}
+
+/** Key an already-persisted entry by its stored canonical installation path.
+ * Unlike a live target the entry's rotating `binPath` may no longer resolve, so
+ * the value frozen at write time is the authoritative identity. In-memory or
+ * legacy stores that never passed through the reader may lack it; fall back to
+ * canonicalizing the raw path so those callers still get a stable key. */
+function entryKey(entry: Pick<CliRuntimeUpdateEntry, 'runtimeId' | 'installationPath' | 'binPath'>): string {
+  const installationPath = entry.installationPath || canonicalInstallationPath(entry.binPath);
+  return `${entry.runtimeId}:${installationPath}`;
 }
 
 /** De-duplicate only identical update sources. If two bots assign different
@@ -553,7 +588,7 @@ function dedupeCandidates(targets: CliRuntimeUpdateCandidate[]): CliRuntimeUpdat
   }>();
   for (const target of targets) {
     if (!target.binPath) continue;
-    const key = targetInstallationKey(target);
+    const key = canonicalInstallationPath(target.binPath);
     const sourceFingerprint = updateSourceFingerprint(target.provider, target.packageName);
     const existing = grouped.get(key);
     if (!existing) {
@@ -583,6 +618,16 @@ function dedupeTargets(targets: CliRuntimeUpdateTarget[]): CliRuntimeUpdateTarge
   return dedupeCandidates(targets);
 }
 
+/** Group key for reconciling a persisted entry / live target onto its update
+ * source. A runtimeId can host multiple installs and an installation can be
+ * re-pointed at a different package, so identity is (runtimeId, source
+ * fingerprint). Uses a `\u0000` separator so neither half can forge the
+ * boundary, written as a source escape (not a literal NUL byte) to keep the
+ * file text-tool friendly. */
+function sourceGroupKey(runtimeId: string, sourceFingerprint: string): string {
+  return `${runtimeId}\u0000${sourceFingerprint}`;
+}
+
 /** Project persisted status onto the runtimes configured right now. The
  * monitor eventually prunes stale entries, but Dashboard reads can happen
  * immediately after an agent/runtime edit; filtering here prevents an old
@@ -598,7 +643,7 @@ export function filterCliRuntimeUpdateEntriesForTargets(
   const current = new Map(dedupeTargets(refreshedTargets).map((target) => [targetKey(target), target]));
   const visible: CliRuntimeUpdateEntry[] = [];
   for (const entry of entries) {
-    const target = current.get(targetKey(entry));
+    const target = current.get(entryKey(entry));
     if (!target) continue;
     if (updateSourceFingerprint(entry.provider, entry.packageName)
         !== updateSourceFingerprint(target.provider, target.packageName)) continue;
@@ -712,6 +757,90 @@ export async function runCliRuntimeUpdateAudit(deps: CliRuntimeUpdateAuditDeps):
   ));
   const targets = dedupeTargets(refreshedTargets);
   const configuredKeys = new Set(targets.map(targetKey));
+
+  // Reconcile persisted keys onto stable canonical identities before any TTL
+  // decision. Two things move an entry:
+  //   1. Reindex: an entry keyed by a historical raw path whose install is
+  //      still present collapses onto its realpath identity (entryKey).
+  //   2. Migrate: a legacy entry whose raw path is already dead (a rotated FNM
+  //      launcher symlink from before this build) is adopted onto the live
+  //      target's stable key, but only when exactly one orphan shares the
+  //      target's runtimeId + sourceFingerprint — so a rotating path stops
+  //      minting fresh rows and the post-upgrade tick keeps its watermark
+  //      instead of notifying once more.
+  const reconciled: Record<string, CliRuntimeUpdateEntry> = {};
+  let reindexed = false;
+  for (const [oldKey, entry] of Object.entries(store.entries)) {
+    const key = entryKey(entry);
+    if (key !== oldKey) reindexed = true;
+    const existing = reconciled[key];
+    if (!existing) {
+      reconciled[key] = entry;
+    } else {
+      // Duplicate identity (e.g. two raw-path keys for one live install): keep
+      // the freshest row and drop the rest.
+      reindexed = true;
+      if (entry.lastCheckedAt > existing.lastCheckedAt) reconciled[key] = entry;
+    }
+  }
+  store.entries = reconciled;
+  storeChanged ||= reindexed;
+
+  // Orphans are reconciled entries not already sitting on a configured target
+  // key. Only a *stale* orphan — installationPath no longer on disk (a dead
+  // rotating FNM launcher, or a removed install) — may be adopted. An orphan
+  // whose installationPath still resolves to a real file is a genuinely
+  // different install; adopting it would splice its watermark onto another
+  // installation, so it is pruned and re-probed under its own identity. Group
+  // by (runtimeId, sourceFingerprint) so a target only adopts an unambiguous
+  // one.
+  const orphansBySource = new Map<string, { key: string; entry: CliRuntimeUpdateEntry }[]>();
+  for (const [key, entry] of Object.entries(store.entries)) {
+    if (configuredKeys.has(key)) continue;
+    if (existsSync(entry.installationPath)) continue;
+    const group = sourceGroupKey(
+      entry.runtimeId,
+      entry.sourceFingerprint ?? updateSourceFingerprint(entry.provider, entry.packageName),
+    );
+    (orphansBySource.get(group) ?? orphansBySource.set(group, []).get(group)!).push({ key, entry });
+  }
+  // A group's watermark can only be reattributed when *both* sides are
+  // unambiguous: exactly one stale orphan AND exactly one live install lacking
+  // an entry. When a runtimeId+source hosts two distinct installs (allowed —
+  // they keep independent TTL/watermark by canonical path), there is no way to
+  // decide which install the dead orphan's state belonged to, so migrating by
+  // target iteration order would silently graft a stale watermark onto an
+  // arbitrary install and suppress its next probe. In that case migrate none;
+  // the ambiguous orphan is pruned below and each install re-probes under its
+  // own identity.
+  const liveTargetsNeedingEntry = new Map<string, number>();
+  for (const target of targets) {
+    if (store.entries[targetKey(target)]) continue;
+    const group = sourceGroupKey(
+      target.runtimeId,
+      updateSourceFingerprint(target.provider, target.packageName),
+    );
+    liveTargetsNeedingEntry.set(group, (liveTargetsNeedingEntry.get(group) ?? 0) + 1);
+  }
+  for (const target of targets) {
+    const key = targetKey(target);
+    if (store.entries[key]) continue;
+    const group = sourceGroupKey(
+      target.runtimeId,
+      updateSourceFingerprint(target.provider, target.packageName),
+    );
+    const candidates = orphansBySource.get(group);
+    if (!candidates || candidates.length !== 1) continue;
+    if (liveTargetsNeedingEntry.get(group) !== 1) continue;
+    const { key: oldKey, entry } = candidates[0]!;
+    delete store.entries[oldKey];
+    orphansBySource.delete(group);
+    // Rebind identity to the live installation; status/watermark carry over.
+    store.entries[key] = { ...entry, binPath: target.binPath, installationPath: canonicalInstallationPath(target.binPath) };
+    storeChanged = true;
+    log(`migrated ${target.displayName} store identity onto ${key}`);
+  }
+
   let pruned = false;
   for (const key of Object.keys(store.entries)) {
     if (configuredKeys.has(key)) continue;
@@ -722,6 +851,7 @@ export async function runCliRuntimeUpdateAudit(deps: CliRuntimeUpdateAuditDeps):
 
   for (const target of targets) {
     const key = targetKey(target);
+    const installationPath = canonicalInstallationPath(target.binPath);
     const previous = store.entries[key];
     const sourceFingerprint = updateSourceFingerprint(target.provider, target.packageName);
     const previousSourceFingerprint = previous
@@ -750,6 +880,7 @@ export async function runCliRuntimeUpdateAudit(deps: CliRuntimeUpdateAuditDeps):
         runtimeId: target.runtimeId,
         displayName: target.displayName,
         binPath: target.binPath,
+        installationPath,
         provider: target.provider,
         ...(target.packageName ? { packageName: target.packageName } : {}),
         sourceFingerprint,
@@ -769,6 +900,7 @@ export async function runCliRuntimeUpdateAudit(deps: CliRuntimeUpdateAuditDeps):
         runtimeId: target.runtimeId,
         displayName: target.displayName,
         binPath: target.binPath,
+        installationPath,
         provider: target.provider,
         ...(target.packageName ? { packageName: target.packageName } : {}),
         sourceFingerprint,

--- a/test/cli-runtime-update.test.ts
+++ b/test/cli-runtime-update.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import {
   CLI_RUNTIME_UPDATE_CHECK_INTERVAL_MS,
   buildCliRuntimeUpdateCard,
@@ -39,6 +39,7 @@ function updateEntry(
     runtimeId: 'codex',
     displayName: 'Codex',
     binPath: 'codex',
+    installationPath: overrides.installationPath ?? resolve(overrides.binPath ?? 'codex'),
     provider: 'internal',
     managed: true,
     current: '0.144.1',
@@ -1073,6 +1074,7 @@ describe('runCliRuntimeUpdateAudit', () => {
       runtimeId: 'vendor-codex',
       displayName: 'Vendor Codex',
       binPath: '/opt/vendor-codex',
+      installationPath: '/opt/vendor-codex',
       provider: 'npm',
       packageName: '@vendor/codex-new',
       sourceFingerprint: JSON.stringify(['npm', '@vendor/codex-new']),
@@ -1334,5 +1336,338 @@ describe('CLI runtime update store and card', () => {
 
     expect(card).toContain('Unknown Codex');
     expect(card).not.toContain('codex update');
+  });
+});
+
+describe('runCliRuntimeUpdateAudit with FNM rotating launcher symlinks', () => {
+  let dir: string;
+  let realInstall: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'botmux-cli-runtime-fnm-'));
+    // One real installation, mirroring @openai/codex under an fnm node version.
+    mkdirSync(join(dir, 'install', 'bin'), { recursive: true });
+    realInstall = join(dir, 'install', 'bin', 'codex.js');
+    writeFileSync(realInstall, '#!/usr/bin/env node\n');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Mint a fresh per-shell launcher symlink like fnm's
+   * `/run/user/.../fnm_multishells/<pid>_.../bin/codex`, all resolving to the
+   * single real install. */
+  function rotatingBin(shellId: string): string {
+    const shellBin = join(dir, 'multishells', shellId, 'bin');
+    mkdirSync(shellBin, { recursive: true });
+    const link = join(shellBin, 'codex');
+    symlinkSync(realInstall, link);
+    return link;
+  }
+
+  it('does not re-probe or re-notify within 24h when the raw path rotates but realpath is stable (criteria 1)', async () => {
+    let now = 1_000_000;
+    let store: CliRuntimeUpdateStore = { entries: {} };
+    const probe = vi.fn(async (target: CliRuntimeUpdateTarget) => ({
+      current: '0.146.0',
+      latest: '0.147.0',
+      managed: true,
+      updateCommand: `${target.binPath} update`,
+    }));
+    const notified: string[] = [];
+    const deps = (binPath: string) => ({
+      now: () => now,
+      targets: () => [runtimeTarget({ runtimeId: 'codex', binPath, provider: 'internal' })],
+      readStore: () => store,
+      writeStore: (next: CliRuntimeUpdateStore) => { store = structuredClone(next); },
+      probe,
+      notify: async (entry: CliRuntimeUpdateEntry) => { notified.push(entry.latest!); },
+    });
+
+    // First tick: fresh shell -> probe + notify once.
+    await runCliRuntimeUpdateAudit(deps(rotatingBin('101_aaa')));
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(notified).toEqual(['0.147.0']);
+
+    const key = `codex:${realInstall}`;
+    expect(Object.keys(store.entries)).toEqual([key]);
+    expect(store.entries[key].installationPath).toBe(realInstall);
+
+    // Second tick 1h later: new fnm shell -> new raw path, same realpath.
+    // TTL must hold and the watermark must survive: no probe, no notify.
+    now += 60 * 60 * 1_000;
+    await runCliRuntimeUpdateAudit(deps(rotatingBin('202_bbb')));
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(notified).toEqual(['0.147.0']);
+    expect(Object.keys(store.entries)).toEqual([key]);
+  });
+
+  it('re-probes after 24h through a rotated path but does not notify again for the same latest (criteria 2)', async () => {
+    let now = 1_000_000;
+    let store: CliRuntimeUpdateStore = { entries: {} };
+    const probe = vi.fn(async () => ({
+      current: '0.146.0',
+      latest: '0.147.0',
+      managed: true,
+      updateCommand: 'codex update',
+    }));
+    const notified: string[] = [];
+    const deps = (binPath: string) => ({
+      now: () => now,
+      targets: () => [runtimeTarget({ runtimeId: 'codex', binPath, provider: 'internal' })],
+      readStore: () => store,
+      writeStore: (next: CliRuntimeUpdateStore) => { store = structuredClone(next); },
+      probe,
+      notify: async (entry: CliRuntimeUpdateEntry) => { notified.push(entry.latest!); },
+    });
+
+    await runCliRuntimeUpdateAudit(deps(rotatingBin('301_aaa')));
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(notified).toEqual(['0.147.0']);
+
+    // > 24h later, through a rotated launcher path: TTL elapses so we re-probe,
+    // but the unchanged latest must not notify again.
+    now += CLI_RUNTIME_UPDATE_CHECK_INTERVAL_MS + 1;
+    await runCliRuntimeUpdateAudit(deps(rotatingBin('302_bbb')));
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(notified).toEqual(['0.147.0']);
+  });
+
+  it('treats a launcher retargeted to a different real install as a new identity (criteria 3)', async () => {
+    let now = 1_000_000;
+    let store: CliRuntimeUpdateStore = { entries: {} };
+    const probe = vi.fn(async () => ({
+      current: '0.146.0',
+      latest: '0.147.0',
+      managed: true,
+      updateCommand: 'codex update',
+    }));
+    const notified: string[] = [];
+    const deps = (binPath: string) => ({
+      now: () => now,
+      targets: () => [runtimeTarget({ runtimeId: 'codex', binPath, provider: 'internal' })],
+      readStore: () => store,
+      writeStore: (next: CliRuntimeUpdateStore) => { store = structuredClone(next); },
+      probe,
+      notify: async (entry: CliRuntimeUpdateEntry) => { notified.push(entry.latest!); },
+    });
+
+    await runCliRuntimeUpdateAudit(deps(rotatingBin('401_aaa')));
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(notified).toEqual(['0.147.0']);
+    const firstKey = `codex:${realInstall}`;
+
+    // A genuinely different install (upgrade to a new node version dir) is a new
+    // realpath. Even within the old TTL window it must re-probe under its own
+    // key and notify on its own merits — not inherit the prior watermark.
+    mkdirSync(join(dir, 'install-v2', 'bin'), { recursive: true });
+    const realInstallV2 = join(dir, 'install-v2', 'bin', 'codex.js');
+    writeFileSync(realInstallV2, '#!/usr/bin/env node\n');
+    const shellBin = join(dir, 'multishells', '402_bbb', 'bin');
+    mkdirSync(shellBin, { recursive: true });
+    const link = join(shellBin, 'codex');
+    symlinkSync(realInstallV2, link);
+
+    now += 60 * 60 * 1_000; // still inside the 24h TTL of the old entry
+    await runCliRuntimeUpdateAudit(deps(link));
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(notified).toEqual(['0.147.0', '0.147.0']);
+    const secondKey = `codex:${realInstallV2}`;
+    expect(secondKey).not.toBe(firstKey);
+    expect(store.entries[secondKey].installationPath).toBe(realInstallV2);
+  });
+
+  it('migrates a legacy raw-path entry onto the stable key without re-notifying (criteria = safe upgrade)', async () => {
+    const now = 5_000_000;
+    // Store written by an older build: keyed by a now-dead fnm launcher path,
+    // no installationPath, already carrying a notification watermark.
+    const deadRawPath = join(dir, 'multishells', 'OLD_dead', 'bin', 'codex');
+    const legacyKey = `codex:${deadRawPath}`;
+    let store: CliRuntimeUpdateStore = {
+      entries: {
+        [legacyKey]: {
+          ...updateEntry({
+            runtimeId: 'codex',
+            binPath: deadRawPath,
+            provider: 'internal',
+            current: '0.146.0',
+            latest: '0.147.0',
+            updateCommand: 'codex update',
+            lastCheckedAt: now - 1_000,
+            lastNotifiedVersion: '0.147.0',
+          }),
+          // Simulate a pre-fix persisted row: identity field absent.
+          installationPath: undefined as unknown as string,
+        },
+      },
+    };
+    const probe = vi.fn(async () => ({
+      current: '0.146.0',
+      latest: '0.147.0',
+      managed: true,
+      updateCommand: 'codex update',
+    }));
+    const notify = vi.fn(async () => {});
+
+    // A live shell resolves to the real install; TTL has not elapsed.
+    await runCliRuntimeUpdateAudit({
+      now: () => now,
+      targets: () => [runtimeTarget({ runtimeId: 'codex', binPath: rotatingBin('501_live'), provider: 'internal' })],
+      readStore: () => store,
+      writeStore: (next: CliRuntimeUpdateStore) => { store = structuredClone(next); },
+      probe,
+      notify,
+    });
+
+    const stableKey = `codex:${realInstall}`;
+    // Legacy row was moved onto the stable identity; watermark carried over so
+    // upgrading botmux does not fire one more notification, and TTL is honored.
+    expect(Object.keys(store.entries)).toEqual([stableKey]);
+    expect(store.entries[stableKey]).toMatchObject({
+      installationPath: realInstall,
+      lastNotifiedVersion: '0.147.0',
+      latest: '0.147.0',
+    });
+    expect(probe).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('does not migrate a dead orphan onto an arbitrary install when two live installs share runtimeId+source (ambiguous group)', async () => {
+    const now = 5_500_000;
+    // Two genuinely distinct installs of the same distribution (e.g. one under
+    // an old node version dir, one under a new one), both currently live and
+    // both sharing runtimeId 'codex' + the same update source. Neither has a
+    // persisted entry yet.
+    mkdirSync(join(dir, 'install-b', 'bin'), { recursive: true });
+    mkdirSync(join(dir, 'install-c', 'bin'), { recursive: true });
+    const installB = join(dir, 'install-b', 'bin', 'codex.js');
+    const installC = join(dir, 'install-c', 'bin', 'codex.js');
+    writeFileSync(installB, '#!/usr/bin/env node\n');
+    writeFileSync(installC, '#!/usr/bin/env node\n');
+    const binB = join(dir, 'multishells', 'B_live', 'bin');
+    const binC = join(dir, 'multishells', 'C_live', 'bin');
+    mkdirSync(binB, { recursive: true });
+    mkdirSync(binC, { recursive: true });
+    symlinkSync(installB, join(binB, 'codex'));
+    symlinkSync(installC, join(binC, 'codex'));
+
+    // A single dead orphan from a removed install, same runtimeId+source,
+    // carrying a within-TTL watermark. Adopting it onto B or C by iteration
+    // order would suppress that install's next probe/notify — the bug.
+    const deadRawPath = join(dir, 'multishells', 'OLD_dead', 'bin', 'codex');
+    const orphanKey = `codex:${resolve(deadRawPath)}`;
+    let store: CliRuntimeUpdateStore = {
+      entries: {
+        [orphanKey]: updateEntry({
+          runtimeId: 'codex',
+          binPath: deadRawPath,
+          provider: 'internal',
+          current: '0.146.0',
+          latest: '0.147.0',
+          updateCommand: 'codex update',
+          lastCheckedAt: now - 1_000,
+          lastNotifiedVersion: '0.147.0',
+        }),
+      },
+    };
+    const probe = vi.fn(async () => ({
+      current: '0.146.0',
+      latest: '0.147.0',
+      managed: true,
+      updateCommand: 'codex update',
+    }));
+    const notified: string[] = [];
+
+    await runCliRuntimeUpdateAudit({
+      now: () => now,
+      targets: () => [
+        runtimeTarget({ runtimeId: 'codex', binPath: join(binB, 'codex'), provider: 'internal' }),
+        runtimeTarget({ runtimeId: 'codex', binPath: join(binC, 'codex'), provider: 'internal' }),
+      ],
+      readStore: () => store,
+      writeStore: (next: CliRuntimeUpdateStore) => { store = structuredClone(next); },
+      probe,
+      notify: async (entry: CliRuntimeUpdateEntry) => { notified.push(entry.latest!); },
+    });
+
+    // Ambiguous group: no migration. Each live install probes and notifies
+    // under its own canonical identity; the dead orphan is pruned.
+    const keyB = `codex:${installB}`;
+    const keyC = `codex:${installC}`;
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(notified).toEqual(['0.147.0', '0.147.0']);
+    expect(Object.keys(store.entries).sort()).toEqual([keyB, keyC].sort());
+    expect(store.entries[keyB]?.installationPath).toBe(installB);
+    expect(store.entries[keyC]?.installationPath).toBe(installC);
+  });
+
+  it('reindexes a pre-fix entry whose rotating symlink is still alive, keeping its watermark (criteria 1/4 boundary)', async () => {
+    const now = 6_000_000;
+    // Reviewer boundary: an older build persisted this row keyed by a rotating
+    // launcher path that HAPPENS to still resolve at upgrade time, and the row
+    // has no installationPath. The real reader must recover the stable identity
+    // from that live path so the entry reindexes (not "stale-only migrates")
+    // onto the canonical key — otherwise the carried watermark would be lost and
+    // the first post-upgrade audit would notify once more.
+    const aliveOldBin = rotatingBin('601_old_alive');
+    const legacyKey = `codex:${aliveOldBin}`; // pre-fix key = raw path
+    // Write a v-without-installationPath store straight to disk, then read it
+    // back through the production reader (not an in-memory shortcut).
+    writeFileSync(cliRuntimeUpdateStorePathIn(dir), JSON.stringify({
+      entries: {
+        [legacyKey]: {
+          cliId: 'codex',
+          runtimeId: 'codex',
+          displayName: 'Codex',
+          binPath: aliveOldBin,
+          provider: 'internal',
+          managed: true,
+          current: '0.146.0',
+          latest: '0.147.0',
+          updateAvailable: true,
+          updateCommand: 'codex update',
+          lastCheckedAt: now - 1_000,
+          lastNotifiedVersion: '0.147.0',
+          // installationPath intentionally absent (pre-fix store).
+        },
+      },
+    }));
+    // The reader derives installationPath from the still-live raw path.
+    const recovered = readCliRuntimeUpdateStoreFrom(dir);
+    expect(recovered.entries[legacyKey]?.installationPath).toBe(realInstall);
+
+    const probe = vi.fn(async () => ({
+      current: '0.146.0',
+      latest: '0.147.0',
+      managed: true,
+      updateCommand: 'codex update',
+    }));
+    const notify = vi.fn(async () => {});
+
+    // Next audit uses a freshly rotated launcher path (different raw path, same
+    // realpath), still inside the 24h TTL.
+    await runCliRuntimeUpdateAudit({
+      now: () => now,
+      targets: () => [runtimeTarget({ runtimeId: 'codex', binPath: rotatingBin('602_new_alive'), provider: 'internal' })],
+      readStore: () => readCliRuntimeUpdateStoreFrom(dir),
+      writeStore: (next: CliRuntimeUpdateStore) => { writeCliRuntimeUpdateStoreTo(dir, next); },
+      probe,
+      notify,
+    });
+
+    const persisted = JSON.parse(readFileSync(cliRuntimeUpdateStorePathIn(dir), 'utf8')) as {
+      entries: Record<string, CliRuntimeUpdateEntry>;
+    };
+    const stableKey = `codex:${realInstall}`;
+    expect(Object.keys(persisted.entries)).toEqual([stableKey]);
+    expect(persisted.entries[stableKey]).toMatchObject({
+      installationPath: realInstall,
+      lastNotifiedVersion: '0.147.0',
+      lastCheckedAt: now - 1_000,
+    });
+    // Watermark survived and TTL held: no re-probe, no extra notification.
+    expect(probe).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 问题
botmux 在 FNM 环境下 Codex 更新提醒每小时重复发送：版本差检测正确，但同一个 latest 每小时都通知一次。

## 根因
`cli-runtime-update` 持久化 key = `runtimeId + raw binPath`。FNM 每个新 login/interactive shell 生成一个新的 `/run/user/.../fnm_multishells/<pid>_.../bin/codex` 临时软链，`resolveCommand('codex')` 每小时拿到不同 raw path → 新 key；旧 key 不在 configuredKeys 里被 prune 删除；新 entry 丢失 `lastCheckedAt` / `lastNotifiedVersion` → 24h TTL 和「同版本只提醒一次」水位双双失效 → 每小时 probe + notify。这些路径最终都指向同一个 npm 安装。

## 改动（src/core/cli-runtime-update.ts）
1. 持久化 key 改为 `runtimeId + canonical realpath`；raw binPath 降级为纯展示字段。
2. entry 新增持久字段 `installationPath`（写入时冻结的 realpath）——旋转软链下次读取已失效无法再解析，故身份必须落盘；`validEntry` 对旧行从 binPath 兜底推导，无回归。
3. `canonicalInstallationPath()`（realpath 失败回退 resolve），targetKey/entryKey/dedupe/filter 全部收敛到同一 identity，旋转软链自然折叠到同一行。
4. 审计前 reindex + migration 双路径：软链仍活着 → entryKey 命中稳定 key，整行（含 watermark + lastCheckedAt）搬运；软链已死成孤儿 → 按 runtimeId + sourceFingerprint 唯一匹配迁移并保留 watermark。升级不再多提醒一次；真换安装（realpath 变、旧文件还在）判为新身份、重新 probe、不串旧水位；不同 provider/package 不串 watermark。

## 影响面
仅改 host 侧 Codex 更新监控（`core/cli-runtime-update`），read-only 探测语义不变，不触碰其它 CLI/后端/IM 路径。

## 测试
- 用真实 symlink 模拟 FNM 旋转，新增回归用例覆盖验收标准 1–4：1h 内旋转不 probe/不 notify；超 24h 重探但 latest 不变不重复 notify；换安装重新 probe 不串水位；旧行迁移不重复提醒；软链仍活着走 reindex 保留 watermark。
- `cli-runtime-update` 42 passed；tsc 全量 emit 通过。