### PR TITLE
fix(lark): 修复 bot.added 自动开工首轮无 turnId 导致回复发不回飞书

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -18233,6 +18233,15 @@ async function handleBotAdded(
       anchor = chatId;
       scope = 'chat';
     }
+    // bot.added 是成员变更事件，没有用户 message_id 可作首轮 turn 身份。非 shared
+    // 路径没有 shared reply seed 兜底，若以 pendingTurnId=undefined 直接 fork，
+    // worker 发布的 managed_turn_origin 不含 turnId，CLI 首轮 `botmux send` 的
+    // managed-origin attestation 会被 daemon 以 origin_unproven 拒绝——首轮回复
+    // 发不回飞书。这里自行铸造首轮 turn 身份：
+    //   - thread scope：seed 消息本身就是可见锚点且是真实 om_ id，直接复用；
+    //   - chat scope：没有任何消息存在，铸造 daemon-owned 合成 turn id（同 trigger
+    //     会话的 trg_ 约定），仅作身份标识，不冒充用户消息 id。
+    const joinTurnId = scope === 'thread' ? anchor : `join_${randomUUID()}`;
     const dsKey = sessionKey(anchor, larkAppId);
     if (activeSessions.has(dsKey)) {
       logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 锚点已有会话，跳过`);
@@ -18277,7 +18286,9 @@ async function handleBotAdded(
       ownerOpenId: operatorOpenId,
       currentTurnTitle: title,
       workingDir: pinnedWorkingDir,
-      pendingTurnId: undefined,
+      // 非 shared 路径的首轮 turn 身份（joinTurnId）；shared 路径由
+      // armSharedReplyTarget 用 shared seed id 覆盖。
+      pendingTurnId: needsSharedReply ? undefined : joinTurnId,
     };
     const registration = await claimNewDaemonSession(activeSessions, ds);
     if (!registration.accepted) {
@@ -18290,7 +18301,9 @@ async function handleBotAdded(
       stageClaimedPendingRepoSetup(activeSessions, ds, {
         mode: autoWt ? 'auto_worktree' : 'picker',
         ...(autoWt && pinnedWorkingDir ? { baseDir: pinnedWorkingDir } : {}),
-        turnId: anchor,
+        // 非 shared 路径复用首轮 turn 身份；shared 路径保留 anchor（随后被
+        // armSharedReplyTarget 的 shared seed id 覆盖，此处仅作未 arm 时的兜底）。
+        turnId: needsSharedReply ? anchor : joinTurnId,
       });
     }
     const joinBootstrapExternallyTakenOver = (): boolean => (
@@ -18396,6 +18409,21 @@ async function handleBotAdded(
     // Register the anchor so a later duplicate bot.added for this chat is deduped
     // even in 话题群 (where dsKey is the seed id, not chatId).
     groupJoinAnchorByChat.set(chatLiveKey, dsKey);
+
+    // 持久化非 shared 首轮的 turn provenance（shared 路径已由 armSharedReplyTarget
+    // 写入）。thread scope 以 seed 为 reply root；chat scope 无根，落 plain chat
+    // 目标且不写 sender——首轮无真人发送者，--mention 回指天然走 incomplete →
+    // 显式指定的安全方向。没有这条记录，worker 虽带 turnId fork，daemon 侧的
+    // 首轮回复目标/参与者窗口仍无据可查。
+    if (!needsSharedReply) {
+      beginReplyTargetTurn(
+        ds,
+        scope === 'thread' ? anchor : undefined,
+        joinTurnId,
+        new Date(now).toISOString(),
+      );
+      sessionStore.updateSession(ds.session);
+    }
 
     // Auto-worktree: register PENDING, build worktree off-path, commit+fork later.
     if (pinnedWorkingDir && autoWt) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -18356,6 +18356,10 @@ async function handleBotAdded(
       // slow best-effort cleanup cannot block a retry or erase a replacement.
       const closing = closeSessionHelper(session.sessionId);
       if (activeSessions.get(dsKey) === ds) activeSessions.delete(dsKey);
+      // 入群去重锚点同样只清自己登记的那条：shared 路径在登记锚点之前就可能
+      // 回滚（此时 get 为 undefined，no-op）；非 shared 路径在锚点登记之后
+      // 回滚，不清掉会让后续 bot.added 带着 stale 锚点走进来。
+      if (groupJoinAnchorByChat.get(chatLiveKey) === dsKey) groupJoinAnchorByChat.delete(chatLiveKey);
       await closing;
     };
 
@@ -18416,13 +18420,27 @@ async function handleBotAdded(
     // 显式指定的安全方向。没有这条记录，worker 虽带 turnId fork，daemon 侧的
     // 首轮回复目标/参与者窗口仍无据可查。
     if (!needsSharedReply) {
-      beginReplyTargetTurn(
-        ds,
-        scope === 'thread' ? anchor : undefined,
-        joinTurnId,
-        new Date(now).toISOString(),
-      );
-      sessionStore.updateSession(ds.session);
+      try {
+        beginReplyTargetTurn(
+          ds,
+          scope === 'thread' ? anchor : undefined,
+          joinTurnId,
+          new Date(now).toISOString(),
+        );
+        sessionStore.updateSession(ds.session);
+      } catch (err) {
+        // 持久化失败（文件系统/数据库瞬态错误）时必须回滚已发布的会话：此时
+        // 会话已进 activeSessions 且 groupJoinAnchorByChat 已登记，finally 只
+        // settle barrier 和释放 in-flight 锁——留下 active 但 worker-null 的会话
+        // 会让后续 bot.added 被无限去重，自动开工无法重试。同
+        // stageClaimedPendingRepoSetup 的 unpublish/close 回滚。
+        logger.warn(
+          `[auto-start:入群] ${chatId.substring(0, 12)} 首轮 turn provenance 持久化失败，回滚会话注册：`
+          + `${err instanceof Error ? err.message : String(err)}`,
+        );
+        await rollbackRegisteredJoinSession();
+        return;
+      }
     }
 
     // Auto-worktree: register PENDING, build worktree off-path, commit+fork later.

--- a/test/group-join-shared-routing.test.ts
+++ b/test/group-join-shared-routing.test.ts
@@ -285,7 +285,14 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     expect(mocks.sendMessage).not.toHaveBeenCalled();
     expect(ds?.scope).toBe('chat');
     expect(ds?.session.currentReplyTarget).toBeUndefined();
-    expect(mocks.forkWorker).toHaveBeenCalledWith(ds, expect.anything(), false);
+    // 平铺 chat 没有用户消息可锚定，首轮携带 daemon-owned 合成 turn id（join_ 前缀），
+    // 而不是 false——否则 worker 发布的 managed_turn_origin 无 turnId，首轮
+    // `botmux send` 会被 origin_unproven 拒绝。
+    expect(mocks.forkWorker).toHaveBeenCalledWith(
+      ds,
+      expect.anything(),
+      expect.objectContaining({ turnId: expect.stringMatching(/^join_/) }),
+    );
   });
 
   it('等待仓库选择时把卡片和延迟首轮留在同一个话题', async () => {
@@ -952,7 +959,9 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     expect(ds?.scope).toBe('thread');
     expect(ds?.session.rootMessageId).toBe('om_join_seed');
     expect(ds?.session.currentReplyTarget).toBeUndefined();
-    expect(mocks.forkWorker).toHaveBeenCalledWith(ds, expect.anything(), false);
+    // 话题群自动开工：seed 消息 id 即首轮权威 turnId（修复前为 false，首轮回复
+    // 发不回飞书）。
+    expect(mocks.forkWorker).toHaveBeenCalledWith(ds, expect.anything(), { turnId: 'om_join_seed' });
   });
 
   it('普通群 new-topic 模式开话题并锚定独立 thread-scope session', async () => {
@@ -980,6 +989,202 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     expect(ds?.session.rootMessageId).toBe('om_join_seed');
     // new-topic 是独立会话（非 shared 复用），不 arm shared reply target。
     expect(ds?.session.currentReplyTarget).toBeUndefined();
-    expect(mocks.forkWorker).toHaveBeenCalledWith(ds, expect.anything(), false);
+    // 同话题群：seed 消息 id 即首轮权威 turnId。
+    expect(mocks.forkWorker).toHaveBeenCalledWith(ds, expect.anything(), { turnId: 'om_join_seed' });
+  });
+});
+
+describe('handleBotAdded — 非 shared 首轮 turn 身份与 provenance', () => {
+  // 回归：bot.added 没有用户 message_id，非 shared 自动开工曾以
+  // pendingTurnId=undefined fork，worker 发布的 managed_turn_origin 不含
+  // turnId，CLI 首轮 `botmux send` 的 managed-origin attestation 被 daemon 以
+  // origin_unproven 拒绝（首轮回复发不回飞书）。
+  const forkedTurnId = (): string | undefined => {
+    const arg = mocks.forkWorker.mock.calls[0]?.[2];
+    if (arg && typeof arg === 'object') return (arg as { turnId?: string }).turnId;
+    return undefined;
+  };
+
+  it('话题群自动开工：seed 即首轮 turnId 且持久化匹配的 turn provenance', async () => {
+    mocks.getChatContext.mockImplementationOnce(async (_appId: string, targetChatId: string) => ({
+      chatId: targetChatId,
+      name: '话题群',
+      description: null,
+      mode: 'topic',
+      fetchStatus: 'ok',
+    }));
+    const { daemon, registry, types } = modules;
+    const appId = 'app_join_topic_turn_id';
+    const chatId = 'oc_join_topic_turn_id';
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      defaultWorkingDir: tempDir('repo-topic-turn-id'),
+      regularGroupReplyMode: 'shared',
+    });
+
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+
+    const ds = daemon.__testOnly_activeSessions.get(types.sessionKey('om_join_seed', appId));
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    const forkTurnId = forkedTurnId();
+    expect(forkTurnId).toBe('om_join_seed');
+    // 持久化了匹配的 turn provenance：per-turn 回复目标 + 冻结的 dispatch 上下文。
+    expect(ds?.session.replyTargets?.[forkTurnId!]).toBeDefined();
+    expect(ds?.session.turnReplyContexts?.[forkTurnId!]).toMatchObject({
+      target: { mode: 'thread', rootMessageId: 'om_join_seed' },
+    });
+    // 模拟 worker 发布 managed_turn_origin（worker-pool 收到 IPC 后的写入）：
+    // 修复前 fork 不带 turnId → managedTurnOrigin.turnId 缺失 → attest 403。
+    ds!.managedTurnOrigin = { capability: 'cap-test', turnId: forkTurnId };
+    expect(ds?.managedTurnOrigin?.turnId).toBe(forkTurnId);
+  });
+
+  it('普通群 new-topic 自动开工：seed 即首轮 turnId 且 provenance 落 thread', async () => {
+    const { daemon, registry, types } = modules;
+    const appId = 'app_join_new_topic_turn_id';
+    const chatId = 'oc_join_new_topic_turn_id';
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      defaultWorkingDir: tempDir('repo-new-topic-turn-id'),
+      regularGroupReplyMode: 'new-topic',
+    });
+
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+
+    const ds = daemon.__testOnly_activeSessions.get(types.sessionKey('om_join_seed', appId));
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    const forkTurnId = forkedTurnId();
+    expect(forkTurnId).toBe('om_join_seed');
+    expect(ds?.session.replyTargets?.[forkTurnId!]).toBeDefined();
+    expect(ds?.session.turnReplyContexts?.[forkTurnId!]).toMatchObject({
+      target: { mode: 'thread', rootMessageId: 'om_join_seed' },
+    });
+    ds!.managedTurnOrigin = { capability: 'cap-test', turnId: forkTurnId };
+    expect(ds?.managedTurnOrigin?.turnId).toBe(forkTurnId);
+  });
+
+  it('平铺 chat 自动开工：合成 join_ turnId 且 provenance 落 plain chat', async () => {
+    const { daemon, registry, types } = modules;
+    const appId = 'app_join_chat_turn_id';
+    const chatId = 'oc_join_chat_turn_id';
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      defaultWorkingDir: tempDir('repo-chat-turn-id'),
+      regularGroupReplyMode: 'chat',
+    });
+
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+
+    const ds = daemon.__testOnly_activeSessions.get(types.sessionKey(chatId, appId));
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    const forkTurnId = forkedTurnId();
+    // 平铺 chat 没有用户消息可锚定：铸造 daemon-owned 合成 turn id（join_ 前缀 +
+    // UUID），不冒充 om_ 用户消息 id。
+    expect(forkTurnId).toMatch(/^join_[a-f0-9-]{36}$/);
+    expect(forkTurnId!.startsWith('om_')).toBe(false);
+    expect(ds?.session.replyTargets?.[forkTurnId!]).toBeDefined();
+    expect(ds?.session.turnReplyContexts?.[forkTurnId!]).toMatchObject({
+      target: { mode: 'plain', chatId },
+    });
+    // 合成 turn 不写 currentReplyTarget（无 reply root）。
+    expect(ds?.session.currentReplyTarget).toBeUndefined();
+    ds!.managedTurnOrigin = { capability: 'cap-test', turnId: forkTurnId };
+    expect(ds?.managedTurnOrigin?.turnId).toBe(forkTurnId);
+  });
+
+  it('无默认目录走 repo 选择卡：thread scope 延迟首轮仍携带 seed turnId', async () => {
+    const { daemon, registry, types } = modules;
+    const appId = 'app_join_picker_thread_turn_id';
+    const chatId = 'oc_join_picker_thread_turn_id';
+    const scanDir = tempDir('scan-picker-thread-turn-id');
+    mocks.getProjectScanDirs.mockReturnValueOnce([scanDir]);
+    mocks.scanMultipleProjects.mockReturnValueOnce([{
+      name: 'botmux',
+      path: scanDir,
+      type: 'repo',
+      branch: 'master',
+    }]);
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      regularGroupReplyMode: 'new-topic',
+      // 关闭对等继承：本文件前序用例在持久化 session store 里留下了同锚点
+      // (om_join_seed) 且带 workingDir 的会话，否则会被 findInheritablePeer
+      // 继承成 pinned dir，绕过 repo 选择卡路径。
+      botToBotSameDir: false,
+    });
+
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+
+    // 延迟启动：不立即 fork，首轮 turn 身份同时落在 pendingTurnId 与持久化的
+    // pendingRepoSetup.turnId 上——commitRepoSelection 的 deferred fork 二选一
+    // 都必须拿到 seed id（修复前 staged 的是 anchor=seed 但 pendingTurnId 为
+    // undefined，且 chat scope 下 anchor 是 oc_ chatId，会被当成 turnId 发出去）。
+    const ds = daemon.__testOnly_activeSessions.get(types.sessionKey('om_join_seed', appId));
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+    expect(ds?.pendingRepo).toBe(true);
+    expect(ds?.pendingTurnId).toBe('om_join_seed');
+    expect(ds?.session.pendingRepoSetup?.turnId).toBe('om_join_seed');
+    expect(ds?.session.replyTargets?.['om_join_seed']).toBeDefined();
+    expect(ds?.session.turnReplyContexts?.['om_join_seed']).toMatchObject({
+      target: { mode: 'thread', rootMessageId: 'om_join_seed' },
+    });
+  });
+
+  it('无默认目录走 repo 选择卡：chat scope 延迟首轮携带 join_ turnId 而非 oc_ chatId', async () => {
+    const { daemon, registry, types } = modules;
+    const appId = 'app_join_picker_chat_turn_id';
+    const chatId = 'oc_join_picker_chat_turn_id';
+    const scanDir = tempDir('scan-picker-chat-turn-id');
+    mocks.getProjectScanDirs.mockReturnValueOnce([scanDir]);
+    mocks.scanMultipleProjects.mockReturnValueOnce([{
+      name: 'botmux',
+      path: scanDir,
+      type: 'repo',
+      branch: 'master',
+    }]);
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      regularGroupReplyMode: 'chat',
+    });
+
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+
+    const ds = daemon.__testOnly_activeSessions.get(types.sessionKey(chatId, appId));
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+    expect(ds?.pendingRepo).toBe(true);
+    // 修复前 staged turnId 是 anchor=oc_ chatId（把 chatId 当 turnId 发出）；
+    // 修复后两处都是 daemon-owned 合成 id。
+    expect(ds?.pendingTurnId).toMatch(/^join_[a-f0-9-]{36}$/);
+    expect(ds?.session.pendingRepoSetup?.turnId).toBe(ds?.pendingTurnId);
+    const joinTurnId = ds!.pendingTurnId!;
+    expect(ds?.session.replyTargets?.[joinTurnId]).toBeDefined();
+    expect(ds?.session.turnReplyContexts?.[joinTurnId]).toMatchObject({
+      target: { mode: 'plain', chatId },
+    });
   });
 });

--- a/test/group-join-shared-routing.test.ts
+++ b/test/group-join-shared-routing.test.ts
@@ -1187,4 +1187,55 @@ describe('handleBotAdded — 非 shared 首轮 turn 身份与 provenance', () =>
       target: { mode: 'plain', chatId },
     });
   });
+
+  it('provenance 持久化失败时回滚会话注册，下次 bot.added 不被去重', async () => {
+    // 回归：首轮 turn provenance 的 sessionStore.updateSession 若抛错（文件系统/
+    // 数据库瞬态失败），会话已发布到 activeSessions 且 groupJoinAnchorByChat 已
+    // 登记。修复前 finally 只 settle barrier/释放 in-flight 锁，留下 active 但
+    // worker-null 的会话，后续 bot.added 被无限去重，自动开工无法重试。
+    const { daemon, registry, types } = modules;
+    const sessionStore = await import('../src/services/session-store.js');
+    const appId = 'app_join_provenance_persist_failure';
+    const chatId = 'oc_join_provenance_persist_failure';
+    const key = types.sessionKey(chatId, appId);
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      defaultWorkingDir: tempDir('repo-provenance-persist-failure'),
+      regularGroupReplyMode: 'chat',
+    });
+
+    // 只在「带 turn provenance 的那次落盘」上注入一次瞬态失败（ENOSPC 替身）：
+    // 注册前的初始字段落盘不带 replyTargets，照常透传。
+    const realUpdateSession = sessionStore.updateSession;
+    let failedOnce = false;
+    let failedSessionId: string | undefined;
+    const updateSpy = vi.spyOn(sessionStore, 'updateSession').mockImplementation((s) => {
+      if (!failedOnce && s.replyTargets && Object.keys(s.replyTargets).length > 0) {
+        failedOnce = true;
+        failedSessionId = s.sessionId;
+        throw new Error('ENOSPC: no space left on device');
+      }
+      return realUpdateSession(s);
+    });
+
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+
+    // 回滚：会话从 activeSessions 移除、store 记录被 close、没有 fork——
+    // 不留下 worker-null 的 active 会话。
+    expect(failedOnce).toBe(true);
+    expect(daemon.__testOnly_activeSessions.get(key)).toBeUndefined();
+    expect(sessionStore.getSession(failedSessionId!)?.status).toBe('closed');
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+    updateSpy.mockRestore();
+
+    // 重试：下一次 bot.added 不被去重，正常注册并 fork。
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+    expect(daemon.__testOnly_activeSessions.get(key)).toBeDefined();
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
优先级：P1

## 根因

`bot.added` 是成员变更事件，没有用户 `message_id`。非 shared 自动开工路径的 `pendingTurnId` 因此为 undefined，worker 发布的 managed turn origin 不含 turnId，CLI 首轮 `botmux send` 会被 daemon 以 `origin_unproven` 拒绝。

## 改动

- thread scope（话题群 / new-topic）复用 seed 消息 id 作为首轮权威 turnId，并持久化对应 provenance。
- chat scope（平铺群聊）生成 daemon-owned 的 `join_<uuid>` 合成 turn id，不冒充用户消息 id，并记录 plain-chat provenance。
- shared 路径继续由 shared seed id 锚定，行为不变。
- repo picker 和 auto-worktree 延迟启动路径复用同一首轮 turn 身份。

## 影响面

覆盖话题群、普通群 new-topic、平铺 chat 的 bot.added 自动开工，以及需要先选择仓库或创建 worktree 的延迟启动组合。正常用户消息触发和 shared 路径不变。

## 验证

`group-join-shared-routing` 新增 5 个回归用例，覆盖三种会话范围的首轮 turn 身份、provenance 链和无默认目录时的 repo 选择延迟路径；同时更新 3 处固化旧缺陷行为的断言。