### PR TITLE
fix(traex): 识别 item_completed 用户事件，修复 adopt 回合静默丢失

### DIFF
--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -3,9 +3,11 @@
  *
  * TRAE is a Codex-family CLI, but its terminal event is NOT byte-identical to
  * upstream Codex:
- *   - genuine user input is confirmed by event_msg `user_message`; TRAE also
- *     writes internal runtime injections as response_item role=user messages,
- *     so those records alone are not user-attribution evidence;
+ *   - genuine user input is confirmed by event_msg `user_message` or, in
+ *     TraeX 0.201.4 rollout dialect, event_msg `item_completed` with a
+ *     `UserMessage` item; TRAE also writes internal runtime injections as
+ *     response_item role=user messages, so those records alone are not
+ *     user-attribution evidence;
  *   - assistant response_item messages have no `phase` and are emitted many
  *     times during tool use, so none of them is a safe turn boundary;
  *   - event_msg `task_complete` is the durable end-of-turn marker and carries
@@ -121,6 +123,48 @@ interface TraexPendingAgentMessages {
 const traexPendingAgentCache = new Map<string, TraexPendingAgentMessages>();
 const TRAEX_PENDING_AGENT_CACHE_MAX = 512;
 
+/** New and legacy user event dialects can mirror one another in the same
+ * rollout. Keep de-duplication scoped to a rollout and its stable turn id:
+ * identical prompts in distinct turns must remain distinct local turns. */
+const traexSeenUserTurns = new Map<string, Set<string>>();
+const TRAEX_SEEN_USER_TURN_PATHS_MAX = 512;
+const TRAEX_SEEN_USER_TURNS_PER_PATH_MAX = 4096;
+
+function claimTraexUserTurn(path: string, turnId: unknown): boolean {
+  if (typeof turnId !== 'string' || turnId.length === 0) return true;
+  let seen = traexSeenUserTurns.get(path);
+  if (!seen) {
+    seen = new Set<string>();
+    traexSeenUserTurns.set(path, seen);
+    if (traexSeenUserTurns.size > TRAEX_SEEN_USER_TURN_PATHS_MAX) {
+      const oldestPath = traexSeenUserTurns.keys().next().value;
+      if (oldestPath) traexSeenUserTurns.delete(oldestPath);
+    }
+  }
+  if (seen.has(turnId)) return false;
+  seen.add(turnId);
+  if (seen.size > TRAEX_SEEN_USER_TURNS_PER_PATH_MAX) {
+    const oldestTurnId = seen.keys().next().value;
+    if (oldestTurnId) seen.delete(oldestTurnId);
+  }
+  return true;
+}
+
+function itemCompletedUserText(item: unknown): string {
+  if (!item || typeof item !== 'object') return '';
+  const record = item as { type?: unknown; content?: unknown };
+  if (record.type !== 'UserMessage' || !Array.isArray(record.content)) return '';
+  const parts: string[] = [];
+  for (const block of record.content) {
+    if (!block || typeof block !== 'object') continue;
+    const textBlock = block as { type?: unknown; text?: unknown };
+    if (textBlock.type === 'text' && typeof textBlock.text === 'string') {
+      parts.push(textBlock.text);
+    }
+  }
+  return parts.join('');
+}
+
 function traexPendingAgentState(path: string): TraexPendingAgentMessages {
   let state = traexPendingAgentCache.get(path);
   if (!state) {
@@ -228,6 +272,16 @@ export function drainTraexRollout(
   const sourceSessionId = codexSessionIdFromRolloutPath(path);
 
   const events: CodexBridgeEvent[] = [];
+  const seenUserTurns = new Set<string>();
+  const legacyUserIndexesWithoutTurnId = new Map<string, number>();
+  const claimUserTurn = (turnId: unknown): boolean => {
+    if (typeof turnId !== 'string' || turnId.length === 0) return true;
+    if (seenUserTurns.has(turnId)) return false;
+    seenUserTurns.add(turnId);
+    // Probes must not consume the persistent de-duplication claim that the
+    // production drainer needs when it observes this same record later.
+    return probe || claimTraexUserTurn(path, turnId);
+  };
   let latestModel: string | undefined;
   let latestReasoningEffort: string | undefined;
   let cursor = start;
@@ -254,7 +308,33 @@ export function drainTraexRollout(
       && payload.type === 'user_message'
       && typeof payload.message === 'string') {
       const userText = payload.message;
-      if (userText) {
+      if (userText && claimUserTurn(payload.turn_id)) {
+        events.push({ ...base, kind: 'user', text: userText });
+        if (typeof payload.turn_id !== 'string' || payload.turn_id.length === 0) {
+          legacyUserIndexesWithoutTurnId.set(userText, events.length - 1);
+        }
+        // New turn: drop any agent_message state an unterminated predecessor
+        // left behind so it can't be attributed to this turn.
+        if (!probe) traexPendingAgentCache.delete(path);
+      }
+      continue;
+    }
+    if (obj.type === 'event_msg'
+      && payload.type === 'item_completed') {
+      const userText = itemCompletedUserText(payload.item);
+      if (userText && claimUserTurn(payload.turn_id)) {
+        // Legacy user_message records did not always carry a turn id. When
+        // the same drain also contains their 0.201.4 UserMessage mirror,
+        // replace the uncorrelatable legacy event with the turn-addressable
+        // item_completed event instead of starting two local turns.
+        const legacyIndex = legacyUserIndexesWithoutTurnId.get(userText);
+        if (legacyIndex !== undefined) {
+          events.splice(legacyIndex, 1);
+          legacyUserIndexesWithoutTurnId.delete(userText);
+          for (const [text, index] of legacyUserIndexesWithoutTurnId) {
+            if (index > legacyIndex) legacyUserIndexesWithoutTurnId.set(text, index - 1);
+          }
+        }
         events.push({ ...base, kind: 'user', text: userText });
         // New turn: drop any agent_message state an unterminated predecessor
         // left behind so it can't be attributed to this turn.
@@ -306,6 +386,7 @@ export function drainTraexRollout(
             : '';
       }
       if (!probe) traexPendingAgentCache.delete(path);
+      legacyUserIndexesWithoutTurnId.clear();
       events.push({
         ...base,
         kind: 'assistant_final',
@@ -331,6 +412,7 @@ export function drainTraexRollout(
       && typeof payload.turn_id === 'string'
       && payload.turn_id.length > 0) {
       if (!probe) traexPendingAgentCache.delete(path);
+      legacyUserIndexesWithoutTurnId.clear();
       events.push({
         ...base,
         kind: 'assistant_final',
@@ -431,8 +513,8 @@ function normaliseInputText(text: string): string {
   return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
-/** Submit-confirmation probe: only a complete event_msg/user_message record
- * appended after `fromOffset` can match. Read-only — drains with `probe` so
+/** Submit-confirmation probe: only a complete user event record appended after
+ * `fromOffset` can match. Read-only — drains with `probe` so
  * it never mutates the per-turn agent_message cache the production drainer
  * relies on (a re-drain of the same live rollout at a different offset must
  * not clear pending turn state). Not currently wired into the production

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -39,6 +39,24 @@ function user(text: string, timestamp = '2000-01-01T00:00:01.000Z') {
   };
 }
 
+function itemCompleted(
+  item: { type: string; id: string; content: Array<{ type: string; text: string }> },
+  turnId = '00000000-0000-7000-8000-000000000010',
+  timestamp = '2000-01-01T00:00:01.000Z',
+) {
+  return {
+    timestamp,
+    type: 'event_msg',
+    payload: {
+      type: 'item_completed',
+      thread_id: SID,
+      turn_id: turnId,
+      item,
+      completed_at_ms: Date.parse(timestamp),
+    },
+  };
+}
+
 function userResponseItem(text: string, timestamp = '2000-01-01T00:00:01.000Z') {
   return {
     timestamp,
@@ -232,6 +250,129 @@ describe('drainTraexRollout', () => {
         text: 'durable final answer',
         sourceSessionId: SID,
       }),
+    ]);
+  });
+
+  it('closes a TraeX 0.201.4 item_completed user turn in adopt mode', () => {
+    // Production change that must fail this test: stop accepting the explicit
+    // UserMessage item_completed shape emitted by TraeX 0.201.4.
+    const turnId = '00000000-0000-7000-8000-000000000111';
+    writeFileSync(path, [
+      line({
+        timestamp: '2000-01-01T00:00:00.999Z',
+        type: 'history_mutation',
+        payload: {
+          turn_id: turnId,
+          operation: 'append',
+          items: [{
+            type: 'message',
+            id: 'msg-user',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'probe from adopted terminal' }],
+          }],
+        },
+      }),
+      line(itemCompleted({
+        type: 'UserMessage',
+        id: 'msg-user',
+        content: [{ type: 'text', text: 'probe from adopted terminal' }],
+      }, turnId)),
+      line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent',
+        content: [{ type: 'Text', text: 'tool progress must not start a turn' }],
+      }, turnId, '2000-01-01T00:00:02.000Z')),
+      line({
+        timestamp: '2000-01-01T00:00:03.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: turnId,
+          last_agent_message: 'delivered final',
+        },
+      }),
+    ].join(''));
+
+    const queue = new CodexBridgeQueue();
+    queue.setLocalTurns(true, 0);
+    queue.ingest(drainTraexRollout(path, 0, { adoptMode: true }).events);
+
+    expect(queue.drainEmittable()).toEqual([
+      expect.objectContaining({
+        isLocal: true,
+        userText: 'probe from adopted terminal',
+        finalText: 'delivered final',
+      }),
+    ]);
+  });
+
+  it('does not double-count mixed user_message and item_completed dialects for one turn', () => {
+    const turnId = '00000000-0000-7000-8000-000000000112';
+    writeFileSync(path, [
+      line({
+        timestamp: '2000-01-01T00:00:01.000Z',
+        type: 'event_msg',
+        payload: { type: 'user_message', turn_id: turnId, message: 'same turn' },
+      }),
+      line(itemCompleted({
+        type: 'UserMessage',
+        id: 'msg-user',
+        content: [{ type: 'text', text: 'same turn' }],
+      }, turnId, '2000-01-01T00:00:01.001Z')),
+      line(taskComplete('done')),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.filter(event => event.kind === 'user')).toHaveLength(1);
+  });
+
+  it('does not double-count a legacy user_message without turn_id before its item_completed mirror', () => {
+    const turnId = '00000000-0000-7000-8000-000000000116';
+    writeFileSync(path, [
+      line({
+        timestamp: '2000-01-01T00:00:01.000Z',
+        type: 'event_msg',
+        payload: { type: 'user_message', message: 'legacy mirror has no turn id' },
+      }),
+      line(itemCompleted({
+        type: 'UserMessage',
+        id: 'msg-user',
+        content: [{ type: 'text', text: 'legacy mirror has no turn id' }],
+      }, turnId, '2000-01-01T00:00:01.001Z')),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.filter(event => event.kind === 'user')).toHaveLength(1);
+  });
+
+  it('keeps identical item_completed prompts from separate turns', () => {
+    const firstTurnId = '00000000-0000-7000-8000-000000000113';
+    const secondTurnId = '00000000-0000-7000-8000-000000000114';
+    writeFileSync(path, [
+      line(itemCompleted({
+        type: 'UserMessage', id: 'msg-first', content: [{ type: 'text', text: 'repeat prompt' }],
+      }, firstTurnId)),
+      line(itemCompleted({
+        type: 'UserMessage', id: 'msg-second', content: [{ type: 'text', text: 'repeat prompt' }],
+      }, secondTurnId, '2000-01-01T00:00:02.000Z')),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.filter(event => event.kind === 'user'))
+      .toEqual([
+        expect.objectContaining({ text: 'repeat prompt' }),
+        expect.objectContaining({ text: 'repeat prompt' }),
+      ]);
+  });
+
+  it('does not let an item_completed submit probe consume the production user event', () => {
+    const turnId = '00000000-0000-7000-8000-000000000115';
+    writeFileSync(path, line(itemCompleted({
+      type: 'UserMessage',
+      id: 'msg-user',
+      content: [{ type: 'text', text: 'probe must stay read-only' }],
+    }, turnId)));
+
+    expect(traexRolloutHasUserInputSince(path, 0, 'probe must stay read-only')).toBe(true);
+    expect(drainTraexRollout(path, 0).events).toEqual([
+      expect.objectContaining({ kind: 'user', text: 'probe must stay read-only' }),
     ]);
   });
 


### PR DESCRIPTION
## 改了什么

TraeX 0.201.x（现场实测 0.201.4）部分 rollout 不再写 `event_msg/user_message`，
用户输入只存在于 `history_mutation` 和 `event_msg/item_completed`（`item.type = "UserMessage"`）。
当前 `drainTraexRollout()` 只认 `event_msg/user_message`，导致：

- 用户回合起点识别不到 → 队列里没有 collecting/local turn；
- 后续非空 `task_complete` 变成孤立 final，无法闭合投递；
- worker 仍报 idle，表现为「terminal 正常完成、飞书无回复」。

本 PR：

- 新增从 `event_msg/item_completed` 的 `UserMessage` item 提取用户事件（严格判定 `item.type`，`AgentMessage` / 工具结果一律忽略）；
- 新旧方言按 `turn_id` 去重；对无 `turn_id` 的旧 `user_message`，在同一次 drain 命中其 `item_completed` 镜像时替换而非双计；
- 保持 `task_complete` 为唯一权威终态，不盲发孤立 final；
- 提交确认探针（probe）保持只读，不消费生产去重状态。

## 为什么

修复 live `/adopt` 接管 TraeX fullscreen 会话时最终回答静默丢失（现场 0.201.4 复现）。

## 影响面

- 仅改 `src/services/traex-transcript.ts`（TraeX transcript reader）+ 其单测；
- TraeX / CoCo 0.200+ 共用该 reader，一并覆盖；
- 不动 Codex 原生 reader、Claude bridge、其它 CLI、非 adopt 投递；
- reader 语义与后端（tmux/PtyBackend）及 fullscreen/default TUI 解耦。

## 验证

- `pnpm build` 通过；
- 定向单测 129/129 通过：`traex-transcript` / `codex-bridge-queue` / `traex-worker-bridge-wiring`；
- 新增回归：0.201.4 item_completed 闭环、AgentMessage/tool 不误判、新旧方言不双计、无 turn_id 旧镜像不双计、同文本跨回合不误去重、探针只读不吞生产事件。
