### PR TITLE
chore(ci): 切换 npm 发布到 Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,8 +153,10 @@ jobs:
 
       - name: Upgrade npm for Trusted Publishing
         # npm Trusted Publishing (OIDC) 要求 npm CLI >= 11.5.1（需 Node >= 22.14.0）。
-        # Node 22 自带的 npm 可能不够新，这里直接升到 latest 确保支持 OIDC。
-        run: npm install -g npm@latest
+        # Node 22 自带的 npm 可能不够新，这里升级到固定的 11.19.0（2026-07-28 的最新
+        # 11.x）。不用 npm@latest —— floating latest 可能跳到 npm 12 并在 tag-push 发版
+        # 时引入破坏性改动；固定版本确保发版流程可预测。
+        run: npm install -g npm@11.19.0
 
       - name: Sync version from git tag to package.json
         run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,10 @@ jobs:
       # 永远不显示(即便 squash 出的新 commit 能从 tag 到达也不行)。此权限用于发一条
       # 可见的时间线评论作为 squash 兼容的替代。
       pull-requests: write
+      # id-token: write —— npm Trusted Publishing (OIDC) 要求 GitHub 能为本 job 签发
+      # OIDC token，npm CLI 用它向 registry 证明「确实是从已授权的 workflow 发布」，
+      # 无需存储长期 npm token。发布前须在 npmjs.com 上为两个包配置 Trusted Publisher。
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -146,6 +150,11 @@ jobs:
 
       - run: npm install -g pnpm@9.5.0
       - run: pnpm install --frozen-lockfile
+
+      - name: Upgrade npm for Trusted Publishing
+        # npm Trusted Publishing (OIDC) 要求 npm CLI >= 11.5.1（需 Node >= 22.14.0）。
+        # Node 22 自带的 npm 可能不够新，这里直接升到 latest 确保支持 OIDC。
+        run: npm install -g npm@latest
 
       - name: Sync version from git tag to package.json
         run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
@@ -240,14 +249,14 @@ jobs:
       - run: pnpm workflow-core:test
 
       - name: Publish workflow core to npm
+        # npm Trusted Publishing (OIDC) 流程:actions/setup-node 已配置 registry-url,
+        # npm CLI 检测到 id-token 权限后会自动向 GitHub OIDC Provider 请求 token 并用
+        # 它向 registry 认证,无需 NODE_AUTH_TOKEN。不传 NODE_AUTH_TOKEN 环境变量是
+        # 必需的 —— 若该变量存在,npm 会优先用它做传统认证而跳过 OIDC 流程。
         run: node scripts/publish-npm-if-missing.mjs ./packages/workflow-core "${{ steps.dist_tag.outputs.tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
       - name: Publish botmux to npm
         run: node scripts/publish-npm-if-missing.mjs . "${{ steps.dist_tag.outputs.tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

npm 正在逐步限制 CI 环境使用长期 access token，推荐使用 Trusted Publishing (OIDC) 作为更安全的替代方案。

## 改动内容

将 GitHub Actions 的 npm 发布流程从存储的 `NPM_ACCESS_TOKEN` secret 切换到 npm Trusted Publishing (OIDC)：

1. **添加 OIDC 权限**：在 `release` job 添加 `id-token: write` 权限，让 GitHub 能为该 job 签发 OIDC token
2. **升级 npm**：发布前升级 npm 到固定的 `11.19.0`（2026-07-28 的最新 11.x），满足 Trusted Publishing 要求（>= 11.5.1）。不用 `npm@latest` —— floating latest 可能跳到 npm 12 并在 tag-push 发版时引入破坏性改动
3. **移除 token 认证**：发布步骤不再传递 `NODE_AUTH_TOKEN` 环境变量，让 npm CLI 自动使用 OIDC 认证流程

## 影响范围

- ✅ `release.yml` 的 `release` job（实际发布 npm 包）
- ✅ `scripts/publish-npm-if-missing.mjs` 脚本本身不需改动（它不注入 token，仅继承环境变量）
- ℹ️ `npm-dist-tag.yml` 保持使用 token（Trusted Publishing 不支持 `npm dist-tag` 操作）
- ℹ️ `desktop` job 和其他 job 不受影响

## Trusted Publisher 配置状态

✅ 已确认两个包的 Trusted Publisher 均已配置完成：
- `botmux`
- `botmux-workflow-core`

下次 `v*` tag push 即可通过 OIDC 发布。

## 测试验证

- ✅ workflow 语法正确（GitHub Actions YAML 格式）
- ✅ 保持所有现有发版门禁（deepcoldy-only latest、防降级、master-ancestor 检查）
- ✅ 不改变 `publish-npm-if-missing.mjs` 的 fail-closed 语义
- ✅ npm 版本固定，避免意外升级
- ⚠️ 实际发版测试需等下次 tag push

## 参考

- [npm Trusted Publishing 文档](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions)
- [GitHub Actions OIDC 文档](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9ff7902-207a-4b5d-83ee-35e97920e0bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9ff7902-207a-4b5d-83ee-35e97920e0bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

