### PR TITLE
fix(riff): keychain 无有效 JWT 时按需触发 bytedcli 刷新再重读

### DIFF
--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -1,7 +1,8 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, delimiter } from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { createHash } from 'node:crypto';
 import type {
   SessionBackend,
@@ -274,7 +275,7 @@ export async function cancelRiffTaskById(
 ): Promise<boolean> {
   const attempt = async (): Promise<void> => {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    const jwt = new RiffBackend(cfg as RiffBackendConfig, 'orphan-cancel')['resolveJwt']();
+    const jwt = await new RiffBackend(cfg as RiffBackendConfig, 'orphan-cancel')['resolveJwt']({ allowRefresh: false });
     if (jwt) headers['x-jwt-token'] = jwt;
     const resp = await fetch(`${cfg.baseUrl}/api/task-cancel`, {
       method: 'POST', headers, body: JSON.stringify({ id: taskId }), signal: AbortSignal.timeout(4000),
@@ -583,12 +584,20 @@ export function resolveJwtRefreshCmd(
   return null;
 }
 
-/** Minimum gap between JWT refresh attempts. A single stuck/expired token would
- *  otherwise trigger a refresh on EVERY getJwt() call (reconnect loops read the
- *  JWT once per attempt); we refresh at most once per window and let the shared
- *  keychain re-read serve subsequent calls. Also caps the cost of a refresh
- *  command that keeps failing (e.g. bytedcli not logged in). */
+/** Minimum gap between speculative JWT refresh attempts. When the keychain
+ *  holds no live token, a reconnect/follow-up loop would otherwise trigger a
+ *  refresh on EVERY getJwt() call; we cap proactive refreshes at one per window
+ *  and let the shared keychain re-read serve the rest. Also caps the cost of a
+ *  refresh command that keeps failing (e.g. bytedcli not logged in). A refresh
+ *  driven by an actual server 401 bypasses this window (see `force`). */
 export const JWT_REFRESH_DEBOUNCE_MS = 60_000;
+
+/** How long a single refresh command may run before we give up. Once the
+ *  refresh is asynchronous (below) this no longer blocks the event loop — it
+ *  only bounds one awaited child process — so we keep it generous: a cold
+ *  bytedcli token fetch can take a few seconds, and a session that cannot get a
+ *  JWT has nothing useful to do anyway. */
+export const JWT_REFRESH_TIMEOUT_MS = 30_000;
 
 /** Process-wide last-attempt timestamp (ms). Shared across RiffBackend instances
  *  because the orphan-cancel path builds a throwaway instance per call — a
@@ -596,42 +605,72 @@ export const JWT_REFRESH_DEBOUNCE_MS = 60_000;
  *  attempted", so the first call always runs regardless of the clock's
  *  magnitude. Reset helper for tests. */
 let lastJwtRefreshAtMs = Number.NEGATIVE_INFINITY;
+/** In-flight refresh, shared process-wide so concurrent callers COALESCE onto a
+ *  single child process instead of each spawning their own bytedcli. `null`
+ *  between attempts. */
+let inFlightJwtRefresh: Promise<boolean> | null = null;
 export function __resetJwtRefreshDebounceForTest(): void {
   lastJwtRefreshAtMs = Number.NEGATIVE_INFINITY;
+  inFlightJwtRefresh = null;
+}
+
+export interface RefreshBytecloudJwtOpts {
+  /** Injectable async runner (defaults to a real execFile). */
+  runner?: (bin: string, args: string[]) => Promise<void>;
+  /** Injectable clock for the debounce window (defaults to Date.now()). */
+  nowMs?: number;
+  /** Bypass the debounce window. Set only when an actual server 401/403 proved
+   *  the current token is bad — a rejection is authoritative evidence worth one
+   *  more attempt even inside the window. Never set for speculative refreshes. */
+  force?: boolean;
 }
 
 /**
- * Run the JWT-refresh command once, honouring the debounce window. Never throws:
- * a missing command, a non-zero exit, or a timeout all resolve to `false` (the
- * caller then falls back to whatever the keychain holds — i.e. the pre-change
- * behaviour). Returns true only when a command actually ran to completion.
+ * Run the JWT-refresh command once, ASYNCHRONOUSLY. Never throws: a missing
+ * command, a non-zero exit, or a timeout all resolve to `false` (the caller then
+ * falls back to whatever the keychain holds — i.e. the pre-change behaviour).
+ * Resolves true only when a command actually ran to completion.
  *
- * Pure-ish + injectable (runner / now) so the debounce and fail-closed paths are
- * unit-testable without spawning a real process.
+ * Async + injectable (runner / now / force) so it never blocks the event loop
+ * (critical on the daemon-side orphan-cancel path) and the debounce / coalesce /
+ * fail-closed paths are unit-testable without spawning a real process.
+ *
+ * COALESCE: if a refresh is already in flight, ride it instead of spawning a
+ * second bytedcli — concurrent getJwt() callers share one refresh.
  */
 export function refreshBytecloudJwt(
   cmd: string[] | null,
-  runner: (bin: string, args: string[]) => void = defaultJwtRefreshRunner,
-  nowMs: number = Date.now(),
-): boolean {
-  if (!cmd || cmd.length === 0) return false;
-  if (nowMs - lastJwtRefreshAtMs < JWT_REFRESH_DEBOUNCE_MS) return false;
+  opts: RefreshBytecloudJwtOpts = {},
+): Promise<boolean> {
+  const { runner = defaultJwtRefreshRunner, nowMs = Date.now(), force = false } = opts;
+  if (!cmd || cmd.length === 0) return Promise.resolve(false);
+  // Coalesce first: a forced caller still rides an in-flight refresh rather than
+  // racing a second child — the running one will rewrite the keychain either way.
+  if (inFlightJwtRefresh) return inFlightJwtRefresh;
+  // Debounce: cap the cost of a refresh that keeps failing. A forced (401-driven)
+  // refresh bypasses the window — the token was provably rejected.
+  if (!force && nowMs - lastJwtRefreshAtMs < JWT_REFRESH_DEBOUNCE_MS) return Promise.resolve(false);
   lastJwtRefreshAtMs = nowMs;
   const [bin, ...args] = cmd;
-  try {
-    runner(bin!, args);
-    return true;
-  } catch (err) {
-    logger.warn(`[riff] JWT refresh command failed: ${err instanceof Error ? err.message : String(err)}`);
-    return false;
-  }
+  const run = (async (): Promise<boolean> => {
+    try {
+      await runner(bin!, args);
+      return true;
+    } catch (err) {
+      logger.warn(`[riff] JWT refresh command failed: ${err instanceof Error ? err.message : String(err)}`);
+      return false;
+    }
+  })();
+  inFlightJwtRefresh = run;
+  return run.finally(() => { if (inFlightJwtRefresh === run) inFlightJwtRefresh = null; });
 }
 
-/** Default refresh runner: execFileSync with a bounded timeout. stdout/stderr are
- *  discarded — the command's SIDE EFFECT (rewriting the keychain) is what matters;
- *  we re-read the keychain afterwards rather than parse its output. */
-function defaultJwtRefreshRunner(bin: string, args: string[]): void {
-  execFileSync(bin, args, { timeout: 30_000, stdio: ['ignore', 'ignore', 'ignore'] });
+const execFileAsync = promisify(execFile);
+/** Default refresh runner: async execFile with a bounded timeout. stdout/stderr
+ *  are discarded — the command's SIDE EFFECT (rewriting the keychain) is what
+ *  matters; we re-read the keychain afterwards rather than parse its output. */
+async function defaultJwtRefreshRunner(bin: string, args: string[]): Promise<void> {
+  await execFileAsync(bin, args, { timeout: JWT_REFRESH_TIMEOUT_MS });
 }
 
 function defaultRunGit(cwd: string): (args: string[]) => string | null {
@@ -841,12 +880,20 @@ export class RiffBackend implements SessionBackend {
     if (this.currentTaskId) cb(this.currentTaskId);
   }
 
-  /** Resolve JWT dynamically — re-reads env/keychain each call so auto-refresh works. */
-  private getJwt(): string | null {
-    return this.resolveJwt();
+  /** Resolve JWT dynamically — re-reads env/keychain each call so auto-refresh
+   *  works. Async because a keychain miss may trigger a (non-blocking) CLI
+   *  refresh. `opts.allowRefresh=false` skips the refresh entirely (daemon-side
+   *  orphan-cancel: a best-effort teardown must never freeze the daemon on a
+   *  host-identity refresh). `opts.forceRefresh=true` bypasses the debounce
+   *  window (an actual server 401 proved the token bad). */
+  private getJwt(opts: { allowRefresh?: boolean; forceRefresh?: boolean } = {}): Promise<string | null> {
+    return this.resolveJwt(opts);
   }
 
-  private resolveJwt(): string | null {
+  private async resolveJwt(
+    opts: { allowRefresh?: boolean; forceRefresh?: boolean } = {},
+  ): Promise<string | null> {
+    const { allowRefresh = true, forceRefresh = false } = opts;
     if (this.config.jwt) return this.config.jwt;
     const envKey = this.config.jwtEnv ?? 'RIFF_JWT';
     const fromEnv = process.env[envKey];
@@ -854,21 +901,26 @@ export class RiffBackend implements SessionBackend {
 
     // Fallback: try ByteCloud Auth SDK keychain (kaboo-cli / aiden-cli / cjadk / bytedcli)
     const fromKeychain = this.readJwtFromBytecloudKeychain();
-    if (fromKeychain) {
+    // A forced refresh (post-401) intentionally ignores an existing keychain
+    // token: the server just rejected whatever we had, so re-reading the same
+    // store without refreshing first would hand back the same bad token.
+    if (fromKeychain && !forceRefresh) {
       logger.info(`[riff] JWT loaded from ByteCloud keychain`);
       return fromKeychain;
     }
 
-    // No live keychain token — every candidate is expired, within the safety
-    // window, or absent. This is exactly the "token expired mid-task" case (the
-    // JWT is re-read per request, so a reconnect after expiry lands here). Before
-    // giving up to a 401 that would abort the turn, ask the owning CLI to refresh
-    // (debounced, non-fatal), then re-read once. Skipped inside a full AIME
-    // runtime to preserve the fail-closed identity boundary (we never trigger a
-    // host-identity refresh there — the AIME store is refreshed inside AIME).
-    if (!isFullAimeRuntime(process.env)) {
+    // No live keychain token (or a forced post-401 refresh) — every candidate is
+    // expired, within the safety window, or absent. This is exactly the "token
+    // expired mid-task" / "expired at startup" case (the JWT is re-read per
+    // request). Before giving up to a 401 that would abort the turn, ask the
+    // owning CLI to refresh (non-blocking async, coalesced, non-fatal), then
+    // re-read once. Skipped when allowRefresh=false (daemon-side orphan-cancel)
+    // and inside a full AIME runtime (fail-closed identity boundary — we never
+    // trigger a host-identity refresh there; the AIME store is refreshed inside
+    // AIME).
+    if (allowRefresh && !isFullAimeRuntime(process.env)) {
       const cmd = resolveJwtRefreshCmd(this.config.jwtRefreshCmd);
-      if (refreshBytecloudJwt(cmd)) {
+      if (await refreshBytecloudJwt(cmd, { force: forceRefresh })) {
         const refreshed = this.readJwtFromBytecloudKeychain();
         if (refreshed) {
           logger.info(`[riff] JWT refreshed via ByteCloud CLI and reloaded from keychain`);
@@ -877,6 +929,10 @@ export class RiffBackend implements SessionBackend {
       }
     }
 
+    // Forced refresh found nothing new — fall back to the (rejected) keychain
+    // token rather than null: a stale token is no worse than no token, and the
+    // caller already knows it 401'd.
+    if (fromKeychain) return fromKeychain;
     logger.warn(`[riff] JWT not found in config, env ${envKey}, or ByteCloud keychain; API calls will fail`);
     return null;
   }
@@ -1531,10 +1587,32 @@ export class RiffBackend implements SessionBackend {
     }
 
     // Resolve JWT last — right before the request — so the safety-window
-    // freshness check reflects the token that actually goes on the wire.
-    const jwt = this.getJwt();
-    if (jwt) headers['x-jwt-token'] = jwt;
-    const resp = await fetch(url, { method: 'POST', headers, body, signal: AbortSignal.timeout(this.createTimeoutMs) });
+    // freshness check reflects the token that actually goes on the wire. `body`
+    // (string or FormData) is re-extractable per fetch, so the retry below can
+    // reuse it.
+    const post = (jwt: string | null): Promise<Response> => {
+      const h = { ...headers };
+      if (jwt) h['x-jwt-token'] = jwt;
+      return fetch(url, { method: 'POST', headers: h, body, signal: AbortSignal.timeout(this.createTimeoutMs) });
+    };
+
+    const firstJwt = await this.getJwt();
+    let resp = await post(firstJwt);
+
+    // One retry on an auth rejection. A 401/403 is authoritative proof the token
+    // was bad (expired mid-flight / stale at startup), so it justifies forcing a
+    // JWT refresh that bypasses the debounce window. We retry ONLY when the
+    // refresh produced a genuinely different token — otherwise the second POST
+    // would just replay the same rejected credential (this also naturally
+    // no-ops inside a full AIME runtime, where the host refresh is skipped).
+    // Other statuses (400/5xx) are not auth problems and are not retried.
+    if (resp.status === 401 || resp.status === 403) {
+      const freshJwt = await this.getJwt({ forceRefresh: true });
+      if (freshJwt && freshJwt !== firstJwt) {
+        logger.warn(`[riff] task create/follow-up got HTTP ${resp.status}; retrying once with a refreshed JWT`);
+        resp = await post(freshJwt);
+      }
+    }
 
     if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
     const result = (await resp.json()) as RiffTaskResponse;
@@ -1602,7 +1680,7 @@ export class RiffBackend implements SessionBackend {
   private async cancelTask(taskId: string): Promise<void> {
     const url = `${this.config.baseUrl}/api/task-cancel`;
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    const jwt = this.getJwt();
+    const jwt = await this.getJwt();
     if (jwt) headers['x-jwt-token'] = jwt;
     const resp = await fetch(url, {
       method: 'POST',
@@ -1643,7 +1721,7 @@ export class RiffBackend implements SessionBackend {
   private async streamTask(taskId: string): Promise<void> {
     const url = `${this.config.baseUrl}/api2/task-stream?id=${encodeURIComponent(taskId)}`;
     const headers: Record<string, string> = {};
-    const jwt = this.getJwt();
+    const jwt = await this.getJwt();
     if (jwt) headers['x-jwt-token'] = jwt;
 
     this.abortController = new AbortController();
@@ -1954,7 +2032,7 @@ export class RiffBackend implements SessionBackend {
     try {
       const url = `${this.config.baseUrl}/api/task-detail?id=${encodeURIComponent(taskId)}`;
       const headers: Record<string, string> = {};
-      const jwt = this.getJwt();
+      const jwt = await this.getJwt();
       if (jwt) headers['x-jwt-token'] = jwt;
       const resp = await fetch(url, { headers, signal: AbortSignal.timeout(8000) });
       if (!resp.ok) return;
@@ -1986,7 +2064,7 @@ export class RiffBackend implements SessionBackend {
     try {
       const url = `${this.config.baseUrl}/api/task-detail?id=${encodeURIComponent(taskId)}`;
       const headers: Record<string, string> = {};
-      const jwt = this.getJwt();
+      const jwt = await this.getJwt();
       if (jwt) headers['x-jwt-token'] = jwt;
 
       const resp = await fetch(url, { headers, signal: AbortSignal.timeout(8000) });

--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, delimiter } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import type {
@@ -83,6 +83,28 @@ export interface RiffBackendConfig {
   jwt?: string;
   /** Name of env var containing the JWT token (default: RIFF_JWT). */
   jwtEnv?: string;
+  /**
+   * Command to refresh the ByteCloud JWT when the keychain holds no live token.
+   * When neither `config.jwt` nor the env token is set and `readBytecloudKeychainJwt`
+   * returns null (every candidate expired / within the safety window / absent),
+   * riff task creation would fail with a 401 that aborts the whole turn. Before
+   * giving up, we run this command ONCE (debounced) to let the owning CLI
+   * (bytedcli / kaboo-cli) refresh credentials and rewrite the keychain, then
+   * re-read. bytedcli is the ByteCloud JWT owner: `bytedcli auth
+   * get-bytecloud-jwt-token --force-refresh` refreshes via its Auth SDK and
+   * writes the token to `~/.local/share/bytedcli/data/bytecloud-auth/…`, which is
+   * already a `bytecloudKeychainCandidates` path.
+   *
+   * Shape: [binary, ...args]. When unset, resolves in order:
+   *   1. env `BOTMUX_RIFF_JWT_REFRESH_CMD` (space-split, e.g. `bytedcli auth get-bytecloud-jwt-token --force-refresh`)
+   *   2. a `bytedcli` binary found on PATH → `bytedcli auth get-bytecloud-jwt-token --force-refresh`
+   *   3. otherwise no auto-refresh (fail-closed to the old behaviour — a 401).
+   * We intentionally do NOT default to `npx @bytedance-dev/bytedcli@latest`: an
+   * uncached/`@latest` npx resolve can block ~30s per call, far too slow for a
+   * synchronous pre-request refresh. Deployments wanting npx must set the env
+   * explicitly (and ideally pin the version).
+   */
+  jwtRefreshCmd?: string[];
   /** Sandbox resource pool selected for newly-created tasks. Riff defaults to
    *  BOE when omitted; follow-ups inherit the parent task's sandbox. */
   sandboxCluster?: RiffSandboxCluster;
@@ -309,6 +331,13 @@ function aimeDataHome(env: NodeJS.ProcessEnv): string | null {
   return join(workspace, sanitizeAimeUser(user), '.local', 'share');
 }
 
+/** True when BOTH AIME vars are set (trimmed non-empty), i.e. bytedcli swaps its
+ *  storage root to the AIME workspace. In that runtime we must not trigger a
+ *  host-identity JWT refresh — see resolveJwt's fail-closed skip. */
+function isFullAimeRuntime(env: NodeJS.ProcessEnv): boolean {
+  return aimeDataHome(env) !== null;
+}
+
 /**
  * The keychain candidates for a ByteCloud tool's `bytecloud-auth/` store, across
  * the CLIs botmux users log into (kaboo-cli / aiden-cli / cjadk / bytedcli).
@@ -502,6 +531,107 @@ export function readBytecloudKeychainJwt(
     if (!bestLive || exp > bestLive.exp) bestLive = { jwt, exp };
   }
   return bestLive?.jwt ?? opaqueFallback;
+}
+
+/**
+ * Locate a `bytedcli` binary on PATH (used to build the default JWT-refresh
+ * command). Returns the bare name `bytedcli` when found so execFileSync resolves
+ * it via PATH, or null when absent. Injectable env/platform for testing.
+ *
+ * We look for a real installed binary rather than defaulting to
+ * `npx @bytedance-dev/bytedcli@latest`: an uncached / `@latest` npx resolve can
+ * block ~30s, which is unacceptable on the synchronous pre-request path. If
+ * bytedcli is not installed we simply do not auto-refresh (fail-closed to the
+ * prior behaviour — the request may 401, exactly as before this change).
+ */
+export function findBytedcliBinary(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const pathVar = env.PATH ?? env.Path ?? '';
+  if (!pathVar) return null;
+  const names = platform === 'win32' ? ['bytedcli.cmd', 'bytedcli.exe', 'bytedcli'] : ['bytedcli'];
+  for (const dir of pathVar.split(delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      try {
+        if (existsSync(join(dir, name))) return 'bytedcli';
+      } catch { /* ignore unreadable PATH entry */ }
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the JWT-refresh command: explicit config → env
+ * `BOTMUX_RIFF_JWT_REFRESH_CMD` (space-split) → a PATH-resident bytedcli →
+ * null (no auto-refresh). See RiffBackendConfig.jwtRefreshCmd for the rationale.
+ */
+export function resolveJwtRefreshCmd(
+  configured: string[] | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string[] | null {
+  if (configured && configured.length > 0) return configured;
+  const fromEnv = env.BOTMUX_RIFF_JWT_REFRESH_CMD?.trim();
+  if (fromEnv) {
+    const parts = fromEnv.split(/\s+/).filter(Boolean);
+    if (parts.length > 0) return parts;
+  }
+  const bin = findBytedcliBinary(env, platform);
+  if (bin) return [bin, 'auth', 'get-bytecloud-jwt-token', '--force-refresh'];
+  return null;
+}
+
+/** Minimum gap between JWT refresh attempts. A single stuck/expired token would
+ *  otherwise trigger a refresh on EVERY getJwt() call (reconnect loops read the
+ *  JWT once per attempt); we refresh at most once per window and let the shared
+ *  keychain re-read serve subsequent calls. Also caps the cost of a refresh
+ *  command that keeps failing (e.g. bytedcli not logged in). */
+export const JWT_REFRESH_DEBOUNCE_MS = 60_000;
+
+/** Process-wide last-attempt timestamp (ms). Shared across RiffBackend instances
+ *  because the orphan-cancel path builds a throwaway instance per call — a
+ *  per-instance clock there would never debounce. `-Infinity` means "never
+ *  attempted", so the first call always runs regardless of the clock's
+ *  magnitude. Reset helper for tests. */
+let lastJwtRefreshAtMs = Number.NEGATIVE_INFINITY;
+export function __resetJwtRefreshDebounceForTest(): void {
+  lastJwtRefreshAtMs = Number.NEGATIVE_INFINITY;
+}
+
+/**
+ * Run the JWT-refresh command once, honouring the debounce window. Never throws:
+ * a missing command, a non-zero exit, or a timeout all resolve to `false` (the
+ * caller then falls back to whatever the keychain holds — i.e. the pre-change
+ * behaviour). Returns true only when a command actually ran to completion.
+ *
+ * Pure-ish + injectable (runner / now) so the debounce and fail-closed paths are
+ * unit-testable without spawning a real process.
+ */
+export function refreshBytecloudJwt(
+  cmd: string[] | null,
+  runner: (bin: string, args: string[]) => void = defaultJwtRefreshRunner,
+  nowMs: number = Date.now(),
+): boolean {
+  if (!cmd || cmd.length === 0) return false;
+  if (nowMs - lastJwtRefreshAtMs < JWT_REFRESH_DEBOUNCE_MS) return false;
+  lastJwtRefreshAtMs = nowMs;
+  const [bin, ...args] = cmd;
+  try {
+    runner(bin!, args);
+    return true;
+  } catch (err) {
+    logger.warn(`[riff] JWT refresh command failed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
+/** Default refresh runner: execFileSync with a bounded timeout. stdout/stderr are
+ *  discarded — the command's SIDE EFFECT (rewriting the keychain) is what matters;
+ *  we re-read the keychain afterwards rather than parse its output. */
+function defaultJwtRefreshRunner(bin: string, args: string[]): void {
+  execFileSync(bin, args, { timeout: 30_000, stdio: ['ignore', 'ignore', 'ignore'] });
 }
 
 function defaultRunGit(cwd: string): (args: string[]) => string | null {
@@ -727,6 +857,24 @@ export class RiffBackend implements SessionBackend {
     if (fromKeychain) {
       logger.info(`[riff] JWT loaded from ByteCloud keychain`);
       return fromKeychain;
+    }
+
+    // No live keychain token — every candidate is expired, within the safety
+    // window, or absent. This is exactly the "token expired mid-task" case (the
+    // JWT is re-read per request, so a reconnect after expiry lands here). Before
+    // giving up to a 401 that would abort the turn, ask the owning CLI to refresh
+    // (debounced, non-fatal), then re-read once. Skipped inside a full AIME
+    // runtime to preserve the fail-closed identity boundary (we never trigger a
+    // host-identity refresh there — the AIME store is refreshed inside AIME).
+    if (!isFullAimeRuntime(process.env)) {
+      const cmd = resolveJwtRefreshCmd(this.config.jwtRefreshCmd);
+      if (refreshBytecloudJwt(cmd)) {
+        const refreshed = this.readJwtFromBytecloudKeychain();
+        if (refreshed) {
+          logger.info(`[riff] JWT refreshed via ByteCloud CLI and reloaded from keychain`);
+          return refreshed;
+        }
+      }
     }
 
     logger.warn(`[riff] JWT not found in config, env ${envKey}, or ByteCloud keychain; API calls will fail`);

--- a/test/riff-backend.test.ts
+++ b/test/riff-backend.test.ts
@@ -877,6 +877,9 @@ describe('RiffBackend', () => {
       });
       (be as any).currentTaskId = 'task-A';
       const p = (be as any).fetchDirectAccessUrl('task-A');
+      // getJwt is now async, so the task-detail fetch (which assigns resolveDetail)
+      // only fires after a microtask. Flush before driving the response.
+      await flush();
       (be as any).currentTaskId = 'task-B';
       resolveDetail(Response.json({ success: true, data: { task: { directAccessUrl: 'https://old-a.example/' } } }));
       await p;
@@ -1501,6 +1504,65 @@ describe('RiffBackend', () => {
       expect(urls[urls.length - 1]).toBe(`${BASE}/sandbox-access?sessionId=z`);
       await flush();
       expect(urls[urls.length - 1]).toBe('https://port-8080-z.sandbox.example.com/');
+    });
+  });
+
+  describe('create/follow-up 401 retry with refreshed JWT (申晗: startup must actually get a JWT)', () => {
+    /** A task-execute fetch mock: first POST 401s, the retry (if any) 200s.
+     *  task-stream stays pending; task-detail/cancel resolve instantly. */
+    function authRetryFetch(): { execHeaders: Array<string | undefined> } {
+      const execHeaders: Array<string | undefined> = [];
+      let execCount = 0;
+      const mock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+        const u = String(url);
+        if (u.includes('/api/task-execute')) {
+          execCount += 1;
+          const h = (init?.headers ?? {}) as Record<string, string>;
+          execHeaders.push(h['x-jwt-token']);
+          return execCount === 1
+            ? new Response('unauthorized', { status: 401 })
+            : Response.json({ success: true, data: { id: 'task-ok', status: 'running' } });
+        }
+        if (u.includes('/api2/task-stream')) return pendingSseResponse();
+        return Response.json({ success: true, data: {} });
+      });
+      vi.stubGlobal('fetch', mock);
+      return { execHeaders };
+    }
+
+    it('retries ONCE with a freshly-refreshed token after a 401 and succeeds', async () => {
+      const { execHeaders } = authRetryFetch();
+      const be = makeBackend();
+      // Script getJwt: stale token first, forced refresh yields a different one.
+      const gj = vi.spyOn(be as any, 'getJwt').mockImplementation(async (opts: any) => {
+        return opts?.forceRefresh ? 'JWT-FRESH' : 'JWT-STALE';
+      });
+      be.spawn('', [], {} as any);
+      be.write('hello');
+      await flush(); await flush();
+
+      // Two task-execute POSTs: the stale-token attempt (401), then the refreshed retry.
+      expect(execHeaders).toEqual(['JWT-STALE', 'JWT-FRESH']);
+      // The retry used a forced refresh.
+      expect(gj.mock.calls.some(c => (c[0] as any)?.forceRefresh === true)).toBe(true);
+      // Task adopted → currentTaskId set from the successful retry.
+      expect((be as any).currentTaskId).toBe('task-ok');
+    });
+
+    it('does NOT retry when the forced refresh yields the SAME token (no pointless replay)', async () => {
+      const { execHeaders } = authRetryFetch();
+      const be = makeBackend();
+      // Refresh produces nothing new — same token both times.
+      vi.spyOn(be as any, 'getJwt').mockResolvedValue('JWT-SAME');
+      const emitErr = vi.spyOn(be as any, 'emitError');
+      be.spawn('', [], {} as any);
+      be.write('hello');
+      await flush(); await flush();
+
+      // Only the first POST happened; no retry because the token was unchanged.
+      expect(execHeaders).toEqual(['JWT-SAME']);
+      // The 401 surfaces as a turn-ending error (unchanged pre-existing behaviour).
+      expect(emitErr).toHaveBeenCalled();
     });
   });
 });

--- a/test/riff-jwt-refresh.test.ts
+++ b/test/riff-jwt-refresh.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, delimiter } from 'node:path';
+import {
+  findBytedcliBinary,
+  resolveJwtRefreshCmd,
+  refreshBytecloudJwt,
+  JWT_REFRESH_DEBOUNCE_MS,
+  __resetJwtRefreshDebounceForTest,
+} from '../src/adapters/backend/riff-backend.js';
+
+// The refresh helpers are pure + injectable (runner / now / env / platform), so
+// none of these tests spawn a real process. findBytedcliBinary is probed against
+// a real temp PATH dir (no mocking of node:fs).
+
+describe('findBytedcliBinary — PATH probe', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'bytedcli-path-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns "bytedcli" when a matching binary exists on a PATH segment', () => {
+    const bin = join(dir, 'bytedcli');
+    writeFileSync(bin, '#!/bin/sh\n');
+    chmodSync(bin, 0o755);
+    const env = { PATH: ['/nope/a', dir, '/nope/b'].join(delimiter) } as NodeJS.ProcessEnv;
+    expect(findBytedcliBinary(env, 'linux')).toBe('bytedcli');
+  });
+
+  it('returns null with an empty or missing PATH', () => {
+    expect(findBytedcliBinary({ PATH: '' }, 'linux')).toBeNull();
+    expect(findBytedcliBinary({} as NodeJS.ProcessEnv, 'linux')).toBeNull();
+  });
+
+  it('returns null when no PATH segment contains the binary', () => {
+    const env = { PATH: ['/nope/a', dir].join(delimiter) } as NodeJS.ProcessEnv;
+    expect(findBytedcliBinary(env, 'linux')).toBeNull();
+  });
+});
+
+describe('resolveJwtRefreshCmd — precedence', () => {
+  it('explicit config command wins over everything', () => {
+    const env = { BOTMUX_RIFF_JWT_REFRESH_CMD: 'other cmd' } as NodeJS.ProcessEnv;
+    expect(resolveJwtRefreshCmd(['my', 'cmd', '--x'], env, 'linux')).toEqual(['my', 'cmd', '--x']);
+  });
+
+  it('falls back to the env var (space-split, blanks dropped)', () => {
+    const env = {
+      BOTMUX_RIFF_JWT_REFRESH_CMD: '  bytedcli auth get-bytecloud-jwt-token --force-refresh  ',
+    } as NodeJS.ProcessEnv;
+    expect(resolveJwtRefreshCmd(undefined, env, 'linux')).toEqual([
+      'bytedcli', 'auth', 'get-bytecloud-jwt-token', '--force-refresh',
+    ]);
+  });
+
+  it('empty env var is ignored (no phantom command)', () => {
+    const env = { BOTMUX_RIFF_JWT_REFRESH_CMD: '   ', PATH: '/nope' } as NodeJS.ProcessEnv;
+    expect(resolveJwtRefreshCmd(undefined, env, 'linux')).toBeNull();
+  });
+
+  it('returns null when nothing is configured and bytedcli is not on PATH', () => {
+    const env = { PATH: '/nope/bin' } as NodeJS.ProcessEnv;
+    expect(resolveJwtRefreshCmd(undefined, env, 'linux')).toBeNull();
+  });
+
+  it('empty config array is treated as unset (does not shadow env/PATH resolution)', () => {
+    const env = { BOTMUX_RIFF_JWT_REFRESH_CMD: 'bytedcli auth x' } as NodeJS.ProcessEnv;
+    expect(resolveJwtRefreshCmd([], env, 'linux')).toEqual(['bytedcli', 'auth', 'x']);
+  });
+});
+
+describe('refreshBytecloudJwt — debounce + fail-closed', () => {
+  beforeEach(() => { __resetJwtRefreshDebounceForTest(); });
+  afterEach(() => { __resetJwtRefreshDebounceForTest(); });
+
+  it('returns false immediately when no command resolves (fail-closed, no run)', () => {
+    const runner = vi.fn();
+    expect(refreshBytecloudJwt(null, runner, 1_000)).toBe(false);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('runs the command and returns true on success', () => {
+    const runner = vi.fn();
+    const ok = refreshBytecloudJwt(['bytedcli', 'auth', 'x', '--force-refresh'], runner, 1_000);
+    expect(ok).toBe(true);
+    expect(runner).toHaveBeenCalledWith('bytedcli', ['auth', 'x', '--force-refresh']);
+  });
+
+  it('swallows a throwing runner (non-fatal) and returns false', () => {
+    const runner = vi.fn(() => { throw new Error('bytedcli not logged in'); });
+    expect(refreshBytecloudJwt(['bytedcli', 'auth', 'x'], runner, 1_000)).toBe(false);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces: a second call within the window does not run again', () => {
+    const runner = vi.fn();
+    const cmd = ['bytedcli', 'auth', 'x'];
+    expect(refreshBytecloudJwt(cmd, runner, 1_000)).toBe(true);
+    // 1s later — still inside the 60s window
+    expect(refreshBytecloudJwt(cmd, runner, 2_000)).toBe(false);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows another run once the debounce window has fully elapsed', () => {
+    const runner = vi.fn();
+    const cmd = ['bytedcli', 'auth', 'x'];
+    expect(refreshBytecloudJwt(cmd, runner, 1_000)).toBe(true);
+    expect(refreshBytecloudJwt(cmd, runner, 1_000 + JWT_REFRESH_DEBOUNCE_MS)).toBe(true);
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('a FAILED attempt still consumes the debounce window (caps flapping refresh cost)', () => {
+    const runner = vi.fn(() => { throw new Error('boom'); });
+    const cmd = ['bytedcli', 'auth', 'x'];
+    expect(refreshBytecloudJwt(cmd, runner, 1_000)).toBe(false);
+    // even though it failed, we don't hammer the command within the window
+    expect(refreshBytecloudJwt(cmd, runner, 2_000)).toBe(false);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('an empty command array resolves to false without touching the debounce clock', () => {
+    const runner = vi.fn();
+    expect(refreshBytecloudJwt([], runner, 1_000)).toBe(false);
+    // clock untouched → a real command right after still runs
+    expect(refreshBytecloudJwt(['bytedcli', 'x'], runner, 1_500)).toBe(true);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/riff-jwt-refresh.test.ts
+++ b/test/riff-jwt-refresh.test.ts
@@ -1,14 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, delimiter } from 'node:path';
 import {
+  RiffBackend,
   findBytedcliBinary,
   resolveJwtRefreshCmd,
   refreshBytecloudJwt,
   JWT_REFRESH_DEBOUNCE_MS,
   __resetJwtRefreshDebounceForTest,
 } from '../src/adapters/backend/riff-backend.js';
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
 
 // The refresh helpers are pure + injectable (runner / now / env / platform), so
 // none of these tests spawn a real process. findBytedcliBinary is probed against
@@ -69,60 +74,187 @@ describe('resolveJwtRefreshCmd — precedence', () => {
   });
 });
 
-describe('refreshBytecloudJwt — debounce + fail-closed', () => {
+describe('refreshBytecloudJwt — async debounce + coalesce + fail-closed', () => {
   beforeEach(() => { __resetJwtRefreshDebounceForTest(); });
   afterEach(() => { __resetJwtRefreshDebounceForTest(); });
 
-  it('returns false immediately when no command resolves (fail-closed, no run)', () => {
-    const runner = vi.fn();
-    expect(refreshBytecloudJwt(null, runner, 1_000)).toBe(false);
+  // An async no-op runner (the production runner is now async execFile).
+  const okRunner = () => vi.fn(async () => {});
+
+  it('returns false immediately when no command resolves (fail-closed, no run)', async () => {
+    const runner = okRunner();
+    expect(await refreshBytecloudJwt(null, { runner, nowMs: 1_000 })).toBe(false);
     expect(runner).not.toHaveBeenCalled();
   });
 
-  it('runs the command and returns true on success', () => {
-    const runner = vi.fn();
-    const ok = refreshBytecloudJwt(['bytedcli', 'auth', 'x', '--force-refresh'], runner, 1_000);
+  it('runs the command and returns true on success', async () => {
+    const runner = okRunner();
+    const ok = await refreshBytecloudJwt(['bytedcli', 'auth', 'x', '--force-refresh'], { runner, nowMs: 1_000 });
     expect(ok).toBe(true);
     expect(runner).toHaveBeenCalledWith('bytedcli', ['auth', 'x', '--force-refresh']);
   });
 
-  it('swallows a throwing runner (non-fatal) and returns false', () => {
-    const runner = vi.fn(() => { throw new Error('bytedcli not logged in'); });
-    expect(refreshBytecloudJwt(['bytedcli', 'auth', 'x'], runner, 1_000)).toBe(false);
+  it('swallows a throwing runner (non-fatal) and returns false', async () => {
+    const runner = vi.fn(async () => { throw new Error('bytedcli not logged in'); });
+    expect(await refreshBytecloudJwt(['bytedcli', 'auth', 'x'], { runner, nowMs: 1_000 })).toBe(false);
     expect(runner).toHaveBeenCalledTimes(1);
   });
 
-  it('debounces: a second call within the window does not run again', () => {
-    const runner = vi.fn();
+  it('debounces: a second call within the window does not run again', async () => {
+    const runner = okRunner();
     const cmd = ['bytedcli', 'auth', 'x'];
-    expect(refreshBytecloudJwt(cmd, runner, 1_000)).toBe(true);
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 1_000 })).toBe(true);
     // 1s later — still inside the 60s window
-    expect(refreshBytecloudJwt(cmd, runner, 2_000)).toBe(false);
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 2_000 })).toBe(false);
     expect(runner).toHaveBeenCalledTimes(1);
   });
 
-  it('allows another run once the debounce window has fully elapsed', () => {
-    const runner = vi.fn();
+  it('allows another run once the debounce window has fully elapsed', async () => {
+    const runner = okRunner();
     const cmd = ['bytedcli', 'auth', 'x'];
-    expect(refreshBytecloudJwt(cmd, runner, 1_000)).toBe(true);
-    expect(refreshBytecloudJwt(cmd, runner, 1_000 + JWT_REFRESH_DEBOUNCE_MS)).toBe(true);
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 1_000 })).toBe(true);
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 1_000 + JWT_REFRESH_DEBOUNCE_MS })).toBe(true);
     expect(runner).toHaveBeenCalledTimes(2);
   });
 
-  it('a FAILED attempt still consumes the debounce window (caps flapping refresh cost)', () => {
-    const runner = vi.fn(() => { throw new Error('boom'); });
+  it('a FAILED attempt still consumes the debounce window (caps flapping refresh cost)', async () => {
+    const runner = vi.fn(async () => { throw new Error('boom'); });
     const cmd = ['bytedcli', 'auth', 'x'];
-    expect(refreshBytecloudJwt(cmd, runner, 1_000)).toBe(false);
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 1_000 })).toBe(false);
     // even though it failed, we don't hammer the command within the window
-    expect(refreshBytecloudJwt(cmd, runner, 2_000)).toBe(false);
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 2_000 })).toBe(false);
     expect(runner).toHaveBeenCalledTimes(1);
   });
 
-  it('an empty command array resolves to false without touching the debounce clock', () => {
-    const runner = vi.fn();
-    expect(refreshBytecloudJwt([], runner, 1_000)).toBe(false);
+  it('an empty command array resolves to false without touching the debounce clock', async () => {
+    const runner = okRunner();
+    expect(await refreshBytecloudJwt([], { runner, nowMs: 1_000 })).toBe(false);
     // clock untouched → a real command right after still runs
-    expect(refreshBytecloudJwt(['bytedcli', 'x'], runner, 1_500)).toBe(true);
+    expect(await refreshBytecloudJwt(['bytedcli', 'x'], { runner, nowMs: 1_500 })).toBe(true);
     expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it('force=true bypasses the debounce window (a 401 proved the token bad)', async () => {
+    const runner = okRunner();
+    const cmd = ['bytedcli', 'auth', 'x'];
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 1_000 })).toBe(true);
+    // Inside the window a speculative refresh is skipped…
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 2_000 })).toBe(false);
+    // …but a forced (post-401) refresh runs anyway.
+    expect(await refreshBytecloudJwt(cmd, { runner, nowMs: 3_000, force: true })).toBe(true);
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('COALESCE: concurrent callers share ONE in-flight refresh (no double spawn)', async () => {
+    // A runner that stays pending until we release it, so both calls overlap.
+    let release!: () => void;
+    const gate = new Promise<void>(res => { release = res; });
+    const runner = vi.fn(async () => { await gate; });
+    const cmd = ['bytedcli', 'auth', 'x'];
+    const a = refreshBytecloudJwt(cmd, { runner, nowMs: 1_000 });
+    // Second caller arrives while the first is still running → rides the same promise.
+    const b = refreshBytecloudJwt(cmd, { runner, nowMs: 1_010 });
+    release();
+    expect(await a).toBe(true);
+    expect(await b).toBe(true);
+    expect(runner).toHaveBeenCalledTimes(1); // coalesced — only one child spawned
+  });
+
+  it('COALESCE: even a forced caller rides an in-flight refresh instead of racing a 2nd child', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(res => { release = res; });
+    const runner = vi.fn(async () => { await gate; });
+    const cmd = ['bytedcli', 'auth', 'x'];
+    const a = refreshBytecloudJwt(cmd, { runner, nowMs: 1_000 });
+    const forced = refreshBytecloudJwt(cmd, { runner, nowMs: 1_010, force: true });
+    release();
+    expect(await a).toBe(true);
+    expect(await forced).toBe(true);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Integration coverage for resolveJwt's new branch (the AIME-skip gate +
+// refresh→re-read + allowRefresh/forceRefresh options), which the pure-function
+// tests above do not exercise. We drive the REAL resolveJwt and prove whether
+// the refresh branch fired by pointing the refresh command at a `touch` that
+// writes a marker file, and by scripting the keychain read via a spy.
+describe('resolveJwt — refresh branch integration (AIME gate + allowRefresh + force)', () => {
+  let dir: string;
+  let marker: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    __resetJwtRefreshDebounceForTest();
+    dir = mkdtempSync(join(tmpdir(), 'riff-resolvejwt-'));
+    marker = join(dir, 'refreshed');
+    // A real, harmless refresh command whose SIDE EFFECT (creating `marker`) lets
+    // us assert the refresh actually ran. `node -e` avoids depending on coreutils.
+    process.env.BOTMUX_RIFF_JWT_REFRESH_CMD = `${process.execPath} -e require('fs').writeFileSync(${JSON.stringify(marker)},'x')`;
+    delete process.env.AIME_WORKSPACE_PATH;
+    delete process.env.AIME_CURRENT_USER;
+    delete process.env.RIFF_JWT;
+  });
+  afterEach(() => {
+    __resetJwtRefreshDebounceForTest();
+    rmSync(dir, { recursive: true, force: true });
+    process.env = { ...savedEnv };
+  });
+
+  /** A backend with no static jwt/env, so resolveJwt falls through to keychain. */
+  function backend(): RiffBackend {
+    return new RiffBackend({ baseUrl: 'https://riff.example.com' } as any, 'sess-resolvejwt');
+  }
+
+  it('non-AIME + no live keychain token → triggers refresh, then re-reads the fresh token', async () => {
+    const be = backend();
+    // First read (pre-refresh) misses; second read (post-refresh) hits.
+    const spy = vi.spyOn(be as any, 'readJwtFromBytecloudKeychain')
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce('FRESH-JWT');
+    const jwt = await (be as any).resolveJwt();
+    expect(jwt).toBe('FRESH-JWT');
+    expect(existsSync(marker)).toBe(true);       // refresh command actually ran
+    expect(spy).toHaveBeenCalledTimes(2);         // miss → refresh → re-read
+  });
+
+  it('full AIME runtime → NEVER triggers a host refresh (fail-closed identity boundary)', async () => {
+    process.env.AIME_WORKSPACE_PATH = join(dir, 'ws');
+    process.env.AIME_CURRENT_USER = 'alice';
+    const be = backend();
+    const spy = vi.spyOn(be as any, 'readJwtFromBytecloudKeychain').mockReturnValue(null);
+    const jwt = await (be as any).resolveJwt();
+    expect(jwt).toBeNull();
+    expect(existsSync(marker)).toBe(false);       // refresh must NOT have run
+    expect(spy).toHaveBeenCalledTimes(1);         // single miss, no re-read
+  });
+
+  it('allowRefresh:false (orphan-cancel path) → never refreshes even when keychain is empty', async () => {
+    const be = backend();
+    const spy = vi.spyOn(be as any, 'readJwtFromBytecloudKeychain').mockReturnValue(null);
+    const jwt = await (be as any).resolveJwt({ allowRefresh: false });
+    expect(jwt).toBeNull();
+    expect(existsSync(marker)).toBe(false);       // daemon-side teardown must not spawn bytedcli
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a live keychain token short-circuits before any refresh', async () => {
+    const be = backend();
+    const spy = vi.spyOn(be as any, 'readJwtFromBytecloudKeychain').mockReturnValue('LIVE-JWT');
+    const jwt = await (be as any).resolveJwt();
+    expect(jwt).toBe('LIVE-JWT');
+    expect(existsSync(marker)).toBe(false);       // no refresh when we already have a token
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('forceRefresh:true ignores an existing keychain token and refreshes first', async () => {
+    const be = backend();
+    // With force, the first (pre-refresh) read is bypassed; we refresh, then read fresh.
+    const spy = vi.spyOn(be as any, 'readJwtFromBytecloudKeychain')
+      .mockReturnValueOnce('STALE-JWT')  // would be returned WITHOUT force
+      .mockReturnValueOnce('FRESH-JWT'); // post-refresh re-read
+    const jwt = await (be as any).resolveJwt({ forceRefresh: true });
+    expect(jwt).toBe('FRESH-JWT');
+    expect(existsSync(marker)).toBe(true);
   });
 });


### PR DESCRIPTION
## 背景
riff backend 每次调用现取 JWT（`getJwt`→`resolveJwt`），来源优先级：`config.jwt` → 环境变量 → ByteCloud keychain。keychain 选择器已含 30s 安全窗、按 `exp` 选最新鲜 token。

但当**所有 keychain 候选都过期/将过期/缺失**时，`resolveJwt` 直接返回 `null`，请求带不上 `x-jwt-token` → riff 侧 401 → 整个 turn 失败。

这正是「**任务运行途中 JWT 过期**」的暴露点：JWT 每请求现取，SSE ~183s 周期重连时重新取 JWT，撞上过期就 401；且该 401 发生在「连接确立时钟」置位之前，`connLivedMs=0` 不满足 healthy 阈值 → 不退还重连预算 → 白重试 6 次（约 61s）后判失败。而此时远端 riff 任务其实仍在跑/可能已完成，botmux 只是收不了尾。

## 改动
在 `resolveJwt` 的 keychain 读取失败分支，新增「**按需触发刷新 → 重读一次**」：

- 新增可注入纯函数 `findBytedcliBinary` / `resolveJwtRefreshCmd` / `refreshBytecloudJwt`
- 刷新命令解析优先级：`config.jwtRefreshCmd` → env `BOTMUX_RIFF_JWT_REFRESH_CMD`（空格分割）→ PATH 上的 `bytedcli`（`bytedcli auth get-bytecloud-jwt-token --force-refresh`）→ `null`（不刷新，fail-closed 保持改动前行为）
- **bytedcli 是 ByteCloud JWT 的官方 owner**：刷新后写回 `~/.local/share/bytedcli/data/bytecloud-auth/…`，正是现有 `bytecloudKeychainCandidates` 候选路径之一，故重读时被 exp-aware 选择器自动选中，**无需改动 keychain 读取逻辑**
- **60s 防抖**（进程级共享，兼顾 orphan-cancel 每次新建的临时实例）；命令缺失/非零退出/超时一律吞掉返回 `false`，**绝不抛错影响主流程**
- **刻意不默认 `npx @bytedance-dev/bytedcli@latest`**：未缓存/`@latest` 版本检查会阻塞约 30s，不适合同步预检路径；需要 npx 的部署显式配 env（并建议 pin 版本）
- **全 AIME 运行时跳过自动刷新**，保留既有 fail-closed 身份边界，绝不跨身份刷 host token

## 影响面
- **仅 riff backend**；未触碰 `adapters/cli/` 共用基类、`PtyBackend`/`TmuxBackend` 及其它 20+ CLI
- keychain 读取逻辑零改动，仅在「本会 401」的失败分支前插入一次可选刷新
- **默认降级安全**：PATH 无 bytedcli 时 `resolveJwtRefreshCmd` 返回 `null`，行为与改动前完全一致
- 跨平台：`findBytedcliBinary` 按注入 platform 处理 win32（`.cmd`/`.exe`）与 posix；刷新触发本身不涉平台差异

## 部署说明
要真正启用自动刷新，需让 daemon 机上 `bytedcli` 可执行：① 全局装 bytedcli 使其上 PATH；或 ② 配 env `BOTMUX_RIFF_JWT_REFRESH_CMD`。否则维持现状（不自动刷新，撞过期仍 401）——这是刻意的 fail-closed，避免默认跑一个可能 30s 的 npx。

## 测试验证
- `pnpm build` 通过
- 新增 `test/riff-jwt-refresh.test.ts` **15 例**（PATH 探测正/负、命令解析优先级、60s 防抖、失败吞掉不抛、失败仍占用防抖窗口、空命令不占用防抖时钟等）
- 既有 `test/riff-keychain-jwt.test.ts` **49 例无回归**，合计 **64 通过**
- riff 相关全量：`riff-backend`(70) / `riff-explicit-close`(9) / `riff-sandbox-bypass` / `cli-list-riff`(2) / `worker-riff-env`(2) 共 **91 例通过**
- **端到端实测**（用 botmux 编译产物）：构造 keychain 无 token → 触发（绝对路径假 bytedcli）写 keychain → 重读到新 token（`cli_name: bytedcli`），链路通；真实环境 bytedcli 不在 PATH 时 `resolveJwtRefreshCmd=null` 优雅降级不崩；配 env 时被正确采纳

🤖 Generated with [Claude Code](https://claude.com/claude-code)