### PR TITLE
fix(traex): 兼容新版活动状态避免假空闲

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -106,9 +106,10 @@ export const TRAE_MIGRATION_DONE_MARKERS = [
  *  - Standalone queue notice: "Too many requests right now. You're in the
  *    queue."
  *
- * TraeX forked from Codex and DELETED the "esc to interrupt" footer hint —
- * `grep -a -c "esc to interrupt"` returns 0 across every local release and
- * the 94MB TUI logs — so the Codex pattern's second anchor is invalid here.
+ * A live TraeX 0.201.6 turn also renders an `esc to interrupt` activity
+ * footer while retaining the visible composer and context bar. Raw PTY and
+ * 100ms screen captures verified seven rotating glyphs and ordinary activity
+ * labels as well as PreToolUse/PostToolUse/UserPromptSubmit hook-runner rows.
  *
  * Three branches:
  *  1. Spinner-anchored labels: "<braille frame><space><label>". The frame
@@ -123,7 +124,13 @@ export const TRAE_MIGRATION_DONE_MARKERS = [
  *     so the frame anchor must not be required for it. The line anchor keeps
  *     assistant prose quoting the string mid-sentence ("…says Queued for
  *     capacity whenever…") from registering as busy.
- *  3. (staticBusyPattern below) the same queue evidence as a pre-idle latch
+ *  3. Line-anchored activity rows. These require one of the seven observed
+ *     rotating glyphs, a no-parentheses activity label, and an elapsed-time /
+ *     `esc to interrupt` footer in one pair of parentheses. A closing quote
+ *     immediately after the footer is rejected so `◆ Ran echo "(...)"`
+ *     history cannot revive an already-idle session. Hook-runner rows use the
+ *     same footer shape, so they need no event-name-specific arm.
+ *  4. (staticBusyPattern below) the same queue evidence as a pre-idle latch
  *     inside IdleDetector — see TRAEX_STATIC_BUSY_PATTERN.
  *
  * Both states must be covered: the worker's busy-pattern idle probe marks
@@ -169,10 +176,15 @@ const TRAEX_QUEUE_STATIC_ARMS = [
   "Too many requests right now\\. You're in the queue",
 ];
 
+/** TraeX activity footer captured from a live 0.201.6 TUI. Keep it line- and
+ *  glyph-anchored: no-alt-screen history can contain the same words. */
+const TRAEX_ACTIVITY_PATTERN = String.raw`(?:^|[\n\r])[ \t]*[⋄✧◇✦❖◈◆][ \t]*[^()\r\n]{0,240}\([^()\r\n]*\d+(?:h|m|s)(?:[ \t]+\d+(?:m|s))?[^()\r\n]*\besc[ \t]+to[ \t]+interrupt\b[^()\r\n]*\)(?![ \t]*["'\x60])`;
+
 const TRAEX_ACTIVE_BUSY_PATTERN = new RegExp(
   [
     `[${TRAEX_SPINNER_FRAMES}][ \\t]?(?:${TRAEX_SPINNER_LABELS.join('|')})`,
     ...TRAEX_QUEUE_STATIC_ARMS.map((arm) => `(?:^|[\\n\\r])[ \\t]*${arm}`),
+    TRAEX_ACTIVITY_PATTERN,
   ].join('|'),
   'i',
 );

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1879,7 +1879,7 @@ describe('busyPattern', () => {
     expect(busy!.test('press esc to interrupt')).toBe(false);
   });
 
-  it('traex matches spinner-anchored working labels and standalone queue strings but not prose or idle composer', () => {
+  it('traex matches spinner, queue, and live activity rows but not history or idle composer', () => {
     // Regression: a static capacity-queue screen matches readyPattern's
     // `\d+% left` status-bar arm and survives the 2s quiescence window,
     // flipping the card/Dashboard to Idle while the session is still waiting
@@ -1898,9 +1898,8 @@ describe('busyPattern', () => {
     //   queue strings:   "Queued for capacity",
     //                    "Too many requests right now. You're in the queue."
     //   idle composer:   "Ask TraeCode CLI to do anything" + "100% context left"
-    // TraeX forked from Codex and DELETED the "esc to interrupt" footer hint
-    // (0 hits across all releases + the 94MB TUI logs), so the Codex
-    // pattern's second anchor is invalid here.
+    // Live 0.201.6 raw-PTY + screen captures verified all seven rotating
+    // activity glyphs and hook-runner labels with the same footer shape.
     const busy = createTraexAdapter('/bin/traex').busyPattern;
     expect(busy).toBeDefined();
     // Spinner-anchored working labels: "<braille frame> <label>".
@@ -1921,6 +1920,18 @@ describe('busyPattern', () => {
     expect(busy!.test('Queued for capacity at position 3.')).toBe(true);
     expect(busy!.test("Too many requests right now. You're in the queue.")).toBe(true);
     expect(busy!.test("Too many requests right now. You're in the queue at position 3.")).toBe(true);
+    // Live activity and hook-runner shapes across the full rotating glyph set.
+    for (const glyph of [...'⋄✧◇✦❖◈◆']) {
+      expect(busy!.test(`${glyph} Working… (2s • esc to interrupt)`)).toBe(true);
+    }
+    expect(busy!.test('⋄ Running 4 PreToolUse hooks (7s • esc to interrupt)')).toBe(true);
+    expect(busy!.test('❖ Running 2 PostToolUse hooks (13s • esc to interrupt)')).toBe(true);
+    expect(busy!.test('✦ Running 3 UserPromptSubmit hooks (0s • esc to interrupt)')).toBe(true);
+    expect(busy!.test('◆ Running 2 Stop hooks (21s • ↓ 73 tokens • esc to interrupt)')).toBe(true);
+    expect(busy!.test('✦ Running Notification hook (22s • ↓ 73 tokens • esc to interrupt)')).toBe(true);
+    expect(busy!.test('◈ 读取 Bubble resource draft… (36m 20s • ↑ 68.7K tokens • esc to interrupt)')).toBe(true);
+    expect(busy!.test('  ⋄Working… (0s • esc to interrupt)────────────────────')).toBe(true);
+    expect(busy!.test('✧ Reading 2 files… (5s • esc to interrupt)\r\n')).toBe(true);
     // Mid-sentence prose quotes must NOT match — the line anchor is the
     // discriminator for the standalone arms (the braille frame for the
     // spinner arms).
@@ -1932,6 +1943,16 @@ describe('busyPattern', () => {
     expect(busy!.test('Working… on the fix')).toBe(false);
     expect(busy!.test('Working through the implementation')).toBe(false);
     expect(busy!.test('press esc to interrupt')).toBe(false);
+    expect(busy!.test('The previous status was ✦ Running 2 PreToolUse hooks')).toBe(false);
+    expect(busy!.test('◆ Ran rg for esc to interrupt')).toBe(false);
+    expect(busy!.test('◆ Ran echo "(36m 20s • ↑ 68.7K tokens • esc to interrupt)"')).toBe(false);
+    expect(busy!.test("◆ Ran echo '(36m 20s • ↑ 68.7K tokens • esc to interrupt)'")).toBe(false);
+    expect(busy!.test('◆ Ran echo `(36m 20s • ↑ 68.7K tokens • esc to interrupt)`')).toBe(false);
+    expect(busy!.test('◆ Ran grep (2m 3s) for "esc to interrupt" in logs')).toBe(false);
+    expect(busy!.test('◇ diff (12s): -◈ old (1m 1s • esc to interrupt)')).toBe(false);
+    // Accepted recall-first residual: tightening this would reject observed PTY
+    // footer redraws that append separators/content in the same logical line.
+    expect(busy!.test('◈ note: the footer reads (36m 20s • esc to interrupt) now')).toBe(true);
   });
 
   it('traex staticBusyPattern latches only on line-anchored queue evidence', () => {
@@ -1995,6 +2016,9 @@ describe('idleToBusyPattern', () => {
     // Standalone queue strings.
     expect(adapter.idleToBusyPattern!.test('Queued for capacity')).toBe(true);
     expect(adapter.idleToBusyPattern!.test("Too many requests right now. You're in the queue.")).toBe(true);
+    expect(adapter.idleToBusyPattern!.test('⋄ Running 4 PreToolUse hooks (7s • esc to interrupt)')).toBe(true);
+    expect(adapter.idleToBusyPattern!.test('❖ Running 2 PostToolUse hooks (13s • esc to interrupt)')).toBe(true);
+    expect(adapter.idleToBusyPattern!.test('◈ Updating resources (12m 4s • ↑ 8.2K tokens • esc to interrupt)')).toBe(true);
     // Prose without the braille frame anchor must NOT flip idle→busy.
     expect(adapter.idleToBusyPattern!.test('Working… on the fix')).toBe(false);
   });

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -223,8 +223,8 @@ describe('IdleDetector: TraeX capacity-queue busy pattern', () => {
   //   queue strings:   "Queued for capacity",
   //                    "Too many requests right now. You're in the queue."
   //   idle composer:   "Ask TraeCode CLI to do anything" + "100% context left"
-  // TraeX forked from Codex and DELETED the "esc to interrupt" footer hint
-  // (0 hits across all releases + the 94MB TUI logs).
+  // Live 0.201.6 captures verified seven activity glyphs and hook-runner rows
+  // using the same elapsed-time / `esc to interrupt` footer.
   const traexAdapter = createTraexAdapter('/bin/true');
 
   it('flips a queued session back to busy when the capacity-queue string renders after a false idle', () => {
@@ -279,6 +279,36 @@ describe('IdleDetector: TraeX capacity-queue busy pattern', () => {
     detector.fireIdle();
     detector.feed('\x1b[2K⠹ Pondering…');
     expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('flips busy on live hook-runner and activity rows across rotating glyphs', () => {
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('\x1b[2K\x1b[38;5;2m⋄\x1b[0m Running 4 PreToolUse hooks (7s • esc to interrupt)');
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    detector.fireIdle();
+    detector.feed('\x1b[2K❖ Running 2 PostToolUse hooks (13s • esc to interrupt)');
+    expect(cb).toHaveBeenCalledTimes(2);
+    detector.dispose();
+  });
+
+  it('does not promote transcript prose, commands, or diff history quoting activity text', () => {
+    const detector = new IdleDetector(traexAdapter);
+    const cb = vi.fn();
+    detector.onBusy(cb);
+
+    detector.fireIdle();
+    detector.feed('The previous status was ✦ Running 2 PreToolUse hooks');
+    detector.feed('\n◆ Ran rg for esc to interrupt');
+    detector.feed('\n◆ Ran echo "(36m 20s • ↑ 68.7K tokens • esc to interrupt)"');
+    detector.feed('\n◆ Ran grep (2m 3s) for "esc to interrupt" in logs');
+    detector.feed('\n◇ diff (12s): -◈ old (1m 1s • esc to interrupt)');
+    expect(cb).not.toHaveBeenCalled();
     detector.dispose();
   });
 


### PR DESCRIPTION
## 问题

TraeX 0.201.6 的真实 TUI 在 turn 仍运行时会保留 composer/context bar，同时渲染带活动 glyph、耗时及 `esc to interrupt` 的 activity footer；hook-runner 也使用同一 footer 形态，例如：

- `⋄ Running 4 PreToolUse hooks (7s • esc to interrupt)`
- `◆ Running 2 Stop hooks (21s • ↓ 73 tokens • esc to interrupt)`
- `◈ Working… (2s • esc to interrupt)`

现有 TraeX `readyPattern` 会命中仍可见的 composer 或 `Context N% left`，而原有 `busyPattern` 只覆盖旧 spinner 文案和 capacity queue，未覆盖上述 activity footer。PTY 短暂静默后，Botmux 可能提前把仍在执行的 TraeX session 标记为 idle，并触发 DONE reaction。

## 根因

这是既有 TUI 形态未被 adapter 完整覆盖，而不是已确认的 0.201.6 新增版本边界。旧 `busyPattern` 无法抵消仍在屏幕上的 `readyPattern` 证据，导致活跃 turn 被误判为 idle。

这与 #928 修复的 capacity queue 假 Idle 属于同一类 UI 形态漂移：`readyPattern` 仍可见，但对应的 busy 证据未被识别。

## 改动

- 扩展 TraeX 专属 `busyPattern` / `idleToBusyPattern`，新增统一 activity-footer grammar：
  - 行首为真机观察到的 7 个轮换 glyph：`⋄✧◇✦❖◈◆`；
  - activity 描述后必须存在同一对括号内的 elapsed time 与 `esc to interrupt`；
  - hook-runner 与普通 activity row 走同一规则，不枚举 hook 事件名。
- 保留 master 原有的 spinner 文案和 capacity queue 分支，旧版本已有识别能力不变。
- 使用无括号描述段和右括号后的引号阻断，排除 `◆ Ran ...`、echo、grep、diff 等历史行误唤醒；不使用严格行尾锚，兼容真实 PTY 重绘把分隔线/后续内容拼到 footer 后的情况。
- 保留现有 `readyPattern`，避免重新引入首次 prompt 注入延迟/丢失问题。
- 不修改公共 `IdleDetector`、structured lifecycle gate 或其他 CLI adapter。

## 关于初版 hook 专用 arm

初版 PR 曾增加只匹配固定 `✦` 与 `PreToolUse/PostToolUse`、且允许无 footer 的候选 arm；它并非 master 中的既有兼容逻辑。

随后通过 raw PTY 和每 100ms screen capture 复测，实际捕获到的 `PreToolUse`、`PostToolUse`、`UserPromptSubmit`、`Stop`、`Notification` hook-runner 行均带 elapsed / `esc to interrupt` footer，glyph 也会轮换；本次采样未观察到 footer-less hook frame。因此当前实现用统一 footer grammar 替代该候选 arm：覆盖事件和 glyph 更完整，也避免无 footer 的宽松历史行触发 `idleToBusyPattern`。

这不构成对低版本的回退：master 从未包含该 arm，且 master 原有 spinner/queue 规则均完整保留。如果未来获得某版本 footer-less hook frame 的真实捕获，可再基于该证据增加有边界的兼容分支。

## 取舍

`◈ note: the footer reads (36m 20s • esc to interrupt) now` 这类极少见、恰好以活动 glyph 开头并包含完整 footer 形态的正文仍可能判 busy。当前选择 recall-first：更严格的行尾/尾随文本约束会漏掉已经观察到的真实 PTY footer 重绘，重新引入本 PR 要修复的提前 DONE。对应行为已用测试显式记录。

## 影响面

- 仅影响 TraeX CLI 的 screen busy/idle 判断。
- PTY/tmux 的首次 idle 防护和 idle→busy 自愈复用现有路径。
- 其他 CLI、消息投递和 lifecycle-blocking 行为不变。
- 未引入按 CLI 版本分支；当前 adapter/runtime 不按版本选择 screen pattern，兼容形态并集比未经证实的 semver 边界更稳妥。

## 真机验证

在独立临时 Git 目录中配置两个各延迟 4 秒、无业务副作用的同步 hook，通过独立 tmux 启动 TraeX 0.201.6，并在 turn 前挂 `pipe-pane` 抓 raw PTY，同时每 100ms 采集 screen。

实测确认：

- 7 个活动 glyph 全部出现：`⋄✧◇✦❖◈◆`；
- hook-runner 与普通活动态共用 elapsed / `esc to interrupt` footer；
- 捕获到 `PreToolUse`、`PostToolUse`、`UserPromptSubmit`、`Stop`、`Notification` hook 行；
- hook-runner glyph 同样轮换；
- 本次 raw PTY 与 100ms screen 采样未观察到 footer-less hook 行。

实验后已关闭独立 tmux、删除临时目录/raw PTY/screen/hook 日志，并移除 TraeX 自动写入的临时项目 trust 记录。未修改全局 hook，未重启 Botmux；无新增软件安装。

## 测试

- 正向：7 帧普通 footer，以及 PreToolUse / PostToolUse / UserPromptSubmit / Stop / Notification 真机 hook 形态；
- 负向：普通 prose、`◆ Ran`、单双引号/backtick echo、grep 前置括号、diff 多括号；
- `bun x vitest run --project unit test/cli-adapters.test.ts test/idle-detector.test.ts`：494 passed；
- `bun run build`：通过；
- `git diff --check`：通过；
- 完整 unit 的剩余失败已在干净 master 对照复现或隔离通过，未发现与本改动相关的回归。

> 验证使用仓库声明的 Bun 1.4.0；宿主默认 Bun 1.3.11 无法解析当前 lockfile。
