### PR TITLE
feat(session-manager): sender/mentions 搬进 hook envelope，用户输入只剩正文

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1092,7 +1092,29 @@ function sessionIsNoTransport(larkAppId?: string, chatId?: string): boolean {
   return !larkTransportEnabled({ chatId, apiOnly });
 }
 
-export function buildNewTopicPrompt(
+/** opening 构建选项。在原有 larkAppId/chatId/whiteboardId 等之外，新增 hook 模式
+ *  （#794 后续）所需的 turnId 与 sessionBackendType：turnId 是 opening 轮的权威
+ *  turnId（= 发给 worker 的 turnId，最终成为 managedTurnOrigin.turnId），用于
+ *  sidecar 绑定；sessionBackendType 取会话冻结的后端类型（远端后端无本地 hook 进程）。 */
+type NewTopicOpts = {
+  larkAppId?: string;
+  chatId?: string;
+  whiteboardId?: string;
+  substituteTrigger?: SubstituteTrigger;
+  chatContext?: ChatContext;
+  turnId?: string;
+  sessionBackendType?: BackendType;
+};
+
+type NewTopicBlockKey = 'routing' | 'skill' | 'identity' | 'sessionId' | 'role'
+  | 'summaryMemory' | 'whiteboard' | 'chatContextPolicy' | 'chatContext'
+  | 'userMessage' | 'sender' | 'substitute' | 'senderNote' | 'attachments'
+  | 'mentions' | 'availableBots';
+
+/** opening 的 hook 模式（#794 后续）：whiteboard/sender/mentions 搬进 hook envelope，
+ *  PTY 文本只剩用户正文（+ role/summaryMemory 等稳定上下文）。与 follow-up 同一套
+ *  sidecar/claim 机制。inline 模式（hookMode=false）输出与历史完全一致。 */
+function buildNewTopicBlocks(
   userMessage: string,
   sessionId: string,
   cliId: CliId,
@@ -1104,11 +1126,15 @@ export function buildNewTopicPrompt(
   botIdentity?: { name?: string; openId?: string },
   locale?: Locale,
   sender?: ResolvedSender,
-  opts?: { larkAppId?: string; chatId?: string; whiteboardId?: string; substituteTrigger?: SubstituteTrigger; chatContext?: ChatContext },
-): string {
+  opts?: NewTopicOpts,
+  hookMode = false,
+): Array<{ key: NewTopicBlockKey; text: string }> {
   const adapter = createCliAdapterSync(cliId, cliPathOverride);
   if (adapter.inputEnvelope === 'service-user') {
-    return buildServiceUserPrompt([userMessage, ...(followUps ?? [])].join('\n\n'));
+    // service-user 适配器（ebsd）自带完整外壳，不参与分块：包成单块返回，
+    // join 后与历史字符串逐字一致；hook 模式下该块不在 ENVELOPE_KEYS 里，
+    // 全部留在 PTY 文本（且 service-user 适配器本就不满足 hook 模式前置条件）。
+    return [{ key: 'userMessage', text: buildServiceUserPrompt([userMessage, ...(followUps ?? [])].join('\n\n')) }];
   }
   // Non-Claude CLIs receive the botmux routing hints inline via the prompt
   // (Claude Code builds its own via --append-system-prompt). Source hints
@@ -1185,8 +1211,11 @@ export function buildNewTopicPrompt(
   const mergedMessage = followUps && followUps.length > 0
     ? [userMessage, ...followUps].join('\n\n')
     : userMessage;
-  const userBlock = `<user_message>\n${mergedMessage}\n</user_message>`;
-  const parts: string[] = [];
+  // hook 模式（#794 后续）：PTY 文本只保留用户正文，不再包 <user_message> 外壳。
+  // 理由同 follow-up：会话发现主防线是 collectBotmuxSessionIdentities 按文件名排除，
+  // 标题提取有 ?? rawContent 兜底。inline 模式保持原样。
+  const userBlock = hookMode ? mergedMessage : `<user_message>\n${mergedMessage}\n</user_message>`;
+  const blocks: Array<{ key: NewTopicBlockKey; text: string }> = [];
 
   // Put stable, instruction-like context before the user's first turn. This
   // improves salience without moving per-turn attribution (sender/mentions)
@@ -1195,40 +1224,60 @@ export function buildNewTopicPrompt(
   // message — same position as in follow-ups — not after it, where it could be
   // misread as part of the user's text.
   if (!adapter.injectsSessionContext) {
-    if (routingBlock) parts.push(routingBlock);
-    if (skillBlock) parts.push(skillBlock);
-    if (identityBlock) parts.push(identityBlock);
-    parts.push(`<session_id>${xmlEscape(sessionId)}</session_id>`);
+    if (routingBlock) blocks.push({ key: 'routing', text: routingBlock });
+    if (skillBlock) blocks.push({ key: 'skill', text: skillBlock });
+    if (identityBlock) blocks.push({ key: 'identity', text: identityBlock });
+    blocks.push({ key: 'sessionId', text: `<session_id>${xmlEscape(sessionId)}</session_id>` });
   }
-  if (roleBlock) parts.push(roleBlock);
-  if (summaryMemoryBlock) parts.push(summaryMemoryBlock);
-  if (whiteboardBlock) parts.push(whiteboardBlock);
-  if (chatContextPolicyBlock) parts.push(chatContextPolicyBlock);
-  if (chatContextBlock) parts.push(chatContextBlock);
+  if (roleBlock) blocks.push({ key: 'role', text: roleBlock });
+  if (summaryMemoryBlock) blocks.push({ key: 'summaryMemory', text: summaryMemoryBlock });
+  if (whiteboardBlock) blocks.push({ key: 'whiteboard', text: whiteboardBlock });
+  if (chatContextPolicyBlock) blocks.push({ key: 'chatContextPolicy', text: chatContextPolicyBlock });
+  if (chatContextBlock) blocks.push({ key: 'chatContext', text: chatContextBlock });
 
-  parts.push(userBlock);
+  blocks.push({ key: 'userMessage', text: userBlock });
 
   const senderBlock = renderSenderTag(sender, opts?.larkAppId);
-  if (senderBlock) parts.push(senderBlock);
+  if (senderBlock) blocks.push({ key: 'sender', text: senderBlock });
 
   const substituteBlock = renderSubstituteTrigger(opts?.substituteTrigger);
-  if (substituteBlock) parts.push(substituteBlock);
+  if (substituteBlock) blocks.push({ key: 'substitute', text: substituteBlock });
 
   const senderNote = renderCursorSenderNote(cliId, !!senderBlock, locale);
-  if (senderNote) parts.push(senderNote);
+  if (senderNote) blocks.push({ key: 'senderNote', text: senderNote });
 
   const attachHint = formatAttachmentsHint(attachments, locale);
-  if (attachHint) parts.push(attachHint);
+  if (attachHint) blocks.push({ key: 'attachments', text: attachHint });
 
   // CLIs with injectsSessionContext (Claude Code) get Lark routing/identity
   // and session ID via system prompt, so skip those blocks here.
-  if (mentionBlock) parts.push(mentionBlock);
-  if (botBlock) parts.push(botBlock);
+  if (mentionBlock) blocks.push({ key: 'mentions', text: mentionBlock });
+  if (botBlock) blocks.push({ key: 'availableBots', text: botBlock });
   // The per-session skill catalog block is appended later in the worker-pool
   // fork path (prepareSessionSkillPrompt), which also writes the manifest and
   // resolves delivery — keeping a single injection site avoids double-rendering.
 
-  return parts.join('\n\n');
+  return blocks;
+}
+
+export function buildNewTopicPrompt(
+  userMessage: string,
+  sessionId: string,
+  cliId: CliId,
+  cliPathOverride?: string,
+  attachments?: LarkAttachment[],
+  mentions?: LarkMention[],
+  availableBots?: Array<{ name: string; displayName: string; openId: string }>,
+  followUps?: string[],
+  botIdentity?: { name?: string; openId?: string },
+  locale?: Locale,
+  sender?: ResolvedSender,
+  opts?: NewTopicOpts,
+): string {
+  return buildNewTopicBlocks(
+    userMessage, sessionId, cliId, cliPathOverride, attachments, mentions,
+    availableBots, followUps, botIdentity, locale, sender, opts,
+  ).map((b) => b.text).join('\n\n');
 }
 
 /** Build the legacy opening prompt plus a Codex App structured sidecar. The
@@ -1262,8 +1311,43 @@ export function buildNewTopicCliInput(
     /** Host-resolved identity for this turn. Only the caller knows where the
      *  turn came from, so it is passed in rather than derived here. */
     trustedCaller?: CliTurnPayload['trustedCaller'];
+    /** opening 轮的权威 turnId（= 发给 worker 的 turnId，最终成为
+     *  managedTurnOrigin.turnId）。hook 模式下用于 sidecar 绑定；缺失回退 inline。 */
+    turnId?: string;
+    /** 会话冻结的后端类型，用于 hook 模式判定（远端后端无本地 hook 进程）。 */
+    sessionBackendType?: BackendType;
   },
 ): CliTurnPayload {
+  // hook 注入模式（#794 后续）：opening 也走 sidecar——whiteboard/sender/mentions
+  // 写入 per-turn sidecar，PTY 文本只剩用户正文（+ role/summaryMemory 等稳定上下文）。
+  // 与 follow-up 同一套 sidecar/claim 机制；turnId 是 claim 的权威键，缺失或条件
+  // 不满足时回退 inline（legacy 路径），行为与历史完全一致。
+  const hookTurnId = opts?.turnId;
+  if (resolveEnvelopeInjectionMode({
+    cliId,
+    cliPathOverride,
+    sessionBackendType: opts?.sessionBackendType,
+    larkAppId: opts?.larkAppId,
+  }) === 'hook' && hookTurnId) {
+    const blocks = buildNewTopicBlocks(
+      userMessage, sessionId, cliId, cliPathOverride, attachments, mentions,
+      availableBots, followUps, botIdentity, locale, sender, opts, true,
+    );
+    const ENVELOPE_KEYS = new Set<NewTopicBlockKey>(['whiteboard', 'sender', 'mentions']);
+    const ptyText = blocks
+      .filter((b) => !ENVELOPE_KEYS.has(b.key))
+      .map((b) => b.text)
+      .join('\n\n');
+    const hookEnvelope = blocks
+      .filter((b) => ENVELOPE_KEYS.has(b.key))
+      .map((b) => b.text)
+      .join('\n\n');
+    if (hookEnvelope && hookEnvelope.length <= HOOK_ENVELOPE_MAX_CHARS) {
+      writePromptContext(sessionId, hookTurnId, ptyText, hookEnvelope);
+      return { content: ptyText };
+    }
+    // 无 envelope（无 whiteboard/sender/mentions）或超限 → 回退 inline。
+  }
   const content = buildNewTopicPrompt(
     userMessage, sessionId, cliId, cliPathOverride, attachments, mentions,
     availableBots, followUps, botIdentity, locale, sender, opts,
@@ -1401,7 +1485,12 @@ function buildFollowUpBlocks(
   }
   if (whiteboardBlock) blocks.push({ key: 'whiteboard', text: whiteboardBlock });
 
-  blocks.push({ key: 'userMessage', text: `<user_message>\n${content}\n</user_message>` });
+  // hook 模式（#794 后续）：PTY 文本只保留用户正文，不再包 <user_message> 外壳。
+  // 外壳的唯一作用是给 transcript 消费方（会话发现 / 标题提取）做结构标记，
+  // 但会话发现的主防线是 collectBotmuxSessionIdentities 的按文件名排除（不依赖
+  // transcript 内容），标题提取有 ?? rawContent 兜底，所以 hook 模式下可以去掉。
+  // inline 模式保持原样（其它 CLI 与旧会话发现正则仍依赖外壳）。
+  blocks.push({ key: 'userMessage', text: hookMode ? content : `<user_message>\n${content}\n</user_message>` });
 
   const senderBlock = renderSenderTag(opts?.sender, opts?.larkAppId);
   if (senderBlock) blocks.push({ key: 'sender', text: senderBlock });
@@ -1460,9 +1549,19 @@ const HOOK_ENVELOPE_MAX_CHARS = 8000;
  *     （read-isolation 下是 per-bot BOT_HOME 那份，不是全局）；
  *  4. （在 buildFollowUpCliInput 里）envelope 不超 8k。
  * 任一不满足 → inline（现状字节不变）。
+ *
+ * opening（buildNewTopicCliInput）复用同一判定：cfg 字段是 FollowUpOpts /
+ * NewTopicOpts 的结构化子集，两边都满足。
  */
-function resolveEnvelopeInjectionMode(opts?: FollowUpOpts): 'hook' | 'inline' {
-  if (!opts?.cliId) return 'inline';
+type EnvelopeInjectionCfg = {
+  cliId?: CliId;
+  cliPathOverride?: string;
+  sessionBackendType?: BackendType;
+  larkAppId?: string;
+};
+
+function resolveEnvelopeInjectionMode(cfg?: EnvelopeInjectionCfg): 'hook' | 'inline' {
+  if (!cfg?.cliId) return 'inline';
   // 远端后端（riff 等）没有本地 Claude hook 进程，sidecar 写了没人读，
   // 必须用会话冻结的 backendType（不是当前 bot 配置，那是 next-session 生效）。
   // 只有确知在本地跑 CLI 的后端才允许 hook 模式（白名单）。未来新增远端后端
@@ -1471,19 +1570,19 @@ function resolveEnvelopeInjectionMode(opts?: FollowUpOpts): 'hook' | 'inline' {
   // fail-closed（review B3）：sessionBackendType 缺失（null/undefined）时不再短路
   // 放过，强制 inline。现网 spawn 的 reconcileRiffBackendType 已把 claude-code 钉在
   // 本地后端，此条是防未来远端后端的硬化；所有调用点都传 ds.session.backendType。
-  if (!opts.sessionBackendType || !LOCAL_BACKENDS.has(opts.sessionBackendType)) return 'inline';
+  if (!cfg.sessionBackendType || !LOCAL_BACKENDS.has(cfg.sessionBackendType)) return 'inline';
   let adapter: CliAdapter;
   try {
-    adapter = createCliAdapterSync(opts.cliId, opts.cliPathOverride);
+    adapter = createCliAdapterSync(cfg.cliId, cfg.cliPathOverride);
   } catch { return 'inline'; }
   if (!adapter.supportsInvisiblePromptHook || !adapter.hookInstall?.userPromptSubmitCommand) return 'inline';
-  if (!opts.larkAppId) return 'inline';
+  if (!cfg.larkAppId) return 'inline';
   let botConfig: BotConfig;
   try {
-    botConfig = getBot(opts.larkAppId).config;
+    botConfig = getBot(cfg.larkAppId).config;
   } catch { return 'inline'; }
   if (botConfig.envelopeInjection !== 'auto') return 'inline';
-  const effectivePath = effectivePromptHookConfigPath(adapter, botConfig, opts.larkAppId, opts.sessionBackendType);
+  const effectivePath = effectivePromptHookConfigPath(adapter, botConfig, cfg.larkAppId, cfg.sessionBackendType);
   if (!effectivePath || !hasInstalledPromptHookCached(effectivePath)) return 'inline';
   return 'hook';
 }
@@ -1535,15 +1634,21 @@ export function buildFollowUpCliInput(
   // 其余块。超限或无条件时回退 inline（legacy 路径），行为与历史完全一致。
   // turnId 是 claim 的权威键：缺失时无法做 turn 绑定，回退 inline（避免 reminder 被
   // 剥离却无 sidecar 可领）。
+  //
+  // #794 后续：sender/mentions 也搬进 hook envelope，PTY 文本只剩用户正文（+ role/
+  // summaryMemory 等稳定上下文）。模型经 system-reminder 仍看得到发送者与提及，
+  // 输入框不再出现 <user_message>/<sender>/<mentions> 标签。代价：hook 注入内容不落
+  // transcript，insight 发送者归因对 hook 模式会话降级为「未知用户」（用户已确认接受）。
   const hookTurnId = opts?.turnId;
   if (resolveEnvelopeInjectionMode(opts) === 'hook' && hookTurnId) {
     const blocks = buildFollowUpBlocks(content, sessionId, opts, true);
+    const ENVELOPE_KEYS = new Set<FollowUpBlockKey>(['reminder', 'whiteboard', 'sender', 'mentions']);
     const ptyText = blocks
-      .filter((b) => b.key !== 'reminder' && b.key !== 'whiteboard')
+      .filter((b) => !ENVELOPE_KEYS.has(b.key))
       .map((b) => b.text)
       .join('\n\n');
     const hookEnvelope = blocks
-      .filter((b) => b.key === 'reminder' || b.key === 'whiteboard')
+      .filter((b) => ENVELOPE_KEYS.has(b.key))
       .map((b) => b.text)
       .join('\n\n');
     if (hookEnvelope && hookEnvelope.length <= HOOK_ENVELOPE_MAX_CHARS) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16891,6 +16891,15 @@ function buildReservedInitialInput(
       // master: thread the joined-chat context into the opening prompt (group-join
       // auto-start passes this via pendingChatContext).
       chatContext: ds.pendingChatContext,
+      // #794 后续：opening 也走 hook 注入（sender/mentions 进 envelope，PTY 文本
+      // 只剩正文）。turnId 必须与 forkReservedInitialSession 传给 forkWorker 的
+      // 权威 turnId 一致（= 最终 managedTurnOrigin.turnId），sidecar 才能被 claim。
+      // raw 命令冷启动（pendingRawInput）的 buffered follow-up 走 raw_input IPC
+      // 延迟发送，turnId 权威流不同，暂不启用 hook，保持 inline。
+      turnId: ds.pendingRawInput
+        ? undefined
+        : (ds.pendingTurnId ?? ds.session.pendingRepoSetup?.turnId),
+      sessionBackendType: ds.session.backendType,
     },
   );
   // R5-B1-1: COPY the frozen new-topic steer authorization onto the opening
@@ -20520,6 +20529,10 @@ async function handleThreadReplyAdmitted(
             codexAppText: parsed.content,
             codexAppApplicationContext,
             codexAppMessageContext,
+            // #794 后续：empty-start 首轮 opening 也走 hook 注入。turnId 与下方
+            // sendWorkerInput 的权威 turnId（parsed.messageId）一致，sidecar 可被 claim。
+            turnId: parsed.messageId,
+            sessionBackendType: ds.session.backendType,
           },
         )
       : buildFollowUpCliInput(promptContent, ds.session.sessionId, {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -20798,6 +20798,11 @@ async function handleThreadReplyAdmitted(
           codexAppText: reforkCodexApp.text,
           codexAppApplicationContext,
           codexAppMessageContext: reforkCodexApp.messageContext,
+          // #794 后续：worker-null refork 的 empty-start 首轮 opening 也走 hook 注入。
+          // turnId 与下方 forkWorker 的权威 turnId 一致（非 queued 时 = parsed.messageId）；
+          // queued dashboard 场景的 turnId 是合成的，权威流不同，保持 inline。
+          turnId: queuedHasDurableTail ? undefined : parsed.messageId,
+          sessionBackendType: ds.session.backendType,
         },
       );
     } else {

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -587,6 +587,13 @@ export async function commitRepoSelection(
               codexAppFollowUps: ds.pendingCodexAppFollowUps,
               codexAppFollowUpContexts: ds.pendingCodexAppFollowUpContexts,
               chatContext: ds.pendingChatContext,
+              // #794 后续：opening 走 hook 注入（sender/mentions 进 envelope，PTY 文本
+              // 只剩正文）。turnId 与下方 forkWorker 的权威 turnId 一致；raw 命令冷启动
+              // 的 buffered follow-up 走 raw_input IPC 延迟发送，turnId 权威流不同，不启用。
+              turnId: pendingRawInput
+                ? undefined
+                : (ds.pendingTurnId ?? ds.session.pendingRepoSetup?.turnId),
+              sessionBackendType: ds.session.backendType,
             },
           )
         : undefined;

--- a/test/initial-user-turn-opening.test.ts
+++ b/test/initial-user-turn-opening.test.ts
@@ -26,6 +26,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { claimPromptContext, fingerprintPromptText, prefixOf } from '../src/services/prompt-context-store.js';
 
 const mocks = vi.hoisted(() => {
   process.env.SESSION_DATA_DIR = `${process.env.TMPDIR ?? '/tmp'}/botmux-initial-turn-${process.pid}`;
@@ -499,11 +500,14 @@ describe('empty-started session — first real business turn must use the new-to
     expect(ds.session.initialUserTurnPending).toBeUndefined();
   });
 
-  it('worker-null refork + auto hook: opening 轮不写 speculative sidecar（review 三审 HIGH-3）', async () => {
+  it('worker-null refork + auto hook: opening 轮写合法 sidecar（非 speculative follow-up reminder）', async () => {
     // 三审发现：opening 分支曾无条件先跑 buildReforkCliInput（有写 sidecar 的副作用），
     // 结果被 buildNewTopicCliInput 覆盖丢弃，但 sidecar 已写入 opening 的 turnId，
     // opening 的 hook 会领到这份没发出去的 speculative reminder → 双注入。
-    // 修复后 opening 分支直接用 buildNewTopicCliInput（不写 sidecar）。
+    // 修复后 opening 分支直接用 buildNewTopicCliInput。#794 后续后 opening 也走 hook
+    // 注入：写的是**合法** opening sidecar（whiteboard/sender/mentions，无 follow-up
+    // reminder），opening 内容只剩正文。本测试锁住：sidecar 是 opening envelope（claim
+    // 回的内容不含 <botmux_reminder>），不是 speculative follow-up reminder。
     const anchor = 'om_hook_opening_root';
     const ds = seedEmptyStarted(anchor, { live: false, hasHistory: true, cliId: 'claude-code' });
     ds.session.backendType = 'pty';
@@ -526,13 +530,17 @@ describe('empty-started session — first real business turn must use the new-to
       makeCtx(anchor, 'om_hook_first'),
     );
 
-    // opening 用 new-topic 构造，不应有 sidecar 写入
-    const sidecarDir = join(process.env.SESSION_DATA_DIR!, 'prompt-ctx', ds.session.sessionId);
-    expect(existsSync(sidecarDir)).toBe(false);
-    // opening 内容应包含 user_message（new-topic 开场）；claude 系列不内联 routing 块
+    // opening 走 hook 模式：PTY 文本只剩正文，无 <user_message> 外壳 / reminder
     const opening = forkInputs()[0]!.content;
-    expect(opening).toContain('<user_message>');
+    expect(opening).toBe('第一条消息');
+    expect(opening).not.toContain('<user_message>');
     expect(opening).not.toContain('<botmux_reminder>');
+    // sidecar 是合法 opening envelope：claim 回的内容含 sender，不含 follow-up reminder
+    // （若写的是 speculative buildReforkCliInput sidecar，envelope 会含 <botmux_reminder>）
+    const envelope = claimPromptContext(ds.session.sessionId, 'om_hook_first', fingerprintPromptText(opening), prefixOf(opening));
+    expect(envelope).toBeDefined();
+    expect(envelope).toContain('<sender ');
+    expect(envelope).not.toContain('<botmux_reminder>');
   });
 
   it('worker-null refork keeps --resume when a non-IM path already fed the CLI', async () => {

--- a/test/prompt-hook-injection.test.ts
+++ b/test/prompt-hook-injection.test.ts
@@ -100,7 +100,7 @@ vi.mock('../src/adapters/hook-installer.js', () => ({
 
 // ─── 被测模块 ──────────────────────────────────────────────────────────────
 
-import { buildFollowUpCliInput } from '../src/core/session-manager.js';
+import { buildFollowUpCliInput, buildNewTopicCliInput } from '../src/core/session-manager.js';
 import { claimPromptContext, fingerprintPromptText, prefixOf } from '../src/services/prompt-context-store.js';
 
 const SESSION_ID = 'hook-session-789';
@@ -142,21 +142,24 @@ describe('buildFollowUpCliInput — hook 注入模式', () => {
     else process.env.SESSION_DATA_DIR = prevDataDir;
   });
 
-  it('auto + claude-code + preflight 通过：reminder/whiteboard 进 sidecar，PTY 文本只留其余块', () => {
+  it('auto + claude-code + preflight 通过：reminder/whiteboard/sender/mentions 进 sidecar，PTY 文本只剩正文', () => {
     const result = buildFollowUpCliInput('帮我修个 bug', SESSION_ID, followUpOpts({ whiteboardId: 'wb_1' }));
 
-    // PTY 文本：有 user_message / sender / mentions，无 reminder / whiteboard
-    expect(result.content).toContain('<user_message>\n帮我修个 bug\n</user_message>');
-    expect(result.content).toContain('<sender ');
-    expect(result.content).toContain('<mentions>');
+    // PTY 文本：只剩用户正文，无 user_message 外壳 / sender / mentions / reminder / whiteboard
+    expect(result.content).toBe('帮我修个 bug');
+    expect(result.content).not.toContain('<user_message>');
+    expect(result.content).not.toContain('<sender ');
+    expect(result.content).not.toContain('<mentions>');
     expect(result.content).not.toContain('<botmux_reminder>');
     expect(result.content).not.toContain('<whiteboard');
 
-    // sidecar：按 PTY 文本指纹读回，含 reminder + whiteboard
+    // sidecar：按 PTY 文本指纹读回，含 reminder + whiteboard + sender + mentions
     const envelope = claimByPrompt(SESSION_ID, TURN_ID, result.content);
     expect(envelope).toBeDefined();
     expect(envelope).toContain('<botmux_reminder>');
     expect(envelope).toContain('<whiteboard');
+    expect(envelope).toContain('<sender ');
+    expect(envelope).toContain('<mentions>');
     // hook 模式用描述式文案（命令式原文只出现在 inline 路径）
     expect(envelope).toContain('本会话通过 botmux 桥接飞书');
     expect(envelope).not.toContain('至少 botmux send 回应一次');
@@ -266,6 +269,101 @@ describe('buildFollowUpCliInput — hook 注入模式', () => {
     });
     const result = buildFollowUpCliInput('帮我修个 bug', SESSION_ID, followUpOpts({ sessionBackendType: undefined }));
     expect(result.content).toContain('<botmux_reminder>');
+    expect(claimByPrompt(SESSION_ID, TURN_ID, result.content)).toBeUndefined();
+  });
+});
+
+describe('buildNewTopicCliInput — hook 注入模式（opening）', () => {
+  let prevDataDir: string | undefined;
+  beforeEach(() => {
+    prevDataDir = process.env.SESSION_DATA_DIR;
+    process.env.SESSION_DATA_DIR = '/tmp/test-sessions';
+    getBotMock.mockReturnValue({
+      config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code', envelopeInjection: 'auto' as const },
+    });
+    preflightMock.mockReturnValue(true);
+  });
+  afterEach(() => {
+    if (prevDataDir === undefined) delete process.env.SESSION_DATA_DIR;
+    else process.env.SESSION_DATA_DIR = prevDataDir;
+  });
+
+  const openingOpts = (overrides: Record<string, unknown> = {}) => ({
+    larkAppId: LARK_APP_ID,
+    whiteboardId: 'wb_1',
+    turnId: TURN_ID,
+    sessionBackendType: 'pty' as const,
+    ...overrides,
+  });
+
+  it('auto + claude-code + preflight 通过 + turnId：whiteboard/sender/mentions 进 sidecar，PTY 文本只剩正文', () => {
+    const result = buildNewTopicCliInput(
+      '帮我修个 bug', SESSION_ID, 'claude-code', undefined,
+      undefined,
+      [{ name: 'Bob', openId: 'ou_bob' }],
+      undefined, undefined,
+      { name: 'Bot', openId: 'ou_bot' },
+      undefined,
+      { openId: 'ou_sender', type: 'user' as const, name: 'Sender' },
+      openingOpts(),
+    );
+
+    // PTY 文本：只剩用户正文，无 user_message 外壳 / sender / mentions / whiteboard
+    expect(result.content).toBe('帮我修个 bug');
+    expect(result.content).not.toContain('<user_message>');
+    expect(result.content).not.toContain('<sender ');
+    expect(result.content).not.toContain('<mentions>');
+    expect(result.content).not.toContain('<whiteboard');
+
+    // sidecar：含 whiteboard + sender + mentions
+    const envelope = claimByPrompt(SESSION_ID, TURN_ID, result.content);
+    expect(envelope).toBeDefined();
+    expect(envelope).toContain('<whiteboard');
+    expect(envelope).toContain('<sender ');
+    expect(envelope).toContain('<mentions>');
+  });
+
+  it('缺 turnId：回退 inline（有 user_message 外壳，无 sidecar）', () => {
+    const result = buildNewTopicCliInput(
+      '帮我修个 bug', SESSION_ID, 'claude-code', undefined,
+      undefined, undefined, undefined, undefined,
+      { name: 'Bot', openId: 'ou_bot' },
+      undefined,
+      { openId: 'ou_sender', type: 'user' as const, name: 'Sender' },
+      openingOpts({ turnId: undefined }),
+    );
+    expect(result.content).toContain('<user_message>');
+    expect(result.content).toContain('<sender ');
+    expect(claimByPrompt(SESSION_ID, TURN_ID, result.content)).toBeUndefined();
+  });
+
+  it('off：完全 inline（无 sidecar）', () => {
+    getBotMock.mockReturnValue({
+      config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code', envelopeInjection: 'off' as const },
+    });
+    const result = buildNewTopicCliInput(
+      '帮我修个 bug', SESSION_ID, 'claude-code', undefined,
+      undefined, undefined, undefined, undefined,
+      { name: 'Bot', openId: 'ou_bot' },
+      undefined,
+      { openId: 'ou_sender', type: 'user' as const, name: 'Sender' },
+      openingOpts(),
+    );
+    expect(result.content).toContain('<user_message>');
+    expect(claimByPrompt(SESSION_ID, TURN_ID, result.content)).toBeUndefined();
+  });
+
+  it('无 whiteboard/sender/mentions（envelope 为空）：回退 inline，保留外壳', () => {
+    // envelope 为空时不写 sidecar，回退 inline——外壳保留给会话发现/标题提取用。
+    const result = buildNewTopicCliInput(
+      '帮我修个 bug', SESSION_ID, 'claude-code', undefined,
+      undefined, undefined, undefined, undefined,
+      undefined,
+      undefined,
+      undefined,
+      openingOpts({ whiteboardId: undefined }),
+    );
+    expect(result.content).toContain('<user_message>');
     expect(claimByPrompt(SESSION_ID, TURN_ID, result.content)).toBeUndefined();
   });
 });

--- a/test/prompt-hook-injection.test.ts
+++ b/test/prompt-hook-injection.test.ts
@@ -366,4 +366,39 @@ describe('buildNewTopicCliInput — hook 注入模式（opening）', () => {
     expect(result.content).toContain('<user_message>');
     expect(claimByPrompt(SESSION_ID, TURN_ID, result.content)).toBeUndefined();
   });
+
+  it('skill catalog 追加到 prompt 尾部后：全量指纹 miss，prefix 兜底仍能 claim', () => {
+    // opening 是 CLI generation 的首轮，prepareSessionSkillPrompt 会把 skill catalog
+    // 追加到 prompt 尾部（${opts.prompt}\n\n${catalog}），这才是 claude-code 真正
+    // typed 进 PTY 的文本。sidecar 按「catalog 追加前」的 ptyText 写指纹，所以 hook
+    // fire 时全量指纹 exact match 会 miss，只能靠 prefix 兜底（前 30 归一字符，catalog
+    // 在尾 → 前 30 不变 → turnId 定域 0/1 条 → 救回）。本测试锁住这条 fallback 路径。
+    // 注意：消息需长于 PREFIX_FALLBACK_LEN（30 字符），否则前 30 字符本身就被追加改变。
+    const longMessage = '帮我修个 bug，这个问题出现在用户登录模块，需要排查一下认证流程的 token 刷新逻辑';
+    const result = buildNewTopicCliInput(
+      longMessage, SESSION_ID, 'claude-code', undefined,
+      undefined,
+      [{ name: 'Bob', openId: 'ou_bob' }],
+      undefined, undefined,
+      { name: 'Bot', openId: 'ou_bot' },
+      undefined,
+      { openId: 'ou_sender', type: 'user' as const, name: 'Sender' },
+      openingOpts(),
+    );
+    expect(result.content).toBe(longMessage);
+
+    // 模拟 prepareSessionSkillPrompt 把 catalog 追加到尾部
+    const catalog = '<botmux_skills>\n- skill-a\n- skill-b\n</botmux_skills>';
+    const typedText = `${result.content}\n\n${catalog}`;
+
+    // 全量指纹 miss（typed 文本 ≠ sidecar 的 ptyText），且 exact miss 不消费 sidecar
+    const exactMiss = claimPromptContext(SESSION_ID, TURN_ID, fingerprintPromptText(typedText));
+    expect(exactMiss).toBeUndefined();
+
+    // 但 sidecar 还在，用 prefix 兜底能 claim 回 envelope
+    const rescued = claimPromptContext(SESSION_ID, TURN_ID, fingerprintPromptText(typedText), prefixOf(typedText));
+    expect(rescued).toBeDefined();
+    expect(rescued).toContain('<sender ');
+    expect(rescued).toContain('<mentions>');
+  });
 });

--- a/test/scheduler-silent-execute.test.ts
+++ b/test/scheduler-silent-execute.test.ts
@@ -795,7 +795,8 @@ describe('executeScheduledTask — live-session injection', () => {
       const content = typeof injected === 'string' ? injected : injected.content;
       // 本地后端 + auto → hook 模式：reminder 进 sidecar，PTY 文本里没有
       expect(content).not.toContain('<botmux_reminder>');
-      expect(content).toContain('<user_message>');
+      // #794 后续：hook 模式连 <user_message> 外壳也剥掉，PTY 文本只剩正文
+      expect(content).not.toContain('<user_message>');
     } finally {
       (BOT.config as Record<string, unknown>).envelopeInjection = prev;
     }


### PR DESCRIPTION
## 改了什么

#794 后续：把 `<sender>` 与 `<mentions>` 从 PTY 文本搬进 UserPromptSubmit hook 的 system-reminder，并去掉 `<user_message>` 外壳，让用户输入框只剩消息正文。模型经 hook envelope 仍看得到发送者与提及，`--mention` 决策与 A2A 归因不受影响。

- **follow-up hook 模式**：envelope 从 reminder/whiteboard 扩到 reminder/whiteboard/sender/mentions；`userMessage` 块在 hook 模式下输出纯正文
- **opening（新话题第一条）**：此前完全没走 hook，现复用同一套 sidecar/claim 机制。`buildNewTopicPrompt` 重构为 blocks 结构（inline 输出字节不变），`buildNewTopicCliInput` 在 hook 模式下把 whiteboard/sender/mentions 写进 sidecar、PTY 文本只剩正文
- **调用点**传入权威 turnId + sessionBackendType：`buildReservedInitialInput`（主 opening 路径）、card-handler repo-selection、live-worker empty-start 首轮、worker-null refork opening（empty-start 丢 worker 后的首条真实 turn）。raw 命令冷启动的 buffered follow-up 走 raw_input IPC 延迟发送，turnId 权威流不同，暂保持 inline；queued dashboard 场景 turnId 是合成的，同样保持 inline

## 为什么

用户反馈输入框里 `<user_message>` / `<sender>` / `<mentions>` 标签是噪音。reminder/whiteboard 已在 #794 搬进 hook，这次把剩余的 per-turn 归因元数据也搬进去，输入框只剩正文。

## 影响面与权衡

- **会话发现（/adopt）**：主防线是 `collectBotmuxSessionIdentities()` 按文件名（=sessionId）排除，不依赖 transcript 内容，已关闭会话不会漏进 picker。transcript 标记正则仍匹配 inline 模式与旧会话，作为跨机/丢库的兜底
- **insight 发送者归因**：hook 注入内容不落 transcript，hook 模式会话的 sender/mentions 归因降级为「未知用户」（正文与 @ 仍在）。这是干净 prompt 的已知代价
- **短正文 + priority skills 的 opening 指纹漂移**：opening 是 CLI generation 首轮，worker 的 `prepareSessionSkillPrompt` 会把 skill catalog 追加到 prompt 尾部。sidecar 按「catalog 追加前」的 ptyText 写指纹，hook 看到的是 ptyText+catalog → 全量指纹失配 → 靠 prefix 兜底（前 30 归一字符）。当 ptyText 归一化后 ≥30 字符时 prefix 不受尾部追加影响，可靠救回；当正文 <30 字符且配了 priority skills 时，prefix 会被 catalog 头污染，该 opening 轮的 sender/mentions/whiteboard 静默丢失（fail-open，正文仍在，模型只是看不到这轮的发送者/提及）。可达条件窄（`envelopeInjection=auto` + 配了 priority skills + 正文很短），属 latent。根治（hook 端剥掉尾部 catalog 再算指纹）或加 guard 留 follow-up
- **标题提取**：`extractBotmuxLarkNativeSessionTitlePrompt` 有 `?? rawContent` 兜底，不受影响
- **超限/无条件时回退 inline**，行为与历史完全一致；仅 claude-code + 本地后端 + `envelopeInjection=auto` + hook 已装 时生效
- 跨 CLI：仅 claude-code 走 hook 模式，其它 CLI 仍 inline，不受影响

## 测试

- `pnpm build` 通过
- `prompt-hook-injection`（含 opening 5 例：hook 模式 PTY 只剩正文 / 缺 turnId 回退 inline / off 完全 inline / envelope 为空回退 inline / skill catalog 追加后 prefix 兜底仍能 claim）
- `prompt-builder`、`card-handler-repo-select`、`resumable-session-discovery`、`bridge-turn-queue`、`session-title`、`prompt-context-store`、`ipc-prompt-ctx-claim-route`、`scheduler-silent-execute`、`initial-user-turn-opening` 等相关套件全绿（300+ 例）
- rebase 到最新 upstream/master 后重新 build + 测试通过
- CI build job 通过
