### PR TITLE
fix(cursor): survive login delay and promote queued follow-ups

### DIFF
--- a/src/adapters/cli/cursor.ts
+++ b/src/adapters/cli/cursor.ts
@@ -142,10 +142,22 @@ export function createCursorAdapter(pathOverride?: string): CliAdapter {
     },
 
     completionPattern: undefined,
-    // Verified on Cursor Agent 2026.08.11. This is the real mounted composer,
-    // unlike the browser-login and startup screens. Once it has appeared at
-    // least once the worker may safely type-ahead subsequent Lark messages.
-    readyPattern: /→\s+Plan, search, build anything/,
+    // The mounted composer's placeholder, matched to prove the real input box
+    // exists (unlike the browser-login and startup screens). Once it has
+    // appeared at least once the worker may safely type-ahead subsequent Lark
+    // messages.
+    //
+    // BOTH placeholder states must match. Cursor Agent 2026.08.11 picks the
+    // placeholder as `sessionEmpty ? "Plan, search, build anything" : "Add a
+    // follow-up"` and never switches back once the chat has any history. The
+    // worker resets the IdleDetector (clearing readySeen) before every write,
+    // and the IdleDetector suppresses quiescence-idle until readyPattern is seen
+    // again — so a first-turn-only pattern would match on turn 1 but never on
+    // turn 2+, leaving the CLI stuck reporting "working" forever (quiescence
+    // permanently suppressed, no idle edge). Matching the post-turn placeholder
+    // too keeps every turn's idle edge alive. Neither placeholder appears on the
+    // login/startup screens, so the boot-time guard is unchanged.
+    readyPattern: /→\s+(?:Plan, search, build anything|Add a follow-up)/,
     deferFirstPromptTimeoutUntilReady: true,
     supportsTypeAhead: true,
     skillsDir: '~/.cursor/skills',

--- a/src/adapters/cli/cursor.ts
+++ b/src/adapters/cli/cursor.ts
@@ -20,7 +20,7 @@ export function createCursorAdapter(pathOverride?: string): CliAdapter {
     id: 'cursor',
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
-    buildArgs({ resume, resumeSessionId, model, disableCliBypass }) {
+    buildArgs({ resume, resumeSessionId, initialPrompt, model, disableCliBypass }) {
       // --trust pre-answers the "Workspace Trust Required" startup dialog.
       // Without it, the first spawn in a never-trusted directory (= every
       // fresh-worktree topic) blocks on that dialog; the dialog sits silent,
@@ -40,8 +40,15 @@ export function createCursorAdapter(pathOverride?: string): CliAdapter {
       if (model && model.trim()) {
         base.push('--model', model.trim());
       }
-      if (!resume) return base;
-      if (resumeSessionId) return [...base, '--resume', resumeSessionId];
+      if (!resume) {
+        if (initialPrompt) base.push(initialPrompt);
+        return base;
+      }
+      if (resumeSessionId) {
+        base.push('--resume', resumeSessionId);
+        if (initialPrompt) base.push(initialPrompt);
+        return base;
+      }
       // No persisted chat id: start FRESH, never `--continue`. Cursor's
       // `--continue` (= `--resume=-1`) resumes the globally most recent chat,
       // which is shared across every botmux session of this bot (same Cursor
@@ -50,8 +57,15 @@ export function createCursorAdapter(pathOverride?: string): CliAdapter {
       // topic group's context leaking into a private chat. Losing this
       // session's context is the lesser evil; matches reasonix/antigravity,
       // which reject `--continue` for the same "most recent is racy" reason.
+      if (initialPrompt) base.push(initialPrompt);
       return base;
     },
+
+    // Cursor accepts a positional prompt and does not hand it to the TUI until
+    // authentication and startup have completed. Keep the opening turn on that
+    // path: writing it to the PTY after the worker's bounded startup timeout can
+    // otherwise feed the prompt into a still-active browser-login flow.
+    passesInitialPromptViaArgs: true,
 
     buildResumeCommand({ cliSessionId }) {
       // Cursor's chat id is opaque and not derivable from botmux's sessionId;
@@ -119,9 +133,21 @@ export function createCursorAdapter(pathOverride?: string): CliAdapter {
       }
       await delay(200);
       emitEnter();
+      // While Cursor is running a turn, the first Enter parks the text in its
+      // "follow-ups" panel ("enter steer"). A second Enter promotes that item
+      // into the active agent turn. At an idle empty composer the extra Enter
+      // is a no-op, so use the same sequence for serial and type-ahead writes.
+      await delay(200);
+      emitEnter();
     },
 
     completionPattern: undefined,
+    // Verified on Cursor Agent 2026.08.11. This is the real mounted composer,
+    // unlike the browser-login and startup screens. Once it has appeared at
+    // least once the worker may safely type-ahead subsequent Lark messages.
+    readyPattern: /→\s+Plan, search, build anything/,
+    deferFirstPromptTimeoutUntilReady: true,
+    supportsTypeAhead: true,
     skillsDir: '~/.cursor/skills',
     systemHints: BOTMUX_SHELL_HINTS,
     altScreen: true,

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -831,11 +831,17 @@ describe('cursor buildArgs', () => {
   const adapter = createCursorAdapter('/usr/bin/cursor-agent');
 
   it('fresh session passes trust/force/model flags without resume flags', () => {
-    const args = adapter.buildArgs({ sessionId: 'sess-cursor', resume: false, model: 'gpt-5' });
+    const args = adapter.buildArgs({
+      sessionId: 'sess-cursor',
+      resume: false,
+      initialPrompt: 'first Lark turn',
+      model: 'gpt-5',
+    });
     expect(args).toContain('--trust');
     expect(args).toContain('--force');
     expect(args).toContain('--model');
     expect(args).toContain('gpt-5');
+    expect(args.at(-1)).toBe('first Lark turn');
     expect(args).not.toContain('--resume');
     expect(args).not.toContain('--continue');
   });
@@ -846,11 +852,13 @@ describe('cursor buildArgs', () => {
       sessionId: 'sess-cursor',
       resume: true,
       resumeSessionId: chatId,
+      initialPrompt: 'resume turn',
     });
     expect(args).toContain('--trust');
     expect(args).toContain('--resume');
     const idx = args.indexOf('--resume');
     expect(args[idx + 1]).toBe(chatId);
+    expect(args.at(-1)).toBe('resume turn');
     expect(args).not.toContain('--continue');
   });
 
@@ -874,6 +882,13 @@ describe('cursor buildArgs', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-cursor', resume: false, disableCliBypass: true });
     expect(args).toContain('--trust');
     expect(args).not.toContain('--force');
+  });
+
+  it('delivers the opening prompt through argv and enables post-ready type-ahead', () => {
+    expect(adapter.passesInitialPromptViaArgs).toBe(true);
+    expect(adapter.readyPattern?.test('  → Plan, search, build anything')).toBe(true);
+    expect(adapter.deferFirstPromptTimeoutUntilReady).toBe(true);
+    expect(adapter.supportsTypeAhead).toBe(true);
   });
 });
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -890,6 +890,20 @@ describe('cursor buildArgs', () => {
     expect(adapter.deferFirstPromptTimeoutUntilReady).toBe(true);
     expect(adapter.supportsTypeAhead).toBe(true);
   });
+
+  it('readyPattern matches BOTH the empty-session and post-turn composer placeholders', () => {
+    // Cursor Agent 2026.08.11 renders `sessionEmpty ? "Plan, search, build
+    // anything" : "Add a follow-up"` and never reverts. The worker resets the
+    // IdleDetector (clearing readySeen) before every write, and quiescence-idle
+    // is suppressed until readyPattern is seen again — so if the pattern only
+    // matched the empty-session placeholder, turn 2+ would never re-seed ready
+    // and the CLI would be stuck reporting "working" forever. Both must match.
+    expect(adapter.readyPattern?.test('  → Plan, search, build anything')).toBe(true);
+    expect(adapter.readyPattern?.test('  → Add a follow-up')).toBe(true);
+    // Guard against over-broad matching: the arrow-prefixed composer glyph is
+    // required, so unrelated screen text with the phrase must not false-match.
+    expect(adapter.readyPattern?.test('Plan, search, build anything')).toBe(false);
+  });
 });
 
 describe('genius buildArgs', () => {

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { IdleDetector } from '../src/utils/idle-detector.js';
 import type { CliAdapter } from '../src/adapters/cli/types.js';
 import { createCocoAdapter } from '../src/adapters/cli/coco.js';
+import { createCursorAdapter } from '../src/adapters/cli/cursor.js';
 import { createGeniusAdapter } from '../src/adapters/cli/genius.js';
 import { createGrokAdapter } from '../src/adapters/cli/grok.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
@@ -826,6 +827,39 @@ describe('IdleDetector: quiescence detection', () => {
     detector.feed('READY>');
     vi.advanceTimersByTime(2000);
     expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  // Regression (PR #996 P0): cursor-agent renders `sessionEmpty ? "Plan,
+  // search, build anything" : "Add a follow-up"` and never reverts. The worker
+  // reset()s the detector before every write (clearing readySeen), and
+  // quiescence stays suppressed until readyPattern is seen again. A
+  // first-turn-only readyPattern therefore matched on turn 1 but never on turn
+  // 2+, so idle never fired again and the CLI was stuck reporting "working".
+  // With the real cursor adapter's two-state readyPattern, every turn's idle
+  // edge survives the reset.
+  it('cursor: idle still fires on turn 2+ after the composer placeholder switches', () => {
+    const detector = new IdleDetector(createCursorAdapter('/bin/cursor-agent'));
+    const cb = vi.fn();
+    detector.onIdle(cb);
+
+    // Turn 1: empty-session composer.
+    detector.feed('  → Plan, search, build anything');
+    vi.advanceTimersByTime(2000);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Worker resets before writing the next turn's input (clears readySeen).
+    detector.reset();
+
+    // Turn 2: cursor now shows the post-turn placeholder. The bug: this never
+    // matched a first-turn-only pattern, so readySeen stayed false and idle
+    // never fired. The fix: the two-state pattern matches, idle fires again.
+    detector.feed('working on it...');
+    vi.advanceTimersByTime(2000);
+    expect(cb, 'quiescence must stay suppressed until the post-turn composer is seen').toHaveBeenCalledTimes(1);
+    detector.feed('  → Add a follow-up');
+    vi.advanceTimersByTime(2000);
+    expect(cb, 'turn-2 idle must fire on the post-turn "Add a follow-up" placeholder').toHaveBeenCalledTimes(2);
     detector.dispose();
   });
 });

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -47,6 +47,7 @@ import {
 import { createAidenAdapter } from '../src/adapters/cli/aiden.js';
 import { createCocoAdapter } from '../src/adapters/cli/coco.js';
 import { createCodexAdapter } from '../src/adapters/cli/codex.js';
+import { createCursorAdapter } from '../src/adapters/cli/cursor.js';
 import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 import { createGeminiAdapter } from '../src/adapters/cli/gemini.js';
 import { createGeniusAdapter } from '../src/adapters/cli/genius.js';
@@ -665,6 +666,44 @@ describe('writeInput: edge cases', () => {
     const pty = makeTmuxPty();
     await adapter.writeInput(pty, '');
     expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+
+  it('cursor: submits then activates the follow-up steer action in tmux', async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter = createCursorAdapter('/bin/cursor-agent');
+      const pty = makeTmuxPty();
+      const write = adapter.writeInput(pty, 'steer this turn');
+      await vi.runAllTimersAsync();
+      await write;
+
+      expect(pty.sendText).toHaveBeenCalledWith('steer this turn');
+      expect(pty.sendSpecialKeys.mock.calls).toEqual([
+        ['Enter'],
+        ['Enter'],
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cursor: submits then activates follow-up steering in raw PTY mode', async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter = createCursorAdapter('/bin/cursor-agent');
+      const pty = makeRawPty();
+      const write = adapter.writeInput(pty, 'steer raw turn');
+      await vi.runAllTimersAsync();
+      await write;
+
+      expect(pty.write.mock.calls.map(c => c[0])).toEqual([
+        'steer raw turn',
+        '\r',
+        '\r',
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('kimi: settles only the first write for each backend instance', async () => {


### PR DESCRIPTION
## Summary
- Pass the opening Lark turn as a positional `cursor-agent` argument and hold later writes until the real composer (`→ Plan, search, build anything`) appears, so a long browser-login no longer swallows the first message.
- After each typed message, send Enter twice: the first parks text in Cursor's follow-ups panel, the second steers it into the active turn (idle composer treats the extra Enter as a no-op).
- Enable `supportsTypeAhead` / `deferFirstPromptTimeoutUntilReady` on the Cursor adapter so subsequent Feishu messages are not stuck in botmux's pending queue.

## Test plan
- [ ] Fresh Cursor session: start a topic while login/startup is still running; confirm the first Feishu message lands as the agent prompt after the TUI is ready, not in the login UI.
- [ ] Mid-turn follow-up: send a second Feishu message while Cursor is still generating; confirm it is steered into the active turn instead of sitting in the follow-ups queue.
- [ ] Idle composer: send a message when Cursor is idle; confirm a single extra Enter does not submit an empty prompt.
- [ ] Adapter unit coverage: `cursor buildArgs` + `writeInput` double-Enter cases in `test/cli-adapters.test.ts` and `test/write-input.test.ts`.