### PR TITLE
fix(codex): Hook 审核菜单显示时暂存远程输入

### DIFF
--- a/src/utils/stuck-detector.ts
+++ b/src/utils/stuck-detector.ts
@@ -122,6 +122,39 @@ export function matchHookReviewScreen(snapshot: string): 'hook review level 1' |
   return undefined;
 }
 
+/** Codex startup review is a separate three-choice screen from the detailed
+ * Hooks browser. It owns Enter/arrow keys, so normal BotMux input must not be
+ * pasted into it. Keep its signature strict and footer-anchored to avoid
+ * treating quoted discussion text as an active menu. */
+function isStartupHookReviewScreen(snapshot: string): boolean {
+  if (!snapshot) return false;
+  const viewport = snapshot
+    .split('\n')
+    .map(stripAnsi)
+    .slice(-VIEWPORT_LINES);
+  let end = viewport.length;
+  while (end > 0 && viewport[end - 1].trim() === '') end--;
+  if (end === 0) return false;
+  const trimmed = viewport.slice(0, end);
+  const lastLine = trimmed[trimmed.length - 1].trim();
+  if (!/^Press enter to confirm or esc to go back$/i.test(lastLine)) return false;
+  const region = trimmed.slice(Math.max(0, trimmed.length - 18)).join('\n');
+  return /^Hooks need review$/im.test(region)
+    && /^\d+\s+hooks?\s+are new or changed\.$/im.test(region)
+    && /^\s*1\.\s+Review hooks$/im.test(region)
+    && /^\s*>?\s*2\.\s+Trust all and continue$/im.test(region)
+    && /^\s*3\.\s+Continue without trusting \(hooks won't run\)$/im.test(region);
+}
+
+/** A Hook-review menu owns Enter/arrow keys instead of the normal Codex
+ * composer. Queue BotMux-originated input until the operator resolves it:
+ * otherwise a message submit can accidentally select "Trust all" or be lost
+ * before it reaches the model. Kept pure so the worker wiring is testable. */
+export function shouldHoldInputForHookReview(snapshot: string): boolean {
+  return matchHookReviewScreen(snapshot) !== undefined
+    || isStartupHookReviewScreen(snapshot);
+}
+
 export interface StuckDetectorCallbacks {
   /** Called when the timeout elapses. Return true to fire the warning; false
    *  to silently re-arm (e.g. the CLI just finished a long turn). */

--- a/src/utils/stuck-detector.ts
+++ b/src/utils/stuck-detector.ts
@@ -124,8 +124,14 @@ export function matchHookReviewScreen(snapshot: string): 'hook review level 1' |
 
 /** Codex startup review is a separate three-choice screen from the detailed
  * Hooks browser. It owns Enter/arrow keys, so normal BotMux input must not be
- * pasted into it. Keep its signature strict and footer-anchored to avoid
- * treating quoted discussion text as an active menu. */
+ * pasted into it. The patterns below follow the official `rust-v0.147.0`
+ * snapshot: every rendered line has a left margin and `›` may mark ANY
+ * selected option. Keep the signature strict and footer-anchored to avoid
+ * treating quoted discussion text as an active menu.
+ *
+ * The footer is rendered from the active keymap. Like the existing detailed
+ * Hooks-browser detector, this recognises Codex's default keymap wording; a
+ * custom keymap that changes the hint fails open rather than guessing. */
 function isStartupHookReviewScreen(snapshot: string): boolean {
   if (!snapshot) return false;
   const viewport = snapshot
@@ -139,11 +145,11 @@ function isStartupHookReviewScreen(snapshot: string): boolean {
   const lastLine = trimmed[trimmed.length - 1].trim();
   if (!/^Press enter to confirm or esc to go back$/i.test(lastLine)) return false;
   const region = trimmed.slice(Math.max(0, trimmed.length - 18)).join('\n');
-  return /^Hooks need review$/im.test(region)
-    && /^\d+\s+hooks?\s+are new or changed\.$/im.test(region)
-    && /^\s*1\.\s+Review hooks$/im.test(region)
-    && /^\s*>?\s*2\.\s+Trust all and continue$/im.test(region)
-    && /^\s*3\.\s+Continue without trusting \(hooks won't run\)$/im.test(region);
+  return /^\s*Hooks need review$/im.test(region)
+    && /^\s*\d+\s+hooks?\s+(?:is|are) new or changed\.$/im.test(region)
+    && /^\s*[›>]?\s*1\.\s+Review hooks$/im.test(region)
+    && /^\s*[›>]?\s*2\.\s+Trust all and continue$/im.test(region)
+    && /^\s*[›>]?\s*3\.\s+Continue without trusting \(hooks won't run\)$/im.test(region);
 }
 
 /** A Hook-review menu owns Enter/arrow keys instead of the normal Codex

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2223,7 +2223,7 @@ function refreshHookReviewInputHold(snapshot: string): void {
   }
   hookReviewInputHoldNotified = false;
   log('Hook review menu cleared — releasing queued input');
-  if (pendingMessages.length > 0) queueMicrotask(() => { void flushPending(); });
+  if (hasPendingInputForFlush()) queueMicrotask(() => { void flushPending(); });
 }
 
 function notifyHookReviewInputHold(): void {
@@ -2492,6 +2492,16 @@ let pendingSessionRename: string | null = null;
 let nativeSessionTitleSyncInFlight: string | undefined;
 let nativeSessionTitleAppliedThreadId: string | undefined;
 let nativeSessionTitleRevision = 0;
+
+/** Every user-controlled input class that flushPending can deliver. Keep this
+ * shared with review-menu release handling so a queued raw command, adopt
+ * message, or native rename is not stranded after the menu disappears. */
+function hasPendingInputForFlush(): boolean {
+  return pendingMessages.length > 0
+    || pendingAdoptMessages.length > 0
+    || pendingRawInputs.length > 0
+    || pendingSessionRename !== null;
+}
 let nativeSessionTitleResumeUpdatedAt: number | undefined;
 let nativeSessionTitleCurrentGenerationResume = false;
 const nativeSessionTitleSyncAbortControllers = new Set<AbortController>();
@@ -10708,7 +10718,7 @@ async function flushPending(): Promise<void> {
     ambiguousSubmissionRecoveryHold = null;
   }
   if (ambiguousSubmissionRecoveryHold?.backend === backend) return;
-  if (pendingMessages.length === 0 && pendingAdoptMessages.length === 0 && pendingRawInputs.length === 0 && pendingSessionRename === null) return;  // nothing to flush — keep isPromptReady
+  if (!hasPendingInputForFlush()) return;  // nothing to flush — keep isPromptReady
   if (sessionRenameInFlight()) return;  // wait for /rename to finish before any user input
   if (commandLineWritesPending > 0) return;  // do not splice into text -> Enter
   // 注入进行中不得并发写 PTY（用户消息留在 pendingMessages，注入完成后的下一次
@@ -18179,12 +18189,22 @@ process.on('message', async (raw: unknown) => {
       // shell。bareShellCheckInProgress 覆盖“检查进行中”、bareShellLaunchBlocked
       // 覆盖“仍停在裸 shell 的安全 hold”两种状态，一并入队；若该进程随后出现
       // 真实 PTY prompt 且 leaf 已变为非 shell，markPromptReady 会恢复排空。
+      // Hook-review menus are another direct-write hazard: raw_input normally
+      // preserves busy delivery, but its Enter/arrow sequence must never drive
+      // the menu's current selection.
+      refreshHookReviewInputHold(lastAnalyzerSnapshot || renderer?.rawSnapshot() || '');
       if (cliRestartInProgress || rawInputRestartGate || sessionRenameInFlight()
         || shouldHoldCodexRunnerInput(codexRunnerFreshness)
         || injectionFlushing || shouldDeferUserFlush(pendingInjections)
-        || bareShellCheckInProgress || bareShellLaunchBlocked) {
+        || bareShellCheckInProgress || bareShellLaunchBlocked
+        || hookReviewInputHold) {
         freshnessInputQueue.enqueueRaw(msg);
-        log(`Deferred passthrough slash command until CLI input gate settles: ${msg.content}`);
+        if (hookReviewInputHold) {
+          notifyHookReviewInputHold();
+          log(`Deferred passthrough slash command while Hook review is visible: ${msg.content}`);
+        } else {
+          log(`Deferred passthrough slash command until CLI input gate settles: ${msg.content}`);
+        }
       } else {
         await deliverRawInput(msg);
       }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -330,7 +330,11 @@ import { tmuxEnv, probeTmuxFunctionalWithRetry } from './setup/ensure-tmux.js';
 import { probeZmxVersion } from './setup/ensure-zmx.js';
 import { tmuxRestartJitterMs } from './core/tmux-recovery.js';
 import { IdleDetector } from './utils/idle-detector.js';
-import { StuckDetector, matchHookReviewScreen } from './utils/stuck-detector.js';
+import {
+  StuckDetector,
+  matchHookReviewScreen,
+  shouldHoldInputForHookReview,
+} from './utils/stuck-detector.js';
 import { processStuckWarningTuiKeys, shouldRearmStuckDetector } from './utils/stuck-key-guard.js';
 import { sendTuiKeySequence, submitTuiTextInput } from './utils/tui-input-delivery.js';
 import { captureToPng } from './utils/screenshot-renderer.js';
@@ -2202,6 +2206,37 @@ let readyPatternSeenDuringHold = false;
 let awaitingPostSessionStartPromptEvidence = false;
 /** Scoped marker set only by IdleDetector's screen-driven callback. */
 let postSessionStartPromptEvidenceInFlight = false;
+/** A visible Codex Hook-review screen owns Enter/arrow keys. Keep queued IM
+ * input out of that menu so an automated submit cannot accidentally select
+ * “Trust all” or get consumed as menu navigation. */
+let hookReviewInputHold = false;
+let hookReviewInputHoldNotified = false;
+
+function refreshHookReviewInputHold(snapshot: string): void {
+  if (!snapshot.trim()) return;
+  const blocked = shouldHoldInputForHookReview(snapshot);
+  if (blocked === hookReviewInputHold) return;
+  hookReviewInputHold = blocked;
+  if (blocked) {
+    log('Hook review menu visible — holding queued input until the menu is resolved');
+    return;
+  }
+  hookReviewInputHoldNotified = false;
+  log('Hook review menu cleared — releasing queued input');
+  if (pendingMessages.length > 0) queueMicrotask(() => { void flushPending(); });
+}
+
+function notifyHookReviewInputHold(): void {
+  if (hookReviewInputHoldNotified) return;
+  hookReviewInputHoldNotified = true;
+  send({
+    type: 'user_notify',
+    turnId: currentBotmuxTurnId,
+    message:
+      '⚠️ Codex 正在显示 Hook 审核菜单。为避免消息误触“Trust all”或被菜单吞掉，'
+      + 'BotMux 已暂存后续消息；请先在终端完成 Hook 选择，恢复普通输入框后会自动投递。',
+  });
+}
 
 /** Wait until the PTY has been quiet for READY_FLUSH_SETTLE_MS (Ink render
  *  drained), capped at READY_FLUSH_SETTLE_CAP_MS, then flush the held prompt.
@@ -9657,6 +9692,7 @@ function onPtyData(data: string): void {
     }
   }
   renderer?.write(data);
+  refreshHookReviewInputHold(`${renderer?.rawSnapshot() ?? ''}\n${data}`);
 
   // In tmux-attach mode, each web client has its own tmux attach PTY —
   // no relay needed. In non-tmux mode AND in pipe mode (adopt-bridge),
@@ -9767,6 +9803,7 @@ async function onBackendScreenResync(snapshot: string): Promise<void> {
   // current viewport: a prior local attach may have changed the real geometry.
   const visibleSnapshot = nextRenderer?.rawSnapshot() ?? '';
   lastAnalyzerSnapshot = visibleSnapshot;
+  refreshHookReviewInputHold(visibleSnapshot);
 
   // ZMX history does not carry the authoritative current PTY dimensions. A
   // local `zmx attach` can resize the session below our default 120x24 and that
@@ -10684,6 +10721,14 @@ async function flushPending(): Promise<void> {
   // flushPendingInjections 消费完 barrier 后由其 finally 的 re-kick 排空。
   if (shouldDeferUserFlush(pendingInjections)) return;
   if (bareShellLaunchBlocked) return;  // launch is held at a bare shell — don't type prompts into it
+  // A Hook-review page has an active selection and consumes Enter/arrow keys.
+  // Re-check the rendered viewport right before a literal write; PTY chunks
+  // can arrive between idle detection and this queue drain.
+  refreshHookReviewInputHold(lastAnalyzerSnapshot || renderer?.rawSnapshot() || '');
+  if (hookReviewInputHold) {
+    notifyHookReviewInputHold();
+    return;
+  }
   // Screen-idle is not a durable receipt. A permission/AskUser prompt can look
   // idle while the logical delivery is unresolved, so no following IM or
   // meeting turn may cross this boundary until an explicit terminal releases
@@ -13243,6 +13288,8 @@ async function spawnCli(
   bareShellLaunchBlocked = false;
   bareShellChecked = false;
   bareShellCheckInProgress = false;
+  hookReviewInputHold = false;
+  hookReviewInputHoldNotified = false;
 
   // ── Resume pre-flight check + two-tier fallback ──────────────────────────
   // Tier 0 (adapter capability): adapters whose buildArgs can only resume a

--- a/test/fixtures/codex-startup-hooks-review-rust-v0.147.0.snap
+++ b/test/fixtures/codex-startup-hooks-review-rust-v0.147.0.snap
@@ -1,0 +1,15 @@
+---
+source: openai/codex codex-rs/tui/src/startup_hooks_review.rs
+snapshot: codex_tui__startup_hooks_review__tests__startup_hooks_review_prompt.snap
+ref: rust-v0.147.0
+---
+
+  Hooks need review
+  2 hooks are new or changed.
+  Hooks can run outside the sandbox after you trust them.
+
+› 1. Review hooks
+  2. Trust all and continue
+  3. Continue without trusting (hooks won't run)
+
+  Press enter to confirm or esc to go back

--- a/test/hook-review-input-hold-wiring.test.ts
+++ b/test/hook-review-input-hold-wiring.test.ts
@@ -7,19 +7,37 @@ describe('Hook review input hold wiring', () => {
   it('holds queued input before the literal write and only releases after the menu clears', () => {
     const holdStart = worker.indexOf('function refreshHookReviewInputHold');
     const hold = worker.slice(holdStart, worker.indexOf('\n/** Wait until', holdStart));
+    const queueHelperStart = worker.indexOf('function hasPendingInputForFlush(): boolean');
+    const queueHelper = worker.slice(queueHelperStart, worker.indexOf('\nlet nativeSessionTitleResumeUpdatedAt', queueHelperStart));
     const flushStart = worker.indexOf('async function flushPending(): Promise<void>');
     const flush = worker.slice(flushStart, worker.indexOf('\n  // Screen-idle', flushStart));
 
     expect(holdStart).toBeGreaterThanOrEqual(0);
+    expect(queueHelperStart).toBeGreaterThanOrEqual(0);
     expect(hold).toContain('queueMicrotask(() => { void flushPending(); })');
+    expect(hold).toContain('hasPendingInputForFlush()');
+    expect(queueHelper).toContain('pendingMessages.length > 0');
+    expect(queueHelper).toContain('pendingAdoptMessages.length > 0');
+    expect(queueHelper).toContain('pendingRawInputs.length > 0');
+    expect(queueHelper).toContain('pendingSessionRename !== null');
+    expect(flush).toContain('if (!hasPendingInputForFlush()) return;');
     expect(flush).toContain("refreshHookReviewInputHold(lastAnalyzerSnapshot || renderer?.rawSnapshot() || '');");
     expect(flush).toContain('notifyHookReviewInputHold();');
     expect(flush).toContain('if (hookReviewInputHold)');
   });
 
-  it('refreshes the hold from live PTY output and clears it on a new CLI spawn', () => {
+  it('refreshes the hold from live PTY output, gates direct raw input, and clears it on a new CLI spawn', () => {
+    const rawStart = worker.indexOf("case 'raw_input': {");
+    const raw = worker.slice(rawStart, worker.indexOf("case 'rename_session':", rawStart));
+
     expect(worker).toContain("refreshHookReviewInputHold(`${renderer?.rawSnapshot() ?? ''}\\n${data}`);");
     expect(worker).toContain('refreshHookReviewInputHold(visibleSnapshot);');
+    expect(rawStart).toBeGreaterThanOrEqual(0);
+    expect(raw).toContain("refreshHookReviewInputHold(lastAnalyzerSnapshot || renderer?.rawSnapshot() || '');");
+    expect(raw).toContain('if (hookReviewInputHold)');
+    expect(raw).toContain('freshnessInputQueue.enqueueRaw(msg);');
+    expect(raw).toContain('notifyHookReviewInputHold();');
+    expect(raw.indexOf('if (hookReviewInputHold)')).toBeLessThan(raw.indexOf('await deliverRawInput(msg);'));
     expect(worker).toContain('hookReviewInputHold = false;');
     expect(worker).toContain('hookReviewInputHoldNotified = false;');
   });

--- a/test/hook-review-input-hold-wiring.test.ts
+++ b/test/hook-review-input-hold-wiring.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const worker = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+
+describe('Hook review input hold wiring', () => {
+  it('holds queued input before the literal write and only releases after the menu clears', () => {
+    const holdStart = worker.indexOf('function refreshHookReviewInputHold');
+    const hold = worker.slice(holdStart, worker.indexOf('\n/** Wait until', holdStart));
+    const flushStart = worker.indexOf('async function flushPending(): Promise<void>');
+    const flush = worker.slice(flushStart, worker.indexOf('\n  // Screen-idle', flushStart));
+
+    expect(holdStart).toBeGreaterThanOrEqual(0);
+    expect(hold).toContain('queueMicrotask(() => { void flushPending(); })');
+    expect(flush).toContain("refreshHookReviewInputHold(lastAnalyzerSnapshot || renderer?.rawSnapshot() || '');");
+    expect(flush).toContain('notifyHookReviewInputHold();');
+    expect(flush).toContain('if (hookReviewInputHold)');
+  });
+
+  it('refreshes the hold from live PTY output and clears it on a new CLI spawn', () => {
+    expect(worker).toContain("refreshHookReviewInputHold(`${renderer?.rawSnapshot() ?? ''}\\n${data}`);");
+    expect(worker).toContain('refreshHookReviewInputHold(visibleSnapshot);');
+    expect(worker).toContain('hookReviewInputHold = false;');
+    expect(worker).toContain('hookReviewInputHoldNotified = false;');
+  });
+});

--- a/test/stuck-detector.test.ts
+++ b/test/stuck-detector.test.ts
@@ -21,6 +21,10 @@ import {
 const FIXTURES = join(__dirname, 'fixtures');
 const LEVEL_1_SNAPSHOT = readFileSync(join(FIXTURES, 'codex-hooks-browser-level1.snap'), 'utf-8');
 const LEVEL_2_SNAPSHOT = readFileSync(join(FIXTURES, 'codex-hooks-browser-level2.snap'), 'utf-8');
+const STARTUP_HOOKS_REVIEW_SNAPSHOT = readFileSync(
+  join(FIXTURES, 'codex-startup-hooks-review-rust-v0.147.0.snap'),
+  'utf-8',
+);
 
 describe('StuckDetector', () => {
   beforeEach(() => {
@@ -211,20 +215,16 @@ describe('StuckDetector', () => {
 });
 
 describe('shouldHoldInputForHookReview', () => {
-  const STARTUP_REVIEW = [
-    'Hooks need review',
-    '13 hooks are new or changed.',
-    'Hooks can run outside the sandbox after you trust them.',
-    '',
-    '1. Review hooks',
-    '> 2. Trust all and continue',
-    '3. Continue without trusting (hooks won\'t run)',
-    '',
-    'Press enter to confirm or esc to go back',
-  ].join('\n');
+  it('holds input on the official Codex startup review snapshot so Enter cannot trust all', () => {
+    expect(shouldHoldInputForHookReview(STARTUP_HOOKS_REVIEW_SNAPSHOT)).toBe(true);
+  });
 
-  it('holds input on the Codex startup review menu so Enter cannot trust all', () => {
-    expect(shouldHoldInputForHookReview(STARTUP_REVIEW)).toBe(true);
+  it('accepts the singular count and a selection arrow on any option', () => {
+    const singularWithThirdSelected = STARTUP_HOOKS_REVIEW_SNAPSHOT
+      .replace('2 hooks are new or changed.', '1 hook is new or changed.')
+      .replace('› 1. Review hooks', '  1. Review hooks')
+      .replace('  3. Continue without trusting (hooks won\'t run)', '› 3. Continue without trusting (hooks won\'t run)');
+    expect(shouldHoldInputForHookReview(singularWithThirdSelected)).toBe(true);
   });
 
   it('releases input on an ordinary Codex composer', () => {
@@ -233,7 +233,7 @@ describe('shouldHoldInputForHookReview', () => {
 
   it('does not mistake quoted startup-review text for an active menu', () => {
     expect(shouldHoldInputForHookReview(
-      `The terminal printed:\n${STARTUP_REVIEW}\n\n› Ask Codex to do anything`,
+      `The terminal printed:\n${STARTUP_HOOKS_REVIEW_SNAPSHOT}\n\n› Ask Codex to do anything`,
     )).toBe(false);
   });
 });

--- a/test/stuck-detector.test.ts
+++ b/test/stuck-detector.test.ts
@@ -10,7 +10,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { StuckDetector, matchHookReviewScreen } from '../src/utils/stuck-detector.js';
+import {
+  StuckDetector,
+  matchHookReviewScreen,
+  shouldHoldInputForHookReview,
+} from '../src/utils/stuck-detector.js';
 
 // Official Codex TUI snapshots read from fixture files (not inline constants)
 // so the classifier is tested against the real on-disk representation.
@@ -203,6 +207,34 @@ describe('StuckDetector', () => {
 
     expect(onStuck).toHaveBeenCalledTimes(1);
     detector.dispose();
+  });
+});
+
+describe('shouldHoldInputForHookReview', () => {
+  const STARTUP_REVIEW = [
+    'Hooks need review',
+    '13 hooks are new or changed.',
+    'Hooks can run outside the sandbox after you trust them.',
+    '',
+    '1. Review hooks',
+    '> 2. Trust all and continue',
+    '3. Continue without trusting (hooks won\'t run)',
+    '',
+    'Press enter to confirm or esc to go back',
+  ].join('\n');
+
+  it('holds input on the Codex startup review menu so Enter cannot trust all', () => {
+    expect(shouldHoldInputForHookReview(STARTUP_REVIEW)).toBe(true);
+  });
+
+  it('releases input on an ordinary Codex composer', () => {
+    expect(shouldHoldInputForHookReview('› Ask Codex to do anything')).toBe(false);
+  });
+
+  it('does not mistake quoted startup-review text for an active menu', () => {
+    expect(shouldHoldInputForHookReview(
+      `The terminal printed:\n${STARTUP_REVIEW}\n\n› Ask Codex to do anything`,
+    )).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 概述

当 Codex 显示 Hook 审核菜单时，暂存 BotMux 的远程/IM 输入，避免消息提交所需的 Enter 或方向键被菜单消费、误触当前选项（例如 `Trust all and continue`）。

本 PR 不依赖具体 Hook 名称、Hook 命令、hash、企业配置或平台隧道；它只按 Codex 公共 TUI 审核菜单的渲染形态工作。

## 问题

BotMux 正常会将 IM 输入写入 Codex 的交互式终端：普通 composer 中 Enter 用于提交消息，但 Hook 审核菜单中 Enter/方向键属于菜单控制。

如果此时继续投递远程输入，可能发生：

- 用户消息被菜单消费，根本没有进入模型；
- 当前选项被误确认；
- 原生命令、后续消息或菜单导航相互交错，造成不可预测状态。

## 方案

### 严格识别活动审核菜单

新增 `shouldHoldInputForHookReview(snapshot)`，覆盖两类 Codex UI：

1. 既有 Hooks browser / per-hook review 页面；
2. 启动阶段的三选项审核页面：Review hooks / Trust all and continue / Continue without trusting。

启动审核页的匹配直接使用 Codex `rust-v0.147.0` 官方渲染快照作为 fixture，并处理真实渲染细节：

- 两空格左缩进；
- `›` 选中箭头可位于任意选项；
- `1 hook is new or changed.` 与 `N hooks are new or changed.`；
- footer 必须是当前视口最后一个非空行。

因此普通 composer 或终端历史/引用文本中的相同菜单文案不会误判为当前活动菜单。默认 keymap footer 文案沿用既有 Hooks browser 检测；自定义 keymap 改变该提示时 fail-open，不猜测菜单状态。

### 输入队列保护

```text
PTY 输出或 backend screen resync 观察到审核菜单
→ hookReviewInputHold = true
→ 普通 IM 消息、adopt 消息、raw/passthrough 命令和原生 rename 都不写入终端
→ 待投递输入保留在队列，只通知一次

操作员在终端中完成审核菜单
→ hookReviewInputHold = false
→ 所有待投递输入队列重新触发 flushPending
```

`raw_input` 原本允许 busy delivery，因此单独在其直接写入路径前重查审核菜单，避免绕过 `flushPending` 后直接发送 Enter/方向键。每个新 CLI generation 会重置 hold 状态，避免旧 UI 状态跨重启/重新 attach 泄漏。

## 安全与兼容性

- 不自动信任、拒绝、确认或选择任何 Hook；最终选择始终由终端中的操作员完成。
- 不读取或解析 Hook 命令、名称、hash 或配置路径。
- 不改变普通 Codex composer、非 Codex CLI、terminal URL、WebSocket 或平台隧道行为。
- 菜单签名不完整或不是当前活动视口时不 hold 输入，避免广泛误阻塞。

## 验证

覆盖：

- 官方 Codex `rust-v0.147.0` 启动审核快照；
- 单数/复数 count、任意选项带选择箭头；
- 普通 composer 与引用/历史文本不误判；
- PTY 输出、backend resync、写入前检查、新 CLI generation reset；
- 普通消息、adopt 消息、raw 输入、rename 的队列恢复；
- raw_input 不会绕过审核菜单进入直接写入路径；
- 既有 raw-input、rename、IME 和输入 gate 行为保持不变。

已执行：

```text
vitest run --project unit \
  test/stuck-detector.test.ts \
  test/hook-review-input-hold-wiring.test.ts \
  test/input-gate.test.ts \
  test/web-terminal-ime.test.ts \
  test/session-rename-worker.test.ts \
  test/raw-input-followup-atomicity.test.ts \
  test/worker-ordinary-im-receipt-wiring.test.ts
```

结果：**7 个测试文件、138 项测试通过**。

另已执行 `pnpm build`，通过 TypeScript、脚本类型检查、Dashboard 打包、公开域名审计和产物审计。
