### PR TITLE
fix(omp): 冷 resume 时自动迁移 pre-#955 旧共享目录会话记录

### DIFF
--- a/src/services/oh-my-pi-legacy-migration.ts
+++ b/src/services/oh-my-pi-legacy-migration.ts
@@ -1,0 +1,491 @@
+import { createHash, randomBytes } from 'node:crypto';
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  readdirSync,
+  realpathSync,
+  unlinkSync,
+  writeSync,
+  type Stats,
+} from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+import { scanJsonlFromFd } from './jsonl-cursor.js';
+import { ompMessageText } from './omp-transcript.js';
+import { fsyncDirectorySyncPortable } from '../utils/fs-durability.js';
+import { withFileLockSync } from '../utils/file-lock.js';
+
+const JSONL_SUFFIX = '.jsonl';
+const COPY_CHUNK_BYTES = 64 * 1024;
+const NO_FOLLOW = process.platform === 'win32' ? 0 : (constants.O_NOFOLLOW ?? 0);
+const DEFAULT_LIMITS = {
+  maxBuckets: 256,
+  maxFiles: 4_096,
+  maxFileBytes: 16 * 1024 * 1024,
+  maxTotalBytes: 128 * 1024 * 1024,
+  maxLineBytes: 1024 * 1024,
+} as const;
+
+export interface OmpLegacyMigrationLimits {
+  maxBuckets: number;
+  maxFiles: number;
+  maxFileBytes: number;
+  maxTotalBytes: number;
+  maxLineBytes: number;
+}
+
+/** Deterministic race hooks for the focused filesystem tests. Production never supplies them. */
+export interface OmpLegacyMigrationTestHooks {
+  beforeCopy?: (sourcePath: string) => void;
+  beforePublish?: (targetPath: string) => void;
+}
+
+export interface OmpLegacyMigrationOptions {
+  limits?: Partial<OmpLegacyMigrationLimits>;
+  testHooks?: OmpLegacyMigrationTestHooks;
+}
+
+export type OmpLegacyMigrationResult =
+  | { status: 'migrated'; sourcePath: string; targetPath: string; artifactDirectoryPreserved: boolean }
+  | { status: 'skipped'; reason: 'exact-history-exists' | 'no-match' | 'ambiguous' | 'inconclusive'; detail?: string };
+
+interface Candidate {
+  path: string;
+  realPath: string;
+  bucketReal: string;
+  stats: Stats;
+}
+
+function isStrictDescendant(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel.length > 0 && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+function lstatIfPresent(path: string): Stats | undefined {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+function exactDirectoryState(exactSessionDir: string): 'empty' | 'history' | 'unsafe' {
+  const stats = lstatIfPresent(exactSessionDir);
+  if (!stats) return 'empty';
+  if (stats.isSymbolicLink() || !stats.isDirectory()) return 'unsafe';
+  for (const entry of readdirSync(exactSessionDir, { withFileTypes: true })) {
+    // The name alone blocks migration. A symlink, directory, FIFO, or raced leaf
+    // ending in .jsonl is uncertainty, never permission to publish another file.
+    if (entry.name.endsWith(JSONL_SUFFIX)) return 'history';
+  }
+  return 'empty';
+}
+
+function isValidTitleSlot(record: Record<string, unknown>): boolean {
+  return record.type === 'title'
+    && record.v === 1
+    && typeof record.title === 'string'
+    && typeof record.updatedAt === 'string'
+    && typeof record.pad === 'string';
+}
+
+function scanCandidate(
+  fd: number,
+  candidate: Candidate,
+  effectiveSessionId: string,
+  canonicalWorkingDir: string,
+  limits: OmpLegacyMigrationLimits,
+): 'match' | 'reject' | 'inconclusive' {
+  let physicalLine = 0;
+  let header: Record<string, unknown> | undefined;
+  let malformed = false;
+  let oversizedLine = false;
+  let targetMarker = false;
+  let foreignMarker = false;
+  const exactMarker = `<session_id>${effectiveSessionId}</session_id>`;
+  const markerPattern = /<session_id>([^<>\r\n]+)<\/session_id>/g;
+
+  const cursor = scanJsonlFromFd(fd, 0, {
+    endOffset: candidate.stats.size,
+    onError: () => { malformed = true; },
+    onLine: line => {
+      physicalLine++;
+      if (Buffer.byteLength(line, 'utf8') > limits.maxLineBytes) {
+        oversizedLine = true;
+        return;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        malformed = true;
+        return;
+      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        malformed = true;
+        return;
+      }
+      const record = parsed as Record<string, unknown>;
+      if (physicalLine === 1 && isValidTitleSlot(record)) return;
+      const expectedHeaderLine = physicalLine === 1 ? 1 : 2;
+      if (!header && physicalLine === expectedHeaderLine) {
+        header = record;
+        return;
+      }
+      if (record.type !== 'message') return;
+      const message = record.message;
+      if (!message || typeof message !== 'object' || Array.isArray(message)) return;
+      const messageRecord = message as Record<string, unknown>;
+      if (messageRecord.role !== 'user') return;
+      const text = ompMessageText(messageRecord.content);
+      if (text.includes(exactMarker)) targetMarker = true;
+      markerPattern.lastIndex = 0;
+      for (let marker = markerPattern.exec(text); marker; marker = markerPattern.exec(text)) {
+        if (marker[1] !== effectiveSessionId) foreignMarker = true;
+      }
+    },
+  });
+
+  if (!cursor || cursor.pendingTail || malformed || oversizedLine) return 'inconclusive';
+  if (!header
+    || header.type !== 'session'
+    || !Number.isSafeInteger(header.version)
+    || (header.version as number) < 1
+    || typeof header.id !== 'string'
+    || header.id.length === 0
+    || /[/\\]/.test(header.id)
+    || typeof header.timestamp !== 'string'
+    || header.timestamp.length === 0
+    || typeof header.cwd !== 'string') return 'reject';
+  if (!basename(candidate.path).endsWith(`_${header.id}${JSONL_SUFFIX}`)) return 'reject';
+  try {
+    if (realpathSync(header.cwd) !== canonicalWorkingDir) return 'reject';
+  } catch {
+    return 'reject';
+  }
+  return targetMarker && !foreignMarker ? 'match' : 'reject';
+}
+
+function discoverCandidate(
+  sessionsRootReal: string,
+  effectiveSessionId: string,
+  canonicalWorkingDir: string,
+  limits: OmpLegacyMigrationLimits,
+): { candidate?: Candidate; reason?: 'no-match' | 'ambiguous' | 'inconclusive'; detail?: string } {
+  const rootEntries = readdirSync(sessionsRootReal, { withFileTypes: true });
+  let bucketsSeen = 0;
+  let filesSeen = 0;
+  let totalBytes = 0;
+  const matches: Candidate[] = [];
+
+  for (const entry of rootEntries) {
+    if (entry.name === 'botmux') continue;
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    bucketsSeen++;
+    if (bucketsSeen > limits.maxBuckets) {
+      return { reason: 'inconclusive', detail: 'legacy bucket scan limit exhausted' };
+    }
+    const bucketPath = join(sessionsRootReal, entry.name);
+    const bucketStats = lstatSync(bucketPath);
+    if (bucketStats.isSymbolicLink() || !bucketStats.isDirectory()) {
+      return { reason: 'inconclusive', detail: 'legacy bucket changed during scan' };
+    }
+    const bucketReal = realpathSync(bucketPath);
+    if (dirname(bucketReal) !== sessionsRootReal) {
+      return { reason: 'inconclusive', detail: 'legacy bucket escaped sessions root' };
+    }
+
+    for (const fileEntry of readdirSync(bucketPath, { withFileTypes: true })) {
+      if (!fileEntry.name.endsWith(JSONL_SUFFIX)) continue;
+      filesSeen++;
+      if (filesSeen > limits.maxFiles) {
+        return { reason: 'inconclusive', detail: 'legacy file scan limit exhausted' };
+      }
+      const path = join(bucketPath, fileEntry.name);
+      const stats = lstatSync(path);
+      if (stats.isSymbolicLink() || !stats.isFile()) {
+        return { reason: 'inconclusive', detail: 'unsafe legacy JSONL entry' };
+      }
+      if (stats.size > limits.maxFileBytes) {
+        return { reason: 'inconclusive', detail: 'legacy per-file scan limit exhausted' };
+      }
+      totalBytes += stats.size;
+      if (totalBytes > limits.maxTotalBytes) {
+        return { reason: 'inconclusive', detail: 'legacy total scan limit exhausted' };
+      }
+      const realPath = realpathSync(path);
+      if (dirname(realPath) !== bucketReal || !isStrictDescendant(sessionsRootReal, realPath)) {
+        return { reason: 'inconclusive', detail: 'legacy JSONL escaped its bucket' };
+      }
+
+      let fd: number | undefined;
+      try {
+        fd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW);
+        const opened = fstatSync(fd);
+        if (!opened.isFile()
+          || opened.dev !== stats.dev
+          || opened.ino !== stats.ino
+          || opened.size !== stats.size
+          || opened.mtimeMs !== stats.mtimeMs
+          || opened.ctimeMs !== stats.ctimeMs) {
+          return { reason: 'inconclusive', detail: 'legacy JSONL changed while opening' };
+        }
+        const candidate = { path, realPath, bucketReal, stats };
+        const outcome = scanCandidate(fd, candidate, effectiveSessionId, canonicalWorkingDir, limits);
+        if (outcome === 'inconclusive') {
+          return { reason: 'inconclusive', detail: 'legacy JSONL was malformed or exceeded a line limit' };
+        }
+        if (outcome === 'match') matches.push(candidate);
+      } finally {
+        if (fd !== undefined) closeSync(fd);
+      }
+    }
+  }
+
+  if (matches.length === 0) return { reason: 'no-match' };
+  if (matches.length !== 1) return { reason: 'ambiguous' };
+  return { candidate: matches[0] };
+}
+
+function sameSnapshot(left: Stats, right: Stats): boolean {
+  return left.isFile()
+    && right.isFile()
+    && left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs;
+}
+
+function writeAll(fd: number, buffer: Buffer, length: number): void {
+  let offset = 0;
+  while (offset < length) {
+    const written = writeSync(fd, buffer, offset, length - offset);
+    if (written <= 0) throw new Error('short write while migrating OMP transcript');
+    offset += written;
+  }
+}
+
+function digestFd(fd: number, size: number): string {
+  const digest = createHash('sha256');
+  const buffer = Buffer.allocUnsafe(COPY_CHUNK_BYTES);
+  let offset = 0;
+  while (offset < size) {
+    const count = readSync(fd, buffer, 0, Math.min(buffer.length, size - offset), offset);
+    if (count <= 0) throw new Error('short read while verifying OMP transcript');
+    digest.update(buffer.subarray(0, count));
+    offset += count;
+  }
+  return digest.digest('hex');
+}
+
+function copyCandidate(
+  candidate: Candidate,
+  exactSessionDir: string,
+  sessionsRootReal: string,
+  hooks: OmpLegacyMigrationTestHooks | undefined,
+): { targetPath: string; artifactDirectoryPreserved: boolean } {
+  hooks?.beforeCopy?.(candidate.path);
+  const rescanned = lstatSync(candidate.path);
+  if (!sameSnapshot(rescanned, candidate.stats)
+    || realpathSync(candidate.path) !== candidate.realPath
+    || dirname(candidate.realPath) !== candidate.bucketReal) {
+    throw new Error('legacy OMP source changed after attribution');
+  }
+
+  const botmuxRoot = dirname(exactSessionDir);
+  const botmuxStats = lstatIfPresent(botmuxRoot);
+  if (botmuxStats && (botmuxStats.isSymbolicLink() || !botmuxStats.isDirectory())) {
+    throw new Error('unsafe OMP botmux session root');
+  }
+  if (!botmuxStats) mkdirSync(botmuxRoot, { mode: 0o700 });
+  const botmuxReal = realpathSync(botmuxRoot);
+  if (dirname(botmuxReal) !== sessionsRootReal || basename(botmuxReal) !== 'botmux') {
+    throw new Error('OMP botmux session root escaped sessions root');
+  }
+
+  if (!lstatIfPresent(exactSessionDir)) {
+    mkdirSync(exactSessionDir, { mode: 0o700 });
+  }
+  const targetDirStats = lstatSync(exactSessionDir);
+  if (targetDirStats.isSymbolicLink() || !targetDirStats.isDirectory()) {
+    throw new Error('unsafe exact OMP session directory');
+  }
+  const targetDirReal = realpathSync(exactSessionDir);
+  if (dirname(targetDirReal) !== botmuxReal || basename(targetDirReal) !== basename(exactSessionDir)) {
+    throw new Error('exact OMP session directory escaped botmux root');
+  }
+  if (exactDirectoryState(targetDirReal) !== 'empty') {
+    throw new Error('exact OMP history appeared before copy');
+  }
+
+  const targetPath = join(targetDirReal, basename(candidate.path));
+  const tempPath = join(targetDirReal, `.${basename(candidate.path)}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`);
+  let sourceFd: number | undefined;
+  let tempFd: number | undefined;
+  try {
+    sourceFd = openSync(candidate.path, constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW);
+    const opened = fstatSync(sourceFd);
+    if (!sameSnapshot(opened, candidate.stats)) throw new Error('legacy OMP source raced while opening');
+
+    tempFd = openSync(
+      tempPath,
+      constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | NO_FOLLOW,
+      0o600,
+    );
+    fchmodSync(tempFd, 0o600);
+    const buffer = Buffer.allocUnsafe(COPY_CHUNK_BYTES);
+    const sourceDigest = createHash('sha256');
+    let copiedBytes = 0;
+    while (copiedBytes < opened.size) {
+      const count = readSync(sourceFd, buffer, 0, Math.min(buffer.length, opened.size - copiedBytes), copiedBytes);
+      if (count <= 0) throw new Error('short read while migrating OMP transcript');
+      sourceDigest.update(buffer.subarray(0, count));
+      writeAll(tempFd, buffer, count);
+      copiedBytes += count;
+    }
+    const sourceAfterCopy = fstatSync(sourceFd);
+    if (!sameSnapshot(sourceAfterCopy, opened) || copiedBytes !== opened.size) {
+      throw new Error('legacy OMP source changed while copying');
+    }
+    const tempStats = fstatSync(tempFd);
+    if (!tempStats.isFile() || tempStats.nlink !== 1 || tempStats.size !== copiedBytes
+      || (process.platform !== 'win32' && (tempStats.mode & 0o777) !== 0o600)) {
+      throw new Error('unsafe OMP temporary transcript copy');
+    }
+    fsyncSync(tempFd);
+    const expectedDigest = sourceDigest.digest('hex');
+
+    hooks?.beforePublish?.(targetPath);
+    if (exactDirectoryState(targetDirReal) !== 'empty' || lstatIfPresent(targetPath)) {
+      throw new Error('exact OMP history appeared before publication');
+    }
+    linkSync(tempPath, targetPath);
+    unlinkSync(tempPath);
+    closeSync(tempFd);
+    tempFd = undefined;
+
+    const destinationFd = openSync(targetPath, constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW);
+    try {
+      const destination = fstatSync(destinationFd);
+      if (!destination.isFile() || destination.nlink !== 1 || destination.size !== opened.size
+        || (process.platform !== 'win32' && (destination.mode & 0o777) !== 0o600)
+        || digestFd(destinationFd, destination.size) !== expectedDigest) {
+        throw new Error('published OMP transcript failed identity verification');
+      }
+    } finally {
+      closeSync(destinationFd);
+    }
+    fsyncDirectorySyncPortable(targetDirReal);
+
+    const artifactPath = candidate.path.slice(0, -JSONL_SUFFIX.length);
+    const artifactStats = lstatIfPresent(artifactPath);
+    return {
+      targetPath,
+      artifactDirectoryPreserved: !!artifactStats && !artifactStats.isSymbolicLink() && artifactStats.isDirectory(),
+    };
+  } catch (error) {
+    if (tempFd !== undefined) {
+      try { closeSync(tempFd); } catch { /* best effort */ }
+    }
+    try { unlinkSync(tempPath); } catch { /* absent or already published */ }
+    // Never delete a published destination: it is complete and no-overwrite.
+    // The ordinary exact probe conservatively treats it as present even if a
+    // later durability or verification step fails.
+    throw error;
+  } finally {
+    if (sourceFd !== undefined) {
+      try { closeSync(sourceFd); } catch { /* best effort */ }
+    }
+  }
+}
+
+/**
+ * Copy one uniquely attributable pre-exact-dir OMP transcript into the exact
+ * Botmux directory. Every uncertainty is reported as a skip; the caller then
+ * runs the existing pure exact-path resume probe and fresh fallback.
+ */
+export function migrateLegacyOmpSession(
+  effectiveSessionId: string,
+  workingDir: string,
+  exactSessionDir: string,
+  options: OmpLegacyMigrationOptions = {},
+): OmpLegacyMigrationResult {
+  try {
+    if (!effectiveSessionId || effectiveSessionId === '.' || effectiveSessionId === '..'
+      || /[/\\]/.test(effectiveSessionId)) {
+      return { status: 'skipped', reason: 'inconclusive', detail: 'invalid effective OMP session id' };
+    }
+    const limits = { ...DEFAULT_LIMITS, ...options.limits };
+    if (Object.values(limits).some(value => !Number.isSafeInteger(value) || value < 1)) {
+      return { status: 'skipped', reason: 'inconclusive', detail: 'invalid migration scan limits' };
+    }
+
+    const expectedBotmuxRoot = dirname(exactSessionDir);
+    const sessionsRoot = dirname(expectedBotmuxRoot);
+    if (basename(exactSessionDir) !== effectiveSessionId
+      || basename(expectedBotmuxRoot) !== 'botmux'
+      || resolve(exactSessionDir) !== join(resolve(sessionsRoot), 'botmux', effectiveSessionId)) {
+      return { status: 'skipped', reason: 'inconclusive', detail: 'exact OMP directory does not match effective id' };
+    }
+    const sessionsStats = lstatSync(sessionsRoot);
+    if (sessionsStats.isSymbolicLink() || !sessionsStats.isDirectory()) {
+      return { status: 'skipped', reason: 'inconclusive', detail: 'unsafe OMP sessions root' };
+    }
+    const sessionsRootReal = realpathSync(sessionsRoot);
+    if (sessionsRootReal !== resolve(sessionsRoot)) {
+      return { status: 'skipped', reason: 'inconclusive', detail: 'OMP sessions root is not canonical' };
+    }
+    const canonicalWorkingDir = realpathSync(workingDir);
+    const lockDigest = createHash('sha256').update(exactSessionDir).digest('hex').slice(0, 24);
+    const lockTarget = join(sessionsRootReal, `.botmux-legacy-migration-${lockDigest}`);
+
+    return withFileLockSync(lockTarget, () => {
+      const exactState = exactDirectoryState(exactSessionDir);
+      if (exactState === 'history') return { status: 'skipped', reason: 'exact-history-exists' };
+      if (exactState === 'unsafe') {
+        return { status: 'skipped', reason: 'inconclusive', detail: 'unsafe exact OMP session directory' };
+      }
+
+      const discovered = discoverCandidate(
+        sessionsRootReal,
+        effectiveSessionId,
+        canonicalWorkingDir,
+        limits,
+      );
+      if (!discovered.candidate) {
+        return {
+          status: 'skipped',
+          reason: discovered.reason ?? 'inconclusive',
+          detail: discovered.detail,
+        };
+      }
+      const copied = copyCandidate(
+        discovered.candidate,
+        exactSessionDir,
+        sessionsRootReal,
+        options.testHooks,
+      );
+      return {
+        status: 'migrated',
+        sourcePath: discovered.candidate.path,
+        ...copied,
+      };
+    });
+  } catch (error) {
+    return {
+      status: 'skipped',
+      reason: 'inconclusive',
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/services/omp-transcript.ts
+++ b/src/services/omp-transcript.ts
@@ -41,7 +41,8 @@ export interface OmpDrainOptions {
 
 type OmpTerminalStopReason = 'stop' | 'length' | 'error' | 'aborted';
 
-function visibleText(content: unknown): string {
+/** Canonical text projection for OMP message content. */
+export function ompMessageText(content: unknown): string {
   if (typeof content === 'string') return content.trim();
   if (!Array.isArray(content)) return '';
   const parts: string[] = [];
@@ -220,7 +221,7 @@ export function drainOmpTranscript(
           state = {};
         }
       }
-      const text = visibleText(message.content);
+      const text = ompMessageText(message.content);
       if (text) {
         events.push({
           uuid: `${path}:${lineStart}`,
@@ -251,7 +252,7 @@ export function drainOmpTranscript(
       uuid: `${path}:${lineStart}`,
       timestampMs: timestampMs(entry, message),
       kind: 'assistant_final',
-      text: visibleText(message.content),
+      text: ompMessageText(message.content),
       ...terminalOutcome(stopReason as OmpTerminalStopReason),
     };
     state = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -267,6 +267,7 @@ import { claudeJsonlPathForSession, resolveJsonlFromPid, findOpenClaudeSessionId
 import { sessionReadyHookCommand } from './adapters/hook-command.js';
 import { mtrSessionIdForBotmuxSession } from './adapters/cli/mtr.js';
 import { ompSessionDir } from './adapters/cli/oh-my-pi.js';
+import { migrateLegacyOmpSession } from './services/oh-my-pi-legacy-migration.js';
 import type { CliAdapter, PtyHandle, SubmitRecheckResult, CliId } from './adapters/cli/types.js';
 import { strictInputHandle } from './adapters/cli/strict-input-handle.js';
 import { PtyBackend } from './adapters/backend/pty-backend.js';
@@ -13356,6 +13357,27 @@ async function spawnCli(
       // Preserve the existing fail-safe: the adapter probe / two-tier fallback
       // below still decides whether resume is possible.
       log(`WARN Claude resume transcript sync failed: ${(err as Error).message}`);
+    }
+  }
+  // Pre-exact-dir OMP versions stored transcripts in cwd-derived shared
+  // buckets. Only a cold, non-adopt resume may copy one uniquely attributable
+  // legacy JSONL into the exact effective-id directory. The adapter probe below
+  // intentionally stays synchronous and pure: it only decides whether this
+  // preflight published an exact resume target.
+  if (cfg.cliId === 'oh-my-pi' && effectiveResume && !willReattachPersistent && !cfg.adoptMode) {
+    const exactOmpSessionDir = ompSessionDir(effectiveAdapterSessionId);
+    const migrated = migrateLegacyOmpSession(
+      effectiveAdapterSessionId,
+      cfg.workingDir,
+      exactOmpSessionDir,
+    );
+    if (migrated.status === 'migrated') {
+      log(`OMP legacy resume transcript migrated: ${migrated.sourcePath} → ${migrated.targetPath}`);
+      if (migrated.artifactDirectoryPreserved) {
+        log(`OMP legacy artifact directory preserved outside sandbox: ${migrated.sourcePath.slice(0, -'.jsonl'.length)}`);
+      }
+    } else if (migrated.reason !== 'no-match' && migrated.reason !== 'exact-history-exists') {
+      log(`WARN OMP legacy resume migration skipped (${migrated.reason}${migrated.detail ? `: ${migrated.detail}` : ''})`);
     }
   }
   // Hermes stores sessions in a SQLite state.db (not cwd-scoped JSONL). Resolve

--- a/test/fs-policy-bwrap.e2e.test.ts
+++ b/test/fs-policy-bwrap.e2e.test.ts
@@ -238,14 +238,21 @@ d('bwrap three-tier enforcement (real bubblewrap)', () => {
       const sessionsRoot = join(agentRoot, 'sessions');
       const own = ompSessionDir('self');
       const sibling = join(sessionsRoot, 'botmux/sibling');
+      const legacy = join(sessionsRoot, '-legacy-project');
       const terminalSessions = join(agentRoot, 'terminal-sessions');
       const siblingTranscript = join(sibling, 'secret.jsonl');
+      const legacyTranscript = join(legacy, 'legacy.jsonl');
+      const migratedTranscript = join(own, 'migrated.jsonl');
       const breadcrumb = join(terminalSessions, 'pane');
       expect(own).toBe(join(sessionsRoot, 'botmux/self'));
-      const adapterArgs = createOhMyPiAdapter('/usr/bin/omp').buildArgs({ sessionId: 'self', resume: false });
-      expect(adapterArgs[adapterArgs.indexOf('--session-dir') + 1]).toBe(own);
-
       mkdirSync(own, { recursive: true });
+      mkdirSync(legacy, { recursive: true });
+      writeFileSync(legacyTranscript, 'LEGACY_SECRET');
+      writeFileSync(migratedTranscript, 'MIGRATED_EXACT');
+      const adapterArgs = createOhMyPiAdapter('/usr/bin/omp').buildArgs({ sessionId: 'self', resume: true });
+      expect(adapterArgs[adapterArgs.indexOf('--session-dir') + 1]).toBe(own);
+      expect(adapterArgs[adapterArgs.indexOf('--resume') + 1]).toBe(migratedTranscript);
+
       mkdirSync(sibling, { recursive: true });
       mkdirSync(terminalSessions, { recursive: true });
       writeFileSync(join(agentRoot, 'agent.db'), 'state');
@@ -262,6 +269,7 @@ d('bwrap three-tier enforcement (real bubblewrap)', () => {
 
       expect(run(args, `printf updated >> ${JSON.stringify(join(agentRoot, 'agent.db'))}`).status).toBe(0);
       expect(readFileSync(join(agentRoot, 'agent.db'), 'utf8')).toContain('updated');
+      expect(run(args, `cat ${JSON.stringify(migratedTranscript)}`).out).toContain('MIGRATED_EXACT');
       expect(run(args, `printf own > ${JSON.stringify(join(own, 'new.jsonl'))}`).status).toBe(0);
       expect(readFileSync(join(own, 'new.jsonl'), 'utf8')).toBe('own');
 
@@ -271,6 +279,9 @@ d('bwrap three-tier enforcement (real bubblewrap)', () => {
       const siblingRead = run(args, `cat ${JSON.stringify(siblingTranscript)}`);
       expect(siblingRead.status).not.toBe(0);
       expect(siblingRead.out).not.toContain('SIBLING_SECRET');
+      const legacyRead = run(args, `cat ${JSON.stringify(legacyTranscript)}`);
+      expect(legacyRead.status).not.toBe(0);
+      expect(legacyRead.out).not.toContain('LEGACY_SECRET');
 
       const other = join(sessionsRoot, 'botmux/other');
       expect(run(args, `mkdir ${JSON.stringify(other)}`).status).not.toBe(0);

--- a/test/oh-my-pi-legacy-migration.test.ts
+++ b/test/oh-my-pi-legacy-migration.test.ts
@@ -1,0 +1,284 @@
+import { randomUUID } from 'node:crypto';
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createOhMyPiAdapter, ompSessionDir } from '../src/adapters/cli/oh-my-pi.js';
+import { migrateLegacyOmpSession } from '../src/services/oh-my-pi-legacy-migration.js';
+
+const TS = '2026-08-20T05:47:50.955Z';
+const NATIVE_ID = '01a01db6-232b-7000-aa2e-f9a749493d62';
+
+function row(value: Record<string, unknown>): string {
+  return `${JSON.stringify(value)}\n`;
+}
+
+function transcript(options: {
+  sessionId: string;
+  cwd: string;
+  nativeId?: string;
+  role?: string;
+  markerSessionId?: string;
+  foreignSessionId?: string;
+  titleSlot?: boolean;
+  suffix?: string;
+}): string {
+  const nativeId = options.nativeId ?? NATIVE_ID;
+  const marker = options.markerSessionId ?? options.sessionId;
+  const title = options.titleSlot
+    ? row({ type: 'title', v: 1, title: 'legacy', updatedAt: TS, pad: '' })
+    : '';
+  const markers = [
+    `<session_id>${marker}</session_id>`,
+    options.foreignSessionId ? `<session_id>${options.foreignSessionId}</session_id>` : '',
+  ].filter(Boolean).join('\n');
+  return title
+    + row({ type: 'session', version: 3, id: nativeId, timestamp: TS, cwd: options.cwd })
+    + row({
+      type: 'message',
+      id: randomUUID(),
+      parentId: null,
+      timestamp: TS,
+      message: {
+        role: options.role ?? 'user',
+        content: [{ type: 'text', text: `${markers}\ninline preview artifact://1${options.suffix ?? ''}` }],
+      },
+    });
+}
+
+describe('OMP legacy session migration', () => {
+  let root: string;
+  let home: string;
+  let cwd: string;
+  let sessionsRoot: string;
+  let sessionId: string;
+  let exactDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'botmux-omp-legacy-'));
+    home = join(root, 'home');
+    cwd = join(home, 'repo');
+    sessionsRoot = join(home, '.omp', 'agent', 'sessions');
+    sessionId = 'effective-botmux-session';
+    mkdirSync(cwd, { recursive: true });
+    mkdirSync(sessionsRoot, { recursive: true });
+    vi.stubEnv('HOME', home);
+    exactDir = ompSessionDir(sessionId);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function legacyFile(bucket: string, body: string, nativeId = NATIVE_ID): string {
+    const dir = join(sessionsRoot, bucket);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `2026-08-20T05-47-50-955Z_${nativeId}.jsonl`);
+    writeFileSync(path, body);
+    return path;
+  }
+
+  it('copies one parsed exact user-marker match byte-for-byte with private modes and keeps artifacts legacy-only', () => {
+    const body = transcript({ sessionId, cwd, titleSlot: true });
+    const source = legacyFile('-repo', body);
+    const artifactDir = source.slice(0, -'.jsonl'.length);
+    mkdirSync(artifactDir);
+    writeFileSync(join(artifactDir, '1.bash.log'), 'large legacy tool output');
+    if (process.platform !== 'win32') chmodSync(source, 0o644);
+
+    const result = migrateLegacyOmpSession(sessionId, cwd, exactDir);
+
+    expect(result).toMatchObject({
+      status: 'migrated',
+      sourcePath: source,
+      targetPath: join(exactDir, basename(source)),
+      artifactDirectoryPreserved: true,
+    });
+    if (result.status !== 'migrated') throw new Error('expected migration');
+    expect(readFileSync(result.targetPath)).toEqual(readFileSync(source));
+    expect(readFileSync(source, 'utf8')).toBe(body);
+    if (process.platform !== 'win32') {
+      expect(lstatSync(source).mode & 0o777).toBe(0o644);
+      expect(lstatSync(result.targetPath).mode & 0o777).toBe(0o600);
+      expect(lstatSync(exactDir).mode & 0o777).toBe(0o700);
+    }
+    expect(readFileSync(result.targetPath, 'utf8')).toContain('inline preview artifact://1');
+    expect(readdirSync(exactDir)).toEqual([basename(source)]);
+    expect(readFileSync(join(artifactDir, '1.bash.log'), 'utf8')).toBe('large legacy tool output');
+
+    const args = createOhMyPiAdapter('/usr/bin/omp').buildArgs({ sessionId, resume: true });
+    expect(args[args.indexOf('--resume') + 1]).toBe(result.targetPath);
+    expect(args[args.indexOf('--session-dir') + 1]).toBe(exactDir);
+  });
+
+  it('keeps the adapter exact probe pure until the explicit migration preflight publishes', () => {
+    const adapter = createOhMyPiAdapter('/usr/bin/omp');
+    legacyFile('-repo', transcript({ sessionId, cwd }));
+
+    expect(adapter.checkResumeTargetExists?.({ sessionId })).toBe(false);
+    expect(lstatSync(sessionsRoot).isDirectory()).toBe(true);
+    expect(() => lstatSync(exactDir)).toThrow();
+
+    expect(migrateLegacyOmpSession(sessionId, cwd, exactDir).status).toBe('migrated');
+    expect(adapter.checkResumeTargetExists?.({ sessionId })).toBe(true);
+  });
+
+  it('treats any exact top-level JSONL entry as authoritative and retries idempotently', () => {
+    const source = legacyFile('-repo', transcript({ sessionId, cwd }));
+    const first = migrateLegacyOmpSession(sessionId, cwd, exactDir);
+    expect(first.status).toBe('migrated');
+    const before = readFileSync(source);
+
+    const retry = migrateLegacyOmpSession(sessionId, cwd, exactDir);
+    expect(retry).toEqual({ status: 'skipped', reason: 'exact-history-exists' });
+    expect(readFileSync(source)).toEqual(before);
+    expect(readdirSync(exactDir).filter(name => name.endsWith('.jsonl'))).toHaveLength(1);
+  });
+
+  it('does not choose between a preexisting divergent exact history and legacy history', () => {
+    const source = legacyFile('-repo', transcript({ sessionId, cwd }));
+    mkdirSync(exactDir, { recursive: true });
+    const exact = join(exactDir, 'fresh.jsonl');
+    writeFileSync(exact, 'fresh divergent branch\n');
+
+    expect(migrateLegacyOmpSession(sessionId, cwd, exactDir)).toEqual({
+      status: 'skipped', reason: 'exact-history-exists',
+    });
+    expect(readFileSync(source, 'utf8')).toContain(sessionId);
+    expect(readFileSync(exact, 'utf8')).toBe('fresh divergent branch\n');
+  });
+
+  it('rejects zero, multiple, assistant-only, foreign, cwd, header, and filename mismatches', () => {
+    const cases: Array<[string, () => void, string]> = [
+      ['assistant marker', () => { legacyFile('-a', transcript({ sessionId, cwd, role: 'assistant' })); }, 'no-match'],
+      ['foreign marker', () => { legacyFile('-a', transcript({ sessionId, cwd, foreignSessionId: 'another-session' })); }, 'no-match'],
+      ['cwd mismatch', () => {
+        const other = join(home, 'other');
+        mkdirSync(other);
+        legacyFile('-a', transcript({ sessionId, cwd: other }));
+      }, 'no-match'],
+      ['invalid header', () => { legacyFile('-a', `${row({ type: 'custom' })}${row({ type: 'message' })}`); }, 'no-match'],
+      ['missing header version', () => {
+        legacyFile('-a', transcript({ sessionId, cwd }).replace('"version":3,', ''));
+      }, 'no-match'],
+      ['filename mismatch', () => { legacyFile('-a', transcript({ sessionId, cwd, nativeId: 'different-native' })); }, 'no-match'],
+      ['malformed complete row', () => { legacyFile('-a', `${transcript({ sessionId, cwd })}{bad}\n`); }, 'inconclusive'],
+      ['partial row', () => { legacyFile('-a', `${transcript({ sessionId, cwd })}{"type":`); }, 'inconclusive'],
+    ];
+
+    for (const [name, arrange, reason] of cases) {
+      rmSync(sessionsRoot, { recursive: true, force: true });
+      mkdirSync(sessionsRoot, { recursive: true });
+      arrange();
+      const result = migrateLegacyOmpSession(sessionId, cwd, exactDir);
+      expect(result, name).toMatchObject({ status: 'skipped', reason });
+      expect(() => lstatSync(exactDir), name).toThrow();
+    }
+
+    rmSync(sessionsRoot, { recursive: true, force: true });
+    mkdirSync(sessionsRoot, { recursive: true });
+    legacyFile('-a', transcript({ sessionId, cwd }));
+    legacyFile('-b', transcript({ sessionId, cwd, nativeId: '01a01db6-232b-7000-aa2e-f9a749493d63' }), '01a01db6-232b-7000-aa2e-f9a749493d63');
+    expect(migrateLegacyOmpSession(sessionId, cwd, exactDir)).toMatchObject({
+      status: 'skipped', reason: 'ambiguous',
+    });
+    expect(() => lstatSync(exactDir)).toThrow();
+  });
+
+  it('fails closed for symlink and special JSONL entries', () => {
+    const safe = legacyFile('-safe', transcript({ sessionId, cwd }));
+    const unsafeBucket = join(sessionsRoot, '-unsafe');
+    mkdirSync(unsafeBucket);
+    symlinkSync(safe, join(unsafeBucket, 'linked.jsonl'));
+    expect(migrateLegacyOmpSession(sessionId, cwd, exactDir)).toMatchObject({
+      status: 'skipped', reason: 'inconclusive',
+    });
+    expect(() => lstatSync(exactDir)).toThrow();
+
+    rmSync(unsafeBucket, { recursive: true, force: true });
+    mkdirSync(join(unsafeBucket, 'special.jsonl'), { recursive: true });
+    expect(migrateLegacyOmpSession(sessionId, cwd, exactDir)).toMatchObject({
+      status: 'skipped', reason: 'inconclusive',
+    });
+
+    rmSync(unsafeBucket, { recursive: true, force: true });
+    mkdirSync(exactDir, { recursive: true });
+    symlinkSync(safe, join(exactDir, 'unsafe-exact.jsonl'));
+    expect(migrateLegacyOmpSession(sessionId, cwd, exactDir)).toEqual({
+      status: 'skipped', reason: 'exact-history-exists',
+    });
+  });
+
+  it('never treats another exact Botmux directory as a legacy bucket', () => {
+    const sibling = join(sessionsRoot, 'botmux', 'sibling');
+    mkdirSync(sibling, { recursive: true });
+    writeFileSync(
+      join(sibling, `2026-08-20T05-47-50-955Z_${NATIVE_ID}.jsonl`),
+      transcript({ sessionId, cwd }),
+    );
+    expect(migrateLegacyOmpSession(sessionId, cwd, exactDir)).toEqual({
+      status: 'skipped', reason: 'no-match', detail: undefined,
+    });
+    expect(() => lstatSync(exactDir)).toThrow();
+  });
+
+  it('fails closed when scan budgets are exhausted', () => {
+    legacyFile('-a', transcript({ sessionId, cwd }));
+    legacyFile('-b', transcript({ sessionId: 'other', cwd, nativeId: '01a01db6-232b-7000-aa2e-f9a749493d64' }), '01a01db6-232b-7000-aa2e-f9a749493d64');
+    const result = migrateLegacyOmpSession(sessionId, cwd, exactDir, {
+      limits: { maxBuckets: 1 },
+    });
+    expect(result).toMatchObject({ status: 'skipped', reason: 'inconclusive' });
+    expect(() => lstatSync(exactDir)).toThrow();
+  });
+
+  it('detects source mutation, cleans its temp, and preserves the source', () => {
+    const source = legacyFile('-repo', transcript({ sessionId, cwd }));
+    const result = migrateLegacyOmpSession(sessionId, cwd, exactDir, {
+      testHooks: {
+        beforeCopy: path => writeFileSync(path, `${readFileSync(path, 'utf8')}changed\n`),
+      },
+    });
+    expect(result).toMatchObject({ status: 'skipped', reason: 'inconclusive' });
+    expect(readFileSync(source, 'utf8')).toContain('changed');
+    expect(() => lstatSync(exactDir)).toThrow();
+  });
+
+  it('does not overwrite a concurrent destination and removes only its private temp', () => {
+    const source = legacyFile('-repo', transcript({ sessionId, cwd }));
+    const targetName = basename(source);
+    const result = migrateLegacyOmpSession(sessionId, cwd, exactDir, {
+      testHooks: {
+        beforePublish: targetPath => writeFileSync(targetPath, 'competitor\n'),
+      },
+    });
+    expect(result).toMatchObject({ status: 'skipped', reason: 'inconclusive' });
+    expect(readFileSync(join(exactDir, targetName), 'utf8')).toBe('competitor\n');
+    expect(readFileSync(source, 'utf8')).toContain(sessionId);
+    expect(readdirSync(exactDir).filter(name => name.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('pins the cold-resume worker guard and preflight-before-probe ordering', () => {
+    const worker = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+    const preflight = worker.indexOf("if (cfg.cliId === 'oh-my-pi' && effectiveResume && !willReattachPersistent && !cfg.adoptMode)");
+    const migration = worker.indexOf('migrateLegacyOmpSession(', preflight);
+    const probe = worker.indexOf('cliAdapter.checkResumeTargetExists?.({', migration);
+    expect(preflight).toBeGreaterThan(-1);
+    expect(migration).toBeGreaterThan(preflight);
+    expect(probe).toBeGreaterThan(migration);
+    expect(worker.slice(migration, probe)).toContain('effectiveAdapterSessionId');
+    expect(worker.slice(migration, probe)).toContain('cfg.workingDir');
+  });
+});

--- a/test/structured-bridge-clis.test.ts
+++ b/test/structured-bridge-clis.test.ts
@@ -113,10 +113,15 @@ describe('resolveFileBridgePath (oh-my-pi)', () => {
 
   it('resolves only the newest transcript inside the exact Botmux session directory', () => {
     const dir = join(ROOT, '.omp', 'agent', 'sessions', 'botmux', 'sid-omp');
+    const legacyDir = join(ROOT, '.omp', 'agent', 'sessions', '-legacy-project');
     mkdirSync(dir, { recursive: true });
+    mkdirSync(legacyDir, { recursive: true });
     const path = join(dir, 'session.jsonl');
+    const legacyPath = join(legacyDir, 'legacy.jsonl');
     writeFileSync(path, '');
+    writeFileSync(legacyPath, 'legacy history must not be attached');
     expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sid-omp' })).toBe(path);
+    expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sid-omp' })).not.toBe(legacyPath);
     expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sibling' })).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 背景

#955 起，每个 botmux OMP 会话钉到独立的 exact 目录 `~/.omp/agent/sessions/botmux/<effective-id>/`，resume 只从该目录内的精确 JSONL 读取。但 #955 之前开的会话，transcript 落在旧的 **cwd-derived 共享 bucket**（如 `~/.omp/agent/sessions/-repo/`）——升级后这些老会话 resume 时在 exact 目录找不到记录，退化成 fresh 会话，历史丢失。

## 改动

在**冷（非 adopt）resume** OMP 会话时，于既有 adapter probe 之前插入一个 fail-safe 迁移预检 `migrateLegacyOmpSession`：

1. 扫描旧的共享 bucket，找出**唯一可归属**本 exact 会话的 transcript；
2. 归属靠四重比对——botmux 每条 prompt 注入的 `<session_id>` marker（命中本会话且不含 foreign id）+ header 校验（`type=session`/version/id/timestamp/cwd）+ `header.cwd` 的 realpath 与当前工作目录匹配 + 文件名后缀与内部 native-id 一致；
3. **恰好命中 1 个**才把它原子地拷进 exact 目录（临时文件 `O_CREAT|O_EXCL|O_NOFOLLOW` 0o600 → 边拷边算 sha256 → fsync → `linkSync` 不覆盖发布 → 重开目标复验摘要 → fsync 目录），随后既有 resume 逻辑正常续接历史；
4. **任何不确定**（0/多匹配、文件畸形、symlink、超扫描预算）→ skip → 落回既有 fresh 兜底，**从不 throw 进 spawn 路径**。

配套：`omp-transcript.ts` 的 `visibleText` 提升为导出的 `ompMessageText`（纯加法，迁移侧复用同一文本投影，单一来源）；worker.ts 接线（guard：`cliId==='oh-my-pi' && effectiveResume && !willReattachPersistent && !cfg.adoptMode`）。

## 安全姿态

改动触及沙盒边界 + worker 启动热路径 + 跨会话读，全程 fail-closed / fail-safe：

- 「绝不覆盖已有文件」由 `linkSync`（内核级 EEXIST 不覆盖）保证，发布前存在检查兜底，catch 块只删临时文件、永不删已发布目标；
- symlink/TOCTOU 三层冗余：lstat 守卫 → realpath 逃逸检查 → `O_NOFOLLOW` open + fstat（dev/ino/size/mtime/ctime）快照，copy 前后各复核一次；
- 幂等（exact 目录已有任何顶层 .jsonl 即视为已迁移，短路跳过）；`withFileLockSync` 按 exact 目录 hash 跨进程串行化；扫描预算封顶（256 bucket / 4096 file / 单文件 16MB / 总 128MB / 单行 1MB）；
- 跳过 `botmux` 命名空间目录，绝不把别的 exact 会话误当 legacy bucket。

## 影响面

- **跨 CLI**：迁移逻辑仅在 `cliId==='oh-my-pi'` 下触发，对其余 20+ CLI 完全 no-op；未改动 `adapters/cli/` 共用基类；`ompMessageText` 重命名是纯加法，旧调用点全部改到新名，无外部消费者。
- **跨后端/会话类型**：仅冷启动 resume 路径生效；`adoptMode`、持久后端 reattach（`willReattachPersistent`）、fresh 启动均跳过。
- **跨平台**：daemon 跑 Linux，路径符号常量与 `O_NOFOLLOW` 在 Linux 完备；Windows 上 `NO_FOLLOW=0`（第三层不存在），但不影响生产环境。
- **沙盒**：迁移在 host worker（本就可信）执行，只有通过四重校验的那一份进沙盒；legacy 共享 bucket 本就是 #955 之前的 resume 数据源，未引入新信任边界。

## 测试验证

- `pnpm build` / `tsc --noEmit` 全绿（CI build job SUCCESS）
- 新增 `test/oh-my-pi-legacy-migration.test.ts` 11 例（byte-for-byte 拷贝 + 私有权限、幂等重试、发散 exact 历史不选边、零/多/assistant-only/foreign/cwd/header/filename 全拒、symlink/special fail-closed、预算耗尽、源文件突变 TOCTOU、并发目标不覆盖、worker guard 顺序）
- `test/fs-policy-bwrap.e2e.test.ts` 扩展为真 bubblewrap e2e：迁移文件沙盒内可读、legacy 源不可读
- `test/structured-bridge-clis.test.ts` 补 legacy 桶不被 exact resolve 误挂
- 反向变异验证测试有牙：foreign-marker / cwd / filename / ambiguous / 源突变 TOCTOU / no-overwrite 各自精准触发对应测试失败

## 后续

这是为 #955 升级断层打的**过渡兼容补丁**。待存量老会话自然消解后应移除此逻辑（见 follow-up issue）。
