### PR TITLE
docs(session): 更正 sqlite-compat 损坏库的抛点说明，区分读写两条路径

### DIFF
--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -120,7 +120,9 @@ export function assertSqliteSupported(): void {
 function openDbForOwnStore(path: string): SqliteDatabaseLike {
   requireSqliteEngine(`会话存储 ${basename(path)} `);
   const db = openDatabaseSyncOrThrow(path);
-  // Both engines validate the file at first use, not in the constructor.
+  // Neither engine validates the file in the constructor. `busy_timeout` is
+  // connection-level and touches no page either; the first statement that can
+  // reject a corrupt file is `journal_mode` below — still inside this helper.
   db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
   db.exec('PRAGMA journal_mode = WAL;');
   db.exec('PRAGMA synchronous = NORMAL;');
@@ -140,7 +142,10 @@ function openDbForRead(path: string): SqliteDatabaseLike {
   } catch {
     db = openDatabaseSyncOrThrow(path, { readOnly: true });
   }
-  // First use: file validation (corrupt → throw here, skippable by scan).
+  // NOT a validation point: `busy_timeout` is connection-level and touches no
+  // page, so a corrupt file survives it — this helper RETURNS A HANDLE for one.
+  // The read path's validation happens at the caller's first page-touching
+  // statement (the SELECT), which the scan loops treat as a skippable store.
   db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
   return db;
 }

--- a/src/services/sqlite-compat.ts
+++ b/src/services/sqlite-compat.ts
@@ -150,13 +150,16 @@ export function openDatabaseSyncNow(path: string, opts: OpenOptions = {}): Datab
 
 /**
  * Synchronous open that distinguishes "no engine" from "engine loaded, file
- * unusable". Module-load errors throw from `require`. Both runtimes defer
- * file validation to first use — a corrupt / locked file does **not** throw
- * from the constructor; it surfaces at the first `exec` / query
- * (`file is not a database`). Fail-closed stores (session-store) call this
- * then immediately `PRAGMA busy_timeout`, so SQLITE_NOTADB still throws
- * inside the open helper's caller and is not collapsed into "runtime has
- * no SQLite".
+ * unusable". Module-load errors throw from `require`. Neither runtime validates
+ * the file in the constructor, and `PRAGMA busy_timeout` does not either (it is
+ * connection-level and touches no page). A corrupt / locked file is rejected by
+ * the first PAGE-TOUCHING statement, which differs per path:
+ *   • write path (`openDbForOwnStore`): `PRAGMA journal_mode` — inside the helper.
+ *   • read path (`openDbForRead`): the helper RETURNS A HANDLE; the caller's
+ *     first SELECT throws (`file is not a database`).
+ * Either way the throw lands inside a scan loop's try, which rethrows only
+ * `SessionStoreSqliteUnavailableError` and skips everything else — so
+ * SQLITE_NOTADB stays "skippable store", never "runtime has no SQLite".
  */
 export function openDatabaseSyncOrThrow(path: string, opts: OpenOptions = {}): DatabaseSyncLike {
   return openWithLoadedEngine(path, opts);


### PR DESCRIPTION
## 为什么

#852 合入后留下三处注释与实际行为不符，其中一处会导致危险的误读。

`session-store.ts` 的 `openDbForRead` 里：

```ts
  // First use: file validation (corrupt → throw here, skippable by scan).
  db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
```

「throw **here**」指紧随其后的 `busy_timeout`，但那是连接级设置、**不碰数据库页**，损坏文件过得去——**这条路径实际会成功返回一个句柄**，真正的抛点是调用方的 `SELECT`。按字面读会得出「`openDbForRead` 返回成功 ⇒ 文件可用」，这是最危险的一种误读。

## 改了什么

三处注释一并对齐实测行为（纯注释，运行时逻辑零变化）：

| 位置 | 更正后表述 |
|---|---|
| `openDbForOwnStore` | 构造函数与 `busy_timeout` 都不校验；第一条能拒绝损坏库的是紧随的 `journal_mode`，仍在 helper 内 |
| `openDbForRead` | `busy_timeout` 不是校验点，helper 会为损坏库返回句柄；校验发生在调用方首个 page-touching 语句（SELECT） |
| `openDatabaseSyncOrThrow` JSDoc | 按「第一条 page-touching 语句」分写读/写两条路径，替代原先「call this then immediately `PRAGMA busy_timeout`, so … throws inside the open helper's caller」 |

**分型结论不变**：两种抛点都落在扫描循环的 `try` 内（只 rethrow `SessionStoreSqliteUnavailableError`、其余 skip），所以「损坏 = 可跳过 / 缺引擎 = fail-closed」完整成立。代码无需改动。

## 影响面

仅 `src/services/session-store.ts` 与 `src/services/sqlite-compat.ts` 的注释。不改运行时行为，不影响任何 CLI、会话类型、后端或平台。

## 验证

- **证明是纯注释**：两个文件去掉注释后与 master **逐字节相同**（`perl` strip 注释后 `diff` 为空）。
- `tsc -p tsconfig.json --noEmit` 干净（exit 0）。
- `session-store-sqlite` / `session-store` / `fs-policy` / `session-store-bwrap` 四套件 **198 passed**。
- **新注释的每条断言双 runtime 实测为真**（Node 22.21.1 / Bun 1.4.0，损坏 `.db`）：

```
claim1 构造函数不校验                          : TRUE / TRUE
claim2 busy_timeout 不是校验点                 : TRUE / TRUE
claim3 写路径在 journal_mode 拒绝              : TRUE / TRUE  (file is not a database)
claim4a 读路径为损坏库返回句柄                 : TRUE / TRUE
claim4b 调用方 SELECT 抛错                     : TRUE / TRUE  (file is not a database)
```