### PR TITLE
fix(mcp): 网关 socket 按 session 确定化 + relay 断线重连，daemon 重启不再杀持久 pane

### DIFF
--- a/src/core/plugins/mcp/gateway.ts
+++ b/src/core/plugins/mcp/gateway.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto';
-import { createConnection } from 'node:net';
+import { createConnection, type Socket as NetSocket } from 'node:net';
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport, getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
@@ -781,13 +782,12 @@ export async function runMcpGateway(): Promise<void> {
   const env = resolveGatewayEnvironment();
   const socketPath = env[MCP_GATEWAY_SOCKET_ENV]?.trim();
   if (socketPath) {
-    let authToken: string;
     try {
-      authToken = readMcpGatewayAuthToken(socketPath);
+      readMcpGatewayAuthToken(socketPath);
     } catch {
       throw new Error('Botmux MCP Gateway authentication token is unavailable; restart this Botmux session');
     }
-    await relayMcpGateway(socketPath, authToken);
+    await runReconnectingMcpRelay(socketPath, { env });
     return;
   }
   if (env[MCP_GATEWAY_REQUIRED_ENV] === '1') {
@@ -813,40 +813,294 @@ export async function runMcpGateway(): Promise<void> {
   await connectPromise;
 }
 
-/** Byte-for-byte stdio relay from a CLI-native MCP launcher to the trusted
- * worker-side Gateway. No plugin metadata or credentials are loaded here. */
-export async function relayMcpGateway(
-  socketPath: string,
-  authToken: string,
-  input: NodeJS.ReadableStream = process.stdin,
-  output: NodeJS.WritableStream = process.stdout,
-): Promise<void> {
+/** Single connection attempt: connect + authenticate. The caller owns the
+ * socket lifecycle after this resolves. */
+async function connectMcpGatewaySocket(socketPath: string): Promise<NetSocket> {
+  // The token is re-read on EVERY attempt: the replacement host rotates it
+  // (atomically) before listening, so a reconnecting relay must never pin the
+  // token it read at process start.
+  const authToken = readMcpGatewayAuthToken(socketPath);
   const socket = createConnection({ path: socketPath });
   socket.setNoDelay(true);
-  await new Promise<void>((resolve, reject) => {
-    const onConnect = () => {
-      socket.off('error', onInitialError);
-      resolve();
-    };
-    const onInitialError = (error: Error) => {
-      socket.off('connect', onConnect);
-      reject(new Error(`Botmux MCP Gateway relay connection failed: ${error.message}`));
-    };
-    socket.once('connect', onConnect);
-    socket.once('error', onInitialError);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onConnect = () => {
+        socket.off('error', onInitialError);
+        resolve();
+      };
+      const onInitialError = (error: Error) => {
+        socket.off('connect', onConnect);
+        reject(new Error(`Botmux MCP Gateway relay connection failed: ${error.message}`));
+      };
+      socket.once('connect', onConnect);
+      socket.once('error', onInitialError);
+    });
+    await sendMcpGatewayHandshake(socket, authToken);
+    return socket;
+  } catch (error) {
+    socket.destroy();
+    throw error;
+  }
+}
+
+interface RelayTuning {
+  /** First-ever connect must succeed within this window (the host normally
+   *  exists before the CLI spawns, so this only smooths startup races). */
+  initialBudgetMs: number;
+  /** After a disconnect the relay retries for this long before exiting. The
+   *  default is UNBOUNDED: the CLI owns the relay's lifetime (stdin close →
+   *  exit), the reattach decision in the worker assumes a surviving pane's
+   *  relay is still alive, and a capped-backoff unix connect attempt every few
+   *  seconds is free — whereas giving up would silently strand the pane's MCP
+   *  client after a long daemon outage (most CLIs never restart a dead MCP
+   *  server mid-session). Env override exists for tests. */
+  reconnectBudgetMs: number;
+  /** First retry delay; doubles per attempt, capped at maxBackoffMs. */
+  backoffMs: number;
+  maxBackoffMs: number;
+}
+
+function relayTuning(env: NodeJS.ProcessEnv): RelayTuning {
+  const num = (key: string, fallback: number): number => {
+    const parsed = Number(env[key]);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  };
+  const backoffMs = num('BOTMUX_MCP_RELAY_BACKOFF_MS', 250);
+  return {
+    initialBudgetMs: num('BOTMUX_MCP_RELAY_INITIAL_BUDGET_MS', 15_000),
+    reconnectBudgetMs: num('BOTMUX_MCP_RELAY_RECONNECT_BUDGET_MS', Number.POSITIVE_INFINITY),
+    backoffMs,
+    maxBackoffMs: Math.max(backoffMs, num('BOTMUX_MCP_RELAY_MAX_BACKOFF_MS', 5_000)),
+  };
+}
+
+/** Cap on client lines buffered while the Gateway is unreachable. MCP traffic
+ *  is small JSON messages; hitting this means something is badly wrong and the
+ *  relay should die visibly rather than balloon. */
+const RELAY_OUTAGE_BUFFER_MAX_BYTES = 8 * 1024 * 1024;
+
+/** Newline-framed stdio relay from a CLI-native MCP launcher to the trusted
+ * worker-side Gateway that SURVIVES host replacement. No plugin metadata or
+ * credentials are loaded here.
+ *
+ * Why not a byte pipe: the worker-side Gateway host dies with the worker on
+ * every daemon restart/upgrade, and the CLI process (in a persistent tmux/zmx
+ * pane) lives on with this relay as its MCP server. A single-shot pipe forced
+ * the worker to kill the surviving pane ("cold-resume") just to refresh the
+ * MCP plumbing — interrupting whatever turn the CLI was executing. Instead the
+ * relay:
+ *   1. frames both directions as newline-delimited JSON (the MCP stdio
+ *      framing), buffering client lines while the Gateway is unreachable;
+ *   2. reconnects to the SAME deterministic socket path with backoff, re-reads
+ *      the rotated auth token per attempt;
+ *   3. replays the captured `initialize` request + `notifications/initialized`
+ *      on the fresh Gateway connection (each host connection is a brand-new
+ *      MCP server that expects the handshake), swallowing the replayed
+ *      response iff the client already saw the original one — the client
+ *      never re-initializes and must not receive a duplicate response id.
+ * Requests in flight across a disconnect lose their responses; the client's
+ * own MCP timeout surfaces those as failed tool calls, which is the honest
+ * outcome. */
+export async function runReconnectingMcpRelay(
+  socketPath: string,
+  opts: {
+    input?: NodeJS.ReadableStream;
+    output?: NodeJS.WritableStream;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<void> {
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const tuning = relayTuning(opts.env ?? process.env);
+
+  let socket: NetSocket | null = null;
+  let connected = false;
+  let everConnected = false;
+  let inputEnded = false;
+  let settled = false;
+  const destroySocket = (): void => { socket?.destroy(); };
+
+  // Client → server lines held while the Gateway is unreachable (or while an
+  // initialize replay is in flight, to preserve ordering).
+  const pendingClientLines: string[] = [];
+  let pendingBytes = 0;
+
+  // Captured MCP handshake for replay onto fresh Gateway connections.
+  let initializeLine: string | undefined;
+  let initializeId: string | number | null | undefined;
+  let initializeSentToServer = false;
+  let initializeResponseForwarded = false;
+  let initializedNotificationLine: string | undefined;
+
+  // Replay-in-progress state for the current connection.
+  let replayAwaitingResponse = false;
+
+  let finish!: () => void;
+  let fatal!: (error: Error) => void;
+  const done = new Promise<void>((resolve, reject) => {
+    finish = () => { if (!settled) { settled = true; resolve(); } };
+    fatal = (error: Error) => { if (!settled) { settled = true; reject(error); } };
   });
 
-  try {
-    await sendMcpGatewayHandshake(socket, authToken);
-    input.pipe(socket);
-    socket.pipe(output, { end: false });
-    await new Promise<void>((resolve, reject) => {
-      socket.once('close', resolve);
-      socket.once('error', reject);
+  const tryParse = (line: string): any => {
+    try { return JSON.parse(line); } catch { return undefined; }
+  };
+  const idEquals = (a: unknown, b: unknown): boolean => a !== undefined && b !== undefined && a === b;
+
+  const writeServerLine = (line: string): void => {
+    socket?.write(`${line}\n`);
+    const parsed = tryParse(line);
+    if (parsed?.method === 'initialize' && idEquals(parsed.id, initializeId)) {
+      initializeSentToServer = true;
+    }
+  };
+
+  const bufferClientLine = (line: string): void => {
+    pendingBytes += Buffer.byteLength(line) + 1;
+    if (pendingBytes > RELAY_OUTAGE_BUFFER_MAX_BYTES) {
+      fatal(new Error('Botmux MCP Gateway relay buffered too much during a Gateway outage'));
+      return;
+    }
+    pendingClientLines.push(line);
+  };
+
+  const flushPendingClientLines = (): void => {
+    while (pendingClientLines.length > 0 && connected && !replayAwaitingResponse) {
+      const line = pendingClientLines.shift()!;
+      pendingBytes -= Buffer.byteLength(line) + 1;
+      writeServerLine(line);
+    }
+  };
+
+  const onClientLine = (line: string): void => {
+    if (line.trim().length === 0) return;
+    const parsed = tryParse(line);
+    if (parsed?.method === 'initialize' && parsed.id !== undefined && initializeLine === undefined) {
+      initializeLine = line;
+      initializeId = parsed.id;
+    } else if (parsed?.method === 'notifications/initialized') {
+      initializedNotificationLine = line;
+    }
+    if (connected && !replayAwaitingResponse) writeServerLine(line);
+    else bufferClientLine(line);
+  };
+
+  const onServerLine = (line: string): void => {
+    if (line.trim().length === 0) return;
+    const parsed = tryParse(line);
+    const isInitializeResponse = parsed !== undefined
+      && parsed.method === undefined
+      && idEquals(parsed.id, initializeId);
+    if (replayAwaitingResponse && isInitializeResponse) {
+      replayAwaitingResponse = false;
+      // Forward the replayed response only when the client never saw the
+      // original (disconnect raced the first response); otherwise a duplicate
+      // response id would corrupt the client's MCP session.
+      if (!initializeResponseForwarded) {
+        initializeResponseForwarded = true;
+        output.write(`${line}\n`);
+      }
+      if (initializedNotificationLine !== undefined) writeServerLine(initializedNotificationLine);
+      flushPendingClientLines();
+      return;
+    }
+    if (isInitializeResponse) initializeResponseForwarded = true;
+    output.write(`${line}\n`);
+  };
+
+  const attachSocket = (fresh: NetSocket): void => {
+    socket = fresh;
+    connected = true;
+    everConnected = true;
+    const decoder = new StringDecoder('utf8');
+    let tail = '';
+    fresh.on('data', (chunk: Buffer) => {
+      tail += decoder.write(chunk);
+      for (;;) {
+        const newline = tail.indexOf('\n');
+        if (newline < 0) break;
+        const line = tail.slice(0, newline).replace(/\r$/, '');
+        tail = tail.slice(newline + 1);
+        onServerLine(line);
+      }
     });
+    fresh.on('error', () => { /* surfaced via 'close' */ });
+    fresh.once('close', () => {
+      if (socket !== fresh) return;
+      socket = null;
+      connected = false;
+      replayAwaitingResponse = false;
+      if (inputEnded || settled) {
+        finish();
+        return;
+      }
+      void reconnectLoop(false);
+    });
+    if (initializeSentToServer && initializeLine !== undefined) {
+      // Fresh Gateway connection = fresh MCP server: replay the handshake the
+      // client already performed. Pending client lines stay queued until the
+      // replayed response arrives so the server never sees requests
+      // pre-initialize.
+      replayAwaitingResponse = true;
+      fresh.write(`${initializeLine}\n`);
+    } else {
+      flushPendingClientLines();
+    }
+  };
+
+  const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+  const reconnectLoop = async (initial: boolean): Promise<void> => {
+    const budgetMs = initial && !everConnected ? tuning.initialBudgetMs : tuning.reconnectBudgetMs;
+    const startedAt = Date.now();
+    let delayMs = tuning.backoffMs;
+    for (;;) {
+      if (inputEnded || settled) { finish(); return; }
+      try {
+        attachSocket(await connectMcpGatewaySocket(socketPath));
+        return;
+      } catch (error) {
+        if (Date.now() - startedAt + delayMs > budgetMs) {
+          fatal(new Error(
+            `Botmux MCP Gateway unreachable for ${Math.round(budgetMs / 1000)}s `
+            + `(${error instanceof Error ? error.message : String(error)}); giving up`,
+          ));
+          return;
+        }
+        await sleep(delayMs);
+        delayMs = Math.min(delayMs * 2, tuning.maxBackoffMs);
+      }
+    }
+  };
+
+  const inputDecoder = new StringDecoder('utf8');
+  let inputTail = '';
+  input.on('data', (chunk: Buffer | string) => {
+    inputTail += typeof chunk === 'string' ? chunk : inputDecoder.write(chunk);
+    for (;;) {
+      const newline = inputTail.indexOf('\n');
+      if (newline < 0) break;
+      const line = inputTail.slice(0, newline).replace(/\r$/, '');
+      inputTail = inputTail.slice(newline + 1);
+      onClientLine(line);
+    }
+  });
+  input.once('end', () => {
+    inputEnded = true;
+    if (socket) socket.destroy();
+    else finish();
+  });
+  input.once('error', () => {
+    inputEnded = true;
+    if (socket) socket.destroy();
+    else finish();
+  });
+  input.resume?.();
+
+  await reconnectLoop(true);
+  try {
+    await done;
   } finally {
-    input.unpipe(socket);
-    socket.unpipe(output);
-    socket.destroy();
+    destroySocket();
   }
 }

--- a/src/core/plugins/mcp/host.ts
+++ b/src/core/plugins/mcp/host.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, lstatSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer, type Server as NetServer, type Socket } from 'node:net';
@@ -26,17 +26,69 @@ export function sessionMcpGatewayPathRegex(
   return `^${escapeForRegex(root)}/bmcp-${uid}-[^/]+(?:/|$)`;
 }
 
-function gatewaySocketDir(sessionId: string, dataDir: string): string {
+/** Deterministic per-session Gateway socket directory.
+ *
+ * The name is a pure function of (dataDir, sessionId) — NO random component —
+ * so a replacement worker (daemon restart / upgrade) re-serves the socket at
+ * the exact path a surviving persistent pane's relay already holds in its
+ * environment, and the relay can simply reconnect instead of the worker having
+ * to kill the pane and cold-resume the CLI.
+ *
+ * Stays under tmpdir (not dataDir) to keep the Unix socket below macOS's short
+ * sun_path limit, and keeps the `bmcp-<uid>-` prefix so the existing Seatbelt
+ * deny regex (sessionMcpGatewayPathRegex) covers it unchanged. The predictable
+ * name is safe because ensurePrivateGatewayDir fails closed unless the
+ * directory is a real 0700 directory owned by this uid — a squatter can only
+ * DoS session startup, never observe traffic (connections still require the
+ * rotating auth token). */
+export function sessionMcpGatewaySocketDir(sessionId: string, dataDir: string): string {
   const uid = process.getuid?.() ?? 0;
   const sessionKey = createHash('sha256')
     .update(dataDir)
     .update('\0')
     .update(sessionId)
     .digest('hex')
-    .slice(0, 8);
-  // mkdtemp is atomic, avoids a predictable shared parent under /tmp, and
-  // keeps the resulting Unix socket below macOS's short sun_path limit.
-  return mkdtempSync(join(tmpdir(), `bmcp-${uid}-${sessionKey}-`));
+    .slice(0, 16);
+  return join(tmpdir(), `bmcp-${uid}-${sessionKey}`);
+}
+
+/** Deterministic per-session Gateway socket path (see sessionMcpGatewaySocketDir). */
+export function sessionMcpGatewaySocketPath(sessionId: string, dataDir: string): string {
+  return join(sessionMcpGatewaySocketDir(sessionId, dataDir), 'g.sock');
+}
+
+/** Create-or-verify the deterministic socket directory. Fail closed on
+ *  anything that is not a 0700 directory owned by this uid: a symlink or a
+ *  foreign-owned squat must abort session startup rather than let the Gateway
+ *  serve (or the token be written) through an attacker-controlled path. */
+function ensurePrivateGatewayDir(dir: string): void {
+  try {
+    mkdirSync(dir, { mode: 0o700 });
+    return;
+  } catch (err: any) {
+    if (err?.code !== 'EEXIST') throw err;
+  }
+  const stat = lstatSync(dir);
+  if (!stat.isDirectory()) {
+    throw new Error(`Gateway socket dir ${dir} exists and is not a directory (planted symlink/file?)`);
+  }
+  const uid = process.getuid?.();
+  if (uid !== undefined && stat.uid !== uid) {
+    throw new Error(`Gateway socket dir ${dir} is owned by uid ${stat.uid} (expected ${uid})`);
+  }
+  if ((stat.mode & 0o077) !== 0) chmodSync(dir, 0o700);
+}
+
+/** Rotate the Gateway auth token atomically (tmp + rename) so a relay that
+ *  re-reads the file mid-rotation always sees either the old or the new token,
+ *  never a partial write or a missing file. */
+function rotateGatewayAuthToken(socketPath: string): string {
+  const token = randomBytes(32).toString('base64url');
+  const finalPath = mcpGatewayAuthTokenPath(socketPath);
+  const tmpPath = `${finalPath}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+  writeFileSync(tmpPath, `${token}\n`, { mode: 0o600, flag: 'wx' });
+  renameSync(tmpPath, finalPath);
+  return token;
 }
 
 /**
@@ -50,11 +102,14 @@ export async function startSessionMcpGatewayHost(opts: {
   trustedTurnIdentity?: GatewayTrustedTurnIdentityProvider;
   onError?: (error: Error) => void;
 }): Promise<SessionMcpGatewayHost> {
-  const socketDir = gatewaySocketDir(opts.sessionId, opts.dataDir);
+  const socketDir = sessionMcpGatewaySocketDir(opts.sessionId, opts.dataDir);
   const socketPath = join(socketDir, 'g.sock');
-  const authToken = randomBytes(32).toString('base64url');
-  chmodSync(socketDir, 0o700);
-  writeFileSync(mcpGatewayAuthTokenPath(socketPath), `${authToken}\n`, { mode: 0o600, flag: 'wx' });
+  ensurePrivateGatewayDir(socketDir);
+  // A stale socket file from a dead worker generation blocks bind(); a live
+  // predecessor is impossible (the daemon runs one worker per session), so
+  // removing it unconditionally is safe and makes the fresh host authoritative.
+  rmSync(socketPath, { force: true });
+  const authToken = rotateGatewayAuthToken(socketPath);
 
   const sockets = new Set<Socket>();
   const connectionClosers = new Set<() => Promise<void>>();
@@ -107,7 +162,7 @@ export async function startSessionMcpGatewayHost(opts: {
     server.once('listening', onListening);
     server.listen(socketPath);
   }).catch((error) => {
-    rmSync(socketDir, { recursive: true, force: true });
+    rmSync(socketPath, { force: true });
     throw error;
   });
   server.on('error', reportError);
@@ -115,7 +170,7 @@ export async function startSessionMcpGatewayHost(opts: {
     chmodSync(socketPath, 0o600);
   } catch (error) {
     server.close();
-    rmSync(socketDir, { recursive: true, force: true });
+    rmSync(socketPath, { force: true });
     throw error;
   }
 
@@ -125,10 +180,19 @@ export async function startSessionMcpGatewayHost(opts: {
     close(): Promise<void> {
       closing ??= (async () => {
         for (const socket of sockets) socket.destroy();
-        // Revoke the filesystem capability before the first await. Worker
-        // signal handlers call process.exit(), so async-only cleanup would
-        // otherwise leave a stale socket directory behind.
-        rmSync(socketDir, { recursive: true, force: true });
+        // Revoke the listener capability before the first await. Worker signal
+        // handlers call process.exit(), so async-only cleanup would otherwise
+        // leave a stale connectable socket behind.
+        //
+        // Deliberately unlink ONLY the socket file — the directory (and the
+        // auth token inside it) must survive worker generations: a sandboxed
+        // persistent pane bind-mounts this directory BY INODE (bwrap --ro-bind),
+        // so deleting and recreating the directory would permanently detach the
+        // pane's view. The replacement host reuses the directory in place,
+        // rotates the token, and re-binds the socket at the same path so the
+        // pane's relay can reconnect. A token file without a listener grants
+        // nothing.
+        rmSync(socketPath, { force: true });
         const serverClosed = new Promise<void>((resolve) => {
           if (!server.listening) {
             resolve();

--- a/src/core/plugins/mcp/launch-record.ts
+++ b/src/core/plugins/mcp/launch-record.ts
@@ -1,0 +1,81 @@
+/**
+ * Persisted record of the Gateway socket path a session's CLI was LAUNCHED
+ * with. Written by the worker when it starts a CLI generation whose
+ * environment carries `BOTMUX_MCP_GATEWAY_SOCKET`; consulted by the NEXT
+ * worker generation (after a daemon restart) to decide whether a surviving
+ * persistent pane can be reattached.
+ *
+ * Reattach is only safe when the pane's relay can reach the replacement host:
+ *   - the recorded socket path must equal the deterministic path the new host
+ *     will bind (sessionMcpGatewaySocketPath) — a pane launched by an older
+ *     build with an mkdtemp-random path can never reconnect and must still be
+ *     cold-resumed;
+ *   - the record's relay protocol version must be ≥ 2 — version 2 is the
+ *     first relay that reconnects after a socket loss (older relays exit on
+ *     the first disconnect, so reattaching would strand a dead MCP client).
+ *
+ * The record lives outside the pane's reach (worker data dir, not session
+ * tmpfs) and is cleared whenever a CLI generation launches without a Gateway.
+ */
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/** Bumped when the relay's reconnect contract changes incompatibly. */
+export const MCP_GATEWAY_RELAY_PROTOCOL_VERSION = 2;
+
+export interface McpGatewayLaunchRecord {
+  version: number;
+  socketPath: string;
+}
+
+export function mcpGatewayLaunchRecordPath(dataDir: string, sessionId: string): string {
+  return join(dataDir, 'mcp-gateway-launch', `${sessionId}.json`);
+}
+
+export function writeMcpGatewayLaunchRecord(
+  dataDir: string,
+  sessionId: string,
+  socketPath: string,
+): void {
+  const path = mcpGatewayLaunchRecordPath(dataDir, sessionId);
+  mkdirSync(dirname(path), { recursive: true });
+  const record: McpGatewayLaunchRecord = {
+    version: MCP_GATEWAY_RELAY_PROTOCOL_VERSION,
+    socketPath,
+  };
+  writeFileSync(path, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+}
+
+export function clearMcpGatewayLaunchRecord(dataDir: string, sessionId: string): void {
+  rmSync(mcpGatewayLaunchRecordPath(dataDir, sessionId), { force: true });
+}
+
+export function readMcpGatewayLaunchRecord(
+  dataDir: string,
+  sessionId: string,
+): McpGatewayLaunchRecord | null {
+  let raw: string;
+  try {
+    raw = readFileSync(mcpGatewayLaunchRecordPath(dataDir, sessionId), 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.version === 'number' && typeof parsed?.socketPath === 'string') {
+      return { version: parsed.version, socketPath: parsed.socketPath };
+    }
+  } catch { /* malformed record — treated as absent below */ }
+  return null;
+}
+
+/** Pure decision: may the worker reattach a surviving persistent pane that
+ *  carries plugin MCP state, instead of killing it for a cold-resume? */
+export function mcpGatewayPaneReattachSafe(
+  record: McpGatewayLaunchRecord | null,
+  expectedSocketPath: string,
+): boolean {
+  return record !== null
+    && record.version >= MCP_GATEWAY_RELAY_PROTOCOL_VERSION
+    && record.socketPath === expectedSocketPath;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -112,9 +112,16 @@ import { TurnTerminalDeduper } from './services/turn-terminal-deduper.js';
 import { defaultGatewayEntry, ensureGatewayEntry } from './core/plugins/mcp/gateway-installer.js';
 import {
   sessionMcpGatewayPathRegex,
+  sessionMcpGatewaySocketPath,
   startSessionMcpGatewayHost,
   type SessionMcpGatewayHost,
 } from './core/plugins/mcp/host.js';
+import {
+  clearMcpGatewayLaunchRecord,
+  mcpGatewayPaneReattachSafe,
+  readMcpGatewayLaunchRecord,
+  writeMcpGatewayLaunchRecord,
+} from './core/plugins/mcp/launch-record.js';
 import {
   MCP_GATEWAY_REQUIRED_ENV,
   MCP_GATEWAY_SOCKET_ENV,
@@ -1548,7 +1555,14 @@ async function prepareCliPluginGenerationAndGateway(
       trustedTurnIdentity: currentGatewayTrustedTurnIdentity,
       onError: error => log(`[mcp-gateway] host error: ${error.message}`),
     });
+    // Record the (deterministic) socket path this CLI generation is wired to.
+    // The NEXT worker generation reads it to decide whether a surviving
+    // persistent pane can be reattached (relay reconnects to the same path)
+    // instead of killed for a cold-resume.
+    writeMcpGatewayLaunchRecord(config.session.dataDir, cfg.sessionId, sessionMcpGatewayHost.socketPath);
     log(`[mcp-gateway] trusted host listening for ${manifest.entries.length} plugin server(s)`);
+  } else {
+    clearMcpGatewayLaunchRecord(config.session.dataDir, cfg.sessionId);
   }
   return manifest;
 }
@@ -12739,11 +12753,24 @@ async function spawnCli(
     if (effectiveBackendType === 'zmx') {
       resolvedZmxSessionProbe = paneProbe;
     }
-    if (paneProbe === 'exists') {
-      // The trusted Gateway host belongs to the worker and cannot survive a
-      // worker/daemon replacement. Cold-resume the CLI so its MCP client gets a
-      // fresh relay socket instead of reattaching to a dead connection.
-      log(`[mcp-gateway] persistent pane ${cfg.sessionId} has plugin MCP state — cold-resuming with a fresh host`);
+    const paneRelayReattachSafe = paneProbe === 'exists'
+      && mcpGatewayPaneReattachSafe(
+        readMcpGatewayLaunchRecord(config.session.dataDir, cfg.sessionId),
+        sessionMcpGatewaySocketPath(cfg.sessionId, config.session.dataDir),
+      );
+    if (paneRelayReattachSafe) {
+      // The pane's CLI was launched against the deterministic Gateway socket
+      // path by a reconnect-capable relay: the replacement host (started in
+      // prepareCliPluginGenerationAndGateway) re-binds the same path and the
+      // relay reconnects on its own. Reattaching preserves whatever turn the
+      // CLI is executing — the whole point of the persistent backend.
+      log(`[mcp-gateway] persistent pane ${cfg.sessionId} keeps its relay socket path — reattaching; relay reconnects to the refreshed host`);
+    } else if (paneProbe === 'exists') {
+      // Legacy pane (mkdtemp-random socket path, or a relay predating
+      // reconnect support): its MCP client can never reach the replacement
+      // host. Cold-resume the CLI so it gets a fresh relay socket instead of
+      // reattaching to a dead connection.
+      log(`[mcp-gateway] persistent pane ${cfg.sessionId} has plugin MCP state without a reconnect-capable relay — cold-resuming with a fresh host`);
       const persistentBackendType = effectiveBackendType as PersistentBackendType;
       const persistentTarget = selectedBackend.persistentBackendTarget;
       if (effectiveBackendType === 'zmx') {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1549,22 +1549,37 @@ async function prepareCliPluginGenerationAndGateway(
   const manifest = readSessionMcpRuntimeManifest(cfg.sessionId, config.session.dataDir);
   stopSessionMcpGatewayHost();
   if (adapter.mcpGateway && manifest?.entries.length) {
-    sessionMcpGatewayHost = await startSessionMcpGatewayHost({
-      sessionId: cfg.sessionId,
-      dataDir: config.session.dataDir,
-      trustedTurnIdentity: currentGatewayTrustedTurnIdentity,
-      onError: error => log(`[mcp-gateway] host error: ${error.message}`),
-    });
-    // Record the (deterministic) socket path this CLI generation is wired to.
-    // The NEXT worker generation reads it to decide whether a surviving
-    // persistent pane can be reattached (relay reconnects to the same path)
-    // instead of killed for a cold-resume.
-    writeMcpGatewayLaunchRecord(config.session.dataDir, cfg.sessionId, sessionMcpGatewayHost.socketPath);
+    await startAndRecordSessionMcpGatewayHost(cfg.sessionId);
     log(`[mcp-gateway] trusted host listening for ${manifest.entries.length} plugin server(s)`);
   } else {
     clearMcpGatewayLaunchRecord(config.session.dataDir, cfg.sessionId);
   }
   return manifest;
+}
+
+/** Bind the trusted MCP Gateway host at the session's DETERMINISTIC socket path
+ *  and persist its launch record. Deliberately does NOT refresh the plugin/Skill
+ *  generation: prepareCliPluginGenerationAndGateway does that for fresh/resumed
+ *  spawns, whereas a warm reattach to a surviving pane keeps the CLI's existing
+ *  catalog untouched — but the host itself died with the previous worker, so the
+ *  reattach path must still re-serve it here so the pane's surviving relay can
+ *  reconnect to the same path (see spawnCli's paneRelayReattachSafe branch).
+ *  The caller owns stopping any prior host first (prepare*) or gating on absence
+ *  (reattach). Token rotation + stale-socket removal are handled inside
+ *  startSessionMcpGatewayHost. The trusted-turn-identity provider (#917) is
+ *  wired here so BOTH the fresh/resumed host and the re-served reattach host
+ *  inject the per-turn host-signed caller — the reattach path must not lose it. */
+async function startAndRecordSessionMcpGatewayHost(sessionId: string): Promise<void> {
+  sessionMcpGatewayHost = await startSessionMcpGatewayHost({
+    sessionId,
+    dataDir: config.session.dataDir,
+    trustedTurnIdentity: currentGatewayTrustedTurnIdentity,
+    onError: error => log(`[mcp-gateway] host error: ${error.message}`),
+  });
+  // The NEXT worker generation reads this record to decide whether a surviving
+  // persistent pane can be reattached (relay reconnects to the same path)
+  // instead of killed for a cold-resume.
+  writeMcpGatewayLaunchRecord(config.session.dataDir, sessionId, sessionMcpGatewayHost.socketPath);
 }
 
 /** v2 read isolation — provision a bot's PER-BOT config dir under its BOT_HOME so the
@@ -12760,11 +12775,22 @@ async function spawnCli(
       );
     if (paneRelayReattachSafe) {
       // The pane's CLI was launched against the deterministic Gateway socket
-      // path by a reconnect-capable relay: the replacement host (started in
-      // prepareCliPluginGenerationAndGateway) re-binds the same path and the
-      // relay reconnects on its own. Reattaching preserves whatever turn the
-      // CLI is executing — the whole point of the persistent backend.
-      log(`[mcp-gateway] persistent pane ${cfg.sessionId} keeps its relay socket path — reattaching; relay reconnects to the refreshed host`);
+      // path by a reconnect-capable relay. Reattaching preserves whatever turn
+      // the CLI is executing — the whole point of the persistent backend — but
+      // the trusted host died with the previous worker, so we must RE-SERVE it
+      // here at the same deterministic path for the pane's surviving relay to
+      // reconnect to. This reattach path skips prepareCliPluginGenerationAndGateway
+      // (it must not refresh the catalog on a warm reattach), which is the only
+      // other host starter; without this the relay would reconnect forever to a
+      // socket nothing binds. Start only when this fresh worker has no live host
+      // yet — never stomp a host an in-worker restart already brought up.
+      if (!sessionMcpGatewayHost) {
+        await startAndRecordSessionMcpGatewayHost(cfg.sessionId);
+        if (spawnGeneration !== cliSpawnGeneration) throw new CliSpawnSupersededError();
+        log(`[mcp-gateway] persistent pane ${cfg.sessionId} keeps its relay socket path — re-served trusted host at the same path; relay reconnects on its own`);
+      } else {
+        log(`[mcp-gateway] persistent pane ${cfg.sessionId} keeps its relay socket path — reattaching; live host already bound, relay stays connected`);
+      }
     } else if (paneProbe === 'exists') {
       // Legacy pane (mkdtemp-random socket path, or a relay predating
       // reconnect support): its MCP client can never reach the replacement

--- a/test/plugin-mcp-gateway.test.ts
+++ b/test/plugin-mcp-gateway.test.ts
@@ -559,6 +559,131 @@ describe('plugin MCP Gateway', () => {
     expect(readMcpGatewayLaunchRecord(dataDir, sessionId)).toBeNull();
   });
 
+  // ─── Worker reattach wiring (source lock) ──────────────────────────────────
+  //
+  // spawnCli is not exported (repo convention: source-lock tests, see
+  // resume-fresh-policy.test.ts). These pin the P0 fix: the pane-reattach-safe
+  // branch MUST re-serve the trusted Gateway host at the deterministic path so
+  // the surviving pane's relay can reconnect. Without it (the shipped bug) the
+  // reattach branch only logged, willReattachPersistent stayed true, and the
+  // sole host starter (prepareCliPluginGenerationAndGateway) was gated out by
+  // `if (!willReattachPersistent)` — the relay then reconnected forever to a
+  // socket nothing binds.
+  describe('reattach-safe branch re-serves the Gateway host (source lock)', () => {
+    const workerSource = readFileSync(resolve('src/worker.ts'), 'utf8');
+
+    it('exposes a host-only starter that does NOT refresh the plugin generation', () => {
+      // The starter must be separate from prepareCliPluginGenerationAndGateway
+      // (which calls refreshCliPluginGeneration) so a warm reattach keeps the
+      // CLI's existing catalog untouched while still binding a fresh host.
+      const start = workerSource.indexOf('async function startAndRecordSessionMcpGatewayHost');
+      expect(start).toBeGreaterThan(-1);
+      const block = workerSource.slice(start, start + 800);
+      expect(block).toContain('startSessionMcpGatewayHost(');
+      expect(block).toContain('writeMcpGatewayLaunchRecord(');
+      // Host-only: must NOT re-run the catalog/plugin refresh on this path.
+      expect(block).not.toContain('refreshCliPluginGeneration(');
+      // Both host-start paths (fresh/resumed via prepare*, and the re-served
+      // reattach host) route through this helper, so it MUST keep #917's
+      // per-turn trusted-caller provider wired — otherwise a warm reattach (and
+      // every spawn) would silently stop injecting the host-signed identity.
+      // The worker-level wiring is not otherwise exercised by a runtime test.
+      expect(block).toContain('trustedTurnIdentity: currentGatewayTrustedTurnIdentity');
+    });
+
+    it('starts the replacement host inside the paneRelayReattachSafe branch', () => {
+      const start = workerSource.indexOf('if (paneRelayReattachSafe) {');
+      expect(start).toBeGreaterThan(-1);
+      // Scope strictly to the reattach-safe branch (ends at the legacy
+      // cold-resume `else if`), so a host start anywhere else can't satisfy this.
+      const branchEnd = workerSource.indexOf('} else if (paneProbe === \'exists\') {', start);
+      expect(branchEnd).toBeGreaterThan(start);
+      const branch = workerSource.slice(start, branchEnd);
+      expect(branch).toContain('startAndRecordSessionMcpGatewayHost(');
+      // Only when this fresh worker has no live host yet — never stomp a host an
+      // in-worker restart already brought up.
+      expect(branch).toContain('if (!sessionMcpGatewayHost)');
+    });
+
+    it('re-serving is awaited and guarded by the spawn-generation fence', () => {
+      const start = workerSource.indexOf('if (paneRelayReattachSafe) {');
+      const branchEnd = workerSource.indexOf('} else if (paneProbe === \'exists\') {', start);
+      const branch = workerSource.slice(start, branchEnd);
+      expect(branch).toContain('await startAndRecordSessionMcpGatewayHost(');
+      // A concurrent restart must not let a superseded generation keep running.
+      expect(branch).toContain('if (spawnGeneration !== cliSpawnGeneration) throw new CliSpawnSupersededError();');
+    });
+  });
+
+  it('re-served reattach host binds the same deterministic path a stranded relay reconnects to', async () => {
+    // End-to-end proof of the fix's mechanism: a relay left running after its
+    // host dies (the daemon-restart pane) has an in-flight call HANG, and the
+    // moment a replacement host is bound at the SAME deterministic path — which
+    // is exactly what startAndRecordSessionMcpGatewayHost now does on the
+    // reattach branch — that same in-flight call resolves.
+    const sessionId = 'reattach-reserve-reconnect';
+    const dataDir = join(home, 'custom-botmux', 'data');
+    vi.stubEnv('SESSION_DATA_DIR', dataDir);
+    installFixturePlugin('plugin-a', 'alpha');
+    refreshSessionMcpRuntimeManifest({ sessionId, pluginIds: ['plugin-a'], dataDir });
+
+    const host1 = await startSessionMcpGatewayHost({ sessionId, dataDir });
+    // The worker persists this record when it launches the CLI generation.
+    writeMcpGatewayLaunchRecord(dataDir, sessionId, host1.socketPath);
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['--import', 'tsx', resolve('src/cli.ts'), 'mcp', 'serve'],
+      cwd: resolve('.'),
+      env: {
+        ...mcpServeEnvironment(sessionId),
+        SESSION_DATA_DIR: dataDir,
+        [MCP_GATEWAY_SOCKET_ENV]: host1.socketPath,
+        [MCP_GATEWAY_REQUIRED_ENV]: '1',
+        BOTMUX_MCP_RELAY_BACKOFF_MS: '50',
+      },
+      stderr: 'pipe',
+    });
+    const client = new Client({ name: 'reattach-reserve-test', version: '1.0.0' });
+    let host2: Awaited<ReturnType<typeof startSessionMcpGatewayHost>> | undefined;
+    try {
+      await client.connect(transport);
+      expect((await client.listTools()).tools.map(t => t.name).sort()).toEqual(['alpha_unique', 'echo']);
+
+      // The worker's reattach decision, evaluated from the persisted record.
+      expect(mcpGatewayPaneReattachSafe(
+        readMcpGatewayLaunchRecord(dataDir, sessionId),
+        sessionMcpGatewaySocketPath(sessionId, dataDir),
+      )).toBe(true);
+
+      // Daemon restart kills the host; the pane's relay + client live on.
+      await host1.close();
+      await new Promise(r => setTimeout(r, 150));
+
+      // A call during the outage must buffer, not fail.
+      let settled = false;
+      const pendingCall = client.callTool({ name: 'echo', arguments: {} })
+        .then(res => { settled = true; return res; });
+      const duringOutage = await Promise.race([
+        pendingCall.then(() => 'resolved'),
+        new Promise<string>(r => setTimeout(() => r('still-pending'), 1500)),
+      ]);
+      expect(duringOutage).toBe('still-pending');
+      expect(settled).toBe(false);
+
+      // The fix: re-serve the host at the SAME deterministic path (what
+      // startAndRecordSessionMcpGatewayHost does on the reattach branch).
+      host2 = await startSessionMcpGatewayHost({ sessionId, dataDir });
+      expect(host2.socketPath).toBe(host1.socketPath);
+
+      const result = await pendingCall;
+      expect((result.content[0] as { text: string }).text).toContain(`session=${sessionId}`);
+    } finally {
+      await client.close().catch(() => undefined);
+      await host2?.close();
+    }
+  }, 30_000);
+
   it('fails closed when a managed relay loses its worker-owned socket', () => {
     const run = spawnSync(
       process.execPath,

--- a/test/plugin-mcp-gateway.test.ts
+++ b/test/plugin-mcp-gateway.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
@@ -16,8 +16,17 @@ import {
 import { refreshSessionMcpRuntimeManifest } from '../src/core/plugins/mcp/session-runtime.js';
 import {
   sessionMcpGatewayPathRegex,
+  sessionMcpGatewaySocketDir,
+  sessionMcpGatewaySocketPath,
   startSessionMcpGatewayHost,
 } from '../src/core/plugins/mcp/host.js';
+import {
+  MCP_GATEWAY_RELAY_PROTOCOL_VERSION,
+  mcpGatewayPaneReattachSafe,
+  readMcpGatewayLaunchRecord,
+  clearMcpGatewayLaunchRecord,
+  writeMcpGatewayLaunchRecord,
+} from '../src/core/plugins/mcp/launch-record.js';
 import {
   MCP_GATEWAY_REQUIRED_ENV,
   MCP_GATEWAY_SOCKET_ENV,
@@ -466,6 +475,90 @@ describe('plugin MCP Gateway', () => {
     }
   });
 
+  it('relay survives a Gateway host replacement: reconnects, replays initialize, flushes buffered requests', async () => {
+    const sessionId = 'relay-reconnect-across-hosts';
+    const customDataDir = join(home, 'custom-botmux', 'data');
+    vi.stubEnv('SESSION_DATA_DIR', customDataDir);
+    installFixturePlugin('plugin-a', 'alpha');
+    refreshSessionMcpRuntimeManifest({
+      sessionId,
+      pluginIds: ['plugin-a'],
+      dataDir: customDataDir,
+    });
+    const host1 = await startSessionMcpGatewayHost({ sessionId, dataDir: customDataDir });
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['--import', 'tsx', resolve('src/cli.ts'), 'mcp', 'serve'],
+      cwd: resolve('.'),
+      env: {
+        ...mcpServeEnvironment(sessionId),
+        SESSION_DATA_DIR: customDataDir,
+        [MCP_GATEWAY_SOCKET_ENV]: host1.socketPath,
+        [MCP_GATEWAY_REQUIRED_ENV]: '1',
+        BOTMUX_MCP_RELAY_BACKOFF_MS: '50',
+      },
+      stderr: 'pipe',
+    });
+    const client = new Client({ name: 'relay-reconnect-test', version: '1.0.0' });
+    let host2: Awaited<ReturnType<typeof startSessionMcpGatewayHost>> | undefined;
+    try {
+      await client.connect(transport);
+      expect((await client.listTools()).tools.map(tool => tool.name).sort()).toEqual(['alpha_unique', 'echo']);
+
+      // Kill the host the way a daemon restart does. The relay (and the MCP
+      // client on top of it) stays alive inside the "pane".
+      await host1.close();
+      // Give the relay a moment to observe the disconnect so the next request
+      // is deterministically buffered rather than racing the close event.
+      await new Promise(resolveDelay => setTimeout(resolveDelay, 150));
+
+      // Issue a request during the outage — it must buffer, not fail.
+      const pendingCall = client.callTool({ name: 'echo', arguments: {} });
+
+      // Replacement worker: same session → same deterministic socket path.
+      host2 = await startSessionMcpGatewayHost({ sessionId, dataDir: customDataDir });
+      expect(host2.socketPath).toBe(host1.socketPath);
+
+      // The relay reconnects, replays initialize/initialized on the fresh
+      // Gateway connection (the client never re-initializes), then flushes the
+      // buffered call.
+      const result = await pendingCall;
+      expect((result.content[0] as { text: string }).text).toContain(`session=${sessionId}`);
+
+      // Steady-state after the swap keeps working.
+      expect((await client.listTools()).tools.map(tool => tool.name).sort()).toEqual(['alpha_unique', 'echo']);
+    } finally {
+      await client.close().catch(() => undefined);
+      await host2?.close();
+    }
+  }, 30_000);
+
+  it('decides pane reattach from the persisted Gateway launch record', () => {
+    const dataDir = join(home, 'custom-botmux', 'data');
+    const sessionId = 'launch-record-session';
+    const expected = sessionMcpGatewaySocketPath(sessionId, dataDir);
+
+    // No record (legacy pane or never launched with a gateway) → cold-resume.
+    expect(mcpGatewayPaneReattachSafe(readMcpGatewayLaunchRecord(dataDir, sessionId), expected)).toBe(false);
+
+    // Matching record from a reconnect-capable relay → reattach.
+    writeMcpGatewayLaunchRecord(dataDir, sessionId, expected);
+    expect(mcpGatewayPaneReattachSafe(readMcpGatewayLaunchRecord(dataDir, sessionId), expected)).toBe(true);
+
+    // Path mismatch (e.g. dataDir moved, or an mkdtemp-era path) → cold-resume.
+    expect(mcpGatewayPaneReattachSafe(
+      { version: MCP_GATEWAY_RELAY_PROTOCOL_VERSION, socketPath: '/tmp/bmcp-0-deadbeef-XYZ/g.sock' },
+      expected,
+    )).toBe(false);
+
+    // Pre-reconnect relay protocol → cold-resume.
+    expect(mcpGatewayPaneReattachSafe({ version: 1, socketPath: expected }, expected)).toBe(false);
+
+    // Cleared record (generation launched without a gateway) → cold-resume.
+    clearMcpGatewayLaunchRecord(dataDir, sessionId);
+    expect(readMcpGatewayLaunchRecord(dataDir, sessionId)).toBeNull();
+  });
+
   it('fails closed when a managed relay loses its worker-owned socket', () => {
     const run = spawnSync(
       process.execPath,
@@ -572,15 +665,49 @@ describe('plugin MCP Gateway', () => {
     expect(profile.indexOf(writeDeny)).toBeGreaterThan(profile.indexOf(allow));
   });
 
-  it('revokes the worker-owned socket path synchronously during shutdown', async () => {
+  it('revokes the worker-owned socket path synchronously during shutdown but keeps the directory', async () => {
     const host = await startSessionMcpGatewayHost({
       sessionId: 'synchronous-socket-revoke',
       dataDir: join(home, 'custom-botmux', 'data'),
     });
     expect(existsSync(host.socketPath)).toBe(true);
     const closing = host.close();
-    expect(existsSync(host.socketDir)).toBe(false);
+    // The socket (the connectable capability) is gone synchronously; the
+    // directory must SURVIVE so a sandboxed pane's bwrap bind mount (pinned to
+    // the directory inode) still sees the replacement host's socket after a
+    // worker restart.
+    expect(existsSync(host.socketPath)).toBe(false);
+    expect(existsSync(host.socketDir)).toBe(true);
     await closing;
+  });
+
+  it('re-serves the same deterministic socket path across host generations', async () => {
+    const dataDir = join(home, 'custom-botmux', 'data');
+    const host1 = await startSessionMcpGatewayHost({ sessionId: 'stable-path', dataDir });
+    expect(host1.socketPath).toBe(sessionMcpGatewaySocketPath('stable-path', dataDir));
+    const path1 = host1.socketPath;
+    await host1.close();
+    const host2 = await startSessionMcpGatewayHost({ sessionId: 'stable-path', dataDir });
+    try {
+      expect(host2.socketPath).toBe(path1);
+      expect(existsSync(host2.socketPath)).toBe(true);
+    } finally {
+      await host2.close();
+    }
+  });
+
+  it('fails closed when the deterministic socket dir is a planted symlink', async () => {
+    const dataDir = join(home, 'custom-botmux', 'data');
+    const plantedTarget = join(home, 'attacker-target');
+    mkdirSync(plantedTarget, { recursive: true });
+    const dir = sessionMcpGatewaySocketDir('symlink-squat', dataDir);
+    symlinkSync(plantedTarget, dir);
+    try {
+      await expect(startSessionMcpGatewayHost({ sessionId: 'symlink-squat', dataDir }))
+        .rejects.toThrow(/not a directory/);
+    } finally {
+      rmSync(dir, { force: true });
+    }
   });
 
   it('closes the Gateway once when its MCP host stdin ends', async () => {


### PR DESCRIPTION
## 改了什么

带 plugin MCP 状态的 tmux/zmx 持久会话，此前每次 daemon 重启都会被 worker 主动 kill 再 `claude --resume` 冷启动（日志：`[mcp-gateway] persistent pane … cold-resuming with a fresh host`），正在执行的 turn 直接被打断——这正是「会话既没 botmux send 也没走到飞书兜底」最底层的根因链一环：turn 被杀 → resume 不续跑 → 兜底无 final 可发。

根因：MCP gateway host 活在 worker 进程内，socket 路径含 `mkdtemp` 随机段、auth token 随 worker 生成，worker 一死 pane 里的 relay 永远连不回来，只能杀 pane 换新 env。

本 PR 让 daemon 重启对这类会话真正无缝：

1. **host（`src/core/plugins/mcp/host.ts`）**
   - socket 目录改为 `(dataDir, sessionId)` 确定化路径 `/tmp/bmcp-<uid>-<hash16>`（去掉 mkdtemp 随机段），worker 重启后在**原路径**重建 socket
   - 目录**原地复用、close 只删 socket 文件不删目录**——bwrap 沙盒按 inode bind 目录，删目录会永久断开沙盒 pane 的视图
   - token 每代**原子轮换**（tmp + rename），relay 每次重连重读
   - 确定化路径被抢占（symlink / 非本 uid 目录）时 **fail closed**

2. **relay（`src/core/plugins/mcp/gateway.ts`）**
   - 单次字节管道改为**按行成帧的重连 relay**：断线后退避重连（250ms 起倍增、封顶 5s，stdin 存活期间不放弃）
   - 向新 gateway 连接**重放 initialize/initialized 握手**（每个 host 连接是全新 MCP server）；客户端已见过原响应则吞掉重放响应，避免重复 response id
   - 断连期间**缓冲客户端请求**（上限 8MiB），重连补发；跨断连的 in-flight 响应按 MCP 客户端超时自然失败

3. **worker（`src/worker.ts`）**
   - CLI 启动时落盘 launch record（socket 路径 + relay 协议版本，`data/mcp-gateway-launch/<sid>.json`）
   - 下一代 worker 据此判定：幸存 pane 的 relay 可重连 → **直接 reattach 不杀 pane**；旧构建启动的 pane（mkdtemp 路径 / 旧单次 relay）→ 保持原冷恢复路径，自然滚动迁移

## 影响面

- **CLI**：所有带 `mcpGateway` 的 CLI（claude-code 及 forks、codex 等）共用 relay/host；无 plugin MCP 的会话完全不经过此路径，行为不变
- **后端**：仅影响 tmux/zellij/zmx/herdr 持久后端的 reattach 决策；PTY 会话不变（决策块本身要求 `!== 'pty'`）
- **沙盒**：bwrap（目录 inode bind → 原地复用解决）与 macOS seatbelt（deny regex `bmcp-<uid>-*` 布局兼容，policy 按路径不按 inode）均核对
- **安全**：随机段的初衷（/tmp 抢占 + sun_path 短路径）用「所有权校验 fail closed + 保持 tmpdir 短路径」承接；token 仍每代轮换、连接仍需握手鉴权；无监听时 token 文件不构成能力

## 测试

- `npx vitest run --project unit test/plugin-mcp-gateway.test.ts`：**21 通过**，新增：
  - relay 在 host 换代后重连、重放 initialize、补发断连期间缓冲的请求（e2e，真实 `mcp serve` 子进程）
  - 同 session 跨 host 代际 socket 路径稳定；close 后目录保留
  - 确定化目录被 symlink 抢占时 fail closed
  - launch record 的 reattach 决策（无记录/路径不匹配/旧协议版本 → 冷恢复）
- `pnpm build` 通过
- 全量 unit 套件：失败集与 master 基线完全一致（同批 8 个环境既有失败，如本机 bwrap 限制导致的 plugin-mcp-sandbox），**零新增回归**
