### PR TITLE
fix(daemon): 修复 PM2 God 的 systemd cgroup 归属

### DIFF
--- a/src/autostart.ts
+++ b/src/autostart.ts
@@ -18,6 +18,14 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync, readFileSync } from 'node:fs';
 import { homedir, userInfo } from 'node:os';
 import { join, dirname } from 'node:path';
+import {
+  BOTMUX_SYSTEMD_SERVICE,
+  BOTMUX_SYSTEMD_SERVICE_ENV,
+  describeExternalPm2Owner,
+  inspectLinuxPm2GodOwnership,
+  revalidateLinuxPm2GodProcess,
+  type LinuxPm2GodProcess,
+} from './core/pm2-lifecycle-owner.js';
 
 export interface AutostartOpts {
   /** Absolute path to the botmux package root (one level up from dist/). */
@@ -29,7 +37,15 @@ export interface AutostartOpts {
 }
 
 const LABEL = 'com.botmux.daemon';
-const SERVICE_NAME = 'botmux.service';
+const SERVICE_NAME = BOTMUX_SYSTEMD_SERVICE;
+const SYSTEMCTL_DEFAULT_TIMEOUT_MS = 10_000;
+// A restart job may wait behind unrelated user-manager work. Enqueue it
+// without blocking, then poll explicitly; on expiry we cancel the unit job and
+// keep the repair driver alive until systemd confirms there is no late restart.
+const SYSTEMD_RESTART_JOB_WAIT_MS = 255_000;
+const SYSTEMD_CANCEL_SETTLE_WAIT_MS = 240_000;
+const SYSTEMD_JOB_POLL_MS = 200;
+const SYSTEMD_JOB_POLL_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 const WINDOWS_TASK_NAME = 'botmux-daemon';
 
 function platform(): 'macos' | 'linux' | 'windows' | 'unsupported' {
@@ -196,38 +212,450 @@ function statusMac(): void {
 
 // ─── Linux (user systemd) ────────────────────────────────────────────────────
 
-function unitContent(opts: AutostartOpts): string {
-  // Type=oneshot + RemainAfterExit=yes because `botmux start` calls pm2
-  // start which forks and returns immediately; without RemainAfterExit
-  // systemd would consider the unit "inactive (dead)" right after launch.
+export function renderLinuxSystemdUnit(opts: AutostartOpts): string {
+  // PM2 forks its God daemon and records the child PID before `botmux start`
+  // returns. Type=forking + PIDFile makes that God the service's MainPID, so
+  // systemd owns both its cgroup and its lifetime instead of merely remembering
+  // that a one-shot launcher once succeeded.
   return `[Unit]
 Description=botmux daemon (IM <-> AI coding CLI bridge)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=forking
+PIDFile=${join(opts.configDir, 'pm2', 'pm2.pid')}
+# ExecStop retires the Botmux fleet and then terminates the exact PM2 God.
+# systemd must not terminate the God after a failed attested shutdown. ExecStop
+# owns the exact SIGTERM; systemd's fallback signal is deliberately non-fatal.
+# Persistent tmux/herdr/zellij sessions survive for the next daemon.
+KillMode=process
+KillSignal=SIGCONT
+RestartKillSignal=SIGCONT
+FinalKillSignal=SIGCONT
+SendSIGKILL=no
+TimeoutStopSec=45
+TimeoutStartSec=180
 WorkingDirectory=${opts.configDir}
 Environment=PATH=${currentPath()}
-ExecStart=${nodeBin()} ${cliJs(opts)} start
-ExecStop=${nodeBin()} ${cliJs(opts)} stop
+Environment=${BOTMUX_SYSTEMD_SERVICE_ENV}=${SERVICE_NAME}
+ExecStart=${nodeBin()} ${cliJs(opts)} start --systemd-service
+ExecStop=${nodeBin()} ${cliJs(opts)} stop --systemd-service
 
 [Install]
 WantedBy=default.target
 `;
 }
 
+export interface LinuxSystemdServiceState {
+  loadState: string;
+  activeState: string;
+  subState: string;
+  type: string;
+  mainPid: number;
+  killMode: string;
+  killSignal: string;
+  restartKillSignal: string;
+  finalKillSignal: string;
+  sendSigkill: string;
+  timeoutStart: string;
+  timeoutStop: string;
+  workingDirectory: string;
+  pidFile: string;
+  environment: string;
+  execStart: string;
+  execStop: string;
+  job: string;
+}
+
+export function parseLinuxSystemdShow(output: string): LinuxSystemdServiceState {
+  const values = new Map<string, string>();
+  for (const line of output.split(/\r?\n/)) {
+    const separator = line.indexOf('=');
+    if (separator <= 0) continue;
+    values.set(line.slice(0, separator), line.slice(separator + 1));
+  }
+  const parsedMainPid = Number.parseInt(values.get('MainPID') ?? '0', 10);
+  return {
+    loadState: values.get('LoadState') ?? '',
+    activeState: values.get('ActiveState') ?? '',
+    subState: values.get('SubState') ?? '',
+    type: values.get('Type') ?? '',
+    mainPid: Number.isSafeInteger(parsedMainPid) && parsedMainPid > 1 ? parsedMainPid : 0,
+    killMode: values.get('KillMode') ?? '',
+    killSignal: values.get('KillSignal') ?? '',
+    restartKillSignal: values.get('RestartKillSignal') ?? '',
+    finalKillSignal: values.get('FinalKillSignal') ?? '',
+    sendSigkill: values.get('SendSIGKILL') ?? '',
+    timeoutStart: values.get('TimeoutStartUSec') ?? '',
+    timeoutStop: values.get('TimeoutStopUSec') ?? '',
+    workingDirectory: values.get('WorkingDirectory') ?? '',
+    pidFile: values.get('PIDFile') ?? '',
+    environment: values.get('Environment') ?? '',
+    execStart: values.get('ExecStart') ?? '',
+    execStop: values.get('ExecStop') ?? '',
+    job: values.get('Job') ?? '',
+  };
+}
+
+export function assessLinuxSystemdService(input: {
+  state: LinuxSystemdServiceState;
+  expectedPidFile: string;
+  expectedNodeBin: string;
+  expectedCliJs: string;
+  expectedWorkingDirectory: string;
+  expectedPath: string;
+  godPids: number[];
+}): { errors: string[]; restartRequired: boolean } {
+  const errors: string[] = [];
+  const { state } = input;
+  if (state.loadState !== 'loaded') errors.push(`LoadState=${state.loadState || '(empty)'}`);
+  if (state.job) errors.push(`pending systemd Job=${state.job}`);
+  if (new Set(['activating', 'deactivating', 'reloading']).has(state.activeState)) {
+    errors.push(`ActiveState=${state.activeState}`);
+  }
+  if (state.type !== 'forking') errors.push(`Type=${state.type || '(empty)'}`);
+  if (state.killMode !== 'process') errors.push(`KillMode=${state.killMode || '(empty)'}`);
+  const sigcont = new Set(['18', 'SIGCONT']);
+  if (!sigcont.has(state.killSignal)) errors.push(`KillSignal=${state.killSignal || '(empty)'}`);
+  if (!sigcont.has(state.restartKillSignal)) {
+    errors.push(`RestartKillSignal=${state.restartKillSignal || '(empty)'}`);
+  }
+  if (!sigcont.has(state.finalKillSignal)) {
+    errors.push(`FinalKillSignal=${state.finalKillSignal || '(empty)'}`);
+  }
+  if (state.sendSigkill !== 'no') errors.push(`SendSIGKILL=${state.sendSigkill || '(empty)'}`);
+  if (state.timeoutStart !== '3min') {
+    errors.push(`TimeoutStartSec=${state.timeoutStart || '(empty)'}`);
+  }
+  if (state.timeoutStop !== '45s') {
+    errors.push(`TimeoutStopSec=${state.timeoutStop || '(empty)'}`);
+  }
+  if (state.workingDirectory !== input.expectedWorkingDirectory) {
+    errors.push(`WorkingDirectory=${state.workingDirectory || '(empty)'}`);
+  }
+  if (state.pidFile !== input.expectedPidFile) {
+    errors.push(`PIDFile=${state.pidFile || '(empty)'}`);
+  }
+  const environmentAssignments = state.environment.match(/"[^"]*"|\S+/g)
+    ?.map(value => value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value)
+    ?? [];
+  if (!environmentAssignments.includes(`${BOTMUX_SYSTEMD_SERVICE_ENV}=${SERVICE_NAME}`)) {
+    errors.push(`Environment 缺少 ${BOTMUX_SYSTEMD_SERVICE_ENV}=${SERVICE_NAME}`);
+  }
+  const effectivePaths = environmentAssignments.filter(value => value.startsWith('PATH='));
+  if (JSON.stringify(effectivePaths) !== JSON.stringify([`PATH=${input.expectedPath}`])) {
+    errors.push(`Environment PATH=${effectivePaths.join(',') || '(empty)'}`);
+  }
+  if (input.godPids.length > 1) {
+    errors.push(`multiple PM2 God daemons: ${input.godPids.join(', ')}`);
+  }
+  const effectiveArgv = (value: string): string[] => [...value.matchAll(/argv\[\]=([^;]*?)\s*;/g)]
+    .map(match => match[1]!.trim());
+  const expectedStartArgv = `${input.expectedNodeBin} ${input.expectedCliJs} start --systemd-service`;
+  if (JSON.stringify(effectiveArgv(state.execStart)) !== JSON.stringify([expectedStartArgv])) {
+    errors.push(
+      `systemd 有效 ExecStart 被 drop-in 覆盖: ${state.execStart || '(empty)'}`,
+    );
+  }
+  const expectedStopArgv = `${input.expectedNodeBin} ${input.expectedCliJs} stop --systemd-service`;
+  if (JSON.stringify(effectiveArgv(state.execStop)) !== JSON.stringify([expectedStopArgv])) {
+    errors.push(`ExecStop=${state.execStop || '(empty)'}`);
+  }
+  const exactGod = input.godPids.length === 1 ? input.godPids[0] : 0;
+  const restartRequired = state.activeState !== 'active'
+    || state.subState !== 'running'
+    || exactGod === 0
+    || state.mainPid !== exactGod;
+  return { errors, restartRequired };
+}
+
 function userSystemdAvailable(): boolean {
   // Check the user manager is reachable. In containers / sshd-without-DBus
   // sessions `systemctl --user` will fail with "Failed to connect to bus".
-  const r = spawnSync('systemctl', ['--user', 'show-environment'], { stdio: 'pipe' });
+  const r = spawnSync('systemctl', ['--user', 'show-environment'], {
+    stdio: 'pipe',
+    timeout: SYSTEMCTL_DEFAULT_TIMEOUT_MS,
+  });
   return r.status === 0;
+}
+
+export function linuxUserSystemdAvailable(): boolean {
+  return process.platform === 'linux' && userSystemdAvailable();
+}
+
+function assertLinuxServiceOwnershipAvailable(opts: AutostartOpts): void {
+  const ownership = inspectLinuxPm2GodOwnership(join(opts.configDir, 'pm2'));
+  if (ownership.kind !== 'external') return;
+  throw new Error(
+    `检测到 PM2 God Daemon 不属于 ${SERVICE_NAME}: ${describeExternalPm2Owner(ownership)}。\n`
+    + `为避免复用其它 supervisor 的 cgroup，本次操作已中止。请先停止 Botmux Session，`
+    + `再由原 owner 停掉该 PM2 God，最后重试。`,
+  );
+}
+
+function systemctlUser(args: string[], timeout = SYSTEMCTL_DEFAULT_TIMEOUT_MS): string {
+  const result = spawnSync('systemctl', ['--user', ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout,
+  });
+  if (result.status !== 0) {
+    const stderr = String(result.stderr ?? '').trim();
+    const detail = result.error?.message ?? (stderr || `status ${result.status}`);
+    throw new Error(`systemctl --user ${args.join(' ')} 失败: ${detail}`);
+  }
+  return String(result.stdout ?? '');
+}
+
+function writeLinuxServiceUnit(opts: AutostartOpts): { path: string; changed: boolean } {
+  const path = unitPath();
+  let changed = false;
+  const content = renderLinuxSystemdUnit(opts);
+  const previous = existsSync(path) ? readFileSync(path, 'utf8') : undefined;
+  if (previous !== content) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content);
+    changed = true;
+  }
+  return { path, changed };
+}
+
+export function inspectLinuxSystemdService(): LinuxSystemdServiceState {
+  return parseLinuxSystemdShow(systemctlUser([
+    'show',
+    SERVICE_NAME,
+    '--property=LoadState',
+    '--property=ActiveState',
+    '--property=SubState',
+    '--property=Type',
+    '--property=MainPID',
+    '--property=KillMode',
+    '--property=KillSignal',
+    '--property=RestartKillSignal',
+    '--property=FinalKillSignal',
+    '--property=SendSIGKILL',
+    '--property=TimeoutStartUSec',
+    '--property=TimeoutStopUSec',
+    '--property=WorkingDirectory',
+    '--property=PIDFile',
+    '--property=Environment',
+    '--property=ExecStart',
+    '--property=ExecStop',
+    '--property=Job',
+  ]));
+}
+
+function linuxServiceJobSettled(state: LinuxSystemdServiceState): boolean {
+  return !state.job && !new Set(['activating', 'deactivating', 'reloading']).has(state.activeState);
+}
+
+function waitForLinuxServiceJobToSettle(timeoutMs: number): boolean {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    if (linuxServiceJobSettled(inspectLinuxSystemdService())) return true;
+    Atomics.wait(SYSTEMD_JOB_POLL_BUFFER, 0, 0, SYSTEMD_JOB_POLL_MS);
+  } while (Date.now() < deadline);
+  return false;
+}
+
+function cancelLinuxServiceJobsAndSettle(reason: string): string {
+  let cancelFailure = '';
+  try {
+    const jobs = systemctlUser([
+      'list-jobs',
+      SERVICE_NAME,
+      '--no-legend',
+      '--plain',
+      '--no-pager',
+    ]);
+    const jobIds = jobs.split(/\r?\n/)
+      .map(line => line.trim().match(/^(\d+)\s/)?.[1])
+      .filter((id): id is string => Boolean(id));
+    for (const jobId of jobIds) systemctlUser(['cancel', jobId]);
+  } catch (error) {
+    cancelFailure = error instanceof Error ? error.message : String(error);
+  }
+  let settled = false;
+  let settleFailure = '';
+  try {
+    settled = waitForLinuxServiceJobToSettle(SYSTEMD_CANCEL_SETTLE_WAIT_MS);
+  } catch (error) {
+    settleFailure = error instanceof Error ? error.message : String(error);
+  }
+  if (!settled) {
+    throw new Error(
+      `${reason}; 无法确认 systemd restart job 已终止`
+      + `${cancelFailure ? `; cancel: ${cancelFailure}` : ''}`
+      + `${settleFailure ? `; settle: ${settleFailure}` : ''}`,
+    );
+  }
+  return `${reason}; 已取消并确认 systemd 不会延迟旋转 PM2 God`
+    + `${cancelFailure ? ` (cancel 返回: ${cancelFailure})` : ''}`;
+}
+
+function cancelLinuxServiceJobAndThrow(reason: string): never {
+  throw new Error(cancelLinuxServiceJobsAndSettle(reason));
+}
+
+function syncAndInspectLinuxService(opts: AutostartOpts): {
+  changed: boolean;
+  godProcesses: LinuxPm2GodProcess[];
+  restartRequired: boolean;
+} {
+  if (!linuxUserSystemdAvailable()) {
+    throw new Error('当前会话连不上 user systemd，无法校验或修复 botmux.service。');
+  }
+  const written = writeLinuxServiceUnit(opts);
+  // Always reload when the unit exists. This deliberately retries a previous
+  // failed reload even when the on-disk content is already up to date.
+  systemctlUser(['daemon-reload']);
+
+  const ownership = inspectLinuxPm2GodOwnership(join(opts.configDir, 'pm2'));
+  if (ownership.kind === 'external') {
+    throw new Error(
+      `检测到 PM2 God Daemon 不属于 ${SERVICE_NAME}: ${describeExternalPm2Owner(ownership)}`,
+    );
+  }
+  const godProcesses = ownership.kind === 'owned' ? ownership.processes : [];
+  const godPids = godProcesses.map(process => process.pid);
+  const assessment = assessLinuxSystemdService({
+    state: inspectLinuxSystemdService(),
+    expectedPidFile: join(opts.configDir, 'pm2', 'pm2.pid'),
+    expectedNodeBin: nodeBin(),
+    expectedCliJs: cliJs(opts),
+    expectedWorkingDirectory: opts.configDir,
+    expectedPath: currentPath(),
+    godPids,
+  });
+  if (assessment.errors.length > 0) {
+    throw new Error(
+      `${SERVICE_NAME} 有效配置校验失败: ${assessment.errors.join('; ')}。`
+      + '请检查 ~/.config/systemd/user/botmux.service.d/ 下的覆盖配置。',
+    );
+  }
+  return {
+    changed: written.changed,
+    godProcesses,
+    restartRequired: assessment.restartRequired,
+  };
+}
+
+function restartLinuxServiceAndVerify(opts: AutostartOpts): void {
+  // The prepare snapshot may be minutes old after credential preflight and
+  // plugin admission. Bind the comparison baseline again at the actual job
+  // boundary, then prove its process generation one final time.
+  let stateBefore = inspectLinuxSystemdService();
+  if (!linuxServiceJobSettled(stateBefore)) {
+    const detail = cancelLinuxServiceJobsAndSettle(
+      `${SERVICE_NAME} restart 边界发现并发中的 systemd job`,
+    );
+    console.warn(`⚠️  ${detail}`);
+    stateBefore = inspectLinuxSystemdService();
+  }
+  const before = inspectLinuxPm2GodOwnership(join(opts.configDir, 'pm2'));
+  if (before.kind === 'external' || (before.kind === 'owned' && before.processes.length !== 1)) {
+    throw new Error(
+      `${SERVICE_NAME} restart 前 ownership 不唯一: `
+      + (before.kind === 'external' ? describeExternalPm2Owner(before) : before.processes.map(p => p.pid).join(', ')),
+    );
+  }
+  const restartBaseline = before.kind === 'owned' ? before.processes : [];
+  const exactBefore = restartBaseline[0];
+  if (exactBefore && !revalidateLinuxPm2GodProcess(exactBefore, join(opts.configDir, 'pm2'))) {
+    throw new Error(`${SERVICE_NAME} restart 前 PM2 God generation 已变化，请重试`);
+  }
+  if (exactBefore && stateBefore.activeState !== 'active'
+      && stateBefore.activeState !== 'failed'
+      && stateBefore.activeState !== 'inactive') {
+    throw new Error(
+      `${SERVICE_NAME} restart 前状态无法安全分类: ActiveState=${stateBefore.activeState || '(empty)'}`,
+    );
+  }
+  systemctlUser(['restart', '--no-block', SERVICE_NAME]);
+  try {
+    if (!waitForLinuxServiceJobToSettle(SYSTEMD_RESTART_JOB_WAIT_MS)) {
+      cancelLinuxServiceJobAndThrow(`${SERVICE_NAME} restart job 排队或执行超时`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('已取消并确认') || message.includes('无法确认 systemd restart job')) throw error;
+    cancelLinuxServiceJobAndThrow(`${SERVICE_NAME} restart job 状态读取失败: ${message}`);
+  }
+
+  // An older ExecStart selected by a systemd drop-in may itself rewrite the
+  // main unit. Restore the current definition once more before readback.
+  writeLinuxServiceUnit(opts);
+  systemctlUser(['daemon-reload']);
+
+  const ownership = inspectLinuxPm2GodOwnership(join(opts.configDir, 'pm2'));
+  if (ownership.kind !== 'owned') {
+    throw new Error(
+      `${SERVICE_NAME} 启动后未得到 PM2 God Daemon ownership`
+      + (ownership.kind === 'external' ? `: ${describeExternalPm2Owner(ownership)}` : '（PM2 God 不存在）'),
+    );
+  }
+  const previous = restartBaseline.length === 1 ? restartBaseline[0] : undefined;
+  const current = ownership.processes.length === 1 ? ownership.processes[0] : undefined;
+  if (previous && current
+      && current.pid === previous.pid
+      && current.startIdentity === previous.startIdentity) {
+    throw new Error(
+      `${SERVICE_NAME} 重启后 PM2 God generation 未变化（pid ${previous.pid}）；`
+      + 'ExecStop 可能未完成，拒绝把本次操作报告为成功。',
+    );
+  }
+  const state = inspectLinuxSystemdService();
+  const assessment = assessLinuxSystemdService({
+    state,
+    expectedPidFile: join(opts.configDir, 'pm2', 'pm2.pid'),
+    expectedNodeBin: nodeBin(),
+    expectedCliJs: cliJs(opts),
+    expectedWorkingDirectory: opts.configDir,
+    expectedPath: currentPath(),
+    godPids: ownership.processes.map(process => process.pid),
+  });
+  if (assessment.errors.length > 0 || assessment.restartRequired) {
+    const runtimeMismatch = assessment.restartRequired
+      ? [`MainPID=${state.mainPid || 0}, God=${ownership.processes.map(process => process.pid).join(',')}, SubState=${state.subState}`]
+      : [];
+    throw new Error(
+      `${SERVICE_NAME} 运行态迁移后校验失败: `
+      + [...assessment.errors, ...runtimeMismatch].join('; '),
+    );
+  }
+}
+
+/**
+ * Ensure the non-enabled service definition exists and start through systemd.
+ * A missing God is created inside botmux.service; an owned God left behind by
+ * a failed/inactive service is recovered through the same systemd boundary.
+ */
+export function handoffLinuxPm2Start(opts: AutostartOpts): void {
+  assertLinuxServiceOwnershipAvailable(opts);
+  syncAndInspectLinuxService(opts);
+  restartLinuxServiceAndVerify(opts);
+}
+
+/** Write/reload/validate without stopping the current generation. */
+export function prepareLinuxPm2ServiceRepair(opts: AutostartOpts): boolean {
+  if (process.platform !== 'linux') return false;
+  assertLinuxServiceOwnershipAvailable(opts);
+  const synced = syncAndInspectLinuxService(opts);
+  return synced.restartRequired;
+}
+
+/** Apply a previously validated repair and verify the exact new generation. */
+export function applyLinuxPm2ServiceRepair(opts: AutostartOpts): void {
+  restartLinuxServiceAndVerify(opts);
 }
 
 function lingerEnabled(): boolean {
   const username = userInfo().username;
-  const r = spawnSync('loginctl', ['show-user', username, '--property=Linger'], { stdio: 'pipe' });
+  const r = spawnSync('loginctl', ['show-user', username, '--property=Linger'], {
+    stdio: 'pipe',
+    timeout: SYSTEMCTL_DEFAULT_TIMEOUT_MS,
+  });
   if (r.status !== 0) return false;
   return r.stdout.toString().trim().endsWith('=yes');
 }
@@ -236,30 +664,30 @@ function enableLinux(opts: AutostartOpts): void {
   if (!userSystemdAvailable()) {
     console.error(`❌ 当前会话连不上 user systemd（缺少 DBus / 容器环境）。`);
     console.error(``);
-    console.error(`   回退方案：把下面这条写入系统级 cron / rc.local / 你常用的 init：`);
-    console.error(`     ${nodeBin()} ${cliJs(opts)} start`);
-    console.error(``);
-    console.error(`   或在有 systemd --user 的桌面环境里再次运行 botmux autostart enable。`);
+    console.error(`   PM2 必须由独立的 botmux.service cgroup 创建，不能从 cron/rc.local 直接启动。`);
+    console.error(`   请在有 systemd --user 的登录环境里再次运行 botmux autostart enable。`);
     process.exit(1);
   }
 
-  const path = unitPath();
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, unitContent(opts));
+  assertLinuxServiceOwnershipAvailable(opts);
+  const { path } = writeLinuxServiceUnit(opts);
   console.log(`✅ 已写入 systemd unit: ${path}`);
-
-  const reload = spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' });
-  if (reload.status !== 0) {
-    console.error(`❌ systemctl --user daemon-reload 失败:`);
-    console.error(reload.stderr.toString());
-    process.exit(1);
+  const synced = syncAndInspectLinuxService(opts);
+  if (synced.restartRequired && synced.godProcesses.length > 0) {
+    throw new Error(
+      `${SERVICE_NAME} 文件已修复，但当前 God 尚未成为 MainPID；`
+      + '请运行 `botmux restart` 完成运行态迁移后再启用 autostart。',
+    );
   }
 
   // No `--now` here on purpose: enable should only register the autostart hook,
   // not interfere with whatever daemon state the user already has. Daemon
   // lifecycle stays under `botmux start`/`stop`. The unit will trigger on next
   // boot via WantedBy=default.target.
-  const en = spawnSync('systemctl', ['--user', 'enable', SERVICE_NAME], { stdio: 'pipe' });
+  const en = spawnSync('systemctl', ['--user', 'enable', SERVICE_NAME], {
+    stdio: 'pipe',
+    timeout: SYSTEMCTL_DEFAULT_TIMEOUT_MS,
+  });
   if (en.status !== 0) {
     console.error(`❌ systemctl --user enable 失败:`);
     console.error(en.stderr.toString());
@@ -288,14 +716,21 @@ function disableLinux(): void {
   // so the running pm2 daemon is left untouched. To stop it, the user runs
   // `botmux stop` (or `systemctl --user stop botmux.service` for a clean
   // ExecStop-mediated shutdown) explicitly.
-  const dis = spawnSync('systemctl', ['--user', 'disable', SERVICE_NAME], { stdio: 'pipe' });
+  const dis = spawnSync('systemctl', ['--user', 'disable', SERVICE_NAME], {
+    stdio: 'pipe',
+    timeout: SYSTEMCTL_DEFAULT_TIMEOUT_MS,
+  });
   if (dis.status === 0) console.log(`✅ 已禁用 ${SERVICE_NAME}`);
   else console.warn(`⚠️  disable 返回非零（可能本来就未启用）`);
 
+  let removed = false;
   if (existsSync(path)) {
     unlinkSync(path);
     console.log(`✅ 已删除 ${path}`);
-    spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' });
+    removed = true;
+  }
+  if (removed) {
+    systemctlUser(['daemon-reload']);
   } else {
     console.log(`ℹ️  ${path} 不存在`);
   }
@@ -311,8 +746,14 @@ function statusLinux(): void {
     console.log(`user systemd: 不可用（缺少 DBus / 容器环境）`);
     return;
   }
-  const isEnabled = spawnSync('systemctl', ['--user', 'is-enabled', SERVICE_NAME], { stdio: 'pipe' });
-  const isActive = spawnSync('systemctl', ['--user', 'is-active', SERVICE_NAME], { stdio: 'pipe' });
+  const isEnabled = spawnSync('systemctl', ['--user', 'is-enabled', SERVICE_NAME], {
+    stdio: 'pipe',
+    timeout: SYSTEMCTL_DEFAULT_TIMEOUT_MS,
+  });
+  const isActive = spawnSync('systemctl', ['--user', 'is-active', SERVICE_NAME], {
+    stdio: 'pipe',
+    timeout: SYSTEMCTL_DEFAULT_TIMEOUT_MS,
+  });
   console.log(`enabled: ${isEnabled.stdout.toString().trim() || isEnabled.stderr.toString().trim()}`);
   console.log(`active: ${isActive.stdout.toString().trim() || isActive.stderr.toString().trim()}`);
   console.log(`Linger: ${lingerEnabled() ? 'yes' : 'no（登出后服务会停）'}`);
@@ -517,14 +958,7 @@ export function refreshAutostart(opts: AutostartOpts): boolean {
     case 'linux': {
       const path = unitPath();
       if (!existsSync(path)) return false;
-      const next = unitContent(opts);
-      const prev = readFileSync(path, 'utf-8');
-      if (prev === next) return false;
-      writeFileSync(path, next);
-      if (userSystemdAvailable()) {
-        spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' });
-      }
-      return true;
+      return syncAndInspectLinuxService(opts).changed;
     }
     case 'windows': {
       const script = windowsScriptPath();

--- a/src/autostart.ts
+++ b/src/autostart.ts
@@ -21,6 +21,7 @@ import { join, dirname } from 'node:path';
 import {
   BOTMUX_SYSTEMD_SERVICE,
   BOTMUX_SYSTEMD_SERVICE_ENV,
+  ExternalPm2GodOwnershipError,
   describeExternalPm2Owner,
   inspectLinuxPm2GodOwnership,
   revalidateLinuxPm2GodProcess,
@@ -387,11 +388,7 @@ export function linuxUserSystemdAvailable(): boolean {
 function assertLinuxServiceOwnershipAvailable(opts: AutostartOpts): void {
   const ownership = inspectLinuxPm2GodOwnership(join(opts.configDir, 'pm2'));
   if (ownership.kind !== 'external') return;
-  throw new Error(
-    `检测到 PM2 God Daemon 不属于 ${SERVICE_NAME}: ${describeExternalPm2Owner(ownership)}。\n`
-    + `为避免复用其它 supervisor 的 cgroup，本次操作已中止。请先停止 Botmux Session，`
-    + `再由原 owner 停掉该 PM2 God，最后重试。`,
-  );
+  throw new ExternalPm2GodOwnershipError(ownership);
 }
 
 function systemctlUser(args: string[], timeout = SYSTEMCTL_DEFAULT_TIMEOUT_MS): string {
@@ -513,9 +510,7 @@ function syncAndInspectLinuxService(opts: AutostartOpts): {
 
   const ownership = inspectLinuxPm2GodOwnership(join(opts.configDir, 'pm2'));
   if (ownership.kind === 'external') {
-    throw new Error(
-      `检测到 PM2 God Daemon 不属于 ${SERVICE_NAME}: ${describeExternalPm2Owner(ownership)}`,
-    );
+    throw new ExternalPm2GodOwnershipError(ownership);
   }
   const godProcesses = ownership.kind === 'owned' ? ownership.processes : [];
   const godPids = godProcesses.map(process => process.pid);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,7 +42,16 @@ import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { acceptedDispatchBotAppIds, activeConversationBotOpenIds, buildDispatchCompletionBrief, parseDispatchBotSpec, buildDispatchMessages, buildRepoPrimeText, buildReportContent, eligibleAutoMentionAliases, foldableChatSessionAppIds, offTopicSubBotTopic, resolveReportPlacement, resolveReportRecipient, resolveSendTarget, threadRootForReachability } from './core/dispatch.js';
 import { pickTurnReplyTarget, collectTurnWindowParticipants } from './core/reply-target.js';
-import { enableAutostart, disableAutostart, autostartStatus, refreshAutostart } from './autostart.js';
+import {
+  enableAutostart,
+  disableAutostart,
+  autostartStatus,
+  refreshAutostart,
+  handoffLinuxPm2Start,
+  prepareLinuxPm2ServiceRepair,
+  applyLinuxPm2ServiceRepair,
+  inspectLinuxSystemdService,
+} from './autostart.js';
 import { tmuxEnv } from './setup/ensure-tmux.js';
 import { writeBotsJsonAtomic as writeBotsAtomic } from './setup/bots-store.js';
 import {
@@ -132,6 +141,12 @@ import { dispatchDeferredTopicSend, reusableDeferredTopicRoot, type DeferredSche
 import { readDeferredTopicBinding } from './core/deferred-topic-binding.js';
 import { resolveDaemonEnv } from './cli/daemon-lifecycle-env.js';
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
+import {
+  captureReadonlyPm2Jlist,
+  printReadonlyPm2Status,
+  spawnReadonlyPm2Logs,
+} from './cli/pm2-readonly.js';
+import { runExistingPm2Command } from './cli/pm2-existing.js';
 import { pm2ManagedExitConfig } from './pm2-graceful-exit.js';
 import {
   parseCanonicalPm2Id,
@@ -143,6 +158,20 @@ import { assertLinuxPm2GodExecutableUsable } from './cli/pm2-preflight.js';
 import { assertNoUnregisteredLiveDaemonDescriptorsIn } from './cli/pm2-descriptor-guard.js';
 import { assertPm2DaemonShutdownCapabilitiesIn } from './cli/pm2-shutdown-capability.js';
 import { assertIncludePm2RestartAdmission } from './cli/pm2-god-admission.js';
+import {
+  BOTMUX_SYSTEMD_SERVICE,
+  BOTMUX_SYSTEMD_SERVICE_ENV,
+  currentLinuxSystemdCgroup,
+  describeExternalPm2Owner,
+  inspectLinuxPm2Command,
+  inspectLinuxPm2GodOwnership,
+  inspectLinuxPm2ReadonlyTarget,
+  revalidateLinuxPm2GodProcess,
+  scanLinuxPm2GodPids,
+  type LinuxPm2Command,
+  type LinuxPm2CommandInspection,
+  type LinuxPm2GodProcess,
+} from './core/pm2-lifecycle-owner.js';
 import {
   requestAttestedDaemonShutdown,
   requestAttestedDaemonShutdownBatch,
@@ -376,21 +405,7 @@ function listPm2GodDaemonPids(home: string = PM2_HOME): number[] {
   const marker = `God Daemon (${home})`;
   const pids: number[] = [];
   if (process.platform === 'linux') {
-    let entries: string[];
-    try { entries = readdirSync('/proc'); }
-    catch (err) {
-      throw new Error(`cannot inspect /proc for duplicate PM2 Gods: ${err instanceof Error ? err.message : err}`);
-    }
-    for (const ent of entries) {
-      if (!/^\d+$/.test(ent)) continue;
-      const pid = parseInt(ent, 10);
-      if (!pid) continue;
-      try {
-        const cmd = readFileSync(`/proc/${pid}/cmdline`, 'utf-8').replace(/\u0000/g, ' ').trim();
-        if (cmd.includes('PM2 v') && cmd.includes(marker)) pids.push(pid);
-      } catch { /* another user's or already-exited process */ }
-    }
-    return pids.sort((a, b) => a - b);
+    return scanLinuxPm2GodPids(home);
   }
   if (process.platform === 'win32') {
     const windowsScan = spawnSync('powershell.exe', [
@@ -438,6 +453,76 @@ function listPm2GodDaemonPids(home: string = PM2_HOME): number[] {
   return pids.sort((a, b) => a - b);
 }
 
+function linuxPm2CommandInspection(
+  command: LinuxPm2Command,
+  home: string = PM2_HOME,
+): LinuxPm2CommandInspection {
+  if (process.platform !== 'linux') {
+    return { ownership: { kind: 'absent' }, plan: { kind: 'direct' } };
+  }
+  return inspectLinuxPm2Command({ command, home });
+}
+
+function pm2LifecycleOwnershipError(inspection: LinuxPm2CommandInspection): Error {
+  const { plan, ownership } = inspection;
+  if (plan.kind === 'reject') {
+    return new Error(
+      `检测到 PM2 God Daemon 归属于其它 supervisor (${plan.owner}): `
+      + `${describeExternalPm2Owner(ownership)}。拒绝复用；请先停止 Botmux Session，`
+      + `再由原 owner 停掉该 PM2 God，最后重试。`,
+    );
+  }
+  return new Error(
+    'PM2 God Daemon 尚未由 botmux.service 建立；请先运行 `botmux start` 完成 systemd handoff。',
+  );
+}
+
+function assertDirectPm2Access(
+  command: LinuxPm2Command,
+  home: string = PM2_HOME,
+): LinuxPm2CommandInspection {
+  const inspection = linuxPm2CommandInspection(command, home);
+  if (inspection.plan.kind !== 'direct') throw pm2LifecycleOwnershipError(inspection);
+  return inspection;
+}
+
+function linuxReadonlyPm2Available(
+  home: string = PM2_HOME,
+): { available: boolean; expectedGod?: LinuxPm2GodProcess } {
+  if (process.platform !== 'linux' || home !== PM2_HOME) return { available: true };
+  const target = inspectLinuxPm2ReadonlyTarget(home);
+  if (!target) return { available: false };
+  return typeof target === 'object'
+    ? { available: true, expectedGod: target }
+    : { available: true };
+}
+
+function handoffLinuxPm2StartIfNeeded(): boolean {
+  const inspection = linuxPm2CommandInspection('start');
+  const { plan } = inspection;
+  if (plan.kind === 'direct') {
+    if (process.platform !== 'linux' || inspection.ownership.kind !== 'owned') return false;
+    const god = inspection.ownership.processes.length === 1
+      ? inspection.ownership.processes[0]
+      : undefined;
+    if (!god) throw pm2LifecycleOwnershipError(inspection);
+    const state = inspectLinuxSystemdService();
+    if (state.activeState === 'active'
+        && state.subState === 'running'
+        && state.mainPid === god.pid) return false;
+    handoffLinuxPm2Start({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR });
+    console.log(`✅ 已由 ${BOTMUX_SYSTEMD_SERVICE} 接管现有 PM2 God`);
+    return true;
+  }
+  if (plan.kind === 'reject') throw pm2LifecycleOwnershipError(inspection);
+  if (plan.kind !== 'handoff') throw pm2LifecycleOwnershipError(inspection);
+  handoffLinuxPm2Start({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR });
+  console.log(`✅ daemon 已由 ${plan.service} 启动`);
+  console.log('   日志: botmux logs');
+  console.log('   状态: botmux status');
+  return true;
+}
+
 function listSingletonPm2GodDaemonPidsForMutation(home: string = PM2_HOME): number[] {
   const pids = listPm2GodDaemonPids(home);
   if (pids.length <= 1) return pids;
@@ -455,19 +540,42 @@ function assertNoDuplicatePm2GodDaemons(home: string = PM2_HOME): void {
 }
 
 function runPm2(args: string[], inherit = true, home: string = PM2_HOME, timeoutMs?: number): void {
-  const pm2 = buildPm2SpawnCommand(pm2Bin(), args);
-  const r = spawnSync(pm2.command, pm2.args, {
-    stdio: inherit ? 'inherit' : 'pipe',
-    env: pm2Env(home),
-    shell: pm2.shell ?? false,
-    timeout: timeoutMs,
-  });
-  if (r.status !== 0) {
-    // r.error is set when the process couldn't be spawned/timed out (status null);
-    // prefer it so failures don't surface as a bare "status null".
-    const detail = r.error?.message ?? `status ${r.status}`;
-    throw new Error(`pm2 ${args.join(' ')} failed: ${detail}`);
+  const inspection = assertDirectPm2Access('plugin', home);
+  if (process.platform === 'linux' && inspection.ownership.kind === 'owned') {
+    if (inspection.ownership.processes.length !== 1) {
+      throw new Error(
+        `refusing PM2 mutation: expected one botmux.service-owned God for ${home}, got `
+        + `${inspection.ownership.processes.map(process => process.pid).join(', ') || 'none'}`,
+      );
+    }
+    runExistingPm2Command({
+      pkgRoot: PKG_ROOT,
+      home,
+      args,
+      inherit,
+      timeoutMs,
+      env: pm2Env(home),
+      expectedGod: inspection.ownership.processes[0]!,
+    });
+  } else {
+    // Only the botmux.service caller may reach this with an absent primary God.
+    // Legacy/non-Linux homes retain their platform-specific PM2 CLI behavior.
+    const pm2 = buildPm2SpawnCommand(pm2Bin(), args);
+    const r = spawnSync(pm2.command, pm2.args, {
+      stdio: inherit ? 'inherit' : 'pipe',
+      env: pm2Env(home),
+      shell: pm2.shell ?? false,
+      timeout: timeoutMs,
+    });
+    if (r.status !== 0) {
+      // r.error is set when the process couldn't be spawned/timed out (status null);
+      // prefer it so failures don't surface as a bare "status null".
+      const detail = r.error?.message ?? `status ${r.status}`;
+      throw new Error(`pm2 ${args.join(' ')} failed: ${detail}`);
+    }
   }
+  const after = linuxPm2CommandInspection('plugin', home);
+  if (after.plan.kind === 'reject') throw pm2LifecycleOwnershipError(after);
 }
 
 /**
@@ -476,27 +584,17 @@ function runPm2(args: string[], inherit = true, home: string = PM2_HOME, timeout
  * a shell) as well as macOS/Linux. Throws on non-zero exit / spawn failure.
  */
 function pm2Capture(args: string[], home: string = PM2_HOME, timeoutMs = 10_000): string {
-  const pm2 = buildPm2SpawnCommand(pm2Bin(), args);
-  const r = spawnSync(pm2.command, pm2.args, {
-    encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: pm2Env(home),
-    shell: pm2.shell ?? false,
-    timeout: timeoutMs,
-    // `pm2 jlist` serializes EVERY process's full env + metadata, so its stdout
-    // grows ~linearly with the bot count. Node's default spawnSync maxBuffer is
-    // 1 MiB — a box with ~30+ bots blows past it and spawnSync fails with
-    // ENOBUFS, which surfaced as `start-bot` (dashboard "bring one bot online")
-    // dying before it could launch anything. Lift the cap well above any real
-    // fleet size. (ps/git captures elsewhere already do the same.)
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  if (r.status !== 0) {
-    const detail = r.error?.message
-      ?? ((r.stderr ? String(r.stderr).trim() : '') || `status ${r.status}`);
-    throw new Error(`pm2 ${args.join(' ')} failed: ${detail}`);
+  if (args.length !== 1 || args[0] !== 'jlist') {
+    throw new Error(`unsupported read-only PM2 command: ${args.join(' ')}`);
   }
-  return typeof r.stdout === 'string' ? r.stdout : '';
+  const readonly = linuxReadonlyPm2Available(home);
+  if (!readonly.available) return '[]';
+  return captureReadonlyPm2Jlist({
+    pkgRoot: PKG_ROOT,
+    home,
+    timeoutMs,
+    expectedGod: readonly.expectedGod,
+  });
 }
 
 async function cmdInternalPm2StartExact(args: string[]): Promise<void> {
@@ -2679,19 +2777,45 @@ function preflightNodeSanity(home: string = PM2_HOME): void {
 }
 
 async function cmdStart(): Promise<void> {
+  const systemdServiceStart = process.argv.includes('--systemd-service');
+  if (systemdServiceStart) {
+    if (process.platform !== 'linux'
+        || process.env[BOTMUX_SYSTEMD_SERVICE_ENV] !== BOTMUX_SYSTEMD_SERVICE
+        || !currentLinuxSystemdCgroup().split('/').includes(BOTMUX_SYSTEMD_SERVICE)) {
+      throw new Error('[start] --systemd-service requires the exact botmux.service cgroup');
+    }
+  }
   if (!hasConfig()) {
     console.error('❌ 未找到配置文件');
     console.error('   请先运行: botmux setup');
     process.exit(1);
   }
   ensureConfigDir();
+  if (systemdServiceStart) {
+    const ownership = inspectLinuxPm2GodOwnership(PM2_HOME);
+    if (ownership.kind === 'external' || (ownership.kind === 'owned' && ownership.processes.length !== 1)) {
+      throw new Error(
+        `[start] systemd ExecStart requires unique botmux.service PM2 ownership: ${describeExternalPm2Owner(ownership) || ownership.kind}`,
+      );
+    }
+    const observedGod = ownership.kind === 'owned' ? ownership.processes[0] : undefined;
+    if (observedGod && !observedGod.startIdentity) {
+      throw new Error('[start] cannot bind the existing PM2 God process generation');
+    }
+  }
   await ensureSystemDependencies();
 
-  // 启动前快速校验每个 bot 的凭证. Codex review 边界 #5: 凭证无效是
-  // 唯一应该阻塞 start 的情况; scope/event 缺失在 daemon 起来后用 WARN
-  // + 私信处理 (event-dispatcher.checkRequiredScopes).
-  //
-  // 失败时打印明确的 appId 前缀和错误码, 不打印 secret, 不 spawn pm2 进程.
+  const botsForCheck = await preflightConfiguredBotCredentials();
+  if (!systemdServiceStart && handoffLinuxPm2StartIfNeeded()) return;
+  if (systemdServiceStart) {
+    await startConfiguredFleet(botsForCheck, { systemdServiceStart: true });
+  } else {
+    await startConfiguredFleet(botsForCheck);
+  }
+}
+
+/** Validate before systemd handoff so a predictable failure cannot stop the old fleet. */
+async function preflightConfiguredBotCredentials() {
   const botsForCheck = loadBotsJson();
   if (botsForCheck.length > 0) {
     const { validateCredentials } = await import('./setup/verify-permissions.js');
@@ -2719,6 +2843,13 @@ async function cmdStart(): Promise<void> {
       process.exit(1);
     }
   }
+  return botsForCheck;
+}
+
+async function startConfiguredFleet(
+  botsForCheck: ReturnType<typeof loadBotsJson>,
+  options: { systemdServiceStart?: boolean } = {},
+): Promise<void> {
 
   await withFileLock(PM2_FLEET_MUTATION_LOCK_TARGET, async () => {
     await withFileLock(BOTS_JSON_FILE, async () => {
@@ -2729,7 +2860,7 @@ async function cmdStart(): Promise<void> {
       assertNoDuplicatePm2GodDaemons();
       preflightNodeSanity();
       cleanupLegacyPm2();
-      const currentProjection = readVerifiedBotmuxPm2Projection('start');
+      let currentProjection = readVerifiedBotmuxPm2Projection('start');
       assertNoUnregisteredLiveDaemonDescriptors('start', currentProjection);
       assertCanonicalUniquePm2Rows('start', currentProjection);
       const configuredNames = configuredCoreProcessNames(lockedBots);
@@ -2746,12 +2877,26 @@ async function cmdStart(): Promise<void> {
           );
           return;
         } catch (error) {
-          throw new Error(
-            `[start] refusing PM2 start while a partial/live core fleet exists `
-            + `(${liveEntries.map(entry => `${entry.name}:${entry.pid}`).join(', ')}): `
-            + `${error instanceof Error ? error.message : String(error)}; `
-            + 'use start-bot only for an exact one-missing-bot fleet, or restart',
-          );
+          if (!options.systemdServiceStart) {
+            throw new Error(
+              `[start] refusing PM2 start while a partial/live core fleet exists `
+              + `(${liveEntries.map(entry => `${entry.name}:${entry.pid}`).join(', ')}): `
+              + `${error instanceof Error ? error.message : String(error)}; `
+              + 'use start-bot only for an exact one-missing-bot fleet, or restart',
+            );
+          }
+        }
+      }
+      // A killed/failed ExecStart may leave partial core rows in an otherwise
+      // reusable service-owned God. Retry their normal attested shutdown and
+      // rebuild only the core fleet; plugin rows stay on the same God.
+      if (options.systemdServiceStart && currentProjection.length > 0) {
+        deleteAllBotmuxProcesses();
+        cleanupStaleDaemonDescriptors();
+        currentProjection = readVerifiedBotmuxPm2Projection('systemd-start-recovery');
+        assertNoUnregisteredLiveDaemonDescriptors('systemd-start-recovery', currentProjection);
+        if (currentProjection.length > 0) {
+          throw new Error('[systemd-start] core fleet recovery left PM2 rows behind');
         }
       }
       const unprovenDormant = currentProjection.filter(
@@ -2784,7 +2929,9 @@ async function cmdStart(): Promise<void> {
       );
     }, { maxWaitMs: 5_000 });
   }, { maxWaitMs: 5_000 });
-  await reconcilePluginServicesForCli(undefined, { autoOnly: true });
+  await reconcilePluginServicesForCli(undefined, {
+    autoOnly: true,
+  });
   const bots = loadBotsJson();
   const count = bots.length || 1;
   console.log(`\n✅ daemon 已启动${count > 1 ? ` (${count} 个机器人, 每个独立进程)` : ''}`);
@@ -2792,8 +2939,13 @@ async function cmdStart(): Promise<void> {
   console.log(`   状态: botmux status`);
   // If the user previously enabled autostart, sync the unit file in case
   // node/cli.js paths changed since (nvm switch, npm upgrade, etc.).
-  if (refreshAutostart({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR })) {
-    console.log(`   autostart unit 已同步到当前 Node/cli.js 路径`);
+  // A Type=forking unit necessarily has a live start Job/activating state
+  // until this ExecStart child returns. The parent repair transaction already
+  // wrote and daemon-reloaded the unit; self-refresh here would reject that
+  // expected in-flight state and make every systemd start fail.
+  if (!options.systemdServiceStart
+      && refreshAutostart({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR })) {
+    console.log(`   autostart 主 unit 已同步到当前 Node/cli.js 路径`);
   }
   await printDashboardHintWithRetry();
 }
@@ -3513,6 +3665,15 @@ function cleanupLegacyPm2(
   assertNoDuplicatePm2GodDaemons(legacyHome);
   preflightNodeSanity(legacyHome);
   assertNoDuplicatePm2GodDaemons(legacyHome);
+  // Read through the non-daemonizing client first. An unrelated legacy God is
+  // not a migration target and must remain untouched; a legacy God that does
+  // contain Botmux rows is ownership-gated before any shutdown signal/delete.
+  const legacyProjection = readVerifiedBotmuxPm2Projection(
+    'legacy-cleanup-discovery',
+    legacyHome,
+  );
+  if (legacyProjection.length === 0) return false;
+  assertDirectPm2Access('plugin', legacyHome);
   if (bootstrapOperation) bootstrapDeleteAllBotmuxProcesses(bootstrapOperation, legacyHome);
   else {
     const currentProjection = readVerifiedBotmuxPm2Projection('legacy-cleanup-authority');
@@ -3521,14 +3682,59 @@ function cleanupLegacyPm2(
   return true;
 }
 
+function terminateSystemdOwnedPm2God(): void {
+  if (process.platform !== 'linux') {
+    throw new Error('[systemd-stop] PM2 God retirement is only supported on Linux');
+  }
+  if (process.env[BOTMUX_SYSTEMD_SERVICE_ENV] !== BOTMUX_SYSTEMD_SERVICE) {
+    throw new Error('[systemd-stop] missing botmux.service environment attestation');
+  }
+  const callerCgroup = currentLinuxSystemdCgroup();
+  if (!callerCgroup.split('/').includes(BOTMUX_SYSTEMD_SERVICE)) {
+    throw new Error(`[systemd-stop] caller is outside ${BOTMUX_SYSTEMD_SERVICE}: ${callerCgroup}`);
+  }
+
+  const ownership = inspectLinuxPm2GodOwnership(PM2_HOME);
+  if (ownership.kind === 'absent') return;
+  if (ownership.kind !== 'owned' || ownership.processes.length !== 1) {
+    throw new Error(
+      `[systemd-stop] refusing ambiguous PM2 God retirement: ${describeExternalPm2Owner(ownership) || ownership.kind}`,
+    );
+  }
+  const target = ownership.processes[0]!;
+  const identity = target.startIdentity;
+  if (!identity || !revalidateLinuxPm2GodProcess(target, PM2_HOME)) {
+    throw new Error(`[systemd-stop] cannot bind PM2 God pid ${target.pid} to a process generation`);
+  }
+  try {
+    process.kill(target.pid, 'SIGTERM');
+  } catch (error) {
+    if (readSupervisorProcessStartIdentity(target.pid) !== identity) return;
+    throw new Error(
+      `[systemd-stop] failed to signal PM2 God ${target.pid}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const deadline = Date.now() + 30_000;
+  while (readSupervisorProcessStartIdentity(target.pid) === identity) {
+    if (Date.now() >= deadline) {
+      throw new Error(`[systemd-stop] PM2 God ${target.pid} did not exit after SIGTERM`);
+    }
+    sleepSyncMs(50);
+  }
+}
+
 async function cmdStop(): Promise<void> {
   const includePluginServices = process.argv.includes('--with-plugin');
+  const systemdServiceStop = process.argv.includes('--systemd-service');
   const bootstrapShutdownProtocol = process.argv.includes('--bootstrap-shutdown-protocol');
   const bootstrapConfirmed = process.argv.includes('--yes');
   if (bootstrapShutdownProtocol && !bootstrapConfirmed) {
     throw new Error(
       '[stop] --bootstrap-shutdown-protocol requires --yes after confirming every Session/Riff workload is idle',
     );
+  }
+  if (systemdServiceStop && includePluginServices) {
+    throw new Error('[stop] --systemd-service cannot be combined with --with-plugin');
   }
   ensureConfigDir();
   await withFileLock(PM2_FLEET_MUTATION_LOCK_TARGET, async () => {
@@ -3540,6 +3746,7 @@ async function cmdStop(): Promise<void> {
       if (includePluginServices) {
         await stopPluginServicesForCli(undefined, { autoOnly: true });
       }
+      if (systemdServiceStop) terminateSystemdOwnedPm2God();
       console.log('daemon 已通过一次性 shutdown-protocol bootstrap 安全边界停止。');
       return;
     }
@@ -3561,6 +3768,7 @@ async function cmdStop(): Promise<void> {
       if (includePluginServices) {
         await stopPluginServicesForCli(undefined, { autoOnly: true });
       }
+      if (systemdServiceStop) terminateSystemdOwnedPm2God();
       console.log('daemon 未在运行。');
       return;
     }
@@ -3612,7 +3820,140 @@ async function cmdStop(): Promise<void> {
     }
     cleanupStaleDaemonDescriptors();
     if (includePluginServices) await stopPluginServicesForCli(undefined, { autoOnly: true });
+    if (systemdServiceStop) terminateSystemdOwnedPm2God();
   }, { maxWaitMs: 5_000 });
+}
+
+interface RestartLifecycleFlags {
+  includePm2: boolean;
+  includePluginServices: boolean;
+  bootstrapShutdownProtocol: boolean;
+  bootstrapConfirmed: boolean;
+}
+
+function validateRestartLifecycleFlags(argv: string[] = process.argv): RestartLifecycleFlags {
+  const flags = {
+    includePm2: argv.includes('--include-pm2'),
+    includePluginServices: argv.includes('--with-plugin'),
+    bootstrapShutdownProtocol: argv.includes('--bootstrap-shutdown-protocol'),
+    bootstrapConfirmed: argv.includes('--yes'),
+  };
+  if (flags.bootstrapShutdownProtocol && !flags.bootstrapConfirmed) {
+    throw new Error(
+      '[restart] --bootstrap-shutdown-protocol requires --yes after confirming every Session/Riff workload is idle',
+    );
+  }
+  if (flags.bootstrapShutdownProtocol && flags.includePm2) {
+    throw new Error('[restart] --bootstrap-shutdown-protocol cannot be combined with --include-pm2');
+  }
+  return flags;
+}
+
+async function preflightRestartGenerationForSystemdRepair(): Promise<void> {
+  assertNoDuplicatePm2GodDaemons();
+  preflightNodeSanity();
+  await ensureSystemDependencies();
+  await preflightConfiguredBotCredentials();
+}
+
+async function restoreManualPluginServicesAfterSystemdRepair(pluginIds: string[]): Promise<void> {
+  if (pluginIds.length === 0) return;
+  const { startPluginServices } = await import('./core/plugins/service-manager.js');
+  const reports = await startPluginServices(pluginIds);
+  const incomplete = pluginIds.filter(id => !reports.some(report => (
+    report.pluginId === id
+    && (report.action === 'started' || report.action === 'already-running')
+    && report.status === 'online'
+    && Number.isSafeInteger(report.pid)
+    && report.pid! > 1
+  )));
+  if (incomplete.length > 0) {
+    throw new Error(
+      '[systemd-repair] manual plugin service restore incomplete: '
+      + incomplete.map(id => {
+        const report = reports.find(item => item.pluginId === id);
+        return `${id}:${report?.warning ?? report?.status ?? report?.action ?? 'missing-report'}`;
+      }).join(', '),
+    );
+  }
+  console.log(`✅ 已恢复迁移前运行的 manual plugin service: ${pluginIds.join(', ')}`);
+}
+
+async function bootstrapRetireCoreForSystemdRepair(): Promise<void> {
+  await withFileLock(PM2_FLEET_MUTATION_LOCK_TARGET, async () => {
+    assertNoDuplicatePm2GodDaemons();
+    cleanupLegacyPm2('restart');
+    bootstrapDeleteAllBotmuxProcesses('restart');
+    cleanupStaleDaemonDescriptors();
+  }, { maxWaitMs: 5_000 });
+}
+
+async function migrateLinuxPm2ServiceIfRequired(
+  repairRequired: boolean,
+  flags: RestartLifecycleFlags,
+): Promise<boolean> {
+  if (!repairRequired) return false;
+  await preflightRestartGenerationForSystemdRepair();
+  const { snapshotRunningManualPluginServiceIds } = await import('./core/plugins/service-manager.js');
+  const manualPluginIds = await snapshotRunningManualPluginServiceIds();
+  if (flags.bootstrapShutdownProtocol) await bootstrapRetireCoreForSystemdRepair();
+  const restartIntentDir = resolveDataDir();
+  const restartAttemptId = randomBytes(16).toString('hex');
+  let restartIntentPrepared = false;
+  try {
+    const now = Date.now();
+    let stagedRestartIntent: RestartIntent | null = null;
+    try {
+      stagedRestartIntent = consumeRestartIntentTo(restartIntentDir, now);
+    } catch { /* intent reporting is best-effort */ }
+    try {
+      writeRestartAttemptIntentTo(
+        restartIntentDir,
+        stagedRestartIntent ?? { kind: 'manual', at: new Date(now).toISOString() },
+        now,
+        restartAttemptId,
+      );
+      restartIntentPrepared = true;
+    } catch { /* intent reporting is best-effort */ }
+
+    let failure: unknown;
+    try {
+      applyLinuxPm2ServiceRepair({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR });
+    } catch (error) {
+      failure = error;
+    }
+    try {
+      await restoreManualPluginServicesAfterSystemdRepair(manualPluginIds);
+    } catch (restoreError) {
+      failure = failure
+        ? new AggregateError([failure, restoreError], '[systemd-repair] repair and plugin restore both failed')
+        : restoreError;
+    }
+    if (failure) throw failure;
+  } catch (error) {
+    if (restartIntentPrepared) {
+      try {
+        removeRestartIntentAttemptTo(restartIntentDir, restartAttemptId);
+      } catch { /* best-effort */ }
+    }
+    throw error;
+  }
+  if (restartIntentPrepared) {
+    let committed = false;
+    try {
+      committed = commitRestartIntentAttemptTo(restartIntentDir, restartAttemptId);
+    } catch { /* best-effort after verified repair */ }
+    if (!committed) {
+      try {
+        removeRestartIntentAttemptTo(restartIntentDir, restartAttemptId);
+      } catch { /* best-effort */ }
+      console.warn('⚠️  daemon 已恢复，但重启摘要凭据未能提交；本次不会发送重启摘要。');
+    }
+  }
+  console.log('✅ daemon 与 systemd 运行态已由 botmux.service 完成修复和重启');
+  console.log('   日志: botmux logs');
+  console.log('   状态: botmux status');
+  return true;
 }
 
 async function cmdRestart(): Promise<void> {
@@ -3634,22 +3975,18 @@ async function cmdRestart(): Promise<void> {
     process.exit(1);
   }
   ensureConfigDir();
+  const lifecycleFlags = validateRestartLifecycleFlags();
+  if (lifecycleFlags.includePm2) {
+    assertIncludePm2RestartAdmission(listPm2GodDaemonPids());
+  }
+  const autostartOpts = { pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR };
+  const systemdRepair = prepareLinuxPm2ServiceRepair(autostartOpts);
+  if (await migrateLinuxPm2ServiceIfRequired(systemdRepair, lifecycleFlags)) return;
   await withFileLock(PM2_FLEET_MUTATION_LOCK_TARGET, async () => {
-    const includePm2 = process.argv.includes('--include-pm2');
-    const includePluginServices = process.argv.includes('--with-plugin');
-    const bootstrapShutdownProtocol = process.argv.includes('--bootstrap-shutdown-protocol');
-    const bootstrapConfirmed = process.argv.includes('--yes');
-    if (bootstrapShutdownProtocol && !bootstrapConfirmed) {
-      throw new Error(
-        '[restart] --bootstrap-shutdown-protocol requires --yes after confirming every Session/Riff workload is idle',
-      );
-    }
-    if (bootstrapShutdownProtocol && includePm2) {
-      throw new Error('[restart] --bootstrap-shutdown-protocol cannot be combined with --include-pm2');
-    }
-    if (includePm2) {
-      assertIncludePm2RestartAdmission(listPm2GodDaemonPids());
-    }
+    const {
+      includePluginServices,
+      bootstrapShutdownProtocol,
+    } = lifecycleFlags;
 
     const restartIntentDir = resolveDataDir();
     let stagedRestartIntent: RestartIntent | null = null;
@@ -3736,7 +4073,7 @@ async function cmdRestart(): Promise<void> {
 
     await reconcilePluginServicesForCli(undefined, { autoOnly: true });
     if (refreshAutostart({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR })) {
-      console.log(`autostart unit 已同步到当前 Node/cli.js 路径`);
+      console.log(`autostart 主 unit 已同步到当前 Node/cli.js 路径`);
     }
     await printDashboardHintWithRetry();
   }, { maxWaitMs: 5_000 });
@@ -4171,6 +4508,11 @@ function warnIfLegacyBotmuxAlive(): void {
 }
 
 function cmdLogs(): void {
+  const readonly = linuxReadonlyPm2Available();
+  if (!readonly.available) {
+    console.log('daemon 未在运行，暂无 PM2 日志。');
+    return;
+  }
   warnIfLegacyBotmuxAlive();
   const lines = process.argv.includes('--lines')
     ? process.argv[process.argv.indexOf('--lines') + 1] || '50'
@@ -4200,20 +4542,28 @@ function cmdLogs(): void {
     target = `/^${PM2_NAME}/`;
   }
 
-  // Use spawn for streaming output. Windows cannot spawn a .js CLI script
-  // directly, so run the bundled pm2 script through the current node.exe.
-  const pm2 = buildPm2SpawnCommand(pm2Bin(), ['logs', target, '--lines', lines]);
-  const child = spawn(pm2.command, pm2.args, {
-    stdio: 'inherit',
-    env: pm2Env(),
-    shell: pm2.shell ?? false,
+  const child = spawnReadonlyPm2Logs({
+    pkgRoot: PKG_ROOT,
+    home: PM2_HOME,
+    target,
+    lines,
+    expectedGod: readonly.expectedGod,
   });
   child.on('exit', code => process.exit(code ?? 0));
 }
 
 function cmdStatus(): void {
+  const readonly = linuxReadonlyPm2Available();
+  if (!readonly.available) {
+    console.log('daemon 未在运行。');
+    return;
+  }
   warnIfLegacyBotmuxAlive();
-  runPm2(['status']);
+  printReadonlyPm2Status({
+    pkgRoot: PKG_ROOT,
+    home: PM2_HOME,
+    expectedGod: readonly.expectedGod,
+  });
 }
 
 function cmdUpgrade(): void {
@@ -12440,7 +12790,7 @@ async function reconcilePluginServicesForCli(
   options: { autoOnly?: boolean } = {},
 ): Promise<void> {
   const { startPluginServices } = await import('./core/plugins/service-manager.js');
-  const reports = await startPluginServices(pluginIds, options);
+  const reports = await startPluginServices(pluginIds, { autoOnly: options.autoOnly });
   if (reports.length > 0) {
     console.log('\n插件 host service:');
     console.log(formatPluginServiceReports(reports));
@@ -12452,7 +12802,7 @@ async function stopPluginServicesForCli(
   options: { autoOnly?: boolean } = {},
 ): Promise<void> {
   const { stopPluginServices } = await import('./core/plugins/service-manager.js');
-  const reports = await stopPluginServices(pluginIds, options);
+  const reports = await stopPluginServices(pluginIds, { autoOnly: options.autoOnly });
   if (reports.length > 0) {
     console.log('\n插件 host service:');
     console.log(formatPluginServiceReports(reports));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -161,6 +161,7 @@ import { assertIncludePm2RestartAdmission } from './cli/pm2-god-admission.js';
 import {
   BOTMUX_SYSTEMD_SERVICE,
   BOTMUX_SYSTEMD_SERVICE_ENV,
+  ExternalPm2GodOwnershipError,
   currentLinuxSystemdCgroup,
   describeExternalPm2Owner,
   inspectLinuxPm2Command,
@@ -465,16 +466,22 @@ function linuxPm2CommandInspection(
 
 function pm2LifecycleOwnershipError(inspection: LinuxPm2CommandInspection): Error {
   const { plan, ownership } = inspection;
-  if (plan.kind === 'reject') {
-    return new Error(
-      `检测到 PM2 God Daemon 归属于其它 supervisor (${plan.owner}): `
-      + `${describeExternalPm2Owner(ownership)}。拒绝复用；请先停止 Botmux Session，`
-      + `再由原 owner 停掉该 PM2 God，最后重试。`,
-    );
+  if (plan.kind === 'reject' && ownership.kind === 'external') {
+    return new ExternalPm2GodOwnershipError(ownership);
   }
   return new Error(
     'PM2 God Daemon 尚未由 botmux.service 建立；请先运行 `botmux start` 完成 systemd handoff。',
   );
+}
+
+async function runPm2LifecycleCliCommand(action: () => void | Promise<void>): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    if (!(error instanceof ExternalPm2GodOwnershipError)) throw error;
+    console.error(`❌ ${error.message}`);
+    process.exitCode = error.exitCode;
+  }
 }
 
 function assertDirectPm2Access(
@@ -13367,14 +13374,14 @@ switch (command) {
     else await cmdSetup();
     break;
   }
-  case 'start':   await cmdStart(); break;
+  case 'start':   await runPm2LifecycleCliCommand(() => cmdStart()); break;
   case 'serve':   await cmdServe(process.argv.slice(3)); break;
-  case 'start-bot': await cmdStartBot(process.argv.slice(3)); break;
-  case 'stop-bot': await cmdStopBot(process.argv.slice(3)); break;
-  case 'stop':    await cmdStop(); break;
-  case 'restart': await cmdRestart(); break;
-  case 'logs':    cmdLogs(); break;
-  case 'status':  cmdStatus(); break;
+  case 'start-bot': await runPm2LifecycleCliCommand(() => cmdStartBot(process.argv.slice(3))); break;
+  case 'stop-bot': await runPm2LifecycleCliCommand(() => cmdStopBot(process.argv.slice(3))); break;
+  case 'stop':    await runPm2LifecycleCliCommand(() => cmdStop()); break;
+  case 'restart': await runPm2LifecycleCliCommand(() => cmdRestart()); break;
+  case 'logs':    await runPm2LifecycleCliCommand(() => cmdLogs()); break;
+  case 'status':  await runPm2LifecycleCliCommand(() => cmdStatus()); break;
   case 'upgrade':
   case 'update':  cmdUpgrade(); break;
   case 'dashboard': await cmdDashboard(process.argv.slice(3)); break;
@@ -13581,7 +13588,7 @@ switch (command) {
     break;
   }
   case 'plugin':
-  case 'plugins':  await cmdPlugin(process.argv.slice(3)); break;
+  case 'plugins':  await runPm2LifecycleCliCommand(() => cmdPlugin(process.argv.slice(3))); break;
   case 'whiteboard':
   case 'wb':       await cmdWhiteboard(process.argv[3] ?? 'status', process.argv.slice(4)); break;
   case 'thread':   {
@@ -13597,13 +13604,15 @@ switch (command) {
     break;
   }
   case 'autostart': {
-    ensureConfigDir();
-    const sub = process.argv[3] ?? 'status';
-    const opts = { pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR };
-    if (sub === 'enable' || sub === 'install') enableAutostart(opts);
-    else if (sub === 'disable' || sub === 'uninstall') disableAutostart(opts);
-    else if (sub === 'status') autostartStatus(opts);
-    else { console.error(`用法: botmux autostart <enable|disable|status>`); process.exit(1); }
+    await runPm2LifecycleCliCommand(() => {
+      ensureConfigDir();
+      const sub = process.argv[3] ?? 'status';
+      const opts = { pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR };
+      if (sub === 'enable' || sub === 'install') enableAutostart(opts);
+      else if (sub === 'disable' || sub === 'uninstall') disableAutostart(opts);
+      else if (sub === 'status') autostartStatus(opts);
+      else { console.error(`用法: botmux autostart <enable|disable|status>`); process.exit(1); }
+    });
     break;
   }
   default:

--- a/src/cli/pm2-existing-client.ts
+++ b/src/cli/pm2-existing-client.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/** Execute a bounded PM2 mutation only when its RPC daemon already exists. */
+import { createRequire } from 'node:module';
+import {
+  inspectLinuxPm2GodOwnership,
+  revalidateLinuxPm2GodProcess,
+  type LinuxPm2GodProcess,
+} from '../core/pm2-lifecycle-owner.js';
+
+const require = createRequire(import.meta.url);
+const pm2 = require('pm2') as any;
+const ABSENT_EXIT_CODE = 4;
+const CONNECT_TIMEOUT_MS = 5_000;
+const MUTATION_TIMEOUT_MS = 25_000;
+
+type Mutation =
+  | { operation: 'start'; target: string; only?: string; updateEnv?: boolean }
+  | { operation: 'restart'; target: string; updateEnv?: boolean }
+  | { operation: 'stop' | 'delete'; target: string };
+type Request = Mutation & { expectedGod: LinuxPm2GodProcess };
+
+function fail(message: string, code = 1): never {
+  console.error(message);
+  process.exit(code);
+}
+
+let request: Request;
+try {
+  request = JSON.parse(process.argv[2] ?? '') as Request;
+} catch (error) {
+  fail(`invalid PM2 existing-daemon request: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+const timer = setTimeout(() => fail('PM2 existing-daemon RPC connection timed out'), CONNECT_TIMEOUT_MS);
+timer.unref();
+let mutationTimer: NodeJS.Timeout | undefined;
+let mutationSettled = false;
+
+function complete(error?: Error | null): void {
+  mutationSettled = true;
+  if (mutationTimer) clearTimeout(mutationTimer);
+  if (error) fail(`PM2 existing-daemon ${request.operation} failed: ${error.message}`);
+  pm2.disconnect((disconnectError?: Error | null) => {
+    if (disconnectError) fail(`PM2 existing-daemon disconnect failed: ${disconnectError.message}`);
+    process.exit(0);
+  });
+}
+
+pm2.Client.pingDaemon((alive: boolean) => {
+  if (!alive) {
+    clearTimeout(timer);
+    fail('PM2 God disappeared before mutation; refusing to daemonize from this caller', ABSENT_EXIT_CODE);
+  }
+  pm2.Client.launchRPC((connectError: Error | null | undefined) => {
+    if (connectError) fail(`PM2 existing-daemon RPC connection failed: ${connectError.message}`);
+    clearTimeout(timer);
+    const rpcSocket = pm2.Client.client?.sock;
+    if (!rpcSocket?.set) fail('PM2 existing-daemon RPC socket cannot disable reconnect');
+    // pm2-axon otherwise queues an in-flight request and reconnects to a new
+    // rpc.sock owner after 100ms. A generation check cannot bind the eventual
+    // recipient unless reconnection is disabled before the check and send.
+    rpcSocket.set('retry timeout', 0);
+    rpcSocket.set('retry max timeout', 0);
+    rpcSocket.retry = 0;
+    rpcSocket.once('close', () => {
+      if (!mutationSettled) fail(`PM2 God disconnected before ${request.operation} completed`);
+    });
+    // launchRPC pins this client to one socket generation. Revalidate the exact
+    // PID/birth/cgroup only after that connection exists: a God replaced after
+    // the parent's ownership check can no longer receive a mutation first.
+    const home = process.env.PM2_HOME ?? '';
+    const ownership = inspectLinuxPm2GodOwnership(home);
+    const current = ownership.kind === 'absent' || ownership.processes.length !== 1
+      ? undefined
+      : ownership.processes[0];
+    if (!request.expectedGod?.startIdentity
+        || !current
+        || current.pid !== request.expectedGod.pid
+        || current.startIdentity !== request.expectedGod.startIdentity
+        || current.cgroup !== request.expectedGod.cgroup
+        || !revalidateLinuxPm2GodProcess(request.expectedGod, home)) {
+      mutationSettled = true;
+      pm2.disconnect(() => fail(
+        `PM2 God generation changed before mutation (expected pid ${request.expectedGod?.pid ?? 'unknown'})`,
+        ABSENT_EXIT_CODE,
+      ));
+      return;
+    }
+    // Keep the helper alive until PM2 acknowledges the mutation. With Axon
+    // reconnect disabled, a closed socket must never let an unacknowledged
+    // queued request fall through Node's beforeExit path with status 0.
+    mutationTimer = setTimeout(
+      () => fail(`PM2 existing-daemon ${request.operation} response timed out`),
+      MUTATION_TIMEOUT_MS,
+    );
+    switch (request.operation) {
+      case 'start':
+        pm2.start(request.target, {
+          ...(request.only ? { only: request.only } : {}),
+          ...(request.updateEnv ? { updateEnv: true } : {}),
+        }, complete);
+        return;
+      case 'restart':
+        pm2.restart(request.target, { updateEnv: request.updateEnv === true }, complete);
+        return;
+      case 'stop':
+        pm2.stop(request.target, complete);
+        return;
+      case 'delete':
+        pm2.delete(request.target, complete);
+        return;
+      default:
+        fail('unsupported PM2 existing-daemon mutation');
+    }
+  });
+});

--- a/src/cli/pm2-existing.ts
+++ b/src/cli/pm2-existing.ts
@@ -1,0 +1,85 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { LinuxPm2GodProcess } from '../core/pm2-lifecycle-owner.js';
+
+const ABSENT_EXIT_CODE = 4;
+
+type ExistingPm2Mutation =
+  | { operation: 'start'; target: string; only?: string; updateEnv?: boolean }
+  | { operation: 'restart'; target: string; updateEnv?: boolean }
+  | { operation: 'stop' | 'delete'; target: string };
+
+type ExistingPm2Request = ExistingPm2Mutation & { expectedGod: LinuxPm2GodProcess };
+
+function mutationFromArgs(args: string[]): ExistingPm2Mutation {
+  const [operation, target] = args;
+  if (!target) throw new Error(`unsupported PM2 mutation without target: ${args.join(' ')}`);
+  if (operation === 'stop' || operation === 'delete') {
+    if (args.length !== 2) throw new Error(`unsupported PM2 mutation: ${args.join(' ')}`);
+    return { operation, target };
+  }
+  if (operation !== 'start') throw new Error(`unsupported PM2 mutation: ${args.join(' ')}`);
+  const onlyIndex = args.indexOf('--only');
+  const only = onlyIndex >= 0 ? args[onlyIndex + 1] : undefined;
+  const updateEnv = args.includes('--update-env');
+  const expectedLength = 2 + (only ? 2 : 0) + (updateEnv ? 1 : 0);
+  if (args.length !== expectedLength || (onlyIndex >= 0 && !only)) {
+    throw new Error(`unsupported PM2 start mutation: ${args.join(' ')}`);
+  }
+  if (updateEnv && !only) return { operation: 'restart', target, updateEnv: true };
+  return {
+    operation: 'start',
+    target,
+    ...(only ? { only } : {}),
+    ...(updateEnv ? { updateEnv: true } : {}),
+  };
+}
+
+function helperArgs(pkgRoot: string, request: ExistingPm2Request): string[] {
+  const built = join(pkgRoot, 'dist', 'cli', 'pm2-existing-client.js');
+  const payload = JSON.stringify(request);
+  // Source/test execution must not silently select a stale dist helper with an
+  // older request contract. Installed production code runs from dist and uses
+  // the sibling built helper.
+  if (import.meta.url.includes('/dist/cli/pm2-existing.js') && existsSync(built)) {
+    return [built, payload];
+  }
+  return ['--import', 'tsx', join(pkgRoot, 'src', 'cli', 'pm2-existing-client.ts'), payload];
+}
+
+/** Mutate an attested existing God without PM2's public connect/daemonize path. */
+export function runExistingPm2Command(input: {
+  pkgRoot: string;
+  home: string;
+  args: string[];
+  inherit?: boolean;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  nodePath?: string;
+  expectedGod: LinuxPm2GodProcess;
+}): void {
+  if (!input.expectedGod.startIdentity) {
+    throw new Error(`PM2 God pid ${input.expectedGod.pid} has no process-birth identity`);
+  }
+  const request = { ...mutationFromArgs(input.args), expectedGod: input.expectedGod };
+  const result = spawnSync(
+    input.nodePath ?? process.execPath,
+    helperArgs(input.pkgRoot, request),
+    {
+      stdio: input.inherit === false ? 'pipe' : 'inherit',
+      env: {
+        ...(input.env ?? process.env),
+        PM2_HOME: input.home,
+      },
+      timeout: input.timeoutMs ?? 30_000,
+    },
+  );
+  if (result.status === 0) return;
+  const stderr = String(result.stderr ?? '').trim();
+  const detail = result.error?.message ?? (stderr || `status ${result.status}`);
+  if (result.status === ABSENT_EXIT_CODE) {
+    throw new Error(`PM2 God disappeared before mutation; no replacement daemon was created: ${detail}`);
+  }
+  throw new Error(`PM2 existing-daemon ${input.args.join(' ')} failed: ${detail}`);
+}

--- a/src/cli/pm2-readonly-client.ts
+++ b/src/cli/pm2-readonly-client.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Side-effect-free PM2 observer.
+ *
+ * PM2's public `connect`/CLI path daemonizes when the RPC socket disappears.
+ * This helper deliberately calls pingDaemon + launchRPC directly and never
+ * calls Client.start/connect, so a status/logs race cannot create a new God in
+ * the observer's cgroup.
+ */
+import { createRequire } from 'node:module';
+import {
+  inspectLinuxPm2GodOwnership,
+  revalidateLinuxPm2GodProcess,
+  type LinuxPm2GodProcess,
+} from '../core/pm2-lifecycle-owner.js';
+
+const require = createRequire(import.meta.url);
+const pm2 = require('pm2') as any;
+const mode = process.argv[2];
+const target = process.argv[3] || 'all';
+const lines = Number.parseInt(process.argv[4] || '50', 10);
+const CONNECT_TIMEOUT_MS = 5_000;
+const ABSENT_EXIT_CODE = 3;
+let expectedGod: LinuxPm2GodProcess | undefined;
+try {
+  expectedGod = process.env.BOTMUX_PM2_EXPECTED_GOD
+    ? JSON.parse(process.env.BOTMUX_PM2_EXPECTED_GOD) as LinuxPm2GodProcess
+    : undefined;
+} catch (error) {
+  fail(`invalid PM2 read-only generation binding: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+function fail(message: string, code = 1): never {
+  console.error(message);
+  process.exit(code);
+}
+
+function disableAxonReconnect(socket: any, label: string): void {
+  if (!socket?.set) fail(`PM2 read-only ${label} socket cannot disable reconnect`);
+  socket.set('retry timeout', 0);
+  socket.set('retry max timeout', 0);
+  // pm2-axon caches the current backoff separately after connect.
+  socket.retry = 0;
+}
+
+function revalidateExpectedGod(phase: string): void {
+  if (!expectedGod) return;
+  const home = process.env.PM2_HOME ?? '';
+  const ownership = inspectLinuxPm2GodOwnership(home);
+  const current = ownership.kind === 'absent' || ownership.processes.length !== 1
+    ? undefined
+    : ownership.processes[0];
+  if (!expectedGod.startIdentity
+      || !current
+      || current.pid !== expectedGod.pid
+      || current.startIdentity !== expectedGod.startIdentity
+      || current.cgroup !== expectedGod.cgroup
+      || !revalidateLinuxPm2GodProcess(expectedGod, home)) {
+    fail(`PM2 God generation changed before read-only ${phase}`);
+  }
+}
+
+const timer = setTimeout(() => {
+  fail('PM2 read-only RPC connection timed out');
+}, CONNECT_TIMEOUT_MS);
+timer.unref();
+
+pm2.Client.pingDaemon((alive: boolean) => {
+  if (!alive) {
+    clearTimeout(timer);
+    if (mode === 'jlist') process.exit(ABSENT_EXIT_CODE);
+    console.log(mode === 'logs' ? 'daemon 未在运行，暂无 PM2 日志。' : 'daemon 未在运行。');
+    process.exit(0);
+  }
+  pm2.Client.launchRPC((connectError: Error | null | undefined) => {
+    if (connectError) fail(`PM2 read-only RPC connection failed: ${connectError.message}`);
+    clearTimeout(timer);
+    const rpcSocket = pm2.Client.client?.sock;
+    disableAxonReconnect(rpcSocket, 'RPC');
+    revalidateExpectedGod(mode);
+    if (mode === 'jlist') {
+      pm2.list((error: Error | null | undefined, list: unknown[]) => {
+        if (error) fail(`PM2 read-only jlist failed: ${error.message}`);
+        process.stdout.write(JSON.stringify(Array.isArray(list) ? list : []));
+        pm2.disconnect(() => process.exit(0));
+      });
+      return;
+    }
+    if (mode === 'status') {
+      pm2.speedList(null);
+      return;
+    }
+    if (mode === 'logs') {
+      const launchBus = pm2.Client.launchBus.bind(pm2.Client);
+      pm2.Client.launchBus = (callback: (...args: any[]) => void) => {
+        launchBus((error: Error | null | undefined, bus: unknown, busSocket: any) => {
+          if (error) fail(`PM2 read-only bus connection failed: ${error.message}`);
+          disableAxonReconnect(busSocket, 'bus');
+          revalidateExpectedGod('logs bus connection');
+          // Closing this generation's publisher must end the observer. Never
+          // reconnect to a replacement God that later owns the same pathname.
+          busSocket.once('close', () => process.exit(0));
+          callback(error, bus, busSocket);
+        });
+      };
+      pm2.streamLogs(target, Number.isFinite(lines) ? lines : 50, false, undefined, false);
+      return;
+    }
+    fail(`unknown PM2 read-only mode: ${mode}`);
+  });
+});

--- a/src/cli/pm2-readonly.ts
+++ b/src/cli/pm2-readonly.ts
@@ -1,0 +1,85 @@
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { LinuxPm2GodProcess } from '../core/pm2-lifecycle-owner.js';
+
+const ABSENT_EXIT_CODE = 3;
+
+function helperArgs(pkgRoot: string, modeArgs: string[]): string[] {
+  const built = join(pkgRoot, 'dist', 'cli', 'pm2-readonly-client.js');
+  if (import.meta.url.includes('/dist/cli/pm2-readonly.js') && existsSync(built)) {
+    return [built, ...modeArgs];
+  }
+  return ['--import', 'tsx', join(pkgRoot, 'src', 'cli', 'pm2-readonly-client.ts'), ...modeArgs];
+}
+
+function readonlyEnv(
+  home: string,
+  expectedGod?: LinuxPm2GodProcess,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...baseEnv,
+    PM2_HOME: home,
+    PM2_SILENT: 'true',
+    PM2_USAGE: 'CLI',
+  };
+  delete env.BOTMUX_PM2_EXPECTED_GOD;
+  if (expectedGod) env.BOTMUX_PM2_EXPECTED_GOD = JSON.stringify(expectedGod);
+  return env;
+}
+
+export function captureReadonlyPm2Jlist(input: {
+  pkgRoot: string;
+  home: string;
+  nodePath?: string;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  expectedGod?: LinuxPm2GodProcess;
+}): string {
+  const result = spawnSync(input.nodePath ?? process.execPath, helperArgs(input.pkgRoot, ['jlist']), {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: readonlyEnv(input.home, input.expectedGod, { ...process.env, ...(input.env ?? {}) }),
+    timeout: input.timeoutMs ?? 10_000,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.status === ABSENT_EXIT_CODE) return '[]';
+  if (result.status !== 0) {
+    const detail = result.error?.message
+      ?? (String(result.stderr ?? '').trim() || `status ${result.status}`);
+    throw new Error(`PM2 read-only jlist failed: ${detail}`);
+  }
+  return String(result.stdout ?? '');
+}
+
+export function printReadonlyPm2Status(input: {
+  pkgRoot: string;
+  home: string;
+  nodePath?: string;
+  expectedGod?: LinuxPm2GodProcess;
+}): void {
+  const result = spawnSync(input.nodePath ?? process.execPath, helperArgs(input.pkgRoot, ['status']), {
+    stdio: 'inherit',
+    env: readonlyEnv(input.home, input.expectedGod),
+    timeout: 15_000,
+  });
+  if (result.status !== 0) {
+    throw new Error(`PM2 read-only status failed: ${result.error?.message ?? `status ${result.status}`}`);
+  }
+}
+
+export function spawnReadonlyPm2Logs(input: {
+  pkgRoot: string;
+  home: string;
+  target: string;
+  lines: string;
+  nodePath?: string;
+  expectedGod?: LinuxPm2GodProcess;
+}): ChildProcess {
+  return spawn(
+    input.nodePath ?? process.execPath,
+    helperArgs(input.pkgRoot, ['logs', input.target, input.lines]),
+    { stdio: 'inherit', env: readonlyEnv(input.home, input.expectedGod) },
+  );
+}

--- a/src/core/plugins/pm2.ts
+++ b/src/core/plugins/pm2.ts
@@ -9,7 +9,7 @@ import { captureReadonlyPm2Jlist } from '../../cli/pm2-readonly.js';
 import { runExistingPm2Command } from '../../cli/pm2-existing.js';
 import { stripPm2GracefulExitMarker } from '../../pm2-graceful-exit.js';
 import {
-  describeExternalPm2Owner,
+  ExternalPm2GodOwnershipError,
   inspectLinuxPm2Command,
   inspectLinuxPm2ReadonlyTarget,
   type LinuxPm2GodProcess,
@@ -56,9 +56,10 @@ function assertPluginPm2MutationOwned() {
   });
   if (plan.kind === 'direct') return { ownership, plan };
   if (plan.kind === 'reject') {
-    throw new Error(
-      `plugin PM2 拒绝复用其它 supervisor 的 God Daemon: ${describeExternalPm2Owner(ownership)}`,
-    );
+    if (ownership.kind !== 'external') {
+      throw new Error('plugin PM2 ownership plan rejected a non-external God');
+    }
+    throw new ExternalPm2GodOwnershipError(ownership);
   }
   throw new Error('plugin PM2 尚无 botmux.service owner；请先运行 `botmux start`。');
 }

--- a/src/core/plugins/pm2.ts
+++ b/src/core/plugins/pm2.ts
@@ -3,10 +3,20 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { buildPm2SpawnCommand } from '../../cli/pm2-command.js';
+import { captureReadonlyPm2Jlist } from '../../cli/pm2-readonly.js';
+import { runExistingPm2Command } from '../../cli/pm2-existing.js';
 import { stripPm2GracefulExitMarker } from '../../pm2-graceful-exit.js';
+import {
+  describeExternalPm2Owner,
+  inspectLinuxPm2Command,
+  inspectLinuxPm2ReadonlyTarget,
+  type LinuxPm2GodProcess,
+} from '../pm2-lifecycle-owner.js';
 
 const require = createRequire(import.meta.url);
+const PKG_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
 const BOTMUX_HOME = join(homedir(), '.botmux');
 export const PLUGIN_PM2_HOME = join(BOTMUX_HOME, 'pm2');
 export const PLUGIN_PM2_PREFIX = 'botmux-plugin-';
@@ -39,11 +49,54 @@ function pm2Env(extra?: Record<string, string>): NodeJS.ProcessEnv {
   return { ...inherited, ...(extra ?? {}), PM2_HOME: PLUGIN_PM2_HOME };
 }
 
+function assertPluginPm2MutationOwned() {
+  if (process.platform !== 'linux') return undefined;
+  const { ownership, plan } = inspectLinuxPm2Command({
+    command: 'plugin', home: PLUGIN_PM2_HOME,
+  });
+  if (plan.kind === 'direct') return { ownership, plan };
+  if (plan.kind === 'reject') {
+    throw new Error(
+      `plugin PM2 拒绝复用其它 supervisor 的 God Daemon: ${describeExternalPm2Owner(ownership)}`,
+    );
+  }
+  throw new Error('plugin PM2 尚无 botmux.service owner；请先运行 `botmux start`。');
+}
+
+function pluginPm2Query(): { available: boolean; expectedGod?: LinuxPm2GodProcess } {
+  if (process.platform !== 'linux') return { available: true };
+  const target = inspectLinuxPm2ReadonlyTarget(PLUGIN_PM2_HOME);
+  if (!target) return { available: false };
+  return typeof target === 'object'
+    ? { available: true, expectedGod: target }
+    : { available: true };
+}
+
 export function runPluginPm2(args: string[], opts: { inherit?: boolean; timeoutMs?: number; env?: Record<string, string> } = {}): void {
+  const inspection = assertPluginPm2MutationOwned();
+  const env = pm2Env(opts.env);
+  if (inspection?.ownership.kind === 'owned') {
+    if (inspection.ownership.processes.length !== 1) {
+      throw new Error(
+        `plugin PM2 mutation requires exactly one botmux.service-owned God; found `
+        + `${inspection.ownership.processes.map(process => process.pid).join(', ') || 'none'}`,
+      );
+    }
+    runExistingPm2Command({
+      pkgRoot: PKG_ROOT,
+      home: PLUGIN_PM2_HOME,
+      args,
+      inherit: opts.inherit,
+      timeoutMs: opts.timeoutMs,
+      env,
+      expectedGod: inspection.ownership.processes[0]!,
+    });
+    return;
+  }
   const pm2 = buildPm2SpawnCommand(pm2Bin(), args);
   const result = spawnSync(pm2.command, pm2.args, {
     stdio: opts.inherit === false ? 'pipe' : 'inherit',
-    env: pm2Env(opts.env),
+    env,
     shell: pm2.shell ?? false,
     timeout: opts.timeoutMs,
   });
@@ -55,22 +108,16 @@ export function runPluginPm2(args: string[], opts: { inherit?: boolean; timeoutM
 }
 
 export function capturePluginPm2(args: string[], opts: { timeoutMs?: number; env?: Record<string, string> } = {}): string {
-  const pm2 = buildPm2SpawnCommand(pm2Bin(), args);
-  const result = spawnSync(pm2.command, pm2.args, {
-    encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: pm2Env(opts.env),
-    shell: pm2.shell ?? false,
-    timeout: opts.timeoutMs ?? 10_000,
-    // `pm2 jlist` output scales with the process count (full env per process);
-    // Node's 1 MiB default spawnSync buffer overflows to ENOBUFS on large
-    // fleets. Match cli.ts pm2Capture — lift the cap far above any real size.
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  if (result.status !== 0) {
-    const detail = result.error?.message
-      ?? ((result.stderr ? String(result.stderr).trim() : '') || `status ${result.status}`);
-    throw new Error(`pm2 ${args.join(' ')} failed: ${detail}`);
+  if (args.length !== 1 || args[0] !== 'jlist') {
+    throw new Error(`unsupported read-only plugin PM2 command: ${args.join(' ')}`);
   }
-  return typeof result.stdout === 'string' ? result.stdout : '';
+  const query = pluginPm2Query();
+  if (!query.available) return '[]';
+  return captureReadonlyPm2Jlist({
+    pkgRoot: PKG_ROOT,
+    home: PLUGIN_PM2_HOME,
+    timeoutMs: opts.timeoutMs,
+    env: pm2Env(opts.env),
+    expectedGod: query.expectedGod,
+  });
 }

--- a/src/core/plugins/service-manager.ts
+++ b/src/core/plugins/service-manager.ts
@@ -57,7 +57,7 @@ export class PluginServiceDeleteError extends Error {
   }
 }
 
-interface Pm2AppInfo {
+export interface Pm2AppInfo {
   name: string;
   pid?: number;
   status?: string;
@@ -302,6 +302,32 @@ function selectedRecords(pluginIds?: readonly string[], autoOnly = false): Insta
     .filter(record => !!record.manifest.service)
     .filter(record => !autoOnly || record.manifest.service?.mode === 'auto')
     .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Capture manual services that must be restored after the shared PM2 God rotates. */
+export async function snapshotRunningManualPluginServiceIds(): Promise<string[]> {
+  return withPluginServiceLock(async () => {
+    return selectRunningManualPluginServiceIds(selectedRecords(), readPm2Apps());
+  });
+}
+
+export function selectRunningManualPluginServiceIds(
+  records: readonly InstalledPluginRecord[],
+  pm2Apps: readonly Pm2AppInfo[],
+): string[] {
+  const apps = new Map(pm2Apps.map(app => [app.name, app]));
+  return records
+    .filter(record => record.manifest.service?.mode === 'manual')
+    .filter(record => {
+      const app = apps.get(pluginPm2AppName(record.id));
+      return !!app
+        && app.status !== 'stopped'
+        && app.status !== 'errored'
+        && ((typeof app.pid === 'number' && app.pid > 1)
+          || app.status === 'online'
+          || app.status === 'launching');
+    })
+    .map(record => record.id);
 }
 
 function reportFromState(

--- a/src/core/pm2-lifecycle-owner.ts
+++ b/src/core/pm2-lifecycle-owner.ts
@@ -15,6 +15,27 @@ export type LinuxPm2GodOwnership =
   | { kind: 'owned'; processes: LinuxPm2GodProcess[] }
   | { kind: 'external'; processes: LinuxPm2GodProcess[] };
 
+type ExternalLinuxPm2GodOwnership = Extract<LinuxPm2GodOwnership, { kind: 'external' }>;
+
+/** A stable CLI-facing refusal: never reuse or signal a God owned by another cgroup. */
+export class ExternalPm2GodOwnershipError extends Error {
+  readonly code = 'BOTMUX_PM2_EXTERNAL_OWNER';
+  readonly exitCode = 2;
+
+  constructor(ownership: ExternalLinuxPm2GodOwnership) {
+    const owner = serviceOwnerFromCgroup(ownership.processes[0]?.cgroup ?? 'unknown');
+    super([
+      `检测到 PM2 God Daemon 归属于其它 supervisor (${owner}): ${describeExternalPm2Owner(ownership)}。`,
+      '为避免复用外部 cgroup，本次操作已拒绝。',
+      '迁移建议：',
+      '1. 先确认所有 Botmux Session/Riff workload 已空闲；',
+      '2. 由当前 owner 安全停止该 PM2 God generation（不要直接运行 `pm2 kill`，它会绕过 Botmux shutdown 校验）；',
+      '3. 确认旧 God 已退出后，运行 `botmux restart`，由 botmux.service 建立新的 owner。',
+    ].join('\n'));
+    this.name = 'ExternalPm2GodOwnershipError';
+  }
+}
+
 export type LinuxPm2Command = 'start' | 'restart' | 'status' | 'logs' | 'stop' | 'start-bot' | 'plugin';
 
 export type LinuxPm2CommandPlan =
@@ -198,8 +219,10 @@ export function revalidateLinuxPm2GodProcess(
 }
 
 function serviceOwnerFromCgroup(path: string): string {
-  const service = path.split('/').reverse().find(part => part.endsWith('.service'));
-  return service ?? path;
+  const owner = path.split('/').reverse().find(
+    part => part.endsWith('.service') || part.endsWith('.scope'),
+  );
+  return owner ?? path;
 }
 
 export function planLinuxPm2Command(input: {
@@ -252,9 +275,10 @@ export function inspectLinuxPm2ReadonlyTarget(
   const { ownership, plan } = inspectLinuxPm2Command({ command: 'status', home }, deps);
   if (plan.kind === 'absent') return false;
   if (plan.kind === 'reject') {
-    throw new Error(
-      `检测到 PM2 God Daemon 归属于其它 supervisor，拒绝复用: ${describeExternalPm2Owner(ownership)}`,
-    );
+    if (ownership.kind !== 'external') {
+      throw new Error('PM2 ownership plan rejected a non-external God');
+    }
+    throw new ExternalPm2GodOwnershipError(ownership);
   }
   if (plan.kind !== 'direct' || ownership.kind !== 'owned') return true;
   if (ownership.processes.length !== 1) {

--- a/src/core/pm2-lifecycle-owner.ts
+++ b/src/core/pm2-lifecycle-owner.ts
@@ -1,0 +1,273 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+
+export const BOTMUX_SYSTEMD_SERVICE = 'botmux.service';
+export const BOTMUX_SYSTEMD_SERVICE_ENV = 'BOTMUX_SYSTEMD_SERVICE';
+
+export interface LinuxPm2GodProcess {
+  pid: number;
+  cgroup: string;
+  /** /proc/<pid>/stat starttime, bound while cmdline+cgroup were stable. */
+  startIdentity?: string;
+}
+
+export type LinuxPm2GodOwnership =
+  | { kind: 'absent' }
+  | { kind: 'owned'; processes: LinuxPm2GodProcess[] }
+  | { kind: 'external'; processes: LinuxPm2GodProcess[] };
+
+export type LinuxPm2Command = 'start' | 'restart' | 'status' | 'logs' | 'stop' | 'start-bot' | 'plugin';
+
+export type LinuxPm2CommandPlan =
+  | { kind: 'direct' }
+  | { kind: 'handoff'; service: typeof BOTMUX_SYSTEMD_SERVICE }
+  | { kind: 'absent' }
+  | { kind: 'reject'; owner: string };
+
+export interface LinuxPm2InspectionDeps {
+  procEntries?: () => string[];
+  readText?: (path: string) => string;
+  currentUid?: number;
+  statUid?: (path: string) => number;
+}
+
+function processDisappeared(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'ENOENT' || code === 'ESRCH' || code === 'ENOTDIR';
+}
+
+function procReadError(path: string, error: unknown): Error {
+  return new Error(
+    `cannot inspect ${path}: ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
+
+function normalizedCgroupPath(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('/')) return trimmed;
+
+  let unified: string | undefined;
+  for (const line of trimmed.split(/\r?\n/)) {
+    const first = line.indexOf(':');
+    const second = first < 0 ? -1 : line.indexOf(':', first + 1);
+    if (second < 0) continue;
+    const hierarchy = line.slice(0, first);
+    const controllers = line.slice(first + 1, second);
+    const path = line.slice(second + 1).trim();
+    if (!path) continue;
+    if (controllers.split(',').includes('name=systemd')) return path;
+    if (hierarchy === '0' && controllers === '') unified = path;
+  }
+  return unified;
+}
+
+function cgroupHasService(path: string | undefined, service = BOTMUX_SYSTEMD_SERVICE): boolean {
+  return path?.split('/').includes(service) === true;
+}
+
+export function classifyLinuxPm2GodOwnership(
+  entries: ReadonlyArray<LinuxPm2GodProcess>,
+  service = BOTMUX_SYSTEMD_SERVICE,
+): LinuxPm2GodOwnership {
+  if (entries.length === 0) return { kind: 'absent' };
+  const processes = entries.map(entry => ({
+    pid: entry.pid,
+    cgroup: normalizedCgroupPath(entry.cgroup) ?? '(unreadable)',
+    ...(entry.startIdentity ? { startIdentity: entry.startIdentity } : {}),
+  }));
+  const external = processes.filter(entry => !cgroupHasService(entry.cgroup, service));
+  return external.length === 0
+    ? { kind: 'owned', processes }
+    : { kind: 'external', processes: external };
+}
+
+export function linuxSystemdCgroupForPid(
+  pid: number,
+  readText: (path: string) => string = path => readFileSync(path, 'utf8'),
+): string {
+  return normalizedCgroupPath(readText(`/proc/${pid}/cgroup`)) ?? '(unreadable)';
+}
+
+export function currentLinuxSystemdCgroup(
+  readText: (path: string) => string = path => readFileSync(path, 'utf8'),
+): string {
+  return linuxSystemdCgroupForPid(process.pid, readText);
+}
+
+export function scanLinuxPm2GodPids(
+  home: string,
+  deps: LinuxPm2InspectionDeps = {},
+): number[] {
+  const procEntries = deps.procEntries ?? (() => readdirSync('/proc'));
+  const readText = deps.readText ?? (path => readFileSync(path, 'utf8'));
+  const marker = `God Daemon (${home})`;
+  const currentUid = deps.currentUid ?? process.getuid?.();
+  const statUid = deps.statUid ?? (path => statSync(path).uid);
+  const pids: number[] = [];
+  let entries: string[];
+  try {
+    entries = procEntries();
+  } catch (error) {
+    throw new Error(
+      `cannot inspect /proc for PM2 God daemons: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number(entry);
+    if (!Number.isSafeInteger(pid) || pid <= 1) continue;
+    if (currentUid !== undefined) {
+      try {
+        // hidepid=1 deliberately makes another user's cmdline unreadable. It
+        // cannot be our PM2_HOME owner, so exclude it before the fail-closed
+        // candidate inspection below.
+        if (statUid(`/proc/${pid}`) !== currentUid) continue;
+      } catch (error) {
+        if (processDisappeared(error)) continue;
+        throw procReadError(`/proc/${pid}`, error);
+      }
+    }
+    try {
+      const cmdline = readText(`/proc/${pid}/cmdline`).replace(/\u0000/g, ' ').trim();
+      if (cmdline.includes('PM2 v') && cmdline.includes(marker)) pids.push(pid);
+    } catch (error) {
+      // ENOENT/ESRCH is the normal process-table race. Permission and I/O
+      // failures are unknown ownership, never evidence that no God exists.
+      if (!processDisappeared(error)) throw procReadError(`/proc/${pid}/cmdline`, error);
+    }
+  }
+  return [...new Set(pids)].sort((a, b) => a - b);
+}
+
+export function inspectLinuxPm2GodOwnership(
+  home: string,
+  deps: LinuxPm2InspectionDeps = {},
+): LinuxPm2GodOwnership {
+  const readText = deps.readText ?? (path => readFileSync(path, 'utf8'));
+  const pids = scanLinuxPm2GodPids(home, deps);
+  const processes: LinuxPm2GodProcess[] = [];
+  for (const pid of pids) {
+    try {
+      const startBefore = linuxProcStartIdentity(readText(`/proc/${pid}/stat`));
+      const cmdline = readText(`/proc/${pid}/cmdline`).replace(/\u0000/g, ' ').trim();
+      if (!cmdline.includes('PM2 v') || !cmdline.includes(`God Daemon (${home})`)) continue;
+      const cgroup = readText(`/proc/${pid}/cgroup`);
+      const startAfter = linuxProcStartIdentity(readText(`/proc/${pid}/stat`));
+      if (!startBefore || startBefore !== startAfter) {
+        throw new Error(`PM2 God pid ${pid} changed generation during ownership inspection`);
+      }
+      processes.push({ pid, cgroup, startIdentity: startBefore });
+    } catch (error) {
+      // A God that exited after the cmdline scan is absent. Any other failure
+      // leaves ownership unknown and must stop the lifecycle operation.
+      if (!processDisappeared(error)) throw procReadError(`/proc/${pid}/cgroup`, error);
+    }
+  }
+  return classifyLinuxPm2GodOwnership(processes);
+}
+
+function linuxProcStartIdentity(raw: string): string | undefined {
+  const closeParen = raw.lastIndexOf(')');
+  if (closeParen < 0) return undefined;
+  const fields = raw.slice(closeParen + 2).trim().split(/\s+/);
+  return fields[19] || undefined;
+}
+
+/** Rebind cmdline, cgroup and birth immediately before a PID-addressed signal. */
+export function revalidateLinuxPm2GodProcess(
+  expected: LinuxPm2GodProcess,
+  home: string,
+  deps: Pick<LinuxPm2InspectionDeps, 'readText'> = {},
+): boolean {
+  if (!expected.startIdentity) return false;
+  const readText = deps.readText ?? (path => readFileSync(path, 'utf8'));
+  try {
+    const startBefore = linuxProcStartIdentity(readText(`/proc/${expected.pid}/stat`));
+    const cmdline = readText(`/proc/${expected.pid}/cmdline`).replace(/\u0000/g, ' ').trim();
+    const cgroup = normalizedCgroupPath(readText(`/proc/${expected.pid}/cgroup`));
+    const startAfter = linuxProcStartIdentity(readText(`/proc/${expected.pid}/stat`));
+    return startBefore === expected.startIdentity
+      && startAfter === expected.startIdentity
+      && cmdline.includes('PM2 v')
+      && cmdline.includes(`God Daemon (${home})`)
+      && cgroup === normalizedCgroupPath(expected.cgroup);
+  } catch (error) {
+    if (processDisappeared(error)) return false;
+    throw procReadError(`/proc/${expected.pid}`, error);
+  }
+}
+
+function serviceOwnerFromCgroup(path: string): string {
+  const service = path.split('/').reverse().find(part => part.endsWith('.service'));
+  return service ?? path;
+}
+
+export function planLinuxPm2Command(input: {
+  command: LinuxPm2Command;
+  ownership: LinuxPm2GodOwnership;
+  callerCgroup: string;
+}): LinuxPm2CommandPlan {
+  if (input.ownership.kind === 'external') {
+    return {
+      kind: 'reject',
+      owner: serviceOwnerFromCgroup(input.ownership.processes[0]?.cgroup ?? 'unknown'),
+    };
+  }
+  if (input.ownership.kind === 'owned') return { kind: 'direct' };
+  if (input.command === 'start' || input.command === 'restart' || input.command === 'plugin') {
+    if (cgroupHasService(normalizedCgroupPath(input.callerCgroup))) return { kind: 'direct' };
+    if (input.command === 'plugin') return { kind: 'absent' };
+    return { kind: 'handoff', service: BOTMUX_SYSTEMD_SERVICE };
+  }
+  return { kind: 'absent' };
+}
+
+export interface LinuxPm2CommandInspection {
+  ownership: LinuxPm2GodOwnership;
+  plan: LinuxPm2CommandPlan;
+}
+
+/** Bind one ownership snapshot and caller cgroup to one lifecycle decision. */
+export function inspectLinuxPm2Command(input: {
+  command: LinuxPm2Command;
+  home: string;
+  callerCgroup?: string;
+}, deps: LinuxPm2InspectionDeps = {}): LinuxPm2CommandInspection {
+  const ownership = inspectLinuxPm2GodOwnership(input.home, deps);
+  return {
+    ownership,
+    plan: planLinuxPm2Command({
+      command: input.command,
+      ownership,
+      callerCgroup: input.callerCgroup ?? currentLinuxSystemdCgroup(deps.readText),
+    }),
+  };
+}
+
+/** Project a status/logs request without ever creating a missing PM2 God. */
+export function inspectLinuxPm2ReadonlyTarget(
+  home: string,
+  deps: LinuxPm2InspectionDeps = {},
+): false | true | LinuxPm2GodProcess {
+  const { ownership, plan } = inspectLinuxPm2Command({ command: 'status', home }, deps);
+  if (plan.kind === 'absent') return false;
+  if (plan.kind === 'reject') {
+    throw new Error(
+      `检测到 PM2 God Daemon 归属于其它 supervisor，拒绝复用: ${describeExternalPm2Owner(ownership)}`,
+    );
+  }
+  if (plan.kind !== 'direct' || ownership.kind !== 'owned') return true;
+  if (ownership.processes.length !== 1) {
+    throw new Error(
+      `PM2 read-only query found multiple Gods: ${ownership.processes.map(process => process.pid).join(', ')}`,
+    );
+  }
+  return ownership.processes[0]!;
+}
+
+export function describeExternalPm2Owner(ownership: LinuxPm2GodOwnership): string {
+  if (ownership.kind !== 'external') return '';
+  return ownership.processes
+    .map(entry => `${entry.pid}@${entry.cgroup}`)
+    .join(', ');
+}

--- a/src/desktop/main/pm2-apps.ts
+++ b/src/desktop/main/pm2-apps.ts
@@ -5,6 +5,10 @@ import type { DesktopPaths } from '../shared/types.js';
 import { buildBundledPath } from './node-command.js';
 import type { RuntimeLaunchTarget } from './runtime-service.js';
 import { parsePm2Apps, type Pm2AppSummary } from './runtime-source.js';
+import {
+  inspectLinuxPm2ReadonlyTarget,
+  type LinuxPm2GodProcess,
+} from '../../core/pm2-lifecycle-owner.js';
 
 interface Pm2ListDeps {
   existsSync?: (path: string) => boolean;
@@ -14,9 +18,18 @@ interface Pm2ListDeps {
   timeoutMs?: number;
   /** Probed user shell PATH for bundled runtimes (see probeShellPathEnv). */
   pathEnv?: string;
+  /** Test seam for the side-effect-free PM2 lifecycle preflight. */
+  pm2QueryAvailable?: (home: string) => boolean | LinuxPm2GodProcess;
 }
 
 export const defaultPm2ListTimeoutMs = 25_000;
+
+function pm2QueryAvailable(home: string): boolean | LinuxPm2GodProcess {
+  // The direct-RPC helper is side-effect free and determines absence without
+  // relying on process.title, which is not reflected in Windows CIM CommandLine.
+  if (process.platform !== 'linux') return true;
+  return inspectLinuxPm2ReadonlyTarget(home);
+}
 
 export function listPm2Apps(
   paths: DesktopPaths,
@@ -29,26 +42,35 @@ export function listPm2Apps(
   if (!existsSync(pm2Bin)) {
     return Promise.reject(new Error(`PM2 binary not found: ${pm2Bin}`));
   }
+  let expectedGod: LinuxPm2GodProcess | undefined;
+  try {
+    const query = (deps.pm2QueryAvailable ?? pm2QueryAvailable)(paths.pm2Home);
+    if (!query) return Promise.resolve([]);
+    expectedGod = typeof query === 'object' ? query : undefined;
+  } catch (error) {
+    return Promise.reject(error);
+  }
 
-  const command = runtime.kind === 'bundled' ? runtime.nodePath : pm2Bin;
-  const args = runtime.kind === 'bundled' ? [pm2Bin, 'jlist'] : ['jlist'];
+  const command = runtime.kind === 'bundled'
+    ? runtime.nodePath
+    : (deps.execPath ?? process.execPath);
+  const args = [join(packageRoot, 'dist', 'cli', 'pm2-readonly-client.js'), 'jlist'];
   const baseEnv = deps.env ?? process.env;
   const env: NodeJS.ProcessEnv = {
     ...baseEnv,
-    // External PM2 bins use /usr/bin/env node; Finder-launched apps need a
-    // repaired PATH so discovery does not depend on the user's shell startup.
-    // jlist may be the first pm2 contact and thus start the pm2 daemon, whose
-    // env sticks and propagates into resurrected apps — so the bundled branch
-    // carries the probed shell PATH with the SAME ordering as the daemon-start
-    // spawn (buildBundledPath); pm2 itself is launched via the absolute
-    // nodePath and never resolves node through this PATH.
+    // Finder-launched apps still need a repaired PATH for app metadata and
+    // follow-up launches. The observer itself uses an absolute Node path and
+    // direct RPC; it never creates a missing PM2 daemon.
     PATH: runtime.kind === 'bundled'
       ? buildBundledPath(baseEnv.PATH, runtime.nodePath, deps.pathEnv)
       : withRuntimePath(baseEnv.PATH, runtime.binPath, runtime.pathEnv),
     PM2_HOME: paths.pm2Home,
     SESSION_DATA_DIR: paths.dataDir,
   };
-  delete env.ELECTRON_RUN_AS_NODE;
+  delete env.BOTMUX_PM2_EXPECTED_GOD;
+  if (expectedGod) env.BOTMUX_PM2_EXPECTED_GOD = JSON.stringify(expectedGod);
+  if (runtime.kind === 'bundled') delete env.ELECTRON_RUN_AS_NODE;
+  else if (process.versions.electron) env.ELECTRON_RUN_AS_NODE = '1';
 
   return new Promise((resolve, reject) => {
     // PM2 discovery is a status input, not decorative data: errors reject so
@@ -82,6 +104,10 @@ export function listPm2Apps(
     });
     child.on('close', code => {
       finish(() => {
+        if (code === 3) {
+          resolve([]);
+          return;
+        }
         if (code !== 0 || !stdout) {
           const detail = concise(stderr || `exit code ${code ?? 1}`);
           reject(new Error(`PM2 jlist failed: ${detail}`));

--- a/test/autostart-existing-unit-repair.test.ts
+++ b/test/autostart-existing-unit-repair.test.ts
@@ -1,0 +1,200 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  home: '',
+  restarted: false,
+  rotateGod: false,
+  currentPid: 8101,
+  currentBirth: 'existing-generation',
+  initialMainPid: 0,
+  invalidPostRestart: false,
+  jobPending: false,
+  stallRestart: false,
+  systemctlCalls: [] as string[][],
+}));
+
+vi.mock('node:os', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => mocks.home };
+});
+
+vi.mock('node:child_process', () => ({
+  spawnSync: (_command: string, args: string[]) => {
+    mocks.systemctlCalls.push(args);
+    if (args.includes('show-environment') || args.includes('daemon-reload')) {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (args.includes('list-jobs')) {
+      return {
+        status: 0,
+        stdout: mocks.jobPending ? '991 botmux.service restart running\n' : '',
+        stderr: '',
+      };
+    }
+    if (args.includes('cancel')) {
+      mocks.jobPending = false;
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (args.includes('restart')) {
+      if (mocks.stallRestart) mocks.jobPending = true;
+      else if (!mocks.jobPending) mocks.restarted = true;
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (args.includes('show')) {
+      const pid = mocks.restarted && mocks.rotateGod ? 8202 : mocks.currentPid;
+      return {
+        status: 0,
+        stderr: '',
+        stdout: [
+          'LoadState=loaded',
+          'ActiveState=active',
+          `SubState=${mocks.restarted ? 'running' : 'exited'}`,
+          'Type=forking',
+          `MainPID=${mocks.restarted ? pid : mocks.initialMainPid}`,
+          'KillMode=process',
+          'KillSignal=18',
+          'RestartKillSignal=18',
+          'FinalKillSignal=18',
+          'SendSIGKILL=no',
+          'TimeoutStartUSec=3min',
+          'TimeoutStopUSec=45s',
+          `WorkingDirectory=${join(mocks.home, '.botmux')}`,
+          `PIDFile=${join(mocks.home, '.botmux', 'pm2', 'pm2.pid')}`,
+          `Environment=PATH=${process.env.PATH} BOTMUX_SYSTEMD_SERVICE=botmux.service`,
+          `ExecStart={ path=${process.execPath} ; argv[]=${process.execPath} /opt/botmux/dist/cli.js start${mocks.invalidPostRestart && mocks.restarted ? '' : ' --systemd-service'} ; }`,
+          `ExecStop={ path=${process.execPath} ; argv[]=${process.execPath} /opt/botmux/dist/cli.js stop --systemd-service ; }`,
+          `Job=${mocks.jobPending ? '991' : ''}`,
+        ].join('\n'),
+      };
+    }
+    return { status: 1, stdout: '', stderr: `unexpected systemctl args: ${args.join(' ')}` };
+  },
+}));
+
+vi.mock('../src/core/pm2-lifecycle-owner.js', () => ({
+  BOTMUX_SYSTEMD_SERVICE: 'botmux.service',
+  BOTMUX_SYSTEMD_SERVICE_ENV: 'BOTMUX_SYSTEMD_SERVICE',
+  describeExternalPm2Owner: () => '',
+  inspectLinuxPm2GodOwnership: () => ({
+    kind: 'owned',
+    processes: [{
+      pid: mocks.restarted && mocks.rotateGod ? 8202 : mocks.currentPid,
+      cgroup: '/user.slice/botmux.service',
+      startIdentity: mocks.restarted && mocks.rotateGod
+        ? 'replacement-generation'
+        : mocks.currentBirth,
+    }],
+  }),
+  revalidateLinuxPm2GodProcess: () => true,
+}));
+
+import {
+  applyLinuxPm2ServiceRepair,
+  prepareLinuxPm2ServiceRepair,
+} from '../src/autostart.js';
+
+describe.runIf(process.platform === 'linux')('existing systemd unit repair', () => {
+  const opts = {
+    pkgRoot: '/opt/botmux',
+    configDir: '',
+    logDir: '',
+  };
+
+  beforeAll(() => {
+    mocks.home = mkdtempSync(join(tmpdir(), 'botmux-autostart-existing-'));
+    opts.configDir = join(mocks.home, '.botmux');
+    opts.logDir = join(opts.configDir, 'logs');
+    const unitDir = join(mocks.home, '.config', 'systemd', 'user');
+    mkdirSync(unitDir, { recursive: true });
+    writeFileSync(join(unitDir, 'botmux.service'), [
+      '[Service]',
+      'Type=oneshot',
+      'RemainAfterExit=yes',
+      'ExecStart=/home/test/.local/bin/botmux start',
+    ].join('\n'));
+  });
+
+  afterAll(() => {
+    rmSync(mocks.home, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    mocks.restarted = false;
+    mocks.rotateGod = false;
+    mocks.currentPid = 8101;
+    mocks.currentBirth = 'existing-generation';
+    mocks.initialMainPid = 0;
+    mocks.invalidPostRestart = false;
+    mocks.jobPending = false;
+    mocks.stallRestart = false;
+    mocks.systemctlCalls.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('rewrites the legacy unit and makes the replacement God MainPID', () => {
+    mocks.rotateGod = true;
+    expect(prepareLinuxPm2ServiceRepair(opts)).toBe(true);
+    const unit = readFileSync(
+      join(mocks.home, '.config', 'systemd', 'user', 'botmux.service'),
+      'utf8',
+    );
+    expect(unit).toContain('Type=forking');
+    expect(unit).toContain('/opt/botmux/dist/cli.js stop --systemd-service');
+
+    applyLinuxPm2ServiceRepair(opts);
+
+    expect(mocks.restarted).toBe(true);
+    expect(mocks.rotateGod).toBe(true);
+    expect(mocks.systemctlCalls.some(args => args.includes('restart'))).toBe(true);
+  });
+
+  it('requires an already tracked healthy God to rotate on service restart', () => {
+    mocks.initialMainPid = mocks.currentPid;
+
+    expect(prepareLinuxPm2ServiceRepair(opts)).toBe(true);
+    expect(() => applyLinuxPm2ServiceRepair(opts)).toThrow(/generation 未变化/);
+  });
+
+  it('accepts a replacement generation for an already tracked God', () => {
+    mocks.initialMainPid = mocks.currentPid;
+    mocks.rotateGod = true;
+
+    expect(prepareLinuxPm2ServiceRepair(opts)).toBe(true);
+    expect(() => applyLinuxPm2ServiceRepair(opts)).not.toThrow();
+  });
+
+  it('fails when an effective override changes ExecStart after restart', () => {
+    mocks.invalidPostRestart = true;
+    mocks.rotateGod = true;
+
+    expect(prepareLinuxPm2ServiceRepair(opts)).toBe(true);
+    expect(() => applyLinuxPm2ServiceRepair(opts)).toThrow(/运行态迁移后校验失败/);
+  });
+
+  it('cancels a restart job that does not settle before the deadline', () => {
+    mocks.stallRestart = true;
+    let now = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      now += 300_000;
+      return now;
+    });
+
+    expect(prepareLinuxPm2ServiceRepair(opts)).toBe(true);
+    expect(() => applyLinuxPm2ServiceRepair(opts)).toThrow(/已取消并确认/);
+    expect(mocks.systemctlCalls.some(args => args.includes('cancel') && args.includes('991'))).toBe(true);
+    expect(mocks.jobPending).toBe(false);
+  });
+
+  it('settles a concurrent job before issuing its own restart', () => {
+    mocks.rotateGod = true;
+    expect(prepareLinuxPm2ServiceRepair(opts)).toBe(true);
+    mocks.jobPending = true;
+    applyLinuxPm2ServiceRepair(opts);
+
+    expect(mocks.systemctlCalls.some(args => args.includes('cancel') && args.includes('991'))).toBe(true);
+    expect(mocks.restarted).toBe(true);
+  });
+});

--- a/test/autostart-pm2-ownership.test.ts
+++ b/test/autostart-pm2-ownership.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assessLinuxSystemdService,
+  parseLinuxSystemdShow,
+  renderLinuxSystemdUnit,
+} from '../src/autostart.js';
+import {
+  BOTMUX_SYSTEMD_SERVICE,
+  classifyLinuxPm2GodOwnership,
+  planLinuxPm2Command,
+  revalidateLinuxPm2GodProcess,
+  scanLinuxPm2GodPids,
+} from '../src/core/pm2-lifecycle-owner.js';
+
+describe('Linux PM2 lifecycle ownership', () => {
+  it('makes botmux.service own and track the PM2 God daemon', () => {
+    const unit = renderLinuxSystemdUnit({
+      pkgRoot: '/opt/botmux',
+      configDir: '/home/test/.botmux',
+      logDir: '/home/test/.botmux/logs',
+    });
+
+    expect(unit).toContain('Type=forking');
+    expect(unit).toContain('PIDFile=/home/test/.botmux/pm2/pm2.pid');
+    expect(unit).toContain('KillMode=process');
+    expect(unit).toContain('KillSignal=SIGCONT');
+    expect(unit).toContain('RestartKillSignal=SIGCONT');
+    expect(unit).toContain('SendSIGKILL=no');
+    expect(unit).toContain('stop --systemd-service');
+    expect(unit).toContain('Environment=BOTMUX_SYSTEMD_SERVICE=botmux.service');
+
+    expect(unit).toContain('/opt/botmux/dist/cli.js start --systemd-service');
+    expect(unit).toContain('/opt/botmux/dist/cli.js stop --systemd-service');
+  });
+
+  it('rejects a God daemon inherited from another supervisor cgroup', () => {
+    const ownership = classifyLinuxPm2GodOwnership([
+      {
+        pid: 4100,
+        cgroup: '0::/user.slice/user-1001.slice/user@1001.service/app.slice/hapi.service\n',
+      },
+    ]);
+
+    expect(ownership).toEqual({
+      kind: 'external',
+      processes: [{
+        pid: 4100,
+        cgroup: '/user.slice/user-1001.slice/user@1001.service/app.slice/hapi.service',
+      }],
+    });
+    expect(planLinuxPm2Command({
+      command: 'start',
+      ownership,
+      callerCgroup: '/user.slice/user-1001.slice/user@1001.service/app.slice/hapi.service',
+    })).toEqual({ kind: 'reject', owner: 'hapi.service' });
+  });
+
+  it('recognizes the botmux service in cgroup v1 systemd controller output', () => {
+    expect(classifyLinuxPm2GodOwnership([{
+      pid: 4200,
+      cgroup: [
+        '8:memory:/user.slice/user-1001.slice/user@1001.service',
+        '1:name=systemd:/user.slice/user-1001.slice/user@1001.service/app.slice/botmux.service',
+      ].join('\n'),
+    }])).toEqual({
+      kind: 'owned',
+      processes: [{
+        pid: 4200,
+        cgroup: '/user.slice/user-1001.slice/user@1001.service/app.slice/botmux.service',
+      }],
+    });
+  });
+
+  it('hands the first mutating start to botmux.service', () => {
+    expect(planLinuxPm2Command({
+      command: 'start',
+      ownership: { kind: 'absent' },
+      callerCgroup: '/user.slice/user-1001.slice/user@1001.service/app.slice/hapi.service',
+    })).toEqual({ kind: 'handoff', service: BOTMUX_SYSTEMD_SERVICE });
+  });
+
+  it('keeps read-only status side-effect free when PM2 is absent', () => {
+    expect(planLinuxPm2Command({
+      command: 'status',
+      ownership: { kind: 'absent' },
+      callerCgroup: '/user.slice/user-1001.slice/user@1001.service/app.slice/hapi.service',
+    })).toEqual({ kind: 'absent' });
+  });
+
+  it('allows the service-owned start path to create the first God daemon', () => {
+    expect(planLinuxPm2Command({
+      command: 'plugin',
+      ownership: { kind: 'absent' },
+      callerCgroup: '/user.slice/user-1001.slice/user@1001.service/app.slice/botmux.service',
+    })).toEqual({ kind: 'direct' });
+  });
+
+  it('fails closed when procfs cannot prove a process is unrelated', () => {
+    const error = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    expect(() => scanLinuxPm2GodPids('/home/test/.botmux/pm2', {
+      procEntries: () => ['5100'],
+      currentUid: 1000,
+      statUid: () => 1000,
+      readText: () => { throw error; },
+    } as any)).toThrow(/cannot inspect \/proc\/5100\/cmdline/);
+  });
+
+  it('ignores unreadable foreign-uid processes before inspecting PM2 markers', () => {
+    const error = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    expect(scanLinuxPm2GodPids('/home/test/.botmux/pm2', {
+      procEntries: () => ['6100', '6200'],
+      currentUid: 1000,
+      statUid: path => path.endsWith('/6100') ? 0 : 1000,
+      readText: path => {
+        if (path.includes('/6100/')) throw error;
+        return 'PM2 v6.0.14: God Daemon (/home/test/.botmux/pm2)';
+      },
+    } as any)).toEqual([6200]);
+  });
+
+  it('revalidates cmdline, cgroup and the original birth before a God signal', () => {
+    const home = '/home/test/.botmux/pm2';
+    const stat = `6200 (PM2 God) S ${Array(18).fill('0').join(' ')} 777`;
+    const readText = (path: string) => {
+      if (path.endsWith('/stat')) return stat;
+      if (path.endsWith('/cmdline')) return `PM2 v6.0.14: God Daemon (${home})`;
+      return '0::/user.slice/botmux.service';
+    };
+    expect(revalidateLinuxPm2GodProcess({
+      pid: 6200,
+      cgroup: '/user.slice/botmux.service',
+      startIdentity: '777',
+    }, home, { readText })).toBe(true);
+    expect(revalidateLinuxPm2GodProcess({
+      pid: 6200,
+      cgroup: '/user.slice/botmux.service',
+      startIdentity: '888',
+    }, home, { readText })).toBe(false);
+  });
+
+  it('plans a running-generation migration when MainPID does not track the God', () => {
+    const state = parseLinuxSystemdShow([
+      'LoadState=loaded',
+      'ActiveState=active',
+      'SubState=exited',
+      'Type=forking',
+      'MainPID=0',
+      'KillMode=process',
+      'KillSignal=18',
+      'RestartKillSignal=18',
+      'FinalKillSignal=18',
+      'SendSIGKILL=no',
+      'TimeoutStartUSec=3min',
+      'TimeoutStopUSec=45s',
+      'WorkingDirectory=/home/test/.botmux',
+      'PIDFile=/home/test/.botmux/pm2/pm2.pid',
+      'Environment=PATH=/usr/bin BOTMUX_SYSTEMD_SERVICE=botmux.service',
+      'ExecStart={ path=/usr/bin/node ; argv[]=/usr/bin/node /opt/botmux/dist/cli.js start --systemd-service ; }',
+      'ExecStop={ path=/usr/bin/node ; argv[]=/usr/bin/node /opt/botmux/dist/cli.js stop --systemd-service ; }',
+    ].join('\n'));
+
+    expect(assessLinuxSystemdService({
+      state,
+      expectedPidFile: '/home/test/.botmux/pm2/pm2.pid',
+      expectedNodeBin: '/usr/bin/node',
+      expectedCliJs: '/opt/botmux/dist/cli.js',
+      expectedWorkingDirectory: '/home/test/.botmux',
+      expectedPath: '/usr/bin',
+      godPids: [5300],
+    })).toEqual({
+      errors: [],
+      restartRequired: true,
+    });
+  });
+
+  it('accepts the effective generation only when systemd tracks the exact God', () => {
+    const state = parseLinuxSystemdShow([
+      'LoadState=loaded',
+      'ActiveState=active',
+      'SubState=running',
+      'Type=forking',
+      'MainPID=5300',
+      'KillMode=process',
+      'KillSignal=18',
+      'RestartKillSignal=18',
+      'FinalKillSignal=18',
+      'SendSIGKILL=no',
+      'TimeoutStartUSec=3min',
+      'TimeoutStopUSec=45s',
+      'WorkingDirectory=/home/test/.botmux',
+      'PIDFile=/home/test/.botmux/pm2/pm2.pid',
+      'Environment=PATH=/usr/bin BOTMUX_SYSTEMD_SERVICE=botmux.service',
+      'ExecStart={ path=/usr/bin/node ; argv[]=/usr/bin/node /opt/botmux/dist/cli.js start --systemd-service ; }',
+      'ExecStop={ path=/usr/bin/node ; argv[]=/usr/bin/node /opt/botmux/dist/cli.js stop --systemd-service ; }',
+    ].join('\n'));
+
+    expect(assessLinuxSystemdService({
+      state,
+      expectedPidFile: '/home/test/.botmux/pm2/pm2.pid',
+      expectedNodeBin: '/usr/bin/node',
+      expectedCliJs: '/opt/botmux/dist/cli.js',
+      expectedWorkingDirectory: '/home/test/.botmux',
+      expectedPath: '/usr/bin',
+      godPids: [5300],
+    })).toEqual({
+      errors: [],
+      restartRequired: false,
+    });
+  });
+
+  it('surfaces an effective ExecStart override instead of claiming path sync', () => {
+    const state = parseLinuxSystemdShow([
+      'LoadState=loaded',
+      'ActiveState=active',
+      'SubState=running',
+      'Type=forking',
+      'MainPID=5300',
+      'KillMode=process',
+      'KillSignal=18',
+      'RestartKillSignal=18',
+      'FinalKillSignal=18',
+      'SendSIGKILL=no',
+      'TimeoutStartUSec=3min',
+      'TimeoutStopUSec=45s',
+      'WorkingDirectory=/home/test/.botmux',
+      'PIDFile=/home/test/.botmux/pm2/pm2.pid',
+      'Environment=PATH=/usr/bin BOTMUX_SYSTEMD_SERVICE=botmux.service',
+      'ExecStart={ path=/home/test/.local/bin/botmux ; argv[]=/home/test/.local/bin/botmux start ; }',
+      'ExecStop={ path=/usr/bin/node ; argv[]=/usr/bin/node /opt/botmux/dist/cli.js stop --systemd-service ; }',
+    ].join('\n'));
+
+    expect(assessLinuxSystemdService({
+      state,
+      expectedPidFile: '/home/test/.botmux/pm2/pm2.pid',
+      expectedNodeBin: '/usr/bin/node',
+      expectedCliJs: '/opt/botmux/dist/cli.js',
+      expectedWorkingDirectory: '/home/test/.botmux',
+      expectedPath: '/usr/bin',
+      godPids: [5300],
+    })).toEqual({
+      errors: [expect.stringMatching(/ExecStart/)],
+      restartRequired: false,
+    });
+  });
+
+  it('rejects lookalike environment and wrong argv even when they mention the expected values', () => {
+    const state = parseLinuxSystemdShow([
+      'LoadState=loaded',
+      'ActiveState=active',
+      'SubState=running',
+      'Type=forking',
+      'MainPID=5300',
+      'KillMode=process',
+      'KillSignal=18',
+      'RestartKillSignal=18',
+      'FinalKillSignal=18',
+      'SendSIGKILL=no',
+      'TimeoutStartUSec=3min',
+      'TimeoutStopUSec=45s',
+      'WorkingDirectory=/tmp',
+      'PIDFile=/home/test/.botmux/pm2/pm2.pid',
+      'Environment=PATH=/bin BOTMUX_SYSTEMD_SERVICE=botmux.service.evil',
+      'ExecStart={ path=/usr/bin/node ; argv[]=/usr/bin/node /opt/botmux/dist/cli.js status ; }',
+      'ExecStop={ path=/usr/bin/node ; argv[]=/usr/bin/node /opt/botmux/dist/cli.js stop --systemd-service extra ; }',
+    ].join('\n'));
+
+    const assessment = assessLinuxSystemdService({
+      state,
+      expectedPidFile: '/home/test/.botmux/pm2/pm2.pid',
+      expectedNodeBin: '/usr/bin/node',
+      expectedCliJs: '/opt/botmux/dist/cli.js',
+      expectedWorkingDirectory: '/home/test/.botmux',
+      expectedPath: '/usr/bin',
+      godPids: [5300],
+    });
+    expect(assessment.errors).toEqual([
+      expect.stringMatching(/WorkingDirectory/),
+      expect.stringMatching(/Environment/),
+      expect.stringMatching(/Environment PATH/),
+      expect.stringMatching(/ExecStart/),
+      expect.stringMatching(/ExecStop/),
+    ]);
+  });
+});

--- a/test/autostart-refresh-retry.test.ts
+++ b/test/autostart-refresh-retry.test.ts
@@ -1,0 +1,93 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  home: '',
+  reloadAttempts: 0,
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('node:os', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => mocks.home };
+});
+
+vi.mock('node:child_process', () => ({
+  spawnSync: mocks.spawnSync,
+}));
+
+vi.mock('../src/core/pm2-lifecycle-owner.js', () => ({
+  BOTMUX_SYSTEMD_SERVICE: 'botmux.service',
+  BOTMUX_SYSTEMD_SERVICE_ENV: 'BOTMUX_SYSTEMD_SERVICE',
+  describeExternalPm2Owner: () => '',
+  inspectLinuxPm2GodOwnership: () => ({ kind: 'absent' }),
+}));
+
+import { refreshAutostart } from '../src/autostart.js';
+
+describe.runIf(process.platform === 'linux')('Linux autostart refresh retry', () => {
+  beforeEach(() => {
+    mocks.home = mkdtempSync(join(tmpdir(), 'botmux-autostart-refresh-'));
+    mocks.reloadAttempts = 0;
+    mocks.spawnSync.mockReset();
+    mocks.spawnSync.mockImplementation((_command: string, args: string[]) => {
+      if (args.includes('show-environment')) return { status: 0, stdout: '', stderr: '' };
+      if (args.includes('daemon-reload')) {
+        mocks.reloadAttempts += 1;
+        return mocks.reloadAttempts === 1
+          ? { status: 1, stdout: '', stderr: 'temporary bus failure' }
+          : { status: 0, stdout: '', stderr: '' };
+      }
+      if (args.includes('show')) {
+        return {
+          status: 0,
+          stderr: '',
+          stdout: [
+            'LoadState=loaded',
+            'ActiveState=inactive',
+            'SubState=dead',
+            'Type=forking',
+            'MainPID=0',
+            'KillMode=process',
+            'KillSignal=18',
+            'RestartKillSignal=18',
+            'FinalKillSignal=18',
+            'SendSIGKILL=no',
+            'TimeoutStartUSec=3min',
+            'TimeoutStopUSec=45s',
+            `WorkingDirectory=${join(mocks.home, '.botmux')}`,
+            `PIDFile=${join(mocks.home, '.botmux', 'pm2', 'pm2.pid')}`,
+            `Environment=PATH=${process.env.PATH} BOTMUX_SYSTEMD_SERVICE=botmux.service`,
+            `ExecStart={ path=${process.execPath} ; argv[]=${process.execPath} /opt/botmux/dist/cli.js start --systemd-service ; }`,
+            `ExecStop={ path=${process.execPath} ; argv[]=${process.execPath} /opt/botmux/dist/cli.js stop --systemd-service ; }`,
+          ].join('\n'),
+        };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+  });
+
+  afterEach(() => {
+    rmSync(mocks.home, { recursive: true, force: true });
+  });
+
+  it('retries daemon-reload even when the repaired file already matches', () => {
+    const unitDir = join(mocks.home, '.config', 'systemd', 'user');
+    const unit = join(unitDir, 'botmux.service');
+    mkdirSync(unitDir, { recursive: true });
+    writeFileSync(unit, '[Service]\nType=oneshot\nRemainAfterExit=yes\n');
+    const opts = {
+      pkgRoot: '/opt/botmux',
+      configDir: join(mocks.home, '.botmux'),
+      logDir: join(mocks.home, '.botmux', 'logs'),
+    };
+
+    expect(() => refreshAutostart(opts)).toThrow(/temporary bus failure/);
+    expect(readFileSync(unit, 'utf8')).toContain('Type=forking');
+
+    expect(refreshAutostart(opts)).toBe(false);
+    expect(mocks.reloadAttempts).toBe(2);
+  });
+});

--- a/test/desktop/desktop-pm2-apps.test.ts
+++ b/test/desktop/desktop-pm2-apps.test.ts
@@ -30,7 +30,32 @@ function childProcessStub() {
   return child;
 }
 
+const runningPm2 = { pm2QueryAvailable: () => true };
+
 describe('desktop PM2 app listing', () => {
+  it('passes the inspected God generation to the read-only helper', async () => {
+    const child = childProcessStub();
+    const spawn = vi.fn(() => child);
+    const expectedGod = {
+      pid: 7310,
+      cgroup: '/user.slice/botmux.service',
+      startIdentity: 'desktop-generation',
+    };
+    const promise = listPm2Apps(paths, runtime, {
+      pm2QueryAvailable: () => expectedGod,
+      existsSync: () => true,
+      spawn: spawn as any,
+      execPath: '/Electron',
+      env: {},
+    });
+    child.stdout.emit('data', '[]');
+    child.emit('close', 0);
+
+    await expect(promise).resolves.toEqual([]);
+    const env = (spawn.mock.calls[0] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2].env;
+    expect(JSON.parse(env.BOTMUX_PM2_EXPECTED_GOD!)).toEqual(expectedGod);
+  });
+
   it('runs PM2 through the bundled Node absolute path', async () => {
     const child = childProcessStub();
     const spawn = vi.fn(() => child);
@@ -43,6 +68,7 @@ describe('desktop PM2 app listing', () => {
       runtimeSource: 'bundled',
     };
     const promise = listPm2Apps(paths, bundled, {
+      ...runningPm2,
       existsSync: () => true,
       spawn: spawn as any,
       env: { PATH: '/usr/bin:/bin', ELECTRON_RUN_AS_NODE: '1' },
@@ -53,7 +79,7 @@ describe('desktop PM2 app listing', () => {
     await expect(promise).resolves.toEqual([]);
     expect(spawn).toHaveBeenCalledWith(
       bundled.nodePath,
-      [`${bundled.root}/node_modules/pm2/bin/pm2`, 'jlist'],
+      [`${bundled.root}/dist/cli/pm2-readonly-client.js`, 'jlist'],
       expect.objectContaining({ env: expect.not.objectContaining({ ELECTRON_RUN_AS_NODE: expect.anything() }) }),
     );
   });
@@ -70,6 +96,7 @@ describe('desktop PM2 app listing', () => {
       runtimeSource: 'bundled',
     };
     const promise = listPm2Apps(paths, bundled, {
+      ...runningPm2,
       existsSync: () => true,
       spawn: spawn as any,
       env: { PATH: '/usr/bin:/bin' },
@@ -106,6 +133,7 @@ describe('desktop PM2 app listing', () => {
     const child = childProcessStub();
     const spawn = vi.fn(() => child);
     const promise = listPm2Apps(paths, runtime, {
+      ...runningPm2,
       existsSync: () => true,
       spawn: spawn as any,
       execPath: '/Electron',
@@ -118,11 +146,28 @@ describe('desktop PM2 app listing', () => {
     await expect(promise).rejects.toThrow('PM2 jlist failed');
   });
 
+  it('treats the read-only helper absence code as an empty process list', async () => {
+    const child = childProcessStub();
+    const spawn = vi.fn(() => child);
+    const promise = listPm2Apps(paths, runtime, {
+      ...runningPm2,
+      existsSync: () => true,
+      spawn: spawn as any,
+      execPath: '/Electron',
+      env: {},
+    });
+
+    child.emit('close', 3);
+
+    await expect(promise).resolves.toEqual([]);
+  });
+
   it('rejects and kills PM2 discovery when it times out', async () => {
     vi.useFakeTimers();
     const child = childProcessStub();
     const spawn = vi.fn(() => child);
     const promise = expect(listPm2Apps(paths, runtime, {
+      ...runningPm2,
       existsSync: () => true,
       spawn: spawn as any,
       execPath: '/Electron',
@@ -142,6 +187,7 @@ describe('desktop PM2 app listing', () => {
     const child = childProcessStub();
     const spawn = vi.fn(() => child);
     const promise = expect(listPm2Apps(paths, runtime, {
+      ...runningPm2,
       existsSync: () => true,
       spawn: spawn as any,
       execPath: '/Electron',
@@ -166,6 +212,7 @@ describe('desktop PM2 app listing', () => {
       binPath: '/home/.botmux/bin/botmux',
       pathEnv: shellPath,
     }, {
+      ...runningPm2,
       existsSync: () => true,
       spawn: spawn as any,
       env: { PATH: '/usr/bin:/bin' },
@@ -179,5 +226,15 @@ describe('desktop PM2 app listing', () => {
     const pathEntries = (spawn.mock.calls[0]![2] as any).env.PATH.split(':');
     expect(pathEntries.indexOf('/Users/me/.nvm/versions/node/v22.22.2/bin')).toBeGreaterThan(-1);
     expect(pathEntries.indexOf('/Users/me/.nvm/versions/node/v22.22.2/bin')).toBeLessThan(pathEntries.indexOf('/usr/bin'));
+  });
+
+  it('does not spawn PM2 while listing an absent daemon', async () => {
+    const spawn = vi.fn();
+    await expect(listPm2Apps(paths, runtime, {
+      existsSync: () => true,
+      spawn: spawn as any,
+      pm2QueryAvailable: () => false,
+    })).resolves.toEqual([]);
+    expect(spawn).not.toHaveBeenCalled();
   });
 });

--- a/test/fixtures/systemd-migration/desired/botmux-migration-fixture.service
+++ b/test/fixtures/systemd-migration/desired/botmux-migration-fixture.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=botmux systemd migration desired fixture
+
+[Service]
+Type=forking
+PIDFile=%t/botmux-migration-god.pid
+KillMode=process
+KillSignal=SIGCONT
+RestartKillSignal=SIGCONT
+FinalKillSignal=SIGCONT
+SendSIGKILL=no
+TimeoutStopSec=2
+ExecStart=/bin/sh -c 'pid="$(cat %t/botmux-migration-god.pid 2>/dev/null || true)"; if ! kill -0 "$pid" 2>/dev/null; then sleep 300 & echo $! > %t/botmux-migration-god.pid; fi'
+ExecStop=/bin/sh -c 'pid="$(cat %t/botmux-migration-god.pid 2>/dev/null || true)"; if kill -0 "$pid" 2>/dev/null; then kill "$pid"; while kill -0 "$pid" 2>/dev/null; do sleep 0.05; done; fi'

--- a/test/fixtures/systemd-migration/failing/botmux-migration-fixture.service
+++ b/test/fixtures/systemd-migration/failing/botmux-migration-fixture.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=botmux systemd failed-stop fixture
+
+[Service]
+Type=forking
+PIDFile=%t/botmux-migration-god.pid
+KillMode=process
+KillSignal=SIGCONT
+RestartKillSignal=SIGCONT
+FinalKillSignal=SIGCONT
+SendSIGKILL=no
+TimeoutStopSec=300ms
+ExecStart=/bin/sh -c 'pid="$(cat %t/botmux-migration-god.owner 2>/dev/null || true)"; if kill -0 "$pid" 2>/dev/null; then echo "$pid" > %t/botmux-migration-god.pid; else sleep 300 & pid=$!; echo "$pid" > %t/botmux-migration-god.owner; echo "$pid" > %t/botmux-migration-god.pid; fi'
+ExecStop=/bin/false

--- a/test/fixtures/systemd-migration/legacy/botmux-migration-fixture.service
+++ b/test/fixtures/systemd-migration/legacy/botmux-migration-fixture.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=botmux systemd migration legacy fixture
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+KillMode=control-group
+ExecStart=/bin/sh -c 'sleep 300 & echo $! > %t/botmux-migration-god.pid; sleep 300 & echo $! > %t/botmux-migration-persistent.pid'
+ExecStop=/bin/true

--- a/test/plugin-pm2-env.test.ts
+++ b/test/plugin-pm2-env.test.ts
@@ -5,10 +5,24 @@ import { join } from 'node:path';
 
 const childProcess = vi.hoisted(() => ({
   spawnSync: vi.fn(),
+  ownershipProcesses: [
+    { pid: 123, cgroup: '/user.slice/botmux.service', startIdentity: 'fixture-birth' },
+  ] as Array<{ pid: number; cgroup: string; startIdentity: string }>,
 }));
 
 vi.mock('node:child_process', () => ({
   spawnSync: childProcess.spawnSync,
+}));
+
+vi.mock('../src/core/pm2-lifecycle-owner.js', () => ({
+  describeExternalPm2Owner: () => '',
+  inspectLinuxPm2Command: () => ({
+    ownership: {
+      kind: 'owned',
+      processes: childProcess.ownershipProcesses,
+    },
+    plan: { kind: 'direct' },
+  }),
 }));
 
 describe('plugin PM2 environment', () => {
@@ -20,6 +34,9 @@ describe('plugin PM2 environment', () => {
     vi.stubEnv('kill_timeout', '3500');
     vi.resetModules();
     childProcess.spawnSync.mockReset();
+    childProcess.ownershipProcesses = [
+      { pid: 123, cgroup: '/user.slice/botmux.service', startIdentity: 'fixture-birth' },
+    ];
     childProcess.spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
   });
 
@@ -41,6 +58,8 @@ describe('plugin PM2 environment', () => {
     expect(options.env.kill_timeout).toBeUndefined();
     expect(options.env.PLUGIN_VALUE).toBe('preserved');
     expect(options.env.PM2_HOME).toBe(join(home, '.botmux', 'pm2'));
+    expect(options.env.PM2_SILENT).toBeUndefined();
+    expect(options.env.PM2_USAGE).toBeUndefined();
   });
 
   it('does not leak the daemon PM2 graceful-exit sentinel into plugin PM2 apps', async () => {
@@ -58,5 +77,18 @@ describe('plugin PM2 environment', () => {
 
     const options = childProcess.spawnSync.mock.calls[0]?.[2] as { env: NodeJS.ProcessEnv };
     expect(options.env[PM2_GRACEFUL_EXIT_CODE_ENV]).toBeUndefined();
+  });
+
+  it('refuses a mutation when multiple service-owned Gods share the plugin home', async () => {
+    childProcess.ownershipProcesses = [
+      { pid: 123, cgroup: '/user.slice/botmux.service', startIdentity: 'birth-a' },
+      { pid: 456, cgroup: '/user.slice/botmux.service', startIdentity: 'birth-b' },
+    ];
+    vi.resetModules();
+    const { runPluginPm2 } = await import('../src/core/plugins/pm2.js');
+
+    expect(() => runPluginPm2(['start', 'fixture'], { inherit: false }))
+      .toThrow(/exactly one.*123, 456/);
+    expect(childProcess.spawnSync).not.toHaveBeenCalled();
   });
 });

--- a/test/plugin-service-manual-snapshot.test.ts
+++ b/test/plugin-service-manual-snapshot.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { selectRunningManualPluginServiceIds } from '../src/core/plugins/service-manager.js';
+import type { InstalledPluginRecord } from '../src/core/plugins/types.js';
+
+function record(id: string, mode: 'auto' | 'manual'): InstalledPluginRecord {
+  return { id, manifest: { service: { mode } } } as InstalledPluginRecord;
+}
+
+describe('manual plugin service snapshot', () => {
+  it('keeps only live manual services for restoration after God rotation', () => {
+    const records = [
+      record('manual-online', 'manual'),
+      record('manual-launching', 'manual'),
+      record('manual-stopped', 'manual'),
+      record('auto-online', 'auto'),
+    ];
+
+    expect(selectRunningManualPluginServiceIds(records, [
+      { name: 'botmux-plugin-manual-online', pid: 101, status: 'online' },
+      { name: 'botmux-plugin-manual-launching', pid: 0, status: 'launching' },
+      { name: 'botmux-plugin-manual-stopped', pid: 0, status: 'stopped' },
+      { name: 'botmux-plugin-auto-online', pid: 202, status: 'online' },
+    ])).toEqual(['manual-online', 'manual-launching']);
+  });
+});

--- a/test/pm2-existing-client.test.ts
+++ b/test/pm2-existing-client.test.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { runExistingPm2Command } from '../src/cli/pm2-existing.js';
+import { captureReadonlyPm2Jlist } from '../src/cli/pm2-readonly.js';
+import { inspectLinuxPm2GodOwnership } from '../src/core/pm2-lifecycle-owner.js';
+
+const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const PM2_PATH = join(PKG_ROOT, 'node_modules', 'pm2', 'bin', 'pm2');
+
+describe.runIf(process.platform === 'linux')('existing PM2 RPC mutation boundary', () => {
+  let root = '';
+  let pm2Home = '';
+  let config = '';
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'botmux-pm2-existing-'));
+    pm2Home = join(root, 'pm2');
+    mkdirSync(pm2Home, { recursive: true });
+    const script = join(root, 'fixture.cjs');
+    config = join(root, 'ecosystem.config.cjs');
+    writeFileSync(script, 'setInterval(() => {}, 1000);\n');
+    writeFileSync(config, `module.exports = { apps: [{ name: 'botmux-existing-fixture', script: ${JSON.stringify(script)} }] };\n`);
+    const boot = spawnSync(process.execPath, [PM2_PATH, 'status'], {
+      env: { ...process.env, PM2_HOME: pm2Home },
+      stdio: 'ignore',
+      timeout: 10_000,
+    });
+    expect(boot.status).toBe(0);
+  });
+
+  afterAll(() => {
+    spawnSync(process.execPath, [PM2_PATH, 'kill'], {
+      env: { ...process.env, PM2_HOME: pm2Home },
+      stdio: 'ignore',
+      timeout: 10_000,
+    });
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  it('mutates an existing God without rotation, then fails absent without replacement', () => {
+    const pidFile = join(pm2Home, 'pm2.pid');
+    const originalPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10);
+    const originalOwnership = inspectLinuxPm2GodOwnership(pm2Home);
+    expect(originalOwnership.kind).not.toBe('absent');
+    const originalGod = originalOwnership.kind === 'absent'
+      ? undefined
+      : originalOwnership.processes[0];
+    expect(originalGod?.pid).toBe(originalPid);
+    runExistingPm2Command({
+      pkgRoot: PKG_ROOT,
+      home: pm2Home,
+      args: ['start', config],
+      inherit: false,
+      expectedGod: originalGod!,
+    });
+    const apps = JSON.parse(captureReadonlyPm2Jlist({ pkgRoot: PKG_ROOT, home: pm2Home }));
+    expect(apps.some((app: any) => app.name === 'botmux-existing-fixture')).toBe(true);
+    expect(Number.parseInt(readFileSync(pidFile, 'utf8'), 10)).toBe(originalPid);
+
+    runExistingPm2Command({
+      pkgRoot: PKG_ROOT,
+      home: pm2Home,
+      args: ['delete', 'botmux-existing-fixture'],
+      inherit: false,
+      expectedGod: originalGod!,
+    });
+    const killed = spawnSync(process.execPath, [PM2_PATH, 'kill'], {
+      env: { ...process.env, PM2_HOME: pm2Home },
+      stdio: 'ignore',
+      timeout: 10_000,
+    });
+    expect(killed.status).toBe(0);
+
+    expect(() => runExistingPm2Command({
+      pkgRoot: PKG_ROOT,
+      home: pm2Home,
+      args: ['start', config],
+      inherit: false,
+      expectedGod: originalGod!,
+    })).toThrow(/no replacement daemon was created/);
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  it('rejects a replacement generation before applying the mutation', () => {
+    const boot = spawnSync(process.execPath, [PM2_PATH, 'status'], {
+      env: { ...process.env, PM2_HOME: pm2Home },
+      stdio: 'ignore',
+      timeout: 10_000,
+    });
+    expect(boot.status).toBe(0);
+    const ownership = inspectLinuxPm2GodOwnership(pm2Home);
+    expect(ownership.kind).not.toBe('absent');
+    const god = ownership.kind === 'absent' ? undefined : ownership.processes[0];
+    expect(god).toBeDefined();
+    expect(() => runExistingPm2Command({
+      pkgRoot: PKG_ROOT,
+      home: pm2Home,
+      args: ['start', config],
+      inherit: false,
+      expectedGod: { ...god!, startIdentity: `${god!.startIdentity}-replaced` },
+    })).toThrow(/generation changed before mutation/);
+    const apps = JSON.parse(captureReadonlyPm2Jlist({ pkgRoot: PKG_ROOT, home: pm2Home }));
+    expect(apps.some((app: any) => app.name === 'botmux-existing-fixture')).toBe(false);
+  });
+});

--- a/test/pm2-readonly-cli.test.ts
+++ b/test/pm2-readonly-cli.test.ts
@@ -1,0 +1,106 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { captureReadonlyPm2Jlist } from '../src/cli/pm2-readonly.js';
+import { inspectLinuxPm2GodOwnership } from '../src/core/pm2-lifecycle-owner.js';
+
+const CLI_PATH = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+const PM2_PATH = fileURLToPath(new URL('../node_modules/pm2/bin/pm2', import.meta.url));
+const homes: string[] = [];
+
+function tempHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'botmux-pm2-readonly-'));
+  homes.push(home);
+  return home;
+}
+
+function runStatus(home: string) {
+  return spawnSync(process.execPath, ['--import', 'tsx', CLI_PATH, 'status'], {
+    cwd: dirname(dirname(CLI_PATH)),
+    encoding: 'utf8',
+    timeout: 15_000,
+    env: { ...process.env, HOME: home },
+  });
+}
+
+describe.runIf(process.platform === 'linux')('PM2 read-only CLI lifecycle boundary', () => {
+  afterEach(() => {
+    for (const home of homes.splice(0)) {
+      const pm2Home = join(home, '.botmux', 'pm2');
+      spawnSync(process.execPath, [PM2_PATH, 'kill'], {
+        env: { ...process.env, PM2_HOME: pm2Home },
+        stdio: 'ignore',
+        timeout: 10_000,
+      });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('reports absence without creating a PM2 God daemon', () => {
+    const home = tempHome();
+    const result = runStatus(home);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('daemon 未在运行');
+    expect(existsSync(join(home, '.botmux', 'pm2', 'pm2.pid'))).toBe(false);
+  });
+
+  it('refuses to query a God daemon inherited from the caller cgroup', () => {
+    const home = tempHome();
+    const pm2Home = join(home, '.botmux', 'pm2');
+    mkdirSync(pm2Home, { recursive: true });
+    const boot = spawnSync(process.execPath, [PM2_PATH, 'status'], {
+      env: { ...process.env, PM2_HOME: pm2Home },
+      stdio: 'ignore',
+      timeout: 10_000,
+    });
+    expect(boot.status).toBe(0);
+
+    const result = runStatus(home);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/其它 supervisor|拒绝复用/);
+  });
+
+  it('queries an existing God through direct RPC without rotating its generation', () => {
+    const home = tempHome();
+    const pm2Home = join(home, '.botmux', 'pm2');
+    mkdirSync(pm2Home, { recursive: true });
+    const boot = spawnSync(process.execPath, [PM2_PATH, 'status'], {
+      env: { ...process.env, PM2_HOME: pm2Home },
+      stdio: 'ignore',
+      timeout: 10_000,
+    });
+    expect(boot.status).toBe(0);
+    const pidFile = join(pm2Home, 'pm2.pid');
+    const originalPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10);
+
+    expect(JSON.parse(captureReadonlyPm2Jlist({
+      pkgRoot: dirname(dirname(CLI_PATH)),
+      home: pm2Home,
+    }))).toEqual([]);
+    expect(Number.parseInt(readFileSync(pidFile, 'utf8'), 10)).toBe(originalPid);
+  });
+
+  it('rejects a different God generation after the parent ownership check', () => {
+    const home = tempHome();
+    const pm2Home = join(home, '.botmux', 'pm2');
+    mkdirSync(pm2Home, { recursive: true });
+    expect(spawnSync(process.execPath, [PM2_PATH, 'status'], {
+      env: { ...process.env, PM2_HOME: pm2Home },
+      stdio: 'ignore',
+      timeout: 10_000,
+    }).status).toBe(0);
+    const ownership = inspectLinuxPm2GodOwnership(pm2Home);
+    expect(ownership.kind).not.toBe('absent');
+    const god = ownership.kind === 'absent' ? undefined : ownership.processes[0];
+
+    expect(() => captureReadonlyPm2Jlist({
+      pkgRoot: dirname(dirname(CLI_PATH)),
+      home: pm2Home,
+      expectedGod: { ...god!, startIdentity: `${god!.startIdentity}-replaced` },
+    })).toThrow(/generation changed/);
+  });
+});

--- a/test/pm2-readonly-cli.test.ts
+++ b/test/pm2-readonly-cli.test.ts
@@ -17,8 +17,8 @@ function tempHome(): string {
   return home;
 }
 
-function runStatus(home: string) {
-  return spawnSync(process.execPath, ['--import', 'tsx', CLI_PATH, 'status'], {
+function runCli(home: string, ...args: string[]) {
+  return spawnSync(process.execPath, ['--import', 'tsx', CLI_PATH, ...args], {
     cwd: dirname(dirname(CLI_PATH)),
     encoding: 'utf8',
     timeout: 15_000,
@@ -41,7 +41,7 @@ describe.runIf(process.platform === 'linux')('PM2 read-only CLI lifecycle bounda
 
   it('reports absence without creating a PM2 God daemon', () => {
     const home = tempHome();
-    const result = runStatus(home);
+    const result = runCli(home, 'status');
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('daemon 未在运行');
@@ -59,9 +59,14 @@ describe.runIf(process.platform === 'linux')('PM2 read-only CLI lifecycle bounda
     });
     expect(boot.status).toBe(0);
 
-    const result = runStatus(home);
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toMatch(/其它 supervisor|拒绝复用/);
+    for (const command of ['status', 'logs']) {
+      const result = runCli(home, command);
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('❌ 检测到 PM2 God Daemon 归属于其它 supervisor');
+      expect(result.stderr).toContain('迁移建议：');
+      expect(result.stderr).toContain('botmux restart');
+      expect(result.stderr).not.toMatch(/\n\s+at /);
+    }
   });
 
   it('queries an existing God through direct RPC without rotating its generation', () => {

--- a/test/shutdown-supervisor-contract.test.ts
+++ b/test/shutdown-supervisor-contract.test.ts
@@ -125,6 +125,25 @@ describe('graceful shutdown supervisor contract', () => {
     expect(stop).toContain('PM2 registry mutation incomplete');
   });
 
+  it('lets systemd retire only the exact owned God after an attested fleet stop', () => {
+    const helperStart = cli.indexOf('function terminateSystemdOwnedPm2God()');
+    const helperEnd = cli.indexOf('async function cmdStop()', helperStart);
+    const helper = cli.slice(helperStart, helperEnd);
+    expect(helper).toContain('process.env[BOTMUX_SYSTEMD_SERVICE_ENV]');
+    expect(helper).toContain('currentLinuxSystemdCgroup()');
+    expect(helper).toContain("ownership.processes.length !== 1");
+    expect(helper).toContain('readSupervisorProcessStartIdentity(target.pid)');
+    expect(helper).toContain("process.kill(target.pid, 'SIGTERM')");
+    expect(helper).not.toContain('SIGKILL');
+
+    const stopStart = cli.indexOf('async function cmdStop()');
+    const stopEnd = cli.indexOf('async function cmdRestart()', stopStart);
+    const stop = cli.slice(stopStart, stopEnd);
+    expect(stop).toContain("process.argv.includes('--systemd-service')");
+    expect(stop.indexOf('terminateSystemdOwnedPm2God()', stop.indexOf('PM2 registry mutation incomplete')))
+      .toBeGreaterThan(stop.indexOf('PM2 registry mutation incomplete'));
+  });
+
   it('restart waits for the fleet decision before any PM2 delete', () => {
     const start = cli.indexOf('function deleteAllBotmuxProcesses(');
     const end = cli.indexOf('/**\n * One-time migration', start);
@@ -384,8 +403,12 @@ describe('graceful shutdown supervisor contract', () => {
     const restartStart = cli.indexOf('async function cmdRestart()');
     const restartEnd = cli.indexOf('/**\n * Bring a SINGLE bot', restartStart);
     const restart = cli.slice(restartStart, restartEnd);
-    expect(restart).toContain("process.argv.includes('--bootstrap-shutdown-protocol')");
-    expect(restart).toContain("process.argv.includes('--yes')");
+    const flagsStart = cli.indexOf('function validateRestartLifecycleFlags(');
+    const flagsEnd = cli.indexOf('async function preflightRestartGenerationForSystemdRepair()', flagsStart);
+    const flags = cli.slice(flagsStart, flagsEnd);
+    expect(flags).toContain("argv.includes('--bootstrap-shutdown-protocol')");
+    expect(flags).toContain("argv.includes('--yes')");
+    expect(restart).toContain('validateRestartLifecycleFlags()');
     expect(restart).toContain("bootstrapDeleteAllBotmuxProcesses('restart')");
     expect(restart).toContain('else deleteAllBotmuxProcesses()');
     expect(cli).toContain('botmux restart --bootstrap-shutdown-protocol --yes');

--- a/test/systemd-pm2-migration.e2e.ts
+++ b/test/systemd-pm2-migration.e2e.ts
@@ -1,0 +1,169 @@
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const fixtureRoot = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'systemd-migration');
+const systemdAvailable = process.platform === 'linux'
+  && spawnSync('systemctl', ['--user', 'show-environment'], {
+    stdio: 'ignore',
+    timeout: 5_000,
+  }).status === 0;
+
+describe.runIf(systemdAvailable)('systemd PM2 generation migration', () => {
+  const suffix = `${process.pid}-${Date.now()}`;
+  const unit = `botmux-migration-${suffix}.service`;
+  const pidPrefix = `botmux-migration-${suffix}`;
+  const failingUnit = `botmux-migration-failing-${suffix}.service`;
+  const failingPidPrefix = `botmux-migration-failing-${suffix}`;
+  const runtimeDir = process.env.XDG_RUNTIME_DIR || `/run/user/${process.getuid?.()}`;
+  const godPidFile = join(runtimeDir, `${pidPrefix}-god.pid`);
+  const persistentPidFile = join(runtimeDir, `${pidPrefix}-persistent.pid`);
+  const failingGodPidFile = join(runtimeDir, `${failingPidPrefix}-god.pid`);
+  const failingGodOwnerFile = join(runtimeDir, `${failingPidPrefix}-god.owner`);
+  let tempRoot = '';
+  let legacyUnit = '';
+  let desiredUnit = '';
+  let failingUnitPath = '';
+
+  function systemctl(...args: string[]): string {
+    const result = spawnSync('systemctl', ['--user', ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+    });
+    if (result.status !== 0) {
+      throw new Error(`systemctl ${args.join(' ')} failed: ${result.stderr || result.status}`);
+    }
+    return result.stdout;
+  }
+
+  function state(property: string): string {
+    return stateOf(unit, property);
+  }
+
+  function stateOf(targetUnit: string, property: string): string {
+    return systemctl('show', targetUnit, `--property=${property}`, '--value').trim();
+  }
+
+  function readPid(path: string): number {
+    return Number.parseInt(readFileSync(path, 'utf8').trim(), 10);
+  }
+
+  function assertFixtureSleep(pid: number): void {
+    expect(readFileSync(`/proc/${pid}/comm`, 'utf8').trim()).toBe('sleep');
+    expect(readFileSync(`/proc/${pid}/cgroup`, 'utf8')).toContain(`/${unit}`);
+  }
+
+  beforeAll(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'botmux-systemd-migration-'));
+    legacyUnit = join(tempRoot, 'legacy', unit);
+    desiredUnit = join(tempRoot, 'desired', unit);
+    failingUnitPath = join(tempRoot, 'failing', failingUnit);
+    mkdirSync(dirname(legacyUnit), { recursive: true });
+    mkdirSync(dirname(desiredUnit), { recursive: true });
+    mkdirSync(dirname(failingUnitPath), { recursive: true });
+    const legacy = readFileSync(join(fixtureRoot, 'legacy', 'botmux-migration-fixture.service'), 'utf8')
+      .replaceAll('botmux-migration', pidPrefix);
+    const desired = readFileSync(join(fixtureRoot, 'desired', 'botmux-migration-fixture.service'), 'utf8')
+      .replaceAll('botmux-migration', pidPrefix);
+    const failing = readFileSync(join(fixtureRoot, 'failing', 'botmux-migration-fixture.service'), 'utf8')
+      .replaceAll('botmux-migration', failingPidPrefix);
+    writeFileSync(legacyUnit, legacy);
+    writeFileSync(desiredUnit, desired);
+    writeFileSync(failingUnitPath, failing);
+  });
+
+  afterAll(() => {
+    spawnSync('systemctl', ['--user', 'stop', unit], { stdio: 'ignore', timeout: 10_000 });
+    spawnSync('systemctl', ['--user', 'stop', failingUnit], { stdio: 'ignore', timeout: 10_000 });
+    if (existsSync(persistentPidFile)) {
+      const pid = readPid(persistentPidFile);
+      try {
+        assertFixtureSleep(pid);
+        process.kill(pid, 'SIGTERM');
+      } catch { /* already gone or identity mismatch: do not signal */ }
+    }
+    if (existsSync(failingGodPidFile)) {
+      const pid = readPid(failingGodPidFile);
+      try {
+        expect(readFileSync(`/proc/${pid}/comm`, 'utf8').trim()).toBe('sleep');
+        expect(readFileSync(`/proc/${pid}/cgroup`, 'utf8')).toContain(`/${failingUnit}`);
+        process.kill(pid, 'SIGTERM');
+      } catch { /* already gone or identity mismatch: do not signal */ }
+    }
+    spawnSync('systemctl', ['--user', 'disable', '--runtime', unit], { stdio: 'ignore', timeout: 10_000 });
+    spawnSync('systemctl', ['--user', 'disable', '--runtime', failingUnit], { stdio: 'ignore', timeout: 10_000 });
+    spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore', timeout: 10_000 });
+    spawnSync('systemctl', ['--user', 'reset-failed', unit], { stdio: 'ignore', timeout: 10_000 });
+    spawnSync('systemctl', ['--user', 'reset-failed', failingUnit], { stdio: 'ignore', timeout: 10_000 });
+    rmSync(godPidFile, { force: true });
+    rmSync(persistentPidFile, { force: true });
+    rmSync(failingGodPidFile, { force: true });
+    rmSync(failingGodOwnerFile, { force: true });
+    if (tempRoot) rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('makes the replacement God MainPID while persistent children survive service restarts', () => {
+    systemctl('link', '--runtime', '--force', legacyUnit);
+    systemctl('daemon-reload');
+    systemctl('start', unit);
+
+    expect(state('MainPID')).toBe('0');
+    expect(state('SubState')).toBe('exited');
+    const legacyGod = readPid(godPidFile);
+    const persistentPid = readPid(persistentPidFile);
+    assertFixtureSleep(persistentPid);
+
+    systemctl('link', '--runtime', '--force', desiredUnit);
+    systemctl('daemon-reload');
+    expect(state('Type')).toBe('forking');
+    expect(state('KillMode')).toBe('process');
+    expect(state('KillSignal')).toBe('18');
+    expect(state('RestartKillSignal')).toBe('18');
+    expect(state('FinalKillSignal')).toBe('18');
+    expect(state('SendSIGKILL')).toBe('no');
+    expect(state('MainPID')).toBe('0');
+
+    systemctl('restart', unit);
+    const firstGod = readPid(godPidFile);
+    expect(firstGod).not.toBe(legacyGod);
+    expect(state('MainPID')).toBe(String(firstGod));
+    expect(state('SubState')).toBe('running');
+    assertFixtureSleep(persistentPid);
+
+    systemctl('restart', unit);
+    const secondGod = readPid(godPidFile);
+    expect(secondGod).not.toBe(firstGod);
+    expect(state('MainPID')).toBe(String(secondGod));
+    assertFixtureSleep(persistentPid);
+  });
+
+  it('leaves the God alive when the attested ExecStop fails', () => {
+    systemctl('link', '--runtime', '--force', failingUnitPath);
+    systemctl('daemon-reload');
+    systemctl('start', failingUnit);
+    const god = readPid(failingGodPidFile);
+    expect(stateOf(failingUnit, 'MainPID')).toBe(String(god));
+
+    const restarted = spawnSync('systemctl', ['--user', 'restart', failingUnit], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+    });
+    expect(restarted.status).toBe(0);
+    expect(readPid(failingGodPidFile)).toBe(god);
+    expect(() => process.kill(god, 0)).not.toThrow();
+    expect(readFileSync(`/proc/${god}/comm`, 'utf8').trim()).toBe('sleep');
+  });
+
+});


### PR DESCRIPTION
## 背景

Closes #774

PM2 God 首次启动时会继承调用方所在的 cgroup；即使随后 daemonize，也不会自动迁出该进程组。因此，如果首次启动来自 IDE、Agent Runner 或其他 systemd service，PM2 God 和 Botmux daemon 的生命周期会意外绑定到该调用方，调用方重启或清理 cgroup 时会连带终止 Botmux。

本 PR 将 Linux 下的生命周期明确为：

```text
botmux.service
└── PM2 God Daemon
    ├── botmux daemon
    ├── dashboard
    └── plugin services
```

## 修改思路

### 1. 让 systemd 正式接管 PM2 God

Linux user service 从 `Type=oneshot + RemainAfterExit` 调整为：

- `Type=forking`
- `PIDFile=~/.botmux/pm2/pm2.pid`
- `MainPID` 指向 PM2 God
- `ExecStart`、`ExecStop` 使用仅限 systemd service 内部调用的入口

PM2 God 由 `botmux.service` 内部创建，因此 God、daemon 和 dashboard 都进入独立的 `botmux.service` cgroup，不再继承执行 `botmux start` 的终端或其他 supervisor。

Service 使用 `KillMode=process`，并由经过 PID、进程启动代际和 cgroup 校验的 `ExecStop` 精确结束 PM2 God，避免 systemd 在重启时误杀需要跨 daemon 重启保留的 tmux、herd 或 zellij 会话。

### 2. 普通 restart 自动修复已有 Service

`botmux restart` 在 Linux 下会：

1. 重写当前版本的 `~/.config/systemd/user/botmux.service`
2. 执行 `systemctl --user daemon-reload`
3. 校验有效的 Type、PIDFile、ExecStart、ExecStop、PATH、WorkingDirectory 和 shutdown 策略
4. 判断当前 PM2 God 是否已成为 `botmux.service` 的 MainPID
5. 必要时通过 `systemctl --user restart botmux.service` 完成迁移
6. 重启后重新校验 God ownership、service 状态和 MainPID

已有的旧版 `Type=oneshot` unit 不需要手动删除或重新执行 `autostart enable`，普通 restart 即可修复文件和运行态。

实现只维护一个主 `botmux.service`，不生成额外的 drop-in/conf 文件。

### 3. 拒绝复用其他 supervisor 的 God

新增 Linux PM2 lifecycle ownership 检查，通过 `/proc` 同时绑定 PM2_HOME、PID、进程启动代际和 systemd cgroup。

当已有 God 属于其他 service/cgroup 时，start、restart、status、logs、stop、插件服务 mutation 和 autostart 操作都会 fail closed，不会自动结束或连接外部 God。

CLI 会输出稳定的退出码 `2` 和不带 Node stack 的迁移提示，明确当前 owner、需要先确认 Session/Riff workload 空闲、不得直接使用绕过 shutdown 校验的 `pm2 kill`，以及旧 God 退出后应重新运行 `botmux restart`。本 PR 不会自动 signal 外部 God，避免越权操作其他 supervisor 管理的进程。

### 4. 只读命令不隐式拉起 PM2

PM2 的公共 CLI/connect 路径在 socket 不存在时可能自动创建 God。新增只读 RPC 客户端用于 status、logs 和 Desktop 查询：

- God 不存在时直接报告未运行
- God 已归属 `botmux.service` 时只连接既有 RPC socket
- God 属于其他 service/cgroup 时拒绝查询并输出迁移提示
- 不调用 PM2 daemonize/start 路径
- 查询期间绑定既有 God 的 PID、启动代际和 cgroup
- socket 断开后不自动重连到替换 generation

### 5. 约束已有 God 上的 mutation

插件服务等必须修改现有 PM2 registry 的操作会在 mutation 前确认 God 唯一且属于 `botmux.service`，关闭 RPC socket 自动重连，并在发送请求前再次校验 PID、启动代际和 cgroup。God 消失或被替换时直接失败，不在调用方 cgroup 中创建新 God。

### 6. 保留插件服务与持久会话

- 自动插件服务由正常启动流程重新 reconcile
- 正在运行的 manual plugin service 在 systemd 迁移前记录并在成功后恢复
- tmux、herd、zellij 等持久会话不会随 God 一起被 systemd 清理

## 影响范围

- **Linux**：daemon 首次启动和必要的 Service 修复统一经过 user systemd；外部 cgroup 的 God 不再隐式复用；旧版主 unit 可通过普通 restart 自动修复。
- **macOS / Windows**：launchd 和 Task Scheduler 注册方式不变；PM2 查询改为不 daemonize 的只读 RPC，不引入 Linux ownership 判断。
- **CLI / 后端 / 会话类型**：未修改 AI CLI adapter 和飞书消息处理路径；PtyBackend 与持久会话后端启动协议不变；插件服务继续使用 Botmux 专用 PM2_HOME。

## 设计边界

本 PR 聚焦 Issue 要求的基本生命周期问题：建立明确的 `botmux.service` owner、校验并拒绝外部 God、自动修复旧版主 Service、阻止只读命令隐式 daemonize。

没有引入额外 drop-in 配置、持久迁移 journal、自动 retirement/handoff 或跨崩溃恢复事务。

## 验证

### 构建

```bash
pnpm build
```

通过，包括 TypeScript 编译、dashboard bundle 和 dist audit。

### 定向测试与真实 systemd E2E

```bash
pnpm exec vitest run \
  test/autostart-existing-unit-repair.test.ts \
  test/autostart-pm2-ownership.test.ts \
  test/autostart-refresh-retry.test.ts \
  test/plugin-service-manual-snapshot.test.ts \
  test/pm2-existing-client.test.ts \
  test/pm2-readonly-cli.test.ts \
  test/desktop/desktop-pm2-apps.test.ts \
  test/plugin-pm2-env.test.ts \
  test/shutdown-supervisor-contract.test.ts \
  test/systemd-pm2-migration.e2e.ts
```

结果：10 个测试文件、62 个用例全部通过。

测试覆盖：

- 旧 `Type=oneshot` unit 迁移到 `Type=forking`
- PM2 God 换代后成为 MainPID
- God 和核心进程进入 Botmux service cgroup
- 持久子进程跨 service restart 存活
- ExecStop 失败时不会由 systemd fallback 强杀 God
- status/logs 遇到 external God 时返回退出码 2、给出迁移提示且不打印 Node stack

### 本地运行

```bash
pnpm switch:here
pnpm daemon:restart
```

实际读回：

- `botmux.service` 为 `active/running`
- `Type=forking`
- `MainPID` 与唯一 PM2 God PID 一致
- PM2 God、`botmux-0`、dashboard 均属于 `botmux.service` cgroup
- daemon 与 dashboard 均为 `online`
- 已有 tmux 会话在 restart 后仍然存在
