### PR TITLE
fix(omp): 兼容新版会话、忙态追加与状态显示

### DIFF
--- a/src/adapters/cli/oh-my-pi.ts
+++ b/src/adapters/cli/oh-my-pi.ts
@@ -217,6 +217,8 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
 
     completionPattern: undefined,
     readyPattern: undefined,
+    busyPattern: /Working(?:\.\.\.|…)/,
+    supportsTypeAhead: true,
     systemHints: BOTMUX_SHELL_HINTS,
     altScreen: true,
     skillsDir: '~/.omp/agent/skills',

--- a/src/adapters/cli/oh-my-pi.ts
+++ b/src/adapters/cli/oh-my-pi.ts
@@ -1,8 +1,13 @@
+import { homedir } from 'node:os';
+import { realpathSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { TERMINAL_CANCEL_COOLDOWN_MS } from '../backend/critical-control-key.js';
 
+import { findLatestJsonl } from '../../services/claude-transcript.js';
 import { delay } from '../../utils/timing.js';
 
 const OMP_INPUT_CHUNK_CHARS = 512;
@@ -10,6 +15,24 @@ const OMP_INPUT_CHUNK_NEWLINES = 9;
 const OMP_INPUT_THROTTLE_MS = 20;
 const BRACKETED_PASTE_START = '\x1b[200~';
 const BRACKETED_PASTE_END = '\x1b[201~';
+
+export function ompSessionDir(sessionId: string): string {
+  if (!sessionId || sessionId === '.' || sessionId === '..' || /[/\\]/.test(sessionId)) {
+    throw new Error(`Invalid Botmux session id for OMP: ${sessionId}`);
+  }
+  const lexicalHome = homedir();
+  let canonicalHome = lexicalHome;
+  try { canonicalHome = realpathSync(lexicalHome); } catch { /* lexical fallback */ }
+  return join(canonicalHome, '.omp', 'agent', 'sessions', 'botmux', sessionId);
+}
+
+export function ompTranscriptPath(sessionId: string): string | null {
+  return findLatestJsonl(ompSessionDir(sessionId));
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
 /** Match OMP's paste semantics before putting content on a key-event path. */
 function normalizeOmpInput(text: string): string {
@@ -115,19 +138,23 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
 
   return {
     id: 'oh-my-pi',
-    authPaths: ['~/.omp/agent/auth.json'],
+    authPaths: ['~/.omp/agent'],
     resolvedBin: bin,
 
-    // oh-my-pi has no --session-id; sessions are managed internally.
-    // buildResumeCommand handles resume separately. Do NOT pass Lark prompts
+    // oh-my-pi has no --session-id. Keep each Botmux session in its own OMP
+    // directory and resume only an exact transcript from that directory.
+    // Do NOT pass Lark prompts
     // as positional launch args: OMP deposits those in the TUI composer but
     // does not auto-submit them. Route prompts through writeInput, where botmux
     // controls the final submit key.
-    buildArgs({ model, workingDir, disableCliBypass }) {
-      const args = [
-        '--tools', 'read,bash,edit,write,browser,web_search,ast_grep,ast_edit,lsp,debug,find,eval,search,task,ask',
-        '--no-title',
-      ];
+    buildArgs({ sessionId, resume, model, workingDir, disableCliBypass }) {
+      const sessionDir = ompSessionDir(sessionId);
+      const args = ['--no-title'];
+      if (resume) {
+        const transcript = ompTranscriptPath(sessionId);
+        if (transcript) args.push('--resume', transcript);
+      }
+      args.push('--session-dir', sessionDir);
       if (!disableCliBypass) {
         args.push('--approval-mode', 'yolo');
       }
@@ -140,11 +167,14 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
     // the reliable path.
     passesInitialPromptViaArgs: false,
 
-    // --continue resumes the latest local session.  No precise session-id
-    // mapping exists (gemini/opencode share this limitation), so this is
-    // best-effort convenience rather than guaranteed per-session resume.
-    buildResumeCommand() {
-      return 'omp --continue';
+    buildResumeCommand({ sessionId }) {
+      const transcript = ompTranscriptPath(sessionId);
+      if (!transcript) return null;
+      return `omp --resume ${shellQuote(transcript)} --session-dir ${shellQuote(ompSessionDir(sessionId))}`;
+    },
+
+    checkResumeTargetExists({ sessionId }) {
+      return ompTranscriptPath(sessionId) !== null;
     },
 
     async writeInput(pty: PtyHandle, content: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13261,6 +13261,15 @@ function getVersion(): string {
 
 const command = process.argv[2];
 
+const ROOT_FLEET_MUTATION_COMMANDS = new Set(['start', 'stop', 'restart', 'upgrade', 'update']);
+if (
+  ROOT_FLEET_MUTATION_COMMANDS.has(command ?? '')
+  && process.argv.slice(3).some(arg => arg === '--help' || arg === '-h')
+) {
+  showHelp();
+  process.exit(0);
+}
+
 // Workflow safety gate (Slice C0): a CLI invoked inside a workflow
 // subagent worker (BOTMUX_WORKFLOW=1, set by v3/ephemeral-pool) must not
 // trigger chat-facing effects, schedule mutations, or recursively authorize /

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1891,7 +1891,7 @@ function bumpStreamCardStatusRevision(ds: DaemonSession): void {
 /** Re-render a just-created starting card when a newer worker status arrived
  * during its POST. The turn id is forwarded to scheduleCardPatch so a late
  * patch from turn N cannot overwrite turn N+1's card. */
-function reconcilePostedStartingCard(ds: DaemonSession, turnId: string, revisionAtPost: number): void {
+function reconcilePostedStartingCard(ds: DaemonSession, turnId: string | undefined, revisionAtPost: number): void {
   if ((ds.streamCardStatusRevision ?? 0) === revisionAtPost) return;
   if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL || ds.streamCardPending) return;
   const botCfg = getBot(ds.larkAppId).config;
@@ -10203,8 +10203,10 @@ function setupWorkerHandlers(
         // in-flight. In that case CARD_POSTING_SENTINEL is already set — don't
         // POST a second card; the in-flight POST becomes this turn's card.
         if (ds.streamCardId === CARD_POSTING_SENTINEL) break;
+        const pendingNewTurn = !!ds.streamCardPending;
         const postingGeneration = ds.streamCardTurnGeneration ?? 0;
         const cardReplyTarget = captureStreamingCardReplyTarget(ds, msg.turnId);
+        const statusRevisionAtPost = ds.streamCardStatusRevision ?? 0;
         ds.streamCardId = CARD_POSTING_SENTINEL;
         try {
           ds.streamCardNonce = randomBytes(4).toString('hex');
@@ -10212,7 +10214,9 @@ function setupWorkerHandlers(
           // See PATCH-branch comment above re: lastScreenStatus preference.
           // For relay (kill+fork with surviving tmux/CLI), this avoids the
           // jarring "启动中" right after the M1 "已接力" announcement.
-          const initStatus = ds.usageLimit ? 'limited' : (ds.lastScreenStatus ?? 'starting');
+          const initStatus = pendingNewTurn
+            ? turnStartingCardStatus(ds, effectiveCliId)
+            : (ds.usageLimit ? 'limited' : (ds.lastScreenStatus ?? 'starting'));
           const streamCardJson = buildStreamingCard(
             ds.session.sessionId,
             sessionAnchorId(ds),
@@ -10274,6 +10278,9 @@ function setupWorkerHandlers(
           // resume where the CLI kept running), arm here — same authorized arm
           // point as the reuse branch, now that streamCardId is the real id.
           syncUsageRefreshTimer(ds);
+          if (!superseded) {
+            reconcilePostedStartingCard(ds, cardReplyTarget.turnId, statusRevisionAtPost);
+          }
           if (superseded && ds.streamCardPendingTurnId) {
             void postTurnStartingCard(ds, cb.sessionReply, ds.streamCardPendingTurnId);
           }

--- a/src/services/file-bridge-path.ts
+++ b/src/services/file-bridge-path.ts
@@ -15,6 +15,7 @@ import { cocoEventsPathForSession, findCocoSessionByPid } from './coco-transcrip
 import { findPiTranscriptByPid, findPiTranscriptBySessionId } from './pi-transcript.js';
 import { findGrokSessionByPid, findGrokUpdatesBySessionId } from './grok-transcript.js';
 import { findCursorTranscriptByChatId, findCursorTranscriptByPid } from './cursor-transcript.js';
+import { ompTranscriptPath } from '../adapters/cli/oh-my-pi.js';
 
 export interface FileBridgePathOpts {
   sessionId?: string;
@@ -48,6 +49,8 @@ function resolveBySessionId(cliId: string, sessionId: string, cwd?: string): str
     }
     case 'pi':
       return findPiTranscriptBySessionId(sessionId, cwd);
+    case 'oh-my-pi':
+      return ompTranscriptPath(sessionId) ?? undefined;
     case 'grok':
       return findGrokUpdatesBySessionId(sessionId, cwd);
     case 'traex':

--- a/src/services/local-cli-opener.ts
+++ b/src/services/local-cli-opener.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
 import { chmod, lstat, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { CliAdapter, CliId } from '../adapters/cli/types.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
@@ -186,7 +186,18 @@ function adoptedMetadata(ds: DaemonSession): AdoptedMetadata | undefined {
 }
 
 function quoteKnownResumeCommand(cliId: LocalCliId, raw: string): string | null {
-  if (cliId === 'oh-my-pi') return raw === 'omp --continue' ? raw : null;
+  if (cliId === 'oh-my-pi') {
+    const quotedPath = String.raw`'(?:[^']|'\\'')*'`;
+    const match = new RegExp(
+      `^omp --resume (${quotedPath}) --session-dir (${quotedPath})(?![\\s\\S])`,
+    ).exec(raw);
+    if (!match) return null;
+    const decodePath = (token: string): string | null => {
+      const value = token.slice(1, -1).split("'\\''").join("'");
+      return isAbsolute(value) && shellQuote(value) === token ? value : null;
+    };
+    return decodePath(match[1]) !== null && decodePath(match[2]) !== null ? raw : null;
+  }
   const prefix = `${RESUME_COMMAND_PREFIXES[cliId]} `;
   if (!raw.startsWith(prefix)) return null;
   const sid = raw.slice(prefix.length).trim();

--- a/src/services/omp-transcript.ts
+++ b/src/services/omp-transcript.ts
@@ -1,0 +1,272 @@
+/**
+ * Incremental reader for Oh My Pi's append-only session JSONL.
+ *
+ * OMP can append a plugin continuation immediately after an apparently final
+ * assistant `stop`. Therefore terminal assistant records remain provisional
+ * until a decisive later record or the worker's guarded quiet-tick flush.
+ */
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readSync,
+  statSync,
+} from 'node:fs';
+
+import type { CodexBridgeEvent } from './codex-transcript.js';
+
+export interface OmpProvisionalFinal {
+  event: CodexBridgeEvent;
+  /** Session-tree entry that supplied the provisional assistant terminal. */
+  entryId?: string;
+  /** Candidate plus metadata descendants, used to recognize same-lineage work. */
+  lineageIds: string[];
+}
+
+export interface OmpTranscriptState {
+  provisionalFinal?: OmpProvisionalFinal;
+}
+
+export interface OmpDrainResult {
+  events: CodexBridgeEvent[];
+  newOffset: number;
+  pendingTail: string;
+  state: OmpTranscriptState;
+}
+
+export interface OmpDrainOptions {
+  /** Worker-only: release a file-tail candidate after its guarded quiet probe. */
+  flushTrailingFinal?: boolean;
+}
+
+type OmpTerminalStopReason = 'stop' | 'length' | 'error' | 'aborted';
+
+function visibleText(content: unknown): string {
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const item of content) {
+    if (!item || typeof item !== 'object') continue;
+    if ((item as { type?: unknown }).type === 'text'
+      && typeof (item as { text?: unknown }).text === 'string') {
+      parts.push((item as { text: string }).text);
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+function hasToolCall(content: unknown): boolean {
+  return Array.isArray(content) && content.some(item =>
+    !!item
+    && typeof item === 'object'
+    && (item as { type?: unknown }).type === 'toolCall');
+}
+
+function terminalOutcome(stopReason: OmpTerminalStopReason): Pick<
+  CodexBridgeEvent,
+  'terminalStatus' | 'terminalErrorCode'
+> {
+  switch (stopReason) {
+    case 'stop':
+    case 'length':
+      return {};
+    case 'error':
+      return { terminalStatus: 'failed', terminalErrorCode: 'omp_turn_error' };
+    case 'aborted':
+      return { terminalStatus: 'ambiguous', terminalErrorCode: 'omp_turn_aborted' };
+  }
+}
+
+function timestampMs(entry: Record<string, unknown>, message?: Record<string, unknown>): number {
+  if (typeof entry.timestamp === 'string') {
+    const parsed = Date.parse(entry.timestamp);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  if (typeof message?.timestamp === 'number' && Number.isFinite(message.timestamp)) {
+    return message.timestamp;
+  }
+  return Date.now();
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isExplicitContinuation(entry: Record<string, unknown>, message?: Record<string, unknown>): boolean {
+  const customType = stringField(entry.customType) ?? stringField(message?.customType);
+  return customType === 'prewalk-continue';
+}
+
+function candidateTracksParent(
+  candidate: OmpProvisionalFinal,
+  parentId: string | undefined,
+): boolean {
+  return !!parentId && candidate.lineageIds.includes(parentId);
+}
+
+function addMetadataDescendant(
+  candidate: OmpProvisionalFinal,
+  entryId: string | undefined,
+  parentId: string | undefined,
+): OmpProvisionalFinal {
+  if (!entryId || !candidateTracksParent(candidate, parentId)
+    || candidate.lineageIds.includes(entryId)) return candidate;
+  return { ...candidate, lineageIds: [...candidate.lineageIds, entryId] };
+}
+
+function cloneState(state: OmpTranscriptState | undefined): OmpTranscriptState {
+  const candidate = state?.provisionalFinal;
+  return candidate
+    ? { provisionalFinal: { ...candidate, event: { ...candidate.event }, lineageIds: [...candidate.lineageIds] } }
+    : {};
+}
+
+/**
+ * Drain only complete JSONL lines. The returned byte offset never includes a
+ * partial tail, so the worker can use offset equality as its quiet-cycle clock.
+ */
+export function drainOmpTranscript(
+  path: string,
+  fromOffset: number,
+  previousState: OmpTranscriptState = {},
+  options: OmpDrainOptions = {},
+): OmpDrainResult {
+  if (!existsSync(path)) {
+    return { events: [], newOffset: 0, pendingTail: '', state: {} };
+  }
+
+  let size: number;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return { events: [], newOffset: fromOffset, pendingTail: '', state: cloneState(previousState) };
+  }
+
+  const truncated = size < fromOffset;
+  const start = truncated ? 0 : fromOffset;
+  let state = truncated ? {} : cloneState(previousState);
+  const events: CodexBridgeEvent[] = [];
+
+  let completeText = '';
+  let pendingTail = '';
+  let newOffset = start;
+  if (size > start) {
+    const length = size - start;
+    const buffer = Buffer.alloc(length);
+    const fd = openSync(path, 'r');
+    try {
+      readSync(fd, buffer, 0, length, start);
+    } finally {
+      closeSync(fd);
+    }
+    const text = buffer.toString('utf8');
+    const lastNewline = text.lastIndexOf('\n');
+    completeText = lastNewline >= 0 ? text.slice(0, lastNewline + 1) : '';
+    pendingTail = lastNewline >= 0 ? text.slice(lastNewline + 1) : text;
+    newOffset = start + Buffer.byteLength(completeText, 'utf8');
+  }
+
+  let cursor = start;
+  for (const line of completeText.split('\n')) {
+    if (line.length === 0) {
+      cursor += 1;
+      continue;
+    }
+    const lineStart = cursor;
+    cursor += Buffer.byteLength(line, 'utf8') + 1;
+
+    let entry: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(line);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
+      entry = parsed as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const entryId = stringField(entry.id);
+    const parentId = stringField(entry.parentId);
+    const message = entry.message && typeof entry.message === 'object' && !Array.isArray(entry.message)
+      ? entry.message as Record<string, unknown>
+      : undefined;
+    const role = stringField(message?.role);
+    let candidate = state.provisionalFinal;
+
+    if (entry.type !== 'message') {
+      if (candidate && candidateTracksParent(candidate, parentId)) {
+        if (isExplicitContinuation(entry)) {
+          state = {};
+        } else {
+          // Title/model/compaction/custom metadata cannot settle a candidate,
+          // but retaining its id keeps later child activity lineage-aware.
+          state = { provisionalFinal: addMetadataDescendant(candidate, entryId, parentId) };
+        }
+      }
+      continue;
+    }
+    if (!message) continue;
+
+    if (role === 'user') {
+      const steering = message.steering === true;
+      if (candidate) {
+        if (steering) {
+          // OMP folded this user message into the active loop. The old stop was
+          // intermediate; CodexBridgeQueue will HOL-drop it when this user starts.
+          state = {};
+        } else {
+          // An ordinary next user proves the prior loop ended. Emit its terminal
+          // before the new user so FIFO non-steered turns remain interleaved.
+          events.push(candidate.event);
+          state = {};
+        }
+      }
+      const text = visibleText(message.content);
+      if (text) {
+        events.push({
+          uuid: `${path}:${lineStart}`,
+          timestampMs: timestampMs(entry, message),
+          kind: 'user',
+          text,
+        });
+      }
+      continue;
+    }
+
+    const sameLineage = !!candidate && candidateTracksParent(candidate, parentId);
+    if (sameLineage && (role === 'assistant' || role === 'toolResult'
+      || role === 'bashExecution' || role === 'pythonExecution'
+      || isExplicitContinuation(entry, message))) {
+      state = {};
+      candidate = undefined;
+    }
+
+    if (role !== 'assistant') continue;
+    const stopReason = stringField(entry.stopReason) ?? stringField(message.stopReason);
+    const isHardTerminal = stopReason === 'error' || stopReason === 'aborted';
+    const isTextTerminal = (stopReason === 'stop' || stopReason === 'length')
+      && !hasToolCall(message.content);
+    if (!isHardTerminal && !isTextTerminal) continue;
+
+    const event: CodexBridgeEvent = {
+      uuid: `${path}:${lineStart}`,
+      timestampMs: timestampMs(entry, message),
+      kind: 'assistant_final',
+      text: visibleText(message.content),
+      ...terminalOutcome(stopReason as OmpTerminalStopReason),
+    };
+    state = {
+      provisionalFinal: {
+        event,
+        entryId,
+        lineageIds: entryId ? [entryId] : [],
+      },
+    };
+  }
+
+  if (options.flushTrailingFinal && state.provisionalFinal) {
+    events.push(state.provisionalFinal.event);
+    state = {};
+  }
+
+  return { events, newOffset, pendingTail, state };
+}

--- a/src/services/structured-bridge-clis.ts
+++ b/src/services/structured-bridge-clis.ts
@@ -23,6 +23,7 @@ export const STRUCTURED_BRIDGE_ALWAYS_CLI_IDS = [
   'hermes',
   'mtr',
   'pi',
+  'oh-my-pi',
   'grok',
 ] as const satisfies readonly CliId[];
 
@@ -55,7 +56,9 @@ const ADOPT_SET: ReadonlySet<string> = new Set(STRUCTURED_BRIDGE_ADOPT_CLI_IDS);
  *  stop/length-without-toolcall and on the hard error/aborted edges (verified
  *  against pi 0.84.2: `terminate:true` is still not persisted and the newer
  *  pending/deferred StopReasons never reach the session JSONL), so a started
- *  Pi turn may suppress the screen-ready heuristic. Accepted gap: a custom
+ *  Pi turn may suppress the screen-ready heuristic. OMP additionally retains
+ *  terminal records provisionally until a decisive record or guarded quiet
+ *  tick proves no plugin continuation follows. Accepted gap: a custom
  *  tool returning `terminate:true` leaves a started turn with no on-disk
  *  terminal — the card stays working until the NEXT user turn's transcript
  *  user event HOL-drops the unclosed head (botmux ships no such tool; same
@@ -70,6 +73,7 @@ const ADOPT_SET: ReadonlySet<string> = new Set(STRUCTURED_BRIDGE_ADOPT_CLI_IDS);
 export const STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS = [
   'codex',
   'pi',
+  'oh-my-pi',
   'grok',
 ] as const satisfies readonly CliId[];
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -194,6 +194,7 @@ import { currentHermesStateOffset, drainHermesStateDb, resolveHermesStateDbPath 
 import { filterHermesEventsForBotmuxSession } from './services/hermes-session-filter.js';
 import { currentMtrSessionOffset, drainMtrSession, findLatestMtrSessionByDirectory, findMtrSessionById, type MtrTranscriptSource } from './services/mtr-transcript.js';
 import { drainPiTranscript } from './services/pi-transcript.js';
+import { drainOmpTranscript, type OmpTranscriptState } from './services/omp-transcript.js';
 import {
   drainGrokUpdates,
   findGrokSessionByPid,
@@ -1779,6 +1780,7 @@ const adoptWriteQueue = new AsyncSerialQueue();
  *  adapter's hermesBridgeAttach reads the correct mode. */
 let lastSpawnEffectiveResume = false;
 let lastSpawnEffectiveCliSessionId: string | undefined;
+let lastSpawnEffectiveAdapterSessionId: string | undefined;
 let lastSpawnDeferInitialPrompt = false;
 let lastSpawnQueuedInitialPrompt: string | undefined;
 let lastSpawnQueuedInitialPromptLogicalContent: string | undefined;
@@ -4152,6 +4154,10 @@ let activeRuntimePublished = false;
 const codexBridgeQueue = new CodexBridgeQueue();
 let codexBridgeWatcher: FSWatcher | null = null;
 let codexBridgeTimer: NodeJS.Timeout | null = null;
+let ompBridgeState: OmpTranscriptState = {};
+let ompQuietCandidateKey: string | undefined;
+let ompQuietCandidateCompleteOffset: number | undefined;
+const ompRetiredTranscriptPaths = new Set<string>();
 /** Settings are observed on the same append-only cursor as bridge output.
  *  The tracker owns rollout-generation clear/update semantics and publishes a
  *  dedicated IPC event, independent of PTY redraw frequency. */
@@ -5779,6 +5785,10 @@ function structuredBridgeIsPi(): boolean {
   return lastInitConfig?.cliId === 'pi';
 }
 
+function structuredBridgeIsOmp(): boolean {
+  return lastInitConfig?.cliId === 'oh-my-pi';
+}
+
 function structuredBridgeIsGrok(): boolean {
   return lastInitConfig?.cliId === 'grok';
 }
@@ -5791,7 +5801,11 @@ function currentHermesBridgeDbPath(): string {
   return hermesBridgeDbPath ?? resolveHermesStateDbPath();
 }
 
-function structuredBridgeIngestPath(path: string, offset: number) {
+function structuredBridgeIngestPath(
+  path: string,
+  offset: number,
+  opts: { flushOmpTrailingFinal?: boolean } = {},
+) {
   if (structuredBridgeIsCodex()) return drainCodexRollout(path, offset);
   // adoptMode gates the drainer's bare-sentinel synthesis: adopt posts
   // transcript text verbatim, so a synthesised token would leak into Lark.
@@ -5800,6 +5814,13 @@ function structuredBridgeIngestPath(path: string, offset: number) {
   }
   if (codexBridgeIsCursor()) return drainCursorTranscript(path, offset);
   if (structuredBridgeIsPi()) return drainPiTranscript(path, offset);
+  if (structuredBridgeIsOmp()) {
+    const result = drainOmpTranscript(path, offset, ompBridgeState, {
+      flushTrailingFinal: opts.flushOmpTrailingFinal,
+    });
+    ompBridgeState = result.state;
+    return result;
+  }
   if (structuredBridgeIsGrok()) return drainGrokUpdates(path, offset);
   if (structuredBridgeIsHermes()) {
     const result = drainHermesStateDb(offset, currentHermesBridgeDbPath());
@@ -5887,6 +5908,7 @@ function codexBridgeStartTimer(): void {
       // fd is process-scoped, so following that fd cannot select a sibling
       // TRAE process merely because it shares the working directory.
       maybeFollowTraexSessionRotationViaPid();
+      maybeFollowOmpTranscriptRotation();
       if (!codexBridgeRolloutPath) {
         // Late-attach: cliSessionId (writeInput / daemon probe) then adopt
         // pid. Path lookup is centralized in resolveFileBridgePath so
@@ -5925,6 +5947,7 @@ function codexBridgeStartTimer(): void {
         }
       }
       codexBridgeIngest();
+      maybeFlushOmpTrailingFinalOnQuietTick();
       if (isPromptReady) emitReadyCodexTurns();
     } catch (err: any) {
       log(`Codex bridge tick error: ${err.message}`);
@@ -6021,6 +6044,9 @@ function mtrBridgeIngest(): void {
 }
 
 function codexBridgeAttach(rolloutPath: string, mode: 'baseline-existing' | 'baseline-existing-skip-tail' | 'fresh-empty' | 'split-live'): void {
+  ompBridgeState = {};
+  ompQuietCandidateKey = undefined;
+  ompQuietCandidateCompleteOffset = undefined;
   codexBridgeRolloutPath = rolloutPath;
   if (structuredBridgeIsCodex()) codexServiceTierTracker.bind(rolloutPath);
   if (mode === 'fresh-empty') {
@@ -6192,6 +6218,9 @@ function codexBridgeDetachFile(): void {
   codexBridgeOffset = 0;
   codexBridgePendingTail = '';
   codexBridgeBaselineDone = false;
+  ompBridgeState = {};
+  ompQuietCandidateKey = undefined;
+  ompQuietCandidateCompleteOffset = undefined;
 }
 
 /** Resolve the pid of the Codex process this worker observes (spawned child or
@@ -6515,9 +6544,32 @@ function maybeFollowTraexSessionRotationViaPid(): void {
   codexBridgeNotifyCliSessionId(observed.cliSessionId);
 }
 
+/** OMP may create a new JSONL in the same isolated Botmux session directory.
+ * Follow only that exact directory; no pid/global-session discovery is used. */
+function maybeFollowOmpTranscriptRotation(): void {
+  if (!structuredBridgeIsOmp() || !codexBridgeRolloutPath
+    || !lastSpawnEffectiveAdapterSessionId) return;
+  const next = resolveFileBridgePath('oh-my-pi', {
+    sessionId: lastSpawnEffectiveAdapterSessionId,
+  });
+  if (!next || next === codexBridgeRolloutPath || ompRetiredTranscriptPaths.has(next)) return;
+  const retired = codexBridgeRolloutPath;
+  try {
+    codexBridgeIngest();
+    emitReadyCodexTurns();
+  } catch (err: any) {
+    log(`OMP pre-rotation bridge drain failed: ${err.message}`);
+  }
+  log(`OMP transcript rotated: ${codexBridgeRolloutPath} → ${next}`);
+  ompRetiredTranscriptPaths.add(retired);
+  codexBridgeDetachFile();
+  codexBridgeAttach(next, 'fresh-empty');
+}
+
 function codexBridgeIngest(opts: {
   signalIdle?: boolean;
   hydrationOwnerKey?: string;
+  flushOmpTrailingFinal?: boolean;
 } = {}): void {
   // Follow-up RPC turns install their exact bridge mark only after the
   // turn/start ACK passes the generation fence. Ordinary ingest must not
@@ -6537,7 +6589,9 @@ function codexBridgeIngest(opts: {
     return;
   }
   if (!codexBridgeRolloutPath || !codexBridgeBaselineDone) return;
-  const result = structuredBridgeIngestPath(codexBridgeRolloutPath, codexBridgeOffset);
+  const result = structuredBridgeIngestPath(codexBridgeRolloutPath, codexBridgeOffset, {
+    flushOmpTrailingFinal: opts.flushOmpTrailingFinal,
+  });
   codexBridgeOffset = result.newOffset;
   codexBridgePendingTail = result.pendingTail;
   if (structuredBridgeIsTraex()) {
@@ -6571,6 +6625,40 @@ function codexBridgeIngest(opts: {
   if (opts.signalIdle !== false && result.events.some(event => event.kind === 'assistant_final')) {
     idleDetector?.fireIdle();
   }
+}
+
+/** Confirm an OMP file-tail terminal only after one complete quiet bridge tick
+ * and an authoritative current viewport with no busy marker. This deliberately
+ * runs while lifecycle blocking is asserted; ingesting the final releases it. */
+function maybeFlushOmpTrailingFinalOnQuietTick(): void {
+  if (!structuredBridgeIsOmp()) return;
+  const candidate = ompBridgeState.provisionalFinal;
+  if (!candidate) {
+    ompQuietCandidateKey = undefined;
+    ompQuietCandidateCompleteOffset = undefined;
+    return;
+  }
+  const key = candidate.event.uuid;
+  if (ompQuietCandidateKey !== key
+    || ompQuietCandidateCompleteOffset !== codexBridgeOffset) {
+    ompQuietCandidateKey = key;
+    ompQuietCandidateCompleteOffset = codexBridgeOffset;
+    return;
+  }
+  if (codexBridgePendingTail || !hasStructuredLifecycleBlock() || !backend
+    || !backendScreenEvidenceIsAuthoritativeForMutation()
+    || !cliAdapter?.busyPattern) return;
+  try {
+    const screen = captureBackendScreen(backend);
+    if (!screen || cliAdapter.busyPattern.test(busyProbeRegion(screen))) return;
+  } catch (err: any) {
+    log(`OMP quiet-final viewport capture failed: ${err.message}`);
+    return;
+  }
+
+  ompQuietCandidateKey = undefined;
+  ompQuietCandidateCompleteOffset = undefined;
+  codexBridgeIngest({ flushOmpTrailingFinal: true });
 }
 
 /** 将 Codex 的结构化 429 终态同步为既有的限流状态。 */
@@ -7148,6 +7236,10 @@ function stopCodexBridge(): void {
   codexBridgeOffset = 0;
   codexBridgePendingTail = '';
   codexBridgeBaselineDone = false;
+  ompBridgeState = {};
+  ompQuietCandidateKey = undefined;
+  ompQuietCandidateCompleteOffset = undefined;
+  ompRetiredTranscriptPaths.clear();
   hermesBridgeOffset = 0;
   hermesBridgeBaselineDone = false;
   hermesBridgeSourceSessionId = undefined;
@@ -13241,6 +13333,8 @@ async function spawnCli(
   // the fresh session's first turn.
   lastSpawnEffectiveResume = effectiveResume;
   lastSpawnEffectiveCliSessionId = effectiveCliSessionId;
+  lastSpawnEffectiveAdapterSessionId = effectiveAdapterSessionId;
+  ompRetiredTranscriptPaths.clear();
 
   // ttadk 网关：模型走 ttadk 自己的 `-m`（启动期注入到 ttadk 前缀，见下方 wrapperCli
   // 分支），不能再把 cfg.model 透给底层适配器，否则真实 CLI 会再吃一个 --model 重复。
@@ -15036,7 +15130,7 @@ async function spawnCli(
     } else {
       codexBridgeStartTimer();
     }
-  } else if (cfg.cliId === 'pi' || cfg.cliId === 'grok') {
+  } else if (cfg.cliId === 'pi' || cfg.cliId === 'grok' || cfg.cliId === 'oh-my-pi') {
     // File-backed: pin path when known (pi session id / grok --session-id
     // UUID), else arm the poller. Grok collision-fallback (dir already
     // exists → no --session-id → grok mints id) is recovered via writeInput
@@ -15180,7 +15274,8 @@ async function spawnCli(
       // itself fail-opens on non-authoritative screens (ZMX), so a stale
       // `Working...` in ZMX history can never block a structured terminal.
       const busyGuardedIdle = evidenceSource === 'screen'
-        || (evidenceSource === 'external' && structuredBridgeIsPi());
+        || (evidenceSource === 'external'
+          && (structuredBridgeIsPi() || structuredBridgeIsOmp()));
       if (busyGuardedIdle && idleBackend
         && deferPromptReadyWhileBusy(`${cliName()} ${evidenceSource}-idle`, idleBackend)) return;
       drainBridgesThenMarkReady(evidenceSource);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,7 +15,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { accessSync, chmodSync, mkdirSync, writeFileSync, unlinkSync, rmdirSync, existsSync, statSync, lstatSync, readdirSync, readlinkSync, readFileSync, realpathSync, copyFileSync, watch as fsWatch, createWriteStream, openSync, closeSync, fstatSync, constants as fsConstants, type FSWatcher, type WriteStream } from 'node:fs';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
-import { join, basename, dirname, delimiter } from 'node:path';
+import { join, basename, dirname, delimiter, relative } from 'node:path';
 import { resolveBotmuxWrapperBinDir, prependBotmuxBin } from './core/botmux-wrapper.js';
 import { homedir, tmpdir, userInfo } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -259,6 +259,7 @@ import { delay } from './utils/timing.js';
 import { claudeJsonlPathForSession, resolveJsonlFromPid, findOpenClaudeSessionIds, syncClaudeResumeTargetToCwd, DEFAULT_CLAUDE_DATA_DIR } from './adapters/cli/claude-code.js';
 import { sessionReadyHookCommand } from './adapters/hook-command.js';
 import { mtrSessionIdForBotmuxSession } from './adapters/cli/mtr.js';
+import { ompSessionDir } from './adapters/cli/oh-my-pi.js';
 import type { CliAdapter, PtyHandle, SubmitRecheckResult, CliId } from './adapters/cli/types.js';
 import { strictInputHandle } from './adapters/cli/strict-input-handle.js';
 import { PtyBackend } from './adapters/backend/pty-backend.js';
@@ -13748,6 +13749,25 @@ async function spawnCli(
       return p; // not even '/' resolved (impossible) → lexical fallback
     };
 
+    // OMP keeps all transcripts under one shared state root. Materialize this
+    // Botmux session's exact directory before allow-path existence filtering;
+    // the policy below masks the shared sessions parent and re-opens only this
+    // deeper directory read-write.
+    const ompCurrentSessionDir = cliAdapter.id === 'oh-my-pi'
+      ? ompSessionDir(effectiveAdapterSessionId)
+      : undefined;
+    if (ompCurrentSessionDir) mkdirSync(ompCurrentSessionDir, { recursive: true, mode: 0o700 });
+    const canonicalOmpSessionsRoot = ompCurrentSessionDir
+      ? canonical(dirname(dirname(ompCurrentSessionDir)))
+      : undefined;
+    const canonicalOmpSessionDir = ompCurrentSessionDir
+      ? canonical(ompCurrentSessionDir)
+      : undefined;
+    if (canonicalOmpSessionsRoot && canonicalOmpSessionDir
+      && relative(canonicalOmpSessionsRoot, canonicalOmpSessionDir) !== join('botmux', effectiveAdapterSessionId)) {
+      throw new Error('[sandbox] OMP session directory escapes its managed sessions root');
+    }
+
     // User three-tier lists: the new sandboxPaths field, or a pre-migration
     // session/config's legacy fields mapped through the SAME lossless mapping
     // the startup migration uses.
@@ -13855,6 +13875,9 @@ async function spawnCli(
     // the child can't see them.
     if (process.platform === 'linux') {
       mandatoryDenyPaths.push(join(canonical(dataDir), 'sandboxes', cfg.sessionId));
+    }
+    if (canonicalOmpSessionsRoot) {
+      mandatoryDenyPaths.push(canonicalOmpSessionsRoot);
     }
     if (process.platform === 'darwin') {
       const osUserHomeDir = userInfo().homedir;
@@ -14085,7 +14108,7 @@ async function spawnCli(
       ]),
       botmuxInstallRoot,
       outbox,
-      extraWritePaths: keepExisting([process.env.TMPDIR]),
+      extraWritePaths: keepExisting([process.env.TMPDIR, canonicalOmpSessionDir]),
       userPaths,
       mandatoryDenyPaths,
       mandatoryDenyRegexes,

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1012,6 +1012,11 @@ describe('oh-my-pi buildArgs', () => {
     expect(adapter.passesInitialPromptViaArgs).toBe(false);
     expect(adapter.altScreen).toBe(true);
     expect(adapter.authPaths).toEqual(['~/.omp/agent']);
+    expect(adapter.supportsTypeAhead).toBe(true);
+    expect(adapter.busyPattern?.test('Working...')).toBe(true);
+    expect(adapter.busyPattern?.test('Working…')).toBe(true);
+    expect(adapter.mergeQueuedInput).not.toBe(true);
+    expect(adapter.reliableTurnTerminal).not.toBe(true);
   });
 
   it('does not include --session-id (oh-my-pi has none)', () => {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mkdirSync, rmSync, appendFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, appendFileSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { codexHome } from '../src/services/codex-paths.js';
 
 // ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ import { createMirAdapter } from '../src/adapters/cli/mir.js';
 import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
-import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
+import { createOhMyPiAdapter, ompSessionDir } from '../src/adapters/cli/oh-my-pi.js';
 import { createKimiAdapter } from '../src/adapters/cli/kimi.js';
 import { createGrokAdapter } from '../src/adapters/cli/grok.js';
 import { createKiroCliAdapter } from '../src/adapters/cli/kiro-cli.js';
@@ -985,24 +985,85 @@ describe('pi buildArgs', () => {
 
 describe('oh-my-pi buildArgs', () => {
   const adapter = createOhMyPiAdapter('/usr/bin/omp');
+  let home: string;
 
-  it('launches omp TUI with tools, approval-mode, and no-title', () => {
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'botmux-omp-adapter-'));
+    vi.stubEnv('HOME', home);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('launches an isolated omp TUI with runtime-default tools, approval-mode, and no-title', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-omp', resume: false, initialPrompt: 'hello omp' });
     expect(adapter.resolvedBin).toBe('/usr/bin/omp');
-    expect(args).toContain('--tools');
-    expect(args).toContain('read,bash,edit,write,browser,web_search,ast_grep,ast_edit,lsp,debug,find,eval,search,task,ask');
+    expect(args).not.toContain('--tools');
+    expect(args.join(' ')).not.toMatch(/browser|ast_grep/);
     expect(args).toContain('--approval-mode');
     expect(args[args.indexOf('--approval-mode') + 1]).toBe('yolo');
     expect(args).toContain('--no-title');
+    expect(args[args.indexOf('--session-dir') + 1]).toBe(ompSessionDir('sess-omp'));
+    expect(args).not.toContain('--resume');
+    expect(args).not.toContain('--continue');
     expect(args).not.toContain('hello omp');
     expect(adapter.passesInitialPromptViaArgs).toBe(false);
     expect(adapter.altScreen).toBe(true);
+    expect(adapter.authPaths).toEqual(['~/.omp/agent']);
   });
 
   it('does not include --session-id (oh-my-pi has none)', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-omp', resume: false });
     expect(args).not.toContain('--session-id');
-    expect(args).not.toContain('sess-omp');
+  });
+
+  it('rejects path-like session ids instead of escaping the managed OMP root', () => {
+    expect(() => ompSessionDir('../sibling')).toThrow('Invalid Botmux session id for OMP');
+    expect(() => ompSessionDir('nested/session')).toThrow('Invalid Botmux session id for OMP');
+  });
+
+  it('uses the canonical home path when HOME is a symlink', () => {
+    const realHome = join(home, "real'home");
+    const linkedHome = join(home, 'linked-home');
+    mkdirSync(realHome);
+    symlinkSync(realHome, linkedHome, 'dir');
+    vi.stubEnv('HOME', linkedHome);
+
+    const expected = join(realpathSync(realHome), '.omp', 'agent', 'sessions', 'botmux', 'sess-linked');
+    expect(ompSessionDir('sess-linked')).toBe(expected);
+    const args = adapter.buildArgs({ sessionId: 'sess-linked', resume: false });
+    expect(args[args.indexOf('--session-dir') + 1]).toBe(expected);
+  });
+
+  it('resumes the newest top-level JSONL exactly and ignores nested transcripts', () => {
+    const sessionDir = ompSessionDir('sess-omp');
+    const nestedDir = join(sessionDir, 'nested');
+    mkdirSync(nestedDir, { recursive: true });
+    const older = join(sessionDir, 'older.jsonl');
+    const newest = join(sessionDir, 'newest.jsonl');
+    const nested = join(nestedDir, 'not-a-candidate.jsonl');
+    writeFileSync(older, '{}\n');
+    writeFileSync(newest, '{}\n');
+    writeFileSync(nested, '{}\n');
+    utimesSync(older, new Date(1_000), new Date(1_000));
+    utimesSync(newest, new Date(2_000), new Date(2_000));
+    utimesSync(nested, new Date(3_000), new Date(3_000));
+
+    const args = adapter.buildArgs({ sessionId: 'sess-omp', resume: true });
+    expect(args[args.indexOf('--resume') + 1]).toBe(newest);
+    expect(args[args.indexOf('--session-dir') + 1]).toBe(sessionDir);
+    expect(args).not.toContain('--continue');
+    expect(adapter.checkResumeTargetExists?.({ sessionId: 'sess-omp' })).toBe(true);
+    expect(adapter.buildResumeCommand?.({ sessionId: 'sess-omp' }))
+      .toBe(`omp --resume '${newest}' --session-dir '${sessionDir}'`);
+  });
+
+  it('fails the resume probe closed when the isolated directory has no transcript', () => {
+    mkdirSync(ompSessionDir('sess-omp'), { recursive: true });
+    expect(adapter.checkResumeTargetExists?.({ sessionId: 'sess-omp' })).toBe(false);
+    expect(adapter.buildResumeCommand?.({ sessionId: 'sess-omp' })).toBeNull();
   });
 
   it('omits --approval-mode yolo when disableCliBypass is true', () => {
@@ -1910,10 +1971,10 @@ describe('buildResumeCommand', () => {
       .toBe('pi --session-id bm-pi');
   });
 
-  it('oh-my-pi emits `omp --continue` (best-effort, ignores sessionId)', () => {
+  it('oh-my-pi returns null when its isolated exact transcript is absent', () => {
     const a = createOhMyPiAdapter('/bin/omp');
-    expect(a.buildResumeCommand?.({ sessionId: 'bm-omp', cliSessionId: 'ignored' }))
-      .toBe('omp --continue');
+    expect(a.buildResumeCommand?.({ sessionId: randomUUID(), cliSessionId: 'ignored' }))
+      .toBeNull();
   });
 
   it('copilot emits `copilot --resume <cliSessionId>` when known, null otherwise', () => {

--- a/test/cli-root-help.test.ts
+++ b/test/cli-root-help.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -38,6 +38,54 @@ describe('botmux root help workflow surface', () => {
       expect(stdout).not.toContain('template <run|resume|cancel|ls|tail|validate|show>');
       expect(stdout).not.toContain('v2 执行兼容面');
       expect(stdout).not.toContain('workflow <run|resume|cancel|ls|tail|validate|show>');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['start', '--help'],
+    ['start', '-h'],
+    ['stop', '--help'],
+    ['stop', '-h'],
+    ['restart', '--help'],
+    ['restart', '-h'],
+    ['upgrade', '--help'],
+    ['upgrade', '-h'],
+    ['update', '--help'],
+    ['update', '-h'],
+  ])('%s %s prints root help without fleet or package-manager side effects', (command, flag) => {
+    const home = mkdtempSync(join(tmpdir(), 'botmux-root-help-mutation-'));
+    const binDir = join(home, 'empty-bin');
+    const sentinel = join(home, 'mutation-sentinel');
+    mkdirSync(binDir);
+    writeFileSync(sentinel, 'untouched\n');
+    try {
+      const env = {
+        ...process.env,
+        HOME: home,
+        PATH: binDir,
+        SESSION_DATA_DIR: join(home, '.botmux', 'data'),
+        BOTS_CONFIG: join(home, '.botmux', 'bots.json'),
+      };
+      delete env.BOTMUX_WORKFLOW;
+      const before = readdirSync(home).sort();
+      const stdout = execFileSync(
+        process.execPath,
+        [
+          '--import',
+          'tsx',
+          fileURLToPath(new URL('../src/cli.ts', import.meta.url)),
+          command,
+          flag,
+        ],
+        { cwd: process.cwd(), env, encoding: 'utf-8' },
+      );
+
+      expect(stdout).toContain('botmux v');
+      expect(stdout).toContain('restart     重启 daemon');
+      expect(readdirSync(home).sort()).toEqual(before);
+      expect(readFileSync(sentinel, 'utf8')).toBe('untouched\n');
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/test/fs-policy-bwrap.e2e.test.ts
+++ b/test/fs-policy-bwrap.e2e.test.ts
@@ -22,12 +22,13 @@
  * file- vs dir-shaped denies, mode-000 the empty sources, pre-create missing
  * mask mountpoints, then invoke bwrap.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, rmdirSync, writeFileSync, mkdirSync, chmodSync, realpathSync, existsSync, statSync, lstatSync, readlinkSync } from 'node:fs';
+import { mkdtempSync, rmSync, rmdirSync, writeFileSync, mkdirSync, chmodSync, realpathSync, existsSync, statSync, lstatSync, readlinkSync, readFileSync, symlinkSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { buildFsPolicy, compileToBwrap } from '../src/adapters/cli/fs-policy.js';
+import { createOhMyPiAdapter, ompSessionDir } from '../src/adapters/cli/oh-my-pi.js';
 
 const bwrapUsable = process.platform === 'linux'
   && spawnSync('sh', ['-c', 'command -v bwrap'], { stdio: 'ignore' }).status === 0
@@ -224,6 +225,59 @@ d('bwrap three-tier enforcement (real bubblewrap)', () => {
     expect(run(args, `echo x > ${JSON.stringify(join(denied, 'evil'))} && echo WROTE`).out).not.toContain('WROTE');
     expect(existsSync(join(denied, 'evil'))).toBe(false);
     rmSync(denied, { recursive: true, force: true });
+  });
+
+  it('OMP state stays writable while only the current transcript directory is carved through the sessions mask', () => {
+    const realHome = join(S, 'omp-real-home');
+    const linkedHome = join(S, 'omp-linked-home');
+    mkdirSync(realHome);
+    symlinkSync(realHome, linkedHome, 'dir');
+    vi.stubEnv('HOME', linkedHome);
+    try {
+      const agentRoot = join(realpathSync(realHome), '.omp', 'agent');
+      const sessionsRoot = join(agentRoot, 'sessions');
+      const own = ompSessionDir('self');
+      const sibling = join(sessionsRoot, 'botmux/sibling');
+      const terminalSessions = join(agentRoot, 'terminal-sessions');
+      const siblingTranscript = join(sibling, 'secret.jsonl');
+      const breadcrumb = join(terminalSessions, 'pane');
+      expect(own).toBe(join(sessionsRoot, 'botmux/self'));
+      const adapterArgs = createOhMyPiAdapter('/usr/bin/omp').buildArgs({ sessionId: 'self', resume: false });
+      expect(adapterArgs[adapterArgs.indexOf('--session-dir') + 1]).toBe(own);
+
+      mkdirSync(own, { recursive: true });
+      mkdirSync(sibling, { recursive: true });
+      mkdirSync(terminalSessions, { recursive: true });
+      writeFileSync(join(agentRoot, 'agent.db'), 'state');
+      writeFileSync(join(agentRoot, 'agent.db-wal'), 'wal');
+      writeFileSync(join(agentRoot, 'config.yml'), 'config');
+      writeFileSync(siblingTranscript, 'SIBLING_SECRET');
+      writeFileSync(breadcrumb, `${join(S, 'proj')}\n${siblingTranscript}\nfresh\n`);
+
+      const { args } = build({
+        readWrite: [agentRoot, own],
+        deny: [sessionsRoot],
+      });
+      expect(args).toContain(own);
+
+      expect(run(args, `printf updated >> ${JSON.stringify(join(agentRoot, 'agent.db'))}`).status).toBe(0);
+      expect(readFileSync(join(agentRoot, 'agent.db'), 'utf8')).toContain('updated');
+      expect(run(args, `printf own > ${JSON.stringify(join(own, 'new.jsonl'))}`).status).toBe(0);
+      expect(readFileSync(join(own, 'new.jsonl'), 'utf8')).toBe('own');
+
+      const breadcrumbRead = run(args, `cat ${JSON.stringify(breadcrumb)}`);
+      expect(breadcrumbRead.status).toBe(0);
+      expect(breadcrumbRead.out).toContain(siblingTranscript);
+      const siblingRead = run(args, `cat ${JSON.stringify(siblingTranscript)}`);
+      expect(siblingRead.status).not.toBe(0);
+      expect(siblingRead.out).not.toContain('SIBLING_SECRET');
+
+      const other = join(sessionsRoot, 'botmux/other');
+      expect(run(args, `mkdir ${JSON.stringify(other)}`).status).not.toBe(0);
+      expect(existsSync(other)).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it('deny → allow → deny (4 layers): the DEEPEST deny is masked, secret unreadable+unwritable, middle carve-out still works', () => {

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../src/adapters/cli/fs-policy.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 import { createReasonixAdapter } from '../src/adapters/cli/reasonix.js';
+import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
 
 const ctx = (o: Partial<FsPolicyContext> = {}): FsPolicyContext => ({
   platform: 'darwin',
@@ -108,6 +109,49 @@ describe('mergeFsRules + accessForPath (the policy semantics)', () => {
 });
 
 describe('buildFsPolicy', () => {
+  it('isolates OMP transcripts while keeping shared agent state and only the current sid writable', () => {
+    const adapter = createOhMyPiAdapter('/usr/bin/omp');
+    const sessionsRoot = '/home/u/.omp/agent/sessions';
+    const ownSessionDir = `${sessionsRoot}/botmux/self`;
+    const p = buildFsPolicy(ctx({
+      platform: 'linux',
+      homeDir: '/home/u',
+      botHome: '/home/u/.botmux/bots/cli_self',
+      botmuxHome: '/home/u/.botmux',
+      sessionDataDir: '/home/u/.botmux/data',
+      workingDir: '/home/u/proj',
+      redirectedCliData: false,
+      authPaths: adapter.authPaths?.map(path => path.replace(/^~/, '/home/u')),
+      mandatoryDenyPaths: [sessionsRoot],
+      extraWritePaths: [ownSessionDir],
+    }));
+
+    for (const path of [
+      '/home/u/.omp/agent/agent.db',
+      '/home/u/.omp/agent/agent.db-wal',
+      '/home/u/.omp/agent/config.yml',
+      '/home/u/.omp/agent/terminal-sessions/pane',
+      `${ownSessionDir}/turn.jsonl`,
+    ]) {
+      expect(accessForPath(p.rules, path).access).toBe('readWrite');
+    }
+    expect(accessForPath(p.rules, sessionsRoot).access).toBe('deny');
+    expect(accessForPath(p.rules, `${sessionsRoot}/botmux/sibling/secret.jsonl`).access).toBe('deny');
+
+    const { args } = compileToBwrap(p, {
+      emptyDir: '/sbx/empty',
+      emptiesDir: '/sbx/empties',
+      chdir: '/home/u/proj',
+    });
+    const mask = args.indexOf(sessionsRoot);
+    const carve = args.indexOf(ownSessionDir);
+    expect(args[mask - 1]).toBe('--tmpfs');
+    expect(carve).toBeGreaterThan(mask);
+    expect(args[carve - 1]).toBe('--bind');
+    expect(args.lastIndexOf(sessionsRoot)).toBeGreaterThan(carve);
+    expect(args[args.lastIndexOf(sessionsRoot) - 1]).toBe('--remount-ro');
+  });
+
   it('reasonix state root is read-write so identity, sessions, leases and skills persist in sandbox', () => {
     const adapter = createReasonixAdapter('/usr/bin/reasonix');
     const p = buildFsPolicy(ctx({
@@ -607,6 +651,19 @@ describe('resolveRedirectedAdapterAuthPaths (redirect authPath suppression)', ()
     // (the #605 P1 namespace bug — canonical vs lexical divergence under symlinked $HOME).
     expect(src).not.toMatch(/declaredAuthPaths:\s*\[\.\.\.\(cliAdapter\.authPaths[\s\S]*?\)\]\.map\(expandTilde\)(?!Lexical)/);
     expect(src).not.toMatch(/isolatedCodexHome\s*\?\s*`\$\{sandboxHome\}\/\.codex`/);
+  });
+
+  it('WIRING GUARD: worker pre-creates and carves the same effective OMP sid used by launch/resume args', () => {
+    const src = readFileSync(resolve('src/worker.ts'), 'utf8');
+    expect(src).toContain("import { ompSessionDir } from './adapters/cli/oh-my-pi.js';");
+    expect(src).toMatch(/ompCurrentSessionDir\s*=\s*cliAdapter\.id === 'oh-my-pi'[\s\S]*?ompSessionDir\(effectiveAdapterSessionId\)/);
+    const precreate = src.indexOf('if (ompCurrentSessionDir) mkdirSync(ompCurrentSessionDir');
+    const policyAssembly = src.indexOf('const fsPolicyCtx =', precreate);
+    expect(precreate).toBeGreaterThan(-1);
+    expect(policyAssembly).toBeGreaterThan(precreate);
+    expect(src).toContain("relative(canonicalOmpSessionsRoot, canonicalOmpSessionDir) !== join('botmux', effectiveAdapterSessionId)");
+    expect(src).toContain('mandatoryDenyPaths.push(canonicalOmpSessionsRoot)');
+    expect(src).toContain('extraWritePaths: keepExisting([process.env.TMPDIR, canonicalOmpSessionDir])');
   });
 
   it('SYMLINKED-HOME regression (codex #605 P1): worker-assembly under /home/u → /data00/home/u keeps Claude/Codex dropped, Seed/Relay bytedcli kept', () => {

--- a/test/local-cli-opener.test.ts
+++ b/test/local-cli-opener.test.ts
@@ -80,7 +80,9 @@ describe('local-cli-opener', () => {
         session: { ...ds().session, cliId, cliSessionId: 'ses_nativeid' },
       }), {
         mode: 'resume',
-        adapterFactory: (id) => createCliAdapterSync(id, '/bin/echo'),
+        adapterFactory: (id) => id === 'oh-my-pi'
+          ? ({ buildResumeCommand: () => "omp --resume '/tmp/omp/turn.jsonl' --session-dir '/tmp/omp'" })
+          : createCliAdapterSync(id, '/bin/echo'),
       });
 
       expect(supportsLocalCliOpen(cliId)).toBe(true);
@@ -108,6 +110,39 @@ describe('local-cli-opener', () => {
       ok: true,
       command: "cd '/tmp/project'\\''s dir' && codex resume 'native'\\''id'",
     });
+  });
+
+  it('accepts only the exact shell-quoted OMP resume command shape', () => {
+    const session = ds({
+      session: { ...ds().session, cliId: 'oh-my-pi', cliSessionId: undefined },
+    });
+    const valid = "omp --resume '/tmp/omp/turn'\\''s.jsonl' --session-dir '/tmp/omp/session'\\''s'";
+    const accepted = buildLocalCliOpenCommand(session, {
+      mode: 'resume',
+      adapterFactory: () => ({ buildResumeCommand: () => valid }),
+    });
+    expect(accepted).toEqual({
+      ok: true,
+      command: `cd '/tmp/project'\\''s dir' && ${valid}`,
+    });
+
+    for (const raw of [
+      "omp --resume '/tmp/omp/turn.jsonl' --session-dir '/tmp/omp'; touch /tmp/pwn",
+      "omp --resume '/tmp/omp/turn.jsonl' --session-dir '/tmp/omp'\ntouch /tmp/pwn",
+      "omp --resume '/tmp/omp/turn.jsonl'",
+      "omp --session-dir '/tmp/omp' --resume '/tmp/omp/turn.jsonl'",
+      "omp --resume '/tmp/omp/turn.jsonl' --session-dir '/tmp/omp' --model extra",
+      "omp --resume /tmp/omp/turn.jsonl --session-dir '/tmp/omp'",
+      "omp --resume '/tmp/omp/turn.jsonl' --session-dir /tmp/omp",
+      "omp --resume 'tmp/omp/turn.jsonl' --session-dir '/tmp/omp'",
+      "omp --resume '$HOME/.omp/turn.jsonl' --session-dir '/tmp/omp'",
+    ]) {
+      const rejected = buildLocalCliOpenCommand(session, {
+        mode: 'resume',
+        adapterFactory: () => ({ buildResumeCommand: () => raw }),
+      });
+      expect(rejected).toMatchObject({ ok: false, error: 'missing_resume_id' });
+    }
   });
 
   it('uses the frozen configured Codex executable for local resume', () => {
@@ -442,7 +477,7 @@ describe('local-cli-opener', () => {
     expect(isLocalCliOpenReady(pending, { mode: 'resume', adapterFactory })).toBe(true);
   });
 
-  it('treats adopted ids and oh-my-pi continue as ready resume targets', () => {
+  it('treats adopted ids and oh-my-pi exact transcript paths as ready resume targets', () => {
     const adopted = ds({
       adoptedFrom: { source: 'tmux', tmuxTarget: 'dev:1.2', cliId: 'traex', cwd: '/repo', sessionId: 'adopt-native' },
       workingDir: undefined,
@@ -458,7 +493,9 @@ describe('local-cli-opener', () => {
     });
     expect(isLocalCliOpenReady(ohMyPi, {
       mode: 'resume',
-      adapterFactory: () => ({ buildResumeCommand: () => 'omp --continue' }),
+      adapterFactory: () => ({
+        buildResumeCommand: () => "omp --resume '/tmp/omp/turn.jsonl' --session-dir '/tmp/omp'",
+      }),
     })).toBe(true);
   });
 

--- a/test/omp-transcript.test.ts
+++ b/test/omp-transcript.test.ts
@@ -1,0 +1,248 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  drainOmpTranscript,
+  type OmpTranscriptState,
+} from '../src/services/omp-transcript.js';
+import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
+
+const ROOT = join(tmpdir(), `botmux-omp-transcript-${process.pid}`);
+const PATH = join(ROOT, 'session.jsonl');
+const TS = '2026-08-20T12:00:00.000Z';
+
+function entry(value: Record<string, unknown>): string {
+  return `${JSON.stringify(value)}\n`;
+}
+
+function message(
+  id: string,
+  parentId: string | null,
+  role: string,
+  content: unknown,
+  extra: Record<string, unknown> = {},
+): string {
+  return entry({
+    type: 'message',
+    id,
+    parentId,
+    timestamp: TS,
+    message: { role, content, ...extra },
+  });
+}
+
+function text(value: string): Array<{ type: 'text'; text: string }> {
+  return [{ type: 'text', text: value }];
+}
+
+beforeEach(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+  mkdirSync(ROOT, { recursive: true });
+  writeFileSync(PATH, '');
+});
+
+afterEach(() => rmSync(ROOT, { recursive: true, force: true }));
+
+describe('drainOmpTranscript', () => {
+  it('holds a trailing stop until an explicit quiet flush and emits it once', () => {
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('hello'))
+      + message('a1', 'u1', 'assistant', text('answer'), { stopReason: 'stop' }));
+
+    const first = drainOmpTranscript(PATH, 0);
+    expect(first.events.map(event => event.kind)).toEqual(['user']);
+    expect(first.state.provisionalFinal?.event.text).toBe('answer');
+
+    const quiet = drainOmpTranscript(PATH, first.newOffset, first.state, {
+      flushTrailingFinal: true,
+    });
+    expect(quiet.events).toMatchObject([{
+      kind: 'assistant_final',
+      text: 'answer',
+      uuid: `${PATH}:${Buffer.byteLength(message('u1', null, 'user', text('hello')))}`,
+    }]);
+    expect(quiet.state.provisionalFinal).toBeUndefined();
+
+    const repeated = drainOmpTranscript(PATH, quiet.newOffset, quiet.state, {
+      flushTrailingFinal: true,
+    });
+    expect(repeated.events).toEqual([]);
+  });
+
+  it('preserves a candidate across metadata but retracts it for a parent-linked continuation', () => {
+    const initial = message('u1', null, 'user', text('hello'))
+      + message('a1', 'u1', 'assistant', text('intermediate'), { stopReason: 'stop' });
+    appendFileSync(PATH, initial);
+    const first = drainOmpTranscript(PATH, 0);
+
+    appendFileSync(PATH,
+      entry({ type: 'title_change', id: 'm1', parentId: 'a1', timestamp: TS, title: 'metadata' })
+      + entry({
+        type: 'custom_message',
+        id: 'c1',
+        parentId: 'm1',
+        timestamp: TS,
+        customType: 'prewalk-continue',
+        content: 'continue',
+        display: false,
+      })
+      + message('a2', 'c1', 'assistant', text('real final'), { stopReason: 'stop' }));
+
+    const continued = drainOmpTranscript(PATH, first.newOffset, first.state);
+    expect(continued.events).toEqual([]);
+    expect(continued.state.provisionalFinal?.event.text).toBe('real final');
+    expect(continued.state.provisionalFinal?.event.uuid).toContain(':');
+  });
+
+  it('retracts an intermediate candidate on steering and attributes the merged final after FIFO users', () => {
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('first'))
+      + message('a1', 'u1', 'assistant', text('intermediate'), { stopReason: 'stop' })
+      + message('u2', 'a1', 'user', text('steer two'), { steering: true })
+      + message('u3', 'u2', 'user', text('steer three'), { steering: true })
+      + message('a2', 'u3', 'assistant', text('merged'), { stopReason: 'stop' }));
+
+    const result = drainOmpTranscript(PATH, 0);
+    expect(result.events.map(event => [event.kind, event.text])).toEqual([
+      ['user', 'first'],
+      ['user', 'steer two'],
+      ['user', 'steer three'],
+    ]);
+    expect(result.state.provisionalFinal?.event.text).toBe('merged');
+  });
+
+  it('feeds repeated steers to the existing queue so only the newest turn owns the merged final', () => {
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('first'))
+      + message('u2', 'u1', 'user', text('steer two'), { steering: true })
+      + message('u3', 'u2', 'user', text('steer three'), { steering: true })
+      + message('a1', 'u3', 'assistant', text('merged'), { stopReason: 'stop' }));
+
+    const drained = drainOmpTranscript(PATH, 0);
+    const flushed = drainOmpTranscript(PATH, drained.newOffset, drained.state, {
+      flushTrailingFinal: true,
+    });
+    const queue = new CodexBridgeQueue();
+    queue.mark('t1', 'first', 1);
+    queue.mark('t2', 'steer two', 1);
+    queue.mark('t3', 'steer three', 1);
+    queue.ingest([...drained.events, ...flushed.events]);
+
+    const ready = queue.drainEmittable();
+    expect(ready.map(turn => turn.turnId)).toEqual(['t3']);
+    expect(ready[0]?.finalText).toBe('merged');
+    expect(queue.size()).toBe(0);
+  });
+
+  it('releases a prior candidate before the next ordinary user', () => {
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('first'))
+      + message('a1', 'u1', 'assistant', text('first final'), { stopReason: 'stop' })
+      + message('u2', 'a1', 'user', text('second')));
+
+    const result = drainOmpTranscript(PATH, 0);
+    expect(result.events.map(event => [event.kind, event.text])).toEqual([
+      ['user', 'first'],
+      ['assistant_final', 'first final'],
+      ['user', 'second'],
+    ]);
+    expect(result.state.provisionalFinal).toBeUndefined();
+  });
+
+  it.each([
+    ['error', 'failed', 'omp_turn_error'],
+    ['aborted', 'ambiguous', 'omp_turn_aborted'],
+  ] as const)('keeps empty %s terminals as provisional %s outcomes', (stopReason, status, code) => {
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('hello'))
+      + message('a1', 'u1', 'assistant', [], { stopReason }));
+    const result = drainOmpTranscript(PATH, 0);
+    expect(result.state.provisionalFinal?.event).toMatchObject({
+      kind: 'assistant_final',
+      text: '',
+      terminalStatus: status,
+      terminalErrorCode: code,
+    });
+  });
+
+  it('keeps a tool-free length terminal provisional', () => {
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('hello'))
+      + message('a1', 'u1', 'assistant', text('truncated answer'), { stopReason: 'length' }));
+    const result = drainOmpTranscript(PATH, 0);
+    expect(result.state.provisionalFinal?.event).toMatchObject({
+      kind: 'assistant_final',
+      text: 'truncated answer',
+    });
+  });
+
+  it('treats toolUse and stop/length carrying tool calls as non-terminal', () => {
+    const toolCall = [{ type: 'toolCall', id: 'tool-1', name: 'bash', arguments: {} }];
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('hello'))
+      + message('a1', 'u1', 'assistant', toolCall, { stopReason: 'toolUse' })
+      + message('a2', 'a1', 'assistant', toolCall, { stopReason: 'stop' })
+      + message('a3', 'a2', 'assistant', toolCall, { stopReason: 'length' }));
+    const result = drainOmpTranscript(PATH, 0);
+    expect(result.events.map(event => event.kind)).toEqual(['user']);
+    expect(result.state.provisionalFinal).toBeUndefined();
+  });
+
+  it('does not advance past a partial JSONL tail and parses it exactly once after completion', () => {
+    const user = message('u1', null, 'user', text('hello'));
+    const assistant = message('a1', 'u1', 'assistant', text('done'), { stopReason: 'stop' });
+    appendFileSync(PATH, user + assistant.slice(0, -1));
+
+    const partial = drainOmpTranscript(PATH, 0);
+    expect(partial.events.map(event => event.kind)).toEqual(['user']);
+    expect(partial.newOffset).toBe(Buffer.byteLength(user));
+    expect(partial.pendingTail).not.toBe('');
+    expect(partial.state.provisionalFinal).toBeUndefined();
+
+    appendFileSync(PATH, '\n');
+    const completed = drainOmpTranscript(PATH, partial.newOffset, partial.state);
+    expect(completed.events).toEqual([]);
+    expect(completed.state.provisionalFinal?.event.text).toBe('done');
+  });
+
+  it('preserves metadata across drains and retracts on later same-lineage activity', () => {
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('hello'))
+      + message('a1', 'u1', 'assistant', text('intermediate'), { stopReason: 'stop' }));
+    const candidate = drainOmpTranscript(PATH, 0);
+
+    appendFileSync(PATH,
+      entry({ type: 'title_change', id: 'm1', parentId: 'a1', timestamp: TS, title: 'metadata' }));
+    const metadata = drainOmpTranscript(PATH, candidate.newOffset, candidate.state);
+    expect(metadata.events).toEqual([]);
+    expect(metadata.state.provisionalFinal?.event.text).toBe('intermediate');
+
+    appendFileSync(PATH,
+      message('tool1', 'm1', 'toolResult', text('continued work')));
+    const continued = drainOmpTranscript(PATH, metadata.newOffset, metadata.state);
+    expect(continued.events).toEqual([]);
+    expect(continued.state.provisionalFinal).toBeUndefined();
+  });
+
+  it('resets stale provisional state when the file truncates', () => {
+    appendFileSync(PATH,
+      message('u1', null, 'user', text('old'))
+      + message('a1', 'u1', 'assistant', text('old final'), { stopReason: 'stop' }));
+    const old = drainOmpTranscript(PATH, 0);
+    expect(old.state.provisionalFinal).toBeDefined();
+
+    truncateSync(PATH, 0);
+    appendFileSync(PATH, message('u2', null, 'user', text('new')));
+    const reset = drainOmpTranscript(PATH, old.newOffset, old.state as OmpTranscriptState);
+    expect(reset.events.map(event => event.text)).toEqual(['new']);
+    expect(reset.state.provisionalFinal).toBeUndefined();
+  });
+});

--- a/test/structured-bridge-clis.test.ts
+++ b/test/structured-bridge-clis.test.ts
@@ -19,8 +19,9 @@ import {
 import { resolveFileBridgePath } from '../src/services/file-bridge-path.js';
 
 describe('structured-bridge-clis', () => {
-  it('allowlists include grok; hermes stays out of the adopt-forward list', () => {
+  it('always-on includes OMP without widening adopt forwarding', () => {
     expect(STRUCTURED_BRIDGE_ALWAYS_CLI_IDS).toContain('grok');
+    expect(STRUCTURED_BRIDGE_ALWAYS_CLI_IDS).toContain('oh-my-pi');
     expect(STRUCTURED_BRIDGE_ADOPT_CLI_IDS).toContain('grok');
     expect(STRUCTURED_BRIDGE_ADOPT_CLI_IDS).toContain('cursor');
     // hermes is bridge-ALWAYS but must NOT be adopt-forwarded: it has no
@@ -31,9 +32,10 @@ describe('structured-bridge-clis', () => {
     expect(STRUCTURED_BRIDGE_ADOPT_CLI_IDS).not.toContain('hermes');
     expect(isStructuredBridgeAdoptCli('hermes')).toBe(false);
     for (const id of STRUCTURED_BRIDGE_ALWAYS_CLI_IDS) {
-      if (id === 'hermes') continue;
+      if (id === 'hermes' || id === 'oh-my-pi') continue;
       expect(STRUCTURED_BRIDGE_ADOPT_CLI_IDS).toContain(id);
     }
+    expect(STRUCTURED_BRIDGE_ADOPT_CLI_IDS).not.toContain('oh-my-pi');
   });
 
   it('fallback treats cursor as adopt-only', () => {
@@ -57,9 +59,10 @@ describe('structured-bridge-clis', () => {
     // started Pi turn may suppress the screen-ready heuristic (the custom-tool
     // terminate:true gap is accepted — next user turn HOL-drops the head).
     // grok: user_message_chunk → turn_completed with normalized stop reasons.
-    expect(STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS).toEqual(['codex', 'pi', 'grok']);
+    expect(STRUCTURED_BRIDGE_LIFECYCLE_BLOCKING_CLI_IDS).toEqual(['codex', 'pi', 'oh-my-pi', 'grok']);
     expect(isStructuredBridgeLifecycleBlockingCli('codex')).toBe(true);
     expect(isStructuredBridgeLifecycleBlockingCli('pi')).toBe(true);
+    expect(isStructuredBridgeLifecycleBlockingCli('oh-my-pi')).toBe(true);
     expect(isStructuredBridgeLifecycleBlockingCli('grok')).toBe(true);
     for (const id of ['traex', 'coco', 'hermes', 'mtr', 'cursor']) {
       expect(isStructuredBridgeLifecycleBlockingCli(id)).toBe(false);
@@ -90,5 +93,30 @@ describe('resolveFileBridgePath (grok)', () => {
     expect(resolveFileBridgePath('grok', { sessionId: sid, cwd })).toBe(updates);
     expect(resolveFileBridgePath('grok', { sessionId: sid })).toBe(updates); // walk
     expect(resolveFileBridgePath('grok', { sessionId: 'bbbbbbbb-bbbb-4ccc-8ddd-eeeeeeeeeeee', cwd })).toBeUndefined();
+  });
+});
+
+describe('resolveFileBridgePath (oh-my-pi)', () => {
+  const ROOT = join(tmpdir(), `botmux-fbp-omp-${process.pid}`);
+  const ORIGINAL_HOME = process.env.HOME;
+
+  beforeEach(() => {
+    process.env.HOME = ROOT;
+    rmSync(ROOT, { recursive: true, force: true });
+    mkdirSync(ROOT, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(ROOT, { recursive: true, force: true });
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+  });
+
+  it('resolves only the newest transcript inside the exact Botmux session directory', () => {
+    const dir = join(ROOT, '.omp', 'agent', 'sessions', 'botmux', 'sid-omp');
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'session.jsonl');
+    writeFileSync(path, '');
+    expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sid-omp' })).toBe(path);
+    expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sibling' })).toBeUndefined();
   });
 });

--- a/test/worker-argv-reaction-status.integration.test.ts
+++ b/test/worker-argv-reaction-status.integration.test.ts
@@ -101,7 +101,115 @@ function piTranscriptRecord(role: 'user' | 'assistant', text: string, stopReason
   }) + '\n';
 }
 
+function ompTranscriptRecord(
+  id: string,
+  parentId: string | null,
+  role: 'user' | 'assistant',
+  content: string,
+  stopReason?: string,
+): string {
+  return JSON.stringify({
+    type: 'message',
+    id,
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role,
+      content: content ? [{ type: 'text', text: content }] : [],
+      ...(stopReason ? { stopReason } : {}),
+    },
+  }) + '\n';
+}
+
 describe('worker argv reaction status', () => {
+  it('attaches a spawned OMP bridge and quiet-flushes one trailing final', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-omp-quiet-final-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    const sessionId = 'sid-worker-omp-quiet-final';
+    const transcriptDir = join(root, '.omp', 'agent', 'sessions', 'botmux', sessionId);
+    const transcriptPath = join(transcriptDir, 'session.jsonl');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(transcriptDir, { recursive: true });
+    writeFileSync(transcriptPath, '');
+
+    const fakeOmp = join(root, 'fake-omp');
+    writeFileSync(fakeOmp, `#!/usr/bin/env node
+process.stdout.write('OMP ready\\n');
+process.stdin.on('data', () => {
+  process.stdout.write('\\r\\u001b[2KWorking...');
+  setTimeout(() => process.stdout.write('\\r\\u001b[2KOMP ready\\n'), 3_000);
+});
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakeOmp, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: sessionId,
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => {
+      const message = raw as WorkerToDaemon;
+      messages.push(message);
+      if (message.type === 'error') logs.push(`worker error: ${message.message}\n`);
+    });
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId,
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'oh-my-pi',
+      cliPathOverride: fakeOmp,
+      backendType: 'pty',
+      prompt: '',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+    } satisfies DaemonToWorker);
+
+    await waitForLog(child, logs, 'Codex bridge fresh-empty:');
+    await waitForPromptReady(child, messages, logs);
+    child.send({
+      type: 'message',
+      content: 'ordinary OMP turn',
+      turnId: 'om_omp_turn',
+    } satisfies DaemonToWorker);
+    await waitForLog(child, logs, 'Writing to PTY (flush): "ordinary OMP turn');
+
+    appendFileSync(transcriptPath,
+      ompTranscriptRecord('u1', null, 'user', 'ordinary OMP turn')
+      + ompTranscriptRecord('a1', 'u1', 'assistant', 'OMP final answer', 'stop'));
+
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 2_200));
+    expect(messages.some(message =>
+      message.type === 'final_output' && message.turnId === 'om_omp_turn')).toBe(false);
+
+    const deadline = Date.now() + 8_000;
+    while (Date.now() < deadline && !messages.some(message =>
+      message.type === 'final_output' && message.turnId === 'om_omp_turn')) {
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 25));
+    }
+    const finals = messages.filter(message =>
+      message.type === 'final_output' && message.turnId === 'om_omp_turn');
+    expect(finals).toHaveLength(1);
+    expect(finals[0]).toMatchObject({ content: 'OMP final answer' });
+    expect(logs.join('')).toContain('Codex bridge fresh-empty:');
+  }, 20_000);
+
   it('keeps an argv-baked Pi turn working until its viewport loses Working...', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-worker-pi-busy-'));
     tempDirs.add(root);

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -36,6 +36,7 @@ vi.mock('../src/im/lark/card-builder.js', () => ({
   buildStreamingCard: vi.fn((...args: any[]) => JSON.stringify({
     type: 'streaming',
     readUrl: args[2],
+    status: args[5],
     localCliReady: args[15] === true,
     // Signature tail after the master merge: 15 localCliReady, 16 usage,
     // 17 runtimeDisplayName, 18 serviceTierBadge.
@@ -632,6 +633,7 @@ describe('Worker ready: set_display_mode re-sync', () => {
 
     // updateMessage should have been called (PATCH existing card)
     expect(updateMessageMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(updateMessageMock.mock.calls[0][2])).toMatchObject({ status: 'working' });
     // sessionReply should NOT be called (didn't fall through to POST)
     expect(sessionReplyMock).not.toHaveBeenCalled();
     // worker.send should be called with set_display_mode
@@ -874,11 +876,72 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(ds.streamCardPending).toBe(false);
   });
 
+  it('ready POST starts a pending turn busy and reconciles a working update received in flight', async () => {
+    let resolvePost!: (messageId: string) => void;
+    sessionReplyMock.mockImplementationOnce(() => new Promise<string>((resolve) => {
+      resolvePost = resolve;
+    }));
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      lastScreenStatus: 'idle',
+      streamCardPending: true,
+      streamCardPendingTurnId: 'om_turn_1',
+      streamCardId: undefined,
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', {
+      type: 'ready', port: 9999, token: 'tok_abc', turnId: 'om_turn_1',
+    });
+    await flush();
+
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(sessionReplyMock.mock.calls[0][1])).toMatchObject({ status: 'starting' });
+
+    fakeWorker.emit('message', {
+      type: 'screen_update',
+      content: 'working after cold resume',
+      status: 'working',
+      turnId: 'om_turn_1',
+    });
+    await flush();
+    expect(updateMessageMock).not.toHaveBeenCalled();
+
+    resolvePost('om_new_card');
+    await flush();
+    await flush();
+
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(ds.streamCardId).toBe('om_new_card');
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+    expect(updateMessageMock.mock.calls[0][1]).toBe('om_new_card');
+    expect(JSON.parse(updateMessageMock.mock.calls[0][2])).toMatchObject({ status: 'working' });
+  });
+
+  it('ready POST without a pending new turn preserves the last live status', async () => {
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      lastScreenStatus: 'idle',
+      streamCardPending: false,
+      streamCardId: undefined,
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(sessionReplyMock.mock.calls[0][1])).toMatchObject({ status: 'idle' });
+  });
+
   it('does not let an older ready POST consume a newer turn pending state', async () => {
     let resolveFirst!: (messageId: string) => void;
+    let resolveSecond!: (messageId: string) => void;
     sessionReplyMock
       .mockImplementationOnce(() => new Promise<string>(resolve => { resolveFirst = resolve; }))
-      .mockResolvedValueOnce('om_newer_card');
+      .mockImplementationOnce(() => new Promise<string>(resolve => { resolveSecond = resolve; }));
     const fakeWorker = makeFakeWorker();
     const ds = makeDs({
       streamCardPending: true,
@@ -895,6 +958,14 @@ describe('Worker ready: set_display_mode re-sync', () => {
     await flush();
     expect(ds.streamCardId).toBe(CARD_POSTING_SENTINEL);
 
+    fakeWorker.emit('message', {
+      type: 'screen_update',
+      content: 'older turn working while its card posts',
+      status: 'working',
+      turnId: 'om_turn_1',
+    });
+    await flush();
+
     ds.streamCardPending = true;
     ds.streamCardTurnGeneration = 2;
     ds.streamCardPendingTurnId = 'om_turn_2';
@@ -905,6 +976,14 @@ describe('Worker ready: set_display_mode re-sync', () => {
 
     expect(sessionReplyMock).toHaveBeenCalledTimes(2);
     expect(sessionReplyMock.mock.calls[1][4]).toBe('om_turn_2');
+    expect(ds.streamCardId).toBe(CARD_POSTING_SENTINEL);
+    expect(ds.streamCardPending).toBe(true);
+    expect(updateMessageMock).not.toHaveBeenCalled();
+
+    resolveSecond('om_newer_card');
+    await flush();
+    await flush();
+
     expect(ds.streamCardId).toBe('om_newer_card');
     expect(ds.streamCardPending).toBe(false);
     expect(ds.streamCardPendingTurnId).toBeUndefined();

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -486,7 +486,7 @@ describe('worker structured-turn status wiring', () => {
     expect(tickPrune).toBeGreaterThan(finallyBlock);
   });
 
-  it('routes Pi external idle through the busy-viewport guard; ZMX stays fail-open', () => {
+  it('routes Pi and OMP external idle through the busy-viewport guard; ZMX stays fail-open', () => {
     const callback = source.slice(
       source.indexOf('idleDetector.onIdle(async (evidenceSource)'),
       source.indexOf('drainBridgesThenMarkReady(evidenceSource);'),
@@ -495,7 +495,7 @@ describe('worker structured-turn status wiring', () => {
     // Working... — an external idle landing while the authoritative viewport
     // still shows busy must defer exactly like a screen idle.
     expect(callback).toContain("evidenceSource === 'screen'");
-    expect(callback).toContain("evidenceSource === 'external' && structuredBridgeIsPi()");
+    expect(callback).toContain('structuredBridgeIsPi() || structuredBridgeIsOmp()');
     expect(callback).toContain('deferPromptReadyWhileBusy(`${cliName()} ${evidenceSource}-idle`, idleBackend)');
 
     // The guard fail-opens on non-authoritative screens (ZMX) BEFORE testing
@@ -514,6 +514,28 @@ describe('worker structured-turn status wiring', () => {
     // so a deferred ZMX turn can never be pinned by the probe loop.
     const probe = functionSlice('scheduleBusyPatternIdleProbe', 'spawnCli');
     expect(probe).toContain('if (!backendScreenEvidenceIsAuthoritativeForMutation()) return;');
+  });
+
+  it('flushes an OMP trailing candidate only after a complete quiet tick and non-busy viewport', () => {
+    const quiet = functionSlice('maybeFlushOmpTrailingFinalOnQuietTick', 'maybeEmitCodexStructuredRateLimit');
+    const arm = quiet.indexOf('ompQuietCandidateCompleteOffset = codexBridgeOffset');
+    const tailGate = quiet.indexOf('codexBridgePendingTail', arm);
+    const lifecycleGate = quiet.indexOf('hasStructuredLifecycleBlock()', arm);
+    const authoritativeGate = quiet.indexOf('backendScreenEvidenceIsAuthoritativeForMutation()', arm);
+    const capture = quiet.indexOf('captureBackendScreen(backend)', authoritativeGate);
+    const busy = quiet.indexOf('cliAdapter.busyPattern.test(busyProbeRegion(screen))', capture);
+    const flush = quiet.indexOf('codexBridgeIngest({ flushOmpTrailingFinal: true })', busy);
+    expect(arm).toBeGreaterThanOrEqual(0);
+    expect(tailGate).toBeGreaterThan(arm);
+    expect(lifecycleGate).toBeGreaterThan(arm);
+    expect(authoritativeGate).toBeGreaterThan(arm);
+    expect(capture).toBeGreaterThan(authoritativeGate);
+    expect(busy).toBeGreaterThan(capture);
+    expect(flush).toBeGreaterThan(busy);
+
+    const ticker = functionSlice('codexBridgeStartTimer', 'hermesBridgeAttach');
+    expect(ticker.indexOf('codexBridgeIngest()'))
+      .toBeLessThan(ticker.indexOf('maybeFlushOmpTrailingFinalOnQuietTick()'));
   });
 
   it('publishes first-turn working from the projected status for argv-baked prompts, as a pure publisher', () => {


### PR DESCRIPTION
## 改动概览

- 移除 Oh My Pi 已废弃的硬编码工具名，使用 OMP 当前默认工具集。
- 为每个 Botmux 会话使用独立的 OMP session 目录，并通过精确 JSONL 路径恢复，避免 `--continue` 串到同目录下的其它会话。
- 在沙盒中仅开放当前会话 transcript 目录，同时保留 OMP 既有的宿主用户认证/配置访问模型。
- 支持普通飞书消息在 OMP 忙态时通过原生 steer 立即追加，并通过结构化 transcript bridge 将合并后的最终回复归属到最新匹配消息。
- 对 OMP JSONL 的暂定终态做 continuation 消歧，仅在完整行静默且权威终端画面已无 busy marker 时释放最终回复。
- 收紧本地恢复命令，只允许绝对、完整引用且不可追加参数的 `--resume` 命令。
- 在任何状态变更前处理 `start|stop|restart|update|upgrade --help/-h`，避免帮助命令产生副作用。
- 修复冷恢复/冷 refork 后状态卡错误停留在“等待输入”：新轮先显示启动态，POST 期间到达的 working 状态会在同一张卡提交后补齐；恢复/relay 旧卡语义保持不变。

## 原因

- OMP 17.3.5 已删除旧工具名，旧参数会在启动阶段直接报错退出。
- OMP 的 `--continue` 受终端 breadcrumb 影响，不能提供会话级精确恢复与隔离。
- 忙态普通 Enter 已具备 steer 语义，但 Botmux 原先既未即时提交，也没有可靠的结构化归属链路。
- worker 冷恢复时会沿用上一轮的 `idle` 状态创建新卡；若 POST 期间收到 working 更新，该更新只写入内存且缺少提交后对账，卡片可能长期显示“等待输入”。

## 影响面

- OMP 适配器、会话恢复、沙盒路径、结构化 transcript bridge 与普通消息 busy steer。
- 根 CLI 的状态变更命令帮助守卫。
- worker-ready 的新轮状态卡创建/对账共享路径；未改 restored-card reuse/PATCH、非 pending relay/recovery、durable/VC/raw/startup gate，也未增加 OMP 状态卡特判。
- OMP transcript 按 Botmux session 隔离；认证与配置数据库仍按宿主用户共享，维持现有信任边界。

## 验证

- `pnpm build`：通过（TypeScript、脚本类型检查、dashboard bundle、dist audit）。
- `pnpm test`：1053 个测试文件通过，17623 条测试通过，17 条按平台条件跳过。
- 状态卡/OMP/help/restart 聚焦回归：790 条通过。
- 真实 bubblewrap、worker/OMP 集成回归：114 条通过。
- 独立实现检查：无 P0/P1/P2 finding。
- `git diff --check`：通过。
- CodeGraph：已同步。
- `pnpm switch:here && pnpm daemon:restart`：本机全局 wrapper 已指向该 checkout，8 个 PM2 进程全部 online，既有会话恢复成功。

## 安全边界

- durable/dispatch-attempt、VC/meeting、raw、startup/reattach 与 stale-generation 输入仍保持串行，不进入 busy steer。
- OMP 不声明 `reliableTurnTerminal`；本改动不扩张为 durable exactly-once 语义。
- 状态卡对账使用发卡前 revision 与 captured turn target，superseded POST 不会覆盖更新轮次。
