### PR TITLE
fix(terminal): 修复接入中心平台后浏览器 Web 终端的三处回归（#933 引入）

### DIFF
--- a/src/core/dashboard-url.ts
+++ b/src/core/dashboard-url.ts
@@ -177,8 +177,17 @@ export function buildV3RunDetailUrl(runId: string, opts: { host: string; port: n
  * Build the platform owner-login URL advertised by an unauthenticated
  * Dashboard response. The SPA replaces only the hash-route `next` value, so
  * the server never exposes the Dashboard token or machine tunnel credential.
+ *
+ * `next` is where the platform lands the browser AFTER it mints this machine's
+ * host-only proxy-session cookie (the credential the owner check reads; the
+ * cross-subdomain SSO cookie alone does NOT make a request owner-writable). It
+ * defaults to the SPA home `/#/`; pass a terminal path `/s/<sessionId>` so an
+ * owner opening the read-only web terminal is returned to that very terminal
+ * WITH the freshly-minted proxy cookie in place — the platform routes a
+ * `/s/`-prefixed `next` to the terminal subdomain surface, so the round-trip
+ * lands the owner back on a now-writable terminal instead of the dashboard.
  */
-export function buildPlatformDashboardLoginUrl(): string | undefined {
+export function buildPlatformDashboardLoginUrl(next: string = '/#/'): string | undefined {
   if (!isRemoteAccessEnabled()) return undefined;
   const binding = readPlatformBinding();
   const machineId = binding?.machineId.trim();
@@ -189,7 +198,8 @@ export function buildPlatformDashboardLoginUrl(): string | undefined {
       return undefined;
     }
     const loginUrl = new URL(`/open/${encodeURIComponent(machineId)}`, platform);
-    loginUrl.searchParams.set('next', '/#/');
+    // searchParams.set percent-encodes the whole value, so pass the raw path.
+    loginUrl.searchParams.set('next', next);
     return loginUrl.toString();
   } catch {
     return undefined;

--- a/src/dashboard/control-csrf.ts
+++ b/src/dashboard/control-csrf.ts
@@ -30,6 +30,7 @@
  */
 import { createHash, randomBytes } from 'node:crypto';
 import { logger } from '../utils/logger.js';
+import { platformBrowserAuthorities } from '../platform/binding.js';
 
 /** 提交控制类请求时携带 CSRF 票据的头名。`<form>` 设不了自定义头，这是关键。 */
 export const CONTROL_CSRF_HEADER = 'x-botmux-csrf';
@@ -164,7 +165,10 @@ function publicUrlAuthority(): string | undefined {
 }
 
 /** 本请求可能的自身 authority：直连是 `Host`，反代/平台隧道下还有转发头，外加
- *  运维显式声明的对外基址。 */
+ *  运维显式声明的对外基址；绑定中心平台时再加本机可信的平台浏览器子域
+ *  (`m-`/`t-<machineId>.<平台域名>`)——平台隧道反代不透传 `X-Forwarded-Host`，
+ *  这是唯一能让平台浏览器终端的同源校验认出「浏览器实际访问的子域」的候选来源
+ *  （见 {@link platformBrowserAuthorities}，每请求重读 platform.json、fail-closed）。 */
 function requestAuthorities(headers: ControlRequestHeadersLike): Array<string | undefined> {
   const forwarded = headerValue(headers['x-forwarded-host']);
   return [
@@ -172,6 +176,7 @@ function requestAuthorities(headers: ControlRequestHeadersLike): Array<string | 
     // 逗号分隔时第一个才是最初的客户端所见 host。
     forwarded ? forwarded.split(',')[0] : undefined,
     publicUrlAuthority(),
+    ...platformBrowserAuthorities(),
   ];
 }
 

--- a/src/dashboard/terminal-front-proxy.ts
+++ b/src/dashboard/terminal-front-proxy.ts
@@ -200,7 +200,25 @@ export function createTerminalFrontProxy(options: TerminalFrontProxyOptions): {
         viewForwardProof = options.viewCapabilityForwardProof?.(viewToken);
       }
     }
-    const proxyGrant = actor && !hasExplicitQueryCapability
+    // P1-6: an explicit `?token=`/`?viewToken=` query capability is normally the
+    // SOLE authorization basis — no proxy grant is injected next to it, so a wrong
+    // token can't borrow the opener's owner ambient. But a `?viewToken=` READ link
+    // is the one the Feishu card hands the owner, and stripping the owner's proxy
+    // grant there regressed the pre-3.16 behavior "owner logs in → can operate":
+    // the viewToken forced read-only and the owner's platform identity was dropped
+    // (#933). Carve out exactly that case — a verified platform OWNER opening a
+    // viewToken-only link (never `?token=`, which keeps its independent-capability
+    // path) still gets the signed WRITE grant. This does NOT reopen P1-6: the grant
+    // is minted here from `actor` — whose owner role is itself gated on the
+    // platform-injected dashboard-token cookie matching this machine's live secret
+    // (resolveDashboardIdentity), a value a viewToken holder does not possess — and
+    // travels as an HMAC-signed `X-Botmux-Terminal-Control` header, never as a
+    // passed-through client cookie/role. A guest/teammate viewToken opener has no
+    // owner actor, so this branch does not fire and they stay read-only.
+    const ownerWithViewToken = actor?.terminalCapability === 'owner'
+      && url.searchParams.has('viewToken')
+      && !url.searchParams.has('token');
+    const proxyGrant = actor && (!hasExplicitQueryCapability || ownerWithViewToken)
       ? options.control.grantForProxy(actor, parsed.sessionId)
       : undefined;
     if (actor && proxyGrant?.scope === 'read') readAuthSessionId = actor.authSessionId;

--- a/src/platform/binding.ts
+++ b/src/platform/binding.ts
@@ -89,6 +89,44 @@ export function platformMachineBaseUrl(): string | null {
 }
 
 /**
+ * 平台面向浏览器的、本机可信子域 authority 列表（`host` 形式，不含 scheme）。
+ *
+ * 中心平台把本机放在 `<前缀>-<machineId>.<平台域名>` 子域下,再经隧道反代回本机
+ * dashboard——反代时把 `Host` 改写成回环上游、且**不带 `X-Forwarded-Host`**,于是
+ * 浏览器发的管理类 WS/请求携带的 `Origin: https://<前缀>-<machineId>.<平台域名>`
+ * 在 dashboard 的同源校验里找不到匹配的候选 authority(见 dashboard/control-csrf.ts
+ * 的 `requestAuthorities`),被判跨站拒掉——平台浏览器终端 disconnected。
+ *
+ * 这里由本机 `platform.json`(0600 host-authority,machineId 平台签发、跨站页面
+ * **伪造不进**)派生出**精确前缀**的可信 authority,交给 `requestAuthorities` 并入
+ * 候选。为什么**枚举** `m-`/`t-` 精确前缀而非通配 `<任意前缀>-<machineId>`:
+ *   • 安全门须 fail-closed。枚举只依赖「这 2 个前缀反代到本机」这条弱不变量;通配
+ *     `*-<machineId>` 依赖「**任何**前缀标签都不会落到攻击者可控源」——强得多、且
+ *     本进程无从验证(平台路由表不在部署机上)。
+ *   • 失败方向相反:枚举漏一个前缀 = 那种终端连不上(响、加一行前缀即修);通配一旦
+ *     平台某天把某 `<label>-<machineId>` 挂到多租户/共享源上 = **静默把跨源认成同源**
+ *     的 CSRF 洞。宁可响不可哑。
+ * `m-` 是仓库既有约定(`platformMachineBaseUrl`);`t-` 是平台给浏览器分享链接实际使用
+ * 的独立终端子域(仓库无此字面量,故 #933 的同源门漏了它)。未绑定平台 → 返回空数组,
+ * 不放行任何平台 authority(fail-closed)。
+ *
+ * 每次调用都重读 `platform.json`(不缓存):`botmux bind|unbind` 热重载不重启 daemon
+ * (见 worker.ts 亦每请求 uncached 读),缓存会在解绑+machineToken 吊销后仍放行 stale
+ * 平台 authority = fail-open;每请求读天然 fail-closed(解绑→文件没了→空数组)。
+ */
+export function platformBrowserAuthorities(): string[] {
+  const b = readPlatformBinding();
+  if (!b) return [];
+  try {
+    const host = new URL(b.platformUrl).host;
+    if (!host) return [];
+    return [`m-${b.machineId}.${host}`, `t-${b.machineId}.${host}`];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * 自建反代对外基址（`BOTMUX_PUBLIC_URL`）：没接中心平台、但自己用 nginx 等反代把
  * dashboard 暴露到单一公网/内网域名时，设成 `http://botmux.example.com`
  * （scheme + host[:port]，尾部斜杠会被去掉）。设了之后 dashboard / 卡片终端链接改吐

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -163,6 +163,7 @@ import {
 } from './core/terminal-control-grant.js';
 import { appendControlAudit, controlAuditRecord } from './dashboard/control-audit.js';
 import { readPlatformBinding } from './platform/binding.js';
+import { buildPlatformDashboardLoginUrl } from './core/dashboard-url.js';
 import { loadDashboardSecret, loadPersistedToken } from './dashboard/auth.js';
 import { InflightInputTracker } from './core/inflight-input-tracker.js';
 import { InputTurnDeduper } from './core/input-turn-dedupe.js';
@@ -1951,6 +1952,19 @@ interface WorkerTerminalAccess extends TerminalAccessDecision {
   auditUser?: string;
   /** Fixed grant expiry. Writable WS connections are closed at this boundary. */
   controlExpiresAt?: number;
+}
+
+/**
+ * Owner-login URL for THIS session's read-only web terminal, or '' when the
+ * machine is unbound / remote access is off (banner then shows non-link text).
+ * `next=/s/<sessionId>` is what makes the round-trip land the owner back on a
+ * writable terminal: the platform routes a `/s/`-prefixed next to the terminal
+ * subdomain surface and mints the host-only proxy-session cookie there, which
+ * is the credential the owner write-check reads (the cross-subdomain SSO cookie
+ * alone does not). See buildPlatformDashboardLoginUrl.
+ */
+function deriveTerminalLoginUrl(sid: string): string {
+  return buildPlatformDashboardLoginUrl(`/s/${encodeURIComponent(sid)}`) ?? '';
 }
 
 function resolveTerminalAccessForReq(req: IncomingMessage, url: URL): WorkerTerminalAccess {
@@ -15793,7 +15807,22 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         return;
       }
       const loginHdr = req.headers['x-botmux-login-url'];
-      const loginUrl = typeof loginHdr === 'string' && /^https?:\/\/[^"'<>\s]+$/.test(loginHdr) ? loginHdr : '';
+      // The central front proxy only injects X-Botmux-Login-Url on the SPA 401
+      // path, never on `/s/` terminal requests — so a read-only web terminal
+      // showed an owner-login banner that was a dead <div> (no href). When the
+      // header is absent, self-derive the platform owner-login URL for THIS
+      // session's terminal path: `/open/<machineId>?next=/s/<sessionId>`. The
+      // `/s/` next routes the platform to the terminal subdomain surface and,
+      // after login, lands the browser back on this terminal WITH the host-only
+      // proxy-session cookie the owner check requires (the cross-subdomain SSO
+      // cookie alone does not make the request writable). Returns '' when this
+      // machine is unbound or remote access is off, so the banner falls back to
+      // its non-link text form rather than a broken link.
+      const headerLoginUrl = typeof loginHdr === 'string' && /^https?:\/\/[^"'<>\s]+$/.test(loginHdr)
+        ? loginHdr
+        : '';
+      const loginUrl = headerLoginUrl
+        || (sessionId ? deriveTerminalLoginUrl(sessionId) : '');
       // Herdr snapshots contain screen cells but not terminal mode state. On a
       // refreshed page an alt-screen CLI would otherwise look like an empty
       // normal buffer until resize causes a redraw. Preserve that mode so

--- a/test/dashboard-url.test.ts
+++ b/test/dashboard-url.test.ts
@@ -217,6 +217,18 @@ describe('buildPlatformDashboardLoginUrl', () => {
     setBinding({ platformUrl: 'https://platform.example/base', machineId: 'm/1', machineToken: 'secret' });
     expect(buildPlatformDashboardLoginUrl()).toContain('/open/m%2F1?');
   });
+
+  it('routes a `/s/<sessionId>` next so an owner logging in from the read-only terminal lands back on a writable terminal (#933)', () => {
+    setRemote(true);
+    setBinding({ platformUrl: 'https://platform.example', machineId: 'm-1', machineToken: 'secret' });
+    const url = buildPlatformDashboardLoginUrl('/s/sess-42');
+    // The platform routes a `/s/`-prefixed next to the terminal subdomain
+    // surface and mints the host-only proxy cookie there; the whole next is
+    // percent-encoded as one query value.
+    expect(url).toBe('https://platform.example/open/m-1?next=%2Fs%2Fsess-42');
+    // Default is unchanged — the existing SPA-401 caller must keep landing on /#/.
+    expect(buildPlatformDashboardLoginUrl()).toBe('https://platform.example/open/m-1?next=%2F%23%2F');
+  });
 });
 
 describe('buildV3RunDetailUrl', () => {

--- a/test/platform-browser-authorities.test.ts
+++ b/test/platform-browser-authorities.test.ts
@@ -1,0 +1,108 @@
+// test/platform-browser-authorities.test.ts
+// #933 回归修复：平台隧道反代不透传 X-Forwarded-Host、且把 Host 改写成回环上游，
+// 于是浏览器管理类 WS 携带的 `Origin: https://<前缀>-<machineId>.<平台域名>` 在
+// dashboard 同源校验里找不到候选 authority → 判跨站 403 → 平台浏览器终端 disconnected。
+// 修法：由本机 platform.json 派生 {m-,t-}<machineId>.<平台host> 精确前缀并入候选。
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const readSecureHostFileSync = vi.fn();
+vi.mock('../src/platform/secure-host-file.js', () => ({
+  readSecureHostFileSync: (...a: unknown[]) => readSecureHostFileSync(...a),
+  writeSecureHostFileSync: vi.fn(),
+  unlinkSecureHostFileSync: vi.fn(),
+  UnsafeHostAuthorityFileError: class extends Error {},
+}));
+
+import { platformBrowserAuthorities } from '../src/platform/binding.js';
+import { managementUpgradeOrigin } from '../src/dashboard/control-csrf.js';
+
+const MACHINE_ID = 'ff27a1b1e45b4504';
+function bindTo(platformUrl: string | null): void {
+  readSecureHostFileSync.mockReset();
+  readSecureHostFileSync.mockReturnValue(
+    platformUrl === null
+      ? null
+      : JSON.stringify({ platformUrl, machineId: MACHINE_ID, machineToken: 'tkn' }),
+  );
+}
+
+describe('platformBrowserAuthorities', () => {
+  beforeEach(() => readSecureHostFileSync.mockReset());
+
+  it('绑定平台时派生 m-/t- 两个精确前缀 authority（host 形式，含平台 host）', () => {
+    bindTo('https://botmux.example.com');
+    expect(platformBrowserAuthorities()).toEqual([
+      `m-${MACHINE_ID}.botmux.example.com`,
+      `t-${MACHINE_ID}.botmux.example.com`,
+    ]);
+  });
+
+  it('未绑定平台 → 空数组（fail-closed，不放行任何平台 authority）', () => {
+    bindTo(null);
+    expect(platformBrowserAuthorities()).toEqual([]);
+  });
+
+  it('platformUrl 不可解析 → 空数组，不抛', () => {
+    readSecureHostFileSync.mockReset();
+    readSecureHostFileSync.mockReturnValue(
+      JSON.stringify({ platformUrl: 'not a url', machineId: MACHINE_ID, machineToken: 'tkn' }),
+    );
+    expect(platformBrowserAuthorities()).toEqual([]);
+  });
+
+  it('每次调用都重读 platform.json（不缓存）：解绑后当次即空 = 无 fail-open', () => {
+    bindTo('https://botmux.example.com');
+    expect(platformBrowserAuthorities()).toHaveLength(2);
+    // 解绑（unbind 热重载不重启 daemon）：下一次调用必须当场读到「没绑定」。
+    bindTo(null);
+    expect(platformBrowserAuthorities()).toEqual([]);
+  });
+});
+
+describe('#933 managementUpgradeOrigin 认平台子域', () => {
+  it('平台 t- 子域 Origin 在 Host 被改写成回环、无 XFH 时仍判同源（disconnected 修复）', () => {
+    bindTo('https://botmux.example.com');
+    const verdict = managementUpgradeOrigin({
+      origin: `https://t-${MACHINE_ID}.botmux.example.com`,
+      host: '127.0.0.1:7891', // 平台隧道裸桥接后 daemon 看到的 Host
+      // 注意：无 x-forwarded-host —— 正是线上的实况
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('平台 m- 机器子域 Origin 同样判同源', () => {
+    bindTo('https://botmux.example.com');
+    const verdict = managementUpgradeOrigin({
+      origin: `https://m-${MACHINE_ID}.botmux.example.com`,
+      host: '127.0.0.1:7891',
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('反向变异守卫：未绑定平台时，同一 t- Origin 必被判跨站拒（证明放行确实来自派生而非放水）', () => {
+    bindTo(null);
+    const verdict = managementUpgradeOrigin({
+      origin: `https://t-${MACHINE_ID}.botmux.example.com`,
+      host: '127.0.0.1:7891',
+    });
+    expect(verdict.ok).toBe(false);
+  });
+
+  it('负向：别的 machineId 的平台子域仍判跨站拒（白名单精确到本机、不越界）', () => {
+    bindTo('https://botmux.example.com');
+    const verdict = managementUpgradeOrigin({
+      origin: 'https://t-deadbeefdeadbeef.botmux.example.com',
+      host: '127.0.0.1:7891',
+    });
+    expect(verdict.ok).toBe(false);
+  });
+
+  it('负向：本机 machineId 但挂在别的平台域名下仍判跨站拒（host 精确相等）', () => {
+    bindTo('https://botmux.example.com');
+    const verdict = managementUpgradeOrigin({
+      origin: `https://t-${MACHINE_ID}.evil.example.com`,
+      host: '127.0.0.1:7891',
+    });
+    expect(verdict.ok).toBe(false);
+  });
+});

--- a/test/terminal-front-proxy.test.ts
+++ b/test/terminal-front-proxy.test.ts
@@ -310,8 +310,18 @@ describe('central terminal front proxy boundary', () => {
               expect(forwarded.grantScope, cell).toBeUndefined();
               expect(forwarded.cookie, cell).toBe('botmux_dashboard_token=ambient-management-cookie');
             }
+          } else if (tokenState.name === 'viewToken' && identity.actor?.terminalCapability === 'owner') {
+            // #933 回归修复：viewToken 只读链接是飞书卡片发给 owner 的那条，owner 登录后
+            // 打开它应恢复「可操作」——proxy 为已验证 owner 补签 WRITE grant（HMAC 签名、
+            // 客户端伪造不了），与 viewToken 的只读能力叠加。这不重开 P1-6：grant 由 actor
+            // 派生，而 owner 身份本身锚在「平台注入的 cookie == 本机 live secret」上，
+            // viewToken 持有者并不具备；且仍不透传任何 ambient cookie/role。
+            expect(forwarded.grantScope, cell).toBe('write');
+            expect(forwarded.cookie, cell).toBeUndefined();
+            expect(forwarded.role, cell).toBeUndefined();
           } else {
             // 显式 query capability（对错皆然）→ 唯一授权依据：无 grant、无 ambient。
+            // （owner×viewToken 例外见上；?token= 写链接一律保持独立能力路径不补 grant。）
             expect(forwarded.grantScope, cell).toBeUndefined();
             expect(forwarded.cookie, cell).toBeUndefined();
             expect(forwarded.role, cell).toBeUndefined();
@@ -478,6 +488,82 @@ describe('central terminal front proxy boundary', () => {
       // H5 logout / session expiry sweeps this auth session — the bridged
       // read socket must die immediately, not at the token's expiry.
       control.releaseByAuthSession('h5-auth-9');
+      await closed;
+    } finally {
+      await close(front);
+      await close(upstream);
+    }
+  });
+
+  it('#933: owner + viewToken gets a WRITE bridge that logout still closes (P1-5 index holds)', async () => {
+    // The #933 regression fix hands a verified platform OWNER a signed WRITE grant
+    // even on a viewToken-only link. That grant is leaseMarker-less, so it does NOT
+    // go through registerWritableSocket — it must instead land in the auth-session
+    // read-socket index via bridgeAuthSession's `proxyGrant ? actor.authSessionId`
+    // fallback, or logout would leave the owner's writable stream alive. Prove both:
+    // (a) the owner IS granted write on a viewToken link, and (b) logout of the
+    // owner's auth session closes that very socket.
+    const control = new TerminalControlManager({ secret: SECRET, audit: { append() {} } });
+    let bridgedGrantScope: 'read' | 'write' | undefined;
+    const upstream = createServer(() => {});
+    upstream.on('upgrade', (req, socket) => {
+      const raw = req.headers[TERMINAL_CONTROL_HEADER];
+      const verified = typeof raw === 'string'
+        ? verifyTerminalControlGrant(SECRET, raw, 's1')
+        : undefined;
+      bridgedGrantScope = verified?.ok ? verified.claims.scope : undefined;
+      socket.write('HTTP/1.1 101 Switching Protocols\r\nupgrade: websocket\r\nconnection: Upgrade\r\n\r\n');
+      socket.on('end', () => socket.destroy());
+      socket.on('error', () => socket.destroy());
+    });
+    const upstreamPort = await listen(upstream);
+    const ownerAuthSession = 'platform:machine:owner';
+    const proxy = createTerminalFrontProxy({
+      resolvePort: () => upstreamPort,
+      // A verified platform owner (its owner role is itself gated on the
+      // dashboard-token cookie === live secret inside resolveDashboardIdentity;
+      // a viewToken holder cannot forge it).
+      resolveActor: () => ({
+        userId: 'platform:machine:owner',
+        authSessionId: ownerAuthSession,
+        expiresAt: Number.MAX_SAFE_INTEGER,
+        terminalCapability: 'owner' as const,
+      }),
+      control,
+      isAuthSessionLive: () => true,
+    });
+    const front = createServer((_req, res) => res.writeHead(404).end());
+    front.on('upgrade', (req, socket, head) => {
+      if (!proxy.handleUpgrade(req, socket, head)) socket.destroy();
+    });
+    const frontPort = await listen(front);
+    try {
+      const client = connect(frontPort, '127.0.0.1');
+      const upgraded = new Promise<void>((resolve, reject) => {
+        let raw = '';
+        client.on('data', chunk => {
+          raw += chunk.toString();
+          if (raw.includes('101')) resolve();
+        });
+        client.on('error', reject);
+        setTimeout(() => reject(new Error(`no 101 upgrade\n${raw}`)), 4_000).unref();
+      });
+      // viewToken-only link (never ?token=) — the exact shape the Feishu card
+      // hands the owner. Any opaque view token; the owner's grant is what carries
+      // write, not the token.
+      client.write(
+        'GET /s/s1/?viewToken=opaque-view-capability HTTP/1.1\r\nHost: front\r\n'
+        + 'Upgrade: websocket\r\nConnection: Upgrade\r\n'
+        + 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n',
+      );
+      await upgraded;
+      // (a) the owner actually received a WRITE grant on the viewToken link.
+      expect(bridgedGrantScope).toBe('write');
+      // (b) logging out the owner's auth session closes this writable bridge now.
+      // Without the :203 carve-out, proxyGrant would be undefined → the socket is
+      // never indexed → this close never fires and the test times out.
+      const closed = new Promise<void>(resolve => client.on('close', () => resolve()));
+      control.releaseByAuthSession(ownerAuthSession);
       await closed;
     } finally {
       await close(front);


### PR DESCRIPTION
## 背景

#933（Agent Workbench，3.16.0 首含）给 web 终端加了整套新安全层（CSRF/Origin 门、viewToken 只读能力、接管租约），同时打破了「走中心平台在浏览器打开终端」的**三处既有体验**。三处同根一族、均在 botmux 侧修复，平台侧无需改动。用户实测：升级到 3.16.0 前一切正常。

## 三处回归与修复

### 1. 终端 disconnected
WS 升级的 Origin 同源门 `managementUpgradeOrigin` 不认平台给浏览器分享终端用的 `t-<machineId>.<平台域名>` 子域。平台隧道把请求裸桥接回本机 dashboard 时改写 Host 为回环、且**不带 X-Forwarded-Host**，浏览器 Origin 找不到候选 authority → 判跨站 403（WS 的 403 浏览器拿不到状态码，只表现为 disconnected；HTTP GET 无此门故页面能开、只有流断）。

**修复**：新增 `platformBrowserAuthorities()`，由本机 `platform.json` **每请求**派生 `{m-,t-}<machineId>.<平台host>` 精确前缀并入 `requestAuthorities` 候选。
- 每请求重读、**不缓存**：`bind/unbind` 热重载不重启 daemon，缓存会在解绑 + machineToken 吊销后仍放行 stale = fail-open；每请求读天然 fail-closed（解绑→文件没了→空数组）。
- **枚举**精确前缀而非通配 `*-<machineId>`：安全门须 fail-closed。漏前缀 = 终端连不上（响，加一行即修）；通配一旦某 `<label>-<machineId>` 挂到共享/多租户源 = 静默把跨源认成同源的 CSRF 洞。宁可响不可哑。

### 2. owner 飞书登录后仍只读
front-proxy 对「带 query 凭据」一律剥掉平台注入的 owner 身份（cookie+role）。viewToken 只读链接（飞书卡片发给 owner 的那条）因此把 owner 的写权限也剥没了，退化只读。

**修复**：front-proxy 对「已验证平台 owner + 仅 viewToken（非 `?token=`）」补签既有的 HMAC 签名 **write grant**（`X-Botmux-Terminal-Control`）。viewToken 给读、签名 grant 给写，叠加。
- 不重开 P1-6：owner 身份锚在「平台注入 dashboard-token cookie == 本机 live secret」上，viewToken 持有者不具备；且**零原始 cookie/role 透传**（走签名 grant 非 header 放行）。guest/teammate 无 owner actor，该分支不触发，仍只读。
- 该 grant 无 leaseMarker，经 `registerReadSocket` 登记进 auth-session 索引 → owner 登出/轮转时随之关闭（P1-5 不漏）。

### 3. owner 登录 banner 点击无反应
让 banner 变可点的 `X-Botmux-Login-Url` 头**从未在 `/s/` 终端反代路径注入**（仅 dashboard SPA 401 路径注入），故 banner 退化成无 href 的死 `<div>`。此前因 WS 连不上无人走到「看得见 banner」，第 1 处修好后才暴露（并非本次引入）。

**修复**：worker 自派生登录 URL（本就有 `sessionId` + 读 `platform.json`），指向 `/open/<machineId>?next=/s/<sessionId>`。`/s/` 前缀的 next 使平台路由到**终端子域**登录、在该子域下发 host-only proxy-session cookie（owner 写判定读的正是它；跨子域 SSO cookie 不足以拿写），登录后 302 回本终端且已可写。`buildPlatformDashboardLoginUrl` 加 `next` 参数（默认 `/#/` 不变，dashboard 401 老调用零影响）。

## 影响面

- **公共层 `requestAuthorities`**：同时喂 WS 升级门 / 有副作用 POST 的 CSRF 门（takeover·unlock）/ standing-link 同源判定。放宽平台 authority 对三者都成立且正确——平台 Origin 的接管/解锁本就应被认作同源（此前也在默默吃 403）。
- 改动集中在 dashboard 终端反代 + worker 终端 HTTP，**不影响非平台路径**（本地直连 / 自建反代 `BOTMUX_PUBLIC_URL`）。
- 跨 CLI/后端：终端反代与 worker HTTP 是所有 CLI × 后端共用的读屏/操作通道，改动只在「平台绑定 + 浏览器 Origin/登录」这一维，未触碰 PTY/tmux/adapter 逻辑。

## 验证

- `pnpm build` 全绿（tsc + typecheck:scripts + dashboard bundle + audit-dist）。
- 新增/改动测试 **146 相关用例通过**：平台 authority 派生（含未绑定 fail-closed / 不缓存 / 别的 machineId 与别的平台域名仍拒）、同源门认平台 `t-`/`m-` 子域、owner viewToken 可写、**owner 登出即断写 socket**、login URL `next=/s/` 正确编码且默认不变。
- **三处均做反向变异**：各自回退 → 对应断言立即转红；尤其「owner 登出即断写 socket」回退后 socket 不登记 → 测试超时，钉死 P1-5 socket 索引。
- **真机实测**（部署本 checkout 到 live daemon）：终端可连（CSRF 判跨站拒归零）、owner 登录后直接可操作、banner 引导登录闭环。
- 平台侧 `/open`→`/__open`→在 `t-` 子域下发 proxy cookie 的登录回跳链路经**交叉核实闭环、无需平台改动**（`/s/` 前缀 next 判 terminal surface；302 与 Set-Cookie 同响应、同 host 跳转，SameSite=Lax 不丢 cookie）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)