### PR TITLE
fix(dashboard): 修复 master build 红——ls 唤醒对齐通用远程后端守卫

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1274,8 +1274,12 @@ ipcRoute('POST', '/api/sessions/:sessionId/wake', async (req, res, params) => {
     if (ds.adoptedFrom || ds.initConfig?.adoptMode) {
       return jsonRes(res, 409, { ok: false, error: 'adopt_wake_unsupported' });
     }
-    if (isRiffBackendSession(ds)) {
-      return jsonRes(res, 409, { ok: false, error: 'riff_wake_unsupported' });
+    if (isRemoteBackendSession(ds)) {
+      return jsonRes(res, 409, {
+        ok: false,
+        error: 'remote_wake_unsupported',
+        message: t('cmd.wake.remote_unsupported', undefined, localeForBot(ds.larkAppId)),
+      });
     }
     if (rejectProtectedSessionMutation(res, [ds])) return;
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -305,6 +305,7 @@ export const messages: Record<string, string> = {
   'cmd.cd.remote_unsupported': '⚠️ Remote-backend sessions (Riff / Mojo) cannot switch working directory or role in place. Use /close to close the current remote session, then create one from the new directory.',
   'cmd.takeover.riff_unsupported': '⚠️ Riff sessions cannot adopt or import another session in place. Use /close to safely close the current remote session, then create or import a session.',
   'cmd.takeover.remote_unsupported': '⚠️ Remote-backend sessions (Riff / Mojo) cannot adopt or import another session in place. Use /close to safely close the current remote session, then create or import a session.',
+  'cmd.wake.remote_unsupported': '⚠️ Remote-backend sessions (Riff / Mojo) cannot be woken from `botmux ls`: the remote lineage is not held in a local pane, so it cannot be fork-resumed locally. Send a new message to that session to continue it.',
   'cmd.cd.usage': 'Usage: /cd <path>\nExample: /cd ~/projects/my-app',
   'cmd.cd.switched': 'Working directory switched to {path}. It will resume there on your next message.',
   'cmd.cd.created_switched': '📁 Directory did not exist — created it and switched to {path}. It will resume there on your next message.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -306,6 +306,7 @@ export const messages: Record<string, string> = {
   'cmd.cd.remote_unsupported': '⚠️ 远程后端会话（Riff / Mojo）不支持中途切换工作目录或角色。请先用 /close 关闭当前远程会话，再从新目录创建会话。',
   'cmd.takeover.riff_unsupported': '⚠️ Riff 会话不支持原地接管或导入其他会话。请先用 /close 安全关闭当前远程会话，再新建或导入会话。',
   'cmd.takeover.remote_unsupported': '⚠️ 远程后端会话（Riff / Mojo）不支持原地接管或导入其他会话。请先用 /close 安全关闭当前远程会话，再新建或导入会话。',
+  'cmd.wake.remote_unsupported': '⚠️ 远程后端会话（Riff / Mojo）不支持从 `botmux ls` 唤醒：远端 lineage 不在本地 pane 中，无法本地 fork 恢复。请直接向该会话发送新消息以继续。',
   'cmd.cd.usage': '用法：/cd <path>\n例如：/cd ~/projects/my-app',
   'cmd.cd.switched': '工作目录已切换到 {path}，下次发消息时将在新目录下恢复。',
   'cmd.cd.created_switched': '📁 目录不存在，已自动创建并切换到 {path}，下次发消息时将在新目录下恢复。',

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -1939,6 +1939,34 @@ describe('POST /api/sessions/:sessionId/wake', () => {
     }
   });
 
+  it('refuses to wake a remote-backend (riff/mojo) session — the lineage is not a local pane to fork-resume', async () => {
+    // Regression guard for the generalized remote predicate: a remote session's
+    // worker-less row must NOT be fork-resumed by `botmux ls` wake (a riff-only
+    // guard here would let a mojo session slip through — the exact class the
+    // remote-retirement guards were hardened against).
+    const ds = {
+      session: { sessionId: 's-list-wake-remote', cliId: 'riff', backendType: 'riff' },
+      initConfig: { backendType: 'riff' },
+      worker: null,
+      adoptedFrom: undefined,
+      hasHistory: true,
+    } as any;
+    const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+    const forkSpy = vi.spyOn(workerPool, 'forkWorker').mockReturnValue(true);
+
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-list-wake-remote/wake`, { method: 'POST' });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toMatchObject({ ok: false, error: 'remote_wake_unsupported' });
+      expect(forkSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      forkSpy.mockRestore();
+    }
+  });
+
   it('does not restart a live worker when a Lark wake races the local picker', async () => {
     const send = vi.fn();
     const ds = {


### PR DESCRIPTION
## 改了什么

修复 **master build 恒红**:`#912`(ls 自动唤醒休眠会话)在 `src/core/dashboard-ipc-server.ts` 的 `POST /api/sessions/:id/wake` 路由里调用了 `isRiffBackendSession(ds)`,但该文件只 `import` 了 `isRemoteBackendSession`,漏了这个符号 → `tsc` 报 `TS2552: Cannot find name 'isRiffBackendSession'` → `pnpm build` 恒挂。

master CI 当前就是红的(`bd5d5b95a` / `101ffc67b` 的 CI 均 failure),挡住所有 PR 的绿。

## 为什么这么修(不是补 import)

补上 import 能让它编译,但会留下一个**语义回归**:`wake` 与 `restart` / `cd` 同属"销毁本地 pane 再 fork 恢复"语义,而远程后端(**riff 和 mojo**)的 lineage 不在本地 pane 里,都不该被 `botmux ls` 唤醒 fork。用 riff-only 谓词正是 `test/worker-remote-retirement-protocol.test.ts` 守卫测试**专门盯防的回归类**——mojo 会从 riff-only 守卫溜过去(该测试注释:"a copied riff-only guard ... goes red here instead of waiting for a reviewer")。

所以对齐本仓既有约定:
- 谓词改为通用 `isRemoteBackendSession(ds)`(与 restart 路由 `dashboard-ipc-server.ts:1223`、cd 路由 `:1786` 一致)。
- 错误码对齐兄弟路由 `remote_<verb>_unsupported` 命名 → `remote_wake_unsupported`(原 `riff_wake_unsupported` 无任何外部消费方:CLI `ls` 客户端 `cli.ts:5460` 只透传 `body.error`,不 switch,重命名安全)。
- 补中英 i18n `cmd.wake.remote_unsupported`,与 `cmd.{restart,cd,takeover}.remote_unsupported` 同风格。

## 影响面

- 动的是 daemon dashboard IPC 的 **ls-wake 路由**一处。
- 语义上**只收紧不放宽**:riff → riff+mojo;非远程(本地 pty/tmux)会话的 wake 行为完全不变。
- 不涉及跨平台 / 跨 CLI 适配器 / 其它后端。

## 测试验证

- `pnpm build` 干净(tsc + typecheck:scripts + dashboard bundle + audit);此前恒红,现绿。
- `test/worker-remote-retirement-protocol.test.ts` 守卫测试转绿(**12/12**;此前该文件 1 红,正卡在 dashboard-ipc-server 的 riff-only 调用)。
- `test/dashboard-ipc.test.ts` 新增用例:remote 后端(riff/mojo)会话 wake → **409 `remote_wake_unsupported` 且不 `forkWorker`**;**反向变异**(去掉该守卫)用例转红(`expected 200 to be 409`),确认有牙。
- i18n 相关 + dashboard-ipc 全量:445 + 154 绿。

> 本 PR 是给 master 止血的独立小修复(类似 #949 之于 #917),与 #947(工作流开关)无关。合入后 #947 rebase 即可让其 CI 转绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)