### PR TITLE
fix(dsh): 兼容版本化凭据文件

### DIFF
--- a/src/dsh-runner.ts
+++ b/src/dsh-runner.ts
@@ -263,16 +263,21 @@ ${providersYaml}
 `;
 }
 
-/** Load ~/.dsh/.credentials.yaml (flat KEY: value) as a string map. Missing
- *  file → empty (the runtime then falls back to the ambient environment). */
+/** Load credential references from ~/.dsh/.credentials.yaml as an env map.
+ *  Current DSH writes `{ version: 1, refs: { KEY: value } }`; retain support
+ *  for the pre-release flat `KEY: value` layout used by older installations.
+ *  Missing file → empty (the runtime then falls back to ambient environment). */
 function loadCredentials(): Record<string, string> {
   const credPath = join(homedir(), '.dsh', '.credentials.yaml');
   if (!existsSync(credPath)) return {};
   const parsed = parseYaml(readFileSync(credPath, 'utf8')) as unknown;
+  const source = isRecord(parsed) && parsed.version === 1 && isRecord(parsed.refs)
+    ? parsed.refs
+    : parsed;
   const out: Record<string, string> = {};
-  if (isRecord(parsed)) {
-    for (const [k, v] of Object.entries(parsed)) {
-      if (typeof v === 'string') out[k] = v;
+  if (isRecord(source)) {
+    for (const [k, v] of Object.entries(source)) {
+      if (typeof v === 'string' && v.length > 0) out[k] = v;
     }
   }
   return out;

--- a/test/dsh-runner.test.ts
+++ b/test/dsh-runner.test.ts
@@ -382,14 +382,52 @@ describe('dsh-runner', () => {
     await waitFor(() => parseMarkers(h.stdout).some(m => m.kind === 'final'), { label: 'final marker' });
   });
 
-  it('boots with credentials from ~/.dsh/.credentials.yaml and no ambient DEEPSEEK_API_KEY', async () => {
+  it('passes versioned credential refs to the dsh child without exposing records', async () => {
     const home = mkdtempSync(join(tmpdir(), 'dsh-runner-test-'));
-    writeNativeDshConfig(home, SUPER_RELAY_SETTINGS, 'SUPER_RELAY_API_KEY: cred-from-file\nDEEPSEEK_API_KEY: ds-from-file\n');
-    h = spawnRunner('happy', [], { DEEPSEEK_API_KEY: '' }, home);
+    writeNativeDshConfig(home, SUPER_RELAY_SETTINGS, `
+version: 1
+refs:
+  SUPER_RELAY_API_KEY: cred-from-versioned-file
+records:
+  llm-pi-ai/super-relay:
+    kind: grant
+    payload:
+      access: must-not-be-an-env-value
+`);
+    h = spawnRunner('happy', [], {
+      SUPER_RELAY_API_KEY: undefined,
+      FAKE_DSH_EXPECT_ENV_JSON: JSON.stringify({ SUPER_RELAY_API_KEY: 'cred-from-versioned-file' }),
+      FAKE_DSH_EXPECT_ABSENT_ENV: 'records',
+    }, home);
     await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
 
-    // The runner booted successfully reading credentials from the native file.
     expect(existsSync(join(home, '.dsh', 'botmux', 'cordis.yml'))).toBe(true);
+  });
+
+  it('retains support for pre-release flat credential files', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-runner-test-'));
+    writeNativeDshConfig(home, SUPER_RELAY_SETTINGS, 'SUPER_RELAY_API_KEY: cred-from-flat-file\n');
+    h = spawnRunner('happy', [], {
+      SUPER_RELAY_API_KEY: undefined,
+      FAKE_DSH_EXPECT_ENV_JSON: JSON.stringify({ SUPER_RELAY_API_KEY: 'cred-from-flat-file' }),
+    }, home);
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
+  });
+
+  it('lets ambient credentials override the versioned credential file', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-runner-test-'));
+    writeNativeDshConfig(home, SUPER_RELAY_SETTINGS, `
+version: 1
+refs:
+  SUPER_RELAY_API_KEY: cred-from-file
+  EMPTY_CREDENTIAL: ''
+`);
+    h = spawnRunner('happy', [], {
+      SUPER_RELAY_API_KEY: 'cred-from-environment',
+      FAKE_DSH_EXPECT_ENV_JSON: JSON.stringify({ SUPER_RELAY_API_KEY: 'cred-from-environment' }),
+      FAKE_DSH_EXPECT_ABSENT_ENV: 'EMPTY_CREDENTIAL',
+    }, home);
+    await waitFor(() => h.stdout.includes('›'), { label: 'ready marker' });
   });
 
   it('lets --model argv override the settings.yaml model', async () => {

--- a/test/fixtures/fake-dsh-server.mjs
+++ b/test/fixtures/fake-dsh-server.mjs
@@ -36,6 +36,26 @@ import { appendFileSync } from 'node:fs';
 const scenario = process.env.FAKE_DSH_SCENARIO ?? 'happy';
 const finalText = process.env.FAKE_DSH_FINAL_TEXT ?? '你好，我是 dsh。';
 const logPath = process.env.FAKE_DSH_LOG;
+const expectedEnv = process.env.FAKE_DSH_EXPECT_ENV_JSON
+  ? JSON.parse(process.env.FAKE_DSH_EXPECT_ENV_JSON)
+  : {};
+const expectedAbsentEnv = (process.env.FAKE_DSH_EXPECT_ABSENT_ENV ?? '')
+  .split(',')
+  .map(name => name.trim())
+  .filter(Boolean);
+
+for (const [name, expected] of Object.entries(expectedEnv)) {
+  if (process.env[name] !== expected) {
+    process.stderr.write(`expected env ${name} to match test value\n`);
+    process.exit(2);
+  }
+}
+for (const name of expectedAbsentEnv) {
+  if (process.env[name] !== undefined) {
+    process.stderr.write(`expected env ${name} to be absent\n`);
+    process.exit(2);
+  }
+}
 
 let inputBuffer = '';
 let promptCount = 0;


### PR DESCRIPTION
## 背景

Botmux 的 Official dsh runner 会复用 `~/.dsh/settings.yaml` 与 `~/.dsh/.credentials.yaml`。当前 `loadCredentials()` 只按预发布期的平铺 `KEY: value` 格式读取凭据，但新版 DSH Models 页面写入的是版本化文档：

```yaml
version: 1
refs:
  PROVIDER_API_KEY: ...
records:
  ...
```

因此 runner 虽然能生成正确的 pi-ai provider composition，却没有把 `refs` 中的凭据传给 `dsh-jsonrpc-agent`，最终报 `no credential for provider route`。

## 修改

- 识别 `version: 1` 文档并仅从 `refs` 提取非空字符串凭据
- 保留旧版 flat mapping 兼容
- 保持环境变量覆盖文件凭据的既有优先级
- 不将 `records` 等结构化凭据内容注入子进程环境
- 增加 fake server 环境断言及三组回归测试

## 影响面

仅影响 `dsh` Official JSON-RPC runner 的本地凭据加载。其它 CLI、后端和飞书路由不受影响。

## 验证

基于当前 master 对应文件执行：

```bash
pnpm vitest run --project unit test/dsh-runner.test.ts
pnpm exec tsc --noEmit
git diff --check -- src/dsh-runner.ts test/dsh-runner.test.ts test/fixtures/fake-dsh-server.mjs
```

结果：

- dsh-runner：22/22 tests passed
- TypeScript：通过
- diff check：通过
- 本机真实链路验证：Official dsh 使用 DSH `version: 1 / refs` 凭据后完成模型调用并通过 Botmux bridge 返回 final output
