### PR TITLE
fix(cards): worker ready 先补发 set_display_mode,修复重启后截图流静默失效

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -9449,8 +9449,9 @@ function setupWorkerHandlers(
         // the card-POST race and `ready` breaks at the sentinel — the worker
         // then never starts its screenshot loop while the daemon keeps
         // rendering "waiting for first screenshot" forever. Sending before the
-        // card exists is safe: screenshot_uploaded stores currentImageKey
-        // unconditionally and only gates the card PATCH on streamCardId.
+        // card exists is safe: at worst the first screenshot_uploaded is
+        // dropped by the streamCardPending gate and the next 10s cycle
+        // delivers a fresh frame.
         syncWorkerDisplayMode(ds);
         // Treat `ready` as a full state boundary for the usage refresh: clear
         // any timer inherited from a PRIOR worker generation up front, so the
@@ -10163,7 +10164,6 @@ function setupWorkerHandlers(
         // Drop uploads that arrived during a new-turn handoff — the image_key may
         // reflect previous turn's content. Next 10s cycle picks up fresh content.
         if (ds.streamCardPending) break;
-        ds.currentImageKey = msg.imageKey;
         const prevStatus = ds.lastScreenStatus;
         updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
@@ -10180,7 +10180,6 @@ function setupWorkerHandlers(
           imageKey: msg.imageKey,
           content: ds.lastScreenContent ?? '',
         });
-        persistStreamCardState(ds);
         // screenshot_uploaded never ARMS the usage refresh — screen_update owns
         // the authorized arm. Here we only tear it down: unconditionally on
         // leaving `working`, and on a managed/silent turn (below) that must not
@@ -10188,7 +10187,18 @@ function setupWorkerHandlers(
         // re-render the prior visible card with THIS managed/hidden turn's
         // content — the same leak class as substitute-turn card suppression.
         if (ds.lastScreenStatus !== 'working') clearUsageRefreshTimer(ds);
-        if (managedAuxUiSuppressed(msg.turnId, msg.dispatchAttempt)) { clearUsageRefreshTimer(ds); break; }
+        if (managedAuxUiSuppressed(msg.turnId, msg.dispatchAttempt)) {
+          clearUsageRefreshTimer(ds);
+          persistStreamCardState(ds);
+          break;
+        }
+        // Store the image key only AFTER the managed gate: now that the ready
+        // handler re-syncs display mode on every path, a worker can be
+        // uploading during a suppressed managed/silent turn — letting that
+        // frame into ds.currentImageKey would paste it onto the next visible
+        // card render (the same leak class the comment above names).
+        ds.currentImageKey = msg.imageKey;
+        persistStreamCardState(ds);
         if ((ds.displayMode ?? 'hidden') !== 'screenshot') break;
         if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL || !workerHasInitialized(ds)) break;
         const readUrl = readableTerminalUrlFor(ds);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -9440,6 +9440,18 @@ function setupWorkerHandlers(
         }
         startupState.ready = true;
         ds.workerReady = true;
+        // Restore the daemon-owned display mode BEFORE any card handling: a
+        // fresh worker always boots with displayMode='hidden', and every early
+        // break below (managed / replyAlreadySent / streamingCardDisabled /
+        // CARD_POSTING_SENTINEL) used to skip the re-sync entirely. The
+        // sentinel break is not even rare: a headless backend (mojo) reaches
+        // prompt-ready synchronously on spawn, so screen_update reliably wins
+        // the card-POST race and `ready` breaks at the sentinel — the worker
+        // then never starts its screenshot loop while the daemon keeps
+        // rendering "waiting for first screenshot" forever. Sending before the
+        // card exists is safe: screenshot_uploaded stores currentImageKey
+        // unconditionally and only gates the card PATCH on streamCardId.
+        syncWorkerDisplayMode(ds);
         // Treat `ready` as a full state boundary for the usage refresh: clear
         // any timer inherited from a PRIOR worker generation up front, so the
         // managed/replyAlreadySent/disabled/recovery/sentinel early-breaks below
@@ -9527,7 +9539,6 @@ function setupWorkerHandlers(
         // (if any) is left untouched. The next real user turn clears this flag
         // (rememberLastCliInput) and the normal card flow resumes.
         if (ds.suppressRecoveryCard) {
-          syncWorkerDisplayMode(ds);
           logger.info(`[${t}] Restored session — suppressing recovery streaming card (silent restart)`);
           break;
         }
@@ -9588,8 +9599,6 @@ function setupWorkerHandlers(
               scheduleCodexServiceTierPatch(ds);
             }
             persistStreamCardState(ds);
-            // Re-sync worker's display mode (it starts fresh in 'hidden')
-            syncWorkerDisplayMode(ds);
             // The restored card is now the active one — withdraw any cards
             // frozen before the daemon went down so they don't pile up in the
             // thread on each restart.
@@ -9673,8 +9682,6 @@ function setupWorkerHandlers(
           }
           ds.parkedStreamCardNonce = undefined;
           persistStreamCardState(ds);
-          // Re-sync worker's display mode (it starts fresh in 'hidden')
-          syncWorkerDisplayMode(ds);
           // New card is live — recall any cards frozen by previous turns.
           // Done after `streamCardId` is committed so we never delete the old
           // card without a successor visible to the user.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7460,6 +7460,8 @@ let displayMode: DisplayMode = 'hidden';
 let screenshotTimer: ReturnType<typeof setInterval> | null = null;
 let pendingShotTimer: ReturnType<typeof setTimeout> | null = null;
 let lastShotHash = '';
+// Throttle for the happy-path upload log in captureAndUpload (one line/min).
+let lastUploadLogAtMs = 0;
 let larkAppIdForUpload = '';
 let larkAppSecretForUpload = '';
 let larkBrandForUpload: 'feishu' | 'lark' = 'feishu';
@@ -7564,6 +7566,14 @@ async function captureAndUpload(): Promise<void> {
   }
 
   const status = projectedRuntimeScreenStatus();
+  // Success is otherwise completely silent (skips and failures log above), which
+  // made "loop alive and uploading" indistinguishable from "loop never started"
+  // in the daemon log. One throttled line keeps the happy path observable.
+  const nowMs = Date.now();
+  if (nowMs - lastUploadLogAtMs >= 60_000) {
+    lastUploadLogAtMs = nowMs;
+    log(`Screenshot uploaded (${png.length}B, key=${imageKey.slice(0, 12)}…)`);
+  }
   send({
     type: 'screenshot_uploaded',
     imageKey,
@@ -17292,7 +17302,10 @@ process.on('message', async (raw: unknown) => {
     }
 
     case 'refresh_screen': {
-      if (displayMode !== 'screenshot') break;
+      // The daemon only offers manual refresh on a screenshot-mode card, so
+      // landing here in another mode means the display-mode re-sync was lost —
+      // say so instead of eating the click silently.
+      if (displayMode !== 'screenshot') { log(`Manual screenshot refresh ignored: displayMode=${displayMode}`); break; }
       lastShotHash = '';
       if (screenshotTimer) {
         clearInterval(screenshotTimer);

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -585,6 +585,99 @@ describe('Worker ready: set_display_mode re-sync', () => {
     });
   });
 
+  it('sentinel early-break (in-flight card POST) still sends set_display_mode', async () => {
+    // The mojo-shape race: a headless backend reaches prompt-ready synchronously
+    // on spawn, so a screen_update wins the card POST and `ready` finds
+    // CARD_POSTING_SENTINEL already set. The old implementation broke out of the
+    // handler right there and the fresh worker stayed displayMode='hidden'
+    // forever ("waiting for first screenshot…"). Note: we only assert the
+    // worker got the mode — the first screenshot_uploaded may still be dropped
+    // by the streamCardPending gate; the next 10s cycle delivers it.
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      displayMode: 'screenshot',
+      streamCardPending: false,
+      streamCardId: CARD_POSTING_SENTINEL,
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+
+    // No duplicate card POST while the sentinel is held.
+    expect(sessionReplyMock).not.toHaveBeenCalled();
+    expect(fakeWorker.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'set_display_mode', mode: 'screenshot' }),
+    );
+  });
+
+  it('managed/silent-suppressed ready (apiOnly transport) still sends set_display_mode', async () => {
+    // apiOnly makes auxUiSuppressedFor() return true — the "worker exists, no
+    // card will ever be posted" shape. The mode re-sync must not be tied to
+    // card delivery. Implementation is restored in finally: clearAllMocks()
+    // does not undo a leaked mockImplementation for later tests.
+    const getBotMock = vi.mocked(getBot);
+    const originalGetBot = getBotMock.getMockImplementation();
+    getBotMock.mockImplementation((() => ({
+      config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code', apiOnly: true },
+      resolvedAllowedUsers: [],
+      botOpenId: 'ou_bot',
+      botName: 'TestBot',
+    })) as any);
+    try {
+      const fakeWorker = makeFakeWorker();
+      const ds = makeDs({
+        displayMode: 'screenshot',
+        streamCardPending: false,
+        streamCardId: undefined,
+        worker: fakeWorker,
+      });
+
+      __testOnly_setupWorkerHandlers(ds, fakeWorker);
+      fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+      await flush();
+
+      expect(sessionReplyMock).not.toHaveBeenCalled();
+      expect(fakeWorker.send).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'set_display_mode', mode: 'screenshot' }),
+      );
+    } finally {
+      getBotMock.mockImplementation(originalGetBot as any);
+    }
+  });
+
+  it('streamingCardDisabled ready still sends set_display_mode', async () => {
+    const getBotMock = vi.mocked(getBot);
+    const originalGetBot = getBotMock.getMockImplementation();
+    getBotMock.mockImplementation((() => ({
+      config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code', disableStreamingCard: true },
+      resolvedAllowedUsers: [],
+      botOpenId: 'ou_bot',
+      botName: 'TestBot',
+    })) as any);
+    try {
+      const fakeWorker = makeFakeWorker();
+      const ds = makeDs({
+        displayMode: 'screenshot',
+        streamCardPending: false,
+        streamCardId: undefined,
+        worker: fakeWorker,
+      });
+
+      __testOnly_setupWorkerHandlers(ds, fakeWorker);
+      fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+      await flush();
+
+      expect(sessionReplyMock).not.toHaveBeenCalled();
+      expect(fakeWorker.send).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'set_display_mode', mode: 'screenshot' }),
+      );
+    } finally {
+      getBotMock.mockImplementation(originalGetBot as any);
+    }
+  });
+
   it('re-applies readiness when cli_session_id races a restored-card PATCH', async () => {
     let resolveRestorePatch!: () => void;
     updateMessageMock.mockImplementationOnce(() => new Promise<void>((resolve) => {

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -678,6 +678,42 @@ describe('Worker ready: set_display_mode re-sync', () => {
     }
   });
 
+  it('suppressed managed turn screenshot never lands in currentImageKey', async () => {
+    // With the early re-sync, a worker can be uploading during a managed/silent
+    // turn — that frame must not become the next visible card's image.
+    const getBotMock = vi.mocked(getBot);
+    const originalGetBot = getBotMock.getMockImplementation();
+    getBotMock.mockImplementation((() => ({
+      config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code', apiOnly: true },
+      resolvedAllowedUsers: [],
+      botOpenId: 'ou_bot',
+      botName: 'TestBot',
+    })) as any);
+    try {
+      const fakeWorker = makeFakeWorker();
+      const ds = makeDs({
+        displayMode: 'screenshot',
+        streamCardPending: false,
+        streamCardId: 'om_visible_card',
+        worker: fakeWorker,
+      });
+
+      __testOnly_setupWorkerHandlers(ds, fakeWorker);
+      fakeWorker.emit('message', {
+        type: 'screenshot_uploaded',
+        imageKey: 'img_managed_frame',
+        status: 'working',
+        turnId: 'turn-managed',
+      });
+      await flush();
+
+      expect(ds.currentImageKey).toBeUndefined();
+      expect(updateMessageMock).not.toHaveBeenCalled();
+    } finally {
+      getBotMock.mockImplementation(originalGetBot as any);
+    }
+  });
+
   it('re-applies readiness when cli_session_id races a restored-card PATCH', async () => {
     let resolveRestorePatch!: () => void;
     updateMessageMock.mockImplementationOnce(() => new Promise<void>((resolve) => {


### PR DESCRIPTION
## 改了什么

1. `worker-pool.ts` `case 'ready'`:把 `syncWorkerDisplayMode(ds)` 提到处理最前(`workerReady = true` 之后),覆盖 managed / replyAlreadySent / streamingCardDisabled / suppressRecoveryCard / `CARD_POSTING_SENTINEL` 全部 early break;删除原先散在三个卡片出口的冗余调用
2. `worker.ts` `refresh_screen`:非截图模式不再静默 break,补一条说明日志
3. `worker.ts` `captureAndUpload`:成功路径补每分钟一条限流日志(字节数 + image_key 前缀)——此前成功零日志,「截图循环活着」和「从没启动」在日志上不可分

## 为什么

worker 重启后,daemon 只在 `case 'ready'` 的三个卡片出口补发 `set_display_mode`;当 screen_update 抢先发起卡片 POST(`streamCardId === CARD_POSTING_SENTINEL`)时,`ready` 走 sentinel 分支**静默 break,不补发**。新一代 worker 的 `displayMode` 永远停在 `'hidden'`:截图循环不启动、手动刷新被 `displayMode !== 'screenshot'` 门禁静默吞掉,daemon 侧 `ds.displayMode` 仍是 `'screenshot'` 且 `currentImageKey` 已被重置 → 卡片永远渲染「(等待第一张截图…)」。

对 headless 后端(mojo)这是**必现**:spawn 即同步 prompt-ready,screen_update 每次都赢得竞速。PTY/tmux CLI 因 TUI 出画面慢、ready 通常先到,所以过去只偶发。

提前 sync 是安全的:`startScreenshotLoop` 幂等;首张截图最多被 `streamCardPending` gate 丢弃,10s 后下一拍补上(预期行为)。

**复审返修(Wallpaper F1/F2)**:managed/silent 轮次的截图不再写入 `currentImageKey`(赋值移到 managedAuxUiSuppressed 门禁之后,堵住被抑制轮次的帧污染下一次可见卡片的泄漏窗口),并新增对返修前实现红的回归用例;ready 处「提前 sync 安全性」注释的错误理由已修正。

## 影响面

- `worker-pool.ts` ready 处理是**全 CLI × 全后端共用路径**:变化是「sync 从部分出口提前到所有路径」,对原本就会 sync 的 PATCH/POST/recovery 路径仅时序提前(卡片首帧反而更快);新覆盖的是 sentinel/managed/disabled 这几个此前漏掉的形态
- worker.ts 两处为纯可观测性增强,不改行为

## 实测验证

- `test/worker-ready-display-mode.test.ts` 新增 3 用例:sentinel 竞速(**对旧实现红**,red→green 已验证)、apiOnly-managed、streamingCardDisabled;31/31 ✅
- 周边回归:card-integration / transfer-input-gate-wiring / mojo-worker-wiring 共 68/68 ✅
- 全量测试与 master 基线对照:失败文件集完全一致(12 个既有 flaky/env 文件),0 新增
- Live 验证(macOS,部署本分支后):mojo 会话卡片点「📖 显示输出」,1 秒内 worker 日志出现 `Display mode → screenshot` → `Screenshot loop started` → `Screenshot uploaded (224018B, key=img_v3_0214n…)`,卡片出图 ✅(修复前同场景 40 分钟零上传、两次手动刷新被静默吞掉)

根因排查:local_cc_Wallpaper(独立只读排查);修复与测试:本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

