### PR TITLE
feat(dashboard): 统一 dashboard 弹窗交互，消除浏览器原生 confirm/prompt

### DIFF
--- a/src/dashboard/web/confirm-modal.tsx
+++ b/src/dashboard/web/confirm-modal.tsx
@@ -2,10 +2,12 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 // ── ConfirmModal 系统 ─────────────────────────────────────────────────────────
 // 基于原生 <dialog>：showModal() 提供顶层渲染、Esc 取消与焦点圈禁（Tab 循环
-// 在 modal 内）。多个 confirm 并发时排队，依次展示。
-// 用法：
+// 在 modal 内）。多个弹窗并发时排队，依次展示。两种弹窗共用同一套队列/焦点/
+// Esc/遮罩机制，队首靠 kind 区分是「确认」还是「文本输入」：
 //   const ok = await confirm({ title: '删除会话', message: '该操作不可撤销', danger: true });
 //   const ok = await confirm({ title: '解散群', message: '...', requireText: '解散' });
+//   const dir = await promptText({ title: '调试终端', message: '工作目录：' });
+//     // 确认返回输入串（空串亦合法），取消/Esc/点遮罩返回 null —— 对齐 window.prompt
 
 export interface ConfirmOptions {
   title: string;
@@ -20,12 +22,27 @@ export interface ConfirmOptions {
   requireText?: string;
 }
 
-interface PendingConfirm {
-  options: ConfirmOptions;
-  resolve: (value: boolean) => void;
+export interface PromptOptions {
+  title: string;
+  /** 输入框上方的说明 / 标签 */
+  message: string;
+  /** 危险操作：确认按钮用红色 */
+  danger?: boolean;
+  /** 默认「确认」 */
+  confirmLabel?: string;
+  /** 默认「取消」 */
+  cancelLabel?: string;
+  /** 输入框占位符 */
+  placeholder?: string;
+  /** 输入框初始值（取消仍返回 null，与 window.prompt 一致） */
+  defaultValue?: string;
 }
 
-let queue: PendingConfirm[] = [];
+type PendingItem =
+  | { kind: 'confirm'; options: ConfirmOptions; resolve: (value: boolean) => void }
+  | { kind: 'prompt'; options: PromptOptions; resolve: (value: string | null) => void };
+
+let queue: PendingItem[] = [];
 const listeners = new Set<() => void>();
 
 function emit(): void {
@@ -34,17 +51,31 @@ function emit(): void {
 
 export function confirm(options: ConfirmOptions): Promise<boolean> {
   return new Promise<boolean>(resolve => {
-    queue = [...queue, { options, resolve }];
+    queue = [...queue, { kind: 'confirm', options, resolve }];
     emit();
   });
 }
 
-function settle(value: boolean): void {
+/**
+ * 带自由文本输入的弹窗（替代阻塞式 window.prompt）。
+ * 确认时 resolve 输入串（空串合法）；取消 / Esc / 点遮罩时 resolve null。
+ */
+export function promptText(options: PromptOptions): Promise<string | null> {
+  return new Promise<string | null>(resolve => {
+    queue = [...queue, { kind: 'prompt', options, resolve }];
+    emit();
+  });
+}
+
+// accepted=用户点了确认/回车；text=当前输入框内容。confirm 项忽略 text 只回布尔，
+// prompt 项在确认时回 text、否则回 null。
+function settle(accepted: boolean, text: string): void {
   const [current, ...rest] = queue;
   if (!current) return;
   queue = rest;
   emit();
-  current.resolve(value);
+  if (current.kind === 'prompt') current.resolve(accepted ? text : null);
+  else current.resolve(accepted);
 }
 
 export function ConfirmModalRoot() {
@@ -56,7 +87,11 @@ export function ConfirmModalRoot() {
 
   const current = queue[0];
   const options = current?.options;
-  const requireText = options?.requireText;
+  const isPrompt = current?.kind === 'prompt';
+  // 强确认门只属于 confirm 项；prompt 无门（允许空串提交，对齐 window.prompt）
+  const requireText = current?.kind === 'confirm' ? current.options.requireText : undefined;
+  const placeholder = current?.kind === 'prompt' ? current.options.placeholder : undefined;
+  const showInput = isPrompt || !!requireText;
   const canConfirm = requireText ? typed === requireText : true;
 
   useEffect(() => {
@@ -68,7 +103,7 @@ export function ConfirmModalRoot() {
   }, []);
 
   // 队首变化时打开/关闭原生 dialog。dialog 保持挂载，靠 children 切换内容，
-  // 这样排队中的下一个 confirm 可以无缝接上。
+  // 这样排队中的下一个弹窗可以无缝接上。
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
@@ -83,15 +118,16 @@ export function ConfirmModalRoot() {
     }
   }, [current]);
 
-  // 每次队首变化：重置强确认输入并把焦点落到输入框/确认按钮
+  // 每次队首变化：把输入框重置为初始值（prompt 用 defaultValue，其余清空），
+  // 并把焦点落到输入框/确认按钮
   useEffect(() => {
     if (!current) return;
-    setTyped('');
+    setTyped(current.kind === 'prompt' ? current.options.defaultValue ?? '' : '');
     window.requestAnimationFrame(() => {
-      if (requireText) inputRef.current?.focus();
+      if (showInput) inputRef.current?.focus();
       else confirmRef.current?.focus();
     });
-  }, [current, requireText]);
+  }, [current, showInput]);
 
   // 卸载兜底：避免残留打开的 modal 卡住页面交互
   useEffect(
@@ -110,11 +146,11 @@ export function ConfirmModalRoot() {
       onCancel={event => {
         // Esc = 取消（阻止默认 close，统一走 settle 关队列）
         event.preventDefault();
-        settle(false);
+        settle(false, '');
       }}
       onClick={event => {
         // 点击 mask（::backdrop 的点击 retarget 到 dialog 自身）= 取消
-        if (event.target === event.currentTarget) settle(false);
+        if (event.target === event.currentTarget) settle(false, '');
       }}
     >
       {options ? (
@@ -123,24 +159,25 @@ export function ConfirmModalRoot() {
             {options.title}
           </h3>
           <p className="confirm-modal-message">{options.message}</p>
-          {requireText ? (
+          {showInput ? (
             <div className="confirm-modal-input-row">
               <input
                 ref={inputRef}
                 type="text"
                 className="confirm-modal-input"
                 value={typed}
+                placeholder={placeholder}
                 autoComplete="off"
                 spellCheck={false}
                 onInput={event => setTyped((event.target as HTMLInputElement).value)}
                 onKeyDown={event => {
-                  if (event.key === 'Enter' && canConfirm) settle(true);
+                  if (event.key === 'Enter' && canConfirm) settle(true, typed);
                 }}
               />
             </div>
           ) : null}
           <div className="confirm-modal-footer">
-            <button type="button" className="btn-cancel" onClick={() => settle(false)}>
+            <button type="button" className="btn-cancel" onClick={() => settle(false, '')}>
               {options.cancelLabel ?? '取消'}
             </button>
             <button
@@ -148,7 +185,7 @@ export function ConfirmModalRoot() {
               type="button"
               className={options.danger ? 'btn-danger' : 'btn-primary'}
               disabled={!canConfirm}
-              onClick={() => settle(true)}
+              onClick={() => settle(true, typed)}
             >
               {options.confirmLabel ?? '确认'}
             </button>

--- a/src/dashboard/web/confirm-modal.tsx
+++ b/src/dashboard/web/confirm-modal.tsx
@@ -158,7 +158,7 @@ export function ConfirmModalRoot() {
           <h3 id="confirm-modal-title" className="confirm-modal-title">
             {options.title}
           </h3>
-          <p className="confirm-modal-message">{options.message}</p>
+          <p id="confirm-modal-message" className="confirm-modal-message">{options.message}</p>
           {showInput ? (
             <div className="confirm-modal-input-row">
               <input
@@ -169,9 +169,12 @@ export function ConfirmModalRoot() {
                 placeholder={placeholder}
                 autoComplete="off"
                 spellCheck={false}
+                aria-labelledby="confirm-modal-message"
                 onInput={event => setTyped((event.target as HTMLInputElement).value)}
                 onKeyDown={event => {
-                  if (event.key === 'Enter' && canConfirm) settle(true, typed);
+                  // isComposing：IME 组词（中/日/韩）期间的 Enter 是「上屏候选词」，
+                  // 不是提交，放行给输入法处理，避免强确认文本或目录被截断误提交。
+                  if (event.key === 'Enter' && !event.nativeEvent.isComposing && canConfirm) settle(true, typed);
                 }}
               />
             </div>

--- a/src/dashboard/web/customization-page.tsx
+++ b/src/dashboard/web/customization-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { LoadingState } from './dashboard-components.js';
 import { mountReactPage, type PageDisposer } from './react-mount.js';
+import { confirm } from './confirm-modal.js';
 
 // ─── Types (mirror src/dashboard/customization-api.ts payloads) ──────────────
 
@@ -363,7 +364,7 @@ function CustomizationPage() {
           <button className="cz-btn cz-btn-ghost" onClick={() => setShowHistory(h => !h)}>历史 / 回滚 ({data.history.length})</button>
           <a className="cz-btn cz-btn-ghost" href="/api/customization/export" download>导出 bundle</a>
           <button className="cz-btn cz-btn-ghost" onClick={() => setShowImport(true)}>导入 bundle</button>
-          <button className="cz-btn cz-btn-danger" onClick={async () => { if (confirm('把所有 prompt/skill 覆盖恢复出厂？（会先存快照，可回滚撤回）')) { await post('/api/customization/reset-all'); flash('已全部恢复出厂'); } }}>全部恢复出厂</button>
+          <button className="cz-btn cz-btn-danger" onClick={async () => { if (await confirm({ title: '全部恢复出厂', message: '把所有 prompt/skill 覆盖恢复出厂？会先存快照，可回滚撤回。', danger: true, confirmLabel: '恢复出厂' })) { await post('/api/customization/reset-all'); flash('已全部恢复出厂'); } }}>全部恢复出厂</button>
         </div>
 
         {showHistory ? (
@@ -375,7 +376,7 @@ function CustomizationPage() {
                   <span className="cz-hist-when">{rel(s.at)}</span>
                   <span className="cz-hist-label">{s.label}</span>
                   <span className="cz-hist-sum">prompt {s.summary.promptKeys} · skill {s.summary.skills} · {s.summary.enabled ? 'on' : 'off'}</span>
-                  <button className="cz-link" onClick={async () => { if (confirm('回滚到此快照？')) { await post('/api/customization/rollback', { id: s.id }); flash('已回滚'); } }}>回滚到此</button>
+                  <button className="cz-link" onClick={async () => { if (await confirm({ title: '回滚快照', message: '回滚到此快照？回滚本身也会存快照，非破坏式。', confirmLabel: '回滚' })) { await post('/api/customization/rollback', { id: s.id }); flash('已回滚'); } }}>回滚到此</button>
                 </div>
               ))}
             </div>

--- a/src/dashboard/web/sessions-page.tsx
+++ b/src/dashboard/web/sessions-page.tsx
@@ -118,7 +118,7 @@ import {
   type SessionsKanbanTeamBoardData,
 } from './sessions-kanban.js';
 import { toast } from './toast.js';
-import { confirm } from './confirm-modal.js';
+import { confirm, promptText } from './confirm-modal.js';
 
 type SessionRow = Record<string, any> & { sessionId: string; status: string };
 
@@ -3742,7 +3742,7 @@ function SessionsPage(): React.JSX.Element {
   // 调试终端：起一个 owner-only 裸 bash（不绑飞书话题），在新标签打开 xterm 页面。
   // 让用户把「复制复现命令」拿到的命令粘进去改参数复现问题，用完关闭即回收。
   const openDebugTerminal = useCallback(async (): Promise<void> => {
-    const input = window.prompt(t('sessions.debugTerminalPrompt'), '');
+    const input = await promptText({ title: t('sessions.debugTerminal'), message: t('sessions.debugTerminalPrompt') });
     if (input === null) return; // 用户取消
     const workingDir = input.trim();
     const tab = window.open('about:blank', '_blank');

--- a/test/confirm-modal.test.ts
+++ b/test/confirm-modal.test.ts
@@ -1,0 +1,181 @@
+/**
+ * confirm-modal.test.ts
+ *
+ * 覆盖统一弹窗系统 (src/dashboard/web/confirm-modal.tsx) 的行为契约，重点是
+ * 新增的 promptText 变体与 window.prompt 的语义对齐：
+ *
+ *   - promptText 确认 → resolve 输入串；**确认空输入 → resolve ''（不是 null）**
+ *   - promptText 取消 / Esc / 点遮罩 → resolve null
+ *   - confirm 仍 resolve 布尔（回归保护，两种弹窗共用队列不能串味）
+ *   - 并发排队 FIFO，prompt / confirm 混排各自 resolve 正确类型
+ *
+ * ConfirmModalRoot 用原生 <dialog>：react-test-renderer 无 DOM 宿主，dialogRef
+ * 恒为 null，showModal()/focus() 的 effect 均有 null 兜底，因此可安全渲染；
+ * 只需 stub window.requestAnimationFrame。所有交互通过队首 dialog 的 props
+ * (onClick / onCancel) 及卡片内 input/button 的 props 触发。
+ */
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { confirm, promptText, ConfirmModalRoot } from '../src/dashboard/web/confirm-modal.js';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// window.requestAnimationFrame 是队首变化 effect 里唯一的浏览器依赖（用于把焦点
+// 落到输入框）；node 环境没有 window，stub 成一个不真正调度的空实现即可——ref 恒
+// 为 null，回调即便执行也是 no-op。
+function withStubbedWindow(): void {
+  vi.stubGlobal('window', { requestAnimationFrame: (_cb: FrameRequestCallback) => 0 });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// 渲染一个 ConfirmModalRoot 并返回其 renderer；队列是模块级单例，弹窗调用在
+// 渲染前后皆可，emit() 会驱动 root 重渲染到最新队首。
+function mountRoot(): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(createElement(ConfirmModalRoot));
+  });
+  return renderer;
+}
+
+// 入队 confirm/promptText 必须包进 act：confirm()/promptText() 会同步 emit() →
+// ConfirmModalRoot 的 force() 状态更新，不裹 act 则该更新不会 flush 到测试树，
+// 队首内容（按钮/输入框）不会渲染出来，随后的 findByType 会落空、promise 永不结算。
+function enqueue<T>(start: () => Promise<T>): Promise<T> {
+  let promise!: Promise<T>;
+  act(() => { promise = start(); });
+  return promise;
+}
+
+function dialogOf(renderer: TestRenderer.ReactTestRenderer): TestRenderer.ReactTestInstance {
+  return renderer.root.findByType('dialog');
+}
+function inputOf(renderer: TestRenderer.ReactTestRenderer): TestRenderer.ReactTestInstance {
+  return renderer.root.findByType('input');
+}
+// 队首无输入框时 findByType 会抛，用可选查找
+function maybeInput(renderer: TestRenderer.ReactTestRenderer): TestRenderer.ReactTestInstance | undefined {
+  return renderer.root.findAllByType('input')[0];
+}
+function buttonByText(renderer: TestRenderer.ReactTestRenderer, text: string): TestRenderer.ReactTestInstance {
+  return renderer.root.findAll(n => n.type === 'button' && n.children.includes(text))[0];
+}
+function click(renderer: TestRenderer.ReactTestRenderer, text: string): void {
+  act(() => buttonByText(renderer, text).props.onClick());
+}
+function typeInto(renderer: TestRenderer.ReactTestRenderer, value: string): void {
+  act(() => inputOf(renderer).props.onInput({ target: { value } }));
+}
+
+describe('promptText — window.prompt 语义对齐', () => {
+  it('确认后 resolve 输入的文本', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => promptText({ title: 'T', message: '工作目录：' }));
+    typeInto(renderer, '/tmp/repro');
+    click(renderer, '确认');
+    expect(await p).toBe('/tmp/repro');
+  });
+
+  it('确认空输入 resolve 空串 ""（关键：区别于取消的 null）', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => promptText({ title: 'T', message: 'M' }));
+    // 不输入任何内容，直接确认
+    click(renderer, '确认');
+    const v = await p;
+    expect(v).toBe('');
+    expect(v).not.toBeNull();
+  });
+
+  it('取消 → resolve null（即便已输入内容也不回传）', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => promptText({ title: 'T', message: 'M' }));
+    typeInto(renderer, '不该被返回');
+    click(renderer, '取消');
+    expect(await p).toBeNull();
+  });
+
+  it('Esc (dialog onCancel) → resolve null', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => promptText({ title: 'T', message: 'M' }));
+    typeInto(renderer, 'abc');
+    act(() => dialogOf(renderer).props.onCancel({ preventDefault() {} }));
+    expect(await p).toBeNull();
+  });
+
+  it('点遮罩 (target === currentTarget) → resolve null', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => promptText({ title: 'T', message: 'M' }));
+    act(() => {
+      const el = {};
+      dialogOf(renderer).props.onClick({ target: el, currentTarget: el });
+    });
+    expect(await p).toBeNull();
+  });
+
+  it('defaultValue 预填输入框，确认原样回传', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => promptText({ title: 'T', message: 'M', defaultValue: '/home/x' }));
+    expect(inputOf(renderer).props.value).toBe('/home/x');
+    click(renderer, '确认');
+    expect(await p).toBe('/home/x');
+  });
+});
+
+describe('confirm — 布尔语义回归 (共用队列不能串味)', () => {
+  it('确认 → true，且卡片默认无输入框', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => confirm({ title: 'T', message: 'M' }));
+    expect(maybeInput(renderer)).toBeUndefined(); // 普通 confirm 不渲染输入框
+    click(renderer, '确认');
+    expect(await p).toBe(true);
+  });
+
+  it('取消 → false（不是 null，也不是空串）', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => confirm({ title: 'T', message: 'M' }));
+    click(renderer, '取消');
+    const v = await p;
+    expect(v).toBe(false);
+    expect(v).not.toBeNull();
+  });
+
+  it('requireText 强确认：输入匹配前确认按钮 disabled', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => confirm({ title: 'T', message: 'M', requireText: '解散' }));
+    expect(buttonByText(renderer, '确认').props.disabled).toBe(true);
+    typeInto(renderer, '解散');
+    expect(buttonByText(renderer, '确认').props.disabled).toBe(false);
+    click(renderer, '确认');
+    expect(await p).toBe(true);
+  });
+});
+
+describe('并发排队 — prompt / confirm 混排各自 resolve 正确类型', () => {
+  it('FIFO：先 confirm 后 promptText，依次结算互不串味', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p1 = enqueue(() => confirm({ title: 'C', message: 'M' }));
+    const p2 = enqueue(() => promptText({ title: 'P', message: 'M' }));
+    // 队首是 confirm（无输入框），点确认 → true
+    expect(maybeInput(renderer)).toBeUndefined();
+    click(renderer, '确认');
+    expect(await p1).toBe(true);
+    // 队首推进到 prompt（有输入框），输入并确认 → 文本
+    typeInto(renderer, 'second');
+    click(renderer, '确认');
+    expect(await p2).toBe('second');
+  });
+});

--- a/test/confirm-modal.test.ts
+++ b/test/confirm-modal.test.ts
@@ -29,16 +29,26 @@ function withStubbedWindow(): void {
 }
 
 afterEach(() => {
+  // 卸载本用例挂载的所有 root：ConfirmModalRoot 在挂载期把 listener 注册进模块级
+  // listeners Set，卸载才会移除。不清理则跨用例累积 stale root（当前 ref 恒 null
+  // 无害，但脆——一个 emit() 会驱动所有历史 root 重渲染）。
+  act(() => {
+    for (const r of mountedRoots) r.unmount();
+  });
+  mountedRoots.length = 0;
   vi.unstubAllGlobals();
 });
 
 // 渲染一个 ConfirmModalRoot 并返回其 renderer；队列是模块级单例，弹窗调用在
-// 渲染前后皆可，emit() 会驱动 root 重渲染到最新队首。
+// 渲染前后皆可，emit() 会驱动 root 重渲染到最新队首。挂载的 root 收进 mountedRoots，
+// 由 afterEach 统一 unmount（见上）。
+const mountedRoots: TestRenderer.ReactTestRenderer[] = [];
 function mountRoot(): TestRenderer.ReactTestRenderer {
   let renderer!: TestRenderer.ReactTestRenderer;
   act(() => {
     renderer = TestRenderer.create(createElement(ConfirmModalRoot));
   });
+  mountedRoots.push(renderer);
   return renderer;
 }
 
@@ -69,6 +79,10 @@ function click(renderer: TestRenderer.ReactTestRenderer, text: string): void {
 }
 function typeInto(renderer: TestRenderer.ReactTestRenderer, value: string): void {
   act(() => inputOf(renderer).props.onInput({ target: { value } }));
+}
+// 模拟输入框按键；isComposing 走 nativeEvent，对齐产品代码读的 event.nativeEvent.isComposing
+function keyDown(renderer: TestRenderer.ReactTestRenderer, key: string, opts: { isComposing?: boolean } = {}): void {
+  act(() => inputOf(renderer).props.onKeyDown({ key, nativeEvent: { isComposing: opts.isComposing ?? false } }));
 }
 
 describe('promptText — window.prompt 语义对齐', () => {
@@ -128,6 +142,31 @@ describe('promptText — window.prompt 语义对齐', () => {
     expect(inputOf(renderer).props.value).toBe('/home/x');
     click(renderer, '确认');
     expect(await p).toBe('/home/x');
+  });
+
+  it('Enter 键提交（非组词）→ resolve 当前输入', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    const p = enqueue(() => promptText({ title: 'T', message: 'M' }));
+    typeInto(renderer, '/srv/app');
+    keyDown(renderer, 'Enter');
+    expect(await p).toBe('/srv/app');
+  });
+
+  it('IME 组词中的 Enter 不提交（isComposing=true 时放行给输入法）', async () => {
+    withStubbedWindow();
+    const renderer = mountRoot();
+    let settled = false;
+    const p = enqueue(() => promptText({ title: 'T', message: 'M' }).then(v => { settled = true; return v; }));
+    typeInto(renderer, '目录');
+    // 组词上屏的 Enter：不得提交
+    keyDown(renderer, 'Enter', { isComposing: true });
+    await Promise.resolve(); // 放行微任务，若误 settle 这里 settled 会翻真
+    expect(settled).toBe(false);
+    expect(maybeInput(renderer)).toBeDefined(); // 弹窗仍开，队首未结算
+    // 组词结束后的 Enter 才真正提交
+    keyDown(renderer, 'Enter', { isComposing: false });
+    expect(await p).toBe('目录');
   });
 });
 


### PR DESCRIPTION
## 背景

`window.alert` 在 dashboard 源码里其实已经清零（唯一命中是 `game/index.js`，Godot 引擎打包产物，不算），但排查 `confirm/prompt` 时发现：dashboard 早已有统一友好弹窗 `confirm-modal`（十余页面在用 `await confirm({title,message,danger})`），却仍残留三处浏览器原生阻塞弹窗——样式无法统一、阻塞主线程、不受主题控制、移动端体验差。本次收口。

## 改了什么

**1. `confirm-modal` 新增 `promptText()` 变体**（带文本输入的友好弹窗）
- 复用既有 `<dialog>` 的队列 / 焦点 / Esc / 遮罩机制，与 `confirm()` 共用同一挂载点 `ConfirmModalRoot`
- 契约对齐 `window.prompt`：**确认返回输入串（空串 `''` 合法），取消 / Esc / 点遮罩返回 `null`**
- 支持 `placeholder` / `defaultValue`；输入框复用既有 `.confirm-modal-input` 样式（原给强确认用），视觉与现网一致

**2. `customization-page` 两处原生 `window.confirm` → 统一 `confirm({...})`**
- 「全部恢复出厂」（危险操作，红色确认）、「回滚快照」

**3. `sessions-page` 调试终端工作目录输入 `window.prompt` → `promptText()`**
- 保持 `null = 取消` 语义，复用既有 i18n 文案（`sessions.debugTerminal` / `sessions.debugTerminalPrompt`），无需新增 key

**刻意保留不动**：`clipboard.ts` 的 `window.prompt` 是 async clipboard + `execCommand` 全部失败后的最后兜底，靠系统弹窗让用户手动复制，无 DOM 依赖，改成自绘弹窗反而更脆。

## 影响面

- **纯前端 dashboard（web）**，不涉及 daemon / worker / 后端 / 其它 CLI / 其它 IM / 其它会话类型。
- `confirm-modal.tsx` 是 **12 个页面共享文件**，本次为**纯增量**：`confirm()` / `ConfirmOptions` 的签名与行为**完全不变**，泛化后的 `queue` / `settle` 对 confirm 分支逻辑等价。回归测试专门守护「confirm 取消返回 `false` 而非 `null`」这一不串味契约。
- `customization-page` 与 `sessions-page` 同为 `pageRoute` + `mountReactPage` 独立 React root 挂载，与现网已用统一 `confirm` 的 sessions / groups / roles 等页面机制一致；`confirm-modal` 的队列是**模块级单例**跨 React root 共享，`ConfirmModalRoot` 在主壳常驻，不会挂起。

## 测试验证

- **`pnpm build`（tsc + esbuild）全绿**。
- **新增 `test/confirm-modal.test.ts`（10 用例，react-test-renderer 交互）**，隔离跑 10/10 绿，全量套件里同样 10/10 绿。覆盖：
  - `promptText`：确认返回文本 / **确认空输入返回空串（区别于取消的 `null`）** / 取消·Esc·点遮罩返回 `null` / `defaultValue` 预填回传
  - `confirm` 布尔语义回归：确认→`true`、取消→`false`（不是 `null`/空串）、`requireText` 强确认门
  - prompt·confirm 混排 FIFO，各自 resolve 正确类型
- **反向变异验证有牙**：
  - ① 把 prompt 确认改为恒返回 `null` → 4 条相关测试立刻变红
  - ② 把空串折叠成 `null`（`text || null`）→ 精准**只有**「确认空输入返回空串」1 条变红（这正是 `promptText` 相对 `window.prompt` 最易写坏、也最需保护的契约点：空目录 = 用会话默认目录，若被折叠成 `null` 会误判为取消）
- **全量 unit 套件对照 baseline 无新增回归**：`18033 passed / 30 failed`，30 条失败全部归因为既有环境/root-绕权限/并发超时/master 上 shell-hints 文案漂移（mojo EACCES、bwrap sandbox、config-dir、v3-workflow durable-cancel 30s 超时、`shared-hints` 文案等），**均与本 diff 零代码交集**——本 diff 只碰 3 个 `dashboard/web/` 文件，失败文件无一属于 dashboard web 前端。

## 截图

改动本质是「用现网已在用的统一弹窗组件替换浏览器原生弹窗」，视觉即现网既有 `confirm-modal` 样式（sessions/groups 删除确认在用），此处 prompt 变体复用同一 `.confirm-modal-input`。如需 live 截图可另行部署本 checkout 后补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
