### PR TITLE
perf(worker): 截图 PNG 编码异步化，消除网页终端每 10 秒一次的卡顿

### DIFF
--- a/src/utils/screenshot-renderer.ts
+++ b/src/utils/screenshot-renderer.ts
@@ -211,8 +211,13 @@ export interface CaptureOpts {
   startY: number;
 }
 
-/** Capture a section of the terminal buffer to a PNG buffer. */
-export function captureToPng(terminal: Terminal, opts: CaptureOpts): Buffer {
+/** Capture a section of the terminal buffer to a PNG buffer.
+ *  异步：PNG 编码走 @napi-rs/canvas 的 `encode('png')`（Rust 线程池），不阻塞
+ *  Node 主线程 event loop。改自同步 `toBuffer('image/png')`——它会把整段 zlib
+ *  压缩压在主线程，10s 一次的截图循环因此每 10s 顿一下主线程；而网页终端的
+ *  xterm WS 也由同一 worker event loop 中转，用户就感到「过几秒卡一次」（TUI
+ *  满屏高频重绘尤其明显）。逐格绘制仍同步，但 napi-rs 原生渲染很快，主阻塞在编码侧。 */
+export async function captureToPng(terminal: Terminal, opts: CaptureOpts): Promise<Buffer> {
   ensureFontRegistered();
   const { cols, rows, startY } = opts;
   const buffer = terminal.buffer.active;
@@ -280,5 +285,5 @@ export function captureToPng(terminal: Terminal, opts: CaptureOpts): Buffer {
     }
   }
 
-  return canvas.toBuffer('image/png');
+  return await canvas.encode('png');
 }

--- a/src/utils/transient-snapshot.ts
+++ b/src/utils/transient-snapshot.ts
@@ -117,7 +117,7 @@ export async function snapshotToPng(
     // the *current* visible rows, not buffer rows 0..N-1 which may be
     // stale scrollback after that scroll.
     const startY = terminal.buffer.active.baseY;
-    const png = captureToPng(terminal, { cols: snap.cols, rows: snap.rows, startY });
+    const png = await captureToPng(terminal, { cols: snap.cols, rows: snap.rows, startY });
     const content = readViewportText(terminal, { filter: true, startY, rows: snap.rows });
     return { png, ansi: snap.ansi, content };
   } finally {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8297,7 +8297,7 @@ async function captureAndUpload(): Promise<void> {
       usageLimitContent = snap;
       const shotCols = clamp(term.cols, MIN_RENDER_COLS, MAX_RENDER_COLS);
       const shotRows = clamp(term.rows, MIN_RENDER_ROWS, MAX_RENDER_ROWS);
-      png = captureToPng(term, { cols: shotCols, rows: shotRows, startY });
+      png = await captureToPng(term, { cols: shotCols, rows: shotRows, startY });
     }
   } catch (err: any) {
     logError(`Screenshot render failed: ${err?.message ?? err}`);

--- a/test/transient-snapshot.test.ts
+++ b/test/transient-snapshot.test.ts
@@ -36,9 +36,10 @@ vi.mock('node:fs', async () => {
 });
 
 // captureToPng would try to use the canvas — stub it for tests so we can
-// verify the wiring without actually rendering a PNG.
+// verify the wiring without actually rendering a PNG. Async to match the real
+// signature (encode('png') returns Promise<Buffer>); snapshotToPng awaits it.
 vi.mock('../src/utils/screenshot-renderer.js', () => ({
-  captureToPng: vi.fn(() => Buffer.from('FAKE_PNG_BYTES')),
+  captureToPng: vi.fn(async () => Buffer.from('FAKE_PNG_BYTES')),
 }));
 
 import { execSync, spawnSync } from 'node:child_process';


### PR DESCRIPTION
## 问题
网页终端（尤其 Claude 这类全屏 TUI）经平台中转时**每约 10 秒卡顿一次**。

## 根因
worker 每 10 秒一次的截图上传（给飞书卡片用）`captureAndUpload → captureToPng` 里，`canvas.toBuffer('image/png')` 是**同步** API，整段 PNG 编码（zlib 压缩）压在主线程。实测一屏（约 200×50）截图同步编码要**阻塞 event loop ~54ms**。

而网页终端的 xterm WS 也由**同一个 worker event loop** 中转，编码那 ~54ms 里 PTY→WS 中转被憋住，event loop 一恢复就 burst 涌出 → 用户看到「卡一下」。TUI 满屏高频重绘尤其明显；普通 webshell（normal-buffer 行滚动）流量平缓，几乎无感——与实际观察一致。

> 背景：这是 Web 终端中转卡顿的第二个轴。第一个轴是中转链路裸 socket 的 Nagle（已另行修复），修完鼠标滚动流畅了，但残留这个 10s 周期卡顿，定位到本条。

## 改动
`captureToPng` 改为异步，用 @napi-rs/canvas 的 `encode('png')`（`Promise<Buffer>`，Rust 线程池编码）替代同步 `toBuffer('image/png')`。PNG 编码不再占用主线程，event loop 在编码期间保持空转、继续中转终端字节。逐格绘制仍同步，但 napi-rs 原生渲染很快，主阻塞在编码侧。

调用点（均已在 async 上下文，加 `await` 即可）：
- `src/utils/transient-snapshot.ts` `snapshotToPng`
- `src/worker.ts` `captureAndUpload`

## 影响面
- 仅影响截图生成路径（飞书卡片预览）；用量识别取的快照文本另有 2s `screen_update` 供给，**不依赖**截图路径。输出 PNG 字节与同步版逐字节一致。
- 截图循环是全 CLI/后端共用路径，无平台/会话类型差异。

## 验证
- `tsc` = 0
- `test/transient-snapshot.test.ts` 10/10、`test/worker-structured-lifecycle-status.test.ts` 30/30 绿（测试替身由同步 mock 改 async，匹配真实签名）
- 实测对拍（一屏量级 canvas）：
  - 同步 `toBuffer('image/png')`：阻塞主线程 **53.6ms**（期间 event loop 冻结）
  - 异步 `encode('png')`：墙钟 37.4ms，期间主线程仍跑了 **35 个 1ms tick**（event loop 未冻结）
  - 两者 PNG 字节完全一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)