### PR TITLE
fix(issue): 固定默认目录兜底领取仓库扫描

### DIFF
--- a/src/im/lark/issue-command-deps.ts
+++ b/src/im/lark/issue-command-deps.ts
@@ -5,7 +5,7 @@
  * bot 注册表都在这里装配。card-handler 与 command-handler 都从这里取。
  */
 import { config } from '../../config.js';
-import { effectiveBotDisplayName, getBot, type BotConfig } from '../../bot-registry.js';
+import { effectiveBotDisplayName, effectiveDefaultWorkingDir, getBot } from '../../bot-registry.js';
 import { logger } from '../../utils/logger.js';
 import { configuredWorkingDirs } from '../../utils/working-dir.js';
 import { readPlatformBinding } from '../../platform/binding.js';
@@ -87,25 +87,6 @@ export function setIssueActivate(fn: ActivateSession): void {
   registeredActivate = fn;
 }
 
-/**
- * Issue 领取必须选一个本地仓库，但固定目录模式的 Bot 只配置
- * `defaultWorkingDir`，没有仓库卡片使用的 `workingDir/workingDirs`。
- *
- * 显式扫描根始终优先；只有完全没配置扫描根时，才把固定默认目录作为
- * Issue 领取的兜底扫描入口。这样不会把 default 混进已有的多仓库候选，
- * 也不改变普通新会话“直接进入 defaultWorkingDir”的行为。
- */
-export function issueWorkingDirs(
-  cfg: Pick<BotConfig, 'workingDir' | 'workingDirs' | 'defaultWorkingDir'>,
-): string[] {
-  const explicit = configuredWorkingDirs({
-    workingDir: cfg.workingDir,
-    workingDirs: cfg.workingDirs,
-  });
-  if (explicit.length > 0) return explicit;
-  return configuredWorkingDirs({ workingDir: cfg.defaultWorkingDir });
-}
-
 export function buildIssueCommandDeps(activate: ActivateSession | undefined = registeredActivate): IssueCommandDeps {
   return {
     fetchTeams: () => fetchTeams() as any,
@@ -123,9 +104,20 @@ export function buildIssueCommandDeps(activate: ActivateSession | undefined = re
     workingDirs: (larkAppId: string) => {
       try {
         const cfg = getBot(larkAppId).config;
-        return issueWorkingDirs(cfg);
+        return configuredWorkingDirs({
+          workingDir: cfg.workingDir,
+          workingDirs: cfg.workingDirs,
+        });
       } catch {
         return [];
+      }
+    },
+
+    defaultWorkingDir: (larkAppId: string) => {
+      try {
+        return effectiveDefaultWorkingDir(getBot(larkAppId).config);
+      } catch {
+        return undefined;
       }
     },
 

--- a/src/im/lark/issue-command-deps.ts
+++ b/src/im/lark/issue-command-deps.ts
@@ -5,8 +5,9 @@
  * bot 注册表都在这里装配。card-handler 与 command-handler 都从这里取。
  */
 import { config } from '../../config.js';
-import { effectiveBotDisplayName, getBot } from '../../bot-registry.js';
+import { effectiveBotDisplayName, getBot, type BotConfig } from '../../bot-registry.js';
 import { logger } from '../../utils/logger.js';
+import { configuredWorkingDirs } from '../../utils/working-dir.js';
 import { readPlatformBinding } from '../../platform/binding.js';
 import {
   bindIssue,
@@ -86,6 +87,25 @@ export function setIssueActivate(fn: ActivateSession): void {
   registeredActivate = fn;
 }
 
+/**
+ * Issue 领取必须选一个本地仓库，但固定目录模式的 Bot 只配置
+ * `defaultWorkingDir`，没有仓库卡片使用的 `workingDir/workingDirs`。
+ *
+ * 显式扫描根始终优先；只有完全没配置扫描根时，才把固定默认目录作为
+ * Issue 领取的兜底扫描入口。这样不会把 default 混进已有的多仓库候选，
+ * 也不改变普通新会话“直接进入 defaultWorkingDir”的行为。
+ */
+export function issueWorkingDirs(
+  cfg: Pick<BotConfig, 'workingDir' | 'workingDirs' | 'defaultWorkingDir'>,
+): string[] {
+  const explicit = configuredWorkingDirs({
+    workingDir: cfg.workingDir,
+    workingDirs: cfg.workingDirs,
+  });
+  if (explicit.length > 0) return explicit;
+  return configuredWorkingDirs({ workingDir: cfg.defaultWorkingDir });
+}
+
 export function buildIssueCommandDeps(activate: ActivateSession | undefined = registeredActivate): IssueCommandDeps {
   return {
     fetchTeams: () => fetchTeams() as any,
@@ -103,10 +123,7 @@ export function buildIssueCommandDeps(activate: ActivateSession | undefined = re
     workingDirs: (larkAppId: string) => {
       try {
         const cfg = getBot(larkAppId).config;
-        return [
-          ...(cfg.workingDir ? [cfg.workingDir] : []),
-          ...(cfg.workingDirs ?? []),
-        ];
+        return issueWorkingDirs(cfg);
       } catch {
         return [];
       }

--- a/src/im/lark/issue-command.ts
+++ b/src/im/lark/issue-command.ts
@@ -16,7 +16,7 @@
  * 未经校验。
  */
 import { logger } from '../../utils/logger.js';
-import { scanMultipleProjects } from '../../services/project-scanner.js';
+import { describeProjectDir, scanMultipleProjects } from '../../services/project-scanner.js';
 import { configuredWorkingDirs, expandHomePath } from '../../utils/working-dir.js';
 import {
   ISSUE_ACTION_CLAIM_CANCEL,
@@ -54,8 +54,10 @@ export interface IssueCommandDeps {
   >;
   /** 该 bot 的管理员 open_id 名单（`resolvedAllowedUsers`）。 */
   allowedUsers: (larkAppId: string) => string[];
-  /** 该 bot 配置的工作目录（未展开 `~`）。 */
+  /** 该 bot 显式配置的仓库扫描根（未展开 `~`）。 */
   workingDirs: (larkAppId: string) => string[];
+  /** 该 bot 的有效固定目录（fixed / default-oncall，未展开 `~`）。 */
+  defaultWorkingDir: (larkAppId: string) => string | undefined;
   /** 跑 [[issue-release]] 的 `releaseIssue`。按锚点释放，锚点由调用方从当前会话推出来。 */
   runRelease: (anchorId: string) => Promise<TerminalResult>;
   /** 跑 [[issue-release]] 的 `completeIssue`（验收完成）。与释放同形，只是目标态不同。 */
@@ -120,18 +122,31 @@ function toRow(i: PlatformIssue): IssueRowData {
 /**
  * 扫出该 bot 可选的仓库。
  *
- * 不能直接用 `workingDirs`：它常常配的是一个工作区父目录（`~/claude-code-workspace`），
- * 直接当候选，选中的会是工作区根目录。扫一层才拿得到真正的仓库和 worktree。
+ * 显式 `workingDirs` 是工作区父目录，需要递归找出其中的仓库和 worktree。
+ * fixed / default-oncall 则钉住一个目录：只有该目录本身是 git 仓库时才直接生成唯一候选，
+ * 不能把它当扫描根，否则 `~` 等大目录会同步卡住卡片回调，单仓库也会展开数百个 worktree。
  */
 export function reposFor(larkAppId: string, deps: IssueCommandDeps): RepoChoice[] {
   const dirs = configuredWorkingDirs({ workingDirs: deps.workingDirs(larkAppId) }).map(expandHomePath);
-  if (!dirs.length) return [];
   try {
-    return scanMultipleProjects(dirs, 3, { includeWorktrees: true }).map((p) => ({
-      name: p.name,
-      path: p.path,
-      ...(p.branch ? { branch: p.branch } : {}),
-    }));
+    if (dirs.length > 0) {
+      return scanMultipleProjects(dirs, 3, { includeWorktrees: true }).map((p) => ({
+        name: p.name,
+        path: p.path,
+        ...(p.branch ? { branch: p.branch } : {}),
+      }));
+    }
+
+    const defaultDir = deps.defaultWorkingDir(larkAppId)?.trim();
+    if (!defaultDir) return [];
+    const path = expandHomePath(defaultDir);
+    const project = describeProjectDir(path);
+    if (!project) return [];
+    return [{
+      name: project.name,
+      path,
+      ...(project.branch ? { branch: project.branch } : {}),
+    }];
   } catch (e) {
     // 扫描失败不该让整个命令挂掉：回落到空候选，确认卡会说明"没扫到仓库"。
     logger.warn(`[issue] 扫描仓库失败: ${String((e as Error)?.message ?? e)}`);

--- a/test/issue-command-deps.test.ts
+++ b/test/issue-command-deps.test.ts
@@ -1,24 +1,83 @@
-import { describe, expect, it } from 'vitest';
-import { issueWorkingDirs } from '../src/im/lark/issue-command-deps.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import {
+  __testOnly_resetBotRegistry,
+  registerBot,
+  type BotConfig,
+} from '../src/bot-registry.js';
+import { buildIssueCommandDeps } from '../src/im/lark/issue-command-deps.js';
+import { reposFor } from '../src/im/lark/issue-command.js';
 
-describe('Issue 领取仓库来源', () => {
-  it('没有显式扫描根时回退到固定默认目录', () => {
-    expect(issueWorkingDirs({ defaultWorkingDir: '~/botmux' })).toEqual(['~/botmux']);
+function register(config: Partial<BotConfig> & Pick<BotConfig, 'larkAppId'>): void {
+  registerBot({
+    larkAppSecret: '',
+    cliId: 'codex',
+    apiOnly: true,
+    ...config,
   });
+}
 
-  it('显式扫描根存在时不混入固定默认目录', () => {
-    expect(issueWorkingDirs({
+beforeEach(() => __testOnly_resetBotRegistry());
+afterEach(() => __testOnly_resetBotRegistry());
+
+describe('Issue 领取仓库依赖接线', () => {
+  it('显式扫描根优先，不混入 fixed 默认目录', () => {
+    register({
+      larkAppId: 'app_card',
       workingDir: '~/workspace',
       workingDirs: ['~/workspace', '~/other-workspace'],
-      defaultWorkingDir: '~/botmux',
-    })).toEqual(['~/workspace', '~/other-workspace']);
+      defaultWorkingDir: '~/fixed-repo',
+    });
+
+    const deps = buildIssueCommandDeps();
+    expect(deps.workingDirs('app_card')).toEqual(['~/workspace', '~/other-workspace']);
+    expect(deps.defaultWorkingDir('app_card')).toBe('~/fixed-repo');
   });
 
-  it('空白配置不会制造无效候选', () => {
-    expect(issueWorkingDirs({
-      workingDir: ' ',
-      workingDirs: ['', '  '],
-      defaultWorkingDir: ' ',
-    })).toEqual([]);
+  it('fixed 模式接出 defaultWorkingDir，显式扫描根保持为空', () => {
+    register({ larkAppId: 'app_fixed', defaultWorkingDir: '~/fixed-repo' });
+
+    const deps = buildIssueCommandDeps();
+    expect(deps.workingDirs('app_fixed')).toEqual([]);
+    expect(deps.defaultWorkingDir('app_fixed')).toBe('~/fixed-repo');
+  });
+
+  it('oncall 模式接出有效默认目录，显式扫描根保持为空', () => {
+    register({
+      larkAppId: 'app_oncall',
+      defaultOncall: { enabled: true, workingDir: '~/oncall-repo', since: 1 },
+    });
+
+    const deps = buildIssueCommandDeps();
+    expect(deps.workingDirs('app_oncall')).toEqual([]);
+    expect(deps.defaultWorkingDir('app_oncall')).toBe('~/oncall-repo');
+  });
+
+  it('oncall 有效默认目录接入候选生成全链路', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'botmux-issue-oncall-repo-'));
+    try {
+      mkdirSync(join(repo, '.git'));
+      writeFileSync(join(repo, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+      register({
+        larkAppId: 'app_oncall_flow',
+        defaultOncall: { enabled: true, workingDir: repo, since: 1 },
+      });
+
+      expect(reposFor('app_oncall_flow', buildIssueCommandDeps())).toEqual([{
+        name: basename(repo),
+        path: repo,
+        branch: 'unknown',
+      }]);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('未知 bot 返回空配置', () => {
+    const deps = buildIssueCommandDeps();
+    expect(deps.workingDirs('missing')).toEqual([]);
+    expect(deps.defaultWorkingDir('missing')).toBeUndefined();
   });
 });

--- a/test/issue-command-deps.test.ts
+++ b/test/issue-command-deps.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { issueWorkingDirs } from '../src/im/lark/issue-command-deps.js';
+
+describe('Issue 领取仓库来源', () => {
+  it('没有显式扫描根时回退到固定默认目录', () => {
+    expect(issueWorkingDirs({ defaultWorkingDir: '~/botmux' })).toEqual(['~/botmux']);
+  });
+
+  it('显式扫描根存在时不混入固定默认目录', () => {
+    expect(issueWorkingDirs({
+      workingDir: '~/workspace',
+      workingDirs: ['~/workspace', '~/other-workspace'],
+      defaultWorkingDir: '~/botmux',
+    })).toEqual(['~/workspace', '~/other-workspace']);
+  });
+
+  it('空白配置不会制造无效候选', () => {
+    expect(issueWorkingDirs({
+      workingDir: ' ',
+      workingDirs: ['', '  '],
+      defaultWorkingDir: ' ',
+    })).toEqual([]);
+  });
+});

--- a/test/issue-command.test.ts
+++ b/test/issue-command.test.ts
@@ -5,8 +5,10 @@ import {
   handleIssueDone,
   handleIssueRelease,
   handleIssueStatus,
+  reposFor,
   type IssueCommandDeps,
 } from '../src/im/lark/issue-command.js';
+import { scanMultipleProjects } from '../src/services/project-scanner.js';
 import {
   ISSUE_ACTION_CLAIM_CANCEL,
   ISSUE_ACTION_CLAIM_CONFIRM,
@@ -15,6 +17,10 @@ import {
   ISSUE_ACTION_PAGE,
   ISSUE_ACTION_TEAM,
 } from '../src/im/lark/issue-card.js';
+
+vi.mock('../src/services/project-scanner.js', () => ({
+  scanMultipleProjects: vi.fn(() => []),
+}));
 
 const APP = 'cli_worker';
 const ME = 'ou_admin';
@@ -157,6 +163,37 @@ describe('看板导航', () => {
 });
 
 describe('领取', () => {
+  it('只把依赖提供的仓库目录传给候选扫描器', () => {
+    vi.clearAllMocks();
+    vi.mocked(scanMultipleProjects).mockReturnValueOnce([{
+      name: 'card-mode-repo',
+      path: '/w/card-mode-repo',
+      type: 'repo',
+      branch: 'main',
+    }]);
+
+    const choices = reposFor(APP, deps({ workingDirs: () => ['/w/card-mode'] }).d);
+
+    expect(scanMultipleProjects).toHaveBeenCalledWith(
+      ['/w/card-mode'],
+      3,
+      { includeWorktrees: true },
+    );
+    expect(choices).toEqual([{
+      name: 'card-mode-repo',
+      path: '/w/card-mode-repo',
+      branch: 'main',
+    }]);
+  });
+
+  it('依赖没有提供仓库目录时不调用扫描器', () => {
+    vi.clearAllMocks();
+    const choices = reposFor(APP, deps({ workingDirs: () => [] }).d);
+
+    expect(choices).toEqual([]);
+    expect(scanMultipleProjects).not.toHaveBeenCalled();
+  });
+
   it('打开确认卡时按标签自动匹配仓库', async () => {
     const { d } = deps({ workingDirs: () => [] });
     const r = await handleIssueCardAction(

--- a/test/issue-command.test.ts
+++ b/test/issue-command.test.ts
@@ -8,7 +8,7 @@ import {
   reposFor,
   type IssueCommandDeps,
 } from '../src/im/lark/issue-command.js';
-import { scanMultipleProjects } from '../src/services/project-scanner.js';
+import { describeProjectDir, scanMultipleProjects } from '../src/services/project-scanner.js';
 import {
   ISSUE_ACTION_CLAIM_CANCEL,
   ISSUE_ACTION_CLAIM_CONFIRM,
@@ -19,6 +19,7 @@ import {
 } from '../src/im/lark/issue-card.js';
 
 vi.mock('../src/services/project-scanner.js', () => ({
+  describeProjectDir: vi.fn(() => null),
   scanMultipleProjects: vi.fn(() => []),
 }));
 
@@ -48,6 +49,7 @@ function deps(over: Partial<IssueCommandDeps> = {}) {
     runClaim,
     allowedUsers: () => [ME],
     workingDirs: () => [],
+    defaultWorkingDir: () => undefined,
     ...over,
   };
   return {
@@ -172,7 +174,10 @@ describe('领取', () => {
       branch: 'main',
     }]);
 
-    const choices = reposFor(APP, deps({ workingDirs: () => ['/w/card-mode'] }).d);
+    const choices = reposFor(APP, deps({
+      workingDirs: () => ['/w/card-mode'],
+      defaultWorkingDir: () => '/w/fixed-repo',
+    }).d);
 
     expect(scanMultipleProjects).toHaveBeenCalledWith(
       ['/w/card-mode'],
@@ -184,13 +189,36 @@ describe('领取', () => {
       path: '/w/card-mode-repo',
       branch: 'main',
     }]);
+    expect(describeProjectDir).not.toHaveBeenCalled();
   });
 
-  it('依赖没有提供仓库目录时不调用扫描器', () => {
+  it('fixed/oncall 默认目录本身是仓库时直接生成唯一候选', () => {
     vi.clearAllMocks();
-    const choices = reposFor(APP, deps({ workingDirs: () => [] }).d);
+    vi.mocked(describeProjectDir).mockReturnValueOnce({ name: 'fixed-repo', branch: 'main' });
+
+    const choices = reposFor(APP, deps({
+      workingDirs: () => [],
+      defaultWorkingDir: () => '/w/fixed-repo',
+    }).d);
+
+    expect(choices).toEqual([{
+      name: 'fixed-repo',
+      path: '/w/fixed-repo',
+      branch: 'main',
+    }]);
+    expect(describeProjectDir).toHaveBeenCalledWith('/w/fixed-repo');
+    expect(scanMultipleProjects).not.toHaveBeenCalled();
+  });
+
+  it('fixed/oncall 默认目录不是仓库时不递归扫描', () => {
+    vi.clearAllMocks();
+    const choices = reposFor(APP, deps({
+      workingDirs: () => [],
+      defaultWorkingDir: () => '/w/large-root',
+    }).d);
 
     expect(choices).toEqual([]);
+    expect(describeProjectDir).toHaveBeenCalledWith('/w/large-root');
     expect(scanMultipleProjects).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## 改了什么

- Issue 领取继续优先使用显式 `workingDir` / `workingDirs` 扫描根
- 显式扫描根缺失时，通过 `effectiveDefaultWorkingDir` 同时覆盖 fixed 与 default-oncall 模式
- fixed/oncall 兜底目录只在**自身是 Git 仓库**时直接生成唯一候选，不递归扫描子目录，也不展开其 linked worktrees
- 非仓库的大目录（例如 `~`、工作区父目录）维持空候选，避免同步扫描超过飞书卡片回调时限
- 补充 `buildIssueCommandDeps` 真实接线、Oncall 全链路、显式优先级和不递归扫描测试

## 影响面

仅影响飞书 Issue Board 的领取候选仓库解析：

- 显式 card 扫描模式保持原行为（递归扫描仓库和 worktree）
- fixed/default-oncall 模式新增单仓库兜底
- 普通话题启动、Oncall 权限/绑定、CLI/后端和其它 IM 路径均不变

## 验证

- `bun run build`（Bun 1.4.0）：通过
- Issue / working-dir / Oncall / onboarding 扩展回归：14 files / 342 tests passed
- `tsc --noEmit --pretty false`：通过
- `git diff --check`：通过

Fixes #1038