### PR TITLE
fix(terminal): 恢复平台只读访客在 Web 终端只读页的 SSO 登录引导

### DIFF
--- a/src/core/terminal-write-auth.ts
+++ b/src/core/terminal-write-auth.ts
@@ -28,6 +28,22 @@
 
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
+/**
+ * 中央前门 → worker 的「平台只读访客」**展示层**提示头（#933 回归修复）。
+ *
+ * 背景：平台注入的 Cookie / `X-Botmux-Role` 在两条路上都会被 dashboard 前门剥掉
+ * （显式 query capability 走 P1-6 的 stripBrowserCredentials；无 capability 时换成
+ * 内部签名 grant）。剥掉之后 worker 的 `platformReadonly` 恒为 false，只读终端页
+ * 便不再显示「owner 登录后可操作 →」的 SSO 引导——冷打开飞书卡片链接的平台访客
+ * 被困在一个没有任何登录入口的只读页里。
+ *
+ * 该头只影响只读页渲染哪条横幅（登录引导 vs 纯只读提示），**不进入任何读/写授权
+ * 判定**：直连 worker 伪造它，最多让一个本来就只读的页面多显示一条登录引导链接。
+ * 前门在 terminalForwardHeaders 丢弃全部客户端 `x-botmux-*` 之后才设置它，浏览器
+ * 无法夹带。
+ */
+export const TERMINAL_PLATFORM_READONLY_HINT_HEADER = 'x-botmux-platform-readonly';
+
 export interface TerminalWriteInput {
   /** Value of the `X-Botmux-Role` request header (normalized to a single string, or undefined). */
   role: string | undefined;

--- a/src/dashboard/terminal-front-proxy.ts
+++ b/src/dashboard/terminal-front-proxy.ts
@@ -7,6 +7,7 @@ import {
 import type { Duplex } from 'node:stream';
 import { requestLiteralLoopback } from '../core/loopback-target.js';
 import { TERMINAL_VIEW_FORWARD_HEADER } from '../core/terminal-control-grant.js';
+import { TERMINAL_PLATFORM_READONLY_HINT_HEADER } from '../core/terminal-write-auth.js';
 import type {
   TerminalControlManager,
   TerminalDashboardActor,
@@ -231,6 +232,16 @@ export function createTerminalFrontProxy(options: TerminalFrontProxyOptions): {
     // Set AFTER the header build, which drops every client-supplied `x-botmux-*`
     // on this path: a browser can never smuggle its own forward proof through.
     if (viewForwardProof) headers[TERMINAL_VIEW_FORWARD_HEADER] = viewForwardProof;
+    // #933 回归修复：`terminalCapability === 'readonly'` 只可能来自平台注入身份
+    // （teammate/guest —— legacy/H5 都是 'controlled'，平台 owner 是 'owner'）。上面
+    // 两条路都已把平台注入的 Cookie / X-Botmux-Role 剥掉（P1-6 strip 或换内部 grant），
+    // worker 便判不出「平台认证过的只读访客」→ platformReadonly 恒 false → 只读终端页
+    // 上的「owner 登录后可操作 →」SSO 引导消失，冷打开卡片链接的人困在无登录入口的
+    // 只读页里。补一个仅展示用的提示头（授权判定完全不读它，见常量注释）；同样设在
+    // terminalForwardHeaders 之后，客户端自带的同名头已被整片丢弃、无法夹带。
+    if (actor?.terminalCapability === 'readonly') {
+      headers[TERMINAL_PLATFORM_READONLY_HINT_HEADER] = '1';
+    }
     return { ...parsed, port, revoked: false, actor, proxyGrant, readAuthSessionId, headers };
   };
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -157,6 +157,7 @@ import {
   deriveTerminalWriteToken,
   resolveTerminalAccessForRequest,
   safeTerminalTokenEqual,
+  TERMINAL_PLATFORM_READONLY_HINT_HEADER,
   type TerminalAccessDecision,
 } from './core/terminal-write-auth.js';
 import {
@@ -16104,6 +16105,12 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         res.end('Forbidden');
         return;
       }
+      // #933 回归修复：平台注入的 Cookie/Role 会被中央前门剥掉（P1-6 / 内部 grant），
+      // 此时 platformReadonly 判不出来；前门改用这个展示层提示头把「平台认证过的只读
+      // 访客」这一事实带过来。只影响只读页渲染哪条横幅（SSO 登录引导 vs 纯只读提示），
+      // 不参与任何授权判定——hasRead/hasWrite 在它之前就已定死。
+      const platformReadonlyHint = !hasWrite
+        && req.headers[TERMINAL_PLATFORM_READONLY_HINT_HEADER] !== undefined;
       const loginHdr = req.headers['x-botmux-login-url'];
       // The central front proxy only injects X-Botmux-Login-Url on the SPA 401
       // path, never on `/s/` terminal requests — so a read-only web terminal
@@ -16144,7 +16151,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         || effectiveBackendType === 'tmux'
         || effectiveBackendType === 'zellij';
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend, allowReadOnlyRemoteScroll));
+      res.end(getTerminalHtml(hasWrite, platformReadonly || platformReadonlyHint, loginUrl, forceRemoteScroll, localTerminalBackend, allowReadOnlyRemoteScroll));
     });
 
     wss = new WebSocketServer({

--- a/test/terminal-front-proxy.test.ts
+++ b/test/terminal-front-proxy.test.ts
@@ -334,6 +334,73 @@ describe('central terminal front proxy boundary', () => {
     await close(upstream);
   });
 
+  // ── #933 回归修复：平台只读访客的展示层提示头 ────────────────────────────────
+  // 剥掉平台注入的 Cookie/Role（P1-6 strip / 内部 grant 两条路都会剥）之后，worker
+  // 判不出「平台认证过的只读访客」，只读终端页上的「owner 登录后可操作 →」SSO 引导
+  // 从此消失。前门补一个仅展示用的提示头；它必须：只发给平台只读身份（teammate/
+  // guest），别的身份一概不发；客户端自带的同名头在这些路径上被整片丢弃。
+  it('#933 hint: platform readonly viewers get the display-only hint header, every other identity does not', async () => {
+    const observed: Array<{ url: string; hint?: string; cookie?: string; role?: string }> = [];
+    const upstream = createServer((req, res) => {
+      const hint = req.headers['x-botmux-platform-readonly'];
+      observed.push({
+        url: req.url ?? '',
+        ...(typeof hint === 'string' ? { hint } : {}),
+        ...(req.headers.cookie ? { cookie: req.headers.cookie } : {}),
+        ...(typeof req.headers['x-botmux-role'] === 'string' ? { role: req.headers['x-botmux-role'] as string } : {}),
+      });
+      res.end('ok');
+    });
+    const upstreamPort = await listen(upstream);
+
+    const identities: Array<{ name: string; actor: TerminalDashboardActor | null; expectHint: boolean }> = [
+      { name: 'platform-teammate', actor: { userId: 'p:teammate', authSessionId: 's:teammate', expiresAt: Number.MAX_SAFE_INTEGER, terminalCapability: 'readonly' }, expectHint: true },
+      { name: 'platform-guest', actor: { userId: 'p:guest', authSessionId: 's:guest', expiresAt: Number.MAX_SAFE_INTEGER, terminalCapability: 'readonly' }, expectHint: true },
+      { name: 'platform-owner', actor: { userId: 'p:owner', authSessionId: 's:owner', expiresAt: Number.MAX_SAFE_INTEGER, terminalCapability: 'owner' }, expectHint: false },
+      { name: 'legacy', actor: { userId: 'legacy-owner', authSessionId: 'legacy-auth', expiresAt: Number.MAX_SAFE_INTEGER, terminalCapability: 'controlled' }, expectHint: false },
+      { name: 'h5', actor: { userId: 'ou_h5', authSessionId: 'h5-auth', expiresAt: Date.now() + 30 * 60_000, terminalCapability: 'controlled' }, expectHint: false },
+    ];
+    for (const identity of identities) {
+      const control = new TerminalControlManager({ secret: SECRET, audit: { append() {} } });
+      const proxy = createTerminalFrontProxy({
+        resolvePort: () => upstreamPort,
+        resolveActor: () => identity.actor,
+        control,
+        isAuthSessionLive: () => true,
+      });
+      const front = createServer((req, res) => {
+        const url = new URL(req.url ?? '/', 'http://localhost');
+        if (!proxy.handleHttp(req, res, url)) res.writeHead(404).end();
+      });
+      const frontPort = await listen(front);
+      try {
+        // 冷打开卡片链接（viewToken）与 SSO 回跳后的无 token 路径都要覆盖：两条路
+        // 都会剥凭证，缺哪条 worker 都会在对应场景丢掉登录引导。
+        for (const query of ['?viewToken=card-view-capability', '']) {
+          observed.length = 0;
+          await fetch(`http://127.0.0.1:${frontPort}/s/s1/${query}`, {
+            headers: {
+              cookie: 'botmux_dashboard_token=platform-injected-machine-cookie',
+              'x-botmux-role': 'teammate',
+              // 客户端自带的同名头必须被丢弃：断言值恒为前门自己设置的 '1'。
+              'x-botmux-platform-readonly': 'forged-by-client',
+            },
+          });
+          const cell = `${identity.name} × ${query || 'no-token'}`;
+          expect(observed, cell).toHaveLength(1);
+          // 提示头绝不与 ambient 凭证同行：cookie/role 在这些路径上照旧被剥。
+          expect(observed[0].cookie, cell).toBeUndefined();
+          expect(observed[0].role, cell).toBeUndefined();
+          if (identity.expectHint) expect(observed[0].hint, cell).toBe('1');
+          else expect(observed[0].hint, cell).toBeUndefined();
+        }
+      } finally {
+        await close(front);
+      }
+    }
+    await close(upstream);
+  });
+
   // ── P1-5: bound view capabilities are refused once their auth session died ─
 
   it('P1-5: a bound view capability of a revoked auth session is refused before the worker', async () => {

--- a/test/web-terminal-touch-scroll.test.ts
+++ b/test/web-terminal-touch-scroll.test.ts
@@ -66,7 +66,7 @@ describe('web terminal touch scrolling', () => {
       + "        || effectiveBackendType === 'zellij';",
     );
     expect(workerSource).toContain(
-      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend, allowReadOnlyRemoteScroll)',
+      'getTerminalHtml(hasWrite, platformReadonly || platformReadonlyHint, loginUrl, forceRemoteScroll, localTerminalBackend, allowReadOnlyRemoteScroll)',
     );
     expect(workerSource).toContain('var localTerminalBackend=${localTerminalBackend};');
     // Guard the exclusion explicitly: neither Herdr nor Riff may appear in the gate.

--- a/test/worker-terminal-read-auth.integration.test.ts
+++ b/test/worker-terminal-read-auth.integration.test.ts
@@ -208,6 +208,23 @@ setInterval(() => {}, 1_000);
     expect(viewHtml).toContain('var hasToken=false');
     // The browser must carry the view capability into its WS connection too.
     expect(viewHtml).toContain("base+'/'+location.search");
+    // 无平台提示头时按本地只读渲染（readonly 横幅，不是 SSO 登录引导）。
+    expect(viewHtml).toContain('var platformReadonly=false');
+
+    // #933 回归修复：中央前门剥掉平台注入的 Cookie/Role 后，用展示层提示头把「平台
+    // 认证过的只读访客」带过来 → 页面渲染 SSO 登录引导（platformReadonly=true），
+    // 而读/写授权判定不受它影响（仍是只读：hasToken=false）。
+    const platformHintView = await fetch(`${base}/?viewToken=${encodeURIComponent(ready.viewToken!)}`, {
+      headers: { 'x-botmux-platform-readonly': '1' },
+    });
+    expect(platformHintView.status).toBe(200);
+    const platformHintHtml = await platformHintView.text();
+    expect(platformHintHtml).toContain('var hasToken=false');
+    expect(platformHintHtml).toContain('var platformReadonly=true');
+    // 提示头绝不能把写权限带出来：伪造它 + 错误 token 仍被整体拒绝。
+    expect((await fetch(`${base}/?token=wrong-token`, {
+      headers: { 'x-botmux-platform-readonly': '1' },
+    })).status).toBe(403);
 
     // Every historically issued stable view token fails closed on this worker.
     expect((await fetch(`${base}/?viewToken=${encodeURIComponent(retiredStableViewToken(secret, sessionId))}`)).status).toBe(403);


### PR DESCRIPTION
## 问题

冷打开飞书卡片「打开 Web 终端」链接（浏览器无 t- 子域 SSO 会话）时，页面是只读的，且**没有任何登录入口**——「owner 登录后可操作 →」引导横幅不显示，用户无法从页面走 SSO 变可写，观感即“打开的界面没法直接操作”。

## 根因

#933 的 P1-6 让 dashboard 前端代理剥掉平台注入的 Cookie / `X-Botmux-Role`（显式 query capability 走 `stripBrowserCredentials`；无 capability 路径换成内部签名 grant 时同样剥离）。worker 侧 `platformReadonly` 的判定依赖看到这对凭证，从此恒为 false → 只读页渲染的是无引导的「只读模式」横幅而非 SSO 登录引导。#960 修复的三处 #933 回归（t- Origin、owner+viewToken 可写、banner 死 div）不含这条显示层；owner 路径正常可写把它盖住，直到访客以冷态（guest）落到该页才暴露。

## 修法

- `dashboard/terminal-front-proxy.ts`：`prepare()` 在剥凭证之后，对平台只读身份（`terminalCapability === 'readonly'`，只可能由平台注入的 teammate/guest 产生；legacy/H5 为 `controlled`、平台 owner 为 `owner`）补发**仅展示用**提示头 `x-botmux-platform-readonly: 1`。设置于 `terminalForwardHeaders` 丢弃全部客户端 `x-botmux-*` 之后，浏览器无法伪造夹带
- `core/terminal-write-auth.ts`：新增该头常量与语义注释
- `worker.ts`：终端页 GET 渲染时消费该提示头（`platformReadonly || platformReadonlyHint`），恢复登录引导横幅；`hasRead`/`hasWrite` 判定在其之前完成，**该头不参与任何授权判定**——直连伪造它最多让一个本就只读的页面多显示一条登录链接

P1-6 边界原样保留：凭证剥离不变、写授权仍只走签名 grant / 显式 token。

## 影响面

- 共用路径：dashboard 前端代理（平台浏览器终端全部流量）+ worker 终端页渲染，均为展示层增量
- 不受影响：owner 可写路径（签名 grant 机制未动）、H5/legacy 身份（`controlled` 不发提示头）、本地直连/daemon 终端代理路径（无平台身份）、WS 写权限首帧机制（#971）

## 测试验证

- `pnpm build` 通过
- `terminal-front-proxy.test.ts`（20 用例）新增身份矩阵：仅 platform-teammate/guest 在「viewToken 链接」与「无 token」两条路径收到提示头，owner/legacy/H5 不收；客户端伪造的同名头被丢弃；cookie/role 照旧剥离
- `worker-terminal-read-auth.integration.test.ts`（真实 worker 进程）：带提示头的只读页渲染 `platformReadonly=true`、授权不变仍 `hasToken=false`；「伪造提示头 + 错误 token」仍整体 403
- 周边回归：`terminal-control` / `terminal-control-route` / `terminal-write-frame` / `terminal-view-capability` / `debug-terminal` / `web-terminal-touch-scroll`（接缝字面量同步更新）/ `terminal-proxy` / `agent-workbench-terminal-control` / `agent-workbench-api` 全绿
- live 实测（`pnpm switch:here && pnpm daemon:restart` 后经真实平台 t- 域）：修复前只读页 `platformReadonly=false`（无登录入口），修复后 `=true` 且登录链接完整指向 `/open/<machineId>?next=/s/<sessionId>`；owner 回归 HTTP `hasToken=true`、WS 首帧 `write:true` 无影响；冷态无痕窗口点卡片链接可见登录引导、SSO 回跳后可直接输入

Made with [Cursor](https://cursor.com)