### PR TITLE
fix(card): 隔离跨话题流式卡片清理

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -97,6 +97,7 @@ import { updateSessionTitle } from './session-title.js';
 import { requestAgentSessionRename } from './session-rename.js';
 import { hasProtectedSessionMutationOwnership } from './session-mutation-guard.js';
 import { withBotTurnMutation } from './bot-turn-mutation-gate.js';
+import { rehomeReplyTargetState } from './reply-target.js';
 import {
   configuredRuntimeDisplayName,
   sessionConfiguredRuntimeDisplayName,
@@ -1857,6 +1858,7 @@ export async function handleCommand(
                 session.ownerOpenId = oldSession.ownerOpenId;
                 session.creatorOpenId = oldSession.creatorOpenId;
                 session.lastCallerOpenId = oldSession.lastCallerOpenId;
+                rehomeReplyTargetState(current);
                 sessionStore.updateSession(session);
                 current.hasHistory = false;
                 activeSessions.set(key, current);

--- a/src/core/reply-target.ts
+++ b/src/core/reply-target.ts
@@ -442,3 +442,60 @@ export function syncReplyTargetState(ds: DaemonSession, s?: Session): void {
   ds.replyThreadAliases = source.replyThreadAliases;
   ds.currentReplyTarget = source.currentReplyTarget;
 }
+
+/**
+ * Rebind reply metadata after a live DaemonSession is moved to another Lark
+ * destination or assigned a replacement Session record. Source-chat message
+ * ids must never survive as routing authority in the new destination.
+ *
+ * Per-turn sender/participant attribution is retained for buffered inputs, but
+ * every visible target is rewritten to the session's new canonical surface.
+ * Callers detach/clear the old live card before invoking this helper, so its
+ * persisted destination key is cleared as part of the same lifecycle boundary.
+ */
+export function rehomeReplyTargetState(ds: DaemonSession): void {
+  const target = resolveInboundReplyTarget({
+    scope: ds.scope,
+    chatId: ds.chatId,
+    threadRootId: ds.session.rootMessageId,
+  });
+
+  if (ds.session.turnReplyContexts) {
+    const contexts: NonNullable<Session['turnReplyContexts']> = {};
+    for (const [turnId, context] of Object.entries(ds.session.turnReplyContexts)) {
+      contexts[turnId] = {
+        target,
+        ...(context.replyTargetSenderOpenId
+          ? { replyTargetSenderOpenId: context.replyTargetSenderOpenId }
+          : {}),
+        ...(context.replyTargetSenderIsBot !== undefined
+          ? { replyTargetSenderIsBot: context.replyTargetSenderIsBot }
+          : {}),
+      };
+    }
+    ds.session.turnReplyContexts = contexts;
+  }
+
+  if (ds.session.replyTargets) {
+    const targets: NonNullable<Session['replyTargets']> = {};
+    for (const [turnId, entry] of Object.entries(ds.session.replyTargets)) {
+      targets[turnId] = {
+        updatedAt: entry.updatedAt,
+        ...(entry.senderOpenId ? { senderOpenId: entry.senderOpenId } : {}),
+        ...(entry.participants?.length ? { participants: entry.participants } : {}),
+        ...(entry.participantsIncomplete ? { participantsIncomplete: true } : {}),
+      };
+    }
+    ds.session.replyTargets = targets;
+  }
+
+  ds.replyThreadAliases = undefined;
+  ds.currentReplyTarget = undefined;
+  ds.session.replyThreadAliases = undefined;
+  ds.session.currentReplyTarget = undefined;
+  ds.session.quoteTargetId = undefined;
+  ds.session.quoteTargetSenderOpenId = undefined;
+  ds.session.quoteTargetSenderIsBot = undefined;
+  ds.streamCardReplyTargetKey = undefined;
+  ds.session.streamCardReplyTargetKey = undefined;
+}

--- a/src/core/reply-target.ts
+++ b/src/core/reply-target.ts
@@ -1,5 +1,5 @@
 import type { DaemonSession } from './types.js';
-import type { FrozenSessionReplyContext, LarkMention, ReplyTargetEntry, Session, TurnParticipant } from '../types.js';
+import type { FrozenSessionReplyContext, FrozenSessionReplyTarget, LarkMention, ReplyTargetEntry, Session, TurnParticipant } from '../types.js';
 
 /** Merge participants by open_id, keeping the richest label (a later entry can
  *  fill a missing name / promote isBot). Order-stable on first appearance so a
@@ -86,6 +86,15 @@ export type SessionReplyTarget =
   | { mode: 'plain'; chatId: string }
   | { mode: 'thread'; rootMessageId: string }
   | { mode: 'quote'; rootMessageId: string };
+
+/** Stable key for one visible Lark destination. Keep the reply mode in the key:
+ * a quoted top-level reply and a reply inside that message's thread share the
+ * same message id but are different visible surfaces. */
+export function replyTargetKey(target: FrozenSessionReplyTarget): string {
+  return target.mode === 'plain'
+    ? `plain:${target.chatId}`
+    : `${target.mode}:${target.rootMessageId}`;
+}
 
 /** Freeze the visible Lark destination for one inbound turn before any
  * lifecycle mutation can replace or remove its session. `replyRootId` is

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1425,6 +1425,7 @@ export function persistStreamCardState(ds: DaemonSession): void {
   if (
     s.streamCardId === cardId &&
     s.streamCardNonce === ds.streamCardNonce &&
+    s.streamCardReplyTargetKey === ds.streamCardReplyTargetKey &&
     s.displayMode === ds.displayMode &&
     s.currentImageKey === ds.currentImageKey &&
     s.currentTurnTitle === ds.currentTurnTitle &&
@@ -1437,6 +1438,7 @@ export function persistStreamCardState(ds: DaemonSession): void {
   ) return;
   s.streamCardId = cardId;
   s.streamCardNonce = ds.streamCardNonce;
+  s.streamCardReplyTargetKey = ds.streamCardReplyTargetKey;
   s.displayMode = ds.displayMode;
   s.currentImageKey = ds.currentImageKey;
   s.currentTurnTitle = ds.currentTurnTitle;
@@ -1685,6 +1687,7 @@ export async function restoreActiveSessions(
           adoptedFrom: adopted,
           streamCardId: session.streamCardId,
           streamCardNonce: session.streamCardNonce,
+          streamCardReplyTargetKey: session.streamCardReplyTargetKey,
           displayMode: session.displayMode === 'screenshot' || session.displayMode === 'hidden'
             ? session.displayMode
             : (session.streamExpanded ? 'screenshot' : 'hidden'),
@@ -1889,6 +1892,7 @@ export async function restoreActiveSessions(
       // letting the next update create a new card.
       streamCardId: session.streamCardId,
       streamCardNonce: session.streamCardNonce,
+      streamCardReplyTargetKey: session.streamCardReplyTargetKey,
       displayMode: session.displayMode ?? (session.streamExpanded ? 'screenshot' : 'hidden'),
       currentImageKey: session.currentImageKey,
       currentTurnTitle: session.currentTurnTitle,
@@ -2546,6 +2550,7 @@ export async function resumeSession(
     ownerOpenId: session.ownerOpenId,
     streamCardId: session.streamCardId,
     streamCardNonce: session.streamCardNonce,
+    streamCardReplyTargetKey: session.streamCardReplyTargetKey,
     displayMode: session.displayMode ?? (session.streamExpanded ? 'screenshot' : 'hidden'),
     currentImageKey: session.currentImageKey,
     currentTurnTitle: session.currentTurnTitle,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -17,6 +17,10 @@ import type { CodexServiceTierSnapshot } from '../services/codex-service-tier.js
 /** Frozen card state — cached content for historical streaming cards that can still be toggled. */
 export interface FrozenCard {
   messageId: string;      // Lark message_id for PATCHing
+  /** Stable visible destination of this card (`plain:oc_*`, `thread:om_*`, or
+   *  `quote:om_*`). Chat-scope sessions can move between multiple Lark topics;
+   *  cleanup must only withdraw predecessors from the same destination. */
+  replyTargetKey?: string;
   content: string;        // frozen text snapshot — kept so "导出文字" still works on historical cards
   title: string;          // turn title at freeze time
   /** Legacy boolean expand/collapse — kept for migrating old persisted cards. */
@@ -215,6 +219,10 @@ export interface DaemonSession {
   ownerOpenId?: string;          // receives owner-only links and controls write-enabled access
   streamCardId?: string;         // message_id of the streaming card in group (PATCHed with live output)
   streamCardNonce?: string;       // unique nonce for the current streaming card — embedded in button values to distinguish old vs current card
+  /** Visible Lark destination of the live streaming card. Unlike
+   * currentReplyTarget this remains bound to the card after a newer turn is
+   * accepted, so parking cannot attribute the predecessor to the new topic. */
+  streamCardReplyTargetKey?: string;
   streamCardPending?: boolean;    // true while the newest turn still needs its own streaming card
   /** Monotonic in-memory generation for accepted user turns. Card POST
    * completions use it to avoid clearing a newer turn's pending state. */

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -25,7 +25,7 @@ import {
   markMessageListenerRunPreviewRunning,
 } from '../services/message-listener-run-preview-store.js';
 import { persistStreamCardState, rememberLastCliInput } from './session-manager.js';
-import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, replyTargetKey } from './reply-target.js';
+import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, rehomeReplyTargetState, replyTargetKey } from './reply-target.js';
 import { updateMessage, deleteMessage, sendEphemeralCard, sendUserMessage, addReaction, removeReaction, getMessageChatId, MessageWithdrawnError } from '../im/lark/client.js';
 import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildTuiPromptFailedCard, buildRelayedFrozenCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { codexServiceTierBadge } from '../services/codex-service-tier.js';
@@ -4827,6 +4827,7 @@ export async function transferSession(
   ds.streamCardId = undefined;
   ds.streamCardNonce = undefined;
   ds.currentImageKey = undefined;
+  rehomeReplyTargetState(ds);
 
   sessionStore.updateSession(ds.session);
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1281,9 +1281,22 @@ function logWorkerStderr(t: string, line: string): void {
 // the first POST returns a real message_id.
 export const CARD_POSTING_SENTINEL = '__posting__';
 
-function streamingCardReplyTargetKey(ds: DaemonSession, turnId?: string): string {
-  const replyContext = frozenReplyContextForTurn(ds, fallbackTurnId(ds, turnId));
-  return replyTargetKey(replyContext.target);
+/**
+ * Freeze the destination used by one streaming-card POST before dispatch.
+ * A POST may await the Lark API while another turn replaces
+ * `currentReplyTarget`; callers must commit this captured key rather than
+ * re-reading mutable session state after the request resolves.
+ */
+function captureStreamingCardReplyTarget(
+  ds: DaemonSession,
+  turnId?: string,
+): { turnId: string | undefined; replyTargetKey: string } {
+  const effectiveTurnId = fallbackTurnId(ds, turnId);
+  const replyContext = frozenReplyContextForTurn(ds, effectiveTurnId);
+  return {
+    turnId: effectiveTurnId,
+    replyTargetKey: replyTargetKey(replyContext.target),
+  };
 }
 
 /**
@@ -1401,6 +1414,7 @@ export async function postTurnStartingCard(
   const previousCardId = ds.streamCardId;
   const previousNonce = ds.streamCardNonce;
   const previousReplyTargetKey = ds.streamCardReplyTargetKey;
+  const cardReplyTarget = captureStreamingCardReplyTarget(ds, turnId);
   // A newer turn may have arrived while the previous turn's POST was still in
   // flight, so beginNewTurn could not park that sentinel. Park the now-live
   // predecessor here before replacing its identity.
@@ -1452,7 +1466,7 @@ export async function postTurnStartingCard(
   };
   try {
     const messageId = await sessionReply(
-      anchorAtPost, cardJson, 'interactive', larkAppIdAtPost, turnId,
+      anchorAtPost, cardJson, 'interactive', larkAppIdAtPost, cardReplyTarget.turnId,
     );
     if (!stillOwnsPost()) {
       void deleteMessage(larkAppIdAtPost, messageId).catch(() => { /* best-effort stale-card cleanup */ });
@@ -1461,7 +1475,7 @@ export async function postTurnStartingCard(
       return false;
     }
     ds.streamCardId = messageId;
-    ds.streamCardReplyTargetKey = streamingCardReplyTargetKey(ds, turnId);
+    ds.streamCardReplyTargetKey = cardReplyTarget.replyTargetKey;
     ds.parkedStreamCardNonce = undefined;
     const superseded = (ds.streamCardTurnGeneration ?? 0) !== generation;
     if (!superseded) {
@@ -1535,6 +1549,7 @@ export async function postFreshStreamingCard(
   const prevNonce = ds.streamCardNonce;
   const prevReplyTargetKey = ds.streamCardReplyTargetKey;
   const prevPending = ds.streamCardPending;
+  const cardReplyTarget = captureStreamingCardReplyTarget(ds);
 
   ds.streamCardNonce = randomBytes(4).toString('hex');
   const cardJson = buildStreamingCard(
@@ -1560,9 +1575,10 @@ export async function postFreshStreamingCard(
   );
   ds.streamCardId = CARD_POSTING_SENTINEL;
   try {
-    const turnId = ds.currentReplyTarget?.turnId;
-    ds.streamCardId = await sessionReply(sessionAnchorId(ds), cardJson, 'interactive', ds.larkAppId, turnId);
-    ds.streamCardReplyTargetKey = streamingCardReplyTargetKey(ds, turnId);
+    ds.streamCardId = await sessionReply(
+      sessionAnchorId(ds), cardJson, 'interactive', ds.larkAppId, cardReplyTarget.turnId,
+    );
+    ds.streamCardReplyTargetKey = cardReplyTarget.replyTargetKey;
     // This card is now the live one for the current turn. Clear the new-turn
     // pending flag so the next screen_update PATCHes it instead of POSTing a
     // duplicate (the gate above only suppresses cards when disabled+unforced;
@@ -7677,6 +7693,7 @@ function setupWorkerHandlers(
         // POST a second card; the in-flight POST becomes this turn's card.
         if (ds.streamCardId === CARD_POSTING_SENTINEL) break;
         const postingGeneration = ds.streamCardTurnGeneration ?? 0;
+        const cardReplyTarget = captureStreamingCardReplyTarget(ds, msg.turnId);
         ds.streamCardId = CARD_POSTING_SENTINEL;
         try {
           ds.streamCardNonce = randomBytes(4).toString('hex');
@@ -7710,13 +7727,15 @@ function setupWorkerHandlers(
             sessionRuntimeDisplayName(ds, botCfg),
             codexServiceTierBadge(effectiveCliId, ds.codexServiceTier),
           );
-          const postedCardId = await scopedReply(streamCardJson, 'interactive', msg.turnId);
+          const postedCardId = await scopedReply(
+            streamCardJson, 'interactive', cardReplyTarget.turnId,
+          );
           if (!ownsLifecycleMutation()) {
             void deleteMessage(ds.larkAppId, postedCardId).catch(() => { /* best-effort stale-card cleanup */ });
             break;
           }
           ds.streamCardId = postedCardId;
-          ds.streamCardReplyTargetKey = streamingCardReplyTargetKey(ds, msg.turnId);
+          ds.streamCardReplyTargetKey = cardReplyTarget.replyTargetKey;
           // This card IS the current turn's live card — clear the new-turn flag
           // so subsequent screen_updates PATCH it (starting → working) instead of
           // POSTing a second card. Without this, a re-fork that happens while
@@ -8122,14 +8141,15 @@ function setupWorkerHandlers(
           // not POSTed as duplicate cards.
           ds.streamCardPending = false;
           ds.streamCardId = CARD_POSTING_SENTINEL;
-          scopedReply(cardJson, 'interactive', msg.turnId)
+          const cardReplyTarget = captureStreamingCardReplyTarget(ds, msg.turnId);
+          scopedReply(cardJson, 'interactive', cardReplyTarget.turnId)
             .then(msgId => {
               if (!ownsLifecycleMutation()) {
                 void deleteMessage(ds.larkAppId, msgId).catch(() => { /* best-effort stale-card cleanup */ });
                 return;
               }
               ds.streamCardId = msgId;
-              ds.streamCardReplyTargetKey = streamingCardReplyTargetKey(ds, msg.turnId);
+              ds.streamCardReplyTargetKey = cardReplyTarget.replyTargetKey;
               const superseded = (ds.streamCardTurnGeneration ?? 0) !== postingGeneration;
               if (!superseded) ds.streamCardPendingTurnId = undefined;
               ds.parkedStreamCardNonce = undefined;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -25,7 +25,7 @@ import {
   markMessageListenerRunPreviewRunning,
 } from '../services/message-listener-run-preview-store.js';
 import { persistStreamCardState, rememberLastCliInput } from './session-manager.js';
-import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn } from './reply-target.js';
+import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, replyTargetKey } from './reply-target.js';
 import { updateMessage, deleteMessage, sendEphemeralCard, sendUserMessage, addReaction, removeReaction, getMessageChatId, MessageWithdrawnError } from '../im/lark/client.js';
 import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildTuiPromptFailedCard, buildRelayedFrozenCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { codexServiceTierBadge } from '../services/codex-service-tier.js';
@@ -1281,6 +1281,11 @@ function logWorkerStderr(t: string, line: string): void {
 // the first POST returns a real message_id.
 export const CARD_POSTING_SENTINEL = '__posting__';
 
+function streamingCardReplyTargetKey(ds: DaemonSession, turnId?: string): string {
+  const replyContext = frozenReplyContextForTurn(ds, fallbackTurnId(ds, turnId));
+  return replyTargetKey(replyContext.target);
+}
+
 /**
  * Move the current streaming card into `frozenCards` without freezing it
  * cosmetically. The next successful card POST will sweep it via
@@ -1304,6 +1309,7 @@ export function parkStreamCard(ds: DaemonSession): void {
   if (!ds.frozenCards) ds.frozenCards = loadFrozenCards(ds.session.sessionId);
   ds.frozenCards.set(ds.streamCardNonce, {
     messageId: ds.streamCardId,
+    replyTargetKey: ds.streamCardReplyTargetKey,
     content: ds.lastScreenContent ?? '',
     title: ds.currentTurnTitle ?? '',
     displayMode: ds.displayMode ?? 'hidden',
@@ -1320,9 +1326,12 @@ export function parkStreamCard(ds: DaemonSession): void {
 }
 
 /**
- * Delete previously-frozen streaming cards from Lark and clear the cache.
+ * Delete previously-frozen streaming cards from the live card's visible Lark
+ * destination and clear those entries from the cache.
  * Called whenever a new streaming card becomes the active one — old turns'
- * cards just add visual clutter when scrolling thread history.
+ * cards just add visual clutter when scrolling that destination's history.
+ * A chat-scope session may answer in several Lark topics; cards from another
+ * topic remain frozen until a successor is posted in that same topic.
  *
  * Lazy-loads `frozenCards` from disk if the in-memory Map is missing
  * (post daemon-restart). Best-effort delete; failures (already withdrawn,
@@ -1340,9 +1349,15 @@ export function recallFrozenCards(ds: DaemonSession): void {
   const activeId = ds.streamCardId && ds.streamCardId !== CARD_POSTING_SENTINEL
     ? ds.streamCardId
     : undefined;
+  const activeReplyTargetKey = ds.streamCardReplyTargetKey;
   const targets: string[] = [];
   for (const [nonce, fc] of [...ds.frozenCards.entries()]) {
     if (activeId && fc.messageId === activeId) continue;
+    // Legacy sessions have no destination key. Preserve the old sweep-all
+    // behavior only while the live card is also legacy. Once a new card has an
+    // exact destination, fail safe: never withdraw an unattributed card that
+    // may be visible in another topic.
+    if (activeReplyTargetKey && fc.replyTargetKey !== activeReplyTargetKey) continue;
     targets.push(fc.messageId);
     ds.frozenCards.delete(nonce);
   }
@@ -1385,6 +1400,7 @@ export async function postTurnStartingCard(
   const effectiveCliId = sessionCliId(ds, botCfg);
   const previousCardId = ds.streamCardId;
   const previousNonce = ds.streamCardNonce;
+  const previousReplyTargetKey = ds.streamCardReplyTargetKey;
   // A newer turn may have arrived while the previous turn's POST was still in
   // flight, so beginNewTurn could not park that sentinel. Park the now-live
   // predecessor here before replacing its identity.
@@ -1430,6 +1446,7 @@ export async function postTurnStartingCard(
     if (riffRetirementAdmissionPhase(ds) === null || !ownsPostIdentity()) return false;
     ds.streamCardId = previousCardId;
     ds.streamCardNonce = previousNonce;
+    ds.streamCardReplyTargetKey = previousReplyTargetKey;
     persistStreamCardState(ds);
     return true;
   };
@@ -1444,6 +1461,7 @@ export async function postTurnStartingCard(
       return false;
     }
     ds.streamCardId = messageId;
+    ds.streamCardReplyTargetKey = streamingCardReplyTargetKey(ds, turnId);
     ds.parkedStreamCardNonce = undefined;
     const superseded = (ds.streamCardTurnGeneration ?? 0) !== generation;
     if (!superseded) {
@@ -1470,6 +1488,7 @@ export async function postTurnStartingCard(
     }
     ds.streamCardId = previousCardId;
     ds.streamCardNonce = previousNonce;
+    ds.streamCardReplyTargetKey = previousReplyTargetKey;
     persistStreamCardState(ds);
     logger.warn(`[${tag(ds)}] Failed to post starting card for turn ${turnId.substring(0, 12)}: ${err}`);
     if ((ds.streamCardTurnGeneration ?? 0) !== generation && ds.streamCardPendingTurnId) {
@@ -1514,6 +1533,7 @@ export async function postFreshStreamingCard(
   // together so a failed /card leaves no orphaned nonce/pending state).
   const prevCardId = ds.streamCardId;
   const prevNonce = ds.streamCardNonce;
+  const prevReplyTargetKey = ds.streamCardReplyTargetKey;
   const prevPending = ds.streamCardPending;
 
   ds.streamCardNonce = randomBytes(4).toString('hex');
@@ -1540,7 +1560,9 @@ export async function postFreshStreamingCard(
   );
   ds.streamCardId = CARD_POSTING_SENTINEL;
   try {
-    ds.streamCardId = await sessionReply(sessionAnchorId(ds), cardJson, 'interactive', ds.larkAppId, ds.currentReplyTarget?.turnId);
+    const turnId = ds.currentReplyTarget?.turnId;
+    ds.streamCardId = await sessionReply(sessionAnchorId(ds), cardJson, 'interactive', ds.larkAppId, turnId);
+    ds.streamCardReplyTargetKey = streamingCardReplyTargetKey(ds, turnId);
     // This card is now the live one for the current turn. Clear the new-turn
     // pending flag so the next screen_update PATCHes it instead of POSTing a
     // duplicate (the gate above only suppresses cards when disabled+unforced;
@@ -1562,6 +1584,7 @@ export async function postFreshStreamingCard(
   } catch (err) {
     ds.streamCardId = prevCardId;
     ds.streamCardNonce = prevNonce;
+    ds.streamCardReplyTargetKey = prevReplyTargetKey;
     ds.streamCardPending = prevPending;
     flushPendingLocalCliOpenReadinessPatch(ds);
     flushPendingRiffUrlPatch(ds);
@@ -7693,6 +7716,7 @@ function setupWorkerHandlers(
             break;
           }
           ds.streamCardId = postedCardId;
+          ds.streamCardReplyTargetKey = streamingCardReplyTargetKey(ds, msg.turnId);
           // This card IS the current turn's live card — clear the new-turn flag
           // so subsequent screen_updates PATCH it (starting → working) instead of
           // POSTing a second card. Without this, a re-fork that happens while
@@ -8105,6 +8129,7 @@ function setupWorkerHandlers(
                 return;
               }
               ds.streamCardId = msgId;
+              ds.streamCardReplyTargetKey = streamingCardReplyTargetKey(ds, msg.turnId);
               const superseded = (ds.streamCardTurnGeneration ?? 0) !== postingGeneration;
               if (!superseded) ds.streamCardPendingTurnId = undefined;
               ds.parkedStreamCardNonce = undefined;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4357,6 +4357,7 @@ function beginNewTurn(ds: DaemonSession, title: string, turnId: string): void {
       ds.parkedStreamCardNonce = ds.streamCardNonce;
       ds.frozenCards.set(ds.streamCardNonce, {
         messageId: ds.streamCardId,
+        replyTargetKey: ds.streamCardReplyTargetKey,
         content: ds.lastScreenContent ?? '',
         title: prevTitle,
         displayMode: prevMode,

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -88,7 +88,7 @@ import { forkWorker, sendWorkerInput, sendWorkerSessionInput, killWorker, closeS
 import { getSessionWorkingDir, buildNewTopicCliInput, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput, ensureSessionWhiteboard } from '../../core/session-manager.js';
 import { markInitialUserTurnPending } from '../../core/initial-user-turn.js';
 import { publishAttentionPatch, publishClosedSessionPatch, announcePendingRepoSession } from '../../core/session-activity.js';
-import { fallbackTurnId } from '../../core/reply-target.js';
+import { fallbackTurnId, rehomeReplyTargetState } from '../../core/reply-target.js';
 import { sendWorkerIpc } from '../../core/worker-ipc.js';
 import { validateWorkingDir } from '../../core/working-dir.js';
 import type { DaemonToWorker, DisplayMode, TermActionKey } from '../../types.js';
@@ -747,6 +747,7 @@ export async function commitRepoSelection(
         }
         current.streamCardId = undefined;
         current.streamCardNonce = undefined;
+        rehomeReplyTargetState(current);
         current.streamCardPending = undefined;
         current.lastScreenContent = undefined;
         current.lastScreenStatus = undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -419,6 +419,8 @@ export interface Session {
    *  (rather than a fresh POST) after daemon restart. */
   streamCardId?: string;
   streamCardNonce?: string;
+  /** Stable visible destination of the persisted live streaming card. */
+  streamCardReplyTargetKey?: string;
   /** Legacy field kept for migrating sessions persisted before displayMode was added. */
   streamExpanded?: boolean;
   /** Card body display mode — 'hidden' | 'screenshot'. */

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -1023,12 +1023,27 @@ describe('repo select card — plain switch', () => {
     const originalRoot = 'om_original_chat_start';
     const ds = makeDs({
       scope: 'chat',
+      currentReplyTarget: {
+        rootMessageId: 'om_old_reply_topic',
+        turnId: 'turn-old',
+        updatedAt: new Date().toISOString(),
+      },
+      replyThreadAliases: {
+        om_old_reply_topic: {
+          createdAt: new Date().toISOString(),
+          lastUsedAt: new Date().toISOString(),
+        },
+      },
+      streamCardReplyTargetKey: 'thread:om_old_reply_topic',
       session: {
         ...makeDs().session,
         scope: 'chat',
         rootMessageId: originalRoot,
       },
     });
+    ds.session.currentReplyTarget = ds.currentReplyTarget;
+    ds.session.replyThreadAliases = ds.replyThreadAliases;
+    ds.session.streamCardReplyTargetKey = 'thread:om_old_reply_topic';
     ds.session.workingDir = '/repos/gamma';
     const activeSessions = new Map([[sessionKey(CHAT_ID, APP_ID), ds]]);
     const sessionReply = vi.fn(async () => 'om_reply');
@@ -1050,6 +1065,12 @@ describe('repo select card — plain switch', () => {
     expect(createSession).toHaveBeenCalledWith(CHAT_ID, originalRoot, 'beta (main)', 'group', 'chat');
     expect(ds.session.scope).toBe('chat');
     expect(ds.session.rootMessageId).toBe(originalRoot);
+    expect(ds.currentReplyTarget).toBeUndefined();
+    expect(ds.replyThreadAliases).toBeUndefined();
+    expect(ds.streamCardReplyTargetKey).toBeUndefined();
+    expect(ds.session.currentReplyTarget).toBeUndefined();
+    expect(ds.session.replyThreadAliases).toBeUndefined();
+    expect(ds.session.streamCardReplyTargetKey).toBeUndefined();
     const persisted = vi.mocked(updateSession).mock.calls.find(
       ([s]) => s.sessionId.startsWith('uuid-new-'),
     )?.[0];

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -2634,8 +2634,23 @@ describe('handleCommand', () => {
       const ds = makeDaemonSession({
         pendingRepo: false,
         scope: 'chat',
+        currentReplyTarget: {
+          rootMessageId: 'om_old_reply_topic',
+          turnId: 'turn-old',
+          updatedAt: new Date().toISOString(),
+        },
+        replyThreadAliases: {
+          om_old_reply_topic: {
+            createdAt: new Date().toISOString(),
+            lastUsedAt: new Date().toISOString(),
+          },
+        },
+        streamCardReplyTargetKey: 'thread:om_old_reply_topic',
         session: makeSession({ scope: 'chat', rootMessageId: originalRoot }),
       });
+      ds.session.currentReplyTarget = ds.currentReplyTarget;
+      ds.session.replyThreadAliases = ds.replyThreadAliases;
+      ds.session.streamCardReplyTargetKey = 'thread:om_old_reply_topic';
       const deps = makeDeps(ds);
       deps.activeSessions.clear();
       deps.activeSessions.set(sessionKey(CHAT_ID, LARK_APP_ID), ds);
@@ -2652,6 +2667,12 @@ describe('handleCommand', () => {
       );
       expect(ds.session.scope).toBe('chat');
       expect(ds.session.rootMessageId).toBe(originalRoot);
+      expect(ds.currentReplyTarget).toBeUndefined();
+      expect(ds.replyThreadAliases).toBeUndefined();
+      expect(ds.streamCardReplyTargetKey).toBeUndefined();
+      expect(ds.session.currentReplyTarget).toBeUndefined();
+      expect(ds.session.replyThreadAliases).toBeUndefined();
+      expect(ds.session.streamCardReplyTargetKey).toBeUndefined();
       const persisted = vi.mocked(sessionStore.updateSession).mock.calls.find(
         ([s]) => s.sessionId === 'new-session-123',
       )?.[0];

--- a/test/frozen-card-store.test.ts
+++ b/test/frozen-card-store.test.ts
@@ -237,7 +237,7 @@ describe('deleteFrozenCards', () => {
 describe('round-trip: save then load', () => {
   it('returns the same data after save + load', () => {
     const cards = new Map<string, FrozenCard>();
-    cards.set('nonce_1', makeFrozenCard({ messageId: 'om_111', content: 'snap 1', title: 'T1', expanded: false }));
+    cards.set('nonce_1', makeFrozenCard({ messageId: 'om_111', replyTargetKey: 'thread:om_topic_1', content: 'snap 1', title: 'T1', expanded: false }));
     cards.set('nonce_2', makeFrozenCard({ messageId: 'om_222', content: 'snap 2', title: 'T2', expanded: true }));
 
     saveFrozenCards('round-trip', cards);

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -325,6 +325,26 @@ describe('recallFrozenCards', () => {
     expect(deleteMessageMock).toHaveBeenCalledTimes(1);
     expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_only');
   });
+
+  it('withdraws only frozen cards from the live card reply target', () => {
+    const map = new Map<string, FrozenCard>();
+    map.set('topic_a', makeFrozen('om_card_a', { replyTargetKey: 'thread:om_topic_a' }));
+    map.set('topic_b', makeFrozen('om_card_b', { replyTargetKey: 'thread:om_topic_b' }));
+    map.set('legacy', makeFrozen('om_card_legacy'));
+    const ds = makeDs(map);
+    ds.streamCardId = 'om_card_b_live';
+    ds.streamCardReplyTargetKey = 'thread:om_topic_b';
+
+    recallFrozenCards(ds);
+
+    expect(deleteMessageMock).toHaveBeenCalledTimes(1);
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_card_b');
+    expect(ds.frozenCards?.has('topic_a')).toBe(true);
+    expect(ds.frozenCards?.has('topic_b')).toBe(false);
+    // Old persisted cards have no trustworthy topic attribution. Once the live
+    // card does, fail safe instead of potentially withdrawing another topic.
+    expect(ds.frozenCards?.has('legacy')).toBe(true);
+  });
 });
 
 describe('restoreUsageLimitRuntimeState', () => {
@@ -485,6 +505,45 @@ describe('postTurnStartingCard', () => {
     expect(ds.streamCardId).toBe('om_turn_card_1');
     expect(ds.streamCardPending).toBe(false);
     expect(ds.streamCardPendingTurnId).toBeUndefined();
+  });
+
+  it('isolates frozen-card cleanup when one chat session moves A to B to A', async () => {
+    const ds = makeDs();
+    ds.scope = 'chat';
+    ds.workerReady = true;
+    ds.streamCardId = 'om_card_a1';
+    ds.streamCardNonce = 'nonce_a1';
+    ds.streamCardReplyTargetKey = 'thread:om_topic_a';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_b1';
+    ds.currentTurnTitle = 'topic B';
+    ds.session.turnReplyContexts = {
+      om_turn_b1: { target: { mode: 'thread', rootMessageId: 'om_topic_b' } },
+      om_turn_a2: { target: { mode: 'thread', rootMessageId: 'om_topic_a' } },
+    };
+    const sessionReply = vi.fn()
+      .mockResolvedValueOnce('om_card_b1')
+      .mockResolvedValueOnce('om_card_a2');
+
+    await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_b1')).resolves.toBe(true);
+
+    expect(ds.streamCardReplyTargetKey).toBe('thread:om_topic_b');
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+    expect([...ds.frozenCards!.values()].map(card => card.messageId)).toEqual(['om_card_a1']);
+
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 2;
+    ds.streamCardPendingTurnId = 'om_turn_a2';
+    ds.currentTurnTitle = 'topic A again';
+
+    await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_a2')).resolves.toBe(true);
+
+    expect(ds.streamCardReplyTargetKey).toBe('thread:om_topic_a');
+    expect(deleteMessageMock).toHaveBeenCalledTimes(1);
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_card_a1');
+    expect([...ds.frozenCards!.values()].map(card => card.messageId)).toEqual(['om_card_b1']);
+    expect([...ds.frozenCards!.values()][0]?.replyTargetKey).toBe('thread:om_topic_b');
   });
 
   it('posts the newest queued turn after an older card POST finishes', async () => {

--- a/test/reply-target-fallback.test.ts
+++ b/test/reply-target-fallback.test.ts
@@ -21,6 +21,7 @@ import {
   frozenReplyContextForTurn,
   isSubstituteTurn,
   pickTurnReplyTarget,
+  rehomeReplyTargetState,
   resolveInboundReplyTarget,
   resolveSessionReplyTarget,
 } from '../src/core/reply-target.js';
@@ -111,6 +112,84 @@ describe('fallbackTurnId × resolveSessionReplyTarget (the leak fix)', () => {
     });
     const target = resolveSessionReplyTarget(ds, fallbackTurnId(ds as DaemonSession, undefined));
     expect(target).toEqual({ mode: 'quote', rootMessageId: 'om_trigger' });
+  });
+});
+
+describe('rehomeReplyTargetState', () => {
+  it('removes source-topic routing authority while preserving buffered-turn attribution', () => {
+    const ds = makeDs({
+      scope: 'thread',
+      chatId: 'oc_target',
+      currentReplyTarget: {
+        rootMessageId: 'om_source_topic',
+        turnId: 'turn-source',
+        updatedAt: NOW,
+        quoteOnly: true,
+      },
+      replyThreadAliases: {
+        om_source_topic: { createdAt: NOW, lastUsedAt: NOW },
+      },
+      streamCardReplyTargetKey: 'thread:om_source_topic',
+    });
+    ds.session.chatId = 'oc_target';
+    ds.session.rootMessageId = 'om_target_topic';
+    ds.session.scope = 'thread';
+    ds.session.currentReplyTarget = ds.currentReplyTarget;
+    ds.session.replyThreadAliases = ds.replyThreadAliases;
+    ds.session.streamCardReplyTargetKey = 'thread:om_source_topic';
+    ds.session.quoteTargetId = 'om_source_message';
+    ds.session.quoteTargetSenderOpenId = 'ou_source';
+    ds.session.quoteTargetSenderIsBot = false;
+    ds.session.turnReplyContexts = {
+      'turn-source': {
+        target: { mode: 'thread', rootMessageId: 'om_source_topic' },
+        quoteTargetId: 'om_source_message',
+        replyTargetSenderOpenId: 'ou_source',
+        replyTargetSenderIsBot: false,
+      },
+    };
+    ds.session.replyTargets = {
+      'turn-source': {
+        rootMessageId: 'om_source_topic',
+        updatedAt: NOW,
+        quoteOnly: true,
+        substitute: true,
+        senderOpenId: 'ou_source',
+        participants: [{ openId: 'ou_source', isBot: false }],
+        participantsIncomplete: true,
+      },
+    };
+
+    rehomeReplyTargetState(ds as DaemonSession);
+
+    expect(ds.currentReplyTarget).toBeUndefined();
+    expect(ds.replyThreadAliases).toBeUndefined();
+    expect(ds.streamCardReplyTargetKey).toBeUndefined();
+    expect(ds.session.currentReplyTarget).toBeUndefined();
+    expect(ds.session.replyThreadAliases).toBeUndefined();
+    expect(ds.session.streamCardReplyTargetKey).toBeUndefined();
+    expect(ds.session.quoteTargetId).toBeUndefined();
+    expect(ds.session.quoteTargetSenderOpenId).toBeUndefined();
+    expect(ds.session.quoteTargetSenderIsBot).toBeUndefined();
+    expect(ds.session.turnReplyContexts).toEqual({
+      'turn-source': {
+        target: { mode: 'thread', rootMessageId: 'om_target_topic' },
+        replyTargetSenderOpenId: 'ou_source',
+        replyTargetSenderIsBot: false,
+      },
+    });
+    expect(ds.session.replyTargets).toEqual({
+      'turn-source': {
+        updatedAt: NOW,
+        senderOpenId: 'ou_source',
+        participants: [{ openId: 'ou_source', isBot: false }],
+        participantsIncomplete: true,
+      },
+    });
+    expect(frozenReplyContextForTurn(ds as DaemonSession, 'turn-source').target).toEqual({
+      mode: 'thread',
+      rootMessageId: 'om_target_topic',
+    });
   });
 });
 

--- a/test/transfer-session.test.ts
+++ b/test/transfer-session.test.ts
@@ -219,6 +219,68 @@ describe('transferSession', () => {
     expect(registry.has(sessionKey('om_dm_topic_root', 'cli_app_test'))).toBe(true);
   });
 
+  it('re-homes buffered reply metadata so the resumed worker cannot route back to the source topic', async () => {
+    const ds = makeDs({
+      currentReplyTarget: {
+        rootMessageId: 'om_source_reply',
+        turnId: 'turn-source',
+        updatedAt: new Date().toISOString(),
+      },
+      replyThreadAliases: {
+        om_source_reply: {
+          createdAt: new Date().toISOString(),
+          lastUsedAt: new Date().toISOString(),
+        },
+      },
+      streamCardReplyTargetKey: 'thread:om_source_reply',
+    });
+    ds.session.currentReplyTarget = ds.currentReplyTarget;
+    ds.session.replyThreadAliases = ds.replyThreadAliases;
+    ds.session.streamCardReplyTargetKey = 'thread:om_source_reply';
+    ds.session.turnReplyContexts = {
+      'turn-source': {
+        target: { mode: 'thread', rootMessageId: 'om_source_reply' },
+        quoteTargetId: 'om_source_message',
+        replyTargetSenderOpenId: 'ou_user',
+      },
+    };
+    ds.session.replyTargets = {
+      'turn-source': {
+        rootMessageId: 'om_source_reply',
+        quoteOnly: true,
+        substitute: true,
+        updatedAt: new Date().toISOString(),
+        senderOpenId: 'ou_user',
+      },
+    };
+    registry.set(sessionKey('om_source_root', 'cli_app_test'), ds);
+
+    const result = await callTransfer(
+      ds.session.sessionId,
+      'oc_target',
+      'om_target_topic',
+      'group',
+      'thread',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(ds.currentReplyTarget).toBeUndefined();
+    expect(ds.replyThreadAliases).toBeUndefined();
+    expect(ds.streamCardReplyTargetKey).toBeUndefined();
+    expect(ds.session.currentReplyTarget).toBeUndefined();
+    expect(ds.session.replyThreadAliases).toBeUndefined();
+    expect(ds.session.streamCardReplyTargetKey).toBeUndefined();
+    expect(ds.session.turnReplyContexts?.['turn-source']).toEqual({
+      target: { mode: 'thread', rootMessageId: 'om_target_topic' },
+      replyTargetSenderOpenId: 'ou_user',
+    });
+    expect(ds.session.replyTargets?.['turn-source']).toEqual({
+      updatedAt: expect.any(String),
+      senderOpenId: 'ou_user',
+    });
+    expect(sessionStore.updateSession).toHaveBeenCalledWith(ds.session);
+  });
+
   it('returns session_not_active when sessionId not in registry', async () => {
     const r = await callTransfer('does-not-exist', 'oc_target', 'om_target_root');
     expect(r.ok).toBe(false);

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -350,6 +350,83 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(logs).not.toContain('view_cap');
   });
 
+  it('ready POST keeps the dispatch-time topic when currentReplyTarget changes while awaiting Lark', async () => {
+    let resolvePost!: (messageId: string) => void;
+    sessionReplyMock.mockImplementationOnce(() => new Promise<string>((resolve) => {
+      resolvePost = resolve;
+    }));
+    const now = new Date().toISOString();
+    const targetA = { rootMessageId: 'om_topic_a', turnId: 'om_turn_a', updatedAt: now };
+    const targetB = { rootMessageId: 'om_topic_b', turnId: 'om_turn_b', updatedAt: now };
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'chat',
+      currentReplyTarget: targetA,
+      session: {
+        ...makeDs().session,
+        scope: 'chat',
+        currentReplyTarget: targetA,
+        replyTargets: { om_turn_a: targetA, om_turn_b: targetB },
+      },
+      streamCardPending: true,
+      streamCardId: undefined,
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+
+    expect(sessionReplyMock.mock.calls[0][4]).toBe('om_turn_a');
+    ds.currentReplyTarget = targetB;
+    ds.session.currentReplyTarget = targetB;
+    resolvePost('om_new_card');
+    await flush();
+
+    expect(ds.streamCardReplyTargetKey).toBe('thread:om_topic_a');
+  });
+
+  it('screen_update POST keeps the dispatch-time topic when currentReplyTarget changes while awaiting Lark', async () => {
+    let resolvePost!: (messageId: string) => void;
+    sessionReplyMock.mockImplementationOnce(() => new Promise<string>((resolve) => {
+      resolvePost = resolve;
+    }));
+    const now = new Date().toISOString();
+    const targetA = { rootMessageId: 'om_topic_a', turnId: 'om_turn_a', updatedAt: now };
+    const targetB = { rootMessageId: 'om_topic_b', turnId: 'om_turn_b', updatedAt: now };
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      scope: 'chat',
+      currentReplyTarget: targetA,
+      session: {
+        ...makeDs().session,
+        scope: 'chat',
+        currentReplyTarget: targetA,
+        replyTargets: { om_turn_a: targetA, om_turn_b: targetB },
+      },
+      streamCardPending: true,
+      streamCardId: undefined,
+      workerReady: true,
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', {
+      type: 'screen_update',
+      content: 'working in topic A',
+      status: 'working',
+    });
+    await flush();
+
+    expect(sessionReplyMock.mock.calls[0][4]).toBe('om_turn_a');
+    ds.currentReplyTarget = targetB;
+    ds.session.currentReplyTarget = targetB;
+    resolvePost('om_new_card');
+    await flush();
+
+    expect(ds.streamCardReplyTargetKey).toBe('thread:om_topic_a');
+  });
+
   it('treats port=0 as ready without Web Terminal and keeps screen/screenshot state flowing', async () => {
     const fakeWorker = makeFakeWorker();
     const ds = makeDs({


### PR DESCRIPTION
## 问题

BotMux 3.14.0 的 chat-scope 会话可以把不同飞书话题的 turn 路由到同一个 session/worker。每轮回复的目标已经按 turn 冻结，因此新卡片会发到正确话题；但流式卡片清理仍按整个 session 执行。

实际表现是：

1. 话题 A 发消息，出现流式卡片 A。
2. 同一个 chat-scope session 在话题 B 接受新 turn，卡片 B 正确发到话题 B。
3. 卡片 B 发布成功后，`recallFrozenCards()` 撤回卡片 A。
4. 再切回话题 A，会反过来撤回话题 B 的卡片。

脱敏后的现场日志结构如下：

```text
Reply in chat-scope session ...
Replied ... to message <topic-A-or-B-root> [msgType=interactive, replyInThread=true]
[session] Recalled 1 previous streaming card(s)
[session] Posted starting card for turn ...
```

上游仓库限制外部账号创建 Issue，因此这里直接在 PR 中保留完整问题说明和修复。

## 根因

- `FrozenCard` 只保存 `messageId/content/title/...`，没有保存卡片实际发往哪个飞书回复目标。
- live card 使用单个 `streamCardId/streamCardNonce`，但没有与其绑定的稳定回复目标。
- `currentReplyTarget` 会被后来接受的 turn 覆盖，不能用它反推上一张 live card 的归属。
- 新卡片发布成功后，`recallFrozenCards()` 遍历并撤回 session 内全部旧卡片，所以会跨话题删除。

共享 session/worker 是 `chat`/`shared` 模式的既有语义；本 PR 只修复卡片被跨话题撤回，不改变会话上下文共享方式。

## 修复

- 为 live card 和 frozen card 增加稳定的 `replyTargetKey`，区分：
  - `plain:oc_*`：群顶层消息；
  - `thread:om_*`：话题内回复；
  - `quote:om_*`：普通引用回复。
- 每次卡片 POST 发出前，一次性捕获 effective turn 和 reply target key；请求完成后直接提交捕获值，不再从可能已被覆盖的会话状态重新计算。
- parking/freezing 时把 live card 的原目标一同保存。
- `recallFrozenCards()` 只撤回与新 live card 目标相同的旧卡片；其他话题的卡片继续保留，等该话题自己的下一张卡片成功发布后再清理。
- 将 live card 的目标随 session 持久化，daemon 重启后仍能正确归属。
- 对升级前没有目标信息的历史卡片采取 fail-safe：一旦新 live card 已有精确目标，不冒险撤回归属未知的旧卡片。

## 影响面

- 改动位于公共 `worker-pool` 流式卡片路径，对所有 CLI/后端共用；没有修改 CLI 输入、worker 调度或会话路由。
- thread-scope 和普通群顶层会话的目标 key 始终相同，仍保持“新卡片成功后清理上一张”的原行为。
- chat/shared 跨话题场景改为按话题清理。
- new-topic 模式本来就是独立 session，不改变其行为。
- POST 失败仍会恢复上一张卡片的 ID、nonce 和目标，不会提前撤回可见卡片。

## 验证

```text
pnpm build
✓ TypeScript、Dashboard bundle、dist audit 通过

pnpm test -- \
  test/recall-frozen-cards.test.ts \
  test/frozen-card-store.test.ts \
  test/worker-ready-display-mode.test.ts \
  test/session-adopt.test.ts \
  test/usage-refresh-timer-wiring.test.ts \
  test/session-lifecycle-start.test.ts
✓ 6 files / 235 tests passed
```

新增回归覆盖：

- session 内同时存在 A/B 两个话题的 frozen card，只撤回当前目标的卡片；
- A → B 时保留 A；
- A → B → A 时只撤回旧 A，保留 B；
- `replyTargetKey` 可随 frozen-card store 完整持久化。

全量 `pnpm test` 在本机运行超过 180 秒后被超时终止；其中 `codex-app-runner.integration.test.ts` 有 42 个环境相关失败。上述受影响路径的定向测试和完整 build 均已通过。

未切换 live daemon 到本 worktree，避免影响当前机器上其他正在运行的 BotMux 会话。

## 后续审查补充：会话迁移边界

进一步复核发现，`/relay` 和 mid-session `/repo` 会复用同一个 `DaemonSession`，但原实现只改写 Session/飞书锚点，旧话题的 `currentReplyTarget`、`turnReplyContexts`、`replyTargets`、alias 和 live-card target key 仍可能留在运行态。replacement worker 的 `ready` 没有 turnId 时，这些旧状态可把新卡片或回复重新路由/标记到来源话题。

本次补充修复：

- 在跨飞书目标迁移时，把仍需保留的 buffered-turn sender/participant 信息保留下来，但将所有可见回复目标统一重定位到新 session 的 canonical surface。
- 清除旧话题 alias、current/quote target 和 live-card target key，确保来源消息 ID 不再具有路由权限。
- 同一规则覆盖 `/relay`、卡片 repo switch、文本 `/repo` switch 三条生命周期路径。
- 新增 helper、transfer、卡片切仓和文本切仓回归测试。

最新验证：

```text
当前分支：11 files / 681 tests passed
pnpm build passed

模拟合并 upstream/master (f92664b1)：
10 files / 673 tests passed
pnpm build passed
```
