### PR TITLE
fix(bridge): pending turn 落盘 journal，daemon 重启后恢复被打断回合的兜底输出

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -855,6 +855,7 @@ export const messages: Record<string, string> = {
   'worker.raw_input_failed_recovery': '⚠️ The slash command could not be confirmed as delivered to {cliName}, so the follow-up text in the same message was not submitted.\nReason: {reason}',
   'worker.raw_input_failed_command_only_recovery': '⚠️ The slash command could not be confirmed as delivered to {cliName}.\nReason: {reason}',
   'worker.empty_final_completed': '⚠️ {cliName} reported this turn as completed, but botmux captured no final text from the terminal transcript and saw no tracked reply for this turn. If you already replied via a redirected send (--top-level / --into / --override-chat), you can ignore this. Otherwise open the web terminal to inspect the last output, or resend a message to continue the session.',
+  'worker.bridge_restored_turn_notice': '⚠️ This turn was interrupted by a botmux restart. Below is the output recovered from the terminal transcript (may be incomplete):',
   'worker.failed_reason_unavailable': 'no error summary was safe to display',
   'worker.empty_final_failed': '⚠️ {cliName} failed this turn: {reason}\nThe complete error remains available in the web terminal and daemon logs. Resolve the issue, then resend the message.',
   'worker.empty_final_failed_invalid_request': '⚠️ The {cliName} request was rejected: {reason}\nCheck the CLI, model gateway, and tool schema configuration, then resend the message.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -856,6 +856,7 @@ export const messages: Record<string, string> = {
   'worker.raw_input_failed_recovery': '⚠️ Slash 命令未能确认送达 {cliName}，同一条消息中紧随其后的正文没有继续提交。\n原因：{reason}',
   'worker.raw_input_failed_command_only_recovery': '⚠️ Slash 命令未能确认送达 {cliName}。\n原因：{reason}',
   'worker.empty_final_completed': '⚠️ {cliName} 已报告本轮处理完成，但 botmux 没有从终端记录里捕获到最终文本，也没有追踪到本轮的回复。若你已经通过改道发送（--top-level / --into / --override-chat）回复过，可忽略本提示；否则请打开 Web 终端查看最后输出，或直接重发消息让会话继续。',
+  'worker.bridge_restored_turn_notice': '⚠️ 本轮曾因 botmux 重启中断，以下是从终端记录恢复的该轮输出（可能不完整）：',
   'worker.failed_reason_unavailable': '未提供可安全展示的错误摘要',
   'worker.empty_final_failed': '⚠️ {cliName} 本轮执行失败：{reason}\n完整错误已保留在 Web 终端和 daemon 日志中；排除问题后请重发消息。',
   'worker.empty_final_failed_invalid_request': '⚠️ {cliName} 请求被拒绝：{reason}\n请检查 CLI、模型网关和工具 schema 配置，修复后重发消息。',

--- a/src/services/bridge-turn-journal.ts
+++ b/src/services/bridge-turn-journal.ts
@@ -137,6 +137,50 @@ export function selectRestorableBridgeTurns(
   const maxAgeMs = opts.maxAgeMs ?? BRIDGE_TURN_RESTORE_MAX_AGE_MS;
   return entries
     .filter(entry => entry.jsonlPath === opts.currentJsonlPath
-      && nowMs - entry.markTimeMs <= maxAgeMs)
+      && nowMs - entry.markTimeMs <= maxAgeMs
+      // Only PLAIN Lark IM turns are restorable. Durable turns
+      // (dispatchAttempt set) have their own cross-restart recovery owner (the
+      // daemon's persisted queuedActivation* write-ahead + receipt
+      // auto-redispatch); restoring one from the journal would double-deliver
+      // (recovered partial + re-dispatched attempt share a turnId but carry
+      // different lastUuids, so the daemon dedupe can't collapse them). The
+      // write side already skips journaling them; this is belt-and-braces for a
+      // journal file left behind by a pre-fix build across an upgrade.
+      && entry.dispatchAttempt === undefined)
     .sort((a, b) => a.markTimeMs - b.markTimeMs);
+}
+
+/**
+ * One-shot latch that confines journal restore to a worker process's FIRST
+ * bridge baseline. Extracted from worker.ts (like InflightInputTracker) so the
+ * "restore at most once, only on the first baseline" rule is unit-testable.
+ *
+ * Why it exists: the journal recovers a plain-IM turn orphaned by a
+ * CROSS-process death (daemon restart / worker crash) — there the whole worker
+ * is new and no other recovery owner survives. But an IN-worker CLI restart
+ * (crash-respawn / cwd-move / durable lease expiry) keeps the process alive, so
+ * its InflightInputTracker carryover ALREADY re-delivers the interrupted plain
+ * IM input as a full fresh answer. If the journal ALSO restored that turn on the
+ * post-restart baseline, the recovered partial and the fresh answer — same
+ * turnId, different lastUuid — would both reach Lark (the daemon dedupe can't
+ * collapse them). The worker arms this latch on every watcher teardown, so only
+ * the first baseline (the one with no competing recovery owner) may restore.
+ */
+export class BridgeRestoreGate {
+  private consumed = false;
+
+  /** True only on the first call after construction — the process's first
+   *  baseline. Every later call (a post-restart baseline) returns false. Does
+   *  NOT itself consume the latch: an empty-journal first baseline must still
+   *  arm it via markGenerationRetired so a later restart can't restore. */
+  mayRestoreOnThisBaseline(): boolean {
+    return !this.consumed;
+  }
+
+  /** Arm the latch: a CLI generation has ended (watcher torn down), so any
+   *  future baseline is an in-worker restart, never first-baseline recovery.
+   *  Idempotent. */
+  markGenerationRetired(): void {
+    this.consumed = true;
+  }
 }

--- a/src/services/bridge-turn-journal.ts
+++ b/src/services/bridge-turn-journal.ts
@@ -1,0 +1,142 @@
+/**
+ * Durable journal of PENDING (not yet terminalized) Lark bridge turns.
+ *
+ * The Claude-bridge attribution queue (`BridgeTurnQueue`) lives in worker
+ * memory: when the worker dies mid-turn (daemon restart / upgrade / crash),
+ * every pending mark is lost, and on respawn the bridge baselines the
+ * transcript to EOF — so the interrupted turn's user line AND whatever
+ * assistant text the model produced before the kill are silently skipped.
+ * The user gets neither a `botmux send` (the model never reached it) nor the
+ * transcript-driven fallback (nothing left to harvest). This journal closes
+ * that gap:
+ *
+ *   - the worker appends an entry when it marks a Lark turn (delivery time),
+ *     recording everything the queue needs to re-create the mark PLUS the
+ *     consumed transcript offset at that moment;
+ *   - the entry is removed at every turn-terminal outcome (emitted,
+ *     suppressed, dropped, expired);
+ *   - on respawn, `bridgeAbsorbBaseline` consults the journal instead of
+ *     blindly baselining to EOF: surviving entries are re-marked and the
+ *     transcript is re-drained from the recorded offset, so the interrupted
+ *     turn's output is attributed and delivered through the NORMAL fallback
+ *     gate (send-marker dedup still applies — `turn-sends` markers persist
+ *     across restarts).
+ *
+ * Removal happens BEFORE the final_output IPC is sent (clear-at-pop): if the
+ * worker dies in between, the answer is lost rather than duplicated — the
+ * daemon-side dedupe key does not survive restarts, so duplicating would be
+ * the worse failure.
+ *
+ * The whole file is rewritten atomically (tmp + rename) on every mutation;
+ * the pending set is tiny (type-ahead depth, single digits), so this is
+ * cheaper and simpler than an append-only log with compaction.
+ */
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export interface BridgeTurnJournalEntry {
+  turnId: string;
+  dispatchAttempt?: number;
+  /** Wall-clock millis of the original mark — restored verbatim so the
+   *  send-marker window and the split cutoff keep their original bounds. */
+  markTimeMs: number;
+  fingerprint?: string;
+  contentNormalized?: string;
+  /** Transcript file the mark was armed against. Restore is scoped to the
+   *  SAME file — a rotation between generations makes attribution unsafe. */
+  jsonlPath: string;
+  /** Consumed transcript offset when the mark was armed. The turn's user
+   *  line can only exist at/after this byte, so restore re-drains from here
+   *  instead of re-reading the whole file. Always a line boundary. */
+  offsetAtMark: number;
+}
+
+/** Entries older than this are dropped at restore instead of re-marked: a
+ *  partial answer from days ago posted into a thread that has long moved on
+ *  is noise, not recovery. */
+export const BRIDGE_TURN_RESTORE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** Bound on tracked entries — pathological mark storms must not grow the
+ *  journal unboundedly. Oldest entries are shed first (they are also the
+ *  first to fail the restore age gate). */
+const MAX_JOURNAL_ENTRIES = 32;
+
+interface BridgeTurnJournalFile {
+  version: 1;
+  pending: BridgeTurnJournalEntry[];
+}
+
+export function readBridgeTurnJournal(path: string): BridgeTurnJournalEntry[] {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as BridgeTurnJournalFile;
+    if (parsed?.version !== 1 || !Array.isArray(parsed.pending)) return [];
+    return parsed.pending.filter(entry =>
+      typeof entry?.turnId === 'string'
+      && typeof entry?.markTimeMs === 'number'
+      && typeof entry?.jsonlPath === 'string'
+      && typeof entry?.offsetAtMark === 'number');
+  } catch {
+    return [];
+  }
+}
+
+export function writeBridgeTurnJournal(path: string, pending: BridgeTurnJournalEntry[]): void {
+  const bounded = pending.length > MAX_JOURNAL_ENTRIES
+    ? pending.slice(pending.length - MAX_JOURNAL_ENTRIES)
+    : pending;
+  const payload: BridgeTurnJournalFile = { version: 1, pending: bounded };
+  mkdirSync(dirname(path), { recursive: true });
+  const tmpPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, `${JSON.stringify(payload)}\n`, { mode: 0o600 });
+  renameSync(tmpPath, path);
+}
+
+export function appendBridgeTurnJournalEntry(path: string, entry: BridgeTurnJournalEntry): void {
+  const pending = readBridgeTurnJournal(path)
+    .filter(existing => !(existing.turnId === entry.turnId && existing.dispatchAttempt === entry.dispatchAttempt));
+  pending.push(entry);
+  writeBridgeTurnJournal(path, pending);
+}
+
+export function removeBridgeTurnJournalEntry(
+  path: string,
+  turnId: string,
+  dispatchAttempt?: number,
+): void {
+  const pending = readBridgeTurnJournal(path);
+  const remaining = pending.filter(entry =>
+    !(entry.turnId === turnId
+      && (dispatchAttempt === undefined || entry.dispatchAttempt === dispatchAttempt)));
+  if (remaining.length === pending.length) return;
+  if (remaining.length === 0) {
+    rmSync(path, { force: true });
+    return;
+  }
+  writeBridgeTurnJournal(path, remaining);
+}
+
+export function clearBridgeTurnJournal(path: string): void {
+  rmSync(path, { force: true });
+}
+
+/** Pure restore filter: which journal entries may be re-marked on this
+ *  worker generation? Scoped to the same transcript file (rotation between
+ *  generations makes offset+fingerprint attribution unsafe) and bounded by
+ *  age (stale partials are noise). */
+export function selectRestorableBridgeTurns(
+  entries: readonly BridgeTurnJournalEntry[],
+  opts: { currentJsonlPath: string; nowMs?: number; maxAgeMs?: number },
+): BridgeTurnJournalEntry[] {
+  const nowMs = opts.nowMs ?? Date.now();
+  const maxAgeMs = opts.maxAgeMs ?? BRIDGE_TURN_RESTORE_MAX_AGE_MS;
+  return entries
+    .filter(entry => entry.jsonlPath === opts.currentJsonlPath
+      && nowMs - entry.markTimeMs <= maxAgeMs)
+    .sort((a, b) => a.markTimeMs - b.markTimeMs);
+}

--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -103,6 +103,11 @@ export interface BridgePendingTurn {
    *  the turn — short fingerprints ("hello", "test") would otherwise risk
    *  matching pre-existing user lines in unrelated sibling jsonls. */
   markTimeMs?: number;
+  /** Set when this mark was re-created from the durable turn journal after a
+   *  worker/daemon restart interrupted the turn. The emit path prefixes the
+   *  delivered fallback with an "interrupted by restart" notice so the user
+   *  can tell a recovered partial answer from a live one. */
+  restoredFromJournal?: boolean;
 }
 
 /** Trim a Lark message into a stable fingerprint. Keeps a leading window
@@ -181,6 +186,7 @@ export class BridgeTurnQueue {
     markTimeMs: number = Date.now(),
     contentNormalized?: string,
     dispatchAttempt?: number,
+    opts?: { restoredFromJournal?: boolean },
   ): string {
     this.queue.push({
       turnId,
@@ -190,6 +196,7 @@ export class BridgeTurnQueue {
       contentFingerprint,
       contentNormalized,
       markTimeMs,
+      ...(opts?.restoredFromJournal ? { restoredFromJournal: true } : {}),
     });
     return turnId;
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -111,6 +111,7 @@ import {
 import { TurnTerminalDeduper } from './services/turn-terminal-deduper.js';
 import {
   appendBridgeTurnJournalEntry,
+  BridgeRestoreGate,
   clearBridgeTurnJournal,
   readBridgeTurnJournal,
   removeBridgeTurnJournalEntry,
@@ -4058,6 +4059,19 @@ const bridgeSecondaryPaths = new Map<string, number>(); // path → offset
 let bridgeOffset = 0;
 let bridgePendingTail = '';
 const bridgeQueue = new BridgeTurnQueue();
+/** Journal-restore of interrupted Lark turns is allowed AT MOST ONCE per worker
+ *  process, and only on the FIRST baseline this process runs. Rationale: the
+ *  journal exists to recover a turn that a *cross-process* death (daemon
+ *  restart / worker crash) orphaned — there the whole worker is new and no
+ *  other recovery owner survives. An *in-worker* CLI restart (crash-respawn,
+ *  cwd-move, durable lease expiry) keeps this process alive, so its
+ *  InflightInputTracker carryover already re-delivers the interrupted plain-IM
+ *  input (a full fresh answer) — letting the journal ALSO restore that turn
+ *  would post the recovered partial AND the fresh answer (same turnId, different
+ *  lastUuid → daemon dedupe can't collapse them). Armed on every watcher
+ *  teardown so restore is confined to the one baseline with no competing
+ *  recovery owner. */
+const bridgeRestoreGate = new BridgeRestoreGate();
 /** uuids of structured transcript rate-limit records already turned into a
  *  `limited` emit. Readers may re-read from offset 0 after rotation, so the
  *  stable record uuid keeps the notification idempotent. */
@@ -4488,6 +4502,12 @@ function bridgeAbsorbBaseline(): void {
  *      persist across restarts, so an answer the model already `botmux
  *      send`-ed before the kill stays suppressed. */
 function tryRestoreInterruptedBridgeTurns(): boolean {
+  // At-most-once, and only on this worker process's FIRST bridge baseline. Any
+  // baseline that runs after a watcher teardown is an in-worker CLI restart
+  // whose InflightInputTracker carryover already re-delivers the interrupted
+  // turn — restoring here too would double-deliver (see bridgeRestoreGate,
+  // armed in stopBridgeWatcher).
+  if (!bridgeRestoreGate.mayRestoreOnThisBaseline()) return false;
   const journalPath = bridgeTurnJournalFilePath();
   if (!journalPath || !bridgeJsonlPath) return false;
   const entries = readBridgeTurnJournal(journalPath);
@@ -5289,6 +5309,12 @@ function stopBridgeWatcher(): void {
   // A fresh backend must not inherit a terminal/fingerprint from the exited
   // process; durable replay is owned by the receiver with a new attempt.
   bridgeQueue.clearPending();
+  // A watcher teardown means this worker process has now had at least one CLI
+  // generation, so any FUTURE baseline is an in-worker restart — never the
+  // first-baseline cross-process recovery the journal is for. Disarm journal
+  // restore: the restart's InflightInputTracker carryover already re-delivers
+  // the interrupted turn, and restoring on top would double-deliver.
+  bridgeRestoreGate.markGenerationRetired();
   bridgePreambleSent = false;
 }
 
@@ -5356,10 +5382,17 @@ function bridgeMarkPendingTurn(
   const markTimeMs = Date.now();
   bridgeQueue.mark(turnId, fingerprint, markTimeMs, contentNormalized, dispatchAttempt);
   // Journal the mark so a worker/daemon restart mid-turn can restore it
-  // (bridgeAbsorbBaseline). Adopt mode is excluded: its baseline absorbs the
-  // whole transcript with different semantics, and adopt drain never
-  // suppresses — restore marks would double-attribute.
-  if (!lastInitConfig?.adoptMode && bridgeJsonlPath) {
+  // (bridgeAbsorbBaseline). Excluded:
+  //   - adopt mode: its baseline absorbs the whole transcript with different
+  //     semantics and never suppresses — restore marks would double-attribute;
+  //   - durable turns (dispatchAttempt !== undefined): a durable delivery has
+  //     its OWN cross-restart recovery owner (the daemon's persisted
+  //     queuedActivation* write-ahead + receipt auto-redispatch), so a journal
+  //     restore is always redundant for it and — because the recovered partial
+  //     and the re-dispatched attempt carry the same turnId but different
+  //     lastUuid — would double-deliver. Only PLAIN Lark IM turns (no other
+  //     recovery owner) actually need the journal.
+  if (!lastInitConfig?.adoptMode && bridgeJsonlPath && dispatchAttempt === undefined) {
     journalBridgeTurnMark({
       turnId,
       dispatchAttempt,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -109,6 +109,14 @@ import {
   evaluateVcMeetingManagedSend,
 } from './services/vc-meeting-send-policy.js';
 import { TurnTerminalDeduper } from './services/turn-terminal-deduper.js';
+import {
+  appendBridgeTurnJournalEntry,
+  clearBridgeTurnJournal,
+  readBridgeTurnJournal,
+  removeBridgeTurnJournalEntry,
+  selectRestorableBridgeTurns,
+  writeBridgeTurnJournal,
+} from './services/bridge-turn-journal.js';
 import { defaultGatewayEntry, ensureGatewayEntry } from './core/plugins/mcp/gateway-installer.js';
 import {
   sessionMcpGatewayPathRegex,
@@ -4225,6 +4233,49 @@ function bridgeMarkerPath(): string | undefined {
   return join(process.env.SESSION_DATA_DIR, 'turn-sends', `${sessionId}.jsonl`);
 }
 
+/** Durable journal of pending Lark bridge turns (services/bridge-turn-journal).
+ *  Written at mark time, cleared at every turn-terminal outcome; consulted by
+ *  bridgeAbsorbBaseline after a restart so an interrupted turn's output can
+ *  still reach Lark. Sibling of the turn-sends marker file. */
+function bridgeTurnJournalFilePath(): string | undefined {
+  if (!process.env.SESSION_DATA_DIR || !sessionId) return undefined;
+  return join(process.env.SESSION_DATA_DIR, 'turn-marks', `${sessionId}.json`);
+}
+
+function journalBridgeTurnMark(entry: {
+  turnId: string;
+  dispatchAttempt?: number;
+  markTimeMs: number;
+  fingerprint?: string;
+  contentNormalized?: string;
+  jsonlPath: string;
+  offsetAtMark: number;
+}): void {
+  const path = bridgeTurnJournalFilePath();
+  if (!path) return;
+  try {
+    appendBridgeTurnJournalEntry(path, entry);
+  } catch (err: any) {
+    log(`Bridge turn journal write failed (${err.message}) — restart recovery unavailable for turn ${entry.turnId.substring(0, 8)}`);
+  }
+}
+
+function journalBridgeTurnClear(turnId: string, dispatchAttempt?: number): void {
+  const path = bridgeTurnJournalFilePath();
+  if (!path) return;
+  try {
+    removeBridgeTurnJournalEntry(path, turnId, dispatchAttempt);
+  } catch (err: any) {
+    log(`Bridge turn journal clear failed (${err.message}) for turn ${turnId.substring(0, 8)}`);
+  }
+}
+
+function clearBridgeTurnJournalFile(): void {
+  const path = bridgeTurnJournalFilePath();
+  if (!path) return;
+  try { clearBridgeTurnJournal(path); } catch { /* best-effort — session is closing */ }
+}
+
 function readSendMarkers(): BridgeSendMarker[] {
   if (closeRequested) return [];
   const path = bridgeMarkerPath();
@@ -4386,6 +4437,12 @@ function scheduleHerdrAdoptBridgeQuietEmit(): void {
 function bridgeAbsorbBaseline(): void {
   if (!bridgeJsonlPath) return;
   if (!lastInitConfig?.adoptMode) {
+    // Restart recovery: if the previous generation left pending Lark turns in
+    // the durable journal (worker/daemon died mid-turn), re-mark them and
+    // baseline BEHIND their recorded offsets instead of skipping to EOF — the
+    // interrupted turn's user line and partial assistant output are then
+    // re-attributed and delivered through the normal fallback gate.
+    if (tryRestoreInterruptedBridgeTurns()) return;
     const cursor = baselineJsonlCursor(bridgeJsonlPath);
     bridgeOffset = cursor.newOffset;
     bridgePendingTail = cursor.pendingTail;
@@ -4403,6 +4460,66 @@ function bridgeAbsorbBaseline(): void {
   // claude-code fallback bridge also uses baseline-existing on daemon
   // restart/resume; it must not emit the "/adopt 前最后一轮" message.
   if (lastInitConfig?.adoptMode) maybeEmitAdoptPreamble(result.events);
+}
+
+/** Restore journal-persisted pending turns after a restart interrupted them.
+ *
+ *  Returns true when it established the bridge cursor itself (restore mode);
+ *  false when there is nothing to restore and the caller should run the
+ *  normal baseline-to-EOF.
+ *
+ *  Scope guards (all deliberate):
+ *    - non-adopt only (caller gates);
+ *    - same transcript file only — a sessionId rotation between generations
+ *      invalidates offsets and risks cross-file mis-attribution;
+ *    - bounded age (BRIDGE_TURN_RESTORE_MAX_AGE_MS) — a partial answer from
+ *      days ago is noise, not recovery.
+ *
+ *  Safety properties:
+ *    - events before the earliest mark (minus the same 5s guard the
+ *      fingerprint switch uses) are ABSORBED as history, so old turns are
+ *      never re-emitted;
+ *    - a stray prior-turn assistant tail after the cutoff can only synthesize
+ *      a local turn, which the non-adopt emit gate always suppresses;
+ *    - a restored mark whose user line never landed in the jsonl simply
+ *      never starts, and pruneExpired clears it (journal entry included) on
+ *      the first idle tick;
+ *    - the send-marker gate still applies at emit — turn-sends markers
+ *      persist across restarts, so an answer the model already `botmux
+ *      send`-ed before the kill stays suppressed. */
+function tryRestoreInterruptedBridgeTurns(): boolean {
+  const journalPath = bridgeTurnJournalFilePath();
+  if (!journalPath || !bridgeJsonlPath) return false;
+  const entries = readBridgeTurnJournal(journalPath);
+  if (entries.length === 0) return false;
+  const restorable = selectRestorableBridgeTurns(entries, { currentJsonlPath: bridgeJsonlPath });
+  if (restorable.length !== entries.length) {
+    // Entries for rotated-away files or beyond the age cap can never restore —
+    // drop them now so they don't linger across future generations.
+    try { writeBridgeTurnJournal(journalPath, restorable); } catch { /* best-effort */ }
+  }
+  if (restorable.length === 0) return false;
+  for (const entry of restorable) {
+    bridgeQueue.mark(
+      entry.turnId,
+      entry.fingerprint,
+      entry.markTimeMs,
+      entry.contentNormalized,
+      entry.dispatchAttempt,
+      { restoredFromJournal: true },
+    );
+  }
+  const fromOffset = Math.min(...restorable.map(entry => entry.offsetAtMark));
+  const drained = drainTranscript(bridgeJsonlPath, fromOffset);
+  bridgeOffset = drained.newOffset;
+  bridgePendingTail = drained.pendingTail;
+  const cutoffMs = Math.min(...restorable.map(entry => entry.markTimeMs)) - 5_000;
+  const { history, live } = splitTranscriptEventsByCutoff(drained.events, cutoffMs);
+  bridgeQueue.absorb(history);
+  if (live.length > 0) bridgeQueue.ingest(live, bridgeJsonlPath);
+  bridgeBaselineDone = true;
+  log(`Bridge restored ${restorable.length} interrupted turn(s) from journal (drain ${fromOffset}→${bridgeOffset}, absorbed=${history.length}, live=${live.length})`);
+  return true;
 }
 
 /** Record `bridgeStalePidStateSessionId` if the pid file's current sid
@@ -4935,6 +5052,7 @@ function bridgeIngest(): void {
   const expired = bridgeQueue.pruneExpired(BRIDGE_PENDING_TURN_TTL_MS);
   for (const t of expired) {
     if (t.contentFingerprint) bridgeFingerprintScanLastMs.delete(t.contentFingerprint);
+    journalBridgeTurnClear(t.turnId, t.dispatchAttempt);
     log(`Bridge mark expired after ${Math.round(BRIDGE_PENDING_TURN_TTL_MS / 1000)}s without matching a jsonl user line (turnId=${t.turnId}) — dropped to prevent rotation-fallback scan loop.`);
   }
   // Drain secondary paths first so any trailing assistant text on an old
@@ -5235,7 +5353,23 @@ function bridgeMarkPendingTurn(
   const normalised = normaliseForFingerprint(messageText);
   const contentNormalized = normalised.length > 0 ? normalised : undefined;
   const turnId = preferredTurnId ?? randomBytes(8).toString('hex');
-  bridgeQueue.mark(turnId, fingerprint, Date.now(), contentNormalized, dispatchAttempt);
+  const markTimeMs = Date.now();
+  bridgeQueue.mark(turnId, fingerprint, markTimeMs, contentNormalized, dispatchAttempt);
+  // Journal the mark so a worker/daemon restart mid-turn can restore it
+  // (bridgeAbsorbBaseline). Adopt mode is excluded: its baseline absorbs the
+  // whole transcript with different semantics, and adopt drain never
+  // suppresses — restore marks would double-attribute.
+  if (!lastInitConfig?.adoptMode && bridgeJsonlPath) {
+    journalBridgeTurnMark({
+      turnId,
+      dispatchAttempt,
+      markTimeMs,
+      fingerprint,
+      contentNormalized,
+      jsonlPath: bridgeJsonlPath,
+      offsetAtMark: bridgeOffset,
+    });
+  }
   return turnId;
 }
 
@@ -5265,6 +5399,13 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
         requireExplicitTerminalForDurable: true,
       });
   if (ready.length === 0) return;
+  // Every popped turn is terminal (emitted or suppressed below) — retire its
+  // durable journal entry NOW, before the final_output IPC. Clear-before-send:
+  // if the worker dies in between, the answer is lost rather than duplicated
+  // (the daemon-side dedupe key does not survive restarts).
+  for (const turn of ready) {
+    if (!turn.isLocal) journalBridgeTurnClear(turn.turnId, turn.dispatchAttempt);
+  }
   const adoptMode = lastInitConfig?.adoptMode === true;
   // Send markers (`botmux send` landed in own thread) + the queue's first
   // still-unready turn. The latter caps the LAST ready turn's window —
@@ -5377,9 +5518,16 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
       continue;
     }
 
+    // A restored turn's fallback is a RECOVERED partial/final produced around
+    // a worker restart — label it so the user can tell it from a live answer.
+    // Prefix is applied AFTER the suppress gate so dedup compares the model's
+    // own text, never the notice.
+    const deliveredText = turn.restoredFromJournal
+      ? `${t('worker.bridge_restored_turn_notice')}\n\n${postText}`
+      : postText;
     send({
       type: 'final_output',
-      content: postText,
+      content: deliveredText,
       lastUuid,
       turnId: turn.turnId,
       ...(turn.dispatchAttempt !== undefined ? { dispatchAttempt: turn.dispatchAttempt } : {}),
@@ -9944,6 +10092,7 @@ function dropFailedBridgeMark(bridgeTurnId?: string, dispatchAttempt?: number): 
   const droppedStructured = codexBridgeQueue.dropPendingTurn(bridgeTurnId, dispatchAttempt);
   if (dropped) {
     if (dropped.contentFingerprint) bridgeFingerprintScanLastMs.delete(dropped.contentFingerprint);
+    journalBridgeTurnClear(bridgeTurnId, dispatchAttempt);
     log(`Bridge mark dropped after submit failure (turnId=${bridgeTurnId}) — rotation-fallback scan will stop spinning on this fingerprint.`);
   }
   if (droppedStructured) {
@@ -18099,11 +18248,13 @@ process.on('message', async (raw: unknown) => {
         catch { /* logged by backend */ }
       }
       killCli();
-      // Bridge marker file outlives a single CLI process (we keep it across
-      // restarts so a mid-flight send is still credited), but a real close
-      // tears down the session — purge the file so a future re-use of the
-      // same sessionId starts clean.
+      // Bridge marker + turn-journal files outlive a single CLI process (kept
+      // across restarts so a mid-flight send is still credited and an
+      // interrupted turn can be restored), but a real close tears down the
+      // session — purge both so a future re-use of the same sessionId starts
+      // clean.
       clearSendMarkers();
+      clearBridgeTurnJournalFile();
       cleanup();
       process.exit(0);
     }
@@ -18276,6 +18427,7 @@ process.on('message', async (raw: unknown) => {
       stopCodexBridge();
       killCli();
       clearSendMarkers();
+      clearBridgeTurnJournalFile();
       cleanup();
       process.exit(0);
     }

--- a/test/bridge-turn-journal.test.ts
+++ b/test/bridge-turn-journal.test.ts
@@ -25,6 +25,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   appendBridgeTurnJournalEntry,
+  BridgeRestoreGate,
   clearBridgeTurnJournal,
   readBridgeTurnJournal,
   removeBridgeTurnJournalEntry,
@@ -131,6 +132,46 @@ describe('selectRestorableBridgeTurns', () => {
     ];
     const restorable = selectRestorableBridgeTurns(entries, { currentJsonlPath: '/a.jsonl', nowMs: now });
     expect(restorable.map(e => e.turnId)).toEqual(['older', 'newer']);
+  });
+
+  it('excludes durable turns (dispatchAttempt set) — they self-recover, restoring would double-deliver', () => {
+    // A durable turn has its own cross-restart recovery owner (daemon
+    // queuedActivation* write-ahead + receipt auto-redispatch). Restoring it
+    // from the journal too would post the recovered partial AND the
+    // re-dispatched attempt (same turnId, different lastUuid → daemon dedupe
+    // can't collapse them). The write side no longer journals durable turns;
+    // this guards a journal left behind by a pre-fix build across an upgrade.
+    const entries = [
+      entry({ turnId: 'plain', jsonlPath: '/a.jsonl', markTimeMs: now - 1_000 }),
+      entry({ turnId: 'durable', jsonlPath: '/a.jsonl', markTimeMs: now - 2_000, dispatchAttempt: 1 }),
+    ];
+    const restorable = selectRestorableBridgeTurns(entries, { currentJsonlPath: '/a.jsonl', nowMs: now });
+    expect(restorable.map(e => e.turnId)).toEqual(['plain']);
+  });
+});
+
+describe('BridgeRestoreGate (restore at most once, only on the first baseline)', () => {
+  it('allows restore on the first baseline, refuses every later baseline', () => {
+    const gate = new BridgeRestoreGate();
+    // First baseline of a fresh worker process (daemon restart / crash) — the
+    // one baseline with no competing recovery owner.
+    expect(gate.mayRestoreOnThisBaseline()).toBe(true);
+    // Peeking again without a generation retiring must NOT flip it: an empty
+    // first baseline that never restored still needs to restore if the file
+    // shows up on a lazy re-baseline within the same generation.
+    expect(gate.mayRestoreOnThisBaseline()).toBe(true);
+  });
+
+  it('disarms after a CLI generation is retired (in-worker restart)', () => {
+    const gate = new BridgeRestoreGate();
+    // A watcher teardown ends the first CLI generation. Every baseline after
+    // this is an in-worker restart whose carryover already re-delivers the
+    // interrupted turn — restoring again would double-deliver.
+    gate.markGenerationRetired();
+    expect(gate.mayRestoreOnThisBaseline()).toBe(false);
+    // Idempotent + terminal: further retirements keep it disarmed.
+    gate.markGenerationRetired();
+    expect(gate.mayRestoreOnThisBaseline()).toBe(false);
   });
 });
 

--- a/test/bridge-turn-journal.test.ts
+++ b/test/bridge-turn-journal.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for the durable bridge-turn journal (restart recovery of interrupted
+ * Lark turns) and the restore recipe worker.ts applies on top of it:
+ *
+ *   journal fs ops       — append / read / remove / clear, malformed input,
+ *                          bounded growth
+ *   restore filter       — same-jsonl scoping, age cap, mark-order sort
+ *   restore semantics    — the exact sequence tryRestoreInterruptedBridgeTurns
+ *                          performs (re-mark restored → split by cutoff →
+ *                          absorb history / ingest live → drain at idle),
+ *                          driven against the real BridgeTurnQueue + the real
+ *                          send-marker gate for the four outcomes:
+ *                            1. model already `botmux send`-ed before the kill
+ *                               → suppressed (turn-sends markers persist)
+ *                            2. model never sent → recovered text emitted,
+ *                               turn flagged restoredFromJournal
+ *                            3. partial output only → same as 2 (that IS the
+ *                               recovery case)
+ *                            4. no output / user line never landed → turn
+ *                               never starts; pruneExpired retires it
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  appendBridgeTurnJournalEntry,
+  clearBridgeTurnJournal,
+  readBridgeTurnJournal,
+  removeBridgeTurnJournalEntry,
+  selectRestorableBridgeTurns,
+  writeBridgeTurnJournal,
+  BRIDGE_TURN_RESTORE_MAX_AGE_MS,
+  type BridgeTurnJournalEntry,
+} from '../src/services/bridge-turn-journal.js';
+import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from '../src/services/bridge-turn-queue.js';
+import { shouldSuppressBridgeEmit, type BridgeSendMarker } from '../src/services/bridge-fallback-gate.js';
+import { splitTranscriptEventsByCutoff, type TranscriptEvent } from '../src/services/claude-transcript.js';
+
+function user(uuid: string, content: string, timestampMs: number): TranscriptEvent {
+  return { type: 'user', uuid, timestamp: new Date(timestampMs).toISOString(), message: { role: 'user', content } };
+}
+function assistant(uuid: string, text: string, timestampMs: number): TranscriptEvent {
+  return {
+    type: 'assistant',
+    uuid,
+    timestamp: new Date(timestampMs).toISOString(),
+    message: { role: 'assistant', content: [{ type: 'text', text }] },
+  };
+}
+
+function entry(overrides: Partial<BridgeTurnJournalEntry> = {}): BridgeTurnJournalEntry {
+  return {
+    turnId: 'turn-1',
+    markTimeMs: 1_000_000,
+    jsonlPath: '/tmp/session.jsonl',
+    offsetAtMark: 0,
+    ...overrides,
+  };
+}
+
+describe('bridge turn journal file ops', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'bridge-turn-journal-'));
+    path = join(dir, 'turn-marks', 'session.json');
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('appends, reads back, removes per turn, and clears', () => {
+    appendBridgeTurnJournalEntry(path, entry({ turnId: 't1', markTimeMs: 1 }));
+    appendBridgeTurnJournalEntry(path, entry({ turnId: 't2', markTimeMs: 2, dispatchAttempt: 3 }));
+    expect(readBridgeTurnJournal(path).map(e => e.turnId)).toEqual(['t1', 't2']);
+
+    removeBridgeTurnJournalEntry(path, 't1');
+    expect(readBridgeTurnJournal(path).map(e => e.turnId)).toEqual(['t2']);
+
+    // Removing the last entry deletes the file entirely.
+    removeBridgeTurnJournalEntry(path, 't2', 3);
+    expect(readBridgeTurnJournal(path)).toEqual([]);
+    expect(existsSync(path)).toBe(false);
+
+    appendBridgeTurnJournalEntry(path, entry({ turnId: 't3' }));
+    clearBridgeTurnJournal(path);
+    expect(readBridgeTurnJournal(path)).toEqual([]);
+  });
+
+  it('re-marking the same turnId+attempt replaces the old entry', () => {
+    appendBridgeTurnJournalEntry(path, entry({ turnId: 't1', offsetAtMark: 10 }));
+    appendBridgeTurnJournalEntry(path, entry({ turnId: 't1', offsetAtMark: 99 }));
+    const entries = readBridgeTurnJournal(path);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].offsetAtMark).toBe(99);
+  });
+
+  it('treats malformed or wrong-shape files as empty', () => {
+    writeBridgeTurnJournal(path, [entry()]);
+    writeFileSync(path, 'not json');
+    expect(readBridgeTurnJournal(path)).toEqual([]);
+    writeFileSync(path, JSON.stringify({ version: 99, pending: [entry()] }));
+    expect(readBridgeTurnJournal(path)).toEqual([]);
+    writeFileSync(path, JSON.stringify({ version: 1, pending: [{ turnId: 42 }] }));
+    expect(readBridgeTurnJournal(path)).toEqual([]);
+  });
+
+  it('bounds journal growth by shedding oldest entries', () => {
+    const many = Array.from({ length: 50 }, (_, i) => entry({ turnId: `t${i}`, markTimeMs: i }));
+    writeBridgeTurnJournal(path, many);
+    const kept = readBridgeTurnJournal(path);
+    expect(kept.length).toBe(32);
+    expect(kept[0].turnId).toBe('t18');
+    expect(kept.at(-1)!.turnId).toBe('t49');
+    // Sanity: the payload really is a single JSON object, not an append log.
+    expect(JSON.parse(readFileSync(path, 'utf8')).version).toBe(1);
+  });
+});
+
+describe('selectRestorableBridgeTurns', () => {
+  const now = 10_000_000;
+
+  it('keeps only same-file, fresh entries, sorted by mark time', () => {
+    const entries = [
+      entry({ turnId: 'newer', jsonlPath: '/a.jsonl', markTimeMs: now - 1_000 }),
+      entry({ turnId: 'rotated', jsonlPath: '/b.jsonl', markTimeMs: now - 1_000 }),
+      entry({ turnId: 'older', jsonlPath: '/a.jsonl', markTimeMs: now - 5_000 }),
+      entry({ turnId: 'stale', jsonlPath: '/a.jsonl', markTimeMs: now - BRIDGE_TURN_RESTORE_MAX_AGE_MS - 1 }),
+    ];
+    const restorable = selectRestorableBridgeTurns(entries, { currentJsonlPath: '/a.jsonl', nowMs: now });
+    expect(restorable.map(e => e.turnId)).toEqual(['older', 'newer']);
+  });
+});
+
+describe('restore semantics against the real queue + gate', () => {
+  // Timeline: an old completed turn, then the interrupted turn's user line and
+  // partial assistant output, then the worker died. The new generation
+  // re-marks from the journal and re-drains from the recorded offset.
+  const markTimeMs = 1_700_000_000_000;
+  const cutoffMs = markTimeMs - 5_000; // same guard the fingerprint switch uses
+  const larkMessage = '@Bot 检查部署结果并汇报';
+
+  function restoredQueueWithEvents(events: TranscriptEvent[]): BridgeTurnQueue {
+    const q = new BridgeTurnQueue();
+    q.mark(
+      'turn-interrupted',
+      makeFingerprint(larkMessage),
+      markTimeMs,
+      normaliseForFingerprint(larkMessage),
+      undefined,
+      { restoredFromJournal: true },
+    );
+    const { history, live } = splitTranscriptEventsByCutoff(events, cutoffMs);
+    q.absorb(history);
+    if (live.length > 0) q.ingest(live, '/tmp/session.jsonl');
+    return q;
+  }
+
+  const oldTurnEvents = [
+    user('old-u', '<user_message>早先的问题</user_message>', markTimeMs - 60_000),
+    assistant('old-a', '早先的回答', markTimeMs - 55_000),
+  ];
+  const interruptedTurnEvents = [
+    user('cur-u', `<user_message>${larkMessage}</user_message>`, markTimeMs + 1_000),
+    assistant('cur-a', '部署已验证，fleet 全部在线。正准备汇报时被杀。', markTimeMs + 20_000),
+  ];
+
+  it('recovers the interrupted turn: history absorbed, live attributed, restored flag set', () => {
+    const q = restoredQueueWithEvents([...oldTurnEvents, ...interruptedTurnEvents]);
+    const ready = q.drainEmittable();
+    expect(ready).toHaveLength(1);
+    expect(ready[0].turnId).toBe('turn-interrupted');
+    expect(ready[0].restoredFromJournal).toBe(true);
+    // Only the interrupted turn's assistant text — the old turn was absorbed.
+    expect(ready[0].assistantUuids).toEqual(['cur-a']);
+  });
+
+  it('suppresses the recovered turn when a persisted send marker already covers it (已 send)', () => {
+    const q = restoredQueueWithEvents([...oldTurnEvents, ...interruptedTurnEvents]);
+    const [turn] = q.drainEmittable();
+    // turn-sends markers persist across restarts; the model sent this text
+    // mid-turn before the kill.
+    const markers: BridgeSendMarker[] = [{
+      sentAtMs: markTimeMs + 15_000,
+      contentLength: normaliseForFingerprint('部署已验证，fleet 全部在线。正准备汇报时被杀。').length,
+    }];
+    expect(shouldSuppressBridgeEmit(
+      { markTimeMs: turn.markTimeMs, isLocal: turn.isLocal, finalText: '部署已验证，fleet 全部在线。正准备汇报时被杀。' },
+      undefined,
+      markers,
+      false,
+    )).toBe(true);
+  });
+
+  it('emits the recovered turn when nothing was sent (未 send / 部分输出)', () => {
+    const q = restoredQueueWithEvents([...oldTurnEvents, ...interruptedTurnEvents]);
+    const [turn] = q.drainEmittable();
+    expect(shouldSuppressBridgeEmit(
+      { markTimeMs: turn.markTimeMs, isLocal: turn.isLocal, finalText: '部署已验证，fleet 全部在线。正准备汇报时被杀。' },
+      undefined,
+      [],
+      false,
+    )).toBe(false);
+  });
+
+  it('holds a restored turn whose user line landed but produced no output yet, and prunes one whose user line never landed (无输出)', () => {
+    // Case A: user line landed, no assistant text — started turn is held (not
+    // popped, not pruned) so a post-restart continuation can still attach.
+    const started = restoredQueueWithEvents([...oldTurnEvents, interruptedTurnEvents[0]]);
+    expect(started.drainEmittable()).toHaveLength(0);
+    expect(started.pruneExpired(1, markTimeMs + 10 * 60_000)).toHaveLength(0);
+    expect(started.peek()[0]?.started).toBe(true);
+
+    // Case B: the kill happened before Claude wrote the user line — the mark
+    // never starts and the TTL sweep retires it.
+    const neverStarted = restoredQueueWithEvents(oldTurnEvents);
+    expect(neverStarted.drainEmittable()).toHaveLength(0);
+    const expired = neverStarted.pruneExpired(1, markTimeMs + 10 * 60_000);
+    expect(expired.map(t => t.turnId)).toEqual(['turn-interrupted']);
+  });
+
+  it('a stray prior-turn assistant tail after the cutoff only synthesizes a local turn, which the non-adopt gate suppresses', () => {
+    // The previous turn's late assistant flush can land after cutoff without a
+    // matching user line. It must not be attributed to the restored Lark turn,
+    // and its synthesized local turn is always suppressed in non-adopt mode.
+    const q = restoredQueueWithEvents([
+      assistant('stray-a', '上一轮迟到的输出', markTimeMs - 2_000),
+      ...interruptedTurnEvents,
+    ]);
+    const ready = q.drainEmittable();
+    const larkTurn = ready.find(t => t.turnId === 'turn-interrupted');
+    expect(larkTurn?.assistantUuids).toEqual(['cur-a']);
+    for (const t of ready.filter(t => t.turnId !== 'turn-interrupted')) {
+      expect(t.isLocal).toBe(true);
+      expect(shouldSuppressBridgeEmit(
+        { markTimeMs: t.markTimeMs, isLocal: t.isLocal },
+        undefined,
+        [],
+        false,
+      )).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## 改了什么

「兜底续上」第二道防线（第一道是 #943 的 mcp-gateway 重连）。此前 Claude bridge 的 pending turn marks 只活在 worker 内存：daemon 重启杀掉 worker 后，respawn 的 bridge 直接 baseline 到 transcript 末尾（防重发历史的有意设计），被打断回合的 user line 和已产出的 assistant 文本被一并跳过——用户既等不到 `botmux send`（模型没执行到），也等不到兜底（无 final 可捞），话题静默。

1. **新增 `services/bridge-turn-journal`**：worker mark 一个 Lark turn 时，把 `turnId / markTimeMs / fingerprint / 归一化全文 / jsonl 路径 / 当时消费 offset` 原子落盘到 `data/turn-marks/<sid>.json`（与既有 `turn-sends` send 去重 marker 并列）；回合到达任一终结点（emit、suppress、drop、TTL 过期）即清除。**clear-before-send**：worker 在发出 final_output IPC 之前先清 journal——若恰在其间死掉，结果是丢一条而不是重复发（daemon 侧 dedupe key 不跨重启）。

2. **respawn 恢复**（`bridgeAbsorbBaseline`）：journal 有未终结回合时不再盲跳 EOF，改为从记录 offset 重放 transcript，按「最早 markTimeMs − 5s」cutoff（与 fingerprint switch 同一约定）把之前的事件 absorb 成历史、之后正常 ingest。恢复的 mark 带 `restoredFromJournal` 标志走既有归因/兜底管线：
   - 模型被杀前已 `botmux send` 过 → turn-sends marker 跨重启持久，emit gate 照常抑制，不重复
   - 没 send 过 → 中断前的输出作为兜底发出，正文前带标注「⚠️ 本轮曾因 botmux 重启中断，以下是从终端记录恢复的该轮输出（可能不完整）」（zh/en i18n）
   - user line 落了但没有任何输出 → started turn 保持等待（resume 后若续跑可继续归因）
   - user line 根本没落盘（杀在提交前）→ mark 永不 start，既有 2 分钟 TTL 清扫回收并连带清 journal

3. **范围护栏**：仅非 adopt；仅同一 transcript 文件（代际间 sessionId rotation 使 offset/归因不可靠，放弃恢复）；仅 24h 内的 mark；cutoff 后迟到的上一轮 assistant 尾巴只会合成 local turn，被非 adopt gate 恒定抑制，不会错发。session 真正 close 时 journal 随 turn-sends 一起清空。

## 影响面

- 仅影响 **Claude 系 jsonl bridge 的非 adopt 会话**在 worker/daemon 重启后的恢复路径；无重启的正常回合，journal 在终结时即清除，不参与任何决策
- **结构化 bridge（codex 系 RPC）未动**——它有独立的持久化/生命周期机制
- adopt 会话、PTY/tmux 各 backend 的正常 turn 流程行为不变（改动点在 baseline 与终结点埋点，均有 adopt/local 判断护栏）
- in-worker CLI 重启（crash respawn）同样受益：stop/start bridge watcher 后由同一 journal 恢复

## 测试

- 新增 `test/bridge-turn-journal.test.ts` **10 测全绿**：文件操作（append/replace/remove/clear/malformed/容量上限）、恢复筛选（同文件/时限/排序）、以及在真实 `BridgeTurnQueue` + 真实 send-marker gate 上驱动的四种恢复情形 + 跨 cutoff 迟到输出抑制
- bridge 相关既有 6 套件（turn-queue / fallback-gate / rotation-policy / input / final-output-retry / codex-bridge-queue）**311 测全绿**
- `pnpm build` 通过；全量 unit 套件失败集与 master 基线完全一致（config-dir / mojo-quarantine / plugin-mcp-sandbox 等本机环境既有失败），**零新增回归**
