### PR TITLE
fix(dashboard): daemon IPC 鉴权读密钥改走宿主凭证安全原语

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -5,7 +5,8 @@ import { readFileSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { logger } from '../utils/logger.js';
-import { cliAuthBind, verifyHmac } from '../dashboard/auth.js';
+import { cliAuthBind, loadDashboardSecret, verifyHmac } from '../dashboard/auth.js';
+import { UnsafeHostAuthorityFileError } from '../platform/secure-host-file.js';
 import { WORKFLOW_DAEMON_IPC_ROUTE_PREFIX } from '../workflows/v3/daemon-ipc-auth.js';
 import { V3_SESSION_RUN_MUTATION_ROUTE_PREFIX } from '../workflows/v3/session-relay.js';
 import { REPORT_SESSION_RELAY_ROUTE } from './report-session-relay.js';
@@ -585,10 +586,40 @@ function closeUntrustedRequestAfterResponse(req: IncomingMessage, res: ServerRes
 let injectedIpcSecret: string | null = null;
 /** Test seam: override the secret used to verify token-route HMAC. */
 export function setIpcAuthSecret(secret: string | null): void { injectedIpcSecret = secret; }
+let loggedUnsafeIpcSecretAt = 0;
+/**
+ * Load the machine-local dashboard secret used to verify token-route HMAC.
+ *
+ * Goes through {@link loadDashboardSecret} — the same strict host-authority
+ * reader the dashboard and daemon startup use — instead of a bare
+ * `readFileSync`: the leaf must be a regular 0600 file owned by the current
+ * user and must NOT be a symlink, and `~/.botmux` must not be
+ * group/other-writable. This is a per-request verifier on ~96 daemon IPC routes,
+ * so an attacker who can plant a symlink or loose-perms `.dashboard-secret` after
+ * boot must not have that content trusted as the HMAC key here (the dashboard
+ * caches its secret once at startup; this path re-reads every request, so it is
+ * the more exposed reader).
+ *
+ * Fail-closed either way: an unsafe shape returns `null` (→ nobody can sign →
+ * 401) rather than being followed. We log it — throttled, since this runs per
+ * request — so a planted/misconfigured credential is diagnosable instead of
+ * looking identical to "no secret on disk".
+ */
 function ipcAuthSecret(): string | null {
   if (injectedIpcSecret) return injectedIpcSecret;
-  try { return readFileSync(dashboardSecretPath(), 'utf8').trim() || null; }
-  catch { return null; }
+  try {
+    return loadDashboardSecret(dashboardSecretPath());
+  } catch (err) {
+    if (err instanceof UnsafeHostAuthorityFileError) {
+      const now = Date.now();
+      if (now - loggedUnsafeIpcSecretAt > 60_000) {
+        loggedUnsafeIpcSecretAt = now;
+        logger.error(`[dashboard-ipc] 拒绝使用不安全的 .dashboard-secret：${err.message}（IPC 鉴权 fail-closed）`);
+      }
+      return null;
+    }
+    return null;
+  }
 }
 /** Authenticate legacy terminal-token routes with the machine-local dashboard
  * secret. Workflow v3 mutations intentionally use their separate, full-request

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -1,7 +1,7 @@
 // test/dashboard-ipc.test.ts
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { createHmac, randomBytes } from 'node:crypto';
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { request as httpRequest } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -249,6 +249,98 @@ describe('dashboard IPC server', () => {
       headers: trustedHostHeaders('GET', '/api/sessions', handle.port, rotatedSecret),
     });
     expect(currentSecret.status).toBe(200);
+  });
+});
+
+// The verifier's REAL on-disk secret read (ipcAuthSecret → loadDashboardSecret)
+// — every other test injects the key via setIpcAuthSecret and never exercises
+// this branch. This is a per-request verifier on ~96 daemon IPC routes; a
+// symlinked / loose-perms `.dashboard-secret` planted after boot must not be
+// followed and trusted as the HMAC key (it fails closed → 401), and a genuine
+// 0600 secret must still authenticate. We point HOME at a temp dir so
+// dashboardSecretPath() resolves there; loadDashboardSecret re-reads per call.
+describe('IPC auth reads the on-disk dashboard secret through the secure primitive', () => {
+  const REAL_SECRET = 'real-ondisk-ipc-secret-cafebabe';
+  let home: string;
+  let botmuxDir: string;
+  let secretPath: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    // Force the disk path (no injected override) for this whole describe.
+    setIpcAuthSecret(null);
+    home = mkdtempSync(join(tmpdir(), 'bmx-ipc-home-'));
+    botmuxDir = join(home, '.botmux');
+    mkdirSync(botmuxDir, { recursive: true, mode: 0o700 });
+    secretPath = join(botmuxDir, '.dashboard-secret');
+    prevHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    // Loosen back to a removable shape before rm (a 0700 dir is fine here).
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it('authenticates a valid trusted-host signature against a real 0600 secret', async () => {
+    writeFileSync(secretPath, REAL_SECRET, { mode: 0o600 });
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const base = `http://127.0.0.1:${handle.port}`;
+
+    const authed = await fetch(`${base}/api/sessions`, {
+      headers: trustedHostHeaders('GET', '/api/sessions', handle.port, REAL_SECRET),
+    });
+    expect(authed.status).toBe(200);
+
+    const wrongKey = await fetch(`${base}/api/sessions`, {
+      headers: trustedHostHeaders('GET', '/api/sessions', handle.port, 'not-the-secret'),
+    });
+    expect(wrongKey.status).toBe(401);
+  });
+
+  it('fails closed (401) when the secret leaf is a symlink, without following it', async () => {
+    if (process.platform === 'win32') return;
+    // A local attacker who can write ~/.botmux plants a symlink to content they
+    // know; the secure reader must refuse it rather than sign with that value.
+    const planted = join(home, 'attacker-known');
+    writeFileSync(planted, REAL_SECRET, { mode: 0o600 });
+    symlinkSync(planted, secretPath);
+
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const base = `http://127.0.0.1:${handle.port}`;
+
+    // Even signing with the exact planted content is rejected: the leaf is a
+    // symlink, so its value is never loaded as the HMAC key.
+    const forged = await fetch(`${base}/api/sessions`, {
+      headers: trustedHostHeaders('GET', '/api/sessions', handle.port, REAL_SECRET),
+    });
+    expect(forged.status).toBe(401);
+    // The symlink target is untouched.
+    expect(readFileSync(planted, 'utf8')).toBe(REAL_SECRET);
+  });
+
+  it('fails closed (401) when the secret file has loose (0644) permissions', async () => {
+    if (process.platform === 'win32') return;
+    writeFileSync(secretPath, REAL_SECRET, { mode: 0o644 });
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const base = `http://127.0.0.1:${handle.port}`;
+
+    const res = await fetch(`${base}/api/sessions`, {
+      headers: trustedHostHeaders('GET', '/api/sessions', handle.port, REAL_SECRET),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('fails closed (401) when the secret is absent', async () => {
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const base = `http://127.0.0.1:${handle.port}`;
+
+    const res = await fetch(`${base}/api/sessions`, {
+      headers: trustedHostHeaders('GET', '/api/sessions', handle.port, REAL_SECRET),
+    });
+    expect(res.status).toBe(401);
   });
 });
 


### PR DESCRIPTION
优先级：P1（延续 #920 的同类安全收敛）

## 背景 / 根因

#920 已把 `loadDashboardSecret` / `loadOrCreateDashboardSecret` 收敛到严格的宿主凭证安全原语（`readSecureHostFileSync` / `withSecureHostParentSync`：强制 0600、`O_NOFOLLOW` 拒符号链接、属主校验、Linux 目录句柄锚定防祖先替换）。

但 `src/core/dashboard-ipc-server.ts` 的 `ipcAuthSecret()` 仍用**裸 `readFileSync`** 读同一份 `~/.botmux/.dashboard-secret`——跟随符号链接、不校验属主/权限/祖先。它是**每请求执行的活跃 HMAC 验证器**，守着约 96 条 daemon IPC 路由（含 mutation / close / slash 注入等），是全仓最后一处对该密钥的裸读。

暴露面其实比 #920 已修好的 `dashboard.ts` **更大**：`dashboard.ts` 在启动时把 `SECRET` 缓存一次（开机后再种符号链接无效），而 `ipcAuthSecret()` **每请求重读**（开机后种的符号链接照样生效）。能替换 `~/.botmux`（或其某级祖先目录）的本地攻击者，可植入指向已知内容的符号链接密钥，随后伪造 `X-Botmux-Cli-*` 头骗过 IPC 鉴权、驱动 daemon IPC。威胁模型与 #920 完全一致。

## 改动

- `ipcAuthSecret()` 改走 `loadDashboardSecret(dashboardSecretPath())`——与 dashboard / daemon 启动同一套严格读取：0600、`O_NOFOLLOW` 拒符号链接、属主校验、目录不可组/他人写。
- **fail-closed 行为保持不变**：不安全形态（符号链接 / 松权限 / 目录可写）返回 `null`（→ 无人能签 → 401），绝不跟随；缺失 / 空密钥仍返回 `null`。新增按 60s 节流的错误日志，让被植入 / 配错的凭证**可诊断**，而不是与「磁盘上根本没有密钥」无从区分（这是每请求路径，故节流防刷屏）。
- 测试注入 seam（`setIpcAuthSecret`）不变。

## 影响面

- **仅** daemon IPC 鉴权读密钥这一处（`dashboard-ipc-server.ts`）。`dashboard.ts` / CLI / daemon 启动早已走安全原语，不受影响。
- 跨平台：安全原语内部已按 win32 / Linux(procfs) / 其它 POSIX 分别处理；本改动只是复用它，无新增平台分支。
- 跨会话类型：IPC 路由对所有 CLI × 后端一致，收紧的是「读密钥」而非任何具体路由逻辑，不改变已鉴权请求的行为。

## 验证

- `pnpm build` 绿。
- `dashboard-ipc` + `dashboard-auth` 共 **228 测通过**（含 4 条新增真实磁盘读路径测试）。
- **补齐此前零覆盖的真实读分支**（既有 ipc 测试全部用 `setIpcAuthSecret` 注入，从不走磁盘读）：① 真实 0600 密钥可鉴权（错误 key 401）；② 符号链接叶子 fail-closed（401）且**不触碰** symlink 目标；③ 0644 松权限 fail-closed（401）；④ 密钥缺失 fail-closed（401）。
- **反向变异**：把 `ipcAuthSecret()` 还原成裸 `readFileSync` 后，符号链接 + 0644 两测立即失败（返回 200 而非 401），证明新测确实覆盖该分支、不是空转。

---
说明：这是 #920 review 中发现的同类漏点的独立 follow-up PR（#920 本身已合入、修得对，此处为其余下的一处）。属自动评审发起的初步修复，最终以维护者审阅为准。

🤖 Generated with [Claude Code](https://claude.com/claude-code)