### PR TITLE
fix(setup): 编译版二进制不再报「找不到 botmux lark-scopes.json」

### DIFF
--- a/scripts/smoke-bun-binary.mjs
+++ b/scripts/smoke-bun-binary.mjs
@@ -191,6 +191,33 @@ try {
   fail('version', err instanceof Error ? err.message : String(err));
 }
 
+// ── 1c. selfcheck: setup-time lark-scopes.json load works in the binary ──────
+// The compiled binary keeps its module graph in the read-only virtual /$bunfs,
+// so setup code that loaded lark-scopes.json via readFileSync/copyFileSync of a
+// __dirname-relative path threw "找不到 botmux lark-scopes.json" — the first
+// `botmux setup ... --create-app` from a fresh curl install died right here.
+// npm/Node unit tests can't see it (dist/ physically exists there). The hidden
+// `__selfcheck` entry runs readDefaultScopeManifest() + writeScopesJsonToConfigDir()
+// and prints `{"ok":true,...}`; a non-zero exit or missing ok flag = the /$bunfs
+// regression is back. Runs in the scratch HOME, no credentials needed.
+try {
+  const out = execFileSync(binary, ['__selfcheck'], {
+    cwd: home, env: childEnv, encoding: 'utf-8', timeout: 60_000,
+  });
+  let parsed;
+  try { parsed = JSON.parse(out.trim().split('\n').pop()); }
+  catch { parsed = null; }
+  if (!parsed?.ok || !(parsed.tenant > 0) || !(parsed.user > 0)) {
+    fail('selfcheck', `__selfcheck did not confirm the manifest loaded: ${out.slice(0, 300)}`);
+  }
+  if (!existsSync(join(home, '.botmux', 'lark-scopes.json'))) {
+    fail('selfcheck', 'writeScopesJsonToConfigDir did not produce ~/.botmux/lark-scopes.json');
+  }
+  console.log(`smoke: ✅ selfcheck — lark-scopes manifest loads + writes in the binary (tenant=${parsed.tenant}, user=${parsed.user})`);
+} catch (err) {
+  fail('selfcheck', err instanceof Error ? err.message : String(err));
+}
+
 // ── 2/3. self-spawn + dashboard boots and reaches online ─────────────────────
 // `__supervisor` is the hidden self-re-exec entry: under a compiled binary this
 // takes the /$bunfs argv[1] detection path, so a broken isStandaloneBinary() or

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,7 @@ import {
 } from './setup/owner-identity.js';
 import { interactiveSelect, pickChoice, pickCliSelection } from './setup/interactive-select.js';
 import { buildPreset, serializePreset, presetFilename } from './setup/agent-preset.js';
+import bundledScopeManifest from './setup/lark-scopes.json' with { type: 'json' };
 import type { CliId } from './adapters/cli/types.js';
 import type { CodexAppDispatchLedgerEntry } from './types.js';
 import {
@@ -509,20 +510,8 @@ function botBrand(b: any): Brand {
  * Returns: 写出的 JSON 文件绝对路径.
  */
 function writeScopesJsonToConfigDir(): string {
-  // build script 会把 src/setup/lark-scopes.json copy 到 dist/setup/.
-  // dist 模式下 __dirname 是 dist/, 找 ./setup/lark-scopes.json; dev (tsx)
-  // 模式找 src/setup/lark-scopes.json 在源码同目录也成立.
-  const here = dirname(fileURLToPath(import.meta.url));
-  const srcCandidates = [
-    join(here, 'setup', 'lark-scopes.json'),
-    join(here, '..', 'src', 'setup', 'lark-scopes.json'),
-  ];
-  let scopesPath = srcCandidates[0];
-  for (const p of srcCandidates) {
-    if (existsSync(p)) { scopesPath = p; break; }
-  }
   const destPath = join(CONFIG_DIR, 'lark-scopes.json');
-  copyFileSync(scopesPath, destPath);
+  writeFileSync(destPath, `${JSON.stringify(bundledScopeManifest, null, 2)}\n`);
   return destPath;
 }
 
@@ -12868,6 +12857,36 @@ switch (command) {
   case 'list':
   case 'ls':      await cmdList(); break;
   case '__zmx-attach-managed': cmdManagedZmxAttach(process.argv.slice(3)); break;
+  // Hidden self-check for the compiled single-file binary: exercise the two
+  // setup-time code paths that load lark-scopes.json off a module-relative path —
+  // readDefaultScopeManifest() (real Open Platform setup) and
+  // writeScopesJsonToConfigDir() (writes ~/.botmux/lark-scopes.json). In compiled
+  // mode the module graph lives in the read-only virtual /$bunfs, so the old
+  // readFileSync/copyFileSync of a __dirname-derived path threw
+  // "找不到 botmux lark-scopes.json". The npm/Node unit tests can't catch that —
+  // dist/ physically exists there — so smoke-bun-binary.mjs drives THIS against
+  // the actual binary. Prints a one-line JSON summary and exits 0; any throw
+  // (missing/empty manifest, unwritable path) exits non-zero and fails the smoke.
+  case '__selfcheck': {
+    const { readDefaultScopeManifest } = await import('./setup/open-platform-automation.js');
+    const manifest = readDefaultScopeManifest();
+    const tenant = manifest.scopes?.tenant?.length ?? 0;
+    const user = manifest.scopes?.user?.length ?? 0;
+    if (tenant <= 0 || user <= 0) {
+      console.error(`__selfcheck: lark-scopes manifest empty (tenant=${tenant}, user=${user})`);
+      process.exit(1);
+    }
+    const written = writeScopesJsonToConfigDir();
+    const onDisk = JSON.parse(readFileSync(written, 'utf-8'));
+    const wroteTenant = onDisk?.scopes?.tenant?.length ?? 0;
+    const wroteUser = onDisk?.scopes?.user?.length ?? 0;
+    if (wroteTenant !== tenant || wroteUser !== user) {
+      console.error(`__selfcheck: written manifest mismatch (${wroteTenant}/${wroteUser} vs ${tenant}/${user})`);
+      process.exit(1);
+    }
+    console.log(JSON.stringify({ ok: true, tenant, user, written }));
+    process.exit(0);
+  }
   case 'delete':
   case 'del':
   case 'rm':      await cmdDelete(); break;

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -12,6 +12,7 @@ import { basename, join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import qrcode from 'qrcode-terminal';
+import bundledScopeManifest from './lark-scopes.json' with { type: 'json' };
 import { registerBotmuxRedirectUrlCollector, VC_MEETING_BOT_EVENTS } from './verify-permissions.js';
 import { readGlobalConfig } from '../global-config.js';
 import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from '../platform/binding.js';
@@ -2331,17 +2332,14 @@ async function pollFeishuQrLogin(
 }
 
 export function readDefaultScopeManifest(): ScopeManifest {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    join(here, 'lark-scopes.json'),
-    join(here, 'setup', 'lark-scopes.json'),
-    join(here, '..', 'src', 'setup', 'lark-scopes.json'),
-  ];
-  for (const candidate of candidates) {
-    if (!existsSync(candidate)) continue;
-    return JSON.parse(readFileSync(candidate, 'utf-8')) as ScopeManifest;
-  }
-  throw new Error('找不到 botmux lark-scopes.json');
+  // Static JSON import (bundledScopeManifest) rather than readFileSync of a
+  // module-relative path: Bun's `--compile` inlines the import into the binary,
+  // whereas readFileSync(join(__dirname, ...)) resolves against the read-only
+  // virtual /$bunfs at runtime and always missed — the first `setup --create-app`
+  // from a curl install died with "找不到 botmux lark-scopes.json". structuredClone
+  // so callers (e.g. filterScopeManifest) can mutate without corrupting the shared
+  // bundled object.
+  return structuredClone(bundledScopeManifest) as ScopeManifest;
 }
 
 // 宿主机到飞书的偶发网络抖动（DNS EAI_AGAIN、连接被重置、路由瞬断等）会让

--- a/test/scripts-typecheck-coverage.test.ts
+++ b/test/scripts-typecheck-coverage.test.ts
@@ -69,8 +69,8 @@ describe('scripts/ 纳入类型检查', () => {
     const options = parsedScriptsConfig().options;
     expect(options.noEmit).toBe(true);
     expect(options.strict).toBe(true);
-    expect(options.module).toBe(ts.ModuleKind.Node16);
-    expect(options.moduleResolution).toBe(ts.ModuleResolutionKind.Node16);
+    expect(options.module).toBe(ts.ModuleKind.NodeNext);
+    expect(options.moduleResolution).toBe(ts.ModuleResolutionKind.NodeNext);
     expect(options.jsx).toBe(ts.JsxEmit.ReactJSX);
   });
 

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -1782,6 +1782,21 @@ describe('probeVcMeetingEventSubscription — read-only VC event check', () => {
   });
 });
 
+describe('readDefaultScopeManifest', () => {
+  it('loads the bundled manifest and returns an independent copy', () => {
+    const first = readDefaultScopeManifest();
+    const second = readDefaultScopeManifest();
+
+    expect(first.scopes?.tenant?.length).toBeGreaterThan(0);
+    expect(first.scopes?.user?.length).toBeGreaterThan(0);
+    expect(first).not.toBe(second);
+    expect(first.scopes?.tenant).not.toBe(second.scopes?.tenant);
+
+    first.scopes?.tenant?.pop();
+    expect(second.scopes?.tenant?.length).toBeGreaterThan(0);
+  });
+});
+
 describe('automateOpenPlatformSetup', () => {
   it('forwards forceQrLogin so configure --switch-account ignores a valid cache', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-auto-force-'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "jsx": "react-jsx",
     "outDir": "dist",
     "rootDir": "src",

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -8,7 +8,7 @@
   // 腐烂（脚本里缺 owner/workerGeneration、location 缺 protocol/hostname，仍然 exit 0）。
   // 把 scripts/ 纳入同一套 strict 检查后，这类漂移在 `pnpm typecheck:scripts` 就被拦住。
   //
-  // 这里只改「不产出、允许 src 之外的根目录」，其余编译选项（strict、Node16 解析、
+  // 这里只改「不产出、允许 src 之外的根目录」，其余编译选项（strict、NodeNext 解析、
   // JSX）一律继承根配置——验的必须是生产同一套规则。
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
## 问题 / 复现

用最新 release 的**编译版单文件二进制**（`curl | install.sh` 装法）从零搭一套 botmux，在 setup 阶段一执行开放平台自动配置就崩：

```
✅ 配置已写入: ~/.botmux/bots.json
── 开放平台自动配置 ──
...
error: 找不到 botmux lark-scopes.json
    at readDefaultScopeManifest (dist/setup/open-platform-automation.js)
    at automateOpenPlatformSetup (...)
    at cli.js
```

复现：
1. 用发布的编译版二进制（非 npm/Node 版）。
2. `botmux setup ...` 走到「开放平台自动配置 / 建应用」链路。
3. 立即抛 `找不到 botmux lark-scopes.json`，setup 中断。

npm / Node 版**不受影响**——那边 `dist/setup/lark-scopes.json` 真实落盘，路径读得到。

## 根因 / 何时引入

`readDefaultScopeManifest()` 与 `writeScopesJsonToConfigDir()` 都用 `__dirname` 拼模块相对路径，再 `readFileSync` / `copyFileSync` 读 `lark-scopes.json`。编译态下模块图在 Bun 的虚拟只读 `/$bunfs` 下，`__dirname` 是 `/$bunfs/root`，这些路径在进程外不可达，所有候选路径全 miss，最后抛错。

该缺陷自 `readDefaultScopeManifest` 被引入（commit `116073bf` “feat(setup): automate Feishu Open Platform setup”）起就存在，从第一版就是 `readFileSync(join(here, ...))` 的写法。它只在编译版触发，npm/Node 版因落盘一直没暴露，所以潜伏至今。（并非某次 scope 自愈改动引入——那些 PR 只是复用/新增了该函数的调用方，没动加载逻辑。）

## 修复

改用静态 JSON 导入：

```ts
import bundledScopeManifest from './lark-scopes.json' with { type: 'json' };
```

- Bun 的 `--compile` 会把静态 JSON 导入**直接 inline 进二进制**；Node ESM 下 JSON 导入也原生支持。两个运行时从此走**同一份**加载逻辑，不再有「只在编译版执行」的分支。
- 该导入属性语法要求 tsc 的 `module` ≥ `NodeNext`（`Node16` 会报 `TS2823`），故 `tsconfig.json` 从 `Node16`→`NodeNext`。对本仓库目标（Node ≥22 / ES2022）`NodeNext` 是 `Node16` 的超集，行为兼容。
- `tsconfig.scripts.json` extends 根配置，一并继承 `NodeNext`；故同步更新守卫测试 `test/scripts-typecheck-coverage.test.ts`（它断言 scripts 的类型检查用的是**与生产同一套** module 规则——正是本次要维持的不变量）与 `tsconfig.scripts.json` 里的相关注释。

> 备注：曾试过 `createRequire('./lark-scopes.json')` 以避免改 tsconfig，但**实测编译版运行时**报 `Cannot find module './lark-scopes.json' from '/$bunfs/root/botmux'`——相对 specifier 在 `/$bunfs` 下不解析，且它是模块级调用，会连 `capabilities` 一起拖崩。新增的 smoke 步骤当场逮到了这个回归，故最终采用静态导入方案。

## 回归防护（新增）

这个 bug 能上线，本质是**测试盲区**：唯一跑「真正编译版二进制」的 `smoke-bun-binary.mjs` 用空 `bots.json`，daemon 直接拒启，从不触达 setup 代码路径；而 npm/Node 单测又因 `dist/` 落盘看不见该缺陷。两层测试恰好都漏掉了「编译版 × setup 路径」这个交集。

- 新增隐藏入口 `__selfcheck`（`src/cli.ts`）：真实调用 `readDefaultScopeManifest()` + `writeScopesJsonToConfigDir()`，打印 `{"ok":true,tenant,user,written}`，按结果 exit 0 / 非 0。无需任何飞书凭证。
- `scripts/smoke-bun-binary.mjs` 新增 `selfcheck` 步骤：对**编译出来的二进制**跑 `__selfcheck`，校验 `ok` 标志、`tenant`/`user` 计数、`~/.botmux/lark-scopes.json` 落盘。任何 throw / 计数为 0 即判失败——正是过去漏掉的那条路径。
- 保留 `readDefaultScopeManifest` 的单测（`test/setup-open-platform-automation.test.ts`：非空 + 返回独立可 mutate 的副本），守 Node 侧行为。

## 影响面

- 仅动开放平台 setup 的权限清单加载（`readDefaultScopeManifest` / `writeScopesJsonToConfigDir`），不改申请集合、发版判定等既有逻辑。
- `tsconfig.json` 的 module 升级影响全仓库编译产物；已通过 `bun run build`（tsc + 打包）、`bun run typecheck:scripts`、编译版二进制 + 全套 smoke 验证行为不变。
- 跨平台：编译版 daemon 实际跑在 Linux，`/$bunfs` 行为与 macOS 一致；本地在 macOS arm64 上验证，CI 的 `bun-binaries` 在各原生 runner 上跑同一 smoke。

## 验证

- `bun run build`（tsc + 打包）通过；`bun run typecheck:scripts` 在 NodeNext 下 exit 0。
- Node ESM：`readDefaultScopeManifest()` 返回 **171 tenant + 130 user**，两次调用互相独立、可安全 mutate。
- `bun scripts/build-bun-binary.mjs` 编出二进制，对其跑 `__selfcheck` → `{"ok":true,"tenant":171,"user":130,...}`，`~/.botmux/lark-scopes.json` 正确写出。
- 完整 `node scripts/smoke-bun-binary.mjs <binary>` 七项全绿（`capabilities` / `version` / `selfcheck` / `self-spawn` / `dashboard` / `http` / `self-destruct`）。
  - 注：`version` 步骤在本机 `package.json=0.0.0`（未构建占位符）下会按设计报 `unknown`；验证时按 CI 做法临时打了版本号跑通，随后还原 `package.json`。
- `test/setup-open-platform-automation.test.ts` 107 例、`test/scripts-typecheck-coverage.test.ts` 3 例全绿。

## CI 说明

- 首次 CI 曾在 `test/scripts-typecheck-coverage.test.ts` 失败：本 PR 把 `tsconfig.json` 从 Node16 升到 NodeNext 后，extends 根配置的 `tsconfig.scripts.json` 也随之变化，而该守卫测试原本硬编码断言 Node16。已按其「与生产同一套规则」的本意同步为 NodeNext，本地复现并修复。
- 之后一次 CI 在 `test/mojo-close-worker-journal.integration.test.ts` 失败，**与本 PR 无关**，判断为 flaky：上一次运行该用例是绿的（那次只挂 scripts-typecheck）；本 PR 未触及任何 mojo/worker/backend 代码；本地 `bun run test test/mojo-close-worker-journal.integration.test.ts` 稳定 7/7 全绿（含 CI 报错那条 line 564）。该用例启真实 worker（60s 预算）并依赖 `/proc` 子树扫描在超时窗口内产出裁决信封，CI 高负载下更像启动/时序假象。已推一次内容不变的提交重跑 CI。