### PR TITLE
fix(bridge): 普通会话 final_output 重试携带稳定 Lark uuid，消除歧义失败导致的重复回复

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -14,7 +14,7 @@ import { whiteboardEnabled } from '../services/whiteboard-store.js';
 import { cliSupportsNativeUsage } from '../services/transcript-resolver.js';
 import { cleanupTraexAskHooks, installHook } from '../adapters/hook-installer.js';
 import { hookCommandFor } from '../adapters/hook-command.js';
-import { randomBytes, randomUUID } from 'node:crypto';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { mayRestoreWriteAdmission } from '../adapters/backend/destroy-result.js';
 import { config } from '../config.js';
 import { readGlobalConfig } from '../global-config.js';
@@ -11585,6 +11585,30 @@ function finalOutputDedupeKey(ds: DaemonSession, msg: Extract<WorkerToDaemon, { 
   return `${msg.sessionId ?? ds.session.sessionId}:${msg.lastUuid || msg.turnId}`;
 }
 
+/**
+ * Stable Lark `uuid` idempotency token for an ordinary bridge final_output
+ * delivery. Derived from the same identity as the daemon-side dedupe key, so
+ * every retry of the same answer — and any duplicate IPC/re-emit of the same
+ * turn — collapses into ONE Lark message (the Feishu `uuid` field is
+ * idempotent for 1h and returns the original message_id on repeat).
+ *
+ * Without it, the daemon's own transient-failure retry
+ * (`FINAL_OUTPUT_RETRY_BACKOFF_MS`, up to 3 attempts) is at-least-once: an
+ * ambiguous first attempt whose reply the server accepted but whose response
+ * the client never saw (network error/timeout) creates a brand-new copy on
+ * each retry — the user-visible "the answer repeated 3 times" incident. The
+ * VC-managed (`vcp_*`) and Codex App settlement (`ca_*`) paths already carry
+ * their own stable provider keys; this closes the same gap for the ordinary
+ * thread/chat fallback path.
+ */
+function bridgeFinalOutputUuid(
+  ds: DaemonSession,
+  msg: Extract<WorkerToDaemon, { type: 'final_output' }>,
+): string {
+  const seed = finalOutputDedupeKey(ds, msg);
+  return `bf_${createHash('sha256').update(seed, 'utf8').digest('hex').slice(0, 46)}`;
+}
+
 function shouldDropMismatchedFinalOutput(
   ds: DaemonSession,
   msg: Extract<WorkerToDaemon, { type: 'final_output' }>,
@@ -12115,7 +12139,7 @@ function deliverFinalOutput(
                 }
               : {}),
           }
-        : codexAppSettlementReply;
+        : codexAppSettlementReply ?? { uuid: bridgeFinalOutputUuid(ds, msg) };
       const messageId = await scopedReply(
         canonicalOutput.content,
         canonicalOutput.msgType,

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -2043,6 +2043,72 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(cards[0]).not.toContain('Token ↑');
   });
 
+  it('keeps a stable Lark uuid across ordinary final_output retries so an ambiguous first attempt cannot duplicate the answer', async () => {
+    // Regression (duplicate-reply incident): the daemon retries final_output
+    // delivery up to 3 times on transient failure. The ordinary (non-VC,
+    // non-Codex-App) path used to carry NO Lark `uuid`, so an ambiguous first
+    // attempt — the server accepted the reply but the client saw a network
+    // error — created a brand-new copy on each retry. With 3 attempts the
+    // user saw the same answer up to 3 times. Every retry must now carry one
+    // stable uuid so the Feishu server (uuid field, 1h idempotent TTL)
+    // collapses retries into the original message.
+    const sessionReply = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ambiguous: server accepted, response lost'))
+      .mockResolvedValueOnce('om_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+
+    const ds = makeDs();
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+
+    // Attempt 1 (delay 0) — ambiguous failure.
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    // Attempt 2 (delay 5000) — success, carrying the SAME uuid as attempt 1.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(sessionReply).toHaveBeenCalledTimes(2);
+
+    const firstOpts = sessionReply.mock.calls[0][5] as { uuid?: string } | undefined;
+    const secondOpts = sessionReply.mock.calls[1][5] as { uuid?: string } | undefined;
+    expect(firstOpts?.uuid).toMatch(/^bf_[0-9a-f]{46}$/);
+    expect(secondOpts?.uuid).toBe(firstOpts!.uuid);
+    expect(ds.lastBridgeEmittedUuid).toBe(SCOPED_DEDUPE_KEY);
+  });
+
+  it('derives a distinct Lark uuid per ordinary turn so different answers are never collapsed', async () => {
+    const sessionReply = vi.fn(async () => 'om_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+
+    const ds = makeDs();
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+    __testOnly_deliverFinalOutput(
+      ds,
+      { ...finalOutputMsg(), lastUuid: 'uuid-2', turnId: 'turn-2' },
+      'tag',
+      0,
+    );
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(sessionReply).toHaveBeenCalledTimes(2);
+    const firstUuid = (sessionReply.mock.calls[0][5] as { uuid?: string }).uuid;
+    const secondUuid = (sessionReply.mock.calls[1][5] as { uuid?: string }).uuid;
+    expect(firstUuid).toMatch(/^bf_[0-9a-f]{46}$/);
+    expect(secondUuid).toMatch(/^bf_[0-9a-f]{46}$/);
+    expect(secondUuid).not.toBe(firstUuid);
+  });
+
   it('reads a sandboxed Claude transcript through the daemon reply-card boundary', async () => {
     const actualCostCalculator =
       await vi.importActual<typeof import('../src/core/cost-calculator.js')>(


### PR DESCRIPTION
优先级：P1

## 根因

daemon 的 `deliverFinalOutput` 使用 at-least-once 重试。若首次发送已被飞书接受，但客户端因超时或网络错误未收到响应，后续重试没有幂等键，每次都会产生一条新消息，用户最多看到同一回复重复三次。

## 改动

为普通桥接路径补充稳定 Lark uuid：从 `sessionId:lastUuid|turnId` 派生 `bf_<sha256>`，总长 49 字符，满足飞书 uuid 不超过 50 字符的约束。同一轮的重试和重复 IPC 重发会在飞书服务端折叠为同一条消息。

## 影响面

- 所有 CLI 的普通桥接 final_output 共用该路径。
- 话题、群聊和 adopt 会话的 `sessionReply` 分支均透传 uuid。
- HTTP wait/async 在发送前被拦截，文档评论使用其他 API，不受影响。
- VC 托管与 Codex App 结算继续使用各自已有的稳定 provider key。
- 投递发生在 daemon 侧，与 Pty/Tmux 后端无关。

## 验证

`bridge-final-output-retry.test.ts` 新增两项回归：同一轮重试的 uuid 稳定且格式合法；不同轮次的 uuid 不会互相折叠。