### PR TITLE
fix(codex): 完善共享接入边界

### DIFF
--- a/docs/design/codex-app-shared-adopt.md
+++ b/docs/design/codex-app-shared-adopt.md
@@ -35,7 +35,6 @@ thread，而不是创建第二个服务端或取得/伪造 writer lock。
 - GUI 发起的新 turn 可以同步到 IM；IM 发起的 turn 可以在 GUI 上连续可见。
 - 断开 BotMux 只移除 IM 入口，不关闭原 App Server thread。
 - BotMux daemon 重启后可重新接入保留的远程 TUI，不杀掉已有 App Server。
-- Web 终端可作为独立的诊断/手工操作入口，并在 worker 重启后不代理到死端口。
 
 ### 非目标
 
@@ -136,7 +135,9 @@ BotMux 对共享 thread 使用 split-live 边界：
 共享 adopt 的 remote TUI 与原 App Server 是不同生命周期：
 
 - BotMux daemon 重启不应停止已有 App Server；
-- 已保留的 tmux/remote TUI 可被新 worker 重新 attach；
+- tmux 等持久后端中，已保留的 remote TUI 可被新 worker 重新 attach；
+- `pty` 后端的 daemon 重启会带走 remote TUI 进程，但 BotMux 不会主动关闭
+  server-side thread；后续连接会创建新的官方 remote client；
 - worker 关闭时需要保留远程 TUI，避免把 GUI 仍依赖的会话误杀。
 
 ## 7. 兼容性与影响范围

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1329,7 +1329,9 @@ export interface BotConfig {
    * Server. This does not make BotMux an app-server owner: after the operator
    * explicitly selects an existing thread via `/adopt`, BotMux launches the
    * official `codex --remote <endpoint> resume <thread>` TUI as a second
-   * client. New threads are deliberately not auto-created in this mode.
+   * client. For the `cliId: "codex"` shared-adopt path, new remote threads are
+   * deliberately not auto-created; `cliId: "codex-app"` retains its existing
+   * new-session workflow until the operator explicitly selects a shared thread.
    */
   existingAppServer?: ExistingAppServerConfig;
   /**

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -1547,12 +1547,25 @@ export async function handleCommand(
           const current = [...activeSessions.values()].find(
             candidate => candidate.session.sessionId === closedSessionId,
           );
-          if (!current || !isSharedAdoptSession(current)) return false;
-          await closeWorkerPoolSession(closedSessionId);
-          return true;
+          if (!current || !isSharedAdoptSession(current)) return 'missing' as const;
+          try {
+            const result = await closeWorkerPoolSession(closedSessionId);
+            if (!result.ok) return 'refused' as const;
+            return result.outcome === 'closed' ? 'closed' as const : 'residual' as const;
+          } catch {
+            return 'refused' as const;
+          }
         });
-        if (!detached) {
+        if (detached === 'missing') {
           await sessionReply(rootId, t('cmd.no_active_session', undefined, loc));
+          break;
+        }
+        if (detached === 'refused') {
+          await sessionReply(rootId, t('cmd.detach.failed', undefined, loc));
+          break;
+        }
+        if (detached === 'residual') {
+          await sessionReply(rootId, t('cmd.detach.residual', undefined, loc));
           break;
         }
         await sessionReply(

--- a/src/core/existing-app-server.ts
+++ b/src/core/existing-app-server.ts
@@ -30,6 +30,12 @@ export function normalizeExistingAppServerEndpoint(
   if (typeof raw !== 'string' || !raw.trim()) {
     throw endpointError(label, 'must be a non-empty string');
   }
+  // URL parsing and String#trim may silently discard some trailing C0 controls.
+  // Reject them before normalization so every caller sees one unambiguous,
+  // printable endpoint value.
+  if (/[\u0000-\u001F\u007F]/.test(raw)) {
+    throw endpointError(label, 'must not contain control characters');
+  }
   const endpoint = raw.trim();
   if (/\s/.test(endpoint)) {
     throw endpointError(label, 'must not contain whitespace');

--- a/test/close-consumer-matrix.test.ts
+++ b/test/close-consumer-matrix.test.ts
@@ -76,9 +76,9 @@ const CONSUMERS: Record<string, Rule> = {
   // ── user surfaces: must render refusal AND residual ──────────────────────
   'core/command-handler.ts::handleCommand::closeSession': {
     category: 'user_surface',
-    why: '/close and shared-adopt disconnect both branch on refused/residual '
-      + 'results; neither reports an ordinary close/disconnect while cleanup is '
-      + 'unproven.',
+    why: '/close plus shared-adopt /detach and /disconnect all branch on '
+      + 'refused/residual results; none report an ordinary close/disconnect while '
+      + 'cleanup is unproven.',
     count: 4,
   },
   'core/command-handler.ts::commitRepoSelection::closeSession': {

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -1904,6 +1904,59 @@ describe('handleCommand', () => {
       expect(reply).not.toContain('App Server 和 Codex App 会话仍在运行');
     });
 
+    it.each([
+      {
+        command: '/detach',
+        close: {
+          ok: true,
+          outcome: 'closed',
+          alreadyClosed: false,
+          known: true,
+        },
+        expected: 'App Server 和 Codex App 会话仍在运行',
+      },
+      {
+        command: '/detach',
+        close: {
+          ok: false,
+          alreadyClosed: false,
+          error: 'remote_close_unproven',
+          retryable: true,
+        },
+        expected: '未能安全断开',
+      },
+      {
+        command: '/disconnect',
+        close: {
+          ok: true,
+          outcome: 'closed_with_residual',
+          residual: { reason: 'local_subtree_boundary_unproven' },
+          alreadyClosed: false,
+          known: true,
+        },
+        expected: '未能确认完全断开',
+      },
+    ])('maps shared $command close outcomes without claiming an unverified detach', async ({ command, close, expected }) => {
+      const ds = makeDaemonSession({
+        session: makeSession({
+          cliId: 'codex' as any,
+          cliSessionId: '019e-existing-app-server-thread',
+          existingAppServerEndpoint: 'unix:///home/testuser/.codex/app-server-control/app-server-control.sock',
+        }),
+      });
+      const deps = makeDeps(ds);
+      vi.mocked(closeSession).mockResolvedValueOnce(close as never);
+
+      await handleCommand(command, ROOT_ID, makeLarkMessage(command), deps, LARK_APP_ID);
+
+      expect(closeSession).toHaveBeenCalledWith('sess-001');
+      const reply = vi.mocked(deps.sessionReply).mock.calls[0]?.[1] as string;
+      expect(reply).toContain(expected);
+      if ((close as { outcome?: string }).outcome !== 'closed') {
+        expect(reply).not.toContain('App Server 和 Codex App 会话仍在运行');
+      }
+    });
+
     it('closes through the authoritative worker-pool lifecycle and removes the session', async () => {
       const ds = makeDaemonSession();
       const deps = makeDeps(ds);

--- a/test/existing-app-server.test.ts
+++ b/test/existing-app-server.test.ts
@@ -27,6 +27,15 @@ describe('existing Codex App Server endpoint validation', () => {
     expect(() => normalizeExistingAppServerEndpoint(endpoint)).toThrow();
   });
 
+  it.each([
+    'unix:///tmp/codex.sock\u0000',
+    'unix:///tmp/codex.sock\u001b',
+    'unix:///tmp/codex.sock\u007f',
+    'ws://127.0.0.1:9931\n',
+  ])('rejects endpoint control characters before URL normalization', (endpoint) => {
+    expect(() => normalizeExistingAppServerEndpoint(endpoint)).toThrow(/control characters/);
+  });
+
   it('requires exactly an endpoint object when the feature is configured', () => {
     expect(normalizeExistingAppServerConfig(undefined)).toBeUndefined();
     expect(normalizeExistingAppServerConfig({


### PR DESCRIPTION
## 概述

这是 #974（已合入 shared-adopt）的后续小修复 PR，集中处理合入评论中列出的 4 条非阻断建议。

不重做 shared-adopt 主功能，不改变“不起第二个 App Server、不抢 writer、官方 `codex --remote ... resume ...` 作为第二客户端”的核心设计。

## 变更

### 1. endpoint 显式拒绝控制字符

`existingAppServer.endpoint` 在 URL 解析和 `trim` 前显式拒绝 C0 / DEL 控制字符：

```text
U+0000–U+001F
U+007F
```

这样不会依赖 URL 解析器静默剥离尾部控制字符，所有调用方都得到可打印、无歧义的 endpoint。

新增 NUL、ESC、DEL、换行的回归用例。

### 2. `/detach` / `/disconnect` 与 `/close` 使用同一安全结果语义

此前 shared-adopt 的 `/close`、历史 close 卡片和 disconnect 卡片已经区分：

```text
missing
refused
closed_with_residual
closed
```

但文字 `/detach` / `/disconnect` 仍沿用旧的乐观成功路径。

本 PR 使它们也只在普通 `closed` 时确认断开；`refused`、异常或 `closed_with_residual` 会明确提示未完成，不会把未证实的清理报告为成功。

### 3. 收窄 `existingAppServer` 注释承诺

“不会自动创建新 thread”只适用于 `cliId: "codex"` 的 shared-adopt 路径。

`cliId: "codex-app"` 仍保留既有的新会话工作流，直到操作员显式 `/adopt` 选择共享 thread。更新注释以免读者误解为所有配置组合都禁止新会话。

### 4. 明确 daemon 重启的后端限定

文档现在明确：

- tmux 等持久后端可以保留并重新 attach remote TUI；
- `pty` 后端在 daemon 重启时会失去 remote TUI 进程；
- 但 BotMux 不会主动关闭 server-side thread，后续连接会创建新的官方 remote client。

同时移除 shared-adopt 设计文档中已经属于 #975 的 Web Terminal worker-restart 表述，保持 PR 范围清晰。

## 影响范围

- 仅涉及 existing App Server endpoint 校验、shared-adopt 文字断开命令和注释/设计文档；
- 不改变 Codex App、Codex CLI 或 App Server 源码；
- 不改变终端路由、CDN、WebSocket 鉴权或 Hook 审核菜单保护；
- 不改变已合入的 shared-adopt 主架构。

## 验证

已执行：

```text
vitest run --project unit \
  test/existing-app-server.test.ts \
  test/command-handler.test.ts \
  test/close-consumer-matrix.test.ts \
  test/bot-registry.test.ts \
  test/existing-app-server-worker-shutdown.test.ts \
  test/restart-worker-null-reattach.test.ts \
  test/kill-worker-orphaned-backend.test.ts \
  test/session-adopt.test.ts
```

结果：**8 个测试文件、458 项测试通过**。

另已执行 `pnpm build`，通过 TypeScript、脚本类型检查、Dashboard 打包、公开域名审计和产物审计。
