### PR TITLE
fix(lark): 机器人改名后互@不再向对方注入老名字

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -429,7 +429,7 @@ function republishResolvedAllowedUsers(larkAppId: string, resolved: string[]): v
   try { writeDaemonDescriptor(desc); } catch { /* best effort */ }
 }
 let vcMeetingTerminalReconciler: VcMeetingTerminalReconciler | undefined;
-import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, markForwardFollowupsSessionsReady, writeBotInfoFile, canOperate, canRunDaemonCommand, evaluateTalk, evaluateBotTalk, evaluateAskAnswerTalk, askCustomReplyCandidate, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext, type EventHandlers } from './im/lark/event-dispatcher.js';
+import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, markForwardFollowupsSessionsReady, writeBotInfoFile, canOperate, canRunDaemonCommand, evaluateTalk, evaluateBotTalk, evaluateAskAnswerTalk, askCustomReplyCandidate, grantCommandRestriction, isKnownPeerBot, resolveSiblingBotNameByUnionId, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext, type EventHandlers } from './im/lark/event-dispatcher.js';
 import { getDocSubscription, listAllDocSubscriptions, listDocSubscriptionsForSession, putDocSubscription, removeDocSubscription, setDocCommentPollCursor, type DocSubscription } from './services/doc-subs-store.js';
 import { BOT_REPLY_SENTINEL, subscribeDocFile, unsubscribeDocFile, addCommentReaction, removeCommentReaction, hasBotSentinel, isBotAuthoredReply, listDocComments } from './im/lark/doc-comment.js';
 import { learnFromMentions, resolveSender, flushIdentityCacheSync, type ResolvedSender } from './im/lark/identity-cache.js';
@@ -18643,18 +18643,28 @@ async function handleBotAdded(
 
 export const __testOnly_handleBotAdded = handleBotAdded;
 
-/** Reverse-lookup a foreign bot's display name for a sender open_id observed on
- *  this app's WS events. Priority:
+/** Reverse-lookup a foreign bot's display name for a sender observed on this
+ *  app's WS events. Priority:
+ *    0) union_id → current sibling name — rename-proof. The sender's tenant-
+ *       stable union_id (stamped on the event) maps to the one locally-configured
+ *       sibling that learned it, whose bots-info.json botName is rewritten by its
+ *       OWN daemon on every rename. This is the only source that reflects a rename
+ *       when the renamed bot merely SENDS to us (no @ of it flows through us, so
+ *       the by-name cross-ref below never refreshes on that event).
  *    1) bot-openids-${larkAppId}.json — per-app cross-ref populated by
  *       updateBotOpenIdCrossRef when @mentions go through us. Open_id is
  *       per-app scoped, so this is the authoritative map for this larkAppId.
+ *       (The writer now evicts pre-rename aliases, so a stale name here self-heals
+ *       the next time that bot is @-mentioned by its new name.)
  *    2) bots-info.json — fallback for bots not yet in our cross-ref but
  *       registered as botmux peers (matches by their self-reported open_id;
  *       only works when the peer's app id space coincides with ours).
- *  Returns "Bot" if neither lookup hits — keeps the prefix readable rather
- *  than blocking the message.
+ *  Returns "Bot" if nothing hits — keeps the prefix readable rather than
+ *  blocking the message.
  */
-function lookupForeignBotName(senderOpenId: string, larkAppId: string): string {
+function lookupForeignBotName(senderOpenId: string, larkAppId: string, senderUnionId?: string): string {
+  const currentName = resolveSiblingBotNameByUnionId(config.session.dataDir, larkAppId, senderUnionId);
+  if (currentName) return currentName;
   for (const [name, openId] of Object.entries(readPeerCrossRef(config.session.dataDir, larkAppId))) {
     if (openId === senderOpenId) return name;
   }
@@ -18769,7 +18779,8 @@ async function handleThreadReplyAdmitted(
     senderOpenIdForPrefix !== selfBotOpenId &&
     (isBotSenderType ||
       isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenIdForPrefix));
-  const foreignBotName = isForeignBot ? lookupForeignBotName(senderOpenIdForPrefix!, larkAppId) : undefined;
+  const senderUnionIdForPrefix = parsed.senderUnionId || data?.sender?.sender_id?.union_id;
+  const foreignBotName = isForeignBot ? lookupForeignBotName(senderOpenIdForPrefix!, larkAppId, senderUnionIdForPrefix) : undefined;
   const botSenderPrefix = isForeignBot
     ? `${tr('daemon.foreign_bot_mention_prefix', { botName: foreignBotName! }, localeForBot(larkAppId))}\n`
     : '';

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -936,6 +936,64 @@ export function isVerifiedLocalSiblingBot(
 }
 
 /**
+ * Resolve a foreign bot sender's CURRENT display name from its tenant-stable
+ * `union_id` — rename-proof, unlike the per-app name→open_id cross-ref.
+ *
+ * Why this exists: `lookupForeignBotName` historically read the receiver-local
+ * cross-ref (`bot-openids-<receiverApp>.json`), which only learns a bot's name
+ * when THAT bot is @-mentioned in one of the receiver's own events. When a
+ * renamed bot merely *sends* to us (the `[来自 X 的 @mention]` prefix path), no
+ * mention of X flows through us, so its cross-ref entry stays frozen at the old
+ * name. `union_id` is stamped on every inbound event's `sender.sender_id` and is
+ * stable across renames AND shared tenant-wide, so it maps the sender to the one
+ * locally-configured sibling that learned the same union_id, whose live
+ * `bots-info.json` entry is rewritten by its OWN daemon on every rename
+ * (setBotRenamer → writeBotInfoFile). That is the freshest cross-process name.
+ *
+ * Matches exactly one sibling (same ambiguity guard as isVerifiedLocalSiblingBot).
+ * Returns undefined on empty/unknown union_id, ambiguity, or a missing bots-info
+ * entry, so the caller falls back to the cross-ref / "Bot". Cross-deployment team
+ * peers aren't locally configured, so they return undefined here and rely on the
+ * cross-ref (whose stale aliases the writer now evicts on the next @ by new name).
+ */
+export function resolveSiblingBotNameByUnionId(
+  dataDir: string,
+  larkAppId: string,
+  senderUnionId: string | undefined,
+): string | undefined {
+  const unionId = (senderUnionId ?? '').trim();
+  if (!unionId) return undefined;
+
+  // union_id → the single locally-configured sibling appId that learned it.
+  let siblingAppId: string | undefined;
+  try {
+    for (const cfg of loadBotConfigs()) {
+      const appId = (cfg.larkAppId ?? '').trim();
+      if (!appId || appId === larkAppId) continue;
+      if (getBotUnionId(dataDir, appId) === unionId) {
+        if (siblingAppId) return undefined; // two siblings share a union_id → ambiguous
+        siblingAppId = appId;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  if (!siblingAppId) return undefined;
+
+  // appId → current botName from the shared, rename-fresh bots-info.json.
+  try {
+    const infoPath = join(dataDir, 'bots-info.json');
+    if (existsSync(infoPath)) {
+      const entries: Array<{ larkAppId?: string; botName?: string | null }> =
+        JSON.parse(readFileSync(infoPath, 'utf-8'));
+      const name = entries.find(e => e.larkAppId === siblingAppId)?.botName;
+      if (typeof name === 'string' && name.trim()) return name.trim();
+    }
+  } catch { /* fall through to caller's cross-ref path */ }
+  return undefined;
+}
+
+/**
  * Should a FOREIGN bot sender be trusted to collaborate (route/spawn a session)
  * WITHOUT `/grant`, because it's a teammate? Two trust sources, both rooted in
  * tenant-stable identity or team-controlled group membership — never a name:
@@ -1002,6 +1060,21 @@ export function updateBotOpenIdCrossRef(
     const openId = mentionOpenId(m);
     if (!name || !openId) continue;
     if (!knownBotNames.has(name.toLowerCase())) continue;
+    // Evict pre-rename aliases before recording the current name. An open_id is
+    // unique to one bot, so any OTHER name key still pointing at this open_id is
+    // a name that bot used before it was renamed. Left in place, the file would
+    // accumulate every historical name and lookupForeignBotName() (which returns
+    // the FIRST name matching an open_id, i.e. the oldest) would keep serving the
+    // stale one. Dropping them keeps the map at exactly the current name per
+    // open_id, and self-heals a table already polluted by past renames the next
+    // time this bot is @-mentioned by its new name. (Object.entries snapshots the
+    // keys, so deleting from `existing` inside the loop is safe.)
+    for (const [existingName, existingOpenId] of Object.entries(existing)) {
+      if (existingOpenId === openId && existingName !== name) {
+        delete existing[existingName];
+        changed = true;
+      }
+    }
     if (existing[name] === openId) continue;
     existing[name] = openId;
     changed = true;

--- a/test/bot-rename-name-refresh.test.ts
+++ b/test/bot-rename-name-refresh.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression: a renamed bot's OLD name kept surfacing when it @-mentioned
+ * another bot. Two independent leaks, both fixed here:
+ *
+ *   WRITER — updateBotOpenIdCrossRef only ever ADDED a name→open_id entry and
+ *   never evicted the pre-rename alias. `bot-openids-<app>.json` accumulated
+ *   every historical name for one open_id (observed live:
+ *   ou_… → ['Claude2','Claude分身','Botmux开发者(Claude)']). lookupForeignBotName
+ *   returns the FIRST name matching an open_id (insertion order = the OLDEST),
+ *   so the stale name won. The fix drops any other name key pointing at the same
+ *   open_id before recording the current one → one current name per open_id, and
+ *   self-heals a polluted table on the next @ by the new name.
+ *
+ *   READER — resolveSiblingBotNameByUnionId resolves a sibling's CURRENT name
+ *   from its tenant-stable union_id (stamped on every inbound event) → the one
+ *   locally-configured sibling that learned that union_id → its bots-info.json
+ *   botName, which the sibling's own daemon rewrites on every rename. This is the
+ *   only source that reflects a rename when the renamed bot merely SENDS to us
+ *   (no @ of it flows through us, so the by-name cross-ref never refreshes then).
+ *
+ * Run: pnpm vitest run test/bot-rename-name-refresh.test.ts
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  updateBotOpenIdCrossRef,
+  readBotOpenIdCrossRef,
+  resolveSiblingBotNameByUnionId,
+} from '../src/im/lark/event-dispatcher.js';
+import { readPeerCrossRef, __resetPeerCrossRefCacheForTest } from '../src/services/peer-cross-ref-store.js';
+import { recordBotUnionId } from '../src/services/bot-union-ids-store.js';
+
+const RECEIVER_APP = 'cli_receiver_rename_test';
+const SIBLING_APP = 'cli_sibling_rename_test';
+const SIBLING_OPEN_ID = 'ou_sibling_open_id'; // receiver-scoped open_id of the sibling
+const SIBLING_UNION_ID = 'on_sibling_union_id';
+
+let dataDir = '';
+let prevBotsConfig: string | undefined;
+
+/** Point loadBotConfigs() at a temp bots.json listing the receiver + one sibling. */
+function seedBotConfigs(): void {
+  const fp = join(dataDir, 'bots.json');
+  writeFileSync(fp, JSON.stringify([
+    { larkAppId: RECEIVER_APP, larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
+    { larkAppId: SIBLING_APP, larkAppSecret: 's', cliId: 'codex' },
+  ]));
+  process.env.BOTS_CONFIG = fp;
+}
+
+/** Write the shared, rename-fresh bots-info.json (each daemon rewrites its own row on rename). */
+function seedBotsInfo(siblingName: string): void {
+  writeFileSync(join(dataDir, 'bots-info.json'), JSON.stringify([
+    { larkAppId: RECEIVER_APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
+    { larkAppId: SIBLING_APP, botOpenId: 'ou_sibling_self', botName: siblingName, cliId: 'codex' },
+  ]));
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-rename-refresh-'));
+  process.env.SESSION_DATA_DIR = dataDir;
+  prevBotsConfig = process.env.BOTS_CONFIG;
+  __resetPeerCrossRefCacheForTest();
+});
+
+afterEach(() => {
+  __resetPeerCrossRefCacheForTest();
+  if (prevBotsConfig === undefined) delete process.env.BOTS_CONFIG;
+  else process.env.BOTS_CONFIG = prevBotsConfig;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('writer: updateBotOpenIdCrossRef evicts pre-rename name aliases', () => {
+  it('keeps exactly one current name per open_id after a rename', () => {
+    // Sibling was first seen as "OldName", then renamed to "NewName". Both names
+    // are "known bot names" (bots-info.json) so both would match the guard.
+    seedBotsInfo('NewName'); // used only as the knownBotNames source here
+    writeFileSync(join(dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: RECEIVER_APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
+      { larkAppId: SIBLING_APP, botOpenId: 'ou_sibling_self', botName: 'NewName', cliId: 'codex' },
+      // OldName must also be a known name so the first-seen learn is allowed.
+      { larkAppId: 'cli_ghost', botOpenId: null, botName: 'OldName', cliId: 'codex' },
+    ]));
+
+    // First contact under the old name.
+    updateBotOpenIdCrossRef(dataDir, RECEIVER_APP, [
+      { name: 'OldName', id: { open_id: SIBLING_OPEN_ID } },
+    ]);
+    expect(readPeerCrossRef(dataDir, RECEIVER_APP)).toEqual({ OldName: SIBLING_OPEN_ID });
+
+    __resetPeerCrossRefCacheForTest();
+    // After rename, the same open_id is @-mentioned under the new name.
+    updateBotOpenIdCrossRef(dataDir, RECEIVER_APP, [
+      { name: 'NewName', id: { open_id: SIBLING_OPEN_ID } },
+    ]);
+
+    __resetPeerCrossRefCacheForTest();
+    const after = readPeerCrossRef(dataDir, RECEIVER_APP);
+    // The stale alias is gone; only the current name maps to the open_id.
+    expect(after).toEqual({ NewName: SIBLING_OPEN_ID });
+    expect(after).not.toHaveProperty('OldName');
+  });
+
+  it('does not disturb a different bot that shares the mention batch', () => {
+    writeFileSync(join(dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'a', botOpenId: null, botName: 'Alpha', cliId: 'codex' },
+      { larkAppId: 'b', botOpenId: null, botName: 'Beta', cliId: 'codex' },
+      { larkAppId: 'c', botOpenId: null, botName: 'AlphaRenamed', cliId: 'codex' },
+    ]));
+    updateBotOpenIdCrossRef(dataDir, RECEIVER_APP, [
+      { name: 'Alpha', id: { open_id: 'ou_alpha' } },
+      { name: 'Beta', id: { open_id: 'ou_beta' } },
+    ]);
+    __resetPeerCrossRefCacheForTest();
+    // Alpha renames; Beta untouched. Only Alpha's alias should be rewritten.
+    updateBotOpenIdCrossRef(dataDir, RECEIVER_APP, [
+      { name: 'AlphaRenamed', id: { open_id: 'ou_alpha' } },
+    ]);
+    __resetPeerCrossRefCacheForTest();
+    expect(readPeerCrossRef(dataDir, RECEIVER_APP)).toEqual({
+      AlphaRenamed: 'ou_alpha',
+      Beta: 'ou_beta',
+    });
+  });
+
+  it('readBotOpenIdCrossRef reflects the healed single name', () => {
+    writeFileSync(join(dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'x', botOpenId: null, botName: 'Nom', cliId: 'codex' },
+      { larkAppId: 'y', botOpenId: null, botName: 'NomV2', cliId: 'codex' },
+    ]));
+    updateBotOpenIdCrossRef(dataDir, RECEIVER_APP, [{ name: 'Nom', id: { open_id: 'ou_nom' } }]);
+    __resetPeerCrossRefCacheForTest();
+    updateBotOpenIdCrossRef(dataDir, RECEIVER_APP, [{ name: 'NomV2', id: { open_id: 'ou_nom' } }]);
+    __resetPeerCrossRefCacheForTest();
+    const m = readBotOpenIdCrossRef(dataDir, RECEIVER_APP);
+    // lowercased keys; only the current name survives.
+    expect([...m.keys()]).toEqual(['nomv2']);
+    expect(m.get('nomv2')).toBe('ou_nom');
+  });
+});
+
+describe('reader: resolveSiblingBotNameByUnionId returns the CURRENT name (rename-proof)', () => {
+  beforeEach(() => {
+    seedBotConfigs();
+    recordBotUnionId(dataDir, SIBLING_APP, SIBLING_UNION_ID);
+  });
+
+  it('resolves the fresh bots-info name via union_id even when the cross-ref is stale', () => {
+    // The by-name cross-ref still holds the OLD name (never refreshed because the
+    // renamed sibling merely SENDS to us — no @ of it flows through the receiver).
+    writeFileSync(join(dataDir, `bot-openids-${RECEIVER_APP}.json`), JSON.stringify({ OldName: SIBLING_OPEN_ID }));
+    // bots-info.json carries the CURRENT name (sibling's own daemon rewrote it).
+    seedBotsInfo('CurrentName');
+    __resetPeerCrossRefCacheForTest();
+
+    expect(resolveSiblingBotNameByUnionId(dataDir, RECEIVER_APP, SIBLING_UNION_ID)).toBe('CurrentName');
+  });
+
+  it('returns undefined for an unknown/empty union_id (caller falls back to cross-ref)', () => {
+    seedBotsInfo('CurrentName');
+    expect(resolveSiblingBotNameByUnionId(dataDir, RECEIVER_APP, undefined)).toBeUndefined();
+    expect(resolveSiblingBotNameByUnionId(dataDir, RECEIVER_APP, '')).toBeUndefined();
+    expect(resolveSiblingBotNameByUnionId(dataDir, RECEIVER_APP, 'on_not_a_sibling')).toBeUndefined();
+  });
+
+  it('returns undefined when two configured siblings share a union_id (ambiguous → fail safe)', () => {
+    // A second sibling learned the same union_id. Can't disambiguate → undefined.
+    writeFileSync(join(dataDir, 'bots.json'), JSON.stringify([
+      { larkAppId: RECEIVER_APP, larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
+      { larkAppId: SIBLING_APP, larkAppSecret: 's', cliId: 'codex' },
+      { larkAppId: 'cli_sibling_two', larkAppSecret: 's', cliId: 'codex' },
+    ]));
+    recordBotUnionId(dataDir, 'cli_sibling_two', SIBLING_UNION_ID);
+    seedBotsInfo('CurrentName');
+    expect(resolveSiblingBotNameByUnionId(dataDir, RECEIVER_APP, SIBLING_UNION_ID)).toBeUndefined();
+  });
+
+  it('returns undefined when the sibling has no bots-info row yet (caller falls back)', () => {
+    // union_id maps to a configured sibling, but bots-info.json has no name for it.
+    writeFileSync(join(dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: RECEIVER_APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
+    ]));
+    expect(resolveSiblingBotNameByUnionId(dataDir, RECEIVER_APP, SIBLING_UNION_ID)).toBeUndefined();
+  });
+});

--- a/test/bot-rename-name-refresh.test.ts
+++ b/test/bot-rename-name-refresh.test.ts
@@ -77,7 +77,6 @@ describe('writer: updateBotOpenIdCrossRef evicts pre-rename name aliases', () =>
   it('keeps exactly one current name per open_id after a rename', () => {
     // Sibling was first seen as "OldName", then renamed to "NewName". Both names
     // are "known bot names" (bots-info.json) so both would match the guard.
-    seedBotsInfo('NewName'); // used only as the knownBotNames source here
     writeFileSync(join(dataDir, 'bots-info.json'), JSON.stringify([
       { larkAppId: RECEIVER_APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
       { larkAppId: SIBLING_APP, botOpenId: 'ou_sibling_self', botName: 'NewName', cliId: 'codex' },


### PR DESCRIPTION
## 问题
机器人改名后，另一个 bot 收到互@消息时，喂给 CLI 的 prompt 里（`[来自 X 的 @mention]` 前缀 + `<sender name=\"X\">` 标签）仍是改名前的**老名字**。

## 根因（两层）
名字来自接收方本地的 `bot-openids-<appId>.json` 交叉表（名字→open_id）：
1. **写入端** `updateBotOpenIdCrossRef` 只按名字键新增/覆盖、**从不淘汰旧名键** → 一个 open_id 累积历史上所有用过的名字（线上实测一个 open_id 挂了 `['Claude2','Claude分身','Botmux开发者(Claude)']` 之类）。
2. **读取端** `lookupForeignBotName` 遍历 `Object.entries` 返回**第一个**命中 = 插入序最老的名字。

且改名的 bot 只是「发消息」给对方时，事件 `mentions[]` 里 @ 的是**接收方**而非它自己，那条事件根本不刷新它在对方交叉表里的条目——所以**只修写入端不够**，读取端必须用改名不变的身份现查。

## 修复（两层）
- **读取端（立即生效）**：新增 `resolveSiblingBotNameByUnionId`，用事件自带、租户级稳定、改名不变的 `union_id` → 定位本机唯一配置的兄弟 bot（`bot-union-ids.json`）→ 读它自己 daemon 每次改名都重写的 `bots-info.json` 当前 `botName`（`setBotRenamer → writeBotInfoFile`）。改名后**下一条消息就是新名，无需再被 @**。歧义（两兄弟同 union_id）/查不到 → 返回 undefined 回退交叉表。
- **写入端（数据自愈）**：学到 (新名, open_id) 时淘汰所有指向同一 open_id 的旧名键 → 每个 open_id 只留当前名，止住累积，旧污染表在该 bot 下次被 @ 新名时自愈。

## 影响面（多 CLI × 多后端 × 多 IM 横向排查）
- 名字构建点唯一（`daemon.ts` 的 `handleThreadReplyAdmitted`），bot→bot @ 全走 `handleThreadReply`；`<sender>` 标签经 `resolveSender` 的 hint 优先于 identity 缓存，一并修好（bot 类型跳过 contact API）。
- 交叉表所有消费者：按 open_id 取值的（`isKnownPeerBot` / `knownBotOpenIdsFromCrossRef` 用 `.values()`）**不受影响**；按当前名查的（`cli.ts` / `core/dispatch.ts` / `client.ts` / `dashboard-ipc-server.ts`）改后**反而更准**（交叉表 key 与当前 bots-info 名对齐，改名不再查空）——无回归。
- 一 bot 一 daemon，跨进程拿兄弟当前名只能读共享的 `bots-info.json`（不能 `getBot(siblingAppId)`）。
- 平台/跨部署 team peer 非本机配置 → 读取端返回 undefined，仍走交叉表（写入端淘汰旧名让其在新名被 @ 时自愈）。

## 验证
- `pnpm build` 绿。
- 新增单测 `test/bot-rename-name-refresh.test.ts` 7/7 绿。
- 直接相关套件 `event-dispatcher` / `peer-cross-ref-store` / `peer-bot-operate` / `bot-routing` / `list-chat-bot-members` 共 **373/373 绿**。
- **反向变异逐层验证**：两个 fix 分别失活 → 对应测试精确变红（writer 3 条 / reader 1 条），互不串扰；恢复后全绿。
- 说明：`daemon-rename-route.test.ts` 有 2 条失败（"passes the accepted Lark message id" / "v3-grill"），已在**未改动的 pristine master 上复现同样失败**＝既有基线，与本 PR 无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)