### PR TITLE
fix(vc): 修复会议监听最终输出投递

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -654,7 +654,7 @@ const pendingRemoteWorkerCloses = new Map<string, {
   resolve: (result: RemoteWorkerCloseResult) => void;
 }>();
 
-export function setActiveSessionsRegistry(m: Map<string, DaemonSession>): void {
+export function setActiveSessionsRegistry(m: Map<string, DaemonSession> | undefined): void {
   activeSessionsRegistry = m;
 }
 
@@ -9240,7 +9240,7 @@ function setupWorkerHandlers(
     && sessionAnchorId(ds) === handlerAnchor
     && (
       !activeSessionsRegistry
-      || activeSessionsRegistry.get(sessionKey(handlerAnchor, handlerLarkAppId)) === ds
+      || activeSessionsRegistry.get(activeSessionKey(ds)) === ds
     );
   const ownsLifecycleMutation = (): boolean =>
     ownsWorkerSession() && !isSessionTransferring(ds);

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -103,9 +103,10 @@ import {
   getDaemonReplyCardUsageSnapshot,
   initWorkerPool,
   __testOnly_setupWorkerHandlers,
+  setActiveSessionsRegistry,
 } from '../src/core/worker-pool.js';
 import { MessageWithdrawnError } from '../src/im/lark/client.js';
-import type { DaemonSession } from '../src/core/types.js';
+import { activeSessionKey, type DaemonSession } from '../src/core/types.js';
 import type { WorkerToDaemon } from '../src/types.js';
 import { EventEmitter } from 'node:events';
 import { homedir, tmpdir } from 'node:os';
@@ -250,6 +251,7 @@ describe('Bridge final_output delivery (P2 retry)', () => {
   afterEach(async () => {
     const { __testOnly_closeSkillFeedbackStores } = await import('../src/services/skill-feedback-store.js');
     await __testOnly_closeSkillFeedbackStores();
+    setActiveSessionsRegistry(undefined);
     rmSync('/tmp/test-sessions', { recursive: true, force: true });
     clearMessageListenerRunPreviewStore();
     vi.useRealTimers();
@@ -1708,6 +1710,43 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect((await getSkillFeedbackStore('/tmp/test-sessions')).findDeliveryByPlatformMessage(
       'lark', ds.larkAppId, 'om_meeting_fallback',
     )).toBeUndefined();
+  });
+
+  it('delivers a listener-thread result when the receiver uses its dedicated active-session key', async () => {
+    const sessionReply = vi.fn(async () => 'om_vc_receiver_fallback');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+    ds.scope = 'chat';
+    ds.session.scope = 'chat';
+    ds.session.vcMeetingReceiver = {
+      listenerAppId: 'listener-app',
+      meetingId: 'meeting-1',
+      memberId: 'member-1',
+      memberEpoch: 1,
+    };
+    seedReceiverReceipt('listener_thread');
+    setActiveSessionsRegistry(new Map([[activeSessionKey(ds), ds]]));
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', {
+      ...listenerFinalOutputMsg(),
+      sessionId: ds.session.sessionId,
+      turnId: 'delivery-stable-key',
+      dispatchAttempt: 1,
+    } satisfies Extract<WorkerToDaemon, { type: 'final_output' }>);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    expect(listVcMeetingListenerMessageIds('/tmp/test-sessions', {
+      listenerAppId: 'listener-app',
+      meetingId: 'meeting-1',
+      targetChatId: ds.chatId,
+    })).toEqual(['om_vc_receiver_fallback']);
   });
 
   it('treats a valid skip decision as a successful no-message outcome', async () => {


### PR DESCRIPTION
## 问题

会议 receiver 使用专用的 `activeSessionKey(ds)` 注册到 `activeSessions`，但 worker 的最终输出生命周期所有权校验仍按可见聊天锚点查询。

因此 receiver 已正常存在、Agent 已产生 `final_output` 时，校验会错误认为会话所有权已变化，并在调用飞书发送接口前放弃最终输出。

## 修复

所有权校验统一使用会话实际注册键 `activeSessionKey(ds)`。

## 回归测试

新增会议 receiver 回归：当 `activeSessions` 使用 `vc-receiver:<sessionId>` 专用 key 注册时，`listener_thread` 最终输出仍成功发送并写入监听群消息索引。

已执行：

```bash
corepack pnpm test -- --run \
  test/bridge-final-output-retry.test.ts \
  test/vc-meeting-delivery-receiver.test.ts \
  test/vc-meeting-send-policy.test.ts \
  test/vc-meeting-im-reply.test.ts
# 125 passed

PATH=/tmp/botmux-upstream-tools-20260819:$PATH corepack pnpm build
# passed