### PR TITLE
fix(ask): 待答 ask 不再吞掉带附件的消息

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -394,7 +394,7 @@ function republishResolvedAllowedUsers(larkAppId: string, resolved: string[]): v
   try { writeDaemonDescriptor(desc); } catch { /* best effort */ }
 }
 let vcMeetingTerminalReconciler: VcMeetingTerminalReconciler | undefined;
-import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, markForwardFollowupsSessionsReady, writeBotInfoFile, canOperate, canRunDaemonCommand, evaluateTalk, evaluateBotTalk, evaluateAskAnswerTalk, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext, type EventHandlers } from './im/lark/event-dispatcher.js';
+import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, markForwardFollowupsSessionsReady, writeBotInfoFile, canOperate, canRunDaemonCommand, evaluateTalk, evaluateBotTalk, evaluateAskAnswerTalk, askCustomReplyCandidate, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext, type EventHandlers } from './im/lark/event-dispatcher.js';
 import { getDocSubscription, listAllDocSubscriptions, listDocSubscriptionsForSession, putDocSubscription, removeDocSubscription, setDocCommentPollCursor, type DocSubscription } from './services/doc-subs-store.js';
 import { BOT_REPLY_SENTINEL, subscribeDocFile, unsubscribeDocFile, addCommentReaction, removeCommentReaction, hasBotSentinel, isBotAuthoredReply, listDocComments } from './im/lark/doc-comment.js';
 import { learnFromMentions, resolveSender, flushIdentityCacheSync, type ResolvedSender } from './im/lark/identity-cache.js';
@@ -18863,35 +18863,38 @@ async function handleThreadReplyAdmitted(
   // 回调 URL 已在上方 return，可用来中止）。答复权限 = canTalk，由
   // broker 在 submitCustomReply 内按注入的 canTalkChecker 判定：非授权人返回
   // 'unauthorized'，这里 fall through 到正常路由。卡片由 broker.onSettle 自动 PATCH。
-  // `!threadGrill`：grill goal 分支只改写 promptContent 后 fall-through（不 return），
-  // cmdContent 仍是字面量 `/workflow new <目标>`；若不排除，待回答 ask 会把它当答案吞掉，
-  // grill 永远不启动。grill 必须穿过拦截器走正常转发。
-  if (threadSenderOpenId && threadChatId && !threadGrill) {
-    const askReplyText = cmdContent.trim();
-    if (askReplyText) {
-      const pendingAsk = findPendingAskByAnchor({ larkAppId, chatId: threadChatId, anchor });
-      if (pendingAsk) {
-        const outcome = submitCustomReply({
-          askId: pendingAsk.askId,
-          by: threadSenderOpenId,
-          text: askReplyText,
-          // Actor context so the broker's talk check uses the same predicate as
-          // the dispatcher gate / quota recheck: a bot text-reply → evaluateBotTalk
-          // (covers team-拉群 with no union_id), a platform teamMember human →
-          // evaluateTalk's teamMember union leg. Omitting it (card clicks) degrades
-          // to the plain evaluateTalk(openId, chatType).
-          actor: {
-            botSender: isBotSenderType || isForeignBot,
-            senderUnionId: threadTeamTrustUnionId,
-            memberUnionId: threadSenderUnionId,
-          },
-        });
-        if (outcome === 'accepted') {
-          logger.info(`[${anchor.substring(0, 12)}] ask custom reply accepted from ${threadSenderOpenId.substring(0, 12)}`);
-          return;
-        }
-        logger.info(`[${anchor.substring(0, 12)}] ask custom reply not accepted (${outcome}); falling through to normal routing`);
+  // 「哪些消息算纯文字答复」收口在 askCustomReplyCandidate（含带资源消息与 grill
+  // 触发的排除理由），拦截器这里只负责拿着结果去 settle。
+  const askCandidate = askCustomReplyCandidate({
+    senderOpenId: threadSenderOpenId,
+    chatId: threadChatId,
+    cmdContent,
+    resourceCount: resources.length,
+    isWorkflowGrillTrigger: !!threadGrill,
+  });
+  if (askCandidate) {
+    const pendingAsk = findPendingAskByAnchor({ larkAppId, chatId: askCandidate.chatId, anchor });
+    if (pendingAsk) {
+      const outcome = submitCustomReply({
+        askId: pendingAsk.askId,
+        by: askCandidate.senderOpenId,
+        text: askCandidate.text,
+        // Actor context so the broker's talk check uses the same predicate as
+        // the dispatcher gate / quota recheck: a bot text-reply → evaluateBotTalk
+        // (covers team-拉群 with no union_id), a platform teamMember human →
+        // evaluateTalk's teamMember union leg. Omitting it (card clicks) degrades
+        // to the plain evaluateTalk(openId, chatType).
+        actor: {
+          botSender: isBotSenderType || isForeignBot,
+          senderUnionId: threadTeamTrustUnionId,
+          memberUnionId: threadSenderUnionId,
+        },
+      });
+      if (outcome === 'accepted') {
+        logger.info(`[${anchor.substring(0, 12)}] ask custom reply accepted from ${askCandidate.senderOpenId.substring(0, 12)}`);
+        return;
       }
+      logger.info(`[${anchor.substring(0, 12)}] ask custom reply not accepted (${outcome}); falling through to normal routing`);
     }
   }
 

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1569,6 +1569,48 @@ export function evaluateAskAnswerTalk(
     : evaluateTalk(larkAppId, chatId, senderOpenId, actor?.senderUnionId, actor?.memberUnionId, chatType).allowed;
 }
 
+/** 一条 thread reply 被判定为「待答 ask 的文字答复」后，拦截器需要的三个已收窄值。 */
+export interface AskCustomReplyCandidate {
+  senderOpenId: string;
+  chatId: string;
+  text: string;
+}
+
+/**
+ * 这条 thread reply 能不能被待答 ask 当成「自定义回复」吞掉——handleThreadReply
+ * 里那道拦截器的唯一生产判据。
+ *
+ * 命中时该消息会走 submitCustomReply settle 掉 ask，**不再**作为新一轮输入转发给
+ * CLI。因此只有**真正的纯文字答复**才可以被吞：
+ *
+ *  - `resourceCount > 0` 一律不吞。文件 / 图片消息也有非空正文（解析器给的
+ *    `[文件 1: x.pdf]` / `[图片 1]` 占位文本），只看文本非空会让成员在旧操作卡
+ *    有效期内发的新附件被当成旧问题的答案消费掉：新资料不进附件路由，旧 ask 被
+ *    一段占位文本 settle。带资源的消息必须落回正常消息 / 附件路由。
+ *  - workflow grill 触发（`/workflow [new] <目标>`）不吞：grill 分支只改写
+ *    promptContent 后 fall-through，cmdContent 仍是字面量，被吞掉 grill 就永远
+ *    不启动。
+ *  - 没有 senderOpenId / chatId 时不吞：答复权限与 ask 归属都无从判定。
+ *
+ * 抽成导出谓词（而非把条件内联进 daemon）的意义与 {@link evaluateAskAnswerTalk}
+ * 一致：让**判据本身**能被回归测试直接咬住。拦截命中后的鉴权仍在 broker 内由
+ * canTalkChecker 判定，本函数不涉及权限。
+ */
+export function askCustomReplyCandidate(input: {
+  senderOpenId: string | undefined;
+  chatId: string | undefined;
+  cmdContent: string;
+  resourceCount: number;
+  isWorkflowGrillTrigger: boolean;
+}): AskCustomReplyCandidate | undefined {
+  if (!input.senderOpenId || !input.chatId) return undefined;
+  if (input.isWorkflowGrillTrigger) return undefined;
+  if (input.resourceCount > 0) return undefined;
+  const text = input.cmdContent.trim();
+  if (!text) return undefined;
+  return { senderOpenId: input.senderOpenId, chatId: input.chatId, text };
+}
+
 export function canOperate(
   larkAppId: string,
   _chatId: string | undefined,

--- a/test/ask-custom-reply-candidate.test.ts
+++ b/test/ask-custom-reply-candidate.test.ts
@@ -1,0 +1,91 @@
+/**
+ * askCustomReplyCandidate 的回归 —— handleThreadReply 里「这条 thread reply 该不该
+ * 被待答 ask 当成文字答复吞掉」的生产判据。
+ *
+ * 修的缺陷：判据原本只看 `cmdContent.trim()` 非空，从不看 resources。文件 / 图片
+ * 消息的正文是解析器生成的 `[文件 1: x.pdf]` / `[图片 1]` 占位文本（非空），于是
+ * 同一话题里还有一张未结的 `botmux ask` 操作卡时，成员发的**新附件**会被当成旧
+ * 问题的答案 settle 掉：新资料不进附件路由，旧 ask 被一段占位文本结掉。
+ *
+ * 这里既咬正向（纯文字仍被接纳）也咬负向（带资源必须落回正常路由），并直接把
+ * 生产解析器 parseEventMessage 的真实输出喂进判据——用真实占位文本，而不是测试
+ * 里手抄一个 `[文件 1: …]` 字面量，否则占位文本格式一变本文件就测不到东西了。
+ *
+ * Run: pnpm vitest run test/ask-custom-reply-candidate.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { askCustomReplyCandidate } from '../src/im/lark/event-dispatcher.js';
+import { parseEventMessage } from '../src/im/lark/message-parser.js';
+
+const SENDER = 'ou_answerer';
+const CHAT = 'oc_ask';
+
+function candidateFor(
+  overrides: Partial<Parameters<typeof askCustomReplyCandidate>[0]> = {},
+): ReturnType<typeof askCustomReplyCandidate> {
+  return askCustomReplyCandidate({
+    senderOpenId: SENDER,
+    chatId: CHAT,
+    cmdContent: '确认归档 ATLAS-30',
+    resourceCount: 0,
+    isWorkflowGrillTrigger: false,
+    ...overrides,
+  });
+}
+
+/** 走生产解析器拿一条飞书消息的真实 (正文, 资源数)，不手抄占位文本。 */
+function parsedMessage(messageType: string, content: Record<string, unknown>): { cmdContent: string; resourceCount: number } {
+  const { parsed, resources } = parseEventMessage({
+    sender: { sender_id: { open_id: SENDER }, sender_type: 'user' },
+    message: {
+      message_id: 'om_probe',
+      chat_id: CHAT,
+      chat_type: 'p2p',
+      message_type: messageType,
+      content: JSON.stringify(content),
+    },
+  });
+  return { cmdContent: parsed.content, resourceCount: resources.length };
+}
+
+describe('askCustomReplyCandidate — 待答 ask 的自定义回复拦截判据', () => {
+  it('纯文字答复：接纳为 custom reply，并把收窄后的三个值交给拦截器', () => {
+    expect(candidateFor()).toEqual({ senderOpenId: SENDER, chatId: CHAT, text: '确认归档 ATLAS-30' });
+  });
+
+  it('纯文字答复：两端空白被裁掉（broker 侧也裁，这里保持同一形状）', () => {
+    expect(candidateFor({ cmdContent: '  不归档  ' })?.text).toBe('不归档');
+  });
+
+  it('带资源的文件消息：不被拦截，落回正常消息 / 附件路由', () => {
+    const message = parsedMessage('file', { file_key: 'file_probe', file_name: '安全测试资料.pdf' });
+    // 前提校验：文件消息的正文确实非空 —— 缺陷正是「非空就吞」造成的。
+    expect(message.cmdContent.trim()).not.toBe('');
+    expect(message.resourceCount).toBeGreaterThan(0);
+    expect(candidateFor(message)).toBeUndefined();
+  });
+
+  it('带资源的图片消息：同样不被拦截', () => {
+    const message = parsedMessage('image', { image_key: 'img_probe' });
+    expect(message.cmdContent.trim()).not.toBe('');
+    expect(message.resourceCount).toBeGreaterThan(0);
+    expect(candidateFor(message)).toBeUndefined();
+  });
+
+  it('附带说明文字的文件消息：仍不被拦截 —— 有资源就不是纯文字答复', () => {
+    expect(candidateFor({ cmdContent: '确认归档 ATLAS-30', resourceCount: 1 })).toBeUndefined();
+  });
+
+  it('workflow grill 触发：不被拦截，否则 grill 永远不启动', () => {
+    expect(candidateFor({ cmdContent: '/workflow new 梳理归档流程', isWorkflowGrillTrigger: true })).toBeUndefined();
+  });
+
+  it('空正文：不被拦截（broker 也会以 stale 拒掉）', () => {
+    expect(candidateFor({ cmdContent: '   ' })).toBeUndefined();
+  });
+
+  it('缺 senderOpenId / chatId：不被拦截 —— 答复权限与 ask 归属都无从判定', () => {
+    expect(candidateFor({ senderOpenId: undefined })).toBeUndefined();
+    expect(candidateFor({ chatId: undefined })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 问题

同一话题（私聊 / 话题群）里还有一张未结的 `botmux ask` 操作卡时，成员发送的**新文件 / 图片消息**会被自定义回复拦截器当成旧问题的文字答案 `submitCustomReply` 掉：

- 新附件不再进入正常消息 / 附件路由，CLI 完全收不到这一轮；
- 旧 ask 被一段 `[文件 1: 资料.pdf]` 占位文本 settle，调用方拿到一个无法解析的答案。

实测复现路径：一个用 `botmux ask buttons` 做「资料处理完，请选择下一步」操作卡的插件流程，在操作卡 10 分钟有效期内再发一份资料，这份资料就静默丢失；等旧 ask 超时后重发同一份资料则一切正常。

## 根因

`handleThreadReplyAdmitted` 的拦截判据只看 `cmdContent.trim()` 非空：

```ts
if (threadSenderOpenId && threadChatId && !threadGrill) {
  const askReplyText = cmdContent.trim();
  if (askReplyText) { /* → submitCustomReply */ }
}
```

而文件 / 图片消息的正文恰好是 `message-parser` 生成的**非空占位文本**（`[文件 N: name]` / `[图片 N]`），所以「这条消息有没有资源」从未参与判断。注释里写的「仅拦截纯文字」与实现并不一致。

## 改动

把判据抽成 `event-dispatcher` 的导出谓词 `askCustomReplyCandidate()`，并加上 `resourceCount > 0` 排除：带资源的消息一律落回正常消息 / 附件路由。

行为差异只有这一条。以下全部不变：

- 纯文字自定义答复仍被接纳并 settle 原 ask（含两端空白裁剪）；
- workflow grill 触发（`/workflow [new] <目标>`）仍穿过拦截器；
- 空正文、缺 `senderOpenId` / `chatId` 仍不拦截；
- 按钮点击路径不经过这里；
- 鉴权仍在 broker 内由注入的 `canTalkChecker` 判定，本谓词不涉及权限；
- 会话锚点与 ask 超时语义均未触碰。

抽成导出谓词（而不是在 daemon 里多加一个 `&&`）的意义与既有的 `evaluateAskAnswerTalk` 一致：让**判据本身**能被回归测试直接咬住，而不是只能靠人工核对 daemon 内联条件。

## 测试

新增 `test/ask-custom-reply-candidate.test.ts`（8 个用例，正向 + 负向）。正文与资源数**直接取自生产解析器 `parseEventMessage` 的真实输出**，而不是测试里手抄一个 `[文件 1: …]` 字面量——否则占位文本格式一变，这个文件就测不到任何东西了。

```
pnpm vitest run test/ask-custom-reply-candidate.test.ts   → 8 passed
```

红/绿验证：临时删掉 `resourceCount > 0` 那一行后，文件消息、图片消息、带说明文字的文件消息 3 个用例立刻转红。

回归：

```
pnpm vitest run --project unit test/ask-*.test.ts          → 183 passed
npx tsc --noEmit                                           → 0 errors
pnpm test（全量 unit）                                      → 946 files / 15514 passed
```

全量 unit 剩余 5 个失败与本改动无关，已在同一机器上用未打补丁的 pristine `master` 复核：`riff-keychain-jwt` 的 3 个失败在 pristine 上同样红（读真实 `~/.config`，与环境相关）；`v3-host` 与 `worker-argv-reaction-status` 单独跑均绿，属全量并行下的时序抖动。

Made with [Cursor](https://cursor.com)