### PR TITLE
feat(cli): 提供当前轮次可信发信人身份

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7732,6 +7732,8 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
               显式轮换 token，并打印新的登录 URL
   device enroll|status|logout
               在宿主终端注册、查看或清除 desktop device 凭证（AI CLI 会话内拒绝）
+  actor current --json
+              返回当前 BotMux turn 的已验证企业用户名，不暴露 open_id/邮箱；脱离当前进程树时拒绝
   mojo-containment list|revoke
               查看 / 显式撤销无法自证静止的 mojo containment handle（设备隔离
               blocker 的可审计操作员出口；revoke 需 --yes，存活证据需 --force）
@@ -14559,7 +14561,7 @@ async function runPluginCommandByName(rawCommand: string, commandArgs: string[])
 // daemon-side getBotClient/larkTransportEnabled gates remain authoritative.
 const LARK_FACING_COMMANDS = new Set([
   'send', 'dispatch', 'create-group', 'history', 'quoted', 'bots', 'grant', 'react', 'thread',
-  'vc-agent', 'report',
+  'vc-agent', 'report', 'actor',
 ]);
 if (LARK_FACING_COMMANDS.has(command) && managedOriginHasNoTransport()) {
   console.error(
@@ -14586,6 +14588,31 @@ switch (command) {
       break;
     }
     process.stdout.write(`${JSON.stringify(botmuxCapabilities())}\n`);
+    break;
+  }
+  case 'actor': {
+    const { parseCurrentActorArgs, resolveBotmuxAncestorContext, resolveCurrentActor } = await import('./cli/current-actor.js');
+    const parsed = parseCurrentActorArgs(process.argv.slice(3));
+    if (!parsed.ok) {
+      console.error(parsed.error);
+      process.exitCode = 2;
+      break;
+    }
+    try {
+      const { ipcPort, sessionId } = resolveBotmuxAncestorContext();
+      const actor = await resolveCurrentActor({
+        ipcPort,
+        sessionId,
+      });
+      process.stdout.write(`${JSON.stringify(actor)}\n`);
+    } catch {
+      process.stdout.write(`${JSON.stringify({
+        schema: 'botmux.current-actor.v2',
+        status: 'blocked',
+        error: 'current_actor_unverified',
+      })}\n`);
+      process.exitCode = 2;
+    }
     break;
   }
   case 'setup': {

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -7,6 +7,7 @@ export interface BotmuxCapabilitiesDocument {
     stable_app_dispatch_v1: true;
     stable_dispatch_acceptance_v1: true;
     managed_activation_v2: true;
+    current_actor_v2: true;
   };
 }
 
@@ -34,6 +35,7 @@ export function botmuxCapabilities(): BotmuxCapabilitiesDocument {
       stable_app_dispatch_v1: true,
       stable_dispatch_acceptance_v1: true,
       managed_activation_v2: true,
+      current_actor_v2: true,
     },
   };
 }

--- a/src/cli/current-actor.ts
+++ b/src/cli/current-actor.ts
@@ -1,0 +1,182 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+export const CURRENT_ACTOR_SCHEMA = 'botmux.current-actor.v2' as const;
+export const CURRENT_ACTOR_ROUTE = '/api/current-actor';
+
+export interface CurrentActorDocument {
+  schema: typeof CURRENT_ACTOR_SCHEMA;
+  status: 'verified';
+  actor: {
+    enterpriseDomainVerified: true;
+    username: string;
+  };
+}
+export interface ResolveCurrentActorOptions {
+  ipcPort: number;
+  sessionId: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface BotmuxAncestorContext {
+  sessionId: string;
+  larkAppId: string;
+  ipcPort: number;
+}
+
+export class CurrentActorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CurrentActorError';
+  }
+}
+
+export function parseCurrentActorArgs(args: string[]): { ok: true } | { ok: false; error: string } {
+  return args.length === 2 && args[0] === 'current' && args[1] === '--json'
+    ? { ok: true }
+    : { ok: false, error: '用法: botmux actor current --json' };
+}
+
+export function normalizeEnterpriseEmail(value: unknown): { email: string; username: string } {
+  if (typeof value !== 'string') {
+    throw new CurrentActorError('current Lark actor has no verified enterprise email');
+  }
+  const email = value.trim().toLowerCase();
+  const separator = email.indexOf('@');
+  if (separator <= 0 || separator === email.length - 1 || email.indexOf('@', separator + 1) !== -1) {
+    throw new CurrentActorError('current Lark actor enterprise email is invalid');
+  }
+  if (email.slice(separator + 1) !== 'bytedance.com') {
+    throw new CurrentActorError('current Lark actor is outside the supported enterprise domain');
+  }
+  return { email, username: email.slice(0, separator) };
+}
+
+function parentPid(pid: number, procRoot: string): number | undefined {
+  if (process.platform === 'linux' || procRoot !== '/proc') {
+    try {
+      const raw = readFileSync(`${procRoot}/${pid}/stat`, 'utf8');
+      const fields = raw.slice(raw.lastIndexOf(')') + 2).trim().split(/\s+/);
+      const value = Number(fields[1]);
+      return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+    } catch { return undefined; }
+  }
+  const ps = ['/usr/bin/ps', '/bin/ps'].find(existsSync);
+  if (!ps) return undefined;
+  try {
+    const value = Number(execFileSync(ps, ['-o', 'ppid=', '-p', String(pid)], {
+      encoding: 'utf8', timeout: 2_000, stdio: ['ignore', 'pipe', 'ignore'],
+      env: { PATH: '/usr/bin:/bin', LANG: 'C' },
+    }).trim());
+    return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+  } catch { return undefined; }
+}
+
+function processEnvironment(pid: number, procRoot: string): Record<string, string> | undefined {
+  if (process.platform !== 'linux' && procRoot === '/proc') return undefined;
+  try {
+    const env: Record<string, string> = {};
+    for (const item of readFileSync(`${procRoot}/${pid}/environ`).toString('utf8').split('\0')) {
+      const separator = item.indexOf('=');
+      if (separator > 0) env[item.slice(0, separator)] = item.slice(separator + 1);
+    }
+    return env;
+  } catch { return undefined; }
+}
+
+/** Read routing only from an already-running BotMux CLI ancestor. A child can
+ * mutate its own env but cannot rewrite its parent's kernel-held environment. */
+export function resolveBotmuxAncestorContext(
+  startPid = process.ppid,
+  procRoot = '/proc',
+): BotmuxAncestorContext {
+  if (process.platform !== 'linux' && procRoot === '/proc') {
+    throw new CurrentActorError('current actor ancestor attestation is unsupported');
+  }
+  const contexts: BotmuxAncestorContext[] = [];
+  let pid = startPid;
+  for (let depth = 0; depth < 32 && pid > 1; depth++) {
+    const env = processEnvironment(pid, procRoot);
+    if (!env) throw new CurrentActorError('current actor ancestor attestation failed');
+    if (env.BOTMUX === '1') {
+      const ipcPort = Number(env.BOTMUX_DAEMON_IPC_PORT);
+      if (!env.BOTMUX_SESSION_ID || !env.BOTMUX_LARK_APP_ID?.startsWith('cli_')
+        || !Number.isSafeInteger(ipcPort) || ipcPort < 1 || ipcPort > 65_535) {
+        throw new CurrentActorError('current actor ancestor attestation failed');
+      }
+      contexts.push({
+        sessionId: env.BOTMUX_SESSION_ID,
+        larkAppId: env.BOTMUX_LARK_APP_ID,
+        ipcPort,
+      });
+    }
+    const parent = parentPid(pid, procRoot);
+    if (!parent) break;
+    pid = parent;
+  }
+  if (contexts.length === 0 || contexts.some(context => (
+    context.sessionId !== contexts[0].sessionId
+    || context.larkAppId !== contexts[0].larkAppId
+    || context.ipcPort !== contexts[0].ipcPort
+  ))) {
+    throw new CurrentActorError('current actor ancestor attestation failed');
+  }
+  return contexts[0];
+}
+
+function isCurrentActorDocument(value: unknown): value is CurrentActorDocument {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const document = value as Record<string, unknown>;
+  if (document.schema !== CURRENT_ACTOR_SCHEMA || document.status !== 'verified') return false;
+  const actor = document.actor;
+  if (!actor || typeof actor !== 'object' || Array.isArray(actor)) return false;
+  const fields = actor as Record<string, unknown>;
+  return fields.enterpriseDomainVerified === true
+    && typeof fields.username === 'string'
+    && fields.username.length > 0
+    && fields.username === fields.username.trim()
+    && fields.username === fields.username.toLowerCase();
+}
+
+/**
+ * Ask the owning daemon for the current human actor. The daemon identifies the
+ * HTTP client through the live loopback socket, proves that process belongs to
+ * the exact live CLI/worker generation, and reads sender identity from its
+ * in-memory turn state. Environment values are routing hints only.
+ */
+export async function resolveCurrentActor(
+  options: ResolveCurrentActorOptions,
+): Promise<CurrentActorDocument> {
+  if (!Number.isSafeInteger(options.ipcPort) || options.ipcPort <= 0 || options.ipcPort > 65_535) {
+    throw new CurrentActorError('owning BotMux daemon port is unavailable');
+  }
+  if (!options.sessionId || options.sessionId.length > 256) {
+    throw new CurrentActorError('current BotMux session is unavailable');
+  }
+  let response: Response;
+  try {
+    response = await (options.fetchImpl ?? fetch)(
+      `http://127.0.0.1:${options.ipcPort}${CURRENT_ACTOR_ROUTE}`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sessionId: options.sessionId }),
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+  } catch (error) {
+    throw new CurrentActorError(
+      `owning BotMux daemon is unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new CurrentActorError('owning BotMux daemon returned an invalid actor response');
+  }
+  if (!response.ok || !isCurrentActorDocument(payload)) {
+    throw new CurrentActorError('current BotMux actor could not be verified by the owning daemon');
+  }
+  return payload;
+}

--- a/src/cli/current-actor.ts
+++ b/src/cli/current-actor.ts
@@ -8,8 +8,7 @@ export interface CurrentActorDocument {
   schema: typeof CURRENT_ACTOR_SCHEMA;
   status: 'verified';
   actor: {
-    enterpriseDomainVerified: true;
-    username: string;
+    email: string;
   };
 }
 export interface ResolveCurrentActorOptions {
@@ -37,19 +36,16 @@ export function parseCurrentActorArgs(args: string[]): { ok: true } | { ok: fals
     : { ok: false, error: '用法: botmux actor current --json' };
 }
 
-export function normalizeEnterpriseEmail(value: unknown): { email: string; username: string } {
+export function normalizeActorEmail(value: unknown): string {
   if (typeof value !== 'string') {
-    throw new CurrentActorError('current Lark actor has no verified enterprise email');
+    throw new CurrentActorError('current Lark actor has no verified email');
   }
   const email = value.trim().toLowerCase();
   const separator = email.indexOf('@');
   if (separator <= 0 || separator === email.length - 1 || email.indexOf('@', separator + 1) !== -1) {
-    throw new CurrentActorError('current Lark actor enterprise email is invalid');
+    throw new CurrentActorError('current Lark actor email is invalid');
   }
-  if (email.slice(separator + 1) !== 'bytedance.com') {
-    throw new CurrentActorError('current Lark actor is outside the supported enterprise domain');
-  }
-  return { email, username: email.slice(0, separator) };
+  return email;
 }
 
 function parentPid(pid: number, procRoot: string): number | undefined {
@@ -131,11 +127,11 @@ function isCurrentActorDocument(value: unknown): value is CurrentActorDocument {
   const actor = document.actor;
   if (!actor || typeof actor !== 'object' || Array.isArray(actor)) return false;
   const fields = actor as Record<string, unknown>;
-  return fields.enterpriseDomainVerified === true
-    && typeof fields.username === 'string'
-    && fields.username.length > 0
-    && fields.username === fields.username.trim()
-    && fields.username === fields.username.toLowerCase();
+  if (Object.keys(fields).length !== 1 || typeof fields.email !== 'string'
+    || fields.email !== fields.email.trim()
+    || fields.email !== fields.email.toLowerCase()) return false;
+  try { return normalizeActorEmail(fields.email) === fields.email; }
+  catch { return false; }
 }
 
 /**

--- a/src/core/current-actor-attestation.ts
+++ b/src/core/current-actor-attestation.ts
@@ -1,0 +1,244 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, readlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { CURRENT_ACTOR_SCHEMA, normalizeEnterpriseEmail, type CurrentActorDocument } from '../cli/current-actor.js';
+import { resolveVerifiedUserIdentity } from '../im/lark/identity-cache.js';
+import { collectSessionLineagePids } from './preview-port-owner.js';
+import { larkTransportEnabled, type DaemonSession } from './types.js';
+
+const TCP_ESTABLISHED_STATE = '01';
+
+export interface ProcessIdentity {
+  pid: number;
+  procStart: string;
+}
+
+export type LoopbackPeerResolution =
+  | { ok: true; peer: ProcessIdentity }
+  | { ok: false; reason: 'platform_unsupported' | 'not_loopback' | 'socket_unavailable' | 'peer_unresolved' };
+
+function readProcStart(pid: number, procRoot: string): string | undefined {
+  if (!Number.isSafeInteger(pid) || pid <= 1) return undefined;
+  try {
+    const raw = readFileSync(join(procRoot, String(pid), 'stat'), 'utf8');
+    const closeParen = raw.lastIndexOf(')');
+    if (closeParen < 0) return undefined;
+    const fields = raw.slice(closeParen + 2).trim().split(/\s+/);
+    return /^\d+$/.test(fields[19] ?? '') ? fields[19] : undefined;
+  } catch { /* use the hardened ps fallback below when procfs is unavailable */ }
+  if (procRoot !== '/proc') return undefined;
+  const ps = ['/usr/bin/ps', '/bin/ps'].find(existsSync);
+  if (!ps) return undefined;
+  try {
+    const started = execFileSync(ps, ['-o', 'lstart=', '-p', String(pid)], {
+      encoding: 'utf8', timeout: 2_000, stdio: ['ignore', 'pipe', 'ignore'],
+      env: { PATH: '/usr/bin:/bin', LANG: 'C' },
+    }).trim();
+    return started || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function snapshotProcessIdentities(
+  cliPid: number,
+  procRoot = '/proc',
+): string[] | undefined {
+  if (procRoot === '/proc' && process.platform !== 'linux') return undefined;
+  const lineage = collectSessionLineagePids(procRoot, [cliPid]);
+  if (!lineage || lineage.size === 0) return undefined;
+  const identities: string[] = [];
+  for (const pid of lineage) {
+    const raw = readProcStart(pid, procRoot);
+    if (raw) identities.push(`${pid}:${raw}`);
+  }
+  return identities.length > 0 ? identities.sort() : undefined;
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
+}
+
+function peerSocketInodes(procRoot: string, clientPort: number, serverPort: number): Set<string> | undefined {
+  const out = new Set<string>();
+  let tableRead = false;
+  for (const relative of ['net/tcp', 'net/tcp6']) {
+    let text: string;
+    try {
+      text = readFileSync(join(procRoot, relative), 'utf8');
+      tableRead = true;
+    } catch {
+      continue;
+    }
+    for (const line of text.split('\n')) {
+      const fields = line.trim().split(/\s+/);
+      if (fields.length < 10 || fields[3] !== TCP_ESTABLISHED_STATE) continue;
+      const localPort = Number.parseInt(fields[1]?.split(':').at(-1) ?? '', 16);
+      const remotePort = Number.parseInt(fields[2]?.split(':').at(-1) ?? '', 16);
+      if (localPort !== clientPort || remotePort !== serverPort) continue;
+      if (/^\d+$/.test(fields[9])) out.add(fields[9]);
+    }
+  }
+  return tableRead ? out : undefined;
+}
+
+/** Resolve the process that owns the client half of one live loopback TCP request. */
+export function resolveLoopbackPeerProcesses(input: {
+  remoteAddress?: string;
+  remotePort?: number;
+  localPort?: number;
+  procRoot?: string;
+}): LoopbackPeerResolution {
+  const procRoot = input.procRoot ?? '/proc';
+  if (procRoot === '/proc' && process.platform !== 'linux') {
+    return { ok: false, reason: 'platform_unsupported' };
+  }
+  if (!isLoopbackAddress(input.remoteAddress)) return { ok: false, reason: 'not_loopback' };
+  if (!Number.isSafeInteger(input.remotePort) || !input.remotePort
+    || !Number.isSafeInteger(input.localPort) || !input.localPort) {
+    return { ok: false, reason: 'socket_unavailable' };
+  }
+  const inodes = peerSocketInodes(procRoot, input.remotePort, input.localPort);
+  if (!inodes || inodes.size !== 1) return { ok: false, reason: 'peer_unresolved' };
+  const inode = [...inodes][0];
+  const needle = `socket:[${inode}]`;
+  let entries: string[];
+  try { entries = readdirSync(procRoot); } catch { return { ok: false, reason: 'peer_unresolved' }; }
+  const peers: ProcessIdentity[] = [];
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number(entry);
+    let fds: string[];
+    try { fds = readdirSync(join(procRoot, entry, 'fd')); } catch { continue; }
+    let ownsSocket = false;
+    for (const fd of fds) {
+      try {
+        if (readlinkSync(join(procRoot, entry, 'fd', fd)) === needle) {
+          ownsSocket = true;
+          break;
+        }
+      } catch { /* process/fd raced away */ }
+    }
+    if (!ownsSocket) continue;
+    const procStart = readProcStart(pid, procRoot);
+    if (procStart) peers.push({ pid, procStart });
+  }
+  return peers.length === 1
+    ? { ok: true, peer: peers[0] }
+    : { ok: false, reason: 'peer_unresolved' };
+}
+
+function peerBelongsToCurrentTurn(input: {
+  peer: ProcessIdentity;
+  cliPid: number;
+  procRoot: string;
+  preexistingProcessIdentities: ReadonlySet<string>;
+}): boolean {
+  if (input.procRoot === '/proc' && process.platform !== 'linux') return false;
+  let pid = input.peer.pid;
+  for (let depth = 0; depth < 32 && pid > 1; depth++) {
+    if (pid === input.cliPid) return true;
+    try {
+      const raw = readFileSync(join(input.procRoot, String(pid), 'stat'), 'utf8');
+      const fields = raw.slice(raw.lastIndexOf(')') + 2).trim().split(/\s+/);
+      const parent = Number(fields[1]);
+      const started = fields[19];
+      if (!Number.isSafeInteger(parent) || !/^\d+$/.test(started ?? '')
+        || input.preexistingProcessIdentities.has(`${pid}:${started}`)) return false;
+      pid = parent;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export type CurrentActorDaemonResult =
+  | { ok: true; document: CurrentActorDocument }
+  | { ok: false; error: 'current_actor_unverified' };
+
+/** Daemon-owned authorization and identity lookup for the current live turn. */
+export async function resolveDaemonCurrentActor(input: {
+  sessionId: string;
+  peer: ProcessIdentity;
+  findSession: (sessionId: string) => DaemonSession | undefined;
+  resolveIdentity?: typeof resolveVerifiedUserIdentity;
+  procRoot?: string;
+}): Promise<CurrentActorDaemonResult> {
+  const ds = input.findSession(input.sessionId);
+  const turnId = ds?.managedTurnOrigin?.turnId;
+  const generation = ds?.workerGeneration;
+  const attestation = ds?.localProcessAttestation;
+  const cliPid = attestation?.cliPid;
+  const cliProcStart = attestation?.cliProcStart;
+  const processIdentities = ds?.managedTurnOrigin?.preexistingProcessIdentities;
+  const workerPid = ds?.worker?.pid;
+  const workerProcStart = workerPid ? readProcStart(workerPid, input.procRoot ?? '/proc') : undefined;
+  if (!ds || ds.session.status !== 'active'
+    || !larkTransportEnabled({ chatId: ds.chatId, apiOnly: ds.initConfig?.apiOnly })
+    || !turnId || generation === undefined
+    || !workerPid || !workerProcStart || ds.worker?.killed === true
+    || attestation?.workerGeneration !== generation
+    || !cliPid || !cliProcStart
+    || !processIdentities || processIdentities.length === 0
+    || readProcStart(cliPid, input.procRoot ?? '/proc') !== cliProcStart) {
+    return { ok: false, error: 'current_actor_unverified' };
+  }
+  const procRoot = input.procRoot ?? '/proc';
+  const preexistingProcessIdentities = new Set(processIdentities);
+  if (!peerBelongsToCurrentTurn({
+      peer: input.peer, cliPid, procRoot,
+      preexistingProcessIdentities,
+    })
+    || readProcStart(input.peer.pid, input.procRoot ?? '/proc') !== input.peer.procStart) {
+    return { ok: false, error: 'current_actor_unverified' };
+  }
+  const senderOpenId = ds.managedTurnOrigin?.callerOpenId;
+  if (!senderOpenId?.startsWith('ou_')) return { ok: false, error: 'current_actor_unverified' };
+
+  const frozen = {
+    ds, turnId, generation, senderOpenId, capability: ds.managedTurnOrigin!.capability,
+    workerPid, workerProcStart, processIdentities: [...processIdentities],
+  };
+  const identity = await (input.resolveIdentity ?? resolveVerifiedUserIdentity)(ds.larkAppId, senderOpenId);
+  if (!identity || identity.type !== 'user' || identity.openId !== senderOpenId) {
+    return { ok: false, error: 'current_actor_unverified' };
+  }
+  let username: string;
+  try { ({ username } = normalizeEnterpriseEmail(identity.email)); }
+  catch { return { ok: false, error: 'current_actor_unverified' }; }
+
+  const current = input.findSession(input.sessionId);
+  const currentSender = current?.managedTurnOrigin?.callerOpenId;
+  if (current !== frozen.ds || current?.session.status !== 'active'
+    || current.workerGeneration !== frozen.generation
+    || current.worker?.pid !== frozen.workerPid
+    || current.worker?.killed === true
+    || current.localProcessAttestation?.workerGeneration !== frozen.generation
+    || current.localProcessAttestation?.cliPid !== cliPid
+    || current.localProcessAttestation?.cliProcStart !== cliProcStart
+    || current.managedTurnOrigin?.turnId !== frozen.turnId
+    || current.managedTurnOrigin?.capability !== frozen.capability
+    || JSON.stringify(current.managedTurnOrigin?.preexistingProcessIdentities)
+      !== JSON.stringify(frozen.processIdentities)
+    || currentSender !== frozen.senderOpenId
+    || readProcStart(frozen.workerPid, input.procRoot ?? '/proc') !== frozen.workerProcStart
+    || readProcStart(cliPid, input.procRoot ?? '/proc') !== cliProcStart
+    || readProcStart(input.peer.pid, input.procRoot ?? '/proc') !== input.peer.procStart
+    || !peerBelongsToCurrentTurn({
+      peer: input.peer, cliPid, procRoot,
+      preexistingProcessIdentities: new Set(frozen.processIdentities),
+    })) {
+    return { ok: false, error: 'current_actor_unverified' };
+  }
+
+  return {
+    ok: true,
+    document: {
+      schema: CURRENT_ACTOR_SCHEMA,
+      status: 'verified',
+      actor: { username, enterpriseDomainVerified: true },
+    },
+  };
+}

--- a/src/core/current-actor-attestation.ts
+++ b/src/core/current-actor-attestation.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, readlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { CURRENT_ACTOR_SCHEMA, normalizeEnterpriseEmail, type CurrentActorDocument } from '../cli/current-actor.js';
+import { CURRENT_ACTOR_SCHEMA, normalizeActorEmail, type CurrentActorDocument } from '../cli/current-actor.js';
 import { resolveVerifiedUserIdentity } from '../im/lark/identity-cache.js';
 import { collectSessionLineagePids } from './preview-port-owner.js';
 import { larkTransportEnabled, type DaemonSession } from './types.js';
@@ -205,8 +205,8 @@ export async function resolveDaemonCurrentActor(input: {
   if (!identity || identity.type !== 'user' || identity.openId !== senderOpenId) {
     return { ok: false, error: 'current_actor_unverified' };
   }
-  let username: string;
-  try { ({ username } = normalizeEnterpriseEmail(identity.email)); }
+  let email: string;
+  try { email = normalizeActorEmail(identity.email); }
   catch { return { ok: false, error: 'current_actor_unverified' }; }
 
   const current = input.findSession(input.sessionId);
@@ -238,7 +238,7 @@ export async function resolveDaemonCurrentActor(input: {
     document: {
       schema: CURRENT_ACTOR_SCHEMA,
       status: 'verified',
-      actor: { username, enterpriseDomainVerified: true },
+      actor: { email },
     },
   };
 }

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -45,6 +45,13 @@ import { claimPromptContext } from '../services/prompt-context-store.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { normalizeCliRuntimeConfig, type CliRuntimeConfig } from '../adapters/cli/runtime.js';
 import { evaluateReadIsolationGate } from '../adapters/cli/read-isolation.js';
+import {
+  CURRENT_ACTOR_ROUTE,
+} from '../cli/current-actor.js';
+import {
+  resolveDaemonCurrentActor,
+  resolveLoopbackPeerProcesses,
+} from './current-actor-attestation.js';
 
 /** Whether read isolation can actually be ENFORCED for this bot right now — the
  *  SAME gate the worker fail-closes on (adapter support + no wrapperCli + macOS).
@@ -722,6 +729,10 @@ function routeHasNarrowUntrustedAuth(method: string, pathname: string): boolean 
   // the handler writes the authoritative tuple into a host-owned read-only
   // proof sidecar, so loopback response spoofing cannot confer authority.
   if (method === 'POST' && pathname === MANAGED_ORIGIN_ATTEST_ROUTE) return true;
+  // The daemon authenticates this route from the live loopback peer process
+  // and its private worker IPC state. It intentionally accepts no file/env
+  // capability because those are writable by an unconfined same-UID Agent.
+  if (method === 'POST' && pathname === CURRENT_ACTOR_ROUTE) return true;
   // Workflow v3 mutations carry their own domain-separated full-envelope
   // protocol (request signature over method/path/exact body with nonce
   // anti-replay + boot audience, signed response), keyed on the same host
@@ -951,6 +962,49 @@ ipcRoute('POST', MANAGED_ORIGIN_ATTEST_ROUTE, async (req, res) => {
   } finally {
     managedOriginPreauthInFlight -= 1;
   }
+});
+
+ipcRoute('POST', CURRENT_ACTOR_ROUTE, async (req, res) => {
+  let body: { sessionId?: unknown };
+  try {
+    body = await readBoundedJsonBody(req, 1_024, 1_000);
+  } catch (err) {
+    if (err instanceof IpcBodyTooLargeError || err instanceof IpcBodyTimeoutError) {
+      closeUntrustedRequestAfterResponse(req, res);
+    }
+    return jsonRes(res, err instanceof IpcBodyTooLargeError ? 413 : 400, {
+      schema: 'botmux.current-actor.v2',
+      status: 'blocked',
+      error: 'current_actor_unverified',
+    });
+  }
+  const sessionId = typeof body.sessionId === 'string' && body.sessionId.length <= 256
+    ? body.sessionId
+    : '';
+  const peer = resolveLoopbackPeerProcesses({
+    remoteAddress: req.socket.remoteAddress,
+    remotePort: req.socket.remotePort,
+    localPort: req.socket.localPort,
+  });
+  if (!sessionId || !peer.ok) {
+    return jsonRes(res, 403, {
+      schema: 'botmux.current-actor.v2',
+      status: 'blocked',
+      error: 'current_actor_unverified',
+    });
+  }
+  const result = await resolveDaemonCurrentActor({
+    sessionId,
+    peer: peer.peer,
+    findSession: findActiveBySessionId,
+  });
+  return result.ok
+    ? jsonRes(res, 200, result.document)
+    : jsonRes(res, 403, {
+        schema: 'botmux.current-actor.v2',
+        status: 'blocked',
+        error: result.error,
+      });
 });
 
 // ─── Session list / detail ─────────────────────────────────────────────────

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -493,6 +493,13 @@ export interface DaemonSession {
     originChannelId?: string;
     turnId?: string;
     dispatchAttempt?: number;
+    /** Current human caller, carried over private worker IPC from the
+     * daemon-authenticated input envelope. Never sourced from CLI env/files. */
+    callerOpenId?: string;
+    /** Linux pid:starttime identities already present in the CLI subtree when
+     * this turn authority was published. Actor callers may not traverse one of
+     * these old descendants; the long-lived CLI root itself is the exception. */
+    preexistingProcessIdentities?: string[];
   };
   /** Authority snapshot captured when an explicit Lark IM message was
    * deterministically routed into this dedicated meeting receiver. */

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -27,7 +27,7 @@ import {
 } from '../services/message-listener-run-preview-store.js';
 import { persistStreamCardState, rememberLastCliInput } from './session-manager.js';
 import { resolveSessionLaunchModel } from './session-model.js';
-import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, rehomeReplyTargetState, replyTargetKey } from './reply-target.js';
+import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, pickTurnReplyTarget, rehomeReplyTargetState, replyTargetKey } from './reply-target.js';
 import { updateMessage, deleteMessage, sendEphemeralCard, sendUserMessage, addReaction, removeReaction, getMessageChatId, MessageWithdrawnError } from '../im/lark/client.js';
 import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildTuiPromptFailedCard, buildRelayedFrozenCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { codexServiceTierBadge } from '../services/codex-service-tier.js';
@@ -424,6 +424,7 @@ import { hasProtectedSessionMutationOwnership } from './session-mutation-guard.j
 import { DONE_REACTION_EMOJI_TYPE } from './pending-response.js';
 import { buildTerminalUrl } from './terminal-url.js';
 import { prependBotmuxBin, resolveBotmuxWrapperBinDir } from './botmux-wrapper.js';
+import { snapshotProcessIdentities } from './current-actor-attestation.js';
 import { usageLimitStateKey, isActiveWorkRuntimeStatus, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
 import {
   evaluateVcMeetingManagedSend,
@@ -9852,6 +9853,21 @@ function isMeetingDrivenTurn(
   return resolveVcMeetingImTurnOrigin(ds.session, turnId) !== undefined;
 }
 
+function currentGatewayCallerOpenId(ds: DaemonSession, turnId: string): string | undefined {
+  // The daemon owns this per-turn sender map. The worker contributes only the
+  // turn id over private IPC; it can never choose which human that id denotes.
+  return pickTurnReplyTarget(ds.session, turnId)?.senderOpenId;
+}
+
+function currentTurnProcessIdentities(
+  ds: DaemonSession,
+  turnId: string | undefined,
+): string[] | undefined {
+  return turnId && ds.localProcessAttestation?.cliPid
+    ? snapshotProcessIdentities(ds.localProcessAttestation.cliPid)
+    : undefined;
+}
+
 function setupWorkerHandlers(
   ds: DaemonSession,
   worker: ChildProcess,
@@ -12151,12 +12167,19 @@ function setupWorkerHandlers(
             break;
           }
         }
+        const preexistingProcessIdentities = currentTurnProcessIdentities(ds, msg.turnId);
         ds.managedTurnOrigin = {
           capability: msg.capability,
           ...(msg.originChannelId ? { originChannelId: msg.originChannelId } : {}),
           ...(msg.turnId ? { turnId: msg.turnId } : {}),
           ...(msg.dispatchAttempt !== undefined
             ? { dispatchAttempt: msg.dispatchAttempt }
+            : {}),
+          ...((msg.turnId && currentGatewayCallerOpenId(ds, msg.turnId))
+            ? { callerOpenId: currentGatewayCallerOpenId(ds, msg.turnId) }
+            : {}),
+          ...(preexistingProcessIdentities
+            ? { preexistingProcessIdentities }
             : {}),
         };
         break;

--- a/src/im/lark/identity-cache.ts
+++ b/src/im/lark/identity-cache.ts
@@ -348,6 +348,45 @@ export interface ResolvedSender {
 }
 
 /**
+ * Resolve a human user from the authoritative contact API for a
+ * security-sensitive current-turn identity check. Unlike resolveSender(), this
+ * deliberately bypasses the persisted display cache: an old cached email must
+ * not authorize a new credential operation.
+ */
+export async function resolveVerifiedUserIdentity(
+  larkAppId: string,
+  openId: string,
+): Promise<{ openId: string; type: 'user'; name?: string; email?: string } | undefined> {
+  if (!openId) return undefined;
+  try {
+    const c = getBotClient(larkAppId);
+    const res = await larkGet(c, `/open-apis/contact/v3/users/${encodeURIComponent(openId)}`, {
+      user_id_type: 'open_id',
+    });
+    const user = res?.code === 0 ? res?.data?.user : undefined;
+    if (!user) return undefined;
+    const rawName: unknown = user.name;
+    const rawEmail: unknown = user.enterprise_email ?? user.email;
+    const name = typeof rawName === 'string' && rawName.trim() ? rawName.trim() : undefined;
+    const email = typeof rawEmail === 'string' && rawEmail.trim() ? rawEmail.trim() : undefined;
+    recordIdentity(larkAppId, {
+      openId,
+      name,
+      email,
+      contactResolvedAt: Date.now(),
+      type: 'user',
+      source: 'contact_api',
+    });
+    return { openId, type: 'user', name, email };
+  } catch (err: any) {
+    logger.debug(
+      `[identity] strict contact lookup for ${openId.substring(0, 12)} failed: ${err?.message ?? err}`,
+    );
+    return undefined;
+  }
+}
+
+/**
  * Resolve sender identity for prompt injection.
  *
  * Inputs are taken directly from the Lark event (`sender_id.open_id`,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17851,6 +17851,11 @@ function publishLocalProcessAttestation(cliPid?: number): void {
     ...(cliPid ? { cliPid } : {}),
     ...(cliProcStart ? { cliProcStart } : {}),
   });
+  // IPC preserves order: the daemon records this exact CLI pid/generation
+  // before it snapshots the current turn's pre-existing descendants. This is
+  // required for the opening turn, whose origin is first published before the
+  // CLI process exists, and whenever a wrapper resolves to a new real CLI pid.
+  if (currentBotmuxTurnId) publishSandboxRelayCapability();
 }
 
 /** Deliver a terminal IPC message before exiting the worker. `process.send()`

--- a/test/api-only-cli-gate.behavior.test.ts
+++ b/test/api-only-cli-gate.behavior.test.ts
@@ -16,7 +16,7 @@ import { tmpdir } from 'node:os';
  * Requires the compiled artifact; skips if dist is absent.
  */
 const CLI = resolve('dist/cli.js');
-const LARK_FACING = ['send', 'dispatch', 'create-group', 'history', 'quoted', 'bots', 'grant'];
+const LARK_FACING = ['send', 'dispatch', 'create-group', 'history', 'quoted', 'bots', 'grant', 'actor'];
 
 let DATA_DIR = '';
 const VIRTUAL_SID = 'sess_behavior_virtual';

--- a/test/capabilities.test.ts
+++ b/test/capabilities.test.ts
@@ -24,6 +24,7 @@ describe('botmux capabilities contract', () => {
         stable_app_dispatch_v1: true,
         stable_dispatch_acceptance_v1: true,
         managed_activation_v2: true,
+        current_actor_v2: true,
       },
     });
   });

--- a/test/cli-root-help.test.ts
+++ b/test/cli-root-help.test.ts
@@ -25,6 +25,7 @@ describe('botmux root help workflow surface', () => {
 
       expect(stdout).toContain('workflow save [last|runId] [名称]');
       expect(stdout).toContain('goal run <goal> [--run-id <id>]');
+      expect(stdout).toContain('actor current --json');
       expect(stdout).toContain('同一 run-id 可安全重放终态或接续崩溃运行');
       expect(stdout).toContain('发布当前 Bot 全局版本 / 确认 unsafe lint 请由用户在飞书显式发送');
       expect(stdout).toContain('workflow run <名称|workflowId> [--param key=value ...]');

--- a/test/current-actor-attestation.test.ts
+++ b/test/current-actor-attestation.test.ts
@@ -98,13 +98,17 @@ describe('daemon current actor attestation', () => {
     writeProc(procRoot, 90, 1, '900');
     writeProc(procRoot, 100, 1, '1000');
     writeProc(procRoot, 200, 1, '3000');
+    const resolveIdentity = vi.fn(async () => ({
+      openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com',
+    }));
     await expect(resolveDaemonCurrentActor({
       sessionId: 's1',
       peer: { pid: 200, procStart: '3000' },
       findSession: () => activeSession(),
-      resolveIdentity: vi.fn(),
+      resolveIdentity,
       procRoot,
     })).resolves.toEqual({ ok: false, error: 'current_actor_unverified' });
+    expect(resolveIdentity).not.toHaveBeenCalled();
   });
 
   it('rejects a new descendant reached through an old-turn child', async () => {
@@ -115,13 +119,17 @@ describe('daemon current actor attestation', () => {
     writeProc(procRoot, 102, 101, '1200');
     const ds = activeSession();
     ds.managedTurnOrigin.preexistingProcessIdentities = ['100:1000', '101:1100'];
+    const resolveIdentity = vi.fn(async () => ({
+      openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com',
+    }));
     await expect(resolveDaemonCurrentActor({
       sessionId: 's1',
       peer: { pid: 102, procStart: '1200' },
       findSession: () => ds,
-      resolveIdentity: vi.fn(),
+      resolveIdentity,
       procRoot,
     })).resolves.toEqual({ ok: false, error: 'current_actor_unverified' });
+    expect(resolveIdentity).not.toHaveBeenCalled();
   });
 
   it('rejects a stale worker generation before identity lookup', async () => {
@@ -145,6 +153,21 @@ describe('daemon current actor attestation', () => {
     const ds = activeSession();
     const resolveIdentity = vi.fn(async () => {
       ds.managedTurnOrigin = { capability: 'db'.repeat(32), turnId: 'om_next', callerOpenId: 'ou_other' };
+      return { openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com' };
+    });
+    await expect(resolveDaemonCurrentActor({
+      sessionId: 's1', peer: { pid: 100, procStart: '1000' },
+      findSession: () => ds, resolveIdentity, procRoot,
+    })).resolves.toEqual({ ok: false, error: 'current_actor_unverified' });
+  });
+
+  it('rejects a sender change during the live Contact lookup', async () => {
+    const procRoot = mkdtempSync(join(tmpdir(), 'actor-proc-'));
+    writeProc(procRoot, 90, 1, '900');
+    writeProc(procRoot, 100, 1, '1000');
+    const ds = activeSession();
+    const resolveIdentity = vi.fn(async () => {
+      ds.managedTurnOrigin.callerOpenId = 'ou_other';
       return { openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com' };
     });
     await expect(resolveDaemonCurrentActor({

--- a/test/current-actor-attestation.test.ts
+++ b/test/current-actor-attestation.test.ts
@@ -1,0 +1,155 @@
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  resolveDaemonCurrentActor,
+  resolveLoopbackPeerProcesses,
+} from '../src/core/current-actor-attestation.js';
+
+function procStat(pid: number, ppid: number, start: string): string {
+  const tail = ['S', String(ppid), '1', '1', '0', '-1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', start];
+  return `${pid} (proc ${pid}) ${tail.join(' ')}\n`;
+}
+
+function writeProc(root: string, pid: number, ppid: number, start: string): void {
+  const dir = join(root, String(pid));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'stat'), procStat(pid, ppid, start));
+}
+
+function activeSession(): any {
+  return {
+    session: { sessionId: 's1', status: 'active' },
+    worker: { pid: 90, killed: false },
+    chatId: 'oc_chat',
+    larkAppId: 'cli_app',
+    workerGeneration: 7,
+    localProcessAttestation: {
+      backendType: 'pty',
+      credentialIsolated: false,
+      cliPid: 100,
+      cliProcStart: '1000',
+      workerGeneration: 7,
+    },
+    managedTurnOrigin: {
+      capability: 'ca'.repeat(32),
+      turnId: 'om_turn',
+      callerOpenId: 'ou_current',
+      preexistingProcessIdentities: ['100:1000'],
+    },
+    initConfig: { apiOnly: false },
+  };
+}
+
+describe('daemon current actor attestation', () => {
+  it('derives the HTTP client pid from the live kernel socket tuple', () => {
+    const procRoot = mkdtempSync(join(tmpdir(), 'actor-peer-'));
+    mkdirSync(join(procRoot, 'net'), { recursive: true });
+    writeFileSync(join(procRoot, 'net', 'tcp'), [
+      'sl local_address rem_address st tx_queue rx_queue tr tm->when retrnsmt uid timeout inode',
+      '0: 0100007F:C350 0100007F:1F0F 01 00000000:00000000 00:00000000 00000000 1000 0 4242',
+    ].join('\n'));
+    writeFileSync(join(procRoot, 'net', 'tcp6'), '');
+    writeProc(procRoot, 101, 100, '2000');
+    mkdirSync(join(procRoot, '101', 'fd'), { recursive: true });
+    symlinkSync('socket:[4242]', join(procRoot, '101', 'fd', '7'));
+
+    expect(resolveLoopbackPeerProcesses({
+      remoteAddress: '127.0.0.1',
+      remotePort: 50_000,
+      localPort: 7_951,
+      procRoot,
+    })).toEqual({ ok: true, peer: { pid: 101, procStart: '2000' } });
+  });
+
+  it('rejects a non-loopback request before process lookup', () => {
+    expect(resolveLoopbackPeerProcesses({
+      remoteAddress: '10.0.0.1', remotePort: 50_000, localPort: 7_951,
+    })).toEqual({ ok: false, reason: 'not_loopback' });
+  });
+
+  it('binds a live client descendant to the in-memory turn caller', async () => {
+    const procRoot = mkdtempSync(join(tmpdir(), 'actor-proc-'));
+    writeProc(procRoot, 90, 1, '900');
+    writeProc(procRoot, 100, 1, '1000');
+    writeProc(procRoot, 101, 100, '2000');
+    const ds = activeSession();
+    const resolveIdentity = vi.fn(async () => ({
+      openId: 'ou_current', type: 'user' as const, email: 'Current.User@BYTEDANCE.COM',
+    }));
+
+    await expect(resolveDaemonCurrentActor({
+      sessionId: 's1',
+      peer: { pid: 101, procStart: '2000' },
+      findSession: () => ds,
+      resolveIdentity,
+      procRoot,
+    })).resolves.toMatchObject({
+      ok: true,
+      document: { actor: { username: 'current.user', enterpriseDomainVerified: true } },
+    });
+    expect(resolveIdentity).toHaveBeenCalledWith('cli_app', 'ou_current');
+  });
+
+  it('rejects a same-uid process outside the attested CLI lineage', async () => {
+    const procRoot = mkdtempSync(join(tmpdir(), 'actor-proc-'));
+    writeProc(procRoot, 90, 1, '900');
+    writeProc(procRoot, 100, 1, '1000');
+    writeProc(procRoot, 200, 1, '3000');
+    await expect(resolveDaemonCurrentActor({
+      sessionId: 's1',
+      peer: { pid: 200, procStart: '3000' },
+      findSession: () => activeSession(),
+      resolveIdentity: vi.fn(),
+      procRoot,
+    })).resolves.toEqual({ ok: false, error: 'current_actor_unverified' });
+  });
+
+  it('rejects a new descendant reached through an old-turn child', async () => {
+    const procRoot = mkdtempSync(join(tmpdir(), 'actor-proc-'));
+    writeProc(procRoot, 90, 1, '900');
+    writeProc(procRoot, 100, 1, '1000');
+    writeProc(procRoot, 101, 100, '1100');
+    writeProc(procRoot, 102, 101, '1200');
+    const ds = activeSession();
+    ds.managedTurnOrigin.preexistingProcessIdentities = ['100:1000', '101:1100'];
+    await expect(resolveDaemonCurrentActor({
+      sessionId: 's1',
+      peer: { pid: 102, procStart: '1200' },
+      findSession: () => ds,
+      resolveIdentity: vi.fn(),
+      procRoot,
+    })).resolves.toEqual({ ok: false, error: 'current_actor_unverified' });
+  });
+
+  it('rejects a stale worker generation before identity lookup', async () => {
+    const procRoot = mkdtempSync(join(tmpdir(), 'actor-proc-'));
+    writeProc(procRoot, 90, 1, '900');
+    writeProc(procRoot, 100, 1, '1000');
+    const ds = activeSession();
+    ds.localProcessAttestation.workerGeneration = 6;
+    const resolveIdentity = vi.fn();
+    await expect(resolveDaemonCurrentActor({
+      sessionId: 's1', peer: { pid: 100, procStart: '1000' },
+      findSession: () => ds, resolveIdentity, procRoot,
+    })).resolves.toEqual({ ok: false, error: 'current_actor_unverified' });
+    expect(resolveIdentity).not.toHaveBeenCalled();
+  });
+
+  it('rejects a turn rotation during the live Contact lookup', async () => {
+    const procRoot = mkdtempSync(join(tmpdir(), 'actor-proc-'));
+    writeProc(procRoot, 90, 1, '900');
+    writeProc(procRoot, 100, 1, '1000');
+    const ds = activeSession();
+    const resolveIdentity = vi.fn(async () => {
+      ds.managedTurnOrigin = { capability: 'db'.repeat(32), turnId: 'om_next', callerOpenId: 'ou_other' };
+      return { openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com' };
+    });
+    await expect(resolveDaemonCurrentActor({
+      sessionId: 's1', peer: { pid: 100, procStart: '1000' },
+      findSession: () => ds, resolveIdentity, procRoot,
+    })).resolves.toEqual({ ok: false, error: 'current_actor_unverified' });
+  });
+});

--- a/test/current-actor-attestation.test.ts
+++ b/test/current-actor-attestation.test.ts
@@ -77,7 +77,7 @@ describe('daemon current actor attestation', () => {
     writeProc(procRoot, 101, 100, '2000');
     const ds = activeSession();
     const resolveIdentity = vi.fn(async () => ({
-      openId: 'ou_current', type: 'user' as const, email: 'Current.User@BYTEDANCE.COM',
+      openId: 'ou_current', type: 'user' as const, email: 'Current.User@Example.COM',
     }));
 
     await expect(resolveDaemonCurrentActor({
@@ -88,7 +88,7 @@ describe('daemon current actor attestation', () => {
       procRoot,
     })).resolves.toMatchObject({
       ok: true,
-      document: { actor: { username: 'current.user', enterpriseDomainVerified: true } },
+      document: { actor: { email: 'current.user@example.com' } },
     });
     expect(resolveIdentity).toHaveBeenCalledWith('cli_app', 'ou_current');
   });
@@ -99,7 +99,7 @@ describe('daemon current actor attestation', () => {
     writeProc(procRoot, 100, 1, '1000');
     writeProc(procRoot, 200, 1, '3000');
     const resolveIdentity = vi.fn(async () => ({
-      openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com',
+      openId: 'ou_current', type: 'user' as const, email: 'current@example.com',
     }));
     await expect(resolveDaemonCurrentActor({
       sessionId: 's1',
@@ -120,7 +120,7 @@ describe('daemon current actor attestation', () => {
     const ds = activeSession();
     ds.managedTurnOrigin.preexistingProcessIdentities = ['100:1000', '101:1100'];
     const resolveIdentity = vi.fn(async () => ({
-      openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com',
+      openId: 'ou_current', type: 'user' as const, email: 'current@example.com',
     }));
     await expect(resolveDaemonCurrentActor({
       sessionId: 's1',
@@ -153,7 +153,7 @@ describe('daemon current actor attestation', () => {
     const ds = activeSession();
     const resolveIdentity = vi.fn(async () => {
       ds.managedTurnOrigin = { capability: 'db'.repeat(32), turnId: 'om_next', callerOpenId: 'ou_other' };
-      return { openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com' };
+      return { openId: 'ou_current', type: 'user' as const, email: 'current@example.com' };
     });
     await expect(resolveDaemonCurrentActor({
       sessionId: 's1', peer: { pid: 100, procStart: '1000' },
@@ -168,7 +168,7 @@ describe('daemon current actor attestation', () => {
     const ds = activeSession();
     const resolveIdentity = vi.fn(async () => {
       ds.managedTurnOrigin.callerOpenId = 'ou_other';
-      return { openId: 'ou_current', type: 'user' as const, email: 'current@bytedance.com' };
+      return { openId: 'ou_current', type: 'user' as const, email: 'current@example.com' };
     });
     await expect(resolveDaemonCurrentActor({
       sessionId: 's1', peer: { pid: 100, procStart: '1000' },

--- a/test/current-actor.test.ts
+++ b/test/current-actor.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   CURRENT_ACTOR_SCHEMA,
   CurrentActorError,
-  normalizeEnterpriseEmail,
+  normalizeActorEmail,
   parseCurrentActorArgs,
   resolveBotmuxAncestorContext,
   resolveCurrentActor,
@@ -65,13 +65,13 @@ describe('current actor client contract', () => {
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
       schema: CURRENT_ACTOR_SCHEMA,
       status: 'verified',
-      actor: { enterpriseDomainVerified: true, username: 'current.user' },
+      actor: { email: 'current.user@example.com' },
     }), { status: 200 }));
     await expect(resolveCurrentActor({
       ipcPort: 7951,
       sessionId: 'sess-1',
       fetchImpl: fetchImpl as typeof fetch,
-    })).resolves.toMatchObject({ status: 'verified', actor: { username: 'current.user' } });
+    })).resolves.toMatchObject({ status: 'verified', actor: { email: 'current.user@example.com' } });
     expect(fetchImpl).toHaveBeenCalledWith(
       'http://127.0.0.1:7951/api/current-actor',
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ sessionId: 'sess-1' }) }),
@@ -79,9 +79,10 @@ describe('current actor client contract', () => {
   });
 
   it.each([
-    [{ schema: 'botmux.current-actor.v1', status: 'verified', actor: { username: 'x', enterpriseDomainVerified: true } }],
-    [{ schema: CURRENT_ACTOR_SCHEMA, status: 'verified', actor: { username: 'X', enterpriseDomainVerified: true } }],
-    [{ schema: CURRENT_ACTOR_SCHEMA, status: 'verified', actor: { username: 'x', enterpriseDomainVerified: false } }],
+    [{ schema: 'botmux.current-actor.v1', status: 'verified', actor: { email: 'x@example.com' } }],
+    [{ schema: CURRENT_ACTOR_SCHEMA, status: 'verified', actor: { email: 'X@example.com' } }],
+    [{ schema: CURRENT_ACTOR_SCHEMA, status: 'verified', actor: { email: 'not-an-email' } }],
+    [{ schema: CURRENT_ACTOR_SCHEMA, status: 'verified', actor: { email: 'x@example.com', username: 'x' } }],
   ])('rejects an invalid daemon document: %j', async (payload) => {
     await expect(resolveCurrentActor({
       ipcPort: 7951,
@@ -98,8 +99,12 @@ describe('current actor client contract', () => {
     })).rejects.toThrow(CurrentActorError);
   });
 
-  it.each([undefined, '', 'not-an-email', '@bytedance.com', 'a@b@c', 'a@example.com'])(
-    'normalizer rejects an invalid enterprise email: %s',
-    (email) => expect(() => normalizeEnterpriseEmail(email)).toThrow(CurrentActorError),
+  it.each([undefined, '', 'not-an-email', '@example.com', 'a@b@c'])(
+    'normalizer rejects an invalid email: %s',
+    (email) => expect(() => normalizeActorEmail(email)).toThrow(CurrentActorError),
   );
+
+  it('normalizes an actor email without enforcing a tenant domain', () => {
+    expect(normalizeActorEmail(' Current.User@Example.COM ')).toBe('current.user@example.com');
+  });
 });

--- a/test/current-actor.test.ts
+++ b/test/current-actor.test.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  CURRENT_ACTOR_SCHEMA,
+  CurrentActorError,
+  normalizeEnterpriseEmail,
+  parseCurrentActorArgs,
+  resolveBotmuxAncestorContext,
+  resolveCurrentActor,
+} from '../src/cli/current-actor.js';
+
+function writeProcEnv(root: string, pid: number, parent: number, env: Record<string, string>): void {
+  const dir = join(root, String(pid));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'stat'), `${pid} (proc) S ${parent} 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 100\n`);
+  writeFileSync(join(dir, 'environ'), Object.entries(env).map(([key, value]) => `${key}=${value}`).join('\0'));
+}
+
+describe('current actor client contract', () => {
+  it.skipIf(process.platform !== 'linux')('gets route hints from a consistent BotMux ancestor', () => {
+    const root = mkdtempSync(join(tmpdir(), 'actor-env-'));
+    const env = {
+      BOTMUX: '1', BOTMUX_SESSION_ID: 's1', BOTMUX_LARK_APP_ID: 'cli_app',
+      BOTMUX_DAEMON_IPC_PORT: '7951',
+    };
+    writeProcEnv(root, 20, 10, env);
+    writeProcEnv(root, 10, 1, env);
+    expect(resolveBotmuxAncestorContext(20, root)).toEqual({
+      sessionId: 's1', larkAppId: 'cli_app', ipcPort: 7951,
+    });
+  });
+
+  it.skipIf(process.platform !== 'linux')('rejects conflicting BotMux ancestors', () => {
+    const root = mkdtempSync(join(tmpdir(), 'actor-env-'));
+    writeProcEnv(root, 20, 10, {
+      BOTMUX: '1', BOTMUX_SESSION_ID: 's1', BOTMUX_LARK_APP_ID: 'cli_app', BOTMUX_DAEMON_IPC_PORT: '7951',
+    });
+    writeProcEnv(root, 10, 1, {
+      BOTMUX: '1', BOTMUX_SESSION_ID: 's2', BOTMUX_LARK_APP_ID: 'cli_app', BOTMUX_DAEMON_IPC_PORT: '7951',
+    });
+    expect(() => resolveBotmuxAncestorContext(20, root)).toThrow(CurrentActorError);
+  });
+
+  it('republishes the opening turn after the live CLI pid is attested', () => {
+    const worker = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+    const start = worker.indexOf('function publishLocalProcessAttestation');
+    const body = worker.slice(start, worker.indexOf('/** Deliver a terminal IPC', start));
+    expect(body).toContain("type: 'local_process_attestation'");
+    expect(body).toContain('if (currentBotmuxTurnId) publishSandboxRelayCapability()');
+  });
+
+  it('accepts only the machine-readable current command', () => {
+    expect(parseCurrentActorArgs(['current', '--json'])).toEqual({ ok: true });
+    expect(parseCurrentActorArgs(['current'])).toEqual({
+      ok: false,
+      error: '用法: botmux actor current --json',
+    });
+  });
+
+  it('accepts only an exact verified daemon response', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      schema: CURRENT_ACTOR_SCHEMA,
+      status: 'verified',
+      actor: { enterpriseDomainVerified: true, username: 'current.user' },
+    }), { status: 200 }));
+    await expect(resolveCurrentActor({
+      ipcPort: 7951,
+      sessionId: 'sess-1',
+      fetchImpl: fetchImpl as typeof fetch,
+    })).resolves.toMatchObject({ status: 'verified', actor: { username: 'current.user' } });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:7951/api/current-actor',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ sessionId: 'sess-1' }) }),
+    );
+  });
+
+  it.each([
+    [{ schema: 'botmux.current-actor.v1', status: 'verified', actor: { username: 'x', enterpriseDomainVerified: true } }],
+    [{ schema: CURRENT_ACTOR_SCHEMA, status: 'verified', actor: { username: 'X', enterpriseDomainVerified: true } }],
+    [{ schema: CURRENT_ACTOR_SCHEMA, status: 'verified', actor: { username: 'x', enterpriseDomainVerified: false } }],
+  ])('rejects an invalid daemon document: %j', async (payload) => {
+    await expect(resolveCurrentActor({
+      ipcPort: 7951,
+      sessionId: 'sess-1',
+      fetchImpl: vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 })) as typeof fetch,
+    })).rejects.toThrow(CurrentActorError);
+  });
+
+  it('fails closed when the daemon refuses the request', async () => {
+    await expect(resolveCurrentActor({
+      ipcPort: 7951,
+      sessionId: 'sess-1',
+      fetchImpl: vi.fn(async () => new Response('{}', { status: 403 })) as typeof fetch,
+    })).rejects.toThrow(CurrentActorError);
+  });
+
+  it.each([undefined, '', 'not-an-email', '@bytedance.com', 'a@b@c', 'a@example.com'])(
+    'normalizer rejects an invalid enterprise email: %s',
+    (email) => expect(() => normalizeEnterpriseEmail(email)).toThrow(CurrentActorError),
+  );
+});

--- a/test/identity-cache-strict.test.ts
+++ b/test/identity-cache-strict.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const larkGet = vi.fn();
+const getBotClient = vi.fn(() => ({ marker: true }));
+
+vi.mock('../src/bot-registry.js', () => ({ getBotClient }));
+vi.mock('../src/config.js', () => ({ config: { session: { dataDir: '/tmp/botmux-test' } } }));
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../src/im/lark/client.js', () => ({
+  larkGet,
+  getMessageDetail: vi.fn(),
+}));
+
+describe('resolveVerifiedUserIdentity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('always reads the exact current open_id from the contact API', async () => {
+    larkGet.mockResolvedValue({
+      code: 0,
+      data: {
+        user: {
+          name: 'Current User',
+          email: 'personal@example.com',
+          enterprise_email: 'current.user@bytedance.com',
+        },
+      },
+    });
+    const { resolveVerifiedUserIdentity } = await import('../src/im/lark/identity-cache.js');
+
+    await expect(resolveVerifiedUserIdentity('cli_current', 'ou_current')).resolves.toEqual({
+      openId: 'ou_current',
+      type: 'user',
+      name: 'Current User',
+      email: 'current.user@bytedance.com',
+    });
+    expect(larkGet).toHaveBeenCalledWith(
+      { marker: true },
+      '/open-apis/contact/v3/users/ou_current',
+      { user_id_type: 'open_id' },
+    );
+  });
+
+  it('fails closed on a missing or failed contact result', async () => {
+    larkGet.mockResolvedValue({ code: 41050 });
+    const { resolveVerifiedUserIdentity } = await import('../src/im/lark/identity-cache.js');
+    await expect(resolveVerifiedUserIdentity('cli_current', 'ou_current')).resolves.toBeUndefined();
+
+    larkGet.mockRejectedValueOnce(new Error('network'));
+    await expect(resolveVerifiedUserIdentity('cli_current', 'ou_current')).resolves.toBeUndefined();
+  });
+});

--- a/test/ipc-current-actor-route.test.ts
+++ b/test/ipc-current-actor-route.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../src/im/lark/identity-cache.js', () => ({
   resolveVerifiedUserIdentity: vi.fn(async (_app: string, openId: string) => ({
-    openId, type: 'user', email: 'current.user@bytedance.com',
+    openId, type: 'user', email: 'current.user@example.com',
   })),
 }));
 
@@ -55,7 +55,7 @@ describe('POST /api/current-actor', () => {
     expect(await response.json()).toEqual({
       schema: 'botmux.current-actor.v2',
       status: 'verified',
-      actor: { username: 'current.user', enterpriseDomainVerified: true },
+      actor: { email: 'current.user@example.com' },
     });
   });
 

--- a/test/ipc-current-actor-route.test.ts
+++ b/test/ipc-current-actor-route.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/im/lark/identity-cache.js', () => ({
+  resolveVerifiedUserIdentity: vi.fn(async (_app: string, openId: string) => ({
+    openId, type: 'user', email: 'current.user@bytedance.com',
+  })),
+}));
+
+import { startIpcServer, type IpcServerHandle } from '../src/core/dashboard-ipc-server.js';
+import { readProcessStartIdentity } from '../src/utils/process-identity.js';
+import * as workerPool from '../src/core/worker-pool.js';
+
+let ipc: IpcServerHandle | null = null;
+
+afterEach(async () => {
+  if (ipc) await ipc.close();
+  ipc = null;
+  vi.restoreAllMocks();
+});
+
+function activeSession(): any {
+  return {
+    session: { sessionId: 's-actor', status: 'active' },
+    chatId: 'oc_chat',
+    larkAppId: 'cli_app',
+    workerGeneration: 7,
+    worker: { pid: process.pid, killed: false },
+    localProcessAttestation: {
+      backendType: 'pty',
+      credentialIsolated: false,
+      cliPid: process.pid,
+      cliProcStart: readProcessStartIdentity(process.pid),
+      workerGeneration: 7,
+    },
+    managedTurnOrigin: {
+      capability: 'ca'.repeat(32),
+      turnId: 'om_turn',
+      callerOpenId: 'ou_current',
+      preexistingProcessIdentities: [`${process.pid}:${readProcessStartIdentity(process.pid)}`],
+    },
+    initConfig: { apiOnly: false },
+  };
+}
+
+describe('POST /api/current-actor', () => {
+  it('returns only the daemon-resolved actor for a live CLI descendant', async () => {
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(activeSession());
+    ipc = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const response = await fetch(`http://127.0.0.1:${ipc.port}/api/current-actor`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: 's-actor', callerOpenId: 'ou_forged' }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      schema: 'botmux.current-actor.v2',
+      status: 'verified',
+      actor: { username: 'current.user', enterpriseDomainVerified: true },
+    });
+  });
+
+  it('fails closed when daemon live-turn state has no human caller', async () => {
+    const ds = activeSession();
+    delete ds.managedTurnOrigin.callerOpenId;
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+    ipc = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const response = await fetch(`http://127.0.0.1:${ipc.port}/api/current-actor`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: 's-actor' }),
+    });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      schema: 'botmux.current-actor.v2',
+      status: 'blocked',
+      error: 'current_actor_unverified',
+    });
+  });
+});

--- a/test/workflow-c0-isolation.test.ts
+++ b/test/workflow-c0-isolation.test.ts
@@ -63,6 +63,7 @@ describe('Slice C0 — chat side-effect isolation', () => {
     ['preset', 'export'],
     ['whiteboard', 'status'],
     ['vc-agent', 'join'],
+    ['actor', 'current', '--json'],
   ])('botmux %s is denied by the workflow root-command allowlist', (...args) => {
     const out = runCli(args, { BOTMUX_WORKFLOW: '1' });
     expect(out.status).toBe(2);


### PR DESCRIPTION
## 背景

在群聊和话题会话中，同一个 BotMux 实例会连续处理不同发信人的请求。需要执行用户级操作的工具必须知道“是谁触发了当前轮次”，但 session owner、进程环境变量和 prompt 文本都不能准确表达这个事实。缺少统一接口时，各工具只能自行推断，容易产生跨轮次或跨用户误用。

## 功能价值

- 为 BotMux 工具提供统一、机器可读的当前轮次 Actor 查询接口，避免每个工具重复实现身份推断
- Actor 始终来自 daemon 记录的当前 turn sender，不使用 session owner 或 prompt 中的身份字段
- 旧轮次、跨 session、脱离当前 worker/CLI 进程链以及无法严格解析身份的请求均 fail closed
- 通过 capability 协商暴露版本，调用方可以在不兼容的 BotMux 版本上明确拒绝，而不是降级到不可信来源

这使 BotMux 能承载需要按发信人隔离的自动化，例如用户级凭据、个人工作区或其他主体绑定资源的访问。

## 输出契约

`botmux actor current --json` 返回版本化的 `botmux.current-actor.v2` 文档；成功时 `actor` 精确只有一个字段：

```json
{
  "schema": "botmux.current-actor.v2",
  "status": "verified",
  "actor": { "email": "user@example.com" }
}
```

- email 实时取自 Contact API，并规范化为 trim 后的小写形式
- 仅校验基本邮箱结构，不在 BotMux 内硬编码任何租户域名或下游业务策略
- 域名白名单、账号映射等策略由调用方按自身场景处理

## 实现

- 新增 `botmux actor current --json`，并在 `botmux capabilities --json` 中声明 `current_actor_v2`
- daemon 从当前 turn 的 reply target 读取 sender，并通过实时 Contact API 解析身份
- 查询绑定活跃 session、worker generation、CLI PID/starttime、当前 turn capability 和实时进程链
- Contact API 查询完成后再次校验上述状态，避免查询期间发生 turn 或 worker 切换
- CLI 只转发 daemon 结果，不提供本地身份 fallback

## 信任边界

本实现解决的是共享 BotMux 会话中不同发信人之间的身份隔离。同一 OS UID 下的本地进程仍属于 BotMux 当前运行时信任域；如果未来需要抵御该信任域内的主动篡改，需要再引入独立的系统级认证边界。

## 验证

- `corepack pnpm build`
- Actor、capability 与 CLI 定向回归：8 个测试文件，87 项测试通过
- 覆盖当前 sender、旧 turn、跨 session、worker generation、CLI 进程链、实时身份解析、email-only 契约及 capability/CLI 契约
- 变异验证：强制放行 lineage guard 时对应两个拒绝用例失败；删除 sender 漂移复检时最小差异用例失败

## 最新对象

- head：`1db4db3b2a0c96934ee73b985696be2cbc4d0c1e`
- tree：`f599c5611aa492d724ad6316f1dde1fde4b7cee2`
- base：`9c19530f4cd0d6ad328edde480a6c5945d2766ec`