### PR TITLE
fix(web): web 终端种子恢复 pane 输入模式，修复 grok 等鼠标模式 TUI 的点击交互

### DIFF
--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -83,6 +83,57 @@ export function composeSeedBody(
   return body + `\x1b[${cursor.y + 1};${cursor.x + 1}H`;
 }
 
+/** Pane input modes tmux tracks per pane but capture-pane cannot express.
+ *  A capture-pane seed carries screen cells only — the DECSET state that tells
+ *  the receiving xterm to REPORT mouse events (or use app cursor keys) is
+ *  gone, so a mouse-mode TUI (grok build: 1003+1006) never hears clicks from
+ *  a freshly-connected web client. */
+export interface PaneInputModes {
+  mouseStandard: boolean; // DECSET 1000 — press/release reporting
+  mouseButton: boolean;   // DECSET 1002 — 1000 + drag motion
+  mouseAll: boolean;      // DECSET 1003 — 1002 + any motion
+  mouseSgr: boolean;      // DECSET 1006 — SGR extended encoding
+  appCursorKeys: boolean; // DECSET 1 (DECCKM) — \x1bOA-style arrows
+  appKeypad: boolean;     // DECKPAM
+  cursorVisible: boolean; // DECTCEM — emit hide only (xterm default is visible)
+}
+
+/** Render {@link PaneInputModes} as the escape sequence that re-asserts them on
+ *  a fresh xterm. Appended AFTER the seed body: DECSET never moves the cursor,
+ *  so composeSeedBody's cursor restore stays intact. Exported for tests. */
+export function paneInputModeSeed(m: PaneInputModes): string {
+  let seq = '';
+  if (m.mouseStandard) seq += '\x1b[?1000h';
+  if (m.mouseButton) seq += '\x1b[?1002h';
+  if (m.mouseAll) seq += '\x1b[?1003h';
+  if (m.mouseSgr) seq += '\x1b[?1006h';
+  if (m.appCursorKeys) seq += '\x1b[?1h';
+  if (m.appKeypad) seq += '\x1b=';
+  if (!m.cursorVisible) seq += '\x1b[?25l';
+  return seq;
+}
+
+/** tmux display-message format string matching {@link parsePaneModeFlags}. */
+export const PANE_MODE_FLAGS_FORMAT =
+  '#{mouse_standard_flag} #{mouse_button_flag} #{mouse_all_flag} #{mouse_sgr_flag}'
+  + ' #{keypad_cursor_flag} #{keypad_flag} #{cursor_flag}';
+
+/** Parse the {@link PANE_MODE_FLAGS_FORMAT} output. Null on malformed output
+ *  (pane vanished mid-query → tmux prints an error line, not flags). */
+export function parsePaneModeFlags(out: string): PaneInputModes | null {
+  const f = out.trim().split(/\s+/);
+  if (f.length !== 7 || f.some(v => v !== '0' && v !== '1')) return null;
+  return {
+    mouseStandard: f[0] === '1',
+    mouseButton: f[1] === '1',
+    mouseAll: f[2] === '1',
+    mouseSgr: f[3] === '1',
+    appCursorKeys: f[4] === '1',
+    appKeypad: f[5] === '1',
+    cursorVisible: f[6] === '1',
+  };
+}
+
 /**
  * Spread lifecycle probes after a mass daemon restore. Workers are separate
  * processes, so a process-local mutex cannot prevent them all from hitting the
@@ -679,6 +730,27 @@ export class TmuxPipeBackend implements SessionBackend {
    *  doesn't need this fix — applications write proper `\r\n`. */
   captureCurrentScreen(): string {
     return this.captureWithBounds('-S - -E -', { restoreCursor: true });
+  }
+
+  /** Escape sequence re-asserting the pane's live input modes (mouse tracking,
+   *  app cursor keys, cursor visibility) on a fresh web-terminal xterm. The
+   *  worker appends this to write-capable clients' capture-pane seed — without
+   *  it a mouse-mode TUI (grok build enables 1003+1006) never receives clicks,
+   *  so double-click-to-expand etc. silently do nothing in the web terminal.
+   *  Empty string when the pane is gone or tmux can't be queried. */
+  capturePaneInputModes(): string {
+    if (this.exited) return '';
+    try {
+      const out = execSync(
+        `tmux display-message -p -t ${shellescape(this.paneTarget)} ${shellescape(PANE_MODE_FLAGS_FORMAT)}`,
+        // Explicit stdio — see getChildPid for why default leaks tmux stderr.
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 2000, env: tmuxEnv() },
+      );
+      const modes = parsePaneModeFlags(out);
+      return modes ? paneInputModeSeed(modes) : '';
+    } catch {
+      return '';
+    }
   }
 
   /** Snapshot ONLY the currently visible pane (no scrollback). Equivalent to

--- a/src/adapters/backend/types.ts
+++ b/src/adapters/backend/types.ts
@@ -112,6 +112,13 @@ export interface SessionBackend {
   getChildPid?(): number | null;
   captureCurrentScreen?(): string;
   /**
+   * Escape sequence re-asserting the pane's live input modes (mouse tracking,
+   * app cursor keys, …) on a fresh web-terminal client. Snapshot seeds carry
+   * screen cells but no DECSET state; backends that can query it (tmux) expose
+   * this so mouse-mode TUIs keep receiving clicks after a page (re)load.
+   */
+  capturePaneInputModes?(): string;
+  /**
    * Complete one authoritative screen refresh that starts after this call.
    * Snapshot-only backends use this as a completion fence before the worker
    * declares a turn idle, so a final burst cannot be lost to polling phase.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14734,8 +14734,17 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
             scrollback,
             onError: log,
           });
-        if (seed.length > 0) {
-          ws.send(seed + herdrWebCursorSequence());
+        // A capture-pane seed carries screen cells but no DECSET state: a fresh
+        // client xterm never learns the CLI enabled mouse tracking (grok build:
+        // 1003+1006), so clicks/double-clicks are silently swallowed instead of
+        // reported. Re-assert the pane's live input modes after the seed —
+        // write clients only: a read-only viewer forwards no input anyway, and
+        // mouse-mode xterm would break its plain select-to-copy. Raw-scrollback
+        // seeds already contain the original DECSET bytes; backends that can't
+        // be queried (herdr/zmx/pty) simply don't implement the hook.
+        const modeSeed = hasWrite ? (backend?.capturePaneInputModes?.() ?? '') : '';
+        if (seed.length > 0 || modeSeed.length > 0) {
+          ws.send(seed + modeSeed + herdrWebCursorSequence());
         }
 
         ws.on('message', (raw) => {
@@ -15137,13 +15146,34 @@ if(hasToken && !/[?&]imefix=0\\b/.test(location.search)){(function(){
 
 // ── WebSocket ──
 var ws_=null,el=document.getElementById('status');
+function _sendInput(d){if(ws_&&ws_.readyState===1)ws_.send(JSON.stringify({type:'input',data:d}))}
+// Pure pointer-motion reports (SGR button code 35 + shift/alt/ctrl modifier
+// bits). Emitted by xterm once the seed re-asserts DECSET 1003 (grok build) —
+// one per cell crossed. Each forwarded report costs a synchronous tmux
+// send-keys exec in the worker, so an unthrottled sweep across a 120-col pane
+// would stall the relay for every viewer. Clicks/drags/wheel stay immediate.
+var _MOTION_RE=/^(?:\\x1b\\[<(?:35|39|43|47|51|55|59|63);\\d+;\\d+[Mm])+$/;
+var _motionPend=null,_motionT=0;
 term.onData(function(d){
   if(!hasToken){
     // Mouse escape sequences are input too: a TUI can bind clicks or wheel
     // events to actions. View links never forward terminal bytes.
     _showReadonlyToast();return;
   }
-  if(ws_&&ws_.readyState===1)ws_.send(JSON.stringify({type:'input',data:d}));
+  if(_MOTION_RE.test(d)){
+    // Trailing throttle: keep only the LATEST motion, flush every 90ms. Hover
+    // feedback survives; the send-keys exec rate is bounded (~11/s).
+    _motionPend=d;
+    if(!_motionT)_motionT=setTimeout(function(){
+      _motionT=0;if(_motionPend){_sendInput(_motionPend);_motionPend=null}
+    },90);
+    return;
+  }
+  // A press/release/drag/key supersedes any pending motion (it carries its own
+  // coordinates); dropping it preserves event ordering for the TUI.
+  if(_motionT){clearTimeout(_motionT);_motionT=0}
+  _motionPend=null;
+  _sendInput(d);
 });
 var fixedSize=false,_lastC=0,_lastR=0,_rzT=0;
 function sendResize(){

--- a/test/web-terminal-mouse-modes.test.ts
+++ b/test/web-terminal-mouse-modes.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Web-terminal input-mode restoration (grok build double-click regression).
+ *
+ * A capture-pane seed carries screen cells but no DECSET state, so a freshly
+ * connected web client's xterm never learned the CLI had enabled mouse
+ * tracking — grok build (1003 any-motion + 1006 SGR) then never received
+ * clicks, and double-click-to-expand silently did nothing. Verifies:
+ *
+ *   - paneInputModeSeed maps tmux pane flags → DECSET re-assert sequence
+ *   - parsePaneModeFlags parses/rejects display-message output
+ *   - TmuxPipeBackend.capturePaneInputModes queries the REAL pane target and
+ *     composes the sequence (empty on error/exit)
+ *   - worker seed appends the mode seed for WRITE clients only, and the client
+ *     script trailing-throttles pure-motion reports (1003 floods → send-keys)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+import { execSync } from 'node:child_process';
+import {
+  paneInputModeSeed,
+  parsePaneModeFlags,
+  PANE_MODE_FLAGS_FORMAT,
+  TmuxPipeBackend,
+} from '../src/adapters/backend/tmux-pipe-backend.js';
+
+const mockedExecSync = vi.mocked(execSync);
+
+describe('paneInputModeSeed', () => {
+  it('re-asserts grok build modes (1003 any-motion + 1006 SGR)', () => {
+    expect(paneInputModeSeed({
+      mouseStandard: false,
+      mouseButton: false,
+      mouseAll: true,
+      mouseSgr: true,
+      appCursorKeys: false,
+      appKeypad: false,
+      cursorVisible: true,
+    })).toBe('\x1b[?1003h\x1b[?1006h');
+  });
+
+  it('is empty for a mode-less pane (plain shell)', () => {
+    expect(paneInputModeSeed({
+      mouseStandard: false,
+      mouseButton: false,
+      mouseAll: false,
+      mouseSgr: false,
+      appCursorKeys: false,
+      appKeypad: false,
+      cursorVisible: true,
+    })).toBe('');
+  });
+
+  it('covers every tracked mode, hiding the cursor only when the pane does', () => {
+    expect(paneInputModeSeed({
+      mouseStandard: true,
+      mouseButton: true,
+      mouseAll: true,
+      mouseSgr: true,
+      appCursorKeys: true,
+      appKeypad: true,
+      cursorVisible: false,
+    })).toBe('\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?1h\x1b=\x1b[?25l');
+  });
+});
+
+describe('parsePaneModeFlags', () => {
+  it('parses a grok build pane', () => {
+    expect(parsePaneModeFlags('0 0 1 1 0 0 1\n')).toEqual({
+      mouseStandard: false,
+      mouseButton: false,
+      mouseAll: true,
+      mouseSgr: true,
+      appCursorKeys: false,
+      appKeypad: false,
+      cursorVisible: true,
+    });
+  });
+
+  it('rejects malformed output (pane vanished → tmux error line)', () => {
+    expect(parsePaneModeFlags("can't find pane: %42")).toBeNull();
+    expect(parsePaneModeFlags('')).toBeNull();
+    expect(parsePaneModeFlags('0 0 1 1 0 0')).toBeNull();
+    expect(parsePaneModeFlags('0 0 2 1 0 0 1')).toBeNull();
+  });
+});
+
+describe('TmuxPipeBackend.capturePaneInputModes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queries the real pane target and composes the DECSET sequence', () => {
+    const backend = new TmuxPipeBackend('main:1.2', { ownsSession: false });
+    mockedExecSync.mockReturnValueOnce('0 0 1 1 0 0 1\n' as any);
+
+    expect(backend.capturePaneInputModes()).toBe('\x1b[?1003h\x1b[?1006h');
+
+    const cmd = String(mockedExecSync.mock.calls[0][0]);
+    expect(cmd).toContain("display-message -p -t 'main:1.2'");
+    expect(cmd).toContain(PANE_MODE_FLAGS_FORMAT);
+  });
+
+  it('returns empty when tmux fails or output is malformed', () => {
+    const backend = new TmuxPipeBackend('main:1.2', { ownsSession: false });
+    mockedExecSync.mockImplementationOnce(() => { throw new Error('no server'); });
+    expect(backend.capturePaneInputModes()).toBe('');
+
+    mockedExecSync.mockReturnValueOnce("can't find pane\n" as any);
+    expect(backend.capturePaneInputModes()).toBe('');
+  });
+});
+
+describe('worker web-terminal wiring (source assertions)', () => {
+  const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+
+  it('appends the pane mode seed for write clients only', () => {
+    expect(workerSource).toContain(
+      "const modeSeed = hasWrite ? (backend?.capturePaneInputModes?.() ?? '') : '';",
+    );
+    expect(workerSource).toContain('ws.send(seed + modeSeed + herdrWebCursorSequence());');
+    // Mode seed alone must still be sent when the capture seed is empty.
+    expect(workerSource).toContain('if (seed.length > 0 || modeSeed.length > 0) {');
+  });
+
+  it('trailing-throttles pure-motion mouse reports in the client script', () => {
+    // Motion = SGR button code 35 plus shift(+4)/alt(+8)/ctrl(+16) combinations.
+    expect(workerSource).toContain(
+      'var _MOTION_RE=/^(?:\\\\x1b\\\\[<(?:35|39|43|47|51|55|59|63);\\\\d+;\\\\d+[Mm])+$/;',
+    );
+    // Non-motion input must cancel a pending motion to preserve event order.
+    const onData = workerSource.slice(
+      workerSource.indexOf('term.onData(function(d){'),
+      workerSource.indexOf('var fixedSize='),
+    );
+    expect(onData).toContain('_motionPend=d;');
+    expect(onData).toContain('if(_motionT){clearTimeout(_motionT);_motionT=0}');
+    expect(onData.indexOf('_MOTION_RE.test(d)')).toBeLessThan(onData.indexOf('_sendInput(d);'));
+  });
+
+  it('keeps the motion-code set in sync with the client regex', () => {
+    // Base 35 (0b100011: motion, no button) + modifier bits 4/8/16.
+    const expected = [0, 4, 8, 12, 16, 20, 24, 28].map(m => 35 + m).join('|');
+    expect(workerSource).toContain(`(?:${expected})`);
+  });
+});

--- a/test/web-terminal-touch-scroll.test.ts
+++ b/test/web-terminal-touch-scroll.test.ts
@@ -26,7 +26,7 @@ describe('web terminal touch scrolling', () => {
   it('restores the real Herdr attach cursor after snapshot rendering', () => {
     expect(workerSource).toContain('be.onWebTerminalCursor(relayHerdrWebCursor);');
     expect(workerSource).toContain('scrollback}${herdrWebCursorSequence()}');
-    expect(workerSource).toContain('ws.send(seed + herdrWebCursorSequence());');
+    expect(workerSource).toContain('ws.send(seed + modeSeed + herdrWebCursorSequence());');
   });
 
   it('forces Herdr alternate-screen CLIs to remote-scroll after a snapshot-only refresh', () => {


### PR DESCRIPTION
## 问题

botmux 支持 grok build 后，在 web 终端（写权限）里 grok TUI 的鼠标交互全部失效：无法双击展开执行过程、无法点击选中 transcript 块等。

根因：web 终端 shared-relay 路径用 `tmux capture-pane` 快照给新连接做种子，快照只包含屏幕格子内容，**不包含 DECSET 终端模式状态**。grok build TUI 启动时开启了 `1003`（any-motion 鼠标追踪）+ `1006`（SGR 编码）（真实 pane 实测 `mouse_all_flag=1 mouse_sgr_flag=1`），但浏览器端 xterm.js 从种子里学不到这一点，于是从不生成鼠标上报——点击被 xterm 当作本地文本选择吞掉。

## 改动

- **`TmuxPipeBackend.capturePaneInputModes()`**（新增）：一次 `tmux display-message` 读取 `mouse_standard/button/all/sgr_flag`、`keypad_cursor_flag`、`keypad_flag`、`cursor_flag`，转成 DECSET 重申序列。纯函数 `paneInputModeSeed` / `parsePaneModeFlags` 导出可单测；pane 消失/输出异常时安全返回空串
- **worker 种子路径**：仅对**写权限**客户端在种子后追加该序列（`SessionBackend` 上是可选方法）。只读端不加：只读本来就不转发输入，保持其普通 select-to-copy 体验
- **前端 `term.onData`**：对纯 motion 上报（SGR 按钮码 35+shift/alt/ctrl 修饰位组合）做 90ms trailing 节流。1003 模式下指针扫过一行 ≈ 每格一条上报，而每条转发在 worker 里都是一次同步 `tmux send-keys` exec，不节流会卡住所有 viewer 的 relay。点击/拖拽/滚轮/键盘不受影响；非 motion 输入会丢弃 pending motion 保证事件有序

## 影响面

- 生效范围：默认 tmux(pipe) 后端的 web 终端 shared-relay 路径（含 adopt-tmux）。herdr / zmx / pty / zellij 后端未实现该可选方法 → 行为完全不变；tmux-attach（崩溃诊断）与 zellij-attach 路径由 attach 客户端自身处理模式，不经过此路径
- 跨 CLI：未开鼠标模式的 CLI（claude / codex 等）flags 全 0 → 追加空串，无任何变化；开鼠标模式的 CLI（grok、opencode 等）在 web 里获得与原生终端一致的鼠标交互
- 行为变化：开鼠标模式的 CLI 在**写模式** web 终端里选文本需按住 Shift（与 iTerm 等原生终端行为一致）；只读链接不受影响

## 测试验证

- `pnpm build` 通过
- `pnpm vitest run test/web-terminal-mouse-modes.test.ts test/web-terminal-touch-scroll.test.ts test/tmux-pipe-backend.test.ts test/web-terminal-seed.test.ts test/web-terminal-seed-cursor.test.ts` → 5 文件 74 用例全绿（新增 `web-terminal-mouse-modes.test.ts` 覆盖纯函数映射、display-message 寻址、worker 接线与前端节流的源码断言）
- 全量 unit 套件：仅 `skill-doctor-command.test.ts` 2 例失败，`git stash` 后重跑同样失败，确认为存量问题，与本改动无关
- e2e：真实 tmux 3.3a + grok 1.0.3 pane 上 `capturePaneInputModes()` 返回 `\x1b[?1003h\x1b[?1006h`
- live 实测：`pnpm switch:here && pnpm daemon:restart` 后，用浏览器打开一个 grok 会话的写权限 web 终端——`term.modes.mouseTrackingMode` 由 `none` 变为 `any`、buffer 为 alternate；双击折叠的执行块（`Listed 4 dirs, Read 14 files [hooks: 3]`）成功展开出内部 `Thought for 2.2s` 详情，TUI 底栏切换为 `→:expand / Enter:open / Ctrl+e:expand thinking` 选中态快捷键（截图在内部会话中验证留档，含会话内容不附到公开 PR）