### PR TITLE
fix(dashboard): 顶栏文档链接直接指向官方文档站

### DIFF
--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -1286,7 +1286,7 @@ function DashboardShell(): React.JSX.Element {
               <ThemeMenuSlot />
               <a
                 className="topbar-docs-link"
-                href="https://bytedance.aiforce.cloud/app/app_4k9smq6rdxher/"
+                href="https://deepcoldy.github.io/botmux/"
                 target="_blank"
                 rel="noopener noreferrer"
                 title={t('nav.docs')}

--- a/src/desktop/renderer/index.html
+++ b/src/desktop/renderer/index.html
@@ -153,7 +153,7 @@
           <a
             id="docs-link"
             class="topbar-link"
-            href="https://bytedance.aiforce.cloud/app/app_4k9smq6rdxher/"
+            href="https://deepcoldy.github.io/botmux/"
             target="_blank"
             rel="noopener noreferrer"
             data-i18n="action.docs"


### PR DESCRIPTION
## 背景

Dashboard 顶栏右上角「文档」按钮（Web Dashboard 与桌面端壳层各有一处）当前指向 `https://bytedance.aiforce.cloud/app/app_4k9smq6rdxher/`，点击后会重定向到官方文档站 `https://deepcoldy.github.io/botmux/`。本次把链接改为直接指向官方文档站，去掉这层跳转。

## 改动

- `src/dashboard/web/app.tsx`：`topbar-docs-link` 的 href 改为 `https://deepcoldy.github.io/botmux/`
- `src/desktop/renderer/index.html`：桌面端壳层 `docs-link` 的 href 同步改为同一地址

打开方式（新标签页、`rel="noopener noreferrer"`）与中英文文案均保持不变。

## 影响面

- 仅静态前端资源（dashboard web + desktop renderer），不涉及 daemon / worker / 适配器 / 后端 / 会话类型
- zh/en 行为一致，样式与 i18n 文案未改动，未新增依赖，未改构建链路

## 验证

- `bun run build` 通过（tsc + dashboard:bundle + 各阶段检查）
- `bun run test -- test/desktop/dashboard-desktop-shell.test.ts` 通过（1 个文件 5 个用例）
- `rg` 确认仓库内已无 `bytedance.aiforce` / `app_4k9smq6rdxher` 残留；bundle 产物 `dist/dashboard-web/app.js` 已包含新地址
