### PR TITLE
fix(lark): 透传发送失败的飞书错误详情

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -2074,6 +2074,16 @@ function shortLarkPath(url: unknown): string {
  * access token can't leak.
  */
 export function formatLarkError(v: any): string | null {
+  // The SDK logger calls logger.error(formatErrors(error)), so its first
+  // argument is an array containing the already-sanitized Axios shape. Accept
+  // that wrapper here as well as the raw error received by CLI callers.
+  if (Array.isArray(v)) {
+    for (const item of v) {
+      const formatted = formatLarkError(item);
+      if (formatted) return formatted;
+    }
+    return null;
+  }
   if (!v || typeof v !== 'object') return null;
   const isAxios = v.isAxiosError === true || v.name === 'AxiosError' || (v.config && (v.response || v.status != null));
   if (!isAxios) return null;

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -2103,6 +2103,12 @@ export function formatLarkError(v: any): string | null {
   if (typeof code === 'number') parts.push(`code=${code}`);
   if (typeof msg === 'string' && msg) parts.push(`"${msg}"`);
   if (logId) parts.push(`log_id=${logId}`);
+  // Without an HTTP response, the transport code/message is the only useful
+  // signal. Keep it while still excluding config, headers, and stack.
+  if (httpStatus == null && typeof code !== 'number') {
+    if (typeof v.code === 'string' && v.code) parts.push(v.code);
+    if (typeof v.message === 'string' && v.message) parts.push(`"${v.message}"`);
+  }
   if (!parts.length) return null;
   return parts.join(' ');
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,7 +130,7 @@ import {
   PM2_DAEMON_KILL_TIMEOUT_MS,
   PM2_DAEMON_RESTART_DELAY_MS,
 } from './core/shutdown-budgets.js';
-import { dispatchPrimaryMessage, findStdinAliasAttachment, normalizeInteractiveCardInput, sendFileAttachments, sendVideoAttachments, shouldSendAsPureVideo, validateSlashSend, validateVideoAttachments } from './cli/send-dispatch.js';
+import { describeSendFailure, dispatchPrimaryMessage, findStdinAliasAttachment, normalizeInteractiveCardInput, sendFileAttachments, sendVideoAttachments, shouldSendAsPureVideo, validateSlashSend, validateVideoAttachments } from './cli/send-dispatch.js';
 import { buildCardPatchSuccessOutput, CARD_COMMAND_USAGE, CARD_PATCH_USAGE, cardPatchArgsWantHelp, executeCardPatch, parseCardPatchArgs, readCardPatchInput } from './cli/card-dispatch.js';
 import { dispatchDeferredTopicSend, reusableDeferredTopicRoot, type DeferredScheduleRunData } from './cli/deferred-topic-send.js';
 import { readDeferredTopicBinding } from './core/deferred-topic-binding.js';
@@ -7021,7 +7021,7 @@ import { resolveFeedbackPolicyForDelivery, resolveFeedbackTeamId } from './servi
 import { normalizeFeedbackPolicy } from './services/feedback-policy.js';
 import { applyInlineMentions } from './im/lark/inline-mentions.js';
 import { renderBrandTemplate } from './im/lark/brand-template.js';
-import { effectiveDefaultWorkingDir, formatLarkError, loadBotConfigs, resolveBrandLabel, resolveUsageDisplay } from './bot-registry.js';
+import { effectiveDefaultWorkingDir, loadBotConfigs, resolveBrandLabel, resolveUsageDisplay } from './bot-registry.js';
 import { config } from './config.js';
 import { getSessionUsageSnapshot } from './core/cost-calculator.js';
 import {
@@ -7038,12 +7038,6 @@ import {
   managedVcSendPayloadError,
   containsLarkAtTag,
 } from './services/send-policy.js';
-
-/** Keep provider details visible to the agent without leaking Axios config. */
-function describeSendFailure(err: unknown): string {
-  return formatLarkError(err)
-    ?? (err instanceof Error && err.message ? err.message : String(err));
-}
 
 /**
  * Sandbox relay mode for `botmux send`. Inside a file-sandbox the CLI cannot

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7021,7 +7021,7 @@ import { resolveFeedbackPolicyForDelivery, resolveFeedbackTeamId } from './servi
 import { normalizeFeedbackPolicy } from './services/feedback-policy.js';
 import { applyInlineMentions } from './im/lark/inline-mentions.js';
 import { renderBrandTemplate } from './im/lark/brand-template.js';
-import { effectiveDefaultWorkingDir, loadBotConfigs, resolveBrandLabel, resolveUsageDisplay } from './bot-registry.js';
+import { effectiveDefaultWorkingDir, formatLarkError, loadBotConfigs, resolveBrandLabel, resolveUsageDisplay } from './bot-registry.js';
 import { config } from './config.js';
 import { getSessionUsageSnapshot } from './core/cost-calculator.js';
 import {
@@ -7038,6 +7038,12 @@ import {
   managedVcSendPayloadError,
   containsLarkAtTag,
 } from './services/send-policy.js';
+
+/** Keep provider details visible to the agent without leaking Axios config. */
+function describeSendFailure(err: unknown): string {
+  return formatLarkError(err)
+    ?? (err instanceof Error && err.message ? err.message : String(err));
+}
 
 /**
  * Sandbox relay mode for `botmux send`. Inside a file-sandbox the CLI cannot
@@ -8365,7 +8371,7 @@ async function cmdSend(rest: string[]): Promise<void> {
           : {}),
       }));
     } catch (e: any) {
-      console.error(`语音发送失败：${e?.message ?? e}`);
+      console.error(`语音发送失败：${describeSendFailure(e)}`);
       if (dir) { try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ } }
       process.exit(1);
     }
@@ -8433,7 +8439,7 @@ async function cmdSend(rest: string[]): Promise<void> {
       console.error(`✓ 已回复文档评论 ${exactDocTarget.commentId.slice(0, 12)}（${chunks.length} 条）`);
       console.log(JSON.stringify({ success: true, commentId: exactDocTarget.commentId, sessionId: originSessionId, kind: 'doc-comment', chunks: chunks.length }));
     } catch (e: any) {
-      console.error(`文档评论发送失败：${e?.message ?? e}`);
+      console.error(`文档评论发送失败：${describeSendFailure(e)}`);
       process.exit(1);
     }
     return;
@@ -9435,7 +9441,7 @@ async function cmdSend(rest: string[]): Promise<void> {
         : {}),
     }));
   } catch (err: any) {
-    console.error(`发送失败: ${err.message}`);
+    console.error(`发送失败: ${describeSendFailure(err)}`);
     process.exit(1);
   }
 }

--- a/src/cli/send-dispatch.ts
+++ b/src/cli/send-dispatch.ts
@@ -1,4 +1,5 @@
 import { extname } from 'node:path';
+import { formatLarkError } from '../bot-registry.js';
 import type { ManagedHookOrigin } from '../services/hook-runner.js';
 
 export type SendMessageFn = (
@@ -113,7 +114,7 @@ export async function sendFileAttachments(
       await deps.beforeEffect?.();
       sent.push(await deps.dispatch(JSON.stringify({ file_key: fileKey }), 'file'));
     } catch (err: any) {
-      failed.push({ path: fp, error: err?.message ?? String(err) });
+      failed.push({ path: fp, error: formatLarkError(err) ?? err?.message ?? String(err) });
     }
   }
   return { sent, failed };
@@ -406,7 +407,7 @@ export async function sendVideoAttachments(
       failed.push({
         path: video.videoPath,
         coverPath: video.coverPath,
-        error: err?.message ?? String(err),
+        error: formatLarkError(err) ?? err?.message ?? String(err),
       });
     }
   }

--- a/src/cli/send-dispatch.ts
+++ b/src/cli/send-dispatch.ts
@@ -28,6 +28,12 @@ export type DispatchPrimaryDeps = {
   replyMessage: ReplyMessageFn;
 };
 
+/** Keep provider details visible without leaking Axios config or headers. */
+export function describeSendFailure(err: unknown): string {
+  return formatLarkError(err)
+    ?? (err instanceof Error && err.message ? err.message : String(err));
+}
+
 /**
  * Paths that resolve to the process's own stdin. `botmux send` reads stdin for
  * the message body (the documented `echo "msg" | botmux send` form), so passing
@@ -113,8 +119,8 @@ export async function sendFileAttachments(
       const fileKey = await deps.uploadFile(appId, fp);
       await deps.beforeEffect?.();
       sent.push(await deps.dispatch(JSON.stringify({ file_key: fileKey }), 'file'));
-    } catch (err: any) {
-      failed.push({ path: fp, error: formatLarkError(err) ?? err?.message ?? String(err) });
+    } catch (err: unknown) {
+      failed.push({ path: fp, error: describeSendFailure(err) });
     }
   }
   return { sent, failed };
@@ -403,11 +409,11 @@ export async function sendVideoAttachments(
       const messageId = await send(content, 'media');
       primaryUsed = true;
       sent.push(messageId);
-    } catch (err: any) {
+    } catch (err: unknown) {
       failed.push({
         path: video.videoPath,
         coverPath: video.coverPath,
-        error: formatLarkError(err) ?? err?.message ?? String(err),
+        error: describeSendFailure(err),
       });
     }
   }

--- a/test/cli-send-dispatch.test.ts
+++ b/test/cli-send-dispatch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  describeSendFailure,
   dispatchPrimaryMessage,
   findStdinAliasAttachment,
   normalizeInteractiveCardInput,
@@ -11,6 +12,32 @@ import {
 } from '../src/cli/send-dispatch.js';
 
 class MessageWithdrawnError extends Error {}
+
+describe('describeSendFailure', () => {
+  it('preserves Lark business details instead of falling back to the HTTP message', () => {
+    const err = {
+      isAxiosError: true,
+      message: 'Request failed with status code 400',
+      config: { method: 'post', url: 'https://open.feishu.cn/open-apis/im/v1/messages' },
+      response: {
+        status: 400,
+        data: {
+          code: 230022,
+          msg: 'content contains sensitive information',
+          log_id: 'LOGREAL123',
+        },
+      },
+    };
+
+    expect(describeSendFailure(err)).toBe(
+      'POST im/v1/messages → 400 code=230022 "content contains sensitive information" log_id=LOGREAL123',
+    );
+  });
+
+  it('falls back to a plain Error message for non-Lark failures', () => {
+    expect(describeSendFailure(new Error('upload boom'))).toBe('upload boom');
+  });
+});
 
 describe('dispatchPrimaryMessage hook context wiring', () => {
   const baseOptions = {

--- a/test/cli-send-dispatch.test.ts
+++ b/test/cli-send-dispatch.test.ts
@@ -218,6 +218,28 @@ describe('sendFileAttachments (best-effort, never throws after primary send)', (
       { path: '/y', error: 'dispatch down' },
     ]);
   });
+
+  it('surfaces the Lark business error (code/log_id) instead of a bare HTTP message', async () => {
+    const uploadFile = vi.fn(async (_app: string, p: string) => {
+      if (p === '/bad') {
+        throw {
+          isAxiosError: true,
+          config: { method: 'post', url: 'https://open.feishu.cn/open-apis/im/v1/messages' },
+          response: { status: 400, data: { code: 230022, msg: 'content contains sensitive information', log_id: 'LOG789' } },
+          message: 'Request failed with status code 400',
+        };
+      }
+      return `key:${p}`;
+    });
+    const dispatch = vi.fn(async (content: string) => `om:${content}`);
+
+    const res = await sendFileAttachments({ uploadFile, dispatch }, 'cli_app', ['/bad']);
+
+    expect(res.failed).toEqual([{
+      path: '/bad',
+      error: 'POST im/v1/messages → 400 code=230022 "content contains sensitive information" log_id=LOG789',
+    }]);
+  });
 });
 
 describe('shouldSendAsPureVideo', () => {

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -46,7 +46,7 @@ describe('cmdSend hook context wiring', () => {
     const cmdSendStart = cliSource.indexOf('async function cmdSend(');
     const cmdDispatchStart = cliSource.indexOf('async function cmdDispatch(', cmdSendStart);
     const cmdSend = cliSource.slice(cmdSendStart, cmdDispatchStart);
-    expect(cliSource).toContain('function describeSendFailure(err: unknown): string');
+    expect(cliSource).toContain('describeSendFailure');
     expect(cmdSend).toContain('语音发送失败：${describeSendFailure(e)}');
     expect(cmdSend).toContain('文档评论发送失败：${describeSendFailure(e)}');
     expect(cmdSend).toContain('发送失败: ${describeSendFailure(err)}');

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -42,6 +42,16 @@ function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{
 }
 
 describe('cmdSend hook context wiring', () => {
+  it('passes Lark business error details through every cmdSend failure exit', () => {
+    const cmdSendStart = cliSource.indexOf('async function cmdSend(');
+    const cmdDispatchStart = cliSource.indexOf('async function cmdDispatch(', cmdSendStart);
+    const cmdSend = cliSource.slice(cmdSendStart, cmdDispatchStart);
+    expect(cliSource).toContain('function describeSendFailure(err: unknown): string');
+    expect(cmdSend).toContain('语音发送失败：${describeSendFailure(e)}');
+    expect(cmdSend).toContain('文档评论发送失败：${describeSendFailure(e)}');
+    expect(cmdSend).toContain('发送失败: ${describeSendFailure(err)}');
+  });
+
   it('strips trailing memory citations before relay and direct-send rendering', () => {
     const relayStart = cliSource.indexOf('async function relaySend(');
     const relayEnd = cliSource.indexOf('\nfunction currentBotIsApiOnly', relayStart);

--- a/test/lark-error-format.test.ts
+++ b/test/lark-error-format.test.ts
@@ -65,6 +65,16 @@ describe('formatLarkError', () => {
     expect(formatLarkError(err)).toBe('POST im/v1/messages → 403 code=230002 "bot not in chat"');
   });
 
+  it('unwraps the nested array passed by the Lark SDK logger', () => {
+    const sdkLoggerArg = [[{
+      config: { method: 'post', url: 'https://open.feishu.cn/open-apis/im/v1/messages' },
+      response: { status: 400, data: { code: 230022, msg: 'content contains sensitive information', log_id: 'LOG456' } },
+    }]];
+    expect(formatLarkError(sdkLoggerArg)).toBe(
+      'POST im/v1/messages → 400 code=230022 "content contains sensitive information" log_id=LOG456',
+    );
+  });
+
   it('returns null for non-axios values so callers fall back', () => {
     expect(formatLarkError('plain string')).toBeNull();
     expect(formatLarkError({ hello: 'world' })).toBeNull();

--- a/test/lark-error-format.test.ts
+++ b/test/lark-error-format.test.ts
@@ -3,7 +3,7 @@
  * a single triage line (status + code/msg/log_id) without leaking the bearer
  * token or dumping the stack/config blob.
  *
- * Run:  pnpm vitest run test/lark-error-format.test.ts
+ * Run:  bun run test -- test/lark-error-format.test.ts
  */
 import { describe, it, expect, vi } from 'vitest';
 
@@ -55,6 +55,28 @@ describe('formatLarkError', () => {
       status: 400,
     };
     expect(formatLarkError(err)).toBe('GET contact/v3/users/ou_x → 400');
+  });
+
+  it('preserves the transport code and message when no HTTP response exists', () => {
+    const err = {
+      name: 'AxiosError',
+      code: 'ECONNREFUSED',
+      message: 'connect ECONNREFUSED 127.0.0.1:1',
+      config: {
+        method: 'post',
+        url: 'https://open.feishu.cn/open-apis/im/v1/messages',
+        headers: { Authorization: 'Bearer t-secretToken' },
+      },
+    };
+    expect(formatLarkError(err)).toBe(
+      'POST im/v1/messages → ? ECONNREFUSED "connect ECONNREFUSED 127.0.0.1:1"',
+    );
+
+    expect(formatLarkError({
+      name: 'AxiosError',
+      message: 'timeout of 15000ms exceeded',
+      config: { method: 'post', url: 'https://open.feishu.cn/open-apis/im/v1/messages' },
+    })).toBe('POST im/v1/messages → ? "timeout of 15000ms exceeded"');
   });
 
   it('detects axios shape via config+response even without name', () => {


### PR DESCRIPTION
## 改动
飞书 SDK 在 HTTP 400/4xx 时会抛出包含 `response.data.code/msg/log_id` 的 AxiosError，但 `botmux send` 原来只输出 `err.message`，agent 只能看到通用 HTTP 状态。

本 PR 增加脱敏错误格式化：提取 HTTP 方法、API 路径、状态码、飞书业务错误码、描述和 `log_id`，不输出 Axios `config`、请求头或 stack。兼容 SDK logger 传入的嵌套数组，并接入普通文本、语音、文档评论、附件和视频发送失败路径。

对于没有 HTTP response 的超时、断连、DNS 等 transport failure，格式化结果额外保留 transport code/message，例如 `POST im/v1/messages → ? ECONNREFUSED "connect ECONNREFUSED 127.0.0.1:1"`。已有 HTTP/飞书业务错误输出保持不变。

发送错误描述逻辑收敛为 `send-dispatch` 导出的 `describeSendFailure`，CLI 与附件/视频路径共用，并通过行为测试直接验证，不再只依赖源码字符串守卫。

## 影响面
- 只改变 Lark 发送失败的 CLI/日志错误展示，不改变成功发送、重试、路由或权限逻辑。
- `botmux send` 的 sandbox relay 会原样转发 host CLI 的 stderr，因此隔离会话也能看到相同错误详情。
- 无 response 时只读取 error 的 `code`/`message`；仍不序列化 config、headers 或 stack。
- 其他 CLI 适配器、后端和会话类型没有行为改动。

## 验证
- `bun run test -- test/lark-error-format.test.ts test/cli-send-dispatch.test.ts test/cli-send-hook-context.test.ts`：3 个文件、70/70 通过
- 覆盖 HTTP 业务错误、ECONNREFUSED、仅 message 的 timeout、普通 Error fallback、附件/视频失败路径
- 变异验证：移除 helper 对 `formatLarkError` 的调用后，直接行为测试及附件业务错误测试均失败
- `bun run build`：通过
- `bun run daemon:restart`：通过