### PR TITLE
feat(lark): 支持可信 OnCall 拉群后自动开放当前群对话权限

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1559,6 +1559,10 @@ export interface BotConfig {
    */
   ownerOpenId?: string;
   allowedChatGroups?: string[];
+  /** 可触发当前群自动开放聊天的可信拉群 operator。 */
+  autoOncallOperatorOpenIds?: string[];
+  /** 由可信拉群事件产生的群级 talk 授权。 */
+  autoOncallChats?: string[];
   /** Oncall bindings: chat_id → default workingDir. Any group member can talk; allowedUsers still gates card buttons / daemon commands. */
   oncallChats?: OncallChat[];
   /** UI language for this bot: 'zh' or 'en'. Falls back to BOTMUX_LANG / LANG env when unset. */
@@ -2871,12 +2875,14 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
         }));
     }
 
-    let allowedChatGroups: string[] | undefined;
-    if (Array.isArray(entry.allowedChatGroups)) {
-      allowedChatGroups = entry.allowedChatGroups
-        .filter((x: any): x is string => typeof x === 'string' && x.trim().length > 0)
-        .map((x: string) => x.trim());
-    }
+    const parseStringArray = (value: unknown): string[] | undefined => Array.isArray(value)
+      ? [...new Set(value
+        .filter((x: unknown): x is string => typeof x === 'string' && x.trim().length > 0)
+        .map(x => x.trim()))]
+      : undefined;
+    const allowedChatGroups = parseStringArray(entry.allowedChatGroups);
+    const autoOncallOperatorOpenIds = parseStringArray(entry.autoOncallOperatorOpenIds);
+    const autoOncallChats = parseStringArray(entry.autoOncallChats);
 
     // defaultOncall: per-bot default for auto-binding new group chats.
     // Tolerate missing fields: an entry with `enabled:true` but no workingDir
@@ -3164,6 +3170,8 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
         ? entry.ownerOpenId
         : undefined,
       allowedChatGroups,
+      autoOncallOperatorOpenIds,
+      autoOncallChats,
       oncallChats,
       defaultOncall,
       defaultOncallAutoboundChats,

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -73,6 +73,11 @@ import type { VcMeetingPushContext, VcMeetingPushEventKind } from '../../vc-agen
 import type { VcMeetingImTurnOrigin } from '../../types.js';
 import { DEFAULT_GRANT_DURATION_MS, DEFAULT_GRANT_QUOTA } from '../../services/grant-policy.js';
 import { readPeerCrossRef, writePeerCrossRef } from '../../services/peer-cross-ref-store.js';
+import {
+  addAutoOncallChat,
+  isAutoOncallOperator,
+  removeAutoOncallChat,
+} from '../../services/auto-oncall-store.js';
 
 // 大厅回执互教的防环闸：每进程对同一打卡者只回一次（见 hall swallow 分支）。
 const hallEchoReplied = new Set<string>();
@@ -1641,10 +1646,13 @@ function grantNotExpired(
   return false;
 }
 
-/** 整群 talk 授权命中判断（裸 `/grant` 写入的 allowedChatGroups）。chat 维度、sender 无关，
+/** 整群 talk 授权命中判断（手动 `/grant` 或可信拉群事件）。chat 维度、sender 无关，
  *  与 oncall 同一个安全模型：只放行 canTalk / bot 路由闸，canOperate 绝不读它。 */
 function hasAllowedChatGroup(larkAppId: string, chatId: string | undefined): boolean {
-  return !!chatId && !!getBot(larkAppId).config.allowedChatGroups?.includes(chatId);
+  if (!chatId) return false;
+  const cfg = getBot(larkAppId).config;
+  return cfg.allowedChatGroups?.includes(chatId) === true
+    || cfg.autoOncallChats?.includes(chatId) === true;
 }
 
 /**
@@ -4012,6 +4020,12 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         const operatorOpenId: string | undefined = data?.operator_id?.open_id;
         if (!chatId) return;
         logger.info(`[auto-start:入群] bot added to chat=${chatId.substring(0, 12)} by ${String(operatorOpenId ?? '?').substring(0, 12)}`);
+        if (isAutoOncallOperator(larkAppId, operatorOpenId)) {
+          const result = await addAutoOncallChat(larkAppId, chatId);
+          if (!result.ok) {
+            logger.warn(`[auto-oncall:${larkAppId}] failed to add chat=${chatId}: ${result.reason}`);
+          }
+        }
         // 进群先自动拉 owner（不受任何开工开关影响，失败仅日志）：bot 应始终
         // 处于 owner 可见的群里。放在 handleBotAdded 之前，让 autoStart 的
         // D7「群内需有 allowedUser」闸能吃到刚拉进来的 owner。
@@ -4026,11 +4040,23 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     // bot.deleted 同样只推给被移出的 bot 自己的 app——清自己的 key 即可(语义
     // 同 bot.added:进程边界上够不到兄弟 daemon;「别的 bot 离群→存量 bot
     // 陈旧」靠①守卫+TTL)。user.added/deleted_v1 推给群内已订阅的所有 bot
-    // app,每个 bot 自己的 WS 都收到,各自清自己那条。纯本地 map 删除,同步
-    // 处理、即时 ACK,不进 work 队列;去重也不必要——失效是幂等的。
+    // app,每个 bot 自己的 WS 都收到,各自清自己那条。统计缓存同步
+    // 失效，配置授权的撤销进 ACK-safe 异步队列。
     'im.chat.member.bot.deleted_v1': (data: any) => {
       const chatId: string | undefined = data?.chat_id;
-      if (chatId) invalidateChatStats(larkAppId, chatId);
+      if (!chatId) return;
+      invalidateChatStats(larkAppId, chatId);
+      const eventKey = `im.chat.member.bot.deleted_v1:${larkAppId}:${eventIdForKey(data) ?? chatId}`;
+      scheduleAckSafeEvent(eventKey, async () => {
+        try {
+          const result = await removeAutoOncallChat(larkAppId, chatId);
+          if (!result.ok) {
+            logger.warn(`[auto-oncall:${larkAppId}] failed to remove chat=${chatId}: ${result.reason}`);
+          }
+        } catch (err) {
+          logger.warn(`[auto-oncall:${larkAppId}] failed to remove chat=${chatId}: ${err}`);
+        }
+      }, 'bot-deleted event');
     },
     'im.chat.member.user.added_v1': (data: any) => {
       const chatId: string | undefined = data?.chat_id;

--- a/src/services/auto-oncall-store.ts
+++ b/src/services/auto-oncall-store.ts
@@ -1,0 +1,64 @@
+/**
+ * Trusted bot-added events grant talk-only access to the current bot × chat.
+ * The automatic source is stored separately from manual allowedChatGroups so
+ * removing the bot can revoke only the access created by that event.
+ */
+import { getBot } from '../bot-registry.js';
+import { logger } from '../utils/logger.js';
+import { rmwBotEntry } from './config-store.js';
+
+type Fail = { ok: false; reason: string };
+
+export function isAutoOncallOperator(larkAppId: string, operatorOpenId: string | undefined): boolean {
+  if (!operatorOpenId) return false;
+  try {
+    return getBot(larkAppId).config.autoOncallOperatorOpenIds?.includes(operatorOpenId) === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function addAutoOncallChat(
+  larkAppId: string,
+  chatId: string,
+): Promise<{ ok: true; created: boolean } | Fail> {
+  let bot;
+  try { bot = getBot(larkAppId); } catch { return { ok: false, reason: 'bot_not_registered' }; }
+
+  const r = await rmwBotEntry<{ created: boolean }>(larkAppId, (entry) => {
+    const current: string[] = Array.isArray(entry.autoOncallChats) ? entry.autoOncallChats : [];
+    const created = !current.includes(chatId);
+    if (created) entry.autoOncallChats = [...current, chatId];
+    return { write: created, result: { created } };
+  });
+  if (!r.ok) return r;
+
+  const inMemory = bot.config.autoOncallChats ?? [];
+  if (!inMemory.includes(chatId)) bot.config.autoOncallChats = [...inMemory, chatId];
+  if (r.result.created) logger.info(`[auto-oncall:${larkAppId}] +chat ${chatId}`);
+  return { ok: true, created: r.result.created };
+}
+
+export async function removeAutoOncallChat(
+  larkAppId: string,
+  chatId: string,
+): Promise<{ ok: true; removed: boolean } | Fail> {
+  let bot;
+  try { bot = getBot(larkAppId); } catch { return { ok: false, reason: 'bot_not_registered' }; }
+
+  const r = await rmwBotEntry<{ removed: boolean }>(larkAppId, (entry) => {
+    const current: string[] = Array.isArray(entry.autoOncallChats) ? entry.autoOncallChats : [];
+    const removed = current.includes(chatId);
+    const next = current.filter(id => id !== chatId);
+    if (next.length > 0) entry.autoOncallChats = next;
+    else delete entry.autoOncallChats;
+    return { write: removed, result: { removed } };
+  });
+  if (!r.ok) return r;
+
+  const next = (bot.config.autoOncallChats ?? []).filter(id => id !== chatId);
+  if (next.length > 0) bot.config.autoOncallChats = next;
+  else delete bot.config.autoOncallChats;
+  if (r.result.removed) logger.info(`[auto-oncall:${larkAppId}] -chat ${chatId}`);
+  return { ok: true, removed: r.result.removed };
+}

--- a/src/services/grant-store.ts
+++ b/src/services/grant-store.ts
@@ -398,27 +398,39 @@ export async function addAllowedChatGroup(
   return { ok: true, created: r.result.created };
 }
 
-/** 撤销整群 talk 授权：把 chatId 从 allowedChatGroups 移除。 */
+/**
+ * 显式撤销整群 talk 授权：同一 RMW 内清掉手动与自动两种来源。
+ * bot 退群时只撤销自动来源，仍由 auto-oncall-store 单独处理。
+ */
 export async function removeAllowedChatGroup(
   larkAppId: string, chatId: string,
 ): Promise<{ ok: true; removed: boolean } | Fail> {
   let bot; try { bot = getBot(larkAppId); } catch { return { ok: false, reason: 'bot_not_registered' }; }
-  const r = await rmwBotEntry<{ removed: boolean }>(larkAppId, (entry) => {
-    const cur: string[] = Array.isArray(entry.allowedChatGroups) ? entry.allowedChatGroups : [];
-    const removed = cur.includes(chatId);
-    const next = cur.filter((c: string) => c !== chatId);
-    if (next.length > 0) entry.allowedChatGroups = next;
+  type Removed = { manual: boolean; automatic: boolean };
+  const r = await rmwBotEntry<Removed>(larkAppId, (entry) => {
+    const manual: string[] = Array.isArray(entry.allowedChatGroups) ? entry.allowedChatGroups : [];
+    const automatic: string[] = Array.isArray(entry.autoOncallChats) ? entry.autoOncallChats : [];
+    const removed = { manual: manual.includes(chatId), automatic: automatic.includes(chatId) };
+    const nextManual = manual.filter((c: string) => c !== chatId);
+    const nextAutomatic = automatic.filter((c: string) => c !== chatId);
+    if (nextManual.length > 0) entry.allowedChatGroups = nextManual;
     else delete entry.allowedChatGroups;
-    return { write: removed, result: { removed } };
+    if (nextAutomatic.length > 0) entry.autoOncallChats = nextAutomatic;
+    else delete entry.autoOncallChats;
+    return { write: removed.manual || removed.automatic, result: removed };
   });
   if (!r.ok) return r;
-  if (r.result.removed) {
-    const next = (bot.config.allowedChatGroups ?? []).filter(c => c !== chatId);
-    if (next.length > 0) bot.config.allowedChatGroups = next;
+  const removed = r.result.manual || r.result.automatic;
+  if (removed) {
+    const nextManual = (bot.config.allowedChatGroups ?? []).filter(c => c !== chatId);
+    const nextAutomatic = (bot.config.autoOncallChats ?? []).filter(c => c !== chatId);
+    if (nextManual.length > 0) bot.config.allowedChatGroups = nextManual;
     else delete bot.config.allowedChatGroups;
-    logger.info(`[grant:${larkAppId}] -chatGroup ${chatId}`);
+    if (nextAutomatic.length > 0) bot.config.autoOncallChats = nextAutomatic;
+    else delete bot.config.autoOncallChats;
+    logger.info(`[grant:${larkAppId}] -chatGroup ${chatId} sources=${JSON.stringify(r.result)}`);
   }
-  return { ok: true, removed: r.result.removed };
+  return { ok: true, removed };
 }
 
 /**

--- a/test/auto-oncall-store.test.ts
+++ b/test/auto-oncall-store.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for trusted bot-added talk authorization persistence.
+ *
+ * Run: pnpm vitest run --project unit test/auto-oncall-store.test.ts
+ */
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+let configPath: string;
+
+async function freshModules() {
+  vi.resetModules();
+  const registry = await import('../src/bot-registry.js');
+  const store = await import('../src/services/auto-oncall-store.js');
+  registry.loadBotConfigs().forEach(config => registry.registerBot(config));
+  return { registry, store };
+}
+
+function writeConfig(entry: Record<string, unknown> = {}) {
+  writeFileSync(configPath, JSON.stringify([{
+    larkAppId: 'app_auto_oncall',
+    larkAppSecret: 'secret',
+    cliId: 'claude-code',
+    ...entry,
+  }], null, 2), 'utf-8');
+}
+
+function readConfig(): any {
+  return JSON.parse(readFileSync(configPath, 'utf-8'))[0];
+}
+
+beforeEach(() => {
+  const dir = mkdtempSync(join(tmpdir(), 'botmux-auto-oncall-store-'));
+  configPath = join(dir, 'bots.json');
+  process.env.BOTS_CONFIG = configPath;
+});
+
+afterEach(() => {
+  delete process.env.BOTS_CONFIG;
+  vi.restoreAllMocks();
+});
+
+describe('auto-oncall-store', () => {
+  it('normalizes config arrays and matches only the exact trusted operator', async () => {
+    writeConfig({
+      autoOncallOperatorOpenIds: [' ou_byte_oncall ', '', 'ou_byte_oncall', 'ou_other'],
+      autoOncallChats: [' oc_existing ', 'oc_existing', ''],
+    });
+    const { registry, store } = await freshModules();
+
+    expect(registry.getBot('app_auto_oncall').config.autoOncallOperatorOpenIds)
+      .toEqual(['ou_byte_oncall', 'ou_other']);
+    expect(registry.getBot('app_auto_oncall').config.autoOncallChats).toEqual(['oc_existing']);
+    expect(store.isAutoOncallOperator('app_auto_oncall', 'ou_byte_oncall')).toBe(true);
+    expect(store.isAutoOncallOperator('app_auto_oncall', 'OU_BYTE_ONCALL')).toBe(false);
+    expect(store.isAutoOncallOperator('app_auto_oncall', 'ou_byte_oncall_suffix')).toBe(false);
+    expect(store.isAutoOncallOperator('app_auto_oncall', undefined)).toBe(false);
+  });
+
+  it('persists and hot-updates an add, with duplicate adds remaining idempotent', async () => {
+    writeConfig({ autoOncallOperatorOpenIds: ['ou_byte_oncall'] });
+    const { registry, store } = await freshModules();
+
+    expect(await store.addAutoOncallChat('app_auto_oncall', 'oc_new'))
+      .toEqual({ ok: true, created: true });
+    expect(readConfig().autoOncallChats).toEqual(['oc_new']);
+    expect(registry.getBot('app_auto_oncall').config.autoOncallChats).toEqual(['oc_new']);
+
+    expect(await store.addAutoOncallChat('app_auto_oncall', 'oc_new'))
+      .toEqual({ ok: true, created: false });
+    expect(readConfig().autoOncallChats).toEqual(['oc_new']);
+  });
+
+  it('keeps an automatic authorization after reloading bots.json', async () => {
+    writeConfig();
+    const { registry, store } = await freshModules();
+    await store.addAutoOncallChat('app_auto_oncall', 'oc_persisted');
+
+    registry.__testOnly_resetBotRegistry();
+    registry.loadBotConfigs().forEach(config => registry.registerBot(config));
+
+    expect(registry.getBot('app_auto_oncall').config.autoOncallChats).toEqual(['oc_persisted']);
+  });
+
+  it('removes only automatic authorization and preserves manual allowedChatGroups', async () => {
+    writeConfig({
+      allowedChatGroups: ['oc_shared', 'oc_manual'],
+      autoOncallChats: ['oc_shared'],
+    });
+    const { registry, store } = await freshModules();
+
+    expect(await store.removeAutoOncallChat('app_auto_oncall', 'oc_shared'))
+      .toEqual({ ok: true, removed: true });
+    expect(readConfig().autoOncallChats).toBeUndefined();
+    expect(readConfig().allowedChatGroups).toEqual(['oc_shared', 'oc_manual']);
+    expect(registry.getBot('app_auto_oncall').config.autoOncallChats).toBeUndefined();
+    expect(registry.getBot('app_auto_oncall').config.allowedChatGroups)
+      .toEqual(['oc_shared', 'oc_manual']);
+  });
+
+  it('returns bot_not_registered for writes to an unknown bot', async () => {
+    writeConfig();
+    const { store } = await freshModules();
+
+    expect(await store.addAutoOncallChat('missing', 'oc_x'))
+      .toEqual({ ok: false, reason: 'bot_not_registered' });
+    expect(await store.removeAutoOncallChat('missing', 'oc_x'))
+      .toEqual({ ok: false, reason: 'bot_not_registered' });
+  });
+});

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -117,6 +117,15 @@ vi.mock('../src/services/substitute-chat-toggle-store.js', () => ({
   setSubstituteEnabledForChat: vi.fn(),
 }));
 
+const mockIsAutoOncallOperator = vi.fn(() => false);
+const mockAddAutoOncallChat = vi.fn(async () => ({ ok: true as const, created: false }));
+const mockRemoveAutoOncallChat = vi.fn(async () => ({ ok: true as const, removed: false }));
+vi.mock('../src/services/auto-oncall-store.js', () => ({
+  isAutoOncallOperator: (...args: any[]) => mockIsAutoOncallOperator(...args),
+  addAutoOncallChat: (...args: any[]) => mockAddAutoOncallChat(...args),
+  removeAutoOncallChat: (...args: any[]) => mockRemoveAutoOncallChat(...args),
+}));
+
 // Capture the registered event handlers from EventDispatcher.register()
 let capturedHandlers: Record<string, Function> = {};
 let capturedWsClientOptions: Record<string, any> | undefined;
@@ -7741,6 +7750,135 @@ describe('rawMessageIngressAnchor', () => {
       thread_id: 'omt_second',
     });
     expect(second).toBe(first);
+  });
+});
+
+describe('trusted bot-added event — automatic chat talk authorization', () => {
+  const OTHER_APP_ID = 'app-bot-b';
+  const TRUSTED_OPERATOR = 'ou_byte_oncall';
+  let handlers: ReturnType<typeof makeHandlers>;
+  let botStates: Map<string, any>;
+
+  beforeEach(() => {
+    capturedHandlers = {};
+    __resetEventClaimsForTest();
+    mockIsAutoOncallOperator.mockReset();
+    mockAddAutoOncallChat.mockReset();
+    mockRemoveAutoOncallChat.mockReset();
+    botStates = new Map([
+      [MY_APP_ID, {
+        config: {
+          larkAppId: MY_APP_ID,
+          larkAppSecret: 'secret',
+          cliId: 'claude-code',
+          allowedUsers: ['ou_admin'],
+          autoOncallOperatorOpenIds: [TRUSTED_OPERATOR],
+        },
+        botOpenId: MY_OPEN_ID,
+        resolvedAllowedUsers: ['ou_admin'],
+      }],
+      [OTHER_APP_ID, {
+        config: {
+          larkAppId: OTHER_APP_ID,
+          larkAppSecret: 'secret-b',
+          cliId: 'claude-code',
+          allowedUsers: ['ou_other_admin'],
+          autoOncallOperatorOpenIds: [TRUSTED_OPERATOR],
+        },
+        botOpenId: OTHER_BOT_OPEN_ID,
+        resolvedAllowedUsers: ['ou_other_admin'],
+      }],
+    ]);
+    mockGetBot.mockImplementation((appId: string) => botStates.get(appId));
+    mockIsAutoOncallOperator.mockImplementation((appId: string, operatorOpenId: string | undefined) =>
+      botStates.get(appId)?.config.autoOncallOperatorOpenIds?.includes(operatorOpenId) === true);
+    mockAddAutoOncallChat.mockImplementation(async (appId: string, chatId: string) => {
+      const config = botStates.get(appId).config;
+      const chats: string[] = config.autoOncallChats ?? [];
+      const created = !chats.includes(chatId);
+      if (created) config.autoOncallChats = [...chats, chatId];
+      return { ok: true as const, created };
+    });
+    mockRemoveAutoOncallChat.mockImplementation(async (appId: string, chatId: string) => {
+      const config = botStates.get(appId).config;
+      const chats: string[] = config.autoOncallChats ?? [];
+      const removed = chats.includes(chatId);
+      const next = chats.filter(id => id !== chatId);
+      if (next.length > 0) config.autoOncallChats = next;
+      else delete config.autoOncallChats;
+      return { ok: true as const, removed };
+    });
+    handlers = makeHandlers();
+    startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
+  });
+
+  function botAddedEvent(overrides: Record<string, unknown> = {}) {
+    return {
+      event_id: 'evt-auto-oncall-added',
+      chat_id: 'oc_auto_oncall',
+      operator_id: { open_id: TRUSTED_OPERATOR },
+      ...overrides,
+    };
+  }
+
+  it('opens talk only for the current bot × current chat, never operate', async () => {
+    capturedHandlers['im.chat.member.bot.added_v1'](botAddedEvent());
+    await flushEventWork();
+
+    expect(canTalk(MY_APP_ID, 'oc_auto_oncall', USER_OPEN_ID)).toBe(true);
+    expect(canOperate(MY_APP_ID, 'oc_auto_oncall', USER_OPEN_ID)).toBe(false);
+    expect(canTalk(MY_APP_ID, 'oc_other_chat', USER_OPEN_ID)).toBe(false);
+    expect(canTalk(OTHER_APP_ID, 'oc_auto_oncall', USER_OPEN_ID)).toBe(false);
+  });
+
+  it('does not turn an open bot into allowlist mode after opening a chat automatically', async () => {
+    const bot = botStates.get(MY_APP_ID);
+    delete bot.config.allowedUsers;
+    bot.resolvedAllowedUsers = [];
+
+    capturedHandlers['im.chat.member.bot.added_v1'](botAddedEvent());
+    await flushEventWork();
+
+    expect(canTalk(MY_APP_ID, 'oc_auto_oncall', USER_OPEN_ID)).toBe(true);
+    expect(canTalk(MY_APP_ID, 'oc_other_chat', USER_OPEN_ID)).toBe(true);
+    expect(canOperate(MY_APP_ID, 'oc_other_chat', USER_OPEN_ID)).toBe(true);
+  });
+
+  it('does not open a group added by a non-trusted user, regardless of group name', async () => {
+    capturedHandlers['im.chat.member.bot.added_v1'](botAddedEvent({
+      event_id: 'evt-untrusted-added',
+      operator_id: { open_id: 'ou_not_trusted' },
+      name: 'Production OnCall 紧急响应群',
+    }));
+    await flushEventWork();
+
+    expect(mockAddAutoOncallChat).not.toHaveBeenCalled();
+    expect(canTalk(MY_APP_ID, 'oc_auto_oncall', USER_OPEN_ID)).toBe(false);
+  });
+
+  it('dedupes repeated delivery of the same bot-added event', async () => {
+    const event = botAddedEvent();
+    capturedHandlers['im.chat.member.bot.added_v1'](event);
+    capturedHandlers['im.chat.member.bot.added_v1'](event);
+    await flushEventWork();
+
+    expect(mockAddAutoOncallChat).toHaveBeenCalledTimes(1);
+    expect(botStates.get(MY_APP_ID).config.autoOncallChats).toEqual(['oc_auto_oncall']);
+  });
+
+  it('cleans the automatic authorization when this bot leaves the chat', async () => {
+    capturedHandlers['im.chat.member.bot.added_v1'](botAddedEvent());
+    await flushEventWork();
+    expect(canTalk(MY_APP_ID, 'oc_auto_oncall', USER_OPEN_ID)).toBe(true);
+
+    capturedHandlers['im.chat.member.bot.deleted_v1']({
+      event_id: 'evt-auto-oncall-deleted',
+      chat_id: 'oc_auto_oncall',
+    });
+    await flushEventWork();
+
+    expect(mockRemoveAutoOncallChat).toHaveBeenCalledWith(MY_APP_ID, 'oc_auto_oncall');
+    expect(canTalk(MY_APP_ID, 'oc_auto_oncall', USER_OPEN_ID)).toBe(false);
   });
 });
 

--- a/test/grant-store.test.ts
+++ b/test/grant-store.test.ts
@@ -138,15 +138,30 @@ describe('grant-store', () => {
     expect(readConfig().allowedChatGroups).toEqual(['oc_team']);
   });
 
-  it('removeAllowedChatGroup removes the chat_id from disk & memory', async () => {
-    writeConfig({ allowedUsers: ['ou_owner'], allowedChatGroups: ['oc_team', 'oc_other'] });
+  it('removeAllowedChatGroup atomically revokes manual and automatic whole-chat access', async () => {
+    writeConfig({
+      allowedUsers: ['ou_owner'],
+      allowedChatGroups: ['oc_team', 'oc_other'],
+      autoOncallChats: ['oc_team', 'oc_auto_other'],
+    });
     const { registry, store } = await freshModules();
     const r = await store.removeAllowedChatGroup('a1', 'oc_team');
     expect(r).toEqual({ ok: true, removed: true });
     expect(readConfig().allowedChatGroups).toEqual(['oc_other']);
+    expect(readConfig().autoOncallChats).toEqual(['oc_auto_other']);
     expect(registry.getBot('a1').config.allowedChatGroups).toEqual(['oc_other']);
+    expect(registry.getBot('a1').config.autoOncallChats).toEqual(['oc_auto_other']);
     // removing one that isn't there
     expect(await store.removeAllowedChatGroup('a1', 'oc_team')).toEqual({ ok: true, removed: false });
+  });
+
+  it('removeAllowedChatGroup reports an automatic-only revoke as removed', async () => {
+    writeConfig({ allowedUsers: ['ou_owner'], autoOncallChats: ['oc_team'] });
+    const { registry, store } = await freshModules();
+
+    expect(await store.removeAllowedChatGroup('a1', 'oc_team')).toEqual({ ok: true, removed: true });
+    expect(readConfig().autoOncallChats).toBeUndefined();
+    expect(registry.getBot('a1').config.autoOncallChats).toBeUndefined();
   });
 
 });


### PR DESCRIPTION
## 改动说明

- 扩展 `BotConfig`，新增可信拉群 operator 与自动群聊授权配置，并在解析时 trim、去空、去重。
- 新增自动授权 Store，使用 `rmwBotEntry()` 原子持久化 `autoOncallChats`，同时热更新内存配置。
- 接入 `im.chat.member.bot.added_v1`：仅可信 operator 拉群时为当前 bot × 当前 chat 开放对话。
- 接入 `im.chat.member.bot.deleted_v1`：bot 退群时仅清理自动来源授权，保留人工 `allowedChatGroups`。
- 更新 `canTalk` 白名单判断，并补充 Store 与事件分发测试。

## 安全边界

- operator 必须按当前应用视角的 `open_id` 精确匹配。
- 授权严格限定在当前 bot × 当前 chat，其他 bot 和其他群不会继承。
- 自动授权只开放 `canTalk`，不开放 `canOperate`；`/restart`、`/grant`、`/cd` 等管理能力仍受原权限控制。

## 验证

- `pnpm vitest run --project unit test/auto-oncall-store.test.ts test/event-dispatcher.test.ts`
  - 2 个测试文件、183 条测试全部通过。
- `pnpm build` 通过。
- 已确认构建产物包含 `autoOncallChats` / `auto-oncall` 逻辑。

本 PR 不包含真实 ByteOncall `open_id`。