### PR TITLE
fix(send): 删掉收敛引用时那条无效说明，不再给模型添噪音

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8820,11 +8820,6 @@ async function cmdSend(rest: string[]): Promise<void> {
       currentThreadId: probedThreadId,
       explicitQuote,
     })) {
-      logger.info(
-        `[send] quote target ${quoteTargetId.substring(0, 12)} was answered flat at top level but now `
-        + `belongs to topic ${String(probedThreadId).substring(0, 12)}; posting flat instead of quoting `
-        + 'so the reply does not land in an after-the-fact topic',
-      );
       effectiveQuoteTargetId = undefined;
     }
   }

--- a/test/send-after-the-fact-topic-quote-wiring.test.ts
+++ b/test/send-after-the-fact-topic-quote-wiring.test.ts
@@ -17,6 +17,29 @@ import { describe, expect, it } from 'vitest';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliSource = readFileSync(join(__dirname, '..', 'src', 'cli.ts'), 'utf8');
 
+/** 判据收敛块，按真实大括号配对取，不用固定行宽。固定宽度窗口两个方向都不安全：
+ *  窄了 → 块里新增几行就把目标推出窗口，干净代码也变红；宽了 → 越过闭合括号，
+ *  于是「赋值必须落在判据 if 块内」这类断言即便赋值被移到块外也照样通过。
+ *  剔除注释行，避免把代码注释掉后、注释里残留的同样字符仍能满足断言。 */
+function convergenceBlock(): string {
+  const lines = cliSource.split('\n');
+  const start = lines.findIndex(
+    l => l.includes('if (quoteTargetId && !explicitQuote && quotedTurnInThread === false)'),
+  );
+  if (start < 0) throw new Error('convergence block guard not found');
+  let depth = 0;
+  const out: string[] = [];
+  for (let i = start; i < lines.length; i++) {
+    out.push(lines[i]);
+    for (const ch of lines[i]) {
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+    }
+    if (i > start && depth <= 0) break;
+  }
+  return out.filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+}
+
 describe('botmux send: 事后开的话题不再被 quote 带进去（接线）', () => {
   it('判据从 send-policy 导入,不在 cli 里手抄一份', () => {
     // 手抄副本会让判据本体的变异测不到 —— 同一个 PR 的 dispatcher 侧已经踩过一次。
@@ -49,10 +72,7 @@ describe('botmux send: 事后开的话题不再被 quote 带进去（接线）',
     const live = assignLines.filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l));
     expect(live.length).toBeGreaterThan(0);
     // 且它落在判据的 if 块里。
-    const idx = lines.findIndex(l => l.includes('shouldDropAfterTheFactTopicQuote({'));
-    expect(idx).toBeGreaterThan(-1);
-    const block = lines.slice(idx, idx + 14).filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
-    expect(block).toMatch(/effectiveQuoteTargetId = undefined;/);
+    expect(convergenceBlock()).toMatch(/effectiveQuoteTargetId = undefined;/);
   });
 
   it('送进发送链的是**收敛后**的值,不是原始 quoteTargetId', () => {


### PR DESCRIPTION
#1069 的替代方案（该 PR 已关闭）。#1023 的收尾。

## 问题

#1023 在 `botmux send` 收敛引用目标时留了一条 `logger.info` 说明，它在生产里**从不产出任何输出**：`cli.ts:279` 对共享模块的 logger 做了 `setSilent(true)`（保 stdout 的 JSON 流不被 transitive 日志污染），`logger.ts:41` 于是在无 DEBUG 时直接早返回 —— **即便把 stdout 与 stderr 全量捕获也是 0 字节**（跑真 logger 模块验过）。

原先想把它改走 `console.error` 让它可见，复审后判断**这条说明本身不该保留**：

- `botmux send` 的 stderr **会被模型读回**（`cli.ts:9358` 注释明写 success 输出是 "the model reads back"），这类文案既占上下文（约 73 token），措辞还会诱发行为。
- 它宣告「本条改为平铺发送」却**不声明已送达成功**，而模型紧接着读到的是 `若还有要发给用户的内容，继续 botmux send` ⇒ 存在「没按要求引用 ⇒ 是否要重发」的误读空间。而重发是本仓明文在防的失败模式：`cli.ts:8218`（"which would invite a duplicate"）、`cli.ts:9370`（"else the agent retries → duplicate"）。
- 对比同类给模型看的提示，可见它的措辞是个异类：

| 位置 | 文案 | 宣告"偏离调用方意图" | 给"勿重发"定心话 |
|---|---|---|---|
| `cli.ts:9342/9345` | `⚠️ 附件未发送（主消息已送达 …，请勿重发）` | 是 | ✅ 有 |
| `cli.ts:8920` | `引用目标 … 已撤回，改为普通发送` | 否（纯客观陈述） | — |
| 被删这条 | `… 本条改为平铺发送，避免回复落进事后创建的话题` | **是** | ❌ **无** |

  ⇒ `8920` 不构成保留它的先例：那条陈述客观事实，这条宣告的是对调用方意图的改写。
- 它**不参与任何控制流**（不影响 exit code、不进 stdout JSON，判据/探测/收敛逻辑都不读它），删掉行为逐字不变。真要排查这条路径，`quotedMessageId: null` 加 Lark 原始 `thread_id` 是更直接的证据。

## 改动

- 删掉那条 `logger.info`
- 顺带修掉接线用例里的固定宽度窗口：原先 `slice(idx, idx + 14)` 截源码判断「收敛赋值必须落在判据 if 块内」。固定行宽**两个方向都不安全** —— 窄了被块内新增的行推出窗口（干净代码误红），宽了越过闭合括号（赋值被移到块外也照样通过）。改为按**大括号配对**取块

## 影响面

仅 `botmux send` 收敛引用目标时的一行输出 + 一条测试断言的取块方式。**不改变任何发送行为**：判据、探测、收敛逻辑与 #1023 逐字一致。

## 验证

均为实际执行结果：

- `tsc --noEmit` exit=0 零输出
- `bun run build` 通过；产物核对：`dist/cli.js` 已无该日志，收敛赋值仍在
- **相关 4 套件 + 全部 22 个以源码文本断言 `cli.ts` 的套件合计 846/846** 通过（删除会改变行偏移，所以把这类断言全跑了一遍）
- **bundle 级证明零行为变更**：分别编译改动前后的 `dist/cli.js` 逐语句比对，**整个 bundle 只少了这一条日志语句**（5 行纯删除，别处零差异）
- **反向变异**：把收敛赋值移出判据 if 块（改为无条件执行）→ **1 红**；同一变异在原先的 14 行窗口下是**全绿**，即该断言此前对这个方向没有牙

🤖 Generated with [Claude Code](https://claude.com/claude-code)
