### PR TITLE
fix(dashboard): .dashboard-secret 读写强制走宿主凭证安全原语

### DIFF
--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -1,8 +1,4 @@
 import { randomBytes, createHmac, timingSafeEqual } from 'node:crypto';
-import {
-  readFileSync, existsSync, mkdirSync, chmodSync, linkSync, unlinkSync, writeFileSync,
-} from 'node:fs';
-import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { dirname } from 'node:path';
 import {
   readSecureHostFileSync,
@@ -99,61 +95,40 @@ export function generateToken(): string {
 /**
  * Load a dashboard HMAC secret from disk. Empty / whitespace-only files are
  * treated as missing so callers never sign requests with an empty key.
+ *
+ * Goes through the same strict host-authority primitives as the persisted
+ * token: the leaf must be a regular 0600 file owned by the current user and
+ * must not be a symlink, and its directory (`~/.botmux`) must not be
+ * group/other-writable. An unsafe shape throws
+ * {@link UnsafeHostAuthorityFileError} (fail-closed) instead of being followed:
+ * a symlinked or loose-perms secret could be planted by a local attacker who
+ * can replace the credential directory, letting them forge CLI HMAC headers
+ * and mint dashboard tokens.
  */
 export function loadDashboardSecret(secretPath: string): string | null {
-  if (!existsSync(secretPath)) return null;
-  const secret = readFileSync(secretPath, 'utf8').trim();
-  return secret.length > 0 ? secret : null;
+  const secret = readSecureHostFileSync(secretPath, 256)?.trim();
+  return secret ? secret : null;
 }
 
-/** Load the dashboard HMAC secret, creating a fresh 0600 secret when absent. */
+/**
+ * Load the dashboard HMAC secret, creating a fresh 0600 secret when absent or
+ * empty. The credential directory is pinned once (Linux: via an open directory
+ * descriptor) and the lock, the read, and the write all resolve through that
+ * same anchor — so a symlinked HOME / shared-drive ancestor still works while
+ * an ancestor rename mid-section cannot redirect the secret into a substituted
+ * directory, and a leaf symlink is refused. The file lock makes get-or-create
+ * linearizable across dashboard processes.
+ */
 export function loadOrCreateDashboardSecret(secretPath: string): string {
-  const existing = loadDashboardSecret(secretPath);
-  if (existing) return existing;
-  const secret = randomBytes(32).toString('base64url');
-  mkdirSync(dirname(secretPath), { recursive: true });
-  // Daemon fleets and the dashboard start concurrently on a fresh install.
-  // A rename-based "atomic write" is individually atomic but not
-  // create-if-absent: two winners can each return a different key while only
-  // the last rename remains on disk. Publish a fully-written temp inode with
-  // link(2) instead. The link is atomic and fails with EEXIST for every loser;
-  // losers then read the single winner's complete value.
-  const temp = `${secretPath}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`;
-  try {
-    writeFileSync(temp, secret, { mode: 0o600, flag: 'wx' });
-    try {
-      linkSync(temp, secretPath);
-      chmodSync(secretPath, 0o600);
+  return withSecureHostParentSync(secretPath, (parent) =>
+    parent.withLeafLock(() => {
+      const existing = parent.readLeaf(256)?.trim();
+      if (existing) return existing;
+      const secret = randomBytes(32).toString('base64url');
+      parent.writeLeaf(secret);
       return secret;
-    } catch (err) {
-      const raced = loadDashboardSecret(secretPath);
-      if (raced) return raced;
-      // Existing-but-empty/corrupt file: publish one permanent repair seed via
-      // link(2). Every concurrent initializer either wins that O_EXCL election
-      // or reads the same fully-written seed, then atomically restores the main
-      // path with the identical value. Keeping the 0600 seed makes crash recovery
-      // replayable and avoids stale PID locks (and their delete/recreate races).
-      const repairSeedPath = `${secretPath}.repair-seed`;
-      let repairSecret: string;
-      try {
-        linkSync(temp, repairSeedPath);
-        chmodSync(repairSeedPath, 0o600);
-        repairSecret = secret;
-      } catch (seedErr) {
-        if ((seedErr as NodeJS.ErrnoException).code !== 'EEXIST') throw seedErr;
-        const published = loadDashboardSecret(repairSeedPath);
-        if (!published) {
-          throw new Error(`dashboard secret repair seed is unreadable: ${repairSeedPath}`);
-        }
-        repairSecret = published;
-      }
-      atomicWriteFileSync(secretPath, repairSecret, { mode: 0o600 });
-      chmodSync(secretPath, 0o600);
-      return repairSecret;
-    }
-  } finally {
-    try { unlinkSync(temp); } catch { /* already absent */ }
-  }
+    }),
+  );
 }
 
 /**

--- a/test/daemon-internal-client.test.ts
+++ b/test/daemon-internal-client.test.ts
@@ -101,7 +101,7 @@ describe('secret loading', () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-client-secret-'));
     dirs.push(dir);
     const secretPath = join(dir, '.dashboard-secret');
-    writeFileSync(secretPath, '  \n');
+    writeFileSync(secretPath, '  \n', { mode: 0o600 });
 
     expect(() => createDaemonClient({
       appId: 'cli_test',

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -506,38 +506,78 @@ describe('dashboard secret persistence', () => {
   it('loadDashboardSecret returns null when file is absent or whitespace-only', () => {
     expect(loadDashboardSecret(secretPath)).toBeNull();
     const p = join(dir, 'empty-secret');
-    writeFileSync(p, '   \n');
+    writeFileSync(p, '   \n', { mode: 0o600 });
     expect(loadDashboardSecret(p)).toBeNull();
   });
 
   it('loadOrCreateDashboardSecret overwrites whitespace-only file with a fresh 0600 secret', () => {
     mkdirSync(join(dir, 'nested'));
-    writeFileSync(secretPath, ' \n');
+    writeFileSync(secretPath, ' \n', { mode: 0o600 });
     const secret = loadOrCreateDashboardSecret(secretPath);
     expect(secret).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(loadDashboardSecret(secretPath)).toBe(secret);
     expect(statSync(secretPath).mode & 0o777).toBe(0o600);
   });
 
-  it('ignores a legacy stale repair lock and converges through a permanent seed', () => {
+  it('legacy repair-seed / repair-lock residue does not block creation', () => {
+    // 旧版 link(2) 选举机制留下的 .repair-seed / .repair.lock 残留不应阻塞
+    // 新版基于文件锁的 get-or-create，也不会再生成新的 repair-seed。
     mkdirSync(join(dir, 'nested'));
-    writeFileSync(secretPath, ' \n');
-    const lockPath = `${secretPath}.repair.lock`;
-    writeFileSync(lockPath, '');
+    writeFileSync(`${secretPath}.repair-seed`, 'legacy', { mode: 0o600 });
+    writeFileSync(`${secretPath}.repair.lock`, '');
 
     const secret = loadOrCreateDashboardSecret(secretPath);
 
     expect(secret).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(loadDashboardSecret(secretPath)).toBe(secret);
     expect(statSync(secretPath).mode & 0o777).toBe(0o600);
-    expect(loadDashboardSecret(`${secretPath}.repair-seed`)).toBe(secret);
-    expect(statSync(`${secretPath}.repair-seed`).mode & 0o777).toBe(0o600);
-    expect(existsSync(lockPath)).toBe(true); // ignored legacy residue cannot block startup
+    expect(existsSync(`${secretPath}.repair.lock`)).toBe(true); // 残留被忽略，不阻塞启动
   });
 
-  it('concurrent processes repairing one corrupt secret converge on the repair seed', async () => {
+  it('refuses to read a secret leaf symlink without touching its target', () => {
+    if (process.platform === 'win32') return;
     mkdirSync(join(dir, 'nested'));
-    writeFileSync(secretPath, ' \n');
+    const victim = join(dir, 'victim');
+    writeFileSync(victim, 'keep-me', { mode: 0o600 });
+    symlinkSync(victim, secretPath);
+
+    expect(() => loadDashboardSecret(secretPath)).toThrow(UnsafeHostAuthorityFileError);
+    expect(readFileSync(victim, 'utf8')).toBe('keep-me');
+  });
+
+  it('refuses to create through a secret leaf symlink without touching its target', () => {
+    if (process.platform === 'win32') return;
+    mkdirSync(join(dir, 'nested'));
+    const victim = join(dir, 'victim');
+    writeFileSync(victim, 'keep-me', { mode: 0o600 });
+    symlinkSync(victim, secretPath);
+
+    expect(() => loadOrCreateDashboardSecret(secretPath)).toThrow(UnsafeHostAuthorityFileError);
+    expect(readFileSync(victim, 'utf8')).toBe('keep-me');
+  });
+
+  it('fails closed when the secret file has loose permissions', () => {
+    if (process.platform === 'win32') return;
+    mkdirSync(join(dir, 'nested'));
+    writeFileSync(secretPath, 'x'.repeat(43), { mode: 0o644 });
+    expect(() => loadDashboardSecret(secretPath)).toThrow(/0600/);
+  });
+
+  it('fails closed when the credential directory is group-writable', () => {
+    if (process.platform === 'win32') return;
+    const nested = join(dir, 'nested');
+    mkdirSync(nested);
+    chmodSync(nested, 0o770); // 组内用户可替换叶子凭证文件
+    try {
+      expect(() => loadOrCreateDashboardSecret(secretPath))
+        .toThrow(/组内或其它用户写入|不可信祖先/);
+    } finally {
+      chmodSync(nested, 0o700);
+    }
+  });
+
+  it('concurrent processes creating one absent secret converge on a single value', async () => {
+    mkdirSync(join(dir, 'nested'));
     const goPath = join(dir, 'go');
     const authModuleUrl = new URL('../src/dashboard/auth.ts', import.meta.url).href;
     const childSource = `
@@ -564,7 +604,7 @@ describe('dashboard secret persistence', () => {
     try {
       const deadline = Date.now() + 10_000;
       while (!children.every(entry => existsSync(entry.readyPath))) {
-        if (Date.now() >= deadline) throw new Error('repair children did not reach barrier');
+        if (Date.now() >= deadline) throw new Error('secret children did not reach barrier');
         await new Promise(resolve => setTimeout(resolve, 10));
       }
       writeFileSync(goPath, 'go');
@@ -578,7 +618,6 @@ describe('dashboard secret persistence', () => {
       const secrets = exits.map(result => result.stdout);
       expect(new Set(secrets).size).toBe(1);
       expect(secrets[0]).toBe(loadDashboardSecret(secretPath));
-      expect(secrets[0]).toBe(loadDashboardSecret(`${secretPath}.repair-seed`));
       expect(statSync(secretPath).mode & 0o777).toBe(0o600);
     } finally {
       for (const { child } of children) {

--- a/test/dashboard-endpoint.test.ts
+++ b/test/dashboard-endpoint.test.ts
@@ -64,7 +64,8 @@ function makeFetch(ports: Record<number, PortBehaviour>): typeof fetch {
 let dir: string;
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'bmx-dash-'));
-  writeFileSync(join(dir, '.dashboard-secret'), SECRET);
+  // 生产环境 secret 始终以 0600 落盘；fixture 必须匹配，否则安全读取会 fail-closed。
+  writeFileSync(join(dir, '.dashboard-secret'), SECRET, { mode: 0o600 });
 });
 afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
@@ -117,7 +118,7 @@ describe('callDashboard', () => {
   });
 
   it('returns no-secret when the secret file is whitespace-only', async () => {
-    writeFileSync(join(dir, '.dashboard-secret'), ' \n');
+    writeFileSync(join(dir, '.dashboard-secret'), ' \n', { mode: 0o600 });
     const r = await callDashboard({ configDir: dir, defaultPort: 7891, path: '/__cli/rotate', fetchImpl: makeFetch({}) });
     expect(r).toEqual({ ok: false, reason: 'no-secret' });
   });

--- a/test/exact-chat-grant-cli.test.ts
+++ b/test/exact-chat-grant-cli.test.ts
@@ -152,7 +152,7 @@ describe('botmux grant chat CLI boundary', () => {
     mkdirSync(configDir, { recursive: true });
     mkdirSync(registryDir, { recursive: true });
     const secret = 'exact-grant-cli-test-secret';
-    writeFileSync(join(configDir, '.dashboard-secret'), secret);
+    writeFileSync(join(configDir, '.dashboard-secret'), secret, { mode: 0o600 });
     const botsConfig = join(root, 'bots.json');
     writeFileSync(botsConfig, JSON.stringify([{
       larkAppId: 'cli_receiver',
@@ -272,7 +272,7 @@ describe('botmux grant chat CLI boundary', () => {
     const registryDir = join(dataDir, 'dashboard-daemons');
     mkdirSync(configDir, { recursive: true });
     mkdirSync(registryDir, { recursive: true });
-    writeFileSync(join(configDir, '.dashboard-secret'), 'exact-grant-cli-stable-subject-secret');
+    writeFileSync(join(configDir, '.dashboard-secret'), 'exact-grant-cli-stable-subject-secret', { mode: 0o600 });
     const botsConfig = join(root, 'bots.json');
     writeFileSync(botsConfig, JSON.stringify([{
       larkAppId: 'cli_receiver',


### PR DESCRIPTION
优先级：P0

## 根因

`.dashboard-secret` 是 CLI 与 Dashboard loopback HMAC 的共享密钥，与 `platform.json` 同属宿主凭证，但此前使用裸 `fs` 读写：读取会跟随符号链接，也不校验属主、权限和祖先目录；创建时的 `link(2)` 选举同样不防叶子符号链接。能替换凭证目录或其祖先的本地攻击者可植入已知密钥，伪造 CLI HMAC 头并接管会话。

## 改动

- 读取统一改走 `readSecureHostFileSync`：强制 0600、`O_NOFOLLOW`、属主校验，并在 Linux 下通过目录句柄锚定防止祖先替换。
- 创建改为 `withSecureHostParentSync` + `withLeafLock` 的线性化 get-or-create；移除旧 `link(2)` 选举和 repair-seed 机制。
- 空文件仍按缺失处理并原子重建；不安全形态一律 fail-closed，抛出 `UnsafeHostAuthorityFileError`。

## 影响面

改动仅覆盖 Dashboard 宿主密钥读写路径。既有调用点已在失败时捕获并退出，不会在安全校验失败后降级使用不可信凭证。

## 验证

- 读、写两路均拒绝叶子符号链接，且链接目标不被触碰。
- 拒绝 0644 文件和组可写凭证目录。
- 旧 repair-seed / repair.lock 残留不阻塞启动。
- 8 个进程并发创建最终收敛到同一个 0600 密钥。