### PR TITLE
fix(sandbox): 让 legacy readIsolation 收敛到 sandbox 并 fail-closed (#801)

### DIFF
--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -1258,7 +1258,19 @@ export interface MigratedSandboxFields {
  * reverse script (design doc §6.2). Returns null when nothing to migrate.
  */
 export function migrateLegacySandboxFields(entry: LegacySandboxFields & { sandboxPaths?: unknown }): MigratedSandboxFields | null {
-  if (entry.sandboxPaths !== undefined) return null; // already on the new model
+  // `readIsolation: true` ALWAYS implies the file sandbox, so it must converge to
+  // `sandbox: true` even on an entry that already carries the new `sandboxPaths`
+  // field — that combination (readIsolation + sandboxPaths, no `sandbox`) used to
+  // fall through the "already on the new model" short-circuit below and could
+  // NEVER be migrated. Its isolation then hung entirely on worker.ts's legacy
+  // `|| cfg.readIsolation === true` compatibility branch: the day that branch is
+  // dropped (the intended convergence), such a bot silently becomes unsandboxed.
+  // Path migration is skipped here (the new-model lists are authoritative); only
+  // the missing `sandbox` flag is filled in.
+  const readIsolationImpliesSandbox = entry.readIsolation === true && entry.sandbox !== true;
+  if (entry.sandboxPaths !== undefined) {
+    return readIsolationImpliesSandbox ? { sandbox: true } : null; // already on the new model
+  }
   const hasLegacy = entry.readIsolation === true
     || (entry.sandboxReadonlyPaths?.length ?? 0) > 0
     || (entry.sandboxHidePaths?.length ?? 0) > 0

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -2399,6 +2399,13 @@ export function botAcceptsSlashFromBots(larkAppId: string): boolean {
 }
 
 /**
+ * Bots whose legacy `readIsolation` has already been folded into `sandbox` in
+ * memory and warned about — the warn must fire once per process, not on every
+ * loadBotConfigs() call (event dispatch / dashboard paths re-parse the file).
+ */
+const legacyReadIsolationWarned = new Set<string>();
+
+/**
  * Load bot configurations from one of (in priority order):
  * 1. BOTS_CONFIG env var — path to a JSON file
  * 2. ~/.botmux/bots.json — default config path
@@ -2927,6 +2934,18 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
     const sanitizedEnv = sanitizePerBotEnv(entry.env);
     const env = Object.keys(sanitizedEnv).length > 0 ? sanitizedEnv : undefined;
 
+    // Explicit fail-closed notice for the alias fold below: the entry asks for
+    // read isolation but carries no `sandbox: true`, i.e. the startup migration
+    // has not converged it (core-only skips migration, a read-only bots.json
+    // only warns, and a `sandboxPaths`-carrying entry was unreachable for it
+    // before this release). It IS treated as sandboxed — say so instead of
+    // leaving the discrepancy to the legacy compatibility branch in worker.ts.
+    if (entry.readIsolation === true && entry.sandbox !== true
+      && !legacyReadIsolationWarned.has(entry.larkAppId)) {
+      legacyReadIsolationWarned.add(entry.larkAppId);
+      logger.warn(`[bot-registry:${entry.larkAppId}] legacy readIsolation=true without sandbox=true — 按沙盒处理（fail-closed）。请在 bots.json 补 "sandbox": true，或让 daemon 启动时的 sandbox 迁移写回（BOTMUX_CORE_ONLY=1 或 bots.json 只读时不会发生）。`);
+    }
+
     const skills = readBotSkillPolicy(entry.skills);
     // Presence is semantic for plugins: [] is an exact "none" override, while
     // an absent field inherits the machine defaults.
@@ -3010,7 +3029,19 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       codexAppCleanInput: entry.codexAppCleanInput === true || undefined,
       codexRpcInput: entry.codexRpcInput === true,
       existingAppServer,
-      sandbox: entry.sandbox === true,
+      // FAIL-CLOSED alias fold: legacy `readIsolation: true` ALWAYS means "this
+      // bot runs sandboxed", so the in-memory config says so even when the disk
+      // migration never ran (BOTMUX_CORE_ONLY=1 skips it; a read-only bots.json
+      // only warns). Without this, such a bot kept `sandbox: false` in memory
+      // and stayed isolated purely through worker.ts's legacy
+      // `|| cfg.readIsolation === true` branch, while every consumer that reads
+      // the flag alone disagreed — most consequentially forkWorker, which FREEZES
+      // `session.sandbox = botCfg.sandbox === true` onto the session and hands
+      // that frozen value to sandbox-keyed decisions downstream
+      // (evaluateVcMeetingConsumerIsolation, restore/refork sibling fields).
+      // Folding here makes "readIsolation ⇒ sandboxed" hold at every layer
+      // instead of at each remembered call site.
+      sandbox: entry.sandbox === true || entry.readIsolation === true,
       sandboxPaths: entry.sandboxPaths && typeof entry.sandboxPaths === 'object' && !Array.isArray(entry.sandboxPaths)
         ? {
             readWrite: normalizeStringList(entry.sandboxPaths.readWrite),

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -5020,6 +5020,15 @@ ipcRoute('PUT', '/api/bot-sandbox', async (req, res) => {
   let body: { enabled?: unknown };
   try { body = await readJsonBody<{ enabled?: unknown }>(req); }
   catch { return jsonRes(res, 400, { ok: false, error: 'bad_json' }); }
+  // Legacy `readIsolation: true` implies the sandbox (bot-registry folds it in
+  // fail-closed), so clearing `sandbox` alone would leave the bot sandboxed while
+  // this toggle reports OFF. Refuse rather than lie. Clearing read isolation is a
+  // policy change in its own right and must go through PUT /api/bot-read-isolation,
+  // which carries the active-session / pane-teardown guards this next-session-only
+  // route deliberately lacks.
+  if (body.enabled !== true && sandboxStore.getBotReadIsolation(cachedLarkAppId)) {
+    return jsonRes(res, 409, { ok: false, error: 'sandbox_legacy_read_isolation_set' });
+  }
   // File-sandbox policy is frozen onto each Session at creation and reused on
   // restore; this toggle is intentionally next-session-only and cannot mutate
   // a live pane's profile.

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -1967,4 +1967,22 @@ describe('normalizeTurnTimeoutMs / MAX_TURN_TIMEOUT_MS', () => {
     const { DASHBOARD_MAX_TURN_TIMEOUT_MS } = await import('../src/dashboard/web/bot-defaults-page.js');
     expect(DASHBOARD_MAX_TURN_TIMEOUT_MS).toBe(mod.MAX_TURN_TIMEOUT_MS);
   });
+
+  it('folds legacy readIsolation into sandbox (fail-closed, migration may never have run)', () => {
+    // Core-only skips the startup migration and a read-only bots.json only warns,
+    // so the loader itself must hold "readIsolation ⇒ sandboxed" — otherwise the
+    // frozen session.sandbox (forkWorker) disagrees with what the worker enforces.
+    const [legacyOnly, withPaths, plain, off] = mod.parseBotConfigsFromText(JSON.stringify([
+      { larkAppId: 'ri_a', larkAppSecret: 's', readIsolation: true },
+      { larkAppId: 'ri_b', larkAppSecret: 's', readIsolation: true, sandboxPaths: { readOnly: ['/p'] } },
+      { larkAppId: 'ri_c', larkAppSecret: 's', sandbox: true },
+      { larkAppId: 'ri_d', larkAppSecret: 's' },
+    ]));
+    expect(legacyOnly.sandbox).toBe(true);
+    expect(legacyOnly.readIsolation).toBe(true);
+    expect(withPaths.sandbox).toBe(true);
+    expect(withPaths.sandboxPaths).toEqual({ readOnly: ['/p'], readWrite: [], deny: [] });
+    expect(plain.sandbox).toBe(true);
+    expect(off.sandbox).toBe(false); // no opt-in anywhere → still off
+  });
 });

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -2223,6 +2223,66 @@ describe('POST /api/sessions/:sessionId/suspend', () => {
   });
 });
 
+describe('PUT /api/bot-sandbox', () => {
+  it('refuses to turn the sandbox off while legacy readIsolation still implies it', async () => {
+    const appId = 'test-sandbox-off-legacy-read-isolation';
+    registerBot({
+      larkAppId: appId,
+      larkAppSecret: 'secret',
+      cliId: 'codex-app',
+      workingDir: process.cwd(),
+      workingDirs: [process.cwd()],
+      readIsolation: true,
+    } as any);
+    setLarkAppId(appId);
+    const updateSpy = vi.spyOn(sandboxStore, 'updateBotSandbox');
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/bot-sandbox`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toMatchObject({ ok: false, error: 'sandbox_legacy_read_isolation_set' });
+      // nothing persisted: the bot stays sandboxed, as readIsolation still demands
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      updateSpy.mockRestore();
+    }
+  });
+
+  it('still allows turning the sandbox on with legacy readIsolation set', async () => {
+    const appId = 'test-sandbox-on-legacy-read-isolation';
+    registerBot({
+      larkAppId: appId,
+      larkAppSecret: 'secret',
+      cliId: 'codex-app',
+      workingDir: process.cwd(),
+      workingDirs: [process.cwd()],
+      readIsolation: true,
+    } as any);
+    setLarkAppId(appId);
+    const updateSpy = vi.spyOn(sandboxStore, 'updateBotSandbox')
+      .mockResolvedValue({ ok: true, sandbox: true } as any);
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/bot-sandbox`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, sandbox: true });
+      expect(updateSpy).toHaveBeenCalledWith(appId, true);
+    } finally {
+      updateSpy.mockRestore();
+    }
+  });
+});
+
 describe('PUT /api/bot-read-isolation', () => {
   for (const enabled of [false, true]) {
     it(`treats ${enabled}→${enabled} as a no-op even with active and persisted pending owners`, async () => {

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -1004,6 +1004,28 @@ describe('migrateLegacySandboxFields', () => {
     expect(migrateLegacySandboxFields({ sandbox: true })).toBeNull();
     expect(migrateLegacySandboxFields({})).toBeNull();
   });
+
+  it('still absorbs readIsolation on a sandboxPaths-carrying entry (fail-open gap)', () => {
+    // The entry shape that could never be migrated: new-model paths present, but
+    // the sandbox flag only implied by legacy readIsolation. Isolation must not
+    // depend on worker.ts's legacy or-branch surviving.
+    expect(migrateLegacySandboxFields({
+      readIsolation: true,
+      sandboxPaths: { readOnly: ['/some/path'] },
+    })).toEqual({ sandbox: true });
+    // Paths are NOT rewritten — the new-model lists stay authoritative.
+    expect(migrateLegacySandboxFields({
+      readIsolation: true,
+      sandboxReadonlyPaths: ['~/legacy'],
+      sandboxPaths: { readOnly: ['/new'] },
+    })).toEqual({ sandbox: true });
+    // Already converged (sandbox:true) → still a no-op, so migration stays idempotent.
+    expect(migrateLegacySandboxFields({
+      sandbox: true,
+      readIsolation: true,
+      sandboxPaths: { readOnly: ['/some/path'] },
+    })).toBeNull();
+  });
 });
 
 describe('compiler parity with accessForPath', () => {

--- a/test/sandbox-migration.test.ts
+++ b/test/sandbox-migration.test.ts
@@ -50,6 +50,27 @@ describe('migrateSandboxConfigOnDisk', () => {
     expect(e.sandboxPaths).toEqual({ deny: ['~/x'] });
   });
 
+  it('absorbs readIsolation on an entry that already carries sandboxPaths', async () => {
+    // Pre-fix this entry hit the "already on the new model" short-circuit and was
+    // NEVER migrated: it stayed sandboxed only through worker.ts's legacy
+    // readIsolation or-branch, so removing that branch would silently unsandbox it.
+    write([{
+      larkAppId: 'cli_c', larkAppSecret: 's',
+      readIsolation: true,
+      sandboxPaths: { readOnly: ['/some/path'] },
+    }]);
+    const { migrated } = await migrateSandboxConfigOnDisk(botsPath);
+    expect(migrated).toEqual(['cli_c']);
+    const [e] = read();
+    expect(e.sandbox).toBe(true);
+    expect(e.readIsolation).toBe(true); // kept for downgrade
+    expect(e.sandboxPaths).toEqual({ readOnly: ['/some/path'] }); // paths untouched
+    // and converged: a second pass has nothing left to do
+    const after = readFileSync(botsPath, 'utf-8');
+    expect((await migrateSandboxConfigOnDisk(botsPath)).migrated).toEqual([]);
+    expect(readFileSync(botsPath, 'utf-8')).toBe(after);
+  });
+
   it('is idempotent: second run migrates nothing and leaves the file unchanged', async () => {
     write([{ larkAppId: 'cli_a', larkAppSecret: 's', sandbox: true, sandboxHidePaths: ['~/.aws'] }]);
     await migrateSandboxConfigOnDisk(botsPath);


### PR DESCRIPTION
## Summary

针对 #801 第二节的 fail-open 迁移边界。按 @deepcoldy 的方向（readIsolation 收敛到 sandbox、不当长期一等开关）实作，只做「让 `readIsolation === true` ⇒ 一定是沙盒」这条不变量在每一层都成立，不动 #602 预留的分阶段 API。

### 一、迁移永远跑不到的 entry（issue 第二节）

`migrateLegacySandboxFields()` 第一行 `if (entry.sandboxPaths !== undefined) return null` 会让这种 entry 永远无法迁移：

```jsonc
{ "readIsolation": true, "sandboxPaths": { "readOnly": ["/some/path"] } }  // 没有 sandbox
```

现在改成：`sandboxPaths` 已存在时，若 `readIsolation === true && sandbox !== true` 仍回传 `{ sandbox: true }`（**只补 flag，不重写 paths** — 新模型的三层清单仍是权威）。已经是 `sandbox: true` 的 entry 照旧回 null，迁移维持幂等。

### 二、迁移跑不到时的显式 fail-closed（issue 第二节的建议）

`BOTMUX_CORE_ONLY=1` 会跳过启动迁移，bots.json 只读时 `migrateSandboxConfigOnDisk` 也只 warn 不写。所以在 loader（`parseBotConfigsFromText`）加一道显式折叠 + warn：

- `sandbox: entry.sandbox === true || entry.readIsolation === true`
- 命中 `readIsolation=true && sandbox!==true` 时 warn 一次（per process per bot，`loadBotConfigs()` 在事件派发/dashboard 路径会重复呼叫）

这不只是为了「未来移除 worker.ts 的 or 分支时不掉安全」。**目前就已经有实际分歧**：`forkWorker` 会把 `session.sandbox = botCfg.sandbox === true` 冻结到 session 上，对这类 entry 冻结成 `false`；worker 靠 `|| cfg.readIsolation` 仍然沙盒，但下游只看这个冻结值的判断（例如 `evaluateVcMeetingConsumerIsolation({ sandbox: ds.session.sandbox })`、restore/refork 的 sandboxHidePaths/ReadonlyPaths/Network 兄弟栏位）会认为「没沙盒」。折叠在 loader 之后，这些点自动一致，不必逐个记得补 or。

worker.ts 的 legacy 相容分支**保留不动**（本 PR 不移除任何相容路径）。

### 三、顺带：`PUT /api/bot-sandbox` 关闭时不再说谎

折叠后 `getBotSandbox()` 对这类 bot 回 true（属实），但把开关关掉只会 `delete entry.sandbox`，`readIsolation` 还在 → bot 依然沙盒，UI 却显示 OFF。所以 disable 且 `readIsolation` 仍设定时回 409 `sandbox_legacy_read_isolation_set`，请改走 `PUT /api/bot-read-isolation`（那条带 #602 的 active-session / pane teardown 闸门）。

这是把「静默无效」换成「明确报错」，没有绕过 #602 任何闸门。若 maintainer 觉得该由别的方式收敛（例如让 sandbox 路由也共用那套闸门后一起清掉两个栏位），这一 hunk 可以单独拿掉，不影响前两项。

### 关于 issue 第三节第 1 点

`worker-pool.ts` 的 `|| !larkTransportEnabled(...)` 强制隔离已在 #899 移除（现在是 `readIsolation: botCfg.readIsolation === true`，纯 opt-in），所以本 PR 不需要再拆 `sandboxForced`。

## 可利用性结论

不是可直接利用的漏洞：今天这类 entry 仍然被 `worker.ts` 的 `|| cfg.readIsolation === true` 兜住，沙盒实际是开的。真正的现况问题是**跨层状态不一致**（冻结的 `session.sandbox` 与实际执行不符）以及**收敛路径被堵死**（这类 entry 永远迁移不到新模型），一旦相容分支被移除就是无声掉安全。所以修的是不变量本身，而不是补某个呼叫点。

## Test plan

- `test/fs-policy.test.ts` — `migrateLegacySandboxFields`：`readIsolation` + `sandboxPaths` → `{ sandbox: true }`；paths 不被改写；已收敛的 entry 仍是 no-op
- `test/sandbox-migration.test.ts` — 落盘验证：该 entry 会被迁移、`sandboxPaths` 原样保留、`readIsolation` 保留供降级、第二次跑无变更
- `test/bot-registry.test.ts` — loader 折叠：`readIsolation` → `sandbox: true`，没有任何 opt-in 的 bot 仍是 false
- `test/dashboard-ipc.test.ts` — `PUT /api/bot-sandbox` 关闭被 409 挡下且不落盘；开启不受影响
- `npx tsc --noEmit` 通过；`test/fs-policy` / `test/sandbox-migration` / `test/bot-registry` 共 212 tests 通过
- ⚠️ `test/dashboard-ipc.test.ts` 在我的容器里跑不起来（node-pty 原生模组缺 prebuild、无 make 可编译，master 上同样失败），该档新增的两个 case 未在本机实跑，麻烦 CI 覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)