### PR TITLE
fix(dashboard): Devbox 导出解析修复 fail-open，按 stdout/stderr 分流

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,9 +141,11 @@ import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from './platform/bi
 import { isRemoteAccessEnabled } from './global-config.js';
 import {
   DASHBOARD_COMMAND_USAGE,
-  executeDashboardCommand,
+  dashboardExportTimeoutForBudget,
+  executeDashboardCommandWithExportRefresh,
   formatDashboardFallbackFailure,
   formatDashboardSuccessLines,
+  refreshDashboardResultAfterExport,
 } from './cli/dashboard-command.js';
 import { globalInstallUpdateLockTarget, globalInstallUpdateLockTargetIn, installLatestBotmuxSync } from './core/maintenance.js';
 import {
@@ -3129,15 +3131,16 @@ async function callDashboardEndpoint(path: DashboardEndpoint): Promise<Dashboard
  * `devboxDashboardBaseUrl()` 读侧用的是同一份判据，避免写 9002、读 9001。
  * 非 Devbox / 已配置中心平台或自建反代 / `merlin-cli` 不可用时全部静默 no-op。
  */
-async function ensureDevboxDashboardExportForCurrentPort(): Promise<void> {
+async function ensureDevboxDashboardExportForCurrentPort(timeoutMs?: number): Promise<string | null> {
   const portFile = join(CONFIG_DIR, '.dashboard-port');
   const port = Number((existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : '')
     || process.env.BOTMUX_DASHBOARD_PORT || '7891');
-  await ensureDevboxDashboardExport({
+  return ensureDevboxDashboardExport({
     port,
     remoteBaseConfigured: Boolean(
       (isRemoteAccessEnabled() && platformMachineBaseUrl()) || publicReverseProxyBaseUrl(),
     ),
+    timeoutMs,
   });
 }
 
@@ -3152,13 +3155,22 @@ async function printDashboardHintWithRetry(): Promise<void> {
   const stepMs = 500;
   const started = Date.now();
   let last: Awaited<ReturnType<typeof callDashboardEndpoint>> | null = null;
-  // 只在轮询之前做一次：导出结果与「dashboard 起没起来」无关，放在循环体里每轮都会
-  // 重新 spawn 一次 merlin-cli，而失败路径最坏每轮付满 5s 超时——本函数自己的预算
-  // 才 6s，实测会把 start/restart 的这段拖到近两倍。
-  await ensureDevboxDashboardExportForCurrentPort();
   while (Date.now() - started < maxWaitMs) {
     last = await callDashboardEndpoint('/__cli/current');
     if (last.ok) {
+      // Only export after the endpoint proves which port the dashboard actually
+      // owns (callDashboard may self-heal `.dashboard-port`). Do it once, then
+      // re-read the non-mutating current URL so this very hint sees the export.
+      const exportTimeoutMs = dashboardExportTimeoutForBudget(
+        maxWaitMs - (Date.now() - started),
+      );
+      if (exportTimeoutMs !== null) {
+        last = await refreshDashboardResultAfterExport(
+          last,
+          () => ensureDevboxDashboardExportForCurrentPort(exportTimeoutMs),
+          callDashboardEndpoint,
+        );
+      }
       console.log(`   面板: botmux dashboard (${last.url})`);
       // 走中心化平台链接时，附带本地直连兜底，平台异常也能直接 ip:port 访问。
       if (last.localUrl) console.log(`   本地直连(平台异常时可用): ${last.localUrl}`);
@@ -3187,12 +3199,11 @@ async function printDashboardHintWithRetry(): Promise<void> {
  * `dashboard` is the non-rotating get-or-create form; help and invalid
  * subcommands never call either credential endpoint. */
 async function cmdDashboard(args: string[]): Promise<void> {
-  const rawAction = args[0]?.toLowerCase();
-  const resolvesEndpoint = args.length <= 1
-    && !args.some(arg => ['--help', '-h', 'help'].includes(arg.toLowerCase()))
-    && (rawAction === undefined || rawAction === 'current' || rawAction === 'rotate');
-  if (resolvesEndpoint) await ensureDevboxDashboardExportForCurrentPort();
-  const execution = await executeDashboardCommand(args, callDashboardEndpoint);
+  const execution = await executeDashboardCommandWithExportRefresh(
+    args,
+    callDashboardEndpoint,
+    () => ensureDevboxDashboardExportForCurrentPort(),
+  );
   if (execution.kind === 'help') {
     console.log(DASHBOARD_COMMAND_USAGE);
     return;

--- a/src/cli/dashboard-command.ts
+++ b/src/cli/dashboard-command.ts
@@ -15,6 +15,17 @@ export type DashboardCommandExecution =
 const LEGACY_ENSURE_TOKEN_GATE_PREFIX =
   '401 <h1>Token expired</h1><p>Run <code>botmux dashboard</code>';
 
+const MIN_DASHBOARD_EXPORT_BUDGET_MS = 500;
+const MAX_DASHBOARD_EXPORT_TIMEOUT_MS = 5_000;
+
+/** Bound the best-effort export to the caller's remaining startup budget.
+ * Returning null below 500ms avoids a predictably doomed spawn and its
+ * process-local failure cache. */
+export function dashboardExportTimeoutForBudget(remainingMs: number): number | null {
+  if (!Number.isFinite(remainingMs) || remainingMs < MIN_DASHBOARD_EXPORT_BUDGET_MS) return null;
+  return Math.min(MAX_DASHBOARD_EXPORT_TIMEOUT_MS, Math.floor(remainingMs));
+}
+
 function legacyEnsureRouteMissing(result: DashboardResult): boolean {
   if (result.ok) return false;
   if (result.reason === 'wrong-service') return true;
@@ -48,6 +59,52 @@ export function formatDashboardFallbackFailure(
 ): string {
   const operation = action === 'current' ? 'Dashboard lookup' : 'Rotation';
   return `${operation} failed: ${failure.detail ?? failure.reason}`;
+}
+
+/**
+ * Refresh a successful dashboard response after the CLI has created/reused a
+ * Devbox export. The first endpoint call is deliberately outside this helper:
+ * it proves the dashboard is live and lets callDashboard() repair a stale
+ * `.dashboard-port` before merlin-cli is allowed to export anything. A second
+ * non-mutating current read is needed because the first response was rendered
+ * before the export cache existed. If export/refresh fails, retain the already
+ * usable local response rather than turning a best-effort enhancement fatal.
+ */
+export async function refreshDashboardResultAfterExport(
+  result: Extract<DashboardResult, { ok: true }>,
+  ensureExport: () => Promise<string | null>,
+  callEndpoint: (path: DashboardEndpoint) => Promise<DashboardResult>,
+): Promise<Extract<DashboardResult, { ok: true }>> {
+  let exported: string | null;
+  try {
+    exported = await ensureExport();
+  } catch {
+    return result;
+  }
+  if (!exported) return result;
+  try {
+    const refreshed = await callEndpoint('/__cli/current');
+    return refreshed.ok ? refreshed : result;
+  } catch {
+    return result;
+  }
+}
+
+/** Execute the user-facing command first, then add the Devbox export as a
+ * post-success enhancement. Keeping that order in one tested helper prevents a
+ * future refactor from exporting the configured/stale port before endpoint
+ * discovery has identified the live dashboard. */
+export async function executeDashboardCommandWithExportRefresh(
+  args: readonly string[],
+  callEndpoint: (path: DashboardEndpoint) => Promise<DashboardResult>,
+  ensureExport: () => Promise<string | null>,
+): Promise<DashboardCommandExecution> {
+  const execution = await executeDashboardCommand(args, callEndpoint);
+  if (execution.kind !== 'endpoint' || !execution.result.ok) return execution;
+  return {
+    ...execution,
+    result: await refreshDashboardResultAfterExport(execution.result, ensureExport, callEndpoint),
+  };
 }
 
 /**

--- a/src/dashboard/control-csrf.ts
+++ b/src/dashboard/control-csrf.ts
@@ -171,9 +171,10 @@ function publicUrlAuthority(): string | undefined {
  * Merlin Devbox 私有短链的 authority。同 {@link publicUrlAuthority}，只参与
  * Origin 的精确 host+port 比对，值只来自本机 0600 缓存。
  *
- * `devboxDashboardBaseUrl()` 自带短 TTL 的进程内 memo，所以这条控制类请求热路径
- * （每次控制请求 / WS 升级，被判跨站时还会再走一次 warnForeignOrigin）不会每次都
- * 付一遍 secure-file 读——与紧邻的 `publicAuthorityCache` 保持同样的缓存姿势。
+ * `devboxDashboardBaseUrl()` 用 cache / 实际端口 / 设置文件的元数据指纹校验进程内
+ * memo，所以这条控制类请求热路径（每次控制请求 / WS 升级，被判跨站时还会再走一次
+ * warnForeignOrigin）只付较轻的 stat，不会每次重读并解析 secure-file；文件一变，
+ * 下一次请求立即重算，不把旧隧道留在可信 authority 里。
  */
 function devboxUrlAuthority(): string | undefined {
   const raw = devboxDashboardBaseUrl();

--- a/src/platform/devbox-dashboard-export.ts
+++ b/src/platform/devbox-dashboard-export.ts
@@ -1,10 +1,11 @@
-import { accessSync, constants, readFileSync } from 'node:fs';
+import { accessSync, constants, readFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
 import { parse as parseDotEnv } from 'dotenv';
 
+import { logger } from '../utils/logger.js';
 import {
   readSecureHostFileSync,
   writeSecureHostFileSync,
@@ -19,11 +20,6 @@ const DASHBOARD_PORT_PATH = join(CONFIG_DIR, '.dashboard-port');
 const DEFAULT_DASHBOARD_PORT = 7891;
 const EXPORT_TIMEOUT_MS = 5_000;
 const AUTO_EXPORT_ENV_KEY = 'BOTMUX_DEVBOX_AUTO_EXPORT';
-/** Read-side memo TTL: `devboxDashboardBaseUrl()` sits on the CSRF hot path
- *  (every control request / WS upgrade), and each miss costs a secure-file read
- *  plus a `.dashboard-port` read. Short enough that a `botmux dashboard`
- *  re-export is picked up within seconds without a restart. */
-const BASE_URL_MEMO_TTL_MS = 5_000;
 /** Negative cache for a failed export: `merlin-cli` hanging must not make every
  *  later call in the same process pay the full timeout again. */
 const EXPORT_FAILURE_TTL_MS = 60_000;
@@ -34,15 +30,25 @@ interface DevboxDashboardExportCache {
   shortUrl: string;
 }
 
+export interface DevboxExportStreams {
+  stdout: string;
+  stderr: string;
+}
+
+export type DevboxEnvFileMode = 'read' | 'ignore';
+
 export interface EnsureDevboxDashboardExportOptions {
   port: number;
   remoteBaseConfigured: boolean;
   env?: NodeJS.ProcessEnv;
   cachePath?: string;
+  /** Defaults to `read`, even when `env` is injected. Tests/callers that need
+   * a hermetic environment must opt out explicitly. */
+  envFileMode?: DevboxEnvFileMode;
   envFilePath?: string;
   timeoutMs?: number;
   merlinCliPath?: string;
-  runExport?: (binary: string, port: number, timeoutMs: number) => Promise<string>;
+  runExport?: (binary: string, port: number, timeoutMs: number) => Promise<DevboxExportStreams>;
 }
 
 export interface DevboxDashboardBaseUrlOptions {
@@ -51,16 +57,17 @@ export interface DevboxDashboardBaseUrlOptions {
   port?: number;
   cachePath?: string;
   env?: NodeJS.ProcessEnv;
+  envFileMode?: DevboxEnvFileMode;
   envFilePath?: string;
   portFilePath?: string;
 }
 
-let baseUrlMemo: { key: string; at: number; url: string | null } | null = null;
+let baseUrlMemo: { key: string; url: string | null } | null = null;
 let exportFailure: { key: string; at: number } | null = null;
 
-/** Drop the in-process read-side memo and the export negative cache. Called
- *  after a successful export (so the fresh short link is visible immediately)
- *  and by tests, which otherwise observe a previous case's memo. */
+/** Drop the in-process read-side memo and the export negative cache. A successful
+ *  same-process export calls this directly; cross-process writes are detected by
+ *  the file fingerprints folded into the memo key below. */
 export function resetDevboxDashboardExportCaches(): void {
   baseUrlMemo = null;
   exportFailure = null;
@@ -86,10 +93,11 @@ export function resetDevboxDashboardExportCaches(): void {
  */
 function autoExportSetting(
   env: NodeJS.ProcessEnv,
-  envFilePath = ENV_FILE_PATH,
+  envFilePath: string | null,
 ): string | undefined {
   const inline = env[AUTO_EXPORT_ENV_KEY];
   if (inline !== undefined) return inline;
+  if (envFilePath === null) return undefined;
   try {
     return parseDotEnv(readFileSync(envFilePath, 'utf8'))[AUTO_EXPORT_ENV_KEY];
   } catch {
@@ -98,7 +106,15 @@ function autoExportSetting(
   }
 }
 
-function enabled(env: NodeJS.ProcessEnv, envFilePath?: string): boolean {
+function resolveEnvFilePath(
+  envFileMode: DevboxEnvFileMode | undefined,
+  envFilePath: string | undefined,
+): string | null {
+  if (envFileMode === 'ignore') return null;
+  return envFilePath ?? ENV_FILE_PATH;
+}
+
+function enabled(env: NodeJS.ProcessEnv, envFilePath: string | null): boolean {
   const raw = (autoExportSetting(env, envFilePath) ?? '1').trim().toLowerCase();
   return raw !== '0' && raw !== 'false';
 }
@@ -160,6 +176,7 @@ function readCache(path = CACHE_PATH): DevboxDashboardExportCache | null {
 
 function computeDevboxDashboardBaseUrl(opts: DevboxDashboardBaseUrlOptions): string | null {
   const env = opts.env ?? process.env;
+  const envFilePath = resolveEnvFilePath(opts.envFileMode, opts.envFilePath);
   const workspaceId = env.ARNOLD_WORKSPACE_ID?.trim();
   // Devbox gates FIRST, switch second. `enabled()` may read ~/.botmux/.env (the
   // CLI has no dotenv step of its own), while these two only read env vars — and
@@ -167,7 +184,7 @@ function computeDevboxDashboardBaseUrl(opts: DevboxDashboardBaseUrlOptions): str
   // reached constantly from the CSRF hot path and must cost zero syscalls there.
   // All three are side-effect-free reads, so the AND is commutative.
   if (!workspaceId || !env.PORT_LIST) return null;
-  if (!enabled(env, opts.envFilePath)) return null;
+  if (!enabled(env, envFilePath)) return null;
   const port = opts.port ?? resolveDashboardPort(env, opts.portFilePath);
   if (port === null) return null;
   const cached = readCache(opts.cachePath ?? CACHE_PATH);
@@ -180,6 +197,38 @@ function computeDevboxDashboardBaseUrl(opts: DevboxDashboardBaseUrlOptions): str
   return cached.shortUrl;
 }
 
+/** Cheap metadata fingerprint used to validate the hot-path memo without
+ * reopening and reparsing secure files on every control request. Atomic writes
+ * change the inode; in-place writes change size/mtime/ctime. A missing file has
+ * its own stable fingerprint and is invalidated as soon as the file appears. */
+function fileFingerprint(path: string): string {
+  try {
+    const stat = statSync(path);
+    return `${path}:${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`;
+  } catch {
+    return `${path}:missing`;
+  }
+}
+
+function baseUrlMemoKey(opts: DevboxDashboardBaseUrlOptions): string {
+  const env = opts.env ?? process.env;
+  const cachePath = opts.cachePath ?? CACHE_PATH;
+  const portFilePath = opts.portFilePath ?? DASHBOARD_PORT_PATH;
+  const envFilePath = resolveEnvFilePath(opts.envFileMode, opts.envFilePath);
+  return JSON.stringify([
+    opts.port ?? null,
+    env.ARNOLD_WORKSPACE_ID ?? null,
+    env.PORT_LIST ?? null,
+    env.BOTMUX_DASHBOARD_PORT ?? null,
+    env[AUTO_EXPORT_ENV_KEY] ?? null,
+    fileFingerprint(cachePath),
+    opts.port === undefined ? fileFingerprint(portFilePath) : null,
+    env[AUTO_EXPORT_ENV_KEY] === undefined && envFilePath !== null
+      ? fileFingerprint(envFilePath)
+      : null,
+  ]);
+}
+
 /**
  * The Devbox private short link to use as this host's public base, or null.
  *
@@ -187,16 +236,22 @@ function computeDevboxDashboardBaseUrl(opts: DevboxDashboardBaseUrlOptions): str
  * pass it; the rest resolve it from `~/.botmux/.dashboard-port`.
  */
 export function devboxDashboardBaseUrl(opts: DevboxDashboardBaseUrlOptions = {}): string | null {
-  // Only the production shape (real cache/env/settings paths) is memoized;
-  // callers that inject paths — tests — always recompute.
-  const memoizable = opts.cachePath === undefined && opts.env === undefined
-    && opts.envFilePath === undefined && opts.portFilePath === undefined;
-  const key = String(opts.port ?? '');
-  const now = Date.now();
-  if (memoizable && baseUrlMemo && baseUrlMemo.key === key
-    && now - baseUrlMemo.at < BASE_URL_MEMO_TTL_MS) return baseUrlMemo.url;
+  const env = opts.env ?? process.env;
+  const workspaceId = env.ARNOLD_WORKSPACE_ID?.trim();
+  const inlineSetting = env[AUTO_EXPORT_ENV_KEY]?.trim().toLowerCase();
+  // Ordinary hosts are the overwhelmingly common case. These values come
+  // only from the process environment, so reject them before fingerprinting
+  // any files on the synchronous CSRF/control-request path.
+  if (!workspaceId || !env.PORT_LIST || inlineSetting === '0' || inlineSetting === 'false') {
+    return null;
+  }
+  // The key includes the cache, bound-port, and settings-file fingerprints.
+  // This keeps the expensive secure read/JSON parse off the CSRF hot path while
+  // making a cross-process export or port rebind visible on the very next call.
+  const key = baseUrlMemoKey(opts);
+  if (baseUrlMemo?.key === key) return baseUrlMemo.url;
   const url = computeDevboxDashboardBaseUrl(opts);
-  if (memoizable) baseUrlMemo = { key, at: now, url };
+  baseUrlMemo = { key, url };
   return url;
 }
 
@@ -215,7 +270,11 @@ function findMerlinCli(): string {
   return 'merlin-cli';
 }
 
-async function runMerlinExport(binary: string, port: number, timeoutMs: number): Promise<string> {
+async function runMerlinExport(
+  binary: string,
+  port: number,
+  timeoutMs: number,
+): Promise<DevboxExportStreams> {
   return new Promise((resolve, reject) => {
     const child = spawn(binary, ['cpu-devbox', 'export', '--port', String(port)], {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -235,10 +294,7 @@ async function runMerlinExport(binary: string, port: number, timeoutMs: number):
     });
     child.once('close', code => {
       clearTimeout(timer);
-      // stdout first: the result object is the payload, stderr only carries
-      // warnings/log lines. parseExportOutput scans both, but ordering makes
-      // the intended source win when a warning happens to be JSON too.
-      if (code === 0) resolve(`${stdout}\n${stderr}`);
+      if (code === 0) resolve({ stdout, stderr });
       else reject(new Error(`merlin-cli exited ${code}`));
     });
   });
@@ -252,55 +308,188 @@ async function runMerlinExport(binary: string, port: number, timeoutMs: number):
  * warning containing braces (`Warning: config {legacy} deprecated`) or on a JSON
  * log line. Scanning candidates instead keeps the parse working around noise.
  */
-function* jsonObjectCandidates(output: string): Generator<string> {
-  for (let i = 0; i < output.length; i++) {
-    if (output[i] !== '{') continue;
-    let depth = 0;
-    let inString = false;
-    let escaped = false;
-    for (let j = i; j < output.length; j++) {
-      const ch = output[j];
-      if (inString) {
-        if (escaped) escaped = false;
-        else if (ch === '\\') escaped = true;
-        else if (ch === '"') inString = false;
-        continue;
-      }
-      if (ch === '"') { inString = true; continue; }
-      if (ch === '{') depth++;
-      else if (ch === '}' && --depth === 0) {
-        yield output.slice(i, j + 1);
-        i = j; // Nested objects are part of this candidate, not candidates too.
-        break;
-      }
-    }
-  }
+interface JsonObjectCandidate {
+  text: string;
+  start: number;
+  /** Exclusive end; null means the opening brace was never closed. */
+  end: number | null;
 }
 
-function parseExportOutput(output: string): { shortUrl: string; isPublic: boolean } | null {
+function* jsonObjectCandidates(output: string): Generator<JsonObjectCandidate> {
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < output.length; i++) {
+    const ch = output[i];
+    if (start < 0) {
+      if (ch === '{') {
+        start = i;
+        depth = 1;
+      }
+      continue;
+    }
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') { inString = true; continue; }
+    if (ch === '{') depth++;
+    else if (ch === '}' && --depth === 0) {
+      yield { text: output.slice(start, i + 1), start, end: i + 1 };
+      start = -1;
+    }
+  }
+  // Once a result-shaped object has been seen, silently ignoring a truncated
+  // suffix can turn a later public verdict into a fail-open private result.
+  // Report the malformed tail to the caller so the entire output is rejected.
+  if (start >= 0) yield { text: output.slice(start), start, end: null };
+}
+
+/** Count security-relevant JSON property names before JSON.parse discards
+ * duplicate keys. This also sees nested keys, so a second result-shaped object
+ * embedded inside the first candidate is treated as ambiguous. */
+function securityPropertyKeyCounts(json: string): { shortUrl: number; isPublic: number } {
+  const counts = { shortUrl: 0, isPublic: 0 };
+  for (let i = 0; i < json.length; i++) {
+    if (json[i] !== '"') continue;
+    const start = i;
+    let escaped = false;
+    for (i++; i < json.length; i++) {
+      const ch = json[i];
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') break;
+    }
+    let next = i + 1;
+    while (/\s/.test(json[next] ?? '')) next++;
+    if (json[next] !== ':') continue;
+    try {
+      const propertyName: unknown = JSON.parse(json.slice(start, i + 1));
+      if (propertyName === 'short_url') counts.shortUrl++;
+      else if (propertyName === 'is_public') counts.isPublic++;
+    } catch {
+      // The enclosing JSON parse will reject this candidate too.
+    }
+  }
+  return counts;
+}
+
+function canonicalSecurityMarkerCounts(parsed: object): { shortUrl: number; isPublic: number } {
+  const canonical = JSON.stringify(parsed);
+  return {
+    shortUrl: canonical.match(/\bshort_url\b/gu)?.length ?? 0,
+    isPublic: canonical.match(/\bis_public\b/gu)?.length ?? 0,
+  };
+}
+
+type ParsedExportResult = { shortUrl: string; isPublic: false };
+
+function rejectExportOutput(source: 'stdout' | 'stderr', reason: string): null {
+  // Deliberately omit candidate text and URLs: DEBUG=1 should explain the
+  // parser decision without copying a possibly credential-bearing payload.
+  logger.debug(`[devbox-export] rejected ${source} output: ${reason}`);
+  return null;
+}
+
+/** Strict three-state parse: result / rejected null / no result shape undefined. */
+function parseExportOutput(
+  output: string,
+  source: 'stdout' | 'stderr',
+): ParsedExportResult | null | undefined {
+  let found: ParsedExportResult | null = null;
+  let scannedThrough = 0;
+  const containsRawSecurityField = (text: string) => /\b(?:short_url|is_public)\b/u.test(text);
   for (const candidate of jsonObjectCandidates(output)) {
+    // A result can also be rendered as key=value/plaintext. Treat security
+    // fields outside JSON candidates as result-shaped ambiguity, otherwise a
+    // public stdout verdict could be misclassified as "no result" and fall
+    // through to a private-looking stderr object.
+    if (containsRawSecurityField(output.slice(scannedThrough, candidate.start))) {
+      return rejectExportOutput(source, 'result fields outside a JSON candidate');
+    }
+    if (candidate.end === null) {
+      return rejectExportOutput(source, 'unterminated object candidate');
+    }
+    scannedThrough = candidate.end;
+    const candidateText = candidate.text;
+    // Inspect security keys before parsing: JSON syntax errors must not make a
+    // public/result-shaped candidate disappear while a neighbouring private
+    // candidate remains eligible. Malformed brace warnings without these keys
+    // are still harmless noise and remain skippable.
+    const keyCounts = securityPropertyKeyCounts(candidateText);
     let parsed: unknown;
-    try { parsed = JSON.parse(candidate); } catch { continue; }
+    try {
+      parsed = JSON.parse(candidateText);
+    } catch {
+      // A colon makes this look object-shaped even when it uses Python/JS
+      // quoting rather than strict JSON. Reject that ambiguity instead of
+      // allowing an unparseable public verdict to disappear beside a private
+      // one. Plain brace prose such as `{legacy}` remains harmless noise.
+      if (candidateText.includes(':')
+        || containsRawSecurityField(candidateText)
+        || keyCounts.shortUrl > 0
+        || keyCounts.isPublic > 0) {
+        return rejectExportOutput(source, 'malformed object-shaped candidate');
+      }
+      continue;
+    }
     if (!parsed || typeof parsed !== 'object') continue;
     const result = parsed as { short_url?: unknown; is_public?: unknown };
+    // JSON loggers can wrap a plaintext verdict in a string value. Re-encoding
+    // the parsed object canonicalizes Unicode escapes, then comparing all
+    // markers with actual property-key counts exposes any marker hidden in a
+    // value without penalizing escaped spellings of the real keys.
+    const canonicalMarkerCounts = canonicalSecurityMarkerCounts(parsed);
+    if (canonicalMarkerCounts.shortUrl > keyCounts.shortUrl
+      || canonicalMarkerCounts.isPublic > keyCounts.isPublic) {
+      return rejectExportOutput(source, 'result fields inside a JSON value');
+    }
     // A candidate without `short_url` is noise (a warning/log object) — skip it.
-    // One that HAS it is the export result and decides the outcome here: a
-    // public or credentialed URL fails closed instead of letting a later object
-    // in the stream override the verdict.
-    if (!('short_url' in result)) continue;
+    if (keyCounts.shortUrl === 0) continue;
+    // Exactly one top-level result is accepted. Duplicate/nested security keys
+    // are ambiguous, and JSON.parse's last-key-wins behavior must not be able
+    // to hide a preceding public verdict.
+    if (keyCounts.shortUrl !== 1
+      || keyCounts.isPublic !== 1
+      || !Object.prototype.hasOwnProperty.call(result, 'short_url')
+      || !Object.prototype.hasOwnProperty.call(result, 'is_public')) {
+      return rejectExportOutput(source, 'ambiguous or nested result fields');
+    }
+    // Multiple result-shaped objects are ambiguous. In particular, a private-
+    // looking log record followed by the real public verdict must never make a
+    // public link eligible merely because it appeared first.
+    if (found) return rejectExportOutput(source, 'multiple result candidates');
     const shortUrl = validPrivateShortUrl(result.short_url);
-    if (!shortUrl || result.is_public !== false) return null;
-    return { shortUrl, isPublic: false };
+    if (!shortUrl || result.is_public !== false) {
+      return rejectExportOutput(source, 'invalid URL or non-private export verdict');
+    }
+    found = { shortUrl, isPublic: false };
   }
-  return null;
+  if (containsRawSecurityField(output.slice(scannedThrough))) {
+    return rejectExportOutput(source, 'result fields outside a JSON candidate');
+  }
+  return found ?? undefined;
+}
+
+/** stdout is authoritative when it contains either a valid result or a
+ * rejection. Only a truly result-free stdout may fall back to stderr. */
+function parseMerlinExportStreams(output: DevboxExportStreams): ParsedExportResult | null {
+  const stdoutResult = parseExportOutput(output.stdout, 'stdout');
+  if (stdoutResult === null) return null;
+  if (stdoutResult !== undefined) return stdoutResult;
+  return parseExportOutput(output.stderr, 'stderr') ?? null;
 }
 
 export async function ensureDevboxDashboardExport(
   opts: EnsureDevboxDashboardExportOptions,
 ): Promise<string | null> {
   const env = opts.env ?? process.env;
+  const envFilePath = resolveEnvFilePath(opts.envFileMode, opts.envFilePath);
   const workspaceId = env.ARNOLD_WORKSPACE_ID?.trim();
-  if (!enabled(env, opts.envFilePath) || opts.remoteBaseConfigured || !workspaceId
+  if (!enabled(env, envFilePath) || opts.remoteBaseConfigured || !workspaceId
     || !env.PORT_LIST || !isExportablePort(opts.port, env)) {
     return null;
   }
@@ -316,7 +505,7 @@ export async function ensureDevboxDashboardExport(
   const binary = opts.merlinCliPath ?? findMerlinCli();
   try {
     const output = await (opts.runExport ?? runMerlinExport)(binary, opts.port, opts.timeoutMs ?? EXPORT_TIMEOUT_MS);
-    const result = parseExportOutput(output);
+    const result = parseMerlinExportStreams(output);
     if (!result) {
       exportFailure = { key: failureKey, at: Date.now() };
       return null;

--- a/test/dashboard-command.test.ts
+++ b/test/dashboard-command.test.ts
@@ -1,10 +1,22 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  dashboardExportTimeoutForBudget,
   executeDashboardCommand,
+  executeDashboardCommandWithExportRefresh,
   formatDashboardFallbackFailure,
   formatDashboardSuccessLines,
+  refreshDashboardResultAfterExport,
 } from '../src/cli/dashboard-command.js';
 import type { DashboardEndpoint } from '../src/cli/dashboard-endpoint.js';
+
+describe('dashboardExportTimeoutForBudget', () => {
+  it('skips doomed sub-500ms exports and caps a healthy budget at five seconds', () => {
+    expect(dashboardExportTimeoutForBudget(499)).toBeNull();
+    expect(dashboardExportTimeoutForBudget(500)).toBe(500);
+    expect(dashboardExportTimeoutForBudget(1_234.9)).toBe(1_234);
+    expect(dashboardExportTimeoutForBudget(6_000)).toBe(5_000);
+  });
+});
 
 describe('executeDashboardCommand', () => {
   it.each([['--help'], ['-h'], ['help']])('%s is non-mutating', async (...args) => {
@@ -217,6 +229,109 @@ describe('executeDashboardCommand', () => {
       argument: 'wat',
     });
     expect(callEndpoint).not.toHaveBeenCalled();
+  });
+});
+
+describe('refreshDashboardResultAfterExport', () => {
+  it('exports only after a live result, then re-reads current without rotating', async () => {
+    const events: string[] = [];
+    const ensureExport = vi.fn(async () => {
+      events.push('export');
+      return 'https://devbox.example.com';
+    });
+    const callEndpoint = vi.fn(async (path: DashboardEndpoint) => {
+      events.push(path);
+      return { ok: true as const, url: 'https://devbox.example.com/?t=token' };
+    });
+
+    await expect(refreshDashboardResultAfterExport(
+      { ok: true, url: 'http://127.0.0.1:9002/?t=token' },
+      ensureExport,
+      callEndpoint,
+    )).resolves.toEqual({ ok: true, url: 'https://devbox.example.com/?t=token' });
+    expect(events).toEqual(['export', '/__cli/current']);
+    expect(callEndpoint).not.toHaveBeenCalledWith('/__cli/rotate');
+  });
+
+  it('keeps the usable local response when export is unavailable', async () => {
+    const original = { ok: true as const, url: 'http://127.0.0.1:9002/?t=token' };
+    const callEndpoint = vi.fn();
+    await expect(refreshDashboardResultAfterExport(
+      original,
+      async () => null,
+      callEndpoint,
+    )).resolves.toBe(original);
+    expect(callEndpoint).not.toHaveBeenCalled();
+  });
+
+  it('keeps the first live response when the post-export refresh fails', async () => {
+    const original = { ok: true as const, url: 'http://127.0.0.1:9002/?t=token' };
+    await expect(refreshDashboardResultAfterExport(
+      original,
+      async () => 'https://devbox.example.com',
+      async () => ({ ok: false, reason: 'unreachable' }),
+    )).resolves.toBe(original);
+  });
+
+  it('keeps the first live response when export rejects', async () => {
+    const original = { ok: true as const, url: 'http://127.0.0.1:9002/?t=token' };
+    const callEndpoint = vi.fn();
+    await expect(refreshDashboardResultAfterExport(
+      original,
+      async () => { throw new Error('cache raced with another process'); },
+      callEndpoint,
+    )).resolves.toBe(original);
+    expect(callEndpoint).not.toHaveBeenCalled();
+  });
+
+  it('keeps the first live response when the post-export refresh rejects', async () => {
+    const original = { ok: true as const, url: 'http://127.0.0.1:9002/?t=token' };
+    await expect(refreshDashboardResultAfterExport(
+      original,
+      async () => 'https://devbox.example.com',
+      async () => { throw new Error('dashboard stopped'); },
+    )).resolves.toBe(original);
+  });
+});
+
+describe('executeDashboardCommandWithExportRefresh', () => {
+  it('discovers the dashboard before export and refreshes only with current', async () => {
+    const events: string[] = [];
+    let currentCalls = 0;
+    const callEndpoint = vi.fn(async (path: DashboardEndpoint) => {
+      events.push(path);
+      currentCalls += path === '/__cli/current' ? 1 : 0;
+      return {
+        ok: true as const,
+        url: currentCalls > 1
+          ? 'https://devbox.example.com/?t=token'
+          : 'http://127.0.0.1:9002/?t=token',
+      };
+    });
+    const ensureExport = vi.fn(async () => {
+      events.push('export');
+      return 'https://devbox.example.com';
+    });
+
+    await expect(executeDashboardCommandWithExportRefresh(
+      ['current'],
+      callEndpoint,
+      ensureExport,
+    )).resolves.toMatchObject({
+      kind: 'endpoint',
+      result: { ok: true, url: 'https://devbox.example.com/?t=token' },
+    });
+    expect(events).toEqual(['/__cli/current', 'export', '/__cli/current']);
+    expect(callEndpoint).not.toHaveBeenCalledWith('/__cli/rotate');
+  });
+
+  it('does not export for help, invalid argv, or a failed first endpoint', async () => {
+    const ensureExport = vi.fn();
+    const failedEndpoint = vi.fn(async () => ({ ok: false as const, reason: 'unreachable' as const }));
+    await executeDashboardCommandWithExportRefresh(['help'], failedEndpoint, ensureExport);
+    await executeDashboardCommandWithExportRefresh(['wat'], failedEndpoint, ensureExport);
+    await executeDashboardCommandWithExportRefresh(['current'], failedEndpoint, ensureExport);
+    expect(ensureExport).not.toHaveBeenCalled();
   });
 });
 

--- a/test/devbox-dashboard-export.test.ts
+++ b/test/devbox-dashboard-export.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -13,10 +13,13 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 import {
+  type DevboxExportStreams,
   devboxDashboardBaseUrl,
   ensureDevboxDashboardExport,
   resetDevboxDashboardExportCaches,
 } from '../src/platform/devbox-dashboard-export.js';
+import { logger } from '../src/utils/logger.js';
+import { spawnSyncTsEvalWithRepoImports } from './helpers/ts-runner.js';
 
 const readSpy = vi.mocked(readFileSync);
 
@@ -29,6 +32,14 @@ function tmpDir() {
 function fixture() {
   return join(tmpDir(), 'cache.json');
 }
+
+function exportStreams(stdout: string, stderr = ''): DevboxExportStreams {
+  return { stdout, stderr };
+}
+
+const IGNORE_ENV_FILE = { envFileMode: 'ignore' as const };
+const PRIVATE_RESULT = '{"short_url":"https://devbox.example.com","is_public":false}';
+const PUBLIC_RESULT = '{"short_url":"https://devbox.example.com","is_public":true}';
 
 const devboxEnv = {
   ARNOLD_WORKSPACE_ID: '103424',
@@ -43,12 +54,13 @@ beforeEach(() => {
 describe('ensureDevboxDashboardExport', () => {
   it('parses warning-prefixed private export output and persists a reusable cache', async () => {
     const cachePath = fixture();
-    const runExport = vi.fn(async () => 'Warning: upgrade available\n{"short_url":"https://devbox.example.com","is_public":false}\n');
+    const runExport = vi.fn(async () => exportStreams(`Warning: upgrade available\n${PRIVATE_RESULT}\n`));
 
     await expect(ensureDevboxDashboardExport({
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath,
       merlinCliPath: '/fake/merlin-cli',
       runExport,
@@ -57,13 +69,19 @@ describe('ensureDevboxDashboardExport', () => {
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath,
       merlinCliPath: '/fake/merlin-cli',
       runExport,
     })).resolves.toBe('https://devbox.example.com');
 
     expect(runExport).toHaveBeenCalledTimes(1);
-    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, port: 9001 })).toBe('https://devbox.example.com');
+    expect(devboxDashboardBaseUrl({
+      cachePath,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      port: 9001,
+    })).toBe('https://devbox.example.com');
     expect(readFileSync(cachePath, 'utf8')).not.toContain('token');
   });
 
@@ -73,19 +91,22 @@ describe('ensureDevboxDashboardExport', () => {
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath,
       merlinCliPath: '/fake/merlin-cli',
-      runExport: async () => '{"short_url":"https://devbox.example.com","is_public":false}',
+      runExport: async () => exportStreams(PRIVATE_RESULT),
     });
     expect(devboxDashboardBaseUrl({
       cachePath,
       port: 9001,
       env: { ...devboxEnv, ARNOLD_WORKSPACE_ID: 'other' },
+      ...IGNORE_ENV_FILE,
     })).toBeNull();
     expect(devboxDashboardBaseUrl({
       cachePath,
       port: 9001,
       env: { ...devboxEnv, BOTMUX_DEVBOX_AUTO_EXPORT: '0' },
+      ...IGNORE_ENV_FILE,
     })).toBeNull();
   });
 
@@ -93,11 +114,12 @@ describe('ensureDevboxDashboardExport', () => {
   // not cover it. Without this case, replacing the whole PORT_LIST branch with
   // `return false` left the suite green.
   it('exports a port that only PORT_LIST allows', async () => {
-    const runExport = vi.fn(async () => '{"short_url":"https://devbox.example.com","is_public":false}');
+    const runExport = vi.fn(async () => exportStreams(PRIVATE_RESULT));
     await expect(ensureDevboxDashboardExport({
       port: 10001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath: fixture(),
       merlinCliPath: '/fake/merlin-cli',
       runExport,
@@ -118,6 +140,7 @@ describe('ensureDevboxDashboardExport', () => {
       port,
       remoteBaseConfigured,
       env,
+      envFileMode: 'read',
       cachePath: fixture(),
       envFilePath: join(tmpDir(), 'absent.env'),
       merlinCliPath: '/fake/merlin-cli',
@@ -133,19 +156,179 @@ describe('ensureDevboxDashboardExport', () => {
     // A later private object must not override an earlier public verdict.
     ['public result followed by a private-looking object',
       '{"short_url":"https://devbox.example.com","is_public":true}\n{"short_url":"https://evil.example.com","is_public":false}'],
+    // Nor may a private-looking log line hide the actual public verdict.
+    ['private-looking log followed by a public result for the same URL',
+      '{"level":"preview","short_url":"https://devbox.example.com","is_public":false}\n'
+      + '{"short_url":"https://devbox.example.com","is_public":true}'],
+    ['two private-looking result objects (ambiguous output)',
+      '{"short_url":"https://one.example.com","is_public":false}\n'
+      + '{"short_url":"https://two.example.com","is_public":false}'],
+    ['a truncated public result after a private-looking result',
+      '{"short_url":"https://devbox.example.com","is_public":false}\n'
+      + '{"short_url":"https://devbox.example.com","is_public":true'],
+    ['an unmatched warning swallowing a later public result',
+      '{"short_url":"https://devbox.example.com","is_public":false}\nWarning {\n'
+      + '{"short_url":"https://devbox.example.com","is_public":true}'],
+    ['a nested second result-shaped object',
+      '{"short_url":"https://devbox.example.com","is_public":false,'
+      + '"preview":{"short_url":"https://devbox.example.com","is_public":true}}'],
+    ['duplicate public/private verdict keys',
+      '{"short_url":"https://devbox.example.com","is_public":true,"is_public":false}'],
+    ['a private result followed by balanced malformed public output',
+      '{"short_url":"https://devbox.example.com","is_public":false}\n'
+      + '{"short_url":"https://devbox.example.com","is_public":true,}'],
+    ['balanced malformed public output followed by a private result',
+      '{"short_url":"https://devbox.example.com","is_public":true,}\n'
+      + '{"short_url":"https://devbox.example.com","is_public":false}'],
+    ['a private result followed by Python-style public output',
+      '{"short_url":"https://devbox.example.com","is_public":false}\n'
+      + "{'short_url':'https://devbox.example.com','is_public':true}"],
+    ['a private result followed by unquoted-key public output',
+      '{"short_url":"https://devbox.example.com","is_public":false}\n'
+      + '{short_url:"https://devbox.example.com",is_public:true}'],
   ])('fails closed for %s', async (_name, output) => {
     await expect(ensureDevboxDashboardExport({
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath: fixture(),
       merlinCliPath: '/fake/merlin-cli',
-      runExport: async () => output,
+      runExport: async () => exportStreams(output),
     })).resolves.toBeNull();
   });
 
-  // merlin-cli's output shape is outside this repo's control and stderr is mixed
-  // in, so a brace anywhere in a warning used to break the whole parse.
+  it.each([
+    ['clean output', ''],
+    ['brace prose', 'Note {see docs}'],
+    ['object-like retry warning', 'Warning: retry {attempt: 3}'],
+    ['Python-style config warning', "Warning: config {'legacy': true}"],
+    ['progress warning', 'Exporting {step 1/3: creating tunnel}'],
+    ['an unmatched opening brace', 'Tip: diagnostic context {'],
+    ['Go struct formatting', 'state={Port:9001 Public:false}'],
+    ['an echoed result', PRIVATE_RESULT],
+  ])('ignores %s on stderr once stdout has a valid result', async (_name, stderr) => {
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams(PRIVATE_RESULT, stderr),
+    })).resolves.toBe('https://devbox.example.com');
+  });
+
+  it.each([
+    ['plain progress', 'export completed\n'],
+    ['a JSON log object', '{"level":"info","message":"done"}\n'],
+    ['harmless brace prose', 'Warning {legacy}\n'],
+  ])('falls back to stderr when stdout contains only %s', async (_name, stdout) => {
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams(stdout, PRIVATE_RESULT),
+    })).resolves.toBe('https://devbox.example.com');
+  });
+
+  // Mutation guard: changing the stdout-null branch to fall through into
+  // stderr would incorrectly accept the private-looking stderr object here.
+  it('does not fall back to stderr after stdout rejects a public result', async () => {
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams(PUBLIC_RESULT, PRIVATE_RESULT),
+    })).resolves.toBeNull();
+  });
+
+  it('does not treat a plaintext public stdout verdict as result-free', async () => {
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams(
+        'short_url=https://public.example is_public=true',
+        PRIVATE_RESULT,
+      ),
+    })).resolves.toBeNull();
+  });
+
+  it('rejects plaintext result fields after a private stderr JSON candidate', async () => {
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams(
+        '',
+        `${PRIVATE_RESULT}\nshort_url=https://public.example is_public=true`,
+      ),
+    })).resolves.toBeNull();
+  });
+
+  it.each([
+    ['plain markers',
+      '{"level":"info","message":"short_url=https://public.example is_public=true"}'],
+    ['Unicode-escaped markers',
+      '{"level":"info","message":"\\u0073hort_url=https://public.example is_\\u0070ublic=true"}'],
+  ])('does not treat stdout JSON log values containing %s as result-free', async (_name, stdout) => {
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams(stdout, PRIVATE_RESULT),
+    })).resolves.toBeNull();
+  });
+
+  it('rejects a private JSON result that carries a conflicting plaintext verdict value', async () => {
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams(
+        '{"short_url":"https://private.example","is_public":false,'
+        + '"message":"actual short_url=https://public.example is_public=true"}',
+      ),
+    })).resolves.toBeNull();
+  });
+
+  it('logs a URL-free debug reason when a result-shaped candidate is rejected', async () => {
+    const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams(PUBLIC_RESULT),
+    })).resolves.toBeNull();
+    expect(debug).toHaveBeenCalledWith(expect.stringContaining('non-private export verdict'));
+    expect(JSON.stringify(debug.mock.calls)).not.toContain('devbox.example.com');
+    debug.mockRestore();
+  });
+
+  // Strict scanning still tolerates harmless noise in the same stream, which
+  // covers injected runners and future merlin-cli versions that log to stdout.
   it.each([
     ['a brace inside a warning', 'Warning: config {legacy} deprecated\n{"short_url":"https://devbox.example.com","is_public":false}'],
     ['a JSON log line', '{"level":"warn","msg":"x"}\n{"short_url":"https://devbox.example.com","is_public":false}'],
@@ -157,9 +340,10 @@ describe('ensureDevboxDashboardExport', () => {
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath: fixture(),
       merlinCliPath: '/fake/merlin-cli',
-      runExport: async () => output,
+      runExport: async () => exportStreams(output),
     })).resolves.toBe('https://devbox.example.com');
   });
 
@@ -168,11 +352,24 @@ describe('ensureDevboxDashboardExport', () => {
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath: fixture(),
       merlinCliPath: '/fake/merlin-cli',
       runExport: async () => { throw new Error('timeout'); },
     })).resolves.toBeNull();
   });
+
+  it('fails softly in linear time for many unmatched opening braces', async () => {
+    await expect(ensureDevboxDashboardExport({
+      port: 9001,
+      remoteBaseConfigured: false,
+      env: devboxEnv,
+      ...IGNORE_ENV_FILE,
+      cachePath: fixture(),
+      merlinCliPath: '/fake/merlin-cli',
+      runExport: async () => exportStreams('{'.repeat(50_000)),
+    })).resolves.toBeNull();
+  }, 1_000);
 
   // A hanging merlin-cli pays the full timeout. Repeating that on every caller
   // in the same process is what made `start` overrun its own 6s budget.
@@ -183,6 +380,7 @@ describe('ensureDevboxDashboardExport', () => {
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath,
       merlinCliPath: '/fake/merlin-cli',
       runExport,
@@ -253,6 +451,7 @@ describe('ensureDevboxDashboardExport', () => {
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      envFileMode: 'read',
       cachePath: join(dir, 'cache.json'),
       envFilePath,
       merlinCliPath: '/fake/merlin-cli',
@@ -267,11 +466,56 @@ describe('ensureDevboxDashboardExport', () => {
       port: 9001,
       remoteBaseConfigured: false,
       env: { ...devboxEnv, BOTMUX_DEVBOX_AUTO_EXPORT: '1' },
+      envFileMode: 'read',
       cachePath: join(dir, 'cache.json'),
       envFilePath,
       merlinCliPath: '/fake/merlin-cli',
-      runExport: async () => '{"short_url":"https://devbox.example.com","is_public":false}',
+      runExport: async () => exportStreams(PRIVATE_RESULT),
     })).resolves.toBe('https://devbox.example.com');
+  });
+
+  it('reads the settings file by default even with env injection and ignores it only explicitly', () => {
+    const home = tmpDir();
+    mkdirSync(join(home, '.botmux'), { mode: 0o700 });
+    writeFileSync(join(home, '.botmux', '.env'), 'BOTMUX_DEVBOX_AUTO_EXPORT=0\n', { mode: 0o600 });
+    const child = spawnSyncTsEvalWithRepoImports(`
+      const { ensureDevboxDashboardExport } = await import('./src/platform/devbox-dashboard-export.js');
+      const defaultsToRead = await ensureDevboxDashboardExport({
+        port: 9001,
+        remoteBaseConfigured: false,
+        env: process.env,
+        cachePath: process.env.HOME + '/read-cache.json',
+        merlinCliPath: '/fake/merlin-cli',
+        runExport: async () => ({ stdout: '${PRIVATE_RESULT}', stderr: '' }),
+      });
+      const explicitlyIgnored = await ensureDevboxDashboardExport({
+        port: 9001,
+        remoteBaseConfigured: false,
+        env: process.env,
+        envFileMode: 'ignore',
+        cachePath: process.env.HOME + '/ignored-cache.json',
+        merlinCliPath: '/fake/merlin-cli',
+        runExport: async () => ({
+          stdout: '{"short_url":"https://isolated.example.com","is_public":false}',
+          stderr: '',
+        }),
+      });
+      console.log(JSON.stringify({ defaultsToRead, explicitlyIgnored }));
+    `, {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: home,
+        ARNOLD_WORKSPACE_ID: 'probe',
+        PORT_LIST: '9001',
+      },
+      encoding: 'utf8',
+    });
+    expect(child.status, child.stderr?.toString()).toBe(0);
+    expect(JSON.parse(child.stdout.toString())).toEqual({
+      defaultsToRead: null,
+      explicitlyIgnored: 'https://isolated.example.com',
+    });
   });
 });
 
@@ -282,9 +526,12 @@ describe('devboxDashboardBaseUrl', () => {
       port,
       remoteBaseConfigured: false,
       env: devboxEnv,
+      ...IGNORE_ENV_FILE,
       cachePath,
       merlinCliPath: '/fake/merlin-cli',
-      runExport: async () => `{"short_url":"https://tunnel-for-${port}.example.com","is_public":false}`,
+      runExport: async () => exportStreams(
+        `{"short_url":"https://tunnel-for-${port}.example.com","is_public":false}`,
+      ),
     });
     return cachePath;
   }
@@ -294,9 +541,10 @@ describe('devboxDashboardBaseUrl', () => {
   // entirely and keep advertising (and trusting) that stale tunnel.
   it('rejects a cache written for a different dashboard port', async () => {
     const cachePath = await seedCache(9001);
-    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, port: 9001 }))
+    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, ...IGNORE_ENV_FILE, port: 9001 }))
       .toBe('https://tunnel-for-9001.example.com');
-    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, port: 9002 })).toBeNull();
+    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, ...IGNORE_ENV_FILE, port: 9002 }))
+      .toBeNull();
   });
 
   it('resolves the port from .dashboard-port when the caller does not pass one', async () => {
@@ -304,11 +552,12 @@ describe('devboxDashboardBaseUrl', () => {
     const portFilePath = join(tmpDir(), '.dashboard-port');
 
     writeFileSync(portFilePath, '9001\n');
-    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, portFilePath }))
+    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, ...IGNORE_ENV_FILE, portFilePath }))
       .toBe('https://tunnel-for-9001.example.com');
 
     writeFileSync(portFilePath, '9002\n');
-    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, portFilePath })).toBeNull();
+    expect(devboxDashboardBaseUrl({ cachePath, env: devboxEnv, ...IGNORE_ENV_FILE, portFilePath }))
+      .toBeNull();
   });
 
   it('falls back to BOTMUX_DASHBOARD_PORT when no port file exists', async () => {
@@ -318,11 +567,61 @@ describe('devboxDashboardBaseUrl', () => {
       cachePath,
       portFilePath,
       env: { ...devboxEnv, BOTMUX_DASHBOARD_PORT: '9002' },
+      ...IGNORE_ENV_FILE,
     })).toBe('https://tunnel-for-9002.example.com');
     expect(devboxDashboardBaseUrl({
       cachePath,
       portFilePath,
       env: { ...devboxEnv, BOTMUX_DASHBOARD_PORT: '9001' },
+      ...IGNORE_ENV_FILE,
     })).toBeNull();
+  });
+
+  it('invalidates the production memo immediately on cross-process cache and port writes', () => {
+    const home = tmpDir();
+    const configDir = join(home, '.botmux');
+    mkdirSync(configDir, { mode: 0o700 });
+    chmodSync(configDir, 0o700);
+    writeFileSync(join(configDir, '.dashboard-port'), '9001\n', { mode: 0o600 });
+
+    const childEnv = {
+      ...process.env,
+      HOME: home,
+      ARNOLD_WORKSPACE_ID: 'probe',
+      PORT_LIST: '9001,9002',
+    };
+    delete childEnv.BOTMUX_DEVBOX_AUTO_EXPORT;
+    const child = spawnSyncTsEvalWithRepoImports(`
+      const { chmodSync, renameSync, writeFileSync } = await import('node:fs');
+      const { join } = await import('node:path');
+      const { devboxDashboardBaseUrl } = await import('./src/platform/devbox-dashboard-export.js');
+      const dir = join(process.env.HOME, '.botmux');
+      const portPath = join(dir, '.dashboard-port');
+      const cachePath = join(dir, 'devbox-dashboard-export.json');
+      const atomicWrite = (path, text) => {
+        const temp = path + '.next';
+        writeFileSync(temp, text, { mode: 0o600 });
+        chmodSync(temp, 0o600);
+        renameSync(temp, path);
+      };
+      const cache = (port, shortUrl) => JSON.stringify({ workspaceId: 'probe', port, shortUrl }) + '\\n';
+      const firstMiss = devboxDashboardBaseUrl();
+      atomicWrite(cachePath, cache(9001, 'https://fresh-9001.example.com'));
+      const afterExternalExport = devboxDashboardBaseUrl();
+      atomicWrite(portPath, '9002\\n');
+      atomicWrite(cachePath, cache(9002, 'https://fresh-9002.example.com'));
+      const afterPortDrift = devboxDashboardBaseUrl();
+      console.log(JSON.stringify({ firstMiss, afterExternalExport, afterPortDrift }));
+    `, {
+      cwd: process.cwd(),
+      env: childEnv,
+      encoding: 'utf8',
+    });
+    expect(child.status, child.stderr?.toString()).toBe(0);
+    expect(JSON.parse(child.stdout.toString())).toEqual({
+      firstMiss: null,
+      afterExternalExport: 'https://fresh-9001.example.com',
+      afterPortDrift: 'https://fresh-9002.example.com',
+    });
   });
 });

--- a/test/devbox-dashboard-export.test.ts
+++ b/test/devbox-dashboard-export.test.ts
@@ -395,12 +395,17 @@ describe('ensureDevboxDashboardExport', () => {
   // covered, so removing the second's write left the suite green.
   it('does not re-spawn after an unparseable exit-0 export inside the window', async () => {
     const cachePath = fixture();
-    const runExport = vi.fn(async () => 'merlin-cli: unexpected output');
+    // Must be the {stdout, stderr} shape: returning a bare string made this land
+    // in the runner-threw branch (reading .stdout off a string yields undefined,
+    // and the scan throws), so it exercised the OTHER negative-cache write site
+    // and stayed green when this one was deleted.
+    const runExport = vi.fn(async () => ({ stdout: 'merlin-cli: unexpected output', stderr: '' }));
     const call = () => ensureDevboxDashboardExport({
       port: 9001,
       remoteBaseConfigured: false,
       env: devboxEnv,
       cachePath,
+      envFileMode: 'ignore' as const,
       merlinCliPath: '/fake/merlin-cli',
       runExport,
     });


### PR DESCRIPTION
## 改了什么

#1060 合入后的补充修复。主要是一处 **fail-open**：`parseExportOutput` 遇到第一个带 `short_url` 的对象就采信，只要前面一条日志说私有、后面真实结果说公开，那个公开 URL 就会被接受并写进缓存，进而进入 dashboard 链接与 CSRF 可信 authority。

在当前 master 上可复现（`is_public:false` 的前提被绕过）：

```
输入 stdout:
  {"level":"preview","short_url":"https://public.example","is_public":false}
  {"short_url":"https://public.example","is_public":true}
当前 master 判定 = https://public.example   ← 应为 null
```

根因是导出输出把 stdout 与 stderr 拼成一个字符串再解析，噪声与结果同流。本 PR：

- `runMerlinExport` 保留 `{ stdout, stderr }` 边界。解析三态（命中 / 拒绝 / 无结果形状）：stdout 一旦判定歧义即 fail closed、**绝不回落 stderr**；只有 stdout 确实没有结果形状时才读 stderr 兼容旧形态
- 多个结果形状候选、重复或嵌套的 `short_url` / `is_public`、明文 `key=value`、JSON 字符串值里藏 verdict、Unicode 转义键名、未闭合的尾巴，一律 fail closed
- 副作用是解析不再被 stderr 噪声带偏：带冒号的花括号提示、Python 风格字典、Go `%v` 结构体打印、不配对花括号，此前会让整条解析失败（功能静默不启用），现在不影响

顺带三处：

- 歧义拒绝补 debug 日志，只记录固定原因，**不记录候选文本与 URL**；此前失败全程静默，真机上无法区分「不是 devbox」「`merlin-cli` 不可用」「被解析器拒了」
- 启动提示里剩余预算不足 500ms 时直接跳过导出，不再发起注定超时的 spawn，也不会因此点亮失败负缓存
- `~/.botmux/.env` 兜读改为显式 `envFileMode`（默认始终读取）。此前靠「调用方有没有传 `env`」推断，任何写成 `env: process.env` 的改写都会让关闭开关在 CLI 侧无声失效；测试改用显式 `ignore` 隔离，不再受开发机真实 `.env` 影响
- 修好一个空用例：注入点契约改成 `{ stdout, stderr }` 后，某个负缓存用例仍返回裸字符串，落进的是「runner 抛异常」分支，把它声称覆盖的那条写入点删掉后依然全绿（变异存活）

## 影响面

只影响 Merlin Devbox 自动导出这一条路径。普通主机在读任何文件之前就靠纯 env 判据提前返回，行为不变。中心平台与 `BOTMUX_PUBLIC_URL` 优先级不变。

## 验证

```
tsc --noEmit                exit 0
audit:domains               no private deployment hostnames found
git diff --check            exit 0
直接相关 7 个测试文件        209 passed
波及面 22 个测试文件         869 passed
带干扰 HOME 复跑解析用例      56 passed
```

新增用例覆盖 8 类 stderr 噪声形态与 16 条安全反例。每条修复都做了变异测试（改回缺陷形态后对应用例必须转红），包括：stdout 拒绝时回落 stderr、500ms 下限、`.env` 兜读按 env 推断、负缓存的两个写入点。

注：`tsconfig.json` 的 `include` 只有 `src/**/*`，测试文件不进 `tsc --noEmit`，所以注入点签名漂移这类问题类型检查发现不了，只能靠变异测试暴露。

真机行为仍以 Devbox 上的验收为准。
