### PR TITLE
fix(skills): 单 Bot 接力默认留在当前话题

### DIFF
--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -627,7 +627,7 @@ team scope 输出的 \`agents[]\` 每项：\`appId\`（拉群/补人就用它）
 
 const HANDOFF_SKILL = `---
 name: botmux-handoff
-description: 把当前任务交棒给团队里另一个机器人时使用（多机器人协作接力）。当你做完自己负责的部分、需要另一个机器人接手下一步，或用户说"交给X""让X接着做""@某bot继续""下一步谁谁来"时触发。先用 botmux-bots 查花名册挑对象，再用结构化交接发给对方。
+description: 把当前任务交棒给团队里另一个机器人时使用（多机器人协作接力）。当你做完自己负责的部分、需要另一个机器人接手下一步，或用户说"交给X""让X接着做""@某bot继续""下一步谁谁来"时触发。单个目标 bot 或单个专项的接力默认保留在当前话题，不新建子项目话题；先用 botmux-bots 查花名册挑对象，再用结构化交接发给对方。
 ---
 
 # botmux-handoff — 机器人接力交棒
@@ -640,6 +640,13 @@ description: 把当前任务交棒给团队里另一个机器人时使用（多�
    - 按 \`capability\` 挑**合适**的接手机器人；
    - 确认它 \`mentionable: true\`（若为 false，先让它/用户 \`/introduce\` 一次再点名）。
 2. 用 \`botmux send --mention\` 发一条**结构化交接**给它。
+
+## 话题规则
+
+- **单 bot 接力留在当前话题**：直接运行 \`botmux send --mention\`，不加 \`--top-level\`；BotMux 会把消息发回当前轮次所在话题。
+- 不要为单个接手者运行不带 \`--into\` 的 \`botmux dispatch\`：它会额外发一条顶层子项目消息、新建话题。
+- 如果必须使用稳定 App ID 和接单确认，使用 \`botmux dispatch --into <当前话题根消息id> --bot-app <larkAppId> ...\`，明确追加到当前话题。
+- 只有任务确实拆成多个独立子项目、需要并行跟踪和主 bot 汇总时，才使用 \`botmux-orchestrate\` 新开话题。
 
 ## 交接必须包含 5 要素
 
@@ -1234,7 +1241,7 @@ $${GOAL_ENV.INPUTS_PATH}
 
 const ORCHESTRATE_SKILL = `---
 name: botmux-orchestrate
-description: 多 bot 长期项目编排。仅当任务同时需要「多个 bot 分工」+「持续的 goal 群/多话题协调与进度板」+「主 bot 汇总验收」时触发，例如多组 coder/reviewer 并行推进。若只是一个有界 DAG、跑完即散、产出单一交付物，应使用 botmux-workflow；单步任务直接处理。显式提到 botmux orchestrate / goal supervise / dispatch 派活时也使用。
+description: 多 bot 长期项目编排。仅当任务同时需要「多个 bot 分工」+「持续的 goal 群/多话题协调与进度板」+「主 bot 汇总验收」时触发，例如多组 coder/reviewer 并行推进。若只是一个有界 DAG、跑完即散、产出单一交付物，应使用 botmux-workflow；只把下一步或单个专项交给一个 bot 时，必须使用 botmux-handoff 留在当前话题，不得新建子项目话题。显式提到 botmux orchestrate / goal supervise / dispatch 派活时也使用。
 ---
 
 # botmux-orchestrate — 多 bot 多话题编排
@@ -1244,7 +1251,7 @@ description: 多 bot 长期项目编排。仅当任务同时需要「多个 bot 
 ## 适用 & 不适用
 - 适用：一个长期项目同时满足三个结构化判据：① **多个 bot 分工**处理基本独立的子项目；② 需要持续存在的 **goal 群/多话题协调**和共享进度板；③ 主 bot 要持续收件并做最终**验收**。
 - 不适用：一个**有界 DAG、跑完即散、只有一个交付物**的多步目标——使用 **botmux-workflow**。
-- 不适用：单步请求 / 普通改代码（直接做），或只需把下一步交给一个 bot（用 botmux-handoff）。
+- 不适用：单步请求 / 普通改代码（直接做），或只需把下一步、单个专项交给一个 bot（用 botmux-handoff，留在当前话题）。
 
 ## 物理事实（先记牢）
 - **你和子 bot 之间没有直连**，只能靠飞书消息触发；**没有请求-响应关联**——子 bot 干完用 \`botmux report\` 把回报发回**你这条主编排话题**（不是在它自己的子话题里 @ 你——那条子话题没有你的会话，@ 会另起一个无上下文的新会话）。对你就是「话题里来了条新消息」，你被唤起（带完整上下文）后去读任务板拿结构化状态。

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -220,6 +220,19 @@ describe('built-in botmux-handoff skill', () => {
     expect(skill!.content).toContain('mentionable');
     expect(skill!.content).toContain('/introduce');
     expect(skill!.content).toContain('botmux send --mention');
+    expect(skill!.content).toContain('单 bot 接力留在当前话题');
+    expect(skill!.content).toContain('botmux dispatch --into');
+    expect(skill!.content).toContain('不要为单个接手者运行不带 `--into` 的 `botmux dispatch`');
+  });
+});
+
+describe('built-in botmux-orchestrate skill', () => {
+  it('keeps a single-specialist handoff in the current topic', () => {
+    const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-orchestrate');
+    expect(skill).toBeDefined();
+    expect(skill!.content).toContain('单个专项交给一个 bot');
+    expect(skill!.content).toContain('botmux-handoff');
+    expect(skill!.content).toContain('留在当前话题');
   });
 });
 


### PR DESCRIPTION
## 改了什么

- 明确单 Bot 或单专项接力使用 `botmux-handoff`，默认留在当前话题
- 说明 `botmux dispatch` 不带 `--into` 会新建子项目话题
- 约束 `botmux-orchestrate` 仅用于需要多话题并行跟踪的项目
- 补充内置 Skill 回归测试

## 为什么

避免简单接力被错误升级为多话题编排，减少上下文割裂和额外协作噪音。

## 影响范围

仅修改内置 `botmux-handoff` 与 `botmux-orchestrate` 的提示词，不改变 CLI 分发运行时逻辑。影响所有安装这些内置 Skill 的 CLI；不涉及后端、平台或会话持久化协议。

## 验证

- `pnpm exec vitest run test/builtin-skills.test.ts`：23 tests passed
- `pnpm build`：通过
- `git diff --check`：通过