### PR TITLE
fix(worker): codex 有结构化 429 信号后关闭其扫屏限流误判

### DIFF
--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -428,6 +428,13 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
     // submit immediately and never spuriously reports a mid-turn send failure.
     supportsTypeAhead: true,
     reliableTurnTerminal: true,
+    // Worker's maybeEmitCodexStructuredRateLimit reads the rollout's
+    // `codex_rate_limited` terminal (isCodexRateLimitEvent) and emits a
+    // structured `limited` state — so codex is the rate-limit authority and the
+    // screen-scan `rate` heuristic is suppressed for it (see
+    // isStructuredRateLimitAuthoritative). Only codex among the codexBridgeQueue
+    // CLIs runs that emit (structuredBridgeIsCodex gate), so the flag stays here.
+    emitsStructuredRateLimit: true,
     altScreen: false,   // --no-alt-screen disables alternate screen
     // Codex has no per-session skill injection like Claude's `--plugin-dir`.
     // Verified empirically on codex 0.136.0 (via `codex debug prompt-input`,

--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -47,10 +47,12 @@ import { delay } from '../../utils/timing.js';
  *       terminal stopReason), and `terminate` is not persisted — so that turn
  *       has no on-disk end marker.
  *  Setting `reliableTurnTerminal` would (a) claim VC-meeting delivery eligibility
- *  Pi can't honor, (b) suppress the busy-marker idle probe Pi actually relies on,
- *  and (c) make `structuredRateLimitAuthoritative` suppress Pi's screen `rate`
- *  verdict with no structured replacement (real 429s vanish). Leaving it unset
- *  keeps Pi on its proven quiescence + `Working...` busy-marker idle path.
+ *  Pi can't honor and (b) suppress the busy-marker idle probe Pi actually relies
+ *  on, so it stays unset — keeping Pi on its proven quiescence + `Working...`
+ *  busy-marker idle path. (Pi's screen `rate` verdict is NOT at risk here:
+ *  `structuredRateLimitAuthoritative` gates on `claudeDataDir` /
+ *  `emitsStructuredRateLimit`, neither of which Pi sets — Pi has no structured
+ *  rate-limit emit, so it correctly keeps screen-scanning real 429s.)
  *
  *  ## Idle detection
  *  Pi is a pure-quiescence adapter (no `readyPattern`, no `injectsReadyHook`).

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -390,6 +390,21 @@ export interface CliAdapter {
    *  capability; `queued` and `final_output` are not completion receipts. */
   readonly reliableTurnTerminal?: boolean;
 
+  /** The adapter PUBLISHES a structured `limited` screen_update from a machine
+   *  rate-limit signal in its transcript (not from scraping screen text). When
+   *  true, `isStructuredRateLimitAuthoritative` treats it as the sole rate-limit
+   *  authority and suppresses the screen-scan `rate` heuristic — otherwise the
+   *  model's own output or a dev editing rate-limit code puts "429" / "exceeded
+   *  retry limit" on screen and the scraper false-positives (it cannot tell a
+   *  printed "429" from a request that actually returned 429). The Claude family
+   *  is authoritative via `claudeDataDir` regardless of this flag; Codex sets it
+   *  because the worker's `maybeEmitCodexStructuredRateLimit` reads the rollout's
+   *  `codex_rate_limited` terminal and emits `limited`. Do NOT set it for a
+   *  codexBridgeQueue CLI that has no such emit (grok / traex / pi / hermes /
+   *  mtr / cursor) — suppressing their screen scan would silently drop the real
+   *  429 backoff + Dashboard「需要你」signal. */
+  readonly emitsStructuredRateLimit?: boolean;
+
   /** True when this adapter supports running under per-bot read isolation (its
    *  data root is redirectable into BOT_HOME — CLAUDE_CONFIG_DIR / CODEX_HOME —
    *  and it runs correctly under the worker's whole-process Seatbelt wrapper,

--- a/src/utils/cli-usage-limit.ts
+++ b/src/utils/cli-usage-limit.ts
@@ -120,26 +120,36 @@ export interface DetectUsageLimitOptions {
 
 /**
  * Whether a CLI adapter is authoritative for structured rate limits — i.e. it
- * actually PUBLISHES a `limited` screen_update from its transcript. Only the
- * Claude family does (via the worker's `maybeEmitStructuredRateLimit` on the
- * `bridgeJsonlPath` path), and it is exactly the adapters that carry
- * `claudeDataDir`. When true, the worker passes `suppressRateKind` so the
- * screen-scan `rate` verdict is suppressed in favor of the structured signal.
+ * actually PUBLISHES a `limited` screen_update from a machine signal in its
+ * transcript rather than from scraping screen text. Two families qualify:
  *
- * Gate on `claudeDataDir`, NOT `reliableTurnTerminal`: the codexBridgeQueue
- * CLIs emit NO structured `limited` state, so suppressing their screen `rate`
- * would drop the Dashboard「需要你」signal + backoff on a real 429. Most of
- * them (codex / grok / traex) DO set `reliableTurnTerminal`, so gating on that
- * flag would wrongly suppress them; pi is also codexBridgeQueue-backed but does
- * not set it — either way, none carry `claudeDataDir`, so all correctly stay
- * screen-scanning. Extracted as a pure predicate so the split has a direct
- * unit-test surface (see cli-usage-limit.test.ts) — a future adapter can't
- * silently re-broaden it.
+ *  - The Claude family (`claudeDataDir`): the worker's
+ *    `maybeEmitStructuredRateLimit` reads the transcript's `error:"rate_limit"`
+ *    record on the `bridgeJsonlPath` path.
+ *  - Codex (`emitsStructuredRateLimit`): `maybeEmitCodexStructuredRateLimit`
+ *    reads the rollout's `codex_rate_limited` terminal (`isCodexRateLimitEvent`)
+ *    and emits `limited`. This emit runs only under the `structuredBridgeIsCodex`
+ *    gate, so among codexBridgeQueue CLIs only codex sets the flag.
+ *
+ * When true the worker passes `suppressRateKind` so the screen-scan `rate`
+ * verdict is dropped in favor of the structured signal — otherwise the model's
+ * own output (or a dev editing rate-limit code) puts "429" / "exceeded retry
+ * limit" on screen and the scraper cannot tell a printed 429 from a request
+ * that actually returned 429.
+ *
+ * The other codexBridgeQueue CLIs (grok / traex / pi / hermes / mtr / cursor)
+ * emit NO structured `limited` state, so they must keep screen-scanning: set
+ * neither field on them or a real 429 silently loses its backoff + Dashboard
+ * 「需要你」signal. Most set `reliableTurnTerminal`, so gating on that flag would
+ * wrongly suppress them; gating on these two explicit capability fields keeps
+ * the split exact. Extracted as a pure predicate so it has a direct unit-test
+ * surface (see cli-usage-limit.test.ts) — a future adapter can't silently
+ * re-broaden it.
  */
 export function isStructuredRateLimitAuthoritative(
-  adapter: { readonly claudeDataDir?: string } | null | undefined,
+  adapter: { readonly claudeDataDir?: string; readonly emitsStructuredRateLimit?: boolean } | null | undefined,
 ): boolean {
-  return !!adapter?.claudeDataDir;
+  return !!adapter?.claudeDataDir || !!adapter?.emitsStructuredRateLimit;
 }
 
 export function detectCliUsageLimit(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3707,26 +3707,30 @@ function codexAppLivenessStatus(base: RuntimeScreenStatus, nowMs = Date.now()): 
 
 /**
  * True when this CLI has an authoritative STRUCTURED rate-limit signal that is
- * actually PUBLISHED as a `limited` screen_update — i.e. the Claude family,
- * whose `bridgeIngest → maybeEmitStructuredRateLimit()` reads the transcript's
- * `error:"rate_limit"` record. For those CLIs the screen-text `rate` heuristic
- * is not just redundant but harmful: the model's own output or a dev editing
- * rate-limit code/tests puts phrases like "429 Too Many Requests" / "exceeded
- * retry limit" on screen, which the scraper cannot distinguish from a real
- * limit. So we suppress the screen-scan `rate` verdict and let the structured
- * path be the sole authority. `usage` (quota "hit your limit …") has no
- * structured equivalent yet, so it still comes from the screen.
+ * actually PUBLISHED as a `limited` screen_update. Two families qualify: the
+ * Claude family, whose `bridgeIngest → maybeEmitStructuredRateLimit()` reads the
+ * transcript's `error:"rate_limit"` record; and codex, whose
+ * `maybeEmitCodexStructuredRateLimit()` reads the rollout's `codex_rate_limited`
+ * terminal (`isCodexRateLimitEvent`). For those CLIs the screen-text `rate`
+ * heuristic is not just redundant but harmful: the model's own output or a dev
+ * editing rate-limit code/tests puts phrases like "429 Too Many Requests" /
+ * "exceeded retry limit" on screen, which the scraper cannot distinguish from a
+ * real limit. So we suppress the screen-scan `rate` verdict and let the
+ * structured path be the sole authority. `usage` (quota "hit your limit …") has
+ * no structured equivalent yet, so it still comes from the screen.
  *
- * Gate on `claudeDataDir` (the Claude-family marker: claude-code / seed /
- * genius), NOT on `reliableTurnTerminal`. Both are "transcript-backed", but the
- * structured rate-limit EMIT only exists on the Claude bridge (`bridgeJsonlPath`
- * path). The codexBridgeQueue CLIs (codex / grok / traex / pi) map an `error`
- * terminal to a failed/ambiguous receipt but publish NO `limited` state — so
- * suppressing their screen `rate` verdict would silently drop the Dashboard
- * 「需要你」signal + backoff on a real 429. Pi joining reliableTurnTerminal made
- * that latent over-suppression concrete; scoping to claudeDataDir fixes it for
- * every codexBridgeQueue CLI at once. (A future structured rate-limit emit for
- * those CLIs can widen this predicate.)
+ * Gate on the two capability fields (`claudeDataDir` for the Claude family;
+ * `emitsStructuredRateLimit` for codex), NOT on `reliableTurnTerminal`. The
+ * structured rate-limit EMIT only exists where those fields are set: codex's
+ * emit runs under the `structuredBridgeIsCodex()` gate, so among the
+ * codexBridgeQueue CLIs only codex carries the flag. The rest (grok / traex /
+ * pi / hermes / mtr / cursor) map an `error` terminal to a failed/ambiguous
+ * receipt but publish NO `limited` state — suppressing their screen `rate`
+ * verdict would silently drop the Dashboard「需要你」signal + backoff on a real
+ * 429. Most set `reliableTurnTerminal`, so gating on that flag would wrongly
+ * suppress them; gating on the explicit capability fields keeps the split
+ * exact. (A future structured rate-limit emit for another CLI just sets its
+ * `emitsStructuredRateLimit`.)
  */
 function structuredRateLimitAuthoritative(): boolean {
   return isStructuredRateLimitAuthoritative(cliAdapter);
@@ -4839,7 +4843,8 @@ function bridgeIngest(): void {
  *  session surfaces in Dashboard「需要你」with a retry countdown — identical
  *  wire shape to the screen-text detector's classify() output, so the daemon /
  *  card / persistence paths need no change. Claude-only (bridgeQueue is the
- *  Claude bridge; Codex uses codexBridgeQueue and has no structured 429). */
+ *  Claude bridge; Codex has its own structured 429 via
+ *  maybeEmitCodexStructuredRateLimit on the codexBridgeQueue path). */
 function maybeEmitStructuredRateLimit(events: readonly TranscriptEvent[]): void {
   for (const ev of events) {
     if (!ev.uuid || emittedRateLimitUuids.has(ev.uuid)) continue;

--- a/test/cli-usage-limit.test.ts
+++ b/test/cli-usage-limit.test.ts
@@ -289,17 +289,19 @@ describe('detectCliUsageLimit', () => {
   });
 });
 
-describe('isStructuredRateLimitAuthoritative — Claude-family only, not all reliableTurnTerminal', () => {
+describe('isStructuredRateLimitAuthoritative — structured-emit CLIs only, not all reliableTurnTerminal', () => {
   // This is the predicate the worker's structuredRateLimitAuthoritative()
-  // delegates to. Testing it directly (not the adapter.claudeDataDir field)
-  // means a regression that re-broadens the gate to reliableTurnTerminal — which
-  // would wrongly suppress screen-rate for codex/grok/traex/pi — turns this red.
+  // delegates to. Testing it directly (not the raw adapter fields) means a
+  // regression that re-broadens the gate to reliableTurnTerminal — which would
+  // wrongly suppress screen-rate for grok/traex/pi — turns this red.
   it('is true for the Claude family (they publish structured limited events)', () => {
     expect(isStructuredRateLimitAuthoritative(createClaudeCodeAdapter('/bin/claude'))).toBe(true);
     expect(isStructuredRateLimitAuthoritative(createGeniusAdapter('/bin/genius'))).toBe(true);
   });
-  it('is false for codexBridgeQueue CLIs (no structured limited emit → keep screen scan)', () => {
-    expect(isStructuredRateLimitAuthoritative(createCodexAdapter('/bin/codex'))).toBe(false);
+  it('is true for codex (maybeEmitCodexStructuredRateLimit publishes limited from codex_rate_limited)', () => {
+    expect(isStructuredRateLimitAuthoritative(createCodexAdapter('/bin/codex'))).toBe(true);
+  });
+  it('is false for codexBridgeQueue CLIs with no structured limited emit (keep screen scan)', () => {
     expect(isStructuredRateLimitAuthoritative(createGrokAdapter('/bin/grok'))).toBe(false);
     expect(isStructuredRateLimitAuthoritative(createTraexAdapter('/bin/traex'))).toBe(false);
     expect(isStructuredRateLimitAuthoritative(createPiAdapter('/bin/pi'))).toBe(false);


### PR DESCRIPTION
## 问题

codex 会话经常弹出「当前已达到 Codex 使用限额，请在 5-10 min 后再试」，但账号/LLM 实际并没有被限流。

根因在扫屏检测 `detectCliUsageLimit`：它每帧扫终端画面文本，只要出现 `status: 429` / `429 Too Many Requests` / `exceeded retry limit` 就按硬性 429 处理，并套一个 5-10 min 的兜底冷却（`hardRateLimitFallbackTime`，label 恒为「5-10 min」，非模型服务返回）。于是把 **agent 的回答内容、工具输出、上下文里出现的 429 字样** 误当成「LLM 请求被限流」。

典型触发：在 codex 里排查 429 相关问题时，屏幕上的 429 字样触发自身误报；而且冷却期内、或上下文里持续包含 429 字样时继续对话会反复触发（`classify()` 扫的是当前屏幕快照，不是本次请求结果）。

## 根因分析

不是「codex 缺结构化限流信号」。worker 已有 `maybeEmitCodexStructuredRateLimit`：它读 rollout 的 `codex_rate_limited` 终态（`isCodexRateLimitEvent`）并 emit `limited` —— 这是「请求真的返回 429」的机器信号。

问题是没有据此关掉扫屏：两条路径并存，扫屏仍会误报。而 `isStructuredRateLimitAuthoritative` 此前只 gate 在 `claudeDataDir`，只有 Claude 家族借结构化信号关掉了扫屏。

## 改动

- `types.ts`：新增适配器能力位 `emitsStructuredRateLimit`，表示「本适配器会从 transcript 的机器信号 emit 结构化 `limited`」。
- `codex.ts`：置 `emitsStructuredRateLimit: true`（结构化 emit 仅在 `structuredBridgeIsCodex()` 分支运行，其它 codexBridgeQueue CLI 没有）。
- `cli-usage-limit.ts`：`isStructuredRateLimitAuthoritative` 同时认 `claudeDataDir` 与 `emitsStructuredRateLimit`。
- 同步更新 worker.ts / pi.ts 中已过期的相关注释。

效果：codex 与 Claude 家族一致，以结构化 429 为唯一权威、关掉扫屏 `rate` 误判；`usage`（额度类，无结构化等价物）仍走扫屏，不变。

## 影响面

- **不动其它 codexBridgeQueue CLI**：grok / traex / pi / hermes / mtr / cursor 均无结构化 emit，未置该位，继续扫屏 —— 真实 429 的 backoff 与 Dashboard「需要你」信号不受影响。谓词仍不 gate 在 `reliableTurnTerminal`（否则会误伤这批）。
- Claude 家族路径不变（仍走 `claudeDataDir`）。

## 验证

- `pnpm build` 通过。
- 更新/新增单测：断言 codex 现为 authoritative、grok/traex/pi 仍非、null/undefined/空对象为 false。
- 相关测试全绿：cli-usage-limit / cli-adapters / cli-selection / codex-effort-wiring / codex-adapter-history-ownership / write-input，共 599 例通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)