### PR TITLE
fix(test): MCP sandbox 断言对齐 #917 的 _meta 回显

### DIFF
--- a/test/plugin-mcp-sandbox.test.ts
+++ b/test/plugin-mcp-sandbox.test.ts
@@ -221,9 +221,10 @@ describe.skipIf(process.platform !== 'linux' || !existsSync(builtCli) || !bwrapU
 
         expect((await client.listTools()).tools.map(tool => tool.name).sort()).toEqual(['alpha_unique', 'echo']);
         const result = await client.callTool({ name: 'echo', arguments: { value: 1 } });
-        expect((result.content[0] as { text: string }).text).toContain(
-          `alpha:echo:{"value":1}:session=${sessionId}:token=host-only-token`,
-        );
+        const echoed = (result.content[0] as { text: string }).text;
+        // #917 fixture 回显 `_meta`，不再与 session 字段连成一段。
+        expect(echoed).toContain('alpha:echo:{"value":1}');
+        expect(echoed).toContain(`session=${sessionId}:token=host-only-token`);
       } finally {
         if (client) await client.close().catch(() => undefined);
         else if (transport) await transport.close().catch(() => undefined);


### PR DESCRIPTION
优先级：P1（master `build` 当前红灯，本 PR 转绿）

## 根因

#917 给 MCP fixture 的 echo 加上 `meta=${JSON.stringify(_meta ?? {})}`，用来验证 `_meta.botmuxTrustedCaller`。`plugin-mcp-gateway` 已改成只断言 `session=` / `token=`；`plugin-mcp-sandbox` 仍 `toContain('alpha:echo:{"value":1}:session=...')`。

无宿主身份时实际回显是 `alpha:echo:{"value":1}:meta={}:session=...`，连续子串断裂。该文件 `skipIf` Linux + 可用 bwrap，macOS 本机会 skip，合入后 Linux CI 才红。

## 改动

- `test/plugin-mcp-sandbox.test.ts`：分段断言 `alpha:echo:{"value":1}` 与 `session=${id}:token=host-only-token`，与 gateway 测试对齐。
- 不改 Gateway / worker / sandbox 运行时，也不放宽「token 不进沙箱」的隔离断言。

## 影响面

- 仅测试断言。覆盖的是 Linux bwrap 下 session MCP 经 trusted host 转发；其它 CLI、后端、会话类型无行为变化。
- **跨平台**：该文件本就只在 Linux + bwrap 跑；macOS / 无 bwrap 继续 skip。
- **跨 CLI / 跨后端 / 跨会话类型**：不触及 `adapters/`、`worker.ts`、`daemon.ts`。

## 验证

- `pnpm build` 通过。
- `pnpm exec vitest run test/plugin-mcp-sandbox.test.ts test/plugin-mcp-gateway.test.ts --reporter=dot`：gateway 20 通过；sandbox 3 skip（本机非 Linux/bwrap，与改前相同）。sandbox 两条失败用例需 Linux CI 实跑确认。