### PR TITLE
fix(cli): ls 自动恢复休眠会话

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,6 +106,10 @@ import {
   type SessionPickerLayout,
 } from './cli/session-picker-layout.js';
 import { computeSessionPickerScrollWindow } from './cli/session-picker-viewport.js';
+import {
+  canWakeDormantBackendForAttach,
+  wakeDormantBackendForAttach,
+} from './cli/session-list-wake.js';
 import { terminalCellWidth } from './cli/terminal-width.js';
 import {
   attachFrozenManagedZmxSession,
@@ -5162,6 +5166,34 @@ function hasRecoverableBackingSession(s: SessionData, snapshot?: BackingProbeSna
   return !!target && backingProbe(snapshot, target) === 'exists';
 }
 
+async function requestDormantSessionWake(session: SessionData): Promise<
+  | { ok: true }
+  | { ok: false; error: string }
+> {
+  const online = listOnlineDaemons();
+  const daemon = session.larkAppId
+    ? online.find(d => d.larkAppId === session.larkAppId)
+    : online.length === 1 ? online[0] : undefined;
+  if (!daemon) {
+    return {
+      ok: false,
+      error: session.larkAppId || online.length === 0
+        ? '所属 daemon 不在线，请先运行 botmux status'
+        : '历史会话缺少 bot 归属，多 daemon 环境下无法安全唤醒',
+    };
+  }
+
+  try {
+    const path = `/api/sessions/${encodeURIComponent(session.sessionId)}/wake`;
+    const response = await fetchDaemonIpc(daemon.ipcPort, path, { method: 'POST' });
+    const body: any = await response.json().catch(() => ({}));
+    if (response.ok && body?.ok) return { ok: true };
+    return { ok: false, error: body?.error ?? `HTTP ${response.status}` };
+  } catch (err: any) {
+    return { ok: false, error: err?.message ?? String(err) };
+  }
+}
+
 /** Shorten path for display: replace $HOME with ~. */
 function shortenPath(p: string): string {
   const home = homedir();
@@ -5191,6 +5223,7 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
     isAdopt: boolean;
     targetLabel: string;
     canAttach: boolean;
+    canWake: boolean;
   }> {
     return active.map(s => {
       const isAdopt = isAdoptedSession(s);
@@ -5233,6 +5266,13 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
           && backing.probe === 'exists'
           && !!('attachBackend' in backing && backing.attachBackend)
           && !!('target' in backing && backing.target),
+        canWake: canWakeDormantBackendForAttach({
+          isAdopt,
+          probe: backing.probe,
+          realManagedSession: isRealManagedSession(s),
+          attachBackend: 'attachBackend' in backing ? backing.attachBackend : undefined,
+          target: 'target' in backing ? backing.target : undefined,
+        }),
       };
     });
   }
@@ -5390,6 +5430,8 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
       footerLine = `${styledFooter('warn', selected.targetLabel, labelWidth)}\x1b[2m${fitLine(suffix, width)}\x1b[0m`;
     } else if (selected.canAttach) {
       footerLine = styledFooter('success', `${selected.attachBackend}: ${selected.backendTarget?.sessionName}`, width);
+    } else if (selected.canWake) {
+      footerLine = styledFooter('warn', `${selected.targetLabel}（Enter 恢复并连接）`, width);
     } else {
       footerLine = styledFooter('dim', `${selected.targetLabel}（不可连接）`, width);
     }
@@ -5407,7 +5449,8 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
     }
 
     // Keybinding hints
-    const fullHints = `↑/↓ 选择  ⏎ ${selected?.canAttach ? '连接' : '不可连接'}  d 删除  q 退出`;
+    const enterAction = selected?.canAttach ? '连接' : selected?.canWake ? '恢复' : '不可连接';
+    const fullHints = `↑/↓ 选择  ⏎ ${enterAction}  d 删除  q 退出`;
     const compactHints = '↑/↓ 选择  ⏎  d  q';
     const hints = displayWidth(fullHints) <= width ? fullHints : compactHints;
     process.stdout.write(`\n${footerPrefix()}${styledFooter('dim', hints, width)}\n`);
@@ -5440,6 +5483,7 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
     }
 
     let deleteInFlight = false;
+    let wakeInFlight = false;
 
     async function deleteSession(idx: number): Promise<void> {
       const r = rows[idx];
@@ -5472,7 +5516,7 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
     }
 
     process.stdin.on('data', async (key: string) => {
-      if (deleteInFlight) return;
+      if (deleteInFlight || wakeInFlight) return;
       // Delete confirmation mode
       if (confirmDelete) {
         confirmDelete = false;
@@ -5531,10 +5575,32 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
           render();
           return;
         }
-        if (!selected.canAttach) {
+        if (!selected.canAttach && !selected.canWake) {
           flash = { style: 'warn', text: '该会话没有可连接的持久后端' };
           render();
           return;
+        }
+        if (selected.canWake) {
+          const target = selected.backendTarget;
+          if (!target) {
+            flash = { style: 'error', text: '恢复目标缺失' };
+            render();
+            return;
+          }
+          wakeInFlight = true;
+          flash = { style: 'warn', text: `正在恢复 ${target.backendType}: ${persistentTargetDisplay(target)}…` };
+          render();
+          const recovered = await wakeDormantBackendForAttach({
+            target,
+            wake: () => requestDormantSessionWake(selected.session),
+            probe: probePersistentBackendTarget,
+          });
+          wakeInFlight = false;
+          if (!recovered.ok) {
+            flash = { style: 'error', text: `恢复失败: ${recovered.error}` };
+            render();
+            return;
+          }
         }
         if (selected.attachBackend === 'zmx') {
           const target = selected.backendTarget;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,8 +108,10 @@ import {
 import { computeSessionPickerScrollWindow } from './cli/session-picker-viewport.js';
 import {
   canWakeDormantBackendForAttach,
+  type SessionListWakeRequestContext,
   wakeDormantBackendForAttach,
 } from './cli/session-list-wake.js';
+import { SESSION_WAKE_DEADLINE_HEADER } from './core/session-wake-deadline.js';
 import { terminalCellWidth } from './cli/terminal-width.js';
 import {
   attachFrozenManagedZmxSession,
@@ -5166,7 +5168,10 @@ function hasRecoverableBackingSession(s: SessionData, snapshot?: BackingProbeSna
   return !!target && backingProbe(snapshot, target) === 'exists';
 }
 
-async function requestDormantSessionWake(session: SessionData): Promise<
+async function requestDormantSessionWake(
+  session: SessionData,
+  context: SessionListWakeRequestContext,
+): Promise<
   | { ok: true }
   | { ok: false; error: string }
 > {
@@ -5185,7 +5190,11 @@ async function requestDormantSessionWake(session: SessionData): Promise<
 
   try {
     const path = `/api/sessions/${encodeURIComponent(session.sessionId)}/wake`;
-    const response = await fetchDaemonIpc(daemon.ipcPort, path, { method: 'POST' });
+    const response = await fetchDaemonIpc(daemon.ipcPort, path, {
+      method: 'POST',
+      signal: context.signal,
+      headers: { [SESSION_WAKE_DEADLINE_HEADER]: String(context.deadlineMs) },
+    });
     const body: any = await response.json().catch(() => ({}));
     if (response.ok && body?.ok) return { ok: true };
     return { ok: false, error: body?.error ?? `HTTP ${response.status}` };
@@ -5474,16 +5483,23 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
     };
     process.stdout.on('resize', onResize);
 
+    let deleteInFlight = false;
+    let wakeInFlight = false;
+    let wakeAbortController: AbortController | null = null;
+    let pickerClosed = false;
+
     function cleanup(): void {
+      if (pickerClosed) return;
+      pickerClosed = true;
+      wakeAbortController?.abort();
+      wakeAbortController = null;
+      process.stdin.off('data', onInput);
       process.stdout.off('resize', onResize);
       process.stdin.setRawMode(false);
       process.stdin.pause();
       process.stdout.write('\x1b[?25h');   // show cursor
       process.stdout.write('\x1b[?1049l'); // leave alt screen
     }
-
-    let deleteInFlight = false;
-    let wakeInFlight = false;
 
     async function deleteSession(idx: number): Promise<void> {
       const r = rows[idx];
@@ -5515,7 +5531,15 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
         : { style: 'warn', text: `✓ 已离线删除 ${s.sessionId.substring(0, 8)}` };
     }
 
-    process.stdin.on('data', async (key: string) => {
+    async function onInput(key: string): Promise<void> {
+      // Exit always wins, including while the wake HTTP or backend probe is
+      // pending. cleanup aborts the shared deadline signal before restoring
+      // the terminal, so Ctrl-C/q/Esc can never be swallowed by in-flight work.
+      if (key === '\x03' || key === 'q' || key === '\x1b') {
+        cleanup();
+        resolve();
+        return;
+      }
       if (deleteInFlight || wakeInFlight) return;
       // Delete confirmation mode
       if (confirmDelete) {
@@ -5527,18 +5551,11 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
         } else {
           flash = { style: 'dim', text: '取消删除' };
         }
-        render();
+        if (!pickerClosed) render();
         return;
       }
 
       flash = null;
-
-      // Ctrl-C or q or Esc
-      if (key === '\x03' || key === 'q' || key === '\x1b') {
-        cleanup();
-        resolve();
-        return;
-      }
 
       if (rows.length === 0) {
         // No sessions left, only q works
@@ -5588,14 +5605,19 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
             return;
           }
           wakeInFlight = true;
+          const wakeController = new AbortController();
+          wakeAbortController = wakeController;
           flash = { style: 'warn', text: `正在恢复 ${target.backendType}: ${persistentTargetDisplay(target)}…` };
           render();
           const recovered = await wakeDormantBackendForAttach({
             target,
-            wake: () => requestDormantSessionWake(selected.session),
+            wake: context => requestDormantSessionWake(selected.session, context),
             probe: probePersistentBackendTarget,
+            signal: wakeController.signal,
           });
+          if (wakeAbortController === wakeController) wakeAbortController = null;
           wakeInFlight = false;
+          if (pickerClosed) return;
           if (!recovered.ok) {
             flash = { style: 'error', text: `恢复失败: ${recovered.error}` };
             render();
@@ -5645,7 +5667,9 @@ function interactiveSessionPicker(active: SessionData[], probeSnapshot: BackingP
         resolve();
         return;
       }
-    });
+    }
+
+    process.stdin.on('data', onInput);
   });
 }
 

--- a/src/cli/session-list-wake.ts
+++ b/src/cli/session-list-wake.ts
@@ -1,6 +1,12 @@
 import type { PersistentBackendTarget, SessionProbe } from '../adapters/backend/types.js';
+import { SESSION_WAKE_TIMEOUT_MS } from '../core/session-wake-deadline.js';
 
-export type SessionListWakeRequest = () => Promise<
+export interface SessionListWakeRequestContext {
+  signal: AbortSignal;
+  deadlineMs: number;
+}
+
+export type SessionListWakeRequest = (context: SessionListWakeRequestContext) => Promise<
   | { ok: true }
   | { ok: false; error: string }
 >;
@@ -35,26 +41,82 @@ export async function wakeDormantBackendForAttach(options: {
   timeoutMs?: number;
   pollIntervalMs?: number;
   sleep?: (ms: number) => Promise<void>;
+  signal?: AbortSignal;
+  now?: () => number;
 }): Promise<SessionListWakeResult> {
-  const wake = await options.wake();
-  if (!wake.ok) return wake;
-
+  const now = options.now ?? Date.now;
+  const timeoutMs = Math.max(0, options.timeoutMs ?? SESSION_WAKE_TIMEOUT_MS);
+  const deadlineMs = now() + timeoutMs;
   const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? 100);
-  const attempts = Math.max(1, Math.ceil((options.timeoutMs ?? 15_000) / pollIntervalMs));
   const sleep = options.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)));
-  let lastProbe: SessionProbe = 'missing';
+  const controller = new AbortController();
+  let deadlineExpired = false;
+  let lastProbe: SessionProbe | undefined;
+  const aborted = Symbol('aborted');
+  const onCallerAbort = () => controller.abort(options.signal?.reason);
+  if (options.signal?.aborted) onCallerAbort();
+  else options.signal?.addEventListener('abort', onCallerAbort, { once: true });
 
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    lastProbe = options.probe(options.target);
-    if (lastProbe === 'exists') return { ok: true };
-    if (attempt + 1 < attempts) await sleep(pollIntervalMs);
-  }
-
-  return {
+  const deadlineTimer = setTimeout(() => {
+    deadlineExpired = true;
+    controller.abort(new Error('session wake deadline exceeded'));
+  }, Math.max(0, deadlineMs - now()));
+  deadlineTimer.unref?.();
+  const abortPromise = new Promise<typeof aborted>(resolve => {
+    if (controller.signal.aborted) resolve(aborted);
+    else controller.signal.addEventListener('abort', () => resolve(aborted), { once: true });
+  });
+  const interrupted = (): SessionListWakeResult => ({
+    ok: false,
+    error: deadlineExpired || now() >= deadlineMs ? '恢复超时' : '恢复已取消',
+    ...(lastProbe ? { lastProbe } : {}),
+  });
+  const probeTimeout = (): SessionListWakeResult => ({
     ok: false,
     error: lastProbe === 'unknown'
       ? '后端已唤醒，但持久后端状态无法确认'
       : '后端已唤醒，但等待持久会话启动超时',
-    lastProbe,
-  };
+    ...(lastProbe ? { lastProbe } : {}),
+  });
+
+  try {
+    if (controller.signal.aborted) return interrupted();
+    if (now() >= deadlineMs) {
+      deadlineExpired = true;
+      controller.abort(new Error('session wake deadline exceeded'));
+      return interrupted();
+    }
+    const wake = await Promise.race([
+      options.wake({ signal: controller.signal, deadlineMs }),
+      abortPromise,
+    ]);
+    if (wake === aborted) return interrupted();
+    if (now() >= deadlineMs) {
+      deadlineExpired = true;
+      controller.abort(new Error('session wake deadline exceeded'));
+      return interrupted();
+    }
+    if (!wake.ok) return wake;
+
+    for (;;) {
+      if (controller.signal.aborted) return interrupted();
+      if (now() >= deadlineMs) return probeTimeout();
+      lastProbe = options.probe(options.target);
+      if (lastProbe === 'exists') return { ok: true };
+
+      const remainingMs = deadlineMs - now();
+      if (remainingMs <= 0) return probeTimeout();
+      const wait = await Promise.race([
+        sleep(Math.min(pollIntervalMs, remainingMs)).then(() => 'slept' as const),
+        abortPromise,
+      ]);
+      if (wait === aborted) return interrupted();
+    }
+  } catch (err) {
+    if (controller.signal.aborted) return interrupted();
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(deadlineTimer);
+    options.signal?.removeEventListener('abort', onCallerAbort);
+  }
 }

--- a/src/cli/session-list-wake.ts
+++ b/src/cli/session-list-wake.ts
@@ -1,0 +1,60 @@
+import type { PersistentBackendTarget, SessionProbe } from '../adapters/backend/types.js';
+
+export type SessionListWakeRequest = () => Promise<
+  | { ok: true }
+  | { ok: false; error: string }
+>;
+
+export type SessionListWakeResult =
+  | { ok: true }
+  | { ok: false; error: string; lastProbe?: SessionProbe };
+
+export function canWakeDormantBackendForAttach(input: {
+  isAdopt: boolean;
+  probe: SessionProbe;
+  realManagedSession: boolean;
+  attachBackend?: 'tmux' | 'zmx';
+  target?: PersistentBackendTarget;
+}): boolean {
+  return !input.isAdopt
+    && input.probe === 'missing'
+    && input.realManagedSession
+    && !!input.attachBackend
+    && !!input.target;
+}
+
+/**
+ * Ask the owning daemon to materialize a dormant session, then wait until its
+ * exact persistent backend target is attachable. The daemon request is the
+ * concurrency fence; this helper only observes the backing target afterwards.
+ */
+export async function wakeDormantBackendForAttach(options: {
+  target: PersistentBackendTarget;
+  wake: SessionListWakeRequest;
+  probe: (target: PersistentBackendTarget) => SessionProbe;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<SessionListWakeResult> {
+  const wake = await options.wake();
+  if (!wake.ok) return wake;
+
+  const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? 100);
+  const attempts = Math.max(1, Math.ceil((options.timeoutMs ?? 15_000) / pollIntervalMs));
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)));
+  let lastProbe: SessionProbe = 'missing';
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    lastProbe = options.probe(options.target);
+    if (lastProbe === 'exists') return { ok: true };
+    if (attempt + 1 < attempts) await sleep(pollIntervalMs);
+  }
+
+  return {
+    ok: false,
+    error: lastProbe === 'unknown'
+      ? '后端已唤醒，但持久后端状态无法确认'
+      : '后端已唤醒，但等待持久会话启动超时',
+    lastProbe,
+  };
+}

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -119,7 +119,11 @@ import { enrichHistorySenders, type HistoryBotInfo } from '../dashboard/history-
 import {
   validateCodexAppManagedSendOrigin,
 } from '../utils/codex-app-dispatch-ledger.js';
-import { withBotTurnAdmission, withBotTurnMutation } from './bot-turn-mutation-gate.js';
+import { tryWithBotTurnMutation, withBotTurnAdmission, withBotTurnMutation } from './bot-turn-mutation-gate.js';
+import {
+  SESSION_WAKE_DEADLINE_HEADER,
+  sessionWakeAcquireTimeoutMs,
+} from './session-wake-deadline.js';
 import {
   protectedSessionMutationReasons,
 } from './session-mutation-guard.js';
@@ -1200,10 +1204,16 @@ ipcRoute('POST', '/api/sessions/:sessionId/restart', async (_req, res, params) =
  * Unlike restart, this is idempotent when a live worker already exists: a Lark
  * message may race the local picker, and that race must never restart an active
  * turn. Empty input re-attaches/cold-resumes without creating a model turn. */
-ipcRoute('POST', '/api/sessions/:sessionId/wake', async (_req, res, params) => {
+ipcRoute('POST', '/api/sessions/:sessionId/wake', async (req, res, params) => {
   const initial = findActiveBySessionId(params.sessionId);
   if (!initial) return jsonRes(res, 404, { ok: false, error: 'session_not_active' });
-  return withBotTurnMutation(initial.larkAppId, () => {
+  const acquireTimeoutMs = sessionWakeAcquireTimeoutMs(
+    req.headers[SESSION_WAKE_DEADLINE_HEADER],
+  );
+  const mutation = await tryWithBotTurnMutation(initial.larkAppId, acquireTimeoutMs, () => {
+    // A picker that exits aborts its fetch. If the request was queued behind an
+    // admitted turn, never materialize the session after that caller is gone.
+    if (req.aborted || res.destroyed) return;
     const ds = findActiveBySessionId(params.sessionId);
     if (!ds) return jsonRes(res, 404, { ok: false, error: 'session_not_active' });
     if (isSessionTransferring(ds)) {
@@ -1232,6 +1242,9 @@ ipcRoute('POST', '/api/sessions/:sessionId/wake', async (_req, res, params) => {
     }
     jsonRes(res, 200, { ok: true, sessionId: params.sessionId, cliId, woke: true });
   });
+  if (!mutation.acquired && !res.destroyed) {
+    jsonRes(res, 409, { ok: false, error: 'wake_mutation_timeout' });
+  }
 });
 
 /** Manually suspend one active session: kill the worker + CLI/pane, session

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1196,6 +1196,44 @@ ipcRoute('POST', '/api/sessions/:sessionId/restart', async (_req, res, params) =
   });
 });
 
+/** Materialize a dormant active session for a local `botmux list` attach.
+ * Unlike restart, this is idempotent when a live worker already exists: a Lark
+ * message may race the local picker, and that race must never restart an active
+ * turn. Empty input re-attaches/cold-resumes without creating a model turn. */
+ipcRoute('POST', '/api/sessions/:sessionId/wake', async (_req, res, params) => {
+  const initial = findActiveBySessionId(params.sessionId);
+  if (!initial) return jsonRes(res, 404, { ok: false, error: 'session_not_active' });
+  return withBotTurnMutation(initial.larkAppId, () => {
+    const ds = findActiveBySessionId(params.sessionId);
+    if (!ds) return jsonRes(res, 404, { ok: false, error: 'session_not_active' });
+    if (isSessionTransferring(ds)) {
+      return jsonRes(res, 409, { ok: false, error: 'session_transferring' });
+    }
+    if (ds.adoptedFrom || ds.initConfig?.adoptMode) {
+      return jsonRes(res, 409, { ok: false, error: 'adopt_wake_unsupported' });
+    }
+    if (isRiffBackendSession(ds)) {
+      return jsonRes(res, 409, { ok: false, error: 'riff_wake_unsupported' });
+    }
+    if (rejectProtectedSessionMutation(res, [ds])) return;
+
+    const cliId = ds.session.cliId ?? 'unknown';
+    if (ds.worker && !ds.worker.killed) {
+      return jsonRes(res, 200, {
+        ok: true,
+        sessionId: params.sessionId,
+        cliId,
+        woke: false,
+        reason: 'already_running',
+      });
+    }
+    if (!forkWorker(ds, '', ds.hasHistory)) {
+      return jsonRes(res, 409, { ok: false, error: 'wake_refused' });
+    }
+    jsonRes(res, 200, { ok: true, sessionId: params.sessionId, cliId, woke: true });
+  });
+});
+
 /** Manually suspend one active session: kill the worker + CLI/pane, session
  *  stays active and cold-resumes from its transcript on the next message —
  *  the same semantics the idle-worker sweeper applies over the live cap.

--- a/src/core/session-wake-deadline.ts
+++ b/src/core/session-wake-deadline.ts
@@ -1,0 +1,16 @@
+export const SESSION_WAKE_TIMEOUT_MS = 15_000;
+export const SESSION_WAKE_DEADLINE_HEADER = 'x-botmux-wake-deadline-ms';
+
+/** Clamp an optional trusted-host deadline to the daemon's own maximum wait. */
+export function sessionWakeAcquireTimeoutMs(
+  header: string | string[] | undefined,
+  nowMs = Date.now(),
+): number {
+  const raw = Array.isArray(header) ? header[0] : header;
+  const requested = typeof raw === 'string' && raw.trim() ? Number(raw) : Number.NaN;
+  const localDeadlineMs = nowMs + SESSION_WAKE_TIMEOUT_MS;
+  const deadlineMs = Number.isSafeInteger(requested) && requested > 0
+    ? Math.min(requested, localDeadlineMs)
+    : localDeadlineMs;
+  return Math.max(0, deadlineMs - nowMs);
+}

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -34,6 +34,11 @@ import {
 } from '../src/core/ask-broker.js';
 import { managedOriginAttestationProofPath } from '../src/core/managed-origin-capability.js';
 import { MANAGED_ORIGIN_PROOF_DOMAIN } from '../src/core/managed-origin-attestation.js';
+import {
+  __testOnly_resetBotTurnMutationGates,
+  withBotTurnAdmission,
+} from '../src/core/bot-turn-mutation-gate.js';
+import { SESSION_WAKE_DEADLINE_HEADER } from '../src/core/session-wake-deadline.js';
 
 // Loopback-HMAC the write-link routes require. Inject a known secret per test
 // (setIpcAuthSecret) and sign with it, so the suite doesn't depend on a real
@@ -1836,6 +1841,52 @@ describe('POST /api/sessions/:sessionId/wake', () => {
     } finally {
       findSpy.mockRestore();
       forkSpy.mockRestore();
+    }
+  });
+
+  it('times out while another turn holds the bot mutation gate and never wakes later', async () => {
+    const appId = 'app-list-wake-timeout';
+    const ds = {
+      larkAppId: appId,
+      session: { sessionId: 's-list-timeout', cliId: 'codex' },
+      worker: null,
+      adoptedFrom: undefined,
+      hasHistory: true,
+    } as any;
+    const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+    const forkSpy = vi.spyOn(workerPool, 'forkWorker');
+    let releaseAdmission!: () => void;
+    let markAdmissionStarted!: () => void;
+    const admissionStarted = new Promise<void>(resolve => { markAdmissionStarted = resolve; });
+    const admissionHold = new Promise<void>(resolve => { releaseAdmission = resolve; });
+    const admission = withBotTurnAdmission(appId, async () => {
+      markAdmissionStarted();
+      await admissionHold;
+    });
+
+    try {
+      await admissionStarted;
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const path = '/api/sessions/s-list-timeout/wake';
+      const res = await fetch(`http://127.0.0.1:${handle.port}${path}`, {
+        method: 'POST',
+        headers: { [SESSION_WAKE_DEADLINE_HEADER]: String(Date.now() + 50) },
+      });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toMatchObject({ ok: false, error: 'wake_mutation_timeout' });
+      expect(forkSpy).not.toHaveBeenCalled();
+
+      releaseAdmission();
+      await admission;
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(forkSpy).not.toHaveBeenCalled();
+    } finally {
+      releaseAdmission();
+      await admission;
+      findSpy.mockRestore();
+      forkSpy.mockRestore();
+      __testOnly_resetBotTurnMutationGates();
     }
   });
 });

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -1790,6 +1790,56 @@ describe('POST /api/sessions/:sessionId/restart', () => {
   });
 });
 
+describe('POST /api/sessions/:sessionId/wake', () => {
+  it('cold-resumes a worker-less active session without sending a prompt', async () => {
+    const ds = {
+      session: { sessionId: 's-list-wake', cliId: 'codex' },
+      worker: null,
+      adoptedFrom: undefined,
+      hasHistory: true,
+    } as any;
+    const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+    const forkSpy = vi.spyOn(workerPool, 'forkWorker').mockReturnValue(true);
+
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-list-wake/wake`, { method: 'POST' });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, sessionId: 's-list-wake', woke: true });
+      expect(forkSpy).toHaveBeenCalledWith(ds, '', true);
+    } finally {
+      findSpy.mockRestore();
+      forkSpy.mockRestore();
+    }
+  });
+
+  it('does not restart a live worker when a Lark wake races the local picker', async () => {
+    const send = vi.fn();
+    const ds = {
+      session: { sessionId: 's-list-race', cliId: 'codex' },
+      worker: { send, killed: false },
+      adoptedFrom: undefined,
+      hasHistory: true,
+    } as any;
+    const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+    const forkSpy = vi.spyOn(workerPool, 'forkWorker');
+
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-list-race/wake`, { method: 'POST' });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, woke: false, reason: 'already_running' });
+      expect(send).not.toHaveBeenCalled();
+      expect(forkSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      forkSpy.mockRestore();
+    }
+  });
+});
+
 describe('POST /api/sessions/:sessionId/suspend', () => {
   it('suspends a live session via suspendWorker (manual_suspend reason)', async () => {
     const ds = {

--- a/test/session-list-wake.test.ts
+++ b/test/session-list-wake.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   canWakeDormantBackendForAttach,
   wakeDormantBackendForAttach,
 } from '../src/cli/session-list-wake.js';
 
 const target = { backendType: 'tmux' as const, sessionName: 'bmx-deadbeef' };
+
+afterEach(() => vi.useRealTimers());
 
 describe('botmux list dormant backend wake', () => {
   it('offers recovery only for a missing Botmux-managed attachable backend', () => {
@@ -32,12 +34,17 @@ describe('botmux list dormant backend wake', () => {
   });
 
   it('wakes once and waits through missing/unknown probes until attachable', async () => {
-    const wake = vi.fn(async () => ({ ok: true as const }));
+    let now = 1_000;
+    const wake = vi.fn(async ({ signal, deadlineMs }: { signal: AbortSignal; deadlineMs: number }) => {
+      expect(signal.aborted).toBe(false);
+      expect(deadlineMs).toBe(1_030);
+      return { ok: true as const };
+    });
     const probe = vi.fn()
       .mockReturnValueOnce('missing')
       .mockReturnValueOnce('unknown')
       .mockReturnValueOnce('exists');
-    const sleep = vi.fn(async () => {});
+    const sleep = vi.fn(async (ms: number) => { now += ms; });
 
     await expect(wakeDormantBackendForAttach({
       target,
@@ -46,6 +53,7 @@ describe('botmux list dormant backend wake', () => {
       sleep,
       timeoutMs: 30,
       pollIntervalMs: 10,
+      now: () => now,
     })).resolves.toEqual({ ok: true });
     expect(wake).toHaveBeenCalledOnce();
     expect(probe).toHaveBeenCalledTimes(3);
@@ -65,13 +73,15 @@ describe('botmux list dormant backend wake', () => {
   });
 
   it('reports a bounded timeout without treating an unknown probe as missing', async () => {
+    let now = 1_000;
     const result = await wakeDormantBackendForAttach({
       target,
       wake: async () => ({ ok: true }),
       probe: () => 'unknown',
-      sleep: async () => {},
+      sleep: async ms => { now += ms; },
       timeoutMs: 20,
       pollIntervalMs: 10,
+      now: () => now,
     });
 
     expect(result).toMatchObject({
@@ -79,5 +89,30 @@ describe('botmux list dormant backend wake', () => {
       lastProbe: 'unknown',
       error: expect.stringContaining('无法确认'),
     });
+  });
+
+  it('aborts a never-resolving wake when the shared deadline expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000);
+    let wakeSignal: AbortSignal | undefined;
+    const wake = vi.fn(({ signal }: { signal: AbortSignal }) => {
+      wakeSignal = signal;
+      return new Promise<{ ok: true }>(() => {});
+    });
+
+    const pending = wakeDormantBackendForAttach({
+      target,
+      wake,
+      probe: () => 'missing',
+      timeoutMs: 20,
+    });
+    await vi.advanceTimersByTimeAsync(20);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('超时'),
+    });
+    expect(wake).toHaveBeenCalledOnce();
+    expect(wakeSignal?.aborted).toBe(true);
   });
 });

--- a/test/session-list-wake.test.ts
+++ b/test/session-list-wake.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  canWakeDormantBackendForAttach,
+  wakeDormantBackendForAttach,
+} from '../src/cli/session-list-wake.js';
+
+const target = { backendType: 'tmux' as const, sessionName: 'bmx-deadbeef' };
+
+describe('botmux list dormant backend wake', () => {
+  it('offers recovery only for a missing Botmux-managed attachable backend', () => {
+    expect(canWakeDormantBackendForAttach({
+      isAdopt: false,
+      probe: 'missing',
+      realManagedSession: true,
+      attachBackend: 'tmux',
+      target,
+    })).toBe(true);
+    expect(canWakeDormantBackendForAttach({
+      isAdopt: false,
+      probe: 'unknown',
+      realManagedSession: true,
+      attachBackend: 'tmux',
+      target,
+    })).toBe(false);
+    expect(canWakeDormantBackendForAttach({
+      isAdopt: true,
+      probe: 'missing',
+      realManagedSession: true,
+      attachBackend: 'tmux',
+      target,
+    })).toBe(false);
+  });
+
+  it('wakes once and waits through missing/unknown probes until attachable', async () => {
+    const wake = vi.fn(async () => ({ ok: true as const }));
+    const probe = vi.fn()
+      .mockReturnValueOnce('missing')
+      .mockReturnValueOnce('unknown')
+      .mockReturnValueOnce('exists');
+    const sleep = vi.fn(async () => {});
+
+    await expect(wakeDormantBackendForAttach({
+      target,
+      wake,
+      probe,
+      sleep,
+      timeoutMs: 30,
+      pollIntervalMs: 10,
+    })).resolves.toEqual({ ok: true });
+    expect(wake).toHaveBeenCalledOnce();
+    expect(probe).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not probe when the owning daemon refuses the wake', async () => {
+    const probe = vi.fn(() => 'exists' as const);
+    const result = await wakeDormantBackendForAttach({
+      target,
+      wake: async () => ({ ok: false, error: 'session_transferring' }),
+      probe,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'session_transferring' });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('reports a bounded timeout without treating an unknown probe as missing', async () => {
+    const result = await wakeDormantBackendForAttach({
+      target,
+      wake: async () => ({ ok: true }),
+      probe: () => 'unknown',
+      sleep: async () => {},
+      timeoutMs: 20,
+      pollIntervalMs: 10,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      lastProbe: 'unknown',
+      error: expect.stringContaining('无法确认'),
+    });
+  });
+});

--- a/test/session-picker-responsive.test.ts
+++ b/test/session-picker-responsive.test.ts
@@ -1,6 +1,7 @@
 import * as pty from 'node-pty';
 import xtermHeadless from '@xterm/headless';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { createServer } from 'node:http';
 import {
   mkdirSync,
   mkdtempSync,
@@ -87,6 +88,7 @@ function makeFixture(
   titleFor?: (index: number) => string,
   adoptTmuxTarget?: string,
   dormantTmux = false,
+  wakeDaemonPort?: number,
 ): { root: string; dataDir: string } {
   const root = mkdtempSync(join(tmpdir(), 'botmux-picker-responsive-'));
   tempDirs.push(root);
@@ -136,6 +138,19 @@ function makeFixture(
     selected.backendType = 'tmux';
     delete selected.pid;
     selected.lastCliInput = 'resume this conversation';
+    if (wakeDaemonPort !== undefined) {
+      selected.larkAppId = 'cli_test_wake';
+      const daemonDir = join(dataDir, 'dashboard-daemons');
+      mkdirSync(daemonDir, { recursive: true });
+      writeFileSync(join(daemonDir, 'cli_test_wake.json'), JSON.stringify({
+        larkAppId: 'cli_test_wake',
+        ipcPort: wakeDaemonPort,
+        lastHeartbeat: Date.now(),
+      }));
+      const configDir = join(root, '.botmux');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(join(configDir, '.dashboard-secret'), 'picker-wake-test-secret');
+    }
   }
   writeFileSync(join(dataDir, 'sessions.json'), JSON.stringify(sessions));
   return { root, dataDir };
@@ -148,13 +163,20 @@ async function spawnPicker(
   modern = false,
   adoptTmuxTarget?: string,
   dormantTmux = false,
+  wakeDaemonPort?: number,
 ): Promise<{
   child: pty.IPty;
   terminal: InstanceType<typeof Terminal>;
   renderCount: () => number;
   waitForRender: (minimum: number) => Promise<void>;
 }> {
-  const fixture = makeFixture(multiBot, titleFor, adoptTmuxTarget, dormantTmux);
+  const fixture = makeFixture(
+    multiBot,
+    titleFor,
+    adoptTmuxTarget,
+    dormantTmux,
+    wakeDaemonPort,
+  );
   const env: Record<string, string> = {
     ...(process.env as Record<string, string>),
     HOME: fixture.root,
@@ -364,5 +386,41 @@ describe('session picker real terminal responsiveness', () => {
     expect(screen.lines.some(line => line.includes('tmux: bmx-48000000') && line.includes('Enter 恢复并连接'))).toBe(true);
     expect(screen.lines.some(line => line.includes('⏎ 恢复'))).toBe(true);
     await closePicker(picker.child, picker.terminal);
+  });
+
+  it('lets q abort a never-resolving wake and exits raw mode promptly', async () => {
+    let markRequestStarted!: () => void;
+    const requestStarted = new Promise<void>(resolve => { markRequestStarted = resolve; });
+    const server = createServer(() => { markRequestStarted(); });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('test daemon did not bind a TCP port');
+
+    try {
+      const picker = await spawnPicker(120, false, undefined, false, undefined, true, address.port);
+      const exited = new Promise<void>(resolve => picker.child.onExit(() => resolve()));
+      const beforeWake = picker.renderCount();
+      picker.child.write('\r');
+      await picker.waitForRender(beforeWake + 1);
+      expect(inspectScreen(picker.terminal).lines.some(line => line.includes('正在恢复 tmux'))).toBe(true);
+      await Promise.race([
+        requestStarted,
+        delay(2_000).then(() => { throw new Error('wake request did not reach test daemon'); }),
+      ]);
+
+      picker.child.write('q');
+      await Promise.race([
+        exited,
+        delay(1_000).then(() => { throw new Error('picker did not exit after q'); }),
+      ]);
+      picker.terminal.dispose();
+      const idx = children.indexOf(picker.child);
+      if (idx >= 0) children.splice(idx, 1);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
   });
 });

--- a/test/session-picker-responsive.test.ts
+++ b/test/session-picker-responsive.test.ts
@@ -82,7 +82,12 @@ function makeTerminal(cols: number, modern = false): InstanceType<typeof Termina
   return terminal;
 }
 
-function makeFixture(multiBot: boolean, titleFor?: (index: number) => string, adoptTmuxTarget?: string): { root: string; dataDir: string } {
+function makeFixture(
+  multiBot: boolean,
+  titleFor?: (index: number) => string,
+  adoptTmuxTarget?: string,
+  dormantTmux = false,
+): { root: string; dataDir: string } {
   const root = mkdtempSync(join(tmpdir(), 'botmux-picker-responsive-'));
   tempDirs.push(root);
   const dataDir = join(root, 'data');
@@ -125,17 +130,31 @@ function makeFixture(multiBot: boolean, titleFor?: (index: number) => string, ad
       originalCliPid: process.pid,
     };
   }
+  if (dormantTmux) {
+    const selectedId = `48000000-1111-2222-3333-444444444444`;
+    const selected = sessions[selectedId] as Record<string, unknown>;
+    selected.backendType = 'tmux';
+    delete selected.pid;
+    selected.lastCliInput = 'resume this conversation';
+  }
   writeFileSync(join(dataDir, 'sessions.json'), JSON.stringify(sessions));
   return { root, dataDir };
 }
 
-async function spawnPicker(cols: number, multiBot: boolean, titleFor?: (index: number) => string, modern = false, adoptTmuxTarget?: string): Promise<{
+async function spawnPicker(
+  cols: number,
+  multiBot: boolean,
+  titleFor?: (index: number) => string,
+  modern = false,
+  adoptTmuxTarget?: string,
+  dormantTmux = false,
+): Promise<{
   child: pty.IPty;
   terminal: InstanceType<typeof Terminal>;
   renderCount: () => number;
   waitForRender: (minimum: number) => Promise<void>;
 }> {
-  const fixture = makeFixture(multiBot, titleFor, adoptTmuxTarget);
+  const fixture = makeFixture(multiBot, titleFor, adoptTmuxTarget, dormantTmux);
   const env: Record<string, string> = {
     ...(process.env as Record<string, string>),
     HOME: fixture.root,
@@ -336,6 +355,14 @@ describe('session picker real terminal responsiveness', () => {
     // The visible (printable) part of the payload still shows — only the control
     // bytes were stripped, so the label is not silently dropped.
     expect(screen.lines.some(line => line.includes('evil') && line.includes('injected'))).toBe(true);
+    await closePicker(picker.child, picker.terminal);
+  });
+
+  it('offers recovery when the selected managed tmux backend is missing', async () => {
+    const picker = await spawnPicker(120, false, undefined, false, undefined, true);
+    const screen = inspectScreen(picker.terminal);
+    expect(screen.lines.some(line => line.includes('tmux: bmx-48000000') && line.includes('Enter 恢复并连接'))).toBe(true);
+    expect(screen.lines.some(line => line.includes('⏎ 恢复'))).toBe(true);
     await closePicker(picker.child, picker.terminal);
   });
 });


### PR DESCRIPTION
## 改动内容

- botmux ls/list 选中持久后端确认缺失的 Botmux 托管会话时，向所属 daemon 请求幂等唤醒，等待精确 tmux/ZMX target 恢复后再连接。
- 新增内部 wake IPC；已有 live worker 时直接返回，不重启正在工作的会话，避免与飞书消息唤醒发生竞态。
- wake HTTP、服务端 mutation acquisition 和 backend probe 共用一个 15 秒绝对 deadline；请求退出会 abort IPC fetch。
- Ctrl-C/q/Esc 在 in-flight guard 前处理，恢复等待期间可立即退出 raw mode。
- picker 明确显示“Enter 恢复并连接”；adopt、Riff、状态探测 unknown、transfer 和受保护 mutation 保持 fail closed。

## 问题原因

主机重启会清空 tmux/ZMX backing，但活跃会话记录和 transcript 仍然保留，可由 daemon 冷恢复。此前 list 会保留这些会话行，Enter 却只连接已经存在的 backing，因此本地入口不可用，而飞书新消息仍能触发恢复。

## 影响范围

- 平台：共享 CLI/daemon IPC，macOS 和 Linux 使用同一逻辑。
- CLI：不依赖具体 CLI adapter，Claude Code、Codex 等本地 CLI 共用。
- 后端：仅 tmux/ZMX 可连接后端开放恢复；PTY、Riff、adopt 不开放。
- 会话：仅 status=active、真实 Botmux 托管、backing 确认 missing 的会话；live worker 和受保护状态不被重启。
- 可取消性：never-resolving HTTP 和被 admission 占用的 mutation gate 都有界；退出键主动中止客户端等待。

## 验证

- pnpm build
- pnpm exec vitest run --project unit test/session-list-wake.test.ts test/session-list-liveness.test.ts test/session-picker-responsive.test.ts test/dashboard-ipc.test.ts
- 4 个测试文件，167 项测试全部通过。
- never-resolving wake 下按 q 可在 1 秒内退出 raw mode；服务端 mutation 超时后不会延迟执行 forkWorker。
- 本机真实验证：missing tmux 会话在 botmux ls 中按 Enter 后完成冷恢复，target online，成功 attach/detach，未发送新 prompt。