### PR TITLE
fix(codex-app): 支持显式 Bot-to-bot @steer

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import {
 import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { acceptedDispatchBotAppIds, activeConversationBotOpenIds, buildDispatchCompletionBrief, parseDispatchBotSpec, buildDispatchMessages, buildRepoPrimeText, buildReportContent, eligibleAutoMentionAliases, foldableChatSessionAppIds, offTopicSubBotTopic, resolveReportPlacement, resolveReportRecipient, resolveSendTarget, threadRootForReachability } from './core/dispatch.js';
+import { withBotSteerDirective } from './core/bot-steer-directive.js';
 import { pickTurnReplyTarget, collectTurnWindowParticipants } from './core/reply-target.js';
 import { enableAutostart, disableAutostart, autostartStatus, refreshAutostart } from './autostart.js';
 import { tmuxEnv } from './setup/ensure-tmux.js';
@@ -7387,6 +7388,8 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
     @ 硬门：每条回复须三选一 --mention/--mention-back/--no-mention，否则报错不发。
     按内容价值选：有实质结论要对方看/确认/决策→--mention-back(或--mention点名)；
     纯记录/低优先级进度/简短确认→--no-mention；没信息量的"收到"不如不发。
+    Bot→Bot 默认进入 Queue；要显式调整对方活跃的 Codex App turn，把 @steer 写成
+    正文首个语义行（可放在收件人 @ 行之后）。接收端会消费该指令，不交给模型。
     （可设 BOTMUX_REQUIRE_MENTION_DECISION=false 关闭硬门）
   bots list                            列出当前群聊中的机器人（含 open_id）
   history [--limit N] [--scope session|thread|chat|ambient] [--with-card-json]
@@ -10858,8 +10861,9 @@ async function cmdDispatch(rest: string[]): Promise<void> {
                         派单前按双方 receiver 视角建立并回读 talk-only exact chatGrant，
                         发送后等待目标 session 接单确认；不支持 --repo 管理命令
   --bot <spec>          兼容外部/旧链路；spec = open_id[:名字[:角色]]，不保证本机双向授权
-  --brief <text>        子项目简报 / 追加内容
+  --brief <text>        子项目简报 / 追加内容；首个语义行写 @steer 可显式调整活跃 Codex App turn
   --brief-file <path>   从文件读取简报
+  --steer               在简报前注入通用 @steer 指令；普通 dispatch 默认仍进入 Queue
   --repo <path>         预设子 bot 工作目录（绝对路径，需在子 bot 所在机器上存在）
   --standby             仅 --repo 待命，不派简报
   --into <root_id>      回到已有话题线程追加（与 --title/种子互斥）
@@ -10879,6 +10883,7 @@ async function cmdDispatch(rest: string[]): Promise<void> {
   const repo = argValue(rest, '--repo');
   const intoRoot = argValue(rest, '--into');
   const standby = rest.includes('--standby');
+  const steer = rest.includes('--steer');
   const botSpecs = argValues(rest, '--bot');
   const botAppSpecs = argValues(rest, '--bot-app');
 
@@ -10901,6 +10906,10 @@ async function cmdDispatch(rest: string[]): Promise<void> {
     console.error('--standby 与 --into 不能同用。');
     process.exit(1);
   }
+  if (standby && steer) {
+    console.error('--standby 与 --steer 不能同用（待命模式没有简报可调整当前 turn）。');
+    process.exit(1);
+  }
   if (botAppSpecs.length > 0 && repo) {
     console.error('--bot-app 仅自动建立 talk-only chatGrant，不能授权 /repo 管理命令；请使用驻守 Bot 的默认工作目录，或另走显式 operate 信任链路。');
     process.exit(1);
@@ -10909,6 +10918,7 @@ async function cmdDispatch(rest: string[]): Promise<void> {
     console.error('缺少简报。用 --brief 或 --brief-file 指定（仅 --standby 模式可省略）。');
     process.exit(1);
   }
+  if (steer) brief = withBotSteerDirective(brief);
   if (!intoRoot && !title.trim()) {
     console.error('新开话题需要 --title。往已有话题追加请用 --into <root_id>。');
     process.exit(1);

--- a/src/core/bot-steer-directive.ts
+++ b/src/core/bot-steer-directive.ts
@@ -1,0 +1,50 @@
+export interface ParsedBotSteerDirective {
+  requested: boolean;
+  /** Message body with the control directive removed. */
+  content: string;
+}
+
+/**
+ * Consume the generic bot-to-bot `@steer` control directive.
+ *
+ * The directive must be the first semantic line, optionally following one or
+ * more leading @recipient lines emitted by Lark. Both forms are accepted:
+ *
+ *   @steer
+ *   adjust the current task
+ *
+ *   @TargetBot
+ *   @steer adjust the current task
+ *
+ * This parser is deliberately transport-only and language-neutral. It does not
+ * authorize anything by itself; the daemon additionally requires a positively
+ * classified foreign-bot sender and applies the existing control-lane gates.
+ */
+export function parseBotSteerDirective(content: string): ParsedBotSteerDirective {
+  const lines = content.split(/\r?\n/);
+  let index = 0;
+  while (index < lines.length && !lines[index]!.trim()) index++;
+
+  while (index < lines.length) {
+    const line = lines[index]!.trim();
+    const match = /^@steer(?:\s+(.*))?$/i.exec(line);
+    if (match) {
+      const inlineContent = match[1]?.trim();
+      if (inlineContent) lines[index] = inlineContent;
+      else lines.splice(index, 1);
+      return { requested: true, content: lines.join('\n') };
+    }
+    if (!line.startsWith('@')) break;
+    index++;
+    while (index < lines.length && !lines[index]!.trim()) index++;
+  }
+
+  return { requested: false, content };
+}
+
+/** Add the wire directive once; used by generic sender-side convenience flags. */
+export function withBotSteerDirective(content: string): string {
+  return parseBotSteerDirective(content).requested
+    ? content
+    : `@steer\n${content}`;
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,6 +4,7 @@ import { readFileSync, existsSync, mkdirSync, unlinkSync, watch, readdirSync } f
 import { installDaemonRejectionGuard } from './utils/daemon-rejection-guard.js';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { readPeerCrossRef } from './services/peer-cross-ref-store.js';
+import { parseBotSteerDirective } from './core/bot-steer-directive.js';
 import { readAllowedUsersResolveCache, writeAllowedUsersResolveCache } from './utils/allowed-users-cache.js';
 import { join, dirname } from 'node:path';
 import { homedir, loadavg, cpus, totalmem, freemem } from 'node:os';
@@ -17496,29 +17497,32 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
  * (handleNewTopicAdmitted + handleThreadReplyAdmitted), so a plain-human turn is
  * authorized identically whether it opens a new topic or continues one (R6/R7-B1).
  *
- * FAIL-CLOSED by construction (R7-B1): authorization requires a POSITIVE
- * `humanSender` (senderType === 'user' AND not a known peer bot) AND the absence
- * of every control-rewrite / dedicated-receiver signal. Excluding a list of
- * known non-human sources is NOT enough — an exclude-list is never complete, so
- * any un-enumerated non-user source would fail OPEN. The positive humanSender
- * gate makes the default deny: anything that is not provably a real human turn
- * with no special semantics stays forced-serial.
+ * FAIL-CLOSED by construction (R7-B1): authorization requires either a POSITIVE
+ * `humanSender` (senderType === 'user' AND not a known peer bot), or a known peer
+ * bot carrying the explicit `@steer` directive. Both lanes must also have no
+ * control-rewrite / dedicated-receiver signal. Anything not positively matched
+ * by one of those lanes stays forced-serial.
  */
 function computeCodexAppSteerable(facts: {
   humanSender: boolean;
   adopted: boolean;
   isForeignBot: boolean;
   isBotSenderType: boolean;
+  explicitBotSteer: boolean;
   substituteTrigger: boolean;
   controlRewrite: boolean;
   messageListener: boolean;
   vcMeetingReceiver: boolean;
   vcMeetingImTurnOrigin: boolean;
 }): boolean {
-  return facts.humanSender
-    && !facts.adopted
+  const plainHuman = facts.humanSender
     && !facts.isForeignBot
-    && !facts.isBotSenderType
+    && !facts.isBotSenderType;
+  const explicitBotSteer = facts.explicitBotSteer
+    && facts.isForeignBot;
+
+  return (plainHuman || explicitBotSteer)
+    && !facts.adopted
     && !facts.substituteTrigger
     && !facts.controlRewrite
     && !facts.messageListener
@@ -17650,6 +17654,19 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
   // the contact API. Must run before any await on the sender resolver.
   learnFromMentions(larkAppId, parsed.mentions);
 
+  const senderOpenId: string | undefined = data.sender?.sender_id?.open_id;
+  const isBotSenderType = data.sender?.sender_type === 'app' || data.sender?.sender_type === 'bot';
+  const isForeignBotSender = isBotSenderType
+    || (!!senderOpenId && senderOpenId !== getBot(larkAppId).botOpenId
+        && isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId));
+  // `@steer` is a generic bot-to-bot transport directive, not model content.
+  // Consume it only from a positively classified bot sender; a human writing
+  // the same text keeps the literal body (human turns are already steerable).
+  const botSteerDirective = isForeignBotSender
+    ? parseBotSteerDirective(parsed.content)
+    : { requested: false, content: parsed.content };
+  if (botSteerDirective.requested) parsed.content = botSteerDirective.content;
+
   const followupContent = parsed.content.trim();
   let content = composeForwardFollowupContent(forwardSeedContent, followupContent);
   // Strip leading @<bot> mentions so "@bot /oncall bind" is recognized as a command.
@@ -17662,7 +17679,6 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
   // (already thread-scope) it's just a prefix strip — no routing change.
   // Empty prompt is allowed: later setup chooses either a repo picker or a
   // visible thread that waits for the first real task, without an empty worker.
-  const senderOpenId: string | undefined = data.sender?.sender_id?.open_id;
   const forceTopic = parseForceTopicInvocation(cmdContent);
   if (forceTopic) {
     if (await replyGrantRestrictionIfNeeded(
@@ -17698,7 +17714,6 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
   // 飞书盖章的 bot 发送方。既锁 union 信任腿（下面的 teamTrustUnionId），也决定
   // talk 复查走哪个谓词（evaluateBotTalk vs evaluateTalk）——两者必须同源，见
   // enforceMessageQuotaForCliInput 的 botSender 说明。
-  const isBotSenderType = data.sender?.sender_type === 'app' || data.sender?.sender_type === 'bot';
   const teamTrustUnionId: string | undefined = isBotSenderType ? senderUnionId : undefined;
   // A bot-sent new topic (e.g. a message-listener match on a third-party alert
   // bot's card) must NOT make that bot the session owner: daemon-generated
@@ -17707,9 +17722,6 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
   // surfaces (restart/report/cards) to it. Mirror the handleThreadReply +
   // auto-create paths (isForeignBot → ownerOpenId/ownerUnionId undefined); keep
   // creatorOpenId + quoteTarget* so botmux report / first-turn quote still work.
-  const isForeignBotSender = isBotSenderType
-    || (!!senderOpenId && senderOpenId !== getBot(larkAppId).botOpenId
-        && isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId));
   const ownerOpenIdForSession = isForeignBotSender ? undefined : senderOpenId;
   const ownerUnionIdForSession = isForeignBotSender ? undefined : senderUnionId;
   const botCfg = getBot(larkAppId).config;
@@ -18222,8 +18234,10 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
     pendingSubstituteTrigger: substituteTrigger,
     pendingSubstituteControlCard: shouldSendSubstituteControlCard,
     pendingSender: newTopicSender,
-    // R6-B1: freeze the plain-human steer authorization into the NEW-TOPIC opening
-    // metadata from inbound source facts (the same helper the follow-up twin uses).
+    // Freeze steer authorization into the NEW-TOPIC opening metadata from
+    // inbound source facts (the same helper the follow-up twin uses). The two
+    // allowed lanes are a plain human turn and a foreign bot carrying the
+    // explicit, language-neutral `@steer` directive; ordinary bot traffic is serial.
     // A brand-new session has no VC receiver yet; foreign-bot maps to the bot-sender
     // fact here. buildReservedInitialInput COPIES this onto the opening payload;
     // forkReservedInitialSession never infers it.
@@ -18239,6 +18253,7 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
       isForeignBot: isBotSenderType
         || isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId),
       isBotSenderType,
+      explicitBotSteer: botSteerDirective.requested,
       substituteTrigger: !!substituteTrigger,
       controlRewrite: !!newTopicGrill,
       messageListener: !!messageListener,
@@ -19056,6 +19071,10 @@ async function handleThreadReplyAdmitted(
     senderOpenIdForPrefix !== selfBotOpenId &&
     (isBotSenderType ||
       isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenIdForPrefix));
+  const botSteerDirective = isForeignBot
+    ? parseBotSteerDirective(parsed.content)
+    : { requested: false, content: parsed.content };
+  if (botSteerDirective.requested) parsed.content = botSteerDirective.content;
   const senderUnionIdForPrefix = parsed.senderUnionId || data?.sender?.sender_id?.union_id;
   const foreignBotName = isForeignBot ? lookupForeignBotName(senderOpenIdForPrefix!, larkAppId, senderUnionIdForPrefix) : undefined;
   const botSenderPrefix = isForeignBot
@@ -19638,14 +19657,15 @@ async function handleThreadReplyAdmitted(
   // opening path — would silently drop it. When a claim token IS held (a
   // concurrent first turn owns the opening) or a queued-activation ACK is
   // pending, a live worker MUST keep buffering to preserve FIFO submission order.
-  // Codex App steer authorization (Blocking 1, decision A) — computed ONCE here,
+  // Codex App steer authorization — computed ONCE here,
   // BEFORE every admission/fork branch below (R5-B1-1): the earliest tail-admit
   // (initialStartPending follower), pending-repo follower, worker-null refork,
   // and new-topic auto-create paths all need the same frozen value, and several
   // of them return before the later existing-owner branch. Explicit positive
-  // ONLY for a plain-human-interactive turn (real human sender; none of
-  // foreign-bot / bot-sender / substitute-rewrite / v3-grill / message-listener /
-  // VC receiver / VC origin / adopt). Never inferred from the delivery sink;
+  // only for a plain-human-interactive turn or a foreign bot carrying an
+  // explicit `@steer` directive. Plain @mentions, reports, other bot traffic,
+  // substitute-rewrite, v3-grill, message-listener, VC and adopt stay serial.
+  // Never inferred from the delivery sink;
   // ignored by acceptCodexAppDispatch for non-codex-app CLIs. A new-topic root
   // must FREEZE this into its opening payload — forkReservedInitialSession is
   // shared by bot-added / scheduler / system bootstrap and only COPIES an
@@ -19657,6 +19677,7 @@ async function handleThreadReplyAdmitted(
     adopted: !!ds?.adoptedFrom,
     isForeignBot,
     isBotSenderType,
+    explicitBotSteer: botSteerDirective.requested,
     substituteTrigger: !!substituteTrigger,
     controlRewrite: !!threadGrill,
     messageListener: !!ctx.messageListener,

--- a/test/bot-steer-directive.test.ts
+++ b/test/bot-steer-directive.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseBotSteerDirective,
+  withBotSteerDirective,
+} from '../src/core/bot-steer-directive.js';
+
+describe('parseBotSteerDirective', () => {
+  it('consumes a standalone leading directive', () => {
+    expect(parseBotSteerDirective('@steer\nadjust the current task')).toEqual({
+      requested: true,
+      content: 'adjust the current task',
+    });
+  });
+
+  it('consumes an inline directive after a leading recipient line', () => {
+    expect(parseBotSteerDirective('@TargetBot（coder）\n\n@steer use the new API')).toEqual({
+      requested: true,
+      content: '@TargetBot（coder）\n\nuse the new API',
+    });
+  });
+
+  it('does not treat prose or a similar handle as a directive', () => {
+    for (const content of [
+      'please explain @steer behavior',
+      '@steering\nkeep queued',
+      'normal bot-to-bot message',
+    ]) {
+      expect(parseBotSteerDirective(content)).toEqual({ requested: false, content });
+    }
+  });
+
+  it('adds the directive idempotently for sender-side convenience flags', () => {
+    expect(withBotSteerDirective('adjust the current task'))
+      .toBe('@steer\nadjust the current task');
+    expect(withBotSteerDirective('@steer adjust the current task'))
+      .toBe('@steer adjust the current task');
+  });
+});

--- a/test/initial-user-turn-opening.test.ts
+++ b/test/initial-user-turn-opening.test.ts
@@ -147,11 +147,12 @@ function writeBots(entries: unknown[]): void {
 
 function makeEventData(messageId: string, text: string, rootId?: string, extra?: {
   senderOpenId?: string;
+  senderType?: string;
   mentions?: any[];
   parentId?: string;
 }): any {
   return {
-    sender: { sender_id: { open_id: extra?.senderOpenId ?? OWNER }, sender_type: 'user' },
+    sender: { sender_id: { open_id: extra?.senderOpenId ?? OWNER }, sender_type: extra?.senderType ?? 'user' },
     message: {
       message_id: messageId,
       root_id: rootId,
@@ -407,6 +408,49 @@ describe('empty-started session — first real business turn must use the new-to
     // on. The test does NOT hand-inject the flag anywhere.
     const opts = mocks.sendWorkerInput.mock.calls[0]?.[3];
     expect(opts?.codexAppSteerable).toBe(true);
+  });
+
+  it('live worker: a foreign-bot @steer turn is steerable and the directive is not model content', async () => {
+    const anchor = 'om_bot_steer_root';
+    registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'codex-app',
+      allowedUsers: [OWNER],
+      oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
+    }).resolvedAllowedUsers = [OWNER];
+    seedEmptyStarted(anchor, { cliId: 'codex-app' });
+
+    await handleThreadReply(
+      makeEventData('om_bot_steer_msg', '@steer\n改用新的 API 继续做', anchor, { senderType: 'bot' }),
+      makeCtx(anchor, 'om_bot_steer_msg'),
+    );
+
+    const payload = liveInputs()[0]!;
+    const opts = mocks.sendWorkerInput.mock.calls[0]?.[3];
+    expect(opts?.codexAppSteerable).toBe(true);
+    expect(payload.content).toContain('改用新的 API 继续做');
+    expect(payload.content).not.toContain('@steer');
+  });
+
+  it('live worker: a plain foreign-bot @mention stays queued', async () => {
+    const anchor = 'om_bot_queue_root';
+    registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'codex-app',
+      allowedUsers: [OWNER],
+      oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
+    }).resolvedAllowedUsers = [OWNER];
+    seedEmptyStarted(anchor, { cliId: 'codex-app' });
+
+    await handleThreadReply(
+      makeEventData('om_bot_queue_msg', '普通 bot-to-bot 消息', anchor, { senderType: 'bot' }),
+      makeCtx(anchor, 'om_bot_queue_msg'),
+    );
+
+    const opts = mocks.sendWorkerInput.mock.calls[0]?.[3];
+    expect(opts?.codexAppSteerable).toBeUndefined();
   });
 
   it('worker-null refork: a plain human Codex App opening carries the frozen steerable flag on the fork payload (R4-B1)', async () => {
@@ -790,6 +834,7 @@ describe('computeCodexAppSteerable — fail-closed positive-human gate (R7-B1)',
     adopted: false,
     isForeignBot: false,
     isBotSenderType: false,
+    explicitBotSteer: false,
     substituteTrigger: false,
     controlRewrite: false,
     messageListener: false,
@@ -824,5 +869,32 @@ describe('computeCodexAppSteerable — fail-closed positive-human gate (R7-B1)',
     expect(computeCodexAppSteerable({
       ...humanFacts, humanSender: false, isForeignBot: true,
     })).toBe(false);
+  });
+
+  it('authorizes a known peer bot only when it carries an explicit @steer directive', () => {
+    const botFacts = {
+      ...humanFacts,
+      humanSender: false,
+      isForeignBot: true,
+      isBotSenderType: true,
+    };
+    expect(computeCodexAppSteerable({ ...botFacts })).toBe(false);
+    expect(computeCodexAppSteerable({ ...botFacts, explicitBotSteer: true })).toBe(true);
+  });
+
+  it('keeps every special control lane serial even for explicit bot @steer', () => {
+    const botFacts = {
+      ...humanFacts,
+      humanSender: false,
+      isForeignBot: true,
+      isBotSenderType: true,
+      explicitBotSteer: true,
+    };
+    for (const key of [
+      'adopted', 'substituteTrigger', 'controlRewrite', 'messageListener',
+      'vcMeetingReceiver', 'vcMeetingImTurnOrigin',
+    ] as const) {
+      expect(computeCodexAppSteerable({ ...botFacts, [key]: true })).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## 背景

Botmux 当前把普通 bot-to-bot `@mention` 作为串行输入处理：目标 Codex App 正忙时，消息进入 Queue，不打断当前 turn。这适合完成回报、进度同步等大多数协作消息。

但跨 Bot 协作也需要一个明确的 opt-in 原语，让发送方可以表示「这不是下一轮任务，而是要调整对方正在执行的方向」。这个选择不应该依赖 Bot 名称、Leader/Agent 角色或某套业务编排文案。

本 PR 新增通用的 bot-to-bot `@steer` 指令：

| 入站消息 | 活跃 Codex App 会话中的行为 |
| --- | --- |
| 真人直接发言 | 保持原有 **Steer** |
| 普通 bot-to-bot `@mention` | **Queue** |
| foreign bot 消息首个语义行携带 `@steer` | **Steer** |
| adopt / control rewrite / listener / VC 等控制通道 | 继续强制串行 |

## 使用方式

`@steer` 可以独占一行，也可以和调整内容写在同一行；Lark 生成的收件人 `@` 行可以位于它之前：

```text
@steer
Use the new API and continue the current task.
```

```text
@TargetBot
@steer Use the new API and continue the current task.
```

例如现有发送入口无需新增业务命令：

```bash
botmux send --mention <open_id:BotName> "@steer Use the new API and continue."
```

`botmux dispatch` 另提供 sender-side 便利开关，不需要改写 brief 文件：

```bash
botmux dispatch --into <root_id> --bot-app <app_id> --steer --brief-file <path>
```

该开关只是在 brief 前幂等注入 wire-level `@steer`。也可以直接把 `@steer` 放在 brief 的首个语义行；没有该指令时，dispatch/report/普通 bot 消息都保持 Queue。

## 做了什么

- 保留 `daemon.ts` 中既有的 Codex App Steer 授权函数和 fail-closed Gate，只为它增加一个显式 foreign-bot `@steer` 授权分支。
- 新增独立、无业务语义的 `src/core/bot-steer-directive.ts`，负责解析和注入 wire directive：
  - 只识别首个语义位置的独立 `@steer` token，不匹配正文中的说明文字或 `@steering`；
  - 兼容 Lark 在正文前生成一个或多个收件人 `@` 行；
  - 支持独占行和 `@steer <content>` 两种写法；
  - 命中后从正文消费指令，模型只看到真实调整内容。
- 新话题与 thread follow-up 两条 admission 路径都在既有授权点消费该指令。
- `botmux dispatch --steer` 提供发送端便利入口，幂等注入同一个通用 wire directive；普通 dispatch 默认语义不变。
- `@steer` 本身不构成授权：接收端还必须正向判定发送方为 foreign bot，并继续经过 adopt、substitute、control rewrite、message listener、VC receiver/origin 等既有串行 Gate。
- CLI help 补充 Bot-to-bot Queue / `@steer` 的语义和写法。

实现不读取 `botmux dispatch` 的完成回报协议，不包含 Harness/Leader/职能 Agent 判断，也不依赖中文文案。

## 影响范围

- 只改变 Codex App 的显式 bot-to-bot Steer opt-in。
- 没有 `@steer` 的所有 bot 消息保持原行为。
- 非 Codex App CLI 不消费该授权标记，现有 dispatch 接收逻辑不变。
- 真人消息的既有 Steer 行为不变。

## 测试验证

```bash
pnpm vitest run --project unit \
  test/bot-steer-directive.test.ts \
  test/dispatch.test.ts \
  test/initial-user-turn-opening.test.ts \
  test/daemon-codex-app-workflow-wiring.test.ts \
  test/transfer-gate-steer-authorization.test.ts
```

结果：**5 files / 135 tests 全部通过**（rebase 至最新 `master` 后复跑）。

覆盖：

- 真人消息继续 Steer；
- foreign bot 的 `@steer` 进入真实 daemon → worker 路径并获得 Steer 授权；
- 指令在交给模型前被移除；
- 普通 foreign-bot 消息保持 Queue；
- directive 位置、inline 形式及相似字符串拒绝；
- 所有既有控制通道继续串行；
- dispatch 既有 92 项用例无回归。

完整构建：

```bash
pnpm build
```

结果：通过（TypeScript、scripts typecheck、dashboard bundle、build audit）。
