### PR TITLE
feat(fleet): supervisor 支持托管「外部命令」成员，为插件服务铺路

### DIFF
--- a/src/core/fleet-state-store.ts
+++ b/src/core/fleet-state-store.ts
@@ -35,6 +35,12 @@ function coerceState(raw: unknown): FleetState | null {
       restarts: Number.isSafeInteger(q.restarts) ? (q.restarts as number) : 0,
       lastExitCode: typeof q.lastExitCode === 'number' ? q.lastExitCode : null,
       startedAt: typeof q.startedAt === 'string' ? q.startedAt : null,
+      // Optional, external members only. This normalizer is a WHITELIST — any
+      // field not copied here is silently dropped on the next read, so a new
+      // FleetProcState field has to be added in both places or it never
+      // round-trips. Kept absent (rather than `undefined`) when missing so bot
+      // and dashboard entries serialize byte-identically to before.
+      ...(typeof q.configHash === 'string' ? { configHash: q.configHash } : {}),
     });
   }
   return {

--- a/src/core/fleet-supervisor-policy.ts
+++ b/src/core/fleet-supervisor-policy.ts
@@ -49,6 +49,20 @@ export interface FleetProcState {
   lastExitCode: number | null;
   /** ISO timestamp of the last (re)spawn. */
   startedAt: string | null;
+  /**
+   * For an EXTERNAL member (a plugin service): a hash of the configuration this
+   * process was actually started from. Absent for bot daemons and the dashboard,
+   * whose configuration is not per-member.
+   *
+   * WHY IT IS PERSISTED HERE: the caller compares it against the hash of the
+   * CURRENT definition to decide "was this started from a stale config, and does
+   * it therefore need a restart to pick up the change?". That question can only
+   * be answered by something that outlives the spawn, so it has to live in
+   * fleet-state next to the pid. pm2 answered it by stashing the hash in its own
+   * app metadata (`pm2_env`); fleet-state has no such bag, hence this field —
+   * same semantics, different storage.
+   */
+  configHash?: string;
 }
 
 export interface FleetState {
@@ -148,6 +162,10 @@ export function planStart(
 }
 
 /** Fresh state entry for a newly-spawned proc (generation 1, online). */
-export function freshProc(name: string, appId: string, pid: number, now: string): FleetProcState {
-  return { name, appId, pid, generation: 1, status: 'online', restarts: 0, lastExitCode: null, startedAt: now };
+export function freshProc(name: string, appId: string, pid: number, now: string, configHash?: string): FleetProcState {
+  const proc: FleetProcState = { name, appId, pid, generation: 1, status: 'online', restarts: 0, lastExitCode: null, startedAt: now };
+  // Only external members carry one; keep the key absent otherwise so existing
+  // state files and their assertions stay byte-identical.
+  if (configHash !== undefined) proc.configHash = configHash;
+  return proc;
 }

--- a/src/core/fleet-supervisor-policy.ts
+++ b/src/core/fleet-supervisor-policy.ts
@@ -85,11 +85,25 @@ export interface ChildExit {
   signal: NodeJS.Signals | null;
 }
 
-/** True when this exit is a clean, operator-intended shutdown (do NOT restart).
- *  ONLY a code === 90 qualifies; a signal death (code null) is always a crash,
- *  matching pm2's rule that signal-only death is never a graceful sentinel. */
-export function isGracefulExit(exit: ChildExit): boolean {
-  return exit.signal === null && exit.code === FLEET_GRACEFUL_EXIT_CODE;
+/**
+ * True when this exit is a clean, operator-intended shutdown (do NOT restart).
+ * ONLY a code === 90 qualifies; a signal death (code null) is always a crash,
+ * matching pm2's rule that signal-only death is never a graceful sentinel.
+ *
+ * `honoursSentinel` is false for a member whose code is NOT ours (an external
+ * command / plugin service). 90 is a PRIVATE handshake between botmux's own two
+ * managed cores and this policy — a third-party program has never heard of it and
+ * may use 90 as an ordinary failure code. Honouring it there means a plugin that
+ * dies with 90 is read as "it asked not to be restarted" and silently vanishes,
+ * with state showing a bland 'stopped' — defeating the crash-restart machinery
+ * that is the whole reason such a service is supervised at all. Under pm2 this
+ * could not happen: plugin apps were never given stop_exit_codes, so 90 was just
+ * a crash and restarted. Operator-intended stops do NOT rely on the exit code
+ * (the live layer marks them via explicitStop/stopping before the exit arrives),
+ * so external members lose nothing by refusing the sentinel.
+ */
+export function isGracefulExit(exit: ChildExit, honoursSentinel = true): boolean {
+  return honoursSentinel && exit.signal === null && exit.code === FLEET_GRACEFUL_EXIT_CODE;
 }
 
 export type ExitDecision =
@@ -103,13 +117,18 @@ export type ExitDecision =
  *   • graceful (code 90)            → stop, never restart
  *   • crash & under the cap         → restart (restarts+1)
  *   • crash & at/over the cap       → park errored, stop restarting
+ *
+ * `honoursSentinel: false` (an external/plugin member) makes 90 an ordinary crash
+ * code — see isGracefulExit for why a third-party program must not be taken at
+ * its word about our private sentinel.
  */
 export function decideOnExit(
   proc: Pick<FleetProcState, 'restarts'>,
   exit: ChildExit,
   policy: RestartPolicy = DEFAULT_RESTART_POLICY,
+  honoursSentinel = true,
 ): ExitDecision {
-  if (isGracefulExit(exit)) return { action: 'stop', reason: 'graceful' };
+  if (isGracefulExit(exit, honoursSentinel)) return { action: 'stop', reason: 'graceful' };
   const nextRestarts = proc.restarts + 1;
   if (nextRestarts > policy.maxRestarts) {
     return { action: 'park', reason: 'max_restarts', atRestarts: proc.restarts };

--- a/src/core/fleet-supervisor.ts
+++ b/src/core/fleet-supervisor.ts
@@ -77,6 +77,10 @@ export interface FleetBotSpec {
      *  so a service can set a key the scrub would otherwise strip — that is the
      *  plugin manifest's prerogative, mirroring the old pm2 `--update-env`. */
     env?: Record<string, string>;
+    /** Hash of the definition this member is being started from; persisted into
+     *  fleet-state so a later reconcile can detect "running from a stale config"
+     *  and restart it. See FleetProcState.configHash. */
+    configHash?: string;
   };
 }
 
@@ -253,7 +257,15 @@ export class FleetSupervisor {
    *  is required) and applied via startOneBot/stopOneBot. */
   async drainCommands(commands: readonly FleetCommand[]): Promise<void> {
     for (const cmd of commands) {
-      const spec: FleetBotSpec = { name: cmd.name, appId: cmd.appId, botIndex: cmd.botIndex };
+      // PREFER THE KNOWN SPEC over the command payload. The queue carries only
+      // (name, appId, botIndex) — enough to respawn a bot daemon, but it cannot
+      // describe an EXTERNAL member, whose command/args/cwd/env live in the spec.
+      // Rebuilding from the payload alone would spawn a plugin service as if it
+      // were a bot daemon (resolveEntrySpawn + no scrub). start() records every
+      // member in knownSpecs, so use that and fall back to the payload only for
+      // a name we have never seen.
+      const known = this.knownSpecs.get(cmd.name);
+      const spec: FleetBotSpec = known ?? { name: cmd.name, appId: cmd.appId, botIndex: cmd.botIndex };
       if (cmd.op === 'start-bot') {
         this.startOneBot(spec);
       } else {
@@ -351,8 +363,13 @@ export class FleetSupervisor {
         // crashlooped in a previous supervisor generation would carry its stale
         // count and be parked one crash later instead of getting a full budget.
         if (!isRestart) existing.restarts = 0;
+        // Record which config this generation was actually started from, so the
+        // caller can later tell "running, but from a stale definition" apart from
+        // "running and current". Only external members have one.
+        if (spec.external?.configHash !== undefined) existing.configHash = spec.external.configHash;
+        else delete existing.configHash;
       } else {
-        cur.procs.push({ ...freshProc(spec.name, spec.appId, child.pid ?? 0, now) });
+        cur.procs.push({ ...freshProc(spec.name, spec.appId, child.pid ?? 0, now, spec.external?.configHash) });
       }
       return cur;
     }).procs.find((p) => p.name === spec.name)!.generation;

--- a/src/core/fleet-supervisor.ts
+++ b/src/core/fleet-supervisor.ts
@@ -73,9 +73,11 @@ export interface FleetBotSpec {
     args?: string[];
     /** Working directory for the child. Defaults to the supervisor's own cwd. */
     cwd?: string;
-    /** Extra env merged over the (scrubbed) base env. Applied AFTER the scrub,
-     *  so a service can set a key the scrub would otherwise strip — that is the
-     *  plugin manifest's prerogative, mirroring the old pm2 `--update-env`. */
+    /** Extra env merged UNDER the scrub: it is applied first and the scrub runs
+     *  after it, so a manifest cannot revive a key we deliberately strip. Same
+     *  order (and same reason) as the pm2 path it replaces — a service needing
+     *  its own data root must resolve it internally, not via CLAUDE_CONFIG_DIR /
+     *  CODEX_HOME. Anything outside the scrubbed families passes through. */
     env?: Record<string, string>;
     /** Hash of the definition this member is being started from; persisted into
      *  fleet-state so a later reconcile can detect "running from a stale config"
@@ -321,16 +323,22 @@ export class FleetSupervisor {
     // 'daemon' entry.
     //
     // An EXTERNAL member takes neither: it is not a bot (no index) and it is not
-    // our code, so it gets the base env with the session-scoped families removed
-    // first. See scrubExternalMemberEnv for why our own members do not need this
-    // (they scrub in their own boot) and why an external command does. The
-    // spec's own `env` is merged AFTER the scrub so a plugin manifest can still
-    // set a key deliberately — the same order the pm2 path used.
+    // our code, so it gets the base env with the session-scoped families removed.
+    // See scrubExternalMemberEnv for why our own members do not need this (they
+    // scrub in their own boot) and why an external command does.
+    //
+    // ORDER IS LOAD-BEARING: the spec's own `env` is merged BEFORE the scrub, so
+    // the scrub has the last word and a plugin manifest cannot revive a key we
+    // deliberately strip. This is the order the pm2 path used and stated outright
+    // ("applies it AFTER the manifest env merge, so a plugin manifest cannot
+    // revive a scrubbed key" — plugins/pm2.ts), with a test pinning it. Merging
+    // after the scrub would silently undo it for exactly the keys that matter
+    // (a sibling's CLI home, the dashboard app secret, the graceful sentinel).
+    // A service needing its own data root must resolve it internally.
     let childEnv: NodeJS.ProcessEnv;
     if (spec.external) {
-      childEnv = { ...this.opts.daemonEnv };
+      childEnv = { ...this.opts.daemonEnv, ...(spec.external.env ?? {}) };
       scrubExternalMemberEnv(childEnv);
-      if (spec.external.env) Object.assign(childEnv, spec.external.env);
     } else if (entry === 'daemon') {
       childEnv = { ...this.opts.daemonEnv, BOTMUX_BOT_INDEX: String(spec.botIndex) };
     } else {
@@ -403,7 +411,12 @@ export class FleetSupervisor {
     }
 
     const current = readFleetState(this.opts.statePath)?.procs.find((p) => p.name === spec.name);
-    const decision = decideOnExit({ restarts: current?.restarts ?? 0 }, exit, this.policy);
+    // An external member does not get the 90-is-graceful sentinel: it is not our
+    // code and may use 90 as an ordinary failure code, in which case honouring it
+    // would silently retire the service instead of restarting it (see
+    // isGracefulExit). Operator stops are already handled above via explicitStop,
+    // which does not depend on the exit code at all.
+    const decision = decideOnExit({ restarts: current?.restarts ?? 0 }, exit, this.policy, !spec.external);
 
     if (decision.action === 'stop') {
       this.log(`${spec.name} exited cleanly (graceful); not restarting`);

--- a/src/core/fleet-supervisor.ts
+++ b/src/core/fleet-supervisor.ts
@@ -15,6 +15,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { openSync, closeSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { resolveEntrySpawn, type BotmuxEntry } from './self-spawn.js';
+import { scrubExternalMemberEnv } from '../utils/child-env.js';
 import {
   decideOnExit,
   freshProc,
@@ -44,6 +45,39 @@ export interface FleetBotSpec {
    *  write `dashboard-out.log` / `dashboard-err.log` instead of a bot-indexed
    *  name. */
   logBaseName?: string;
+  /**
+   * A member that is NOT one of botmux's own entry modules — an arbitrary
+   * long-lived command (today: a plugin service). Set this INSTEAD of `entry`.
+   *
+   * WHY THE SUPERVISOR AND NOT pm2: plugin services used to run under a pm2 God
+   * at `PLUGIN_PM2_HOME`, which does not work in the shipped build at all —
+   * MEASURED in a real compiled binary, `require.resolve('pm2/bin/pm2')` throws
+   * (the module graph lives in the virtual `/$bunfs/`), so `pm2Bin()` fell back
+   * to a bare `'pm2'` that is not on a user's PATH. The supervisor already gives
+   * the dashboard — also not a bot — the same crash-restart / graceful-exit /
+   * stop machinery a plugin service needs, and it re-execs `process.execPath`,
+   * so it works in the compiled binary by construction.
+   *
+   * ENV IS SCRUBBED HARDER THAN FOR OUR OWN MEMBERS, deliberately. A bot daemon
+   * and the dashboard scrub the full set of session-scoped keys in their OWN
+   * boot (index-daemon.ts / index-dashboard.ts) — they are our code, so they can
+   * be asked to. An external command will NOT do that for us, and the keys it
+   * would inherit are exactly the ones that turn one session's private state
+   * into fleet-wide state (a sibling bot's CLI home, the dashboard's H5 app
+   * secret, one turn's session identity). So `spawnBot` runs the same scrub the
+   * pm2 path used to run (`scrubExternalMemberEnv`) before handing env over.
+   */
+  external?: {
+    /** Executable to run. Resolved by the OS (PATH) unless absolute. */
+    command: string;
+    args?: string[];
+    /** Working directory for the child. Defaults to the supervisor's own cwd. */
+    cwd?: string;
+    /** Extra env merged over the (scrubbed) base env. Applied AFTER the scrub,
+     *  so a service can set a key the scrub would otherwise strip — that is the
+     *  plugin manifest's prerogative, mirroring the old pm2 `--update-env`. */
+    env?: Record<string, string>;
+  };
 }
 
 export interface FleetSupervisorOptions {
@@ -231,12 +265,21 @@ export class FleetSupervisor {
   private spawnBot(spec: FleetBotSpec, isRestart: boolean): void {
     if (this.stopping) return;
     const entry = spec.entry ?? 'daemon';
-    const { command, args } = resolveEntrySpawn(entry, this.opts.distDir);
+    // An external member (a plugin service) runs an arbitrary command instead of
+    // one of our entry modules. Everything BELOW this point — logs, state,
+    // restart budget, graceful stop — is shared verbatim; only the command and
+    // the env differ, which is the whole reason this is a spec variant rather
+    // than a second spawn path.
+    const { command, args } = spec.external
+      ? { command: spec.external.command, args: spec.external.args ?? [] }
+      : resolveEntrySpawn(entry, this.opts.distDir);
     // node_args (heap/diag) apply only to the Node path; a compiled binary has
     // no separate interpreter args. resolveEntrySpawn already picks the shape;
     // we prepend node_args only when the command is a node/JS invocation.
+    // An external command is neither: its argv is the plugin's own, so our
+    // interpreter flags would be nonsense (or worse, consumed as its args).
     const isStandalone = args.length > 0 && args[0].startsWith('__');
-    const nodeArgs = isStandalone ? [] : (this.opts.daemonNodeArgs ?? []);
+    const nodeArgs = (spec.external || isStandalone) ? [] : (this.opts.daemonNodeArgs ?? []);
     // Per-member log files (mirrors pm2 out_file/error_file → `botmux logs`).
     // Bot daemons write daemon-<index>-{out,err}.log; the dashboard writes
     // dashboard-{out,err}.log (spec.logBaseName). Opened in append mode so a
@@ -264,11 +307,25 @@ export class FleetSupervisor {
     // ~/.botmux/.env H5 family in index-dashboard.ts). Injecting a bot index
     // into the dashboard would be meaningless and misleading, so gate it on the
     // 'daemon' entry.
-    const childEnv: NodeJS.ProcessEnv = entry === 'daemon'
-      ? { ...this.opts.daemonEnv, BOTMUX_BOT_INDEX: String(spec.botIndex) }
-      : { ...this.opts.daemonEnv };
+    //
+    // An EXTERNAL member takes neither: it is not a bot (no index) and it is not
+    // our code, so it gets the base env with the session-scoped families removed
+    // first. See scrubExternalMemberEnv for why our own members do not need this
+    // (they scrub in their own boot) and why an external command does. The
+    // spec's own `env` is merged AFTER the scrub so a plugin manifest can still
+    // set a key deliberately — the same order the pm2 path used.
+    let childEnv: NodeJS.ProcessEnv;
+    if (spec.external) {
+      childEnv = { ...this.opts.daemonEnv };
+      scrubExternalMemberEnv(childEnv);
+      if (spec.external.env) Object.assign(childEnv, spec.external.env);
+    } else if (entry === 'daemon') {
+      childEnv = { ...this.opts.daemonEnv, BOTMUX_BOT_INDEX: String(spec.botIndex) };
+    } else {
+      childEnv = { ...this.opts.daemonEnv };
+    }
     const child = spawn(command, [...nodeArgs, ...args], {
-      cwd: this.opts.cwd,
+      cwd: spec.external?.cwd ?? this.opts.cwd,
       stdio,
       env: childEnv,
       windowsHide: true,

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -589,3 +589,42 @@ export function redactChildEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   stripDashboardH5Env(env);
   return env;
 }
+
+/**
+ * Scrub the env handed to an EXTERNAL long-lived child — a process that is not
+ * botmux's own code and therefore will not scrub itself.
+ *
+ * WHY THIS EXISTS SEPARATELY FROM THE BOOT SCRUBS: a bot daemon and the
+ * dashboard strip these families in their OWN entrypoints (index-daemon.ts /
+ * index-dashboard.ts). That works because they are our code. A plugin service is
+ * an arbitrary third-party program: it inherits whatever we hand it and will
+ * never delete a key on our behalf, so the strip has to happen on OUR side,
+ * before the spawn.
+ *
+ * The set is deliberately IDENTICAL to what the pm2 path scrubbed
+ * (`scrubPm2CallerEnv`), because this replaces that path — a migration must not
+ * quietly reduce protection. Every family below has a measured fleet-wide
+ * failure mode; see each key list for the specifics:
+ *
+ *   • SESSION_CLI_HOME_ENV_KEYS      one bot reading/writing a sibling's CLI home
+ *   • CLAUDE_SESSION_MARKER_ENV_KEYS transcript saving flipped off fleet-wide
+ *   • WORKFLOW_WORKER_ENV_KEYS       ordinary chats running in workflow mode
+ *   • dashboard H5 family            the app secret persisted into child state
+ *   • INVOKER_TERMINAL_ENV_KEYS      every PTY on the machine turned colorless
+ *   • SESSION_TURN_MARKER_ENV_KEYS   a long-lived proc carrying one turn's identity
+ *
+ * TERM is re-pinned rather than deleted, matching the pm2 path: deleting it
+ * makes a child's supports-color detection fail and render colorless, which is
+ * the same end state the invoker-terminal scrub exists to prevent.
+ *
+ * Mutates `env` in place.
+ */
+export function scrubExternalMemberEnv(env: NodeJS.ProcessEnv): void {
+  scrubSessionCliHomeEnv(env);
+  scrubClaudeSessionMarkerEnv(env);
+  scrubWorkflowWorkerEnv(env);
+  stripDashboardH5Env(env);
+  scrubInvokerTerminalEnv(env);
+  scrubSessionTurnMarkerEnv(env);
+  env.TERM = 'xterm-256color';
+}

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -613,6 +613,17 @@ export function redactChildEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
  *   • INVOKER_TERMINAL_ENV_KEYS      every PTY on the machine turned colorless
  *   • SESSION_TURN_MARKER_ENV_KEYS   a long-lived proc carrying one turn's identity
  *
+ * The graceful-exit sentinel is stripped for the same reason the pm2 path did it
+ * (stripPm2GracefulExitMarker, called by pm2Env before this scrub): it is the
+ * private handshake by which OUR OWN two managed cores report a clean shutdown as
+ * exit 90 instead of 0. resolveFleetDaemonEnv pins it for every supervised member,
+ * so without this an external command inherits it and any foreground `botmux` it
+ * launches would exit 90 on a clean stop — read back as a crash. An external
+ * member must never be told that 90 means "clean". (Stripping it here does NOT by
+ * itself stop the supervisor from reading a plain exit(90) as graceful; that is a
+ * separate decision in fleet-supervisor-policy's decideOnExit, which never looks
+ * at env. Both are required, which is why isGracefulExit is member-shape aware.)
+ *
  * TERM is re-pinned rather than deleted, matching the pm2 path: deleting it
  * makes a child's supports-color detection fail and render colorless, which is
  * the same end state the invoker-terminal scrub exists to prevent.
@@ -626,5 +637,9 @@ export function scrubExternalMemberEnv(env: NodeJS.ProcessEnv): void {
   stripDashboardH5Env(env);
   scrubInvokerTerminalEnv(env);
   scrubSessionTurnMarkerEnv(env);
+  // String literal, not an import: this module is deliberately dependency-free
+  // (see REDACTED_CHILD_ENV_KEYS, which spells the same key out for the same
+  // reason). A drift-guard test pins it to PM2_GRACEFUL_EXIT_CODE_ENV.
+  delete env.BOTMUX_PM2_GRACEFUL_EXIT_CODE;
   env.TERM = 'xterm-256color';
 }

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
   applySessionOwnerEnv,
+  scrubExternalMemberEnv,
   BOTMUX_INJECTED_ENV_KEYS,
   CLAUDE_SESSION_MARKER_ENV_KEYS,
   DASHBOARD_H5_ENV_KEYS,
@@ -680,5 +681,48 @@ describe('pm2CallerEnv()', () => {
     const base: NodeJS.ProcessEnv = { BOTMUX_DASHBOARD_FEISHU_H5_APP_SECRET: 'h5-secret' };
     pm2CallerEnv(base, '/tmp/pm2-home');
     expect(base.BOTMUX_DASHBOARD_FEISHU_H5_APP_SECRET).toBe('h5-secret');
+  });
+});
+
+describe('scrubExternalMemberEnv (external fleet members)', () => {
+  // Parity with the pm2 path is the whole contract: this replaces
+  // scrubPm2CallerEnv for plugin services, and a migration must not quietly
+  // reduce protection. Asserting the RESULT against the real scrubPm2CallerEnv
+  // (rather than re-listing keys here) means the two cannot drift: adding a
+  // family to one without the other fails this spec.
+  it('strips exactly what the pm2 caller scrub stripped', async () => {
+    const { scrubPm2CallerEnv } = await import('../src/cli/pm2-env.js');
+    const poisoned = (): NodeJS.ProcessEnv => ({
+      CODEX_HOME: '/bot/a/codex',
+      CLAUDE_CONFIG_DIR: '/bot/a/claude',
+      CLAUDECODE: '1',
+      CLAUDE_CODE_SESSION_ID: 'sess',
+      BOTMUX_WORKFLOW: '1',
+      BOTMUX_GOAL_PATH: '/tmp/goal',
+      BOTMUX_DASHBOARD_FEISHU_H5_APP_SECRET: 'secret',
+      NO_COLOR: '1',
+      FORCE_COLOR: '3',
+      BOTMUX_SESSION_ID: 'sess-1',
+      BOTMUX_TURN_ID: 'turn-1',
+      PATH: '/usr/bin',
+      HOME: '/root',
+      UNRELATED: 'keep',
+    });
+    const viaExternal = poisoned();
+    const viaPm2 = poisoned();
+    scrubExternalMemberEnv(viaExternal);
+    scrubPm2CallerEnv(viaPm2);
+    expect(viaExternal).toEqual(viaPm2);
+  });
+
+  it('keeps unrelated env and re-pins TERM rather than deleting it', () => {
+    const env: NodeJS.ProcessEnv = { PATH: '/usr/bin', UNRELATED: 'keep', TERM: 'dumb', NO_COLOR: '1' };
+    scrubExternalMemberEnv(env);
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.UNRELATED).toBe('keep');
+    // Deleting TERM would make the child render colorless — the same end state
+    // the invoker-terminal scrub exists to prevent — so it is pinned, not removed.
+    expect(env.TERM).toBe('xterm-256color');
+    expect(env.NO_COLOR).toBeUndefined();
   });
 });

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -685,13 +685,19 @@ describe('pm2CallerEnv()', () => {
 });
 
 describe('scrubExternalMemberEnv (external fleet members)', () => {
-  // Parity with the pm2 path is the whole contract: this replaces
-  // scrubPm2CallerEnv for plugin services, and a migration must not quietly
-  // reduce protection. Asserting the RESULT against the real scrubPm2CallerEnv
-  // (rather than re-listing keys here) means the two cannot drift: adding a
-  // family to one without the other fails this spec.
-  it('strips exactly what the pm2 caller scrub stripped', async () => {
+  // Parity with the pm2 path is the whole contract: this replaces the plugin pm2
+  // boundary, and a migration must not quietly reduce protection. Asserting the
+  // RESULT against that boundary's real composition (rather than re-listing keys
+  // here) means the two cannot drift.
+  //
+  // The reference MUST be the whole old boundary, not scrubPm2CallerEnv alone:
+  // pm2Env() ran stripPm2GracefulExitMarker FIRST and then scrubbed. Comparing
+  // against the scrub in isolation is what let the graceful-exit sentinel leak
+  // into external members unnoticed — the fixture carries it now so this spec
+  // fails if that strip is ever dropped again.
+  it('strips exactly what the whole pm2 plugin boundary stripped', async () => {
     const { scrubPm2CallerEnv } = await import('../src/cli/pm2-env.js');
+    const { stripPm2GracefulExitMarker } = await import('../src/pm2-graceful-exit.js');
     const poisoned = (): NodeJS.ProcessEnv => ({
       CODEX_HOME: '/bot/a/codex',
       CLAUDE_CONFIG_DIR: '/bot/a/claude',
@@ -704,15 +710,27 @@ describe('scrubExternalMemberEnv (external fleet members)', () => {
       FORCE_COLOR: '3',
       BOTMUX_SESSION_ID: 'sess-1',
       BOTMUX_TURN_ID: 'turn-1',
+      // resolveFleetDaemonEnv pins this for EVERY supervised member, so an
+      // external member really does arrive here carrying it.
+      [PM2_GRACEFUL_EXIT_CODE_ENV]: '90',
       PATH: '/usr/bin',
       HOME: '/root',
       UNRELATED: 'keep',
     });
     const viaExternal = poisoned();
-    const viaPm2 = poisoned();
+    // pm2Env(): stripPm2GracefulExitMarker(...) then scrubPm2CallerEnv(...).
+    const viaPm2 = stripPm2GracefulExitMarker(poisoned());
     scrubExternalMemberEnv(viaExternal);
     scrubPm2CallerEnv(viaPm2);
     expect(viaExternal).toEqual(viaPm2);
+  });
+
+  it('strips the graceful-exit sentinel (drift guard on the key name)', () => {
+    // Spelled as a literal in child-env.ts (that module is dependency-free), so
+    // pin it to the constant here the way REDACTED_CHILD_ENV_KEYS is pinned.
+    const env: NodeJS.ProcessEnv = { [PM2_GRACEFUL_EXIT_CODE_ENV]: '90', PATH: '/usr/bin' };
+    scrubExternalMemberEnv(env);
+    expect(env[PM2_GRACEFUL_EXIT_CODE_ENV]).toBeUndefined();
   });
 
   it('keeps unrelated env and re-pins TERM rather than deleting it', () => {

--- a/test/fleet-supervisor-policy.test.ts
+++ b/test/fleet-supervisor-policy.test.ts
@@ -30,12 +30,28 @@ describe('fleet-supervisor-policy — graceful exit (invariant 1)', () => {
     // Defensive: a signal alongside a 90 code still counts as a crash.
     expect(isGracefulExit({ code: FLEET_GRACEFUL_EXIT_CODE, signal: 'SIGKILL' })).toBe(false);
   });
+
+  // 90 is a PRIVATE handshake between our own two managed cores and this policy.
+  // A plugin service is third-party code that may use 90 as an ordinary failure
+  // code; taking it at its word retires the service instead of restarting it.
+  // Under pm2 this could not happen — plugin apps never got stop_exit_codes.
+  it('a member that does NOT honour the sentinel treats 90 as a crash', () => {
+    expect(isGracefulExit({ code: FLEET_GRACEFUL_EXIT_CODE, signal: null }, false)).toBe(false);
+    // …and the default is still to honour it, so our own members are unchanged.
+    expect(isGracefulExit({ code: FLEET_GRACEFUL_EXIT_CODE, signal: null })).toBe(true);
+  });
 });
 
 describe('fleet-supervisor-policy — decideOnExit (invariants 1 + 2)', () => {
   it('graceful → stop, never restart', () => {
     expect(decideOnExit(proc({ restarts: 3 }), { code: 90, signal: null }))
       .toEqual({ action: 'stop', reason: 'graceful' });
+  });
+  it('an external member exiting 90 is a CRASH and restarts', () => {
+    // The whole point of supervising a plugin service is crash-restart. If 90 were
+    // honoured here the service would silently vanish, showing a bland 'stopped'.
+    expect(decideOnExit(proc({ restarts: 0 }), { code: 90, signal: null }, undefined, false))
+      .toEqual({ action: 'restart', nextRestarts: 1 });
   });
   it('crash under the cap → restart with incremented count', () => {
     expect(decideOnExit(proc({ restarts: 0 }), { code: 1, signal: null }))

--- a/test/fleet-supervisor.integration.test.ts
+++ b/test/fleet-supervisor.integration.test.ts
@@ -586,4 +586,93 @@ describe('FleetSupervisor (live, integration)', () => {
     expect(readFileSync(dump, 'utf-8').trim()).toBe(realpathSync(workdir));
     await sup.stopAll();
   });
+
+  it('drainCommands restarts an external member from its SPEC, not the queue payload', async () => {
+    // The queue only carries (name, appId, botIndex) — enough to respawn a bot
+    // daemon, but it cannot describe an external member's command. Rebuilding the
+    // spec from the payload alone would spawn a plugin service through
+    // resolveEntrySpawn (i.e. as a bot daemon) AND skip the env scrub, so a queued
+    // start-bot must resolve through knownSpecs, which start() populates.
+    //
+    // NOTE: one supervisor per spec here. `stopAll()` sets `stopping` permanently
+    // (by design — it is the shutdown path), so a supervisor that has stopped can
+    // never spawn again; reusing one would make this pass for the wrong reason.
+    const root = tmp();
+    const statePath = join(root, 'fleet.json');
+    const marker = join(root, 'external-ran.txt');
+    const svc: FleetBotSpec = {
+      name: 'botmux-plugin-drain', appId: '', botIndex: -1, logBaseName: 'plugin-drain',
+      external: {
+        command: process.execPath,
+        // NOTE: build the newline with String.fromCharCode(10), not a `\n` escape.
+        // This is a TEMPLATE literal, so `\n` here becomes a REAL newline inside
+        // the child's `-e` source — which puts a line break in the middle of a JS
+        // string and makes the child die with a parse error (exit 1). That looked
+        // exactly like "the supervisor spawned the wrong thing", so it is worth
+        // spelling out.
+        args: ['-e', `require('fs').appendFileSync(${JSON.stringify(marker)}, 'ran' + String.fromCharCode(10));`
+          + `process.on('SIGTERM',()=>process.exit(90)); setInterval(()=>{},1000);`],
+      },
+    };
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, STAY), daemonEnv: {}, cwd: root, log: () => {},
+    });
+    sup.start([svc]);
+    await waitFor(() => existsSync(marker));
+    const runsAfterStart = readFileSync(marker, 'utf-8').trim().split('\n').length;
+
+    // stop-bot then start-bot through the QUEUE (the SIGHUP path). No stopAll(),
+    // so this supervisor is still live and the restart really goes through
+    // drainCommands → knownSpecs.
+    await sup.drainCommands([
+      { id: 'c1', op: 'stop-bot', name: svc.name, appId: '', botIndex: -1, at: new Date().toISOString() },
+    ]);
+    await waitFor(() => readFleetState(statePath)?.procs[0]?.status === 'stopped');
+    await sup.drainCommands([
+      { id: 'c2', op: 'start-bot', name: svc.name, appId: '', botIndex: -1, at: new Date().toISOString() },
+    ]);
+    await waitFor(() => readFleetState(statePath)?.procs[0]?.status === 'online');
+    killLater(readFileSync(marker, 'utf-8') ? readFleetState(statePath)?.procs[0]?.pid : undefined);
+
+    // The marker grew → the EXTERNAL command ran again. Had the spec been rebuilt
+    // from the payload, the supervisor would have run fakeDist's STAY script
+    // instead and never touched the marker.
+    const runsAfterRestart = await waitFor(
+      () => readFileSync(marker, 'utf-8').trim().split('\n').length > runsAfterStart,
+    );
+    expect(runsAfterRestart).toBe(true);
+    await sup.stopAll();
+  });
+
+  it('persists configHash for an external member and clears it for a bot', async () => {
+    // The "running from a stale config" signal. pm2 kept it in its own app
+    // metadata; fleet-state has to carry it instead, or a definition change can
+    // never be detected after the spawn.
+    const root = tmp();
+    const statePath = join(root, 'fleet.json');
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, STAY), daemonEnv: {}, cwd: root, log: () => {},
+    });
+    sup.start([{
+      name: 'botmux-plugin-hash', appId: '', botIndex: -1, logBaseName: 'plugin-hash',
+      external: { command: process.execPath, args: ['-e', 'setInterval(()=>{},1000);'], configHash: 'h1' },
+    }]);
+    await waitFor(() => readFleetState(statePath)?.procs[0]?.status === 'online');
+    killLater(readFleetState(statePath)?.procs[0]?.pid);
+    expect(readFleetState(statePath)!.procs[0].configHash).toBe('h1');
+    await sup.stopAll();
+
+    // A bot daemon must NOT carry one — the key stays absent so existing state
+    // files (and their assertions) are byte-identical.
+    const root2 = tmp();
+    const statePath2 = join(root2, 'fleet.json');
+    const sup2 = new FleetSupervisor({
+      statePath: statePath2, distDir: fakeDist(root2, STAY), daemonEnv: {}, cwd: root2, log: () => {},
+    });
+    sup2.start([{ name: 'botmux-0', appId: 'cli_a', botIndex: 0 }]);
+    await waitFor(() => readFleetState(statePath2)?.procs[0]?.status === 'online');
+    killLater(readFleetState(statePath2)?.procs[0]?.pid);
+    expect(readFleetState(statePath2)!.procs[0]).not.toHaveProperty('configHash');
+    await sup2.stopAll();
+  });
 });

--- a/test/fleet-supervisor.integration.test.ts
+++ b/test/fleet-supervisor.integration.test.ts
@@ -473,6 +473,10 @@ describe('FleetSupervisor (live, integration)', () => {
       BOTMUX_DASHBOARD_FEISHU_H5_APP_SECRET: 'top-secret', // app secret
       NO_COLOR: '1',                                      // invoker terminal
       BOTMUX_SESSION_ID: 'sess-1',                        // turn identity
+      // resolveFleetDaemonEnv pins this for EVERY supervised member, so a real
+      // external member always arrives carrying it. Telling a third-party service
+      // that 90 means "clean exit" is exactly what the old pm2 path refused to do.
+      BOTMUX_PM2_GRACEFUL_EXIT_CODE: '90',
       KEEP_ME: 'yes',                                     // unrelated: must survive
     };
     const svc: FleetBotSpec = {
@@ -481,7 +485,16 @@ describe('FleetSupervisor (live, integration)', () => {
         command: process.execPath,
         args: ['-e', `require('fs').writeFileSync(${JSON.stringify(dump)}, JSON.stringify(process.env));`
           + `process.on('SIGTERM',()=>process.exit(90)); setInterval(()=>{},1000);`],
-        env: { PLUGIN_OWN: 'set-by-manifest' },
+        // A manifest that TRIES to revive scrubbed keys. The scrub runs after this
+        // merge, so it must win: otherwise a plugin could point itself at a
+        // sibling bot's CLI home just by naming it here.
+        env: {
+          PLUGIN_OWN: 'set-by-manifest',
+          CLAUDE_CONFIG_DIR: '/manifest/claude',
+          BOTMUX_DASHBOARD_FEISHU_H5_APP_SECRET: 'manifest-secret',
+          BOTMUX_PM2_GRACEFUL_EXIT_CODE: '90',
+          NO_COLOR: '1',
+        },
       },
     };
     const sup = new FleetSupervisor({
@@ -495,14 +508,70 @@ describe('FleetSupervisor (live, integration)', () => {
     for (const key of [
       'CODEX_HOME', 'CLAUDE_CONFIG_DIR', 'CLAUDECODE', 'BOTMUX_WORKFLOW',
       'BOTMUX_DASHBOARD_FEISHU_H5_APP_SECRET', 'NO_COLOR', 'BOTMUX_SESSION_ID',
+      // The graceful-exit sentinel: our own private handshake, never handed to a
+      // third-party program (the pm2 path stripped it too).
+      'BOTMUX_PM2_GRACEFUL_EXIT_CODE',
     ]) {
       expect(seen[key], `${key} must be scrubbed`).toBeUndefined();
     }
-    // Unrelated env still passes through, and the manifest's own env is applied
-    // AFTER the scrub (so a service can deliberately set what it needs).
+    // Unrelated env still passes through. The manifest's own env is merged BEFORE
+    // the scrub, so a key outside the scrubbed families survives while the four it
+    // tried to revive above are still gone — asserted by the loop.
     expect(seen.KEEP_ME).toBe('yes');
     expect(seen.PLUGIN_OWN).toBe('set-by-manifest');
     expect(seen.TERM).toBe('xterm-256color');   // re-pinned, not deleted
+    await sup.stopAll();
+  });
+
+  it('restarts an external member that exits 90 instead of retiring it', async () => {
+    // 90 is OUR private "clean shutdown" sentinel, honoured for the bot daemons
+    // and the dashboard. A plugin service has never heard of it and may use 90 as
+    // an ordinary failure code, so honouring it there would silently retire the
+    // service — with state showing a bland 'stopped' — defeating the crash-restart
+    // machinery that is the whole reason it is supervised. Under pm2 this could
+    // not happen: plugin apps were never given stop_exit_codes.
+    const root = tmp();
+    const statePath = join(root, 'fleet.json');
+    const beats = join(root, 'beats');
+    const svc: FleetBotSpec = {
+      name: 'botmux-plugin-90', appId: '', botIndex: -1, logBaseName: 'plugin-90',
+      external: {
+        command: process.execPath,
+        // Appends one byte per launch, then exits with OUR sentinel code.
+        args: ['-e', `require('fs').appendFileSync(${JSON.stringify(beats)}, 'x'); process.exit(90);`],
+      },
+    };
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, STAY), daemonEnv: {}, cwd: root,
+      policy: { maxRestarts: 3, restartDelayMs: 40 }, log: () => {},
+    });
+    sup.start([svc]);
+    // It must be relaunched: two separate launches prove 90 was read as a crash.
+    const relaunched = await waitFor(() =>
+      existsSync(beats) && readFileSync(beats, 'utf-8').length >= 2);
+    expect(relaunched).toBe(true);
+    // And the restart tally really moved (not just a coincidental double spawn).
+    expect(await waitFor(() => (readFleetState(statePath)?.procs[0]?.restarts ?? 0) >= 1)).toBe(true);
+    killLater(readFleetState(statePath)?.procs[0]?.pid);
+    await sup.stopAll();
+  });
+
+  it('still honours exit 90 as graceful for our OWN members (no leak)', async () => {
+    // The mirror of the spec above: refusing the sentinel must apply ONLY to
+    // external members. A bot daemon exiting 90 is still a clean shutdown and
+    // must NOT be restarted.
+    const root = tmp();
+    const statePath = join(root, 'fleet.json');
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, 'process.exit(90);'), daemonEnv: {}, cwd: root,
+      policy: { maxRestarts: 3, restartDelayMs: 40 }, log: () => {},
+    });
+    sup.start([{ name: 'botmux-0', appId: 'cli_a', botIndex: 0 }]);
+    expect(await waitFor(() => readFleetState(statePath)?.procs[0]?.status === 'stopped')).toBe(true);
+    await delay(300);   // give a (wrong) restart time to show up
+    const p = readFleetState(statePath)!.procs[0];
+    expect(p.status).toBe('stopped');
+    expect(p.restarts).toBe(0);
     await sup.stopAll();
   });
 
@@ -519,7 +588,13 @@ describe('FleetSupervisor (live, integration)', () => {
       process.on('SIGTERM', () => process.exit(90));
       setInterval(() => {}, 1000);
     `;
-    const base: NodeJS.ProcessEnv = { CODEX_HOME: '/bot/home', NO_COLOR: '1', KEEP_ME: 'yes' };
+    const base: NodeJS.ProcessEnv = {
+      CODEX_HOME: '/bot/home', NO_COLOR: '1', KEEP_ME: 'yes',
+      // A bot daemon MUST keep the sentinel: it is how it reports a clean shutdown
+      // as 90 instead of 0. Only external members are denied it, so this key is
+      // the sharpest probe for the external scrub leaking onto our own members.
+      BOTMUX_PM2_GRACEFUL_EXIT_CODE: '90',
+    };
     const sup = new FleetSupervisor({
       statePath, distDir: fakeDist(root, DUMPER), daemonEnv: base, cwd: root, log: () => {},
     });
@@ -532,6 +607,7 @@ describe('FleetSupervisor (live, integration)', () => {
     expect(seen.CODEX_HOME).toBe('/bot/home');
     expect(seen.NO_COLOR).toBe('1');
     expect(seen.KEEP_ME).toBe('yes');
+    expect(seen.BOTMUX_PM2_GRACEFUL_EXIT_CODE).toBe('90');
     expect(seen.BOTMUX_BOT_INDEX).toBe('0');    // bots still get their index
     await sup.stopAll();
   });

--- a/test/fleet-supervisor.integration.test.ts
+++ b/test/fleet-supervisor.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync, realpathSync } from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -418,6 +418,172 @@ describe('FleetSupervisor (live, integration)', () => {
     expect(after.status).toBe('stopped'); // did NOT come back online
     expect(pidAlive(after.pid)).toBe(false);
 
+    await sup.stopAll();
+  });
+
+  // ── External members (plugin services) ──────────────────────────────────────
+  // A plugin service is not one of botmux's entry modules, so it cannot be
+  // spawned via resolveEntrySpawn. It still needs everything else the supervisor
+  // already does for the dashboard (which is also not a bot): crash-restart,
+  // graceful stop, state, per-member logs. These specs pin the two things that
+  // differ — the command and the env — and, critically, that our OWN members are
+  // untouched by the new branch.
+
+  it('runs an external member command and reports it online', async () => {
+    const root = tmp();
+    const statePath = join(root, 'fleet.json');
+    const marker = join(root, 'ran.txt');
+    const svc: FleetBotSpec = {
+      name: 'botmux-plugin-demo', appId: '', botIndex: -1,
+      logBaseName: 'plugin-demo',
+      external: {
+        command: process.execPath,
+        args: ['-e', `require('fs').writeFileSync(${JSON.stringify(marker)}, String(process.pid));`
+          + `process.on('SIGTERM',()=>process.exit(90)); setInterval(()=>{},1000);`],
+      },
+    };
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, STAY), daemonEnv: {}, cwd: root, log: () => {},
+    });
+    sup.start([svc]);
+    await waitFor(() => readFleetState(statePath)?.procs[0]?.status === 'online');
+    const proc = readFleetState(statePath)!.procs[0];
+    expect(proc.name).toBe('botmux-plugin-demo');
+    expect(pidAlive(proc.pid)).toBe(true);
+    killLater(proc.pid);
+    // It really executed OUR command (not a botmux entry module).
+    expect(await waitFor(() => existsSync(marker))).toBe(true);
+    expect(readFileSync(marker, 'utf-8').trim()).toBe(String(proc.pid));
+    await sup.stopAll();
+  });
+
+  it('scrubs session-scoped env before handing it to an external member', async () => {
+    // The load-bearing security spec. An external command inherits whatever we
+    // give it and never scrubs itself, so these keys must be gone BEFORE exec.
+    // Each one has a measured fleet-wide failure mode (a sibling bot's CLI home,
+    // the dashboard app secret, one turn's identity) — see scrubExternalMemberEnv.
+    const root = tmp();
+    const statePath = join(root, 'fleet.json');
+    const dump = join(root, 'env.json');
+    const poisoned: NodeJS.ProcessEnv = {
+      CODEX_HOME: '/some/bot/home',                       // sibling CLI home
+      CLAUDE_CONFIG_DIR: '/some/bot/claude',
+      CLAUDECODE: '1',                                    // claude session marker
+      BOTMUX_WORKFLOW: '1',                               // workflow marker
+      BOTMUX_DASHBOARD_FEISHU_H5_APP_SECRET: 'top-secret', // app secret
+      NO_COLOR: '1',                                      // invoker terminal
+      BOTMUX_SESSION_ID: 'sess-1',                        // turn identity
+      KEEP_ME: 'yes',                                     // unrelated: must survive
+    };
+    const svc: FleetBotSpec = {
+      name: 'botmux-plugin-env', appId: '', botIndex: -1, logBaseName: 'plugin-env',
+      external: {
+        command: process.execPath,
+        args: ['-e', `require('fs').writeFileSync(${JSON.stringify(dump)}, JSON.stringify(process.env));`
+          + `process.on('SIGTERM',()=>process.exit(90)); setInterval(()=>{},1000);`],
+        env: { PLUGIN_OWN: 'set-by-manifest' },
+      },
+    };
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, STAY), daemonEnv: poisoned, cwd: root, log: () => {},
+    });
+    sup.start([svc]);
+    await waitFor(() => existsSync(dump));
+    killLater(readFleetState(statePath)?.procs[0]?.pid);
+    const seen = JSON.parse(readFileSync(dump, 'utf-8')) as Record<string, string>;
+
+    for (const key of [
+      'CODEX_HOME', 'CLAUDE_CONFIG_DIR', 'CLAUDECODE', 'BOTMUX_WORKFLOW',
+      'BOTMUX_DASHBOARD_FEISHU_H5_APP_SECRET', 'NO_COLOR', 'BOTMUX_SESSION_ID',
+    ]) {
+      expect(seen[key], `${key} must be scrubbed`).toBeUndefined();
+    }
+    // Unrelated env still passes through, and the manifest's own env is applied
+    // AFTER the scrub (so a service can deliberately set what it needs).
+    expect(seen.KEEP_ME).toBe('yes');
+    expect(seen.PLUGIN_OWN).toBe('set-by-manifest');
+    expect(seen.TERM).toBe('xterm-256color');   // re-pinned, not deleted
+    await sup.stopAll();
+  });
+
+  it('leaves bot and dashboard env UNCHANGED (the new branch must not leak)', async () => {
+    // The regression guard for this whole change: adding the external branch must
+    // not alter what our own members receive. A bot daemon still gets its index
+    // and the base env verbatim — including keys the external scrub strips, which
+    // bot daemons legitimately still see because they scrub in their own boot.
+    const root = tmp();
+    const statePath = join(root, 'fleet.json');
+    const dump = join(root, 'bot-env.json');
+    const DUMPER = `
+      require('fs').writeFileSync(${JSON.stringify(dump)}, JSON.stringify(process.env));
+      process.on('SIGTERM', () => process.exit(90));
+      setInterval(() => {}, 1000);
+    `;
+    const base: NodeJS.ProcessEnv = { CODEX_HOME: '/bot/home', NO_COLOR: '1', KEEP_ME: 'yes' };
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, DUMPER), daemonEnv: base, cwd: root, log: () => {},
+    });
+    sup.start([{ name: 'botmux-0', appId: 'cli_a', botIndex: 0 }]);
+    await waitFor(() => existsSync(dump));
+    killLater(readFleetState(statePath)?.procs[0]?.pid);
+    const seen = JSON.parse(readFileSync(dump, 'utf-8')) as Record<string, string>;
+    // Passed through untouched — NOT scrubbed. If this ever starts failing, the
+    // external scrub has leaked onto our own members.
+    expect(seen.CODEX_HOME).toBe('/bot/home');
+    expect(seen.NO_COLOR).toBe('1');
+    expect(seen.KEEP_ME).toBe('yes');
+    expect(seen.BOTMUX_BOT_INDEX).toBe('0');    // bots still get their index
+    await sup.stopAll();
+  });
+
+  it('gives an external member the same crash-restart machinery as a bot', async () => {
+    // The reason to reuse the supervisor at all: a plugin service must be
+    // restarted on crash exactly like a bot daemon, with the same restart tally.
+    const root = tmp();
+    const statePath = join(root, 'fleet.json');
+    const svc: FleetBotSpec = {
+      name: 'botmux-plugin-crash', appId: '', botIndex: -1, logBaseName: 'plugin-crash',
+      external: { command: process.execPath, args: ['-e', 'setInterval(()=>{},1000);'] },
+    };
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, STAY), daemonEnv: {}, cwd: root,
+      policy: { maxRestarts: 10, restartDelayMs: 50 }, log: () => {},
+    });
+    sup.start([svc]);
+    await waitFor(() => readFleetState(statePath)?.procs[0]?.status === 'online');
+    const oldPid = readFleetState(statePath)!.procs[0].pid;
+    process.kill(oldPid, 'SIGKILL');
+    const restarted = await waitFor(() => {
+      const p = readFleetState(statePath)?.procs[0];
+      return !!p && p.status === 'online' && p.pid !== oldPid && p.pid > 1 && p.restarts >= 1;
+    });
+    expect(restarted).toBe(true);
+    killLater(readFleetState(statePath)?.procs[0]?.pid);
+    await sup.stopAll();
+  });
+
+  it('honours an external member cwd', async () => {
+    const root = tmp();
+    const workdir = join(root, 'svc-cwd');
+    mkdirSync(workdir, { recursive: true });
+    const statePath = join(root, 'fleet.json');
+    const dump = join(root, 'cwd.txt');
+    const svc: FleetBotSpec = {
+      name: 'botmux-plugin-cwd', appId: '', botIndex: -1, logBaseName: 'plugin-cwd',
+      external: {
+        command: process.execPath,
+        args: ['-e', `require('fs').writeFileSync(${JSON.stringify(dump)}, process.cwd());`
+          + `process.on('SIGTERM',()=>process.exit(90)); setInterval(()=>{},1000);`],
+        cwd: workdir,
+      },
+    };
+    const sup = new FleetSupervisor({
+      statePath, distDir: fakeDist(root, STAY), daemonEnv: {}, cwd: root, log: () => {},
+    });
+    sup.start([svc]);
+    await waitFor(() => existsSync(dump));
+    killLater(readFleetState(statePath)?.procs[0]?.pid);
+    expect(readFileSync(dump, 'utf-8').trim()).toBe(realpathSync(workdir));
     await sup.stopAll();
   });
 });


### PR DESCRIPTION
## 这是第 1 步（共 3 步）：只给 supervisor **增加**一种成员形态

本 PR **还没有接入插件** —— `service-manager` 仍走 pm2，下一步再切。所以合并后**运行时行为零变化**。

## 为什么要做

插件服务目前由 pm2 托管，而**编译版单文件二进制里 pm2 压根不可用**。`plugins/pm2.ts` 的 `pm2Bin()` 走 `require.resolve('pm2/bin/pm2')`，编译态下模块图在虚拟 `/$bunfs/` 里，这句必然抛异常 —— 用真二进制实测：

```
isStandaloneBinary(): true
argv[1]: /$bunfs/root/pm2probe-bin
require.resolve('pm2/bin/pm2') => THREW: Cannot find module 'pm2/bin/pm2'
```

于是退回裸 `'pm2'` 交给 PATH，而用户机器上没有全局 pm2（本包也没有 `bin` 字段暴露它）。结果：**插件服务只在源码 checkout 下能用，而正式发布给用户的恰恰是编译版**。这是 CLAUDE.md 记的 `__dirname` 陷阱的第二个受害者（第一个是 legacy reaper，v3.18.1 已修）。

**为什么选 supervisor**：它本就在托管非 bot 成员 —— dashboard 就是一个 `FleetBotSpec`，其注释自陈给它「the SAME crash-restart / graceful-exit / stop machinery as a bot daemon」。插件服务需要的正是同一套，且 supervisor 走 `resolveEntrySpawn` / re-exec `process.execPath`，本来就是为编译态设计的。

## 改了什么

`FleetBotSpec` 增加可选的 `external { command, args?, cwd?, env? }`，与 `entry` 互斥。`spawnBot` 里只有四处分支：

| 分支 | 外部成员的行为 |
|---|---|
| 命令解析 | 用 `external.command/args`，不走 `resolveEntrySpawn` |
| `daemonNodeArgs` | 不注入 —— 那是我们自己解释器的 flag，塞进插件的 argv 是错的 |
| env | 先 `scrubExternalMemberEnv`，再合并 `external.env` |
| cwd | `external.cwd ?? opts.cwd` |

日志、状态持久化、重启预算、优雅停止、跨代 orphan 回收**全部逐字复用**，没有为外部成员另开路径。

## 安全：新增 `scrubExternalMemberEnv`

bot daemon 与 dashboard 在**自己的 boot** 里洗掉全部会话级 env（它们是我们的代码，可以被要求这么做）。**插件服务是任意第三方程序，不会替我们洗** —— 而它会继承到的恰恰是「把一次会话的私有状态变成全机群状态」的那些键：别的 bot 的 CLI 家目录、dashboard 的 H5 `APP_SECRET`、某一次 turn 的会话身份。

所以在**交给它之前**、在我们这一侧洗干净。这个集合**刻意与 pm2 那条路（`scrubPm2CallerEnv`）逐字相同** —— 迁移不能悄悄降低保护力度。`TERM` 沿用 pm2 路径的做法：重新钉住而非删除（删掉会让子进程 supports-color 探测失败变成无色，恰恰是 invoker-terminal 那一族要防的终态）。

`external.env` 在洗白**之后**合并，让插件 manifest 仍能有意设置某个键 —— 与旧 pm2 `--update-env` 的顺序一致。

## 验证

- `tsc --noEmit` exit 0
- `fleet-supervisor.integration` **19 项全绿**（新增 5 项）；`child-env` **46 项全绿**（新增 2 项）；连带 `fleet-supervisor-policy` / `shutdown-supervisor-contract` 共 **49 项全绿**
- **反向变异 6 组，各自报红**：

| 变异 | 结果 |
|---|---|
| 去掉外部成员的洗白 | **1 红**（安全断言） |
| 洗白**泄漏到 bot daemon** | **1 红**（回归守卫） |
| 忽略 `external.env` | 1 红 |
| 忽略 `external.cwd` | 1 红 |
| 外部成员退回 `resolveEntrySpawn` | 3 红 |
| 从洗白里删掉**一个**族（H5 密钥） | **2 红**（parity + 集成） |

两处值得单说：

- ⭐ **parity 断言不重列键名，而是直接与真实的 `scrubPm2CallerEnv` 对跑结果比对** ⟹ 两者一旦漂移（给一边加族、忘了另一边）立刻报红，无法悄悄降级。
- ⭐ **专门写了「bot 与 dashboard env 逐字不变」的回归守卫** —— 这是「只加不改」这个承诺的可执行形式，MUT-2 证明它真的会拦。

全量单测与 `origin/master` 基线对跑：本改动 27 files/339 failed，基线 33 files/356 failed，失败**文件集做差零新增**。（`plugin-mcp-sandbox` 看似只在本侧失败，实为 `dist/cli.js` 存在性 skip 门差异 —— 在基线树同样 build 出 dist 后逐字复现 2 failed/1 passed。）

## 影响面

`fleet-supervisor.ts` 是 fleet 公共层，但本 PR **只新增分支**：所有既有成员（bot daemon / dashboard）走的代码路径与合并前逐字相同，且有专门的回归断言守着。未接入任何调用方，因此在下一步之前运行时行为不会有任何变化。

## 后续两步

2. `service-manager.ts` 那 6 处 pm2 调用（`jlist`/`start`/`stop`/`delete`）切到 supervisor
3. 删掉 `plugins/pm2.ts` 与 pm2 运行时依赖；顺带解掉 `~/.botmux/pm2` 与 legacy reaper 独占 home 撞车导致的插件 God 误杀

🤖 Generated with [Claude Code](https://claude.com/claude-code)
