### PR TITLE
fix(cli): 稳定性专项——ENOBUFS、恢复广播抑制、loopback 放宽、版本错配警告

### DIFF
--- a/src/adapters/adopt-route.ts
+++ b/src/adapters/adopt-route.ts
@@ -58,6 +58,8 @@ function defaultReadParent(pid: number): number | null {
   try {
     const out = execFileSync('ps', ['-o', 'ppid=', '-p', String(pid)], {
       encoding: 'utf-8',
+      // 与其它 ps 进程表扫描保持一致：显式 maxBuffer，防 ENOBUFS。
+      maxBuffer: 32 * 1024 * 1024,
     });
     const ppid = parseInt(out.trim(), 10);
     if (Number.isInteger(ppid) && ppid > 0) return ppid;

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -496,6 +496,8 @@ export function findServerPid(sessionName: string): number | null {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 3000,
+      // 全进程表扫描：显式抬高 maxBuffer，防输出超过 Node 默认 1MiB 时 ENOBUFS。
+      maxBuffer: 32 * 1024 * 1024,
       env: zellijEnv(),
     });
     servers = parseZellijServerProcs(out);
@@ -553,6 +555,8 @@ export function findPaneCliPid(sessionName: string, _binBasename: string): numbe
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 3000,
+      // 全进程表扫描：显式抬高 maxBuffer，防输出超过 Node 默认 1MiB 时 ENOBUFS。
+      maxBuffer: 32 * 1024 * 1024,
       env: zellijEnv(),
     });
     const children: number[] = [];

--- a/src/adapters/cli/reasonix.ts
+++ b/src/adapters/cli/reasonix.ts
@@ -44,7 +44,11 @@ export function isDescendantOf(pid: number, ancestorPid: number): boolean {
     return false;
   }
   try {
-    const raw = execFileSync('ps', ['-axo', 'pid=,ppid='], { encoding: 'utf-8' });
+    // 全进程表扫描：显式抬高 maxBuffer，防输出超过 Node 默认 1MiB 时 ENOBUFS。
+    const raw = execFileSync('ps', ['-axo', 'pid=,ppid='], {
+      encoding: 'utf-8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
     const ppidOf = new Map<number, number>();
     for (const line of raw.split('\n')) {
       const m = line.trim().match(/^(\d+)\s+(\d+)$/);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -168,7 +168,7 @@ import {
   resolveGlobalInstallPlan,
   UnsupportedGlobalInstallError,
 } from './utils/global-install.js';
-import { isLocalDevInstall, botmuxCliEntryAt, bakedBinaryVersion, botmuxInstallRoot } from './utils/install-info.js';
+import { isLocalDevInstall, botmuxCliEntryAt, bakedBinaryVersion, botmuxInstallRoot, botmuxVersion } from './utils/install-info.js';
 import { currentUpdateStrategy, replaceStandaloneBinary } from './core/binary-self-update.js';
 import { fetchLatestVersion, isNewerVersion } from './core/update-check.js';
 import { resolveCurrentVersion } from './utils/install-diagnostics.js';
@@ -274,6 +274,7 @@ import {
 } from './core/plugins/dependencies.js';
 import { authorizeV3DaemonCommand } from './workflows/v3/cli-daemon-command-authority.js';
 import {
+  detectDaemonVersionMismatch,
   findOnlineDaemon,
   listOnlineDaemons as listOnlineDaemonsIn,
   resolveDaemonIpcPort,
@@ -3102,6 +3103,19 @@ async function cmdStatus(): Promise<void> {
   // the authoritative status now (supervisor-owned), so there is no second
   // registry to reconcile against. Legacy pm2 still gets surfaced by
   // warnIfLegacyBotmuxAlive above, which is what a pre-migration host needs.
+  warnIfDaemonVersionMismatch();
+}
+
+/** CLI↔daemon 版本错配感知：npm 升级后 daemon 若仍跑旧代码，新功能会静默
+ * 失效。daemon 描述符的 version 字段由新版 daemon 发布；旧 daemon 无此字段
+ * （detectDaemonVersionMismatch 跳过），源码 checkout（0.0.0）也跳过。 */
+function warnIfDaemonVersionMismatch(): void {
+  const cliVersion = botmuxVersion();
+  const daemonVersion = detectDaemonVersionMismatch(cliVersion, listOnlineDaemons());
+  if (daemonVersion) {
+    console.log('');
+    console.log(`⚠️  版本不一致：daemon 运行 v${daemonVersion}，CLI 为 v${cliVersion}，新功能可能不生效，请执行 botmux restart`);
+  }
 }
 
 async function cmdUpgrade(): Promise<void> {

--- a/src/codex-rpc-engine.ts
+++ b/src/codex-rpc-engine.ts
@@ -548,7 +548,7 @@ export class CodexRpcEngine {
     let argv = '';
     try { argv = readFileSync(`/proc/${pid}/cmdline`, 'utf8').replace(/\0/g, ' '); }
     catch {
-      try { argv = execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }); }
+      try { argv = execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 32 * 1024 * 1024 }); }
       catch { return false; }
     }
     if (!/\bapp-server\b/.test(argv)) return false;

--- a/src/core/browser-restart.ts
+++ b/src/core/browser-restart.ts
@@ -198,7 +198,7 @@ export async function restartBrowser(
     appPathFor?: (bundleId: string) => Promise<string>;
   } = {},
 ): Promise<RestartResult> {
-  const run = opts.run ?? (async (file, args) => pExecFile(file, args, { timeout: 15_000 }));
+  const run = opts.run ?? (async (file, args) => pExecFile(file, args, { timeout: 15_000, maxBuffer: 32 * 1024 * 1024 }));
   const sleep = opts.sleep ?? ((ms) => new Promise<void>(r => setTimeout(r, ms)));
   const now = opts.now ?? (() => Date.now());
   const quitTimeoutMs = opts.quitTimeoutMs ?? 12_000;

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -28,6 +28,7 @@ import {
 } from '../services/codex-reasoning-effort.js';
 import * as asyncTriggerStore from '../services/async-trigger-store.js';
 import { resolveAsyncTriggerState, decideAsyncOwnership } from '../services/async-trigger-state.js';
+import { isLoopbackPeer } from '../utils/loopback-peers.js';
 import * as scheduleStore from '../services/schedule-store.js';
 import * as groupsStore from '../services/groups-store.js';
 import { createGroupWithBots, transferGroupOwner } from '../services/group-creator.js';
@@ -2724,7 +2725,9 @@ ipcRoute('POST', '/api/sessions/:sessionId/resume', async (req, res, params) => 
 ipcRoute('POST', '/api/sessions/migrate-to-chat', async (req, res) => {
   const remote = req.socket.remoteAddress;
   // node may report '127.0.0.1' or '::ffff:127.0.0.1' (IPv4 mapped) or '::1'.
-  const localish = remote === '127.0.0.1' || remote === '::1' || remote === '::ffff:127.0.0.1';
+  // 复用 loopback-peers：定制内核把 loopback peer 上报成 LAN IP 时，
+  // BOTMUX_LOOPBACK_PEERS 放行的地址同样适用于此跨 daemon 迁移端点。
+  const localish = remote ? isLoopbackPeer(remote) : false;
   if (!localish) return jsonRes(res, 403, { ok: false, error: 'not_local' });
 
   let body: {

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -257,7 +257,11 @@ export function readCmdline(pid: number): string[] {
     return readFileSync(`/proc/${pid}/cmdline`, 'utf-8').split('\0').filter(Boolean);
   } catch {
     try {
-      const out = execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+      const out = execFileSync('ps', ['-o', 'args=', '-p', String(pid)], {
+        encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'],
+        // 与其它 ps 进程表扫描保持一致：显式 maxBuffer，防 ENOBUFS。
+        maxBuffer: 32 * 1024 * 1024,
+      });
       return out.trim().split(/\s+/).filter(Boolean);
     } catch { return []; }
   }
@@ -428,6 +432,8 @@ export function readProcessStartTime(pid: number): number | undefined {
   try {
     const out = execFileSync('ps', ['-o', 'lstart=', '-p', String(pid)], {
       encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'],
+      // 与其它 ps 进程表扫描保持一致：显式 maxBuffer，防 ENOBUFS。
+      maxBuffer: 32 * 1024 * 1024,
     }).trim();
     if (out) {
       const ms = Date.parse(out);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -11281,6 +11281,21 @@ function setupWorkerHandlers(
     dispatchAttempt?: number,
   ): Promise<void> => {
     if (startupState.failureNotified) return;
+    // Restart recovery (daemon restart batch-restore): stay silent in the chat.
+    // Without this guard every restored session whose worker fails to start
+    // posts a "会话启动失败" card into its own topic — a broadcast storm during
+    // bulk restore. The failure still lands in the daemon log below; the owner
+    // gets the recovery DM summary instead, and the next real user turn clears
+    // suppressRecoveryCard (rememberLastCliInput) so later failures notify
+    // normally. Do NOT set failureNotified here: a later generation failing
+    // after the flag clears must still surface.
+    if (ds.suppressRecoveryCard) {
+      logger.warn(
+        `[${t}] Startup failure notification suppressed by suppressRecoveryCard `
+        + `(session recovery mode) sid=${ds.session.sessionId}: ${reason}`,
+      );
+      return;
+    }
     startupState.failureNotified = true;
     emitSessionLifecycleHook(ds, 'session.requires_attention', {
       reason: 'worker_start_failed',

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -11284,11 +11284,12 @@ function setupWorkerHandlers(
     // Restart recovery (daemon restart batch-restore): stay silent in the chat.
     // Without this guard every restored session whose worker fails to start
     // posts a "会话启动失败" card into its own topic — a broadcast storm during
-    // bulk restore. The failure still lands in the daemon log below; the owner
-    // gets the recovery DM summary instead, and the next real user turn clears
-    // suppressRecoveryCard (rememberLastCliInput) so later failures notify
-    // normally. Do NOT set failureNotified here: a later generation failing
-    // after the flag clears must still surface.
+    // bulk restore. The failure still lands in the daemon log below; the next
+    // real user turn surfaces it via the ordinary ingress-failure notice, and
+    // the next successful CLI input clears suppressRecoveryCard
+    // (rememberLastCliInput) so later failures notify normally. Do NOT set
+    // failureNotified here: a later generation failing after the flag clears
+    // must still surface.
     if (ds.suppressRecoveryCard) {
       logger.warn(
         `[${t}] Startup failure notification suppressed by suppressRecoveryCard `

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -299,6 +299,7 @@ import { claimInitialUserTurn, isInitialUserTurnPending, releaseInitialUserTurn 
 import { applyQueuedCodexAppLegacyFallback, mergeQueuedCodexAppTurn } from './core/session-create.js';
 import { fillNativeTopicId } from './core/native-topic-id.js';
 import { findOnlineDaemon, listOnlineDaemons } from './utils/daemon-discovery.js';
+import { botmuxVersion } from './utils/install-info.js';
 import { beginReplyTargetTurn, buildTurnParticipantsFrom, chatSessionAnsweredRootAtTopLevel, fallbackTurnId, isSubstituteTurn, resolveInboundReplyTarget, resolveSessionReplyTarget, syncReplyTargetState } from './core/reply-target.js';
 import { readDeferredTopicBinding } from './core/deferred-topic-binding.js';
 import {
@@ -4041,6 +4042,10 @@ interface DaemonDescriptor {
    * never sees them; empty if the bot has no allowlist configured.
    */
   resolvedAllowedUsers: string[];
+  /** botmux version of this daemon process (from package.json). Absent for
+   * daemons started by older builds; lets `botmux status` detect a CLI↔daemon
+   * version mismatch after an npm upgrade. */
+  version?: string;
 }
 
 function writeDaemonDescriptor(d: DaemonDescriptor): void {
@@ -21864,6 +21869,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     // email/on_ forms; emitting only ou_ avoids a startup race where the dashboard
     // briefly sees an unusable on_/email (the resolution below rewrites this field).
     resolvedAllowedUsers: getBot(cfg.larkAppId).resolvedAllowedUsers.filter(u => u.startsWith('ou_')),
+    version: botmuxVersion(),
   };
   // Expose the live descriptor module-level so the deferred allowedUsers resolve
   // retry can republish healed open_ids coherently (see republishResolvedAllowedUsers).

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -20637,6 +20637,16 @@ async function handleThreadReplyAdmitted(
               : {}),
           },
         );
+        // A user-triggered refork ends the post-restart recovery silence. This
+        // queued path returns without rememberLastCliInput (the ordinary place
+        // that clears suppressRecoveryCard), so without this line the flag
+        // survives forever: a later async worker death is muted by
+        // notifyStartupFailure and the user gets zero feedback, message after
+        // message. Clear ONLY the recovery flag — no rememberLastCliInput here
+        // (it must not run when the fork throws, see the main refork path).
+        // Timing mirrors the main path: after forkWorker returned, so a sync
+        // throw keeps the flag and falls through to the ingress notice.
+        ds.suppressRecoveryCard = undefined;
         if (ownsInitialStartClaim()) retainInitialStartClaim = true;
       } catch (err) {
         ds.initialStartPending = false;
@@ -20661,6 +20671,11 @@ async function handleThreadReplyAdmitted(
           dispatchAttempt: ds.session.queuedActivationDispatchAttempt,
           ...(retainedQueuedActivation.trustedCaller ? { trustedCaller: retainedQueuedActivation.trustedCaller } : {}),
         });
+        // Same recovery-silence contract as the queuedActivationPending branch
+        // above: fork accepted → user has intervened → clear
+        // suppressRecoveryCard (this path also skips rememberLastCliInput), so
+        // a later async worker failure still notifies instead of being muted.
+        ds.suppressRecoveryCard = undefined;
         if (ownsInitialStartClaim()) retainInitialStartClaim = true;
       } catch (err) {
         // Keep the staged tail for a later activation attempt, but release the

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -6,6 +6,7 @@ import {
   withSecureHostParentSync,
   writeSecureHostFileSync,
 } from '../platform/secure-host-file.js';
+import { isLoopbackPeer } from '../utils/loopback-peers.js';
 
 const NONCE_TTL_MS = 60_000;
 const TS_WINDOW_S = 30;
@@ -45,7 +46,8 @@ export function signCliAuth(secretB64Url: string, bind?: string): HmacAttempt {
 
 /**
  * Verify a CLI rotation HMAC attempt.
- * - Source IP must be loopback (127.0.0.1 / ::1 / IPv4-mapped form).
+ * - Source IP must be loopback (127.0.0.1 / ::1 / IPv4-mapped form, plus any
+ *   BOTMUX_LOOPBACK_PEERS entries — see utils/loopback-peers.ts).
  * - Timestamp must be within ±TS_WINDOW_S seconds of now.
  * - Nonce must not have been seen in the last NONCE_TTL_MS.
  * - HMAC-SHA256(secret, `${ts}:${nonce}` [+ `:${bind}`]) must match `sig`
@@ -58,11 +60,7 @@ export function verifyHmac(
   remoteAddr: string,
   bind?: string,
 ): { ok: boolean; reason?: string } {
-  if (
-    remoteAddr !== '127.0.0.1' &&
-    remoteAddr !== '::1' &&
-    !remoteAddr.endsWith('::ffff:127.0.0.1')
-  ) {
+  if (!isLoopbackPeer(remoteAddr)) {
     return { ok: false, reason: 'remote_not_loopback' };
   }
   const tsNum = Number(attempt.ts);

--- a/src/dashboard/daemon-internal-auth.ts
+++ b/src/dashboard/daemon-internal-auth.ts
@@ -24,6 +24,8 @@
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 
+import { isLoopbackPeer } from '../utils/loopback-peers.js';
+
 /** Window during which a (ts, nonce) tuple is accepted; mirrors the spec ±60s. */
 export const TS_WINDOW_MS = 60_000;
 
@@ -94,12 +96,14 @@ export function checkSig(wireSig: string, expectedRaw: Buffer): boolean {
   return timingSafeEqual(provided, expectedRaw);
 }
 
-/** All-or-nothing loopback predicate, identical to `auth.ts`'s inline check. */
+/**
+ * All-or-nothing loopback predicate. Delegates to `utils/loopback-peers.ts`,
+ * which keeps the legacy default allow-list (127.0.0.1 / ::1 /
+ * ::ffff:127.0.0.1) and adds opt-in BOTMUX_LOOPBACK_PEERS entries for hosts
+ * whose kernel reports loopback peers as LAN IPs.
+ */
 export function isLoopback(remoteAddr: string | undefined): boolean {
-  if (!remoteAddr) return false;
-  if (remoteAddr === '127.0.0.1' || remoteAddr === '::1') return true;
-  if (remoteAddr.endsWith('::ffff:127.0.0.1')) return true;
-  return false;
+  return isLoopbackPeer(remoteAddr);
 }
 
 /** Persistent (in-memory) nonce store with lazy GC. */

--- a/src/utils/daemon-discovery.ts
+++ b/src/utils/daemon-discovery.ts
@@ -25,6 +25,9 @@ export interface OnlineDaemonInfo {
   cliId?: string;
   pid?: number;
   lastHeartbeat?: number;
+  /** botmux version of the process serving this daemon (from package.json).
+   * Absent for daemons started by older builds. */
+  version?: string;
 }
 
 const STALE_MS = 90_000;
@@ -88,6 +91,7 @@ export function listOnlineDaemons(dataDir?: string): OnlineDaemonInfo[] {
         ...(typeof d.cliId === 'string' && d.cliId.trim() ? { cliId: d.cliId.trim() } : {}),
         pid: d.pid,
         lastHeartbeat: d.lastHeartbeat,
+        ...(typeof d.version === 'string' && d.version.trim() ? { version: d.version.trim() } : {}),
       });
     } catch { /* malformed — skip */ }
   }
@@ -97,4 +101,30 @@ export function listOnlineDaemons(dataDir?: string): OnlineDaemonInfo[] {
 /** Find a specific online daemon by larkAppId. Returns null if offline / not found. */
 export function findOnlineDaemon(larkAppId: string, dataDir?: string): OnlineDaemonInfo | null {
   return listOnlineDaemons(dataDir).find(d => d.larkAppId === larkAppId) ?? null;
+}
+
+/**
+ * Compare the running CLI's version against the versions advertised by online
+ * daemons. Returns the first mismatching daemon version, or null when every
+ * daemon matches or no meaningful comparison is possible.
+ *
+ * - Daemons started by older builds don't publish a version field — skipped
+ *   (backward compat), never treated as a mismatch.
+ * - A source checkout reports '0.0.0' (the real version is injected only at
+ *   publish time). When the CLI itself runs from a checkout there is nothing
+ *   sensible to compare, so the check is skipped entirely rather than emitting
+ *   noise against daemons that may also be 0.0.0.
+ */
+export function detectDaemonVersionMismatch(
+  cliVersion: string,
+  daemons: OnlineDaemonInfo[],
+): string | null {
+  const cli = cliVersion.trim();
+  if (!cli || cli === '0.0.0') return null;
+  for (const d of daemons) {
+    const daemonVersion = (d.version ?? '').trim();
+    if (!daemonVersion) continue;
+    if (daemonVersion !== cli) return daemonVersion;
+  }
+  return null;
 }

--- a/src/utils/loopback-peers.ts
+++ b/src/utils/loopback-peers.ts
@@ -1,0 +1,223 @@
+/**
+ * Loopback peer predicate for internal HMAC-authenticated HTTP endpoints.
+ *
+ * Historically three call sites each inlined the same strict literal check
+ * (`127.0.0.1` / `::1` / `::ffff:127.0.0.1`). On hosts with a customized
+ * network stack the kernel can report a loopback TCP peer's address as a LAN
+ * IP, which made every internal HMAC request fail with 401. This module keeps
+ * the exact same default allow-list and adds an opt-in env extension:
+ *
+ *   BOTMUX_LOOPBACK_PEERS=10.0.0.5,192.168.0.0/16,fd00::/8
+ *
+ * Comma-separated IPv4/IPv6 literals or CIDRs. Invalid items are ignored
+ * (fail-closed: never throw, never allow) and logged once at parse time.
+ *
+ * The parsed env is cached for the process lifetime — daemon env is immutable
+ * after boot; tests reset the cache via __resetLoopbackPeersCacheForTest().
+ */
+
+import { logger } from './logger.js';
+
+/** Default loopback literals — semantics identical to the legacy inline checks. */
+function isDefaultLoopback(addr: string): boolean {
+  return (
+    addr === '127.0.0.1' ||
+    addr === '::1' ||
+    // covers ::ffff:127.0.0.1 (IPv4-mapped loopback); kept as a suffix check
+    // for byte-for-byte compatibility with the previous three call sites.
+    addr.endsWith('::ffff:127.0.0.1')
+  );
+}
+
+interface ParsedIp {
+  version: 4 | 6;
+  /** 32-bit value for IPv4, 128-bit value for IPv6. */
+  value: bigint;
+  /** Embedded IPv4 for IPv4-mapped IPv6 (::ffff:a.b.c.d), else undefined. */
+  mappedV4?: bigint;
+}
+
+const IPV4_RE = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+function parseIpv4Octets(addr: string): number[] | null {
+  const m = IPV4_RE.exec(addr);
+  if (!m) return null;
+  const octets = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
+  if (octets.some((o) => o > 255)) return null;
+  return octets;
+}
+
+function ipv4OctetsToBigInt(octets: number[]): bigint {
+  return (
+    (BigInt(octets[0]) << 24n) |
+    (BigInt(octets[1]) << 16n) |
+    (BigInt(octets[2]) << 8n) |
+    BigInt(octets[3])
+  );
+}
+
+const IPV6_GROUP_RE = /^[0-9a-fA-F]{1,4}$/;
+
+/**
+ * Parse an IPv6 literal, including the dotted-quad tail form
+ * (`::ffff:192.168.1.1`). Returns null on any malformed input.
+ */
+function parseIpv6(addr: string): ParsedIp | null {
+  // Strip a zone index (fe80::1%eth0) — socket peer addresses never carry
+  // one, but be lenient with hand-written env entries.
+  const zoneIdx = addr.indexOf('%');
+  let body = zoneIdx >= 0 ? addr.slice(0, zoneIdx) : addr;
+  if (body === '') return null;
+
+  // Dotted-quad tail occupies the final 32 bits (2 groups). Rewrite it as two
+  // hex groups up front so the ellipsis logic below only deals with pure IPv6.
+  const lastColon = body.lastIndexOf(':');
+  if (lastColon >= 0) {
+    const tail = body.slice(lastColon + 1);
+    if (tail.includes('.')) {
+      const octets = parseIpv4Octets(tail);
+      if (octets === null) return null;
+      const hi = ((octets[0] << 8) | octets[1]).toString(16);
+      const lo = ((octets[2] << 8) | octets[3]).toString(16);
+      body = `${body.slice(0, lastColon + 1)}${hi}:${lo}`;
+    }
+  }
+
+  const halves = body.split('::');
+  if (halves.length > 2) return null;
+
+  let groups: string[];
+  if (halves.length === 2) {
+    const head = halves[0] === '' ? [] : halves[0].split(':');
+    const tailGroups = halves[1] === '' ? [] : halves[1].split(':');
+    const missing = 8 - head.length - tailGroups.length;
+    if (missing < 1) return null; // '::' must compress at least one group
+    groups = [...head, ...Array<string>(missing).fill('0'), ...tailGroups];
+  } else {
+    // No ellipsis: exactly 8 groups, no padding.
+    groups = body.split(':');
+    if (groups.length !== 8) return null;
+  }
+  if (groups.length !== 8) return null;
+
+  let value = 0n;
+  for (const g of groups) {
+    if (!IPV6_GROUP_RE.test(g)) return null;
+    value = (value << 16n) | BigInt(parseInt(g, 16));
+  }
+
+  // IPv4-mapped (::ffff:a.b.c.d): top 80 bits zero, next 16 bits 0xffff.
+  // Parenthesize explicitly — `&` binds looser than `===` in JS.
+  const mappedV4 =
+    (value >> 48n) === 0n && ((value >> 32n) & 0xffffn) === 0xffffn
+      ? value & 0xffffffffn
+      : undefined;
+
+  return { version: 6, value, mappedV4 };
+}
+
+function parseIp(addr: string): ParsedIp | null {
+  const trimmed = addr.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes(':')) return parseIpv6(trimmed);
+  const octets = parseIpv4Octets(trimmed);
+  if (octets === null) return null;
+  return { version: 4, value: ipv4OctetsToBigInt(octets) };
+}
+
+interface CidrEntry {
+  version: 4 | 6;
+  network: bigint;
+  mask: bigint;
+}
+
+function prefixMask(bits: number, prefix: number): bigint {
+  if (prefix === 0) return 0n;
+  if (prefix >= bits) return (1n << BigInt(bits)) - 1n;
+  return ((1n << BigInt(bits)) - 1n) ^ ((1n << BigInt(bits - prefix)) - 1n);
+}
+
+/** Parse one env item (IP literal or CIDR). Returns null for invalid items. */
+function parseEntry(raw: string): CidrEntry | null {
+  const item = raw.trim();
+  if (!item) return null;
+  const slash = item.indexOf('/');
+  if (slash < 0) {
+    const ip = parseIp(item);
+    if (ip === null) return null;
+    const bits = ip.version === 4 ? 32 : 128;
+    return { version: ip.version, network: ip.value, mask: prefixMask(bits, bits) };
+  }
+  const ipPart = item.slice(0, slash).trim();
+  const prefixPart = item.slice(slash + 1).trim();
+  if (!/^\d+$/.test(prefixPart)) return null;
+  const prefix = Number(prefixPart);
+  const ip = parseIp(ipPart);
+  if (ip === null) return null;
+  const bits = ip.version === 4 ? 32 : 128;
+  if (prefix > bits) return null;
+  const mask = prefixMask(bits, prefix);
+  // Normalize host bits away so e.g. 192.168.1.5/16 behaves like 192.168.0.0/16.
+  return { version: ip.version, network: ip.value & mask, mask };
+}
+
+let cachedEntries: CidrEntry[] | null = null;
+
+function getEntries(): CidrEntry[] {
+  if (cachedEntries === null) {
+    cachedEntries = parseEnv(process.env.BOTMUX_LOOPBACK_PEERS);
+  }
+  return cachedEntries;
+}
+
+function parseEnv(raw: string | undefined): CidrEntry[] {
+  if (!raw) return [];
+  const entries: CidrEntry[] = [];
+  for (const part of raw.split(',')) {
+    const entry = parseEntry(part);
+    if (entry === null) {
+      // Fail-closed: skip the item, but surface the typo once at startup.
+      logger.warn(
+        `[loopback-peers] ignoring invalid BOTMUX_LOOPBACK_PEERS item: ${JSON.stringify(part)}`,
+      );
+      continue;
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+function entryMatches(entry: CidrEntry, ip: ParsedIp): boolean {
+  if (entry.version === 4) {
+    // An IPv4 env entry matches a native IPv4 peer and an IPv4-mapped IPv6
+    // peer (::ffff:192.168.1.1 counts as 192.168.1.1) — a custom kernel may
+    // report either family for the same loopback connection.
+    const v4 = ip.version === 4 ? ip.value : ip.mappedV4;
+    if (v4 === undefined) return false;
+    return (v4 & entry.mask) === entry.network;
+  }
+  // IPv6 env entries compare full 128-bit values; a native IPv4 peer never
+  // matches an IPv6 entry (write an IPv4 entry for those).
+  if (ip.version !== 6) return false;
+  return (ip.value & entry.mask) === entry.network;
+}
+
+/**
+ * Whether a socket peer address counts as loopback for internal HMAC auth.
+ *
+ * Default semantics (unchanged): `127.0.0.1`, `::1`, and any address ending
+ * with `::ffff:127.0.0.1`. Additional peers come from BOTMUX_LOOPBACK_PEERS.
+ * Empty/undefined/unparseable addresses are rejected.
+ */
+export function isLoopbackPeer(addr: string | undefined | null): boolean {
+  if (!addr) return false;
+  if (isDefaultLoopback(addr)) return true;
+  const ip = parseIp(addr);
+  if (ip === null) return false;
+  return getEntries().some((e) => entryMatches(e, ip));
+}
+
+/** Test-only: drop the cached env parse so the next call re-reads the env. */
+export function __resetLoopbackPeersCacheForTest(): void {
+  cachedEntries = null;
+}

--- a/src/workflows/v3/daemon-ipc-auth.ts
+++ b/src/workflows/v3/daemon-ipc-auth.ts
@@ -23,6 +23,7 @@ import type { IncomingMessage } from 'node:http';
 
 import { dashboardSecretPath } from '../../core/dashboard-secret.js';
 import { loadDashboardSecret } from '../../dashboard/auth.js';
+import { isLoopbackPeer } from '../../utils/loopback-peers.js';
 
 export const WORKFLOW_DAEMON_IPC_DOMAIN = 'botmux-workflow-daemon-ipc/v1';
 export const WORKFLOW_DAEMON_IPC_RESPONSE_DOMAIN = 'botmux-workflow-daemon-ipc/v1/response';
@@ -216,7 +217,7 @@ function headerString(req: IncomingMessage, name: string): string | undefined {
 }
 
 function isLoopback(address: string | undefined): boolean {
-  return address === '127.0.0.1' || address === '::1' || Boolean(address?.endsWith('::ffff:127.0.0.1'));
+  return isLoopbackPeer(address);
 }
 
 async function readBoundedBody(

--- a/test/daemon-ordinary-ingress-failure-notice.test.ts
+++ b/test/daemon-ordinary-ingress-failure-notice.test.ts
@@ -440,4 +440,62 @@ describe('durable admission then failing status reply → no resend advice (PR #
     expect(repliedText()).toContain(resendNotice());
     expect(repliedText()).not.toContain(admittedNotice());
   });
+
+  it('queued-activation-pending refork clears suppressRecoveryCard (user inbound ends restart silence)', async () => {
+    const anchor = 'om_thread_queued_pending';
+    const ds = seedThreadSession(anchor, 'seeded') as any;
+    // Restart restore: recovery silence set, a queued activation still pending
+    // from before the daemon died.
+    ds.suppressRecoveryCard = true;
+    ds.session.queuedActivationPending = true;
+    ds.session.queuedActivationInput = '';
+    ds.session.queuedActivationTurnId = 'turn-queued-pending-1';
+
+    await handleThreadReply(
+      makeEventData('om_msg_qp', '继续', anchor),
+      makeCtx(anchor, 'om_msg_qp'),
+    );
+
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    // This branch returns without rememberLastCliInput, so it must clear the
+    // recovery flag itself — otherwise every later async worker death stays
+    // muted and the session is permanently silent.
+    expect(ds.suppressRecoveryCard).toBeUndefined();
+  });
+
+  it('retained-queued-activation refork clears suppressRecoveryCard too', async () => {
+    const anchor = 'om_thread_queued_retained';
+    const ds = seedThreadSession(anchor, 'seeded') as any;
+    ds.suppressRecoveryCard = true;
+    ds.session.queued = true;
+    ds.session.queuedActivationInput = { content: 'retained opening task' };
+    ds.session.queuedActivationTurnId = 'turn-queued-retained-1';
+
+    await handleThreadReply(
+      makeEventData('om_msg_qr', '继续任务', anchor),
+      makeCtx(anchor, 'om_msg_qr'),
+    );
+
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.suppressRecoveryCard).toBeUndefined();
+  });
+
+  it('queued refork keeps suppressRecoveryCard when forkWorker throws synchronously (clear happens only after acceptance)', async () => {
+    const anchor = 'om_thread_queued_throw';
+    const ds = seedThreadSession(anchor, 'seeded') as any;
+    ds.suppressRecoveryCard = true;
+    ds.session.queuedActivationPending = true;
+    ds.session.queuedActivationInput = '';
+    mocks.forkWorker.mockImplementationOnce(() => {
+      throw new Error('fork threw: EAGAIN');
+    });
+
+    await expect(
+      handleThreadReply(makeEventData('om_msg_qt', '继续', anchor), makeCtx(anchor, 'om_msg_qt')),
+    ).rejects.toThrow('fork threw: EAGAIN');
+
+    // Timing contract: the flag is cleared only AFTER forkWorker returns. A
+    // sync throw keeps the silence and routes to the ingress-notice catch.
+    expect(ds.suppressRecoveryCard).toBe(true);
+  });
 });

--- a/test/daemon-version-mismatch.test.ts
+++ b/test/daemon-version-mismatch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { detectDaemonVersionMismatch, type OnlineDaemonInfo } from '../src/utils/daemon-discovery.js';
+
+function daemon(version?: string): OnlineDaemonInfo {
+  return {
+    larkAppId: 'cli_test',
+    ipcPort: 1,
+    ...(version === undefined ? {} : { version }),
+  };
+}
+
+describe('detectDaemonVersionMismatch', () => {
+  it('returns null when every daemon advertises the same version as the CLI', () => {
+    expect(detectDaemonVersionMismatch('1.2.3', [daemon('1.2.3'), daemon('1.2.3')])).toBeNull();
+  });
+
+  it('returns the mismatching daemon version when a daemon runs older code', () => {
+    expect(detectDaemonVersionMismatch('1.2.3', [daemon('1.2.3'), daemon('1.1.0')])).toBe('1.1.0');
+  });
+
+  it('skips daemons without a version field (old daemons, backward compat)', () => {
+    expect(detectDaemonVersionMismatch('1.2.3', [daemon(), daemon(undefined)])).toBeNull();
+  });
+
+  it('skips the check entirely when the CLI runs from a source checkout (0.0.0)', () => {
+    expect(detectDaemonVersionMismatch('0.0.0', [daemon('1.2.3')])).toBeNull();
+    expect(detectDaemonVersionMismatch('', [daemon('1.2.3')])).toBeNull();
+  });
+
+  it('treats a source-checkout daemon (0.0.0) against a published CLI as a mismatch', () => {
+    expect(detectDaemonVersionMismatch('1.2.3', [daemon('0.0.0')])).toBe('0.0.0');
+  });
+
+  it('returns null when no daemons are online', () => {
+    expect(detectDaemonVersionMismatch('1.2.3', [])).toBeNull();
+  });
+
+  it('ignores blank version strings', () => {
+    expect(detectDaemonVersionMismatch('1.2.3', [daemon('   ')])).toBeNull();
+  });
+});

--- a/test/loopback-peers.test.ts
+++ b/test/loopback-peers.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockWarn = vi.fn();
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: (...a: any[]) => mockWarn(...a), error: vi.fn() },
+}));
+
+import {
+  isLoopbackPeer,
+  __resetLoopbackPeersCacheForTest,
+} from '../src/utils/loopback-peers.js';
+
+const ENV_KEY = 'BOTMUX_LOOPBACK_PEERS';
+let savedEnv: string | undefined;
+
+function setEnv(value: string | undefined): void {
+  if (value === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = value;
+  __resetLoopbackPeersCacheForTest();
+}
+
+beforeEach(() => {
+  savedEnv = process.env[ENV_KEY];
+  delete process.env[ENV_KEY];
+  __resetLoopbackPeersCacheForTest();
+  mockWarn.mockReset();
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = savedEnv;
+  __resetLoopbackPeersCacheForTest();
+});
+
+describe('isLoopbackPeer — defaults (no env)', () => {
+  it('allows the legacy loopback literals', () => {
+    expect(isLoopbackPeer('127.0.0.1')).toBe(true);
+    expect(isLoopbackPeer('::1')).toBe(true);
+    expect(isLoopbackPeer('::ffff:127.0.0.1')).toBe(true);
+  });
+
+  it('rejects LAN and non-loopback addresses', () => {
+    expect(isLoopbackPeer('192.168.1.5')).toBe(false);
+    expect(isLoopbackPeer('10.0.0.1')).toBe(false);
+    expect(isLoopbackPeer('172.16.0.1')).toBe(false);
+    expect(isLoopbackPeer('fe80::1')).toBe(false);
+    expect(isLoopbackPeer('2001:db8::1')).toBe(false);
+  });
+
+  it('rejects empty / undefined / unparseable input', () => {
+    expect(isLoopbackPeer(undefined)).toBe(false);
+    expect(isLoopbackPeer(null)).toBe(false);
+    expect(isLoopbackPeer('')).toBe(false);
+    expect(isLoopbackPeer('localhost')).toBe(false);
+  });
+});
+
+describe('isLoopbackPeer — BOTMUX_LOOPBACK_PEERS IP literals', () => {
+  it('allows an env-configured IPv4 while still rejecting other LAN IPs', () => {
+    setEnv('10.0.0.5');
+    expect(isLoopbackPeer('10.0.0.5')).toBe(true);
+    expect(isLoopbackPeer('10.0.0.6')).toBe(false);
+    expect(isLoopbackPeer('192.168.1.5')).toBe(false);
+    // defaults still hold
+    expect(isLoopbackPeer('127.0.0.1')).toBe(true);
+    expect(isLoopbackPeer('::ffff:127.0.0.1')).toBe(true);
+  });
+
+  it('allows an env-configured IPv6 literal', () => {
+    setEnv('fd00::1234');
+    expect(isLoopbackPeer('fd00::1234')).toBe(true);
+    expect(isLoopbackPeer('fd00::1235')).toBe(false);
+  });
+
+  it('tolerates whitespace around entries', () => {
+    setEnv(' 10.0.0.5 , 192.168.1.10 ');
+    expect(isLoopbackPeer('10.0.0.5')).toBe(true);
+    expect(isLoopbackPeer('192.168.1.10')).toBe(true);
+    expect(isLoopbackPeer('10.0.0.6')).toBe(false);
+  });
+});
+
+describe('isLoopbackPeer — CIDR', () => {
+  it('matches IPv4 CIDR in-segment and rejects out-of-segment', () => {
+    setEnv('192.168.0.0/16');
+    expect(isLoopbackPeer('192.168.1.5')).toBe(true);
+    expect(isLoopbackPeer('192.168.255.254')).toBe(true);
+    expect(isLoopbackPeer('192.169.1.1')).toBe(false);
+    expect(isLoopbackPeer('10.0.0.1')).toBe(false);
+  });
+
+  it('normalizes host bits in an IPv4 CIDR entry', () => {
+    setEnv('192.168.1.5/16');
+    expect(isLoopbackPeer('192.168.2.3')).toBe(true);
+  });
+
+  it('matches IPv6 CIDR with bigint mask comparison', () => {
+    setEnv('fd00::/8');
+    expect(isLoopbackPeer('fd00::1')).toBe(true);
+    expect(isLoopbackPeer('fdff::1')).toBe(true);
+    expect(isLoopbackPeer('fe00::1')).toBe(false);
+    expect(isLoopbackPeer('fe80::1')).toBe(false);
+  });
+
+  it('matches an IPv4-mapped IPv6 peer against an IPv4 CIDR entry', () => {
+    setEnv('192.168.0.0/16');
+    expect(isLoopbackPeer('::ffff:192.168.1.5')).toBe(true);
+    expect(isLoopbackPeer('::ffff:10.0.0.1')).toBe(false);
+  });
+
+  it('matches an IPv4-mapped IPv6 env entry against the same peer', () => {
+    setEnv('::ffff:192.168.1.1');
+    expect(isLoopbackPeer('::ffff:192.168.1.1')).toBe(true);
+    expect(isLoopbackPeer('::ffff:192.168.1.2')).toBe(false);
+  });
+
+  it('supports a /0 catch-all per family', () => {
+    setEnv('0.0.0.0/0');
+    expect(isLoopbackPeer('8.8.8.8')).toBe(true);
+    expect(isLoopbackPeer('fd00::1')).toBe(false);
+    setEnv('::/0');
+    expect(isLoopbackPeer('fd00::1')).toBe(true);
+    expect(isLoopbackPeer('8.8.8.8')).toBe(false);
+  });
+});
+
+describe('isLoopbackPeer — invalid env items are ignored (fail-closed)', () => {
+  it('ignores non-IP, out-of-range octets, and oversized prefixes without throwing', () => {
+    expect(() => setEnv('not-an-ip,999.1.1.1/8,10.0.0.0/99')).not.toThrow();
+    expect(isLoopbackPeer('10.0.0.1')).toBe(false);
+    expect(isLoopbackPeer('999.1.1.1')).toBe(false);
+    expect(isLoopbackPeer('127.0.0.1')).toBe(true);
+    // each invalid item surfaced a warning, never an allow
+    expect(mockWarn).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps valid entries alongside invalid ones', () => {
+    setEnv('not-an-ip,10.0.0.5,garbage/24');
+    expect(isLoopbackPeer('10.0.0.5')).toBe(true);
+    expect(isLoopbackPeer('10.0.0.6')).toBe(false);
+  });
+
+  it('ignores IPv6 prefixes longer than 128', () => {
+    expect(() => setEnv('fd00::/129')).not.toThrow();
+    expect(isLoopbackPeer('fd00::1')).toBe(false);
+  });
+
+  it('treats an empty env as no extra entries', () => {
+    setEnv('');
+    expect(isLoopbackPeer('10.0.0.1')).toBe(false);
+    expect(isLoopbackPeer('127.0.0.1')).toBe(true);
+  });
+});
+
+describe('isLoopbackPeer — ::ffff:127.0.0.1 invariant', () => {
+  it('is always allowed regardless of env', () => {
+    expect(isLoopbackPeer('::ffff:127.0.0.1')).toBe(true);
+    setEnv('10.0.0.5');
+    expect(isLoopbackPeer('::ffff:127.0.0.1')).toBe(true);
+    setEnv('not-an-ip');
+    expect(isLoopbackPeer('::ffff:127.0.0.1')).toBe(true);
+  });
+});

--- a/test/worker-startup-suppress-recovery.test.ts
+++ b/test/worker-startup-suppress-recovery.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Daemon-side wiring test — worker-pool `notifyStartupFailure` recovery-mode
+ * suppression (restart broadcast-storm fix).
+ *
+ * Pins the contract: while `ds.suppressRecoveryCard` is set (daemon-restart
+ * batch restore, cleared by the first real CLI input), a worker startup
+ * failure must NOT post a "会话启动失败" card into the session's chat — the
+ * failure still lands in the daemon log. Once the flag clears, failures
+ * notify normally again.
+ *
+ * Harness mirrors worker-startup-retry-wiring.test.ts (fake worker
+ * EventEmitter + __testOnly_setupWorkerHandlers).
+ *
+ * Run:  pnpm vitest run --project unit test/worker-startup-suppress-recovery.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('../src/im/lark/client.js', () => {
+  class MessageWithdrawnError extends Error {
+    constructor(id: string) { super(`withdrawn: ${id}`); this.name = 'MessageWithdrawnError'; }
+  }
+  return {
+    updateMessage: vi.fn(async () => {}),
+    deleteMessage: vi.fn(async () => {}),
+    MessageWithdrawnError,
+  };
+});
+
+vi.mock('../src/im/lark/card-builder.js', () => ({
+  buildStreamingCard: vi.fn(() => '{"type":"streaming"}'),
+  buildSessionCard: vi.fn(() => '{"type":"session"}'),
+  buildTuiPromptCard: vi.fn(() => '{}'),
+  buildTuiPromptResolvedCard: vi.fn(() => '{}'),
+  getCliDisplayName: vi.fn(() => 'Codex'),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'codex' },
+    resolvedAllowedUsers: [],
+    botOpenId: 'ou_bot',
+    botName: 'TestBot',
+  })),
+  getAllBots: vi.fn(() => []),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    web: { externalHost: 'localhost' },
+    session: { dataDir: '/tmp/test-sessions' },
+    daemon: { backendType: 'tmux', cliId: 'codex' },
+  },
+}));
+
+const updateSessionMock = vi.fn();
+const sessionReplyMock = vi.fn(async () => 'om_reply');
+vi.mock('../src/services/session-store.js', () => ({
+  registerSessionBridgeSendMarkerCleanupFence: vi.fn(),
+  cleanupSessionBridgeSendMarkers: vi.fn(),
+  cleanupSessionBridgeSendMarkersNow: vi.fn(),
+  closeSession: vi.fn(),
+  updateSession: (...args: any[]) => updateSessionMock(...args),
+}));
+
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  loadFrozenCards: vi.fn(() => new Map()),
+  saveFrozenCards: vi.fn(),
+}));
+
+vi.mock('../src/services/session-lifecycle-hooks.js', () => ({
+  emitSessionLifecycleHook: vi.fn(),
+  emitSessionStateTransitionHook: vi.fn(),
+}));
+
+vi.mock('../src/core/session-manager.js', () => ({
+  persistStreamCardState: vi.fn(),
+  ensureSessionWhiteboard: vi.fn(),
+  rememberLastCliInput: vi.fn(),
+}));
+
+vi.mock('../src/core/dashboard-events.js', () => ({
+  dashboardEventBus: { publish: vi.fn() },
+}));
+
+vi.mock('../src/core/dashboard-rows.js', () => ({
+  composeRowFromActive: vi.fn(),
+}));
+
+vi.mock('../src/skills/installer.js', () => ({
+  ensureSkills: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/registry.js', () => ({
+  createCliAdapterSync: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/claude-code.js', () => ({
+  claudeJsonlPathForSession: vi.fn(),
+}));
+
+vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
+  TmuxBackend: class {},
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: class { constructor() {} },
+  WSClient: class { start() {} },
+  EventDispatcher: class { register() {} },
+  LoggerLevel: { info: 2 },
+}));
+
+import { initWorkerPool, __testOnly_setupWorkerHandlers, restartCounts } from '../src/core/worker-pool.js';
+import { logger } from '../src/utils/logger.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+function makeFakeWorker() {
+  const w = new EventEmitter() as any;
+  w.killed = false;
+  w.send = vi.fn();
+  w.kill = vi.fn();
+  w.pid = 12345;
+  w.stdout = new EventEmitter();
+  w.stderr = new EventEmitter();
+  return w;
+}
+
+function makeDs(sessionId: string, worker: any): DaemonSession {
+  return {
+    session: {
+      sessionId,
+      rootMessageId: 'om_root',
+      chatId: 'oc_chat',
+      title: 'Test Session',
+      status: 'active' as any,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      pid: null,
+      chatType: 'group',
+    },
+    worker,
+    workerPort: null,
+    workerToken: null,
+    larkAppId: 'app_test',
+    chatId: 'oc_chat',
+    chatType: 'group',
+    spawnedAt: Date.now(),
+    cliVersion: '1.0',
+    lastMessageAt: Date.now(),
+    hasHistory: true,
+    displayMode: 'hidden',
+    lastScreenContent: '',
+    lastScreenStatus: 'working',
+    currentTurnTitle: 'Test task',
+  } as DaemonSession;
+}
+
+const flush = () => new Promise<void>(r => setTimeout(r, 0));
+
+const DETERMINISTIC_REASON = 'spawn codex ENOENT';
+
+describe("worker-pool startup failure × suppressRecoveryCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restartCounts.clear();
+    initWorkerPool({
+      sessionReply: sessionReplyMock,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    } as any);
+  });
+
+  it('suppresses the startup-failure card in recovery mode but still logs (daemon-restart restore)', async () => {
+    const ds = makeDs('sid-recovery-suppressed', makeFakeWorker());
+    ds.suppressRecoveryCard = true;
+    const worker = makeFakeWorker();
+    ds.worker = worker;
+    __testOnly_setupWorkerHandlers(ds, worker);
+    worker.emit('message', { type: 'error', message: DETERMINISTIC_REASON });
+    await flush();
+
+    expect(sessionReplyMock).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('suppressRecoveryCard'),
+    );
+    // The reason must stay visible in the daemon log for post-mortems.
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(DETERMINISTIC_REASON),
+    );
+  });
+
+  it('suppresses a turn-carrying startup failure in recovery mode too (guard precedes turn handling)', async () => {
+    const ds = makeDs('sid-recovery-turn', makeFakeWorker());
+    ds.suppressRecoveryCard = true;
+    const worker = makeFakeWorker();
+    ds.worker = worker;
+    __testOnly_setupWorkerHandlers(ds, worker);
+    worker.emit('message', {
+      type: 'error',
+      message: DETERMINISTIC_REASON,
+      turnId: 'turn-recovery-1',
+      dispatchAttempt: 1,
+    });
+    await flush();
+
+    expect(sessionReplyMock).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('suppressRecoveryCard'),
+    );
+  });
+
+  it('posts the startup-failure card when suppressRecoveryCard is off (regression guard)', async () => {
+    const ds = makeDs('sid-recovery-off', makeFakeWorker());
+    const worker = makeFakeWorker();
+    ds.worker = worker;
+    __testOnly_setupWorkerHandlers(ds, worker);
+    worker.emit('message', { type: 'error', message: DETERMINISTIC_REASON });
+    await flush();
+
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock).toHaveBeenCalledWith(
+      'om_root',
+      expect.stringContaining(DETERMINISTIC_REASON),
+      'text',
+      'app_test',
+      undefined,
+      undefined,
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('suppressRecoveryCard'),
+    );
+  });
+
+  it('does not permanently mute the session: a failure after the flag clears still notifies', async () => {
+    const ds = makeDs('sid-recovery-transient', makeFakeWorker());
+    ds.suppressRecoveryCard = true;
+    const worker = makeFakeWorker();
+    ds.worker = worker;
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    // First failure lands during recovery: suppressed, no card.
+    worker.emit('message', { type: 'error', message: DETERMINISTIC_REASON });
+    await flush();
+    expect(sessionReplyMock).not.toHaveBeenCalled();
+
+    // First real CLI input clears the recovery silence (rememberLastCliInput
+    // in production); the same worker generation failing again must notify.
+    ds.suppressRecoveryCard = undefined;
+    worker.emit('message', { type: 'error', message: DETERMINISTIC_REASON });
+    await flush();
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(sessionReplyMock).toHaveBeenCalledWith(
+      'om_root',
+      expect.stringContaining(DETERMINISTIC_REASON),
+      'text',
+      'app_test',
+      undefined,
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
# 稳定性专项（4 项修复）

来自「Botmux 交流群」用户反馈的稳定性专项。**已 rebase 到最新 master**，原 5 项中的 pm2 jlist 超时项因 master 完成 pm2→supervisor 迁移而作废（详见文末）。

## 改了什么

### 1. `fix(cli)`: ps 进程表扫描增加 maxBuffer 防止 ENOBUFS

进程表输出超过 Node 默认 1MiB 时 `execFileSync('ps')` 抛 ENOBUFS，导致相关功能 fail-closed。统一给进程表扫描加 `maxBuffer: 32MiB`，覆盖 6 处：`reasonix`、`zellij-backend`（×2）、`adopt-route`、`session-discovery`（×2）、`codex-rpc-engine`、`browser-restart`。

只影响输出超限的失败路径，成功路径输出字节等价。

### 2. `fix(worker-pool)`: 恢复模式下抑制启动失败卡片广播

daemon 重启批量恢复会话时，每个失败 worker 都往自己会话发「会话启动失败」卡片，形成广播风暴。`notifyStartupFailure` 在 `suppressRecoveryCard` 期间只写 daemon 日志、不发卡片。

关键不变量：**不设 `failureNotified`** —— 抑制解除后同代 worker 再失败仍会正常通知，失败不会被永久吞掉。

配套修复两条 queued refork 路径（`queuedActivationPending` / `retainedQueuedActivation`）：这两条 fork 后直接 return、不走 `rememberLastCliInput`（全仓唯一清除 `suppressRecoveryCard` 的地方），标志会永久残留，导致后续每条消息的启动失败都被静默、用户零反馈。改为在 **forkWorker 被接受之后**清除该标志（时序对齐主 refork 路径：fork 同步抛错时保留标志，回落到 ingress notice 通道）。

### 3. `fix(dashboard)`: loopback 判定支持自定义放行地址

定制内核会把 loopback peer 上报成 LAN IP，导致 4 处 HMAC 认证点严格 `127.0.0.1/::1` 判定全部 401。新建 `src/utils/loopback-peers.ts`，支持 env `BOTMUX_LOOPBACK_PEERS`（IP/CIDR）额外放行。

**默认行为与原内联检查逐字节等价**，非法项 fail-closed 忽略（只跳过、不抛错、不放行）。迁移 4 处门禁：`dashboard/auth`、`daemon-internal-auth`、`workflows/v3/daemon-ipc-auth`、`dashboard-ipc-server`（migrate-to-chat）。

### 4. `feat(cli)`: status 检测 CLI 与 daemon 版本错配

升级 npm 包后 daemon 仍跑旧代码，新功能静默失效。`DaemonDescriptor` 加可选 `version` 字段，`botmux status` 检测到错配时打印醒目警告并提示 restart。

向后兼容：旧 daemon 无该字段则跳过；CLI 运行在源码 checkout（`0.0.0`）时整体跳过。

## 关于原第 5 项（pm2 jlist 超时 env 化）

原 PR 含一项「pm2 jlist 超时改为 env 可配置」，rebase 时发现 master 已完成 **pm2 → supervisor 迁移**：

- 其唯一落点 `src/cli/restart-shutdown-preflight.ts` 已被删除，`pm2Capture` / `readVerifiedBotmuxPm2Projection` 整条 pm2 guard chain 一并移除；
- master 的 `shutdown-supervisor-contract.test.ts` 用契约测试钉死这些符号不得回归。

该项已随 pm2 逻辑一并删除。同样地，第 1 项中针对 cli.ts pm2 God 扫描的 2 处 maxBuffer（及其依赖已删函数的测试文件）也一并移除，其余 6 处保留。

## 影响面

- **跨平台**：ps 扫描覆盖 Linux/macOS；loopback 为纯 bigint 计算，无平台依赖
- **跨 CLI**：maxBuffer 只影响失败路径，不触及适配器运行时语义
- **跨后端 / 会话类型**：恢复抑制对话题/群/adopt 一视同仁；queued 两条路径的修复覆盖重启恢复场景
- **公共层**：loopback 4 处认证点默认零行为变化；descriptor 新增可选字段，既有读者向后兼容

## 测试验证

- `bun run build` 通过（tsc + dashboard bundle + 全部 audit）
- **pm2 契约测试通过** —— 确认 rebase 未把 master 已删除的 pm2 guard chain 带回
- 相关套件 14 个、333 用例全绿，含：本 PR 新增测试（恢复抑制 / queued 清标志 / loopback-peers / 版本错配）、4 处认证点、session-discovery、adopt-route、worker-startup 重试链路、refork 链路
- 对当前 master trial merge 无冲突