### PR TITLE
feat(lark): 平台团队成员 talk 免 /grant 改按「团队共属」判，不再限平台登记的群

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1593,8 +1593,8 @@ export function canTalk(
  *   锁定为「飞书盖章的 bot 发送方」（daemon 的 teamTrustUnionId），否则恶意成员把
  *   真人 union 报成 bot 就能让真人继承 bot 信任。
  * @param memberUnionId  发送方 union（teamMember 腿）——可为真人 union（未锁 bot）。
- *   仅授 chat 作用域内的 talk、不授 operate，且要求 union 在该团队的成员名单里
- *   （memberUnionIds 来自平台鉴权的团队成员，非机器自报），故喂真人 union 是安全的。
+ *   授 talk、不授 operate，要求 union 与本 bot 同属一个平台团队（memberUnionIds
+ *   来自平台鉴权的团队成员，非机器自报），不限 chat，故喂真人 union 是安全的。
  * @param chatType  当前会话类型。**仅 p2pOpen 腿读它**；省略时该腿不生效（fail-closed），
  *   所以拿不到 chatType 的调用点保持原语义、不会误放行。
  */

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -20,7 +20,7 @@ import { resolveNonsupportMessage, stripLeadingMentions, mentionOpenId, mentionA
 import { recordObservedBots, listObservedBots } from '../../services/observed-bots-store.js';
 import { isTeamBot, recordTeamBot } from '../../services/team-bots-store.js';
 import { isTeamGroupChat } from '../../services/team-groups-store.js';
-import { isPlatformTeamBot, isPlatformHallChat, isPlatformTeamMemberChat } from '../../services/platform-team-store.js';
+import { isPlatformTeamBot, isPlatformHallChat, isPlatformTeamMember } from '../../services/platform-team-store.js';
 import { getBotUnionId, recordBotUnionId, recordBotUnionIdFromMentions } from '../../services/bot-union-ids-store.js';
 import { getDocSubscription, putDocSubscription, removeDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
 import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed, BOT_REPLY_SENTINEL } from './doc-comment.js';
@@ -1629,10 +1629,12 @@ export function evaluateTalk(
   if (senderUnionId && (isTeamBot(config.session.dataDir, senderUnionId) || isPlatformTeamBot(config.session.dataDir, senderUnionId))) {
     return { allowed: true, reason: 'teamBot' };
   }
-  // 平台团队成员（人）：发送者 union_id 是本群所属平台团队的成员 → talk 免 grant。
-  // 严格 chat 作用域（isPlatformTeamMemberChat 要求成员与群在同一团队），只放 talk：
-  // canOperate 不引这一腿，/restart 等仍限 allowedUsers。授权用户在团队群里 @ bot 即免卡。
-  if (memberUnionId && isPlatformTeamMemberChat(config.session.dataDir, chatId, memberUnionId)) {
+  // 平台团队成员（人）：发送者 union_id 与本 bot 同属某平台团队 → talk 免 grant，
+  // 不限群（手动建群 / 原生 /invite 拉的群同样生效，不再要求群 ∈ 平台登记的
+  // groupChatIds）。作用域锚在「团队共属」：本 bot ∈ team.bots ∧ 发送者 ∈ 同队
+  // memberUnionIds（isPlatformTeamMember 要求同一 team 同时成立），跨团队不泄漏。
+  // 只放 talk：canOperate 不引这一腿，/restart 等仍限 allowedUsers。
+  if (memberUnionId && isPlatformTeamMember(config.session.dataDir, larkAppId, memberUnionId)) {
     return { allowed: true, reason: 'teamMember' };
   }
   if (hasAllowedChatGroup(larkAppId, chatId)) return { allowed: true, reason: 'allowedChatGroup' };
@@ -1675,7 +1677,7 @@ export function evaluateTalk(
  *     `union_id` 的情况（此时 gate 前那次 `recordTeamBot` 被 `senderUnionId &&` 短路，
  *     evaluateTalk 的 teamBot 腿必然落空）。**这条不能下沉进 evaluateTalk**：那是人/bot
  *     共用的，加进去等于团队群里任何真人都自动过 canTalk，绕开 teamMember 腿的成员校验
- *     （isPlatformTeamMemberChat 要求 union 在该团队成员名单里）。它另外两条 union 锚定
+ *     （isPlatformTeamMember 要求 union 与本 bot 同属一个平台团队）。它另外两条 union 锚定
  *     的腿与 evaluateTalk 的 teamBot 腿重合，留着是为了让「bot 团队信任」只有一处定义。
  *
  *  2. `p2pOpen`（−）：不传 chatType → 该腿 fail-closed 不生效。飞书里 bot 之间不存在
@@ -3291,7 +3293,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       }
 
       const senderOpenId = sender?.sender_id?.open_id as string | undefined;
-      // 人的 union_id：平台团队成员 talk-免grant 腿（isPlatformTeamMemberChat）要用。
+      // 人的 union_id：平台团队成员 talk-免grant 腿（isPlatformTeamMember）要用。
       const humanSenderUnionId = sender?.sender_id?.union_id as string | undefined;
       // defaultOncall 自动绑定必须在 canTalk 权限判断前完成，否则已开 defaultOncall
       // 的群首次 @bot 时 oncallChats 中还没有该 chat → evaluateTalk 判无权限 → 误弹

--- a/src/services/platform-team-store.ts
+++ b/src/services/platform-team-store.ts
@@ -166,24 +166,31 @@ export function isPlatformTeamBot(dataDir: string, unionId: string | undefined):
   return false;
 }
 
-/** Is `unionId` a HUMAN member of a platform team AND is `chatId` one of that
- *  team's group chats? The talk-免grant leg for people: a teammate speaking in
- *  the team's own group is trusted to TALK without /grant — but scoped to those
- *  groups (not everywhere), and TALK only (operate stays allowedUsers-gated, the
- *  caller must never route this predicate into canOperate). Both conditions must
- *  hold on the SAME team so cross-team leakage is impossible. */
-export function isPlatformTeamMemberChat(
+/** Is `unionId` a HUMAN member of a platform team that THIS bot (`botAppId`)
+ *  also belongs to? The talk-免grant leg for people: a teammate is trusted to
+ *  TALK to a bot on their own team without /grant, in ANY chat they share —
+ *  not just platform-拉群 groups. The scope anchor is TEAM CO-MEMBERSHIP
+ *  (bot ∈ team.bots ∧ sender ∈ team.memberUnionIds on the SAME team), not the
+ *  chat: this is what lets a手动/原生 invite 群 work at parity with拉群 groups
+ *  (those 群 never enter groupChatIds; keying on the chat left them 要 /grant).
+ *
+ *  Cross-team leakage stays impossible because both predicates must hold on the
+ *  SAME team, and the bot only ever sees teams it is itself opted into (platform
+ *  team-sync is pushed per member machine; a bot not in team T never appears in
+ *  T.bots, so T's members can't reach it here). TALK only — operate stays
+ *  allowedUsers-gated; the caller must never route this predicate into canOperate. */
+export function isPlatformTeamMember(
   dataDir: string,
-  chatId: string | undefined,
+  botAppId: string | undefined,
   unionId: string | undefined,
 ): boolean {
-  const cid = (chatId ?? '').trim();
+  const appId = (botAppId ?? '').trim();
   const uid = (unionId ?? '').trim();
-  if (!cid || !uid) return false;
+  if (!appId || !uid) return false;
   const data = readFile(dataDir);
   if (!data) return false;
   for (const t of data.teams) {
-    if (t.memberUnionIds.includes(uid) && t.groupChatIds.includes(cid)) return true;
+    if (t.memberUnionIds.includes(uid) && t.bots.some((b) => b.appId === appId)) return true;
   }
   return false;
 }

--- a/src/services/platform-team-store.ts
+++ b/src/services/platform-team-store.ts
@@ -46,7 +46,8 @@ export interface PlatformTeamSyncTeam {
   groupChatIds: string[];
   bots: PlatformTeamBot[];
   /** Team members' (people's) union_ids — the human talk-免grant leg: a member
-   *  is trusted to TALK (never operate) inside this team's group chats. */
+   *  is trusted to TALK (never operate) to any bot on the SAME team, in any chat
+   *  they share with it (not scoped to this team's group chats). */
   memberUnionIds: string[];
 }
 

--- a/test/ask-answer-talk-dispatch.test.ts
+++ b/test/ask-answer-talk-dispatch.test.ts
@@ -59,11 +59,12 @@ function restricted(): void {
   bot.resolvedAllowedUsers = ['ou_owner'];
 }
 
-/** 布置一个平台团队：CHAT 是其协作群、MEMBER_UNION 是其成员（走 teamMember 腿）。 */
+/** 布置一个平台团队：本 bot APP 在其 bots roster、MEMBER_UNION 是其成员（走 teamMember
+ *  腿）。teamMember 腿现在锚在「本 bot ∈ 同队 bots」，不看 chatId，故 chatId 仅用于占位。 */
 function recordPlatformTeamMember(chatId: string, memberUnionId: string): void {
   applyPlatformTeamSync(tempDir, {
     rev: 'rev-1',
-    teams: [{ teamId: 'team-1', teamName: 'Team One', groupChatIds: [chatId], memberUnionIds: [memberUnionId], bots: [] }],
+    teams: [{ teamId: 'team-1', teamName: 'Team One', groupChatIds: [chatId], memberUnionIds: [memberUnionId], bots: [{ appId: APP }] }],
   });
 }
 

--- a/test/bot-talk-parity.test.ts
+++ b/test/bot-talk-parity.test.ts
@@ -111,8 +111,10 @@ const CASES: Record<Exclude<TalkReason, 'none'>, ParityCase> = {
       + '否则恶意成员把真人 union 报成 bot 就能继承 bot 信任。所以人侧不命中不是 parity 缺口，而是这条腿的定义。',
   },
   teamMember: {
-    // 平台团队成员（真人）腿走 memberUnionId：布置一个平台团队（CHAT 是其协作群、
-    // MEMBER_UNION 是其成员），人侧传 memberUnionId=MEMBER_UNION → 命中 reason:'teamMember'。
+    // 平台团队成员（真人）腿走 memberUnionId：布置一个平台团队（本 bot APP 在其 bots
+    // roster、MEMBER_UNION 是其成员），人侧传 memberUnionId=MEMBER_UNION → 命中
+    // reason:'teamMember'。teamMember 腿现在锚在「本 bot ∈ 同队 bots」，不看 chatId，
+    // 所以 CHAT 在不在 groupChatIds 都免 grant（此处仍列 CHAT 是为了 bot 侧的团队拉群腿）。
     //
     // bot 侧同样放行，但走的是**另一条腿**：平台协作群会被镜像成团队拉群
     // （applyPlatformTeamSync → team-groups），故 evaluateBotTalk 经团队拉群腿命中
@@ -122,7 +124,7 @@ const CASES: Record<Exclude<TalkReason, 'none'>, ParityCase> = {
       restricted();
       applyPlatformTeamSync(tempDir, {
         rev: 'rev-1',
-        teams: [{ teamId: 'team-1', teamName: 'Team One', groupChatIds: [CHAT], memberUnionIds: [MEMBER_UNION], bots: [] }],
+        teams: [{ teamId: 'team-1', teamName: 'Team One', groupChatIds: [CHAT], memberUnionIds: [MEMBER_UNION], bots: [{ appId: APP }] }],
       });
     },
     humanMemberUnionId: MEMBER_UNION,

--- a/test/platform-team-store.test.ts
+++ b/test/platform-team-store.test.ts
@@ -13,7 +13,7 @@ import {
   getPlatformTeamSyncRev,
   isPlatformTeamBot,
   isPlatformHallChat,
-  isPlatformTeamMemberChat,
+  isPlatformTeamMember,
   listPlatformTeams,
   PLATFORM_TEAM_PREFIX,
 } from '../src/services/platform-team-store.js';
@@ -88,25 +88,27 @@ describe('applyPlatformTeamSync', () => {
     expect(isPlatformHallChat(dataDir, 'oc_hall_a')).toBe(false);
   });
 
-  it('isPlatformTeamMemberChat: member in a team group → true; scoped to same team, talk-only', () => {
+  it('isPlatformTeamMember: member of a team this bot is in → true; scoped by team co-membership, not chat, talk-only', () => {
     applyPlatformTeamSync(dataDir, payload('rev1', [
       team('t1', ['oc_hall1', 'oc_group1'], [{ appId: 'cli_a', unionId: 'on_bot' }], ['on_alice', 'on_bob']),
       team('t2', ['oc_hall2'], [{ appId: 'cli_b', unionId: 'on_bot2' }], ['on_carol']),
     ]));
-    // 成员在本团队的群里（大厅或协作群）→ true
-    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', 'on_alice')).toBe(true);
-    expect(isPlatformTeamMemberChat(dataDir, 'oc_group1', 'on_bob')).toBe(true);
-    // 跨团队不泄漏：t2 成员在 t1 群里 → false；t1 成员在 t2 群里 → false
-    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', 'on_carol')).toBe(false);
-    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall2', 'on_alice')).toBe(false);
-    // 非成员 union、非团队群、空值 → false
-    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', 'on_bot')).toBe(false); // bot 不是 member
-    expect(isPlatformTeamMemberChat(dataDir, 'oc_other', 'on_alice')).toBe(false);
-    expect(isPlatformTeamMemberChat(dataDir, '', 'on_alice')).toBe(false);
-    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', undefined)).toBe(false);
+    // 成员与本 bot 同属一个团队 → true，任意群（含未登记的手动群）都免 grant，不再看 chatId
+    expect(isPlatformTeamMember(dataDir, 'cli_a', 'on_alice')).toBe(true);
+    expect(isPlatformTeamMember(dataDir, 'cli_a', 'on_bob')).toBe(true);
+    // 跨团队不泄漏：t2 成员对 t1 的 bot cli_a → false；t1 成员对 t2 的 bot cli_b → false
+    expect(isPlatformTeamMember(dataDir, 'cli_a', 'on_carol')).toBe(false);
+    expect(isPlatformTeamMember(dataDir, 'cli_b', 'on_alice')).toBe(false);
+    // t2 成员对 t2 的 bot cli_b → true（本队内）
+    expect(isPlatformTeamMember(dataDir, 'cli_b', 'on_carol')).toBe(true);
+    // 非成员 union（bot 自己的 union 不是 member）、非本队 bot、空值 → false
+    expect(isPlatformTeamMember(dataDir, 'cli_a', 'on_bot')).toBe(false); // bot 不是 member
+    expect(isPlatformTeamMember(dataDir, 'cli_unknown', 'on_alice')).toBe(false); // 本机不托管这个 bot
+    expect(isPlatformTeamMember(dataDir, '', 'on_alice')).toBe(false);
+    expect(isPlatformTeamMember(dataDir, 'cli_a', undefined)).toBe(false);
     // 团队消失 → 不再命中
     applyPlatformTeamSync(dataDir, payload('rev2', []));
-    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', 'on_alice')).toBe(false);
+    expect(isPlatformTeamMember(dataDir, 'cli_a', 'on_alice')).toBe(false);
   });
 
   it('rejects a payload without rev and sanitizes malformed teams', () => {

--- a/test/platform-team-trust.test.ts
+++ b/test/platform-team-trust.test.ts
@@ -33,7 +33,9 @@ function seedPlatformTeam(): void {
     rev: 'r1',
     teams: [{
       teamId: 't1', teamName: 'T1', groupChatIds: ['oc_hall', 'oc_group'],
-      bots: [{ appId: 'cli_peer', unionId: 'on_peer', name: 'Peer' }],
+      // 本 bot pf1 也在团队 bots roster 里 —— teamMember 腿现在锚在「本 bot ∈ 同队 bots」，
+      // 不再看 chatId。cli_peer 是同队的另一个 bot（teamBot 腿用）。
+      bots: [{ appId: 'cli_peer', unionId: 'on_peer', name: 'Peer' }, { appId: 'pf1', unionId: 'on_pf1', name: 'Self' }],
       memberUnionIds: ['on_teammate'],
     }],
   });
@@ -82,8 +84,8 @@ describe('evaluateTalk teamBot leg (quota gate end-to-end hole fix)', () => {
   });
 });
 
-describe('evaluateTalk teamMember leg (human 免grant, talk-only, chat-scoped)', () => {
-  it('allows a team member (human) TALK inside a team group via memberUnionId', () => {
+describe('evaluateTalk teamMember leg (human 免grant, talk-only, team-co-membership-scoped)', () => {
+  it('allows a team member (human) TALK when sender & bot share a platform team, via memberUnionId', () => {
     seedPlatformTeam();
     // 人的 union 走第 5 参 memberUnionId，不进 bot-trust（第 4 参）
     const ev = evaluateTalk('pf1', 'oc_group', 'ou_tp', undefined, 'on_teammate');
@@ -91,9 +93,12 @@ describe('evaluateTalk teamMember leg (human 免grant, talk-only, chat-scoped)',
     expect(ev.reason).toBe('teamMember');
   });
 
-  it('is chat-scoped: same member NOT allowed outside the team groups', () => {
+  it('is NOT chat-scoped: same member allowed in ANY chat, incl. 未登记的手动/原生 invite 群', () => {
     seedPlatformTeam();
-    expect(evaluateTalk('pf1', 'oc_random', 'ou_tp', undefined, 'on_teammate').allowed).toBe(false);
+    // oc_random 不在 groupChatIds 里（手动建群 / 原生 invite 场景）——照样免 grant
+    const ev = evaluateTalk('pf1', 'oc_random', 'ou_tp', undefined, 'on_teammate');
+    expect(ev.allowed).toBe(true);
+    expect(ev.reason).toBe('teamMember');
   });
 
   it('member union in the bot-trust slot must NOT grant operate (talk-only leg)', () => {


### PR DESCRIPTION
## 背景

Oncall 排查发现：走中心化平台 create-group 拉的群，同团队成员 @ bot 默认免 /grant；但**手动建群 / 飞书原生 /invite** 拉进来的 bot，即使发送者与 bot 同属一个平台团队，仍要 /grant。与预期「同团队内两条路径都免 grant」不符。

## 根因

`evaluateTalk` 的 teamMember 免 grant 腿此前锚在「chatId ∈ 平台登记的 groupChatIds」（`isPlatformTeamMemberChat`）。而 groupChatIds 唯一写入路径是平台 `create-group` 时 `addTeamGroupChat`——手动/原生 invite 不过平台，群永不进清单，第二个条件恒不满足 → 退回 /grant。

## 改动

把作用域锚从「群 scope」换成「团队共属 scope」：
- `isPlatformTeamMemberChat(dataDir, chatId, unionId)` → `isPlatformTeamMember(dataDir, botAppId, unionId)`
- 判据：**本 bot ∈ team.bots ∧ 发送者 union ∈ 同队 memberUnionIds**（同一 team 同时成立）
- `evaluateTalk` 改传 `larkAppId` 取代 `chatId`

去掉群 scope 后不再受群限制，手动群与平台拉群一致免 grant。

### 为什么跨团队仍不泄漏
两条件必须落在**同一 team**；且本机的 team-sync 只含本 bot opt-in 的团队——bot 不在团队 T 就不会出现在 T.bots，T 的成员无从命中本 bot。

### 安全边界不变
- 只放 **talk**：`canOperate` 不引这一腿，/restart 等仍限 allowedUsers
- teamBot / allowedChatGroup / oncall / p2pOpen / grant 各腿不变
- bot 侧 `evaluateBotTalk` 不接受 memberUnionId，语义不变

## 影响面
仅 `event-dispatcher` 的 evaluateTalk teamMember 腿 + `platform-team-store` 谓词。同步更新 4 个测试的 fixture（teamMember 场景把本 bot 加进 team.bots）。

## 测试
- `pnpm build` 通过
- platform-team-store 7/7、platform-team-trust 10/10、bot-talk-parity 18/18、ask-answer-talk-dispatch 7/7、event-dispatcher 295/295、grant-gates 11/11 全绿
- 全量 unit 余下失败经 clean origin/master 逐项比对，确认为**既有失败**（v3-goal-cli / mojo-launcher-env-quarantine / workflow-feature-gate / workflow-discovery-hints，均 env/spawn 敏感项），与本改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)