### PR TITLE
fix(usage-limit): 修复 CLI 仍在工作时误报限额已达

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -391,6 +391,7 @@ import type {
   DisplayMode,
   StreamStatus,
   QueuedActivationTailEntry,
+  ScreenStatus,
 } from '../types.js';
 import {
   appendAcceptedCodexAppDispatch,
@@ -416,7 +417,7 @@ import { hasProtectedSessionMutationOwnership } from './session-mutation-guard.j
 import { DONE_REACTION_EMOJI_TYPE } from './pending-response.js';
 import { buildTerminalUrl } from './terminal-url.js';
 import { prependBotmuxBin, resolveBotmuxWrapperBinDir } from './botmux-wrapper.js';
-import { usageLimitStateKey, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
+import { usageLimitStateKey, isActiveWorkRuntimeStatus, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
 import {
   evaluateVcMeetingManagedSend,
   resolveVcMeetingImTurnOrigin,
@@ -1747,6 +1748,35 @@ function updateUsageLimitState(ds: DaemonSession, usageLimit?: CliUsageLimitStat
   ds.usageLimit = usageLimit;
   persistStreamCardState(ds);
   armUsageLimitRetryTimer(ds, previous);
+}
+
+/**
+ * Resolve the daemon-side screen status in the presence of a usage limit.
+ *
+ * Limit state is intentionally sticky across ticks that carry no fresh verdict
+ * (the worker re-emits only while the limit text stays on screen; screenshot
+ * ticks arrive every 10s), so a recorded limit survives ordinary idle frames
+ * and the cooldown card stays up until the user retries. But it must
+ * self-heal on evidence of active work: a blocked CLI does not produce
+ * `working`/`analyzing` frames, so a limit that survives such a frame was a
+ * false positive (a flicker-frame screen scan, or a structured emit the CLI
+ * recovered from). Without this the card keeps showing 「限额已达」 for the
+ * rest of the turn even though the CLI is demonstrably still running — the
+ * reported 误报. The worker-side status gate (detectScreenUsageLimit) prevents
+ * the detection while active; this is the daemon-side net for limits recorded
+ * during an idle flicker before work resumed.
+ */
+function resolveUsageAwareScreenStatus(
+  ds: DaemonSession,
+  workerStatus: ScreenStatus,
+  freshUsageLimit: CliUsageLimitState | undefined,
+): ScreenStatus {
+  if (freshUsageLimit) return 'limited';
+  if (ds.usageLimit && isActiveWorkRuntimeStatus(workerStatus)) {
+    clearUsageLimitState(ds);
+    return workerStatus;
+  }
+  return ds.usageLimit ? 'limited' : workerStatus;
 }
 
 const WORKER_ERROR_MARKER = '[botmux-worker-error]';
@@ -10527,7 +10557,7 @@ function setupWorkerHandlers(
         const prevStatus = ds.lastScreenStatus;
         updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenContent = msg.content;
-        ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
+        ds.lastScreenStatus = resolveUsageAwareScreenStatus(ds, msg.status, msg.usageLimit);
         bumpStreamCardStatusRevision(ds);
         // A suspend that arrived mid-turn parked itself here. Defer until this
         // screen_update has finished using process state — suspendWorker nulls
@@ -10755,7 +10785,7 @@ function setupWorkerHandlers(
         if (ds.streamCardPending) break;
         const prevStatus = ds.lastScreenStatus;
         updateUsageLimitState(ds, msg.usageLimit);
-        ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
+        ds.lastScreenStatus = resolveUsageAwareScreenStatus(ds, msg.status, msg.usageLimit);
         bumpStreamCardStatusRevision(ds);
         // Same deferred-suspend checkpoint as the screen_update branch, and
         // deferred for the same reason (see runPendingSuspendIfSettled).

--- a/src/utils/cli-usage-limit.ts
+++ b/src/utils/cli-usage-limit.ts
@@ -116,6 +116,20 @@ export interface DetectUsageLimitOptions {
    * unaffected — it has no structured equivalent yet.
    */
   suppressRateKind?: boolean;
+  /**
+   * Whether the CLI is demonstrably producing output (PTY activity within the
+   * caller's freshness window). The active-work gate in detectScreenUsageLimit
+   * only suppresses the verdict while this is true. `working`/`analyzing`
+   * alone do not prove output is progressing — `working` is the default
+   * projection whenever promptReady === false — so a non-structured CLI
+   * blocked at a rate/quota error screen that never renders its configured
+   * ready prompt stays `working` forever (only Codex App projects `stalled`),
+   * and a genuine blocking 429 would be suppressed indefinitely. Pass `false`
+   * when PTY output has been quiescent past the window so the detector still
+   * runs on a parked error screen. Omit (or pass `true`) to keep the
+   * conservative suppress-on-working behavior.
+   */
+  outputActive?: boolean;
 }
 
 /**
@@ -130,6 +144,13 @@ export interface DetectUsageLimitOptions {
  * screen is the CLI's own output or a transient retry it is handling
  * internally, and a screen-scan verdict must be suppressed. Root cause of the
  * "CLI 还在跑却提示限额已达" false reports (Codex/Hermes, 2026-08).
+ *
+ * Caveat (refined by detectScreenUsageLimit's `outputActive` option): in this
+ * worker `working` is the DEFAULT projection whenever promptReady === false,
+ * not proof that output is progressing. A non-structured CLI blocked at a
+ * rate-limit error screen that never renders its ready prompt stays `working`
+ * forever (only Codex App projects `stalled`), so the status alone is not a
+ * safe suppression gate — pair it with an output-activity signal.
  */
 export function isActiveWorkRuntimeStatus(status: string | null | undefined): boolean {
   return status === 'working' || status === 'analyzing';
@@ -141,6 +162,13 @@ export function isActiveWorkRuntimeStatus(status: string | null | undefined): bo
  * choke point owns the "active work suppresses the verdict" policy — keeping
  * it out of the pure text classifier, whose existing callers (turn-start
  * stale-banner snapshot) have no fresh status context.
+ *
+ * The suppression requires BOTH an active-work status AND actively progressing
+ * output (`outputActive !== false`). When `outputActive` is `false` the CLI is
+ * parked (PTY quiescent) even though the status says `working` — a blocked
+ * non-structured CLI's error screen — so the detector must still run. Callers
+ * that cannot assess output activity omit the hint and keep suppressing on
+ * working/analyzing (the conservative default).
  */
 export function detectScreenUsageLimit(
   text: string,
@@ -148,7 +176,9 @@ export function detectScreenUsageLimit(
   now: Date = new Date(),
   opts: DetectUsageLimitOptions = {},
 ): CliUsageLimitDetection {
-  if (isActiveWorkRuntimeStatus(status)) return { limited: false };
+  if (isActiveWorkRuntimeStatus(status) && opts.outputActive !== false) {
+    return { limited: false };
+  }
   return detectCliUsageLimit(text, now, opts);
 }
 

--- a/src/utils/cli-usage-limit.ts
+++ b/src/utils/cli-usage-limit.ts
@@ -119,6 +119,40 @@ export interface DetectUsageLimitOptions {
 }
 
 /**
+ * Whether a runtime screen status proves the CLI is actively doing work.
+ *
+ * The screen-scan detector cannot tell a live limit block from limit-shaped
+ * text the CLI itself put on screen — a model answer quoting a business 429,
+ * tool output, docs, test fixtures. The runtime status disambiguates: a
+ * rate/usage limit blocks the CLI, and a blocked CLI sits at an error/prompt
+ * screen (`idle`/`stalled`); it does not keep producing output. So while the
+ * CLI is `working`/`analyzing`, any "429 / rate limit / usage limit" text on
+ * screen is the CLI's own output or a transient retry it is handling
+ * internally, and a screen-scan verdict must be suppressed. Root cause of the
+ * "CLI 还在跑却提示限额已达" false reports (Codex/Hermes, 2026-08).
+ */
+export function isActiveWorkRuntimeStatus(status: string | null | undefined): boolean {
+  return status === 'working' || status === 'analyzing';
+}
+
+/**
+ * Screen-frame detection: `detectCliUsageLimit` gated on the frame's runtime
+ * status. The worker's per-frame classify path goes through here so a single
+ * choke point owns the "active work suppresses the verdict" policy — keeping
+ * it out of the pure text classifier, whose existing callers (turn-start
+ * stale-banner snapshot) have no fresh status context.
+ */
+export function detectScreenUsageLimit(
+  text: string,
+  status: string | null | undefined,
+  now: Date = new Date(),
+  opts: DetectUsageLimitOptions = {},
+): CliUsageLimitDetection {
+  if (isActiveWorkRuntimeStatus(status)) return { limited: false };
+  return detectCliUsageLimit(text, now, opts);
+}
+
+/**
  * Whether a CLI adapter is authoritative for structured rate limits — i.e. it
  * actually PUBLISHES a `limited` screen_update from a machine signal in its
  * transcript rather than from scraping screen text. Two families qualify:

--- a/src/utils/usage-limit-tracker.ts
+++ b/src/utils/usage-limit-tracker.ts
@@ -21,10 +21,31 @@ export interface UsageLimitTracker<S extends string = string> {
   classify(content: string, status: S): { status: S | 'limited'; usageLimit?: CliUsageLimitState };
   detectedThisTurn(seq: number): boolean;
   noteStructuredLimit(state: CliUsageLimitState): void;
+  /**
+   * A turn completed successfully (a harvested bridge final_output is being
+   * emitted). Clears the structured-limit latch so a stale limit is not
+   * re-emitted on the next classify(). Mirrors the daemon's final_output
+   * self-heal (worker-pool clears ds.usageLimit on a real harvested answer):
+   * in an adopted session the user can recover from a structured rate limit
+   * in their own terminal without triggering beginTurn(), so without this the
+   * latch would re-pin the card / Dashboard after the daemon already cleared.
+   */
+  noteTurnCompleted(): void;
 }
 
 export function createUsageLimitTracker<S extends string = string>(opts: {
   isRateKindSuppressed: () => boolean;
+  /**
+   * Whether the CLI is demonstrably producing output (PTY activity within the
+   * caller's freshness window). The screen-scan active-work gate only
+   * suppresses the verdict while this returns true: a `working` status alone
+   * does not prove output is progressing (it is the default projection
+   * whenever promptReady === false), so a non-structured CLI blocked at a
+   * rate-limit error screen that never renders its ready prompt would
+   * otherwise be suppressed forever. Omit to keep the conservative
+   * suppress-on-working behavior (used by pure unit tests).
+   */
+  isOutputActive?: () => boolean;
 }): UsageLimitTracker<S> {
   let turnSeq = 0;
   let detectedTurn: number | undefined;
@@ -67,8 +88,15 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
       // model answer / tool output quoting a business 429) or a transient retry
       // it is handling internally — never a live block, which would park the
       // CLI at an error/prompt screen (idle/stalled). Suppressing here is the
-      // primary fix for the "CLI 还在跑却提示限额已达" false reports.
-      const detected = detectScreenUsageLimit(content, status, undefined, { suppressRateKind: opts.isRateKindSuppressed() });
+      // primary fix for the "CLI 还在跑却提示限额已达" false reports. The
+      // isOutputActive hint refines the gate: `working` alone does not prove
+      // output is progressing, so a parked error screen on a non-structured
+      // CLI is still detected (see cli-usage-limit.detectScreenUsageLimit).
+      const outputActive = opts.isOutputActive?.();
+      const detected = detectScreenUsageLimit(content, status, undefined, {
+        suppressRateKind: opts.isRateKindSuppressed(),
+        ...(outputActive !== undefined ? { outputActive } : {}),
+      });
       if (!detected.limited) {
         // Re-emit an authoritative structured limit recorded this turn so a
         // genuinely blocked CLI keeps its card (see activeStructured).
@@ -100,6 +128,16 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
       suppressedRetryReadyKey = undefined;
       detectedTurn = turnSeq;
       activeStructured = { seq: turnSeq, state };
+    },
+    // A successfully harvested turn (bridge final_output) is definitive
+    // evidence the CLI recovered from any structured limit that parked it.
+    // Drop the latch so the next classify() does not re-emit the stale limit
+    // — the daemon's final_output handler already cleared ds.usageLimit for
+    // the same recovery, and a re-emit would re-pin the card / Dashboard.
+    // detectedTurn is intentionally left as a historical fact (it self-clears
+    // on the next beginTurn).
+    noteTurnCompleted(): void {
+      activeStructured = undefined;
     },
   };
 }

--- a/src/utils/usage-limit-tracker.ts
+++ b/src/utils/usage-limit-tracker.ts
@@ -1,0 +1,105 @@
+import {
+  detectCliUsageLimit,
+  detectScreenUsageLimit,
+  usageLimitStateKey,
+  type CliUsageLimitState,
+} from './cli-usage-limit.js';
+
+/**
+ * Per-turn usage-limit state machine. Owns the turn counter, the
+ * "did this turn hit a limit" flag, the stale retry-ready banner suppression,
+ * and the stickiness of authoritative STRUCTURED limits — so classify()'s
+ * state writes are explicit method calls rather than hidden mutations of
+ * module globals.
+ *
+ * Generic over the runtime status union so the worker can plug in its
+ * RuntimeScreenStatus while tests drive it with plain strings.
+ */
+export interface UsageLimitTracker<S extends string = string> {
+  currentTurn(): number;
+  beginTurn(snapshot: string): number;
+  classify(content: string, status: S): { status: S | 'limited'; usageLimit?: CliUsageLimitState };
+  detectedThisTurn(seq: number): boolean;
+  noteStructuredLimit(state: CliUsageLimitState): void;
+}
+
+export function createUsageLimitTracker<S extends string = string>(opts: {
+  isRateKindSuppressed: () => boolean;
+}): UsageLimitTracker<S> {
+  let turnSeq = 0;
+  let detectedTurn: number | undefined;
+  let suppressedRetryReadyKey: string | undefined;
+  // A STRUCTURED limit (transcript error record, Claude/Codex) is authoritative
+  // and one-shot at the source (UUID-deduped emit). Re-emit it on every
+  // classify() until the turn ends: a genuinely blocked CLI keeps its
+  // 「限额已达」 card even while the active-work gate suppresses the
+  // (rate-suppressed) screen text — otherwise a working frame that races ahead
+  // of prompt detection would let the daemon-side self-heal clear an
+  // authoritative limit, and nothing would re-report it for the rest of the
+  // blocked turn. Screen-scan detections stay one-shot: the daemon self-heal is
+  // the correct remedy for THEIR false positives (idle-flicker mis-hits).
+  let activeStructured: { seq: number; state: CliUsageLimitState } | undefined;
+
+  return {
+    currentTurn(): number {
+      return turnSeq;
+    },
+    // Open a new turn; remember any stale retry-ready banner still on screen so
+    // classify() doesn't re-flag it as a fresh limit this turn.
+    beginTurn(snapshot: string): number {
+      turnSeq++;
+      detectedTurn = undefined;
+      activeStructured = undefined;
+      const current = detectCliUsageLimit(snapshot, undefined, { suppressRateKind: opts.isRateKindSuppressed() });
+      suppressedRetryReadyKey = current.limited && current.retryReady
+        ? usageLimitStateKey(current)
+        : undefined;
+      return turnSeq;
+    },
+    // Map a runtime status to a usage-limit-aware status, recording whether this
+    // turn hit a limit (read back via detectedThisTurn).
+    classify(
+      content: string,
+      status: S,
+    ): { status: S | 'limited'; usageLimit?: CliUsageLimitState } {
+      // Gate the screen-scan verdict on the runtime status: while the CLI is
+      // actively working, limit-shaped text on screen is its own output (a
+      // model answer / tool output quoting a business 429) or a transient retry
+      // it is handling internally — never a live block, which would park the
+      // CLI at an error/prompt screen (idle/stalled). Suppressing here is the
+      // primary fix for the "CLI 还在跑却提示限额已达" false reports.
+      const detected = detectScreenUsageLimit(content, status, undefined, { suppressRateKind: opts.isRateKindSuppressed() });
+      if (!detected.limited) {
+        // Re-emit an authoritative structured limit recorded this turn so a
+        // genuinely blocked CLI keeps its card (see activeStructured).
+        if (activeStructured?.seq === turnSeq) {
+          return { status: 'limited', usageLimit: activeStructured.state };
+        }
+        return { status };
+      }
+
+      const key = usageLimitStateKey(detected);
+      if (detected.retryReady && key === suppressedRetryReadyKey) {
+        return { status };
+      }
+
+      suppressedRetryReadyKey = undefined;
+      detectedTurn = turnSeq;
+      return { status: 'limited', usageLimit: detected };
+    },
+    detectedThisTurn(seq: number): boolean {
+      return detectedTurn === seq;
+    },
+    // Record a limit that came from a STRUCTURED signal (transcript error
+    // record) rather than screen text. Mirrors classify()'s state writes so
+    // the tracker stays coherent: mark this turn as having hit a limit (read
+    // by detectedThisTurn for the submit-confirmation recheck), clear any
+    // stale retry-ready suppression, and hold the state for re-emission until
+    // the turn ends. The actual emit is done by the caller.
+    noteStructuredLimit(state: CliUsageLimitState): void {
+      suppressedRetryReadyKey = undefined;
+      detectedTurn = turnSeq;
+      activeStructured = { seq: turnSeq, state };
+    },
+  };
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3972,12 +3972,28 @@ function structuredRateLimitAuthoritative(): boolean {
   return isStructuredRateLimitAuthoritative(cliAdapter);
 }
 
+/**
+ * PTY-quiescence window for the usage-limit active-work gate. A `working`
+ * status alone does not prove output is progressing (it is the default
+ * projection whenever promptReady === false), so the screen-scan suppression
+ * only applies while PTY output is this fresh. A non-structured CLI blocked at
+ * a rate/quota error screen that never renders its ready prompt goes silent
+ * past this window and is correctly detected instead of being suppressed
+ * forever. Aligns with the StuckDetector's PTY-quiescence threshold.
+ */
+const USAGE_LIMIT_OUTPUT_ACTIVE_WINDOW_MS = 15_000;
+
+function isOutputActivelyProgressing(): boolean {
+  return Date.now() - lastPtyActivityAtMs < USAGE_LIMIT_OUTPUT_ACTIVE_WINDOW_MS;
+}
+
 // Per-turn usage-limit state machine (extracted to utils/usage-limit-tracker
 // for unit testing). The structured-limit stickiness it owns is load-bearing:
 // a one-shot transcript emit must survive the daemon's working-frame self-heal
 // while the CLI stays genuinely blocked.
 const usageLimitTracker = createUsageLimitTracker<RuntimeScreenStatus>({
   isRateKindSuppressed: structuredRateLimitAuthoritative,
+  isOutputActive: isOutputActivelyProgressing,
 });
 
 function currentUsageLimitSnapshot(): string {
@@ -5611,6 +5627,11 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
         const rawUserText = userEv ? extractTurnStartText(userEv) : '';
         const fields = formatLocalTurnFields(rawUserText, postText);
         if (!fields) continue;
+        // A harvested answer proves the CLI recovered from any structured
+        // limit that parked it — mirror the daemon's final_output self-heal
+        // (worker-pool clears ds.usageLimit there) by dropping the tracker's
+        // re-emit latch so the next classify() does not re-pin the card.
+        usageLimitTracker.noteTurnCompleted();
         send({
           type: 'final_output',
           content: fields.content,
@@ -5625,6 +5646,7 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
       // Headless local turn — see formatHeadlessLocalTurnContent for context.
       const headlessContent = formatHeadlessLocalTurnContent(postText);
       if (!headlessContent) continue;
+      usageLimitTracker.noteTurnCompleted();
       send({
         type: 'final_output',
         content: headlessContent,
@@ -5643,6 +5665,7 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
     const deliveredText = turn.restoredFromJournal
       ? `${t('worker.bridge_restored_turn_notice')}\n\n${postText}`
       : postText;
+    usageLimitTracker.noteTurnCompleted();
     send({
       type: 'final_output',
       content: deliveredText,
@@ -7131,6 +7154,9 @@ function emitReadyCodexTurns(): void {
       // Lark's per-message limit; daemon owns the card chrome.
       const fields = formatLocalTurnFields(turn.userText ?? '', postContent);
       if (!fields) continue;
+      // Harvested answer → drop the structured-limit re-emit latch (mirrors
+      // the daemon's final_output self-heal; see emitReadyTurns).
+      usageLimitTracker.noteTurnCompleted();
       send({
         type: 'final_output',
         ...(sourceHermesSessionId ? { sourceHermesSessionId } : {}),
@@ -7143,6 +7169,7 @@ function emitReadyCodexTurns(): void {
       });
       continue;
     }
+    usageLimitTracker.noteTurnCompleted();
     send({
       type: 'final_output',
       ...(sourceHermesSessionId ? { sourceHermesSessionId } : {}),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -342,7 +342,8 @@ import {
   type HerdrWebScrollDirection,
 } from './utils/herdr-web-history.js';
 import { parseWorkerRequestUrl } from './utils/worker-http.js';
-import { detectCliUsageLimit, usageLimitStateKey, structuredRateLimitState, isStructuredRateLimitAuthoritative, type CliUsageLimitState } from './utils/cli-usage-limit.js';
+import { structuredRateLimitState, isStructuredRateLimitAuthoritative, type CliUsageLimitState } from './utils/cli-usage-limit.js';
+import { createUsageLimitTracker } from './utils/usage-limit-tracker.js';
 import { uploadImageBuffer } from './utils/lark-upload.js';
 import { applySessionOwnerEnv, redactChildEnv, scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv } from './utils/child-env.js';
 import {
@@ -3971,65 +3972,13 @@ function structuredRateLimitAuthoritative(): boolean {
   return isStructuredRateLimitAuthoritative(cliAdapter);
 }
 
-// Per-turn usage-limit state machine. Owns the turn counter plus the
-// "did this turn hit a limit" / "suppress a stale retry-ready banner" flags, so
-// classify()'s state writes are explicit method calls rather than hidden
-// mutations of module globals from a function that otherwise reads as a pure
-// mapper.
-function createUsageLimitTracker() {
-  let turnSeq = 0;
-  let detectedTurn: number | undefined;
-  let suppressedRetryReadyKey: string | undefined;
-
-  return {
-    currentTurn(): number {
-      return turnSeq;
-    },
-    // Open a new turn; remember any stale retry-ready banner still on screen so
-    // classify() doesn't re-flag it as a fresh limit this turn.
-    beginTurn(snapshot: string): number {
-      turnSeq++;
-      detectedTurn = undefined;
-      const current = detectCliUsageLimit(snapshot, undefined, { suppressRateKind: structuredRateLimitAuthoritative() });
-      suppressedRetryReadyKey = current.limited && current.retryReady
-        ? usageLimitStateKey(current)
-        : undefined;
-      return turnSeq;
-    },
-    // Map a runtime status to a usage-limit-aware status, recording whether this
-    // turn hit a limit (read back via detectedThisTurn).
-    classify(
-      content: string,
-      status: RuntimeScreenStatus,
-    ): { status: RuntimeScreenStatus | 'limited'; usageLimit?: CliUsageLimitState } {
-      const detected = detectCliUsageLimit(content, undefined, { suppressRateKind: structuredRateLimitAuthoritative() });
-      if (!detected.limited) return { status };
-
-      const key = usageLimitStateKey(detected);
-      if (detected.retryReady && key === suppressedRetryReadyKey) {
-        return { status };
-      }
-
-      suppressedRetryReadyKey = undefined;
-      detectedTurn = turnSeq;
-      return { status: 'limited', usageLimit: detected };
-    },
-    detectedThisTurn(seq: number): boolean {
-      return detectedTurn === seq;
-    },
-    // Record a limit that came from a STRUCTURED signal (transcript error
-    // record) rather than screen text. Mirrors classify()'s state writes so
-    // the tracker stays coherent: mark this turn as having hit a limit (read
-    // by detectedThisTurn for the submit-confirmation recheck) and clear any
-    // stale retry-ready suppression. The actual emit is done by the caller.
-    noteStructuredLimit(): void {
-      suppressedRetryReadyKey = undefined;
-      detectedTurn = turnSeq;
-    },
-  };
-}
-
-const usageLimitTracker = createUsageLimitTracker();
+// Per-turn usage-limit state machine (extracted to utils/usage-limit-tracker
+// for unit testing). The structured-limit stickiness it owns is load-bearing:
+// a one-shot transcript emit must survive the daemon's working-frame self-heal
+// while the CLI stays genuinely blocked.
+const usageLimitTracker = createUsageLimitTracker<RuntimeScreenStatus>({
+  isRateKindSuppressed: structuredRateLimitAuthoritative,
+});
 
 function currentUsageLimitSnapshot(): string {
   if (!backendScreenEvidenceIsAuthoritativeForMutation()) return '';
@@ -5306,7 +5255,7 @@ function maybeEmitStructuredRateLimit(events: readonly TranscriptEvent[]): void 
     // Prefer a clock parsed from the record's own text ("... resets 10:40pm");
     // fall back to the shared bucketed cooldown when it carries none.
     const usageLimit = structuredRateLimitState(apiErrorMessageText(ev));
-    usageLimitTracker.noteStructuredLimit();
+    usageLimitTracker.noteStructuredLimit(usageLimit);
     send({
       type: 'screen_update',
       content: currentUsageLimitSnapshot(),
@@ -6667,7 +6616,7 @@ function maybeEmitCodexStructuredRateLimit(events: readonly CodexBridgeEvent[]):
     if (!isCodexRateLimitEvent(ev) || emittedRateLimitUuids.has(ev.uuid)) continue;
     emittedRateLimitUuids.add(ev.uuid);
     const usageLimit = structuredRateLimitState(ev.terminalErrorSummary ?? '429 Too Many Requests');
-    usageLimitTracker.noteStructuredLimit();
+    usageLimitTracker.noteStructuredLimit(usageLimit);
     send({
       type: 'screen_update',
       content: currentUsageLimitSnapshot(),

--- a/test/cli-usage-limit.test.ts
+++ b/test/cli-usage-limit.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   detectCliUsageLimit,
+  detectScreenUsageLimit,
+  isActiveWorkRuntimeStatus,
   HARD_RATE_LIMIT_COOLDOWN_MS,
   usageLimitStateKey,
   structuredRateLimitState,
@@ -310,5 +312,71 @@ describe('isStructuredRateLimitAuthoritative — structured-emit CLIs only, not 
     expect(isStructuredRateLimitAuthoritative(null)).toBe(false);
     expect(isStructuredRateLimitAuthoritative(undefined)).toBe(false);
     expect(isStructuredRateLimitAuthoritative({})).toBe(false);
+  });
+});
+
+describe('isActiveWorkRuntimeStatus', () => {
+  it('is true only for working/analyzing', () => {
+    expect(isActiveWorkRuntimeStatus('working')).toBe(true);
+    expect(isActiveWorkRuntimeStatus('analyzing')).toBe(true);
+    for (const s of ['idle', 'stalled', 'limited', 'starting', '', undefined, null]) {
+      expect(isActiveWorkRuntimeStatus(s)).toBe(false);
+    }
+  });
+});
+
+describe('detectScreenUsageLimit — runtime-status gate (误报根治)', () => {
+  const now = new Date(2026, 4, 19, 17, 30);
+  // The exact false-positive class from the 2026-08 reports: the CLI's own
+  // output (model answer / tool output quoting a business 429) sitting on
+  // screen while the CLI is still actively working.
+  const business429Screen = [
+    'TOS 返回 429 Too Many Requests，排查结论：',
+    'status: 429 是服务端限流，不是 LLM 侧限额',
+    'exceeded retry limit 后已降级处理',
+  ].join('\n');
+
+  it('suppresses the verdict while the CLI is working', () => {
+    expect(detectScreenUsageLimit(business429Screen, 'working', now).limited).toBe(false);
+  });
+
+  it('suppresses the verdict while the CLI is analyzing', () => {
+    expect(detectScreenUsageLimit(business429Screen, 'analyzing', now).limited).toBe(false);
+  });
+
+  it('still detects a genuine block when the CLI is idle', () => {
+    const result = detectScreenUsageLimit(business429Screen, 'idle', now);
+    expect(result.limited).toBe(true);
+    if (!result.limited) return;
+    expect(result.kind).toBe('rate');
+    expect(result.retryLabel).toBe('5-10 min');
+  });
+
+  it('does not suppress for stalled sessions (a stalled CLI may be genuinely blocked)', () => {
+    expect(detectScreenUsageLimit(business429Screen, 'stalled', now).limited).toBe(true);
+  });
+
+  it('treats an undefined status as non-working (detection proceeds)', () => {
+    expect(detectScreenUsageLimit(business429Screen, undefined, now).limited).toBe(true);
+  });
+
+  it('suppresses usage-quota text on a working screen too', () => {
+    const text = "You've hit your usage limit. Try again at 10:36 PM.";
+    // The pure text classifier still flags it (no status context there);
+    // the screen-frame gate is what prevents the false positive.
+    expect(detectCliUsageLimit(text, now).limited).toBe(true);
+    expect(detectScreenUsageLimit(text, 'working', now).limited).toBe(false);
+  });
+
+  it('keeps suppressRateKind semantics on top of the status gate', () => {
+    // Claude family: rate suppressed even when idle; usage still detected.
+    expect(detectScreenUsageLimit(business429Screen, 'idle', now, { suppressRateKind: true }).limited).toBe(false);
+    const usage = detectScreenUsageLimit(
+      "You've hit your usage limit. Try again at 10:36 PM.",
+      'idle',
+      now,
+      { suppressRateKind: true },
+    );
+    expect(usage.limited).toBe(true);
   });
 });

--- a/test/cli-usage-limit.test.ts
+++ b/test/cli-usage-limit.test.ts
@@ -379,4 +379,31 @@ describe('detectScreenUsageLimit — runtime-status gate (误报根治)', () => 
     );
     expect(usage.limited).toBe(true);
   });
+
+  it('working + outputActive=false still detects a blocking 429 (non-structured CLI parked at error screen)', () => {
+    // A non-structured CLI (codex/grok/traex/pi) whose rate-limit error screen
+    // does not render its configured ready prompt never transitions the idle
+    // detector to idle, so the projected status stays `working` forever (only
+    // Codex App projects `stalled`). `working` alone does not prove output is
+    // progressing — with outputActive=false (PTY quiescent) the gate must not
+    // suppress, or a genuine blocking 429 is hidden indefinitely and the limit
+    // card / backoff path never runs.
+    const result = detectScreenUsageLimit(business429Screen, 'working', now, { outputActive: false });
+    expect(result.limited).toBe(true);
+    if (!result.limited) return;
+    expect(result.kind).toBe('rate');
+    expect(result.retryLabel).toBe('5-10 min');
+  });
+
+  it('working + outputActive=true keeps suppressing (output progressing = CLI own output)', () => {
+    expect(detectScreenUsageLimit(business429Screen, 'working', now, { outputActive: true }).limited).toBe(false);
+  });
+
+  it('analyzing + outputActive=false also detects', () => {
+    expect(detectScreenUsageLimit(business429Screen, 'analyzing', now, { outputActive: false }).limited).toBe(true);
+  });
+
+  it('omitting outputActive keeps the conservative suppress-on-working default', () => {
+    expect(detectScreenUsageLimit(business429Screen, 'working', now).limited).toBe(false);
+  });
 });

--- a/test/usage-limit-sticky-recovery.test.ts
+++ b/test/usage-limit-sticky-recovery.test.ts
@@ -1,0 +1,175 @@
+/**
+ * 限额状态的粘性与自愈（daemon 侧 screen_update / screenshot_uploaded 处理器）。
+ *
+ * 背景：限额状态一旦命中会粘在 ds.usageLimit 上，直到下一轮用户消息才清除。
+ * 2026-08 的线上误报（Codex/Hermes）有一类是：CLI 实际仍在工作（worker 持续
+ * 上报 working），卡片却一直显示「限额已达」。修复约定：
+ *   - worker 帧带新鲜 usageLimit → limited（权威判定）
+ *   - worker 帧无 usageLimit 且状态为 working/analyzing → 旧限额是误报，清除
+ *   - worker 帧无 usageLimit 且状态为 idle/stalled → 保持 limited（冷却/重试 UX）
+ *
+ * Run: pnpm vitest run test/usage-limit-sticky-recovery.test.ts
+ */
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(() => ({
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+  })),
+}));
+
+import { registerBot } from '../src/bot-registry.js';
+import { initWorkerPool, __testOnly_setupWorkerHandlers } from '../src/core/worker-pool.js';
+import type { CliUsageLimitState } from '../src/utils/cli-usage-limit.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+const APP = 'limit_app';
+
+function makeDs(over: Partial<DaemonSession> = {}): DaemonSession {
+  // status:'active' 是 screen_update 处理器 ownsLifecycleMutation 守卫的要求；
+  // workerPort 让 workerHasInitialized 通过（与 turn-reactions 测试同型）。
+  const session: any = { sessionId: 'sess-' + Math.random().toString(36).slice(2), chatId: 'oc_x', rootMessageId: 'om_root', status: 'active' };
+  return { session, larkAppId: APP, chatId: 'oc_x', scope: 'chat', ...over } as unknown as DaemonSession;
+}
+
+function makeFakeWorker() {
+  const worker = new EventEmitter() as any;
+  worker.killed = false;
+  worker.send = vi.fn();
+  worker.kill = vi.fn();
+  worker.pid = 4242;
+  worker.stdout = new EventEmitter();
+  worker.stderr = new EventEmitter();
+  return worker;
+}
+
+async function flush(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function rateLimitState(): CliUsageLimitState {
+  return {
+    limited: true,
+    kind: 'rate',
+    retryAtMs: Date.now() + 60_000,
+    retryLabel: '5-10 min',
+    retryReady: false,
+  };
+}
+
+describe('usage-limit sticky state self-heal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SESSION_DATA_DIR = mkdtempSync(join(tmpdir(), 'botmux-limit-'));
+    registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_o'],
+      disableStreamingCard: true,
+    });
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+  });
+
+  it('limited → working(无 usageLimit) 自愈：清除限额状态', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({ worker, workerPort: 9999 });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', { type: 'screen_update', content: '429 Too Many Requests', status: 'limited', usageLimit: rateLimitState() });
+    await flush();
+    expect(ds.usageLimit).toBeDefined();
+    expect(ds.lastScreenStatus).toBe('limited');
+
+    // CLI 恢复工作：worker 上报 working 且不带新鲜 usageLimit。
+    worker.emit('message', { type: 'screen_update', content: 'working output continues', status: 'working' });
+    await flush();
+
+    expect(ds.usageLimit).toBeUndefined();
+    expect(ds.usageLimitRetryTimer).toBeUndefined();
+    expect(ds.lastScreenStatus).toBe('working');
+  });
+
+  it('limited → idle(无 usageLimit) 保持 limited：冷却/重试 UX 不被普通 idle 帧冲掉', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({ worker, workerPort: 9999 });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    const limit = rateLimitState();
+    worker.emit('message', { type: 'screen_update', content: '429 Too Many Requests', status: 'limited', usageLimit: limit });
+    await flush();
+
+    worker.emit('message', { type: 'screen_update', content: 'still blocked', status: 'idle' });
+    await flush();
+
+    expect(ds.usageLimit).toBeDefined();
+    expect(ds.lastScreenStatus).toBe('limited');
+  });
+
+  it('limited → working(带新鲜 usageLimit) 保持 limited：新鲜判定优先', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({ worker, workerPort: 9999 });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', { type: 'screen_update', content: '429 Too Many Requests', status: 'limited', usageLimit: rateLimitState() });
+    await flush();
+
+    const fresh = rateLimitState();
+    worker.emit('message', { type: 'screen_update', content: '429 Too Many Requests', status: 'working', usageLimit: fresh });
+    await flush();
+
+    expect(ds.usageLimit).toBe(fresh);
+    expect(ds.lastScreenStatus).toBe('limited');
+  });
+
+  it('screenshot_uploaded 通道同样自愈', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({ worker, workerPort: 9999, displayMode: 'screenshot' });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', { type: 'screenshot_uploaded', imageKey: 'img_1', status: 'limited', usageLimit: rateLimitState() });
+    await flush();
+    expect(ds.usageLimit).toBeDefined();
+    expect(ds.lastScreenStatus).toBe('limited');
+
+    worker.emit('message', { type: 'screenshot_uploaded', imageKey: 'img_2', status: 'working' });
+    await flush();
+
+    expect(ds.usageLimit).toBeUndefined();
+    expect(ds.lastScreenStatus).toBe('working');
+  });
+
+  it('stalled 帧不触发自愈：停滞会话可能真的卡在限额错误屏', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({ worker, workerPort: 9999 });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', { type: 'screen_update', content: '429 Too Many Requests', status: 'limited', usageLimit: rateLimitState() });
+    await flush();
+
+    worker.emit('message', { type: 'screen_update', content: 'no progress', status: 'stalled' });
+    await flush();
+
+    expect(ds.usageLimit).toBeDefined();
+    expect(ds.lastScreenStatus).toBe('limited');
+  });
+});

--- a/test/usage-limit-tracker.test.ts
+++ b/test/usage-limit-tracker.test.ts
@@ -98,3 +98,102 @@ describe('usage-limit tracker — 结构化限流粘性重发', () => {
     expect(suppressed.classify('output', 'working').status).toBe('limited');
   });
 });
+
+describe('usage-limit tracker — adopted 会话本地恢复后清除结构化 latch', () => {
+  it('本地 turn 成功完成（noteTurnCompleted）后不再重发旧限额', () => {
+    // 场景：adopted Claude/Codex 会话命中结构化限流（latch 置位），用户在本地
+    // 终端直接恢复——不触发 beginTurn()。daemon 的 final_output handler 已清
+    // ds.usageLimit，但 tracker 的 activeStructured latch 仍在；若不清，下次
+    // periodic / prompt-ready classify 会重发旧限额，把卡片/Dashboard 重新钉住。
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    const seq = tracker.beginTurn('');
+    const limit = structuredLimit();
+    tracker.noteStructuredLimit(limit);
+    // 恢复前：working 帧仍重发（防 daemon 自愈误清的既有保护）。
+    expect(tracker.classify('anything', 'working').status).toBe('limited');
+
+    // bridge 收获到本地 turn 的 final_output → noteTurnCompleted（与 daemon
+    // final_output handler 清 ds.usageLimit 同一恢复路径）。
+    tracker.noteTurnCompleted();
+
+    // 恢复后：不再重发旧限额。
+    expect(tracker.classify('anything', 'working').status).toBe('working');
+    expect(tracker.classify('anything', 'idle').status).toBe('idle');
+    // 历史事实保留：本轮确实命中过限额（detectedThisTurn 供 submit-confirmation
+    // recheck 读取），latch 清除不影响该标记。
+    expect(tracker.detectedThisTurn(seq)).toBe(true);
+  });
+
+  it('noteTurnCompleted 后下一轮 beginTurn 行为不变', () => {
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    tracker.beginTurn('');
+    tracker.noteStructuredLimit(structuredLimit());
+    tracker.noteTurnCompleted();
+    // 新一轮正常开始：扫屏判定恢复工作。
+    tracker.beginTurn('');
+    expect(tracker.classify('429 Too Many Requests', 'idle').status).toBe('limited');
+  });
+
+  it('未命中结构化限流时 noteTurnCompleted 是 no-op', () => {
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    tracker.beginTurn('');
+    tracker.noteTurnCompleted(); // 不应抛错，也不影响普通判定。
+    expect(tracker.classify('plain output', 'idle').status).toBe('idle');
+  });
+});
+
+describe('usage-limit tracker — outputActive 门控（working 不等于输出在进展）', () => {
+  const blocked429Screen = 'exceeded retry limit, last status: 429 Too Many Requests, request id: req_x';
+
+  it('working + outputActive=false 仍检出阻塞 429（非结构化 CLI 卡死错误屏）', () => {
+    // 非结构化 CLI（codex/grok/traex/pi）的限额错误屏不渲染配置的 ready
+    // prompt，idle detector 永不转 idle，状态一直是 working（只有 Codex App
+    // 会 project stalled）。outputActive=false 表示 PTY 已静默（CLI 被阻塞，
+    // 不是在产出），扫屏判定必须运行——真实阻塞 429 不能被无限抑制。
+    const tracker = createUsageLimitTracker({
+      isRateKindSuppressed: () => false,
+      isOutputActive: () => false,
+    });
+    tracker.beginTurn('');
+    const blocked = tracker.classify(blocked429Screen, 'working');
+    expect(blocked.status).toBe('limited');
+    expect(blocked.usageLimit?.kind).toBe('rate');
+  });
+
+  it('working + outputActive=true 保持抑制（输出进展中 = CLI 自己的输出）', () => {
+    // PTY 活跃（模型正在输出）时屏幕上的 429 文案是业务输出/内部重试，仍抑制。
+    const tracker = createUsageLimitTracker({
+      isRateKindSuppressed: () => false,
+      isOutputActive: () => true,
+    });
+    tracker.beginTurn('');
+    expect(tracker.classify(blocked429Screen, 'working').status).toBe('working');
+  });
+
+  it('未注入 isOutputActive 时保持保守默认（working 一律抑制）', () => {
+    // 纯单测/无输出活动信号的调用方保持既有行为。
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    tracker.beginTurn('');
+    expect(tracker.classify(blocked429Screen, 'working').status).toBe('working');
+  });
+
+  it('analyzing + outputActive=false 同样检出', () => {
+    const tracker = createUsageLimitTracker({
+      isRateKindSuppressed: () => false,
+      isOutputActive: () => false,
+    });
+    tracker.beginTurn('');
+    expect(tracker.classify(blocked429Screen, 'analyzing').status).toBe('limited');
+  });
+
+  it('outputActive 门控不影响结构化限流重发', () => {
+    // 结构化限流是权威信号，重发不受 outputActive 影响（P1#1 的粘性保护）。
+    const tracker = createUsageLimitTracker({
+      isRateKindSuppressed: () => true,
+      isOutputActive: () => true,
+    });
+    tracker.beginTurn('');
+    tracker.noteStructuredLimit(structuredLimit());
+    expect(tracker.classify('output', 'working').status).toBe('limited');
+  });
+});

--- a/test/usage-limit-tracker.test.ts
+++ b/test/usage-limit-tracker.test.ts
@@ -1,0 +1,100 @@
+/**
+ * 限额状态机单测：扫屏门控 + 结构化限流的粘性重发。
+ *
+ * 背景：worker 的扫屏判定在 working/analyzing 帧被门控抑制（误报根治），
+ * 但 Claude/Codex 的结构化限流是「一次性 emit + UUID 去重」的权威信号。
+ * 若结构化限流命中后 CLI 仍被阻塞，而 worker 状态在 prompt 检测生效前
+ * 投影为 working（projectRuntimeScreenStatus 在 promptReady=false 时的
+ * 默认值就是 working），daemon 侧的 working 帧自愈会把这条权威限额清掉，
+ * 且 Claude 家族的扫屏 rate 判定被 suppressRateKind 关闭，再也不会重新
+ * 上报——真限流卡片被静默吞掉。因此结构化限额必须在本轮内逐帧重发，
+ * 让 daemon 的「新鲜 usageLimit 优先」分支始终生效。
+ *
+ * Run: pnpm vitest run test/usage-limit-tracker.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+import { createUsageLimitTracker } from '../src/utils/usage-limit-tracker.js';
+import type { CliUsageLimitState } from '../src/utils/cli-usage-limit.js';
+
+function structuredLimit(): CliUsageLimitState {
+  return {
+    limited: true,
+    kind: 'rate',
+    retryAtMs: Date.now() + 60_000,
+    retryLabel: '5-10 min',
+    retryReady: false,
+  };
+}
+
+describe('usage-limit tracker — 结构化限流粘性重发', () => {
+  it('结构化限流命中后，working 帧仍重发 limited（防 daemon 自愈误清）', () => {
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    const seq = tracker.beginTurn('');
+    const limit = structuredLimit();
+    tracker.noteStructuredLimit(limit);
+
+    // 屏幕上没有任何限流文案、CLI 还在 working：扫屏门控会抑制，但权威
+    // 结构化限额必须原样重发，daemon 收到新鲜 usageLimit 就不会自愈清除。
+    const working = tracker.classify('模型正在输出业务 429 的排查结论', 'working');
+    expect(working.status).toBe('limited');
+    expect(working.usageLimit).toBe(limit);
+
+    // idle 帧同样保持：CLI 被阻塞落到 idle，卡片不回落。
+    const idle = tracker.classify('rate limit reached', 'idle');
+    expect(idle.status).toBe('limited');
+    expect(idle.usageLimit).toBe(limit);
+
+    expect(tracker.detectedThisTurn(seq)).toBe(true);
+  });
+
+  it('analyzing 帧同样重发结构化限流', () => {
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    tracker.beginTurn('');
+    tracker.noteStructuredLimit(structuredLimit());
+    expect(tracker.classify('thinking', 'analyzing').status).toBe('limited');
+  });
+
+  it('下一轮 beginTurn 后停止重发：限额卡片随新轮次清除', () => {
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    tracker.beginTurn('');
+    tracker.noteStructuredLimit(structuredLimit());
+    expect(tracker.classify('anything', 'working').status).toBe('limited');
+
+    tracker.beginTurn('');
+    expect(tracker.classify('anything', 'working').status).toBe('working');
+    expect(tracker.classify('anything', 'idle').status).toBe('idle');
+  });
+
+  it('扫屏命中保持一次性：不在后续帧重发（误报由 daemon 自愈兜底）', () => {
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    tracker.beginTurn('');
+    // idle 抖动帧扫屏命中。
+    const detected = tracker.classify('429 Too Many Requests', 'idle');
+    expect(detected.status).toBe('limited');
+    expect(detected.usageLimit).toBeDefined();
+    // 下一帧屏幕已无该文案（或状态变化）：不重发，daemon 可自愈清除。
+    expect(tracker.classify('plain output', 'idle').status).toBe('idle');
+    expect(tracker.classify('plain output', 'working').status).toBe('working');
+  });
+
+  it('扫屏门控保持不变：working 帧不出限额结论', () => {
+    const tracker = createUsageLimitTracker({ isRateKindSuppressed: () => false });
+    tracker.beginTurn('');
+    expect(tracker.classify('429 Too Many Requests', 'working').status).toBe('working');
+    expect(tracker.classify('429 Too Many Requests', 'analyzing').status).toBe('analyzing');
+    // idle/stalled 帧维持原判定，真实限流（CLI 被阻塞）仍可检出。
+    expect(tracker.classify('429 Too Many Requests', 'idle').status).toBe('limited');
+    expect(tracker.classify('429 Too Many Requests', 'stalled').status).toBe('limited');
+  });
+
+  it('suppressRateKind 语义在结构化重发之外保持不变', () => {
+    // Claude 家族：rate 被抑制，usage 仍检出；结构化重发不受影响。
+    const suppressed = createUsageLimitTracker({ isRateKindSuppressed: () => true });
+    suppressed.beginTurn('');
+    expect(suppressed.classify('429 Too Many Requests', 'idle').status).toBe('idle');
+    expect(suppressed.classify("You've hit your usage limit. Try again at 10:36 PM.", 'idle').status).toBe('limited');
+    // 结构化限流即使在 suppressRateKind 下也重发。
+    suppressed.noteStructuredLimit(structuredLimit());
+    expect(suppressed.classify('output', 'working').status).toBe('limited');
+  });
+});


### PR DESCRIPTION
优先级：P1

## 根因

扫屏逻辑无法区分 CLI 自身限流与模型回答、工具输出或业务错误中的 429 文本；同时 daemon 的 usageLimit 状态具有粘性，一次 idle 抖动误命中后，即使后续屏幕恢复 working 也不会自愈。结构化限流又只上报一次，可能被过早到达的 working 帧清除后永久丢失。

## 改动

- worker 的扫屏限流增加运行态门控：working/analyzing 不输出限额结论，idle/stalled 保持原判定。
- daemon 增加 usageLimit 自愈：无新鲜限额信号的 working/analyzing 帧清除旧状态，普通 idle 保持冷却期粘性。
- Claude/Codex transcript 的结构化限流在本轮逐帧重发，避免被 prompt 检测前的 working 帧吞掉。
- 将状态机提取到 `utils/usage-limit-tracker.ts`，并注入 rate-kind suppression 便于独立验证。

## 影响面

影响所有 CLI 的扫屏限额路径；结构化 Claude/Codex 信号仍保持权威。真实额度耗尽会阻塞 CLI 并进入 idle/stalled，因此仍能被检出。

## 验证

- `cli-usage-limit.test.ts` 覆盖 working/analyzing 抑制、idle/stalled 检出和 suppression 组合语义。
- `usage-limit-sticky-recovery.test.ts` 覆盖 limited→working 自愈、limited→idle 保持、新鲜判定优先、截图通道和 stalled 行为。
- `usage-limit-tracker.test.ts` 覆盖结构化信号逐帧重发、下轮清除、扫屏命中一次性及门控语义。
- `pnpm build` 通过；全量测试 15524 项通过。另有 2 个 skill-doctor 环境相关失败在干净 master 同样存在。