### PR TITLE
fix(dashboard): 编译版二进制内嵌前端产物，Dashboard 不再整站 404

### DIFF
--- a/scripts/bun-native-embed-plugin.mjs
+++ b/scripts/bun-native-embed-plugin.mjs
@@ -1,4 +1,5 @@
-// Bun build plugin: make botmux's native addons survive `bun build --compile`.
+// Bun build plugin: make botmux's native addons AND the Dashboard frontend
+// survive `bun build --compile`.
 //
 // `bun --compile` embeds a `.node` only when it is *statically* `require()`d in
 // the bundle. botmux's native deps load theirs through dynamic/relative paths
@@ -7,6 +8,11 @@
 // (the source tree's node_modules is gone; paths resolve inside /$bunfs/). This
 // plugin replaces those loaders at build time with ones that statically require
 // the exact embedded `.node` we hand it, so Bun bundles + serves it.
+//
+// The Dashboard's static frontend has the same shape of problem — it is reached
+// via a `__dirname`-derived directory that does not exist in a compiled binary —
+// and is fixed the same way, by injecting static embedded-file imports. See the
+// `dist/dashboard.js` hook at the bottom.
 //
 // Exported as a factory so both build-bun-binary.mjs and any programmatic caller
 // pass the resolved native paths explicitly (no env/global coupling).
@@ -18,6 +24,7 @@
 
 import { readFileSync } from 'node:fs';
 import { dirname as nodeDirname } from 'node:path';
+import { buildDashboardEmbedPreamble } from './generate-dashboard-embed.mjs';
 
 /**
  * @param {{ ptyNode: string, spawnHelper: string|null, skiaNode?: string|null }} opts
@@ -84,6 +91,19 @@ export function makeNativeEmbedPlugin({ ptyNode, spawnHelper, skiaNode = null })
           return { contents: preamble + '\n' + original, loader: 'js' };
         });
       }
+
+      // ── Dashboard frontend ────────────────────────────────────────────────
+      // Same class of problem as the natives above, for static assets: the
+      // Dashboard resolves its frontend as `join(__dirname, 'dashboard-web')`,
+      // which in a compiled binary points into the virtual /$bunfs/ and does not
+      // exist — so every asset request fell through to the catch-all 404 and the
+      // Dashboard was completely unreachable from a binary (npm/source were
+      // fine). Prepend static `type: 'file'` imports for the whole bundle plus
+      // the request-path → embedded-path map the server reads.
+      build.onLoad({ filter: /[\\/]dist[\\/]dashboard\.js$/ }, (args) => {
+        const original = readFileSync(args.path, 'utf8');
+        return { contents: buildDashboardEmbedPreamble() + '\n' + original, loader: 'js' };
+      });
     },
   };
 }

--- a/scripts/generate-dashboard-embed.mjs
+++ b/scripts/generate-dashboard-embed.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Build the JS preamble that embeds the Dashboard frontend into the compiled
+// binary. Imported by scripts/bun-native-embed-plugin.mjs, which prepends the
+// returned source to `dist/dashboard.js` at compile time.
+//
+// WHY ANY OF THIS: the Dashboard serves its static frontend by resolving
+// `join(__dirname, 'dashboard-web')`. In the compiled single binary `__dirname`
+// is the virtual `/$bunfs/root`, so that directory does not exist and EVERY
+// asset request fell through to the catch-all 404 — the post-login redirect to
+// `/` answered `{"error":"not_found_yet","path":"/"}` and the Dashboard was
+// unreachable from a compiled binary while working fine from npm/source.
+// `bun build --compile` embeds nothing by itself: only statically traced imports
+// are pulled in, and the frontend has no import edge to the server module.
+//
+// WHY A MANIFEST rather than pointing WEB_DIR at /$bunfs/root: Bun renames each
+// embedded file with a content hash (`index.html` → `index-c7k0x1v9.html` —
+// MEASURED), so a request path can never address the embedded file directly. The
+// extension IS preserved, which keeps the server's extension-based MIME lookup
+// working untouched.
+//
+// WHY INJECTED rather than a generated module the server imports: a static
+// `import './dashboard-web-embedded.js'` would make `tsc` and every plain source
+// checkout demand an artifact that only exists after `bun run dashboard:bundle`;
+// and a runtime `require()` of it does not work at all — Bun embeds only what it
+// can trace statically, and MEASURED, requiring the manifest bundled 1 module and
+// embedded zero assets, leaving the binary still 404ing everything.
+//
+// GENERATED, never hand-written: chunk filenames are content-hashed and change on
+// every frontend build, so a hand-kept list would rot into 404s for precisely the
+// lazy chunks it missed.
+
+import { readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const WEB_DIR = join(REPO_ROOT, 'dist', 'dashboard-web');
+
+/** Every file under `dir`, as WEB_DIR-relative POSIX paths. */
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const abs = join(dir, name);
+    if (statSync(abs).isDirectory()) { out.push(...walk(abs)); continue; }
+    // Dev-only reload markers are written by `build-dashboard.mjs --watch` and
+    // must never ship inside a released binary.
+    if (name === '.botmux-dashboard-dev' || name === '.botmux-dashboard-reload') continue;
+    out.push(relative(WEB_DIR, abs).split(/[\\/]/).join('/'));
+  }
+  return out;
+}
+
+/**
+ * JS source that imports every Dashboard asset as an embedded file and publishes
+ * the request-path → embedded-path map on `globalThis`.
+ *
+ * Throws when the frontend bundle is missing: shipping a binary whose Dashboard
+ * 404s on every request is the bug this exists to fix, so fail the BUILD instead
+ * of producing that binary again.
+ */
+export function buildDashboardEmbedPreamble() {
+  if (!existsSync(WEB_DIR)) {
+    throw new Error(
+      `dist/dashboard-web missing — run \`bun run build\` (or \`bun run dashboard:bundle\`) before compiling; `
+      + 'a binary without it serves a 404 for every Dashboard request.',
+    );
+  }
+  const rels = walk(WEB_DIR).sort();
+  if (rels.length === 0) throw new Error('dist/dashboard-web has no files to embed.');
+
+  const imports = [];
+  const entries = [];
+  rels.forEach((rel, i) => {
+    const id = `__bmxAsset${i}`;
+    // Absolute specifier: the preamble is prepended to dist/dashboard.js, and an
+    // absolute path is resolvable regardless of that file's own location. The
+    // real extension is preserved so Bun's embedded copy keeps it.
+    imports.push(`import ${id} from ${JSON.stringify(join(WEB_DIR, rel))} with { type: 'file' };`);
+    entries.push(`  ${JSON.stringify(rel)}: ${id},`);
+  });
+
+  return [
+    '// ── injected by scripts/generate-dashboard-embed.mjs (compiled builds only) ──',
+    ...imports,
+    // Null prototype: the server looks assets up by REQUEST path, so the map must
+    // not answer `__proto__` / `constructor` / `toString` with inherited values.
+    // The server also guards its own lookup; this keeps the object itself honest.
+    'globalThis.__BOTMUX_DASHBOARD_ASSETS__ = Object.assign(Object.create(null), {',
+    ...entries,
+    '});',
+    '',
+  ].join('\n');
+}
+
+/** Asset count, for the build log. */
+export function dashboardEmbedAssetCount() {
+  return existsSync(WEB_DIR) ? walk(WEB_DIR).length : 0;
+}

--- a/scripts/smoke-bun-binary.mjs
+++ b/scripts/smoke-bun-binary.mjs
@@ -275,6 +275,38 @@ for (;;) {
 }
 console.log(`smoke: ✅ http — dashboard is serving (status ${served})`);
 
+// ── 4b. the embedded frontend must actually be there ─────────────────────────
+// REGRESSION GUARD for a shipped bug this smoke test walked straight past.
+//
+// Check 4 accepts ANY status, on the reasoning that an unauthenticated `/`
+// legitimately 404s. True — but it made the check blind to a 404 with a
+// completely different cause: the Dashboard resolves its frontend as
+// `join(__dirname, 'dashboard-web')`, which in a compiled binary points inside
+// the virtual /$bunfs/ and does not exist, and `bun --compile` embeds nothing it
+// cannot trace statically. So EVERY asset 404'd, the post-login redirect to `/`
+// answered `{"error":"not_found_yet","path":"/"}`, and the Dashboard was
+// unreachable from any compiled binary — while npm/source installs were fine, and
+// while this smoke test reported ✅.
+//
+// Distinguish the two 404s by CAUSE rather than status: `not_found_yet` is the
+// server's catch-all miss (no asset), whereas an auth rejection carries the token
+// gate's own shape. Asserting on the body is what makes an empty-frontend binary
+// fail the build instead of shipping.
+const assetProbe = await fetch(`http://127.0.0.1:${PORTS.dashboard}/`, {
+  signal: AbortSignal.timeout(5_000),
+});
+const assetBody = await assetProbe.text();
+if (assetBody.includes('not_found_yet')) {
+  fail(
+    'frontend',
+    `dashboard answered its catch-all miss for \`/\` (${assetProbe.status}: ${assetBody.slice(0, 120)}).\n`
+    + 'The compiled binary has no embedded Dashboard frontend, so every page and asset 404s.\n'
+    + 'Expected the build plugin to inject dist/dashboard-web (scripts/generate-dashboard-embed.mjs) — '
+    + 'run `bun run build` before compiling, and check that hook still matches dist/dashboard.js.',
+  );
+}
+console.log(`smoke: ✅ frontend — embedded Dashboard assets resolve (no catch-all miss on /)`);
+
 // ── 5. the wrapper write must NOT destroy an install.sh-style binary ─────────
 // REGRESSION GUARD for a shipped bug this smoke test used to walk straight past.
 //

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -11,6 +11,7 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { createHmac, randomBytes } from 'node:crypto';
 import { logger } from './utils/logger.js';
+import { isStandaloneBinary } from './core/self-spawn.js';
 import { gracefulProcessExitCode } from './pm2-graceful-exit.js';
 import { config, isWildcardBindHost } from './config.js';
 import { listenWithProbe } from './utils/listen-with-probe.js';
@@ -159,7 +160,7 @@ import { parseCloseResidual, type ParsedCloseResidual } from './core/close-resid
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { getGitRepoInfo } from './core/session-row-enrichment.js';
 import { deleteWhiteboard, listWhiteboards, readWhiteboard, whiteboardEnabled } from './services/whiteboard-store.js';
-import { isLocalDevInstall, botmuxVersion, botmuxVersionAt, botmuxCliEntry, botmuxCliEntryAt, botmuxInstallRoot } from './utils/install-info.js';
+import { isLocalDevInstall, botmuxVersion, botmuxVersionAt, botmuxCliEntry, botmuxCliEntryAt, botmuxInstallRoot, bakedBinaryVersion } from './utils/install-info.js';
 import { checkNode, detectBotmuxInstalls, resolveCurrentVersion, resolveCurrentVersionAt } from './utils/install-diagnostics.js';
 import {
   fetchLatestVersion,
@@ -1859,6 +1860,92 @@ const WEB_DIR = join(__dirname, 'dashboard-web');
 const DEV_RELOAD_MARKER = join(WEB_DIR, '.botmux-dashboard-dev');
 const DEV_RELOAD_VERSION = join(WEB_DIR, '.botmux-dashboard-reload');
 
+/**
+ * Request-relative asset path → on-disk path to read, or null when we have no
+ * such asset. The ONE place that knows whether the frontend lives on disk
+ * (source/npm) or inside the compiled binary's virtual filesystem.
+ *
+ * WHY: `WEB_DIR` is derived from `__dirname`, which in the compiled single binary
+ * is the virtual `/$bunfs/root` — a path that does not exist on disk (the
+ * documented CLAUDE.md `__dirname` hazard). Every asset request therefore missed
+ * and fell through to the catch-all 404: the login redirect landed on `/` and
+ * returned `{"error":"not_found_yet","path":"/"}`, so the Dashboard was entirely
+ * unreachable from a compiled binary while working fine from npm/source.
+ *
+ * In compiled mode the assets are embedded instead (see
+ * scripts/generate-dashboard-embed.mjs) and Bun renames each one with a content
+ * hash, so the request path cannot address them directly — the generated manifest
+ * supplies the mapping. Extensions are preserved, so MIME lookup is unaffected.
+ *
+ * Path traversal is handled differently per mode, and both are closed:
+ *  • Embedded: the manifest is a build-time allowlist, so a traversal string
+ *    simply misses. The lookup still goes through `hasOwnProperty` and a string
+ *    check — a plain `map[rel]` answers `__proto__`/`constructor`/`toString` with
+ *    inherited objects and functions (MEASURED), and handing one of those onward
+ *    would only be stopped by a downstream throw. A security property should not
+ *    rest on that.
+ *  • On disk: the resolved path must stay inside WEB_DIR.
+ *
+ * Returns null (→ caller 404s) rather than throwing: an asset genuinely absent
+ * from the bundle must stay a 404, exactly as a missing file on disk does.
+ */
+function resolveWebAsset(rel: string): string | null {
+  const embedded = embeddedDashboardAssets();
+  if (embedded) {
+    if (!Object.prototype.hasOwnProperty.call(embedded, rel)) return null;
+    const fp = embedded[rel];
+    return typeof fp === 'string' && fp.length > 0 ? fp : null;
+  }
+  // Source / npm install: real directory on disk. Keep the path-traversal guard
+  // here — `rel` is derived from the request.
+  const fp = resolve(WEB_DIR, rel);
+  const relToRoot = relative(resolve(WEB_DIR), fp);
+  if (relToRoot === '..' || relToRoot.startsWith('..\\') || relToRoot.startsWith('../') || isAbsolute(relToRoot)) return null;
+  return fp;
+}
+
+/**
+ * The compiled binary's embedded-asset manifest, or null when running from
+ * source/npm (where the frontend is a real directory on disk). Resolved once and
+ * cached — including the null.
+ *
+ * HOW IT GETS HERE: the compiled build's plugin (scripts/bun-native-embed-plugin.mjs)
+ * prepends a generated block of `import … with { type: 'file' }` statements to
+ * this module and assigns the map to `globalThis.__BOTMUX_DASHBOARD_ASSETS__`.
+ *
+ * It has to arrive by build-time injection rather than an ordinary import:
+ *  • A static `import './dashboard-web-embedded.js'` would make `tsc` (and a
+ *    plain source checkout) demand a generated artifact that only exists after
+ *    `bun run dashboard:bundle`.
+ *  • A runtime `require()` of it does NOT work: Bun only embeds what it can trace
+ *    statically, and MEASURED, a `createRequire` require of the manifest bundled
+ *    1 module and embedded zero assets — the binary would still 404 everything.
+ */
+let embeddedAssetsCache: Record<string, string> | null | undefined;
+function embeddedDashboardAssets(): Record<string, string> | null {
+  if (embeddedAssetsCache !== undefined) return embeddedAssetsCache;
+  const injected = (globalThis as Record<string, unknown>).__BOTMUX_DASHBOARD_ASSETS__;
+  if (injected && typeof injected === 'object') {
+    embeddedAssetsCache = injected as Record<string, string>;
+  } else {
+    embeddedAssetsCache = null;
+    // A compiled binary with no injected manifest is a BUILD regression, not a
+    // runtime condition to paper over. Say it loudly: the symptom is a 404 on
+    // every page, which otherwise reads as a routing or auth bug.
+    if (isStandaloneBinary()) {
+      logger.error('[dashboard] compiled binary has no embedded frontend — every asset will 404');
+    }
+  }
+  return embeddedAssetsCache;
+}
+
+/** Cache-busting stamp for embedded assets, whose `mtimeMs` is 0 (MEASURED).
+ *  The baked release version changes with every binary, so it invalidates a
+ *  browser's cached copy exactly when the binary changes. */
+function embeddedAssetStamp(): string {
+  return (bakedBinaryVersion() ?? 'embedded').replace(/[^\w.-]/g, '');
+}
+
 const MIME: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
   '.js': 'application/javascript',
@@ -1926,11 +2013,14 @@ function serveStatic(
   options: { injectHtml?: (html: string) => string } = {},
 ): boolean {
   const rel = pathname === '/' ? 'index.html' : pathname.replace(/^\/+/, '');
-  const fp = resolve(WEB_DIR, rel);
-  const webRoot = resolve(WEB_DIR);
-  const relToRoot = relative(webRoot, fp);
-  // Path-traversal guard: resolved path must stay inside WEB_DIR.
-  if (relToRoot === '..' || relToRoot.startsWith('..\\') || relToRoot.startsWith('../') || isAbsolute(relToRoot)) return false;
+  const fp = resolveWebAsset(rel);
+  if (!fp) return false;
+  // Asset-identity decisions below key off the REQUEST path, not `fp`: in the
+  // compiled binary `fp` is a content-hash-renamed file in the virtual fs
+  // (`chunks/x.js` → `/$bunfs/root/x-<hash>.js`), so `relative(WEB_DIR, fp)`
+  // would classify every embedded asset wrongly — no chunk would be immutable
+  // and index.html would never get its CSRF shell injected.
+  const relToRoot = rel;
   try {
     const st = statSync(fp);
     if (!st.isFile()) return false;
@@ -1938,7 +2028,11 @@ function serveStatic(
     // a deploy never serves new JS with old CSS. Lazy chunks are content-hashed
     // and can be cached immutably once the current app.js points at them.
     const immutableChunk = relToRoot.startsWith('chunks/') || relToRoot.startsWith('chunks\\');
-    const etag = `W/"${st.size.toString(16)}-${Math.floor(st.mtimeMs).toString(16)}"`;
+    // `mtimeMs` is 0 for an embedded file (MEASURED), so the ETag would collapse
+    // to size alone across a whole compiled release. Fold in the baked build
+    // identity so a new binary always invalidates the browser's cache.
+    const etagStamp = st.mtimeMs > 0 ? Math.floor(st.mtimeMs).toString(16) : embeddedAssetStamp();
+    const etag = `W/"${st.size.toString(16)}-${etagStamp}"`;
     const isIndex = relToRoot === 'index.html';
     const devIndex = isIndex && dashboardDevReloadEnabled();
     // 注入 CSRF 票据的壳是每次请求现生成的：ETag 只反映磁盘文件，走 304 会让浏览


### PR DESCRIPTION
## 问题

**编译版单文件二进制的 Dashboard 完全打不开**。登录链接把 cookie 种上、跳到 `/`，而 `/` 返回：

```
{"error":"not_found_yet","path":"/"}
```

即「登录成功后被送到一个不存在的页面」。用户视角是整站 404，token 有效也没用（去掉 `?t=` 直接开 `/` 看到的是同一个 404）。**npm / 源码安装不受影响。**

`not_found_yet` 是 `src/dashboard.ts` 最底层的兜底 404，说明请求到达了服务端，只是没有任何路由/资源命中。

## 根因

两条叠加，都只在编译态成立：

1. `dashboard.ts` 用 `join(__dirname, 'dashboard-web')` 定位前端。编译态 `__dirname` 在虚拟 `/$bunfs/` 里，该目录在磁盘上不存在（实测 `ls '/$bunfs/root/dashboard-web'` → No such file），`serveStatic` 的 `statSync` 抛错 → 返回 false → 落到兜底 404。这是 CLAUDE.md 记载的 `__dirname` 陷阱的**第二处**。
2. 更根本的：`bun build --compile` **只嵌入能静态追踪到的 import**，而前端产物与服务端模块之间没有任何 import 边 —— `build-bun-binary.mjs` 里 `dashboard-web` 出现 **0 次**，二进制里根本没有前端。

所以这不是「路径算错了、资源在别处」，而是「资源压根没进二进制」。

## 改法

编译时由 build plugin 把整个 `dist/dashboard-web` 以 `import … with { type: 'file' }` 注入 `dist/dashboard.js`，并生成「请求路径 → 嵌入路径」映射挂到 `globalThis.__BOTMUX_DASHBOARD_ASSETS__`；`serveStatic` 经由新增的 `resolveWebAsset()` 查表，源码态仍走磁盘目录。

| 文件 | 改动 |
|---|---|
| `scripts/generate-dashboard-embed.mjs`（新增） | 遍历 `dist/dashboard-web` 生成注入用的 import 序列 + 映射表 |
| `scripts/bun-native-embed-plugin.mjs` | 新增 `dist/dashboard.js` 的 `onLoad` 钩子做注入（与 node-pty 嵌入手法同源） |
| `src/dashboard.ts` | `resolveWebAsset()` 统一两种形态的资源定位；ETag 兼容嵌入文件 |
| `scripts/smoke-bun-binary.mjs` | 堵上让本 bug 溜过去的检测缺口（见下） |

### 几处不是风格选择、而是实测逼出来的

- **必须有映射表**，不能把 `WEB_DIR` 指向 `/$bunfs/root`：Bun 会给嵌入文件改成内容哈希名（实测 `index.html` → `index-c7k0x1v9.html`），请求路径无法直接寻址。扩展名被保留，所以按扩展名判 MIME 的逻辑不用动。
- **必须由 plugin 注入**，不能让服务端 import 生成文件：静态 `import './dashboard-web-embedded.js'` 会让 `tsc` 和任何纯源码 checkout 依赖一个只在 `dashboard:bundle` 后存在的产物；而运行时 `require()` **直接不成立** —— 实测 require 版本只 `bundle 1 modules`、嵌入 0 个资源，二进制照样整站 404。这条否掉了我的初版设计。
- **资产身份判定改用请求路径**（`relToRoot = rel`）：嵌入后 `fp` 是哈希改名过的虚拟路径，用 `relative(WEB_DIR, fp)` 会把每个资源都判错 —— chunk 拿不到 `immutable` 缓存、`index.html` 拿不到 CSRF 外壳注入。
- **ETag 折入 baked 版本号**：嵌入文件 `mtimeMs` 恒为 0（实测），原公式会退化成只按体积，整个发布周期内不失效。

### 安全

嵌入态查表天然挡住路径穿越（键是构建期白名单）。但**裸 `map[rel]` 对 `__proto__` / `constructor` / `toString` 会返回继承来的对象和函数**（实测），仅靠下游 `statSync` 抛错兜住不可靠 —— 故查表走 `hasOwnProperty` + 字符串校验，生成的映射表本身也用 `Object.create(null)`。源码态保留原有的「解析后必须仍在 WEB_DIR 内」防护。

## 顺带堵上的检测缺口

`smoke-bun-binary.mjs` 原注释写着：

> ANY HTTP status proves the listener bound (an unauthenticated `/` legitimately answers 404).

这个假设本身没错，但它让检查对「**因为没有前端而 404**」完全免疫 —— 于是它一路 ✅ 到发版。新增按**原因**而非状态码判别的检查：命中 `not_found_yet` 兜底即 fail。

## 影响面

只动 Dashboard 静态资源服务与编译流程，**不涉及**任何 CLI 适配器、后端（`PtyBackend` / `TmuxBackend`）、会话类型或 IM 层。源码 / npm 形态的代码路径除了多一层 `resolveWebAsset` 间接调用外行为不变（已回归验证）。

## 验证

均为**真编译版二进制**实测，不是单测推断。

**反向验证 —— 新 smoke 检查确实有牙：**

```
改前的 3.18.1-canary.2 二进制：
  smoke: ✅ http — dashboard is serving (status 404)      ← 旧检查，漏检现场
  smoke: FAIL [frontend] ... {"error":"not_found_yet","path":"/"}

修复后的二进制：
  smoke: ✅ http — dashboard is serving (status 200)      ← 404 → 200
  smoke: ✅ frontend — embedded Dashboard assets resolve
  smoke: all checks passed                                ← 7 项全绿
```

**浏览器完整流程**（`curl -L` + cookie jar）：

```
/                      → 200  1249B  text/html   真 SPA 外壳（含 <!doctype html>）
/assets/app.js         → 200  54103B             与 dist 体积逐字一致
/assets/style.css      → 200  859100B
/assets/design-tokens.css / brand-logo.png       → 200
/apple-touch-icon.png / favicon.ico              → 200
/workbench.webmanifest                           → 200
/assets/chunks/agent-workbench-dock-page-5GFLBHLQ.js
                       → 200  cache-control: public, max-age=31536000, immutable
```

最后一条同时佐证「资产身份判定用请求路径」这一改动生效 —— 用哈希名判会拿不到 `immutable`。

**ETag 协商**：首次 `W/"d357-embedded"`，带 `If-None-Match` 重取 → **304**。

**安全**：

```
/assets/../../../../etc/passwd          → 404，未泄露
/assets/..%2f..%2f..%2fetc%2fpasswd     → 404，未泄露
/assets/__proto__ / constructor / toString → 均 404
```

**源码态回归**（`node dist/index-dashboard.js`，无嵌入 manifest）：`/` → 200 真 SPA、资源全 200、ETag 仍是真实 mtime（`W/"d357-1a048992cfa"` 而非 `embedded`）、穿越仍被挡。

**测试**：dashboard 相关 6 个文件 **217 项全绿**；全量 5 files / 28 tests 失败，**无一项与 dashboard 相关**，且都在既存失败清单里（`dsh-runner` 22 项正是 `tsc` 报缺 yaml 模块那个文件）。`resource-monitor-darwin` 全量下失败、单跑 26/26 通过，属负载相关 flaky（与本改动零交集，文件内唯一出现 `dashboard` 的地方是一句注释）。`tsc` 除 `dsh-runner` 外零错误。
