### PR TITLE
feat(cursor): spawn 会话补齐无 botmux send 时的 transcript 兜底（对齐 codex）

### DIFF
--- a/src/adapters/cli/cursor.ts
+++ b/src/adapters/cli/cursor.ts
@@ -97,9 +97,10 @@ export function createCursorAdapter(pathOverride?: string): CliAdapter {
       //     backslash-before-CR as a soft-newline (not part of the submitted
       //     text) and no LF byte hits the stream, making it fold-immune. Costs a
       //     cosmetic trailing `\` in the local TUI render only.
-      // Submit is always a bare Enter (\r). No on-disk submit verification —
-      // cursor's transcript path isn't documented, so the worker relies on
-      // idle detection + the bridge fallback timer.
+      // Submit is always a bare Enter (\r). No adapter-side on-disk submit
+      // verification; the worker relies on idle detection plus the structured
+      // transcript bridge (agent-transcripts JSONL, see cursor-transcript.ts)
+      // for turn attribution and the send-less fallback.
       const useKeys = !!(pty.sendText && pty.sendSpecialKeys);
       const emitText = (s: string) => (useKeys ? pty.sendText!(s) : pty.write(s));
       const emitSoftNewline = () => {

--- a/src/services/codex-bridge-queue.ts
+++ b/src/services/codex-bridge-queue.ts
@@ -308,6 +308,21 @@ export class CodexBridgeQueue {
     return true;
   }
 
+  /** Refresh the head's bounded attribution-only lease while the CLI is
+   *  visibly busy. Cursor's transcript mirror may not flush the current
+   *  turn's user line until the first assistant step (or the whole turn)
+   *  completes, which can exceed the 20s lease measured from write time; the
+   *  caller ticks this while the CLI is working so the countdown effectively
+   *  starts at idle. Confirmed and rpc-active turns keep their own leases. */
+  refreshUnstartedHeadAttributionLease(nowMs: number = this.now()): boolean {
+    const head = this.queue.find(turn => !turn.started && turn.finalText === undefined);
+    if (!head || head.rpcActive) return false;
+    if (head.submitConfirmedAtMs !== undefined) return false;
+    if (head.unconfirmedAttributionStartedAtMs === undefined) return false;
+    head.unconfirmedAttributionStartedAtMs = nowMs;
+    return true;
+  }
+
   /** Finish verification without positive submit evidence. A bare mark remains
    *  available for transcript attribution but no longer gates screen-ready. */
   finishSubmitVerification(

--- a/src/services/cursor-transcript.ts
+++ b/src/services/cursor-transcript.ts
@@ -160,6 +160,47 @@ export interface CursorDrainResult {
   /** A line written without its terminating \n yet — informational; only
    *  complete lines produce events. */
   pendingTail: string;
+  /** Byte offset of the snapshot EOF (start + bytes actually read). Same
+   *  snapshot as the drain — no second statSync, so no TOCTOU. Used as the
+   *  attach baseline when the snapshot ends mid in-flight MESSAGE line: that
+   *  line is old output and must be skipped, restoring the old `size`
+   *  baseline semantics without the 64 KiB tail-window probe (which could
+   *  start mid-multibyte-char and drift the byte arithmetic). */
+  readEndOffset: number;
+  /** True when the drain read a complete, stable snapshot (bytesRead === len,
+   *  no I/O failure). False on a short read (file truncated between stat and
+   *  read) or any I/O failure — the caller must NOT commit a baseline from a
+   *  partial snapshot. Trivially true for no-op drains (size <= start). */
+  snapshotComplete: boolean;
+}
+
+/** Whether the cursor transcript fallback is disabled for this session.
+ *  The 30s fail-safe sets `disabled=true` when the baseline can't be
+ *  committed; this stops BOTH polling and mark attribution (not just
+ *  polling). Other CLIs are unaffected — only cursor has the per-session
+ *  disable switch. Pure function for testability. */
+export function isCursorFallbackDisabled(cliId: string | undefined, disabled: boolean): boolean {
+  return cliId === 'cursor' && disabled;
+}
+
+/** Classification of a pending-tail fragment (a partial JSON line at EOF)
+ *  for baseline selection at attach time. */
+export type CursorTailClass = 'message' | 'footer' | 'defer';
+
+/** Classify a pending-tail fragment by its PREFIX. Cursor's JSONL is compact
+ *  JSON: conversation messages start with `{"role":"user"` /
+ *  `{"role":"assistant"`; the turn_ended status footer starts with
+ *  `{"type":"turn_ended"`. Only a COMPLETE known discriminator classifies —
+ *  a half-written value, unknown type, or unexpected shape returns 'defer'
+ *  (the caller waits for the next tick rather than guessing). Cursor's
+ *  internal schema is not promised stable: a future conversation line could
+ *  carry a top-level `type`, so widening the match would reopen the
+ *  stale-replay hole. A parseable COMPLETE line is handled by the object
+ *  classifier (isStatusFooterObject) inside the drain, not here. */
+export function classifyCursorPendingTail(fragment: string): CursorTailClass {
+  if (fragment.startsWith('{"role":"user"') || fragment.startsWith('{"role":"assistant"')) return 'message';
+  if (fragment.startsWith('{"type":"turn_ended"')) return 'footer';
+  return 'defer';
 }
 
 /** Concatenate the text of all `type:'text'` blocks. Cursor uses the same
@@ -261,63 +302,96 @@ function isStatusFooterObject(obj: any): boolean {
  *  observed live on cursor-agent 2026.08.11). Leaving the offset at the
  *  footer's start costs a ~40-byte re-read per poll and re-parses to zero
  *  events, so no duplicates can result. */
-export function drainCursorTranscript(path: string, fromOffset: number): CursorDrainResult {
-  if (!existsSync(path)) return { events: [], newOffset: fromOffset, pendingTail: '' };
+/** Optional dependency injection for deterministic short-read / race
+ *  testing. Production callers omit this and use the real fs functions. */
+export interface CursorDrainDeps {
+  stat?: (path: string) => number;
+  read?: (fd: number, buf: Buffer, offset: number, length: number, position: number) => number;
+}
+
+export function drainCursorTranscript(path: string, fromOffset: number, deps: CursorDrainDeps = {}): CursorDrainResult {
+  const statSize = deps.stat ?? ((p: string) => statSync(p).size);
+  const readFn = deps.read ?? readSync;
+  const empty = (offset: number, complete = true): CursorDrainResult =>
+    ({ events: [], newOffset: offset, pendingTail: '', readEndOffset: offset, snapshotComplete: complete });
+  if (!existsSync(path)) return empty(fromOffset, false);
   let size: number;
-  try { size = statSync(path).size; } catch { return { events: [], newOffset: fromOffset, pendingTail: '' }; }
-  let start = fromOffset;
+  try { size = statSize(path); } catch { return empty(fromOffset, false); }
+  const start = fromOffset;
   // Cursor's mirror can briefly disappear / shrink while it rewrites. Do not
   // reset to 0 here: replaying the full history pollutes attribution state and
   // can wedge a live turn behind old events. Wait for the mirror to grow past
-  // the last consumed byte instead. (The footer rewind above keeps the
+  // the last consumed byte instead. (The footer rewind below keeps the
   // committed offset at the truncation point, so the equal-size no-op window
   // during a footer-truncate is expected and harmless.)
-  if (size < start) return { events: [], newOffset: fromOffset, pendingTail: '' };
-  if (size === start) return { events: [], newOffset: start, pendingTail: '' };
+  if (size < start) return empty(fromOffset);
+  if (size === start) return empty(start);
 
   const len = size - start;
   const buf = Buffer.alloc(len);
-  const fd = openSync(path, 'r');
-  try { readSync(fd, buf, 0, len, start); } finally { closeSync(fd); }
-  const text = buf.toString('utf8');
-  const lastNl = text.lastIndexOf('\n');
-  const completeText = lastNl >= 0 ? text.slice(0, lastNl + 1) : '';
-  let pendingTail = lastNl >= 0 ? text.slice(lastNl + 1) : text;
-  let newOffset = start + Buffer.byteLength(completeText, 'utf8');
+  let bytesRead = 0;
+  try {
+    const fd = openSync(path, 'r');
+    try { bytesRead = readFn(fd, buf, 0, len, start); } finally { closeSync(fd); }
+  } catch { return empty(fromOffset, false); }
+  // Capture the ACTUAL bytes read. If Cursor truncates the mirror between
+  // statSync and readSync, bytesRead < len and the buffer tail is zero-filled
+  // garbage — scanning it would push readEndOffset past the real data and
+  // ghost the next turn. snapshotComplete=false tells the caller to defer
+  // rather than commit a baseline from a partial snapshot.
+  const snapshotComplete = bytesRead === len;
+  const readEndOffset = start + bytesRead;
+  const data = buf.subarray(0, bytesRead);
 
+  // Walk raw newline (0x0a) positions instead of decoding the whole buffer
+  // and re-encoding per line. When `start` lands mid-multibyte-char (a
+  // baseline at the old `size` during a footer-truncate rewrite), the decoded
+  // string's byte length no longer maps 1:1 to file offsets, and the old
+  // `Buffer.byteLength(line, 'utf8') + 1` arithmetic drifts past the true
+  // line boundary. Raw 0x0a indices are always exact file offsets; the first
+  // segment after a mid-char start decodes with a U+FFFD prefix and fails
+  // JSON.parse (skipped), so no drift accumulates.
   const events: CodexBridgeEvent[] = [];
-  // Byte start of the current TRAILING run of parsed status/footer lines.
-  // Reset by any message line or unparseable fragment; blank lines don't
-  // break the run. When set after the scan, newOffset rewinds to it.
+  // Byte start (file-absolute) of the current TRAILING run of parsed
+  // status/footer lines. Reset by any message line or unparseable fragment;
+  // blank lines don't break the run. When set after the scan, newOffset
+  // rewinds to it.
   let trailingFooterStart: number | undefined;
-  // Track byte offset within the file so synthetic uuids are stable across
-  // re-drains (message lines are append-only; only the footer moves).
-  let cursor = start;
-  for (const line of completeText.split('\n')) {
-    if (line.length === 0) {
-      cursor += 1; // the \n after an empty line
-      continue;
+  let newOffset = start;
+  let segStart = 0; // data-relative start of the current line segment
+  let nlIdx = data.indexOf(0x0a);
+  while (nlIdx !== -1) {
+    const lineBuf = data.subarray(segStart, nlIdx); // excludes the \n
+    const lineFileStart = start + segStart;
+    newOffset = start + nlIdx + 1; // file-absolute, after the \n
+    if (lineBuf.length > 0) {
+      const line = lineBuf.toString('utf8');
+      let obj: any;
+      try { obj = JSON.parse(line); } catch {
+        trailingFooterStart = undefined;
+        segStart = nlIdx + 1;
+        nlIdx = data.indexOf(0x0a, segStart);
+        continue;
+      }
+      if (isStatusFooterObject(obj)) {
+        trailingFooterStart ??= lineFileStart;
+      } else {
+        trailingFooterStart = undefined;
+        // No per-event timestamp in Cursor's JSONL — stamp with the drain
+        // wall-clock. Combined with byte-offset baselining at attach, this
+        // keeps the CodexBridgeQueue freshness gates happy without a real
+        // timestamp.
+        const ev = eventFromLine(path, lineFileStart, obj, Date.now());
+        if (ev) events.push(ev);
+      }
     }
-    const lineByteLen = Buffer.byteLength(line, 'utf8') + 1; // include \n
-    const lineStart = cursor;
-    cursor += lineByteLen;
-    let obj: any;
-    try { obj = JSON.parse(line); } catch {
-      trailingFooterStart = undefined;
-      continue;
-    }
-    if (isStatusFooterObject(obj)) {
-      trailingFooterStart ??= lineStart;
-      continue;
-    }
-    trailingFooterStart = undefined;
-    // No per-event timestamp in Cursor's JSONL — stamp with the drain
-    // wall-clock. Combined with byte-offset baselining at attach, this keeps
-    // the CodexBridgeQueue freshness gates happy without a real timestamp.
-    const timestampMs = Date.now();
-    const ev = eventFromLine(path, lineStart, obj, timestampMs);
-    if (ev) events.push(ev);
+    segStart = nlIdx + 1;
+    nlIdx = data.indexOf(0x0a, segStart);
   }
+  // Pending tail: bytes after the last \n (or the whole buffer if no \n).
+  // Starts at a line boundary, so it decodes cleanly even when `start` was
+  // mid-char.
+  let pendingTail = data.subarray(segStart).toString('utf8');
 
   // Cursor frequently leaves the final JSON object at EOF without a trailing
   // newline until the next turn mutates the mirror. If the tail is already a
@@ -325,15 +399,15 @@ export function drainCursorTranscript(path: string, fromOffset: number): CursorD
   // it (status footer); otherwise keep it pending.
   if (pendingTail.length > 0) {
     try {
-      const lineStart = newOffset;
+      const lineFileStart = newOffset;
       const obj = JSON.parse(pendingTail);
       if (isStatusFooterObject(obj)) {
-        trailingFooterStart ??= lineStart;
+        trailingFooterStart ??= lineFileStart;
       } else {
         trailingFooterStart = undefined;
-        const ev = eventFromLine(path, lineStart, obj, Date.now());
+        const ev = eventFromLine(path, lineFileStart, obj, Date.now());
         if (ev) events.push(ev);
-        newOffset = size;
+        newOffset = readEndOffset;
       }
       pendingTail = '';
     } catch {
@@ -344,68 +418,5 @@ export function drainCursorTranscript(path: string, fromOffset: number): CursorD
     newOffset = trailingFooterStart;
     pendingTail = '';
   }
-  return { events, newOffset, pendingTail };
-}
-
-const BASELINE_FOOTER_PROBE_BYTES = 64 * 1024;
-
-/** Baseline offset for attaching to an EXISTING cursor transcript (resume /
- *  restart re-attach): the byte frontier future drains should start from.
- *  Like a plain size baseline this leaves all history (and any partial tail —
- *  old in-flight output) behind the offset, but REWINDS before a trailing run
- *  of status/footer lines so the next turn's footer-truncating rewrite (see
- *  drainCursorTranscript) starts exactly at the committed offset instead of
- *  behind it. Returns undefined when the file is missing/unreadable so the
- *  caller can keep its existing degrade path. */
-export function cursorBaselineOffset(path: string): number | undefined {
-  let size: number;
-  try {
-    if (!existsSync(path)) return undefined;
-    size = statSync(path).size;
-  } catch { return undefined; }
-  if (size === 0) return 0;
-
-  const len = Math.min(size, BASELINE_FOOTER_PROBE_BYTES);
-  const probeStart = size - len;
-  const buf = Buffer.alloc(len);
-  let read = 0;
-  try {
-    const fd = openSync(path, 'r');
-    try { read = readSync(fd, buf, 0, len, probeStart); } finally { closeSync(fd); }
-  } catch { return undefined; }
-  const probe = buf.subarray(0, read).toString('utf8');
-
-  // Walk the probe's line layout forward, tracking the same trailing-footer
-  // run the drain uses. The first probe segment may be a mid-line fragment
-  // (probe boundary), which safely resets the run via its parse failure.
-  const lastNl = probe.lastIndexOf('\n');
-  const completeText = lastNl >= 0 ? probe.slice(0, lastNl + 1) : '';
-  const tail = lastNl >= 0 ? probe.slice(lastNl + 1) : probe;
-  let trailingFooterStart: number | undefined;
-  let cursor = probeStart;
-  for (const line of completeText.split('\n')) {
-    if (line.length === 0) { cursor += 1; continue; }
-    const lineStart = cursor;
-    cursor += Buffer.byteLength(line, 'utf8') + 1;
-    let obj: any;
-    try { obj = JSON.parse(line); } catch {
-      trailingFooterStart = undefined;
-      continue;
-    }
-    if (isStatusFooterObject(obj)) trailingFooterStart ??= lineStart;
-    else trailingFooterStart = undefined;
-  }
-  if (tail.length > 0) {
-    // A parseable status-footer tail joins the run; a message tail (old
-    // in-flight output) or a still-being-written fragment is skipped like the
-    // plain size baseline does. Tail start is derived from completeText's byte
-    // length, NOT the loop cursor — the split's trailing empty segment would
-    // otherwise inflate the cursor by one.
-    const tailStart = probeStart + Buffer.byteLength(completeText, 'utf8');
-    try {
-      if (isStatusFooterObject(JSON.parse(tail))) trailingFooterStart ??= tailStart;
-      else trailingFooterStart = undefined;
-    } catch { trailingFooterStart = undefined; }
-  }
-  return trailingFooterStart ?? size;
+  return { events, newOffset, pendingTail, readEndOffset, snapshotComplete };
 }

--- a/src/services/cursor-transcript.ts
+++ b/src/services/cursor-transcript.ts
@@ -238,9 +238,29 @@ function eventFromLine(path: string, lineStart: number, obj: any, timestampMs: n
   return undefined;
 }
 
+/** True for a parsed JSONL object that is NOT a conversation message —
+ *  cursor-agent's status/footer lines like `{"type":"turn_ended",
+ *  "status":"success"}`. These are NOT append-only: cursor appends one at EOF
+ *  when a turn ends, then the NEXT turn's flush truncates it away and writes
+ *  the new user/assistant lines starting at the footer's old byte position
+ *  (footer re-appended at the new EOF). */
+function isStatusFooterObject(obj: any): boolean {
+  return (obj?.role ?? obj?.message?.role) === undefined;
+}
+
 /** Increment-read the transcript from `fromOffset`. Mirrors the byte-offset
  *  contract of codex-transcript.drainCodexRollout so the worker can reuse the
- *  same fs.watch / poll wakeup machinery and the shared CodexBridgeQueue. */
+ *  same fs.watch / poll wakeup machinery and the shared CodexBridgeQueue.
+ *
+ *  Footer invariant: `newOffset` NEVER advances past a trailing run of parsed
+ *  status/footer objects (see isStatusFooterObject). Consuming the footer
+ *  would strand the offset at the old EOF — the next turn REWRITES from the
+ *  footer's start, so the new user line would begin BEHIND the committed
+ *  offset and the drain would only ever see a mid-line fragment of it (the
+ *  turn then never fingerprint-matches and the send-less fallback ghosts,
+ *  observed live on cursor-agent 2026.08.11). Leaving the offset at the
+ *  footer's start costs a ~40-byte re-read per poll and re-parses to zero
+ *  events, so no duplicates can result. */
 export function drainCursorTranscript(path: string, fromOffset: number): CursorDrainResult {
   if (!existsSync(path)) return { events: [], newOffset: fromOffset, pendingTail: '' };
   let size: number;
@@ -249,7 +269,9 @@ export function drainCursorTranscript(path: string, fromOffset: number): CursorD
   // Cursor's mirror can briefly disappear / shrink while it rewrites. Do not
   // reset to 0 here: replaying the full history pollutes attribution state and
   // can wedge a live turn behind old events. Wait for the mirror to grow past
-  // the last consumed byte instead.
+  // the last consumed byte instead. (The footer rewind above keeps the
+  // committed offset at the truncation point, so the equal-size no-op window
+  // during a footer-truncate is expected and harmless.)
   if (size < start) return { events: [], newOffset: fromOffset, pendingTail: '' };
   if (size === start) return { events: [], newOffset: start, pendingTail: '' };
 
@@ -264,8 +286,12 @@ export function drainCursorTranscript(path: string, fromOffset: number): CursorD
   let newOffset = start + Buffer.byteLength(completeText, 'utf8');
 
   const events: CodexBridgeEvent[] = [];
+  // Byte start of the current TRAILING run of parsed status/footer lines.
+  // Reset by any message line or unparseable fragment; blank lines don't
+  // break the run. When set after the scan, newOffset rewinds to it.
+  let trailingFooterStart: number | undefined;
   // Track byte offset within the file so synthetic uuids are stable across
-  // re-drains (the transcript is append-only).
+  // re-drains (message lines are append-only; only the footer moves).
   let cursor = start;
   for (const line of completeText.split('\n')) {
     if (line.length === 0) {
@@ -276,7 +302,15 @@ export function drainCursorTranscript(path: string, fromOffset: number): CursorD
     const lineStart = cursor;
     cursor += lineByteLen;
     let obj: any;
-    try { obj = JSON.parse(line); } catch { continue; }
+    try { obj = JSON.parse(line); } catch {
+      trailingFooterStart = undefined;
+      continue;
+    }
+    if (isStatusFooterObject(obj)) {
+      trailingFooterStart ??= lineStart;
+      continue;
+    }
+    trailingFooterStart = undefined;
     // No per-event timestamp in Cursor's JSONL — stamp with the drain
     // wall-clock. Combined with byte-offset baselining at attach, this keeps
     // the CodexBridgeQueue freshness gates happy without a real timestamp.
@@ -287,18 +321,91 @@ export function drainCursorTranscript(path: string, fromOffset: number): CursorD
 
   // Cursor frequently leaves the final JSON object at EOF without a trailing
   // newline until the next turn mutates the mirror. If the tail is already a
-  // complete JSON object, consume it now; otherwise keep it pending.
+  // complete JSON object, consume it now (message) or hold the offset before
+  // it (status footer); otherwise keep it pending.
   if (pendingTail.length > 0) {
     try {
       const lineStart = newOffset;
       const obj = JSON.parse(pendingTail);
-      const ev = eventFromLine(path, lineStart, obj, Date.now());
-      if (ev) events.push(ev);
-      newOffset = size;
+      if (isStatusFooterObject(obj)) {
+        trailingFooterStart ??= lineStart;
+      } else {
+        trailingFooterStart = undefined;
+        const ev = eventFromLine(path, lineStart, obj, Date.now());
+        if (ev) events.push(ev);
+        newOffset = size;
+      }
       pendingTail = '';
     } catch {
       // Still being written.
     }
   }
+  if (trailingFooterStart !== undefined) {
+    newOffset = trailingFooterStart;
+    pendingTail = '';
+  }
   return { events, newOffset, pendingTail };
+}
+
+const BASELINE_FOOTER_PROBE_BYTES = 64 * 1024;
+
+/** Baseline offset for attaching to an EXISTING cursor transcript (resume /
+ *  restart re-attach): the byte frontier future drains should start from.
+ *  Like a plain size baseline this leaves all history (and any partial tail —
+ *  old in-flight output) behind the offset, but REWINDS before a trailing run
+ *  of status/footer lines so the next turn's footer-truncating rewrite (see
+ *  drainCursorTranscript) starts exactly at the committed offset instead of
+ *  behind it. Returns undefined when the file is missing/unreadable so the
+ *  caller can keep its existing degrade path. */
+export function cursorBaselineOffset(path: string): number | undefined {
+  let size: number;
+  try {
+    if (!existsSync(path)) return undefined;
+    size = statSync(path).size;
+  } catch { return undefined; }
+  if (size === 0) return 0;
+
+  const len = Math.min(size, BASELINE_FOOTER_PROBE_BYTES);
+  const probeStart = size - len;
+  const buf = Buffer.alloc(len);
+  let read = 0;
+  try {
+    const fd = openSync(path, 'r');
+    try { read = readSync(fd, buf, 0, len, probeStart); } finally { closeSync(fd); }
+  } catch { return undefined; }
+  const probe = buf.subarray(0, read).toString('utf8');
+
+  // Walk the probe's line layout forward, tracking the same trailing-footer
+  // run the drain uses. The first probe segment may be a mid-line fragment
+  // (probe boundary), which safely resets the run via its parse failure.
+  const lastNl = probe.lastIndexOf('\n');
+  const completeText = lastNl >= 0 ? probe.slice(0, lastNl + 1) : '';
+  const tail = lastNl >= 0 ? probe.slice(lastNl + 1) : probe;
+  let trailingFooterStart: number | undefined;
+  let cursor = probeStart;
+  for (const line of completeText.split('\n')) {
+    if (line.length === 0) { cursor += 1; continue; }
+    const lineStart = cursor;
+    cursor += Buffer.byteLength(line, 'utf8') + 1;
+    let obj: any;
+    try { obj = JSON.parse(line); } catch {
+      trailingFooterStart = undefined;
+      continue;
+    }
+    if (isStatusFooterObject(obj)) trailingFooterStart ??= lineStart;
+    else trailingFooterStart = undefined;
+  }
+  if (tail.length > 0) {
+    // A parseable status-footer tail joins the run; a message tail (old
+    // in-flight output) or a still-being-written fragment is skipped like the
+    // plain size baseline does. Tail start is derived from completeText's byte
+    // length, NOT the loop cursor — the split's trailing empty segment would
+    // otherwise inflate the cursor by one.
+    const tailStart = probeStart + Buffer.byteLength(completeText, 'utf8');
+    try {
+      if (isStatusFooterObject(JSON.parse(tail))) trailingFooterStart ??= tailStart;
+      else trailingFooterStart = undefined;
+    } catch { trailingFooterStart = undefined; }
+  }
+  return trailingFooterStart ?? size;
 }

--- a/src/services/structured-bridge-clis.ts
+++ b/src/services/structured-bridge-clis.ts
@@ -2,10 +2,12 @@
  * Single source of truth for which CliIds use the structured transcript
  * bridge (CodexBridgeQueue path in the worker).
  *
- * Split intentionally:
- *   - ALWAYS: harvested whenever the CLI is botmux-spawned (or adopted)
- *   - CURSOR: adopt-only — botmux-spawned cursor replies via `botmux send`,
- *     so the transcript bridge stays off outside adopt mode
+ * ALWAYS = harvested whenever the CLI is botmux-spawned (or adopted).
+ * Cursor was historically adopt-only (spawned cursor replied via `botmux
+ * send` with no fallback, so a send-less turn ghosted the thread); it now
+ * rides the same always-on fallback as codex — the send-marker gate in
+ * bridge-fallback-gate.ts suppresses the transcript emit when the model
+ * did send, exactly like the other structured CLIs.
  *
  * File-path resolution for JSONL-style bridges lives in
  * `resolveFileBridgePath` (same module family, worker-facing). Hermes/MTR
@@ -25,6 +27,7 @@ export const STRUCTURED_BRIDGE_ALWAYS_CLI_IDS = [
   'pi',
   'oh-my-pi',
   'grok',
+  'cursor',
 ] as const satisfies readonly CliId[];
 
 /** Adopt must forward pid/cwd/cliSessionId for these (CLIs whose worker
@@ -83,15 +86,9 @@ export function isStructuredBridgeLifecycleBlockingCli(cliId: string | undefined
   return !!cliId && LIFECYCLE_BLOCKING_SET.has(cliId);
 }
 
-/** Worker `codexBridgeFallbackActive` — cursor only when adoptMode. */
-export function isStructuredBridgeFallbackActive(
-  cliId: string | undefined,
-  adoptMode?: boolean,
-): boolean {
-  if (!cliId) return false;
-  if (ALWAYS_SET.has(cliId)) return true;
-  if (cliId === 'cursor') return adoptMode === true;
-  return false;
+/** Worker `codexBridgeFallbackActive`. */
+export function isStructuredBridgeFallbackActive(cliId: string | undefined): boolean {
+  return !!cliId && ALWAYS_SET.has(cliId);
 }
 
 /** Daemon adopt path — forward transcript bind fields. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -214,7 +214,7 @@ import {
   isStructuredBridgeFallbackActive,
   isStructuredBridgeLifecycleBlockingCli,
 } from './services/structured-bridge-clis.js';
-import { drainCursorTranscript, findCursorChatIdByPid, findCursorTranscriptByChatId, findCursorTranscriptByPid } from './services/cursor-transcript.js';
+import { cursorBaselineOffset, drainCursorTranscript, findCursorChatIdByPid, findCursorTranscriptByChatId, findCursorTranscriptByPid } from './services/cursor-transcript.js';
 import { shouldObserveCursorChatId, shouldPersistObservedCursorChatId } from './services/cursor-resume-policy.js';
 import { extractKiroSessionIdFromOutput } from './services/kiro-session.js';
 import { baselineJsonlCursor } from './services/jsonl-cursor.js';
@@ -6046,6 +6046,18 @@ function codexBridgeStartTimer(): void {
           }
         }
         codexBridgeIngest();
+        // Cursor's mirror can flush THIS turn's user line as late as the end
+        // of the first assistant step (a tool-less reply flushes the whole
+        // turn at once, at the end). While the CLI is visibly busy the head's
+        // bounded attribution lease must not lapse waiting for that flush —
+        // refresh it each tick; the 20s countdown then effectively starts
+        // when the CLI goes idle, preserving the wedge protection for a
+        // swallowed Enter. Non-adopt only: adopt keeps its historical timing
+        // (an expired adopt mark degrades to local-turn synthesis, still
+        // visible in Lark).
+        if (!isPromptReady && !lastInitConfig?.adoptMode) {
+          codexBridgeQueue.refreshUnstartedHeadAttributionLease();
+        }
         if (isPromptReady) emitReadyCodexTurns();
         return;
       }
@@ -6363,6 +6375,20 @@ function cursorBridgeAttach(path: string, mode: CursorAttachMode = 'baseline-exi
     }
   }
   codexBridgeAttach(path, mode === 'baseline-existing' ? 'baseline-existing-skip-tail' : mode);
+  if (mode === 'baseline-existing') {
+    // A transcript at rest ends with cursor's `turn_ended` status footer, and
+    // the next turn REWRITES from that footer's byte position. A plain size
+    // baseline would sit PAST it, so the next user line would start behind the
+    // committed offset and never be ingested (turn never starts, fallback
+    // ghosts). Rewind the baseline to the footer's start; the footer re-parses
+    // to zero events so nothing duplicates.
+    const rewound = cursorBaselineOffset(path);
+    if (rewound !== undefined && rewound < codexBridgeOffset) {
+      log(`Cursor bridge baseline rewound before trailing status footer: ${codexBridgeOffset} → ${rewound}`);
+      codexBridgeOffset = rewound;
+      codexBridgePendingTail = '';
+    }
+  }
 }
 
 /** Drop the current file-backed bridge attachment (watcher + path cursor).

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -214,7 +214,7 @@ import {
   isStructuredBridgeFallbackActive,
   isStructuredBridgeLifecycleBlockingCli,
 } from './services/structured-bridge-clis.js';
-import { cursorBaselineOffset, drainCursorTranscript, findCursorChatIdByPid, findCursorTranscriptByChatId, findCursorTranscriptByPid } from './services/cursor-transcript.js';
+import { drainCursorTranscript, findCursorChatIdByPid, findCursorTranscriptByChatId, findCursorTranscriptByPid, classifyCursorPendingTail, isCursorFallbackDisabled, type CursorTailClass } from './services/cursor-transcript.js';
 import { shouldObserveCursorChatId, shouldPersistObservedCursorChatId } from './services/cursor-resume-policy.js';
 import { extractKiroSessionIdFromOutput } from './services/kiro-session.js';
 import { baselineJsonlCursor } from './services/jsonl-cursor.js';
@@ -4267,6 +4267,19 @@ let codexBridgeRolloutPath: string | undefined;
 let codexBridgeOffset = 0;
 let codexBridgePendingTail = '';
 let codexBridgeBaselineDone = false;
+/** True while a cursor attach is deferred: the from-0 drain found a partial
+ *  tail too short to classify (message vs footer). The poller re-runs
+ *  cursorBridgeAttach each tick until the line grows enough to commit a
+ *  baseline. During defer, codexBridgeRolloutPath is set but
+ *  codexBridgeBaselineDone is false, so codexBridgeIngest is a no-op. */
+let cursorBaselineDeferred = false;
+/** When the defer started (for the bounded fail-safe). */
+let cursorDeferStartedAtMs: number | undefined;
+/** Set by the 30s fail-safe: the cursor transcript fallback is disabled for
+ *  this session. The CLI keeps working (input is released) but no transcript
+ *  baseline is ever committed. */
+let cursorBridgeDisabled = false;
+const CURSOR_DEFER_FAILSAFE_MS = 30_000;
 let publishedActiveRuntime: TraexRuntimeSnapshot = {};
 let activeRuntimePublished = false;
 const codexBridgeQueue = new CodexBridgeQueue();
@@ -5880,6 +5893,11 @@ function drainPathInto(path: string, fromOffset: number): { offset: number; tail
 // shared with the Claude path.
 
 function codexBridgeFallbackActive(): boolean {
+  // The 30s fail-safe disables the cursor transcript fallback for this
+  // session: not just polling, but also mark attribution — otherwise
+  // flushPending would keep piling 20s attribution heads that never get a
+  // transcript start. Other CLIs are unaffected.
+  if (isCursorFallbackDisabled(lastInitConfig?.cliId, cursorBridgeDisabled)) return false;
   // Transcript-backed CLIs whose final output can be harvested when the
   // model forgets to call `botmux send` — see
   // services/structured-bridge-clis.ts (single source of the allowlist).
@@ -6027,6 +6045,20 @@ function codexBridgeStartTimer(): void {
         return;
       }
       if (codexBridgeIsCursor()) {
+        // Fail-safe: if the baseline defer has lasted too long, disable this
+        // session's transcript fallback and release held input. The CLI keeps
+        // working (no transcript attribution) rather than wedging forever.
+        if (cursorBaselineDeferred && cursorDeferStartedAtMs !== undefined
+          && Date.now() - cursorDeferStartedAtMs > CURSOR_DEFER_FAILSAFE_MS) {
+          cursorBridgeDisabled = true;
+          cursorBaselineDeferred = false;
+          cursorDeferStartedAtMs = undefined;
+          codexBridgeDetachFile();
+          log('Cursor bridge fallback disabled (defer timeout); releasing held input');
+          void flushPending();
+          return;
+        }
+        if (cursorBridgeDisabled) return;
         // Late-attach: the transcript usually exists at adopt time (the
         // session is already running), so cursorBridgeAttach in setup wins.
         // This covers the rare race where pid→chatId resolved but the JSONL
@@ -6040,9 +6072,21 @@ function codexBridgeStartTimer(): void {
             path = findCursorTranscriptByPid(codexAdoptPendingPid)?.path;
           }
           if (path) {
+            // Only clear the pending identity once the baseline is actually
+            // committed. A deferred attach (partial tail too short to
+            // classify) keeps the sid/pid so the poller can retry below.
+            if (cursorBridgeAttach(path, cursorLateAttachMode(path)) === 'attached') {
+              codexBridgePendingSessionId = undefined;
+              codexAdoptPendingPid = undefined;
+            }
+          }
+        } else if (cursorBaselineDeferred) {
+          // Retry a deferred baseline: the from-0 drain's partial tail was
+          // too short to classify last tick. Re-drain and commit once the
+          // line grows enough. Clear the pending identity only on success.
+          if (cursorBridgeAttach(codexBridgeRolloutPath, 'baseline-existing') === 'attached') {
             codexBridgePendingSessionId = undefined;
             codexAdoptPendingPid = undefined;
-            cursorBridgeAttach(path, cursorLateAttachMode(path));
           }
         }
         codexBridgeIngest();
@@ -6338,6 +6382,7 @@ function codexBridgeAttach(rolloutPath: string, mode: 'baseline-existing' | 'bas
 }
 
 type CursorAttachMode = 'baseline-existing' | 'fresh-empty';
+type CursorAttachResult = 'attached' | 'deferred';
 
 function cursorLateAttachMode(path: string): CursorAttachMode {
   const start = codexAdoptStartMs;
@@ -6360,35 +6405,97 @@ function cursorLateAttachMode(path: string): CursorAttachMode {
 }
 
 /** Attach the Cursor adopt bridge. Cursor's JSONL has no per-event
- *  timestamp, so existing transcripts are baselined by byte offset. Cursor
- *  restore intentionally skips any partial tail present at attach time: it is
- *  old in-flight output and must not be attributed to the next Lark turn. If
- *  the transcript is created after /adopt, attach fresh so the first
- *  post-adopt Lark/user turn can still be attributed. */
-function cursorBridgeAttach(path: string, mode: CursorAttachMode = 'baseline-existing'): void {
-  if (mode === 'baseline-existing' && existsSync(path)) {
-    try {
-      const full = drainCursorTranscript(path, 0);
-      maybeEmitCodexAdoptPreamble(full.events);
-    } catch (err: any) {
-      log(`Cursor bridge preamble drain failed: ${err.message}`);
-    }
-  }
-  codexBridgeAttach(path, mode === 'baseline-existing' ? 'baseline-existing-skip-tail' : mode);
+ *  timestamp, so existing transcripts are baselined by byte offset. The
+ *  from-0 drain's frontier is footer-aware (never advances past a trailing
+ *  turn_ended footer), but a snapshot can also end mid in-flight line:
+ *
+ *  - partial MESSAGE line → old in-flight output; baseline at the snapshot
+ *    EOF (readEndOffset) to skip it, restoring the old `size` baseline.
+ *  - partial FOOTER line → hold at the footer's line start (newOffset) so
+ *    the completed footer is recognized and the next turn's rewrite is not
+ *    ghosted.
+ *  - tail too short to classify → DEFER: arm the poller but commit no
+ *    baseline; the poller re-drains each tick until the line grows enough
+ *    to classify. Guessing would reopen the stale-replay / ghost hole.
+ *
+ *  Returns 'attached' (baseline committed) or 'deferred' (caller must keep
+ *  its own sid/pid and let the poller retry). If the transcript is created
+ *  after /adopt, attach fresh so the first post-adopt Lark/user turn can
+ *  still be attributed. */
+function cursorBridgeAttach(path: string, mode: CursorAttachMode = 'baseline-existing'): CursorAttachResult {
+  // The fail-safe disabled this session's fallback — don't retry.
+  if (cursorBridgeDisabled) return 'deferred';
+  let drainFrontier: number | undefined;
+  let tailClass: CursorTailClass | 'none' = 'none';
+  let snapshotOk = true;
   if (mode === 'baseline-existing') {
-    // A transcript at rest ends with cursor's `turn_ended` status footer, and
-    // the next turn REWRITES from that footer's byte position. A plain size
-    // baseline would sit PAST it, so the next user line would start behind the
-    // committed offset and never be ingested (turn never starts, fallback
-    // ghosts). Rewind the baseline to the footer's start; the footer re-parses
-    // to zero events so nothing duplicates.
-    const rewound = cursorBaselineOffset(path);
-    if (rewound !== undefined && rewound < codexBridgeOffset) {
-      log(`Cursor bridge baseline rewound before trailing status footer: ${codexBridgeOffset} → ${rewound}`);
-      codexBridgeOffset = rewound;
-      codexBridgePendingTail = '';
+    if (!existsSync(path)) {
+      // File missing: can't establish a baseline. Defer — do NOT enter the
+      // generic missing→fresh branch (that would read old history as live
+      // when the mirror reappears, causing stale misattribution).
+      snapshotOk = false;
+    } else {
+      try {
+        const full = drainCursorTranscript(path, 0);
+        if (!full.snapshotComplete) {
+          // Short read / I/O failure: partial snapshot. The events may be
+          // valid but the frontier is unreliable — defer, don't feed
+          // preamble or commit a baseline.
+          snapshotOk = false;
+        } else {
+          maybeEmitCodexAdoptPreamble(full.events);
+          if (full.pendingTail.length > 0) {
+            tailClass = classifyCursorPendingTail(full.pendingTail);
+            if (tailClass === 'message') {
+              // Old in-flight message line: skip it (baseline at snapshot EOF).
+              drainFrontier = full.readEndOffset;
+            } else {
+              // 'footer': hold at the footer's line start so the completed
+              // footer is recognized and held. 'defer' is handled below.
+              drainFrontier = full.newOffset;
+            }
+          } else {
+            // No partial tail: footer-aware frontier (≤ size in every state).
+            drainFrontier = full.newOffset;
+          }
+        }
+      } catch (err: any) {
+        log(`Cursor bridge preamble drain failed: ${err.message}`);
+        snapshotOk = false;
+      }
     }
   }
+  if (!snapshotOk || tailClass === 'defer') {
+    // The snapshot is unusable (missing / short read / I/O failure) or the
+    // partial tail is too short to classify. Arm the poller but commit no
+    // baseline; the poller re-runs this attach each tick until a complete
+    // snapshot classifies. The caller keeps its own sid/pid (it only clears
+    // them on 'attached'), so a path re-resolution stays possible.
+    cursorBaselineDeferred = true;
+    cursorDeferStartedAtMs ??= Date.now();
+    codexBridgeRolloutPath = path;
+    codexBridgeStartTimer();
+    log(`Cursor bridge baseline deferred: ${path} (snapshotOk=${snapshotOk}, tail=${tailClass})`);
+    return 'deferred';
+  }
+  // Successfully attached: clear defer state and re-kick held input (same
+  // live backend — safe to write now that the baseline is committed).
+  const wasDeferred = cursorBaselineDeferred;
+  cursorBaselineDeferred = false;
+  cursorDeferStartedAtMs = undefined;
+  codexBridgeAttach(path, mode === 'baseline-existing' ? 'baseline-existing-skip-tail' : mode);
+  if (mode === 'baseline-existing' && drainFrontier !== undefined) {
+    // Commit the drain's frontier unconditionally: it is the safe frontier
+    // (≤ the skip-tail size in every reachable state), so this is a no-op
+    // when there is no trailing footer / partial line and a rewind otherwise.
+    if (drainFrontier < codexBridgeOffset) {
+      log(`Cursor bridge baseline rewound before trailing status footer: ${codexBridgeOffset} → ${drainFrontier}`);
+    }
+    codexBridgeOffset = drainFrontier;
+    codexBridgePendingTail = '';
+  }
+  if (wasDeferred) void flushPending();
+  return 'attached';
 }
 
 /** Drop the current file-backed bridge attachment (watcher + path cursor).
@@ -6406,6 +6513,11 @@ function codexBridgeDetachFile(): void {
   ompBridgeState = {};
   ompQuietCandidateKey = undefined;
   ompQuietCandidateCompleteOffset = undefined;
+  // Clear cursor defer state. Do NOT re-kick flushPending here: a rotation
+  // detach's held input is released by the NEXT attach's success re-kick,
+  // not during the gap (writing mid-rotation could land in the wrong file).
+  cursorBaselineDeferred = false;
+  cursorDeferStartedAtMs = undefined;
 }
 
 /** Resolve the pid of the Codex process this worker observes (spawned child or
@@ -6638,8 +6750,11 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
     // agent-transcript JSONL, so it resolves the path directly.
     const cursorPath = resolveFileBridgePath('cursor', { sessionId: cliSessionId });
     if (cursorPath) {
-      codexBridgePendingSessionId = undefined;
-      cursorBridgeAttach(cursorPath, cursorLateAttachMode(cursorPath));
+      // Clear the pending sid only once the baseline is committed; a deferred
+      // attach keeps it so the poller can retry.
+      if (cursorBridgeAttach(cursorPath, cursorLateAttachMode(cursorPath)) === 'attached') {
+        codexBridgePendingSessionId = undefined;
+      }
     } else {
       codexBridgePendingSessionId = cliSessionId;
       codexBridgeStartTimer();
@@ -7456,6 +7571,12 @@ function stopCodexBridge(): void {
   codexBridgePendingSessionId = undefined;
   codexAdoptPendingPid = undefined;
   codexAdoptStartMs = undefined;
+  // Clear cursor defer state. Do NOT re-kick flushPending: teardown means
+  // the old backend is exiting; held input is taken over by the new
+  // generation's ready/init lifecycle, not written to the dying CLI.
+  cursorBaselineDeferred = false;
+  cursorDeferStartedAtMs = undefined;
+  cursorBridgeDisabled = false;
   grokBridgePidProbeLastMs = 0;
 }
 
@@ -10880,6 +11001,13 @@ async function flushPending(): Promise<void> {
   // old CLI. Never let a new flush (including one triggered by the old
   // backend's idle/task-done callback) write across that restart boundary.
   if (cliRestartInProgress) return;
+  // During a cursor baseline defer, hold ALL botmux-controlled PTY input:
+  // the transcript baseline isn't committed yet, so sending input now could
+  // be ghosted (the live turn's events would be swallowed by the baseline
+  // when it commits). The gate is cursor-only — non-cursor CLIs and cursor's
+  // normal attached rounds flush as usual. Released by cursorBridgeAttach
+  // (success) or the 30s fail-safe.
+  if (codexBridgeIsCursor() && cursorBaselineDeferred) return;
   if (initialInputOwnershipPending) return;
   if (shouldHoldCodexRunnerInput(codexRunnerFreshness)) return;
   if (isFlushing) return;  // while loop in active flush will pick up new messages
@@ -12099,7 +12227,12 @@ function setupAdoptTranscriptBridges(cfg: Extract<DaemonToWorker, { type: 'init'
       if (probed) path = probed.path;
     }
     if (path) {
-      cursorBridgeAttach(path);
+      // On defer, stash the adopt identity so the poller can re-resolve /
+      // retry; cursorBridgeAttach already armed the timer.
+      if (cursorBridgeAttach(path) === 'deferred') {
+        if (cfg.cliSessionId) codexBridgePendingSessionId = cfg.cliSessionId;
+        codexAdoptPendingPid = cfg.adoptCliPid;
+      }
     } else {
       if (cfg.cliSessionId) codexBridgePendingSessionId = cfg.cliSessionId;
       codexAdoptPendingPid = cfg.adoptCliPid;
@@ -15500,7 +15633,11 @@ async function spawnCli(
       ? resolveFileBridgePath('cursor', { sessionId: effectiveCliSessionId })
       : undefined;
     if (path) {
-      cursorBridgeAttach(path, effectiveResume ? 'baseline-existing' : 'fresh-empty');
+      // On defer (resume only — fresh-empty has no from-0 drain), stash the
+      // chatId so the poller can re-resolve / retry.
+      if (cursorBridgeAttach(path, effectiveResume ? 'baseline-existing' : 'fresh-empty') === 'deferred') {
+        if (effectiveCliSessionId) codexBridgePendingSessionId = effectiveCliSessionId;
+      }
     } else {
       if (effectiveCliSessionId) codexBridgePendingSessionId = effectiveCliSessionId;
       codexBridgeStartTimer();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5881,9 +5881,9 @@ function drainPathInto(path: string, fromOffset: number): { offset: number; tail
 
 function codexBridgeFallbackActive(): boolean {
   // Transcript-backed CLIs whose final output can be harvested when the
-  // model forgets to call `botmux send`. Cursor is adopt-only — see
+  // model forgets to call `botmux send` — see
   // services/structured-bridge-clis.ts (single source of the allowlist).
-  return isStructuredBridgeFallbackActive(lastInitConfig?.cliId, lastInitConfig?.adoptMode === true);
+  return isStructuredBridgeFallbackActive(lastInitConfig?.cliId);
 }
 
 /** A Codex App shared-adopt starts a SECOND official `codex --remote` client
@@ -6337,8 +6337,14 @@ function cursorLateAttachMode(path: string): CursorAttachMode {
       // be ingested from byte 0 rather than swallowed as history.
       if (Number.isFinite(birthtimeMs) && birthtimeMs >= start - 5_000) return 'fresh-empty';
     } catch { /* fall back to history-safe baseline */ }
+    return 'baseline-existing';
   }
-  return 'baseline-existing';
+  // Non-adopt (botmux-spawned): a FRESH spawn's chatId is a brand-new UUID,
+  // so its JSONL can only contain THIS session's lines — always ingest from
+  // byte 0, even when the file appears (with the first turn already inside)
+  // before the poller attaches. A RESUME spawn's JSONL carries the prior
+  // run's history and must be baselined behind the tail.
+  return lastSpawnEffectiveResume ? 'baseline-existing' : 'fresh-empty';
 }
 
 /** Attach the Cursor adopt bridge. Cursor's JSONL has no per-event
@@ -10509,6 +10515,11 @@ function observeCursorCliSessionId(pid: number, label = 'spawn'): void {
       }
       persistCliSessionId(chatId);
       log(`Observed Cursor chatId via pid ${realPid}${realPid === pid ? '' : ` (launcher ${pid})`} (${label}): ${chatId}`);
+      // The chatId also names the agent-transcript JSONL — hand it to the
+      // structured bridge so a `botmux send`-less turn can be harvested.
+      // Safe when already attached (first-attach-wins) and when the JSONL
+      // doesn't exist yet (arms the 1s late-attach poller).
+      codexBridgeNotifyCliSessionId(chatId);
       return;
     }
     attempts++;
@@ -15448,6 +15459,24 @@ async function spawnCli(
       codexBridgePendingSessionId = sid;
       codexBridgeStartTimer();
     } else {
+      codexBridgeStartTimer();
+    }
+  } else if (cfg.cliId === 'cursor') {
+    // Cursor's chatId (= cliSessionId) is only discoverable from the CLI's
+    // open store.db fd, so a FRESH spawn has no id yet at this point —
+    // observeCursorCliSessionId's pid poll surfaces it and
+    // codexBridgeNotifyCliSessionId completes the attach. A RESUME spawn
+    // knows the chatId up front and can resolve the JSONL immediately (it
+    // persists from the prior run). Attach modes: resume → baseline behind
+    // the existing tail (history must not replay); fresh → ingest from byte
+    // 0 (the JSONL is chatId-scoped, so it can only hold this session).
+    const path = effectiveCliSessionId
+      ? resolveFileBridgePath('cursor', { sessionId: effectiveCliSessionId })
+      : undefined;
+    if (path) {
+      cursorBridgeAttach(path, effectiveResume ? 'baseline-existing' : 'fresh-empty');
+    } else {
+      if (effectiveCliSessionId) codexBridgePendingSessionId = effectiveCliSessionId;
       codexBridgeStartTimer();
     }
   }

--- a/test/codex-bridge-queue.test.ts
+++ b/test/codex-bridge-queue.test.ts
@@ -439,6 +439,62 @@ describe('CodexBridgeQueue', () => {
     ]);
   });
 
+  it('busy-tick lease refresh keeps a slow-flushing mirror turn alive, then resumes expiry at idle', () => {
+    let now = 0;
+    const q = new CodexBridgeQueue(() => now);
+
+    // Cursor mirror shape: writeInput returns undefined (attribution-only
+    // lease), and the transcript flushes the user line only when the first
+    // assistant step / whole turn completes — potentially far beyond the
+    // bare 20s lease. The worker refreshes the lease every tick while the
+    // CLI is visibly busy.
+    q.mark('slow-mirror', 'prompt whose jsonl line flushes late', now);
+    q.beginSubmitVerification('slow-mirror', now);
+    q.finishSubmitVerification('slow-mirror', now);
+
+    // 90s of busy ticks: without refresh this head would expire at 20s.
+    for (now = 1_000; now <= 90_000; now += 1_000) {
+      expect(q.refreshUnstartedHeadAttributionLease()).toBe(true);
+      expect(q.pruneExpiredPreStartHeads()).toEqual([]);
+    }
+
+    // Turn end: the mirror flushes user + final together; the head still
+    // matches and the turn completes normally.
+    q.ingest([
+      userEv('prompt whose jsonl line flushes late', 'u-slow-mirror', 90_500),
+      asstEv('late-flushed answer', 'a-slow-mirror', 90_501),
+    ]);
+    expect(q.drainEmittable()).toEqual([
+      expect.objectContaining({ turnId: 'slow-mirror', finalText: 'late-flushed answer' }),
+    ]);
+
+    // A swallowed Enter still expires: once refreshes stop (CLI idle), the
+    // bounded lease resumes counting down from the last refresh.
+    q.mark('swallowed', 'enter never landed', now);
+    q.beginSubmitVerification('swallowed', now);
+    q.finishSubmitVerification('swallowed', now);
+    q.refreshUnstartedHeadAttributionLease();
+    const lastRefresh = now;
+    now = lastRefresh + STRUCTURED_UNCONFIRMED_ATTRIBUTION_GRACE_MS + 1;
+    expect(q.pruneExpiredPreStartHeads().map(turn => turn.turnId)).toEqual(['swallowed']);
+  });
+
+  it('lease refresh leaves started, confirmed, and rpc-active turns alone', () => {
+    let now = 0;
+    const q = new CodexBridgeQueue(() => now);
+    expect(q.refreshUnstartedHeadAttributionLease()).toBe(false);
+
+    q.mark('started', 'already running prompt', now);
+    q.ingest([userEv('already running prompt', 'u-refresh-started', 1)]);
+    expect(q.refreshUnstartedHeadAttributionLease()).toBe(false);
+    q.ingest([asstEv('done', 'a-refresh-started', 2)]);
+    q.drainEmittable();
+
+    q.mark('confirmed', 'confirmed submit', now);
+    q.confirmPendingTurn('confirmed', now);
+    expect(q.refreshUnstartedHeadAttributionLease()).toBe(false);
+  });
+
   it('expires consecutive confirmed stale heads until a buffered live turn can start', () => {
     let now = 19_000;
     const q = new CodexBridgeQueue(() => now);

--- a/test/cursor-attach-defer-wiring.test.ts
+++ b/test/cursor-attach-defer-wiring.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Source-level wiring assertions for the cursor attach defer state machine.
+// The defer logic (classify → select baseline, short-read snapshotComplete)
+// is unit-tested in cursor-transcript.test.ts; these tests pin the WORKER
+// wiring: the 5 call sites must only clear their pending identity on
+// 'attached' (never on 'deferred'), the poller must retry a deferred
+// baseline, flushPending must hold input during defer, the 30s fail-safe
+// must disable + release, and teardown must clear state WITHOUT re-kicking
+// (the exit matrix). Source-level because cursorBridgeAttach touches
+// module-level bridge state that is impractical to spin up in a unit test.
+// Behavioral coverage (write=0 during defer, one prompt once after attach)
+// is provided by the drain-level tests + live verification.
+
+const source = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+
+function functionSlice(name: string, nextName: string): string {
+  const start = source.indexOf(`function ${name}`);
+  const end = source.indexOf(`function ${nextName}`, start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('cursor attach defer wiring', () => {
+  it('cursorBridgeAttach returns attached|deferred, defers on !snapshotComplete, and re-kicks on success', () => {
+    const body = functionSlice('cursorBridgeAttach', 'codexBridgeDetachFile');
+    expect(body).toContain("CursorAttachResult");
+    expect(body).toContain("'attached'");
+    expect(body).toContain("'deferred'");
+    // Fail-safe disabled → don't retry.
+    expect(body).toContain('cursorBridgeDisabled');
+    // snapshotComplete gate: a short read / missing file defers.
+    expect(body).toContain('snapshotOk');
+    expect(body).toContain('!full.snapshotComplete');
+    expect(body).toContain('!existsSync(path)');
+    // The defer branch arms the poller but commits no baseline.
+    expect(body).toContain('cursorBaselineDeferred = true');
+    expect(body).toContain('cursorDeferStartedAtMs ??= Date.now()');
+    expect(body).toContain('codexBridgeStartTimer()');
+    expect(body).toContain("return 'deferred'");
+    // The commit branch clears the flag and returns attached.
+    expect(body).toContain('cursorBaselineDeferred = false');
+    expect(body).toContain('cursorDeferStartedAtMs = undefined');
+    expect(body).toContain("return 'attached'");
+    // Re-kick held input after a successful attach (same live backend).
+    expect(body).toContain('if (wasDeferred) void flushPending()');
+  });
+
+  it('flushPending holds ALL botmux-controlled PTY input during cursor defer', () => {
+    // Use the exact signature to avoid matching flushPendingInjections.
+    const start = source.indexOf('async function flushPending(): Promise<void> {');
+    const end = source.indexOf('function sendToPty(', start + 1);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const body = source.slice(start, end);
+    // The gate must be cursor-only (not just the flag) and before any
+    // shift/mark/write — it sits among the early-return guards.
+    expect(body).toContain('codexBridgeIsCursor() && cursorBaselineDeferred');
+    // The gate must appear BEFORE the first write/shift.
+    const gateIdx = body.indexOf('codexBridgeIsCursor() && cursorBaselineDeferred');
+    const writeIdx = body.search(/backend\.(write|sendInput|writeInput)/);
+    expect(gateIdx).toBeGreaterThanOrEqual(0);
+    if (writeIdx >= 0) expect(gateIdx).toBeLessThan(writeIdx);
+  });
+
+  it('poller has a 30s fail-safe that disables the fallback and releases input', () => {
+    const pollerCursor = source.slice(
+      source.indexOf('if (codexBridgeIsCursor()) {', source.indexOf('codexBridgeStartTimer')),
+      source.indexOf('codexBridgeIngest()', source.indexOf('cursorBaselineDeferred')),
+    );
+    // Fail-safe: timeout check.
+    expect(pollerCursor).toContain('CURSOR_DEFER_FAILSAFE_MS');
+    expect(pollerCursor).toContain('cursorDeferStartedAtMs');
+    // On timeout: disable + clear + detach + re-kick.
+    expect(pollerCursor).toContain('cursorBridgeDisabled = true');
+    expect(pollerCursor).toContain('cursorBaselineDeferred = false');
+    expect(pollerCursor).toContain('codexBridgeDetachFile()');
+    expect(pollerCursor).toContain('void flushPending()');
+    // Disabled → skip the cursor branch entirely.
+    expect(pollerCursor).toContain('if (cursorBridgeDisabled) return');
+  });
+
+  it('codexBridgeDetachFile clears defer state WITHOUT re-kicking (rotation exit)', () => {
+    const body = functionSlice('codexBridgeDetachFile', 'currentCodexObservedPid');
+    expect(body).toContain('cursorBaselineDeferred = false');
+    expect(body).toContain('cursorDeferStartedAtMs = undefined');
+    // Rotation detach must NOT re-kick — the new attach re-kicks on success.
+    expect(body).not.toContain('void flushPending()');
+  });
+
+  it('stopCodexBridge clears defer state WITHOUT re-kicking (teardown exit)', () => {
+    const body = functionSlice('stopCodexBridge', 'retainSecondaryPathIfStillReferenced');
+    expect(body).toContain('cursorBaselineDeferred = false');
+    expect(body).toContain('cursorDeferStartedAtMs = undefined');
+    expect(body).toContain('cursorBridgeDisabled = false');
+    // Teardown must NOT re-kick — held input is taken over by the new
+    // generation's ready/init lifecycle, not written to the dying CLI.
+    expect(body).not.toContain('void flushPending()');
+  });
+
+  it('all 5 cursorBridgeAttach call sites gate pending-clear on the return value', () => {
+    // Every cursorBridgeAttach call must inspect its return value so a
+    // deferred attach never clears the caller's pending sid/pid.
+    const callIndices: number[] = [];
+    let idx = source.indexOf('cursorBridgeAttach(');
+    while (idx !== -1) {
+      // Skip the function definition itself.
+      if (!source.slice(idx - 9, idx).includes('function ')) {
+        callIndices.push(idx);
+      }
+      idx = source.indexOf('cursorBridgeAttach(', idx + 1);
+    }
+    // 5 call sites: timer late-attach, poller defer retry, notify, adopt
+    // direct, spawnCli. All must inspect the return value.
+    expect(callIndices.length).toBe(5);
+    for (const i of callIndices) {
+      // Within 200 chars after the call, there must be a return-value check
+      // ('attached' or 'deferred') — the caller inspects the result.
+      const after = source.slice(i, i + 200);
+      expect(after).toMatch(/=== '(attached|deferred)'/);
+    }
+  });
+
+  it('fail-safe truly disables fallback mark (not just polling)', () => {
+    // codexBridgeFallbackActive must check cursorBridgeDisabled, so after
+    // the 30s fail-safe the mark path (codexBridgeMarkPendingTurn) is also
+    // skipped — not just the poller ingest. Otherwise disabled sessions
+    // would pile up 20s attribution heads with no transcript start.
+    const fallbackFn = functionSlice('codexBridgeFallbackActive', 'hasStructuredLifecycleBlock');
+    expect(fallbackFn).toContain('isCursorFallbackDisabled');
+    expect(fallbackFn).toContain('cursorBridgeDisabled');
+    // The mark path in flushPending is gated by codexBridgeActive, which is
+    // assigned from codexBridgeFallbackActive().
+    const flushStart = source.indexOf('async function flushPending(): Promise<void> {');
+    const flushEnd = source.indexOf('function sendToPty(', flushStart + 1);
+    const flushBody = source.slice(flushStart, flushEnd);
+    expect(flushBody).toContain('const codexBridgeActive = codexBridgeFallbackActive()');
+    // The mark call must be inside the codexBridgeActive gate.
+    const markIdx = flushBody.indexOf('codexBridgeMarkPendingTurn');
+    const activeIdx = flushBody.indexOf('codexBridgeActive');
+    expect(markIdx).toBeGreaterThan(activeIdx);
+  });
+});

--- a/test/cursor-transcript.test.ts
+++ b/test/cursor-transcript.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync, mkdirSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  cursorBaselineOffset,
   drainCursorTranscript,
   cursorChatIdFromStoreDbPath,
   findCursorTranscriptByChatId,
@@ -247,5 +248,107 @@ describe('drainCursorTranscript', () => {
     const r2 = drainCursorTranscript(path, r1.newOffset);
     expect(r2.events).toEqual([]);
     expect(r2.newOffset).toBe(r1.newOffset);
+  });
+
+  const turnEnded = { type: 'turn_ended', status: 'success' };
+
+  it('never advances the offset past a trailing turn_ended status footer', () => {
+    const messages = line(userMsg('first')) + line(assistantFinal('reply'));
+    writeFileSync(path, messages + line(turnEnded));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events.map(e => e.kind)).toEqual(['user', 'assistant_final']);
+    expect(r.newOffset).toBe(Buffer.byteLength(messages, 'utf8'));
+    // Re-drain from the held-back offset: the footer re-parses to zero events
+    // and the offset stays put — no duplicates, no progress.
+    const again = drainCursorTranscript(path, r.newOffset);
+    expect(again.events).toEqual([]);
+    expect(again.newOffset).toBe(r.newOffset);
+  });
+
+  it('holds the offset before a footer left at EOF without a trailing newline', () => {
+    const messages = line(userMsg('first')) + line(assistantFinal('reply'));
+    writeFileSync(path, messages + JSON.stringify(turnEnded));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events.map(e => e.kind)).toEqual(['user', 'assistant_final']);
+    expect(r.newOffset).toBe(Buffer.byteLength(messages, 'utf8'));
+    expect(r.pendingTail).toBe('');
+  });
+
+  it('survives cursor\'s footer-truncating rewrite between turns (live regression)', () => {
+    // Turn 1 at rest: messages + turn_ended footer. Cursor's NEXT turn
+    // truncates the footer and writes the new user/assistant lines starting
+    // at the footer's old byte position, re-appending the footer at EOF.
+    // A drain that had consumed the footer would commit an offset INSIDE the
+    // next turn's user line and permanently miss its user event — observed
+    // live on cursor-agent 2026.08.11 (spawned session, turn 2 ghosted).
+    const turn1 = line(userMsg('turn one prompt')) + line(assistantFinal('turn one answer'));
+    writeFileSync(path, turn1 + line(turnEnded));
+    const r1 = drainCursorTranscript(path, 0);
+    expect(r1.events).toHaveLength(2);
+
+    const turn2 = line(userMsg('turn two prompt')) + line(assistantFinal('turn two answer'));
+    writeFileSync(path, turn1 + turn2 + line(turnEnded));
+    const r2 = drainCursorTranscript(path, r1.newOffset);
+    expect(r2.events.map(e => ({ kind: e.kind, text: e.text }))).toEqual([
+      { kind: 'user', text: 'turn two prompt' },
+      { kind: 'assistant_final', text: 'turn two answer' },
+    ]);
+  });
+
+  it('rewinds through a run of consecutive trailing status lines', () => {
+    const messages = line(userMsg('first')) + line(assistantFinal('reply'));
+    writeFileSync(path, messages + line(turnEnded) + line({ type: 'other_status' }));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.newOffset).toBe(Buffer.byteLength(messages, 'utf8'));
+  });
+
+  it('a status line followed by message lines is consumed normally', () => {
+    writeFileSync(path,
+      line(turnEnded) + line(userMsg('after footer')) + line(assistantFinal('answer')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events.map(e => e.kind)).toEqual(['user', 'assistant_final']);
+    expect(r.newOffset).toBe(statSync(path).size);
+  });
+});
+
+describe('cursorBaselineOffset', () => {
+  const turnEnded = { type: 'turn_ended', status: 'success' };
+
+  it('returns undefined for a missing file', () => {
+    expect(cursorBaselineOffset(join(dir, 'nope.jsonl'))).toBeUndefined();
+  });
+
+  it('baselines to file size when the transcript ends with a message line', () => {
+    writeFileSync(path, line(userMsg('first')) + line(assistantFinal('reply')));
+    expect(cursorBaselineOffset(path)).toBe(statSync(path).size);
+  });
+
+  it('rewinds before a trailing turn_ended footer (with and without newline)', () => {
+    const messages = line(userMsg('first')) + line(assistantFinal('reply'));
+    writeFileSync(path, messages + line(turnEnded));
+    expect(cursorBaselineOffset(path)).toBe(Buffer.byteLength(messages, 'utf8'));
+    writeFileSync(path, messages + JSON.stringify(turnEnded));
+    expect(cursorBaselineOffset(path)).toBe(Buffer.byteLength(messages, 'utf8'));
+  });
+
+  it('skips a partial message tail like a plain size baseline (old in-flight output)', () => {
+    writeFileSync(path, line(userMsg('first')) + '{"role":"assistant","message":{"content"');
+    expect(cursorBaselineOffset(path)).toBe(statSync(path).size);
+  });
+
+  it('resume flow: baseline then footer-truncating rewrite still yields the next turn', () => {
+    const turn1 = line(userMsg('old prompt')) + line(assistantFinal('old answer'));
+    writeFileSync(path, turn1 + line(turnEnded));
+    const baseline = cursorBaselineOffset(path)!;
+    // History stays behind the baseline...
+    expect(drainCursorTranscript(path, baseline).events).toEqual([]);
+    // ...and the next turn's rewrite from the footer position is fully seen.
+    const turn2 = line(userMsg('new prompt')) + line(assistantFinal('new answer'));
+    writeFileSync(path, turn1 + turn2 + line(turnEnded));
+    const r = drainCursorTranscript(path, baseline);
+    expect(r.events.map(e => ({ kind: e.kind, text: e.text }))).toEqual([
+      { kind: 'user', text: 'new prompt' },
+      { kind: 'assistant_final', text: 'new answer' },
+    ]);
   });
 });

--- a/test/cursor-transcript.test.ts
+++ b/test/cursor-transcript.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync, mkdirSync, unlinkSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync, mkdirSync, unlinkSync, truncateSync, readSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  cursorBaselineOffset,
   drainCursorTranscript,
   cursorChatIdFromStoreDbPath,
   findCursorTranscriptByChatId,
+  classifyCursorPendingTail,
+  isCursorFallbackDisabled,
+  type CursorDrainDeps,
 } from '../src/services/cursor-transcript.js';
+import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
 
 let dir: string;
 let path: string;
@@ -311,44 +314,420 @@ describe('drainCursorTranscript', () => {
   });
 });
 
-describe('cursorBaselineOffset', () => {
+// Regression: the resume/reattach baseline reuses drainCursorTranscript(path,
+// 0).newOffset as the safe frontier (cursorBridgeAttach). A >64KiB multibyte
+// transcript must still rewind that frontier exactly to the footer start — a
+// tail-window probe that decoded mid-char would drift the byte arithmetic past
+// it and ghost the next turn's user event. The drain reads from byte 0 (a char
+// boundary), so it has no window; this locks in that the frontier stays exact
+// at scale for CJK (3-byte) and emoji (4-byte) content.
+describe('drainCursorTranscript >64KiB multibyte frontier', () => {
   const turnEnded = { type: 'turn_ended', status: 'success' };
 
-  it('returns undefined for a missing file', () => {
-    expect(cursorBaselineOffset(join(dir, 'nope.jsonl'))).toBeUndefined();
+  for (const [label, ch] of [['CJK', '量'], ['emoji', '😀']] as const) {
+    it(`${label}: frontier holds at the footer start and the next turn survives a footer-truncating rewrite`, () => {
+      const giant = line(userMsg(ch.repeat(30000)));
+      writeFileSync(path, giant + line(turnEnded));
+      expect(statSync(path).size).toBeGreaterThan(65536);
+      const frontier = drainCursorTranscript(path, 0).newOffset;
+      expect(frontier).toBe(Buffer.byteLength(giant, 'utf8'));
+      // Resume: the next turn truncates the footer and rewrites from its byte
+      // position. The drain from the committed frontier must see BOTH events.
+      const turn2 = line(userMsg('resume 后还能归因吗？')) + line(assistantFinal('能。'));
+      writeFileSync(path, giant + turn2 + line(turnEnded));
+      const r = drainCursorTranscript(path, frontier);
+      expect(r.events.map(e => e.kind)).toEqual(['user', 'assistant_final']);
+    });
+  }
+});
+
+// ── Option 3: three-way pending-tail classification ──────────────────────
+// The attach baseline depends on what the partial tail IS: a message tail is
+// skipped (readEndOffset), a footer tail is held (newOffset), and a tail too
+// short to classify defers the attach. The classifier is a conservative
+// prefix matcher — only a COMPLETE known discriminator classifies; anything
+// else defers (wait a tick rather than guess, because cursor's internal schema
+// is not promised stable and a wrong guess reopens the stale-replay / ghost
+// hole).
+describe('classifyCursorPendingTail', () => {
+  it('classifies a complete role discriminator as message', () => {
+    expect(classifyCursorPendingTail('{"role":"user"')).toBe('message');
+    expect(classifyCursorPendingTail('{"role":"assistant"')).toBe('message');
+    expect(classifyCursorPendingTail('{"role":"user","message":{"content"')).toBe('message');
+    expect(classifyCursorPendingTail('{"role":"assistant","message"')).toBe('message');
   });
 
-  it('baselines to file size when the transcript ends with a message line', () => {
+  it('classifies a complete turn_ended discriminator as footer', () => {
+    expect(classifyCursorPendingTail('{"type":"turn_ended"')).toBe('footer');
+    expect(classifyCursorPendingTail('{"type":"turn_ended","status":"success"')).toBe('footer');
+  });
+
+  it('defers on a half-written discriminator value', () => {
+    expect(classifyCursorPendingTail('{"role":"use')).toBe('defer');
+    expect(classifyCursorPendingTail('{"role":"assistan')).toBe('defer');
+    expect(classifyCursorPendingTail('{"type":"turn_')).toBe('defer');
+    expect(classifyCursorPendingTail('{"type":"turn_ended"')).toBe('footer'); // complete → footer
+  });
+
+  it('defers on an unknown type value (schema not promised stable)', () => {
+    expect(classifyCursorPendingTail('{"type":"unknown"')).toBe('defer');
+    expect(classifyCursorPendingTail('{"type":"message"')).toBe('defer');
+    expect(classifyCursorPendingTail('{"type":"turn_started"')).toBe('defer');
+  });
+
+  it('defers on too-short prefixes (cannot see the full discriminator)', () => {
+    expect(classifyCursorPendingTail('')).toBe('defer');
+    expect(classifyCursorPendingTail('{')).toBe('defer');
+    expect(classifyCursorPendingTail('{"')).toBe('defer');
+    expect(classifyCursorPendingTail('{"r')).toBe('defer');
+    expect(classifyCursorPendingTail('{"t')).toBe('defer');
+    expect(classifyCursorPendingTail('{"role')).toBe('defer');
+    expect(classifyCursorPendingTail('{"role":')).toBe('defer');
+    expect(classifyCursorPendingTail('{"type')).toBe('defer');
+  });
+
+  it('defers on non-{ start or unexpected whitespace', () => {
+    expect(classifyCursorPendingTail('not json')).toBe('defer');
+    expect(classifyCursorPendingTail(' {"role":"user"')).toBe('defer'); // leading space
+    expect(classifyCursorPendingTail('{ "role":"user"')).toBe('defer'); // space after {
+    expect(classifyCursorPendingTail('{"role": "user"')).toBe('defer'); // space after :
+  });
+
+  it('defers when the role value is not user|assistant', () => {
+    expect(classifyCursorPendingTail('{"role":"system"')).toBe('defer');
+    expect(classifyCursorPendingTail('{"role":"tool"')).toBe('defer');
+    expect(classifyCursorPendingTail('{"role":"量')).toBe('defer'); // multibyte value, not user/assistant
+  });
+});
+
+// ── isCursorFallbackDisabled (fail-safe mark gate) ───────────────────────
+// The 30s fail-safe must disable BOTH polling and mark attribution. This
+// pure function is the mark gate: cursor+disabled → false (no mark), other
+// CLIs unaffected. Reverse-mutation target: if the gate is removed, the
+// wiring test (codexBridgeFallbackActive checks cursorBridgeDisabled) still
+// passes but this test goes red — proving the behavioral claim is pinned.
+describe('isCursorFallbackDisabled', () => {
+  it('returns true only for cursor+disabled', () => {
+    expect(isCursorFallbackDisabled('cursor', true)).toBe(true);
+    expect(isCursorFallbackDisabled('cursor', false)).toBe(false);
+    expect(isCursorFallbackDisabled('codex', true)).toBe(false);
+    expect(isCursorFallbackDisabled('codex', false)).toBe(false);
+    expect(isCursorFallbackDisabled('claude-code', true)).toBe(false);
+    expect(isCursorFallbackDisabled(undefined, true)).toBe(false);
+    expect(isCursorFallbackDisabled(undefined, false)).toBe(false);
+  });
+});
+
+// ── Option 3: drain-level partial-tail baseline regression ───────────────
+// These tests simulate what cursorBridgeAttach does: drain from 0, classify
+// the pending tail, pick the baseline (message → readEndOffset, footer →
+// newOffset, none → newOffset), then verify the next turn survives.
+describe('drainCursorTranscript partial-tail baseline (option 3)', () => {
+  const turnEnded = { type: 'turn_ended', status: 'success' };
+
+  it('readEndOffset is the snapshot EOF (same snapshot, no second stat)', () => {
     writeFileSync(path, line(userMsg('first')) + line(assistantFinal('reply')));
-    expect(cursorBaselineOffset(path)).toBe(statSync(path).size);
+    const r = drainCursorTranscript(path, 0);
+    expect(r.readEndOffset).toBe(statSync(path).size);
+    expect(r.newOffset).toBe(statSync(path).size); // no footer → frontier = EOF
   });
 
-  it('rewinds before a trailing turn_ended footer (with and without newline)', () => {
-    const messages = line(userMsg('first')) + line(assistantFinal('reply'));
-    writeFileSync(path, messages + line(turnEnded));
-    expect(cursorBaselineOffset(path)).toBe(Buffer.byteLength(messages, 'utf8'));
-    writeFileSync(path, messages + JSON.stringify(turnEnded));
-    expect(cursorBaselineOffset(path)).toBe(Buffer.byteLength(messages, 'utf8'));
+  it('group 1: partial message tail → baseline at readEndOffset skips it, next turn intact', () => {
+    // Turn 1 at rest (no footer — the previous turn was interrupted or the
+    // footer was already truncated for the next write). A partial assistant
+    // line is being written: old in-flight output that must be skipped.
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    const partial = '{"role":"assistant","message":{"content":[{"type":"text","text":"OLD in-flight';
+    writeFileSync(path, turn1 + partial);
+    const full = drainCursorTranscript(path, 0);
+    expect(full.pendingTail).toBe(partial);
+    expect(classifyCursorPendingTail(full.pendingTail)).toBe('message');
+    // cursorBridgeAttach would baseline at readEndOffset (skip the partial).
+    const baseline = full.readEndOffset;
+    expect(baseline).toBe(statSync(path).size);
+
+    // The partial completes + footer is written.
+    const completed = partial + ' answer"}]}' + '\n';
+    writeFileSync(path, turn1 + completed + line(turnEnded));
+    // Drain from the baseline: the completed old line's tail is a fragment
+    // (fails JSON.parse, skipped); the footer is held. No stale assistant_final.
+    const r2 = drainCursorTranscript(path, baseline);
+    expect(r2.events.map(e => e.kind)).not.toContain('assistant_final');
+    expect(r2.events.map(e => e.text)).not.toContain('OLD in-flight answer');
+    // The frontier advanced to the footer's start (past the skipped fragment).
+    const footerStart = Buffer.byteLength(turn1 + completed, 'utf8');
+    expect(r2.newOffset).toBe(footerStart);
+
+    // Turn 2: footer-truncating rewrite from the footer's byte position.
+    const turn2 = line(userMsg('turn two')) + line(assistantFinal('answer two'));
+    writeFileSync(path, turn1 + completed + turn2 + line(turnEnded));
+    const r3 = drainCursorTranscript(path, r2.newOffset);
+    expect(r3.events.map(e => ({ kind: e.kind, text: e.text }))).toEqual([
+      { kind: 'user', text: 'turn two' },
+      { kind: 'assistant_final', text: 'answer two' },
+    ]);
   });
 
-  it('skips a partial message tail like a plain size baseline (old in-flight output)', () => {
-    writeFileSync(path, line(userMsg('first')) + '{"role":"assistant","message":{"content"');
-    expect(cursorBaselineOffset(path)).toBe(statSync(path).size);
-  });
+  it('group 2: partial footer tail → baseline at newOffset (footer line start), next turn not ghosted', () => {
+    // Turn 1 at rest, but the footer is only partially written.
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    const partialFooter = '{"type":"turn_ended","status":"succ';
+    writeFileSync(path, turn1 + partialFooter);
+    const full = drainCursorTranscript(path, 0);
+    expect(full.pendingTail).toBe(partialFooter);
+    expect(classifyCursorPendingTail(full.pendingTail)).toBe('footer');
+    // cursorBridgeAttach would baseline at newOffset (the footer's line start).
+    const baseline = full.newOffset;
+    expect(baseline).toBe(Buffer.byteLength(turn1, 'utf8'));
 
-  it('resume flow: baseline then footer-truncating rewrite still yields the next turn', () => {
-    const turn1 = line(userMsg('old prompt')) + line(assistantFinal('old answer'));
+    // The footer completes.
     writeFileSync(path, turn1 + line(turnEnded));
-    const baseline = cursorBaselineOffset(path)!;
-    // History stays behind the baseline...
-    expect(drainCursorTranscript(path, baseline).events).toEqual([]);
-    // ...and the next turn's rewrite from the footer position is fully seen.
-    const turn2 = line(userMsg('new prompt')) + line(assistantFinal('new answer'));
+    const r2 = drainCursorTranscript(path, baseline);
+    expect(r2.events).toEqual([]); // footer re-parses to zero events
+    expect(r2.newOffset).toBe(baseline); // held at the footer's start
+
+    // Turn 2: footer-truncating rewrite. The new user line starts at the
+    // footer's old position (= baseline). It must NOT be ghosted.
+    const turn2 = line(userMsg('turn two')) + line(assistantFinal('answer two'));
+    writeFileSync(path, turn1 + turn2 + line(turnEnded));
+    const r3 = drainCursorTranscript(path, baseline);
+    expect(r3.events.map(e => ({ kind: e.kind, text: e.text }))).toEqual([
+      { kind: 'user', text: 'turn two' },
+      { kind: 'assistant_final', text: 'answer two' },
+    ]);
+  });
+
+  it('group 3: partial footer overwritten by new user before completing', () => {
+    // Turn 1 at rest, footer partially written.
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    const partialFooter = '{"type":"turn_ended","status":"succ';
+    writeFileSync(path, turn1 + partialFooter);
+    const full = drainCursorTranscript(path, 0);
+    expect(classifyCursorPendingTail(full.pendingTail)).toBe('footer');
+    const baseline = full.newOffset; // hold at footer line start
+
+    // Before the footer completes, turn 2 truncates it and writes the new
+    // user line starting at the footer's old position.
+    const turn2 = line(userMsg('turn two')) + line(assistantFinal('answer two'));
+    writeFileSync(path, turn1 + turn2 + line(turnEnded));
+    const r = drainCursorTranscript(path, baseline);
+    // The partial footer is gone; the new user/final are read from the
+    // footer's old position. No ghost, no stale footer.
+    expect(r.events.map(e => ({ kind: e.kind, text: e.text }))).toEqual([
+      { kind: 'user', text: 'turn two' },
+      { kind: 'assistant_final', text: 'answer two' },
+    ]);
+  });
+
+  for (const [label, ch] of [['CJK', '量'], ['emoji', '😀']] as const) {
+    it(`group 4: ${label} — drain from a mid-char baseline does not drift (raw 0x0a index)`, () => {
+      // A giant multibyte assistant line, then a partial tail that ends
+      // mid-char. The snapshot EOF (readEndOffset) is mid-multibyte-char.
+      const turn1 = line(userMsg('q')) + line(assistantFinal(ch.repeat(30000)));
+      // Append a partial user line cut mid-char (3-byte CJK: E9 87 8F; cut
+      // after 2 bytes so the decoded tail has a U+FFFD).
+      const partialPrefix = '{"role":"user","message":{"content":[{"type":"text","text":"';
+      const partialBytes = Buffer.from(partialPrefix + ch, 'utf8');
+      const cutLen = partialBytes.length - 1; // drop the last byte → mid-char
+      const buf = Buffer.concat([Buffer.from(turn1, 'utf8'), partialBytes.subarray(0, cutLen)]);
+      writeFileSync(path, buf);
+      expect(statSync(path).size).toBeGreaterThan(65536);
+
+      const full = drainCursorTranscript(path, 0);
+      // The partial tail decodes with a U+FFFD (mid-char cut).
+      expect(full.pendingTail).toContain('\uFFFD');
+      // readEndOffset is the snapshot EOF (mid-char).
+      const baseline = full.readEndOffset;
+      expect(baseline).toBe(statSync(path).size);
+
+      // The partial completes (full char + closing JSON + newline).
+      const completed = partialPrefix + ch + '"}]}' + '\n';
+      writeFileSync(path, Buffer.concat([Buffer.from(turn1, 'utf8'), Buffer.from(completed, 'utf8')]));
+      // Drain from the mid-char baseline. The first segment decodes with a
+      // U+FFFD prefix, fails JSON.parse, and is skipped by the raw 0x0a index
+      // — no drift past the true line boundary, no false events.
+      const r = drainCursorTranscript(path, baseline);
+      expect(r.events).toEqual([]); // fragment skipped, no false parse
+      // The frontier advanced to the completed line's end (a line boundary).
+      expect(r.newOffset).toBe(statSync(path).size);
+    });
+  }
+
+  it('group 5: partial line with no newline across ticks — offset does not advance, no false parse', () => {
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    const partial = '{"role":"assistant","message":{"content":[{"type":"text","text":"still writing';
+    writeFileSync(path, turn1 + partial);
+    const r1 = drainCursorTranscript(path, 0);
+    expect(r1.pendingTail).toBe(partial);
+    expect(r1.newOffset).toBe(Buffer.byteLength(turn1, 'utf8')); // held at partial line start
+
+    // Tick 2: the partial grows but still has no newline.
+    const partial2 = partial + ' more text';
+    writeFileSync(path, turn1 + partial2);
+    const r2 = drainCursorTranscript(path, r1.newOffset);
+    expect(r2.pendingTail).toBe(partial2);
+    expect(r2.newOffset).toBe(r1.newOffset); // still held, no advance
+    expect(r2.events).toEqual([]); // no false parse
+
+    // Tick 3: still no newline, no growth (no-op).
+    const r3 = drainCursorTranscript(path, r2.newOffset);
+    expect(r3.newOffset).toBe(r2.newOffset);
+    expect(r3.events).toEqual([]);
+  });
+
+  it('group 6a: defer (tail too short) → next tick footer completes → baseline at footer start, turn 2 not lost', () => {
+    // A very short partial tail — too short to classify (could be role or
+    // type). cursorBridgeAttach would defer: no baseline committed, poller
+    // retries next tick.
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    writeFileSync(path, turn1 + '{"ty');
+    const full1 = drainCursorTranscript(path, 0);
+    expect(full1.pendingTail).toBe('{"ty');
+    expect(classifyCursorPendingTail(full1.pendingTail)).toBe('defer');
+
+    // Next tick: the tail grows to a complete turn_ended footer.
+    writeFileSync(path, turn1 + line(turnEnded));
+    const full2 = drainCursorTranscript(path, 0);
+    expect(full2.pendingTail).toBe(''); // footer complete, held
+    // No tail → baseline = newOffset (footer start).
+    const baseline = full2.newOffset;
+    expect(baseline).toBe(Buffer.byteLength(turn1, 'utf8'));
+
+    // Turn 2: footer-truncating rewrite. First turn not lost.
+    const turn2 = line(userMsg('turn two')) + line(assistantFinal('answer two'));
     writeFileSync(path, turn1 + turn2 + line(turnEnded));
     const r = drainCursorTranscript(path, baseline);
     expect(r.events.map(e => ({ kind: e.kind, text: e.text }))).toEqual([
-      { kind: 'user', text: 'new prompt' },
-      { kind: 'assistant_final', text: 'new answer' },
+      { kind: 'user', text: 'turn two' },
+      { kind: 'assistant_final', text: 'answer two' },
     ]);
+  });
+
+  it('group 6b: defer (short tail) → grows to message discriminator → baseline at readEndOffset (skip)', () => {
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    writeFileSync(path, turn1 + '{"ro');
+    expect(classifyCursorPendingTail(drainCursorTranscript(path, 0).pendingTail)).toBe('defer');
+
+    // Grows to a complete message discriminator.
+    const partial = '{"role":"assistant","message":{"content":[{"type":"text","text":"OLD in-flight';
+    writeFileSync(path, turn1 + partial);
+    const full2 = drainCursorTranscript(path, 0);
+    expect(classifyCursorPendingTail(full2.pendingTail)).toBe('message');
+    // Baseline = readEndOffset (skip the old in-flight line).
+    expect(full2.readEndOffset).toBe(statSync(path).size);
+    expect(full2.newOffset).toBe(Buffer.byteLength(turn1, 'utf8')); // footer-aware frontier
+  });
+});
+
+// ── Option 3 group 8: short-read TOCTOU + snapshotComplete ───────────────
+// If Cursor truncates the mirror between statSync and readSync, readSync
+// returns fewer bytes than len. The drain must report snapshotComplete=false
+// and readEndOffset=actual bytesRead (not the stale stat size), so the caller
+// defers instead of committing a baseline past the real data.
+describe('drainCursorTranscript short-read (group 8)', () => {
+  const turnEnded = { type: 'turn_ended', status: 'success' };
+
+  it('snapshotComplete=false for a missing file', () => {
+    const r = drainCursorTranscript(join(dir, 'missing.jsonl'), 0);
+    expect(r.snapshotComplete).toBe(false);
+    expect(r.readEndOffset).toBe(0);
+  });
+
+  it('snapshotComplete=true for an empty file', () => {
+    writeFileSync(path, '');
+    const r = drainCursorTranscript(path, 0);
+    expect(r.snapshotComplete).toBe(true);
+    expect(r.readEndOffset).toBe(0);
+  });
+
+  it('snapshotComplete=true for a normal complete read', () => {
+    writeFileSync(path, line(userMsg('first')) + line(assistantFinal('reply')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.snapshotComplete).toBe(true);
+    expect(r.readEndOffset).toBe(statSync(path).size);
+  });
+
+  it('short-read (truncate between stat and read) → snapshotComplete=false, readEndOffset=actual bytesRead', () => {
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    writeFileSync(path, turn1 + line(turnEnded));
+    const originalSize = statSync(path).size;
+    // Inject a read stub that truncates the file AFTER stat but BEFORE read,
+    // deterministically reproducing the stat→read truncation race.
+    const deps: CursorDrainDeps = {
+      read: (fd: number, buf: Buffer, offset: number, length: number, position: number) => {
+        truncateSync(path, 14); // simulate Cursor truncating mid-read
+        return readSync(fd, buf, offset, length, position);
+      },
+    };
+    const r = drainCursorTranscript(path, 0, deps);
+    expect(r.snapshotComplete).toBe(false);
+    expect(r.readEndOffset).toBe(14); // actual bytesRead, NOT originalSize
+    expect(r.readEndOffset).toBeLessThan(originalSize);
+    // The caller (cursorBridgeAttach) must defer on !snapshotComplete — it
+    // must NOT feed these partial events to preamble or commit a baseline.
+  });
+
+  it('short-read with a message tail → caller defers (does not commit baseline past real data)', () => {
+    // Simulate the attach scenario: file has history + a partial message
+    // tail, then is truncated between stat and read.
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    const partial = '{"role":"assistant","message":{"content":[{"type":"text","text":"OLD';
+    writeFileSync(path, turn1 + partial);
+    const deps: CursorDrainDeps = {
+      read: (fd: number, buf: Buffer, offset: number, length: number, position: number) => {
+        truncateSync(path, 20); // truncate to 20 bytes (mid history)
+        return readSync(fd, buf, offset, length, position);
+      },
+    };
+    const r = drainCursorTranscript(path, 0, deps);
+    expect(r.snapshotComplete).toBe(false);
+    // The caller checks snapshotComplete and defers — it never reaches the
+    // classify/commit path. This test pins the contract: a short read must
+    // not produce a committable frontier.
+    expect(r.readEndOffset).toBe(20);
+  });
+});
+
+// ── Option 3: queue-level stale-partial regression ───────────────────────
+// When a spawn/resume attach skips an old in-flight message line (baseline at
+// readEndOffset), the line's later completion must NOT produce a stale
+// assistant_final that fingerprint-matches a newly-marked turn. The drain
+// reads the completion as a fragment (skipped), so the queue never sees it.
+describe('cursor transcript + queue: stale partial completion does not replay', () => {
+  const turnEnded = { type: 'turn_ended', status: 'success' };
+
+  it('old in-flight assistant completes after skip → no stale final; new turn matches cleanly', () => {
+    const turn1 = line(userMsg('turn one')) + line(assistantFinal('answer one'));
+    const partial = '{"role":"assistant","message":{"content":[{"type":"text","text":"OLD in-flight';
+    writeFileSync(path, turn1 + partial);
+
+    // Attach: drain from 0, classify as message, baseline at readEndOffset.
+    const full = drainCursorTranscript(path, 0);
+    expect(classifyCursorPendingTail(full.pendingTail)).toBe('message');
+    const baseline = full.readEndOffset;
+
+    // The old history (turn1 events) is NOT absorbed into the queue (the
+    // bridge only emits the adopt preamble from them). Mark a NEW turn.
+    const queue = new CodexBridgeQueue();
+    queue.mark('turn-2', 'turn two prompt');
+
+    // The old partial completes + footer. Drain from the baseline: the
+    // completion is a fragment (skipped), so no stale assistant_final is
+    // ingested into the queue.
+    const completed = partial + ' answer"}]}' + '\n';
+    writeFileSync(path, turn1 + completed + line(turnEnded));
+    const r2 = drainCursorTranscript(path, baseline);
+    queue.ingest(r2.events);
+    // No stale final matched the new mark.
+    const pending = (queue as any).queue as any[];
+    expect(pending[0]?.started).toBeFalsy();
+
+    // Turn 2's user line is appended (after the footer-truncating rewrite).
+    const turn2 = line(userMsg('turn two prompt')) + line(assistantFinal('answer two'));
+    writeFileSync(path, turn1 + completed + turn2 + line(turnEnded));
+    const r3 = drainCursorTranscript(path, r2.newOffset);
+    queue.ingest(r3.events);
+    // The new user event fingerprint-matched the mark → the turn started.
+    expect(pending[0]?.started).toBe(true);
   });
 });

--- a/test/structured-bridge-clis.test.ts
+++ b/test/structured-bridge-clis.test.ts
@@ -38,11 +38,12 @@ describe('structured-bridge-clis', () => {
     expect(STRUCTURED_BRIDGE_ADOPT_CLI_IDS).not.toContain('oh-my-pi');
   });
 
-  it('fallback treats cursor as adopt-only', () => {
-    expect(isStructuredBridgeFallbackActive('cursor')).toBe(false);
-    expect(isStructuredBridgeFallbackActive('cursor', true)).toBe(true);
+  it('fallback is always-on for cursor (spawned sessions harvest send-less finals too)', () => {
+    expect(isStructuredBridgeFallbackActive('cursor')).toBe(true);
     expect(isStructuredBridgeFallbackActive('grok')).toBe(true);
     expect(isStructuredBridgeFallbackActive('hermes')).toBe(true);
+    expect(isStructuredBridgeFallbackActive('claude-code')).toBe(false);
+    expect(isStructuredBridgeFallbackActive(undefined)).toBe(false);
   });
 
   it('adopt idle/input allowlists match historical worker behaviour', () => {


### PR DESCRIPTION
## 改了什么 & 为什么

botmux 自己 spawn 的 cursor 会话此前没有 transcript 兜底：structured bridge 的 allowlist 把 cursor 限制为 **adopt-only**（`420aa12fe` 引入 cursor 桥时的范围），模型完成一轮却忘调 `botmux send` 时整轮静默——而 claude/codex 会从 transcript 收割最终回答补发。cursor 的排水器（`cursor-transcript.ts`）与共享 CodexBridgeQueue / 兜底闸门（`bridge-fallback-gate.ts`）早已就位，本次只补 spawn 侧接线：

- `structured-bridge-clis.ts`：cursor 移入 `STRUCTURED_BRIDGE_ALWAYS_CLI_IDS`，删除 adopt-only 特例（`isStructuredBridgeFallbackActive` 去掉 `adoptMode` 参数，唯一调用方同步更新）
- `worker.ts` `spawnCli`：新增 cursor 桥 attach 分支——resume 用已知 chatId 直接解析 JSONL attach（`baseline-existing`，历史不重放）；fresh spawn 此时还没有 chatId，先武装 1s poller
- `worker.ts` `observeCursorCliSessionId`：pid→store.db fd 观察到 chatId 后，除 persist 外同步调 `codexBridgeNotifyCliSessionId`（JSONL 未创建时挂 pending sid 走 late-attach；已 attach 时 first-attach-wins 直接返回）
- `worker.ts` `cursorLateAttachMode`：补非 adopt 语义——fresh spawn 从字节 0 摄入（chatId 级 JSONL 只含本会话，即使 attach 前首轮已落盘也不会误吞），resume 基线在既有尾部之后；**adopt 分支行为逐字不变**（birthtime 判定 + 异常回退 baseline-existing）

兜底语义与 codex 完全一致（同一 `emitReadyCodexTurns` + send-marker 闸门）：本轮已 `botmux send` 则压制；prose+`BOTMUX_NOTHING_TO_SEND` 哨兵取 prose 补发（做了活忘发的场景）；纯哨兵按真静默处理，不打扰话题。

## 影响面评估

- **cursor 非 adopt 会话**（新增路径）：每轮 flush 时 mark 指纹 → transcript user 行匹配开轮 → text-only assistant 行关轮 → 闸门决定补发/压制。提交验证租约有界（20s/30s），JSONL 迟迟不出现时 mark 静默过期，不会误报
- **cursor adopt 会话**：仅注释级变化，attach 模式判定原逻辑保留
- **其它 structured CLI**（codex/traex/coco/hermes/mtr/pi/grok）：allowlist 判定结果不变；`emitTurnTerminal` 有 per-turn claim 去重，结构化终端与 screen-idle 终端双路发射与 coco/grok 现状同形
- **已知边界（与改动前行为相同，不激活兜底）**：`--continue` 降级 resume（无 chatId 可观察）；sandbox 下宿主读不到 `~/.cursor/projects` JSONL

## 测试

- `pnpm build` 通过
- `pnpm vitest run test/structured-bridge-clis.test.ts test/cursor-transcript.test.ts test/bridge-fallback-gate.test.ts` → 93 passed
- 全量 `pnpm test` → 950 files passed，仅 `test/skill-doctor-command.test.ts` 2 例失败；已在干净 `origin/master` worktree 复跑确认为环境相关的既有失败，与本改动无关
- live 验证：`pnpm switch:here && pnpm daemon:restart` 后在飞书新开 cursor 话题实测（结果将补充在评论）

Made with [Cursor](https://cursor.com)