### PR TITLE
fix(release): 容器构建后把 dist-bin 交还宿主用户，修 Checksums 的 Permission denied

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,3 +223,22 @@ jobs:
               chown -R "$HOST_UID:$HOST_GID" dist-bin
             '
 
+      - name: Prove the host can WRITE into dist-bin (canary.5's actual failure)
+        # Not cosmetic — this is the only place CI can catch the ownership bug.
+        #
+        # v3.18.0-canary.5 failed AFTER both musl builds and all smoke checks passed:
+        # the release leg's `Checksums` step writes .sha256 files INTO dist-bin, and
+        # the container had left it owned by root, so the runner's non-root user got
+        # `Permission denied`. This PR job has no such step, so without the check
+        # below it would stay green while the release breaks — exactly the asymmetry
+        # that let the bug ship.
+        #
+        # Deliberately mirrors what `Checksums` does (create a file in the directory)
+        # rather than merely reading a file: read access was never the problem.
+        run: |
+          echo "dist-bin owner: $(stat -c '%u:%g' dist-bin) (runner is $(id -u):$(id -g))"
+          cd dist-bin
+          for f in botmux-*; do sha256sum "$f" > "$f.sha256"; done
+          ls -la
+          echo "✅ host user wrote checksums into a container-produced directory"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
           docker run --rm \
             -v "$PWD:/work" -w /work \
             -e CI_RUN_NUMBER="${{ github.run_number }}" \
+            -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
             node:22-alpine sh -euc '
               # python3/make/g++ are node-gyp'"'"'s toolchain: node-pty has no linux
               # prebuild and must compile here. binutils supplies readelf.
@@ -210,5 +211,15 @@ jobs:
               # ERR_DLOPEN_FAILED. So running the binary at all proves the musl
               # native loads; no separate PTY step is needed.
               node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64-musl
+
+              # Hand dist-bin back to the HOST user, exactly as the release leg does.
+              #
+              # This job needs it less (nothing after this step touches dist-bin), and
+              # that asymmetry is precisely how the bug shipped: the release leg has a
+              # `Checksums` step that WRITES into dist-bin, and root-owned files made
+              # it fail with `Permission denied` after both musl builds had succeeded.
+              # Keeping the two legs isomorphic means the PR gate exercises the same
+              # ownership handoff the release depends on.
+              chown -R "$HOST_UID:$HOST_GID" dist-bin
             '
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -792,6 +792,7 @@ jobs:
             -v "$PWD:/work" -w /work \
             -e RELEASE_TAG \
             -e MATRIX_TARGETS="${{ matrix.targets }}" \
+            -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
             node:22-alpine sh -euc '
               apk add --no-cache python3 make g++ libstdc++ binutils >/dev/null
 
@@ -828,11 +829,28 @@ jobs:
               BIN="dist-bin/botmux-linux-${HOST_ARCH}-musl"
               if [ ! -x "$BIN" ]; then echo "musl binary $BIN not built"; exit 1; fi
               node scripts/smoke-bun-binary.mjs "$BIN"
+
+              # Hand dist-bin back to the HOST user before exiting.
+              #
+              # WHY (this broke v3.18.0-canary.5, after the container work itself had
+              # fully succeeded): the container runs as root, so everything it writes
+              # through the bind mount is uid 0. The runner host user is `runner`
+              # (uid 1001) and CANNOT create files inside a root-owned directory:
+              #   dist-bin/botmux-linux-arm64-musl.sha256: Permission denied
+              # Both musl legs built, smoke-passed, and then died in `Checksums`.
+              #
+              # `-v` bind mounts share the host inode, so ownership is not remapped
+              # for us (a `container:` job did not have this problem because GitHub
+              # ran the whole job as the same user). Reproduced and fixed as a
+              # non-root user before committing — my original verification ran as
+              # root, which can write anywhere and therefore could not see it.
+              chown -R "$HOST_UID:$HOST_GID" dist-bin
             '
 
       - name: Checksums
-        # Runs on the host: the binaries are bind-mount writebacks, owned by root
-        # (the container user), but world-readable — verified.
+        # Runs on the host, writing .sha256 files INTO dist-bin — which is why the
+        # container hands ownership back above. Readable is not enough; this step
+        # needs write permission on the directory.
         run: |
           cd dist-bin
           for f in botmux-*; do sha256sum "$f" > "$f.sha256"; done

--- a/test/ci-musl-gate.test.ts
+++ b/test/ci-musl-gate.test.ts
@@ -165,4 +165,26 @@ describe('release.yml — the musl legs stay wired into the publish chain', () =
     expect(header).not.toMatch(/^\s*container:/m);
     expect(job).toContain('docker run');
   });
+
+  it('hands dist-bin back to the host user (Checksums writes INTO it)', () => {
+    // THE REGRESSION THIS PINS — v3.18.0-canary.5, and note where it struck: both
+    // musl legs BUILT and smoke-PASSED, then `Checksums` died with
+    //   dist-bin/botmux-linux-arm64-musl.sha256: Permission denied
+    // The container runs as root, `-v` bind mounts share the host inode without
+    // remapping ownership, and the runner host user (uid 1001) cannot create files
+    // inside a root-owned directory. A job-level `container:` never had this problem
+    // because GitHub ran every step as the same user — so the problem was INTRODUCED
+    // by moving to `docker run`, and only bites steps that WRITE into dist-bin.
+    //
+    // Asserted on both workflows even though ci.yml has no step after the container:
+    // that asymmetry is how this shipped. Keeping the legs isomorphic means the PR
+    // gate exercises the same ownership handoff the release depends on.
+    for (const code of [RELEASE_CODE, CI_CODE]) {
+      const marker = code.includes('bun-binaries-musl:') ? 'bun-binaries-musl:' : 'bun-binary-musl:';
+      const job = code.slice(code.indexOf(marker));
+      expect(job).toMatch(/chown -R "\$HOST_UID:\$HOST_GID" dist-bin/);
+      // The ids must actually be passed in, or the chown expands to `:` and fails.
+      expect(job).toMatch(/-e HOST_UID="\$\(id -u\)" -e HOST_GID="\$\(id -g\)"/);
+    }
+  });
 });

--- a/test/ci-musl-gate.test.ts
+++ b/test/ci-musl-gate.test.ts
@@ -68,8 +68,19 @@ describe('ci.yml — the musl artifact is gated on PRs, not only at release', ()
     // does NOT tolerate is compiling the musl target on glibc, which is the actual
     // hazard — `pty.node` is embedded at build time and would be the wrong libc.
     const job = CI_CODE.slice(CI_CODE.indexOf('bun-binary-musl:'));
-    expect(job).toMatch(/alpine|musl/);                       // a musl environment
-    expect(job).toMatch(/readelf[\s\S]*libc/);                // linkage proven, not assumed
+
+    // A musl ENVIRONMENT, and note carefully why this is not just /musl/: the word
+    // "musl" also appears in `--target bun-linux-x64-musl`, so a bare /alpine|musl/
+    // is satisfied by a job that compiles the musl target on plain glibc — the exact
+    // hazard. (Measured: against that shape, a bare /alpine|musl/ PASSES.) Match an
+    // actual musl image reference instead.
+    expect(job).toMatch(/(?:container:\s*|docker run[\s\S]{0,400}?)[\w./:-]*alpine/);
+
+    // The linkage must be PROVEN, not assumed. This is the load-bearing assertion:
+    // it is what rejects the glibc-built-musl shape, because the workflow's own
+    // readelf gate then fails closed at build time on a native lacking libc.musl.
+    expect(job).toMatch(/readelf[\s\S]*libc/);
+
     expect(job).toContain('--target bun-linux-x64-musl');     // the musl artifact
   });
 
@@ -144,9 +155,10 @@ describe('release.yml — the musl legs stay wired into the publish chain', () =
   it('MECHANISM: each musl leg builds on musl and proves the linkage', () => {
     // Implementation-agnostic, like its ci.yml counterpart: what must hold is that
     // the musl artifacts are built in a musl environment with the linkage verified,
-    // not that any particular container mechanism is used.
+    // not that any particular container mechanism is used. Same caveat as there —
+    // an alpine IMAGE reference, not a bare /musl/ which the target name satisfies.
     const job = RELEASE_CODE.slice(RELEASE_CODE.indexOf('bun-binaries-musl:'));
-    expect(job).toMatch(/alpine|musl/);
+    expect(job).toMatch(/(?:container:\s*|docker run[\s\S]{0,400}?)[\w./:-]*alpine/);
     expect(job).toMatch(/readelf[\s\S]*libc/);
   });
 
@@ -186,5 +198,17 @@ describe('release.yml — the musl legs stay wired into the publish chain', () =
       // The ids must actually be passed in, or the chown expands to `:` and fails.
       expect(job).toMatch(/-e HOST_UID="\$\(id -u\)" -e HOST_GID="\$\(id -g\)"/);
     }
+  });
+
+  it('ci.yml PROVES the host can write into dist-bin, not just that chown is present', () => {
+    // The chown assertion above is a source pin: it cannot tell whether the chown
+    // actually achieves anything. And CI's own musl job has no step that writes into
+    // dist-bin, so a broken chown would leave this gate green — the same structural
+    // blindness that let canary.5 ship (the release leg writes there, the PR leg
+    // did not). ci.yml therefore carries an explicit host-side write, and it must
+    // CREATE a file (sha256sum > file), because read access was never the problem.
+    const job = CI_CODE.slice(CI_CODE.indexOf('bun-binary-musl:'));
+    const afterContainer = job.slice(job.lastIndexOf('chown -R'));
+    expect(afterContainer).toMatch(/sha256sum[\s\S]*>/);
   });
 });


### PR DESCRIPTION
`v3.18.0-canary.5` 发版失败。⚠️ 但**失败点在 #1054 的 arm64 修复之后**——那个改动是
有效的，arm64 腿这次真的编出来了：

```
bun-binaries-musl (arm64)   readelf → NEEDED libc.musl-aarch64.so.1     ✅
                            ✅ built ...-arm64-musl (version=3.18.0-canary.5)
                            smoke: all checks passed                     ✅
                            Checksums → 💥 Permission denied
```

两条 musl 腿都是同一形态：**构建成功、smoke 全过，然后死在 `Checksums`**。

```
dist-bin/botmux-linux-arm64-musl.sha256: Permission denied
```

## 根因：这是 `docker run` 引入的新失败面，`container:` 时代不存在

容器以 root 运行，`-v` bind mount 与宿主**共享 inode、不做 ownership 重映射** ⟹
容器写出的 `dist-bin/` 属 uid 0。而 runner 宿主用户是 `runner`(uid 1001)，**无法在
root 拥有的目录里创建文件**——而 `Checksums` 正是往 `dist-bin/` 里**写** `.sha256`。

job 级 `container:` 从来没这个问题：GitHub 让所有 step 跑在同一个用户下。所以这个
缺陷是 #1054 换成 `docker run` 时**引入**的，且只咬「往 dist-bin 里写」的步骤。

**修法**：把宿主 uid/gid 传进容器，容器退出前 `chown -R` 交还。

## ⚠️ 这个失败我本该在 #1054 就抓到，证据是我自己打印出来的

#1054 的验证脚本输出里有一行：

```
✅ 159950296 bytes, owner uid=0, mode=755
```

我把它当成「产物可读 ⟹ 回写成功」，**`uid=0` 就在同一行里，我读过去了**。更根本的是：
这台机器以 root 跑，**root 能写任何地方 ⟹ 我的验证形态在原理上就不可能失败**。

这次改成 `setpriv --reuid=1001` 复现，先拿到 `Permission denied`，再验修好。

⭐ **教训：「可读」不等于「可写」，而验证时的身份决定了能不能看见这个区别。以 root
验权限相关的改动等于没验。**

## 验证

真容器跑修好后的形态，宿主侧以 **uid 1001** 执行 Checksums：

```
in-container owner: 0
after chown:        1001
host-side Checksums step, as uid 1001:
   botmux-linux-x64-musl
   botmux-linux-x64-musl.sha256
✅ non-root host wrote the checksums
```

## ci.yml 一并加同一个 chown（它其实不需要）

ci.yml 的 musl job 后面没有任何步骤动 `dist-bin`，所以不加也不会失败。但
**这个不对称正是缺陷得以出厂的原因**：release 腿有个往 dist-bin 里写的 `Checksums`，
PR 腿没有 ⟹ **PR 门结构上碰不到这个失败面**。保持两腿同构，让 PR 门真的走一遍同样的
所有权交接。理由与 #1054 的同构化完全一致。

## 测试

断言两个 workflow 都有 `chown -R "$HOST_UID:$HOST_GID" dist-bin`
**且**都真的把 id 传进去了——少传的话 `chown` 会展开成 `:` 而失败，所以两半都要钉。

反向变异（与下节合计 5 条，全红）：
| 变异 | 结果 |
|---|---|
| 删 release.yml 的 chown | ✅ 红 |
| 保留 chown 但不传 HOST_UID/GID | ✅ 红 |
| 只删 ci.yml 那半（同构半边） | ✅ 红 |

## 附带：合入 #1055 的 a1 精度修复

本 PR 同时 cherry-pick 了 `87f42e690`（原 #1055），因为它同改这个测试文件，分开合会
制造无谓的冲突，而本 PR 是**发版阻塞项**。#1055 可以关掉。

那条修的是复审发现的精度问题：`/alpine|musl/` 会被 `--target bun-linux-x64-musl`
里的 `musl` 满足 ⟹ 对「环境是不是 musl」零证据。改成匹配真实镜像引用，四种形态实测
（hazard 不匹配 ✅ / 两个真实 workflow 匹配 ✅ / job 级 `container:` 形态仍匹配 ✅
——收紧不能顺手把未来的 musl runner 判死）。

41 测试全绿（gate 13 + 分发 + install.sh）；`bun run build` exit 0；workflow 校验
11 项全过。

## 影响面

只动 CI/发版 workflow 与其测试，**不动运行时代码**。合完需重打 canary tag
（canary.5 已用掉且发版未成功）；npm 侧 **零污染**，两个 musl 包仍只有 `0.0.0` 占位版、
主包无 canary.5——`binary-subpackages`/`release` 都 `needs` 这条腿，整链 fail-closed
跳过，这是第二次验证这套排序有效。

---

## 追加：给 ci.yml 加一步「宿主真能写进 dist-bin」的证明

上面那条 chown 断言是 **source pin**——只能证明 `chown` 这行**存在**，不能证明它
**有效**。而 ci.yml 的 musl job 后面本来没有任何步骤往 dist-bin 里写 ⟹ **chown 写坏了
这个门照样绿**，正是让 canary.5 出厂的同一种结构性盲区（release 腿往那儿写，PR 腿不写）。

所以 ci.yml 显式加一步：宿主侧 `sha256sum "$f" > "$f.sha256"`，**必须创建文件**
（只读从来不是问题所在），并打印 `dist-bin` owner 与 `id -u` 对照。

实测这一步是**真门禁**而非装饰：容器写出 root 拥有的 dist-bin、**不做 chown**，以
uid 1001 跑同样命令：

```
dist-bin owner: 0:0  (writer will be 1001:1001)
exit code: 2
   sh: 1: cannot create botmux-linux-x64-musl.sha256: Permission denied
✅ the proof step FAILS without chown — it is a real gate
```

⚠️ 又要交代一次 harness 失误（**本轮第三次同类**）：第一版判定脚本写成
`if cmd | sed 's/^/  /'; then`，测到的是 **sed 的退出码**（永远 0）⟹ 明明输出里就写着
`Permission denied`，它却报「PASSED without chown」。改成直接捕获退出码才对。

⭐ **管道会吞掉被测命令的退出码**——判据必须落在命令本身上。

测试合计 **11 → 13 条**。**5 条反向变异全红**：删 release 的 chown / 不传 id /
只删 ci.yml 那半 / 删掉证明步骤 / 把证明降级成只读。
