### PR TITLE
fix(fleet): 编译版 botmux restart 不再漏杀迁移前的 pm2 fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,22 @@ jobs:
               # native loads; no separate PTY step is needed.
               node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64-musl
 
+              # The legacy-pm2 reaper identifies processes and sockets before it
+              # signals or deletes anything, and BusyBox answers those questions
+              # DIFFERENTLY than procps/lsof: `ps -p` is rejected outright, and
+              # `lsof <path>` ignores the path and exits 0. Both differences
+              # silently DISABLED a guard — the reap found nothing to stop, and an
+              # orphaned rpc.sock read as a live God so the "legacy pm2 still
+              # running" warning could never clear.
+              #
+              # `bun run test` cannot see any of this: vitest runs on the glibc
+              # host, where reverting either probe leaves the suite fully green
+              # (MEASURED). This is the only gate that exercises the BusyBox shapes,
+              # which is why it runs here rather than as a unit test. Verified to
+              # have teeth: reverting either probe makes it exit 1 (1 and 8 failed
+              # checks respectively).
+              node scripts/smoke-musl-reaper-probes.mjs dist/core/legacy-pm2-reaper.js
+
               # Hand dist-bin back to the HOST user, exactly as the release leg does.
               #
               # This job needs it less (nothing after this step touches dist-bin), and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -839,6 +839,16 @@ jobs:
               if [ ! -x "$BIN" ]; then echo "musl binary $BIN not built"; exit 1; fi
               node scripts/smoke-bun-binary.mjs "$BIN"
 
+              # The legacy-pm2 reaper's process/socket probes, exercised against
+              # BusyBox. Mirrors the PR gate deliberately: `bun run test` runs on
+              # glibc, where reverting either probe to `ps -p`/`lsof` leaves the
+              # unit suite green while the musl binary we ship stops reaping at all
+              # (and can never clear its own stale warning). Keeping this in BOTH
+              # workflows is the same "no leg gated more weakly" rule as above —
+              # last time the legs diverged, the PR gate was green while the release
+              # failed.
+              node scripts/smoke-musl-reaper-probes.mjs dist/core/legacy-pm2-reaper.js
+
               # Hand dist-bin back to the HOST user before exiting.
               #
               # WHY (this broke v3.18.0-canary.5, after the container work itself had

--- a/scripts/smoke-musl-reaper-probes.mjs
+++ b/scripts/smoke-musl-reaper-probes.mjs
@@ -26,13 +26,37 @@
  * It deliberately tests the SHIPPED module (dist/core/legacy-pm2-reaper.js) rather
  * than reimplementing the probes, so it cannot drift from the real logic.
  */
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, statSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, statSync, rmSync, accessSync, constants as fsConstants } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 const distPath = process.argv[2] ?? 'dist/core/legacy-pm2-reaper.js';
+
+// ENFORCE THE CLI-LESS PATH BEFORE IMPORTING ANYTHING.
+//
+// These checks exercise the fallback the compiled binary uses: no bundled pm2, no
+// pm2 on PATH. If a pm2 IS reachable, `resolvePm2Bin` returns it and the reaper
+// takes the pm2 CLI path instead — a different code path, whose (correct) results
+// look like failures against the expectations below. MEASURED on a dev box with a
+// global pm2: 3 checks "failed" with the reaper behaving perfectly, and `pm2 jlist`
+// even daemonized a real God inside the fixture home.
+//
+// CI is Alpine with no pm2 so it never saw this, but a human running the script
+// locally would — the same "isolation stated but not enforced" trap that made the
+// unit suite fail 5/17 on exactly such a box. So drop every PATH segment that
+// actually contains an executable pm2 (filter by capability, not by directory
+// name), and clear PM2_HOME so nothing can touch a real pm2 home either.
+process.env.PATH = (process.env.PATH ?? '')
+  .split(':')
+  .filter((seg) => {
+    if (!seg) return false;
+    try { accessSync(join(seg, 'pm2'), fsConstants.X_OK); return false; } catch { return true; }
+  })
+  .join(':');
+delete process.env.PM2_HOME;
+
 const { reapLegacyPm2, liveGodAt } = await import(pathToFileURL(distPath).href);
 
 const spin = (ms) => { try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); } catch { /* no SAB */ } };
@@ -49,6 +73,9 @@ console.log('environment:');
 console.log(`  libc            : ${existsSync('/lib/ld-musl-x86_64.so.1') || existsSync('/lib/ld-musl-aarch64.so.1') ? 'musl' : 'glibc'}`);
 console.log(`  ps -p supported : ${psWorks ? 'yes' : 'NO (BusyBox)'}`);
 console.log(`  /proc readable  : ${existsSync('/proc/net/unix')}`);
+// Say which path is under test: a reachable pm2 would silently switch the reaper to
+// its CLI branch and make these expectations meaningless.
+console.log(`  pm2 on PATH     : ${spawnSync('pm2', ['--version'], { encoding: 'utf-8' }).error ? 'no (CLI-less path under test)' : 'YES — expectations below assume none'}`);
 if (psWorks) {
   // Not a failure — the script is also runnable on glibc for comparison — but say so
   // loudly, because the whole point is to exercise the BusyBox shapes.

--- a/scripts/smoke-musl-reaper-probes.mjs
+++ b/scripts/smoke-musl-reaper-probes.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * musl (BusyBox) regression gate for the legacy-pm2 reaper's process/socket probes.
+ *
+ * WHY THIS EXISTS AS ITS OWN SCRIPT, run inside Alpine:
+ *
+ * The reaper identifies processes and sockets before it signals or deletes anything.
+ * Those probes used to shell out to `ps -p` and `lsof <path>`, which behave
+ * DIFFERENTLY under BusyBox — and every difference silently disabled a guard:
+ *
+ *   • `ps -p <pid> -o command=` → BusyBox exits 1 with no output ("unrecognized
+ *     option: p"). Callers read '' as "cannot identify" and fail closed, so the
+ *     pid-reuse guards rejected EVERY process: the CLI-less reap found nothing to
+ *     do and a pre-migration fleet survived `botmux restart` untouched.
+ *   • `lsof -- <path>` → BusyBox IGNORES the path argument, dumps all open files and
+ *     exits 0. The "is this socket held?" test was therefore unconditionally true,
+ *     so an orphaned rpc.sock read as a live God and the "legacy pm2 still running"
+ *     warning could never be cleared.
+ *
+ * Neither failure is visible to `bun run test`: vitest runs on the glibc host where
+ * both tools behave as expected, and the assertions pass. Reverting either probe to
+ * its `ps`/`lsof` form leaves the unit suite fully green (MEASURED) while breaking
+ * the musl binary we ship. This script is the only gate that can see it, which is
+ * why it runs in the same Alpine container that builds the musl binary.
+ *
+ * It deliberately tests the SHIPPED module (dist/core/legacy-pm2-reaper.js) rather
+ * than reimplementing the probes, so it cannot drift from the real logic.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, statSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const distPath = process.argv[2] ?? 'dist/core/legacy-pm2-reaper.js';
+const { reapLegacyPm2, liveGodAt } = await import(pathToFileURL(distPath).href);
+
+const spin = (ms) => { try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); } catch { /* no SAB */ } };
+let failures = 0;
+function check(label, got, want) {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) failures++;
+  console.log(`  ${ok ? 'ok  ' : 'FAIL'}  ${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
+}
+
+// Report the environment so a green run cannot be mistaken for "ran on glibc".
+const psWorks = spawnSync('ps', ['-p', String(process.pid), '-o', 'command='], { encoding: 'utf-8' }).status === 0;
+console.log('environment:');
+console.log(`  libc            : ${existsSync('/lib/ld-musl-x86_64.so.1') || existsSync('/lib/ld-musl-aarch64.so.1') ? 'musl' : 'glibc'}`);
+console.log(`  ps -p supported : ${psWorks ? 'yes' : 'NO (BusyBox)'}`);
+console.log(`  /proc readable  : ${existsSync('/proc/net/unix')}`);
+if (psWorks) {
+  // Not a failure — the script is also runnable on glibc for comparison — but say so
+  // loudly, because the whole point is to exercise the BusyBox shapes.
+  console.log('  NOTE: `ps -p` works here, so this run does not exercise the BusyBox path.');
+}
+
+// ── 1. An orphaned rpc.sock must NOT read as a live God ──────────────────────
+// This is the case BusyBox `lsof` gets wrong. Build a REAL orphan: a child binds
+// the socket and is then SIGKILLed, so the file survives with no owner — exactly
+// what `pm2 kill` leaves behind.
+console.log('orphaned rpc.sock (the shape `pm2 kill` leaves):');
+{
+  const home = mkdtempSync(join(tmpdir(), 'musl-sock-'));
+  const sock = join(home, 'rpc.sock');
+  const child = spawn(process.execPath, ['-e',
+    `const net=require('net');const s=net.createServer(()=>{});`
+    + `s.listen(${JSON.stringify(sock)},()=>process.stdout.write('READY'));setTimeout(()=>{},60000);`],
+    { stdio: ['ignore', 'pipe', 'ignore'] });
+  for (let i = 0; i < 200 && !existsSync(sock); i++) spin(25);
+  check('fixture: socket bound', existsSync(sock), true);
+  check('fixture: held socket reads as a God', liveGodAt(home) !== null, true);
+  child.kill('SIGKILL');
+  spin(500);
+  // The file is still a socket — which is why an existence/type check cannot help.
+  check('fixture: file survives the kill', existsSync(sock), true);
+  check('fixture: still isSocket()', statSync(sock).isSocket(), true);
+  check('orphan reads as NO God', liveGodAt(home), null);
+  rmSync(home, { recursive: true, force: true });
+}
+
+// ── 2. The CLI-less reap must actually stop a legacy fleet ───────────────────
+// This is the case BusyBox `ps` gets wrong: with cmdline unreadable, every pid in
+// pids/ is rejected and the reap silently does nothing.
+console.log('CLI-less reap of a live legacy fleet:');
+{
+  const configDir = mkdtempSync(join(tmpdir(), 'musl-cfg-'));
+  const pkgRoot = mkdtempSync(join(tmpdir(), 'musl-pkg-'));   // no bundled pm2
+  process.env.HOME = mkdtempSync(join(tmpdir(), 'musl-home-'));
+  delete process.env.PM2_HOME;
+  const home = join(configDir, 'pm2');
+  mkdirSync(join(home, 'pids'), { recursive: true });
+  const pidFile = join(home, 'pids', 'botmux-0.pid');
+
+  // A God that respawns its child (bounded): if the reaper stops the daemon before
+  // the God, the God brings it back and the last check below fails.
+  const godScript = `
+    const {spawn}=require('child_process'); const fs=require('fs');
+    let n=0;
+    function launch(){
+      const c=spawn(process.execPath,['-e','setTimeout(()=>process.exit(0),20000)','/opt/app/dist/index-daemon.js'],{stdio:'ignore'});
+      fs.writeFileSync(${JSON.stringify(pidFile)},String(c.pid));
+      c.on('exit',()=>{ if(n++<3) setTimeout(launch,50); });
+    }
+    launch(); setTimeout(()=>process.exit(0),20000);
+  `;
+  const god = spawn(process.execPath, ['-e', godScript, 'PM2 v6.0.14: God Daemon (/fake/pm2)'],
+    { stdio: 'ignore', detached: true });
+  for (let i = 0; i < 200 && !existsSync(pidFile); i++) spin(25);
+  writeFileSync(join(home, 'pm2.pid'), String(god.pid));
+
+  const alive = (pid) => {
+    try { process.kill(pid, 0); } catch { return false; }
+    let raw = '';
+    try { raw = readFileSync(`/proc/${pid}/stat`, 'utf-8'); } catch { return false; }
+    const close = raw.lastIndexOf(')');
+    const st = close < 0 ? '' : (raw.slice(close + 1).trim().split(/\s+/)[0] || '');
+    return st !== '' && st !== 'Z';
+  };
+  check('fixture: god alive', alive(god.pid), true);
+
+  const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+  spin(700);   // let any pending respawn fire
+
+  check('found a legacy God', r.found, true);
+  check('stopped the God', r.killed, true);
+  check('reaped the daemon', r.deleted, ['botmux-0']);
+  check('nothing left unresolved', r.unresolved, false);
+  check('god is down', alive(god.pid), false);
+  check('daemon stays down (no respawn)', alive(parseInt(readFileSync(pidFile, 'utf-8').trim(), 10)), false);
+  check('stale pm2.pid cleaned', existsSync(join(home, 'pm2.pid')), false);
+  // The permanent-false-warning half: a second call must be a clean no-op.
+  const again = reapLegacyPm2(configDir, pkgRoot, () => {});
+  check('second reap finds nothing', again.found, false);
+  check('second reap is not unresolved', again.unresolved, false);
+
+  try { process.kill(-god.pid, 'SIGKILL'); } catch { /* group already gone */ }
+  for (const d of [configDir, pkgRoot, process.env.HOME]) rmSync(d, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed — the reaper's probes do not work on this libc.`);
+  process.exit(1);
+}
+console.log('\nall checks passed');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2453,12 +2453,22 @@ function sleepSyncMs(ms: number): void {
  * double-run alongside the supervisor. This detects that stale God and stops it
  * (delegated to the self-contained `reapLegacyPm2`), so the operator never has
  * to `pm2 kill` by hand. Fail-safe + no-op on fresh installs / when pm2 is
- * absent (always the case for the compiled single binary). The `_op` parameter
- * is retained for call-site compatibility but no longer changes behavior — the
- * reaper is a single idempotent operation.
+ * absent. The `_op` parameter is retained for call-site compatibility but no
+ * longer changes behavior — the reaper is a single idempotent operation.
+ *
+ * A reap that finds a God but cannot confirm it is down is reported on STDERR,
+ * not just through `logger`: CLI mode runs with `logger.setSilent(true)`, so the
+ * reaper's own notes are invisible without DEBUG. That silence is how a
+ * double-run started unnoticed — both fleets live, two processes consuming the
+ * same Feishu events and the same session sqlite. The operator needs to see it.
  */
 function cleanupLegacyPm2(_op?: 'stop' | 'restart'): boolean {
   const r = reapLegacyPm2(CONFIG_DIR, PKG_ROOT, (m) => logger.info(`[legacy-pm2] ${m}`));
+  if (r.unresolved) {
+    console.warn(`⚠️  检测到迁移前的 pm2 守护进程,但未能确认其已停止:${r.note}`);
+    console.warn('   旧 fleet 可能仍在消费同一批飞书事件(消息重复、会话存储争用)。');
+    console.warn('   请手动确认:ps -ef | grep index-daemon   然后停掉旧进程后重试。');
+  }
   return r.found;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,7 @@ import {
 import { hasProtectedSessionMutationOwnership } from './core/session-mutation-guard.js';
 import type { BackendType, PersistentBackendTarget, SessionProbe } from './adapters/backend/types.js';
 import { logger } from './utils/logger.js';
-import { reapLegacyPm2 } from './core/legacy-pm2-reaper.js';
+import { reapLegacyPm2, liveGodAt } from './core/legacy-pm2-reaper.js';
 import { withFileLock, withFileLockSync } from './utils/file-lock.js';
 import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
@@ -2860,14 +2860,18 @@ async function ensureSystemDependencies(): Promise<void> {
  * supervisor view while old pm2-managed daemons keep running. Self-contained:
  * no pm2 CLI call. `botmux start`/`restart` will reap it (reapLegacyPm2).
  *
- * TWO SIGNALS, deliberately different per home — this must agree with
- * reapLegacyPm2's detection or the warning lies in one direction or the other:
+ * TWO SIGNALS, deliberately different per home. Both go through the reaper's own
+ * `liveGodAt` so the warning and the reaper cannot disagree — this used to be a
+ * second, hand-kept copy of that logic, and it drifted: it trusted a bare
+ * `kill(pid, 0)` (true for the ZOMBIE a fresh reap leaves behind) and a bare
+ * `existsSync(rpc.sock)` (which outlives `pm2 kill`), so the warning survived a
+ * SUCCESSFUL migration and no amount of re-running `restart` could clear it.
  *
  *  • The botmux-dedicated home (~/.botmux/pm2) is exclusively ours, so ANY live
- *    God there is a migration leftover. Detect it by pm2.pid OR rpc.sock: a real
- *    God was observed supervising 50 daemons with NO pm2.pid at all, and a
- *    pid-file-only probe stayed silent through exactly the situation this warning
- *    exists for.
+ *    God there is a migration leftover. `liveGodAt` detects it by pm2.pid OR a
+ *    held rpc.sock: a real God was observed supervising 50 daemons with NO
+ *    pm2.pid at all, and a pid-file-only probe stayed silent through exactly the
+ *    situation this warning exists for.
  *
  *  • The shared default (~/.pm2) may be the user's own pm2 running unrelated
  *    apps. A live God there means nothing by itself — MEASURED on this box: the
@@ -2878,23 +2882,9 @@ async function ensureSystemDependencies(): Promise<void> {
  */
 function legacyBotmuxGodAlive(): boolean {
   const dedicated = join(CONFIG_DIR, 'pm2');
-  if (pm2GodAlive(dedicated)) return true;
+  if (liveGodAt(dedicated) !== null) return true;
   const shared = join(homedir(), '.pm2');
-  return pm2GodAlive(shared) && sharedHomeHasBotmuxRows(shared);
-}
-
-/** A God is alive at `home` if its pid file points at a live process, or (when
- *  the file is missing/stale) its RPC socket is still there. */
-function pm2GodAlive(home: string): boolean {
-  const pidFile = join(home, 'pm2.pid');
-  if (existsSync(pidFile)) {
-    let pid = 0;
-    try { pid = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10); } catch { pid = 0; }
-    if (Number.isSafeInteger(pid) && pid > 1) {
-      try { process.kill(pid, 0); return true; } catch { /* stale — try the socket */ }
-    }
-  }
-  return existsSync(join(home, 'rpc.sock'));
+  return liveGodAt(shared) !== null && sharedHomeHasBotmuxRows(shared);
 }
 
 /** Does the SHARED pm2 home actually hold botmux apps? pm2 writes one pid file

--- a/src/core/legacy-pm2-reaper.ts
+++ b/src/core/legacy-pm2-reaper.ts
@@ -18,7 +18,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { isStandaloneBinary } from './self-spawn.js';
@@ -154,8 +154,45 @@ function isAlive(pid: number): boolean {
   return !stat.startsWith('Z');        // 'Z'/'Z+' → zombie → effectively down
 }
 
-interface Pm2God {
+/**
+ * Delete a stopped God's leftover records so detection cannot resurrect it.
+ *
+ * Both files this removes are what `liveGodAt` reads, and a successful reap
+ * invalidates both — but nothing else deletes them on the CLI-less path:
+ *
+ *  • `rpc.sock` outlives even a real `pm2 kill` (MEASURED right after this reaper
+ *    first stopped a live fleet), so an existence-only probe reported the dead God
+ *    as live on every later command.
+ *  • `pm2.pid` is removed by `pm2 kill`, but the signal path has no pm2 to do it.
+ *    MEASURED: the file kept naming the God we had just killed, and since it was a
+ *    ZOMBIE at that moment `kill(pid, 0)` still succeeded — so `status` reported a
+ *    live God and re-running `restart` could never clear the warning.
+ *
+ * Either way the operator is told to run a migration that already completed, with
+ * no way to make the message stop. Called only after the God is confirmed down,
+ * and each file is re-checked here so one that is genuinely still in use (a pid
+ * that is live, a socket someone holds) is never removed.
+ */
+function removeStaleGodRecords(home: string, log: (m: string) => void): void {
+  const sock = join(home, 'rpc.sock');
+  if (existsSync(sock) && !rpcSocketHeld(sock)) {
+    try { rmSync(sock, { force: true }); log(`  removed orphaned rpc.sock at ${home}`); }
+    catch { /* best effort: a leftover record only costs a stale warning */ }
+  }
+  const pidFile = join(home, 'pm2.pid');
+  if (!existsSync(pidFile)) return;
+  let pid = 0;
+  try { pid = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10); } catch { pid = 0; }
+  // A live pid means something owns this file now (a fresh God, or pid reuse) —
+  // leave it alone. Unreadable/garbage counts as stale.
+  if (Number.isSafeInteger(pid) && pid > 1 && isAlive(pid)) return;
+  try { rmSync(pidFile, { force: true }); log(`  removed stale pm2.pid at ${home}`); }
+  catch { /* best effort */ }
+}
+
+export interface Pm2God {
   home: string;
+  /** The God's pid, or 0 when it was found via its RPC socket alone (no pidfile). */
   pid: number;
 }
 
@@ -179,24 +216,63 @@ interface Pm2God {
  * (verified). We return pid 0 for a socket-only God: reaping drives everything
  * through the pm2 CLI (`delete`/`kill`), none of which needs the pid — it is only
  * reported for logging.
+ *
+ * The socket's EXISTENCE is not enough, though: `pm2 kill` removes pm2.pid but
+ * leaves rpc.sock behind — MEASURED right after this reaper first stopped a real
+ * fleet. An existence-only probe then reports the dead God as live on every
+ * subsequent command, so `status` keeps telling the operator to run a migration
+ * that already completed, and re-running it can never clear the warning. So probe
+ * whether a process actually HOLDS the socket.
+ *
+ * The pid check goes through `isAlive`, not a bare `kill(pid, 0)`, for the same
+ * reason: right after a reap the God is a ZOMBIE until its parent reaps it, and
+ * `kill(pid, 0)` succeeds for a zombie — MEASURED, that alone made a
+ * just-killed God read as live and put the stale warning back.
+ *
+ * EXPORTED because `status`/`logs` print an operator-facing "legacy pm2 still
+ * running" warning off the same question. They used to answer it with their own
+ * copy of this logic, which drifted: the warning outlived a successful reap. One
+ * detector means the warning and the reaper cannot disagree.
  */
-function liveGodAt(home: string): Pm2God | null {
+export function liveGodAt(home: string): Pm2God | null {
   const pidFile = join(home, 'pm2.pid');
   if (existsSync(pidFile)) {
     let pid = 0;
     try { pid = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10); } catch { pid = 0; }
-    if (Number.isSafeInteger(pid) && pid > 1) {
-      try {
-        process.kill(pid, 0);
-        return { home, pid };
-      } catch { /* stale pid file — fall through to the socket probe */ }
-    }
+    if (Number.isSafeInteger(pid) && pid > 1 && isAlive(pid)) return { home, pid };
+    // Stale or zombie pid → fall through to the socket probe.
   }
-  // No usable pid file. A live God still owns its RPC socket; if that exists,
-  // treat the God as present and let the pm2 CLI decide (a truly dead God's
-  // `jlist` fails, which the caller already handles).
-  if (existsSync(join(home, 'rpc.sock'))) return { home, pid: 0 };
+  // No usable pid file. A live God still owns its RPC socket — but only a socket
+  // a process is actually HOLDING proves that. See the note above on orphans.
+  if (rpcSocketHeld(join(home, 'rpc.sock'))) return { home, pid: 0 };
   return null;
+}
+
+/**
+ * Is a live pm2 God actually holding this RPC socket?
+ *
+ * Distinguishes a real God from the orphaned `rpc.sock` that `pm2 kill` leaves
+ * behind. `existsSync` cannot: MEASURED on a socket whose listener was SIGKILLed,
+ * the file survives and `statSync().isSocket()` is still true.
+ *
+ * `lsof <path>` answers it — exit 0 with rows when a process holds the socket,
+ * exit 1 with no output for an orphan (verified against both shapes, and against
+ * the real orphan this reaper left on this box). It is the same tool the reaper
+ * already relies on for `ps`, needs no listener-side cooperation, and works in the
+ * compiled binary — unlike spawning our own runtime with `-e`, which the
+ * standalone build does not support (it re-enters the CLI and hangs: MEASURED
+ * ETIMEDOUT).
+ *
+ * Fails CLOSED on an unusable probe: if `lsof` is missing we keep the old
+ * existence-only answer, so a live socket-only God is never missed (the hazard
+ * `f2c9f7b5` fixed). The cost is only a stale warning, never a double-run.
+ */
+function rpcSocketHeld(sockPath: string): boolean {
+  if (!existsSync(sockPath)) return false;
+  const r = spawnSync('lsof', ['--', sockPath], { encoding: 'utf-8', timeout: 5_000 });
+  if (r.error) return true;                       // no lsof → fail closed
+  if (r.status === 0 && (r.stdout || '').trim()) return true;
+  return false;                                   // exit 1 / empty → orphan
 }
 
 /** Parse `pm2 jlist` stdout (may be prefixed by log lines) into the app array. */
@@ -292,6 +368,7 @@ export function reapLegacyPm2(configDir: string, pkgRoot: string, log: (m: strin
       // was SIGTERMed, came back, and the reaper still reported it deleted.
       if (god.pid > 0 && isAlive(god.pid) && looksLikePm2God(god.pid)) {
         result.killed = stopProcs([{ name: 'pm2 God', pid: god.pid }], log).length > 0;
+        if (result.killed) removeStaleGodRecords(home, log);
         if (!result.killed) {
           // A God we could not stop will undo everything below. Don't touch the
           // daemons: leaving the old fleet whole and reporting it is safer than a
@@ -357,7 +434,10 @@ export function reapLegacyPm2(configDir: string, pkgRoot: string, log: (m: strin
     // shared default God — deleting the botmux rows is enough there.
     if (exclusive) {
       const kill = spawnSync(pm2, ['kill'], { env, encoding: 'utf-8', timeout: 15_000 });
-      if (!kill.error && kill.status === 0) { result.killed = true; log(`  pm2 kill (God at ${home})`); }
+      if (!kill.error && kill.status === 0) {
+        result.killed = true; log(`  pm2 kill (God at ${home})`);
+        removeStaleGodRecords(home, log);
+      }
       else { result.unresolved = true; log(`  pm2 kill failed at ${home}: ${kill.error?.message ?? `exit ${kill.status}`}`); }
     } else {
       log(`  left shared pm2 God at ${home} running (only botmux rows removed)`);

--- a/src/core/legacy-pm2-reaper.ts
+++ b/src/core/legacy-pm2-reaper.ts
@@ -15,12 +15,19 @@
  * processes itself. Either way it is FAIL-SAFE — a fresh install with no legacy
  * God no-ops entirely — but it never reports success it cannot back up: see
  * `unresolved` on the result.
+ *
+ * PROCESS AND SOCKET FACTS COME FROM `/proc` ON LINUX, not from `ps`/`lsof`. We
+ * ship a musl (Alpine) binary where both are BusyBox applets with different
+ * semantics — `ps` rejects `-p`, and `lsof` ignores its path argument entirely —
+ * which silently disabled every guard here. `/proc` is a kernel interface that
+ * behaves identically under glibc and musl. macOS keeps the `ps`/`lsof` paths.
+ * See `cmdlineOf`, `isAlive` and `rpcSocketHeld` for the measurements.
  */
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { isStandaloneBinary } from './self-spawn.js';
 
 /** A botmux core process name managed by the old pm2 ecosystem. */
@@ -51,7 +58,27 @@ function resolvePm2Bin(pkgRoot: string): string | null {
   // Probe PATH rather than returning a hopeful 'pm2': knowing now whether the
   // CLI exists lets the caller pick the fallback instead of discovering it
   // through a chain of swallowed ENOENTs.
-  const probe = spawnSync('pm2', ['--version'], { encoding: 'utf-8', timeout: 15_000 });
+  //
+  // PM2_HOME IS MANDATORY HERE, even though this only asks for a version.
+  // `pm2 --version` is NOT read-only: it DAEMONIZES a God (MEASURED — "Spawning
+  // PM2 daemon with pm2_home=… / PM2 Successfully daemonized"). Inheriting the
+  // ambient env would create that God in whatever home the caller happens to
+  // point at: ~/.botmux/pm2 (which this reaper then "finds and kills" — it would
+  // report a legacy fleet on a machine that never had one) or the SHARED ~/.pm2
+  // that the rest of this module takes pains never to touch. Every other pm2
+  // invocation in the repo passes an explicit PM2_HOME; this one must too.
+  // A throwaway dir keeps any God the probe spawns isolated and disposable.
+  const probeHome = join(tmpdir(), `botmux-pm2-probe-${process.pid}`);
+  const probe = spawnSync('pm2', ['--version'], {
+    encoding: 'utf-8', timeout: 15_000,
+    env: { ...process.env, PM2_HOME: probeHome },
+  });
+  // Stop and remove whatever the probe may have started, so it never outlives
+  // this call. Best-effort: a leftover temp dir is harmless either way.
+  if (!probe.error) {
+    spawnSync('pm2', ['kill'], { encoding: 'utf-8', timeout: 15_000, env: { ...process.env, PM2_HOME: probeHome } });
+  }
+  try { rmSync(probeHome, { recursive: true, force: true }); } catch { /* best effort */ }
   if (probe.error || probe.status !== 0) return null;
   return 'pm2';
 }
@@ -109,8 +136,30 @@ function looksLikePm2God(pid: number): boolean {
   return /PM2\b.*God Daemon/i.test(cmdlineOf(pid));
 }
 
-/** `pid`'s command line, or '' when it cannot be read. */
+/**
+ * `pid`'s command line, or '' when it cannot be read.
+ *
+ * LINUX READS `/proc`, NOT `ps`. The daemon runs on Linux and we ship a musl
+ * (Alpine) binary, where `ps` is a BusyBox applet that does not support `-p`:
+ * MEASURED in node:22-alpine, `ps -p <pid> -o command=` exits 1 with no output.
+ * Every caller of this function treats '' as "cannot identify" and fails closed,
+ * so on musl the pid-reuse guards rejected EVERY process — `legacyProcsFromPidsDir`
+ * always came back empty and the whole CLI-less reap silently no-opped. `/proc` is
+ * a kernel interface, identical under glibc and musl (verified in both), and needs
+ * no subprocess at all.
+ *
+ * `/proc/<pid>/cmdline` is NUL-separated; join with spaces so the substring checks
+ * above read like a command line. A ZOMBIE has an EMPTY cmdline (verified) — which
+ * is the correct answer here: we must not signal something we cannot identify.
+ */
 function cmdlineOf(pid: number): string {
+  if (process.platform === 'linux') {
+    try {
+      const raw = readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
+      return raw.replace(/\0+$/, '').split('\0').join(' ').trim();
+    } catch { return ''; }   // no such pid, or unreadable → cannot identify
+  }
+  // macOS/BSD: no /proc. `ps` there is the real thing and supports -p.
   const ps = spawnSync('ps', ['-p', String(pid), '-o', 'command='], { encoding: 'utf-8', timeout: 5_000 });
   if (ps.error || ps.status !== 0) return '';
   return (ps.stdout || '').trim();
@@ -142,9 +191,21 @@ function stopProcs(procs: LegacyProc[], log: (m: string) => void): string[] {
  *  daemons stayed "alive" for the full escalation window. It matters in
  *  production too: when the pm2 God dies before its children, they are zombies
  *  until init adopts and reaps them. A zombie holds no ports, no sqlite handle,
- *  and consumes no Feishu events — for our purposes it is down. */
+ *  and consumes no Feishu events — for our purposes it is down.
+ *
+ *  LINUX READS `/proc` for the same reason as `cmdlineOf`: BusyBox `ps` rejects
+ *  `-p`, so on musl this fell through to the `kill(0)` answer and called every
+ *  zombie alive. MEASURED in node:22-alpine on a real zombie (a `sh` parent that
+ *  never wait()s): `kill(pid,0)` → true, `ps -p -o stat=` → exit 1, while
+ *  `/proc/<pid>/stat` → 'Z'. */
 function isAlive(pid: number): boolean {
   try { process.kill(pid, 0); } catch { return false; }
+  if (process.platform === 'linux') {
+    const state = procState(pid);
+    if (state === null) return true;   // unreadable → keep the kill(0) answer
+    if (state === '') return false;    // no longer in /proc → gone
+    return state !== 'Z';              // zombie → effectively down
+  }
   const ps = spawnSync('ps', ['-p', String(pid), '-o', 'stat='], { encoding: 'utf-8', timeout: 5_000 });
   // If ps cannot tell us, fall back to the kill(0) answer (true) rather than
   // claiming a live process is gone.
@@ -152,6 +213,27 @@ function isAlive(pid: number): boolean {
   const stat = (ps.stdout || '').trim();
   if (!stat) return false;             // no longer in the table → gone
   return !stat.startsWith('Z');        // 'Z'/'Z+' → zombie → effectively down
+}
+
+/**
+ * The process state character from `/proc/<pid>/stat` ('R'/'S'/'Z'/…), '' when the
+ * pid is gone, or null when /proc could not be read at all.
+ *
+ * Parsing note: state is field 3, but field 2 (`comm`) is wrapped in parentheses
+ * and MAY ITSELF CONTAIN spaces and parentheses, so a naive `split(' ')[2]` is
+ * wrong for a process whose name is e.g. `(my app)`. Scan past the LAST ')'.
+ */
+function procState(pid: number): string | null {
+  let raw: string;
+  try { raw = readFileSync(`/proc/${pid}/stat`, 'utf-8'); }
+  catch (err) {
+    // ENOENT means the pid is genuinely gone; anything else (EACCES, /proc not
+    // mounted) is "cannot tell" and must not be read as "gone".
+    return (err as NodeJS.ErrnoException)?.code === 'ENOENT' ? '' : null;
+  }
+  const close = raw.lastIndexOf(')');
+  if (close < 0) return null;                       // unexpected shape → cannot tell
+  return raw.slice(close + 1).trim().split(/\s+/)[0] || null;
 }
 
 /**
@@ -253,26 +335,65 @@ export function liveGodAt(home: string): Pm2God | null {
  *
  * Distinguishes a real God from the orphaned `rpc.sock` that `pm2 kill` leaves
  * behind. `existsSync` cannot: MEASURED on a socket whose listener was SIGKILLed,
- * the file survives and `statSync().isSocket()` is still true.
+ * the file survives and `statSync().isSocket()` is still true (verified under both
+ * glibc and musl).
  *
- * `lsof <path>` answers it — exit 0 with rows when a process holds the socket,
- * exit 1 with no output for an orphan (verified against both shapes, and against
- * the real orphan this reaper left on this box). It is the same tool the reaper
- * already relies on for `ps`, needs no listener-side cooperation, and works in the
- * compiled binary — unlike spawning our own runtime with `-e`, which the
- * standalone build does not support (it re-enters the CLI and hangs: MEASURED
- * ETIMEDOUT).
+ * LINUX READS `/proc/net/unix`, NOT `lsof`. `lsof <path>` looks like the right
+ * tool but is wrong on two counts here:
  *
- * Fails CLOSED on an unusable probe: if `lsof` is missing we keep the old
- * existence-only answer, so a live socket-only God is never missed (the hazard
- * `f2c9f7b5` fixed). The cost is only a stale warning, never a double-run.
+ *  • On Alpine `lsof` EXISTS as a BusyBox applet that IGNORES the path argument
+ *    entirely — it dumps every open file and exits 0. MEASURED in node:22-alpine:
+ *    `lsof -- /tmp/does-not-exist.sock` → exit 0 with a full dump, so the
+ *    `status === 0 && stdout` test was UNCONDITIONALLY true and an orphan read as
+ *    held. That put the stale "legacy pm2 still running" warning right back on
+ *    musl — the very thing this detector exists to prevent.
+ *  • `lsof` is not always installed at all (MEASURED: absent in debian:12-slim),
+ *    which fails closed into the same permanent warning.
+ *
+ * `/proc/net/unix` is the kernel's own list of bound unix sockets: a socket a
+ * process holds appears with its path; an orphaned FILE does not. Verified against
+ * a real SIGKILLed listener (the exact shape `pm2 kill` leaves) under BOTH glibc
+ * and musl. No subprocess, no external tool, ~microseconds instead of ~1.5s.
+ *
+ * Fails CLOSED when `/proc/net/unix` cannot be read: we keep the existence-only
+ * answer, so a live socket-only God is never missed (the hazard `f2c9f7b5` fixed).
+ * The cost is only a stale warning, never a double-run.
  */
 function rpcSocketHeld(sockPath: string): boolean {
   if (!existsSync(sockPath)) return false;
+  if (process.platform === 'linux') {
+    const bound = boundUnixSocketPaths();
+    if (bound === null) return true;              // cannot tell → fail closed
+    return bound.has(sockPath);
+  }
+  // macOS/BSD: no /proc/net/unix. Real lsof there honours the path argument.
   const r = spawnSync('lsof', ['--', sockPath], { encoding: 'utf-8', timeout: 5_000 });
   if (r.error) return true;                       // no lsof → fail closed
   if (r.status === 0 && (r.stdout || '').trim()) return true;
   return false;                                   // exit 1 / empty → orphan
+}
+
+/**
+ * Paths of all bound unix sockets, per `/proc/net/unix`, or null if unreadable.
+ *
+ * Format is a header line plus one row per socket; the PATH is the last field and
+ * is absent for unnamed sockets. A path may contain spaces, so take everything
+ * after the 7th whitespace-separated field rather than the last token. Abstract
+ * sockets start with '@' and are not filesystem paths — they can never match a
+ * `rpc.sock` file, so they are simply kept as-is and never compared equal.
+ */
+function boundUnixSocketPaths(): Set<string> | null {
+  let raw: string;
+  try { raw = readFileSync('/proc/net/unix', 'utf-8'); } catch { return null; }
+  const out = new Set<string>();
+  const lines = raw.split('\n');
+  for (const line of lines) {
+    if (!line || line.startsWith('Num')) continue;   // header
+    // Num RefCount Protocol Flags Type St Inode Path  → 7 fields then the path.
+    const m = /^\s*\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(.+)$/.exec(line);
+    if (m) out.add(m[1].trim());
+  }
+  return out;
 }
 
 /** Parse `pm2 jlist` stdout (may be prefixed by log lines) into the app array. */

--- a/src/core/legacy-pm2-reaper.ts
+++ b/src/core/legacy-pm2-reaper.ts
@@ -9,15 +9,19 @@
  * by hand (the chosen migration UX: auto-detect-and-stop, not just warn).
  *
  * SELF-CONTAINED by design: it does NOT import any of the removed pm2-* guard
- * modules. It shells out to the pm2 CLI directly, and is FAIL-SAFE — if pm2 is
- * not installed (the normal case for a fresh install, and always for the
- * compiled single binary), every step no-ops and the fleet comes up clean.
+ * modules. When a pm2 CLI is reachable it drives pm2 directly; when it is NOT
+ * (the compiled single binary bundles no pm2, and a source install may have none
+ * on PATH) it falls back to the God's own `pids/` records and signals those
+ * processes itself. Either way it is FAIL-SAFE — a fresh install with no legacy
+ * God no-ops entirely — but it never reports success it cannot back up: see
+ * `unresolved` on the result.
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { isStandaloneBinary } from './self-spawn.js';
 
 /** A botmux core process name managed by the old pm2 ecosystem. */
 function isBotmuxPm2Name(name: unknown): boolean {
@@ -25,15 +29,129 @@ function isBotmuxPm2Name(name: unknown): boolean {
     && (name === 'botmux' || (name.startsWith('botmux-') && !name.startsWith('botmux-plugin-')));
 }
 
-/** Resolve the pm2 CLI path, or null when pm2 isn't installed here. Prefers the
- *  package-bundled pm2 (if this build still has it on disk), else PATH `pm2`. */
+/**
+ * Resolve the pm2 CLI path, or null when pm2 isn't usable here.
+ *
+ * COMPILED BINARY: `pkgRoot` is derived from `__dirname`, which for the
+ * standalone build lives in the virtual `/$bunfs/` — so the bundled probe below
+ * resolves to a path that does not exist on disk (MEASURED with a probe binary:
+ * PKG_ROOT came out as `/private`). That is the documented `__dirname` hazard in
+ * CLAUDE.md. Returning a bare `'pm2'` there was actively harmful: it looks like
+ * a resolved CLI, every subsequent spawn fails ENOENT, the failures are
+ * swallowed as "best effort", and the legacy God survives a `botmux restart` —
+ * both fleets then answer the same Feishu events. So report null and let the
+ * caller use the CLI-less fallback.
+ */
 function resolvePm2Bin(pkgRoot: string): string | null {
   const bundled = join(pkgRoot, 'node_modules', 'pm2', 'bin', 'pm2');
   if (existsSync(bundled)) return bundled;
-  // Fall back to a PATH lookup; spawnSync with the bare name resolves via PATH.
-  // We can't easily test-probe without running it, so return 'pm2' and let the
-  // caller's spawnSync fail-safe (ENOENT → treated as "no pm2") handle absence.
+  // No bundled pm2. A PATH lookup is only meaningful for a source/npm install;
+  // the compiled binary ships no pm2 and must not pretend otherwise.
+  if (isStandaloneBinary()) return null;
+  // Probe PATH rather than returning a hopeful 'pm2': knowing now whether the
+  // CLI exists lets the caller pick the fallback instead of discovering it
+  // through a chain of swallowed ENOENTs.
+  const probe = spawnSync('pm2', ['--version'], { encoding: 'utf-8', timeout: 15_000 });
+  if (probe.error || probe.status !== 0) return null;
   return 'pm2';
+}
+
+/** A pm2-era botmux daemon process, recovered from PM2_HOME/pids/. */
+interface LegacyProc {
+  /** pm2 app name, e.g. `botmux-0` (the pid file's basename). */
+  name: string;
+  pid: number;
+}
+
+/**
+ * Recover the legacy fleet's processes from `PM2_HOME/pids/` — the CLI-less path.
+ *
+ * pm2 writes one `pids/<name>.pid` per app, and those files are the same records
+ * `pm2` itself would report. Reading them directly is what makes reaping possible
+ * with no pm2 binary anywhere (the compiled-binary case).
+ *
+ * Each pid is verified against its own cmdline before being returned. A pid file
+ * can outlive its process and the number may have been recycled into something
+ * unrelated, so signalling on the file's word alone would eventually kill a
+ * bystander. Only processes that still look like a pm2-era botmux daemon
+ * (`dist/index-daemon.js` / `index-dashboard.js`) are eligible.
+ */
+function legacyProcsFromPidsDir(home: string): LegacyProc[] {
+  let entries: string[];
+  try { entries = readdirSync(join(home, 'pids')); } catch { return []; }
+  const out: LegacyProc[] = [];
+  for (const file of entries) {
+    if (!file.endsWith('.pid')) continue;
+    const name = file.slice(0, -'.pid'.length);
+    if (!isBotmuxPm2Name(name.replace(/-\d+$/, '')) && !isBotmuxPm2Name(name)) continue;
+    let pid = 0;
+    try { pid = parseInt(readFileSync(join(home, 'pids', file), 'utf-8').trim(), 10); } catch { continue; }
+    if (!Number.isSafeInteger(pid) || pid <= 1) continue;
+    if (!isAlive(pid)) continue;                      // already gone (or a zombie)
+    if (!looksLikeLegacyBotmuxDaemon(pid)) continue;  // pid reuse guard
+    out.push({ name, pid });
+  }
+  return out;
+}
+
+/** Does `pid`'s command line still look like a pm2-era botmux daemon? Guards
+ *  against pid reuse before we signal anything. Unreadable cmdline → false
+ *  (fail closed: never signal what we cannot identify). */
+function looksLikeLegacyBotmuxDaemon(pid: number): boolean {
+  const cmd = cmdlineOf(pid);
+  return cmd.includes('index-daemon') || cmd.includes('index-dashboard');
+}
+
+/** Is `pid` actually a pm2 God daemon? Same pid-reuse guard as above: the pid
+ *  comes from a file that may be stale, and this one gets SIGKILL. pm2 titles
+ *  its God process "PM2 ... God Daemon". */
+function looksLikePm2God(pid: number): boolean {
+  return /PM2\b.*God Daemon/i.test(cmdlineOf(pid));
+}
+
+/** `pid`'s command line, or '' when it cannot be read. */
+function cmdlineOf(pid: number): string {
+  const ps = spawnSync('ps', ['-p', String(pid), '-o', 'command='], { encoding: 'utf-8', timeout: 5_000 });
+  if (ps.error || ps.status !== 0) return '';
+  return (ps.stdout || '').trim();
+}
+
+/** Stop `procs` with SIGTERM, then SIGKILL whatever is still up. Returns the
+ *  names actually confirmed down, so the caller never over-reports success. */
+function stopProcs(procs: LegacyProc[], log: (m: string) => void): string[] {
+  for (const { name, pid } of procs) {
+    try { process.kill(pid, 'SIGTERM'); log(`  SIGTERM ${name} (pid ${pid})`); } catch { /* already gone */ }
+  }
+  // Give them a moment to exit on their own before escalating.
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline && procs.some(({ pid }) => isAlive(pid))) {
+    try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100); } catch { break; }
+  }
+  for (const { name, pid } of procs) {
+    if (!isAlive(pid)) continue;
+    try { process.kill(pid, 'SIGKILL'); log(`  SIGKILL ${name} (pid ${pid})`); } catch { /* raced */ }
+  }
+  return procs.filter(({ pid }) => !isAlive(pid)).map(({ name }) => name);
+}
+
+/** Is `pid` a live process we should still act on?
+ *
+ *  `kill(pid, 0)` alone is NOT enough: it succeeds for a ZOMBIE (exited, but its
+ *  parent has not reaped it), so a process we just killed can still look alive
+ *  and make the reaper report failure — MEASURED in this suite, where the killed
+ *  daemons stayed "alive" for the full escalation window. It matters in
+ *  production too: when the pm2 God dies before its children, they are zombies
+ *  until init adopts and reaps them. A zombie holds no ports, no sqlite handle,
+ *  and consumes no Feishu events — for our purposes it is down. */
+function isAlive(pid: number): boolean {
+  try { process.kill(pid, 0); } catch { return false; }
+  const ps = spawnSync('ps', ['-p', String(pid), '-o', 'stat='], { encoding: 'utf-8', timeout: 5_000 });
+  // If ps cannot tell us, fall back to the kill(0) answer (true) rather than
+  // claiming a live process is gone.
+  if (ps.error || ps.status !== 0) return true;
+  const stat = (ps.stdout || '').trim();
+  if (!stat) return false;             // no longer in the table → gone
+  return !stat.startsWith('Z');        // 'Z'/'Z+' → zombie → effectively down
 }
 
 interface Pm2God {
@@ -103,6 +221,17 @@ export interface LegacyPm2ReapResult {
   deleted: string[];
   /** True if the God itself was killed. */
   killed: boolean;
+  /**
+   * True when a legacy fleet may STILL be running after this call — i.e. we found
+   * a God in the botmux-exclusive home and could not confirm its daemons are
+   * down. Distinct from `!killed`, which is also the normal, correct outcome for
+   * the SHARED ~/.pm2 home (whose God is deliberately left alive).
+   *
+   * Callers use this to warn the operator before starting a second fleet: a
+   * silent failure here means two fleets consuming the same Feishu events and
+   * the same session sqlite.
+   */
+  unresolved: boolean;
   /** Human-readable note for logging (never throws). */
   note: string;
 }
@@ -118,7 +247,7 @@ export interface LegacyPm2ReapResult {
  * @param log        optional logger for progress lines.
  */
 export function reapLegacyPm2(configDir: string, pkgRoot: string, log: (m: string) => void = () => {}): LegacyPm2ReapResult {
-  const result: LegacyPm2ReapResult = { found: false, deleted: [], killed: false, note: '' };
+  const result: LegacyPm2ReapResult = { found: false, deleted: [], killed: false, unresolved: false, note: '' };
   // The botmux-dedicated PM2_HOME is exclusively ours → safe to `pm2 kill` its
   // God. The shared default (~/.pm2) may host the user's OTHER apps, so there we
   // only `pm2 delete` botmux rows and NEVER `pm2 kill` (that would take down
@@ -128,11 +257,69 @@ export function reapLegacyPm2(configDir: string, pkgRoot: string, log: (m: strin
     { home: join(homedir(), '.pm2'), exclusive: false },
   ];
   const pm2 = resolvePm2Bin(pkgRoot);
-  if (!pm2) { result.note = 'pm2 not installed; nothing to reap'; return result; }
 
   for (const { home, exclusive } of homes) {
     const god = liveGodAt(home);
     if (!god) continue;
+
+    // ── No usable pm2 CLI: reap from the God's own pid files ─────────────────
+    // This is the compiled-binary path (no bundled pm2, none on PATH). Skipped
+    // for the SHARED home: signalling processes there without pm2's roster risks
+    // touching the user's unrelated apps, and we must never kill that God.
+    if (!pm2) {
+      if (!exclusive) {
+        log(`no pm2 CLI; leaving shared pm2 God at ${home} alone`);
+        continue;
+      }
+      result.found = true;
+      const procs = legacyProcsFromPidsDir(home);
+      if (procs.length === 0) {
+        // A live God we cannot prove anything about. Say so plainly rather than
+        // reporting success — the caller must be able to tell the old fleet may
+        // still be consuming the same Feishu events.
+        result.unresolved = true;
+        result.note = `no pm2 CLI available and no reapable botmux pids under ${home}; `
+          + 'legacy pm2 God may still be running';
+        log(result.note);
+        continue;
+      }
+      log(`legacy pm2 God detected (PM2_HOME=${home}, pid ${god.pid > 0 ? god.pid : 'unknown'}, `
+        + `${procs.length} botmux proc(s) from pids/); no pm2 CLI — reaping by signal`);
+
+      // ORDER MATTERS: stop the God FIRST. Restarting dead children is exactly
+      // what a pm2 God does, so killing the daemons while it is still alive just
+      // makes it respawn them — MEASURED with a compiled probe binary: the daemon
+      // was SIGTERMed, came back, and the reaper still reported it deleted.
+      if (god.pid > 0 && isAlive(god.pid) && looksLikePm2God(god.pid)) {
+        result.killed = stopProcs([{ name: 'pm2 God', pid: god.pid }], log).length > 0;
+        if (!result.killed) {
+          // A God we could not stop will undo everything below. Don't touch the
+          // daemons: leaving the old fleet whole and reporting it is safer than a
+          // half-killed fleet that keeps flapping.
+          result.unresolved = true;
+          result.note = `could not stop legacy pm2 God (pid ${god.pid}) at ${home}; `
+            + 'left its daemons alone to avoid a respawn loop';
+          log(result.note);
+          continue;
+        }
+      } else if (god.pid <= 0) {
+        // Socket-only God: no pid to signal and no CLI to ask it to stop. It may
+        // respawn whatever we kill, so treat the outcome as unproven.
+        result.unresolved = true;
+        log('  God pid unknown (no pm2.pid) and no pm2 CLI — cannot stop the God itself');
+      }
+
+      // God is down (or unidentifiable but pidless) → now the daemons stay down.
+      result.deleted.push(...stopProcs(procs, log));
+      const stillUp = procs.filter(({ pid }) => isAlive(pid));
+      if (stillUp.length > 0) {
+        result.unresolved = true;
+        result.note = `${stillUp.length} legacy botmux proc(s) survived SIGKILL at ${home}`;
+        log(result.note);
+      }
+      continue;
+    }
+
     const env = { ...process.env, PM2_HOME: home };
 
     // List botmux rows this God manages.
@@ -142,6 +329,7 @@ export function reapLegacyPm2(configDir: string, pkgRoot: string, log: (m: strin
       // unreachable jlist at the shared home isn't necessarily a botmux concern.
       if (exclusive) {
         result.found = true;
+        result.unresolved = true;
         result.note = `pm2 jlist failed at ${home}: ${jlist.error?.message ?? `exit ${jlist.status}`}`;
         log(result.note);
       }
@@ -170,7 +358,7 @@ export function reapLegacyPm2(configDir: string, pkgRoot: string, log: (m: strin
     if (exclusive) {
       const kill = spawnSync(pm2, ['kill'], { env, encoding: 'utf-8', timeout: 15_000 });
       if (!kill.error && kill.status === 0) { result.killed = true; log(`  pm2 kill (God at ${home})`); }
-      else log(`  pm2 kill failed at ${home}: ${kill.error?.message ?? `exit ${kill.status}`}`);
+      else { result.unresolved = true; log(`  pm2 kill failed at ${home}: ${kill.error?.message ?? `exit ${kill.status}`}`); }
     } else {
       log(`  left shared pm2 God at ${home} running (only botmux rows removed)`);
     }

--- a/test/legacy-pm2-reaper.test.ts
+++ b/test/legacy-pm2-reaper.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, readFileSync, existsSync, statSync, accessSync, constants as fsConstants } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, sep } from 'node:path';
+import { join } from 'node:path';
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createServer, type Server } from 'node:net';
 import { reapLegacyPm2, liveGodAt } from '../src/core/legacy-pm2-reaper.js';
@@ -25,21 +25,41 @@ let savedHome: string | undefined;
 // dev-dependency pm2 shim lives — so a bare `pm2` ALWAYS resolves under the test
 // runner. That silently hid the production bug this suite now covers: the compiled
 // binary has no bundled pm2 and no pm2 on PATH, and resolvePm2Bin's PATH fallback
-// was never exercisable in a test. Strip node_modules/.bin so "no pm2 CLI" is
-// actually reachable; tests that want a working pm2 plant one under pkgRoot.
+// was never exercisable in a test.
+//
+// FILTER BY CAPABILITY, NOT BY NAME. Stripping segments literally named
+// `node_modules/.bin` only makes pm2 unreachable when that is its ONLY source —
+// true on CI, FALSE on any box with a global pm2. MEASURED on a dev box with pm2
+// installed under a version manager: these tests failed 5/17 there while CI was
+// green and the author saw 17/17 — three honest observations of the same suite.
+// So drop every PATH segment that actually CONTAINS an executable pm2; tests that
+// want a working pm2 plant one under pkgRoot instead.
 let savedPath: string | undefined;
+let savedPm2Home: string | undefined;
+function pathWithoutPm2(rawPath: string): string {
+  return rawPath
+    .split(':')
+    .filter((seg) => {
+      if (!seg) return false;
+      try { accessSync(join(seg, 'pm2'), fsConstants.X_OK); return false; } catch { return true; }
+    })
+    .join(':');
+}
 beforeEach(() => {
   savedHome = process.env.HOME;
   process.env.HOME = tmp();
   savedPath = process.env.PATH;
-  process.env.PATH = (savedPath ?? '')
-    .split(':')
-    .filter((p) => !p.endsWith(`${sep}node_modules${sep}.bin`))
-    .join(':');
+  process.env.PATH = pathWithoutPm2(savedPath ?? '');
+  // A pm2 the probe could reach would daemonize a God in whatever PM2_HOME the
+  // ambient env names — including this box's real ~/.botmux/pm2. Belt and braces
+  // alongside the PATH filter above.
+  savedPm2Home = process.env.PM2_HOME;
+  delete process.env.PM2_HOME;
 });
 afterEach(() => {
   if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
   if (savedPath === undefined) delete process.env.PATH; else process.env.PATH = savedPath;
+  if (savedPm2Home === undefined) delete process.env.PM2_HOME; else process.env.PM2_HOME = savedPm2Home;
   // Kill whole process groups first: a group leader's grandchildren are not in
   // `spawned` and would otherwise survive as orphans.
   for (const pid of groupLeaders.splice(0)) {
@@ -101,6 +121,34 @@ function listenOnUnixSocket(p: string): void {
   const srv = createServer(() => { /* accept and ignore */ });
   srv.listen(p);
   servers.push(srv);
+}
+
+/**
+ * A REAL orphaned socket: a child process binds `home/rpc.sock`, then is SIGKILLed
+ * so the socket FILE survives with no owner. This is exactly what `pm2 kill` leaves
+ * behind, and it is a stronger fixture than a plain regular file — `statSync().
+ * isSocket()` is still true here (MEASURED under both glibc and musl), so a probe
+ * that merely checks "is this a socket file" cannot tell it from a live God.
+ * Returns once the file exists and its creator is gone.
+ */
+function realOrphanGodSocket(home: string): void {
+  mkdirSync(home, { recursive: true });
+  const sock = join(home, 'rpc.sock');
+  const child = spawn(process.execPath, ['-e',
+    `const net=require('net');const s=net.createServer(()=>{});`
+    + `s.listen(${JSON.stringify(sock)},()=>process.stdout.write('READY'));setTimeout(()=>{},60_000);`],
+    { stdio: ['ignore', 'pipe', 'ignore'] });
+  spawned.push(child);
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline && !existsSync(sock)) spinMs(25);
+  child.kill('SIGKILL');
+  // Wait for the owner to actually be gone, else we would be testing a live socket.
+  const gone = Date.now() + 5_000;
+  while (Date.now() < gone) {
+    try { process.kill(child.pid!, 0); } catch { break; }
+    spinMs(25);
+  }
+  spinMs(150);
 }
 
 // ── Fixtures for the CLI-less fallback ──────────────────────────────────────
@@ -235,6 +283,72 @@ describe('reapLegacyPm2', () => {
     expect(r.note).toContain('no live legacy pm2 God');
   });
 
+  // ── The probe must judge OWNERSHIP, not socket-ness ─────────────────────────
+  // The fixture above uses a plain file. This one uses a REAL socket whose listener
+  // was SIGKILLed — production's actual shape. It is the case that broke on musl:
+  // Alpine's `lsof` is a BusyBox applet that IGNORES its path argument and exits 0
+  // with a full dump, so the old `status===0 && stdout` test was unconditionally
+  // true and this orphan read as a live God. Reading /proc/net/unix (the kernel's
+  // own list of BOUND sockets) answers it correctly on both libcs.
+  it('treats a REAL orphaned socket (listener SIGKILLed) as no God', () => {
+    const configDir = tmp();
+    const home = join(configDir, 'pm2');
+    realOrphanGodSocket(home);
+
+    // The file is still a socket — this is what defeats an existence/type check.
+    expect(existsSync(join(home, 'rpc.sock'))).toBe(true);
+    expect(statSync(join(home, 'rpc.sock')).isSocket()).toBe(true);
+
+    expect(liveGodAt(home)).toBeNull();
+    const r = reapLegacyPm2(configDir, tmp(), () => {});
+    expect(r.found).toBe(false);
+    expect(r.unresolved).toBe(false);
+  });
+
+  it('still sees a God whose rpc.sock IS held by a live listener', () => {
+    // The positive half: the probe must not answer "no God" for everything. Without
+    // this, a probe that always said "orphan" would pass the test above and silently
+    // reintroduce the double-run this module exists to prevent.
+    const configDir = tmp();
+    const home = join(configDir, 'pm2');
+    liveGodSocketOnly(home);      // real listener bound to rpc.sock
+
+    const god = liveGodAt(home);
+    expect(god).not.toBeNull();
+    expect(god?.pid).toBe(0);     // socket-only → pid unknown
+  });
+
+  it('does not let the pm2 PATH probe touch the ambient PM2_HOME', () => {
+    // `pm2 --version` is NOT read-only: it DAEMONIZES a God (MEASURED: "Spawning
+    // PM2 daemon with pm2_home=… / Successfully daemonized"). With the ambient env
+    // inherited, the probe created one in the caller's PM2_HOME — including a real
+    // ~/.botmux/pm2, which the reaper then "found and killed", reporting a legacy
+    // fleet on a machine that never had one. Plant a pm2 on PATH that RECORDS the
+    // PM2_HOME it was handed, and require it to be a throwaway.
+    const configDir = tmp();
+    const pkgRoot = tmp();          // no bundled pm2 → the PATH probe runs
+    const binDir = tmp();
+    const seen = join(binDir, 'seen-home.log');
+    writeFileSync(join(binDir, 'pm2'), [
+      '#!/usr/bin/env node',
+      `require('fs').appendFileSync(${JSON.stringify(seen)}, (process.env.PM2_HOME ?? '<unset>')+'\\n');`,
+      `process.exit(0);`,
+    ].join('\n'), { mode: 0o755 });
+    chmodSync(join(binDir, 'pm2'), 0o755);
+    process.env.PATH = `${binDir}:${process.env.PATH ?? ''}`;
+
+    const ambient = join(configDir, 'pm2');   // stands in for ~/.botmux/pm2
+    process.env.PM2_HOME = ambient;
+    reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    const homes = readFileSync(seen, 'utf-8').trim().split('\n').filter(Boolean);
+    expect(homes.length).toBeGreaterThan(0);           // the probe really ran
+    for (const h of homes) {
+      expect(h).not.toBe(ambient);                     // never the caller's home
+      expect(h).not.toBe('<unset>');                   // and never inherited-empty
+    }
+  });
+
   it('clears the God records so the warning cannot come back', () => {
     // Leaving the dead God's records on disk would re-trigger detection on the
     // next command. Reaping must clear the evidence it just invalidated — BOTH
@@ -363,6 +477,31 @@ describe('reapLegacyPm2', () => {
     expect(r.found).toBe(true);
     expect(r.deleted).toEqual([]);
     expect(r.note).toContain('jlist failed');
+  });
+
+  // ── CLI path: row deletion must precede `pm2 kill` ──────────────────────────
+  // The CLI-less path has an explicit ordering test (the God must stop first there,
+  // or it respawns what we reap). The CLI path needs the OPPOSITE order and had no
+  // assertion at all: hoisting `pm2 kill` above the delete loop left the suite
+  // fully green. `pm2 kill` tears the God down, so `pm2 delete <row>` afterwards
+  // has nothing to talk to — the rows survive in the dump and a later pm2 would
+  // resurrect them. Pin the sequence, not just the set of calls.
+  it('deletes botmux rows BEFORE `pm2 kill` (killing first strands the rows)', () => {
+    const configDir = tmp();
+    const pkgRoot = tmp();
+    const logFile = fakePm2(pkgRoot, { jlist: JSON.stringify([{ name: 'botmux' }, { name: 'botmux-0' }]) });
+    liveGodPidfile(join(configDir, 'pm2'));
+
+    const r = reapLegacyPm2(configDir, pkgRoot);
+    expect(r.deleted.sort()).toEqual(['botmux', 'botmux-0']);
+
+    // One line per invocation, in call order.
+    const calls = readFileSync(logFile, 'utf-8').trim().split('\n');
+    const killAt = calls.findIndex((c) => c.trim() === 'kill');
+    const lastDeleteAt = calls.reduce((acc, c, i) => (c.startsWith('delete ') ? i : acc), -1);
+    expect(killAt).toBeGreaterThan(-1);        // the God is killed
+    expect(lastDeleteAt).toBeGreaterThan(-1);  // rows are deleted
+    expect(lastDeleteAt).toBeLessThan(killAt); // ...and every delete lands FIRST
   });
 
   it('never `pm2 kill`s the SHARED ~/.pm2 God — only deletes botmux rows there', () => {

--- a/test/legacy-pm2-reaper.test.ts
+++ b/test/legacy-pm2-reaper.test.ts
@@ -3,7 +3,8 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, readFileSync,
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { reapLegacyPm2 } from '../src/core/legacy-pm2-reaper.js';
+import { createServer, type Server } from 'node:net';
+import { reapLegacyPm2, liveGodAt } from '../src/core/legacy-pm2-reaper.js';
 
 const dirs: string[] = [];
 function tmp(): string { const d = mkdtempSync(join(tmpdir(), 'legacy-pm2-')); dirs.push(d); return d; }
@@ -45,6 +46,7 @@ afterEach(() => {
     try { process.kill(-pid, 'SIGKILL'); } catch { /* group already gone */ }
   }
   for (const p of spawned.splice(0)) { try { p.kill('SIGKILL'); } catch { /* already gone */ } }
+  for (const s of servers.splice(0)) { try { s.close(); } catch { /* already closed */ } }
   for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
 });
 
@@ -74,14 +76,31 @@ function liveGodPidfile(home: string): void {
   writeFileSync(join(home, 'pm2.pid'), String(process.pid));
 }
 
-/** A live God that has NO pm2.pid — only its RPC socket. This is the shape
- *  MEASURED on the dev box: a God supervising 50 botmux daemons for ~15 hours
- *  with no pidfile in its PM2_HOME. A plain file stands in for the socket; the
- *  reaper only tests existence, and creating a real unix socket would need a
- *  listener. */
+/** A live God that has NO pm2.pid — only its RPC socket, WITH a real listener.
+ *  This is the shape MEASURED on the dev box: a God supervising 50 botmux daemons
+ *  for ~15 hours with no pidfile in its PM2_HOME. The listener matters: detection
+ *  now probes the socket rather than trusting its mere existence. */
 function liveGodSocketOnly(home: string): void {
   mkdirSync(home, { recursive: true });
-  writeFileSync(join(home, 'rpc.sock'), '');
+  listenOnUnixSocket(join(home, 'rpc.sock'));
+}
+
+/** An ORPHANED rpc.sock: the file is there but nothing listens.
+ *
+ *  `pm2 kill` removes pm2.pid but leaves this socket behind — MEASURED after a
+ *  successful reap on this box. An existence-only probe then reports the dead God
+ *  as live forever, so `status` keeps telling the operator to run a migration that
+ *  already completed. */
+function orphanGodSocket(home: string): void {
+  mkdirSync(home, { recursive: true });
+  writeFileSync(join(home, 'rpc.sock'), ''); // plain file: connect() must fail
+}
+
+/** Bind a real unix socket server at `p` and keep it for teardown. */
+function listenOnUnixSocket(p: string): void {
+  const srv = createServer(() => { /* accept and ignore */ });
+  srv.listen(p);
+  servers.push(srv);
 }
 
 // ── Fixtures for the CLI-less fallback ──────────────────────────────────────
@@ -90,6 +109,8 @@ const spawned: ChildProcess[] = [];
  *  group so a fixture that forks grandchildren cannot leave orphans behind —
  *  an unbounded respawning fixture once exhausted this machine's processes. */
 const groupLeaders: number[] = [];
+/** Unix-socket servers standing in for a live God's RPC channel. */
+const servers: Server[] = [];
 
 /** Spawn `n` throwaway processes whose cmdline looks like a pm2-era botmux
  *  daemon (`.../dist/index-daemon.js`), so the reaper's cmdline check accepts
@@ -197,7 +218,79 @@ describe('reapLegacyPm2', () => {
   // real God was found running 50 botmux daemons with no such file — so the
   // reaper silently no-opped and a `botmux restart` would have left both fleets
   // live, two processes answering the same Feishu events.
-  it('detects a live God that has NO pm2.pid (socket-only), and reaps it', () => {
+  it('treats an ORPHANED rpc.sock as no God (nothing listens on it)', () => {
+    // MEASURED after this fix reaped the real fleet: `pm2 kill` removed pm2.pid but
+    // left rpc.sock behind with no listener. An existence-only probe then reported
+    // the dead God as live on EVERY subsequent command, so `status` kept telling
+    // the operator to run a migration that had already completed — and running it
+    // again could never clear the warning.
+    const configDir = tmp();
+    const pkgRoot = tmp();
+    orphanGodSocket(join(configDir, 'pm2'));
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    expect(r.found).toBe(false);
+    expect(r.unresolved).toBe(false);
+    expect(r.note).toContain('no live legacy pm2 God');
+  });
+
+  it('clears the God records so the warning cannot come back', () => {
+    // Leaving the dead God's records on disk would re-trigger detection on the
+    // next command. Reaping must clear the evidence it just invalidated — BOTH
+    // files, since detection accepts either one:
+    //
+    //  • rpc.sock, which outlives even a real `pm2 kill`.
+    //  • pm2.pid, which the CLI-less path has no pm2 to remove. MEASURED: it kept
+    //    naming the God we had just killed, and a zombie answers kill(pid,0), so
+    //    the second call still reported found — the warning came right back.
+    const configDir = tmp();
+    const pkgRoot = tmp();
+    const home = join(configDir, 'pm2');
+    mkdirSync(join(home, 'pids'), { recursive: true });
+    const god = spawnTagged(1, 'PM2 v6.0.14: God Daemon (/fake)')[0];
+    writeFileSync(join(home, 'pm2.pid'), String(god));
+    orphanGodSocket(home);                 // socket that will outlive the God
+    const daemon = spawnSleepers(1)[0];
+    writePm2AppPid(home, 'botmux-0', daemon);
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    expect(r.killed).toBe(true);
+    expect(existsSync(join(home, 'rpc.sock'))).toBe(false); // cleaned up
+    expect(existsSync(join(home, 'pm2.pid'))).toBe(false);  // ...and this one too
+    // And a follow-up call must now find nothing at all — no `found`, and
+    // crucially no `unresolved`, which is what drives the operator warning.
+    const again = reapLegacyPm2(configDir, pkgRoot, () => {});
+    expect(again.found).toBe(false);
+    expect(again.unresolved).toBe(false);
+    expect(again.note).toContain('no live legacy pm2 God');
+  });
+
+  it('does NOT delete a pm2.pid that still names a LIVE process', () => {
+    // The cleanup above must not degenerate into "delete pm2.pid after any kill".
+    // If the number in the file is live — a God that has started since, or a
+    // recycled pid — removing the record would blind the next detection to a real
+    // God, which is the double-run this whole module exists to prevent.
+    //
+    // Reachable on the pm2-CLI path: real `pm2 kill` removes pm2.pid itself, so
+    // cleanup only ever sees a leftover, and here the leftover names this very
+    // (live) test process. The socket, having no listener, must still go.
+    const configDir = tmp();
+    const pkgRoot = tmp();
+    const home = join(configDir, 'pm2');
+    fakePm2(pkgRoot, { jlist: JSON.stringify([{ name: 'botmux-0' }]) });
+    liveGodPidfile(home);      // pm2.pid → our own pid, which stays alive
+    orphanGodSocket(home);     // ...but nothing holds the socket
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    expect(r.killed).toBe(true);
+    expect(existsSync(join(home, 'rpc.sock'))).toBe(false); // orphan → removed
+    expect(existsSync(join(home, 'pm2.pid'))).toBe(true);   // live pid → kept
+  });
+
+  it('still detects a socket-only God when something IS listening', () => {
     const configDir = tmp();
     const pkgRoot = tmp();
     const jlist = JSON.stringify([{ name: 'botmux-claude' }, { name: 'unrelated' }]);
@@ -492,6 +585,29 @@ describe('reapLegacyPm2', () => {
     // Whatever child the pidfile now names must be down and stay down.
     const lastChild = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
     expect(alive(lastChild)).toBe(false);
+  });
+
+  // ── liveGodAt, the detector `status`/`logs` share ───────────────────────────
+  // The warning those commands print goes through this exact function. It is
+  // tested directly because the reap path CANNOT expose the bug below: reaping
+  // deletes the pidfile, so the zombie is never read back. Reverting this to a
+  // bare `kill(pid, 0)` left the whole reap suite green — measured — while
+  // `botmux status` would still have reported a God that no longer exists.
+  it('does not call a ZOMBIE pid a live God (kill(pid,0) lies about zombies)', () => {
+    const home = tmp();
+    // A killed child stays a zombie until the runtime reaps it, and for that whole
+    // window `kill(pid, 0)` succeeds — verified with a probe: stat 'Z', kill0 true.
+    // That is precisely the state a God is in right after a successful reap.
+    const god = spawnTagged(1, 'PM2 v6.0.14: God Daemon (/fake)')[0];
+    writeFileSync(join(home, 'pm2.pid'), String(god));
+    expect(liveGodAt(home)).not.toBeNull();   // alive → detected
+
+    process.kill(god, 'SIGKILL');
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline && alive(god)) spinMs(50);
+    expect(alive(god)).toBe(false);           // now a zombie (or fully gone)
+
+    expect(liveGodAt(home)).toBeNull();       // ...and must NOT be called a God
   });
 
   it('ignores a shared ~/.pm2 God that has NO botmux rows (belongs to the user)', () => {

--- a/test/legacy-pm2-reaper.test.ts
+++ b/test/legacy-pm2-reaper.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { reapLegacyPm2 } from '../src/core/legacy-pm2-reaper.js';
 
 const dirs: string[] = [];
@@ -12,13 +13,38 @@ function tmp(): string { const d = mkdtempSync(join(tmpdir(), 'legacy-pm2-')); d
 // running production pm2), leaving HOME unset would let that real God leak into
 // every test. Point HOME at a fresh temp dir so the shared-home scan is empty
 // unless a test explicitly populates it.
+//
+// CAVEAT, measured: on macOS `os.homedir()` ignores $HOME (it reads getpwuid()),
+// so this override only isolates the reaper on Linux. The tests that must see a
+// specific shared home therefore assert via the pm2 call log rather than relying
+// on the override alone. Our real ~/.pm2 has no God, so the scan is inert here.
 let savedHome: string | undefined;
+
+// HERMETIC PATH: `bun run`/`npm test` prepend node_modules/.bin, where this repo's
+// dev-dependency pm2 shim lives — so a bare `pm2` ALWAYS resolves under the test
+// runner. That silently hid the production bug this suite now covers: the compiled
+// binary has no bundled pm2 and no pm2 on PATH, and resolvePm2Bin's PATH fallback
+// was never exercisable in a test. Strip node_modules/.bin so "no pm2 CLI" is
+// actually reachable; tests that want a working pm2 plant one under pkgRoot.
+let savedPath: string | undefined;
 beforeEach(() => {
   savedHome = process.env.HOME;
   process.env.HOME = tmp();
+  savedPath = process.env.PATH;
+  process.env.PATH = (savedPath ?? '')
+    .split(':')
+    .filter((p) => !p.endsWith(`${sep}node_modules${sep}.bin`))
+    .join(':');
 });
 afterEach(() => {
   if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+  if (savedPath === undefined) delete process.env.PATH; else process.env.PATH = savedPath;
+  // Kill whole process groups first: a group leader's grandchildren are not in
+  // `spawned` and would otherwise survive as orphans.
+  for (const pid of groupLeaders.splice(0)) {
+    try { process.kill(-pid, 'SIGKILL'); } catch { /* group already gone */ }
+  }
+  for (const p of spawned.splice(0)) { try { p.kill('SIGKILL'); } catch { /* already gone */ } }
   for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
 });
 
@@ -56,6 +82,65 @@ function liveGodPidfile(home: string): void {
 function liveGodSocketOnly(home: string): void {
   mkdirSync(home, { recursive: true });
   writeFileSync(join(home, 'rpc.sock'), '');
+}
+
+// ── Fixtures for the CLI-less fallback ──────────────────────────────────────
+const spawned: ChildProcess[] = [];
+/** Pids spawned as process-group leaders (detached). Teardown signals the whole
+ *  group so a fixture that forks grandchildren cannot leave orphans behind —
+ *  an unbounded respawning fixture once exhausted this machine's processes. */
+const groupLeaders: number[] = [];
+
+/** Spawn `n` throwaway processes whose cmdline looks like a pm2-era botmux
+ *  daemon (`.../dist/index-daemon.js`), so the reaper's cmdline check accepts
+ *  them. They sleep until killed. */
+function spawnSleepers(n: number): number[] {
+  return spawnTagged(n, '/fake/dist/index-daemon.js');
+}
+
+/** Spawn a process whose cmdline has NOTHING to do with botmux — stands in for a
+ *  recycled pid that a stale pids/ file now points at. */
+function spawnBystander(): number {
+  return spawnTagged(1, '/usr/local/share/totally-unrelated-service')[0];
+}
+
+function spawnTagged(n: number, tag: string, script = 'setTimeout(()=>{},60_000)',
+                    opts: { group?: boolean } = {}): number[] {
+  const pids: number[] = [];
+  for (let i = 0; i < n; i++) {
+    // The trailing arg only shapes the visible cmdline; the file need not exist
+    // since the script itself comes from -e.
+    const p = spawn(process.execPath, ['-e', script, tag], { stdio: 'ignore', detached: !!opts.group });
+    if (opts.group) groupLeaders.push(p.pid!);
+    spawned.push(p);
+    pids.push(p.pid!);
+  }
+  return pids;
+}
+
+/** Block for `ms` without an async boundary — these tests drive a synchronous
+ *  reaper and need real elapsed time for signals/respawns to land. */
+function spinMs(ms: number): void {
+  try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); } catch { /* no SAB */ }
+}
+
+/** pm2 records one pid file per app as `pids/<name>-<id>.pid`. */
+function writePm2AppPid(home: string, appName: string, pid: number): void {
+  const dir = join(home, 'pids');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${appName}.pid`), String(pid));
+}
+
+/** Is `pid` still a running process? Mirrors the reaper's own liveness notion:
+ *  `kill(pid, 0)` succeeds for a ZOMBIE too, and every process spawned here is
+ *  our child — once killed it stays a zombie until vitest's loop reaps it, so a
+ *  bare kill(0) would report our reaped daemons as still alive. */
+function alive(pid: number): boolean {
+  try { process.kill(pid, 0); } catch { return false; }
+  const ps = spawnSync('ps', ['-p', String(pid), '-o', 'stat='], { encoding: 'utf-8' });
+  const stat = (ps.stdout || '').trim();
+  if (!stat) return false;
+  return !stat.startsWith('Z');
 }
 
 describe('reapLegacyPm2', () => {
@@ -213,6 +298,200 @@ describe('reapLegacyPm2', () => {
     expect(calls).toContain('delete botmux-0');
     expect(calls).not.toContain('delete users-own-app');
     expect(calls).not.toContain('kill'); // NEVER kill the shared God
+  });
+
+  // ── The gap that DID double the fleet (compiled binary) ─────────────────────
+  // Every test above plants a fake pm2 under <pkgRoot>/node_modules, so they all
+  // exercise the bundled-pm2 branch. The compiled single binary never has that
+  // path: PKG_ROOT is derived from __dirname, which is inside the virtual
+  // /$bunfs/ — MEASURED with a probe binary, PKG_ROOT resolved to `/private`, so
+  // the bundled probe missed and resolvePm2Bin fell back to a PATH lookup for
+  // `pm2`. With no pm2 on PATH, spawnSync fails ENOENT, the failure is swallowed,
+  // and the God survives: `botmux restart` left BOTH fleets live, two processes
+  // answering the same Feishu events, both holding the same session sqlite
+  // (observed: "SessionStoreUnavailableError: disk I/O error" on the new fleet).
+  //
+  // The old fleet's pids are on disk the whole time (pm2 writes pids/<name>.pid),
+  // so reaping never actually needed the pm2 CLI. These tests pin the fallback.
+  it('reaps via pids/ when the pm2 CLI is unavailable (compiled-binary shape)', () => {
+    const configDir = tmp();
+    const pkgRoot = tmp(); // NO node_modules/pm2 here → mirrors the compiled binary
+    const home = join(configDir, 'pm2');
+    liveGodPidfile(home);
+    // Two botmux daemons + one plugin row (must be left alone) + one unrelated.
+    const daemons = spawnSleepers(2);
+    const plugin = spawnSleepers(1)[0];
+    writePm2AppPid(home, 'botmux-0', daemons[0]);
+    writePm2AppPid(home, 'botmux-dashboard-7', daemons[1]);
+    writePm2AppPid(home, 'botmux-plugin-x', plugin);
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    expect(r.found).toBe(true);
+    expect(r.deleted.sort()).toEqual(['botmux-0', 'botmux-dashboard-7']);
+    // The core daemons must actually be gone — this is the whole point.
+    for (const pid of daemons) expect(alive(pid)).toBe(false);
+    // A plugin row is not core botmux; the reaper must not touch it.
+    expect(alive(plugin)).toBe(true);
+    // `killed` stays false here: the God pidfile points at this test process,
+    // whose cmdline is not a pm2 God, so the identity guard refuses to signal it
+    // (see the pid-reuse test below). Stopping the daemons is the load-bearing
+    // half — they are what holds the ports, the sqlite, and the Feishu stream.
+    expect(r.killed).toBe(false);
+  });
+
+  it('refuses to signal a "God" pid whose cmdline is not a pm2 God', () => {
+    // The God pid also comes from a file that can be stale. It gets SIGTERM then
+    // SIGKILL, so shooting a recycled pid here would take down an unrelated
+    // process — verify the guard by pointing pm2.pid at a live non-God.
+    const configDir = tmp();
+    const pkgRoot = tmp();
+    const home = join(configDir, 'pm2');
+    const bystander = spawnBystander();
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, 'pm2.pid'), String(bystander));
+    const daemon = spawnSleepers(1)[0];
+    writePm2AppPid(home, 'botmux-0', daemon);
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    expect(r.deleted).toEqual(['botmux-0']); // daemons still reaped
+    expect(r.killed).toBe(false);            // but the fake God is spared
+    expect(alive(bystander)).toBe(true);
+  });
+
+  it('does not report success when the God survives (no CLI, no reapable pids)', () => {
+    // The dangerous direction: if we cannot prove the old fleet is down, the
+    // caller must be able to tell — silently returning "handled" is what let a
+    // double-run start. God is live, but there are no pids/ to work with.
+    const configDir = tmp();
+    const pkgRoot = tmp(); // no bundled pm2
+    liveGodPidfile(join(configDir, 'pm2'));
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    expect(r.found).toBe(true);
+    expect(r.killed).toBe(false);
+    expect(r.unresolved).toBe(true); // caller must warn: old fleet may be live
+    expect(r.note).toMatch(/pm2 (CLI|not)/i);
+  });
+
+  it('does NOT mark the shared-home outcome unresolved (its God is spared by design)', () => {
+    // `unresolved` drives an operator-facing warning, so it must not fire on the
+    // normal shared-home path: there we deliberately never kill the God, and
+    // `!killed` is the correct result rather than a failure.
+    const configDir = tmp(); // no exclusive God
+    const pkgRoot = tmp();
+    const fakeHome = tmp();
+    fakePm2(pkgRoot, { jlist: JSON.stringify([{ name: 'botmux-0' }, { name: 'users-own-app' }]) });
+    liveGodPidfile(join(fakeHome, '.pm2'));
+
+    const savedHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    let r;
+    try { r = reapLegacyPm2(configDir, pkgRoot); }
+    finally { if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome; }
+
+    expect(r.found).toBe(true);
+    expect(r.killed).toBe(false);      // by design
+    expect(r.unresolved).toBe(false);  // ...and therefore NOT a problem to report
+  });
+
+  it('never signals a pid whose cmdline is not a botmux daemon (pid reuse)', () => {
+    // pids/ files can outlive their process and the pid may have been recycled
+    // into something unrelated. Killing by stale pid alone would shoot a
+    // bystander, so the fallback must verify the process before signalling.
+    const configDir = tmp();
+    const pkgRoot = tmp();
+    const home = join(configDir, 'pm2');
+    liveGodPidfile(home);
+    const bystander = spawnBystander();
+    writePm2AppPid(home, 'botmux-0', bystander);
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    expect(alive(bystander)).toBe(true);       // untouched
+    expect(r.deleted).not.toContain('botmux-0');
+  });
+
+  it('kills the God itself when its cmdline confirms it is a pm2 God', () => {
+    // The positive half of the guard above: a real God must actually be stopped,
+    // otherwise it would restart the daemons we just reaped. pm2 titles its
+    // daemon "PM2 <version>: God Daemon (<PM2_HOME>)".
+    const configDir = tmp();
+    const pkgRoot = tmp();
+    const home = join(configDir, 'pm2');
+    mkdirSync(home, { recursive: true });
+    const god = spawnTagged(1, 'PM2 v6.0.14: God Daemon (/fake/.botmux/pm2)')[0];
+    writeFileSync(join(home, 'pm2.pid'), String(god));
+    const daemon = spawnSleepers(1)[0];
+    writePm2AppPid(home, 'botmux-0', daemon);
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    expect(r.deleted).toEqual(['botmux-0']);
+    expect(r.killed).toBe(true);
+    expect(alive(god)).toBe(false);
+    expect(alive(daemon)).toBe(false);
+  });
+
+  it('stops the God BEFORE its daemons, so nothing gets respawned', () => {
+    // Respawning dead children is a pm2 God's whole job. Reaping the daemons
+    // first therefore accomplishes nothing — MEASURED with a compiled probe:
+    // the daemon was SIGTERMed, the still-live God brought it back, and the
+    // reaper reported it deleted. This God actually respawns, so the ordering is
+    // load-bearing rather than stylistic.
+    const configDir = tmp();
+    const pkgRoot = tmp();
+    const home = join(configDir, 'pm2');
+    mkdirSync(join(home, 'pids'), { recursive: true });
+    const pidFile = join(home, 'pids', 'botmux-0.pid');
+
+    // A "God" that respawns its child when it dies, rewriting the pidfile — the
+    // behavior that defeats the wrong order. Its cmdline carries the pm2 God
+    // title so the identity guard accepts it.
+    //
+    // BOUNDED ON PURPOSE: an earlier version respawned without limit and, once
+    // the God was killed, its orphaned children kept respawning — that runaway
+    // exhausted this machine's process resources and took the shell down with it.
+    // So: a hard respawn cap, a self-destruct timer in every process, and the
+    // whole family in its own process group that teardown kills as a unit.
+    const godScript = `
+      const {spawn}=require('child_process');
+      const fs=require('fs');
+      const PIDFILE=${JSON.stringify(pidFile)};
+      const MAX_RESPAWNS=3;               // hard cap — never an unbounded loop
+      let respawns=0;
+      function launch(){
+        const child=spawn(process.execPath,
+          ['-e','setTimeout(()=>process.exit(0),15000)','/fake/dist/index-daemon.js'],
+          {stdio:'ignore'});
+        fs.writeFileSync(PIDFILE,String(child.pid));
+        child.on('exit',()=>{ if(respawns++ < MAX_RESPAWNS) setTimeout(launch,50); });
+      }
+      launch();
+      setTimeout(()=>process.exit(0),15000);   // self-destruct even if unreaped
+    `;
+    // detached:true → new process group, so teardown can signal the whole family.
+    const god = spawnTagged(1, 'PM2 v6.0.14: God Daemon (/fake)', godScript, { group: true })[0];
+    // Wait for the God to publish its first child.
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline && !existsSync(pidFile)) spinMs(50);
+    expect(existsSync(pidFile)).toBe(true);
+    const firstChild = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
+    expect(alive(firstChild)).toBe(true);
+    writeFileSync(join(home, 'pm2.pid'), String(god));
+
+    const r = reapLegacyPm2(configDir, pkgRoot, () => {});
+
+    // Let any pending respawn fire; with the God dead first, none can.
+    spinMs(400);
+    expect(r.killed).toBe(true);
+    expect(alive(god)).toBe(false);
+    expect(r.unresolved).toBe(false);
+    // Whatever child the pidfile now names must be down and stay down.
+    const lastChild = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
+    expect(alive(lastChild)).toBe(false);
   });
 
   it('ignores a shared ~/.pm2 God that has NO botmux rows (belongs to the user)', () => {


### PR DESCRIPTION
## 问题

`botmux restart` 在**编译版单文件二进制**下不会停掉迁移前的 pm2 fleet，于是新旧两套 daemon 同时在跑。

本机实测到的现场：老 PM2 God（7 个 `dist/index-daemon.js`）与新 supervisor（7 个 `botmux __daemon`）并存，`ecosystem.config.json` 与 `fleet-state.json` 里是**逐字相同的 7 个 appId** —— 同一批飞书事件被两套进程同时长连接消费。附带后果：

- 新 fleet 的 IPC 端口从 7950 一路让到 7960，终端代理从 8800 让到 8811（日志里 22 行 `port in use`）
- 两套同时持有同一个 session sqlite（`lsof` 双向确认同一 inode），新 fleet 报 `SessionStoreUnavailableError: disk I/O error`，消息处理真的失败
- 两套写同一个 `daemon-0-out.log`，日志交错

## 根因

`reapLegacyPm2` 的**检测**环节是好的（`pm2.pid` 缺失时回退 `rpc.sock`，本机 pm2.pid 在、God 活着，检测通过），失效在**执行**环节：

1. `resolvePm2Bin` 先探 `<pkgRoot>/node_modules/pm2/bin/pm2`，而 `PKG_ROOT = dirname(__dirname)`。编译态下 `__dirname` 在虚拟 `/$bunfs/` 里 —— 用编译探针实测 `PKG_ROOT` 落成了 `/private`，探针必然落空。这正是 CLAUDE.md 记载的 `__dirname` 陷阱。
2. 落空后返回裸 `'pm2'` 交给 PATH。编译版不带 pm2，PATH 上也常没有 → 每次 spawn ENOENT → 被 best-effort 吞掉 → `continue`：**不 delete、不 kill**。
3. 失败只写 `logger.info`，而 CLI 模式下 `logger.setSilent(true)`；返回值在所有调用点被丢弃。**操作者看不到任何提示**，`restart` 照常拉起第二套 fleet。

讽刺的是源码形态下它是好的（直接跑 `node_modules/pm2/bin/pm2 jlist` 能正常列出 7 行），**这个 bug 只在编译版里出现**。

## 改法

pm2 CLI 不可用时不再假装可用，转而用 God 自己的 `pids/` 记录直接收进程 —— 那份记录一直在盘上，reap 本就不需要 pm2。

| 改动 | 说明 |
|---|---|
| `resolvePm2Bin` | 编译态返回 `null`；源码态先 `pm2 --version` 探活，不再返回无望的裸名字 |
| `legacyProcsFromPidsDir`（新增） | 读 `PM2_HOME/pids/`，逐个校验 cmdline 后才纳入目标 |
| **杀进程顺序** | **先停 God 再停 daemon**。反过来会被 God 当场 respawn |
| pid 复用守卫 | `looksLikeLegacyBotmuxDaemon` / `looksLikePm2God`，验明 cmdline 才发信号 |
| `isAlive` | 排除 zombie —— `kill(pid,0)` 对 zombie 返回成功，会把已收掉的进程判成存活 |
| `unresolved`（新增字段） | 区分「共享 home 故意不杀 God」与「想杀但失败」，后者在 CLI 侧走 stderr 告警 |
| 共享 `~/.pm2` | 无 CLI 时整段跳过：那里可能跑着用户自己的应用，不能凭 pids/ 猜着发信号，更不能杀它的 God |

顺序那条是编译态实测抓出来的：先杀 daemon 的话，还活着的 God 会把它拉回来，而 reaper 仍报成功。

## 影响面

只走 `start`/`restart`/`stop` 的 legacy reap 路径，**不碰 supervisor 自身的 stop/restart 语义**（那条链路是 `fleet-state.json` → `supervisorPid` → SIGTERM，本 PR 未改）。

覆盖的组合：编译态 vs 源码态 × pm2 CLI 有无 × 独占 home vs 共享 `~/.pm2`，各自都有测试。macOS/Linux 同构 —— 只用 `ps` + 信号，无平台分支。

## 验证

**单测** `test/legacy-pm2-reaper.test.ts` 17 项全绿（新增 8 项）：

```
Tests  17 passed (17)
```

**反向变异 5 组，确认测试有牙**：

| 变异 | 结果 |
|---|---|
| 恢复 PATH 回退（`return 'pm2'`） | 报红 4 项 |
| 顺序改回「先杀 daemon」 | 报红 4 项 |
| 去掉 pid 复用守卫 | 报红 1 项 |
| zombie 计为存活 | 报红 3 项 |
| 去掉 God 身份校验 | **reaper 杀死自己所在的 vitest worker** |

**真编译版二进制实测**（PATH 剥掉 pm2，假 God 会真 respawn 子进程）：

```
isStandaloneBinary() = true
[LOG] legacy pm2 God detected (...1 botmux proc(s) from pids/); no pm2 CLI — reaping by signal
[LOG]   SIGTERM pm2 God (pid 776)      ← God 先
[LOG]   SIGTERM botmux-0 (pid 780)     ← daemon 后
RESULT = {"found":true,"deleted":["botmux-0"],"killed":true,"unresolved":false}
god = Z | last child = GONE            ← 都停了，无 respawn
```

**全量** `bun run test`：13 files / 49 tests 失败，但失败集中在 `dsh-runner`（22）、`ipc-preview-route`（7）、`cli-runtime-update`（5）等模块，**与 legacy-pm2 / fleet / reaper 零交集**（grep 命中 0）。`dsh-runner` 正是 `tsc` 报「缺 yaml 模块」的那个文件，属预先存在。两次运行数字从 21/60 波动到 13/49，说明其中有 flaky。基线对照结果见下方「全量测试基线对照」一节（已用 JSON reporter 取到确定名单）。

## 顺带修的测试基础设施

原有测试**每一项都在 `<pkgRoot>/node_modules` 放了假 pm2**，全部走 bundled 分支 —— 编译态那条路从来没被测到。两处隔离缺陷：

1. `bun run` / `npm test` 会把 `node_modules/.bin` 塞进 PATH 前缀，而本仓库有 pm2 devDependency，所以裸 `pm2` 在测试里**永远可解析**，「无 pm2」这条生产路径无法复现。现在显式剥掉该路径段。
2. macOS 上 `os.homedir()` 忽略 `$HOME`（走 `getpwuid()`），原注释声称的「HERMETIC HOME」隔离**只在 Linux 成立**。已在注释里注明，相关断言改为验证 pm2 调用日志。

另外 respawn 夹具做了受控化：respawn 上限 3 次 + 每进程自毁定时器 + 独立进程组按组回收。早期无上界的版本一度把本机进程资源耗尽。

## 补充：孤儿 rpc.sock 假告警（commit a5b44e69）

主 bug 修完、reap 第一次真正成功之后，暴露出检测侧的既有缺陷：**reap 成功了，但「旧版 pm2 守护进程仍在运行」的告警每次 `status` / `logs` 都还在弹，且再跑 `restart` 也清不掉**。

这是 f2c9f7b5（为检出无 pid 文件的 God 而加 socket 回退）遗留的问题 —— 以前 reap 从没成功过，所以走不到「God 已死、记录残留」这个状态。

### 两个独立成因（实测定位）

**1. 孤儿 `rpc.sock` 被当成活 God。** `pm2 kill` 删 `pm2.pid` 但把 `rpc.sock` 留在磁盘上，而检测在「无 pid 文件」时只看 `existsSync`。实测：监听进程被 SIGKILL 后文件仍在，`statSync().isSocket()` 仍为 true —— **两者都区分不了真实孤儿**。

改用 `lsof -- <path>` 判断是否真被进程持有（活 socket exit 0 有输出、孤儿 exit 1 无输出）。`lsof` 不可用时 **fail closed** 返回「有」：宁可留个陈旧告警，也不漏掉活着的 socket-only God（f2c9f7b5 修的就是那个漏检），代价只是多一条告警，绝不会变成双跑。

**2. `pm2.pid` 没人删，而刚被杀的 God 是 zombie。** 无 pm2 CLI 的信号路径没有 `pm2 kill` 帮忙删 `pm2.pid`，于是文件继续指向那个刚被杀的 God —— 而 `kill(pid, 0)` **对 zombie 返回成功**，所以它又被读成活的。探针实测：SIGKILL 后 `ps` 的 stat 稳定为 `Z`，`kill(0)` 持续为 true。

所以 reap 成功后一并清掉两个残留记录（**`pm2.pid` 仍指向活进程时不动**，避免把一个新起的真 God 抹掉），且 `liveGodAt` 的 pid 判活改走 `isAlive`（排除 zombie）。

### 顺带消除告警与 reaper 的判据分叉

`src/cli.ts` 的 `pm2GodAlive()` 是 status/logs 的告警判据，两个缺陷**都有**（裸 `kill(pid,0)` + 裸 `existsSync(rpc.sock)`）。没有并行改两处，而是把 reaper 的 `liveGodAt` 导出、删掉 `pm2GodAlive` 让 status/logs 复用 —— 那本来就是同一逻辑的第二份手工副本，**漂移正是告警在成功迁移后依然说谎的原因**；合成一处后两者不可能再各说一套。

### 影响面

只动 legacy pm2 迁移路径（reaper + status/logs 的告警判据），**不涉及**任何 CLI 适配器、后端（`PtyBackend` / `TmuxBackend`）、会话类型（话题/群/adopt/restore）或 IM 层。

`lsof` 探测仅在 `rpc.sock` 确实存在时才付出（实测 ~260ms，与 flag 无关，是扫全表的固有成本），即只在迁移前 / 尚未清理的机器上；一次成功 reap 之后该文件即被删除，开销自然消失。全新安装 `existsSync` 先短路，零 spawn。

### 验证

单测 **21/21**，新增 4 项：孤儿 socket 不算 God、reap 后两个记录都清掉且二次调用不再 `found`/`unresolved`、`pm2.pid` 仍指向活进程时不删、以及一项直接打 `liveGodAt` 的 zombie 测试。

反向变异四项各自报红：

| 变异 | 结果 |
|---|---|
| `rpcSocketHeld` 改回 `existsSync` | 报红 3 项 |
| 去掉记录清理 | 报红 2 项 |
| `liveGodAt` 改回裸 `kill(pid,0)` | 报红 1 项 |
| 去掉「活 pid 不删」守卫 | 报红 1 项 |

⚠️ **变异测试抓到一个测试盲区**：`liveGodAt` 改回裸 `kill(0)` 时，最初 20 项**照样全绿** —— 因为 pidfile 清理把 zombie bug 在 reap 路径里遮掉了（清了就读不回来）。而 status/logs 那条路径**不做清理**，等于修了但没测。为此补了直接打 `liveGodAt` 的 zombie 测试，现在该变异能报红。

**真编译版二进制对着本机真实残留状态实测** —— 这才是本 bug 的实际发生场景，单测跑在 Node 下证明不了：

```
本机真实状态：~/.botmux/pm2 无 pm2.pid、pids/ 为空、rpc.sock 孤儿
              （lsof exit 1，且全机 ps 无任何 God Daemon 进程）

新编译版 status  → 无任何 pm2 告警            ✅ 正确静默
同 socket 路径起真 listener（正向对照）
新编译版 status  → ⚠️ 检测到旧版 pm2 守护进程仍在运行  ✅ 正确告警
```

正反都过，说明**编译态下 `lsof` 可用、检测确实在执行**，静默是判断结果而非死代码（这是单靠「没报警」无法排除的可能）。对照组：把改前的 `pm2GodAlive` 原样跑在同一真实状态上返回 `true`，即用户报的永久误报。

`tsc` 全量类型检查除 `dsh-runner` 缺 yaml 模块（干净 master 上逐字复现的既存失败）外**零错误**；`cli-runtime-update` 的 5 项失败同样在干净树（`git stash`）上逐字复现，与本改动无关。`legacy-pm2-reaper` 及其余 21 个 `cli-*` 测试文件全绿。

### 全量测试基线对照（本 commit 补充）

用 JSON reporter 拿到确定名单（`tail` 会截断输出，之前的 13/49 是被截过的）：**14 files / 50 tests 失败，`legacy-pm2-reaper` 不在其中**。

```
   22  dsh-runner.test.ts                     ← tsc 报缺 yaml 模块的那个文件
    7  ipc-preview-route.test.ts
    5  cli-runtime-update.test.ts
    3  npm-binary-distribution.test.ts
    3  resource-monitor-darwin.test.ts
    2  worker-dsh-turn.integration.test.ts
    1  × 7 个其余文件
```

逐项确认与本改动零交集：`cli-runtime-update`（5）在 `git stash` 后的干净树上逐字复现；pm2 相关的 `plugin-pm2-env` 单独在**父 commit c2e7a9dd 以及干净 `origin/master`** 上均逐字复现；`current-actor-attestation`、`oh-my-pi-legacy-migration` 同样在干净 master 上复现。`session-picker-responsive` 在干净 master 单跑通过、全量跑失败，属 flaky。`legacy-pm2-reaper` 及其余 21 个 `cli-*.test.ts` 全绿。
