### PR TITLE
fix(pi): 修复 argv 首轮启动空窗假 idle 误置就绪（三层根治）

### DIFF
--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -58,7 +58,20 @@ import { delay } from '../../utils/timing.js';
  *  idle probe and the reattach probe (`scheduleReattachIdleProbe`, gated on
  *  `busyPattern`), so a turn — and a reattached persistent pane with no new PTY
  *  output — is marked ready via the `Working...` marker exactly as before this
- *  change. `assistant_final` events additionally fire idle when they land. */
+ *  change. `assistant_final` events additionally fire idle when they land.
+ *  Three guards keep quiescence honest (the raw heuristic alone mis-fires):
+ *    1. Startup window: the TUI renders its input box seconds before the CLI
+ *       begins consuming an argv-baked first prompt (extension/model loading).
+ *       The worker holds the first ready until the turn has visibly started —
+ *       `Working...` seen on PTY, or the transcript's first user record
+ *       (worker `spawnArgvTurnStartEvidenceSeen` gate).
+ *    2. Mid-turn: pi is in STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS, so a
+ *       transcript-started turn without a terminal suppresses screen idle
+ *       (drainPiTranscript emits terminals for stop/length-no-toolcall and the
+ *       hard error/aborted edges — see pi-transcript.ts for the accepted
+ *       custom-tool `terminate:true` gap).
+ *    3. Post-idle: `idleToBusyPattern` flips a falsely published ready back to
+ *       working when `Working...` reappears. */
 export function createPiAdapter(pathOverride?: string): CliAdapter {
   const bin = resolveCommand(pathOverride ?? 'pi');
   return {
@@ -112,6 +125,13 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
 
     completionPattern: undefined,
     busyPattern: /Working\.\.\./,
+    // Self-heal for a falsely published ready (e.g. a startup-window quiescence
+    // idle slipping past the gates): if `Working...` renders AFTER an idle was
+    // reported, IdleDetector fires onBusy and the worker pulls isPromptReady
+    // back to false + republishes working. Safe as an idle→busy edge marker:
+    // Pi's `Working...` is an ephemeral status line, never part of transcript
+    // history redraws, so a completed turn cannot revive a closed card.
+    idleToBusyPattern: /Working\.\.\./,
     readyPattern: undefined,
     // Pi's native Message Queue parks/steers submit-while-busy input; the JSONL
     // transcript bridge (drainPiTranscript) + the `Working...` busy marker are

--- a/src/services/pi-transcript.ts
+++ b/src/services/pi-transcript.ts
@@ -43,9 +43,12 @@
  *
  * Accepted gap: a custom tool returning `terminate:true` ends the agent right
  * after its toolResult with the last assistant record being `toolUse` (and
- * `terminate` is not persisted), so that turn has NO on-disk boundary. We do not
- * synthesize one; quiescence idle marks the session ready and the next ordinary
- * user turn HOL-drops the unclosed collecting head.
+ * `terminate` is not persisted — re-verified on pi 0.84.2: SessionManager
+ * writes no terminate field, and the newer `pending`/`deferred` StopReasons
+ * are provider-stream states that never reach the session JSONL). We do not
+ * synthesize a boundary; with pi in STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS
+ * such a turn keeps the session projected busy until the next ordinary user
+ * turn HOL-drops the unclosed collecting head (botmux ships no such tool).
  *
  * ## Type-ahead shape
  * Pi's Message Queue is an active-turn STEER (TUI shows "Steering: …" +
@@ -297,9 +300,10 @@ export function drainPiTranscript(path: string, fromOffset: number): PiDrainResu
     // tool returning terminate:true ends the agent right after its toolResult;
     // the last assistant record is `toolUse` (not a terminal stopReason) and
     // `terminate` is NOT persisted, so that turn has no on-disk end marker. We
-    // deliberately do NOT try to synthesize one — quiescence idle still marks
-    // the session ready, and the next ordinary user turn HOL-drops the
-    // unclosed collecting head. (botmux ships no such tool.)
+    // deliberately do NOT try to synthesize one — with pi lifecycle-blocking
+    // the started turn keeps the session projected busy until the next
+    // ordinary user turn HOL-drops the unclosed collecting head. (botmux
+    // ships no such tool.)
     const isHardTerminal = stopReason === 'error' || stopReason === 'aborted';
     const isTextTerminal = (stopReason === 'stop' || stopReason === 'length')
       && !hasToolCall(obj.message.content);

--- a/src/services/structured-bridge-clis.ts
+++ b/src/services/structured-bridge-clis.ts
@@ -51,11 +51,21 @@ const ADOPT_SET: ReadonlySet<string> = new Set(STRUCTURED_BRIDGE_ADOPT_CLI_IDS);
 
 /** Drivers whose transcript contract exposes every terminal edge needed for a
  *  strong started-turn status gate. Codex has final_answer plus explicit
- *  turn_aborted parsing. Other structured drivers still
- *  use the queue for attribution, but their interrupted/error shapes are not
- *  yet complete enough to let a started turn suppress screen-ready forever. */
+ *  turn_aborted parsing. Pi's drainPiTranscript closes a turn on
+ *  stop/length-without-toolcall and on the hard error/aborted edges (verified
+ *  against pi 0.84.2: `terminate:true` is still not persisted and the newer
+ *  pending/deferred StopReasons never reach the session JSONL), so a started
+ *  Pi turn may suppress the screen-ready heuristic. Accepted gap: a custom
+ *  tool returning `terminate:true` leaves a started turn with no on-disk
+ *  terminal — the card stays working until the NEXT user turn's transcript
+ *  user event HOL-drops the unclosed head (botmux ships no such tool; same
+ *  bounded-recovery shape Codex accepts for lost rollout finals). Other
+ *  structured drivers still use the queue for attribution, but their
+ *  interrupted/error shapes are not yet complete enough to let a started turn
+ *  suppress screen-ready forever. */
 export const STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS = [
   'codex',
+  'pi',
 ] as const satisfies readonly CliId[];
 
 const LIFECYCLE_BLOCKING_SET: ReadonlySet<string> = new Set(STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1735,6 +1735,25 @@ let spawnArgvInitialPromptBusy = false;
  * arm above; quiescence argv adapters seed working then idle at first ready.
  */
 let spawnArgvNeedsWorkingSeed = false;
+/**
+ * Startup-window evidence for an argv-baked first prompt: true once the turn
+ * has VISIBLY started — busyPattern seen in the raw PTY stream since spawn, or
+ * a live structured-transcript user/final event ingested. Pi's TUI renders its
+ * input box seconds before it begins consuming the argv prompt (extension /
+ * model loading), and during that gap the screen shows no busy marker and the
+ * transcript has no user record — quiescence then reports a FALSE first idle
+ * ("not started yet", not "turn complete"). Until this latches,
+ * markPromptReady holds ready + re-arms instead of seeding working→idle.
+ */
+let spawnArgvTurnStartEvidenceSeen = false;
+/** Rolling ANSI-stripped PTY tail scanned for busyPattern while the argv
+ *  first-turn evidence gate is armed; dropped once evidence latches. */
+let spawnArgvTurnStartBusyScanTail = '';
+/** Fail-open deadline for the evidence gate: past this instant the gate stops
+ *  holding, so an argv prompt the CLI never consumed (e.g. dropped on a
+ *  restart) cannot park the card at 工作中 forever. */
+let spawnArgvTurnStartEvidenceDeadlineMs = 0;
+let spawnArgvTurnStartFailOpenTimer: ReturnType<typeof setTimeout> | null = null;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
 /** True once a crash diagnostic tmux shell (bmx-diag-<sid>) is live. */
@@ -6048,6 +6067,9 @@ function codexBridgeIngest(opts: {
   }
   if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   codexBridgeQueue.ingest(result.events);
+  // After ingest so the latch's delivery re-kick observes the started turn —
+  // the flush's own bridge mark must queue behind it, not ahead of it.
+  noteSpawnArgvTurnStartTranscriptEvidence(result.events);
   pruneExpiredStructuredHeadsAndEmit('structured ingest');
   // Transcript-driven idle: a normal `assistant_final` or no-output
   // `turn_aborted` is Codex declaring end-of-turn, far more reliable than the screen-pattern heuristic
@@ -9007,6 +9029,25 @@ function onPtyData(data: string): void {
   maybeReportDeferredTopicMaterialization(data);
   maybeCaptureKiroSessionId(data);
   captureWorkflowTranscript(data);
+  // Argv first-turn start evidence (Pi): latch the busy marker from the raw
+  // PTY stream. The viewport-based defer cannot see a marker that has not
+  // rendered yet, and a fast turn can paint and clear `Working...` between
+  // screen samples — the stream sees every byte exactly once.
+  if (
+    spawnArgvNeedsWorkingSeed
+    && !spawnArgvTurnStartEvidenceSeen
+    && structuredBridgeIsPi()
+    && cliAdapter?.busyPattern
+  ) {
+    spawnArgvTurnStartBusyScanTail = tailChars(
+      spawnArgvTurnStartBusyScanTail + stripAnsiForLog(data),
+      500,
+    );
+    if (cliAdapter.busyPattern.test(spawnArgvTurnStartBusyScanTail)) {
+      spawnArgvTurnStartEvidenceSeen = true;
+      spawnArgvTurnStartBusyScanTail = '';
+    }
+  }
   renderer?.write(data);
 
   // In tmux-attach mode, each web client has its own tmux attach PTY —
@@ -9255,6 +9296,120 @@ function scheduleStructuredStartGraceRecheck(remainingMs: number): void {
   structuredStartGraceRecheckTimer.unref?.();
 }
 
+/** How long the argv first-turn evidence gate may hold ready with no start
+ *  evidence at all. Pi's startup gap (extension/model loading before it
+ *  consumes the argv prompt) is typically 3–9s; 90s covers slow hosts while
+ *  keeping a never-consumed argv prompt from parking the card at 工作中
+ *  forever. */
+const SPAWN_ARGV_TURN_START_EVIDENCE_GRACE_MS = 90_000;
+
+/** True while markPromptReady must hold the argv-baked first prompt's ready:
+ *  no "turn started" evidence yet and the bounded grace has not expired.
+ *  Scoped to Pi — the only quiescence-argv adapter with BOTH evidence channels
+ *  (busyPattern + always-on structured transcript); Gemini/OpenCode/MTR keep
+ *  their historical first-idle behavior. Never applies to the Grok-class busy
+ *  arm, whose first ready is handled by spawnArgvInitialPromptBusy. */
+function spawnArgvTurnStartGateHolds(): boolean {
+  if (!spawnArgvNeedsWorkingSeed || spawnArgvInitialPromptBusy) return false;
+  if (!structuredBridgeIsPi()) return false;
+  if (spawnArgvTurnStartEvidenceSeen) return false;
+  return Date.now() < spawnArgvTurnStartEvidenceDeadlineMs;
+}
+
+/** Latch "the argv first turn actually began" from live structured-transcript
+ *  events. The latch must happen at INGEST time, not lazily at gate time: a
+ *  fast first turn can be started AND drained/emitted before markPromptReady
+ *  runs, leaving no started turn to observe in the queue. A user record is the
+ *  authoritative start signal; a final implies start too (covers a drain that
+ *  sees both lines at once).
+ *
+ *  The latch is also a DELIVERY DRIVER, not just a boolean: when evidence
+ *  lands later than the 15s first-prompt timeout, every markPromptReady-based
+ *  driver has already fired rejected and stopped (probe one-shot, timeout
+ *  short-circuit) and the 90s fail-open stands down on evidenceSeen — with a
+ *  silent PTY nothing else would ever deliver a startup-queued message. The
+ *  user record hitting disk is itself the proof the TUI accepts input, so
+ *  re-kick immediately. (The PTY busyPattern latch needs no re-kick: busy
+ *  output implies a later quiescence edge that re-drives markPromptReady.) */
+function noteSpawnArgvTurnStartTranscriptEvidence(events: readonly { kind: string }[]): void {
+  // The whole evidence mechanism is Pi-scoped (matching the onPtyData busy
+  // scan and spawnArgvTurnStartGateHolds); this generic ingest path also
+  // serves Grok — another argv-baked + structured-bridge + type-ahead CLI —
+  // so without this guard the flush side effect below would add a new
+  // startup-window write for Grok (whose first ready is owned by the
+  // SessionStart busy arm, not by this gate).
+  if (!structuredBridgeIsPi()) return;
+  if (spawnArgvTurnStartEvidenceSeen || !spawnArgvNeedsWorkingSeed) return;
+  if (!events.some(ev => ev.kind === 'user' || ev.kind === 'assistant_final')) return;
+  spawnArgvTurnStartEvidenceSeen = true;
+  spawnArgvTurnStartBusyScanTail = '';
+  if (!isPromptReady && pendingMessages.length > 0) {
+    log('Argv first-turn start evidence landed via transcript — releasing startup-queued input');
+    flushQueuedInputAfterTurnStartEvidence();
+  }
+}
+
+function stopSpawnArgvTurnStartFailOpen(): void {
+  if (!spawnArgvTurnStartFailOpenTimer) return;
+  clearTimeout(spawnArgvTurnStartFailOpenTimer);
+  spawnArgvTurnStartFailOpenTimer = null;
+}
+
+/** Turn-start evidence in hand ⇒ startup-queued input becomes deliverable.
+ *
+ *  Messages that arrive during startup (awaitingFirstPrompt) skip
+ *  handleMessage's type-ahead write (shouldWriteNow holds them, "no input box
+ *  yet") and historically relied on markPromptReady()'s tail flush for
+ *  delivery. When a Pi argv first turn never lands its terminal record
+ *  (terminate:true gap), every ready driver dies rejected: the structured
+ *  lifecycle block refuses quiescence idles, the queued-message busy probe
+ *  and the 15s first-prompt timeout both short-circuit through the same
+ *  rejected markPromptReady(), and the 90s fail-open stands down once
+ *  evidence is latched. Without an explicit re-kick the message sits in
+ *  pendingMessages forever (card pinned at 工作中, the next transcript user
+ *  event never appears, HOL-drop never fires).
+ *
+ *  Two call sites, one safety argument — input may only be re-kicked once the
+ *  TUI provably booted far enough to accept it:
+ *   1. markPromptReady()'s lifecycle-block rejection (a started turn /
+ *      confirmed submit exists);
+ *   2. the transcript-evidence latch in codexBridgeIngest (the user record
+ *      just hit disk — the ONLY driver left when evidence lands later than
+ *      every probe/timeout and the PTY stays silent).
+ *  The argv turn-start evidence gate must NOT re-kick — before any evidence
+ *  the TUI may still be loading extensions/models and a type-ahead paste
+ *  could be dropped or land in a half-drawn screen (flushPending() has no
+ *  awaitingFirstPrompt gate of its own; shouldWriteNow()'s hold is the only
+ *  startup input protection).
+ *
+ *  flushPending() still re-checks its own admission gates (type-ahead
+ *  allowance, durable HOL, injection serialization, restart fences,
+ *  ready-gate settle), so a non-type-ahead adapter keeps holding until a real
+ *  ready edge; this is a re-kick, never a bypass of those gates. */
+function flushQueuedInputAfterTurnStartEvidence(): void {
+  if (pendingMessages.length === 0) return;
+  flushPending();
+}
+
+/** Re-drive the held first idle if no start evidence ever appears. Without
+ *  this, a swallowed quiescence idle followed by a fully silent PTY (argv
+ *  prompt never consumed) would leave no later signal to re-check the gate.
+ *  The re-driven idle still passes deferPromptReadyWhileBusy, so a turn whose
+ *  evidence was merely missed keeps deferring on a busy viewport. */
+function scheduleSpawnArgvTurnStartFailOpen(): void {
+  if (spawnArgvTurnStartFailOpenTimer) return;
+  const backendAtSchedule = backend;
+  const cliGenerationAtSchedule = cliSpawnGeneration;
+  spawnArgvTurnStartFailOpenTimer = setTimeout(() => {
+    spawnArgvTurnStartFailOpenTimer = null;
+    if (backend !== backendAtSchedule || cliSpawnGeneration !== cliGenerationAtSchedule) return;
+    if (isPromptReady || !spawnArgvNeedsWorkingSeed || spawnArgvTurnStartEvidenceSeen) return;
+    log('Argv-baked first prompt showed no start evidence within grace — failing open to quiescence idle');
+    idleDetector?.fireIdle();
+  }, Math.max(1, spawnArgvTurnStartEvidenceDeadlineMs - Date.now()));
+  spawnArgvTurnStartFailOpenTimer.unref?.();
+}
+
 function markPromptReady(): void {
   if (bareShellLaunchBlocked) {
     log('Ignoring non-PTY prompt-ready while bare-shell launch block is active');
@@ -9329,6 +9484,29 @@ function markPromptReady(): void {
     return;
   }
   if (freshnessAction === 'ignore') return;
+  // Argv-baked first prompt start gate (Pi): the TUI paints its input box
+  // seconds before the CLI begins consuming the argv prompt, and that startup
+  // window has no busyPattern on screen and no transcript user record —
+  // quiescence then produces a FALSE first idle ("not started yet", not "turn
+  // complete"). Letting it through would set isPromptReady for the whole turn
+  // and seed working→idle mid-turn (premature ✅ DONE + card flip to 等待输入).
+  // Hold ready and re-arm until the turn visibly starts; bounded fail-open via
+  // SPAWN_ARGV_TURN_START_EVIDENCE_GRACE_MS restores the historical quiescence
+  // behavior if evidence never appears.
+  // Deliberately NO flush re-kick here (unlike the lifecycle block below):
+  // with zero turn-start evidence the TUI may still be booting, and a
+  // type-ahead paste could be dropped or land in a half-drawn screen —
+  // shouldWriteNow()'s awaitingFirstPrompt hold is the only startup input
+  // protection and flushPending() does not re-check it. Queued messages are
+  // delivered the moment evidence appears (the transcript latch re-kicks, a
+  // busy-marker latch implies a later quiescence edge) or by the 90s
+  // fail-open.
+  if (spawnArgvTurnStartGateHolds()) {
+    log('Argv-baked first prompt has not visibly started (no busy marker or transcript user event since spawn) — re-arming idle detector');
+    idleDetector?.reset();
+    scheduleSpawnArgvTurnStartFailOpen();
+    return;
+  }
   // Screen prompt/quiescence is only a UI heuristic. Structured transcript
   // bridges have the stronger lifecycle signal: a transcript-started turn
   // without assistant_final is still running even if the TUI redraw exposes a
@@ -9344,6 +9522,7 @@ function markPromptReady(): void {
     log('Ignoring prompt-ready heuristic while a structured turn is unfinished or submit verification/start is pending');
     idleDetector?.reset();
     if (remainingMs !== undefined) scheduleStructuredStartGraceRecheck(remainingMs);
+    flushQueuedInputAfterTurnStartEvidence();
     return;
   }
   structuredRejectedReadyEvidenceGeneration = undefined;
@@ -12342,6 +12521,14 @@ async function spawnCli(
     injectsReadyHook: cliAdapter.injectsReadyHook === true,
     reliableTurnTerminal: cliAdapter.reliableTurnTerminal === true,
   });
+  // Fresh evidence window for the argv first-turn start gate (Pi): the new
+  // generation must not inherit a previous spawn's latch or fail-open timer.
+  stopSpawnArgvTurnStartFailOpen();
+  spawnArgvTurnStartEvidenceSeen = false;
+  spawnArgvTurnStartBusyScanTail = '';
+  spawnArgvTurnStartEvidenceDeadlineMs = spawnArgvNeedsWorkingSeed
+    ? Date.now() + SPAWN_ARGV_TURN_START_EVIDENCE_GRACE_MS
+    : 0;
   if (deferInitialPrompt && preparedDeferredInput) {
     piInitialPromptAdditionalArgs = [...(preparedDeferredInput.additionalArgs ?? [])];
     piInitialPromptEnv = { ...(preparedDeferredInput.env ?? {}) };
@@ -14226,6 +14413,8 @@ function killCli(opts: {
   stopReattachIdleProbe();
   stopBusyPatternIdleProbe();
   stopStructuredStartGraceRecheck();
+  stopSpawnArgvTurnStartFailOpen();
+  spawnArgvTurnStartBusyScanTail = '';
   structuredRejectedReadyEvidenceGeneration = undefined;
   ptyOutputGeneration.reset();
   // Cancel any pending ready-gate fallback / settle timers; spawnCli re-arms on respawn.

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1460,8 +1460,18 @@ describe('idleToBusyPattern', () => {
     expect(busy!.test('Working through the implementation')).toBe(false);
   });
 
+  it('pi opts in with the same Working... marker as its busyPattern', () => {
+    // Pi's `Working...` is an ephemeral status line (never part of transcript
+    // history redraws), so idle→busy recovery is safe: a falsely published
+    // ready self-heals when the marker renders again.
+    const adapter = createPiAdapter('/bin/pi');
+    expect(adapter.idleToBusyPattern).toBeDefined();
+    expect(adapter.idleToBusyPattern!.source).toBe(adapter.busyPattern!.source);
+    expect(adapter.idleToBusyPattern!.test('● Working... (esc to interrupt)')).toBe(true);
+    expect(adapter.idleToBusyPattern!.test('Working through the implementation')).toBe(false);
+  });
+
   it.each([
-    ['pi', createPiAdapter('/bin/pi')],
     ['genius', createGeniusAdapter('/bin/genius')],
     ['grok', createGrokAdapter('/bin/grok')],
   ])('%s keeps legacy busyPattern semantics and does not opt in', (_name, adapter) => {

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -147,11 +147,6 @@ describe('IdleDetector: onBusy()', () => {
 
   it.each([
     {
-      name: 'Pi',
-      cli: createPiAdapter('/bin/pi'),
-      redraw: '\x1b[2JWorking... on it',
-    },
-    {
       name: 'Genius',
       cli: createGeniusAdapter('/bin/genius'),
       redraw: '\x1b[2JThe previous screen said esc to interrupt while it was running.',
@@ -171,6 +166,36 @@ describe('IdleDetector: onBusy()', () => {
     detector.fireIdle();
     detector.feed(redraw);
     expect(cb).not.toHaveBeenCalled();
+    detector.dispose();
+  });
+
+  it('Pi opts in: Working... after idle flips busy so a false ready self-heals', () => {
+    // Pi's `Working...` is an ephemeral status line — never part of transcript
+    // history redraws — so the adapter explicitly sets idleToBusyPattern. A
+    // falsely published ready (e.g. a startup-window quiescence idle that
+    // slipped past the gates) is corrected as soon as the marker renders:
+    // the worker's onBusy pulls isPromptReady back to false and republishes
+    // working.
+    const cli = createPiAdapter('/bin/pi');
+    expect(cli.idleToBusyPattern?.source).toBe(cli.busyPattern?.source);
+
+    const detector = new IdleDetector(cli);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('\x1b[2K plain redraw without the marker');
+    expect(cb).not.toHaveBeenCalled();
+    detector.feed('\x1b[2K● Working... (esc to interrupt)');
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Re-arms per idle cycle: a second marker in the same cycle stays quiet,
+    // the next idle re-arms the edge.
+    detector.feed('● Working... still');
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.fireIdle();
+    detector.feed('● Working...');
+    expect(cb).toHaveBeenCalledTimes(2);
     detector.dispose();
   });
 });

--- a/test/structured-bridge-clis.test.ts
+++ b/test/structured-bridge-clis.test.ts
@@ -51,10 +51,15 @@ describe('structured-bridge-clis', () => {
     expect(isStructuredBridgeAdoptCli('cursor')).toBe(true);
   });
 
-  it('enables the strong status gate only for Codex with a complete terminal contract', () => {
-    expect(STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS).toEqual(['codex']);
+  it('enables the strong status gate only for drivers with a complete terminal contract', () => {
+    // codex: final_answer + explicit turn_aborted. pi: drainPiTranscript closes
+    // on stop/length-without-toolcall plus hard error/aborted edges, so a
+    // started Pi turn may suppress the screen-ready heuristic (the custom-tool
+    // terminate:true gap is accepted — next user turn HOL-drops the head).
+    expect(STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS).toEqual(['codex', 'pi']);
     expect(isStructuredBridgeLifecycleBlockingCli('codex')).toBe(true);
-    for (const id of ['traex', 'coco', 'hermes', 'mtr', 'pi', 'grok', 'cursor']) {
+    expect(isStructuredBridgeLifecycleBlockingCli('pi')).toBe(true);
+    for (const id of ['traex', 'coco', 'hermes', 'mtr', 'grok', 'cursor']) {
       expect(isStructuredBridgeLifecycleBlockingCli(id)).toBe(false);
     }
   });

--- a/test/worker-argv-reaction-status.integration.test.ts
+++ b/test/worker-argv-reaction-status.integration.test.ts
@@ -88,6 +88,19 @@ async function waitForPromptReady(
   throw new Error(`timed out waiting for prompt_ready: ${JSON.stringify(messages)}\n${logs.join('')}`);
 }
 
+/** A Pi transcript `message` record, shaped like SessionManager's JSONL. */
+function piTranscriptRecord(role: 'user' | 'assistant', text: string, stopReason?: string): string {
+  return JSON.stringify({
+    type: 'message',
+    timestamp: new Date().toISOString(),
+    message: {
+      role,
+      content: [{ type: 'text', text }],
+      ...(stopReason ? { stopReason } : {}),
+    },
+  }) + '\n';
+}
+
 describe('worker argv reaction status', () => {
   it('keeps an argv-baked Pi turn working until its viewport loses Working...', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-busy-'));
@@ -95,10 +108,20 @@ describe('worker argv reaction status', () => {
     const dataDir = join(root, 'session');
     mkdirSync(dataDir, { recursive: true });
 
+    // Real Pi writes a user record when it begins consuming the argv prompt
+    // and a terminal assistant record when the turn ends. With pi in the
+    // lifecycle-blocking allowlist a started turn without a terminal holds
+    // ready, so the fake must produce the realistic transcript shape.
+    const cliSessionId = 'deadbeef-1234-4678-9abc-def012345678';
+    const piSessionsDir = join(root, '.pi', 'agent', 'sessions', dataDir.replace(/\//g, '--'));
+    mkdirSync(piSessionsDir, { recursive: true });
+    const transcriptPath = join(piSessionsDir, `20260810120000_${cliSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '');
+
     const fakePi = join(root, 'fake-pi');
     writeFileSync(fakePi, `#!/usr/bin/env node
 process.stdout.write('Working...\\n');
-setTimeout(() => process.stdout.write('\\x1b[2J\\x1b[HDone without transcript final\\n'), 4_500);
+setTimeout(() => process.stdout.write('\\x1b[2J\\x1b[HDone after transcript final\\n'), 4_500);
 setInterval(() => {}, 1_000);
 `);
     chmodSync(fakePi, 0o755);
@@ -130,6 +153,7 @@ setInterval(() => {}, 1_000);
       workingDir: dataDir,
       cliId: 'pi',
       cliPathOverride: fakePi,
+      cliSessionId,
       backendType: 'pty',
       prompt: 'hello from argv',
       larkAppId: 'app_test',
@@ -137,16 +161,32 @@ setInterval(() => {}, 1_000);
       turnId: 'om_turn',
     } satisfies DaemonToWorker);
 
+    await waitForLog(child, logs, 'Codex bridge fresh-empty:');
+    appendFileSync(transcriptPath, piTranscriptRecord('user', 'hello from argv'));
+
     const deadline = Date.now() + 3_500;
     while (Date.now() < deadline) {
       await new Promise(resolvePromise => setTimeout(resolvePromise, 25));
     }
     expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
 
-    const updates = await waitForScreenUpdates(child, messages, 2, logs);
+    appendFileSync(transcriptPath, piTranscriptRecord('assistant', 'final answer', 'stop'));
+
+    await waitForScreenUpdates(
+      child,
+      messages,
+      1,
+      logs,
+      update => update.status === 'idle',
+      'idle screen update',
+    );
+    const updates = messages.filter(
+      (message): message is Extract<WorkerToDaemon, { type: 'screen_update' }> =>
+        message.type === 'screen_update',
+    );
     expect(updates[0]?.status).toBe('working');
     expect(updates.at(-1)?.status).toBe('idle');
-  }, 15_000);
+  }, 20_000);
 
   it('defers a Pi transcript final that lands while the viewport still shows Working...', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-external-busy-'));
@@ -212,6 +252,10 @@ setInterval(() => {}, 1_000);
     // The bridge must be attached before the terminal record lands, otherwise
     // the append below is never ingested and no external idle fires at all.
     await waitForLog(child, logs, 'Codex bridge fresh-empty:');
+    // The turn's start: real Pi writes the user record when it begins
+    // consuming the argv prompt (required now that a started-without-terminal
+    // pi turn lifecycle-blocks ready).
+    appendFileSync(transcriptPath, piTranscriptRecord('user', 'hello from argv'));
     // Wait until the authoritative viewport provably shows Working... — the
     // first quiescence screen-idle deferral is that proof. Appending earlier
     // would race the fake's first write into the backend capture and the
@@ -222,15 +266,7 @@ setInterval(() => {}, 1_000);
     // regression covers. drainPiTranscript maps a stopReason:"stop" record
     // without tool calls to a terminal assistant_final, and codexBridgeIngest
     // fireIdle()s on it (source=external).
-    appendFileSync(transcriptPath, JSON.stringify({
-      type: 'message',
-      timestamp: new Date().toISOString(),
-      message: {
-        role: 'assistant',
-        content: [{ type: 'text', text: 'final answer' }],
-        stopReason: 'stop',
-      },
-    }) + '\n');
+    appendFileSync(transcriptPath, piTranscriptRecord('assistant', 'final answer', 'stop'));
 
     // The external idle MUST reach the busy-viewport guard (this log line is
     // the proof the transcript final was ingested and deferred — without it
@@ -267,6 +303,14 @@ setInterval(() => {}, 1_000);
     const dataDir = join(root, 'session');
     mkdirSync(dataDir, { recursive: true });
 
+    // Realistic transcript shape (user at start, terminal at end) — a started
+    // pi turn without a terminal lifecycle-blocks ready.
+    const cliSessionId = 'deadbeef-1234-4678-9abc-def012345679';
+    const piSessionsDir = join(root, '.pi', 'agent', 'sessions', dataDir.replace(/\//g, '--'));
+    mkdirSync(piSessionsDir, { recursive: true });
+    const transcriptPath = join(piSessionsDir, `20260810120000_${cliSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '');
+
     // Argv-baked first prompt (no flushPending). The fake stays running for the
     // whole first turn, then clears the screen so the turn settles idle. The
     // window must span at least a couple of SCREEN_UPDATE_INTERVAL_MS ticks so the
@@ -274,7 +318,7 @@ setInterval(() => {}, 1_000);
     const fakePi = join(root, 'fake-pi');
     writeFileSync(fakePi, `#!/usr/bin/env node
 process.stdout.write('Working...\\n');
-setTimeout(() => process.stdout.write('\\x1b[2J\\x1b[HDone without transcript final\\n'), 6_000);
+setTimeout(() => process.stdout.write('\\x1b[2J\\x1b[HDone after transcript final\\n'), 6_000);
 setInterval(() => {}, 1_000);
 `);
     chmodSync(fakePi, 0o755);
@@ -306,12 +350,16 @@ setInterval(() => {}, 1_000);
       workingDir: dataDir,
       cliId: 'pi',
       cliPathOverride: fakePi,
+      cliSessionId,
       backendType: 'pty',
       prompt: 'hello from argv',
       larkAppId: 'app_test',
       larkAppSecret: 'secret',
       turnId: 'om_turn',
     } satisfies DaemonToWorker);
+
+    await waitForLog(child, logs, 'Codex bridge fresh-empty:');
+    appendFileSync(transcriptPath, piTranscriptRecord('user', 'hello from argv'));
 
     // The publisher must emit `working` WHILE the first turn is still running —
     // i.e. before prompt_ready. This log line is the proof it fired through the
@@ -329,6 +377,10 @@ setInterval(() => {}, 1_000);
     );
     expect(preReady.some(message => message.status === 'working'), JSON.stringify(messages)).toBe(true);
     expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+    // The turn's terminal: readiness follows once the fake clears Working...
+    // (external idle defers on the busy viewport, then the probe/quiescence
+    // finishes the turn).
+    appendFileSync(transcriptPath, piTranscriptRecord('assistant', 'final answer', 'stop'));
     // Dedup: the publisher sends `working` at most once per first turn even
     // though it runs every tick (lastSentStatus guard). Count the working
     // updates emitted before the first prompt_ready lands.
@@ -350,6 +402,384 @@ setInterval(() => {}, 1_000);
     );
     expect(updates.at(-1)?.status).toBe('idle');
   }, 25_000);
+
+  it('re-arms a startup-window false idle until the argv-baked Pi first turn visibly starts', async () => {
+    // Pi's TUI paints its input box seconds before the CLI begins consuming
+    // the argv prompt (extension/model loading). In that startup window the
+    // screen shows no Working... and the transcript has no user record, so a
+    // quiescence idle means "not started yet" — it must be re-armed (no
+    // prompt_ready, no working→idle seed) and the card must stay 工作中. Once
+    // the transcript user record lands, a mid-turn quiescence idle is
+    // suppressed by the structured lifecycle gate, and the transcript final
+    // then drives the real ready edge.
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-startup-gap-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+
+    const cliSessionId = 'deadbeef-1234-4678-9abc-def01234567a';
+    const piSessionsDir = join(root, '.pi', 'agent', 'sessions', dataDir.replace(/\//g, '--'));
+    mkdirSync(piSessionsDir, { recursive: true });
+    const transcriptPath = join(piSessionsDir, `20260810120000_${cliSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '');
+
+    // The fake reproduces the gap: an idle-looking input box at spawn, total
+    // silence (NO Working...), then some mid-turn output so quiescence can
+    // fire again while the started turn is running.
+    const fakePi = join(root, 'fake-pi');
+    writeFileSync(fakePi, `#!/usr/bin/env node
+process.stdout.write('┌─ pi ──────────┐\\n│ ❯ type here   │\\n└───────────────┘\\n');
+setTimeout(() => process.stdout.write('streaming tokens\\n'), 6_000);
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakePi, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-pi-startup-gap',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-pi-startup-gap',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'pi',
+      cliPathOverride: fakePi,
+      cliSessionId,
+      backendType: 'pty',
+      prompt: 'hello from argv',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_turn',
+    } satisfies DaemonToWorker);
+
+    // The startup-window quiescence idle is re-armed by the evidence gate —
+    // this log is the proof it was caught (before the fix it flowed through
+    // markPromptReady and seeded a premature working→idle).
+    await waitForLog(child, logs, 'Argv-baked first prompt has not visibly started');
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+    expect(
+      messages.some(message => message.type === 'screen_update' && message.status === 'idle'),
+      JSON.stringify(messages),
+    ).toBe(false);
+
+    // Turn actually starts: real Pi writes the user record at that instant.
+    appendFileSync(transcriptPath, piTranscriptRecord('user', 'hello from argv'));
+
+    // Mid-turn quiescence (the fake's 6s output going quiet) must now be
+    // suppressed by the structured lifecycle gate (started turn, no terminal).
+    await waitForLog(child, logs, 'Ignoring prompt-ready heuristic while a structured turn is unfinished');
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+
+    // Terminal record → external idle → real ready + working→idle seed.
+    appendFileSync(transcriptPath, piTranscriptRecord('assistant', 'final answer', 'stop'));
+    await waitForPromptReady(child, messages, logs);
+
+    // prompt_ready is sent before the seed's working→idle pair; wait for the
+    // seed's idle to land instead of counting raw updates.
+    await waitForScreenUpdates(
+      child,
+      messages,
+      1,
+      logs,
+      update => update.status === 'idle',
+      'idle screen update',
+    );
+    const updates = messages.filter(
+      (message): message is Extract<WorkerToDaemon, { type: 'screen_update' }> =>
+        message.type === 'screen_update',
+    );
+    expect(updates.some(message => message.status === 'working'), JSON.stringify(messages)).toBe(true);
+    expect(updates.at(-1)?.status).toBe('idle');
+  }, 30_000);
+
+  it('delivers a message queued during startup even when every ready heuristic is lifecycle-blocked', async () => {
+    // The terminate-gap deadlock: the argv first turn is transcript-started
+    // but never gets a terminal record. A follow-up message arriving while
+    // awaitingFirstPrompt is still true skips handleMessage's type-ahead write
+    // and queues, relying on markPromptReady()'s tail flush — but the
+    // lifecycle gate rejects every ready heuristic (quiescence idle, the
+    // queued-message busy probe, the 15s first-prompt timeout all funnel into
+    // the same rejected markPromptReady()). Without the rejected-ready
+    // re-kick the message sits in pendingMessages forever and the card pins
+    // at 工作中. The re-kick must deliver it via Pi's type-ahead while the
+    // turn correctly stays non-ready.
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-queued-deadlock-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+
+    const cliSessionId = 'deadbeef-1234-4678-9abc-def01234567b';
+    const piSessionsDir = join(root, '.pi', 'agent', 'sessions', dataDir.replace(/\//g, '--'));
+    mkdirSync(piSessionsDir, { recursive: true });
+    const transcriptPath = join(piSessionsDir, `20260810120000_${cliSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '');
+
+    // Input-box TUI, then permanent silence — the shape a custom-tool
+    // terminate leaves behind (screen back at the prompt, no terminal record).
+    const fakePi = join(root, 'fake-pi');
+    writeFileSync(fakePi, `#!/usr/bin/env node
+process.stdout.write('┌─ pi ──────────┐\\n│ ❯ type here   │\\n└───────────────┘\\n');
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakePi, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-pi-queued-deadlock',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-pi-queued-deadlock',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'pi',
+      cliPathOverride: fakePi,
+      cliSessionId,
+      backendType: 'pty',
+      prompt: 'hello from argv',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_turn',
+    } satisfies DaemonToWorker);
+
+    await waitForLog(child, logs, 'Codex bridge fresh-empty:');
+    // Turn starts on disk but never terminates (terminate:true gap).
+    appendFileSync(transcriptPath, piTranscriptRecord('user', 'hello from argv'));
+
+    // Follow-up arrives while awaitingFirstPrompt is still true → must queue.
+    child.send({
+      type: 'message',
+      content: 'second message please',
+      turnId: 'om_turn_2',
+    } satisfies DaemonToWorker);
+    await waitForLog(child, logs, 'Queued message (');
+
+    // The rejected-ready re-kick must deliver the queued message through Pi's
+    // type-ahead path (driven by the quiescence idle / queued-message busy
+    // probe whose markPromptReady() the lifecycle gate rejects).
+    await waitForLog(child, logs, 'Writing to PTY (flush): "second message please');
+
+    // Delivery must not have required (or produced) a false ready edge: the
+    // started-without-terminal first turn keeps the session non-ready.
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+  }, 30_000);
+
+  it('holds a startup-queued message until turn-start evidence appears, then delivers via type-ahead', async () => {
+    // Startup input safety: before ANY turn-start evidence (no busy marker on
+    // the PTY stream, no transcript user record) the TUI may still be loading
+    // extensions/models, so a type-ahead paste could be dropped or land in a
+    // half-drawn screen. The evidence-gate rejection must therefore NOT
+    // re-kick flushPending() — the queued message stays queued through the
+    // gate's false-idle rejections. Once the transcript user record lands
+    // (evidence + started turn), the next lifecycle-rejected ready edge
+    // delivers it via Pi's type-ahead.
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-startup-hold-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+
+    const cliSessionId = 'deadbeef-1234-4678-9abc-def01234567c';
+    const piSessionsDir = join(root, '.pi', 'agent', 'sessions', dataDir.replace(/\//g, '--'));
+    mkdirSync(piSessionsDir, { recursive: true });
+    const transcriptPath = join(piSessionsDir, `20260810120000_${cliSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '');
+
+    // Input box at spawn, then one later output burst so a quiescence edge can
+    // re-drive markPromptReady() after the user record lands.
+    const fakePi = join(root, 'fake-pi');
+    writeFileSync(fakePi, `#!/usr/bin/env node
+process.stdout.write('┌─ pi ──────────┐\\n│ ❯ type here   │\\n└───────────────┘\\n');
+setTimeout(() => process.stdout.write('streaming tokens\\n'), 10_000);
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakePi, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-pi-startup-hold',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-pi-startup-hold',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'pi',
+      cliPathOverride: fakePi,
+      cliSessionId,
+      backendType: 'pty',
+      prompt: 'hello from argv',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_turn',
+    } satisfies DaemonToWorker);
+
+    await waitForLog(child, logs, 'Codex bridge fresh-empty:');
+    // Follow-up during the no-evidence startup window → queues.
+    child.send({
+      type: 'message',
+      content: 'second message please',
+      turnId: 'om_turn_2',
+    } satisfies DaemonToWorker);
+    await waitForLog(child, logs, 'Queued message (');
+
+    // The evidence gate rejects the startup false idle(s)...
+    await waitForLog(child, logs, 'Argv-baked first prompt has not visibly started');
+    // ...and must NOT deliver the queued message while there is still no
+    // turn-start evidence (this window also covers the queued-message busy
+    // probe's rejected markPromptReady()).
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 3_000));
+    expect(
+      logs.some(entry => entry.includes('Writing to PTY (flush)')),
+      logs.join(''),
+    ).toBe(false);
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+
+    // Turn-start evidence lands (started turn, still no terminal). The next
+    // rejected-ready edge (quiescence after the fake's 10s output, or the 15s
+    // first-prompt timeout probe) must deliver the queued message.
+    appendFileSync(transcriptPath, piTranscriptRecord('user', 'hello from argv'));
+    await waitForLog(child, logs, 'Writing to PTY (flush): "second message please');
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+  }, 35_000);
+
+  it('delivers a startup-queued message when turn-start evidence lands after every probe and timeout died', async () => {
+    // The slow-evidence deadlock: the transcript user record lands only AFTER
+    // the 15s first-prompt timeout (whose probe fired a rejected
+    // markPromptReady() and stopped), with a permanently silent PTY (no
+    // quiescence edge will ever come) and the 90s fail-open standing down on
+    // evidenceSeen. The evidence latch itself must act as the delivery
+    // driver — without it the queued second message needs a third message or
+    // fresh PTY output to unlock.
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-slow-evidence-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+
+    const cliSessionId = 'deadbeef-1234-4678-9abc-def01234567d';
+    const piSessionsDir = join(root, '.pi', 'agent', 'sessions', dataDir.replace(/\//g, '--'));
+    mkdirSync(piSessionsDir, { recursive: true });
+    const transcriptPath = join(piSessionsDir, `20260810120000_${cliSessionId}.jsonl`);
+    writeFileSync(transcriptPath, '');
+
+    // Input box once, then permanent silence.
+    const fakePi = join(root, 'fake-pi');
+    writeFileSync(fakePi, `#!/usr/bin/env node
+process.stdout.write('┌─ pi ──────────┐\\n│ ❯ type here   │\\n└───────────────┘\\n');
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakePi, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-pi-slow-evidence',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    const initSentAt = Date.now();
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-pi-slow-evidence',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'pi',
+      cliPathOverride: fakePi,
+      cliSessionId,
+      backendType: 'pty',
+      prompt: 'hello from argv',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_turn',
+    } satisfies DaemonToWorker);
+
+    await waitForLog(child, logs, 'Codex bridge fresh-empty:');
+    child.send({
+      type: 'message',
+      content: 'second message please',
+      turnId: 'om_turn_2',
+    } satisfies DaemonToWorker);
+    await waitForLog(child, logs, 'Queued message (');
+
+    // Outlive the 15s first-prompt timeout (its probe fires one rejected
+    // markPromptReady and stops). Everything that could deliver has now died.
+    while (Date.now() - initSentAt < 17_000) {
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 100));
+    }
+    expect(
+      logs.some(entry => entry.includes('Writing to PTY (flush)')),
+      logs.join(''),
+    ).toBe(false);
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+
+    // Evidence lands NOW — with a silent PTY the transcript latch is the only
+    // remaining driver and must release the queued message itself.
+    appendFileSync(transcriptPath, piTranscriptRecord('user', 'hello from argv'));
+    await waitForLog(child, logs, 'releasing startup-queued input');
+    await waitForLog(child, logs, 'Writing to PTY (flush): "second message please');
+    expect(messages.some(message => message.type === 'prompt_ready'), JSON.stringify(messages)).toBe(false);
+  }, 40_000);
 
   it('never lets an idle escape between the two working edges on a Grok-class first turn', async () => {
     // Grok arms spawnArgvInitialPromptBusy (argv-baked prompt + injectsReadyHook +

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -574,6 +574,40 @@ describe('worker structured-turn status wiring', () => {
   });
 
 
+  it('scopes the argv turn-start evidence machinery and its flush side effect to Pi', () => {
+    // The transcript-evidence latch lives on the GENERIC codexBridgeIngest
+    // path, which also serves Grok (argv-baked + structured bridge +
+    // type-ahead). Its flush side effect must be Pi-gated, or Grok would gain
+    // a new startup-window write whose first ready is owned by the
+    // SessionStart busy arm instead.
+    const note = functionSlice('noteSpawnArgvTurnStartTranscriptEvidence', 'stopSpawnArgvTurnStartFailOpen');
+    const piGuard = note.indexOf('if (!structuredBridgeIsPi()) return;');
+    const latch = note.indexOf('spawnArgvTurnStartEvidenceSeen = true');
+    const flush = note.indexOf('flushQueuedInputAfterTurnStartEvidence()');
+    expect(piGuard).toBeGreaterThanOrEqual(0);
+    expect(latch).toBeGreaterThan(piGuard);
+    expect(flush).toBeGreaterThan(latch);
+
+    const gate = functionSlice('spawnArgvTurnStartGateHolds', 'noteSpawnArgvTurnStartTranscriptEvidence');
+    expect(gate).toContain('structuredBridgeIsPi()');
+
+    // markPromptReady branch boundary: the no-evidence gate must NOT re-kick
+    // (startup input protection — the TUI may not accept input yet); the
+    // lifecycle-block branch must re-kick (turn-start evidence exists there).
+    // functionSlice('markPromptReady', …) starts at markPromptReadyFromPty
+    // (prefix match) and also spans the helper definitions, so anchor on the
+    // literal markPromptReady body before locating the two gate branches.
+    const body = functionSlice('markPromptReady', 'persistCliSessionId');
+    const markStart = body.indexOf('function markPromptReady(): void');
+    expect(markStart).toBeGreaterThanOrEqual(0);
+    const evidenceGate = body.indexOf('if (spawnArgvTurnStartGateHolds()) {', markStart);
+    const lifecycleGate = body.indexOf('if (hasStructuredLifecycleBlock()) {', markStart);
+    expect(evidenceGate).toBeGreaterThanOrEqual(0);
+    expect(lifecycleGate).toBeGreaterThan(evidenceGate);
+    expect(body.slice(evidenceGate, lifecycleGate)).not.toContain('flushQueuedInputAfterTurnStartEvidence');
+    expect(body.slice(lifecycleGate)).toContain('flushQueuedInputAfterTurnStartEvidence()');
+  });
+
   it('carries the structured mark through adopt submit confirmation and exception cleanup', () => {
     const adopt = functionSlice('writeAdoptMessage', 'isWorkflowWorker');
     const handler = source.slice(source.indexOf("case 'message':"), source.indexOf("case 'raw_input':"));


### PR DESCRIPTION
## 问题与根因

Pi 适配器把首轮 prompt 烤进 argv（`passesInitialPromptViaArgs`），worker spawn 后 Pi TUI 画完输入框到真正开始消化 prompt 之间有 ~3–9s 启动空窗（加载扩展/模型）。此期间：

- `IdleDetector` 是纯静默检测（2s 静默 + 3s 无 spinner），空窗无任何 busy 痕迹 → 触发**假 idle**；
- `deferPromptReadyWhileBusy` 只认视口上的 `Working...`，空窗屏幕还没有该标记 → 直接放行；
- `markPromptReady()` 的 `spawnArgvNeedsWorkingSeed` 分支假设「quiescence 型 argv 首轮的第一个 ready = 轮次完成」，于是补打 working→idle —— 卡片提前翻「等待输入」、daemon 触发过早 ✅ DONE；
- Pi 无 `idleToBusyPattern` 且不在 lifecycle-blocking 名单，`isPromptReady` 被假 idle 置 true 后整轮投影 idle，无法自愈。

## 三层修复

**第一层（主修）— worker「轮次已开始」证据门**
- 新增 `spawnArgvTurnStartEvidenceSeen`：spawn 后从两个通道锁存证据——① `onPtyData` 对原始 PTY 流做 ANSI 剥离滚动扫描 `busyPattern`；② `codexBridgeIngest` 摄入 live transcript `user`/`assistant_final` 事件时锁存（在 ingest 时锁存——快轮次可能在 markPromptReady 前已 emit 出队）。
- 证据出现前，启动期 quiescence idle 一律 `idleDetector.reset()` re-arm，不置 ready、不补打 working→idle；90s 有界 fail-open（generation-fenced 定时器）防 argv prompt 从未被消费时卡片永久「工作中」。
- **证据机制整体 Pi-scoped**（gate、PTY 扫描、transcript 锁存均以 `structuredBridgeIsPi()` 收口）；Gemini/OpenCode/MTR 保持原首轮行为，Grok 走既有 busy-arm 不受影响。

**第二层（防御）— pi 适配器补 `idleToBusyPattern`**
- 与 `busyPattern` 同值（`/Working\.\.\./`）。误置 ready 后 `Working...` 再现即触发 `wireIdleDetectorBusyTransition` → `isPromptReady=false` + 重发 working 自愈。`Working...` 是瞬态状态行、不进聊天历史，不会被 transcript 重绘误触发。

**第三层（长期）— pi 加入 `STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS`**
- transcript started turn 未终态时，`hasStructuredLifecycleBlock()` 压制屏幕 ready 启发式（mid-turn quiescence 不再提前 mark ready）。
- 终态契约核实（pi 0.84.2 实包 + 真实 transcript 抽样）：`drainPiTranscript` 已覆盖 stop/length（无 toolCall）+ error/aborted 硬终态；`terminate:true` 仍不落盘，新增的 `pending`/`deferred` StopReason 是 provider 流状态、不进 session JSONL → 保持 `reliableTurnTerminal` 不设。

## 启动期排队输入可达性配套

gate 拒绝 ready 后，启动期排队的消息不能失去投递驱动（`awaitingFirstPrompt` 期间到达的消息被 `shouldWriteNow` 排队，历史上依赖 markPromptReady 尾部 flush 投递；queued-message busy probe 与 15s first-prompt timeout 都经由同一个被拒的 `markPromptReady()` 短路熄火）：

- **lifecycle-block 拒绝分支补踢 `flushPending()`**：到达该分支即有 turn-start 证据（started turn / confirmed submit），TUI 可证已就绪——否则 terminate-gap 首轮的后续消息永久卡队、HOL-drop 永不发生。
- **证据门（无任何证据）拒绝分支故意不补踢**：TUI 可能仍在加载，type-ahead 写入有丢失/写错界面风险——`shouldWriteNow` 的 `awaitingFirstPrompt` hold 是启动期唯一输入保护，`flushPending` 不复查该条件。
- **transcript 证据锁存兼作投递驱动**：evidence 晚于 15s timeout 落盘且 PTY 永久静默时，markPromptReady 系驱动已全部熄火、90s fail-open 因 evidenceSeen stand down——锁存瞬间补踢是唯一剩余驱动（user 记录落盘即 TUI 可接收输入的证明）。锁存点在 `queue.ingest` 之后（补踢的 bridge mark 排在已 started 的 argv turn 之后），并以 `structuredBridgeIsPi()` 收口，不波及同为 argv-baked + structured bridge + type-ahead 的 Grok。

## 影响面评估

- **worker.ts 公共层**：`markPromptReady` 两个 gate、`onPtyData` 扫描、`codexBridgeIngest` 锁存均以 `structuredBridgeIsPi()` + `spawnArgvNeedsWorkingSeed` 双条件收口，非 Pi CLI 与非 argv 首轮路径零行为变化（静态断言测试锁定作用域与分支补踢边界）；spawnCli/killCli 增加状态复位与定时器清理。
- **structured-bridge 名单**：仅扩 lifecycle-blocking 一项；Pi 普通轮次的 mark→verify→finish 流程不变（`beginSubmitVerification` 在 writeInput 返回后即 finish，不产生长 lease）。
- **既有 Pi 集成测试**改为写真实 transcript 形态（user 起始 + stop 终态）以匹配 lifecycle-blocking 语义；fake 不落盘的旧写法在新语义下会退化为 20s lease fail-open，不再代表真实 Pi。
- **会话类型**：adopt（无 argv prompt）不 arm gate；resume 带首轮 prompt 时 gate 语义与 fresh 相同；长 prompt `@file` 形态经核实会展开原文进 user 记录，指纹匹配不受影响。

## 测试验证

- `pnpm build` ✅、`tsc --noEmit` ✅
- `worker-argv-reaction-status.integration` **10/10 全绿**，新增回归覆盖：
  - 启动空窗假 idle 被证据门 re-arm（无 prompt_ready、无 idle 卡片、持续投影 working）
  - transcript user 落盘后 mid-turn quiescence 被结构化 gate 压下
  - terminate-gap 下启动期排队消息经 type-ahead 投递（不依赖后续消息）
  - 无 start evidence 时保持排队（3s 负面窗口断言无写入），evidence 出现后才投递
  - evidence 晚于 15s timeout 落盘且 PTY 永久静默时，随证据立即投递
  - 以上投递用例均以「移除对应驱动后用例复现卡死」的反事实方式验证有效性
- 相关单测全绿：idle-detector / structured-bridge-clis / pi-transcript / codex-bridge-queue / worker-structured-lifecycle-status（含 Pi 作用域静态断言）/ cli-adapters
- 非 Pi 回归：Grok busy-arm、Gemini limited-settle、adopt Pi 用例不变且全绿
- 已部署 live daemon 在飞书话题群实测 Pi 首轮