### PR TITLE
fix(lark): 关闭卡片会话恢复时不再强制发卡

### DIFF
--- a/src/core/current-actor-attestation.ts
+++ b/src/core/current-actor-attestation.ts
@@ -91,10 +91,10 @@ export function resolveLoopbackPeerProcesses(input: {
   procRoot?: string;
 }): LoopbackPeerResolution {
   const procRoot = input.procRoot ?? '/proc';
+  if (!isLoopbackAddress(input.remoteAddress)) return { ok: false, reason: 'not_loopback' };
   if (procRoot === '/proc' && process.platform !== 'linux') {
     return { ok: false, reason: 'platform_unsupported' };
   }
-  if (!isLoopbackAddress(input.remoteAddress)) return { ok: false, reason: 'not_loopback' };
   if (!Number.isSafeInteger(input.remotePort) || !input.remotePort
     || !Number.isSafeInteger(input.localPort) || !input.localPort) {
     return { ok: false, reason: 'socket_unavailable' };

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -2675,9 +2675,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
             ? t('card.action.resume_success_fresh', { cliName }, localeForBot(result.ds.larkAppId))
             : t('card.action.resume_success', { cliName }, localeForBot(result.ds.larkAppId));
           // Restore the ORIGINAL live streaming card (🖥️ header + usage line +
-          // 显示输出/终端/操作链接/关闭会话) as a WITHDRAW-then-REPOST (old closed card
-          // recalled, fresh card posted at the thread bottom), AND send the
-          // "✅ 会话已恢复…" text follow-up — both are wanted.
+          // 显示输出/终端/操作链接/关闭会话) as a WITHDRAW-then-REPOST when live
+          // cards are enabled. Card-off bots only withdraw the stale closed card
+          // and send the "✅ 会话已恢复…" text follow-up.
           // Ordering is load-bearing for two reasons:
           //   1) ACK the callback FIRST (bare `return` → empty ACK), THEN
           //      post/delete in the background — deleting the just-clicked card
@@ -2687,20 +2687,32 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
           //      never briefly shows zero cards (same invariant as park→recall).
           // Skip in private-card mode (clicked card may be an ephemeral snapshot).
           const botCfgResume = getBot(result.ds.larkAppId).config;
+          const shouldRepostStreamingCard = botCfgResume.disableStreamingCard !== true
+            && !botCfgResume.noCardChats?.includes(result.ds.chatId);
           if (cardMessageId && value?.visibility !== 'private' && !botCfgResume.privateCard) {
             const staleCardId = cardMessageId;
             const resumedDs = result.ds;
             void (async () => {
               try {
-                const freshCardId = await sessionReply(rootId, buildStreamingCardJson(resumedDs), 'interactive');
-                resumedDs.streamCardId = freshCardId;
+                if (shouldRepostStreamingCard) {
+                  const freshCardId = await sessionReply(rootId, buildStreamingCardJson(resumedDs), 'interactive');
+                  resumedDs.streamCardId = freshCardId;
+                } else {
+                  resumedDs.streamCardId = undefined;
+                  resumedDs.streamCardNonce = undefined;
+                  resumedDs.streamCardReplyTargetKey = undefined;
+                }
                 persistStreamCardState(resumedDs);
                 await deleteMessage(resumedDs.larkAppId, staleCardId).catch(() => { /* already withdrawn/expired */ });
-                // Also send the "✅ 会话已恢复…" text follow-up (the original resume
-                // behavior). Both are wanted: the live streaming card AND the text
-                // prompt telling the user to send a message to continue.
+                // Also send the "✅ 会话已恢复…" text follow-up (the original
+                // resume behavior) telling the user to send a message to continue.
                 await deliverEphemeralOrReply(resumedDs, operatorOpenId, resumeMsg, 'text', () => sessionReply(rootId, resumeMsg));
-                logger.info(`[${targetSessionId.substring(0, 8)}] Resumed via card button (withdraw + repost streaming card + text)`);
+                logger.info(
+                  `[${targetSessionId.substring(0, 8)}] Resumed via card button `
+                  + (shouldRepostStreamingCard
+                    ? '(withdraw + repost streaming card + text)'
+                    : '(withdraw card + text; streaming card disabled)'),
+                );
               } catch (err) {
                 logger.warn(`[${targetSessionId.substring(0, 8)}] resume card repost failed: ${err instanceof Error ? err.message : String(err)}`);
               }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14213,6 +14213,10 @@ async function spawnCli(
     // the checkout root. Exposed readOnly so `botmux` + claude hooks can exec
     // `node <checkout>/dist/cli.js`.
     const botmuxInstallRoot = canonical(dirname(dirname(fileURLToPath(import.meta.url))));
+    // A development worktree may share dependencies through a node_modules
+    // symlink. Seatbelt resolves that link before matching policy rules, so the
+    // checkout grant alone does not cover the canonical dependency tree.
+    const botmuxDependencyRoot = canonical(join(botmuxInstallRoot, 'node_modules'));
 
     // Pre-create the OWN writable dirs/files the sandboxed CLI creates on
     // demand, so they EXIST at spawn and survive the existence-filter below
@@ -14477,6 +14481,7 @@ async function spawnCli(
       })),
       execPaths: keepExisting([...execDirs, ...execCarve]),
       readonlyRoots: keepExisting([
+        botmuxDependencyRoot,
         ...(cfg.skillReadonlyRoots ?? []),
         ...piInitialPromptReadonlyRoots,
         // Adapter-declared read-only host paths (e.g. traex/coco first-run

--- a/test/card-handler-resume-receipt.test.ts
+++ b/test/card-handler-resume-receipt.test.ts
@@ -37,6 +37,20 @@ const ROOT_ID = 'om_root_resume';
 const CHAT_ID = 'oc_1';
 const OWNER = 'ou_owner';
 
+function configureBot(overrides: Record<string, unknown> = {}): void {
+  const dir = mkdtempSync(join(tmpdir(), 'botmux-resume-receipt-'));
+  const cfg = join(dir, 'bots.json');
+  writeFileSync(cfg, JSON.stringify([{
+    larkAppId: APP_ID,
+    larkAppSecret: 's',
+    cliId: 'copilot',
+    lang: 'zh',
+    allowedUsers: [OWNER],
+    ...overrides,
+  }], null, 2));
+  process.env.BOTS_CONFIG = cfg;
+}
+
 function makeDs(cliId: string, cliSessionId?: string): DaemonSession {
   return {
     larkAppId: APP_ID,
@@ -85,16 +99,7 @@ async function fresh() {
 }
 
 beforeEach(() => {
-  const dir = mkdtempSync(join(tmpdir(), 'botmux-resume-receipt-'));
-  const cfg = join(dir, 'bots.json');
-  writeFileSync(cfg, JSON.stringify([{
-    larkAppId: APP_ID,
-    larkAppSecret: 's',
-    cliId: 'copilot',
-    lang: 'zh',
-    allowedUsers: [OWNER],
-  }], null, 2));
-  process.env.BOTS_CONFIG = cfg;
+  configureBot();
 });
 
 afterEach(() => {
@@ -103,7 +108,7 @@ afterEach(() => {
 });
 
 describe('card-handler resume receipt', () => {
-  // The resume flow reposts the live streaming card FIRST (sessionReply with an
+  // With streaming cards enabled, the resume flow reposts the live card FIRST (sessionReply with an
   // interactive card body) and then sends the "会话已恢复 / 新起干净会话" text
   // receipt from a background task. So the receipt is no longer sessionReply
   // call[0] — it is the TEXT call among the sessionReply calls. Extract it by
@@ -166,5 +171,33 @@ describe('card-handler resume receipt', () => {
     const receipt = textReceipt(sessionReply);
     expect(receipt).toContain('会话已恢复');
     expect(receipt).not.toContain('新起干净会话');
+  });
+
+  it('does not repost a live card when streaming cards are disabled for the bot', async () => {
+    configureBot({ disableStreamingCard: true });
+    const { handler, resumeSession: mockedResume } = await fresh();
+    mockedResume.mockResolvedValue({ ok: true, ds: makeDs('copilot', 'cli-sess-9') });
+    const sessionReply = vi.fn(async () => 'om_reply');
+    const deps = { activeSessions: new Map(), sessionReply, lastRepoScan: new Map() } as any;
+
+    await handler.handleCardAction(resumeAction(), deps, APP_ID);
+    await flushBackground();
+
+    expect(repostedCardCount(sessionReply)).toBe(0);
+    expect(textReceipt(sessionReply)).toContain('会话已恢复');
+  });
+
+  it('does not repost a live card when streaming cards are disabled for the chat', async () => {
+    configureBot({ noCardChats: [CHAT_ID] });
+    const { handler, resumeSession: mockedResume } = await fresh();
+    mockedResume.mockResolvedValue({ ok: true, ds: makeDs('copilot', 'cli-sess-9') });
+    const sessionReply = vi.fn(async () => 'om_reply');
+    const deps = { activeSessions: new Map(), sessionReply, lastRepoScan: new Map() } as any;
+
+    await handler.handleCardAction(resumeAction(), deps, APP_ID);
+    await flushBackground();
+
+    expect(repostedCardCount(sessionReply)).toBe(0);
+    expect(textReceipt(sessionReply)).toContain('会话已恢复');
   });
 });

--- a/test/cli-runtime-update.test.ts
+++ b/test/cli-runtime-update.test.ts
@@ -1349,6 +1349,7 @@ describe('runCliRuntimeUpdateAudit with FNM rotating launcher symlinks', () => {
     mkdirSync(join(dir, 'install', 'bin'), { recursive: true });
     realInstall = join(dir, 'install', 'bin', 'codex.js');
     writeFileSync(realInstall, '#!/usr/bin/env node\n');
+    realInstall = realpathSync(realInstall);
   });
 
   afterEach(() => {
@@ -1464,6 +1465,7 @@ describe('runCliRuntimeUpdateAudit with FNM rotating launcher symlinks', () => {
     mkdirSync(join(dir, 'install-v2', 'bin'), { recursive: true });
     const realInstallV2 = join(dir, 'install-v2', 'bin', 'codex.js');
     writeFileSync(realInstallV2, '#!/usr/bin/env node\n');
+    const canonicalInstallV2 = realpathSync(realInstallV2);
     const shellBin = join(dir, 'multishells', '402_bbb', 'bin');
     mkdirSync(shellBin, { recursive: true });
     const link = join(shellBin, 'codex');
@@ -1473,9 +1475,9 @@ describe('runCliRuntimeUpdateAudit with FNM rotating launcher symlinks', () => {
     await runCliRuntimeUpdateAudit(deps(link));
     expect(probe).toHaveBeenCalledTimes(2);
     expect(notified).toEqual(['0.147.0', '0.147.0']);
-    const secondKey = `codex:${realInstallV2}`;
+    const secondKey = `codex:${canonicalInstallV2}`;
     expect(secondKey).not.toBe(firstKey);
-    expect(store.entries[secondKey].installationPath).toBe(realInstallV2);
+    expect(store.entries[secondKey].installationPath).toBe(canonicalInstallV2);
   });
 
   it('migrates a legacy raw-path entry onto the stable key without re-notifying (criteria = safe upgrade)', async () => {
@@ -1545,6 +1547,8 @@ describe('runCliRuntimeUpdateAudit with FNM rotating launcher symlinks', () => {
     const installC = join(dir, 'install-c', 'bin', 'codex.js');
     writeFileSync(installB, '#!/usr/bin/env node\n');
     writeFileSync(installC, '#!/usr/bin/env node\n');
+    const canonicalInstallB = realpathSync(installB);
+    const canonicalInstallC = realpathSync(installC);
     const binB = join(dir, 'multishells', 'B_live', 'bin');
     const binC = join(dir, 'multishells', 'C_live', 'bin');
     mkdirSync(binB, { recursive: true });
@@ -1593,13 +1597,13 @@ describe('runCliRuntimeUpdateAudit with FNM rotating launcher symlinks', () => {
 
     // Ambiguous group: no migration. Each live install probes and notifies
     // under its own canonical identity; the dead orphan is pruned.
-    const keyB = `codex:${installB}`;
-    const keyC = `codex:${installC}`;
+    const keyB = `codex:${canonicalInstallB}`;
+    const keyC = `codex:${canonicalInstallC}`;
     expect(probe).toHaveBeenCalledTimes(2);
     expect(notified).toEqual(['0.147.0', '0.147.0']);
     expect(Object.keys(store.entries).sort()).toEqual([keyB, keyC].sort());
-    expect(store.entries[keyB]?.installationPath).toBe(installB);
-    expect(store.entries[keyC]?.installationPath).toBe(installC);
+    expect(store.entries[keyB]?.installationPath).toBe(canonicalInstallB);
+    expect(store.entries[keyC]?.installationPath).toBe(canonicalInstallC);
   });
 
   it('reindexes a pre-fix entry whose rotating symlink is still alive, keeping its watermark (criteria 1/4 boundary)', async () => {

--- a/test/codex-browser-broker.test.ts
+++ b/test/codex-browser-broker.test.ts
@@ -5,7 +5,7 @@ import {
   resolveCodexBrowserPluginRoot,
   type DynamicToolCallParams,
 } from '../src/services/codex-browser-broker.js';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -182,7 +182,7 @@ describe('resolveCodexBrowserPluginRoot', () => {
         writeFileSync(join(scripts, 'browser-service.mjs'), 'export {}');
       }
       expect(resolveCodexBrowserPluginRoot()).toBe(
-        join(root, 'plugins', 'cache', 'openai-bundled', 'chrome', '26.10.1'),
+        realpathSync(join(root, 'plugins', 'cache', 'openai-bundled', 'chrome', '26.10.1')),
       );
     } finally {
       if (previousCodexHome === undefined) delete process.env.CODEX_HOME;

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -586,6 +586,7 @@ describe('dashboard secret persistence', () => {
     if (process.platform === 'win32') return;
     mkdirSync(join(dir, 'nested'));
     writeFileSync(secretPath, 'x'.repeat(43), { mode: 0o644 });
+    chmodSync(secretPath, 0o644);
     expect(() => loadDashboardSecret(secretPath)).toThrow(/0600/);
   });
 

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -1,7 +1,7 @@
 // test/dashboard-ipc.test.ts
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { createHmac, randomBytes } from 'node:crypto';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { request as httpRequest } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -329,6 +329,7 @@ describe('IPC auth reads the on-disk dashboard secret through the secure primiti
   it('fails closed (401) when the secret file has loose (0644) permissions', async () => {
     if (process.platform === 'win32') return;
     writeFileSync(secretPath, REAL_SECRET, { mode: 0o644 });
+    chmodSync(secretPath, 0o644);
     handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
     const base = `http://127.0.0.1:${handle.port}`;
 

--- a/test/global-config.test.ts
+++ b/test/global-config.test.ts
@@ -23,6 +23,7 @@ describe('global dashboard config', () => {
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'botmux-global-config-'));
     vi.stubEnv('HOME', home);
+    vi.stubEnv('BOTMUX_WORKFLOW_ENABLED', '');
     mkdirSync(dirname(globalConfigPath()), { recursive: true });
   });
 

--- a/test/ipc-current-actor-route.test.ts
+++ b/test/ipc-current-actor-route.test.ts
@@ -43,7 +43,7 @@ function activeSession(): any {
 }
 
 describe('POST /api/current-actor', () => {
-  it('returns only the daemon-resolved actor for a live CLI descendant', async () => {
+  it.skipIf(process.platform !== 'linux')('returns only the daemon-resolved actor for a live CLI descendant', async () => {
     vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(activeSession());
     ipc = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
     const response = await fetch(`http://127.0.0.1:${ipc.port}/api/current-actor`, {

--- a/test/ipc-preview-route.test.ts
+++ b/test/ipc-preview-route.test.ts
@@ -12,6 +12,7 @@ import * as sessionStore from '../src/services/session-store.js';
 
 const CAPABILITY = 'ac'.repeat(32);
 const HOST_SECRET = 'preview-route-host-secret';
+const itWithRealProcfs = it.skipIf(process.platform !== 'linux');
 let ipc: IpcServerHandle | null = null;
 let targetServer: Server | null = null;
 
@@ -87,7 +88,7 @@ async function postPreview(
 }
 
 describe('POST /api/sessions/:sessionId/preview', () => {
-  it('validates, persists, publishes, and returns only a safe same-origin descriptor', async () => {
+  itWithRealProcfs('validates, persists, publishes, and returns only a safe same-origin descriptor', async () => {
     const port = await reachablePort();
     const ds = activeSession();
     vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
@@ -194,7 +195,7 @@ describe('POST /api/sessions/:sessionId/preview', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
-  it('P1-13: discards a registration whose worker generation advanced during the probe', async () => {
+  itWithRealProcfs('P1-13: discards a registration whose worker generation advanced during the probe', async () => {
     const port = await reachablePort();
     const ds = activeSession();
     let lookups = 0;
@@ -223,7 +224,7 @@ describe('POST /api/sessions/:sessionId/preview', () => {
     expect(publish).not.toHaveBeenCalled();
   });
 
-  it('P1-13: discards a registration whose session was closed during the probe', async () => {
+  itWithRealProcfs('P1-13: discards a registration whose session was closed during the probe', async () => {
     const port = await reachablePort();
     const ds = activeSession();
     let lookups = 0;
@@ -257,7 +258,7 @@ describe('POST /api/sessions/:sessionId/preview', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
-  it('本机后端矩阵: pty/tmux/zellij still register normally', async () => {
+  itWithRealProcfs('本机后端矩阵: pty/tmux/zellij still register normally', async () => {
     for (const backendType of ['pty', 'tmux', 'zellij']) {
       const port = await reachablePort();
       const ds = activeSession(`s-${backendType}`);
@@ -282,7 +283,7 @@ describe('POST /api/sessions/:sessionId/preview', () => {
   // 鉴权，**没有 previewTarget 自己**，于是谁先 settle 谁先写、后 settle 的无条件覆盖
   // ——胜负由 probe 耗时决定，不是由请求先后决定（单 host 超时 750ms，不带 host 时
   // 127.0.0.1 与 ::1 串行试，「A 慢一秒、B 快一毫秒」是常规而非极端）。
-  it('P1-3: 慢请求不再覆盖 await 期间落地的新注册', async () => {
+  itWithRealProcfs('P1-3: 慢请求不再覆盖 await 期间落地的新注册', async () => {
     const port = await reachablePort();
     const ds = activeSession();
     const winner = {
@@ -310,7 +311,7 @@ describe('POST /api/sessions/:sessionId/preview', () => {
     expect(publish).not.toHaveBeenCalled();
   });
 
-  it('P1-3: 没有并发写入时，覆盖旧目标照常成功', async () => {
+  itWithRealProcfs('P1-3: 没有并发写入时，覆盖旧目标照常成功', async () => {
     const port = await reachablePort();
     const ds = activeSession();
     ds.session.previewTarget = {
@@ -326,7 +327,7 @@ describe('POST /api/sessions/:sessionId/preview', () => {
     expect(ds.session.previewTarget).toMatchObject({ port });
   });
 
-  it('restores in-memory state when durable persistence fails', async () => {
+  itWithRealProcfs('restores in-memory state when durable persistence fails', async () => {
     const port = await reachablePort();
     const previous = {
       host: '127.0.0.1', port: 1111, registeredAt: '2026-08-10T00:00:00.000Z',

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -187,7 +187,7 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     expect(r.status).toBe(0);
     expect(r.wrote).toBe(true);
     const content = readFileSync(r.launcher, 'utf-8');
-    expect(content).toBe(`#!/bin/sh\nexec "${r.binary}" "$@"\n`);
+    expect(content).toBe(`#!/bin/sh\nexec "${realpathSync(r.binary)}" "$@"\n`);
     // No node anywhere — the binary is self-contained. `node` as a command word,
     // so a path merely containing "node" cannot produce a false pass.
     expect(content).not.toMatch(/(^|\s)node(\s|$)/m);
@@ -298,7 +298,9 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     if (muslDir) writeFileSync(join(fakeLib, muslDir), '');
     let src = readFileSync(POSTINSTALL, 'utf-8')
       .replace("for (const dir of ['/lib', '/usr/lib'])", `for (const dir of ['${fakeLib}'])`)
-      .replace("existsSync('/etc/alpine-release')", 'false');
+      .replace("existsSync('/etc/alpine-release')", 'false')
+      .replaceAll('process.platform', "'linux'")
+      .replaceAll('process.arch', "'x64'");
     src = src.replace(
       'if (process.report?.getReport?.()?.header?.glibcVersionRuntime) return false;',
       'if (undefined) return false;',
@@ -341,7 +343,7 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     expect(r.stderr).toContain('no prebuilt binary package');
   });
 
-  it('glibc short-circuit: a reported glibc runtime settles it before any probe', () => {
+  it.skipIf(process.platform !== 'linux')('glibc short-circuit: a reported glibc runtime settles it before any probe', () => {
     // Unmodified script on this (glibc) box: even though the real /lib may contain
     // anything, glibcVersionRuntime is present so musl must never be claimed.
     expect(process.report.getReport().header.glibcVersionRuntime).toBeTruthy();

--- a/test/oh-my-pi-legacy-migration.test.ts
+++ b/test/oh-my-pi-legacy-migration.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   rmSync,
   symlinkSync,
@@ -102,7 +103,7 @@ describe('OMP legacy session migration', () => {
 
     expect(result).toMatchObject({
       status: 'migrated',
-      sourcePath: source,
+      sourcePath: realpathSync(source),
       targetPath: join(exactDir, basename(source)),
       artifactDirectoryPreserved: true,
     });

--- a/test/plugin-pm2-env.test.ts
+++ b/test/plugin-pm2-env.test.ts
@@ -93,8 +93,14 @@ describe('plugin PM2 environment', () => {
     vi.resetModules();
     const { runPluginPm2 } = await import('../src/core/plugins/pm2.js');
 
-    expect(() => runPluginPm2(['start', 'fixture'], { inherit: false }))
-      .toThrow(/exactly one.*123, 456/);
+    const hostPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    try {
+      expect(() => runPluginPm2(['start', 'fixture'], { inherit: false }))
+        .toThrow(/exactly one.*123, 456/);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: hostPlatform });
+    }
     expect(childProcess.spawnSync).not.toHaveBeenCalled();
   });
   it('does not leak the Dashboard Feishu H5 login family into plugin PM2 apps', async () => {

--- a/test/structured-bridge-clis.test.ts
+++ b/test/structured-bridge-clis.test.ts
@@ -3,7 +3,7 @@
  * Keeps the single-source helpers honest without pulling the worker.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, realpathSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -120,7 +120,7 @@ describe('resolveFileBridgePath (oh-my-pi)', () => {
     const legacyPath = join(legacyDir, 'legacy.jsonl');
     writeFileSync(path, '');
     writeFileSync(legacyPath, 'legacy history must not be attached');
-    expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sid-omp' })).toBe(path);
+    expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sid-omp' })).toBe(realpathSync(path));
     expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sid-omp' })).not.toBe(legacyPath);
     expect(resolveFileBridgePath('oh-my-pi', { sessionId: 'sibling' })).toBeUndefined();
   });


### PR DESCRIPTION
## 问题

点击已关闭会话卡片的“恢复会话”后，卡片回调会直接撤回旧卡并重新发送实时流式卡片。这个分支绕过了 Bot 级 `disableStreamingCard` 和群级 `noCardChats`，因此即使关闭卡片，首次恢复仍会出现一张“启动中”卡片。

同时，macOS 全量测试暴露了几类环境差异：`/var` 与 `/private/var` 的路径别名、依赖真实 Linux procfs 的路由集成测试、严格 umask、继承的 daemon 环境变量，以及 worktree 共享 `node_modules` 时 Seatbelt 对 symlink 的规范化。

## 修改

- 恢复卡片回调统一遵守 Bot 级和群级的卡片关闭配置：
  - 卡片开启时保持原有“撤回旧卡、重发实时卡、发送文本回执”行为；
  - 卡片关闭时只撤回旧卡、清理残留卡片状态并发送文本回执；
  - 私有卡片路径保持不变。
- 补充 Bot 级与群级关闭卡片的恢复回归测试。
- macOS 测试按能力边界收敛：
  - 路径断言比较 realpath，不因 Darwin 跳过；
  - 只有读取真实 `/proc` 的用例在非 Linux 平台跳过，假 procfs 算法测试继续跨平台运行；
  - 非 loopback 地址先于平台能力检查拒绝；
  - 显式构造文件权限、隔离继承环境，并让 PM2 所属算法测试在模拟 Linux 平台下运行；
  - 为 Seatbelt 只读开放 worktree symlink 解析后的依赖根目录。

## 影响面

- 卡片修复位于飞书公共卡片回调，影响所有 CLI 的普通群聊可见卡片恢复；卡片开启行为、私有卡片、`/adopt`、Dashboard/internal resume 和 worker ready 展示逻辑不变。
- procfs 产品能力仍只在 Linux 上提供强归属证明；macOS 继续 fail closed。
- Seatbelt 新增的依赖目录授权仅为只读，覆盖开发 worktree 共享依赖的场景，不扩大写权限。
- 检查了当前 open PR，没有发现相同修复；#849 涉及 worker ready/stable-card 展示，#1005 涉及 daemon 重启恢复失败广播，均不覆盖本问题。

## 验证

- `bun run test`：1106 个测试文件通过、8 个按平台跳过；18644 条测试通过、101 条跳过，零失败。
- rebase 最新 master 后复跑 19 个受影响测试文件：855 条通过、9 条按平台跳过，零失败。
- `bun run build`：通过。
- `git diff --check`：通过。

按要求未执行 `switch:here`，也未重启 live daemon。
