### PR TITLE
fix(release): Release 先建草稿，二进制附完再公开，消除 curl 安装的 404 窗口

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,21 +508,30 @@ jobs:
             echo 'CHANGELOG_EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub Release (desktop assets attached asynchronously)
-        # npm-first: the Release is created right after npm publish, WITHOUT the
-        # macOS assets — those are uploaded later by `attach-desktop-assets` once
-        # signing/notarization finishes. So the Release exists with npm already
-        # live but no .dmg/.zip yet. Normally the desktop bundle lands within the
-        # same run (a few minutes) once macOS signing completes — but signing is
-        # behind a human approval gate that can wait up to 30 days, or be
-        # rejected / fail / be cancelled; in those cases the Release stays
-        # npm-only until the manual recovery re-run (see attach-desktop-assets).
-        # softprops keeps the release editable so the later --clobber upload just
-        # adds the files.
+      - name: Create GitHub Release as a DRAFT (published once binaries are attached)
+        # WHY A DRAFT (this was a real user-facing 404): `releases/latest/download/…`
+        # starts resolving to a release the moment it is PUBLISHED, but the binaries
+        # are uploaded by the separate `attach-bun-binaries` job which cannot run
+        # until the release exists. On v3.18.0 that gap was 72 seconds (published
+        # 09:11:58, assets attached 09:13:10) and a user running install.sh inside it
+        # got:
+        #   curl: (56) The requested URL returned error: 404
+        #   botmux install: download failed: …/releases/latest/download/botmux-darwin-arm64
+        #
+        # A draft is invisible to `latest` and to anonymous downloads, so the window
+        # closes: `publish-github-release` below flips it public only after the
+        # binaries are in place. Verified against the real API: uploading to a draft
+        # BY TAG NAME works, publishing preserves the assets, and the asset is then
+        # anonymously downloadable (HTTP 200).
+        #
+        # Desktop (.dmg/.zip) is deliberately NOT part of this gate — signing sits
+        # behind a human approval that can wait up to 30 days, so it still attaches
+        # asynchronously to the already-published release, exactly as before.
         uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.changelog.outputs.body }}
           prerelease: ${{ steps.dist_tag.outputs.prerelease == 'true' }}
+          draft: true
 
       - name: Comment "Released in" on included PRs
         # squash 兼容的「已发布」标记:GitHub 原生侧栏 released 徽标只认 PR 分支的原始
@@ -972,6 +981,76 @@ jobs:
         run: |
           ls -la dist-bin
           gh release upload "$RELEASE_TAG" dist-bin/botmux-* --clobber --repo "$GITHUB_REPOSITORY"
+
+  publish-github-release:
+    # Flip the draft release public — the LAST step of the release, on purpose.
+    #
+    # WHY THIS JOB EXISTS: `releases/latest/download/…` resolves as soon as a release
+    # is published, but the binaries are attached by `attach-bun-binaries`, which
+    # cannot run before the release exists. Publishing immediately therefore opened a
+    # window where install.sh 404s — 72 seconds on v3.18.0, and a real user hit it.
+    # Creating the release as a draft and publishing HERE means `latest` never points
+    # at a release without binaries.
+    #
+    # WHY IT IS NOT PART OF `attach-bun-binaries`: keeping "upload" and "publish"
+    # separate means a partial upload cannot publish. If attach fails, this job is
+    # skipped and the release stays a DRAFT — invisible to `latest`, so users keep
+    # getting the previous version instead of a 404. That is the fail-closed
+    # direction: npm is already live either way.
+    #
+    # RECOVERY FROM A STUCK DRAFT (verified, because the obvious assumption is wrong):
+    # `workflow_dispatch` does NOT re-run this job — it carries
+    # `github.event_name == 'push'`, and the dispatch path only reaches
+    # `refresh-desktop-assets`. Re-running the failed RUN works only while the
+    # compiled-binary artifacts still exist (`retention-days: 7`). So:
+    #   • within 7 days → re-run the failed jobs of that run; or
+    #   • any time      → attach the assets and publish by hand:
+    #       gh release upload vX.Y.Z <binaries+sha256> --clobber
+    #       gh release edit   vX.Y.Z --draft=false
+    # A draft blocks only the curl/install.sh path; npm already serves the same
+    # binaries inside the platform subpackages, so this is never a total outage.
+    #
+    # `--draft=false` is idempotent: publishing an already-public release is a no-op.
+    if: github.event_name == 'push' && needs.attach-bun-binaries.result == 'success'
+    needs: [attach-bun-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Verify every install.sh asset is present BEFORE publishing
+        # The gate this whole change exists for. install.sh derives asset names from
+        # `uname -s`/`uname -m` (+ a `-musl` suffix when the libc is musl), so a
+        # missing or misnamed asset is a 404 for exactly the platforms it covers —
+        # and nothing else in the pipeline checks the NAMES at all. Refusing to
+        # publish leaves the release a draft, which is strictly better than a public
+        # release that 404s.
+        run: |
+          missing=""
+          for a in botmux-linux-x64 botmux-linux-arm64 botmux-linux-x64-musl \
+                   botmux-linux-arm64-musl botmux-darwin-x64 botmux-darwin-arm64; do
+            for f in "$a" "$a.sha256"; do
+              gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+                --json assets --jq '[.assets[].name]|index("'"$f"'")' | grep -q '^[0-9]' \
+                || missing="$missing $f"
+            done
+          done
+          if [ -n "$missing" ]; then
+            echo "REFUSING to publish: missing release assets:$missing"
+            echo "The release stays a DRAFT, so releases/latest/download keeps serving the"
+            echo "previous version instead of 404ing. Fix the assets, then re-run."
+            exit 1
+          fi
+          echo "ok: all 12 install.sh assets present"
+
+      - name: Publish the release
+        run: |
+          gh release edit "$RELEASE_TAG" --draft=false --repo "$GITHUB_REPOSITORY"
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,isPrerelease,assets \
+            --jq '"published: isDraft=\(.isDraft) prerelease=\(.isPrerelease) assets=\(.assets|length)"'
 
   attach-desktop-assets:
     # npm-first tail: once the parallel `desktop` job has signed+notarized the

--- a/test/release-draft-until-assets.test.ts
+++ b/test/release-draft-until-assets.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+/**
+ * The GitHub Release must never be publicly visible without its binaries attached.
+ *
+ * THE BUG THIS DEFENDS AGAINST, and it reached a user: `releases/latest/download/…`
+ * starts resolving the moment a release is PUBLISHED, but the binaries are uploaded
+ * by `attach-bun-binaries`, which cannot run until the release exists. On v3.18.0 the
+ * gap was 72 seconds (published 09:11:58, assets attached 09:13:10) and install.sh
+ * inside that window died with:
+ *
+ *   curl: (56) The requested URL returned error: 404
+ *   botmux install: download failed: …/releases/latest/download/botmux-darwin-arm64
+ *
+ * The fix is to create the release as a DRAFT and publish it only after the assets
+ * land. Measured against the real API: while draft, BOTH url shapes install.sh uses
+ * (`latest/download/<asset>` and `download/<tag>/<asset>`) return 404 to an anonymous
+ * client, and `latest` keeps serving the PREVIOUS release — so users get the old
+ * version rather than an error. After publishing, the pinned-tag url returns 200.
+ *
+ * WHAT THESE TESTS ASSERT — the invariant, not the mechanism: "no public release
+ * without binaries". Parsed as YAML (not text) because the claims are structural:
+ * job dependencies, a boolean flag, and step ORDER.
+ */
+
+const RELEASE_YML = resolve(import.meta.dirname, '../.github/workflows/release.yml');
+const doc = parseYaml(readFileSync(RELEASE_YML, 'utf-8')) as {
+  jobs: Record<string, {
+    if?: string;
+    needs?: string | string[];
+    steps?: Array<{ name?: string; uses?: string; run?: string; with?: Record<string, unknown> }>;
+  }>;
+};
+const jobs = doc.jobs;
+const needsOf = (name: string) => {
+  const n = jobs[name]?.needs;
+  return Array.isArray(n) ? n : n ? [n] : [];
+};
+const runsOf = (name: string) => (jobs[name]?.steps ?? []).map((s) => s.run ?? '').join('\n');
+
+/** Every asset install.sh can ask for: `botmux-<os>-<arch>` (+ `-musl` on musl hosts),
+ *  each with a `.sha256` sibling. A missing one is a 404 for exactly those hosts. */
+const INSTALL_SH_ASSETS = [
+  'botmux-linux-x64',
+  'botmux-linux-arm64',
+  'botmux-linux-x64-musl',
+  'botmux-linux-arm64-musl',
+  'botmux-darwin-x64',
+  'botmux-darwin-arm64',
+];
+
+describe('release.yml — no public Release without its binaries', () => {
+  it('creates the Release as a DRAFT', () => {
+    // A draft is invisible to `latest` and to anonymous downloads, which is what
+    // closes the window. Publishing at creation time is the defect.
+    const create = (jobs.release.steps ?? []).find((s) => (s.uses ?? '').includes('softprops'));
+    expect(create, 'release job must create the GitHub Release').toBeDefined();
+    expect(create!.with?.draft).toBe(true);
+  });
+
+  it('publishes only AFTER the binaries are attached', () => {
+    expect(jobs['publish-github-release'], 'a separate publish job must exist').toBeDefined();
+    expect(needsOf('publish-github-release')).toContain('attach-bun-binaries');
+    expect(runsOf('publish-github-release')).toContain('--draft=false');
+  });
+
+  it('a FAILED upload leaves the Release a draft (fail-closed)', () => {
+    // The direction that matters. Without the explicit success check, GitHub would
+    // run this job even when the upload failed — publishing an assetless release,
+    // i.e. reintroducing the 404 permanently instead of for 72 seconds. A draft
+    // means `latest` keeps serving the previous version.
+    expect(jobs['publish-github-release'].if ?? '')
+      .toContain("needs.attach-bun-binaries.result == 'success'");
+  });
+
+  it('refuses to publish unless every install.sh asset is present', () => {
+    const runs = runsOf('publish-github-release');
+    for (const asset of INSTALL_SH_ASSETS) expect(runs).toContain(asset);
+    expect(runs).toContain('.sha256');
+    expect(runs).toMatch(/REFUSING to publish/);
+  });
+
+  it('verifies the assets BEFORE flipping the draft, not after', () => {
+    // Order is the whole point: a check that runs after publishing cannot prevent
+    // anything. Compare positions rather than trusting the step names.
+    const steps = jobs['publish-github-release'].steps ?? [];
+    const verify = steps.findIndex((s) => (s.run ?? '').includes('REFUSING to publish'));
+    const publish = steps.findIndex((s) => (s.run ?? '').includes('--draft=false'));
+    expect(verify).toBeGreaterThanOrEqual(0);
+    expect(publish).toBeGreaterThan(verify);
+  });
+
+  it('no OTHER job publishes the Release', () => {
+    // One publication point, or the ordering guarantee above is bypassable.
+    for (const name of Object.keys(jobs)) {
+      if (name === 'publish-github-release') continue;
+      expect(runsOf(name), `${name} must not flip the draft`).not.toContain('--draft=false');
+    }
+  });
+
+  it('macOS signing does NOT gate publication', () => {
+    // Signing sits behind a human approval that can wait up to 30 days. If the
+    // desktop jobs gated publication, the Release would stay a draft that whole
+    // time — so the .dmg/.zip must keep attaching to an already-public Release.
+    for (const name of ['attach-desktop-assets', 'refresh-desktop-assets']) {
+      if (jobs[name]) expect(needsOf(name)).not.toContain('publish-github-release');
+    }
+  });
+});


### PR DESCRIPTION
用户在 `v3.18.0` 发版后跑 curl 安装拿到 404：

    curl: (56) The requested URL returned error: 404
    botmux install: download failed: .../releases/latest/download/botmux-darwin-arm64

**不是缺构建，是时间窗**：

    09:11:58  Release 发布 → `latest` 别名立刻指向它
    09:13:10  attach-bun-binaries 才把 12 个资产传完

`releases/latest/download/…` 一旦 Release **公开**就开始解析，而资产由 attach 这个
**独立 job** 上传（它必须等 Release 存在才能传）⟹ 中间 **72 秒**必然 404。用户正好
撞在里面。这是**结构性的、每次正式发版都有**，只是通常没人在那 72 秒里安装。

**修法（申晗选的方案①）**：Release 先建成 **draft**，新增 `publish-github-release`
job 在资产附完后才 `--draft=false` 公开。草稿对 `latest` 与匿名下载都不可见 ⟹ 窗口
彻底消失。

**为什么公开这一步单独成 job，而不是塞进 attach**：让「上传」与「公开」分离，**部分
上传就无法公开**。attach 失败时 publish 被 skip、Release 停在草稿 ⟹ `latest` 继续
指向**上一个正式版**，用户装到旧版本（能用）而不是 404（不能用）。这是 fail-closed
方向；npm 两种情况下都已上线（恢复路径见文末）。

**另加一道资产名门禁**：公开前逐个核 install.sh 会请求的 12 个资产
（`botmux-<os>-<arch>[-musl]` + `.sha256`）。缺任何一个就拒绝公开、留作草稿。
这堵的是本仓库既有的一个零检查风险面——资产**名字**与 install.sh 的推导（`uname -s`/
`uname -m` + musl 后缀）是两套独立命名，对不上就是那些平台永久 404，而此前没有任何
检查覆盖它。

**桌面端刻意不进这道门**：macOS 签名挂在人工审批上、可能等 30 天，若它 gate 公开，
Release 会整整 30 天停在草稿。`.dmg`/`.zip` 仍异步附到已公开的 Release，行为不变。

## 验证（真打 GitHub API，不是推理）

草稿机制此前没人在本仓库用过，逐条实测：

    上传到草稿(按 tag 名) → ✅ 可以（attach 与 desktop 都按 tag 寻址，这是前提）
    公开后资产是否保留    → ✅ 保留
    公开后匿名可下载      → ✅ HTTP 200

窗口是否真关闭（**匿名** curl，与用户形态一致；用非 `v*` tag 名以免触发发版）：

    草稿期  download/<tag>/<asset>        → 404  ✅ 两种 URL 形态都关闭
    草稿期  latest/download/<asset>       → 404  ✅
    草稿期  latest/download/<上一版资产>   → 200  ✅ latest 仍服务旧版，用户不受影响
    公开后  download/<tag>/<asset>        → 200  ✅

⚠️ 第三行是关键：证明「关掉新版」不等于「关掉整个 latest」——用户在发版期间安装拿到的
是**上一个可用版本**，而不是任何形式的报错。探针 release 与 tag 均已删除并核实无残留。

## 测试

新增 `test/release-draft-until-assets.test.ts` 7 条，按 **YAML 结构**断言（不是文本
匹配），钉的是不变量「不存在没有二进制的公开 Release」：草稿创建 / 公开在 attach 之后 /
attach 失败保持草稿 / 12 个资产逐个覆盖 / 核查在公开**之前** / 只有一处能公开 /
签名不 gate 公开。

**7 条反向变异全部转红**：删 `draft: true` / 删 publish 的 success 门 / 改 needs /
删资产门 / 资产门漏掉 arm64-musl / 把核查挪到公开之后 / 让签名 gate 公开。

⚠️ 交代一次假阴性：「删资产门」第一版报**未捕获**，实为 `REFUSING to publish` 这个
字符串**在另一个无关 job(防 latest 降级)里已存在**，`.replace(…, 1)` 命中了那一处 ⟹
**变异压根没落地**。按 job 范围重做并核对出现次数(3→2)后确实转红。⭐**判「未捕获」也
需要证据：先确认变异真的改动了目标。**

48 测试全绿（发版 7 + musl gate 13 + 分发 + install.sh）；`bun run build` exit 0。

## 影响面

只动发版 workflow 与其测试，**不动运行时代码**：不涉及任何 CLI 适配器、backend、
会话类型或 IM 层。npm 发布链（`binary-subpackages` → `release`）顺序未变，改的只是
「Release 何时对外可见」。下次打 tag 即生效；本次改动本身不需要重发版。

## 追加：更正「卡草稿如何恢复」的注释（我原来写错了）

第一版注释写「草稿可以事后手工公开**或重跑**」。查完发现**「重跑」这半句不准确**：
`workflow_dispatch` **不会**重跑 `publish-github-release`——它带
`github.event_name == 'push'`，而 dispatch 路径只到 `refresh-desktop-assets`。

实际恢复路径（已核实，写进注释）：
- **7 天内**：重跑那个失败 run 的失败 job（编译产物 `retention-days: 7`，过期就没了）
- **任何时候**：手工两条命令
  `gh release upload vX.Y.Z <binaries+sha256> --clobber` → `gh release edit vX.Y.Z --draft=false`

⭐ 这条值得写进注释而不是只存在我脑子里：**「卡在草稿」的代价取决于恢复路径有多顺**，
而恢复路径不是我想当然的那个。顺带说明「草稿只挡 curl 那条路，npm 仍在服务同样的
二进制」——所以永远不构成完全不可用。
