### PR TITLE
feat(team): 团队维度 Agent 互查 + 跨机拉群客户端半环

### DIFF
--- a/docs-site/docs/en/cli-commands.md
+++ b/docs-site/docs/en/cli-commands.md
@@ -45,7 +45,8 @@ Session info is inferred automatically from ancestor-process markers, so the age
 | Command | Description |
 |------|------|
 | `botmux send [content]` | Send a message to the current topic (stdin / heredoc / `--content-file`; `--images`/`--files`/`--videos`/`--card-file`/`--card-json`/`--mention`) |
-| `botmux bots list` | List the bots in the current group (including open_id) |
+| `botmux bots list` | List the bots in the current group (including open_id); `--scope team [--team <id>]` discovers same-team, opted-in agents across machines (by specialty) |
+| `botmux bots invite --chat <chatId> --team <id> --agent <appId>...` | Add same-team agents + their owners into a group you're already in (auto-adds the platform app first if absent) |
 | `botmux history [--limit N]` | Pull the session history (JSON) |
 | `botmux quoted <message_id>` | Pull a single quoted message (JSON) |
 | `botmux schedule add/list/remove/pause/resume/run` | Manage scheduled tasks |

--- a/docs-site/docs/en/multi-bot.mdx
+++ b/docs-site/docs/en/multi-bot.mdx
@@ -23,6 +23,32 @@ After that, a bot can explicitly @ the other from its own session with `botmux s
 
 > A hard fact about cross-bot collaboration: **if you don't `--mention` the other bot, it won't be triggered at all**.
 
+## Team scope: cross-machine discovery + create-group / invite
+
+Once connected to the central platform, you can discover agents **on other people's machines within the same team** by **specialty** (even ones not yet in your group), and pull them in to collaborate. Three commands, each with a distinct job:
+
+```bash
+# Discover: list same-team, opted-in agents (use --team when this machine is in several teams)
+botmux bots list --scope team [--team <teamId>]
+
+# New group: pull discovered agents (by appId) + their owners into a platform-created focused group
+botmux create-group --team <teamId> --agent <appId> [--agent ...] [--name "Group name"]
+
+# Add to an existing group: add agents + their owners into a group you're already in (owners always included)
+botmux bots invite --chat <chatId> --team <teamId> --agent <appId> [--agent ...]
+```
+
+Each agent from `bots list --scope team` carries: `appId` (use it to invite), `name`, `specialties` (an array of tags), `mentionable`, `online`, `owner`, `machineId/machineName`.
+
+Key points:
+
+- **Opt-in gate**: the discovery list **only contains agents that joined the team** — i.e. their owner explicitly added them via the platform's "Manage bots". If an agent doesn't show up, its owner most likely hasn't added it yet.
+- **`specialties` / `mentionable` / `online` are self-reported** by the agent — for selection only, not a trusted credential.
+- **appId only, no @ needed**: precisely because you can't @ someone else's bot before it's in your group, team discovery/create-group/invite all go by appId + platform auth, sidestepping "can't click what you can't see". Authorization (team membership, opt-in) lives entirely on the platform; the CLI makes no such judgment.
+- **`bots invite` target group** requires: **you are already in it** and **the platform bot is in it**. When the platform bot is absent, botmux **automatically uses a local bot already in the group to add it, then retries** — usually invisible; only when the group requires owner approval to add bots, or you have no local bot in that group, will it ask you to add it manually.
+
+**Don't confuse the three add paths**: `create-group --team` (cross-team new group) / `bots invite` (add same-team people into a group you're already in) / Lark `/invite` (add a same-tenant bot within the current group).
+
 ## Typical scenarios
 
 - **Code review**: have Claude Code and Codex review the same MR together, picking holes in each other's views when they disagree.

--- a/docs-site/docs/zh/cli-commands.md
+++ b/docs-site/docs/zh/cli-commands.md
@@ -43,7 +43,8 @@ session 信息通过祖先进程标记自动推断，agent 直接调：
 | 命令 | 说明 |
 |------|------|
 | `botmux send [content]` | 向当前话题发消息（stdin / heredoc / `--content-file`；`--images`/`--files`/`--videos`/`--card-file`/`--card-json`/`--mention`） |
-| `botmux bots list` | 列出当前群里的机器人（含 open_id） |
+| `botmux bots list` | 列出当前群里的机器人（含 open_id）；`--scope team [--team <id>]` 跨机发现同团队、已 opt-in 的 agent（按专长） |
+| `botmux bots invite --chat <chatId> --team <id> --agent <appId>...` | 往「你已在场」的群补入同团队 agent + 各自 owner（平台 app 不在时自动拉进群再补） |
 | `botmux history [--limit N]` | 拉会话历史（JSON） |
 | `botmux quoted <message_id>` | 拉被引用的单条消息（JSON） |
 | `botmux schedule add/list/remove/pause/resume/run` | 管理定时任务 |

--- a/docs-site/docs/zh/multi-bot.mdx
+++ b/docs-site/docs/zh/multi-bot.mdx
@@ -23,6 +23,32 @@ botmux 会默认通过飞书群机器人列表自动发现当前群里的 bot。
 
 > 跨 bot 协作的硬性事实：**不 `--mention` 对方 bot，对方完全不会被触发**。
 
+## 团队维度：跨机发现 + 拉群 / 补人
+
+接入中心平台后，可以按**专长**发现**同团队、别人机器上**的 agent（哪怕还没进你的群），并把它们拉进群协作。三条命令、各管一摊：
+
+```bash
+# 发现：列同团队、已 opt-in 的 agent（本机在多团队时用 --team 指定）
+botmux bots list --scope team [--team <teamId>]
+
+# 建新群：把发现到的 agent（按 appId）+ 各自 owner 拉进一个平台代建的聚焦新群
+botmux create-group --team <teamId> --agent <appId> [--agent ...] [--name "群名"]
+
+# 往已有群补人：把 agent + 各自 owner 加进一个「你已在场」的群（恒带 owner）
+botmux bots invite --chat <chatId> --team <teamId> --agent <appId> [--agent ...]
+```
+
+`bots list --scope team` 返回的每个 agent 带：`appId`（拉群/补人就用它）、`name`、`specialties`（专长标签数组）、`mentionable`、`online`、`owner`、`machineId/machineName`。
+
+要点：
+
+- **opt-in 闸**：发现列表**只含已加入团队的 agent**——即它的 owner 在平台「管理机器人」把它显式加进了团队。查不到某个 agent，多半是对方 owner 还没加进来。
+- **`specialties` / `mentionable` / `online` 是 agent 自报**，仅供挑选参考，不是可信凭据。
+- **只认 appId、不需要 @**：正因为别人的 bot 进你群前你根本 @不到它，团队发现/拉群/补人全走 appId + 平台鉴权，天然绕开「看不见就点不着」。授权（团队成员校验、opt-in）全在平台，CLI 不做判断。
+- **`bots invite` 的目标群**要求：**你本人已在该群**，且**平台机器人在该群**。平台机器人不在时，botmux 会**自动用群里已有的本机 bot 把它拉进群、再自动重试补人**，通常无感；只有群设「加机器人需群主审批」或本机没有 bot 在该群时，才会提示你手动添加。
+
+**三条拉人路径别混**：`create-group --team`（跨 team 建新群）/ `bots invite`（往你已在场的群补同团队的人）/ 飞书 `/invite`（当前群内、同租户加 bot）。
+
 ## 典型场景
 
 - **代码 review**：让 Claude Code 和 Codex 一起看同一个 MR，观点不同时互相挑刺。

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12839,7 +12839,7 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
 
   if (!chatArg) {
     console.error('用法: botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]');
-    console.error('--chat 必填：目标群 chatId（必须是本团队自己建/拉的协作群，非机器人大厅）。');
+    console.error('--chat 必填：目标群 chatId（须已有平台机器人 BotmuxPlatform + 你本机的 bot 在场，非机器人大厅）。');
     process.exit(1);
   }
   if (appIds.length === 0) {
@@ -12858,10 +12858,13 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
     else if (res.reason === 'not_deployed') console.error('平台尚未部署补人端点（/v1/machine/groups/:chatId/members）。等平台上线后重试。');
     else if (res.reason === 'rate_limited') console.error(`补人被限流，${rateLimitRetryHint(res)}。`);
     else if (res.reason === 'client' && res.status === 403) {
-      // 403 可能是 chat_not_in_team（目标群不是本团队的群）/ chat_is_hall（大厅不允许补人）/ not_in_team_bots。
+      // 403 分支（平台按 error code 返回）：可行性/归属/opt-in/大厅，各给可操作的提示。
       const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';
-      const hint = res.error === 'chat_not_in_team' ? '目标群不是本团队的协作群，只能往本团队自己建/拉的群补人'
+      const hint =
+          res.error === 'platform_bot_not_in_chat' ? '平台机器人（BotmuxPlatform）还不在目标群里——请先把它拉进该群，再补人'
+        : res.error === 'requester_bot_not_in_chat' ? '目标群里没有你这台机器的 bot——只能往「已有你自己 bot 在场」的群补人（先让你的 bot 进群）'
         : res.error === 'chat_is_hall' ? '目标群是机器人大厅，不允许往里补人（大厅是 bot-only 身份登记群）'
+        : res.error === 'chat_not_in_team' ? '目标群不是本团队的协作群'
         : `相关 bot${which} 未由其 owner 在平台「管理机器人」加入该团队`;
       console.error(`补人被拒（403 ${res.error}）：${hint}。`);
     } else if (res.reason === 'client' && res.status === 404) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11883,7 +11883,7 @@ botmux create-group — 用一组机器人新建飞书群
  * 但 stdout 的 chatId 已经可用（群已建，别重建）。
  */
 async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
-  const { fetchTeamAgents, fetchTeams, createTeamGroup, addTeamGroupMembers, describeTeamAgentsFailure } =
+  const { fetchTeamAgents, fetchTeams, createTeamGroup, addTeamGroupMembers, describeTeamAgentsFailure, rateLimitRetryHint } =
     await import('./platform/team-agents-client.js');
   const jsonStatus = rest.includes('--json-status');
   const name = argValue(rest, '--name');
@@ -11920,7 +11920,7 @@ async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
   if (chatArg !== undefined) {
     if (!chatArg.trim()) { console.error('--chat 不能为空（传目标群 chatId）。'); process.exit(1); }
     await runAddTeamGroupMembers({
-      addTeamGroupMembers, describeTeamAgentsFailure,
+      addTeamGroupMembers, describeTeamAgentsFailure, rateLimitRetryHint,
       chatId: chatArg.trim(), teamId, appIds, jsonStatus,
       includeOwners: includeOwnersFalse ? false : undefined,
     });
@@ -11931,7 +11931,7 @@ async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
   if (!res.ok) {
     if (res.reason === 'unbound') console.error('本机未绑定平台。拉群需要先 botmux bind。');
     else if (res.reason === 'not_deployed') console.error('平台尚未部署拉群端点（/v1/machine/groups）。等平台上线后重试。');
-    else if (res.reason === 'rate_limited') console.error('拉群被限流（同机 30s 一次），请稍后重试。');
+    else if (res.reason === 'rate_limited') console.error(`拉群被限流，${rateLimitRetryHint(res)}。`);
     else if (res.reason === 'client' && res.status === 403) {
       // 403 not_in_team_bots：所选 agent（或本机 bot）没 opt-in 进团队。平台可能带回具体 appIds。
       const which = res.appIds && res.appIds.length ? `：${res.appIds.join('、')}` : '';
@@ -11979,6 +11979,7 @@ async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
 async function runAddTeamGroupMembers(a: {
   addTeamGroupMembers: typeof import('./platform/team-agents-client.js').addTeamGroupMembers;
   describeTeamAgentsFailure: typeof import('./platform/team-agents-client.js').describeTeamAgentsFailure;
+  rateLimitRetryHint: typeof import('./platform/team-agents-client.js').rateLimitRetryHint;
   chatId: string; teamId: string; appIds: string[]; jsonStatus: boolean; includeOwners?: boolean;
 }): Promise<void> {
   const res = await a.addTeamGroupMembers({
@@ -11988,7 +11989,7 @@ async function runAddTeamGroupMembers(a: {
   if (!res.ok) {
     if (res.reason === 'unbound') console.error('本机未绑定平台。补人需要先 botmux bind。');
     else if (res.reason === 'not_deployed') console.error('平台尚未部署补人端点（/v1/machine/groups/:chatId/members）。等平台上线后重试。');
-    else if (res.reason === 'rate_limited') console.error('补人被限流，请稍后重试。');
+    else if (res.reason === 'rate_limited') console.error(`补人被限流，${a.rateLimitRetryHint(res)}。`);
     else if (res.reason === 'client' && res.status === 403) {
       // 403 可能是 chat_not_in_team（目标群不是本团队的群）/ chat_is_hall（大厅不允许补人）/ not_in_team_bots。
       const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11631,6 +11631,15 @@ botmux create-group — 用一组机器人新建飞书群
     return;
   }
 
+  // Deprecation 闸：--chat 曾经是 create-group 的「往已有群补人」模式，现已拆成独立命令
+  // `bots invite`。若仍传 --chat，必须**报错早退**而不是静默忽略——否则用户本意补人、
+  // 却因 --chat 被丢弃照常建了个新群（真实副作用，多一个群）。放在 team 分流之前拦。
+  if (hasFlagOrEq(rest, '--chat')) {
+    console.error('create-group 不再支持 --chat（往已有群补人已拆成独立命令）。请改用：');
+    console.error('  botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]');
+    process.exit(1);
+  }
+
   // 团队模式：走平台端点3 建新群，与本机飞书建群是两条完全不同的路径。必须在 transport
   // 闸门之前分流——平台代建群，本机 bot 不需要飞书传输身份（沙盒/apiOnly 也能发起）。
   // 「往已有群补人」是独立的 `bots invite`，不在这里。

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12865,7 +12865,7 @@ async function tryAutoAddPlatformBot(
  * {ok, chatId, invalidBotIds, invalidOwnerUnionIds, teamId}；invalid* 非空 → 非零退出。
  */
 async function cmdBotsInvite(rest: string[]): Promise<void> {
-  const { addTeamGroupMembers, fetchTeams, describeTeamAgentsFailure, rateLimitRetryHint } =
+  const { addTeamGroupMembers, fetchTeams, describeTeamAgentsFailure, rateLimitRetryHint, shouldTryAutoAddPlatformBot } =
     await import('./platform/team-agents-client.js');
   const jsonStatus = rest.includes('--json-status');
   const chatArg = (argValue(rest, '--chat') ?? '').trim();
@@ -12889,9 +12889,11 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
   // (a) 自动化：撞 platform_bot_not_in_chat 且平台回传了 platformAppId → 用群里已有的本机 bot
   // 当代理，把平台后端 app 拉进目标群，再自动重试一次补人。让「往任意我在的群补人」尽量无感；
   // 碰到「加 bot 需群主审批 / 代理 bot 无成员管理 scope」时 addBotToChat 会失败，落回下面的手动提示。
-  if (!res.ok && res.reason === 'client' && res.status === 403 && res.error === 'platform_bot_not_in_chat' && res.platformAppId) {
+  let autoAddAttempted = false;
+  if (shouldTryAutoAddPlatformBot(res)) {
     const added = await tryAutoAddPlatformBot(chatArg, res.platformAppId);
     if (added.ok) {
+      autoAddAttempted = true;
       console.error(`（已用群内 bot「${added.proxyName}」把平台应用拉进群，重试补人…）`);
       res = await addTeamGroupMembers({ chatId: chatArg, teamId, appIds });
     } else {
@@ -12912,7 +12914,12 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
       const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';
       const appLabel = res.platformAppName ? `${res.platformAppName}（${res.platformAppId ?? ''}）` : (res.platformAppId ?? '平台应用');
       const hint =
-          res.error === 'platform_bot_not_in_chat' ? `平台应用还不在目标群里——请在群设置添加应用：${appLabel}，再补人`
+          res.error === 'platform_bot_not_in_chat'
+            // 已自动拉过还撞它：飞书加 app 通常同步生效，多半是刚加完成员表还没刷新——提示稍等重试，
+            // 别让用户对着刚拉进去的 app 再手动加一遍（pi review nit）。没自动拉过才引导手动添加。
+            ? (autoAddAttempted
+                ? `平台应用已自动拉进群、但补人仍报它不在——飞书成员同步通常几秒内完成，请稍等片刻重试 botmux bots invite`
+                : `平台应用还不在目标群里——请在群设置添加应用：${appLabel}，再补人`)
         : res.error === 'requester_not_in_chat' ? '你本人还不在目标群里——只能往「你自己已在场」的群补人（先加入该群）'
         : res.error === 'requester_bot_not_in_chat' ? '你本人还不在目标群里——只能往「你自己已在场」的群补人（先加入该群）'
         : res.error === 'chat_is_hall' ? '目标群是机器人大厅，不允许往里补人（大厅是 bot-only 身份登记群）'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11636,7 +11636,7 @@ botmux create-group — 用一组机器人新建飞书群
   // 却因 --chat 被丢弃照常建了个新群（真实副作用，多一个群）。放在 team 分流之前拦。
   if (hasFlagOrEq(rest, '--chat')) {
     console.error('create-group 不再支持 --chat（往已有群补人已拆成独立命令）。请改用：');
-    console.error('  botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]');
+    console.error('  botmux bots invite --chat <chatId> --team <id> --agent <appId>...');
     process.exit(1);
   }
 
@@ -12669,7 +12669,7 @@ async function cmdBots(sub: string, rest: string[]): Promise<void> {
 
   if (sub !== 'list' && sub !== 'ls' && sub !== '') {
     console.error('用法: botmux bots list [--scope chat|team] [--team <id>] [--session-id ID]');
-    console.error('      botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]');
+    console.error('      botmux bots invite --chat <chatId> --team <id> --agent <appId>...');
     process.exit(1);
   }
 
@@ -12819,7 +12819,7 @@ async function cmdBotsListTeam(rest: string[]): Promise<void> {
 }
 
 /**
- * `botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]`
+ * `botmux bots invite --chat <chatId> --team <id> --agent <appId>...`
  * —— 往**已存在的团队群**补人（同 team、已 opt-in 的 agent + 各自 owner），打平台端点4。
  *
  * 独立于 create-group（建新群）：语义是「群已经在了，往里加人」，不该跟建群混在一个命令里。
@@ -12834,12 +12834,12 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
     await import('./platform/team-agents-client.js');
   const jsonStatus = rest.includes('--json-status');
   const chatArg = (argValue(rest, '--chat') ?? '').trim();
-  const includeOwnersFalse = rest.includes('--no-owners');
   const appIds = [...new Set(argValues(rest, '--agent').map(s => s.trim()).filter(Boolean))];
 
   if (!chatArg) {
-    console.error('用法: botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]');
-    console.error('--chat 必填：目标群 chatId（须已有平台机器人 BotmuxPlatform + 你本机的 bot 在场，非机器人大厅）。');
+    console.error('用法: botmux bots invite --chat <chatId> --team <id> --agent <appId>...');
+    console.error('--chat 必填：目标群 chatId（须已有平台机器人 BotmuxPlatform 在场，且你本人已在该群，非机器人大厅）。');
+    console.error('补人恒把 agent + 各自 owner 一起拉进群。');
     process.exit(1);
   }
   if (appIds.length === 0) {
@@ -12849,10 +12849,7 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
 
   const teamId = await resolveSingleTeamIdOrExit(fetchTeams, describeTeamAgentsFailure, argValue(rest, '--team'), '补人');
 
-  const res = await addTeamGroupMembers({
-    chatId: chatArg, teamId, appIds,
-    ...(includeOwnersFalse ? { includeOwners: false } : {}),
-  });
+  const res = await addTeamGroupMembers({ chatId: chatArg, teamId, appIds });
   if (!res.ok) {
     if (res.reason === 'unbound') console.error('本机未绑定平台。补人需要先 botmux bind。');
     else if (res.reason === 'not_deployed') console.error('平台尚未部署补人端点（/v1/machine/groups/:chatId/members）。等平台上线后重试。');
@@ -12862,7 +12859,8 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
       const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';
       const hint =
           res.error === 'platform_bot_not_in_chat' ? '平台机器人（BotmuxPlatform）还不在目标群里——请先把它拉进该群，再补人'
-        : res.error === 'requester_bot_not_in_chat' ? '目标群里没有你这台机器的 bot——只能往「已有你自己 bot 在场」的群补人（先让你的 bot 进群）'
+        : res.error === 'requester_not_in_chat' ? '你本人还不在目标群里——只能往「你自己已在场」的群补人（先加入该群）'
+        : res.error === 'requester_bot_not_in_chat' ? '你本人还不在目标群里——只能往「你自己已在场」的群补人（先加入该群）'
         : res.error === 'chat_is_hall' ? '目标群是机器人大厅，不允许往里补人（大厅是 bot-only 身份登记群）'
         : res.error === 'chat_not_in_team' ? '目标群不是本团队的协作群'
         : `相关 bot${which} 未由其 owner 在平台「管理机器人」加入该团队`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11988,7 +11988,7 @@ async function runAddTeamGroupMembers(a: {
   if (!res.ok) {
     if (res.reason === 'unbound') console.error('本机未绑定平台。补人需要先 botmux bind。');
     else if (res.reason === 'not_deployed') console.error('平台尚未部署补人端点（/v1/machine/groups/:chatId/members）。等平台上线后重试。');
-    else if (res.reason === 'rate_limited') console.error('补人被限流（同机 30s 一次），请稍后重试。');
+    else if (res.reason === 'rate_limited') console.error('补人被限流，请稍后重试。');
     else if (res.reason === 'client' && res.status === 403) {
       // 403 可能是 chat_not_in_team（目标群不是本团队的群）/ chat_is_hall（大厅不允许补人）/ not_in_team_bots。
       const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';
@@ -12004,16 +12004,18 @@ async function runAddTeamGroupMembers(a: {
     process.exit(1);
   }
 
-  const { added, invalidBotIds, invalidOwnerUnionIds } = res.value;
+  const { invalidBotIds, invalidOwnerUnionIds } = res.value;
   // stdout 单行 chatId（与建群一致：调用方拿到即可复用该群）。
   console.log(a.chatId);
+  const hasInvalid = invalidBotIds.length > 0 || invalidOwnerUnionIds.length > 0;
   if (a.jsonStatus) {
-    console.log(JSON.stringify({ ok: true, chatId: a.chatId, added, invalidBotIds, invalidOwnerUnionIds, teamId: a.teamId }));
+    console.log(JSON.stringify({ ok: true, chatId: a.chatId, invalidBotIds, invalidOwnerUnionIds, teamId: a.teamId }));
   }
-  if (added.length > 0) console.error(`✅ 已加入群：${added.join('、')}`);
+  // 补人幂等（已在群内视作成功）；平台 200 不列「实际加了谁」，成功即 invalid* 为空。
+  if (!hasInvalid) console.error('✅ 补人成功（选中的 agent 及其 owner 均已在群内或已加入）。');
   if (invalidBotIds.length > 0) console.error(`⚠️ 以下 agent 未加入团队或补入失败：${invalidBotIds.join('、')}`);
   if (invalidOwnerUnionIds.length > 0) console.error(`⚠️ 以下 owner 未能补入：${invalidOwnerUnionIds.join('、')}`);
-  if (invalidBotIds.length > 0 || invalidOwnerUnionIds.length > 0) process.exitCode = 1;
+  if (hasInvalid) process.exitCode = 1;
 }
 
 // ─── Bots subcommand ─────────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,7 @@ import { withFileLock, withFileLockSync } from './utils/file-lock.js';
 import { pm2CallerEnv } from './cli/pm2-env.js';
 import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
-import { firstPositional } from './cli/arg-utils.js';
+import { firstPositional, hasFlagOrEq } from './cli/arg-utils.js';
 import { isColdResumeDormant, isRealManagedSession, sessionListDisposition } from './cli/session-list-liveness.js';
 import {
   computeSessionPickerLayout,
@@ -11603,12 +11603,17 @@ botmux create-group — 用一组机器人新建飞书群
                    部分失败都保持历史兼容，只输出单行 chatId；部分失败仍以非零退出表示。
 
 团队模式（跨机拉群，走中心化平台）:
+  # 建聚焦新群：
   botmux create-group --team <teamId> --agent <appId> [--agent ...] [--name "群名"]
+  # 往已存在的团队群补人：
+  botmux create-group --chat <chatId> --team <teamId> --agent <appId> [--agent ...] [--no-owners]
 
   用途：把「同团队、已 opt-in」的**别人机器上的** agent（用 bots list --scope team 发现到的 appId）
-  和它们各自的 owner 一起拉进一个聚焦新群——由平台代建、代拉，全程 machine-auth。
+  和它们各自的 owner 一起拉进群——由平台代建/代拉，全程 machine-auth。
   正因为发起人在别人 bot 进群前 @不到它，这条只认 appId、不依赖任何飞书 @，天然绕开视角问题。
   --agent 至少一个、可多次、按 appId 去重。团队模式忽略 --bot/--kickoff/--working-dir（那些是本机建群用的）。
+  --chat <chatId>：往**已存在的团队群**补人（而非建新群）；目标群必须是本团队自己建/拉的协作群
+                   （机器人大厅除外），否则平台拒绝。--no-owners 只补 bot、不拉 owner（默认连 owner 一起补）。
   未传 --team：本机唯一团队则自动用它，多个要求显式指定。
 
 行为:
@@ -11630,9 +11635,11 @@ botmux create-group — 用一组机器人新建飞书群
     return;
   }
 
-  // 团队模式：走平台端点3 拉群，与本机飞书建群是两条完全不同的路径。必须在 transport
-  // 闸门之前分流——平台代建群，本机 bot 不需要飞书传输身份（沙盒/apiOnly 也能发起）。
-  if (rest.includes('--team') || rest.includes('--agent')) {
+  // 团队模式：走平台端点3/4 拉群/补人，与本机飞书建群是两条完全不同的路径。必须在 transport
+  // 闸门之前分流——平台代建/代拉，本机 bot 不需要飞书传输身份（沙盒/apiOnly 也能发起）。
+  // 用 hasFlagOrEq（同时认 `--team` 与 `--team=xxx`）：argValue/argValues 支持 = 形式，
+  // 分流若只 includes('--team') 精确匹配，`--team=t1` 会漏判、落到本机建群路径报错误导（pi review P2）。
+  if (hasFlagOrEq(rest, '--team') || hasFlagOrEq(rest, '--agent') || hasFlagOrEq(rest, '--chat')) {
     await cmdCreateGroupTeam(rest);
     return;
   }
@@ -11876,10 +11883,12 @@ botmux create-group — 用一组机器人新建飞书群
  * 但 stdout 的 chatId 已经可用（群已建，别重建）。
  */
 async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
-  const { fetchTeamAgents, fetchTeams, createTeamGroup, describeTeamAgentsFailure } =
+  const { fetchTeamAgents, fetchTeams, createTeamGroup, addTeamGroupMembers, describeTeamAgentsFailure } =
     await import('./platform/team-agents-client.js');
   const jsonStatus = rest.includes('--json-status');
   const name = argValue(rest, '--name');
+  const chatArg = argValue(rest, '--chat');
+  const includeOwnersFalse = rest.includes('--no-owners');
   const appIds = [...new Set(argValues(rest, '--agent').map(s => s.trim()).filter(Boolean))];
 
   if (appIds.length === 0) {
@@ -11907,14 +11916,26 @@ async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
     teamId = teams[0].teamId;
   }
 
+  // --chat：往「已存在的团队群」补人（端点4/B），而非建新群（端点3）。
+  if (chatArg !== undefined) {
+    if (!chatArg.trim()) { console.error('--chat 不能为空（传目标群 chatId）。'); process.exit(1); }
+    await runAddTeamGroupMembers({
+      addTeamGroupMembers, describeTeamAgentsFailure,
+      chatId: chatArg.trim(), teamId, appIds, jsonStatus,
+      includeOwners: includeOwnersFalse ? false : undefined,
+    });
+    return;
+  }
+
   const res = await createTeamGroup({ teamId, appIds, ...(name !== undefined ? { name } : {}) });
   if (!res.ok) {
     if (res.reason === 'unbound') console.error('本机未绑定平台。拉群需要先 botmux bind。');
     else if (res.reason === 'not_deployed') console.error('平台尚未部署拉群端点（/v1/machine/groups）。等平台上线后重试。');
     else if (res.reason === 'rate_limited') console.error('拉群被限流（同机 30s 一次），请稍后重试。');
     else if (res.reason === 'client' && res.status === 403) {
-      // 403 not_in_team_bots：所选 agent（或本机 bot）没 opt-in 进团队。
-      console.error(`拉群被拒（403 ${res.error}）：请确认相关 bot 已由其 owner 在平台「管理机器人」加入该团队。`);
+      // 403 not_in_team_bots：所选 agent（或本机 bot）没 opt-in 进团队。平台可能带回具体 appIds。
+      const which = res.appIds && res.appIds.length ? `：${res.appIds.join('、')}` : '';
+      console.error(`拉群被拒（403 ${res.error}）：请确认相关 bot 已由其 owner 在平台「管理机器人」加入该团队${which}。`);
     } else if (res.reason === 'client' && res.status === 404) {
       console.error(`团队不存在或本机 owner 不是其成员：teamId=${teamId}`);
     } else {
@@ -11947,6 +11968,52 @@ async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
   if (shareLink) console.error(`群分享链接：${shareLink}`);
   // 部分失败 → 非零退出（但群已建、chatId 已在 stdout，调用方应复用不重建）。
   if (hasInvalid) process.exitCode = 1;
+}
+
+/**
+ * B（端点4）：往已存在的团队群 `chatId` 补人。与建新群共用 cmdCreateGroupTeam 的团队解析，
+ * 只是走 addTeamGroupMembers。输出协议：stdout 单行 chatId（补人成功即原样回传，skill 友好、
+ * 与建群一致）；--json-status 追加 {ok, chatId, added, invalid*}；invalid* 非空 → 非零退出。
+ * 授权/opt-in/大厅排除全在平台，CLI 只如实展示平台判定。
+ */
+async function runAddTeamGroupMembers(a: {
+  addTeamGroupMembers: typeof import('./platform/team-agents-client.js').addTeamGroupMembers;
+  describeTeamAgentsFailure: typeof import('./platform/team-agents-client.js').describeTeamAgentsFailure;
+  chatId: string; teamId: string; appIds: string[]; jsonStatus: boolean; includeOwners?: boolean;
+}): Promise<void> {
+  const res = await a.addTeamGroupMembers({
+    chatId: a.chatId, teamId: a.teamId, appIds: a.appIds,
+    ...(a.includeOwners !== undefined ? { includeOwners: a.includeOwners } : {}),
+  });
+  if (!res.ok) {
+    if (res.reason === 'unbound') console.error('本机未绑定平台。补人需要先 botmux bind。');
+    else if (res.reason === 'not_deployed') console.error('平台尚未部署补人端点（/v1/machine/groups/:chatId/members）。等平台上线后重试。');
+    else if (res.reason === 'rate_limited') console.error('补人被限流（同机 30s 一次），请稍后重试。');
+    else if (res.reason === 'client' && res.status === 403) {
+      // 403 可能是 chat_not_in_team（目标群不是本团队的群）/ chat_is_hall（大厅不允许补人）/ not_in_team_bots。
+      const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';
+      const hint = res.error === 'chat_not_in_team' ? '目标群不是本团队的协作群，只能往本团队自己建/拉的群补人'
+        : res.error === 'chat_is_hall' ? '目标群是机器人大厅，不允许往里补人（大厅是 bot-only 身份登记群）'
+        : `相关 bot${which} 未由其 owner 在平台「管理机器人」加入该团队`;
+      console.error(`补人被拒（403 ${res.error}）：${hint}。`);
+    } else if (res.reason === 'client' && res.status === 404) {
+      console.error(`团队不存在或本机 owner 不是其成员：teamId=${a.teamId}`);
+    } else {
+      console.error(`补人失败：${a.describeTeamAgentsFailure(res)}`);
+    }
+    process.exit(1);
+  }
+
+  const { added, invalidBotIds, invalidOwnerUnionIds } = res.value;
+  // stdout 单行 chatId（与建群一致：调用方拿到即可复用该群）。
+  console.log(a.chatId);
+  if (a.jsonStatus) {
+    console.log(JSON.stringify({ ok: true, chatId: a.chatId, added, invalidBotIds, invalidOwnerUnionIds, teamId: a.teamId }));
+  }
+  if (added.length > 0) console.error(`✅ 已加入群：${added.join('、')}`);
+  if (invalidBotIds.length > 0) console.error(`⚠️ 以下 agent 未加入团队或补入失败：${invalidBotIds.join('、')}`);
+  if (invalidOwnerUnionIds.length > 0) console.error(`⚠️ 以下 owner 未能补入：${invalidOwnerUnionIds.join('、')}`);
+  if (invalidBotIds.length > 0 || invalidOwnerUnionIds.length > 0) process.exitCode = 1;
 }
 
 // ─── Bots subcommand ─────────────────────────────────────────────────────────
@@ -12737,6 +12804,8 @@ async function cmdBotsListTeam(rest: string[]): Promise<void> {
     if (!teamsRes.ok) {
       if (teamsRes.reason === 'unbound') {
         console.error('本机未绑定平台（~/.botmux/platform.json 缺失）。团队发现需要先 botmux bind。');
+      } else if (teamsRes.reason === 'not_deployed') {
+        console.error('平台尚未部署团队端点（/v1/machine/teams）。等平台上线后重试。');
       } else {
         console.error(`拉取团队列表失败：${describeTeamAgentsFailure(teamsRes)}`);
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12819,12 +12819,54 @@ async function cmdBotsListTeam(rest: string[]): Promise<void> {
 }
 
 /**
+ * (a) 自动化辅助：把平台后端 app（platformAppId）拉进目标群 `chatId`。
+ *
+ * 飞书约束：加应用的 app 自己得在群里。所以找一个**已在该群、且本机可用凭据**的 bot 当代理
+ * （addBotToChat proxy）。优先用本会话 bot（它天然在本群且已注册），否则遍历 bots.json 里其它
+ * 非 apiOnly bot、逐个 isInChat 命中即用。全都不在群/加失败（无 scope、群需群主审批）→ 返回失败，
+ * 由调用方回退到手动引导。
+ */
+async function tryAutoAddPlatformBot(
+  chatId: string, platformAppId: string,
+): Promise<{ ok: true; proxyName: string } | { ok: false; reason: string }> {
+  try {
+    const { loadBotConfigs, registerBot } = await import('./bot-registry.js');
+    const { isInChat, addBotToChat } = await import('./services/groups-store.js');
+    let cfgs: Array<{ larkAppId: string; cliId?: string; apiOnly?: boolean }>;
+    try { cfgs = loadBotConfigs() as any; } catch { return { ok: false, reason: '读 bots.json 失败' }; }
+    // 候选代理：本会话 bot 优先（已在本群、已注册），其余非 apiOnly bot 兜底。
+    const self = process.env.BOTMUX_LARK_APP_ID;
+    const ordered = [
+      ...cfgs.filter(c => c.larkAppId === self),
+      ...cfgs.filter(c => c.larkAppId !== self && c.apiOnly !== true),
+    ];
+    if (ordered.length === 0) return { ok: false, reason: '本机无可用 bot 当代理' };
+    for (const cfg of ordered) {
+      if (cfg.apiOnly === true) continue;
+      try { registerBot(cfg as any); } catch { /* 已注册/凭据缺失 → 下面 isInChat 会失败并跳过 */ }
+      let inChat = false;
+      try { inChat = await isInChat(cfg.larkAppId, chatId); } catch { inChat = false; }
+      if (!inChat) continue;
+      const r = await addBotToChat(cfg.larkAppId, chatId, [platformAppId]);
+      const one = r[0];
+      if (one?.ok) return { ok: true, proxyName: cfg.cliId ? `${cfg.cliId}/${cfg.larkAppId}` : cfg.larkAppId };
+      // 加失败（无 scope / 群需审批 / invalid）→ 记原因，继续试下一个代理。
+      if (one?.error) return { ok: false, reason: `代理 ${cfg.larkAppId} 添加失败：${one.error}` };
+    }
+    return { ok: false, reason: '本机没有已在该群、且有权限的 bot 可当代理' };
+  } catch (e: any) {
+    return { ok: false, reason: String(e?.message ?? e) };
+  }
+}
+
+/**
  * `botmux bots invite --chat <chatId> --team <id> --agent <appId>...`
  * —— 往**已存在的团队群**补人（同 team、已 opt-in 的 agent + 各自 owner），打平台端点4。
  *
  * 独立于 create-group（建新群）：语义是「群已经在了，往里加人」，不该跟建群混在一个命令里。
  * 全程 machine-auth、只认 appId（发起人在别人 bot 进群前 @不到它，靠 appId 绕开视角问题）。
  * 授权/opt-in 闸/大厅排除全在平台，CLI 零判断、只如实展示平台判定。
+ * 若平台回 platform_bot_not_in_chat 且带 platformAppId → 自动用群内本机 bot 把平台 app 拉进群、重试。
  *
  * 输出：stdout 单行 chatId（skill 友好，与 create-group 一致）；--json-status 追加
  * {ok, chatId, invalidBotIds, invalidOwnerUnionIds, teamId}；invalid* 非空 → 非零退出。
@@ -12849,7 +12891,25 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
 
   const teamId = await resolveSingleTeamIdOrExit(fetchTeams, describeTeamAgentsFailure, argValue(rest, '--team'), '补人');
 
-  const res = await addTeamGroupMembers({ chatId: chatArg, teamId, appIds });
+  let res = await addTeamGroupMembers({ chatId: chatArg, teamId, appIds });
+
+  // (a) 自动化：撞 platform_bot_not_in_chat 且平台回传了 platformAppId → 用群里已有的本机 bot
+  // 当代理，把平台后端 app 拉进目标群，再自动重试一次补人。让「往任意我在的群补人」尽量无感；
+  // 碰到「加 bot 需群主审批 / 代理 bot 无成员管理 scope」时 addBotToChat 会失败，落回下面的手动提示。
+  if (!res.ok && res.reason === 'client' && res.status === 403 && res.error === 'platform_bot_not_in_chat' && res.platformAppId) {
+    const added = await tryAutoAddPlatformBot(chatArg, res.platformAppId);
+    if (added.ok) {
+      console.error(`（已用群内 bot「${added.proxyName}」把平台应用拉进群，重试补人…）`);
+      res = await addTeamGroupMembers({ chatId: chatArg, teamId, appIds });
+    } else {
+      // 自动拉失败：给可操作的手动引导（用平台回传的 app 名/id），不静默。
+      const appLabel = res.platformAppName ? `${res.platformAppName}（${res.platformAppId}）` : res.platformAppId;
+      console.error(`补人前置：平台应用不在目标群，且自动添加未成功（${added.reason}）。`);
+      console.error(`请在群设置里手动添加应用：${appLabel}，然后重试 botmux bots invite。`);
+      process.exit(1);
+    }
+  }
+
   if (!res.ok) {
     if (res.reason === 'unbound') console.error('本机未绑定平台。补人需要先 botmux bind。');
     else if (res.reason === 'not_deployed') console.error('平台尚未部署补人端点（/v1/machine/groups/:chatId/members）。等平台上线后重试。');
@@ -12857,8 +12917,9 @@ async function cmdBotsInvite(rest: string[]): Promise<void> {
     else if (res.reason === 'client' && res.status === 403) {
       // 403 分支（平台按 error code 返回）：可行性/归属/opt-in/大厅，各给可操作的提示。
       const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';
+      const appLabel = res.platformAppName ? `${res.platformAppName}（${res.platformAppId ?? ''}）` : (res.platformAppId ?? '平台应用');
       const hint =
-          res.error === 'platform_bot_not_in_chat' ? '平台机器人（BotmuxPlatform）还不在目标群里——请先把它拉进该群，再补人'
+          res.error === 'platform_bot_not_in_chat' ? `平台应用还不在目标群里——请在群设置添加应用：${appLabel}，再补人`
         : res.error === 'requester_not_in_chat' ? '你本人还不在目标群里——只能往「你自己已在场」的群补人（先加入该群）'
         : res.error === 'requester_bot_not_in_chat' ? '你本人还不在目标群里——只能往「你自己已在场」的群补人（先加入该群）'
         : res.error === 'chat_is_hall' ? '目标群是机器人大厅，不允许往里补人（大厅是 bot-only 身份登记群）'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11602,6 +11602,15 @@ botmux create-group — 用一组机器人新建飞书群
   --json-status    可选；在 chatId 后追加一行结构化完成状态。默认 stdout 无论完整成功或
                    部分失败都保持历史兼容，只输出单行 chatId；部分失败仍以非零退出表示。
 
+团队模式（跨机拉群，走中心化平台）:
+  botmux create-group --team <teamId> --agent <appId> [--agent ...] [--name "群名"]
+
+  用途：把「同团队、已 opt-in」的**别人机器上的** agent（用 bots list --scope team 发现到的 appId）
+  和它们各自的 owner 一起拉进一个聚焦新群——由平台代建、代拉，全程 machine-auth。
+  正因为发起人在别人 bot 进群前 @不到它，这条只认 appId、不依赖任何飞书 @，天然绕开视角问题。
+  --agent 至少一个、可多次、按 appId 去重。团队模式忽略 --bot/--kickoff/--working-dir（那些是本机建群用的）。
+  未传 --team：本机唯一团队则自动用它，多个要求显式指定。
+
 行为:
   - 第一个解析到的 bot 作为 creator（决定建群身份 + 初始群主 + open_id app scope）。
   - 邀请用户 / 转让群主 / @通知 对象都从 creator 的 resolvedAllowedUsers 取首个 open_id（email 自动转换；
@@ -11620,6 +11629,14 @@ botmux create-group — 用一组机器人新建飞书群
 `);
     return;
   }
+
+  // 团队模式：走平台端点3 拉群，与本机飞书建群是两条完全不同的路径。必须在 transport
+  // 闸门之前分流——平台代建群，本机 bot 不需要飞书传输身份（沙盒/apiOnly 也能发起）。
+  if (rest.includes('--team') || rest.includes('--agent')) {
+    await cmdCreateGroupTeam(rest);
+    return;
+  }
+
   // create-group builds a real Feishu group (cross-bot). A no-transport turn
   // (apiOnly bot or HTTP virtual session) may not originate one — central gate.
   assertTurnTransportOrExit('create-group');
@@ -11841,6 +11858,95 @@ botmux create-group — 用一组机器人新建飞书群
     console.log(JSON.stringify(completion));
   }
   if (!completion.success) process.exitCode = 1;
+}
+
+/**
+ * `botmux create-group --team <teamId> --agent <appId>...` — 跨机拉群（走中心化平台端点3）。
+ *
+ * 与本机飞书建群（cmdCreateGroup 主体）是两条不同路径：这里把「同团队、已 opt-in」的、
+ * **别人机器上的** agent（appId 从 bots list --scope team 发现而来）+ 各自 owner + 本机 owner
+ * 一起拉进一个平台代建的聚焦新群。全程 machine-auth、只认 appId、不依赖任何飞书 @。
+ *
+ * 硬约束：CLI 零授权判断（团队成员校验 + opt-in 闸 team.bots 全在平台）；平台把未 opt-in /
+ * 拉不动的对象放进 invalidBotIds / invalidOwnerUnionIds 原样带回，这里只如实展示、不解释成
+ * "失败"（未 opt-in 是对方 owner 没加进团队，不是本次调用错）。
+ *
+ * 输出协议对齐主命令：成功拿到 chatId → stdout 写单行 chatId（skill 友好）；--json-status
+ * 追加一行结构化 JSON（含 shareLink / invalid* / 部分失败标记）。有 invalid* 时 exit 非零，
+ * 但 stdout 的 chatId 已经可用（群已建，别重建）。
+ */
+async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
+  const { fetchTeamAgents, fetchTeams, createTeamGroup, describeTeamAgentsFailure } =
+    await import('./platform/team-agents-client.js');
+  const jsonStatus = rest.includes('--json-status');
+  const name = argValue(rest, '--name');
+  const appIds = [...new Set(argValues(rest, '--agent').map(s => s.trim()).filter(Boolean))];
+
+  if (appIds.length === 0) {
+    console.error('团队模式需要至少一个 --agent <appId>（用 botmux bots list --scope team 发现 appId）。');
+    process.exit(1);
+  }
+
+  // 团队解析：与 bots list --scope team 同一套（未传 --team → 端点1；唯一即用/多个要求指定）。
+  let teamId = argValue(rest, '--team');
+  if (!teamId) {
+    const teamsRes = await fetchTeams();
+    if (!teamsRes.ok) {
+      if (teamsRes.reason === 'unbound') console.error('本机未绑定平台。拉群需要先 botmux bind。');
+      else if (teamsRes.reason === 'not_deployed') console.error('平台尚未部署团队端点，等上线后重试。');
+      else console.error(`拉取团队列表失败：${describeTeamAgentsFailure(teamsRes)}`);
+      process.exit(1);
+    }
+    const teams = teamsRes.value;
+    if (teams.length === 0) { console.error('本机未加入任何平台团队，无法拉群。'); process.exit(1); }
+    if (teams.length > 1) {
+      console.error('本机属于多个平台团队，请用 --team <id> 指定其一：');
+      for (const t of teams) console.error(`  ${t.teamId}  ${t.teamName}`);
+      process.exit(1);
+    }
+    teamId = teams[0].teamId;
+  }
+
+  const res = await createTeamGroup({ teamId, appIds, ...(name !== undefined ? { name } : {}) });
+  if (!res.ok) {
+    if (res.reason === 'unbound') console.error('本机未绑定平台。拉群需要先 botmux bind。');
+    else if (res.reason === 'not_deployed') console.error('平台尚未部署拉群端点（/v1/machine/groups）。等平台上线后重试。');
+    else if (res.reason === 'rate_limited') console.error('拉群被限流（同机 30s 一次），请稍后重试。');
+    else if (res.reason === 'client' && res.status === 403) {
+      // 403 not_in_team_bots：所选 agent（或本机 bot）没 opt-in 进团队。
+      console.error(`拉群被拒（403 ${res.error}）：请确认相关 bot 已由其 owner 在平台「管理机器人」加入该团队。`);
+    } else if (res.reason === 'client' && res.status === 404) {
+      console.error(`团队不存在或本机 owner 不是其成员：teamId=${teamId}`);
+    } else {
+      console.error(`拉群失败：${describeTeamAgentsFailure(res)}`);
+    }
+    process.exit(1);
+  }
+
+  const { chatId, shareLink, invalidBotIds, invalidOwnerUnionIds } = res.value;
+  if (!chatId) {
+    // 平台回 ok 但没给 chatId：异常，别静默成功。
+    console.error(`平台未返回 chatId（ok=${res.value.ok}）。`);
+    if (jsonStatus) console.log(JSON.stringify({ ...res.value, ok: false }));
+    process.exit(1);
+  }
+
+  // stdout 单行 chatId（skill 友好，主命令同款协议）。
+  console.log(chatId);
+  const hasInvalid = invalidBotIds.length > 0 || invalidOwnerUnionIds.length > 0;
+  if (jsonStatus) {
+    console.log(JSON.stringify({ ok: true, chatId, shareLink, invalidBotIds, invalidOwnerUnionIds, teamId }));
+  }
+  // 未 opt-in / 拉不动的对象走 stderr 提示（不污染 stdout 的 chatId 契约）。
+  if (invalidBotIds.length > 0) {
+    console.error(`⚠️ 以下 agent 未加入团队或拉取失败，未入群：${invalidBotIds.join('、')}`);
+  }
+  if (invalidOwnerUnionIds.length > 0) {
+    console.error(`⚠️ 以下 owner 未能拉入：${invalidOwnerUnionIds.join('、')}`);
+  }
+  if (shareLink) console.error(`群分享链接：${shareLink}`);
+  // 部分失败 → 非零退出（但群已建、chatId 已在 stdout，调用方应复用不重建）。
+  if (hasInvalid) process.exitCode = 1;
 }
 
 // ─── Bots subcommand ─────────────────────────────────────────────────────────
@@ -12531,9 +12637,23 @@ async function cmdBots(sub: string, rest: string[]): Promise<void> {
   process.env.SESSION_DATA_DIR ??= resolveDataDir();
 
   if (sub !== 'list' && sub !== 'ls' && sub !== '') {
-    console.error('用法: botmux bots list [--session-id ID]');
+    console.error('用法: botmux bots list [--scope chat|team] [--team <id>] [--session-id ID]');
     process.exit(1);
   }
+
+  // `--scope team`：跨机发现同团队、已 opt-in 的 agent（打平台端点2，machine-auth）。
+  // 与默认的 chat scope 完全不同——它不读飞书群花名册、不需要会话/传输身份，
+  // 所以在会话解析 / transport 闸门之前分流。空 team 列表是正常态（没别人 opt-in）。
+  const scope = (argValue(rest, '--scope') ?? 'chat').toLowerCase();
+  if (scope === 'team') {
+    await cmdBotsListTeam(rest);
+    return;
+  }
+  if (scope !== 'chat') {
+    console.error(`未知 --scope "${scope}"（仅支持 chat | team）`);
+    process.exit(1);
+  }
+
   // `bots list` reads the Feishu chat roster (listChatBotMembers). A no-transport
   // turn has no chat roster — central hard gate (also stops the routing prompt
   // from advertising a Feishu-dependent helper in this context).
@@ -12593,6 +12713,75 @@ async function cmdBots(sub: string, rest: string[]): Promise<void> {
     const result = formatBotInfoEntriesForCli(botEntries, appId, collaborationFactsFor(botEntries.map(bot => bot.larkAppId)));
     console.log(JSON.stringify({ sessionId: sid, bots: result, total: result.length, collaborationHelp, note: `chat query failed: ${err.message}` }, null, 2));
   }
+}
+
+/**
+ * `botmux bots list --scope team [--team <id>]` — 跨机发现同团队、已 opt-in（owner
+ * 加进 team.bots）的 agent，打平台端点2（machine-auth，Bearer=machineToken）。
+ *
+ * 与 chat scope 的关键区别 + 硬约束：
+ *  - 走 machine-auth，不读飞书群花名册、不需要传输身份 → 沙盒/apiOnly bot 也能查。
+ *  - **CLI 不做任何授权判断**：团队成员校验 + opt-in 闸全在平台，这里只透传、只展示。
+ *  - specialties / mentionable 是 agent 自报 → 仅展示，不当可信凭据。
+ *  - 未传 --team：先打端点1 拉本机 owner 的团队；唯一就用它，多个要求显式 --team
+ *    （不猜），零个则提示本机没加入任何平台团队。
+ */
+async function cmdBotsListTeam(rest: string[]): Promise<void> {
+  const { fetchTeamAgents, fetchTeams, describeTeamAgentsFailure } = await import('./platform/team-agents-client.js');
+  const jsonOut = argFlag(rest, '--json');
+
+  let teamId = argValue(rest, '--team');
+  let teamNameHint: string | undefined;
+  if (!teamId) {
+    const teamsRes = await fetchTeams();
+    if (!teamsRes.ok) {
+      if (teamsRes.reason === 'unbound') {
+        console.error('本机未绑定平台（~/.botmux/platform.json 缺失）。团队发现需要先 botmux bind。');
+      } else {
+        console.error(`拉取团队列表失败：${describeTeamAgentsFailure(teamsRes)}`);
+      }
+      process.exit(1);
+    }
+    const teams = teamsRes.value;
+    if (teams.length === 0) {
+      // 空不是错误：本机 owner 还没加入任何平台团队。
+      console.log(JSON.stringify({ scope: 'team', teams: [], agents: [], total: 0, note: '本机未加入任何平台团队' }, null, 2));
+      return;
+    }
+    if (teams.length > 1) {
+      console.error('本机属于多个平台团队，请用 --team <id> 指定其一：');
+      for (const t of teams) console.error(`  ${t.teamId}  ${t.teamName}`);
+      process.exit(1);
+    }
+    teamId = teams[0].teamId;
+    teamNameHint = teams[0].teamName;
+  }
+
+  const res = await fetchTeamAgents(teamId);
+  if (!res.ok) {
+    if (res.reason === 'unbound') {
+      console.error('本机未绑定平台（~/.botmux/platform.json 缺失）。团队发现需要先 botmux bind。');
+    } else if (res.reason === 'not_deployed') {
+      console.error('平台尚未部署团队 agent 发现端点（/v1/machine/agents）。等平台上线后重试。');
+    } else if (res.reason === 'client' && res.status === 404) {
+      console.error(`团队不存在或本机 owner 不是其成员：teamId=${teamId}`);
+    } else {
+      console.error(`拉取团队 agent 失败：${describeTeamAgentsFailure(res)}`);
+    }
+    process.exit(1);
+  }
+
+  const { teamName, agents } = res.value;
+  // 输出对齐 chat scope 的 JSON 形状（scope 标注 + total），字段是平台端点2 的原样透传。
+  // 提醒：发现列表只含**已加入 team.bots** 的 agent（owner 在平台「管理机器人」显式加入）。
+  console.log(JSON.stringify({
+    scope: 'team',
+    teamId,
+    teamName: teamName || teamNameHint || teamId,
+    agents,
+    total: agents.length,
+    note: '发现列表只含已加入团队（owner 在平台「管理机器人」opt-in）的 agent；specialties/mentionable 为 agent 自报，仅供参考不可信。',
+  }, null, jsonOut ? 0 : 2));
 }
 
 // ─── botmux lang ─────────────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12830,30 +12830,23 @@ async function tryAutoAddPlatformBot(
   chatId: string, platformAppId: string,
 ): Promise<{ ok: true; proxyName: string } | { ok: false; reason: string }> {
   try {
-    const { loadBotConfigs, registerBot } = await import('./bot-registry.js');
-    const { isInChat, addBotToChat } = await import('./services/groups-store.js');
-    let cfgs: Array<{ larkAppId: string; cliId?: string; apiOnly?: boolean }>;
-    try { cfgs = loadBotConfigs() as any; } catch { return { ok: false, reason: '读 bots.json 失败' }; }
-    // 候选代理：本会话 bot 优先（已在本群、已注册），其余非 apiOnly bot 兜底。
-    const self = process.env.BOTMUX_LARK_APP_ID;
-    const ordered = [
-      ...cfgs.filter(c => c.larkAppId === self),
-      ...cfgs.filter(c => c.larkAppId !== self && c.apiOnly !== true),
-    ];
-    if (ordered.length === 0) return { ok: false, reason: '本机无可用 bot 当代理' };
-    for (const cfg of ordered) {
-      if (cfg.apiOnly === true) continue;
-      try { registerBot(cfg as any); } catch { /* 已注册/凭据缺失 → 下面 isInChat 会失败并跳过 */ }
-      let inChat = false;
-      try { inChat = await isInChat(cfg.larkAppId, chatId); } catch { inChat = false; }
-      if (!inChat) continue;
-      const r = await addBotToChat(cfg.larkAppId, chatId, [platformAppId]);
-      const one = r[0];
-      if (one?.ok) return { ok: true, proxyName: cfg.cliId ? `${cfg.cliId}/${cfg.larkAppId}` : cfg.larkAppId };
-      // 加失败（无 scope / 群需审批 / invalid）→ 记原因，继续试下一个代理。
-      if (one?.error) return { ok: false, reason: `代理 ${cfg.larkAppId} 添加失败：${one.error}` };
-    }
-    return { ok: false, reason: '本机没有已在该群、且有权限的 bot 可当代理' };
+    const { findLocalBotInChat } = await import('./im/lark/client.js');
+    const { addBotToChat } = await import('./services/groups-store.js');
+    // 用安静探测客户端找一个「已在目标群」的本机 bot 当代理（本会话 bot 优先）。
+    // 不在群的 bot 探测 miss 被静音，不刷 axios 400 噪音（见 client.findLocalBotInChat）。
+    const proxy = await findLocalBotInChat(chatId, process.env.BOTMUX_LARK_APP_ID);
+    if (!proxy) return { ok: false, reason: '本机没有已在该群的 bot 可当代理' };
+    // 代理 bot 需已在注册表（getBotClient 可用）——从 bots.json 注册一次（幂等）。
+    try {
+      const { loadBotConfigs, registerBot } = await import('./bot-registry.js');
+      const cfg = loadBotConfigs().find((c: any) => c.larkAppId === proxy.larkAppId);
+      if (cfg) registerBot(cfg);
+    } catch { /* 已注册或读配置失败 → addBotToChat 若拿不到 client 会报错并回退 */ }
+    const r = await addBotToChat(proxy.larkAppId, chatId, [platformAppId]);
+    const one = r[0];
+    if (one?.ok) return { ok: true, proxyName: proxy.cliId ? `${proxy.cliId}/${proxy.larkAppId}` : proxy.larkAppId };
+    // 加失败（无 scope / 群需群主审批 / invalid）→ 回退手动引导。
+    return { ok: false, reason: `代理 ${proxy.larkAppId} 添加失败：${one?.error ?? 'unknown'}` };
   } catch (e: any) {
     return { ok: false, reason: String(e?.message ?? e) };
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11602,19 +11602,15 @@ botmux create-group — 用一组机器人新建飞书群
   --json-status    可选；在 chatId 后追加一行结构化完成状态。默认 stdout 无论完整成功或
                    部分失败都保持历史兼容，只输出单行 chatId；部分失败仍以非零退出表示。
 
-团队模式（跨机拉群，走中心化平台）:
-  # 建聚焦新群：
+团队模式（跨机建聚焦新群，走中心化平台）:
   botmux create-group --team <teamId> --agent <appId> [--agent ...] [--name "群名"]
-  # 往已存在的团队群补人：
-  botmux create-group --chat <chatId> --team <teamId> --agent <appId> [--agent ...] [--no-owners]
 
   用途：把「同团队、已 opt-in」的**别人机器上的** agent（用 bots list --scope team 发现到的 appId）
-  和它们各自的 owner 一起拉进群——由平台代建/代拉，全程 machine-auth。
+  和它们各自的 owner 一起拉进一个平台代建的聚焦新群，全程 machine-auth。
   正因为发起人在别人 bot 进群前 @不到它，这条只认 appId、不依赖任何飞书 @，天然绕开视角问题。
   --agent 至少一个、可多次、按 appId 去重。团队模式忽略 --bot/--kickoff/--working-dir（那些是本机建群用的）。
-  --chat <chatId>：往**已存在的团队群**补人（而非建新群）；目标群必须是本团队自己建/拉的协作群
-                   （机器人大厅除外），否则平台拒绝。--no-owners 只补 bot、不拉 owner（默认连 owner 一起补）。
   未传 --team：本机唯一团队则自动用它，多个要求显式指定。
+  （往**已存在**的团队群补人是独立命令：botmux bots invite --chat <chatId> --team X --agent ...）
 
 行为:
   - 第一个解析到的 bot 作为 creator（决定建群身份 + 初始群主 + open_id app scope）。
@@ -11635,11 +11631,10 @@ botmux create-group — 用一组机器人新建飞书群
     return;
   }
 
-  // 团队模式：走平台端点3/4 拉群/补人，与本机飞书建群是两条完全不同的路径。必须在 transport
-  // 闸门之前分流——平台代建/代拉，本机 bot 不需要飞书传输身份（沙盒/apiOnly 也能发起）。
-  // 用 hasFlagOrEq（同时认 `--team` 与 `--team=xxx`）：argValue/argValues 支持 = 形式，
-  // 分流若只 includes('--team') 精确匹配，`--team=t1` 会漏判、落到本机建群路径报错误导（pi review P2）。
-  if (hasFlagOrEq(rest, '--team') || hasFlagOrEq(rest, '--agent') || hasFlagOrEq(rest, '--chat')) {
+  // 团队模式：走平台端点3 建新群，与本机飞书建群是两条完全不同的路径。必须在 transport
+  // 闸门之前分流——平台代建群，本机 bot 不需要飞书传输身份（沙盒/apiOnly 也能发起）。
+  // 「往已有群补人」是独立的 `bots invite`，不在这里。
+  if (hasFlagOrEq(rest, '--team') || hasFlagOrEq(rest, '--agent')) {
     await cmdCreateGroupTeam(rest);
     return;
   }
@@ -11882,13 +11877,40 @@ botmux create-group — 用一组机器人新建飞书群
  * 追加一行结构化 JSON（含 shareLink / invalid* / 部分失败标记）。有 invalid* 时 exit 非零，
  * 但 stdout 的 chatId 已经可用（群已建，别重建）。
  */
+/**
+ * 解析团队维度命令的目标 teamId：显式 --team 优先；否则打端点1，唯一即用、多个要求指定、
+ * 零个报错。用于「必须落到一个具体 team」的动作（建群 / 补人）——list 侧的空 team 是正常态、
+ * 输出空列表，不走这里。`action` 只用于文案（"拉群"/"补人"）。
+ */
+async function resolveSingleTeamIdOrExit(
+  fetchTeams: typeof import('./platform/team-agents-client.js').fetchTeams,
+  describeTeamAgentsFailure: typeof import('./platform/team-agents-client.js').describeTeamAgentsFailure,
+  teamArg: string | undefined,
+  action: string,
+): Promise<string> {
+  if (teamArg) return teamArg;
+  const teamsRes = await fetchTeams();
+  if (!teamsRes.ok) {
+    if (teamsRes.reason === 'unbound') console.error(`本机未绑定平台。${action}需要先 botmux bind。`);
+    else if (teamsRes.reason === 'not_deployed') console.error('平台尚未部署团队端点，等上线后重试。');
+    else console.error(`拉取团队列表失败：${describeTeamAgentsFailure(teamsRes)}`);
+    process.exit(1);
+  }
+  const teams = teamsRes.value;
+  if (teams.length === 0) { console.error(`本机未加入任何平台团队，无法${action}。`); process.exit(1); }
+  if (teams.length > 1) {
+    console.error('本机属于多个平台团队，请用 --team <id> 指定其一：');
+    for (const t of teams) console.error(`  ${t.teamId}  ${t.teamName}`);
+    process.exit(1);
+  }
+  return teams[0].teamId;
+}
+
 async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
-  const { fetchTeamAgents, fetchTeams, createTeamGroup, addTeamGroupMembers, describeTeamAgentsFailure, rateLimitRetryHint } =
+  const { fetchTeams, createTeamGroup, describeTeamAgentsFailure, rateLimitRetryHint } =
     await import('./platform/team-agents-client.js');
   const jsonStatus = rest.includes('--json-status');
   const name = argValue(rest, '--name');
-  const chatArg = argValue(rest, '--chat');
-  const includeOwnersFalse = rest.includes('--no-owners');
   const appIds = [...new Set(argValues(rest, '--agent').map(s => s.trim()).filter(Boolean))];
 
   if (appIds.length === 0) {
@@ -11896,36 +11918,7 @@ async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // 团队解析：与 bots list --scope team 同一套（未传 --team → 端点1；唯一即用/多个要求指定）。
-  let teamId = argValue(rest, '--team');
-  if (!teamId) {
-    const teamsRes = await fetchTeams();
-    if (!teamsRes.ok) {
-      if (teamsRes.reason === 'unbound') console.error('本机未绑定平台。拉群需要先 botmux bind。');
-      else if (teamsRes.reason === 'not_deployed') console.error('平台尚未部署团队端点，等上线后重试。');
-      else console.error(`拉取团队列表失败：${describeTeamAgentsFailure(teamsRes)}`);
-      process.exit(1);
-    }
-    const teams = teamsRes.value;
-    if (teams.length === 0) { console.error('本机未加入任何平台团队，无法拉群。'); process.exit(1); }
-    if (teams.length > 1) {
-      console.error('本机属于多个平台团队，请用 --team <id> 指定其一：');
-      for (const t of teams) console.error(`  ${t.teamId}  ${t.teamName}`);
-      process.exit(1);
-    }
-    teamId = teams[0].teamId;
-  }
-
-  // --chat：往「已存在的团队群」补人（端点4/B），而非建新群（端点3）。
-  if (chatArg !== undefined) {
-    if (!chatArg.trim()) { console.error('--chat 不能为空（传目标群 chatId）。'); process.exit(1); }
-    await runAddTeamGroupMembers({
-      addTeamGroupMembers, describeTeamAgentsFailure, rateLimitRetryHint,
-      chatId: chatArg.trim(), teamId, appIds, jsonStatus,
-      includeOwners: includeOwnersFalse ? false : undefined,
-    });
-    return;
-  }
+  const teamId = await resolveSingleTeamIdOrExit(fetchTeams, describeTeamAgentsFailure, argValue(rest, '--team'), '拉群');
 
   const res = await createTeamGroup({ teamId, appIds, ...(name !== undefined ? { name } : {}) });
   if (!res.ok) {
@@ -11967,55 +11960,6 @@ async function cmdCreateGroupTeam(rest: string[]): Promise<void> {
   }
   if (shareLink) console.error(`群分享链接：${shareLink}`);
   // 部分失败 → 非零退出（但群已建、chatId 已在 stdout，调用方应复用不重建）。
-  if (hasInvalid) process.exitCode = 1;
-}
-
-/**
- * B（端点4）：往已存在的团队群 `chatId` 补人。与建新群共用 cmdCreateGroupTeam 的团队解析，
- * 只是走 addTeamGroupMembers。输出协议：stdout 单行 chatId（补人成功即原样回传，skill 友好、
- * 与建群一致）；--json-status 追加 {ok, chatId, added, invalid*}；invalid* 非空 → 非零退出。
- * 授权/opt-in/大厅排除全在平台，CLI 只如实展示平台判定。
- */
-async function runAddTeamGroupMembers(a: {
-  addTeamGroupMembers: typeof import('./platform/team-agents-client.js').addTeamGroupMembers;
-  describeTeamAgentsFailure: typeof import('./platform/team-agents-client.js').describeTeamAgentsFailure;
-  rateLimitRetryHint: typeof import('./platform/team-agents-client.js').rateLimitRetryHint;
-  chatId: string; teamId: string; appIds: string[]; jsonStatus: boolean; includeOwners?: boolean;
-}): Promise<void> {
-  const res = await a.addTeamGroupMembers({
-    chatId: a.chatId, teamId: a.teamId, appIds: a.appIds,
-    ...(a.includeOwners !== undefined ? { includeOwners: a.includeOwners } : {}),
-  });
-  if (!res.ok) {
-    if (res.reason === 'unbound') console.error('本机未绑定平台。补人需要先 botmux bind。');
-    else if (res.reason === 'not_deployed') console.error('平台尚未部署补人端点（/v1/machine/groups/:chatId/members）。等平台上线后重试。');
-    else if (res.reason === 'rate_limited') console.error(`补人被限流，${a.rateLimitRetryHint(res)}。`);
-    else if (res.reason === 'client' && res.status === 403) {
-      // 403 可能是 chat_not_in_team（目标群不是本团队的群）/ chat_is_hall（大厅不允许补人）/ not_in_team_bots。
-      const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';
-      const hint = res.error === 'chat_not_in_team' ? '目标群不是本团队的协作群，只能往本团队自己建/拉的群补人'
-        : res.error === 'chat_is_hall' ? '目标群是机器人大厅，不允许往里补人（大厅是 bot-only 身份登记群）'
-        : `相关 bot${which} 未由其 owner 在平台「管理机器人」加入该团队`;
-      console.error(`补人被拒（403 ${res.error}）：${hint}。`);
-    } else if (res.reason === 'client' && res.status === 404) {
-      console.error(`团队不存在或本机 owner 不是其成员：teamId=${a.teamId}`);
-    } else {
-      console.error(`补人失败：${a.describeTeamAgentsFailure(res)}`);
-    }
-    process.exit(1);
-  }
-
-  const { invalidBotIds, invalidOwnerUnionIds } = res.value;
-  // stdout 单行 chatId（与建群一致：调用方拿到即可复用该群）。
-  console.log(a.chatId);
-  const hasInvalid = invalidBotIds.length > 0 || invalidOwnerUnionIds.length > 0;
-  if (a.jsonStatus) {
-    console.log(JSON.stringify({ ok: true, chatId: a.chatId, invalidBotIds, invalidOwnerUnionIds, teamId: a.teamId }));
-  }
-  // 补人幂等（已在群内视作成功）；平台 200 不列「实际加了谁」，成功即 invalid* 为空。
-  if (!hasInvalid) console.error('✅ 补人成功（选中的 agent 及其 owner 均已在群内或已加入）。');
-  if (invalidBotIds.length > 0) console.error(`⚠️ 以下 agent 未加入团队或补入失败：${invalidBotIds.join('、')}`);
-  if (invalidOwnerUnionIds.length > 0) console.error(`⚠️ 以下 owner 未能补入：${invalidOwnerUnionIds.join('、')}`);
   if (hasInvalid) process.exitCode = 1;
 }
 
@@ -12706,8 +12650,17 @@ async function cmdUserPromptHook(): Promise<void> {
 async function cmdBots(sub: string, rest: string[]): Promise<void> {
   process.env.SESSION_DATA_DIR ??= resolveDataDir();
 
+  // `bots invite`：往**已存在的团队群**补人（同 team、已 opt-in 的 agent + 各自 owner），
+  // 打平台端点4（machine-auth）。独立子命令——与「建新群」的 create-group 语义分开，
+  // 不再靠 create-group --chat 区分（那个入口易被误读成"建群"）。在会话/transport 闸门前分流。
+  if (sub === 'invite') {
+    await cmdBotsInvite(rest);
+    return;
+  }
+
   if (sub !== 'list' && sub !== 'ls' && sub !== '') {
     console.error('用法: botmux bots list [--scope chat|team] [--team <id>] [--session-id ID]');
+    console.error('      botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]');
     process.exit(1);
   }
 
@@ -12854,6 +12807,73 @@ async function cmdBotsListTeam(rest: string[]): Promise<void> {
     total: agents.length,
     note: '发现列表只含已加入团队（owner 在平台「管理机器人」opt-in）的 agent；specialties/mentionable 为 agent 自报，仅供参考不可信。',
   }, null, jsonOut ? 0 : 2));
+}
+
+/**
+ * `botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]`
+ * —— 往**已存在的团队群**补人（同 team、已 opt-in 的 agent + 各自 owner），打平台端点4。
+ *
+ * 独立于 create-group（建新群）：语义是「群已经在了，往里加人」，不该跟建群混在一个命令里。
+ * 全程 machine-auth、只认 appId（发起人在别人 bot 进群前 @不到它，靠 appId 绕开视角问题）。
+ * 授权/opt-in 闸/大厅排除全在平台，CLI 零判断、只如实展示平台判定。
+ *
+ * 输出：stdout 单行 chatId（skill 友好，与 create-group 一致）；--json-status 追加
+ * {ok, chatId, invalidBotIds, invalidOwnerUnionIds, teamId}；invalid* 非空 → 非零退出。
+ */
+async function cmdBotsInvite(rest: string[]): Promise<void> {
+  const { addTeamGroupMembers, fetchTeams, describeTeamAgentsFailure, rateLimitRetryHint } =
+    await import('./platform/team-agents-client.js');
+  const jsonStatus = rest.includes('--json-status');
+  const chatArg = (argValue(rest, '--chat') ?? '').trim();
+  const includeOwnersFalse = rest.includes('--no-owners');
+  const appIds = [...new Set(argValues(rest, '--agent').map(s => s.trim()).filter(Boolean))];
+
+  if (!chatArg) {
+    console.error('用法: botmux bots invite --chat <chatId> --team <id> --agent <appId>... [--no-owners]');
+    console.error('--chat 必填：目标群 chatId（必须是本团队自己建/拉的协作群，非机器人大厅）。');
+    process.exit(1);
+  }
+  if (appIds.length === 0) {
+    console.error('至少一个 --agent <appId>（用 botmux bots list --scope team 发现 appId）。');
+    process.exit(1);
+  }
+
+  const teamId = await resolveSingleTeamIdOrExit(fetchTeams, describeTeamAgentsFailure, argValue(rest, '--team'), '补人');
+
+  const res = await addTeamGroupMembers({
+    chatId: chatArg, teamId, appIds,
+    ...(includeOwnersFalse ? { includeOwners: false } : {}),
+  });
+  if (!res.ok) {
+    if (res.reason === 'unbound') console.error('本机未绑定平台。补人需要先 botmux bind。');
+    else if (res.reason === 'not_deployed') console.error('平台尚未部署补人端点（/v1/machine/groups/:chatId/members）。等平台上线后重试。');
+    else if (res.reason === 'rate_limited') console.error(`补人被限流，${rateLimitRetryHint(res)}。`);
+    else if (res.reason === 'client' && res.status === 403) {
+      // 403 可能是 chat_not_in_team（目标群不是本团队的群）/ chat_is_hall（大厅不允许补人）/ not_in_team_bots。
+      const which = res.appIds && res.appIds.length ? `（${res.appIds.join('、')}）` : '';
+      const hint = res.error === 'chat_not_in_team' ? '目标群不是本团队的协作群，只能往本团队自己建/拉的群补人'
+        : res.error === 'chat_is_hall' ? '目标群是机器人大厅，不允许往里补人（大厅是 bot-only 身份登记群）'
+        : `相关 bot${which} 未由其 owner 在平台「管理机器人」加入该团队`;
+      console.error(`补人被拒（403 ${res.error}）：${hint}。`);
+    } else if (res.reason === 'client' && res.status === 404) {
+      console.error(`团队不存在或本机 owner 不是其成员：teamId=${teamId}`);
+    } else {
+      console.error(`补人失败：${describeTeamAgentsFailure(res)}`);
+    }
+    process.exit(1);
+  }
+
+  const { invalidBotIds, invalidOwnerUnionIds } = res.value;
+  console.log(chatArg); // stdout 单行 chatId（与 create-group 一致）
+  const hasInvalid = invalidBotIds.length > 0 || invalidOwnerUnionIds.length > 0;
+  if (jsonStatus) {
+    console.log(JSON.stringify({ ok: true, chatId: chatArg, invalidBotIds, invalidOwnerUnionIds, teamId }));
+  }
+  // 补人幂等（已在群内视作成功）；平台 200 不列「实际加了谁」，成功即 invalid* 为空。
+  if (!hasInvalid) console.error('✅ 补人成功（选中的 agent 及其 owner 均已在群内或已加入）。');
+  if (invalidBotIds.length > 0) console.error(`⚠️ 以下 agent 未加入团队或补入失败：${invalidBotIds.join('、')}`);
+  if (invalidOwnerUnionIds.length > 0) console.error(`⚠️ 以下 owner 未能补入：${invalidOwnerUnionIds.join('、')}`);
+  if (hasInvalid) process.exitCode = 1;
 }
 
 // ─── botmux lang ─────────────────────────────────────────────────────────────

--- a/src/cli/arg-utils.ts
+++ b/src/cli/arg-utils.ts
@@ -18,3 +18,11 @@ export function firstPositional(args: string[], flagsWithValue: string[]): strin
   }
   return undefined;
 }
+
+/** True if `flag` is present in either bare (`--team`) or `=`-value (`--team=t1`)
+ *  form. Use for presence checks on flags that ALSO carry a value via
+ *  argValue/argValues, where a bare `args.includes(flag)` misses the
+ *  `--flag=value` spelling (e.g. team-mode routing on `create-group`). */
+export function hasFlagOrEq(args: string[], flag: string): boolean {
+  return args.some(a => a === flag || a.startsWith(flag + '='));
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -288,6 +288,7 @@ import { readPlatformBinding } from './platform/binding.js';
 import { startPlatformTunnelClient, type PlatformBotInfo, type PlatformTeamSyncMessage } from './platform/tunnel-client.js';
 import { applyPlatformTeamSync, getPlatformTeamSyncRev, listPlatformTeams } from './services/platform-team-store.js';
 import { getBotUnionId } from './services/bot-union-ids-store.js';
+import { getBotSpecialties } from './services/bot-profile-store.js';
 import { cleanupIdleSessions, parseIdleCleanupHours } from './dashboard/session-cleanup.js';
 import {
   compatMachineIdForAuthenticatedRequest,
@@ -6901,11 +6902,12 @@ function readPlatformBotsInfo(): PlatformBotInfo[] {
     // Merge per-bot team-visibility config (showInTeam) from bots.json by
     // larkAppId so the platform team page can hide bots. Default: showInTeam =
     // true (shown). bots.json may be unreadable from the dashboard process →
-    // fall back to the default.
-    const cfgByAppId = new Map<string, { showInTeam?: boolean }>();
+    // fall back to the default. apiOnly is read from the same config to derive
+    // `mentionable` (a core-only bot has no Feishu transport → can't be @-ed).
+    const cfgByAppId = new Map<string, { showInTeam?: boolean; apiOnly?: boolean }>();
     try {
       for (const cfg of loadBotConfigs()) {
-        cfgByAppId.set(cfg.larkAppId, { showInTeam: cfg.showInTeam });
+        cfgByAppId.set(cfg.larkAppId, { showInTeam: cfg.showInTeam, apiOnly: cfg.apiOnly });
       }
     } catch {
       /* defaults below */
@@ -6923,6 +6925,13 @@ function readPlatformBotsInfo(): PlatformBotInfo[] {
           // 自家消息回声学到的租户稳定 union_id（可能尚未学到 → undefined）。
           // 平台聚合团队 roster 用，见 bot-union-ids-store / platform-team-store。
           unionId: e.larkAppId ? getBotUnionId(config.session.dataDir, e.larkAppId) : undefined,
+          // 团队维度 Agent 互查（additive，交接契约 §端点2 / register|heartbeat）：
+          //  · specialties：owner 预配的专长标签（bot-profiles），发现/拉群匹配依据，仅展示不可信。
+          //  · mentionable：是否有飞书传输身份能被 @（core-only/apiOnly → false）。cfg 读不到
+          //    时保守按可传输(true)，与 team-bot-directory「undefined 按可传输」同源
+          //    （fail-open 仅在本机自报、无跨部署放大风险；真正的 no-transport 由 apiOnly 明示）。
+          specialties: e.larkAppId ? getBotSpecialties(config.session.dataDir, e.larkAppId) : [],
+          mentionable: cfg?.apiOnly !== true,
         };
       })
       .filter((b) => b.appId);

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -142,6 +142,39 @@ export function __testOnly_resetAllBotClients(): void {
   allBotClientsFingerprint = null;
 }
 
+/**
+ * Find the first locally-configured (non-apiOnly) bot that is a member of
+ * `chatId`, using the QUIET probe clients (probeLarkLogger) — so misses for
+ * bots not in the chat don't splash AxiosError blobs to stdout/logs the way a
+ * plain getBotClient()+isInChat loop does.
+ *
+ * Used by `bots invite`'s auto-add flow to pick a proxy bot already in the
+ * target group (Feishu requires the adding app to be a member). Returns the
+ * matching bot's appId+cliId, or null if none of our bots are in that chat.
+ * `preferAppId` (e.g. the current session bot) is checked first.
+ */
+export async function findLocalBotInChat(
+  chatId: string,
+  preferAppId?: string,
+): Promise<{ larkAppId: string; cliId: string } | null> {
+  const clients = getAllBotClients();
+  const ordered = [
+    ...clients.filter((c) => c.appId === preferAppId),
+    ...clients.filter((c) => c.appId !== preferAppId),
+  ];
+  for (const { appId, cliId, client } of ordered) {
+    try {
+      const res: any = await larkGet(client, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members/is_in_chat`);
+      if ((res.code === 0 || res.code === undefined) && res.data?.is_in_chat) {
+        return { larkAppId: appId, cliId };
+      }
+    } catch {
+      /* probe miss (other-tenant / no scope / not in chat) — quiet, try next */
+    }
+  }
+  return null;
+}
+
 // ─── Error types ──────────────────────────────────────────────────────────────
 
 /** Thrown when the target message has been withdrawn (Lark code 230011). */

--- a/src/platform/team-agents-client.ts
+++ b/src/platform/team-agents-client.ts
@@ -18,7 +18,7 @@
  *    的正常含义是「同团队里还没有别人 opt-in」，不是错误。
  *
  * 错误分型沿用 issue-client 的口径（network 可重试 / forbidden 停手 / client 4xx 请求本身
- * 有问题 / server 5xx 退避），额外把端点3 的 429 `rate_limited`（同机 30s 一次）单列出来，
+ * 有问题 / server 5xx 退避），额外把建群/补人共用的 429 `rate_limited` 单列出来，
  * 让 CLI 能给出「稍后再试」而不是当成永久失败。
  */
 import { getJson, postJson } from './platform-http.js';
@@ -69,8 +69,10 @@ export interface AddTeamGroupMembersResult {
 export type TeamAgentsFailure =
   | { ok: false; reason: 'unbound' }
   | { ok: false; reason: 'network'; error: string }
-  /** 端点3 专有：429，同机 30s 一次的限流。稍后重试即可，别当永久失败。 */
-  | { ok: false; reason: 'rate_limited'; status: number; error: string }
+  /** 429：建群/补人共用同一个限流器（同机 30s 窗）。多 pod 下限流表是进程内 per-pod Map，
+   *  全局实际速率 ≈ N_pod × (1/30s)，所以不保证精确 30s——退避读平台带回的 `retryAfterMs`
+   *  更诚实（多 pod 下真实等待本就不确定）。稍后重试即可，别当永久失败。 */
+  | { ok: false; reason: 'rate_limited'; status: number; error: string; retryAfterMs?: number }
   | { ok: false; reason: 'forbidden'; status: number; error: string }
   /** 404 + 非 JSON/无 error 体：平台框架级路由兜底（apex 的 text/plain "not found"），
    *  = 端点2/3 还没部署到本机绑定的平台。与「非成员/团队不存在」的**业务 404**
@@ -105,7 +107,12 @@ function classify(status: number, json: unknown): TeamAgentsFailure {
   const error = hasError ? rawErr : `http_${status}`;
   // 平台在部分 403（如 not_in_team_bots）体里带回被拒的具体 agent appIds，透出以便精准提示。
   const bodyAppIds = strList((json as { appIds?: unknown })?.appIds);
-  if (status === 429) return { ok: false, reason: 'rate_limited', status, error };
+  if (status === 429) {
+    // 429 体带 retryAfterMs（建群/补人都带）→ 读它做退避，别写死 30s（多 pod 下真实等待不确定）。
+    const ra = (json as { retryAfterMs?: unknown })?.retryAfterMs;
+    const retryAfterMs = typeof ra === 'number' && Number.isFinite(ra) && ra >= 0 ? ra : undefined;
+    return { ok: false, reason: 'rate_limited', status, error, ...(retryAfterMs !== undefined ? { retryAfterMs } : {}) };
+  }
   if (status === 401 || status === 403) {
     // 403 分型必须**按 error code**，不能「有 error 体就当 client」：
     //  · 请求对象类（opt-in / 群归属）→ client（请求本身的问题，改参数才有意义）：
@@ -249,7 +256,7 @@ export function fetchTeamAgents(
  * 这里全靠 appId 走 machine-auth，不依赖任何飞书 @。
  *
  * 平台会把未 opt-in / 拉不动的对象放进 invalidBotIds / invalidOwnerUnionIds 原样带回；
- * 429 rate_limited（同机 30s 一次）单独分型，让上层提示稍后再试。
+ * 429 rate_limited（建群/补人共用限流器）单独分型，让上层读 retryAfterMs 退避、提示稍后再试。
  */
 export function createTeamGroup(
   args: { teamId: string; appIds: string[]; name?: string },
@@ -302,12 +309,21 @@ export function isRetriable(f: TeamAgentsFailure): boolean {
   return f.reason === 'network' || f.reason === 'rate_limited' || (f.reason === 'server' && f.status >= 500);
 }
 
+/** 429 的重试提示：优先用平台带回的 retryAfterMs（多 pod 下比写死 30s 诚实），否则中性文案。 */
+export function rateLimitRetryHint(f: Extract<TeamAgentsFailure, { reason: 'rate_limited' }>): string {
+  if (f.retryAfterMs !== undefined) {
+    const sec = Math.ceil(f.retryAfterMs / 1000);
+    return `请约 ${sec} 秒后重试`;
+  }
+  return '请稍后重试';
+}
+
 /** 把一次失败转成给人看的一句话（CLI 直接打印）。unbound 由调用方单独提示（要引导 bind）。 */
 export function describeTeamAgentsFailure(f: TeamAgentsFailure): string {
   switch (f.reason) {
     case 'unbound': return '本机未绑定平台';
     case 'network': return `网络错误：${f.error}（稍后重试）`;
-    case 'rate_limited': return '被限流（同机 30s 一次），请稍后重试';
+    case 'rate_limited': return `被限流，${rateLimitRetryHint(f)}`;
     case 'forbidden': return `凭证失效或无权限（${f.status} ${f.error}），可能需要重新 botmux bind`;
     case 'not_deployed': return '平台尚未部署团队 agent 端点（/v1/machine/agents|groups），请等平台上线后重试';
     case 'client': return `请求被拒（${f.status} ${f.error}）`;

--- a/src/platform/team-agents-client.ts
+++ b/src/platform/team-agents-client.ts
@@ -115,16 +115,17 @@ function classify(status: number, json: unknown): TeamAgentsFailure {
   }
   if (status === 401 || status === 403) {
     // 403 分型必须**按 error code**，不能「有 error 体就当 client」：
-    //  · 请求对象类（opt-in / 群资格）→ client（请求本身的问题，改参数/前置动作才有意义）：
-    //    not_in_team_bots（bot 没 opt-in）、chat_is_hall（大厅不可补人）、
+    //  · 请求对象类（群资格 / opt-in）→ client（改前置动作/参数才有意义）：
     //    platform_bot_not_in_chat（平台 bot 不在目标群 → 先把平台 bot 拉进群）、
-    //    requester_bot_not_in_chat（群里没有发起方本机的 bot → 不是你在协作的群）。
+    //    requester_not_in_chat（发起方 owner 本人不在该群 → 只能往你自己在的群补人）、
+    //    chat_is_hall（大厅不可补人）、not_in_team_bots（bot 没 opt-in）。
     //  · 其余 403（如 machine_ownership_mismatch：机器 RETIRED/换绑 owner）是**凭证/归属问题** → forbidden，
     //    该去 rebind，不是改参数——归 client 会误导排查方向。纯 401 / 无 error 体的 403 同理 forbidden。
-    //  （旧 chat_not_in_team 随 groupChatIds 判据下线，被上面两个 *_not_in_chat 取代。）
+    //  （归属闸按「人」判：飞书列群成员不返回 bot、不支持 app_id，故验发起方 owner unionId ∈ 群，
+    //   不是 bot ∈ 群。旧 chat_not_in_team / requester_bot_not_in_chat 均下线，保留兼容解析。）
     const CLIENT_403 = new Set([
-      'not_in_team_bots', 'chat_is_hall', 'platform_bot_not_in_chat', 'requester_bot_not_in_chat',
-      'chat_not_in_team', // 兼容：旧端点未升级前仍可能回它
+      'platform_bot_not_in_chat', 'requester_not_in_chat', 'chat_is_hall', 'not_in_team_bots',
+      'chat_not_in_team', 'requester_bot_not_in_chat', // 兼容：端点未升级前的旧码
       'not_found',
     ]);
     if (status === 403 && hasError && CLIENT_403.has(rawErr as string)) {
@@ -281,23 +282,21 @@ export function createTeamGroup(
 }
 
 /**
- * 端点4（B）：往一个**已存在的团队群** `chatId` 补人——把 `appIds` 指定的 agent
- * （+ 默认各自 owner）加进去。与端点3（建新群）互补：这条服务「群已经在了、往里加同 team
- * 别人的 agent」的场景。
+ * 端点4（B）：往一个**已存在的群** `chatId` 补人——把 `appIds` 指定的 agent **+ 各自 owner**
+ * 一起加进去。与端点3（建新群）互补：这条服务「群已经在了、往里加同 team 别人的 agent」的场景。
+ * 补人**恒带 owner**（agent 不进没主人的群），无「只补 bot」选项。
  *
- * 平台侧授权（客户端零判断，只透传）：① 调用者是 teamId 成员（否则 404）；② chatId 必须是
- * 该 team 自己的协作群（∈ groupChatIds，且**排除机器人大厅**）——否则 403 `chat_not_in_team`
- * / `chat_is_hall`，杜绝拿任意 chatId 往别人群塞人；③ opt-in 闸同 team.bots。
- *
- * `includeOwners` 默认 true（对齐端点3「bot 不进没主人的群」）；只加**被加 bot 各自的 owner**
- * （都是 team 成员、同信任域），绝不加任意真人。传 false 则只补 bot、不动人。
+ * 平台侧授权（客户端零判断，只透传）——判据按「人」判（飞书列群成员不返回 bot、不支持 app_id）：
+ *  ① 可行性闸：平台 bot ∈ chat（tenant token is_in_chat）——它不在就根本加不进人，否则 403
+ *     `platform_bot_not_in_chat`；② 归属闸：发起方 owner（machineToken 里的 unionId，不可伪造）
+ *     ∈ chat——「你本人已在这群，只是把队友 bot+owner 拉进来」，否则 403 `requester_not_in_chat`；
+ *  ③ opt-in 闸同 team.bots；④ 大厅排除。杜绝往「你不在的陌生群」塞人。
  */
 export function addTeamGroupMembers(
-  args: { chatId: string; teamId: string; appIds: string[]; includeOwners?: boolean },
+  args: { chatId: string; teamId: string; appIds: string[] },
   opts: TeamAgentsClientOptions = {},
 ): Promise<TeamAgentsClientResult<AddTeamGroupMembersResult>> {
   const body: Record<string, unknown> = { teamId: args.teamId, appIds: args.appIds };
-  if (args.includeOwners !== undefined) body.includeOwners = args.includeOwners;
   return call(
     opts,
     'POST',

--- a/src/platform/team-agents-client.ts
+++ b/src/platform/team-agents-client.ts
@@ -1,0 +1,268 @@
+/**
+ * 团队维度 Agent 互查 / 拉群的 machine-auth 客户端（打 `/v1/machine/*`，
+ * Bearer = machineToken）。与 [[issue-client]] 同源共用 platform-http + 平台绑定，
+ * 只是覆盖的是「团队 agent 发现 + 拉群」这一组端点：
+ *
+ *  1. GET  /v1/machine/teams                → 本机 owner 所属平台团队（复用 issue-client.fetchTeams
+ *     也能拿到，这里不重复实现）。
+ *  2. GET  /v1/machine/agents?teamId=       → 同团队、已 opt-in（owner 加进 team.bots）的 agent 列表。
+ *  3. POST /v1/machine/groups {teamId,appIds,name?} → 平台代建一个聚焦新群，把选中的 agent
+ *     和各自 owner 一起拉进去，返回 chatId + shareLink。
+ *
+ * 设计不变量（对齐交接的硬约束）：
+ *  - **CLI 不做任何授权判断**：团队成员校验 + opt-in 闸（team.bots）全在平台。本客户端只透传
+ *    machineToken、把平台的判定结果原样带回，绝不本地放行/拦截。
+ *  - agent 自报的 `specialties` / `mentionable` **仅展示、不可信**：解析进来只为让上层
+ *    （agent / 人）挑 bot，不构成任何能力凭据。
+ *  - 发现结果只含「已加入 team.bots」的 agent —— 这是平台侧过滤的，不是我们能感知的；空列表
+ *    的正常含义是「同团队里还没有别人 opt-in」，不是错误。
+ *
+ * 错误分型沿用 issue-client 的口径（network 可重试 / forbidden 停手 / client 4xx 请求本身
+ * 有问题 / server 5xx 退避），额外把端点3 的 429 `rate_limited`（同机 30s 一次）单列出来，
+ * 让 CLI 能给出「稍后再试」而不是当成永久失败。
+ */
+import { getJson, postJson } from './platform-http.js';
+import { readPlatformBinding } from './binding.js';
+
+/** 平台返回的一个团队 agent。字段对齐交接契约 §端点2。 */
+export interface TeamAgent {
+  appId: string;
+  openId?: string;
+  unionId?: string;
+  name: string;
+  /** agent 自报的专长标签（发现/拉群匹配依据）。**仅展示、不可信**。
+   *  契约键为 `specialties`（曾拟名 capabilities，因与「权限凭据」语义撞车改名，且改名前零消费方）。 */
+  specialties: string[];
+  /** agent 自报是否可被 @（= 有飞书传输身份）。**仅展示、不可信**。 */
+  mentionable: boolean;
+  /** 平台的在线判定（心跳新鲜度）。 */
+  online: boolean;
+  owner: { unionId?: string; name?: string };
+  machineId?: string;
+  machineName?: string;
+}
+
+export interface TeamAgentsResult {
+  teamId: string;
+  teamName: string;
+  agents: TeamAgent[];
+}
+
+/** 端点3 建群结果。invalidBotIds / invalidOwnerUnionIds 是平台侧过滤掉的对象（未 opt-in / 拉不动）。 */
+export interface CreateTeamGroupResult {
+  ok: boolean;
+  chatId: string;
+  shareLink?: string;
+  invalidBotIds: string[];
+  invalidOwnerUnionIds: string[];
+}
+
+export type TeamAgentsFailure =
+  | { ok: false; reason: 'unbound' }
+  | { ok: false; reason: 'network'; error: string }
+  /** 端点3 专有：429，同机 30s 一次的限流。稍后重试即可，别当永久失败。 */
+  | { ok: false; reason: 'rate_limited'; status: number; error: string }
+  | { ok: false; reason: 'forbidden'; status: number; error: string }
+  /** 404 + 非 JSON/无 error 体：平台框架级路由兜底（apex 的 text/plain "not found"），
+   *  = 端点2/3 还没部署到本机绑定的平台。与「非成员/团队不存在」的**业务 404**
+   *  （JSON `{error:'not_found'}`）区分开——后者归 client。判据：业务 404 一定带
+   *  可解析的 `.error`，路由缺失兜底不带（平台契约明确、稳定）。 */
+  | { ok: false; reason: 'not_deployed'; status: number }
+  /** 其余 4xx（400 invalid / 403 not_in_team_bots / 404 not_found 业务态）：请求本身的问题。 */
+  | { ok: false; reason: 'client'; status: number; error: string }
+  | { ok: false; reason: 'server'; status: number; error: string };
+
+export type TeamAgentsClientResult<T> = { ok: true; value: T } | TeamAgentsFailure;
+
+export interface TeamAgentsClientOptions {
+  /** 覆盖平台地址与凭证（测试用；缺省读 ~/.botmux/platform.json）。 */
+  binding?: { platformUrl: string; machineToken: string; machineId: string } | null;
+  timeoutMs?: number;
+  /** 注入 HTTP 实现（测试用）。 */
+  http?: { get: typeof getJson; post: typeof postJson };
+}
+
+function resolveBinding(opts: TeamAgentsClientOptions) {
+  if (opts.binding !== undefined) return opts.binding;
+  const b = readPlatformBinding();
+  return b ? { platformUrl: b.platformUrl, machineToken: b.machineToken, machineId: b.machineId } : null;
+}
+
+function classify(status: number, json: unknown): TeamAgentsFailure {
+  const rawErr = (json as { error?: unknown })?.error;
+  const hasError = typeof rawErr === 'string' && rawErr.length > 0;
+  const error = hasError ? rawErr : `http_${status}`;
+  if (status === 429) return { ok: false, reason: 'rate_limited', status, error };
+  if (status === 401 || status === 403) {
+    // 403 not_in_team_bots 是「这个 bot 没 opt-in 进团队」——语义上是请求对象不对，不是凭证失效，
+    // 归 client（请求本身的问题）；只有纯 401 / 无 error 体的 403 当 forbidden（凭证/归属问题，停手）。
+    // ⚠️ 不要据此假设「非法请求永远拿 403、不会撞 429」：平台端点3 的检查顺序是
+    // 404(成员) → 429(限流) → 403(opt-in)，且限流器只在真正建群那步 arm。所以一个**合法**
+    // 建群请求 arm 了 30s 窗后，紧接着的非 opt-in 请求会先撞 429、而非 403。分型按**当次
+    // status** 判即可（本函数就是这么做的），别把「同参数重发结果恒定」写进任何调用方逻辑。
+    if (status === 403 && hasError) return { ok: false, reason: 'client', status, error };
+    return { ok: false, reason: 'forbidden', status, error };
+  }
+  // 404 的两义性（平台契约明确、稳定）：
+  //  · 业务 404「非成员/团队不存在」（成员校验，端点3 最前一道）→ 一定带 JSON `{error:'not_found'}`
+  //    （hasError=true）→ client。
+  //  · 框架路由缺失兜底（apex 的 text/plain "not found"，端点未部署）→ 无可解析 error → not_deployed。
+  // getJson/postJson 对非 JSON 响应返回 {}，故「404 且无 .error」即路由未上线，不能误报成业务 404。
+  if (status === 404 && !hasError) return { ok: false, reason: 'not_deployed', status };
+  if (status >= 400 && status < 500) return { ok: false, reason: 'client', status, error };
+  return { ok: false, reason: 'server', status, error };
+}
+
+async function call<T>(
+  opts: TeamAgentsClientOptions,
+  method: 'GET' | 'POST',
+  path: string,
+  body: unknown,
+  pick: (json: any) => T,
+): Promise<TeamAgentsClientResult<T>> {
+  const binding = resolveBinding(opts);
+  if (!binding) return { ok: false, reason: 'unbound' };
+  const http = opts.http ?? { get: getJson, post: postJson };
+  const url = `${binding.platformUrl.replace(/\/+$/, '')}${path}`;
+  const reqOpts = {
+    headers: { authorization: `Bearer ${binding.machineToken}` },
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+  };
+  let res: { status: number; json: unknown };
+  try {
+    res = method === 'GET' ? await http.get(url, reqOpts) : await http.post(url, body ?? {}, reqOpts);
+  } catch (e) {
+    return { ok: false, reason: 'network', error: String((e as Error)?.message ?? e) };
+  }
+  if (res.status < 200 || res.status >= 300) return classify(res.status, res.json);
+  return { ok: true, value: pick(res.json) };
+}
+
+/** 一个 agent 自报的专长标签（契约键 `specialties`）。
+ *  仅收非空字符串、去重、保序；任何非数组/脏值 → 空数组（仅展示，不因脏数据报错）。 */
+function pickSpecialties(raw: unknown): string[] {
+  const src = (raw as { specialties?: unknown }) ?? {};
+  const arr = Array.isArray(src.specialties) ? src.specialties : [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const v of arr) {
+    if (typeof v !== 'string') continue;
+    const s = v.trim();
+    if (!s || seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out;
+}
+
+function normalizeAgent(raw: unknown): TeamAgent | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const a = raw as Record<string, unknown>;
+  const appId = typeof a.appId === 'string' ? a.appId.trim() : '';
+  if (!appId) return null;
+  const ownerRaw = (a.owner && typeof a.owner === 'object' ? a.owner : {}) as Record<string, unknown>;
+  return {
+    appId,
+    openId: typeof a.openId === 'string' ? a.openId : undefined,
+    unionId: typeof a.unionId === 'string' ? a.unionId : undefined,
+    name: typeof a.name === 'string' && a.name ? a.name : appId,
+    specialties: pickSpecialties(a),
+    mentionable: a.mentionable === true,
+    online: a.online === true,
+    owner: {
+      unionId: typeof ownerRaw.unionId === 'string' ? ownerRaw.unionId : undefined,
+      name: typeof ownerRaw.name === 'string' ? ownerRaw.name : undefined,
+    },
+    machineId: typeof a.machineId === 'string' ? a.machineId : undefined,
+    machineName: typeof a.machineName === 'string' ? a.machineName : undefined,
+  };
+}
+
+function strList(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((x): x is string => typeof x === 'string') : [];
+}
+
+/**
+ * 端点1：本机 owner 所属的平台团队。与 [[issue-client]].fetchTeams 打的是同一个端点，
+ * 这里单列一份是为了让整条团队发现/拉群链共用同一套 TeamAgentsFailure 分型（含 429），
+ * 上层错误处理不必跨两个 client 的 union。
+ */
+export function fetchTeams(
+  opts: TeamAgentsClientOptions = {},
+): Promise<TeamAgentsClientResult<Array<{ teamId: string; teamName: string }>>> {
+  return call(opts, 'GET', '/v1/machine/teams', undefined, (j) => {
+    const arr = Array.isArray(j?.teams) ? j.teams : [];
+    return arr
+      .map((t: unknown) => {
+        const o = (t && typeof t === 'object' ? t : {}) as Record<string, unknown>;
+        const teamId = typeof o.teamId === 'string' ? o.teamId.trim() : '';
+        if (!teamId) return null;
+        return { teamId, teamName: typeof o.teamName === 'string' ? o.teamName : teamId };
+      })
+      .filter((t: { teamId: string; teamName: string } | null): t is { teamId: string; teamName: string } => !!t);
+  });
+}
+
+/**
+ * 端点2：列出同团队、已 opt-in 的 agent。平台按 `teamId` 过滤 + opt-in 闸（team.bots），
+ * 客户端零判断。空 agents 是正常态（同团队还没别人加入），不是错误。
+ */
+export function fetchTeamAgents(
+  teamId: string,
+  opts: TeamAgentsClientOptions = {},
+): Promise<TeamAgentsClientResult<TeamAgentsResult>> {
+  return call(
+    opts,
+    'GET',
+    `/v1/machine/agents?teamId=${encodeURIComponent(teamId)}`,
+    undefined,
+    (j) => ({
+      teamId: typeof j?.teamId === 'string' ? j.teamId : teamId,
+      teamName: typeof j?.teamName === 'string' ? j.teamName : teamId,
+      agents: (Array.isArray(j?.agents) ? j.agents : [])
+        .map(normalizeAgent)
+        .filter((a: TeamAgent | null): a is TeamAgent => !!a),
+    }),
+  );
+}
+
+/**
+ * 端点3：让平台代建一个聚焦新群，把 `appIds` 指定的 agent + 各自 owner + 本机 owner 拉进去。
+ * `appIds` 是**跨机 appId**（从端点2 发现而来）——正因为发起人在别人 bot 进群前 @不到它，
+ * 这里全靠 appId 走 machine-auth，不依赖任何飞书 @。
+ *
+ * 平台会把未 opt-in / 拉不动的对象放进 invalidBotIds / invalidOwnerUnionIds 原样带回；
+ * 429 rate_limited（同机 30s 一次）单独分型，让上层提示稍后再试。
+ */
+export function createTeamGroup(
+  args: { teamId: string; appIds: string[]; name?: string },
+  opts: TeamAgentsClientOptions = {},
+): Promise<TeamAgentsClientResult<CreateTeamGroupResult>> {
+  const body: Record<string, unknown> = { teamId: args.teamId, appIds: args.appIds };
+  if (args.name !== undefined) body.name = args.name;
+  return call(opts, 'POST', '/v1/machine/groups', body, (j) => ({
+    ok: j?.ok === true,
+    chatId: typeof j?.chatId === 'string' ? j.chatId : '',
+    shareLink: typeof j?.shareLink === 'string' ? j.shareLink : undefined,
+    invalidBotIds: strList(j?.invalidBotIds),
+    invalidOwnerUnionIds: strList(j?.invalidOwnerUnionIds),
+  }));
+}
+
+/** 该失败是否值得退避后重投（对齐 issue-client.isRetriable，额外含 429 限流）。 */
+export function isRetriable(f: TeamAgentsFailure): boolean {
+  return f.reason === 'network' || f.reason === 'rate_limited' || (f.reason === 'server' && f.status >= 500);
+}
+
+/** 把一次失败转成给人看的一句话（CLI 直接打印）。unbound 由调用方单独提示（要引导 bind）。 */
+export function describeTeamAgentsFailure(f: TeamAgentsFailure): string {
+  switch (f.reason) {
+    case 'unbound': return '本机未绑定平台';
+    case 'network': return `网络错误：${f.error}（稍后重试）`;
+    case 'rate_limited': return '被限流（同机 30s 一次），请稍后重试';
+    case 'forbidden': return `凭证失效或无权限（${f.status} ${f.error}），可能需要重新 botmux bind`;
+    case 'not_deployed': return '平台尚未部署团队 agent 端点（/v1/machine/agents|groups），请等平台上线后重试';
+    case 'client': return `请求被拒（${f.status} ${f.error}）`;
+    case 'server': return `平台错误（${f.status} ${f.error}），稍后重试`;
+  }
+}

--- a/src/platform/team-agents-client.ts
+++ b/src/platform/team-agents-client.ts
@@ -57,10 +57,11 @@ export interface CreateTeamGroupResult {
   invalidOwnerUnionIds: string[];
 }
 
-/** 端点4（B：往已存在的团队群补人）结果。对齐端点3 的 invalid* 语义，另带 added（实际加入的 appId）。 */
+/** 端点4（B：往已存在的团队群补人）结果。对齐端点3 的 invalid* 语义：invalidBotIds /
+ *  invalidOwnerUnionIds 是平台过滤掉的对象（未 opt-in / 拉不动）。平台 200 体不返回「实际
+ *  加了哪些」——补人是幂等的（已在群内视作成功），成功即以 invalid* 为空表达，不单列 added。 */
 export interface AddTeamGroupMembersResult {
   ok: boolean;
-  added: string[];
   invalidBotIds: string[];
   invalidOwnerUnionIds: string[];
 }
@@ -290,7 +291,6 @@ export function addTeamGroupMembers(
     body,
     (j) => ({
       ok: j?.ok === true,
-      added: strList(j?.added),
       invalidBotIds: strList(j?.invalidBotIds),
       invalidOwnerUnionIds: strList(j?.invalidOwnerUnionIds),
     }),

--- a/src/platform/team-agents-client.ts
+++ b/src/platform/team-agents-client.ts
@@ -326,6 +326,26 @@ export function isRetriable(f: TeamAgentsFailure): boolean {
   return f.reason === 'network' || f.reason === 'rate_limited' || (f.reason === 'server' && f.status >= 500);
 }
 
+/**
+ * 一次 addTeamGroupMembers 结果是否应触发「自动拉平台 app 进群 + 重试」。
+ *
+ * 仅当：失败 + 403 client + error==='platform_bot_not_in_chat' + 平台回传了 platformAppId。
+ * 提出成纯函数是为了**锁死自动拉的触发条件与单次性**：调用方据它决定「拉一次+重试一次」，
+ * 重试后的结果**不再**喂回本函数（调用方不递归），所以无论重试成功、仍撞 platform_bot_not_in_chat、
+ * 还是穿透到 requester_not_in_chat，都不会二次触发自动拉——终止性由「调用一次、不回环」保证。
+ * 缺 platformAppId（旧端点未回传）→ false，回退手动引导，不会尝试拉一个不知道 id 的 app。
+ */
+export function shouldTryAutoAddPlatformBot(
+  res: TeamAgentsClientResult<unknown>,
+): res is TeamAgentsFailure & { reason: 'client'; platformAppId: string } {
+  return !res.ok
+    && res.reason === 'client'
+    && res.status === 403
+    && res.error === 'platform_bot_not_in_chat'
+    && typeof res.platformAppId === 'string'
+    && res.platformAppId.length > 0;
+}
+
 /** 429 的重试提示：优先用平台带回的 retryAfterMs（多 pod 下比写死 30s 诚实），否则中性文案。 */
 export function rateLimitRetryHint(f: Extract<TeamAgentsFailure, { reason: 'rate_limited' }>): string {
   if (f.retryAfterMs !== undefined) {

--- a/src/platform/team-agents-client.ts
+++ b/src/platform/team-agents-client.ts
@@ -115,11 +115,18 @@ function classify(status: number, json: unknown): TeamAgentsFailure {
   }
   if (status === 401 || status === 403) {
     // 403 分型必须**按 error code**，不能「有 error 体就当 client」：
-    //  · 请求对象类（opt-in / 群归属）→ client（请求本身的问题，改参数才有意义）：
-    //    not_in_team_bots（bot 没 opt-in）、chat_not_in_team（目标群不是本团队的）、chat_is_hall（大厅不可补人）。
+    //  · 请求对象类（opt-in / 群资格）→ client（请求本身的问题，改参数/前置动作才有意义）：
+    //    not_in_team_bots（bot 没 opt-in）、chat_is_hall（大厅不可补人）、
+    //    platform_bot_not_in_chat（平台 bot 不在目标群 → 先把平台 bot 拉进群）、
+    //    requester_bot_not_in_chat（群里没有发起方本机的 bot → 不是你在协作的群）。
     //  · 其余 403（如 machine_ownership_mismatch：机器 RETIRED/换绑 owner）是**凭证/归属问题** → forbidden，
-    //    该去 rebind，不是改参数——归 client 会误导用户「确认 bot 已加入团队」。纯 401 / 无 error 体的 403 同理 forbidden。
-    const CLIENT_403 = new Set(['not_in_team_bots', 'chat_not_in_team', 'chat_is_hall', 'not_found']);
+    //    该去 rebind，不是改参数——归 client 会误导排查方向。纯 401 / 无 error 体的 403 同理 forbidden。
+    //  （旧 chat_not_in_team 随 groupChatIds 判据下线，被上面两个 *_not_in_chat 取代。）
+    const CLIENT_403 = new Set([
+      'not_in_team_bots', 'chat_is_hall', 'platform_bot_not_in_chat', 'requester_bot_not_in_chat',
+      'chat_not_in_team', // 兼容：旧端点未升级前仍可能回它
+      'not_found',
+    ]);
     if (status === 403 && hasError && CLIENT_403.has(rawErr as string)) {
       return { ok: false, reason: 'client', status, error, ...(bodyAppIds.length ? { appIds: bodyAppIds } : {}) };
     }

--- a/src/platform/team-agents-client.ts
+++ b/src/platform/team-agents-client.ts
@@ -79,10 +79,12 @@ export type TeamAgentsFailure =
    *  （JSON `{error:'not_found'}`）区分开——后者归 client。判据：业务 404 一定带
    *  可解析的 `.error`，路由缺失兜底不带（平台契约明确、稳定）。 */
   | { ok: false; reason: 'not_deployed'; status: number }
-  /** 其余 4xx（400 invalid / 403 not_in_team_bots|chat_not_in_team|chat_is_hall / 404 not_found 业务态）：
-   *  请求本身的问题。`appIds` 是平台在 403 体里带回的「被拒的具体 agent」（如 not_in_team_bots），
-   *  透出后提示能精准到 agent；无则 undefined。 */
-  | { ok: false; reason: 'client'; status: number; error: string; appIds?: string[] }
+  /** 其余 4xx（400 invalid / 403 not_in_team_bots|chat_is_hall|platform_bot_not_in_chat|
+   *  requester_not_in_chat / 404 not_found 业务态）：请求本身的问题。
+   *  · `appIds`：平台在 403 体里带回的「被拒的具体 agent」（如 not_in_team_bots），透出后提示精准到 agent。
+   *  · `platformAppId` / `platformAppName`：仅 `platform_bot_not_in_chat` 带——平台后端 app 的 app_id
+   *    （+ 可选可读名），供客户端「自动把平台 app 拉进群」或引导手动添加。 */
+  | { ok: false; reason: 'client'; status: number; error: string; appIds?: string[]; platformAppId?: string; platformAppName?: string }
   | { ok: false; reason: 'server'; status: number; error: string };
 
 export type TeamAgentsClientResult<T> = { ok: true; value: T } | TeamAgentsFailure;
@@ -107,6 +109,15 @@ function classify(status: number, json: unknown): TeamAgentsFailure {
   const error = hasError ? rawErr : `http_${status}`;
   // 平台在部分 403（如 not_in_team_bots）体里带回被拒的具体 agent appIds，透出以便精准提示。
   const bodyAppIds = strList((json as { appIds?: unknown })?.appIds);
+  // platform_bot_not_in_chat 的 403 体带平台后端 app 身份（自动拉平台 app 进群 / 引导手动加）。
+  const jb = json as { platformAppId?: unknown; platformAppName?: unknown };
+  const platformAppId = typeof jb?.platformAppId === 'string' && jb.platformAppId ? jb.platformAppId : undefined;
+  const platformAppName = typeof jb?.platformAppName === 'string' && jb.platformAppName ? jb.platformAppName : undefined;
+  const clientExtra = {
+    ...(bodyAppIds.length ? { appIds: bodyAppIds } : {}),
+    ...(platformAppId ? { platformAppId } : {}),
+    ...(platformAppName ? { platformAppName } : {}),
+  };
   if (status === 429) {
     // 429 体带 retryAfterMs（建群/补人都带）→ 读它做退避，别写死 30s（多 pod 下真实等待不确定）。
     const ra = (json as { retryAfterMs?: unknown })?.retryAfterMs;
@@ -129,7 +140,7 @@ function classify(status: number, json: unknown): TeamAgentsFailure {
       'not_found',
     ]);
     if (status === 403 && hasError && CLIENT_403.has(rawErr as string)) {
-      return { ok: false, reason: 'client', status, error, ...(bodyAppIds.length ? { appIds: bodyAppIds } : {}) };
+      return { ok: false, reason: 'client', status, error, ...clientExtra };
     }
     return { ok: false, reason: 'forbidden', status, error };
   }
@@ -140,7 +151,7 @@ function classify(status: number, json: unknown): TeamAgentsFailure {
   // getJson/postJson 对非 JSON 响应返回 {}，故「404 且无 .error」即路由未上线，不能误报成业务 404。
   if (status === 404 && !hasError) return { ok: false, reason: 'not_deployed', status };
   if (status >= 400 && status < 500) {
-    return { ok: false, reason: 'client', status, error, ...(bodyAppIds.length ? { appIds: bodyAppIds } : {}) };
+    return { ok: false, reason: 'client', status, error, ...clientExtra };
   }
   return { ok: false, reason: 'server', status, error };
 }

--- a/src/platform/team-agents-client.ts
+++ b/src/platform/team-agents-client.ts
@@ -57,6 +57,14 @@ export interface CreateTeamGroupResult {
   invalidOwnerUnionIds: string[];
 }
 
+/** 端点4（B：往已存在的团队群补人）结果。对齐端点3 的 invalid* 语义，另带 added（实际加入的 appId）。 */
+export interface AddTeamGroupMembersResult {
+  ok: boolean;
+  added: string[];
+  invalidBotIds: string[];
+  invalidOwnerUnionIds: string[];
+}
+
 export type TeamAgentsFailure =
   | { ok: false; reason: 'unbound' }
   | { ok: false; reason: 'network'; error: string }
@@ -68,8 +76,10 @@ export type TeamAgentsFailure =
    *  （JSON `{error:'not_found'}`）区分开——后者归 client。判据：业务 404 一定带
    *  可解析的 `.error`，路由缺失兜底不带（平台契约明确、稳定）。 */
   | { ok: false; reason: 'not_deployed'; status: number }
-  /** 其余 4xx（400 invalid / 403 not_in_team_bots / 404 not_found 业务态）：请求本身的问题。 */
-  | { ok: false; reason: 'client'; status: number; error: string }
+  /** 其余 4xx（400 invalid / 403 not_in_team_bots|chat_not_in_team|chat_is_hall / 404 not_found 业务态）：
+   *  请求本身的问题。`appIds` 是平台在 403 体里带回的「被拒的具体 agent」（如 not_in_team_bots），
+   *  透出后提示能精准到 agent；无则 undefined。 */
+  | { ok: false; reason: 'client'; status: number; error: string; appIds?: string[] }
   | { ok: false; reason: 'server'; status: number; error: string };
 
 export type TeamAgentsClientResult<T> = { ok: true; value: T } | TeamAgentsFailure;
@@ -92,15 +102,19 @@ function classify(status: number, json: unknown): TeamAgentsFailure {
   const rawErr = (json as { error?: unknown })?.error;
   const hasError = typeof rawErr === 'string' && rawErr.length > 0;
   const error = hasError ? rawErr : `http_${status}`;
+  // 平台在部分 403（如 not_in_team_bots）体里带回被拒的具体 agent appIds，透出以便精准提示。
+  const bodyAppIds = strList((json as { appIds?: unknown })?.appIds);
   if (status === 429) return { ok: false, reason: 'rate_limited', status, error };
   if (status === 401 || status === 403) {
-    // 403 not_in_team_bots 是「这个 bot 没 opt-in 进团队」——语义上是请求对象不对，不是凭证失效，
-    // 归 client（请求本身的问题）；只有纯 401 / 无 error 体的 403 当 forbidden（凭证/归属问题，停手）。
-    // ⚠️ 不要据此假设「非法请求永远拿 403、不会撞 429」：平台端点3 的检查顺序是
-    // 404(成员) → 429(限流) → 403(opt-in)，且限流器只在真正建群那步 arm。所以一个**合法**
-    // 建群请求 arm 了 30s 窗后，紧接着的非 opt-in 请求会先撞 429、而非 403。分型按**当次
-    // status** 判即可（本函数就是这么做的），别把「同参数重发结果恒定」写进任何调用方逻辑。
-    if (status === 403 && hasError) return { ok: false, reason: 'client', status, error };
+    // 403 分型必须**按 error code**，不能「有 error 体就当 client」：
+    //  · 请求对象类（opt-in / 群归属）→ client（请求本身的问题，改参数才有意义）：
+    //    not_in_team_bots（bot 没 opt-in）、chat_not_in_team（目标群不是本团队的）、chat_is_hall（大厅不可补人）。
+    //  · 其余 403（如 machine_ownership_mismatch：机器 RETIRED/换绑 owner）是**凭证/归属问题** → forbidden，
+    //    该去 rebind，不是改参数——归 client 会误导用户「确认 bot 已加入团队」。纯 401 / 无 error 体的 403 同理 forbidden。
+    const CLIENT_403 = new Set(['not_in_team_bots', 'chat_not_in_team', 'chat_is_hall', 'not_found']);
+    if (status === 403 && hasError && CLIENT_403.has(rawErr as string)) {
+      return { ok: false, reason: 'client', status, error, ...(bodyAppIds.length ? { appIds: bodyAppIds } : {}) };
+    }
     return { ok: false, reason: 'forbidden', status, error };
   }
   // 404 的两义性（平台契约明确、稳定）：
@@ -109,7 +123,9 @@ function classify(status: number, json: unknown): TeamAgentsFailure {
   //  · 框架路由缺失兜底（apex 的 text/plain "not found"，端点未部署）→ 无可解析 error → not_deployed。
   // getJson/postJson 对非 JSON 响应返回 {}，故「404 且无 .error」即路由未上线，不能误报成业务 404。
   if (status === 404 && !hasError) return { ok: false, reason: 'not_deployed', status };
-  if (status >= 400 && status < 500) return { ok: false, reason: 'client', status, error };
+  if (status >= 400 && status < 500) {
+    return { ok: false, reason: 'client', status, error, ...(bodyAppIds.length ? { appIds: bodyAppIds } : {}) };
+  }
   return { ok: false, reason: 'server', status, error };
 }
 
@@ -247,6 +263,38 @@ export function createTeamGroup(
     invalidBotIds: strList(j?.invalidBotIds),
     invalidOwnerUnionIds: strList(j?.invalidOwnerUnionIds),
   }));
+}
+
+/**
+ * 端点4（B）：往一个**已存在的团队群** `chatId` 补人——把 `appIds` 指定的 agent
+ * （+ 默认各自 owner）加进去。与端点3（建新群）互补：这条服务「群已经在了、往里加同 team
+ * 别人的 agent」的场景。
+ *
+ * 平台侧授权（客户端零判断，只透传）：① 调用者是 teamId 成员（否则 404）；② chatId 必须是
+ * 该 team 自己的协作群（∈ groupChatIds，且**排除机器人大厅**）——否则 403 `chat_not_in_team`
+ * / `chat_is_hall`，杜绝拿任意 chatId 往别人群塞人；③ opt-in 闸同 team.bots。
+ *
+ * `includeOwners` 默认 true（对齐端点3「bot 不进没主人的群」）；只加**被加 bot 各自的 owner**
+ * （都是 team 成员、同信任域），绝不加任意真人。传 false 则只补 bot、不动人。
+ */
+export function addTeamGroupMembers(
+  args: { chatId: string; teamId: string; appIds: string[]; includeOwners?: boolean },
+  opts: TeamAgentsClientOptions = {},
+): Promise<TeamAgentsClientResult<AddTeamGroupMembersResult>> {
+  const body: Record<string, unknown> = { teamId: args.teamId, appIds: args.appIds };
+  if (args.includeOwners !== undefined) body.includeOwners = args.includeOwners;
+  return call(
+    opts,
+    'POST',
+    `/v1/machine/groups/${encodeURIComponent(args.chatId)}/members`,
+    body,
+    (j) => ({
+      ok: j?.ok === true,
+      added: strList(j?.added),
+      invalidBotIds: strList(j?.invalidBotIds),
+      invalidOwnerUnionIds: strList(j?.invalidOwnerUnionIds),
+    }),
+  );
 }
 
 /** 该失败是否值得退避后重投（对齐 issue-client.isRetriable，额外含 429 限流）。 */

--- a/src/platform/tunnel-client.ts
+++ b/src/platform/tunnel-client.ts
@@ -18,6 +18,12 @@ export interface PlatformBotInfo {
   /** bot 自己的租户稳定 union_id（自家消息回声学到，见 bot-union-ids-store）。
    *  平台按团队聚合成 roster 随 team-sync 下发，成员机器据此免 /grant 互信。 */
   unionId?: string;
+  /** 团队维度 Agent 互查（additive，交接契约）：owner 预配的专长标签，
+   *  发现/拉群的匹配依据。**agent 自报 → 仅展示、不可信**，绝不当能力凭据。
+   *  不报 = 空默认值（平台侧 additive 接受）。 */
+  specialties?: string[];
+  /** 是否有飞书传输身份能被 @（core-only/apiOnly → false）。**自报 → 仅展示、不可信**。 */
+  mentionable?: boolean;
 }
 
 /** 平台 team-sync 下发的原始负载（校验/落盘在 platform-team-store）。 */

--- a/src/services/bot-profile-store.ts
+++ b/src/services/bot-profile-store.ts
@@ -150,8 +150,13 @@ export function clearBotCapability(dataDir: string, larkAppId: string): boolean 
   const existing = readProfile(dataDir, larkAppId);
   const had = existing?.capability !== undefined;
   if (existing?.specialties && existing.specialties.length > 0) {
-    // Keep the file — specialties still live here.
-    writeProfileAtomic(dataDir, larkAppId, { specialties: existing.specialties, updatedAt: Date.now() });
+    // Keep the file — specialties still live here. Preserve updatedBy so the
+    // audit trail (who last touched this profile) survives a capability clear.
+    writeProfileAtomic(dataDir, larkAppId, {
+      specialties: existing.specialties,
+      updatedAt: Date.now(),
+      ...(existing.updatedBy ? { updatedBy: existing.updatedBy } : {}),
+    });
   } else {
     try { unlinkSync(profilePath(dataDir, larkAppId)); } catch { /* already gone */ }
   }

--- a/src/services/bot-profile-store.ts
+++ b/src/services/bot-profile-store.ts
@@ -1,10 +1,17 @@
 /**
- * Team-level bot profile store: a short, human-facing **capability label** per
- * bot (keyed by larkAppId), separate from the full team role markdown.
+ * Team-level bot profile store: a short, human-facing **capability label** plus
+ * structured **specialties** tags per bot (keyed by larkAppId), separate from
+ * the full team role markdown.
  *
  * Why separate from the team role (see role-resolver.ts):
  * - The capability label is a one-liner used in the collaboration roster
  *   (`botmux bots list`) for discovery/selection — "后端 bot，擅长服务端排查".
+ * - `specialties` is a structured string[] of short tags (e.g. ["backend",
+ *   "pr-review"]) — the machine-matchable discovery signal reported to the
+ *   centralized platform (BotInfo.specialties) so teammates can find a bot by
+ *   what it's good at. Self-reported → display/selection only, NEVER a
+ *   trusted credential (deliberately unrelated to the config `capabilities`
+ *   field, which gates VC actions).
  * - The full team role is the persona injected into the CLI `<role>` block.
  * Keeping them apart lets the roster stay scannable while the role stays rich.
  *
@@ -22,8 +29,17 @@ import { randomUUID } from 'node:crypto';
 /** A capability label longer than this is almost certainly a full role, not a tag. */
 const MAX_CAPABILITY_CHARS = 120;
 
+/** Bounds for structured specialties tags. Discovery labels are short by design;
+ *  cap both count and per-tag length so a bad writer can't bloat the heartbeat
+ *  payload (specialties ride every register/heartbeat to the platform). */
+const MAX_SPECIALTIES = 20;
+const MAX_SPECIALTY_CHARS = 40;
+
 export interface BotProfile {
   capability?: string;
+  /** Structured discovery tags reported to the platform as BotInfo.specialties.
+   *  Self-reported, display-only — never a trusted capability credential. */
+  specialties?: string[];
   updatedAt: number;
   updatedBy?: string;
 }
@@ -41,7 +57,14 @@ function readProfile(dataDir: string, larkAppId: string): BotProfile | null {
   if (!existsSync(fp)) return null;
   try {
     const parsed = JSON.parse(readFileSync(fp, 'utf-8'));
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as BotProfile;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const p = parsed as BotProfile;
+      // Normalize specialties on read so a hand-edited / legacy file can never
+      // leak a dirty value (non-array, dupes, over-long) to the platform. Only
+      // materialize the field when the file actually had one.
+      if ('specialties' in p) p.specialties = normalizeSpecialties(p.specialties);
+      return p;
+    }
   } catch { /* corrupt — treat as absent */ }
   return null;
 }
@@ -66,18 +89,72 @@ export function getBotCapability(dataDir: string, larkAppId: string): string | n
   return getBotProfile(dataDir, larkAppId)?.capability ?? null;
 }
 
-/** Set (or overwrite) a bot's capability label. Trimmed and length-capped. */
+/** Normalize a specialties list: trim, drop empties, dedupe (order-preserving),
+ *  cap per-tag length and total count. Non-array → []. */
+function normalizeSpecialties(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const v of raw) {
+    if (typeof v !== 'string') continue;
+    const s = v.trim().slice(0, MAX_SPECIALTY_CHARS);
+    if (!s || seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+    if (out.length >= MAX_SPECIALTIES) break;
+  }
+  return out;
+}
+
+/** Structured discovery tags for a bot (empty array if none). */
+export function getBotSpecialties(dataDir: string, larkAppId: string): string[] {
+  return getBotProfile(dataDir, larkAppId)?.specialties ?? [];
+}
+
+/**
+ * Set (or overwrite) a bot's capability label. Trimmed and length-capped.
+ * Merges into the existing profile so it never clobbers `specialties`.
+ */
 export function setBotCapability(dataDir: string, larkAppId: string, capability: string, updatedBy?: string, now: number = Date.now()): void {
   if (!larkAppId) return;
   const label = capability.trim().slice(0, MAX_CAPABILITY_CHARS);
-  writeProfileAtomic(dataDir, larkAppId, { capability: label, updatedAt: now, ...(updatedBy ? { updatedBy } : {}) });
+  const existing = readProfile(dataDir, larkAppId);
+  writeProfileAtomic(dataDir, larkAppId, {
+    ...(existing?.specialties ? { specialties: existing.specialties } : {}),
+    capability: label,
+    updatedAt: now,
+    ...(updatedBy ? { updatedBy } : {}),
+  });
 }
 
-/** Remove a bot's capability label (deletes its profile file). Returns true if one existed. */
+/**
+ * Set (or overwrite) a bot's specialties tags. Normalized (trim/dedupe/capped).
+ * Merges into the existing profile so it never clobbers the `capability` label.
+ * An empty list persists as an explicit `[]` (owner cleared their tags).
+ */
+export function setBotSpecialties(dataDir: string, larkAppId: string, specialties: string[], updatedBy?: string, now: number = Date.now()): void {
+  if (!larkAppId) return;
+  const tags = normalizeSpecialties(specialties);
+  const existing = readProfile(dataDir, larkAppId);
+  writeProfileAtomic(dataDir, larkAppId, {
+    ...(existing?.capability ? { capability: existing.capability } : {}),
+    specialties: tags,
+    updatedAt: now,
+    ...(updatedBy ? { updatedBy } : {}),
+  });
+}
+
+/** Remove a bot's capability label. Preserves `specialties`. Returns true if a
+ *  label existed. Deletes the whole profile file only when nothing else remains. */
 export function clearBotCapability(dataDir: string, larkAppId: string): boolean {
-  const fp = profilePath(dataDir, larkAppId);
-  const had = readProfile(dataDir, larkAppId)?.capability !== undefined;
-  try { unlinkSync(fp); } catch { /* already gone */ }
+  const existing = readProfile(dataDir, larkAppId);
+  const had = existing?.capability !== undefined;
+  if (existing?.specialties && existing.specialties.length > 0) {
+    // Keep the file — specialties still live here.
+    writeProfileAtomic(dataDir, larkAppId, { specialties: existing.specialties, updatedAt: Date.now() });
+  } else {
+    try { unlinkSync(profilePath(dataDir, larkAppId)); } catch { /* already gone */ }
+  }
   return had;
 }
 

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -528,12 +528,16 @@ botmux send --top-level --chat-id oc_xxxxxxxxxxxx "📦 自动推送内容..."
 
 const BOTS_SKILL = `---
 name: botmux-bots
-description: 列出当前飞书群里可协作的机器人（协作花名册：含能力标签、是否有团队角色、以及你能否可靠 @ 到它）。在需要点名其他机器人协作、或交棒给队友前查看时使用。
+description: 列出可协作的机器人（协作花名册）。默认列**当前飞书群内**的 bot（含能力标签、是否有团队角色、能否可靠 @ 到它）；加 --scope team 则跨机列**同团队、已 opt-in** 的 agent 供按专长发现，并可用 create-group --team 把它们拉进新群。在需要点名协作、交棒队友、或跨机找/拉别人的 agent 前使用。
 ---
 
-# botmux-bots — 群内协作花名册
+# botmux-bots — 协作花名册（群内 + 团队维度）
 
-## 用法
+两种 scope，用途不同：
+- **chat（默认）**：\`botmux bots list\` —— 列**当前群里**的 bot，判断能不能 @、派活。
+- **team**：\`botmux bots list --scope team\` —— 跨机列**同团队、已 opt-in** 的 agent（在别人机器上、还没进你的群），用于按专长发现后拉群协作。
+
+## 用法（chat scope，默认）
 
 \`\`\`bash
 botmux bots list
@@ -577,13 +581,39 @@ botmux bots list
 }
 \`\`\`
 
-## 关键规则
+## 关键规则（chat scope）
 
 1. **只 @ \`mentionable=true\` 的机器人**。\`mentionable=false\` 表示"知道它在群里，但当前点不准"（飞书 open_id 按 app 隔离）——这种先让它 / 用户在群里 \`/introduce\` 一次，再点名。
 2. 按 \`capability\` 挑合适的队友，而不是乱点。
 3. **\`unknown\` ≠ 不可用、更 ≠ 离线**：只是这条命令当前没有足够证据。别把 \`unknown\` 当成"它挂了"而放弃派活；语义拿不准就查 \`collaborationHelp\`。
 4. \`authorization.operate\` 默认按 \`false\`/\`unknown\` 处理：能对话不等于能让它跑 \`/repo\`、\`/restart\` 等管理动作，那类要单独授权。
 5. 配合 botmux send：\`botmux send --mention "ou_yyy:后端Bot" "请帮忙处理"\`
+
+## 团队维度：跨机发现 + 拉群（--scope team）
+
+用途：找到**同团队、还没进你群、在别人机器上**的 agent，按专长挑出来，拉进一个聚焦新群一起干活。
+
+\`\`\`bash
+# 1) 发现：列同团队已 opt-in 的 agent（本机在多团队时用 --team 指定）
+botmux bots list --scope team [--team <teamId>]
+
+# 2) 拉群：把发现到的 agent（按 appId）+ 各自 owner 拉进一个平台代建的新群
+botmux create-group --team <teamId> --agent <appId> [--agent ...] [--name "群名"]
+\`\`\`
+
+team scope 输出的 \`agents[]\` 每项：\`appId\`（拉群就用它）、\`name\`、\`specialties\`（专长标签数组，发现依据）、\`mentionable\`、\`online\`、\`owner\`、\`machineId/machineName\`。
+
+**必须知道的语义**：
+- **opt-in 闸**：发现列表**只含已加入团队的 agent**——即它的 owner 在平台「管理机器人」里把它显式加进了团队（\`team.bots\`）。没加进来的 agent 你看不到、也拉不动。查不到某个 agent？多半是对方 owner 还没 opt-in，不是命令坏了。
+- **specialties / mentionable / online 是 agent 自报**：仅供你挑选参考，**不是可信凭据**，别拿它当权限判断。
+- **CLI 不做任何授权判断**：团队成员校验、opt-in 闸全在平台。你只管发现 + 拉群，平台会拒绝越权的调用。
+- **拉群只认 appId、不需要 @**：正因为别人 bot 进你群前你根本 @不到它，team 拉群全走 appId + machine-auth，天然绕开"看不见就点不着"。拉群结果里 \`invalidBotIds\` / \`invalidOwnerUnionIds\` 是平台过滤掉的（未 opt-in / 拉不动），如实展示即可。
+- 平台端点没上线时命令会明确提示「平台尚未部署…端点」——那是平台侧还没部署，不是你调错。
+
+**team 拉群 vs 飞书 /invite —— 别混**：
+- \`create-group --team\`：跨机、拉**同团队但不在任何共同群**的 agent + owner，**新建**聚焦群。这是"首次把没见过面的 agent 聚到一起"的路径。
+- \`/invite\`（飞书群内 slash）：把 bot 加进**当前已存在的**群，走飞书原生加成员，**限同租户**、只拉 bot 不带 owner。用于"群已经在了，把某个同租户 bot 也拉进来"。
+- 一句话：跨 team 从零聚人 → \`create-group --team\`；当前群补人（同租户）→ \`/invite\`。
 
 ## 要把任务交棒给别的机器人？
 

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -528,7 +528,7 @@ botmux send --top-level --chat-id oc_xxxxxxxxxxxx "📦 自动推送内容..."
 
 const BOTS_SKILL = `---
 name: botmux-bots
-description: 列出可协作的机器人（协作花名册）。默认列**当前飞书群内**的 bot（含能力标签、是否有团队角色、能否可靠 @ 到它）；加 --scope team 则跨机列**同团队、已 opt-in** 的 agent 供按专长发现，并可用 create-group --team 把它们拉进新群。在需要点名协作、交棒队友、或跨机找/拉别人的 agent 前使用。
+description: 列出可协作的机器人（协作花名册）。默认列**当前飞书群内**的 bot（含能力标签、是否有团队角色、能否可靠 @ 到它）；加 --scope team 则跨机列**同团队、已 opt-in** 的 agent 供按专长发现，并可用 create-group --team 拉进新群、或 bots invite 补进已有团队群。在需要点名协作、交棒队友、或跨机找/拉别人的 agent 前使用。
 ---
 
 # botmux-bots — 协作花名册（群内 + 团队维度）
@@ -597,23 +597,28 @@ botmux bots list
 # 1) 发现：列同团队已 opt-in 的 agent（本机在多团队时用 --team 指定）
 botmux bots list --scope team [--team <teamId>]
 
-# 2) 拉群：把发现到的 agent（按 appId）+ 各自 owner 拉进一个平台代建的新群
+# 2a) 建新群：把发现到的 agent（按 appId）+ 各自 owner 拉进一个平台代建的**新群**
 botmux create-group --team <teamId> --agent <appId> [--agent ...] [--name "群名"]
+
+# 2b) 往已有群补人：把 agent + 各自 owner 加进一个**已存在的团队群**（--no-owners 只补 bot）
+botmux bots invite --chat <chatId> --team <teamId> --agent <appId> [--agent ...] [--no-owners]
 \`\`\`
 
-team scope 输出的 \`agents[]\` 每项：\`appId\`（拉群就用它）、\`name\`、\`specialties\`（专长标签数组，发现依据）、\`mentionable\`、\`online\`、\`owner\`、\`machineId/machineName\`。
+team scope 输出的 \`agents[]\` 每项：\`appId\`（拉群/补人就用它）、\`name\`、\`specialties\`（专长标签数组，发现依据）、\`mentionable\`、\`online\`、\`owner\`、\`machineId/machineName\`。
 
 **必须知道的语义**：
 - **opt-in 闸**：发现列表**只含已加入团队的 agent**——即它的 owner 在平台「管理机器人」里把它显式加进了团队（\`team.bots\`）。没加进来的 agent 你看不到、也拉不动。查不到某个 agent？多半是对方 owner 还没 opt-in，不是命令坏了。
 - **specialties / mentionable / online 是 agent 自报**：仅供你挑选参考，**不是可信凭据**，别拿它当权限判断。
-- **CLI 不做任何授权判断**：团队成员校验、opt-in 闸全在平台。你只管发现 + 拉群，平台会拒绝越权的调用。
-- **拉群只认 appId、不需要 @**：正因为别人 bot 进你群前你根本 @不到它，team 拉群全走 appId + machine-auth，天然绕开"看不见就点不着"。拉群结果里 \`invalidBotIds\` / \`invalidOwnerUnionIds\` 是平台过滤掉的（未 opt-in / 拉不动），如实展示即可。
+- **CLI 不做任何授权判断**：团队成员校验、opt-in 闸全在平台。你只管发现 + 拉群/补人，平台会拒绝越权的调用。
+- **只认 appId、不需要 @**：正因为别人 bot 进你群前你根本 @不到它，team 拉群/补人全走 appId + machine-auth，天然绕开"看不见就点不着"。结果里 \`invalidBotIds\` / \`invalidOwnerUnionIds\` 是平台过滤掉的（未 opt-in / 拉不动），如实展示即可。
+- \`bots invite\` 的目标群必须是**本团队自己建/拉的协作群**（平台记过的），且**不能是机器人大厅**；否则平台回 403 \`chat_not_in_team\` / \`chat_is_hall\`。
 - 平台端点没上线时命令会明确提示「平台尚未部署…端点」——那是平台侧还没部署，不是你调错。
 
-**team 拉群 vs 飞书 /invite —— 别混**：
-- \`create-group --team\`：跨机、拉**同团队但不在任何共同群**的 agent + owner，**新建**聚焦群。这是"首次把没见过面的 agent 聚到一起"的路径。
-- \`/invite\`（飞书群内 slash）：把 bot 加进**当前已存在的**群，走飞书原生加成员，**限同租户**、只拉 bot 不带 owner。用于"群已经在了，把某个同租户 bot 也拉进来"。
-- 一句话：跨 team 从零聚人 → \`create-group --team\`；当前群补人（同租户）→ \`/invite\`。
+**三条拉人路径 —— 别混**：
+- \`create-group --team\`：跨机、把**同团队但不在任何共同群**的 agent + owner **新建**成一个聚焦群。"首次把没见过面的 agent 聚到一起"。
+- \`bots invite --chat\`：把同团队 agent + owner 加进一个**已存在的团队群**（跨机、machine-auth、只认 appId）。"群已经在了，往里补同团队的人"。
+- \`/invite\`（飞书群内 slash）：把 bot 加进**当前已存在的**群，走飞书原生加成员，**限同租户**、只拉 bot 不带 owner。"群在了，把某个同租户 bot 也拉进来"。
+- 一句话：跨 team 从零聚人 → \`create-group --team\`；跨 team 往已有团队群补人 → \`bots invite\`；当前群补同租户 bot → \`/invite\`。
 
 ## 要把任务交棒给别的机器人？
 

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -600,8 +600,8 @@ botmux bots list --scope team [--team <teamId>]
 # 2a) 建新群：把发现到的 agent（按 appId）+ 各自 owner 拉进一个平台代建的**新群**
 botmux create-group --team <teamId> --agent <appId> [--agent ...] [--name "群名"]
 
-# 2b) 往已有群补人：把 agent + 各自 owner 加进一个**已存在的团队群**（--no-owners 只补 bot）
-botmux bots invite --chat <chatId> --team <teamId> --agent <appId> [--agent ...] [--no-owners]
+# 2b) 往已有群补人：把 agent + 各自 owner 加进一个**你已在场的**群（恒带 owner）
+botmux bots invite --chat <chatId> --team <teamId> --agent <appId> [--agent ...]
 \`\`\`
 
 team scope 输出的 \`agents[]\` 每项：\`appId\`（拉群/补人就用它）、\`name\`、\`specialties\`（专长标签数组，发现依据）、\`mentionable\`、\`online\`、\`owner\`、\`machineId/machineName\`。
@@ -611,14 +611,14 @@ team scope 输出的 \`agents[]\` 每项：\`appId\`（拉群/补人就用它）
 - **specialties / mentionable / online 是 agent 自报**：仅供你挑选参考，**不是可信凭据**，别拿它当权限判断。
 - **CLI 不做任何授权判断**：团队成员校验、opt-in 闸全在平台。你只管发现 + 拉群/补人，平台会拒绝越权的调用。
 - **只认 appId、不需要 @**：正因为别人 bot 进你群前你根本 @不到它，team 拉群/补人全走 appId + machine-auth，天然绕开"看不见就点不着"。结果里 \`invalidBotIds\` / \`invalidOwnerUnionIds\` 是平台过滤掉的（未 opt-in / 拉不动），如实展示即可。
-- \`bots invite\` 的目标群必须是**本团队自己建/拉的协作群**（平台记过的），且**不能是机器人大厅**；否则平台回 403 \`chat_not_in_team\` / \`chat_is_hall\`。
+- \`bots invite\` 的目标群要满足：**平台机器人（BotmuxPlatform）已在群里**（否则平台加不进人 → 403 \`platform_bot_not_in_chat\`，先把它拉进群）+ **你本人已在该群**（→ 403 \`requester_not_in_chat\`，只能往你自己在场的群补人）+ **非机器人大厅**（→ 403 \`chat_is_hall\`）。补人恒把 agent + 各自 owner 一起拉进。
 - 平台端点没上线时命令会明确提示「平台尚未部署…端点」——那是平台侧还没部署，不是你调错。
 
 **三条拉人路径 —— 别混**：
 - \`create-group --team\`：跨机、把**同团队但不在任何共同群**的 agent + owner **新建**成一个聚焦群。"首次把没见过面的 agent 聚到一起"。
-- \`bots invite --chat\`：把同团队 agent + owner 加进一个**已存在的团队群**（跨机、machine-auth、只认 appId）。"群已经在了，往里补同团队的人"。
+- \`bots invite --chat\`：把同团队 agent + 各自 owner 加进一个**你已在场、且平台机器人也在**的群（跨机、machine-auth、只认 appId）。"群已经在了，往里补同团队的人（含其 owner）"。
 - \`/invite\`（飞书群内 slash）：把 bot 加进**当前已存在的**群，走飞书原生加成员，**限同租户**、只拉 bot 不带 owner。"群在了，把某个同租户 bot 也拉进来"。
-- 一句话：跨 team 从零聚人 → \`create-group --team\`；跨 team 往已有团队群补人 → \`bots invite\`；当前群补同租户 bot → \`/invite\`。
+- 一句话：跨 team 从零聚人 → \`create-group --team\`；往你已在场的群补同团队的人 → \`bots invite\`；当前群补同租户 bot → \`/invite\`。
 
 ## 要把任务交棒给别的机器人？
 

--- a/test/bot-profile-store.test.ts
+++ b/test/bot-profile-store.test.ts
@@ -114,6 +114,14 @@ describe('bot-profile-store specialties', () => {
     expect(getBotSpecialties(dataDir, 'app1')).toEqual(['backend']); // survived
   });
 
+  it('clearBotCapability keeps updatedBy when rewriting to preserve specialties (review nit)', () => {
+    setBotCapability(dataDir, 'app1', 'X', 'ou_author');
+    setBotSpecialties(dataDir, 'app1', ['backend'], 'ou_author');
+    clearBotCapability(dataDir, 'app1');
+    // File was rewritten (specialties survive) — the audit trail must not be dropped.
+    expect(getBotProfile(dataDir, 'app1')?.updatedBy).toBe('ou_author');
+  });
+
   it('empty specialties list persists as explicit [] (owner cleared tags)', () => {
     setBotSpecialties(dataDir, 'app1', ['backend']);
     setBotSpecialties(dataDir, 'app1', []);

--- a/test/bot-profile-store.test.ts
+++ b/test/bot-profile-store.test.ts
@@ -2,12 +2,13 @@
  * Team-level bot capability label store.
  * Run: pnpm vitest run test/bot-profile-store.test.ts
  */
-import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   getBotProfile, getBotCapability, setBotCapability, clearBotCapability, listBotProfiles,
+  getBotSpecialties, setBotSpecialties,
 } from '../src/services/bot-profile-store.js';
 
 let dataDir: string;
@@ -68,5 +69,65 @@ describe('bot-profile-store', () => {
     setBotCapability(dataDir, 'app3', 'C');
     const all = listBotProfiles(dataDir);
     expect(Object.keys(all).sort()).toEqual(['app1', 'app2', 'app3']);
+  });
+});
+
+describe('bot-profile-store specialties', () => {
+  it('defaults to empty array when nothing recorded', () => {
+    expect(getBotSpecialties(dataDir, 'app1')).toEqual([]);
+  });
+
+  it('sets and reads back specialties tags', () => {
+    setBotSpecialties(dataDir, 'app1', ['backend', 'pr-review']);
+    expect(getBotSpecialties(dataDir, 'app1')).toEqual(['backend', 'pr-review']);
+  });
+
+  it('normalizes: trims, drops empties, dedupes order-preserving', () => {
+    setBotSpecialties(dataDir, 'app1', ['  backend ', 'backend', '', 'frontend', '   ']);
+    expect(getBotSpecialties(dataDir, 'app1')).toEqual(['backend', 'frontend']);
+  });
+
+  it('caps per-tag length and total count', () => {
+    const long = 'x'.repeat(100);
+    setBotSpecialties(dataDir, 'app1', [long]);
+    expect(getBotSpecialties(dataDir, 'app1')[0].length).toBeLessThanOrEqual(40);
+    setBotSpecialties(dataDir, 'app2', Array.from({ length: 50 }, (_, i) => `tag${i}`));
+    expect(getBotSpecialties(dataDir, 'app2').length).toBeLessThanOrEqual(20);
+  });
+
+  it('setting specialties does NOT clobber the capability label (and vice versa)', () => {
+    setBotCapability(dataDir, 'app1', '后端 bot');
+    setBotSpecialties(dataDir, 'app1', ['backend']);
+    expect(getBotCapability(dataDir, 'app1')).toBe('后端 bot');
+    expect(getBotSpecialties(dataDir, 'app1')).toEqual(['backend']);
+    // Overwrite the label — specialties survive.
+    setBotCapability(dataDir, 'app1', '改了');
+    expect(getBotCapability(dataDir, 'app1')).toBe('改了');
+    expect(getBotSpecialties(dataDir, 'app1')).toEqual(['backend']);
+  });
+
+  it('clearBotCapability preserves specialties (keeps the file)', () => {
+    setBotCapability(dataDir, 'app1', 'X');
+    setBotSpecialties(dataDir, 'app1', ['backend']);
+    expect(clearBotCapability(dataDir, 'app1')).toBe(true);
+    expect(getBotCapability(dataDir, 'app1')).toBeNull();
+    expect(getBotSpecialties(dataDir, 'app1')).toEqual(['backend']); // survived
+  });
+
+  it('empty specialties list persists as explicit [] (owner cleared tags)', () => {
+    setBotSpecialties(dataDir, 'app1', ['backend']);
+    setBotSpecialties(dataDir, 'app1', []);
+    expect(getBotSpecialties(dataDir, 'app1')).toEqual([]);
+    expect(getBotProfile(dataDir, 'app1')?.specialties).toEqual([]);
+  });
+
+  it('a corrupt/hand-edited specialties value never leaks (normalized on read)', () => {
+    // Write a file with a dirty specialties by hand, then read via the store.
+    setBotSpecialties(dataDir, 'app1', ['ok']);
+    const fp = join(dataDir, 'bot-profiles', 'app1.json');
+    const raw = JSON.parse(readFileSync(fp, 'utf-8'));
+    raw.specialties = ['ok', 'ok', 42, '', '  dup ', 'dup'];
+    writeFileSync(fp, JSON.stringify(raw));
+    expect(getBotSpecialties(dataDir, 'app1')).toEqual(['ok', 'dup']);
   });
 });

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -197,6 +197,7 @@ describe('built-in botmux-bots skill (collaboration roster)', () => {
     const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-bots');
     expect(skill!.content).toContain('--scope team');
     expect(skill!.content).toContain('create-group --team');
+    expect(skill!.content).toContain('bots invite');
     expect(skill!.content).toContain('--agent');
     expect(skill!.content).toContain('specialties');
     expect(skill!.content).toContain('opt-in');

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -190,6 +190,20 @@ describe('built-in botmux-bots skill (collaboration roster)', () => {
     expect(skill!.content).toContain('operate');
     expect(skill!.content).toContain('unknown');
   });
+
+  it('documents team-scope discovery + cross-machine group creation and their opt-in gate', () => {
+    // Team维度 Agent 互查: --scope team discovery + create-group --team, plus the
+    // opt-in (team.bots) gate and the boundary vs the Feishu /invite slash.
+    const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-bots');
+    expect(skill!.content).toContain('--scope team');
+    expect(skill!.content).toContain('create-group --team');
+    expect(skill!.content).toContain('--agent');
+    expect(skill!.content).toContain('specialties');
+    expect(skill!.content).toContain('opt-in');
+    // Self-reported → not a trusted credential; CLI does no authorization.
+    expect(skill!.content).toContain('不是可信凭据');
+    expect(skill!.content).toContain('/invite');
+  });
 });
 
 describe('built-in botmux-handoff skill', () => {

--- a/test/cli-arg-utils.test.ts
+++ b/test/cli-arg-utils.test.ts
@@ -6,7 +6,7 @@
  * Run:  pnpm vitest run test/cli-arg-utils.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { firstPositional } from '../src/cli/arg-utils.js';
+import { firstPositional, hasFlagOrEq } from '../src/cli/arg-utils.js';
 
 describe('firstPositional', () => {
   it('returns the first non-flag token in a plain positional list', () => {
@@ -32,5 +32,32 @@ describe('firstPositional', () => {
   it('returns undefined when no positional is present', () => {
     expect(firstPositional(['--session-id', 'uuid-1'], ['--session-id'])).toBeUndefined();
     expect(firstPositional([], ['--session-id'])).toBeUndefined();
+  });
+});
+
+describe('hasFlagOrEq', () => {
+  // Guards create-group's team-mode routing: `--team=t1` must trigger it, not
+  // just bare `--team`. A plain args.includes() misses the `=` spelling and the
+  // command wrongly falls through to local-group creation (pi review P2).
+  it('matches the bare flag form', () => {
+    expect(hasFlagOrEq(['--team', 't1', '--agent', 'cli_a'], '--team')).toBe(true);
+    expect(hasFlagOrEq(['--agent', 'cli_a'], '--agent')).toBe(true);
+  });
+
+  it('matches the =value form', () => {
+    expect(hasFlagOrEq(['--team=t1', '--agent=cli_a'], '--team')).toBe(true);
+    expect(hasFlagOrEq(['--team=t1', '--agent=cli_a'], '--agent')).toBe(true);
+    expect(hasFlagOrEq(['--chat=oc_1'], '--chat')).toBe(true);
+  });
+
+  it('is false when the flag is absent', () => {
+    expect(hasFlagOrEq(['--bot', 'x', '--name', 'g'], '--team')).toBe(false);
+    expect(hasFlagOrEq([], '--team')).toBe(false);
+  });
+
+  it('does not match a different flag that shares a prefix', () => {
+    // `--teammate` must not satisfy a `--team` check.
+    expect(hasFlagOrEq(['--teammate', 'x'], '--team')).toBe(false);
+    expect(hasFlagOrEq(['--teammate=x'], '--team')).toBe(false);
   });
 });

--- a/test/team-agents-client.test.ts
+++ b/test/team-agents-client.test.ts
@@ -288,6 +288,12 @@ describe('addTeamGroupMembers（端点4 / B：往现有群补人）', () => {
     expect(isRetriable(r as any)).toBe(false);
   });
 
+  it('403 platform_bot_not_in_chat 带 platformAppId(+name) → 透传到 failure（自动拉平台 app 用）', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'platform_bot_not_in_chat', platformAppId: 'cli_plat', platformAppName: '平台应用' } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_x', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'platform_bot_not_in_chat', platformAppId: 'cli_plat', platformAppName: '平台应用' });
+  });
+
   it('403 requester_not_in_chat（发起方 owner 本人不在该群）→ client', async () => {
     const { o } = opts([{ status: 403, json: { error: 'requester_not_in_chat' } }]);
     const r = await addTeamGroupMembers({ chatId: 'oc_x', teamId: 't1', appIds: ['cli_a'] }, o);

--- a/test/team-agents-client.test.ts
+++ b/test/team-agents-client.test.ts
@@ -1,0 +1,232 @@
+/**
+ * 团队维度 Agent 互查 / 拉群的 machine-auth 客户端。
+ * Run: pnpm vitest run test/team-agents-client.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  fetchTeamAgents,
+  fetchTeams,
+  createTeamGroup,
+  isRetriable,
+  describeTeamAgentsFailure,
+  type TeamAgentsClientOptions,
+} from '../src/platform/team-agents-client.js';
+
+const BINDING = {
+  platformUrl: 'https://platform.example',
+  machineToken: 'mt-secret',
+  machineId: 'm-1',
+};
+
+function fakeHttp(responses: Array<{ status: number; json: unknown } | Error>) {
+  const calls: Array<{ method: string; url: string; body?: unknown; headers?: Record<string, string> }> = [];
+  let i = 0;
+  const next = () => {
+    const r = responses[Math.min(i++, responses.length - 1)];
+    if (r instanceof Error) return Promise.reject(r);
+    return Promise.resolve(r);
+  };
+  return {
+    calls,
+    http: {
+      get: ((url: string, opts: any) => { calls.push({ method: 'GET', url, headers: opts?.headers }); return next(); }) as any,
+      post: ((url: string, body: unknown, opts: any) => { calls.push({ method: 'POST', url, body, headers: opts?.headers }); return next(); }) as any,
+    },
+  };
+}
+
+function opts(responses: Array<{ status: number; json: unknown } | Error>): {
+  o: TeamAgentsClientOptions;
+  calls: ReturnType<typeof fakeHttp>['calls'];
+} {
+  const f = fakeHttp(responses);
+  return { o: { binding: BINDING, http: f.http }, calls: f.calls };
+}
+
+describe('fetchTeams（端点1）', () => {
+  it('带 Bearer，正常解析 teams', async () => {
+    const { o, calls } = opts([{ status: 200, json: { teams: [{ teamId: 't1', teamName: 'One' }, { teamId: 't2', teamName: 'Two' }] } }]);
+    const r = await fetchTeams(o);
+    expect(r).toEqual({ ok: true, value: [{ teamId: 't1', teamName: 'One' }, { teamId: 't2', teamName: 'Two' }] });
+    expect(calls[0].url).toBe('https://platform.example/v1/machine/teams');
+    expect(calls[0].headers?.authorization).toBe('Bearer mt-secret');
+  });
+
+  it('丢弃无 teamId 的脏项，teamName 缺省回落到 teamId', async () => {
+    const { o } = opts([{ status: 200, json: { teams: [{ teamName: '没id' }, { teamId: 't3' }] } }]);
+    const r = await fetchTeams(o);
+    expect(r).toEqual({ ok: true, value: [{ teamId: 't3', teamName: 't3' }] });
+  });
+
+  it('unbound 时不发请求', async () => {
+    const f = fakeHttp([{ status: 200, json: {} }]);
+    const r = await fetchTeams({ binding: null, http: f.http });
+    expect(r).toEqual({ ok: false, reason: 'unbound' });
+    expect(f.calls).toHaveLength(0);
+  });
+});
+
+describe('describeTeamAgentsFailure', () => {
+  it('每种 reason 都给一句人话', () => {
+    expect(describeTeamAgentsFailure({ ok: false, reason: 'unbound' })).toContain('未绑定');
+    expect(describeTeamAgentsFailure({ ok: false, reason: 'rate_limited', status: 429, error: 'rate_limited' })).toContain('限流');
+    expect(describeTeamAgentsFailure({ ok: false, reason: 'forbidden', status: 401, error: 'x' })).toContain('bind');
+    expect(describeTeamAgentsFailure({ ok: false, reason: 'client', status: 403, error: 'not_in_team_bots' })).toContain('not_in_team_bots');
+  });
+});
+
+describe('未绑定平台', () => {
+  it('所有调用直接 unbound，不发任何请求', async () => {
+    const f = fakeHttp([{ status: 200, json: {} }]);
+    const r = await fetchTeamAgents('t1', { binding: null, http: f.http });
+    expect(r).toEqual({ ok: false, reason: 'unbound' });
+    expect(f.calls).toHaveLength(0);
+  });
+});
+
+describe('fetchTeamAgents（端点2）', () => {
+  it('带 Bearer + teamId query，normalize agent 字段', async () => {
+    const { o, calls } = opts([{
+      status: 200,
+      json: {
+        teamId: 't1', teamName: 'Team One',
+        agents: [{
+          appId: 'cli_a', openId: 'ou_a', unionId: 'on_a', name: 'A',
+          specialties: ['backend', 'pr-review'], mentionable: true, online: true,
+          owner: { unionId: 'on_owner', name: 'Owner' }, machineId: 'm-2', machineName: 'box2',
+        }],
+      },
+    }]);
+    const r = await fetchTeamAgents('t1', o);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(calls[0].url).toBe('https://platform.example/v1/machine/agents?teamId=t1');
+    expect(calls[0].headers?.authorization).toBe('Bearer mt-secret');
+    expect(r.value.teamName).toBe('Team One');
+    expect(r.value.agents[0]).toMatchObject({
+      appId: 'cli_a', name: 'A', specialties: ['backend', 'pr-review'],
+      mentionable: true, online: true, owner: { unionId: 'on_owner', name: 'Owner' },
+    });
+  });
+
+  it('空 agents 是正常态，不报错', async () => {
+    const { o } = opts([{ status: 200, json: { teamId: 't1', teamName: 'T', agents: [] } }]);
+    const r = await fetchTeamAgents('t1', o);
+    expect(r).toEqual({ ok: true, value: { teamId: 't1', teamName: 'T', agents: [] } });
+  });
+
+  it('丢弃无 appId 的脏 agent，坏 specialties → 空数组', async () => {
+    const { o } = opts([{
+      status: 200,
+      json: {
+        teamId: 't1', teamName: 'T',
+        agents: [
+          { name: '没有 appId' },                                    // 丢弃
+          { appId: 'cli_b', name: 'B', specialties: 'not-array' },   // specialties → []
+          { appId: 'cli_c', name: 'C', specialties: ['x', 'x', 42, ''] }, // 去重去脏
+        ],
+      },
+    }]);
+    const r = await fetchTeamAgents('t1', o);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.agents.map(a => a.appId)).toEqual(['cli_b', 'cli_c']);
+    expect(r.value.agents[0].specialties).toEqual([]);
+    expect(r.value.agents[1].specialties).toEqual(['x']);
+  });
+
+  it('mentionable/online 缺省保守为 false', async () => {
+    const { o } = opts([{ status: 200, json: { teamId: 't1', teamName: 'T', agents: [{ appId: 'cli_a', name: 'A' }] } }]);
+    const r = await fetchTeamAgents('t1', o);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.agents[0].mentionable).toBe(false);
+    expect(r.value.agents[0].online).toBe(false);
+    expect(r.value.agents[0].specialties).toEqual([]);
+  });
+
+  it('404 非成员/团队不存在（业务态，带 JSON error）→ client（不重试）', async () => {
+    const { o } = opts([{ status: 404, json: { error: 'not_found' } }]);
+    const r = await fetchTeamAgents('t1', o);
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 404, error: 'not_found' });
+    expect(isRetriable(r as any)).toBe(false);
+  });
+
+  it('404 纯文本兜底（无 error，路由未部署）→ not_deployed，与"非成员"区分', async () => {
+    // getJson/postJson 对纯文本响应返回 {} → 无 .error → 端点未部署。
+    const { o } = opts([{ status: 404, json: {} }]);
+    const r = await fetchTeamAgents('t1', o);
+    expect(r).toMatchObject({ ok: false, reason: 'not_deployed', status: 404 });
+    expect(isRetriable(r as any)).toBe(false);
+  });
+});
+
+describe('createTeamGroup（端点3）', () => {
+  it('POST body 带 teamId+appIds(+name)，回 chatId/shareLink/invalid*', async () => {
+    const { o, calls } = opts([{
+      status: 200,
+      json: { ok: true, chatId: 'oc_1', shareLink: 'https://l/x', invalidBotIds: ['cli_z'], invalidOwnerUnionIds: [] },
+    }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a', 'cli_b'], name: '小群' }, o);
+    expect(r).toEqual({
+      ok: true,
+      value: { ok: true, chatId: 'oc_1', shareLink: 'https://l/x', invalidBotIds: ['cli_z'], invalidOwnerUnionIds: [] },
+    });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://platform.example/v1/machine/groups');
+    expect(calls[0].body).toEqual({ teamId: 't1', appIds: ['cli_a', 'cli_b'], name: '小群' });
+  });
+
+  it('不传 name 时 body 不含 name 键', async () => {
+    const { o, calls } = opts([{ status: 200, json: { ok: true, chatId: 'oc_1' } }]);
+    await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(calls[0].body).toEqual({ teamId: 't1', appIds: ['cli_a'] });
+  });
+
+  it('403 not_in_team_bots（带 error 体）→ client，不重试', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'not_in_team_bots' } }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'not_in_team_bots' });
+    expect(isRetriable(r as any)).toBe(false);
+  });
+
+  it('429 rate_limited（同机 30s 一次）→ 单独分型且可重试', async () => {
+    const { o } = opts([{ status: 429, json: { error: 'rate_limited' } }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'rate_limited', status: 429 });
+    expect(isRetriable(r as any)).toBe(true);
+  });
+
+  it('分型只看当次 status：一个非 opt-in 请求也可能拿 429（不是恒定 403）', async () => {
+    // 平台端点3 检查顺序 404→429→403，限流器只在真正建群那步 arm。合法请求 arm 了 30s 窗后，
+    // 紧接着的非 opt-in 请求会先撞 429、而非 403。所以「非法请求恒 403」不成立——分型按当次
+    // status 判即可。这条守住不把「同参数重发结果恒定」写进逻辑。
+    const first = opts([{ status: 200, json: { ok: true, chatId: 'oc_1' } }]);
+    expect((await createTeamGroup({ teamId: 't1', appIds: ['cli_ok'] }, first.o)).ok).toBe(true);
+    // 同一个非 opt-in 参数，平台这次因限流回 429（而非 403）——客户端如实分型成 rate_limited。
+    const second = opts([{ status: 429, json: { error: 'rate_limited' } }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_not_optin'] }, second.o);
+    expect(r).toMatchObject({ ok: false, reason: 'rate_limited', status: 429 });
+  });
+
+  it('503 → server，可重试', async () => {
+    const { o } = opts([{ status: 503, json: {} }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'server', status: 503 });
+    expect(isRetriable(r as any)).toBe(true);
+  });
+
+  it('纯 401 → forbidden，停手不重试', async () => {
+    const { o } = opts([{ status: 401, json: {} }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'forbidden', status: 401 });
+    expect(isRetriable(r as any)).toBe(false);
+  });
+
+  it('网络异常 → network，可重试', async () => {
+    const { o } = opts([new Error('ECONNREFUSED')]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'network' });
+    expect(isRetriable(r as any)).toBe(true);
+  });
+});

--- a/test/team-agents-client.test.ts
+++ b/test/team-agents-client.test.ts
@@ -10,6 +10,7 @@ import {
   addTeamGroupMembers,
   isRetriable,
   describeTeamAgentsFailure,
+  rateLimitRetryHint,
   type TeamAgentsClientOptions,
 } from '../src/platform/team-agents-client.js';
 
@@ -211,6 +212,23 @@ describe('createTeamGroup（端点3）', () => {
     const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
     expect(r).toMatchObject({ ok: false, reason: 'rate_limited', status: 429 });
     expect(isRetriable(r as any)).toBe(true);
+  });
+
+  it('429 带 retryAfterMs → 解析进 failure，rateLimitRetryHint 用它给秒数', async () => {
+    const { o } = opts([{ status: 429, json: { error: 'rate_limited', retryAfterMs: 12000 } }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'rate_limited', retryAfterMs: 12000 });
+    if (r.ok) return;
+    if (r.reason !== 'rate_limited') return;
+    expect(rateLimitRetryHint(r)).toContain('12 秒');
+  });
+
+  it('429 无 retryAfterMs → hint 回落中性文案（不写死 30s）', async () => {
+    const { o } = opts([{ status: 429, json: { error: 'rate_limited' } }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    if (r.ok || r.reason !== 'rate_limited') { expect.fail('expected rate_limited'); return; }
+    expect(r.retryAfterMs).toBeUndefined();
+    expect(rateLimitRetryHint(r)).toBe('请稍后重试');
   });
 
   it('分型只看当次 status：一个非 opt-in 请求也可能拿 429（不是恒定 403）', async () => {

--- a/test/team-agents-client.test.ts
+++ b/test/team-agents-client.test.ts
@@ -266,19 +266,13 @@ describe('createTeamGroup（端点3）', () => {
 });
 
 describe('addTeamGroupMembers（端点4 / B：往现有群补人）', () => {
-  it('POST 到 /groups/:chatId/members，body 带 teamId+appIds，默认不含 includeOwners', async () => {
+  it('POST 到 /groups/:chatId/members，body 带 teamId+appIds（补人恒带 owner，无 includeOwners）', async () => {
     const { o, calls } = opts([{ status: 200, json: { ok: true, chatId: 'oc_1', invalidBotIds: [], invalidOwnerUnionIds: [] } }]);
     const r = await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a', 'cli_b'] }, o);
     expect(r).toEqual({ ok: true, value: { ok: true, invalidBotIds: [], invalidOwnerUnionIds: [] } });
     expect(calls[0].method).toBe('POST');
     expect(calls[0].url).toBe('https://platform.example/v1/machine/groups/oc_1/members');
     expect(calls[0].body).toEqual({ teamId: 't1', appIds: ['cli_a', 'cli_b'] });
-  });
-
-  it('includeOwners:false 显式进 body（只补 bot 不拉人）', async () => {
-    const { o, calls } = opts([{ status: 200, json: { ok: true, chatId: 'oc_1' } }]);
-    await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a'], includeOwners: false }, o);
-    expect(calls[0].body).toEqual({ teamId: 't1', appIds: ['cli_a'], includeOwners: false });
   });
 
   it('chatId 进 path 时被 URL 编码', async () => {
@@ -294,10 +288,10 @@ describe('addTeamGroupMembers（端点4 / B：往现有群补人）', () => {
     expect(isRetriable(r as any)).toBe(false);
   });
 
-  it('403 requester_bot_not_in_chat（群里没有发起方本机的 bot）→ client', async () => {
-    const { o } = opts([{ status: 403, json: { error: 'requester_bot_not_in_chat' } }]);
+  it('403 requester_not_in_chat（发起方 owner 本人不在该群）→ client', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'requester_not_in_chat' } }]);
     const r = await addTeamGroupMembers({ chatId: 'oc_x', teamId: 't1', appIds: ['cli_a'] }, o);
-    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'requester_bot_not_in_chat' });
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'requester_not_in_chat' });
     expect(isRetriable(r as any)).toBe(false);
   });
 

--- a/test/team-agents-client.test.ts
+++ b/test/team-agents-client.test.ts
@@ -7,6 +7,7 @@ import {
   fetchTeamAgents,
   fetchTeams,
   createTeamGroup,
+  addTeamGroupMembers,
   isRetriable,
   describeTeamAgentsFailure,
   type TeamAgentsClientOptions,
@@ -190,6 +191,21 @@ describe('createTeamGroup（端点3）', () => {
     expect(isRetriable(r as any)).toBe(false);
   });
 
+  it('403 not_in_team_bots 带 appIds → 透传到 failure.appIds（review P2 优化）', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'not_in_team_bots', appIds: ['cli_x', 'cli_y'] } }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_x', 'cli_y', 'cli_z'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, appIds: ['cli_x', 'cli_y'] });
+  });
+
+  it('403 machine_ownership_mismatch → forbidden（凭证问题，非 client）（review P1）', async () => {
+    // 机器 RETIRED / 换绑 owner 时平台发这个 403。它是凭证/归属问题（该 rebind），不能像
+    // not_in_team_bots 那样归 client 并提示「确认 bot 已加入团队」——那会误导排查方向。
+    const { o } = opts([{ status: 403, json: { error: 'machine_ownership_mismatch' } }]);
+    const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'forbidden', status: 403, error: 'machine_ownership_mismatch' });
+    expect(isRetriable(r as any)).toBe(false);
+  });
+
   it('429 rate_limited（同机 30s 一次）→ 单独分型且可重试', async () => {
     const { o } = opts([{ status: 429, json: { error: 'rate_limited' } }]);
     const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
@@ -228,5 +244,63 @@ describe('createTeamGroup（端点3）', () => {
     const r = await createTeamGroup({ teamId: 't1', appIds: ['cli_a'] }, o);
     expect(r).toMatchObject({ ok: false, reason: 'network' });
     expect(isRetriable(r as any)).toBe(true);
+  });
+});
+
+describe('addTeamGroupMembers（端点4 / B：往现有群补人）', () => {
+  it('POST 到 /groups/:chatId/members，body 带 teamId+appIds，默认不含 includeOwners', async () => {
+    const { o, calls } = opts([{ status: 200, json: { ok: true, chatId: 'oc_1', invalidBotIds: [], invalidOwnerUnionIds: [] } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a', 'cli_b'] }, o);
+    expect(r).toEqual({ ok: true, value: { ok: true, added: [], invalidBotIds: [], invalidOwnerUnionIds: [] } });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://platform.example/v1/machine/groups/oc_1/members');
+    expect(calls[0].body).toEqual({ teamId: 't1', appIds: ['cli_a', 'cli_b'] });
+  });
+
+  it('includeOwners:false 显式进 body（只补 bot 不拉人）', async () => {
+    const { o, calls } = opts([{ status: 200, json: { ok: true, chatId: 'oc_1' } }]);
+    await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a'], includeOwners: false }, o);
+    expect(calls[0].body).toEqual({ teamId: 't1', appIds: ['cli_a'], includeOwners: false });
+  });
+
+  it('chatId 进 path 时被 URL 编码', async () => {
+    const { o, calls } = opts([{ status: 200, json: { ok: true } }]);
+    await addTeamGroupMembers({ chatId: 'oc/weird id', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(calls[0].url).toBe('https://platform.example/v1/machine/groups/oc%2Fweird%20id/members');
+  });
+
+  it('403 chat_not_in_team（目标群不是本团队的群）→ client', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'chat_not_in_team' } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_x', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'chat_not_in_team' });
+    expect(isRetriable(r as any)).toBe(false);
+  });
+
+  it('403 chat_is_hall（机器人大厅不允许补人）→ client', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'chat_is_hall' } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_hall', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'chat_is_hall' });
+  });
+
+  it('200 带 invalid* → 如实透传', async () => {
+    const { o } = opts([{ status: 200, json: { ok: true, chatId: 'oc_1', invalidBotIds: ['cli_z'], invalidOwnerUnionIds: ['on_w'] } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a', 'cli_z'] }, o);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.invalidBotIds).toEqual(['cli_z']);
+    expect(r.value.invalidOwnerUnionIds).toEqual(['on_w']);
+  });
+
+  it('502 feishu_unavailable → server，可重试', async () => {
+    const { o } = opts([{ status: 502, json: { error: 'feishu_unavailable' } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'server', status: 502 });
+    expect(isRetriable(r as any)).toBe(true);
+  });
+
+  it('404 路由未部署（纯文本）→ not_deployed', async () => {
+    const { o } = opts([{ status: 404, json: {} }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'not_deployed', status: 404 });
   });
 });

--- a/test/team-agents-client.test.ts
+++ b/test/team-agents-client.test.ts
@@ -287,10 +287,17 @@ describe('addTeamGroupMembers（端点4 / B：往现有群补人）', () => {
     expect(calls[0].url).toBe('https://platform.example/v1/machine/groups/oc%2Fweird%20id/members');
   });
 
-  it('403 chat_not_in_team（目标群不是本团队的群）→ client', async () => {
-    const { o } = opts([{ status: 403, json: { error: 'chat_not_in_team' } }]);
+  it('403 platform_bot_not_in_chat（平台 bot 不在目标群）→ client', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'platform_bot_not_in_chat' } }]);
     const r = await addTeamGroupMembers({ chatId: 'oc_x', teamId: 't1', appIds: ['cli_a'] }, o);
-    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'chat_not_in_team' });
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'platform_bot_not_in_chat' });
+    expect(isRetriable(r as any)).toBe(false);
+  });
+
+  it('403 requester_bot_not_in_chat（群里没有发起方本机的 bot）→ client', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'requester_bot_not_in_chat' } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_x', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'requester_bot_not_in_chat' });
     expect(isRetriable(r as any)).toBe(false);
   });
 
@@ -298,6 +305,18 @@ describe('addTeamGroupMembers（端点4 / B：往现有群补人）', () => {
     const { o } = opts([{ status: 403, json: { error: 'chat_is_hall' } }]);
     const r = await addTeamGroupMembers({ chatId: 'oc_hall', teamId: 't1', appIds: ['cli_a'] }, o);
     expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'chat_is_hall' });
+  });
+
+  it('403 machine_ownership_mismatch → forbidden（凭证问题，非 client）', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'machine_ownership_mismatch' } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_x', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'forbidden', status: 403 });
+  });
+
+  it('403 chat_not_in_team（旧码，端点未升级前兼容）→ 仍 client', async () => {
+    const { o } = opts([{ status: 403, json: { error: 'chat_not_in_team' } }]);
+    const r = await addTeamGroupMembers({ chatId: 'oc_x', teamId: 't1', appIds: ['cli_a'] }, o);
+    expect(r).toMatchObject({ ok: false, reason: 'client', status: 403, error: 'chat_not_in_team' });
   });
 
   it('200 带 invalid* → 如实透传', async () => {

--- a/test/team-agents-client.test.ts
+++ b/test/team-agents-client.test.ts
@@ -11,6 +11,7 @@ import {
   isRetriable,
   describeTeamAgentsFailure,
   rateLimitRetryHint,
+  shouldTryAutoAddPlatformBot,
   type TeamAgentsClientOptions,
 } from '../src/platform/team-agents-client.js';
 
@@ -339,5 +340,42 @@ describe('addTeamGroupMembers（端点4 / B：往现有群补人）', () => {
     const { o } = opts([{ status: 404, json: {} }]);
     const r = await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a'] }, o);
     expect(r).toMatchObject({ ok: false, reason: 'not_deployed', status: 404 });
+  });
+});
+
+describe('shouldTryAutoAddPlatformBot（自动拉平台 app 的触发条件 + 单次性）', () => {
+  const base = { ok: false as const, reason: 'client' as const, status: 403 };
+
+  it('platform_bot_not_in_chat + platformAppId → true', () => {
+    expect(shouldTryAutoAddPlatformBot({ ...base, error: 'platform_bot_not_in_chat', platformAppId: 'cli_plat' })).toBe(true);
+  });
+
+  it('platform_bot_not_in_chat 但无 platformAppId（旧端点未回传）→ false（不拉未知 id 的 app）', () => {
+    expect(shouldTryAutoAddPlatformBot({ ...base, error: 'platform_bot_not_in_chat' })).toBe(false);
+  });
+
+  it('成功结果 → false', () => {
+    expect(shouldTryAutoAddPlatformBot({ ok: true, value: {} })).toBe(false);
+  });
+
+  it('其它 403（requester_not_in_chat / chat_is_hall / not_in_team_bots）→ false', () => {
+    for (const error of ['requester_not_in_chat', 'chat_is_hall', 'not_in_team_bots']) {
+      expect(shouldTryAutoAddPlatformBot({ ...base, error })).toBe(false);
+    }
+  });
+
+  it('非 403（如 429 / forbidden / server）→ false', () => {
+    expect(shouldTryAutoAddPlatformBot({ ok: false, reason: 'rate_limited', status: 429, error: 'x' })).toBe(false);
+    expect(shouldTryAutoAddPlatformBot({ ok: false, reason: 'forbidden', status: 403, error: 'x' })).toBe(false);
+    expect(shouldTryAutoAddPlatformBot({ ok: false, reason: 'server', status: 502, error: 'x' })).toBe(false);
+  });
+
+  it('单次性：重试后即便仍是 platform_bot_not_in_chat，也由调用方「只喂首个结果」保证不再触发——本函数是纯判定，多次调用同输入结果稳定', () => {
+    // 编排层的终止性 = 调用方拉一次+重试一次、重试结果不回喂本函数（见 cmdBotsInvite）。
+    // 这里锁住「同一个仍撞 platform_bot_not_in_chat 的结果，本函数依旧返回 true」——若未来有人
+    // 把重试结果错误地回喂进来，会立刻在评审/测试中暴露成潜在二次触发点。
+    const retryStillFail = { ...base, error: 'platform_bot_not_in_chat', platformAppId: 'cli_plat' };
+    expect(shouldTryAutoAddPlatformBot(retryStillFail)).toBe(true);
+    expect(shouldTryAutoAddPlatformBot(retryStillFail)).toBe(true); // 幂等、无副作用
   });
 });

--- a/test/team-agents-client.test.ts
+++ b/test/team-agents-client.test.ts
@@ -251,7 +251,7 @@ describe('addTeamGroupMembers（端点4 / B：往现有群补人）', () => {
   it('POST 到 /groups/:chatId/members，body 带 teamId+appIds，默认不含 includeOwners', async () => {
     const { o, calls } = opts([{ status: 200, json: { ok: true, chatId: 'oc_1', invalidBotIds: [], invalidOwnerUnionIds: [] } }]);
     const r = await addTeamGroupMembers({ chatId: 'oc_1', teamId: 't1', appIds: ['cli_a', 'cli_b'] }, o);
-    expect(r).toEqual({ ok: true, value: { ok: true, added: [], invalidBotIds: [], invalidOwnerUnionIds: [] } });
+    expect(r).toEqual({ ok: true, value: { ok: true, invalidBotIds: [], invalidOwnerUnionIds: [] } });
     expect(calls[0].method).toBe('POST');
     expect(calls[0].url).toBe('https://platform.example/v1/machine/groups/oc_1/members');
     expect(calls[0].body).toEqual({ teamId: 't1', appIds: ['cli_a', 'cli_b'] });


### PR DESCRIPTION
## 背景

团队维度 Agent 互查 —— 同一 team 内成员互相发现对方的 botmux agent，并可拉群协作。平台仓已落地协议字段 + machine-auth 端点（agents 发现 / groups 拉群，均已上线 botmux.bytedance.net）。本 PR 补齐 botmux 主仓的 **CLI + daemon 客户端半环**。

## 改了什么

- **daemon 上报（additive）**：`PlatformBotInfo` + `readPlatformBotsInfo` 增加 `specialties: string[]` 与 `mentionable: boolean`，随 register/heartbeat 上报。`specialties` 是 owner 预配的专长标签（发现/拉群匹配依据，**仅展示不可信**）；`mentionable` = 有飞书传输身份（apiOnly → false）。
- **本地存储**：`bot-profile-store` 增加结构化 `specialties`，与既有自由文本 `capability` 标签共存、merge 写互不覆盖、读时归一化（去脏/去重/限长）。**刻意避开代码里已有的 `capabilities` 字段**——那是 VC 会议 sink 的**权限凭据**（`meeting.output.request` 等，会 gate 真实动作），与「自报、不可信、仅展示」的发现标签语义相反，同名会污染权限判定。
- **machine-auth 客户端** `platform/team-agents-client`：端点 1/2/3 + 错误分型。额外区分「路由未部署」（框架级纯文本 404）与「非成员」（业务 JSON `{error:not_found}` 404），避免误报；429 限流单列。
- **CLI**：
  - `bots list --scope team [--team X]` → 打端点2 跨机发现同团队已 opt-in agent（未传 `--team` 先打端点1，唯一即用 / 多个要求指定）。
  - `create-group --team <teamId> --agent <appId>...` → 打端点3 由平台代建聚焦新群并拉入选中 agent + 各自 owner。
  - 全程 machine-auth，**CLI 零授权判断**（团队成员校验 + opt-in 闸 team.bots 全在平台）。
- **skill**：`botmux-bots` 补「团队发现 + 跨机拉群 + opt-in 边界 + 与飞书 `/invite` 分工」章节。

## 为什么这么设计

`team.bots` 里的 bot 本就同处机器人大厅、能互 @；拉群端点的价值是「为具体任务开聚焦小群」，不是「首次能对话」。发起人在别人 bot 进群前根本 @不到它，所以拉群只认 appId、走 machine-auth，天然绕开视角问题。`specialties`/`mentionable` 是 agent 自报 → 仅供挑选参考，绝不当可信凭据。

## 影响面

- **跨平台**：纯服务端 HTTP + 本地文件读写，无平台相关代码，Linux/macOS 一致。
- **跨 CLI**：`bot-profile-store` 的 capability 读写、`bots list` 输出被所有 CLI 共用——已在既有测试（bots-list-output / dashboard-bot-payload / role-resolver 等）验证无回归。
- **跨会话类型**：team scope 命令走 machine-auth、不依赖飞书传输，沙盒/apiOnly bot 也能发起，在 transport 闸门之前分流；不影响既有 chat-scope `bots list` 与本机 `create-group`。

## 测试验证

- `pnpm build` 通过。
- 新增 `team-agents-client`（19 项）+ 扩 `bot-profile-store`（含 specialties 归一化/merge，24 项）与 `builtin-skills`（团队 scope 断言）测试；相关回归 **180 项全绿**。
- **live 端到端**（botmux.bytedance.net 真 machineToken）：
  - 端点2 逐团队逐分型对上：200 有成员（字段逐字段一致）/ 空列表返回空数组 / JSON content-type。
  - 端点3 未 opt-in appId → `403 not_in_team_bots`，CLI 正确提示 + exit 1。
  - 真建群 happy-path 成功：`ok:true` + chatId + shareLink，选中 agent 与各自 owner 均成功入群，`invalidBotIds`/`invalidOwnerUnionIds` 为空。

## 备注

- `specialties` 值需**发版**后各 owner 机器升级到带上报代码的 daemon 才会出现（当前线上 agent 均为 `[]`，跑的还是旧 daemon）。
- 「往已存在的群加 agent」（当前群补人）平台暂无机器端点，作为后续 B 阶段推进；本 PR 只含「建聚焦新群」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
