### PR TITLE
fix(sandbox): codex-app / mir 的二级 spawn 路径改用 canonical，修沙盒内 ENOENT

### DIFF
--- a/src/adapters/cli/codex-app.ts
+++ b/src/adapters/cli/codex-app.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { promisify } from 'node:util';
-import { resolveCommand } from './registry.js';
+import { resolveCommandReal } from './registry.js';
 import { parseDebugModelsJson } from './model-catalog-json.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
@@ -50,15 +50,24 @@ export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
     // re-expose its bin dir when it lives under /run (fnm/nvm) — else --tmpfs /run
     // masks it and the in-sandbox app-server spawn ENOENTs into a crash-loop. Same
     // lazy resolve+cache as buildArgs; only an executable path, never the cwd.
+    //
+    // CANONICAL (resolveCommandReal), and it must stay identical to the path handed
+    // to `--codex-bin` below: the sandbox authorizes `dirname(canonical(p))`, while
+    // codex-app-runner.ts spawns `--codex-bin` verbatim. `codex` on PATH is commonly
+    // a symlink chain (`~/.local/bin/codex` → `…/standalone/current/bin/codex` → a
+    // versioned release dir), so a raw path would be authorized-as-canonical yet
+    // spawned-as-symlink and ENOENT inside the sandbox.
     sandboxExtraExecPaths() {
-      return [(cachedCodexBin ??= resolveCommand(rawCodexBin))];
+      return [(cachedCodexBin ??= resolveCommandReal(rawCodexBin))];
     },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, botName, botOpenId, locale, model, reasoningEffort, codexBrowser }) {
       const args = [
         runnerPath(),
         '--session-id', sessionId,
-        '--codex-bin', (cachedCodexBin ??= resolveCommand(rawCodexBin)),
+        // Canonical for the same reason as sandboxExtraExecPaths above — the runner
+        // hands this straight to spawn().
+        '--codex-bin', (cachedCodexBin ??= resolveCommandReal(rawCodexBin)),
       ];
       if (resume && resumeSessionId) args.push('--thread-id', resumeSessionId);
       pushOpt(args, '--cwd', workingDir);
@@ -86,7 +95,10 @@ export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
         // 的测试 import 阶段炸（mock 无 execFile 导出）；推迟到调用时，fail-soft
         // 的 try/catch 兜住（契约：任何异常 → null）。
         const execFileAsync = promisify(execFile);
-        const codexBin = (cachedCodexBin ??= resolveCommand(rawCodexBin));
+        // Shares `cachedCodexBin` with the two call sites above, so it must use the
+        // same resolver or whichever runs first would decide the cached value and
+        // silently change what the other two get. It also execs the binary itself.
+        const codexBin = (cachedCodexBin ??= resolveCommandReal(rawCodexBin));
         const { stdout } = await execFileAsync(codexBin, ['debug', 'models'], {
           timeout: 8000,
           maxBuffer: 16 * 1024 * 1024,

--- a/src/adapters/cli/dsh.ts
+++ b/src/adapters/cli/dsh.ts
@@ -1,28 +1,10 @@
 import { fileURLToPath } from 'node:url';
-import { existsSync, mkdirSync, realpathSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { resolveCommand } from './registry.js';
+import { resolveCommandReal } from './registry.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
-
-/**
- * Resolve the dsh binary to its REAL (symlink-followed) path.
- *
- * `resolveCommand` returns the raw entry as found on PATH — which is commonly a
- * symlink (e.g. `~/.local/bin/dsh-jsonrpc-agent` → the SDK's package dir), and
- * the user's HOME may itself be a symlink (`/home/x` → `/data00/home/x`). The
- * file sandbox only exposes the CANONICAL target dir read-only (worker.ts maps
- * exec paths through `dirname(canonical(p))`), so a spawn against the original
- * symlink path ENOENTs inside the sandbox. Canonicalizing here makes the path we
- * hand the runner (`--dsh-bin`) identical to the one the sandbox authorized, so
- * the in-sandbox spawn resolves. Falls back to the raw path if realpath fails
- * (binary genuinely absent — surfaces the same ENOENT as before, unmasked).
- */
-function realResolveCommand(cmd: string): string {
-  const resolved = resolveCommand(cmd);
-  try { return realpathSync(resolved); } catch { return resolved; }
-}
 
 function runnerPath(): string {
   // Source-level worker integration tests execute through tsx and need the
@@ -68,11 +50,11 @@ export function createDshAdapter(pathOverride?: string): CliAdapter {
     // by the runner. Declare its CANONICAL path so the file sandbox re-exposes
     // its bin dir when it lives under /run (fnm/nvm) — else --tmpfs /run masks
     // it and the in-sandbox spawn ENOENTs into a crash-loop. Must match the
-    // path handed to --dsh-bin below (both canonical via realResolveCommand) so
+    // path handed to --dsh-bin below (both canonical via resolveCommandReal) so
     // the authorized dir and the spawned path agree. Same lazy resolve+cache as
     // buildArgs; only an executable path, never the cwd.
     sandboxExtraExecPaths() {
-      return [(cachedDshBin ??= realResolveCommand(rawDshBin))];
+      return [(cachedDshBin ??= resolveCommandReal(rawDshBin))];
     },
 
     buildArgs({ sessionId, workingDir, botName, botOpenId, locale, model, turnTimeoutMs }) {
@@ -87,7 +69,7 @@ export function createDshAdapter(pathOverride?: string): CliAdapter {
       const args = [
         runnerPath(),
         '--session-id', sessionId,
-        '--dsh-bin', (cachedDshBin ??= realResolveCommand(rawDshBin)),
+        '--dsh-bin', (cachedDshBin ??= resolveCommandReal(rawDshBin)),
       ];
       pushOpt(args, '--cwd', workingDir);
       pushOpt(args, '--bot-name', botName);

--- a/src/adapters/cli/mir.ts
+++ b/src/adapters/cli/mir.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
-import { resolveCommand } from './registry.js';
+import { resolveCommandReal } from './registry.js';
 
 /**
  * Mir CLI (mircli) adapter — drives the local `mircli` in non-interactive Print
@@ -41,14 +41,30 @@ export function createMirAdapter(pathOverride?: string): CliAdapter {
   // (resolvedBin is the node runner itself). Resolve a bare name to an absolute
   // path and hand it to the runner via --mircli-bin; the runner falls back to
   // MIRCLI_BIN / `mircli` on PATH when unset.
+  //
+  // CANONICAL (resolveCommandReal): mir-runner.ts spawns this path verbatim
+  // (`this.mircliBin || MIRCLI_BIN || 'mircli'`), and the file sandbox authorizes
+  // `dirname(canonical(p))` — so a symlink-installed mircli would be
+  // authorized-as-canonical yet spawned-as-symlink and ENOENT inside the sandbox.
+  // Same defect class as codex-app / dsh.
   let cachedMircliBin: string | undefined;
   const mircliBin = (): string | undefined => {
     if (!pathOverride || !pathOverride.trim()) return undefined;
-    return (cachedMircliBin ??= resolveCommand(pathOverride.trim()));
+    return (cachedMircliBin ??= resolveCommandReal(pathOverride.trim()));
   };
   return {
     id: 'mir',
     resolvedBin: process.execPath,
+
+    // resolvedBin is node running the runner, so the REAL mircli is a SECOND-stage
+    // spawn that the sandbox would otherwise never expose (`--tmpfs /run` masks
+    // fnm/nvm bin farms). Declared only when an explicit override gives us a path
+    // to canonicalize — with no override the runner resolves `mircli` from PATH
+    // inside the sandbox, which this adapter cannot know here.
+    sandboxExtraExecPaths() {
+      const bin = mircliBin();
+      return bin ? [bin] : [];
+    },
 
     buildArgs({ sessionId, botName, botOpenId, locale }) {
       const args = [runnerPath(), '--session-id', sessionId];

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 import { locateExecutable } from '../../utils/executable.js';
@@ -168,6 +168,33 @@ export function resolveCommand(cmd: string): string {
     }
   }
   return cmd;
+}
+
+/**
+ * `resolveCommand` + realpath — use this for any path that will be handed to a
+ * SPAWNER (a runner's `--*-bin` argv, or anything the adapter execs itself).
+ *
+ * WHY: `resolveCommand` returns the entry as found on PATH, which is commonly a
+ * symlink — `~/.local/bin/codex` → `~/.codex/packages/standalone/current/bin/codex`
+ * → a versioned release dir (two hops, and the middle `current` re-points on every
+ * upgrade). The file sandbox authorizes `dirname(canonical(p))` (see worker.ts's
+ * `execDirs`), so a spawn against the ORIGINAL symlink path ENOENTs inside the
+ * sandbox and the second-stage process crash-loops. Canonicalizing here makes the
+ * spawned path identical to the one the sandbox authorized.
+ *
+ * NOT needed for `resolvedBin` alone: the worker canonicalizes that itself on both
+ * the authorization side and the spawn side. The bug only appears where an adapter
+ * passes a path THROUGH to something else that execs it — which is why this is a
+ * shared helper rather than folded into `resolveCommand` (that would also rewrite
+ * the many display/probe call sites, where the user-facing PATH entry is the more
+ * useful string).
+ *
+ * Falls back to the non-canonical path when realpath fails (binary genuinely
+ * absent) so the failure surfaces as the same unmasked ENOENT as before.
+ */
+export function resolveCommandReal(cmd: string): string {
+  const resolved = resolveCommand(cmd);
+  try { return realpathSync(resolved); } catch { return resolved; }
 }
 
 /**

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -554,6 +554,49 @@ describe('codex-app buildArgs', () => {
     expect(args).toContain('thread-123');
   });
 
+  it('canonicalizes a symlinked codex so --codex-bin matches the sandbox-authorized path', () => {
+    // Regression, same class as the dsh case below: `codex` on PATH is commonly a
+    // symlink CHAIN — measured on the dev box, ~/.local/bin/codex →
+    // …/standalone/current/bin/codex → …/releases/<version>/bin/codex, where the
+    // middle `current` hop re-points on every upgrade. The file sandbox authorizes
+    // only dirname(realpath(bin)) (worker.ts `execDirs`), while
+    // codex-app-runner.ts spawns --codex-bin verbatim → `execvp … No such file or
+    // directory` inside the sandbox and an app-server crash-loop.
+    //
+    // Verified against a real bwrap sandbox: raw path → execvp ENOENT, canonical
+    // path → exit 0. All three call sites must agree, since they share one cache.
+    const root = mkdtempSync(join(tmpdir(), 'codex-symlink-'));
+    try {
+      const realDir = join(root, 'releases', '1.2.3', 'bin');
+      mkdirSync(realDir, { recursive: true });
+      const realBin = join(realDir, 'codex');
+      writeFileSync(realBin, '#!/bin/sh\n', { mode: 0o755 });
+      // Two hops, mirroring the real install: link/codex → current/codex → realBin.
+      const midDir = join(root, 'current', 'bin');
+      mkdirSync(midDir, { recursive: true });
+      const midBin = join(midDir, 'codex');
+      symlinkSync(realBin, midBin);
+      const linkDir = join(root, 'local', 'bin');
+      mkdirSync(linkDir, { recursive: true });
+      const linkBin = join(linkDir, 'codex');
+      symlinkSync(midBin, linkBin);
+
+      const symlinkAdapter = createCodexAppAdapter(linkBin);
+      const canonicalReal = realpathSync(realBin);
+      expect(linkBin).not.toBe(canonicalReal); // the hazard exists in this fixture
+
+      const args = symlinkAdapter.buildArgs({ sessionId: 's', resume: false });
+      const binIdx = args.indexOf('--codex-bin');
+      expect(binIdx).toBeGreaterThanOrEqual(0);
+      expect(args[binIdx + 1]).toBe(canonicalReal);
+      // Must equal the argv exactly — the sandbox authorizes from THIS list while
+      // the runner spawns the argv; any divergence is the bug.
+      expect(symlinkAdapter.sandboxExtraExecPaths?.()).toEqual([canonicalReal]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('passes the opt-in browser bridge only to the Codex App runner', () => {
     const disabled = adapter.buildArgs({ sessionId: 'sess-app', resume: false });
     expect(disabled).not.toContain('--browser-family');

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -853,6 +853,54 @@ describe('mir buildArgs (runner model)', () => {
     expect(args).not.toContain('--mircli-bin');
   });
 
+  it('canonicalizes a symlinked mircli so --mircli-bin matches the sandbox-authorized path', () => {
+    // Same defect class as codex-app above and dsh below: mir-runner.ts spawns
+    // `this.mircliBin || MIRCLI_BIN || 'mircli'` verbatim, while the file sandbox
+    // authorizes only dirname(realpath(bin)) (worker.ts `execDirs`) → a raw
+    // symlink path ENOENTs inside the sandbox.
+    //
+    // mir's gap used to be the WIDEST of the three: before this it declared no
+    // sandboxExtraExecPaths at all, so the second-stage binary was never exposed.
+    const root = mkdtempSync(join(tmpdir(), 'mircli-symlink-'));
+    try {
+      const realDir = join(root, 'releases', '2.0.0', 'bin');
+      mkdirSync(realDir, { recursive: true });
+      const realBin = join(realDir, 'mircli');
+      writeFileSync(realBin, '#!/bin/sh\n', { mode: 0o755 });
+      // Two hops, matching how versioned CLIs are usually installed.
+      const midDir = join(root, 'current', 'bin');
+      mkdirSync(midDir, { recursive: true });
+      const midBin = join(midDir, 'mircli');
+      symlinkSync(realBin, midBin);
+      const linkDir = join(root, 'local', 'bin');
+      mkdirSync(linkDir, { recursive: true });
+      const linkBin = join(linkDir, 'mircli');
+      symlinkSync(midBin, linkBin);
+
+      const symlinkAdapter = createMirAdapter(linkBin);
+      const canonicalReal = realpathSync(realBin);
+      expect(linkBin).not.toBe(canonicalReal); // the hazard exists in this fixture
+
+      const args = symlinkAdapter.buildArgs({ sessionId: 's', resume: false });
+      const idx = args.indexOf('--mircli-bin');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(args[idx + 1]).toBe(canonicalReal);
+      // The sandbox authorizes from this list while the runner spawns the argv —
+      // any divergence between the two IS the bug.
+      expect(symlinkAdapter.sandboxExtraExecPaths?.()).toEqual([canonicalReal]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('declares no sandbox exec path when there is no cliPathOverride', () => {
+    // Without an override the runner resolves `mircli` from PATH *inside* the
+    // sandbox, which the adapter cannot know here — so it declares nothing rather
+    // than guessing. Documents the remaining gap (tracked as a follow-up): that
+    // PATH entry may not be bind-mounted, and would still ENOENT.
+    expect(adapter.sandboxExtraExecPaths?.()).toEqual([]);
+  });
+
   it('has no portable copy-paste resume command (mircli owns the session store)', () => {
     expect(adapter.buildResumeCommand?.({ sessionId: 'sess-mir', cliSessionId: 'conv-abc' })).toBeNull();
   });


### PR DESCRIPTION
## 改了什么

#1025 修的是 dsh 的沙盒软链接 ENOENT。同类缺陷还有**两处未修**，本 PR 补上，并把那个 helper 提成共享工具（复审建议）。

| 适配器 | 问题 | runner 侧 |
|---|---|---|
| `codex-app` | `sandboxExtraExecPaths` 与 `--codex-bin` 都用裸 `resolveCommand` | `codex-app-runner.ts:331` 原样 spawn → app-server 崩溃循环 |
| `mir` | `--mircli-bin` 裸 `resolveCommand`，且**完全没声明** `sandboxExtraExecPaths` | `mir-runner.ts:190` 原样 spawn |

## 根因（与 #1025 同构）

`resolveCommand` 返回 PATH 上找到的原始条目，常常是软链接；而文件沙盒只授权 `dirname(canonical(p))`（`worker.ts` 的 `execDirs`）。于是沙盒内 spawn 原始软链接路径必然 ENOENT。

⭐ **本机 `codex` 是两跳软链接**，比 dsh 那次更容易踩：

```
/root/.local/bin/codex
  → /root/.codex/packages/standalone/current/bin/codex
  → /root/.codex/packages/standalone/releases/0.149.1-x86_64-unknown-linux-musl/bin/codex
```

中间那跳是 `current`，**每次 codex 升级都会换指向** —— 所以沙盒授权的目录还会随版本漂移。

## 范围控制：只改「交给 spawner 的路径」

**没有动 `resolvedBin`**：worker 对它在授权侧（`dirname(canonical(p))`）与 spawn 侧（`canonical(cliAdapter.resolvedBin)`）都自己 canonical 一次，那条路径本来就是对的。

这也是**没有把 realpath 直接塞进 `resolveCommand`** 的原因：那会一并改写大量展示/探测调用点，而那些地方用户可见的 PATH 条目才是更有用的字符串。全仓枚举过 30 处 `resolveCommand` 调用点，只有「把路径透传给别的东西去 exec」的才需要改。

`codex-app` 的 `detectModels` 也一并改，因为它与另两处**共享同一个 `cachedCodexBin`**：若各用不同解析器，谁先跑就决定了缓存值，会静默改变另两处拿到的路径。

## 实际测试验证

**真 bwrap 端到端**（按 #1025 的标准，不是只读代码）。只 bind `dirname(canonical(codex))`、tmpfs 根，然后分别 spawn 两种路径：

```
沙盒只授权: /root/.codex/packages/standalone/releases/0.149.1-.../bin

[raw]       status=1 stderr="bwrap: execvp /root/.local/bin/codex: No such file or directory"
[canonical] status=0 stdout="codex-cli 0.149.1"
```

**新增回归用例**（造两跳软链接，与真实安装同形）：`--codex-bin` 与 `sandboxExtraExecPaths()` 必须都等于 canonical **且彼此一致**（沙盒从后者授权、runner spawn 前者，任何分歧就是这个 bug）。

**反向变异**：把 `buildArgs` 退回裸 `resolveCommand` → 该用例报红（1 failed / 401 passed），确认有牙。

**回归面**：
- `tsc --noEmit` 0 错、`pnpm build` 绿
- `cli-adapters` 402 + `sandbox` 26 + `codex-app-context` + `codex-app-control` = **484 项全绿**
- `dsh-runner` + `mir-local-runtime` + `mira-output` = **38 项全绿**（`registry.ts` 是全适配器共用面，特意跑了别的 CLI）

## 影响面

- `registry.ts` 新增导出（共用面，但纯新增，不改 `resolveCommand` 行为）
- `codex-app.ts` 三处、`mir.ts` 两处（含新增 `sandboxExtraExecPaths` 声明）
- mir 的声明只在**配了 cliPathOverride** 时返回路径；没配时 runner 在沙盒内自己从 PATH 解析 `mircli`，适配器无从得知，故返回空数组而不是瞎猜
