### PR TITLE
fix: isolate feed-group OAuth tokens by owner

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2509,6 +2509,7 @@ export async function handleCommand(
             botCfg2.larkAppSecret,
             normalizeBrand(botCfg2.brand),
             FEED_GROUP_OAUTH_SCOPES,
+            message.senderId,
           );
           await sessionReply(rootId, [
             t('cmd.login.tags_title', undefined, loc),

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -4596,6 +4596,7 @@ ipcRoute('POST', '/api/session-group-tag-auth', async (_req, res) => {
       cfg.larkAppSecret,
       normalizeBrand(cfg.brand),
       FEED_GROUP_OAUTH_SCOPES,
+      cfg.ownerOpenId,
     );
     jsonRes(res, 200, { ok: true, authUrl });
   } catch (e: any) {
@@ -4608,7 +4609,7 @@ ipcRoute('GET', '/api/session-group-tag-status', async (_req, res) => {
   if (!cachedLarkAppId) return jsonRes(res, 503, { error: 'larkAppId_not_set' });
   try {
     const cfg = getBot(cachedLarkAppId).config;
-    const status = getFeedGroupAuthStatus(cfg.larkAppId, normalizeBrand(cfg.brand));
+    const status = getFeedGroupAuthStatus(cfg.larkAppId, normalizeBrand(cfg.brand), cfg.ownerOpenId);
     jsonRes(res, 200, { ok: true, ...status, tagMode: cfg.sessionGroup?.tag?.mode ?? 'feed-group' });
   } catch (e: any) {
     jsonRes(res, 500, { ok: false, error: e?.message ?? String(e) });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -6364,7 +6364,13 @@ const server = createServer(async (req, res) => {
       try { bot = loadBotConfigs().find(item => !item.apiOnly && (!appId || item.larkAppId === appId)); }
       catch { /* handled below */ }
       if (!bot) return jsonRes(res, 404, { ok: false, error: 'bot_not_found' });
-      const { authUrl } = generateAuthUrl(bot.larkAppId, bot.larkAppSecret, normalizeBrand(bot.brand), [...FEED_GROUP_SCOPES]);
+      const { authUrl } = generateAuthUrl(
+        bot.larkAppId,
+        bot.larkAppSecret,
+        normalizeBrand(bot.brand),
+        [...FEED_GROUP_SCOPES],
+        bot.ownerOpenId,
+      );
       return jsonRes(res, 200, { ok: true, larkAppId: bot.larkAppId, authUrl });
     }
 

--- a/src/dashboard/feed-groups.ts
+++ b/src/dashboard/feed-groups.ts
@@ -27,13 +27,13 @@ type ApiEnvelope = {
 };
 
 async function userApi(
-  bot: Pick<BotConfig, 'larkAppId' | 'larkAppSecret' | 'brand'>,
+  bot: Pick<BotConfig, 'larkAppId' | 'larkAppSecret' | 'brand' | 'ownerOpenId'>,
   path: string,
   init: RequestInit,
   fetchImpl: typeof fetch = fetch,
 ): Promise<Record<string, unknown>> {
   const brand = normalizeBrand(bot.brand);
-  const token = await resolveUserToken(bot.larkAppId, bot.larkAppSecret, brand);
+  const token = await resolveUserToken(bot.larkAppId, bot.larkAppSecret, brand, bot.ownerOpenId);
   if (!token) throw new FeedGroupApiError('尚未获得飞书标签权限，请点击「立即授权」按钮进行授权。', 'user_login_required', 401);
   const response = await fetchImpl(`${larkHosts(brand).openApi}${path}`, {
     ...init,
@@ -53,7 +53,7 @@ async function userApi(
 
 /** List all live native Feishu/Lark conversation labels for the authorized user. */
 export async function listFeedGroups(
-  bot: Pick<BotConfig, 'larkAppId' | 'larkAppSecret' | 'brand'>,
+  bot: Pick<BotConfig, 'larkAppId' | 'larkAppSecret' | 'brand' | 'ownerOpenId'>,
   fetchImpl: typeof fetch = fetch,
 ): Promise<FeedGroup[]> {
   const groups: FeedGroup[] = [];

--- a/src/services/feed-group-tagger.ts
+++ b/src/services/feed-group-tagger.ts
@@ -49,21 +49,22 @@ interface TagCache {
   lastAuthNudgeAt?: number;
 }
 
-function cachePath(appId: string): string {
-  return join(config.session.dataDir, `feed-group-cache-${appId}.json`);
+function cachePath(appId: string, ownerOpenId?: string): string {
+  const suffix = ownerOpenId ? `-${ownerOpenId.replace(/[^a-zA-Z0-9_-]/g, '_')}` : '';
+  return join(config.session.dataDir, `feed-group-cache-${appId}${suffix}.json`);
 }
 
-function loadCache(appId: string): TagCache {
+function loadCache(appId: string, ownerOpenId?: string): TagCache {
   try {
-    const fp = cachePath(appId);
+    const fp = cachePath(appId, ownerOpenId);
     if (existsSync(fp)) return JSON.parse(readFileSync(fp, 'utf-8')) as TagCache;
   } catch { /* corrupted cache → start fresh */ }
   return {};
 }
 
-function saveCache(appId: string, cache: TagCache): void {
+function saveCache(appId: string, cache: TagCache, ownerOpenId?: string): void {
   try {
-    const fp = cachePath(appId);
+    const fp = cachePath(appId, ownerOpenId);
     mkdirSync(dirname(fp), { recursive: true });
     writeFileSync(fp, JSON.stringify(cache, null, 2), 'utf-8');
   } catch (err) {
@@ -71,12 +72,12 @@ function saveCache(appId: string, cache: TagCache): void {
   }
 }
 
-function nudgeThrottled(appId: string): boolean {
-  const cache = loadCache(appId);
+function nudgeThrottled(appId: string, ownerOpenId?: string): boolean {
+  const cache = loadCache(appId, ownerOpenId);
   const now = Date.now();
   if (cache.lastAuthNudgeAt && now - cache.lastAuthNudgeAt < NUDGE_INTERVAL_MS) return true;
   cache.lastAuthNudgeAt = now;
-  saveCache(appId, cache);
+  saveCache(appId, cache, ownerOpenId);
   return false;
 }
 
@@ -124,7 +125,7 @@ function scopeEnableLink(host: string, appId: string, scope: string): string {
 }
 
 async function maybeNudgeScope(larkAppId: string, ownerOpenId: string, scope: string): Promise<void> {
-  if (nudgeThrottled(larkAppId)) return;
+  if (nudgeThrottled(larkAppId, ownerOpenId)) return;
   try {
     const cfg = getBot(larkAppId).config;
     const host = larkHosts(normalizeBrand(cfg.brand)).openApi;
@@ -234,7 +235,7 @@ async function callFeedGroupApi(
 }
 
 async function maybeNudgeOwnerForAuth(larkAppId: string, ownerOpenId: string, reason: string): Promise<void> {
-  if (nudgeThrottled(larkAppId)) return;
+  if (nudgeThrottled(larkAppId, ownerOpenId)) return;
   try {
     const cfg = getBot(larkAppId).config;
     const { authUrl } = generateAuthUrl(
@@ -242,6 +243,7 @@ async function maybeNudgeOwnerForAuth(larkAppId: string, ownerOpenId: string, re
       cfg.larkAppSecret,
       normalizeBrand(cfg.brand),
       FEED_GROUP_OAUTH_SCOPES,
+      ownerOpenId,
     );
     const loc = localeForBot(larkAppId);
     await sendUserMessage(
@@ -286,21 +288,21 @@ async function tagViaFeedGroup(larkAppId: string, chatId: string, ownerOpenId: s
   const brand = normalizeBrand(cfg.brand);
   const host = larkHosts(brand).openApi;
 
-  const userToken = await resolveUserToken(cfg.larkAppId, cfg.larkAppSecret, brand);
+  const userToken = await resolveUserToken(cfg.larkAppId, cfg.larkAppSecret, brand, ownerOpenId);
   if (!userToken) {
     logger.info(`[session-tag] no user token for ${larkAppId}; skip feed-group tagging ${chatId.substring(0, 12)}`);
     void maybeNudgeOwnerForAuth(larkAppId, ownerOpenId, 'no_token');
     return;
   }
 
-  const cache = loadCache(larkAppId);
+  const cache = loadCache(larkAppId, ownerOpenId);
   if (!cache.groupId) {
     // Reuse an existing same-name group first (multi-bot / reinstall dedup).
     const existing = await findFeedGroupByName(host, userToken, name);
     if (existing) {
       cache.groupId = existing;
       cache.name = name;
-      saveCache(larkAppId, cache);
+      saveCache(larkAppId, cache, ownerOpenId);
       logger.info(`[session-tag] reusing existing feed group "${name}" → ${existing}`);
     }
   }
@@ -343,7 +345,7 @@ async function tagViaFeedGroup(larkAppId: string, chatId: string, ownerOpenId: s
     cache.groupId = created.data?.group_id;
     cache.name = actualName;
     cache.configuredName = name;
-    saveCache(larkAppId, cache);
+    saveCache(larkAppId, cache, ownerOpenId);
     logger.info(`[session-tag] feed group "${actualName}" → ${cache.groupId}`);
   } else if ((cache.configuredName ?? cache.name) !== name) {
     // 配置名变更才触发改名；对比 configuredName 而非实际名，避免退避名（name·bot）
@@ -355,7 +357,7 @@ async function tagViaFeedGroup(larkAppId: string, chatId: string, ownerOpenId: s
     if (renamed.ok) {
       cache.name = name;
       cache.configuredName = name;
-      saveCache(larkAppId, cache);
+      saveCache(larkAppId, cache, ownerOpenId);
     } else {
       logger.warn(`[session-tag] feed group rename failed (keeping old name): code=${renamed.code} ${renamed.msg}`);
     }

--- a/src/utils/user-token.ts
+++ b/src/utils/user-token.ts
@@ -12,7 +12,7 @@ import { readFileSync, mkdirSync, existsSync, unlinkSync, readdirSync } from 'no
 import { atomicWriteFileSync } from './atomic-write.js';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { logger } from './logger.js';
 import { type Brand, larkHosts } from '../im/lark/lark-hosts.js';
 import { readGlobalConfig } from '../global-config.js';
@@ -33,6 +33,11 @@ function tokenPathForApp(appId: string): string {
   return join(TOKEN_DIR, `user-token-${appId}.json`);
 }
 
+function tokenPathForOwner(appId: string, ownerOpenId: string): string {
+  const ownerKey = createHash('sha256').update(ownerOpenId).digest('hex').slice(0, 20);
+  return join(TOKEN_DIR, `user-token-${appId}-${ownerKey}.json`);
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface TokenStore {
@@ -48,6 +53,8 @@ export interface TokenStore {
    */
   appId?: string;
   brand?: Brand;
+  /** OAuth token subject. Required for owner-scoped personal-data operations. */
+  ownerOpenId?: string;
 }
 
 interface TokenResponse {
@@ -59,6 +66,7 @@ interface TokenResponse {
   scope: string;
   error?: string;
   error_description?: string;
+  open_id?: string;
 }
 
 // ─── Pending login state ──────────────────────────────────────────────────────
@@ -70,6 +78,8 @@ interface PendingLogin {
   appSecret: string;
   /** 租户品牌——决定回调换 token 时打哪个域名。缺省 feishu。 */
   brand: Brand;
+  /** Expected OAuth subject for owner-scoped flows. */
+  ownerOpenId?: string;
   createdAt: number;
 }
 
@@ -127,8 +137,8 @@ function loadTokenFromPath(path: string): TokenStore | null {
   }
 }
 
-function saveTokenForApp(token: TokenStore, appId: string): void {
-  const path = tokenPathForApp(appId);
+function saveTokenForApp(token: TokenStore, appId: string, ownerOpenId?: string): void {
+  const path = ownerOpenId ? tokenPathForOwner(appId, ownerOpenId) : tokenPathForApp(appId);
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   // 0600：OAuth token 是密钥，且原子写每次重建文件，不传 mode 会把用户
@@ -159,7 +169,14 @@ function tokenMatches(t: TokenStore, appId: string, brand: Brand): boolean {
  * 取指定 app 的 token。优先 per-app 文件，其次回退旧的单文件；两者都过
  * {@link tokenMatches} 校验（文件名 + 内容双重把关），不匹配一律视为无 token。
  */
-function loadTokenForApp(appId: string, brand: Brand): { token: TokenStore; source: string } | null {
+function loadTokenForApp(appId: string, brand: Brand, ownerOpenId?: string): { token: TokenStore; source: string } | null {
+  if (ownerOpenId) {
+    const token = loadTokenFromPath(tokenPathForOwner(appId, ownerOpenId));
+    if (token && tokenMatches(token, appId, brand) && token.ownerOpenId === ownerOpenId) {
+      return { token, source: 'botmux(owner)' };
+    }
+    return null;
+  }
   const perApp = loadTokenFromPath(tokenPathForApp(appId));
   if (perApp && tokenMatches(perApp, appId, brand)) return { token: perApp, source: 'botmux' };
   const legacy = loadTokenFromPath(LEGACY_TOKEN_PATH);
@@ -169,7 +186,7 @@ function loadTokenForApp(appId: string, brand: Brand): { token: TokenStore; sour
 
 // ─── Token refresh ────────────────────────────────────────────────────────────
 
-async function refreshToken(token: TokenStore, appId: string, appSecret: string, brand: Brand = 'feishu'): Promise<TokenStore | null> {
+async function refreshToken(token: TokenStore, appId: string, appSecret: string, brand: Brand = 'feishu', ownerOpenId?: string): Promise<TokenStore | null> {
   try {
     const res = await fetch(`${larkHosts(brand).openApi}/open-apis/authen/v2/oauth/token`, {
       method: 'POST',
@@ -197,10 +214,11 @@ async function refreshToken(token: TokenStore, appId: string, appSecret: string,
       scope: data.scope || token.scope,
       appId,
       brand,
+      ...(ownerOpenId ? { ownerOpenId } : {}),
     };
 
     // Write to this app's own token file (per-app, brand-stamped)
-    try { saveTokenForApp(updated, appId); } catch { /* best-effort */ }
+    try { saveTokenForApp(updated, appId, ownerOpenId); } catch { /* best-effort */ }
     logger.info('[user-token] Refreshed User Access Token');
     return updated;
   } catch (err: any) {
@@ -215,13 +233,13 @@ async function refreshToken(token: TokenStore, appId: string, appSecret: string,
  * Resolve a valid User Access Token.
  * Returns access_token string, or null if unavailable.
  */
-export async function resolveUserToken(appId: string, appSecret: string, brand: Brand = 'feishu'): Promise<string | null> {
+export async function resolveUserToken(appId: string, appSecret: string, brand: Brand = 'feishu', ownerOpenId?: string): Promise<string | null> {
   // 1. Environment variable (explicit global override)
   const envToken = process.env.FEISHU_USER_ACCESS_TOKEN;
-  if (envToken) return envToken;
+  if (envToken && !ownerOpenId) return envToken;
 
   // 2. Per-app token file (mismatched / 别的 bot 的 token → null，调用方提示 /login)
-  const loaded = loadTokenForApp(appId, brand);
+  const loaded = loadTokenForApp(appId, brand, ownerOpenId);
   if (!loaded) return null;
 
   const { token } = loaded;
@@ -232,7 +250,7 @@ export async function resolveUserToken(appId: string, appSecret: string, brand: 
 
   // access_token expired — try refresh
   if (isValid(token.refresh_expires_at) || (!token.refresh_expires_at && token.refresh_token)) {
-    const refreshed = await refreshToken(token, appId, appSecret, brand);
+    const refreshed = await refreshToken(token, appId, appSecret, brand, ownerOpenId);
     if (refreshed) return refreshed.access_token;
   }
 
@@ -296,7 +314,7 @@ export function resolveOAuthRedirectUri(): string {
  * Generate an OAuth authorization URL. Returns the URL and stores pending state.
  * Called by /login command handler.
  */
-export function generateAuthUrl(appId: string, appSecret: string, brand: Brand = 'feishu', extraScopes: string[] = []): { authUrl: string; state: string } {
+export function generateAuthUrl(appId: string, appSecret: string, brand: Brand = 'feishu', extraScopes: string[] = [], ownerOpenId?: string): { authUrl: string; state: string } {
   const state = randomBytes(32).toString('hex');
   const redirectUri = resolveOAuthRedirectUri();
 
@@ -320,6 +338,7 @@ export function generateAuthUrl(appId: string, appSecret: string, brand: Brand =
     appId,
     appSecret,
     brand,
+    ...(ownerOpenId ? { ownerOpenId } : {}),
     createdAt: Date.now(),
   });
   savePendingLogin(pendingLogins.get(state)!);
@@ -370,9 +389,10 @@ export async function tryHandleCallbackUrl(url: string): Promise<CallbackHandleR
  * authorized = a stored token for this app carries the feed-group write scope
  * and is still usable (valid or refreshable).
  */
-export function getFeedGroupAuthStatus(appId: string, brand: Brand = 'feishu'): { authorized: boolean; expiresAt?: string } {
+export function getFeedGroupAuthStatus(appId: string, brand: Brand = 'feishu', ownerOpenId?: string): { authorized: boolean; expiresAt?: string } {
   try {
-    const loaded = loadTokenForApp(appId, brand);
+    if (!ownerOpenId) return { authorized: false };
+    const loaded = loadTokenForApp(appId, brand, ownerOpenId);
     if (!loaded) return { authorized: false };
     const token = loaded.token;
     const scopes = (token.scope ?? '').split(/\s+/);
@@ -429,6 +449,10 @@ export async function handleCallbackUrl(url: string): Promise<string | null> {
     if (data.error || !data.access_token) {
       return `❌ 授权失败：${data.error_description || data.error || 'unknown error'}`;
     }
+    if (pending.ownerOpenId && data.open_id !== pending.ownerOpenId) {
+      logger.warn(`[user-token] OAuth subject mismatch for ${pending.appId}`);
+      return '❌ 授权失败：授权账号与发起授权的用户不一致，请使用正确账号重试';
+    }
 
     const now = new Date();
     const token: TokenStore = {
@@ -442,9 +466,10 @@ export async function handleCallbackUrl(url: string): Promise<string | null> {
       scope: data.scope,
       appId: pending.appId,
       brand: pending.brand,
+      ...(pending.ownerOpenId ? { ownerOpenId: pending.ownerOpenId } : {}),
     };
 
-    saveTokenForApp(token, pending.appId);
+    saveTokenForApp(token, pending.appId, pending.ownerOpenId);
     logger.info(`[user-token] OAuth login successful, token saved for ${pending.appId}`);
 
     const expiresAt = new Date(token.expires_at).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });

--- a/test/user-token-cross-process-callback.test.ts
+++ b/test/user-token-cross-process-callback.test.ts
@@ -77,4 +77,23 @@ describe('tryHandleCallbackUrl across module instances', () => {
     expect(result).not.toBeNull();
     expect(result!.matched).toBe(false);
   });
+
+  it('rejects a callback authorized by a different user than the expected owner', async () => {
+    const a = await import('../src/utils/user-token.js');
+    const { state } = a.generateAuthUrl(APP_ID, APP_SECRET, 'feishu', ['im:feed_group_v1:write'], 'ou_expected');
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        access_token: 'token_b', refresh_token: 'refresh_b', token_type: 'Bearer',
+        expires_in: 3600, refresh_token_expires_in: 7200,
+        scope: 'im:feed_group_v1:write', open_id: 'ou_other',
+      }),
+    })) as any);
+
+    const message = await a.handleCallbackUrl(
+      `http://127.0.0.1:9768/callback?code=test_code&state=${encodeURIComponent(state)}`,
+    );
+    expect(message).toContain('授权账号与发起授权的用户不一致');
+    expect(await a.resolveUserToken(APP_ID, APP_SECRET, 'feishu', 'ou_expected')).toBeNull();
+  });
 });

--- a/test/user-token-per-app.test.ts
+++ b/test/user-token-per-app.test.ts
@@ -9,10 +9,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { createHash } from 'node:crypto';
 
 const DIR = join(homedir(), '.botmux', 'data');
 const legacyPath = join(DIR, 'user-token.json');
 const perAppPath = (appId: string) => join(DIR, `user-token-${appId}.json`);
+const perOwnerPath = (appId: string, owner: string) => join(
+  DIR,
+  `user-token-${appId}-${createHash('sha256').update(owner).digest('hex').slice(0, 20)}.json`,
+);
 
 // In-memory fake filesystem keyed by absolute path.
 const files = new Map<string, string>();
@@ -79,6 +84,25 @@ describe('resolveUserToken — per-app isolation', () => {
     process.env.FEISHU_USER_ACCESS_TOKEN = 'ENV_TOK';
     const { resolveUserToken } = await fresh();
     expect(await resolveUserToken('whatever', 'sec', 'lark')).toBe('ENV_TOK');
+  });
+
+  it('isolates owner-scoped tokens and never falls back to the global env token', async () => {
+    files.set(perOwnerPath('app_a', 'ou_a'), validToken({
+      access_token: 'TOK_A', appId: 'app_a', brand: 'feishu', ownerOpenId: 'ou_a',
+    }));
+    process.env.FEISHU_USER_ACCESS_TOKEN = 'GLOBAL_TOK';
+    const { resolveUserToken } = await fresh();
+    expect(await resolveUserToken('app_a', 'sec', 'feishu', 'ou_a')).toBe('TOK_A');
+    expect(await resolveUserToken('app_a', 'sec', 'feishu', 'ou_b')).toBeNull();
+  });
+
+  it('reports feed-group auth independently for each owner', async () => {
+    files.set(perOwnerPath('app_a', 'ou_a'), validToken({
+      appId: 'app_a', brand: 'feishu', ownerOpenId: 'ou_a', scope: 'im:feed_group_v1:write',
+    }));
+    const { getFeedGroupAuthStatus } = await fresh();
+    expect(getFeedGroupAuthStatus('app_a', 'feishu', 'ou_a').authorized).toBe(true);
+    expect(getFeedGroupAuthStatus('app_a', 'feishu', 'ou_b').authorized).toBe(false);
   });
 
   // Hardening (Codex review): validate the file's inner appId/brand, not just the


### PR DESCRIPTION
## Summary
- scope feed-group OAuth tokens and personal group caches by appId plus ownerOpenId
- bind OAuth state to the expected owner and reject mismatched callback subjects
- isolate authorization status and nudge throttling per owner
- add A/B token isolation and callback identity regression coverage

Fixes #896

## Verification
- pnpm vitest run test/user-token-per-app.test.ts test/user-token-cross-process-callback.test.ts
- pnpm build
- pnpm exec tsc --noEmit