### PR TITLE
fix(web-terminal): fall back on EACCES (Windows winnat reserved ports), not just EADDRINUSE

### DIFF
--- a/src/utils/web-terminal-listen.ts
+++ b/src/utils/web-terminal-listen.ts
@@ -11,9 +11,17 @@ export interface ListenWebTerminalOpts {
 }
 
 /**
- * Bind the per-session web-terminal HTTP server, recovering from a busy
+ * Bind the per-session web-terminal HTTP server, recovering from an unbindable
  * `preferredPort` (e.g. a persisted webPort reused on worker re-fork that some
- * other process now holds) by retrying on an OS-assigned random port.
+ * other process now holds, or one that fell into a Windows winnat/Hyper-V
+ * reserved TCP range) by retrying on an OS-assigned random port.
+ *
+ * Both EADDRINUSE (port busy) and EACCES (port administratively reserved) are
+ * treated the same way: "can't bind THIS port, try another". On Windows the
+ * winnat reserved ranges re-randomize on every reboot, so a persisted webPort
+ * that bound fine yesterday can start failing with EACCES after a reboot; the
+ * OS never hands a reserved port back from listen(0), so the random-port retry
+ * always succeeds. Only genuinely non-recoverable errors reject.
  *
  * CRITICAL — why the `wss.on('error')` below is load-bearing, not cosmetic:
  * `new WebSocketServer({ server })` makes the ws library proxy the HTTP server's
@@ -76,10 +84,10 @@ export function listenWebTerminalWithFallback(opts: ListenWebTerminalOpts): Prom
       // on an already-listening server (ERR_SERVER_ALREADY_LISTEN, thrown
       // synchronously from the emit → unhandled → crash). Defense in depth.
       if (settled) return;
-      if (err.code === 'EADDRINUSE' && !fallbackAttempted) {
+      if ((err.code === 'EADDRINUSE' || err.code === 'EACCES') && !fallbackAttempted) {
         fallbackAttempted = true;
         if (preferredPort) {
-          log(`Preferred port ${preferredPort} in use (${err.code}), falling back to random`);
+          log(`Preferred port ${preferredPort} unavailable (${err.code}), falling back to random`);
         } else {
           log(`Port ${listenPort} bind failed (${err.code}), retrying with random port`);
         }

--- a/test/web-terminal-listen.test.ts
+++ b/test/web-terminal-listen.test.ts
@@ -111,10 +111,53 @@ describe('listenWebTerminalWithFallback', () => {
     expect(logs.some((line) => line.includes('retrying with random port'))).toBe(true);
   });
 
-  it('rejects (does not fall back) for non-EADDRINUSE errors', async () => {
+  it('falls back to a random port when the preferred port is winnat-reserved (EACCES)', async () => {
+    // Windows-specific regression: a persisted webPort that lands in a
+    // winnat/Hyper-V reserved TCP range binds with EACCES (not EADDRINUSE) after
+    // a reboot re-randomizes the reservations. The previous condition only
+    // recovered from EADDRINUSE, so EACCES fell through to reject → the worker
+    // exited code 1 with "listen EACCES: permission denied 0.0.0.0:<port>" and
+    // the bot could receive messages but never start a session. Simulate the
+    // reserved-port EACCES on the first bind, then let the fallback bind.
     const { httpServer, wss } = makePair();
-    // No preferredPort → an invalid host triggers a non-EADDRINUSE error which
-    // must reject rather than silently retry.
+    const originalListen = httpServer.listen;
+    let listenCalls = 0;
+
+    httpServer.listen = ((...args: Parameters<Server['listen']>) => {
+      listenCalls++;
+      if (listenCalls === 1) {
+        const err = Object.assign(new Error('listen EACCES: permission denied 0.0.0.0:58634'), {
+          code: 'EACCES',
+          errno: -4092,
+          syscall: 'listen',
+          address: '0.0.0.0',
+          port: 58634,
+        }) as NodeJS.ErrnoException;
+        process.nextTick(() => httpServer.emit('error', err));
+        return httpServer;
+      }
+      return Reflect.apply(originalListen, httpServer, args) as Server;
+    }) as Server['listen'];
+
+    const logs: string[] = [];
+    const boundPort = await listenWebTerminalWithFallback({
+      httpServer,
+      wss,
+      host: '127.0.0.1',
+      preferredPort: 58634,
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(listenCalls).toBe(2);
+    expect(boundPort).toBeGreaterThan(0);
+    expect(boundPort).not.toBe(58634);
+    expect(logs.some((line) => line.includes('unavailable (EACCES)'))).toBe(true);
+  });
+
+  it('rejects (does not fall back) for errors that are neither EADDRINUSE nor EACCES', async () => {
+    const { httpServer, wss } = makePair();
+    // No preferredPort → an invalid host triggers a non-recoverable error
+    // (e.g. EADDRNOTAVAIL) which must reject rather than silently retry.
     await expect(
       listenWebTerminalWithFallback({ httpServer, wss, host: '203.0.113.1', preferredPort: undefined }),
     ).rejects.toBeTruthy();


### PR DESCRIPTION
## Problem

`listenWebTerminalWithFallback` recovers an unbindable `preferredPort` by retrying on an OS‑assigned random port — but the recovery branch only matched **`EADDRINUSE`**. A bind that fails with **`EACCES`** fell through to `reject`, which crashes the session worker (`exit 1`).

This bites hard on Windows. `winnat`/Hyper‑V/WSL reserve a rotating set of TCP ranges, and **those reservations re‑randomize on every reboot**. A persisted session `webPort` that bound fine yesterday can land inside a reserved range after a reboot, and Windows then rejects the bind with `EACCES`, not `EADDRINUSE`. Observed in production:

```
[worker:<id>] Init: session=<id>, cwd=..., render=160x50
[worker:<id>] WSS server error: EACCES listen EACCES: permission denied 0.0.0.0:58634
[<id>] Worker process exited (code: 1)
```

Symptom: the bot **receives messages but can never start a session** — every `@` returns "会话启动失败: listen EACCES: permission denied 0.0.0.0:\<port\>". The same session/port (`58634`) had bound cleanly with `HTTP listening on 0.0.0.0:58634` before the reboot, which is the tell that the reservation set moved under it.

## Fix

Treat `EACCES` the same as `EADDRINUSE` in the fallback condition — both mean "can't bind *this* port, try another". `listen(0)` never returns an administratively‑reserved port, so the random‑port retry always succeeds. Genuinely non‑recoverable errors (e.g. `EADDRNOTAVAIL`) still reject.

```diff
-      if (err.code === 'EADDRINUSE' && !fallbackAttempted) {
+      if ((err.code === 'EADDRINUSE' || err.code === 'EACCES') && !fallbackAttempted) {
```

One line of behavior; the rest of the diff is the docstring and a regression test.

## Verification

**On the affected Windows host (real bind, not mocked):**
- Confirmed `58634 ∈ [58595–58694]` reserved via `netsh int ipv4 show excludedportrange protocol=tcp`.
- **Before:** feeding a genuinely‑reserved port → `REJECT_EACCES` (reproduces the crash).
- **After:** a reserved port *and* the exact production port `58634` → both fall back to a random bindable port; a non‑reserved fixed port still binds directly.

**Unit (`test/web-terminal-listen.test.ts`):**
- New test simulates reserved‑port `EACCES` on first bind and asserts fallback.
- **Mutation‑checked:** the new test **fails** against the old `EADDRINUSE`‑only condition (with the exact `listen EACCES: permission denied 0.0.0.0:58634` error) and passes with the fix — so it isn't vacuous.
- `vitest run --project unit test/web-terminal-listen.test.ts` → **5 passed**. `tsc --noEmit` clean on both files.

## Notes

Discovered while debugging a botmux bot on a Windows box that went silent after a reboot. Both `EADDRINUSE` and `EACCES` are "port not bindable right now" conditions, so folding them into the existing recovery keeps the helper's original contract while closing the Windows‑reboot gap.
