### PR TITLE
fix(traex): 容量排队期间保持工作状态，修复 Dashboard 假 Idle

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -458,6 +458,12 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
     // viewport probe is forbidden from mutating state. See the
     // TRAEX_STATIC_BUSY_PATTERN comment.
     staticBusyPattern: TRAEX_STATIC_BUSY_PATTERN,
+    // Clear the static-busy latch only on real composer evidence (line-start
+    // ›/❯, excluding numbered selector rows). The broad readyPattern also
+    // matches `\d+% left` (status bar), which the queue screen itself
+    // carries — using it to clear the latch would re-open the ZMX false-idle
+    // bug when queue and status bar arrive in separate chunks.
+    staticBusyClearPattern: /(?:^|[\n\r])\s*[›❯](?!\s*\d+\.)/,
     // TRAE has shipped both the Codex-style `›` prompt and the Claude-style
     // `❯` prompt; v0.200.7 also renders a "Context 100% left" status bar.
     // Startup advisory / picker screens also use `❯ 1.` as a menu cursor, so

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -155,6 +155,124 @@ export const TRAE_MIGRATION_DONE_MARKERS = [
   '~/.trae/.coco-migrated',
 ] as const;
 
+/**
+ * TraeX active-turn busy marker. Every anchor below is extracted verbatim
+ * from the traex binary's compiled-in TUI string tables and verified across
+ * all 9 local releases (0.201.1-alpha.5 … 0.201.2-alpha.2, both `traex` and
+ * `traex-code-mode-host`):
+ *
+ *  - Spinner frames: the contiguous string "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+ *    (braille rotation compiled into every release).
+ *  - Spinner label set 1 (thinking/working rotation): "Thinking longer…",
+ *    "Deep in thought…", "Almost there…", "Running command…",
+ *    "Command in flight…", "Chugging along…", "Finishing up…", "Executing…",
+ *    "Hang tight…", "Waiting for response…", "Any second now…",
+ *    "Poking the model…", "On its way…", "Shh, it's thinking…",
+ *    "Thinking…", "Reasoning through it…", "Mulling it over…",
+ *    "Pondering…", "Working it out…", "Piecing it together…".
+ *  - Spinner label set 2 (approval/working/queue): "Reviewing approval
+ *    request", "Working…", "Working on it…", "Queued for capacity".
+ *  - Standalone queue notice: "Too many requests right now. You're in the
+ *    queue."
+ *
+ * TraeX forked from Codex and DELETED the "esc to interrupt" footer hint —
+ * `grep -a -c "esc to interrupt"` returns 0 across every local release and
+ * the 94MB TUI logs — so the Codex pattern's second anchor is invalid here.
+ *
+ * Three branches:
+ *  1. Spinner-anchored labels: "<braille frame><space><label>". The frame
+ *     never appears in transcript prose, so assistant output like
+ *     "Working… on the fix" cannot revive a completed card. Covers the
+ *     working/thinking rotation AND the spinner-prefixed queue state
+ *     ("⠋ Queued for capacity" — the queue screen can render a frozen
+ *     spinner frame in front of the label).
+ *  2. Standalone capacity-queue strings, line-anchored
+ *     (`(?:^|[\n\r])[ \t]*…`): "Queued for capacity" and the full queue
+ *     notice. The queue screen can render statically (no animating spinner),
+ *     so the frame anchor must not be required for it. The line anchor keeps
+ *     assistant prose quoting the string mid-sentence ("…says Queued for
+ *     capacity whenever…") from registering as busy.
+ *  3. (staticBusyPattern below) the same queue evidence as a pre-idle latch
+ *     inside IdleDetector — see TRAEX_STATIC_BUSY_PATTERN.
+ *
+ * Both states must be covered: the worker's busy-pattern idle probe marks
+ * the prompt ready as soon as the marker leaves the viewport, so matching
+ * only the queue strings would flash Idle the moment the queue resolves
+ * into a real working turn.
+ */
+const TRAEX_SPINNER_FRAMES = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
+
+const TRAEX_SPINNER_LABELS = [
+  // Set 1 — thinking/working rotation (compiled-in spinner string table).
+  'Thinking longer…',
+  'Deep in thought…',
+  'Almost there…',
+  'Running command…',
+  'Command in flight…',
+  'Chugging along…',
+  'Finishing up…',
+  'Executing…',
+  'Hang tight…',
+  'Waiting for response…',
+  'Any second now…',
+  'Poking the model…',
+  'On its way…',
+  "Shh, it's thinking…",
+  'Thinking…',
+  'Reasoning through it…',
+  'Mulling it over…',
+  'Pondering…',
+  'Working it out…',
+  'Piecing it together…',
+  // Set 2 — approval/working/queue.
+  'Reviewing approval request',
+  'Working…',
+  'Working on it…',
+  'Queued for capacity',
+] as const;
+
+/** Line-anchored standalone capacity-queue strings. Shared by the active
+ *  busy pattern and the pre-idle static latch (see below). */
+const TRAEX_QUEUE_STATIC_ARMS = [
+  'Queued for capacity',
+  "Too many requests right now\\. You're in the queue",
+];
+
+const TRAEX_ACTIVE_BUSY_PATTERN = new RegExp(
+  [
+    `[${TRAEX_SPINNER_FRAMES}][ \\t]?(?:${TRAEX_SPINNER_LABELS.join('|')})`,
+    ...TRAEX_QUEUE_STATIC_ARMS.map((arm) => `(?:^|[\\n\\r])[ \\t]*${arm}`),
+  ].join('|'),
+  'i',
+);
+
+/**
+ * Pre-idle static-busy latch for the capacity-queue screen (ZMX gap).
+ *
+ * busyPattern/idleToBusyPattern cannot cover the FIRST static queue on ZMX:
+ *  - busyPattern is a viewport probe; deferPromptReadyWhileBusy() and the
+ *    idle probe bail when backendScreenEvidenceIsAuthoritativeForMutation()
+ *    is false (ZMX history is not a trustworthy current viewport).
+ *  - idleToBusyPattern only self-heals an ALREADY-published idle, and only
+ *    from fresh PTY bytes; a static queue screen emits none.
+ *
+ * This pattern is consumed inside IdleDetector from the raw PTY byte stream
+ * (the same trust level as readyPattern/completionPattern — NOT the
+ * forbidden screen-capture snapshot): a chunk carrying queue evidence latches
+ * "static busy" and suppresses screen-derived idle until a chunk with
+ * readyPattern evidence but no queue string redraws (the real composer).
+ * Includes the spinner-prefixed queue form: a frozen braille frame in front
+ * of the label would otherwise only buy the 3s spinner guard, after which
+ * the static screen would still false-idle.
+ */
+const TRAEX_STATIC_BUSY_PATTERN = new RegExp(
+  [
+    `[${TRAEX_SPINNER_FRAMES}][ \\t]?Queued for capacity`,
+    ...TRAEX_QUEUE_STATIC_ARMS.map((arm) => `(?:^|[\\n\\r])[ \\t]*${arm}`),
+  ].join('|'),
+  'i',
+);
+
 export function createTraexAdapter(pathOverride?: string): CliAdapter {
   const rawBin = pathOverride ?? 'traex';
   let cachedBin: string | undefined;
@@ -329,6 +447,17 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
     },
 
     completionPattern: undefined,
+    // Active-turn busy marker — spinner-anchored working/thinking labels plus
+    // standalone capacity-queue strings. See the TRAEX_ACTIVE_BUSY_PATTERN
+    // comment for the binary-extracted evidence and why both states are
+    // required.
+    busyPattern: TRAEX_ACTIVE_BUSY_PATTERN,
+    idleToBusyPattern: TRAEX_ACTIVE_BUSY_PATTERN,
+    // Pre-idle latch for the static capacity-queue screen — holds the session
+    // busy before the first idle on backends (ZMX) where the busyPattern
+    // viewport probe is forbidden from mutating state. See the
+    // TRAEX_STATIC_BUSY_PATTERN comment.
+    staticBusyPattern: TRAEX_STATIC_BUSY_PATTERN,
     // TRAE has shipped both the Codex-style `›` prompt and the Claude-style
     // `❯` prompt; v0.200.7 also renders a "Context 100% left" status bar.
     // Startup advisory / picker screens also use `❯ 1.` as a menu cursor, so

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -364,6 +364,14 @@ export interface CliAdapter {
    *  the latch — it is authoritative independently of the screen observer. */
   readonly staticBusyPattern?: RegExp;
 
+  /** Opt-in CLEAR pattern for the pre-idle static-busy latch. Matches the
+   *  real composer prompt (e.g. line-start ›/❯) so the latch can clear when
+   *  the queue screen redraws into the composer. Must NOT match the status
+   *  bar (e.g. `\d+% left`) — the queue screen itself carries a status bar,
+   *  so the broad readyPattern can never clear the latch. Only tested against
+   *  the CURRENT chunk (fresh composer evidence), not the rolling tail. */
+  readonly staticBusyClearPattern?: RegExp;
+
   /** Ready marker regex — matches when the CLI's input prompt is rendered and
    *  functional.  When set, the idle detector suppresses quiescence-based idle
    *  until this pattern appears in the PTY output.  Checked every cycle (reset

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -357,11 +357,12 @@ export interface CliAdapter {
    *  mutation — this consumes raw PTY evidence inside IdleDetector, so it also
    *  holds on backends where screen capture must not mutate state (ZMX):
    *  while latched, screen-derived idle is suppressed until a PTY chunk with
-   *  readyPattern evidence but WITHOUT this marker arrives (the queue screen
-   *  itself matches readyPattern's status-bar arm, so readyPattern alone can
-   *  never clear it). The latch is set/cleared from the current chunk only;
-   *  reset() rebases it. External structured completion (fireIdle) bypasses
-   *  the latch — it is authoritative independently of the screen observer. */
+   *  explicit composer evidence (staticBusyClearPattern) redraws AFTER the
+   *  last queue marker. The latch is set from the rolling outputTail (queue
+   *  markers can be split across chunks); clear is decided by the LAST
+   *  static/clear evidence position within the current chunk. reset() rebases
+   *  it. External structured completion (fireIdle) bypasses the latch — it is
+   *  authoritative independently of the screen observer. */
   readonly staticBusyPattern?: RegExp;
 
   /** Opt-in CLEAR pattern for the pre-idle static-busy latch. Matches the

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -350,6 +350,20 @@ export interface CliAdapter {
    *  contain old busy text; existing adapters remain opt-out by default. */
   readonly idleToBusyPattern?: RegExp;
 
+  /** Opt-in PRE-idle busy latch for static busy screens that emit no further
+   *  PTY bytes after the initial render (e.g. a capacity-queue notice drawn
+   *  alongside a readyPattern status bar). Unlike busyPattern — a viewport
+   *  probe that only runs on backends whose screen cache is authoritative for
+   *  mutation — this consumes raw PTY evidence inside IdleDetector, so it also
+   *  holds on backends where screen capture must not mutate state (ZMX):
+   *  while latched, screen-derived idle is suppressed until a PTY chunk with
+   *  readyPattern evidence but WITHOUT this marker arrives (the queue screen
+   *  itself matches readyPattern's status-bar arm, so readyPattern alone can
+   *  never clear it). The latch is set/cleared from the current chunk only;
+   *  reset() rebases it. External structured completion (fireIdle) bypasses
+   *  the latch — it is authoritative independently of the screen observer. */
+  readonly staticBusyPattern?: RegExp;
+
   /** Ready marker regex — matches when the CLI's input prompt is rendered and
    *  functional.  When set, the idle detector suppresses quiescence-based idle
    *  until this pattern appears in the PTY output.  Checked every cycle (reset

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -117,16 +117,23 @@ export class IdleDetector {
     //  arrives (consistent with idleToBusy/completionPattern split-chunk
     //  handling).
     // CLEAR: explicit composer evidence (staticBusyClearPattern) in the
-    //  CURRENT chunk takes priority — the tail may still carry residual
-    //  queue text from a previous chunk, but a fresh composer redraw means
-    //  the queue is gone. The broad readyPattern includes `\d+% left`
-    //  (status bar), which the queue screen itself carries — using it to
-    //  clear would re-open the false-idle bug when queue and status bar
-    //  arrive in separate chunks.
+    //  CURRENT chunk. The broad readyPattern includes `\d+% left` (status
+    //  bar), which the queue screen itself carries — using it to clear
+    //  would re-open the false-idle bug when queue and status bar arrive
+    //  in separate chunks.
+    // ORDER: within a single chunk, whichever evidence appears LAST wins —
+    //  a submitted user message (`› text`) followed by a fresh queue line
+    //  must NOT clear the latch (the queue is fresher), while a queue line
+    //  followed by a real composer redraw must clear it.
     if (this.staticBusyPattern) {
-      if (this.staticBusyClearPattern?.test(stripped)) {
+      const clearIdx = this.staticBusyClearPattern
+        ? lastMatchIndex(this.staticBusyClearPattern, stripped)
+        : -1;
+      const staticChunkIdx = lastMatchIndex(this.staticBusyPattern, stripped);
+      const staticTailIdx = lastMatchIndex(this.staticBusyPattern, this.outputTail);
+      if (clearIdx >= 0 && clearIdx > staticChunkIdx) {
         this.staticBusyLatch = false;
-      } else if (this.staticBusyPattern.test(stripped) || this.staticBusyPattern.test(this.outputTail)) {
+      } else if (staticTailIdx >= 0) {
         this.staticBusyLatch = true;
       }
     }
@@ -245,4 +252,17 @@ export class IdleDetector {
       .replace(/\x1b\[(\d*)C/g, (_m, n) => ' '.repeat(Number(n) || 1))
       .replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][0-9A-B]|\x1b\[[\?]?[0-9;]*[hlmsuJ]/g, '');
   }
+}
+
+/** Find the LAST match index of a regex in a string, or -1. Handles
+ *  non-global regexes by cloning with the g flag. */
+function lastMatchIndex(re: RegExp, s: string): number {
+  const g = new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g');
+  let last = -1;
+  let m: RegExpExecArray | null;
+  while ((m = g.exec(s)) !== null) {
+    last = m.index;
+    if (g.lastIndex === m.index) g.lastIndex++;
+  }
+  return last;
 }

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -86,7 +86,14 @@ export class IdleDetector {
     }
 
     const stripped = this.stripAnsi(data);
-    this.outputTail = (this.outputTail + stripped).slice(-500);
+    // Shift the clear position left when the tail window drops characters
+    // from the head, so it stays relative to the current window.
+    const combined = this.outputTail + stripped;
+    const dropped = Math.max(0, combined.length - 500);
+    this.outputTail = combined.slice(-500);
+    if (this.staticBusyClearTailPos >= 0) {
+      this.staticBusyClearTailPos = Math.max(-1, this.staticBusyClearTailPos - dropped);
+    }
 
     // Only an explicitly opted-in CLI marker may turn a previously reported
     // idle cycle back into busy. Plain PTY activity — and legacy busyPattern

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -22,19 +22,22 @@ export class IdleDetector {
   private completionPattern: RegExp | undefined;
   private idleToBusyPattern: RegExp | undefined;
   private staticBusyPattern: RegExp | undefined;
+  private staticBusyClearPattern: RegExp | undefined;
   private busyTransitionArmed = false;
   private readyPattern: RegExp | undefined;
   private readySeen = false;
-  /** Pre-idle latch for static busy screens (capacity queue). Set from a PTY
-   *  chunk carrying explicit static-busy evidence; suppresses screen-derived
-   *  idle until a chunk with readyPattern evidence but no static-busy marker
-   *  redraws. See CliAdapter.staticBusyPattern. */
+  /** Pre-idle latch for static busy screens (capacity queue). Set from PTY
+   *  chunks carrying explicit static-busy evidence (scanned across chunks
+   *  via the rolling tail); suppresses screen-derived idle until a chunk
+   *  with explicit composer evidence (staticBusyClearPattern) redraws.
+   *  See CliAdapter.staticBusyPattern / staticBusyClearPattern. */
   private staticBusyLatch = false;
 
   constructor(cli: CliAdapter) {
     this.completionPattern = cli.completionPattern;
     this.idleToBusyPattern = cli.idleToBusyPattern;
     this.staticBusyPattern = cli.staticBusyPattern;
+    this.staticBusyClearPattern = cli.staticBusyClearPattern;
     this.readyPattern = cli.readyPattern;
   }
 
@@ -107,18 +110,24 @@ export class IdleDetector {
       this.readySeen = true;
     }
 
-    // Pre-idle static-busy latch (capacity-queue screens). Decided from the
-    // CURRENT chunk only: the queue text and the queue screen's `100% left`
-    // status bar both linger in outputTail, so tail matching could never
-    // clear the latch and a stale tail ready marker would clear it mid-queue.
-    // A chunk carrying the static-busy marker means the latest redraw still
-    // shows the queue; a chunk carrying fresh ready evidence without it means
-    // the composer is back.
+    // Pre-idle static-busy latch (capacity-queue screens).
+    // SET: scan both the current chunk AND the rolling tail — the queue
+    //  marker can be split across chunks ("Queued for cap" + "acity"), and
+    //  the tail already holds the full text by the time the second chunk
+    //  arrives (consistent with idleToBusy/completionPattern split-chunk
+    //  handling).
+    // CLEAR: explicit composer evidence (staticBusyClearPattern) in the
+    //  CURRENT chunk takes priority — the tail may still carry residual
+    //  queue text from a previous chunk, but a fresh composer redraw means
+    //  the queue is gone. The broad readyPattern includes `\d+% left`
+    //  (status bar), which the queue screen itself carries — using it to
+    //  clear would re-open the false-idle bug when queue and status bar
+    //  arrive in separate chunks.
     if (this.staticBusyPattern) {
-      if (this.staticBusyPattern.test(stripped)) {
-        this.staticBusyLatch = true;
-      } else if (this.readyPattern?.test(stripped)) {
+      if (this.staticBusyClearPattern?.test(stripped)) {
         this.staticBusyLatch = false;
+      } else if (this.staticBusyPattern.test(stripped) || this.staticBusyPattern.test(this.outputTail)) {
+        this.staticBusyLatch = true;
       }
     }
 

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -32,6 +32,10 @@ export class IdleDetector {
    *  with explicit composer evidence (staticBusyClearPattern) redraws.
    *  See CliAdapter.staticBusyPattern / staticBusyClearPattern. */
   private staticBusyLatch = false;
+  /** Tail position of the last composer clear evidence. Queue evidence in
+   *  the tail at or before this position is stale (from before the clear)
+   *  and must not re-set the latch. -1 = no clear recorded. */
+  private staticBusyClearTailPos = -1;
 
   constructor(cli: CliAdapter) {
     this.completionPattern = cli.completionPattern;
@@ -77,6 +81,7 @@ export class IdleDetector {
       this.isIdle = false;
       this.outputTail = '';
       this.readySeen = false;
+      this.staticBusyClearTailPos = -1;
       this.lastSpinnerAt = Date.now();
     }
 
@@ -125,6 +130,9 @@ export class IdleDetector {
     //  a submitted user message (`› text`) followed by a fresh queue line
     //  must NOT clear the latch (the queue is fresher), while a queue line
     //  followed by a real composer redraw must clear it.
+    // STALE-TAIL: after a clear, queue text lingering in the tail must not
+    //  re-set the latch. Record the clear position in the tail; only queue
+    //  evidence AFTER that position is fresh enough to set.
     if (this.staticBusyPattern) {
       const clearIdx = this.staticBusyClearPattern
         ? lastMatchIndex(this.staticBusyClearPattern, stripped)
@@ -133,7 +141,13 @@ export class IdleDetector {
       const staticTailIdx = lastMatchIndex(this.staticBusyPattern, this.outputTail);
       if (clearIdx >= 0 && clearIdx > staticChunkIdx) {
         this.staticBusyLatch = false;
-      } else if (staticTailIdx >= 0) {
+        // Record where the clear landed in the tail so stale queue text
+        // before it doesn't re-set the latch on the next chunk.
+        const chunkStart = this.outputTail.length - stripped.length;
+        this.staticBusyClearTailPos = chunkStart >= 0
+          ? chunkStart + clearIdx
+          : this.outputTail.length;
+      } else if (staticTailIdx >= 0 && staticTailIdx > this.staticBusyClearTailPos) {
         this.staticBusyLatch = true;
       }
     }
@@ -173,6 +187,7 @@ export class IdleDetector {
     this.outputTail = '';
     this.readySeen = false;
     this.staticBusyLatch = false;
+    this.staticBusyClearTailPos = -1;
     this.lastSpinnerAt = Date.now();
     this.clearTimer();
   }
@@ -189,6 +204,7 @@ export class IdleDetector {
     this.outputTail = '';
     this.readySeen = false;
     this.staticBusyLatch = false;
+    this.staticBusyClearTailPos = -1;
     this.lastSpinnerAt = 0;
     this.clearTimer();
   }
@@ -209,6 +225,7 @@ export class IdleDetector {
     this.busyCallback = null;
     this.busyTransitionArmed = false;
     this.staticBusyLatch = false;
+    this.staticBusyClearTailPos = -1;
   }
 
   private quiescenceCheck(): void {

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -21,13 +21,20 @@ export class IdleDetector {
   private busyCallback: (() => void) | null = null;
   private completionPattern: RegExp | undefined;
   private idleToBusyPattern: RegExp | undefined;
+  private staticBusyPattern: RegExp | undefined;
   private busyTransitionArmed = false;
   private readyPattern: RegExp | undefined;
   private readySeen = false;
+  /** Pre-idle latch for static busy screens (capacity queue). Set from a PTY
+   *  chunk carrying explicit static-busy evidence; suppresses screen-derived
+   *  idle until a chunk with readyPattern evidence but no static-busy marker
+   *  redraws. See CliAdapter.staticBusyPattern. */
+  private staticBusyLatch = false;
 
   constructor(cli: CliAdapter) {
     this.completionPattern = cli.completionPattern;
     this.idleToBusyPattern = cli.idleToBusyPattern;
+    this.staticBusyPattern = cli.staticBusyPattern;
     this.readyPattern = cli.readyPattern;
   }
 
@@ -100,6 +107,21 @@ export class IdleDetector {
       this.readySeen = true;
     }
 
+    // Pre-idle static-busy latch (capacity-queue screens). Decided from the
+    // CURRENT chunk only: the queue text and the queue screen's `100% left`
+    // status bar both linger in outputTail, so tail matching could never
+    // clear the latch and a stale tail ready marker would clear it mid-queue.
+    // A chunk carrying the static-busy marker means the latest redraw still
+    // shows the queue; a chunk carrying fresh ready evidence without it means
+    // the composer is back.
+    if (this.staticBusyPattern) {
+      if (this.staticBusyPattern.test(stripped)) {
+        this.staticBusyLatch = true;
+      } else if (this.readyPattern?.test(stripped)) {
+        this.staticBusyLatch = false;
+      }
+    }
+
     // Track spinner — but not if it's part of completion marker,
     // and not after ready pattern is seen (status bar chars like · are not real spinners)
     if (SPINNER_RE.test(stripped) && !(this.completionPattern?.test(stripped) || this.completionPattern?.test(this.outputTail)) && !this.readySeen) {
@@ -114,7 +136,9 @@ export class IdleDetector {
       this.clearTimer();
       this.quiescenceTimer = setTimeout(() => {
         this.quiescenceTimer = null;
-        if (!this.isIdle) this.markIdle('screen');
+        // A static-busy latch outranks a completion marker: the queue screen
+        // can carry both, and the latch only clears on a composer redraw.
+        if (!this.isIdle && !this.staticBusyLatch) this.markIdle('screen');
       }, 500);
       return;
     }
@@ -132,6 +156,7 @@ export class IdleDetector {
     this.busyTransitionArmed = false;
     this.outputTail = '';
     this.readySeen = false;
+    this.staticBusyLatch = false;
     this.lastSpinnerAt = Date.now();
     this.clearTimer();
   }
@@ -147,6 +172,7 @@ export class IdleDetector {
     this.busyTransitionArmed = false;
     this.outputTail = '';
     this.readySeen = false;
+    this.staticBusyLatch = false;
     this.lastSpinnerAt = 0;
     this.clearTimer();
   }
@@ -166,11 +192,17 @@ export class IdleDetector {
     this.idleCallback = null;
     this.busyCallback = null;
     this.busyTransitionArmed = false;
+    this.staticBusyLatch = false;
   }
 
   private quiescenceCheck(): void {
     this.quiescenceTimer = null;
     if (this.isIdle) return;
+    // Explicit static-busy evidence (capacity queue): the screen is not
+    // quiescing into a prompt — it is parked on a queue notice. Do not mark
+    // idle and do not re-arm: the latch clears on the composer redraw, whose
+    // feed() re-arms quiescence.
+    if (this.staticBusyLatch) return;
     const sinceSpinner = Date.now() - this.lastSpinnerAt;
     if (sinceSpinner < SPINNER_GUARD_MS) {
       this.quiescenceTimer = setTimeout(

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1486,6 +1486,85 @@ describe('busyPattern', () => {
     expect(busy!.test('Working through the implementation')).toBe(false);
     expect(busy!.test('press esc to interrupt')).toBe(false);
   });
+
+  it('traex matches spinner-anchored working labels and standalone queue strings but not prose or idle composer', () => {
+    // Regression: a static capacity-queue screen matches readyPattern's
+    // `\d+% left` status-bar arm and survives the 2s quiescence window,
+    // flipping the card/Dashboard to Idle while the session is still waiting
+    // for capacity. The busyPattern must cover both the queue screen and the
+    // normal working indicator so the worker's deferPromptReadyWhileBusy
+    // backstop (and its idle probe) holds the session busy until a real
+    // terminal state.
+    //
+    // Every anchor below is extracted verbatim from the traex binary's
+    // compiled-in TUI string tables (verified across all 9 local releases,
+    // 0.201.1-alpha.5 … 0.201.2-alpha.2, both `traex` and
+    // `traex-code-mode-host`):
+    //   spinner frames:  "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    //   working labels:  "Working…", "Thinking…", "Pondering…",
+    //                    "Working it out…" (full rotation in traex.ts)
+    //   queue strings:   "Queued for capacity",
+    //                    "Too many requests right now. You're in the queue."
+    //   idle composer:   "Ask TraeCode CLI to do anything" + "100% context left"
+    // TraeX forked from Codex and DELETED the "esc to interrupt" footer hint
+    // (0 hits across all releases + the 94MB TUI logs), so the Codex
+    // pattern's second anchor is invalid here.
+    const busy = createTraexAdapter('/bin/traex').busyPattern;
+    expect(busy).toBeDefined();
+    // Spinner-anchored working labels: "<braille frame> <label>".
+    expect(busy!.test('⠋ Working…')).toBe(true);
+    expect(busy!.test('⠹ Thinking…')).toBe(true);
+    expect(busy!.test('⠸ Pondering…')).toBe(true);
+    expect(busy!.test('⠼ Working it out…')).toBe(true);
+    // Spinner-prefixed queue state: the queue screen can render a frozen
+    // braille frame in front of the label, and the label is part of the
+    // compiled-in spinner string table.
+    expect(busy!.test('⠋ Queued for capacity')).toBe(true);
+    // Standalone capacity-queue strings — the queue screen may render
+    // statically (no animating spinner), so no frame anchor is required.
+    // Line-anchored: bare line, indented line, and `at position N` suffix
+    // all match.
+    expect(busy!.test('Queued for capacity')).toBe(true);
+    expect(busy!.test('  Queued for capacity')).toBe(true);
+    expect(busy!.test('Queued for capacity at position 3.')).toBe(true);
+    expect(busy!.test("Too many requests right now. You're in the queue.")).toBe(true);
+    expect(busy!.test("Too many requests right now. You're in the queue at position 3.")).toBe(true);
+    // Mid-sentence prose quotes must NOT match — the line anchor is the
+    // discriminator for the standalone arms (the braille frame for the
+    // spinner arms).
+    expect(busy!.test('The status line says Queued for capacity right now')).toBe(false);
+    expect(busy!.test("It printed Too many requests right now. You're in the queue. and stopped")).toBe(false);
+    // Idle composer must NOT match.
+    expect(busy!.test('› Ask TraeCode CLI to do anything                        100% context left')).toBe(false);
+    // Prose must NOT match — the braille frame anchor is the discriminator.
+    expect(busy!.test('Working… on the fix')).toBe(false);
+    expect(busy!.test('Working through the implementation')).toBe(false);
+    expect(busy!.test('press esc to interrupt')).toBe(false);
+  });
+
+  it('traex staticBusyPattern latches only on line-anchored queue evidence', () => {
+    // The pre-idle static latch (ZMX gap) consumes queue evidence straight
+    // from the PTY byte stream — see TRAEX_STATIC_BUSY_PATTERN in traex.ts.
+    // It must match every queue-screen shape (bare / indented / spinner-
+    // prefixed / at-position suffix / ANSI-stripped by IdleDetector) and
+    // must NOT match prose quotes or the idle composer.
+    const staticBusy = createTraexAdapter('/bin/traex').staticBusyPattern;
+    expect(staticBusy).toBeDefined();
+    expect(staticBusy!.test('Queued for capacity')).toBe(true);
+    expect(staticBusy!.test('  Queued for capacity')).toBe(true);
+    expect(staticBusy!.test('Queued for capacity at position 3.')).toBe(true);
+    expect(staticBusy!.test('⠋ Queued for capacity')).toBe(true);
+    expect(staticBusy!.test("Too many requests right now. You're in the queue.")).toBe(true);
+    expect(staticBusy!.test("Too many requests right now. You're in the queue at position 3.")).toBe(true);
+    // Mid-sentence prose quotes must NOT latch.
+    expect(staticBusy!.test('The status line says Queued for capacity right now')).toBe(false);
+    expect(staticBusy!.test("It printed Too many requests right now. You're in the queue. and stopped")).toBe(false);
+    // Idle composer must NOT latch.
+    expect(staticBusy!.test('› Ask TraeCode CLI to do anything                        100% context left')).toBe(false);
+    // Working labels without the queue string must NOT latch — the latch is
+    // queue-only; ordinary working turns are covered by the spinner guard.
+    expect(staticBusy!.test('⠋ Working…')).toBe(false);
+  });
 });
 
 describe('idleToBusyPattern', () => {
@@ -1506,6 +1585,26 @@ describe('idleToBusyPattern', () => {
     expect(adapter.idleToBusyPattern!.source).toBe(adapter.busyPattern!.source);
     expect(adapter.idleToBusyPattern!.test('● Working... (esc to interrupt)')).toBe(true);
     expect(adapter.idleToBusyPattern!.test('Working through the implementation')).toBe(false);
+  });
+
+  it('traex opts into idle→busy recovery with the same strict active marker as busyPattern', () => {
+    // The capacity-queue screen can render AFTER a false idle was already
+    // published (readyPattern's `\d+% left` arm matched the status bar and
+    // quiescence fired). idleToBusyPattern must flip the session back to
+    // working when the queue marker or a working spinner label appears in
+    // the PTY stream. Strings are the same binary-extracted anchors as the
+    // busyPattern test above.
+    const adapter = createTraexAdapter('/bin/traex');
+    expect(adapter.idleToBusyPattern).toBeDefined();
+    expect(adapter.idleToBusyPattern!.source).toBe(adapter.busyPattern!.source);
+    // Spinner-anchored working labels.
+    expect(adapter.idleToBusyPattern!.test('⠋ Working…')).toBe(true);
+    expect(adapter.idleToBusyPattern!.test('⠙ Pondering…')).toBe(true);
+    // Standalone queue strings.
+    expect(adapter.idleToBusyPattern!.test('Queued for capacity')).toBe(true);
+    expect(adapter.idleToBusyPattern!.test("Too many requests right now. You're in the queue.")).toBe(true);
+    // Prose without the braille frame anchor must NOT flip idle→busy.
+    expect(adapter.idleToBusyPattern!.test('Working… on the fix')).toBe(false);
   });
 
   it.each([

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -660,22 +660,25 @@ describe('IdleDetector: static capacity-queue pre-idle latch', () => {
     // the tail window slides (drops from head). The clear position must
     // shift left too — otherwise a fresh queue landing at a low index in
     // the new window is falsely treated as stale (position < clearPos).
+    // Do NOT advance timers between clear and fresh queue: an idle fire
+    // would reset clearPos via the isIdle path, making the test pass
+    // without exercising the slide-decrement.
     const detector = new IdleDetector(traexAdapter);
     const idleCb = vi.fn();
     detector.onIdle(idleCb);
 
-    // Queue + clear, with enough filler to push the clear to a high index.
+    // Queue + filler + composer clear, all before any timer advance.
     detector.feed('Queued for capacity\n100% left');
     detector.feed('z'.repeat(471) + '\n');
     detector.feed('\n› Ask TraeCode CLI to do anything');
-    vi.advanceTimersByTime(2_500);
-    expect(idleCb).toHaveBeenCalledTimes(1);
 
     // Fresh queue lands at a LOW index in the new tail window (after the
     // slide). It must re-latch despite the old high clearPos.
     detector.feed('\nQueued for capacity\n' + 't'.repeat(430));
     vi.advanceTimersByTime(10_000);
-    expect(idleCb).toHaveBeenCalledTimes(1); // latch held, no new idle
+    // Latch held: idle does NOT fire. Without the slide-decrement, the
+    // stale clearPos would suppress the latch and idle would fire.
+    expect(idleCb).not.toHaveBeenCalled();
     detector.dispose();
   });
 });

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -654,6 +654,30 @@ describe('IdleDetector: static capacity-queue pre-idle latch', () => {
     expect(idleCb).toHaveBeenCalledTimes(1);
     detector.dispose();
   });
+
+  it('stale-tail: clear position shifts left when tail window slides', () => {
+    // After a composer clear, if the turn produces >~470 chars of output,
+    // the tail window slides (drops from head). The clear position must
+    // shift left too — otherwise a fresh queue landing at a low index in
+    // the new window is falsely treated as stale (position < clearPos).
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    // Queue + clear, with enough filler to push the clear to a high index.
+    detector.feed('Queued for capacity\n100% left');
+    detector.feed('z'.repeat(471) + '\n');
+    detector.feed('\n› Ask TraeCode CLI to do anything');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+
+    // Fresh queue lands at a LOW index in the new tail window (after the
+    // slide). It must re-latch despite the old high clearPos.
+    detector.feed('\nQueued for capacity\n' + 't'.repeat(430));
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).toHaveBeenCalledTimes(1); // latch held, no new idle
+    detector.dispose();
+  });
 });
 
 // ─── Completion pattern matching ──────────────────────────────────────────

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -549,6 +549,39 @@ describe('IdleDetector: static capacity-queue pre-idle latch', () => {
     expect(idleCb).toHaveBeenCalledTimes(1);
     detector.dispose();
   });
+
+  it('chunk-internal freshness: submitted user line before fresh queue does not clear latch', () => {
+    // ZMX prefix snapshots merge new history into one delta. A submitted
+    // user message (`› text`) followed by a fresh queue line in the SAME
+    // chunk must NOT clear the latch — the queue is fresher evidence.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('› 请修复这个问题\nQueued for capacity\nContext 100% left');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Real composer (placeholder text, not a submitted user line) clears.
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('chunk-internal freshness: queue before composer in same chunk clears latch', () => {
+    // The inverse: a queue line followed by a real composer redraw in the
+    // same chunk means the queue is gone — the latch must clear and idle
+    // must fire after quiescence.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('Queued for capacity\nContext 100% left\n› Ask TraeCode CLI to do anything');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
 });
 
 // ─── Completion pattern matching ──────────────────────────────────────────

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -23,6 +23,7 @@ function makeCli(opts: {
   busyPattern?: RegExp;
   idleToBusyPattern?: RegExp;
   staticBusyPattern?: RegExp;
+  staticBusyClearPattern?: RegExp;
   readyPattern?: RegExp;
 } = {}): CliAdapter {
   return {
@@ -34,6 +35,7 @@ function makeCli(opts: {
     busyPattern: opts.busyPattern,
     idleToBusyPattern: opts.idleToBusyPattern,
     staticBusyPattern: opts.staticBusyPattern,
+    staticBusyClearPattern: opts.staticBusyClearPattern,
     readyPattern: opts.readyPattern,
     systemHints: [],
     altScreen: false,
@@ -475,6 +477,7 @@ describe('IdleDetector: static capacity-queue pre-idle latch', () => {
     // depend on traex's exact string table.
     const detector = new IdleDetector(makeCli({
       staticBusyPattern: /(?:^|[\n\r])[ \t]*QUEUED/i,
+      staticBusyClearPattern: /PROMPT>/,
       readyPattern: /PROMPT>/,
     }));
     const idleCb = vi.fn();
@@ -492,6 +495,58 @@ describe('IdleDetector: static capacity-queue pre-idle latch', () => {
     detector.feed('PROMPT> ');
     vi.advanceTimersByTime(5_500);
     expect(idleCb).toHaveBeenCalledTimes(2);
+    detector.dispose();
+  });
+
+  it('chunk-invariant: queue line and status bar in separate deltas do not clear the latch', () => {
+    // ZMX captures history at ~50ms tail debounce / 250ms hot poll; adjacent
+    // prefix snapshots each emitData(delta). A queue line in one capture and
+    // the `\d+% left` status bar in the next must NOT clear the latch — the
+    // broad readyPattern matches the status bar, so only explicit composer
+    // evidence (staticBusyClearPattern) may clear it.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    // Chunk 1: queue line only (no status bar yet).
+    detector.feed('\x1b[2KQueued for capacity');
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Chunk 2: status bar in a separate delta. The old code cleared the
+    // latch here because readyPattern matches `\d+% left`.
+    detector.feed('\nContext 100% left');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Real composer redraw clears the latch and idle fires.
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('chunk-invariant: queue marker split across chunks is detected via rolling tail', () => {
+    // The queue text itself can be split across PTY chunks ("Queued for cap"
+    // + "acity"). The latch must scan the rolling outputTail, not just the
+    // current chunk, to detect the full marker.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    // Chunk 1: first half of the queue marker (no match yet).
+    detector.feed('\x1b[2KQueued for cap');
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Chunk 2: second half + status bar. The rolling tail now contains the
+    // full "Queued for capacity" string — the latch must fire.
+    detector.feed('acity\nContext 100% left');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Real composer redraw clears the latch and idle fires.
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
     detector.dispose();
   });
 });

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -582,6 +582,78 @@ describe('IdleDetector: static capacity-queue pre-idle latch', () => {
     expect(idleCb).toHaveBeenCalledTimes(1);
     detector.dispose();
   });
+
+  it('stale-tail: composer clear followed by status-only redraw does not re-latch', () => {
+    // After a composer redraw clears the latch, a subsequent status-bar-only
+    // chunk (no composer, no fresh queue) must NOT re-set the latch from
+    // stale queue text lingering in the rolling tail. ZMX hot-poll makes
+    // composer→status-redraw a common sequence. The status-only chunk
+    // arrives BEFORE quiescence fires (isIdle still false), so the stale
+    // tail is still present.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    // Queue screen latches.
+    detector.feed('Queued for capacity\nContext 100% left');
+    vi.advanceTimersByTime(5_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Composer redraw clears the latch. Do NOT advance timers yet — the
+    // stale tail is still present.
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything');
+
+    // Status-bar-only redraw: tail still has old queue text, but it must
+    // not re-latch (stale position < clear position).
+    detector.feed('\x1b[2K100% left');
+    vi.advanceTimersByTime(5_000);
+    // Idle fires: the latch was not re-set by the stale tail.
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('stale-tail: composer+status same chunk followed by status-only redraw does not re-latch', () => {
+    // Real-world shape: the composer line itself carries the status bar,
+    // followed by a pure status-bar redraw — all before quiescence fires.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('Queued for capacity\n100% left');
+    vi.advanceTimersByTime(5_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Composer + status in the same chunk — clear wins (composer is after
+    // queue in the chunk).
+    detector.feed('› Ask TraeCode CLI to do anything   100% left');
+
+    // Pure status redraw must not re-latch from stale tail.
+    detector.feed('100% left');
+    vi.advanceTimersByTime(5_000);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('stale-tail: fresh queue after clear re-latches (position > clear pos)', () => {
+    // Control: a genuinely new queue screen AFTER the clear must re-latch.
+    // The new queue arrives after idle fired (isIdle=true), so feed()
+    // resets the tail and clear position — the new queue is fresh.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('Queued for capacity\nContext 100% left');
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+
+    // New queue screen — fresh evidence after the clear.
+    detector.feed('\x1b[2KQueued for capacity\nContext 100% left');
+    vi.advanceTimersByTime(10_000);
+    // Latch held: idle does NOT fire again.
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
 });
 
 // ─── Completion pattern matching ──────────────────────────────────────────

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -13,6 +13,7 @@ import { createCocoAdapter } from '../src/adapters/cli/coco.js';
 import { createGeniusAdapter } from '../src/adapters/cli/genius.js';
 import { createGrokAdapter } from '../src/adapters/cli/grok.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
+import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -21,6 +22,7 @@ function makeCli(opts: {
   completionPattern?: RegExp;
   busyPattern?: RegExp;
   idleToBusyPattern?: RegExp;
+  staticBusyPattern?: RegExp;
   readyPattern?: RegExp;
 } = {}): CliAdapter {
   return {
@@ -31,6 +33,7 @@ function makeCli(opts: {
     completionPattern: opts.completionPattern,
     busyPattern: opts.busyPattern,
     idleToBusyPattern: opts.idleToBusyPattern,
+    staticBusyPattern: opts.staticBusyPattern,
     readyPattern: opts.readyPattern,
     systemHints: [],
     altScreen: false,
@@ -196,6 +199,299 @@ describe('IdleDetector: onBusy()', () => {
     detector.fireIdle();
     detector.feed('● Working...');
     expect(cb).toHaveBeenCalledTimes(2);
+    detector.dispose();
+  });
+});
+
+// ─── TraeX capacity-queue busy pattern (regression) ──────────────────────
+
+describe('IdleDetector: TraeX capacity-queue busy pattern', () => {
+  // Bind directly to the production adapter so this suite stays honest if the
+  // pattern in adapters/cli/traex.ts ever changes — no parallel hand-rolled
+  // regex to drift out of sync. '/bin/true' stub keeps resolveCommand() from
+  // failing on hosts without `traex` installed; the lazy resolvedBin getter
+  // is never touched by IdleDetector.
+  //
+  // All PTY text below is composed from strings extracted verbatim from the
+  // traex binary's compiled-in TUI string tables (verified across all 9 local
+  // releases, 0.201.1-alpha.5 … 0.201.2-alpha.2):
+  //   spinner frames:  "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+  //   working labels:  "Working…", "Pondering…" (full rotation in traex.ts)
+  //   queue strings:   "Queued for capacity",
+  //                    "Too many requests right now. You're in the queue."
+  //   idle composer:   "Ask TraeCode CLI to do anything" + "100% context left"
+  // TraeX forked from Codex and DELETED the "esc to interrupt" footer hint
+  // (0 hits across all releases + the 94MB TUI logs).
+  const traexAdapter = createTraexAdapter('/bin/true');
+
+  it('flips a queued session back to busy when the capacity-queue string renders after a false idle', () => {
+    // TraeX's readyPattern matches the `\d+% left` status bar, so a static
+    // queue screen survives the 2s quiescence window and fires a false idle.
+    // The adapter's idleToBusyPattern must flip the session back to working
+    // as soon as the queue marker renders in the PTY stream.
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('\x1b[2KQueued for capacity');
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('flips busy when the full queue notice renders after a false idle', () => {
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed("\x1b[2KToo many requests right now. You're in the queue.");
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('flips busy when a spinner-anchored working label renders after a false idle', () => {
+    // The same self-heal must cover the ordinary working screen, not just
+    // the capacity queue — a false idle during a working turn should recover
+    // when the spinner status line renders again. The braille frame + label
+    // is the real TUI rendering (frame from the compiled-in spinner set,
+    // label from the compiled-in spinner string table).
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('\x1b[2K⠋ Working…');
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('flips busy on rotating spinner labels beyond Working…', () => {
+    // The working status rotates through the full compiled-in label set;
+    // every frame must self-heal a false idle.
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('\x1b[2K⠹ Pondering…');
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('does not flip busy on an idle composer redraw', () => {
+    // The idle composer (with the `\d+% left` status bar that readyPattern
+    // matches) must NOT trigger the busy transition — only the explicit
+    // active-turn markers do.
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    expect(cb).not.toHaveBeenCalled();
+    detector.dispose();
+  });
+
+  it('does not flip busy on prose containing a working label without the spinner frame', () => {
+    // The braille frame anchor is the discriminator: assistant output like
+    // "Working… on the fix" must not revive a completed card.
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('Working… on the fix');
+    expect(cb).not.toHaveBeenCalled();
+    detector.dispose();
+  });
+
+  it('re-arms the busy edge after the next idle cycle', () => {
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('\x1b[2KQueued for capacity');
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // A second queue screen in the same idle→busy cycle stays quiet.
+    detector.feed('\x1b[2KQueued for capacity');
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // The next idle re-arms the edge.
+    detector.fireIdle();
+    detector.feed('\x1b[2K⠼ Working it out…');
+    expect(cb).toHaveBeenCalledTimes(2);
+    detector.dispose();
+  });
+});
+
+// ─── TraeX static capacity-queue pre-idle latch (ZMX regression) ─────────
+
+describe('IdleDetector: static capacity-queue pre-idle latch', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Same production adapter as the suite above — see its comment for the
+  // binary-extraction evidence behind every string used here.
+  const traexAdapter = createTraexAdapter('/bin/true');
+
+  it('ZMX shape: one queue+status chunk followed by silence never goes idle; composer redraw recovers', () => {
+    // The supported ZMX backend cannot use busyPattern viewport probes
+    // (its history is not an authoritative viewport) and never feeds
+    // history into IdleDetector, so a static queue screen that matches
+    // readyPattern's `\d+% left` arm used to survive quiescence and fire a
+    // false idle with no PTY bytes left to self-heal. The pre-idle latch
+    // must consume the queue evidence straight from the byte stream.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    // Single chunk: ANSI clear-line + queue notice + readyPattern status bar.
+    detector.feed('\x1b[2KQueued for capacity\nContext 100% left');
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Complete silence, timers far past quiescence (2s) + spinner guard (3s).
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    // Queue resolves: the real composer redraws (prompt marker, no queue
+    // string) — the latch must clear and normal quiescence fire idle.
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('holds the spinner-prefixed queue screen busy the same way', () => {
+    // The queue screen can render a frozen braille frame in front of the
+    // label; the spinner guard alone would expire after 3s and still
+    // false-idle. The latch must cover the spinner-prefixed form too.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('\x1b[2K⠋ Queued for capacity\nContext 100% left');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('holds the full queue notice busy, with or without the at-position suffix', () => {
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed("\x1b[2KToo many requests right now. You're in the queue at position 3.\nContext 100% left");
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('does not latch on a mid-sentence prose quote of the queue string', () => {
+    // Line anchoring: assistant transcript prose quoting the queue notice
+    // mid-line must not suppress idle. The chunk carries a real composer at
+    // the bottom so quiescence is allowed to run.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('The CLI printed "Queued for capacity" and then stalled\n› Ask TraeCode CLI to do anything\nContext 100% left');
+    vi.advanceTimersByTime(5_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('does not clear the latch on a noise chunk without fresh ready evidence', () => {
+    // The latch is decided from the CURRENT chunk: a stray redraw fragment
+    // carrying neither the queue marker nor ready evidence must leave it
+    // armed (the queue screen's own `100% left` lingers in the tail and
+    // must not be allowed to clear it).
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('\x1b[2KQueued for capacity\nContext 100% left');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    detector.feed('\x1b[2K');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    vi.advanceTimersByTime(2_500);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('clears the latch on reset so a rebased cycle can go idle', () => {
+    // ZMX resync / botmux submit call reset(): a latched queue cycle must
+    // not suppress idle forever after the state rebase.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('\x1b[2KQueued for capacity\nContext 100% left');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    detector.reset();
+    detector.feed('\x1b[2K› Ask TraeCode CLI to do anything\nContext 100% left');
+    // reset() synthesizes a recent spinner timestamp, so idle needs the full
+    // 3s spinner guard on top of the 2s quiescence window.
+    vi.advanceTimersByTime(6_000);
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('lets external structured completion (fireIdle) through while latched', () => {
+    // reliableTurnTerminal (task_complete) is authoritative independently
+    // of the screen observer; the latch must not block it.
+    const detector = new IdleDetector(traexAdapter);
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('\x1b[2KQueued for capacity\nContext 100% left');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    detector.fireIdle();
+    expect(idleCb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('generic adapter: latch suppresses screen idle but not external idle, and recovers on composer', () => {
+    // Mechanism-level check with a stub adapter so the behavior does not
+    // depend on traex's exact string table.
+    const detector = new IdleDetector(makeCli({
+      staticBusyPattern: /(?:^|[\n\r])[ \t]*QUEUED/i,
+      readyPattern: /PROMPT>/,
+    }));
+    const idleCb = vi.fn();
+    detector.onIdle(idleCb);
+
+    detector.feed('QUEUED for capacity\n');
+    vi.advanceTimersByTime(10_000);
+    expect(idleCb).not.toHaveBeenCalled();
+
+    detector.fireIdle();
+    expect(idleCb).toHaveBeenCalledTimes(1);
+
+    // After the external idle, a composer redraw clears the latch and a
+    // later silence goes idle via the screen path.
+    detector.feed('PROMPT> ');
+    vi.advanceTimersByTime(5_500);
+    expect(idleCb).toHaveBeenCalledTimes(2);
     detector.dispose();
   });
 });


### PR DESCRIPTION
优先级：P1

## 根因

TraeX 适配器缺少 `busyPattern` / `idleToBusyPattern`。容量排队画面静止时会匹配状态栏 ready pattern，并在 2 秒静默窗后被 IdleDetector 判为 idle；worker 又因没有 busy pattern 直接放行 prompt-ready，导致 Dashboard 和卡片在仍排队时显示 Idle。

## 改动

为 TraeX 增加真实 TUI 工作态与排队态锚点：

- spinner 帧集加 23 条旋转工作文案，通过 braille 帧前缀避免正文误判。
- 独立覆盖 `Queued for capacity` 和 `Too many requests right now. You're in the queue` 两类可能静态渲染的排队提示。
- 同时覆盖排队态与真实 working turn，避免队列消解、排队标记离开视口时短暂闪现假 Idle。

这些锚点来自 9 个本地 TraeX 版本（0.201.1-alpha.5 至 0.201.2-alpha.2）的编译期 TUI 字符串；TraeX 已删除 Codex 的 `esc to interrupt` 页脚，因此没有沿用不成立的 Codex 模式。

## 影响面

仅修改 TraeX CLI 适配器的空闲/繁忙识别，不影响其他 CLI、会话后端或消息投递路径。

## 验证

- 9 个 TraeX / traex-code-mode-host 二进制均验证包含所用工作与排队字符串。
- 对 94MB TUI 日志验证 `esc to interrupt` 命中为 0。
- 相关测试全部使用真实 TraeX 字符串，覆盖静态排队、spinner 工作态及从排队切换到工作态的连续 busy 判定。