### PR TITLE
fix(codex-app): 修复完成通知与 start/steer 响应竞态导致最终输出丢失

### DIFF
--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -107,8 +107,10 @@ interface ActiveTurn {
   startResponsePending?: boolean;
   /** New steer admission is closed (completion seen or a definite rejection). */
   steeringClosed?: boolean;
-  /** The authoritative terminal `turn/completed` payload, once observed for the
-   * proven canonical id. */
+  /** A terminal `turn/completed` payload observed while a start/steer response
+   * is still in flight. It may be canonical or non-canonical; once that RPC
+   * barrier clears, the former settles directly and the latter reconciles from
+   * bounded history. */
   terminalCompletion?: JsonObject;
   /** The single in-flight steer RPC (at most one), and the id it targets. */
   steerInFlight?: { dispatch: Dispatch; expectedTurnId: string };
@@ -154,6 +156,10 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const RECONCILIATION_TIMEOUT_MS = 5_000;
 const RECONCILIATION_PAGE_LIMIT = 3;
 const RECONCILIATION_PAGE_SIZE = 50;
+/** Consecutive app-server lifecycle notifications may arrive in separate stdout
+ * reads. Briefly debounce an idle edge so turn/completed followed immediately
+ * by an autonomous turn/started never exposes a false ready boundary. */
+const RUNNER_IDLE_SETTLE_MS = 20;
 
 class AppServerRpcError extends Error {
   constructor(
@@ -560,7 +566,7 @@ function connectControlSocket(): void {
         // The first acceptance happens before app-server initialization; it is
         // not a ready boundary. Re-authentication can publish the live state
         // only after initialization has completed.
-        if (controlAcceptanceCount > 1 && runnerReady) emitRunnerState();
+        if (controlAcceptanceCount > 1 && runnerReady) settleRunnerState();
         flushControlQueue();
       } else if (action.type === 'ack' && controlAccepted) {
         if (action.seq > controlAckedSeq) controlAckedSeq = action.seq;
@@ -693,6 +699,7 @@ let cleanInputUnsupported = false;
 let codexVersionChecked = false;
 let codexVersion: CodexVersion | undefined;
 let cleanVersionWarningShown = false;
+let runnerIdleSettleTimer: NodeJS.Timeout | undefined;
 
 /** Per-turn token accumulators keyed by codex native turn id. Fed by
  *  thread/tokenUsage/updated notifications; drained (and deleted) when the
@@ -736,6 +743,33 @@ function emitRunnerState(
     acceptingInput: runnerReady,
     ...(busy && !tracksTurn ? { tracksTurn: false } : {}),
   });
+}
+
+function cancelRunnerIdleSettle(): void {
+  if (!runnerIdleSettleTimer) return;
+  clearTimeout(runnerIdleSettleTimer);
+  runnerIdleSettleTimer = undefined;
+}
+
+/** Publish native-busy immediately, but debounce idle across adjacent app-server
+ * lifecycle records. The timer re-reads live state, so queued input or a newly
+ * started native turn cannot be overwritten by a stale busy:false callback. */
+function settleRunnerState(): void {
+  if (generationFenced) return;
+  if (nativeActiveTurnId !== undefined) {
+    cancelRunnerIdleSettle();
+    emitRunnerState(true, activeTurn !== null);
+    return;
+  }
+  if (runnerIdleSettleTimer) return;
+  runnerIdleSettleTimer = setTimeout(() => {
+    runnerIdleSettleTimer = undefined;
+    if (generationFenced) return;
+    const busy = processing || queue.length > 0 || nativeActiveTurnId !== undefined;
+    emitRunnerState(busy, activeTurn !== null);
+    if (!busy) prompt();
+  }, RUNNER_IDLE_SETTLE_MS);
+  runnerIdleSettleTimer.unref?.();
 }
 
 function detectedCodexVersion(): CodexVersion | undefined {
@@ -1035,7 +1069,10 @@ function handleNotification(msg: JsonObject, replayedAfterResponse = false): voi
     // A Goal continuation is native work, not a Botmux turn. Keep the worker
     // busy while explicitly advertising that the initialized runner can accept
     // a Lark follow-up through turn/steer.
-    if (runnerReady) emitRunnerState(true, false);
+    if (runnerReady) {
+      cancelRunnerIdleSettle();
+      emitRunnerState(true, false);
+    }
     return;
   }
 
@@ -1049,7 +1086,7 @@ function handleNotification(msg: JsonObject, replayedAfterResponse = false): voi
       // false-flag head was parked behind it (B3 gate), nativeActiveTurnId is
       // now cleared (line above) so re-kick the drain to start it as its own
       // turn — otherwise it would sleep forever. drainQueue no-ops when idle.
-      if (runnerReady) emitRunnerState();
+      if (runnerReady) settleRunnerState();
       if (queue.length > 0 && nativeActiveTurnId === undefined) void drainQueue();
       return;
     }
@@ -1061,13 +1098,23 @@ function handleNotification(msg: JsonObject, replayedAfterResponse = false): voi
     if (inGroupMode(turn)) {
       turn.completionSeen = true;
       turn.steeringClosed = true;
+      // Preserve every completion across an outstanding RPC response. Prefer a
+      // canonical candidate if several terminal notifications cross the same
+      // barrier; a later foreign completion must not overwrite proven content.
+      const bufferedId = typeof turn.terminalCompletion?.id === 'string'
+        ? turn.terminalCompletion.id
+        : undefined;
+      if (!turn.terminalCompletion
+          || completedId === turn.canonicalNativeTurnId
+          || bufferedId !== turn.canonicalNativeTurnId) {
+        turn.terminalCompletion = nativeTurn;
+      }
       // A steer RPC racing this completion, or a still-pending root start
       // response, is a barrier: buffer and let that continuation settle the group
       // once it appends its member / binds canonical. (canonical-only barrier.)
       const isCanonical = turn.canonicalNativeTurnId !== undefined
         && completedId === turn.canonicalNativeTurnId;
       if (isCanonical) {
-        turn.terminalCompletion = nativeTurn;
         if (turn.steerInFlight || turn.startResponsePending) {
           emitLifecycle({ kind: 'completion_race', appTurnId: completedId, category: 'steer_in_flight' });
           return;
@@ -1583,6 +1630,29 @@ async function reconcileSteeredGroupFromHistory(
   await turn.reconciliation;
 }
 
+/** Resume group settlement after an outstanding start/steer RPC has cleared.
+ * app-server responses and notifications can share one stdout read, so the
+ * notification handler may run before the awaiting RPC continuation. Preserve
+ * both canonical and non-canonical completions across that boundary. */
+function resumeBufferedGroupCompletion(turn: ActiveTurn): boolean {
+  if (activeTurn !== turn
+      || turn.completed
+      || !inGroupMode(turn)
+      || !turn.completionSeen
+      || !turn.terminalCompletion
+      || turn.steerInFlight
+      || turn.startResponsePending) return false;
+  const completedId = typeof turn.terminalCompletion.id === 'string'
+    ? turn.terminalCompletion.id
+    : undefined;
+  if (completedId !== undefined && completedId === turn.canonicalNativeTurnId) {
+    settleSteeredCompletion(turn, turn.terminalCompletion);
+  } else {
+    void reconcileSteeredGroupFromHistory(turn, completedId);
+  }
+  return true;
+}
+
 
 /**
  * Opportunistically admit the queue head as a pre-final `turn/steer` into the
@@ -1651,7 +1721,24 @@ async function tryAdmitSteer(): Promise<void> {
       // once this native turn completes the head starts its own turn.
       turn.steeringClosed = true;
       emitLifecycle({ kind: 'steer_rejected_fallback', appTurnId: expectedTurnId, category: 'definite_rejection' });
-      if (turn.completionSeen && turn.terminalCompletion) settleSteeredCompletion(turn, turn.terminalCompletion);
+      // A completion buffered while this steer was in flight must settle now.
+      // terminalCompletion may be non-canonical (PR broadened it), so route by
+      // identity exactly like resumeBufferedGroupCompletion — but WITHOUT its
+      // inGroupMode guard: this rejected steer never appended, so accepted.length
+      // is still 1 and inGroupMode is false here. Blindly calling
+      // settleSteeredCompletion would trust a foreign turn's items (wrong
+      // attribution); the helper would instead no-op and strand the completion
+      // (hang). Canonical → settle directly; non-canonical → bounded reconcile.
+      if (turn.completionSeen && turn.terminalCompletion) {
+        const bufferedId = typeof turn.terminalCompletion.id === 'string'
+          ? turn.terminalCompletion.id
+          : undefined;
+        if (bufferedId !== undefined && bufferedId === turn.canonicalNativeTurnId) {
+          settleSteeredCompletion(turn, turn.terminalCompletion);
+        } else {
+          void reconcileSteeredGroupFromHistory(turn, bufferedId);
+        }
+      }
       return;
     }
     // Unknown outcome (transport/timeout/generic rpc/protocol): fence — never
@@ -1691,10 +1778,7 @@ async function tryAdmitSteer(): Promise<void> {
   });
   // A completion may have arrived while this steer was in flight (barrier): settle
   // now that the group is final. Otherwise chain the next queued follow-up.
-  if (turn.completionSeen && turn.terminalCompletion) {
-    settleSteeredCompletion(turn, turn.terminalCompletion);
-    return;
-  }
+  if (resumeBufferedGroupCompletion(turn)) return;
   void tryAdmitSteer();
 }
 
@@ -1971,6 +2055,10 @@ async function runTurn(message: QueuedInput): Promise<void> {
     && ((turn.accepted?.length ?? 0) > 1
       || turn.identityProof === 'exact_started'
       || turn.identityProof === 'exact_completed');
+  // A group may have received a non-canonical completion in the same stdout
+  // read as its start/steer response. With both RPC barriers clear, reconcile
+  // it before the single-root compatibility path below.
+  resumeBufferedGroupCompletion(turn);
   if (settleBufferedCanonical) {
     settleSteeredCompletion(turn, turn.terminalCompletion!);
   }
@@ -1999,13 +2087,23 @@ async function runTurn(message: QueuedInput): Promise<void> {
       void reconcileCompletedTurn(turn, turn.nativeTurnId);
     } else if (turn.requestKind === 'start' && nativeMatches.length === 1) {
       completeActiveTurnFromNative(turn, nativeMatches[0]);
+    } else if (pendingCompletions.length > 0) {
+      // A mismatched completion can share one stdout read with turn/start's
+      // response. It was buffered while requestAccepted was false; replay the
+      // regular reconciliation path instead of silently dropping it.
+      const observedId = pendingCompletions.slice().reverse().find(
+        (completion: JsonObject) => typeof completion?.id === 'string',
+      )?.id;
+      void reconcileCompletedTurn(turn, observedId);
     }
   }
   // B4: only NOW, after buffered completions were replayed, admit a follow-up.
   // A follow-up that arrived during the RPC (before canonical was proven) steers
   // here; if the group already closed (completion-before-response), canSteer
   // refuses and it stays serial. Never kick before the replay above.
-  if (!turn.completed) void tryAdmitSteer();
+  // Reconciliation owns settlement once started. Do not admit a follow-up into
+  // a turn whose non-canonical terminal identity is still being resolved.
+  if (!turn.completed && !turn.reconciliation) void tryAdmitSteer();
   await turn.done;
 
   // Expand the ordered accepted group into N signed finals (N===1 for every
@@ -2076,9 +2174,7 @@ async function drainQueue(): Promise<void> {
         && nativeActiveTurnId !== undefined
         && queue[0].codexAppSteerable !== true;
       if (queue.length === 0 || parkedBehindGoal) {
-        const nativeBusy = nativeActiveTurnId !== undefined;
-        emitRunnerState(nativeBusy, !nativeBusy);
-        if (!nativeBusy) prompt();
+        settleRunnerState();
       }
     }
   } finally {
@@ -2184,6 +2280,7 @@ async function main(): Promise<void> {
 }
 
 process.on('SIGTERM', () => {
+  cancelRunnerIdleSettle();
   if (controlReconnectTimer) clearTimeout(controlReconnectTimer);
   controlSocket?.destroy();
   client?.close();
@@ -2191,6 +2288,7 @@ process.on('SIGTERM', () => {
 });
 
 process.on('SIGINT', () => {
+  cancelRunnerIdleSettle();
   if (controlReconnectTimer) clearTimeout(controlReconnectTimer);
   controlSocket?.destroy();
   client?.close();

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -156,6 +156,11 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const RECONCILIATION_TIMEOUT_MS = 5_000;
 const RECONCILIATION_PAGE_LIMIT = 3;
 const RECONCILIATION_PAGE_SIZE = 50;
+/** Delay between bounded-history re-scans while a keep-pending reconcile waits
+ * for the accepted native turn's own completion. The regular notification
+ * handler settles the turn the moment its real completion arrives, so this only
+ * paces the fallback scan (a thin completion whose full record is history-only). */
+const RECONCILIATION_KEEP_PENDING_RETRY_MS = 200;
 /** Consecutive app-server lifecycle notifications may arrive in separate stdout
  * reads. Briefly debounce an idle edge so turn/completed followed immediately
  * by an autonomous turn/started never exposes a false ready boundary. */
@@ -939,7 +944,11 @@ function reportIdentityConflict(turn: ActiveTurn, observedNativeTurnId?: string,
   turn.resolveDone();
 }
 
-async function reconcileCompletedTurn(turn: ActiveTurn, observedNativeTurnId?: string): Promise<void> {
+async function reconcileCompletedTurn(
+  turn: ActiveTurn,
+  observedNativeTurnId?: string,
+  options: { keepPendingWhileActive?: boolean } = {},
+): Promise<void> {
   if (turn.reconciliation || turn.completed) return turn.reconciliation;
   const clientUserMessageId = turn.clientUserMessageId;
   if (!clientUserMessageId || !threadId) {
@@ -947,42 +956,69 @@ async function reconcileCompletedTurn(turn: ActiveTurn, observedNativeTurnId?: s
     return;
   }
   const epoch = turn.epoch;
-  const deadlineAtMs = Date.now() + RECONCILIATION_TIMEOUT_MS;
+  const sleep = (ms: number) => new Promise<void>(resolvePromise => setTimeout(resolvePromise, ms));
   turn.reconciliation = (async () => {
-    const matches: Array<{ turn: JsonObject; itemIndex: number }> = [];
-    let cursor: string | null | undefined;
-    for (let page = 0; page < RECONCILIATION_PAGE_LIMIT; page++) {
-      const remaining = deadlineAtMs - Date.now();
-      if (remaining <= 0) break;
-      const result = await client.request('thread/turns/list', {
-        threadId,
-        ...(cursor ? { cursor } : {}),
-        limit: RECONCILIATION_PAGE_SIZE,
-        sortDirection: 'desc',
-        itemsView: 'full',
-      }, { timeoutMs: remaining });
-      for (const candidate of Array.isArray(result?.data) ? result.data : []) {
-        if (!isTerminalNativeTurn(candidate)) continue;
-        const indexes = exactClientItemIndexes(candidate, clientUserMessageId);
-        if (indexes.length === 1) matches.push({ turn: candidate, itemIndex: indexes[0] });
-        else if (indexes.length > 1) {
-          reportIdentityConflict(turn, observedNativeTurnId, 'client id appears more than once in one turn');
-          return;
+    for (;;) {
+      // Each scan gets a fresh RPC budget. With keepPendingWhileActive the outer
+      // loop is intentionally unbounded — the accepted native turn's own
+      // lifecycle bounds the wait, and the no-progress watchdog is the safety
+      // net for a turn that never completes.
+      const scanDeadlineAtMs = Date.now() + RECONCILIATION_TIMEOUT_MS;
+      const matches: Array<{ turn: JsonObject; itemIndex: number }> = [];
+      let cursor: string | null | undefined;
+      for (let page = 0; page < RECONCILIATION_PAGE_LIMIT; page++) {
+        const remaining = scanDeadlineAtMs - Date.now();
+        if (remaining <= 0) break;
+        const result = await client.request('thread/turns/list', {
+          threadId,
+          ...(cursor ? { cursor } : {}),
+          limit: RECONCILIATION_PAGE_SIZE,
+          sortDirection: 'desc',
+          itemsView: 'full',
+        }, { timeoutMs: remaining });
+        for (const candidate of Array.isArray(result?.data) ? result.data : []) {
+          if (!isTerminalNativeTurn(candidate)) continue;
+          const indexes = exactClientItemIndexes(candidate, clientUserMessageId);
+          if (indexes.length === 1) matches.push({ turn: candidate, itemIndex: indexes[0] });
+          else if (indexes.length > 1) {
+            reportIdentityConflict(turn, observedNativeTurnId, 'client id appears more than once in one turn');
+            return;
+          }
         }
+        cursor = typeof result?.nextCursor === 'string' ? result.nextCursor : null;
+        if (!cursor) break;
       }
-      cursor = typeof result?.nextCursor === 'string' ? result.nextCursor : null;
-      if (!cursor) break;
+      if (activeTurn !== turn || turn.epoch !== epoch || turn.completed) return;
+      if (matches.length === 1) {
+        completeActiveTurnFromNative(turn, matches[0].turn, matches[0].itemIndex);
+        return;
+      }
+      if (matches.length > 1) {
+        reportIdentityConflict(turn, observedNativeTurnId, 'bounded history lookup found multiple matches');
+        return;
+      }
+      // No terminal turn with an exact client-id match in bounded history.
+      //
+      // A single foreign-id completion buffered before the start/steer response
+      // is not causal proof that the ACCEPTED turn terminated: it can be a late
+      // arrival from a previous / autonomous turn while the accepted turn is
+      // still running, whose terminal record cannot be in history yet. Failing
+      // closed immediately would kill the running turn and discard its real
+      // completion when it arrives moments later.
+      //
+      // keepPendingWhileActive: keep the turn pending and re-scan while the
+      // accepted native turn is still active. The turn's own completion settles
+      // it through the regular notification handler (tripping the turn.completed
+      // guard above); a thin completion whose full record exists only in history
+      // is picked up by a re-scan. Fail closed only once the native turn is no
+      // longer active with still no match. The wait is bounded by the turn's own
+      // lifecycle and the no-progress watchdog, not a timer.
+      if (!options.keepPendingWhileActive) break;
+      if (nativeActiveTurnId !== turn.nativeTurnId) break;
+      await sleep(RECONCILIATION_KEEP_PENDING_RETRY_MS);
+      if (activeTurn !== turn || turn.epoch !== epoch || turn.completed) return;
     }
-    if (activeTurn !== turn || turn.epoch !== epoch || turn.completed) return;
-    if (matches.length === 1) {
-      completeActiveTurnFromNative(turn, matches[0].turn, matches[0].itemIndex);
-      return;
-    }
-    reportIdentityConflict(
-      turn,
-      observedNativeTurnId,
-      matches.length === 0 ? 'bounded history lookup found no match' : 'bounded history lookup found multiple matches',
-    );
+    reportIdentityConflict(turn, observedNativeTurnId, 'bounded history lookup found no match');
   })().catch(err => {
     if (activeTurn === turn && !turn.completed) {
       reportIdentityConflict(turn, observedNativeTurnId, `bounded history lookup failed: ${asError(err).message}`);
@@ -2043,9 +2079,12 @@ async function runTurn(message: QueuedInput): Promise<void> {
   // R4-B2 defense-in-depth: the buffered terminal's id MUST equal the proven
   // canonical id before we settle from it — a first-proof-wins violation upstream
   // would otherwise let terminal A's content ship under a different native id.
+  // A MISSING id must NOT settle directly: it routes through bounded-history
+  // reconcile (the same rule resumeBufferedGroupCompletion applies), so a
+  // malformed payload can never bypass attribution by omitting its id.
   const bufferedTerminalMatchesCanonical = turn.terminalCompletion !== undefined
-    && (typeof turn.terminalCompletion.id !== 'string'
-      || turn.terminalCompletion.id === turn.canonicalNativeTurnId);
+    && typeof turn.terminalCompletion.id === 'string'
+    && turn.terminalCompletion.id === turn.canonicalNativeTurnId;
   const settleBufferedCanonical = !turn.completed
     && turn.completionSeen
     && turn.terminalCompletion
@@ -2091,10 +2130,17 @@ async function runTurn(message: QueuedInput): Promise<void> {
       // A mismatched completion can share one stdout read with turn/start's
       // response. It was buffered while requestAccepted was false; replay the
       // regular reconciliation path instead of silently dropping it.
+      //
+      // keepPendingWhileActive: this single foreign-id completion is not proof
+      // the accepted turn terminated — it may be a late arrival from a previous
+      // / autonomous turn while the accepted turn is still running (its terminal
+      // record cannot be in history yet). Keep the turn pending until its own
+      // completion settles it; fail closed only if the native turn is no longer
+      // active with no exact match in bounded history.
       const observedId = pendingCompletions.slice().reverse().find(
         (completion: JsonObject) => typeof completion?.id === 'string',
       )?.id;
-      void reconcileCompletedTurn(turn, observedId);
+      void reconcileCompletedTurn(turn, observedId, { keepPendingWhileActive: true });
     }
   }
   // B4: only NOW, after buffered completions were replayed, admit a follow-up.

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -991,7 +991,18 @@ async function reconcileCompletedTurn(
   // Stored on the turn (not a closure local) so handleNotification can RESET
   // it on every forward-progress notification — a fixed deadline would kill a
   // legitimate long-running turn before the 90s liveness window fires.
-  if (options.keepPendingWhileActive) {
+  //
+  // Gate arming on a bound native id. The progress-reset guard in
+  // handleNotification is `notificationTurnId !== turn.nativeTurnId` — when
+  // nativeTurnId is unset (a protocol-anomaly start response that returned no
+  // id and had no prior exact turn/started proof) that guard falls fully open,
+  // so ANY foreign/autonomous turn's progress would keep resetting this
+  // deadline while `acceptedTurnWentTerminal` can never fire (it needs the id).
+  // The loop would then never terminate. Without a native id we cannot track
+  // this turn's own liveness at all, so fail closed immediately (leave the
+  // deadline unset → the `?? 0` check below trips on the first scan) rather
+  // than hang on unrelated activity.
+  if (options.keepPendingWhileActive && turn.nativeTurnId) {
     turn.keepPendingDeadlineAtMs = Date.now() + keepPendingTimeoutMs();
   }
   let conflictReason = 'bounded history lookup found no match';

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -161,6 +161,24 @@ const RECONCILIATION_PAGE_SIZE = 50;
  * handler settles the turn the moment its real completion arrives, so this only
  * paces the fallback scan (a thin completion whose full record is history-only). */
 const RECONCILIATION_KEEP_PENDING_RETRY_MS = 200;
+/** Wall-clock ceiling for a keep-pending reconcile's re-scan loop. The accepted
+ * native turn's own lifecycle normally bounds the wait (its completion settles
+ * the turn through the regular notification handler); this ceiling is the
+ * fail-closed safety net for a turn that never completes — without it the loop
+ * would poll thread/turns/list (~5Hz) forever. The no-progress watchdog only
+ * projects a stalled UI state and never cancels the runner, so it is NOT a
+ * safety net for this loop. */
+const RECONCILIATION_KEEP_PENDING_TIMEOUT_MS = 30_000;
+
+/** Test-only shrink for the keep-pending ceiling (same convention as the
+ * startup timeout override); production always uses the constant above. */
+function keepPendingTimeoutMs(): number {
+  if (process.env.NODE_ENV === 'test') {
+    const override = Number(process.env.BOTMUX_TEST_CODEX_APP_KEEP_PENDING_TIMEOUT_MS);
+    if (Number.isFinite(override) && override > 0) return override;
+  }
+  return RECONCILIATION_KEEP_PENDING_TIMEOUT_MS;
+}
 /** Consecutive app-server lifecycle notifications may arrive in separate stdout
  * reads. Briefly debounce an idle edge so turn/completed followed immediately
  * by an autonomous turn/started never exposes a false ready boundary. */
@@ -957,14 +975,23 @@ async function reconcileCompletedTurn(
   }
   const epoch = turn.epoch;
   const sleep = (ms: number) => new Promise<void>(resolvePromise => setTimeout(resolvePromise, ms));
+  // keepPendingWhileActive: wall-clock ceiling for the re-scan loop below.
+  const keepPendingDeadlineAtMs = options.keepPendingWhileActive
+    ? Date.now() + keepPendingTimeoutMs()
+    : 0;
+  let conflictReason = 'bounded history lookup found no match';
   turn.reconciliation = (async () => {
     for (;;) {
-      // Each scan gets a fresh RPC budget. With keepPendingWhileActive the outer
-      // loop is intentionally unbounded — the accepted native turn's own
-      // lifecycle bounds the wait, and the no-progress watchdog is the safety
-      // net for a turn that never completes.
+      // Each scan gets a fresh RPC budget.
       const scanDeadlineAtMs = Date.now() + RECONCILIATION_TIMEOUT_MS;
       const matches: Array<{ turn: JsonObject; itemIndex: number }> = [];
+      // Whether THIS turn's own native turn has a terminal record in the
+      // scanned history. The GLOBAL nativeActiveTurnId slot flipping to a
+      // different id is NOT proof this turn terminated — an autonomous Goal
+      // turn/started (or a late edge from another turn) flips it while the
+      // accepted turn is still running. Only the accepted turn's own terminal
+      // record is, so it is tracked per scan instead of comparing global slots.
+      let acceptedTurnWentTerminal = false;
       let cursor: string | null | undefined;
       for (let page = 0; page < RECONCILIATION_PAGE_LIMIT; page++) {
         const remaining = scanDeadlineAtMs - Date.now();
@@ -978,6 +1005,9 @@ async function reconcileCompletedTurn(
         }, { timeoutMs: remaining });
         for (const candidate of Array.isArray(result?.data) ? result.data : []) {
           if (!isTerminalNativeTurn(candidate)) continue;
+          if (turn.nativeTurnId && candidate?.id === turn.nativeTurnId) {
+            acceptedTurnWentTerminal = true;
+          }
           const indexes = exactClientItemIndexes(candidate, clientUserMessageId);
           if (indexes.length === 1) matches.push({ turn: candidate, itemIndex: indexes[0] });
           else if (indexes.length > 1) {
@@ -1007,18 +1037,28 @@ async function reconcileCompletedTurn(
       // completion when it arrives moments later.
       //
       // keepPendingWhileActive: keep the turn pending and re-scan while the
-      // accepted native turn is still active. The turn's own completion settles
-      // it through the regular notification handler (tripping the turn.completed
-      // guard above); a thin completion whose full record exists only in history
-      // is picked up by a re-scan. Fail closed only once the native turn is no
-      // longer active with still no match. The wait is bounded by the turn's own
-      // lifecycle and the no-progress watchdog, not a timer.
+      // accepted native turn has NOT itself gone terminal in history. The
+      // turn's own completion settles it through the regular notification
+      // handler (tripping the turn.completed guard above); a thin completion
+      // whose full record exists only in history is picked up by a re-scan.
+      // Fail closed only when (a) the accepted turn's OWN terminal record is
+      // in history with still no exact match — a genuine identity conflict,
+      // distinct from another turn merely starting — or (b) the wall-clock
+      // ceiling is reached (the turn never completes), so the loop cannot
+      // poll thread/turns/list forever.
       if (!options.keepPendingWhileActive) break;
-      if (nativeActiveTurnId !== turn.nativeTurnId) break;
+      if (acceptedTurnWentTerminal) {
+        conflictReason = 'accepted native turn terminated without an exact client id match';
+        break;
+      }
+      if (Date.now() >= keepPendingDeadlineAtMs) {
+        conflictReason = 'bounded history lookup found no match within the keep-pending deadline';
+        break;
+      }
       await sleep(RECONCILIATION_KEEP_PENDING_RETRY_MS);
       if (activeTurn !== turn || turn.epoch !== epoch || turn.completed) return;
     }
-    reportIdentityConflict(turn, observedNativeTurnId, 'bounded history lookup found no match');
+    reportIdentityConflict(turn, observedNativeTurnId, conflictReason);
   })().catch(err => {
     if (activeTurn === turn && !turn.completed) {
       reportIdentityConflict(turn, observedNativeTurnId, `bounded history lookup failed: ${asError(err).message}`);

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -28,6 +28,7 @@ import {
   parseCodexAppControlWireRecord,
   takeCodexAppControlLocatorEndpoint,
 } from './utils/codex-app-control.js';
+import { CODEX_APP_NO_PROGRESS_TIMEOUT_MS } from './utils/codex-app-turn-liveness.js';
 import {
   TurnTokenUsageAccumulator,
   parseTokenUsagePair,
@@ -119,6 +120,12 @@ interface ActiveTurn {
    * completion seen while a steer RPC is still in flight is buffered here as a
    * barrier and only settles the group after the steer response resolves. */
   completionSeen?: boolean;
+  /** Wall-clock ceiling for a keep-pending reconcile's re-scan loop, stored on
+   * the turn so the notification handler can RESET it on forward progress. A
+   * fixed deadline would kill a legitimate long-running turn before the 90s
+   * liveness window fires; resetting on progress aligns the two: the loop only
+   * fail-closes after the same no-progress interval the watchdog projects. */
+  keepPendingDeadlineAtMs?: number;
 }
 
 /** One admitted input tracked inside an ActiveTurn's ordered accepted group. */
@@ -161,14 +168,19 @@ const RECONCILIATION_PAGE_SIZE = 50;
  * handler settles the turn the moment its real completion arrives, so this only
  * paces the fallback scan (a thin completion whose full record is history-only). */
 const RECONCILIATION_KEEP_PENDING_RETRY_MS = 200;
-/** Wall-clock ceiling for a keep-pending reconcile's re-scan loop. The accepted
- * native turn's own lifecycle normally bounds the wait (its completion settles
- * the turn through the regular notification handler); this ceiling is the
- * fail-closed safety net for a turn that never completes — without it the loop
- * would poll thread/turns/list (~5Hz) forever. The no-progress watchdog only
- * projects a stalled UI state and never cancels the runner, so it is NOT a
- * safety net for this loop. */
-const RECONCILIATION_KEEP_PENDING_TIMEOUT_MS = 30_000;
+/** Fail-closed window for a keep-pending reconcile's re-scan loop, structurally
+ * aligned with the worker's Codex App no-progress liveness window by reusing
+ * its constant: the loop must never fail-closed while the watchdog still
+ * considers the turn alive. The deadline is RESET on every forward-progress
+ * notification for the accepted turn (see handleNotification), so a legitimate
+ * long tool/model turn that keeps emitting activity is not killed by a stale
+ * fixed ceiling. The accepted native turn's own lifecycle normally bounds the
+ * wait (its completion settles the turn through the regular notification
+ * handler); this window is the fail-closed safety net for a turn that goes
+ * silent — without it the loop would poll thread/turns/list (~5Hz) forever.
+ * The no-progress watchdog only projects a stalled UI state and never cancels
+ * the runner, so it is NOT a safety net for this loop. */
+const RECONCILIATION_KEEP_PENDING_TIMEOUT_MS = CODEX_APP_NO_PROGRESS_TIMEOUT_MS;
 
 /** Test-only shrink for the keep-pending ceiling (same convention as the
  * startup timeout override); production always uses the constant above. */
@@ -976,9 +988,12 @@ async function reconcileCompletedTurn(
   const epoch = turn.epoch;
   const sleep = (ms: number) => new Promise<void>(resolvePromise => setTimeout(resolvePromise, ms));
   // keepPendingWhileActive: wall-clock ceiling for the re-scan loop below.
-  const keepPendingDeadlineAtMs = options.keepPendingWhileActive
-    ? Date.now() + keepPendingTimeoutMs()
-    : 0;
+  // Stored on the turn (not a closure local) so handleNotification can RESET
+  // it on every forward-progress notification — a fixed deadline would kill a
+  // legitimate long-running turn before the 90s liveness window fires.
+  if (options.keepPendingWhileActive) {
+    turn.keepPendingDeadlineAtMs = Date.now() + keepPendingTimeoutMs();
+  }
   let conflictReason = 'bounded history lookup found no match';
   turn.reconciliation = (async () => {
     for (;;) {
@@ -1051,7 +1066,7 @@ async function reconcileCompletedTurn(
         conflictReason = 'accepted native turn terminated without an exact client id match';
         break;
       }
-      if (Date.now() >= keepPendingDeadlineAtMs) {
+      if (Date.now() >= (turn.keepPendingDeadlineAtMs ?? 0)) {
         conflictReason = 'bounded history lookup found no match within the keep-pending deadline';
         break;
       }
@@ -1303,6 +1318,12 @@ function handleNotification(msg: JsonObject, replayedAfterResponse = false): voi
   // Every notification for the active app-server turn is evidence of forward
   // progress, including reasoning/status events that do not render text.
   emitTurnActivity(turn, 'progress');
+  // Reset the keep-pending reconcile ceiling on progress: a turn that is still
+  // emitting activity must not be killed by a stale fixed deadline while the
+  // 90s liveness window is being refreshed by the same progress markers.
+  if (turn.keepPendingDeadlineAtMs !== undefined) {
+    turn.keepPendingDeadlineAtMs = Date.now() + keepPendingTimeoutMs();
+  }
 
   if (msg.method === 'item/started') {
     const item = params.item;

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -1208,6 +1208,113 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
     }
   });
 
+  it('settles when a canonical completion is buffered and the racing tryAdmitSteer steer is then definitely rejected (accepted.length===1)', async () => {
+    // REGRESSION REPRO for the tryAdmitSteer definite-rejection branch: a
+    // steerable root proves canonical via exact turn/started; the first follow-up
+    // steers via tryAdmitSteer. On that steer the fixture emits the CANONICAL
+    // turn/completed AND a definite steer rejection in ONE stdout chunk. The
+    // runner buffers the completion (steerInFlight set) then hits the rejection
+    // catch — where accepted.length is STILL 1 (the first steer never appended),
+    // so inGroupMode is false. The rejection branch must settle the buffered
+    // canonical completion directly; a resume path gated on inGroupMode would
+    // strand it and hang the session forever (busy never returns to false).
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-admit-reject-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    const control = new ControlCollector(dir);
+    await control.listen();
+    const harness = startRunner(fakeCodex, dir, logPath, '0.144.6', 'steer-admit-reject-buffered', control.bootstrap.path);
+
+    const send = (text: string, replyTurnId: string) => {
+      const encoded = encodeRunnerInput(
+        `legacy:${text}`,
+        { text, clientUserMessageId: replyTurnId },
+        replyTurnId,
+        true,
+      );
+      harness.child.stdin.write(`${CONTROL_PREFIX}${encoded}\r`);
+    };
+
+    try {
+      await waitFor(harness, () => control.states.some(state => state.busy === false));
+      send('root', 'om_ar_root');
+      await waitFor(harness, () => readRequests(logPath).some(r => r.method === 'turn/start'));
+      // Follow-up steers into the proven-canonical root via tryAdmitSteer.
+      send('follow', 'om_ar_follow');
+      // The turn MUST settle. A hang here (session stuck busy) is the regression:
+      // the rejection catch at line ~1700 is the SOLE settle point for the
+      // buffered canonical completion (accepted.length===1 → inGroupMode false).
+      await waitFor(harness, () => control.states.filter(state => state.busy === false).length >= 2);
+
+      const requests = readRequests(logPath);
+      expect(requests.filter(r => r.method === 'turn/steer')).toHaveLength(1);
+      // The buffered canonical completion settled the root directly (no history
+      // reconcile, no identity error): the root's real answer is rebuilt from the
+      // canonical completion's items. The rejected follow-up then starts its own
+      // serial turn.
+      const diagnostics = control.markers.filter(
+        m => m.kind === 'diagnostic' && m.payload.code === 'native_turn_identity_conflict',
+      );
+      expect(diagnostics).toHaveLength(0);
+      const rootFinal = control.finals.find(f => f.turnId === 'om_ar_root');
+      expect(rootFinal?.content).toBe('buffered canonical answer');
+    } finally {
+      await stopChild(harness.child);
+      await control.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed (never trusts foreign text) when the buffered completion is NON-canonical and the racing tryAdmitSteer steer is rejected', async () => {
+    // codex's reported blocker: the PR broadened terminalCompletion to also hold
+    // NON-canonical completions. The tryAdmitSteer rejection branch must NOT
+    // blindly hand a non-canonical completion to settleSteeredCompletion — with
+    // no full items that path would trust existing streamed text and mis-attribute
+    // a foreign turn's answer. It must route to bounded-history reconcile and,
+    // finding no full-group match, fail closed with an identity conflict.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-admit-reject-nc-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    const control = new ControlCollector(dir);
+    await control.listen();
+    const harness = startRunner(fakeCodex, dir, logPath, '0.144.6', 'steer-admit-reject-noncanon', control.bootstrap.path);
+
+    const send = (text: string, replyTurnId: string) => {
+      const encoded = encodeRunnerInput(
+        `legacy:${text}`,
+        { text, clientUserMessageId: replyTurnId },
+        replyTurnId,
+        true,
+      );
+      harness.child.stdin.write(`${CONTROL_PREFIX}${encoded}\r`);
+    };
+
+    try {
+      await waitFor(harness, () => control.states.some(state => state.busy === false));
+      send('root', 'om_nc_root');
+      await waitFor(harness, () => readRequests(logPath).some(r => r.method === 'turn/start'));
+      send('follow', 'om_nc_follow');
+      // Must settle (no hang) AND fail closed: an identity-conflict diagnostic,
+      // never a final carrying a foreign turn's model text.
+      await waitFor(harness, () => control.markers.some(
+        m => m.kind === 'diagnostic' && m.payload.code === 'native_turn_identity_conflict',
+      ));
+      await waitFor(harness, () => control.states.filter(state => state.busy === false).length >= 2);
+      const rootFinal = control.finals.find(f => f.turnId === 'om_nc_root');
+      expect(rootFinal?.content).toContain('identity conflict');
+      // A bounded-history reconcile ran (proof it did NOT blindly settle).
+      expect(readRequests(logPath).some(r => r.method === 'thread/turns/list')).toBe(true);
+    } finally {
+      await stopChild(harness.child);
+      await control.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when a steered group terminal turn omits a member (B5 group-aware identity defense)', async () => {
     // B5: when the canonical completion carries itemsView:'full', EVERY steered
     // member that sent a clientId must appear exactly once in strictly-increasing

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -2016,6 +2016,62 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
     }
   });
 
+  it('resets the keep-pending ceiling on progress so a long-running turn is not killed before its real completion', async () => {
+    // REGRESSION for the keep-pending ceiling semantics: a stale pre-response
+    // completion triggers keepPendingWhileActive. The accepted turn then emits
+    // periodic progress for ~5s — longer than the test's 3s keep-pending
+    // ceiling — and only then sends its REAL completion. A FIXED 3s ceiling
+    // would reportIdentityConflict at 3s and discard the real answer; a
+    // progress-resettable ceiling must keep the turn pending and deliver it.
+    // This aligns the runner's fail-closed with the worker's 90s no-progress
+    // liveness window: both are refreshed by the same activity.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-keep-pending-progress-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    const control = new ControlCollector(dir);
+    await control.listen();
+    const harness = startRunner(
+      fakeCodex,
+      dir,
+      logPath,
+      '0.144.6',
+      'pre-response-foreign-completion-long-progress',
+      control.bootstrap.path,
+      { env: { BOTMUX_TEST_CODEX_APP_KEEP_PENDING_TIMEOUT_MS: '3000' } },
+    );
+
+    try {
+      await waitFor(harness, () => harness.stdout.includes('Codex App connected.'));
+      harness.child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('legacy', {
+        text: 'stale completion then long progress',
+        clientUserMessageId: 'om_keep_pending_progress',
+      })}\r`);
+      // The turn MUST settle with the REAL answer arriving at ~5s — well past
+      // the 3s fixed ceiling. A fail-closed identity-conflict here is the
+      // regression: the stale ceiling killed a turn that was still making
+      // progress.
+      await waitFor(harness, () => control.finals.length === 1
+        && control.states.filter(state => state.busy === false).length >= 2);
+      const diagnostics = control.markers.filter(
+        marker => marker.kind === 'diagnostic' && marker.payload.code === 'native_turn_identity_conflict',
+      );
+      expect(diagnostics).toHaveLength(0);
+      expect(control.finals[0]).toMatchObject({
+        turnId: 'om_keep_pending_progress',
+        content: 'real answer after long progress',
+      });
+      // Reconcile ran (the stale completion was replayed into keep-pending).
+      expect(readRequests(logPath).some(request => request.method === 'thread/turns/list')).toBe(true);
+      expect(harness.child.exitCode).toBeNull();
+    } finally {
+      await stopChild(harness.child);
+      await control.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps the startup deadline armed through initialize and never exposes a pre-ready prompt', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-runner-startup-deadline-'));
     const fakeCodex = join(dir, 'fake-codex');

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -2016,6 +2016,60 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
     }
   });
 
+  it('fails closed (does not hang on foreign progress) when keep-pending arms without a bound native id', async () => {
+    // REGRESSION for the keep-pending arm guard: the turn/start response succeeds
+    // but returns NO native id (protocol anomaly) and no exact turn/started proved
+    // one first, so turn.nativeTurnId stays undefined. A stale foreign completion
+    // arms keep-pending. handleNotification's progress-reset guard
+    // (notificationTurnId !== turn.nativeTurnId) falls fully open on the unset id,
+    // so a FOREIGN turn's periodic progress would keep resetting the deadline
+    // forever while acceptedTurnWentTerminal (which needs the id) can never fire —
+    // an unbounded hang that blocks the runner FIFO. The fix refuses to arm
+    // keep-pending without a native id, so the loop fails closed on the first scan
+    // regardless of foreign chatter. A hang here (no diagnostic, no final) is the
+    // regression.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-keep-pending-unbound-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    const control = new ControlCollector(dir);
+    await control.listen();
+    const harness = startRunner(
+      fakeCodex,
+      dir,
+      logPath,
+      '0.144.6',
+      'pre-response-foreign-completion-unbound-id',
+      control.bootstrap.path,
+      { env: { BOTMUX_TEST_CODEX_APP_KEEP_PENDING_TIMEOUT_MS: '1000' } },
+    );
+
+    try {
+      await waitFor(harness, () => harness.stdout.includes('Codex App connected.'));
+      harness.child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('legacy', {
+        text: 'unbound id start response then foreign progress',
+        clientUserMessageId: 'om_keep_pending_unbound',
+      })}\r`);
+      // Must fail closed promptly (the deadline was never armed, so the first
+      // scan trips `?? 0`) despite the foreign turn's progress every 300ms. A
+      // hang here — no diagnostic, no final — is the regression: foreign activity
+      // resetting a fallen-open guard's deadline forever.
+      await waitFor(harness, () => control.markers.some(
+        marker => marker.kind === 'diagnostic' && marker.payload.code === 'native_turn_identity_conflict',
+      ));
+      await waitFor(harness, () => control.finals.length === 1
+        && control.states.filter(state => state.busy === false).length >= 2);
+      expect(control.finals[0]).toMatchObject({ turnId: 'om_keep_pending_unbound' });
+      expect(String(control.finals[0].content ?? '')).toContain('identity conflict');
+      expect(harness.child.exitCode).toBeNull();
+    } finally {
+      await stopChild(harness.child);
+      await control.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('resets the keep-pending ceiling on progress so a long-running turn is not killed before its real completion', async () => {
     // REGRESSION for the keep-pending ceiling semantics: a stale pre-response
     // completion triggers keepPendingWhileActive. The accepted turn then emits

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -1903,6 +1903,119 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
     }
   });
 
+  it('does not let an autonomous Goal turn/started flip the keep-pending reconcile into a false kill', async () => {
+    // REGRESSION for the keep-pending exit condition: a stale foreign completion
+    // before the start response replays into reconcile with keepPendingWhileActive.
+    // An autonomous Goal turn/started then flips the GLOBAL nativeActiveTurnId
+    // slot while the accepted turn is still running. The global slot flip is not
+    // proof this turn terminated — the turn must stay pending and settle with
+    // its own real completion (arriving 1.5s after the response), not fail-closed
+    // on the Goal's turn/started. The old exit condition (nativeActiveTurnId !==
+    // turn.nativeTurnId) killed the turn here and swallowed the real answer.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-goal-switch-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    const control = new ControlCollector(dir);
+    await control.listen();
+    const harness = startRunner(fakeCodex, dir, logPath, '0.144.6', 'pre-response-foreign-completion-goal-switch', control.bootstrap.path);
+
+    try {
+      await waitFor(harness, () => harness.stdout.includes('Codex App connected.'));
+      harness.child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('legacy', {
+        text: 'stale completion then goal switch',
+        clientUserMessageId: 'om_goal_switch_pre',
+      })}\r`);
+      // The turn MUST settle with the REAL answer arriving after the Goal's
+      // turn/started flipped the global native slot — not an identity-conflict
+      // error. A fail-closed here is the regression: the Goal's lifecycle edge
+      // was misread as this turn's termination. The final transaction is only
+      // emitted after await turn.done, so finals.length===1 proves the turn
+      // settled (the autonomous Goal stays native-busy by design, so the runner
+      // intentionally does NOT go idle here).
+      await waitFor(harness, () => control.finals.length === 1);
+      // The else branch fired (reconcile scanned history while pending) — proof
+      // the stale completion was replayed — and it did NOT kill the turn.
+      expect(readRequests(logPath).some(request => request.method === 'thread/turns/list')).toBe(true);
+      const diagnostics = control.markers.filter(
+        marker => marker.kind === 'diagnostic' && marker.payload.code === 'native_turn_identity_conflict',
+      );
+      expect(diagnostics).toHaveLength(0);
+      expect(control.finals[0]).toMatchObject({
+        turnId: 'om_goal_switch_pre',
+        content: 'real answer despite goal switch',
+      });
+      expect(harness.child.exitCode).toBeNull();
+    } finally {
+      await stopChild(harness.child);
+      await control.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('bounds the keep-pending re-scan loop and fail-closes when the native turn never completes', async () => {
+    // REGRESSION for the unbounded history poll: a stale foreign completion
+    // before the start response replays into reconcile with keepPendingWhileActive,
+    // and the accepted native turn hangs forever. The re-scan loop must stop
+    // after its wall-clock ceiling (shrunk to 1s here via the test override) and
+    // fail-closed — identity conflict + turn.done settles — instead of polling
+    // thread/turns/list (~5Hz) forever. The no-progress watchdog is not a safety
+    // net here: it only projects a stalled UI state and never cancels the runner.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-keep-pending-bound-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    const control = new ControlCollector(dir);
+    await control.listen();
+    const harness = startRunner(
+      fakeCodex,
+      dir,
+      logPath,
+      '0.144.6',
+      'pre-response-foreign-completion-hang',
+      control.bootstrap.path,
+      { env: { BOTMUX_TEST_CODEX_APP_KEEP_PENDING_TIMEOUT_MS: '1000' } },
+    );
+
+    try {
+      await waitFor(harness, () => harness.stdout.includes('Codex App connected.'));
+      harness.child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('legacy', {
+        text: 'stale completion then hang',
+        clientUserMessageId: 'om_keep_pending_hang',
+      })}\r`);
+      // The ceiling (1s) trips: reconcile fail-closes with an identity conflict
+      // and the turn settles with an explicit error final.
+      await waitFor(harness, () => control.markers.some(
+        marker => marker.kind === 'diagnostic' && marker.payload.code === 'native_turn_identity_conflict',
+      ));
+      await waitFor(harness, () => control.finals.length === 1
+        && control.states.filter(state => state.busy === false).length >= 2);
+      expect(control.finals[0]).toMatchObject({
+        turnId: 'om_keep_pending_hang',
+      });
+      expect(String(control.finals[0].content ?? '')).toContain('identity conflict');
+      // The re-scan count is bounded by the ceiling: 1000ms / 200ms retry ≈ 5-6
+      // scans (one turns/list page each). A runaway loop would dwarf this.
+      const listCountAtSettle = readRequests(logPath)
+        .filter(request => request.method === 'thread/turns/list').length;
+      expect(listCountAtSettle).toBeGreaterThanOrEqual(1);
+      expect(listCountAtSettle).toBeLessThanOrEqual(8);
+      // After fail-closed the loop must NOT keep polling: observe for 600ms
+      // (3x the retry interval) and assert the count did not grow.
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 600));
+      const listCountAfterQuiet = readRequests(logPath)
+        .filter(request => request.method === 'thread/turns/list').length;
+      expect(listCountAfterQuiet).toBe(listCountAtSettle);
+      expect(harness.child.exitCode).toBeNull();
+    } finally {
+      await stopChild(harness.child);
+      await control.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps the startup deadline armed through initialize and never exposes a pre-ready prompt', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-runner-startup-deadline-'));
     const fakeCodex = join(dir, 'fake-codex');

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -1851,14 +1851,18 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
     });
   }
 
-  it('settles (fail-closed, not hang) when a pre-response foreign completion has no exact items and mismatches the native id', async () => {
-    // REGRESSION for the pendingCompletions replay else branch: a foreign
-    // turn/completed (no client items, id unrelated to this turn) arrives
-    // BEFORE the start response. Master silently dropped it on replay (no
-    // exact/native match), so if it was the real terminal event the turn hung
-    // forever (busy never returned to false → 90s no-progress alert). The fix
-    // routes it through reconcile, which fails closed with an identity conflict.
-    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-preresp-foreign-'));
+  it('keeps the accepted turn pending and settles on its real completion when a stale pre-response completion mismatches the native id', async () => {
+    // REGRESSION for the pendingCompletions replay else branch: a STALE
+    // turn/completed (previous/autonomous turn, no client items, unrelated id)
+    // arrives BEFORE the start response. Master silently dropped it on replay
+    // (hang risk if it was the real terminal event); the initial fix reconciled
+    // immediately and failed closed — but the accepted turn was still running,
+    // so bounded history had no terminal record yet and the REAL completion
+    // arriving 100ms later was discarded (identity-conflict false kill, real
+    // answer lost). The fix keeps the turn pending while the native turn is
+    // active: the real completion settles it with the real answer, no identity
+    // conflict.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-stale-preresp-'));
     const fakeCodex = join(dir, 'fake-codex');
     const logPath = join(dir, 'requests.jsonl');
     copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
@@ -1870,26 +1874,26 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
     try {
       await waitFor(harness, () => harness.stdout.includes('Codex App connected.'));
       harness.child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('legacy', {
-        text: 'foreign completion before response',
-        clientUserMessageId: 'om_foreign_pre',
+        text: 'stale completion before response',
+        clientUserMessageId: 'om_stale_pre',
       })}\r`);
-      // The turn MUST settle. A hang here (busy stuck true) is the regression:
-      // master dropped the buffered foreign completion on replay, so turn.done
-      // never resolved. The fix reconciles and fails closed.
-      await waitFor(harness, () => control.markers.some(marker => marker.kind === 'diagnostic')
-        && control.finals.length === 1
+      // The turn MUST settle with the REAL answer (arriving 100ms after the
+      // response), not an identity-conflict error. A fail-closed here is the
+      // regression: the stale pre-response completion killed a still-running
+      // turn and swallowed its real completion.
+      await waitFor(harness, () => control.finals.length === 1
         && control.states.filter(state => state.busy === false).length >= 2);
-      // Reconcile ran (thread/turns/list) — proof the else branch fired, not a
-      // silent drop.
+      // The else branch fired (reconcile scanned history) — proof the stale
+      // completion was replayed, not silently dropped — and it did NOT kill the
+      // turn: no identity-conflict diagnostic.
       expect(readRequests(logPath).some(request => request.method === 'thread/turns/list')).toBe(true);
-      const diagnostic = control.markers.find(marker => marker.kind === 'diagnostic');
-      expect(diagnostic?.payload).toMatchObject({
-        code: 'native_turn_identity_conflict',
-        turnId: 'om_foreign_pre',
-      });
+      const diagnostics = control.markers.filter(
+        marker => marker.kind === 'diagnostic' && marker.payload.code === 'native_turn_identity_conflict',
+      );
+      expect(diagnostics).toHaveLength(0);
       expect(control.finals[0]).toMatchObject({
-        turnId: 'om_foreign_pre',
-        content: expect.stringContaining('Codex App native turn identity conflict'),
+        turnId: 'om_stale_pre',
+        content: 'real answer after response',
       });
       expect(harness.child.exitCode).toBeNull();
     } finally {

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -1851,6 +1851,54 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
     });
   }
 
+  it('settles (fail-closed, not hang) when a pre-response foreign completion has no exact items and mismatches the native id', async () => {
+    // REGRESSION for the pendingCompletions replay else branch: a foreign
+    // turn/completed (no client items, id unrelated to this turn) arrives
+    // BEFORE the start response. Master silently dropped it on replay (no
+    // exact/native match), so if it was the real terminal event the turn hung
+    // forever (busy never returned to false → 90s no-progress alert). The fix
+    // routes it through reconcile, which fails closed with an identity conflict.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-preresp-foreign-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    const control = new ControlCollector(dir);
+    await control.listen();
+    const harness = startRunner(fakeCodex, dir, logPath, '0.144.6', 'pre-response-foreign-completion', control.bootstrap.path);
+
+    try {
+      await waitFor(harness, () => harness.stdout.includes('Codex App connected.'));
+      harness.child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('legacy', {
+        text: 'foreign completion before response',
+        clientUserMessageId: 'om_foreign_pre',
+      })}\r`);
+      // The turn MUST settle. A hang here (busy stuck true) is the regression:
+      // master dropped the buffered foreign completion on replay, so turn.done
+      // never resolved. The fix reconciles and fails closed.
+      await waitFor(harness, () => control.markers.some(marker => marker.kind === 'diagnostic')
+        && control.finals.length === 1
+        && control.states.filter(state => state.busy === false).length >= 2);
+      // Reconcile ran (thread/turns/list) — proof the else branch fired, not a
+      // silent drop.
+      expect(readRequests(logPath).some(request => request.method === 'thread/turns/list')).toBe(true);
+      const diagnostic = control.markers.find(marker => marker.kind === 'diagnostic');
+      expect(diagnostic?.payload).toMatchObject({
+        code: 'native_turn_identity_conflict',
+        turnId: 'om_foreign_pre',
+      });
+      expect(control.finals[0]).toMatchObject({
+        turnId: 'om_foreign_pre',
+        content: expect.stringContaining('Codex App native turn identity conflict'),
+      });
+      expect(harness.child.exitCode).toBeNull();
+    } finally {
+      await stopChild(harness.child);
+      await control.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps the startup deadline armed through initialize and never exposes a pre-ready prompt', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-runner-startup-deadline-'));
     const fakeCodex = join(dir, 'fake-codex');

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -788,6 +788,73 @@ function handle(request) {
     }, 100);
     return;
   }
+  if (behavior === 'pre-response-foreign-completion-goal-switch' && turnAttempt === 1) {
+    // REGRESSION for the keep-pending exit condition: a STALE foreign completion
+    // (no client items, unrelated id) arrives BEFORE the start response and is
+    // replayed into reconcile with keepPendingWhileActive. 250ms later an
+    // autonomous Goal turn/started flips the GLOBAL nativeActiveTurnId slot;
+    // 1.5s later THIS turn's real completion arrives. The global slot flip is
+    // NOT proof this turn terminated — the runner must keep the turn pending
+    // and settle it with the real answer, not fail-closed on the Goal's
+    // turn/started (which would discard the real completion).
+    const threadId = request.params.threadId;
+    const turnId = `turn-fake-${turnAttempt}`;
+    const clientId = request.params.clientUserMessageId ?? null;
+    notify('turn/completed', {
+      threadId,
+      turn: { id: 'turn-stale-pre-response', status: 'completed' },
+    });
+    respond(request.id, { turn: { id: turnId } });
+    notify('turn/started', { threadId, turn: { id: turnId } });
+    setTimeout(() => {
+      notify('turn/started', {
+        threadId,
+        turn: { id: 'turn-goal-auto', status: 'inProgress', itemsView: 'full', items: [] },
+      });
+    }, 250);
+    setTimeout(() => {
+      notify('item/completed', {
+        threadId,
+        turnId,
+        item: {
+          id: `message-real-${turnAttempt}`,
+          type: 'agentMessage',
+          phase: 'final_answer',
+          text: 'real answer despite goal switch',
+        },
+      });
+      notify('turn/completed', {
+        threadId,
+        turn: {
+          id: turnId,
+          status: 'completed',
+          itemsView: 'full',
+          error: null,
+          items: [
+            { id: `user-${turnAttempt}`, type: 'userMessage', clientId, content: request.params.input },
+            { id: `message-real-${turnAttempt}`, type: 'agentMessage', phase: 'final_answer', text: 'real answer despite goal switch' },
+          ],
+        },
+      });
+    }, 1500);
+    return;
+  }
+  if (behavior === 'pre-response-foreign-completion-hang' && turnAttempt === 1) {
+    // REGRESSION for the keep-pending re-scan bound: a STALE foreign completion
+    // before the start response replays into reconcile with keepPendingWhileActive,
+    // and the accepted native turn NEVER completes (hang). The re-scan loop must
+    // stop after its wall-clock ceiling and fail-closed (identity conflict +
+    // turn.done settles) — not poll thread/turns/list (~5Hz) forever.
+    const threadId = request.params.threadId;
+    const turnId = `turn-fake-${turnAttempt}`;
+    notify('turn/completed', {
+      threadId,
+      turn: { id: 'turn-stale-pre-response', status: 'completed' },
+    });
+    respond(request.id, { turn: { id: turnId } });
+    notify('turn/started', { threadId, turn: { id: turnId } });
+    return;
+  }
   if (behavior === 'completion-A-started-B') {
     // R4-B2 crossing 1: exact completion A proves canonical=A; then an exact
     // turn/started B (DIFFERENT id) arrives → first-proof-wins must fence (a later

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -745,23 +745,47 @@ function handle(request) {
     return;
   }
   if (behavior === 'pre-response-foreign-completion' && turnAttempt === 1) {
-    // A foreign turn/completed (NO client items, id unrelated to this turn)
-    // arrives BEFORE the turn/start response. Unlike completion-before-response-
-    // mismatch, this carries no exact-client items, so the runner cannot upgrade
-    // it to canonical proof. It must buffer it (requestAccepted=false), then
-    // after the response binds the real native id, replay it through the
-    // pendingCompletions else branch into reconcile — settling fail-closed
-    // (identity conflict, history has no match), NOT hanging forever. Direct
-    // regression for the else branch master lacked (silent drop → permanent
-    // pending → 90s no-progress alert).
+    // A STALE completion (previous/autonomous turn, NO client items, id unrelated
+    // to this turn) arrives BEFORE the turn/start response. The runner buffers it
+    // (requestAccepted=false). After the response binds the real native id, the
+    // pendingCompletions replay must NOT fail-closed on it: the accepted turn is
+    // still running, so bounded history cannot yet contain its terminal record.
+    // 100ms later the REAL completion arrives and must settle the turn with the
+    // real answer — the stale completion must be ignored, not kill the turn.
     const threadId = request.params.threadId;
     const turnId = `turn-fake-${turnAttempt}`;
+    const clientId = request.params.clientUserMessageId ?? null;
     notify('turn/completed', {
       threadId,
-      turn: { id: 'turn-foreign-pre-response', status: 'completed' },
+      turn: { id: 'turn-stale-pre-response', status: 'completed' },
     });
     respond(request.id, { turn: { id: turnId } });
     notify('turn/started', { threadId, turn: { id: turnId } });
+    setTimeout(() => {
+      notify('item/completed', {
+        threadId,
+        turnId,
+        item: {
+          id: `message-real-${turnAttempt}`,
+          type: 'agentMessage',
+          phase: 'final_answer',
+          text: 'real answer after response',
+        },
+      });
+      notify('turn/completed', {
+        threadId,
+        turn: {
+          id: turnId,
+          status: 'completed',
+          itemsView: 'full',
+          error: null,
+          items: [
+            { id: `user-${turnAttempt}`, type: 'userMessage', clientId, content: request.params.input },
+            { id: `message-real-${turnAttempt}`, type: 'agentMessage', phase: 'final_answer', text: 'real answer after response' },
+          ],
+        },
+      });
+    }, 100);
     return;
   }
   if (behavior === 'completion-A-started-B') {

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -855,6 +855,33 @@ function handle(request) {
     notify('turn/started', { threadId, turn: { id: turnId } });
     return;
   }
+  if (behavior === 'pre-response-foreign-completion-unbound-id' && turnAttempt === 1) {
+    // REGRESSION for the keep-pending arm guard: the turn/start response SUCCEEDS
+    // but carries NO native id (protocol anomaly: result.turn.id and
+    // result.turnId both absent), and no exact turn/started proved the id first.
+    // The runner binds turn.nativeTurnId = undefined, then arms keep-pending on
+    // the stale foreign completion. handleNotification's progress-reset guard
+    // (notificationTurnId !== turn.nativeTurnId) falls fully open on the unset
+    // id, so a FOREIGN turn's periodic progress would otherwise keep resetting
+    // the deadline forever while acceptedTurnWentTerminal can never fire — an
+    // unbounded hang. The fix refuses to arm keep-pending without a native id,
+    // so the loop fails closed immediately instead of hanging on foreign activity.
+    const threadId = request.params.threadId;
+    // Stale foreign completion BEFORE the response (buffered, requestAccepted=false).
+    notify('turn/completed', { threadId, turn: { id: 'turn-stale-unbound', status: 'completed' } });
+    // Success response with NO native id (anomaly).
+    respond(request.id, {});
+    // A foreign turn emits progress forever; our turn never speaks / goes terminal.
+    setInterval(() => {
+      notify('item/agentMessage/delta', {
+        threadId,
+        turnId: 'turn-foreign-keepalive',
+        itemId: 'message-foreign',
+        delta: '.',
+      });
+    }, 300);
+    return;
+  }
   if (behavior === 'pre-response-foreign-completion-long-progress' && turnAttempt === 1) {
     // REGRESSION for the keep-pending ceiling semantics: a STALE foreign
     // completion before the start response replays into reconcile with

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -85,6 +85,16 @@ function respond(id, result) {
   write({ id, result });
 }
 
+/** Write several JSON-RPC messages in ONE stdout chunk so the runner receives
+ * them in a single read. Adjacent pipe writes coalesce whenever the reader is
+ * scheduled late; this makes that transport condition deterministic for the
+ * completion-race regression repros. */
+function writeBatch(messages) {
+  process.stdout.write(messages
+    .map(message => JSON.stringify({ jsonrpc: '2.0', ...message }) + '\n')
+    .join(''));
+}
+
 function reject(id, code, message) {
   write({ id, error: { code, message } });
 }
@@ -430,6 +440,49 @@ function handle(request) {
         emitTurnCompletion(activeTurn.threadId, activeTurn.turnId, activeTurn.outputSchema);
         activeTurn = undefined;
       }
+      return;
+    }
+    if (behavior === 'steer-admit-reject-buffered' || behavior === 'steer-admit-reject-noncanon') {
+      if (!activeTurn || request.params.expectedTurnId !== activeTurn.turnId) {
+        reject(request.id, -32602, 'expectedTurnId does not match active turn');
+        return;
+      }
+      // The race this repro pins: the turn actually COMPLETED at the exact moment
+      // tryAdmitSteer's steer RPC lands. Emit turn/completed AND a definite steer
+      // rejection in ONE stdout chunk. The runner buffers the completion while
+      // steerInFlight is set, then the rejection catch must settle it —
+      // accepted.length is still 1 here (first steer never appended), so any
+      // inGroupMode-gated resume path would strand it (hang).
+      const { threadId, turnId } = activeTurn;
+      // noncanon: a DIFFERENT native id with NO full items. The rejection branch
+      // must NOT blindly trust it (that would attribute foreign/streamed text);
+      // it must route to bounded-history reconcile and fail closed (no match).
+      const completion = behavior === 'steer-admit-reject-noncanon'
+        ? {
+            method: 'turn/completed',
+            params: { threadId, turn: { id: 'turn-foreign-nc', status: 'completed' } },
+          }
+        : {
+            method: 'turn/completed',
+            params: {
+              threadId,
+              turn: {
+                id: turnId,
+                status: 'completed',
+                itemsView: 'full',
+                error: null,
+                items: [
+                  { id: 'user-root', type: 'userMessage', clientId: groupClientIds[0], content: [] },
+                  { id: 'message-final', type: 'agentMessage', phase: 'final_answer', text: 'buffered canonical answer' },
+                ],
+              },
+            },
+          };
+      writeBatch([
+        completion,
+        { id: request.id, error: { code: -32601, message: 'active turn not steerable' } },
+      ]);
+      activeTurn = undefined;
       return;
     }
     if (behavior === 'steer-group-mismatch') {
@@ -780,6 +833,21 @@ function handle(request) {
     });
     // The original turn/start is answered later — as an explicit RPC error — from
     // the turn/steer handler, after the steer is accepted.
+    return;
+  }
+  if ((behavior === 'steer-admit-reject-buffered' || behavior === 'steer-admit-reject-noncanon') && turnAttempt === 1) {
+    // Canonical proven by the START RESPONSE (not an exact turn/started): respond
+    // with the canonical id and emit only a BARE turn/started (no exact-client
+    // items), then HOLD the turn open. identityProof stays 'start_response', so
+    // the tryAdmitSteer rejection catch is the SOLE settle point for the buffered
+    // canonical completion. The follow-up (turnAttempt 2) that falls back after
+    // the rejection completes normally through completeTurn.
+    const threadId = request.params.threadId;
+    const turnId = `turn-fake-${turnAttempt}`;
+    activeTurn = { threadId, turnId, outputSchema: request.params.outputSchema };
+    groupClientIds = [request.params.clientUserMessageId ?? null];
+    respond(request.id, { turn: { id: turnId } });
+    notify('turn/started', { threadId, turn: { id: turnId } });
     return;
   }
   completeTurn(request);

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -744,6 +744,26 @@ function handle(request) {
     setTimeout(() => respond(request.id, { turn: { id: 'turn-response-B' } }), 120);
     return;
   }
+  if (behavior === 'pre-response-foreign-completion' && turnAttempt === 1) {
+    // A foreign turn/completed (NO client items, id unrelated to this turn)
+    // arrives BEFORE the turn/start response. Unlike completion-before-response-
+    // mismatch, this carries no exact-client items, so the runner cannot upgrade
+    // it to canonical proof. It must buffer it (requestAccepted=false), then
+    // after the response binds the real native id, replay it through the
+    // pendingCompletions else branch into reconcile — settling fail-closed
+    // (identity conflict, history has no match), NOT hanging forever. Direct
+    // regression for the else branch master lacked (silent drop → permanent
+    // pending → 90s no-progress alert).
+    const threadId = request.params.threadId;
+    const turnId = `turn-fake-${turnAttempt}`;
+    notify('turn/completed', {
+      threadId,
+      turn: { id: 'turn-foreign-pre-response', status: 'completed' },
+    });
+    respond(request.id, { turn: { id: turnId } });
+    notify('turn/started', { threadId, turn: { id: turnId } });
+    return;
+  }
   if (behavior === 'completion-A-started-B') {
     // R4-B2 crossing 1: exact completion A proves canonical=A; then an exact
     // turn/started B (DIFFERENT id) arrives → first-proof-wins must fence (a later

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -855,6 +855,63 @@ function handle(request) {
     notify('turn/started', { threadId, turn: { id: turnId } });
     return;
   }
+  if (behavior === 'pre-response-foreign-completion-long-progress' && turnAttempt === 1) {
+    // REGRESSION for the keep-pending ceiling semantics: a STALE foreign
+    // completion before the start response replays into reconcile with
+    // keepPendingWhileActive. The accepted turn then emits periodic progress
+    // (item/agentMessage/delta) for ~5s — LONGER than the test's 3s keep-pending
+    // ceiling — and only then sends its REAL completion. A fixed ceiling would
+    // kill the turn at 3s (identity conflict, real answer discarded); a
+    // progress-resettable ceiling must keep the turn pending and deliver the
+    // real answer.
+    const threadId = request.params.threadId;
+    const turnId = `turn-fake-${turnAttempt}`;
+    const clientId = request.params.clientUserMessageId ?? null;
+    notify('turn/completed', {
+      threadId,
+      turn: { id: 'turn-stale-pre-response', status: 'completed' },
+    });
+    respond(request.id, { turn: { id: turnId } });
+    notify('turn/started', { threadId, turn: { id: turnId } });
+    // Periodic progress every 1s — each delta resets the keep-pending ceiling.
+    const progressTimer = setInterval(() => {
+      notify('item/agentMessage/delta', {
+        threadId,
+        turnId,
+        itemId: 'message-progress',
+        delta: '.',
+      });
+    }, 1000);
+    // Real completion after 5s — beyond the 3s test ceiling but within the
+    // progress-resettable window (ceiling refreshed at 1s/2s/3s/4s).
+    setTimeout(() => {
+      clearInterval(progressTimer);
+      notify('item/completed', {
+        threadId,
+        turnId,
+        item: {
+          id: 'message-final',
+          type: 'agentMessage',
+          phase: 'final_answer',
+          text: 'real answer after long progress',
+        },
+      });
+      notify('turn/completed', {
+        threadId,
+        turn: {
+          id: turnId,
+          status: 'completed',
+          itemsView: 'full',
+          error: null,
+          items: [
+            { id: 'user-root', type: 'userMessage', clientId, content: request.params.input },
+            { id: 'message-final', type: 'agentMessage', phase: 'final_answer', text: 'real answer after long progress' },
+          ],
+        },
+      });
+    }, 5000);
+    return;
+  }
   if (behavior === 'completion-A-started-B') {
     // R4-B2 crossing 1: exact completion A proves canonical=A; then an exact
     // turn/started B (DIFFERENT id) arrives → first-proof-wins must fence (a later


### PR DESCRIPTION
优先级：P0

## 根因

Codex App 的 `turn/completed` 通知可能与 `turn/start` 或 `turn/steer` RPC 响应出现在同一个 stdout chunk。通知先于 RPC await 续体处理时，完成事件会在屏障期间被缓冲或丢弃；屏障清除后的结算路径又存在缺口，最终导致 `turn.done` 永不 resolve、final 事务不发送、会话持续 busy 并触发无进展告警。

## 改动

- `terminalCompletion` 同时缓存 canonical 与 non-canonical 完成事件。
- 新增 `resumeBufferedGroupCompletion`，在 start/steer 响应屏障清除后按身份直接结算或进入有界历史对账。
- steer 拒绝路径按身份分流，避免 foreign turn 文本误归属，也避免单 accepted turn 被永久搁置。
- `pendingCompletions` 无 exact/native 匹配时进入 reconcile，不再静默丢弃。
- idle 边沿增加 20ms debounce，并阻止 reconciliation 期间再次触发 steer admission。

## 影响面

改动仅位于 codex-app-runner，不修改 idle-detector、worker 或其他 CLI 的公共执行路径。普通会话和其他后端不受影响。

## 验证

- 新增 canonical 缓冲后拒绝结算、non-canonical 缓冲后 fail-closed 两个集成回归。
- fixture 支持在单个 chunk 内投递完成通知与拒绝响应。
- 新增 pre-response foreign completion 直接集成回归：无 exact items 且 turn id 不匹配时必须完成历史对账并 fail-closed，`turn.done` 最终 settle；回退修复后该用例会超时复现原故障。