### PR TITLE
perf(repo-scan): 游离 HEAD 直接用短 SHA，去掉超多 tag 仓库上 2-6s 的 git describe

### DIFF
--- a/src/services/project-scanner.ts
+++ b/src/services/project-scanner.ts
@@ -87,19 +87,26 @@ export function describeProjectDir(dir: string): { name: string; branch: string 
 }
 
 /** `rev-parse --abbrev-ref HEAD` returns the literal string `HEAD` when
- *  detached — that's the signal to fall through to tag/SHA. */
+ *  detached — that's the signal to fall back to the short SHA.
+ *
+ *  We deliberately do NOT run `git describe --tags --exact-match HEAD` here:
+ *  it only returns something when HEAD sits exactly on a tagged commit (a rare
+ *  "checked out a release tag" case), yet to decide that it must load every tag
+ *  ref into a map first — on a repo with a huge tag count (~100k observed) that
+ *  single call costs 2–6s. The common detached case (a worktree parked on an
+ *  ordinary dev commit) matches no tag and pays that cost for nothing, then
+ *  falls back to the SHA anyway. So skip straight to the short SHA. */
 function getGitRef(dir: string): string {
   const branch = runGit('rev-parse --abbrev-ref HEAD', dir);
   if (branch && branch !== 'HEAD') return branch;
-  const tag = runGit('describe --tags --exact-match HEAD', dir);
-  if (tag) return tag;
   const sha = runGit('rev-parse --short HEAD', dir);
   return sha || 'unknown';
 }
 
-function describeDetachedHead(worktreePath: string, headSha: string): string {
-  const tag = runGit('describe --tags --exact-match HEAD', worktreePath);
-  if (tag) return tag;
+/** The worktree-list porcelain already hands us the detached HEAD's full SHA,
+ *  so return its short form directly — no `git` subprocess, and (same reasoning
+ *  as getGitRef) no expensive tag describe on huge-tag repos. */
+function describeDetachedHead(_worktreePath: string, headSha: string): string {
   return headSha ? headSha.slice(0, 7) : 'unknown';
 }
 

--- a/test/project-scanner.test.ts
+++ b/test/project-scanner.test.ts
@@ -542,13 +542,14 @@ describe('scanProjects', () => {
     expect(wt.branch).toBe('release/2026.05');
   });
 
-  // ─── Detached HEAD: tag / short-sha fallback ─────────────────────────────
+  // ─── Detached HEAD: always short-sha, never a tag describe ───────────────
 
-  it('should report the tag name when a worktree has detached HEAD pointing at a tag', () => {
+  it('should report the short SHA for a detached-HEAD worktree and NEVER run git describe --tags', () => {
     const mainPath = mkRepo('repo');
     const detachedPath = mkWorktreeGitlink('checkout-v1', '/some/.git/worktrees/x');
 
-    mockedExecSync.mockImplementation((cmd: string, opts?: any) => {
+    let describeCalled = false;
+    mockedExecSync.mockImplementation((cmd: string, _opts?: any) => {
       const cmdStr = String(cmd);
       if (cmdStr.includes('rev-parse --git-common-dir')) {
         return `${mainPath}/.git\n`;
@@ -565,8 +566,11 @@ describe('scanProjects', () => {
           '',
         ].join('\n');
       }
-      if (cmdStr.includes('describe --tags --exact-match HEAD')) {
-        if (opts?.cwd === detachedPath) return 'v1.2.3\n';
+      // Even if HEAD sits exactly on a tag, we no longer pay the (2–6s on
+      // huge-tag repos) describe cost — the detached label is the short SHA.
+      if (cmdStr.includes('describe --tags')) {
+        describeCalled = true;
+        return 'v1.2.3\n';
       }
       return '';
     });
@@ -575,7 +579,8 @@ describe('scanProjects', () => {
     const wt = results.find(r => r.type === 'worktree')!;
 
     expect(wt.path).toBe(detachedPath);
-    expect(wt.branch).toBe('v1.2.3');
+    expect(wt.branch).toBe('bbbbbbb'); // short SHA from the porcelain HEAD line, not the tag
+    expect(describeCalled).toBe(false); // the expensive tag describe must be gone
   });
 
   it('should fall back to the short SHA when a worktree has detached HEAD not pointing at any tag', () => {

--- a/test/project-scanner.test.ts
+++ b/test/project-scanner.test.ts
@@ -604,9 +604,8 @@ describe('scanProjects', () => {
           '',
         ].join('\n');
       }
-      if (cmdStr.includes('describe --tags --exact-match HEAD')) {
-        throw new Error('fatal: no tag exactly matches HEAD');
-      }
+      // No `describe --tags` mock here: the detached label now comes straight
+      // from the porcelain HEAD SHA, so the scanner never shells out to describe.
       return '';
     });
 


### PR DESCRIPTION
## 问题

仓库选择卡的分支标签在 detached HEAD 时会跑 `git describe --tags --exact-match HEAD` 想显示 tag 名。但：

- `--exact-match` 只在 HEAD **恰好落在某个被打了 tag 的 commit** 上才返回 tag，否则返回空；
- 为判断有没有 exact 命中，git 仍要把仓库的**全部 tag 引用读进映射**——在 tag 数量巨大的仓库（现场实测约 11 万个 tag）单次调用耗 **2–6 秒**；
- 而真正常见的「游离在某个工作 commit 上的 worktree」（如一批 detached 的开发 worktree）匹配不到任何 tag，**白付了遍历 tag 的成本**，最后仍回退到短 SHA。

这是 #756 现场剖析里 134 项扫描耗时 76s 的主要单项来源（详见该 PR 描述）。#756 用「扫描搬进子进程」隔离了主线程卡顿，但没消除这条 git describe 本身的慢；本 PR 从根上去掉它。

## 改动

detached HEAD 一律直接用短 SHA，不再 describe：

- `getGitRef`：删掉 `describe --tags --exact-match` 步骤，`rev-parse --abbrev-ref HEAD` 拿不到分支名就直接 `rev-parse --short HEAD`。
- `describeDetachedHead`：`git worktree list --porcelain` 已经给出该 worktree 的 HEAD 全 SHA，直接取短形式返回——连一次 git 子进程都省了。

## 影响面

- 仅改共用扫描器 `src/services/project-scanner.ts` 的**分支标签取值**；所有 CLI / 后端 / 平台共用同一扫描器。
- **不影响**仓库识别（仍靠 `.git` 标记判断）、worktree 去重（`--git-common-dir`）、扫描目录数/时长预算护栏。
- 唯一行为差异在一个**窄场景**：detached HEAD 恰好停在某个 release tag 上时，原来显示 tag 名（如 `v1.2.3`），现在显示短 SHA。取舍是：为这个罕见场景的「好看」在超多 tag 仓库上付 2–6s/仓库不值得，且普通 detached worktree 本来就拿不到 tag。

## 验证

- `pnpm build` 通过（tsc + dashboard bundle + dist audit）。
- 定向测试全绿（隔离跑，共 586 例）：`project-scanner`(47) + `repo-selection` + `command-handler` + `card-builder` + `card-handler-repo-select` + `group-join-shared-routing`。全量 `vitest run` 的失败集与 master 逐一比对均为既有环境项，无本 PR 引入的回归。
- 更新了 detached-HEAD 用例：断言标签是短 SHA，并断言 `git describe --tags` **永不被调用**（red-on-old：退回旧实现该用例失败，证明测试有牙）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
