### PR TITLE
fix(traex): 恢复 live card token 展示

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -1,13 +1,12 @@
 import { execFile } from 'node:child_process';
-import { existsSync, statSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import { promisify } from 'node:util';
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import { parseDebugModelsJson } from './model-catalog-json.js';
 import type { CliAdapter, PtyHandle } from './types.js';
-import { traeStateDbPath, traeSessionsRoot, traeHistoryPath } from '../../services/traex-paths.js';
+import { traeSessionsRoot, traeHistoryPath } from '../../services/traex-paths.js';
 import {
+  findTraexSessionIdByBotmuxSessionId,
   traexHistoryMatchDelta,
   traexHistorySize,
   findTraexRolloutSetByPid,
@@ -30,78 +29,6 @@ import { delay } from '../../utils/timing.js';
  *     exact role=user record in that rollout's post-submit byte delta.
  *   - Skills are installed into ~/.trae/skills.
  */
-
-// -- SQLite helpers (node:sqlite, Node 22+ experimental) -----------------
-
-type DatabaseSyncLike = {
-  prepare(sql: string): StatementSyncLike;
-  close(): void;
-};
-type StatementSyncLike = {
-  get(...params: unknown[]): any;
-  all(...params: unknown[]): any[];
-};
-
-let sqliteModule: { DatabaseSync: new (path: string) => DatabaseSyncLike } | null = null;
-let sqliteLoadAttempted = false;
-
-function loadSqlite(): typeof sqliteModule {
-  if (sqliteLoadAttempted) return sqliteModule;
-  sqliteLoadAttempted = true;
-  // node:sqlite is the built-in experimental SQLite binding available in
-  // Node 22+. The runtime may still reject it (older Node without the
-  // feature); callers treat that as verification-unavailable and fail closed.
-  // 必须走 createRequire：本包是 ESM（"type":"module"），裸 require 是
-  // ReferenceError —— 之前就是被这里的 try/catch 吞掉，导致生产 dist 里
-  // SQLite 提交验证/会话反查整条链路静默失效。
-  try {
-    const req = createRequire(import.meta.url);
-    sqliteModule = req('node:sqlite') as typeof sqliteModule;
-  } catch {
-    sqliteModule = null;
-  }
-  return sqliteModule;
-}
-
-function withDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
-  const mod = loadSqlite();
-  if (!mod) return null;
-  const dbPath = traeStateDbPath();
-  if (!existsSync(dbPath)) return null;
-  let db: DatabaseSyncLike | undefined;
-  try {
-    db = new mod.DatabaseSync(dbPath);
-    return fn(db);
-  } catch {
-    return null;
-  } finally {
-    try { db?.close(); } catch { /* ignore */ }
-  }
-}
-
-/** Adapter-side session-id ownership uses findTraexRolloutSetByPid +
- * traexHistorySidIsOwned directly in writeInput (kept as raw three-state so the
- * enumeration-unavailable case can fast-degrade). The authoritative persist /
- * bridge-attach decision additionally re-checks worker-side via
- * traexHistorySidOwnedByCurrentPid, whose pid resolution is richer than
- * pty.cliPid (and covers the sandbox bwrap-supervisor case). */
-
-
-/** Scan threads backwards for the most recent thread whose first_user_message
- *  references the botmux session id. Used by buildArgs(resume) and
- *  buildResumeCommand to recover a TRAE-native session UUID from a botmux
- *  session id. */
-function latestTraeSessionForBotmuxSession(botmuxSessionId: string): string | undefined {
-  return withDb((db) => {
-    const rows = db.prepare(
-      'SELECT id, first_user_message AS firstMessage FROM threads ORDER BY created_at DESC LIMIT 200',
-    ).all() as { id: string; firstMessage?: string }[];
-    for (const r of rows) {
-      if (r.firstMessage && r.firstMessage.includes(botmuxSessionId)) return r.id;
-    }
-    return undefined;
-  }) ?? undefined;
-}
 
 // -------------------------------------------------------------------------
 
@@ -330,13 +257,13 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
       if (workingDir) baseArgs.push('-C', workingDir);
       if (!resume) return baseArgs;
 
-      const traeSessionId = resumeSessionId ?? latestTraeSessionForBotmuxSession(sessionId);
+      const traeSessionId = resumeSessionId ?? findTraexSessionIdByBotmuxSessionId(sessionId);
       if (!traeSessionId) return baseArgs;
       return ['resume', ...baseArgs, traeSessionId];
     },
 
     buildResumeCommand({ sessionId, cliSessionId }) {
-      const sid = cliSessionId ?? latestTraeSessionForBotmuxSession(sessionId);
+      const sid = cliSessionId ?? findTraexSessionIdByBotmuxSessionId(sessionId);
       if (!sid) return null;
       return `traex resume ${sid}`;
     },

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -36,6 +36,7 @@ import {
   statSync,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -53,7 +54,7 @@ import {
 } from './bridge-fallback-gate.js';
 import { isInternalCodexSessionMeta } from './codex-session-meta.js';
 import { baselineJsonlCursor } from './jsonl-cursor.js';
-import { traeSessionsRoot } from './traex-paths.js';
+import { traeSessionsRoot, traeStateDbPath } from './traex-paths.js';
 
 export { splitCodexEventsByCutoff as splitTraexEventsByCutoff };
 export { extractLastCodexTurn as extractLastTraexTurn };
@@ -87,6 +88,45 @@ export interface TraexRuntimeSnapshot {
 
 const IS_LINUX = platform() === 'linux';
 const TRAEX_SESSION_META_SCAN_MAX_BYTES = 4 * 1024 * 1024;
+
+type DatabaseSyncLike = {
+  prepare(sql: string): StatementSyncLike;
+  close(): void;
+};
+type StatementSyncLike = {
+  all(...params: unknown[]): any[];
+};
+
+let sqliteModule: { DatabaseSync: new (path: string) => DatabaseSyncLike } | null = null;
+let sqliteLoadAttempted = false;
+
+function loadSqlite(): typeof sqliteModule {
+  if (sqliteLoadAttempted) return sqliteModule;
+  sqliteLoadAttempted = true;
+  try {
+    const req = createRequire(import.meta.url);
+    sqliteModule = req('node:sqlite') as typeof sqliteModule;
+  } catch {
+    sqliteModule = null;
+  }
+  return sqliteModule;
+}
+
+function withTraeDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
+  const mod = loadSqlite();
+  if (!mod) return null;
+  const dbPath = traeStateDbPath();
+  if (!existsSync(dbPath)) return null;
+  let db: DatabaseSyncLike | undefined;
+  try {
+    db = new mod.DatabaseSync(dbPath);
+    return fn(db);
+  } catch {
+    return null;
+  } finally {
+    try { db?.close(); } catch { /* ignore */ }
+  }
+}
 
 type TraexRolloutKind = 'user' | 'internal' | 'legacy' | 'empty' | 'pending';
 
@@ -837,4 +877,26 @@ export function findTraexRolloutBySessionId(cliSessionId: string): string | unde
     }
   }
   return undefined;
+}
+
+
+/** Find the newest TRAE native session whose first prompt contains Botmux's
+ *  session id. This mirrors Codex's history.jsonl bridge, but TRAE keeps the
+ *  mapping in the `threads` SQLite table. It is intentionally best-effort:
+ *  callers fall back to treating `sessionId` as a native id when unavailable. */
+export function findTraexSessionIdByBotmuxSessionId(botmuxSessionId: string): string | undefined {
+  if (!botmuxSessionId) return undefined;
+  return withTraeDb((db) => {
+    const rows = db.prepare(
+      'SELECT id, first_user_message AS firstMessage FROM threads ORDER BY created_at DESC LIMIT 200',
+    ).all() as { id?: string; firstMessage?: string }[];
+    for (const r of rows) {
+      if (typeof r.id === 'string'
+        && typeof r.firstMessage === 'string'
+        && r.firstMessage.includes(botmuxSessionId)) {
+        return r.id;
+      }
+    }
+    return undefined;
+  }) ?? undefined;
 }

--- a/src/services/transcript-resolver.ts
+++ b/src/services/transcript-resolver.ts
@@ -9,7 +9,7 @@ import { findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId } from
 import { codexHome as configuredCodexHome } from './codex-paths.js';
 import { cocoEventsPathForSession } from './coco-transcript.js';
 import { findCursorTranscriptByChatId } from './cursor-transcript.js';
-import { findTraexRolloutBySessionId } from './traex-transcript.js';
+import { findTraexRolloutBySessionId, findTraexSessionIdByBotmuxSessionId } from './traex-transcript.js';
 import { findPiTranscriptBySessionId } from './pi-transcript.js';
 import { findGrokUpdatesBySessionId } from './grok-transcript.js';
 
@@ -323,7 +323,13 @@ export function resolveSessionTranscriptPath(q: TranscriptPathQuery): ResolvedTr
       return path ? { path, kind: 'cursor' } : null;
     }
     case 'traex': {
-      const path = cachedTranscriptPathLookup(`traex:${sid}`, null, () => findTraexRolloutBySessionId(sid) ?? null, { retryMiss: q.fresh });
+      const path = cachedTranscriptPathLookup(`traex:${q.sessionId}:${q.cliSessionId ?? ''}`, null, () => {
+        const mappedSid = q.cliSessionId
+          ? undefined
+          : findTraexSessionIdByBotmuxSessionId(q.sessionId);
+        const traexSid = q.cliSessionId || mappedSid || q.sessionId;
+        return findTraexRolloutBySessionId(traexSid) ?? null;
+      }, { retryMiss: q.fresh });
       return path ? { path, kind: 'traex' } : null;
     }
     case 'grok': {

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -71,6 +71,7 @@ vi.mock('../src/services/codex-transcript.js', () => ({
 
 vi.mock('../src/services/traex-transcript.js', () => ({
   findTraexRolloutBySessionId: vi.fn(() => undefined),
+  findTraexSessionIdByBotmuxSessionId: vi.fn(() => undefined),
 }));
 
 vi.mock('../src/services/pi-transcript.js', () => ({
@@ -111,7 +112,7 @@ vi.mock('../src/adapters/cli/registry.js', () => ({
 import { existsSync, readFileSync } from 'node:fs';
 import { findAidenLatestCheckpointByBotmuxSessionId, findAidenLatestCheckpointBySessionId } from '../src/services/aiden-checkpoints.js';
 import { findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId } from '../src/services/codex-transcript.js';
-import { findTraexRolloutBySessionId } from '../src/services/traex-transcript.js';
+import { findTraexRolloutBySessionId, findTraexSessionIdByBotmuxSessionId } from '../src/services/traex-transcript.js';
 import { findPiTranscriptBySessionId } from '../src/services/pi-transcript.js';
 import {
   getSessionJsonlPath,
@@ -164,6 +165,8 @@ beforeEach(() => {
   vi.mocked(findCodexSessionIdByBotmuxSessionId).mockReturnValue(undefined);
   vi.mocked(findTraexRolloutBySessionId).mockReset();
   vi.mocked(findTraexRolloutBySessionId).mockReturnValue(undefined);
+  vi.mocked(findTraexSessionIdByBotmuxSessionId).mockReset();
+  vi.mocked(findTraexSessionIdByBotmuxSessionId).mockReturnValue(undefined);
   vi.mocked(findPiTranscriptBySessionId).mockReset();
   vi.mocked(findPiTranscriptBySessionId).mockReturnValue(undefined);
   vi.mocked(findAidenLatestCheckpointBySessionId).mockReset();
@@ -798,6 +801,30 @@ describe('getSessionTokenUsage', () => {
       context: { usedTokens: 90, windowTokens: 1_000, percentUsed: 9 },
       tokens: { in: 120, out: 12 },
     });
+  });
+
+  it('maps Botmux session ids to TraeX native session ids for usage lookup', () => {
+    vi.mocked(findTraexSessionIdByBotmuxSessionId).mockReturnValue('mapped-traex-sid');
+    vi.mocked(findTraexRolloutBySessionId).mockReturnValue('/home/testuser/.trae/cli/sessions/2026/06/30/rollout-mapped-traex-sid.jsonl');
+    setupJsonl(JSON.stringify({
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: {
+          total_token_usage: { input_tokens: 55, output_tokens: 6 },
+        },
+      },
+    }));
+
+    expect(getSessionTokenUsage({
+      cliId: 'traex',
+      sessionId: 'botmux-sid',
+    })).toMatchObject({
+      in: 55,
+      out: 6,
+    });
+    expect(findTraexSessionIdByBotmuxSessionId).toHaveBeenCalledWith('botmux-sid');
+    expect(findTraexRolloutBySessionId).toHaveBeenCalledWith('mapped-traex-sid');
   });
 
   it('reports TraeX rollouts via the codex fold, capturing the turn_context model', () => {


### PR DESCRIPTION
## Summary
- Add a shared TraeX SQLite `threads.first_user_message` lookup from Botmux session id to native TraeX session id.
- Use that mapping in transcript resolution so live-card token usage works even when older sessions did not persist `cliSessionId`.
- Reuse the shared mapping in the TraeX adapter resume path instead of keeping duplicate local lookup code.
- Keep the latest `drainTraexRollout` user-turn semantics from upstream master unchanged; no longer reintroduces `response_item role=user` as user-turn evidence.

## Feishu doc
https://bytedance.larkoffice.com/docx/Swa0d4GOFovsddxSl9ecf7ben11

## Verification
- `python /home/shenpeng.sp0916/.agents/skills/mr-diff-guard/scripts/check_diff_allowlist.py --base origin/master --allow '^src/adapters/cli/traex\.ts$' --allow '^src/services/traex-transcript\.ts$' --allow '^src/services/transcript-resolver\.ts$' --allow '^test/cost-calculator\.test\.ts$'`
- `git diff --check origin/master`
- `pnpm exec vitest run --project unit test/cost-calculator.test.ts test/traex-transcript.test.ts` — 102 passed
- `pnpm run build`

## Review status
- Rebased/squashed onto upstream `master` at `d910f835`.
- PR is mergeable after branch update.
- Independent local review by Developer: PASS.
