### PR TITLE
fix(core): 重启成功后恢复 worker 就绪状态

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -10750,7 +10750,21 @@ function setupWorkerHandlers(
           logger.warn(`[${t}] Ignored restart_result from stale worker generation`);
           break;
         }
-        restartCoordinator.resolve(ds.session.sessionId, msg.attemptId, msg.status);
+        const restartSettled = restartCoordinator.resolve(
+          ds.session.sessionId,
+          msg.attemptId,
+          msg.status,
+        );
+        // requestSessionRestart() fences the live generation by clearing
+        // workerReady before asking the worker to respawn its CLI in place. An
+        // in-worker respawn does not emit the process-level `ready` message
+        // again, so the matching successful receipt is the authoritative edge
+        // that must release that fence. Without this assignment the terminal
+        // can be prompt-ready/idle while relay and fork remain permanently
+        // blocked as `worker_busy`.
+        if (restartSettled && msg.status === 'succeeded') {
+          ds.workerReady = true;
+        }
         break;
       }
 

--- a/test/restart-worker-ready-lifecycle.test.ts
+++ b/test/restart-worker-ready-lifecycle.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workerPoolSource = readFileSync(
+  new URL('../src/core/worker-pool.ts', import.meta.url),
+  'utf8',
+);
+
+describe('in-worker restart lifecycle fence', () => {
+  it('releases workerReady only after the current restart succeeds', () => {
+    const start = workerPoolSource.indexOf("case 'restart_result':");
+    const end = workerPoolSource.indexOf("case 'cli_session_id':", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const branch = workerPoolSource.slice(start, end);
+    const staleWorkerGuard = branch.indexOf('if (ds.worker !== worker)');
+    const resolve = branch.indexOf('restartCoordinator.resolve(');
+    const successGuard = branch.indexOf("restartSettled && msg.status === 'succeeded'");
+    const releaseFence = branch.indexOf('ds.workerReady = true;');
+
+    expect(staleWorkerGuard).toBeGreaterThanOrEqual(0);
+    expect(resolve).toBeGreaterThan(staleWorkerGuard);
+    expect(successGuard).toBeGreaterThan(resolve);
+    expect(releaseFence).toBeGreaterThan(successGuard);
+  });
+
+  it('keeps failed or stale restart receipts from releasing workerReady', () => {
+    const start = workerPoolSource.indexOf("case 'restart_result':");
+    const end = workerPoolSource.indexOf("case 'cli_session_id':", start);
+    const branch = workerPoolSource.slice(start, end);
+
+    expect(branch.match(/ds\.workerReady = true;/g)).toHaveLength(1);
+    expect(branch).toContain("if (restartSettled && msg.status === 'succeeded')");
+  });
+});


### PR DESCRIPTION
## 问题

存量会话执行 `/restart` 时，daemon 会先把 `workerReady` 设为 `false`，以阻止 fork、relay 等生命周期操作与 CLI 重启并发。

CLI 在同一个 worker 进程内恢复后只发送 `prompt_ready` 和 `restart_result`，不会再次发送进程级 `ready`。原逻辑虽然结算了 restart coordinator，却没有恢复 `workerReady`。因此终端和卡片已经显示 idle，fork/relay 仍会永久返回 `worker_busy`。

复现顺序：

1. 在正常会话执行 `/restart`。
2. 等待 replacement CLI 回到输入提示符。
3. 执行 `/fork --create ...`。
4. fork 被误判为 mid-turn；新建群随后回滚解散。

## 修复

处理当前 worker 的 `restart_result` 时：

- 先由 restart coordinator 校验并结算匹配的 attempt；
- 仅当匹配成功且状态为 `succeeded` 时恢复 `ds.workerReady = true`；
- 失败、超时、重复回执和旧 worker 回执仍保持 fail-closed。

## 影响面

改动位于 `core/worker-pool` 的公共生命周期状态处理，覆盖所有采用 in-worker restart 的本地 CLI 和普通群／话题会话。

不改变 transcript、消息路由、fork 数据复制方式或远端 backend 的失败策略。失败重启不会被误标为 ready。

## 验证

- 聚焦重启测试：5 个测试文件，56 个测试通过。
- `/restart` 命令与 transfer/fork 组合回归：2 个测试文件，359 个测试通过。
- 合计：7 个测试文件，415 个测试通过。
- `pnpm build` 通过：TypeScript、脚本类型检查、Dashboard bundle、dist audit 全部完成。
- `git diff --check` 通过。
