### PR TITLE
test(ci): 收紧 musl 门禁的「musl 环境」断言，原来那条是装饰性的

### DIFF
--- a/test/ci-musl-gate.test.ts
+++ b/test/ci-musl-gate.test.ts
@@ -68,8 +68,19 @@ describe('ci.yml — the musl artifact is gated on PRs, not only at release', ()
     // does NOT tolerate is compiling the musl target on glibc, which is the actual
     // hazard — `pty.node` is embedded at build time and would be the wrong libc.
     const job = CI_CODE.slice(CI_CODE.indexOf('bun-binary-musl:'));
-    expect(job).toMatch(/alpine|musl/);                       // a musl environment
-    expect(job).toMatch(/readelf[\s\S]*libc/);                // linkage proven, not assumed
+
+    // A musl ENVIRONMENT, and note carefully why this is not just /musl/: the word
+    // "musl" also appears in `--target bun-linux-x64-musl`, so a bare /alpine|musl/
+    // is satisfied by a job that compiles the musl target on plain glibc — the exact
+    // hazard. (Measured: against that shape, a bare /alpine|musl/ PASSES.) Match an
+    // actual musl image reference instead.
+    expect(job).toMatch(/(?:container:\s*|docker run[\s\S]{0,400}?)[\w./:-]*alpine/);
+
+    // The linkage must be PROVEN, not assumed. This is the load-bearing assertion:
+    // it is what rejects the glibc-built-musl shape, because the workflow's own
+    // readelf gate then fails closed at build time on a native lacking libc.musl.
+    expect(job).toMatch(/readelf[\s\S]*libc/);
+
     expect(job).toContain('--target bun-linux-x64-musl');     // the musl artifact
   });
 
@@ -144,9 +155,10 @@ describe('release.yml — the musl legs stay wired into the publish chain', () =
   it('MECHANISM: each musl leg builds on musl and proves the linkage', () => {
     // Implementation-agnostic, like its ci.yml counterpart: what must hold is that
     // the musl artifacts are built in a musl environment with the linkage verified,
-    // not that any particular container mechanism is used.
+    // not that any particular container mechanism is used. Same caveat as there —
+    // an alpine IMAGE reference, not a bare /musl/ which the target name satisfies.
     const job = RELEASE_CODE.slice(RELEASE_CODE.indexOf('bun-binaries-musl:'));
-    expect(job).toMatch(/alpine|musl/);
+    expect(job).toMatch(/(?:container:\s*|docker run[\s\S]{0,400}?)[\w./:-]*alpine/);
     expect(job).toMatch(/readelf[\s\S]*libc/);
   });
 


### PR DESCRIPTION
复审复现我上一个 commit（#1054）的变异实验时发现精度问题，核完**他说得对**。

## 缺陷：`/alpine|musl/` 被 target 名字满足，那条断言是装饰性的

`--target bun-linux-x64-musl` 里就含 `musl`。拿「在 glibc runner 上直编 musl 目标、
无任何容器」这个 hazard 形态去打三条子断言，**逐条**实测：

```
a1  /alpine|musl/          → PASSES（装饰性）
a2  readelf...libc         → fails（有牙）
a3  --target ...-musl      → PASSES（装饰性）
```

⚠️ 所以 #1054 里我写的「机制断言拒绝 glibc 编 musl」**不准确**：转红完全由 a2 一条
承担，a1 对「环境是不是 musl」提供零证据。

系统级保证仍然成立，但成立路径是「测试确保 readelf 门被**接线**，门本身在 CI 构建期
fail-closed 拦住 hazard」——**不是测试直接识别 hazard**。这个区别值得写清楚，否则下一个
人会把 `/alpine|musl/` 当成 musl 环境的证据。

## 修法

a1 改成匹配真实的**镜像引用**而非裸词：

```ts
expect(job).toMatch(/(?:container:\s*|docker run[\s\S]{0,400}?)[\w./:-]*alpine/);
```

四种形态实测（判据从测试文件里**抽取**正则，不手抄副本）：

| 形态 | 期望 | 结果 |
|---|---|---|
| hazard（glibc、无容器） | 不匹配 | ✅ 有牙 |
| 真实 ci.yml | 匹配 | ✅ |
| 真实 release.yml | 匹配 | ✅ |
| job 级 `container:` 形态 | 匹配 | ✅ 容忍度未破 |

最后一行是关键：收紧不能顺手把「未来换成 musl runner / 纯 x64 矩阵下用 `container:`」
一起判死——那就又从**锁机制**退回**锁手段**了，正是 #1054 要摆脱的形状。

## 交代两次同形状的自身失误

⚠️ ① 第一版校验脚本把正则**硬编码成字面量**，我改了测试却没改脚本 ⟹ 它一直在评判
旧正则、把修好的判成没修好。与 #1054 里「变异没落地却报未捕获」同源：**手抄一份被测
对象的副本，它会静默漂移**。改成从测试文件抽取后四项才全对。

⚠️ ② 收紧后一度把 `container:` 形态也拒了——`[\w./:-]*` 跨不过冒号后的空格。补
`\s*` 修好。这条正是上面那张表最后一行存在的理由。

## ⭐ 一般教训：聚合断言会掩盖各子项的牙

三条 `expect` 写在同一个 `it` 里，整体转红只需其中一条起作用，我据此以为三条都有效。
**逐条对 hazard 单独求值**才看得见真相。以后写这种多条件门禁断言，要么拆成独立
`it`，要么在验牙时逐条求值。

## 验证

11 测试仍全绿；分发 + install.sh + 本文件共 **39 全绿**；workflow 校验 11 项全过
（YAML 解析 / 无 job 级 container / `docker run` 在位 / 未钉 `--platform` / 嵌入脚本
过 `sh -n` / 脚本尾部未被引号截断，两个 workflow 各一遍）。

## 影响面

**只改测试文件**，不动 workflow、不动运行时代码。#1054 的 workflow 改动已随
`9ff9688ac` 合入并已用于 `v3.18.0-canary.5` 发版。
