### PR TITLE
fix(backend): tmux 启动超时竞态不再误判为确定性失败，daemon 增加瞬态启动失败自愈重试

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -59,6 +59,29 @@ export function isTmuxServerLevelErrorText(stderrText: string): boolean {
 }
 
 /**
+ * True when a thrown exec*Sync error represents the caller's own `timeout`
+ * deadline firing — regardless of the exit-status shape Node attached.
+ *
+ * Node reports a spawnSync timeout as `error.code === 'ETIMEDOUT'` while ALSO
+ * reporting whatever the child managed to do around the kill. Normally the
+ * child dies from the kill signal (`status: null, signal: 'SIGTERM'`), but
+ * under heavy load the client can complete and exit cleanly in the same window
+ * the deadline fires — the throw then carries `status: 0/1, signal: null` PLUS
+ * the ETIMEDOUT error. 2026-08-23: exactly that shape escaped every
+ * "clean numeric exit ⇒ the server answered deterministically" classifier
+ * during a post-outage mass cold-restart (261 sessions rebuilt in ~40s after
+ * the shared server died): `new-session` had actually succeeded server-side,
+ * but the launch was classified as a deterministic rejection, not retried, and
+ * the worker died user-visibly ("会话启动失败: spawnSync tmux ETIMEDOUT").
+ *
+ * A deadline is NEVER an authoritative server answer. Every tmux classifier
+ * must check this BEFORE any status-shape branch.
+ */
+export function isExecTimeoutError(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException | null | undefined)?.code === 'ETIMEDOUT';
+}
+
+/**
  * TmuxBackend — session backend using tmux for process persistence.
  *
  * Architecture: pty-under-tmux.
@@ -160,6 +183,10 @@ export class TmuxBackend implements SessionBackend {
       });
       return 'exists';
     } catch (e: any) {
+      // Deadline first: a timed-out client can surface a clean numeric exit
+      // when its completion races the kill (see isExecTimeoutError) — that is
+      // still "no answer", never an authoritative 'missing'.
+      if (isExecTimeoutError(e)) return 'unknown';
       if (e && typeof e.status === 'number' && !e.signal) {
         const stderrText = (e.stderr?.toString?.() ?? '').trim();
         if (isTmuxServerLevelErrorText(stderrText)) return 'unknown';

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -31,7 +31,7 @@ import { randomBytes } from 'node:crypto';
 import { StringDecoder } from 'node:string_decoder';
 import type { SessionBackend, SessionProbe, SpawnOpts } from './types.js';
 import { tmuxEnv } from '../../setup/ensure-tmux.js';
-import { buildBotmuxEnvAssignments, resolveUserShell, shellWrapperScript, shellCommandArgv, shellKindForPath, TmuxBackend, isTmuxServerLevelErrorText } from './tmux-backend.js';
+import { buildBotmuxEnvAssignments, resolveUserShell, shellWrapperScript, shellCommandArgv, shellKindForPath, TmuxBackend, isTmuxServerLevelErrorText, isExecTimeoutError } from './tmux-backend.js';
 import { resolveBotmuxWrapperBinDir } from '../../core/botmux-wrapper.js';
 import { LivenessGate, ADOPT_LIVENESS_MAX_FAILURES } from './liveness-gate.js';
 
@@ -70,6 +70,13 @@ export function setStartupTmuxRetrySleepForTests(fn: ((ms: number) => void) | nu
  *  refused/no socket, command timeout, spawn-level EMFILE/EAGAIN) is plausibly
  *  transient under a stalled/overloaded shared server. */
 function isRetryableStartupTmuxFailure(err: any): boolean {
+  // Deadline first (2026-08-23 regression): a timed-out client can exit
+  // cleanly in the same window the kill fires, so the throw carries a numeric
+  // status + empty stderr alongside ETIMEDOUT. Reading that as "the server
+  // answered and rejected deterministically" turned a new-session that had
+  // actually SUCCEEDED server-side into a fatal, user-visible 会话启动失败
+  // during the post-outage restart storm. A timeout is never deterministic.
+  if (isExecTimeoutError(err)) return true;
   if (err && typeof err.status === 'number' && !err.signal) {
     return isTmuxServerLevelErrorText((err.stderr?.toString?.() ?? '').trim());
   }
@@ -676,6 +683,12 @@ export class TmuxPipeBackend implements SessionBackend {
       ).trim();
       return { state: paneId.length > 0 ? 'exists' : 'missing', reason: paneId.length > 0 ? undefined : 'empty pane id' };
     } catch (err: any) {
+      // Deadline first: a timed-out probe can carry a clean numeric exit when
+      // the client's completion races the kill (isExecTimeoutError). That is
+      // "no answer", never an authoritative 'missing'.
+      if (isExecTimeoutError(err)) {
+        return { state: 'unknown', reason: 'probe deadline (ETIMEDOUT)' };
+      }
       if (err && typeof err.status === 'number' && !err.signal) {
         const stderr = (err.stderr?.toString?.() ?? '').trim();
         if (isTmuxServerLevelErrorText(stderr)) {
@@ -810,6 +823,9 @@ export class TmuxPipeBackend implements SessionBackend {
       });
       return 'up';
     } catch (err: any) {
+      // Deadline first — same race as probePaneAddressability: a clean exit
+      // status attached to an ETIMEDOUT throw is still "no answer".
+      if (isExecTimeoutError(err)) return 'unreachable';
       if (err && typeof err.status === 'number' && !err.signal) {
         const stderr = (err.stderr?.toString?.() ?? '').trim();
         // Connection-level wording ("error connecting", "lost server") ⇒ the
@@ -909,11 +925,13 @@ export class TmuxPipeBackend implements SessionBackend {
       // capture-screenshot backend; verified geometry-neutral on the pipe
       // backend (toggling status on a detached session changes neither pane
       // size nor cursor), so it's safe to default ON.
-      execSync(`tmux set-option -t ${t} status on`, { stdio: 'ignore', env });
-      execSync(`tmux set-option -t ${t} mouse on`, { stdio: 'ignore', env });
-      execSync(`tmux set-option -s set-clipboard on`, { stdio: 'ignore', env });
-      execSync(`tmux set-option -t ${t} history-limit 50000`, { stdio: 'ignore', env });
-      execSync(`tmux set-option -t ${t} window-size largest`, { stdio: 'ignore', env });
+      // Bounded: these are cosmetic and best-effort, but without a timeout a
+      // wedged shared server would pin the worker's startup path indefinitely.
+      execSync(`tmux set-option -t ${t} status on`, { stdio: 'ignore', env, timeout: 5000 });
+      execSync(`tmux set-option -t ${t} mouse on`, { stdio: 'ignore', env, timeout: 5000 });
+      execSync(`tmux set-option -s set-clipboard on`, { stdio: 'ignore', env, timeout: 5000 });
+      execSync(`tmux set-option -t ${t} history-limit 50000`, { stdio: 'ignore', env, timeout: 5000 });
+      execSync(`tmux set-option -t ${t} window-size largest`, { stdio: 'ignore', env, timeout: 5000 });
     } catch { /* session may not be ready yet — benign */ }
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -148,6 +148,12 @@ export interface DaemonSession {
    *  resolved launch model so that recovery does not relaunch on a stale one.
    *  Cleared when a worker generation reports ready. In-memory only. */
   crashDiagnosticParked?: boolean;
+  /** Daemon-side bounded auto-retry state for TRANSIENT worker startup
+   *  failures (e.g. "spawnSync tmux ETIMEDOUT" during a post-outage restart
+   *  storm — see worker-startup-retry.ts). `attempts` counts the current
+   *  failing streak; `timer` is the pending blank re-fork. Reset (timer
+   *  cleared) when a worker generation reaches `ready`. In-memory only. */
+  startupAutoRetry?: { attempts: number; timer?: NodeJS.Timeout };
   /** Dashboard「复现命令」：worker 在 `ready` 时上报的、该 session 本次冷启的近似
    *  可复现 CLI 调用（bin + argv + cwd + 权威注入 env）。**只驻内存、绝不落盘**
    *  ——命令含 provider token / 凭证 env，写进默认 0644 的 sessions-*.json 会让同机

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -460,6 +460,11 @@ import { sendWorkerIpc } from './worker-ipc.js';
 import { cleanupExplicitSessionBacking } from './explicit-session-backing-cleanup.js';
 import { REMOTE_ADMISSION_RESTORE_TIMEOUT_MS } from './shutdown-budgets.js';
 import {
+  MAX_STARTUP_AUTO_RETRIES,
+  isTransientStartupFailure,
+  startupAutoRetryDelayMs,
+} from './worker-startup-retry.js';
+import {
   managedOriginCapabilityPath,
   replaceManagedOriginCapabilityFile,
 } from './managed-origin-capability.js';
@@ -10005,6 +10010,63 @@ function setupWorkerHandlers(
       logger.error(`[${t}] Failed to deliver worker startup failure to Lark: ${err?.message ?? err}`);
     }
   };
+  /**
+   * Daemon-side self-heal for TRANSIENT startup/relaunch failures (see
+   * worker-startup-retry.ts; 2026-08-23 tmux restart-storm incident). Returns
+   * true when a silent bounded retry was scheduled INSTEAD of a user-visible
+   * notify. Scope is deliberately narrow:
+   *   - only turn-less failures — a turn-carrying failure has a waiting sender
+   *     and (for durable VC/at-most-once turns) its own delivery state machine
+   *     that must keep owning retries;
+   *   - only reasons the classifier deems transient host/backend pressure;
+   *   - bounded by MAX_STARTUP_AUTO_RETRIES per failing streak (reset on a
+   *     worker generation reaching `ready`), so a persistent failure still
+   *     surfaces to the user with the standard card.
+   * The retry itself is a blank re-fork (`forkWorker(ds, '', true)`) — exactly
+   * what a daemon restart or the next inbound message would do: re-attach when
+   * the backing pane survived (the 08-23 case — pane and CLI were alive, only
+   * the worker had died), cold `--resume` otherwise.
+   */
+  const scheduleTransientStartupRetry = (
+    reason: string,
+    turnId?: string,
+    dispatchAttempt?: number,
+  ): boolean => {
+    if (turnId !== undefined || dispatchAttempt !== undefined) return false;
+    if (startupState.failureNotified) return false;
+    if (!isTransientStartupFailure(reason)) return false;
+    if (ds.session.status !== 'active') return false;
+    const attempts = (ds.startupAutoRetry?.attempts ?? 0) + 1;
+    if (attempts > MAX_STARTUP_AUTO_RETRIES) return false;
+    // Mark this generation handled so the pre-ready exit guard cannot post a
+    // duplicate start_exited_early card behind the scheduled retry.
+    startupState.failureNotified = true;
+    const delayMs = startupAutoRetryDelayMs(ds.session.sessionId, attempts);
+    logger.warn(
+      `[${t}] Transient worker startup failure (${reason}); `
+      + `auto-retry ${attempts}/${MAX_STARTUP_AUTO_RETRIES} in ${Math.round(delayMs / 1000)}s`,
+    );
+    const timer = setTimeout(() => {
+      if (ds.startupAutoRetry?.timer === timer) ds.startupAutoRetry.timer = undefined;
+      // Lifecycle guards: the session may have been closed, replaced in the
+      // registry, or revived by an inbound message while the timer slept.
+      if (ds.session.status !== 'active') return;
+      if (ds.worker && !ds.worker.killed) return;
+      if (activeSessionsRegistry && activeSessionsRegistry.get(activeSessionKey(ds)) !== ds) return;
+      logger.info(
+        `[${t}] Auto-retrying worker start (${attempts}/${MAX_STARTUP_AUTO_RETRIES}) `
+        + 'after transient startup failure',
+      );
+      try {
+        forkWorker(ds, '', true);
+      } catch (err: any) {
+        logger.error(`[${t}] Startup auto-retry fork failed: ${err?.message ?? err}`);
+      }
+    }, delayMs);
+    timer.unref?.();
+    ds.startupAutoRetry = { attempts, timer };
+    return true;
+  };
 
   // Adopt mode flags — computed once, used in all buildStreamingCard calls.
   // Bridge mode (the v3 default for /adopt) hides the legacy takeover button.
@@ -10170,6 +10232,13 @@ function setupWorkerHandlers(
         }
         startupState.ready = true;
         ds.workerReady = true;
+        // A generation reached ready: the transient-startup failing streak is
+        // over. Clear the budget and any still-pending retry timer (an inbound
+        // message may have revived the session while a retry slept).
+        if (ds.startupAutoRetry) {
+          if (ds.startupAutoRetry.timer) clearTimeout(ds.startupAutoRetry.timer);
+          ds.startupAutoRetry = undefined;
+        }
         // Restore the daemon-owned display mode BEFORE any card handling: a
         // fresh worker always boots with displayMode='hidden', and every early
         // break below (managed / replyAlreadySent / streamingCardDisabled /
@@ -11523,7 +11592,11 @@ function setupWorkerHandlers(
         logger.error(`[${t}] Worker error: ${msg.message}`);
         // `error` is a fatal launch-generation signal. It normally arrives
         // during init, but can also follow a previously-ready worker whose CLI
-        // recovery/restart fails; that later failure must remain user-visible.
+        // recovery/restart fails; that later failure must remain user-visible —
+        // UNLESS it is a turn-less transient (post-outage restart storm), where
+        // a bounded silent re-fork self-heals without waking anyone (08-23:
+        // idle sessions got "会话启动失败" cards while their panes were alive).
+        if (scheduleTransientStartupRetry(msg.message, msg.turnId, msg.dispatchAttempt)) break;
         await notifyStartupFailure(msg.message, msg.turnId, msg.dispatchAttempt);
         break;
       }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -10064,6 +10064,12 @@ function setupWorkerHandlers(
       }
     }, delayMs);
     timer.unref?.();
+    // An inbound message can revive the session between two failing
+    // generations; if the replacement fails too, the previous generation's
+    // still-pending timer must not survive as an orphan (its guards make a
+    // double blank re-fork merely wasteful, not harmful — but one streak owns
+    // exactly one pending retry).
+    if (ds.startupAutoRetry?.timer) clearTimeout(ds.startupAutoRetry.timer);
     ds.startupAutoRetry = { attempts, timer };
     return true;
   };

--- a/src/core/worker-startup-retry.ts
+++ b/src/core/worker-startup-retry.ts
@@ -1,0 +1,74 @@
+/**
+ * Daemon-side self-heal policy for TRANSIENT worker startup failures.
+ *
+ * 2026-08-23 incident: the shared tmux server died and every bot's workers
+ * cold-restarted their sessions simultaneously (261 tmux sessions rebuilt in
+ * ~40s, load ≈ 17). A handful of workers hit client-side deadlines against the
+ * overloaded server ("spawnSync tmux ETIMEDOUT") and the daemon's only
+ * response was a user-visible "会话启动失败" card on sessions nobody had
+ * touched for days — even though the backing tmux pane and CLI process were
+ * actually alive (only the managing worker had died).
+ *
+ * The worker side retries what it can (see tmux-pipe-backend's startup retry
+ * loops), but any escape hatch — a mis-classified error, a not-yet-hardened
+ * call site, a genuinely long stall — used to be terminal. This policy gives
+ * the daemon a bounded second line of defence: classify the worker's fatal
+ * startup reason, and if it is plausibly transient, schedule a blank re-fork
+ * (re-attach if the pane survived, cold `--resume` otherwise — the exact
+ * recovery a daemon restart or the next inbound message would perform) with
+ * spaced, decorrelated backoff. Only when the budget is exhausted does the
+ * failure surface to the chat.
+ *
+ * Pure module: the classifier and delay schedule are unit-tested; the timer
+ * wiring lives in worker-pool's setupWorkerHandlers.
+ */
+
+/** Maximum daemon-side auto-retries per failing streak. Reset when a worker
+ *  generation reaches `ready`. */
+export const MAX_STARTUP_AUTO_RETRIES = 3;
+
+/** Base backoff per attempt (1-indexed). Spaced widely enough that attempt 2+
+ *  lands after a restart herd has drained (the 08-23 storm settled in ~60s). */
+const STARTUP_AUTO_RETRY_BASE_DELAYS_MS = [15_000, 60_000, 180_000];
+
+/**
+ * Is this fatal worker startup reason plausibly transient host/backend
+ * pressure (worth a silent daemon-side retry) rather than a deterministic
+ * configuration/installation failure (surface immediately)?
+ *
+ * Matches connection-level and resource-pressure signatures only:
+ *   - exec deadline (`ETIMEDOUT`) — the 08-23 escape;
+ *   - connect-level failures against a stalled/restarting shared server
+ *     (`ECONNREFUSED`, tmux's "error connecting to …" / "lost server" /
+ *     "server exited unexpectedly");
+ *   - fd/process pressure (`EAGAIN`, `EMFILE`, `ENFILE`).
+ * Deliberately NOT matched: ENOENT/EACCES (binary genuinely missing/broken),
+ * CLI-specific launch errors, config validation — retrying only delays the
+ * same user-actionable failure.
+ */
+export function isTransientStartupFailure(reason: string): boolean {
+  return /\bETIMEDOUT\b|\bECONNREFUSED\b|\bEAGAIN\b|\bEMFILE\b|\bENFILE\b|error connecting to|lost server|server exited unexpectedly/i.test(reason);
+}
+
+/**
+ * Deterministic decorrelated backoff: base delay for the attempt, jittered to
+ * 75%–125% by a session-id hash (same FNV-1a style as tmuxRestartJitterMs).
+ * Deterministic jitter keeps the schedule unit-testable while spreading a
+ * whole storm's retries — the failure mode being healed IS mass simultaneity,
+ * so N failed sessions must not re-storm the server on one shared timer edge.
+ */
+export function startupAutoRetryDelayMs(sessionId: string, attempt: number): number {
+  const clamped = Math.min(
+    Math.max(1, Math.floor(attempt)),
+    STARTUP_AUTO_RETRY_BASE_DELAYS_MS.length,
+  );
+  const base = STARTUP_AUTO_RETRY_BASE_DELAYS_MS[clamped - 1];
+  const input = `${sessionId}:startup-retry:${clamped}`;
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  const jitter = (hash >>> 0) % (base / 2 + 1);
+  return Math.round(base * 0.75 + jitter);
+}

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -254,6 +254,47 @@ describe('TmuxPipeBackend.spawn', () => {
     }
   });
 
+  it('treats a deadline that raced a clean exit (ETIMEDOUT + numeric status) as retryable — 2026-08-23 regression', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      let newSessionAttempts = 0;
+      mockedExecFileSync.mockImplementation(((_bin: any, args: any) => {
+        if (Array.isArray(args) && args.includes('new-session')) {
+          newSessionAttempts += 1;
+          if (newSessionAttempts === 1) {
+            // The exact 08-23 storm shape: the overloaded client finished and
+            // exited CLEANLY (numeric status, no signal, empty stderr) in the
+            // same window the exec deadline fired, so Node attached BOTH the
+            // clean exit and the ETIMEDOUT error. The server had actually
+            // created the session. The old classifier read "clean numeric exit
+            // ⇒ deterministic rejection" and killed the launch user-visibly.
+            throw Object.assign(new Error('spawnSync tmux ETIMEDOUT'), {
+              code: 'ETIMEDOUT',
+              errno: -110,
+              syscall: 'spawnSync tmux',
+              status: 0,
+              signal: null,
+              stderr: Buffer.from(''),
+            });
+          }
+          // Retry discovers the session DOES exist server-side → success.
+          throw Object.assign(new Error('cmd failed'), {
+            status: 1,
+            signal: null,
+            stderr: Buffer.from('duplicate session: bmx-owned'),
+          });
+        }
+        return '' as any;
+      }) as any);
+
+      const be = new TmuxPipeBackend('bmx-owned', { createSession: true, ownsSession: true });
+      expect(() => be.spawn('echo', [], spawnOpts())).not.toThrow();
+      expect(newSessionAttempts).toBe(2);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
   it('does NOT retry new-session on a server-answered deterministic rejection', () => {
     let newSessionAttempts = 0;
     mockedExecFileSync.mockImplementation(((_bin: any, args: any) => {

--- a/test/tmux-probe.test.ts
+++ b/test/tmux-probe.test.ts
@@ -78,6 +78,19 @@ describe('TmuxBackend.probeSession', () => {
     expect(TmuxBackend.probeSession(NAME)).toBe('unknown');
   });
 
+  it('returns "unknown" when the deadline raced a clean exit (ETIMEDOUT + numeric status) — 2026-08-23 regression', () => {
+    // Under heavy load the probe client can finish and exit cleanly in the
+    // same window the exec deadline fires; Node attaches BOTH the numeric
+    // status and the ETIMEDOUT error. A deadline is never an authoritative
+    // server answer — reading this shape as 'missing' fed destructive
+    // liveness/kill-verify counters during the 08-23 restart storm.
+    bothThrow(
+      { code: 'ETIMEDOUT', status: 1, signal: null, stderr: Buffer.from('') },
+      { code: 'ETIMEDOUT', status: 1, signal: null, stderr: Buffer.from('') },
+    );
+    expect(TmuxBackend.probeSession(NAME)).toBe('unknown');
+  });
+
   it('returns "unknown" on a clean CONNECTION-level failure (server stall ⇒ instant ECONNREFUSED), NOT "missing"', () => {
     // Linux fails unix-socket connect() with an instant clean ECONNREFUSED when
     // the shared server's accept backlog overflows — the client never reached

--- a/test/tmux-startup-storm-recovery.test.ts
+++ b/test/tmux-startup-storm-recovery.test.ts
@@ -1,0 +1,164 @@
+/**
+ * 真实场景回归 — 2026-08-23 tmux 恢复风暴事故复现（真实 tmux，独立 socket）。
+ *
+ * 事故时序：共享 tmux server 意外退出 → 全部会话的 worker 同时冷重建（261 个
+ * 会话 / ~40s，load ≈ 17）→ 个别 `tmux new-session` 在服务端**已成功建出会话**，
+ * 但客户端压到 execFileSync 的 5s deadline —— 且客户端恰好在 kill 窗口内自己
+ * 干净退出（numeric status + 无 signal + 空 stderr + ETIMEDOUT error 并存）。
+ * 旧分类器把这读成「服务端确定性拒绝」→ 不重试 → worker fatal → 沉睡多日的
+ * 会话收到「会话启动失败: spawnSync tmux ETIMEDOUT」。
+ *
+ * 本测试用 PATH shim 包住真实 tmux 精确复刻这一时序：
+ *   - 第一次 `new-session` 先转发给真实 tmux（服务端真实建出 bmx-* 会话），
+ *     然后 trap TERM 后台 sleep 顶住客户端直到 deadline，被 kill 时 `exit 0`
+ *     —— 制造出与事故完全一致的「clean exit + ETIMEDOUT」错误形状；
+ *   - 后续所有调用原样透传真实 tmux。
+ * 断言 TmuxPipeBackend.spawn() 自愈成功：重试撞上 "duplicate session" 被识别为
+ * 「上一次超时的尝试其实已建成」→ 收编该会话、pipe-pane 正常挂上，全程无异常。
+ *
+ * 全部 tmux 流量走本测试专属 TMUX_TMPDIR（私有 socket），绝不触碰共享 default
+ * server 上的真实会话。
+ *
+ * Run:  pnpm vitest run test/tmux-startup-storm-recovery.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync, execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { TmuxPipeBackend } from '../src/adapters/backend/tmux-pipe-backend.js';
+
+function realTmuxPath(): string | null {
+  try {
+    return execSync('command -v tmux', { encoding: 'utf-8', shell: '/bin/sh' }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+const REAL_TMUX = realTmuxPath();
+const SESSION_NAME = 'bmx-stormrep';
+
+describe.skipIf(!REAL_TMUX)('tmux startup storm recovery (real tmux, shimmed deadline)', () => {
+  let workDir: string;
+  let shimDir: string;
+  let markerPath: string;
+  let attemptLogPath: string;
+  let savedPath: string | undefined;
+  let savedTmuxTmpdir: string | undefined;
+
+  const realTmuxEnv = () => ({
+    ...process.env,
+    PATH: savedPath,
+    TMUX_TMPDIR: workDir,
+  } as NodeJS.ProcessEnv);
+
+  beforeAll(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'bmx-storm-'));
+    shimDir = join(workDir, 'shim');
+    markerPath = join(workDir, 'first-new-session.marker');
+    attemptLogPath = join(workDir, 'new-session-attempts.log');
+    execSync(`mkdir -p ${shimDir}`);
+
+    // The shim IS the storm: first new-session really creates the session on
+    // the (private) server, then holds the client past the caller's 5s
+    // deadline and converts the deadline kill into a CLEAN exit 0 — the exact
+    // 08-23 error shape (numeric status + no signal + ETIMEDOUT attached).
+    const shim = [
+      '#!/bin/sh',
+      `REAL='${REAL_TMUX}'`,
+      `MARKER='${markerPath}'`,
+      `ATTEMPTS='${attemptLogPath}'`,
+      'if [ "$1" = "new-session" ]; then',
+      '  echo attempt >> "$ATTEMPTS"',
+      '  if [ ! -e "$MARKER" ]; then',
+      '    : > "$MARKER"',
+      '    "$REAL" "$@"',
+      '    trap "exit 0" TERM',
+      '    sleep 30 &',
+      '    wait $!',
+      '    exit 0',
+      '  fi',
+      'fi',
+      'exec "$REAL" "$@"',
+      '',
+    ].join('\n');
+    const shimPath = join(shimDir, 'tmux');
+    writeFileSync(shimPath, shim);
+    chmodSync(shimPath, 0o755);
+
+    savedPath = process.env.PATH;
+    savedTmuxTmpdir = process.env.TMUX_TMPDIR;
+    process.env.PATH = `${shimDir}:${process.env.PATH ?? ''}`;
+    // Private socket dir: the storm must never touch the shared default server.
+    process.env.TMUX_TMPDIR = workDir;
+  });
+
+  afterAll(() => {
+    process.env.PATH = savedPath;
+    if (savedTmuxTmpdir === undefined) delete process.env.TMUX_TMPDIR;
+    else process.env.TMUX_TMPDIR = savedTmuxTmpdir;
+    try {
+      execFileSync(REAL_TMUX!, ['kill-server'], {
+        stdio: 'ignore',
+        env: { ...process.env, TMUX_TMPDIR: workDir },
+        timeout: 5000,
+      });
+    } catch { /* server already gone */ }
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('self-heals a new-session that succeeded server-side but hit the client deadline', () => {
+    const backend = new TmuxPipeBackend(SESSION_NAME, { createSession: true, ownsSession: true });
+    const startedAt = Date.now();
+    expect(() => backend.spawn('sleep', ['60'], {
+      cwd: workDir,
+      cols: 80,
+      rows: 24,
+      env: process.env as Record<string, string>,
+    })).not.toThrow();
+    const elapsedMs = Date.now() - startedAt;
+
+    try {
+      // The deadline genuinely fired (this was not a fast-path success) …
+      expect(existsSync(markerPath)).toBe(true);
+      expect(elapsedMs).toBeGreaterThanOrEqual(4500);
+      // … the retry ran and adopted the already-created session ("duplicate
+      // session" answered by the real server) instead of failing the launch.
+      const attempts = readFileSync(attemptLogPath, 'utf-8').trim().split('\n').length;
+      expect(attempts).toBe(2);
+      // The session the timed-out first attempt created is alive and is the one
+      // we attached to (authoritative check against the real server).
+      expect(() => execFileSync(REAL_TMUX!, ['has-session', '-t', SESSION_NAME], {
+        stdio: 'ignore',
+        env: realTmuxEnv(),
+        timeout: 5000,
+      })).not.toThrow();
+      // Live-pane plumbing works end to end after the recovery.
+      expect(() => backend.sendText('storm-recovery-probe')).not.toThrow();
+    } finally {
+      backend.kill();
+    }
+  }, 25_000);
+
+  it('subsequent launches on the recovered server take the fast path (no residual storm)', () => {
+    const backend = new TmuxPipeBackend('bmx-stormrep2', { createSession: true, ownsSession: true });
+    const startedAt = Date.now();
+    expect(() => backend.spawn('sleep', ['60'], {
+      cwd: workDir,
+      cols: 80,
+      rows: 24,
+      env: process.env as Record<string, string>,
+    })).not.toThrow();
+    try {
+      expect(Date.now() - startedAt).toBeLessThan(4000);
+    } finally {
+      backend.kill();
+      try {
+        execFileSync(REAL_TMUX!, ['kill-session', '-t', 'bmx-stormrep2'], {
+          stdio: 'ignore', env: realTmuxEnv(), timeout: 5000,
+        });
+      } catch { /* already gone */ }
+    }
+  }, 15_000);
+});

--- a/test/worker-startup-retry-wiring.test.ts
+++ b/test/worker-startup-retry-wiring.test.ts
@@ -255,6 +255,28 @@ describe("worker-pool 'error' transient self-heal wiring", () => {
     expect(ds.startupAutoRetry?.attempts).toBe(1);
   });
 
+  it('clears the previous pending timer when a later generation schedules the next attempt (no orphan timers)', async () => {
+    const ds = makeDs('sid-orphan-timer', makeFakeWorker());
+
+    await failOnce(ds, INCIDENT_REASON);
+    expect(ds.startupAutoRetry?.attempts).toBe(1);
+    const firstTimer = ds.startupAutoRetry!.timer;
+    expect(firstTimer).toBeDefined();
+
+    // An inbound message revives the session, the replacement generation fails
+    // too: attempt 2 must REPLACE the pending attempt-1 timer, not stack an
+    // orphan beside it.
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    try {
+      await failOnce(ds, INCIDENT_REASON);
+      expect(ds.startupAutoRetry?.attempts).toBe(2);
+      expect(ds.startupAutoRetry?.timer).not.toBe(firstTimer);
+      expect(clearSpy.mock.calls.some(([handle]) => handle === firstTimer)).toBe(true);
+    } finally {
+      clearSpy.mockRestore();
+    }
+  });
+
   it('the pending retry no-ops (no fork) when another path already revived the session', async () => {
     vi.useFakeTimers();
     const ds = makeDs('sid-revived', makeFakeWorker());

--- a/test/worker-startup-retry-wiring.test.ts
+++ b/test/worker-startup-retry-wiring.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Daemon-side wiring test — worker-pool `case 'error'` transient self-heal
+ * (2026-08-23 tmux restart-storm incident).
+ *
+ * Pins the contract of scheduleTransientStartupRetry:
+ *   - a TURN-LESS transient failure ("spawnSync tmux ETIMEDOUT") schedules a
+ *     bounded silent retry: NO user-visible 会话启动失败 card, retry state on ds;
+ *   - repeated transient failures escalate attempts; once the budget
+ *     (MAX_STARTUP_AUTO_RETRIES) is exhausted the standard card IS posted;
+ *   - a turn-carrying failure keeps the immediate notify (the sender is
+ *     waiting; durable deliveries own their retries);
+ *   - a deterministic failure (ENOENT install breakage) notifies immediately.
+ *
+ * Harness mirrors crash-loop-diagnostic.test.ts (fake worker EventEmitter +
+ * __testOnly_setupWorkerHandlers).
+ *
+ * Run:  pnpm vitest run --project unit test/worker-startup-retry-wiring.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('../src/im/lark/client.js', () => {
+  class MessageWithdrawnError extends Error {
+    constructor(id: string) { super(`withdrawn: ${id}`); this.name = 'MessageWithdrawnError'; }
+  }
+  return {
+    updateMessage: vi.fn(async () => {}),
+    deleteMessage: vi.fn(async () => {}),
+    MessageWithdrawnError,
+  };
+});
+
+vi.mock('../src/im/lark/card-builder.js', () => ({
+  buildStreamingCard: vi.fn(() => '{"type":"streaming"}'),
+  buildSessionCard: vi.fn(() => '{"type":"session"}'),
+  buildTuiPromptCard: vi.fn(() => '{}'),
+  buildTuiPromptResolvedCard: vi.fn(() => '{}'),
+  getCliDisplayName: vi.fn(() => 'Codex'),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'codex' },
+    resolvedAllowedUsers: [],
+    botOpenId: 'ou_bot',
+    botName: 'TestBot',
+  })),
+  getAllBots: vi.fn(() => []),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    web: { externalHost: 'localhost' },
+    session: { dataDir: '/tmp/test-sessions' },
+    daemon: { backendType: 'tmux', cliId: 'codex' },
+  },
+}));
+
+const updateSessionMock = vi.fn();
+const sessionReplyMock = vi.fn(async () => 'om_reply');
+vi.mock('../src/services/session-store.js', () => ({
+  registerSessionBridgeSendMarkerCleanupFence: vi.fn(),
+  cleanupSessionBridgeSendMarkers: vi.fn(),
+  cleanupSessionBridgeSendMarkersNow: vi.fn(),
+  closeSession: vi.fn(),
+  updateSession: (...args: any[]) => updateSessionMock(...args),
+}));
+
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  loadFrozenCards: vi.fn(() => new Map()),
+  saveFrozenCards: vi.fn(),
+}));
+
+vi.mock('../src/services/session-lifecycle-hooks.js', () => ({
+  emitSessionLifecycleHook: vi.fn(),
+  emitSessionStateTransitionHook: vi.fn(),
+}));
+
+vi.mock('../src/core/session-manager.js', () => ({
+  persistStreamCardState: vi.fn(),
+  ensureSessionWhiteboard: vi.fn(),
+  rememberLastCliInput: vi.fn(),
+}));
+
+vi.mock('../src/core/dashboard-events.js', () => ({
+  dashboardEventBus: { publish: vi.fn() },
+}));
+
+vi.mock('../src/core/dashboard-rows.js', () => ({
+  composeRowFromActive: vi.fn(),
+}));
+
+vi.mock('../src/skills/installer.js', () => ({
+  ensureSkills: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/registry.js', () => ({
+  createCliAdapterSync: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/claude-code.js', () => ({
+  claudeJsonlPathForSession: vi.fn(),
+}));
+
+vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
+  TmuxBackend: class {},
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: class { constructor() {} },
+  WSClient: class { start() {} },
+  EventDispatcher: class { register() {} },
+  LoggerLevel: { info: 2 },
+}));
+
+import { initWorkerPool, __testOnly_setupWorkerHandlers, restartCounts } from '../src/core/worker-pool.js';
+import { MAX_STARTUP_AUTO_RETRIES } from '../src/core/worker-startup-retry.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+function makeFakeWorker() {
+  const w = new EventEmitter() as any;
+  w.killed = false;
+  w.send = vi.fn();
+  w.kill = vi.fn();
+  w.pid = 12345;
+  w.stdout = new EventEmitter();
+  w.stderr = new EventEmitter();
+  return w;
+}
+
+function makeDs(sessionId: string, worker: any): DaemonSession {
+  return {
+    session: {
+      sessionId,
+      rootMessageId: 'om_root',
+      chatId: 'oc_chat',
+      title: 'Test Session',
+      status: 'active' as any,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      pid: null,
+      chatType: 'group',
+    },
+    worker,
+    workerPort: null,
+    workerToken: null,
+    larkAppId: 'app_test',
+    chatId: 'oc_chat',
+    chatType: 'group',
+    spawnedAt: Date.now(),
+    cliVersion: '1.0',
+    lastMessageAt: Date.now(),
+    hasHistory: true,
+    displayMode: 'hidden',
+    lastScreenContent: '',
+    lastScreenStatus: 'working',
+    currentTurnTitle: 'Test task',
+  } as DaemonSession;
+}
+
+const flush = () => new Promise<void>(r => setTimeout(r, 0));
+
+/** One worker GENERATION per failure round, like production: each round wires
+ *  fresh handlers (fresh startupState) on a new fake worker bound to the same
+ *  ds, then delivers the fatal `error` IPC. */
+async function failOnce(ds: DaemonSession, message: string, extras: Record<string, unknown> = {}) {
+  const worker = makeFakeWorker();
+  ds.worker = worker;
+  __testOnly_setupWorkerHandlers(ds, worker);
+  worker.emit('message', { type: 'error', message, ...extras });
+  await flush();
+}
+
+const INCIDENT_REASON = 'spawnSync tmux ETIMEDOUT';
+
+describe("worker-pool 'error' transient self-heal wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restartCounts.clear();
+    initWorkerPool({
+      sessionReply: sessionReplyMock,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('schedules a silent bounded retry for a turn-less transient failure (08-23 incident shape)', async () => {
+    const ds = makeDs('sid-transient', makeFakeWorker());
+    await failOnce(ds, INCIDENT_REASON);
+
+    expect(sessionReplyMock).not.toHaveBeenCalled();
+    expect(ds.startupAutoRetry?.attempts).toBe(1);
+    expect(ds.startupAutoRetry?.timer).toBeDefined();
+  });
+
+  it('escalates attempts per failing generation and surfaces the card only after the budget is exhausted', async () => {
+    const ds = makeDs('sid-budget', makeFakeWorker());
+
+    for (let round = 1; round <= MAX_STARTUP_AUTO_RETRIES; round += 1) {
+      await failOnce(ds, INCIDENT_REASON);
+      expect(sessionReplyMock).not.toHaveBeenCalled();
+      expect(ds.startupAutoRetry?.attempts).toBe(round);
+    }
+
+    // Budget exhausted → the standard user-visible failure card is posted.
+    await failOnce(ds, INCIDENT_REASON);
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock).toHaveBeenCalledWith(
+      'om_root',
+      expect.stringContaining('spawnSync tmux ETIMEDOUT'),
+      'text',
+      'app_test',
+      undefined,
+      undefined,
+    );
+  });
+
+  it('keeps the immediate notify for a turn-carrying transient failure (sender is waiting)', async () => {
+    const ds = makeDs('sid-turn', makeFakeWorker());
+    await failOnce(ds, INCIDENT_REASON, { turnId: 'turn-123' });
+
+    expect(ds.startupAutoRetry).toBeUndefined();
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the immediate notify for a deterministic failure (install breakage)', async () => {
+    const ds = makeDs('sid-enoent', makeFakeWorker());
+    await failOnce(ds, 'spawn codex ENOENT');
+
+    expect(ds.startupAutoRetry).toBeUndefined();
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-notify via the pre-ready exit guard once a retry is scheduled', async () => {
+    const ds = makeDs('sid-exit-guard', makeFakeWorker());
+    const worker = makeFakeWorker();
+    ds.worker = worker;
+    __testOnly_setupWorkerHandlers(ds, worker);
+    worker.emit('message', { type: 'error', message: INCIDENT_REASON });
+    await flush();
+    // The worker process then dies (sendFatalWorkerErrorAndExit → exit 1).
+    worker.emit('exit', 1, null);
+    await flush();
+
+    expect(sessionReplyMock).not.toHaveBeenCalled();
+    expect(ds.startupAutoRetry?.attempts).toBe(1);
+  });
+
+  it('the pending retry no-ops (no fork) when another path already revived the session', async () => {
+    vi.useFakeTimers();
+    const ds = makeDs('sid-revived', makeFakeWorker());
+    const worker = makeFakeWorker();
+    ds.worker = worker;
+    __testOnly_setupWorkerHandlers(ds, worker);
+    worker.emit('message', { type: 'error', message: INCIDENT_REASON });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ds.startupAutoRetry?.attempts).toBe(1);
+
+    // An inbound message revived the session with a live worker before the
+    // timer fired; the retry must yield without touching it (a real fork here
+    // would throw in this harness — reaching child_process.fork of a worker).
+    const revived = makeFakeWorker();
+    ds.worker = revived;
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(ds.worker).toBe(revived);
+    expect(sessionReplyMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/worker-startup-retry.test.ts
+++ b/test/worker-startup-retry.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the daemon-side transient-startup-failure self-heal policy
+ * (src/core/worker-startup-retry.ts).
+ *
+ * Pins the 2026-08-23 incident contract: a "spawnSync tmux ETIMEDOUT" (or any
+ * connection-level / fd-pressure failure) from a worker's fatal startup error
+ * is retried silently with bounded, decorrelated backoff instead of surfacing
+ * "会话启动失败" to a chat nobody touched; deterministic install/config
+ * failures keep the immediate user-visible card.
+ *
+ * Run:  pnpm vitest run test/worker-startup-retry.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_STARTUP_AUTO_RETRIES,
+  isTransientStartupFailure,
+  startupAutoRetryDelayMs,
+} from '../src/core/worker-startup-retry.js';
+
+describe('isTransientStartupFailure', () => {
+  it('classifies the 08-23 incident reason as transient', () => {
+    expect(isTransientStartupFailure('spawnSync tmux ETIMEDOUT')).toBe(true);
+  });
+
+  it('classifies connection-level tmux failures as transient', () => {
+    expect(isTransientStartupFailure(
+      'Command failed: tmux pipe-pane -O -t bmx-x — error connecting to /tmp/tmux-0/default (Connection refused)',
+    )).toBe(true);
+    expect(isTransientStartupFailure('lost server')).toBe(true);
+    expect(isTransientStartupFailure('server exited unexpectedly')).toBe(true);
+    expect(isTransientStartupFailure('connect ECONNREFUSED /tmp/x.sock')).toBe(true);
+  });
+
+  it('classifies fd/process pressure as transient', () => {
+    expect(isTransientStartupFailure('spawn EAGAIN')).toBe(true);
+    expect(isTransientStartupFailure('EMFILE: too many open files')).toBe(true);
+    expect(isTransientStartupFailure('ENFILE: file table overflow')).toBe(true);
+  });
+
+  it('keeps deterministic install/config failures user-visible (NOT transient)', () => {
+    expect(isTransientStartupFailure('spawn codex ENOENT')).toBe(false);
+    expect(isTransientStartupFailure('EACCES: permission denied')).toBe(false);
+    expect(isTransientStartupFailure('tmux 后端在本机不可用')).toBe(false);
+    expect(isTransientStartupFailure('usage: new-session [-AdDEPX] ...')).toBe(false);
+    expect(isTransientStartupFailure(
+      'durable raw activation was not accepted by the backend',
+    )).toBe(false);
+  });
+
+  it('does not fire on substrings of longer identifiers (word boundaries)', () => {
+    expect(isTransientStartupFailure('MY_ETIMEDOUT_FLAG missing')).toBe(false);
+  });
+});
+
+describe('startupAutoRetryDelayMs', () => {
+  it('is deterministic for the same (sessionId, attempt)', () => {
+    const a = startupAutoRetryDelayMs('6241a223-3ce4-4f84-81a8-25397aecff81', 1);
+    const b = startupAutoRetryDelayMs('6241a223-3ce4-4f84-81a8-25397aecff81', 1);
+    expect(a).toBe(b);
+  });
+
+  it('stays within 75%-125% of the base for every attempt', () => {
+    const bases = [15_000, 60_000, 180_000];
+    for (let attempt = 1; attempt <= bases.length; attempt += 1) {
+      for (const sid of ['6241a223', 'e50bbf26', '3d1baa9d', 'ad786ff6', '9f040c45']) {
+        const d = startupAutoRetryDelayMs(sid, attempt);
+        expect(d).toBeGreaterThanOrEqual(bases[attempt - 1] * 0.75);
+        expect(d).toBeLessThanOrEqual(bases[attempt - 1] * 1.25);
+      }
+    }
+  });
+
+  it('decorrelates different sessions on the same attempt (storm must not re-storm)', () => {
+    const delays = new Set(
+      ['6241a223', 'e50bbf26', '3d1baa9d', 'ad786ff6', '9f040c45', '155ea63a', '50c8ecc9']
+        .map(sid => startupAutoRetryDelayMs(sid, 1)),
+    );
+    expect(delays.size).toBeGreaterThan(1);
+  });
+
+  it('clamps out-of-range attempts to the schedule bounds', () => {
+    expect(startupAutoRetryDelayMs('sid', 0)).toBe(startupAutoRetryDelayMs('sid', 1));
+    expect(startupAutoRetryDelayMs('sid', 99)).toBe(startupAutoRetryDelayMs('sid', 3));
+  });
+
+  it('exports a bounded retry budget', () => {
+    expect(MAX_STARTUP_AUTO_RETRIES).toBeGreaterThan(0);
+    expect(MAX_STARTUP_AUTO_RETRIES).toBeLessThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## 背景（2026-08-23 事故）

共享 tmux server 意外退出后，全部 bot 的 worker 同时冷重建会话（261 个 tmux 会话 / ~40 秒，load ≈ 17）。个别 `tmux new-session` 在**服务端已成功建出会话**的情况下，客户端压到 execFileSync 的 5s deadline，最终 worker fatal，多个沉睡多日的会话收到「⚠️ 会话启动失败：spawnSync tmux ETIMEDOUT」——而它们的 tmux pane 和 CLI 进程实际都还活着（全机 9 个会话中招，分布在 5 个 bot）。

## 根因

#962 已给 new-session / pipe-pane 加了启动重试，但分类器 `isRetryableStartupTmuxFailure`（以及 `probeSession` / `probePaneAddressability` / `tmuxServerReachability` 同形状的分类器）存在一个竞态漏洞：**Node 的 spawnSync 超时踢人时，若客户端恰好在 kill 窗口内自己干净退出，抛出的错误会同时带 `code: 'ETIMEDOUT'` 和数值 `status`（无 signal）**。分类器按「干净数值退出 + stderr 非连接级 ⇒ 服务端确定性拒绝」直接判死、不重试。本机负载 17 时这个窗口被大幅拉宽，与事故时间线完全吻合（fatal 恰在 spawn 后 5.0s、无任何 retry 日志、会话在服务端创建成功）。

## 改动

**worker 侧（修根因）**
- `tmux-backend.ts` 新增共享分类助手 `isExecTimeoutError`：`err.code === 'ETIMEDOUT'` 一律视为「没等到应答」，绝不当权威判定——deadline 永远不是服务端的确定性回答
- 四处分类器统一在 status-shape 判断**之前**先查 deadline：`isRetryableStartupTmuxFailure`（修事故主链路：超时重试 → 撞 duplicate session → 收编已建成的会话）、`probeSession`、`probePaneAddressability`、`tmuxServerReachability`（后三处防止同形状错误喂进毁灭性 liveness 计数）
- `applySessionOptions` 的 5 条 set-option 补上 `timeout: 5000`（原先无界，wedged server 会把 worker 启动路径挂死）

**daemon 侧（系统性兜底，本事故的直接解药）**
- 新增 `core/worker-startup-retry.ts`（纯函数，单测覆盖）：瞬态失败分类器（ETIMEDOUT / ECONNREFUSED / EAGAIN / EMFILE / ENFILE / tmux 连接级 error 文案；ENOENT/EACCES 等确定性安装/配置错误不匹配）+ 确定性去相关退避（15s/60s/180s × 75%–125% session-hash jitter，防止风暴重试再风暴）
- `worker-pool.ts` 的 `case 'error'`：**无 turn 归属**且分类为瞬态时，静默调度 `forkWorker(ds, '', true)` 空白重拉（pane 存活则 re-attach——正是事故场景的无损自愈；否则冷 resume），最多 3 次，耗尽才发「会话启动失败」卡片。带 turn 的失败保持原有立即通知（发送方在等；durable VC/at-most-once 的重试归各自状态机管）。worker 达到 ready 即清空重试预算与挂起 timer

## 影响面

- 分类器改动仅影响 tmux 后端、且仅影响 ETIMEDOUT 形状的错误——方向严格是「少误杀、多重试」，不改变干净拒绝（duplicate session、bad option、no server running）的既有语义
- daemon 重试挂在共用 `case 'error'` 上，对所有 CLI 生效，但触发条件收窄为「无 turnId/dispatchAttempt + 瞬态文案 + 预算内」；VC durable / at-most-once 路径因必带 turn 归属而天然不进此分支
- 会话类型：普通话题/群会话、restore/auto-restart 均受益；adopt 会话的 observe 探测同样受益于 probe 分类修正

## 测试验证

- `test/tmux-startup-storm-recovery.test.ts`（新增，**真实场景模拟**）：真实 tmux + 私有 socket + PATH shim 精确复刻事故时序——第一次 new-session 真实建出会话后顶住客户端到 deadline、被 kill 时干净 exit 0（制造 clean-exit+ETIMEDOUT 竞态形状）。红绿对照：**master 代码上必现事故同款 `Error: spawnSync tmux ETIMEDOUT`；本分支自愈成功**（重试撞 duplicate session → 收编 → pipe-pane 正常挂上，2/2 绿）
- `test/worker-startup-retry.test.ts`（新增）：分类器 + 退避策略纯函数单测（10/10）
- `test/worker-startup-retry-wiring.test.ts`（新增）：daemon 接线行为——静默调度 / 预算耗尽才发卡 / 带 turn 立即通知 / 确定性错误立即通知 / exit guard 不重复发卡 / 会话被别的路径救活后重试让位（6/6）
- `test/tmux-pipe-backend.test.ts`、`test/tmux-probe.test.ts` 各补事故形状回归用例
- 相关测试面 14 文件 255 用例全绿；`pnpm build` 绿
- 全量单测的失败集与 origin/master 基线一致（workflow-* / dashboard-bot-defaults / v3-goal-cli / daemon-rename-route / mojo-launcher-env-quarantine 等本机环境基线，同批文件 master 27 fail vs 本分支 28，v3-goal-cli 计时敏感抖动），与本改动无关

Made with [Cursor](https://cursor.com)