### PR TITLE
fix(sandbox): 文件沙盒开启时 auto-worktree 失败改为 fail-closed，杜绝回退真实目录

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -401,6 +401,53 @@ export function localSandboxApplies(
   return true;
 }
 
+/**
+ * The worker's file-sandbox request decision, as ONE shared pure predicate.
+ *
+ * worker.ts computes `sandboxRequested` with this exact shape; the auto-worktree
+ * fail-closed gate (services/default-worktree.ts) reuses it so the two can never
+ * drift again — the riff exemption once only existed in the worker, which let a
+ * sandboxed riff bot fall back to the real default dir on a worktree failure (a
+ * sandbox escape), and the mojo backend (#803) then repeated the SAME drift for a
+ * provably-remote mojo session.
+ *
+ * Shape:
+ *   localSandboxApplies(backend, mojoConfig) && (sandbox || readIsolation || noTransport || BOTMUX_SANDBOX)
+ *
+ * - The REMOTE exemption (riff / provably-remote mojo) wraps the WHOLE union: a
+ *   remote backend has no local CLI process, so even BOTMUX_SANDBOX=1 must not
+ *   engage a local sandbox there.
+ * - mojo is NOT exempt by name alone: only a PROVABLY remote mojo session is
+ *   (see localSandboxApplies / isMojoFullyRemote — cloud on, localDaemon off,
+ *   no wrapperCli, no unprovable env). A local mojo session stays fail-closed.
+ * - `noTransport` mirrors forkWorker's forced readIsolation for a no-transport
+ *   session (apiOnly bot or HTTP virtual chat — worker-pool.ts), which engages
+ *   the local sandbox even with no explicit sandbox flag. The worker folds that
+ *   forcing into `readIsolation` before this predicate runs, so it omits the arm;
+ *   callers that decide BEFORE the SpawnOpts forcing exists (auto-worktree
+ *   fail-closed) must pass it explicitly.
+ */
+export function localSandboxRequested(input: {
+  backendType: string;
+  mojoConfig?: {
+    cloud?: boolean;
+    localDaemon?: boolean;
+    wrapperCli?: string;
+    jwtEnv?: string;
+    env?: Record<string, string>;
+  };
+  sandbox?: boolean;
+  readIsolation?: boolean;
+  noTransport?: boolean;
+  envSandboxEnabled?: boolean;
+}): boolean {
+  if (!localSandboxApplies(input.backendType, input.mojoConfig)) return false;
+  return input.sandbox === true
+    || input.readIsolation === true
+    || input.noTransport === true
+    || input.envSandboxEnabled === true;
+}
+
 
 /** Top-level dirs that are symlinks on usrmerge distros (/bin → usr/bin …) —
  *  replicated inside the tmpfs root so `#!/bin/sh` etc. resolve. */

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -412,7 +412,7 @@ export function localSandboxApplies(
  * provably-remote mojo session.
  *
  * Shape:
- *   localSandboxApplies(backend, mojoConfig) && (sandbox || readIsolation || noTransport || BOTMUX_SANDBOX)
+ *   localSandboxApplies(backend, mojoConfig) && (sandbox || readIsolation || BOTMUX_SANDBOX)
  *
  * - The REMOTE exemption (riff / provably-remote mojo) wraps the WHOLE union: a
  *   remote backend has no local CLI process, so even BOTMUX_SANDBOX=1 must not
@@ -420,12 +420,10 @@ export function localSandboxApplies(
  * - mojo is NOT exempt by name alone: only a PROVABLY remote mojo session is
  *   (see localSandboxApplies / isMojoFullyRemote — cloud on, localDaemon off,
  *   no wrapperCli, no unprovable env). A local mojo session stays fail-closed.
- * - `noTransport` mirrors forkWorker's forced readIsolation for a no-transport
- *   session (apiOnly bot or HTTP virtual chat — worker-pool.ts), which engages
- *   the local sandbox even with no explicit sandbox flag. The worker folds that
- *   forcing into `readIsolation` before this predicate runs, so it omits the arm;
- *   callers that decide BEFORE the SpawnOpts forcing exists (auto-worktree
- *   fail-closed) must pass it explicitly.
+ * - The no-transport arm was REMOVED: forkWorker no longer force-isolates a
+ *   no-transport session (#899 dropped the forced readIsolation), so the arm
+ *   that mirrored it here is dead — the gate must not be stricter than the
+ *   worker it tracks.
  */
 export function localSandboxRequested(input: {
   backendType: string;
@@ -438,13 +436,11 @@ export function localSandboxRequested(input: {
   };
   sandbox?: boolean;
   readIsolation?: boolean;
-  noTransport?: boolean;
   envSandboxEnabled?: boolean;
 }): boolean {
   if (!localSandboxApplies(input.backendType, input.mojoConfig)) return false;
   return input.sandbox === true
     || input.readIsolation === true
-    || input.noTransport === true
     || input.envSandboxEnabled === true;
 }
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -89,6 +89,7 @@ import { withBotTurnMutation } from './bot-turn-mutation-gate.js';
 import { recordQuarantinedLauncherEnvKeys } from './mojo-launcher-env-quarantine.js';
 import { freezeMojoIdentityForSession } from './mojo-session-identity.js';
 import { getBot, getAllBots, loadBotConfigs, resolveBrandLabel, getLoadedConfigPath, getLoadedConfigProvenance, resolveUsageDisplay } from '../bot-registry.js';
+import type { BotConfig } from '../bot-registry.js';
 import { RestartCoordinator, type RestartObserver } from './restart-coordinator.js';
 import { runtimeBuildIdentity } from '../utils/runtime-build-id.js';
 import { scrubWorkflowWorkerEnv } from '../utils/child-env.js';
@@ -8077,6 +8078,62 @@ export function resolveQuarantinedForkPlan(
  * staged behind an ACK, routed through a live owner, or spawn-deferred during
  * device isolation — returns `true`.
  */
+/**
+ * Freeze the worker's sandbox DECISION INPUTS on the session record — the SAME
+ * fields forkWorker's SpawnOpts consumes (`sandbox` / `readIsolation` + the
+ * path lists). Called at TWO edges:
+ *   - pending-session establishment (runAutoWorktreeCommit), BEFORE any git /
+ *     notice await, so the auto-worktree fail-closed gate and the later fork
+ *     consume ONE snapshot; and
+ *   - forkWorker itself (below), preserving the original "recorded at creation"
+ *     semantics for sessions that never went through a pendingRepo phase.
+ *
+ * Without the early freeze, a dashboard `PUT /api/bot-sandbox` toggle landing
+ * while the worktree build is in flight made the gate degrade on the OLD value
+ * while the fork adopted the NEW one: the gate allowed the fallback to the
+ * real default dir and the worker engaged the local sandbox there — the exact
+ * write-escape the fail-closed gate exists to prevent. Re-reading live config
+ * only after the fallback would still leave the recheck→fork await window, so
+ * the decision is frozen ONCE, here, and both consumers read the session.
+ *
+ * Idempotent: an already-frozen session (`sandbox !== undefined`) keeps its
+ * recorded decision — a historical session is never retroactively re-frozen
+ * from a toggled live flag. A `resume` session pre-dating the field stays NOT
+ * sandboxed (same as the fork-time freeze this replaces), and its
+ * `readIsolation` stays undefined so the SpawnOpts live-config fallback
+ * preserves the legacy restore behavior.
+ */
+export function freezeSessionSandboxDecision(
+  ds: DaemonSession,
+  botCfg: Pick<BotConfig, 'sandbox' | 'sandboxPaths' | 'sandboxHidePaths' | 'sandboxReadonlyPaths' | 'sandboxNetwork' | 'readIsolation'>,
+  opts: { resume?: boolean } = {},
+): void {
+  let mutated = false;
+  if (ds.session.sandbox === undefined) {
+    if (!opts.resume) {
+      ds.session.sandbox = botCfg.sandbox === true;
+      ds.session.sandboxPaths = botCfg.sandboxPaths;
+      ds.session.sandboxHidePaths = botCfg.sandboxHidePaths ?? [];
+      ds.session.sandboxReadonlyPaths = botCfg.sandboxReadonlyPaths ?? [];
+      ds.session.sandboxNetwork = botCfg.sandboxNetwork !== false;
+    } else {
+      ds.session.sandbox = false;
+      ds.session.sandboxHidePaths = [];
+      ds.session.sandboxReadonlyPaths = [];
+      ds.session.sandboxNetwork = true;
+    }
+    mutated = true;
+  }
+  // readIsolation is frozen symmetrically: forkWorker's SpawnOpts reads the
+  // session value (with a live-config fallback ONLY for sessions persisted
+  // before this field existed), so the gate and the fork agree on it too.
+  if (ds.session.readIsolation === undefined && !opts.resume) {
+    ds.session.readIsolation = botCfg.readIsolation === true;
+    mutated = true;
+  }
+  if (mutated) sessionStore.updateSession(ds.session);
+}
+
 export function forkWorker(
   ds: DaemonSession,
   promptInput: string | CliTurnPayload,
@@ -8375,22 +8432,11 @@ export function forkWorker(
   // restore — so toggling the live bot flag never retroactively (un)sandboxes a
   // historical session. A brand-new session (resume=false) with no recorded
   // decision adopts the live bot flag; a restore (resume=true) with no recorded
-  // decision predates the sandbox feature → stays NOT sandboxed.
-  if (ds.session.sandbox === undefined) {
-    if (!resume) {
-      ds.session.sandbox = botCfg.sandbox === true;
-      ds.session.sandboxPaths = botCfg.sandboxPaths;
-      ds.session.sandboxHidePaths = botCfg.sandboxHidePaths ?? [];
-      ds.session.sandboxReadonlyPaths = botCfg.sandboxReadonlyPaths ?? [];
-      ds.session.sandboxNetwork = botCfg.sandboxNetwork !== false;
-    } else {
-      ds.session.sandbox = false;
-      ds.session.sandboxHidePaths = [];
-      ds.session.sandboxReadonlyPaths = [];
-      ds.session.sandboxNetwork = true;
-    }
-    sessionStore.updateSession(ds.session);
-  }
+  // decision predates the sandbox feature, so it stays NOT sandboxed. A
+  // pendingRepo session was already frozen at its establishment
+  // (runAutoWorktreeCommit), so this is a no-op there and the fork consumes
+  // the SAME snapshot the auto-worktree gate consumed.
+  freezeSessionSandboxDecision(ds, botCfg, { resume });
 
   // Reserve and durably publish the replacement lifetime before killing an
   // existing worker. A failed reservation leaves the old worker untouched;
@@ -8774,23 +8820,23 @@ export function forkWorker(
     // Per-bot local read isolation (enforced worker-side; the worker gates it).
     // Sibling data needs no app-id enumeration: per-bot dirs are denied wholesale
     // and per-bot session files by filename pattern (see buildV2DenyPaths).
-    // Opt-in only, driven purely by explicit per-bot `readIsolation`. A
-    // no-transport session (apiOnly bot OR HTTP virtual chat) is NO LONGER
-    // force-isolated: disk read scope now follows the owner's own sandbox config,
-    // symmetric with a normal chat session (unset/false → not isolated). Accepted
-    // trade-off: a no-transport session with no sandbox config can read the full
-    // bots.json / sibling BOT_HOME on disk; protecting sibling creds from lateral
-    // read on a multi-bot host now depends on the owner explicitly enabling
-    // sandbox/readIsolation, not on this force. Two adjacent boundaries are
-    // unchanged and independent: (1) this bot's own transport secret is still
-    // withheld from the CLI env (gated on larkTransportEnabled below), so a
-    // no-transport session cannot drive Botmux's own send path even though it can
-    // read the file; (2) mandatory device-credential isolation (worker.ts) still
-    // masks the device authority dir / enrolled creds on enrolled hosts. Full-file
-    // sandbox stays independently driven worker-side by sandboxRequested
-    // (cfg.sandbox || cfg.readIsolation || BOTMUX_SANDBOX=1); session.sandbox is
-    // frozen from botCfg.sandbox at create time, so "follow local sandbox" holds.
-    readIsolation: botCfg.readIsolation === true,
+    // FROZEN at session creation (freezeSessionSandboxDecision) — same snapshot
+    // the auto-worktree fail-closed gate consumes — so a dashboard readIsolation
+    // toggle landing while a worktree build is in flight can't diverge the gate
+    // from the fork. The live-config fallback only covers sessions persisted
+    // before the freeze field existed. A no-transport session (apiOnly bot OR
+    // HTTP virtual chat) is NOT force-isolated: disk read scope follows the
+    // owner's own config, symmetric with a normal chat session. Two adjacent
+    // boundaries are unchanged and independent: (1) this bot's own transport
+    // secret is still withheld from the CLI env (gated on larkTransportEnabled
+    // below), so a no-transport session cannot drive Botmux's own send path even
+    // though it can read the file; (2) mandatory device-credential isolation
+    // (worker.ts) still masks the device authority dir / enrolled creds on
+    // enrolled hosts. Full-file sandbox stays independently driven worker-side by
+    // sandboxRequested (cfg.sandbox || cfg.readIsolation || BOTMUX_SANDBOX=1);
+    // session.sandbox is frozen from botCfg.sandbox at create time, so "follow
+    // local sandbox" holds.
+    readIsolation: ds.session.readIsolation ?? botCfg.readIsolation === true,
     readDenyExtraPaths: botCfg.readDenyExtraPaths ?? [],
     // Identifies THIS daemon lifetime. Stamped onto isolated panes so the worker
     // can tell a suspend→resume reattach (same boot id, still isolated) from a

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -342,6 +342,7 @@ export const messages: Record<string, string> = {
   'worktree.auto_creating': '🌿 Creating an isolated worktree for this session (includes a git fetch, may take a few seconds)…',
   'worktree.auto_created': '🌿 Auto-created an isolated worktree for this session: `{path}`\nBranch `{branch}`, based on `{base}`. Your default directory is untouched.',
   'worktree.auto_fallback': '⚠️ Could not create a worktree in the default directory `{dir}` ({error}); fell back to starting the session directly in the default directory.',
+  'worktree.auto_fail_closed': '⛔ File sandbox is enabled, but an isolated worktree could not be created in the default directory `{dir}` ({error}). To keep the agent\'s writes out of the real directory, this session was not started. Configure the default directory as a git repository and start again, or use /repo to pick a working directory manually.',
   'worktree.err_not_git': 'default directory is not a git repository (or could not be confirmed)',
   'cmd.skip.opened': '▶️ Session started (working dir: {cwd})',
   'cmd.status.running': 'running',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -343,6 +343,7 @@ export const messages: Record<string, string> = {
   'worktree.auto_creating': '🌿 正在为本会话创建独立 worktree（含 git fetch，可能需要几秒）…',
   'worktree.auto_created': '🌿 已为本会话自动创建独立 worktree：`{path}`\n分支 `{branch}`，基于 `{base}`。原默认目录不受影响。',
   'worktree.auto_fallback': '⚠️ 无法在默认目录 `{dir}` 创建 worktree（{error}），已回退到直接在默认目录启动会话。',
+  'worktree.auto_fail_closed': '⛔ 文件沙盒已开启，但默认目录 `{dir}` 无法创建独立 worktree（{error}）。为避免 Agent 写入污染真实目录，本次会话未启动。请将默认目录配置为 git 仓库后重新发起，或使用 /repo 手动选择工作目录。',
   'worktree.err_not_git': '默认目录不是 git 仓库（或暂时无法确认）',
   'cmd.skip.opened': '▶️ 已直接开启会话（工作目录：{cwd}）',
   'cmd.status.running': '运行中',

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -88,6 +88,7 @@ import { buildClosedSessionCard } from '../../core/closed-session-card.js';
 import { ttadkConfigModelChoices } from '../../setup/cli-selection.js';
 import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
+import { AutoWorktreeFailClosedError } from '../../services/default-worktree.js';
 import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-store.js';
 import { forkWorker, sendWorkerInput, sendWorkerSessionInput, killWorker, closeSession as closeWorkerPoolSession, teardownAuthoritativePersistentBackingBeforeClose, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, workerHasInitialized, sessionSupportsWebTerminal, readableTerminalUrlFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL, requestSessionRestart, isSessionTransferring, getDaemonStreamingCardUsageSnapshot, withActiveSessionKeyLock, type WorkerSessionReplyOptions } from '../../core/worker-pool.js';
 import { getSessionWorkingDir, buildNewTopicCliInput, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput, ensureSessionWhiteboard } from '../../core/session-manager.js';
@@ -838,15 +839,18 @@ export async function commitRepoSelection(
  * 仅默认目录 + auto-worktree 的**异步**提交：`ds` 必须已注册进 activeSessions 且处于
  * `pendingRepo` 挂起态（prompt 已 buffer，入站路由不会去抢 fork——见 daemon.ts pendingRepo
  * 分支），本函数在**关键路径之外**（调用方 `void` 掉、立即返回）跑：
- *   1) 在 `baseDir` 建独立 worktree（非 git / 失败 → 回退 baseDir，均经 `notify` 发提示）
+ *   1) 在 `baseDir` 建独立 worktree（非 git / 失败 → 回退 baseDir，均经 `notify` 发提示；
+ *      但**文件沙盒开启时 fail-closed**：抛 {@link AutoWorktreeFailClosedError}，本函数
+ *      拒绝在真实默认目录启动、关闭挂起会话并提示用户——沙盒把 workingDir 直绑真实目录，
+ *      回退等于让 Agent 写入污染真实项目）
  *   2) 用与「选仓库卡」完全相同的 {@link commitRepoSelection} 提交该目录并 fork——复用其
  *      prompt 重建（会 fold 进等待期间 buffer 的后续消息）、代际守卫、僵尸防护。
  *
  * 这样避免了把 git fetch（可长达 30s）同步塞进 spawn/fork 链路的三宗罪：放大重复 spawn
  * 竞态、worker=null 期间被路由在**基目录**抢 fork、阻塞 dashboard/webhook 响应。
  *
- * 永不抛出：worktree 失败已在内部回退；commitRepoSelection 异常被兜底 log（会话仍留在
- * pendingRepo，用户可 /repo 自救），绝不让 unhandled rejection 掀掉 daemon。
+ * 永不抛出：worktree 失败已在内部回退或 fail-closed 收尾；commitRepoSelection 异常被兜底
+ * log（会话仍留在 pendingRepo，用户可 /repo 自救），绝不让 unhandled rejection 掀掉 daemon。
  */
 export async function runAutoWorktreeCommit(deps: {
   ds: DaemonSession;
@@ -903,6 +907,27 @@ export async function runAutoWorktreeCommit(deps: {
       { suppressConfirmReply: true },
     ));
   } catch (e) {
+    if (e instanceof AutoWorktreeFailClosedError) {
+      // Fail-closed: the file sandbox is on and the auto-worktree could not be
+      // created. Starting in the real default dir would let the agent's writes
+      // land in the real project (the sandbox binds workingDir read-write to
+      // the host — a sandbox escape), so the session is refused, not degraded.
+      // Close the never-started pending session and tell the user how to fix.
+      logger.warn(`[${tag(ds)}] auto-worktree fail-closed (sandbox on, session refused): ${e.reason}`);
+      try {
+        await notify(t('worktree.auto_fail_closed', { dir: baseDir, error: e.reason }, localeForBot(larkAppId)));
+      } catch { /* notices are best-effort — never mask the refusal */ }
+      ds.pendingRepo = false;
+      ds.pendingRepoCommitInFlight = false;
+      const key = activeSessionKey(ds);
+      if (activeSessions.get(key) === ds) activeSessions.delete(key);
+      try { sessionStore.closeSession(ds.session.sessionId); } catch { /* already closed */ }
+      publishClosedSessionPatch(
+        ds.session.sessionId,
+        ds.session.closedAt ? Date.parse(ds.session.closedAt) : undefined,
+      );
+      return;
+    }
     // No recovery fork here: forking with an empty prompt would DROP the buffered
     // first turn (pendingPrompt lives only in-memory, not the message queue). Leave
     // the session as commitRepoSelection left it — the inbound router's worker=null

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -913,6 +913,15 @@ export async function runAutoWorktreeCommit(deps: {
       // land in the real project (the sandbox binds workingDir read-write to
       // the host — a sandbox escape), so the session is refused, not degraded.
       // Close the never-started pending session and tell the user how to fix.
+      //
+      // Same mid-build takeover guard as the success path below: a notifier
+      // adoption (etc.) can consume pendingRepo WHILE the up-to-30s build runs
+      // and start its own live session. Closing here would kill that freshly
+      // adopted session, so bail without touching it.
+      if (!ds.pendingRepo) {
+        logger.info(`[${tag(ds)}] auto-worktree fail-closed ignored — pendingRepo already consumed (session taken over): ${e.reason}`);
+        return;
+      }
       logger.warn(`[${tag(ds)}] auto-worktree fail-closed (sandbox on, session refused): ${e.reason}`);
       try {
         await notify(t('worktree.auto_fail_closed', { dir: baseDir, error: e.reason }, localeForBot(larkAppId)));

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -874,6 +874,7 @@ export async function runAutoWorktreeCommit(deps: {
     const { maybeCreateDefaultWorktree } = await import('../../services/default-worktree.js');
     const wt = await maybeCreateDefaultWorktree(larkAppId, baseDir, {
       isBotDefaultDir: true, title, prompt, locale: localeForBot(larkAppId), notify,
+      chatId: ds.chatId,
     });
     // The pendingRepo placeholder can legitimately be consumed WHILE this
     // up-to-30s build runs — e.g. the Codex-notifier「继续处理」callback adopts
@@ -926,6 +927,18 @@ export async function runAutoWorktreeCommit(deps: {
       try {
         await notify(t('worktree.auto_fail_closed', { dir: baseDir, error: e.reason }, localeForBot(larkAppId)));
       } catch { /* notices are best-effort — never mask the refusal */ }
+      // Re-check AFTER the await: the pendingRepo guard above only proves we
+      // owned the session when the notice STARTED. A notifier adoption (etc.)
+      // can consume pendingRepo WHILE the network notice is in flight and start
+      // its own live session on this same ds. The cleanup below is synchronous,
+      // so this recheck makes refusal+cleanup atomic with respect to that
+      // takeover — otherwise we would delete the freshly-adopted session from
+      // activeSessions and mark its durable record closed, orphaning the
+      // adopted worker (the exact race the preceding guard exists to prevent).
+      if (!ds.pendingRepo) {
+        logger.info(`[${tag(ds)}] auto-worktree fail-closed cleanup skipped — pendingRepo consumed during notice (session taken over): ${e.reason}`);
+        return;
+      }
       ds.pendingRepo = false;
       ds.pendingRepoCommitInFlight = false;
       const key = activeSessionKey(ds);

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -90,7 +90,7 @@ import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
 import { AutoWorktreeFailClosedError } from '../../services/default-worktree.js';
 import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-store.js';
-import { forkWorker, sendWorkerInput, sendWorkerSessionInput, killWorker, closeSession as closeWorkerPoolSession, teardownAuthoritativePersistentBackingBeforeClose, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, workerHasInitialized, sessionSupportsWebTerminal, readableTerminalUrlFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL, requestSessionRestart, isSessionTransferring, getDaemonStreamingCardUsageSnapshot, withActiveSessionKeyLock, type WorkerSessionReplyOptions } from '../../core/worker-pool.js';
+import { forkWorker, sendWorkerInput, sendWorkerSessionInput, killWorker, closeSession as closeWorkerPoolSession, teardownAuthoritativePersistentBackingBeforeClose, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, workerHasInitialized, sessionSupportsWebTerminal, readableTerminalUrlFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL, requestSessionRestart, isSessionTransferring, getDaemonStreamingCardUsageSnapshot, withActiveSessionKeyLock, freezeSessionSandboxDecision, type WorkerSessionReplyOptions } from '../../core/worker-pool.js';
 import { getSessionWorkingDir, buildNewTopicCliInput, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput, ensureSessionWhiteboard } from '../../core/session-manager.js';
 import { markInitialUserTurnPending } from '../../core/initial-user-turn.js';
 import { publishAttentionPatch, publishClosedSessionPatch, announcePendingRepoSession } from '../../core/session-activity.js';
@@ -865,6 +865,21 @@ export async function runAutoWorktreeCommit(deps: {
 }): Promise<void> {
   const { ds, anchor, larkAppId, baseDir, title, prompt, operatorOpenId, activeSessions, notify } = deps;
   ds.worktreeCreating = true;
+  // Freeze the worker's sandbox decision inputs on the session BEFORE the first
+  // git/notice await: the fail-closed gate below and the later fork must consume
+  // ONE snapshot. A dashboard `PUT /api/bot-sandbox` toggle landing during the
+  // up-to-30s build would otherwise make the gate degrade on the OLD value
+  // (fallback to the real default dir) while the fork adopts the NEW one and
+  // engages the local sandbox there — the write-escape the gate exists to
+  // prevent. Re-reading live config only after the fallback would still leave
+  // the recheck→fork await window, so the decision is frozen once, here.
+  try {
+    freezeSessionSandboxDecision(ds, getBot(ds.larkAppId).config);
+  } catch (e) {
+    // Bot deregistered between pending creation and here: the gate and the fork
+    // fail independently on getBot, so a missed freeze can't open the window.
+    logger.warn(`[${tag(ds)}] sandbox decision freeze skipped (bot unavailable): ${e instanceof Error ? e.message : e}`);
+  }
   // Surface the pending row NOW (all three callers funnel through here, so this is
   // the single place that guarantees the session is visible on SSE-only dashboards
   // during the up-to-30s build) — commitRepoSelection's forkWorker is what would
@@ -874,7 +889,12 @@ export async function runAutoWorktreeCommit(deps: {
     const { maybeCreateDefaultWorktree } = await import('../../services/default-worktree.js');
     const wt = await maybeCreateDefaultWorktree(larkAppId, baseDir, {
       isBotDefaultDir: true, title, prompt, locale: localeForBot(larkAppId), notify,
-      chatId: ds.chatId,
+      // The gate consumes the session's FROZEN decision (just recorded above),
+      // never live bot config — see freezeSessionSandboxDecision.
+      frozenSandboxDecision: {
+        sandbox: ds.session.sandbox === true,
+        readIsolation: ds.session.readIsolation === true,
+      },
     });
     // The pendingRepo placeholder can legitimately be consumed WHILE this
     // up-to-30s build runs — e.g. the Codex-notifier「继续处理」callback adopts

--- a/src/services/default-worktree.ts
+++ b/src/services/default-worktree.ts
@@ -11,7 +11,11 @@
  * The caller decides whether the resolved dir came from the bot's own default
  * (`isBotDefaultDir`) — only that layer opts in; oncall-bound / sibling-inherited
  * dirs never auto-worktree. A non-git dir or a creation failure degrades to the
- * base dir so the session STILL starts, with a heads-up notice for the chat.
+ * base dir so the session STILL starts, with a heads-up notice for the chat —
+ * UNLESS the file sandbox is enabled, in which case the failure is fail-closed
+ * (see {@link AutoWorktreeFailClosedError}): falling back to the real default dir
+ * would let the agent's writes land in the real project, defeating the isolation
+ * the sandbox promises.
  *
  * ALL user-facing notices are posted from here via the caller-supplied `notify`
  * callback (best-effort — a failed send never propagates), so the three spawn
@@ -30,6 +34,24 @@ import { worktreeSlugFromContextAI } from './worktree-slug-ai.js';
 import { t } from '../i18n/index.js';
 import type { Locale } from '../i18n/types.js';
 import { logger } from '../utils/logger.js';
+
+/**
+ * Raised when auto-worktree cannot be created AND the file sandbox is enabled.
+ *
+ * The file sandbox (bwrap/Seatbelt DIRECT mode) binds `workingDir` read-write
+ * to the REAL host directory — the auto-worktree is the only thing keeping a
+ * session's writes out of the real project. Degrading to the base dir on a
+ * worktree failure would silently defeat that isolation (the agent's new files
+ * would land in the real project — a sandbox escape), so the spawn is refused
+ * instead. The caller ({@link import('../im/lark/card-handler.js').runAutoWorktreeCommit})
+ * closes the pending session and surfaces `reason` to the chat.
+ */
+export class AutoWorktreeFailClosedError extends Error {
+  constructor(public readonly reason: string) {
+    super(reason);
+    this.name = 'AutoWorktreeFailClosedError';
+  }
+}
 
 export interface AutoWorktreeResult {
   /** Dir to spawn the session into: the new worktree on success, else `baseDir`
@@ -64,7 +86,11 @@ export function botAutoWorktreeEnabled(larkAppId: string): boolean {
 /**
  * Given a resolved spawn dir, create a fresh linked worktree off it when the bot
  * opts in AND `isBotDefaultDir` is true. Otherwise returns `baseDir` unchanged.
- * Never throws — a non-git dir or git failure degrades to `baseDir` with a notice.
+ * Never throws on a non-git dir / git failure UNLESS the file sandbox is on —
+ * see {@link AutoWorktreeFailClosedError}: with the sandbox enabled, a fallback
+ * to the real default dir would let the agent's writes land in the real project
+ * (the sandbox binds workingDir read-write to the host), so the spawn is
+ * refused instead of degrading.
  */
 export async function maybeCreateDefaultWorktree(
   larkAppId: string,
@@ -74,6 +100,14 @@ export async function maybeCreateDefaultWorktree(
   if (!ctx.isBotDefaultDir || !botAutoWorktreeEnabled(larkAppId)) {
     return { dir: baseDir };
   }
+  // Fail-closed when the FILE SANDBOX is on: the sandbox wraps the CLI with
+  // workingDir bound read-write to the real host dir (DIRECT mode — the sandbox
+  // protects everything OUTSIDE the whitelist, not the project itself). The
+  // auto-worktree is therefore the only barrier between the agent and the real
+  // project; a silent fallback to baseDir on failure would be a sandbox escape.
+  // BOTMUX_SANDBOX=1 forces the sandbox on regardless of the bot flag (testing).
+  const failClosed = process.env.BOTMUX_SANDBOX === '1'
+    || (() => { try { return getBot(larkAppId).config.sandbox === true; } catch { return false; } })();
   const notify = async (msg: string) => {
     if (!ctx.notify) return;
     try { await ctx.notify(msg); } catch { /* notices are best-effort — never fail a session start */ }
@@ -83,8 +117,10 @@ export async function maybeCreateDefaultWorktree(
   // fallback directly WITHOUT a preceding "creating…" (which would be misleading),
   // and skip the doomed createRepoWorktree call entirely.
   if (!(await isGitWorkTree(baseDir))) {
-    logger.warn(`[auto-worktree:${larkAppId}] default dir is not a git work tree, using it as-is: ${baseDir}`);
-    await notify(t('worktree.auto_fallback', { dir: baseDir, error: t('worktree.err_not_git', undefined, ctx.locale) }, ctx.locale));
+    const reason = t('worktree.err_not_git', undefined, ctx.locale);
+    logger.warn(`[auto-worktree:${larkAppId}] default dir is not a git work tree${failClosed ? ' (fail-closed, refusing base dir)' : ', using it as-is'}: ${baseDir}`);
+    if (failClosed) throw new AutoWorktreeFailClosedError(reason);
+    await notify(t('worktree.auto_fallback', { dir: baseDir, error: reason }, ctx.locale));
     return { dir: baseDir };
   }
 
@@ -116,7 +152,8 @@ export async function maybeCreateDefaultWorktree(
     return { dir: creation.path };
   } catch (e) {
     const error = e instanceof Error ? e.message : String(e);
-    logger.warn(`[auto-worktree:${larkAppId}] failed for ${baseDir}, falling back to base dir: ${error}`);
+    logger.warn(`[auto-worktree:${larkAppId}] failed for ${baseDir}${failClosed ? ' (fail-closed, refusing base dir)' : ', falling back to base dir'}: ${error}`);
+    if (failClosed) throw new AutoWorktreeFailClosedError(error);
     await notify(t('worktree.auto_fallback', { dir: baseDir, error }, ctx.locale));
     return { dir: baseDir };
   }

--- a/src/services/default-worktree.ts
+++ b/src/services/default-worktree.ts
@@ -106,8 +106,12 @@ export async function maybeCreateDefaultWorktree(
   // auto-worktree is therefore the only barrier between the agent and the real
   // project; a silent fallback to baseDir on failure would be a sandbox escape.
   // BOTMUX_SANDBOX=1 forces the sandbox on regardless of the bot flag (testing).
+  // Legacy `readIsolation` is auto-migrated to `sandbox` at daemon startup, but
+  // the worker still honors it for an unmigrated read-only BOTS_CONFIG
+  // (sandboxRequested = sandbox || readIsolation || BOTMUX_SANDBOX) — match that
+  // union so fail-closed tracks the REAL sandbox state, not just the new flag.
   const failClosed = process.env.BOTMUX_SANDBOX === '1'
-    || (() => { try { return getBot(larkAppId).config.sandbox === true; } catch { return false; } })();
+    || (() => { try { const c = getBot(larkAppId).config; return c.sandbox === true || c.readIsolation === true; } catch { return false; } })();
   const notify = async (msg: string) => {
     if (!ctx.notify) return;
     try { await ctx.notify(msg); } catch { /* notices are best-effort — never fail a session start */ }

--- a/src/services/default-worktree.ts
+++ b/src/services/default-worktree.ts
@@ -15,7 +15,10 @@
  * UNLESS the file sandbox is enabled, in which case the failure is fail-closed
  * (see {@link AutoWorktreeFailClosedError}): falling back to the real default dir
  * would let the agent's writes land in the real project, defeating the isolation
- * the sandbox promises.
+ * the sandbox promises. The riff REMOTE backend is exempt: it has no local CLI
+ * process (the agent runs in riff's own remote sandbox), so the local-escape
+ * rationale does not apply and it keeps degrading — matching the worker's
+ * `sandboxRequested = !riffRemoteBackend && …`.
  *
  * ALL user-facing notices are posted from here via the caller-supplied `notify`
  * callback (best-effort — a failed send never propagates), so the three spawn
@@ -36,7 +39,10 @@ import type { Locale } from '../i18n/types.js';
 import { logger } from '../utils/logger.js';
 
 /**
- * Raised when auto-worktree cannot be created AND the file sandbox is enabled.
+ * Raised when auto-worktree cannot be created AND the file sandbox is enabled
+ * on a LOCAL backend. The riff remote backend is exempt (no local CLI process
+ * — the agent's writes land in riff's own remote sandbox, never the real local
+ * dir), matching the worker's `sandboxRequested = !riffRemoteBackend && …`.
  *
  * The file sandbox (bwrap/Seatbelt DIRECT mode) binds `workingDir` read-write
  * to the REAL host directory — the auto-worktree is the only thing keeping a
@@ -86,11 +92,11 @@ export function botAutoWorktreeEnabled(larkAppId: string): boolean {
 /**
  * Given a resolved spawn dir, create a fresh linked worktree off it when the bot
  * opts in AND `isBotDefaultDir` is true. Otherwise returns `baseDir` unchanged.
- * Never throws on a non-git dir / git failure UNLESS the file sandbox is on —
- * see {@link AutoWorktreeFailClosedError}: with the sandbox enabled, a fallback
- * to the real default dir would let the agent's writes land in the real project
- * (the sandbox binds workingDir read-write to the host), so the spawn is
- * refused instead of degrading.
+ * Never throws on a non-git dir / git failure UNLESS the file sandbox is on
+ * (local backend only — riff is exempt, see below): with the sandbox enabled,
+ * a fallback to the real default dir would let the agent's writes land in the
+ * real project (the sandbox binds workingDir read-write to the host), so the
+ * spawn is refused instead of degrading.
  */
 export async function maybeCreateDefaultWorktree(
   larkAppId: string,
@@ -110,8 +116,21 @@ export async function maybeCreateDefaultWorktree(
   // the worker still honors it for an unmigrated read-only BOTS_CONFIG
   // (sandboxRequested = sandbox || readIsolation || BOTMUX_SANDBOX) — match that
   // union so fail-closed tracks the REAL sandbox state, not just the new flag.
+  // The worker's sandboxRequested ALSO excludes the riff remote backend
+  // (`!riffRemoteBackend` — localSandboxApplies): riff has no local CLI process,
+  // the agent runs in riff's own remote sandbox and its writes never touch the
+  // real local dir, so the escape rationale does not apply and the old graceful
+  // fallback must keep working for riff bots.
   const failClosed = process.env.BOTMUX_SANDBOX === '1'
-    || (() => { try { const c = getBot(larkAppId).config; return c.sandbox === true || c.readIsolation === true; } catch { return false; } })();
+    || (() => {
+      try {
+        const c = getBot(larkAppId).config;
+        if (c.sandbox !== true && c.readIsolation !== true) return false;
+        return resolvePairedSpawnBackendType(
+          c.cliId, undefined, c.backendType, config.daemon.backendType,
+        ) !== 'riff';
+      } catch { return false; }
+    })();
   const notify = async (msg: string) => {
     if (!ctx.notify) return;
     try { await ctx.notify(msg); } catch { /* notices are best-effort — never fail a session start */ }

--- a/src/services/default-worktree.ts
+++ b/src/services/default-worktree.ts
@@ -111,26 +111,26 @@ export async function maybeCreateDefaultWorktree(
   // protects everything OUTSIDE the whitelist, not the project itself). The
   // auto-worktree is therefore the only barrier between the agent and the real
   // project; a silent fallback to baseDir on failure would be a sandbox escape.
-  // BOTMUX_SANDBOX=1 forces the sandbox on regardless of the bot flag (testing).
-  // Legacy `readIsolation` is auto-migrated to `sandbox` at daemon startup, but
-  // the worker still honors it for an unmigrated read-only BOTS_CONFIG
-  // (sandboxRequested = sandbox || readIsolation || BOTMUX_SANDBOX) — match that
-  // union so fail-closed tracks the REAL sandbox state, not just the new flag.
-  // The worker's sandboxRequested ALSO excludes the riff remote backend
-  // (`!riffRemoteBackend` — localSandboxApplies): riff has no local CLI process,
-  // the agent runs in riff's own remote sandbox and its writes never touch the
-  // real local dir, so the escape rationale does not apply and the old graceful
-  // fallback must keep working for riff bots.
-  const failClosed = process.env.BOTMUX_SANDBOX === '1'
-    || (() => {
-      try {
-        const c = getBot(larkAppId).config;
-        if (c.sandbox !== true && c.readIsolation !== true) return false;
-        return resolvePairedSpawnBackendType(
-          c.cliId, undefined, c.backendType, config.daemon.backendType,
-        ) !== 'riff';
-      } catch { return false; }
-    })();
+  //
+  // Match the worker's sandboxRequested union EXACTLY (worker.ts):
+  //   sandboxRequested = !riffRemoteBackend && (sandbox || readIsolation || BOTMUX_SANDBOX)
+  // - `readIsolation` is in the union because the worker still honors it for an
+  //   unmigrated BOTS_CONFIG (it's auto-migrated to `sandbox` at daemon startup,
+  //   but a read-only config can still carry the legacy flag).
+  // - The riff exemption MUST wrap the WHOLE union: riff has no local CLI process
+  //   (the agent runs in riff's own remote sandbox, its writes never touch the
+  //   real local dir), so the escape rationale does not apply and the old graceful
+  //   fallback must keep working for riff bots — even when BOTMUX_SANDBOX=1.
+  const failClosed = (() => {
+    try {
+      const c = getBot(larkAppId).config;
+      const riff = resolvePairedSpawnBackendType(
+        c.cliId, undefined, c.backendType, config.daemon.backendType,
+      ) === 'riff';
+      if (riff) return false;
+      return c.sandbox === true || c.readIsolation === true || process.env.BOTMUX_SANDBOX === '1';
+    } catch { return false; }
+  })();
   const notify = async (msg: string) => {
     if (!ctx.notify) return;
     try { await ctx.notify(msg); } catch { /* notices are best-effort — never fail a session start */ }

--- a/src/services/default-worktree.ts
+++ b/src/services/default-worktree.ts
@@ -15,10 +15,10 @@
  * UNLESS the file sandbox is enabled, in which case the failure is fail-closed
  * (see {@link AutoWorktreeFailClosedError}): falling back to the real default dir
  * would let the agent's writes land in the real project, defeating the isolation
- * the sandbox promises. The riff REMOTE backend is exempt: it has no local CLI
- * process (the agent runs in riff's own remote sandbox), so the local-escape
+ * the sandbox promises. A REMOTE backend is exempt: it has no local CLI process
+ * (the agent runs in the backend's own remote sandbox), so the local-escape
  * rationale does not apply and it keeps degrading — matching the worker's
- * `sandboxRequested = !riffRemoteBackend && …`.
+ * `sandboxRequested` via the shared `localSandboxRequested` predicate.
  *
  * ALL user-facing notices are posted from here via the caller-supplied `notify`
  * callback (best-effort — a failed send never propagates), so the three spawn
@@ -32,6 +32,10 @@
 import { getBot } from '../bot-registry.js';
 import { config } from '../config.js';
 import { resolvePairedSpawnBackendType } from '../core/persistent-backend.js';
+import { larkTransportEnabled } from '../core/types.js';
+import { sanitizePerBotEnv } from '../core/per-bot-env.js';
+import { localSandboxRequested } from '../adapters/backend/sandbox.js';
+import { buildEffectiveMojoConfig, normalizeMojoConfig } from '../adapters/backend/mojo-types.js';
 import { createRepoWorktree, isGitWorkTree, pushWorktreeBranch } from './git-worktree.js';
 import { worktreeSlugFromContextAI } from './worktree-slug-ai.js';
 import { t } from '../i18n/index.js';
@@ -40,9 +44,10 @@ import { logger } from '../utils/logger.js';
 
 /**
  * Raised when auto-worktree cannot be created AND the file sandbox is enabled
- * on a LOCAL backend. The riff remote backend is exempt (no local CLI process
- * — the agent's writes land in riff's own remote sandbox, never the real local
- * dir), matching the worker's `sandboxRequested = !riffRemoteBackend && …`.
+ * on a LOCAL backend. A remote backend (riff / provably-remote mojo) is exempt
+ * (no local CLI process — the agent's writes land in the backend's own remote
+ * sandbox, never the real local dir), matching the worker's `sandboxRequested`
+ * via the shared `localSandboxRequested` predicate.
  *
  * The file sandbox (bwrap/Seatbelt DIRECT mode) binds `workingDir` read-write
  * to the REAL host directory — the auto-worktree is the only thing keeping a
@@ -72,6 +77,13 @@ export interface MaybeCreateWorktreeCtx {
   locale: Locale;
   /** Best-effort chat notice sink. Omit for silent (e.g. HTTP-virtual sessions). */
   notify?: (message: string) => Promise<unknown> | void;
+  /**
+   * The session's chatId, when known at this point. Used to detect a no-transport
+   * session (apiOnly bot OR HTTP virtual chat), which forkWorker forces
+   * readIsolation on — that forced isolation engages the local sandbox even with
+   * no explicit sandbox flag, so fail-closed must track it here too.
+   */
+  chatId?: string;
 }
 
 /**
@@ -93,10 +105,10 @@ export function botAutoWorktreeEnabled(larkAppId: string): boolean {
  * Given a resolved spawn dir, create a fresh linked worktree off it when the bot
  * opts in AND `isBotDefaultDir` is true. Otherwise returns `baseDir` unchanged.
  * Never throws on a non-git dir / git failure UNLESS the file sandbox is on
- * (local backend only — riff is exempt, see below): with the sandbox enabled,
- * a fallback to the real default dir would let the agent's writes land in the
- * real project (the sandbox binds workingDir read-write to the host), so the
- * spawn is refused instead of degrading.
+ * (local backend only — a remote backend is exempt, see below): with the sandbox
+ * enabled, a fallback to the real default dir would let the agent's writes land
+ * in the real project (the sandbox binds workingDir read-write to the host), so
+ * the spawn is refused instead of degrading.
  */
 export async function maybeCreateDefaultWorktree(
   larkAppId: string,
@@ -112,23 +124,54 @@ export async function maybeCreateDefaultWorktree(
   // auto-worktree is therefore the only barrier between the agent and the real
   // project; a silent fallback to baseDir on failure would be a sandbox escape.
   //
-  // Match the worker's sandboxRequested union EXACTLY (worker.ts):
-  //   sandboxRequested = !riffRemoteBackend && (sandbox || readIsolation || BOTMUX_SANDBOX)
+  // Reuse the worker's EXACT sandbox-request decision via the shared
+  // localSandboxRequested predicate (worker.ts computes sandboxRequested with
+  // the same call), so this gate can never drift from the worker's real sandbox
+  // state again:
+  //   localSandboxApplies(backend, mojoConfig) && (sandbox || readIsolation || noTransport || BOTMUX_SANDBOX)
+  // - The REMOTE exemption wraps the WHOLE union: riff, and a PROVABLY remote
+  //   mojo session (#803), have no local CLI process (the agent runs in the
+  //   backend's own remote sandbox, its writes never touch the real local dir),
+  //   so the escape rationale does not apply and the old graceful fallback must
+  //   keep working there — even when BOTMUX_SANDBOX=1.
+  // - mojo is NOT exempt by name alone: the proof needs the SAME effective
+  //   config the worker builds (buildEffectiveMojoConfig) — cloud on, localDaemon
+  //   off, no top-level wrapperCli, no unprovable merged env. A local mojo
+  //   session stays fail-closed.
   // - `readIsolation` is in the union because the worker still honors it for an
   //   unmigrated BOTS_CONFIG (it's auto-migrated to `sandbox` at daemon startup,
   //   but a read-only config can still carry the legacy flag).
-  // - The riff exemption MUST wrap the WHOLE union: riff has no local CLI process
-  //   (the agent runs in riff's own remote sandbox, its writes never touch the
-  //   real local dir), so the escape rationale does not apply and the old graceful
-  //   fallback must keep working for riff bots — even when BOTMUX_SANDBOX=1.
+  // - `noTransport` mirrors forkWorker's forced readIsolation for a no-transport
+  //   session (apiOnly bot or HTTP virtual chat — worker-pool.ts), which engages
+  //   the local sandbox even with no explicit sandbox flag.
   const failClosed = (() => {
     try {
       const c = getBot(larkAppId).config;
-      const riff = resolvePairedSpawnBackendType(
+      const effectiveBackend = resolvePairedSpawnBackendType(
         c.cliId, undefined, c.backendType, config.daemon.backendType,
-      ) === 'riff';
-      if (riff) return false;
-      return c.sandbox === true || c.readIsolation === true || process.env.BOTMUX_SANDBOX === '1';
+      );
+      // Build the SAME effective mojo config the worker builds (worker.ts →
+      // buildEffectiveMojoConfig): the remote proof needs the merged
+      // top-level/mojo env AND the top-level wrapperCli, not just the mojo
+      // block. A narrower snapshot would re-open the bypass — a top-level
+      // wrapperCli or a PATH in the merged env voids the cloud proof. An
+      // invalid block is treated as "not provably remote" (fail-closed).
+      const mojoValidation = normalizeMojoConfig(c.mojo);
+      const effectiveMojo = effectiveBackend === 'mojo'
+        ? buildEffectiveMojoConfig(mojoValidation.ok ? mojoValidation.value : undefined, {
+            cliPathOverride: c.cliPathOverride,
+            env: c.env ? sanitizePerBotEnv(c.env) : undefined,
+            wrapperCli: c.wrapperCli,
+          })
+        : undefined;
+      return localSandboxRequested({
+        backendType: effectiveBackend,
+        mojoConfig: effectiveMojo,
+        sandbox: c.sandbox === true,
+        readIsolation: c.readIsolation === true,
+        noTransport: !larkTransportEnabled({ chatId: ctx.chatId ?? '', apiOnly: c.apiOnly }),
+        envSandboxEnabled: process.env.BOTMUX_SANDBOX === '1',
+      });
     } catch { return false; }
   })();
   const notify = async (msg: string) => {

--- a/src/services/default-worktree.ts
+++ b/src/services/default-worktree.ts
@@ -18,7 +18,11 @@
  * the sandbox promises. A REMOTE backend is exempt: it has no local CLI process
  * (the agent runs in the backend's own remote sandbox), so the local-escape
  * rationale does not apply and it keeps degrading — matching the worker's
- * `sandboxRequested` via the shared `localSandboxRequested` predicate.
+ * `sandboxRequested` via the shared `localSandboxRequested` predicate. The
+ * sandbox decision itself is FROZEN on the session at pending-session
+ * establishment (freezeSessionSandboxDecision) and handed in via
+ * `ctx.frozenSandboxDecision`, so a dashboard toggle landing during the build
+ * can't diverge this gate from the later fork.
  *
  * ALL user-facing notices are posted from here via the caller-supplied `notify`
  * callback (best-effort — a failed send never propagates), so the three spawn
@@ -32,7 +36,6 @@
 import { getBot } from '../bot-registry.js';
 import { config } from '../config.js';
 import { resolvePairedSpawnBackendType } from '../core/persistent-backend.js';
-import { larkTransportEnabled } from '../core/types.js';
 import { sanitizePerBotEnv } from '../core/per-bot-env.js';
 import { localSandboxRequested } from '../adapters/backend/sandbox.js';
 import { buildEffectiveMojoConfig, normalizeMojoConfig } from '../adapters/backend/mojo-types.js';
@@ -78,12 +81,16 @@ export interface MaybeCreateWorktreeCtx {
   /** Best-effort chat notice sink. Omit for silent (e.g. HTTP-virtual sessions). */
   notify?: (message: string) => Promise<unknown> | void;
   /**
-   * The session's chatId, when known at this point. Used to detect a no-transport
-   * session (apiOnly bot OR HTTP virtual chat), which forkWorker forces
-   * readIsolation on — that forced isolation engages the local sandbox even with
-   * no explicit sandbox flag, so fail-closed must track it here too.
+   * The session's FROZEN sandbox decision, recorded at pending-session
+   * establishment (freezeSessionSandboxDecision) — the SAME snapshot the later
+   * fork consumes. The gate's boolean arms (sandbox / readIsolation) read THIS,
+   * never live bot config: a dashboard `PUT /api/bot-sandbox` toggle landing
+   * during the up-to-30s build must not change the decision the fork will
+   * adopt (gate degrades on the old value while the fork isolates on the new
+   * one = a fail-open window). When omitted (legacy callers/tests) the gate
+   * falls back to live config, preserving the pre-freeze behavior.
    */
-  chatId?: string;
+  frozenSandboxDecision?: { sandbox: boolean; readIsolation: boolean };
 }
 
 /**
@@ -128,7 +135,14 @@ export async function maybeCreateDefaultWorktree(
   // localSandboxRequested predicate (worker.ts computes sandboxRequested with
   // the same call), so this gate can never drift from the worker's real sandbox
   // state again:
-  //   localSandboxApplies(backend, mojoConfig) && (sandbox || readIsolation || noTransport || BOTMUX_SANDBOX)
+  //   localSandboxApplies(backend, mojoConfig) && (sandbox || readIsolation || BOTMUX_SANDBOX)
+  // - The BOOLEAN arms (sandbox / readIsolation) come from the session's FROZEN
+  //   decision (ctx.frozenSandboxDecision, recorded at pending-session
+  //   establishment) — NOT live bot config. A dashboard sandbox toggle landing
+  //   during this build must not change the decision the fork will consume:
+  //   the gate degrading on the old value while the fork isolates on the new
+  //   one is the fail-open window the freeze closes (re-reading live config
+  //   only after the fallback would still leave the recheck→fork await window).
   // - The REMOTE exemption wraps the WHOLE union: riff, and a PROVABLY remote
   //   mojo session (#803), have no local CLI process (the agent runs in the
   //   backend's own remote sandbox, its writes never touch the real local dir),
@@ -141,9 +155,6 @@ export async function maybeCreateDefaultWorktree(
   // - `readIsolation` is in the union because the worker still honors it for an
   //   unmigrated BOTS_CONFIG (it's auto-migrated to `sandbox` at daemon startup,
   //   but a read-only config can still carry the legacy flag).
-  // - `noTransport` mirrors forkWorker's forced readIsolation for a no-transport
-  //   session (apiOnly bot or HTTP virtual chat — worker-pool.ts), which engages
-  //   the local sandbox even with no explicit sandbox flag.
   const failClosed = (() => {
     try {
       const c = getBot(larkAppId).config;
@@ -167,9 +178,8 @@ export async function maybeCreateDefaultWorktree(
       return localSandboxRequested({
         backendType: effectiveBackend,
         mojoConfig: effectiveMojo,
-        sandbox: c.sandbox === true,
-        readIsolation: c.readIsolation === true,
-        noTransport: !larkTransportEnabled({ chatId: ctx.chatId ?? '', apiOnly: c.apiOnly }),
+        sandbox: ctx.frozenSandboxDecision ? ctx.frozenSandboxDecision.sandbox : c.sandbox === true,
+        readIsolation: ctx.frozenSandboxDecision ? ctx.frozenSandboxDecision.readIsolation : c.readIsolation === true,
         envSandboxEnabled: process.env.BOTMUX_SANDBOX === '1',
       });
     } catch { return false; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -642,6 +642,17 @@ export interface Session {
   sandboxReadonlyPaths?: string[];
   /** Network access decision recorded alongside `sandbox` at session creation. */
   sandboxNetwork?: boolean;
+  /**
+   * Read-isolation decision RECORDED AT SESSION CREATION — the SAME freeze
+   * rationale as `sandbox`. The live bot flag (BotConfig.readIsolation) can be
+   * toggled later, but a session's isolation is frozen here so the auto-worktree
+   * fail-closed gate and the worker fork consume ONE snapshot: a toggle landing
+   * while a worktree build is in flight can't make the gate degrade on the old
+   * value while the fork isolates on the new one (a fail-open window). Undefined
+   * on sessions created before this field existed → the fork falls back to the
+   * live bot flag.
+   */
+  readIsolation?: boolean;
   /** Persisted adopt metadata — allows adopt sessions to survive daemon restarts.
    *  Either tmuxTarget (tmux backend) OR zellijSession+zellijPaneId (zellij). */
   adoptedFrom?: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -285,6 +285,7 @@ import {
   startOutboxWatcher,
   sandboxEnabled,
   localSandboxApplies,
+  localSandboxRequested,
 } from './adapters/backend/sandbox.js';
 import {
   DEVICE_AUTHORITY_DIRECTORY,
@@ -11959,8 +11960,23 @@ async function spawnCli(
     // locally, so the local sandbox stays on rather than being skipped.
     log('mojo runs tools locally (cloud not enabled, or localDaemon set) — keeping the local sandbox engaged');
   }
-  const sandboxRequested = !riffRemoteBackend
-    && (cfg.sandbox === true || cfg.readIsolation === true || sandboxEnabled());
+  // Shared with the auto-worktree fail-closed gate (services/default-worktree.ts):
+  // the SAME predicate decides "does the local file sandbox apply to this spawn",
+  // so the two can never drift again (the riff exemption once only existed here,
+  // and the mojo backend then repeated that drift for a provably-remote session).
+  // forkWorker already forces readIsolation=true for a no-transport session
+  // (worker-pool.ts), so that arm of the union is folded into cfg.readIsolation
+  // here; the noTransport arm exists for callers that decide BEFORE the SpawnOpts
+  // forcing exists (auto-worktree fail-closed).
+  const sandboxRequested = localSandboxRequested({
+    backendType: effectiveBackendType,
+    mojoConfig: effectiveBackendType === 'mojo'
+      ? (riffBackendConfig as EffectiveMojoConfig | undefined)
+      : undefined,
+    sandbox: cfg.sandbox === true,
+    readIsolation: cfg.readIsolation === true,
+    envSandboxEnabled: sandboxEnabled(),
+  });
   const backendIsolationGate = backendSandboxCompatibilityError({
     backendType: effectiveBackendType,
     fileSandboxRequested: sandboxRequested,

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -329,7 +329,10 @@ describe('API-only bot mode — bot-level primitive boundary (source lock)', () 
     // config reads bots.json like a normal chat (accepted trade-off — lateral
     // sibling-cred protection now depends on the owner enabling sandbox).
     const wp = readFileSync(resolve('src/core/worker-pool.ts'), 'utf8');
-    expect(wp).toContain('readIsolation: botCfg.readIsolation === true,');
+    // readIsolation is FROZEN at session creation (freezeSessionSandboxDecision)
+    // — the same snapshot the auto-worktree fail-closed gate consumes — with a
+    // live-config fallback only for sessions persisted before the freeze field.
+    expect(wp).toContain('readIsolation: ds.session.readIsolation ?? botCfg.readIsolation === true,');
     // The old forced-isolation disjunct is gone: readIsolation must NOT be tied to
     // transport state anymore.
     expect(wp).not.toContain('readIsolation: botCfg.readIsolation === true\n      || !larkTransportEnabled(');

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -175,6 +175,7 @@ import { maybeCreateDefaultWorktree, AutoWorktreeFailClosedError } from '../src/
 import { applyConfigField } from '../src/services/bot-config-store.js';
 import { deleteMessage } from '../src/im/lark/client.js';
 import { canOperate } from '../src/im/lark/event-dispatcher.js';
+import { publishClosedSessionPatch } from '../src/core/session-activity.js';
 import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
 import type { ProjectInfo } from '../src/services/project-scanner.js';
@@ -1313,6 +1314,54 @@ describe('repo select card — worktree open', () => {
     expect(closeSession).not.toHaveBeenCalled();
     expect(deps.activeSessions.get(sessionKey(ROOT_ID, APP_ID))).toBe(ds);
     expect(notify).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(killWorker).not.toHaveBeenCalled();
+    expect(ds.worktreeCreating).toBe(false);
+  });
+
+  it('runAutoWorktreeCommit fail-closed does NOT close a session taken over WHILE the refusal notice is in flight', async () => {
+    // P2 review: the refusal cleanup used to run AFTER `await notify()`. The
+    // pendingRepo guard only proved ownership when the notice STARTED — a notifier
+    // adoption can consume pendingRepo while the network notice is in flight and
+    // start its own live session on this same ds. The post-await cleanup then
+    // deleted the freshly-adopted session from activeSessions and marked its
+    // durable record closed, orphaning the adopted worker (the exact race the
+    // preceding guard exists to prevent). The cleanup must re-check pendingRepo
+    // after the await — the cleanup itself is synchronous, so the recheck makes
+    // refusal+cleanup atomic with respect to the takeover.
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: { killed: false } as any });
+    const { deps } = makeDeps(ds);
+    const notice = deferred<unknown>();
+    const notify = vi.fn(() => notice.promise);
+    vi.mocked(maybeCreateDefaultWorktree).mockRejectedValueOnce(
+      new AutoWorktreeFailClosedError('默认目录不是 git 仓库（或暂时无法确认）'),
+    );
+
+    const run = runAutoWorktreeCommit({
+      ds,
+      anchor: ROOT_ID,
+      larkAppId: APP_ID,
+      baseDir: '/repos/alpha',
+      activeSessions: deps.activeSessions,
+      notify,
+    });
+
+    // Wait until the refusal notice is IN FLIGHT (ownership held, cleanup not yet run).
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(ds.pendingRepo).toBe(true);
+
+    // Simulate the notifier adoption consuming pendingRepo while the notice is
+    // in flight, then let the notice settle.
+    ds.pendingRepo = false;
+    notice.resolve(undefined);
+    await run;
+
+    // The adopted session is untouched: not closed, still in the map, no closed
+    // patch — the recheck after the await caught the takeover.
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(deps.activeSessions.get(sessionKey(ROOT_ID, APP_ID))).toBe(ds);
+    expect(publishClosedSessionPatch).not.toHaveBeenCalled();
     expect(forkWorker).not.toHaveBeenCalled();
     expect(killWorker).not.toHaveBeenCalled();
     expect(ds.worktreeCreating).toBe(false);

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -143,9 +143,18 @@ vi.mock('../src/services/worktree-slug-ai.js', () => ({
   }),
 }));
 
-vi.mock('../src/services/default-worktree.js', () => ({
-  maybeCreateDefaultWorktree: vi.fn(async (_appId: string, baseDir: string) => ({ dir: `${baseDir}-wt` })),
-}));
+vi.mock('../src/services/default-worktree.js', () => {
+  class AutoWorktreeFailClosedError extends Error {
+    constructor(public readonly reason: string) {
+      super(reason);
+      this.name = 'AutoWorktreeFailClosedError';
+    }
+  }
+  return {
+    maybeCreateDefaultWorktree: vi.fn(async (_appId: string, baseDir: string) => ({ dir: `${baseDir}-wt` })),
+    AutoWorktreeFailClosedError,
+  };
+});
 
 vi.mock('@larksuiteoapi/node-sdk', () => ({
   Client: class { constructor() {} },
@@ -162,7 +171,7 @@ import { buildNewTopicCliInput, getAvailableBots, getSessionWorkingDir } from '.
 import { getBot } from '../src/bot-registry.js';
 import { createSession, closeSession, updateSession } from '../src/services/session-store.js';
 import { createRepoWorktree, pushWorktreeBranch, removeRepoWorktree } from '../src/services/git-worktree.js';
-import { maybeCreateDefaultWorktree } from '../src/services/default-worktree.js';
+import { maybeCreateDefaultWorktree, AutoWorktreeFailClosedError } from '../src/services/default-worktree.js';
 import { applyConfigField } from '../src/services/bot-config-store.js';
 import { deleteMessage } from '../src/im/lark/client.js';
 import { canOperate } from '../src/im/lark/event-dispatcher.js';
@@ -1229,6 +1238,43 @@ describe('repo select card — worktree open', () => {
     expect(forkWorker).not.toHaveBeenCalled();
     expect(killWorker).not.toHaveBeenCalled();
     expect(ds.workingDir).toBeUndefined();
+    expect(ds.worktreeCreating).toBe(false);
+  });
+
+  it('runAutoWorktreeCommit fail-closes when the sandbox is on and the worktree cannot be created', async () => {
+    // The file sandbox binds workingDir read-write to the real host dir, so a
+    // fallback to the real default dir on a worktree failure would be a sandbox
+    // escape. The session must be REFUSED (closed), not degraded to the real dir.
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+    const notify = vi.fn();
+    vi.mocked(maybeCreateDefaultWorktree).mockRejectedValueOnce(
+      new AutoWorktreeFailClosedError('默认目录不是 git 仓库（或暂时无法确认）'),
+    );
+
+    await runAutoWorktreeCommit({
+      ds,
+      anchor: ROOT_ID,
+      larkAppId: APP_ID,
+      baseDir: '/repos/alpha',
+      activeSessions: deps.activeSessions,
+      notify,
+    });
+
+    // No spawn in the real default dir.
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(killWorker).not.toHaveBeenCalled();
+    // The never-started pending session was closed and removed from the map.
+    expect(ds.pendingRepo).toBe(false);
+    expect(deps.activeSessions.get(sessionKey(ROOT_ID, APP_ID))).toBeUndefined();
+    expect(closeSession).toHaveBeenCalledWith('uuid-old');
+    // The user got a fail-closed notice naming the dir and the reason — not a
+    // "fell back to the default dir" notice.
+    expect(notify).toHaveBeenCalledTimes(1);
+    const notice = notify.mock.calls[0]![0] as string;
+    expect(notice).toContain('文件沙盒已开启');
+    expect(notice).toContain('/repos/alpha');
+    expect(notice).not.toContain('已回退');
     expect(ds.worktreeCreating).toBe(false);
   });
 

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -1278,6 +1278,46 @@ describe('repo select card — worktree open', () => {
     expect(ds.worktreeCreating).toBe(false);
   });
 
+  it('runAutoWorktreeCommit fail-closed does NOT close a session whose pendingRepo was consumed mid-build (takeover)', async () => {
+    // Same mid-build takeover window as the success-path bail test, but with a
+    // FAIL-CLOSED rejection: a notifier adoption consumes pendingRepo and starts
+    // its own live session while the (slow, failing) worktree build runs. The
+    // late refusal must NOT closeSession / publishClosedSessionPatch the freshly
+    // adopted session — that would kill a live session the user just started.
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: { killed: false } as any });
+    const { deps } = makeDeps(ds);
+    const notify = vi.fn();
+    const d = deferred<never>();
+    vi.mocked(maybeCreateDefaultWorktree).mockReturnValueOnce(
+      d.promise.then(() => { throw new AutoWorktreeFailClosedError('git fetch failed'); }) as any,
+    );
+
+    const run = runAutoWorktreeCommit({
+      ds,
+      anchor: ROOT_ID,
+      larkAppId: APP_ID,
+      baseDir: '/repos/alpha',
+      activeSessions: deps.activeSessions,
+      notify,
+    });
+    await vi.waitFor(() => expect(ds.worktreeCreating).toBe(true));
+
+    // Simulate the takeover consuming pendingRepo and owning the session.
+    ds.pendingRepo = false;
+    d.resolve(undefined as never);
+    await run;
+
+    // The adopted session is untouched: not closed, still in the map, no
+    // refusal notice (the adopted session IS running — "session refused" would
+    // be a lie), no fork/kill from this path.
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(deps.activeSessions.get(sessionKey(ROOT_ID, APP_ID))).toBe(ds);
+    expect(notify).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(killWorker).not.toHaveBeenCalled();
+    expect(ds.worktreeCreating).toBe(false);
+  });
+
   it('double click starts ONE background creation and commits once', async () => {
     const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
     const { deps, sessionReply } = makeDeps(ds);

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -98,6 +98,12 @@ vi.mock('../src/core/worker-pool.js', () => {
   deliverEphemeralOrReply: vi.fn(),
   closeSession: vi.fn(async () => ({ ok: true, outcome: 'closed', alreadyClosed: false })),
   withActiveSessionKeyLock,
+  // Simulate the real freeze: record the decision on the session so
+  // runAutoWorktreeCommit's frozenSandboxDecision ctx carries the snapshot.
+  freezeSessionSandboxDecision: vi.fn((ds: any, botCfg: any) => {
+    if (ds.session.sandbox === undefined) ds.session.sandbox = botCfg.sandbox === true;
+    if (ds.session.readIsolation === undefined) ds.session.readIsolation = botCfg.readIsolation === true;
+  }),
   CARD_POSTING_SENTINEL: '__posting__',
   };
 });
@@ -166,7 +172,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 // ─── Imports ──────────────────────────────────────────────────────────────
 
 import { handleCardAction, runAutoWorktreeCommit, type CardHandlerDeps } from '../src/im/lark/card-handler.js';
-import { forkWorker, killWorker, teardownAuthoritativePersistentBackingBeforeClose, deliverEphemeralOrReply, deliverWriteLinkCard, closeSession as closeWorkerPoolSession, withActiveSessionKeyLock } from '../src/core/worker-pool.js';
+import { forkWorker, killWorker, teardownAuthoritativePersistentBackingBeforeClose, deliverEphemeralOrReply, deliverWriteLinkCard, closeSession as closeWorkerPoolSession, withActiveSessionKeyLock, freezeSessionSandboxDecision } from '../src/core/worker-pool.js';
 import { buildNewTopicCliInput, getAvailableBots, getSessionWorkingDir } from '../src/core/session-manager.js';
 import { getBot } from '../src/bot-registry.js';
 import { createSession, closeSession, updateSession } from '../src/services/session-store.js';
@@ -1365,6 +1371,47 @@ describe('repo select card — worktree open', () => {
     expect(forkWorker).not.toHaveBeenCalled();
     expect(killWorker).not.toHaveBeenCalled();
     expect(ds.worktreeCreating).toBe(false);
+  });
+
+  it('runAutoWorktreeCommit freezes the sandbox decision BEFORE the worktree build and hands the snapshot to the gate', async () => {
+    // R2: the fail-closed gate and the later fork must consume ONE sandbox
+    // snapshot. runAutoWorktreeCommit freezes the decision on the session
+    // (freezeSessionSandboxDecision) before any git/notice await, and passes
+    // the frozen values to maybeCreateDefaultWorktree via frozenSandboxDecision.
+    // A dashboard sandbox toggle landing during the build then changes neither.
+    vi.mocked(getBot).mockImplementation(() => ({
+      config: { larkAppId: APP_ID, larkAppSecret: 'secret', cliId: 'claude-code', sandbox: true },
+      resolvedAllowedUsers: [],
+      botName: 'testbot',
+      botOpenId: 'ou_bot',
+    }) as any);
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+    const notify = vi.fn();
+    const gateCtx: any = {};
+    vi.mocked(maybeCreateDefaultWorktree).mockImplementationOnce(async (_app, _dir, ctx) => {
+      Object.assign(gateCtx, ctx);
+      return { dir: '/repos/alpha-wt' };
+    });
+
+    await runAutoWorktreeCommit({
+      ds,
+      anchor: ROOT_ID,
+      larkAppId: APP_ID,
+      baseDir: '/repos/alpha',
+      activeSessions: deps.activeSessions,
+      notify,
+    });
+
+    // The freeze ran and recorded the decision on the session.
+    expect(freezeSessionSandboxDecision).toHaveBeenCalledTimes(1);
+    expect(ds.session.sandbox).toBe(true);
+    // The gate received the FROZEN snapshot (not a live-config re-read).
+    expect(gateCtx.frozenSandboxDecision).toEqual({ sandbox: true, readIsolation: false });
+    // The freeze happened BEFORE the gate (no live-config window between them).
+    const freezeOrder = vi.mocked(freezeSessionSandboxDecision).mock.invocationCallOrder[0]!;
+    const gateOrder = vi.mocked(maybeCreateDefaultWorktree).mock.invocationCallOrder[0]!;
+    expect(freezeOrder).toBeLessThan(gateOrder);
   });
 
   it('double click starts ONE background creation and commits once', async () => {

--- a/test/default-worktree.test.ts
+++ b/test/default-worktree.test.ts
@@ -55,7 +55,7 @@ function makeRepo(name: string): string {
 async function loadWithBot(
   dir: string,
   autoWorktree: boolean,
-  agent: { cliId?: string; backendType?: string; sandbox?: boolean } = {},
+  agent: { cliId?: string; backendType?: string; sandbox?: boolean; readIsolation?: boolean } = {},
 ) {
   writeFileSync(configPath, JSON.stringify([{
     larkAppId: 'app_wt',
@@ -65,6 +65,7 @@ async function loadWithBot(
     defaultWorkingDir: dir,
     ...(autoWorktree ? { defaultWorkingDirAutoWorktree: true } : {}),
     ...(agent.sandbox ? { sandbox: true } : {}),
+    ...(agent.readIsolation ? { readIsolation: true } : {}),
   }], null, 2), 'utf-8');
   vi.resetModules();
   const registry = await import('../src/bot-registry.js');
@@ -186,6 +187,22 @@ describe('maybeCreateDefaultWorktree', () => {
     } finally {
       delete process.env.BOTMUX_SANDBOX;
     }
+  });
+
+  it('fail-closed: legacy readIsolation=true also refuses (worker treats it as sandbox-on)', async () => {
+    // The worker's sandboxRequested unions sandbox || readIsolation || BOTMUX_SANDBOX,
+    // so a legacy readIsolation bot IS sandboxed even when the new `sandbox` flag is
+    // absent (unmigrated read-only BOTS_CONFIG). fail-closed must track that union.
+    const plain = join(tempRoot, 'not-a-repo-riso');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, { readIsolation: true });
+    const notices: string[] = [];
+
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh', notify: (m) => { notices.push(m); },
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+
+    expect(notices).toHaveLength(0); // no fallback-to-real-dir notice
   });
 
   it('sandbox off: worktree creation failure still DEGRADES to base dir (no refusal)', async () => {

--- a/test/default-worktree.test.ts
+++ b/test/default-worktree.test.ts
@@ -220,6 +220,28 @@ describe('maybeCreateDefaultWorktree', () => {
     expect(notices.some(n => n.includes('回退'))).toBe(true); // fallback notice posted
   });
 
+  it('fail-closed does NOT apply to the riff remote backend: sandbox on still DEGRADES', async () => {
+    // The worker's sandboxRequested excludes riff (`!riffRemoteBackend` —
+    // localSandboxApplies): riff has no local CLI process, the agent runs in
+    // riff's own remote sandbox and its writes never touch the real local dir.
+    // fail-closed must track that REAL sandbox state — refusing a riff session
+    // on a worktree failure would brick a supported config (sandbox + riff) for
+    // a local-escape rationale that does not exist there.
+    const plain = join(tempRoot, 'not-a-repo-riff');
+    mkdirSync(plain);
+    // cliId 'riff' forces the riff backend through reconcileRiffBackendType.
+    const { mod } = await loadWithBot(plain, true, { cliId: 'riff', sandbox: true });
+    const notices: string[] = [];
+
+    const r = await mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh', notify: (m) => { notices.push(m); },
+    });
+
+    expect(r.dir).toBe(plain); // degraded to the base dir — riff session still starts
+    expect(notices.some(n => n.includes('回退'))).toBe(true); // fallback notice posted
+    expect(notices.some(n => n.includes('沙盒已开启'))).toBe(false); // no fail-closed refusal
+  });
+
   it('no-ops (no notice, dir unchanged) when the dir did not come from the bot default', async () => {
     const repo = makeRepo('proj');
     const { mod } = await loadWithBot(repo, true);

--- a/test/default-worktree.test.ts
+++ b/test/default-worktree.test.ts
@@ -242,6 +242,26 @@ describe('maybeCreateDefaultWorktree', () => {
     expect(notices.some(n => n.includes('沙盒已开启'))).toBe(false); // no fail-closed refusal
   });
 
+  it('fail-closed does NOT apply to riff even with BOTMUX_SANDBOX=1 (env must not bypass the riff exemption)', async () => {
+    // Regression: the BOTMUX_SANDBOX env check was short-circuiting OUTSIDE the
+    // riff guard, so a riff bot + BOTMUX_SANDBOX=1 fail-closed on a worktree
+    // failure — bricking a session the worker deliberately leaves unsandboxed
+    // (sandboxRequested = !riffRemoteBackend && (... || BOTMUX_SANDBOX)). The
+    // riff exemption must wrap the WHOLE union, env included.
+    const plain = join(tempRoot, 'not-a-repo-riff-env');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, { cliId: 'riff' }); // no sandbox flag
+    process.env.BOTMUX_SANDBOX = '1';
+    try {
+      const r = await mod.maybeCreateDefaultWorktree('app_wt', plain, {
+        isBotDefaultDir: true, locale: 'zh',
+      });
+      expect(r.dir).toBe(plain); // degraded — riff session still starts
+    } finally {
+      delete process.env.BOTMUX_SANDBOX;
+    }
+  });
+
   it('no-ops (no notice, dir unchanged) when the dir did not come from the bot default', async () => {
     const repo = makeRepo('proj');
     const { mod } = await loadWithBot(repo, true);

--- a/test/default-worktree.test.ts
+++ b/test/default-worktree.test.ts
@@ -55,7 +55,16 @@ function makeRepo(name: string): string {
 async function loadWithBot(
   dir: string,
   autoWorktree: boolean,
-  agent: { cliId?: string; backendType?: string; sandbox?: boolean; readIsolation?: boolean } = {},
+  agent: {
+    cliId?: string;
+    backendType?: string;
+    sandbox?: boolean;
+    readIsolation?: boolean;
+    apiOnly?: boolean;
+    wrapperCli?: string;
+    env?: Record<string, string>;
+    mojo?: Record<string, unknown>;
+  } = {},
 ) {
   writeFileSync(configPath, JSON.stringify([{
     larkAppId: 'app_wt',
@@ -66,6 +75,10 @@ async function loadWithBot(
     ...(autoWorktree ? { defaultWorkingDirAutoWorktree: true } : {}),
     ...(agent.sandbox ? { sandbox: true } : {}),
     ...(agent.readIsolation ? { readIsolation: true } : {}),
+    ...(agent.apiOnly ? { apiOnly: true } : {}),
+    ...(agent.wrapperCli ? { wrapperCli: agent.wrapperCli } : {}),
+    ...(agent.env ? { env: agent.env } : {}),
+    ...(agent.mojo ? { mojo: agent.mojo } : {}),
   }], null, 2), 'utf-8');
   vi.resetModules();
   const registry = await import('../src/bot-registry.js');
@@ -260,6 +273,137 @@ describe('maybeCreateDefaultWorktree', () => {
     } finally {
       delete process.env.BOTMUX_SANDBOX;
     }
+  });
+
+  it('fail-closed does NOT apply to a PROVABLY REMOTE mojo session (cloud on) — sandbox on still DEGRADES', async () => {
+    // Regression (maintainer review): the fail-closed predicate only exempted
+    // backend==='riff' and bricked a mojo {cloud:true} + sandbox bot on a
+    // worktree failure, even though the worker applies NO local sandbox to a
+    // provably-remote mojo session (localSandboxApplies → false). The gate now
+    // reuses the worker's shared localSandboxRequested predicate.
+    const plain = join(tempRoot, 'not-a-repo-mojo-remote');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, {
+      cliId: 'mojo', backendType: 'mojo', sandbox: true, mojo: { cloud: true },
+    });
+    const notices: string[] = [];
+
+    const r = await mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh', notify: (m) => { notices.push(m); },
+    });
+
+    expect(r.dir).toBe(plain); // degraded — the remote mojo session still starts
+    expect(notices.some(n => n.includes('回退'))).toBe(true); // fallback notice posted
+    expect(notices.some(n => n.includes('沙盒已开启'))).toBe(false); // no fail-closed refusal
+  });
+
+  it('fail-closed does NOT apply to remote mojo even with BOTMUX_SANDBOX=1 (exemption wraps the whole union)', async () => {
+    const plain = join(tempRoot, 'not-a-repo-mojo-remote-env');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, {
+      cliId: 'mojo', backendType: 'mojo', mojo: { cloud: true },
+    });
+    process.env.BOTMUX_SANDBOX = '1';
+    try {
+      const r = await mod.maybeCreateDefaultWorktree('app_wt', plain, {
+        isBotDefaultDir: true, locale: 'zh',
+      });
+      expect(r.dir).toBe(plain); // degraded — remote mojo session still starts
+    } finally {
+      delete process.env.BOTMUX_SANDBOX;
+    }
+  });
+
+  it('fail-closed DOES apply to a LOCAL mojo session (cloud off) — the name alone must not exempt', async () => {
+    // mojo is NOT unconditionally remote: without cloud:true the agent's tools
+    // run on the bot host, so the local sandbox (and the fail-closed gate) must
+    // stay engaged.
+    const plain = join(tempRoot, 'not-a-repo-mojo-local');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, {
+      cliId: 'mojo', backendType: 'mojo', sandbox: true, mojo: {}, // no cloud → local execution
+    });
+
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh',
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+  });
+
+  it('fail-closed DOES apply to mojo cloud when a top-level wrapperCli voids the remote proof', async () => {
+    // The remote proof needs the SAME effective config the worker builds: a
+    // top-level wrapperCli runs before the binary and can rewrite the env the
+    // decision depends on, so it voids the cloud proof. A narrower snapshot
+    // (mojo block only) would have missed this and skipped the local sandbox.
+    const plain = join(tempRoot, 'not-a-repo-mojo-wrapper');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, {
+      cliId: 'mojo', backendType: 'mojo', sandbox: true, wrapperCli: 'env AGENT_LOCAL_DAEMON=1 mojo',
+      mojo: { cloud: true },
+    });
+
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh',
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+  });
+
+  it('fail-closed DOES apply to mojo cloud when the merged env voids the remote proof', async () => {
+    // Same proof rule via the merged top-level/mojo env: any env key besides the
+    // canonical JWT name can redirect execution (PATH / loader hooks), so it
+    // voids the cloud proof and the local sandbox stays engaged.
+    const plain = join(tempRoot, 'not-a-repo-mojo-env');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, {
+      cliId: 'mojo', backendType: 'mojo', sandbox: true,
+      mojo: { cloud: true, env: { MOJO_PROOF_TEST_VAR: 'x' } },
+    });
+
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh',
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+  });
+
+  it('fail-closed: apiOnly bot with NO explicit sandbox flag REFUSES (forkWorker forces readIsolation on no-transport sessions)', async () => {
+    // P1 review: an apiOnly (core-only) bot has no Lark transport, so forkWorker
+    // forces readIsolation=true for it (worker-pool.ts) — the local sandbox IS
+    // engaged even with no sandbox flag. The fail-closed gate must track that
+    // forced isolation, or a worktree failure would fall back to the real
+    // default dir and launch the forced sandbox there (the exact escape this
+    // change prevents).
+    const plain = join(tempRoot, 'not-a-repo-apionly');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, { apiOnly: true }); // no sandbox flag
+
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh',
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+  });
+
+  it('fail-closed: HTTP virtual chat with NO explicit sandbox flag REFUSES (no-transport forced isolation)', async () => {
+    // Same forced-isolation rule for a synthetic HTTP virtual chat (webhook /
+    // trigger session): forkWorker forces readIsolation on it too.
+    const plain = join(tempRoot, 'not-a-repo-httpvirtual');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true); // no sandbox flag
+
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh', chatId: 'http_async_abc123',
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+  });
+
+  it('fail-closed does NOT apply to apiOnly + riff (the remote exemption wraps the no-transport arm too)', async () => {
+    // A no-transport session on a REMOTE backend still has no local CLI process,
+    // so the remote exemption must wrap the no-transport arm as well — refusing
+    // here would brick a supported config for a local-escape rationale that does
+    // not exist on riff.
+    const plain = join(tempRoot, 'not-a-repo-apionly-riff');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, { cliId: 'riff', apiOnly: true });
+
+    const r = await mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh',
+    });
+
+    expect(r.dir).toBe(plain); // degraded — riff session still starts
   });
 
   it('no-ops (no notice, dir unchanged) when the dir did not come from the bot default', async () => {

--- a/test/default-worktree.test.ts
+++ b/test/default-worktree.test.ts
@@ -7,6 +7,10 @@
  *   - git precheck: a non-git default dir falls back WITHOUT a premature
  *     "creating…" notice (the double-notice bug the review flagged)
  *   - notify ordering on the happy path (creating → created)
+ *   - fail-closed: when the file sandbox is on, a non-git dir or a worktree
+ *     creation failure REFUSES (AutoWorktreeFailClosedError) instead of
+ *     degrading to the real default dir (which would be a sandbox escape —
+ *     the sandbox binds workingDir read-write to the host)
  *
  * Run: pnpm vitest run test/default-worktree.test.ts
  */
@@ -51,7 +55,7 @@ function makeRepo(name: string): string {
 async function loadWithBot(
   dir: string,
   autoWorktree: boolean,
-  agent: { cliId?: string; backendType?: string } = {},
+  agent: { cliId?: string; backendType?: string; sandbox?: boolean } = {},
 ) {
   writeFileSync(configPath, JSON.stringify([{
     larkAppId: 'app_wt',
@@ -60,6 +64,7 @@ async function loadWithBot(
     ...(agent.backendType ? { backendType: agent.backendType } : {}),
     defaultWorkingDir: dir,
     ...(autoWorktree ? { defaultWorkingDirAutoWorktree: true } : {}),
+    ...(agent.sandbox ? { sandbox: true } : {}),
   }], null, 2), 'utf-8');
   vi.resetModules();
   const registry = await import('../src/bot-registry.js');
@@ -132,6 +137,70 @@ describe('maybeCreateDefaultWorktree', () => {
 
     expect(r.dir).toBe(plain);          // degrades to the base dir, session still starts
     expect(notices).toHaveLength(1);    // ONLY the fallback — no misleading "creating…" first
+  });
+
+  it('fail-closed: sandbox on + non-git default dir REFUSES (throws, no fallback to the real dir)', async () => {
+    const plain = join(tempRoot, 'not-a-repo-sbx');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true, { sandbox: true });
+    const notices: string[] = [];
+
+    // The sandbox binds workingDir read-write to the real host dir (DIRECT mode),
+    // so a fallback to baseDir would be a sandbox escape — the spawn is refused.
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh', notify: (m) => { notices.push(m); },
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+
+    // No fallback notice from the service — the caller (runAutoWorktreeCommit)
+    // surfaces the refusal + recovery hint and closes the pending session.
+    expect(notices).toHaveLength(0);
+  });
+
+  it('fail-closed: sandbox on + worktree creation failure REFUSES (throws, only the creating notice)', async () => {
+    // An empty git repo (init, no commits) passes isGitWorkTree but make
+    // createRepoWorktree throw ("fatal: not a valid object name: 'HEAD'").
+    const empty = join(tempRoot, 'empty-repo');
+    mkdirSync(empty);
+    execFileSync('git', ['init', '-b', 'master'], { cwd: empty, stdio: 'ignore' });
+    const { mod } = await loadWithBot(empty, true, { sandbox: true });
+    const notices: string[] = [];
+
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', empty, {
+      isBotDefaultDir: true, locale: 'zh', notify: (m) => { notices.push(m); },
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+
+    // Only the "creating…" heads-up went out; NO fallback-to-real-dir notice.
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain('worktree');
+  });
+
+  it('fail-closed: BOTMUX_SANDBOX=1 env also refuses even without the bot config flag', async () => {
+    const plain = join(tempRoot, 'not-a-repo-env');
+    mkdirSync(plain);
+    const { mod } = await loadWithBot(plain, true); // sandbox config flag OFF
+    process.env.BOTMUX_SANDBOX = '1';
+    try {
+      await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
+        isBotDefaultDir: true, locale: 'zh',
+      })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+    } finally {
+      delete process.env.BOTMUX_SANDBOX;
+    }
+  });
+
+  it('sandbox off: worktree creation failure still DEGRADES to base dir (no refusal)', async () => {
+    const empty = join(tempRoot, 'empty-repo-nosbx');
+    mkdirSync(empty);
+    execFileSync('git', ['init', '-b', 'master'], { cwd: empty, stdio: 'ignore' });
+    const { mod } = await loadWithBot(empty, true); // sandbox off
+    const notices: string[] = [];
+
+    const r = await mod.maybeCreateDefaultWorktree('app_wt', empty, {
+      isBotDefaultDir: true, locale: 'zh', notify: (m) => { notices.push(m); },
+    });
+
+    expect(r.dir).toBe(empty); // degraded to the base dir — session still starts
+    expect(notices.some(n => n.includes('回退'))).toBe(true); // fallback notice posted
   });
 
   it('no-ops (no notice, dir unchanged) when the dir did not come from the bot default', async () => {

--- a/test/default-worktree.test.ts
+++ b/test/default-worktree.test.ts
@@ -233,6 +233,97 @@ describe('maybeCreateDefaultWorktree', () => {
     expect(notices.some(n => n.includes('回退'))).toBe(true); // fallback notice posted
   });
 
+  it('fail-open window: sandbox off→on flip DURING the build is ignored — the gate consumes the frozen session snapshot', async () => {
+    // R3 regression: the gate used to compute fail-closed from LIVE bot config
+    // before any await, while the fork adopted the live value later. A dashboard
+    // PUT /api/bot-sandbox flipping sandbox off→on while the "creating…" notice
+    // was in flight made the gate degrade on the OLD value (fallback to the real
+    // default dir) while the fork engaged the local sandbox on the NEW value
+    // there — the write-escape the gate exists to prevent. The decision is now
+    // frozen at pending-session establishment (freezeSessionSandboxDecision) and
+    // handed to the gate via frozenSandboxDecision; a mid-build flip changes
+    // neither the gate nor the fork (both read the session snapshot).
+    const empty = join(tempRoot, 'empty-repo-flip');
+    mkdirSync(empty);
+    execFileSync('git', ['init', '-b', 'master'], { cwd: empty, stdio: 'ignore' });
+    const { registry, mod } = await loadWithBot(empty, true); // sandbox OFF at freeze time
+
+    // Simulate the pending-session freeze (runAutoWorktreeCommit does this before
+    // any git/notice await): snapshot the decision inputs ONCE.
+    const liveCfg = registry.getBot('app_wt').config;
+    const frozen = {
+      sandbox: liveCfg.sandbox === true,
+      readIsolation: liveCfg.readIsolation === true,
+    };
+    expect(frozen.sandbox).toBe(false);
+
+    const notices: string[] = [];
+    // Flip the LIVE config while the "creating…" notice is in flight — exactly
+    // what updateBotSandbox's in-memory publish does (bot.config.sandbox = true).
+    const flipDuringNotice = (m: string) => {
+      notices.push(m);
+      if (notices.length === 1) {
+        registry.getBot('app_wt').config.sandbox = true;
+      }
+    };
+
+    const r = await mod.maybeCreateDefaultWorktree('app_wt', empty, {
+      isBotDefaultDir: true, locale: 'zh', notify: flipDuringNotice,
+      frozenSandboxDecision: frozen,
+    });
+
+    // The flip really happened on the live config…
+    expect(registry.getBot('app_wt').config.sandbox).toBe(true);
+    // …but the gate consumed the FROZEN snapshot (sandbox:false), so it degrades
+    // instead of refusing — and the fork would read the same frozen session
+    // fields, so no sandbox engages on the real dir (no fallback escape).
+    expect(r.dir).toBe(empty);
+    expect(notices.some(n => n.includes('回退'))).toBe(true);
+
+    // Contrast: a decision computed from the NEW live config (what the OLD gate
+    // would have re-read after the fallback) now REFUSES — proving the flip is
+    // real and the freeze is what kept this build on the degraded path.
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', empty, {
+      isBotDefaultDir: true, locale: 'zh',
+      frozenSandboxDecision: { sandbox: true, readIsolation: false },
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+  });
+
+  it('fail-open window: sandbox on→off flip DURING the build is ignored — the gate still refuses on the frozen snapshot', async () => {
+    // The symmetric direction: frozen ON, live flips OFF mid-build. The gate must
+    // still refuse (fail-closed) — degrading would hand the fork a real dir while
+    // the frozen decision (which the fork consumes) keeps the sandbox engaged.
+    const empty = join(tempRoot, 'empty-repo-flip-off');
+    mkdirSync(empty);
+    execFileSync('git', ['init', '-b', 'master'], { cwd: empty, stdio: 'ignore' });
+    const { registry, mod } = await loadWithBot(empty, true, { sandbox: true });
+
+    const liveCfg = registry.getBot('app_wt').config;
+    const frozen = {
+      sandbox: liveCfg.sandbox === true,
+      readIsolation: liveCfg.readIsolation === true,
+    };
+    expect(frozen.sandbox).toBe(true);
+
+    const notices: string[] = [];
+    const flipDuringNotice = (m: string) => {
+      notices.push(m);
+      if (notices.length === 1) {
+        registry.getBot('app_wt').config.sandbox = false;
+      }
+    };
+
+    await expect(mod.maybeCreateDefaultWorktree('app_wt', empty, {
+      isBotDefaultDir: true, locale: 'zh', notify: flipDuringNotice,
+      frozenSandboxDecision: frozen,
+    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+
+    // The flip really happened…
+    expect(registry.getBot('app_wt').config.sandbox).toBe(false);
+    // …but the gate refused on the frozen ON decision (only the creating notice).
+    expect(notices).toHaveLength(1);
+  });
+
   it('fail-closed does NOT apply to the riff remote backend: sandbox on still DEGRADES', async () => {
     // The worker's sandboxRequested excludes riff (`!riffRemoteBackend` —
     // localSandboxApplies): riff has no local CLI process, the agent runs in
@@ -362,32 +453,37 @@ describe('maybeCreateDefaultWorktree', () => {
     })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
   });
 
-  it('fail-closed: apiOnly bot with NO explicit sandbox flag REFUSES (forkWorker forces readIsolation on no-transport sessions)', async () => {
-    // P1 review: an apiOnly (core-only) bot has no Lark transport, so forkWorker
-    // forces readIsolation=true for it (worker-pool.ts) — the local sandbox IS
-    // engaged even with no sandbox flag. The fail-closed gate must track that
-    // forced isolation, or a worktree failure would fall back to the real
-    // default dir and launch the forced sandbox there (the exact escape this
-    // change prevents).
+  it('apiOnly bot with NO explicit sandbox flag DEGRADES (no-transport sessions are no longer force-isolated)', async () => {
+    // #899 removed forkWorker's forced readIsolation for a no-transport session
+    // (apiOnly bot or HTTP virtual chat): disk read scope now follows the owner's
+    // own sandbox config, symmetric with a normal chat session. The worker
+    // therefore engages NO local sandbox here, so the fail-closed gate must not
+    // refuse either — degrading to the base dir is safe (nothing to escape from).
     const plain = join(tempRoot, 'not-a-repo-apionly');
     mkdirSync(plain);
     const { mod } = await loadWithBot(plain, true, { apiOnly: true }); // no sandbox flag
+    const notices: string[] = [];
 
-    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
-      isBotDefaultDir: true, locale: 'zh',
-    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+    const r = await mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh', notify: (m) => { notices.push(m); },
+    });
+
+    expect(r.dir).toBe(plain); // degraded — no local sandbox would have engaged
+    expect(notices.some(n => n.includes('回退'))).toBe(true);
   });
 
-  it('fail-closed: HTTP virtual chat with NO explicit sandbox flag REFUSES (no-transport forced isolation)', async () => {
-    // Same forced-isolation rule for a synthetic HTTP virtual chat (webhook /
-    // trigger session): forkWorker forces readIsolation on it too.
+  it('HTTP virtual chat with NO explicit sandbox flag DEGRADES (no forced isolation)', async () => {
+    // Same rule for a synthetic HTTP virtual chat (webhook / trigger session):
+    // no forced readIsolation anymore, so no fail-closed refusal.
     const plain = join(tempRoot, 'not-a-repo-httpvirtual');
     mkdirSync(plain);
     const { mod } = await loadWithBot(plain, true); // no sandbox flag
 
-    await expect(mod.maybeCreateDefaultWorktree('app_wt', plain, {
-      isBotDefaultDir: true, locale: 'zh', chatId: 'http_async_abc123',
-    })).rejects.toBeInstanceOf(mod.AutoWorktreeFailClosedError);
+    const r = await mod.maybeCreateDefaultWorktree('app_wt', plain, {
+      isBotDefaultDir: true, locale: 'zh',
+    });
+
+    expect(r.dir).toBe(plain); // degraded — no local sandbox would have engaged
   });
 
   it('fail-closed does NOT apply to apiOnly + riff (the remote exemption wraps the no-transport arm too)', async () => {

--- a/test/riff-sandbox-bypass.test.ts
+++ b/test/riff-sandbox-bypass.test.ts
@@ -6,7 +6,7 @@
  * Run:  pnpm vitest run test/riff-sandbox-bypass.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { localSandboxApplies } from '../src/adapters/backend/sandbox.js';
+import { localSandboxApplies, localSandboxRequested } from '../src/adapters/backend/sandbox.js';
 
 describe('localSandboxApplies', () => {
   it('bypasses the local file sandbox for the riff backend (remote sandbox, no local process)', () => {
@@ -16,6 +16,73 @@ describe('localSandboxApplies', () => {
   it('keeps the sandbox for local backends — fs-policy applies on BOTH platforms now', () => {
     expect(localSandboxApplies('pty')).toBe(true);
     expect(localSandboxApplies('tmux')).toBe(true);
+  });
+});
+
+describe('localSandboxRequested (shared worker ↔ auto-worktree fail-closed predicate)', () => {
+  // The ONE predicate both the worker (sandboxRequested) and the auto-worktree
+  // fail-closed gate use, so the two can never drift again. The remote exemption
+  // must wrap the WHOLE union (sandbox / readIsolation / noTransport / env), and
+  // mojo is exempt ONLY when provably fully remote.
+  it('requests the sandbox for a local backend with any union arm on', () => {
+    expect(localSandboxRequested({ backendType: 'pty', sandbox: true })).toBe(true);
+    expect(localSandboxRequested({ backendType: 'pty', readIsolation: true })).toBe(true);
+    expect(localSandboxRequested({ backendType: 'pty', noTransport: true })).toBe(true);
+    expect(localSandboxRequested({ backendType: 'pty', envSandboxEnabled: true })).toBe(true);
+  });
+
+  it('requests nothing for a local backend with every union arm off', () => {
+    expect(localSandboxRequested({ backendType: 'pty' })).toBe(false);
+    expect(localSandboxRequested({ backendType: 'tmux', sandbox: false, readIsolation: false })).toBe(false);
+  });
+
+  it('exempts riff with ANY union arm — the remote exemption wraps the whole union', () => {
+    expect(localSandboxRequested({ backendType: 'riff', sandbox: true })).toBe(false);
+    expect(localSandboxRequested({ backendType: 'riff', readIsolation: true })).toBe(false);
+    expect(localSandboxRequested({ backendType: 'riff', noTransport: true })).toBe(false);
+    expect(localSandboxRequested({ backendType: 'riff', envSandboxEnabled: true })).toBe(false);
+  });
+
+  it('exempts a PROVABLY remote mojo session (cloud on, localDaemon off, no wrapper, clean env)', () => {
+    // The deepcoldy regression: a mojo {cloud:true} + sandbox bot was refused by
+    // the fail-closed gate even though the worker applies NO local sandbox to it.
+    expect(localSandboxRequested({
+      backendType: 'mojo', mojoConfig: { cloud: true }, sandbox: true,
+    })).toBe(false);
+    expect(localSandboxRequested({
+      backendType: 'mojo', mojoConfig: { cloud: true }, envSandboxEnabled: true,
+    })).toBe(false);
+    expect(localSandboxRequested({
+      backendType: 'mojo', mojoConfig: { cloud: true }, noTransport: true,
+    })).toBe(false);
+  });
+
+  it('does NOT exempt mojo by name alone — a local mojo session stays fail-closed', () => {
+    expect(localSandboxRequested({ backendType: 'mojo', sandbox: true })).toBe(true);
+    expect(localSandboxRequested({ backendType: 'mojo', mojoConfig: {}, sandbox: true })).toBe(true);
+    expect(localSandboxRequested({
+      backendType: 'mojo', mojoConfig: { cloud: false }, sandbox: true,
+    })).toBe(true);
+  });
+
+  it('does NOT exempt mojo cloud when the remote proof is voided (localDaemon / wrapperCli / env)', () => {
+    // localDaemon explicitly opts into host execution.
+    expect(localSandboxRequested({
+      backendType: 'mojo', mojoConfig: { cloud: true, localDaemon: true }, sandbox: true,
+    })).toBe(true);
+    // A top-level wrapperCli runs before the binary and can rewrite the env the
+    // decision depends on — the proof must see it (EffectiveMojoConfig carries it).
+    expect(localSandboxRequested({
+      backendType: 'mojo', mojoConfig: { cloud: true, wrapperCli: 'wrap' }, sandbox: true,
+    })).toBe(true);
+    // Any env key besides the canonical JWT name voids the proof (PATH / loader
+    // hooks can change which binary executes).
+    expect(localSandboxRequested({
+      backendType: 'mojo', mojoConfig: { cloud: true, env: { PATH: '/tmp/fake' } }, sandbox: true,
+    })).toBe(true);
+    expect(localSandboxRequested({
+      backendType: 'mojo', mojoConfig: { cloud: true, env: { X_JWT_TOKEN: 'tok' } }, sandbox: true,
+    })).toBe(false); // the ONE exempt name
   });
 });
 

--- a/test/riff-sandbox-bypass.test.ts
+++ b/test/riff-sandbox-bypass.test.ts
@@ -22,12 +22,12 @@ describe('localSandboxApplies', () => {
 describe('localSandboxRequested (shared worker ↔ auto-worktree fail-closed predicate)', () => {
   // The ONE predicate both the worker (sandboxRequested) and the auto-worktree
   // fail-closed gate use, so the two can never drift again. The remote exemption
-  // must wrap the WHOLE union (sandbox / readIsolation / noTransport / env), and
-  // mojo is exempt ONLY when provably fully remote.
+  // must wrap the WHOLE union (sandbox / readIsolation / env), and mojo is
+  // exempt ONLY when provably fully remote. The no-transport arm was removed
+  // with #899 (forkWorker no longer force-isolates a no-transport session).
   it('requests the sandbox for a local backend with any union arm on', () => {
     expect(localSandboxRequested({ backendType: 'pty', sandbox: true })).toBe(true);
     expect(localSandboxRequested({ backendType: 'pty', readIsolation: true })).toBe(true);
-    expect(localSandboxRequested({ backendType: 'pty', noTransport: true })).toBe(true);
     expect(localSandboxRequested({ backendType: 'pty', envSandboxEnabled: true })).toBe(true);
   });
 
@@ -39,7 +39,6 @@ describe('localSandboxRequested (shared worker ↔ auto-worktree fail-closed pre
   it('exempts riff with ANY union arm — the remote exemption wraps the whole union', () => {
     expect(localSandboxRequested({ backendType: 'riff', sandbox: true })).toBe(false);
     expect(localSandboxRequested({ backendType: 'riff', readIsolation: true })).toBe(false);
-    expect(localSandboxRequested({ backendType: 'riff', noTransport: true })).toBe(false);
     expect(localSandboxRequested({ backendType: 'riff', envSandboxEnabled: true })).toBe(false);
   });
 
@@ -51,9 +50,6 @@ describe('localSandboxRequested (shared worker ↔ auto-worktree fail-closed pre
     })).toBe(false);
     expect(localSandboxRequested({
       backendType: 'mojo', mojoConfig: { cloud: true }, envSandboxEnabled: true,
-    })).toBe(false);
-    expect(localSandboxRequested({
-      backendType: 'mojo', mojoConfig: { cloud: true }, noTransport: true,
     })).toBe(false);
   });
 

--- a/test/session-sandbox-freeze.test.ts
+++ b/test/session-sandbox-freeze.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for freezeSessionSandboxDecision (core/worker-pool): the pending-
+ * session freeze that closes the auto-worktree fail-open window.
+ *
+ * The auto-worktree fail-closed gate runs BEFORE any git/notice await; the worker
+ * fork runs AFTER the up-to-30s build. Both must consume ONE sandbox snapshot.
+ * Freezing the decision inputs (sandbox / readIsolation + path lists) on the
+ * session at pending-session establishment — and making the fork read the
+ * session fields — means a dashboard `PUT /api/bot-sandbox` toggle landing
+ * mid-build changes NEITHER side: the gate can't degrade on the old value while
+ * the fork isolates on the new one (the write-escape the gate exists to
+ * prevent).
+ *
+ * Run: pnpm vitest run test/session-sandbox-freeze.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  process.env.SESSION_DATA_DIR =
+    `${process.env.TMPDIR ?? '/tmp'}/botmux-session-sandbox-freeze-${process.pid}`;
+  delete process.env.BOTMUX_SESSION_ID;
+  delete process.env.BOTMUX_LARK_APP_ID;
+  return { updateSession: vi.fn() };
+});
+
+vi.mock('../src/im/lark/client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/im/lark/client.js')>();
+  return { ...actual };
+});
+vi.mock('../src/services/session-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/session-store.js')>();
+  return { ...actual, updateSession: (...args: any[]) => mocks.updateSession(...args) };
+});
+vi.mock('../src/bot-registry.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/bot-registry.js')>();
+  return {
+    ...actual,
+    getBot: vi.fn(() => ({
+      config: { larkAppId: 'app-freeze', cliId: 'claude-code' },
+      botName: 'TestBot', botOpenId: 'ou_bot', resolvedAllowedUsers: [],
+    })),
+  };
+});
+
+import { freezeSessionSandboxDecision } from '../src/core/worker-pool.js';
+import type { DaemonSession } from '../src/core/types.js';
+import type { BotConfig } from '../src/bot-registry.js';
+
+function makeSession(): DaemonSession {
+  return {
+    session: {
+      sessionId: 'sess_freeze', chatId: 'oc_freeze', rootMessageId: 'om_freeze', title: 'freeze',
+      status: 'active', createdAt: new Date().toISOString(), scope: 'thread', chatType: 'group',
+      larkAppId: 'app_freeze', ownerOpenId: 'ou_owner', workingDir: '/tmp', cliId: 'claude-code',
+    },
+    worker: null, workerPort: null, workerToken: null, larkAppId: 'app_freeze',
+    chatId: 'oc_freeze', chatType: 'group', scope: 'thread', spawnedAt: Date.now(),
+    cliVersion: '1.0.0', lastMessageAt: Date.now(), hasHistory: false, workingDir: '/tmp',
+  } as DaemonSession;
+}
+
+function botCfg(overrides: Partial<BotConfig> = {}): BotConfig {
+  return { larkAppId: 'app_freeze', larkAppSecret: 'secret', ...overrides } as BotConfig;
+}
+
+beforeEach(() => {
+  mocks.updateSession.mockClear();
+});
+
+describe('freezeSessionSandboxDecision', () => {
+  it('records the live bot config on the session at freeze time and persists it', () => {
+    const ds = makeSession();
+    freezeSessionSandboxDecision(ds, botCfg({
+      sandbox: true, readIsolation: true, sandboxNetwork: false,
+      sandboxHidePaths: ['/secret'], sandboxReadonlyPaths: ['/ro'],
+    }));
+    expect(ds.session.sandbox).toBe(true);
+    expect(ds.session.readIsolation).toBe(true);
+    expect(ds.session.sandboxNetwork).toBe(false);
+    expect(ds.session.sandboxHidePaths).toEqual(['/secret']);
+    expect(ds.session.sandboxReadonlyPaths).toEqual(['/ro']);
+    expect(mocks.updateSession).toHaveBeenCalledWith(ds.session);
+  });
+
+  it('is FROZEN: a live sandbox off→on flip after the freeze does not change the recorded decision', () => {
+    // The fail-open window: freeze with sandbox OFF, then the dashboard flips
+    // the live bot config ON while the worktree build is in flight
+    // (updateBotSandbox publishes bot.config.sandbox = true immediately). The
+    // fork consumes ds.session.sandbox / ds.session.readIsolation — they must
+    // stay OFF, so no local sandbox engages on the real default dir.
+    const ds = makeSession();
+    const cfg = botCfg({ sandbox: false, readIsolation: false });
+    freezeSessionSandboxDecision(ds, cfg);
+    expect(ds.session.sandbox).toBe(false);
+    expect(ds.session.readIsolation).toBe(false);
+
+    cfg.sandbox = true;       // PUT /api/bot-sandbox during the build
+    cfg.readIsolation = true;
+
+    // The fork's SpawnOpts reads (worker-pool forkWorker):
+    expect(ds.session.sandbox === true).toBe(false);                          // sandbox arm
+    expect(ds.session.readIsolation ?? (cfg.readIsolation === true)).toBe(false); // readIsolation arm
+    // A second freeze call must not re-freeze either (idempotent).
+    freezeSessionSandboxDecision(ds, cfg);
+    expect(ds.session.sandbox).toBe(false);
+    expect(ds.session.readIsolation).toBe(false);
+    expect(mocks.updateSession).toHaveBeenCalledTimes(1); // only the first freeze persisted
+  });
+
+  it('is FROZEN in the other direction too: a live on→off flip keeps the recorded ON decision', () => {
+    const ds = makeSession();
+    const cfg = botCfg({ sandbox: true, readIsolation: true });
+    freezeSessionSandboxDecision(ds, cfg);
+
+    cfg.sandbox = false;      // dashboard flips OFF during the build
+    cfg.readIsolation = false;
+
+    expect(ds.session.sandbox === true).toBe(true);
+    expect(ds.session.readIsolation ?? (cfg.readIsolation === true)).toBe(true);
+  });
+
+  it('resume session pre-dating the field stays NOT sandboxed and leaves readIsolation to the live fallback', () => {
+    const ds = makeSession();
+    freezeSessionSandboxDecision(ds, botCfg({ sandbox: true, readIsolation: true }), { resume: true });
+    expect(ds.session.sandbox).toBe(false);
+    expect(ds.session.sandboxHidePaths).toEqual([]);
+    expect(ds.session.sandboxNetwork).toBe(true);
+    // readIsolation is NOT frozen on resume: the SpawnOpts live-config fallback
+    // preserves the legacy restore behavior for sessions persisted before the
+    // freeze field existed.
+    expect(ds.session.readIsolation).toBeUndefined();
+  });
+});


### PR DESCRIPTION
优先级：P0

## 根因

文件沙盒会把工作目录以读写方式绑定到宿主机，auto-worktree 是避免 Agent 写入真实项目的隔离层。此前 auto-worktree 创建失败时会静默回退真实默认目录，导致沙盒会话的新文件直接落入真实项目。

## 改动

- 本地文件沙盒实际生效时，auto-worktree 失败改为抛出 `AutoWorktreeFailClosedError`，关闭挂起会话并提示修复默认目录或通过 `/repo` 选择目录。
- fail-closed 判定与 worker 的真实开关对齐，覆盖 `config.sandbox`、legacy `readIsolation` 和 `BOTMUX_SANDBOX=1`。
- riff 是远端执行后端，不会启动本地 CLI 或写入本地工作目录，因此从整个本地沙盒 union 中豁免；沙盒关闭时仍保持原有降级行为。
- 补齐 pendingRepo 在 worktree 创建期间被 notifier 接管的护栏，避免迟到的失败处理误关新会话。

## 影响面

涉及 auto-worktree 启动路径及本地 sandbox/readIsolation 会话；普通非沙盒会话继续允许降级，riff 远端后端行为不变。PTY/Tmux 的后续 worker 运行路径未改动。

## 验证

- 新增 sandbox、legacy readIsolation、riff + sandbox、riff + `BOTMUX_SANDBOX=1` 以及接管竞态回归。
- `pnpm build` 通过。
- default-worktree、card-handler-repo-select、riff-sandbox-bypass、sandbox、dashboard-create-session 等 8 个测试文件 188 项通过。
- trigger-session、notifier 等 6 个测试文件 103 项通过。