### PR TITLE
fix(lark): 修正 Card 2.0 宽度与页脚字号

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9150,7 +9150,7 @@ async function cmdSend(rest: string[]): Promise<void> {
                 tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center',
                 elements: [footer?.element ?? {
                   tag: 'markdown',
-                  text_size: 'notation_small_v2',
+                  text_size: 'notation',
                   content: ' ',
                 }],
               },

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -2650,7 +2650,7 @@ export function buildAdoptSelectCard(
 function wrapAdoptCard(elements: any[], locale?: Locale): any {
   return {
     schema: '2.0',
-    config: { update_multi: true, wide_screen_mode: true },
+    config: { update_multi: true, width_mode: 'fill' },
     header: {
       template: 'blue',
       title: { tag: 'plain_text', content: t('card.adopt.title', undefined, locale) },

--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -73,7 +73,7 @@ export interface ReplyCardFooter {
   element: {
     tag: 'markdown';
     element_id: typeof REPLY_CARD_FOOTER_ELEMENT_ID;
-    text_size: 'notation_small_v2';
+    text_size: 'notation';
     content: string;
   };
 }
@@ -476,7 +476,7 @@ export function buildReplyCardFooter(opts: {
     element: {
       tag: 'markdown',
       element_id: REPLY_CARD_FOOTER_ELEMENT_ID,
-      text_size: 'notation_small_v2',
+      text_size: 'notation',
       content,
     },
   };

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -1301,7 +1301,11 @@ function extractElementText(el: any, parts: string[], imgLabel: (key: string) =>
   if (
     el.element_id === REPLY_CARD_FOOTER_ELEMENT_ID
     && tag === 'markdown'
-    && (el.text_size === undefined || el.text_size === 'notation_small_v2')
+    && (
+      el.text_size === undefined
+      || el.text_size === 'notation'
+      || el.text_size === 'notation_small_v2'
+    )
     && typeof elementText === 'string'
     && hasExactMarkerMarkdown(elementText)
   ) {

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -93,6 +93,12 @@ describe('buildAdoptSelectCard (V2 picker)', () => {
       .filter((e: any) => e.tag === 'interactive_container')
       .map((e: any) => (e.elements ?? []).map((x: any) => x.content ?? '').join('\n'));
 
+  it('uses Card JSON 2.0 fill width instead of the legacy wide-screen field', () => {
+    const card = parse(buildAdoptSelectCard([], 'om_root', 'en'));
+    expect(card.schema).toBe('2.0');
+    expect(card.config).toEqual({ update_multi: true, width_mode: 'fill' });
+  });
+
   it('renders a live session as a card showing CLI / source / path / target, not a dropdown option', () => {
     const card = parse(buildAdoptSelectCard([{
       source: 'herdr',

--- a/test/md-card.test.ts
+++ b/test/md-card.test.ts
@@ -928,7 +928,7 @@ describe('buildReplyCardFooter', () => {
     expect(footer?.element).toMatchObject({
       tag: 'markdown',
       element_id: 'botmux_reply_footer',
-      text_size: 'notation_small_v2',
+      text_size: 'notation',
       content: footer?.content,
     });
   });
@@ -1118,7 +1118,7 @@ describe('buildMarkdownCard footer brand', () => {
   it('empty brand + no recipient → no footer at all (no orphan hr)', () => {
     const els = JSON.parse(buildMarkdownCard('hi', undefined, '')).body.elements;
     expect(els.some((e: any) => e.tag === 'hr')).toBe(false);
-    expect(els.some((e: any) => e.text_size === 'notation_small_v2')).toBe(false);
+    expect(els.some((e: any) => e.element_id === 'botmux_reply_footer')).toBe(false);
     expect(JSON.stringify(els)).not.toContain('botmux');
     expect(els.some((e: any) => e.tag === 'markdown' && /hi/.test(e.content))).toBe(true);
   });
@@ -1289,7 +1289,7 @@ describe('buildContextualReplyCard footer brand', () => {
       title: 'T', assistantText: 'a', assistantLabel: 'Claude', recipientOpenId: 'ou_x', brand: 'Acme',
     })).body.elements;
     const last = els[els.length - 1];
-    expect(last.text_size).toBe('notation_small_v2');
+    expect(last.text_size).toBe('notation');
     expect(last.content).toContain('Acme');
     expect(last.content).not.toContain('botmux');
   });
@@ -1298,7 +1298,7 @@ describe('buildContextualReplyCard footer brand', () => {
     const els = JSON.parse(buildContextualReplyCard({
       title: 'T', assistantText: 'a', assistantLabel: 'Claude', brand: '',
     })).body.elements;
-    expect(els.some((e: any) => e.text_size === 'notation_small_v2')).toBe(false);
+    expect(els.some((e: any) => e.element_id === 'botmux_reply_footer')).toBe(false);
     expect(JSON.stringify(els)).not.toContain('botmux');
   });
 });

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -726,7 +726,11 @@ describe('Interactive card parsing: botmux footer is stripped from prompt', () =
 // ─── Structural footer strip (brand-agnostic, for per-bot custom brands) ──
 
 describe('Interactive card parsing: footer stripped structurally (custom brand)', () => {
-  it('drops a schema 2.0 footer element without text_size when it carries the exact split-font marker', () => {
+  it.each([
+    { name: 'without text_size', textSize: undefined },
+    { name: 'with Card 2.0 notation', textSize: 'notation' },
+    { name: 'with legacy notation_small_v2', textSize: 'notation_small_v2' },
+  ])('drops a schema 2.0 footer $name when it carries the exact split-font marker', ({ textSize }) => {
     const card = {
       schema: '2.0',
       body: { elements: [
@@ -735,6 +739,7 @@ describe('Interactive card parsing: footer stripped structurally (custom brand)'
         {
           element_id: 'botmux_reply_footer',
           tag: 'markdown',
+          ...(textSize === undefined ? {} : { text_size: textSize }),
           content: '[botmux](https://github.com/deepcoldy/botmux)'
             + "<font color='grey'> </font>"
             + '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)'
@@ -753,6 +758,7 @@ describe('Interactive card parsing: footer stripped structurally (custom brand)'
       footer: {
         element_id: 'botmux_reply_footer',
         tag: 'markdown',
+        text_size: 'notation',
         content: '[footer spec](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)',
       },
       expected: 'footer spec',
@@ -919,7 +925,7 @@ describe('botmux internal callback buttons (🔊 语音总结 …) dropped from 
         { tag: 'hr' },
         { tag: 'column_set', flex_mode: 'none', columns: [
           { tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center',
-            elements: [{ tag: 'markdown', text_size: 'notation_small_v2', content: ' ' }] },
+            elements: [{ tag: 'markdown', text_size: 'notation', content: ' ' }] },
           { tag: 'column', width: 'auto', vertical_align: 'center', elements: [{
             tag: 'button',
             text: { tag: 'plain_text', content: '🔊 语音总结' },


### PR DESCRIPTION
## 改动内容

- 将 `/adopt` 选择卡的 Card JSON 2.0 配置从旧版 `wide_screen_mode` 改为 `width_mode: "fill"`，保留 `update_multi: true`
- 将回复卡页脚及语音按钮空占位的字号从无效的 `notation_small_v2` 改为 Card 2.0 枚举 `notation`
- 消息解析继续兼容历史卡片：页脚 `text_size` 缺省、`notation`、`notation_small_v2` 三种形态都能按结构安全剥离；错误 marker 或其它字号不会被误删

## 原因

上述旧字段属于 Card JSON 1.0 或不在 Card 2.0 的合法枚举中，写入 2.0 卡片时不会产生预期的宽度和字号效果。此改动只校正 2.0 路径，并保留历史消息回读兼容性。

## 影响面评估

- 影响飞书 Card 2.0 的 `/adopt` 选择卡，以及复用统一 footer builder 的回复卡发送、fallback、contextual reply 和自定义品牌页脚
- 影响 `history`、`quoted` 与跨 Agent 消息读取中的内部页脚剥离逻辑，同时兼容新旧已发送卡片
- 不修改 Card 1.0 流式卡中的 `wide_screen_mode` / `notation_small_v2`
- 不涉及其它 IM、CLI 适配器、PTY/Tmux 后端或会话路由

## 测试验证

- `./node_modules/.bin/vitest run --project unit test/card-builder.test.ts test/md-card.test.ts test/message-parser.test.ts`
  - 3 个文件、437 条测试全部通过
- `npx -y bun@1.4.0 run build`
  - TypeScript、脚本类型检查、Dashboard bundle 与 dist audit 全部通过
- `npx -y bun@1.4.0 run daemon:restart`
  - daemon 重启烟测通过；验证后已恢复既有 live checkout
- `npx -y bun@1.4.0 run test`
  - 18,724 条通过；7 条现有环境/集成用例失败，集中在端口竞态、root 权限语义、机器级公开 URL 注入及 MCP/DSH 沙箱进程，与本次修改文件和聚焦回归无交集
- `git diff --check`
  - 通过

## 视觉说明

本 PR 不附模拟图片。宽度与字号使用 Card 2.0 官方字段，并由发送 JSON 的精确断言覆盖；历史与新格式的回读兼容由真实归一化形态的解析测试覆盖。
