### PR TITLE
fix(send): 收敛引用时的说明改走 console.error，生产可见

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8820,10 +8820,13 @@ async function cmdSend(rest: string[]): Promise<void> {
       currentThreadId: probedThreadId,
       explicitQuote,
     })) {
-      logger.info(
-        `[send] quote target ${quoteTargetId.substring(0, 12)} was answered flat at top level but now `
-        + `belongs to topic ${String(probedThreadId).substring(0, 12)}; posting flat instead of quoting `
-        + 'so the reply does not land in an after-the-fact topic',
+      // `botmux send` 是短命 CLI 进程，它的 logger 不汇进 daemon 的 out.log ——
+      // 实测用 logger.info 写这条时，daemon 日志里一条都查不到，排查价值为零。
+      // CLI 侧的既有惯例是 console.error（stderr 会被 worker 收进会话日志）。
+      console.error(
+        `[send] 引用目标 ${quoteTargetId.substring(0, 12)} 当初是顶层平铺答复的，`
+        + `但它现在已属于话题 ${String(probedThreadId).substring(0, 12)}；`
+        + '本条改为平铺发送，避免回复落进事后创建的话题',
       );
       effectiveQuoteTargetId = undefined;
     }

--- a/test/send-after-the-fact-topic-quote-wiring.test.ts
+++ b/test/send-after-the-fact-topic-quote-wiring.test.ts
@@ -51,7 +51,7 @@ describe('botmux send: 事后开的话题不再被 quote 带进去（接线）',
     // 且它落在判据的 if 块里。
     const idx = lines.findIndex(l => l.includes('shouldDropAfterTheFactTopicQuote({'));
     expect(idx).toBeGreaterThan(-1);
-    const block = lines.slice(idx, idx + 14).filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+    const block = lines.slice(idx, idx + 20).filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
     expect(block).toMatch(/effectiveQuoteTargetId = undefined;/);
   });
 
@@ -65,5 +65,16 @@ describe('botmux send: 事后开的话题不再被 quote 带进去（接线）',
 
   it('探测走 catch 兜底 ⇒ 飞书报错不阻断发送(失败方向=保持既有 quote)', () => {
     expect(cliSource).toMatch(/const probedThreadId = await getMessageThreadId\([^)]*\)\.catch/);
+  });
+
+  it('收敛时的说明走 console.error 而非 logger(短命 CLI 进程的 logger 进不了 daemon 日志)', () => {
+    // live 实测:用 logger.info 写这条时,daemon out.log 里一条都查不到 ⇒ 排查价值为零。
+    // CLI 侧既有惯例是 console.error(stderr 会被 worker 收进会话日志)。
+    const lines = cliSource.split('\n');
+    const idx = lines.findIndex(l => l.includes('shouldDropAfterTheFactTopicQuote({'));
+    expect(idx).toBeGreaterThan(-1);
+    const block = lines.slice(idx, idx + 16).filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+    expect(block).toMatch(/console\.error\(/);
+    expect(block).not.toMatch(/logger\.(info|debug|warn)\(/);
   });
 });


### PR DESCRIPTION
#1023 的收尾 follow-up。

## 问题

#1023 在 `botmux send` 收敛引用目标时，用 `logger.info` 写了一条说明。**live 实测发现 daemon 的 out.log 里一条都查不到** —— `botmux send` 是短命 CLI 进程，它的 logger 不汇进 daemon 日志，所以这条说明在生产里排查价值为零。

CLI 侧的既有惯例是 `console.error`（`src/cli.ts` 里 493 处 vs `logger` 3 处，#1023 用错了），stderr 会被 worker 收进会话日志。

## 改动

- 那条说明改走 `console.error`，措辞改中文，与 CLI 侧其它输出一致
- 补一条接线用例钉住「这里不得退回 `logger`」，逐行剔除注释行后断言，避免注释掉也能匹配
- 顺带把「收敛赋值必须落在判据 `if` 块内」那条断言的扫描窗口从 14 行放宽到 20 行：新增的三行注释把赋值推出了原窗口，会让该断言误红

## 影响面

仅 `botmux send` 收敛引用目标时的一行输出 + 两条测试断言。**不改变任何发送行为**：判据、探测、收敛逻辑与 #1023 完全一致（`git diff` 只动 `console.error` 那一处和测试）。

## 验证

均为实际执行结果：

- `tsc --noEmit` exit=0
- `bun run build` 通过
- 相关 4 套件 **409/409** 通过（send-policy / send-after-the-fact-topic-quote-wiring / cli-send-dispatch / event-dispatcher）
- 反向变异 2 处均有牙：调用点变死代码 → 1 红；日志退回 `logger.info` → 1 红

## 附：#1023 的 live 实测结果（已在合并前跑完，此处留档）

部署到 fleet 后按原始 Lark API 字段核对（不用 parsed 层，避免 `root_id ?? thread_id` 的 fallback 误导）：

| 场景 | 被引用消息 | 正文回复落点 |
|---|---|---|
| 修复前对照 | 事后被开成话题 | `thread_id=omt_19f4977d…` ❌ 进话题 |
| A 事后开的话题 | 事后被开成话题 | `thread_id=undefined` ✅ 平铺在群 |
| B 用户真开的话题 | `root_id`+`thread_id` 齐全 | `thread_id=omt_19f42a1a…` ✅ 留在话题 |

同 bot、同群、同场景，只有代码不同 —— A 修好了，B 没有回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)