### PR TITLE
fix(cot): 话题会话的思考气泡落进话题内，不再漏到群级别

### DIFF
--- a/src/im/lark/cot-message.ts
+++ b/src/im/lark/cot-message.ts
@@ -37,7 +37,7 @@
 import { mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getBot, getBotClient } from '../../bot-registry.js';
-import { resolveSessionReplyTarget } from '../../core/reply-target.js';
+import { fallbackTurnId, frozenReplyContextForTurn } from '../../core/reply-target.js';
 import { config } from '../../config.js';
 import { logger } from '../../utils/logger.js';
 import { localeForBot, t } from '../../i18n/index.js';
@@ -182,14 +182,34 @@ function ev(eventType: string, content: unknown): CotEvent {
  * Lark id (synthetic scheduler ids → bare chat-level bubble). The flag must
  * NEVER ride a plain-group anchor: reply_in_thread on a non-topic message
  * spawns a brand-new topic.
+ *
+ * Resolution goes through `frozenReplyContextForTurn × fallbackTurnId` — the
+ * EXACT composition the streaming card uses (captureStreamingCardReplyTarget),
+ * not the live `resolveSessionReplyTarget`. The two diverge on a busy session:
+ * `replyTargets` is capped at 32 (REPLY_TARGETS_MAX) while `turnReplyContexts`
+ * holds 256, so a turn registered at message-arrival can have its live entry
+ * pruned before its first `thinking_update` creates the bubble — the frozen
+ * context still says `{thread, om_fold}` where the live one has degraded to
+ * `{plain}`. That would resurrect this very bug in the chat-scope fold-back
+ * case. `fallbackTurnId` additionally covers entries with no turn context of
+ * their own (`/cot show`), which then follow the session's current target.
+ *
+ * The `om_` shape check is a fuse, not decoration: `session.rootMessageId` is
+ * NOT always a message id on a thread-scope session — a silent new-topic
+ * schedule stores a virtual `schedule-run:<task>:<uuid>` anchor, chat-scope
+ * keeps the chatId there as an audit seed, and `schedule add --topic
+ * --root-msg-id <any string>` has no `om_` validation on the way in (the
+ * cross-thread fire path at session-manager.ts:3255 anchors it verbatim
+ * without ever probing it, so it does not self-heal). Feishu rejects a
+ * non-`om_` origin, and a failed create disables thinking for the WHOLE turn —
+ * strictly worse than a chat-level bubble. So degrade instead of throwing it
+ * over the wire. (See the same constraint recorded in ask-card.ts:49.)
  */
 function cotPlacement(ds: DaemonSession, state: CotState): { origin_message_id?: string; reply_in_thread?: boolean } {
-  const target = resolveSessionReplyTarget(ds, state.turnId);
+  const target = frozenReplyContextForTurn(ds, fallbackTurnId(ds, state.turnId)).target;
   if (target.mode === 'thread' || target.mode === 'quote') {
-    // Thread-scope sessions always have rootMessageId; the turn-id fallback
-    // covers degenerate restores (a thread trigger id still threads correctly).
-    const anchor = target.rootMessageId ?? (state.turnId.startsWith('om_') ? state.turnId : undefined);
-    if (!anchor) return {};
+    const anchor = target.rootMessageId;
+    if (!anchor.startsWith('om_')) return {};
     return target.mode === 'thread'
       ? { origin_message_id: anchor, reply_in_thread: true }
       : { origin_message_id: anchor };

--- a/src/im/lark/cot-message.ts
+++ b/src/im/lark/cot-message.ts
@@ -10,9 +10,11 @@
  *
  * Lifecycle per turn, driven by the worker's `thinking_update` IPC:
  *
- *   1. First update → POST create (chat-addressed; `origin_message_id` set to
- *      the triggering message so the bubble lands inside the topic) →
- *      `{cot_id, message_id}` → push RUN_STARTED + REASONING_START prologue.
+ *   1. First update → POST create (chat-addressed; placement mirrors
+ *      sessionReply's reply-target routing — thread targets create with
+ *      `origin_message_id` + `reply_in_thread` so the bubble lands INSIDE the
+ *      topic, see {@link cotPlacement}) → `{cot_id, message_id}` → push
+ *      RUN_STARTED + REASONING_START prologue.
  *   2. Subsequent updates → PUT AG-UI events. The worker sends the FULL
  *      cumulative ENTRY LIST (thinking paragraphs + tool calls/results in
  *      transcript order, append-only); this module pushes each unseen entry
@@ -35,6 +37,7 @@
 import { mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getBot, getBotClient } from '../../bot-registry.js';
+import { resolveSessionReplyTarget } from '../../core/reply-target.js';
 import { config } from '../../config.js';
 import { logger } from '../../utils/logger.js';
 import { localeForBot, t } from '../../i18n/index.js';
@@ -165,6 +168,35 @@ function ev(eventType: string, content: unknown): CotEvent {
   return { event_type: eventType, content: JSON.stringify(content), timestamp: Date.now() };
 }
 
+/**
+ * Create-time placement, mirroring sessionReply's reply-target routing.
+ *
+ * `origin_message_id` alone only PARENTS the bubble (message.get shows
+ * parent/root but no thread_id) — in a topic group it renders at CHAT level,
+ * outside the topic. Landing inside requires `reply_in_thread: true` on the
+ * create, same semantics as the ordinary reply API (verified empirically:
+ * origin+flag → thread_id=omt_*, origin alone → none). So thread targets
+ * (topic sessions, and chat-scope turns folded into a topic) set the flag on
+ * their anchor; quote targets anchor without the flag; plain chat-scope turns
+ * keep the old behavior — anchor to the triggering message when it is a real
+ * Lark id (synthetic scheduler ids → bare chat-level bubble). The flag must
+ * NEVER ride a plain-group anchor: reply_in_thread on a non-topic message
+ * spawns a brand-new topic.
+ */
+function cotPlacement(ds: DaemonSession, state: CotState): { origin_message_id?: string; reply_in_thread?: boolean } {
+  const target = resolveSessionReplyTarget(ds, state.turnId);
+  if (target.mode === 'thread' || target.mode === 'quote') {
+    // Thread-scope sessions always have rootMessageId; the turn-id fallback
+    // covers degenerate restores (a thread trigger id still threads correctly).
+    const anchor = target.rootMessageId ?? (state.turnId.startsWith('om_') ? state.turnId : undefined);
+    if (!anchor) return {};
+    return target.mode === 'thread'
+      ? { origin_message_id: anchor, reply_in_thread: true }
+      : { origin_message_id: anchor };
+  }
+  return state.turnId.startsWith('om_') ? { origin_message_id: state.turnId } : {};
+}
+
 async function apiCreate(ds: DaemonSession, state: CotState): Promise<void> {
   const c = getBotClient(ds.larkAppId);
   const res = await c.request({
@@ -173,10 +205,7 @@ async function apiCreate(ds: DaemonSession, state: CotState): Promise<void> {
     params: { receive_id_type: 'chat_id' },
     data: {
       receive_id: ds.chatId,
-      // Placement: the bubble inherits the topic of the message it originates
-      // from. Turn ids are the triggering Lark message ids for ordinary turns;
-      // synthetic ids (scheduler etc.) are skipped → bubble lands at chat level.
-      ...(state.turnId.startsWith('om_') ? { origin_message_id: state.turnId } : {}),
+      ...cotPlacement(ds, state),
     },
     timeout: COT_REQUEST_TIMEOUT_MS,
   } as any);

--- a/test/cot-message.test.ts
+++ b/test/cot-message.test.ts
@@ -32,7 +32,14 @@ const flush = async (): Promise<void> => {
   for (let i = 0; i < 10; i++) await Promise.resolve();
 };
 
-const makeDs = (): any => ({ larkAppId: 'app1', chatId: 'oc_chat1', session: { sessionId: 's1' } });
+/** Default: a thread-scope (topic) session — scope undefined ≠ 'chat', with
+ *  the topic root as rootMessageId, matching real topic sessions. */
+const makeDs = (over: any = {}): any => ({
+  larkAppId: 'app1',
+  chatId: 'oc_chat1',
+  ...over,
+  session: { sessionId: 's1', rootMessageId: 'om_root1', ...(over.session ?? {}) },
+});
 
 const think = (text: string): any => ({ kind: 'thinking', text });
 const upd = (entries: any[], turnId = 'om_turn1'): any => ({ type: 'thinking_update', entries, turnId });
@@ -56,13 +63,15 @@ beforeEach(() => {
 });
 
 describe('handleCotThinkingUpdate', () => {
-  it('creates the CoT with topic origin, sends the AG-UI prologue and the first segment node', async () => {
+  it('topic session: creates INSIDE the topic (root anchor + reply_in_thread), sends the AG-UI prologue', async () => {
     const ds = makeDs();
     expect(handleCotThinkingUpdate(ds, upd([think('step 1')]))).toBe(true);
     await flush();
     const create = request.mock.calls.find(([req]) => req.method === 'POST')![0];
     expect(create.params).toEqual({ receive_id_type: 'chat_id' });
-    expect(create.data).toEqual({ receive_id: 'oc_chat1', origin_message_id: 'om_turn1' });
+    // origin_message_id alone parents the bubble but leaves it at chat level
+    // (outside the topic) — reply_in_thread is what actually threads it.
+    expect(create.data).toEqual({ receive_id: 'oc_chat1', origin_message_id: 'om_root1', reply_in_thread: true });
     const events = pushedEvents();
     expect(events.map(e => e.type)).toEqual([
       'RUN_STARTED', 'REASONING_START',
@@ -71,12 +80,44 @@ describe('handleCotThinkingUpdate', () => {
     expect(events[3].content.delta).toBe('step 1');
   });
 
-  it('skips origin_message_id for synthetic (non om_) turn ids', async () => {
+  it('topic session with a synthetic (non om_) turn id still threads via the topic root', async () => {
     const ds = makeDs();
     handleCotThinkingUpdate(ds, upd([think('x')], 'sched-123'));
     await flush();
     const create = request.mock.calls.find(([req]) => req.method === 'POST')![0];
+    expect(create.data).toEqual({ receive_id: 'oc_chat1', origin_message_id: 'om_root1', reply_in_thread: true });
+  });
+
+  it('chat-scope session: anchors to the triggering message WITHOUT reply_in_thread (a plain-group anchor must not spawn a topic)', async () => {
+    const ds = makeDs({ scope: 'chat' });
+    handleCotThinkingUpdate(ds, upd([think('x')]));
+    await flush();
+    const create = request.mock.calls.find(([req]) => req.method === 'POST')![0];
+    expect(create.data).toEqual({ receive_id: 'oc_chat1', origin_message_id: 'om_turn1' });
+  });
+
+  it('chat-scope session skips origin_message_id for synthetic turn ids', async () => {
+    const ds = makeDs({ scope: 'chat' });
+    handleCotThinkingUpdate(ds, upd([think('x')], 'sched-123'));
+    await flush();
+    const create = request.mock.calls.find(([req]) => req.method === 'POST')![0];
     expect(create.data).toEqual({ receive_id: 'oc_chat1' });
+  });
+
+  it('chat-scope turn folded into a topic (per-turn thread reply target) threads into that topic', async () => {
+    const ds = makeDs({ scope: 'chat', session: { replyTargets: { om_turn1: { rootMessageId: 'om_fold_root' } } } });
+    handleCotThinkingUpdate(ds, upd([think('x')]));
+    await flush();
+    const create = request.mock.calls.find(([req]) => req.method === 'POST')![0];
+    expect(create.data).toEqual({ receive_id: 'oc_chat1', origin_message_id: 'om_fold_root', reply_in_thread: true });
+  });
+
+  it('chat-scope quote-only reply target anchors to the quote WITHOUT reply_in_thread', async () => {
+    const ds = makeDs({ scope: 'chat', session: { replyTargets: { om_turn1: { rootMessageId: 'om_quote_tgt', quoteOnly: true } } } });
+    handleCotThinkingUpdate(ds, upd([think('x')]));
+    await flush();
+    const create = request.mock.calls.find(([req]) => req.method === 'POST')![0];
+    expect(create.data).toEqual({ receive_id: 'oc_chat1', origin_message_id: 'om_quote_tgt' });
   });
 
   it('pushes each new thinking entry as its own reasoning message (one node per entry)', async () => {

--- a/test/cot-message.test.ts
+++ b/test/cot-message.test.ts
@@ -112,6 +112,47 @@ describe('handleCotThinkingUpdate', () => {
     expect(create.data).toEqual({ receive_id: 'oc_chat1', origin_message_id: 'om_fold_root', reply_in_thread: true });
   });
 
+  it('uses the FROZEN per-turn context, so a pruned live entry cannot flatten the bubble', async () => {
+    // replyTargets is capped at 32 (REPLY_TARGETS_MAX) while turnReplyContexts
+    // holds 256, and the live entry is written at message-arrival while the
+    // bubble is created on the turn's first thinking_update. On a busy session
+    // the live entry can be pruned in that window: the frozen context still
+    // says {thread, om_fold} where resolveSessionReplyTarget has degraded to
+    // {plain} — which would resurrect this very bug in the fold-back case.
+    const ds = makeDs({
+      scope: 'chat',
+      currentReplyTarget: { rootMessageId: 'om_other', turnId: 'om_other_turn', updatedAt: new Date().toISOString() },
+      session: {
+        // Live per-turn entry for om_turn1 is GONE (pruned); only the frozen one remains.
+        replyTargets: {},
+        turnReplyContexts: { om_turn1: { target: { mode: 'thread', rootMessageId: 'om_fold_root' } } },
+        currentReplyTarget: { rootMessageId: 'om_other', turnId: 'om_other_turn', updatedAt: new Date().toISOString() },
+      },
+    });
+    handleCotThinkingUpdate(ds, upd([think('x')]));
+    await flush();
+    const create = request.mock.calls.find(([req]) => req.method === 'POST')![0];
+    expect(create.data).toEqual({ receive_id: 'oc_chat1', origin_message_id: 'om_fold_root', reply_in_thread: true });
+  });
+
+  it('degrades to a chat-level bubble when the thread anchor is not an om_ message id', async () => {
+    // session.rootMessageId is NOT always a message id on a thread-scope
+    // session: a silent new-topic schedule stores `schedule-run:<task>:<uuid>`,
+    // and `schedule add --topic --root-msg-id <any string>` is unvalidated (the
+    // cross-thread fire path anchors it verbatim without probing, so it does
+    // not self-heal). Feishu rejects a non-om_ origin and a failed create kills
+    // thinking for the WHOLE turn — a chat-level bubble is strictly better.
+    for (const bad of ['schedule-run:task1:uuid1', 'oc_chat1']) {
+      request.mockClear();
+      const ds = makeDs({ session: { rootMessageId: bad } });
+      handleCotThinkingUpdate(ds, upd([think('x')], 'schedule:task1:uuid1'));
+      await flush();
+      const create = request.mock.calls.find(([req]) => req.method === 'POST')![0];
+      expect(create.data, `non-om_ anchor ${bad} must not reach Feishu`)
+        .toEqual({ receive_id: 'oc_chat1' });
+    }
+  });
+
   it('chat-scope quote-only reply target anchors to the quote WITHOUT reply_in_thread', async () => {
     const ds = makeDs({ scope: 'chat', session: { replyTargets: { om_turn1: { rootMessageId: 'om_quote_tgt', quoteOnly: true } } } });
     handleCotThinkingUpdate(ds, upd([think('x')]));


### PR DESCRIPTION
## 改了什么

修复话题群（话题会话）里 CoT 思考气泡发到话题外、落在群级别的问题。

根因：`message_cot` create 只传 `origin_message_id` 时，创建出的消息只有 parent/root 关系、**没有 thread_id**（message.get 实测），在话题群里渲染为群级消息。实测该接口支持与普通 reply API 同语义的 `reply_in_thread`：origin + flag 创建后消息 `thread_id` 落到 `omt_*`，正确进话题。

修法：`apiCreate` 的落点改为镜像 sessionReply 的 reply-target 路由（复用 `core/reply-target.ts` 的 `resolveSessionReplyTarget`，与流式卡片同源）：

- **thread target**（话题会话、chat-scope 折叠进话题的 turn）→ 锚定 `rootMessageId` + `reply_in_thread: true`；话题会话的 synthetic turn（scheduler 等）也随锚点进话题，不再漏到群级
- **quote target** → 只锚定引用消息，不带 flag
- **plain chat-scope** → 保持原行为（`om_` 触发消息作 origin）；普通群锚点**绝不能带 `reply_in_thread`**（会凭空拉出新话题），测试有显式断言

## 影响面

只动 `im/lark/cot-message.ts` 的 create 落点（新增 `cotPlacement`），事件流/收尾/孤儿清扫不变。会话类型全覆盖核对：话题会话（修复对象）、chat-scope 普通群（行为不变，含 synthetic turn）、chat-scope 折叠话题/引用（新增正确路由）、p2p（chat-scope plain，行为不变）。

## 测试验证

- 空 API 探针（真实话题群实测）：origin_message_id alone → 无 thread_id（复现 bug）；origin + reply_in_thread → `thread_id = omt_*`（进话题），root 与话题内消息作锚点均验证
- `npx tsc --noEmit` 通过；`test/cot-message.test.ts` 25 用例全绿（落点矩阵：话题/话题+synthetic/chat-scope plain/chat-scope synthetic/折叠话题/quote-only 共 6 个 create 断言）
- 已 `pnpm switch:here && pnpm daemon:restart` 部署，飞书话题会话实测结果见评论

Made with [Cursor](https://cursor.com)