### PR TITLE
refactor(session): 删除 daemon 侧 JSON 写路径，落盘改为行级 upsert

### DIFF
--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -2,7 +2,7 @@
 title: Session 终态：非分布式 virtual actor（持久化仅 SQLite）
 type: design
 date: 2026-08-12
-updated: 2026-08-28（面向终态重写；用词按实现语义收紧）
+updated: 2026-08-28（面向终态重写；补齐删除条件、所有权探测口径与沙盒调用方例外）
 topic: session-virtual-actor
 status: active
 baseline: origin/master@cc5085b6（含已合入的 #852）；#1051 删除 daemon 侧 JSON 写路径（进行中）
@@ -24,7 +24,7 @@ references:
 1. **终态优先。** 步骤为终态服务。允许一步只做其中一块，但禁止引入「旧路径完整保留、新层按设计将来整段删除」的平行实现。
 2. **禁止只覆盖部分写点的 actor 层。** 不再引入 `SessionRuntime` / `SessionProjection`、按调用方群组横切、写点台账、审计 gate。occupancy / apply / turn 必须走同一条命令路径，CLI 与 daemon 共用。新增协议时必须写明将被替换的旧协议，以及旧协议的删除条件（可以分 PR 删除，但不能两套所有权长期并存且没有结束条件）。
 3. **边界必须是结构性的**（模块导出、tsc 可检查）。禁止只靠约定维护的边界。
-4. **修改会话状态 = 向该 session 发命令；同一时刻至多一个激活。** daemon 未运行时，不是另开一套磁盘写入协议，而是由 CLI 或 supervisor 取得租约、在本进程执行同一套 apply。产品语义「daemon 未运行时仍能 close / abandon」保留。
+4. **修改会话状态 = 向该 session 发命令；同一时刻至多一个激活。** daemon 未运行时，不是另开一套磁盘写入协议，而是由宿主 CLI 或 supervisor 取得租约、在本进程执行同一套 apply。产品语义「daemon 未运行时仍能 close / abandon」保留。沙盒内的 CLI 不在此列（见 §1）。
 5. **不把旁路存储并入会话库。** turn-sends、frozen-card、whiteboard 文件、usage-ledger、idempotency、vc-meeting-*、`utils/file-lock.ts` 保持独立生命周期。会话行上的 `whiteboardId` 等字段走会话命令；白板正文仍走 whiteboard store。
 6. **BotId 仍由地址推导，不引入分配式注册表。** 会话库内的占位租约只表示 occupancy，不是身份注册表。
 
@@ -57,7 +57,8 @@ references:
 Host 进程可以更换，apply 实现不能分叉：
 
 - **daemon 运行中**：由该 bot 的长驻 daemon（或 supervisor 下的 bot 进程）持有激活。进程拓扑与现状相同。
-- **daemon 未运行**：CLI 或 supervisor 获取租约，在本进程执行同一段 close / abandon / 解绑白板，写入同一行后释放租约。不再使用 `mutateSessionRowOffline` 作为另一套权威写入。
+- **daemon 未运行**：宿主 CLI 或 supervisor 获取租约，在本进程执行同一段 close / abandon / 解绑白板，写入同一行后释放租约。不再使用 `mutateSessionRowOffline` 作为另一套权威写入。
+- **沙盒内的 CLI 取不到租约。** `botmux send` 一类跑在 bwrap / Seatbelt 里的进程对会话库只有 readOnly 授权，也读不到 daemon IPC secret（改用本轮的 origin capability 证明身份）。它只能发命令；daemon 不在时它只能失败，不能退化成自己写盘。因此「取租约就地 apply」的主体是宿主 CLI 与 supervisor，不是全部 CLI 进程——Stage 2 的设计必须显式区分这两类调用方。
 
 持久化：
 
@@ -87,8 +88,8 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 
 相对终态仍缺：
 
-- **occupancy 存在旁路文件里。** `findDaemon` 读 `dashboard-daemons/*.json` 心跳，写入目标却是会话行。SQLite 锁只串行化写者，不能判断「另一进程是否仍持有将要 `persistRow` 的内存缓存」。在租约写入 SQLite 之前，必须保留 `abortIf` 双次探测。
-- **两套 apply。** daemon 使用 `updateSession` / `persistRow`；CLI 使用 `mutateSessionRowOffline`。后者是第二套权威，不是「临时 host 执行同一套命令」。
+- **occupancy 存在旁路文件里。** `utils/daemon-discovery.ts` 的 `findOnlineDaemon` 读 `dashboard-daemons/*.json` 心跳（90s 过期），写入目标却是会话行。SQLite 锁只串行化写者，不能判断「另一进程是否仍持有将要 `persistRow` 的内存缓存」。在租约写入 SQLite 之前，必须保留 `abortIf` 双次探测。
+- **两套 apply。** daemon 使用 `updateSession` / `persistRow`；其它进程使用 `services/session-offline-write.ts` 的 `mutateSessionRowWhenUnowned`（心跳探测 + `mutateSessionRowOffline`）。后者是第二套权威，不是「临时 host 执行同一套命令」。#1051 已把它收敛成一份实现，删除时只有一个入口。
 - **没有 per-session turn。** 进程内仍依赖多处独立的 fence。
 - **跨进程仍可能读 JSON**（#1051 保留）：当 CLI 已升级、daemon 仍在写 JSON 时，快照、点读、身份扫描、worker、`owner: false` 走 db-else-json。这是迁移兼容，不是终态。升级后自动重启 fleet 落地后，该窗口缩短为一次重启；届时从发布产物中删除 JSON 读写分支。磁盘上的冻结 JSON 文件可以保留。
 
@@ -106,11 +107,21 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 
 已纳入 #1051 的 Stage 0 缺口：
 
-- dashboard 删除白板：daemon 运行中经 IPC 发送 `whiteboardId: null` 解绑（路由原先只接受非空 id）。daemon 未运行时才走 `mutateSessionRowOffline`，且传 `abortIf`（探测 `findOnlineDaemon`）。IPC 失败且 daemon 仍可见时不写盘，避免与内存缓存分叉。
+- dashboard 删除白板：daemon 运行中经 IPC 解绑，daemon 不可见时才离线写。两条路径都对板 id 做比对后再改——删板已经先把板移出 index，daemon 的 `ensureSessionWhiteboard` 会在该会话下一轮立刻补一块新板，无条件清除会把这块新绑定一起抹掉。IPC 侧的比对是路由新增的 `expectWhiteboardId`（不匹配返回 409）。
+- 因 daemon 可见而没能解绑的会话计入 `unresolvedSessions` 返回，不再和「没有会话引用这块板」一样报 0。
+- 解绑的 daemon IPC 带超时：心跳新鲜但 socket 不响应的 daemon 不能把 dashboard 的删除请求一直挂住。
+- 离线写收敛为一个入口 `services/session-offline-write.ts#mutateSessionRowWhenUnowned`（`mutateSessionRowOffline` + 心跳探测），CLI 与 whiteboard-store 共用；CLI 私有的那份心跳解析与 90s 判定删除，改用 `utils/daemon-discovery.ts`。探测与 store 读写用同一个 dataDir。
 - `mutateSessionRowOffline` 的 sqlite 路径在 `openDbForOwnStore` 前再做一次 `existsSync`：读写 open 会创建空库，导致导入门把尚未导入的 store 当成已导入。
 - PR 标题与描述以「daemon 不再写 JSON；跨进程在升级窗口内仍可读 JSON」为准，不再写全仓 db-only。
 
-升级后自动重启 fleet 合入后，再开一个仍属 Stage 0 的 PR，从代码中删除 JSON 读路径（不必等 occupancy）：
+**JSON 读路径的删除条件（两条，先到先算）：**
+
+1. 升级后自动重启 fleet 落地——线上不再有仍在写 JSON 的 daemon。
+2. 兜底复核点 **2026-11-26**（本文 2026-08-28 定稿起 90 天）。届时若 fleet 自动重启仍未落地，就按当时 latest 与「`sessions.db` 首次进入 latest 的版本」之间的跨度，决定直接删除还是再延一期，并把结论写回本节。
+
+第 2 条是必需的：fleet 自动重启不在本文范围，也没有承诺时间点。只写第 1 条，等于把跨进程 JSON 读做成 §不做 明令禁止的「长期不变量」。
+
+条件满足后，再开一个仍属 Stage 0 的 PR，从代码中删除 JSON 读路径（不必等 occupancy）：
 
 - 删除跨进程 JSON 读/写、`StoreFileRef.kind` 分流、沙盒对冻结 JSON 的授权。
 - 若无 `.db` 且尚未导入：失败并提示重启 daemon 完成迁移，不再实现完整的 JSON 离线写。
@@ -130,7 +141,9 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 3. 非当前 host 的写入：`BEGIN IMMEDIATE` → 读租约 → 租约有效则中止并走 IPC（或等待）；租约过期才进入 Stage 2 的短生命周期激活。探测与写入在同一事务内完成。
 4. 租约按心跳续期。90s 过期已有实现，只是心跳文件与会话行不在同一事务。
 
-验收：`findDaemon` **不再作为所有权判断**（仍可用于发现 IPC 地址）。长期同时使用心跳探测和库内租约不算完成。仅用 `BEGIN IMMEDIATE` 替换 `findDaemon` 也不算完成：锁不能表示「另一进程仍持有待写回的内存缓存」。禁止 daemon 未运行时提交 close / abandon 也不算完成：产品语义保留，实现改为获取租约后在本进程 apply。
+验收：`findOnlineDaemon` **不再作为所有权判断**（仍可用于发现 IPC 地址）。#1051 已把 CLI 私有的那份心跳探测并进 `utils/daemon-discovery.ts`，所以验收只需盯住这一个实现的调用点——`services/session-offline-write.ts` 的 `abortIf`、`cli.ts` 的 close / abandon / prune、`whiteboard-store` 的解绑。`dashboard/registry.ts` 读同一批心跳文件，但只用于展示和路由，不参与所有权判断。
+
+长期同时使用心跳探测和库内租约不算完成。仅用 `BEGIN IMMEDIATE` 替换心跳探测也不算完成：锁不能表示「另一进程仍持有待写回的内存缓存」。禁止 daemon 未运行时提交 close / abandon 也不算完成：产品语义保留，实现改为获取租约后在本进程 apply。
 
 #852 之后，这一 stage 的架构收益最大。不做它，turn 队列和单一 apply 无法约束 CLI / dashboard 进程。
 
@@ -138,9 +151,10 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 
 **目标**：close / abandon / 解绑白板 / prune 等命令只有一份实现。依赖 Stage 1。
 
-- CLI、dashboard 只发送命令。daemon 运行中：经 IPC 进入当前激活。daemon 未运行：获取租约，在本进程调用 **同一模块** 的 apply，然后释放租约。
-- 删除 `mutateSessionRowOffline` 作为对外权威写入的语义（若仍存在，只能是短生命周期激活的内部实现，不再是第二条公共写协议）。
-- `abortIf` + `findDaemon` 的所有权探测随 Stage 1 删除。
+- CLI、dashboard 只发送命令。daemon 运行中：经 IPC 进入当前激活。daemon 未运行：宿主 CLI / supervisor 获取租约，在本进程调用 **同一模块** 的 apply，然后释放租约。
+- 沙盒内的 CLI 没有租约能力（§1）：它只发命令，daemon 不在时明确失败。别把它和宿主 CLI 当成同一类调用方。
+- 删除 `mutateSessionRowWhenUnowned` / `mutateSessionRowOffline` 作为对外权威写入的语义（若仍存在，只能是短生命周期激活的内部实现，不再是第二条公共写协议）。
+- `abortIf` + `findOnlineDaemon` 的所有权探测随 Stage 1 删除。
 - daemon 持有激活时，其它进程不得直接更新会话行。
 
 这一步才把「daemon 未运行仍能修改会话」做成与终态一致的实现。若只完成 Stage 1、CLI 仍作为另一套权威写 SQLite，需要理解的协议几乎没有减少。
@@ -180,14 +194,15 @@ daemon 进程内部可以先于 Stage 2 排队；**对外保证**要等所有外
 - 导入：暂存库使用 `journal_mode=DELETE`（避免 bun:sqlite 在 WAL 下 `rename` 出只有文件头的库）、按文件 key 插入而不按行内 `sessionId` 重键、`owner: false` 只读、不因探测路径创建空库而跳过导入。
 - close 路径先写 SQLite 再合并回内存对象，与单一 apply 方向一致，保留。
 - 测试夹具写入真实 SQLite，不再靠写 JSON 让「唯一写入入口」测试误绿。
-- 删除白板：daemon 运行中 IPC 解绑；未运行时带 `abortIf` 的离线写。sqlite 离线写打开前拒绝缺文件。
+- 删除白板：daemon 运行中 IPC 解绑，未运行时离线写，两侧都对板 id 比对；无法解绑的会话计入返回。sqlite 离线写打开前拒绝缺文件。
+- 离线写与 daemon 发现各收敛成一份实现（见 §3 Stage 0 缺口）。Stage 1 / Stage 2 的删除面因此只剩一个入口。
 
 本 PR 明确不做、也不应做：
 
 - occupancy（Stage 1）。与「删除 JSON 写路径」风险和范围都不同。
-- 跨进程改为只读 SQLite。在升级后自动重启 fleet 落地前删除 JSON 回落，会让升级窗口内的 `botmux send` 失败。删除条件是「不再存在仍在写 JSON 的 daemon」，放在 Stage 0 收尾，不是本 PR 的前置。
+- 跨进程改为只读 SQLite。在升级窗口关闭前删除 JSON 回落，会让窗口内的 `botmux send` 失败。删除条件见 Stage 0，不是本 PR 的前置。
 
-合入后的实际状态：daemon 只写 SQLite；其它进程在升级窗口内仍可能读 JSON；occupancy 仍在心跳文件；apply 仍有两套（删白板在 daemon 运行时走 IPC，未运行时走带 `abortIf` 的离线写）。之后按 Stage 1 → 2 → 3 推进。
+合入后的实际状态：daemon 只写 SQLite；其它进程在升级窗口内仍可能读 JSON；occupancy 仍在心跳文件；apply 仍有两套——daemon 的 `updateSession`，和 `mutateSessionRowWhenUnowned` 这一个离线入口。之后按 Stage 1 → 2 → 3 推进。
 
 ## 5. 建议顺序
 
@@ -198,9 +213,9 @@ daemon 进程内部可以先于 Stage 2 排队；**对外保证**要等所有外
  |  (本 PR)      |  删除 JSON 读路径   |------ Stage 1 ------+-- Stage 2 ---+-- Stage 3 ---|
 ```
 
-- **#1051**：删除 daemon JSON 写路径；含白板 IPC 解绑与离线写打开前拒绝缺文件。
-- **与升级后自动重启 fleet 对齐**：从代码删除 JSON 读路径。fleet 实现不在本文范围，但它是删除 JSON 分支的前提。
-- **下一个架构主 PR**：Stage 1 occupancy。先写能失败的测试覆盖「读心跳文件与写会话行之间的窗口」，合入后 `findDaemon` 不再用于所有权判断。
+- **#1051**：删除 daemon JSON 写路径；含白板解绑的 compare-and-set、离线写打开前拒绝缺文件、离线写与 daemon 发现各收敛成一份实现。
+- **删除 JSON 读路径**：条件见 Stage 0（fleet 自动重启落地，或 2026-11-26 的兜底复核点）。fleet 实现不在本文范围。
+- **下一个架构主 PR**：Stage 1 occupancy。先写能失败的测试覆盖「读心跳文件与写会话行之间的窗口」，合入后 `findOnlineDaemon` 不再用于所有权判断。
 - **再下一个**：Stage 2，daemon 未运行时获取租约并执行同一 apply，删除第二套对外写协议。这一阶段减少的概念最多。
 - **Stage 3**：按已有证据把分散 fence 收进 per-session 队列。不设「迁完全部写点」的完成门。
 

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -91,7 +91,7 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 - **occupancy 存在旁路文件里。** `utils/daemon-discovery.ts` 的 `findOnlineDaemon` 读 `dashboard-daemons/*.json` 心跳（90s 过期），写入目标却是会话行。SQLite 锁只串行化写者，不能判断「另一进程是否仍持有将要 `persistRow` 的内存缓存」。在租约写入 SQLite 之前，必须保留 `abortIf` 双次探测。
 - **两套 apply。** daemon 使用 `updateSession` / `persistRow`；其它进程使用 `services/session-offline-write.ts` 的 `mutateSessionRowWhenUnowned`（心跳探测 + `mutateSessionRowOffline`）。后者是第二套权威，不是「临时 host 执行同一套命令」。#1051 已把它收敛成一份实现，删除时只有一个入口。
 - **没有 per-session turn。** 进程内仍依赖多处独立的 fence。
-- **跨进程仍可能读 JSON**（#1051 保留）：当 CLI 已升级、daemon 仍在写 JSON 时，快照、点读、身份扫描、worker、`owner: false` 走 db-else-json。这是迁移兼容，不是终态。升级后自动重启 fleet 落地后，该窗口缩短为一次重启；届时从发布产物中删除 JSON 读写分支。磁盘上的冻结 JSON 文件可以保留。
+- **跨进程仍可能读 JSON**（#1051 保留）：当 CLI 已升级、daemon 仍在写 JSON 时，快照、点读、身份扫描、worker、`owner: false` 走 db-else-json。这是迁移兼容，不是终态。删除这些分支的条件见 Stage 0（fleet 自动重启落地，或 2026-11-26 的兜底复核点）。磁盘上的冻结 JSON 文件可以保留。
 
 #831 / `SessionRuntime` **不合入**。失败原因是只把约 32% 的写点迁入新层、旧 API 完整保留、约 17k 行适配层按设计要整段删除，并在 build 上挂审计脚本。这不能证明会话桥不该用 virtual actor。写点地图和 receipts/lane 只作线索，立项前在现行代码上复核。
 
@@ -128,7 +128,7 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 - 线上不再有仍在写 JSON 的 daemon 之后，删除导入实现及其文件锁；新 bot 直接创建空库。
 - 磁盘上的冻结 JSON 文件可以保留，供回退旧版本读取。
 
-在 fleet 自动重启落地之前，#1051 保留 db-else-json：升级窗口内 `botmux send` 必须仍能读到会话。这不是终态要求。
+删除条件满足之前，#1051 保留 db-else-json：升级窗口内 `botmux send` 必须仍能读到会话。这不是终态要求。
 
 ### Stage 1 — Occupancy 写入 SQLite
 
@@ -207,10 +207,10 @@ daemon 进程内部可以先于 Stage 2 排队；**对外保证**要等所有外
 ## 5. 建议顺序
 
 ```
-现在          #1051 合入        升级后自动重启 fleet     occupancy      单一 apply       turn
- |               |                    |                    |              |              |
- |-- Stage 0 ----+-- Stage 0 收尾 -----|                    |              |              |
- |  (本 PR)      |  删除 JSON 读路径   |------ Stage 1 ------+-- Stage 2 ---+-- Stage 3 ---|
+现在          #1051 合入        删除条件满足          occupancy      单一 apply       turn
+ |               |          (fleet 落地 / 复核点)         |              |              |
+ |-- Stage 0 ----+-- Stage 0 收尾 -----|                  |              |              |
+ |  (本 PR)      |  删除 JSON 读路径   |----- Stage 1 -----+-- Stage 2 ---+-- Stage 3 ---|
 ```
 
 - **#1051**：删除 daemon JSON 写路径；含白板解绑的 compare-and-set、离线写打开前拒绝缺文件、离线写与 daemon 发现各收敛成一份实现。

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -272,12 +272,19 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
 原则 1 在本步兑现。`session-store.ts` 从 2154 行降到约 1800 行，且删掉的全部是机器
 而不是注释：
 
-- **JSON 引擎净删除**：`save()` 整份序列化 + byte-identical 跳写、`load()` 的
-  JSON/legacy 迁移分支、`readExistingSessionsFromDisk` / `readSessionsProjectionStrict`、
-  Remote lineage CAS + readback 的 JSON 实现（约 80 行）、`mutateSessionRowOffline`
-  的 JSON 分支、以及 `StoreFileRef.kind` 撑起来的整套 db-else-json 分流。
-  `resolveStoreFile` / `listStoreRefs` / `readStoreEntries` / `readStoreRowByKey` /
-  `readStoreActiveRows` / `countActiveSessionsOnDisk` / `getSessionFresh` 一律 db-only。
+- **daemon 侧 JSON 引擎净删除**：`save()` 整份序列化 + tmp+rename + byte-identical
+  跳写、`load()` 的 JSON 写回与 legacy→per-bot 迁移写、`readExistingSessionsFromDisk` /
+  `readSessionsProjectionStrict`、Remote lineage CAS + readback 的 JSON 实现（约 80 行）、
+  `repairMissingChatScopes` 与它每次 load 里那次「修完再写回」的事务、
+  `persistRow` 的 `save()` 兜底。拥有者 daemon 从此只写 SQLite。
+
+- **跨进程那一层的 db-else-json 保留**（读 + 离线写）。原计划第 5 条写的是
+  「收敛为 db-only」，**这条被推翻了**：db-only 会在「npm 已升级、daemon 还没重启」
+  的窗口里把 CLI 快照读、点读、身份扫描、worker 读、离线写**五条全部打断**——
+  实测与 master 的 A/B 见下。而这个窗口不是少数落后用户的边角：自动更新默认关闭、
+  `botmux upgrade` 明说让用户自己 `botmux restart`，所以它**没有上界**，且每个老用户
+  升级时都会经历一次。窗口内 agent 连 `botmux send` 都发不出去，等于回不了话。
+  原计划把「灰度稳定」当成可以假设的前提，这个前提不成立。
 - **`withFileLockSync` 只剩导入一处**（编排全部消失）。**没有全删**：导入经固定的
   `<db>.tmp` 暂存，同一 bot 的两个 owner 进程可能短暂并存（重启撞上尚未回收的前任），
   两边都会通过 `existsSync(db)`、写同一个 tmp、发布出损坏库。改 per-process tmp 名会换来
@@ -295,12 +302,11 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
   掉前一条——陈旧的 closed 幽灵行覆盖活行，而且导入只跑一次、JSON 随后冻结，
   不可逆。按文件原 key 导入，错键行保持惰性（身份扫描本来就跳过 key 与
   `sessionId` 不符的行）。这一条是复核时用两个 checkout 跑同一份输入实测出来的。
-- **未导入的 store 一律 fail-closed**，不再静默空投影。新增 `SessionStoreNotImportedError`：
-  「有 `sessions*.json` 但没有 `.db`」意味着拥有该 bot 的 daemon 还在跑迁移前的版本，
-  `loadAllSessionsSnapshot`（仅针对调用方自己的 store）、`mutateSessionRowOffline`、
-  以及 `owner: false` 的 `load()` 都报出可行动的错误。这是删掉 db-else-json 之后
-  「灰度窗口」的诚实形态：把静默降级换成一句「重启 daemon 完成一次性导入」。
-  peer bot 的未导入 store 保持不可见（本来就不是调用方的事）。
+- **升级窗口内行为与 master 逐字一致**（实测 A/B：CLI 快照读 / 点读 / 身份扫描 /
+  worker `getSession` / `getSessionFresh` / 离线写六项全部相同）。`owner: false` 的
+  `load()` 读那份 JSON 但**只读**——scope 修复与 legacy 迁移都是拥有者 daemon 的活，
+  它在导入时做一次。离线写仍落到同一份 JSON（那台 daemon 还在读它），并且**绝不建 .db**：
+  空库会关掉它的一次性导入门。
 - **两条建库地雷已封**（删 JSON 分支时才暴露出来，master 上靠 db-else-json 的
   `existsSync` 前置侥幸不可达）：SQLite 的读写 open **会创建文件**，而一个空库会让
   daemon 的 `existsSync(db)` 导入门判假、静默丢掉整份迁移前的行。现在
@@ -310,8 +316,9 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
   就已失效（它约束的是文件锁），现在连 JSON 路径也没有了，从签名删除；
   fleet shutdown 的 deadline 预检（`remaining <= 0` 直接拒绝）保留，仍在干活。
   等待上限统一由 `busy_timeout`（3s）决定。
-- **沙盒收面**：`fs-policy` 的两处 readOnly 授权不再包含冻结的
-  `sessions-<appId>.json`，只授权 `session-stores/<appId>` 目录；兄弟 bot 仍 deny-by-default。
+- **沙盒**：两处 readOnly 授权改为「store 目录 + 冻结 JSON」并存（目录 bind 的理由见
+  #852：单文件 bind 会钉死 WAL sidecar 的 inode）；兄弟 bot 仍 deny-by-default，
+  且回归里把这条安全断言加强到 sibling 目录本身与共享父目录。
 - **冻结 JSON 的处置（第二 PR 待决项 6）决定：原地保留，不删不改名。** 它已不被任何
   运行时路径读取，代码成本为零；而它是回退到迁移前版本时唯一还能读的副本，改名反而会让
   回退后的旧 daemon 从空库起步、再写出一份新的 JSON。几百 KB 换一条不可逆边界的兜底，
@@ -344,26 +351,16 @@ endsWith('.json')` 动态筛名，整份读改写——按名字 grep 命不中�
 
 **已知边界（本步接受并明写）**：
 
-- 从**迁移前**版本直接升到 db-only 版本、且旧 daemon 仍在跑时，该 bot 的 store 没有
-  `.db`：worker（`owner: false`）与 CLI 离线写都会 fail-closed 报错，直到 daemon 重启完成
-  导入。自动更新默认关闭、`botmux upgrade` 也只提示用户自己 `botmux restart`，所以这个
-  窗口没有上界——**本步的前提就是灰度窗口已关闭**（fleet 里每个 bot 都至少在 #852 的
-  版本上重启过一次）。
-- 跨 bot 发现（`findActiveSessionsByRoot` / `findActiveChatScopeSessionsByChat` /
-  `countActiveSessionsOnDisk` / `collectBotmuxSessionIdentities`）只看 `.db`：未导入的
-  peer 不可见，不报错。
-- 离线写不再顺手收敛整个 store（行级写只碰一行）：错键的脏行不再被删除，
-  保持惰性存在。
-- **沙盒内的未导入检测失效**：`fs-policy` 撤掉了 `sessions-<appId>.json` 授权，
-  bwrap 内的 `existsSync` 看不到那个文件，所以窗口期沙盒里的 `botmux send`
-  仍然是「找不到 session」而不是「请重启 daemon」。保留那条授权能让检测在沙盒里
-  生效，但那等于为一个本步假设已关闭的窗口永久留一个沙盒授权；这里选了减负。
-- **legacy `sessions.json` 里没有 `larkAppId` 的行（多 bot 拆分之前的遗留）不再可见。**
-  实测对照确认：master 上 `loadAllSessionsSnapshot` 经 db-else-json 还能读到它们，
-  db-only 下读不到。这类行本来就不归任何 per-bot store 所有——#852 的导入按
-  `larkAppId === currentAppId` 过滤，从来不收它们；生产 daemon 一律带 appId 启动，
-  扁平 legacy 库只在单 bot 开发/测试下才会建。所以它们此前也只是 CLI 还能列出、
-  还能离线关闭的惰性墓碑，没有 daemon 能恢复或投递。
+- **本步不再依赖任何灰度假设**：跨进程 db-else-json 保留后，升级窗口内的行为与
+  master 一致，什么时候合都安全。代价是 `StoreFileRef.kind` 与三个读函数、
+  `getSessionFresh`、`mutateSessionRowOffline` 的 JSON 分支继续留在库里，
+  约 60 行——它们的清除条件仍是「窗口真的关闭」，但那已经不是本步的前提。
+- 离线写在 SQLite 路径上不再顺手收敛整个 store（行级写只碰一行）：错键的脏行
+  不再被删除，保持惰性存在（读侧本来就按 `sessionId` 过滤）。JSON 路径保持原样。
+- 沙盒**仍然**授权 `sessions-<appId>.json`（一度想撤掉，作为「减面」的一部分）。
+  撤掉会让升级窗口内沙盒里的 `botmux send` 连 stat 都做不到那份 JSON，直接报
+  「找不到 session」——而沙盒是 agent 的主路径，那等于把上面刚修好的窗口兼容
+  在最常用的那条路上又废掉。它的清除条件与 db-else-json 同一条：窗口真的关闭。
 
 ### Step 4 — 按痛点上事务（N 个独立小 PR，ROI gate）
 

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -1,466 +1,220 @@
 ---
-title: Session 架构拆解回收与 store-first 重新分步
+title: Session 终态：非分布式 virtual actor（持久化仅 SQLite）
 type: design
 date: 2026-08-12
-updated: 2026-08-28（Step 3 第一 PR 已合入 master；第二 PR = JSON 净删除 + Step 4(a) 事务化，见「执行结果（2026-08-28）」）
-topic: session-restage-store-first
-status: proposed
-baseline: origin/master@cc5085b6（0828 复核基线，含已合入的 #852；0828 早先基线 0265234d；0827 复核基线 06db2b48；0820 复核基线 3d84aaad；0819 复核基线 47b2c11a；0813 复核基线 16fde8a27；原始基线 723c79ade）
+updated: 2026-08-28（面向终态重写；用词按实现语义收紧）
+topic: session-virtual-actor
+status: active
+baseline: origin/master@cc5085b6（含已合入的 #852）；#1051 删除 daemon 侧 JSON 写路径（进行中）
 references:
-  - feat/virtual_actor_stage2@b6a4982ea（不合入；仅作参考实现、竞态清单与写点地图）
-  - docs/design/2026-08-08-virtual-actor-session-runtime.md（原始提案；本目录保留未跟踪副本）
-  - PR #846（Step 1+2 产出）
-  - PR #852（Step 3 第一 PR：引擎替换 + 导入 + 混合窗口；**已合入 master**）
-  - Step 3 第二 PR：JSON 引擎净删除（db-only）+ Step 4(a) 事务化，兑现原则 1
+  - PR #846（会话行唯一写入入口）
+  - PR #852（per-bot SQLite + JSON 导入 + 混合窗口；已合入 master）
+  - PR #1051（删除 daemon 侧 JSON 写路径 + 行级持久化；进行中）
+  - #831 / feat/virtual_actor_stage2（不合入；SessionRuntime 只覆盖部分写点的失败记录）
 ---
 
-# Session 架构拆解回收与 store-first 重新分步
+# Session 终态：非分布式 virtual actor（持久化仅 SQLite）
 
-> 本文取代 stage2 分支上的 `2026-08-11-session-actor-core-implementation.md` 成为
-> 后续实施的唯一口径。原 0811 文档随其分支一并归档，不再维护。
->
-> **2026-08-13 修订**：Step 1 执行后发现 7 项候选中 6 项的「缺陷」是 stage2
-> runtime 分层自身引入的回归（master 无此缺陷或机制仍活），只有 1 项在 master
-> 真实存在。这暴露了原计划的一个方法论缺陷：**Step 1 的候选清单直接采信了
-> stage2 的修复记录，而 stage2 的修复大多是在收拾迁移自己造成的回归**（§0 的
-> 「fix(session) 15 个」判断在候选粒度上再次得到证实）。据此本次修订：
-> ① 记录 Step 1 实际产出与逐项处置；② **以 master 为唯一证据源重新核实
-> Step 2/3/4 的全部前提**——核实结论是三步全部成立，且 Step 3 的收益比原文
-> 写的更大，但两处前提表述需要修正（见各节【master 复核】）。
->
-> **2026-08-19 修订**：#831 / virtual-actor 仍不合入；现行范式是 store-first，
-> 不是把 actor 缝隙再包一层。Step 3 第一 PR（#852）rebase 到
-> `origin/master@47b2c11a` 后复核：引擎替换与行级写的收益成立，但原文收益
-> 第 1 条（「仲裁不再依赖 findDaemon-TOCTOU」）过满——SQLite 只排序写者，
-> daemon 在位探测仍必须保留；净删除未在本 PR 兑现（JSON 机器仍在，留给灰度
-> 稳定后的第二 PR）。0813 之后 master 还叠了 Remote lineage 改名、Mojo close
-> journal、`SessionStoreUnavailableError` 写门，Step 3 必须带着这些 API 一起
-> 换引擎，不能只按 0813 的 JSON store 形状施工。
->
-> **2026-08-20 修订**：#852 再 rebase 到 `origin/master@3d84aaad`。#846 的
-> 唯一门仍然健壮：src 无会话行直写绕过，CLI 只委托 `loadAllSessionsSnapshot` /
-> `mutateSessionRowOffline`，provenance 仍走 `readSessionRowCopiesAcrossStores`。
-> 0819 之后 master 新增的 Workbench `previewTarget` 在 close/resume 路径上清除，
-> 已语义化并进本 PR 的 `persistRow`。收益判定不变；原则 1 仍待第二 PR 净删除。
-> 同日补记：残余 `findDaemon` probe-vs-publish TOCTOU 的消法是 **store 内占位
-> 租约**（与行写同一 `BEGIN IMMEDIATE`），不是 virtual actor / SessionRuntime；
-> 见 Step 4 候选 (f)。本 PR 不实施。
->
-> **2026-08-27 修订**：#852 再 rebase 到 `origin/master@06db2b48`。master 在
-> 0820 之后把运行时切到 bun 单二进制，并把所有 SQLite 打开收进
-> `sqlite-compat`（Node: `node:sqlite` / Bun: `bun:sqlite`，见 `005ce0ae`）。
-> 会话库若仍 `createRequire('node:sqlite')`，会在编译态把 Step 3 硬门打成假
-> 失败——这是「干净 rebase 不是正确 rebase」（traex-transcript 已写过的
-> 同一类合并坑）。本 PR 改走 compat：引擎缺失抛 `SessionStoreSqliteUnavailableError`；
-> 损坏 `.db` 仍是普通打开失败，扫描可 skip。`engines` 跟 master 的 `node: >=22`，
-> 真门仍是 daemon `assertSqliteSupported()`。原则 1–5 与 Step 2 唯一门、混合窗口
-> `owner: false`、`abortIf`+`findDaemon`、非目标（不回流 actor / 不卷旁路 store）
-> 均未被后续 master 提交破坏；#889 `/cli`、#1017 发信人、#1008 schedule、#946
-> pending-turn journal 要么走 store 字段、要么是设计允许的旁路文件。
+本文是会话态后续实施的唯一口径。旧标题「store-first 重新分步」以及「每步合入必须立刻变简单」不再适用。#852 已把会话行持久化换到 SQLite；后续按终态收拢 occupancy、命令路径和 per-session 串行，不再把这三件事拆成互不相关的独立轨道。
 
-## 0. 背景与决策
+## 0. 原则
 
-对 feat/virtual_actor_stage2（含第一、二阶段全部工作，37 个分支独有提交）以
-origin/master 为基线的综合评估结论：
+核心判据是 **架构简明、可维护、可读**：稳态下需要同时理解的协议要少。不要求每个 PR 的 diff 行数立刻变负。
 
-- 会话态 1,408 个 mutation 中仅 453（32%）收进 SessionRuntime 缝隙，910（65%）仍直写；
-  最大写面（worker-pool 530、daemon 221、session-manager 135）未动。
-- 零个 src 文件被删除，legacy 公共文件体量持平——新层是包上去的，不是换出来的。
-  （补充精确化：`session-store.ts` 在 stage2 上从 832 行**增长到 1,387 行**——
-  在 JSON 全量文件之上叠了一套 owner-bound typed-transition + readback 的平行
-  API，旧 API 原封保留。这正是本计划要反着做的事。）
-- 过渡资产（`current-*` 适配层 17k 行 src + 26k 行绑定测试）按设计将来整体报废；
-  审计脚手架 23k 行挂在 build gate 上，master 每合入一个碰会话态的 PR 都要人工入册。
-- 37 个提交中 fix(session) 15 个（多为迁移自身回归的收束）；identity 子系统经历完整
-  的「建成—修复—拆除」往返。
-- 结论：按调用方群组横切的 staging 使共存面不随进度收窄、收益全部递延到 Target-B，
-  中间态负担大于收益。**决策：#831 不合入，拆解回收，按 store-first 重新分步。**
+1. **终态优先。** 步骤为终态服务。允许一步只做其中一块，但禁止引入「旧路径完整保留、新层按设计将来整段删除」的平行实现。
+2. **禁止只覆盖部分写点的 actor 层。** 不再引入 `SessionRuntime` / `SessionProjection`、按调用方群组横切、写点台账、审计 gate。occupancy / apply / turn 必须走同一条命令路径，CLI 与 daemon 共用。新增协议时必须写明将被替换的旧协议，以及旧协议的删除条件（可以分 PR 删除，但不能两套所有权长期并存且没有结束条件）。
+3. **边界必须是结构性的**（模块导出、tsc 可检查）。禁止只靠约定维护的边界。
+4. **修改会话状态 = 向该 session 发命令；同一时刻至多一个激活。** daemon 未运行时，不是另开一套磁盘写入协议，而是由 CLI 或 supervisor 取得租约、在本进程执行同一套 apply。产品语义「daemon 未运行时仍能 close / abandon」保留。
+5. **不把旁路存储并入会话库。** turn-sends、frozen-card、whiteboard 文件、usage-ledger、idempotency、vc-meeting-*、`utils/file-lock.ts` 保持独立生命周期。会话行上的 `whiteboardId` 等字段走会话命令；白板正文仍走 whiteboard store。
+6. **BotId 仍由地址推导，不引入分配式注册表。** 会话库内的占位租约只表示 occupancy，不是身份注册表。
 
-## 1. 分步原则（硬性判据）
+施工可以分 stage；**稳态下的协议种类必须减少。** occupancy、JSON 回落、离线写、IPC、`abortIf`、mailbox 若无限期并行，读者需要同时记住多套互斥规则。
 
-1. **每一步合入后，系统必须比之前更简单，或至少删掉了东西。** 不满足即不立项。
-2. **边界必须是结构性的**（interface / 唯一导出点，tsc 可执法）；禁止台账式纪律
-   边界与随附的审计 gate。
-3. **收益不许递延超过一步。** 任何「为了第 N+2 步铺路」的纯铺垫不单独成步。
-4. 每一步是一个可独立发布、可独立回退的 PR；事务/串行化语义只在有实测竞态处
-   逐个引入（ROI gate，I1 的教训）。
-5. **（0813 新增）证据只认 master。** stage2 的修复记录、竞态清单、写点地图
-   一律只当「去哪里看」的线索，不当「那里有问题」的证明——Step 1 的执行证明
-   照抄会把 runtime 层自己的回归误判成 master 缺陷。任何一步立项前，其前提
-   必须在 master 代码/实测上独立复核。
+## 1. 终态
 
-## 2. 步骤
+产品单元是 **一条话题对应一个 CLI 会话**。运行时按这个单元寻址和串行，而不是按「本机上的一份会话文件」来理解。
 
-### Step 1 — 独立修复摘取【已完成，PR #846】
+```
+飞书事件 / botmux CLI / dashboard / worker IPC
+        ↓
+   按 sessionId 寻址（bot 级操作按 botId）
+        ↓
+   在 SQLite 事务内读取并获取 occupancy 租约
+        ↓
+   执行同一套 command apply（与当前 host 进程无关）
+        ↓
+   行级写入 SQLite；PTY / worker 由该会话激活持有，不另作状态权威
+```
 
-以 stage2 实现为对照，逐条核实 7 项候选「能否脱离 runtime 层在 master 最小重做」。
-**执行结论：6 项不成立，1 项重做落地。**
+三部分必须同时成立，不能当成可以无限期分开交付的独立功能：
 
-| 候选 | 处置 | 判定依据（均已在 master 代码上核实） |
-|---|---|---|
-| bot listing 热路径 | 无需重做 | master 所有 `getAvailableBots` 调用点本就只在 opening/initial 路径；每消息放大是 C1 切换自身回归（stage2 注释自证 "master parity"） |
-| generation reconcile 单调判定 | 不适用 | 整行深比较 + 隔离台账只存在于 `current-session-executor-runtime.ts`；master `reserveWorkerGeneration` 写失败即回滚重抛（worker-pool.ts:10119），无永久封禁路径 |
-| /close 竞态 VC reconcile 时序 | 不适用 | 竞态由 C1 把 exit 回调改 context-only + `findActiveBySessionId` 早退引入；master 回调闭包 `ds` 直调（daemon.ts:20743/20765），reconcile 不过守卫 |
-| 幂等台账/executor slot 有界回收 | 不适用 | 被 cap 的 Map 全是 runtime 层新建物；master 对应物本已有界（`eventClaims` TTL+prune、`dispatchInputReceipts` cap 64、delivery/fence settle 即删） |
-| 删 async tail-admission | **降级 Step 4 素材** | master 上是活代码：daemon.ts:18766/18825/19370 三个生产投递点仍在调用（见 Step 4 候选 d） |
-| classify/gate 三份收敛 | 不适用 | 重复是 staging 自身制造；master gate 唯一定义（worker-pool.ts:6055），「孤儿 import」在 master 均为活引用 |
-| ingress 终态失败回可行动提示 | **✅ 已重做** | master 真实缺陷：dispatcher 对两个消息入口只有 log-only catch，transport ACK 后异常 = 静默吞消息。PR #846（src +29/−2，回归测试 +273） |
+| 部分 | 稳态含义 |
+|---|---|
+| **身份** | `sessionId` 即寻址键 |
+| **occupancy** | 同一时刻至多一个激活；租约与会话行在同一 SQLite 事务中读写 |
+| **turn** | 针对该 `sessionId` 的命令在跨 `await` 后仍串行执行。实现是按 session 的 Promise 链 / 队列，不引入新的类型层 |
 
-**教训入库**：Step 1 比预期薄——这本身是对 §0「stage2 的 fix 多为迁移自身回归」
-判断的正面验证，不动摇 store-first 决策；动摇的是「拿 stage2 记录当候选清单」
-的做法，已固化为分步原则 5。
+Host 进程可以更换，apply 实现不能分叉：
 
-### Step 2 — 存储缝隙收口【已完成，并入 PR #846】
+- **daemon 运行中**：由该 bot 的长驻 daemon（或 supervisor 下的 bot 进程）持有激活。进程拓扑与现状相同。
+- **daemon 未运行**：CLI 或 supervisor 获取租约，在本进程执行同一段 close / abandon / 解绑白板，写入同一行后释放租约。不再使用 `mutateSessionRowOffline` 作为另一套权威写入。
 
-`services/session-store.ts` 已在 master 存在（832 行、18 个消费模块、全仓 119 处
-`updateSession` 调用）。本步把它变成**唯一的门**：收编绕过它直接触碰会话行持久化
-的路径，persistence 细节（文件布局、锁、tmp+rename）全部内部化为私有。行为零变化。
+持久化：
 
-【master 复核 ✅ 前提成立；实施中的事实修正见「执行结果」】
+- 运行时唯一的会话行存储是 per-bot `session-stores/<appId>/sessions.db`。打开连接必须走 `sqlite-compat`（Node `node:sqlite` / Bun `bun:sqlite`），禁止直连。
+- 写入是行级 upsert；`journal_mode=WAL`、`synchronous=NORMAL`（不低于历史上 JSON `tmp+rename` 且不 fsync 的耐久性；本阶段不提高 durability）。
+- 磁盘上可能仍有导入后未删除的 `sessions-*.json`，只作回退到旧版本时的副本，运行时不读不写。发布产物里不再包含 JSON 会话读写实现。
 
-绕过写者：
+粒度：
 
-- `cli.ts saveSession()` —— **无锁**的整文件 read-modify-write（连 tmp 文件名
-  都是固定 `.tmp`）。**实施期修正**：其唯一调用链
-  `closeSessionForDelete → closeSessionOffline → saveSession` 在 master 上已是
-  **死代码**（活的 delete 流早已换到 `abandonSessionAuthoritatively →
-  abandonSessionOffline`，全程走带锁的 `mutateSessionOffline`）。处置从「修复
-  无锁缺口」改为**整链净删除**（连同孤儿 `loadSessionFresh` 与
-  `SessionDeleteCloseResult`）。
-- `cli.ts mutateSessionOffline()` —— 带锁 + `findDaemon` fail-closed 的离线
-  CAS。语义正确，但它是 store 之外第二份「锁 + 读改写 + strip legacy 字段」的
-  拷贝；收编为 store 导出的唯一离线突变入口。
-- `cli.ts loadSessions()` —— 第二份「读全部会话文件 + repair」实现；由 store
-  的读 API 替代。
+- **寻址和 turn 的键是 session。** 激活可以仍由 per-bot daemon 进程承载（不必引入 Orleans 或跨机器调度）。
+- 现状是整个 bot 的 `Map<string, Session>` 共用一个进程：该进程退出后，此 bot 下所有会话的内存权威同时失效。终态允许只激活单个 session；SQLite 行级读写已支持这一点。
+- `DaemonSession` 的共享可变别名可以保留，直到有独立的重构理由。去掉别名既不能实现 occupancy，也不等于 mailbox。
 
-绕过读者（改为 store 导出的读 API，语义不变）：
+Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker 会并发进入同一 `sessionId`，但一条会话一次只应执行一个 turn。JavaScript 单线程不能防止这一点——`await` 之后另一条请求可以插进同一 session。现有 FIFO、generation、inflight、gate、tail-admission 是分散的串行化实现；终态用按 `sessionId` 的命令队列替换它们，而不是再包一层 runtime 类型。
 
-- `daemon.ts readSessionFreshFromDisk()` —— daemon 自己的无锁直读（per-bot +
-  legacy 双文件）。热回复路径上无锁快照读是正确语义（atomic rename 保证单文件
-  自洽；带锁的 `getSessionFresh` 会阻塞且超时抛错），故收编为 store 的无锁点读
-  导出，与 worker 用的带锁 `getSessionFresh`（刻意要求写序）并存、各守其义。
-- `core/current-turn-provenance.ts readPersistedSession()` —— 跨全部会话文件的
-  只读身份证明扫描。安全敏感：扫描机制收编进 store（数据目录不可枚举 →
-  fail-closed 抛错；单个损坏文件跳过），「恰好解析一次」的判定策略留在原模块。
+## 2. 当前基线
 
-**执行结果（2026-08-13）**：store 新增 4 个导出——`loadAllSessionsSnapshot`
-（跨文件快照读，含 sandbox fallback）、`mutateSessionRowOffline`（带锁离线行
-突变，`abortIf` 在锁内入口与发布前各探测一次 daemon 在位）、
-`readSessionRowFromDisk`（无锁点读）、`readSessionRowCopiesAcrossStores`
-（fail-closed 逐文件身份扫描）；cli.ts 的平行持久化实现与死链整体删除
-（cli.ts +29/−250），daemon/provenance 直读改走 store（−16/−20）。src 全仓
-不再有 session 文件路径拼装点（rg 验证为零）。新增回归 14 例（快照合并/sandbox fallback、
-点读回退、fail-closed 扫描、离线突变的 fresh-row/abortIf 双探测/收敛清理）。
+以 **#852 合入 master（会话行已在 SQLite）** 为基线。#1051 合入后，daemon 进程不再写 JSON。
 
-**范围边界（防蔓延）**：本步只管**会话行**store。以 sessionId 为键的旁路存储
-（turn-sends jsonl、frozen-card-store、whiteboard-store、usage-ledger、
-idempotency-store、vc-meeting-* 系列）不动——它们各自有独立文件与生命周期，
-不属于「会话行持久化」。`utils/file-lock.ts`（1,004 行）是 ~30 个 store 共用的
-基础设施，同样不动。
+已具备：
 
-验收：会话行落盘入口收敛为 1 个模块导出面；删除 cli.ts 分散拷贝与死链。
-**无台账、无审计脚本。** ✅
+- 会话行的落盘入口在 `session-store.ts`（#846）。其它模块不应再按路径拼装并直接写 `sessions*.json`。
+- per-bot SQLite：整行 JSON 列 + VIRTUAL 生成列；首次 `load()` 使用 `BEGIN IMMEDIATE`；worker `owner: false` 不执行导入。
+- 行级 `persistRow`：不再每次把整个 `Map` 序列化覆盖文件，因此不再出现「外部已提交的行被陈旧整图覆盖」。
+- `closeSession` / `reactivateClosedSession` / mojo journal：先写入副本，成功后再 `Object.assign` 到内存对象（别名保持）。
+- bun 单文件二进制；打开库走 `sqlite-compat`。损坏的 `.db` 与「运行时没有 SQLite 引擎」分开处理。
 
-### Step 3 — SQLite 引擎替换（1~2 个 PR）
+相对终态仍缺：
 
-在 Step 2 的门后把 JSON 换成 per-bot SQLite。打开库必须走 `sqlite-compat`
-（Node 的 `node:sqlite` / Bun 的 `bun:sqlite`），禁止再直连 `node:sqlite`。
-Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
-`>=22`（bun 分发）；现行门是 daemon `assertSqliteSupported()` 经 compat 探测。
+- **occupancy 存在旁路文件里。** `findDaemon` 读 `dashboard-daemons/*.json` 心跳，写入目标却是会话行。SQLite 锁只串行化写者，不能判断「另一进程是否仍持有将要 `persistRow` 的内存缓存」。在租约写入 SQLite 之前，必须保留 `abortIf` 双次探测。
+- **两套 apply。** daemon 使用 `updateSession` / `persistRow`；CLI 使用 `mutateSessionRowOffline`。后者是第二套权威，不是「临时 host 执行同一套命令」。
+- **没有 per-session turn。** 进程内仍依赖多处独立的 fence。
+- **跨进程仍可能读 JSON**（#1051 保留）：当 CLI 已升级、daemon 仍在写 JSON 时，快照、点读、身份扫描、worker、`owner: false` 走 db-else-json。这是迁移兼容，不是终态。升级后自动重启 fleet 落地后，该窗口缩短为一次重启；届时从发布产物中删除 JSON 读写分支。磁盘上的冻结 JSON 文件可以保留。
 
-【master 复核 ⚠️ 前提表述需修正，但修正后收益更大】
+#831 / `SessionRuntime` **不合入**。失败原因是只把约 32% 的写点迁入新层、旧 API 完整保留、约 17k 行适配层按设计要整段删除，并在 build 上挂审计脚本。这不能证明会话桥不该用 virtual actor。写点地图和 receipts/lane 只作线索，立项前在现行代码上复核。
 
-原文「每 bot daemon 本来就是自身会话文件的唯一写者——单写者拓扑现成」**不准确**。
-实际写者拓扑：
+## 3. 后续 stage（#852 之后）
 
-- per-bot daemon 是唯一**在线**写者（一 bot 一 daemon 进程）；
-- **CLI 是离线维护写者**（offline close/abandon 等），今天靠
-  「`withFileLockSync` + 锁内 `findDaemon` 探测」维持互斥，存在 TOCTOU 窗口，
-  且 `saveSession` 这条腿连锁都没有（Step 2 先收口）；
-- worker 子进程与其它 bot 的 daemon 是跨文件**读者**（`findInOtherFiles`、
-  `findActiveSessionsMatching`、`countActiveSessionsOnDisk` 等）。
+从会话行已在 SQLite 起重新划分。旧 Step 1–5（摘取缺陷 / 唯一写入入口 / 换引擎 / 按痛点加事务 / 归档）只记录已完成工作，不再当路线图。
 
-这个修正不削弱反而加强 Step 3 的立项理由——SQLite 在 master 上可核实的收益：
+### Stage 0 — 删除 daemon JSON 写路径【进行中：#1051】
 
-1. **写者互斥从文件锁换成引擎锁**：WAL 下多读者成立；离线 CLI 与 daemon 的
-   **写排序**由 `BEGIN IMMEDIATE` 承担。**不是**「findDaemon 探测可以删」——
-   SQLite 锁只排序写者，防的是写写交错；探测防的是「daemon 内存缓存与磁盘
-   分叉」，二者不可互替。残余 probe-vs-publish TOCTOU 与 JSON 时代等宽，仍
-   是 Step 4 候选 (f)，不是本步验收项。消法见该候选：占位进 store，不是再包
-   actor。
-2. **消灭整图覆盖丢失更新这一整类问题**：今天 daemon 进程终身持有一份
-   `Map<string, Session>` 缓存（`load()` 仅一次），每次 `save()` 把**整个 map**
-   序列化重写文件——任何外部进程在窗口内写入的行都会被陈旧整图覆盖。改成
-   行级 upsert 后该类问题在 SQLite 路径上结构性消失。首次 load 必须与离线
-   写者走同一排他协议（`BEGIN IMMEDIATE` 快照读），否则仍会把提交前旧行读进
-   终身缓存。
-3. **热路径成本**：`updateSession` 全仓约 125 个 src 调用点（0813 计 119；
-   0819 基线因 Mojo/dashboard 等新增约 +6）、每条入站消息触发多次，
-   每次 `JSON.stringify` 全部会话行（live 数据实测：单 bot 文件 228KB/40 行、
-   closed 行从不回收、只增不减）再做 byte-identical 跳写。行级写把 O(全部行)
-   变 O(1)。
-4. **净删除**（本步的删除项，兑现原则 1；**第一 PR 不兑现，灰度稳定后的
-   第二 PR 才删**）：store 内 JSON 机器全部私有报废——`withFileLockSync`
-   编排、tmp+rename 原子替换、byte-identical 跳写、legacy `sessions.json`
-   迁移分支、`repairMissingChatScopes`（转为导入期一次性步骤）；以及
-   **Remote lineage CAS + readback 的 JSON 实现**（0813 时名为 Riff；0819
-   基线已改名为 Remote，含 Mojo 共用）。第一 PR 只在 SQLite 上等价重写，
-   JSON 实现与 db-else-json 分流逻辑必须留到回滚窗口关闭。因此第一 PR
-   **暂时违反原则 1 的「合入即更简单」**——这是设计允许的 1~2 PR 切分，
-   不是另起 actor 层；验收以第二 PR 的净删除为准。
-5. durability 口径修正：今天的语义是 **tmp+rename、无 fsync**；SQLite WAL +
-   `synchronous=NORMAL` 首版即不弱于现状，不顺带升级（维持原验收）。
+**目标**：daemon 只写 SQLite；JSON → SQLite 导入正确；运行时更新走行级 upsert。
 
-实施要点（0819 按现行基线补齐，不改目标）：
+#1051 已覆盖本 stage 中收益最大的部分（§4）。本 stage 只收尾，不要把 occupancy 放进同一 PR。
 
-- 首启从既有 JSON **确定性自动导入**（per-bot 文件 + legacy `sessions.json`
-  中属于本 bot 的行；`repairMissingChatScope` 在导入时执行一次）：无操作员
-  仪式、无 promotion、无 HIL。JSON 不可读则 **fail-closed**（`loadFailure` +
-  `SessionStoreUnavailableError`），禁止导入出空库把唯一副本毁掉。
-- **保持 `updateSession(session)` 等既有签名不变**（内部变行级 upsert）。
-  0819 基线门面已比 0813 宽：`listSessionsStrict` / `loadForWrite` /
-  `persistActiveRemoteLineage*`（原 Riff）/ Mojo close journal 必须走同一
-  引擎，不能只换 `updateSession`。
-- 跨 bot 发现类读者改为只读打开兄弟 bot 的 `.db`；扫描函数按 db-else-json
-  解析每个 store。远程 sandbox 无本地 store 的路径（cli.ts `loadSessions`
-  走 `loadAllSessionsSnapshot` + sandbox fallback）语义不变。
-- per-bot 库放 `session-stores/<appId>/sessions.db`（目录 bind，避免 bwrap
-  单文件 inode 钉死 WAL sidecar）；legacy 无 appId 库保持平铺、不进沙盒。
-- worker `owner: false`：混合窗口内旧 daemon 从新 dist spawn 的 worker 不得
-  首启导入。
-- 运行时门：打开库走 `src/services/sqlite-compat.ts`（与 feedback / opencode /
-  traex 同一入口）。Node 免 flag 线仍是 v22.13.0 / v23.4.0，但 `package.json`
-  `engines` **不收紧**——跟 master `node: >=22`（bun 单二进制用 `bun:sqlite`）。
-  真门是 daemon 启动 `assertSqliteSupported()`：模块加载失败才算引擎不可用；
-  损坏 `.db` 不得收成 Unavailable（否则身份扫描会把坏库误判成整机无 SQLite）。
-  opencode.ts 仍标注 experimental，那是先例不是现行能力边界。
-- 经 npm canary 渠道灰度；稳定后删除 JSON 会话持久化路径（第二 PR）。
+建议在本 PR 内补上（范围小，且避免与终态相反的写入路径）：
 
-验收：第一 PR = 引擎互换 + 混合窗口 + 行为等价（含 0819 基线新增 API）；
-第二 PR = 上述净删除。durability 首版与今日等价。
+- dashboard 删除白板：daemon 运行中通过 IPC 清除 `whiteboardId`（现有 `POST /api/sessions/:id/whiteboard` 只接受非空 id，不能解绑）。daemon 未运行时才走离线写，且必须传 `abortIf`。当前实现在 daemon 运行时直接 `UPDATE` SQLite，会造成磁盘行与 daemon 内存不一致；相对 #852 之后的 master，这是新增的第二写者。
+- `mutateSessionRowOffline` 在 sqlite 路径调用 `openDbForOwnStore` 之前，若文件不存在则失败。读写 open 会创建空库，导致 `existsSync(db)` 导入门误判为「已导入」。不要只依赖 `resolveStoreFile` 里的一次 `existsSync`。
+- PR 标题与最早一笔 commit 仍写「全仓 db-only」，与 HEAD 不符。以「daemon 不再写 JSON；跨进程在升级窗口内仍可读 JSON」为准。
 
-**执行结果（2026-08-20，#852 rebase onto origin/master@3d84aaad）**：
+升级后自动重启 fleet 合入后，再开一个仍属 Stage 0 的 PR，从代码中删除 JSON 读路径（不必等 occupancy）：
 
-- store 公共签名保持；内部 SQLite 单表 + 整行 JSON 列 + VIRTUAL 生成列索引。
-- 混合窗口统一 db-else-json；abortIf 双探测保留；首次 load 走 BEGIN IMMEDIATE。
-- 0819 基线新增面已接上：Remote lineage CAS、Mojo journal 经 `persistRow`、
-  损坏 store 的写门对 .db 同样 fail-closed。`BEGIN IMMEDIATE` 超时
-  （SQLITE_BUSY）**不得**收成空投影：daemon restore 走 `listSessions()`，
-  锁等待必须抛错而不能当成「没有会话」。
-- 0820 基线新增面：Workbench `previewTarget` 在 `closeSession` / `reactivateClosedSession`
-  清除并随 `persistRow` 回滚；#846 四导出在 SQLite + 混合窗口下仍是唯一门。
-- 体量：0813 master `session-store.ts` 1390 行 → 本 PR ~2161 行。这是「JSON 机器
-  + SQLite 机器」共存的中间态，印证原则 1 的兑现点在第二 PR，不在本 PR。
-- src 无 SessionRuntime / virtual-actor 缝隙回流。
+- 删除跨进程 JSON 读/写、`StoreFileRef.kind` 分流、沙盒对冻结 JSON 的授权。
+- 若无 `.db` 且尚未导入：失败并提示重启 daemon 完成迁移，不再实现完整的 JSON 离线写。
+- 线上不再有仍在写 JSON 的 daemon 之后，删除导入实现及其文件锁；新 bot 直接创建空库。
+- 磁盘上的冻结 JSON 文件可以保留，供回退旧版本读取。
 
-**执行结果（2026-08-27，#852 rebase onto origin/master@06db2b48）**：
+在 fleet 自动重启落地之前，#1051 保留 db-else-json：升级窗口内 `botmux send` 必须仍能读到会话。这不是终态要求。
 
-- 会话库不再直连 `node:sqlite`，经 `sqliteEngineAvailable` +
-  `openDatabaseSyncOrThrow` 打开；与 master bun 分发同一运行时原则。
-- `engines` 恢复 master 的 `>=22`；硬门文案同时覆盖 Node 升级线与 Bun
-  `bun:sqlite`。损坏库与引擎缺失分型：扫描 skip vs 穿透抛错。
-- 原则自检（对照 3d84aaad..06db2b48）：唯一门仍在（src 无 `sessions*.json`
-  直写绕过；CLI 只委托 store）；worker `owner: false`、fs-policy 授
-  `session-stores/<appId>` 目录、descriptor 后再 `listSessions()` +
-  `BEGIN IMMEDIATE`、`abortIf`+`findDaemon` 均保住。#889 会话级 `/cli` 写的是
-  Session 字段经 `updateSession`；#1017 发信人仍走
-  `readSessionRowCopiesAcrossStores`；#946 journal / #1008 schedule 仍是旁路
-  文件，符合非目标。无 SessionRuntime 回流，Step 4(f) 占位租约仍未实施。
+### Stage 1 — Occupancy 写入 SQLite
 
-**执行结果（2026-08-28，Step 3 第二 PR，基线 `origin/master@0265234d`）**：
+**目标**：occupancy 与会话行在同一事务中读写。这是 grain directory（哪个进程持有激活），不是 actor 框架。
 
-原则 1 在本步兑现。`session-store.ts` 从 2154 行降到约 1800 行，且删掉的全部是机器
-而不是注释：
+实现要点：
 
-- **daemon 侧 JSON 引擎净删除**：`save()` 整份序列化 + tmp+rename + byte-identical
-  跳写、`load()` 的 JSON 写回与 legacy→per-bot 迁移写、`readExistingSessionsFromDisk` /
-  `readSessionsProjectionStrict`、Remote lineage CAS + readback 的 JSON 实现（约 80 行）、
-  `repairMissingChatScopes` 与它每次 load 里那次「修完再写回」的事务、
-  `persistRow` 的 `save()` 兜底。拥有者 daemon 从此只写 SQLite。
+1. 库内保存占位：`owner_pid` / `boot_id` / `lease_until`（或等价的 SQLite 锁会话）。第一版粒度可以 per-bot（与当前 daemon 进程同构）；表结构不要排除将来改为 per-session。
+2. daemon 在首次 `load()` 的同一事务里写入占位。现状是先写 descriptor 文件再 `load()`，两者不在同一原子操作中。
+3. 非当前 host 的写入：`BEGIN IMMEDIATE` → 读租约 → 租约有效则中止并走 IPC（或等待）；租约过期才进入 Stage 2 的短生命周期激活。探测与写入在同一事务内完成。
+4. 租约按心跳续期。90s 过期已有实现，只是心跳文件与会话行不在同一事务。
 
-- **跨进程那一层的 db-else-json 保留**（读 + 离线写）。原计划第 5 条写的是
-  「收敛为 db-only」，**这条被推翻了**：db-only 会在「npm 已升级、daemon 还没重启」
-  的窗口里把 CLI 快照读、点读、身份扫描、worker 读、离线写**五条全部打断**——
-  实测与 master 的 A/B 见下。而这个窗口不是少数落后用户的边角：自动更新默认关闭、
-  `botmux upgrade` 明说让用户自己 `botmux restart`，所以它**没有上界**，且每个老用户
-  升级时都会经历一次。窗口内 agent 连 `botmux send` 都发不出去，等于回不了话。
-  原计划把「灰度稳定」当成可以假设的前提，这个前提不成立。
-- **`withFileLockSync` 只剩导入一处**（编排全部消失）。**没有全删**：导入经固定的
-  `<db>.tmp` 暂存，同一 bot 的两个 owner 进程可能短暂并存（重启撞上尚未回收的前任），
-  两边都会通过 `existsSync(db)`、写同一个 tmp、发布出损坏库。改 per-process tmp 名会换来
-  没人清理的孤儿文件；直接建进最终 `.db` 则会打破本设计赖以成立的不变量——
-  「`.db` 存在」必须等价于「导入已完成」，否则半截导入会静默关掉导入门、丢光迁移前的行。
-- **脏数据修补收敛为导入期一次性**：`stripLegacyPendingCardFields` 与
-  `repairMissingChatScope` 不再挂在每次写、也不再挂在 `load()` 上（`Session` 类型已不含
-  那些字段，SQLite 写出的行天生干净），连带删掉 `repairMissingChatScopes()` 这个
-  map 级修补函数与它在每次 load 里那次「修完再写回」的额外事务。
-  唯一保留的读侧调用在 `loadAllSessionsSnapshot`：它读的是**别人的 store**，
-  这个进程既不拥有也修不了那些行，一次纯内存归一化是合理的，且不写盘。
-  原先只在「恰好对该 store 做过一次离线写」时才发生的 key-mismatch 收敛
-  （旧实现是 `delete data[key]`）**不再发生，也不改成导入期重键**：两条 JSON 记录
-  可能带同一个 `sessionId`，按 `sessionId` 重键会让后写的那条 `INSERT OR REPLACE`
-  掉前一条——陈旧的 closed 幽灵行覆盖活行，而且导入只跑一次、JSON 随后冻结，
-  不可逆。按文件原 key 导入，错键行保持惰性（身份扫描本来就跳过 key 与
-  `sessionId` 不符的行）。这一条是复核时用两个 checkout 跑同一份输入实测出来的。
-- **升级窗口内行为与 master 逐字一致**（实测 A/B：CLI 快照读 / 点读 / 身份扫描 /
-  worker `getSession` / `getSessionFresh` / 离线写六项全部相同）。`owner: false` 的
-  `load()` 读那份 JSON 但**只读**——scope 修复与 legacy 迁移都是拥有者 daemon 的活，
-  它在导入时做一次。离线写仍落到同一份 JSON（那台 daemon 还在读它），并且**绝不建 .db**：
-  空库会关掉它的一次性导入门。
-- **两条建库地雷已封**（删 JSON 分支时才暴露出来，master 上靠 db-else-json 的
-  `existsSync` 前置侥幸不可达）：SQLite 的读写 open **会创建文件**，而一个空库会让
-  daemon 的 `existsSync(db)` 导入门判假、静默丢掉整份迁移前的行。现在
-  `openDbForRead` 对不存在的路径直接抛错，`mutateSessionRowOffline` 在 open 前先
-  `existsSync`，`withOwnStoreDb` 不再自开连接而是走 `loadForWrite()` 复用 load 附着的那个。
-- **死参数删除**：Remote 两个批量 API 的 `options.maxWaitMs` 自 #852 起在 SQLite 路径上
-  就已失效（它约束的是文件锁），现在连 JSON 路径也没有了，从签名删除；
-  fleet shutdown 的 deadline 预检（`remaining <= 0` 直接拒绝）保留，仍在干活。
-  等待上限统一由 `busy_timeout`（3s）决定。
-- **沙盒**：两处 readOnly 授权改为「store 目录 + 冻结 JSON」并存（目录 bind 的理由见
-  #852：单文件 bind 会钉死 WAL sidecar 的 inode）；兄弟 bot 仍 deny-by-default，
-  且回归里把这条安全断言加强到 sibling 目录本身与共享父目录。
-- **冻结 JSON 的处置（第二 PR 待决项 6）决定：原地保留，不删不改名。** 它已不被任何
-  运行时路径读取，代码成本为零；而它是回退到迁移前版本时唯一还能读的副本，改名反而会让
-  回退后的旧 daemon 从空库起步、再写出一份新的 JSON。几百 KB 换一条不可逆边界的兜底，
-  值得。
+验收：`findDaemon` **不再作为所有权判断**（仍可用于发现 IPC 地址）。长期同时使用心跳探测和库内租约不算完成。仅用 `BEGIN IMMEDIATE` 替换 `findDaemon` 也不算完成：锁不能表示「另一进程仍持有待写回的内存缓存」。禁止 daemon 未运行时提交 close / abandon 也不算完成：产品语义保留，实现改为获取租约后在本进程 apply。
 
-**顺带的正向副作用（身份扫描）**：`readSessionRowCopiesAcrossStores` 的「恰好一次」判定
-在 db-only 下更准。legacy → per-bot 的迁移一直是**复制不删除**，所以
-`{sessions.json 含 X, session-stores/A/sessions.db 含 X}` 是常态，今天会被判成「重复 →
-拒绝推断当前调用者」。冻结 JSON 不再是 store 之后这类假歧义消失；同时也堵掉一个伪造面：
-今天任何能往 dataDir 写文件的进程放一个 `sessions-evil.json`，若目标 session 所在 store
-尚无 `.db`，它就是唯一命中并被当作身份来源。
+#852 之后，这一 stage 的架构收益最大。不做它，turn 队列和单一 apply 无法约束 CLI / dashboard 进程。
 
-**顺带修掉的 master 活 bug（#852 引入，非本步回归）**：一次性导入的暂存库原本开
-WAL，而 `renameSync` 只搬走一个文件。`bun:sqlite` 关连接时不把 `-wal` 折回主文件，
-于是行全留在 `sessions.db.tmp-wal` 里，发布出去的是 4KB 只有文件头的库，之后每次
-打开报 `disk I/O error`；导入门是 `existsSync(db)`，这个壳再也不会被重建——迁移前的
-会话在所有活路径上消失。两个 checkout 同一份输入实测复现。暂存改用回滚日志
-（`journal_mode = DELETE`）让文件自包含，真正的库仍跑 WAL。本 PR 把 JSON 引擎删掉
-之后导入是唯一迁移路径，所以必须在这里修。
+### Stage 2 — 单一 apply 路径
 
-**唯一门的一处漏网（本步补上）**：Step 2 的验收写着「src 全仓不再有 session 文件路径
-拼装点（rg 验证为零）」，但 `services/whiteboard-store.ts` 的
-`clearSessionWhiteboardRefs` 是 `readdir` 数据目录 + `startsWith('sessions') &&
-endsWith('.json')` 动态筛名，整份读改写——按名字 grep 命不中，所以历次核查都漏了。
-它在 #852 之后已经静默失效（行搬进 SQLite 后一个文件都匹配不到，`deleteWhiteboard`
-返回 `clearedSessions: 0`，而每一行的 `whiteboardId` 还指着删掉的板）；测试一直绿是
-因为夹具写的正是 JSON。本步改为经 `loadAllSessionsSnapshot` + `mutateSessionRowOffline`。
-**方法论教训**：验证「唯一门」不能只 grep 字面文件名，还要查动态筛名
-（`startsWith`/`endsWith`/正则）与 `readdir` 数据目录的地方。
+**目标**：close / abandon / 解绑白板 / prune 等命令只有一份实现。依赖 Stage 1。
 
-**已知边界（本步接受并明写）**：
+- CLI、dashboard 只发送命令。daemon 运行中：经 IPC 进入当前激活。daemon 未运行：获取租约，在本进程调用 **同一模块** 的 apply，然后释放租约。
+- 删除 `mutateSessionRowOffline` 作为对外权威写入的语义（若仍存在，只能是短生命周期激活的内部实现，不再是第二条公共写协议）。
+- `abortIf` + `findDaemon` 的所有权探测随 Stage 1 删除。
+- daemon 持有激活时，其它进程不得直接更新会话行。
 
-- **本步不再依赖任何灰度假设**：跨进程 db-else-json 保留后，升级窗口内的行为与
-  master 一致，什么时候合都安全。代价是 `StoreFileRef.kind` 与三个读函数、
-  `getSessionFresh`、`mutateSessionRowOffline` 的 JSON 分支继续留在库里，
-  约 60 行——它们的清除条件仍是「窗口真的关闭」，但那已经不是本步的前提。
-- 离线写在 SQLite 路径上不再顺手收敛整个 store（行级写只碰一行）：错键的脏行
-  不再被删除，保持惰性存在（读侧本来就按 `sessionId` 过滤）。JSON 路径保持原样。
-- 沙盒**仍然**授权 `sessions-<appId>.json`（一度想撤掉，作为「减面」的一部分）。
-  撤掉会让升级窗口内沙盒里的 `botmux send` 连 stat 都做不到那份 JSON，直接报
-  「找不到 session」——而沙盒是 agent 的主路径，那等于把上面刚修好的窗口兼容
-  在最常用的那条路上又废掉。它的清除条件与 db-else-json 同一条：窗口真的关闭。
+这一步才把「daemon 未运行仍能修改会话」做成与终态一致的实现。若只完成 Stage 1、CLI 仍作为另一套权威写 SQLite，需要理解的协议几乎没有减少。
 
-### Step 4 — 按痛点上事务（N 个独立小 PR，ROI gate）
+### Stage 3 — Per-session turn
 
-仅对**在 master 上有实测复现**的竞态，用 SQLite 事务原语逐个重做。
-**（0813 收紧）复现要求 test-first：每个候选先在 master 写出能红的竞态测试或
-给出线上事故指针，才允许立项——stage2 竞态清单只指路，不作数。**
-每个 PR 必须删掉它所替代的 ad-hoc 防御——不删旧的，就不上新的。
+**目标**：同一 `sessionId` 上的命令在跨 `await` 后仍串行。按 session 排队，不引入 `SessionRuntime`。
 
-【master 复核 ✅ 事务形状的 ad-hoc 防御真实存在，候选素材如下（未验复现，
-仅为「去哪里看」清单）】
+- 按 `sessionId` 将命令闭包入队（或等价的 Promise 链）。host 仍是 bot 进程。
+- 用队列替换已有测试或线上证据的分散 fence（async tail-admission、worker generation / exit 路径上无保护的 `updateSession`、队首激活 FIFO 等）。没有复现的路径不要为了「更像 actor」而改。
+- stage2 的 receipts / lane 只作线索，立项前在现行代码复核。
 
-- (a) `closeSession`/`reactivateClosedSession` 的手工回滚 —— **已随 Step 3 第二 PR
-  落地，不再单独立项**（原判断「Step 3 落地后事务化即天然替代」成立）。原实现在活的
-  `Session` 对象上就地改，写失败再逐字段还原：`closeSession` 抄 14 个字段、
-  `reactivateClosedSession` 抄 20 个、`mutateMojoCloseJournal` 抄 2 个——一份靠人肉维护的
-  undo 日志，漏抄一个字段就是一次静默不一致。现在改成**先持久化副本、提交成功后再合并回
-  内存对象**（`persistRow(next)` → `Object.assign(session, next)`），失败路径变成「什么都
-  没发生」，没有可漏抄的东西。用 `Object.assign` 而不是替换 map 里的引用，是因为
-  `DaemonSession` 等模块持有同一个对象的别名——§3「不动内存共享可变语义」在此仍然成立。
-  既有的三条回滚回归用例（Riff lineage / previewTarget / mojo park 在写失败后保持原状）
-  一字未改地继续绿，就是等价性的证明。
-- (b) `reserveWorkerGeneration` 回滚重抛（0819：worker-pool.ts `reserveWorkerGeneration`）
-  与 worker exit fence 的**无保护** `updateSession`——后者是 Step 1 分析中发现
-  的疑似真实脆弱点。立项前必须在现行 master 重新定位行号并写出能红的测试。
-- (c) `admitQueuedActivationTail` 的 priorTail 回滚舞蹈（worker-pool.ts
-  `admitQueuedActivationTail`）。**0828 复核：形状与 (a) 相同，但不能照搬 (a) 的消法。**
-  (a) 在 store 内部，可以「持久化副本 → `Object.assign` 回活对象」；(c) 在 store 外部，
-  只能调 `updateSession(session)`，而它会 `sessions.set(id, session)`——传副本进去会把
-  map 里的条目换成副本，切断 `ds.session` 的别名。要按 (a) 的方式做，得先给 store 加一个
-  「按 patch 更新、不重绑引用」的新 API；为省掉 4 行还原代码而新增一个公共写入口，不划算。
-  暂不立项，除非将来另有独立理由引入该 API。
-- (d) **async tail-admission 整套**（0819：daemon.ts
-  `queuedActivationTailAdmissionsOutstanding` / ReleasePending / RetryTimer
-  三件套 + DaemonSession 三字段 + gate 分支）——Step 1 候选 5 的降级素材归位处：
-  若队首激活的 FIFO 语义由事务表达，这套进程内计数器机器就是它替代并删除的
-  ad-hoc 防御。
-- (e) `initial-user-turn` 的 best-effort persist（落盘失败退化为进程内生效）。
-- (f) **离线写 `findDaemon` probe-vs-publish TOCTOU**（0820 口径备忘，未立项）。
-  Step 3 收益第 1 条已写明：SQLite 只排序写者，`abortIf` + `findDaemon` 必须留；
-  残余窗口与 JSON 时代等宽。下面「占位租约」是这条候选若立项时的**消法**，
-  不是本步或 Step 3 的验收项。
+daemon 进程内部可以先于 Stage 2 排队；**对外保证**要等所有外部入口都走同一 apply，否则队列覆盖不到 CLI / dashboard。
 
-stage2 的 receipts / per-session lane 语义仍作设计参考，代码不搬。
+`admitQueuedActivationTail` 一类在 store 外做字段备份再回滚的逻辑：在「按命令更新且不替换 `ds.session` 引用」的 apply 入口出现后删除。不要为少写几行回滚代码单独增加一个公共 patch API。
 
-#### 候选 (f) 消法：占位进 store，不必叫 actor
+### Stage 4 — （可选）按 session 隔离激活
 
-这段窗口**不是**「daemon 进程内少了一个 mailbox」。产品规定了两种权威——
-daemon 活着时内存 `Map` 是权威；daemon 不在时 CLI 必须能改盘（离线 close /
-abandon）。第二种权威不会消失。TOCTOU 来自实现选择：`findDaemon` 读的是旁路
-descriptor（`dashboard-daemons/*.json` 心跳），写的是会话库——检查 A、动手 B。
+仅当「同一 bot 进程内容纳全部会话」导致事件循环或崩溃域不可接受时立项。Stage 1–3 不依赖本 stage。调度仍在本机，不引入跨机器放置。
 
-因此：
+### 不做
 
-- **必然存在的**：daemon 挂了仍要有人能写盘。
-- **不是必然的**：探 descriptor 和写会话行之间的缝。那是占位放在旁路文件上。
-- **与 virtual actor 无关的**：stage2 的 `SessionRuntime` 管进程内怎么改字段；
-  窗口发生在 CLI 进程 vs daemon 进程之间。进程内单线程化消不掉它。stage2 也
-  没消：CLI 仍是第二写者，descriptor 仍在库外。用缝隙层消这条是用错工具。
-- **相关的只是 occupancy 协议**（Orleans grain directory / Durable Object 的
-  瘦身版）：同一时刻一个 activation；没有 activation 才允许 failover 写存储；
-  **占位和数据在同一个原子里**。落到本仓库就是 store 元数据，不是 actor 框架，
-  也不是 §3 禁止的 BotId 注册表。
+- 合入 #831，或任何只把部分写点迁入新层、旧路径完整保留的 runtime。
+- 把旁路文件并入会话库。
+- 为 actor 引入 BotId 分配或注册表。
+- 把跨进程 JSON 读取写成长期不变量。
+- 以「本 PR 净行数未减少」否决朝终态收敛的改动。
 
-若立项（仍要 test-first 复现 + 合入即删旧探测），形态是：
+## 4. #1051 与终态的关系
 
-1. 会话库持有占位：`owner_pid` / `boot_id` / `lease_until`（或 SQLite 锁会话）。
-2. daemon 启动：与首次 load **同一事务**占位（现协议是先写 descriptor 再 load，
-   占位与行不在同一原子）。
-3. CLI 离线写：`BEGIN IMMEDIATE` → 读占位 → 租约有效则 abort 去 IPC，否则改行
-   并 COMMIT。检查和动手一次事务。
-4. 租约靠心跳续期；过期才允许 CLI 当 failover 写者（90s 心跳过期已有，只是
-   和行不在同一原子）。
+**Stage 0 中收益最大的部分已经覆盖，应当合入；不要在本 PR 做 Stage 1。** 增补仅限 Stage 0 缺口。
 
-验收必须**删掉或降级**旁路 `findDaemon` 探路（发现仍可读 descriptor，所有权
-不得再靠它 abort），不能两套探测并存——否则违反「上新必须删旧」。
-`BEGIN IMMEDIATE` 单独代替 `findDaemon` 不构成验收：锁看不见「对面有一份会
-写回的缓存」。禁止 CLI 写盘也不构成验收：离线收尸没了。
+已覆盖：
 
-### Step 5 — 资产归档（无代码）
+- 删除 daemon 的 JSON 写路径（整图 `save()`、JSON CAS、运行时 JSON 迁移写入）。这是换引擎之后减少协议种类最多的一块。
+- 行级 upsert，不再用陈旧整图覆盖已提交行。
+- 导入：暂存库使用 `journal_mode=DELETE`（避免 bun:sqlite 在 WAL 下 `rename` 出只有文件头的库）、按文件 key 插入而不按行内 `sessionId` 重键、`owner: false` 只读、不因探测路径创建空库而跳过导入。
+- close 路径先写 SQLite 再合并回内存对象，与单一 apply 方向一致，保留。
+- 测试夹具写入真实 SQLite，不再靠写 JSON 让「唯一写入入口」测试误绿。
 
-- feat/virtual_actor_stage2 打 tag 归档，#831 关闭并留结论指针；
-- 两份审计台账转为一次性《会话写点地图》静态文档（1,408 写点分布本身有诊断
-  价值），声明停止维护，审计脚本不迁移。
+本 PR 明确不做、也不应做：
 
-## 3. 非目标
+- occupancy（Stage 1）。与「删除 JSON 写路径」风险和范围都不同。
+- 跨进程改为只读 SQLite。在升级后自动重启 fleet 落地前删除 JSON 回落，会让升级窗口内的 `botmux send` 失败。删除条件是「不再存在仍在写 JSON 的 daemon」，放在 Stage 0 收尾，不是本 PR 的前置。
 
-- 不迁移调用方群组，不建 actor 抽象层，不引入 SessionRuntime/SessionProjection 缝隙；
-  virtual-actor（#831 / feat/virtual_actor_stage2）维持不合入，不在 Step 3/4
-  「顺便固化」。store-first 就是对它的替代，不是前置。
-- 不引入分配式身份或任何注册表（BotId 保持地址纯推导）。会话库内的**占位租约**
-  （Step 4 候选 f：哪个 daemon 此刻拥有本 bot 的行）是 store 元数据，不是身份
-  注册表，立项时不得借此引入 BotId 分配。
-- 不动内存 DaemonSession 的共享可变语义——它在单 daemon 进程内工作正常，
-  重构它需要独立的实测理由；也**消不掉**跨进程离线写 TOCTOU（见候选 f）。
-- （0813 明确）不把 sessionId 旁路存储（turn-sends、frozen-card、whiteboard、
-  usage-ledger、idempotency、vc-meeting-*）卷进 Step 2/3 的范围。
+建议合入前补上（仍属 Stage 0）：
 
-## 4. 与 stage2 资产的关系
+- 删除白板：IPC 解绑 + `abortIf`，见 §3 Stage 0。目的是避免本 PR 新增一条与终态相反的第二写路径，不是提前做 occupancy。
+- sqlite 离线写在打开连接前拒绝缺失文件。
+- 标题与 commit 与 HEAD 一致：daemon 不再写 JSON ≠ 所有进程只使用 SQLite。
 
-代码不搬，知识全收：1,408 写点地图（台账坐标）、竞态与幂等语义清单
-（receipts/lane 设计）、以及「纪律性边界必然演化出监视系统」这条反面教训。
-**（0813 追加）使用方式收紧：全部按「线索」使用，逐条在 master 复核后才可
-立项——Step 1 的执行记录（7 项候选 6 项不成立）就是这条规则的成因。**
+合入后的实际状态：daemon 只写 SQLite；其它进程在升级窗口内仍可能读 JSON；occupancy 仍在心跳文件；apply 仍有两套。之后按 Stage 1 → 2 → 3 推进，不再使用「按单个竞态加事务、不实现 per-session 串行」的旧 Step 4。
+
+## 5. 建议顺序
+
+```
+现在          #1051 合入        升级后自动重启 fleet     occupancy      单一 apply       turn
+ |               |                    |                    |              |              |
+ |-- Stage 0 ----+-- Stage 0 收尾 -----|                    |              |              |
+ |  (本 PR)      |  删除 JSON 读路径   |------ Stage 1 ------+-- Stage 2 ---+-- Stage 3 ---|
+                 |  白板 IPC 若未进入本 PR 则单独跟一个 PR
+```
+
+- **#1051**：补上白板解绑与「打开前拒绝缺文件」后合入。这是删除 daemon JSON 写路径的主 PR。
+- **若未打进 #1051**：白板解绑 IPC 单独跟 PR，不等 Stage 1。
+- **与升级后自动重启 fleet 对齐**：从代码删除 JSON 读路径。fleet 实现不在本文范围，但它是删除 JSON 分支的前提。
+- **下一个架构主 PR**：Stage 1 occupancy。先写能失败的测试覆盖「读心跳文件与写会话行之间的窗口」，合入后 `findDaemon` 不再用于所有权判断。
+- **再下一个**：Stage 2，daemon 未运行时获取租约并执行同一 apply，删除第二套对外写协议。这一阶段减少的概念最多。
+- **Stage 3**：按已有证据把分散 fence 收进 per-session 队列。不设「迁完全部写点」的完成门。
+
+`closeSession` 的字段级回滚已在 #1051 替换。`admitQueuedActivationTail`、async tail-admission、generation / exit 上无保护的写入归 Stage 3。`initial-user-turn` 在落盘失败时仅更新内存：有复现再进入 Stage 2 或 3，不单独开事务修复轨道。
+
+## 6. 历史
+
+2026-08 曾用 `SessionRuntime` 包装会话写入（#831）。按调用方群组迁移导致新旧路径长期并存，大部分写点未迁入，适配层按设计要整段删除，审计脚本挂在 build 上。**不合入。** 从中保留并已落地的是：会话行唯一写入入口（#846）、JSON 换成 SQLite（#852）。当时记录的多数「缺陷」是那次包装自己引入的回归，不作为现行证据。
+
+同期口径要求「每步合入必须立刻更简单、收益不得递延、先做存储且不实现 actor」。它避免了再次合入只覆盖部分写点的 runtime，也把 occupancy、单一 apply、turn 拆成互不相关的步骤。本文取代该口径。会话行已由 SQLite 持久化之后，终态是本机 virtual actor：命令、库内租约、按 session 串行；host 进程可更换；不存在第二套权威写入。

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -324,6 +324,14 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
 今天任何能往 dataDir 写文件的进程放一个 `sessions-evil.json`，若目标 session 所在 store
 尚无 `.db`，它就是唯一命中并被当作身份来源。
 
+**顺带修掉的 master 活 bug（#852 引入，非本步回归）**：一次性导入的暂存库原本开
+WAL，而 `renameSync` 只搬走一个文件。`bun:sqlite` 关连接时不把 `-wal` 折回主文件，
+于是行全留在 `sessions.db.tmp-wal` 里，发布出去的是 4KB 只有文件头的库，之后每次
+打开报 `disk I/O error`；导入门是 `existsSync(db)`，这个壳再也不会被重建——迁移前的
+会话在所有活路径上消失。两个 checkout 同一份输入实测复现。暂存改用回滚日志
+（`journal_mode = DELETE`）让文件自包含，真正的库仍跑 WAL。本 PR 把 JSON 引擎删掉
+之后导入是唯一迁移路径，所以必须在这里修。
+
 **已知边界（本步接受并明写）**：
 
 - 从**迁移前**版本直接升到 db-only 版本、且旧 daemon 仍在跑时，该 bot 的 store 没有
@@ -336,6 +344,10 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
   peer 不可见，不报错。
 - 离线写不再顺手收敛整个 store（行级写只碰一行）：错键的脏行不再被删除，
   保持惰性存在。
+- **沙盒内的未导入检测失效**：`fs-policy` 撤掉了 `sessions-<appId>.json` 授权，
+  bwrap 内的 `existsSync` 看不到那个文件，所以窗口期沙盒里的 `botmux send`
+  仍然是「找不到 session」而不是「请重启 daemon」。保留那条授权能让检测在沙盒里
+  生效，但那等于为一个本步假设已关闭的窗口永久留一个沙盒授权；这里选了减负。
 - **legacy `sessions.json` 里没有 `larkAppId` 的行（多 bot 拆分之前的遗留）不再可见。**
   实测对照确认：master 上 `loadAllSessionsSnapshot` 经 db-else-json 还能读到它们，
   db-only 下读不到。这类行本来就不归任何 per-bot store 所有——#852 的导入按

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -2,10 +2,10 @@
 title: Session 终态：非分布式 virtual actor（持久化仅 SQLite）
 type: design
 date: 2026-08-12
-updated: 2026-08-28（面向终态重写；补齐删除条件、所有权探测口径与沙盒调用方例外）
+updated: 2026-09-01（rebase 到 origin/master@7bd2e974；基线含 #852 / #1073 / #1093）
 topic: session-virtual-actor
 status: active
-baseline: origin/master@cc5085b6（含已合入的 #852）；#1051 删除 daemon 侧 JSON 写路径（进行中）
+baseline: origin/master@7bd2e974（含已合入的 #852、#1073 导入 WAL 空壳、#1093 中毒库恢复）；#1051 删除 daemon 侧 JSON 写路径（进行中）
 references:
   - PR #846（会话行唯一写入入口）
   - PR #852（per-bot SQLite + JSON 导入 + 混合窗口；已合入 master）

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -2,15 +2,16 @@
 title: Session 架构拆解回收与 store-first 重新分步
 type: design
 date: 2026-08-12
-updated: 2026-08-27（Step 3 第一 PR rebase 到 origin/master@06db2b48；会话库改走 sqlite-compat，engines 跟 master）
+updated: 2026-08-28（Step 3 第一 PR 已合入 master；第二 PR = JSON 净删除 + Step 4(a) 事务化，见「执行结果（2026-08-28）」）
 topic: session-restage-store-first
 status: proposed
-baseline: origin/master@06db2b48（0827 复核基线；0820 复核基线 3d84aaad；0819 复核基线 47b2c11a；0813 复核基线 16fde8a27；原始基线 723c79ade）
+baseline: origin/master@0265234d（0828 复核基线，含已合入的 #852；0827 复核基线 06db2b48；0820 复核基线 3d84aaad；0819 复核基线 47b2c11a；0813 复核基线 16fde8a27；原始基线 723c79ade）
 references:
   - feat/virtual_actor_stage2@b6a4982ea（不合入；仅作参考实现、竞态清单与写点地图）
   - docs/design/2026-08-08-virtual-actor-session-runtime.md（原始提案；本目录保留未跟踪副本）
   - PR #846（Step 1+2 产出）
-  - PR #852（Step 3 第一 PR：引擎替换 + 导入 + 混合窗口；JSON 净删除另立第二 PR）
+  - PR #852（Step 3 第一 PR：引擎替换 + 导入 + 混合窗口；**已合入 master**）
+  - Step 3 第二 PR：JSON 引擎净删除（db-only）+ Step 4(a) 事务化，兑现原则 1
 ---
 
 # Session 架构拆解回收与 store-first 重新分步
@@ -266,6 +267,71 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
   `readSessionRowCopiesAcrossStores`；#946 journal / #1008 schedule 仍是旁路
   文件，符合非目标。无 SessionRuntime 回流，Step 4(f) 占位租约仍未实施。
 
+**执行结果（2026-08-28，Step 3 第二 PR，基线 `origin/master@0265234d`）**：
+
+原则 1 在本步兑现。`session-store.ts` 从 2154 行降到约 1800 行，且删掉的全部是机器
+而不是注释：
+
+- **JSON 引擎净删除**：`save()` 整份序列化 + byte-identical 跳写、`load()` 的
+  JSON/legacy 迁移分支、`readExistingSessionsFromDisk` / `readSessionsProjectionStrict`、
+  Remote lineage CAS + readback 的 JSON 实现（约 80 行）、`mutateSessionRowOffline`
+  的 JSON 分支、以及 `StoreFileRef.kind` 撑起来的整套 db-else-json 分流。
+  `resolveStoreFile` / `listStoreRefs` / `readStoreEntries` / `readStoreRowByKey` /
+  `readStoreActiveRows` / `countActiveSessionsOnDisk` / `getSessionFresh` 一律 db-only。
+- **`withFileLockSync` 只剩导入一处**（编排全部消失）。**没有全删**：导入经固定的
+  `<db>.tmp` 暂存，同一 bot 的两个 owner 进程可能短暂并存（重启撞上尚未回收的前任），
+  两边都会通过 `existsSync(db)`、写同一个 tmp、发布出损坏库。改 per-process tmp 名会换来
+  没人清理的孤儿文件；直接建进最终 `.db` 则会打破本设计赖以成立的不变量——
+  「`.db` 存在」必须等价于「导入已完成」，否则半截导入会静默关掉导入门、丢光迁移前的行。
+- **脏数据修补收敛为导入期一次性**：`stripLegacyPendingCardFields` 与
+  `repairMissingChatScope` 不再挂在每次写、也不再挂在 `load()` 上（`Session` 类型已不含
+  那些字段，SQLite 写出的行天生干净），连带删掉 `repairMissingChatScopes()` 这个
+  map 级修补函数与它在每次 load 里那次「修完再写回」的额外事务。
+  唯一保留的读侧调用在 `loadAllSessionsSnapshot`：它读的是**别人的 store**，
+  这个进程既不拥有也修不了那些行，一次纯内存归一化是合理的，且不写盘。
+  原先只在「恰好对该 store 做过一次离线写」时才发生的 key-mismatch 收敛，
+  改成导入时按行自身的 `sessionId` 归位——修好而不是丢掉。
+- **未导入的 store 一律 fail-closed**，不再静默空投影。新增 `SessionStoreNotImportedError`：
+  「有 `sessions*.json` 但没有 `.db`」意味着拥有该 bot 的 daemon 还在跑迁移前的版本，
+  `loadAllSessionsSnapshot`（仅针对调用方自己的 store）、`mutateSessionRowOffline`、
+  以及 `owner: false` 的 `load()` 都报出可行动的错误。这是删掉 db-else-json 之后
+  「灰度窗口」的诚实形态：把静默降级换成一句「重启 daemon 完成一次性导入」。
+  peer bot 的未导入 store 保持不可见（本来就不是调用方的事）。
+- **两条建库地雷已封**（删 JSON 分支时才暴露出来，master 上靠 db-else-json 的
+  `existsSync` 前置侥幸不可达）：SQLite 的读写 open **会创建文件**，而一个空库会让
+  daemon 的 `existsSync(db)` 导入门判假、静默丢掉整份迁移前的行。现在
+  `openDbForRead` 对不存在的路径直接抛错，`mutateSessionRowOffline` 在 open 前先
+  `existsSync`，`withOwnStoreDb` 不再自开连接而是走 `loadForWrite()` 复用 load 附着的那个。
+- **死参数删除**：Remote 两个批量 API 的 `options.maxWaitMs` 自 #852 起在 SQLite 路径上
+  就已失效（它约束的是文件锁），现在连 JSON 路径也没有了，从签名删除；
+  fleet shutdown 的 deadline 预检（`remaining <= 0` 直接拒绝）保留，仍在干活。
+  等待上限统一由 `busy_timeout`（3s）决定。
+- **沙盒收面**：`fs-policy` 的两处 readOnly 授权不再包含冻结的
+  `sessions-<appId>.json`，只授权 `session-stores/<appId>` 目录；兄弟 bot 仍 deny-by-default。
+- **冻结 JSON 的处置（第二 PR 待决项 6）决定：原地保留，不删不改名。** 它已不被任何
+  运行时路径读取，代码成本为零；而它是回退到迁移前版本时唯一还能读的副本，改名反而会让
+  回退后的旧 daemon 从空库起步、再写出一份新的 JSON。几百 KB 换一条不可逆边界的兜底，
+  值得。
+
+**顺带的正向副作用（身份扫描）**：`readSessionRowCopiesAcrossStores` 的「恰好一次」判定
+在 db-only 下更准。legacy → per-bot 的迁移一直是**复制不删除**，所以
+`{sessions.json 含 X, session-stores/A/sessions.db 含 X}` 是常态，今天会被判成「重复 →
+拒绝推断当前调用者」。冻结 JSON 不再是 store 之后这类假歧义消失；同时也堵掉一个伪造面：
+今天任何能往 dataDir 写文件的进程放一个 `sessions-evil.json`，若目标 session 所在 store
+尚无 `.db`，它就是唯一命中并被当作身份来源。
+
+**已知边界（本步接受并明写）**：
+
+- 从**迁移前**版本直接升到 db-only 版本、且旧 daemon 仍在跑时，该 bot 的 store 没有
+  `.db`：worker（`owner: false`）与 CLI 离线写都会 fail-closed 报错，直到 daemon 重启完成
+  导入。自动更新默认关闭、`botmux upgrade` 也只提示用户自己 `botmux restart`，所以这个
+  窗口没有上界——**本步的前提就是灰度窗口已关闭**（fleet 里每个 bot 都至少在 #852 的
+  版本上重启过一次）。
+- 跨 bot 发现（`findActiveSessionsByRoot` / `findActiveChatScopeSessionsByChat` /
+  `countActiveSessionsOnDisk` / `collectBotmuxSessionIdentities`）只看 `.db`：未导入的
+  peer 不可见，不报错。
+- 离线写不再顺手收敛整个 store（行级写只碰一行）。收敛点上移到导入。
+
 ### Step 4 — 按痛点上事务（N 个独立小 PR，ROI gate）
 
 仅对**在 master 上有实测复现**的竞态，用 SQLite 事务原语逐个重做。
@@ -276,15 +342,26 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
 【master 复核 ✅ 事务形状的 ad-hoc 防御真实存在，候选素材如下（未验复现，
 仅为「去哪里看」清单）】
 
-- (a) `closeSession`/`reactivateClosedSession` 的手工回滚（session-store.ts
-  `closeSession` / `reactivateClosedSession` / `mutateMojoCloseJournal` 的
-  persistRow 失败还原）——save 抛错时逐字段还原。Step 3 落地后事务化即天然
-  替代，可能不需要独立 PR。行号随 master 漂移，以符号名为准。
+- (a) `closeSession`/`reactivateClosedSession` 的手工回滚 —— **已随 Step 3 第二 PR
+  落地，不再单独立项**（原判断「Step 3 落地后事务化即天然替代」成立）。原实现在活的
+  `Session` 对象上就地改，写失败再逐字段还原：`closeSession` 抄 14 个字段、
+  `reactivateClosedSession` 抄 20 个、`mutateMojoCloseJournal` 抄 2 个——一份靠人肉维护的
+  undo 日志，漏抄一个字段就是一次静默不一致。现在改成**先持久化副本、提交成功后再合并回
+  内存对象**（`persistRow(next)` → `Object.assign(session, next)`），失败路径变成「什么都
+  没发生」，没有可漏抄的东西。用 `Object.assign` 而不是替换 map 里的引用，是因为
+  `DaemonSession` 等模块持有同一个对象的别名——§3「不动内存共享可变语义」在此仍然成立。
+  既有的三条回滚回归用例（Riff lineage / previewTarget / mojo park 在写失败后保持原状）
+  一字未改地继续绿，就是等价性的证明。
 - (b) `reserveWorkerGeneration` 回滚重抛（0819：worker-pool.ts `reserveWorkerGeneration`）
   与 worker exit fence 的**无保护** `updateSession`——后者是 Step 1 分析中发现
   的疑似真实脆弱点。立项前必须在现行 master 重新定位行号并写出能红的测试。
-- (c) `admitQueuedActivationTail` 的 priorTail 回滚舞蹈（0819：worker-pool.ts
-  `admitQueuedActivationTail`）。
+- (c) `admitQueuedActivationTail` 的 priorTail 回滚舞蹈（worker-pool.ts
+  `admitQueuedActivationTail`）。**0828 复核：形状与 (a) 相同，但不能照搬 (a) 的消法。**
+  (a) 在 store 内部，可以「持久化副本 → `Object.assign` 回活对象」；(c) 在 store 外部，
+  只能调 `updateSession(session)`，而它会 `sessions.set(id, session)`——传副本进去会把
+  map 里的条目换成副本，切断 `ds.session` 的别名。要按 (a) 的方式做，得先给 store 加一个
+  「按 patch 更新、不重绑引用」的新 API；为省掉 4 行还原代码而新增一个公共写入口，不划算。
+  暂不立项，除非将来另有独立理由引入该 API。
 - (d) **async tail-admission 整套**（0819：daemon.ts
   `queuedActivationTailAdmissionsOutstanding` / ReleasePending / RetryTimer
   三件套 + DaemonSession 三字段 + gate 分支）——Step 1 候选 5 的降级素材归位处：

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -104,11 +104,11 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 
 #1051 已覆盖本 stage 中收益最大的部分（§4）。本 stage 只收尾，不要把 occupancy 放进同一 PR。
 
-建议在本 PR 内补上（范围小，且避免与终态相反的写入路径）：
+已纳入 #1051 的 Stage 0 缺口：
 
-- dashboard 删除白板：daemon 运行中通过 IPC 清除 `whiteboardId`（现有 `POST /api/sessions/:id/whiteboard` 只接受非空 id，不能解绑）。daemon 未运行时才走离线写，且必须传 `abortIf`。当前实现在 daemon 运行时直接 `UPDATE` SQLite，会造成磁盘行与 daemon 内存不一致；相对 #852 之后的 master，这是新增的第二写者。
-- `mutateSessionRowOffline` 在 sqlite 路径调用 `openDbForOwnStore` 之前，若文件不存在则失败。读写 open 会创建空库，导致 `existsSync(db)` 导入门误判为「已导入」。不要只依赖 `resolveStoreFile` 里的一次 `existsSync`。
-- PR 标题与最早一笔 commit 仍写「全仓 db-only」，与 HEAD 不符。以「daemon 不再写 JSON；跨进程在升级窗口内仍可读 JSON」为准。
+- dashboard 删除白板：daemon 运行中经 IPC 发送 `whiteboardId: null` 解绑（路由原先只接受非空 id）。daemon 未运行时才走 `mutateSessionRowOffline`，且传 `abortIf`（探测 `findOnlineDaemon`）。IPC 失败且 daemon 仍可见时不写盘，避免与内存缓存分叉。
+- `mutateSessionRowOffline` 的 sqlite 路径在 `openDbForOwnStore` 前再做一次 `existsSync`：读写 open 会创建空库，导致导入门把尚未导入的 store 当成已导入。
+- PR 标题与描述以「daemon 不再写 JSON；跨进程在升级窗口内仍可读 JSON」为准，不再写全仓 db-only。
 
 升级后自动重启 fleet 合入后，再开一个仍属 Stage 0 的 PR，从代码中删除 JSON 读路径（不必等 occupancy）：
 
@@ -180,19 +180,14 @@ daemon 进程内部可以先于 Stage 2 排队；**对外保证**要等所有外
 - 导入：暂存库使用 `journal_mode=DELETE`（避免 bun:sqlite 在 WAL 下 `rename` 出只有文件头的库）、按文件 key 插入而不按行内 `sessionId` 重键、`owner: false` 只读、不因探测路径创建空库而跳过导入。
 - close 路径先写 SQLite 再合并回内存对象，与单一 apply 方向一致，保留。
 - 测试夹具写入真实 SQLite，不再靠写 JSON 让「唯一写入入口」测试误绿。
+- 删除白板：daemon 运行中 IPC 解绑；未运行时带 `abortIf` 的离线写。sqlite 离线写打开前拒绝缺文件。
 
 本 PR 明确不做、也不应做：
 
 - occupancy（Stage 1）。与「删除 JSON 写路径」风险和范围都不同。
 - 跨进程改为只读 SQLite。在升级后自动重启 fleet 落地前删除 JSON 回落，会让升级窗口内的 `botmux send` 失败。删除条件是「不再存在仍在写 JSON 的 daemon」，放在 Stage 0 收尾，不是本 PR 的前置。
 
-建议合入前补上（仍属 Stage 0）：
-
-- 删除白板：IPC 解绑 + `abortIf`，见 §3 Stage 0。目的是避免本 PR 新增一条与终态相反的第二写路径，不是提前做 occupancy。
-- sqlite 离线写在打开连接前拒绝缺失文件。
-- 标题与 commit 与 HEAD 一致：daemon 不再写 JSON ≠ 所有进程只使用 SQLite。
-
-合入后的实际状态：daemon 只写 SQLite；其它进程在升级窗口内仍可能读 JSON；occupancy 仍在心跳文件；apply 仍有两套。之后按 Stage 1 → 2 → 3 推进，不再使用「按单个竞态加事务、不实现 per-session 串行」的旧 Step 4。
+合入后的实际状态：daemon 只写 SQLite；其它进程在升级窗口内仍可能读 JSON；occupancy 仍在心跳文件；apply 仍有两套（删白板在 daemon 运行时走 IPC，未运行时走带 `abortIf` 的离线写）。之后按 Stage 1 → 2 → 3 推进。
 
 ## 5. 建议顺序
 
@@ -201,11 +196,9 @@ daemon 进程内部可以先于 Stage 2 排队；**对外保证**要等所有外
  |               |                    |                    |              |              |
  |-- Stage 0 ----+-- Stage 0 收尾 -----|                    |              |              |
  |  (本 PR)      |  删除 JSON 读路径   |------ Stage 1 ------+-- Stage 2 ---+-- Stage 3 ---|
-                 |  白板 IPC 若未进入本 PR 则单独跟一个 PR
 ```
 
-- **#1051**：补上白板解绑与「打开前拒绝缺文件」后合入。这是删除 daemon JSON 写路径的主 PR。
-- **若未打进 #1051**：白板解绑 IPC 单独跟 PR，不等 Stage 1。
+- **#1051**：删除 daemon JSON 写路径；含白板 IPC 解绑与离线写打开前拒绝缺文件。
 - **与升级后自动重启 fleet 对齐**：从代码删除 JSON 读路径。fleet 实现不在本文范围，但它是删除 JSON 分支的前提。
 - **下一个架构主 PR**：Stage 1 occupancy。先写能失败的测试覆盖「读心跳文件与写会话行之间的窗口」，合入后 `findDaemon` 不再用于所有权判断。
 - **再下一个**：Stage 2，daemon 未运行时获取租约并执行同一 apply，删除第二套对外写协议。这一阶段减少的概念最多。

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -5,7 +5,7 @@ date: 2026-08-12
 updated: 2026-08-28（Step 3 第一 PR 已合入 master；第二 PR = JSON 净删除 + Step 4(a) 事务化，见「执行结果（2026-08-28）」）
 topic: session-restage-store-first
 status: proposed
-baseline: origin/master@0265234d（0828 复核基线，含已合入的 #852；0827 复核基线 06db2b48；0820 复核基线 3d84aaad；0819 复核基线 47b2c11a；0813 复核基线 16fde8a27；原始基线 723c79ade）
+baseline: origin/master@cc5085b6（0828 复核基线，含已合入的 #852；0828 早先基线 0265234d；0827 复核基线 06db2b48；0820 复核基线 3d84aaad；0819 复核基线 47b2c11a；0813 复核基线 16fde8a27；原始基线 723c79ade）
 references:
   - feat/virtual_actor_stage2@b6a4982ea（不合入；仅作参考实现、竞态清单与写点地图）
   - docs/design/2026-08-08-virtual-actor-session-runtime.md（原始提案；本目录保留未跟踪副本）

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -289,8 +289,12 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
   map 级修补函数与它在每次 load 里那次「修完再写回」的额外事务。
   唯一保留的读侧调用在 `loadAllSessionsSnapshot`：它读的是**别人的 store**，
   这个进程既不拥有也修不了那些行，一次纯内存归一化是合理的，且不写盘。
-  原先只在「恰好对该 store 做过一次离线写」时才发生的 key-mismatch 收敛，
-  改成导入时按行自身的 `sessionId` 归位——修好而不是丢掉。
+  原先只在「恰好对该 store 做过一次离线写」时才发生的 key-mismatch 收敛
+  （旧实现是 `delete data[key]`）**不再发生，也不改成导入期重键**：两条 JSON 记录
+  可能带同一个 `sessionId`，按 `sessionId` 重键会让后写的那条 `INSERT OR REPLACE`
+  掉前一条——陈旧的 closed 幽灵行覆盖活行，而且导入只跑一次、JSON 随后冻结，
+  不可逆。按文件原 key 导入，错键行保持惰性（身份扫描本来就跳过 key 与
+  `sessionId` 不符的行）。这一条是复核时用两个 checkout 跑同一份输入实测出来的。
 - **未导入的 store 一律 fail-closed**，不再静默空投影。新增 `SessionStoreNotImportedError`：
   「有 `sessions*.json` 但没有 `.db`」意味着拥有该 bot 的 daemon 还在跑迁移前的版本，
   `loadAllSessionsSnapshot`（仅针对调用方自己的 store）、`mutateSessionRowOffline`、
@@ -330,7 +334,14 @@ Node 免 flag 线仍是 v22.13.0 / v23.4.0，但仓库 `engines` 跟 master 的
 - 跨 bot 发现（`findActiveSessionsByRoot` / `findActiveChatScopeSessionsByChat` /
   `countActiveSessionsOnDisk` / `collectBotmuxSessionIdentities`）只看 `.db`：未导入的
   peer 不可见，不报错。
-- 离线写不再顺手收敛整个 store（行级写只碰一行）。收敛点上移到导入。
+- 离线写不再顺手收敛整个 store（行级写只碰一行）：错键的脏行不再被删除，
+  保持惰性存在。
+- **legacy `sessions.json` 里没有 `larkAppId` 的行（多 bot 拆分之前的遗留）不再可见。**
+  实测对照确认：master 上 `loadAllSessionsSnapshot` 经 db-else-json 还能读到它们，
+  db-only 下读不到。这类行本来就不归任何 per-bot store 所有——#852 的导入按
+  `larkAppId === currentAppId` 过滤，从来不收它们；生产 daemon 一律带 appId 启动，
+  扁平 legacy 库只在单 bot 开发/测试下才会建。所以它们此前也只是 CLI 还能列出、
+  还能离线关闭的惰性墓碑，没有 daemon 能恢复或投递。
 
 ### Step 4 — 按痛点上事务（N 个独立小 PR，ROI gate）
 

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -332,6 +332,16 @@ WAL，而 `renameSync` 只搬走一个文件。`bun:sqlite` 关连接时不把 `
 （`journal_mode = DELETE`）让文件自包含，真正的库仍跑 WAL。本 PR 把 JSON 引擎删掉
 之后导入是唯一迁移路径，所以必须在这里修。
 
+**唯一门的一处漏网（本步补上）**：Step 2 的验收写着「src 全仓不再有 session 文件路径
+拼装点（rg 验证为零）」，但 `services/whiteboard-store.ts` 的
+`clearSessionWhiteboardRefs` 是 `readdir` 数据目录 + `startsWith('sessions') &&
+endsWith('.json')` 动态筛名，整份读改写——按名字 grep 命不中，所以历次核查都漏了。
+它在 #852 之后已经静默失效（行搬进 SQLite 后一个文件都匹配不到，`deleteWhiteboard`
+返回 `clearedSessions: 0`，而每一行的 `whiteboardId` 还指着删掉的板）；测试一直绿是
+因为夹具写的正是 JSON。本步改为经 `loadAllSessionsSnapshot` + `mutateSessionRowOffline`。
+**方法论教训**：验证「唯一门」不能只 grep 字面文件名，还要查动态筛名
+（`startsWith`/`endsWith`/正则）与 `readdir` 数据目录的地方。
+
 **已知边界（本步接受并明写）**：
 
 - 从**迁移前**版本直接升到 db-only 版本、且旧 daemon 仍在跑时，该 bot 的 store 没有

--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -770,16 +770,14 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
   push(dropAuthority(ctx.extraWritePaths), 'readWrite', 'internal');
   push(dropAuthority(ctx.readonlyRoots), 'readOnly', 'internal');
   // Own routing metadata (`botmux send` reply routing) — read-only. The store
-  // is SQLite in its own per-bot DIRECTORY (db-else-json mixed window keeps
-  // the .json grant): the dir grant is deliberate — a single-file bwrap bind
-  // pins the inode, and SQLite deletes/recreates -wal/-shm across daemon
-  // restarts, so a persistent pane with file binds would keep reading the dead
-  // WAL forever. A directory bind resolves names live. Sibling bots' store
-  // dirs stay uncovered (deny-by-default).
-  push([
-    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`,
-    `${ctx.sessionDataDir}/session-stores/${ctx.currentAppId}`,
-  ], 'readOnly', 'internal');
+  // is SQLite in its own per-bot DIRECTORY: the dir grant is deliberate — a
+  // single-file bwrap bind pins the inode, and SQLite deletes/recreates
+  // -wal/-shm across daemon restarts, so a persistent pane with file binds
+  // would keep reading the dead WAL forever. A directory bind resolves names
+  // live. Sibling bots' store dirs stay uncovered (deny-by-default). The
+  // pre-SQLite `sessions-<appId>.json` is NOT granted: it is an import source
+  // the store never reads at runtime.
+  push([`${ctx.sessionDataDir}/session-stores/${ctx.currentAppId}`], 'readOnly', 'internal');
   // Own upload bucket — readWRITE: `botmux quoted` / downloadResources writes the
   // downloaded attachment under attachments/<self>/<messageId>/… (not just reads
   // pre-uploaded files). The worker mkdirs it pre-spawn so it survives the
@@ -917,9 +915,8 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
     //    own-app-scoped — NOT the shared secret/port table).
     push([
       `${ctx.sessionDataDir}/bots-info.json`,               // display names for <available_bots> (public-ish)
-      `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`,
       // Own SQLite store DIRECTORY (see the larkTransport grant above for why
-      // a dir, not the three files).
+      // a dir, not the three files). The pre-SQLite JSON is not granted.
       `${ctx.sessionDataDir}/session-stores/${ctx.currentAppId}`,
       `${ctx.sessionDataDir}/bot-openids-${ctx.currentAppId}.json`,
       // Core-only writes its `botmux` wrapper into <dataDir>/bin (dedicated, NOT

--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -774,10 +774,17 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
   // single-file bwrap bind pins the inode, and SQLite deletes/recreates
   // -wal/-shm across daemon restarts, so a persistent pane with file binds
   // would keep reading the dead WAL forever. A directory bind resolves names
-  // live. Sibling bots' store dirs stay uncovered (deny-by-default). The
-  // pre-SQLite `sessions-<appId>.json` is NOT granted: it is an import source
-  // the store never reads at runtime.
-  push([`${ctx.sessionDataDir}/session-stores/${ctx.currentAppId}`], 'readOnly', 'internal');
+  // live. Sibling bots' store dirs stay uncovered (deny-by-default).
+  //
+  // The pre-SQLite `sessions-<appId>.json` is granted too, and stays granted
+  // until the upgrade window is provably closed: while the owning daemon still
+  // runs a pre-SQLite build there is no `.db` at all, and a sandboxed
+  // `botmux send` that cannot even stat that file reports "session not found"
+  // — i.e. the agent silently loses the ability to reply.
+  push([
+    `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`,
+    `${ctx.sessionDataDir}/session-stores/${ctx.currentAppId}`,
+  ], 'readOnly', 'internal');
   // Own upload bucket — readWRITE: `botmux quoted` / downloadResources writes the
   // downloaded attachment under attachments/<self>/<messageId>/… (not just reads
   // pre-uploaded files). The worker mkdirs it pre-spawn so it survives the
@@ -915,8 +922,9 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
     //    own-app-scoped — NOT the shared secret/port table).
     push([
       `${ctx.sessionDataDir}/bots-info.json`,               // display names for <available_bots> (public-ish)
+      `${ctx.sessionDataDir}/sessions-${ctx.currentAppId}.json`,
       // Own SQLite store DIRECTORY (see the larkTransport grant above for why
-      // a dir, not the three files). The pre-SQLite JSON is not granted.
+      // a dir, not the three files, and why the JSON is still granted).
       `${ctx.sessionDataDir}/session-stores/${ctx.currentAppId}`,
       `${ctx.sessionDataDir}/bot-openids-${ctx.currentAppId}.json`,
       // Core-only writes its `botmux` wrapper into <dataDir>/bin (dedicated, NOT

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -249,7 +249,8 @@ import {
   writeManualIntentIfAbsentTo,
   writeRestartAttemptIntentTo,
 } from './services/restart-intent-store.js';
-import { loadAllSessionsSnapshot, mutateSessionRowOffline } from './services/session-store.js';
+import { loadAllSessionsSnapshot } from './services/session-store.js';
+import { mutateSessionRowWhenUnowned } from './services/session-offline-write.js';
 import {
   evaluateVcMeetingManagedSend,
   isTrustedVcMeetingHostRelayParent,
@@ -270,7 +271,12 @@ import {
   enabledPluginDependents,
 } from './core/plugins/dependencies.js';
 import { authorizeV3DaemonCommand } from './workflows/v3/cli-daemon-command-authority.js';
-import { resolveDaemonIpcPort } from './utils/daemon-discovery.js';
+import {
+  findOnlineDaemon,
+  listOnlineDaemons as listOnlineDaemonsIn,
+  resolveDaemonIpcPort,
+  type OnlineDaemonInfo,
+} from './utils/daemon-discovery.js';
 import {
   isSuspendableBackendType,
   killPersistentBackendTarget,
@@ -3574,29 +3580,19 @@ function loadSessions(): Map<string, SessionData> {
 }
 
 /** Offline-only narrow session mutation. Callers must prefer the owning daemon
- * while it is available; session-store rereads the exact row under the shared
- * session-file lock so stale CLI snapshots can never be written back. The
- * daemon-liveness probe runs under that same lock (entry + pre-publication) so
- * two CLIs cannot race each other and an already-published daemon cannot be
- * bypassed by the offline fallback. */
+ * while it is available; the shared helper rereads the exact row under the
+ * store's write exclusion (so a stale CLI snapshot can never be written back)
+ * and re-evaluates the daemon-liveness probe inside it, at entry and again
+ * before publication. */
 function mutateSessionOffline(
   session: SessionData,
   mutate: (current: SessionData) => boolean,
 ): SessionData | undefined {
   const larkAppId = session.larkAppId;
-  return mutateSessionRowOffline(
+  return mutateSessionRowWhenUnowned(
     { sessionId: session.sessionId, ...(larkAppId ? { larkAppId } : {}) },
     current => mutate(current as unknown as SessionData),
-    {
-      dataDir: resolveDataDir(),
-      ...(larkAppId
-        ? {
-            abortIf: () => {
-              try { return !!findDaemon(larkAppId); } catch { return false; /* offline */ }
-            },
-          }
-        : {}),
-    },
+    { dataDir: resolveDataDir() },
   ) as unknown as SessionData | undefined;
 }
 
@@ -5378,53 +5374,19 @@ async function cmdRoleSwitch(argv: string[]): Promise<void> {
  * so SESSION_DATA_DIR / breadcrumb-overridden deployments find the right
  * descriptor directory.
  */
-interface DaemonDescriptorLite {
-  ipcPort: number;
-  larkAppId: string;
-  pid?: number;
-  bootInstanceId?: string;
-  workflowIpcProtocol?: string;
-  lastHeartbeat?: number;
-}
+type DaemonDescriptorLite = OnlineDaemonInfo;
 
-function listDaemonDescriptors(): DaemonDescriptorLite[] {
-  const regDir = join(resolveDataDir(), 'dashboard-daemons');
-  if (!existsSync(regDir)) return [];
-  const all: DaemonDescriptorLite[] = [];
-  let names: string[] = [];
-  try { names = readdirSync(regDir); } catch { return []; }
-  for (const f of names) {
-    if (!f.endsWith('.json')) continue;
-    try {
-      const d = JSON.parse(readFileSync(join(regDir, f), 'utf-8'));
-      if (typeof d?.ipcPort !== 'number' || typeof d?.larkAppId !== 'string') continue;
-      all.push({
-        ipcPort: d.ipcPort,
-        larkAppId: d.larkAppId,
-        ...(typeof d.pid === 'number' ? { pid: d.pid } : {}),
-        ...(typeof d.bootInstanceId === 'string' && d.bootInstanceId
-          ? { bootInstanceId: d.bootInstanceId }
-          : {}),
-        ...(typeof d.workflowIpcProtocol === 'string' && d.workflowIpcProtocol
-          ? { workflowIpcProtocol: d.workflowIpcProtocol }
-          : {}),
-        ...(typeof d.lastHeartbeat === 'number' ? { lastHeartbeat: d.lastHeartbeat } : {}),
-      });
-    } catch { /* skip malformed */ }
-  }
-  return all;
-}
-
+/** Daemon discovery is `utils/daemon-discovery`; the CLI used to carry its own
+ *  copy of the descriptor parse and the 90s staleness cutoff. These two
+ *  wrappers only pin it to THIS process's resolved data dir, so the liveness
+ *  probe and the session store always read the same directory. */
 function listOnlineDaemons(): DaemonDescriptorLite[] {
-  const STALE_MS = 90_000;
-  const now = Date.now();
-  return listDaemonDescriptors().filter(d => now - (d.lastHeartbeat ?? 0) <= STALE_MS);
+  return listOnlineDaemonsIn(resolveDataDir());
 }
 
 function findDaemon(larkAppId?: string): DaemonDescriptorLite | null {
-  const all = listOnlineDaemons();
-  if (larkAppId) return all.find(d => d.larkAppId === larkAppId) ?? null;
-  return all[0] ?? null;
+  if (larkAppId) return findOnlineDaemon(larkAppId, resolveDataDir());
+  return listOnlineDaemons()[0] ?? null;
 }
 
 function normalizeCardUsageSnapshot(value: unknown): CardUsageSnapshot | null {

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -2136,9 +2136,12 @@ ipcRoute('POST', '/api/sessions/:sessionId/whiteboard', async (req, res, params)
   let body: { whiteboardId?: unknown };
   try { body = await readJsonBody(req); }
   catch { return jsonRes(res, 400, { ok: false, error: 'bad_json' }); }
-  if (typeof body.whiteboardId !== 'string'
-    || body.whiteboardId.length === 0
-    || body.whiteboardId.length > 256) {
+  const unbind = body.whiteboardId === null;
+  const bindId = typeof body.whiteboardId === 'string' ? body.whiteboardId : '';
+  const bind = !unbind
+    && bindId.length > 0
+    && bindId.length <= 256;
+  if (!unbind && !bind) {
     return jsonRes(res, 400, { ok: false, error: 'bad_whiteboard_id' });
   }
   const session = findSessionRecord(params.sessionId);
@@ -2148,9 +2151,10 @@ ipcRoute('POST', '/api/sessions/:sessionId/whiteboard', async (req, res, params)
   return withBotTurnAdmission(larkAppId, async () => {
     const current = findSessionRecord(params.sessionId);
     if (!current) return jsonRes(res, 404, { ok: false, error: 'session_not_found' });
-    current.whiteboardId = body.whiteboardId as string;
+    if (unbind) current.whiteboardId = undefined;
+    else current.whiteboardId = bindId;
     sessionStore.updateSession(current);
-    jsonRes(res, 200, { ok: true, whiteboardId: current.whiteboardId });
+    jsonRes(res, 200, { ok: true, whiteboardId: current.whiteboardId ?? null });
   });
 });
 

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -2133,7 +2133,7 @@ ipcRoute('POST', '/api/sessions/:sessionId/board', async (req, res, params) => {
 // short-lived `botmux whiteboard` process rewriting a stale whole Session row
 // over a concurrent Codex App FIFO transition.
 ipcRoute('POST', '/api/sessions/:sessionId/whiteboard', async (req, res, params) => {
-  let body: { whiteboardId?: unknown };
+  let body: { whiteboardId?: unknown; expectWhiteboardId?: unknown };
   try { body = await readJsonBody(req); }
   catch { return jsonRes(res, 400, { ok: false, error: 'bad_json' }); }
   const unbind = body.whiteboardId === null;
@@ -2144,6 +2144,16 @@ ipcRoute('POST', '/api/sessions/:sessionId/whiteboard', async (req, res, params)
   if (!unbind && !bind) {
     return jsonRes(res, 400, { ok: false, error: 'bad_whiteboard_id' });
   }
+  // Optional compare-and-set. Board deletion needs it: between the deleter's
+  // snapshot and this request the daemon may have rebound the session
+  // (`ensureSessionWhiteboard` mints a replacement as soon as the old board
+  // leaves the index), and an unconditional clear would drop that new binding
+  // and orphan the board the daemon just created.
+  const hasExpect = body.expectWhiteboardId !== undefined;
+  const expect = typeof body.expectWhiteboardId === 'string' ? body.expectWhiteboardId : undefined;
+  if (hasExpect && expect === undefined) {
+    return jsonRes(res, 400, { ok: false, error: 'bad_expect_whiteboard_id' });
+  }
   const session = findSessionRecord(params.sessionId);
   if (!session) return jsonRes(res, 404, { ok: false, error: 'session_not_found' });
   const larkAppId = session.larkAppId || cachedLarkAppId;
@@ -2151,6 +2161,13 @@ ipcRoute('POST', '/api/sessions/:sessionId/whiteboard', async (req, res, params)
   return withBotTurnAdmission(larkAppId, async () => {
     const current = findSessionRecord(params.sessionId);
     if (!current) return jsonRes(res, 404, { ok: false, error: 'session_not_found' });
+    if (expect !== undefined && current.whiteboardId !== expect) {
+      return jsonRes(res, 409, {
+        ok: false,
+        error: 'whiteboard_changed',
+        whiteboardId: current.whiteboardId ?? null,
+      });
+    }
     if (unbind) current.whiteboardId = undefined;
     else current.whiteboardId = bindId;
     sessionStore.updateSession(current);

--- a/src/core/remote-shutdown-detach.ts
+++ b/src/core/remote-shutdown-detach.ts
@@ -526,7 +526,6 @@ export async function prepareRemoteFleetForShutdown(
   try {
     snapshots = sessionStore.getActiveRemoteShutdownSnapshotsBatch(
       candidates.map(ds => ds.session.sessionId),
-      { maxWaitMs: Math.min(configuredSnapshotTimeout, remaining) },
     );
   } catch (error) {
     const message = `initial_riff_snapshot_failed:${error instanceof Error
@@ -693,9 +692,7 @@ export function persistPreparedRemoteShutdownFleet(
       owner: result.durableOwnerAtPrepare,
       targetTaskId: result.taskId,
       expectedCurrentTaskIds: [result.durableTaskIdAtPrepare, result.taskId],
-    })), {
-      maxWaitMs: Math.min(configuredPersistTimeout, remaining),
-    });
+    })));
   } catch (error) {
     const batchError = error instanceof sessionStore.RemoteLineageBatchError ? error : undefined;
     const stage = batchError?.stage ?? 'prewrite_io';

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -4907,7 +4907,7 @@ const server = createServer(async (req, res) => {
     if (req.method === 'DELETE' && mWhiteboard) {
       try {
         const id = decodeURIComponent(mWhiteboard[1]);
-        return jsonRes(res, 200, deleteWhiteboard(id));
+        return jsonRes(res, 200, await deleteWhiteboard(id));
       } catch (err: any) {
         return jsonRes(res, 400, { ok: false, error: err?.message ?? 'whiteboard_delete_failed' });
       }

--- a/src/services/session-offline-write.ts
+++ b/src/services/session-offline-write.ts
@@ -1,0 +1,53 @@
+/**
+ * The single offline session-row write for processes that own no store.
+ *
+ * A session row has one authority at a time: while the owning bot's daemon is
+ * up it holds the row in memory and will `persistRow` over anything written
+ * behind its back, so every other process must send it a command instead.
+ * Only when no daemon answers for that bot may another process publish the row
+ * itself — and the liveness probe still has to be re-evaluated inside the
+ * store's write exclusion, so a daemon that comes up between the caller's
+ * check and the commit wins.
+ *
+ * `sessionStore.mutateSessionRowOffline` implements the exclusion and the
+ * re-probe; this wrapper supplies the probe, so no caller has to remember to
+ * pass one (and so the probe and the store read resolve the SAME data dir).
+ * Stage 2 of `docs/design/2026-08-12-session-restage-store-first.md` deletes
+ * both: the offline write becomes a lease plus the daemon's own apply.
+ */
+import { config } from '../config.js';
+import { findOnlineDaemon } from '../utils/daemon-discovery.js';
+import { mutateSessionRowOffline } from './session-store.js';
+import type { Session } from '../types.js';
+
+/**
+ * Mutate one exact row only while its owning daemon is absent.
+ *
+ * Returns the fresh row (mutated when `mutate` returned true), or undefined
+ * when the row is missing or a daemon holds it. A row with no `larkAppId` is a
+ * pre-per-bot legacy row in the flat store: no daemon owns one — daemons all
+ * run per-bot stores — so there is nothing to probe and the write proceeds.
+ */
+export function mutateSessionRowWhenUnowned(
+  target: { sessionId: string; larkAppId?: string },
+  mutate: (current: Session) => boolean,
+  options: { dataDir?: string } = {},
+): Session | undefined {
+  const dataDir = options.dataDir ?? config.session.dataDir;
+  const larkAppId = target.larkAppId;
+  return mutateSessionRowOffline(
+    { sessionId: target.sessionId, ...(larkAppId ? { larkAppId } : {}) },
+    mutate,
+    {
+      dataDir,
+      ...(larkAppId
+        ? {
+            abortIf: () => {
+              try { return !!findOnlineDaemon(larkAppId, dataDir); }
+              catch { return false; /* unreadable registry → treat as offline */ }
+            },
+          }
+        : {}),
+    },
+  );
+}

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -1,4 +1,4 @@
-import { readFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync, copyFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync, copyFileSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { config } from '../config.js';
@@ -55,11 +55,20 @@ function stripLegacyPendingCardFields(session: Record<string, unknown>): void {
 // `Session` type stays the schema authority; the generated columns below only
 // serve hot lookups.
 //
-// SQLite is the ONLY engine. The pre-SQLite `sessions*.json` files are a
-// one-shot IMPORT SOURCE (below) and nothing else: after the import they are
-// frozen in place, never read on any live path and never written again. They
-// are deliberately not deleted — they are the only artifact a downgrade to a
-// pre-SQLite botmux can still read, and they cost a few hundred KB.
+// SQLite is the only engine the OWNING DAEMON ever writes. It imports its
+// pre-SQLite `sessions*.json` once at first load and never writes JSON again.
+//
+// The cross-process surface (worker reads, CLI reads, CLI offline writes) still
+// resolves each store as "use the .db when it exists, else the .json". That is
+// not leftover indecision — it is the upgrade window. `npm i -g` replaces dist
+// and repoints ~/.botmux/bin/botmux immediately, while the daemon that owns the
+// rows keeps running the OLD code (auto-update is off by default and `botmux
+// upgrade` tells the operator to restart by hand), so a store can legitimately
+// have no `.db` for hours or weeks. Dropping the JSON read seam would leave
+// every live session's `botmux send` unable to find itself until that restart.
+//
+// The frozen JSON is deliberately never deleted: it is also the only artifact a
+// downgrade to a pre-SQLite botmux can read, and it costs a few hundred KB.
 
 type SqliteStatementLike = StatementLike;
 type SqliteDatabaseLike = DatabaseSyncLike;
@@ -109,55 +118,6 @@ export class SessionStoreSqliteUnavailableError extends Error {
   override readonly name = 'SessionStoreSqliteUnavailableError';
 }
 
-/** A store whose pre-SQLite `sessions*.json` still exists while its `.db` does
- *  not: the daemon that owns it has not restarted on a SQLite build yet, so
- *  the one-shot import has not run. Only that daemon may import (the
- *  `owner: false` contract), so cross-process callers refuse loudly instead of
- *  reporting an empty store — an offline close that silently no-ops, or a
- *  `botmux send` that cannot find its own session, is the worse outcome. */
-export class SessionStoreNotImportedError extends Error {
-  override readonly name = 'SessionStoreNotImportedError';
-}
-
-/** A per-bot store that still has its own un-imported `sessions-<appId>.json`.
- *
- *  Deliberately narrow. It does NOT consult the legacy `sessions.json`, for two
- *  reasons: that file is never deleted by the legacy→per-bot migration, so it
- *  survives on every upgraded install forever; and no daemon will ever import
- *  it (production daemons always start with an appId, so nothing owns the flat
- *  store). Treating it as "pending" would fire on every freshly added bot —
- *  which has nothing to import at all — and tell its operator to restart a
- *  daemon that is already current. A store with no own JSON is simply new. */
-function unimportedStoreJsonPath(appId: string, dataDir: string): string | undefined {
-  if (existsSync(storeDbPath(appId, dataDir))) return undefined;
-  const ownJsonFp = join(dataDir, storeJsonFileName(appId));
-  return existsSync(ownJsonFp) ? ownJsonFp : undefined;
-}
-
-function assertStoreImported(appId: string | undefined, dataDir: string): void {
-  if (!appId) return;
-  const pendingJsonFp = unimportedStoreJsonPath(appId, dataDir);
-  if (!pendingJsonFp) return;
-  throw new SessionStoreNotImportedError(
-    `会话库尚未迁移到 SQLite：${pendingJsonFp} 存在但 ${storeDbPath(appId, dataDir)} 不存在。`
-    + `拥有该 bot 的 daemon 仍在跑迁移前的版本——请重启 daemon（botmux restart）让它完成一次性导入。`,
-  );
-}
-
-/** Every per-bot store whose own JSON is still waiting to be imported. Used to
- *  explain an empty cross-store scan instead of reporting "row not found". */
-function listUnimportedStoreJsonPaths(dataDir: string): string[] {
-  let names: string[];
-  try { names = readdirSync(dataDir); } catch { return []; }
-  const pending: string[] = [];
-  for (const name of names) {
-    if (!name.startsWith('sessions-') || !name.endsWith('.json')) continue;
-    const appId = name.slice('sessions-'.length, -'.json'.length);
-    const jsonFp = unimportedStoreJsonPath(appId, dataDir);
-    if (jsonFp) pending.push(jsonFp);
-  }
-  return pending;
-}
 
 function sqliteUnavailableMessage(context: string): string {
   return `${context}需要 SQLite 引擎（Node 的 node:sqlite 或 Bun 的 bun:sqlite），但当前运行时不可用。Node 请升级到 ${SQLITE_NODE_VERSION_HINT}；编译版请使用支持 bun:sqlite 的 Bun。当前 runtime: ${process.version}。`;
@@ -259,12 +219,12 @@ export function __testOnly_setBeforeRowPersist(hook: ((sessionId: string) => voi
   testOnlyBeforeRowPersist = hook;
 }
 
-// ─── Store resolution ────────────────────────────────────────────────────────
+// ─── Store resolution (db-else-json, cross-process only) ─────────────────────
 
 type StoreFileRef = {
   /** undefined = the legacy no-appId store. */
   appId?: string;
-  /** Absolute path of that store's `sessions.db`. */
+  kind: 'sqlite' | 'json';
   path: string;
 };
 
@@ -287,24 +247,37 @@ function storeDbPath(appId: string | undefined, dataDir: string): string {
   return appId ? join(sessionStoreSqliteDir(appId, dataDir), 'sessions.db') : join(dataDir, 'sessions.db');
 }
 
-/** Import source only — never read on a live path (see `importJsonStoreToSqlite`). */
+/** The pre-SQLite file for a store: the daemon's one-shot import source, and
+ *  the cross-process read seam until that daemon restarts. */
 function storeJsonFileName(appId: string | undefined): string {
   return appId ? `sessions-${appId}.json` : 'sessions.json';
 }
 
+/** Per-store rule for every cross-process reader and CLI offline writer:
+ *  use the .db when it exists, else the .json (see the upgrade-window note at
+ *  the top of the engine section). */
 function resolveStoreFile(appId: string | undefined, dataDir: string): StoreFileRef {
-  return { appId, path: storeDbPath(appId, dataDir) };
+  const dbPath = storeDbPath(appId, dataDir);
+  if (existsSync(dbPath)) return { appId, kind: 'sqlite', path: dbPath };
+  return { appId, kind: 'json', path: join(dataDir, storeJsonFileName(appId)) };
 }
 
-/** One ref per store that exists on disk: the flat legacy `sessions.db` plus
- *  every `session-stores/<appId>/sessions.db`. `strict` propagates an
- *  unlistable `session-stores/` dir (fail-closed callers must not mistake an
- *  unreadable store set for an empty one); otherwise it degrades to whatever
- *  could be enumerated. */
+/** One ref per store identity across the whole data dir, .db winning: flat
+ *  legacy files + per-bot JSON files + per-bot SQLite store directories.
+ *  `strict` propagates an unlistable `session-stores/` dir (fail-closed
+ *  callers must not mistake an unreadable store set for an empty one);
+ *  otherwise it degrades to the JSON view. */
 function listStoreRefs(dataDir: string, opts: { strict?: boolean } = {}): StoreFileRef[] {
   const names = readdirSync(dataDir);
-  const refs: StoreFileRef[] = [];
-  if (names.includes('sessions.db')) refs.push({ path: join(dataDir, 'sessions.db') });
+  const dbPaths = new Map<string, string>();
+  const jsonPaths = new Map<string, string>();
+  for (const name of names) {
+    if (name === 'sessions.db') dbPaths.set('', join(dataDir, name));
+    else if (name === 'sessions.json') jsonPaths.set('', join(dataDir, name));
+    else if (name.startsWith('sessions-') && name.endsWith('.json')) {
+      jsonPaths.set(name.slice('sessions-'.length, -'.json'.length), join(dataDir, name));
+    }
+  }
   if (names.includes(PER_BOT_STORE_DIRNAME)) {
     let appIds: string[] = [];
     try {
@@ -314,8 +287,17 @@ function listStoreRefs(dataDir: string, opts: { strict?: boolean } = {}): StoreF
     }
     for (const appId of appIds) {
       const dbPath = storeDbPath(appId, dataDir);
-      if (existsSync(dbPath)) refs.push({ appId, path: dbPath });
+      if (existsSync(dbPath)) dbPaths.set(appId, dbPath);
     }
+  }
+  const refs: StoreFileRef[] = [];
+  for (const key of new Set([...dbPaths.keys(), ...jsonPaths.keys()])) {
+    const dbPath = dbPaths.get(key);
+    refs.push({
+      appId: key === '' ? undefined : key,
+      kind: dbPath ? 'sqlite' : 'json',
+      path: dbPath ?? jsonPaths.get(key)!,
+    });
   }
   return refs;
 }
@@ -323,6 +305,11 @@ function listStoreRefs(dataDir: string, opts: { strict?: boolean } = {}): StoreF
 /** All [key, value] entries of one store. Throws on an unreadable store;
  *  callers decide skip-vs-propagate (capability errors always propagate). */
 function readStoreEntries(ref: StoreFileRef): [string, Session][] {
+  if (ref.kind === 'json') {
+    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') return [];
+    return Object.entries(parsed as Record<string, Session>);
+  }
   const db = openDbForRead(ref.path);
   try {
     const rows = db.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
@@ -338,6 +325,11 @@ function readStoreEntries(ref: StoreFileRef): [string, Session][] {
 
 /** Point-read one key from one store. Throws on an unreadable store. */
 function readStoreRowByKey(ref: StoreFileRef, sessionId: string): Session | undefined {
+  if (ref.kind === 'json') {
+    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    return (parsed as Record<string, Session>)[sessionId];
+  }
   // The daemon's hot freshness reads hit its own store — reuse the attached
   // connection instead of opening one per call.
   if (ownStore && loaded && ref.appId === currentAppId && ref.path === getDbPath()) {
@@ -358,6 +350,11 @@ function readStoreActiveRows(
   ref: StoreFileRef,
   hint?: { rootMessageId?: string; chatScopeChatId?: string },
 ): Session[] {
+  if (ref.kind === 'json') {
+    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') return [];
+    return Object.values(parsed as Record<string, Session>).filter(s => s?.status === 'active');
+  }
   const db = openDbForRead(ref.path);
   try {
     let sql = "SELECT row FROM sessions WHERE status = 'active'";
@@ -452,7 +449,6 @@ export function __testOnly_setAfterRemoteBatchRename(hook: (() => void) | undefi
 export function init(appId?: string, opts: { owner?: boolean } = {}): void {
   currentAppId = appId;
   sqliteBootstrapAllowed = opts.owner !== false;
-  warnedUnimportedOwnStore = false;
   loaded = false;
   sessions = new Map();
   loadFailure = undefined;
@@ -1016,6 +1012,32 @@ function recoverPoisonedSqliteStore(dbFp: string, jsonFp: string): {
   return { merged, archivedEvidence };
 }
 
+/** Read this store's pre-SQLite JSON into the in-memory projection WITHOUT
+ *  writing anything back. Only for a non-owning process during the upgrade
+ *  window (see `load()`); the owning daemon imports instead. */
+function loadFromFrozenJson(): void {
+  const jsonFp = getImportJsonPath();
+  const legacyFp = join(config.session.dataDir, 'sessions.json');
+  const sourceFp = existsSync(jsonFp) ? jsonFp
+    : currentAppId && existsSync(legacyFp) ? legacyFp
+      : undefined;
+  sessions = new Map();
+  if (!sourceFp) return;
+  try {
+    const data = parseSessionsProjectionStrict(readFileSync(sourceFp, 'utf-8'), sourceFp);
+    for (const [key, value] of Object.entries(data)) {
+      if (sourceFp === legacyFp && value?.larkAppId !== currentAppId) continue;
+      repairMissingChatScope(value);
+      sessions.set(key, value);
+    }
+    logger.info(`Loaded ${sessions.size} sessions from ${sourceFp} (store not imported yet)`);
+  } catch (err) {
+    logger.error(`Failed to load sessions: ${err}`);
+    loadFailure = err instanceof Error ? err : new Error(String(err));
+    sessions = new Map();
+  }
+}
+
 // Sessions persisted before 2026-04-29 lack `cliId`; consumers must fall back to 'unknown' at the render boundary.
 function load(): void {
   if (loaded) return;
@@ -1075,20 +1097,13 @@ function load(): void {
 
   if (!existsSync(dbFp)) {
     if (!sqliteBootstrapAllowed) {
-      // `owner: false` (a worker) and no store yet. Only reachable when the
-      // daemon that spawned this process still runs a pre-SQLite build: it
-      // keeps writing its JSON file, and creating the .db behind its back
-      // would fork the two representations. Record the failure instead of
-      // starting from an empty projection, so every write gate
-      // (loadForWrite / listSessionsStrict) fails closed until the daemon
-      // restarts on this build and imports.
-      const err = new SessionStoreNotImportedError(
-        `会话库尚未迁移到 SQLite：${dbFp} 不存在，而本进程（owner: false）不得建库。`
-        + `请重启拥有该 bot 的 daemon 完成一次性导入。`,
-      );
-      logger.error(`Failed to load sessions: ${err.message}`);
-      loadFailure = err;
-      sessions = new Map();
+      // `owner: false` (a worker) and no store yet: the daemon that spawned it
+      // still runs the pre-SQLite build and keeps writing its JSON, so this
+      // process reads THAT — creating a .db behind that daemon's back would
+      // fork the two representations. Read-only: the repairs and the
+      // legacy→per-bot migration are the owning daemon's job, and it does them
+      // once, as the import.
+      loadFromFrozenJson();
       loaded = true;
       return;
     }
@@ -1463,34 +1478,31 @@ export function getOwnedSession(sessionId: string): Session | undefined {
   return sessions.get(sessionId);
 }
 
-let warnedUnimportedOwnStore = false;
-
-/** Cross-process fresh read: a point SELECT observes the last committed write
- *  (WAL orders the daemon against offline CLI writers). */
+/** Cross-process fresh read. SQLite: a point SELECT observes the last committed
+ *  write (WAL orders the daemon against offline CLI writers). JSON (a store the
+ *  owning daemon has not imported yet): ordered after writers by the shared file
+ *  lock, as before. */
 export function getSessionFresh(sessionId: string): Session | undefined {
+  ensureDir();
   const dbFp = getDbPath();
-  if (!existsSync(dbFp)) {
-    // Callers here (worker `authorizeManagedSend`) treat undefined as "no such
-    // row" and degrade quietly — a codex-app turn ends up refused as
-    // `origin_mismatch` with nothing in the log pointing at the real cause.
-    // Throwing is not an option (the worker's IPC handler has no catch), so at
-    // least say it once.
-    if (currentAppId && !warnedUnimportedOwnStore
-        && unimportedStoreJsonPath(currentAppId, config.session.dataDir)) {
-      warnedUnimportedOwnStore = true;
-      logger.warn(
-        `会话库尚未迁移到 SQLite：${dbFp} 不存在，本进程的所有会话读取都会落空。`
-        + `请重启拥有该 bot 的 daemon 完成一次性导入。`,
-      );
+  if (existsSync(dbFp)) {
+    try {
+      return readStoreRowByKey({ appId: currentAppId, kind: 'sqlite', path: dbFp }, sessionId);
+    } catch (err) {
+      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+      return undefined;
     }
-    return undefined;
   }
-  try {
-    return readStoreRowByKey({ appId: currentAppId, path: dbFp }, sessionId);
-  } catch (err) {
-    if (err instanceof SessionStoreSqliteUnavailableError) throw err;
-    return undefined;
-  }
+  const fp = getImportJsonPath();
+  return withFileLockSync(fp, () => {
+    if (!existsSync(fp)) return undefined;
+    try {
+      const data = JSON.parse(readFileSync(fp, 'utf-8')) as Record<string, Session>;
+      return data[sessionId];
+    } catch {
+      return undefined;
+    }
+  });
 }
 
 /**
@@ -2108,12 +2120,17 @@ export function countActiveSessionsOnDisk(dataDir: string = config.session.dataD
   let n = 0;
   for (const ref of refs) {
     try {
-      const db = openDbForRead(ref.path);
-      try {
-        const hit = db.prepare("SELECT COUNT(*) AS n FROM sessions WHERE status = 'active'").get() as { n: number };
-        n += hit.n;
-      } finally {
-        db.close();
+      if (ref.kind === 'sqlite') {
+        const db = openDbForRead(ref.path);
+        try {
+          const hit = db.prepare("SELECT COUNT(*) AS n FROM sessions WHERE status = 'active'").get() as { n: number };
+          n += hit.n;
+        } finally {
+          db.close();
+        }
+      } else {
+        const data: Record<string, Session> = JSON.parse(readFileSync(ref.path, 'utf-8'));
+        for (const s of Object.values(data)) if (s?.status === 'active') n++;
       }
     } catch (err) {
       if (err instanceof SessionStoreSqliteUnavailableError) throw err;
@@ -2188,10 +2205,6 @@ export function loadAllSessionsSnapshot(options: {
   fallbackAppId?: string;
 } = {}): Map<string, Session> {
   const dataDir = options.dataDir ?? config.session.dataDir;
-  // Only the caller's own store is asserted: a peer bot that has not migrated
-  // yet is invisible (it was never this caller's business), but the store the
-  // caller belongs to reading as empty would look like "your session is gone".
-  if (options.fallbackAppId) assertStoreImported(options.fallbackAppId, dataDir);
   const out = new Map<string, Session>();
   const readInto = (ref: StoreFileRef): void => {
     let entries: [string, Session][];
@@ -2284,19 +2297,6 @@ export function readSessionRowCopiesAcrossStores(
     if (session.sessionId !== sessionId) continue;
     matches.push(session);
   }
-  if (matches.length === 0) {
-    // "Row not found" and "that bot's store was never imported" are the same
-    // empty scan but completely different actions. Callers turn a zero match
-    // into 「未找到当前进程所属 session」, which sends the operator hunting for a
-    // lost process marker instead of restarting one daemon.
-    const pending = listUnimportedStoreJsonPaths(dataDir);
-    if (pending.length > 0) {
-      throw new SessionStoreNotImportedError(
-        `会话库尚未迁移到 SQLite：${pending.join('、')} 仍未导入，扫描结果不可信。`
-        + `请重启对应 bot 的 daemon（botmux restart）完成一次性导入。`,
-      );
-    }
-  }
   return matches;
 }
 
@@ -2325,34 +2325,59 @@ export function mutateSessionRowOffline(
   options: { dataDir?: string; abortIf?: () => boolean } = {},
 ): Session | undefined {
   const dataDir = options.dataDir ?? config.session.dataDir;
-  assertStoreImported(target.larkAppId, dataDir);
   const ref = resolveStoreFile(target.larkAppId, dataDir);
-  // `openDbForOwnStore` is a read-write open: it would CREATE the store and
-  // poison the owning daemon's import gate. A store that does not exist simply
-  // holds no row.
-  if (!existsSync(ref.path)) return undefined;
 
-  const db = openDbForOwnStore(ref.path);
-  let inTxn = false;
-  try {
-    db.exec('BEGIN IMMEDIATE');
-    inTxn = true;
-    if (options.abortIf?.()) return undefined;
-    const hit = db.prepare('SELECT row FROM sessions WHERE session_id = ?')
-      .get(target.sessionId) as { row: string } | undefined;
-    if (!hit) return undefined;
-    const current = JSON.parse(hit.row) as Session;
-    if (!mutate(current)) return current;
-    if (options.abortIf?.()) return undefined;
-    db.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
-      .run(sessionStatusText(current), JSON.stringify(current), target.sessionId);
-    db.exec('COMMIT');
-    inTxn = false;
-    return current;
-  } finally {
-    if (inTxn) { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
-    db.close();
+  if (ref.kind === 'sqlite') {
+    const db = openDbForOwnStore(ref.path);
+    let inTxn = false;
+    try {
+      db.exec('BEGIN IMMEDIATE');
+      inTxn = true;
+      if (options.abortIf?.()) return undefined;
+      const hit = db.prepare('SELECT row FROM sessions WHERE session_id = ?')
+        .get(target.sessionId) as { row: string } | undefined;
+      if (!hit) return undefined;
+      const current = JSON.parse(hit.row) as Session;
+      if (!mutate(current)) return current;
+      if (options.abortIf?.()) return undefined;
+      db.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
+        .run(sessionStatusText(current), JSON.stringify(current), target.sessionId);
+      db.exec('COMMIT');
+      inTxn = false;
+      return current;
+    } finally {
+      if (inTxn) { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
+      db.close();
+    }
   }
+
+  // Upgrade window: this store's owning daemon still runs the pre-SQLite build
+  // and keeps writing the JSON, so an offline mutation has to land there too —
+  // creating a .db here would fork the two representations behind that daemon's
+  // back. Same file lock the old build takes.
+  const fp = ref.path;
+  return withFileLockSync(fp, () => {
+    if (options.abortIf?.()) return undefined;
+    let data: Record<string, Session> = {};
+    if (existsSync(fp)) {
+      try { data = JSON.parse(readFileSync(fp, 'utf-8')); } catch { /* start fresh */ }
+    }
+    const current = data[target.sessionId];
+    if (!current || !mutate(current)) return current;
+    data[target.sessionId] = current;
+    for (const [key, val] of Object.entries(data)) {
+      if (val && typeof val === 'object' && 'sessionId' in val && (val as Session).sessionId !== key) {
+        delete data[key];
+        continue;
+      }
+      if (val && typeof val === 'object') stripLegacyPendingCardFields(val as unknown as Record<string, unknown>);
+    }
+    if (options.abortIf?.()) return undefined;
+    const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
+    writeFileSync(tmpFp, JSON.stringify(data, null, 2), 'utf-8');
+    renameSync(tmpFp, fp);
+    return current;
+  });
 }
 
 function findActiveSessionsMatching(

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -2328,6 +2328,11 @@ export function mutateSessionRowOffline(
   const ref = resolveStoreFile(target.larkAppId, dataDir);
 
   if (ref.kind === 'sqlite') {
+    // resolveStoreFile already probed existsSync, but a read-write open CREATES
+    // a missing file. The window between that probe and this open must not
+    // plant an empty store: that would make the daemon's import gate skip the
+    // one-shot JSON import and silently drop every pre-SQLite row.
+    if (!existsSync(ref.path)) return undefined;
     const db = openDbForOwnStore(ref.path);
     let inTxn = false;
     try {

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync, copyFileSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync, copyFileSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { config } from '../config.js';
@@ -40,25 +40,26 @@ export class SessionStoreUnavailableError extends Error {
 
 
 // Legacy fields from the removed「处理中」placeholder-card PATCH delivery. They
-// no longer exist on Session and nothing reads them, but sessions persisted
-// before the removal still carry them on disk. Strip on write so the store
-// converges to clean on the first save (daemon + CLI both call this).
+// no longer exist on `Session`, so no code path can produce them any more —
+// only rows persisted before the removal carry them. Stripping happens ONCE,
+// while importing those rows; every row the SQLite engine has ever written is
+// clean by construction, so the write paths do not re-check.
 const LEGACY_PENDING_CARD_FIELDS = ['pendingResponseCardId', 'pendingResponseCardState', 'lastPatchedResponseCardId'] as const;
-export function stripLegacyPendingCardFields(session: Record<string, unknown>): void {
+function stripLegacyPendingCardFields(session: Record<string, unknown>): void {
   for (const f of LEGACY_PENDING_CARD_FIELDS) delete session[f];
 }
 
-// ─── SQLite engine plumbing ──────────────────────────────────────────────────
+// ─── SQLite engine ───────────────────────────────────────────────────────────
 // Per-bot session rows live in `session-stores/<appId>/sessions.db` (legacy
-// no-appId store: `sessions.db`), one table, whole-row JSON column. The TS `Session` type stays
-// the schema authority; the generated columns below only serve hot lookups.
-// The pre-SQLite JSON files are frozen in place on first import and never
-// written again — reinstalling an older botmux and restarting reads them as of
-// the freeze instant (the rollback story for the migration window).
+// no-appId store: `sessions.db`), one table, whole-row JSON column. The TS
+// `Session` type stays the schema authority; the generated columns below only
+// serve hot lookups.
 //
-// Mixed upgrade window (npm upgraded, daemon not yet restarted): every
-// cross-process reader and CLI offline write path resolves each store as
-// "use the .db when it exists, else the .json".
+// SQLite is the ONLY engine. The pre-SQLite `sessions*.json` files are a
+// one-shot IMPORT SOURCE (below) and nothing else: after the import they are
+// frozen in place, never read on any live path and never written again. They
+// are deliberately not deleted — they are the only artifact a downgrade to a
+// pre-SQLite botmux can still read, and they cost a few hundred KB.
 
 type SqliteStatementLike = StatementLike;
 type SqliteDatabaseLike = DatabaseSyncLike;
@@ -108,6 +109,35 @@ export class SessionStoreSqliteUnavailableError extends Error {
   override readonly name = 'SessionStoreSqliteUnavailableError';
 }
 
+/** A store whose pre-SQLite `sessions*.json` still exists while its `.db` does
+ *  not: the daemon that owns it has not restarted on a SQLite build yet, so
+ *  the one-shot import has not run. Only that daemon may import (the
+ *  `owner: false` contract), so cross-process callers refuse loudly instead of
+ *  reporting an empty store — an offline close that silently no-ops, or a
+ *  `botmux send` that cannot find its own session, is the worse outcome. */
+export class SessionStoreNotImportedError extends Error {
+  override readonly name = 'SessionStoreNotImportedError';
+}
+
+/** Refuse a store that still has an un-imported JSON predecessor. The source
+ *  set mirrors `readJsonEntriesForImport`: this store's own file, else — for a
+ *  per-bot store — the legacy `sessions.json` the import would read its rows
+ *  from. A data dir with neither is simply empty and stays silent (a remote
+ *  sandbox has no local store at all). */
+function assertStoreImported(appId: string | undefined, dataDir: string): void {
+  if (existsSync(storeDbPath(appId, dataDir))) return;
+  const ownJsonFp = join(dataDir, storeJsonFileName(appId));
+  const legacyJsonFp = join(dataDir, 'sessions.json');
+  const pendingJsonFp = existsSync(ownJsonFp) ? ownJsonFp
+    : appId && existsSync(legacyJsonFp) ? legacyJsonFp
+      : undefined;
+  if (!pendingJsonFp) return;
+  throw new SessionStoreNotImportedError(
+    `会话库尚未迁移到 SQLite：${pendingJsonFp} 存在但 ${storeDbPath(appId, dataDir)} 不存在。`
+    + `拥有该 bot 的 daemon 仍在跑迁移前的版本——请重启 daemon（botmux restart）让它完成一次性导入。`,
+  );
+}
+
 function sqliteUnavailableMessage(context: string): string {
   return `${context}需要 SQLite 引擎（Node 的 node:sqlite 或 Bun 的 bun:sqlite），但当前运行时不可用。Node 请升级到 ${SQLITE_NODE_VERSION_HINT}；编译版请使用支持 bun:sqlite 的 Bun。当前 runtime: ${process.version}。`;
 }
@@ -148,6 +178,11 @@ function openDbForOwnStore(path: string): SqliteDatabaseLike {
  *  -shm they piggyback on). Callers must only SELECT. */
 function openDbForRead(path: string): SqliteDatabaseLike {
   requireSqliteEngine(`会话存储 ${basename(path)} `);
+  // A read-write open CREATES a missing file. An empty store planted here
+  // would make the owning daemon's `existsSync(db)` import gate skip the
+  // one-shot JSON import and silently discard every pre-SQLite row, so a
+  // reader must refuse an absent store outright (scan loops skip it).
+  if (!existsSync(path)) throw new Error(`session store ${path} does not exist`);
   let db: SqliteDatabaseLike;
   try {
     db = openDatabaseSyncOrThrow(path);
@@ -203,12 +238,12 @@ export function __testOnly_setBeforeRowPersist(hook: ((sessionId: string) => voi
   testOnlyBeforeRowPersist = hook;
 }
 
-// ─── Store file resolution (db-else-json) ────────────────────────────────────
+// ─── Store resolution ────────────────────────────────────────────────────────
 
 type StoreFileRef = {
   /** undefined = the legacy no-appId store. */
   appId?: string;
-  kind: 'sqlite' | 'json';
+  /** Absolute path of that store's `sessions.db`. */
   path: string;
 };
 
@@ -230,34 +265,25 @@ export function sessionStoreSqliteDir(appId: string, dataDir: string = config.se
 function storeDbPath(appId: string | undefined, dataDir: string): string {
   return appId ? join(sessionStoreSqliteDir(appId, dataDir), 'sessions.db') : join(dataDir, 'sessions.db');
 }
+
+/** Import source only — never read on a live path (see `importJsonStoreToSqlite`). */
 function storeJsonFileName(appId: string | undefined): string {
   return appId ? `sessions-${appId}.json` : 'sessions.json';
 }
 
-/** Per-store rule for every cross-process reader and CLI offline writer:
- *  use the .db when it exists, else the .json. */
 function resolveStoreFile(appId: string | undefined, dataDir: string): StoreFileRef {
-  const dbPath = storeDbPath(appId, dataDir);
-  if (existsSync(dbPath)) return { appId, kind: 'sqlite', path: dbPath };
-  return { appId, kind: 'json', path: join(dataDir, storeJsonFileName(appId)) };
+  return { appId, path: storeDbPath(appId, dataDir) };
 }
 
-/** One ref per store identity across the whole data dir, .db winning: flat
- *  legacy files + per-bot JSON files + per-bot SQLite store directories.
- *  `strict` propagates an unlistable `session-stores/` dir (fail-closed
- *  callers must not mistake an unreadable store set for an empty one);
- *  otherwise it degrades to the JSON view. */
+/** One ref per store that exists on disk: the flat legacy `sessions.db` plus
+ *  every `session-stores/<appId>/sessions.db`. `strict` propagates an
+ *  unlistable `session-stores/` dir (fail-closed callers must not mistake an
+ *  unreadable store set for an empty one); otherwise it degrades to whatever
+ *  could be enumerated. */
 function listStoreRefs(dataDir: string, opts: { strict?: boolean } = {}): StoreFileRef[] {
   const names = readdirSync(dataDir);
-  const dbPaths = new Map<string, string>();
-  const jsonPaths = new Map<string, string>();
-  for (const name of names) {
-    if (name === 'sessions.db') dbPaths.set('', join(dataDir, name));
-    else if (name === 'sessions.json') jsonPaths.set('', join(dataDir, name));
-    else if (name.startsWith('sessions-') && name.endsWith('.json')) {
-      jsonPaths.set(name.slice('sessions-'.length, -'.json'.length), join(dataDir, name));
-    }
-  }
+  const refs: StoreFileRef[] = [];
+  if (names.includes('sessions.db')) refs.push({ path: join(dataDir, 'sessions.db') });
   if (names.includes(PER_BOT_STORE_DIRNAME)) {
     let appIds: string[] = [];
     try {
@@ -267,29 +293,15 @@ function listStoreRefs(dataDir: string, opts: { strict?: boolean } = {}): StoreF
     }
     for (const appId of appIds) {
       const dbPath = storeDbPath(appId, dataDir);
-      if (existsSync(dbPath)) dbPaths.set(appId, dbPath);
+      if (existsSync(dbPath)) refs.push({ appId, path: dbPath });
     }
-  }
-  const refs: StoreFileRef[] = [];
-  for (const key of new Set([...dbPaths.keys(), ...jsonPaths.keys()])) {
-    const dbPath = dbPaths.get(key);
-    refs.push({
-      appId: key === '' ? undefined : key,
-      kind: dbPath ? 'sqlite' : 'json',
-      path: dbPath ?? jsonPaths.get(key)!,
-    });
   }
   return refs;
 }
 
-/** All [key, value] entries of one store file. Throws on an unreadable store;
+/** All [key, value] entries of one store. Throws on an unreadable store;
  *  callers decide skip-vs-propagate (capability errors always propagate). */
 function readStoreEntries(ref: StoreFileRef): [string, Session][] {
-  if (ref.kind === 'json') {
-    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
-    if (!parsed || typeof parsed !== 'object') return [];
-    return Object.entries(parsed as Record<string, Session>);
-  }
   const db = openDbForRead(ref.path);
   try {
     const rows = db.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
@@ -303,13 +315,8 @@ function readStoreEntries(ref: StoreFileRef): [string, Session][] {
   }
 }
 
-/** Point-read one key from one store file. Throws on an unreadable store. */
+/** Point-read one key from one store. Throws on an unreadable store. */
 function readStoreRowByKey(ref: StoreFileRef, sessionId: string): Session | undefined {
-  if (ref.kind === 'json') {
-    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
-    return (parsed as Record<string, Session>)[sessionId];
-  }
   // The daemon's hot freshness reads hit its own store — reuse the attached
   // connection instead of opening one per call.
   if (ownStore && loaded && ref.appId === currentAppId && ref.path === getDbPath()) {
@@ -325,16 +332,11 @@ function readStoreRowByKey(ref: StoreFileRef, sessionId: string): Session | unde
   }
 }
 
-/** The active rows of one store file, optionally narrowed by an indexed hint. */
+/** The active rows of one store, optionally narrowed by an indexed hint. */
 function readStoreActiveRows(
   ref: StoreFileRef,
   hint?: { rootMessageId?: string; chatScopeChatId?: string },
 ): Session[] {
-  if (ref.kind === 'json') {
-    const parsed = JSON.parse(readFileSync(ref.path, 'utf-8')) as unknown;
-    if (!parsed || typeof parsed !== 'object') return [];
-    return Object.values(parsed as Record<string, Session>).filter(s => s?.status === 'active');
-  }
   const db = openDbForRead(ref.path);
   try {
     let sql = "SELECT row FROM sessions WHERE status = 'active'";
@@ -438,7 +440,8 @@ export function init(appId?: string, opts: { owner?: boolean } = {}): void {
   }
 }
 
-function getFilePath(): string {
+/** Pre-SQLite JSON file for this store — the one-shot import source. */
+function getImportJsonPath(): string {
   return join(config.session.dataDir, storeJsonFileName(currentAppId));
 }
 
@@ -447,7 +450,7 @@ function getDbPath(): string {
 }
 
 function ensureDir(): void {
-  const dir = dirname(getFilePath());
+  const dir = config.session.dataDir;
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
@@ -473,14 +476,6 @@ export function repairMissingChatScope(session: unknown): boolean {
     return true;
   }
   return false;
-}
-
-function repairMissingChatScopes(): Session[] {
-  const repaired: Session[] = [];
-  for (const session of sessions.values()) {
-    if (repairMissingChatScope(session)) repaired.push(session);
-  }
-  return repaired;
 }
 
 function parseSessionsProjectionStrict(raw: string, fp: string): Record<string, Session> {
@@ -563,7 +558,15 @@ function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
     tmp.exec('BEGIN');
     const insert = tmp.prepare('INSERT OR REPLACE INTO sessions (session_id, status, row) VALUES (?, ?, ?)');
     for (const [key, value] of entries) {
-      insert.run(key, sessionStatusText(value), JSON.stringify(value));
+      // Convergence happens HERE, once, instead of on every write: a JSON file
+      // key that disagrees with the row's own sessionId (historical corruption)
+      // is normalised to the row's id, so the primary key and the row always
+      // agree from this point on. The old whole-file offline write dropped such
+      // rows; keying them correctly keeps the data and fixes the lookup.
+      const rowId = typeof (value as { sessionId?: unknown } | null)?.sessionId === 'string'
+        ? (value as unknown as { sessionId: string }).sessionId
+        : key;
+      insert.run(rowId, sessionStatusText(value), JSON.stringify(value));
     }
     tmp.exec('COMMIT');
     tmp.close();
@@ -989,7 +992,7 @@ function load(): void {
   if (loaded) return;
   ensureDir();
   const dbFp = getDbPath();
-  const jsonFp = getFilePath();
+  const jsonFp = getImportJsonPath();
 
   // A poisoned store must never be mistaken for an empty one. Recover it before
   // anything reads it, or fail closed so listSessionsStrict() throws instead of
@@ -1041,9 +1044,38 @@ function load(): void {
     }
   }
 
-  if (!existsSync(dbFp) && sqliteBootstrapAllowed) {
-    // First start on the SQLite engine: import this store's JSON rows (or
-    // create an empty store) under the same lock every JSON writer uses.
+  if (!existsSync(dbFp)) {
+    if (!sqliteBootstrapAllowed) {
+      // `owner: false` (a worker) and no store yet. Only reachable when the
+      // daemon that spawned this process still runs a pre-SQLite build: it
+      // keeps writing its JSON file, and creating the .db behind its back
+      // would fork the two representations. Record the failure instead of
+      // starting from an empty projection, so every write gate
+      // (loadForWrite / listSessionsStrict) fails closed until the daemon
+      // restarts on this build and imports.
+      const err = new SessionStoreNotImportedError(
+        `会话库尚未迁移到 SQLite：${dbFp} 不存在，而本进程（owner: false）不得建库。`
+        + `请重启拥有该 bot 的 daemon 完成一次性导入。`,
+      );
+      logger.error(`Failed to load sessions: ${err.message}`);
+      loadFailure = err;
+      sessions = new Map();
+      loaded = true;
+      return;
+    }
+    // First start on the SQLite engine: import this store's pre-SQLite JSON
+    // rows (or create an empty store).
+    //
+    // This is the ONLY file lock left in the store — the save/load/offline-write
+    // orchestration it used to serialise is gone with the JSON engine. It stays
+    // because the import stages through a FIXED `<db>.tmp` path, and two owning
+    // processes for the same bot can briefly overlap (a restart racing a not-yet
+    // reaped predecessor): both would pass `existsSync(db)`, write the same tmp
+    // file, and publish a corrupt database. A per-process tmp name would trade
+    // that for orphan files no one cleans up, and building straight into the
+    // final `.db` would break the invariant this design rests on — "the .db
+    // exists" must mean "the import completed", or a partial import silently
+    // disables the import gate and drops every pre-SQLite row.
     mkdirSync(dirname(dbFp), { recursive: true });
     try {
       withFileLockSync(jsonFp, () => {
@@ -1063,121 +1095,42 @@ function load(): void {
     }
   }
 
-  if (existsSync(dbFp)) {
-    let store: OwnSqliteStore;
-    try {
-      store = attachOwnStore(dbFp);
-    } catch (err) {
-      // Unreadable/corrupt .db: same fail-closed gate as a malformed JSON file.
-      logger.error(`Failed to load sessions: ${err}`);
-      loadFailure = err instanceof Error ? err : new Error(String(err));
-      sessions = new Map();
-      loaded = true;
-      return;
-    }
+  let store: OwnSqliteStore;
+  try {
+    store = attachOwnStore(dbFp);
+  } catch (err) {
+    // Unreadable/corrupt .db: fail-closed for every write gate.
+    logger.error(`Failed to load sessions: ${err}`);
+    loadFailure = err instanceof Error ? err : new Error(String(err));
     sessions = new Map();
-    // 排他读：BEGIN IMMEDIATE 与离线 CLI 写者互斥后再取快照。纯 SELECT 不被
-    // 写事务排斥——若一个已通过双 abortIf 探测、正持有 IMMEDIATE 的离线 CLI
-    // 尚未 commit，普通读会把它提交前的旧行读进终身缓存，随后的行写回就会
-    // 覆盖掉 CLI 的提交（JSON 时代由同一把文件锁保证的 load/离线写串行化）。
-    // daemon 先发布 descriptor 再首次 load：新来的写者在探测处让位，已持锁
-    // 的写者让本读取等到它 commit 之后。
-    try {
-      store.db.exec('BEGIN IMMEDIATE');
-      let committed = false;
-      try {
-        for (const [key, value] of readOwnStoreAllRows(store)) sessions.set(key, value);
-        const repaired = repairMissingChatScopes();
-        try {
-          for (const session of repaired) {
-            store.upsert.run(session.sessionId, sessionStatusText(session), JSON.stringify(session));
-          }
-          store.db.exec('COMMIT');
-          committed = true;
-          if (repaired.length > 0) {
-            logger.info(`Repaired ${repaired.length} scope-less chat session(s) in ${dbFp}`);
-          }
-        } catch (err) {
-          // Loading succeeded, so keep the in-memory sessions available (with
-          // the in-memory repairs) even if the best-effort repair cannot be
-          // persisted yet.
-          logger.error(`Failed to persist repaired chat session scopes: ${err}`);
-        }
-      } finally {
-        if (!committed) { try { store.db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
-      }
-    } catch (err) {
-      // Lock contention (SQLITE_BUSY after busy_timeout) must NOT become
-      // loadFailure + empty cache: daemon startup uses listSessions(), which
-      // would then restore nothing while the durable store is healthy.
-      if (ownStore) {
-        try { ownStore.db.close(); } catch { /* already closed */ }
-        ownStore = undefined;
-      }
-      sessions = new Map();
-      throw err;
-    }
-    logger.info(`Loaded ${sessions.size} sessions from ${dbFp}`);
     loaded = true;
     return;
   }
-
-  // JSON engine (non-owning process before the daemon has imported, or a
-  // pre-SQLite store this process may not bootstrap). Behaviour unchanged.
-  withFileLockSync(jsonFp, () => {
-    if (existsSync(jsonFp)) {
-      try {
-        const data = parseSessionsProjectionStrict(readFileSync(jsonFp, 'utf-8'), jsonFp);
-        sessions = new Map(Object.entries(data));
-        const repaired = repairMissingChatScopes();
-        if (repaired.length > 0) {
-          try {
-            const tmpFp = `${jsonFp}.${process.pid}.${randomUUID()}.tmp`;
-            writeFileSync(tmpFp, JSON.stringify(Object.fromEntries(sessions), null, 2), 'utf-8');
-            renameSync(tmpFp, jsonFp);
-            logger.info(`Repaired ${repaired.length} scope-less chat session(s) in ${jsonFp}`);
-          } catch (err) {
-            // Loading succeeded, so keep the in-memory sessions available even
-            // if the best-effort repair cannot be persisted yet.
-            logger.error(`Failed to persist repaired chat session scopes: ${err}`);
-          }
-        }
-        logger.info(`Loaded ${sessions.size} sessions from ${jsonFp}`);
-      } catch (err) {
-        logger.error(`Failed to load sessions: ${err}`);
-        loadFailure = err instanceof Error ? err : new Error(String(err));
-        sessions = new Map();
-      }
-    } else if (currentAppId) {
-      // Per-bot file doesn't exist — migrate matching legacy rows while still
-      // holding the same lock used by daemon saves and offline CLI mutations.
-      const legacyFp = join(config.session.dataDir, 'sessions.json');
-      if (existsSync(legacyFp)) {
-        try {
-          const data = parseSessionsProjectionStrict(readFileSync(legacyFp, 'utf-8'), legacyFp);
-          sessions = new Map();
-          for (const [k, v] of Object.entries(data)) {
-            if (v.larkAppId === currentAppId) sessions.set(k, v);
-          }
-          if (sessions.size > 0) {
-            const repaired = repairMissingChatScopes();
-            const obj = Object.fromEntries(sessions);
-            const tmpFp = `${jsonFp}.${process.pid}.${randomUUID()}.tmp`;
-            writeFileSync(tmpFp, JSON.stringify(obj, null, 2), 'utf-8');
-            renameSync(tmpFp, jsonFp);
-            logger.info(`Migrated ${sessions.size} sessions from sessions.json to ${jsonFp}`);
-            if (repaired.length > 0) {
-              logger.info(`Repaired ${repaired.length} scope-less chat session(s) during migration`);
-            }
-          }
-        } catch (err) {
-          logger.error(`Failed to migrate sessions from legacy file: ${err}`);
-          loadFailure = err instanceof Error ? err : new Error(String(err));
-          sessions = new Map();
-        }
-      }
+  sessions = new Map();
+  // 排他读：BEGIN IMMEDIATE 与离线 CLI 写者互斥后再取快照。纯 SELECT 不被
+  // 写事务排斥——若一个已通过双 abortIf 探测、正持有 IMMEDIATE 的离线 CLI
+  // 尚未 commit，普通读会把它提交前的旧行读进终身缓存，随后的行写回就会
+  // 覆盖掉 CLI 的提交。daemon 先发布 descriptor 再首次 load：新来的写者在
+  // 探测处让位，已持锁的写者让本读取等到它 commit 之后。
+  try {
+    store.db.exec('BEGIN IMMEDIATE');
+    try {
+      for (const [key, value] of readOwnStoreAllRows(store)) sessions.set(key, value);
+    } finally {
+      try { store.db.exec('COMMIT'); } catch { try { store.db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
     }
-  });
+  } catch (err) {
+    // Lock contention (SQLITE_BUSY after busy_timeout) must NOT become
+    // loadFailure + empty cache: daemon startup uses listSessions(), which
+    // would then restore nothing while the durable store is healthy.
+    if (ownStore) {
+      try { ownStore.db.close(); } catch { /* already closed */ }
+      ownStore = undefined;
+    }
+    sessions = new Map();
+    throw err;
+  }
+  logger.info(`Loaded ${sessions.size} sessions from ${dbFp}`);
   loaded = true;
 }
 
@@ -1202,22 +1155,6 @@ function readOwnStoreAllRows(store: OwnSqliteStore): [string, Session][] {
   return entries;
 }
 
-function readExistingSessionsFromDisk(fp: string): { raw: string; parsed: Record<string, Session> } {
-  if (!existsSync(fp)) return { raw: '', parsed: {} };
-  try {
-    const raw = readFileSync(fp, 'utf-8');
-    return { raw, parsed: JSON.parse(raw) as Record<string, Session> };
-  } catch {
-    return { raw: '', parsed: {} };
-  }
-}
-
-function readSessionsProjectionStrict(fp: string): { raw: string; parsed: Record<string, Session> } {
-  if (!existsSync(fp)) return { raw: '', parsed: {} };
-  const raw = readFileSync(fp, 'utf-8');
-  return { raw, parsed: parseSessionsProjectionStrict(raw, fp) };
-}
-
 function duplicateIds(ids: readonly string[]): string[] {
   const seen = new Set<string>();
   const duplicates = new Set<string>();
@@ -1228,19 +1165,13 @@ function duplicateIds(ids: readonly string[]): string[] {
   return [...duplicates];
 }
 
-/** Read-write connection to this process's own store for remote/offline-style
- *  fresh access: the attached connection when loaded, else a short-lived one.
- *  Returns undefined when the store is still on the JSON engine. */
-function withOwnStoreDbIfSqlite<T>(fn: (db: SqliteDatabaseLike) => T): T | undefined {
-  if (ownStore) return fn(ownStore.db);
-  const dbFp = getDbPath();
-  if (!existsSync(dbFp)) return undefined;
-  const db = openDbForOwnStore(dbFp);
-  try {
-    return fn(db);
-  } finally {
-    db.close();
-  }
+/** The connection `load()` attached for this process's own store. Going
+ *  through load() is what keeps the import gate and the `owner: false`
+ *  contract in one place instead of opening a second connection here (a
+ *  read-write open would CREATE the store and poison the import gate). */
+function withOwnStoreDb<T>(fn: (db: SqliteDatabaseLike) => T): T {
+  loadForWrite();
+  return fn(ownStore!.db);
 }
 
 /**
@@ -1249,7 +1180,6 @@ function withOwnStoreDbIfSqlite<T>(fn: (db: SqliteDatabaseLike) => T): T | undef
  */
 export function getActiveRemoteShutdownSnapshotsBatch(
   sessionIds: readonly string[],
-  options: { maxWaitMs?: number } = {},
 ): ActiveRemoteShutdownSnapshot[] {
   if (sessionIds.length === 0) return [];
   const duplicates = duplicateIds(sessionIds);
@@ -1261,9 +1191,9 @@ export function getActiveRemoteShutdownSnapshotsBatch(
     );
   }
 
-  ensureDir();
+  loadForWrite();
   try {
-    const sqliteResult = withOwnStoreDbIfSqlite((db): ActiveRemoteShutdownSnapshot[] => {
+    return withOwnStoreDb((db): ActiveRemoteShutdownSnapshot[] => {
       db.exec('BEGIN');
       try {
         const select = db.prepare('SELECT row FROM sessions WHERE session_id = ?');
@@ -1297,31 +1227,6 @@ export function getActiveRemoteShutdownSnapshotsBatch(
         try { db.exec('COMMIT'); } catch { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
       }
     });
-    if (sqliteResult !== undefined) return sqliteResult;
-
-    const fp = getFilePath();
-    return withFileLockSync(fp, () => {
-      const { parsed } = readSessionsProjectionStrict(fp);
-      const invalid = sessionIds.filter((sessionId) => {
-        const session = parsed[sessionId];
-        return !session || session.status !== 'active';
-      });
-      if (invalid.length > 0) {
-        throw new RemoteLineageBatchError(
-          'prewrite_ownership',
-          invalid,
-          `cannot snapshot non-active remote sessions: ${invalid.join(', ')}`,
-        );
-      }
-      return sessionIds.map((sessionId) => {
-        const session = parsed[sessionId]!;
-        return {
-          sessionId,
-          taskId: session.riffParentTaskId ?? null,
-          owner: remoteDurableOwner(session),
-        };
-      });
-    }, { maxWaitMs: options.maxWaitMs });
   } catch (error) {
     if (error instanceof RemoteLineageBatchError) throw error;
     throw new RemoteLineageBatchError(
@@ -1338,7 +1243,6 @@ export function getActiveRemoteShutdownSnapshotsBatch(
  */
 export function persistActiveRemoteLineagesExactBatch(
   updates: readonly ActiveRemoteLineageBatchUpdate[],
-  options: { maxWaitMs?: number } = {},
 ): ActiveRemoteShutdownSnapshot[] {
   if (updates.length === 0) return [];
   const sessionIds = updates.map(update => update.sessionId);
@@ -1352,10 +1256,9 @@ export function persistActiveRemoteLineagesExactBatch(
   }
 
   loadForWrite();
-  ensureDir();
   let published = false;
   try {
-    const sqliteResult = withOwnStoreDbIfSqlite((db): ActiveRemoteShutdownSnapshot[] => {
+    return withOwnStoreDb((db): ActiveRemoteShutdownSnapshot[] => {
       const select = db.prepare('SELECT row FROM sessions WHERE session_id = ?');
       const update = db.prepare("UPDATE sessions SET status = ?, row = ? WHERE session_id = ?");
       let inTxn = false;
@@ -1392,7 +1295,6 @@ export function persistActiveRemoteLineagesExactBatch(
             ...fresh.session,
             riffParentTaskId: u.targetTaskId ?? undefined,
           };
-          stripLegacyPendingCardFields(next as unknown as Record<string, unknown>);
           const json = JSON.stringify(next);
           if (json !== fresh.raw) {
             update.run(sessionStatusText(next), json, u.sessionId);
@@ -1444,96 +1346,6 @@ export function persistActiveRemoteLineagesExactBatch(
       }
       return verified;
     });
-    if (sqliteResult !== undefined) return sqliteResult;
-
-    const fp = getFilePath();
-    let tmpFp: string | undefined;
-    try {
-      return withFileLockSync(fp, () => {
-        const { raw, parsed } = readSessionsProjectionStrict(fp);
-        const conflicts: string[] = [];
-        for (const update of updates) {
-          const durable = parsed[update.sessionId];
-          const durableTaskId = durable?.riffParentTaskId ?? null;
-          if (!durable
-              || durable.status !== 'active'
-              || !update.expectedCurrentTaskIds.some(candidate => candidate === durableTaskId)
-              || !remoteOwnersEqual(remoteDurableOwner(durable), update.owner)) {
-            conflicts.push(update.sessionId);
-          }
-        }
-        if (conflicts.length > 0) {
-          throw new RemoteLineageBatchError(
-            'prewrite_ownership',
-            conflicts,
-            `Remote lineage batch compare-and-set failed for: ${conflicts.join(', ')}`,
-          );
-        }
-
-        for (const update of updates) {
-          const durable = parsed[update.sessionId]!;
-          const next: Session = {
-            ...durable,
-            riffParentTaskId: update.targetTaskId ?? undefined,
-          };
-          stripLegacyPendingCardFields(next as unknown as Record<string, unknown>);
-          parsed[update.sessionId] = next;
-        }
-
-        const json = JSON.stringify(parsed, null, 2);
-        if (json !== raw) {
-          tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
-          writeFileSync(tmpFp, json, 'utf-8');
-          renameSync(tmpFp, fp);
-          tmpFp = undefined;
-          published = true;
-          testOnlyAfterRemoteBatchRename?.();
-        }
-
-        let verifiedProjection: Record<string, Session>;
-        try {
-          verifiedProjection = readSessionsProjectionStrict(fp).parsed;
-        } catch (error) {
-          throw new RemoteLineageBatchError(
-            published ? 'postrename_ambiguity' : 'prewrite_io',
-            [...sessionIds],
-            `failed to read back Remote lineage batch: ${String(error)}`,
-          );
-        }
-
-        const ambiguous = updates.filter((update) => {
-          const durable = verifiedProjection[update.sessionId];
-          return !durable
-            || durable.status !== 'active'
-            || (durable.riffParentTaskId ?? null) !== update.targetTaskId
-            || !remoteOwnersEqual(remoteDurableOwner(durable), update.owner);
-        }).map(update => update.sessionId);
-        if (ambiguous.length > 0) {
-          throw new RemoteLineageBatchError(
-            published ? 'postrename_ambiguity' : 'prewrite_ownership',
-            ambiguous,
-            `Remote lineage batch readback mismatch for: ${ambiguous.join(', ')}`,
-          );
-        }
-
-        const verified = updates.map((update) => ({
-          sessionId: update.sessionId,
-          taskId: update.targetTaskId,
-          owner: remoteDurableOwner(verifiedProjection[update.sessionId]!),
-        }));
-        if (loaded) {
-          for (const update of updates) {
-            const cached = sessions.get(update.sessionId);
-            if (cached) cached.riffParentTaskId = update.targetTaskId ?? undefined;
-          }
-        }
-        return verified;
-      }, { maxWaitMs: options.maxWaitMs });
-    } finally {
-      if (tmpFp) {
-        try { unlinkSync(tmpFp); } catch { /* best-effort orphan cleanup */ }
-      }
-    }
   } catch (error) {
     if (error instanceof RemoteLineageBatchError) throw error;
     throw new RemoteLineageBatchError(
@@ -1544,41 +1356,17 @@ export function persistActiveRemoteLineagesExactBatch(
   }
 }
 
-/** Whole-map JSON save — only for a store still on the JSON engine. */
-function save(): void {
-  if (loadFailure) throw new SessionStoreUnavailableError(loadFailure);
-  ensureDir();
-  const fp = getFilePath();
-  withFileLockSync(fp, () => {
-    const { raw: existingRaw } = readExistingSessionsFromDisk(fp);
-    const obj: Record<string, Session> = {};
-    for (const [k, v] of sessions) {
-      stripLegacyPendingCardFields(v as unknown as Record<string, unknown>);
-      obj[k] = v;
-    }
-    const json = JSON.stringify(obj, null, 2);
-    // The daemon fires several updateSession()/save() calls per inbound message
-    // (activity bump, pid, stream-card state, …) and many leave the serialized
-    // file byte-identical. Skipping the temp-file write + rename in that case
-    // elides the bulk of the redundant disk I/O.
-    if (json === existingRaw) return;
-    const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
-    writeFileSync(tmpFp, json, 'utf-8');
-    renameSync(tmpFp, fp);
-  });
-}
-
-/** Persist ONE changed row. SQLite engine: dirty-row upsert (a redundant
- *  update that leaves the serialized row identical skips the write, the
- *  row-level analogue of the old byte-identical whole-file skip). JSON
- *  engine: the legacy whole-map save. */
+/** Persist ONE changed row: a dirty-row upsert. A redundant update that leaves
+ *  the serialized row identical skips the write — the daemon fires several
+ *  updateSession() calls per inbound message (activity bump, pid, stream-card
+ *  state, …) and many of them change nothing. */
 function persistRow(session: Session): void {
   if (loadFailure) throw new SessionStoreUnavailableError(loadFailure);
   if (!ownStore) {
-    save();
-    return;
+    throw new SessionStoreUnavailableError(
+      new Error(`session store ${getDbPath()} is not attached`),
+    );
   }
-  stripLegacyPendingCardFields(session as unknown as Record<string, unknown>);
   testOnlyBeforeRowPersist?.(session.sessionId);
   const json = JSON.stringify(session);
   const existing = ownStore.selectRow.get(session.sessionId) as { row: string } | undefined;
@@ -1646,30 +1434,17 @@ export function getOwnedSession(sessionId: string): Session | undefined {
   return sessions.get(sessionId);
 }
 
-/** Cross-process fresh read. SQLite engine: a point SELECT observes the last
- *  committed write (WAL orders daemon/CLI writers). JSON engine: ordered
- *  after writers by the shared file lock, as before. */
+/** Cross-process fresh read: a point SELECT observes the last committed write
+ *  (WAL orders the daemon against offline CLI writers). */
 export function getSessionFresh(sessionId: string): Session | undefined {
-  ensureDir();
   const dbFp = getDbPath();
-  if (existsSync(dbFp)) {
-    try {
-      return readStoreRowByKey({ appId: currentAppId, kind: 'sqlite', path: dbFp }, sessionId);
-    } catch (err) {
-      if (err instanceof SessionStoreSqliteUnavailableError) throw err;
-      return undefined;
-    }
+  if (!existsSync(dbFp)) return undefined;
+  try {
+    return readStoreRowByKey({ appId: currentAppId, path: dbFp }, sessionId);
+  } catch (err) {
+    if (err instanceof SessionStoreSqliteUnavailableError) throw err;
+    return undefined;
   }
-  const fp = getFilePath();
-  return withFileLockSync(fp, () => {
-    if (!existsSync(fp)) return undefined;
-    try {
-      const data = JSON.parse(readFileSync(fp, 'utf-8')) as Record<string, Session>;
-      return data[sessionId];
-    } catch {
-      return undefined;
-    }
-  });
 }
 
 /**
@@ -1760,21 +1535,15 @@ function mutateMojoCloseJournal(
   if (session.backendType !== 'mojo') {
     throw new Error(`cannot mutate Mojo close journal for non-Mojo session ${sessionId}`);
   }
-  const priorJournal = session.mojoCloseJournal
-    ? { ...session.mojoCloseJournal }
-    : undefined;
-  const priorTaskId = session.riffParentTaskId;
   if (session.mojoCloseJournal && !isValidMojoCloseJournal(session.mojoCloseJournal)) {
     throw new Error(`cannot mutate malformed Mojo close journal for ${sessionId}`);
   }
-  mutate(session);
-  try {
-    persistRow(session);
-  } catch (error) {
-    session.mojoCloseJournal = priorJournal;
-    session.riffParentTaskId = priorTaskId;
-    throw error;
-  }
+  // Durable first: `mutate` works on a copy, and a failed persist leaves the
+  // live row untouched — including when `mutate` itself rejects the transition.
+  const next: Session = { ...session };
+  mutate(next);
+  persistRow(next);
+  Object.assign(session, next);
   return session;
 }
 
@@ -2028,22 +1797,19 @@ export function closeSession(
   loadForWrite();
   const session = sessions.get(sessionId);
   if (session) {
-    const priorStatus = session.status;
-    const priorClosedAt = session.closedAt;
-    const priorRiffParentTaskId = session.riffParentTaskId;
+    // The materialised images are cleaned up AFTER the row commits, so the list
+    // has to be read before it is dropped from the row. Not a rollback copy —
+    // the durable-first commit below has nothing to undo.
     const priorDashboardAttachments = session.dashboardAttachments;
-    const priorQueuedAttachments = session.queuedAttachments;
-    const priorPreviewTarget = session.previewTarget;
-    const priorQuarantinedLineage = session.mojoQuarantinedLineage;
-    const priorQuarantineNoticePending = session.mojoQuarantineNoticePending;
-    const priorLocalResidual = session.mojoLocalResidual;
-    const priorMojoCloseJournal = session.mojoCloseJournal
-      ? { ...session.mojoCloseJournal }
-      : undefined;
-    session.status = 'closed';
-    session.closedAt = new Date().toISOString();
-    session.dashboardAttachments = undefined;
-    session.queuedAttachments = undefined;
+    // Durable first: build the closed row, commit it, and only then merge it
+    // into the live object. A failed write leaves the session exactly as it
+    // was, which is what the hand-written field-by-field restore used to
+    // approximate.
+    const next: Session = { ...session };
+    next.status = 'closed';
+    next.closedAt = new Date().toISOString();
+    next.dashboardAttachments = undefined;
+    next.queuedAttachments = undefined;
     // `previewTarget` is a live loopback (host, port) the session's agent
     // registered with `botmux preview <port>` for its CURRENT worker
     // generation — routing state, not a durable property of the conversation.
@@ -2054,41 +1820,25 @@ export function closeSession(
     // else's service. Drop it in the same atomic save as status='closed'.
     // Cleanup only: registration and proxying are untouched, and a resumed
     // session simply re-runs `botmux preview <port>`.
-    session.previewTarget = undefined;
-    session.mojoCloseJournal = undefined;
+    next.previewTarget = undefined;
+    next.mojoCloseJournal = undefined;
     // Survives close on purpose — the containment handle is still in the durable
     // store, so the row must keep reporting the residual until the handle clears.
-    if (opts.parkLocalResidual) session.mojoLocalResidual = opts.parkLocalResidual;
+    if (opts.parkLocalResidual) next.mojoLocalResidual = opts.parkLocalResidual;
     if (opts.parkMojoLineage) {
       // Keep both ids when a different one was already parked: each is the only
       // handle left for manual cleanup of its remote session.
-      const already = session.mojoQuarantinedLineage;
-      session.mojoQuarantinedLineage = already && already !== opts.parkMojoLineage
+      const already = next.mojoQuarantinedLineage;
+      next.mojoQuarantinedLineage = already && already !== opts.parkMojoLineage
         ? `${already},${opts.parkMojoLineage}`
         : opts.parkMojoLineage;
-      session.mojoQuarantineNoticePending = true;
+      next.mojoQuarantineNoticePending = true;
     }
     // Riff cancellation has already completed before this durable transition.
     // Clear its retry handle in the same atomic save as status='closed'.
-    if (opts.clearRiffParentTaskId) session.riffParentTaskId = undefined;
-    try {
-      persistRow(session);
-    } catch (err) {
-      session.status = priorStatus;
-      session.closedAt = priorClosedAt;
-      session.riffParentTaskId = priorRiffParentTaskId;
-      session.dashboardAttachments = priorDashboardAttachments;
-      session.queuedAttachments = priorQueuedAttachments;
-      session.previewTarget = priorPreviewTarget;
-      // Without these two the row keeps a parked lineage after a FAILED close, so
-      // the next turn treats a still-live remote session as quarantined and starts
-      // a new one — i.e. the "close failed, retry unchanged" guarantee is broken.
-      session.mojoQuarantinedLineage = priorQuarantinedLineage;
-      session.mojoQuarantineNoticePending = priorQuarantineNoticePending;
-      session.mojoLocalResidual = priorLocalResidual;
-      session.mojoCloseJournal = priorMojoCloseJournal;
-      throw err;
-    }
+    if (opts.clearRiffParentTaskId) next.riffParentTaskId = undefined;
+    persistRow(next);
+    Object.assign(session, next);
     if (session.larkAppId && priorDashboardAttachments?.length) {
       try {
         cleanupMaterializedDashboardImages(session.larkAppId, priorDashboardAttachments);
@@ -2129,56 +1879,32 @@ export function reactivateClosedSession(
   if (!session) return { ok: false, error: 'not_found' };
   if (session.status !== 'closed') return { ok: false, error: 'not_closed' };
 
-  const prior = {
-    status: session.status,
-    closedAt: session.closedAt,
-    lastMessageAt: session.lastMessageAt,
-    codexAppDispatchLedger: session.codexAppDispatchLedger,
-    codexAppGenerationCommits: session.codexAppGenerationCommits,
-    queued: session.queued,
-    queuedPrompt: session.queuedPrompt,
-    queuedCodexAppText: session.queuedCodexAppText,
-    queuedCodexAppMessageContext: session.queuedCodexAppMessageContext,
-    queuedActivationPending: session.queuedActivationPending,
-    queuedActivationToken: session.queuedActivationToken,
-    queuedActivationInput: session.queuedActivationInput,
-    queuedActivationTurnId: session.queuedActivationTurnId,
-    queuedActivationDispatchAttempt: session.queuedActivationDispatchAttempt,
-    queuedActivationResume: session.queuedActivationResume,
-    queuedActivationTail: session.queuedActivationTail,
-    queuedActivationTailNextOrder: session.queuedActivationTailNextOrder,
-    pendingRepoSetup: session.pendingRepoSetup,
-    previewTarget: session.previewTarget,
-    mojoCloseJournal: session.mojoCloseJournal,
-  };
+  // Durable first (see closeSession): the reactivated row is committed before
+  // it is merged into the live object, so a failed write is a no-op.
+  const next: Session = { ...session };
+  next.status = 'active';
+  next.closedAt = undefined;
+  next.lastMessageAt = new Date().toISOString();
+  next.codexAppDispatchLedger = undefined;
+  next.codexAppGenerationCommits = undefined;
+  next.queued = undefined;
+  next.queuedPrompt = undefined;
+  next.queuedCodexAppText = undefined;
+  next.queuedCodexAppMessageContext = undefined;
+  next.queuedActivationPending = undefined;
+  next.queuedActivationToken = undefined;
+  next.queuedActivationInput = undefined;
+  next.queuedActivationTurnId = undefined;
+  next.queuedActivationDispatchAttempt = undefined;
+  next.queuedActivationResume = undefined;
+  next.queuedActivationTail = undefined;
+  next.queuedActivationTailNextOrder = undefined;
+  next.pendingRepoSetup = undefined;
+  next.previewTarget = undefined;
+  next.mojoCloseJournal = undefined;
 
-  session.status = 'active';
-  session.closedAt = undefined;
-  session.lastMessageAt = new Date().toISOString();
-  session.codexAppDispatchLedger = undefined;
-  session.codexAppGenerationCommits = undefined;
-  session.queued = undefined;
-  session.queuedPrompt = undefined;
-  session.queuedCodexAppText = undefined;
-  session.queuedCodexAppMessageContext = undefined;
-  session.queuedActivationPending = undefined;
-  session.queuedActivationToken = undefined;
-  session.queuedActivationInput = undefined;
-  session.queuedActivationTurnId = undefined;
-  session.queuedActivationDispatchAttempt = undefined;
-  session.queuedActivationResume = undefined;
-  session.queuedActivationTail = undefined;
-  session.queuedActivationTailNextOrder = undefined;
-  session.pendingRepoSetup = undefined;
-  session.previewTarget = undefined;
-  session.mojoCloseJournal = undefined;
-
-  try {
-    persistRow(session);
-  } catch (err) {
-    Object.assign(session, prior);
-    throw err;
-  }
+  persistRow(next);
+  Object.assign(session, next);
   return { ok: true, session };
 }
 
@@ -2209,9 +1935,6 @@ export function persistActiveRemoteLineageExact(
     expectedOwner?: RemoteDurableOwner;
   } = {},
 ): Session {
-  loadForWrite();
-  ensureDir();
-
   const applyChecksAndBuildNext = (durable: Session | undefined): Session => {
     if (!durable || durable.status !== 'active') {
       throw new RemoteLineageOwnershipError(
@@ -2237,7 +1960,6 @@ export function persistActiveRemoteLineageExact(
       ...durable,
       riffParentTaskId: taskId ?? undefined,
     };
-    stripLegacyPendingCardFields(next as unknown as Record<string, unknown>);
     return next;
   };
 
@@ -2251,7 +1973,7 @@ export function persistActiveRemoteLineageExact(
     return next;
   };
 
-  const sqliteResult = withOwnStoreDbIfSqlite((db): Session => {
+  return withOwnStoreDb((db): Session => {
     const select = db.prepare('SELECT row FROM sessions WHERE session_id = ?');
     let inTxn = false;
     try {
@@ -2272,21 +1994,6 @@ export function persistActiveRemoteLineageExact(
       if (inTxn) { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
       throw err;
     }
-  });
-  if (sqliteResult !== undefined) return sqliteResult;
-
-  const fp = getFilePath();
-  return withFileLockSync(fp, () => {
-    const { raw, parsed } = readExistingSessionsFromDisk(fp);
-    const next = applyChecksAndBuildNext(parsed[sessionId]);
-    parsed[sessionId] = next;
-    const json = JSON.stringify(parsed, null, 2);
-    if (json !== raw) {
-      const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
-      writeFileSync(tmpFp, json, 'utf-8');
-      renameSync(tmpFp, fp);
-    }
-    return publishToCache(next);
   });
 }
 
@@ -2355,17 +2062,12 @@ export function countActiveSessionsOnDisk(dataDir: string = config.session.dataD
   let n = 0;
   for (const ref of refs) {
     try {
-      if (ref.kind === 'sqlite') {
-        const db = openDbForRead(ref.path);
-        try {
-          const hit = db.prepare("SELECT COUNT(*) AS n FROM sessions WHERE status = 'active'").get() as { n: number };
-          n += hit.n;
-        } finally {
-          db.close();
-        }
-      } else {
-        const data: Record<string, Session> = JSON.parse(readFileSync(ref.path, 'utf-8'));
-        for (const s of Object.values(data)) if (s?.status === 'active') n++;
+      const db = openDbForRead(ref.path);
+      try {
+        const hit = db.prepare("SELECT COUNT(*) AS n FROM sessions WHERE status = 'active'").get() as { n: number };
+        n += hit.n;
+      } finally {
+        db.close();
       }
     } catch (err) {
       if (err instanceof SessionStoreSqliteUnavailableError) throw err;
@@ -2440,6 +2142,10 @@ export function loadAllSessionsSnapshot(options: {
   fallbackAppId?: string;
 } = {}): Map<string, Session> {
   const dataDir = options.dataDir ?? config.session.dataDir;
+  // Only the caller's own store is asserted: a peer bot that has not migrated
+  // yet is invisible (it was never this caller's business), but the store the
+  // caller belongs to reading as empty would look like "your session is gone".
+  if (options.fallbackAppId) assertStoreImported(options.fallbackAppId, dataDir);
   const out = new Map<string, Session>();
   const readInto = (ref: StoreFileRef): void => {
     let entries: [string, Session][];
@@ -2447,7 +2153,7 @@ export function loadAllSessionsSnapshot(options: {
       entries = readStoreEntries(ref);
     } catch (err) {
       if (err instanceof SessionStoreSqliteUnavailableError) throw err;
-      return; /* missing or corrupt store → skip */
+      return; /* absent or corrupt store → skip */
     }
     // Arrays are deliberately tolerated on the JSON side (Object.entries
     // yields their rows): the historical CLI loader accepted array-shaped
@@ -2560,61 +2266,34 @@ export function mutateSessionRowOffline(
   options: { dataDir?: string; abortIf?: () => boolean } = {},
 ): Session | undefined {
   const dataDir = options.dataDir ?? config.session.dataDir;
+  assertStoreImported(target.larkAppId, dataDir);
   const ref = resolveStoreFile(target.larkAppId, dataDir);
+  // `openDbForOwnStore` is a read-write open: it would CREATE the store and
+  // poison the owning daemon's import gate. A store that does not exist simply
+  // holds no row.
+  if (!existsSync(ref.path)) return undefined;
 
-  if (ref.kind === 'sqlite') {
-    const db = openDbForOwnStore(ref.path);
-    let inTxn = false;
-    try {
-      db.exec('BEGIN IMMEDIATE');
-      inTxn = true;
-      if (options.abortIf?.()) return undefined;
-      const hit = db.prepare('SELECT row FROM sessions WHERE session_id = ?')
-        .get(target.sessionId) as { row: string } | undefined;
-      if (!hit) return undefined;
-      const current = JSON.parse(hit.row) as Session;
-      if (!mutate(current)) return current;
-      stripLegacyPendingCardFields(current as unknown as Record<string, unknown>);
-      if (options.abortIf?.()) return undefined;
-      db.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
-        .run(sessionStatusText(current), JSON.stringify(current), target.sessionId);
-      db.exec('COMMIT');
-      inTxn = false;
-      return current;
-    } finally {
-      if (inTxn) { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
-      db.close();
-    }
-  }
-
-  const fp = ref.path;
-  return withFileLockSync(fp, () => {
+  const db = openDbForOwnStore(ref.path);
+  let inTxn = false;
+  try {
+    db.exec('BEGIN IMMEDIATE');
+    inTxn = true;
     if (options.abortIf?.()) return undefined;
-    let data: Record<string, Session> = {};
-    if (existsSync(fp)) {
-      try { data = JSON.parse(readFileSync(fp, 'utf-8')); } catch { /* start fresh */ }
-    }
-    const current = data[target.sessionId];
-    if (!current || !mutate(current)) return current;
-    data[target.sessionId] = current;
-
-    // Clean up entries where the file key doesn't match the entry's sessionId
-    // (data corruption), and strip removed placeholder-card fields — the same
-    // convergence the daemon's save() applies.
-    for (const [key, val] of Object.entries(data)) {
-      if (val && typeof val === 'object' && 'sessionId' in val && (val as Session).sessionId !== key) {
-        delete data[key];
-        continue;
-      }
-      if (val && typeof val === 'object') stripLegacyPendingCardFields(val as unknown as Record<string, unknown>);
-    }
-
+    const hit = db.prepare('SELECT row FROM sessions WHERE session_id = ?')
+      .get(target.sessionId) as { row: string } | undefined;
+    if (!hit) return undefined;
+    const current = JSON.parse(hit.row) as Session;
+    if (!mutate(current)) return current;
     if (options.abortIf?.()) return undefined;
-    const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
-    writeFileSync(tmpFp, JSON.stringify(data, null, 2), 'utf-8');
-    renameSync(tmpFp, fp);
+    db.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
+      .run(sessionStatusText(current), JSON.stringify(current), target.sessionId);
+    db.exec('COMMIT');
+    inTxn = false;
     return current;
-  });
+  } finally {
+    if (inTxn) { try { db.exec('ROLLBACK'); } catch { /* txn already gone */ } }
+    db.close();
+  }
 }
 
 function findActiveSessionsMatching(

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -119,23 +119,44 @@ export class SessionStoreNotImportedError extends Error {
   override readonly name = 'SessionStoreNotImportedError';
 }
 
-/** Refuse a store that still has an un-imported JSON predecessor. The source
- *  set mirrors `readJsonEntriesForImport`: this store's own file, else — for a
- *  per-bot store — the legacy `sessions.json` the import would read its rows
- *  from. A data dir with neither is simply empty and stays silent (a remote
- *  sandbox has no local store at all). */
-function assertStoreImported(appId: string | undefined, dataDir: string): void {
-  if (existsSync(storeDbPath(appId, dataDir))) return;
+/** A per-bot store that still has its own un-imported `sessions-<appId>.json`.
+ *
+ *  Deliberately narrow. It does NOT consult the legacy `sessions.json`, for two
+ *  reasons: that file is never deleted by the legacy→per-bot migration, so it
+ *  survives on every upgraded install forever; and no daemon will ever import
+ *  it (production daemons always start with an appId, so nothing owns the flat
+ *  store). Treating it as "pending" would fire on every freshly added bot —
+ *  which has nothing to import at all — and tell its operator to restart a
+ *  daemon that is already current. A store with no own JSON is simply new. */
+function unimportedStoreJsonPath(appId: string, dataDir: string): string | undefined {
+  if (existsSync(storeDbPath(appId, dataDir))) return undefined;
   const ownJsonFp = join(dataDir, storeJsonFileName(appId));
-  const legacyJsonFp = join(dataDir, 'sessions.json');
-  const pendingJsonFp = existsSync(ownJsonFp) ? ownJsonFp
-    : appId && existsSync(legacyJsonFp) ? legacyJsonFp
-      : undefined;
+  return existsSync(ownJsonFp) ? ownJsonFp : undefined;
+}
+
+function assertStoreImported(appId: string | undefined, dataDir: string): void {
+  if (!appId) return;
+  const pendingJsonFp = unimportedStoreJsonPath(appId, dataDir);
   if (!pendingJsonFp) return;
   throw new SessionStoreNotImportedError(
     `会话库尚未迁移到 SQLite：${pendingJsonFp} 存在但 ${storeDbPath(appId, dataDir)} 不存在。`
     + `拥有该 bot 的 daemon 仍在跑迁移前的版本——请重启 daemon（botmux restart）让它完成一次性导入。`,
   );
+}
+
+/** Every per-bot store whose own JSON is still waiting to be imported. Used to
+ *  explain an empty cross-store scan instead of reporting "row not found". */
+function listUnimportedStoreJsonPaths(dataDir: string): string[] {
+  let names: string[];
+  try { names = readdirSync(dataDir); } catch { return []; }
+  const pending: string[] = [];
+  for (const name of names) {
+    if (!name.startsWith('sessions-') || !name.endsWith('.json')) continue;
+    const appId = name.slice('sessions-'.length, -'.json'.length);
+    const jsonFp = unimportedStoreJsonPath(appId, dataDir);
+    if (jsonFp) pending.push(jsonFp);
+  }
+  return pending;
 }
 
 function sqliteUnavailableMessage(context: string): string {
@@ -431,6 +452,7 @@ export function __testOnly_setAfterRemoteBatchRename(hook: (() => void) | undefi
 export function init(appId?: string, opts: { owner?: boolean } = {}): void {
   currentAppId = appId;
   sqliteBootstrapAllowed = opts.owner !== false;
+  warnedUnimportedOwnStore = false;
   loaded = false;
   sessions = new Map();
   loadFailure = undefined;
@@ -549,24 +571,31 @@ function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
   const tmp = openDatabaseSyncOrThrow(tmpFp);
   try {
     tmp.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
-    // The temporary file is renamed after close. WAL sidecars keep the old
-    // `.tmp` basename, so publishing only the main file strands the schema
-    // and rows on Bun. The live store switches to WAL when it is opened.
+    // The staging database is deliberately NOT in WAL mode. `renameSync` below
+    // publishes ONE file, so every imported row has to live inside it by the
+    // time we rename — and closing a WAL connection does not reliably fold the
+    // -wal sidecar back into the main file on both engines. Under bun:sqlite it
+    // does not: the rows stay in `<db>.tmp-wal`, the rename publishes a 4 KB
+    // header-only database, and every later open fails with "disk I/O error".
+    // Because the import gate is `existsSync(db)`, that shell is never
+    // rebuilt — the store is bricked and every pre-SQLite session is
+    // unreachable. The rollback journal keeps the staging file self-contained;
+    // the real store still runs WAL (see openDbForOwnStore).
     tmp.exec('PRAGMA journal_mode = DELETE;');
     tmp.exec('PRAGMA synchronous = NORMAL;');
     tmp.exec(SESSIONS_SCHEMA_SQL);
     tmp.exec('BEGIN');
     const insert = tmp.prepare('INSERT OR REPLACE INTO sessions (session_id, status, row) VALUES (?, ?, ?)');
     for (const [key, value] of entries) {
-      // Convergence happens HERE, once, instead of on every write: a JSON file
-      // key that disagrees with the row's own sessionId (historical corruption)
-      // is normalised to the row's id, so the primary key and the row always
-      // agree from this point on. The old whole-file offline write dropped such
-      // rows; keying them correctly keeps the data and fixes the lookup.
-      const rowId = typeof (value as { sessionId?: unknown } | null)?.sessionId === 'string'
-        ? (value as unknown as { sessionId: string }).sessionId
-        : key;
-      insert.run(rowId, sessionStatusText(value), JSON.stringify(value));
+      // Import under the file's OWN key, never the row's sessionId. Re-keying
+      // looks like a cleanup for the historical "key disagrees with
+      // row.sessionId" corruption, but two entries can carry the SAME
+      // sessionId — and then the later one silently replaces the earlier,
+      // letting a stale closed ghost overwrite the live row, irreversibly
+      // (the import runs once and the JSON is frozen afterwards). A
+      // mis-keyed row stays inert instead: identity scans already skip rows
+      // whose sessionId disagrees with the key they were found under.
+      insert.run(key, sessionStatusText(value), JSON.stringify(value));
     }
     tmp.exec('COMMIT');
     tmp.close();
@@ -1434,11 +1463,28 @@ export function getOwnedSession(sessionId: string): Session | undefined {
   return sessions.get(sessionId);
 }
 
+let warnedUnimportedOwnStore = false;
+
 /** Cross-process fresh read: a point SELECT observes the last committed write
  *  (WAL orders the daemon against offline CLI writers). */
 export function getSessionFresh(sessionId: string): Session | undefined {
   const dbFp = getDbPath();
-  if (!existsSync(dbFp)) return undefined;
+  if (!existsSync(dbFp)) {
+    // Callers here (worker `authorizeManagedSend`) treat undefined as "no such
+    // row" and degrade quietly — a codex-app turn ends up refused as
+    // `origin_mismatch` with nothing in the log pointing at the real cause.
+    // Throwing is not an option (the worker's IPC handler has no catch), so at
+    // least say it once.
+    if (currentAppId && !warnedUnimportedOwnStore
+        && unimportedStoreJsonPath(currentAppId, config.session.dataDir)) {
+      warnedUnimportedOwnStore = true;
+      logger.warn(
+        `会话库尚未迁移到 SQLite：${dbFp} 不存在，本进程的所有会话读取都会落空。`
+        + `请重启拥有该 bot 的 daemon 完成一次性导入。`,
+      );
+    }
+    return undefined;
+  }
   try {
     return readStoreRowByKey({ appId: currentAppId, path: dbFp }, sessionId);
   } catch (err) {
@@ -2237,6 +2283,19 @@ export function readSessionRowCopiesAcrossStores(
     if (!session || typeof session !== 'object' || Array.isArray(session)) continue;
     if (session.sessionId !== sessionId) continue;
     matches.push(session);
+  }
+  if (matches.length === 0) {
+    // "Row not found" and "that bot's store was never imported" are the same
+    // empty scan but completely different actions. Callers turn a zero match
+    // into 「未找到当前进程所属 session」, which sends the operator hunting for a
+    // lost process marker instead of restarting one daemon.
+    const pending = listUnimportedStoreJsonPaths(dataDir);
+    if (pending.length > 0) {
+      throw new SessionStoreNotImportedError(
+        `会话库尚未迁移到 SQLite：${pending.join('、')} 仍未导入，扫描结果不可信。`
+        + `请重启对应 bot 的 daemon（botmux restart）完成一次性导入。`,
+      );
+    }
   }
   return matches;
 }

--- a/src/services/sqlite-compat.ts
+++ b/src/services/sqlite-compat.ts
@@ -83,6 +83,40 @@ function wrapBunDatabase(db: {
   };
 }
 
+/**
+ * Load `node:sqlite` WITHOUT letting Node print its experimental warning.
+ *
+ * On Node 22 (the version CI and most installs run) the first load of
+ * `node:sqlite` emits
+ *   `(node:PID) ExperimentalWarning: SQLite is an experimental feature …`
+ * plus a "use --trace-warnings" line, on STDERR. Node 24 no longer does, which
+ * is why this went unnoticed on a 24 dev box.
+ *
+ * For a daemon that is one stray log line. For the CLI it is a real defect: the
+ * two lines land in the middle of a full-screen TUI (`botmux list` runs on the
+ * alternate screen — the warning scrolls the pinned header off the top), and
+ * they pollute the stderr of every agent-facing `botmux` command that touches
+ * the session store. Adding a `process.on('warning')` listener does NOT stop
+ * it — Node's default printer runs regardless — so the emit itself has to be
+ * filtered, narrowly and only for the duration of this require.
+ */
+function requireNodeSqlite(require: NodeRequire): unknown {
+  const originalEmitWarning = process.emitWarning;
+  process.emitWarning = function patchedEmitWarning(warning: unknown, ...rest: unknown[]): void {
+    const text = typeof warning === 'string' ? warning : (warning as Error | undefined)?.message ?? '';
+    const type = typeof rest[0] === 'string'
+      ? rest[0]
+      : (rest[0] as { type?: string } | undefined)?.type;
+    if (type === 'ExperimentalWarning' && /\bSQLite\b/i.test(text)) return;
+    (originalEmitWarning as (...a: unknown[]) => void).call(process, warning, ...rest);
+  } as typeof process.emitWarning;
+  try {
+    return require('node:sqlite');
+  } finally {
+    process.emitWarning = originalEmitWarning;
+  }
+}
+
 function openWithLoadedEngine(path: string, opts: OpenOptions = {}): DatabaseSyncLike {
   const require = createRequire(import.meta.url);
   if (isBunRuntime()) {
@@ -90,7 +124,9 @@ function openWithLoadedEngine(path: string, opts: OpenOptions = {}): DatabaseSyn
     const db = opts.readOnly ? new Database(path, { readonly: true }) : new Database(path);
     return wrapBunDatabase(db as never);
   }
-  const { DatabaseSync } = require('node:sqlite');
+  const { DatabaseSync } = requireNodeSqlite(require) as {
+    DatabaseSync: new (path: string, options?: { readOnly?: boolean }) => unknown;
+  };
   const db = opts.readOnly ? new DatabaseSync(path, { readOnly: true }) : new DatabaseSync(path);
   return db as unknown as DatabaseSyncLike;
 }
@@ -104,7 +140,7 @@ export function sqliteEngineAvailable(): boolean {
       require('bun:sqlite');
       return true;
     }
-    require('node:sqlite');
+    requireNodeSqlite(require);
     return true;
   } catch {
     return false;

--- a/src/services/whiteboard-store.ts
+++ b/src/services/whiteboard-store.ts
@@ -6,6 +6,7 @@ import { config } from '../config.js';
 import { readGlobalConfig } from '../global-config.js';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { withFileLockSync } from '../utils/file-lock.js';
+import { loadAllSessionsSnapshot, mutateSessionRowOffline } from './session-store.js';
 
 export type WhiteboardScope = 'chat' | 'project' | 'custom';
 
@@ -420,24 +421,43 @@ export function appendLog(id: string, entry: { kind: string; actor?: string; to?
   });
 }
 
+/**
+ * Drop a deleted board's id from every session row that still points at it.
+ *
+ * Goes through the session store's offline API. It used to enumerate
+ * `sessions*.json` and rewrite whole files by hand — a second writer outside
+ * the store's single gate, which silently became a no-op the moment the rows
+ * moved into SQLite (the scan simply found no matching files, so
+ * `clearedSessions` reported 0 while every row kept its stale binding).
+ *
+ * `deleteWhiteboard` runs in the dashboard process, which owns no session
+ * store, so the offline row mutation is the correct entry point. A store that
+ * cannot be reached (unreadable, or a bot that has not migrated yet) skips
+ * that one session instead of failing the whole delete.
+ */
 function clearSessionWhiteboardRefs(id: string): number {
+  const dataDir = config.session.dataDir;
+  let snapshot: Map<string, { sessionId: string; larkAppId?: string; whiteboardId?: string }>;
+  try {
+    snapshot = loadAllSessionsSnapshot({ dataDir }) as unknown as Map<string, {
+      sessionId: string; larkAppId?: string; whiteboardId?: string;
+    }>;
+  } catch { return 0; }
   let cleared = 0;
-  let files: string[] = [];
-  try { files = readdirSync(config.session.dataDir); } catch { return 0; }
-  for (const file of files) {
-    if (!file.startsWith('sessions') || !file.endsWith('.json')) continue;
-    const fp = join(config.session.dataDir, file);
-    let data: Record<string, any>;
-    try { data = JSON.parse(readFileSync(fp, 'utf-8')); } catch { continue; }
-    let dirty = false;
-    for (const session of Object.values(data)) {
-      if (session && typeof session === 'object' && session.whiteboardId === id) {
-        delete session.whiteboardId;
-        dirty = true;
-        cleared++;
-      }
-    }
-    if (dirty) atomicWriteFileSync(fp, JSON.stringify(data, null, 2) + '\n');
+  for (const session of snapshot.values()) {
+    if (session?.whiteboardId !== id) continue;
+    try {
+      const published = mutateSessionRowOffline(
+        { sessionId: session.sessionId, larkAppId: session.larkAppId },
+        (current) => {
+          if ((current as { whiteboardId?: string }).whiteboardId !== id) return false;
+          (current as { whiteboardId?: string }).whiteboardId = undefined;
+          return true;
+        },
+        { dataDir },
+      );
+      if (published && (published as { whiteboardId?: string }).whiteboardId === undefined) cleared++;
+    } catch { /* unreachable store → leave this row alone */ }
   }
   return cleared;
 }

--- a/src/services/whiteboard-store.ts
+++ b/src/services/whiteboard-store.ts
@@ -437,8 +437,9 @@ const UNBIND_IPC_TIMEOUT_MS = 5_000;
 
 /** `cleared` — this call removed the binding. `already_changed` — the row no
  *  longer pointed at this board (someone rebound it first); nothing to do.
- *  `unresolved` — the owning daemon is reachable-but-unusable, so the row was
- *  deliberately left alone rather than written behind a live cache. */
+ *  `unresolved` — the row was deliberately left alone: the owning daemon was
+ *  visible but unusable (writing behind its live cache is not allowed), or the
+ *  row was gone by the time the write ran. */
 type UnbindOutcome = 'cleared' | 'already_changed' | 'unresolved';
 
 /**
@@ -528,11 +529,12 @@ async function clearSessionWhiteboardRefs(
 }
 
 /**
- * `unresolvedSessions` counts rows whose binding could NOT be cleared because
- * their owning daemon was visible but unusable. Those rows are not corrupt:
- * the binding points at a board that no longer exists, and the daemon's
- * `ensureSessionWhiteboard` replaces it on the session's next turn. The count
- * is reported so a caller can say so instead of showing a bare `0`.
+ * `unresolvedSessions` counts rows this call could NOT clear — the owning
+ * daemon was visible but its IPC was unusable, or the row vanished between the
+ * snapshot and the write. Those rows are not corrupt: the binding points at a
+ * board that no longer exists, and the daemon's `ensureSessionWhiteboard`
+ * replaces it on the session's next turn. The count exists so a caller can say
+ * that instead of reporting a bare `clearedSessions: 0`.
  */
 export async function deleteWhiteboard(
   id: string,

--- a/src/services/whiteboard-store.ts
+++ b/src/services/whiteboard-store.ts
@@ -6,6 +6,8 @@ import { config } from '../config.js';
 import { readGlobalConfig } from '../global-config.js';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { withFileLockSync } from '../utils/file-lock.js';
+import { fetchDaemonIpc, loadDaemonIpcSecret } from '../core/daemon-ipc-auth.js';
+import { findOnlineDaemon } from '../utils/daemon-discovery.js';
 import { loadAllSessionsSnapshot, mutateSessionRowOffline } from './session-store.js';
 
 export type WhiteboardScope = 'chat' | 'project' | 'custom';
@@ -421,50 +423,87 @@ export function appendLog(id: string, entry: { kind: string; actor?: string; to?
   });
 }
 
+type SessionWhiteboardRef = {
+  sessionId: string;
+  larkAppId?: string;
+  whiteboardId?: string;
+};
+
+/** Daemon running: IPC so the in-memory row is the one that persists.
+ *  Daemon down: locked offline write, aborted if a daemon appears mid-flight. */
+async function unbindSessionWhiteboard(
+  session: SessionWhiteboardRef,
+  boardId: string,
+  dataDir: string,
+): Promise<boolean> {
+  const larkAppId = session.larkAppId;
+  if (larkAppId) {
+    try {
+      const daemon = findOnlineDaemon(larkAppId);
+      if (daemon) {
+        const res = await fetchDaemonIpc(
+          daemon.ipcPort,
+          `/api/sessions/${encodeURIComponent(session.sessionId)}/whiteboard`,
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ whiteboardId: null }),
+          },
+          loadDaemonIpcSecret(),
+        );
+        if (res.ok) return true;
+      }
+    } catch { /* fall through to offline write */ }
+  }
+  const published = mutateSessionRowOffline(
+    { sessionId: session.sessionId, ...(larkAppId ? { larkAppId } : {}) },
+    (current) => {
+      if ((current as SessionWhiteboardRef).whiteboardId !== boardId) return false;
+      (current as SessionWhiteboardRef).whiteboardId = undefined;
+      return true;
+    },
+    {
+      dataDir,
+      ...(larkAppId
+        ? {
+            abortIf: () => {
+              try { return !!findOnlineDaemon(larkAppId); } catch { return false; }
+            },
+          }
+        : {}),
+    },
+  );
+  return !!published && (published as SessionWhiteboardRef).whiteboardId === undefined;
+}
+
 /**
  * Drop a deleted board's id from every session row that still points at it.
  *
- * Goes through the session store's offline API. It used to enumerate
- * `sessions*.json` and rewrite whole files by hand — a second writer outside
- * the store's single gate, which silently became a no-op the moment the rows
- * moved into SQLite (the scan simply found no matching files, so
- * `clearedSessions` reported 0 while every row kept its stale binding).
- *
- * `deleteWhiteboard` runs in the dashboard process, which owns no session
- * store, so the offline row mutation is the correct entry point. A store that
- * cannot be reached (unreadable, or a bot that has not migrated yet) skips
- * that one session instead of failing the whole delete.
+ * Used to enumerate `sessions*.json` and rewrite whole files — a second writer
+ * outside the store gate, and a no-op once rows moved into SQLite. Now: if the
+ * owning daemon is running, clear via IPC (the daemon's cache is authoritative);
+ * if not, `mutateSessionRowOffline` with `abortIf` so a daemon that appears
+ * mid-flight is not raced. Unreadable stores skip that one session.
  */
-function clearSessionWhiteboardRefs(id: string): number {
+async function clearSessionWhiteboardRefs(id: string): Promise<number> {
   const dataDir = config.session.dataDir;
-  let snapshot: Map<string, { sessionId: string; larkAppId?: string; whiteboardId?: string }>;
+  let snapshot: Map<string, SessionWhiteboardRef>;
   try {
-    snapshot = loadAllSessionsSnapshot({ dataDir }) as unknown as Map<string, {
-      sessionId: string; larkAppId?: string; whiteboardId?: string;
-    }>;
+    snapshot = loadAllSessionsSnapshot({ dataDir }) as unknown as Map<string, SessionWhiteboardRef>;
   } catch { return 0; }
   let cleared = 0;
   for (const session of snapshot.values()) {
     if (session?.whiteboardId !== id) continue;
     try {
-      const published = mutateSessionRowOffline(
-        { sessionId: session.sessionId, larkAppId: session.larkAppId },
-        (current) => {
-          if ((current as { whiteboardId?: string }).whiteboardId !== id) return false;
-          (current as { whiteboardId?: string }).whiteboardId = undefined;
-          return true;
-        },
-        { dataDir },
-      );
-      if (published && (published as { whiteboardId?: string }).whiteboardId === undefined) cleared++;
+      if (await unbindSessionWhiteboard(session, id, dataDir)) cleared++;
     } catch { /* unreachable store → leave this row alone */ }
   }
   return cleared;
 }
 
-export function deleteWhiteboard(id: string): { ok: true; id: string; clearedSessions: number } {
+export async function deleteWhiteboard(id: string): Promise<{ ok: true; id: string; clearedSessions: number }> {
   const clean = safeId(id);
-  return withIndexLock(() => {
+  withIndexLock(() => {
     const index = readIndex();
     delete index.boards[clean];
     for (const [key, boardId] of Object.entries(index.bindings)) {
@@ -478,10 +517,10 @@ export function deleteWhiteboard(id: string): { ok: true; id: string; clearedSes
     // sessions at a missing board.md. Index-first means a crash can at worst
     // leave an orphaned dir with no index entry (harmless), never a ghost.
     writeIndex(index);
-    const clearedSessions = clearSessionWhiteboardRefs(clean);
     rmSync(boardDir(clean), { recursive: true, force: true });
-    return { ok: true, id: clean, clearedSessions };
   });
+  const clearedSessions = await clearSessionWhiteboardRefs(clean);
+  return { ok: true, id: clean, clearedSessions };
 }
 
 export function whiteboardPath(id: string): { dir: string; board: string; log: string; meta: string } {

--- a/src/services/whiteboard-store.ts
+++ b/src/services/whiteboard-store.ts
@@ -8,7 +8,8 @@ import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { withFileLockSync } from '../utils/file-lock.js';
 import { fetchDaemonIpc, loadDaemonIpcSecret } from '../core/daemon-ipc-auth.js';
 import { findOnlineDaemon } from '../utils/daemon-discovery.js';
-import { loadAllSessionsSnapshot, mutateSessionRowOffline } from './session-store.js';
+import { loadAllSessionsSnapshot } from './session-store.js';
+import { mutateSessionRowWhenUnowned } from './session-offline-write.js';
 
 export type WhiteboardScope = 'chat' | 'project' | 'custom';
 
@@ -429,17 +430,39 @@ type SessionWhiteboardRef = {
   whiteboardId?: string;
 };
 
-/** Daemon running: IPC so the in-memory row is the one that persists.
- *  Daemon down: locked offline write, aborted if a daemon appears mid-flight. */
+/** A loopback daemon that answers its heartbeat but not its socket must not
+ *  hold the caller's HTTP request open. Generous for a same-host call, short
+ *  enough that a wedged daemon degrades to the offline path. */
+const UNBIND_IPC_TIMEOUT_MS = 5_000;
+
+/** `cleared` — this call removed the binding. `already_changed` — the row no
+ *  longer pointed at this board (someone rebound it first); nothing to do.
+ *  `unresolved` — the owning daemon is reachable-but-unusable, so the row was
+ *  deliberately left alone rather than written behind a live cache. */
+type UnbindOutcome = 'cleared' | 'already_changed' | 'unresolved';
+
+/**
+ * Clear one session's binding to a board that is being deleted.
+ *
+ * Daemon up: send the command, so the row that persists is the daemon's own.
+ * Daemon down: publish the row here, under the store's write exclusion and the
+ * liveness re-probe in {@link mutateSessionRowWhenUnowned}.
+ *
+ * Both paths are compare-and-set against `boardId`. Deletion has already
+ * removed the board from the index by the time this runs, so the daemon's
+ * `ensureSessionWhiteboard` will mint a REPLACEMENT board for the session on
+ * its very next turn — an unconditional clear would drop that fresh binding
+ * and orphan the board the daemon just created.
+ */
 async function unbindSessionWhiteboard(
   session: SessionWhiteboardRef,
   boardId: string,
   dataDir: string,
-): Promise<boolean> {
+): Promise<UnbindOutcome> {
   const larkAppId = session.larkAppId;
   if (larkAppId) {
     try {
-      const daemon = findOnlineDaemon(larkAppId);
+      const daemon = findOnlineDaemon(larkAppId, dataDir);
       if (daemon) {
         const res = await fetchDaemonIpc(
           daemon.ipcPort,
@@ -447,61 +470,73 @@ async function unbindSessionWhiteboard(
           {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ whiteboardId: null }),
+            body: JSON.stringify({ whiteboardId: null, expectWhiteboardId: boardId }),
+            signal: AbortSignal.timeout(UNBIND_IPC_TIMEOUT_MS),
           },
           loadDaemonIpcSecret(),
         );
-        if (res.ok) return true;
+        // 409 is the daemon reporting a different binding — authoritative, and
+        // not something the offline path should try to overrule.
+        if (res.status === 409) return 'already_changed';
+        if (res.ok) return 'cleared';
       }
-    } catch { /* fall through to offline write */ }
+    } catch { /* fall through: the re-probe below decides whether we may write */ }
   }
-  const published = mutateSessionRowOffline(
+  let changed = false;
+  const published = mutateSessionRowWhenUnowned(
     { sessionId: session.sessionId, ...(larkAppId ? { larkAppId } : {}) },
     (current) => {
-      if ((current as SessionWhiteboardRef).whiteboardId !== boardId) return false;
-      (current as SessionWhiteboardRef).whiteboardId = undefined;
+      const row = current as unknown as SessionWhiteboardRef;
+      if (row.whiteboardId !== boardId) return false;
+      row.whiteboardId = undefined;
+      changed = true;
       return true;
     },
-    {
-      dataDir,
-      ...(larkAppId
-        ? {
-            abortIf: () => {
-              try { return !!findOnlineDaemon(larkAppId); } catch { return false; }
-            },
-          }
-        : {}),
-    },
+    { dataDir },
   );
-  return !!published && (published as SessionWhiteboardRef).whiteboardId === undefined;
+  if (!published) return 'unresolved';
+  return changed ? 'cleared' : 'already_changed';
 }
 
 /**
  * Drop a deleted board's id from every session row that still points at it.
  *
  * Used to enumerate `sessions*.json` and rewrite whole files — a second writer
- * outside the store gate, and a no-op once rows moved into SQLite. Now: if the
- * owning daemon is running, clear via IPC (the daemon's cache is authoritative);
- * if not, `mutateSessionRowOffline` with `abortIf` so a daemon that appears
- * mid-flight is not raced. Unreadable stores skip that one session.
+ * outside the store gate, and a no-op once rows moved into SQLite. Now it goes
+ * through {@link unbindSessionWhiteboard} per row. A store this process cannot
+ * read skips that one session.
  */
-async function clearSessionWhiteboardRefs(id: string): Promise<number> {
+async function clearSessionWhiteboardRefs(
+  id: string,
+): Promise<{ cleared: number; unresolved: number }> {
   const dataDir = config.session.dataDir;
   let snapshot: Map<string, SessionWhiteboardRef>;
   try {
     snapshot = loadAllSessionsSnapshot({ dataDir }) as unknown as Map<string, SessionWhiteboardRef>;
-  } catch { return 0; }
+  } catch { return { cleared: 0, unresolved: 0 }; }
   let cleared = 0;
+  let unresolved = 0;
   for (const session of snapshot.values()) {
     if (session?.whiteboardId !== id) continue;
-    try {
-      if (await unbindSessionWhiteboard(session, id, dataDir)) cleared++;
-    } catch { /* unreachable store → leave this row alone */ }
+    let outcome: UnbindOutcome;
+    try { outcome = await unbindSessionWhiteboard(session, id, dataDir); }
+    catch { outcome = 'unresolved'; }
+    if (outcome === 'cleared') cleared++;
+    else if (outcome === 'unresolved') unresolved++;
   }
-  return cleared;
+  return { cleared, unresolved };
 }
 
-export async function deleteWhiteboard(id: string): Promise<{ ok: true; id: string; clearedSessions: number }> {
+/**
+ * `unresolvedSessions` counts rows whose binding could NOT be cleared because
+ * their owning daemon was visible but unusable. Those rows are not corrupt:
+ * the binding points at a board that no longer exists, and the daemon's
+ * `ensureSessionWhiteboard` replaces it on the session's next turn. The count
+ * is reported so a caller can say so instead of showing a bare `0`.
+ */
+export async function deleteWhiteboard(
+  id: string,
+): Promise<{ ok: true; id: string; clearedSessions: number; unresolvedSessions: number }> {
   const clean = safeId(id);
   withIndexLock(() => {
     const index = readIndex();
@@ -519,8 +554,10 @@ export async function deleteWhiteboard(id: string): Promise<{ ok: true; id: stri
     writeIndex(index);
     rmSync(boardDir(clean), { recursive: true, force: true });
   });
-  const clearedSessions = await clearSessionWhiteboardRefs(clean);
-  return { ok: true, id: clean, clearedSessions };
+  // Outside the index lock: unbinding awaits daemon IPC, and the lock is
+  // synchronous. Nothing here reads the index.
+  const { cleared, unresolved } = await clearSessionWhiteboardRefs(clean);
+  return { ok: true, id: clean, clearedSessions: cleared, unresolvedSessions: unresolved };
 }
 
 export function whiteboardPath(id: string): { dir: string; board: string; log: string; meta: string } {

--- a/src/utils/daemon-discovery.ts
+++ b/src/utils/daemon-discovery.ts
@@ -29,8 +29,11 @@ export interface OnlineDaemonInfo {
 
 const STALE_MS = 90_000;
 
-function registryDir(): string {
-  return join(resolveBotmuxDataDir(), 'dashboard-daemons');
+/** `dataDir` lets a caller that already resolved a data dir keep the daemon
+ *  probe and its store access on the SAME directory. Omitting it falls back to
+ *  the process-wide resolution, which is what every host-CLI caller wants. */
+function registryDir(dataDir?: string): string {
+  return join(dataDir ?? resolveBotmuxDataDir(), 'dashboard-daemons');
 }
 
 /** Parse a loopback daemon IPC port from a descriptor or injected env value. */
@@ -58,8 +61,8 @@ export function resolveDaemonIpcPort(
 }
 
 /** List every daemon whose descriptor file is fresh (heartbeat within STALE_MS). */
-export function listOnlineDaemons(): OnlineDaemonInfo[] {
-  const dir = registryDir();
+export function listOnlineDaemons(dataDir?: string): OnlineDaemonInfo[] {
+  const dir = registryDir(dataDir);
   if (!existsSync(dir)) return [];
   const now = Date.now();
   const out: OnlineDaemonInfo[] = [];
@@ -92,6 +95,6 @@ export function listOnlineDaemons(): OnlineDaemonInfo[] {
 }
 
 /** Find a specific online daemon by larkAppId. Returns null if offline / not found. */
-export function findOnlineDaemon(larkAppId: string): OnlineDaemonInfo | null {
-  return listOnlineDaemons().find(d => d.larkAppId === larkAppId) ?? null;
+export function findOnlineDaemon(larkAppId: string, dataDir?: string): OnlineDaemonInfo | null {
+  return listOnlineDaemons(dataDir).find(d => d.larkAppId === larkAppId) ?? null;
 }

--- a/test/api-only-cli-gate.behavior.test.ts
+++ b/test/api-only-cli-gate.behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 import { execFileSync } from 'node:child_process';
 import { resolve, join } from 'node:path';
 import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
@@ -23,10 +24,11 @@ const VIRTUAL_SID = 'sess_behavior_virtual';
 const REAL_SID = 'sess_behavior_real';
 
 function writeSession(sid: string, chatId: string, larkAppId: string) {
-  const fp = join(DATA_DIR, 'sessions.json');
-  const existing = existsSync(fp) ? JSON.parse(readFileSync(fp, 'utf8')) : [];
-  existing.push({ sessionId: sid, chatId, larkAppId, rootMessageId: '', scope: 'chat', status: 'active' });
-  writeFileSync(fp, JSON.stringify(existing));
+  // 会话行只有 SQLite 一种持久层，且按 larkAppId 分库；旧夹具往单个
+  // sessions.json 里 push 数组的写法（靠 JSON 读侧容忍数组形状）已不适用。
+  seedPersistedSessionRows(DATA_DIR, larkAppId, {
+    [sid]: { sessionId: sid, chatId, larkAppId, rootMessageId: '', scope: 'chat', status: 'active' },
+  });
 }
 
 /** Put a marker at THIS process's pid so a spawned child (whose ppid == our pid)

--- a/test/bots-list-cred-registration.test.ts
+++ b/test/bots-list-cred-registration.test.ts
@@ -19,6 +19,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 import { spawnTsScript } from './helpers/ts-runner.js';
 
 const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
@@ -47,7 +48,7 @@ function runCli(args: string[], env: NodeJS.ProcessEnv) {
   });
 }
 
-/** Read-isolated layout: per-bot session file + send-cred inside BOT_HOME, NO bots.json. */
+/** Read-isolated layout: per-bot session store + send-cred inside BOT_HOME, NO bots.json. */
 function seedIsolatedBot(): { home: string; dataDir: string } {
   const root = mkdtempSync(join(tmpdir(), 'botmux-bots-list-cred-'));
   tempDirs.push(root);
@@ -57,7 +58,9 @@ function seedIsolatedBot(): { home: string; dataDir: string } {
   mkdirSync(dataDir, { recursive: true });
   mkdirSync(botHome, { recursive: true });
 
-  writeFileSync(join(dataDir, `sessions-${APP_ID}.json`), JSON.stringify({
+  // The bot's real session store: `session-stores/<appId>/sessions.db`, the only
+  // engine the CLI reads at runtime.
+  seedPersistedSessionRows(dataDir, APP_ID, {
     [SESSION_ID]: {
       sessionId: SESSION_ID,
       chatId: 'oc_isolated_roster_chat',
@@ -69,7 +72,7 @@ function seedIsolatedBot(): { home: string; dataDir: string } {
       createdAt: '2026-01-01T00:00:00.000Z',
       larkAppId: APP_ID,
     },
-  }));
+  });
 
   // The only credential source available to an isolated bot.
   writeFileSync(join(botHome, 'send-cred.json'), JSON.stringify({

--- a/test/cli-list-riff.test.ts
+++ b/test/cli-list-riff.test.ts
@@ -19,11 +19,12 @@
  * kept OUT of every other column (title, session id, working dir), so a matched
  * substring can only have come from the target label the fix produces.
  */
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { readPersistedSessionRows, seedPersistedSessionRows } from './helpers/session-store-disk.js';
 import { spawnTsScript } from './helpers/ts-runner.js';
 
 const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
@@ -64,11 +65,15 @@ function makeSession(sessionId: string, overrides: Partial<StoredSession> = {}):
   };
 }
 
-function writeSessions(dataDir: string, sessions: StoredSession[]): string {
-  mkdirSync(dataDir, { recursive: true });
-  const path = join(dataDir, `sessions-${APP_ID}.json`);
-  writeFileSync(path, JSON.stringify(Object.fromEntries(sessions.map(s => [s.sessionId, s]))));
-  return path;
+/** Seed the bot's real session store (`session-stores/<appId>/sessions.db`) —
+ *  the only engine the CLI reads at runtime. */
+function writeSessions(dataDir: string, sessions: StoredSession[]): void {
+  seedPersistedSessionRows(dataDir, APP_ID, Object.fromEntries(sessions.map(s => [s.sessionId, s])));
+}
+
+/** Read the seeded store back to prove `list` did not mutate/prune any row. */
+function readSessions(dataDir: string): Record<string, StoredSession> {
+  return readPersistedSessionRows(dataDir, APP_ID) as Record<string, StoredSession>;
 }
 
 function runList(
@@ -113,7 +118,7 @@ describe('botmux list — active Riff session', () => {
       backendType: 'riff',
       // No persistentBackendTarget on purpose: Riff has no local backing pane.
     });
-    const sessionsPath = writeSessions(dataDir, [session]);
+    writeSessions(dataDir, [session]);
 
     const result = await runList(dataDir, homeDir);
 
@@ -126,7 +131,7 @@ describe('botmux list — active Riff session', () => {
     expect(result.stdout).toContain('riff');
 
     // list is a READ command: the active record must survive untouched.
-    const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+    const stored = readSessions(dataDir);
     expect(stored[session.sessionId]).toBeDefined();
     expect(stored[session.sessionId].status).toBe('active');
     expect(stored[session.sessionId].backendType).toBe('riff');
@@ -152,7 +157,7 @@ describe('botmux list — active Riff session', () => {
       title: 'row-gamma',
       cliId: 'codex',
     });
-    const sessionsPath = writeSessions(dataDir, [riff, pty, legacy]);
+    writeSessions(dataDir, [riff, pty, legacy]);
 
     const result = await runList(dataDir, homeDir);
 
@@ -168,7 +173,7 @@ describe('botmux list — active Riff session', () => {
     expect(result.stdout).toContain('pty');
 
     // None of the three real managed sessions may be pruned or mutated by list.
-    const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+    const stored = readSessions(dataDir);
     for (const s of [riff, pty, legacy]) {
       expect(stored[s.sessionId]).toBeDefined();
       expect(stored[s.sessionId].status).toBe('active');

--- a/test/cli-persistent-backend-target.test.ts
+++ b/test/cli-persistent-backend-target.test.ts
@@ -19,6 +19,10 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import { spawnTsScript } from './helpers/ts-runner.js';
+import {
+  readPersistedSessionRows,
+  seedPersistedSessionRows,
+} from './helpers/session-store-disk.js';
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = join(TEST_DIR, '..', 'src', 'cli.ts');
@@ -46,11 +50,18 @@ afterEach(() => {
   }
 });
 
+/**
+ * The CLI runs without `BOTMUX_LARK_APP_ID`, so its rows live in the legacy
+ * flat store (`<dataDir>/sessions.db`), not a per-bot one.
+ */
+function storedSession(dataDir: string, sessionId: string): Record<string, any> {
+  return readPersistedSessionRows(dataDir)[sessionId];
+}
+
 function makeFixture(): {
   dataDir: string;
   binDir: string;
   logPath: string;
-  sessionPath: string;
   session: StoredSession;
 } {
   const root = mkdtempSync(join(tmpdir(), 'botmux-cli-target-'));
@@ -76,8 +87,7 @@ function makeFixture(): {
       agentName: 'agent-a',
     },
   };
-  const sessionPath = join(dataDir, 'sessions.json');
-  writeFileSync(sessionPath, JSON.stringify({ [session.sessionId]: session }));
+  seedPersistedSessionRows(dataDir, undefined, { [session.sessionId]: session });
 
   const fakeHerdr = join(binDir, 'herdr');
   writeFileSync(fakeHerdr, `#!/usr/bin/env node
@@ -94,7 +104,7 @@ if (args.join(' ') === 'session list --json') {
 `);
   chmodSync(fakeHerdr, 0o755);
 
-  return { dataDir, binDir, logPath, sessionPath, session };
+  return { dataDir, binDir, logPath, session };
 }
 
 function runCli(
@@ -145,7 +155,7 @@ describe('CLI persisted backend targets', () => {
     expect(result.stdout).toContain('shared-herdr-target');
     expect(result.stdout).toContain('herdr: work/agent-a');
     expect(readLog(fixture.logPath)).toContainEqual(['--session', 'work', 'agent', 'list']);
-    expect(JSON.parse(readFileSync(fixture.sessionPath, 'utf8'))[fixture.session.sessionId].status).toBe('active');
+    expect(storedSession(fixture.dataDir, fixture.session.sessionId).status).toBe('active');
   });
 
   it('offline delete closes only the persisted Herdr agent, never a derived whole session', async () => {
@@ -159,7 +169,7 @@ describe('CLI persisted backend targets', () => {
     expect(calls).toContainEqual(['--session', 'work', 'pane', 'close', 'pane-shared']);
     expect(calls.some(args => args.includes('bmx-abcdef12'))).toBe(false);
     expect(calls.some(args => args[0] === 'session' && (args[1] === 'stop' || args[1] === 'delete'))).toBe(false);
-    expect(JSON.parse(readFileSync(fixture.sessionPath, 'utf8'))[fixture.session.sessionId].status).toBe('closed');
+    expect(storedSession(fixture.dataDir, fixture.session.sessionId).status).toBe('closed');
   });
 
   it('keeps an offline ZMX session active when exact ownership cannot be proved', async () => {
@@ -173,8 +183,7 @@ describe('CLI persisted backend targets', () => {
 
     const sessionId = 'abcdef12-1111-2222-3333-444444444444';
     const sessionName = 'bmx-abcdef12';
-    const sessionPath = join(dataDir, 'sessions.json');
-    writeFileSync(sessionPath, JSON.stringify({
+    seedPersistedSessionRows(dataDir, undefined, {
       [sessionId]: {
         sessionId,
         chatId: 'oc_zmx_target',
@@ -189,7 +198,7 @@ describe('CLI persisted backend targets', () => {
           sessionName,
         },
       },
-    }));
+    });
 
     const fakeZmx = join(binDir, 'zmx');
     writeFileSync(fakeZmx, `#!/usr/bin/env node
@@ -228,7 +237,7 @@ if (args.join(' ') === 'list --short') {
     expect(result.stdout).toContain('已关闭 0 个会话');
     const calls = readLog(logPath);
     expect(calls.some(args => args[0] === 'kill')).toBe(false);
-    const stored = JSON.parse(readFileSync(sessionPath, 'utf8'))[sessionId];
+    const stored = storedSession(dataDir, sessionId);
     expect(stored.status).toBe('active');
     expect(stored.closedAt).toBeUndefined();
   });

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { spawnSyncTsScript, spawnTsScript } from './helpers/ts-runner.js';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 import { startOutboxWatcher } from '../src/adapters/backend/sandbox.js';
 import {
   managedOriginCapabilityPath,
@@ -183,7 +184,7 @@ describe('cmdSend hook context wiring', () => {
   it('does not promote detached spawn-time turn env while durable output is unsettled', () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'botmux-send-stale-origin-'));
     try {
-      writeFileSync(join(dataDir, 'sessions-app-a.json'), JSON.stringify({
+      seedPersistedSessionRows(dataDir, 'app-a', {
         origin: {
           sessionId: 'origin',
           chatId: 'oc_origin',
@@ -210,7 +211,7 @@ describe('cmdSend hook context wiring', () => {
           createdAt: new Date(0).toISOString(),
           larkAppId: 'app-a',
         },
-      }));
+      });
       const result = spawnSyncTsScript(
         join(__dirname, '..', 'src', 'cli.ts'),
         ['send', 'must-not-leak', '--session-id', 'destination', '--no-mention'],
@@ -261,13 +262,13 @@ describe('cmdSend hook context wiring', () => {
       content: 'prompt',
       deliverySink: 'lark',
     }];
-    writeFileSync(join(dataDir, 'sessions-app-a.json'), JSON.stringify({
+    seedPersistedSessionRows(dataDir, 'app-a', {
       session: {
         sessionId: 'session', chatId: 'oc_chat', rootMessageId: 'om_root',
         title: 'read isolated', status: 'active', createdAt: new Date(0).toISOString(),
         larkAppId: 'app-a', cliId: 'codex-app', codexAppDispatchLedger: ledger,
       },
-    }));
+    });
     const fixture = join(root, 'host-send.mjs');
     writeFileSync(fixture, `
       import { readFileSync } from 'node:fs';
@@ -400,7 +401,7 @@ describe('cmdSend hook context wiring', () => {
         turnId: 'turn-stale', dispatchAttempt: 9,
       }),
     );
-    writeFileSync(join(dataDir, 'sessions-app-a.json'), JSON.stringify({
+    seedPersistedSessionRows(dataDir, 'app-a', {
       session: {
         sessionId: 'session', chatId: 'oc_chat', rootMessageId: 'om_root',
         title: 'host', status: 'active', createdAt: new Date(0).toISOString(),
@@ -410,7 +411,7 @@ describe('cmdSend hook context wiring', () => {
           state: 'prepared', content: 'prompt', deliverySink: 'http_wait',
         }],
       },
-    }));
+    });
     try {
       const result = await runCli(
         ['send', 'must not relay', '--session-id', 'session', '--no-mention'],
@@ -434,13 +435,13 @@ describe('cmdSend hook context wiring', () => {
 
   it('rejects a trusted host re-exec when its authorized Codex App ledger was already settled', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'botmux-send-host-ledger-gone-'));
-    writeFileSync(join(dataDir, 'sessions-app-a.json'), JSON.stringify({
+    seedPersistedSessionRows(dataDir, 'app-a', {
       session: {
         sessionId: 'session', chatId: 'oc_chat', rootMessageId: 'om_root',
         title: 'settled', status: 'active', createdAt: new Date(0).toISOString(),
         larkAppId: 'app-a', cliId: 'codex-app', pid: process.pid,
       },
-    }));
+    });
     try {
       const result = await runCli(
         ['send', 'must not downgrade', '--session-id', 'session', '--no-mention'],

--- a/test/current-turn-provenance.test.ts
+++ b/test/current-turn-provenance.test.ts
@@ -8,6 +8,7 @@ import {
   resolveCurrentTurnProvenance,
 } from '../src/core/current-turn-provenance.js';
 import { readProcessStartIdentity } from '../src/core/session-marker.js';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 
 const SCHED_TASK_ID = 'abcdef12';
 const SCHED_TURN_ID = `schedule:${SCHED_TASK_ID}:12345678-1234-1234-1234-123456789abc`;
@@ -53,10 +54,9 @@ describe('resolveCurrentTurnProvenance', () => {
       quoteTargetId: 'turn-current',
       ...overrides,
     };
-    writeFileSync(
-      join(dataDir, 'sessions-cli_real.json'),
-      JSON.stringify({ [session.sessionId]: session }),
-    );
+    // The durable session record lives in the per-bot SQLite store; the frozen
+    // `sessions-<appId>.json` is only an import source and is never read here.
+    seedPersistedSessionRows(dataDir, 'cli_real', { [session.sessionId]: session });
   }
 
   function writeScheduledTask(overrides: Record<string, unknown> = {}): void {

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -268,7 +268,7 @@ describe('buildFsPolicy', () => {
     // …and the bot's OWN pre-SQLite `sessions-<self>.json` is NOT granted any more:
     // it is a one-shot import source the store never reads at runtime, so the
     // allow-list stops covering it (narrower surface, not a weakened assertion).
-    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('none');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');     // own（升级窗口内仍是唯一可读的会话来源）
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/turn-sends/s.jsonl').access).toBe('readWrite');        // OWN session marker only
     // blocker #4: turn-sends is granted per-session-FILE, not the whole dir —
     // another session's marker is NOT writable (can't corrupt its send-dedup).
@@ -461,7 +461,7 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db-shm').access).toBe('readOnly');
     // the legacy `sessions-<self>.json` is a one-shot import source, never read at
     // runtime → deliberately NOT granted (was readOnly before the SQLite-only cut)
-    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('none');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');     // own（升级窗口内仍是唯一可读的会话来源）
     // siblings simply not covered under the allow-list → inaccessible
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_other.json').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other').access).toBe('none');
@@ -1608,7 +1608,7 @@ describe('no-Lark-transport credential profile (larkTransportEnabled=false)', ()
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db').access).toBe('readOnly');
     // the legacy `sessions-<self>.json` is no longer allow-listed, so under
     // no-transport it falls back to the frozen ~/.botmux authority deny.
-    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('deny');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');
     // sibling store dirs get no carve-out out of that authority deny either
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other/sessions.db').access).toBe('deny');
     expect(accessForPath(p.rules, '/opt/botmux/dist/cli.js').access).toBe('readOnly');

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -260,9 +260,15 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/dashboard-daemons/cli_x.json').access).toBe('readOnly'); // daemon IPC discovery
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/bots-info.json').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/bot-openids-cli_self.json').access).toBe('readOnly'); // own
-    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');     // own
+    // own session store = the per-bot SQLite DIRECTORY (dir grant, not file binds:
+    // SQLite recreates -wal/-shm, so a pinned inode would read a dead WAL forever)
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db-wal').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self').access).toBe('readOnly');
+    // …and the bot's OWN pre-SQLite `sessions-<self>.json` is NOT granted any more:
+    // it is a one-shot import source the store never reads at runtime, so the
+    // allow-list stops covering it (narrower surface, not a weakened assertion).
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/turn-sends/s.jsonl').access).toBe('readWrite');        // OWN session marker only
     // blocker #4: turn-sends is granted per-session-FILE, not the whole dir —
     // another session's marker is NOT writable (can't corrupt its send-dedup).
@@ -283,7 +289,12 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/schedules.json').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots/cli_other/schedules.json').access).toBe('none'); // sibling store
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_other.json').access).toBe('none');
+    // sibling session stores stay deny-by-default: neither the store DIR nor any
+    // file in it is covered (the grant is scoped to `session-stores/<self>`).
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other/sessions.db').access).toBe('none');
+    // the shared parent is not granted either — no umbrella over every bot's store
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/bot-openids-cli_other.json').access).toBe('none'); // sibling
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots.json').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots/cli_other/send-cred.json').access).toBe('none');
@@ -291,6 +302,7 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/attachments/cli_other/m/f.pdf').access).toBe('none');
     // a file created AFTER spawn (codex #3 fail-open) is ALSO denied — allow-list, not enumeration
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_futureBot.json').access).toBe('none');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_futureBot/sessions.db').access).toBe('none');
   });
 
   it('lark-cli key store: OWN appsecret + master.key readable, siblings denied (verified live: without this `lark-cli auth` fails EPERM)', () => {
@@ -443,10 +455,16 @@ describe('buildFsPolicy', () => {
     const p = buildFsPolicy(ctx());
     expect(accessForPath(p.rules, '/Users/u/proj/src/x.ts').access).toBe('readWrite');
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots/cli_self/claude/x.jsonl').access).toBe('readWrite');
-    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');
+    // own session store: the per-bot SQLite dir (and everything inside it) is ro
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db-shm').access).toBe('readOnly');
+    // the legacy `sessions-<self>.json` is a one-shot import source, never read at
+    // runtime → deliberately NOT granted (was readOnly before the SQLite-only cut)
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('none');
     // siblings simply not covered under the allow-list → inaccessible
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_other.json').access).toBe('none');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other/sessions.db').access).toBe('none');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/attachments/cli_self/m1/f.pdf').access).toBe('readWrite');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/attachments/cli_other/m1/f.pdf').access).toBe('none');
@@ -1586,8 +1604,13 @@ describe('no-Lark-transport credential profile (larkTransportEnabled=false)', ()
     expect(accessForPath(p.rules, '/Users/u/.botmux/.data-dir').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/bin/botmux').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/bots-info.json').access).toBe('readOnly');
-    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('readOnly');
     expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_self/sessions.db').access).toBe('readOnly');
+    // the legacy `sessions-<self>.json` is no longer allow-listed, so under
+    // no-transport it falls back to the frozen ~/.botmux authority deny.
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/sessions-cli_self.json').access).toBe('deny');
+    // sibling store dirs get no carve-out out of that authority deny either
+    expect(accessForPath(p.rules, '/Users/u/.botmux/data/session-stores/cli_other/sessions.db').access).toBe('deny');
     expect(accessForPath(p.rules, '/opt/botmux/dist/cli.js').access).toBe('readOnly');
   });
 

--- a/test/helpers/session-store-disk.ts
+++ b/test/helpers/session-store-disk.ts
@@ -1,59 +1,92 @@
 /**
- * 直接读/改会话行持久层的测试夹具，按运行时的混合窗口规则解析引擎：
- * 「有 .db 用 .db，否则用 .json」。引擎替换后 daemon store 落在 sessions*.db
- * （既有 JSON 冻结），但夹具保持两种引擎都可用，方便混合窗口场景直接播种 JSON。
+ * 直接读/改/播种会话行持久层的测试夹具。会话库只有 SQLite 一种引擎：
+ * per-bot 落在 `session-stores/<appId>/sessions.db`，legacy 无 appId 落在扁平
+ * `sessions.db`。迁移前的 `sessions*.json` 只是**一次性导入源**，播种它请直接
+ * 写文件（见各测试里的 seedJson），不要走本模块。
  */
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
-function storePaths(dataDir: string, appId?: string): { db: string; json: string } {
-  return {
-    db: appId ? join(dataDir, 'session-stores', appId, 'sessions.db') : join(dataDir, 'sessions.db'),
-    json: join(dataDir, appId ? `sessions-${appId}.json` : 'sessions.json'),
-  };
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  row TEXT NOT NULL,
+  chat_id TEXT GENERATED ALWAYS AS (json_extract(row, '$.chatId')) VIRTUAL,
+  root_message_id TEXT GENERATED ALWAYS AS (json_extract(row, '$.rootMessageId')) VIRTUAL,
+  scope TEXT GENERATED ALWAYS AS (json_extract(row, '$.scope')) VIRTUAL
+);
+`;
+
+export function sessionStorePath(dataDir: string, appId?: string): string {
+  return appId
+    ? join(dataDir, 'session-stores', appId, 'sessions.db')
+    : join(dataDir, 'sessions.db');
 }
 
-/** db-else-json 读某个 store 的全部行（键 → 行对象）。 */
-export function readPersistedSessionRows(dataDir: string, appId?: string): Record<string, any> {
-  const { db, json } = storePaths(dataDir, appId);
-  if (existsSync(db)) {
-    const conn = new DatabaseSync(db);
-    try {
-      conn.exec('PRAGMA busy_timeout = 3000');
-      const rows = conn.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
-      return Object.fromEntries(rows.map(r => [r.session_id, JSON.parse(r.row)]));
-    } finally {
-      conn.close();
+function open(path: string, create: boolean): DatabaseSync {
+  if (create) mkdirSync(dirname(path), { recursive: true });
+  const db = new DatabaseSync(path);
+  db.exec('PRAGMA busy_timeout = 3000');
+  if (create) db.exec(SCHEMA_SQL);
+  return db;
+}
+
+/**
+ * 播种一个 store 的若干行（键 → 行对象），模拟「另一个 bot 的 daemon 已经写过盘」。
+ * 键与 `row.sessionId` 可以故意不一致，用来覆盖脏行场景。
+ */
+export function seedPersistedSessionRows(
+  dataDir: string,
+  appId: string | undefined,
+  rows: Record<string, any>,
+): string {
+  const path = sessionStorePath(dataDir, appId);
+  const db = open(path, true);
+  try {
+    const insert = db.prepare(
+      'INSERT OR REPLACE INTO sessions (session_id, status, row) VALUES (?, ?, ?)',
+    );
+    for (const [key, value] of Object.entries(rows)) {
+      insert.run(key, typeof value?.status === 'string' ? value.status : '', JSON.stringify(value));
     }
+  } finally {
+    db.close();
   }
-  return JSON.parse(readFileSync(json, 'utf8'));
+  return path;
 }
 
-/** 模拟「另一个进程」直改持久层里的一行（旧夹具直接改 JSON 文件的等价物）。 */
+/** 读某个 store 的全部行（键 → 行对象）。 */
+export function readPersistedSessionRows(dataDir: string, appId?: string): Record<string, any> {
+  const path = sessionStorePath(dataDir, appId);
+  if (!existsSync(path)) throw new Error(`no session store at ${path}`);
+  const db = open(path, false);
+  try {
+    const rows = db.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
+    return Object.fromEntries(rows.map(r => [r.session_id, JSON.parse(r.row)]));
+  } finally {
+    db.close();
+  }
+}
+
+/** 模拟「另一个进程」直改持久层里的一行。 */
 export function mutatePersistedSessionRow(
   dataDir: string,
   appId: string | undefined,
   sessionId: string,
   mutate: (row: any) => void,
 ): void {
-  const { db, json } = storePaths(dataDir, appId);
-  if (existsSync(db)) {
-    const conn = new DatabaseSync(db);
-    try {
-      conn.exec('PRAGMA busy_timeout = 3000');
-      const hit = conn.prepare('SELECT row FROM sessions WHERE session_id = ?').get(sessionId) as { row: string } | undefined;
-      if (!hit) throw new Error(`no session row ${sessionId} in ${db}`);
-      const row = JSON.parse(hit.row);
-      mutate(row);
-      conn.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
-        .run(typeof row?.status === 'string' ? row.status : '', JSON.stringify(row), sessionId);
-    } finally {
-      conn.close();
-    }
-    return;
+  const path = sessionStorePath(dataDir, appId);
+  const db = open(path, false);
+  try {
+    const hit = db.prepare('SELECT row FROM sessions WHERE session_id = ?').get(sessionId) as { row: string } | undefined;
+    if (!hit) throw new Error(`no session row ${sessionId} in ${path}`);
+    const row = JSON.parse(hit.row);
+    mutate(row);
+    db.prepare('UPDATE sessions SET status = ?, row = ? WHERE session_id = ?')
+      .run(typeof row?.status === 'string' ? row.status : '', JSON.stringify(row), sessionId);
+  } finally {
+    db.close();
   }
-  const projection = JSON.parse(readFileSync(json, 'utf8')) as Record<string, any>;
-  mutate(projection[sessionId]);
-  writeFileSync(json, JSON.stringify(projection, null, 2));
 }

--- a/test/ipc-whiteboard-route.test.ts
+++ b/test/ipc-whiteboard-route.test.ts
@@ -69,6 +69,43 @@ describe('POST /api/sessions/:sessionId/whiteboard', () => {
     expect(update).toHaveBeenCalledOnce();
   });
 
+  it('clears only when expectWhiteboardId still matches', async () => {
+    const session = { sessionId: 's-wb-cas', larkAppId: 'app-1', whiteboardId: 'wb_old' as string | undefined };
+    mockOwnedSession(session);
+    const update = vi.spyOn(sessionStore, 'updateSession').mockImplementation(() => undefined);
+
+    const res = await postWhiteboard('s-wb-cas', { whiteboardId: null, expectWhiteboardId: 'wb_old' });
+    expect(res.status).toBe(200);
+    expect(session.whiteboardId).toBeUndefined();
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('refuses with 409 when the session was rebound after the caller looked', async () => {
+    // Deleting a board removes it from the index, so the daemon's
+    // ensureSessionWhiteboard mints a replacement on the next turn. A late
+    // unconditional clear would drop that fresh binding and orphan the board.
+    const session = { sessionId: 's-wb-rebound', larkAppId: 'app-1', whiteboardId: 'wb_new' as string | undefined };
+    mockOwnedSession(session);
+    const update = vi.spyOn(sessionStore, 'updateSession').mockImplementation(() => undefined);
+
+    const res = await postWhiteboard('s-wb-rebound', { whiteboardId: null, expectWhiteboardId: 'wb_deleted' });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ ok: false, error: 'whiteboard_changed', whiteboardId: 'wb_new' });
+    expect(session.whiteboardId).toBe('wb_new');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string expectWhiteboardId', async () => {
+    const session = { sessionId: 's-wb-bad-expect', larkAppId: 'app-1', whiteboardId: 'wb_keep' };
+    mockOwnedSession(session);
+    const update = vi.spyOn(sessionStore, 'updateSession').mockImplementation(() => undefined);
+
+    const res = await postWhiteboard('s-wb-bad-expect', { whiteboardId: null, expectWhiteboardId: 7 });
+    expect(res.status).toBe(400);
+    expect(session.whiteboardId).toBe('wb_keep');
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('rejects an empty string (unbind is null, not "")', async () => {
     const session = { sessionId: 's-wb-empty', larkAppId: 'app-1', whiteboardId: 'wb_keep' };
     mockOwnedSession(session);

--- a/test/ipc-whiteboard-route.test.ts
+++ b/test/ipc-whiteboard-route.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  setIpcAuthSecret,
+  startIpcServer,
+  type IpcServerHandle,
+} from '../src/core/dashboard-ipc-server.js';
+import { daemonIpcAuthHeaders } from '../src/core/daemon-ipc-auth.js';
+import * as workerPool from '../src/core/worker-pool.js';
+import * as sessionStore from '../src/services/session-store.js';
+
+const HOST_SECRET = 'test-ipc-whiteboard-host-secret';
+let handle: IpcServerHandle | null = null;
+
+afterEach(async () => {
+  if (handle) await handle.close();
+  handle = null;
+  setIpcAuthSecret(null);
+  vi.restoreAllMocks();
+});
+
+async function postWhiteboard(sessionId: string, body: unknown): Promise<Response> {
+  if (!handle) {
+    setIpcAuthSecret(HOST_SECRET);
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+  }
+  const path = `/api/sessions/${sessionId}/whiteboard`;
+  return fetch(`http://127.0.0.1:${handle.port}${path}`, {
+    method: 'POST',
+    headers: daemonIpcAuthHeaders({
+      secret: HOST_SECRET,
+      port: handle.port,
+      method: 'POST',
+      path,
+      headers: { 'content-type': 'application/json' },
+    }),
+    body: JSON.stringify(body),
+  });
+}
+
+function mockOwnedSession(session: Record<string, unknown>): void {
+  vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+    session,
+    larkAppId: session.larkAppId,
+  } as any);
+}
+
+describe('POST /api/sessions/:sessionId/whiteboard', () => {
+  it('binds a non-empty whiteboard id onto the owned session', async () => {
+    const session = { sessionId: 's-wb', larkAppId: 'app-1', whiteboardId: undefined as string | undefined };
+    mockOwnedSession(session);
+    const update = vi.spyOn(sessionStore, 'updateSession').mockImplementation(() => undefined);
+
+    const res = await postWhiteboard('s-wb', { whiteboardId: 'wb_live' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, whiteboardId: 'wb_live' });
+    expect(session.whiteboardId).toBe('wb_live');
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('clears the binding when whiteboardId is null', async () => {
+    const session = { sessionId: 's-wb-clear', larkAppId: 'app-1', whiteboardId: 'wb_gone' as string | undefined };
+    mockOwnedSession(session);
+    const update = vi.spyOn(sessionStore, 'updateSession').mockImplementation(() => undefined);
+
+    const res = await postWhiteboard('s-wb-clear', { whiteboardId: null });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, whiteboardId: null });
+    expect(session.whiteboardId).toBeUndefined();
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an empty string (unbind is null, not "")', async () => {
+    const session = { sessionId: 's-wb-empty', larkAppId: 'app-1', whiteboardId: 'wb_keep' };
+    mockOwnedSession(session);
+    const update = vi.spyOn(sessionStore, 'updateSession').mockImplementation(() => undefined);
+
+    const res = await postWhiteboard('s-wb-empty', { whiteboardId: '' });
+    expect(res.status).toBe(400);
+    expect(session.whiteboardId).toBe('wb_keep');
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/test/remote-shutdown-detach.test.ts
+++ b/test/remote-shutdown-detach.test.ts
@@ -257,19 +257,20 @@ describe('Remote graceful daemon-shutdown detach coordinator', () => {
     sessionStore.updateSession(second.ds.session);
     const originalSnapshot = sessionStore.getActiveRemoteShutdownSnapshotsBatch;
     const snapshot = vi.spyOn(sessionStore, 'getActiveRemoteShutdownSnapshotsBatch')
-      .mockImplementation((sessionIds, options) => {
+      .mockImplementation((sessionIds) => {
         expect(first.messages).toEqual([]);
         expect(second.messages).toEqual([]);
-        return originalSnapshot(sessionIds, options);
+        return originalSnapshot(sessionIds);
       });
 
     const results = await prepareRemoteFleetForShutdown([first.ds, second.ds]);
 
     expect(snapshot).toHaveBeenCalledTimes(1);
+    // 等待上限现在由 SQLite busy_timeout 决定，批量快照只收 sessionIds 一个参数。
     expect(snapshot).toHaveBeenCalledWith([
       first.ds.session.sessionId,
       second.ds.session.sessionId,
-    ], expect.any(Object));
+    ]);
     expect(results.every(entry => entry.result.ok)).toBe(true);
     expect(first.messages.map(message => message.type)).toEqual(['remote_shutdown_prepare']);
     expect(second.messages.map(message => message.type)).toEqual(['remote_shutdown_prepare']);
@@ -460,9 +461,10 @@ describe('Remote graceful daemon-shutdown detach coordinator', () => {
     let now = 10_000;
     const deadlineMs = 10_100;
     vi.spyOn(sessionStore, 'persistActiveRemoteLineagesExactBatch')
-      .mockImplementation((updates, options) => {
-        originalBatch(updates, options);
+      .mockImplementation((updates) => {
+        const published = originalBatch(updates);
         now = deadlineMs;
+        return published;
       });
 
     const result = persistPreparedRemoteShutdownFleet(

--- a/test/restart-report.test.ts
+++ b/test/restart-report.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { countActiveSessionsOnDisk } from '../src/services/session-store.js';
+import { seedPersistedSessionRows, sessionStorePath } from './helpers/session-store-disk.js';
 import { buildRestartReportText, sendRestartReportIfPending, fetchChangelog } from '../src/core/restart-report.js';
 import {
   commitRestartIntentAttemptTo,
@@ -11,8 +12,8 @@ import {
   writeRestartIntentTo,
 } from '../src/services/restart-intent-store.js';
 
-function writeSessions(dir: string, name: string, sessions: Record<string, { status: string }>) {
-  writeFileSync(join(dir, name), JSON.stringify(sessions));
+function writeSessions(dir: string, appId: string | undefined, sessions: Record<string, { status: string }>) {
+  seedPersistedSessionRows(dir, appId, sessions);
 }
 
 describe('countActiveSessionsOnDisk', () => {
@@ -20,10 +21,10 @@ describe('countActiveSessionsOnDisk', () => {
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'botmux-sess-')); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
-  it('counts active sessions across all bots’ session files', () => {
-    writeSessions(dir, 'sessions-cli_a.json', { s1: { status: 'active' }, s2: { status: 'closed' }, s3: { status: 'active' } });
-    writeSessions(dir, 'sessions-cli_b.json', { s4: { status: 'active' } });
-    writeSessions(dir, 'sessions.json', { s5: { status: 'active' }, s6: { status: 'closed' } });
+  it('counts active sessions across every bot’s session store', () => {
+    writeSessions(dir, 'cli_a', { s1: { status: 'active' }, s2: { status: 'closed' }, s3: { status: 'active' } });
+    writeSessions(dir, 'cli_b', { s4: { status: 'active' } });
+    writeSessions(dir, undefined, { s5: { status: 'active' }, s6: { status: 'closed' } });
     expect(countActiveSessionsOnDisk(dir)).toBe(4);
   });
 
@@ -32,10 +33,14 @@ describe('countActiveSessionsOnDisk', () => {
     expect(countActiveSessionsOnDisk(join(dir, 'nope'))).toBe(0);
   });
 
-  it('ignores non-session files and corrupt session files', () => {
-    writeSessions(dir, 'sessions-cli_a.json', { s1: { status: 'active' } });
-    writeFileSync(join(dir, 'schedules.json'), JSON.stringify({ x: { status: 'active' } })); // not a session file
-    writeFileSync(join(dir, 'sessions-bad.json'), '{corrupt');
+  it('ignores unrelated files, frozen pre-SQLite JSON and corrupt stores', () => {
+    writeSessions(dir, 'cli_a', { s1: { status: 'active' } });
+    writeFileSync(join(dir, 'schedules.json'), JSON.stringify({ x: { status: 'active' } })); // not a session store
+    // A frozen pre-SQLite JSON is an import source, not a store: counting it
+    // would double-count every row its .db already holds.
+    writeFileSync(join(dir, 'sessions-cli_a.json'), JSON.stringify({ s1: { status: 'active' } }));
+    mkdirSync(join(dir, 'session-stores', 'bad'), { recursive: true });
+    writeFileSync(sessionStorePath(dir, 'bad'), '{corrupt');
     expect(countActiveSessionsOnDisk(dir)).toBe(1);
   });
 });
@@ -149,7 +154,7 @@ describe('sendRestartReportIfPending', () => {
 
   it('consumes a fresh intent and DMs the owner a card with the session count + dashboard link', async () => {
     writeRestartIntentTo(dir, { kind: 'manual', at: new Date(T0).toISOString() });
-    writeFileSync(join(dir, 'sessions-cli_primary.json'), JSON.stringify({ s1: { status: 'active' }, s2: { status: 'active' } }));
+    seedPersistedSessionRows(dir, 'cli_primary', { s1: { status: 'active' }, s2: { status: 'active' } });
     const { w, sent } = fakeWiring();
 
     await sendRestartReportIfPending(w);

--- a/test/session-delete-cli.test.ts
+++ b/test/session-delete-cli.test.ts
@@ -13,7 +13,6 @@ import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
-  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -21,6 +20,10 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { spawnTsScript } from './helpers/ts-runner.js';
+import {
+  readPersistedSessionRows,
+  seedPersistedSessionRows,
+} from './helpers/session-store-disk.js';
 import {
   managedOriginCapabilityPath,
   RELAY_ORIGIN_CAPABILITY_BASENAME,
@@ -65,18 +68,24 @@ function makeSession(sessionId: string, overrides: Partial<StoredSession> = {}):
   };
 }
 
-function writeSessions(dataDir: string, sessions: StoredSession[]): string {
+/** Seed this bot's per-bot store: `session-stores/<appId>/sessions.db`. */
+function writeSessions(dataDir: string, sessions: StoredSession[]): void {
   mkdirSync(dataDir, { recursive: true });
-  const path = join(dataDir, `sessions-${APP_ID}.json`);
-  writeFileSync(path, JSON.stringify(Object.fromEntries(sessions.map(s => [s.sessionId, s]))));
-  return path;
+  seedPersistedSessionRows(dataDir, APP_ID, Object.fromEntries(sessions.map(s => [s.sessionId, s])));
 }
 
-function writeLegacySessions(dataDir: string, sessions: StoredSession[]): string {
+/** Seed the legacy no-appId store: the flat `sessions.db`. */
+function writeLegacySessions(dataDir: string, sessions: StoredSession[]): void {
   mkdirSync(dataDir, { recursive: true });
-  const path = join(dataDir, 'sessions.json');
-  writeFileSync(path, JSON.stringify(Object.fromEntries(sessions.map(s => [s.sessionId, s]))));
-  return path;
+  seedPersistedSessionRows(dataDir, undefined, Object.fromEntries(sessions.map(s => [s.sessionId, s])));
+}
+
+function readSessions(dataDir: string): Record<string, StoredSession> {
+  return readPersistedSessionRows(dataDir, APP_ID) as Record<string, StoredSession>;
+}
+
+function readLegacySessions(dataDir: string): Record<string, StoredSession> {
+  return readPersistedSessionRows(dataDir) as Record<string, StoredSession>;
 }
 
 function writeDaemonDescriptor(dataDir: string, port: number): void {
@@ -160,7 +169,7 @@ describe('botmux delete — daemon-first close', () => {
     const homeDir = mkdtempSync(join(tmpdir(), 'botmux-delete-home-'));
     tempDirs.push(dataDir, homeDir);
     const session = makeSession('sess-delete-current');
-    const sessionsPath = writeSessions(dataDir, [session]);
+    writeSessions(dataDir, [session]);
     writeReadIsolatedCapability(dataDir, session.sessionId);
 
     let requestUrl = '';
@@ -195,7 +204,7 @@ describe('botmux delete — daemon-first close', () => {
       });
       // The fake daemon deliberately does not persist. Staying active proves
       // the CLI did not run the legacy local fallback after an IPC success.
-      const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+      const stored = readSessions(dataDir);
       expect(stored[session.sessionId].status).toBe('active');
     } finally {
       await new Promise<void>((resolve, reject) => {
@@ -259,7 +268,7 @@ describe('botmux delete — daemon-first close', () => {
     const relayDir = mkdtempSync(join(tmpdir(), 'botmux-delete-relay-'));
     tempDirs.push(dataDir, relayDir);
     const session = makeSession('sess-delete-rejected');
-    const sessionsPath = writeSessions(dataDir, [session]);
+    writeSessions(dataDir, [session]);
     writeRelayCapability(relayDir);
 
     const server = createServer(async (req, res) => {
@@ -282,7 +291,7 @@ describe('botmux delete — daemon-first close', () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain('origin_unproven');
       expect(result.stdout).toContain('0 个会话');
-      const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+      const stored = readSessions(dataDir);
       expect(stored[session.sessionId].status).toBe('active');
     } finally {
       await new Promise<void>((resolve, reject) => {
@@ -301,7 +310,7 @@ describe('botmux delete — daemon-first close', () => {
       // the daemon-side closeSession() does.
       previewTarget: { host: '127.0.0.1', port: 43111, registeredAt: '2026-07-22T00:00:00.000Z' },
     });
-    const sessionsPath = writeSessions(dataDir, [session]);
+    writeSessions(dataDir, [session]);
 
     const result = await runDelete(dataDir, [session.sessionId], {
       BOTMUX_SESSION_ID: undefined,
@@ -312,7 +321,7 @@ describe('botmux delete — daemon-first close', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('daemon 离线，本地收口');
-    const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+    const stored = readSessions(dataDir);
     expect(stored[session.sessionId].status).toBe('closed');
     expect(stored[session.sessionId].closedAt).toBeTruthy();
     expect(stored[session.sessionId]).not.toHaveProperty('previewTarget');
@@ -363,10 +372,10 @@ describe('botmux delete — daemon-first close', () => {
   it('closes a legacy session (no larkAppId) locally even when a daemon is online', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-legacy-data-'));
     tempDirs.push(dataDir);
-    // Legacy session has no larkAppId and lives in sessions.json, not the
-    // per-bot file. A per-bot daemon cannot persist its close.
+    // Legacy session has no larkAppId and lives in the flat `sessions.db`, not
+    // the per-bot store. A per-bot daemon cannot persist its close.
     const session = makeSession('sess-delete-legacy', { larkAppId: undefined });
-    const sessionsPath = writeLegacySessions(dataDir, [session]);
+    writeLegacySessions(dataDir, [session]);
 
     const seen: string[] = [];
     const server = createServer(async (req, res) => {
@@ -388,12 +397,12 @@ describe('botmux delete — daemon-first close', () => {
       });
 
       // CLI must not route the legacy session to the daemon: the daemon writes
-      // only its own sessions-<appId>.json and would return "200 OK" without
-      // actually closing the legacy row.
+      // only its own session-stores/<appId>/sessions.db and would return
+      // "200 OK" without actually closing the legacy row.
       expect(seen).toEqual([]);
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('daemon 离线，本地收口');
-      const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+      const stored = readLegacySessions(dataDir);
       expect(stored[session.sessionId].status).toBe('closed');
       expect(stored[session.sessionId].closedAt).toBeTruthy();
     } finally {
@@ -408,11 +417,11 @@ describe('botmux delete — daemon-first close', () => {
     tempDirs.push(dataDir);
     // A larkAppId-less session that is ALSO the current session: the injected
     // BOTMUX_DAEMON_IPC_PORT reaches a daemon even with no online descriptor.
-    // The daemon still writes only its own sessions-<appId>.json and would
-    // no-op the legacy close, so the larkAppId guard must divert this to the
-    // offline path too — the injected port is not a second door around it.
+    // The daemon still writes only its own session-stores/<appId>/sessions.db
+    // and would no-op the legacy close, so the larkAppId guard must divert this
+    // to the offline path too — the injected port is not a second door around it.
     const session = makeSession('sess-delete-legacy-cur', { larkAppId: undefined });
-    const sessionsPath = writeLegacySessions(dataDir, [session]);
+    writeLegacySessions(dataDir, [session]);
 
     const seen: string[] = [];
     const server = createServer(async (req, res) => {
@@ -436,7 +445,7 @@ describe('botmux delete — daemon-first close', () => {
       expect(seen).toEqual([]);
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('daemon 离线，本地收口');
-      const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+      const stored = readLegacySessions(dataDir);
       expect(stored[session.sessionId].status).toBe('closed');
       expect(stored[session.sessionId].closedAt).toBeTruthy();
     } finally {
@@ -444,5 +453,31 @@ describe('botmux delete — daemon-first close', () => {
         server.close(err => err ? reject(err) : resolve());
       });
     }
+  });
+
+  it('refuses to act on a store whose pre-SQLite JSON has not been imported yet', async () => {
+    // The CLI used to read `sessions-<appId>.json` as a live store. Now it is a
+    // one-shot import source only, so this same fixture must fail LOUDLY: a
+    // silent "没有活跃会话。" would tell the operator their live session is
+    // already gone while the owning (pre-SQLite) daemon still runs it.
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-unimported-'));
+    tempDirs.push(dataDir);
+    const session = makeSession('sess-delete-unimported');
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(
+      join(dataDir, `sessions-${APP_ID}.json`),
+      JSON.stringify({ [session.sessionId]: session }),
+    );
+
+    const result = await runDelete(dataDir, [session.sessionId], {
+      BOTMUX_SESSION_ID: undefined,
+      BOTMUX_LARK_APP_ID: APP_ID,
+      BOTMUX_SEND_RELAY: undefined,
+      BOTMUX_DAEMON_IPC_PORT: undefined,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).not.toContain('没有活跃会话');
+    expect(`${result.stdout}\n${result.stderr}`).toContain('会话库尚未迁移到 SQLite');
   });
 });

--- a/test/session-delete-cli.test.ts
+++ b/test/session-delete-cli.test.ts
@@ -11,8 +11,10 @@ import { createServer, type IncomingMessage } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -23,6 +25,7 @@ import { spawnTsScript } from './helpers/ts-runner.js';
 import {
   readPersistedSessionRows,
   seedPersistedSessionRows,
+  sessionStorePath,
 } from './helpers/session-store-disk.js';
 import {
   managedOriginCapabilityPath,
@@ -455,19 +458,17 @@ describe('botmux delete — daemon-first close', () => {
     }
   });
 
-  it('refuses to act on a store whose pre-SQLite JSON has not been imported yet', async () => {
-    // The CLI used to read `sessions-<appId>.json` as a live store. Now it is a
-    // one-shot import source only, so this same fixture must fail LOUDLY: a
-    // silent "没有活跃会话。" would tell the operator their live session is
-    // already gone while the owning (pre-SQLite) daemon still runs it.
+  it('closes a session whose owning daemon has not imported the store yet', async () => {
+    // 升级窗口：npm 换了 dist、重指了 launcher，而拥有这些行的 daemon 还在跑
+    // 迁移前的版本、仍然读写 JSON。离线关闭必须照常落到那份 JSON 上——读不到
+    // 会让 CLI 报「没有活跃会话」，等于告诉用户会话没了；而在这里建 .db 会在
+    // 那台 daemon 背后把两种表示分叉，还会关掉它的一次性导入门。
     const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-unimported-'));
     tempDirs.push(dataDir);
     const session = makeSession('sess-delete-unimported');
     mkdirSync(dataDir, { recursive: true });
-    writeFileSync(
-      join(dataDir, `sessions-${APP_ID}.json`),
-      JSON.stringify({ [session.sessionId]: session }),
-    );
+    const jsonFp = join(dataDir, `sessions-${APP_ID}.json`);
+    writeFileSync(jsonFp, JSON.stringify({ [session.sessionId]: session }));
 
     const result = await runDelete(dataDir, [session.sessionId], {
       BOTMUX_SESSION_ID: undefined,
@@ -476,8 +477,9 @@ describe('botmux delete — daemon-first close', () => {
       BOTMUX_DAEMON_IPC_PORT: undefined,
     });
 
-    expect(result.status).not.toBe(0);
+    expect(result.status).toBe(0);
     expect(result.stdout).not.toContain('没有活跃会话');
-    expect(`${result.stdout}\n${result.stderr}`).toContain('会话库尚未迁移到 SQLite');
+    expect(JSON.parse(readFileSync(jsonFp, 'utf-8'))[session.sessionId].status).toBe('closed');
+    expect(existsSync(sessionStorePath(dataDir, APP_ID))).toBe(false);
   });
 });

--- a/test/session-group-birth-anchor.test.ts
+++ b/test/session-group-birth-anchor.test.ts
@@ -144,6 +144,7 @@ import {
   CurrentTurnProvenanceError,
 } from '../src/core/current-turn-provenance.js';
 import { readProcessStartIdentity } from '../src/core/session-marker.js';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 import type { RoutingContext } from '../src/im/lark/event-dispatcher.js';
 
 const APP = 'sg_anchor_app';
@@ -341,12 +342,12 @@ describe('session-group birth first-turn anchoring (image/file/merge_forward)', 
     }
 
     // Now run the REAL resolver end-to-end: persist the exact session object
-    // the daemon just built (what sessions.json would contain), plus a real
-    // authenticated ancestor marker for THIS test process — its own pid and
-    // true procStart — carrying the fork turnId.
+    // the daemon just built into a real SQLite session store (the only engine
+    // the resolver reads), plus a real authenticated ancestor marker for THIS
+    // test process — its own pid and true procStart — carrying the fork turnId.
     const provDir = join(mocks.dataDir, `prov-${session.sessionId}`);
     mkdirSync(join(provDir, '.botmux-cli-pids'), { recursive: true });
-    writeFileSync(join(provDir, 'sessions.json'), JSON.stringify({ [session.sessionId]: session }));
+    seedPersistedSessionRows(provDir, APP, { [session.sessionId]: session });
     const procStart = readProcessStartIdentity(process.pid);
     expect(procStart).toBeTruthy();
     const writeMarker = (turnId: string) => writeFileSync(

--- a/test/session-picker-responsive.test.ts
+++ b/test/session-picker-responsive.test.ts
@@ -14,6 +14,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import { tsRunnerPrefix } from './helpers/ts-runner.js';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 
 const { Terminal } = xtermHeadless;
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
@@ -159,7 +160,9 @@ function makeFixture(
       chmodSync(secretPath, 0o600);
     }
   }
-  writeFileSync(join(dataDir, 'sessions.json'), JSON.stringify(sessions));
+  // The picker (`botmux list`) reads the SQLite session store; these rows carry
+  // no larkAppId, so they belong in the flat legacy store `<dataDir>/sessions.db`.
+  seedPersistedSessionRows(dataDir, undefined, sessions);
   return { root, dataDir };
 }
 

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -10,7 +10,7 @@
  * Run:  bunx vitest run test/session-store-sqlite.test.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, readdirSync, rmSync } from 'fs';
 import { spawn } from 'node:child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -177,6 +177,27 @@ describe('first-start JSON import', () => {
     const rows = readPersistedSessionRows(tempDir, 'appA');
     expect(rows.s1.title).toBe('renamed');
     expect(Object.keys(rows)).toHaveLength(2);
+  });
+
+  it('publishes a SELF-CONTAINED store: no WAL sidecar may hold imported rows', () => {
+    // The staging db is renamed as ONE file, so the rows have to be inside it
+    // at rename time. Staging in WAL mode leaves them in `<db>.tmp-wal`, the
+    // rename publishes a 4 KB header-only shell, and every later open fails
+    // with "disk I/O error" — permanently, because `existsSync(db)` then keeps
+    // the import from ever re-running. Engine-dependent (bun:sqlite does not
+    // fold the sidecar back on close), so this Node-run assertion pins the
+    // observable invariant: nothing of the staging db survives the publish.
+    seedJson('sessions-appA.json', { s1: row('s1'), s2: row('s2', { status: 'closed' }) });
+    init('appA');
+    expect(listSessions()).toHaveLength(2);
+
+    const storeDir = join(tempDir, 'session-stores', 'appA');
+    expect(readdirSync(storeDir).filter(n => n.includes('.tmp'))).toEqual([]);
+
+    // Reopen from scratch: a shell db would throw instead of yielding the rows.
+    init();
+    init('appA');
+    expect(listSessionsStrict().map(s => s.sessionId).sort()).toEqual(['s1', 's2']);
   });
 
   it('a non-owning process (worker under an old daemon) never bootstraps the .db', () => {
@@ -474,6 +495,34 @@ describe('SQLite capability gate', () => {
       () => true,
       { dataDir: tempDir },
     )).toThrow(SessionStoreSqliteUnavailableError);
+  });
+
+  it('does not mistake a brand-new bot for an un-imported one', () => {
+    // The legacy→per-bot migration never deletes `sessions.json`, so it is
+    // present on every upgraded install and NO daemon will ever import it
+    // (production daemons always carry an appId). Treating it as pending would
+    // fire on every freshly added bot — which has nothing to import — and tell
+    // its operator to restart an already-current daemon.
+    seedJson('sessions.json', { old: row('old') });
+    seedPersistedSessionRows(tempDir, 'appA', { a1: row('a1', { larkAppId: 'appA' }) });
+
+    expect(loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appNew' }).size).toBe(1);
+    expect(mutateSessionRowOffline(
+      { sessionId: 'nope', larkAppId: 'appNew' },
+      () => true,
+      { dataDir: tempDir },
+    )).toBeUndefined();
+  });
+
+  it('explains an empty identity scan caused by an un-imported store', () => {
+    // 「行不存在」和「那个 bot 的库还没导入」是同一个空扫描，但动作完全不同。
+    // 调用方会把 0 命中变成「未找到当前进程所属 session」，把人引去查进程标记。
+    seedJson('sessions-appOld.json', { o1: row('o1', { larkAppId: 'appOld' }) });
+    seedPersistedSessionRows(tempDir, 'appA', { a1: row('a1', { larkAppId: 'appA' }) });
+
+    expect(readSessionRowCopiesAcrossStores('a1', tempDir)).toHaveLength(1);
+    expect(() => readSessionRowCopiesAcrossStores('missing', tempDir))
+      .toThrow(SessionStoreNotImportedError);
   });
 
   it('an un-imported store is a migration error, never an engine capability error', () => {

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -54,8 +54,6 @@ import {
   readSessionRowCopiesAcrossStores,
   listSessionsStrict,
   SessionStoreSqliteUnavailableError,
-  SessionStoreNotImportedError,
-  SessionStoreUnavailableError,
 } from '../src/services/session-store.js';
 import {
   readPersistedSessionRows,
@@ -200,16 +198,18 @@ describe('first-start JSON import', () => {
     expect(listSessionsStrict().map(s => s.sessionId).sort()).toEqual(['s1', 's2']);
   });
 
-  it('a non-owning process (worker under an old daemon) never bootstraps the .db', () => {
+  it('a non-owning process (worker under an old daemon) reads the JSON and never bootstraps the .db', () => {
     seedJson('sessions-appA.json', { s1: row('s1') });
 
-    // worker（owner:false）在旧 daemon 还没导入时启动：不许建库，也不许把
-    // 「还没迁移」当成「没有会话」——写门必须挡住，而不是从空投影继续。
+    // worker（owner:false）在旧 daemon 还没导入时启动：照常读得到会话（那台
+    // daemon 还在写这份 JSON），但不许建库——建了就等于在它背后把两种表示
+    // 分叉，还会把它的一次性导入门关掉。
     init('appA', { owner: false });
-    expect(getSession('s1')).toBeUndefined();
+    expect(getSession('s1')?.title).toBe('s1');
+    expect(listSessionsStrict()).toHaveLength(1);
     expect(existsSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'))).toBe(false);
-    expect(() => listSessionsStrict()).toThrow(SessionStoreUnavailableError);
-    expect(() => listSessionsStrict()).toThrow(/尚未迁移/);
+    // 只读：不得把 scope 修复或 legacy 迁移写回 JSON（那是拥有者 daemon 的活）。
+    expect(JSON.parse(readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8')).s1.title).toBe('s1');
 
     // daemon（owner）随后启动才导入
     init('appA');
@@ -245,11 +245,10 @@ describe('the frozen import source is not a store', () => {
     expect(countActiveSessionsOnDisk(tempDir)).toBe(1);
   });
 
-  it('a peer bot that has not imported yet is invisible to cross-bot discovery', () => {
-    // 设计上接受的代价：跨 bot 发现只看 .db。某个 peer 的 daemon 还没在
-    // SQLite 版本上重启过时，它对「跨 bot 继承 workingDir / 活跃数统计 /
-    // adopt 去重」都不可见——而不是被当成一份可信但陈旧的拷贝。调用方自己的
-    // store 走的是 fail-closed 那条路（见下面的 assertStoreImported 用例）。
+  it('an un-imported peer store still composes with imported ones', () => {
+    // 混合升级窗口：appOld 的 daemon 还在跑迁移前的版本（只有 JSON），appNew
+    // 已经切到 SQLite。跨 bot 发现（继承 workingDir、活跃数统计、adopt 去重）
+    // 必须同时看见两者——把没重启过的 peer 读成「不存在」会让继承和去重失效。
     seedJson('sessions-appOld.json', { o1: row('o1', { larkAppId: 'appOld' }) });
     init('appNew');
     const n1 = createSession('oc_chat', 'om_shared_root', 'new bot session');
@@ -258,14 +257,15 @@ describe('the frozen import source is not a store', () => {
     mutatePersistedSessionRow(tempDir, 'appNew', n1.sessionId, (r) => { r.rootMessageId = 'om_o1'; });
 
     const snapshot = loadAllSessionsSnapshot({ dataDir: tempDir });
-    expect(snapshot.has('o1')).toBe(false);
+    expect(snapshot.get('o1')?.larkAppId).toBe('appOld');
     expect(snapshot.get(n1.sessionId)?.larkAppId).toBe('appNew');
 
     init('appThird');
-    expect(findActiveSessionsByRoot('om_o1').map(s => s.sessionId)).toEqual([n1.sessionId]);
-    expect(countActiveSessionsOnDisk(tempDir)).toBe(1);
+    expect(findActiveSessionsByRoot('om_o1').map(s => s.sessionId).sort())
+      .toEqual(['o1', n1.sessionId].sort());
+    expect(countActiveSessionsOnDisk(tempDir)).toBe(2);
     const ids = collectBotmuxSessionIdentities(tempDir);
-    expect(ids.has('o1')).toBe(false);
+    expect(ids.has('o1')).toBe(true);
     expect(ids.has(n1.sessionId)).toBe(true);
   });
 
@@ -497,53 +497,16 @@ describe('SQLite capability gate', () => {
     )).toThrow(SessionStoreSqliteUnavailableError);
   });
 
-  it('does not mistake a brand-new bot for an un-imported one', () => {
-    // The legacy→per-bot migration never deletes `sessions.json`, so it is
-    // present on every upgraded install and NO daemon will ever import it
-    // (production daemons always carry an appId). Treating it as pending would
-    // fire on every freshly added bot — which has nothing to import — and tell
-    // its operator to restart an already-current daemon.
-    seedJson('sessions.json', { old: row('old') });
-    seedPersistedSessionRows(tempDir, 'appA', { a1: row('a1', { larkAppId: 'appA' }) });
-
-    expect(loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appNew' }).size).toBe(1);
-    expect(mutateSessionRowOffline(
-      { sessionId: 'nope', larkAppId: 'appNew' },
-      () => true,
-      { dataDir: tempDir },
-    )).toBeUndefined();
-  });
-
-  it('explains an empty identity scan caused by an un-imported store', () => {
-    // 「行不存在」和「那个 bot 的库还没导入」是同一个空扫描，但动作完全不同。
-    // 调用方会把 0 命中变成「未找到当前进程所属 session」，把人引去查进程标记。
+  it('an un-imported peer store still resolves for the identity scan', () => {
+    // 身份扫描是 fail-closed 的「恰好一次」判定。窗口期把某个 store 读成
+    // 「不存在」，会让本来能唯一命中的行变成 0 命中，命令报「未找到当前进程
+    // 所属 session」，把人引去查进程标记。
     seedJson('sessions-appOld.json', { o1: row('o1', { larkAppId: 'appOld' }) });
     seedPersistedSessionRows(tempDir, 'appA', { a1: row('a1', { larkAppId: 'appA' }) });
 
     expect(readSessionRowCopiesAcrossStores('a1', tempDir)).toHaveLength(1);
-    expect(() => readSessionRowCopiesAcrossStores('missing', tempDir))
-      .toThrow(SessionStoreNotImportedError);
-  });
-
-  it('an un-imported store is a migration error, never an engine capability error', () => {
-    // 引擎在不在 与 这个 store 迁没迁 是两件事，报错必须分型：前者要人升级
-    // 运行时，后者只要重启 daemon。混成一个会把「重启就好」误报成「装不上」。
-    seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
-
-    expect(() => loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appA' }))
-      .toThrow(SessionStoreNotImportedError);
-    expect(() => mutateSessionRowOffline(
-      { sessionId: 's1', larkAppId: 'appA' },
-      (current) => { current.status = 'closed'; return true; },
-      { dataDir: tempDir },
-    )).toThrow(/尚未迁移/);
-    // 没有 .db 也没有 JSON 的数据目录只是「还没有会话」，静默返回空。
-    const emptyDir = mkdtempSync(join(tmpdir(), 'session-store-empty-'));
-    try {
-      expect(loadAllSessionsSnapshot({ dataDir: emptyDir, fallbackAppId: 'appA' }).size).toBe(0);
-    } finally {
-      rmSync(emptyDir, { recursive: true, force: true });
-    }
+    expect(readSessionRowCopiesAcrossStores('o1', tempDir)).toHaveLength(1);
+    expect(readSessionRowCopiesAcrossStores('missing', tempDir)).toHaveLength(0);
   });
 
   it('a corrupt .db is a skippable store, not a missing-engine error', () => {

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -1,12 +1,11 @@
 /**
- * SQLite 引擎替换（Step 3 第一个 PR）的专项回归：
+ * 会话库 SQLite 引擎的专项回归（引擎替换 + JSON 净删除后）：
  *  - 首启确定性自动导入（含 closed 行、legacy sessions.json、幂等/重启不重复导入）
  *  - .db.tmp 原子出现（读者绝不见半成品；残留 tmp 被清理）
- *  - JSON 原地冻结（导入后 daemon 写不再碰 JSON —— 回滚方案的前提）
- *  - 混合窗口 db-else-json（跨进程读 + CLI 离线写，含「冻结 JSON 不算第二份拷贝」）
- *  - SQLite 能力探测报错路径（daemon 硬门；CLI 有 .db 硬报错 / 无 .db 走 JSON；
+ *  - JSON 导入后原地冻结，且**不再是 store**：读者不看它，身份扫描不把它算成第二份
+ *  - 未导入的 store 一律 fail-closed（owner:false 不建库；离线写不静默 no-op）
+ *  - SQLite 能力探测报错路径（daemon 硬门；CLI 有 .db 硬报错；
  *    损坏 .db 不得收成「引擎不可用」）
- *  - worker（owner:false）不触发导入
  *
  * Run:  bunx vitest run test/session-store-sqlite.test.ts
  */
@@ -53,9 +52,16 @@ import {
   mutateSessionRowOffline,
   readSessionRowFromDisk,
   readSessionRowCopiesAcrossStores,
+  listSessionsStrict,
   SessionStoreSqliteUnavailableError,
+  SessionStoreNotImportedError,
+  SessionStoreUnavailableError,
 } from '../src/services/session-store.js';
-import { readPersistedSessionRows, mutatePersistedSessionRow } from './helpers/session-store-disk.js';
+import {
+  readPersistedSessionRows,
+  mutatePersistedSessionRow,
+  seedPersistedSessionRows,
+} from './helpers/session-store-disk.js';
 
 function seedJson(name: string, rows: Record<string, unknown>): string {
   mkdirSync(tempDir, { recursive: true });
@@ -176,9 +182,13 @@ describe('first-start JSON import', () => {
   it('a non-owning process (worker under an old daemon) never bootstraps the .db', () => {
     seedJson('sessions-appA.json', { s1: row('s1') });
 
+    // worker（owner:false）在旧 daemon 还没导入时启动：不许建库，也不许把
+    // 「还没迁移」当成「没有会话」——写门必须挡住，而不是从空投影继续。
     init('appA', { owner: false });
-    expect(getSession('s1')?.title).toBe('s1'); // 读 JSON 照常
+    expect(getSession('s1')).toBeUndefined();
     expect(existsSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'))).toBe(false);
+    expect(() => listSessionsStrict()).toThrow(SessionStoreUnavailableError);
+    expect(() => listSessionsStrict()).toThrow(/尚未迁移/);
 
     // daemon（owner）随后启动才导入
     init('appA');
@@ -187,10 +197,10 @@ describe('first-start JSON import', () => {
   });
 });
 
-// ─── 混合窗口 db-else-json ───────────────────────────────────────────────────
+// ─── 导入之后：冻结 JSON 不再是 store ───────────────────────────────────────
 
-describe('mixed-window db-else-json resolution', () => {
-  it('readers prefer the .db and treat the frozen JSON as superseded, not a second copy', () => {
+describe('the frozen import source is not a store', () => {
+  it('readers ignore the frozen JSON entirely, and it is not a second identity copy', () => {
     // appA 已切 SQLite（daemon 已重启），冻结 JSON 里留着一份陈旧拷贝
     const jsonFp = seedJson('sessions-appA.json', {
       s1: row('s1', { title: 'stale json copy', larkAppId: 'appA' }),
@@ -214,8 +224,11 @@ describe('mixed-window db-else-json resolution', () => {
     expect(countActiveSessionsOnDisk(tempDir)).toBe(1);
   });
 
-  it('stores still on JSON keep full read behaviour, and mixed stores compose', () => {
-    // appOld 还没重启（只有 JSON）；appNew 已切 SQLite
+  it('a peer bot that has not imported yet is invisible to cross-bot discovery', () => {
+    // 设计上接受的代价：跨 bot 发现只看 .db。某个 peer 的 daemon 还没在
+    // SQLite 版本上重启过时，它对「跨 bot 继承 workingDir / 活跃数统计 /
+    // adopt 去重」都不可见——而不是被当成一份可信但陈旧的拷贝。调用方自己的
+    // store 走的是 fail-closed 那条路（见下面的 assertStoreImported 用例）。
     seedJson('sessions-appOld.json', { o1: row('o1', { larkAppId: 'appOld' }) });
     init('appNew');
     const n1 = createSession('oc_chat', 'om_shared_root', 'new bot session');
@@ -224,16 +237,14 @@ describe('mixed-window db-else-json resolution', () => {
     mutatePersistedSessionRow(tempDir, 'appNew', n1.sessionId, (r) => { r.rootMessageId = 'om_o1'; });
 
     const snapshot = loadAllSessionsSnapshot({ dataDir: tempDir });
-    expect(snapshot.get('o1')?.larkAppId).toBe('appOld');
+    expect(snapshot.has('o1')).toBe(false);
     expect(snapshot.get(n1.sessionId)?.larkAppId).toBe('appNew');
 
-    // 跨 bot 发现类读者对两种引擎同时可见（sibling json + sibling db）
     init('appThird');
-    const found = findActiveSessionsByRoot('om_o1');
-    expect(found.map(s => s.sessionId).sort()).toEqual(['o1', n1.sessionId].sort());
-    expect(countActiveSessionsOnDisk(tempDir)).toBe(2);
+    expect(findActiveSessionsByRoot('om_o1').map(s => s.sessionId)).toEqual([n1.sessionId]);
+    expect(countActiveSessionsOnDisk(tempDir)).toBe(1);
     const ids = collectBotmuxSessionIdentities(tempDir);
-    expect(ids.has('o1')).toBe(true);
+    expect(ids.has('o1')).toBe(false);
     expect(ids.has(n1.sessionId)).toBe(true);
   });
 
@@ -265,6 +276,7 @@ describe('mixed-window db-else-json resolution', () => {
   it('offline mutation on the .db keeps the abortIf entry + pre-publication probes', () => {
     seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
     init('appA');
+    listSessions(); // 触发导入 → .db
     const before = readPersistedSessionRows(tempDir, 'appA');
 
     let probes = 0;
@@ -289,6 +301,7 @@ describe('mixed-window db-else-json resolution', () => {
   it('offline mutation hands mutate the FRESH .db row, never the caller snapshot', () => {
     seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
     init('appA');
+    listSessions(); // 触发导入 → .db
     mutatePersistedSessionRow(tempDir, 'appA', 's1', (r) => { r.workerGeneration = 7; });
 
     const published = mutateSessionRowOffline(
@@ -463,27 +476,32 @@ describe('SQLite capability gate', () => {
     )).toThrow(SessionStoreSqliteUnavailableError);
   });
 
-  it('CLI paths keep working on plain JSON stores when the SQLite engine is missing (no .db yet)', () => {
+  it('an un-imported store is a migration error, never an engine capability error', () => {
+    // 引擎在不在 与 这个 store 迁没迁 是两件事，报错必须分型：前者要人升级
+    // 运行时，后者只要重启 daemon。混成一个会把「重启就好」误报成「装不上」。
     seedJson('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
-    __testOnly_setSqliteUnavailable(true);
 
-    expect(readSessionRowFromDisk('s1', 'appA', tempDir)?.sessionId).toBe('s1');
-    expect(loadAllSessionsSnapshot({ dataDir: tempDir }).get('s1')?.larkAppId).toBe('appA');
-    expect(readSessionRowCopiesAcrossStores('s1', tempDir)).toHaveLength(1);
-    const published = mutateSessionRowOffline(
+    expect(() => loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appA' }))
+      .toThrow(SessionStoreNotImportedError);
+    expect(() => mutateSessionRowOffline(
       { sessionId: 's1', larkAppId: 'appA' },
       (current) => { current.status = 'closed'; return true; },
       { dataDir: tempDir },
-    );
-    expect(published?.status).toBe('closed');
+    )).toThrow(/尚未迁移/);
+    // 没有 .db 也没有 JSON 的数据目录只是「还没有会话」，静默返回空。
+    const emptyDir = mkdtempSync(join(tmpdir(), 'session-store-empty-'));
+    try {
+      expect(loadAllSessionsSnapshot({ dataDir: emptyDir, fallbackAppId: 'appA' }).size).toBe(0);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
   });
 
   it('a corrupt .db is a skippable store, not a missing-engine error', () => {
     mkdirSync(join(tempDir, 'session-stores', 'appA'), { recursive: true });
     writeFileSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'), 'this is not a database');
-    // A sibling JSON store (no .db) is the readable copy. The empty legacy
-    // sessions.db that beforeEach init() may have created does not hold s1.
-    seedJson('sessions-appB.json', { s1: row('s1', { title: 'other-bot' }) });
+    // 另一个 bot 的 store 是可读的那份拷贝。
+    seedPersistedSessionRows(tempDir, 'appB', { s1: row('s1', { title: 'other-bot' }) });
 
     expect(() => assertSqliteSupported()).not.toThrow();
     const copies = readSessionRowCopiesAcrossStores('s1', tempDir);

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -70,6 +70,7 @@ import {
   listSessions,
   listSessionsStrict,
   SessionStoreUnavailableError,
+  SessionStoreNotImportedError,
   beginMojoCloseJournal,
   markMojoClosePrepared,
   finishMojoCloseAbort,
@@ -86,6 +87,7 @@ import {
   readSessionRowFromDisk,
   readSessionRowCopiesAcrossStores,
 } from '../src/services/session-store.js';
+import { seedPersistedSessionRows, readPersistedSessionRows, sessionStorePath } from './helpers/session-store-disk.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -1220,11 +1222,12 @@ describe('Edge cases', () => {
 
 // ─── legacy field sanitization ───────────────────────────────────────────────
 
-describe('legacy placeholder-card field stripping', () => {
-  it('removes pendingResponseCard* fields from disk on the next save', () => {
+describe('import-time convergence', () => {
+  it('strips pendingResponseCard* fields while importing, so no written row carries them', () => {
     // A session persisted before the「处理中」placeholder card was removed still
-    // carries the three legacy fields on disk. The next save must drop them so
-    // the file converges to clean (nothing reads them anymore).
+    // carries the three legacy fields. The import drops them once; nothing can
+    // reintroduce them (the fields no longer exist on `Session`), which is why
+    // the write paths no longer re-check.
     mkdirSync(tempDir, { recursive: true });
     writeFileSync(join(tempDir, 'sessions.json'), JSON.stringify({
       s1: {
@@ -1245,15 +1248,40 @@ describe('legacy placeholder-card field stripping', () => {
     expect(onDisk.s1).not.toHaveProperty('pendingResponseCardState');
     expect(onDisk.s1).not.toHaveProperty('lastPatchedResponseCardId');
   });
+
+  it('keys an imported row by its own sessionId when the JSON key disagrees', () => {
+    // Historical corruption: the file key and the row's sessionId diverged. The
+    // pre-SQLite engine only cleaned this up if someone happened to make an
+    // offline write against that store (a side effect of rewriting the whole
+    // file). The import now normalises it once — keeping the row rather than
+    // dropping it, and making the lookup work.
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, 'sessions.json'), JSON.stringify({
+      wrongKey: {
+        sessionId: 'realId', chatId: 'c1', rootMessageId: 'r1', title: 'Mislabelled',
+        status: 'active', createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    }));
+
+    init();
+    expect(getSession('realId')?.title).toBe('Mislabelled');
+    expect(Object.keys(readPersistedRows(tempDir))).toEqual(['realId']);
+  });
 });
 
 // ─── cross-process offline access ────────────────────────────────────────────
 // The absorbed CLI-side persistence (formerly cli.ts loadSessions /
 // mutateSessionOffline / saveSession) and the daemon/provenance direct reads.
 
+/** Pre-SQLite JSON — an IMPORT SOURCE only; the store never reads it at runtime. */
 function seedFile(name: string, rows: Record<string, unknown>): void {
   mkdirSync(tempDir, { recursive: true });
   writeFileSync(join(tempDir, name), JSON.stringify(rows, null, 2));
+}
+
+/** Seed a real store on disk — what "another bot's daemon already wrote" means. */
+function seedStore(appId: string | undefined, rows: Record<string, unknown>): string {
+  return seedPersistedSessionRows(tempDir, appId, rows);
 }
 
 function row(sessionId: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
@@ -1264,12 +1292,12 @@ function row(sessionId: string, extra: Record<string, unknown> = {}): Record<str
 }
 
 describe('loadAllSessionsSnapshot()', () => {
-  it('merges legacy + per-bot files, per-bot wins duplicates and gets larkAppId stamped', () => {
-    seedFile('sessions.json', {
+  it('merges the legacy store + per-bot stores, per-bot wins duplicates and gets larkAppId stamped', () => {
+    seedStore(undefined, {
       legacy1: row('legacy1'),
       dup: row('dup', { title: 'legacy copy' }),
     });
-    seedFile('sessions-appA.json', {
+    seedStore('appA', {
       dup: row('dup', { title: 'per-bot copy' }),
       a1: row('a1'),
     });
@@ -1282,67 +1310,98 @@ describe('loadAllSessionsSnapshot()', () => {
     expect(snapshot.get('a1')?.larkAppId).toBe('appA');
   });
 
-  it('applies the scope repair and skips malformed entries', () => {
-    seedFile('sessions.json', {
+  it('skips malformed rows', () => {
+    seedStore(undefined, {
       broken: { notASession: true },
-      chatScoped: { ...row('chatScoped'), chatId: 'oc_x', rootMessageId: 'oc_x' },
+      ok: row('ok'),
     });
     const snapshot = loadAllSessionsSnapshot({ dataDir: tempDir });
-    expect(snapshot.size).toBe(1);
-    expect(snapshot.get('chatScoped')?.scope).toBe('chat');
+    expect([...snapshot.keys()]).toEqual(['ok']);
   });
 
-  it('falls back to the exact per-bot file when the data dir cannot be enumerated', () => {
-    seedFile('sessions-appB.json', { b1: row('b1') });
-    seedFile('sessions-appC.json', { c1: row('c1') });
+  it('falls back to the exact per-bot store when the data dir cannot be enumerated', () => {
+    seedStore('appB', { b1: row('b1') });
+    seedStore('appC', { c1: row('c1') });
     fsControl.failReaddir = true;
     try {
       const snapshot = loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appB' });
-      // The sandboxed fallback loads only the injected bot's own file.
+      // The sandboxed fallback loads only the injected bot's own store.
       expect([...snapshot.keys()]).toEqual(['b1']);
       expect(snapshot.get('b1')?.larkAppId).toBe('appB');
     } finally {
       fsControl.failReaddir = false;
     }
   });
+
+  it('never creates a store it was only asked to read', () => {
+    mkdirSync(tempDir, { recursive: true });
+    expect(loadAllSessionsSnapshot({ dataDir: tempDir }).size).toBe(0);
+    // A read-write SQLite open would have CREATED this file, and its mere
+    // existence disables the owning daemon's one-shot JSON import.
+    expect(existsSync(sessionStorePath(tempDir))).toBe(false);
+  });
+
+  it("refuses the caller's own store while its pre-SQLite JSON is still un-imported", () => {
+    // Upgrade window: npm already replaced dist, the owning daemon still runs a
+    // pre-SQLite build, so no .db exists. Reporting "no sessions" here would
+    // look to the agent like its own session vanished.
+    seedFile('sessions-appB.json', { b1: row('b1') });
+    expect(() => loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appB' }))
+      .toThrow(SessionStoreNotImportedError);
+    // A peer bot in the same state is simply invisible — never the caller's business.
+    seedStore('appA', { a1: row('a1') });
+    expect([...loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appA' }).keys()])
+      .toEqual(['a1']);
+  });
 });
 
 describe('readSessionRowFromDisk()', () => {
-  it('prefers the owning per-bot file and falls back to legacy', () => {
-    seedFile('sessions.json', { s1: row('s1', { title: 'legacy' }) });
-    seedFile('sessions-appA.json', { s1: row('s1', { title: 'per-bot' }) });
+  it('prefers the owning per-bot store and falls back to legacy', () => {
+    seedStore(undefined, { s1: row('s1', { title: 'legacy' }) });
+    seedStore('appA', { s1: row('s1', { title: 'per-bot' }) });
     expect(readSessionRowFromDisk('s1', 'appA', tempDir)?.title).toBe('per-bot');
     expect(readSessionRowFromDisk('s1', 'appMissing', tempDir)?.title).toBe('legacy');
     expect(readSessionRowFromDisk('s1', undefined, tempDir)?.title).toBe('legacy');
     expect(readSessionRowFromDisk('nope', 'appA', tempDir)).toBeUndefined();
   });
 
-  it('skips a corrupt per-bot file and still reads the legacy copy', () => {
-    mkdirSync(tempDir, { recursive: true });
-    writeFileSync(join(tempDir, 'sessions-appA.json'), '{corrupt');
-    seedFile('sessions.json', { s1: row('s1', { title: 'legacy' }) });
+  it('skips a corrupt per-bot store and still reads the legacy copy', () => {
+    mkdirSync(join(tempDir, 'session-stores', 'appA'), { recursive: true });
+    writeFileSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'), 'not a database');
+    seedStore(undefined, { s1: row('s1', { title: 'legacy' }) });
     expect(readSessionRowFromDisk('s1', 'appA', tempDir)?.title).toBe('legacy');
   });
 });
 
 describe('readSessionRowCopiesAcrossStores()', () => {
-  it('returns one entry per file that holds the id', () => {
-    seedFile('sessions.json', { s1: row('s1', { title: 'legacy' }) });
-    seedFile('sessions-appA.json', { s1: row('s1', { title: 'per-bot' }) });
-    seedFile('sessions-appB.json', { other: row('other') });
+  it('returns one entry per store that holds the id', () => {
+    seedStore(undefined, { s1: row('s1', { title: 'legacy' }) });
+    seedStore('appA', { s1: row('s1', { title: 'per-bot' }) });
+    seedStore('appB', { other: row('other') });
     const copies = readSessionRowCopiesAcrossStores('s1', tempDir);
     expect(copies.map(c => c.title).sort()).toEqual(['legacy', 'per-bot']);
     expect(readSessionRowCopiesAcrossStores('other', tempDir)).toHaveLength(1);
     expect(readSessionRowCopiesAcrossStores('missing', tempDir)).toHaveLength(0);
   });
 
-  it('skips corrupt files and key-mismatched rows without failing the scan', () => {
-    mkdirSync(tempDir, { recursive: true });
-    writeFileSync(join(tempDir, 'sessions-appA.json'), 'not json');
-    seedFile('sessions-appB.json', { s1: row('someOtherId') }); // key ≠ row.sessionId
-    seedFile('sessions.json', { s1: row('s1') });
+  it('skips corrupt stores and key-mismatched rows without failing the scan', () => {
+    mkdirSync(join(tempDir, 'session-stores', 'appA'), { recursive: true });
+    writeFileSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'), 'not a database');
+    seedStore('appB', { s1: row('someOtherId') }); // key ≠ row.sessionId
+    seedStore(undefined, { s1: row('s1') });
     const copies = readSessionRowCopiesAcrossStores('s1', tempDir);
     expect(copies).toHaveLength(1);
+  });
+
+  it('a frozen pre-SQLite JSON is not a second copy of an imported store', () => {
+    // The identity scan authorises only when a row resolves EXACTLY once. The
+    // frozen import source must not read as a second store, or every migrated
+    // session would be refused as ambiguous.
+    seedFile('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
+    init('appA');
+    listSessions(); // import → .db, JSON frozen in place
+    init();
+    expect(readSessionRowCopiesAcrossStores('s1', tempDir)).toHaveLength(1);
   });
 
   it('throws when the data dir itself cannot be listed (fail-closed identity scan)', () => {
@@ -1355,10 +1414,8 @@ describe('mutateSessionRowOffline()', () => {
   it('mutates the FRESH on-disk row, never the caller snapshot (stale-clobber regression)', () => {
     // The row gained a newer field on disk after the caller took its snapshot.
     // The old cli.ts saveSession() would have written the stale snapshot back,
-    // erasing workerGeneration; the locked mutation must preserve it.
-    seedFile('sessions-appA.json', {
-      s1: row('s1', { workerGeneration: 7, larkAppId: 'appA' }),
-    });
+    // erasing workerGeneration; the exclusive row mutation must preserve it.
+    seedStore('appA', { s1: row('s1', { workerGeneration: 7, larkAppId: 'appA' }) });
 
     const published = mutateSessionRowOffline(
       { sessionId: 's1', larkAppId: 'appA' },
@@ -1372,25 +1429,24 @@ describe('mutateSessionRowOffline()', () => {
 
     expect(published?.status).toBe('closed');
     expect(published?.workerGeneration).toBe(7);
-    const onDisk = JSON.parse(readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8'));
+    const onDisk = readPersistedSessionRows(tempDir, 'appA');
     expect(onDisk.s1.status).toBe('closed');
     expect(onDisk.s1.workerGeneration).toBe(7);
   });
 
   it('returns the fresh row without writing when mutate declines', () => {
-    seedFile('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
-    const before = readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8');
+    seedStore('appA', { s1: row('s1', { larkAppId: 'appA' }) });
     const current = mutateSessionRowOffline(
       { sessionId: 's1', larkAppId: 'appA' },
       () => false,
       { dataDir: tempDir },
     );
     expect(current?.sessionId).toBe('s1');
-    expect(readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8')).toBe(before);
+    expect(readPersistedSessionRows(tempDir, 'appA').s1.status).toBe('active');
   });
 
   it('returns undefined for a missing row', () => {
-    seedFile('sessions-appA.json', { s1: row('s1') });
+    seedStore('appA', { s1: row('s1') });
     expect(mutateSessionRowOffline(
       { sessionId: 'ghost', larkAppId: 'appA' },
       () => true,
@@ -1399,22 +1455,21 @@ describe('mutateSessionRowOffline()', () => {
   });
 
   it('aborts untouched when abortIf trips at entry', () => {
-    seedFile('sessions-appA.json', { s1: row('s1') });
-    const before = readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8');
+    seedStore('appA', { s1: row('s1') });
     const result = mutateSessionRowOffline(
       { sessionId: 's1', larkAppId: 'appA' },
       current => { current.status = 'closed'; return true; },
       { dataDir: tempDir, abortIf: () => true },
     );
     expect(result).toBeUndefined();
-    expect(readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8')).toBe(before);
+    expect(readPersistedSessionRows(tempDir, 'appA').s1.status).toBe('active');
   });
 
-  it('re-checks abortIf immediately before publication and leaves the file untouched', () => {
+  it('re-checks abortIf immediately before publication and leaves the row untouched', () => {
     // A daemon that appears during the read/decision phase becomes
-    // authoritative — the second probe must catch it.
-    seedFile('sessions-appA.json', { s1: row('s1') });
-    const before = readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8');
+    // authoritative — the second probe must catch it. SQLite's own locking
+    // orders writers but cannot see a daemon holding a stale in-memory cache.
+    seedStore('appA', { s1: row('s1') });
     let probes = 0;
     const result = mutateSessionRowOffline(
       { sessionId: 's1', larkAppId: 'appA' },
@@ -1423,34 +1478,41 @@ describe('mutateSessionRowOffline()', () => {
     );
     expect(result).toBeUndefined();
     expect(probes).toBe(2);
-    expect(readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8')).toBe(before);
+    expect(readPersistedSessionRows(tempDir, 'appA').s1.status).toBe('active');
   });
 
-  it('converges the file on write: drops key-mismatched rows and legacy card fields', () => {
-    seedFile('sessions-appA.json', {
-      s1: row('s1', { pendingResponseCardId: 'om_old' }),
-      wrongKey: row('actualId'),
-    });
-    mutateSessionRowOffline(
-      { sessionId: 's1', larkAppId: 'appA' },
-      current => { current.title = 'touched'; return true; },
-      { dataDir: tempDir },
-    );
-    const onDisk = JSON.parse(readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8'));
-    expect(onDisk.s1.title).toBe('touched');
-    expect(onDisk.s1).not.toHaveProperty('pendingResponseCardId');
-    expect(onDisk).not.toHaveProperty('wrongKey');
-  });
-
-  it('targets the legacy sessions.json when the row carries no larkAppId', () => {
-    seedFile('sessions.json', { s1: row('s1') });
+  it('targets the legacy store when the row carries no larkAppId', () => {
+    seedStore(undefined, { s1: row('s1') });
     const published = mutateSessionRowOffline(
       { sessionId: 's1' },
       current => { current.status = 'closed'; return true; },
       { dataDir: tempDir },
     );
     expect(published?.status).toBe('closed');
-    const onDisk = JSON.parse(readFileSync(join(tempDir, 'sessions.json'), 'utf-8'));
-    expect(onDisk.s1.status).toBe('closed');
+    expect(readPersistedSessionRows(tempDir).s1.status).toBe('closed');
+  });
+
+  it('never creates the store — an empty one would disable the daemon import gate', () => {
+    // A read-write SQLite open CREATES the file. If an offline write planted an
+    // empty store here, the owning daemon's `existsSync(db)` gate would skip
+    // the one-shot JSON import and silently discard every pre-SQLite row.
+    mkdirSync(join(tempDir, 'session-stores', 'appA'), { recursive: true });
+    expect(mutateSessionRowOffline(
+      { sessionId: 's1', larkAppId: 'appA' },
+      () => true,
+      { dataDir: tempDir },
+    )).toBeUndefined();
+    expect(existsSync(sessionStorePath(tempDir, 'appA'))).toBe(false);
+  });
+
+  it('refuses instead of silently no-opping while the store is still un-imported', () => {
+    // Offline close/abandon during the upgrade window: a silent no-op would
+    // report success while the row stays active.
+    seedFile('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
+    expect(() => mutateSessionRowOffline(
+      { sessionId: 's1', larkAppId: 'appA' },
+      current => { current.status = 'closed'; return true; },
+      { dataDir: tempDir },
+    )).toThrow(SessionStoreNotImportedError);
   });
 });

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -70,7 +70,6 @@ import {
   listSessions,
   listSessionsStrict,
   SessionStoreUnavailableError,
-  SessionStoreNotImportedError,
   beginMojoCloseJournal,
   markMojoClosePrepared,
   finishMojoCloseAbort,
@@ -1348,17 +1347,17 @@ describe('loadAllSessionsSnapshot()', () => {
     expect(existsSync(sessionStorePath(tempDir))).toBe(false);
   });
 
-  it("refuses the caller's own store while its pre-SQLite JSON is still un-imported", () => {
-    // Upgrade window: npm already replaced dist, the owning daemon still runs a
-    // pre-SQLite build, so no .db exists. Reporting "no sessions" here would
-    // look to the agent like its own session vanished.
+  it('still reads a store whose owning daemon has not imported it yet', () => {
+    // Upgrade window: npm already replaced dist and repointed the launcher, but
+    // the daemon that owns these rows still runs the pre-SQLite build and keeps
+    // writing the JSON. Every live session's `botmux send` resolves itself
+    // through here — going db-only would leave the agent unable to reply until
+    // someone restarts the daemon, which nothing forces them to do.
     seedFile('sessions-appB.json', { b1: row('b1') });
-    expect(() => loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appB' }))
-      .toThrow(SessionStoreNotImportedError);
-    // A peer bot in the same state is simply invisible — never the caller's business.
     seedStore('appA', { a1: row('a1') });
-    expect([...loadAllSessionsSnapshot({ dataDir: tempDir, fallbackAppId: 'appA' }).keys()])
-      .toEqual(['a1']);
+    const snapshot = loadAllSessionsSnapshot({ dataDir: tempDir });
+    expect([...snapshot.keys()].sort()).toEqual(['a1', 'b1']);
+    expect(snapshot.get('b1')?.larkAppId).toBe('appB');
   });
 });
 
@@ -1512,14 +1511,19 @@ describe('mutateSessionRowOffline()', () => {
     expect(existsSync(sessionStorePath(tempDir, 'appA'))).toBe(false);
   });
 
-  it('refuses instead of silently no-opping while the store is still un-imported', () => {
-    // Offline close/abandon during the upgrade window: a silent no-op would
-    // report success while the row stays active.
+  it('writes the JSON store while its owning daemon has not imported it yet', () => {
+    // Upgrade window: the pre-SQLite daemon still owns these rows and reads the
+    // JSON, so an offline close has to land there. Creating a .db here would
+    // fork the two representations behind that daemon's back — and the empty
+    // store would also disable its one-shot import gate.
     seedFile('sessions-appA.json', { s1: row('s1', { larkAppId: 'appA' }) });
-    expect(() => mutateSessionRowOffline(
+    const published = mutateSessionRowOffline(
       { sessionId: 's1', larkAppId: 'appA' },
       current => { current.status = 'closed'; return true; },
       { dataDir: tempDir },
-    )).toThrow(SessionStoreNotImportedError);
+    );
+    expect(published?.status).toBe('closed');
+    expect(JSON.parse(readFileSync(join(tempDir, 'sessions-appA.json'), 'utf-8')).s1.status).toBe('closed');
+    expect(existsSync(sessionStorePath(tempDir, 'appA'))).toBe(false);
   });
 });

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -1249,23 +1249,30 @@ describe('import-time convergence', () => {
     expect(onDisk.s1).not.toHaveProperty('lastPatchedResponseCardId');
   });
 
-  it('keys an imported row by its own sessionId when the JSON key disagrees', () => {
-    // Historical corruption: the file key and the row's sessionId diverged. The
-    // pre-SQLite engine only cleaned this up if someone happened to make an
-    // offline write against that store (a side effect of rewriting the whole
-    // file). The import now normalises it once — keeping the row rather than
-    // dropping it, and making the lookup work.
+  it('never lets a duplicate-sessionId ghost overwrite the live row', () => {
+    // Two entries can carry the SAME sessionId under different file keys.
+    // Importing under `row.sessionId` would collapse them and let whichever
+    // comes last win — a stale closed ghost silently replacing the live row,
+    // irreversibly (the import runs once, the JSON is frozen afterwards).
+    // Rows are imported under their own file key; a mis-keyed row stays inert.
     mkdirSync(tempDir, { recursive: true });
     writeFileSync(join(tempDir, 'sessions.json'), JSON.stringify({
-      wrongKey: {
-        sessionId: 'realId', chatId: 'c1', rootMessageId: 'r1', title: 'Mislabelled',
+      realId: {
+        sessionId: 'realId', chatId: 'c1', rootMessageId: 'r1', title: 'CURRENT',
         status: 'active', createdAt: '2026-01-01T00:00:00.000Z',
+      },
+      wrongKey: {
+        sessionId: 'realId', chatId: 'c1', rootMessageId: 'r1', title: 'STALE-DUP',
+        status: 'closed', createdAt: '2026-01-01T00:00:00.000Z',
       },
     }));
 
     init();
-    expect(getSession('realId')?.title).toBe('Mislabelled');
-    expect(Object.keys(readPersistedRows(tempDir))).toEqual(['realId']);
+    expect(getSession('realId')?.title).toBe('CURRENT');
+    expect(getSession('realId')?.status).toBe('active');
+    const onDisk = readPersistedRows(tempDir);
+    expect(onDisk.realId.title).toBe('CURRENT');
+    expect(onDisk.wrongKey.title).toBe('STALE-DUP');
   });
 });
 

--- a/test/sqlite-compat-warning.test.ts
+++ b/test/sqlite-compat-warning.test.ts
@@ -1,0 +1,28 @@
+/**
+ * 会话库上了 SQLite 之后，CLI 的 stderr 必须保持干净。
+ *
+ * Node 22（CI 与多数安装跑的版本）在首次加载 `node:sqlite` 时会打两行
+ * `ExperimentalWarning: SQLite is an experimental feature …`。对 daemon 只是
+ * 一行噪音；对 CLI 是真缺陷：`botmux list` 跑在备用屏上，这两行会把钉住的
+ * 标题挤出屏幕（CI 上正是这样挂的），并且污染每一个碰会话库的 agent 侧
+ * `botmux` 命令的 stderr。加 `process.on('warning')` 监听器挡不住——Node 的
+ * 默认打印照跑——所以必须在 emit 处过滤。
+ *
+ * ⚠️ 这条用例的把关能力**依赖运行时**：Node 24 本身就不再发这个警告，所以在
+ * 24 上它恒绿。真正的回归拦截发生在 CI（Node 22）。
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSyncTsEvalWithRepoImports } from './helpers/ts-runner.js';
+
+describe('sqlite-compat 不把 Node 的实验特性警告漏到 stderr', () => {
+  it('加载引擎不产生任何 ExperimentalWarning', () => {
+    const r = spawnSyncTsEvalWithRepoImports(
+      `import { sqliteEngineAvailable } from './src/services/sqlite-compat.js';
+       process.stdout.write(String(sqliteEngineAvailable()));`,
+      { encoding: 'utf-8', cwd: process.cwd() },
+    );
+    expect(String(r.stdout)).toBe('true');
+    expect(String(r.stderr)).not.toMatch(/ExperimentalWarning/);
+    expect(String(r.stderr)).not.toMatch(/SQLite is an experimental feature/);
+  });
+});

--- a/test/v3-cli-daemon-command-authority.test.ts
+++ b/test/v3-cli-daemon-command-authority.test.ts
@@ -14,6 +14,7 @@ import {
   serializeRunEnvelope,
   type Sha256Digest,
 } from '../src/workflows/v3/run-envelope.js';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 
 const DIGEST = `sha256:${'a'.repeat(64)}` as Sha256Digest;
 const BINDING: RunChatBinding = {
@@ -50,20 +51,25 @@ describe('agent-facing v3 daemon command authority', () => {
     );
   }
 
+  /**
+   * The durable session record now lives only in the per-bot SQLite store
+   * (`session-stores/<appId>/sessions.db`); `sessions-<appId>.json` is no
+   * longer a runtime read path. The row is seeded into the store owned by its
+   * own `larkAppId`, which is exactly how a live daemon would have written it.
+   */
   function writeSession(overrides: Record<string, unknown> = {}): void {
-    writeFileSync(join(dataDir, 'sessions-cli_owner.json'), JSON.stringify({
-      'sess-1': {
-        sessionId: 'sess-1',
-        status: 'active',
-        scope: 'thread',
-        larkAppId: 'cli_owner',
-        chatId: 'oc_owner',
-        rootMessageId: 'om_root',
-        lastCallerOpenId: 'ou_caller',
-        quoteTargetId: 'turn-current',
-        ...overrides,
-      },
-    }));
+    const row = {
+      sessionId: 'sess-1',
+      status: 'active',
+      scope: 'thread',
+      larkAppId: 'cli_owner',
+      chatId: 'oc_owner',
+      rootMessageId: 'om_root',
+      lastCallerOpenId: 'ou_caller',
+      quoteTargetId: 'turn-current',
+      ...overrides,
+    };
+    seedPersistedSessionRows(dataDir, String(row.larkAppId), { 'sess-1': row });
   }
 
   function writeEnvelope(runId: string, binding?: RunChatBinding): void {

--- a/test/v3-host.test.ts
+++ b/test/v3-host.test.ts
@@ -25,6 +25,7 @@ import { DagValidationError } from '../src/workflows/v3/dag.js';
 import { loadAuthorizedV3Run, readRunEnvelope } from '../src/workflows/v3/run-envelope.js';
 import { readProcessStartIdentity } from '../src/core/session-marker.js';
 import { tsEvalArgs, tsRunnerPrefix } from './helpers/ts-runner.js';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 
 function base(): string {
   return mkdtempSync(join(tmpdir(), 'v3-host-'));
@@ -863,13 +864,13 @@ describe('host — chatBindingFromEnv（grill 出生落话题绑定）', () => {
         join(dataDir, '.botmux-cli-pids', String(process.pid)),
         JSON.stringify({ sessionId: 'sess-1', turnId: 'turn-current', procStart }),
       );
-      writeFileSync(join(dataDir, 'sessions-cli_real.json'), JSON.stringify({
+      seedPersistedSessionRows(dataDir, 'cli_real', {
         'sess-1': {
           sessionId: 'sess-1', status: 'active', scope: 'thread',
           larkAppId: 'cli_real', chatId: 'oc_real', rootMessageId: 'om_real',
           ownerOpenId: 'ou_owner_a', lastCallerOpenId: 'ou_caller_b', quoteTargetId: 'turn-current',
         },
-      }));
+      });
 
       expect(chatBindingFromEnv({
         SESSION_DATA_DIR: dataDir,
@@ -903,13 +904,13 @@ describe('host — chatBindingFromEnv（grill 出生落话题绑定）', () => {
         join(dataDir, '.botmux-cli-pids', String(process.pid)),
         JSON.stringify({ sessionId: 'sess-1', turnId: 'turn-old', procStart }),
       );
-      writeFileSync(join(dataDir, 'sessions-cli_real.json'), JSON.stringify({
+      seedPersistedSessionRows(dataDir, 'cli_real', {
         'sess-1': {
           sessionId: 'sess-1', status: 'active', scope: 'thread',
           larkAppId: 'cli_real', chatId: 'oc_real', rootMessageId: 'om_real',
           lastCallerOpenId: 'ou_caller_b', quoteTargetId: 'turn-new',
         },
-      }));
+      });
       expect(() => chatBindingFromEnv({
         SESSION_DATA_DIR: dataDir, BOTMUX_SESSION_ID: 'sess-1', BOTMUX_OWNER_OPEN_ID: 'ou_owner_a',
       } as NodeJS.ProcessEnv, process.pid)).toThrow(/turn-old.*turn-new/);

--- a/test/v3-saved-workflow-cli.test.ts
+++ b/test/v3-saved-workflow-cli.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { readProcessStartIdentity } from '../src/core/session-marker.js';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 
 import {
   assertAgentFacingAppendScope,
@@ -89,7 +90,7 @@ describe('Saved Workflow CLI current-turn authentication', () => {
         join(dataDir, '.botmux-cli-pids', String(process.pid)),
         JSON.stringify({ sessionId: 'sess-1', turnId: 'turn-b', procStart }),
       );
-      writeFileSync(join(dataDir, 'sessions-cli_real.json'), JSON.stringify({
+      seedPersistedSessionRows(dataDir, 'cli_real', {
         'sess-1': {
           sessionId: 'sess-1',
           status: 'active',
@@ -101,7 +102,7 @@ describe('Saved Workflow CLI current-turn authentication', () => {
           lastCallerOpenId: 'ou_caller_b',
           quoteTargetId: 'turn-b',
         },
-      }));
+      });
 
       expect(contextFromEnv({
         SESSION_DATA_DIR: dataDir,
@@ -131,13 +132,13 @@ describe('Saved Workflow CLI current-turn authentication', () => {
         join(dataDir, '.botmux-cli-pids', String(process.pid)),
         JSON.stringify({ sessionId: 'sess-1', turnId: 'turn-old', procStart }),
       );
-      writeFileSync(join(dataDir, 'sessions-cli_real.json'), JSON.stringify({
+      seedPersistedSessionRows(dataDir, 'cli_real', {
         'sess-1': {
           sessionId: 'sess-1', status: 'active', scope: 'thread',
           larkAppId: 'cli_real', chatId: 'oc_real', rootMessageId: 'om_real',
           ownerOpenId: 'ou_owner_a', lastCallerOpenId: 'ou_caller_b', quoteTargetId: 'turn-new',
         },
-      }));
+      });
 
       expect(() => contextFromEnv({
         SESSION_DATA_DIR: dataDir,

--- a/test/whiteboard-cli.test.ts
+++ b/test/whiteboard-cli.test.ts
@@ -225,7 +225,7 @@ describe('botmux whiteboard CLI', () => {
     const prevDataDir = process.env.SESSION_DATA_DIR;
     process.env.SESSION_DATA_DIR = dataDir;
     const { deleteWhiteboard } = await import('../dist/services/whiteboard-store.js');
-    const result = deleteWhiteboard('delete_board');
+    const result = await deleteWhiteboard('delete_board');
     if (prevDataDir === undefined) delete process.env.SESSION_DATA_DIR;
     else process.env.SESSION_DATA_DIR = prevDataDir;
     expect(result).toMatchObject({ ok: true, id: 'delete_board', clearedSessions: 1 });

--- a/test/whiteboard-cli.test.ts
+++ b/test/whiteboard-cli.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { seedPersistedSessionRows, readPersistedSessionRows } from './helpers/session-store-disk.js';
 import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -32,7 +33,8 @@ function runCli(args: string[], input?: string): { status: number; stdout: strin
 }
 
 function writeSession(sessionId: string, workingDir: string): void {
-  writeFileSync(join(dataDir, 'sessions-app1.json'), JSON.stringify({
+  // 会话行只有 SQLite 一种持久层；sessions-<appId>.json 已是一次性导入源。
+  seedPersistedSessionRows(dataDir, 'app1', {
     [sessionId]: {
       sessionId,
       chatId: 'chat1',
@@ -43,7 +45,7 @@ function writeSession(sessionId: string, workingDir: string): void {
       larkAppId: 'app1',
       workingDir,
     },
-  }, null, 2));
+  });
 }
 
 describe('botmux whiteboard CLI', () => {
@@ -125,7 +127,7 @@ describe('botmux whiteboard CLI', () => {
     const cur = runCli(['whiteboard', 'current', '--create', '--session-id', 'session1']);
     expect(cur.status).toBe(0);
     const id = JSON.parse(cur.stdout).current.id;
-    const sessions = JSON.parse(readFileSync(join(dataDir, 'sessions-app1.json'), 'utf-8'));
+    const sessions = readPersistedSessionRows(dataDir, 'app1');
     expect(sessions.session1.whiteboardId).toBe(id);
   });
 
@@ -216,9 +218,9 @@ describe('botmux whiteboard CLI', () => {
     expect(created.status).toBe(0);
     const dir = join(dataDir, 'whiteboards', 'delete_board');
     expect(existsSync(dir)).toBe(true);
-    writeFileSync(join(dataDir, 'sessions-app1.json'), JSON.stringify({
+    seedPersistedSessionRows(dataDir, 'app1', {
       s1: { sessionId: 's1', chatId: 'delete-chat', rootMessageId: 'r', title: 's', status: 'active', createdAt: new Date().toISOString(), larkAppId: 'app1', whiteboardId: 'delete_board' },
-    }, null, 2));
+    });
 
     const prevDataDir = process.env.SESSION_DATA_DIR;
     process.env.SESSION_DATA_DIR = dataDir;
@@ -231,7 +233,7 @@ describe('botmux whiteboard CLI', () => {
     const index = JSON.parse(readFileSync(join(dataDir, 'whiteboards', 'index.json'), 'utf-8'));
     expect(index.boards.delete_board).toBeUndefined();
     expect(Object.values(index.bindings)).not.toContain('delete_board');
-    const sessions = JSON.parse(readFileSync(join(dataDir, 'sessions-app1.json'), 'utf-8'));
+    const sessions = readPersistedSessionRows(dataDir, 'app1');
     expect(sessions.s1.whiteboardId).toBeUndefined();
   });
 

--- a/test/whiteboard-unbind-session.test.ts
+++ b/test/whiteboard-unbind-session.test.ts
@@ -6,7 +6,8 @@ import { seedPersistedSessionRows, readPersistedSessionRows } from './helpers/se
 
 const ipc = vi.hoisted(() => ({
   daemon: null as { larkAppId: string; ipcPort: number } | null,
-  fetchOk: true,
+  status: 200,
+  throws: false,
   fetches: [] as Array<{ port: number; path: string; body: unknown }>,
 }));
 
@@ -35,18 +36,35 @@ vi.mock('../src/core/daemon-ipc-auth.js', () => ({
   fetchDaemonIpc: async (port: number, path: string, init?: RequestInit) => {
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
     ipc.fetches.push({ port, path, body });
-    return { ok: ipc.fetchOk, json: async () => ({ ok: ipc.fetchOk }) };
+    if (ipc.throws) throw new Error('connect ECONNREFUSED');
+    return { ok: ipc.status >= 200 && ipc.status < 300, status: ipc.status, json: async () => ({}) };
   },
 }));
 
 import { createWhiteboard, deleteWhiteboard } from '../src/services/whiteboard-store.js';
+
+function seedBoundSession(appId: string | undefined, boardId: string): void {
+  seedPersistedSessionRows(tempDir, appId, {
+    s1: {
+      sessionId: 's1',
+      chatId: 'c1',
+      rootMessageId: 'r',
+      title: 's',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+      ...(appId ? { larkAppId: appId } : {}),
+      whiteboardId: boardId,
+    },
+  });
+}
 
 describe('deleteWhiteboard session unbind', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'botmux-wb-unbind-'));
     mkdirSync(join(tempDir, 'whiteboards'), { recursive: true });
     ipc.daemon = null;
-    ipc.fetchOk = true;
+    ipc.status = 200;
+    ipc.throws = false;
     ipc.fetches = [];
   });
 
@@ -55,86 +73,69 @@ describe('deleteWhiteboard session unbind', () => {
   });
 
   it('writes the row offline when no owning daemon is visible', async () => {
-    const board = createWhiteboard({
-      id: 'delete_offline',
-      title: 't',
-      larkAppId: 'app1',
-      chatId: 'c1',
-    });
-    seedPersistedSessionRows(tempDir, 'app1', {
-      s1: {
-        sessionId: 's1',
-        chatId: 'c1',
-        rootMessageId: 'r',
-        title: 's',
-        status: 'active',
-        createdAt: new Date().toISOString(),
-        larkAppId: 'app1',
-        whiteboardId: board.id,
-      },
-    });
+    const board = createWhiteboard({ id: 'delete_offline', title: 't', larkAppId: 'app1', chatId: 'c1' });
+    seedBoundSession('app1', board.id);
 
     const result = await deleteWhiteboard(board.id);
-    expect(result).toEqual({ ok: true, id: board.id, clearedSessions: 1 });
+    expect(result).toEqual({ ok: true, id: board.id, clearedSessions: 1, unresolvedSessions: 0 });
     expect(ipc.fetches).toEqual([]);
     expect(readPersistedSessionRows(tempDir, 'app1').s1.whiteboardId).toBeUndefined();
   });
 
   it('clears via owning-daemon IPC and does not write the row behind a live cache', async () => {
-    const board = createWhiteboard({
-      id: 'delete_ipc',
-      title: 't',
-      larkAppId: 'app1',
-      chatId: 'c1',
-    });
-    seedPersistedSessionRows(tempDir, 'app1', {
-      s1: {
-        sessionId: 's1',
-        chatId: 'c1',
-        rootMessageId: 'r',
-        title: 's',
-        status: 'active',
-        createdAt: new Date().toISOString(),
-        larkAppId: 'app1',
-        whiteboardId: board.id,
-      },
-    });
+    const board = createWhiteboard({ id: 'delete_ipc', title: 't', larkAppId: 'app1', chatId: 'c1' });
+    seedBoundSession('app1', board.id);
     ipc.daemon = { larkAppId: 'app1', ipcPort: 18765 };
 
     const result = await deleteWhiteboard(board.id);
-    expect(result.clearedSessions).toBe(1);
+    expect(result).toMatchObject({ clearedSessions: 1, unresolvedSessions: 0 });
     expect(ipc.fetches).toEqual([{
       port: 18765,
       path: '/api/sessions/s1/whiteboard',
-      body: { whiteboardId: null },
+      // Compare-and-set: the daemon may have rebound the session to a fresh
+      // board the moment this one left the index.
+      body: { whiteboardId: null, expectWhiteboardId: board.id },
     }]);
     expect(readPersistedSessionRows(tempDir, 'app1').s1.whiteboardId).toBe(board.id);
   });
 
-  it('does not offline-write when a daemon is visible but IPC fails (abortIf)', async () => {
-    const board = createWhiteboard({
-      id: 'delete_abort',
-      title: 't',
-      larkAppId: 'app1',
-      chatId: 'c1',
-    });
-    seedPersistedSessionRows(tempDir, 'app1', {
-      s1: {
-        sessionId: 's1',
-        chatId: 'c1',
-        rootMessageId: 'r',
-        title: 's',
-        status: 'active',
-        createdAt: new Date().toISOString(),
-        larkAppId: 'app1',
-        whiteboardId: board.id,
-      },
-    });
+  it('leaves a session the daemon rebound alone (IPC 409) and never falls back to a write', async () => {
+    const board = createWhiteboard({ id: 'delete_rebound', title: 't', larkAppId: 'app1', chatId: 'c1' });
+    seedBoundSession('app1', board.id);
     ipc.daemon = { larkAppId: 'app1', ipcPort: 18765 };
-    ipc.fetchOk = false;
+    ipc.status = 409;
 
     const result = await deleteWhiteboard(board.id);
-    expect(result.clearedSessions).toBe(0);
+    // Neither cleared (the daemon owns a different binding now) nor unresolved
+    // (nothing failed) — and the offline path must not try to overrule it.
+    expect(result).toMatchObject({ clearedSessions: 0, unresolvedSessions: 0 });
+    expect(ipc.fetches).toHaveLength(1);
     expect(readPersistedSessionRows(tempDir, 'app1').s1.whiteboardId).toBe(board.id);
+  });
+
+  it('reports the session as unresolved when a daemon is visible but IPC fails', async () => {
+    const board = createWhiteboard({ id: 'delete_abort', title: 't', larkAppId: 'app1', chatId: 'c1' });
+    seedBoundSession('app1', board.id);
+    ipc.daemon = { larkAppId: 'app1', ipcPort: 18765 };
+    ipc.throws = true;
+
+    const result = await deleteWhiteboard(board.id);
+    // The liveness re-probe inside the store aborts the offline write, so the
+    // row is untouched — and the count says so instead of a bare 0.
+    expect(result).toMatchObject({ clearedSessions: 0, unresolvedSessions: 1 });
+    expect(readPersistedSessionRows(tempDir, 'app1').s1.whiteboardId).toBe(board.id);
+  });
+
+  it('writes a legacy row that carries no larkAppId without probing any daemon', async () => {
+    const board = createWhiteboard({ id: 'delete_legacy', title: 't', larkAppId: 'app1', chatId: 'c1' });
+    // Pre-per-bot row in the flat store: no daemon runs a store without an
+    // appId, so there is no owner to defer to.
+    seedBoundSession(undefined, board.id);
+    ipc.daemon = { larkAppId: 'app1', ipcPort: 18765 };
+
+    const result = await deleteWhiteboard(board.id);
+    expect(result).toMatchObject({ clearedSessions: 1, unresolvedSessions: 0 });
+    expect(ipc.fetches).toEqual([]);
+    expect(readPersistedSessionRows(tempDir).s1.whiteboardId).toBeUndefined();
   });
 });

--- a/test/whiteboard-unbind-session.test.ts
+++ b/test/whiteboard-unbind-session.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { seedPersistedSessionRows, readPersistedSessionRows } from './helpers/session-store-disk.js';
+
+const ipc = vi.hoisted(() => ({
+  daemon: null as { larkAppId: string; ipcPort: number } | null,
+  fetchOk: true,
+  fetches: [] as Array<{ port: number; path: string; body: unknown }>,
+}));
+
+let tempDir: string;
+
+vi.mock('../src/config.js', () => ({
+  config: { session: { get dataDir() { return tempDir; } } },
+}));
+
+vi.mock('../src/global-config.js', () => ({
+  readGlobalConfig: () => ({ whiteboard: { enabled: true } }),
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../src/utils/daemon-discovery.js', () => ({
+  findOnlineDaemon: (larkAppId: string) => (
+    ipc.daemon?.larkAppId === larkAppId ? ipc.daemon : null
+  ),
+}));
+
+vi.mock('../src/core/daemon-ipc-auth.js', () => ({
+  loadDaemonIpcSecret: () => 'test-secret',
+  fetchDaemonIpc: async (port: number, path: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    ipc.fetches.push({ port, path, body });
+    return { ok: ipc.fetchOk, json: async () => ({ ok: ipc.fetchOk }) };
+  },
+}));
+
+import { createWhiteboard, deleteWhiteboard } from '../src/services/whiteboard-store.js';
+
+describe('deleteWhiteboard session unbind', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'botmux-wb-unbind-'));
+    mkdirSync(join(tempDir, 'whiteboards'), { recursive: true });
+    ipc.daemon = null;
+    ipc.fetchOk = true;
+    ipc.fetches = [];
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes the row offline when no owning daemon is visible', async () => {
+    const board = createWhiteboard({
+      id: 'delete_offline',
+      title: 't',
+      larkAppId: 'app1',
+      chatId: 'c1',
+    });
+    seedPersistedSessionRows(tempDir, 'app1', {
+      s1: {
+        sessionId: 's1',
+        chatId: 'c1',
+        rootMessageId: 'r',
+        title: 's',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        larkAppId: 'app1',
+        whiteboardId: board.id,
+      },
+    });
+
+    const result = await deleteWhiteboard(board.id);
+    expect(result).toEqual({ ok: true, id: board.id, clearedSessions: 1 });
+    expect(ipc.fetches).toEqual([]);
+    expect(readPersistedSessionRows(tempDir, 'app1').s1.whiteboardId).toBeUndefined();
+  });
+
+  it('clears via owning-daemon IPC and does not write the row behind a live cache', async () => {
+    const board = createWhiteboard({
+      id: 'delete_ipc',
+      title: 't',
+      larkAppId: 'app1',
+      chatId: 'c1',
+    });
+    seedPersistedSessionRows(tempDir, 'app1', {
+      s1: {
+        sessionId: 's1',
+        chatId: 'c1',
+        rootMessageId: 'r',
+        title: 's',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        larkAppId: 'app1',
+        whiteboardId: board.id,
+      },
+    });
+    ipc.daemon = { larkAppId: 'app1', ipcPort: 18765 };
+
+    const result = await deleteWhiteboard(board.id);
+    expect(result.clearedSessions).toBe(1);
+    expect(ipc.fetches).toEqual([{
+      port: 18765,
+      path: '/api/sessions/s1/whiteboard',
+      body: { whiteboardId: null },
+    }]);
+    expect(readPersistedSessionRows(tempDir, 'app1').s1.whiteboardId).toBe(board.id);
+  });
+
+  it('does not offline-write when a daemon is visible but IPC fails (abortIf)', async () => {
+    const board = createWhiteboard({
+      id: 'delete_abort',
+      title: 't',
+      larkAppId: 'app1',
+      chatId: 'c1',
+    });
+    seedPersistedSessionRows(tempDir, 'app1', {
+      s1: {
+        sessionId: 's1',
+        chatId: 'c1',
+        rootMessageId: 'r',
+        title: 's',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        larkAppId: 'app1',
+        whiteboardId: board.id,
+      },
+    });
+    ipc.daemon = { larkAppId: 'app1', ipcPort: 18765 };
+    ipc.fetchOk = false;
+
+    const result = await deleteWhiteboard(board.id);
+    expect(result.clearedSessions).toBe(0);
+    expect(readPersistedSessionRows(tempDir, 'app1').s1.whiteboardId).toBe(board.id);
+  });
+});


### PR DESCRIPTION
## 定位

会话架构 Stage 0（口径：`docs/design/2026-08-12-session-restage-store-first.md`）：**daemon 只写 SQLite，会话行改为行级 upsert。**

不是全仓 db-only，也不是 occupancy / 单一 apply。跨进程在「CLI 已升级、daemon 尚未重启」的窗口内仍走 db-else-json；删除这条回落的条件写在设计文档 Stage 0，不在本 PR。

#852 把引擎换成 SQLite 之后，daemon 仍保留着整套 JSON 写路径（`save()` 整图序列化、JSON CAS、`tmp+rename`）。本 PR 删掉 daemon 侧这套 JSON 写实现。相对当前 merge-base `origin/master@7bd2e974`，`session-store.ts`：**2646 → 2414**（约 −232；master 在此期间因 #1073 / #1093 的导入恢复逻辑变长，所以不再是旧基线上的 2154 → 1925）。跨进程 JSON 读与离线写刻意保留（约 25 行），否则升级窗口内 `botmux send` 读不到会话。

本 PR 不依赖灰度已关闭：升级窗口内六项行为与 master 逐项一致（对照表见「升级窗口」）。已 rebase 到最新 master；`git merge-tree origin/master HEAD` 无冲突。

---

## 改了什么

### 1. daemon 不再写 JSON

删除：

- `save()`：整份 map 序列化 + `tmp+rename` + byte-identical 跳写
- `load()` 里的 JSON 写回，以及 legacy → per-bot 的迁移写
- `readExistingSessionsFromDisk` / `readSessionsProjectionStrict`
- Remote lineage CAS + readback 的 JSON 实现
- `repairMissingChatScopes` 及它每次 load 触发的写回事务
- `persistRow` 回落到 `save()` 的分支

store 内的 `withFileLockSync` 只剩导入（以及 #1093 的中毒库恢复，与导入共用同一把 JSON 文件锁）。导入经固定的 `<db>.tmp` 暂存：同一 bot 的两个 owner 进程短暂并存时（重启撞上尚未回收的前任），两边都会通过 `existsSync(db)` 并写同一个 tmp。换成 per-process 的 tmp 名会留下无人清理的孤儿文件；直接建进最终 `.db` 会打破「`.db` 存在 ≡ 导入已完成」这条不变量。

`sessions-*.json` 降为一次性导入源：拥有该 bot 的 daemon 导入之后不再写它。其它进程在该 daemon 尚未导入时仍可读、可离线写，且任何路径都不得创建空 `.db`——空库会让导入门误判为已完成。

### 2. 导入期做一次性归一化，且不按 `sessionId` 重键

`stripLegacyPendingCardFields` / `repairMissingChatScope` 只在导入时执行一次。`loadAllSessionsSnapshot` 仍做纯内存归一化（它读的是别人的 store，不写盘）。

不按行内 `sessionId` 重键：两条 JSON 记录可以带同一个 `sessionId`，`INSERT OR REPLACE` 会让后写的 closed 幽灵覆盖活行；导入只跑一次、JSON 随后冻结，这一步不可逆。改为按文件原 key 导入，错键行保持不可达（身份扫描本就跳过 key 与 `sessionId` 不符的行）。

### 3. close / reactivate / mojo journal：先落盘，再合并回内存

原先在活对象上就地修改，失败再逐字段还原（close 14 个字段、reactivate 20 个、mojo 2 个）。改为：

```ts
const next: Session = { ...session };
next.status = 'closed';
persistRow(next);             // 抛错 → 内存未改
Object.assign(session, next); // 提交后才落内存
```

用 `Object.assign` 而不是替换 map 引用，保留 `DaemonSession` 的共享别名。既有三条回滚回归（Remote lineage / previewTarget / mojo park）断言未改，继续绿。

### 4. 读写方式打开会创建空库

`new DatabaseSync('<missing>.db')` 会把文件建出来；空库让 `existsSync(db)` 为真、跳过 JSON 导入，迁移前的会话从所有活路径上消失。

- `openDbForRead` 对不存在的路径直接抛错
- `withOwnStoreDb` 复用 `loadForWrite()` 已附着的连接，不再自开
- `mutateSessionRowOffline` 的 sqlite 路径在 `openDbForOwnStore` 前再 `existsSync` 一次，缺文件返回 undefined

### 5. 删除已失效的等待上限参数

Remote 批量 API 的 `options.maxWaitMs` 删除：它约束的是 JSON 文件锁的等待，SQLite 路径上从未生效。等待上限由连接级 `busy_timeout`（3s）决定。fleet shutdown 的 `remaining <= 0` 预检保留。

### 6. 沙盒授权

readOnly 授权为「`session-stores/<appId>` 目录 + 冻结的 `sessions-<appId>.json`」。授目录而不是三个文件，是因为单文件 bind 会钉死 WAL sidecar 的 inode，而 SQLite 在 daemon 重启时会删建 `-wal`/`-shm`——长驻的沙盒面板会一直读着已死的 WAL。兄弟 bot 的 store 目录仍 deny-by-default；测试补了 sibling 目录、共享父目录、spawn 之后才出现的库三条 none 断言。

升级窗口内沙盒里的 `botmux send` 仍要 stat 得到那份冻结 JSON，所以该授权暂不撤。

### 7. 删除白板：daemon 在走 IPC，不在才离线写

`clearSessionWhiteboardRefs` 原先按 `sessions*.json` 筛文件名再整份改写。#852 之后行已在 SQLite，扫描匹配不到文件，`deleteWhiteboard` 返回 `clearedSessions: 0`，而 `whiteboardId` 仍指向已删的板。

改为走 store 后还有三个问题要收：

- **解绑必须按板 id 比对。** 删板会先把板移出 index，daemon 的 `ensureSessionWhiteboard` 因此会在该会话下一轮立刻补一块新板。无条件发 `whiteboardId=null` 会把这块新绑定一起抹掉，并留下一块没人指向的孤儿板。路由新增 `expectWhiteboardId`，不匹配返回 409；离线路径本来就有比对，两侧口径现在一致。
- **未能解绑要报出来。** daemon 可见但 IPC 不可用时，离线写会被存内探测中止——这是对的（不能绕过持有内存缓存的 daemon），但结果不该和「没有会话引用这块板」一样报 0。这类会话计入 `unresolvedSessions` 返回。
- **IPC 要有超时。** 心跳新鲜但 socket 不响应的 daemon，不能把 dashboard 的删除请求一直挂住。

行为分支：daemon 运行中 → IPC 带 CAS 解绑；daemon 不可见 → 离线写；IPC 失败且 daemon 仍可见 → 不写盘，计入 `unresolvedSessions`。

### 8. 离线写与 daemon 发现各收敛成一份实现

新增 `services/session-offline-write.ts#mutateSessionRowWhenUnowned`：把「离线写的前提是没有 daemon 持有这一行」收成一个入口，`cli.ts` 与 `whiteboard-store` 共用，探测与 store 读写用同一个 dataDir。此前每个调用方各自拼一遍 `abortIf`，本 PR 的白板路径第一版就漏了。

`cli.ts` 私有的心跳目录解析与 90s 过期判定（与 `utils/daemon-discovery.ts` 逐字重复）删除，改用共享实现；`listOnlineDaemons` / `findOnlineDaemon` 增加可选 `dataDir` 参数。设计文档 Stage 1 要求「心跳探测不再作为所有权判断」，收敛后只剩一个入口要删。`src/cli.ts` 净 −38 行。

### 9. 冻结的 JSON 文件

磁盘上原地保留、不改名。daemon 导入后运行时不再写它；升级窗口内其它进程仍可能读；它也是回退到迁移前版本时的数据副本。改名会让回退后的旧 daemon 从空库起步，再写出一份新 JSON。

---

## 一并修复的 #852 遗留问题

### A. Bun 上导入发布出只有文件头的库（已在 master，本 PR 只保留）

暂存库开着 WAL、`renameSync` 只搬走主文件，在 Bun 上会发布 4 KB 文件头，导入门永久钉死。这条已由 [#1073](https://github.com/deepcoldy/botmux/pull/1073) 合入 master（暂存 `PRAGMA journal_mode = DELETE`）；已中毒的库由 [#1093](https://github.com/deepcoldy/botmux/pull/1093) 恢复。本 PR rebase 时保留了这两处，没有另开一套实现。

### B. 删除白板后 `whiteboardId` 仍指向已删的板

见上「7」。原因是按文件名筛 `sessions*.json` 的扫描在 #852 之后匹配不到任何文件，而测试夹具当时写的正是 JSON，所以一直绿。

### C. Node 22 加载 `node:sqlite` 时向 stderr 打出 ExperimentalWarning

```
ExperimentalWarning: SQLite is an experimental feature and might change at any time
```

pty 合流后这两行进入 `botmux list` 的备用屏，把钉住的标题挤出第 0 行；CI（Node 22）上 picker 断言读到空行。Node 24 已不发此警告，本机 24 复现不了。#852 之后凡是打开 `.db` 的 CLI 都会污染 stderr，本 PR 让 `botmux list` 也打开库，才在 CI 暴露。

修法是在 `sqlite-compat` 的 `require` 期间过滤该警告，require 结束即还原——`process.on('warning')` 拦不住 Node 的默认打印。回归：`test/sqlite-compat-warning.test.ts`（Node 24 上恒绿，真正的拦截在 CI 的 Node 22）。

---

## 身份扫描

`readSessionRowCopiesAcrossStores` 要求恰好一份。legacy → per-bot 一直是复制而不删除，导入完成后若把冻结 JSON 也算一份，会把合法会话判成重复。本 PR 在已有 `.db` 时不再把同一 bot 的冻结 JSON 算作第二份。

未导入、尚无 `.db` 时 JSON 回落仍在，`sessions-evil.json` 这类按文件名冒充 store 的路径并未从窗口内消失。

---

## 升级窗口

初版曾把跨进程也改成只读 SQLite，前提是「灰度已关闭」。这个前提不成立：`npm i -g` 的 postinstall 会立刻改写 `~/.botmux/bin/botmux`，而 daemon 仍跑着旧代码；自动更新默认关闭，`botmux upgrade` 只提示用户自己 `botmux restart`。窗口没有上界，每个从 JSON 写者升级上来的用户都会经过一次。

同一份仅有 JSON 的数据目录，逐项对照：

| 窗口内操作 | master | 跨进程 db-only（已撤回） | 现在 |
|---|---|---|---|
| CLI 快照读（`botmux send` / `list`） | `['s1']` | **抛错** | `['s1']` |
| CLI 点读 | `LIVE` | undefined | `LIVE` |
| 身份扫描 | 1 份 | 0 份 | 1 份 |
| worker `getSession` | `LIVE` | undefined | `LIVE` |
| worker `getSessionFresh` | `LIVE` | undefined | `LIVE` |
| CLI 离线写 | ok → closed | **抛错** | ok → closed |

所以只删 daemon 的 JSON 写路径。跨进程读、离线写、`owner: false` 的只读 load、沙盒对冻结 JSON 的授权都保留。删除这些分支的条件写在设计文档 Stage 0：升级后自动重启 fleet 落地，或 2026-11-26 的兜底复核点。

老版本升到本版并重启 daemon 后，一次性导入仍会带上 active 与 closed 行（有回归覆盖）。

---

## 影响面

- 主要改 `session-store`、`whiteboard-store`、`dashboard-ipc-server`；新增 `services/session-offline-write.ts`；另及 `cli.ts` 的 daemon 发现、`utils/daemon-discovery.ts`、`fs-policy`、`remote-shutdown-detach` 的调用签名。
- **跨进程**：daemon 在线时写 SQLite；worker `owner: false` 走 db-else-json 只读、不建库；CLI 离线写在已有 `.db` 时走 `BEGIN IMMEDIATE` + 心跳探测（SQLite 锁不替代「daemon 内存与磁盘分叉」的探测），未导入则写 JSON；跨 bot 发现同样 db-else-json。dashboard 删白板：daemon 在则 IPC 带 CAS 解绑，不在才离线写。
- **跨平台**：Linux bwrap / macOS Seatbelt 仍授 store 目录（单文件 bind 会钉死 WAL sidecar 的 inode）。
- **跨 CLI / 后端 / 会话类型**：`updateSession` 等签名不变；Pty/Tmux、话题会话/群会话、adopt/restore、sandbox on/off 仍走同一套 store 导出。
- **`cli.ts` 的 daemon 发现换实现**：约 35 处调用点行为不变（同一个心跳目录、同样的 90s 过期、同样的字段），差异只在数据目录改为显式传入。
- 旁路存储未改：turn-sends / frozen-card / whiteboard 正文 / usage-ledger / idempotency / vc-meeting-* / schedule / pending-turn journal；`utils/file-lock.ts` 本体未动。
- occupancy（库内租约）和单一 apply **不在本 PR**。心跳探测在 CLI 离线写与删白板离线路径上保留。

---

## 已知边界

- 离线写在 SQLite 路径只改一行，不再顺手删除错键行。
- 跨进程 JSON 读分支仍在（约 25 行）。删除条件见设计文档 Stage 0，不是「感觉灰度稳了」。
- Remote 批量的等待上限固定为 `busy_timeout` 3s。
- `restoreActiveSessions` 仍走 `listSessions()`：损坏库会被当成空投影启动（写路径有 `listSessionsStrict`）。与 #852 相同，本 PR 未改。
- 删白板时若某个会话的 daemon 可见但 IPC 不可用，该行的绑定会留在盘上指向已删的板。它不是坏数据：daemon 的 `ensureSessionWhiteboard` 会在该会话下一轮补上新板。本 PR 只保证这种情况被计数报出，不静默。

---

## 测试与验证

未跑 `switch:here`，未重启 live daemon。

- rebase 到 `origin/master@7bd2e974`；`git merge-tree origin/master HEAD` 无冲突。
- `tsc --noEmit -p tsconfig.json` 干净；`bun run build` 通过。
- **必过 CI 全绿**：build / bun-binary / bun-binary-musl / CodeQL / 三个 Analyze。`build` 在 Linux + Node 22 上跑完整 unit。`bun-test` 与 master 同为 34 个文件失败（`continue-on-error`，非门禁）；失败集合与 `origin/master@7bd2e974` 逐文件一致，本 PR 未新增 bun 腿失败。
- 本机（rebase 后）：`test/session-store.test.ts`、`test/session-store-sqlite.test.ts`、`test/session-store-sqlite-poisoned-recovery.test.ts`、`test/session-store-sqlite-bun-import.test.ts`、白板解绑、`fs-policy`、`sqlite-compat-warning`、`remote-shutdown-detach`、`whiteboard-cli` 共 298 条绿。
- Bun 1.4.0 与 Node 24 各跑一次真实导入：均为 24576B、行可读回、无 `.tmp` 残留（修复前 Bun 上是 4096B 空壳 + 孤儿 sidecar + `disk I/O error`；该修复已在 master）。

新增回归覆盖：升级窗口内的 snapshot / 点读 / 身份扫描 / worker 读 / 离线写；`owner: false` 的 load 只读；`botmux delete` 在仅有 JSON 时写回 JSON 且不建 `.db`；snapshot 与离线写都不创建 store；已导入 store 的冻结 JSON 不算身份扫描第二份；导入时剥掉 legacy 卡片字段；同 `sessionId` 的两行不得互相覆盖；白板解绑的 CAS、409 不回落写盘、IPC 失败计入 `unresolvedSessions`、无 `larkAppId` 的 legacy 行不探测 daemon。

夹具：`seedPersistedSessionRows` / `sessionStorePath` 播种真实 SQLite。断言数量只增不减。
