### PR TITLE
fix(test): P1-3 慢 HOME 复现改用 env 忙等，兼容 #920 凭证尺寸上限

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1854,6 +1854,35 @@ let viewToken = randomBytes(32).toString('base64url');
 const DASHBOARD_TOKEN_PATH = join(homedir(), '.botmux', '.dashboard-token');
 const DASHBOARD_SECRET_PATH = join(homedir(), '.botmux', '.dashboard-secret');
 
+// Test-only seam (inert in production): widen the SYNCHRONOUS `.dashboard-secret`
+// read that happens twice inside the terminal WS handshake — once at
+// `verifyClient`, once at the post-upgrade `connection` re-check — so the
+// integration test can land a capability's expiry inside that gap and prove the
+// second check still fail-closes it (see worker-terminal-read-auth P1-3). A real
+// slow HOME (NFS/slow disk) produces the same window in production. The old test
+// bloated the secret file with 32MB of whitespace to force this delay, which is
+// incompatible with #920's strict 0600 host-authority reader (its 256-byte cap
+// rejects a padded file); this env-gated busy-wait reproduces the timing without
+// an oversized or otherwise unsafe credential file. Only ever set by that test.
+const HANDSHAKE_SECRET_READ_DELAY_MS = Number.isFinite(
+  Number(process.env.BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS),
+)
+  ? Math.max(0, Number(process.env.BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS))
+  : 0;
+
+/** Read the dashboard secret on the terminal WS-handshake path. Identical to
+ *  {@link loadDashboardSecret} in production; adds a bounded synchronous delay
+ *  ONLY when the test seam env var is set, to make the handshake read window
+ *  observable without an oversized secret file. */
+function loadHandshakeSecret(): string | null {
+  const secret = loadDashboardSecret(DASHBOARD_SECRET_PATH);
+  if (HANDSHAKE_SECRET_READ_DELAY_MS > 0) {
+    const until = Date.now() + HANDSHAKE_SECRET_READ_DELAY_MS;
+    while (Date.now() < until) { /* busy-wait: mimic a slow synchronous fs read */ }
+  }
+  return secret;
+}
+
 /** Re-derive the stable write (operate) token from the host-only dashboard
  *  secret so a restarted worker mints the SAME token — keeping already-issued
  *  「操作链接」/write links valid across restarts. Falls back to the random
@@ -1923,7 +1952,7 @@ function resolveTerminalAccessForReq(req: IncomingMessage, url: URL): WorkerTerm
   let viewGrantUser: string | undefined;
   let viewGrantExpiresAt: number | undefined;
   if (!viewTokenMatches && looksLikeTerminalControlGrant(viewParam) && sessionId) {
-    const secret = loadDashboardSecret(DASHBOARD_SECRET_PATH);
+    const secret = loadHandshakeSecret();
     if (secret && verifyTerminalViewForward(secret, viewParam, req.headers[TERMINAL_VIEW_FORWARD_HEADER])) {
       const viewGrant = verifyTerminalControlGrant(secret, viewParam, sessionId);
       if (viewGrant.ok
@@ -1951,7 +1980,7 @@ function resolveTerminalAccessForReq(req: IncomingMessage, url: URL): WorkerTerm
   // second synchronous secret-file read on that hot path; only the central
   // front proxy supplies this internal header.
   if (req.headers['x-botmux-terminal-control'] === undefined) return legacy;
-  const secret = loadDashboardSecret(DASHBOARD_SECRET_PATH);
+  const secret = loadHandshakeSecret();
   if (!secret || !sessionId) return legacy;
   const grant = verifyTerminalControlGrant(
     secret,

--- a/test/worker-terminal-read-auth.integration.test.ts
+++ b/test/worker-terminal-read-auth.integration.test.ts
@@ -600,9 +600,12 @@ setInterval(() => {}, 1_000);
   // 过期的窥屏通道，中央前门再怎么撤销也够不着它。
   //
   // 这条缝的宽度就等于那次同步文件读：本地 SSD 上 ~0.1ms，$HOME 挂在慢盘/NFS 上就是
-  // 几十上百毫秒（backlog P1-10 记的正是这种 HOME）。测试把 secret 文件用空白撑大来
-  // 复现慢 HOME 的时序：loadDashboardSecret 读完就 trim，secret 值一个字节没变，生产
-  // 代码一行没动，只是把这条本来就存在的缝拉宽到可稳定观测。
+  // 几十上百毫秒（backlog P1-10 记的正是这种 HOME）。以前靠把 secret 文件用 32MB 空白
+  // 撑大来复现慢 HOME 的时序，但 #920 给宿主凭证读取加了严格 0600 + 256 字节上限，撑大的
+  // 文件会被直接判「大小异常」拒读——于是改用 worker 侧的测试专用 env
+  // （BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS）在握手路径的那次 secret 读后加一段有界
+  // 忙等：secret 值一个字节没变、凭证文件仍是合法的小文件，只是把这条本来就存在的缝
+  // 稳定拉宽到可观测（生产不设该 env，行为不变）。
   it('P1-3: a view capability that dies inside the WS handshake is refused at the connection re-check', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-ws-handshake-race-'));
     tempDirs.add(root);
@@ -611,11 +614,15 @@ setInterval(() => {}, 1_000);
     const secret = 'integration-ws-handshake-race-secret';
     const botmuxDir = join(root, '.botmux');
     mkdirSync(botmuxDir, { recursive: true });
+    // 合法的小凭证文件（0600），满足 #920 的严格宿主凭证读取；握手读窗口由下面的
+    // 测试专用 env 拉宽，而不是靠撑大文件。
     writeFileSync(
       join(botmuxDir, '.dashboard-secret'),
-      `${secret}${' '.repeat(32 * 1024 * 1024)}`,
+      secret,
       { mode: 0o600 },
     );
+    // 握手路径每次读 secret 后忙等这么久，复现慢 HOME 的读窗口（> P1-3 需要的 20ms 下限）。
+    const handshakeReadDelayMs = 40;
 
     // 让 scrollback 非空。socket 一旦被登记，worker 会立刻把这段历史种子推过去，于是
     // 「有没有被登记」在客户端侧是直接可观测的事实，不用去断言 worker 的内部集合。
@@ -640,6 +647,7 @@ setInterval(() => {}, 1_000);
         BOTMUX_SESSION_ID: sessionId,
         LARK_APP_ID: 'app_ws_race',
         LARK_APP_SECRET: 'secret',
+        BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS: String(handshakeReadDelayMs),
       },
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     });


### PR DESCRIPTION
优先级：P1（master build 当前红灯，本 PR 转绿）

## 根因：两个各自绿的 PR 合并后交互变红

master 的 `build` check 目前是 failure，根因是 **#933 与 #920 的交互**：

- **#933**（Agent Workbench）的 `worker-terminal-read-auth` **P1-3** 用例，为复现「慢 HOME 下 `verifyClient` → `connection` 之间视图能力过期」的握手竞态，把 `~/.botmux/.dashboard-secret` 写成 `secret + 32MB 空白`，靠撑大文件来拉宽那次**同步** secret 读的窗口。
- **#920**（已合）给 `loadDashboardSecret` → `readSecureHostFileSync` 加了严格 **0600 + 256 字节上限**；32MB 文件在读之前就被 `assertSecureFileStats` 判「大小异常」抛错。
- 撞点：worker 启动 `refreshTerminalWriteToken()` → `loadDashboardSecret` → 抛错 → worker 在 `ready` 前崩 → P1-3 fail → `build` 红。两个 PR 单独都绿，合到一起才红。

尺寸上限本身是对的（密钥不该几十 MB），所以**改测试的复现手法，而不是动 cap**。

## 改动

- `src/worker.ts`：新增测试专用 env `BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS`（默认不设=0）。握手路径 `resolveTerminalAccessForReq` 的两处 secret 读经 `loadHandshakeSecret()` 包装，仅在该 env>0 时读后忙等指定毫秒，复现慢同步读窗口。
  - **生产完全等价**：env 不设时 `loadHandshakeSecret` 就是 `loadDashboardSecret`，逐字节一致、零延迟；启动 `refreshTerminal*Token` 路径不包装，不拖慢 worker 启动。
  - 用**忙等**而非 `setTimeout`：被测竞态正来自「同步读阻塞事件循环、握手不可中断」，忙等忠实复现同步阻塞；`setTimeout` 会让出事件循环，复现不出该窗口。
- `test/worker-terminal-read-auth.integration.test.ts`：P1-3 改为写**合法的小 0600 凭证文件** + 设 env=40ms，不再撑大文件；注释同步更新。

## 影响面

- 仅测试路径 + 一个**默认关闭**的 worker 测试 env；不改任何生产行为，不动 #920 的凭证尺寸上限。
- 不涉及跨平台/跨 CLI/跨后端差异（改的是 worker 通用握手读密钥的测试可观测性）。

## 验证

- `pnpm build` 绿。
- 全套 `worker-terminal-read-auth` **4 测通过**——其中 3 条不设该 env，证明 `loadHandshakeSecret` 在生产 env 下与原实现等价、无副作用。
- **反向变异**：把 `connection` 二次校验还原成「信任 verifyClient 快照」的历史 bug 后，P1-3 立即出现 `alive` socket（一条活过自己能力有效期的窥屏连接）而失败；还原修复后通过——证明改写后的用例仍**真实压住**该竞态，不是放宽断言蒙混变绿。

---
说明：这是 #920 review 过程中，为让其 follow-up PR #937 的 CI 转绿而发现的 master 既有红灯的独立修复（属自动评审发起的初步修复，最终以维护者审阅为准）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)