### PR TITLE
perf(lark): 缓存 peer cross-ref 读取

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -262,6 +262,7 @@ import type { CliId } from '../adapters/cli/types.js';
 import { isStructuredBridgeAdoptCli } from '../services/structured-bridge-clis.js';
 import { resolveEffectivePluginIds } from './plugins/effective.js';
 import { ensureGatewayEntry } from './plugins/mcp/gateway-installer.js';
+import { readPeerCrossRef } from '../services/peer-cross-ref-store.js';
 import type {
   CliTurnPayload,
   CodexAppDeliverySink,
@@ -1121,14 +1122,7 @@ function sessionAgentConfig(
 
 function loadKnownBotOpenIdsForApp(larkAppId: string): Set<string> {
   const dataDir = config.session.dataDir;
-  let crossRef: Record<string, string> = {};
-  const crossRefPath = join(dataDir, `bot-openids-${larkAppId}.json`);
-  if (existsSync(crossRefPath)) {
-    const parsed = JSON.parse(readFileSync(crossRefPath, 'utf-8'));
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      crossRef = parsed as Record<string, string>;
-    }
-  }
+  const crossRef = readPeerCrossRef(dataDir, larkAppId);
 
   let botEntries: BotMentionEntry[] = [];
   const botInfoPath = join(dataDir, 'bots-info.json');

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,6 +2,7 @@ import { execFileSync, type ChildProcess } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { readFileSync, existsSync, mkdirSync, unlinkSync, watch, readdirSync } from 'node:fs';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
+import { readPeerCrossRef } from './services/peer-cross-ref-store.js';
 import { readAllowedUsersResolveCache, writeAllowedUsersResolveCache } from './utils/allowed-users-cache.js';
 import { join, dirname } from 'node:path';
 import { homedir, loadavg, cpus, totalmem, freemem } from 'node:os';
@@ -18361,15 +18362,9 @@ export const __testOnly_handleBotAdded = handleBotAdded;
  *  than blocking the message.
  */
 function lookupForeignBotName(senderOpenId: string, larkAppId: string): string {
-  try {
-    const fp = join(config.session.dataDir, `bot-openids-${larkAppId}.json`);
-    if (existsSync(fp)) {
-      const data: Record<string, string> = JSON.parse(readFileSync(fp, 'utf-8'));
-      for (const [name, openId] of Object.entries(data)) {
-        if (openId === senderOpenId) return name;
-      }
-    }
-  } catch { /* fall through */ }
+  for (const [name, openId] of Object.entries(readPeerCrossRef(config.session.dataDir, larkAppId))) {
+    if (openId === senderOpenId) return name;
+  }
   try {
     const infoPath = join(config.session.dataDir, 'bots-info.json');
     if (existsSync(infoPath)) {

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -71,6 +71,7 @@ import {
 import type { VcMeetingPushContext, VcMeetingPushEventKind } from '../../vc-agent/types.js';
 import type { VcMeetingImTurnOrigin } from '../../types.js';
 import { DEFAULT_GRANT_DURATION_MS, DEFAULT_GRANT_QUOTA } from '../../services/grant-policy.js';
+import { readPeerCrossRef, writePeerCrossRef } from '../../services/peer-cross-ref-store.js';
 
 // 大厅回执互教的防环闸：每进程对同一打卡者只回一次（见 hall swallow 分支）。
 const hallEchoReplied = new Set<string>();
@@ -883,15 +884,9 @@ export function __resetChatStatsForTest(): void {
 /** Read the per-bot cross-reference: botName(lowercase) → openId as seen by larkAppId's app */
 export function readBotOpenIdCrossRef(dataDir: string, larkAppId: string): Map<string, string> {
   const map = new Map<string, string>();
-  try {
-    const fp = join(dataDir, `bot-openids-${larkAppId}.json`);
-    if (existsSync(fp)) {
-      const data: Record<string, string> = JSON.parse(readFileSync(fp, 'utf-8'));
-      for (const [name, openId] of Object.entries(data)) {
-        map.set(name.toLowerCase(), openId);
-      }
-    }
-  } catch { /* ignore */ }
+  for (const [name, openId] of Object.entries(readPeerCrossRef(dataDir, larkAppId))) {
+    map.set(name.toLowerCase(), openId);
+  }
   return map;
 }
 
@@ -997,11 +992,7 @@ export function updateBotOpenIdCrossRef(
   if (knownBotNames.size === 0) return;
 
   // Read existing cross-reference
-  const fp = join(dataDir, `bot-openids-${larkAppId}.json`);
-  let existing: Record<string, string> = {};
-  try {
-    if (existsSync(fp)) existing = JSON.parse(readFileSync(fp, 'utf-8'));
-  } catch { /* ignore */ }
+  const existing: Record<string, string> = { ...readPeerCrossRef(dataDir, larkAppId) };
 
   // Update with new mentions that match known bot names
   let changed = false;
@@ -1017,8 +1008,7 @@ export function updateBotOpenIdCrossRef(
 
   if (changed) {
     try {
-      if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
-      atomicWriteFileSync(fp, JSON.stringify(existing, null, 2) + '\n');
+      writePeerCrossRef(dataDir, larkAppId, existing);
       logger.debug(`Updated bot open_id cross-ref for ${larkAppId}: ${JSON.stringify(existing)}`);
     } catch (err) {
       logger.debug(`Failed to write bot open_id cross-ref: ${err}`);

--- a/src/services/peer-cross-ref-store.ts
+++ b/src/services/peer-cross-ref-store.ts
@@ -1,0 +1,114 @@
+/**
+ * Process-local cache for the per-receiver Lark peer open_id cross-reference.
+ *
+ * Every lookup still stats the file. The metadata fingerprint makes atomic
+ * replacements from sibling daemon processes visible while avoiding repeated
+ * file-content reads and JSON.parse calls when the file is unchanged.
+ */
+import { mkdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+
+export type PeerCrossRef = Readonly<Record<string, string>>;
+
+type CacheEntry = {
+  version: string;
+  value: PeerCrossRef;
+};
+
+const EMPTY_CROSS_REF: PeerCrossRef = Object.freeze({});
+const cache = new Map<string, CacheEntry>();
+
+function crossRefPath(dataDir: string, larkAppId: string): string {
+  return join(dataDir, `bot-openids-${larkAppId}.json`);
+}
+
+function fileVersion(fp: string): string {
+  try {
+    const stat = statSync(fp);
+    // Writers publish through atomic rename. Include inode and both timestamps
+    // so a same-size replacement is not hidden by coarse mtime resolution.
+    return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`;
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return 'missing';
+    return `unavailable:${err?.code ?? 'unknown'}`;
+  }
+}
+
+function parseCrossRef(raw: string): PeerCrossRef {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return EMPTY_CROSS_REF;
+
+  const entries = Object.entries(parsed)
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string');
+  return entries.length > 0
+    ? Object.freeze(Object.fromEntries(entries))
+    : EMPTY_CROSS_REF;
+}
+
+/** Read a name-preserving peer cross-reference, failing soft to an empty map. */
+export function readPeerCrossRef(dataDir: string, larkAppId: string): PeerCrossRef {
+  const fp = crossRefPath(dataDir, larkAppId);
+
+  // Retry a concurrently replaced file instead of associating bytes from one
+  // inode with another inode's fingerprint. Atomic writers make this converge.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const before = fileVersion(fp);
+    const cached = cache.get(fp);
+    if (cached?.version === before) return cached.value;
+
+    if (before === 'missing' || before.startsWith('unavailable:')) {
+      cache.set(fp, { version: before, value: EMPTY_CROSS_REF });
+      return EMPTY_CROSS_REF;
+    }
+
+    let raw: string;
+    try {
+      raw = readFileSync(fp, 'utf-8');
+    } catch {
+      const after = fileVersion(fp);
+      if (after !== before) continue;
+      return EMPTY_CROSS_REF;
+    }
+
+    const after = fileVersion(fp);
+    if (after !== before) continue;
+
+    let value = EMPTY_CROSS_REF;
+    try {
+      value = parseCrossRef(raw);
+    } catch {
+      // A corrupt file is not an identity signal. Cache the fail-soft result
+      // only for this exact fingerprint so a later repair is visible.
+    }
+    cache.set(fp, { version: after, value });
+    return value;
+  }
+
+  return EMPTY_CROSS_REF;
+}
+
+/** Persist and immediately publish the new snapshot to readers in this process. */
+export function writePeerCrossRef(
+  dataDir: string,
+  larkAppId: string,
+  value: Readonly<Record<string, string>>,
+): void {
+  mkdirSync(dataDir, { recursive: true });
+  const fp = crossRefPath(dataDir, larkAppId);
+  const normalized = Object.freeze(Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  ));
+  atomicWriteFileSync(fp, JSON.stringify(normalized, null, 2) + '\n');
+
+  // Repopulate from a stable post-write snapshot before returning. Usually it
+  // is exactly normalized; if another daemon wins a concurrent atomic rename,
+  // cache that newer winner rather than pairing our bytes with its fingerprint.
+  cache.delete(fp);
+  readPeerCrossRef(dataDir, larkAppId);
+}
+
+/** Test-only: isolate process-local cache state between cases. */
+export function __resetPeerCrossRefCacheForTest(): void {
+  cache.clear();
+}

--- a/src/utils/bot-routing.ts
+++ b/src/utils/bot-routing.ts
@@ -72,7 +72,7 @@ function knownBotNames(entries: BotMentionEntry[], selfAppId?: string): Set<stri
 }
 
 export function knownBotOpenIdsFromCrossRef(
-  crossRef: Record<string, string>,
+  crossRef: Readonly<Record<string, string>>,
   entries: BotMentionEntry[] = [],
   selfAppId?: string,
 ): Set<string> {

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -17,12 +17,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockExistsSync = vi.fn(() => true);
 const mockReadFileSync = vi.fn(() => '[]');
 const mockWriteFileSync = vi.fn();
+const mockCrossRefStatSync = vi.fn();
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return {
     ...actual,
     existsSync: (...args: any[]) => mockExistsSync(...args),
     readFileSync: (...args: any[]) => mockReadFileSync(...args),
+    statSync: (path: any, ...args: any[]) => String(path).includes('bot-openids-')
+      ? mockCrossRefStatSync(path, ...args)
+      : (actual.statSync as any)(path, ...args),
     writeFileSync: (...args: any[]) => mockWriteFileSync(...args),
     mkdirSync: vi.fn(),
   };
@@ -153,6 +157,7 @@ import {
 import { getPendingGrantLimits, _resetForTest as _resetGrantPending } from '../src/im/lark/grant-pending.js';
 import { logger } from '../src/utils/logger.js';
 import { config } from '../src/config.js';
+import { __resetPeerCrossRefCacheForTest } from '../src/services/peer-cross-ref-store.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -163,6 +168,10 @@ const OTHER_BOT_APP_ID = 'app-bot-b';
 const USER_OPEN_ID = 'ou_user_123';
 
 beforeEach(() => {
+  __resetPeerCrossRefCacheForTest();
+  mockCrossRefStatSync.mockReset().mockReturnValue({
+    dev: 1, ino: 1, size: 1, mtimeMs: 1, ctimeMs: 1,
+  });
   capturedWsClientOptions = undefined;
   config.daemon.forwardFollowupWaitMs = 0;
   mockReadFileSync.mockReset().mockReturnValue('[]');

--- a/test/peer-cross-ref-store.test.ts
+++ b/test/peer-cross-ref-store.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsState = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  afterAtomicWrite: undefined as (() => void) | undefined,
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  fsState.readFileSync.mockImplementation(actual.readFileSync);
+  return { ...actual, readFileSync: fsState.readFileSync };
+});
+
+vi.mock('../src/utils/atomic-write.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/utils/atomic-write.js')>();
+  return {
+    ...actual,
+    atomicWriteFileSync: (...args: Parameters<typeof actual.atomicWriteFileSync>) => {
+      actual.atomicWriteFileSync(...args);
+      fsState.afterAtomicWrite?.();
+    },
+  };
+});
+
+import {
+  __resetPeerCrossRefCacheForTest,
+  readPeerCrossRef,
+  writePeerCrossRef,
+} from '../src/services/peer-cross-ref-store.js';
+
+const APP_ID = 'cli_peer_cache_test';
+let dataDir = '';
+let fp = '';
+
+function replaceCrossRef(contents: string): void {
+  const replacement = `${fp}.replacement`;
+  writeFileSync(replacement, contents);
+  renameSync(replacement, fp);
+}
+
+function crossRefContentReadCount(): number {
+  return fsState.readFileSync.mock.calls
+    .filter(([path]) => path === fp)
+    .length;
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-peer-cross-ref-'));
+  fp = join(dataDir, `bot-openids-${APP_ID}.json`);
+  fsState.readFileSync.mockClear();
+  fsState.afterAtomicWrite = undefined;
+  __resetPeerCrossRefCacheForTest();
+});
+
+afterEach(() => {
+  __resetPeerCrossRefCacheForTest();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('peer cross-ref process cache', () => {
+  it('reuses parsed contents while the file fingerprint is unchanged', () => {
+    writeFileSync(fp, JSON.stringify({ Peer: 'ou_peer' }));
+
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_peer' });
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_peer' });
+    expect(crossRefContentReadCount()).toBe(1);
+  });
+
+  it('observes an external same-size atomic replacement', () => {
+    writeFileSync(fp, JSON.stringify({ Peer: 'ou_old1' }));
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_old1' });
+
+    replaceCrossRef(JSON.stringify({ Peer: 'ou_new2' }));
+
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_new2' });
+    expect(crossRefContentReadCount()).toBe(2);
+  });
+
+  it('recovers after a cached missing file is created', () => {
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({});
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({});
+    expect(crossRefContentReadCount()).toBe(0);
+
+    writeFileSync(fp, JSON.stringify({ Peer: 'ou_created' }));
+
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_created' });
+    expect(crossRefContentReadCount()).toBe(1);
+  });
+
+  it('caches corrupt contents fail-soft and recovers after replacement', () => {
+    writeFileSync(fp, '{broken');
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({});
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({});
+    expect(crossRefContentReadCount()).toBe(1);
+
+    replaceCrossRef(JSON.stringify({ Peer: 'ou_repaired' }));
+
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_repaired' });
+    expect(crossRefContentReadCount()).toBe(2);
+  });
+
+  it('makes a local update visible through the write-through cache', () => {
+    writeFileSync(fp, JSON.stringify({ Peer: 'ou_old' }));
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_old' });
+
+    writePeerCrossRef(dataDir, APP_ID, { Peer: 'ou_new', Other: 'ou_other' });
+    const readsAfterWrite = crossRefContentReadCount();
+
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_new', Other: 'ou_other' });
+    expect(crossRefContentReadCount()).toBe(readsAfterWrite);
+    expect(JSON.parse(readFileSync(fp, 'utf-8'))).toEqual({ Peer: 'ou_new', Other: 'ou_other' });
+  });
+
+  it('does not bind local bytes to a sibling replacement fingerprint after write', () => {
+    writeFileSync(fp, JSON.stringify({ Peer: 'ou_old' }));
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_old' });
+    fsState.afterAtomicWrite = () => {
+      replaceCrossRef(JSON.stringify({ Peer: 'ou_sibling' }));
+    };
+
+    writePeerCrossRef(dataDir, APP_ID, { Peer: 'ou_local' });
+
+    expect(readPeerCrossRef(dataDir, APP_ID)).toEqual({ Peer: 'ou_sibling' });
+    expect(JSON.parse(readFileSync(fp, 'utf-8'))).toEqual({ Peer: 'ou_sibling' });
+  });
+});


### PR DESCRIPTION
## 改了什么

为每个飞书应用的 peer open_id cross-ref 增加共享的进程内解析缓存，并让事件鉴权、daemon 名称反查和 worker 终态卡收件人判断复用它。

- 缓存命中时仍执行一次同步 `stat` 校验文件指纹，但跳过重复的文件内容读取、JSON 解析和对象重建
- 指纹包含设备、inode、大小、mtime 和 ctime；兄弟 daemon 通过原子 rename 更新后会立即失效
- 文件缺失、损坏或暂时不可读时 fail-soft 为空身份投影，并在元数据变化后自动恢复
- 本进程更新 cross-ref 后从稳定的磁盘快照重建缓存；若兄弟进程恰好随后覆盖，以磁盘最终赢家为准
- 保留现有名称大小写归一化、peer 鉴权和 fallback 行为

## 为什么

同一条 bot 消息会经过 talk gate、所有者判断、steer 权限和 prompt 前缀等多道检查。原实现每次 `isKnownPeerBot()` 都同步读取并解析同一份 JSON，worker 的终态卡路径还会再次读取。文件未变化时，这些内容 I/O、JSON 解析和临时对象分配没有必要，并会占用 daemon 主事件循环。

## 影响面

- 影响飞书 peer 身份查询的共享生产路径：event dispatcher、daemon 消息前缀和 worker fallback final footer
- 不改变 peer 身份来源、授权边界、消息路由结果、CLI 适配器或 PTY/Tmux/Riff 后端
- 缓存不是永久快照；每次读取仍校验磁盘指纹，因此外部进程更新、删除和修复都能被观察到
- client、Dashboard 和 CLI 的其它 cross-ref 消费路径未扩入本批，控制 PR 范围

## 实际验证

- `pnpm vitest run --project unit test/peer-cross-ref-store.test.ts test/event-dispatcher.test.ts test/bridge-final-output-retry.test.ts`：3 files，375/375 通过
- 扩展定向测试（peer 鉴权、daemon 命令、bot routing、worker footer、daemon 路由）：7 files，518/518 通过
- `pnpm test`：950 个文件、15489 个用例通过；另 1 个无关文件在全量并行负载下 `beforeAll` 超过 10 秒
- `pnpm vitest run test/group-join-shared-routing.test.ts`：超时文件单独复跑，16/16 通过（6.43s）
- `pnpm build`：通过
- `git diff --check`：通过
