### PR TITLE
fix(smoke): 收尾回收 supervisor 拉起的成员，不再留 orphan dashboard

### DIFF
--- a/scripts/smoke-bun-binary.mjs
+++ b/scripts/smoke-bun-binary.mjs
@@ -80,9 +80,66 @@ const childEnv = {
 };
 
 let supervisor;
+
+/**
+ * Reap the supervisor AND the members it spawned.
+ *
+ * WHY THE MEMBERS NEED EXPLICIT HANDLING: cleanup used to SIGKILL only the
+ * supervisor. SIGKILL is not catchable, so the supervisor never got to stop its
+ * own children — the `__dashboard` member it had spawned survived as an orphan.
+ * Observed on EVERY run, including passing ones: the GitHub runner reported
+ * `Terminate orphan process: pid (2717) (botmux-linux-x64)` while tearing the
+ * job down. Harmless on an ephemeral runner, but on a developer machine it
+ * leaves a stray dashboard holding its port, and it means this script does not
+ * actually clean up after itself.
+ *
+ * Order matters: SIGTERM first so the supervisor stops its members the way it
+ * normally would, then a bounded wait, then SIGKILL whatever is still alive —
+ * members first (read out of fleet-state, which records their pids), so nothing
+ * is left parentless. Every step is best-effort: cleanup runs on the failure
+ * path too and must never throw over an already-dead process.
+ */
+const memberPids = () => {
+  try {
+    const state = JSON.parse(readFileSync(join(home, '.botmux', 'fleet-state.json'), 'utf-8'));
+    return (state.procs ?? [])
+      .map((p) => p?.pid)
+      .filter((pid) => typeof pid === 'number' && pid > 0);
+  } catch {
+    return []; // no state file yet, or unreadable — nothing we can target
+  }
+};
+
+const alive = (pid) => {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+};
+
+/** Block the thread briefly. cleanup() runs from exit paths where an `await`
+ *  would never be honoured, so the wait for the supervisor to exit has to be
+ *  synchronous. Atomics.wait on a throwaway buffer is the standard way to sleep
+ *  without spawning anything. */
+const sleepSync = (ms) => {
+  try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); }
+  catch { /* SharedArrayBuffer unavailable — skip the grace period */ }
+};
+
 const cleanup = () => {
+  const members = memberPids();
   if (supervisor && supervisor.exitCode === null) {
-    try { supervisor.kill('SIGKILL'); } catch { /* already gone */ }
+    // Graceful first: lets the supervisor tear down its own members.
+    try { supervisor.kill('SIGTERM'); } catch { /* already gone */ }
+    const deadline = Date.now() + 3_000;
+    while (supervisor.exitCode === null && Date.now() < deadline) sleepSync(100);
+    if (supervisor.exitCode === null) {
+      try { supervisor.kill('SIGKILL'); } catch { /* already gone */ }
+    }
+  }
+  // Sweep any member the supervisor did not manage to stop (it may itself have
+  // been SIGKILLed, or died before handling the SIGTERM).
+  for (const pid of members) {
+    if (alive(pid)) {
+      try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+    }
   }
   try { rmSync(home, { recursive: true, force: true }); } catch { /* best-effort */ }
 };


### PR DESCRIPTION
## 改了什么

`scripts/smoke-bun-binary.mjs` 的 `cleanup()` 原先只对 supervisor 发 `SIGKILL`。SIGKILL 不可捕获，supervisor 没有机会停掉自己的成员，它 spawn 出来的 `__dashboard` 就变成孤儿活了下来。

改为：先 `SIGTERM` 让 supervisor 按正常方式停成员 → 有界等待 3s → 仍在则 `SIGKILL`；随后从 `fleet-state` 读出成员 pid 兜底清扫（supervisor 自己可能被 SIGKILL、或在处理 SIGTERM 前就死了）。

等待用 `Atomics.wait` **同步**阻塞：`cleanup()` 从进程退出路径调用，`await` 不会被执行。

## 为什么

这个残留在**每次**运行都有，包括全绿的那些 —— GitHub runner 收尾时会打：

```
Terminate orphan process: pid (2717) (botmux-linux-x64)
```

在一次性 runner 上无害，但在开发机上会留一个占着 dashboard 端口的进程，而且意味着这个脚本并没有真的清理干净自己。

## 影响面

只动验证脚本，**不碰产品代码**：`scripts/smoke-bun-binary.mjs` 一个文件。该脚本被 `ci.yml` 的 `bun-binary` job 与 `release.yml` 的 `bun-binaries` 矩阵共用，所以两处的收尾都一并变干净。不涉及任何 CLI 适配器 / 后端 / 平台差异。

## 实际测试验证

编译真实 linux-x64 二进制后，按 `/proc/<pid>/cmdline` 精确统计 `__dashboard` 进程数（不用 `pgrep -f`，松散 pattern 会匹配到验证脚本自己的 shell wrapper）：

**修复后**
```
跑 smoke 前的 __dashboard 进程数: 0
smoke: ✅ capabilities — CLI graph loads
smoke: ✅ version — binary reports 0.0.0-orph.1 (not the "unknown" sentinel)
smoke: ✅ self-spawn — supervisor alive, spawned __dashboard (pid 688420)
smoke: ✅ dashboard — booted clean (0 restarts), embedded modules resolve
smoke: ✅ http — dashboard is serving (status 404)
smoke: ✅ self-destruct guard — binary intact at the wrapper path (135726280 bytes)
smoke: all checks passed
跑完后的 __dashboard 进程数: 0
✓ 无 orphan 残留
```

**反向变异**（把 `cleanup` 退回「只 SIGKILL supervisor」重跑，确认这个判据有牙）
```
跑完后的 __dashboard 进程数: 1
🔴 残留 1 个 orphan
  pid 705111: /tmp/orphan-test/botmux __dashboard
```
复现了线上现象；换回修复版即回到 0。