### PR TITLE
fix(adapter): 适配器专项——CoCo 双路径、Antigravity 不重试、Codex 信任框、TRAE 空回复、adopt 新格式

### DIFF
--- a/src/adapters/cli/antigravity.ts
+++ b/src/adapters/cli/antigravity.ts
@@ -191,7 +191,7 @@ export function createAntigravityAdapter(pathOverride?: string): CliAdapter {
       //    as `{"display":"...","timestamp":...,"workspace":"..."}` —
       //    same pattern as Codex/CoCo. We poll the delta past `baseByte`
       //    for our `display` prefix marker. If unseen after the in-band
-      //    retry budget, return {submitted:false, recheck} so the worker
+      //    poll budget, return {submitted:false, recheck} so the worker
       //    can warn the user.
       const baseByte = currentFileSize(HISTORY_PATH);
       const marker = historyMarker(content);
@@ -236,18 +236,14 @@ export function createAntigravityAdapter(pathOverride?: string): CliAdapter {
       await delay(300);
       if (!trySendEnter()) return { submitted: false };
 
-      // 3 retries × 800ms each, then a final grace check. If the user
-      // concurrently types in the web terminal, a stray Enter may submit
-      // their half-typed text — we only retry when the JSONL is provably
-      // unchanged, so the race window is bounded to genuine submit
-      // failures.
-      for (let attempt = 0; attempt < 3; attempt++) {
-        if (await waitForHistoryAppend(HISTORY_PATH, baseByte, marker, 800)) {
-          return undefined;
-        }
-        if (!trySendEnter()) return { submitted: false };
-      }
-      if (await waitForHistoryAppend(HISTORY_PATH, baseByte, marker, 800)) {
+      // Single Enter only — do NOT retry it. agy's history.jsonl append can
+      // lag well past a short per-attempt window (cold start, large initial
+      // prompt, network-bound auth), and a retry Enter lands on the
+      // already-submitted composer: the same prompt then gets submitted
+      // multiple times. Poll history once for the full in-band budget; a
+      // genuinely dropped Enter is recovered by the worker's deferred
+      // recheck, not by a second Enter (same pattern as the grok adapter).
+      if (await waitForHistoryAppend(HISTORY_PATH, baseByte, marker, 3_200)) {
         return undefined;
       }
 

--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -6,18 +6,24 @@ import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import { parseDebugModelsJson } from './model-catalog-json.js';
 import { cocoCacheRoot } from '../../services/coco-paths.js';
+import { traeHistoryPath } from '../../services/traex-paths.js';
+import { traexHistoryMatchDelta } from '../../services/traex-transcript.js';
 import { delay, scaleMs } from '../../utils/timing.js';
 import { installCocoAskPlugin } from '../coco-ask-plugin.js';
 import { TRAE_MIGRATION_DONE_MARKERS } from './traex.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 
-/** Global submit log — CoCo appends one JSON line here on every successful
- *  user submit across all sessions (mode:"user"). Format observed:
- *  `{"content":"...","mode":"user","timestamp":"..."}`. Used the same way
- *  the Codex adapter uses ~/.codex/history.jsonl: write → poll for our
- *  marker → retry Enter if missing → return {submitted:false, recheck}
- *  on final failure so worker can surface a Lark warning. */
-const HISTORY_PATH = join(cocoCacheRoot(), 'history.jsonl');
+/** Legacy global submit log — CoCo / traecli <0.201.5 appends one JSON line
+ *  here on every successful user submit across all sessions (mode:"user").
+ *  Format observed: `{"content":"...","mode":"user","timestamp":"..."}`.
+ *  Still polled for old traecli builds that keep writing here.
+ *
+ *  traecli 0.201.5+ moved the submit log to `$TRAE_HOME/cli/history.jsonl`
+ *  (see traeHistoryPath) in the Codex-shaped `{session_id, ts, text}` format —
+ *  the same file the traex adapter polls. Coco runs the SAME traecli binary,
+ *  so writeInput polls BOTH paths and confirms on whichever records our
+ *  submit; neither path is computed at module load (TRAE_HOME may be set
+ *  after process start). */
 
 function currentFileSize(path: string): number {
   if (!existsSync(path)) return 0;
@@ -95,12 +101,10 @@ function historyDeltaContains(path: string, fromByte: number, prefix: string): b
   return false;
 }
 
-async function waitForHistoryAppend(
-  path: string, fromByte: number, prefix: string, timeoutMs: number,
-): Promise<boolean> {
+async function waitForConfirm(confirm: () => boolean, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + scaleMs(timeoutMs);
   while (Date.now() < deadline) {
-    if (historyDeltaContains(path, fromByte, prefix)) return true;
+    if (confirm()) return true;
     await delay(100);
   }
   return false;
@@ -189,11 +193,6 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
       // send-keys-typing path because Claude Code can toggle bracketed paste
       // OFF after slash commands; CoCo on a fresh-spawn message doesn't have
       // that concern.
-      //
-      // Verification (unchanged): poll CoCo's platform-specific history.jsonl for the
-      // user-submit line whose decoded `content` starts with our prefix.
-      // Retry Enter up to 3 times, then return {submitted:false, recheck}
-      // for the worker's deferred recheck + Lark warning path.
       const hasImagePath = /\.(jpe?g|png|gif|webp|svg|bmp)\b/i.test(content);
       const submitDelay = hasImagePath ? 800 : 500;
 
@@ -209,8 +208,28 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
         }
       };
 
-      const baseByte = currentFileSize(HISTORY_PATH);
+      // Verification: poll BOTH submit logs for our marker and confirm on
+      // whichever records it. The legacy ~/.cache/coco/history.jsonl uses
+      // mode+content PREFIX matching (historyDeltaContains); the new
+      // $TRAE_HOME/cli/history.jsonl uses Codex-shaped {session_id,ts,text}
+      // EXACT matching (traexHistoryMatchDelta, shared with the traex adapter).
+      // Paths are resolved per submit so a TRAE_HOME set after process start
+      // is honored. Retry Enter up to 3 times, then return
+      // {submitted:false, recheck} for the worker's deferred recheck + Lark
+      // warning path.
+      const legacyHistoryPath = join(cocoCacheRoot(), 'history.jsonl');
+      const traeHistory = traeHistoryPath();
+      const baseByteLegacy = currentFileSize(legacyHistoryPath);
+      const baseByteTrae = currentFileSize(traeHistory);
       const prefix = submitPrefix(content);
+
+      // Submit confirmation is ownership-INDEPENDENT: any full-content match
+      // in either global submit log proves the Enter committed (mirrors the
+      // traex adapter's anyMatch rationale — a foreign-first line or absent
+      // pid must never suppress the confirmation).
+      const submitConfirmed = (): boolean =>
+        historyDeltaContains(legacyHistoryPath, baseByteLegacy, prefix)
+        || traexHistoryMatchDelta(traeHistory, baseByteTrae, content).found;
 
       try {
         if (pty.pasteText) {
@@ -231,39 +250,39 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
       await delay(submitDelay);
       if (!trySendEnter()) return { submitted: false };
 
-      // Fresh-install short-wait: when history.jsonl is absent at submit
-      // time, give CoCo up to 1.2s to create it. If our marker shows up →
-      // success. If the file is still absent → trust the Enter and return
+      // Fresh-install short-wait: when BOTH submit logs are absent at submit
+      // time, give CoCo up to 1.2s to create one. If our marker shows up →
+      // success. If both files are still absent → trust the Enter and return
       // (this is the genuine "first run / coco doesn't write history"
-      // case). If the file appeared but our marker isn't there → fall
+      // case). If a file appeared but our marker isn't there → fall
       // through to the normal retry/failure loop — better to warn than to
       // silently mask a real submit failure on a new install.
-      if (!existsSync(HISTORY_PATH) && baseByte === 0) {
-        if (await waitForHistoryAppend(HISTORY_PATH, baseByte, prefix, 1200)) {
+      if (!existsSync(legacyHistoryPath) && !existsSync(traeHistory)) {
+        if (await waitForConfirm(submitConfirmed, 1200)) {
           return { submitted: true };
         }
-        if (!existsSync(HISTORY_PATH)) {
+        if (!existsSync(legacyHistoryPath) && !existsSync(traeHistory)) {
           return undefined;
         }
-        // File appeared during the wait but our marker isn't in it — fall
-        // through to the retry loop. baseByte stays 0 so the loop scans
-        // the whole file.
+        // A file appeared during the wait but our marker isn't in it — fall
+        // through to the retry loop. The baselines stay 0 for the file that
+        // was absent, so the loop scans its whole content.
       }
 
       for (let attempt = 0; attempt < 3; attempt++) {
-        if (await waitForHistoryAppend(HISTORY_PATH, baseByte, prefix, 800)) {
+        if (await waitForConfirm(submitConfirmed, 800)) {
           return { submitted: true };
         }
         if (!trySendEnter()) return { submitted: false };
       }
-      if (await waitForHistoryAppend(HISTORY_PATH, baseByte, prefix, 800)) {
+      if (await waitForConfirm(submitConfirmed, 800)) {
         return { submitted: true };
       }
       // In-band budget exhausted. Hand the worker a recheck closure: a slow
       // CoCo (cold start, large initial prompt, heavy hooks) may still
       // append our marker after retries gave up. Worker re-scans after a
       // delay before deciding whether to warn the user.
-      const recheck = (): boolean => historyDeltaContains(HISTORY_PATH, baseByte, prefix);
+      const recheck = (): boolean => submitConfirmed();
       return { submitted: false, recheck };
     },
 

--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -339,11 +339,47 @@ export async function discoverClaudeFamilySessions(
 
 // ─── Codex / TRAE rollout (codex, traex) ─────────────────────────────────────
 
-/** Parse one Codex/TRAE rollout. `session_meta` carries the resume id + cwd;
- *  the first `event_msg`/`user_message` carries the user's first prompt (the
- *  `response_item` role:user entries include the synthetic
- *  <environment_context>/<permissions> preamble, so we prefer user_message).
- *  Streamed line by line, stopping once id + cwd + title are found. */
+/** Codex >=0.147 rollouts no longer emit `event_msg`/`user_message`; user turns
+ *  then live in `response_item` message role:user entries. The FIRST of those is
+ *  a synthetic startup preamble, never a real prompt. Observed shapes (verified
+ *  against ~80 live ~/.codex rollouts): the `<environment_context>` block, the
+ *  `<recommended_plugins>` list, the legacy `<permissions>` block, and codex's
+ *  `# AGENTS.md instructions for …` injection (which may share the message with
+ *  `<environment_context>` via multiple input_text blocks). */
+const SYNTHETIC_PREAMBLE_PATTERNS: readonly RegExp[] = [
+  /<environment_context\b/,
+  /<recommended_plugins\b/,
+  /<permissions\b/,
+];
+
+function isSyntheticPreamble(text: string): boolean {
+  if (SYNTHETIC_PREAMBLE_PATTERNS.some((re) => re.test(text))) return true;
+  return /^# AGENTS\.md instructions\b/.test(text);
+}
+
+/** Join all `input_text` blocks of a rollout `response_item` message payload —
+ *  content is an array of `{type, text}` and a single user turn may span several
+ *  blocks (e.g. AGENTS.md instructions + environment_context). Mirrors
+ *  joinTextBlocks in codex-transcript; kept local so this discovery service has
+ *  no cross-service dependency. Trimmed so the ^-anchored botmux/synthetic
+ *  checks below see the real start of the prompt. */
+function rolloutResponseItemText(payload: Record<string, unknown>): string {
+  const content = payload.content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    const b = asRecord(block);
+    if (b?.type === 'input_text' && typeof b.text === 'string') parts.push(b.text);
+  }
+  return parts.join('').trim();
+}
+
+/** Parse one Codex/TRAE rollout. `session_meta` carries the resume id + cwd.
+ *  Title preference: the first `event_msg`/`user_message` (legacy format); when
+ *  absent (Codex >=0.147), the first non-synthetic `response_item` role:user
+ *  message — skipping the startup preamble and botmux-injected turns (which mark
+ *  the whole session botmux-origin, same as the user_message path). Streamed
+ *  line by line, stopping once id + cwd + title are found. */
 async function parseRolloutTranscript(
   path: string,
   mtimeMs: number,
@@ -352,7 +388,9 @@ async function parseRolloutTranscript(
   // Accumulate into an object — closure mutation of plain `let` defeats TS's
   // control-flow narrowing at the post-loop guard; object properties keep their
   // declared type.
-  const acc: { id: string | null; cwd: string | null; title: string; botmux: boolean } = { id: null, cwd: null, title: '', botmux: false };
+  const acc: { id: string | null; cwd: string | null; title: string; fallbackTitle: string; botmux: boolean } = {
+    id: null, cwd: null, title: '', fallbackTitle: '', botmux: false,
+  };
   let excluded = false;
   await forEachJsonLine(path, (rec) => {
     const payload = asRecord(rec.payload);
@@ -367,11 +405,23 @@ async function parseRolloutTranscript(
     } else if (rec.type === 'event_msg' && payload?.type === 'user_message' && typeof payload.message === 'string') {
       if (isBotmuxInjected(payload.message)) { acc.botmux = true; return true; } // botmux-origin → drop
       if (!acc.title) acc.title = truncateTitle(payload.message);
+    } else if (rec.type === 'response_item' && payload?.type === 'message' && payload.role === 'user') {
+      // New-format (>=0.147) fallback title source. The first meaningful user
+      // turn determines origin, mirroring parseClaudeTranscript: a synthetic
+      // preamble is skipped, a botmux-wrapped turn drops the session, and the
+      // first raw turn becomes the fallback title (a later event_msg/user_message
+      // still wins when the rollout carries both).
+      const text = rolloutResponseItemText(payload);
+      if (!text) return; // empty / non-text content — not a title candidate
+      if (isSyntheticPreamble(text)) return; // startup preamble, not a user turn
+      if (isBotmuxInjected(text)) { acc.botmux = true; return true; } // botmux-origin → drop
+      if (!acc.fallbackTitle) acc.fallbackTitle = truncateTitle(text);
     }
     return Boolean(acc.id && acc.cwd && acc.title);
   });
-  if (excluded || acc.botmux || !acc.id || !acc.cwd || !acc.title) return null;
-  return { cliSessionId: acc.id, cwd: acc.cwd, title: acc.title, lastActivityAt: mtimeMs };
+  const title = acc.title || acc.fallbackTitle;
+  if (excluded || acc.botmux || !acc.id || !acc.cwd || !title) return null;
+  return { cliSessionId: acc.id, cwd: acc.cwd, title, lastActivityAt: mtimeMs };
 }
 
 export async function discoverRolloutSessions(

--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -347,9 +347,11 @@ export async function discoverClaudeFamilySessions(
  *  `# AGENTS.md instructions for …` injection (which may share the message with
  *  `<environment_context>` via multiple input_text blocks). */
 const SYNTHETIC_PREAMBLE_PATTERNS: readonly RegExp[] = [
-  /<environment_context\b/,
-  /<recommended_plugins\b/,
-  /<permissions\b/,
+  // 锚定行首：合成 preamble 总是独立条目或以 tag 开头；不锚定会误杀散文中
+  // 提及这些标签的真实 prompt（如「<environment_context> 是什么意思」）。
+  /^<environment_context\b/,
+  /^<recommended_plugins\b/,
+  /^<permissions\b/,
 ];
 
 function isSyntheticPreamble(text: string): boolean {
@@ -416,6 +418,11 @@ async function parseRolloutTranscript(
       if (isSyntheticPreamble(text)) return; // startup preamble, not a user turn
       if (isBotmuxInjected(text)) { acc.botmux = true; return true; } // botmux-origin → drop
       if (!acc.fallbackTitle) acc.fallbackTitle = truncateTitle(text);
+      // 新格式（>=0.147）rollout 没有 event_msg/user_message，acc.title 永远
+      // 为空：不含 fallbackTitle 会扫满 MAX_HEAD_LINES_PER_FILE。首个真实用户
+      // 回合即定 origin（与 legacy 路径「id+cwd+title 齐即停扫」一致）；混合
+      // 格式文件中 legacy 条目按时间序在前，acc.title 会先命中早退，不受影响。
+      if (acc.id && acc.cwd && acc.fallbackTitle) return true;
     }
     return Boolean(acc.id && acc.cwd && acc.title);
   });

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -12,13 +12,18 @@
  *     times during tool use, so none of them is a safe turn boundary;
  *   - event_msg `task_complete` is the durable end-of-turn marker and carries
  *     the final visible text in `last_agent_message` (which may be empty).
- *     When it is empty the drainer consults the turn's `agent_message`
- *     records: a `final_answer`-phase message reconstructs a dropped final,
- *     and a commentary message ending in the nothing-to-send sentinel marks
- *     deliberate silence. A non-null `error` payload maps the terminal to
- *     `failed` (mirroring the Codex drainer) so a model-endpoint failure
- *     surfaces its real reason instead of the misleading "completed but
- *     empty" diagnostic.
+ *     When it is empty the drainer consults the turn's assistant records: a
+ *     `final_answer`-phase agent_message reconstructs a dropped final, and a
+ *     commentary message ending in the nothing-to-send sentinel marks
+ *     deliberate silence. Two newer dialects get the same treatment: an
+ *     `item_completed` AgentMessage item (0.201.4+ mirrors the assistant
+ *     message there, symmetric to the UserMessage user dialect) and a
+ *     phase-less `agent_message` (a dialect that dropped the `phase` field,
+ *     cf. codex >= 0.146) — the last of either is a final candidate unless it
+ *     ends in the nothing-to-send sentinel, which marks deliberate silence.
+ *     A non-null `error` payload maps the terminal to `failed` (mirroring the
+ *     Codex drainer) so a model-endpoint failure surfaces its real reason
+ *     instead of the misleading "completed but empty" diagnostic.
  *   - Directory layout differs: sessions live under
  *     ~/.trae/cli/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<uuid>.jsonl
  *     (note the extra `cli/` level vs Codex's ~/.codex/sessions/...).
@@ -158,6 +163,18 @@ interface TraexPendingAgentMessages {
    *  Defensive reconstruction source when task_complete drops the final it
    *  actually produced. */
   lastFinalAnswer?: string;
+  /** Last `item_completed` AgentMessage item text since the turn's
+   *  user_message. TraeX 0.201.4+ can mirror the assistant message as an
+   *  item_completed item (symmetric to the UserMessage user dialect), so the
+   *  last one is a final candidate. NOT phase-guaranteed: a candidate ending
+   *  in the nothing-to-send sentinel is deliberate-silence narration, and the
+   *  sentinel guard at task_complete distinguishes the two. */
+  lastAgentItemText?: string;
+  /** Last PHASE-LESS `agent_message` since the turn's user_message. A dialect
+   *  that dropped the `phase` field (cf. codex >= 0.146) makes commentary and
+   *  final byte-identical, so the last phase-less message is the best final
+   *  candidate — same sentinel guard as lastAgentItemText. */
+  lastAgentMessageNoPhase?: string;
 }
 
 const traexPendingAgentCache = new Map<string, TraexPendingAgentMessages>();
@@ -205,6 +222,33 @@ function itemCompletedUserText(item: unknown): string {
   return parts.join('');
 }
 
+/** Assistant-side mirror of itemCompletedUserText: extract the text of an
+ *  item_completed `AgentMessage` item. TraeX 0.201.4+ can emit the assistant
+ *  message in this shape (symmetric to the UserMessage user dialect), and a
+ *  later dialect may drop the agent_message phase field, so the drainer
+ *  tracks the last AgentMessage item as a final candidate. The block type is
+ *  accepted as 'Text' (observed TraeX 0.201.4 shape), 'output_text' (upstream
+ *  Responses API shape) or lowercase 'text' so dialect drift doesn't silently
+ *  drop the final; non-text blocks (reasoning, tool calls) carry no `text`
+ *  field and are skipped. */
+function itemCompletedAgentText(item: unknown): string {
+  if (!item || typeof item !== 'object') return '';
+  const record = item as { type?: unknown; content?: unknown };
+  if (record.type !== 'AgentMessage' || !Array.isArray(record.content)) return '';
+  const parts: string[] = [];
+  for (const block of record.content) {
+    if (!block || typeof block !== 'object') continue;
+    const textBlock = block as { type?: unknown; text?: unknown };
+    if (typeof textBlock.text !== 'string') continue;
+    if (textBlock.type === 'Text'
+      || textBlock.type === 'text'
+      || textBlock.type === 'output_text') {
+      parts.push(textBlock.text);
+    }
+  }
+  return parts.join('');
+}
+
 function traexPendingAgentState(path: string): TraexPendingAgentMessages {
   let state = traexPendingAgentCache.get(path);
   if (!state) {
@@ -229,6 +273,44 @@ const TRAEX_TRAILING_SENTINEL_RE = new RegExp(
 
 function traexTrailingSentinel(message: string): string | undefined {
   return TRAEX_TRAILING_SENTINEL_RE.exec(message)?.[1];
+}
+
+/** Recover the final text for a SUCCESSFUL turn whose task_complete carried no
+ *  last_agent_message. Sources in priority order:
+ *   1. a final_answer-phase agent_message — the phase field guarantees it is
+ *      the model's answer, not tool narration. Safe in BOTH modes;
+ *   2. the last item_completed AgentMessage item — the 0.201.4+ assistant
+ *      dialect (mirrors the UserMessage user dialect);
+ *   3. the last phase-less agent_message — a dialect that dropped the phase
+ *      field (cf. codex >= 0.146) makes commentary and final byte-identical,
+ *      so the last one is the best candidate.
+ *  Sources 2/3 are NOT phase-guaranteed: a candidate ending in the
+ *  nothing-to-send sentinel is deliberate-silence narration (the model
+ *  replied via `botmux send`), not an answer, so it is excluded from the
+ *  answer candidates and used only for the sentinel synthesis below.
+ *
+ *  Deliberate silence synthesises the bare sentinel the fallback gate already
+ *  treats as genuine silence — NON-ADOPT ONLY: adopt posts transcript text
+ *  verbatim, so a synthesised bare token would leak the literal into Lark. */
+function recoverTraexEmptyFinal(
+  pending: TraexPendingAgentMessages | undefined,
+  adoptMode: boolean,
+): string {
+  if (pending?.lastFinalAnswer?.trim()) return pending.lastFinalAnswer;
+  const candidates: string[] = [];
+  if (pending?.lastAgentItemText?.trim()) candidates.push(pending.lastAgentItemText);
+  if (pending?.lastAgentMessageNoPhase?.trim()) candidates.push(pending.lastAgentMessageNoPhase);
+  const answer = candidates.find(candidate => !traexTrailingSentinel(candidate));
+  if (answer) return answer;
+  if (adoptMode) return '';
+  // No real answer candidate: recognise deliberate silence from whichever
+  // tracked message carries the trailing sentinel (explicit commentary-phase
+  // first, then the phase-less/item candidates).
+  for (const source of [pending?.lastCommentary ?? '', ...candidates]) {
+    const sentinel = traexTrailingSentinel(source);
+    if (sentinel) return sentinel;
+  }
+  return '';
 }
 
 /** Upper bound on how far back readLatestTraexRuntime scans for the newest
@@ -282,9 +364,10 @@ function runtimeFromTraexEntry(entry: any): TraexRuntimeSnapshot | undefined {
  *     Codex drainer) — traecli writes task_complete with
  *     last_agent_message=null AND error when the model endpoint fails, so the
  *     failure must not be read as a silent success;
- *   - otherwise the turn's agent_message records (tracked across drain calls)
- *     recover a dropped final_answer or recognise a trailing
- *     nothing-to-send sentinel as deliberate silence. The sentinel synthesis
+ *   - otherwise the turn's assistant records (tracked across drain calls)
+ *     recover a dropped final_answer, an item_completed AgentMessage item, or
+ *     a phase-less agent_message, and recognise a trailing nothing-to-send
+ *     sentinel on any of them as deliberate silence. The sentinel synthesis
  *     runs only in non-adopt mode: adopt posts transcript text verbatim, so a
  *     synthesised bare token would leak into Lark. */
 export function drainTraexRollout(
@@ -362,30 +445,46 @@ export function drainTraexRollout(
     if (obj.type === 'event_msg'
       && payload.type === 'item_completed') {
       const userText = itemCompletedUserText(payload.item);
-      if (userText && claimUserTurn(payload.turn_id)) {
-        // Legacy user_message records did not always carry a turn id. When
-        // the same drain also contains their 0.201.4 UserMessage mirror,
-        // replace the uncorrelatable legacy event with the turn-addressable
-        // item_completed event instead of starting two local turns.
-        const legacyIndex = legacyUserIndexesWithoutTurnId.get(userText);
-        if (legacyIndex !== undefined) {
-          events.splice(legacyIndex, 1);
-          legacyUserIndexesWithoutTurnId.delete(userText);
-          for (const [text, index] of legacyUserIndexesWithoutTurnId) {
-            if (index > legacyIndex) legacyUserIndexesWithoutTurnId.set(text, index - 1);
+      if (userText) {
+        if (claimUserTurn(payload.turn_id)) {
+          // Legacy user_message records did not always carry a turn id. When
+          // the same drain also contains their 0.201.4 UserMessage mirror,
+          // replace the uncorrelatable legacy event with the turn-addressable
+          // item_completed event instead of starting two local turns.
+          const legacyIndex = legacyUserIndexesWithoutTurnId.get(userText);
+          if (legacyIndex !== undefined) {
+            events.splice(legacyIndex, 1);
+            legacyUserIndexesWithoutTurnId.delete(userText);
+            for (const [text, index] of legacyUserIndexesWithoutTurnId) {
+              if (index > legacyIndex) legacyUserIndexesWithoutTurnId.set(text, index - 1);
+            }
           }
+          events.push({ ...base, kind: 'user', text: userText });
+          // New turn: drop any agent_message state an unterminated predecessor
+          // left behind so it can't be attributed to this turn.
+          if (!probe) traexPendingAgentCache.delete(path);
         }
-        events.push({ ...base, kind: 'user', text: userText });
-        // New turn: drop any agent_message state an unterminated predecessor
-        // left behind so it can't be attributed to this turn.
-        if (!probe) traexPendingAgentCache.delete(path);
+      } else if (!probe) {
+        // Assistant-side mirror of the UserMessage dialect: TraeX 0.201.4+
+        // can emit the assistant message as an item_completed AgentMessage
+        // item. Track the last one as a final candidate (the sentinel guard
+        // at task_complete distinguishes a real answer from deliberate-silence
+        // narration). Tool results and other item types yield no text.
+        const agentText = itemCompletedAgentText(payload.item);
+        if (agentText) {
+          traexPendingAgentState(path).lastAgentItemText = agentText;
+        }
       }
       continue;
     }
     // agent_message records are narration (commentary) or the produced final
     // (final_answer). They are NOT turn boundaries — only task_complete is —
     // so they are tracked per turn and consulted when the terminal arrives
-    // with an empty/missing last_agent_message.
+    // with an empty/missing last_agent_message. A dialect that dropped the
+    // `phase` field (cf. codex >= 0.146) writes phase-less records that are
+    // byte-identical for commentary and final; the last one is the best final
+    // candidate, tracked separately so an explicit commentary-phase message
+    // keeps its deliberate-silence semantics.
     if (!probe
       && obj.type === 'event_msg'
       && payload.type === 'agent_message'
@@ -393,7 +492,9 @@ export function drainTraexRollout(
       && payload.message.length > 0) {
       const pending = traexPendingAgentState(path);
       if (payload.phase === 'final_answer') pending.lastFinalAnswer = payload.message;
-      else pending.lastCommentary = payload.message;
+      else if (typeof payload.phase !== 'string' || payload.phase.length === 0) {
+        pending.lastAgentMessageNoPhase = payload.message;
+      } else pending.lastCommentary = payload.message;
       continue;
     }
     if (obj.type === 'event_msg'
@@ -412,18 +513,19 @@ export function drainTraexRollout(
         //      actually produced (the phase field guarantees it is an answer,
         //      not tool narration). Safe in BOTH modes: it is the model's real
         //      answer, and adopt posts transcript text verbatim anyway;
-        //   2. a commentary message ending in the nothing-to-send sentinel —
-        //      the model deliberately stayed silent (it replied via
+        //   2. the last item_completed AgentMessage item (0.201.4+ assistant
+        //      dialect) or the last phase-less agent_message (phase-dropped
+        //      dialect) — the model's real transcript answer, safe in BOTH
+        //      modes, unless it ends in the nothing-to-send sentinel (then it
+        //      is deliberate-silence narration, not an answer);
+        //   3. a commentary/candidate message ending in the nothing-to-send
+        //      sentinel — the model deliberately stayed silent (it replied via
         //      `botmux send`), so synthesise the bare sentinel the fallback
         //      gate already treats as genuine silence instead of tripping the
         //      misleading "completed but empty" diagnostic. NON-ADOPT ONLY:
         //      adopt posts transcript text verbatim, so a synthesised bare
         //      token would leak the literal into Lark.
-        text = pending?.lastFinalAnswer?.trim()
-          ? pending.lastFinalAnswer
-          : !adoptMode
-            ? traexTrailingSentinel(pending?.lastCommentary ?? '') ?? ''
-            : '';
+        text = recoverTraexEmptyFinal(pending, adoptMode);
       }
       if (!probe) traexPendingAgentCache.delete(path);
       legacyUserIndexesWithoutTurnId.clear();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8810,11 +8810,20 @@ function handleVisibleStartupInteraction(data: string): boolean {
   // 落进死输入队列被静默丢弃（上游 openai/codex#39487）：确认从未提交，直到
   // ~20s 后 submit_unconfirmed 兜底。延迟一个短 tick 再发，让按键处理器就绪；
   // trustHandled 已同步置位，后续 chunk 重复命中同一文案不会重入。
+  // 围栏：400ms 内若发生 respawn（崩溃/配置切换/restart），旧 timer 不得把
+  // Enter 发进新会话的 backend（与本文件其它延迟回调的围栏约定一致）。
+  const backendAtSchedule = backend;
+  const generationAtSchedule = cliSpawnGeneration;
   setTimeout(() => {
-    if (backend && 'sendSpecialKeys' in backend) {
-      (backend as any).sendSpecialKeys('Enter');
-    } else {
-      backend?.write('\r');
+    if (backend !== backendAtSchedule || cliSpawnGeneration !== generationAtSchedule) return;
+    try {
+      if (backend && 'sendSpecialKeys' in backend) {
+        (backend as any).sendSpecialKeys('Enter');
+      } else {
+        backend?.write('\r');
+      }
+    } catch {
+      // tmux session 已退出等场景：空 Enter 无意义，静默丢弃
     }
   }, 400);
   return true;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8806,11 +8806,17 @@ function handleVisibleStartupInteraction(data: string): boolean {
 
   trustHandled = true;
   log('Trust dialog detected, auto-accepting...');
-  if (backend && 'sendSpecialKeys' in backend) {
-    (backend as any).sendSpecialKeys('Enter');
-  } else {
-    backend?.write('\r');
-  }
+  // Codex 0.149 的按键处理器在信任框渲染的瞬间尚未就绪，同步发出的 Enter 会
+  // 落进死输入队列被静默丢弃（上游 openai/codex#39487）：确认从未提交，直到
+  // ~20s 后 submit_unconfirmed 兜底。延迟一个短 tick 再发，让按键处理器就绪；
+  // trustHandled 已同步置位，后续 chunk 重复命中同一文案不会重入。
+  setTimeout(() => {
+    if (backend && 'sendSpecialKeys' in backend) {
+      (backend as any).sendSpecialKeys('Enter');
+    } else {
+      backend?.write('\r');
+    }
+  }, 400);
   return true;
 }
 

--- a/test/antigravity-submit.test.ts
+++ b/test/antigravity-submit.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  appendFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PtyHandle } from '../src/adapters/cli/types.js';
+
+// HISTORY_PATH is computed at module import from os.homedir() (which honors
+// $HOME on POSIX), so redirect HOME to a temp dir BEFORE importing the
+// adapter. BOTMUX_TIME_SCALE collapses the real-time submit waits (300ms
+// settle + 3.2s poll budget) to a few ms without changing which branch the
+// code takes — the same trick write-input.test.ts uses for the other
+// history-verified adapters.
+const SCALE = 0.05;
+const home = mkdtempSync(join(tmpdir(), 'agy-home-'));
+const previousHome = process.env.HOME;
+const previousScale = process.env.BOTMUX_TIME_SCALE;
+process.env.HOME = home;
+process.env.BOTMUX_TIME_SCALE = String(SCALE);
+
+const { createAntigravityAdapter } = await import(
+  '../src/adapters/cli/antigravity.js'
+);
+
+// Choreographed real-time events, scaled by the same factor so their
+// ordering against the adapter's (equally scaled) settle/budget is stable.
+const SETTLE_MS = 300 * SCALE; // pre-Enter settle delay
+const BUDGET_MS = 3_200 * SCALE; // in-band history poll budget
+// Old code retried Enter after each 800ms poll window; the 2nd Enter would
+// fire at ~SETTLE_MS + 800*SCALE. A "slow" append lands AFTER that point
+// (so the old code would have double-submitted) but well inside BUDGET_MS
+// (so the new code still confirms it in-band).
+const OLD_FIRST_RETRY_MS = 800 * SCALE;
+const SLOW_APPEND_MS = SETTLE_MS + OLD_FIRST_RETRY_MS + 25;
+
+const HISTORY_PATH = join(home, '.gemini', 'antigravity-cli', 'history.jsonl');
+
+/** Mirror of antigravity.ts's private `historyMarker` (kept in sync with
+ *  the copy in antigravity-history.test.ts). */
+function jsonEncodedPrefix(content: string): string {
+  return JSON.stringify(content.slice(0, 40))
+    .slice(1, -1)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}
+
+/** agy is Go and writes history.jsonl with encoding/json's default
+ *  SetEscapeHTML(true), so `<` / `>` / `&` land as `<` / `>` /
+ *  `&` on disk. The adapter's marker matches that encoding, so the
+ *  fake appender must emit it too. */
+function encodeDisplay(content: string): string {
+  return JSON.stringify(content)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}
+
+function appendHistory(content: string): void {
+  mkdirSync(join(home, '.gemini', 'antigravity-cli'), { recursive: true });
+  appendFileSync(
+    HISTORY_PATH,
+    `{"display":${encodeDisplay(content)},"timestamp":${Date.now()},"workspace":"/x"}\n`,
+  );
+}
+
+function resetHistory(): void {
+  mkdirSync(join(home, '.gemini', 'antigravity-cli'), { recursive: true });
+  writeFileSync(HISTORY_PATH, '');
+}
+
+interface FakePty {
+  pty: PtyHandle;
+  specialKeys: string[][];
+  texts: string[];
+  enterCount: () => number;
+}
+
+function makePty(enterThrows = false): FakePty {
+  const specialKeys: string[][] = [];
+  const texts: string[] = [];
+  const pty = {
+    write: () => true,
+    sendText: (t: string) => {
+      texts.push(t);
+      return true;
+    },
+    sendSpecialKeys: (...keys: string[]) => {
+      if (enterThrows && keys[0] === 'Enter') {
+        throw new Error('tmux session gone');
+      }
+      specialKeys.push(keys);
+      return true;
+    },
+  } as unknown as PtyHandle;
+  return {
+    pty,
+    specialKeys,
+    texts,
+    enterCount: () => specialKeys.filter((k) => k[0] === 'Enter').length,
+  };
+}
+
+describe('antigravity writeInput — single-Enter submit', () => {
+  const adapter = createAntigravityAdapter('/usr/local/bin/agy');
+
+  beforeAll(() => {
+    resetHistory();
+  });
+
+  afterAll(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousScale === undefined) delete process.env.BOTMUX_TIME_SCALE;
+    else process.env.BOTMUX_TIME_SCALE = previousScale;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('slow history append (past the old 800ms retry window) still confirms with exactly one Enter', async () => {
+    resetHistory();
+    const fake = makePty();
+    const content = '<user_message>\n慢写入验证\n</user_message>';
+    // Append lands after the old code's 2nd Enter would have fired, but
+    // inside the 3.2s in-band budget.
+    const timer = setTimeout(() => appendHistory(content), SLOW_APPEND_MS);
+    try {
+      const result = await adapter.writeInput(fake.pty, content);
+      expect(result).toBeUndefined();
+      expect(fake.enterCount()).toBe(1);
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  it('never appends within budget → submitted:false + recheck, still exactly one Enter', async () => {
+    resetHistory();
+    const fake = makePty();
+    const content = '<user_message>\n永不确认\n</user_message>';
+    const result = await adapter.writeInput(fake.pty, content);
+    expect(result).toBeDefined();
+    expect(result?.submitted).toBe(false);
+    expect(typeof result?.recheck).toBe('function');
+    expect(fake.enterCount()).toBe(1);
+    // The deferred recheck closure resolves once agy finally appends.
+    expect(result!.recheck!()).toBe(false);
+    appendHistory(content);
+    expect(result!.recheck!()).toBe(true);
+  });
+
+  it('fast history append confirms with exactly one Enter', async () => {
+    resetHistory();
+    const fake = makePty();
+    const content = '<user_message>\n快速确认\n</user_message>';
+    const timer = setTimeout(() => appendHistory(content), SETTLE_MS + 10);
+    try {
+      const result = await adapter.writeInput(fake.pty, content);
+      expect(result).toBeUndefined();
+      expect(fake.enterCount()).toBe(1);
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  it('multi-line content uses M-Enter between lines and exactly one trailing Enter', async () => {
+    resetHistory();
+    const fake = makePty();
+    const content = 'line1\nline2';
+    const timer = setTimeout(() => appendHistory(content), SETTLE_MS + 10);
+    try {
+      const result = await adapter.writeInput(fake.pty, content);
+      expect(result).toBeUndefined();
+      expect(fake.specialKeys).toContainEqual(['M-Enter']);
+      expect(fake.enterCount()).toBe(1);
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  it('Enter send failure bails with submitted:false and no recheck', async () => {
+    resetHistory();
+    const fake = makePty(/* enterThrows */ true);
+    const result = await adapter.writeInput(fake.pty, 'anything');
+    expect(result).toEqual({ submitted: false });
+  });
+
+  it('marker present only before the baseByte snapshot does not count as submitted', async () => {
+    // A line written before writeInput snapshots baseByte must not satisfy
+    // the delta scan — otherwise a stale history line would mask a dropped
+    // submit.
+    resetHistory();
+    const content = '<user_message>\n旧行不算\n</user_message>';
+    appendHistory(content);
+    const fake = makePty();
+    const result = await adapter.writeInput(fake.pty, content);
+    expect(result?.submitted).toBe(false);
+    expect(typeof result?.recheck).toBe('function');
+    expect(fake.enterCount()).toBe(1);
+  });
+});

--- a/test/codex-input.e2e.ts
+++ b/test/codex-input.e2e.ts
@@ -148,7 +148,7 @@ describe('Codex first input submission', () => {
     /**
      * Simulates the full production worker flow:
      * 1. Codex spawns → trust dialog appears
-     * 2. Worker detects "Yes, continue" per-chunk → sends \r
+     * 2. Worker detects "Yes, continue" per-chunk → defers 400ms, then sends \r
      * 3. IdleDetector waits for codex to finish loading
      * 4. Idle fires → prompt is written to the actual input box
      * 5. Prompt is submitted successfully
@@ -186,13 +186,16 @@ describe('Codex first input submission', () => {
         stripped,
       });
 
-      // Production trust detection (per-chunk, with fixed pattern)
+      // Production trust detection (per-chunk, with fixed pattern). Codex
+      // 0.149 drops a synchronous Enter (upstream openai/codex#39487), so
+      // production defers the keystroke 400ms after detection — replicate
+      // that timing here.
       if (!trustHandled) {
         if (TRUST_DIALOG_PATTERN.test(stripped)) {
           trustHandled = true;
           trustDetectedAt = Date.now();
-          console.log(`>>> Trust detected at +${trustDetectedAt - spawnTime}ms, dismissing...`);
-          proc!.write('\r');
+          console.log(`>>> Trust detected at +${trustDetectedAt - spawnTime}ms, dismissing in 400ms...`);
+          setTimeout(() => { proc!.write('\r'); }, 400);
           return; // skip idle detector feed (same as production)
         }
       }

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -430,6 +430,94 @@ describe('discoverRolloutSessions (codex / traex)', () => {
     ]);
     expect(await discoverRolloutSessions(sessionsRoot, 10)).toEqual([]);
   });
+
+  // Codex >=0.147 no longer writes event_msg/user_message; user turns live in
+  // response_item message role:user entries. The first is a synthetic preamble
+  // (here AGENTS.md instructions + environment_context in ONE message's two
+  // input_text blocks — the real rollout shape), the second is the real prompt.
+  it('falls back to the first real response_item user message when event_msg/user_message is absent (Codex >=0.147)', async () => {
+    writeRollout('2026/08/19', 'rollout-2026-08-19-newformat.jsonl', [
+      { timestamp: '2026-08-19T22:41:43Z', type: 'session_meta', payload: { id: '01a01a78-8d40-7a80-a7c0-8b467bb31779', cwd: '/root/iserver/botmux' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [
+        { type: 'input_text', text: '# AGENTS.md instructions for /root/iserver/botmux\n\n<INSTRUCTIONS>\nrepo guide\n</INSTRUCTIONS>\n\n' },
+        { type: 'input_text', text: '<environment_context>\n  <cwd>/root/iserver/botmux</cwd>\n  <shell>zsh</shell>\n</environment_context>' },
+      ] } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'refactor the rollout parser for the new format' }] } },
+    ]);
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      cliSessionId: '01a01a78-8d40-7a80-a7c0-8b467bb31779',
+      cwd: '/root/iserver/botmux',
+      title: 'refactor the rollout parser for the new format',
+    });
+  });
+
+  // Every observed synthetic preamble shape must be skipped before the real
+  // prompt is taken as the title (verified against ~80 live ~/.codex rollouts).
+  it('skips each synthetic preamble shape before taking the response_item title', async () => {
+    writeRollout('2026/08/13', 'rollout-envctx.jsonl', [
+      { type: 'session_meta', payload: { id: 'envctx-sid', cwd: '/root/p' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<environment_context>\n  <cwd>/root/p</cwd>\n  <shell>zsh</shell>\n  <current_date>2026-08-13</current_date>\n</environment_context>' }] } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'the real prompt after env context' }] } },
+    ]);
+    writeRollout('2026/08/02', 'rollout-plugins.jsonl', [
+      { type: 'session_meta', payload: { id: 'plugins-sid', cwd: '/root/q' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<recommended_plugins>\nHere is a list of plugins that are available but not installed.\n</recommended_plugins>' }] } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'the real prompt after plugins' }] } },
+    ]);
+    writeRollout('2026/08/01', 'rollout-perms.jsonl', [
+      { type: 'session_meta', payload: { id: 'perms-sid', cwd: '/root/r' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<permissions>\nread-only sandbox\n</permissions>' }] } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'the real prompt after permissions' }] } },
+    ]);
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+    expect(out.map((s) => s.cliSessionId).sort()).toEqual(['envctx-sid', 'perms-sid', 'plugins-sid']);
+    expect(out.find((s) => s.cliSessionId === 'envctx-sid')?.title).toBe('the real prompt after env context');
+    expect(out.find((s) => s.cliSessionId === 'plugins-sid')?.title).toBe('the real prompt after plugins');
+    expect(out.find((s) => s.cliSessionId === 'perms-sid')?.title).toBe('the real prompt after permissions');
+  });
+
+  // A new-format rollout whose first real user turn carries botmux's injected
+  // wrapper is botmux-origin and must be dropped — skipping the message and
+  // taking a later turn would leak botmux sessions into the /adopt picker.
+  it('drops botmux-origin rollouts whose response_item user turn carries the injected wrapper (new format)', async () => {
+    writeRollout('2026/08/20', 'rollout-bmx-newfmt.jsonl', [
+      { type: 'session_meta', payload: { id: 'bmx-newfmt', cwd: '/root/x' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<environment_context>\n  <cwd>/root/x</cwd>\n</environment_context>' }] } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<user_message>\n@Codex do the thing\n</user_message>\n<sender type="user" open_id="ou_abcdefghijklmnop" />' }] } },
+    ]);
+    writeRollout('2026/08/21', 'rollout-ext-newfmt.jsonl', [
+      { type: 'session_meta', payload: { id: 'ext-newfmt', cwd: '/root/y' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<environment_context>\n  <cwd>/root/y</cwd>\n</environment_context>' }] } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'a prompt typed straight into codex' }] } },
+    ]);
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+    expect(out.map((s) => s.cliSessionId)).toEqual(['ext-newfmt']);
+  });
+
+  // Detection is structural: an external new-format session whose prompt merely
+  // discusses botmux's XML in prose must NOT be mis-flagged (mirrors the
+  // event_msg/user_message regression coverage above).
+  it('keeps external new-format sessions that only mention botmux tags in prose', async () => {
+    writeRollout('2026/08/22', 'rollout-ext-discuss.jsonl', [
+      { type: 'session_meta', payload: { id: 'ext-discuss', cwd: '/root/z' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<environment_context>\n  <cwd>/root/z</cwd>\n</environment_context>' }] } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'I am debugging botmux and the <user_message> tag behavior, and why does <sender type= show up?' }] } },
+    ]);
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+    expect(out.map((s) => s.cliSessionId)).toEqual(['ext-discuss']);
+  });
+
+  // A rollout whose only user turns are synthetic preambles (no real prompt)
+  // has no meaningful title and is dropped, not adopted with the preamble.
+  it('drops new-format rollouts with only a synthetic preamble and no real prompt', async () => {
+    writeRollout('2026/08/23', 'rollout-preamble-only.jsonl', [
+      { type: 'session_meta', payload: { id: 'preamble-only', cwd: '/root/p' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: '<environment_context>\n  <cwd>/root/p</cwd>\n</environment_context>' }] } },
+    ]);
+    expect(await discoverRolloutSessions(sessionsRoot, 10)).toEqual([]);
+  });
 });
 
 describe('discoverAntigravitySessions', () => {

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -478,6 +478,17 @@ describe('discoverRolloutSessions (codex / traex)', () => {
     expect(out.find((s) => s.cliSessionId === 'perms-sid')?.title).toBe('the real prompt after permissions');
   });
 
+  // 散文中提及 preamble 标签不是合成 preamble——锚定行首避免误杀真实 prompt。
+  it('does not skip a real prompt that mentions preamble tags in prose', async () => {
+    writeRollout('2026/08/14', 'rollout-prose-tags.jsonl', [
+      { type: 'session_meta', payload: { id: 'prose-sid', cwd: '/root/s' } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'what does <environment_context> mean in codex rollouts? also <permissions> docs' }] } },
+    ]);
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ cliSessionId: 'prose-sid', title: 'what does <environment_context> mean in codex rollouts? also <permissions> docs' });
+  });
+
   // A new-format rollout whose first real user turn carries botmux's injected
   // wrapper is botmux-origin and must be dropped — skipping the message and
   // taking a later turn would leak botmux sessions into the /adopt picker.

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -110,6 +110,20 @@ function agentMessage(text: string, phase: 'commentary' | 'final_answer' = 'comm
   };
 }
 
+// Dialect that dropped the `phase` field (cf. codex >= 0.146): the record
+// carries no phase at all, so commentary and final are byte-identical.
+function agentMessageNoPhase(text: string) {
+  return {
+    timestamp: '2000-01-01T00:00:02.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'agent_message',
+      message: text,
+      memory_citation: null,
+    },
+  };
+}
+
 function taskCompleteWithError(error: unknown, lastAgentMessage?: string) {
   return {
     timestamp: '2000-01-01T00:00:03.000Z',
@@ -669,6 +683,214 @@ describe('drainTraexRollout', () => {
       kind: 'assistant_final',
       text: '这是最终答案',
     }));
+  });
+
+  it('reconstructs the final from the last item_completed AgentMessage item (0.201.4+ assistant dialect)', () => {
+    // Symmetric to the UserMessage user dialect: TraeX 0.201.4+ can emit the
+    // assistant message as an item_completed AgentMessage item. The LAST one
+    // is the final candidate; mid-turn items are overwritten.
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent-mid',
+        content: [{ type: 'Text', text: 'mid-turn progress' }],
+      }, undefined, '2000-01-01T00:00:02.000Z')),
+      line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent-final',
+        content: [{ type: 'Text', text: '这是最终答案' }],
+      }, undefined, '2000-01-01T00:00:02.500Z')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '这是最终答案',
+    }));
+  });
+
+  it('accepts the output_text block shape in an AgentMessage item (upstream Responses API dialect)', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent',
+        content: [{ type: 'output_text', text: '这是最终答案' }],
+      })),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '这是最终答案',
+    }));
+  });
+
+  it('reconstructs an AgentMessage item final in adopt mode (real transcript text, not synthesis)', () => {
+    // Like the final_answer-phase reconstruction, an AgentMessage item is the
+    // model's real transcript answer — safe in BOTH modes. adopt is in fact
+    // the mode where it matters most: drain is the only channel to Lark.
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent',
+        content: [{ type: 'Text', text: '这是最终答案' }],
+      })),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0, { adoptMode: true }).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '这是最终答案',
+    }));
+  });
+
+  it('does not treat an item_completed AgentMessage item as a user turn start', () => {
+    // Regression guard for the #997 boundary: only UserMessage items start a
+    // turn; AgentMessage items are assistant-side and must not emit a user
+    // event even when they carry text.
+    writeFileSync(path, [
+      line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent',
+        content: [{ type: 'Text', text: 'assistant text' }],
+      })),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.filter(event => event.kind === 'user')).toHaveLength(0);
+  });
+
+  it('reconstructs the final from the last phase-less agent_message (phase-dropped dialect, cf. codex >= 0.146)', () => {
+    // A dialect that dropped the `phase` field makes commentary and final
+    // byte-identical; the last phase-less agent_message is the best final
+    // candidate.
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessageNoPhase('中间 commentary')),
+      line(agentMessageNoPhase('这是最终答案')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '这是最终答案',
+    }));
+  });
+
+  it('prefers a final_answer-phase agent_message over a phase-less fallback candidate', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessageNoPhase('别的候选')),
+      line(agentMessage('真正的最终答案', 'final_answer')),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '真正的最终答案',
+    }));
+  });
+
+  it('prefers an AgentMessage item over a phase-less agent_message candidate', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessageNoPhase('phase-less 候选')),
+      line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent',
+        content: [{ type: 'Text', text: 'item 候选' }],
+      })),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: 'item 候选',
+    }));
+  });
+
+  it('recognises deliberate silence in a phase-less agent_message (sentinel, not a false final)', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(agentMessageNoPhase('已通过 botmux send 回报。BOTMUX_NO_REPLY')),
+      line(taskComplete()),
+    ].join(''));
+
+    // Non-adopt: synthesise the bare sentinel the fallback gate treats as
+    // genuine silence instead of posting the narration as the final.
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: 'BOTMUX_NO_REPLY',
+    }));
+    // Adopt: no synthesis (verbatim contract) — the empty final stays empty.
+    expect(drainTraexRollout(path, 0, { adoptMode: true }).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '',
+    }));
+  });
+
+  it('recognises deliberate silence in an item_completed AgentMessage item (sentinel, not a false final)', () => {
+    writeFileSync(path, [
+      line(user('do the work')),
+      line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent',
+        content: [{ type: 'Text', text: '已通过 botmux send 回报。BOTMUX_NO_REPLY' }],
+      })),
+      line(taskComplete()),
+    ].join(''));
+
+    expect(drainTraexRollout(path, 0).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: 'BOTMUX_NO_REPLY',
+    }));
+    expect(drainTraexRollout(path, 0, { adoptMode: true }).events.at(-1)).toEqual(expect.objectContaining({
+      kind: 'assistant_final',
+      text: '',
+    }));
+  });
+
+  it('retains the phase-less agent_message candidate across drain calls (drained before task_complete)', () => {
+    // Turns run for minutes while the poller drains on the second scale: the
+    // phase-less candidate and the task_complete almost never share a drain.
+    const firstBatch = line(user('long-running turn'))
+      + line(agentMessageNoPhase('这是最终答案'));
+    writeFileSync(path, firstBatch);
+    const first = drainTraexRollout(path, 0);
+    expect(first.events.map(event => event.kind)).toEqual(['user']);
+
+    appendFileSync(path, line(taskComplete()));
+    const second = drainTraexRollout(path, first.newOffset);
+    expect(second.events).toEqual([
+      expect.objectContaining({ kind: 'assistant_final', text: '这是最终答案' }),
+    ]);
+  });
+
+  it('a probe re-drain does not consume the AgentMessage item final candidate', () => {
+    // The submit-confirmation probe re-drains the same live rollout; its
+    // item_completed processing must not record (or clear) the assistant
+    // candidate the production drainer is holding for the still-open turn.
+    const firstBatch = line(user('long turn'))
+      + line(itemCompleted({
+        type: 'AgentMessage',
+        id: 'msg-agent',
+        content: [{ type: 'Text', text: '这是最终答案' }],
+      }));
+    writeFileSync(path, firstBatch);
+    const first = drainTraexRollout(path, 0);
+    expect(first.events.map(event => event.kind)).toEqual(['user']);
+
+    // Submit-confirmation probe re-drains the same rollout.
+    expect(traexRolloutHasUserInputSince(path, 0, 'long turn')).toBe(true);
+
+    // Turn completes; the production drain must still see the cached item.
+    appendFileSync(path, line(taskComplete()));
+    const second = drainTraexRollout(path, first.newOffset);
+    expect(second.events).toEqual([
+      expect.objectContaining({ kind: 'assistant_final', text: '这是最终答案' }),
+    ]);
   });
 
   it('a probe re-drain mid-turn does not clear the production pending state', () => {

--- a/test/trust-dialog-defer.test.ts
+++ b/test/trust-dialog-defer.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Trust-dialog Enter deferral (C-3).
+ *
+ * Root cause: Codex 0.149's key handler is not ready the instant the trust
+ * dialog renders, so a synchronous Enter lands in a dead input queue and is
+ * silently dropped (upstream openai/codex#39487) — the confirmation never
+ * submits until the ~20s submit_unconfirmed fallback. Production now sets
+ * trustHandled synchronously (no re-entry) and defers the Enter by 400ms.
+ *
+ * worker.ts is a process entry point with no exports, so the handler under
+ * test is extracted from source, transpiled, and evaluated with its module
+ * level dependencies injected as globals — the same source-truth pattern
+ * backend-gate.test.ts uses for the same helper.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+
+type TrustHandler = (data: string) => boolean;
+
+// The handler's free variables, injected as globals for the eval'd copy.
+let trustHandledValue = false;
+
+function installGlobals(backend: unknown): void {
+  const g = globalThis as Record<string, unknown>;
+  Object.defineProperty(globalThis, 'trustHandled', {
+    configurable: true,
+    get: () => trustHandledValue,
+    set: (v: boolean) => { trustHandledValue = v; },
+  });
+  g.dismissAidenCodexUpdateDialog = () => false;
+  g.lastInitConfig = {};
+  g.log = () => {};
+  g.backend = backend;
+  const patternMatch = workerSource.match(/const TRUST_DIALOG_PATTERN = (\/[^;]+\/);/);
+  if (!patternMatch) throw new Error('TRUST_DIALOG_PATTERN not found in worker.ts');
+  // eslint-disable-next-line no-new-func
+  g.TRUST_DIALOG_PATTERN = new Function(`return ${patternMatch[1]};`)();
+}
+
+function extractTrustHandler(): TrustHandler {
+  const start = workerSource.indexOf('function handleVisibleStartupInteraction(');
+  if (start < 0) throw new Error('handleVisibleStartupInteraction not found in worker.ts');
+  // Brace-match to the function's closing brace. Safe here: the function body
+  // contains no braces inside strings, regexes, or comments.
+  const bodyOpen = workerSource.indexOf('{', start);
+  let depth = 0;
+  let end = -1;
+  for (let i = bodyOpen; i < workerSource.length; i++) {
+    const ch = workerSource[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) { end = i; break; }
+    }
+  }
+  if (end < 0) throw new Error('handleVisibleStartupInteraction brace match failed');
+  const fnSource = workerSource.slice(start, end + 1);
+  const { outputText } = ts.transpileModule(fnSource, {
+    compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.None },
+  });
+  // eslint-disable-next-line no-new-func
+  return new Function(`${outputText}; return handleVisibleStartupInteraction;`)() as TrustHandler;
+}
+
+describe('trust dialog Enter deferral (Codex 0.149 key-handler race)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    trustHandledValue = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('marks trustHandled immediately but defers Enter by 400ms', () => {
+    const sendSpecialKeys = vi.fn();
+    installGlobals({ sendSpecialKeys });
+    const handler = extractTrustHandler();
+
+    expect(handler('Do you trust this folder? Yes, continue')).toBe(true);
+    expect(trustHandledValue, 'trustHandled is set synchronously to block re-entry').toBe(true);
+    expect(sendSpecialKeys, 'Enter must not fire while the key handler is still warming up').not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(399);
+    expect(sendSpecialKeys).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+
+  it('does not re-enter when the same trust text arrives again within the window', () => {
+    const sendSpecialKeys = vi.fn();
+    installGlobals({ sendSpecialKeys });
+    const handler = extractTrustHandler();
+
+    handler('Yes, I trust this folder');
+    expect(handler('Yes, I trust this folder'), 'repeat match must be swallowed').toBe(false);
+    vi.advanceTimersByTime(1_000);
+    expect(sendSpecialKeys, 'exactly one Enter for the whole dialog').toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to backend.write("\\r") when sendSpecialKeys is unavailable', () => {
+    const write = vi.fn();
+    installGlobals({ write });
+    const handler = extractTrustHandler();
+
+    handler('Yes, continue');
+    expect(write).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(400);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith('\r');
+  });
+
+  it('ignores output without trust text and schedules nothing', () => {
+    const sendSpecialKeys = vi.fn();
+    installGlobals({ sendSpecialKeys });
+    const handler = extractTrustHandler();
+
+    expect(handler('ordinary startup output')).toBe(false);
+    vi.advanceTimersByTime(1_000);
+    expect(sendSpecialKeys).not.toHaveBeenCalled();
+  });
+
+  it('keeps the 400ms deferral in the production trust branch', () => {
+    // Source-level guard: the behavioral tests above extract the real
+    // function, but pin the intent here so a "simplification" back to a
+    // synchronous send is caught even at a glance.
+    const start = workerSource.indexOf('function handleVisibleStartupInteraction(');
+    const end = workerSource.indexOf('const APP_RUNNER_OSC_CLI_IDS', start);
+    const helper = workerSource.slice(start, end);
+    expect(helper).toMatch(/setTimeout\([^]*\},\s*400\)/);
+    expect(helper.indexOf('trustHandled = true;')).toBeLessThan(helper.indexOf('setTimeout('));
+  });
+});

--- a/test/trust-dialog-defer.test.ts
+++ b/test/trust-dialog-defer.test.ts
@@ -35,6 +35,8 @@ function installGlobals(backend: unknown): void {
   g.lastInitConfig = {};
   g.log = () => {};
   g.backend = backend;
+  // 围栏变量：延迟 Enter 回调校验 respawn 代际，eval 上下文需注入
+  g.cliSpawnGeneration = 0;
   const patternMatch = workerSource.match(/const TRUST_DIALOG_PATTERN = (\/[^;]+\/);/);
   if (!patternMatch) throw new Error('TRUST_DIALOG_PATTERN not found in worker.ts');
   // eslint-disable-next-line no-new-func
@@ -123,6 +125,19 @@ describe('trust dialog Enter deferral (Codex 0.149 key-handler race)', () => {
     expect(handler('ordinary startup output')).toBe(false);
     vi.advanceTimersByTime(1_000);
     expect(sendSpecialKeys).not.toHaveBeenCalled();
+  });
+
+  it('does not fire the deferred Enter after a respawn (generation fence)', () => {
+    const sendSpecialKeys = vi.fn();
+    installGlobals({ sendSpecialKeys });
+    const handler = extractTrustHandler();
+
+    handler('Yes, continue');
+    // 400ms 窗口内发生 respawn（cliSpawnGeneration 递增 + backend 替换）
+    (globalThis as Record<string, unknown>).cliSpawnGeneration = 1;
+    (globalThis as Record<string, unknown>).backend = { sendSpecialKeys: vi.fn() };
+    vi.advanceTimersByTime(1_000);
+    expect(sendSpecialKeys, '旧 timer 不得向新会话 backend 发 Enter').not.toHaveBeenCalled();
   });
 
   it('keeps the 400ms deferral in the production trust branch', () => {

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -92,6 +92,10 @@ const TIME_SCALE = Number(process.env.BOTMUX_TIME_SCALE);
 const COCO_HISTORY_PATH = platform() === 'darwin'
   ? join(homedir(), 'Library', 'Caches', 'coco', 'history.jsonl')
   : join(homedir(), '.cache', 'coco', 'history.jsonl');
+// traecli 0.201.5+ submit log (Codex-shaped {session_id, ts, text}), shared
+// with the traex adapter. coco's writeInput polls this IN ADDITION to the
+// legacy ~/.cache/coco/history.jsonl ({content, mode:"user"}) path.
+const TRAE_HISTORY_PATH = join(homedir(), '.trae', 'cli', 'history.jsonl');
 const CLAUDE_KEYBINDINGS_PATH = join(homedir(), '.claude', 'keybindings.json');
 
 function appendCodexHistory(content: string, sessionId?: string): void {
@@ -114,6 +118,16 @@ function appendCocoHistory(content: string): void {
 function resetCocoHistory(): void {
   mkdirSync(dirname(COCO_HISTORY_PATH), { recursive: true });
   writeFileSync(COCO_HISTORY_PATH, '');
+}
+
+function appendTraeHistory(content: string, sessionId = 'coco-test-session'): void {
+  mkdirSync(dirname(TRAE_HISTORY_PATH), { recursive: true });
+  appendFileSync(TRAE_HISTORY_PATH, JSON.stringify({ session_id: sessionId, ts: Date.now(), text: content }) + '\n');
+}
+
+function resetTraeHistory(): void {
+  mkdirSync(dirname(TRAE_HISTORY_PATH), { recursive: true });
+  writeFileSync(TRAE_HISTORY_PATH, '');
 }
 
 function writeClaudeKeybindings(bindings: Record<string, string>): void {
@@ -1515,8 +1529,12 @@ describe('coco writeInput submission confirmation', () => {
   // The mock records the last-pasted text and, on the first Enter (when
   // configured to confirm), writes a coco-shaped history line with that
   // content so the adapter's prefix-match path can succeed.
-  function makeCocoPasteTmuxPty(opts?: { confirmCocoSubmit?: boolean }) {
+  function makeCocoPasteTmuxPty(opts?: { confirmCocoSubmit?: boolean; historyTarget?: 'legacy' | 'trae' }) {
     const confirmCocoSubmit = opts?.confirmCocoSubmit ?? true;
+    // 'legacy' → ~/.cache/coco/history.jsonl ({content,mode:"user"}); 'trae' →
+    // ~/.trae/cli/history.jsonl ({session_id,ts,text}) — the two formats coco's
+    // dual-path confirmation must accept.
+    const historyTarget = opts?.historyTarget ?? 'legacy';
     let lastPasted = '';
     let submittedOnce = false;
     return {
@@ -1526,7 +1544,8 @@ describe('coco writeInput submission confirmation', () => {
         if (key !== 'Enter') return;
         if (!confirmCocoSubmit || submittedOnce) return;
         submittedOnce = true;
-        appendCocoHistory(lastPasted);
+        if (historyTarget === 'trae') appendTraeHistory(lastPasted);
+        else appendCocoHistory(lastPasted);
       }),
       pasteText: vi.fn((text: string) => { lastPasted = text; }),
     } satisfies PtyHandle;
@@ -1702,5 +1721,120 @@ describe('coco writeInput submission confirmation', () => {
     expect(result).toEqual({ submitted: true });
     const enterCalls = (pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter').length;
     expect(enterCalls).toBe(1);
+  });
+
+  // ── Dual-path submit confirmation (traecli 0.201.5 migration) ────────────
+  // traecli 0.201.5 moved the submit log from ~/.cache/coco/history.jsonl
+  // ({content,mode:"user"}) to $TRAE_HOME/cli/history.jsonl
+  // ({session_id,ts,text}) — the same file the traex adapter polls. Coco runs
+  // the same binary, so writeInput must poll BOTH and confirm on either.
+
+  it('confirms a submit when only the new ~/.trae/cli/history.jsonl path records it', async () => {
+    // Legacy path exists but holds no marker; the traecli 0.201.5+ path gets
+    // the {session_id,ts,text} line. Before the dual-path fix this submit
+    // false-warned submit_unconfirmed forever.
+    resetCocoHistory();
+    appendCocoHistory('seed prior submit so legacy file exists');
+    resetTraeHistory();
+    const adapter = createCocoAdapter('/bin/coco');
+    const pty = makeCocoPasteTmuxPty({ historyTarget: 'trae' });
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(result).toEqual({ submitted: true });
+    expect(pty.pasteText).toHaveBeenCalledWith(MULTILINE);
+    const enterCalls = pty.sendSpecialKeys.mock.calls.filter(c => c[0] === 'Enter').length;
+    expect(enterCalls).toBe(1);
+  });
+
+  it('honors TRAE_HOME for the new history path (resolved per submit, not at module load)', async () => {
+    // traeHistoryPath() must be evaluated at submit time: TRAE_HOME may be set
+    // after the adapter module loaded. Point it at a custom home and confirm
+    // the marker is found there (and not under the default ~/.trae).
+    const prevTraeHome = process.env.TRAE_HOME;
+    const customHome = join(homedir(), '.trae-coco-dual-path-test-home');
+    process.env.TRAE_HOME = customHome;
+    try {
+      resetCocoHistory();
+      appendCocoHistory('seed prior submit so legacy file exists');
+      const customHistory = join(customHome, 'cli', 'history.jsonl');
+      mkdirSync(dirname(customHistory), { recursive: true });
+      writeFileSync(customHistory, '');
+      let lastPasted = '';
+      const pty: PtyHandle = {
+        write: vi.fn(),
+        sendText: vi.fn(),
+        sendSpecialKeys: vi.fn((key: string) => {
+          if (key !== 'Enter') return;
+          appendFileSync(customHistory, JSON.stringify({ session_id: 'custom-home-session', ts: Date.now(), text: lastPasted }) + '\n');
+        }),
+        pasteText: vi.fn((text: string) => { lastPasted = text; }),
+      };
+
+      const adapter = createCocoAdapter('/bin/coco');
+      const result = await adapter.writeInput(pty, MULTILINE);
+
+      expect(result).toEqual({ submitted: true });
+    } finally {
+      if (prevTraeHome === undefined) delete process.env.TRAE_HOME;
+      else process.env.TRAE_HOME = prevTraeHome;
+      try { rmSync(customHome, { recursive: true, force: true }); } catch { /* memfs / absent */ }
+    }
+  });
+
+  it('fresh install: confirms via the new path when only ~/.trae/cli/history.jsonl appears', async () => {
+    // Both logs absent at submit time; CoCo creates ONLY the new-path file
+    // with our marker during the fresh-install short wait.
+    const { rmSync } = await import('node:fs');
+    try { rmSync(COCO_HISTORY_PATH); } catch { /* may not exist */ }
+    try { rmSync(TRAE_HISTORY_PATH); } catch { /* may not exist */ }
+    const adapter = createCocoAdapter('/bin/coco');
+    const pty = makeCocoPasteTmuxPty({ historyTarget: 'trae' });
+    const result = await adapter.writeInput(pty, MULTILINE);
+    expect(result).toEqual({ submitted: true });
+  });
+
+  it('new path uses EXACT text match — a same-prefix decoy line does not confirm', async () => {
+    // The legacy path matches a 40-char PREFIX; the new path matches the full
+    // text exactly (traexHistoryMatchDelta, shared with traex). A line sharing
+    // only the prefix must NOT confirm on the new path.
+    resetCocoHistory();
+    appendCocoHistory('seed prior submit so legacy file exists');
+    resetTraeHistory();
+    const content = 'shared-prefix '.repeat(4) + 'actual submitted tail';
+    const decoy = content.slice(0, 40) + ' different tail from another pane';
+    const pty: PtyHandle = {
+      write: vi.fn(),
+      sendText: vi.fn(),
+      sendSpecialKeys: vi.fn((key: string) => {
+        if (key !== 'Enter') return;
+        appendTraeHistory(decoy, 'decoy-session');
+      }),
+      pasteText: vi.fn(),
+    };
+
+    const adapter = createCocoAdapter('/bin/coco');
+    const result = await adapter.writeInput(pty, content);
+
+    expect(result).toMatchObject({ submitted: false });
+    expect(typeof (result as any)?.recheck).toBe('function');
+    expect((result as any).recheck()).toBe(false);
+  });
+
+  it('recheck closure scans both paths — a late append to the NEW path flips it to true', async () => {
+    // In-band budget exhausted with neither log holding the marker; the
+    // worker's deferred recheck must still spot a slow append on EITHER path.
+    resetCocoHistory();
+    appendCocoHistory('seed prior submit so legacy file exists');
+    resetTraeHistory();
+    const adapter = createCocoAdapter('/bin/coco');
+    const pty = makeCocoPasteTmuxPty({ confirmCocoSubmit: false });
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(result).toMatchObject({ submitted: false });
+    const recheck = (result as any)?.recheck as () => boolean;
+    expect(typeof recheck).toBe('function');
+    expect(recheck()).toBe(false);
+    appendTraeHistory(MULTILINE, 'late-trae-session');
+    expect(recheck()).toBe(true);
   });
 });


### PR DESCRIPTION
# PR 3: sprint-adapters（CLI 适配器修复 5 项）

## 改了什么

来自「Botmux 交流群」近 7 天用户反馈的适配器专项，5 个修复：

1. **`fix(adapter)`: coco 提交确认兼容 traecli 新历史路径**
   - traecli 0.201.5 把会话记录从 `~/.cache/coco/history.jsonl` 迁到 `~/.trae/cli/history.jsonl`，CoCo 适配器仍查旧路径，消息已提交也持续误报 `submit_unconfirmed`。改为双路径轮询（旧路径 `historyDeltaContains` + 新路径 `traexHistoryMatchDelta`），任一命中即确认；`HISTORY_PATH` 改动态计算（兼容后设 `TRAE_HOME`）。

2. **`fix(adapter)`: antigravity 提交不再重发 Enter**
   - 首次 Enter 后 800ms 内未见 history 确认就补按 Enter（最多 4 次），agy history 写入慢时同一问题重复提交 5-6 次。改为单次 Enter + 3.2s 一次性轮询（总预算不变），超时走 worker 既有 20s deferred recheck 兜底（对齐 grok.ts 的 "Do not retry Enter" 模式）。

3. **`fix(worker)`: 信任框 Enter 延迟 400ms 发送**
   - Codex 0.149 目录信任框出现时按键处理器尚未就绪，立即发 Enter 被吞，消息未提交。`handleVisibleStartupInteraction` trust 分支改为 `trustHandled=true` 同步置位 + `setTimeout(400ms)` fire-and-forget（上游 openai/codex#39487）。

4. **`fix(traex)`: 识别助手侧 item_completed 与无 phase agent_message**
   - TRAE 3.16.1 报「空最终回复」：task_complete 但 last_agent_message 为空。#997 修了用户侧 item_completed，助手侧是对称缺口。新增 `itemCompletedAgentText`（识别 AgentMessage item）+ 无 phase agent_message fallback，均经 `traexTrailingSentinel` 守卫区分 deliberate silence。

5. **`fix(adopt)`: rollout 标题提取兼容 codex 0.147 response_item 格式**
   - Codex 0.147+ 用户消息只存 `response_item`/`message role=user`，adopt 磁盘扫描只认 `event_msg`/`user_message`，新会话不显示（issue #878）。`parseRolloutTranscript` 增加 fallback：取首个非合成 response_item role=user 消息为 title，跳过 environment_context/permissions 等合成 preamble 与 botmux 注入。

## 影响面

- **跨 CLI**：coco/antigravity 改动仅影响各自适配器；traex-transcript 仅影响 traex 会话；resumable-session-discovery 惠及 codex+traex 新格式会话
- **共用路径**：③改了所有 CLI 共用的 `handleVisibleStartupInteraction`——唯一调用方不 await trust 完成，Claude Code 信任框仅 dismiss 晚 400ms 无功能回归；Aiden 更新弹窗分支未触碰
- **跨后端**：antigravity 改动 PtyBackend/TmuxBackend 行为一致
- **旧格式兼容**：coco 旧路径保留（兼容旧 traecli）；adopt 旧格式 event_msg/user_message 优先且早停逻辑不变

## 测试验证

- `pnpm build` 通过
- 新增/更新测试：write-input 141/141、antigravity-submit 16/16（含慢 history 只发 1 次 Enter）、trust-dialog-defer 5 新增 + backend-gate 21、traex-transcript 53/53（11 新增）、resumable-session-discovery 37/37（5 新增）；另用 78 个真实 rollout 只读冒烟，2 个已知新格式文件 title 正确提取
- `pnpm test` 全量：18171 passed；3 个失败（bwrap/dsh 沙箱环境问题）已在干净基线复现确认预存