### PR TITLE
perf(card): 去重相邻重复卡片更新

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1962,7 +1962,11 @@ function flushCardPatch(ds: DaemonSession): void {
   ds.pendingCardJson = undefined;
   ds.pendingCardId = undefined;
   ds.cardPatchInFlight = true;
+  let patchSucceeded = false;
   updateMessage(ds.larkAppId, cardId, json)
+    .then(() => {
+      patchSucceeded = true;
+    })
     .catch(err => {
       if (err instanceof MessageWithdrawnError) {
         // Only clear streamCardId when the withdrawn message is still the
@@ -1985,6 +1989,17 @@ function flushCardPatch(ds: DaemonSession): void {
     })
     .finally(() => {
       ds.cardPatchInFlight = false;
+      // A re-render can queue the exact same state while this PATCH is in
+      // flight. Drop only that adjacent duplicate after confirmed delivery.
+      // Failed PATCHes deliberately retain the queued item so it retries, and
+      // cardId participates in the comparison so a new turn's card is never
+      // mistaken for the card that just completed.
+      if (patchSucceeded
+        && ds.pendingCardId === cardId
+        && ds.pendingCardJson === json) {
+        ds.pendingCardJson = undefined;
+        ds.pendingCardId = undefined;
+      }
       if (ds.pendingCardJson) {
         flushCardPatch(ds);
       }

--- a/test/card-toggle.e2e.ts
+++ b/test/card-toggle.e2e.ts
@@ -316,12 +316,15 @@ describe('Streaming card toggle_stream', () => {
       expect(patchCalls, 'only one PATCH sent').toHaveLength(1);
       expect(parseDisplayMode(ds.pendingCardJson!), 'latest queued should be screenshot').toBe('screenshot');
 
-      // Resolve first → only ONE queued PATCH flushes (the latest)
+      // Resolve first. The latest queued state is byte-identical to the
+      // successful in-flight PATCH for the same card, so it is an adjacent
+      // duplicate and does not need another Lark call.
       patchCalls[0].resolve();
       await flush();
 
-      expect(patchCalls).toHaveLength(2);
-      expect(parseDisplayMode(patchCalls[1].cardJson), 'flushed PATCH should be the latest state').toBe('screenshot');
+      expect(patchCalls).toHaveLength(1);
+      expect(ds.pendingCardJson).toBeUndefined();
+      expect(ds.cardPatchInFlight).toBe(false);
     });
   });
 });

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -919,6 +919,105 @@ describe('scheduleCardPatch withdrawn handling', () => {
   });
 });
 
+describe('scheduleCardPatch adjacent duplicate handling', () => {
+  it('drops an identical PATCH queued for the same card after the in-flight PATCH succeeds', async () => {
+    const ds = makeDs();
+    ds.streamCardId = 'om_SAME';
+
+    let resolvePatch!: () => void;
+    updateMessageMock.mockImplementationOnce(
+      () => new Promise<void>(resolve => { resolvePatch = resolve; }),
+    );
+
+    scheduleCardPatch(ds, '{"state":"same"}');
+    scheduleCardPatch(ds, '{"state":"same"}');
+
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+    expect(ds.pendingCardId).toBe('om_SAME');
+    expect(ds.pendingCardJson).toBe('{"state":"same"}');
+
+    resolvePatch();
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+    expect(ds.pendingCardId).toBeUndefined();
+    expect(ds.pendingCardJson).toBeUndefined();
+    expect(ds.cardPatchInFlight).toBe(false);
+
+    // The optimization is adjacency-only: once the successful PATCH has
+    // settled, the same state scheduled later must still reach Lark.
+    scheduleCardPatch(ds, '{"state":"same"}');
+    expect(updateMessageMock).toHaveBeenCalledTimes(2);
+    await flush();
+    expect(ds.cardPatchInFlight).toBe(false);
+  });
+
+  it('retries an identical queued PATCH when the in-flight PATCH fails', async () => {
+    const ds = makeDs();
+    ds.streamCardId = 'om_RETRY';
+
+    let rejectPatch!: (error: Error) => void;
+    let resolveRetry!: () => void;
+    updateMessageMock
+      .mockImplementationOnce(
+        () => new Promise<void>((_resolve, reject) => { rejectPatch = reject; }),
+      )
+      .mockImplementationOnce(
+        () => new Promise<void>(resolve => { resolveRetry = resolve; }),
+      );
+
+    scheduleCardPatch(ds, '{"state":"retry"}');
+    scheduleCardPatch(ds, '{"state":"retry"}');
+
+    rejectPatch(new Error('temporary failure'));
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenCalledTimes(2);
+    expect(updateMessageMock.mock.calls[1]).toEqual([
+      APP_ID,
+      'om_RETRY',
+      '{"state":"retry"}',
+    ]);
+
+    resolveRetry();
+    await flush();
+    expect(ds.cardPatchInFlight).toBe(false);
+  });
+
+  it('does not deduplicate identical JSON queued for a different card', async () => {
+    const ds = makeDs();
+    ds.streamCardId = 'om_OLD';
+
+    let resolveOldPatch!: () => void;
+    let resolveNewPatch!: () => void;
+    updateMessageMock
+      .mockImplementationOnce(
+        () => new Promise<void>(resolve => { resolveOldPatch = resolve; }),
+      )
+      .mockImplementationOnce(
+        () => new Promise<void>(resolve => { resolveNewPatch = resolve; }),
+      );
+
+    scheduleCardPatch(ds, '{"state":"same-json"}');
+    ds.streamCardId = 'om_NEW';
+    scheduleCardPatch(ds, '{"state":"same-json"}');
+
+    resolveOldPatch();
+    await flush();
+
+    expect(updateMessageMock).toHaveBeenCalledTimes(2);
+    expect(updateMessageMock.mock.calls[1]).toEqual([
+      APP_ID,
+      'om_NEW',
+      '{"state":"same-json"}',
+    ]);
+
+    resolveNewPatch();
+    await flush();
+    expect(ds.cardPatchInFlight).toBe(false);
+  });
+});
+
 // ─── Periodic usage refresh timer (PR #637 follow-up, codex review) ──────────
 //
 // The streaming card re-renders every USAGE_REFRESH_INTERVAL_MS while a turn is


### PR DESCRIPTION
## 改了什么

在 streaming card 的串行 PATCH 队列中，去掉“正在发送的 PATCH 成功后，队列里又出现同一张卡、同一份 JSON”的相邻重复更新。

- 只有前一个 PATCH 明确成功时才去重
- 前一个 PATCH 失败时保留队列项并继续发送，维持重试机会
- `cardId` 不同即使 JSON 相同也不去重，避免新 turn 的卡片被误判
- 不维护长期 last-success 缓存；成功结算后再次调度相同内容仍会正常发送
- 保持原有单飞、latest-wins 和错误处理语义不变

## 为什么

screen update、usage refresh 和交互按钮可能在一个 PATCH 尚未完成时重新渲染出完全相同的卡片。原队列会在前一个请求成功后再发送一次字节相同的 PATCH，增加飞书 API 调用、序列化和事件循环工作，且没有可见收益。

## 影响面

- 只修改飞书 streaming card 的共享 PATCH 调度路径
- 所有 CLI 和 PTY/Tmux/Riff 后端共享这项优化，但 CLI、后端、renderer 和 Lark client 行为不变
- 话题/群聊/恢复会话仍使用原有串行 latest-wins 队列

## 实际验证

- `pnpm vitest run --project unit test/recall-frozen-cards.test.ts test/card-integration.test.ts test/substitute-control-card.test.ts`：3 files，103/103 通过
- `pnpm vitest run test/recall-frozen-cards.test.ts test/card-toggle.e2e.ts`：2 files，61/61 通过
- `pnpm test`：949 个文件、15486 个用例通过；另 1 个无关文件在并行负载下 `beforeAll` 超过 10 秒
- `pnpm vitest run test/group-join-shared-routing.test.ts`：超时文件单独复跑，16/16 通过
- `pnpm build`：通过
