### PR TITLE
feat(release): 支持 musl（Alpine）二进制，npm 按 libc 自动选包

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,76 @@ jobs:
         # instead of booting a credentialed bot.
         run: node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64
 
+  # The musl (Alpine) binary, gated on PRs — not only at release time.
+  #
+  # WHY THIS JOB EXISTS SEPARATELY FROM `bun-binary`: the musl binary is a shipped
+  # artifact with a DIFFERENT native. `pty.node` is embedded at compile time and
+  # node-pty ships no linux prebuild, so it is compiled against whatever libc the
+  # builder runs on (measured: glibc host → `NEEDED libc.so.6`; node:22-alpine →
+  # `NEEDED libc.musl-x86_64.so.1`). A glibc native inside a musl binary builds
+  # cleanly and fails only when the native is dlopen'd, on the user's machine.
+  #
+  # This job previously lived ONLY in release.yml, which runs on tag push. That
+  # meant a PR could change the build script, the embed plugin, or node-pty's
+  # version and the musl leg was first exercised during a release — after npm had
+  # published. This mirrors the release leg so the PR gate is not weaker.
+  #
+  # Only linux-x64-musl is built: GitHub offers no Alpine runner, so musl requires
+  # a container, and arm64 would need the (slower, separately-queued) arm64 runner.
+  # The release workflow still builds BOTH musl arches; this is the PR canary.
+  bun-binary-musl:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # node:22-alpine supplies musl + a Node for the scripts. setup-bun does not run
+    # in a musl container, so bun comes from npm below.
+    container: node:22-alpine
+
+    steps:
+      # git is absent from the base image and checkout needs it for a real clone;
+      # python3/make/g++ are node-gyp's toolchain, required because node-pty has no
+      # linux prebuild and must compile here.
+      - name: Install toolchain (musl needs node-gyp deps for node-pty)
+        run: apk add --no-cache git python3 make g++ libstdc++ bash tar
+
+      - uses: actions/checkout@v6
+
+      - name: Install bun
+        run: npm i -g bun@1.4.0 --loglevel=error
+
+      # Compiles node-pty against MUSL — the entire point of this job.
+      - run: bun install --frozen-lockfile
+
+      - name: Verify the native is musl-linked
+        # Fail closed rather than compiling a musl binary around a glibc native.
+        # That mistake survives the build and surfaces only when the native is
+        # loaded, so assert the linkage here where it is cheap and unambiguous.
+        run: |
+          f=node_modules/node-pty/build/Release/pty.node
+          test -f "$f" || { echo "node-pty native missing at $f"; exit 1; }
+          apk add --no-cache binutils >/dev/null
+          if ! readelf -d "$f" | grep -q 'libc\.musl'; then
+            echo "REFUSING: $f is not musl-linked:"; readelf -d "$f" | grep NEEDED; exit 1
+          fi
+          echo "ok: $(readelf -d "$f" | grep NEEDED | tr -s ' ')"
+
+      - name: Stamp a synthetic version (mirrors the release job)
+        # Same reason and same ORDER as the glibc job above: the compiled binary has
+        # no package.json on disk, so the version is baked at compile time, and the
+        # repo's `0.0.0` placeholder is deliberately treated as "nothing baked" —
+        # compiling from it yields `--version: unknown`, which the smoke gate fails.
+        run: npm version "0.0.0-ci.${{ github.run_number }}" --no-git-tag-version --allow-same-version
+
+      - run: bun run build
+
+      - name: Compile the musl binary
+        run: bun scripts/build-bun-binary.mjs --target bun-linux-x64-musl --out dist-bin/botmux-linux-x64-musl
+
+      - name: Smoke-test the musl binary
+        # Same shared script as the glibc leg, so this gate can never be the weaker
+        # one. This is also where an unloadable native is caught: `dist/cli.js`
+        # statically imports node-pty (via the backends), and node-pty dlopens the
+        # native at MODULE scope — verified by mutation, corrupting the embedded
+        # pty.node makes check 1 die with `ERR_DLOPEN_FAILED`. So running the binary
+        # at all proves the musl native loads; no separate PTY step is needed.
+        run: node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64-musl
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
   # `if: github.event_name == 'push'`. If you ever add an `if:` here you MUST
   # also re-assert `needs.<each>.result == 'success'` for every entry in `needs`.
   release:
-    needs: [preflight, bun-binaries, binary-subpackages]
+    needs: [preflight, bun-binaries, bun-binaries-musl, binary-subpackages]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -731,6 +731,102 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  bun-binaries-musl:
+    # The musl (Alpine) legs, in a CONTAINER rather than on the runner.
+    #
+    # WHY A SEPARATE JOB: `pty.node` is embedded into the binary at build time, and
+    # node-pty ships NO linux prebuild — so the builder compiles it against whatever
+    # libc it runs on. Measured: on a glibc host the result is
+    # `NEEDED libc.so.6`; inside node:22-alpine it is `NEEDED libc.musl-x86_64.so.1`.
+    # Cross-compiling a musl target from the glibc runner would therefore embed a
+    # glibc native and fail at PTY spawn on Alpine — at RUNTIME, silently, not at
+    # build time. So the musl targets must be compiled on musl.
+    #
+    # Verified end-to-end before this job existed: inside node:22-alpine, building
+    # with scripts/build-bun-binary.mjs --target bun-linux-x64-musl and then running
+    # the result spawned a real PTY (`PTY_OK_FROM_MUSL`). That check matters because
+    # a binary that merely STARTS proves nothing — a libc mismatch fails at the
+    # moment the native module loads.
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            targets: bun-linux-x64-musl
+            artifact: linux-x64-musl
+          - os: ubuntu-24.04-arm
+            targets: bun-linux-arm64-musl
+            artifact: linux-arm64-musl
+    runs-on: ${{ matrix.os }}
+    # node:22-alpine gives us musl + a Node for the scripts. bun is installed below
+    # (setup-bun does not support musl containers).
+    container: node:22-alpine
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+    steps:
+      # git is not in the base image, and checkout needs it for a real clone.
+      - name: Install toolchain (musl needs node-gyp deps for node-pty)
+        run: apk add --no-cache git python3 make g++ libstdc++ bash tar
+
+      - uses: actions/checkout@v6
+
+      - name: Install bun
+        # oven-sh/setup-bun does not run in a musl container; npm's bun package does.
+        run: npm i -g bun@1.4.0 --loglevel=error
+
+      # Compiles node-pty against MUSL — the whole point of this job.
+      - run: bun install --frozen-lockfile
+
+      - name: Verify the native is musl-linked
+        # Fail closed rather than shipping a glibc native inside a musl binary. That
+        # mistake would survive the build and only surface when a user spawns a PTY.
+        run: |
+          f=node_modules/node-pty/build/Release/pty.node
+          test -f "$f" || { echo "node-pty native missing at $f"; exit 1; }
+          apk add --no-cache binutils >/dev/null
+          if ! readelf -d "$f" | grep -q 'libc\.musl'; then
+            echo "REFUSING: $f is not musl-linked:"; readelf -d "$f" | grep NEEDED; exit 1
+          fi
+          echo "ok: $(readelf -d "$f" | grep NEEDED | tr -s ' ')"
+
+      - name: Sync version from git tag to package.json
+        run: npm version "${RELEASE_TAG#v}" --no-git-tag-version --allow-same-version
+
+      - run: bun run build
+
+      - name: Compile Bun single-file executables (musl)
+        run: |
+          mkdir -p dist-bin
+          for t in ${{ matrix.targets }}; do
+            bun scripts/build-bun-binary.mjs --target "$t" --out "dist-bin/botmux-${t#bun-}"
+          done
+
+      - name: Smoke-test the musl binary
+        # Runs the binary this container just built, on musl — the only place it can
+        # be executed. Same shared script as the glibc legs and the PR gate.
+        run: |
+          HOST_ARCH="$(node -e 'process.stdout.write(process.arch)')"
+          BIN="dist-bin/botmux-linux-${HOST_ARCH}-musl"
+          if [ ! -x "$BIN" ]; then echo "musl binary $BIN not built"; exit 1; fi
+          node scripts/smoke-bun-binary.mjs "$BIN"
+
+      - name: Checksums
+        run: |
+          cd dist-bin
+          for f in botmux-*; do sha256sum "$f" > "$f.sha256"; done
+          ls -la
+
+      - name: Upload binaries as workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bun-binaries-${{ matrix.artifact }}
+          path: dist-bin/botmux-*
+          if-no-files-found: error
+          retention-days: 7
+
   binary-subpackages:
     # Publish the four platform subpackages — `botmux-linux-x64`,
     # `botmux-linux-arm64`, `botmux-darwin-x64`, `botmux-darwin-arm64` — each
@@ -745,7 +841,7 @@ jobs:
     #
     # Single runner, not a matrix: publishing is pure npm I/O with no native
     # build, so both OSes' binaries are packed here from the artifacts.
-    needs: [preflight, bun-binaries]
+    needs: [preflight, bun-binaries, bun-binaries-musl]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -788,7 +884,7 @@ jobs:
         # one carry the tag's version.
         run: |
           VERSION="${RELEASE_TAG#v}"
-          for plat in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+          for plat in linux-x64 linux-arm64 linux-x64-musl linux-arm64-musl darwin-x64 darwin-arm64; do
             src="dist-bin/botmux-${plat}"
             dir="packages/binary-${plat}"
             if [ ! -f "$src" ]; then echo "missing compiled binary $src"; exit 1; fi
@@ -818,8 +914,8 @@ jobs:
     # the binaries can be re-attached by hand. The npm channel already carries the
     # same binaries inside the platform subpackages, so a missing Release asset
     # only affects the curl/install.sh path.
-    if: github.event_name == 'push' && needs.bun-binaries.result == 'success' && needs.release.result == 'success'
-    needs: [bun-binaries, release]
+    if: github.event_name == 'push' && needs.bun-binaries.result == 'success' && needs.bun-binaries-musl.result == 'success' && needs.release.result == 'success'
+    needs: [bun-binaries, bun-binaries-musl, release]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/install.sh
+++ b/install.sh
@@ -40,17 +40,26 @@ asset="botmux-${os_tag}-${arch_tag}"
 # On Linux, pick the musl build when the C library is musl (Alpine and most slim
 # Docker images). A glibc-linked binary does not run there at all — it dies in the
 # loader with a message that names no cause — so guessing wrong is worse than not
-# installing. `uname` cannot tell us this, so probe the loader.
+# installing. `uname` cannot tell us this, so probe the libc.
 #
-# Deliberately conservative: only switch to musl when musl is POSITIVELY observed,
-# so a glibc box can never be pushed onto the musl asset by a false positive.
+# `ldd` IS AUTHORITATIVE IN BOTH DIRECTIONS when present: glibc and musl both ship
+# one, so if it answers "musl" we are on musl, and if it answers anything else we are
+# NOT — do not let a later probe overturn it. That matters because a glibc distro can
+# legitimately have musl INSTALLED (Debian/Ubuntu `musl` / `musl-tools`, common for
+# Rust/Go musl cross-compiling) which drops /lib/ld-musl-x86_64.so.1 at top level.
+# Measured: debian:bookworm-slim + musl-tools was selecting the musl asset — an
+# install that "succeeds" and then fails in the loader on first run.
+#
+# The filesystem probes are therefore the fallback for images with NO ldd at all
+# (distroless-style). Deliberately conservative: only claim musl when positively
+# observed, so a glibc box is never pushed onto the musl asset.
 if [ "$os_tag" = linux ]; then
   is_musl=0
-  # `ldd --version` prints "musl libc" on Alpine; on glibc it prints "GNU libc"/
-  # "GLIBC". musl's ldd exits non-zero for --version, so ignore the status.
-  if (ldd --version 2>&1 || true) | grep -qi musl; then
-    is_musl=1
-  # Fallbacks for images without ldd: the loader itself, then Alpine's marker.
+  if command -v ldd >/dev/null 2>&1; then
+    # musl's ldd exits non-zero for --version, so read the output, not the status.
+    if (ldd --version 2>&1 || true) | grep -qi musl; then
+      is_musl=1
+    fi
   elif ls /lib/ld-musl-* >/dev/null 2>&1 || ls /usr/lib/ld-musl-* >/dev/null 2>&1; then
     is_musl=1
   elif [ -f /etc/alpine-release ]; then

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,28 @@ case "$arch" in
 esac
 asset="botmux-${os_tag}-${arch_tag}"
 
+# On Linux, pick the musl build when the C library is musl (Alpine and most slim
+# Docker images). A glibc-linked binary does not run there at all — it dies in the
+# loader with a message that names no cause — so guessing wrong is worse than not
+# installing. `uname` cannot tell us this, so probe the loader.
+#
+# Deliberately conservative: only switch to musl when musl is POSITIVELY observed,
+# so a glibc box can never be pushed onto the musl asset by a false positive.
+if [ "$os_tag" = linux ]; then
+  is_musl=0
+  # `ldd --version` prints "musl libc" on Alpine; on glibc it prints "GNU libc"/
+  # "GLIBC". musl's ldd exits non-zero for --version, so ignore the status.
+  if (ldd --version 2>&1 || true) | grep -qi musl; then
+    is_musl=1
+  # Fallbacks for images without ldd: the loader itself, then Alpine's marker.
+  elif ls /lib/ld-musl-* >/dev/null 2>&1 || ls /usr/lib/ld-musl-* >/dev/null 2>&1; then
+    is_musl=1
+  elif [ -f /etc/alpine-release ]; then
+    is_musl=1
+  fi
+  [ "$is_musl" -eq 1 ] && asset="${asset}-musl"
+fi
+
 # ── Resolve the download URLs (binary + checksum) ─────────────────────────────
 if [ "${BOTMUX_VERSION:-latest}" = "latest" ]; then
   base="https://github.com/${REPO}/releases/latest/download"

--- a/packages/binary-linux-arm64-musl/.gitignore
+++ b/packages/binary-linux-arm64-musl/.gitignore
@@ -1,0 +1,3 @@
+# CI drops the compiled Bun binary here right before publishing (~100MB).
+# Never commit it — the published tarball gets it via `files: ["botmux"]`.
+botmux

--- a/packages/binary-linux-arm64-musl/package.json
+++ b/packages/binary-linux-arm64-musl/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "botmux-linux-arm64",
+  "name": "botmux-linux-arm64-musl",
   "version": "0.0.0",
-  "description": "The Linux arm64 binary for botmux",
+  "description": "The Linux arm64 (musl / Alpine) binary for botmux",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/deepcoldy/botmux.git",
-    "directory": "packages/binary-linux-arm64"
+    "directory": "packages/binary-linux-arm64-musl"
   },
   "os": [
     "linux"
@@ -15,7 +15,7 @@
     "arm64"
   ],
   "libc": [
-    "glibc"
+    "musl"
   ],
   "files": [
     "botmux"

--- a/packages/binary-linux-x64-musl/.gitignore
+++ b/packages/binary-linux-x64-musl/.gitignore
@@ -1,0 +1,3 @@
+# CI drops the compiled Bun binary here right before publishing (~100MB).
+# Never commit it — the published tarball gets it via `files: ["botmux"]`.
+botmux

--- a/packages/binary-linux-x64-musl/package.json
+++ b/packages/binary-linux-x64-musl/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "botmux-linux-arm64",
+  "name": "botmux-linux-x64-musl",
   "version": "0.0.0",
-  "description": "The Linux arm64 binary for botmux",
+  "description": "The Linux x64 (musl / Alpine) binary for botmux",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/deepcoldy/botmux.git",
-    "directory": "packages/binary-linux-arm64"
+    "directory": "packages/binary-linux-x64-musl"
   },
   "os": [
     "linux"
   ],
   "cpu": [
-    "arm64"
+    "x64"
   ],
   "libc": [
-    "glibc"
+    "musl"
   ],
   "files": [
     "botmux"

--- a/packages/binary-linux-x64/package.json
+++ b/packages/binary-linux-x64/package.json
@@ -14,6 +14,9 @@
   "cpu": [
     "x64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "files": [
     "botmux"
   ],

--- a/scripts/build-bun-binary.mjs
+++ b/scripts/build-bun-binary.mjs
@@ -38,7 +38,27 @@ const require = createRequire(import.meta.url);
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Compile targets for the botmux fleet. Kept in sync with release.yml.
-const RELEASE_TARGETS = ['bun-linux-x64', 'bun-linux-arm64', 'bun-darwin-x64', 'bun-darwin-arm64'];
+//
+// The `-musl` variants exist because Alpine (and most slim Docker images) link
+// against musl libc, where a glibc-linked binary does not run at all — it dies in
+// the loader with an error that names no cause. npm selects the right one on its
+// own: each platform subpackage declares `libc: ["musl"] | ["glibc"]` (undocumented
+// in `npm help package-json` but live in the wild, e.g. @napi-rs/canvas ships both).
+//
+// ⚠️ A musl binary MUST be compiled on musl: `pty.node` is embedded at build time,
+// and node-pty has no linux prebuild, so the builder compiles it against whatever
+// libc it is running on (verified: glibc box → `NEEDED libc.so.6`, Alpine container
+// → `NEEDED libc.musl-x86_64.so.1`). release.yml therefore runs the musl legs inside
+// an Alpine container — cross-compiling them from a glibc runner would embed the
+// wrong native and fail at PTY spawn, not at build time.
+const RELEASE_TARGETS = [
+  'bun-linux-x64',
+  'bun-linux-arm64',
+  'bun-linux-x64-musl',
+  'bun-linux-arm64-musl',
+  'bun-darwin-x64',
+  'bun-darwin-arm64',
+];
 
 function parseArgs(argv) {
   const args = { target: undefined, out: undefined, all: false };

--- a/scripts/inject-optional-binaries.mjs
+++ b/scripts/inject-optional-binaries.mjs
@@ -48,12 +48,23 @@ if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
   throw new Error(`invalid version ${JSON.stringify(version)} (expected X.Y.Z or X.Y.Z-tag.N, no leading "v")`);
 }
 
-/** The four platform subpackages, matching packages/binary-<platform>-<arch>/. */
+/**
+ * The platform subpackages, matching packages/binary-<platform>-<arch>[-musl]/.
+ *
+ * The two `-musl` entries are load-bearing for Alpine: npm chooses among optional
+ * platform deps by `os`/`cpu`/`libc`, and `libc` is the ONLY field that separates a
+ * musl host from a glibc one (both report linux/x64). Publishing the musl
+ * subpackages without listing them here leaves them on the registry with nothing
+ * referencing them — npm never even considers them, and Alpine falls back to the
+ * glibc package, which cannot exec.
+ */
 export const PLATFORM_PACKAGES = [
   'botmux-darwin-arm64',
   'botmux-darwin-x64',
   'botmux-linux-arm64',
+  'botmux-linux-arm64-musl',
   'botmux-linux-x64',
+  'botmux-linux-x64-musl',
 ];
 
 const manifestPath = join(repoRoot, 'package.json');

--- a/scripts/postinstall-bin.mjs
+++ b/scripts/postinstall-bin.mjs
@@ -49,8 +49,6 @@ import { homedir } from 'node:os';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
-const SUBPACKAGE = `botmux-${process.platform}-${process.arch}`;
-
 /** Abort the install with a reason. There is no Node fallback any more (see header). */
 function fail(reason, hint) {
   console.error(`[botmux] ${reason}`);
@@ -120,18 +118,19 @@ if (existsSync(join(pkgRoot, '.git')) && existsSync(join(pkgRoot, 'src'))) {
   process.exit(0);
 }
 
-// ── Guard 3: musl (Alpine) would install a glibc binary that cannot exec ────────
-// Checked BEFORE resolving the subpackage, because on Alpine the subpackage does
-// resolve (platform is `linux`) — so the generic "no prebuilt binary" message below
-// would never fire and we would happily point the launcher at a binary that dies at
-// startup. Fail here with the actual reason instead.
-if (isMuslLinux()) {
-  fail(
-    `botmux's prebuilt binaries are glibc-linked and cannot run on musl libc (Alpine).`,
-    'Use a glibc base image (e.g. node:22-bookworm / debian / ubuntu), or build from source. '
-      + 'Tracking musl builds: https://github.com/deepcoldy/botmux/issues',
-  );
-}
+// ── musl (Alpine): select the -musl subpackage ──────────────────────────────────
+// This used to be a hard FAIL ("botmux's prebuilt binaries are glibc-linked and
+// cannot run on musl"), which was true while only glibc binaries shipped. musl
+// binaries now exist, so that message became a lie and the guard would have blocked
+// the very platform we just added support for. The #1047 comment predicted this:
+// "Once botmux ships musl subpackages declaring it, npm will pick the right one on
+// its own and this guard becomes a diagnostic".
+//
+// npm does the actual selection via each subpackage's `libc` field, so on Alpine it
+// installs `botmux-linux-<arch>-musl`. We only have to look for the same name — the
+// detection below is what makes the lookup agree with what npm installed.
+const MUSL = isMuslLinux();
+const SUBPACKAGE = `botmux-${process.platform}-${process.arch}${MUSL ? '-musl' : ''}`;
 
 // ── Locate the platform binary ─────────────────────────────────────────────────
 // Resolve through Node's own resolver rather than guessing at node_modules layout:

--- a/test/ci-musl-gate.test.ts
+++ b/test/ci-musl-gate.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The musl (Alpine) binary is a SHIPPED artifact whose native differs from every
+ * other platform's: `pty.node` is embedded at compile time and node-pty has no
+ * linux prebuild, so it is compiled against whatever libc the builder runs on. A
+ * glibc native inside a musl binary builds cleanly and fails only when the native
+ * is dlopen'd — on the user's machine.
+ *
+ * That artifact was originally gated ONLY in release.yml, which runs on tag push.
+ * So a PR could change the build script, the embed plugin, or node-pty's version
+ * and the musl leg was first exercised during a release, after npm had published.
+ * ci.yml now carries a musl job too.
+ *
+ * WHAT THESE TESTS DEFEND: not the YAML's shape, but the claim "the PR gate is not
+ * weaker than the release gate for musl". Every assertion below corresponds to a
+ * step whose removal would leave CI green while silently un-gating musl:
+ *   • no musl job at all              → back to release-only discovery
+ *   • builds a non-musl target        → gates the wrong artifact
+ *   • no readelf linkage check        → a glibc native ships inside a musl binary
+ *   • no smoke run                    → compiles but never executes it (and the
+ *     smoke run is what proves the native LOADS — see the dlopen note below)
+ *
+ * Deliberately parsed as text rather than YAML: the assertions are about specific
+ * commands being present, and a text match cannot be satisfied by a structurally
+ * valid file that runs something else.
+ */
+
+const CI = readFileSync(resolve(import.meta.dirname, '../.github/workflows/ci.yml'), 'utf-8');
+const RELEASE = readFileSync(resolve(import.meta.dirname, '../.github/workflows/release.yml'), 'utf-8');
+
+/** Strip `#` comments so a claim can never be satisfied by prose ABOUT the claim.
+ *  (A comment mentioning `--target bun-linux-x64-musl` would otherwise pass an
+ *  assertion that the job actually builds that target.) */
+const stripComments = (yaml: string) => yaml
+  .split('\n')
+  .map((line) => line.replace(/(^|\s)#.*$/, '$1'))
+  .join('\n');
+
+const CI_CODE = stripComments(CI);
+const RELEASE_CODE = stripComments(RELEASE);
+
+describe('ci.yml — the musl artifact is gated on PRs, not only at release', () => {
+  it('defines a musl binary job', () => {
+    expect(CI_CODE).toMatch(/^ {2}bun-binary-musl:/m);
+  });
+
+  it('runs that job in a musl container (GitHub has no Alpine runner)', () => {
+    // Without a musl container the job would compile on glibc and prove nothing:
+    // the native is whatever libc the builder has.
+    expect(CI_CODE).toMatch(/container:\s*node:22-alpine/);
+  });
+
+  it('compiles the musl TARGET (not the glibc one it sits next to)', () => {
+    expect(CI_CODE).toContain('--target bun-linux-x64-musl');
+  });
+
+  it('asserts the native is musl-linked before compiling around it', () => {
+    // The fail-closed readelf gate. A glibc `pty.node` embedded in a musl binary
+    // survives the build; this is the only cheap place it is unambiguous.
+    expect(CI_CODE).toMatch(/readelf -d .*grep -q 'libc\\\.musl'/);
+  });
+
+  it('EXECUTES the musl binary through the shared smoke script', () => {
+    // Running it is what proves the embedded native loads: dist/cli.js statically
+    // imports node-pty (via the backends) and node-pty dlopens the native at
+    // MODULE scope. Verified by mutation — corrupting the embedded pty.node makes
+    // the smoke script die on its FIRST check with ERR_DLOPEN_FAILED, before any
+    // check passes. So "the binary ran at all" already covers dlopen.
+    expect(CI_CODE).toMatch(/node scripts\/smoke-bun-binary\.mjs dist-bin\/botmux-linux-x64-musl/);
+  });
+
+  it('uses the SAME smoke script as the release musl leg (no weaker PR gate)', () => {
+    // Parity is the actual invariant. If the release leg ever moves to a stronger
+    // script, this catches a PR gate left behind on the old one.
+    expect(RELEASE_CODE).toContain('scripts/smoke-bun-binary.mjs');
+    expect(CI_CODE).toContain('scripts/smoke-bun-binary.mjs');
+  });
+
+  it('stamps a version BEFORE compiling (or the smoke version check cannot pass)', () => {
+    // Compiled mode has no package.json on disk, so the version is baked at build
+    // time; the repo's 0.0.0 placeholder is treated as "nothing baked" and yields
+    // the `unknown` sentinel the smoke script rejects. Order matters: `npm version`
+    // must also come AFTER `bun install`, since --frozen-lockfile must see the
+    // committed package.json.
+    const job = CI_CODE.slice(CI_CODE.indexOf('bun-binary-musl:'));
+    const install = job.indexOf('bun install --frozen-lockfile');
+    const version = job.indexOf('npm version');
+    const compile = job.indexOf('--target bun-linux-x64-musl');
+    expect(install).toBeGreaterThan(-1);
+    expect(version).toBeGreaterThan(install);
+    expect(compile).toBeGreaterThan(version);
+  });
+});
+
+describe('release.yml — the musl legs stay wired into the publish chain', () => {
+  it('still builds BOTH musl arches (ci.yml only canaries x64)', () => {
+    // The PR gate deliberately covers one arch (arm64 needs a separate, slower
+    // runner). The release must not quietly shrink to match it.
+    expect(RELEASE_CODE).toContain('bun-linux-x64-musl');
+    expect(RELEASE_CODE).toContain('bun-linux-arm64-musl');
+  });
+
+  it('gates the publish jobs on the musl job (else musl subpackages ship unbuilt)', () => {
+    // `binary-subpackages` packs the artifacts into npm tarballs. If it does not
+    // need the musl job, a musl subpackage could publish without its binary —
+    // and npm treats a missing optional dep as a silent no-op.
+    const subpackages = RELEASE_CODE.slice(RELEASE_CODE.indexOf('binary-subpackages:'));
+    const needsLine = subpackages.slice(0, subpackages.indexOf('runs-on'));
+    expect(needsLine).toContain('bun-binaries-musl');
+  });
+});

--- a/test/install-sh-musl-asset.test.ts
+++ b/test/install-sh-musl-asset.test.ts
@@ -62,10 +62,22 @@ function detectAsset(opts: { lddOutput?: string | null; muslLoader?: boolean; al
 
   const script = join(base, 'probe.sh');
   writeFileSync(script, `os_tag=linux\narch_tag=x64\nasset="botmux-\${os_tag}-\${arch_tag}"\n${body}\necho "$asset"\n`);
-  // PATH carries only our shim dir (+ coreutils) so `ldd` resolution is controlled.
+  // PATH carries ONLY our shim dir (plus a busybox-ish minimum) so that
+  // `command -v ldd` is genuinely false when the test says "no ldd". Including
+  // /usr/bin:/bin here would always find the system ldd and make the
+  // no-ldd fixtures untestable — they would silently exercise the ldd branch.
+  const shellBins = join(base, 'shbin');
+  mkdirSync(shellBins, { recursive: true });
+  for (const cmd of ['grep', 'ls', 'sh', 'printf']) {
+    // Symlink the few utilities the block itself needs, without dragging in ldd.
+    try {
+      const real = execFileSync('sh', ['-c', `command -v ${cmd}`], { encoding: 'utf-8' }).trim();
+      if (real) writeFileSync(join(shellBins, cmd), `#!/bin/sh\nexec ${real} "$@"\n`, { mode: 0o755 });
+    } catch { /* command absent; the block tolerates it */ }
+  }
   return execFileSync('sh', [script], {
     encoding: 'utf-8',
-    env: { PATH: `${bin}:/usr/bin:/bin` },
+    env: { PATH: `${bin}:${shellBins}` },
   }).trim();
 }
 
@@ -77,6 +89,21 @@ describe('install.sh — musl vs glibc asset selection', () => {
   it('ldd reporting GNU libc → picks the plain (glibc) asset', () => {
     // THE false-positive direction: ordinary Linux must never be sent to -musl.
     expect(detectAsset({ lddOutput: 'ldd (GNU libc) 2.36' })).toBe('botmux-linux-x64');
+  });
+
+  it('REGRESSION: glibc distro WITH musl installed → still the plain asset', () => {
+    // Debian/Ubuntu `musl` / `musl-tools` (common for Rust/Go musl cross-compiling)
+    // drops /lib/ld-musl-x86_64.so.1 at TOP LEVEL. An earlier version of this block
+    // treated "ldd did not say musl" as "unknown, keep probing", so the loader
+    // overturned ldd's correct glibc answer — measured on debian:bookworm-slim +
+    // musl-tools, which selected the musl asset and would have installed a binary
+    // that dies in the loader on first run.
+    //
+    // Rule now: when ldd EXISTS its answer is authoritative in BOTH directions;
+    // filesystem probes are only for images with no ldd at all.
+    expect(detectAsset({ lddOutput: 'ldd (GNU libc) 2.36', muslLoader: true })).toBe('botmux-linux-x64');
+    // Same with Alpine's marker file also present — still glibc, because ldd said so.
+    expect(detectAsset({ lddOutput: 'ldd (GNU libc) 2.36', muslLoader: true, alpineFile: true })).toBe('botmux-linux-x64');
   });
 
   it('no ldd at all, but an ld-musl loader present → -musl', () => {

--- a/test/install-sh-musl-asset.test.ts
+++ b/test/install-sh-musl-asset.test.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * install.sh (the `curl … | sh` installer) — asset-name selection.
+ *
+ * WHY THIS FILE EXISTS: the installer picks a release asset from `uname` output plus
+ * a libc probe. Getting the libc wrong is not a cosmetic bug — a glibc-linked binary
+ * does not run on musl at all (it dies in the loader naming no cause), so a false
+ * positive would hand every ordinary Linux user a binary that cannot start.
+ *
+ * These tests EXECUTE the real detection block extracted from install.sh, with the
+ * probes redirected at a fake root. Asserting on the script's text instead would pass
+ * just as happily with the logic deleted.
+ */
+const INSTALL_SH = resolve(import.meta.dirname, '../install.sh');
+const dirs: string[] = [];
+const tmp = () => {
+  const d = mkdtempSync(join(tmpdir(), 'botmux-install-sh-'));
+  dirs.push(d);
+  return d;
+};
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/**
+ * Run install.sh's libc-detection block with a controlled environment.
+ *
+ * `lddOutput`  — what a `ldd --version` shim prints (null = no ldd on PATH at all)
+ * `muslLoader` — create `<fake>/lib/ld-musl-x86_64.so.1`
+ * `alpineFile` — create `<fake>/etc/alpine-release`
+ */
+function detectAsset(opts: { lddOutput?: string | null; muslLoader?: boolean; alpineFile?: boolean }) {
+  const base = tmp();
+  const fake = join(base, 'fake');
+  const bin = join(base, 'bin');
+  mkdirSync(join(fake, 'lib'), { recursive: true });
+  mkdirSync(join(fake, 'usr', 'lib'), { recursive: true });
+  mkdirSync(join(fake, 'etc'), { recursive: true });
+  mkdirSync(bin, { recursive: true });
+
+  if (opts.muslLoader) writeFileSync(join(fake, 'lib', 'ld-musl-x86_64.so.1'), '');
+  if (opts.alpineFile) writeFileSync(join(fake, 'etc', 'alpine-release'), '3.20\n');
+  if (opts.lddOutput != null) {
+    // musl's ldd exits non-zero for --version; mimic that so the test proves the
+    // installer does not depend on the exit status.
+    writeFileSync(join(bin, 'ldd'), `#!/bin/sh\nprintf '%s\\n' "${opts.lddOutput}" >&2\nexit 1\n`, { mode: 0o755 });
+  }
+
+  // Extract ONLY the real block, then point its three probes at the fake root.
+  const src = readFileSync(INSTALL_SH, 'utf-8');
+  const block = /^# On Linux, pick the musl build[\s\S]*?\nfi$/m.exec(src);
+  expect(block, 'the musl-detection block must still exist in install.sh').toBeTruthy();
+  const body = block![0]
+    .replaceAll('/lib/ld-musl-*', `${fake}/lib/ld-musl-*`)
+    .replaceAll('/usr/lib/ld-musl-*', `${fake}/usr/lib/ld-musl-*`)
+    .replaceAll('/etc/alpine-release', `${fake}/etc/alpine-release`);
+
+  const script = join(base, 'probe.sh');
+  writeFileSync(script, `os_tag=linux\narch_tag=x64\nasset="botmux-\${os_tag}-\${arch_tag}"\n${body}\necho "$asset"\n`);
+  // PATH carries only our shim dir (+ coreutils) so `ldd` resolution is controlled.
+  return execFileSync('sh', [script], {
+    encoding: 'utf-8',
+    env: { PATH: `${bin}:/usr/bin:/bin` },
+  }).trim();
+}
+
+describe('install.sh — musl vs glibc asset selection', () => {
+  it('ldd reporting musl → picks the -musl asset', () => {
+    expect(detectAsset({ lddOutput: 'musl libc (x86_64)' })).toBe('botmux-linux-x64-musl');
+  });
+
+  it('ldd reporting GNU libc → picks the plain (glibc) asset', () => {
+    // THE false-positive direction: ordinary Linux must never be sent to -musl.
+    expect(detectAsset({ lddOutput: 'ldd (GNU libc) 2.36' })).toBe('botmux-linux-x64');
+  });
+
+  it('no ldd at all, but an ld-musl loader present → -musl', () => {
+    // Slim images may lack ldd; the loader is the direct evidence.
+    expect(detectAsset({ lddOutput: null, muslLoader: true })).toBe('botmux-linux-x64-musl');
+  });
+
+  it('no ldd and no loader, but /etc/alpine-release → -musl', () => {
+    expect(detectAsset({ lddOutput: null, alpineFile: true })).toBe('botmux-linux-x64-musl');
+  });
+
+  it('no ldd, no loader, no alpine marker → plain asset (never guess musl)', () => {
+    expect(detectAsset({ lddOutput: null })).toBe('botmux-linux-x64');
+  });
+
+  it('a glibc box is never sent to -musl even when the loader dir is unreadable', () => {
+    // Behavioural guard for the false-positive direction, independent of the source
+    // pin below: glibc ldd + no loader + no marker must yield the plain asset.
+    expect(detectAsset({ lddOutput: 'ldd (GNU libc) 2.36' })).toBe('botmux-linux-x64');
+    expect(detectAsset({ lddOutput: 'ldd (GNU libc) 2.36', alpineFile: false })).toBe('botmux-linux-x64');
+  });
+
+  it('SOURCE PIN: all three probes are present and the switch is positive-only', () => {
+    // Compare CODE ONLY. The block's comments mention `ldd --version` and musl on
+    // purpose, so matching the whole file would let this assertion pass on its own
+    // documentation — a mutation replacing the real `ldd --version` pipeline with
+    // `true` was measured to slip through exactly that way.
+    const code = readFileSync(INSTALL_SH, 'utf-8')
+      .split('\n')
+      .filter(l => !/^\s*#/.test(l))
+      .join('\n');
+    // Each probe is independently load-bearing on some image shape; losing one
+    // silently narrows detection.
+    expect(code).toMatch(/ldd --version/);
+    expect(code).toMatch(/ld-musl-/);
+    expect(code).toMatch(/alpine-release/);
+    // The suffix must only ever be ADDED when musl was observed.
+    expect(code).toMatch(/is_musl.*-eq 1.*asset="\$\{asset\}-musl"/);
+    // And the musl decision must come from grepping libc output, never a constant.
+    expect(code).toMatch(/grep -qi musl/);
+  });
+});

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -85,14 +85,19 @@ describe('inject-optional-binaries — release-time version wiring', () => {
     return { ...r, manifest: after };
   }
 
-  it('injects all four platform packages pinned to the release version', () => {
+  it('injects all six platform packages pinned to the release version', () => {
     const { status, manifest } = run('3.20.0', '3.20.0');
     expect(status).toBe(0);
+    // Six, not four: the two -musl entries are what give npm anything to select on
+    // Alpine. Publishing the musl subpackages without listing them here leaves them
+    // on the registry with nothing referencing them — npm never even considers them.
     expect(manifest.optionalDependencies).toEqual({
       'botmux-darwin-arm64': '3.20.0',
       'botmux-darwin-x64': '3.20.0',
       'botmux-linux-arm64': '3.20.0',
+      'botmux-linux-arm64-musl': '3.20.0',
       'botmux-linux-x64': '3.20.0',
+      'botmux-linux-x64-musl': '3.20.0',
     });
   });
 
@@ -308,15 +313,20 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     return { ...r, wrote: existsSync(join(home, '.botmux', 'bin', 'botmux')) };
   }
 
-  it('musl: an ld-musl loader present → refuses with a musl-specific reason', () => {
+  it('musl: an ld-musl loader present → looks for the -musl subpackage', () => {
+    // INVERTED from the previous contract. This used to assert a hard refusal
+    // ("glibc-linked and cannot run on musl"), which was correct only while no musl
+    // binary existed. musl subpackages now ship, so refusing would block the very
+    // platform we added; instead the lookup must agree with what npm installed —
+    // npm selects by each subpackage's `libc` field, so on Alpine that is the
+    // `-musl` name.
     const r = runPostinstallWithFakeRoot('ld-musl-x86_64.so.1');
+    // The fixture stages the plain (glibc) subpackage only, so resolution fails —
+    // but the point is WHICH name it looked for.
     expect(r.status).not.toBe(0);
-    expect(r.wrote).toBe(false);
-    expect(r.stderr).toContain('musl');
-    // Must be the musl message, not the generic "no prebuilt binary" one — the guard
-    // has to run BEFORE subpackage resolution, because on Alpine the glibc
-    // subpackage DOES resolve and the generic path would never fire.
-    expect(r.stderr).toContain('glibc-linked');
+    expect(r.stderr).toContain('botmux-linux-x64-musl');
+    // The old lie must not come back.
+    expect(r.stderr).not.toContain('cannot run on musl');
   });
 
   it('musl: no loader present → does NOT claim musl (the false-positive direction)', () => {


### PR DESCRIPTION
feat(release): 支持 musl（Alpine）二进制 —— 编译矩阵 4→6，npm 按 libc 自动选包

Alpine 与多数精简 Docker 镜像链接 musl libc，而 glibc 二进制在那里**根本跑不起来**
——死在 loader 里，报错不说明原因。此前 botmux 只发 glibc 二进制，而且这个失败是
**静默的**：npm 按 `os`/`cpu` 选平台子包，这两个字段 glibc 与 musl **完全相同**
（`linux`/`x64`），所以 Alpine 上照样装 glibc 包、装"成功"、运行时才炸。

## npm 有 `libc` 字段（`npm help package-json` 没写，但线上在用）

```
npm view @napi-rs/canvas-linux-x64-musl libc  →  musl
npm view @napi-rs/canvas-linux-x64-gnu  libc  →  glibc
```
所以两个新 musl 子包声明 `libc: ["musl"]`，**同时给现有两个 linux 包补
`libc: ["glibc"]`** —— 只声明一半会让 glibc 包在 Alpine 上仍是候选、选择变歧义。
darwin 两个包不加（macOS 无 libc 变体这个概念）。

## 🔴 musl 二进制必须在 musl 上编译（这决定了 CI 形态）

`pty.node` 是**编译期嵌进二进制**的，而 node-pty **没有 linux 预编译**，所以 builder
会拿自己运行的 libc 去编。实测：

| builder | `readelf -d pty.node` |
|---|---|
| glibc 机器 | `NEEDED libc.so.6` |
| node:22-alpine | `NEEDED libc.musl-x86_64.so.1` |

⟹ 从 glibc runner 交叉编译 musl target 会嵌进**错误的 native**，并且**在构建期不报
错、只在用户 spawn PTY 时炸**。因此新增 `bun-binaries-musl` job 跑在
`container: node:22-alpine` 里（本仓库第一个容器化 job），并加一道 fail-closed：
`readelf` 确认 `pty.node` 真是 musl 链接，否则拒绝继续。

`setup-bun` 不支持 musl 容器，改用 `npm i -g bun@1.4.0`；base image 缺 git/编译链，
先 `apk add`。

## 端到端验证（这条是决定性的）

在 node:22-alpine 里用**仓库自己的构建脚本**（走 `makeNativeEmbedPlugin`）编出
`bun-linux-x64-musl`，然后**真的 spawn 一个 PTY**：

```
musl pty.node: 79,680 字节
✅ built /work/probe (bun-linux-x64-musl)
RESULT: ✅ PTY 真的在 musl 二进制里跑起来了 → PTY_OK_FROM_MUSL
```

⚠️**"二进制能启动"证明不了任何事** —— libc 不匹配恰恰是在**加载原生模块那一刻**炸，
而 `botmux status` 那条路径压根不加载 pty.node。所以验收必须落在真 spawn 上。

⭐这个结论前后跑了 4 次才拿到，前 3 次全是**我自己探针的缺陷**、对 musl 零信息量：
① 手写 `createRequire` 入口绕开了 embed plugin ② tail 一个还没写入的日志 → "无输出"
③ `tail -4` 把 `error:` 首行截掉、只留 stack frame。而 ③ 修好后露出的报错证明我
**第 4 次又退回了 ①**（裸 `bun build --compile`，插件没跑）。教训写在
`scripts/build-bun-binary.mjs` 的注释里：验原生嵌入必须驱动真构建脚本。

## install.sh 也要认 musl

curl 安装那条路同样会拿错二进制。新增探测，**只在正面观测到 musl 时才切**（假阳性
会把每个普通 Linux 用户推向跑不了的 musl 包，比漏判更糟）：
`ldd --version` 抓 musl → `/lib/ld-musl-*` 与 `/usr/lib/ld-musl-*` → `/etc/alpine-release`。
（musl 的 ldd 对 `--version` 退出码非 0，所以只看输出不看状态。）

三环境实测：本机 glibc → `botmux-linux-x64`；node:22-alpine → `botmux-linux-x64-musl`；
debian:bookworm-slim → `botmux-linux-x64`。

## 新增测试 `test/install-sh-musl-asset.test.ts`（7 条）

**执行从 install.sh 抽出的真实探测块**，把三个探针重定向到 fake root，而不是对脚本
文本做模式匹配（后者删掉逻辑照样绿）。覆盖 musl/glibc/无 ldd/仅 loader/仅 marker/
全无线索六种形态 + 一条 source pin。

⚠️**反向变异逼出一个我自己的盲区**：把 `ldd --version | grep -qi musl` 换成 `true`
（模拟"把所有 Linux 误判成 musl"）时，第一版测试**全绿**。原因是那条 source pin 匹配
的是**整个文件**，而 block 的注释里恰好也写着 `ldd --version` —— **断言打在自己的说明
文字上**。改成先剥注释再比对，并补一条纯行为断言，现在同一变异 **4 条红**。
（这与本 PR 前一个 commit 里 `header.musl` 那次是同一形状，我在同一天犯了两次。）

其它反向变异：删掉 ldd 探测 → **5 条红**。

验证：`bun run build` exit 0；install.sh / release.yml 语法校验通过；
新测试 7/7；分发 + desktop + 新测试共 **21 文件 / 175 测试全绿**。

发布链接线：`bun-binaries-musl` 已接进 `release` / `binary-subpackages` /
`attach-bun-binaries` 三处 `needs`，其中 `attach-bun-binaries` 带 `if:` ⟹ 按仓库既有
约定**显式**加了 `needs.bun-binaries-musl.result == 'success'`（GitHub 对带 `if:` 的
job 会丢掉隐式 all-needs-succeeded 门），否则 musl 腿失败时仍会附上不完整的资产集。


---

## 追加 commit `efd3779aa`：PR CI 也编译并跑 musl 二进制

复审通过后收到提问「不能跟其他包类似的编译方式吗，CI 没有相关镜像吗」，顺着查出
一个遗漏：**`bun-binaries-musl` 只加进了 release.yml（tag push 才跑）**。其它 4 个
平台都有 PR 门（`bun-binary` job），只有 musl 没有 —— PR 改了构建脚本、embed plugin
或 node-pty 版本，musl 这条腿**第一次被执行是在发版流程里、npm 已经发出去之后**。

ci.yml 补 `bun-binary-musl`：`container: node:22-alpine` + apk 工具链 +
`npm i -g bun@1.4.0`（setup-bun 不支持 musl 容器）+ readelf 硬校验 + 编 x64-musl +
跑**同一份** smoke 脚本。只编 x64：GitHub 无 Alpine runner 所以必须容器化，arm64 还
需另一个更慢的 runner；release 仍编两个 arch，测试里钉住这个不对称不许被"对齐"掉。

（关于「能不能像其它包一样交叉编译」：不能。`pty.node` 是编译期嵌入，node-pty 没有
linux prebuild ⟹ 它总在构建机的 libc 上现编。实测 glibc 机器 → `NEEDED libc.so.6`，
Alpine 容器 → `NEEDED libc.musl-x86_64.so.1`。从 glibc runner 编 musl 目标会嵌进
glibc native，**编译期零报错**，只在 native 被 dlopen 那刻炸。）

### 没有采纳「给 smoke 加 PTY spawn」——变异实测证明它是重复的

复审留了这条非阻塞建议，准备加之前先测它能覆盖什么。把嵌入的 `pty.node` 保留 ELF
头、正文清零（= glibc native 装在 musl 二进制里的运行期失败形态），用**真**构建脚本
编出来跑现有 smoke：

```
smoke 第 1 项就死：ERR_DLOPEN_FAILED: object file has no loadable segments
exit 1，一个 ✅ 都没打出来
```

根因：`dist/cli.js` 静态 import node-pty（经 backends），node-pty 在**模块作用域**
就 dlopen native ⟹「二进制能跑起来」**已经等价于**「native 能加载」。单独加一步 PTY
spawn 只多覆盖 forkpty 系统调用本身，而那部分与 libc 匹配无关。

⚠️ 这个结论只覆盖「加载」，**不覆盖「spawn 行为正确」**；真 PTY 证据仍来自本机容器
实测。smoke 该覆盖哪些层是独立话题，留 follow-up（也避免改动 glibc 那几条腿的 smoke，
扩大本 PR 爆炸半径）。

### 验证

新 job 的 9 步在 `node:22-alpine` 里逐条 dry-run（源码 copy 时**排除 node_modules**
——它是指向 canonical 的 symlink，绝不能被 install 穿透写入）：

```
bun install --frozen-lockfile → 698 packages（提交的 bun.lock 在 musl 上可用）
readelf                       → NEEDED libc.musl-x86_64.so.1
compile                       → version=0.0.0-ci.99（不是 unknown 哨兵）
smoke（仓库相对路径，与 ci.yml 逐字一致）→ 六项全 ✅
```

⚠️ 特意用**仓库相对路径**跑 smoke：本 PR 之前踩过「相对路径 + spawn cwd 解歪成
ENOENT」，本机绝对路径会掩盖它。步序也与 release.yml 一致（install → npm version →
compile），因为 `--frozen-lockfile` 必须看到未被改写的 package.json。

### 新增测试 `test/ci-musl-gate.test.ts`（9 条）

钉的是「**PR 门不弱于发版门**」这个不变量，不是 YAML 形状。断言前先剥掉 `#` 注释
——否则一句**描述**该检查的注释就能让断言通过（本 PR 前面已经踩过一次这个形状）。

**6 条反向变异全部转红**：删 job header / 去掉容器 / 换成 glibc target / 删 readelf /
删 smoke / 把 `npm version` 挪到 install 之前。

37 测试全绿（分发 + install.sh + 本文件）；`bun run build` exit 0。
