### PR TITLE
fix(dashboard): 全局设置侧栏分组标题与子项拉开层级

### DIFF
--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -18821,19 +18821,19 @@ form.dashboard-toolbar > input[type="text"]:focus {
 }
 
 .settings-nav-group-label {
-  margin: 0 0 2px;
+  margin: 0 0 4px;
   padding: 0 var(--sp-2);
   font-size: var(--fs-12);
-  font-weight: 600;
-  color: var(--muted);
+  font-weight: 700;
+  color: var(--fg);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
 }
 
 .settings-nav-link {
   display: block;
   width: 100%;
-  padding: 5px var(--sp-2);
+  padding: 5px var(--sp-2) 5px calc(var(--sp-2) + 8px);
   border: none;
   border-left: 2px solid transparent;
   background: none;
@@ -18846,7 +18846,7 @@ form.dashboard-toolbar > input[type="text"]:focus {
 }
 
 .settings-nav-link:hover {
-  color: var(--text);
+  color: var(--fg);
   background: var(--surface-muted);
 }
 


### PR DESCRIPTION
## Summary

- 全局设置左侧锚点导航的分组标题（通用设置 / 会议 Agent / 系统与维护）原先与子菜单项共用 `--muted` 色、字号只差 1px，中文下 `uppercase` 无效，层级几乎看不出来
- 分组标题改为 `--fg` + `font-weight: 700`，子项左侧增加 8px 缩进，标题与菜单项一眼可分
- 顺手把子项 hover 的未定义 token `var(--text)` 改成真实存在的 `var(--fg)`

## 影响面

- 仅 dashboard 全局设置页左侧导航样式（`.settings-nav-group-label` / `.settings-nav-link`）
- 颜色走主题 token，浅色 / 深色 / 各皮肤自动适配
- 不改设置表单、路由、其它页面侧栏；窄屏（<960px）仍走原有横向胶囊布局

## Test plan

- [x] `pnpm build` 通过
- [x] 浅色主题静态 harness：标题更深更粗，子项缩进，与改动前对比清晰
- [x] 窄屏 <960px：分组标题仍在胶囊行前，布局未坏
- [x] live dashboard 深色主题打开 `#/settings`：三组标题与子项层级可辨，hover 文字色正常
- [ ] reviewer 刷新全局设置页，确认浅色/深色下标题都比子项更醒目


Made with [Cursor](https://cursor.com)