### PR TITLE
fix(setup): 建应用后收尾步骤对瞬态网络错误重试，不再一抖就丢进手动恢复

### DIFF
--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -1330,8 +1330,13 @@ export async function createOpenPlatformAppWithClient(
   try {
     // 模板应用出生已带 bot + 长连接(重复调用幂等);fallback 的裸自建应用
     // 则必须显式开启——这两步是「一扫即用」的必要条件,在返回凭证前完成。
-    await client.postJson(`/developers/v1/robot/switch/${appId}`, { clientId: appId, enable: true });
-    await client.postJson(`/developers/v1/event/switch/${appId}`, { clientId: appId, eventMode: 4 }); // WebSocket
+    // robot/event switch 都是幂等设值,故对宿主机↔飞书的瞬态网络抖动小步重试:
+    // 一次 undici `fetch failed` 不该让「应用已建成但没启用能力」半途而废
+    // (那会把用户丢进手动读 Secret + CLI 续跑的恢复路径)。
+    await retryIdempotentOnTransientNetworkError(() =>
+      client.postJson(`/developers/v1/robot/switch/${appId}`, { clientId: appId, enable: true }));
+    await retryIdempotentOnTransientNetworkError(() =>
+      client.postJson(`/developers/v1/event/switch/${appId}`, { clientId: appId, eventMode: 4 })); // WebSocket
 
     // 复刻 console launcher「一键创建智能体」的最后一步:立刻用极简版本发布一次,
     // 让应用**上架启用**(tenantAppStatus 0→2)。这样返回的就是一个「已启用、可
@@ -1340,6 +1345,9 @@ export async function createOpenPlatformAppWithClient(
     // (可能留下未发布草稿),都视为创建失败抛出(带 appId,由调用方兜底/提示),
     // 不宣称「后续 setup 会软兜底」——setup 的 nextAppVersion 不复用未发布草稿,
     // 版本号可能撞车导致二次发版继续失败,应用永远停在未启用。
+    // ⚠️ version/create、publish/commit 是非幂等写操作(传输失败即结果未知,
+    // 重放会重复建版/撞版本号),故绝不套 retryIdempotent… 包装,与 fetchRaw
+    // 只对 GET/HEAD 重试同源。
     const versionCreated = await client.postJson(
       `/developers/v1/app_version/create/${appId}`,
       buildAppVersionCreatePayload('1.0.0', [options.creatorUserId]),
@@ -1350,7 +1358,11 @@ export async function createOpenPlatformAppWithClient(
     }
     await client.postJson(`/developers/v1/publish/commit/${appId}/${enableVersionId}`, { clientId: appId });
 
-    const appSecret = await fetchOpenPlatformAppSecret(client, appId);
+    // 读 Secret 是纯只读 POST(getAppSecret 同款,不触碰 reset),幂等可重试:
+    // 应用已建成、已发布,唯独最后一步读 Secret 撞网络抖动而失败最可惜——
+    // 重试让它自愈,而不是把整条链路判死。
+    const appSecret = await retryIdempotentOnTransientNetworkError(() =>
+      fetchOpenPlatformAppSecret(client, appId!));
     return { appId, appSecret };
   } catch (err) {
     throw new CreatedOpenPlatformAppError(appId, err);
@@ -1654,6 +1666,26 @@ function isLikelyTransientNetworkError(err: unknown, depth = 0): boolean {
     return err.cause === undefined || isLikelyTransientNetworkError(err.cause, depth + 1);
   }
   return isLikelyTransientNetworkError((err as { cause?: unknown }).cause, depth + 1);
+}
+
+// 对「幂等」console 请求复用 fetchRaw 的瞬态退避:传输层抖动(fetch failed /
+// ECONNRESET 等)时小步重试,一次网络毛刺不再中断整条链路。API 层拒绝
+// (OpenPlatformApiError、HTTP 非 2xx、code!=0)无 code / cause,isLikely… 判 false,
+// 只会立刻抛出而不会被重放。
+// ⚠️ 只能包装「重复调用无副作用」的请求。app_version/create、publish/commit 这类
+// 「传输失败即结果未知、重放会重复提交/撞版本号」的非幂等写操作绝不能用本包装
+// (与 fetchRaw 只对 GET/HEAD 重试同源:见其上方注释)。
+async function retryIdempotentOnTransientNetworkError<T>(fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= TRANSIENT_FETCH_RETRY_DELAYS_MS.length || !isLikelyTransientNetworkError(err)) {
+        throw err;
+      }
+      await sleep(TRANSIENT_FETCH_RETRY_DELAYS_MS[attempt]);
+    }
+  }
 }
 
 class MutableCookieJar {

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -678,6 +678,113 @@ describe('createFeishuOpenPlatformApp', () => {
     expect(result).toMatchObject({ ok: false, reason: 'session_changed' });
     expect(post).not.toHaveBeenCalled();
   });
+
+  // 应用已建成后,启用能力/发版/读 Secret 这几步撞宿主机↔飞书的瞬态网络抖动
+  // (undici `fetch failed`),此前一次失败就把整条链路判死,用户被丢进「应用已创建
+  // 但配置尚未完成」的手动恢复。幂等步骤(robot/switch、读 Secret)现在小步重试自愈,
+  // 非幂等写(app_version/create、publish/commit)保持一次即抛,不重复提交。
+  const transientCreateError = () =>
+    new TypeError('fetch failed', {
+      cause: Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+    });
+
+  // 复用第一条 happy-path 的建应用流程,允许对指定 path 的前 N 次调用注入瞬态错误。
+  function createAppFetchImpl(
+    calls: string[],
+    inject: (path: string, attempt: number) => void = () => {},
+  ): typeof fetch {
+    const attempts = new Map<string, number>();
+    return (async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      if (href === 'https://open.feishu.cn/app') return new Response(openPlatformPage(), { status: 200 });
+      const path = new URL(href).pathname;
+      calls.push(path);
+      const attempt = (attempts.get(path) ?? 0) + 1;
+      attempts.set(path, attempt);
+      inject(path, attempt); // 可 throw 瞬态错误
+      if (path === '/developers/v1/app/upload/image') {
+        return Response.json({ code: 0, data: { url: 'https://cdn.example/botmux.png' } });
+      }
+      if (path === '/developers/v1/manifest/upsert_by_template') {
+        return Response.json({ code: 0, data: { clientID: 'cli_created' } });
+      }
+      if (path === '/developers/v1/app_version/create/cli_created') {
+        return Response.json({ code: 0, data: { versionId: 'v-enable' } });
+      }
+      if (path === '/developers/v1/secret/cli_created') {
+        return Response.json({ code: 0, data: { secret: 'created-secret' } });
+      }
+      return Response.json({ code: 0 });
+    }) as typeof fetch;
+  }
+
+  it('建成后读 Secret 撞一次瞬态网络错误能自愈,不再把用户丢进手动恢复', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-secret-retry-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: string[] = [];
+    const fetchImpl = createAppFetchImpl(calls, (path, attempt) => {
+      if (path === '/developers/v1/secret/cli_created' && attempt === 1) throw transientCreateError();
+    });
+
+    const result = await createFeishuOpenPlatformApp({
+      name: 'botmux-secret-retry',
+      sessionFilePath: sessionFile,
+      disableBytedcliFallback: true,
+      fetchImpl,
+      onQrCode: () => {},
+    });
+
+    expect(result).toMatchObject({ ok: true, appId: 'cli_created', appSecret: 'created-secret' });
+    // secret 读取重试了一次(首次 + 重试);version/create 只发一次(未受影响)
+    expect(calls.filter(p => p === '/developers/v1/secret/cli_created')).toHaveLength(2);
+    expect(calls.filter(p => p === '/developers/v1/app_version/create/cli_created')).toHaveLength(1);
+  });
+
+  it('建成后启用机器人能力(robot/switch)撞一次瞬态网络错误能自愈', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-robot-retry-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: string[] = [];
+    const fetchImpl = createAppFetchImpl(calls, (path, attempt) => {
+      if (path === '/developers/v1/robot/switch/cli_created' && attempt === 1) throw transientCreateError();
+    });
+
+    const result = await createFeishuOpenPlatformApp({
+      name: 'botmux-robot-retry',
+      sessionFilePath: sessionFile,
+      disableBytedcliFallback: true,
+      fetchImpl,
+      onQrCode: () => {},
+    });
+
+    expect(result).toMatchObject({ ok: true, appId: 'cli_created', appSecret: 'created-secret' });
+    expect(calls.filter(p => p === '/developers/v1/robot/switch/cli_created')).toHaveLength(2);
+  });
+
+  it('非幂等的上架发版(app_version/create)传输错误一次即抛,绝不重试重复建版', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-version-noretry-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: string[] = [];
+    const fetchImpl = createAppFetchImpl(calls, (path) => {
+      // 每次都抛:若被误当幂等重试,calls 里会出现多次
+      if (path === '/developers/v1/app_version/create/cli_created') throw transientCreateError();
+    });
+
+    const result = await createFeishuOpenPlatformApp({
+      name: 'botmux-version-noretry',
+      sessionFilePath: sessionFile,
+      disableBytedcliFallback: true,
+      fetchImpl,
+      onQrCode: () => {},
+    });
+
+    // 应用已建成但发版失败:带 appId 供调用方兜底/提示(手动恢复路径)
+    expect(result).toMatchObject({ ok: false, reason: 'api_error', appId: 'cli_created' });
+    expect(calls.filter(p => p === '/developers/v1/app_version/create/cli_created')).toHaveLength(1);
+  });
 });
 
 describe('automateOpenPlatformSetup', () => {


### PR DESCRIPTION
## 改了什么

Dashboard / CLI 添加机器人时，**应用创建成功之后**还有 5 个 POST 收尾步骤：`robot/switch`（开机器人能力）、`event/switch`（开长连接）、`app_version/create`（建版）、`publish/commit`（发版上架）、读 AppSecret。

底层 `fetchRaw` 已有瞬态网络重试（undici `TypeError('fetch failed')`、ECONNRESET 等），但**只对幂等的 GET/HEAD 生效，所有 POST 一律单发**（见其 `retryable = method==='GET'||'HEAD'` 与注释）。所以宿主机 ↔ 飞书任意一次网络毛刺打在这 5 步里，就中断整条链路；又因为应用已建成、代码为避免重复创建而拒绝重建，用户被丢进「手动去开放平台读 Secret + 敲一长串 CLI 续跑」的恢复路径，卡片报：

> 应用已创建，但配置尚未完成 / 启用机器人能力或读取 AppSecret 失败: fetch failed

本质是**收尾步骤缺瞬态重试**，并非真的配置失败。

## 为什么这么改

- 新增 `retryIdempotentOnTransientNetworkError()`，复用既有 `TRANSIENT_FETCH_RETRY_DELAYS_MS`（`[300, 900]`）+ `isLikelyTransientNetworkError`，**只包住幂等收尾步**：`robot/switch`、`event/switch`、读 secret（纯只读 POST，不触碰 `secret/reset`）。抖一次自动自愈。
- **非幂等写**（`app_version/create`、`publish/commit`）保持一次即抛、绝不重放——传输失败即结果未知，重放会重复建版 / 撞版本号。与 `fetchRaw` 只对 GET/HEAD 重试同源。
- API 层拒绝（`OpenPlatformApiError`：HTTP 非 2xx / `code != 0`）没有网络错误码、没有 `cause`，`isLikelyTransientNetworkError` 判 false，不会被误重试。

## 影响面

- CLI（`cli.ts` 两处）与 Dashboard（`bot-onboarding.ts`）两个建 bot 入口都走 `createFeishuOpenPlatformApp` → `createOpenPlatformAppWithClient`，**一处修复全覆盖**。
- 纯 Feishu 开放平台 console HTTP 自动化链路，不涉及跨平台 / 跨 CLI / 跨后端差异。

## 测试验证

- `pnpm build` 绿。
- `setup-open-platform-automation.test.ts` 54 测 + onboarding/setup 相关共 156 测全绿。
- 补 3 个针对性测试并做**反向变异**证明有牙：
  - 去掉幂等重试 → 「建成后读 Secret 自愈」「robot/switch 自愈」两测挂。
  - 把重试误加到非幂等的 `app_version/create` → 「非幂等发版一次即抛」测抓到重放 3 次。

⚠️ daemon 热路径，真实网络抖动单测覆盖不到；live 验证需 `pnpm switch:here && pnpm daemon:restart`（影响全 fleet，验证后切回 canonical）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
