### PR TITLE
fix(vc): 隔离监听群人工追问输出协议

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -12032,7 +12032,24 @@ function deliverFinalOutput(
           }
         : undefined;
       let visibleAssistantText = msg.content;
-      if (!imOrigin
+      // A listener-chat @mention is a direct human IM turn. Its normal sink is
+      // already plain text, but an existing receiver context may have taught
+      // the model the automatic delivery's decision envelope. Do not expose
+      // that internal protocol to the human; recover its user-visible content
+      // when the stale envelope is valid. (The trusted per-turn instruction
+      // added by the daemon prevents new turns from producing it.)
+      if (imOrigin) {
+        const directImControlledOutput = parseVcMeetingListenerOutput(msg.content);
+        if (directImControlledOutput.ok) {
+          visibleAssistantText = directImControlledOutput.decision === 'publish'
+            ? directImControlledOutput.content
+            : '本次没有生成可展示的答复，请重新提问。';
+          logger.warn(
+            `[${t}] VC listener IM reply recovered stale control envelope `
+            + `turn=${msg.turnId.substring(0, 8)} decision=${directImControlledOutput.decision}`,
+          );
+        }
+      } else if (!imOrigin
         && listenerOutputOwner
         && msg.dispatchAttempt !== undefined
         && listenerOutputProtocol === 'decision_v1') {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -615,6 +615,7 @@ import {
   type VcMeetingImRoutingCandidate,
   type VcMeetingSealedReceiverSessionBinding,
 } from './services/vc-meeting-im-routing.js';
+import { VC_MEETING_HUMAN_IM_OUTPUT_CONTRACT } from './services/vc-meeting-listener-output-protocol.js';
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -17097,7 +17098,10 @@ async function startInitialPassthroughSession(args: {
 
 
 function vcMeetingApplicationContext(ctx: RoutingContext): string {
-  return (ctx.vcMeetingContextLifecycle === 'sealed'
+  return (ctx.vcMeetingImTurnOrigin
+    ? VC_MEETING_HUMAN_IM_OUTPUT_CONTRACT
+    : '')
+    + (ctx.vcMeetingContextLifecycle === 'sealed'
     ? '[会议上下文状态] 本轮正在复用一场已结束会议的专属会话；这是会后追问。可以基于既有会议上下文回答，但不得声称会议仍在进行，也不要尝试会中文本或语音动作。\n'
     : '')
     + (ctx.vcMeetingContextMayLag

--- a/src/services/vc-meeting-listener-output-protocol.ts
+++ b/src/services/vc-meeting-listener-output-protocol.ts
@@ -17,6 +17,20 @@ export const VC_MEETING_LISTENER_OUTPUT_CONTRACT =
   + 'A correction to previously stated information (including time, owner, scope, status, or conclusion) '
   + 'is new information and must not be suppressed merely because most surrounding text is unchanged.';
 
+/**
+ * Trusted per-turn override for a human question sent in the listener chat.
+ *
+ * Automatic meeting deliveries and listener-chat questions share one durable
+ * receiver session so the latter can use the meeting context. The automatic
+ * delivery protocol above must therefore be explicitly disabled for an IM
+ * follow-up; otherwise a model can carry its previous JSON transport contract
+ * into a normal human-facing answer.
+ */
+export const VC_MEETING_HUMAN_IM_OUTPUT_CONTRACT =
+  '[Meeting listener-chat direct question] This turn is a direct human question, not an automatic meeting delivery. '
+  + 'Answer the person in natural-language Markdown only. Do not return, quote, or explain '
+  + 'the internal {"decision":"skip"} / {"decision":"publish","content":"..."} control JSON.\n';
+
 export const VC_MEETING_CONTROLLED_OUTPUT_INSTRUCTION_VERSION = 'meeting-consumer-v2' as const;
 
 /** Frozen on the delivery receipt so a pre-upgrade v1 retry may still emit its

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -1596,6 +1596,71 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(providerUuid).toBeTruthy();
   });
 
+  it('unwraps a stale automatic meeting envelope before replying to a human listener-chat question', async () => {
+    const sessionReply = vi.fn(async () => 'om_vc_direct_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+    ds.scope = 'chat';
+    ds.session.scope = 'chat';
+    ds.session.vcMeetingReceiver = {
+      listenerAppId: 'listener-app', meetingId: 'meeting-im-envelope',
+      memberId: 'member-im-envelope', memberEpoch: 1,
+    };
+    const origin = {
+      listenerAppId: 'listener-app', meetingId: 'meeting-im-envelope', memberId: 'member-im-envelope',
+      memberEpoch: 1, agentAppId: 'app_test', ownerBootId: 'owner-boot', ownerEpoch: 1,
+      membershipGeneration: 1, sinkOwnerGeneration: 1,
+      receiverSessionId: ds.session.sessionId, larkMessageId: 'om_human_envelope',
+    };
+    expect(applyVcMeetingMemberProjection('/tmp/test-sessions', {
+      listenerAppId: origin.listenerAppId,
+      meetingId: origin.meetingId,
+      memberId: origin.memberId,
+      memberEpoch: origin.memberEpoch,
+      agentAppId: origin.agentAppId,
+      ownerBootId: origin.ownerBootId,
+      ownerEpoch: origin.ownerEpoch,
+      role: 'minutes',
+      membershipGeneration: origin.membershipGeneration,
+      status: 'active',
+      responseMode: 'silent',
+      capabilities: ['meeting.read'],
+      ownedSinks: [],
+      sinkOwnerGeneration: origin.sinkOwnerGeneration,
+      joinedAtIngestSeq: 0,
+      receiverSessionId: origin.receiverSessionId,
+      outputChatId: ds.chatId,
+    })).toMatchObject({ ok: true });
+    ds.session.vcMeetingImTurnOrigins = { om_human_envelope: origin };
+    const msg = {
+      ...finalOutputMsg(),
+      content: JSON.stringify({
+        decision: 'publish',
+        content: '请根据当前已启用的能力处理会议相关请求。',
+      }),
+      turnId: 'om_human_envelope',
+      lastUuid: 'bridge-human-envelope',
+    };
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+
+    __testOnly_deliverFinalOutput(ds, msg, 'tag', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    const cardJson = sessionReply.mock.calls[0][1] as string;
+    expect(cardJson).toContain('请根据当前已启用的能力处理会议相关请求。');
+    expect(cardJson).not.toContain('&quot;decision&quot;');
+    expect(cardJson).not.toContain('publish');
+    expect(sessionReply.mock.calls[0][5]).toMatchObject({
+      quoteMessageId: 'om_human_envelope',
+    });
+  });
+
   it('blocks the plain fallback when VC IM authority expires during a withdrawn quote request', async () => {
     let plainFallbackCalls = 0;
     const sessionReply = vi.fn(async (...args: any[]) => {

--- a/test/vc-meeting-listener-output-protocol.test.ts
+++ b/test/vc-meeting-listener-output-protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   parseVcMeetingListenerOutput,
+  VC_MEETING_HUMAN_IM_OUTPUT_CONTRACT,
   VC_MEETING_LISTENER_OUTPUT_CONTRACT,
   vcMeetingListenerOutputProtocolForInstructionVersion,
 } from '../src/services/vc-meeting-listener-output-protocol.js';
@@ -44,6 +45,11 @@ describe('VC meeting listener output protocol', () => {
     expect(VC_MEETING_LISTENER_OUTPUT_CONTRACT).toContain('time, owner, scope, status, or conclusion');
     expect(VC_MEETING_LISTENER_OUTPUT_CONTRACT).not.toContain('fingerprint');
     expect(VC_MEETING_LISTENER_OUTPUT_CONTRACT).not.toContain('debounce');
+  });
+
+  it('keeps direct listener-chat questions out of the automatic JSON transport protocol', () => {
+    expect(VC_MEETING_HUMAN_IM_OUTPUT_CONTRACT).toContain('direct human question');
+    expect(VC_MEETING_HUMAN_IM_OUTPUT_CONTRACT).toContain('natural-language Markdown only');
   });
 
   it('keeps pre-upgrade deliveries on plain output while enabling the v2 contract', () => {


### PR DESCRIPTION
## 问题

自动会议投递会要求模型使用内部 JSON 协议，供 Botmux 判断是否要向监听群发布增量：

```json
{"decision":"skip"}
{"decision":"publish","content":"..."}
```

监听群中的人工 `@Bot` 会路由到同一个会议 receiver session，以复用已有会议上下文。

旧实现没有在人工追问回合显式覆盖自动投递的 JSON 输出协议。因此模型可能沿用上一轮自动纪要的格式，最终被作为人工回复原样渲染到监听群，暴露内部控制 JSON。

## 修复

1. 为监听群人工 `@Bot` 追问注入可信的自然语言输出约束，明确禁止输出或解释内部 `decision/publish` JSON；
2. 增加发送端兜底：若已有会话上下文仍导致人工回复返回合法的 `{"decision":"publish","content":"..."}`，仅向用户展示其中的 `content`；
3. 自动会议投递保持原有严格行为：仍要求并解析 `skip/publish` JSON 协议，不改变自动纪要的投递规则。

## 回归测试

新增覆盖：

- 监听群人工追问具有独立的自然语言输出协议；
- 人工追问错误继承自动投递的 `publish` JSON 时，只渲染 `content` 正文，不显示控制 JSON；
- 会议投递、监听群回复和受控发送策略仍保持原有行为。

已执行：

```bash
corepack pnpm test -- --run \
  test/vc-meeting-listener-output-protocol.test.ts \
  test/bridge-final-output-retry.test.ts \
  test/vc-meeting-delivery-receiver.test.ts \
  test/vc-meeting-send-policy.test.ts \
  test/vc-meeting-im-reply.test.ts
# 131 passed

corepack pnpm build
# passed
```

## 影响范围

仅影响带有可信 `vcMeetingImTurnOrigin` 的监听群人工追问回合。

- 自动会议投递仍使用原有 `skip/publish` 协议；
- 普通飞书会话不受影响；
- 不改变会议权限、事件订阅或受控会议动作的授权规则。