### PR TITLE
fix(dsh): 软链接安装的 dsh-jsonrpc-agent 在 sandbox=true 下启动 ENOENT

### DIFF
--- a/src/adapters/cli/dsh.ts
+++ b/src/adapters/cli/dsh.ts
@@ -1,10 +1,28 @@
 import { fileURLToPath } from 'node:url';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { resolveCommand } from './registry.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
+
+/**
+ * Resolve the dsh binary to its REAL (symlink-followed) path.
+ *
+ * `resolveCommand` returns the raw entry as found on PATH — which is commonly a
+ * symlink (e.g. `~/.local/bin/dsh-jsonrpc-agent` → the SDK's package dir), and
+ * the user's HOME may itself be a symlink (`/home/x` → `/data00/home/x`). The
+ * file sandbox only exposes the CANONICAL target dir read-only (worker.ts maps
+ * exec paths through `dirname(canonical(p))`), so a spawn against the original
+ * symlink path ENOENTs inside the sandbox. Canonicalizing here makes the path we
+ * hand the runner (`--dsh-bin`) identical to the one the sandbox authorized, so
+ * the in-sandbox spawn resolves. Falls back to the raw path if realpath fails
+ * (binary genuinely absent — surfaces the same ENOENT as before, unmasked).
+ */
+function realResolveCommand(cmd: string): string {
+  const resolved = resolveCommand(cmd);
+  try { return realpathSync(resolved); } catch { return resolved; }
+}
 
 function runnerPath(): string {
   // Source-level worker integration tests execute through tsx and need the
@@ -45,12 +63,14 @@ export function createDshAdapter(pathOverride?: string): CliAdapter {
     resolvedBin: process.execPath,
 
     // resolvedBin is node-running-the-runner; the real dsh runtime is spawned
-    // by the runner. Declare it so the file sandbox can re-expose its bin dir
-    // when it lives under /run (fnm/nvm) — else --tmpfs /run masks it and the
-    // in-sandbox spawn ENOENTs into a crash-loop. Same lazy resolve+cache as
+    // by the runner. Declare its CANONICAL path so the file sandbox re-exposes
+    // its bin dir when it lives under /run (fnm/nvm) — else --tmpfs /run masks
+    // it and the in-sandbox spawn ENOENTs into a crash-loop. Must match the
+    // path handed to --dsh-bin below (both canonical via realResolveCommand) so
+    // the authorized dir and the spawned path agree. Same lazy resolve+cache as
     // buildArgs; only an executable path, never the cwd.
     sandboxExtraExecPaths() {
-      return [(cachedDshBin ??= resolveCommand(rawDshBin))];
+      return [(cachedDshBin ??= realResolveCommand(rawDshBin))];
     },
 
     buildArgs({ sessionId, workingDir, botName, botOpenId, locale, model }) {
@@ -61,7 +81,7 @@ export function createDshAdapter(pathOverride?: string): CliAdapter {
       const args = [
         runnerPath(),
         '--session-id', sessionId,
-        '--dsh-bin', (cachedDshBin ??= resolveCommand(rawDshBin)),
+        '--dsh-bin', (cachedDshBin ??= realResolveCommand(rawDshBin)),
       ];
       pushOpt(args, '--cwd', workingDir);
       pushOpt(args, '--bot-name', botName);

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mkdirSync, rmSync, appendFileSync } from 'node:fs';
+import { mkdirSync, rmSync, appendFileSync, mkdtempSync, writeFileSync, symlinkSync, realpathSync } from 'node:fs';
 import { codexHome } from '../src/services/codex-paths.js';
 
 // ---------------------------------------------------------------------------
@@ -604,6 +604,36 @@ describe('dsh buildArgs (runner model)', () => {
 
   it('advertises the deepseek model choices', () => {
     expect(adapter.modelChoices).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro']);
+  });
+
+  it('canonicalizes a symlinked bin so --dsh-bin matches the sandbox-authorized path', () => {
+    // Regression: a symlink-installed dsh-jsonrpc-agent (e.g. ~/.local/bin →
+    // SDK package dir) plus a symlinked HOME made the runner spawn the raw
+    // symlink path, which the file sandbox never exposes (it authorizes only
+    // dirname(realpath(bin))) → `spawn ... ENOENT` crash-loop under sandbox=true.
+    // Both --dsh-bin and sandboxExtraExecPaths() must resolve to the real target.
+    const root = mkdtempSync(join(tmpdir(), 'dsh-symlink-'));
+    try {
+      const realDir = join(root, 'opt', 'runtime');
+      mkdirSync(realDir, { recursive: true });
+      const realBin = join(realDir, 'dsh-jsonrpc-agent-pkg-linux-x64');
+      writeFileSync(realBin, '#!/bin/sh\n', { mode: 0o755 });
+      const linkDir = join(root, 'local', 'bin');
+      mkdirSync(linkDir, { recursive: true });
+      const linkBin = join(linkDir, 'dsh-jsonrpc-agent');
+      symlinkSync(realBin, linkBin);
+
+      const symlinkAdapter = createDshAdapter(linkBin);
+      const canonicalReal = realpathSync(realBin);
+
+      const args = symlinkAdapter.buildArgs({ sessionId: 's', resume: false });
+      const binIdx = args.indexOf('--dsh-bin');
+      expect(binIdx).toBeGreaterThanOrEqual(0);
+      expect(args[binIdx + 1]).toBe(canonicalReal);
+      expect(symlinkAdapter.sandboxExtraExecPaths?.()).toEqual([canonicalReal]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('writeInput frames content with the dsh marker', async () => {


### PR DESCRIPTION
## 问题

启用文件 sandbox（`sandbox=true`）且 `dsh-jsonrpc-agent` 以**软链接**方式安装时，DSH runner 启动即崩溃：

```
dsh runner failed: spawn /home/x/.local/bin/dsh-jsonrpc-agent ENOENT
```

Harness 从未 ready，模型服务也收不到请求，Botmux 反复重试后停在诊断面板。关闭 sandbox 后同样配置端到端成功，故与方舟 endpoint / 模型 / API key / 工作目录均无关。

## 根因

- `dsh.ts` 通过 `resolveCommand()` 拿到的是 PATH 上的**原始软链接路径**（`~/.local/bin/dsh-jsonrpc-agent`），并直接作为 `--dsh-bin` 传给 runner；runner 对该路径 `spawn()`。
- 但 `worker.ts` 构建 sandbox 授权目录时走的是 `dirname(realpath(bin))`（execDirs），只把**软链接解析后的真实目录**挂成只读。
- 结果：sandbox 内 `spawn(原始软链接路径)` 没有对应的绑定源 → `ENOENT`。当用户 HOME 本身也是软链接（`/home/x → /data00/home/x`）时，整条软链接入口都未暴露，问题必现。

即：**软链接入口路径** 与 **canonicalized sandbox 授权路径** 不一致。

## 改动

- 新增 `realResolveCommand()`：在 `resolveCommand()` 之后再 `realpathSync()` 跟随一次软链接；realpath 失败则回退原路径（二进制真缺失时报同样的 ENOENT，不被掩盖）。
- `--dsh-bin` 与 `sandboxExtraExecPaths()` 两处统一改用它，使**交给 runner 的执行路径** == **sandbox 授权路径**。
- 未放开 `~/.local` 等更大目录，sandbox 文件访问面不变（对应原 issue 的方案 1，最小改动）。

改动文件：`src/adapters/cli/dsh.ts`、`test/cli-adapters.test.ts`，共 +57 / -7。

## 验证

- 新增回归用例：真实创建「软链接 bin → 真实目标」，断言 `--dsh-bin` 与 `sandboxExtraExecPaths()` 均返回 canonical 目标路径。
- `test/cli-adapters.test.ts` + `test/dsh-runner.test.ts` 全绿（364 tests）。
- `tsc --noEmit` 全量无报错。

## 仍未验证

| 剩余检查 | 需要的环境 / 原因 | 影响范围 |
| --- | --- | --- |
| `sandbox=true` 真机端到端（软链接 bin + 软链接 HOME，走到 JSON-RPC 握手 ready、`~/.dsh` 可读写而未授权 HOME 仍不可访问） | 需 Linux + bwrap + 真实 dsh 运行时的复现机；本地 macOS 无对应环境 | 阻塞发布，不阻塞合并 |
| `test/worker-dsh-turn.integration.test.ts` 的 sandbox 用例 | 该用例在 **pristine master 上于本地 macOS 同样超时失败**，属既有环境限制（无法建立 sandbox 命名空间），非本 PR 引入 | 不阻塞 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
