### PR TITLE
fix: isolate feed-group OAuth tokens by owner

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2509,6 +2509,7 @@ export async function handleCommand(
             botCfg2.larkAppSecret,
             normalizeBrand(botCfg2.brand),
             FEED_GROUP_OAUTH_SCOPES,
+            message.senderId,
           );
           await sessionReply(rootId, [
             t('cmd.login.tags_title', undefined, loc),

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -4591,11 +4591,13 @@ ipcRoute('POST', '/api/session-group-tag-auth', async (_req, res) => {
   if (!cachedLarkAppId) return jsonRes(res, 503, { error: 'larkAppId_not_set' });
   try {
     const cfg = getBot(cachedLarkAppId).config;
+    if (!cfg.ownerOpenId) return jsonRes(res, 409, { ok: false, error: 'owner_open_id_unavailable' });
     const { authUrl } = generateAuthUrl(
       cfg.larkAppId,
       cfg.larkAppSecret,
       normalizeBrand(cfg.brand),
       FEED_GROUP_OAUTH_SCOPES,
+      cfg.ownerOpenId,
     );
     jsonRes(res, 200, { ok: true, authUrl });
   } catch (e: any) {
@@ -4608,7 +4610,7 @@ ipcRoute('GET', '/api/session-group-tag-status', async (_req, res) => {
   if (!cachedLarkAppId) return jsonRes(res, 503, { error: 'larkAppId_not_set' });
   try {
     const cfg = getBot(cachedLarkAppId).config;
-    const status = getFeedGroupAuthStatus(cfg.larkAppId, normalizeBrand(cfg.brand));
+    const status = getFeedGroupAuthStatus(cfg.larkAppId, normalizeBrand(cfg.brand), cfg.ownerOpenId);
     jsonRes(res, 200, { ok: true, ...status, tagMode: cfg.sessionGroup?.tag?.mode ?? 'feed-group' });
   } catch (e: any) {
     jsonRes(res, 500, { ok: false, error: e?.message ?? String(e) });

--- a/src/services/feed-group-tagger.ts
+++ b/src/services/feed-group-tagger.ts
@@ -49,21 +49,23 @@ interface TagCache {
   lastAuthNudgeAt?: number;
 }
 
-function cachePath(appId: string): string {
-  return join(config.session.dataDir, `feed-group-cache-${appId}.json`);
+function cachePath(appId: string, ownerOpenId?: string): string {
+  return join(config.session.dataDir, ownerOpenId
+    ? `feed-group-cache-${appId}-${encodeURIComponent(ownerOpenId)}.json`
+    : `feed-group-cache-${appId}.json`);
 }
 
-function loadCache(appId: string): TagCache {
+function loadCache(appId: string, ownerOpenId?: string): TagCache {
   try {
-    const fp = cachePath(appId);
+    const fp = cachePath(appId, ownerOpenId);
     if (existsSync(fp)) return JSON.parse(readFileSync(fp, 'utf-8')) as TagCache;
   } catch { /* corrupted cache → start fresh */ }
   return {};
 }
 
-function saveCache(appId: string, cache: TagCache): void {
+function saveCache(appId: string, cache: TagCache, ownerOpenId?: string): void {
   try {
-    const fp = cachePath(appId);
+    const fp = cachePath(appId, ownerOpenId);
     mkdirSync(dirname(fp), { recursive: true });
     writeFileSync(fp, JSON.stringify(cache, null, 2), 'utf-8');
   } catch (err) {
@@ -71,12 +73,12 @@ function saveCache(appId: string, cache: TagCache): void {
   }
 }
 
-function nudgeThrottled(appId: string): boolean {
-  const cache = loadCache(appId);
+function nudgeThrottled(appId: string, ownerOpenId: string): boolean {
+  const cache = loadCache(appId, ownerOpenId);
   const now = Date.now();
   if (cache.lastAuthNudgeAt && now - cache.lastAuthNudgeAt < NUDGE_INTERVAL_MS) return true;
   cache.lastAuthNudgeAt = now;
-  saveCache(appId, cache);
+  saveCache(appId, cache, ownerOpenId);
   return false;
 }
 
@@ -124,7 +126,7 @@ function scopeEnableLink(host: string, appId: string, scope: string): string {
 }
 
 async function maybeNudgeScope(larkAppId: string, ownerOpenId: string, scope: string): Promise<void> {
-  if (nudgeThrottled(larkAppId)) return;
+  if (nudgeThrottled(larkAppId, ownerOpenId)) return;
   try {
     const cfg = getBot(larkAppId).config;
     const host = larkHosts(normalizeBrand(cfg.brand)).openApi;
@@ -234,7 +236,7 @@ async function callFeedGroupApi(
 }
 
 async function maybeNudgeOwnerForAuth(larkAppId: string, ownerOpenId: string, reason: string): Promise<void> {
-  if (nudgeThrottled(larkAppId)) return;
+  if (nudgeThrottled(larkAppId, ownerOpenId)) return;
   try {
     const cfg = getBot(larkAppId).config;
     const { authUrl } = generateAuthUrl(
@@ -242,6 +244,7 @@ async function maybeNudgeOwnerForAuth(larkAppId: string, ownerOpenId: string, re
       cfg.larkAppSecret,
       normalizeBrand(cfg.brand),
       FEED_GROUP_OAUTH_SCOPES,
+      ownerOpenId,
     );
     const loc = localeForBot(larkAppId);
     await sendUserMessage(
@@ -286,21 +289,21 @@ async function tagViaFeedGroup(larkAppId: string, chatId: string, ownerOpenId: s
   const brand = normalizeBrand(cfg.brand);
   const host = larkHosts(brand).openApi;
 
-  const userToken = await resolveUserToken(cfg.larkAppId, cfg.larkAppSecret, brand);
+  const userToken = await resolveUserToken(cfg.larkAppId, cfg.larkAppSecret, brand, ownerOpenId);
   if (!userToken) {
     logger.info(`[session-tag] no user token for ${larkAppId}; skip feed-group tagging ${chatId.substring(0, 12)}`);
     void maybeNudgeOwnerForAuth(larkAppId, ownerOpenId, 'no_token');
     return;
   }
 
-  const cache = loadCache(larkAppId);
+  const cache = loadCache(larkAppId, ownerOpenId);
   if (!cache.groupId) {
     // Reuse an existing same-name group first (multi-bot / reinstall dedup).
     const existing = await findFeedGroupByName(host, userToken, name);
     if (existing) {
       cache.groupId = existing;
       cache.name = name;
-      saveCache(larkAppId, cache);
+      saveCache(larkAppId, cache, ownerOpenId);
       logger.info(`[session-tag] reusing existing feed group "${name}" → ${existing}`);
     }
   }
@@ -343,7 +346,7 @@ async function tagViaFeedGroup(larkAppId: string, chatId: string, ownerOpenId: s
     cache.groupId = created.data?.group_id;
     cache.name = actualName;
     cache.configuredName = name;
-    saveCache(larkAppId, cache);
+    saveCache(larkAppId, cache, ownerOpenId);
     logger.info(`[session-tag] feed group "${actualName}" → ${cache.groupId}`);
   } else if ((cache.configuredName ?? cache.name) !== name) {
     // 配置名变更才触发改名；对比 configuredName 而非实际名，避免退避名（name·bot）
@@ -355,7 +358,7 @@ async function tagViaFeedGroup(larkAppId: string, chatId: string, ownerOpenId: s
     if (renamed.ok) {
       cache.name = name;
       cache.configuredName = name;
-      saveCache(larkAppId, cache);
+      saveCache(larkAppId, cache, ownerOpenId);
     } else {
       logger.warn(`[session-tag] feed group rename failed (keeping old name): code=${renamed.code} ${renamed.msg}`);
     }

--- a/src/utils/user-token.ts
+++ b/src/utils/user-token.ts
@@ -29,8 +29,10 @@ const BUFFER_MS = 60_000; // 60s safety margin before expiry
  * Per-app token 文件：`~/.botmux/data/user-token-<appId>.json`。
  * 一台机器混挂 Feishu + Lark 多 bot 时，各自的 User Token 互不覆盖、互不串用。
  */
-function tokenPathForApp(appId: string): string {
-  return join(TOKEN_DIR, `user-token-${appId}.json`);
+function tokenPathForApp(appId: string, ownerOpenId?: string): string {
+  return join(TOKEN_DIR, ownerOpenId
+    ? `user-token-${appId}-${encodeURIComponent(ownerOpenId)}.json`
+    : `user-token-${appId}.json`);
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -48,6 +50,8 @@ export interface TokenStore {
    */
   appId?: string;
   brand?: Brand;
+  /** OAuth token subject. Required for user-owned resources such as feed groups. */
+  ownerOpenId?: string;
 }
 
 interface TokenResponse {
@@ -70,6 +74,8 @@ interface PendingLogin {
   appSecret: string;
   /** 租户品牌——决定回调换 token 时打哪个域名。缺省 feishu。 */
   brand: Brand;
+  /** Expected OAuth subject; callback rejects a different signed-in user. */
+  ownerOpenId?: string;
   createdAt: number;
 }
 
@@ -127,8 +133,8 @@ function loadTokenFromPath(path: string): TokenStore | null {
   }
 }
 
-function saveTokenForApp(token: TokenStore, appId: string): void {
-  const path = tokenPathForApp(appId);
+function saveTokenForApp(token: TokenStore, appId: string, ownerOpenId?: string): void {
+  const path = tokenPathForApp(appId, ownerOpenId);
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   // 0600：OAuth token 是密钥，且原子写每次重建文件，不传 mode 会把用户
@@ -148,7 +154,8 @@ function isValid(isoDate: string): boolean {
  *   - 未标 appId（升级前的旧单文件）→ 仅当请求 feishu 时认领（彼时只有 feishu 单 bot）
  *   - 标了 appId → 必须同 appId；若也标了 brand，则必须同 brand
  */
-function tokenMatches(t: TokenStore, appId: string, brand: Brand): boolean {
+function tokenMatches(t: TokenStore, appId: string, brand: Brand, ownerOpenId?: string): boolean {
+  if (ownerOpenId !== undefined && t.ownerOpenId !== ownerOpenId) return false;
   if (t.appId === undefined) return brand === 'feishu';
   if (t.appId !== appId) return false;
   if (t.brand !== undefined && t.brand !== brand) return false;
@@ -159,9 +166,11 @@ function tokenMatches(t: TokenStore, appId: string, brand: Brand): boolean {
  * 取指定 app 的 token。优先 per-app 文件，其次回退旧的单文件；两者都过
  * {@link tokenMatches} 校验（文件名 + 内容双重把关），不匹配一律视为无 token。
  */
-function loadTokenForApp(appId: string, brand: Brand): { token: TokenStore; source: string } | null {
-  const perApp = loadTokenFromPath(tokenPathForApp(appId));
-  if (perApp && tokenMatches(perApp, appId, brand)) return { token: perApp, source: 'botmux' };
+function loadTokenForApp(appId: string, brand: Brand, ownerOpenId?: string): { token: TokenStore; source: string } | null {
+  const perApp = loadTokenFromPath(tokenPathForApp(appId, ownerOpenId));
+  if (perApp && tokenMatches(perApp, appId, brand, ownerOpenId)) return { token: perApp, source: 'botmux' };
+  // Owner-scoped callers must never inherit app-wide or legacy credentials.
+  if (ownerOpenId !== undefined) return null;
   const legacy = loadTokenFromPath(LEGACY_TOKEN_PATH);
   if (legacy && tokenMatches(legacy, appId, brand)) return { token: legacy, source: 'botmux(legacy)' };
   return null;
@@ -169,7 +178,7 @@ function loadTokenForApp(appId: string, brand: Brand): { token: TokenStore; sour
 
 // ─── Token refresh ────────────────────────────────────────────────────────────
 
-async function refreshToken(token: TokenStore, appId: string, appSecret: string, brand: Brand = 'feishu'): Promise<TokenStore | null> {
+async function refreshToken(token: TokenStore, appId: string, appSecret: string, brand: Brand = 'feishu', ownerOpenId?: string): Promise<TokenStore | null> {
   try {
     const res = await fetch(`${larkHosts(brand).openApi}/open-apis/authen/v2/oauth/token`, {
       method: 'POST',
@@ -197,10 +206,11 @@ async function refreshToken(token: TokenStore, appId: string, appSecret: string,
       scope: data.scope || token.scope,
       appId,
       brand,
+      ...(ownerOpenId ? { ownerOpenId } : {}),
     };
 
     // Write to this app's own token file (per-app, brand-stamped)
-    try { saveTokenForApp(updated, appId); } catch { /* best-effort */ }
+    try { saveTokenForApp(updated, appId, ownerOpenId); } catch { /* best-effort */ }
     logger.info('[user-token] Refreshed User Access Token');
     return updated;
   } catch (err: any) {
@@ -215,13 +225,13 @@ async function refreshToken(token: TokenStore, appId: string, appSecret: string,
  * Resolve a valid User Access Token.
  * Returns access_token string, or null if unavailable.
  */
-export async function resolveUserToken(appId: string, appSecret: string, brand: Brand = 'feishu'): Promise<string | null> {
+export async function resolveUserToken(appId: string, appSecret: string, brand: Brand = 'feishu', ownerOpenId?: string): Promise<string | null> {
   // 1. Environment variable (explicit global override)
   const envToken = process.env.FEISHU_USER_ACCESS_TOKEN;
-  if (envToken) return envToken;
+  if (envToken && ownerOpenId === undefined) return envToken;
 
   // 2. Per-app token file (mismatched / 别的 bot 的 token → null，调用方提示 /login)
-  const loaded = loadTokenForApp(appId, brand);
+  const loaded = loadTokenForApp(appId, brand, ownerOpenId);
   if (!loaded) return null;
 
   const { token } = loaded;
@@ -232,7 +242,7 @@ export async function resolveUserToken(appId: string, appSecret: string, brand: 
 
   // access_token expired — try refresh
   if (isValid(token.refresh_expires_at) || (!token.refresh_expires_at && token.refresh_token)) {
-    const refreshed = await refreshToken(token, appId, appSecret, brand);
+    const refreshed = await refreshToken(token, appId, appSecret, brand, ownerOpenId);
     if (refreshed) return refreshed.access_token;
   }
 
@@ -296,7 +306,7 @@ export function resolveOAuthRedirectUri(): string {
  * Generate an OAuth authorization URL. Returns the URL and stores pending state.
  * Called by /login command handler.
  */
-export function generateAuthUrl(appId: string, appSecret: string, brand: Brand = 'feishu', extraScopes: string[] = []): { authUrl: string; state: string } {
+export function generateAuthUrl(appId: string, appSecret: string, brand: Brand = 'feishu', extraScopes: string[] = [], ownerOpenId?: string): { authUrl: string; state: string } {
   const state = randomBytes(32).toString('hex');
   const redirectUri = resolveOAuthRedirectUri();
 
@@ -320,6 +330,7 @@ export function generateAuthUrl(appId: string, appSecret: string, brand: Brand =
     appId,
     appSecret,
     brand,
+    ...(ownerOpenId ? { ownerOpenId } : {}),
     createdAt: Date.now(),
   });
   savePendingLogin(pendingLogins.get(state)!);
@@ -370,9 +381,10 @@ export async function tryHandleCallbackUrl(url: string): Promise<CallbackHandleR
  * authorized = a stored token for this app carries the feed-group write scope
  * and is still usable (valid or refreshable).
  */
-export function getFeedGroupAuthStatus(appId: string, brand: Brand = 'feishu'): { authorized: boolean; expiresAt?: string } {
+export function getFeedGroupAuthStatus(appId: string, brand: Brand = 'feishu', ownerOpenId?: string): { authorized: boolean; expiresAt?: string } {
   try {
-    const loaded = loadTokenForApp(appId, brand);
+    if (!ownerOpenId) return { authorized: false };
+    const loaded = loadTokenForApp(appId, brand, ownerOpenId);
     if (!loaded) return { authorized: false };
     const token = loaded.token;
     const scopes = (token.scope ?? '').split(/\s+/);
@@ -430,6 +442,21 @@ export async function handleCallbackUrl(url: string): Promise<string | null> {
       return `❌ 授权失败：${data.error_description || data.error || 'unknown error'}`;
     }
 
+    let actualOpenId: string | undefined;
+    if (pending.ownerOpenId) {
+      const identityRes = await fetch(`${larkHosts(pending.brand).openApi}/open-apis/authen/v1/user_info`, {
+        headers: { Authorization: `Bearer ${data.access_token}` },
+      });
+      const identityBody = await identityRes.json().catch(() => ({})) as { code?: number; data?: { open_id?: string }; open_id?: string };
+      actualOpenId = identityBody.data?.open_id ?? identityBody.open_id;
+      if (!identityRes.ok || (identityBody.code !== undefined && identityBody.code !== 0) || !actualOpenId) {
+        return '❌ 授权失败：无法校验授权用户身份，请重新发起授权';
+      }
+      if (actualOpenId !== pending.ownerOpenId) {
+        return '❌ 授权失败：当前登录用户与发起授权的用户不一致';
+      }
+    }
+
     const now = new Date();
     const token: TokenStore = {
       access_token: data.access_token,
@@ -442,10 +469,11 @@ export async function handleCallbackUrl(url: string): Promise<string | null> {
       scope: data.scope,
       appId: pending.appId,
       brand: pending.brand,
+      ...(actualOpenId ? { ownerOpenId: actualOpenId } : {}),
     };
 
-    saveTokenForApp(token, pending.appId);
-    logger.info(`[user-token] OAuth login successful, token saved for ${pending.appId}`);
+    saveTokenForApp(token, pending.appId, actualOpenId);
+    logger.info(`[user-token] OAuth login successful, token saved for ${pending.appId}${actualOpenId ? ` owner ${actualOpenId}` : ''}`);
 
     const expiresAt = new Date(token.expires_at).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
     return `✅ 授权成功！Token 已保存。\n有效期至 ${expiresAt}，过期后自动刷新。`;

--- a/test/user-token-cross-process-callback.test.ts
+++ b/test/user-token-cross-process-callback.test.ts
@@ -77,4 +77,28 @@ describe('tryHandleCallbackUrl across module instances', () => {
     expect(result).not.toBeNull();
     expect(result!.matched).toBe(false);
   });
+
+  it('rejects a callback authenticated as a different owner', async () => {
+    const a = await import('../src/utils/user-token.js');
+    const { state } = a.generateAuthUrl(APP_ID, APP_SECRET, 'feishu', ['im:feed_group_v1:write'], 'ou_expected');
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.endsWith('/oauth/token')) {
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: 'uat', refresh_token: 'urt', token_type: 'Bearer',
+            expires_in: 3600, refresh_token_expires_in: 7200,
+            scope: 'im:feed_group_v1:write',
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: { open_id: 'ou_other' } }) };
+    }) as any);
+
+    const result = await a.tryHandleCallbackUrl(
+      `http://127.0.0.1:9768/callback?code=test_code&state=${encodeURIComponent(state)}`,
+    );
+    expect(result).toMatchObject({ matched: true, ok: false });
+    expect(result!.message).toContain('不一致');
+  });
 });

--- a/test/user-token-per-app.test.ts
+++ b/test/user-token-per-app.test.ts
@@ -12,7 +12,10 @@ import { join } from 'node:path';
 
 const DIR = join(homedir(), '.botmux', 'data');
 const legacyPath = join(DIR, 'user-token.json');
-const perAppPath = (appId: string) => join(DIR, `user-token-${appId}.json`);
+const perAppPath = (appId: string, ownerOpenId?: string) => join(
+  DIR,
+  ownerOpenId ? `user-token-${appId}-${encodeURIComponent(ownerOpenId)}.json` : `user-token-${appId}.json`,
+);
 
 // In-memory fake filesystem keyed by absolute path.
 const files = new Map<string, string>();
@@ -79,6 +82,29 @@ describe('resolveUserToken — per-app isolation', () => {
     process.env.FEISHU_USER_ACCESS_TOKEN = 'ENV_TOK';
     const { resolveUserToken } = await fresh();
     expect(await resolveUserToken('whatever', 'sec', 'lark')).toBe('ENV_TOK');
+  });
+
+  it('does not expose an app-wide env token to an owner-scoped request', async () => {
+    process.env.FEISHU_USER_ACCESS_TOKEN = 'ENV_TOK';
+    const { resolveUserToken } = await fresh();
+    expect(await resolveUserToken('app_a', 'sec', 'feishu', 'ou_A')).toBeNull();
+  });
+
+  it('isolates two owners of the same app', async () => {
+    files.set(perAppPath('app_a', 'ou_A'), validToken({ access_token: 'TOK_A', appId: 'app_a', brand: 'feishu', ownerOpenId: 'ou_A' }));
+    const { resolveUserToken } = await fresh();
+    expect(await resolveUserToken('app_a', 'sec', 'feishu', 'ou_A')).toBe('TOK_A');
+    expect(await resolveUserToken('app_a', 'sec', 'feishu', 'ou_B')).toBeNull();
+  });
+
+  it('does not let owner B appear feed-group authorized from owner A token', async () => {
+    files.set(perAppPath('app_a', 'ou_A'), validToken({
+      access_token: 'TOK_A', appId: 'app_a', brand: 'feishu', ownerOpenId: 'ou_A',
+      scope: 'im:feed_group_v1:write',
+    }));
+    const { getFeedGroupAuthStatus } = await fresh();
+    expect(getFeedGroupAuthStatus('app_a', 'feishu', 'ou_A').authorized).toBe(true);
+    expect(getFeedGroupAuthStatus('app_a', 'feishu', 'ou_B').authorized).toBe(false);
   });
 
   // Hardening (Codex review): validate the file's inner appId/brand, not just the


### PR DESCRIPTION
## Summary
- key feed-group OAuth tokens and runtime cache by `(appId, ownerOpenId)`
- bind OAuth state to the expected owner and reject callbacks authenticated as another user
- scope authorization status and nudge throttling per owner
- add A/B user isolation and callback identity regression coverage

## Validation
- `pnpm exec vitest run --project unit test/user-token-per-app.test.ts test/user-token-cross-process-callback.test.ts`
- `pnpm build`

Closes #896