### PR TITLE
fix(adopt): 恢复休眠及已关闭的 Botmux 会话

### DIFF
--- a/src/cli/session-list-wake.ts
+++ b/src/cli/session-list-wake.ts
@@ -22,8 +22,18 @@ export function canWakeDormantBackendForAttach(input: {
   attachBackend?: 'tmux' | 'zmx';
   target?: PersistentBackendTarget;
 }): boolean {
+  // tmux 3.6b on macOS reports an absent server socket as a connection-level
+  // failure, which the shared destructive probe correctly keeps `unknown`:
+  // another process could still own an unreachable/unlinked server. A picker
+  // wake is different — it does not claim the old pane is dead or delete it.
+  // The owning daemon serializes the attempt, an existing worker wins as
+  // `already_running`, and tmux session-name uniqueness fences a reachable old
+  // pane. Keep ZMX unknown fail-closed because its attach identity is PID/label
+  // sensitive rather than name-fenced by one shared server.
+  const recoverableProbe = input.probe === 'missing'
+    || (input.probe === 'unknown' && input.attachBackend === 'tmux');
   return !input.isAdopt
-    && input.probe === 'missing'
+    && recoverableProbe
     && input.realManagedSession
     && !!input.attachBackend
     && !!input.target;

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -93,7 +93,7 @@ import {
 } from '../services/role-profile-store.js';
 import type { LarkMessage, DaemonToWorker, CodexAppTurnInput, FrozenSessionReplyTarget, ScheduleExecutionPosition, SessionCliLaunchSnapshotV1 } from '../types.js';
 import type { ResolvedSender } from '../im/lark/identity-cache.js';
-import { activeSessionKey, sessionKey, sessionAnchorId, markRepoCardConsumed, claimCurrentRepoCard } from './types.js';
+import { activeSessionKey, sessionKey, sessionAnchorId, storedSessionAnchorId, markRepoCardConsumed, claimCurrentRepoCard } from './types.js';
 import type { DaemonSession } from './types.js';
 import { t, localeForBot, type Locale } from '../i18n/index.js';
 import { runSkillsImCommand } from './skills/im-command.js';
@@ -109,6 +109,7 @@ import {
   sessionConfiguredRuntimeDisplayName,
 } from './cli-runtime-display.js';
 import { isSessionGroup } from '../services/session-groups-store.js';
+import { resumeStartsFresh } from '../services/resume-fresh-policy.js';
 
 // ─── Exported constants ──────────────────────────────────────────────────────
 
@@ -3101,9 +3102,7 @@ export async function handleCommand(
           const managedTarget = sessionStore.getOwnedSession(directTarget)
             ?? sessionStore.listSessions().find(s => s.cliSessionId === directTarget);
           if (managedTarget) {
-            const managedAnchor = managedTarget.scope === 'chat'
-              ? managedTarget.chatId
-              : managedTarget.rootMessageId;
+            const managedAnchor = storedSessionAnchorId(managedTarget);
             if (!ds || !adoptAnchor || managedAnchor !== adoptAnchor) {
               await sessionReply(rootId, t('cmd.adopt.managed_other_topic', {
                 id: managedTarget.sessionId,
@@ -3113,9 +3112,11 @@ export async function handleCommand(
 
             const result = await resumeSession(managedTarget.sessionId, activeSessions);
             if (result.ok) {
-              await sessionReply(rootId, t('card.action.resume_success', {
-                cliName: sessionCliDisplayName(result.ds),
-              }, localeForBot(result.ds.larkAppId)));
+              const cliName = sessionCliDisplayName(result.ds);
+              const resumeMsg = resumeStartsFresh(result.ds.session)
+                ? t('card.action.resume_success_fresh', { cliName }, localeForBot(result.ds.larkAppId))
+                : t('card.action.resume_success', { cliName }, localeForBot(result.ds.larkAppId));
+              await sessionReply(rootId, resumeMsg);
             } else if (result.error === 'not_closed') {
               await sessionReply(rootId, t('card.action.resume_not_closed', undefined, loc));
             } else if (result.error === 'anchor_occupied') {

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -37,6 +37,7 @@ import {
   buildNewTopicCliInput,
   ensureSessionWhiteboard,
   getAvailableBots,
+  resumeSession,
 } from './session-manager.js';
 import { markInitialUserTurnPending } from './initial-user-turn.js';
 import { discoverSlashCommandsForAdapter, listMcpServerNames, supportsFilesystemCommandDiscovery } from './command-discovery.js';
@@ -3090,6 +3091,50 @@ export async function handleCommand(
         const botCliId = botCfgForAdopt?.cliId;
         const adoptSession = ds?.session;
         const adoptAnchor = ds ? sessionAnchorId(ds) : undefined;
+        const directTarget = adoptArgs;
+
+        // The picker deliberately hides Botmux-managed history, but an exact
+        // id is explicit user intent. Resume the original closed record here;
+        // importing its CLI transcript into this command scratch would create
+        // two Botmux owners for one underlying history session.
+        if (directTarget) {
+          const managedTarget = sessionStore.getOwnedSession(directTarget)
+            ?? sessionStore.listSessions().find(s => s.cliSessionId === directTarget);
+          if (managedTarget) {
+            const managedAnchor = managedTarget.scope === 'chat'
+              ? managedTarget.chatId
+              : managedTarget.rootMessageId;
+            if (!ds || !adoptAnchor || managedAnchor !== adoptAnchor) {
+              await sessionReply(rootId, t('cmd.adopt.managed_other_topic', {
+                id: managedTarget.sessionId,
+              }, loc));
+              break;
+            }
+
+            const result = await resumeSession(managedTarget.sessionId, activeSessions);
+            if (result.ok) {
+              await sessionReply(rootId, t('card.action.resume_success', {
+                cliName: sessionCliDisplayName(result.ds),
+              }, localeForBot(result.ds.larkAppId)));
+            } else if (result.error === 'not_closed') {
+              await sessionReply(rootId, t('card.action.resume_not_closed', undefined, loc));
+            } else if (result.error === 'anchor_occupied') {
+              const detail = result.activeSessionId
+                ? t('card.action.resume_anchor_holder', { short: result.activeSessionId.substring(0, 8) }, loc)
+                : '';
+              await sessionReply(rootId, t('card.action.resume_anchor_occupied', { detail }, loc));
+            } else if (result.error === 'adopt_unsupported') {
+              await sessionReply(rootId, t('card.action.resume_adopt_unsupported', undefined, loc));
+            } else if (result.error === 'deferred_unmaterialized') {
+              await sessionReply(rootId, t('card.action.resume_deferred_unmaterialized', undefined, loc));
+            } else if (result.error === 'resume_cancelled') {
+              await sessionReply(rootId, t('card.action.resume_cancelled', undefined, loc));
+            } else {
+              await sessionReply(rootId, t('cmd.adopt.resume_not_found', undefined, loc));
+            }
+            break;
+          }
+        }
 
         // Discover every supported backend, but only offer live sessions for
         // this bot's configured CLI. A Pi bot must not show Codex/TRAE panes:
@@ -3128,7 +3173,6 @@ export async function handleCommand(
           break;
         }
 
-        const directTarget = adoptArgs;
         if (directTarget) {
           // Match a tmux address ("session:window.pane") OR a zellij target
           // ("session:paneId" / "session/paneId") against the merged list.

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -419,6 +419,7 @@ export const messages: Record<string, string> = {
   'cmd.adopt.success': '📡 Adopted {cliName} · {project} ({pane})',
   'cmd.adopt.resume_success': '↩️ Resumed {cliName} session · {project} — “{title}”',
   'cmd.adopt.resume_not_found': '⚠️ That past session no longer exists or is already in use.',
+  'cmd.adopt.managed_other_topic': '⚠️ That ID belongs to a Botmux session in another topic and cannot be moved here with /adopt. Resume it from the original topic, or run `botmux resume {id}` locally.',
   'cmd.detach.success': '⏏ Disconnected. The original CLI session is untouched.',
   'cmd.detach.existing_app_server_success': '⏏ Disconnected BotMux’s remote Codex client. The development-machine App Server and Codex App conversation are still running.',
   'cmd.detach.failed': '⚠️ BotMux could not safely disconnect this shared entry. The original Codex App conversation is unaffected; please retry shortly.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -420,6 +420,7 @@ export const messages: Record<string, string> = {
   'cmd.adopt.success': '📡 已接入 {cliName} · {project} ({pane})',
   'cmd.adopt.resume_success': '↩️ 已恢复 {cliName} 历史会话 · {project} —「{title}」',
   'cmd.adopt.resume_not_found': '⚠️ 该历史会话已不存在或已被占用。',
+  'cmd.adopt.managed_other_topic': '⚠️ 该 ID 是另一个话题的 Botmux 会话，不能用 /adopt 搬到当前话题。请到原话题点击「恢复会话」，或在本机运行 `botmux resume {id}`。',
   'cmd.detach.success': '⏏ 已断开，原 CLI 会话不受影响',
   'cmd.detach.existing_app_server_success': '⏏ 已断开飞书侧的 Codex 远程客户端；开发机 App Server 和 Codex App 会话仍在运行。',
   'cmd.detach.failed': '⚠️ 未能安全断开 BotMux 共享入口；原 Codex App 会话未受影响，请稍后重试。',

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -160,6 +160,8 @@ vi.mock('../src/services/session-store.js', () => ({
   })),
   updateSession: vi.fn(),
   getSession: vi.fn(() => undefined),
+  getOwnedSession: vi.fn(() => undefined),
+  listSessions: vi.fn(() => []),
   collectBotmuxSessionIdentities: vi.fn(() => new Set<string>()),
 }));
 
@@ -358,6 +360,7 @@ vi.mock('../src/core/session-manager.js', () => ({
   buildNewTopicCliInput: vi.fn((prompt: string) => ({ content: `WRAPPED:${prompt}` })),
   ensureSessionWhiteboard: vi.fn((ds: any) => { ds.session.whiteboardId = 'wb_test'; }),
   getAvailableBots: vi.fn(async () => []),
+  resumeSession: vi.fn(),
 }));
 
 // Only the two discovery/validation entrypoints are stubbed; keep the real
@@ -520,7 +523,7 @@ import { dashboardEventBus, type DashboardEvent } from '../src/core/dashboard-ev
 import { publishClosedSessionPatch } from '../src/core/session-activity.js';
 import { getOwnerOpenId } from '../src/bot-registry.js';
 import { canOperate } from '../src/im/lark/event-dispatcher.js';
-import { getSessionWorkingDir, buildNewTopicPrompt, buildNewTopicCliInput, ensureSessionWhiteboard, getAvailableBots } from '../src/core/session-manager.js';
+import { getSessionWorkingDir, buildNewTopicPrompt, buildNewTopicCliInput, ensureSessionWhiteboard, getAvailableBots, resumeSession } from '../src/core/session-manager.js';
 import * as sessionStore from '../src/services/session-store.js';
 import * as scheduleStore from '../src/services/schedule-store.js';
 import * as scheduler from '../src/core/scheduler.js';
@@ -1539,6 +1542,9 @@ describe('handleCommand', () => {
     vi.mocked(forkSession).mockResolvedValue({ ok: true, childSessionId: 'child-sess-1' });
     vi.mocked(isForkCapableSession).mockReturnValue(true);
     vi.mocked(sessionStore.getSession).mockReturnValue(undefined);
+    vi.mocked(sessionStore.getOwnedSession).mockReturnValue(undefined);
+    vi.mocked(sessionStore.listSessions).mockReturnValue([]);
+    vi.mocked(resumeSession).mockReset();
   });
 
   describe('/fork sub-topic', () => {
@@ -4722,6 +4728,88 @@ describe('handleCommand', () => {
       expect(discoverAdoptableSessions).toHaveBeenCalledWith('claude-code');
       const replyContent = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
       expect(replyContent).toContain('未发现可接入');
+    });
+
+    it('resumes an exact closed Botmux session id instead of treating it as a tmux pane', async () => {
+      const scratch = makeDaemonSession({
+        hasHistory: false,
+        session: makeSession({ sessionId: 'scratch-session', cliId: undefined }),
+      });
+      const restored = makeDaemonSession({
+        session: makeSession({
+          sessionId: 'ad24e30d-25fa-4450-8e84-9e108cb74c92',
+          status: 'active',
+          cliId: 'claude-code',
+          cliSessionId: 'ad24e30d-25fa-4450-8e84-9e108cb74c92',
+        }),
+      });
+      const closed = {
+        ...restored.session,
+        status: 'closed' as const,
+      };
+      vi.mocked(sessionStore.getOwnedSession).mockReturnValueOnce(closed);
+      vi.mocked(resumeSession).mockResolvedValueOnce({ ok: true, ds: restored });
+      const deps = makeDeps(scratch);
+
+      await handleCommand(
+        '/adopt',
+        ROOT_ID,
+        makeLarkMessage('/adopt ad24e30d-25fa-4450-8e84-9e108cb74c92'),
+        deps,
+        LARK_APP_ID,
+      );
+
+      expect(resumeSession).toHaveBeenCalledWith(closed.sessionId, deps.activeSessions);
+      expect(discoverAdoptableSessions).not.toHaveBeenCalled();
+      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      expect(reply).toContain('会话已恢复');
+      expect(reply).not.toContain('tmux pane');
+    });
+
+    it('resolves a closed Botmux session by its CLI-native id without duplicating ownership', async () => {
+      const scratch = makeDaemonSession({
+        hasHistory: false,
+        session: makeSession({ sessionId: 'scratch-session', cliId: undefined }),
+      });
+      const closed = makeSession({
+        sessionId: 'botmux-session-id',
+        status: 'closed',
+        cliId: 'codex',
+        cliSessionId: 'native-thread-id',
+      });
+      const restored = makeDaemonSession({ session: { ...closed, status: 'active' } });
+      vi.mocked(sessionStore.listSessions).mockReturnValueOnce([closed]);
+      vi.mocked(resumeSession).mockResolvedValueOnce({ ok: true, ds: restored });
+      const deps = makeDeps(scratch);
+
+      await handleCommand('/adopt', ROOT_ID, makeLarkMessage('/adopt native-thread-id'), deps, LARK_APP_ID);
+
+      expect(resumeSession).toHaveBeenCalledWith('botmux-session-id', deps.activeSessions);
+      expect(forkWorker).not.toHaveBeenCalled();
+      expect((deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1]).not.toContain('tmux pane');
+    });
+
+    it('does not move a managed session from another topic through /adopt', async () => {
+      const scratch = makeDaemonSession({
+        hasHistory: false,
+        session: makeSession({ sessionId: 'scratch-session', cliId: undefined }),
+      });
+      const closed = makeSession({
+        sessionId: 'other-topic-session',
+        status: 'closed',
+        rootMessageId: 'om_other_topic',
+        cliSessionId: 'native-other-topic',
+      });
+      vi.mocked(sessionStore.getOwnedSession).mockReturnValueOnce(closed);
+      const deps = makeDeps(scratch);
+
+      await handleCommand('/adopt', ROOT_ID, makeLarkMessage('/adopt other-topic-session'), deps, LARK_APP_ID);
+
+      expect(resumeSession).not.toHaveBeenCalled();
+      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      expect(reply).toContain('另一个话题');
+      expect(reply).toContain('botmux resume other-topic-session');
+      expect(reply).not.toContain('tmux pane');
     });
 
     it('passes the bot current custom Codex executable into live adopt discovery', async () => {

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -4812,6 +4812,77 @@ describe('handleCommand', () => {
       expect(reply).not.toContain('tmux pane');
     });
 
+    it('does not resume a materialized scheduled run from the containing chat anchor', async () => {
+      const scratch = makeDaemonSession({
+        scope: 'chat',
+        chatId: CHAT_ID,
+        hasHistory: false,
+        session: makeSession({
+          sessionId: 'scratch-session',
+          scope: 'chat',
+          chatId: CHAT_ID,
+          cliId: undefined,
+        }),
+      });
+      const closed = makeSession({
+        sessionId: 'materialized-schedule-run',
+        status: 'closed',
+        scope: 'chat',
+        chatId: CHAT_ID,
+        rootMessageId: 'om_materialized_root',
+        deferredScheduleRun: {
+          taskId: 'task-1',
+          turnId: 'schedule:task-1:run-1',
+          routingAnchor: 'schedule-run:task-1:run-1',
+          createdAt: '2026-08-27T00:00:00.000Z',
+        },
+      });
+      vi.mocked(sessionStore.getOwnedSession).mockReturnValueOnce(closed);
+      const deps = makeDeps(scratch);
+
+      await handleCommand(
+        '/adopt',
+        ROOT_ID,
+        makeLarkMessage('/adopt materialized-schedule-run'),
+        deps,
+        LARK_APP_ID,
+      );
+
+      expect(resumeSession).not.toHaveBeenCalled();
+      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      expect(reply).toContain('另一个话题');
+    });
+
+    it('says when an exact managed session will resume as a fresh CLI session', async () => {
+      const scratch = makeDaemonSession({
+        hasHistory: false,
+        session: makeSession({ sessionId: 'scratch-session', cliId: undefined }),
+      });
+      const closed = makeSession({
+        sessionId: 'cursor-without-native-id',
+        status: 'closed',
+        cliId: 'cursor',
+        cliSessionId: undefined,
+      });
+      const restored = makeDaemonSession({ session: { ...closed, status: 'active' } });
+      vi.mocked(sessionStore.getOwnedSession).mockReturnValueOnce(closed);
+      vi.mocked(resumeSession).mockResolvedValueOnce({ ok: true, ds: restored });
+      const deps = makeDeps(scratch);
+
+      await handleCommand(
+        '/adopt',
+        ROOT_ID,
+        makeLarkMessage('/adopt cursor-without-native-id'),
+        deps,
+        LARK_APP_ID,
+      );
+
+      expect(resumeSession).toHaveBeenCalledWith(closed.sessionId, deps.activeSessions);
+      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      expect(reply).toContain('新起干净会话');
+      expect(reply).toContain('旧上下文不会带回');
+    });
+
     it('passes the bot current custom Codex executable into live adopt discovery', async () => {
       vi.mocked(getBot).mockImplementation((() => ({
         botName: 'Vendor Codex',

--- a/test/session-list-wake.test.ts
+++ b/test/session-list-wake.test.ts
@@ -9,7 +9,7 @@ const target = { backendType: 'tmux' as const, sessionName: 'bmx-deadbeef' };
 afterEach(() => vi.useRealTimers());
 
 describe('botmux list dormant backend wake', () => {
-  it('offers recovery only for a missing Botmux-managed attachable backend', () => {
+  it('offers recovery for missing backends and an inconclusive tmux control plane', () => {
     expect(canWakeDormantBackendForAttach({
       isAdopt: false,
       probe: 'missing',
@@ -23,6 +23,13 @@ describe('botmux list dormant backend wake', () => {
       realManagedSession: true,
       attachBackend: 'tmux',
       target,
+    })).toBe(true);
+    expect(canWakeDormantBackendForAttach({
+      isAdopt: false,
+      probe: 'unknown',
+      realManagedSession: true,
+      attachBackend: 'zmx',
+      target: { backendType: 'zmx', sessionName: 'bmx-deadbeef' },
     })).toBe(false);
     expect(canWakeDormantBackendForAttach({
       isAdopt: true,


### PR DESCRIPTION
## 问题

- tmux 探针返回 `unknown` 时，`botmux ls` 会把仍可由 owner daemon 冷恢复的受管会话判成无可运行后端并禁止选中。
- `/adopt <Botmux session UUID>` 指向已关闭会话时，旧路径会把 UUID 当成 tmux pane，误报 `tmux pane not found`。

## 修复

- 仅对真实受管、目标完整的 tmux 会话，允许列表在 `unknown` 探针下请求 owner daemon 唤醒；ZMX、全局记录和不完整目标继续 fail closed。
- `/adopt` 收到精确 Botmux session ID 或 CLI session ID 时，先解析受管历史记录；只允许从权威 `storedSessionAnchorId()` 对应的原路由恢复，避免把定时轮次复活到用户发不到消息的虚拟锚点。
- 精确恢复沿用现有 resume 语义：当前 bot 仍按自身 CLI 配置启动；若 adapter 必须依赖原生 session ID 而记录中没有该 ID，回执明确提示下条消息会新起干净会话。

## 验证

- `bun x vitest run --project unit test/command-handler.test.ts`（293 passed）
- `bun x vitest run --project unit test/tmux-probe.test.ts test/session-list-wake.test.ts test/session-resume.test.ts test/resume-fresh-policy.test.ts`（71 passed）
- `bun run build`
- `git diff --check`

## 不在本 PR 范围

Codex `already has an active writer` 冲突处理保持不变。