### PR TITLE
fix(terminal): Worker 退出后清理终端端口状态

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -12240,14 +12240,19 @@ function setupWorkerHandlers(
       ds.worker = null;
       ds.workerReady = false;
       ds.workerPort = null;
+      // A dead worker can no longer refresh its card/usage view.
+      clearUsageRefreshTimer(ds);
+      // A worker owns the terminal HTTP listener. Persisting its former port
+      // after exit leaves the Dashboard proxy routing `/terminal/<session>` to
+      // a dead socket until some later ready event overwrites it. Clear both
+      // durable and aggregated state now so a persistent backend can be
+      // re-attached on demand instead of returning a stale 502.
+      ds.session.webPort = undefined;
       // A queued suspend for THIS generation is now moot — the worker it was
       // about is gone. Leaving it set would suspend the replacement on its
       // first idle (the deferred checkpoint's own "worker gone" branch cannot
       // help: it only runs on a screen update that will never arrive).
       clearPendingSuspendClaim(ds, 'worker exited');
-      // Dead worker generation — stop the periodic usage refresh immediately
-      // instead of waiting a tick for it to self-clear on !workerHasInitialized.
-      clearUsageRefreshTimer(ds);
       ds.workerToken = null;
       ds.workerViewToken = null;
       ds.managedTurnOrigin = undefined;
@@ -12278,6 +12283,13 @@ function setupWorkerHandlers(
       const exitedPreviewTarget = takeSessionPreviewTarget(ds.session);
       sessionStore.updateSession(ds.session);
       if (exitedPreviewTarget !== undefined) publishSessionPreviewCleared(ds.session.sessionId);
+      dashboardEventBus.publish({
+        type: 'session.update',
+        body: {
+          sessionId: ds.session.sessionId,
+          patch: { webPort: null, workerPid: null },
+        },
+      });
     }
     if (!transferRetirement) {
       try {

--- a/test/session-lifecycle-hooks.test.ts
+++ b/test/session-lifecycle-hooks.test.ts
@@ -112,6 +112,7 @@ import {
   __testOnly_setupWorkerHandlers,
 } from '../src/core/worker-pool.js';
 import { dashboardEventBus } from '../src/core/dashboard-events.js';
+import * as sessionStore from '../src/services/session-store.js';
 import type { DaemonSession } from '../src/core/types.js';
 
 function makeFakeWorker() {
@@ -417,6 +418,26 @@ describe('worker-pool lifecycle hook integration', () => {
       reason: 'exit_code_1',
       code: 1,
     }));
+  });
+
+  it('clears the persisted terminal port and Dashboard proxy state on worker exit', () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({ worker, workerPort: 9999 });
+    ds.session.webPort = 9999;
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('exit', 1);
+
+    expect(ds.workerPort).toBe(null);
+    expect(ds.session.webPort).toBeUndefined();
+    expect(sessionStore.updateSession).toHaveBeenCalledWith(ds.session);
+    expect(dashboardEventBus.publish).toHaveBeenCalledWith({
+      type: 'session.update',
+      body: {
+        sessionId: 'sid-lifecycle-test',
+        patch: { webPort: null, workerPid: null },
+      },
+    });
   });
 
   it('suppresses external exit events for an intentional transfer detach', async () => {


### PR DESCRIPTION
## 概述

修复 worker 退出后 Web Terminal 仍可能被 Dashboard 代理到旧端口的问题。

这是通用的 worker 生命周期状态一致性修复，不依赖 Codex App、特定 IM 平台、终端静态资源加载或远程隧道实现。

## 根因

每个 worker 持有自己的终端 HTTP/WebSocket 监听端口。worker 正常退出、崩溃或重启时，运行态 `ds.workerPort` 会被清空，但持久化 `session.webPort` 可能保留旧值，Dashboard 的聚合投影也没有收到端口失效通知。

会出现以下状态不一致：

```text
session 仍 active
worker 已退出
session.webPort 仍指向旧监听端口
Dashboard /terminal/<session> 继续代理到旧端口
→ 上游连接失败 / 502
```

这不是浏览器问题：只要 active session 在 worker 退出后尚未由替代 worker 的 `ready` 事件发布新端口，就可能发生。

## 修复

在 `worker.on('exit')` 的权威代次转换中：

1. 清空运行态 `ds.workerPort`；
2. 同步清空持久化 `ds.session.webPort`；
3. 写入 session store 后发布：

```ts
session.update { webPort: null, workerPid: null }
```

Dashboard 不再把旧监听器当作有效终端目标。可重新 attach 的持久后端会在后续 wake/reattach 后通过新的 `ready` 注册新端口；不可恢复会话则正确显示终端不可用，而不是代理到死 socket。

## 范围

本 PR 不改：

- 终端 URL 或平台路由；
- 浏览器/CDN/static asset 加载；
- terminal capability、write token 或 WebSocket 鉴权；
- Codex App shared-adopt 行为。

它只修正终端可用性的运行态、持久化 session 行和 Dashboard 投影三者一致性。

## 验证

新增回归：模拟具有 `workerPort` / `session.webPort` 的 worker 退出，断言：

- 运行态 `workerPort` 清除；
- 持久化 `session.webPort` 清除；
- session 被持久化；
- Dashboard 收到 `session.update { webPort: null, workerPid: null }`。

已执行：

```text
vitest run --project unit \
  test/session-lifecycle-hooks.test.ts \
  test/usage-refresh-timer-wiring.test.ts \
  test/terminal-proxy.test.ts \
  test/terminal-front-proxy.test.ts \
  test/worker-suspend.test.ts
```

结果：**5 个测试文件、90 项测试通过**。

另已执行 `pnpm build`，通过 TypeScript、脚本类型检查、Dashboard 打包、公开域名审计和产物审计。
