### PR TITLE
fix(session-store): 修复 SQLite 导入孤儿 WAL

### DIFF
--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -521,7 +521,10 @@ function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
   const tmp = openDatabaseSyncOrThrow(tmpFp);
   try {
     tmp.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
-    tmp.exec('PRAGMA journal_mode = WAL;');
+    // The temporary file is renamed after close. WAL sidecars keep the old
+    // `.tmp` basename, so publishing only the main file strands the schema
+    // and rows on Bun. The live store switches to WAL when it is opened.
+    tmp.exec('PRAGMA journal_mode = DELETE;');
     tmp.exec('PRAGMA synchronous = NORMAL;');
     tmp.exec(SESSIONS_SCHEMA_SQL);
     tmp.exec('BEGIN');
@@ -531,6 +534,11 @@ function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
     }
     tmp.exec('COMMIT');
     tmp.close();
+    for (const suffix of ['-wal', '-shm']) {
+      if (existsSync(`${tmpFp}${suffix}`)) {
+        throw new Error(`temporary SQLite import left ${tmpFp}${suffix}`);
+      }
+    }
     renameSync(tmpFp, dbFp);
     return entries.length;
   } catch (err) {

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -514,7 +514,9 @@ function readJsonEntriesForImport(jsonFp: string): [string, Session][] {
 function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
   requireSqliteEngine(`会话存储 ${basename(dbFp)} 首次导入`);
   const tmpFp = `${dbFp}.tmp`;
-  for (const suffix of ['', '-wal', '-shm']) {
+  // `-journal` is DELETE mode's sidecar (the mode this import uses below);
+  // `-wal`/`-shm` cover a crash under an older WAL-based import.
+  for (const suffix of ['', '-journal', '-wal', '-shm']) {
     try { unlinkSync(`${tmpFp}${suffix}`); } catch { /* no leftover from a crashed import */ }
   }
   const entries = readJsonEntriesForImport(jsonFp);
@@ -534,7 +536,7 @@ function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
     }
     tmp.exec('COMMIT');
     tmp.close();
-    for (const suffix of ['-wal', '-shm']) {
+    for (const suffix of ['-journal', '-wal', '-shm']) {
       if (existsSync(`${tmpFp}${suffix}`)) {
         throw new Error(`temporary SQLite import left ${tmpFp}${suffix}`);
       }
@@ -543,7 +545,7 @@ function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
     return entries.length;
   } catch (err) {
     try { tmp.close(); } catch { /* already closed */ }
-    for (const suffix of ['', '-wal', '-shm']) {
+    for (const suffix of ['', '-journal', '-wal', '-shm']) {
       try { unlinkSync(`${tmpFp}${suffix}`); } catch { /* best-effort orphan cleanup */ }
     }
     throw err;

--- a/test/helpers/ts-runner.ts
+++ b/test/helpers/ts-runner.ts
@@ -30,6 +30,8 @@
  */
 
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions, type SpawnSyncOptions, type SpawnSyncReturns } from 'node:child_process';
+import { accessSync, constants } from 'node:fs';
+import { delimiter, join } from 'node:path';
 
 /** True when the current test process is running under Bun rather than Node. */
 export function isBunRuntime(): boolean {
@@ -136,4 +138,37 @@ export function spawnSyncTsEvalWithRepoImports(
   const { command, prefixArgs } = tsRunnerPrefix();
   const { args } = tsEvalArgs(source);
   return spawnSync(command, [...prefixArgs, ...args], options);
+}
+
+/** Resolve an executable Bun from the inherited PATH without invoking a shell. */
+export function resolveBunExecutable(pathValue: string = process.env.PATH ?? ''): string | undefined {
+  const names = process.platform === 'win32' ? ['bun.exe', 'bun.cmd', 'bun'] : ['bun'];
+  for (const dir of pathValue.split(delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = join(dir, name);
+      try {
+        accessSync(candidate, constants.X_OK);
+        return candidate;
+      } catch {
+        // Keep scanning PATH.
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Spawn an inline repo-importing snippet under Bun even when the parent test
+ * process runs under Node. Use only for behavior that is specifically Bun-only.
+ */
+export function spawnSyncBunTsEvalWithRepoImports(
+  source: string,
+  options: SpawnSyncOptions = {},
+): SpawnSyncReturns<string | Buffer> {
+  const command = resolveBunExecutable();
+  if (!command) {
+    throw new Error('bun not found on PATH; cannot run the required Bun-specific regression');
+  }
+  return spawnSync(command, ['-e', source], options);
 }

--- a/test/session-store-sqlite-bun-import.test.ts
+++ b/test/session-store-sqlite-bun-import.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSyncBunTsEvalWithRepoImports } from './helpers/ts-runner.js';
+
+function pinnedBunVersion(): string {
+  const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as {
+    packageManager?: string;
+  };
+  const match = /^bun@(.+)$/.exec(pkg.packageManager ?? '');
+  if (!match) throw new Error(`packageManager is not pinned to Bun: ${pkg.packageManager}`);
+  return match[1];
+}
+
+describe('first-start JSON import under Bun', () => {
+  it('publishes a complete store without temporary SQLite sidecars', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'sqlite-import-bun-'));
+    const fakeHome = mkdtempSync(join(tmpdir(), 'sqlite-import-home-'));
+    try {
+      const rows: Record<string, unknown> = {};
+      for (let i = 0; i < 40; i++) {
+        rows[`s${i}`] = {
+          sessionId: `s${i}`,
+          chatId: 'oc_chat',
+          rootMessageId: `om_s${i}`,
+          title: `t${i}`,
+          status: 'active',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          scope: 'topic',
+        };
+      }
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(rows));
+
+      const storeModule = join(process.cwd(), 'src', 'services', 'session-store.ts');
+      const source = `
+        const store = await import(${JSON.stringify(storeModule)});
+        store.init('appA');
+        console.log(JSON.stringify({
+          runtime: typeof Bun === 'undefined' ? 'node' : 'bun',
+          bunVersion: typeof Bun === 'undefined' ? null : Bun.version,
+          visible: store.listSessions().length,
+        }));
+      `;
+      const child = spawnSyncBunTsEvalWithRepoImports(source, {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+          SESSION_DATA_DIR: dataDir,
+        },
+      });
+
+      expect(child.error).toBeUndefined();
+      expect(child.status, String(child.stderr)).toBe(0);
+      const resultLine = String(child.stdout)
+        .split('\n')
+        .findLast(line => line.trim().startsWith('{'));
+      expect(resultLine, `Bun child produced no result. stderr:\n${child.stderr}`).toBeTruthy();
+      const result = JSON.parse(resultLine!) as {
+        runtime: string;
+        bunVersion: string | null;
+        visible: number;
+      };
+
+      expect(result.runtime).toBe('bun');
+      expect(result.bunVersion).toBe(pinnedBunVersion());
+      expect(result.visible).toBe(40);
+
+      const storeDir = join(dataDir, 'session-stores', 'appA');
+      expect(readdirSync(storeDir).filter(name => name.includes('.tmp'))).toEqual([]);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -107,9 +107,10 @@ describe('first-start JSON import', () => {
     // repairMissingChatScope 发生在导入期
     expect(imported.broken.scope).toBe('chat');
     // .db 落位后可由另一连接重新读取；导入临时库不能留下 basename
-    // 仍为 `.tmp` 的 WAL sidecar，否则 Bun 会把已提交内容留在孤儿 WAL 中。
+    // 仍为 `.tmp` 的日志 sidecar，否则 Bun 会把已提交内容留在孤儿日志中。
     const storeDir = join(tempDir, 'session-stores', 'appA');
     expect(existsSync(join(storeDir, 'sessions.db'))).toBe(true);
+    expect(existsSync(join(storeDir, 'sessions.db.tmp-journal'))).toBe(false);
     expect(existsSync(join(storeDir, 'sessions.db.tmp-wal'))).toBe(false);
     expect(existsSync(join(storeDir, 'sessions.db.tmp-shm'))).toBe(false);
     expect(imported.live.title).toBe('live');

--- a/test/session-store-sqlite.test.ts
+++ b/test/session-store-sqlite.test.ts
@@ -106,8 +106,13 @@ describe('first-start JSON import', () => {
     expect(imported.legacyCard).not.toHaveProperty('pendingResponseCardState');
     // repairMissingChatScope 发生在导入期
     expect(imported.broken.scope).toBe('chat');
-    // .db 落位，JSON 原地冻结（一个字节都不动）
-    expect(existsSync(join(tempDir, 'session-stores', 'appA', 'sessions.db'))).toBe(true);
+    // .db 落位后可由另一连接重新读取；导入临时库不能留下 basename
+    // 仍为 `.tmp` 的 WAL sidecar，否则 Bun 会把已提交内容留在孤儿 WAL 中。
+    const storeDir = join(tempDir, 'session-stores', 'appA');
+    expect(existsSync(join(storeDir, 'sessions.db'))).toBe(true);
+    expect(existsSync(join(storeDir, 'sessions.db.tmp-wal'))).toBe(false);
+    expect(existsSync(join(storeDir, 'sessions.db.tmp-shm'))).toBe(false);
+    expect(imported.live.title).toBe('live');
     expect(readFileSync(jsonFp, 'utf-8')).toBe(jsonBefore);
   });
 


### PR DESCRIPTION
## 变更
首次将 JSON 会话导入 SQLite 时，临时库显式改用 DELETE journaling（不再 WAL）：关闭后主库已自包含，单次 `renameSync` 即可完整发布。同时把导入路径三处 sidecar 循环统一到实际日志模式：pre-import 清理、post-close 守卫、error-path 清理都覆盖 `.tmp-journal`，并保留 `-wal`/`-shm` 以清理旧版本崩溃残留。

新增真正在 Bun 1.4.0 下运行生产导入路径的回归测试。测试通过统一的 `test/helpers/ts-runner.ts` 定位并启动 Bun，子进程自报运行时和版本，导入 40 行后重新读取，并断言没有任何 `.tmp-*` sidecar。

## 原因
Bun 1.4.0 下，导入路径的 prepared statement 尚未 finalize 时调用 `close()`，WAL 不会在关闭时完成 checkpoint。随后只重命名主库，`-wal`/`-shm` 仍保留 `.tmp` basename，schema 和已提交行被留在孤儿 WAL 中；发布后的 `sessions.db` 重开时会报 `SQLite disk I/O error` 或呈现为空库。

DELETE 模式使一次性构建产物在提交后由主文件自包含，不依赖 WAL checkpoint 和多文件同步 rename。live store 打开后仍按既有逻辑切到 WAL。

## 影响范围
仅改 JSON 首次导入的 SQLite 初始化路径及其回归测试；其他 CLI、后端及话题/群组会话路径没有改动。本 PR 阻止新坏库产生，不处理旧版本已经发布的损坏库；存量恢复另行跟进。

## 验证
- `bun run build`：通过
- `bun run test -- test/session-store-sqlite-bun-import.test.ts test/session-store-sqlite.test.ts`：2 个文件、20/20 通过
- 变异验证：仅把导入临时库改回 WAL，新回归稳定失败，Bun 子进程读回 `0/40` 行
- 子进程断言实际运行时为 Bun，且 `Bun.version` 与 `packageManager` 的 `bun@1.4.0` 一致
- `bun run daemon:restart`：通过