### PR TITLE
docs(claude): 写清 worktree 共享 node_modules 的两个实测风险 + bun 在 worktree 下可用

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,30 @@ pnpm build:bun            # 打自包含单文件二进制（scripts/build-bun-b
 
 **测试里 spawn 子进程必须走 `test/helpers/ts-runner.ts`**，不要写 `spawn(process.execPath, ['--import','tsx', …])`：那是 Node-only 形态，Bun 下 `process.execPath` 是 bun 二进制、`bun --import tsx` 不合法，子进程会全部起不来。helper 按运行时解析（Node 加 tsx loader、Bun 原生跑 TS）。片段里 import 仓库模块（`.js` specifier 实际是 `.ts`）时用 `spawnTsEvalWithRepoImports`，普通 `spawnTsEval` 在 Node 下会 ERR_MODULE_NOT_FOUND。
 
+worktree 里也能直接用 bun，且**不额外占依赖体积**——只要不跑 install（见下节）。`bun run <script>` 可以代替 `pnpm run <script>`。实测在「源码 + `node_modules` symlink 到 canonical」的 worktree 里，`bun src/cli.ts`、`bun run build`、`tsc`、`vitest`、`build:bun`（`pty.node` 经 symlink 解析，不复制）以及编出二进制跑 smoke 六项，全部正常。
+
+### worktree 的 node_modules：共享还是独立（改前必读）
+
+worktree 的 `node_modules` **形态不统一**，是逐个手工决定的，不是包管理器行为：
+
+| 形态 | 体积 | 风险 |
+|---|---|---|
+| symlink → canonical | 0 字节 | 见下面两条 🔴 |
+| 独立 `pnpm install` | ~750M | 安全，互不影响 |
+
+**🔴 铁律：绝不在 worktree 里跑任何 install（`pnpm install` / `bun install` 都算）。** 理由不是「浪费一次重装」，是下面两条实测出来的后果——而且它们**与包管理器无关**，bun 和 pnpm 在「穿透 symlink 写进被指向目录」上逐字同构：
+
+1. **两个 worktree 同时 symlink 到同一个目标时，`pnpm install` 会失败并把共享目录删掉**：
+   ```
+   ENOTDIR: not a directory, mkdir '<worktree>/node_modules'
+   → 目标目录被删除
+   ```
+   单个 symlink 时 exit 0、目标完好；双 symlink 指同一目标时 exit 236 且目标被清掉（`bun install` 同场景 exit 0、目标完好）。canonical 的 `node_modules` 是 ~50 个 live daemon 的依赖来源——`/proc/<pid>/maps` 里能看到它们 mmap 着 `node_modules/.pnpm/node-pty@*/…/pty.node`。已在跑的进程靠 inode 存活不会立刻崩，但**任何重启、spawn worker、或新起 CLI 会话都会失败**，等于 fleet 不可恢复。
+
+2. **共享依赖时，后装的 worktree 会静默覆盖先装的版本**：A 要 `ms@2.1.3`、B 要 `ms@2.0.0`、共享同一 `node_modules` → B 装完后 **A 解析到 `2.0.0`**，而 A 的 `package.json` 写的是 `2.1.3`。**exit 0，零报错零警告**，症状会在完全无关的地方冒出来。
+
+所以：**依赖需求与 canonical 完全一致**时才用 symlink（省 750M）；一旦分支动了 `package.json` / lockfile，就该独立 install，并且**在 worktree 之外**做（比如把改动推上去让 CI 装，或在 canonical 上装完再 symlink）。
+
 ### 编译态（单文件二进制）注意
 
 编译版里没有 `dist/` 落在磁盘上——模块图在虚拟只读的 `/$bunfs/` 下，`__dirname` 是 `/$bunfs/root`。所以**任何把 `__dirname` 拼出的路径写到磁盘、或交给别的进程用的代码，在编译态都是坏的**（那个路径进程外不存在，且 sh 里未转义的 `$bunfs` 还会被展开成空串）。曾因此把 install.sh 装在 `~/.botmux/bin/botmux` 的二进制**覆盖成 47 字节的壳**。判断运行形态用 `isStandaloneBinary()`（`src/core/self-spawn.ts`），子进程一律走 `resolveEntrySpawn` / `spawnWorker` re-exec `process.execPath`，不要拼 `dist/*.js` 路径。


### PR DESCRIPTION
## 改了什么

`CLAUDE.md` 新增一节「worktree 的 node_modules：共享还是独立」，并在 Bun 章节补一句 worktree 下可用。**纯文档，无代码变更。**

## 为什么

原文只写了「绝不在 worktree 里跑 `pnpm install`」，但没说后果，也没提 bun。实测下来有两条**与包管理器无关**、且比「浪费一次重装」严重得多的后果：

1. **两个 worktree 同时 symlink 到同一目标时，`pnpm install` 会失败并把共享目录删掉**
   ```
   ENOTDIR: not a directory, mkdir '<worktree>/node_modules'
   → 目标目录被删除
   ```
   变量隔离过：单 symlink → `exit 0` 目标完好；双 symlink 指同一目标 → `exit 236` 且目标被清掉。`bun install` 同场景 `exit 0`、目标完好。

2. **共享依赖时后装的 worktree 静默覆盖版本**
   A 要 `ms@2.1.3`、B 要 `ms@2.0.0`、共享同一 `node_modules` → B 装完后 **A 解析到 `2.0.0`**（A 的 `package.json` 写的是 `2.1.3`），`exit 0` 零报错零警告。

## 顺带纠正一个前提

原以为「worktree 的 node_modules 都是 symlink 到 canonical」。实测三个 worktree **形态不统一**：

| worktree | 形态 | 体积 |
|---|---|---|
| `bun-ws-proxy-fix` | symlink → canonical | 0 字节 |
| `bot-rename-cache-refresh` | 真实目录（近空） | 24K |
| `fix-bot-roster-overflow` | 独立 pnpm 安装（663 包） | 743M |

symlink 不是包管理器行为，是逐个手工决定的。所以文档给出选择标准：**依赖需求与 canonical 一致才 symlink；分支动了 `package.json`/lockfile 就该独立装，且在 worktree 之外做。**

## 「删掉共享目录」的后果按实际机制写

没有笼统写「全线起不来」，而是按查到的机制写：`/proc/<pid>/maps` 显示 live daemon mmap 着 canonical 的 `pty.node`

```
/root/iserver/botmux/node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty/build/Release/pty.node
```

已在跑的进程靠 inode 存活不会立刻崩，但**重启 / spawn worker / 新起 CLI 会话都会失败** —— 是「不可恢复」而非「立刻全崩」。

## bun 在 worktree 下可用（零额外体积）

在「源码 + `node_modules` symlink 到 canonical」的 worktree 里实测全通，**不跑 install 就不额外占依赖体积**：

| 项 | 结果 |
|---|---|
| `bun -e 'require("node-pty")'` | ✅ 拿到 `spawn,fork,createTerminal` |
| `bun src/cli.ts capabilities` | ✅ |
| `bun run build` | ✅ exit 0 |
| `tsc --noEmit` / `vitest` | ✅ exit 0 / 23 测过 |
| `build:bun` | ✅ `pty.node` 经 symlink 解析，不复制 |
| 二进制 smoke | ✅ 六项全绿 |

## 影响面

只改 `CLAUDE.md`。不涉及任何 CLI 适配器 / 后端 / 平台 / 会话类型。
