### PR TITLE
fix(dashboard): 补回 isRiffBackendSession import，修复 master 编译失败

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -224,7 +224,7 @@ import { clearSessionPreviewTarget } from './session-preview-registry.js';
 import { ChatRenameCooldown, ChatRenameSerialQueue, normalizeLarkChatName } from './chat-rename.js';
 import type { DaemonToWorker, ScheduledTask, ParsedSchedule, ScheduleExecutionPosition, Session } from '../types.js';
 import { sessionAnchorId, larkTransportEnabled, type DaemonSession } from './types.js';
-import { isRemoteBackendSession } from './persistent-backend.js';
+import { isRemoteBackendSession, isRiffBackendSession } from './persistent-backend.js';
 import { attachSkillPolicy, detachSkillPolicy } from './skills/im-command.js';
 import { readSkillRegistry } from '../services/skill-registry-store.js';
 import { isSessionGroup } from '../services/session-groups-store.js';


### PR DESCRIPTION
## 问题

master 当前**编译不过**：

```
$ npx tsc --noEmit
src/core/dashboard-ipc-server.ts(1277,9): error TS2552: Cannot find name 'isRiffBackendSession'. Did you mean 'isRemoteBackendSession'?

$ pnpm build
 ELIFECYCLE  Command failed with exit code 2.
```

成因是两个各自都正确的改动叠加：

- **#803**（mojo 远端后端）把 `dashboard-ipc-server.ts` 里的判定从 riff 专用扩成 `isRemoteBackendSession`，顺手移除了 `isRiffBackendSession` 的 import；
- **#912**（`botmux ls` 自动恢复休眠会话）在新增的 `/api/sessions/:sessionId/wake` 路由里加了 `isRiffBackendSession(ds)` 守卫。

于是文件里少了一行 import。自 #912 合入起，master 的 `tsc` / `pnpm build` 一直是红的，任何人 rebase 上来都会撞到。

## 改动

一行，按调用点原意补回 import：

```diff
-import { isRemoteBackendSession } from './persistent-backend.js';
+import { isRemoteBackendSession, isRiffBackendSession } from './persistent-backend.js';
```

**不改行为。** 该守卫返回的错误码是 `riff_wake_unsupported`，针对的就是 riff 这一种远端后端；`isRemoteBackendSession`（riff + mojo 全家）语义更宽，是否也要把 mojo 会话挡在本地 wake 之外属于产品判断，不在本修复范围内——如果维护者认为应该一起挡，改成 `isRemoteBackendSession` 也只是一行，我可以跟进。

## 验证

- 改动前：`npx tsc --noEmit` 报上述错误、`pnpm build` 退出码 2；
- 改动后：`npx tsc --noEmit` 干净、`pnpm build` 通过。
- 定向跑了受影响文件相关的用例，未见新增失败（`ipc-preview-route` / `session-picker-responsive` / `cli-runtime-update` 的既有失败在打此补丁前后完全一致，与本改动无关）。
