### PR TITLE
fix(release): musl 构建改用 docker run，修 arm64 腿在 Alpine 容器里跑不了 JS action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,59 +145,70 @@ jobs:
   # Only linux-x64-musl is built: GitHub offers no Alpine runner, so musl requires
   # a container, and arm64 would need the (slower, separately-queued) arm64 runner.
   # The release workflow still builds BOTH musl arches; this is the PR canary.
+  #
+  # ⚠️ THE COST OF THAT x64-ONLY CHOICE, MEASURED: it was made for runner time, and
+  # arm64-musl turned out to be the one cell with a PLATFORM-level obstacle — a
+  # job-level `container: node:22-alpine` cannot run JS actions (actions/checkout)
+  # on an arm64 runner at all. So this gate was green while the release failed. The
+  # structure below (JS actions on the host, build inside `docker run`) is the fix,
+  # and it is used here too so both workflows stay on ONE shape: if this leg ever
+  # gains an arch, it will not re-learn the same lesson.
   bun-binary-musl:
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    # node:22-alpine supplies musl + a Node for the scripts. setup-bun does not run
-    # in a musl container, so bun comes from npm below.
-    container: node:22-alpine
 
     steps:
-      # git is absent from the base image and checkout needs it for a real clone;
-      # python3/make/g++ are node-gyp's toolchain, required because node-pty has no
-      # linux prebuild and must compile here.
-      - name: Install toolchain (musl needs node-gyp deps for node-pty)
-        run: apk add --no-cache git python3 make g++ libstdc++ bash tar
-
+      # Runs on the HOST (glibc), which is what keeps this arch-portable.
       - uses: actions/checkout@v6
 
-      - name: Install bun
-        run: npm i -g bun@1.4.0 --loglevel=error
-
-      # Compiles node-pty against MUSL — the entire point of this job.
-      - run: bun install --frozen-lockfile
-
-      - name: Verify the native is musl-linked
-        # Fail closed rather than compiling a musl binary around a glibc native.
-        # That mistake survives the build and surfaces only when the native is
-        # loaded, so assert the linkage here where it is cheap and unambiguous.
+      - name: Build and smoke the musl binary inside Alpine
+        # Every musl-side step in one container invocation. `--platform` is
+        # deliberately NOT passed: the image must resolve to the runner's own
+        # architecture, since the native has to be built for the arch it ships on.
         run: |
-          f=node_modules/node-pty/build/Release/pty.node
-          test -f "$f" || { echo "node-pty native missing at $f"; exit 1; }
-          apk add --no-cache binutils >/dev/null
-          if ! readelf -d "$f" | grep -q 'libc\.musl'; then
-            echo "REFUSING: $f is not musl-linked:"; readelf -d "$f" | grep NEEDED; exit 1
-          fi
-          echo "ok: $(readelf -d "$f" | grep NEEDED | tr -s ' ')"
+          docker run --rm \
+            -v "$PWD:/work" -w /work \
+            -e CI_RUN_NUMBER="${{ github.run_number }}" \
+            node:22-alpine sh -euc '
+              # python3/make/g++ are node-gyp'"'"'s toolchain: node-pty has no linux
+              # prebuild and must compile here. binutils supplies readelf.
+              apk add --no-cache python3 make g++ libstdc++ binutils >/dev/null
 
-      - name: Stamp a synthetic version (mirrors the release job)
-        # Same reason and same ORDER as the glibc job above: the compiled binary has
-        # no package.json on disk, so the version is baked at compile time, and the
-        # repo's `0.0.0` placeholder is deliberately treated as "nothing baked" —
-        # compiling from it yields `--version: unknown`, which the smoke gate fails.
-        run: npm version "0.0.0-ci.${{ github.run_number }}" --no-git-tag-version --allow-same-version
+              npm i -g bun@1.4.0 --loglevel=error
+              echo "bun $(bun --version) on $(uname -m)"
 
-      - run: bun run build
+              # Compiles node-pty against MUSL — the entire point of this job.
+              bun install --frozen-lockfile
 
-      - name: Compile the musl binary
-        run: bun scripts/build-bun-binary.mjs --target bun-linux-x64-musl --out dist-bin/botmux-linux-x64-musl
+              # Fail closed rather than compiling a musl binary around a glibc
+              # native: that mistake survives the build and surfaces only when the
+              # native is loaded.
+              f=node_modules/node-pty/build/Release/pty.node
+              test -f "$f" || { echo "node-pty native missing at $f"; exit 1; }
+              if ! readelf -d "$f" | grep -q "libc\.musl"; then
+                echo "REFUSING: $f is not musl-linked:"; readelf -d "$f" | grep NEEDED; exit 1
+              fi
+              echo "ok: $(readelf -d "$f" | grep NEEDED | tr -s " ")"
 
-      - name: Smoke-test the musl binary
-        # Same shared script as the glibc leg, so this gate can never be the weaker
-        # one. This is also where an unloadable native is caught: `dist/cli.js`
-        # statically imports node-pty (via the backends), and node-pty dlopens the
-        # native at MODULE scope — verified by mutation, corrupting the embedded
-        # pty.node makes check 1 die with `ERR_DLOPEN_FAILED`. So running the binary
-        # at all proves the musl native loads; no separate PTY step is needed.
-        run: node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64-musl
+              # Same reason and same ORDER as the glibc job above: the compiled
+              # binary has no package.json on disk, so the version is baked at
+              # compile time, and the repo'"'"'s 0.0.0 placeholder is deliberately
+              # treated as "nothing baked" — compiling from it yields
+              # `--version: unknown`, which the smoke gate fails. Must also come
+              # AFTER install, so --frozen-lockfile sees the committed manifest.
+              npm version "0.0.0-ci.${CI_RUN_NUMBER}" --no-git-tag-version --allow-same-version
+
+              bun run build
+              bun scripts/build-bun-binary.mjs --target bun-linux-x64-musl \
+                --out dist-bin/botmux-linux-x64-musl
+
+              # Same shared script as the glibc leg, so this gate can never be the
+              # weaker one. This is also where an unloadable native is caught:
+              # dist/cli.js statically imports node-pty (via the backends), and
+              # node-pty dlopens the native at MODULE scope — verified by mutation,
+              # corrupting the embedded pty.node makes check 1 die with
+              # ERR_DLOPEN_FAILED. So running the binary at all proves the musl
+              # native loads; no separate PTY step is needed.
+              node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64-musl
+            '
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -732,7 +732,8 @@ jobs:
           retention-days: 7
 
   bun-binaries-musl:
-    # The musl (Alpine) legs, in a CONTAINER rather than on the runner.
+    # The musl (Alpine) legs. The build runs inside Alpine via `docker run`; the
+    # job itself runs on the plain glibc runner.
     #
     # WHY A SEPARATE JOB: `pty.node` is embedded into the binary at build time, and
     # node-pty ships NO linux prebuild — so the builder compiles it against whatever
@@ -742,11 +743,22 @@ jobs:
     # glibc native and fail at PTY spawn on Alpine — at RUNTIME, silently, not at
     # build time. So the musl targets must be compiled on musl.
     #
-    # Verified end-to-end before this job existed: inside node:22-alpine, building
-    # with scripts/build-bun-binary.mjs --target bun-linux-x64-musl and then running
-    # the result spawned a real PTY (`PTY_OK_FROM_MUSL`). That check matters because
-    # a binary that merely STARTS proves nothing — a libc mismatch fails at the
-    # moment the native module loads.
+    # WHY `docker run` AND NOT A JOB-LEVEL `container:` (this cost a failed release):
+    # with `container: node:22-alpine`, the arm64 leg died before running anything:
+    #   JavaScript Actions in Alpine containers are only supported on x64 Linux
+    #   runners. Detected Linux Arm64
+    # actions/checkout is a JS action, and GitHub cannot inject its Node runtime
+    # into a musl container on arm64. The x64 leg was unaffected, which is why the
+    # PR gate (x64-only) stayed green while the release failed. Running JS actions
+    # on the HOST and only the build inside `docker run` sidesteps the limitation
+    # entirely and keeps both arches on one code path.
+    #
+    # Verified end-to-end: inside node:22-alpine, building with
+    # scripts/build-bun-binary.mjs --target bun-linux-x64-musl and then running the
+    # result spawned a real PTY (`PTY_OK_FROM_MUSL`). That check matters because a
+    # binary that merely STARTS proves nothing — a libc mismatch fails at the moment
+    # the native module loads. The bind-mount writeback (artifact readable back on
+    # the host for upload-artifact) was verified with the same shape.
     if: github.event_name == 'push'
     strategy:
       fail-fast: false
@@ -759,61 +771,68 @@ jobs:
             targets: bun-linux-arm64-musl
             artifact: linux-arm64-musl
     runs-on: ${{ matrix.os }}
-    # node:22-alpine gives us musl + a Node for the scripts. bun is installed below
-    # (setup-bun does not support musl containers).
-    container: node:22-alpine
     permissions:
       contents: read
     env:
       RELEASE_TAG: ${{ github.ref_name }}
     steps:
-      # git is not in the base image, and checkout needs it for a real clone.
-      - name: Install toolchain (musl needs node-gyp deps for node-pty)
-        run: apk add --no-cache git python3 make g++ libstdc++ bash tar
-
+      # Runs on the HOST (glibc), so the JS action works on both arches.
       - uses: actions/checkout@v6
 
-      - name: Install bun
-        # oven-sh/setup-bun does not run in a musl container; npm's bun package does.
-        run: npm i -g bun@1.4.0 --loglevel=error
-
-      # Compiles node-pty against MUSL — the whole point of this job.
-      - run: bun install --frozen-lockfile
-
-      - name: Verify the native is musl-linked
-        # Fail closed rather than shipping a glibc native inside a musl binary. That
-        # mistake would survive the build and only surface when a user spawns a PTY.
+      - name: Build the musl binary inside Alpine
+        # Every musl-side step in one container invocation: toolchain, bun, install
+        # (this is what compiles pty.node against musl), the fail-closed linkage
+        # check, version stamp, build, compile, and the shared smoke script.
+        #
+        # `--platform` is deliberately NOT passed: the image resolves to the
+        # runner's own architecture, which is the whole point — the native must be
+        # built for the arch it will ship on, not emulated.
         run: |
-          f=node_modules/node-pty/build/Release/pty.node
-          test -f "$f" || { echo "node-pty native missing at $f"; exit 1; }
-          apk add --no-cache binutils >/dev/null
-          if ! readelf -d "$f" | grep -q 'libc\.musl'; then
-            echo "REFUSING: $f is not musl-linked:"; readelf -d "$f" | grep NEEDED; exit 1
-          fi
-          echo "ok: $(readelf -d "$f" | grep NEEDED | tr -s ' ')"
+          docker run --rm \
+            -v "$PWD:/work" -w /work \
+            -e RELEASE_TAG \
+            -e MATRIX_TARGETS="${{ matrix.targets }}" \
+            node:22-alpine sh -euc '
+              apk add --no-cache python3 make g++ libstdc++ binutils >/dev/null
 
-      - name: Sync version from git tag to package.json
-        run: npm version "${RELEASE_TAG#v}" --no-git-tag-version --allow-same-version
+              # setup-bun does not support musl, and npm ships musl builds of bun
+              # (@oven/bun-linux-{x64,aarch64}-musl), so npm is the way in.
+              npm i -g bun@1.4.0 --loglevel=error
+              echo "bun $(bun --version) on $(uname -m)"
 
-      - run: bun run build
+              # Compiles node-pty against MUSL — the whole point of this job.
+              bun install --frozen-lockfile
 
-      - name: Compile Bun single-file executables (musl)
-        run: |
-          mkdir -p dist-bin
-          for t in ${{ matrix.targets }}; do
-            bun scripts/build-bun-binary.mjs --target "$t" --out "dist-bin/botmux-${t#bun-}"
-          done
+              # Fail closed rather than shipping a glibc native inside a musl
+              # binary: that mistake survives the build and only surfaces when the
+              # native is loaded, on a user machine.
+              f=node_modules/node-pty/build/Release/pty.node
+              test -f "$f" || { echo "node-pty native missing at $f"; exit 1; }
+              if ! readelf -d "$f" | grep -q "libc\.musl"; then
+                echo "REFUSING: $f is not musl-linked:"; readelf -d "$f" | grep NEEDED; exit 1
+              fi
+              echo "ok: $(readelf -d "$f" | grep NEEDED | tr -s " ")"
 
-      - name: Smoke-test the musl binary
-        # Runs the binary this container just built, on musl — the only place it can
-        # be executed. Same shared script as the glibc legs and the PR gate.
-        run: |
-          HOST_ARCH="$(node -e 'process.stdout.write(process.arch)')"
-          BIN="dist-bin/botmux-linux-${HOST_ARCH}-musl"
-          if [ ! -x "$BIN" ]; then echo "musl binary $BIN not built"; exit 1; fi
-          node scripts/smoke-bun-binary.mjs "$BIN"
+              npm version "${RELEASE_TAG#v}" --no-git-tag-version --allow-same-version
+              bun run build
+
+              mkdir -p dist-bin
+              for t in $MATRIX_TARGETS; do
+                bun scripts/build-bun-binary.mjs --target "$t" --out "dist-bin/botmux-${t#bun-}"
+              done
+
+              # Run the binary this container just built, on musl — the only place
+              # it can be executed. Same shared script as the glibc legs and the PR
+              # gate, so no leg is gated more weakly than another.
+              HOST_ARCH="$(node -e "process.stdout.write(process.arch)")"
+              BIN="dist-bin/botmux-linux-${HOST_ARCH}-musl"
+              if [ ! -x "$BIN" ]; then echo "musl binary $BIN not built"; exit 1; fi
+              node scripts/smoke-bun-binary.mjs "$BIN"
+            '
 
       - name: Checksums
+        # Runs on the host: the binaries are bind-mount writebacks, owned by root
+        # (the container user), but world-readable — verified.
         run: |
           cd dist-bin
           for f in botmux-*; do sha256sum "$f" > "$f.sha256"; done

--- a/test/ci-musl-gate.test.ts
+++ b/test/ci-musl-gate.test.ts
@@ -47,20 +47,49 @@ describe('ci.yml — the musl artifact is gated on PRs, not only at release', ()
     expect(CI_CODE).toMatch(/^ {2}bun-binary-musl:/m);
   });
 
-  it('runs that job in a musl container (GitHub has no Alpine runner)', () => {
-    // Without a musl container the job would compile on glibc and prove nothing:
-    // the native is whatever libc the builder has.
-    expect(CI_CODE).toMatch(/container:\s*node:22-alpine/);
+  // ── MECHANISM vs MEANS ───────────────────────────────────────────────────────
+  // A cautionary note earned the hard way. The FIRST version of this suite asserted
+  //     expect(CI_CODE).toMatch(/container:\s*node:22-alpine/)
+  // which was green, and went red when mutated — "has teeth" by the usual test. But
+  // `container:` WAS the P0: on an arm64 runner it makes actions/checkout fail
+  // outright, and v3.18.0-canary.4's release died on it. That assertion had locked
+  // the defect in as the expected shape, so fixing the bug REQUIRED reversing it.
+  //
+  // Reverse-mutation cannot catch this: an assertion pinning a wrong implementation
+  // is indistinguishable from one pinning a right one — both go red when deleted.
+  // The lesson is to assert the INVARIANT (the build happens on musl, and we prove
+  // the native is musl-linked) rather than the MEANS of achieving it. The means-level
+  // checks below are kept deliberately, but only as labelled REGRESSION PINS for one
+  // specific known-bad implementation — never as the primary guarantee.
+
+  it('MECHANISM: builds in a musl environment and proves the native is musl-linked', () => {
+    // Implementation-agnostic on purpose: satisfied by `docker run`, by a job-level
+    // container on an all-x64 matrix, or by a future musl-capable runner. What it
+    // does NOT tolerate is compiling the musl target on glibc, which is the actual
+    // hazard — `pty.node` is embedded at build time and would be the wrong libc.
+    const job = CI_CODE.slice(CI_CODE.indexOf('bun-binary-musl:'));
+    expect(job).toMatch(/alpine|musl/);                       // a musl environment
+    expect(job).toMatch(/readelf[\s\S]*libc/);                // linkage proven, not assumed
+    expect(job).toContain('--target bun-linux-x64-musl');     // the musl artifact
   });
 
-  it('compiles the musl TARGET (not the glibc one it sits next to)', () => {
-    expect(CI_CODE).toContain('--target bun-linux-x64-musl');
+  it('REGRESSION PIN: no job-level container (arm64 cannot run JS actions in one)', () => {
+    // Not the mechanism — one known-bad way of achieving it. GitHub refuses:
+    //   "JavaScript Actions in Alpine containers are only supported on x64 Linux
+    //    runners. Detected Linux Arm64"
+    // The x64 leg was unaffected, which is precisely why this PR gate stayed green
+    // while the release's arm64-musl leg died before a single build step ran.
+    const job = CI_CODE.slice(CI_CODE.indexOf('bun-binary-musl:'));
+    const jobHeader = job.slice(0, job.indexOf('steps:'));
+    expect(jobHeader).not.toMatch(/^\s*container:/m);
   });
 
-  it('asserts the native is musl-linked before compiling around it', () => {
-    // The fail-closed readelf gate. A glibc `pty.node` embedded in a musl binary
-    // survives the build; this is the only cheap place it is unambiguous.
-    expect(CI_CODE).toMatch(/readelf -d .*grep -q 'libc\\\.musl'/);
+  it('REGRESSION PIN: does NOT pin --platform (would emulate the wrong arch)', () => {
+    // Also a means-level pin. `--platform` would pull a foreign-arch image under
+    // qemu and embed a native for the WRONG architecture — the same class of defect
+    // as cross-compiling from glibc, reached by a different route.
+    const job = CI_CODE.slice(CI_CODE.indexOf('bun-binary-musl:'));
+    expect(job).not.toContain('--platform');
   });
 
   it('EXECUTES the musl binary through the shared smoke script', () => {
@@ -110,5 +139,30 @@ describe('release.yml — the musl legs stay wired into the publish chain', () =
     const subpackages = RELEASE_CODE.slice(RELEASE_CODE.indexOf('binary-subpackages:'));
     const needsLine = subpackages.slice(0, subpackages.indexOf('runs-on'));
     expect(needsLine).toContain('bun-binaries-musl');
+  });
+
+  it('MECHANISM: each musl leg builds on musl and proves the linkage', () => {
+    // Implementation-agnostic, like its ci.yml counterpart: what must hold is that
+    // the musl artifacts are built in a musl environment with the linkage verified,
+    // not that any particular container mechanism is used.
+    const job = RELEASE_CODE.slice(RELEASE_CODE.indexOf('bun-binaries-musl:'));
+    expect(job).toMatch(/alpine|musl/);
+    expect(job).toMatch(/readelf[\s\S]*libc/);
+  });
+
+  it('REGRESSION PIN: musl legs carry no job-level container (arm64 breaks in one)', () => {
+    // THE REGRESSION THIS PINS, and it is not hypothetical: v3.18.0-canary.4's
+    // release failed here. With `container: node:22-alpine`, the arm64-musl leg
+    // died at actions/checkout ("JavaScript Actions in Alpine containers are only
+    // supported on x64 Linux runners"), before a single build step ran. Because
+    // `binary-subpackages` and `release` both need this job, the entire publish
+    // chain skipped — correctly, but the release produced nothing.
+    //
+    // Reverting to a job-level container would break arm64 again while leaving the
+    // x64 PR gate green, which is exactly how it slipped through the first time.
+    const job = RELEASE_CODE.slice(RELEASE_CODE.indexOf('bun-binaries-musl:'));
+    const header = job.slice(0, job.indexOf('steps:'));
+    expect(header).not.toMatch(/^\s*container:/m);
+    expect(job).toContain('docker run');
   });
 });


### PR DESCRIPTION
## 背景：v3.18.0-canary.4 发版失败

打完 tag 后发版跑挂了，卡在 arm64 musl 腿：

```
JavaScript Actions in Alpine containers are only supported on x64 Linux runners.
Detected Linux Arm64
```

`actions/checkout` 是 JS action，GitHub 无法把它的 Node runtime 注入 **arm64 上的
musl 容器**。job 第一个 step 就死，后面全部 skipped。x64 那条腿完全正常。

## 零污染：fail-closed 生效了

`binary-subpackages` 与 `release` 都 `needs` 这条腿 ⟹ 一失败整条发布链 skip。
去 npm 核过（带随机 query 参数绕 CDN 缓存，这仓库踩过假 404）：

```
botmux-linux-x64-musl      仍只有 0.0.0 占位版
botmux-linux-arm64-musl    仍只有 0.0.0 占位版
botmux 主包                无 canary.4
```

**没有半发布状态，无需清理。** release.yml 那套「主包最后发、子包先发」的排序第一次
真派上用场。

## 为什么 PR CI 没拦住 —— 我自己挖的坑

ci.yml 的 musl job 我**特意只编 x64**，注释里写的理由是「arm64 需要另一个更慢的
runner」，纯成本考虑。而 arm64-musl 恰好是**唯一有平台级障碍**的那一格 ⟹ PR 门
结构上看不到它。

⭐ **「为省时间少覆盖一格」与「那一格恰好是唯一会坏的」这次撞上了。**

## 修法：JS action 留在宿主，只把构建放进 `docker run`

不再用 job 级 `container:`。checkout 在宿主（glibc）跑，musl 那一串——工具链 / bun /
`bun install` / readelf 门 / version / build / compile / smoke——全在 `docker run`
里。两个 arch 走同一条代码路径，不再依赖 GitHub 对容器的支持程度。

⚠️ 故意**不传 `--platform`**：镜像必须解析成 runner 自己的架构。传了就会用 qemu
模拟另一个 arch，编出**错架构的 native**——与「从 glibc 交叉编译 musl」同一类缺陷。

ci.yml 一并改成同一形态。它现在 x64-only、不改也能绿，但保持两个 workflow **同构**，
下次给它加 arch 时不会重新学一遍这个教训（这正是本次事故的根本形状）。

## 验证

形态在容器里真跑过。⚠️**本机无 qemu，arm64 本身无法模拟——验的是机制，不是 arm64**，
这点如实说明：

```
git archive 干净树 → bind mount → 容器内 bun install 698 包
readelf: NEEDED libc.musl-x86_64.so.1
编译 → smoke 六项全过
回到宿主：产物可读（159950296 bytes, mode 755, ELF magic 正确）
```

⚠️ 最后一条是本次**新增的必查项**：`container:` 下产物天然在工作区；换成 bind mount
后「宿主能否读到并上传」变成一个新的失败面，必须实测（upload-artifact 的前提）。

顺带确认 bun 不是障碍：`bun@1.4.0` 的 optionalDependencies 里
`@oven/bun-linux-aarch64-musl` 存在 ⟹ arm64 alpine 上 `npm i -g bun` 能装。

嵌套引号是这次最容易静默出错的地方（YAML 块 → 单引号 `sh -euc` → 注释里的撇号），
所以加了脚本化校验：YAML 解析 + 无 job 级 container + `docker run` 在位 + 未钉
`--platform` + **把嵌入脚本抽出来过 `sh -n`** + 断言脚本尾部没被引号截断。两个
workflow 各 11 项全过。

## 测试

`test/ci-musl-gate.test.ts` 9 → 11 条。两条断言按新契约重写（原来断言
`container: node:22-alpine`，现在断言**没有** job 级 container + 有 `docker run`），
并新增一条「release 侧不许回到 job 级 container」直接钉住本次事故。

**4 条反向变异全部转红**：
| 变异 | 结果 |
|---|---|
| 把 `container:` 塞回 ci.yml | ✅ 红 |
| 把 `container:` 塞回 release.yml（**canary.4 的真实失败形态**） | ✅ 红 |
| 钉 `--platform linux/amd64` | ✅ 红 |
| 删掉 `docker run` | ✅ 红 |

39 测试全绿（gate + 分发 + install.sh）。

## 影响面

只动 CI/发版 workflow 与其测试，**不动运行时代码**：不涉及任何 CLI 适配器、backend、
会话类型或 IM 层。glibc 四条腿（linux-x64/arm64、darwin-x64/arm64）与 desktop job
未改动。合完需重打一个 canary tag 才能验证发版链真的通。
