### PR TITLE
feat(cli): 增加 Bot 协作决策信息

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -203,8 +203,10 @@ import {
 } from './core/managed-origin-attestation.js';
 import { rejectLikelyWindowsStdinMojibake, decodeStdinBytes } from './cli/stdin-encoding.js';
 import {
+  collaborationHelp,
   formatBotInfoEntriesForCli,
   formatChatBotsForCli,
+  type BotCollaborationFactsByAppId,
 } from './cli/bots-list-output.js';
 import { ensureBotChatGrantMatrix, requestExactChatGrant } from './cli/exact-chat-grant-client.js';
 import {
@@ -7943,7 +7945,7 @@ import { resolveFeedbackPolicyForDelivery, resolveFeedbackTeamId } from './servi
 import { normalizeFeedbackPolicy } from './services/feedback-policy.js';
 import { applyInlineMentions } from './im/lark/inline-mentions.js';
 import { renderBrandTemplate } from './im/lark/brand-template.js';
-import { resolveBrandLabel, resolveUsageDisplay } from './bot-registry.js';
+import { effectiveDefaultWorkingDir, loadBotConfigs, resolveBrandLabel, resolveUsageDisplay } from './bot-registry.js';
 import { config } from './config.js';
 import { getSessionUsageSnapshot } from './core/cost-calculator.js';
 import {
@@ -12109,6 +12111,25 @@ async function cmdBots(sub: string, rest: string[]): Promise<void> {
   let botEntries: BotInfoEntry[] = [];
   try { if (existsSync(botInfoPath)) botEntries = JSON.parse(readFileSync(botInfoPath, 'utf-8')); } catch { /* */ }
 
+  const collaborationFactsFor = (appIds: string[]): BotCollaborationFactsByAppId => {
+    const facts: Record<string, BotCollaborationFactsByAppId[string]> = Object.create(null);
+    const wanted = new Set(appIds.filter(Boolean));
+    try {
+      for (const cfg of loadBotConfigs()) {
+        if (!wanted.has(cfg.larkAppId)) continue;
+        facts[cfg.larkAppId] = {
+          workspaceSource: cfg.oncallChats?.some(c => c.chatId === s.chatId)
+            ? 'oncall'
+            : effectiveDefaultWorkingDir(cfg) ? 'default' : 'unknown',
+          mentionMode: cfg.regularGroupMentionMode ?? 'always',
+          replyMode: cfg.chatReplyModes?.[s.chatId] ?? cfg.regularGroupReplyMode ?? 'chat-topic',
+          transport: cfg.apiOnly !== true,
+        };
+      }
+    } catch { /* config unreadable under isolation: all facts stay unknown */ }
+    return facts;
+  };
+
   try {
     const { listChatBotMembers } = await import('./im/lark/client.js');
     const chatBots = await listChatBotMembers(appId, s.chatId);
@@ -12116,12 +12137,12 @@ async function cmdBots(sub: string, rest: string[]): Promise<void> {
     // botmux daemon on this host). 'introduce' = discovered via /introduce
     // collaboration command (external bot, possibly other-tenant). isSelf is
     // retained (not filtered) so the model can still identify itself when needed.
-    const result = formatChatBotsForCli(chatBots, appId);
-    console.log(JSON.stringify({ sessionId: sid, chatId: s.chatId, bots: result, total: result.length }, null, 2));
+    const result = formatChatBotsForCli(chatBots, appId, collaborationFactsFor(chatBots.map(bot => bot.larkAppId)));
+    console.log(JSON.stringify({ sessionId: sid, chatId: s.chatId, bots: result, total: result.length, collaborationHelp }, null, 2));
   } catch (err: any) {
     // Fallback to bots-info.json
-    const result = formatBotInfoEntriesForCli(botEntries, appId);
-    console.log(JSON.stringify({ sessionId: sid, bots: result, total: result.length, note: `chat query failed: ${err.message}` }, null, 2));
+    const result = formatBotInfoEntriesForCli(botEntries, appId, collaborationFactsFor(botEntries.map(bot => bot.larkAppId)));
+    console.log(JSON.stringify({ sessionId: sid, bots: result, total: result.length, collaborationHelp, note: `chat query failed: ${err.message}` }, null, 2));
   }
 }
 

--- a/src/cli/bots-list-output.ts
+++ b/src/cli/bots-list-output.ts
@@ -7,6 +7,15 @@ export type BotInfoEntryForList = {
   cliId: string;
 };
 
+export type BotCollaborationFacts = {
+  workspaceSource: 'default' | 'oncall' | 'unknown';
+  mentionMode: 'always' | 'topic' | 'never' | 'ambient';
+  replyMode: 'chat' | 'chat-topic' | 'new-topic' | 'shared';
+  transport: boolean;
+};
+
+export type BotCollaborationFactsByAppId = Readonly<Record<string, BotCollaborationFacts>>;
+
 export type BotListOutputEntry = {
   /** Lark display name in the current chat. Good for humans, not stable for workflows. */
   name: string;
@@ -25,43 +34,217 @@ export type BotListOutputEntry = {
   mentionable: boolean;
   /** How the @-mention handle was resolved. */
   mentionSource: 'cross-ref' | 'self' | 'observed' | 'fallback';
+  /** Side-effect-free preflight hints for composing `botmux dispatch`. */
+  dispatch: {
+    /** Dispatch wakes the target with an @; `mentionable` says whether this openId is reliable. */
+    trigger: 'mention';
+    workspace: 'required' | 'optional' | 'none' | 'unknown';
+  };
+  /** Evidence available to an orchestrator before dispatching work to this bot. */
+  collaboration: {
+    reachability: 'ready' | 'needs-introduce' | 'offline' | 'unknown';
+    workspace: {
+      requirement: 'required' | 'optional' | 'none' | 'unknown';
+      source: 'default' | 'oncall' | 'inherited' | 'explicit' | 'none' | 'unknown';
+    };
+    authorization: {
+      talk: 'ready' | 'preflight-required' | 'unknown';
+      operate: boolean | 'unknown';
+    };
+    session: {
+      mentionMode: 'always' | 'topic' | 'never' | 'ambient' | 'unknown';
+      replyMode: 'chat' | 'chat-topic' | 'new-topic' | 'shared' | 'unknown';
+    };
+    runtime: {
+      transport: boolean | 'unknown';
+      deployment: 'local' | 'remote' | 'unknown';
+      stale: boolean | 'unknown';
+    };
+  };
 };
+
+export const collaborationHelp = {
+  general: 'unknown 表示当前命令没有足够证据，不等于不可用；群成员关系、本地配置和发送成功也不能单独证明目标在线或任务完成。',
+  fields: {
+    reachability: {
+      description: '当前 Bot 是否有足够证据被可靠寻址。',
+      values: {
+        ready: '已有当前群的可靠 @ 句柄，可以直接寻址；不代表目标运行时在线。',
+        'needs-introduce': '已识别配置中的 Bot，但 @ 句柄不可靠；先完成 /introduce 再依赖 @ 派发。',
+        offline: '已有权威离线证据；恢复后再派发。',
+        unknown: '缺少当前群的可靠寻址证据；先刷新花名册或完成 /introduce，不能据此判定离线。',
+      },
+    },
+    'workspace.requirement': {
+      description: '派发任务时是否需要指定仓库或工作区。',
+      values: {
+        required: '必须显式提供工作区；缺少仓库时不要派发。',
+        optional: '工作区可省略；代码任务仍应在需要时明确指定仓库。',
+        none: '该 Bot 的任务不需要工作区。',
+        unknown: '能力声明没有给出要求；派发前先确认，不能假定当前目录可用。',
+      },
+    },
+    'workspace.source': {
+      description: '目标创建会话时可用的工作区配置候选来源；目录校验或会话继承可能改变最终 cwd。',
+      values: {
+        default: '已配置目标 Bot 的默认工作区候选；不代表最终 cwd。',
+        oncall: '当前群命中 OnCall 工作区候选；不代表最终 cwd。',
+        inherited: '继承既有会话或话题的工作区。',
+        explicit: '使用派发时显式指定的工作区。',
+        none: '不需要工作区。',
+        unknown: '当前输出没有 cwd 来源证据；不要猜测目标目录。',
+      },
+    },
+    'authorization.talk': {
+      description: '是否具备普通 Bot 间对话所需的授权证据。',
+      values: {
+        ready: '已有对话授权，可以直接交互。',
+        'preflight-required': '用稳定 --bot-app 派发；发送前会建立并回读 talk-only 授权。',
+        unknown: '没有足够对话授权证据；先确认稳定目标和对话信任链路。',
+      },
+    },
+    'authorization.operate': {
+      description: '是否有执行 /repo、/restart 等管理动作的授权证据；与普通对话授权分开判断。',
+      values: {
+        true: '已有 operate 授权证据，可以执行管理动作。',
+        false: '本次 talk-only preflight 不授予 operate；/repo、/restart 等管理动作仍需单独授权。',
+        unknown: '当前命令没有 operate 授权证据；不要按 true 处理。',
+      },
+    },
+    'session.mentionMode': {
+      description: '目标 Bot 在普通群中何时要求 @ 才会响应；不描述私聊或话题群策略。',
+      values: {
+        always: '普通群内始终需要 @ 目标 Bot，包括 shared 话题内的续话。',
+        topic: '普通群顶层需要 @；shared 话题内后续非 @ 消息可继续唤起。',
+        never: '普通群内不需要 @ 即可唤起。',
+        ambient: '普通群内可免 @ 观察消息，但消息明确指向其他成员时保持安静。',
+        unknown: '没有权威普通群配置；派发时保守地使用明确寻址。',
+      },
+    },
+    'session.replyMode': {
+      description: '目标 Bot 在普通群中的回复会落在哪种会话或话题上下文；不描述私聊或话题群策略。',
+      values: {
+        chat: '普通群内复用群级会话，原生话题也折叠到同一会话。',
+        'chat-topic': '普通群顶层复用 chat-scope session；群内原生话题各自使用独立会话。',
+        'new-topic': '普通群顶层派发后新建独立话题，应在新话题跟进结果。',
+        shared: '普通群回复展示在话题中，但复用群级 chat-scope session 和 cwd。',
+        unknown: '没有权威普通群路由配置；不要假定回复位置或上下文会被继承。',
+      },
+    },
+    'runtime.transport': {
+      description: '目标 Bot 的配置是否具备飞书 transport 能力；该字段不是在线健康状态。',
+      values: {
+        true: '配置允许飞书 transport；不证明 daemon 或连接在线。',
+        false: 'apiOnly 配置明确不具备飞书 transport。',
+        unknown: '当前进程读不到权威 BotConfig；群成员关系或 Lark API 成功不能替代配置证据。',
+      },
+    },
+    'runtime.deployment': {
+      description: '目标 Bot 的部署归属；该字段不表示在线状态。',
+      values: {
+        local: '目标 App 在当前 botmux 主机有配置；仍需单独判断运行时健康。',
+        remote: '目标由远端部署管理；派发时需要保留远端回报和路径边界。',
+        unknown: '当前输出无法确定部署归属。',
+      },
+    },
+    'runtime.stale': {
+      description: '已有运行时健康证据是否过期。',
+      values: {
+        true: '健康证据已过期；派发前刷新状态。',
+        false: '有近期权威健康证据。',
+        unknown: '没有健康时间戳或探针证据；不能据此判断在线或离线。',
+      },
+    },
+  },
+} as const;
+
+function dispatchGuide(capability: string | null | undefined): BotListOutputEntry['dispatch'] {
+  const workspace = capability?.match(/\bworkspace\s*:\s*(required|optional|none)\b/i)?.[1]?.toLowerCase();
+  return {
+    trigger: 'mention',
+    workspace: workspace === 'required' || workspace === 'optional' || workspace === 'none'
+      ? workspace
+      : 'unknown',
+  };
+}
+
+function collaborationGuide(
+  row: Pick<BotListOutputEntry, 'source' | 'larkAppId' | 'isSelf' | 'mentionable' | 'dispatch'>,
+  live: boolean,
+  facts: BotCollaborationFacts | undefined,
+): BotListOutputEntry['collaboration'] {
+  const stablePeer = live && row.larkAppId !== '' && !row.isSelf;
+  return {
+    reachability: live
+      ? (row.mentionable ? 'ready' : row.source === 'configured' ? 'needs-introduce' : 'unknown')
+      : 'unknown',
+    workspace: {
+      requirement: row.dispatch.workspace,
+      source: row.dispatch.workspace === 'none' ? 'none' : facts?.workspaceSource ?? 'unknown',
+    },
+    authorization: {
+      talk: stablePeer ? 'preflight-required' : 'unknown',
+      operate: stablePeer ? false : 'unknown',
+    },
+    session: {
+      mentionMode: facts?.mentionMode ?? 'unknown',
+      replyMode: facts?.replyMode ?? 'unknown',
+    },
+    runtime: {
+      transport: facts?.transport ?? 'unknown',
+      deployment: row.larkAppId !== '' && ((live && row.source === 'configured') || facts !== undefined)
+        ? 'local'
+        : 'unknown',
+      stale: 'unknown',
+    },
+  };
+}
 
 export function formatChatBotsForCli(
   chatBots: ChatBotMember[],
   currentLarkAppId: string,
+  factsByAppId: BotCollaborationFactsByAppId = {},
 ): BotListOutputEntry[] {
-  return chatBots.map((cb) => ({
-    name: cb.displayName,
-    openId: cb.openId,
-    isSelf: cb.larkAppId === currentLarkAppId,
-    source: cb.source,
-    larkAppId: cb.larkAppId,
-    workflowBot: cb.larkAppId || null,
-    capability: cb.capability ?? null,
-    hasTeamRole: cb.hasTeamRole,
-    mentionable: cb.mentionable,
-    mentionSource: cb.mentionSource,
-  }));
+  return chatBots.map((cb) => {
+    const row = {
+      name: cb.displayName,
+      openId: cb.openId,
+      isSelf: cb.larkAppId === currentLarkAppId,
+      source: cb.source,
+      larkAppId: cb.larkAppId,
+      workflowBot: cb.larkAppId || null,
+      capability: cb.capability ?? null,
+      hasTeamRole: cb.hasTeamRole,
+      mentionable: cb.mentionable,
+      mentionSource: cb.mentionSource,
+      dispatch: dispatchGuide(cb.capability),
+    } satisfies Omit<BotListOutputEntry, 'collaboration'>;
+    return { ...row, collaboration: collaborationGuide(row, true, factsByAppId[row.larkAppId]) };
+  });
 }
 
 export function formatBotInfoEntriesForCli(
   botEntries: BotInfoEntryForList[],
   currentLarkAppId: string,
+  factsByAppId: BotCollaborationFactsByAppId = {},
 ): BotListOutputEntry[] {
   return botEntries
     .filter((b) => b.botOpenId)
-    .map((b) => ({
-      name: b.botName ?? b.cliId,
-      openId: b.botOpenId!,
-      isSelf: b.larkAppId === currentLarkAppId,
-      source: 'configured' as const,
-      larkAppId: b.larkAppId,
-      workflowBot: b.larkAppId,
-      // Local fallback path (no live chat query): we only know self reliably.
-      capability: null,
-      hasTeamRole: false,
-      mentionable: b.larkAppId === currentLarkAppId,
-      mentionSource: (b.larkAppId === currentLarkAppId ? 'self' : 'fallback') as 'self' | 'fallback',
-    }));
+    .map((b) => {
+      const row = {
+        name: b.botName ?? b.cliId,
+        openId: b.botOpenId!,
+        isSelf: b.larkAppId === currentLarkAppId,
+        source: 'configured' as const,
+        larkAppId: b.larkAppId,
+        workflowBot: b.larkAppId,
+        // Local fallback path (no live chat query): we only know self reliably.
+        capability: null,
+        hasTeamRole: false,
+        mentionable: b.larkAppId === currentLarkAppId,
+        mentionSource: (b.larkAppId === currentLarkAppId ? 'self' : 'fallback') as 'self' | 'fallback',
+        dispatch: dispatchGuide(null),
+      } satisfies Omit<BotListOutputEntry, 'collaboration'>;
+      return { ...row, collaboration: collaborationGuide(row, false, factsByAppId[row.larkAppId]) };
+    });
 }

--- a/src/cli/bots-list-output.ts
+++ b/src/cli/bots-list-output.ts
@@ -173,7 +173,15 @@ function collaborationGuide(
   live: boolean,
   facts: BotCollaborationFacts | undefined,
 ): BotListOutputEntry['collaboration'] {
-  const stablePeer = live && row.larkAppId !== '' && !row.isSelf;
+  // A "stable peer" is a locally-configured bot we can preflight a talk-only
+  // grant against. Gate on source==='configured' explicitly, not just a
+  // non-empty larkAppId: today the sole producers guarantee introduce rows
+  // carry larkAppId='' (so non-empty ⇒ configured), but talk/operate promise a
+  // "--bot-app" dispatch that REQUIRES local config — so we encode that
+  // invariant here rather than relying on it. deployment already gates the same
+  // way; this keeps a future introduce producer carrying a remote app id from
+  // silently flipping talk to preflight-required.
+  const stablePeer = live && row.larkAppId !== '' && row.source === 'configured' && !row.isSelf;
   return {
     reachability: live
       ? (row.mentionable ? 'ready' : row.source === 'configured' ? 'needs-introduce' : 'unknown')

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -549,6 +549,12 @@ botmux bots list
 - \`mentionable\`：**你能不能可靠地 @ 到它**（关键）
 - \`mentionSource\`：\`cross-ref\` | \`observed\` | \`self\` | \`fallback\`
 
+另外每行还带两块**派活前的只读决策信息**（都是从本地配置推导，不代表运行时在线）：
+- \`dispatch\`：\`trigger\`（唤醒方式，恒为 \`mention\`）+ \`workspace\`（派活要不要指定仓库：\`required\`|\`optional\`|\`none\`|\`unknown\`）
+- \`collaboration\`：\`reachability\`（能否可靠寻址）、\`workspace\`（仓库要求 + 工作区候选来源）、\`authorization\`（\`talk\` 对话授权 / \`operate\` 管理动作授权，两层分开判）、\`session\`（普通群 \`mentionMode\` 要不要 @、\`replyMode\` 回复落哪）、\`runtime\`（\`transport\` 有无飞书通道、\`deployment\` 本地/远端、\`stale\` 健康证据是否过期）
+
+顶层还有一个 \`collaborationHelp\`：**逐字段逐枚举值的中文解释就印在同一份输出里**——不确定某个值什么意思，直接查它，不用来问。
+
 \`\`\`json
 {
   "sessionId": "...",
@@ -556,9 +562,18 @@ botmux bots list
   "bots": [
     { "name": "后端Bot", "openId": "ou_yyy", "isSelf": false, "larkAppId": "cli_b",
       "capability": "服务端排查，擅长日志", "hasTeamRole": true,
-      "mentionable": true, "mentionSource": "cross-ref" }
+      "mentionable": true, "mentionSource": "cross-ref",
+      "dispatch": { "trigger": "mention", "workspace": "required" },
+      "collaboration": {
+        "reachability": "ready",
+        "workspace": { "requirement": "required", "source": "oncall" },
+        "authorization": { "talk": "preflight-required", "operate": false },
+        "session": { "mentionMode": "always", "replyMode": "chat-topic" },
+        "runtime": { "transport": true, "deployment": "local", "stale": "unknown" }
+      } }
   ],
-  "total": 1
+  "total": 1,
+  "collaborationHelp": { "general": "unknown 表示当前命令没有足够证据…", "fields": { "reachability": { "description": "…", "values": { "ready": "…" } } } }
 }
 \`\`\`
 
@@ -566,7 +581,9 @@ botmux bots list
 
 1. **只 @ \`mentionable=true\` 的机器人**。\`mentionable=false\` 表示"知道它在群里，但当前点不准"（飞书 open_id 按 app 隔离）——这种先让它 / 用户在群里 \`/introduce\` 一次，再点名。
 2. 按 \`capability\` 挑合适的队友，而不是乱点。
-3. 配合 botmux send：\`botmux send --mention "ou_yyy:后端Bot" "请帮忙处理"\`
+3. **\`unknown\` ≠ 不可用、更 ≠ 离线**：只是这条命令当前没有足够证据。别把 \`unknown\` 当成"它挂了"而放弃派活；语义拿不准就查 \`collaborationHelp\`。
+4. \`authorization.operate\` 默认按 \`false\`/\`unknown\` 处理：能对话不等于能让它跑 \`/repo\`、\`/restart\` 等管理动作，那类要单独授权。
+5. 配合 botmux send：\`botmux send --mention "ou_yyy:后端Bot" "请帮忙处理"\`
 
 ## 要把任务交棒给别的机器人？
 

--- a/test/bots-list-output.test.ts
+++ b/test/bots-list-output.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 import {
+  collaborationHelp,
   formatBotInfoEntriesForCli,
   formatChatBotsForCli,
 } from '../src/cli/bots-list-output.js';
@@ -14,7 +16,7 @@ describe('botmux bots list CLI output mapping', () => {
         name: 'codex',
         displayName: 'Codex Loopy',
         source: 'configured',
-        capability: '后端排查',
+        capability: '后端排查; workspace:required',
         hasTeamRole: true,
         mentionable: true,
         mentionSource: 'cross-ref',
@@ -25,6 +27,7 @@ describe('botmux bots list CLI output mapping', () => {
         name: 'claude',
         displayName: 'Claude Loopy',
         source: 'configured',
+        capability: 'writing; workspace: none',
         hasTeamRole: false,
         mentionable: false,
         mentionSource: 'self',
@@ -41,7 +44,7 @@ describe('botmux bots list CLI output mapping', () => {
       },
     ], 'cli_self');
 
-    expect(rows).toEqual([
+    expect(rows).toMatchObject([
       {
         name: 'Codex Loopy',
         openId: 'ou_self',
@@ -49,10 +52,11 @@ describe('botmux bots list CLI output mapping', () => {
         source: 'configured',
         larkAppId: 'cli_self',
         workflowBot: 'cli_self',
-        capability: '后端排查',
+        capability: '后端排查; workspace:required',
         hasTeamRole: true,
         mentionable: true,
         mentionSource: 'cross-ref',
+        dispatch: { trigger: 'mention', workspace: 'required' },
       },
       {
         name: 'Claude Loopy',
@@ -61,10 +65,11 @@ describe('botmux bots list CLI output mapping', () => {
         source: 'configured',
         larkAppId: 'cli_peer',
         workflowBot: 'cli_peer',
-        capability: null,
+        capability: 'writing; workspace: none',
         hasTeamRole: false,
         mentionable: false,
         mentionSource: 'self',
+        dispatch: { trigger: 'mention', workspace: 'none' },
       },
       {
         name: 'External Loopy',
@@ -77,6 +82,7 @@ describe('botmux bots list CLI output mapping', () => {
         hasTeamRole: false,
         mentionable: true,
         mentionSource: 'observed',
+        dispatch: { trigger: 'mention', workspace: 'unknown' },
       },
     ]);
   });
@@ -103,7 +109,7 @@ describe('botmux bots list CLI output mapping', () => {
       },
     ], 'cli_self');
 
-    expect(rows).toEqual([
+    expect(rows).toMatchObject([
       {
         name: 'codex',
         openId: 'ou_self',
@@ -115,6 +121,7 @@ describe('botmux bots list CLI output mapping', () => {
         hasTeamRole: false,
         mentionable: true,
         mentionSource: 'self',
+        dispatch: { trigger: 'mention', workspace: 'unknown' },
       },
       {
         name: 'Claude Loopy',
@@ -127,7 +134,170 @@ describe('botmux bots list CLI output mapping', () => {
         hasTeamRole: false,
         mentionable: false,
         mentionSource: 'fallback',
+        dispatch: { trigger: 'mention', workspace: 'unknown' },
       },
     ]);
+  });
+
+  it('S-1 gives a mentionable local peer actionable config-backed dispatch evidence', () => {
+    const [row] = formatChatBotsForCli([{
+      larkAppId: 'cli_peer',
+      openId: 'ou_peer',
+      name: 'codex',
+      displayName: 'Codex Peer',
+      source: 'configured',
+      capability: 'code; workspace:required',
+      hasTeamRole: true,
+      mentionable: true,
+      mentionSource: 'cross-ref',
+    }], 'cli_self', {
+      cli_peer: {
+        workspaceSource: 'oncall',
+        mentionMode: 'topic',
+        replyMode: 'shared',
+        transport: true,
+      },
+    });
+
+    expect(row.dispatch).toEqual({ trigger: 'mention', workspace: 'required' });
+    expect(row.collaboration).toMatchObject({
+      reachability: 'ready',
+      workspace: { requirement: 'required', source: 'oncall' },
+      authorization: { talk: 'preflight-required', operate: false },
+      session: { mentionMode: 'topic', replyMode: 'shared' },
+      runtime: { transport: true, deployment: 'local', stale: 'unknown' },
+    });
+
+    const [defaulted] = formatChatBotsForCli([{
+      larkAppId: 'cli_api_only',
+      openId: 'ou_api_only',
+      name: 'headless',
+      displayName: 'Headless Peer',
+      source: 'configured',
+      capability: 'workspace:optional',
+      hasTeamRole: false,
+      mentionable: false,
+      mentionSource: 'fallback',
+    }], 'cli_self', {
+      cli_api_only: {
+        workspaceSource: 'default',
+        mentionMode: 'always',
+        replyMode: 'chat-topic',
+        transport: false,
+      },
+    });
+    expect(defaulted.collaboration).toMatchObject({
+      workspace: { requirement: 'optional', source: 'default' },
+      session: { mentionMode: 'always', replyMode: 'chat-topic' },
+      runtime: { transport: false },
+    });
+  });
+
+  it('S-1 reads peer facts from authoritative BotConfig rather than the transient registry', () => {
+    const cliSource = readFileSync(new URL('../src/cli.ts', import.meta.url), 'utf8');
+    const factsBuilder = cliSource.match(/const collaborationFactsFor[\s\S]*?\n  };/)?.[0] ?? '';
+
+    expect(factsBuilder).toContain('loadBotConfigs()');
+    expect(factsBuilder).not.toContain('getBot(');
+    expect(factsBuilder).not.toContain('registerBot(');
+    expect(factsBuilder).toContain('catch');
+    for (const sensitive of ['ownerOpenId', 'allowedUsers', 'chatGrants', 'globalGrants', 'sandboxPaths', 'env', 'larkAppSecret']) {
+      expect(factsBuilder).not.toContain(sensitive);
+    }
+  });
+
+  it('S-2 keeps unsupported fallback and external conclusions unknown without leaking sensitive config', () => {
+    const [fallback] = formatBotInfoEntriesForCli([{
+      larkAppId: 'cli_peer',
+      botOpenId: 'ou_peer',
+      botName: 'Peer',
+      cliId: 'codex',
+    }], 'cli_self');
+    const [external] = formatChatBotsForCli([{
+      larkAppId: '',
+      openId: 'ou_external',
+      name: 'external',
+      displayName: 'External',
+      source: 'introduce',
+      hasTeamRole: false,
+      mentionable: true,
+      mentionSource: 'observed',
+    }], 'cli_self');
+    const [configuredWithoutFacts] = formatChatBotsForCli([{
+      larkAppId: 'cli_unreadable',
+      openId: 'ou_unreadable',
+      name: 'unreadable',
+      displayName: 'Unreadable Config',
+      source: 'configured',
+      hasTeamRole: false,
+      mentionable: true,
+      mentionSource: 'cross-ref',
+    }], 'cli_self');
+
+    expect(fallback.collaboration).toMatchObject({
+      reachability: 'unknown',
+      workspace: { requirement: 'unknown', source: 'unknown' },
+      authorization: { talk: 'unknown', operate: 'unknown' },
+      session: { mentionMode: 'unknown', replyMode: 'unknown' },
+      runtime: { transport: 'unknown', deployment: 'unknown', stale: 'unknown' },
+    });
+    expect(external.collaboration).toMatchObject({
+      workspace: { requirement: 'unknown', source: 'unknown' },
+      authorization: { talk: 'unknown', operate: 'unknown' },
+      session: { mentionMode: 'unknown', replyMode: 'unknown' },
+      runtime: { transport: 'unknown', deployment: 'unknown', stale: 'unknown' },
+    });
+    expect(configuredWithoutFacts.collaboration).toMatchObject({
+      workspace: { requirement: 'unknown', source: 'unknown' },
+      session: { mentionMode: 'unknown', replyMode: 'unknown' },
+      runtime: { transport: 'unknown', stale: 'unknown' },
+    });
+
+    const serialized = JSON.stringify({ bots: [fallback, external, configuredWithoutFacts], collaborationHelp });
+    for (const key of ['ownerOpenId', 'allowedUsers', 'chatGrants', 'globalGrants', 'oncallChats', 'defaultWorkingDir', 'workingDir', 'sandboxPaths', 'env', 'larkAppSecret', 'secret']) {
+      expect(serialized).not.toContain(`\"${key}\"`);
+    }
+  });
+
+  it('S-3 documents every collaboration value and wires one top-level help object per output path', () => {
+    const expectedValues: Record<string, string[]> = {
+      reachability: ['ready', 'needs-introduce', 'offline', 'unknown'],
+      'workspace.requirement': ['required', 'optional', 'none', 'unknown'],
+      'workspace.source': ['default', 'oncall', 'inherited', 'explicit', 'none', 'unknown'],
+      'authorization.talk': ['ready', 'preflight-required', 'unknown'],
+      'authorization.operate': ['true', 'false', 'unknown'],
+      'session.mentionMode': ['always', 'topic', 'never', 'ambient', 'unknown'],
+      'session.replyMode': ['chat', 'chat-topic', 'new-topic', 'shared', 'unknown'],
+      'runtime.transport': ['true', 'false', 'unknown'],
+      'runtime.deployment': ['local', 'remote', 'unknown'],
+      'runtime.stale': ['true', 'false', 'unknown'],
+    };
+
+    expect(Object.keys(collaborationHelp.fields)).toEqual(Object.keys(expectedValues));
+    for (const [field, values] of Object.entries(expectedValues)) {
+      const help = collaborationHelp.fields[field as keyof typeof collaborationHelp.fields];
+      expect(help.description.length).toBeGreaterThan(0);
+      expect(Object.keys(help.values)).toEqual(values);
+      expect(Object.values(help.values).every(value => value.length > 0)).toBe(true);
+    }
+    expect(collaborationHelp.general).toContain('不等于不可用');
+    expect(collaborationHelp.fields['authorization.talk'].values['preflight-required']).toContain('talk-only');
+    expect(collaborationHelp.fields['authorization.operate'].values.false).toContain('/repo');
+    expect(collaborationHelp.fields['authorization.operate'].values.false).toContain('/restart');
+    expect(collaborationHelp.fields['workspace.source'].description).toContain('候选');
+    expect(collaborationHelp.fields['workspace.source'].description).toContain('最终 cwd');
+    expect(collaborationHelp.fields['session.mentionMode'].description).toContain('普通群');
+    expect(collaborationHelp.fields['session.replyMode'].description).toContain('普通群');
+    expect(collaborationHelp.fields['session.mentionMode'].values.topic).toContain('shared');
+    expect(collaborationHelp.fields['session.replyMode'].values['chat-topic']).toContain('chat-scope');
+    expect(collaborationHelp.fields['session.replyMode'].values.shared).toContain('cwd');
+    expect(collaborationHelp.fields['runtime.transport'].description).toContain('不是在线健康状态');
+    expect(collaborationHelp.fields['runtime.transport'].values.true).toContain('不证明 daemon');
+    expect(collaborationHelp.fields['runtime.transport'].values.false).toContain('apiOnly');
+
+    const cliSource = readFileSync(new URL('../src/cli.ts', import.meta.url), 'utf8');
+    const outputLines = cliSource.split('\n').filter(line => line.includes('console.log(JSON.stringify({ sessionId: sid') && line.includes('collaborationHelp'));
+    expect(outputLines).toHaveLength(2);
+    expect(outputLines.every(line => (line.match(/collaborationHelp/g) ?? []).length === 1)).toBe(true);
   });
 });

--- a/test/bots-list-output.test.ts
+++ b/test/bots-list-output.test.ts
@@ -259,6 +259,40 @@ describe('botmux bots list CLI output mapping', () => {
     }
   });
 
+  it('S-2b gates talk/operate on source===configured, not just a non-empty larkAppId', () => {
+    // Today the sole producers guarantee introduce rows carry larkAppId='' (so
+    // non-empty ⇒ configured). This locks in the defense for a HYPOTHETICAL
+    // future introduce producer that carries a remote stable app id: talk/operate
+    // promise a --bot-app dispatch that requires LOCAL config, so a non-configured
+    // row — even with a non-empty larkAppId — must fall to unknown, never silently
+    // flip to preflight-required. (deployment already gates the same way.)
+    const [introduceWithAppId] = formatChatBotsForCli([{
+      larkAppId: 'cli_remote_future',
+      openId: 'ou_remote',
+      name: 'remote',
+      displayName: 'Remote Introduced',
+      source: 'introduce',
+      hasTeamRole: false,
+      mentionable: true,
+      mentionSource: 'observed',
+    }], 'cli_self');
+    expect(introduceWithAppId.collaboration.authorization).toEqual({ talk: 'unknown', operate: 'unknown' });
+    expect(introduceWithAppId.collaboration.runtime.deployment).toBe('unknown');
+
+    // A locally-configured peer with the same non-empty larkAppId DOES preflight.
+    const [configuredPeer] = formatChatBotsForCli([{
+      larkAppId: 'cli_local',
+      openId: 'ou_local',
+      name: 'local',
+      displayName: 'Local Peer',
+      source: 'configured',
+      hasTeamRole: false,
+      mentionable: true,
+      mentionSource: 'cross-ref',
+    }], 'cli_self');
+    expect(configuredPeer.collaboration.authorization).toEqual({ talk: 'preflight-required', operate: false });
+  });
+
   it('S-3 documents every collaboration value and wires one top-level help object per output path', () => {
     const expectedValues: Record<string, string[]> = {
       reachability: ['ready', 'needs-introduce', 'offline', 'unknown'],

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -171,6 +171,19 @@ describe('built-in botmux-bots skill (collaboration roster)', () => {
     expect(skill!.content).toContain('/introduce');
     expect(skill!.content).toContain('botmux-handoff');
   });
+
+  it('documents the dispatch/collaboration decision fields and the inline help', () => {
+    // Guards against doc drift: the CLI output carries dispatch/collaboration
+    // blocks + a top-level collaborationHelp. An agent that reads this skill
+    // (not just the injected inline help) must learn those fields exist and
+    // that `unknown` means "no evidence", not "offline".
+    const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-bots');
+    expect(skill!.content).toContain('dispatch');
+    expect(skill!.content).toContain('collaboration');
+    expect(skill!.content).toContain('collaborationHelp');
+    expect(skill!.content).toContain('operate');
+    expect(skill!.content).toContain('unknown');
+  });
 });
 
 describe('built-in botmux-handoff skill', () => {


### PR DESCRIPTION
## 改动

- 为 `botmux bots list` 的每个 Bot 增加 `dispatch` 与 `collaboration` 决策数据，覆盖寻址、工作区、授权、普通群会话策略和运行时证据。
- 在顶层增加 `collaborationHelp`，逐字段解释每个枚举值的含义和派发决策边界。
- 仅投影本地配置中的安全枚举和布尔值；读取不到权威配置时返回 `unknown`，不输出路径、owner、授权名单、sandbox、env 或密钥。
- 修正 fallback 的部署归属判断，并明确 `workspace.source` 是会话创建时的配置候选，而不是最终 cwd。

## 原因

编排者在 dispatch 前需要知道目标 Bot 是否可稳定寻址、是否需要仓库、是否要求 @、回复会落在哪种上下文，以及普通对话与管理操作的授权边界，避免凭群成员关系或旧缓存做错误推断。

## 影响面

- 仅影响 `bots list` 的 JSON 输出和对应纯映射测试。
- 不修改 CLI adapter、Pty/Tmux backend、会话创建或消息发送逻辑。
- 普通群 mention/reply 策略在帮助中明确限定；私聊和话题群行为不变。
- read-isolation 下继续使用当前 Bot 的 send-cred；完整配置不可读时协作事实保持 `unknown`。

## 验证

- `pnpm exec vitest run test/bots-list-output.test.ts test/bots-list-cred-registration.test.ts`：7/7 通过。
- `pnpm build`：通过。
- `git diff --check origin/master...HEAD`：通过。
- 实际 Lark 群执行 `botmux bots list`：返回 7 个 Bot，其中 3 个本地配置 Bot、2 个稳定 peer；10 个帮助字段齐全，敏感键检查通过。
- `pnpm daemon:restart` 后 6 个进程均为 online，重启计数为 0。

## 已知边界

现有 capability 未声明 `workspace:required|optional|none` 时，工作区要求按设计返回 `unknown`。