### PR TITLE
fix(dashboard): 修复上下文注入开关刷新后复位

### DIFF
--- a/src/dashboard/bot-payload.ts
+++ b/src/dashboard/bot-payload.ts
@@ -126,6 +126,7 @@ export function botDefaultsPayload(bot: DashboardBotDescriptor, j?: any, error?:
       : null,
     messageQuotaDefaultLimit: typeof j?.messageQuotaDefaultLimit === 'number' ? j.messageQuotaDefaultLimit : null,
     p2pMode: j?.p2pMode === 'thread' ? 'thread' : j?.p2pMode === 'group' ? 'group' : 'chat',
+    envelopeInjection: j?.envelopeInjection === 'auto' ? 'auto' : 'off',
     skillInjection: (j?.skillInjection === 'global' || j?.skillInjection === 'prompt' || j?.skillInjection === 'off') ? j.skillInjection : null,
     skillInjectionDefault: (j?.skillInjectionDefault === 'global' || j?.skillInjectionDefault === 'off') ? j.skillInjectionDefault : 'prompt',
     skillInjectionSupport: (j?.skillInjectionSupport === 'dynamic' || j?.skillInjectionSupport === 'global') ? j.skillInjectionSupport : 'none',

--- a/test/dashboard-bot-payload.test.ts
+++ b/test/dashboard-bot-payload.test.ts
@@ -19,7 +19,7 @@ describe('dashboard bot payload helpers', () => {
       'botToBotSameDir', 'brandLabel', 'canTalkDaemonCommands', 'cliRuntime', 'codexAppCleanInput',
       'customPassthroughCommands', 'defaultOncall', 'defaultWorkingDir',
       'defaultWorkingDirAutoWorktree', 'disableStreamingCard', 'docSubscribeDefaultMode',
-      'env', 'grantDefaultDurationMs', 'launchShell', 'maxLiveWorkers', 'messageQuotaDefaultLimit', 'model',
+      'envelopeInjection', 'env', 'grantDefaultDurationMs', 'launchShell', 'maxLiveWorkers', 'messageQuotaDefaultLimit', 'model',
       'feedback',
       'overloadAlert', 'p2pMode', 'p2pOpen', 'privateCard', 'regularGroupMentionMode',
       'regularGroupReplyMode', 'restrictGrantCommands', 'riff', 'sandbox', 'sandboxPaths',
@@ -173,6 +173,15 @@ describe('dashboard bot payload helpers', () => {
     expect(botDefaultsPayload(daemon, {})).toMatchObject({ codexAppCleanInput: false });
     expect(botDefaultsPayload(daemon, { codexAppCleanInput: true }))
       .toMatchObject({ codexAppCleanInput: true });
+  });
+
+  it('projects hook envelope injection so the dashboard preserves it after refresh', () => {
+    const daemon = { larkAppId: 'app_claude', botName: 'Claude', cliId: 'claude-code' };
+    expect(botDefaultsPayload(daemon, {})).toMatchObject({ envelopeInjection: 'off' });
+    expect(botDefaultsPayload(daemon, { envelopeInjection: 'auto' }))
+      .toMatchObject({ envelopeInjection: 'auto' });
+    expect(botDefaultsPayload(daemon, { envelopeInjection: 'invalid' }))
+      .toMatchObject({ envelopeInjection: 'off' });
   });
 
   it('projects the usage-display mode, defaulting to streaming and honoring legacy/off', () => {


### PR DESCRIPTION
## 改了什么

- 在 Dashboard 聚合 `/api/bots` 行时补充 `envelopeInjection` 字段投影。
- 保留合法的 `auto` 配置，缺省或异常值统一回落为 `off`。
- 把该字段加入 Bot Defaults 可编辑字段契约，并补充刷新回显回归测试。

## 为什么

Daemon 的 `/api/bot-default-oncall` 已返回并持久化 `envelopeInjection=auto`，但 Dashboard 的 `botDefaultsPayload()` 未把该字段传给前端。因此用户勾选成功后，页面刷新会收到缺失值并错误显示为关闭；实际配置通常仍已生效。

## 影响面

- 仅修改 Dashboard 私有 Bot Defaults 聚合 payload 与对应单测。
- 不改变配置写入、daemon 热更新、Claude Code hook 注入逻辑。
- 不影响其它 CLI、后端、会话类型或公开群机器人名册 payload。

## 验证

- `pnpm vitest run --project unit test/dashboard-bot-payload.test.ts`
  - 1 个测试文件通过，24 个测试通过。
- `pnpm build`
  - TypeScript、脚本类型检查、Dashboard bundle、dist audit 全部通过。
- `git diff --check`
  - 通过。
