### PR TITLE
fix(dashboard): 旧会话页「定位话题」补带控制类 CSRF 票据

### DIFF
--- a/src/dashboard/web/sessions-page.tsx
+++ b/src/dashboard/web/sessions-page.tsx
@@ -119,6 +119,7 @@ import {
 } from './sessions-kanban.js';
 import { toast } from './toast.js';
 import { confirm, promptText } from './confirm-modal.js';
+import { controlCsrfHeaders } from './control-csrf.js';
 
 type SessionRow = Record<string, any> & { sessionId: string; status: string };
 
@@ -3330,7 +3331,7 @@ function SessionsPage(): React.JSX.Element {
     // do NOT imperatively mutate the button here — the board's locate button renders
     // its icon via dangerouslySetInnerHTML and a textContent write permanently wipes it.
     try {
-      const r = await fetch(`/api/sessions/${encodeURIComponent(row.sessionId)}/locate`, { method: 'POST' });
+      const r = await fetch(`/api/sessions/${encodeURIComponent(row.sessionId)}/locate`, { method: 'POST', headers: controlCsrfHeaders() });
       const body = await r.json();
       if (body.ok) return true;
       toast(`Locate failed: ${body.error ?? r.status}`, { kind: 'error' });

--- a/test/dashboard-sessions-ui.test.ts
+++ b/test/dashboard-sessions-ui.test.ts
@@ -334,6 +334,17 @@ describe('dashboard sessions filters', () => {
     expect(page).not.toContain('botTriggeredTopics: event.currentTarget.checked');
   });
 
+  it('sends the control CSRF ticket on the session /locate POST', () => {
+    // 服务端只对 locate 这一个会话动作强制校验 P1-11 CSRF 票据（dashboard.ts 的
+    // enforceControlCsrf），旧会话页这条 fetch 曾漏带头，导致点「定位话题」稳定
+    // 403 control_csrf_invalid。回归守卫：locate 必须走 controlCsrfHeaders()。
+    const page = readFileSync(new URL('../src/dashboard/web/sessions-page.tsx', import.meta.url), 'utf8');
+    expect(page).toContain("import { controlCsrfHeaders } from './control-csrf.js';");
+    const locateCall = page.match(/fetch\(`\/api\/sessions\/\$\{encodeURIComponent\(row\.sessionId\)\}\/locate`[^;]*/);
+    expect(locateCall, 'locate fetch call not found').not.toBeNull();
+    expect(locateCall![0]).toContain('headers: controlCsrfHeaders()');
+  });
+
   it('groups thread sessions by chat and root message without claiming ancestry', () => {
     const rows = [
       {


### PR DESCRIPTION
## 问题
Dashboard 旧「会话」页点击「定位话题」稳定报 `control_csrf_invalid`（403）。

## 根因
服务端只对 `locate` 这一个会话动作强制校验 P1-11 一次性 CSRF 票据（`dashboard.ts` 的 `enforceControlCsrf`，仅 gate `op === 'locate'`）。但旧会话页 `src/dashboard/web/sessions-page.tsx` 里的 `/locate` 是**无 header 的裸 POST**，没带页面注入的 `X-Botmux-Csrf` 票据，于是被服务端 403 拒绝。

同仓库 Agent Workbench 侧的写请求已通过 `controlCsrfHeaders()` 正确带票据，唯独旧会话页这条调用漏了。经核对当前 `master`（HEAD `7be0d1d`）依旧存在，属通用回归而非单机个例。

## 改动
- `sessions-page.tsx` 的 `/locate` POST 加上 `headers: controlCsrfHeaders()`（复用已有的 `./control-csrf.js` 助手）。
- `test/dashboard-sessions-ui.test.ts` 新增回归用例，守护该调用必须带票据。

## 影响面
仅前端 dashboard 会话页 `locate` 一条调用。服务端契约不变；其它会话动作（`close/rename/lock/restart/...` 服务端未 gate CSRF）不受影响；无跨 CLI / 跨后端影响。

## 验证
- `pnpm build` 通过。
- `vitest run test/dashboard-sessions-ui.test.ts`：42 passed（含新回归用例）。
- 反向验证：临时移除源码修复后，新增用例如期失败（证明守护有效）。