### PR TITLE
fix(codex): 修复软链接启动时找不到 code mode host

### DIFF
--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process';
 import { existsSync, statSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { resolveCommand } from './registry.js';
+import { resolveCommandReal } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import { parseDebugModelsJson } from './model-catalog-json.js';
 import type { CliAdapter, PtyHandle } from './types.js';
@@ -142,8 +142,9 @@ function latestCodexSessionForBotmuxSession(botmuxSessionId: string): string | u
 
 export function createCodexAdapter(pathOverride?: string): CliAdapter {
   // resolvedBin is lazy: setup constructs adapters only to read static
-  // modelChoices and must not shell out (see resolveCommand); the binary path
-  // is a spawn-time concern.
+  // modelChoices and must not shell out (see resolveCommandReal); the binary
+  // path is a spawn-time concern. Canonicalize before spawning because Codex
+  // locates bundled helper executables relative to its own executable path.
   const rawBin = pathOverride ?? 'codex';
   let cachedBin: string | undefined;
   return {
@@ -175,7 +176,7 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
     // reads/writes its DBs under CODEX_HOME=BOT_HOME/codex instead, and exposing
     // the host ~/.codex would only leak history/sessions it never touches.
     authPaths: ['~/.codex'],
-    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
+    get resolvedBin(): string { return (cachedBin ??= resolveCommandReal(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, forkSession, workingDir, model, reasoningEffort, disableCliBypass, bypassHookTrust, readIsolation, remoteWsUrl, remoteThreadId }) {
       // Hybrid RPC input mode: attach this TUI to the botmux-owned app-server

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -182,12 +182,12 @@ export function resolveCommand(cmd: string): string {
  * sandbox and the second-stage process crash-loops. Canonicalizing here makes the
  * spawned path identical to the one the sandbox authorized.
  *
- * NOT needed for `resolvedBin` alone: the worker canonicalizes that itself on both
- * the authorization side and the spawn side. The bug only appears where an adapter
- * passes a path THROUGH to something else that execs it — which is why this is a
- * shared helper rather than folded into `resolveCommand` (that would also rewrite
- * the many display/probe call sites, where the user-facing PATH entry is the more
- * useful string).
+ * Also use it for `resolvedBin` when the launched executable discovers sibling
+ * resources from its own path. Codex does this for `codex-code-mode-host`, so
+ * launching an app-bundled Codex through a PATH symlink makes it search beside the
+ * symlink unless the adapter canonicalizes first. Keep this helper separate from
+ * `resolveCommand` so display/probe call sites can still report the user-facing PATH
+ * entry when they do not have an execution-path requirement.
  *
  * Falls back to the non-canonical path when realpath fails (binary genuinely
  * absent) so the failure surfaces as the same unmasked ENOENT as before.

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -350,6 +350,28 @@ describe('codex buildArgs', () => {
     expect(args).not.toContain('--codex-bin');
   });
 
+  it('canonicalizes a symlinked app-bundled Codex before spawning it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'codex-direct-symlink-'));
+    try {
+      const resourcesDir = join(root, 'ChatGPT.app', 'Contents', 'Resources');
+      mkdirSync(resourcesDir, { recursive: true });
+      const realBin = join(resourcesDir, 'codex');
+      writeFileSync(realBin, '#!/bin/sh\n', { mode: 0o755 });
+      writeFileSync(join(resourcesDir, 'codex-code-mode-host'), '#!/bin/sh\n', { mode: 0o755 });
+
+      const linkDir = join(root, 'local', 'bin');
+      mkdirSync(linkDir, { recursive: true });
+      const linkBin = join(linkDir, 'codex');
+      symlinkSync(realBin, linkBin);
+
+      const symlinkAdapter = createCodexAdapter(linkBin);
+      expect(linkBin).not.toBe(realpathSync(realBin));
+      expect(symlinkAdapter.resolvedBin).toBe(realpathSync(realBin));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('bypasses the interactive hook-trust gate right after the approval/sandbox bypass when the toggle is on', () => {
     // codex 0.14x adds a "Press t to trust" gate for the botmux-installed
     // ~/.codex/hooks.json hooks; a headless pane can never press `t`, so without


### PR DESCRIPTION
## 问题

当普通 Codex 适配器通过 PATH 中的软链接启动 App 内置 Codex 时，Codex 会按软链接所在目录查找 `codex-code-mode-host`，导致辅助进程缺失并反复失败。

## 修复

- 启动普通 Codex 前将可执行文件解析为 canonical realpath
- 补充 `resolveCommandReal` 的适用契约说明
- 增加 App bundle + PATH 软链接的回归测试

## 验证

- `bun run build`
- `bun run test -- test/cli-adapters.test.ts`（407/407）
- `git diff --check`

## 范围

仅影响普通 `codex` 适配器的可执行文件解析；其他 CLI 适配器和 `codex-app` 行为不变。