### PR TITLE
fix(traex): task_complete 失败回合映射 failed 终态并识别静默轮 sentinel

### DIFF
--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -50,6 +50,7 @@
  *     for turn N+1 could leak a send credit into turn N's window.
  */
 import { normaliseForFingerprint } from './bridge-turn-queue.js';
+import { CODEX_RATE_LIMIT_ERROR_CODE } from './codex-transcript.js';
 
 const MATERIAL_FINAL_LENGTH_RATIO = 2;
 const MATERIAL_FINAL_MIN_EXTRA_CHARS = 120;
@@ -351,4 +352,36 @@ export function shouldEmitFailedBridgeFallback(
   if (turn.isLocal) return false;
   if (turn.terminalStatus !== 'failed') return false;
   return !shouldSuppressBridgeEmit(turn, nextBoundaryMs, markers, adoptMode);
+}
+
+/** Which fallback content the worker should post for a ready structured turn.
+ *  Extracted from emitReadyCodexTurns so the rate-limit skip — which depends
+ *  on whether the CLI owns a dedicated structured rate-limit notification
+ *  chain (Codex only today) — is testable without a live worker.
+ *
+ *  Rate-limit contract: a `codex_rate_limited` terminal is handed to the
+ *  CLI's dedicated chain when one exists, so the generic failed fallback is
+ *  skipped to avoid double-posting. A CLI WITHOUT the chain (e.g. TRAE) must
+ *  fall through to the generic failed fallback — otherwise a 429 turn posts
+ *  nothing at all, regressing "misleading but visible" into "silent". */
+export type StructuredFallbackKind = 'failed' | 'final' | 'empty_completed' | 'none';
+
+export function structuredFallbackKind(
+  turn: BridgeGateInput & { terminalErrorCode?: string },
+  nextBoundaryMs: number | undefined,
+  markers: readonly BridgeSendMarker[],
+  adoptMode: boolean,
+  hasDedicatedRateLimitChain: boolean,
+): StructuredFallbackKind {
+  const rateLimitHandled = hasDedicatedRateLimitChain
+    && turn.terminalErrorCode === CODEX_RATE_LIMIT_ERROR_CODE;
+  if (!rateLimitHandled
+    && shouldEmitFailedBridgeFallback(turn, nextBoundaryMs, markers, adoptMode)) {
+    return 'failed';
+  }
+  if (turn.finalText && turn.finalText.trim()) return 'final';
+  if (shouldEmitEmptyCompletedBridgeFallback(turn, nextBoundaryMs, markers, adoptMode)) {
+    return 'empty_completed';
+  }
+  return 'none';
 }

--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -305,7 +305,10 @@ function codexFailureLeaf(error: unknown): unknown {
   return current;
 }
 
-function safeFailureSummary(error: unknown): string | undefined {
+/** Bounded, redacted user-facing summary of a structured task_complete error.
+ *  Exported for the TRAE drainer, which mirrors the Codex error→failed
+ *  terminal mapping on the same payload shape. */
+export function safeFailureSummary(error: unknown): string | undefined {
   const leaf = codexFailureLeaf(error);
   let message = '';
   let code = '';
@@ -389,7 +392,11 @@ function safeFailureSummary(error: unknown): string | undefined {
     : summary;
 }
 
-function codexTaskFailureCode(error: unknown): string {
+/** Classify a structured task_complete error into a stable failure code.
+ *  Shared with the TRAE drainer (traex-transcript.ts), whose task_complete
+ *  error payloads use the same Codex-family shape — keep one classifier so
+ *  both bridges map e.g. connection failures to the same code. */
+export function codexTaskFailureCode(error: unknown): string {
   let serialized = '';
   try { serialized = JSON.stringify(error); } catch { serialized = String(error ?? ''); }
   const normalized = serialized.toLowerCase();

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -10,6 +10,13 @@
  *     times during tool use, so none of them is a safe turn boundary;
  *   - event_msg `task_complete` is the durable end-of-turn marker and carries
  *     the final visible text in `last_agent_message` (which may be empty).
+ *     When it is empty the drainer consults the turn's `agent_message`
+ *     records: a `final_answer`-phase message reconstructs a dropped final,
+ *     and a commentary message ending in the nothing-to-send sentinel marks
+ *     deliberate silence. A non-null `error` payload maps the terminal to
+ *     `failed` (mirroring the Codex drainer) so a model-endpoint failure
+ *     surfaces its real reason instead of the misleading "completed but
+ *     empty" diagnostic.
  *   - Directory layout differs: sessions live under
  *     ~/.trae/cli/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<uuid>.jsonl
  *     (note the extra `cli/` level vs Codex's ~/.codex/sessions/...).
@@ -35,7 +42,13 @@ import {
   type CodexBridgeEvent,
   type CodexDrainResult,
   codexSessionIdFromRolloutPath,
+  codexTaskFailureCode,
+  safeFailureSummary,
 } from './codex-transcript.js';
+import {
+  BRIDGE_NOTHING_TO_SEND_SENTINEL,
+  BRIDGE_NO_REPLY_SENTINEL_LEGACY,
+} from './bridge-fallback-gate.js';
 import { isInternalCodexSessionMeta } from './codex-session-meta.js';
 import { baselineJsonlCursor } from './jsonl-cursor.js';
 import { traeSessionsRoot } from './traex-paths.js';
@@ -72,6 +85,53 @@ const traexRolloutMetaCache = new Map<string, {
   kind: TraexRolloutKind;
   startedAtMs?: number;
 }>();
+
+/** Per-rollout `agent_message` state for the CURRENTLY OPEN turn, retained
+ *  across drain calls. A turn's commentary/final_answer records are almost
+ *  always drained in earlier polls than its `task_complete` (turns run for
+ *  minutes while the poller runs on the second scale), so same-batch state
+ *  would never see them. Reset on every `user_message` (turn start) and
+ *  consumed/cleared by `task_complete`/`turn_aborted` (turn end); a turn that
+ *  terminates without either leaves at most one stale entry, bounded by the
+ *  same cap/eviction as traexRolloutMetaCache. */
+interface TraexPendingAgentMessages {
+  /** Last commentary-phase `agent_message` since the turn's user_message.
+   *  Its trailing sentinel is the deliberate-silence signal. */
+  lastCommentary?: string;
+  /** Last final_answer-phase `agent_message` since the turn's user_message.
+   *  Defensive reconstruction source when task_complete drops the final it
+   *  actually produced. */
+  lastFinalAnswer?: string;
+}
+
+const traexPendingAgentCache = new Map<string, TraexPendingAgentMessages>();
+const TRAEX_PENDING_AGENT_CACHE_MAX = 512;
+
+function traexPendingAgentState(path: string): TraexPendingAgentMessages {
+  let state = traexPendingAgentCache.get(path);
+  if (!state) {
+    state = {};
+    traexPendingAgentCache.set(path, state);
+    if (traexPendingAgentCache.size > TRAEX_PENDING_AGENT_CACHE_MAX) {
+      const oldest = traexPendingAgentCache.keys().next().value;
+      if (oldest) traexPendingAgentCache.delete(oldest);
+    }
+  }
+  return state;
+}
+
+/** Matches a commentary message that ENDS with a nothing-to-send sentinel
+ *  (current or legacy token), optionally glued to trailing prose — the shape
+ *  TRAE writes when the model replied via `botmux send` and kept only
+ *  narration in the commentary phase. Captures the exact token so the
+ *  synthesised final carries the same one the gate recognises. */
+const TRAEX_TRAILING_SENTINEL_RE = new RegExp(
+  `(${BRIDGE_NOTHING_TO_SEND_SENTINEL}|${BRIDGE_NO_REPLY_SENTINEL_LEGACY})\\s*$`,
+);
+
+function traexTrailingSentinel(message: string): string | undefined {
+  return TRAEX_TRAILING_SENTINEL_RE.exec(message)?.[1];
+}
 
 /** Upper bound on how far back readLatestTraexRuntime scans for the newest
  * model/effort. The newest turn_context sits near the tail, so this is only a
@@ -117,7 +177,16 @@ function runtimeFromTraexEntry(entry: any): TraexRuntimeSnapshot | undefined {
  * `task_complete` is intentionally emitted even when last_agent_message is
  * missing/empty: a silent successful turn still has to release a durable
  * delivery. A non-newline-terminated tail is never parsed, so a process crash
- * halfway through the terminal JSON object cannot manufacture completion. */
+ * halfway through the terminal JSON object cannot manufacture completion.
+ *
+ * Terminal refinement on an empty `last_agent_message`:
+ *   - a non-null `error` payload maps the event to `failed` (same shape as the
+ *     Codex drainer) — traecli writes task_complete with
+ *     last_agent_message=null AND error when the model endpoint fails, so the
+ *     failure must not be read as a silent success;
+ *   - otherwise the turn's agent_message records (tracked across drain calls)
+ *     recover a dropped final_answer or recognise a trailing
+ *     nothing-to-send sentinel as deliberate silence. */
 export function drainTraexRollout(path: string, fromOffset: number): TraexDrainResult {
   if (!existsSync(path)) return { events: [], newOffset: 0, pendingTail: '' };
   let size: number;
@@ -163,17 +232,65 @@ export function drainTraexRollout(path: string, fromOffset: number): TraexDrainR
       && payload.type === 'user_message'
       && typeof payload.message === 'string') {
       const userText = payload.message;
-      if (userText) events.push({ ...base, kind: 'user', text: userText });
+      if (userText) {
+        events.push({ ...base, kind: 'user', text: userText });
+        // New turn: drop any agent_message state an unterminated predecessor
+        // left behind so it can't be attributed to this turn.
+        traexPendingAgentCache.delete(path);
+      }
+      continue;
+    }
+    // agent_message records are narration (commentary) or the produced final
+    // (final_answer). They are NOT turn boundaries — only task_complete is —
+    // so they are tracked per turn and consulted when the terminal arrives
+    // with an empty/missing last_agent_message.
+    if (obj.type === 'event_msg'
+      && payload.type === 'agent_message'
+      && typeof payload.message === 'string'
+      && payload.message.length > 0) {
+      const pending = traexPendingAgentState(path);
+      if (payload.phase === 'final_answer') pending.lastFinalAnswer = payload.message;
+      else pending.lastCommentary = payload.message;
       continue;
     }
     if (obj.type === 'event_msg'
       && payload.type === 'task_complete'
       && typeof payload.turn_id === 'string'
       && payload.turn_id.length > 0) {
+      const pending = traexPendingAgentCache.get(path);
+      const failed = payload.error !== null && payload.error !== undefined;
+      const rawFinal = typeof payload.last_agent_message === 'string'
+        ? payload.last_agent_message
+        : '';
+      let text = rawFinal;
+      if (!failed && rawFinal.trim().length === 0) {
+        // TRAE wrote no final for a successful turn. Recover, in order:
+        //   1. a final_answer-phase agent_message — TRAE dropped the final it
+        //      actually produced (the phase field guarantees it is an answer,
+        //      not tool narration);
+        //   2. a commentary message ending in the nothing-to-send sentinel —
+        //      the model deliberately stayed silent (it replied via
+        //      `botmux send`), so synthesise the bare sentinel the fallback
+        //      gate already treats as genuine silence instead of tripping the
+        //      misleading "completed but empty" diagnostic.
+        text = pending?.lastFinalAnswer && pending.lastFinalAnswer.trim().length > 0
+          ? pending.lastFinalAnswer
+          : traexTrailingSentinel(pending?.lastCommentary ?? '') ?? '';
+      }
+      traexPendingAgentCache.delete(path);
       events.push({
         ...base,
         kind: 'assistant_final',
-        text: typeof payload.last_agent_message === 'string' ? payload.last_agent_message : '',
+        text,
+        // A non-null error means the turn FAILED (e.g. the model endpoint
+        // connection failed before any response). Mirror the Codex drainer:
+        // classify as failed with a safe code/summary so the worker surfaces
+        // the real reason instead of an empty-final alert.
+        ...(failed ? {
+          terminalStatus: 'failed' as const,
+          terminalErrorCode: codexTaskFailureCode(payload.error),
+          terminalErrorSummary: safeFailureSummary(payload.error),
+        } : {}),
       });
       continue;
     }
@@ -185,6 +302,7 @@ export function drainTraexRollout(path: string, fromOffset: number): TraexDrainR
       && payload.type === 'turn_aborted'
       && typeof payload.turn_id === 'string'
       && payload.turn_id.length > 0) {
+      traexPendingAgentCache.delete(path);
       events.push({
         ...base,
         kind: 'assistant_final',

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -286,22 +286,24 @@ export function drainTraexRollout(
         ? payload.last_agent_message
         : '';
       let text = rawFinal;
-      // Synthesis is non-adopt only: adopt posts transcript text verbatim, so
-      // a synthesised bare sentinel would leak the literal token into Lark.
-      // In adopt an empty final stays empty (no alert fires there either).
-      if (!adoptMode && !failed && rawFinal.trim().length === 0) {
+      if (!failed && rawFinal.trim().length === 0) {
         // TRAE wrote no final for a successful turn. Recover, in order:
         //   1. a final_answer-phase agent_message — TRAE dropped the final it
         //      actually produced (the phase field guarantees it is an answer,
-        //      not tool narration);
+        //      not tool narration). Safe in BOTH modes: it is the model's real
+        //      answer, and adopt posts transcript text verbatim anyway;
         //   2. a commentary message ending in the nothing-to-send sentinel —
         //      the model deliberately stayed silent (it replied via
         //      `botmux send`), so synthesise the bare sentinel the fallback
         //      gate already treats as genuine silence instead of tripping the
-        //      misleading "completed but empty" diagnostic.
-        text = pending?.lastFinalAnswer && pending.lastFinalAnswer.trim().length > 0
+        //      misleading "completed but empty" diagnostic. NON-ADOPT ONLY:
+        //      adopt posts transcript text verbatim, so a synthesised bare
+        //      token would leak the literal into Lark.
+        text = pending?.lastFinalAnswer?.trim()
           ? pending.lastFinalAnswer
-          : traexTrailingSentinel(pending?.lastCommentary ?? '') ?? '';
+          : !adoptMode
+            ? traexTrailingSentinel(pending?.lastCommentary ?? '') ?? ''
+            : '';
       }
       if (!probe) traexPendingAgentCache.delete(path);
       events.push({

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -64,6 +64,20 @@ export interface TraexDrainResult extends CodexDrainResult {
   latestReasoningEffort?: string;
 }
 
+export interface TraexDrainOptions {
+  /** Adopt mode: the adopted CLI is botmux-unaware, so the drainer must NOT
+   *  synthesise a bare nothing-to-send sentinel for an empty final — the emit
+   *  layer posts transcript text verbatim in adopt mode and the literal token
+   *  would leak into Lark. Default false (synthesise, matching the non-adopt
+   *  genuine-silence contract). */
+  adoptMode?: boolean;
+  /** Read-only probe: skip the per-turn agent_message cache mutations. Used by
+   *  submit-confirmation probes that re-drain the same live rollout at a
+   *  different offset and must not disturb the production drainer's pending
+   *  turn state. */
+  probe?: boolean;
+}
+
 export interface TraexRuntimeSnapshot {
   model?: string;
   reasoningEffort?: string;
@@ -186,8 +200,16 @@ function runtimeFromTraexEntry(entry: any): TraexRuntimeSnapshot | undefined {
  *     failure must not be read as a silent success;
  *   - otherwise the turn's agent_message records (tracked across drain calls)
  *     recover a dropped final_answer or recognise a trailing
- *     nothing-to-send sentinel as deliberate silence. */
-export function drainTraexRollout(path: string, fromOffset: number): TraexDrainResult {
+ *     nothing-to-send sentinel as deliberate silence. The sentinel synthesis
+ *     runs only in non-adopt mode: adopt posts transcript text verbatim, so a
+ *     synthesised bare token would leak into Lark. */
+export function drainTraexRollout(
+  path: string,
+  fromOffset: number,
+  opts?: TraexDrainOptions,
+): TraexDrainResult {
+  const adoptMode = opts?.adoptMode === true;
+  const probe = opts?.probe === true;
   if (!existsSync(path)) return { events: [], newOffset: 0, pendingTail: '' };
   let size: number;
   try { size = statSync(path).size; } catch { return { events: [], newOffset: fromOffset, pendingTail: '' }; }
@@ -236,7 +258,7 @@ export function drainTraexRollout(path: string, fromOffset: number): TraexDrainR
         events.push({ ...base, kind: 'user', text: userText });
         // New turn: drop any agent_message state an unterminated predecessor
         // left behind so it can't be attributed to this turn.
-        traexPendingAgentCache.delete(path);
+        if (!probe) traexPendingAgentCache.delete(path);
       }
       continue;
     }
@@ -244,7 +266,8 @@ export function drainTraexRollout(path: string, fromOffset: number): TraexDrainR
     // (final_answer). They are NOT turn boundaries — only task_complete is —
     // so they are tracked per turn and consulted when the terminal arrives
     // with an empty/missing last_agent_message.
-    if (obj.type === 'event_msg'
+    if (!probe
+      && obj.type === 'event_msg'
       && payload.type === 'agent_message'
       && typeof payload.message === 'string'
       && payload.message.length > 0) {
@@ -263,7 +286,10 @@ export function drainTraexRollout(path: string, fromOffset: number): TraexDrainR
         ? payload.last_agent_message
         : '';
       let text = rawFinal;
-      if (!failed && rawFinal.trim().length === 0) {
+      // Synthesis is non-adopt only: adopt posts transcript text verbatim, so
+      // a synthesised bare sentinel would leak the literal token into Lark.
+      // In adopt an empty final stays empty (no alert fires there either).
+      if (!adoptMode && !failed && rawFinal.trim().length === 0) {
         // TRAE wrote no final for a successful turn. Recover, in order:
         //   1. a final_answer-phase agent_message — TRAE dropped the final it
         //      actually produced (the phase field guarantees it is an answer,
@@ -277,7 +303,7 @@ export function drainTraexRollout(path: string, fromOffset: number): TraexDrainR
           ? pending.lastFinalAnswer
           : traexTrailingSentinel(pending?.lastCommentary ?? '') ?? '';
       }
-      traexPendingAgentCache.delete(path);
+      if (!probe) traexPendingAgentCache.delete(path);
       events.push({
         ...base,
         kind: 'assistant_final',
@@ -302,7 +328,7 @@ export function drainTraexRollout(path: string, fromOffset: number): TraexDrainR
       && payload.type === 'turn_aborted'
       && typeof payload.turn_id === 'string'
       && payload.turn_id.length > 0) {
-      traexPendingAgentCache.delete(path);
+      if (!probe) traexPendingAgentCache.delete(path);
       events.push({
         ...base,
         kind: 'assistant_final',
@@ -403,15 +429,19 @@ function normaliseInputText(text: string): string {
   return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
-/** Authoritative submit confirmation used by the adapter. Only a complete
- * event_msg/user_message record appended after `fromOffset` can match. */
+/** Submit-confirmation probe: only a complete event_msg/user_message record
+ * appended after `fromOffset` can match. Read-only — drains with `probe` so
+ * it never mutates the per-turn agent_message cache the production drainer
+ * relies on (a re-drain of the same live rollout at a different offset must
+ * not clear pending turn state). Not currently wired into the production
+ * submit-confirmation path; kept as a tested probe. */
 export function traexRolloutHasUserInputSince(
   path: string,
   fromOffset: number,
   expectedText: string,
 ): boolean {
   const expected = normaliseInputText(expectedText);
-  return drainTraexRollout(path, fromOffset).events.some(event =>
+  return drainTraexRollout(path, fromOffset, { probe: true }).events.some(event =>
     event.kind === 'user' && normaliseInputText(event.text) === expected,
   );
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -44,7 +44,7 @@ import { readProcessStartIdentity } from './core/session-marker.js';
 import { roleLibraryRoot, roleLibrarySubtree } from './core/role-library.js';
 import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
-import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldEmitFailedBridgeFallback, shouldSuppressBridgeEmit, stripTrailingBridgeSentinelLine, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
+import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, structuredFallbackKind, stripTrailingBridgeSentinelLine, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { buildSubmitMessagePreview } from './services/submit-notification.js';
 import {
   decideHardTimeoutAction,
@@ -143,7 +143,7 @@ import {
   setCodexAppThreadName,
 } from './services/codex-app-threads.js';
 import { buildBotmuxLarkNativeSessionTitle } from './core/session-title.js';
-import { CODEX_AUTH_ERROR_CODE, CODEX_CONNECTION_ERROR_CODE, CODEX_INVALID_REQUEST_ERROR_CODE, CODEX_RATE_LIMIT_ERROR_CODE, drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, findCodexRolloutSetByPid, codexHistorySidIsOwned, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, isCodexRateLimitEvent, scanCodexThreadSettings, readLatestCodexRuntime, type CodexBridgeEvent, type CodexDrainResult } from './services/codex-transcript.js';
+import { CODEX_AUTH_ERROR_CODE, CODEX_CONNECTION_ERROR_CODE, CODEX_INVALID_REQUEST_ERROR_CODE, drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, findCodexRolloutSetByPid, codexHistorySidIsOwned, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, isCodexRateLimitEvent, scanCodexThreadSettings, readLatestCodexRuntime, type CodexBridgeEvent, type CodexDrainResult } from './services/codex-transcript.js';
 import { CodexServiceTierTracker, resolveCodexServiceTierSnapshot } from './services/codex-service-tier.js';
 import { WORKER_IPC_HANDLER_READY_EVENT } from './worker-ipc-preload.js';
 import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid, findTraexRolloutSetByPid, readLatestTraexRuntime, traexHistorySidIsOwned, type TraexDrainResult, type TraexRuntimeSnapshot } from './services/traex-transcript.js';
@@ -5273,7 +5273,11 @@ function currentHermesBridgeDbPath(): string {
 
 function structuredBridgeIngestPath(path: string, offset: number) {
   if (structuredBridgeIsCodex()) return drainCodexRollout(path, offset);
-  if (structuredBridgeIsTraex()) return drainTraexRollout(path, offset);
+  // adoptMode gates the drainer's bare-sentinel synthesis: adopt posts
+  // transcript text verbatim, so a synthesised token would leak into Lark.
+  if (structuredBridgeIsTraex()) {
+    return drainTraexRollout(path, offset, { adoptMode: lastInitConfig?.adoptMode === true });
+  }
   if (codexBridgeIsCursor()) return drainCursorTranscript(path, offset);
   if (structuredBridgeIsPi()) return drainPiTranscript(path, offset);
   if (structuredBridgeIsGrok()) return drainGrokUpdates(path, offset);
@@ -6517,13 +6521,19 @@ function emitReadyCodexTurns(): void {
       isLocal: turn.isLocal,
       finalText: turn.finalText,
       terminalStatus: turn.terminalStatus,
+      terminalErrorCode: turn.terminalErrorCode,
     };
-    const content = turn.terminalErrorCode !== CODEX_RATE_LIMIT_ERROR_CODE
-      && shouldEmitFailedBridgeFallback(gateInput, nextBoundaryMs, markers, adoptMode)
+    // The rate-limit skip is narrowed to CLIs with a dedicated structured
+    // rate-limit chain (Codex): TRAE 429 has no such chain, so skipping the
+    // generic failed fallback would post nothing at all.
+    const fallbackKind = structuredFallbackKind(
+      gateInput, nextBoundaryMs, markers, adoptMode, structuredBridgeIsCodex(),
+    );
+    const content = fallbackKind === 'failed'
       ? failedBridgeFallbackContent(turn.terminalErrorCode, turn.terminalErrorSummary, turn.finalText)
-      : turn.finalText && turn.finalText.trim()
-        ? turn.finalText
-        : shouldEmitEmptyCompletedBridgeFallback(gateInput, nextBoundaryMs, markers, adoptMode)
+      : fallbackKind === 'final'
+        ? turn.finalText ?? ''
+        : fallbackKind === 'empty_completed'
           ? emptyCompletedBridgeFallbackContent()
           : '';
     if (!content) continue;

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -9,9 +9,14 @@ import {
   shouldEmitEmptyCompletedBridgeFallback,
   shouldEmitFailedBridgeFallback,
   shouldSuppressBridgeEmit,
+  structuredFallbackKind,
   stripTrailingBridgeSentinelLine,
   type BridgeSendMarker,
 } from '../src/services/bridge-fallback-gate.js';
+import {
+  CODEX_CONNECTION_ERROR_CODE,
+  CODEX_RATE_LIMIT_ERROR_CODE,
+} from '../src/services/codex-transcript.js';
 
 const turn = (markTimeMs: number | undefined, isLocal: boolean | undefined = false) =>
   ({ markTimeMs, isLocal });
@@ -550,5 +555,74 @@ describe('shouldEmitFailedBridgeFallback', () => {
       [],
       false,
     )).toBe(true);
+  });
+});
+
+describe('structuredFallbackKind', () => {
+  it('TRAE 429 (no dedicated rate-limit chain) falls through to the generic failed fallback', () => {
+    // The regression this guards: TRAE has no structured rate-limit chain, so
+    // skipping the generic failed fallback for codex_rate_limited posted
+    // nothing at all — "misleading but visible" regressed into "silent".
+    expect(structuredFallbackKind(
+      { ...turn(100), finalText: '', terminalStatus: 'failed', terminalErrorCode: CODEX_RATE_LIMIT_ERROR_CODE },
+      undefined,
+      [],
+      false,
+      false, // hasDedicatedRateLimitChain=false (TRAE)
+    )).toBe('failed');
+  });
+
+  it('Codex 429 (dedicated chain) skips the generic failed fallback', () => {
+    // Codex's maybeEmitCodexStructuredRateLimit already surfaces the limit, so
+    // the generic failed fallback must not double-post.
+    expect(structuredFallbackKind(
+      { ...turn(100), finalText: '', terminalStatus: 'failed', terminalErrorCode: CODEX_RATE_LIMIT_ERROR_CODE },
+      undefined,
+      [],
+      false,
+      true, // hasDedicatedRateLimitChain=true (Codex)
+    )).not.toBe('failed');
+  });
+
+  it('a non-rate-limit failure maps to the failed fallback with or without a chain', () => {
+    for (const hasChain of [false, true]) {
+      expect(structuredFallbackKind(
+        { ...turn(100), finalText: '', terminalStatus: 'failed', terminalErrorCode: CODEX_CONNECTION_ERROR_CODE },
+        undefined,
+        [],
+        false,
+        hasChain,
+      )).toBe('failed');
+    }
+  });
+
+  it('a non-empty final maps to final', () => {
+    expect(structuredFallbackKind(
+      { ...turn(100), finalText: 'answer' },
+      undefined,
+      [],
+      false,
+      false,
+    )).toBe('final');
+  });
+
+  it('an empty completed turn with no markers maps to empty_completed', () => {
+    expect(structuredFallbackKind(
+      { ...turn(100), finalText: '' },
+      undefined,
+      [],
+      false,
+      false,
+    )).toBe('empty_completed');
+  });
+
+  it('a turn suppressed by an in-window send marker maps to none', () => {
+    expect(structuredFallbackKind(
+      { ...turn(100), finalText: '' },
+      undefined,
+      [{ sentAtMs: 150 }],
+      false,
+      false,
+    )).toBe('none');
   });
 });

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -506,6 +506,30 @@ describe('drainTraexRollout', () => {
     }));
   });
 
+  it('reconstructs a final_answer-phase message in adopt mode (real answer, not synthesis)', () => {
+    // final_answer reconstruction is safe in BOTH modes: it is the model's
+    // real transcript answer (phase-guaranteed, not tool narration), and adopt
+    // posts transcript text verbatim anyway. Only the bare-sentinel synthesis
+    // is adopt-gated. adopt is in fact the mode where reconstruction matters
+    // most — drain is the only channel to Lark there.
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessage('思考中', 'commentary')),
+      line(agentMessage('这是最终答案', 'final_answer')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0, { adoptMode: true }).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '这是最终答案',
+    }));
+    // Non-adopt reconstructs identically.
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '这是最终答案',
+    }));
+  });
+
   it('a probe re-drain mid-turn does not clear the production pending state', () => {
     // traexRolloutHasUserInputSince re-drains the same live rollout; its
     // user_message processing must not delete the commentary the production

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -3,6 +3,11 @@ import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
+import { CODEX_CONNECTION_ERROR_CODE } from '../src/services/codex-transcript.js';
+import {
+  isBridgeNothingToSendFinal,
+  shouldEmitEmptyCompletedBridgeFallback,
+} from '../src/services/bridge-fallback-gate.js';
 import {
   drainTraexRollout,
   readLatestTraexRuntime,
@@ -68,6 +73,34 @@ function taskComplete(lastAgentMessage?: string) {
       type: 'task_complete',
       turn_id: '00000000-0000-7000-8000-000000000010',
       ...(lastAgentMessage === undefined ? {} : { last_agent_message: lastAgentMessage }),
+      completed_at: 946_684_803,
+      duration_ms: 1_000,
+    },
+  };
+}
+
+function agentMessage(text: string, phase: 'commentary' | 'final_answer' = 'commentary') {
+  return {
+    timestamp: '2000-01-01T00:00:02.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'agent_message',
+      message: text,
+      phase,
+      memory_citation: null,
+    },
+  };
+}
+
+function taskCompleteWithError(error: unknown, lastAgentMessage?: string) {
+  return {
+    timestamp: '2000-01-01T00:00:03.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'task_complete',
+      turn_id: '00000000-0000-7000-8000-000000000010',
+      ...(lastAgentMessage === undefined ? {} : { last_agent_message: lastAgentMessage }),
+      error,
       completed_at: 946_684_803,
       duration_ms: 1_000,
     },
@@ -290,6 +323,166 @@ describe('drainTraexRollout', () => {
         finalText: 'one merged answer',
       }),
     ]);
+  });
+
+  it('maps a task_complete error payload to a failed terminal (path A: endpoint failure)', () => {
+    // Real shape from rollout-…01a0098a….jsonl: traecli writes task_complete
+    // with last_agent_message=null AND error when the model endpoint fails.
+    writeFileSync(path, [
+      line(user('call the model')),
+      line(taskCompleteWithError({
+        message: 'model endpoint connection failed before receiving an HTTP response: error sending request for url (https://copilot.byteintl.net/api/ide/v2/llm_raw_chat)',
+        codex_error_info: { http_connection_failed: { http_status_code: null } },
+      })),
+    ].join(''));
+
+    const result = drainTraexRollout(path, 0);
+    expect(result.events.at(-1)).toMatchObject({
+      kind: 'assistant_final',
+      text: '',
+      terminalStatus: 'failed',
+      terminalErrorCode: CODEX_CONNECTION_ERROR_CODE,
+    });
+    expect(result.events.at(-1)!.terminalErrorSummary).toContain('model endpoint connection failed');
+    // The provider URL must not survive into the user-facing summary.
+    expect(result.events.at(-1)!.terminalErrorSummary).not.toContain('copilot.byteintl.net');
+  });
+
+  it('classifies as failed even when last_agent_message is present alongside the error', () => {
+    writeFileSync(path, line(user('partial turn'))
+      + line(taskCompleteWithError({ message: 'connection reset by peer' }, 'partial answer')));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toMatchObject({
+      kind: 'assistant_final',
+      text: 'partial answer',
+      terminalStatus: 'failed',
+      terminalErrorCode: CODEX_CONNECTION_ERROR_CODE,
+    });
+  });
+
+  it('synthesises the bare sentinel when the last commentary ends with BOTMUX_NO_REPLY (path B: deliberate silence)', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessage('进度：CI 已绿', 'commentary')),
+      line(agentMessage('我已完成状态回报。BOTMUX_NO_REPLY', 'commentary')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: 'BOTMUX_NO_REPLY',
+    }));
+  });
+
+  it('recognises the current BOTMUX_NOTHING_TO_SEND sentinel as deliberate silence', () => {
+    writeFileSync(path, [
+      line(user('ambient chatter')),
+      line(agentMessage('BOTMUX_NOTHING_TO_SEND', 'commentary')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: 'BOTMUX_NOTHING_TO_SEND',
+    }));
+  });
+
+  it('retains agent_message state across drain calls (commentary drained before task_complete)', () => {
+    // Turns run for minutes while the poller drains on the second scale: the
+    // commentary batch and the task_complete almost never share a drain call.
+    const firstBatch = line(user('long-running turn'))
+      + line(agentMessage('工作中', 'commentary'))
+      + line(agentMessage('已通过 botmux send 回报。BOTMUX_NO_REPLY', 'commentary'));
+    writeFileSync(path, firstBatch);
+    const first = drainTraexRollout(path, 0);
+    expect(first.events.map(event => event.kind)).toEqual(['user']);
+
+    appendFileSync(path, line(taskComplete()));
+    const second = drainTraexRollout(path, first.newOffset);
+    expect(second.events).toEqual([
+      expect.objectContaining({ kind: 'assistant_final', text: 'BOTMUX_NO_REPLY' }),
+    ]);
+  });
+
+  it('does not treat a commentary without a trailing sentinel as silence', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessage('随便聊聊，没有结论', 'commentary')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '',
+    }));
+  });
+
+  it('reconstructs the final from the last final_answer-phase agent_message (defensive: TRAE dropped the final)', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessage('思考中', 'commentary')),
+      line(agentMessage('这是最终答案', 'final_answer')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '这是最终答案',
+    }));
+  });
+
+  it('prefers a final_answer reconstruction over a commentary sentinel', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessage('已回报。BOTMUX_NO_REPLY', 'commentary')),
+      line(agentMessage('真正的最终答案', 'final_answer')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '真正的最终答案',
+    }));
+  });
+
+  it('resets pending agent state at each user_message so a prior turn cannot leak', () => {
+    writeFileSync(path, [
+      line(user('first turn')),
+      line(agentMessage('第一轮已回报。BOTMUX_NO_REPLY', 'commentary')),
+      line(taskComplete()),
+      line(user('second turn')),
+      line(taskComplete()),
+    ].join(''));
+
+    const finals = drainTraexRollout(path, 0).events.filter(event => event.kind === 'assistant_final');
+    expect(finals[0]).toEqual(expect.objectContaining({ text: 'BOTMUX_NO_REPLY' }));
+    expect(finals[1]).toEqual(expect.objectContaining({ text: '' }));
+  });
+
+  it('synthesised sentinel final is genuine silence: the empty-completed alert stays suppressed', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessage('已回报。BOTMUX_NO_REPLY', 'commentary')),
+      line(taskComplete()),
+    ].join(''));
+
+    const queue = new CodexBridgeQueue();
+    queue.mark('delivery-1', 'do the work', Date.parse('2000-01-01T00:00:00.000Z'), 1);
+    queue.ingest(drainTraexRollout(path, 0).events);
+    const turn = queue.drainEmittable()[0];
+    expect(turn.finalText).toBe('BOTMUX_NO_REPLY');
+    expect(isBridgeNothingToSendFinal(turn.finalText)).toBe(true);
+    expect(shouldEmitEmptyCompletedBridgeFallback(
+      {
+        markTimeMs: turn.markTimeMs,
+        isLocal: false,
+        finalText: turn.finalText,
+        terminalStatus: turn.terminalStatus,
+      },
+      undefined,
+      [],
+      false,
+    )).toBe(false);
   });
 });
 

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -3,7 +3,7 @@ import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
-import { CODEX_CONNECTION_ERROR_CODE } from '../src/services/codex-transcript.js';
+import { CODEX_CONNECTION_ERROR_CODE, CODEX_RATE_LIMIT_ERROR_CODE } from '../src/services/codex-transcript.js';
 import {
   isBridgeNothingToSendFinal,
   shouldEmitEmptyCompletedBridgeFallback,
@@ -483,6 +483,62 @@ describe('drainTraexRollout', () => {
       [],
       false,
     )).toBe(false);
+  });
+
+  it('does not synthesise a bare sentinel in adopt mode (verbatim contract)', () => {
+    // adopt posts transcript text verbatim, so a synthesised token would leak
+    // the literal sentinel into Lark. Keep the empty final; no alert fires in
+    // adopt either (shouldEmitEmptyCompletedBridgeFallback is adopt-gated).
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessage('已回报。BOTMUX_NO_REPLY', 'commentary')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0, { adoptMode: true }).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '',
+    }));
+    // Non-adopt still synthesises (existing behaviour).
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: 'BOTMUX_NO_REPLY',
+    }));
+  });
+
+  it('a probe re-drain mid-turn does not clear the production pending state', () => {
+    // traexRolloutHasUserInputSince re-drains the same live rollout; its
+    // user_message processing must not delete the commentary the production
+    // drainer is holding for the still-open turn.
+    const firstBatch = line(user('long turn'))
+      + line(agentMessage('已回报。BOTMUX_NO_REPLY', 'commentary'));
+    writeFileSync(path, firstBatch);
+    const first = drainTraexRollout(path, 0);
+    expect(first.events.map(event => event.kind)).toEqual(['user']);
+
+    // Submit-confirmation probe re-drains the same rollout.
+    expect(traexRolloutHasUserInputSince(path, 0, 'long turn')).toBe(true);
+
+    // Turn completes; the production drain must still see the cached commentary.
+    appendFileSync(path, line(taskComplete()));
+    const second = drainTraexRollout(path, first.newOffset);
+    expect(second.events).toEqual([
+      expect.objectContaining({ kind: 'assistant_final', text: 'BOTMUX_NO_REPLY' }),
+    ]);
+  });
+
+  it('maps a 429 task_complete error to the rate-limit failure code', () => {
+    writeFileSync(path, [
+      line(user('hit the limit')),
+      line(taskCompleteWithError({ message: '429 Too Many Requests' })),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toMatchObject({
+      kind: 'assistant_final',
+      text: '',
+      terminalStatus: 'failed',
+      terminalErrorCode: CODEX_RATE_LIMIT_ERROR_CODE,
+    });
   });
 });
 

--- a/test/traex-worker-bridge-wiring.test.ts
+++ b/test/traex-worker-bridge-wiring.test.ts
@@ -24,7 +24,10 @@ describe('TRAE worker structured-bridge wiring', () => {
     const body = workerSource.slice(start, end);
 
     expect(body).toContain('if (structuredBridgeIsCodex()) return drainCodexRollout(path, offset);');
-    expect(body).toContain('if (structuredBridgeIsTraex()) return drainTraexRollout(path, offset);');
+    // adoptMode is threaded into the TRAE drainer so it does not synthesise a
+    // bare sentinel in adopt mode (where transcript text is posted verbatim).
+    expect(body).toContain('if (structuredBridgeIsTraex())');
+    expect(body).toContain('drainTraexRollout(path, offset, { adoptMode:');
   });
 
   it('publishes the latest TRAE runtime on attach and incremental ingest', () => {
@@ -184,7 +187,10 @@ describe('TRAE worker structured-bridge wiring', () => {
     const end = workerSource.indexOf('\n}\n\nfunction stopCodexBridge', start);
     const body = workerSource.slice(start, end);
 
-    expect(body).toContain('shouldEmitEmptyCompletedBridgeFallback');
+    // The empty-completed fallback is still wired — now via the extracted
+    // structuredFallbackKind decision, whose 'empty_completed' branch posts
+    // emptyCompletedBridgeFallbackContent().
+    expect(body).toContain('structuredFallbackKind');
     expect(body).toContain('emptyCompletedBridgeFallbackContent()');
     expect(body).not.toContain('if (!turn.finalText) continue;');
   });

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -122,9 +122,14 @@ describe('worker structured-turn status wiring', () => {
 
   it('settles terminals after optional output and preserves the empty-completed fallback', () => {
     const emit = functionSlice('emitReadyCodexTurns', 'stopCodexBridge');
-    const emptyFallback = emit.indexOf('shouldEmitEmptyCompletedBridgeFallback');
+    // The empty-completed fallback is still wired before the output guard —
+    // now via the extracted structuredFallbackKind decision, whose
+    // 'empty_completed' branch posts emptyCompletedBridgeFallbackContent().
+    const fallbackKind = emit.indexOf('structuredFallbackKind');
+    const emptyFallback = emit.indexOf('emptyCompletedBridgeFallbackContent()', fallbackKind);
     const outputGuard = emit.indexOf('if (!content) continue;', emptyFallback);
     const terminalLoop = emit.indexOf('for (const turn of ready)', outputGuard);
+    expect(fallbackKind).toBeGreaterThanOrEqual(0);
     expect(emptyFallback).toBeGreaterThanOrEqual(0);
     expect(outputGuard).toBeGreaterThan(emptyFallback);
     expect(terminalLoop).toBeGreaterThan(outputGuard);


### PR DESCRIPTION
## 改了什么

TRAE drainer（`src/services/traex-transcript.ts`）的 `task_complete` 分支此前只读 `last_agent_message`，存在两个独立问题，本 PR 一并修复：

1. **error→failed 映射（治端点失败误报）**：`task_complete` 携带非空 `payload.error` 时，输出 `terminalStatus='failed'` + 错误码 + 脱敏摘要，走 worker 现有的 `failedBridgeFallbackContent`，用户看到真实失败原因（如 "model endpoint connection failed"），而不是误导性的「已报告完成但未捕获最终文本」告警。镜像 `codex-transcript.ts` 的现成逻辑，为此导出复用 `codexTaskFailureCode` / `safeFailureSummary`（纯导出新增，无行为变化）。

2. **commentary 末行 sentinel 识别（治静默轮误报）**：drainer 新增 `agent_message` 事件读取。终态文本为空时，若该轮最后一条 commentary 以 `BOTMUX_NOTHING_TO_SEND` / `BOTMUX_NO_REPLY` 结尾（模型已通过 `botmux send` 回复、commentary 只剩叙述的场景），合成裸 sentinel 作为 finalText，走 fallback gate 现有的 genuine-silence 抑制，不再误发告警。**仅在非 adopt 模式合成**：adopt 逐字投递 transcript 文本，合成的 token 会原样泄漏进飞书（`opts.adoptMode` 由 worker 的 `structuredBridgeIngestPath` 传入）。

3. **final_answer 相位重建（防御）**：终态为空时取该轮最后一条 `phase=final_answer` 的 `agent_message` 作为 finalText——相位字段保证不会把工具 commentary 当答案。当前真机数据里 null 终态轮都没有 final_answer，此条是防 TRAE 未来真丢 final。

4. **429 限流不再静默**：emit 内容决策抽成纯函数 `structuredFallbackKind`（`bridge-fallback-gate.ts`），「跳过通用 failed fallback」收窄到**拥有专用限流通知链的 CLI**（当前仅 Codex，其 `maybeEmitCodexStructuredRateLimit` 已处理）。TRAE 无专用链，429 回落通用 failed fallback，用户可见真实原因，不再从「误导但可见」退化成「完全无消息」。

`agent_message` 状态按 rollout 路径跨 drain 调用保留（一个轮次跨多次 poll，commentary 与 task_complete 几乎不在同一批），`user_message` 重置、`task_complete` / `turn_aborted` 消费后清除，缓存上限 512 条。只读探针 `traexRolloutHasUserInputSince` 以 `opts.probe` 调用，跳过缓存变更，避免重跑 drain 误清生产 pending 状态。

## 为什么

traecli 在模型端点失败时仍写 `task_complete`，但 `last_agent_message=null` 且真实原因放在 `payload.error` 里；drainer 忽略 error 字段，把端点失败误判成「完成但无最终文本」。真机统计：某日 14 个空终态回合中 12 个是端点失败（`error.message="model endpoint connection failed..."`），2 个是模型已 `botmux send` 回复、commentary 末条带 sentinel 的静默轮。两种情况都会触发下面这条误导性告警——端点失败时模型根本没机会执行 `botmux send`，告警却提示用户「可能改道发送过」：

> ⚠️ TRAE 已报告本轮处理完成，但 botmux 没有从终端记录里捕获到最终文本，也没有追踪到本轮的回复。若你已经通过改道发送（--top-level / --into / --override-chat）回复过，可忽略本提示；否则请打开 Web 终端查看最后输出，或直接重发消息让会话继续。
>
> （i18n key：`worker.empty_final_completed`，由 `shouldEmitEmptyCompletedBridgeFallback` 触发）

## 影响面

- **仅影响 TRAE drainer 路径**（`structuredBridgeIsTraex()` 时才走 `drainTraexRollout`）。
- `codex-transcript.ts` 仅新增两个 `export`，Codex 及其它 20+ CLI 的 drainer 行为不变。
- 共用层 `bridge-fallback-gate.ts` 新增 `structuredFallbackKind`（纯函数），`codex-bridge-queue.ts` 未改动。
- 行为变化仅限 TRAE 空终态回合：失败回合从「空完成告警」变为「真实失败原因」；静默回合从「空完成告警」变为「抑制」（非 adopt）；有 `final_answer` 相位消息的空终态回合从「告警」变为「投递重建的 final」；429 回合从「静默」变为「通用 failed fallback 可见」。非空 `last_agent_message` 的回合完全不受影响。adopt 模式不合成 sentinel，保持逐字投递契约。

## 测试验证

- `npx tsc --noEmit` 通过；`pnpm build` 通过。
- 新增单测（`test/traex-transcript.test.ts` + `test/bridge-fallback-gate.test.ts`）：error→failed 映射（含 URL 脱敏、429 映射）、error 与 last_agent_message 并存、sentinel 识别（两种 token、glued 形态）、跨 drain 调用状态保留、无 sentinel 不误判、final_answer 重建、final_answer 优先于 sentinel、user_message 重置防串轮、合成 sentinel 经 queue+gate 确认为 genuine silence、**adopt 模式不合成**、**probe 不扰缓存**、`structuredFallbackKind` 六类用例（TRAE 429→failed / Codex 429 跳过 / 非限流失败 / final / empty_completed / marker 抑制→none）。
- 七个相关测试文件（traex-transcript / codex-transcript / bridge-fallback-gate / codex-bridge-queue / traex-worker-bridge-wiring / worker-structured-lifecycle-status / bridge-final-output-retry）全绿。
- 真机 rollout 验证：对当日真实失败会话（`rollout-...01a0098a....jsonl`）drain，失败回合正确输出 `terminalStatus='failed'`、`terminalErrorCode='codex_connection_failed'`、摘要含 "model endpoint connection failed"；对真实静默会话（`rollout-...01a0087b....jsonl`）drain，null 终态轮正确合成 `BOTMUX_NO_REPLY`。
- 全量套件剩余失败均为环境问题（plugin-mcp-sandbox 的 EACCES、dsh sandbox 在 worktree 路径下、smoke/并发测试），在 base 上同样复现，与本改动无关。