### PR TITLE
fix(setup): 开放平台自动配置无变更时跳过 create+publish 发版

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -677,6 +677,7 @@ async function finishOpenPlatformSetup(
       say('      缺了它，群聊模式 p2pMode=group / 会话群标签 / `/login` 点授权会直接报 20029。');
     }
     if (result.versionId) say(`   已提交发布版本: ${result.versionId}`);
+    else if (result.publishSkipped) say('   本次配置无变更，已跳过发版（未创建新版本）。');
     else say('   已创建版本；未从响应中解析到 versionId，请到开放平台确认是否需要手动发布。');
     say('');
     return outcome;

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -253,7 +253,7 @@ async function tryAutoFixScopes(
   brand: Brand,
   missingCritical: { name: string; desc: string }[],
   missingOptional: { name: string; desc: string }[],
-  opts?: { disableQrLogin?: boolean; silent?: boolean; grantedScopeNames?: string[] },
+  opts?: { disableQrLogin?: boolean; silent?: boolean; grantedScopeNames?: { tenant: string[]; user: string[] } },
 ): Promise<boolean> {
   if (brand !== 'feishu') return false;
 
@@ -265,11 +265,12 @@ async function tryAutoFixScopes(
       brand,
       maxWaitMs: 60_000,
       disableQrLogin: opts?.disableQrLogin,
-      // 把上层自检回读到的「已授权」scope 名字集合往下传：automation 据此在 name
-      // 空间对 manifest 做差集，只对真正还缺的 scope 发 scope/update，并按「确有新增」
-      // 而非「发过 scope/update」置 mutated——这样「配置本就齐全」时才能真正命中无变更
-      // 短路、不再凭空发版。拿不到 granted（如 chicken-and-egg 的 self_manage 冷启动）
-      // 时不传，automation 退回原保守近似。
+      // 把上层自检回读到的「已授权」scope 集合（按 tenant/user 分桶）往下传：automation
+      // 据此在 name 空间**按桶各自**对 manifest 做差集，只对真正还缺的 scope 发
+      // scope/update，并按「确有新增」而非「发过 scope/update」置 mutated——这样「配置本就
+      // 齐全」时才能真正命中无变更短路、不再凭空发版。分桶是为了不让 tenant 授权误伤
+      // user 桶同名 scope（PR #1044 R2）。拿不到 granted（如 chicken-and-egg 的 self_manage
+      // 冷启动）时不传，automation 退回原保守近似。
       grantedScopeNames: opts?.grantedScopeNames,
       onStatus: (msg) => logger.info(`[${larkAppId}] auto-fix: ${msg}`),
       onQrCode: (info) => {
@@ -417,6 +418,23 @@ export async function checkRequiredScopes(larkAppId: string): Promise<void> {
       scopesRaw.map(s => typeof s === 'string' ? s : s?.scope).filter(Boolean) as string[],
     );
 
+    // 按 token 类型分桶的已授权集合，专供 automation 的「无变更短路」按桶做差用。
+    // application/v6 每个 scope 条目自带 token_types:(tenant|user)[]（SDK 类型可查）。
+    // 之所以不能复用上面的扁平 grantedScopes：约 121 个名字同时在 tenant/user 两桶，
+    // tenant/user 是两份独立授权；扁平集合会让「tenant 已授权」误伤 user 桶同名 scope，
+    // 把真正缺的 user 权限静默吞掉（PR #1044 R2）。缺 token_types 的条目**两桶都不放**，
+    // 退回保守近似（该名字照发 scope/update），宁可多发一版也不少发。
+    const grantedScopeBuckets = { tenant: [] as string[], user: [] as string[] };
+    for (const s of scopesRaw) {
+      const name = typeof s === 'string' ? s : s?.scope;
+      if (!name) continue;
+      const tokenTypes: unknown = typeof s === 'string' ? undefined : s?.token_types;
+      if (Array.isArray(tokenTypes)) {
+        if (tokenTypes.includes('tenant')) grantedScopeBuckets.tenant.push(name);
+        if (tokenTypes.includes('user')) grantedScopeBuckets.user.push(name);
+      }
+    }
+
     // 文档评论入口就绪自检：仅对「已订阅过文档」的 bot 生效（opt-in，不打扰其他 bot）。
     // ① 校验文档 app 权限是否开通（可查 → 缺则 DM 深链）② 提醒去后台订阅评论事件
     // drive.notice.comment_add_v1（飞书无 API 可查是否已订阅，只能提醒）——让「订阅
@@ -523,7 +541,7 @@ export async function checkRequiredScopes(larkAppId: string): Promise<void> {
       // before (no API call / no prompt / no nag).
       if (missingOptional.length > 0 && brand === 'feishu') {
         const toppedUp = await tryAutoFixScopes(larkAppId, bot, brand, [], missingOptional,
-          { disableQrLogin: true, silent: true, grantedScopeNames: [...grantedScopes] });
+          { disableQrLogin: true, silent: true, grantedScopeNames: grantedScopeBuckets });
         if (toppedUp) {
           logger.info(`[${larkAppId}] auto-topped-up ${missingOptional.length} optional scope(s): ${missingOptional.map(s => s.name).join('、')}`);
           return;
@@ -539,7 +557,7 @@ export async function checkRequiredScopes(larkAppId: string): Promise<void> {
     // directly add missing scopes and publish a new version without user interaction.
     // Falls through to manual DM warning if session is missing/expired.
     const autoFixed = await tryAutoFixScopes(larkAppId, bot, brand, missingCritical, missingOptional,
-      { grantedScopeNames: [...grantedScopes] });
+      { grantedScopeNames: grantedScopeBuckets });
     if (autoFixed) return;
 
     // Log + DM consolidated message listing all missing critical scopes.

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -253,7 +253,7 @@ async function tryAutoFixScopes(
   brand: Brand,
   missingCritical: { name: string; desc: string }[],
   missingOptional: { name: string; desc: string }[],
-  opts?: { disableQrLogin?: boolean; silent?: boolean },
+  opts?: { disableQrLogin?: boolean; silent?: boolean; grantedScopeNames?: string[] },
 ): Promise<boolean> {
   if (brand !== 'feishu') return false;
 
@@ -265,6 +265,12 @@ async function tryAutoFixScopes(
       brand,
       maxWaitMs: 60_000,
       disableQrLogin: opts?.disableQrLogin,
+      // 把上层自检回读到的「已授权」scope 名字集合往下传：automation 据此在 name
+      // 空间对 manifest 做差集，只对真正还缺的 scope 发 scope/update，并按「确有新增」
+      // 而非「发过 scope/update」置 mutated——这样「配置本就齐全」时才能真正命中无变更
+      // 短路、不再凭空发版。拿不到 granted（如 chicken-and-egg 的 self_manage 冷启动）
+      // 时不传，automation 退回原保守近似。
+      grantedScopeNames: opts?.grantedScopeNames,
       onStatus: (msg) => logger.info(`[${larkAppId}] auto-fix: ${msg}`),
       onQrCode: (info) => {
         logger.warn(
@@ -279,9 +285,12 @@ async function tryAutoFixScopes(
       const scopeDetail = result.scopeCount > 0
         ? `${result.scopeCount} 项权限已导入${result.skippedScopeCount > 0 ? `（${result.skippedScopeCount} 项跳过）` : ''}`
         : '所有必需权限已在应用清单中';
+      const versionDetail = result.publishSkipped
+        ? '无变更，已跳过发版'
+        : `version ${result.versionId ?? 'n/a'} published`;
       logger.info(
         `[${larkAppId}] auto-fix succeeded: ${scopeDetail}, ` +
-        `version ${result.versionId ?? 'n/a'} published, ` +
+        `${versionDetail}, ` +
         `${result.subscribedEventCount} events subscribed`,
       );
       // opt-in / optional-only path: succeeded silently, no admin DM (a bot that
@@ -514,7 +523,7 @@ export async function checkRequiredScopes(larkAppId: string): Promise<void> {
       // before (no API call / no prompt / no nag).
       if (missingOptional.length > 0 && brand === 'feishu') {
         const toppedUp = await tryAutoFixScopes(larkAppId, bot, brand, [], missingOptional,
-          { disableQrLogin: true, silent: true });
+          { disableQrLogin: true, silent: true, grantedScopeNames: [...grantedScopes] });
         if (toppedUp) {
           logger.info(`[${larkAppId}] auto-topped-up ${missingOptional.length} optional scope(s): ${missingOptional.map(s => s.name).join('、')}`);
           return;
@@ -529,7 +538,8 @@ export async function checkRequiredScopes(larkAppId: string): Promise<void> {
     // If a cached Feishu web session exists (~/.botmux/feishu-session.json), we can
     // directly add missing scopes and publish a new version without user interaction.
     // Falls through to manual DM warning if session is missing/expired.
-    const autoFixed = await tryAutoFixScopes(larkAppId, bot, brand, missingCritical, missingOptional);
+    const autoFixed = await tryAutoFixScopes(larkAppId, bot, brand, missingCritical, missingOptional,
+      { grantedScopeNames: [...grantedScopes] });
     if (autoFixed) return;
 
     // Log + DM consolidated message listing all missing critical scopes.

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -153,6 +153,11 @@ export type OpenPlatformAutomationResult =
       /** Managed onboarding only: exact baseline event + callback count read back before session cleanup. */
       verifiedEventCount?: number;
       versionId?: string;
+      /**
+       * 本次因「无任何配置变更」而**跳过了 create+publish**。区别于「发了版但没解析到
+       * versionId」：前者根本没建版（下游别去后台找不存在的草稿、也别把它当 warning）。
+       */
+      publishSkipped?: boolean;
     }
   | {
       ok: false;
@@ -217,6 +222,20 @@ export interface OpenPlatformAutomationOptions {
   appJustCreated?: boolean;
   fetchImpl?: typeof fetch;
   scopeManifest?: ScopeManifest;
+  /**
+   * 调用方已经确知**当前已授权**的 scope 名字集合（来自 tenant-token
+   * `application/v6` 的 scope 列表，见 event-dispatcher 的 `checkRequiredScopes`）。
+   *
+   * 传入时，本函数会在**映射成 ID 之前**用它对 manifest 做 name 差集，只对「真正
+   * 还没授权」的 scope 发 `scope/update`，并且**只在差集非空**时把 scope 记为一次
+   * 变更（驱动末尾是否发版）。不传时保持历史行为：拿不到已授权信号，就以「发出过
+   * 一次非空 scope/update」作为保守近似（宁可偶尔多发一版，也不少发导致新权限不
+   * 生效）。
+   *
+   * ⚠️ 差集必须在 name 空间做：`grantedScopeNames` 与 manifest 都是 scope **name**，
+   * 而 catalog 映射后是 ID，两者不可直接比。
+   */
+  grantedScopeNames?: string[];
   pollIntervalMs?: number;
   maxWaitMs?: number;
   onQrCode?: (info: { qrText: string; qrPayload: string }) => void | Promise<void>;
@@ -1109,8 +1128,23 @@ export async function automateOpenPlatformSetup(
   }
 
   const manifest = options.scopeManifest ?? readDefaultScopeManifest();
+  // 调用方给了「已授权」名字集合时，在**映射成 ID 之前**做 name 差集，把 manifest
+  // 收窄成「本次真正还缺的」——只有它非空才需要发 scope/update、也才算一次变更。
+  // 这正是「无变更短路」在走默认全量 manifest 的生产链路里能真正生效的关键：否则
+  // manifest 恒非空 → scope/update 恒发 → mutated 恒真 → 短路永不触发。
+  const grantedSet = options.grantedScopeNames && options.grantedScopeNames.length > 0
+    ? new Set(options.grantedScopeNames)
+    : undefined;
+  const effectiveManifest: ScopeManifest = grantedSet
+    ? {
+        scopes: {
+          tenant: (manifest.scopes?.tenant ?? []).filter(name => !grantedSet.has(name)),
+          user: (manifest.scopes?.user ?? []).filter(name => !grantedSet.has(name)),
+        },
+      }
+    : manifest;
   const catalog = extractOpenPlatformScopeEntries(allScopesPayload);
-  const mapped = mapManifestScopesToOpenPlatformIds(manifest, catalog);
+  const mapped = mapManifestScopesToOpenPlatformIds(effectiveManifest, catalog);
   const missing = [...mapped.missingTenantScopes, ...mapped.missingUserScopes];
   const skippedScopeCount = missing.length;
   if (missing.length > 0) {
@@ -1124,8 +1158,9 @@ export async function automateOpenPlatformSetup(
   if (importedScopeCount > 0) {
     try {
       await postJson(`/developers/v1/scope/update/${options.appId}`, buildScopeUpdatePayload(options.appId, mapped));
-      // 保守近似：拿不到「哪些本就已授权」的信号，只要成功发出了一次非空
-      // scope/update 就当作可能改动过权限，允许后续发版让新权限生效。
+      // 已知 granted 时：manifest 已收窄成「真正还缺的」，走到这里就一定有新增权限，
+      // 记为变更、允许后续发版让新权限生效。未知 granted 时保守近似：拿不到「哪些本就
+      // 已授权」的信号，只要成功发出了一次非空 scope/update 就当作可能改动过权限。
       mutated = true;
     } catch (err: any) {
       scopeWarning = safeErrorMessage(err);
@@ -1324,9 +1359,12 @@ export async function automateOpenPlatformSetup(
       eventModeReady,
       redirectConfigured,
       redirectWarning,
-      // 没发版：versionId 留空。非受管路径本就不依赖它（受管路径已被 mustPublish
-      // 排除在短路之外），下游只把它当「有则记一笔」。
+      // 没发版：versionId 留空，另置 publishSkipped 标记「本次确实没建版」。非受管
+      // 路径本就不依赖 versionId（受管路径已被 mustPublish 排除在短路之外），下游据
+      // publishSkipped 区分「跳过发版」与「发了版但没解析到 versionId」——前者不该被
+      // classifySetupOpenPlatformOutcome 计入 warning，也不该让 CLI 提示去后台找草稿。
       versionId: undefined,
+      publishSkipped: true,
     };
   }
 

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -1051,6 +1051,15 @@ export async function automateOpenPlatformSetup(
   // 不了)。这一步独立 try/catch:失败只记 redirectWarning,不 return、不阻断后续。
   let redirectConfigured = false;
   let redirectWarning: string | undefined;
+  // 「本次自动化到底改没改过线上配置」。只有确实落地过写操作（redirect 白名单、
+  // scope、事件、回调、接收模式）才置 true。用来在流程末尾判断是否值得再
+  // create+publish 一个新版本——权限/事件全都本就齐全时，历史实现仍会无条件
+  // 发一版（scope 不 diff、发版无短路），存量 bot 每次重启命中自检都凭空多一个
+  // 版本。⚠️ scope/update 用整份 catalog 映射、平台侧幂等 add，botmux 拿不到
+  // 「哪些本就已授权」的可靠信号（scope/all 只是可选权限目录，无 grant flag），
+  // 所以这里以「本次 scope/update 是否真的发出且成功」作为保守近似：宁可偶尔
+  // 多发一版，也不少发导致新权限不生效。
+  let mutated = false;
   try {
     // wanted 显式算一次并原样传下去：`redirectConfigured` 要靠「wanted 是否全部落盘」
     // 判定（见 {@link missingRedirectUrls}），拿不到这份 wanted 就只能退回按 status
@@ -1060,6 +1069,11 @@ export async function automateOpenPlatformSetup(
       // 只有「本次刚建出来的 app」才允许在读失败时盲写覆盖；存量 app 读不到就零写入。
       allowBlindWrite: options.appJustCreated === true,
     });
+    // 只有真的发了写请求（updated / updated_fallback）才算改过；unchanged（幂等
+    // 短路）与 skipped_unreadable（一次都没写）都不置位。
+    if (written.status === 'updated' || written.status === 'updated_fallback') {
+      mutated = true;
+    }
     if (written.status === 'skipped_unreadable') {
       // 「读不到线上现值 → 一次写请求都没发」。与下面的「写了但没写全」是两回事：
       // 这里连线上有什么都不知道，谈不上缺哪几条，措辞也要分开。
@@ -1110,6 +1124,9 @@ export async function automateOpenPlatformSetup(
   if (importedScopeCount > 0) {
     try {
       await postJson(`/developers/v1/scope/update/${options.appId}`, buildScopeUpdatePayload(options.appId, mapped));
+      // 保守近似：拿不到「哪些本就已授权」的信号，只要成功发出了一次非空
+      // scope/update 就当作可能改动过权限，允许后续发版让新权限生效。
+      mutated = true;
     } catch (err: any) {
       scopeWarning = safeErrorMessage(err);
       importedScopeCount = 0;
@@ -1160,6 +1177,9 @@ export async function automateOpenPlatformSetup(
   const missingAppEvents = wantedAppEvents.filter(name => !hasEvent(name));
   const missingUserEvents = VC_MEETING_USER_EVENTS.filter(name => !hasEvent(name));
   if (missingAppEvents.length > 0 || missingUserEvents.length > 0) {
+    // 有缺失事件才进这一支，说明确实要发写请求补订阅——置 mutated。逐个补的
+    // 兜底分支即使个别失败，也已经改过一部分，仍算改动过。
+    mutated = true;
     const eventMode = eventState?.eventMode ?? LONG_CONNECTION_EVENT_MODE;
     try {
       await addEvents(missingAppEvents, missingUserEvents, eventMode);
@@ -1209,6 +1229,8 @@ export async function automateOpenPlatformSetup(
     eventWarnings.push(`读取当前回调订阅失败: ${safeErrorMessage(err)}`);
   }
   if (callbackState && callbackState.callbackMode !== LONG_CONNECTION_EVENT_MODE) {
+    // 回调接收模式不是长连接才需要切——发了 switch 写请求即算改动过。
+    mutated = true;
     try {
       await postJson(`/developers/v1/callback/switch/${options.appId}`, {
         clientId: options.appId,
@@ -1221,6 +1243,8 @@ export async function automateOpenPlatformSetup(
   }
   let missingCallbacks = BOT_BASELINE_CALLBACKS.filter(name => !callbackState?.callbacks.includes(name));
   if (missingCallbacks.length > 0) {
+    // 有缺失回调才补——发了 callback/update 写请求即算改动过。
+    mutated = true;
     try {
       await postJson(
         `/developers/v1/callback/update/${options.appId}`,
@@ -1271,6 +1295,38 @@ export async function automateOpenPlatformSetup(
       eventModeReady,
       redirectConfigured,
       redirectWarning,
+    };
+  }
+
+  // 无变更短路：redirect / scope / 事件 / 回调 / 接收模式一路下来都没落地过任何
+  // 写操作，说明应用配置本就齐全，再 create+publish 一个新版本纯属凭空多一版
+  // （存量 bot 每次重启命中权限自检/VC 自检都发一版）。此时跳过发版，直接回成功。
+  //
+  // 两个例外**必须**照常发版：
+  //  • appJustCreated —— 刚建出来的 app 要靠首次发版才能上架启用；
+  //  • requireVerifiedEvents —— 受管 onboarding/恢复靠回读到的精确 versionId 作为
+  //    激活 ACK（见 bot-onboarding 的 hasExactManagedAutomationAck / versionId 读取），
+  //    不发版就拿不到 versionId，激活会判失败。
+  // 这两条都传 false / 未传时，才走无变更短路。
+  const mustPublish = options.appJustCreated === true || options.requireVerifiedEvents === true;
+  if (!mutated && !mustPublish) {
+    return {
+      ok: true,
+      sessionFile,
+      sessionSource: preparedSession.source,
+      cookieCount: preparedSession.cookieCount,
+      scopeCount: importedScopeCount,
+      skippedScopeCount,
+      scopeWarning,
+      subscribedEventCount,
+      eventWarning,
+      missingVcEvents,
+      eventModeReady,
+      redirectConfigured,
+      redirectWarning,
+      // 没发版：versionId 留空。非受管路径本就不依赖它（受管路径已被 mustPublish
+      // 排除在短路之外），下游只把它当「有则记一笔」。
+      versionId: undefined,
     };
   }
 

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -223,19 +223,23 @@ export interface OpenPlatformAutomationOptions {
   fetchImpl?: typeof fetch;
   scopeManifest?: ScopeManifest;
   /**
-   * 调用方已经确知**当前已授权**的 scope 名字集合（来自 tenant-token
-   * `application/v6` 的 scope 列表，见 event-dispatcher 的 `checkRequiredScopes`）。
+   * 调用方已经确知**当前已授权**的 scope 名字集合，**按 token 类型分桶**（来自
+   * tenant-token `application/v6` 的 scope 列表，见 event-dispatcher 的
+   * `checkRequiredScopes`——该接口每个 scope 条目自带 `token_types: (tenant|user)[]`）。
    *
-   * 传入时，本函数会在**映射成 ID 之前**用它对 manifest 做 name 差集，只对「真正
-   * 还没授权」的 scope 发 `scope/update`，并且**只在差集非空**时把 scope 记为一次
-   * 变更（驱动末尾是否发版）。不传时保持历史行为：拿不到已授权信号，就以「发出过
-   * 一次非空 scope/update」作为保守近似（宁可偶尔多发一版，也不少发导致新权限不
-   * 生效）。
+   * 传入时，本函数会在**映射成 ID 之前**分别用 `tenant` / `user` 桶对 manifest 的
+   * 对应桶做 name 差集，只对「该 token 类型下真正还没授权」的 scope 发 `scope/update`，
+   * 并且**只在差集非空**时把 scope 记为一次变更（驱动末尾是否发版）。不传时保持历史
+   * 行为：拿不到已授权信号，就以「发出过一次非空 scope/update」作为保守近似（宁可偶尔
+   * 多发一版，也不少发导致新权限不生效）。
    *
-   * ⚠️ 差集必须在 name 空间做：`grantedScopeNames` 与 manifest 都是 scope **name**，
-   * 而 catalog 映射后是 ID，两者不可直接比。
+   * ⚠️ 必须**按桶**做差、且在 name 空间做：`lark-scopes.json` 里约 121 个名字同时出现
+   * 在 tenant 与 user 两个桶，而 tenant/user 是两份独立授权。若把已授权名字拍平成一个
+   * 扁平集合去过滤两个桶，「tenant 已授权」会连带把 user 桶里的同名 scope 也误删，导致
+   * 真正缺失的 user 侧权限被静默吞掉、永远补不上（PR #1044 R2）。catalog 映射后是 ID，
+   * 与 name 不可直接比，故差集只能在 mapped 之前的 name 空间做。
    */
-  grantedScopeNames?: string[];
+  grantedScopeNames?: { tenant: string[]; user: string[] };
   pollIntervalMs?: number;
   maxWaitMs?: number;
   onQrCode?: (info: { qrText: string; qrPayload: string }) => void | Promise<void>;
@@ -1132,14 +1136,22 @@ export async function automateOpenPlatformSetup(
   // 收窄成「本次真正还缺的」——只有它非空才需要发 scope/update、也才算一次变更。
   // 这正是「无变更短路」在走默认全量 manifest 的生产链路里能真正生效的关键：否则
   // manifest 恒非空 → scope/update 恒发 → mutated 恒真 → 短路永不触发。
-  const grantedSet = options.grantedScopeNames && options.grantedScopeNames.length > 0
-    ? new Set(options.grantedScopeNames)
+  //
+  // 差集必须**按 token 桶各自做**：约 121 个名字同时在 tenant/user 两桶，而两者是
+  // 两份独立授权。若拿一个扁平集合过滤两桶，「tenant 已授权」会连带删掉 user 桶的
+  // 同名 scope，把真正缺的 user 侧权限静默吞掉（PR #1044 R2）。
+  const grantedTenant = options.grantedScopeNames
+    ? new Set(options.grantedScopeNames.tenant)
     : undefined;
-  const effectiveManifest: ScopeManifest = grantedSet
+  const grantedUser = options.grantedScopeNames
+    ? new Set(options.grantedScopeNames.user)
+    : undefined;
+  const hasGrantedSignal = !!(grantedTenant || grantedUser);
+  const effectiveManifest: ScopeManifest = hasGrantedSignal
     ? {
         scopes: {
-          tenant: (manifest.scopes?.tenant ?? []).filter(name => !grantedSet.has(name)),
-          user: (manifest.scopes?.user ?? []).filter(name => !grantedSet.has(name)),
+          tenant: (manifest.scopes?.tenant ?? []).filter(name => !grantedTenant?.has(name)),
+          user: (manifest.scopes?.user ?? []).filter(name => !grantedUser?.has(name)),
         },
       }
     : manifest;

--- a/src/setup/open-platform-outcome.ts
+++ b/src/setup/open-platform-outcome.ts
@@ -27,12 +27,18 @@ export function classifySetupOpenPlatformOutcome(
   // redirect 白名单没写成功也算 warning：它不阻断建 bot，但缺了它 authorize 直接
   // 20029（群聊模式 p2pMode=group / 会话群标签 / `/login` 全都授权不了）。历史实现
   // 把这种「建好了但一授权就失败」的 bot 报成纯 ready，用户只能等踩坑才发现。
+  //
+  // 例外：`publishSkipped` 说明本次「配置本就齐全、无变更 → 有意跳过发版」。这条
+  // 短路分支里 versionId 必为空、importedScopeCount 必为 0（真发了 scope/update 就
+  // 会置 mutated 而不走短路），两者都是**预期结果**而非缺陷——不排除的话，一次完全
+  // 健康的重启自检会被恒判成 ready_with_warnings。
+  const publishSkipped = result.publishSkipped === true;
   const hasWarnings = Boolean(
     result.scopeWarning
     || result.eventWarning
-    || result.scopeCount === 0
+    || (result.scopeCount === 0 && !publishSkipped)
     || result.skippedScopeCount > 0
-    || !result.versionId
+    || (!result.versionId && !publishSkipped)
     || !result.redirectConfigured
     || result.redirectWarning
   );

--- a/test/scope-optional-autofix.test.ts
+++ b/test/scope-optional-autofix.test.ts
@@ -54,9 +54,11 @@ describe('checkRequiredScopes — opt-in optional-scope auto-top-up', () => {
   });
 
   it('threads the already-granted scope names into the top-up (no-op-publish diff)', () => {
-    // The auto-top-up must forward the scopes it already read back so automation
-    // can diff and skip publishing when nothing is actually new (PR #1044).
-    expect(region).toContain('grantedScopeNames: [...grantedScopes]');
+    // The auto-top-up must forward the scopes it already read back — bucketed by
+    // token type — so automation can diff per bucket and skip publishing when
+    // nothing is actually new (PR #1044). Bucketing avoids a tenant grant masking
+    // a genuinely-missing user-side scope of the same name (PR #1044 R2).
+    expect(region).toContain('grantedScopeNames: grantedScopeBuckets');
   });
 
   it('returns on a successful top-up (before the all-critical-granted log)', () => {
@@ -79,7 +81,7 @@ describe('tryAutoFixScopes — silent / disableQrLogin plumbing', () => {
   const region = fnRegion('async function tryAutoFixScopes(', 4200);
 
   it('accepts the disableQrLogin + silent opts', () => {
-    expect(region).toContain('opts?: { disableQrLogin?: boolean; silent?: boolean; grantedScopeNames?: string[] }');
+    expect(region).toContain('opts?: { disableQrLogin?: boolean; silent?: boolean; grantedScopeNames?: { tenant: string[]; user: string[] } }');
   });
 
   it('threads grantedScopeNames into the Open Platform automation', () => {

--- a/test/scope-optional-autofix.test.ts
+++ b/test/scope-optional-autofix.test.ts
@@ -48,9 +48,15 @@ describe('checkRequiredScopes — opt-in optional-scope auto-top-up', () => {
   });
 
   it('runs the top-up SILENTLY and WITHOUT a second QR (session-only)', () => {
-    expect(region).toContain('{ disableQrLogin: true, silent: true }');
+    expect(region).toContain('disableQrLogin: true, silent: true');
     // passes no critical scopes (optional-only top-up)
     expect(region).toMatch(/tryAutoFixScopes\(larkAppId, bot, brand, \[\], missingOptional,/);
+  });
+
+  it('threads the already-granted scope names into the top-up (no-op-publish diff)', () => {
+    // The auto-top-up must forward the scopes it already read back so automation
+    // can diff and skip publishing when nothing is actually new (PR #1044).
+    expect(region).toContain('grantedScopeNames: [...grantedScopes]');
   });
 
   it('returns on a successful top-up (before the all-critical-granted log)', () => {
@@ -73,7 +79,11 @@ describe('tryAutoFixScopes — silent / disableQrLogin plumbing', () => {
   const region = fnRegion('async function tryAutoFixScopes(', 4200);
 
   it('accepts the disableQrLogin + silent opts', () => {
-    expect(region).toContain('opts?: { disableQrLogin?: boolean; silent?: boolean }');
+    expect(region).toContain('opts?: { disableQrLogin?: boolean; silent?: boolean; grantedScopeNames?: string[] }');
+  });
+
+  it('threads grantedScopeNames into the Open Platform automation', () => {
+    expect(region).toContain('grantedScopeNames: opts?.grantedScopeNames,');
   });
 
   it('threads disableQrLogin into the Open Platform automation', () => {

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -11,6 +11,10 @@ import {
   automateOpenPlatformSetup,
   BOT_BASELINE_APP_EVENTS,
   BOT_BASELINE_CALLBACKS,
+  BOT_OPTIONAL_APP_EVENTS,
+  LONG_CONNECTION_EVENT_MODE,
+  VC_MEETING_APP_EVENTS,
+  VC_MEETING_USER_EVENTS,
   BOTMUX_REDIRECT_URL,
   botmuxFeishuSessionFilePath,
   buildFeishuQrPayload,
@@ -1957,6 +1961,125 @@ describe('automateOpenPlatformSetup', () => {
       .toContain('长连接');
     // 走不到订阅阶段的早期失败(missingVcEvents/eventModeReady 均 undefined)保持原 best-effort 语义
     expect(vcListenerEventGateError({})).toBeNull();
+  });
+
+  // 无变更短路：redirect / scope / 事件 / 回调 / 接收模式一路下来都没落地过写操作时，
+  // 不应再 create+publish 一个新版本（存量 bot 每次重启命中自检都凭空多一版的根因）。
+  describe('无变更时跳过发版', () => {
+    // 「什么都不缺」的 mock：所有 botmux 需要的事件/回调/长连接模式都已就位，
+    // redirect 白名单已含全部 wanted，scope 传空清单 → 全程零写请求。
+    function noopMock(appId: string) {
+      return openPlatformSubscriptionMock(appId, {
+        initial: {
+          appEvents: [...BOT_BASELINE_APP_EVENTS, ...BOT_OPTIONAL_APP_EVENTS, ...VC_MEETING_APP_EVENTS],
+          userEvents: [...VC_MEETING_USER_EVENTS],
+          eventMode: LONG_CONNECTION_EVENT_MODE,
+          callbacks: [...BOT_BASELINE_CALLBACKS],
+          callbackMode: LONG_CONNECTION_EVENT_MODE,
+          redirectUrls: collectBotmuxRedirectUrls(),
+        },
+      });
+    }
+
+    function noopFetch(appId: string, sub: ReturnType<typeof openPlatformSubscriptionMock>, calls: string[]) {
+      return (async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push(href);
+        if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+        if (href.endsWith('/auth')) return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+        if (href.includes(`/scope/all/${appId}`)) {
+          return Response.json({ code: 0, data: { appScopeList: [], userScopeList: [] } });
+        }
+        // 命中发版端点直接抛：无变更时它们绝不该被调用。
+        if (href.includes('/app_version/create/') || href.includes('/publish/commit/')) {
+          throw new Error(`must not publish on no-op: ${href}`);
+        }
+        return sub.handle(href, init) ?? Response.json({ code: 0 });
+      }) as typeof fetch;
+    }
+
+    it('权限/事件/回调全就位时不 create+publish，直接回成功且 versionId 为空', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-noop-'));
+      const sessionFile = join(dir, 'feishu-session.json');
+      writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+      const sub = noopMock('cli_x');
+      const calls: string[] = [];
+
+      const result = await automateOpenPlatformSetup({
+        appId: 'cli_x',
+        sessionFilePath: sessionFile,
+        fetchImpl: noopFetch('cli_x', sub, calls),
+        // 空清单 → importedScopeCount=0 → 不发 scope/update
+        scopeManifest: { scopes: { tenant: [], user: [] } },
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.versionId).toBeUndefined();
+      // 一条发版请求都没有；也没有任何写请求（redirect/scope/event/callback update）。
+      expect(calls.some(u => u.includes('/app_version/create/'))).toBe(false);
+      expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
+      expect(calls.some(u => u.includes('/scope/update/'))).toBe(false);
+      expect(sub.updateBodies).toEqual([]);
+      expect(sub.redirectWrites).toEqual([]);
+    });
+
+    it('appJustCreated=true 时即便无变更也照常发版（新应用要靠首发上架）', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-noop-new-'));
+      const sessionFile = join(dir, 'feishu-session.json');
+      writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+      const sub = noopMock('cli_x');
+      const calls: string[] = [];
+      const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push(href);
+        if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+        if (href.endsWith('/auth')) return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+        if (href.includes('/scope/all/cli_x')) return Response.json({ code: 0, data: { appScopeList: [], userScopeList: [] } });
+        if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
+        return sub.handle(href, init) ?? Response.json({ code: 0 });
+      }) as typeof fetch;
+
+      const result = await automateOpenPlatformSetup({
+        appId: 'cli_x',
+        sessionFilePath: sessionFile,
+        fetchImpl,
+        scopeManifest: { scopes: { tenant: [], user: [] } },
+        appJustCreated: true,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.versionId).toBe('v1');
+      expect(calls.some(u => u.includes('/publish/commit/'))).toBe(true);
+    });
+
+    it('requireVerifiedEvents=true 时即便无变更也照常发版（受管激活靠精确 versionId ACK）', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-noop-managed-'));
+      const sessionFile = join(dir, 'feishu-session.json');
+      writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+      const sub = noopMock('cli_x');
+      const calls: string[] = [];
+      const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push(href);
+        if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+        if (href.endsWith('/auth')) return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+        if (href.includes('/scope/all/cli_x')) return Response.json({ code: 0, data: { appScopeList: [], userScopeList: [] } });
+        if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
+        return sub.handle(href, init) ?? Response.json({ code: 0 });
+      }) as typeof fetch;
+
+      const result = await automateOpenPlatformSetup({
+        appId: 'cli_x',
+        sessionFilePath: sessionFile,
+        fetchImpl,
+        scopeManifest: { scopes: { tenant: [], user: [] } },
+        requireVerifiedEvents: true,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.versionId).toBe('v1');
+      expect(calls.some(u => u.includes('/publish/commit/'))).toBe(true);
+    });
   });
 });
 

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -3,9 +3,10 @@
  *
  * Run: pnpm vitest run test/setup-open-platform-automation.test.ts
  */
-import { mkdirSync, mkdtempSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import {
   automateOpenPlatformSetup,
@@ -2078,6 +2079,179 @@ describe('automateOpenPlatformSetup', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.versionId).toBe('v1');
+      expect(calls.some(u => u.includes('/publish/commit/'))).toBe(true);
+    });
+
+    // 锁生产链路：走**真实默认 manifest**（不注入 scopeManifest）+ 已授权集合。
+    // 这是维护者复审揪出的空白——之前 3 例都注入空 manifest，恰好绕开了唯一有意义
+    // 的那条路径（默认 171+130 项、importedScopeCount 恒 >0 → mutated 恒真 → 短路
+    // 永不触发）。这里用「manifest 全部已授权」模拟「配置本就齐全」的重启自检。
+    const defaultManifest = JSON.parse(
+      readFileSync(join(fileURLToPath(new URL('../src/setup/lark-scopes.json', import.meta.url))), 'utf-8'),
+    ) as { scopes: { tenant: string[]; user: string[] } };
+    const allDefaultScopeNames = [...defaultManifest.scopes.tenant, ...defaultManifest.scopes.user];
+
+    // 用默认 manifest 里的名字构造一份「租户目录」——scope/all 返回它，automation 据此
+    // 把 name 映射成 ID。ID 只要唯一即可。
+    function defaultCatalogFetch(
+      appId: string,
+      sub: ReturnType<typeof openPlatformSubscriptionMock>,
+      calls: string[],
+      captured: { scopeUpdateBodies: Array<Record<string, unknown>> },
+    ) {
+      const nameToId = new Map<string, string>();
+      allDefaultScopeNames.forEach((name, i) => nameToId.set(name, `id_${i}`));
+      return (async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push(href);
+        if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+        if (href.endsWith('/auth')) return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+        if (href.includes(`/scope/all/${appId}`)) {
+          return Response.json({
+            code: 0,
+            data: {
+              appScopeList: defaultManifest.scopes.tenant.map(name => ({ name, id: nameToId.get(name) })),
+              userScopeList: defaultManifest.scopes.user.map(name => ({ name, id: nameToId.get(name) })),
+            },
+          });
+        }
+        if (href.includes(`/scope/update/${appId}`)) {
+          captured.scopeUpdateBodies.push(JSON.parse(String(init?.body)));
+          return Response.json({ code: 0 });
+        }
+        if (href.includes('/app_version/create/') || href.includes('/publish/commit/')) {
+          throw new Error(`must not publish on no-op: ${href}`);
+        }
+        return sub.handle(href, init) ?? Response.json({ code: 0 });
+      }) as typeof fetch;
+    }
+
+    it('默认全量 manifest + grantedScopeNames 覆盖全部权限时，短路生效、零 scope/update、不发版', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-noop-default-'));
+      const sessionFile = join(dir, 'feishu-session.json');
+      writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+      const sub = noopMock('cli_x');
+      const calls: string[] = [];
+      const captured = { scopeUpdateBodies: [] as Array<Record<string, unknown>> };
+
+      const result = await automateOpenPlatformSetup({
+        appId: 'cli_x',
+        sessionFilePath: sessionFile,
+        fetchImpl: defaultCatalogFetch('cli_x', sub, calls, captured),
+        // 关键：不传 scopeManifest（走真实默认清单），但告知「全部已授权」。
+        grantedScopeNames: allDefaultScopeNames,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.versionId).toBeUndefined();
+        expect(result.publishSkipped).toBe(true);
+      }
+      // 全部已授权 → 差集为空 → 一次 scope/update 都不发、也不发版。
+      expect(captured.scopeUpdateBodies).toEqual([]);
+      expect(calls.some(u => u.includes('/scope/update/'))).toBe(false);
+      expect(calls.some(u => u.includes('/app_version/create/'))).toBe(false);
+      expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
+    });
+
+    it('默认全量 manifest + grantedScopeNames 缺一项时，只对缺的那项发 scope/update 并发版', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-default-onemissing-'));
+      const sessionFile = join(dir, 'feishu-session.json');
+      writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+      const sub = noopMock('cli_x');
+      const calls: string[] = [];
+      const captured = { scopeUpdateBodies: [] as Array<Record<string, unknown>> };
+      // 缺一项 tenant scope（其余全部已授权）。
+      const missingName = defaultManifest.scopes.tenant[0];
+      const granted = allDefaultScopeNames.filter(n => n !== missingName);
+      const nameToId = new Map<string, string>();
+      allDefaultScopeNames.forEach((name, i) => nameToId.set(name, `id_${i}`));
+      const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push(href);
+        if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+        if (href.endsWith('/auth')) return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+        if (href.includes('/scope/all/cli_x')) {
+          return Response.json({
+            code: 0,
+            data: {
+              appScopeList: defaultManifest.scopes.tenant.map(name => ({ name, id: nameToId.get(name) })),
+              userScopeList: defaultManifest.scopes.user.map(name => ({ name, id: nameToId.get(name) })),
+            },
+          });
+        }
+        if (href.includes('/scope/update/cli_x')) {
+          captured.scopeUpdateBodies.push(JSON.parse(String(init?.body)));
+          return Response.json({ code: 0 });
+        }
+        if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v-NEW' } });
+        return sub.handle(href, init) ?? Response.json({ code: 0 });
+      }) as typeof fetch;
+
+      const result = await automateOpenPlatformSetup({
+        appId: 'cli_x',
+        sessionFilePath: sessionFile,
+        fetchImpl,
+        grantedScopeNames: granted,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.versionId).toBe('v-NEW');
+        expect(result.publishSkipped).toBeUndefined();
+      }
+      // 只对「真正还缺的那一项」发 scope/update：payload 里恰好一个 tenant scope id、零 user scope。
+      expect(captured.scopeUpdateBodies).toHaveLength(1);
+      expect(captured.scopeUpdateBodies[0].appScopeIDs).toEqual([nameToId.get(missingName)]);
+      expect(captured.scopeUpdateBodies[0].userScopeIDs).toEqual([]);
+      expect(calls.some(u => u.includes('/publish/commit/'))).toBe(true);
+    });
+
+    it('不传 grantedScopeNames（默认全量 manifest）时保持原保守行为：发 scope/update 且发版', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-default-nogrant-'));
+      const sessionFile = join(dir, 'feishu-session.json');
+      writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+      const sub = noopMock('cli_x');
+      const calls: string[] = [];
+      const captured = { scopeUpdateBodies: [] as Array<Record<string, unknown>> };
+      const nameToId = new Map<string, string>();
+      allDefaultScopeNames.forEach((name, i) => nameToId.set(name, `id_${i}`));
+      const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push(href);
+        if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+        if (href.endsWith('/auth')) return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+        if (href.includes('/scope/all/cli_x')) {
+          return Response.json({
+            code: 0,
+            data: {
+              appScopeList: defaultManifest.scopes.tenant.map(name => ({ name, id: nameToId.get(name) })),
+              userScopeList: defaultManifest.scopes.user.map(name => ({ name, id: nameToId.get(name) })),
+            },
+          });
+        }
+        if (href.includes('/scope/update/cli_x')) {
+          captured.scopeUpdateBodies.push(JSON.parse(String(init?.body)));
+          return Response.json({ code: 0 });
+        }
+        if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v-NEW' } });
+        return sub.handle(href, init) ?? Response.json({ code: 0 });
+      }) as typeof fetch;
+
+      const result = await automateOpenPlatformSetup({
+        appId: 'cli_x',
+        sessionFilePath: sessionFile,
+        fetchImpl,
+        // 不传 grantedScopeNames：拿不到已授权信号 → 保守近似 → 照发不误。
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.versionId).toBe('v-NEW');
+        expect(result.publishSkipped).toBeUndefined();
+      }
+      // 保守行为：整份 manifest 全量映射 → 发一次非空 scope/update → 发版。
+      expect(captured.scopeUpdateBodies).toHaveLength(1);
       expect(calls.some(u => u.includes('/publish/commit/'))).toBe(true);
     });
   });

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -2138,8 +2138,12 @@ describe('automateOpenPlatformSetup', () => {
         appId: 'cli_x',
         sessionFilePath: sessionFile,
         fetchImpl: defaultCatalogFetch('cli_x', sub, calls, captured),
-        // 关键：不传 scopeManifest（走真实默认清单），但告知「全部已授权」。
-        grantedScopeNames: allDefaultScopeNames,
+        // 关键：不传 scopeManifest（走真实默认清单），但告知「全部已授权」——
+        // 按桶传：tenant / user 两桶各自全授权。
+        grantedScopeNames: {
+          tenant: [...defaultManifest.scopes.tenant],
+          user: [...defaultManifest.scopes.user],
+        },
       });
 
       expect(result.ok).toBe(true);
@@ -2154,16 +2158,20 @@ describe('automateOpenPlatformSetup', () => {
       expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
     });
 
-    it('默认全量 manifest + grantedScopeNames 缺一项时，只对缺的那项发 scope/update 并发版', async () => {
-      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-default-onemissing-'));
+    // PR #1044 R2 回归：dual-bucket 名字（tenant/user 两桶都有）的 user 侧独缺时，
+    // 必须仍对 user 侧发 scope/update——不能因为 tenant 侧已授权就把它从 user 桶误删。
+    // 用扁平集合做差会把这一项静默吞掉（0 次 scope/update + publishSkipped），本例锁死。
+    it('dual-bucket 名字仅 user 侧缺失时，按桶做差仍申请其 user 授权、不误报无变更', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-dual-user-missing-'));
       const sessionFile = join(dir, 'feishu-session.json');
       writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
       const sub = noopMock('cli_x');
       const calls: string[] = [];
       const captured = { scopeUpdateBodies: [] as Array<Record<string, unknown>> };
-      // 缺一项 tenant scope（其余全部已授权）。
-      const missingName = defaultManifest.scopes.tenant[0];
-      const granted = allDefaultScopeNames.filter(n => n !== missingName);
+      // 取一个同时出现在 tenant 与 user 两桶的名字。
+      const tenantSet = new Set(defaultManifest.scopes.tenant);
+      const dualName = defaultManifest.scopes.user.find(n => tenantSet.has(n))!;
+      expect(dualName, 'expected a dual-bucket scope name in the default manifest').toBeTruthy();
       const nameToId = new Map<string, string>();
       allDefaultScopeNames.forEach((name, i) => nameToId.set(name, `id_${i}`));
       const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
@@ -2192,7 +2200,68 @@ describe('automateOpenPlatformSetup', () => {
         appId: 'cli_x',
         sessionFilePath: sessionFile,
         fetchImpl,
-        grantedScopeNames: granted,
+        // tenant 侧全授权；user 侧独缺 dualName。扁平集合会因 tenant 有 dualName 而误删 user 桶。
+        grantedScopeNames: {
+          tenant: [...defaultManifest.scopes.tenant],
+          user: defaultManifest.scopes.user.filter(n => n !== dualName),
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // 确有新增（user 侧那一项）→ 必须发版、不是无变更。
+        expect(result.publishSkipped).toBeUndefined();
+      }
+      // 恰好对「user 侧缺的那一项」发一次 scope/update：零 tenant id、一个 user id。
+      expect(captured.scopeUpdateBodies).toHaveLength(1);
+      expect(captured.scopeUpdateBodies[0].appScopeIDs).toEqual([]);
+      expect(captured.scopeUpdateBodies[0].userScopeIDs).toEqual([nameToId.get(dualName)]);
+      expect(calls.some(u => u.includes('/publish/commit/'))).toBe(true);
+    });
+
+    it('默认全量 manifest + grantedScopeNames 缺一项时，只对缺的那项发 scope/update 并发版', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-default-onemissing-'));
+      const sessionFile = join(dir, 'feishu-session.json');
+      writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+      const sub = noopMock('cli_x');
+      const calls: string[] = [];
+      const captured = { scopeUpdateBodies: [] as Array<Record<string, unknown>> };
+      // 缺一项**仅出现在 tenant 桶**的 scope（避免 dual 名字干扰，其余全部已授权）。
+      const userSet = new Set(defaultManifest.scopes.user);
+      const missingName = defaultManifest.scopes.tenant.find(n => !userSet.has(n))!;
+      expect(missingName, 'expected a tenant-only scope name').toBeTruthy();
+      const nameToId = new Map<string, string>();
+      allDefaultScopeNames.forEach((name, i) => nameToId.set(name, `id_${i}`));
+      const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push(href);
+        if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+        if (href.endsWith('/auth')) return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+        if (href.includes('/scope/all/cli_x')) {
+          return Response.json({
+            code: 0,
+            data: {
+              appScopeList: defaultManifest.scopes.tenant.map(name => ({ name, id: nameToId.get(name) })),
+              userScopeList: defaultManifest.scopes.user.map(name => ({ name, id: nameToId.get(name) })),
+            },
+          });
+        }
+        if (href.includes('/scope/update/cli_x')) {
+          captured.scopeUpdateBodies.push(JSON.parse(String(init?.body)));
+          return Response.json({ code: 0 });
+        }
+        if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v-NEW' } });
+        return sub.handle(href, init) ?? Response.json({ code: 0 });
+      }) as typeof fetch;
+
+      const result = await automateOpenPlatformSetup({
+        appId: 'cli_x',
+        sessionFilePath: sessionFile,
+        fetchImpl,
+        grantedScopeNames: {
+          tenant: defaultManifest.scopes.tenant.filter(n => n !== missingName),
+          user: [...defaultManifest.scopes.user],
+        },
       });
 
       expect(result.ok).toBe(true);

--- a/test/setup-open-platform-outcome.test.ts
+++ b/test/setup-open-platform-outcome.test.ts
@@ -40,6 +40,19 @@ describe('classifySetupOpenPlatformOutcome', () => {
       .toBe('ready_with_warnings');
   });
 
+  it('无变更短路（publishSkipped）不算 warning：versionId 空、scopeCount 0 都是预期结果', () => {
+    // 一次「配置本就齐全、无变更 → 有意跳过发版」的健康自检：versionId 必空、
+    // importedScopeCount 必为 0。若把这两者仍计入 warning，会把纯健康结果误报成
+    // ready_with_warnings（PR #1044 复审提到的次要问题）。
+    expect(classifySetupOpenPlatformOutcome(
+      success({ versionId: undefined, scopeCount: 0, publishSkipped: true }),
+    ).status).toBe('ready');
+    // publishSkipped 不豁免真正的 warning：白名单没写上仍要报 warning。
+    expect(classifySetupOpenPlatformOutcome(
+      success({ versionId: undefined, scopeCount: 0, publishSkipped: true, redirectConfigured: false }),
+    ).status).toBe('ready_with_warnings');
+  });
+
   it('redirect 白名单没写上时不许报成纯 ready', () => {
     // 权限、事件、发版全绿也没用：白名单缺条目 = authorize 硬失败 20029
     //（群聊模式 p2pMode=group / 会话群标签 / `/login` 全都授权不了）。


### PR DESCRIPTION
## 背景 / 问题

`automateOpenPlatformSetup`（`src/setup/open-platform-automation.ts`）在配置完 redirect / scope / 事件 / 回调 / 接收模式后，**无条件** `app_version/create` + `publish/commit` 发一个新版本。scope 不做 diff、发版也没有"本次是否真有改动"的短路判断。

后果：权限/事件本就齐全的存量 bot，每次重启命中权限自检（`tryAutoFixScopes`）或 VC 事件自检（`ensureVcMeetingEventsSubscribed`）时，即使一条配置都没改，也会凭空多发一个版本。这是 PR #1042 讨论里提到的"无变更也发版"独立问题（#1042 只收敛权限申请范围，未动发版逻辑）。

## 改动

- 新增 `mutated` 标记，仅在**确实落地过写操作**时置位：
  - redirect 白名单 `updated` / `updated_fallback`（`unchanged`、`skipped_unreadable` 不算）
  - 非空 `scope/update` 成功
  - 有缺失事件时补订阅
  - 回调 `switch` / `update`
  - 幂等的 `robot/switch`、`event/switch` 不作为变更信号
- 发版前：`mutated=false` 且**非** `appJustCreated`、**非** `requireVerifiedEvents` → 直接返回成功（`versionId` 留空），跳过 `create+publish`。
- 两个例外仍强制发版：
  - `appJustCreated` —— 新应用靠首次发版才能上架启用；
  - `requireVerifiedEvents` —— 受管 onboarding / 恢复靠回读到的精确 `versionId` 作为激活 ACK（见 `bot-onboarding` 的 `hasExactManagedAutomationAck` / `versionId` 读取），不发版就拿不到 versionId，激活会判失败。

### 保守近似说明

botmux 拿不到"哪些 scope 本就已授权"的可靠信号——console session 侧的 `scope/all` 只是**可选权限目录**（name→id），没有 grant flag；唯一的已授权来源是另一套 auth 的 tenant-token `application/v6` API。因此这里以"本次 `scope/update` 是否真的发出并成功"作为 scope 变更的**保守近似**：宁可偶尔多发一版，也不少发导致新权限不生效。

## 影响面

- 仅 `src/setup` 的开放平台自动配置链路。
- VC preflight / listener 门（`vcListenerEventGateError`）依赖的是 `subscribedEventCount` / `missingVcEvents` / `eventModeReady`，这些在无变更返回里**照常带回**，不受影响。
- 发版可见范围镜像逻辑（`visible/online` → `visibleSuggest`）不变；无变更时根本不进入该分支，也就不触碰可见范围。
- 与 #1042 **无冲突**：本 PR 的改动全在 `automateOpenPlatformSetup` 函数体（L1051-L1298 区域），#1042 改的是 `filterScopeManifest`（L419）、`readDefaultScopeManifest`（L2053）及 `event-dispatcher.ts`，区域完全不相交。

## 验证

- `bun run build` 通过。
- `test/setup-open-platform-automation.test.ts` 88 用例全绿，含新增"无变更时跳过发版"3 例：
  - 权限/事件/回调全就位时不 `create+publish`、零写请求、`versionId` 为空；
  - `appJustCreated=true` 无变更仍发版；
  - `requireVerifiedEvents=true` 无变更仍发版。
- 仓库其余失败用例在本机 clean 工作树上同样失败（FNM symlink 轮转、loopback 绑定、`/private/var` realpath、PM2、npm launcher 等 macOS 环境相关，及个别 timing flaky），与本改动无关。

> 该路径为线上开放平台真实写操作，纯单测无法覆盖端到端行为；合并后建议在一次"配置本就齐全"的重启中观察日志确认不再产生新版本。