### PR TITLE
fix(event-dispatcher): 权限可观测性——无权限不再静默、解析失败可观测、跨 app ou_ 校验、改名防抖

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1683,6 +1683,39 @@ ipcRoute('POST', '/api/sessions/:sessionId/slash', async (req, res, params) => {
 const proactiveChatRenameCooldown = new ChatRenameCooldown();
 const chatRenameSerialQueue = new ChatRenameSerialQueue();
 
+/**
+ * `user_explicit` 改名豁免防抖的凭证核验：请求必须携带与 `ds.managedTurnOrigin`
+ * 匹配的当前 turn origin 凭证（read-isolated CLI 的 capability 回退路径），
+ * 证明改名绑定在一个真实的用户 turn 上。与 `sessionCliIpcAuth` 的区别：
+ * 后者 `trustedHost` 短路放行本机 HMAC 签名请求（不绑定任何 turn），这里
+ * 固定 `trustedHost: false`——本机进程身份不足以证明「用户这一轮要求改名」。
+ * 无凭证 / 凭证过期或不匹配 / 会话无活跃 turn → 一律不放行（调用方据此
+ * 强制走防抖）。
+ */
+function proveCurrentTurnOrigin(
+  ds: DaemonSession | undefined,
+  sessionId: string,
+  body: Record<string, unknown> | undefined,
+): { ok: true } | { ok: false; error: string } {
+  const claimedAttempt = typeof body?.originDispatchAttempt === 'number'
+    && Number.isSafeInteger(body.originDispatchAttempt)
+    && body.originDispatchAttempt > 0
+    ? body.originDispatchAttempt
+    : undefined;
+  const decision = authorizeSessionScopedIpc({
+    trustedHost: false,
+    sessionExists: !!ds,
+    receiverSession: !!ds?.session.vcMeetingReceiver,
+    allowReceiver: true,
+    sessionId,
+    liveOrigin: ds?.managedTurnOrigin,
+    claimedCapability: typeof body?.originCapability === 'string' ? body.originCapability : undefined,
+    claimedTurnId: typeof body?.originTurnId === 'string' ? body.originTurnId : undefined,
+    claimedDispatchAttempt: claimedAttempt,
+  });
+  return decision.ok ? { ok: true } : { ok: false, error: decision.error };
+}
+
 /** Session-scoped external mutation used by the botmux-chat-rename Skill. */
 ipcRoute('POST', '/api/sessions/:sessionId/chat-rename', async (req, res, params) => {
   const body = await readJsonBody<{ name?: unknown; proactive?: unknown } & Record<string, unknown>>(req)
@@ -1696,12 +1729,26 @@ ipcRoute('POST', '/api/sessions/:sessionId/chat-rename', async (req, res, params
   const normalized = normalizeLarkChatName(body.name);
   if (!normalized.ok) return jsonRes(res, 400, normalized);
 
-  const proactive = body.proactive === true;
-  const trigger = proactive ? 'ai_proactive' : 'user_explicit';
+  // 信任模型翻转：`user_explicit`（豁免 10 分钟防抖）不再由 CLI 自报——agent
+  // 漏传 `--proactive` 时服务端原先无核验，防抖被完全绕过。现在只有携带与
+  // `ds.managedTurnOrigin` 匹配的**当前 turn origin 凭证**（read-isolated CLI
+  // 的 capability 回退路径）才豁免防抖；trusted-host（HMAC 签名的本机请求）
+  // 只证明「本机进程」、不绑定具体用户 turn，不算数。无凭证/凭证过期或不匹配
+  // → 强制按 `ai_proactive` 走防抖（fail-closed：宁防抖勿绕过）。显式
+  // `--proactive` 本来就走防抖，行为不变。
+  let effectiveProactive = body.proactive === true;
+  let trigger = effectiveProactive ? 'ai_proactive' : 'user_explicit';
+  if (!effectiveProactive) {
+    const originDecision = proveCurrentTurnOrigin(ds, params.sessionId, body);
+    if (!originDecision.ok) {
+      effectiveProactive = true;
+      trigger = 'ai_proactive';
+    }
+  }
   const cooldownKey = `${ds.larkAppId}:${ds.chatId}`;
   await chatRenameSerialQueue.run(cooldownKey, async () => {
     const result = await groupsStore.renameChat(ds.larkAppId, ds.chatId, normalized.name, {
-      beforeUpdate: proactive
+      beforeUpdate: effectiveProactive
         ? () => {
             const cooldown = proactiveChatRenameCooldown.check(cooldownKey);
             return cooldown.ok
@@ -1725,7 +1772,7 @@ ipcRoute('POST', '/api/sessions/:sessionId/chat-rename', async (req, res, params
       return jsonRes(res, status, result);
     }
     if (result.changed) {
-      if (proactive) proactiveChatRenameCooldown.record(cooldownKey);
+      if (effectiveProactive) proactiveChatRenameCooldown.record(cooldownKey);
       // FR-7: the Lark write already succeeded, so a local cache-refresh
       // failure (ENOSPC/EACCES on the session store) must NOT reverse the
       // outcome into an HTTP 500 — best-effort per session, warn and keep the

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -117,6 +117,7 @@ import type { CliTurnPayload, Session, TrustedCaller, VcMeetingImTurnOrigin, Tur
 import { ensureCjkFontsInstalled } from './utils/font-installer.js';
 import { scrubTmuxServerGlobalEnv } from './setup/ensure-tmux.js';
 import { entryNeedsContactResolve } from './setup/bot-config-editor.js';
+import { detectUnusableOwnerEntries } from './setup/owner-identity.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
 import { validateWorkingDir } from './core/working-dir.js';
 import type { DaemonToWorker, LarkAttachment, LarkMessage } from './types.js';
@@ -22101,6 +22102,18 @@ export async function startDaemon(botIndex?: number): Promise<void> {
             notifyAllowedUsersResolveFailure(cfg.larkAppId, applied.notice, applied.resolved);
             scheduleAllowedUsersResolveRetry(cfg.larkAppId);
           }
+          // B-2: 确定性解析失败（邮箱不存在/不可见/手机号无效）与瞬态故障不同——
+          // 重试无意义，也不会走缓存兜底。此前这类条目被静默丢弃，owner 完全无感知。
+          // 现在 DM owner 列出无法解析的条目（不拒绝启动：可能是临时不可见，且
+          // self-lockout 防护已保证 owner 自身仍在名单内）。
+          if (resolveResult.definitiveMisses.length > 0) {
+            logger.warn(`[${cfg.larkAppId}] allowedUsers 中 ${resolveResult.definitiveMisses.length} 个条目确定性解析失败（未生效，非瞬态不重试）：${resolveResult.definitiveMisses.join(', ')}`);
+            notifyAllowedUsersResolveFailure(
+              cfg.larkAppId,
+              `以下 allowedUsers 条目确定性解析失败，未生效（非瞬态故障，不会自动重试；如确认条目有效，请检查其在本企业/本应用下的可见性）：${resolveResult.definitiveMisses.join(', ')}`,
+              bot.resolvedAllowedUsers,
+            );
+          }
         } catch (err: any) {
           // A full throw is a transient outage: mark every contact-resolvable
           // entry transient so the pure fn can recover each from cache.
@@ -22134,6 +22147,27 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       // will eventually catch up too.
       desc.resolvedAllowedUsers = bot.resolvedAllowedUsers.filter(u => u.startsWith('ou_'));
       try { writeDaemonDescriptor(desc); } catch { /* best effort */ }
+
+      // B-3: 启动期跨 app ou_ 巡检（不拒绝启动）。ou_ 是 app-scoped——从别的 Bot
+      // 复制来的 open_id 在本应用下永远无法匹配发送者，会静默锁死所有人。用本 bot
+      // 凭证探测 ou_/on_ 条目，确定性不可用（99992361 / 41012 / 40001 / code-0 无
+      // user）→ DM owner 警告；网络/scope 错误保持 inconclusive（返回 []），不告警。
+      // 纯 ou_ 名单不走上面的 resolve 块（needsResolve=false），所以巡检放在块外。
+      // fire-and-forget：巡检是建议性警告，不阻塞 daemon 启动。
+      const idEntries = configured.filter(e => e.startsWith('ou_') || e.startsWith('on_'));
+      if (idEntries.length > 0) {
+        void detectUnusableOwnerEntries(cfg.larkAppId, cfg.larkAppSecret, normalizeBrand(cfg.brand), idEntries)
+          .then((unusable) => {
+            if (unusable.length === 0) return;
+            logger.warn(`[${cfg.larkAppId}] allowedUsers 中 ${unusable.length} 个 ou_/on_ 条目在本应用下不可用（可能是其他应用的 open_id）：${unusable.join(', ')}`);
+            notifyAllowedUsersResolveFailure(
+              cfg.larkAppId,
+              `以下 allowedUsers 身份条目在本应用下无法解析（可能是其他应用的 open_id，请改用邮箱/手机号/union_id(on_)）：${unusable.join(', ')}`,
+              bot.resolvedAllowedUsers,
+            );
+          })
+          .catch(() => { /* inconclusive：网络/scope 错误，不告警 */ });
+      }
     }
 
     checkAllowedChatGroupsConfig(bot);

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1245,9 +1245,36 @@ export async function uploadFile(larkAppId: string, filePath: string, opts?: { d
  */
 export type EntryResolveStatus = 'resolved' | 'transient' | 'definitive';
 
+/**
+ * Result of an allowedUsers resolve. `resolved` / `map` feed the runtime
+ * allowlist and `/revoke` reverse-lookup; `errored` + `entryStatus` drive the
+ * last-known-good cache merge (see allowed-users-apply.ts); `definitiveMisses`
+ * surfaces entries that this pass PROVED unresolvable so callers can warn
+ * instead of silently dropping them.
+ */
+export interface AllowedUsersResolveResult {
+  /** Runtime allowlist: `ou_` only, deduped, raw config order preserved. */
+  resolved: string[];
+  /** `raw entry → ou_` map; key equals the literal string in allowedUsers. */
+  map: Map<string, string>;
+  /** True when contact API hit a transient failure (network / 5xx / rate limit). */
+  errored?: boolean;
+  /** Per-raw-entry outcome; entries absent from the map are treated as `definitive`. */
+  entryStatus: Map<string, EntryResolveStatus>;
+  /**
+   * Raw entries (email / mobile / on_) that this pass DEFINITIVELY could not
+   * resolve (a code-0 batch omitted them, or a definitive contact code such as
+   * 41050 / 41012 / 40001). These are NOT transient — no retry will help and
+   * they must never be revived from the last-known-good cache. Literal `ou_`
+   * entries are always 'resolved' (kept as-is) and never appear here.
+   * Callers surface them as warnings / notices rather than failing the resolve.
+   */
+  definitiveMisses: string[];
+}
+
 export async function resolveAllowedUsersWithMap(
   larkAppId: string, raw: string[],
-): Promise<{ resolved: string[]; map: Map<string, string>; errored?: boolean; entryStatus: Map<string, EntryResolveStatus> }> {
+): Promise<AllowedUsersResolveResult> {
   const map = new Map<string, string>();
   // True when a TRANSIENT failure (throw / rate limit / server error) hit any
   // requested item — the caller can then say "resolution failed, retry" instead
@@ -1377,6 +1404,10 @@ export async function resolveAllowedUsersWithMap(
               // the returned user_list → definitive miss (no such user / not
               // visible), NOT a transient failure. Do not fall back to cache.
               entryStatus.set(rawEmail, 'definitive');
+              // B-2: a definitive miss used to be completely silent — the entry
+              // vanished from the runtime allowlist with no log line at all.
+              logger.warn(`allowedUsers email ${rawEmail} definitively unresolved for ${larkAppId} ` +
+                `(code-0 batch omitted it: no such user / not visible); entry dropped from the runtime allowlist.`);
             }
           }
         }
@@ -1443,6 +1474,9 @@ export async function resolveAllowedUsersWithMap(
               // code-0 but this mobile absent from user_list → definitive miss
               // (no such user / not visible), same as the email case.
               entryStatus.set(rawEntry, 'definitive');
+              // B-2: same silent-drop fix as the email branch above.
+              logger.warn(`allowedUsers mobile ${rawEntry} definitively unresolved for ${larkAppId} ` +
+                `(code-0 batch omitted it: no such user / not visible); entry dropped from the runtime allowlist.`);
             }
           }
         }
@@ -1470,7 +1504,17 @@ export async function resolveAllowedUsersWithMap(
       resolved.push(oid);
     }
   }
-  return { resolved, map, errored, entryStatus };
+  // B-2: collect every entry this pass DEFINITIVELY could not resolve, in raw
+  // config order, so callers (runtime write → user-facing warning; startup path
+  // → owner DM) can surface them. Computed from entryStatus at the end so every
+  // definitive-marking site above (email batch / mobile batch / union_id
+  // single-get) is covered by one list. Literal ou_ is always 'resolved' and
+  // never appears; transient entries are excluded (retry may still recover them).
+  const definitiveMisses: string[] = [];
+  for (const v of raw) {
+    if (entryStatus.get(v) === 'definitive') definitiveMisses.push(v);
+  }
+  return { resolved, map, errored, entryStatus, definitiveMisses };
 }
 
 /**

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -43,7 +43,7 @@ import { autoInviteOwnerOnGroupJoin } from '../../services/groups-store.js';
 import { tryHandleReplyModeCommand } from './reply-mode-command.js';
 import { tryHandleSubstituteCommand } from './substitute-command.js';
 import { buildGrantCard } from './card-builder.js';
-import { openPending, isThrottled, clearPending } from './grant-pending.js';
+import { openPending, isThrottled, clearPending, shouldThrottleNotice } from './grant-pending.js';
 import { localeForBot, t } from '../../i18n/index.js';
 import {
   chatQuotaKey,
@@ -1934,17 +1934,32 @@ export function canRunDaemonCommand(
     : canTalk(larkAppId, chatId, senderOpenId, senderUnionId, memberUnionId, chatType);
 }
 
+/** 授权申请卡的处置结果，供调用方决定是否给发送者补发文本提示（卡本身就是反馈时不补）。 */
+export type GrantCardResult = 'sent' | 'throttled' | 'disabled' | 'no_owner' | 'no_requester';
+
+/** 无权限通用提示（p2p / 群聊 disabled / 无 owner 同口径）。文案中性，绝不携带 owner 身份信息。 */
+const NO_PERMISSION_NOTICE_TEXT = '你没有权限使用此 Bot。如需访问权限，请联系管理员。';
+/** 授权卡已在 pending / denied 冷却中被抑制时的提示。 */
+const GRANT_PENDING_NOTICE_TEXT = '授权申请已提交，正在等待管理员处理（或冷却中），请稍后再试。';
+/** 发送者侧提示节流窗口（per-(bot,chat,sender) / per-(bot,sender)）。 */
+const NOTICE_THROTTLE_MS = 10 * 60 * 1000;
+/** owner DM 节流窗口（per-(bot,owner)：不管多少陌生人来问，一天只 DM 一次）。 */
+const OWNER_DM_THROTTLE_MS = 24 * 60 * 60 * 1000;
+
 /**
  * 入口 A：无权限者 @bot 时弹授权申请卡（正文 @owner，由 owner 处置）。
  * 受 grant-pending 节流：pending 中 / deny 冷却期内静默不发。开放模式（无 owner）兜底不发。
+ * 返回处置结果：'sent'（卡已发，卡本身即反馈）/ 'throttled'（被节流抑制）/
+ * 'disabled'（autoGrantRequestCards=false）/ 'no_owner' / 'no_requester'。
  */
 async function maybeSendGrantRequestCard(
   larkAppId: string, message: any, chatId: string, requesterOpenId: string | undefined, messageData?: any,
-): Promise<void> {
-  if (getBot(larkAppId).config.autoGrantRequestCards === false) return;
+): Promise<GrantCardResult> {
+  if (getBot(larkAppId).config.autoGrantRequestCards === false) return 'disabled';
   const owner = getOwnerOpenId(larkAppId);
-  if (!owner || !requesterOpenId) return;
-  if (isThrottled(larkAppId, chatId, requesterOpenId)) return;
+  if (!owner) return 'no_owner';
+  if (!requesterOpenId) return 'no_requester';
+  if (isThrottled(larkAppId, chatId, requesterOpenId)) return 'throttled';
   // 名字优先级：本消息 mentions（真人发送方、被 @ 目标都在此）→ observed-bots 花名册
   // （/introduce 登记过的 (open_id,name)）→ 裸 open_id 兜底。外部 bot 发送方不在自己
   // 消息的 mentions 里（那是 @ 目标），只靠 mentions 会让 owner 只看到 open_id。
@@ -1988,6 +2003,59 @@ async function maybeSendGrantRequestCard(
       clearPending(larkAppId, chatId, requesterOpenId);
       logger.debug(`grant request card send failed: ${err}`);
     });
+  return 'sent';
+}
+
+/** 群聊授权卡未发出时，给发送者补发一条文本反馈（per-(bot,chat,sender) 10 分钟节流，
+ *  fire-and-forget，失败只 debug 日志，绝不影响消息主流程）：
+ *  - 'throttled'         → 「已提交/冷却中」提示；
+ *  - 'disabled'/'no_owner' → 通用无权限提示；
+ *  - 'sent'（卡本身就是反馈）/ 'no_requester' → 不发。 */
+function sendGroupGrantNotice(
+  larkAppId: string,
+  message: any,
+  chatId: string,
+  senderOpenId: string | undefined,
+  result: GrantCardResult | undefined,
+): void {
+  if (!senderOpenId) return;
+  if (result !== 'throttled' && result !== 'disabled' && result !== 'no_owner') return;
+  const text = result === 'throttled' ? GRANT_PENDING_NOTICE_TEXT : NO_PERMISSION_NOTICE_TEXT;
+  if (shouldThrottleNotice(`group-notice:${larkAppId}:${chatId}:${senderOpenId}`, NOTICE_THROTTLE_MS)) return;
+  replyMessage(larkAppId, message.message_id, text, 'text')
+    .catch(err => logger.debug(`group grant notice send failed: ${err}`));
+}
+
+/** p2p 私聊被挡（B-1）：不再静默丢弃。
+ *  1) 给发送者一条通用无权限提示（per-(bot,sender) 10 分钟节流）——文案中性，
+ *     绝不泄露 owner 的 open_id/姓名/任何身份信息；
+ *  2) 把授权申请 best-effort 转发到 owner DM（per-(bot,owner) 24 小时节流，
+ *     无 owner 则跳过），DM 内容可含请求者身份（与授权卡同口径取名）。
+ *  全部 fire-and-forget：提示/DM 失败只记 debug 日志，不影响消息主流程。 */
+async function notifyP2pAccessDenied(
+  larkAppId: string,
+  message: any,
+  senderOpenId: string | undefined,
+): Promise<void> {
+  if (!senderOpenId) return;
+  if (!shouldThrottleNotice(`p2p-notice:${larkAppId}:${senderOpenId}`, NOTICE_THROTTLE_MS)) {
+    replyMessage(larkAppId, message.message_id, NO_PERMISSION_NOTICE_TEXT, 'text')
+      .catch(err => logger.debug(`p2p no-permission notice send failed: ${err}`));
+  }
+  const owner = getOwnerOpenId(larkAppId);
+  if (!owner) return;
+  if (shouldThrottleNotice(`owner-dm:${larkAppId}:${owner}`, OWNER_DM_THROTTLE_MS)) return;
+  // 与授权卡同口径：mentions/observed 花名册在 p2p 场景不可用，直接 best-effort
+  // getUserProfile 取名，失败回落缩略 open_id（ou_xxx…xxxx）。
+  const profileName = (await getUserProfile(larkAppId, senderOpenId).catch(() => null))?.name;
+  const shortRequester = `${senderOpenId.slice(0, 10)}…${senderOpenId.slice(-4)}`;
+  const who = profileName ? `${profileName}（${shortRequester}）` : shortRequester;
+  void dmAdmin(
+    larkAppId,
+    owner,
+    `有用户在私聊中请求访问权限。\n请求者：${who}`,
+    'p2p access request',
+  );
 }
 
 // ─── Group message access check ──────────────────────────────────────────
@@ -3277,8 +3345,13 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
                   `[auto-start:新话题] ${chatId.substring(0, 12)} 其他机器人开新话题但未授权（restricted）→ 发授权卡不自动开工 ` +
                   `msg=${messageId.substring(0, 12)} sender=${senderOpenId?.substring(0, 12) ?? '-'}`,
                 );
-                await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data)
-                  .catch(err => logger.error(`Error sending grant card for foreign-bot new topic: ${err}`));
+                const grantResult = await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data)
+                  .catch((err): undefined => {
+                    logger.error(`Error sending grant card for foreign-bot new topic: ${err}`);
+                    return undefined;
+                  });
+                // 卡被抑制（节流/禁用/无 owner）时给触发 bot 补发文本反馈，保持「发卡后 return」语义不变。
+                sendGroupGrantNotice(larkAppId, message, chatId, senderOpenId, grantResult);
                 return;
               }
               logger.info(
@@ -3362,7 +3435,9 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
             logger.info(`Lazy sibling cross-ref backfill: ${sibling.botName} → ${senderOpenId?.substring(0, 12)} (was cold; skipping /grant)`);
           } else {
             logger.info(`Foreign bot @mention not a known sibling (${sibling.reason}); sending grant request card`);
-            await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data);
+            const grantResult = await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data);
+            // 卡被抑制（节流/禁用/无 owner）时给发送者补发文本反馈。
+            sendGroupGrantNotice(larkAppId, message, chatId, senderOpenId, grantResult);
             return;
           }
         }
@@ -3827,7 +3902,9 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           if (access === 'not_allowed') {
             // 入口 A：无权限者 @bot → 弹授权申请卡（@owner），代替「无操作权限」。
             // 覆盖 ownsSession 真假两种情况，但绝不把该消息喂进已有 session。
-            await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data);
+            const grantResult = await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data);
+            // 卡被抑制（节流/禁用/无 owner）时给发送者补发文本反馈，不再静默丢弃。
+            sendGroupGrantNotice(larkAppId, message, chatId, senderOpenId, grantResult);
             logger.debug(`Ignoring group message from non-allowed user: ${senderOpenId} (grant request card path)`);
             return;
           }
@@ -3852,10 +3929,12 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           }
         }
       } else if (!isAllowed) {
-        // 私聊被挡目前是静默丢弃：owner 不在这个 p2p 会话里，把授权申请卡 reply 回来只会
-        // 发给陌生人自己（卡上的按钮又是 owner 专属），既不可用又泄露 owner —— 所以不发。
-        // 真正的修法是把申请发到 owner 自己的 DM 并加 owner 维度节流，单独一个 PR 做。
+        // 私聊被挡不再静默丢弃（B-1）：给发送者一条通用无权限提示（不泄露 owner 身份），
+        // 并把授权申请 best-effort 转发到 owner DM（owner 维度 24h 节流，无 owner 则跳过）。
+        // 授权申请卡不能 reply 回 p2p——owner 不在这个会话里，卡上的按钮又是 owner 专属，
+        // 既不可用又会把 owner 身份暴露给陌生人，所以申请只走 owner DM 这条暗路。
         logger.debug(`Ignoring p2p message from non-allowed user: ${senderOpenId}`);
+        await notifyP2pAccessDenied(larkAppId, message, senderOpenId);
         return;
       }
 

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -2046,8 +2046,13 @@ async function notifyP2pAccessDenied(
   if (!owner) return;
   if (shouldThrottleNotice(`owner-dm:${larkAppId}:${owner}`, OWNER_DM_THROTTLE_MS)) return;
   // 与授权卡同口径：mentions/observed 花名册在 p2p 场景不可用，直接 best-effort
-  // getUserProfile 取名，失败回落缩略 open_id（ou_xxx…xxxx）。
-  const profileName = (await getUserProfile(larkAppId, senderOpenId).catch(() => null))?.name;
+  // getUserProfile 取名，失败回落缩略 open_id（ou_xxx…xxxx）。contact API 挂起
+  // 时不得阻塞消息分发关键路径——5s 超时后按无名处理（与 daemon.ts 的
+  // notifyAllowedUsersResolveFailure 同一纪律：untimed SDK 路径不 await）。
+  const profileName = await Promise.race([
+    getUserProfile(larkAppId, senderOpenId).catch(() => null),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), 5_000)),
+  ]).then((p) => p?.name);
   const shortRequester = `${senderOpenId.slice(0, 10)}…${senderOpenId.slice(-4)}`;
   const who = profileName ? `${profileName}（${shortRequester}）` : shortRequester;
   void dmAdmin(

--- a/src/im/lark/grant-pending.ts
+++ b/src/im/lark/grant-pending.ts
@@ -152,5 +152,36 @@ export function isThrottled(larkAppId: string, chatId: string, target: string): 
   return false;
 }
 
-export function _resetForTest(): void { table.clear(); lastPrunedAt = 0; }
+// ─── 通用提示节流（无权限提示 / owner DM 等轻量通知）─────────────────────
+// 与上面的授权卡节流互相独立：授权卡状态要挂 nonce/quota/messageData，这里只记
+// 「上次放行时间戳」。用于 B-1 修复后给被挡发送者/owner 的可观测性提示，避免
+// 同一发送者反复触发时刷屏。纯内存，daemon 重启清空。
+type NoticeEntry = { ts: number; windowMs: number };
+const noticeTable = new Map<string, NoticeEntry>();
+let lastNoticePrunedAt = 0;
+
+/** 轻量通知节流：同一 key 在 windowMs 内只放行一次。
+ *  返回 true 表示「仍在窗口内，应抑制」；返回 false 表示「可以发」，并记录本次时间戳。
+ *  过期条目在下次全表 prune（最多每 PRUNE_INTERVAL_MS 一次）时回收，表不会无限增长。 */
+export function shouldThrottleNotice(key: string, windowMs: number): boolean {
+  const now = Date.now();
+  const e = noticeTable.get(key);
+  if (e && now - e.ts < e.windowMs) return true;
+  noticeTable.set(key, { ts: now, windowMs });
+  if (now - lastNoticePrunedAt >= PRUNE_INTERVAL_MS) {
+    lastNoticePrunedAt = now;
+    for (const [k, ent] of noticeTable) {
+      if (now - ent.ts >= ent.windowMs) noticeTable.delete(k);
+    }
+  }
+  return false;
+}
+
+export function _resetForTest(): void {
+  table.clear();
+  noticeTable.clear();
+  lastPrunedAt = 0;
+  lastNoticePrunedAt = 0;
+}
 export function _tableSizeForTest(): number { return table.size; }
+export function _noticeTableSizeForTest(): number { return noticeTable.size; }

--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -16,6 +16,8 @@ import { config } from '../config.js';
 import { writeAllowedUsersResolveCache } from '../utils/allowed-users-cache.js';
 import { rmwBotEntry } from './config-store.js';
 import { resolveAllowedUsersWithMap } from '../im/lark/client.js';
+import type { Brand } from '../im/lark/lark-hosts.js';
+import { detectUnusableOwnerEntries } from '../setup/owner-identity.js';
 import { CLI_OPTIONS, resolveCliId } from '../setup/bot-config-editor.js';
 import { expandHomePath } from '../utils/working-dir.js';
 import { resolveTeamRoleFile } from '../core/role-resolver.js';
@@ -313,16 +315,22 @@ export async function setChatFeedbackPolicy(larkAppId: string, chatId: string, p
 }
 
 export type SetAllowedUsersResult =
-  | { ok: true; raw: string[]; resolved: string[] }
+  | { ok: true; raw: string[]; resolved: string[]; warnings?: string[] }
+  | { ok: false; reason: 'unusable_owner_entries'; entries: string[] }
   | { ok: false; reason: 'bot_not_registered' | 'bot_not_in_config' | 'self_lockout' | 'empty_resolved' | string };
 
 /**
  * 改 allowedUsers（管理员名单）。这是动信任根的敏感操作，与普通字段分开：
+ *   0. **跨 app 身份校验**：ou_/on_ 条目先用本 bot 凭证过 detectUnusableOwnerEntries——
+ *      确定性不可用（跨 app ou_ 99992361 / 41012 / 40001 / code-0 无 user）直接拒绝写入；
+ *      网络/scope 错误保持 inconclusive（不拒绝，走下面的正常流程，瞬态路径兜底）。
  *   1. 用 bot 凭证把邮箱/on_ 解析成 open_id（与启动期同一路径）。
  *   2. **防自锁**：解析后名单必须仍含发起人的 open_id，否则拒绝——避免把自己踢出管理员。
  *   3. 解析后非空才写。
  *   4. 落盘原始条目（邮箱/on_/ou_，与 setup 一致），并同步内存 resolvedAllowedUsers /
  *      rawAllowedUserResolution（与 daemon 启动期赋值同口径），无需重启。
+ *   5. 确定性解析失败（邮箱不存在/不可见等）不拒绝写入（可能临时不可见），但以
+ *      `warnings` 带回，由调用方提示；瞬态失败仍走缓存兜底 + 后台重试。
  *
  * confirm 二次确认由调用方（command-handler）处理，本函数只做校验 + 落盘。
  */
@@ -334,7 +342,26 @@ export async function setBotAllowedUsers(
   let bot;
   try { bot = getBot(larkAppId); } catch { return { ok: false, reason: 'bot_not_registered' }; }
 
-  const { resolved, map, entryStatus } = await resolveAllowedUsersWithMap(larkAppId, rawEntries);
+  // B-3: runtime writes used to accept another app's ou_ verbatim — the literal
+  // passthrough below keeps it in the runtime allowlist but it can never match a
+  // sender, silently locking everyone out. Probe ou_/on_ entries with THIS bot's
+  // credentials BEFORE the resolve so the error is explicit. Only a definitive
+  // verdict rejects; inconclusive (network / scope / no secret → []) proceeds —
+  // fail-closed stays in the resolver's transient path (cache fallback + retry).
+  // Emails/mobiles are not probed here: their definitive misses are warnings
+  // (step 5), not identity rejections.
+  const brand: Brand = bot.config.brand ?? 'feishu';
+  const idEntries = rawEntries.filter(e => e.startsWith('ou_') || e.startsWith('on_'));
+  if (idEntries.length > 0) {
+    const unusable = await detectUnusableOwnerEntries(
+      larkAppId, bot.config.larkAppSecret, brand, idEntries,
+    );
+    if (unusable.length > 0) {
+      return { ok: false, reason: 'unusable_owner_entries', entries: unusable };
+    }
+  }
+
+  const { resolved, map, entryStatus, definitiveMisses } = await resolveAllowedUsersWithMap(larkAppId, rawEntries);
   if (resolved.length === 0) return { ok: false, reason: 'empty_resolved' };
   if (senderOpenId && !resolved.includes(senderOpenId)) return { ok: false, reason: 'self_lockout' };
 
@@ -361,6 +388,19 @@ export async function setBotAllowedUsers(
     if (status === 'definitive') definitiveEntries.push(entry);
     else if (status === 'transient') anyTransient = true;
   }
+  // B-2: definitive misses (no such user / not visible) are NOT transient — the
+  // write still succeeds (the entry may be temporarily invisible, and the
+  // self-lockout guard above proved the sender still resolves), but the caller
+  // must surface which entries never took effect instead of them vanishing
+  // silently. Prefer the resolver's raw-order list; fall back to the
+  // entryStatus-derived one for partial mocks / older callers.
+  const misses = definitiveMisses ?? definitiveEntries;
+  const warnings: string[] = [];
+  if (misses.length > 0) {
+    warnings.push(`以下条目无法解析，未生效：${misses.join(', ')}`);
+    logger.warn(`[config:${larkAppId}] allowedUsers set: ${misses.length} entr${misses.length === 1 ? 'y' : 'ies'} ` +
+      `definitively unresolved (not transient, no retry scheduled): ${misses.join(', ')}`);
+  }
   writeAllowedUsersResolveCache(config.session.dataDir, larkAppId, {
     map,
     retainKeys: rawEntries,
@@ -373,7 +413,9 @@ export async function setBotAllowedUsers(
   // contact API does, instead of silently staying dropped until the next restart.
   if (anyTransient) scheduleAllowedUsersResolveRetryFromMutation(larkAppId);
   logger.info(`[config:${larkAppId}] allowedUsers updated: ${rawEntries.length} entries, ${resolved.length} resolved`);
-  return { ok: true, raw: rawEntries, resolved };
+  return warnings.length > 0
+    ? { ok: true, raw: rawEntries, resolved, warnings }
+    : { ok: true, raw: rawEntries, resolved };
 }
 
 export type CoerceResult =

--- a/src/utils/allowed-users-apply.ts
+++ b/src/utils/allowed-users-apply.ts
@@ -31,6 +31,14 @@ export interface AllowedUsersResolveResultLike {
    * `definitive` (safest: never revived from cache).
    */
   entryStatus?: Map<string, EntryResolveStatus>;
+  /**
+   * Raw entries this pass definitively could not resolve. Unused by the pure
+   * merge (definitive drops are simply not revived — see `entryStatus`); present
+   * so callers can pass the resolver result through unchanged and surface the
+   * misses as warnings / notices. Optional: older callers and partial mocks may
+   * omit it without affecting the merge.
+   */
+  definitiveMisses?: string[];
 }
 
 export interface ApplyAllowedUsersResolveInput {

--- a/test/allowed-users-runtime-guard.test.ts
+++ b/test/allowed-users-runtime-guard.test.ts
@@ -1,0 +1,155 @@
+/**
+ * B-3 integration: the runtime allowedUsers write must reject ou_/on_ entries
+ * that THIS bot's app proves unusable (cross-app open_id 99992361 / 41012 /
+ * 40001 / code-0-without-user) BEFORE writing bots.json, while inconclusive
+ * checks (network / scope) still allow the write.
+ *
+ * Unlike bot-config-store.test.ts (which mocks detectUnusableOwnerEntries),
+ * this file drives the REAL detectUnusableOwnerEntries + REAL
+ * resolveAllowedUsersWithMap, stubbing only the Lark SDK (owner-identity's own
+ * client) and the per-bot HTTP client — so the credential/brand wiring and the
+ * probe-before-resolve ordering are covered end-to-end.
+ *
+ * Run: pnpm vitest run test/allowed-users-runtime-guard.test.ts
+ */
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { userGetMock } = vi.hoisted(() => ({ userGetMock: vi.fn() }));
+
+// detectUnusableOwnerEntries builds its own SDK client per call.
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: class {
+    contact = {
+      v3: {
+        user: {
+          get: userGetMock,
+          batchGetId: async () => ({ code: 0, data: { user_list: [] } }),
+        },
+      },
+    };
+  },
+}));
+
+const APP = 'app-runtime-guard-test';
+
+describe('setBotAllowedUsers runtime cross-app guard (B-3, real detectUnusableOwnerEntries)', () => {
+  let configPath: string;
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-guard-'));
+    configPath = join(dir, 'bots.json');
+    process.env.BOTS_CONFIG = configPath;
+    process.env.SESSION_DATA_DIR = dir;
+    userGetMock.mockReset();
+  });
+  afterEach(() => { delete process.env.BOTS_CONFIG; delete process.env.SESSION_DATA_DIR; });
+
+  function writeConfig(extra: Record<string, unknown> = {}) {
+    writeFileSync(configPath, JSON.stringify([{
+      larkAppId: APP,
+      larkAppSecret: 'secret',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      ...extra,
+    }], null, 2), 'utf-8');
+  }
+  function readConfig(): any {
+    return JSON.parse(readFileSync(configPath, 'utf-8'))[0];
+  }
+
+  /** Load fresh modules, register the bot, stub its HTTP client for the resolver. */
+  async function loaded(emailBatchGetId: any) {
+    vi.resetModules();
+    const registry = await import('../src/bot-registry.js');
+    const store = await import('../src/services/bot-config-store.js');
+    registry.loadBotConfigs().forEach((c: any) => registry.registerBot(c));
+    const st = registry.getBot(APP);
+    // resolveAllowedUsersWithMap talks to this stub: larkGet goes through
+    // request() (ou_ diagnostic / on_ resolve), emails through batchGetId.
+    (st as any).client = {
+      request: async ({ url }: any) => ({
+        code: 0,
+        data: { user: { open_id: decodeURIComponent(String(url).split('/').pop()) } },
+      }),
+      contact: { v3: { user: { get: async () => ({ code: 0, data: { user: {} } }), batchGetId: emailBatchGetId } } },
+    };
+    return { registry, store };
+  }
+
+  it('rejects a cross-app ou_ (99992361) before resolving or writing', async () => {
+    userGetMock.mockResolvedValueOnce({ code: 99992361, msg: 'user not found in app scope' });
+    writeConfig();
+    const { store } = await loaded(async () => {
+      throw new Error('resolver must not run when the probe rejects');
+    });
+    const before = readConfig().allowedUsers;
+
+    const r = await store.setBotAllowedUsers(APP, ['ou_other_app', 'alice@corp.com'], 'ou_alice');
+
+    expect(r).toMatchObject({ ok: false, reason: 'unusable_owner_entries', entries: ['ou_other_app'] });
+    // Probe used the target app credentials with open_id lookup.
+    expect(userGetMock).toHaveBeenCalledWith({
+      path: { user_id: 'ou_other_app' },
+      params: { user_id_type: 'open_id' },
+    });
+    // Nothing written.
+    expect(readConfig().allowedUsers).toEqual(before);
+  });
+
+  it('rejects an ou_ the target app reports as invalid id (41012)', async () => {
+    userGetMock.mockResolvedValueOnce({ code: 41012, msg: 'invalid user id' });
+    writeConfig();
+    const { store } = await loaded(async () => ({ code: 0, data: { user_list: [] } }));
+
+    const r = await store.setBotAllowedUsers(APP, ['ou_invalid'], 'ou_owner');
+
+    expect(r).toMatchObject({ ok: false, reason: 'unusable_owner_entries', entries: ['ou_invalid'] });
+    expect(readConfig().allowedUsers).toEqual(['ou_owner']);
+  });
+
+  it('does NOT reject when the probe is inconclusive (network throw) — write proceeds', async () => {
+    userGetMock.mockRejectedValueOnce(new Error('ECONNRESET'));
+    writeConfig();
+    const { store } = await loaded(async () => ({
+      code: 0,
+      data: { user_list: [{ user_id: 'ou_alice', email: 'alice@corp.com' }] },
+    }));
+
+    const r = await store.setBotAllowedUsers(APP, ['ou_owner', 'alice@corp.com'], 'ou_owner');
+
+    expect(r).toMatchObject({ ok: true });
+    expect(readConfig().allowedUsers).toEqual(['ou_owner', 'alice@corp.com']);
+  });
+
+  it('accepts an ou_ the target app resolves (no false rejection)', async () => {
+    userGetMock.mockResolvedValueOnce({
+      code: 0,
+      data: { user: { open_id: 'ou_owner', union_id: 'on_owner' } },
+    });
+    writeConfig();
+    const { store } = await loaded(async () => ({ code: 0, data: { user_list: [] } }));
+
+    const r = await store.setBotAllowedUsers(APP, ['ou_owner'], 'ou_owner');
+
+    expect(r).toMatchObject({ ok: true });
+    expect(readConfig().allowedUsers).toEqual(['ou_owner']);
+  });
+
+  it('probes on_ entries with user_id_type=union_id and rejects a definitive miss', async () => {
+    userGetMock.mockResolvedValueOnce({ code: 0, data: {} }); // code-0 without user → definitive
+    writeConfig();
+    const { store } = await loaded(async () => ({ code: 0, data: { user_list: [] } }));
+
+    const r = await store.setBotAllowedUsers(APP, ['on_other_tenant'], 'ou_owner');
+
+    expect(r).toMatchObject({ ok: false, reason: 'unusable_owner_entries', entries: ['on_other_tenant'] });
+    expect(userGetMock).toHaveBeenCalledWith({
+      path: { user_id: 'on_other_tenant' },
+      params: { user_id_type: 'union_id' },
+    });
+    expect(readConfig().allowedUsers).toEqual(['ou_owner']);
+  });
+});

--- a/test/bot-config-store.test.ts
+++ b/test/bot-config-store.test.ts
@@ -20,7 +20,8 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 
 // Stub the Lark client so setBotAllowedUsers resolves emails/on_ → fake open_ids
 // without any network. Mirrors resolveAllowedUsersWithMap's contract: pass ou_
-// through, on_xxx → ou_xxx, email → ou_<localpart>, anything else is dropped.
+// through, on_xxx → ou_xxx, email → ou_<localpart> (except ghost@* which models
+// a definitive miss), anything else is dropped.
 vi.mock('../src/im/lark/client.js', () => ({
   resolveAllowedUsersWithMap: async (_appId: string, raw: string[]) => {
     const map = new Map<string, string>();
@@ -30,12 +31,22 @@ vi.mock('../src/im/lark/client.js', () => ({
       let id: string | undefined;
       if (v.startsWith('ou_')) id = v;
       else if (v.startsWith('on_')) id = 'ou_' + v.slice(3);
-      else if (v.includes('@')) id = 'ou_' + v.split('@')[0];
+      else if (v.includes('@') && !v.startsWith('ghost@')) id = 'ou_' + v.split('@')[0];
       if (id) { resolved.push(id); map.set(v, id); entryStatus.set(v, 'resolved'); }
       else entryStatus.set(v, 'definitive');
     }
-    return { resolved, map, entryStatus };
+    const definitiveMisses = [...entryStatus.entries()]
+      .filter(([, s]) => s === 'definitive').map(([e]) => e);
+    return { resolved, map, entryStatus, definitiveMisses };
   },
+}));
+
+// B-3: setBotAllowedUsers probes ou_/on_ entries through detectUnusableOwnerEntries
+// before writing. Default = inconclusive ([]) so existing tests exercise the
+// normal write path; individual tests override the verdict.
+const { detectUnusableMock } = vi.hoisted(() => ({ detectUnusableMock: vi.fn() }));
+vi.mock('../src/setup/owner-identity.js', () => ({
+  detectUnusableOwnerEntries: detectUnusableMock,
 }));
 
 async function freshModules() {
@@ -55,6 +66,10 @@ describe('bot-config store', () => {
     // Isolate the allowedUsers sidecar (setBotAllowedUsers writes it) into the
     // same tmp dir so tests don't pollute the real ~/.botmux/data.
     process.env.SESSION_DATA_DIR = dir;
+    // Inconclusive by default: the cross-app probe must never block a write
+    // unless a test explicitly programs a definitive verdict.
+    detectUnusableMock.mockReset();
+    detectUnusableMock.mockResolvedValue([]);
   });
   afterEach(() => { delete process.env.BOTS_CONFIG; delete process.env.SESSION_DATA_DIR; });
 
@@ -650,6 +665,81 @@ describe('bot-config store', () => {
     const r = await store.setBotAllowedUsers('app_default', ['garbage'], 'ou_owner');
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe('empty_resolved');
+  });
+
+  // B-2: a definitive miss (email不存在/不可见) must not fail the write (the
+  // entry may be temporarily invisible), but the result must carry a warning
+  // naming the dropped entry instead of it vanishing silently.
+  it('setBotAllowedUsers keeps writing but warns when an entry definitively misses (B-2)', async () => {
+    const { store } = await loaded();
+    const r = await store.setBotAllowedUsers(
+      'app_default', ['alice@corp.com', 'ghost@corp.com'], 'ou_alice',
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.resolved).toEqual(['ou_alice']);
+    expect(r.warnings).toBeDefined();
+    expect(r.warnings!.join(' ')).toContain('ghost@corp.com');
+    expect(r.warnings!.join(' ')).toContain('未生效');
+    // Write still happened — raw entries persist so a later resolve can recover.
+    expect(readConfig().allowedUsers).toEqual(['alice@corp.com', 'ghost@corp.com']);
+  });
+
+  it('setBotAllowedUsers returns no warnings when every entry resolves', async () => {
+    const { store } = await loaded();
+    const r = await store.setBotAllowedUsers('app_default', ['alice@corp.com', 'ou_owner'], 'ou_alice');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.warnings).toBeUndefined();
+  });
+
+  // B-3: a runtime write must reject ou_/on_ entries the target app proves
+  // unusable (cross-app open_id etc.) BEFORE writing — the resolver keeps literal
+  // ou_ as-is, so without this guard the entry would silently match nobody.
+  it('setBotAllowedUsers rejects definitively-unusable ou_/on_ entries before writing (B-3)', async () => {
+    detectUnusableMock.mockResolvedValue(['ou_foreign']);
+    const { store } = await loaded();
+    const before = readConfig().allowedUsers;
+    const r = await store.setBotAllowedUsers(
+      'app_default', ['ou_foreign', 'alice@corp.com'], 'ou_alice',
+    );
+    expect(r).toMatchObject({ ok: false, reason: 'unusable_owner_entries', entries: ['ou_foreign'] });
+    // Nothing written — disk keeps the previous allowlist.
+    expect(readConfig().allowedUsers).toEqual(before);
+    // Probe ran with THIS bot's credentials + brand, and only on ou_/on_ entries
+    // (before the resolve, so the error is explicit).
+    expect(detectUnusableMock).toHaveBeenCalledWith('app_default', 'secret', 'feishu', ['ou_foreign']);
+  });
+
+  it('setBotAllowedUsers rejects a definitively-unusable on_ entry with the entries list (B-3)', async () => {
+    detectUnusableMock.mockResolvedValue(['on_other_tenant']);
+    const { store } = await loaded();
+    const r = await store.setBotAllowedUsers('app_default', ['on_other_tenant'], 'ou_owner');
+    expect(r).toMatchObject({ ok: false, reason: 'unusable_owner_entries', entries: ['on_other_tenant'] });
+    expect(readConfig().allowedUsers).toEqual(['ou_owner']);
+  });
+
+  it('setBotAllowedUsers proceeds when the cross-app probe is inconclusive (B-3 fail-closed kept)', async () => {
+    // [] = network error / scope missing / no secret → do NOT reject; the
+    // resolver's transient path (cache fallback + retry) stays the safety net.
+    detectUnusableMock.mockResolvedValue([]);
+    const { store } = await loaded();
+    const r = await store.setBotAllowedUsers('app_default', ['ou_owner', 'alice@corp.com'], 'ou_owner');
+    expect(r).toMatchObject({ ok: true });
+    expect(readConfig().allowedUsers).toEqual(['ou_owner', 'alice@corp.com']);
+  });
+
+  it('setBotAllowedUsers does not probe email/mobile entries for cross-app identity (B-3)', async () => {
+    const { store } = await loaded();
+    const r = await store.setBotAllowedUsers('app_default', ['alice@corp.com'], 'ou_alice');
+    expect(r).toMatchObject({ ok: true });
+    expect(detectUnusableMock).not.toHaveBeenCalled();
+  });
+
+  it('setBotAllowedUsers passes the configured brand into the cross-app probe (B-3)', async () => {
+    const { store } = await loaded({ brand: 'lark' });
+    detectUnusableMock.mockResolvedValue([]);
+    await store.setBotAllowedUsers('app_default', ['ou_owner'], 'ou_owner');
+    expect(detectUnusableMock).toHaveBeenCalledWith('app_default', 'secret', 'lark', ['ou_owner']);
   });
 
   it('coerceConfigValue parses per kind (bool/enum/cli) and rejects junk', async () => {

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -73,6 +73,7 @@ const mockGetChatMode = vi.fn(async () => 'topic' as 'group' | 'topic' | 'p2p');
 const mockGetCachedChatMode = vi.fn(() => undefined as 'group' | 'topic' | 'p2p' | undefined);
 const mockGetChatInfo = vi.fn(async () => ({ userCount: 1, botCount: 1 }));
 const mockReplyMessage = vi.fn(async () => 'msg-id');
+const mockSendUserMessage = vi.fn(async () => 'dm-msg-id');
 const mockUpdateMessage = vi.fn(async () => true);
 const mockListChatMessages = vi.fn(async () => [] as any[]);
 const mockListChatMessagesUntil = vi.fn(async () => [] as any[]);
@@ -90,6 +91,7 @@ vi.mock('../src/im/lark/client.js', () => ({
   listChatBotMembers: (...args: any[]) => mockListChatBotMembers(...args),
   resolveSiblingBotBySenderOpenId: (...args: any[]) => mockResolveSiblingBot(...args),
   replyMessage: (...args: any[]) => mockReplyMessage(...args),
+  sendUserMessage: (...args: any[]) => mockSendUserMessage(...args),
   updateMessage: (...args: any[]) => mockUpdateMessage(...args),
   getMessageDetail: (...args: any[]) => mockGetMessageDetail(...args),
   isHumanOpenId: (...args: any[]) => mockIsHumanOpenId(...args),
@@ -2368,7 +2370,9 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     expect(mockReplyMessage).not.toHaveBeenCalled();
   });
 
-  it('keeps the unknown external bot @blocked path silent when auto grant cards are disabled', async () => {
+  it('falls back to a generic no-permission notice (no card, no owner DM) when auto grant cards are disabled', async () => {
+    // B-1：autoGrantRequestCards=false 时不再静默——给发送者一条通用无权限提示，
+    // 但不发授权卡、不发 owner DM。
     setupBotState({ allowedUsers: ['ou_owner'], autoGrantRequestCards: false });
     mockGetOwnerOpenId.mockReturnValue('ou_owner');
     mockGetChatMode.mockResolvedValueOnce('group');
@@ -2389,10 +2393,18 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
 
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
-    expect(mockReplyMessage).not.toHaveBeenCalled();
+    // 通用无权限提示（文本），不发授权卡
+    expect(mockReplyMessage).toHaveBeenCalledTimes(1);
+    expect(mockReplyMessage).toHaveBeenCalledWith(
+      MY_APP_ID,
+      'msg-001',
+      expect.stringContaining('你没有权限使用此 Bot'),
+      'text',
+    );
+    expect(mockReplyMessage.mock.calls.filter(c => c[3] === 'interactive')).toHaveLength(0);
   });
 
-  it('throttles repeat @blocked mentions from the same bot+chat to a single grant card', async () => {
+  it('throttles repeat @blocked mentions from the same bot+chat to a single grant card (+ one pending notice)', async () => {
     setupBotState({ allowedUsers: ['ou_owner'] });
     mockGetOwnerOpenId.mockReturnValue('ou_owner');
     mockGetChatMode.mockResolvedValue('group');
@@ -2421,12 +2433,19 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     await capturedHandlers['im.message.receive_v1'](makeBlocked('msg-002'));
     await flushEventWork();
 
-    expect(mockReplyMessage).toHaveBeenCalledTimes(1);
+    // 授权卡只发一次（第一次）；第二次被节流抑制 → 补发一条「已提交/冷却中」文本提示（B-1）
+    expect(mockReplyMessage).toHaveBeenCalledTimes(2);
     expect(mockReplyMessage).toHaveBeenCalledWith(
       MY_APP_ID,
       'msg-001',
       expect.stringContaining(OTHER_BOT_OPEN_ID),
       'interactive',
+    );
+    expect(mockReplyMessage).toHaveBeenCalledWith(
+      MY_APP_ID,
+      'msg-002',
+      expect.stringContaining('授权申请已提交'),
+      'text',
     );
   });
 
@@ -4978,6 +4997,222 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
   });
 });
 
+describe('im.message.receive_v1 — 无权限消息可观测性 (B-1: 不再静默丢弃)', () => {
+  let handlers: ReturnType<typeof makeHandlers>;
+  const STRANGER = 'ou_stranger_p2p';
+  const OWNER = 'ou_owner';
+
+  beforeEach(() => {
+    capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
+    _resetGrantPending();
+    mockReplyMessage.mockReset().mockResolvedValue('msg-id');
+    mockSendUserMessage.mockReset().mockResolvedValue('dm-msg-id');
+    mockGetOwnerOpenId.mockReset().mockReturnValue(OWNER);
+    mockGetUserProfile.mockReset().mockResolvedValue(null);
+    mockGetChatMode.mockReset().mockResolvedValue('group');
+    mockFindOncallChat.mockReset().mockReturnValue(undefined);
+    setupBotState({ allowedUsers: [OWNER] });
+    handlers = makeHandlers();
+    startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
+  });
+
+  /** 统计 replyMessage 调用里 msgType 为 text 且内容包含 needle 的次数。 */
+  function textNoticeCalls(needle: string): any[][] {
+    return mockReplyMessage.mock.calls.filter(
+      c => c[3] === 'text' && String(c[2]).includes(needle),
+    );
+  }
+
+  it('p2p 被挡：发送者收到通用无权限提示，owner 收到 DM，提示不含 owner 身份', async () => {
+    const event = makeUserMessageEvent({
+      senderOpenId: STRANGER,
+      content: JSON.stringify({ text: '你好，我想用这个 Bot' }),
+      messageId: 'msg-p2p-denied-1',
+      chatId: 'oc_p2p_stranger',
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    // 发送者收到通用提示（reply 到原消息）
+    const notices = textNoticeCalls('你没有权限使用此 Bot');
+    expect(notices).toHaveLength(1);
+    expect(notices[0][0]).toBe(MY_APP_ID);
+    expect(notices[0][1]).toBe('msg-p2p-denied-1');
+    // 安全红线：给陌生人的提示绝不能携带 owner 的 open_id/姓名
+    expect(notices[0][2]).not.toContain(OWNER);
+    // owner 收到 DM（含请求者身份，与授权卡同口径的缩略 open_id）
+    expect(mockSendUserMessage).toHaveBeenCalledWith(
+      MY_APP_ID,
+      OWNER,
+      expect.stringContaining('私聊'),
+      'text',
+    );
+    const dmContent = mockSendUserMessage.mock.calls[0][2] as string;
+    expect(dmContent).toContain('ou_strange');
+    // 未建会话
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+
+  it('p2p 被挡：节流窗口内第二次不重复发提示、不重复 DM', async () => {
+    for (const mid of ['msg-p2p-throttle-1', 'msg-p2p-throttle-2']) {
+      await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+        senderOpenId: STRANGER,
+        content: JSON.stringify({ text: '在吗' }),
+        messageId: mid,
+        chatId: 'oc_p2p_stranger',
+        chatType: 'p2p',
+      }));
+      await flushEventWork();
+    }
+
+    expect(textNoticeCalls('你没有权限使用此 Bot')).toHaveLength(1);
+    expect(mockSendUserMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('p2p 被挡且无 owner：发送者仍收到提示，但不发 DM', async () => {
+    mockGetOwnerOpenId.mockReturnValue(undefined);
+    const event = makeUserMessageEvent({
+      senderOpenId: STRANGER,
+      content: JSON.stringify({ text: '你好' }),
+      messageId: 'msg-p2p-no-owner-1',
+      chatId: 'oc_p2p_stranger',
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(textNoticeCalls('你没有权限使用此 Bot')).toHaveLength(1);
+    expect(mockSendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('p2p 被挡：owner DM 含请求者名字（profile 可取时）', async () => {
+    mockGetUserProfile.mockResolvedValue({ name: '张三' });
+    const event = makeUserMessageEvent({
+      senderOpenId: STRANGER,
+      content: JSON.stringify({ text: '你好' }),
+      messageId: 'msg-p2p-named-1',
+      chatId: 'oc_p2p_stranger',
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockSendUserMessage).toHaveBeenCalledWith(
+      MY_APP_ID,
+      OWNER,
+      expect.stringContaining('张三'),
+      'text',
+    );
+  });
+
+  it('群聊被挡：授权卡正常发送（sent），不补发文本提示', async () => {
+    const event = makeUserMessageEvent({
+      senderOpenId: STRANGER,
+      content: JSON.stringify({ text: '@_bot_a 帮我看看这个报错' }),
+      messageId: 'msg-group-card-1',
+      chatId: 'chat-group-denied',
+      chatType: 'group',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    // 授权卡（interactive）正常发出
+    expect(mockReplyMessage).toHaveBeenCalledWith(
+      MY_APP_ID,
+      'msg-group-card-1',
+      expect.stringContaining(STRANGER),
+      'interactive',
+    );
+    // 卡本身就是反馈 → 不补发任何文本提示
+    expect(textNoticeCalls('你没有权限')).toHaveLength(0);
+    expect(textNoticeCalls('授权申请已提交')).toHaveLength(0);
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+  });
+
+  it('群聊被挡：节流窗口内第二次 @ → 发「已提交/冷却中」提示，不重复发卡', async () => {
+    for (const mid of ['msg-group-throttle-1', 'msg-group-throttle-2']) {
+      await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+        senderOpenId: STRANGER,
+        content: JSON.stringify({ text: '@_bot_a 再问一次' }),
+        messageId: mid,
+        chatId: 'chat-group-denied',
+        chatType: 'group',
+        mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+      }));
+      await flushEventWork();
+    }
+
+    // 只发了一次卡（第一次），第二次被节流抑制
+    const cardCalls = mockReplyMessage.mock.calls.filter(c => c[3] === 'interactive');
+    expect(cardCalls).toHaveLength(1);
+    // 第二次补发「已提交/冷却中」文本提示
+    expect(textNoticeCalls('授权申请已提交')).toHaveLength(1);
+  });
+
+  it('群聊被挡且 autoGrantRequestCards=false：发通用提示，不发卡、不 DM owner', async () => {
+    setupBotState({ allowedUsers: [OWNER], autoGrantRequestCards: false });
+    const event = makeUserMessageEvent({
+      senderOpenId: STRANGER,
+      content: JSON.stringify({ text: '@_bot_a 帮我看看' }),
+      messageId: 'msg-group-disabled-1',
+      chatId: 'chat-group-denied',
+      chatType: 'group',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(textNoticeCalls('你没有权限使用此 Bot')).toHaveLength(1);
+    expect(mockReplyMessage.mock.calls.filter(c => c[3] === 'interactive')).toHaveLength(0);
+    expect(mockSendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('群聊被挡且无 owner：发通用提示，不发卡', async () => {
+    mockGetOwnerOpenId.mockReturnValue(undefined);
+    const event = makeUserMessageEvent({
+      senderOpenId: STRANGER,
+      content: JSON.stringify({ text: '@_bot_a 帮我看看' }),
+      messageId: 'msg-group-no-owner-1',
+      chatId: 'chat-group-denied',
+      chatType: 'group',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(textNoticeCalls('你没有权限使用此 Bot')).toHaveLength(1);
+    expect(mockReplyMessage.mock.calls.filter(c => c[3] === 'interactive')).toHaveLength(0);
+  });
+
+  it('群聊提示节流：窗口内多次被抑制只发一次提示', async () => {
+    // 第一次：发卡（sent，无提示）。后两次：均被节流 → 只补发一次提示。
+    for (const mid of ['msg-group-nt-1', 'msg-group-nt-2', 'msg-group-nt-3']) {
+      await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+        senderOpenId: STRANGER,
+        content: JSON.stringify({ text: '@_bot_a 继续追问' }),
+        messageId: mid,
+        chatId: 'chat-group-denied',
+        chatType: 'group',
+        mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+      }));
+      await flushEventWork();
+    }
+
+    expect(textNoticeCalls('授权申请已提交')).toHaveLength(1);
+  });
+});
+
 describe('im.message.receive_v1 — regular group thread replies preference', () => {
   let handlers: ReturnType<typeof makeHandlers>;
 
@@ -6030,7 +6265,7 @@ describe('im.message.receive_v1 — 主动开工 场景② (autoStartOnNewTopic,
     expect(mockReplyMessage).toHaveBeenCalledWith(MY_APP_ID, 'msg-bot-seed-stranger', expect.any(String), 'interactive');
   });
 
-  it('restricted 模式陌生 bot 连发两条新话题 → 授权卡去重（节流），只发一次', async () => {
+  it('restricted 模式陌生 bot 连发两条新话题 → 授权卡去重（节流），只发一次卡 + 一条冷却提示', async () => {
     setupAutoTopicBotSender(true, false);
     const e1 = makeBotTopicSeed('msg-bot-dup-1', 'chat-bot-dup');
     const e2 = makeBotTopicSeed('msg-bot-dup-2', 'chat-bot-dup');
@@ -6041,8 +6276,16 @@ describe('im.message.receive_v1 — 主动开工 场景② (autoStartOnNewTopic,
     await flushEventWork();
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
-    // 同 (chat, sender) 在节流窗口内只发一次卡（isThrottled 复用人分支同款节流表）
-    expect(mockReplyMessage).toHaveBeenCalledTimes(1);
+    // 同 (chat, sender) 在节流窗口内只发一次卡（isThrottled 复用人分支同款节流表）；
+    // 第二条被节流抑制 → 补发一条「已提交/冷却中」文本提示（B-1）。
+    expect(mockReplyMessage).toHaveBeenCalledTimes(2);
+    expect(mockReplyMessage).toHaveBeenCalledWith(MY_APP_ID, 'msg-bot-dup-1', expect.any(String), 'interactive');
+    expect(mockReplyMessage).toHaveBeenCalledWith(
+      MY_APP_ID,
+      'msg-bot-dup-2',
+      expect.stringContaining('授权申请已提交'),
+      'text',
+    );
   });
 
   it('open 模式（空 allowlist，默认态）陌生 bot 开新话题（未 @）→ 自动开工（open 腿放行，无需授权卡）', async () => {

--- a/test/grant-pending.test.ts
+++ b/test/grant-pending.test.ts
@@ -11,8 +11,10 @@ import {
   markDenied,
   isThrottled,
   updatePendingGrantLimits,
+  shouldThrottleNotice,
   _resetForTest,
   _tableSizeForTest,
+  _noticeTableSizeForTest,
 } from '../src/im/lark/grant-pending.js';
 
 beforeEach(() => { _resetForTest(); vi.useFakeTimers(); });
@@ -117,6 +119,49 @@ describe('grant-pending', () => {
       openPending('a1', 'oc_2', 'ou_h');     // triggers a sweep
       expect(isThrottled('a1', 'oc_1', 'ou_g')).toBe(true); // still throttled
       expect(checkNonce('a1', 'oc_1', 'ou_g', n)).toBe(true); // nonce still valid
+    });
+  });
+
+  // ─── shouldThrottleNotice：通用提示节流（B-1 无权限提示/DM）──────────────
+  describe('shouldThrottleNotice (generic notice throttle)', () => {
+    it('first call passes, repeats within the window are suppressed, after the window passes again', () => {
+      expect(shouldThrottleNotice('p2p-notice:a1:ou_x', 10 * 60 * 1000)).toBe(false);
+      expect(shouldThrottleNotice('p2p-notice:a1:ou_x', 10 * 60 * 1000)).toBe(true);
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+      expect(shouldThrottleNotice('p2p-notice:a1:ou_x', 10 * 60 * 1000)).toBe(false);
+    });
+
+    it('keys are isolated (per bot/sender/chat/owner)', () => {
+      expect(shouldThrottleNotice('p2p-notice:a1:ou_x', 1000)).toBe(false);
+      expect(shouldThrottleNotice('p2p-notice:a1:ou_y', 1000)).toBe(false); // different sender
+      expect(shouldThrottleNotice('p2p-notice:a2:ou_x', 1000)).toBe(false); // different bot
+      expect(shouldThrottleNotice('group-notice:a1:oc_1:ou_x', 1000)).toBe(false); // different surface
+      expect(shouldThrottleNotice('owner-dm:a1:ou_owner', 1000)).toBe(false); // owner-dim key
+      expect(shouldThrottleNotice('p2p-notice:a1:ou_x', 1000)).toBe(true); // same key still throttled
+    });
+
+    it('owner-dm window (24h) is independent of the 10-min notice window', () => {
+      expect(shouldThrottleNotice('owner-dm:a1:ou_owner', 24 * 60 * 60 * 1000)).toBe(false);
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1); // past the 10-min notice window…
+      expect(shouldThrottleNotice('owner-dm:a1:ou_owner', 24 * 60 * 60 * 1000)).toBe(true); // …but still within 24h
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+      expect(shouldThrottleNotice('owner-dm:a1:ou_owner', 24 * 60 * 60 * 1000)).toBe(false);
+    });
+
+    it('eviction: a flood of distinct notice keys does not grow the table without bound', () => {
+      for (let i = 0; i < 1000; i++) shouldThrottleNotice(`p2p-notice:a1:ou_${i}`, 1000);
+      expect(_noticeTableSizeForTest()).toBe(1000);
+      vi.advanceTimersByTime(11 * 60 * 1000); // past every window + the prune interval
+      shouldThrottleNotice('p2p-notice:a1:ou_fresh', 1000); // triggers the periodic sweep
+      expect(_noticeTableSizeForTest()).toBe(1); // only the fresh key remains
+    });
+
+    it('reset clears the notice table too', () => {
+      shouldThrottleNotice('p2p-notice:a1:ou_x', 1000);
+      expect(_noticeTableSizeForTest()).toBe(1);
+      _resetForTest();
+      expect(_noticeTableSizeForTest()).toBe(0);
+      expect(shouldThrottleNotice('p2p-notice:a1:ou_x', 1000)).toBe(false);
     });
   });
 });

--- a/test/ipc-chat-rename-route.test.ts
+++ b/test/ipc-chat-rename-route.test.ts
@@ -8,9 +8,11 @@ import * as workerPool from '../src/core/worker-pool.js';
 import * as groupsStore from '../src/services/groups-store.js';
 import * as sessionStore from '../src/services/session-store.js';
 import * as botRegistry from '../src/bot-registry.js';
+import { cliAuthBind, signCliAuth } from '../src/dashboard/auth.js';
 import { logger } from '../src/utils/logger.js';
 
 const CAP = 'ab12cd34'.repeat(8);
+const TEST_IPC_SECRET = 'test-ipc-secret-deadbeef';
 let handle: IpcServerHandle | null = null;
 
 afterEach(async () => {
@@ -27,6 +29,40 @@ async function postRename(name: string): Promise<Response> {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ name, proactive: true, originCapability: CAP }),
   });
+}
+
+const RENAME_PATH = '/api/sessions/s-chat-rename/chat-rename';
+
+async function postRenameBody(body: Record<string, unknown>, headers: Record<string, string> = {}): Promise<Response> {
+  if (!handle) handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+  return fetch(`http://127.0.0.1:${handle.port}${RENAME_PATH}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+/** 真实 HMAC 签名 → 请求被标记为 trusted-host（sessionCliIpcAuth 放行，
+ *  但不绑定任何 turn origin）。 */
+function trustedHostHeaders(): Record<string, string> {
+  const auth = signCliAuth(TEST_IPC_SECRET, cliAuthBind('POST', RENAME_PATH, handle!.port));
+  return {
+    'X-Botmux-Cli-Ts': auth.ts,
+    'X-Botmux-Cli-Nonce': auth.nonce,
+    'X-Botmux-Cli-Auth': auth.sig,
+  };
+}
+
+/** renameChat mock：同名幂等；不同名时先过 beforeUpdate 防抖闸。 */
+function mockRenameChatWithGate(current: { name: string }): ReturnType<typeof vi.fn> {
+  return vi.spyOn(groupsStore, 'renameChat').mockImplementation(async (_appId, _chatId, newName, opts) => {
+    if (current.name === newName) return { ok: true, oldName: current.name, newName, changed: false };
+    const gate = opts?.beforeUpdate?.();
+    if (gate && !gate.ok) return { ...gate, oldName: current.name, newName };
+    const oldName = current.name;
+    current.name = newName;
+    return { ok: true, oldName, newName, changed: true };
+  }) as unknown as ReturnType<typeof vi.fn>;
 }
 
 describe('POST /api/sessions/:sessionId/chat-rename', () => {
@@ -106,5 +142,65 @@ describe('POST /api/sessions/:sessionId/chat-rename', () => {
     expect(updateSpy).toHaveBeenCalledOnce();
     // FR-7 requires a cache-refresh warning be recorded on failure.
     expect(warnSpy.mock.calls.some(([msg]) => String(msg).includes('cache_refresh_failed'))).toBe(true);
+  });
+
+  it('honors user_explicit (no cooldown) only with a valid current-turn origin credential', async () => {
+    // read-isolated CLI 路径：携带与 managedTurnOrigin 匹配的 capability →
+    // user_explicit 成立，两次不同名改名都不应被防抖拦截。
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+      session: { sessionId: 's-chat-rename', chatDisplayName: 'old' },
+      managedTurnOrigin: { capability: CAP },
+      larkAppId: 'app-chat-rename-turn',
+      chatId: 'oc-chat-rename-turn',
+      chatType: 'group',
+    } as any);
+    vi.spyOn(workerPool, 'getActiveSessionsRegistry').mockReturnValue(new Map());
+    vi.spyOn(botRegistry, 'getBotOpenId').mockReturnValue('ou_test_bot');
+    const current = { name: 'old' };
+    mockRenameChatWithGate(current);
+
+    const first = await postRenameBody({ name: 'new-a', originCapability: CAP });
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({ ok: true, changed: true, oldName: 'old', newName: 'new-a' });
+
+    // 无防抖：窗口内第二次不同名改名同样成功（user_explicit 不 record cooldown）。
+    const second = await postRenameBody({ name: 'new-b', originCapability: CAP });
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({ ok: true, changed: true, oldName: 'new-a', newName: 'new-b' });
+    expect(current.name).toBe('new-b');
+  });
+
+  it('forces proactive cooldown on a user_explicit claim without a turn-origin credential (trusted-host has no turn binding)', async () => {
+    // trusted-host（HMAC 签名的本机请求）只证明「本机进程」，不绑定用户 turn：
+    // sessionCliIpcAuth 放行，但 proveCurrentTurnOrigin 不放行 → 强制
+    // ai_proactive 走防抖。堵住 agent 漏传 --proactive 绕过防抖的口子。
+    setIpcAuthSecret(TEST_IPC_SECRET);
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+      session: { sessionId: 's-chat-rename', chatDisplayName: 'old' },
+      larkAppId: 'app-chat-rename-noturn',
+      chatId: 'oc-chat-rename-noturn',
+      chatType: 'group',
+    } as any);
+    vi.spyOn(workerPool, 'getActiveSessionsRegistry').mockReturnValue(new Map());
+    vi.spyOn(botRegistry, 'getBotOpenId').mockReturnValue('ou_test_bot');
+    const current = { name: 'old' };
+    mockRenameChatWithGate(current);
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    // 先起服务拿 port（trustedHostHeaders 签名需要绑定 port）。authRequired
+    // 才会走 HMAC 中间件把请求标记为 trusted-host。
+    if (!handle) handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const first = await postRenameBody({ name: 'new-a' }, trustedHostHeaders());
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({ ok: true, changed: true, oldName: 'old', newName: 'new-a' });
+
+    // 被强制按 ai_proactive 记录了防抖 → 窗口内第二次不同名改名 429。
+    const second = await postRenameBody({ name: 'new-b' }, trustedHostHeaders());
+    expect(second.status).toBe(429);
+    expect(await second.json()).toMatchObject({ ok: false, error: 'rate_limited', newName: 'new-b' });
+    expect(current.name).toBe('new-a');
+    // 审计日志如实记录 trigger=ai_proactive（而非自报的 user_explicit）。
+    expect(infoSpy.mock.calls.some(([msg]) =>
+      String(msg).includes('[chat-rename:audit] result=success') && String(msg).includes('trigger=ai_proactive'))).toBe(true);
   });
 });

--- a/test/resolve-allowed-users-union.test.ts
+++ b/test/resolve-allowed-users-union.test.ts
@@ -196,6 +196,95 @@ describe('resolveAllowedUsersWithMap — entryStatus classification (PR#590)', (
   });
 });
 
+// B-2: a code-0 batch that OMITS an entry is a definitive miss (no such user /
+// not visible). It used to be completely silent — the entry vanished from the
+// runtime allowlist with no signal at all. The resolver must now (a) list the
+// raw entry in `definitiveMisses` (config order, ou_ literals never included)
+// and (b) log a WARN naming the entry + app. Transient failures must NOT land
+// in definitiveMisses (retry may still recover them).
+describe('resolveAllowedUsersWithMap — definitiveMisses surfacing (B-2)', () => {
+  it('email code-0 batch omitting an entry → definitiveMisses contains it + WARN names entry and app', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 0, data: { user_list: [{ user_id: 'ou_alice', email: 'alice@corp.com' }] } }),
+    );
+
+    const { definitiveMisses, resolved, entryStatus, errored } = await resolveAllowedUsersWithMap(
+      APP, ['alice@corp.com', 'ghost@corp.com'],
+    );
+
+    expect(definitiveMisses).toEqual(['ghost@corp.com']);
+    expect(resolved).toEqual(['ou_alice']);
+    expect(entryStatus.get('ghost@corp.com')).toBe('definitive');
+    expect(errored).toBeFalsy(); // definitive, not transient
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('ghost@corp.com'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(APP));
+    warn.mockRestore();
+  });
+
+  it('mobile code-0 batch omitting an entry → definitiveMisses contains the RAW config entry', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 0, data: { user_list: [{ user_id: 'ou_bob', mobile: '13800000000' }] } }),
+    );
+
+    const { definitiveMisses, resolved } = await resolveAllowedUsersWithMap(
+      APP, ['13800000000', '13900000000'],
+    );
+
+    expect(definitiveMisses).toEqual(['13900000000']);
+    expect(resolved).toEqual(['ou_bob']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('13900000000'));
+    warn.mockRestore();
+  });
+
+  it('union_id code-0 without open_id → definitiveMisses contains the on_ entry', async () => {
+    stubClient(async ({ path }: any) => ({ code: 0, data: { user: { union_id: path.user_id } } }));
+
+    const { definitiveMisses } = await resolveAllowedUsersWithMap(APP, ['on_ghost']);
+
+    expect(definitiveMisses).toEqual(['on_ghost']);
+  });
+
+  it('literal ou_ entries NEVER appear in definitiveMisses (always kept as resolved)', async () => {
+    // Even a cross-app ou_ (99992361) is kept as-is by design; the runtime write
+    // path guards it separately (B-3). The resolver must not list it as a miss.
+    stubClient(async () => ({ code: 99992361, msg: 'cross app' }));
+
+    const { definitiveMisses, resolved } = await resolveAllowedUsersWithMap(APP, ['ou_other_app']);
+
+    expect(definitiveMisses).toEqual([]);
+    expect(resolved).toEqual(['ou_other_app']);
+  });
+
+  it('transient batch failure (code!=0) → definitiveMisses stays empty (entries are transient, retry-eligible)', async () => {
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 500, msg: 'batch down' }),
+    );
+
+    const { definitiveMisses, errored } = await resolveAllowedUsersWithMap(APP, ['a@corp.com', 'b@corp.com']);
+
+    expect(definitiveMisses).toEqual([]);
+    expect(errored).toBe(true);
+  });
+
+  it('definitiveMisses preserves raw config order and excludes resolved entries', async () => {
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 0, data: { user_list: [{ user_id: 'ou_keep', email: 'keep@corp.com' }] } }),
+    );
+
+    const { definitiveMisses } = await resolveAllowedUsersWithMap(
+      APP, ['gone1@corp.com', 'keep@corp.com', 'gone2@corp.com'],
+    );
+
+    expect(definitiveMisses).toEqual(['gone1@corp.com', 'gone2@corp.com']);
+  });
+});
+
 // End-to-end: resolver → applyAllowedUsersResolve → cache decision, for the exact
 // scenario codex flagged — an email-only owner + a batch-wide error (incl 40001)
 // must NOT be locked out. The whole-request error is transient, so the pure fn


### PR DESCRIPTION
# PR 2: sprint-permission（权限可观测性 4 项）

## 改了什么

来自「Botmux 交流群」近 7 天用户反馈的权限专项，4 个修复：

1. **`fix(event-dispatcher)`: 无权限消息不再静默丢弃**
   - 私聊（p2p）无权限消息此前硬静默丢弃，用户毫无感知（本周 4+ 人反馈「机器人不理我」）。现在：p2p 被挡时给发送者发中性提示（不泄露 owner 信息）+ owner DM（24h 节流）；群聊授权卡被节流/禁用时给发送者简短提示（10min 节流）。

2. **`fix(allowed-users)`: 确定性解析失败可观测**
   - allowedUsers 中邮箱/手机号确定性解析失败（不存在/不可见）此前完全静默（连 WARN 日志都没有），配置「看起来正确」但功能失效。现在 `resolveAllowedUsersWithMap` 返回 `definitiveMisses`，启动时 DM owner 列出无法解析的条目，`setBotAllowedUsers` 返回 warnings（不拒绝写入，可能是临时不可见）。

3. **`fix(allowed-users)`: 运行时写入校验跨 app ou_**
   - `setBotAllowedUsers` 写入前用 `detectUnusableOwnerEntries` 校验 ou_/on_ 条目，跨 app ou_（app-scoped，对目标 Bot 无效）确定性不可用时拒绝写入并返回明确错误；inconclusive（网络/scope 错误）不拒绝（fail-closed 原则保持）。启动期巡检跨 app ou_ 并 DM owner 警告。

4. **`fix(dashboard-ipc)`: chat-rename user_explicit 豁免防抖须持 turn origin 凭证**
   - Agent 未经要求自动改群名（本周用户反馈「干着活突然改群名」）：`chat rename` 缺省 `proactive=false` 被记为 `user_explicit` 完全跳过 10 分钟防抖。翻转信任模型：声明 user_explicit 须持有效 turn origin 凭证，否则强制 proactive 防抖。

## 影响面

- **fail-closed 原则保持**：只有目标 app 明确判定不可用才拒绝写入；网络/scope/无 secret 一律 inconclusive 放行
- **跨 CLI**：改动在 im/lark 和 services 层，不碰适配器/worker/backend，20+ CLI 零影响
- **跨会话类型**：覆盖 p2p、群聊、bot-to-bot 路径
- **安全红线**：未触碰 `BOTMUX_OWNER_OPEN_ID` 注入冻结语义；p2p 提示文案不含 owner 任何身份信息
- **瞬态路径**：errored/transient 分类、缓存兜底、重试调度一行未动

## 测试验证

- `pnpm build` 通过
- 13 个目标测试文件 473/473 全绿（含新增 allowed-users-runtime-guard、grant-pending 节流、event-dispatcher 通知、ipc-chat-rename-route 凭证）
- `pnpm test` 全量：18173 passed；3 个失败（bwrap/dsh 沙箱环境问题）已在干净基线复现确认预存