### PR TITLE
fix(backend): tmux server 抖动不再被误判为会话死亡引发全群雪崩

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -30,6 +30,35 @@ const FISH_PANE_ENV_UNSET_CLAUSE = `set -e ${PANE_ENV_UNSET_KEYS.join(' ')}`;
 let serverGlobalEnvScrubbed = false;
 
 /**
+ * True when a tmux client's stderr reports a CONNECTION-level failure — the
+ * client never got an answer from the shared server, so the error proves
+ * nothing about any particular session/pane:
+ *   - "error connecting to <socket> (Connection refused)" — Linux fails
+ *     unix-socket connect() with an INSTANT clean ECONNREFUSED when the
+ *     server's accept backlog overflows. A busy-but-alive server (stalled a
+ *     couple of seconds under load while hundreds of workers probe it every
+ *     second) mass-produces exactly this error.
+ *   - "error connecting to <socket> (No such file or directory)" — socket file
+ *     missing (server down, or the file was cleaned from /tmp under a live
+ *     server).
+ *   - "lost server" / "server exited unexpectedly" — the connection died
+ *     mid-command.
+ *
+ * Probes must classify these as 'unknown', NEVER as an authoritative
+ * 'missing': on 2026-08-20 a few seconds of backlog overflow on the default
+ * server made every worker's liveness probe read clean-exit "error connecting"
+ * as "pane gone", and the daemon tore down / force-FRESHed dozens of live
+ * sessions across all bots simultaneously.
+ *
+ * Deliberately NOT matched: "no server running on <socket>" — the client did
+ * determine that no server owns the socket, and a not-running server provably
+ * has no sessions, so that one stays an authoritative 'missing'.
+ */
+export function isTmuxServerLevelErrorText(stderrText: string): boolean {
+  return /error connecting to|lost server|server exited unexpectedly/i.test(stderrText);
+}
+
+/**
  * TmuxBackend — session backend using tmux for process persistence.
  *
  * Architecture: pty-under-tmux.
@@ -99,15 +128,23 @@ export class TmuxBackend implements SessionBackend {
   /**
    * Tri-state existence probe. `tmux has-session` exits 0 when the session
    * exists and exits 1 (clean status, no signal) when the server answered but
-   * the session is absent — INCLUDING "no server running". Both collapse to
-   * 'missing' here. 'missing' is NOT a destructive signal on restore: whether a
-   * single pane died (solo crash) or the whole server is gone (machine reboot),
-   * the CLI transcript on disk is still resumable, so restore keeps the session
-   * active and cold-resumes it on the next message (see restoreActiveSessions).
+   * the session is absent — including "no server running" (a not-running server
+   * provably has no sessions). 'missing' is NOT a destructive signal on restore:
+   * whether a single pane died (solo crash) or the whole server is gone (machine
+   * reboot), the CLI transcript on disk is still resumable, so restore keeps the
+   * session active and cold-resumes it on the next message (see
+   * restoreActiveSessions).
+   *
+   * A clean non-zero exit whose stderr is a CONNECTION-level failure ("error
+   * connecting to <socket>", "lost server", …) is 'unknown', not 'missing': the
+   * client never reached the server, so it proved nothing about this session.
+   * Linux fails unix-socket connect() with instant ECONNREFUSED when the
+   * server's accept backlog overflows — a busy-but-alive shared server briefly
+   * looks exactly like this, and 2026-08-20 that misread made kill-verify /
+   * liveness paths treat dozens of live sessions as gone at once.
    * Anything else — a timeout (signal/killed) or a spawn failure (binary not on
    * PATH → ENOENT, not executable → EACCES; neither carries a numeric exit
-   * status) — means we never got an answer → 'unknown', so a flaky/unavailable
-   * tmux can't be mistaken for a gone session either.
+   * status) — also means we never got an answer → 'unknown'.
    *
    * Uses execFileSync (NOT a shell string): running tmux directly keeps a
    * missing/unrunnable binary as ENOENT/EACCES. A shell would instead surface
@@ -116,10 +153,18 @@ export class TmuxBackend implements SessionBackend {
    */
   static probeSession(name: string): SessionProbe {
     try {
-      execFileSync('tmux', ['has-session', '-t', name], { stdio: 'ignore', env: tmuxEnv(), timeout: 3000 });
+      execFileSync('tmux', ['has-session', '-t', name], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        env: tmuxEnv(),
+        timeout: 3000,
+      });
       return 'exists';
     } catch (e: any) {
-      if (e && typeof e.status === 'number' && !e.signal) return 'missing';
+      if (e && typeof e.status === 'number' && !e.signal) {
+        const stderrText = (e.stderr?.toString?.() ?? '').trim();
+        if (isTmuxServerLevelErrorText(stderrText)) return 'unknown';
+        return 'missing';
+      }
       return 'unknown';
     }
   }

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -31,13 +31,49 @@ import { randomBytes } from 'node:crypto';
 import { StringDecoder } from 'node:string_decoder';
 import type { SessionBackend, SessionProbe, SpawnOpts } from './types.js';
 import { tmuxEnv } from '../../setup/ensure-tmux.js';
-import { buildBotmuxEnvAssignments, resolveUserShell, shellWrapperScript, shellCommandArgv, shellKindForPath, TmuxBackend } from './tmux-backend.js';
+import { buildBotmuxEnvAssignments, resolveUserShell, shellWrapperScript, shellCommandArgv, shellKindForPath, TmuxBackend, isTmuxServerLevelErrorText } from './tmux-backend.js';
 import { resolveBotmuxWrapperBinDir } from '../../core/botmux-wrapper.js';
 import { LivenessGate, ADOPT_LIVENESS_MAX_FAILURES } from './liveness-gate.js';
 
 function shellescape(s: string): string {
   // Single-quote-escape, replacing internal ' with '\''
   return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/** Blocking sleep for the synchronous spawn path (SessionBackend.spawn is sync).
+ *  Atomics.wait is allowed on Node's main thread and burns no CPU — spawn only
+ *  runs during session startup, so briefly blocking the worker is fine. */
+function sleepSyncMs(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** Retry delays for startup-time tmux commands (new-session / pipe-pane).
+ *  A daemon restore or a post-outage restart herd hammers the shared server
+ *  with connects; first attempts routinely eat an instant ECONNREFUSED
+ *  (accept-backlog overflow). Two spaced retries ride out a several-second
+ *  stall instead of surfacing "会话启动失败" to every chat at once. */
+const STARTUP_TMUX_RETRY_DELAYS_MS = [1000, 3000];
+
+let startupRetrySleepFn: (ms: number) => void = sleepSyncMs;
+
+/** Test seam: the startup retries sleep SYNCHRONOUSLY (Atomics.wait ignores
+ *  fake timers), which would add real seconds to the unit suite. Pass null to
+ *  restore the real sleep. */
+export function setStartupTmuxRetrySleepForTests(fn: ((ms: number) => void) | null): void {
+  startupRetrySleepFn = fn ?? sleepSyncMs;
+}
+
+/** Is a failed startup-time tmux command worth retrying? A clean non-zero exit
+ *  whose stderr is NOT a connection-level error means the server answered and
+ *  rejected deterministically ("can't find pane", "duplicate session", bad
+ *  option) — retrying only delays the same failure. Everything else (connect
+ *  refused/no socket, command timeout, spawn-level EMFILE/EAGAIN) is plausibly
+ *  transient under a stalled/overloaded shared server. */
+function isRetryableStartupTmuxFailure(err: any): boolean {
+  if (err && typeof err.status === 'number' && !err.signal) {
+    return isTmuxServerLevelErrorText((err.stderr?.toString?.() ?? '').trim());
+  }
+  return true;
 }
 
 /** Convert `\n` to `\r\n` while leaving existing `\r\n` alone. Exported for
@@ -183,6 +219,22 @@ export class TmuxPipeBackend implements SessionBackend {
    *  spawn failures are classified as unknown and never enter this destructive
    *  counter. (Adopted CLI pid-death stays decisive.) */
   private readonly livenessGate = new LivenessGate(ADOPT_LIVENESS_MAX_FAILURES);
+  /** Consecutive lifecycle probes that did NOT answer 'exists' (missing OR
+   *  unknown). Drives probe-interval backoff only — never a teardown decision:
+   *  during a shared-server outage hundreds of workers re-probing every second
+   *  are themselves part of the connect-storm that keeps the accept backlog
+   *  overflowing. */
+  private probeSetbackStreak = 0;
+  /** Wall-clock start of an unbroken run of CONNECTION-level probe failures
+   *  (see probePaneAddressability serverLevel). Connection failures are
+   *  'unknown' and never trip the liveness gate — but a genuinely dead server
+   *  also produces them forever, and its panes ARE dead. Escalate to pane-exit
+   *  only after the server has been continuously unreachable for
+   *  SERVER_OUTAGE_ESCALATE_MS. Cleared by any server-answered probe; probe
+   *  timeouts leave it untouched (a wedged-but-alive server neither proves nor
+   *  disproves the outage). */
+  private serverUnreachableSince: number | null = null;
+  private static readonly SERVER_OUTAGE_ESCALATE_MS = 60_000;
   private cols = 200;
   private rows = 50;
   private exited = false;
@@ -287,16 +339,32 @@ export class TmuxPipeBackend implements SessionBackend {
     // Step 3: ask tmux to replicate the pane's bytes into our fifo.
     // -O causes tmux to overwrite any prior pipe-pane subscription.
     // The shell command must redirect to the fifo; tmux runs it via /bin/sh.
-    try {
-      execSync(
-        `tmux pipe-pane -O -t ${shellescape(this.paneTarget)} 'cat > ${shellescape(this.fifoPath)}'`,
-        { stdio: 'ignore', timeout: 5000, env: tmuxEnv() },
-      );
-      this.pipeAttached = true;
-      this.startLifecycleWatcher();
-    } catch (err: any) {
-      this.fireExit(1, null);
-      throw err;
+    // Bounded retries: this exact command failing with an instant clean
+    // connect error during a shared-server stall / restart herd is what turned
+    // the 2026-08-20 outage into user-visible "会话启动失败" across chats.
+    // Retrying is idempotent (-O overwrites any prior subscription); a
+    // deterministic server-answered rejection (pane genuinely gone) is
+    // re-thrown at once instead of delaying the same failure.
+    for (let attempt = 0; ; attempt++) {
+      try {
+        execSync(
+          `tmux pipe-pane -O -t ${shellescape(this.paneTarget)} 'cat > ${shellescape(this.fifoPath)}'`,
+          { stdio: ['ignore', 'ignore', 'pipe'], timeout: 5000, env: tmuxEnv() },
+        );
+        this.pipeAttached = true;
+        this.startLifecycleWatcher();
+        break;
+      } catch (err: any) {
+        if (!isRetryableStartupTmuxFailure(err) || attempt >= STARTUP_TMUX_RETRY_DELAYS_MS.length) {
+          this.fireExit(1, null);
+          throw err;
+        }
+        const detail = (err?.stderr?.toString?.() ?? '').trim() || err?.message || String(err);
+        process.stderr.write(
+          `[tmux-pipe-backend] pipe-pane attach failed (attempt ${attempt + 1}/${STARTUP_TMUX_RETRY_DELAYS_MS.length + 1}); retrying: ${detail}\n`,
+        );
+        startupRetrySleepFn(STARTUP_TMUX_RETRY_DELAYS_MS[attempt]);
+      }
     }
   }
 
@@ -543,6 +611,8 @@ export class TmuxPipeBackend implements SessionBackend {
   private startLifecycleWatcher(): void {
     this.stopLifecycleWatcher();
     this.livenessGate.reset();
+    this.probeSetbackStreak = 0;
+    this.serverUnreachableSince = null;
     const poll = () => {
       if (this.exited) return;
       // The watched CLI pid (adopt mode) is a pure process.kill(pid,0) syscall —
@@ -556,19 +626,49 @@ export class TmuxPipeBackend implements SessionBackend {
         this.handlePaneExit();
         return;
       }
-      this.recordPaneProbe(this.probePaneAddressability(2000));
-      if (!this.exited) this.lifecycleTimer = setTimeout(poll, 1000);
+      const probe = this.probePaneAddressability(2000);
+      this.probeSetbackStreak = probe.state === 'exists' ? 0 : this.probeSetbackStreak + 1;
+      this.recordPaneProbe(probe);
+      if (!this.exited) this.lifecycleTimer = setTimeout(poll, this.nextProbeDelayMs());
     };
     this.lifecycleTimer = setTimeout(poll, tmuxLifecycleInitialDelayMs(this.paneTarget));
   }
 
   /**
-   * Tri-state pane probe. A clean tmux rejection is `missing`; timeout, signal,
-   * EMFILE/ENFILE and spawn failures are `unknown`, because the shared server
-   * never answered. Collapsing those into false caused every worker to destroy
-   * a live bmx-* session when the default server had a short outage.
+   * Probe-interval backoff: 1s while healthy, then 3s / 9s (capped) while probes
+   * keep NOT answering 'exists'. Two purposes:
+   *   - stretches the missing-streak teardown window from ~3s to ~13s+, so a
+   *     short shared-server stall no longer converts into a fleet-wide teardown;
+   *   - sheds probe load exactly when the shared server is struggling — the
+   *     per-second re-probes from every worker are themselves connect-storm fuel
+   *     (each refused connect frees a backlog slot another worker instantly
+   *     takes).
+   * Detection latency for a genuinely dead pane grows to ~13s worst-case, which
+   * is acceptable: writes still fail fast via guardedSend (its own probe fires
+   * teardown immediately when the pane is authoritatively gone), and adopt-mode
+   * pid-death above stays on the ≤ current-interval path.
    */
-  private probePaneAddressability(timeoutMs: number): { state: SessionProbe; reason?: string } {
+  private nextProbeDelayMs(): number {
+    if (this.probeSetbackStreak <= 0) return 1000;
+    return Math.min(1000 * 3 ** this.probeSetbackStreak, 9000);
+  }
+
+  /**
+   * Tri-state pane probe. A clean tmux rejection that the SERVER actually
+   * answered is `missing`; timeout, signal, EMFILE/ENFILE and spawn failures
+   * are `unknown`, because the shared server never answered. Collapsing those
+   * into false caused every worker to destroy a live bmx-* session when the
+   * default server had a short outage.
+   *
+   * CONNECTION-level clean failures ("error connecting to <socket>", "lost
+   * server" — see isTmuxServerLevelErrorText) are `unknown` too, flagged
+   * `serverLevel` so the caller can run the dead-server escalation clock: a
+   * briefly stalled server refuses connects instantly (unix-socket backlog
+   * overflow ⇒ clean ECONNREFUSED), which is indistinguishable from a missing
+   * pane by exit status alone. Misreading it as `missing` mass-tore-down every
+   * live session across all bots at once (2026-08-20 incident).
+   */
+  private probePaneAddressability(timeoutMs: number): { state: SessionProbe; reason?: string; serverLevel?: boolean } {
     try {
       const paneId = execFileSync(
         'tmux', ['display-message', '-p', '-t', this.paneTarget, '#{pane_id}'],
@@ -578,6 +678,9 @@ export class TmuxPipeBackend implements SessionBackend {
     } catch (err: any) {
       if (err && typeof err.status === 'number' && !err.signal) {
         const stderr = (err.stderr?.toString?.() ?? '').trim();
+        if (isTmuxServerLevelErrorText(stderr)) {
+          return { state: 'unknown', reason: stderr, serverLevel: true };
+        }
         return { state: 'missing', reason: stderr || `tmux display-message exited ${err.status}` };
       }
       const detail = (err?.stderr?.toString?.() ?? '').trim()
@@ -598,13 +701,30 @@ export class TmuxPipeBackend implements SessionBackend {
    * `missing` confirmation detach the observer. Any success resets.
    * (pid-death is handled decisively in the watcher — see startLifecycleWatcher.)
    */
-  private recordPaneProbe(probe: { state: SessionProbe; reason?: string }): void {
+  private recordPaneProbe(probe: { state: SessionProbe; reason?: string; serverLevel?: boolean }): void {
     if (this.exited) return;
     if (probe.state === 'unknown') {
       // Unknown is not evidence of death. Reset the destructive streak so a
       // timeout cannot combine with later unrelated misses, and rate-limit the
       // diagnostic because every managed worker polls this shared server.
       this.livenessGate.reset();
+      if (probe.serverLevel) {
+        // Connection-level failure: could be a live-but-stalled server (ride it
+        // out) or a genuinely dead one (its panes died with it). Run the
+        // escalation clock — only an UNBROKEN run of connection failures longer
+        // than SERVER_OUTAGE_ESCALATE_MS declares the server (and this pane)
+        // dead. Probe timeouts deliberately don't clear the clock: a wedged
+        // server never produced an answer either way.
+        if (this.serverUnreachableSince === null) {
+          this.serverUnreachableSince = Date.now();
+        } else if (Date.now() - this.serverUnreachableSince >= TmuxPipeBackend.SERVER_OUTAGE_ESCALATE_MS) {
+          process.stderr.write(
+            `[tmux-pipe-backend] tmux server continuously unreachable for ${Math.round((Date.now() - this.serverUnreachableSince) / 1000)}s; declaring ${this.ownsSession ? 'managed' : 'adopted'} pane dead (${probe.reason ?? 'connection error'})\n`,
+          );
+          this.handlePaneExit();
+          return;
+        }
+      }
       const now = Date.now();
       if (now - this.lastUnknownProbeLogAt >= 30_000) {
         this.lastUnknownProbeLogAt = now;
@@ -614,6 +734,10 @@ export class TmuxPipeBackend implements SessionBackend {
       }
       return;
     }
+
+    // Server answered (exists OR authoritative missing) — the outage clock
+    // only measures unbroken connection-level silence.
+    this.serverUnreachableSince = null;
 
     const alive = probe.state === 'exists';
     if (!this.livenessGate.record(alive)) {
@@ -635,10 +759,42 @@ export class TmuxPipeBackend implements SessionBackend {
       );
       return;
     }
+    // Server-level circuit breaker: destroying worker/session state over a
+    // "missing" verdict is only safe when the SERVER itself demonstrably
+    // answers. An independent list-sessions cross-check catches any
+    // still-misclassified server failure mode (unrecognised stderr wording,
+    // future tmux message changes) before it becomes a mass teardown.
+    if (!TmuxPipeBackend.tmuxServerAnswers(3000)) {
+      this.livenessGate.reset();
+      if (this.serverUnreachableSince === null) this.serverUnreachableSince = Date.now();
+      process.stderr.write(
+        `[tmux-pipe-backend] pane reported missing but tmux server is not answering; treating as server outage and staying attached\n`,
+      );
+      return;
+    }
     process.stderr.write(
       `[tmux-pipe-backend] ${this.ownsSession ? 'managed' : 'adopted'} pane gone after ${ADOPT_LIVENESS_MAX_FAILURES} consecutive authoritative misses; detaching observer\n`,
     );
     this.handlePaneExit();
+  }
+
+  /** Does the shared tmux server answer at all? A running server always has at
+   *  least one session (tmux exits when its last session closes), so a clean
+   *  `list-sessions` success is proof the server is up and processing clients.
+   *  Any failure — connect refused, no server, timeout — reads as "not
+   *  answering". Used purely as a pre-teardown cross-check; never destructive
+   *  on its own. */
+  private static tmuxServerAnswers(timeoutMs: number): boolean {
+    try {
+      execFileSync('tmux', ['list-sessions'], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        timeout: timeoutMs,
+        env: tmuxEnv(),
+      });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private stopLifecycleWatcher(): void {
@@ -673,7 +829,7 @@ export class TmuxPipeBackend implements SessionBackend {
       resolveBotmuxWrapperBinDir(opts.env ?? process.env),
       shellKindForPath(shellSpec.shell),
     );
-    execFileSync('tmux', [
+    const argv = [
       'new-session',
       '-d',
       '-s', this.paneTarget,
@@ -685,12 +841,32 @@ export class TmuxPipeBackend implements SessionBackend {
         ...envAssignments,
         bin, ...args,
       ]),
-    ], {
-      cwd: opts.cwd,
-      stdio: 'ignore',
-      timeout: 5000,
-      env: tmuxEnv(opts.env),
-    });
+    ];
+    // Bounded retries against a stalled shared server (instant clean
+    // ECONNREFUSED under backlog overflow), a command timeout, or a
+    // spawn-level EMFILE/EAGAIN. A server-answered deterministic rejection
+    // (bad option, …) is re-thrown at once. "duplicate session" on a RETRY
+    // means an earlier timed-out attempt actually created the session
+    // server-side → treat as success.
+    for (let attempt = 0; ; attempt++) {
+      try {
+        execFileSync('tmux', argv, {
+          cwd: opts.cwd,
+          stdio: ['ignore', 'ignore', 'pipe'],
+          timeout: 5000,
+          env: tmuxEnv(opts.env),
+        });
+        break;
+      } catch (err: any) {
+        const stderrText = (err?.stderr?.toString?.() ?? '').trim();
+        if (attempt > 0 && /duplicate session/i.test(stderrText)) break;
+        if (!isRetryableStartupTmuxFailure(err) || attempt >= STARTUP_TMUX_RETRY_DELAYS_MS.length) throw err;
+        process.stderr.write(
+          `[tmux-pipe-backend] new-session failed (attempt ${attempt + 1}/${STARTUP_TMUX_RETRY_DELAYS_MS.length + 1}); retrying: ${stderrText || err?.message || err}\n`,
+        );
+        startupRetrySleepFn(STARTUP_TMUX_RETRY_DELAYS_MS[attempt]);
+      }
+    }
     this.applySessionOptions();
   }
 

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -760,11 +760,21 @@ export class TmuxPipeBackend implements SessionBackend {
       return;
     }
     // Server-level circuit breaker: destroying worker/session state over a
-    // "missing" verdict is only safe when the SERVER itself demonstrably
-    // answers. An independent list-sessions cross-check catches any
-    // still-misclassified server failure mode (unrecognised stderr wording,
-    // future tmux message changes) before it becomes a mass teardown.
-    if (!TmuxPipeBackend.tmuxServerAnswers(3000)) {
+    // "missing" verdict is only safe when the SERVER is not merely UNREACHABLE.
+    // The cross-check distinguishes the server's two failure modes:
+    //   - 'unreachable' (connect refused / lost server / timeout / spawn fail):
+    //     the client never reached the server, which may be a live-but-stalled
+    //     shared server — stay attached and let the outage clock run.
+    //   - 'down' ("no server running"): the server answered that it is not
+    //     running. For a SOLE-SESSION socket that happens precisely BECAUSE
+    //     this pane died (its session was the server's last, so the server
+    //     exited) — the pane is authoritatively gone, so fall through to
+    //     teardown. Collapsing 'down' into "not answering" hung a sole-session
+    //     worker forever: the authoritative-missing branch above reset
+    //     serverUnreachableSince every probe, so the 60s escalation never
+    //     accrued and this cross-check blocked teardown on every pass.
+    const reach = TmuxPipeBackend.tmuxServerReachability(3000);
+    if (reach === 'unreachable') {
       this.livenessGate.reset();
       if (this.serverUnreachableSince === null) this.serverUnreachableSince = Date.now();
       process.stderr.write(
@@ -778,22 +788,38 @@ export class TmuxPipeBackend implements SessionBackend {
     this.handlePaneExit();
   }
 
-  /** Does the shared tmux server answer at all? A running server always has at
-   *  least one session (tmux exits when its last session closes), so a clean
-   *  `list-sessions` success is proof the server is up and processing clients.
-   *  Any failure — connect refused, no server, timeout — reads as "not
-   *  answering". Used purely as a pre-teardown cross-check; never destructive
-   *  on its own. */
-  private static tmuxServerAnswers(timeoutMs: number): boolean {
+  /** Three-state server reachability cross-check. A running server always has
+   *  at least one session (tmux exits when its last session closes), so a clean
+   *  `list-sessions` success ⇒ 'up'. The two failure modes must NOT be
+   *  collapsed, or the pre-teardown cross-check hangs a sole-session worker:
+   *   - 'down': the server answered that it is not running ("no server
+   *     running"). Authoritative; for a sole-session socket this happens
+   *     because the pane died. Teardown is safe.
+   *   - 'unreachable': connect refused / lost server / timeout / spawn failure
+   *     — the client never got an answer, so the server may be live-but-stalled.
+   *     Stay attached.
+   *  Uses the same connection-level classifier as the pane probe so both agree
+   *  on what "the client never reached the server" looks like. Never
+   *  destructive on its own. */
+  private static tmuxServerReachability(timeoutMs: number): 'up' | 'down' | 'unreachable' {
     try {
       execFileSync('tmux', ['list-sessions'], {
         stdio: ['ignore', 'ignore', 'pipe'],
         timeout: timeoutMs,
         env: tmuxEnv(),
       });
-      return true;
-    } catch {
-      return false;
+      return 'up';
+    } catch (err: any) {
+      if (err && typeof err.status === 'number' && !err.signal) {
+        const stderr = (err.stderr?.toString?.() ?? '').trim();
+        // Connection-level wording ("error connecting", "lost server") ⇒ the
+        // client never reached the server ⇒ unreachable. Anything else the
+        // server actually answered — "no server running" included ⇒ down.
+        return isTmuxServerLevelErrorText(stderr) ? 'unreachable' : 'down';
+      }
+      // Timeout (signal/killed) or spawn failure (ENOENT/EACCES — no numeric
+      // exit status) ⇒ no answer ever reached us.
+      return 'unreachable';
     }
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18320,6 +18320,15 @@ process.on('message', async (raw: unknown) => {
         log('Late ready signal after timeout fallback — marking prompt ready now');
         markPromptReady();
       }
+      // CLI 启动确证（SessionStart hook 已跑）：复位连续重启计数——resume 目标
+      // 显然存在且加载成功。这和 prompt 侧复位是同一语义，但更早：2026-08-20
+      // 事故里 resume 后的 CLI 已 ready 二十多秒、还没等到 prompt 复位就被共享
+      // server 抖动误杀，第二次重启因此被 tier-2 强制 FRESH 白丢上下文。到过
+      // ready 的 spawn 崩溃不是「resume 目标不存在」问题，下一轮应有全新预算。
+      if (consecutiveInWorkerRestarts > 0) {
+        log(`SessionStart ready — resetting consecutive restart count (was ${consecutiveInWorkerRestarts})`);
+        consecutiveInWorkerRestarts = 0;
+      }
       if (msg.requestId) {
         send({ type: 'session_ready_ack', requestId: msg.requestId });
       }

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -885,6 +885,49 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     }
   });
 
+  it('tears down when panes read missing AND the cross-check says the server is DOWN (no server running)', () => {
+    // Regression guard for the sole-session hang: when a managed session is the
+    // only session on its socket, its pane dying makes tmux exit, so BOTH the
+    // pane probe and the list-sessions cross-check return authoritative
+    // "no server running" — NOT a connection-level error. That is 'down'
+    // (server gone ⇒ this pane provably gone), so teardown must proceed.
+    // The earlier cross-check collapsed 'down' into "not answering" and stayed
+    // attached forever: each authoritative-missing probe reset the outage
+    // clock, so the 60s escalation never fired and the worker hung until the
+    // next write. Distinct from the connection-level case above (stay attached).
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      mockedExecFileSync.mockImplementation(PANE_OK);
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+      // Sole session's pane died → tmux server exited. EVERY tmux invocation
+      // (pane probe AND list-sessions cross-check) now returns authoritative
+      // "no server running".
+      mockedExecFileSync.mockImplementation((_bin: any, _args: any) => {
+        throw Object.assign(new Error('no server'), {
+          status: 1,
+          signal: null,
+          stderr: Buffer.from('no server running on /tmp/tmux-0/default'),
+        });
+      });
+
+      // Well past the ~13s backed-off teardown window, but far short of the 60s
+      // escalation clock — proving teardown comes from the 'down' cross-check,
+      // not from the outage escalation.
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 15_000);
+      expect(exits).toEqual([[1, null]]);
+      expect(errSpy.mock.calls.some(call => String(call[0]).includes('pane gone after'))).toBe(true);
+      // Must NOT have stayed attached via the outage path.
+      expect(errSpy.mock.calls.some(call => String(call[0]).includes('treating as server outage'))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
   it('never detaches when tmux probes time out or fail to spawn (unknown, not missing)', () => {
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -50,7 +50,12 @@ import {
   TmuxPipeBackend,
   normaliseCaptureLineEndings,
   tmuxLifecycleInitialDelayMs,
+  setStartupTmuxRetrySleepForTests,
 } from '../src/adapters/backend/tmux-pipe-backend.js';
+
+// Startup retries sleep synchronously (Atomics.wait — immune to fake timers);
+// stub the sleep for the whole suite so retry tests don't add real seconds.
+setStartupTmuxRetrySleepForTests(() => {});
 
 const mockedExecSync = vi.mocked(execSync);
 const mockedExecFileSync = vi.mocked(execFileSync);
@@ -127,6 +132,145 @@ describe('TmuxPipeBackend.spawn', () => {
     expect(pipeCalls[0]).toContain('-O');
     expect(pipeCalls[0]).toContain("'0:2.0'");
     expect(pipeCalls[0]).toMatch(/cat > '.*botmux-pipe-.*\.fifo'/);
+  });
+
+  it('retries pipe-pane after a transient connect failure instead of failing the session start', () => {
+    // Startup herd after an outage: the first pipe-pane routinely eats an
+    // instant ECONNREFUSED from the stalled shared server. One spaced retry
+    // must recover instead of surfacing "会话启动失败" to the chat.
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      let pipeAttempts = 0;
+      mockedExecSync.mockImplementation(((cmd: any) => {
+        if (String(cmd).includes('pipe-pane')) {
+          pipeAttempts += 1;
+          if (pipeAttempts === 1) {
+            throw Object.assign(new Error('cmd failed'), {
+              status: 1,
+              signal: null,
+              stderr: Buffer.from('error connecting to /tmp/tmux-0/default (Connection refused)'),
+            });
+          }
+        }
+        return Buffer.from('') as any;
+      }) as any);
+
+      const be = new TmuxPipeBackend('0:2.0');
+      const exits: unknown[] = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      expect(() => be.spawn('', [], spawnOpts())).not.toThrow();
+
+      expect(pipeAttempts).toBe(2);
+      expect(exits).toEqual([]);
+      expect(errSpy.mock.calls.some(call => String(call[0]).includes('pipe-pane attach failed'))).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('still throws (and fires exit) when pipe-pane keeps hitting connect errors after all retries', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      let pipeAttempts = 0;
+      mockedExecSync.mockImplementation(((cmd: any) => {
+        if (String(cmd).includes('pipe-pane')) {
+          pipeAttempts += 1;
+          throw Object.assign(new Error('cmd failed'), {
+            status: 1,
+            signal: null,
+            stderr: Buffer.from('error connecting to /tmp/tmux-0/default (Connection refused)'),
+          });
+        }
+        return Buffer.from('') as any;
+      }) as any);
+
+      const be = new TmuxPipeBackend('0:2.0');
+      const exits: unknown[] = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      expect(() => be.spawn('', [], spawnOpts())).toThrow();
+
+      expect(pipeAttempts).toBe(3);            // initial + 2 retries
+      expect(exits).toEqual([[1, null]]);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('fails pipe-pane FAST on a server-answered deterministic rejection (pane genuinely gone)', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      let pipeAttempts = 0;
+      mockedExecSync.mockImplementation(((cmd: any) => {
+        if (String(cmd).includes('pipe-pane')) {
+          pipeAttempts += 1;
+          throw Object.assign(new Error('cmd failed'), {
+            status: 1,
+            signal: null,
+            stderr: Buffer.from("can't find pane: 0:2.0"),
+          });
+        }
+        return Buffer.from('') as any;
+      }) as any);
+
+      const be = new TmuxPipeBackend('0:2.0');
+      const exits: unknown[] = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      expect(() => be.spawn('', [], spawnOpts())).toThrow();
+
+      expect(pipeAttempts).toBe(1);            // no pointless retries
+      expect(exits).toEqual([[1, null]]);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('retries new-session on a connect failure and treats duplicate-session-on-retry as success', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      let newSessionAttempts = 0;
+      mockedExecFileSync.mockImplementation(((_bin: any, args: any) => {
+        if (Array.isArray(args) && args.includes('new-session')) {
+          newSessionAttempts += 1;
+          if (newSessionAttempts === 1) {
+            // Timed-out first attempt: the client was killed but the server may
+            // have created the session anyway.
+            throw Object.assign(new Error('timed out'), { status: null, signal: 'SIGTERM', killed: true });
+          }
+          // Retry discovers the session DOES exist server-side.
+          throw Object.assign(new Error('cmd failed'), {
+            status: 1,
+            signal: null,
+            stderr: Buffer.from('duplicate session: bmx-owned'),
+          });
+        }
+        return '' as any;
+      }) as any);
+
+      const be = new TmuxPipeBackend('bmx-owned', { createSession: true, ownsSession: true });
+      expect(() => be.spawn('echo', [], spawnOpts())).not.toThrow();
+      expect(newSessionAttempts).toBe(2);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('does NOT retry new-session on a server-answered deterministic rejection', () => {
+    let newSessionAttempts = 0;
+    mockedExecFileSync.mockImplementation(((_bin: any, args: any) => {
+      if (Array.isArray(args) && args.includes('new-session')) {
+        newSessionAttempts += 1;
+        throw Object.assign(new Error('cmd failed'), {
+          status: 1,
+          signal: null,
+          stderr: Buffer.from('usage: new-session [...]'),
+        });
+      }
+      return '' as any;
+    }) as any);
+
+    const be = new TmuxPipeBackend('bmx-owned', { createSession: true, ownsSession: true });
+    expect(() => be.spawn('echo', [], spawnOpts())).toThrow();
+    expect(newSessionAttempts).toBe(1);
   });
 });
 
@@ -515,7 +659,7 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     return '' as any;
   };
 
-  it('fires exit when the tmux pane disappears — but only after 3 consecutive failures', () => {
+  it('fires exit when the tmux pane disappears — but only after 3 consecutive failures (backed-off probes)', () => {
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
@@ -526,13 +670,14 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
       be.spawn('', [], spawnOpts());
       mockedExecFileSync.mockImplementation(PANE_GONE);
 
-      // Two failed probes are NOT enough — the debounce gate must ride them out.
-      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 1_000);
+      // Failed probes back off (1s → 3s → 9s): miss#1 at the initial delay,
+      // miss#2 3s later. Two misses are NOT enough — the gate rides them out.
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 3_000);
       expect(exits).toEqual([]);
 
-      // 3rd consecutive failure trips the gate; the final lenient confirm also
-      // fails ⇒ now we detach.
-      vi.advanceTimersByTime(1_000);
+      // miss#3 lands 9s after miss#2, trips the gate; the final lenient
+      // confirm also fails and the server cross-check answers ⇒ now we detach.
+      vi.advanceTimersByTime(9_000);
       expect(exits).toEqual([[1, null]]);
     } finally {
       vi.useRealTimers();
@@ -551,9 +696,9 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
       be.spawn('', [], spawnOpts());
       mockedExecFileSync.mockImplementation((_bin: any, args: any) => isPaneProbe(args) ? '\n' as any : '' as any);
 
-      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 1_000);
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 3_000);
       expect(exits).toEqual([]);
-      vi.advanceTimersByTime(1_000);
+      vi.advanceTimersByTime(9_000);
       expect(exits).toEqual([[1, null]]);
     } finally {
       vi.useRealTimers();
@@ -595,11 +740,11 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
       be.spawn('', [], spawnOpts());
 
       mockedExecFileSync.mockImplementation(PANE_GONE);
-      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 1_000); // 2 failures
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 3_000); // 2 failures (probes back off 1s→3s)
       mockedExecFileSync.mockImplementation(PANE_OK);
-      vi.advanceTimersByTime(1_000);          // success → reset
+      vi.advanceTimersByTime(9_000);          // success → reset (next probe 9s out)
       mockedExecFileSync.mockImplementation(PANE_GONE);
-      vi.advanceTimersByTime(2_000);          // 2 more failures (gate back to 2)
+      vi.advanceTimersByTime(4_000);          // 2 more failures at 1s + 3s (gate back to 2)
 
       expect(exits).toEqual([]);              // never reached 3 consecutive
     } finally {
@@ -628,9 +773,112 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
 
-      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 2_000);
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 12_000);
       expect(exits).toEqual([]);              // recovered on the confirm, no detach
       expect(paneIdCalls).toBe(4);
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('never trips the gate on connection-level clean errors (server stall ⇒ instant ECONNREFUSED)', () => {
+    // 2026-08-20 incident: a briefly stalled shared server refuses connects
+    // instantly (unix-socket accept backlog overflow). The clean exit-1 +
+    // "error connecting" stderr must classify as UNKNOWN, not authoritative
+    // missing — misreading it tore down every live session across all bots.
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      mockedExecFileSync.mockImplementation(PANE_OK);
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+      mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+        if (isPaneProbe(args)) {
+          throw Object.assign(new Error('cmd failed'), {
+            status: 1,
+            signal: null,
+            stderr: Buffer.from('error connecting to /tmp/tmux-0/default (Connection refused)'),
+          });
+        }
+        return '' as any;
+      });
+
+      // Well past the old 3-miss window but inside the 60s outage escalation.
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 30_000);
+      expect(exits).toEqual([]);
+      expect(errSpy.mock.calls.some(call => String(call[0]).includes('keeping managed session attached'))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('escalates to pane-exit when the server stays continuously unreachable past the outage window', () => {
+    // Connection-level errors are unknown, but a genuinely DEAD server also
+    // produces them forever — and its panes died with it. An unbroken run
+    // longer than the escalation window must eventually declare the pane gone
+    // so the worker can restart/resume instead of holding a zombie session.
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      mockedExecFileSync.mockImplementation(PANE_OK);
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+      mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+        if (isPaneProbe(args)) {
+          throw Object.assign(new Error('cmd failed'), {
+            status: 1,
+            signal: null,
+            stderr: Buffer.from('error connecting to /tmp/tmux-0/default (Connection refused)'),
+          });
+        }
+        return '' as any;
+      });
+
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 80_000);
+      expect(exits).toEqual([[1, null]]);
+      expect(errSpy.mock.calls.some(call => String(call[0]).includes('continuously unreachable'))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('stays attached when panes read missing but the server itself does not answer (cross-check)', () => {
+    // Defense in depth: even an authoritative-looking missing verdict must not
+    // destroy state while an independent list-sessions cross-check says the
+    // server is not answering — covers unrecognised stderr wordings / future
+    // tmux message changes that slip past the connection-error classifier.
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      mockedExecFileSync.mockImplementation(PANE_OK);
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+      mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+        if (isPaneProbe(args)) {
+          throw Object.assign(new Error('no pane'), { status: 1, signal: null });
+        }
+        if (Array.isArray(args) && args.includes('list-sessions')) {
+          throw Object.assign(new Error('cmd failed'), {
+            status: 1,
+            signal: null,
+            stderr: Buffer.from('error connecting to /tmp/tmux-0/default (Connection refused)'),
+          });
+        }
+        return '' as any;
+      });
+
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 13_000);
+      expect(exits).toEqual([]);
+      expect(errSpy.mock.calls.some(call => String(call[0]).includes('treating as server outage'))).toBe(true);
     } finally {
       vi.useRealTimers();
       errSpy.mockRestore();

--- a/test/tmux-probe.test.ts
+++ b/test/tmux-probe.test.ts
@@ -78,6 +78,29 @@ describe('TmuxBackend.probeSession', () => {
     expect(TmuxBackend.probeSession(NAME)).toBe('unknown');
   });
 
+  it('returns "unknown" on a clean CONNECTION-level failure (server stall ⇒ instant ECONNREFUSED), NOT "missing"', () => {
+    // Linux fails unix-socket connect() with an instant clean ECONNREFUSED when
+    // the shared server's accept backlog overflows — the client never reached
+    // the server, so the clean exit-1 proves nothing about this session.
+    // (2026-08-20: misreading this as 'missing' made kill-verify / liveness
+    // consumers treat dozens of live sessions as gone simultaneously.)
+    const stderr = Buffer.from('error connecting to /tmp/tmux-0/default (Connection refused)');
+    bothThrow({ status: 1, signal: null, stderr }, { status: 1, signal: null, stderr });
+    expect(TmuxBackend.probeSession(NAME)).toBe('unknown');
+  });
+
+  it('returns "unknown" when the connection died mid-command (lost server)', () => {
+    const stderr = Buffer.from('lost server');
+    bothThrow({ status: 1, signal: null, stderr }, { status: 1, signal: null, stderr });
+    expect(TmuxBackend.probeSession(NAME)).toBe('unknown');
+  });
+
+  it('keeps "no server running" as authoritative "missing" (a down server provably has no sessions)', () => {
+    const stderr = Buffer.from('no server running on /tmp/tmux-0/default');
+    bothThrow({ status: 1, signal: null, stderr }, { status: 1, signal: null, stderr });
+    expect(TmuxBackend.probeSession(NAME)).toBe('missing');
+  });
+
   it('hasSession() stays a conservative boolean wrapper (false on unknown)', () => {
     bothThrow({ status: 127, signal: null }, { code: 'ENOENT', status: null, signal: null });
     expect(TmuxBackend.hasSession(NAME)).toBe(false);

--- a/test/worker-codex-app-turn-routing.integration.test.ts
+++ b/test/worker-codex-app-turn-routing.integration.test.ts
@@ -41,7 +41,11 @@ async function hardKillWorkerOnly(child: ChildProcess): Promise<void> {
 function waitForChildExit(
   child: ChildProcess,
   logs: string[],
-  timeoutMs = 10_000,
+  // The tmux-pipe lifecycle watcher now backs off its pane probes (1s→3s→9s),
+  // so a genuinely dead managed pane is torn down after ~13s worst-case
+  // (3 backed-off misses + lenient confirm) instead of the old ~3-4s. Give the
+  // worker-exit wait enough headroom to observe that teardown.
+  timeoutMs = 30_000,
 ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
   if (child.exitCode !== null || child.signalCode !== null) {
     return Promise.resolve({ code: child.exitCode, signal: child.signalCode });


### PR DESCRIPTION
## 背景：2026-08-20 全群会话雪崩事故

多个群在同一时间（18:52:57–18:53:39）出现同一类报错：先是「⚠️ 历史会话无法恢复，已新起干净会话（consecutive restart x2）」，随后部分会话「⚠️ 会话启动失败：Command failed: tmux pipe-pane …」。

日志取证还原的完整链条：

1. **tmux server 从未崩溃**（进程 8/2 启动至今存活；部分当时被判死的 bmx-* 会话现在还活着）。它只是短暂停顿了几秒——单线程 server 上挂着 ~250 个会话，11 个 daemon 的 worker 每秒各发一轮探测/截屏/输入，停顿期间 unix socket accept backlog（128）溢出，新 connect() **立即**返回干净的 ECONNREFUSED。
2. 存活探测把「clean exit 1 + `error connecting to /tmp/tmux-0/default`」误读为权威的 **pane 已死**（事发窗口 0 条 unknown 类日志，佐证全是秒回错误而非超时）。3 次 miss 仅间隔 1s + final confirm 也秒被拒 → 3 秒内 11 个 bot 的全部 worker 同时拆除活会话。
3. 重启第 1 次 resume 其实**成功**了（CLI 已跑到 SessionStart ready 二十多秒），但探测风暴未平，刚复活的会话被同一误判**二次误杀**；还没等到 prompt 侧的计数复位 → tier-2「consecutive restart x2 强制 FRESH」→ 白丢上下文。
4. FRESH 启动撞上 ~80 个会话 15 秒内集中重建的连接风暴，`tmux pipe-pane` 又吃 ECONNREFUSED，一次失败即放弃 → 用户看到「会话启动失败」。

## 修复（四层，同一根因的不同暴露点）

| 层 | 改动 |
|---|---|
| 探测分类（根治） | `error connecting` / `lost server` / `server exited` 等**连接级** stderr 归入 `unknown`（不进毁灭性计数、不算 resume 目标缺失）；仅 server 明确应答的缺失（空 pane id、can't find、no server running）保持权威 `missing`。`TmuxBackend.probeSession`（has-session）同步收紧，kill-verify 等消费方不再把「连不上」当「已确认拆除」 |
| server 级熔断 | 拆除前独立 `list-sessions` 交叉验证 server 确实在应答，防未知措辞漏网；连接级失败**连续 60s** 才判定 server 真死、放行 pane-exit（防僵尸会话，server 真死时 worker 仍能重启自愈） |
| 探测退避 | 非 exists 探测间隔 1s→3s→9s（封顶），容忍窗口 ~3s → ~13s+；也在 server 最吃紧时削减每秒数百次的连接风暴本身。真死 pane 的兜底检测延迟增至 ~13s，可接受：写路径 guardedSend 命中权威 missing 时仍即时拆除，adopt 模式 pid 死亡仍走当前间隔 |
| 恢复路径 | ① SessionStart ready 即复位连续重启计数（与既有 prompt 复位同语义、更早），已确证启动成功的会话再被杀不烧 resume 预算、不再被强制 FRESH；② 启动期 `new-session` / `pipe-pane` 对瞬时失败带 1s/3s 间隔重试，重试遇 `duplicate session` 视为成功（前次超时实际已建成），server 应答的确定性失败（pane 真没了、参数错误）不重试快速抛出 |

## 影响面评估

- `TmuxPipeBackend` 是本地默认后端：波及**全部 CLI** 的托管会话与 /adopt 会话，托管/adopt 两条路径的判定差异（pid 死亡即时、pane 探测防抖）均保持不变
- `worker.ts` 的 ready 复位对全部有 session_ready 信号的 CLI 生效；无 hook 的 CLI 仍走原有 prompt 复位，无行为变化
- `TmuxBackend.probeSession` 消费方逐一核对：`killAndVerifyPersistentPane` 对 unknown 本就保守重试（方向更安全）；restore/hasSession 把 unknown 折叠为 false 与原行为一致
- **未改动**：`LivenessGate`（Zellij 观察后端共用）、Zellij/Zmx/Herdr 后端、PtyBackend、TmuxBackend spawn 路径
- 已知边界：daemon 重启恢复期若正逢 server 抖动，restore 侧 hasSession 仍可能保守走冷恢复（不丢上下文，属安全方向），本 PR 不展开

## 测试验证

- `pnpm build` 绿；`tsc --noEmit` 绿
- `test/tmux-pipe-backend.test.ts`（52，含 9 个新回归：连接级错误不触发拆除 / 60s outage 升级 / server 交叉验证兜底 / 退避时间线 / pipe-pane、new-session 重试与快速失败 / duplicate-session 幂等）+ `test/tmux-probe.test.ts`（10，含连接级归 unknown、no server running 保持 missing）全绿
- 后端相关 14 个套件（reattach / copy-mode / env 隔离 / session-liveness / kill-worker-orphaned / zellij-observe / backend-availability 等）251 项全绿
- 真实 tmux e2e：`test/tmux-backend.e2e.ts` 4/4
- 全量单测与 master 基线**双跑对比**：本分支无任何新增失败（两侧失败集一致，均为 master 既有的 workflow/mojo/config-dir 等无关用例）
- 连接级 stderr 措辞已在事故机上实测核对（tmux 3.3a：目标不存在为 exit 0 + 空输出；`error connecting …` 为 clean exit 1），分类器按实测行为覆盖

Made with [Cursor](https://cursor.com)