### PR TITLE
fix(card): 可写终端链接改为按钮渲染，不再裸露 URL

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,7 +8,7 @@ export const messages: Record<string, string> = {
   'card.btn.open_local_codex': 'Open Codex',
   'card.btn.open_local_trae': 'Open TRAE',
   'card.btn.get_write_link': '🔑 Get Write Link',
-  'card.writable_terminal_link': '🔑 Writable terminal (visible to everyone here — anyone can drive it): [{url}]({url})',
+  'card.writable_terminal_warning': '🔑 Writable terminal (visible to everyone here — anyone can drive it)',
   'card.btn.restart_cli': '🔄 Restart {cliName}',
   'card.btn.disconnect': '⏏ Disconnect',
   'card.btn.close_session': '❌ Close Session',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -11,7 +11,7 @@ export const messages: Record<string, string> = {
   'card.btn.open_local_codex': '打开 Codex',
   'card.btn.open_local_trae': '打开 TRAE',
   'card.btn.get_write_link': '🔑 获取操作链接',
-  'card.writable_terminal_link': '🔑 可操作终端（群内可见，任何人可直接操控）：[{url}]({url})',
+  'card.writable_terminal_warning': '🔑 可操作终端（群内可见，任何人可直接操控）',
   'card.btn.restart_cli': '🔄 重启 {cliName}',
   'card.btn.disconnect': '⏏ 断开',
   'card.btn.close_session': '❌ 关闭会话',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1023,10 +1023,25 @@ export function buildStreamingCard(
   // When the bot enables `writableTerminalLinkInCard`, embed the token-bearing
   // link right in the card so anyone here can open a writable terminal without
   // the get-write-link → DM round-trip. The link is intentionally group-visible.
+  // Rendered as a URL button (same shape as the read-only terminal button),
+  // not a markdown link: the token URL is long and wrapped into an ugly raw
+  // URL blob in the card. The group-visible warning stays as a note below.
   if (writableTerminalUrl) {
     elements.push({
-      tag: 'markdown',
-      content: t('card.writable_terminal_link', { url: writableTerminalUrl }, locale),
+      tag: 'action',
+      actions: [{
+        tag: 'button',
+        text: { tag: 'plain_text', content: t('card.btn.open_writable_terminal', undefined, locale) },
+        type: 'primary',
+        multi_url: terminalMultiUrl(writableTerminalUrl),
+      }],
+    });
+    elements.push({
+      tag: 'note',
+      elements: [{
+        tag: 'lark_md',
+        content: t('card.writable_terminal_warning', undefined, locale),
+      }],
     });
   }
 

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -1300,6 +1300,55 @@ describe('buildStreamingCard', () => {
     });
   });
 
+  // ── Writable terminal link (writableTerminalLinkInCard opt-in) ──────────
+
+  describe('writable terminal link', () => {
+    const WURL = 'https://example.com/writable?token=secret';
+
+    const buildWithWritable = (locale: 'zh' | 'en' = 'zh') => parse(buildStreamingCard(
+      SID, ROOT, URL, TITLE, '', 'idle', undefined, 'hidden',
+      undefined, undefined, false, false, locale, undefined, WURL,
+    ));
+
+    const allActionButtons = (card: any): any[] =>
+      card.elements.filter((e: any) => e.tag === 'action').flatMap((row: any) => row.actions);
+
+    it('renders the writable URL as a primary URL button instead of a raw markdown link', () => {
+      const card = buildWithWritable();
+      // No markdown element carries the token URL (the previous shape rendered
+      // the long URL as a raw markdown link blob).
+      const mdLinks = card.elements.filter((e: any) => e.tag === 'markdown');
+      expect(mdLinks.every((m: any) => !m.content.includes('?token='))).toBe(true);
+
+      const writableBtn = allActionButtons(card).find((a: any) => a.multi_url?.url.includes('?token='));
+      expect(writableBtn).toBeDefined();
+      expect(writableBtn.type).toBe('primary');
+      expect(writableBtn.text.content).toContain('可操作');
+      expectDirectUrl(writableBtn.multi_url.url, WURL);
+      expectDirectUrl(writableBtn.multi_url.pc_url, WURL);
+      expect(writableBtn.multi_url.android_url).toBe(WURL);
+      expect(writableBtn.multi_url.ios_url).toBe(WURL);
+    });
+
+    it('keeps the group-visible warning as a note under the button (zh + en)', () => {
+      const zh = buildWithWritable('zh');
+      const zhNote = zh.elements.find((e: any) => e.tag === 'note');
+      expect(zhNote).toBeDefined();
+      expect(JSON.stringify(zhNote)).toContain('群内可见');
+
+      const en = buildWithWritable('en');
+      const enNote = en.elements.find((e: any) => e.tag === 'note');
+      expect(enNote).toBeDefined();
+      expect(JSON.stringify(enNote)).toContain('visible to everyone');
+    });
+
+    it('omits the writable button and warning when no writable URL is set', () => {
+      const card = parse(buildStreamingCard(SID, ROOT, URL, TITLE, '', 'idle'));
+      expect(allActionButtons(card).some((a: any) => a.multi_url?.url.includes('?token='))).toBe(false);
+      expect(card.elements.some((e: any) => e.tag === 'note')).toBe(false);
+    });
+  });
+
   // ── CLI display name ───────────────────────────────────────────────────
 
   it('should default cliId to claude-code', () => {


### PR DESCRIPTION
## 背景

Bot 开启 `writableTerminalLinkInCard`（卡内嵌可写终端）后，streaming 卡片把带 token 的可写终端链接渲染成 markdown 裸链接：URL 很长，在卡片里折行成一坨蓝色 URL 文本，和上方一排按钮（显示输出 / 打开 Web 终端 / 获取操作链接 / 关闭会话）的交互形态不一致。

## 改了什么

`buildStreamingCard` 的可写链接分支（`src/im/lark/card-builder.ts`）：

- **markdown 裸链接 → URL 按钮**：改为与只读「打开 Web 终端」同款的 `multi_url` 按钮（`type: primary`），复用既有文案 `card.btn.open_writable_terminal`（🖥️ 打开可操作 Web 终端），单独一行 action 区
- **警示语保留**：「群内可见，任何人可直接操控」的安全提示不丢，改为按钮下方的 `note` 元素（小灰字）
- **i18n key 更名**：`card.writable_terminal_link`（带 URL 插值的 markdown 文案）→ `card.writable_terminal_warning`（纯警示文案），zh/en 同步；全仓 grep 确认无其他引用

卡片形态示意：

```
修改前：
┌────────────────────────────────────────────────────┐
│ 📖 显示输出  🖥️ 打开 Web 终端  🔑 获取操作链接  ❌ 关闭会话 │
│ 🔑 可操作终端（群内可见，任何人可直接操控）：              │
│ http://10.37.20.168:8802/s/558daadd-56e0-4eaf-aba8-  │
│ cb1318e684da?token=olj6bw3ru6EfgAZcGPB_2Z8mnQ2Mns... │
└────────────────────────────────────────────────────┘

修改后：
┌────────────────────────────────────────────────────┐
│ 📖 显示输出  🖥️ 打开 Web 终端  🔑 获取操作链接  ❌ 关闭会话 │
│ ┌─────────────────────┐                            │
│ │ 🖥️ 打开可操作 Web 终端  │                            │
│ └─────────────────────┘                            │
│ 🔑 可操作终端（群内可见，任何人可直接操控）              │
└────────────────────────────────────────────────────┘
```

## 影响面

- **仅 `buildStreamingCard` 的可写链接分支**：只有 Bot 显式开启 `writableTerminalLinkInCard` 且会话有可写 URL 时才渲染，默认关闭路径零变化
- 按钮是纯 `multi_url` 跳转按钮，**无回调 action**，不经过 `card-handler`，无新增交互面
- 私有快照卡片（`buildPrivateSnapshotCard`）本来就不内嵌可写链接，不受影响；`buildSessionCard` 的写链接卡片此前已用同款按钮
- i18n key 更名不影响 dashboard（该 key 不在 dashboard i18n 子集）

## 测试验证

- `pnpm build`（tsc）通过
- `test/card-builder.test.ts` 182 个测试全过，新增 3 个用例：
  - 可写 URL 渲染为 primary URL 按钮（`multi_url` 四端字段齐全），markdown 元素中不再出现 token URL
  - 警示 note 在 zh/en 下都渲染
  - 无可写 URL 时按钮与 note 均不出现
- 24 个引用 card-builder / i18n 的测试文件共 1436 个测试全过
- 全量套件对照 baseline 无新增回归（少量失败为既有环境性失败，与本 diff 零代码交集）
