### PR TITLE
fix(codex): 关闭 Fast 后清除陈旧 priority 徽标

### DIFF
--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -944,8 +944,14 @@ export function drainCodexRollout(path: string, fromOffset: number): CodexDrainR
 function codexThreadSettingsFromEvent(obj: any): CodexThreadSettings | undefined {
   if (obj?.type !== 'event_msg' || obj.payload?.type !== 'thread_settings_applied') return undefined;
   const raw = obj.payload.thread_settings;
-  const serviceTier = raw?.service_tier;
-  if (typeof serviceTier !== 'string' || !serviceTier) return undefined;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  // Codex omits service_tier when /fast is disabled; that is an applied
+  // default-tier snapshot, not a malformed settings record.
+  const rawServiceTier = raw.service_tier;
+  const serviceTier = rawServiceTier === undefined || rawServiceTier === ''
+    ? 'default'
+    : rawServiceTier;
+  if (typeof serviceTier !== 'string') return undefined;
   const model = typeof raw?.model === 'string' && raw.model ? raw.model : undefined;
   // Effort follows in-session changes made through Codex's own model controls.
   // Codex records it both at the top level and under collaboration_mode.settings;

--- a/test/codex-transcript.test.ts
+++ b/test/codex-transcript.test.ts
@@ -811,7 +811,7 @@ describe('drainCodexRollout', () => {
   });
 });
 
-function threadSettingsApplied(serviceTier: string, ts = '2026-04-29T07:00:00.000Z', model = 'gpt-5.6-sol') {
+function threadSettingsApplied(serviceTier?: string, ts = '2026-04-29T07:00:00.000Z', model = 'gpt-5.6-sol') {
   return {
     timestamp: ts,
     type: 'event_msg',
@@ -820,7 +820,7 @@ function threadSettingsApplied(serviceTier: string, ts = '2026-04-29T07:00:00.00
       thread_settings: {
         model,
         model_provider_id: 'byteseed',
-        service_tier: serviceTier,
+        ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
       },
     },
   };
@@ -869,13 +869,12 @@ describe('Codex thread settings observation', () => {
     expect(scanCodexThreadSettings(path)?.serviceTier).toBe('priority');
   });
 
-  it('does not confuse a settings event that carries no service_tier', () => {
-    writeFileSync(path, ev({
-      timestamp: '2026-04-29T07:00:00.000Z',
-      type: 'event_msg',
-      payload: { type: 'thread_settings_applied', thread_settings: { model: 'x' } },
-    }));
-    expect(scanCodexThreadSettings(path)).toBeUndefined();
+  it('treats a valid settings event that carries no service_tier as default', () => {
+    writeFileSync(path, ev(threadSettingsApplied()));
+    expect(scanCodexThreadSettings(path)).toEqual({
+      model: 'gpt-5.6-sol',
+      serviceTier: 'default',
+    });
   });
 
   it('reads the top-level reasoning_effort (follows an in-session /effort switch)', () => {
@@ -932,6 +931,29 @@ describe('Codex thread settings observation', () => {
 
     expect(second.events).toEqual([]);
     expect(second.latestThreadSettings).toEqual({
+      model: 'gpt-5.6-sol',
+      serviceTier: 'default',
+    });
+  });
+
+  it('clears a live priority snapshot when Codex omits service_tier', () => {
+    writeFileSync(path, ev(threadSettingsApplied('priority')));
+    const first = drainCodexRollout(path, 0);
+    expect(first.latestThreadSettings?.serviceTier).toBe('priority');
+
+    appendFileSync(path, ev(threadSettingsApplied(undefined, '2026-04-29T07:01:00.000Z')));
+    const second = drainCodexRollout(path, first.newOffset);
+    expect(second.latestThreadSettings).toEqual({
+      model: 'gpt-5.6-sol',
+      serviceTier: 'default',
+    });
+  });
+
+  it('backward scan returns the newest omitted service_tier as default', () => {
+    writeFileSync(path,
+      ev(threadSettingsApplied('priority'))
+      + ev(threadSettingsApplied(undefined, '2026-04-29T07:01:00.000Z')));
+    expect(scanCodexThreadSettings(path)).toEqual({
       model: 'gpt-5.6-sol',
       serviceTier: 'default',
     });
@@ -1095,4 +1117,3 @@ describe('codexCotEntriesFromResponseItem (CoT thinking timeline)', () => {
     expect(codexCotEntriesFromResponseItem(undefined)).toEqual([]);
   });
 });
-


### PR DESCRIPTION
## 问题

Codex 关闭 Fast 后，新的 `thread_settings_applied` 记录会省略 `service_tier`。解析器此前跳过这类合法记录，导致实时跟踪和会话恢复继续沿用旧的 `priority`，飞书卡片一直显示 Fast 徽标。

## 修复

- 合法设置记录省略或清空 `service_tier` 时按 `default` 处理；
- 仍拒绝缺少 `thread_settings` 或字段类型错误的畸形记录；
- 增加实时增量读取和反向扫描的回归测试。

## 影响面

只影响 Codex transcript 的 thread settings 解析；不改变其他 CLI、后端或会话类型，也不新增状态源。

## 验证

- `pnpm exec vitest run --project unit test/codex-transcript.test.ts`：85/85 通过
- `pnpm build`：通过（TypeScript、脚本类型检查、dashboard bundle 和产物审计）
