### PR TITLE
fix: hide trailing memory citation metadata

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10774,6 +10774,7 @@ async function cmdReport(rest: string[]): Promise<void> {
     const pos = positionals(rest, ['--top-level', '--legacy-dispatch']);
     content = pos.length ? pos.join(' ') : await readStdin();
   }
+  content = stripTrailingOaiMemoryCitation(content);
   if (!contentFile) rejectLikelyWindowsStdinMojibake(content);
   if (!content.trim()) {
     console.error('没有回报内容。用法: botmux report "子项目X 完成 + 产出位置"');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -230,6 +230,7 @@ import {
 import {
   buildBridgeSendMarkerContent,
   buildBridgeSendPreviewText,
+  stripTrailingOaiMemoryCitation,
 } from './services/bridge-fallback-gate.js';
 import {
   bindRestartLeaseTo,
@@ -8002,6 +8003,7 @@ async function relaySend(
     const pos = positionals(rest, ['--card', '--text', '--top-level', '--no-quote', '--mention-back', '--no-mention', '--anyway', '--voice', '--slash']);
     content = pos.length > 0 ? pos.join(' ') : await readStdin();
   }
+  content = stripTrailingOaiMemoryCitation(content);
   const preparedCardContent = cardJsonArg === undefined && cardFile === undefined && !rest.includes('--voice')
     ? prepareCardMarkdown(extractCardText(content), process.cwd(), 'filesystem')
     : undefined;
@@ -9083,6 +9085,9 @@ async function cmdSend(rest: string[]): Promise<void> {
       content = await readStdin();
     }
   }
+  // Keep memory attribution in the model's rollout, but never render the
+  // complete internal suffix into Lark or count it in send markers.
+  content = stripTrailingOaiMemoryCitation(content);
   if (!contentFile && !customCardRequested) rejectLikelyWindowsStdinMojibake(content);
 
   const managedPayloadError = managedVcSendPayloadError({
@@ -9815,8 +9820,8 @@ async function cmdSend(rest: string[]): Promise<void> {
 
   try {
     // A file-sandbox relay supplies a host-private copy normalized inside the
-    // sandbox namespace. Voice/doc-comment paths returned above and therefore
-    // continue using the untouched raw content.
+    // sandbox namespace. Voice/doc-comment paths returned above use the same
+    // already-sanitized outbound content, without card-markdown preparation.
     let text = extractCardText(content);
     const preparedContentFile = process.env.BOTMUX_CARD_PREPARED_CONTENT_FILE;
     if (preparedContentFile) {

--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -64,6 +64,30 @@ export const BRIDGE_NOTHING_TO_SEND_SENTINEL = 'BOTMUX_NOTHING_TO_SEND';
  *  instruction surface moved to the new name. */
 export const BRIDGE_NO_REPLY_SENTINEL_LEGACY = 'BOTMUX_NO_REPLY';
 
+const OAI_MEMORY_CITATION_OPEN = '<oai-mem-citation>';
+const OAI_MEMORY_CITATION_SUFFIX = /^<oai-mem-citation>\s*<citation_entries>[\s\S]*?<\/citation_entries>\s*<rollout_ids>[\s\S]*?<\/rollout_ids>\s*<\/oai-mem-citation>\s*$/;
+
+/** Remove TraeX/Codex's internal memory-attribution envelope when it is a
+ * complete suffix of an outbound answer. The rollout keeps the block in its
+ * source transcript; only the copy headed to a user-facing surface is cleaned.
+ *
+ * Deliberately conservative:
+ *   - the block must begin at a line boundary and be the final non-whitespace
+ *     content;
+ *   - both required child sections and every closing tag must be present;
+ *   - inline/mid-body mentions, malformed blocks, and fenced examples (whose
+ *     closing fence follows the XML) are preserved verbatim. */
+export function stripTrailingOaiMemoryCitation(text: string): string {
+  const start = text.lastIndexOf(OAI_MEMORY_CITATION_OPEN);
+  if (start < 0) return text;
+  if (start > 0 && text[start - 1] !== '\n' && text[start - 1] !== '\r') return text;
+  if (!OAI_MEMORY_CITATION_SUFFIX.test(text.slice(start))) return text;
+
+  // Remove the blank-line separator that belonged to the metadata suffix, but
+  // otherwise leave the visible answer byte-for-byte unchanged.
+  return text.slice(0, start).replace(/[ \t]*(?:\r?\n[ \t]*)+$/, '');
+}
+
 const BRIDGE_SENTINEL_TOKENS: readonly string[] = [
   BRIDGE_NOTHING_TO_SEND_SENTINEL,
   BRIDGE_NO_REPLY_SENTINEL_LEGACY,
@@ -71,6 +95,7 @@ const BRIDGE_SENTINEL_TOKENS: readonly string[] = [
 
 export function isBridgeNothingToSendFinal(finalText: string | undefined): boolean {
   if (finalText === undefined) return false;
+  const visibleFinalText = stripTrailingOaiMemoryCitation(finalText);
   // "Genuine silence" signal: the final, after stripping a trailing sentinel
   // line, has NOTHING left. This is the #554 case the sentinel exists for — the
   // model was triggered (e.g. ambient group chatter, or a message addressed to
@@ -86,8 +111,8 @@ export function isBridgeNothingToSendFinal(finalText: string | undefined): boole
   // that already `botmux send`-ed is still suppressed, but an un-sent answer is
   // delivered instead of lost). Only a final that is EMPTY once the sentinel is
   // stripped counts as silence here.
-  return stripTrailingBridgeSentinelLine(finalText).trim().length === 0
-    && hasTrailingBridgeSentinelLine(finalText);
+  return stripTrailingBridgeSentinelLine(visibleFinalText).trim().length === 0
+    && hasTrailingBridgeSentinelLine(visibleFinalText);
 }
 
 /** True when the LAST non-empty line of `finalText` is exactly a sentinel token
@@ -153,19 +178,17 @@ export function stripTrailingBridgeSentinelLine(finalText: string): string {
  *  NON-ADOPT: strip a trailing sentinel line so the literal token never reaches
  *  Lark (prose+sentinel = the "did work, forgot to send" shape → post the prose).
  *
- *  ADOPT: return the text VERBATIM. The adopted CLI is botmux-unaware, transcript
- *  drain is its only channel to Lark, and it may legitimately output the literal
- *  sentinel string as content. shouldSuppressBridgeEmit(adoptMode) already
- *  refuses to interpret the sentinel; stripping here would break that contract
- *  (a real answer ending in the token would be truncated, and a verbatim token
- *  reply would be dropped by the caller's empty-guard). Callers must gate their
- *  own "skip if empty after post" check on !adoptMode to match.
+ *  ADOPT: preserve sentinel text verbatim. The adopted CLI is botmux-unaware,
+ *  transcript drain is its only channel to Lark, and it may legitimately output
+ *  that literal sentinel as content. Internal memory-citation metadata is still
+ *  removed in both modes because it is never user-facing answer content.
  *
  *  Shared by emitReadyTurns and emitReadyCodexTurns so the per-mode rule lives in
  *  one place and is unit-tested directly. codex-app does not use adopt and drives
  *  its own strip on the deliverable content path. */
 export function bridgePostText(finalText: string, adoptMode: boolean): string {
-  return adoptMode ? finalText : stripTrailingBridgeSentinelLine(finalText);
+  const withoutMemoryCitation = stripTrailingOaiMemoryCitation(finalText);
+  return adoptMode ? withoutMemoryCitation : stripTrailingBridgeSentinelLine(withoutMemoryCitation);
 }
 
 export interface BridgeSendMarker {
@@ -218,14 +241,15 @@ export function buildBridgeSendPreviewText(content: string): string | undefined 
 export function buildBridgeSendMarkerContent(
   content: string,
 ): Pick<BridgeSendMarker, 'contentLength' | 'previewText'> | undefined {
-  const normalized = normaliseForFingerprint(content);
+  const visibleContent = stripTrailingOaiMemoryCitation(content);
+  const normalized = normaliseForFingerprint(visibleContent);
   if (!normalized) return undefined;
   return {
     // Length stays fingerprint-normalized: the fallback gate compares it against
     // normalise(finalText).length, so it must not count preview-only newlines.
     contentLength: normalized.length,
     // Preview keeps newlines — derive it from the raw body, NOT `normalized`.
-    previewText: buildBridgeSendPreviewText(content),
+    previewText: buildBridgeSendPreviewText(visibleContent),
   };
 }
 
@@ -284,8 +308,11 @@ export function shouldSuppressBridgeEmit(
   //     stripped prose is forwarded by the length check below (markers empty →
   //     markerSetCoversFinal=false → not suppressed → caller posts it).
   // A final WITHOUT a trailing sentinel keeps the pure length-based behavior.
-  if (turn.finalText !== undefined
-      && hasTrailingBridgeSentinelLine(turn.finalText)
+  const visibleFinalText = turn.finalText === undefined
+    ? undefined
+    : stripTrailingOaiMemoryCitation(turn.finalText);
+  if (visibleFinalText !== undefined
+      && hasTrailingBridgeSentinelLine(visibleFinalText)
       && markersInWindow.length > 0) {
     return true;
   }
@@ -294,9 +321,9 @@ export function shouldSuppressBridgeEmit(
   // length used for the material-longer check must match what actually posts —
   // otherwise the trailing sentinel line inflates the final past a same-content
   // `botmux send` and defeats dedup.
-  const gatedFinal = turn.finalText === undefined
+  const gatedFinal = visibleFinalText === undefined
     ? undefined
-    : stripTrailingBridgeSentinelLine(turn.finalText);
+    : stripTrailingBridgeSentinelLine(visibleFinalText);
   return markerSetCoversFinal(markersInWindow, gatedFinal);
 }
 

--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -65,7 +65,7 @@ export const BRIDGE_NOTHING_TO_SEND_SENTINEL = 'BOTMUX_NOTHING_TO_SEND';
 export const BRIDGE_NO_REPLY_SENTINEL_LEGACY = 'BOTMUX_NO_REPLY';
 
 const OAI_MEMORY_CITATION_OPEN = '<oai-mem-citation>';
-const OAI_MEMORY_CITATION_SUFFIX = /^<oai-mem-citation>\s*<citation_entries>[\s\S]*?<\/citation_entries>\s*<rollout_ids>[\s\S]*?<\/rollout_ids>\s*<\/oai-mem-citation>\s*$/;
+const OAI_MEMORY_CITATION_SUFFIX = /^<oai-mem-citation>\s*<citation_entries>(?:(?!<\/citation_entries>)[\s\S])*?<\/citation_entries>\s*<rollout_ids>(?:(?!<\/rollout_ids>)[\s\S])*?<\/rollout_ids>\s*<\/oai-mem-citation>\s*$/;
 
 /** Remove TraeX/Codex's internal memory-attribution envelope when it is a
  * complete suffix of an outbound answer. The rollout keeps the block in its

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -44,7 +44,7 @@ import { readProcessStartIdentity } from './core/session-marker.js';
 import { roleLibraryRoot, roleLibrarySubtree } from './core/role-library.js';
 import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
-import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, structuredFallbackKind, stripTrailingBridgeSentinelLine, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
+import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, structuredFallbackKind, stripTrailingOaiMemoryCitation, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { buildSubmitMessagePreview } from './services/submit-notification.js';
 import {
   decideHardTimeoutAction,
@@ -4017,7 +4017,8 @@ function failedBridgeFallbackContent(errorCode?: string, summary?: string, parti
         ? 'worker.empty_final_failed_connection'
         : 'worker.empty_final_failed';
   const failure = t(key, { cliName: cliName(), reason });
-  return partialText?.trim() ? `${partialText.trim()}\n\n${failure}` : failure;
+  const visiblePartialText = stripTrailingOaiMemoryCitation(partialText ?? '').trim();
+  return visiblePartialText ? `${visiblePartialText}\n\n${failure}` : failure;
 }
 
 // ─── Bridge fallback marker (non-adopt) ────────────────────────────────────
@@ -8537,12 +8538,12 @@ async function handleTrustedCodexAppMarker(
       log(`${cliName()} native turn ${nativeTurnId.substring(0, 12)} mapped to botmux turn ${turnId.substring(0, 12)}`);
     }
     let suppressDelivery = false;
-    // What actually reaches Lark: strip a trailing sentinel line so the literal
-    // token never posts. `finalContent` stays RAW above (the steer_superseded
-    // validator asserts finalContent==='' and must see the unstripped payload).
-    // If nothing remains after stripping, this was a pure-silence final → treat
-    // as suppressed so the daemon persists the FIFO advance without delivering.
-    const deliverableContent = stripTrailingBridgeSentinelLine(finalContent);
+    // What actually reaches Lark: strip internal memory attribution and a
+    // trailing sentinel line. `finalContent` stays RAW above (the
+    // steer_superseded validator asserts finalContent==='' and the fallback gate
+    // must see the unstripped payload). If nothing remains, this was metadata or
+    // a pure-silence final → persist the FIFO advance without delivering.
+    const deliverableContent = bridgePostText(finalContent, false);
     if (deliverableContent.trim().length === 0 && finalContent.trim().length > 0) {
       suppressDelivery = true;
     }

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -11,6 +11,7 @@ import {
   shouldSuppressBridgeEmit,
   structuredFallbackKind,
   stripTrailingBridgeSentinelLine,
+  stripTrailingOaiMemoryCitation,
   type BridgeSendMarker,
 } from '../src/services/bridge-fallback-gate.js';
 import {
@@ -28,6 +29,49 @@ const markerForContent = (sentAtMs: number, content: string): BridgeSendMarker =
     ...buildBridgeSendMarkerContent(content),
   } as BridgeSendMarker;
 };
+
+const memoryCitation = (lineEnding = '\n', rolloutIds = '019c1234') => [
+  '<oai-mem-citation>',
+  '<citation_entries>',
+  'MEMORY.md:10-12|note=[routing context]',
+  '</citation_entries>',
+  '<rollout_ids>',
+  rolloutIds,
+  '</rollout_ids>',
+  '</oai-mem-citation>',
+].join(lineEnding);
+
+describe('stripTrailingOaiMemoryCitation', () => {
+  it('strips only a complete citation suffix and its separator', () => {
+    expect(stripTrailingOaiMemoryCitation(`Visible answer.\n\n${memoryCitation()}`))
+      .toBe('Visible answer.');
+    expect(stripTrailingOaiMemoryCitation(memoryCitation())).toBe('');
+  });
+
+  it('accepts CRLF, trailing whitespace, and an empty rollout_ids section', () => {
+    expect(stripTrailingOaiMemoryCitation(`Visible answer.\r\n\r\n${memoryCitation('\r\n', '')}\r\n  `))
+      .toBe('Visible answer.');
+  });
+
+  it('preserves middle-of-body occurrences and fenced examples', () => {
+    const middle = `${memoryCitation()}\n\nMore visible prose.`;
+    expect(stripTrailingOaiMemoryCitation(middle)).toBe(middle);
+
+    const fenced = `Example:\n\n\`\`\`xml\n${memoryCitation()}\n\`\`\``;
+    expect(stripTrailingOaiMemoryCitation(fenced)).toBe(fenced);
+  });
+
+  it('preserves inline, malformed, and incomplete blocks', () => {
+    const inline = `answer ${memoryCitation()}`;
+    expect(stripTrailingOaiMemoryCitation(inline)).toBe(inline);
+
+    const missingRollouts = '<oai-mem-citation>\n<citation_entries>x</citation_entries>\n</oai-mem-citation>';
+    expect(stripTrailingOaiMemoryCitation(missingRollouts)).toBe(missingRollouts);
+
+    const unclosed = '<oai-mem-citation>\n<citation_entries>x</citation_entries>\n<rollout_ids>';
+    expect(stripTrailingOaiMemoryCitation(unclosed)).toBe(unclosed);
+  });
+});
 
 describe('stripTrailingBridgeSentinelLine', () => {
   it('bare sentinel strips to empty (genuine silence)', () => {
@@ -77,7 +121,7 @@ describe('stripTrailingBridgeSentinelLine', () => {
   });
 });
 
-describe('bridgePostText (adopt contract — codex #791 blocker)', () => {
+describe('bridgePostText (adopt sentinel contract — codex #791 blocker)', () => {
   it('non-adopt strips a trailing sentinel line (posts the prose)', () => {
     expect(bridgePostText(`Here is the answer.\n\n${BRIDGE_NOTHING_TO_SEND_SENTINEL}`, false))
       .toBe('Here is the answer.');
@@ -85,7 +129,7 @@ describe('bridgePostText (adopt contract — codex #791 blocker)', () => {
     expect(bridgePostText(BRIDGE_NOTHING_TO_SEND_SENTINEL, false)).toBe('');
   });
 
-  it('ADOPT returns text VERBATIM — never strips the sentinel', () => {
+  it('ADOPT preserves sentinel text verbatim', () => {
     // The adopted CLI is botmux-unaware; transcript drain is its only channel and
     // it may output the literal token as content. Stripping here would truncate a
     // real answer / drop a verbatim-token reply. shouldSuppressBridgeEmit(adopt)
@@ -101,6 +145,12 @@ describe('bridgePostText (adopt contract — codex #791 blocker)', () => {
   it('leaves ordinary answers untouched in both modes', () => {
     expect(bridgePostText('a normal reply', false)).toBe('a normal reply');
     expect(bridgePostText('a normal reply', true)).toBe('a normal reply');
+  });
+
+  it('removes memory citation metadata from fallback output in both modes', () => {
+    const finalText = `Visible fallback.\n\n${memoryCitation()}`;
+    expect(bridgePostText(finalText, false)).toBe('Visible fallback.');
+    expect(bridgePostText(finalText, true)).toBe('Visible fallback.');
   });
 });
 
@@ -166,6 +216,20 @@ describe('buildBridgeSendMarkerContent', () => {
 });
 
 describe('shouldSuppressBridgeEmit', () => {
+  it('compares visible marker/final lengths without memory citation metadata', () => {
+    const visible = 'The answer already sent to the user.';
+    const withCitation = `${visible}\n\n${memoryCitation()}`;
+    const marker = markerForContent(150, withCitation);
+    expect(marker.contentLength).toBe(normalise(visible).length);
+    expect(marker.previewText).toBe(visible);
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText: withCitation },
+      200,
+      [marker],
+      false,
+    )).toBe(true);
+  });
+
   it('non-adopt: exact nothing-to-send sentinel suppresses without a send marker', () => {
     expect(shouldSuppressBridgeEmit(
       { ...turn(100), finalText: `  ${BRIDGE_NOTHING_TO_SEND_SENTINEL}\n` },

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -71,6 +71,35 @@ describe('stripTrailingOaiMemoryCitation', () => {
     const unclosed = '<oai-mem-citation>\n<citation_entries>x</citation_entries>\n<rollout_ids>';
     expect(stripTrailingOaiMemoryCitation(unclosed)).toBe(unclosed);
   });
+
+  it('stops each section at its first closing tag', () => {
+    const extraCitationText = [
+      '<oai-mem-citation>',
+      '<citation_entries>first</citation_entries>',
+      'visible text after the first closing tag',
+      '<citation_entries>second</citation_entries>',
+      '<rollout_ids>019c1234</rollout_ids>',
+      '</oai-mem-citation>',
+    ].join('\n');
+    expect(stripTrailingOaiMemoryCitation(extraCitationText)).toBe(extraCitationText);
+
+    const extraRolloutText = [
+      '<oai-mem-citation>',
+      '<citation_entries>entry</citation_entries>',
+      '<rollout_ids>first</rollout_ids>',
+      'visible text after the first closing tag',
+      '<rollout_ids>second</rollout_ids>',
+      '</oai-mem-citation>',
+    ].join('\n');
+    expect(stripTrailingOaiMemoryCitation(extraRolloutText)).toBe(extraRolloutText);
+  });
+
+  it('handles a large malformed suffix without combinatorial backtracking', () => {
+    const repeatedCandidates = '</citation_entries><citation_entries>x'.repeat(25_000);
+    const malformed = `<oai-mem-citation><citation_entries>${repeatedCandidates}`
+      + '<rollout_ids>missing final envelope';
+    expect(stripTrailingOaiMemoryCitation(malformed)).toBe(malformed);
+  });
 });
 
 describe('stripTrailingBridgeSentinelLine', () => {

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -44,6 +44,22 @@ function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{
 }
 
 describe('cmdSend hook context wiring', () => {
+  it('strips trailing memory citations before relay and direct-send rendering', () => {
+    const relayStart = cliSource.indexOf('async function relaySend(');
+    const relayEnd = cliSource.indexOf('\nfunction currentBotIsApiOnly', relayStart);
+    const relaySend = cliSource.slice(relayStart, relayEnd);
+    expect(relaySend).toContain('content = stripTrailingOaiMemoryCitation(content);');
+    expect(relaySend.indexOf('content = stripTrailingOaiMemoryCitation(content);'))
+      .toBeLessThan(relaySend.indexOf('prepareCardMarkdown('));
+
+    const cmdSendStart = cliSource.indexOf('async function cmdSend(');
+    const cmdDispatchStart = cliSource.indexOf('async function cmdDispatch(', cmdSendStart);
+    const cmdSend = cliSource.slice(cmdSendStart, cmdDispatchStart);
+    expect(cmdSend).toContain('content = stripTrailingOaiMemoryCitation(content);');
+    expect(cmdSend.indexOf('content = stripTrailingOaiMemoryCitation(content);'))
+      .toBeLessThan(cmdSend.indexOf('const managedPayloadError = managedVcSendPayloadError({'));
+  });
+
   it('delegates CLI session snapshot loading to the session-store gate (scope repair lives behind it)', () => {
     const loadSessionsStart = cliSource.indexOf('function loadSessions()');
     expect(loadSessionsStart).toBeGreaterThanOrEqual(0);

--- a/test/report-daemon-ipc-auth-wiring.test.ts
+++ b/test/report-daemon-ipc-auth-wiring.test.ts
@@ -23,6 +23,18 @@ function dispatchCommandSource(): string {
 }
 
 describe('botmux report daemon IPC auth wiring', () => {
+  it('strips trailing memory citations before every report delivery and preview path', () => {
+    const source = reportCommandSource();
+    const sanitize = source.indexOf('content = stripTrailingOaiMemoryCitation(content);');
+
+    expect(sanitize).toBeGreaterThan(source.indexOf('content = pos.length ? pos.join'));
+    expect(sanitize).toBeLessThan(source.indexOf('if (!contentFile) rejectLikelyWindowsStdinMojibake(content);'));
+    expect(sanitize).toBeLessThan(source.indexOf('if (!content.trim())'));
+    expect(sanitize).toBeLessThan(source.indexOf('report: content'));
+    expect(sanitize).toBeLessThan(source.indexOf('body: { dispatchRoot: dispatchRootCandidate, content }'));
+    expect(sanitize).toBeLessThan(source.indexOf('const paras = buildReportContent({ orchOpenId: reportRecipient, content });'));
+  });
+
   it('routes through the authenticated source daemon when the host secret is available', () => {
     const source = reportCommandSource();
 

--- a/test/worker-app-runner-control-wiring.test.ts
+++ b/test/worker-app-runner-control-wiring.test.ts
@@ -367,7 +367,7 @@ describe('worker app-runner control-channel wiring', () => {
     const markerEnd = workerSource.indexOf('function handleAppRunnerOscMarker(', markerStart);
     const marker = workerSource.slice(markerStart, markerEnd);
     // The deliverable is derived by stripping; the gate input must be the raw text.
-    expect(marker).toContain('const deliverableContent = stripTrailingBridgeSentinelLine(finalContent);');
+    expect(marker).toContain('const deliverableContent = bridgePostText(finalContent, false);');
     const gateInputIdx = marker.indexOf('finalText: finalContent };');
     expect(gateInputIdx).toBeGreaterThan(-1);
     // Guard against reintroducing the bug: the gateInput must NOT be built from


### PR DESCRIPTION
## Summary

- hide complete trailing `<oai-mem-citation>` metadata from user-visible output while keeping memory enabled
- sanitize explicit `botmux send`, transcript fallback, and Codex App final-output paths
- keep malformed, inline, mid-body, and fenced examples unchanged
- exclude hidden metadata from send-marker preview and length calculations

## Validation

- `pnpm run build`
- `pnpm exec tsc --noEmit`
- focused regression suites: 107 tests passed
- full unit suite: 15,487 passed; remaining 6 environment/baseline failures reproduced on upstream/master