### PR TITLE
fix(sandbox): sandbox=true 下 skill manifest 不可读导致 skill show 报 not found

### DIFF
--- a/src/core/skills/cli-session-command.ts
+++ b/src/core/skills/cli-session-command.ts
@@ -1,4 +1,4 @@
-import { readSessionSkillManifest } from './manifest-store.js';
+import { readSessionSkillManifest, SkillManifestReadError, SkillManifestParseError } from './manifest-store.js';
 import { listSkillResources, readSkillEntrypoint, readSkillResource } from './resource-reader.js';
 import { builtinSkillContent, builtinSkillEntries } from '../../skills/injection-mode.js';
 import { whiteboardEnabled } from '../../services/whiteboard-store.js';
@@ -37,7 +37,21 @@ export function runSkillSessionCommand(
   }
   const sessionId = sessionIdFromEnv(env);
   if (!sessionId) return { code: 2, stdout: '', stderr: 'missing BOTMUX_SESSION_ID\n' };
-  const manifest = readSessionSkillManifest(sessionId);
+  let manifest;
+  try {
+    manifest = readSessionSkillManifest(sessionId);
+  } catch (err) {
+    // Present-but-unreadable (sandbox/policy) or corrupt manifest — a real
+    // fault, NOT "not found". Distinct message + exit 1 so the sandbox misconfig
+    // is diagnosable instead of masquerading as an absent manifest (exit 2).
+    if (err instanceof SkillManifestReadError) {
+      return { code: 1, stdout: '', stderr: `skill manifest exists but is unreadable for session ${sessionId} (${(err.cause as any)?.code ?? 'read error'}) — check the file sandbox read-only policy: ${err.path}\n` };
+    }
+    if (err instanceof SkillManifestParseError) {
+      return { code: 1, stdout: '', stderr: `skill manifest is corrupt for session ${sessionId}: ${err.path}\n` };
+    }
+    throw err;
+  }
   if (!manifest) {
     // No user-skill manifest — still surface built-ins for discovery.
     if (sub === 'list') {

--- a/src/core/skills/manifest-store.ts
+++ b/src/core/skills/manifest-store.ts
@@ -1,8 +1,26 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { config } from '../../config.js';
 import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import type { SessionSkillManifest } from './types.js';
+
+/** Manifest file exists but could not be READ (permission denied, I/O error).
+ *  Distinct from "absent" so callers can diagnose a sandbox/policy misconfig
+ *  instead of reporting a misleading "not found". */
+export class SkillManifestReadError extends Error {
+  constructor(public readonly path: string, public readonly cause: any) {
+    super(`skill manifest unreadable (${cause?.code ?? 'read error'}): ${path}`);
+    this.name = 'SkillManifestReadError';
+  }
+}
+
+/** Manifest file was read but is not valid JSON. */
+export class SkillManifestParseError extends Error {
+  constructor(public readonly path: string, public readonly cause: any) {
+    super(`skill manifest is corrupt (invalid JSON): ${path}`);
+    this.name = 'SkillManifestParseError';
+  }
+}
 
 function manifestDir(): string {
   return join(config.session.dataDir, 'skill-manifests');
@@ -19,11 +37,24 @@ export function writeSessionSkillManifest(manifest: SessionSkillManifest): void 
 
 export function readSessionSkillManifest(sessionId: string): SessionSkillManifest | null {
   const file = manifestPath(sessionId);
-  if (!existsSync(file)) return null;
+  let raw: string;
   try {
-    return JSON.parse(readFileSync(file, 'utf-8')) as SessionSkillManifest;
-  } catch {
-    return null;
+    raw = readFileSync(file, 'utf-8');
+  } catch (err: any) {
+    // ENOENT is the only "genuinely absent" case → null (callers report
+    // not-found). A permission error (EACCES/EPERM — e.g. the file sandbox
+    // never exposed this session's manifest) or any other read failure is a
+    // real fault: surface it so `skill show` can tell "no manifest" apart from
+    // "manifest unreadable", instead of masking a sandbox misconfig as
+    // not-found (the historical failure mode).
+    if (err?.code === 'ENOENT') return null;
+    throw new SkillManifestReadError(file, err);
+  }
+  try {
+    return JSON.parse(raw) as SessionSkillManifest;
+  } catch (err: any) {
+    // File is present and readable but corrupt — a distinct, diagnosable fault.
+    throw new SkillManifestParseError(file, err);
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12903,6 +12903,20 @@ async function spawnCli(
         config.session.dataDir,
       ).map(canonical));
     }
+    // The sandboxed CLI reads its OWN session's skill manifest via
+    // `botmux skill show <name>` (manifest-store.ts writes it to
+    // `<config.session.dataDir>/skill-manifests/<sessionId>.json`). Without an
+    // explicit carve-out the file sandbox never exposes it, so the read EACCES's
+    // and `skill show` maps that to "manifest not found" — user-skill bodies are
+    // unreadable under sandbox=true + skillInjection=prompt. Expose ONLY this
+    // session's own manifest file, read-only, canonicalized so a symlinked HOME
+    // (`/home/u` → `/data00/home/u`) still matches. Scoping to the single
+    // `<sessionId>.json` (not the whole skill-manifests dir) keeps a task from
+    // reading other sessions' manifests. Built from config.session.dataDir — the
+    // exact path the store writes to, not the possibly-unset SESSION_DATA_DIR.
+    mandatoryReadOnlyPaths.push(
+      canonical(join(config.session.dataDir, 'skill-manifests', `${cfg.sessionId}.json`)),
+    );
     if (process.platform === 'darwin') {
       const gatewaySocketRoot = canonical(
         sessionMcpGatewayHost ? dirname(sessionMcpGatewayHost.socketDir) : tmpdir(),

--- a/test/skill-cli-commands.test.ts
+++ b/test/skill-cli-commands.test.ts
@@ -62,4 +62,18 @@ describe('botmux skill session command', () => {
   it('refuses to run without a session id', () => {
     expect(runSkillSessionCommand(['list'], {}).stderr).toContain('missing BOTMUX_SESSION_ID');
   });
+
+  it('reports a corrupt manifest as unreadable, not not-found', () => {
+    write(join(dataDir, 'skill-manifests', 'broken.json'), '{ nope');
+    const res = runSkillSessionCommand(['show', 'deploy'], { BOTMUX_SESSION_ID: 'broken' });
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain('corrupt');
+    expect(res.stderr).not.toContain('not found');
+  });
+
+  it('still reports a genuinely absent manifest as not found', () => {
+    const res = runSkillSessionCommand(['show', 'deploy'], { BOTMUX_SESSION_ID: 'absent' });
+    expect(res.code).toBe(2);
+    expect(res.stderr).toContain('manifest not found');
+  });
 });

--- a/test/skill-manifest-store.test.ts
+++ b/test/skill-manifest-store.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { readSessionSkillManifest, writeSessionSkillManifest } from '../src/core/skills/manifest-store.js';
+import {
+  readSessionSkillManifest,
+  writeSessionSkillManifest,
+  SkillManifestReadError,
+  SkillManifestParseError,
+} from '../src/core/skills/manifest-store.js';
 import type { SessionSkillManifest } from '../src/core/skills/types.js';
 
 describe('session skill manifest store', () => {
@@ -33,5 +38,35 @@ describe('session skill manifest store', () => {
     writeSessionSkillManifest(manifest);
 
     expect(readSessionSkillManifest('s1')).toEqual(manifest);
+  });
+
+  it('returns null only when the manifest is genuinely absent (ENOENT)', () => {
+    expect(readSessionSkillManifest('never-written')).toBeNull();
+  });
+
+  it('throws a corrupt-JSON error instead of masking it as not-found', () => {
+    mkdirSync(join(dataDir, 'skill-manifests'), { recursive: true });
+    writeFileSync(join(dataDir, 'skill-manifests', 'bad.json'), '{ not valid json');
+    expect(() => readSessionSkillManifest('bad')).toThrow(SkillManifestParseError);
+  });
+
+  it('throws a read error (not null) when the manifest is present but unreadable', () => {
+    // A permission-denied read (the sandbox never exposed this session's
+    // manifest) must NOT collapse to "not found" — regression for the
+    // sandbox=true skill-body-unreadable bug.
+    mkdirSync(join(dataDir, 'skill-manifests'), { recursive: true });
+    const file = join(dataDir, 'skill-manifests', 'locked.json');
+    writeFileSync(file, '{}');
+    chmodSync(file, 0o000);
+    try {
+      // root ignores mode bits — skip the assertion there rather than false-fail.
+      let readable = true;
+      try { readSessionSkillManifest('locked'); } catch { readable = false; }
+      if (typeof process.getuid === 'function' && process.getuid() === 0) return;
+      expect(readable).toBe(false);
+      expect(() => readSessionSkillManifest('locked')).toThrow(SkillManifestReadError);
+    } finally {
+      chmodSync(file, 0o600);
+    }
   });
 });


### PR DESCRIPTION
## 问题

`sandbox=true` + `skillInjection=prompt` 时，任务内执行 `botmux skill show <name>` 对所有用户 Skill 统一返回：

```
skill manifest not found for session <session-id>
```

但 manifest 文件在沙箱外用同一 session id 能读到，且执行时该文件确实已存在（reporter 提供：session `66a95046-...`，manifest 于 `16:02:58` 已生成，`16:07:30` 任务内连续 5 次 `skill show` 全部 not found）。因此这里的 "not found" 实际是**沙箱不可读**，而非文件不存在。

## 根因

两处叠加：

1. **worker.ts 构造 FsPolicy 时没有把当前 session 的 skill manifest 加入只读白名单**。manifest 由 `manifest-store.ts` 写到 `<config.session.dataDir>/skill-manifests/<sessionId>.json`，但沙箱从未 re-expose 它 → 沙箱内读取 EACCES。
2. **`readSessionSkillManifest()` 只用 `existsSync` 判断**，读失败一律 `catch → 返回 null`，把权限错误吞成了"不存在"，最终显示为 not found，掩盖了沙箱配置缺陷。

## 改动（对应 reporter 的方案，最小范围）

- `worker.ts`：把**仅当前 session 自己的** manifest 文件加入 `mandatoryReadOnlyPaths`，只读；用 `canonical()` 规范化，覆盖 `/home/u → /data00/home/u` 这类 symlink HOME（验收 #6）。只放行 `<sessionId>.json` 单文件、不放整个目录 → 任务读不到别的 session 的 manifest（验收 #2/#3）。路径由 `config.session.dataDir` 构造（store 实际写入路径），不依赖可能未设的 `SESSION_DATA_DIR`。
- `manifest-store.ts`：`readSessionSkillManifest()` **仅 ENOENT 返回 null**；权限/读错误抛 `SkillManifestReadError`，JSON 损坏抛 `SkillManifestParseError`（验收 #4/#5，错误类型可区分）。
- `cli-session-command.ts`：上述两类错误映射成可诊断信息 + exit 1；真正不存在仍是 not found + exit 2。

不扩大对 Botmux 配置 / 凭证 / 其他任务数据的访问面（验收 #8）。

改动文件：`src/worker.ts`、`src/core/skills/manifest-store.ts`、`src/core/skills/cli-session-command.ts` + 两个测试，共 +117 / -9。

## 验证

- 新增回归：manifest 缺失 → null；损坏 → 抛 `SkillManifestParseError`；present-but-unreadable（`chmod 000`）→ 抛 `SkillManifestReadError`（root 下自动跳过）；CLI 层损坏 vs 缺失的消息与退出码区分。
- 全绿：`skill-manifest-store` / `skill-cli-commands` / `session-skill-runtime` / `session-skill-injection` / `session-skill-manifest-resolution` / `skill-resource-reader` / `plugin-cli-generation` / `fs-policy`（70）。
- `tsc --noEmit` 全量无报错。

## 仍未验证

| 剩余检查 | 需要的环境 / 原因 | 影响范围 |
| --- | --- | --- |
| Linux bwrap 下 `sandbox=true` 真机端到端：`skill show` 读到完整 Skill 正文；`~/.dsh`/manifest 只读可读、其他 session manifest 被拒 | 需 Linux + bwrap；本地 macOS 无法建立 sandbox 命名空间 | 阻塞发布，不阻塞合并 |
| `fs-policy-bwrap.e2e` / `sandbox-mask-manifest` 的 bwrap 用例 | 同上（本地 macOS 全部 skip，非本 PR 引入） | 不阻塞 |

## 对现有任务

沙箱策略在任务创建时冻结，本修复只对**新任务**生效；已创建任务需新建任务或重新生成沙箱策略。修复上线后，reporter 临时热更新的 `sandboxPaths.readOnly: .../skill-manifests`（会放大到全目录元数据）应撤销。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
