### PR TITLE
fix(dashboard): re-hydrate after SSE subscribe to close hydrate→subscribe race window

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1447,26 +1447,34 @@ function runGlobalInstall(plan: GlobalInstallPlan): Promise<void> {
 
 /**
  * Attach to one daemon: hydrate its sessions/schedules into the aggregator,
- * THEN open the SSE subscription. Order matters — hydrating after subscribe
- * would let snapshot data clobber events that arrived between subscribe and
- * the snapshot fetch.
+ * THEN open the SSE subscription.
  *
- * However, hydrate-then-subscribe leaves a race window: events that fire
- * between the snapshot fetch and the SSE handshake are missed entirely. To
- * close it, a second lightweight hydration runs after the subscription is
- * established. Its snapshot is newer than the first, so it picks up every
- * missed event; any event arriving after the subscription is delivered via
- * SSE and is at least as new as the second snapshot.
+ * The subscription runs a snapshot barrier (subscribeDaemon's `onConnected`):
+ * after every stream establishment — the first included — and BEFORE any
+ * frame is read, we install a fresh authoritative snapshot while incoming
+ * frames stay queued in the stream; frames then apply on top in order. This
+ * gives two guarantees at once:
+ *
+ * 1. No reverse clobber: the barrier snapshot is installed before any frame
+ *    is applied, so a slow snapshot response can never overwrite state that
+ *    a faster SSE event already delivered (a naive post-subscribe hydrate
+ *    would).
+ * 2. No forward gap: events fired between step 1 below and the stream
+ *    handshake are picked up by the barrier snapshot, and events missed
+ *    during a drop are recovered by the barrier re-run on reconnect.
+ *
+ * The blocking hydrate in step 1 still matters: it populates the cache
+ * before the dashboard starts serving, and keeps a daemon's last-known
+ * state visible even if its SSE stream never connects.
  *
  * Idempotent: a second call for the same daemon while one is in flight is a
- * no-op; a call after attach finished re-hydrates (useful when a daemon
- * restarts and we want to refresh its slice of the cache).
+ * no-op; the subscription itself is installed once.
  */
 async function attachDaemon(d: import('./dashboard/registry.js').DaemonInfo): Promise<void> {
   if (attaching.has(d.larkAppId)) return;
   attaching.add(d.larkAppId);
   try {
-    // 1. Hydrate snapshot (blocking — completes before we wire SSE)
+    // 1. Blocking snapshot (see above)
     try {
       const [sRes, schRes] = await Promise.all([
         fetchDaemonIpc(d.ipcPort, '/api/sessions'),
@@ -1483,46 +1491,51 @@ async function attachDaemon(d: import('./dashboard/registry.js').DaemonInfo): Pr
     } catch (e: any) {
       logger.warn(`[dashboard] hydrate ${d.larkAppId}: ${e.message ?? e}`);
     }
-    // 2. Open SSE subscription if not already (idempotent)
+    // 2. Open SSE subscription if not already (idempotent). The barrier
+    //    below runs inside subscribeDaemon, after the stream is established.
     if (!subs.has(d.larkAppId)) {
       subs.set(
         d.larkAppId,
         subscribeDaemon(d, aggregator, e =>
           logger.warn(`[aggregator] ${d.larkAppId}: ${e.message}`),
           (_url, init) => fetchDaemonIpc(d.ipcPort, '/api/events', init),
-          // On SSE reconnect, re-hydrate to recover events missed while the
-          // stream was down.
-          () => { void rehydrateDaemon(d); },
+          // Snapshot barrier: install an authoritative snapshot before any
+          // frame is read. Frames arriving during this fetch stay queued in
+          // the stream and apply afterwards, so the snapshot can never
+          // clobber fresher SSE state; on reconnect it recovers missed
+          // events.
+          () => reconcileDaemon(d),
         ),
       );
     }
-    // 3. Re-hydrate to close the hydrate→subscribe race window. Events that
-    //    fired between step 1 and step 2 were not delivered over SSE; this
-    //    second snapshot is fetched *after* the subscription, so it reflects
-    //    those events. SSE events arriving after step 2 are applied on top
-    //    and are at least as fresh as this snapshot.
-    await rehydrateDaemon(d);
   } finally {
     attaching.delete(d.larkAppId);
   }
 }
 
 /**
- * Fetch the current session snapshot from one daemon and merge it into the
- * aggregator. Used both for the post-subscribe race-window close and for
- * SSE reconnect recovery.
+ * Fetch one daemon's current session/schedule snapshot and merge it into the
+ * aggregator. Runs as the subscribeDaemon barrier — before SSE frames are
+ * read — on both initial attach and reconnect. Bounded by a timeout so a hung
+ * daemon can't stall frame application indefinitely; on failure the live
+ * stream remains the source of truth (best-effort).
  */
-async function rehydrateDaemon(d: import('./dashboard/registry.js').DaemonInfo): Promise<void> {
+async function reconcileDaemon(d: import('./dashboard/registry.js').DaemonInfo): Promise<void> {
   try {
-    const sRes = await fetchDaemonIpc(d.ipcPort, '/api/sessions');
+    const [sRes, schRes] = await Promise.all([
+      fetchDaemonIpc(d.ipcPort, '/api/sessions', { signal: AbortSignal.timeout(10_000) }),
+      fetchDaemonIpc(d.ipcPort, '/api/schedules', { signal: AbortSignal.timeout(10_000) }),
+    ]);
     const s = await sRes.json() as { sessions: any[] };
+    const sch = await schRes.json() as { schedules: any[] };
     const rows = (s.sessions ?? []).map((row) => (
       d.botAvatarUrl ? { ...row, botAvatarUrl: d.botAvatarUrl } : row
     ));
     aggregator.hydrateSessions(d.larkAppId, rows);
     for (const row of rows) sessionPresentation.schedule(d.larkAppId, row);
+    aggregator.hydrateSchedules(sch.schedules ?? []);
   } catch (e: any) {
-    logger.warn(`[dashboard] re-hydrate ${d.larkAppId}: ${e.message ?? e}`);
+    logger.warn(`[dashboard] reconcile ${d.larkAppId}: ${e.message ?? e}`);
   }
 }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -21,6 +21,7 @@ import {
 } from './dashboard/auth.js';
 import { DaemonRegistry, botsRosterSignature } from './dashboard/registry.js';
 import { Aggregator, subscribeDaemon } from './dashboard/aggregator.js';
+import { reconcileDaemonSnapshot } from './dashboard/daemon-reconcile.js';
 import { createSessionPresentationCoordinator } from './dashboard/session-presentation.js';
 import {
   compactGroupsMatrix,
@@ -1487,7 +1488,7 @@ async function attachDaemon(d: import('./dashboard/registry.js').DaemonInfo): Pr
       ));
       aggregator.hydrateSessions(d.larkAppId, rows);
       for (const row of rows) sessionPresentation.schedule(d.larkAppId, row);
-      aggregator.hydrateSchedules(sch.schedules ?? []);
+      aggregator.hydrateSchedules(d.larkAppId, sch.schedules ?? []);
     } catch (e: any) {
       logger.warn(`[dashboard] hydrate ${d.larkAppId}: ${e.message ?? e}`);
     }
@@ -1503,8 +1504,10 @@ async function attachDaemon(d: import('./dashboard/registry.js').DaemonInfo): Pr
           // frame is read. Frames arriving during this fetch stay queued in
           // the stream and apply afterwards, so the snapshot can never
           // clobber fresher SSE state; on reconnect it recovers missed
-          // events.
-          () => reconcileDaemon(d),
+          // events. The subscription signal is the generation arbitration:
+          // if aborted mid-flight (daemon offline, newer generation), the
+          // snapshot is discarded instead of clobbering the new generation.
+          signal => reconcileDaemon(d, signal),
         ),
       );
     }
@@ -1514,28 +1517,18 @@ async function attachDaemon(d: import('./dashboard/registry.js').DaemonInfo): Pr
 }
 
 /**
- * Fetch one daemon's current session/schedule snapshot and merge it into the
- * aggregator. Runs as the subscribeDaemon barrier — before SSE frames are
- * read — on both initial attach and reconnect. Bounded by a timeout so a hung
- * daemon can't stall frame application indefinitely; on failure the live
- * stream remains the source of truth (best-effort).
+ * Reconcile one daemon's snapshot into the aggregator (subscribeDaemon
+ * barrier). Thin wrapper over reconcileDaemonSnapshot that also schedules
+ * presentation enrichment for the session rows.
  */
-async function reconcileDaemon(d: import('./dashboard/registry.js').DaemonInfo): Promise<void> {
-  try {
-    const [sRes, schRes] = await Promise.all([
-      fetchDaemonIpc(d.ipcPort, '/api/sessions', { signal: AbortSignal.timeout(10_000) }),
-      fetchDaemonIpc(d.ipcPort, '/api/schedules', { signal: AbortSignal.timeout(10_000) }),
-    ]);
-    const s = await sRes.json() as { sessions: any[] };
-    const sch = await schRes.json() as { schedules: any[] };
-    const rows = (s.sessions ?? []).map((row) => (
-      d.botAvatarUrl ? { ...row, botAvatarUrl: d.botAvatarUrl } : row
-    ));
-    aggregator.hydrateSessions(d.larkAppId, rows);
-    for (const row of rows) sessionPresentation.schedule(d.larkAppId, row);
-    aggregator.hydrateSchedules(sch.schedules ?? []);
-  } catch (e: any) {
-    logger.warn(`[dashboard] reconcile ${d.larkAppId}: ${e.message ?? e}`);
+async function reconcileDaemon(
+  d: import('./dashboard/registry.js').DaemonInfo,
+  signal: AbortSignal,
+): Promise<void> {
+  const snapshot = await reconcileDaemonSnapshot(d, aggregator, signal);
+  if (!snapshot) return;
+  for (const row of snapshot.sessions) {
+    sessionPresentation.schedule(d.larkAppId, row);
   }
 }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1451,6 +1451,13 @@ function runGlobalInstall(plan: GlobalInstallPlan): Promise<void> {
  * would let snapshot data clobber events that arrived between subscribe and
  * the snapshot fetch.
  *
+ * However, hydrate-then-subscribe leaves a race window: events that fire
+ * between the snapshot fetch and the SSE handshake are missed entirely. To
+ * close it, a second lightweight hydration runs after the subscription is
+ * established. Its snapshot is newer than the first, so it picks up every
+ * missed event; any event arriving after the subscription is delivered via
+ * SSE and is at least as new as the second snapshot.
+ *
  * Idempotent: a second call for the same daemon while one is in flight is a
  * no-op; a call after attach finished re-hydrates (useful when a daemon
  * restarts and we want to refresh its slice of the cache).
@@ -1483,11 +1490,39 @@ async function attachDaemon(d: import('./dashboard/registry.js').DaemonInfo): Pr
         subscribeDaemon(d, aggregator, e =>
           logger.warn(`[aggregator] ${d.larkAppId}: ${e.message}`),
           (_url, init) => fetchDaemonIpc(d.ipcPort, '/api/events', init),
+          // On SSE reconnect, re-hydrate to recover events missed while the
+          // stream was down.
+          () => { void rehydrateDaemon(d); },
         ),
       );
     }
+    // 3. Re-hydrate to close the hydrate→subscribe race window. Events that
+    //    fired between step 1 and step 2 were not delivered over SSE; this
+    //    second snapshot is fetched *after* the subscription, so it reflects
+    //    those events. SSE events arriving after step 2 are applied on top
+    //    and are at least as fresh as this snapshot.
+    await rehydrateDaemon(d);
   } finally {
     attaching.delete(d.larkAppId);
+  }
+}
+
+/**
+ * Fetch the current session snapshot from one daemon and merge it into the
+ * aggregator. Used both for the post-subscribe race-window close and for
+ * SSE reconnect recovery.
+ */
+async function rehydrateDaemon(d: import('./dashboard/registry.js').DaemonInfo): Promise<void> {
+  try {
+    const sRes = await fetchDaemonIpc(d.ipcPort, '/api/sessions');
+    const s = await sRes.json() as { sessions: any[] };
+    const rows = (s.sessions ?? []).map((row) => (
+      d.botAvatarUrl ? { ...row, botAvatarUrl: d.botAvatarUrl } : row
+    ));
+    aggregator.hydrateSessions(d.larkAppId, rows);
+    for (const row of rows) sessionPresentation.schedule(d.larkAppId, row);
+  } catch (e: any) {
+    logger.warn(`[dashboard] re-hydrate ${d.larkAppId}: ${e.message ?? e}`);
   }
 }
 

--- a/src/dashboard/aggregator.ts
+++ b/src/dashboard/aggregator.ts
@@ -60,9 +60,16 @@ export class Aggregator {
         if (cur) this.sessions.set(ev.body.sessionId, { ...cur, status: 'closed' });
         break;
       }
-      case 'schedule.created':
-        this.schedules.set((ev.body.schedule as Sched).id, ev.body.schedule as Sched);
+      case 'schedule.created': {
+        const schedule = ev.body.schedule as Sched & { larkAppId?: string };
+        // Tag ownerless rows with the reporting daemon so scoped reconcile
+        // (hydrateSchedules) can account for them.
+        this.schedules.set(schedule.id, {
+          ...schedule,
+          larkAppId: schedule.larkAppId ?? larkAppId,
+        });
         break;
+      }
       case 'schedule.updated': {
         const cur = this.schedules.get(ev.body.id);
         if (cur) this.schedules.set(ev.body.id, { ...cur, ...ev.body.patch });
@@ -84,8 +91,24 @@ export class Aggregator {
       this.sessions.set(r.sessionId, mergeSpawnedRow(this.sessions.get(r.sessionId), r, larkAppId));
     }
   }
-  hydrateSchedules(rows: Sched[]): void {
-    for (const r of rows) this.schedules.set(r.id, r);
+  /**
+   * Per-daemon reconcile for schedules. Upserts `rows` and REMOVES schedules
+   * owned by `larkAppId` that are absent from the snapshot: a
+   * `schedule.deleted` missed while the SSE stream was down would otherwise
+   * ghost forever, since upsert alone can't delete. Schedules owned by other
+   * daemons (and ownerless rows) are untouched. Rows missing `larkAppId`
+   * are tagged with the hydrating daemon, which is authoritative for them
+   * (they came from its /api/schedules).
+   */
+  hydrateSchedules(larkAppId: string, rows: Sched[]): void {
+    const incoming = new Set(rows.map(r => r.id));
+    for (const r of rows) {
+      const owner = (r as { larkAppId?: string }).larkAppId ?? larkAppId;
+      this.schedules.set(r.id, { ...r, larkAppId: owner });
+    }
+    for (const [id, cur] of this.schedules) {
+      if (cur.larkAppId === larkAppId && !incoming.has(id)) this.schedules.delete(id);
+    }
   }
 
   getSessions(): Row[] { return [...this.sessions.values()]; }
@@ -138,22 +161,31 @@ export class Aggregator {
  * function.
  *
  * `onConnected` fires after EVERY successful stream establishment — the first
- * connection included — BEFORE any frame is read. While it runs, incoming
- * frames stay queued in the stream; once it resolves, reading begins and the
- * queued frames are applied in order. The caller uses it to install an
- * authoritative snapshot (GET /api/sessions) that is therefore at least as
- * fresh as every frame applied afterwards: a slow snapshot response can
- * never clobber state that a faster SSE event already delivered (the reverse
- * race of a naive post-subscribe hydrate). The same barrier on reconnect
- * recovers events missed while the stream was down. If `onConnected` throws,
- * frames are still read (best-effort).
+ * connection included — BEFORE any frame is read, and receives the
+ * subscription's abort signal. While it runs, incoming frames stay queued in
+ * the stream; once it resolves, reading begins and the queued frames are
+ * applied in order. The caller uses it to install an authoritative snapshot
+ * (GET /api/sessions) that is therefore at least as fresh as every frame
+ * applied afterwards: a slow snapshot response can never clobber state that
+ * a faster SSE event already delivered (the reverse race of a naive
+ * post-subscribe hydrate). The same barrier on reconnect recovers events
+ * missed while the stream was down.
+ *
+ * The signal is also the generation arbitration: if this subscription is
+ * aborted (daemon offline, superseded by a newer generation) while the
+ * callback is in flight, the callback MUST discard its result instead of
+ * applying it — otherwise the stale generation's snapshot reverse-clobbers
+ * the newer one. The callback should fetch with
+ * `AbortSignal.any([signal, timeout])` and re-check `signal.aborted` before
+ * every aggregator mutation. If `onConnected` throws, frames are still read
+ * (best-effort).
  */
 export function subscribeDaemon(
   d: DaemonInfo,
   agg: Aggregator,
   onError: (e: Error) => void,
   fetchImpl: typeof fetch = fetch,
-  onConnected?: () => Promise<void> | void,
+  onConnected?: (signal: AbortSignal) => Promise<void> | void,
 ): () => void {
   const ctrl = new AbortController();
   const url = `http://127.0.0.1:${d.ipcPort}/api/events`;
@@ -183,9 +215,11 @@ export function subscribeDaemon(
         // before any frame is applied. Frames arriving during this call
         // remain queued in the stream and are applied afterwards, in order,
         // so the snapshot can never overwrite fresher SSE-delivered state.
+        // The subscription signal is passed through as the generation
+        // arbitration — the callback must not apply after abort.
         if (onConnected) {
           try {
-            await onConnected();
+            await onConnected(ctrl.signal);
           } catch (e) {
             onError(e instanceof Error ? e : new Error(String(e)));
           }

--- a/src/dashboard/aggregator.ts
+++ b/src/dashboard/aggregator.ts
@@ -134,21 +134,29 @@ export class Aggregator {
 
 /**
  * Subscribe to one daemon's SSE stream and feed events into the aggregator.
- * Auto-reconnects on error with 1s backoff. Returns an abort function.
+ * Auto-reconnects on error OR clean EOF with 1s backoff. Returns an abort
+ * function.
  *
- * `onReconnect` fires after the stream is re-established following a drop,
- * so the caller can re-hydrate and recover events missed while disconnected.
+ * `onConnected` fires after EVERY successful stream establishment — the first
+ * connection included — BEFORE any frame is read. While it runs, incoming
+ * frames stay queued in the stream; once it resolves, reading begins and the
+ * queued frames are applied in order. The caller uses it to install an
+ * authoritative snapshot (GET /api/sessions) that is therefore at least as
+ * fresh as every frame applied afterwards: a slow snapshot response can
+ * never clobber state that a faster SSE event already delivered (the reverse
+ * race of a naive post-subscribe hydrate). The same barrier on reconnect
+ * recovers events missed while the stream was down. If `onConnected` throws,
+ * frames are still read (best-effort).
  */
 export function subscribeDaemon(
   d: DaemonInfo,
   agg: Aggregator,
   onError: (e: Error) => void,
   fetchImpl: typeof fetch = fetch,
-  onReconnect?: () => void,
+  onConnected?: () => Promise<void> | void,
 ): () => void {
   const ctrl = new AbortController();
   const url = `http://127.0.0.1:${d.ipcPort}/api/events`;
-  let hadFailure = false;
   let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 
   // Clear the reconnect backoff immediately on abort so the loop exits
@@ -157,22 +165,45 @@ export function subscribeDaemon(
     if (reconnectTimer) clearTimeout(reconnectTimer);
   }, { once: true });
 
+  const applyFrame = (evt: string, body: unknown): void => {
+    if (evt === 'session.spawned' && d.botAvatarUrl && (body as { session?: unknown })?.session) {
+      const session = (body as { session: Record<string, unknown> }).session;
+      (body as { session: unknown }).session = { ...session, botAvatarUrl: d.botAvatarUrl };
+    }
+    agg.applyEvent(d.larkAppId, { type: evt, body } as any);
+  };
+
   (async () => {
     while (!ctrl.signal.aborted) {
       try {
         const res = await fetchImpl(url, { signal: ctrl.signal });
         if (!res.ok || !res.body) throw new Error(`bad status ${res.status}`);
-        if (hadFailure) {
-          hadFailure = false;
-          onReconnect?.();
+
+        // Snapshot barrier: install the caller's authoritative snapshot
+        // before any frame is applied. Frames arriving during this call
+        // remain queued in the stream and are applied afterwards, in order,
+        // so the snapshot can never overwrite fresher SSE-delivered state.
+        if (onConnected) {
+          try {
+            await onConnected();
+          } catch (e) {
+            onError(e instanceof Error ? e : new Error(String(e)));
+          }
         }
+        if (ctrl.signal.aborted) break;
+
         const reader = res.body.getReader();
         const dec = new TextDecoder();
         let buf = '';
         let evt = '';
         for (;;) {
           const { value, done } = await reader.read();
-          if (done) break;
+          if (done) {
+            // Clean EOF of an established stream means the daemon went away.
+            // Treat it as a disconnect: fall through to the backoff +
+            // barrier re-run path instead of silently tight-looping.
+            throw new Error('sse stream ended (clean EOF)');
+          }
           buf += dec.decode(value, { stream: true });
           let nl: number;
           while ((nl = buf.indexOf('\n')) >= 0) {
@@ -182,11 +213,7 @@ export function subscribeDaemon(
             else if (line.startsWith('data:') && evt) {
               const data = line.slice(5).trim();
               try {
-                const body = JSON.parse(data);
-                if (evt === 'session.spawned' && d.botAvatarUrl && body?.session) {
-                  body.session = { ...body.session, botAvatarUrl: d.botAvatarUrl };
-                }
-                agg.applyEvent(d.larkAppId, { type: evt, body } as any);
+                applyFrame(evt, JSON.parse(data));
               } catch {
                 // Skip malformed frame
               }
@@ -195,10 +222,8 @@ export function subscribeDaemon(
           }
         }
       } catch (e) {
-        if (!ctrl.signal.aborted) {
-          onError(e as Error);
-          hadFailure = true;
-        }
+        if (ctrl.signal.aborted) break;
+        onError(e as Error);
         await new Promise(r => { reconnectTimer = setTimeout(r, 1_000); });
         reconnectTimer = undefined;
       }

--- a/src/dashboard/aggregator.ts
+++ b/src/dashboard/aggregator.ts
@@ -135,21 +135,37 @@ export class Aggregator {
 /**
  * Subscribe to one daemon's SSE stream and feed events into the aggregator.
  * Auto-reconnects on error with 1s backoff. Returns an abort function.
+ *
+ * `onReconnect` fires after the stream is re-established following a drop,
+ * so the caller can re-hydrate and recover events missed while disconnected.
  */
 export function subscribeDaemon(
   d: DaemonInfo,
   agg: Aggregator,
   onError: (e: Error) => void,
   fetchImpl: typeof fetch = fetch,
+  onReconnect?: () => void,
 ): () => void {
   const ctrl = new AbortController();
   const url = `http://127.0.0.1:${d.ipcPort}/api/events`;
+  let hadFailure = false;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Clear the reconnect backoff immediately on abort so the loop exits
+  // without waiting the full second.
+  ctrl.signal.addEventListener('abort', () => {
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+  }, { once: true });
 
   (async () => {
     while (!ctrl.signal.aborted) {
       try {
         const res = await fetchImpl(url, { signal: ctrl.signal });
         if (!res.ok || !res.body) throw new Error(`bad status ${res.status}`);
+        if (hadFailure) {
+          hadFailure = false;
+          onReconnect?.();
+        }
         const reader = res.body.getReader();
         const dec = new TextDecoder();
         let buf = '';
@@ -179,8 +195,12 @@ export function subscribeDaemon(
           }
         }
       } catch (e) {
-        if (!ctrl.signal.aborted) onError(e as Error);
-        await new Promise(r => setTimeout(r, 1_000));
+        if (!ctrl.signal.aborted) {
+          onError(e as Error);
+          hadFailure = true;
+        }
+        await new Promise(r => { reconnectTimer = setTimeout(r, 1_000); });
+        reconnectTimer = undefined;
       }
     }
   })();

--- a/src/dashboard/daemon-reconcile.ts
+++ b/src/dashboard/daemon-reconcile.ts
@@ -1,0 +1,60 @@
+// src/dashboard/daemon-reconcile.ts
+import type { DaemonInfo } from './registry.js';
+import type { Aggregator } from './aggregator.js';
+import { fetchDaemonIpc } from '../core/daemon-ipc-auth.js';
+import { logger } from '../utils/logger.js';
+
+export type DaemonSnapshot = { sessions: any[]; schedules: any[] };
+export type SnapshotFetcher = (port: number, signal: AbortSignal) => Promise<DaemonSnapshot>;
+
+const defaultFetchSnapshot: SnapshotFetcher = async (port, signal) => {
+  const [sRes, schRes] = await Promise.all([
+    fetchDaemonIpc(port, '/api/sessions', { signal }),
+    fetchDaemonIpc(port, '/api/schedules', { signal }),
+  ]);
+  const s = await sRes.json() as { sessions: any[] };
+  const sch = await schRes.json() as { schedules: any[] };
+  return { sessions: s.sessions ?? [], schedules: sch.schedules ?? [] };
+};
+
+/**
+ * Install one daemon's authoritative snapshot into the aggregator. Runs as
+ * the subscribeDaemon barrier — BEFORE any SSE frame is read — on both
+ * initial attach and reconnect, so the snapshot can never clobber fresher
+ * SSE-delivered state.
+ *
+ * Epoch arbitration: `signal` is the subscription's abort signal. If this
+ * subscription was aborted (daemon offline, superseded by a newer
+ * generation) while the fetches were in flight, the result is discarded
+ * entirely — applying it would reverse-clobber the newer generation's
+ * state. The aggregator's hydrate paths have no version arbitration, so the
+ * subscription generation (this signal) is the arbitration: abort ⟺ this
+ * generation is no longer authoritative for the daemon. The check-then-
+ * mutate sequence below has no await in between, so no abort can interleave.
+ *
+ * Best-effort: on failure the live SSE stream remains the source of truth.
+ */
+export async function reconcileDaemonSnapshot(
+  d: DaemonInfo,
+  agg: Aggregator,
+  signal: AbortSignal,
+  fetchSnapshot: SnapshotFetcher = defaultFetchSnapshot,
+): Promise<DaemonSnapshot | undefined> {
+  try {
+    const snapshot = await fetchSnapshot(
+      d.ipcPort,
+      AbortSignal.any([signal, AbortSignal.timeout(10_000)]),
+    );
+    if (signal.aborted) return undefined;
+    const rows = snapshot.sessions.map((row: any) => (
+      d.botAvatarUrl ? { ...row, botAvatarUrl: d.botAvatarUrl } : row
+    ));
+    agg.hydrateSessions(d.larkAppId, rows);
+    agg.hydrateSchedules(d.larkAppId, snapshot.schedules);
+    return snapshot;
+  } catch (e: any) {
+    if (signal.aborted) return undefined;
+    logger.warn(`[dashboard] reconcile ${d.larkAppId}: ${e?.message ?? e}`);
+    return undefined;
+  }
+}

--- a/test/dashboard-aggregator.test.ts
+++ b/test/dashboard-aggregator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Aggregator } from '../src/dashboard/aggregator.js';
+import { Aggregator, subscribeDaemon } from '../src/dashboard/aggregator.js';
 
 describe('Aggregator cache merge', () => {
   it('upsert via session.spawned and session.update', () => {
@@ -127,5 +127,56 @@ describe('Aggregator cache merge', () => {
     expect(seen).toHaveLength(1);
     expect(seen[0].larkAppId).toBe('appB');
     expect(seen[0].type).toBe('session.spawned');
+  });
+});
+
+describe('subscribeDaemon reconnect', () => {
+  const daemon = { larkAppId: 'appA', ipcPort: 19999, botName: 'A' } as any;
+
+  /** A never-ending SSE stream (prevents tight reconnect loops in tests). */
+  function neverEndingSSE(): Response {
+    const stream = new ReadableStream({
+      start(controller) {
+        // Enqueue one event then hold the stream open forever.
+        controller.enqueue(new TextEncoder().encode('event: ping\ndata: {}\n\n'));
+        // Never close — the abort will release the reader.
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  }
+
+  it('does not fire onReconnect on the first successful connection', async () => {
+    let reconnects = 0;
+    const abort = subscribeDaemon(
+      daemon, new Aggregator(),
+      () => {},
+      () => Promise.resolve(neverEndingSSE()),
+      () => { reconnects++; },
+    );
+    await new Promise(r => setTimeout(r, 100));
+    abort();
+    expect(reconnects).toBe(0);
+  });
+
+  it('fires onReconnect after a fetch failure and successful retry', async () => {
+    let reconnects = 0;
+    let call = 0;
+    const abort = subscribeDaemon(
+      daemon, new Aggregator(),
+      () => {},
+      () => {
+        call++;
+        if (call === 1) return Promise.reject(new Error('connection refused'));
+        return Promise.resolve(neverEndingSSE());
+      },
+      () => { reconnects++; },
+    );
+    // Wait for: initial fail → 1s backoff → reconnect → onReconnect
+    await new Promise(r => setTimeout(r, 1_500));
+    abort();
+    expect(reconnects).toBe(1);
   });
 });

--- a/test/dashboard-aggregator.test.ts
+++ b/test/dashboard-aggregator.test.ts
@@ -130,7 +130,7 @@ describe('Aggregator cache merge', () => {
   });
 });
 
-describe('subscribeDaemon reconnect', () => {
+describe('subscribeDaemon barrier & reconnect', () => {
   const daemon = { larkAppId: 'appA', ipcPort: 19999, botName: 'A' } as any;
 
   /** A never-ending SSE stream (prevents tight reconnect loops in tests). */
@@ -148,21 +148,95 @@ describe('subscribeDaemon reconnect', () => {
     });
   }
 
-  it('does not fire onReconnect on the first successful connection', async () => {
-    let reconnects = 0;
+  /** An SSE stream that enqueues `frames` once, then ends with a clean EOF. */
+  function eofSSE(frames: string[]): Response {
+    const enc = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const f of frames) controller.enqueue(enc.encode(f));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  }
+
+  it('runs the barrier on the first connection before any frame is applied', async () => {
+    const agg = new Aggregator();
+    let barrierResolved = false;
     const abort = subscribeDaemon(
-      daemon, new Aggregator(),
+      daemon, agg,
       () => {},
-      () => Promise.resolve(neverEndingSSE()),
-      () => { reconnects++; },
+      () => Promise.resolve(eofSSE([
+        'event: session.spawned\ndata: {"session":{"sessionId":"s1","status":"idle"}}\n\n',
+      ])),
+      async () => {
+        await new Promise(r => setTimeout(r, 100));
+        barrierResolved = true;
+      },
+    );
+    // The frame is queued in the stream while the barrier runs; not applied yet.
+    await new Promise(r => setTimeout(r, 50));
+    expect(barrierResolved).toBe(false);
+    expect(agg.getSessions()).toHaveLength(0);
+    // After the barrier resolves, the queued frame is applied.
+    await new Promise(r => setTimeout(r, 100));
+    expect(barrierResolved).toBe(true);
+    expect(agg.getSessions()).toHaveLength(1);
+    expect(agg.getSession('s1')?.status).toBe('idle');
+    abort();
+  });
+
+  it('a slow barrier snapshot cannot clobber a queued SSE frame', async () => {
+    // Repro of the reverse race: an event delivered over SSE at ~50ms used to
+    // be overwritten by a slow snapshot response finishing at ~144ms. With the
+    // barrier, the snapshot is installed BEFORE any frame is read, so the
+    // queued frame always applies on top and wins.
+    const agg = new Aggregator();
+    const abort = subscribeDaemon(
+      daemon, agg,
+      () => {},
+      () => Promise.resolve(eofSSE([
+        'event: session.exited\ndata: {"sessionId":"s1"}\n\n',
+      ])),
+      async () => {
+        await new Promise(r => setTimeout(r, 150));
+        agg.hydrateSessions('appA', [{ sessionId: 's1', larkAppId: 'appA', status: 'idle' } as any]);
+      },
+    );
+    await new Promise(r => setTimeout(r, 300));
+    expect(agg.getSession('s1')?.status).toBe('closed');
+    abort();
+  });
+
+  it('keeps reading frames when the barrier throws', async () => {
+    const agg = new Aggregator();
+    const errors: Error[] = [];
+    const abort = subscribeDaemon(
+      daemon, agg,
+      e => errors.push(e),
+      () => Promise.resolve(new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(
+            'event: session.spawned\ndata: {"session":{"sessionId":"s1"}}\n\n',
+          ));
+          // Hold open so the only error observed is the barrier's.
+        },
+      }), { status: 200, headers: { 'content-type': 'text/event-stream' } })),
+      async () => { throw new Error('snapshot fetch failed'); },
     );
     await new Promise(r => setTimeout(r, 100));
     abort();
-    expect(reconnects).toBe(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe('snapshot fetch failed');
+    // The live stream still populated the aggregator (best-effort).
+    expect(agg.getSessions()).toHaveLength(1);
   });
 
-  it('fires onReconnect after a fetch failure and successful retry', async () => {
-    let reconnects = 0;
+  it('skips the barrier on a failed fetch and runs it on the successful retry', async () => {
+    let barriers = 0;
     let call = 0;
     const abort = subscribeDaemon(
       daemon, new Aggregator(),
@@ -172,11 +246,36 @@ describe('subscribeDaemon reconnect', () => {
         if (call === 1) return Promise.reject(new Error('connection refused'));
         return Promise.resolve(neverEndingSSE());
       },
-      () => { reconnects++; },
+      () => { barriers++; },
     );
-    // Wait for: initial fail → 1s backoff → reconnect → onReconnect
+    // Wait for: initial fail → 1s backoff → reconnect → barrier
     await new Promise(r => setTimeout(r, 1_500));
     abort();
-    expect(reconnects).toBe(1);
+    expect(barriers).toBe(1);
+  });
+
+  it('treats clean EOF as a disconnect: backs off and re-runs the barrier', async () => {
+    const times: number[] = [];
+    let call = 0;
+    const abort = subscribeDaemon(
+      daemon, new Aggregator(),
+      () => {},
+      () => {
+        call++;
+        if (call === 1) {
+          // Established stream that ends immediately with a clean EOF.
+          return Promise.resolve(eofSSE(['event: ping\ndata: {}\n\n']));
+        }
+        return Promise.resolve(neverEndingSSE());
+      },
+      () => { times.push(Date.now()); },
+    );
+    // Wait for: first connect → clean EOF → 1s backoff → reconnect → barrier
+    await new Promise(r => setTimeout(r, 1_500));
+    abort();
+    expect(times).toHaveLength(2);
+    // The backoff actually elapsed (without it, a tight loop would run
+    // dozens of iterations in this window).
+    expect(times[1] - times[0]).toBeGreaterThanOrEqual(900);
   });
 });

--- a/test/dashboard-aggregator.test.ts
+++ b/test/dashboard-aggregator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Aggregator, subscribeDaemon } from '../src/dashboard/aggregator.js';
+import { reconcileDaemonSnapshot } from '../src/dashboard/daemon-reconcile.js';
 
 describe('Aggregator cache merge', () => {
   it('upsert via session.spawned and session.update', () => {
@@ -45,9 +46,35 @@ describe('Aggregator cache merge', () => {
   it('hydrate seeds the cache', () => {
     const a = new Aggregator();
     a.hydrateSessions('appA', [{ sessionId: 's1', larkAppId: 'appA' } as any]);
-    a.hydrateSchedules([{ id: 't1' } as any]);
+    a.hydrateSchedules('appA', [{ id: 't1' } as any]);
     expect(a.getSessions().length).toBe(1);
     expect(a.getSchedules().length).toBe(1);
+  });
+
+  it('hydrateSchedules removes schedules absent from the daemon snapshot (ghost cleanup)', () => {
+    // A schedule.deleted missed while the SSE stream was down must not ghost:
+    // the reconnect snapshot lacks it, and upsert alone can't delete.
+    const a = new Aggregator();
+    a.hydrateSchedules('appA', [
+      { id: 't1', larkAppId: 'appA' },
+      { id: 't2', larkAppId: 'appA' },
+    ] as any);
+    a.hydrateSchedules('appA', [{ id: 't2', larkAppId: 'appA' }] as any);
+    expect(a.getSchedules().map(s => s.id)).toEqual(['t2']);
+  });
+
+  it('hydrateSchedules scopes deletions to the daemon (other daemons untouched)', () => {
+    const a = new Aggregator();
+    a.hydrateSchedules('appA', [{ id: 't1', larkAppId: 'appA' }] as any);
+    a.hydrateSchedules('appB', [{ id: 't2', larkAppId: 'appB' }] as any);
+    a.hydrateSchedules('appA', []);
+    expect(a.getSchedules().map(s => s.id)).toEqual(['t2']);
+  });
+
+  it('hydrateSchedules tags ownerless rows with the hydrating daemon', () => {
+    const a = new Aggregator();
+    a.hydrateSchedules('appA', [{ id: 't1' }] as any);
+    expect(a.scheduleOwnerOf('t1')).toBe('appA');
   });
 
   it('preserves presentation fields when a daemon replays the same working directory', () => {
@@ -277,5 +304,80 @@ describe('subscribeDaemon barrier & reconnect', () => {
     // The backoff actually elapsed (without it, a tight loop would run
     // dozens of iterations in this window).
     expect(times[1] - times[0]).toBeGreaterThanOrEqual(900);
+  });
+
+  it('passes the subscription signal to onConnected and aborts it on abort', async () => {
+    let received: AbortSignal | undefined;
+    const abort = subscribeDaemon(
+      daemon, new Aggregator(),
+      () => {},
+      () => Promise.resolve(neverEndingSSE()),
+      signal => {
+        received = signal;
+        // Resolve on abort so the loop exits cleanly instead of dangling.
+        return new Promise<void>(resolve => {
+          if (signal.aborted) resolve();
+          else signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      },
+    );
+    await new Promise(r => setTimeout(r, 50));
+    expect(received).toBeInstanceOf(AbortSignal);
+    expect(received!.aborted).toBe(false);
+    abort();
+    expect(received!.aborted).toBe(true);
+  });
+
+  it('discards a stale generation barrier after abort (no cross-generation clobber)', async () => {
+    // Repro of the v3 blocking issue:
+    //   t=56ms  gen A subscription aborted (daemon offline), A's barrier
+    //           fetch still in flight on the independent timeout signal
+    //   t=117ms gen B (same larkAppId, daemon restarted) barrier installs
+    //           authoritative s1=closed
+    //   t=316ms A's stale barrier resolves and must NOT clobber s1 back to
+    //           active
+    const agg = new Aggregator();
+
+    // Gen A: slow barrier whose response arrives/parses DESPITE the abort —
+    // the narrow window (response already in flight) that the post-fetch
+    // signal check must close.
+    let genASignal: AbortSignal | undefined;
+    const abortA = subscribeDaemon(
+      daemon, agg,
+      () => {},
+      () => Promise.resolve(neverEndingSSE()),
+      signal => {
+        genASignal = signal;
+        return reconcileDaemonSnapshot(daemon, agg, signal, async (_port, sig) => {
+          await new Promise(r => setTimeout(r, 300));
+          // The combined signal (subscription | timeout) is aborted by now.
+          expect(sig.aborted).toBe(true);
+          return {
+            sessions: [{ sessionId: 's1', larkAppId: 'appA', status: 'active' }],
+            schedules: [],
+          };
+        });
+      },
+    );
+    await new Promise(r => setTimeout(r, 50));
+    expect(genASignal).toBeInstanceOf(AbortSignal);
+    // Daemon goes offline mid-barrier.
+    abortA();
+
+    // Gen B: daemon restarted, barrier quickly installs the new truth.
+    const abortB = subscribeDaemon(
+      daemon, agg,
+      () => {},
+      () => Promise.resolve(neverEndingSSE()),
+      signal => reconcileDaemonSnapshot(daemon, agg, signal, async () => ({
+        sessions: [{ sessionId: 's1', larkAppId: 'appA', status: 'closed' }],
+        schedules: [],
+      })),
+    );
+    // Wait for gen B's barrier AND gen A's stale fetch to resolve.
+    await new Promise(r => setTimeout(r, 400));
+    abortB();
+    // Gen A's stale active row was discarded by the epoch guard.
+    expect(agg.getSession('s1')?.status).toBe('closed');
   });
 });


### PR DESCRIPTION
## Problem

The dashboard's `attachDaemon()` hydrates session snapshots BEFORE opening the SSE subscription. Events that fire between the snapshot fetch and the SSE handshake are missed entirely, leaving the aggregator with stale status.

**Real incident**: dashboard and Friday's daemon started in the same second (04:00:19). The daemon closed a session during restore 4s later (04:00:23), but the dashboard's SSE subscription wasn't established yet — the `session.exited` event was lost. The session showed as "dormant" in the dashboard for 11 days despite being `closed` on disk and in the daemon.

## Fix

1. **Post-subscribe re-hydration** (`attachDaemon` step 3): after SSE subscription is established, fetch a second snapshot. This snapshot is newer than the first, so it picks up every event missed in the race window. SSE events arriving after the subscription are applied on top and are at least as fresh.

2. **SSE reconnect recovery** (`subscribeDaemon`): new optional `onReconnect` callback fires after the stream re-establishes following a drop. The dashboard uses it to re-hydrate, recovering events missed while disconnected.

3. **Responsive abort**: abort now clears the reconnect backoff timer immediately instead of waiting the full second.

## Test plan

- [x] `dashboard-aggregator.test.ts` — 10 tests pass (8 existing + 2 new for reconnect)
- [x] `tsc --noEmit` clean
- [ ] Manual: restart dashboard alongside a daemon that closes a session during restore → session should show as "closed" not "dormant"