### PR TITLE
style(dashboard): 优化最终回答反馈配置界面

### DIFF
--- a/src/dashboard/web/bot-defaults-page.tsx
+++ b/src/dashboard/web/bot-defaults-page.tsx
@@ -919,14 +919,31 @@ function FeedbackSettingsSection(props: { bot: BotDefaultsRow; patchBot: PatchBo
   }
   return (
     <section className="bd-section" aria-busy={busy}>
-      <h3 className="bd-section-title">最终回答反馈</h3>
-      <ToggleRow checked={on} disabled={busy} title="最终回答反馈" help="默认关闭；只对这个 bot 的最终回答生效" onChange={checked => { setOn(checked); void save(checked); }} />
-      <label className="bd-row"><span>高级 JSON</span><textarea value={json} disabled={busy || !on} rows={10} onChange={e => setJson(e.target.value)} /></label>
-      <div className="actions"><button type="button" className="primary" disabled={busy || !on} onClick={() => void save()}>保存反馈配置</button><StatusSpan status={status} /></div>
-      <h4>每聊天覆盖</h4>
-      <label className="bd-row"><span>聊天</span><select value={chatId} onChange={e => setChatId(e.target.value)}><option value="">选择聊天</option>{chats.map(chat => <option key={chat.chatId} value={chat.chatId}>{chat.name || chat.chatId}</option>)}</select></label>
-      <div className="actions"><button type="button" disabled={busy || !chatId.trim()} onClick={() => void saveChat()}>保存聊天覆盖</button><button type="button" disabled={busy} onClick={() => void loadPreview()}>生效预览</button></div>
-      {preview ? <pre className="code-block">{JSON.stringify(preview, null, 2)}</pre> : null}
+      <h3 className="bd-section-title">
+        <FieldTitle help="开启后，最终回答卡片会显示“结论可用 / 有效推进 / 结论有误”等反馈按钮，用于收集回答质量评价。默认关闭；只影响这个 bot 的最终回答，不影响过程消息。">最终回答反馈</FieldTitle>
+      </h3>
+      <ToggleRow checked={on} disabled={busy} title="最终回答反馈" help={null} description="在最终回答卡片中收集用户评价。" onChange={checked => { setOn(checked); void save(checked); }} />
+      <StatusSpan status={status} />
+      {on ? (
+        <details className="bd-feedback-advanced">
+          <summary>高级配置（JSON 与聊天覆盖）</summary>
+          <div className="bd-feedback-advanced-body">
+            <label className="bd-row"><FieldTitle help="用于自定义反馈按钮、文案、负向原因和是否允许改选。不了解 JSON 配置时保持默认即可。">高级 JSON</FieldTitle><textarea className="bd-feedback-json" value={json} disabled={busy} rows={6} onChange={e => setJson(e.target.value)} /></label>
+            <div className="actions"><button type="button" className="primary" disabled={busy} onClick={() => void save()}>保存反馈配置</button></div>
+            <div className="bd-feedback-chat-override">
+              <h4><FieldTitle help="让同一个 bot 在不同飞书聊天中使用不同反馈规则；聊天配置优先于 bot 默认配置。只有各群规则不同时才需要设置。">每聊天覆盖</FieldTitle></h4>
+              <p className="hint">仅当这个 bot 在不同聊天中需要不同反馈规则时设置。</p>
+              <label className="bd-row"><span>聊天</span><select value={chatId} onChange={e => { setChatId(e.target.value); setPreview(null); }}><option value="">选择聊天</option>{chats.map(chat => <option key={chat.chatId} value={chat.chatId}>{chat.name || chat.chatId}</option>)}</select></label>
+              {chatId.trim() ? (
+                <>
+                  <div className="actions"><button type="button" disabled={busy} onClick={() => void saveChat()}>保存聊天覆盖</button><button type="button" disabled={busy} onClick={() => void loadPreview()}>生效预览</button></div>
+                  {preview ? <pre className="code-block">{JSON.stringify(preview, null, 2)}</pre> : null}
+                </>
+              ) : null}
+            </div>
+          </div>
+        </details>
+      ) : null}
     </section>
   );
 }

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -12971,6 +12971,34 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
   color: var(--fg);
   font: 12px/1.5 var(--mono);
 }
+
+.bd-feedback-advanced {
+  margin-top: 12px;
+  border-top: 1px solid var(--border-soft);
+  padding-top: 10px;
+}
+.bd-feedback-advanced > summary {
+  width: fit-content;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  user-select: none;
+}
+.bd-feedback-advanced > summary:hover { color: var(--fg); }
+.bd-feedback-advanced-body { padding-top: 4px; }
+.bd-tile textarea.bd-feedback-json {
+  min-height: 112px;
+  max-height: 320px;
+  resize: vertical;
+}
+.bd-feedback-chat-override {
+  margin-top: 16px;
+  border-top: 1px solid var(--border-soft);
+  padding-top: 14px;
+}
+.bd-feedback-chat-override > h4 { margin: 0 0 4px; }
+.bd-feedback-chat-override > .hint { margin: 0; }
 :root[data-theme="dark"] .bd-tile textarea,
 :root[data-theme="dark"] .bd-tile input[type=text],
 :root[data-theme="dark"] .bd-tile input[type=number] {

--- a/test/dashboard-feedback-settings.test.ts
+++ b/test/dashboard-feedback-settings.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 describe('Bot Defaults feedback settings', () => {
-  it('renders an off-by-default toggle and advanced JSON editor with a dedicated save route', () => {
+  it('keeps advanced feedback settings compact until the user expands them', () => {
     const page = readFileSync(new URL('../src/dashboard/web/bot-defaults-page.tsx', import.meta.url), 'utf8');
+    const css = readFileSync(new URL('../src/dashboard/web/style.css', import.meta.url), 'utf8');
     const types = readFileSync(new URL('../src/dashboard/web/bot-defaults.ts', import.meta.url), 'utf8');
     const dashboard = readFileSync(new URL('../src/dashboard.ts', import.meta.url), 'utf8');
     expect(types).toContain('FeedbackPolicyLayer');
@@ -11,6 +12,16 @@ describe('Bot Defaults feedback settings', () => {
     expect(page).toContain('高级 JSON');
     expect(page).toContain('每聊天覆盖');
     expect(page).toContain('生效预览');
+    expect(page).toContain('<details className="bd-feedback-advanced">');
+    expect(page).toContain('高级配置（JSON 与聊天覆盖）');
+    expect(page).toContain('最终回答卡片会显示“结论可用 / 有效推进 / 结论有误”等反馈按钮');
+    expect(page).toContain('不了解 JSON 配置时保持默认即可');
+    expect(page).toContain('聊天配置优先于 bot 默认配置');
+    expect(page).toContain('在最终回答卡片中收集用户评价。');
+    expect(page).toContain('rows={6}');
+    expect(page).toContain('{chatId.trim() ? (');
+    expect(css).toContain('.bd-tile textarea.bd-feedback-json');
+    expect(css).toContain('max-height: 320px');
     expect(page).toContain('fetchGroupsSnapshot');
     expect(page).toContain('<select value={chatId}');
     expect(page).not.toContain('聊天 ID（从群组页选择/复制）');


### PR DESCRIPTION
## 改动

- 关闭最终回答反馈时仅保留开关和简短说明，隐藏低频配置
- 将 JSON 与每聊天覆盖收进默认折叠的高级配置
- 将 JSON 编辑器从 10 行收敛到 6 行，并限制最大高度为 320px
- 选择聊天后才展示覆盖保存与生效预览操作
- 为最终回答反馈、高级 JSON、每聊天覆盖补充帮助问号和用途说明

## 为什么

原界面默认展示大面积 JSON 编辑器和聊天覆盖，容易让普通用户误以为这是必配项，也难以理解三个入口的关系。默认折叠低频能力并补充就地帮助后，常用路径只保留开关，需要定制时仍可展开完整配置。

## 影响面

仅调整 Dashboard「Bot 配置 → 消息卡片」中的最终回答反馈配置界面。未修改反馈策略、配置 API、卡片交付、CLI、后端和会话行为；所有 CLI 共用的 Bot 配置页面仅发生展示层变化。

## 验证

- `pnpm exec vitest run test/dashboard-feedback-settings.test.ts`：2 项通过
- `pnpm build`：通过
- `git diff --check`：通过
- live daemon / Dashboard 重启后均为 `online`
- 真实浏览器验证折叠态、展开态、帮助文案和 128px 编辑器初始高度

## 截图

折叠态与展开态截图见下方评论。

