### PR TITLE
fix(install): 按 shell 写入 PATH，并让 loopback 请求绕开代理

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,21 +111,68 @@ printf '%s\n' "✅ installed botmux → $INSTALL_DIR/botmux"
 # zsh users: zsh never reads ~/.profile (measured), so following the hint verbatim
 # left `botmux` still not found. Mirrors scripts/install-path-entry.mjs — keep the
 # two in step. Startup files per shell, all measured:
-#   zsh  → .zshenv                     (only file read by -c, -i and -li alike)
-#   bash → .bashrc AND .bash_profile   (interactive vs login are disjoint)
-#   fish → ~/.config/fish/conf.d/botmux.fish   (and fish is NOT POSIX: `set -gx`)
+#   zsh  → ${ZDOTDIR:-$HOME}/.zshenv   (only file read by -c, -i and -li alike;
+#                                       zsh reads dotfiles from $ZDOTDIR when set)
+#   bash → .bashrc AND its login file  (interactive vs login are disjoint; the
+#                                       login file is the FIRST of .bash_profile →
+#                                       .bash_login → .profile that EXISTS)
+#   fish → ${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/botmux.fish
+#                                      (and fish is NOT POSIX: `set -gx`)
 #   else → .profile                    (sh/ksh/dash read it at login)
 MARKER='# added by botmux installer'
 
+# Quote INSTALL_DIR for LITERAL use inside the rc file we write.
+# ⚠️ SECURITY: INSTALL_DIR is caller-controlled (BOTMUX_INSTALL_DIR) and the line
+# we write is executed by the user's shell on every startup. Inside double quotes
+# a `$(…)`/backtick/`$VAR` in the path would RUN — measured: an install dir with
+# `$(touch /tmp/PWNED)` created that file on every new shell. Single quotes make
+# every byte literal; only `'` needs care, closed and reopened as '\''. Same form
+# works in POSIX shells and fish.
+sq=$(printf '%s' "$INSTALL_DIR" | sed "s/'/'\\\\''/g")
+QUOTED_DIR="'$sq'"
+
 path_line_present() {  # $1=file — already handled, by us or by the user's own line?
   [ -f "$1" ] || return 1
-  # Must be ONE LINE that both names our dir AND is a PATH assignment. Two
-  # independent greps would accept a file where a comment mentions the directory
-  # and an unrelated line exports PATH (measured false positive), and then we
-  # would skip a machine that is not actually configured. Mirrors the per-line
-  # predicate in scripts/install-path-entry.mjs.
-  grep -F "$INSTALL_DIR" "$1" 2>/dev/null \
-    | grep -Eqi "export[[:space:]]+PATH[[:space:]]*=|^[[:space:]]*PATH[[:space:]]*=|set[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*PATH|fish_add_path|path\+=|path=\("
+  # TWO SEPARATE CHECKS, mirroring fileAlreadyHasEntry() in
+  # scripts/install-path-entry.mjs. Do not try to fold them into one.
+  #
+  # (a) OUR OWN line, recognised by its known syntax: the marker plus the exact
+  #     quoted directory we would generate. Needed because the line written for a
+  #     dir containing a quote is  export PATH='/x/q'\''bin'":$PATH"  and ANY
+  #     tokenizer that treats `'` as a separator shreds it into /x/q, \, bin — so
+  #     the quoted spelling can never match a token (measured: a second line was
+  #     appended on every re-install).
+  #
+  # (b) A HAND-WRITTEN line: strip quote syntax, then compare whole PATH elements.
+  #     Substring matching produced three measured false positives that each left
+  #     the real dir unwritten: <INSTALL_DIR>-old (sibling), /backup<INSTALL_DIR>
+  #     (prefix) and <INSTALL_DIR>/other (child). Commented-out lines never count.
+  # NOTE the comment filter: without it, commenting OUT our own generated line
+  # (marker included) still counted as configured, so no working line was ever
+  # added back — measured, install.sh reported configured while the mjs half
+  # correctly said false.
+  if grep -F "$MARKER" "$1" 2>/dev/null \
+    | grep -Ev '^[[:space:]]*#' \
+    | grep -Fq "$QUOTED_DIR"; then
+    return 0
+  fi
+  BOTMUX_RAW_DIR="$INSTALL_DIR" awk '
+    BEGIN { raw = ENVIRON["BOTMUX_RAW_DIR"]; sub(/\/+$/, "", raw) }
+    /^[[:space:]]*#/ { next }
+    !/export[[:space:]]+PATH[[:space:]]*=|^[[:space:]]*PATH[[:space:]]*=|set[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*PATH|fish_add_path|path\+=|path=\(/ { next }
+    {
+      line = $0
+      gsub(/["'"'"']/, "", line)     # quotes are syntax around a plain path here
+      gsub(/[()=]/, " ", line)       # zsh path=(...) and assignments
+      n = split(line, tok, /[:[:space:]]+/)
+      for (i = 1; i <= n; i++) {
+        t = tok[i]
+        sub(/\/+$/, "", t)           # a trailing slash is the same directory
+        if (t != "" && t == raw) { found = 1; exit }
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$1" 2>/dev/null
 }
 
 # bash's LOGIN file is the FIRST of .bash_profile → .bash_login → .profile that
@@ -155,17 +202,27 @@ append_path_line() {  # $1=file  $2=line
 case ":$PATH:" in
   *":$INSTALL_DIR:"*) : ;;  # already on PATH
   *)
-    posix_line="export PATH=\"$INSTALL_DIR:\$PATH\"  $MARKER"
+    # $PATH stays outside the quotes so it still expands; the dir cannot.
+    # The STATEMENT must be idempotent too, not just the file write: an
+    # unconditional prepend re-runs on every shell startup, so nested or
+    # re-sourced shells keep growing PATH (measured: the dir appeared twice at
+    # nesting depth 2). `case` is POSIX, needs no subshell, and the `:` padding
+    # makes it an exact ELEMENT test so `<dir>-old` never satisfies it.
+    posix_line="case \":\$PATH:\" in *:$QUOTED_DIR:*) ;; *) export PATH=$QUOTED_DIR\":\$PATH\" ;; esac  $MARKER"
     wrote=0
     case "$(basename "${SHELL:-}")" in
       *zsh*)
-        f="$HOME/.zshenv"
+        # zsh reads its dotfiles from $ZDOTDIR when set, else $HOME. Writing
+        # $HOME/.zshenv on a ZDOTDIR machine produces a file zsh never reads.
+        f="${ZDOTDIR:-$HOME}/.zshenv"
         if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
         ;;
       *fish*)
-        f="$HOME/.config/fish/conf.d/botmux.fish"
+        # fish's config dir is $XDG_CONFIG_HOME/fish, default ~/.config/fish.
+        f="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/botmux.fish"
         if path_line_present "$f"; then wrote=1
-        else append_path_line "$f" "set -gx PATH \"$INSTALL_DIR\" \$PATH  $MARKER" && wrote=1; fi
+        # fish: `contains` is its own exact list-element test.
+        else append_path_line "$f" "contains $QUOTED_DIR \$PATH; or set -gx PATH $QUOTED_DIR \$PATH  $MARKER" && wrote=1; fi
         ;;
       *bash*)
         # .bashrc (interactive) and the login file are disjoint; write both, but

--- a/install.sh
+++ b/install.sh
@@ -119,11 +119,25 @@ MARKER='# added by botmux installer'
 
 path_line_present() {  # $1=file — already handled, by us or by the user's own line?
   [ -f "$1" ] || return 1
-  # Must be a PATH *assignment* mentioning our dir, not merely a line containing
-  # the word "path" (an install dir can itself contain "path"). Mirrors the regex
-  # in scripts/install-path-entry.mjs.
-  grep -q "$INSTALL_DIR" "$1" 2>/dev/null \
-    && grep -Eqi "export[[:space:]]+PATH[[:space:]]*=|^[[:space:]]*PATH[[:space:]]*=|set[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*PATH|fish_add_path|path\+=|path=\(" "$1" 2>/dev/null
+  # Must be ONE LINE that both names our dir AND is a PATH assignment. Two
+  # independent greps would accept a file where a comment mentions the directory
+  # and an unrelated line exports PATH (measured false positive), and then we
+  # would skip a machine that is not actually configured. Mirrors the per-line
+  # predicate in scripts/install-path-entry.mjs.
+  grep -F "$INSTALL_DIR" "$1" 2>/dev/null \
+    | grep -Eqi "export[[:space:]]+PATH[[:space:]]*=|^[[:space:]]*PATH[[:space:]]*=|set[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*PATH|fish_add_path|path\+=|path=\("
+}
+
+# bash's LOGIN file is the FIRST of .bash_profile → .bash_login → .profile that
+# EXISTS. Creating .bash_profile when the user's login config lives in .profile
+# (or .bash_login) silently stops that file from being read ever again — measured
+# with a sentinel: visible before, MISSING after. So append to whichever already
+# exists, and only create .bash_profile when none does (nothing to shadow then).
+bash_login_file() {
+  for f in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
+    [ -f "$f" ] && { printf '%s\n' "$f"; return 0; }
+  done
+  printf '%s\n' "$HOME/.bash_profile"
 }
 
 append_path_line() {  # $1=file  $2=line
@@ -154,7 +168,9 @@ case ":$PATH:" in
         else append_path_line "$f" "set -gx PATH \"$INSTALL_DIR\" \$PATH  $MARKER" && wrote=1; fi
         ;;
       *bash*)
-        for f in "$HOME/.bashrc" "$HOME/.bash_profile"; do
+        # .bashrc (interactive) and the login file are disjoint; write both, but
+        # never CREATE a login file that would shadow an existing one.
+        for f in "$HOME/.bashrc" "$(bash_login_file)"; do
           if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
         done
         ;;

--- a/install.sh
+++ b/install.sh
@@ -106,12 +106,70 @@ chmod +x "$tmp/$asset"
 mv "$tmp/$asset" "$INSTALL_DIR/botmux"
 printf '%s\n' "✅ installed botmux → $INSTALL_DIR/botmux"
 
-# ── PATH hint ─────────────────────────────────────────────────────────────────
+# ── PATH: write it, don't just suggest it ─────────────────────────────────────
+# This used to only print `echo 'export PATH=…' >> ~/.profile`, which is WRONG for
+# zsh users: zsh never reads ~/.profile (measured), so following the hint verbatim
+# left `botmux` still not found. Mirrors scripts/install-path-entry.mjs — keep the
+# two in step. Startup files per shell, all measured:
+#   zsh  → .zshenv                     (only file read by -c, -i and -li alike)
+#   bash → .bashrc AND .bash_profile   (interactive vs login are disjoint)
+#   fish → ~/.config/fish/conf.d/botmux.fish   (and fish is NOT POSIX: `set -gx`)
+#   else → .profile                    (sh/ksh/dash read it at login)
+MARKER='# added by botmux installer'
+
+path_line_present() {  # $1=file — already handled, by us or by the user's own line?
+  [ -f "$1" ] || return 1
+  # Must be a PATH *assignment* mentioning our dir, not merely a line containing
+  # the word "path" (an install dir can itself contain "path"). Mirrors the regex
+  # in scripts/install-path-entry.mjs.
+  grep -q "$INSTALL_DIR" "$1" 2>/dev/null \
+    && grep -Eqi "export[[:space:]]+PATH[[:space:]]*=|^[[:space:]]*PATH[[:space:]]*=|set[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*PATH|fish_add_path|path\+=|path=\(" "$1" 2>/dev/null
+}
+
+append_path_line() {  # $1=file  $2=line
+  mkdir -p "$(dirname "$1")" 2>/dev/null || return 1
+  # Leading newline only when the file exists and lacks a trailing one, so we
+  # never glue onto an unterminated last line.
+  if [ -f "$1" ] && [ -n "$(tail -c 1 "$1" 2>/dev/null)" ]; then
+    printf '\n%s\n' "$2" >> "$1" || return 1
+  else
+    printf '%s\n' "$2" >> "$1" || return 1
+  fi
+  printf '%s\n' "✓ added $INSTALL_DIR to PATH in $1"
+}
+
 case ":$PATH:" in
   *":$INSTALL_DIR:"*) : ;;  # already on PATH
   *)
-    printf '\n%s\n' "Add $INSTALL_DIR to your PATH, e.g.:"
-    printf '  %s\n' "echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.profile && . ~/.profile"
+    posix_line="export PATH=\"$INSTALL_DIR:\$PATH\"  $MARKER"
+    wrote=0
+    case "$(basename "${SHELL:-}")" in
+      *zsh*)
+        f="$HOME/.zshenv"
+        if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
+        ;;
+      *fish*)
+        f="$HOME/.config/fish/conf.d/botmux.fish"
+        if path_line_present "$f"; then wrote=1
+        else append_path_line "$f" "set -gx PATH \"$INSTALL_DIR\" \$PATH  $MARKER" && wrote=1; fi
+        ;;
+      *bash*)
+        for f in "$HOME/.bashrc" "$HOME/.bash_profile"; do
+          if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
+        done
+        ;;
+      *)
+        f="$HOME/.profile"
+        if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
+        ;;
+    esac
+    if [ "$wrote" = 1 ]; then
+      printf '%s\n' "  open a new terminal (or re-source that file) and \`botmux\` will be on PATH"
+    else
+      printf '\n%s\n' "Add $INSTALL_DIR to your PATH, e.g.:"
+      printf '  %s\n' "echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.profile && . ~/.profile"
+    fi
     ;;
 esac
+
 printf '\n%s\n' "Next: botmux setup"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist/",
     "scripts/postinstall-bin.mjs",
+    "scripts/install-path-entry.mjs",
     "ecosystem.config.cjs",
     "README.md",
     "README.en.md",

--- a/scripts/install-path-entry.mjs
+++ b/scripts/install-path-entry.mjs
@@ -1,0 +1,157 @@
+/**
+ * Put `~/.botmux/bin` on the user's PATH by writing their shell's startup file.
+ *
+ * WHY THIS EXISTS
+ * `npm i -g botmux` has no `bin` field (removed with the Node fallback — see
+ * postinstall-bin.mjs), so the ONLY `botmux` command is the launcher written to
+ * `~/.botmux/bin/botmux`. If that directory is not on PATH, a successful install
+ * still leaves the user with `botmux: command not found`.
+ *
+ * Both installers used to just PRINT a hint, and the hint was:
+ *
+ *     echo 'export PATH="…"' >> ~/.profile
+ *
+ * which is wrong for a large share of users, because **zsh never reads
+ * `~/.profile`** (measured: `zsh -lic` on a home dir containing `.profile` reads
+ * `.zshenv` + `.zprofile` + `.zshrc` and the `.profile` echo never fires). A zsh
+ * user who followed the hint verbatim got a file that is silently ignored — the
+ * command stayed missing with no indication why. That was the reported bug.
+ *
+ * ── WHICH FILE PER SHELL (all measured, not recalled) ─────────────────────────
+ * Startup files actually sourced, by shell and invocation mode:
+ *
+ *   zsh   -c  → .zshenv
+ *         -i  → .zshenv .zshrc
+ *         -li → .zshenv .zprofile .zshrc
+ *   bash  -c  → (none)
+ *         -i  → .bashrc
+ *         -li → .bash_profile           ← NOT .bashrc
+ *   fish      → ~/.config/fish/conf.d/*.fish in all three modes
+ *
+ * So the target per shell is the file that covers the most modes:
+ *   • zsh  → ~/.zshenv                       (the only file read in all 3)
+ *   • bash → ~/.bashrc AND ~/.bash_profile   (login vs interactive are disjoint)
+ *   • fish → ~/.config/fish/conf.d/botmux.fish
+ *
+ * bash genuinely needs both: writing only `.bashrc` misses login shells, and
+ * writing only `.bash_profile` misses ordinary interactive ones.
+ *
+ * ── fish SYNTAX ──────────────────────────────────────────────────────────────
+ * fish is not POSIX; `export PATH="$INSTALL_DIR:$PATH"` is not its syntax. (fish
+ * 3.6 happens to tolerate `export` as a compatibility shim and even produces a
+ * correct PATH — measured — but `set -gx` is the real form and is what we write.)
+ */
+
+import { existsSync, readFileSync, appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { basename } from 'node:path';
+
+/** Marker so we can detect our own previous edit and never write twice. */
+export const PATH_ENTRY_MARKER = '# added by botmux installer';
+
+/**
+ * Which shell is the user actually on? `$SHELL` is the login shell recorded in
+ * passwd, which is what future terminals will start — the right question here,
+ * and better than `process.ppid` guessing (the parent of a postinstall is npm,
+ * not the user's shell).
+ */
+export function detectShell(env = process.env) {
+  const shell = env.SHELL ?? '';
+  const name = basename(shell);
+  if (name.includes('zsh')) return 'zsh';
+  if (name.includes('fish')) return 'fish';
+  if (name.includes('bash')) return 'bash';
+  // Unknown or unset (containers, cron, exotic shells): POSIX `.profile` is the
+  // most portable thing we can offer, and sh/ksh/dash all read it at login.
+  return name ? 'other' : 'unknown';
+}
+
+/**
+ * The startup files to write for a shell, plus the line to write into each.
+ * Returns [] when we have nothing safe to say.
+ */
+export function pathEntryTargets(shell, installDir, home = homedir()) {
+  const posix = `export PATH="${installDir}:$PATH"  ${PATH_ENTRY_MARKER}`;
+  switch (shell) {
+    case 'zsh':
+      // .zshenv is the only file read by non-interactive, interactive and login
+      // zsh alike, so a script/ssh command finds botmux too.
+      return [{ file: join(home, '.zshenv'), line: posix }];
+    case 'bash':
+      // Disjoint coverage — see header. Both, or one of the two common ways of
+      // opening a terminal is left broken.
+      return [
+        { file: join(home, '.bashrc'), line: posix },
+        { file: join(home, '.bash_profile'), line: posix },
+      ];
+    case 'fish':
+      return [{
+        file: join(home, '.config', 'fish', 'conf.d', 'botmux.fish'),
+        line: `set -gx PATH "${installDir}" $PATH  ${PATH_ENTRY_MARKER}`,
+      }];
+    case 'other':
+    case 'unknown':
+    default:
+      return [{ file: join(home, '.profile'), line: posix }];
+  }
+}
+
+/** Is `installDir` already handled by this file (ours or the user's own line)? */
+export function fileAlreadyHasEntry(file, installDir) {
+  if (!existsSync(file)) return false;
+  let text;
+  try { text = readFileSync(file, 'utf8'); } catch { return false; }
+  // Any line that already puts the directory on PATH counts — the user may have
+  // added it by hand in a form we would not generate, and appending a second
+  // entry would be noise, not a fix. Match the ASSIGNMENT forms rather than the
+  // bare word "path": a temp/checkout directory can easily contain "path" in its
+  // name (measured — a `/tmp/bmx-path-XXXX` fixture matched a bare `\bpath\b` and
+  // made an unrelated comment line look like a PATH export).
+  const PATH_ASSIGNMENT = new RegExp(
+    [
+      'export\\s+PATH\\s*=',      // POSIX: export PATH="…"
+      '^\\s*PATH\\s*=',           // POSIX: PATH=…
+      'set\\s+(-\\w+\\s+)*PATH',  // fish:  set -gx PATH …
+      'fish_add_path',            // fish:  fish_add_path …
+      '\\bpath\\+=',              // zsh:   path+=(…)
+      '\\bpath=\\(',              // zsh:   path=(…)
+    ].join('|'),
+    'i',
+  );
+  return text.split('\n').some(l => l.includes(installDir) && PATH_ASSIGNMENT.test(l));
+}
+
+/**
+ * Append the PATH line to every startup file the user's shell reads.
+ *
+ * Returns `{ written: string[], skipped: string[], failed: [{file, error}] }`.
+ * Never throws: a PATH edit failing must not fail the install (the launcher is
+ * already in place and the caller prints a manual fallback).
+ */
+export function ensurePathEntry(opts) {
+  const installDir = opts.installDir;
+  const home = opts.home ?? homedir();
+  const shell = opts.shell ?? detectShell();
+  const targets = pathEntryTargets(shell, installDir, home);
+
+  const written = [], skipped = [], failed = [];
+  for (const { file, line } of targets) {
+    if (fileAlreadyHasEntry(file, installDir)) { skipped.push(file); continue; }
+    try {
+      mkdirSync(dirname(file), { recursive: true });
+      if (existsSync(file)) {
+        // Keep the user's file intact; only append, and only with a leading
+        // newline so we never glue onto an unterminated last line.
+        const prev = readFileSync(file, 'utf8');
+        appendFileSync(file, `${prev.endsWith('\n') || prev === '' ? '' : '\n'}${line}\n`);
+      } else {
+        writeFileSync(file, `${line}\n`);
+      }
+      written.push(file);
+    } catch (err) {
+      failed.push({ file, error: err && err.message ? err.message : String(err) });
+    }
+  }
+  return { shell, written, skipped, failed };
+}

--- a/scripts/install-path-entry.mjs
+++ b/scripts/install-path-entry.mjs
@@ -95,16 +95,50 @@ function bashLoginFile(home) {
 }
 
 /**
+ * Quote a path for literal use inside a shell startup file.
+ *
+ * ⚠️ SECURITY, not cosmetics. The install dir is caller-controlled
+ * (`BOTMUX_INSTALL_DIR`, or just an unusual home), and the line we write is
+ * EXECUTED by the user's shell on every startup. Interpolating it into double
+ * quotes lets `$(…)`, backticks and `$VAR` run: measured — an install dir
+ * containing `$(touch /tmp/PWNED)` created that file the first time zsh started,
+ * and did so on every shell thereafter.
+ *
+ * Single quotes make the shell treat every byte literally; the only character
+ * needing care is `'` itself, closed and re-opened via `'\''`. This form is
+ * identical in POSIX shells and in fish.
+ */
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * The startup files to write for a shell, plus the line to write into each.
  * Returns [] when we have nothing safe to say.
+ *
+ * `env` is read for the two relocation variables below; both are honoured
+ * because writing the un-relocated path produces a file the shell never reads —
+ * the same class of bug as writing `.profile` for zsh.
  */
-export function pathEntryTargets(shell, installDir, home = homedir()) {
-  const posix = `export PATH="${installDir}:$PATH"  ${PATH_ENTRY_MARKER}`;
+export function pathEntryTargets(shell, installDir, home = homedir(), env = process.env) {
+  const q = shellQuote(installDir);
+  // ⚠️ The STATEMENT has to be idempotent too, not just the file write. An
+  // unconditional `export PATH=<dir>:$PATH` re-prepends on every shell startup, so
+  // a nested or re-sourced shell keeps growing PATH — measured: the same directory
+  // appeared twice at nesting depth 2, and `.bash_profile` files that source
+  // `.bashrc` hit it within a single login. `case` is POSIX and quote-safe (no
+  // subshell, no `grep`), and the `:` padding makes it an exact ELEMENT test, so a
+  // sibling like `<dir>-old` never satisfies it.
+  const posix = `case ":$PATH:" in *:${q}:*) ;; *) export PATH=${q}":$PATH" ;; esac  ${PATH_ENTRY_MARKER}`;
   switch (shell) {
-    case 'zsh':
-      // .zshenv is the only file read by non-interactive, interactive and login
-      // zsh alike, so a script/ssh command finds botmux too.
-      return [{ file: join(home, '.zshenv'), line: posix }];
+    case 'zsh': {
+      // ⚠️ zsh reads its dotfiles from $ZDOTDIR when that is set, falling back to
+      // $HOME. Writing $HOME/.zshenv on a machine with ZDOTDIR set produces a file
+      // zsh never reads — measured: `zsh -c botmux` → "command not found".
+      const zdotdir = env.ZDOTDIR?.trim();
+      const base = zdotdir ? zdotdir : home;
+      return [{ file: join(base, '.zshenv'), line: posix }];
+    }
     case 'bash': {
       // Disjoint coverage — see header. Both, or one of the two common ways of
       // opening a terminal is left broken. The login half must not shadow (above).
@@ -115,11 +149,20 @@ export function pathEntryTargets(shell, installDir, home = homedir()) {
       if (login !== join(home, '.bashrc')) targets.push({ file: login, line: posix });
       return targets;
     }
-    case 'fish':
+    case 'fish': {
+      // ⚠️ fish's config dir is $XDG_CONFIG_HOME/fish, defaulting to ~/.config/fish.
+      // Same failure as ZDOTDIR above — measured: with XDG_CONFIG_HOME set, a file
+      // under ~/.config/fish is ignored, while the same line under
+      // $XDG_CONFIG_HOME/fish/conf.d works (positive control).
+      const xdg = env.XDG_CONFIG_HOME?.trim();
+      const configHome = xdg ? xdg : join(home, '.config');
       return [{
-        file: join(home, '.config', 'fish', 'conf.d', 'botmux.fish'),
-        line: `set -gx PATH "${installDir}" $PATH  ${PATH_ENTRY_MARKER}`,
+        file: join(configHome, 'fish', 'conf.d', 'botmux.fish'),
+        // fish: `contains` is its own exact list-element test — PATH is a real list
+        // here, so no delimiter padding is needed.
+        line: `contains ${q} $PATH; or set -gx PATH ${q} $PATH  ${PATH_ENTRY_MARKER}`,
       }];
+    }
     case 'other':
     case 'unknown':
     default:
@@ -132,12 +175,34 @@ export function fileAlreadyHasEntry(file, installDir) {
   if (!existsSync(file)) return false;
   let text;
   try { text = readFileSync(file, 'utf8'); } catch { return false; }
-  // Any line that already puts the directory on PATH counts — the user may have
-  // added it by hand in a form we would not generate, and appending a second
-  // entry would be noise, not a fix. Match the ASSIGNMENT forms rather than the
-  // bare word "path": a temp/checkout directory can easily contain "path" in its
-  // name (measured — a `/tmp/bmx-path-XXXX` fixture matched a bare `\bpath\b` and
-  // made an unrelated comment line look like a PATH export).
+
+  // ⚠️ TWO SEPARATE PREDICATES, deliberately not one clever one.
+  //
+  // Attempt #1 searched for the raw directory as a substring: `<installDir>-old`,
+  // `/backup<installDir>` and `<installDir>/other` all counted as configured, so
+  // the REAL directory was never written (measured, written=0 for each).
+  // Attempt #2 split the line into tokens and compared them — but the line we
+  // WRITE for a directory containing a quote is
+  //     export PATH='/x/q'\''bin'":$PATH"
+  // and ANY tokenizer that treats `'` as a separator shreds that into `/x/q`,
+  // `\`, `bin`, so the quoted spelling can never match a token (measured: marker
+  // count 1 → 2 on every re-install). Shell quoting cannot be undone by splitting
+  // on characters.
+  //
+  // So: recognise OUR line by its own known syntax (marker + the exact quoted
+  // form we would generate), and use conservative whole-token matching only for a
+  // line the USER wrote by hand.
+  const ourQuoted = shellQuote(installDir);
+  const lines = text.split('\n').filter(l => !/^\s*#/.test(l));
+
+  // (a) Our own line, byte-for-byte on the part that identifies the directory.
+  //     `PATH=` + the exact quoted dir is enough; the suffix may legitimately
+  //     differ (`":$PATH"` vs fish's ` $PATH`).
+  if (lines.some(l => l.includes(PATH_ENTRY_MARKER) && l.includes(ourQuoted))) return true;
+
+  // (b) A hand-written line. Compare whole PATH elements, and do NOT treat quotes
+  //     as element separators — strip the wrapping quotes first, then split on the
+  //     characters that actually delimit PATH elements.
   const PATH_ASSIGNMENT = new RegExp(
     [
       'export\\s+PATH\\s*=',      // POSIX: export PATH="…"
@@ -149,7 +214,17 @@ export function fileAlreadyHasEntry(file, installDir) {
     ].join('|'),
     'i',
   );
-  return text.split('\n').some(l => l.includes(installDir) && PATH_ASSIGNMENT.test(l));
+  const target = installDir.replace(/\/+$/, '');
+  return lines.some(l => {
+    if (!PATH_ASSIGNMENT.test(l)) return false;
+    // Quotes here are shell syntax around a plain path (the quote-containing case
+    // is handled by (a)); dropping them leaves the path bytes intact.
+    const bare = l.replace(/["']/g, '');
+    return bare
+      .split(/[:\s()=]+/)
+      .map(t => t.replace(/\/+$/, ''))
+      .some(t => t !== '' && t === target);
+  });
 }
 
 /**
@@ -161,9 +236,10 @@ export function fileAlreadyHasEntry(file, installDir) {
  */
 export function ensurePathEntry(opts) {
   const installDir = opts.installDir;
+  const env = opts.env ?? process.env;
   const home = opts.home ?? homedir();
-  const shell = opts.shell ?? detectShell();
-  const targets = pathEntryTargets(shell, installDir, home);
+  const shell = opts.shell ?? detectShell(env);
+  const targets = pathEntryTargets(shell, installDir, home, env);
 
   const written = [], skipped = [], failed = [];
   for (const { file, line } of targets) {

--- a/scripts/install-path-entry.mjs
+++ b/scripts/install-path-entry.mjs
@@ -25,16 +25,20 @@
  *         -li → .zshenv .zprofile .zshrc
  *   bash  -c  → (none)
  *         -i  → .bashrc
- *         -li → .bash_profile           ← NOT .bashrc
+ *         -li → the FIRST of .bash_profile → .bash_login → .profile
  *   fish      → ~/.config/fish/conf.d/*.fish in all three modes
  *
  * So the target per shell is the file that covers the most modes:
  *   • zsh  → ~/.zshenv                       (the only file read in all 3)
- *   • bash → ~/.bashrc AND ~/.bash_profile   (login vs interactive are disjoint)
+ *   • bash → ~/.bashrc AND its login file    (login vs interactive are disjoint)
  *   • fish → ~/.config/fish/conf.d/botmux.fish
  *
  * bash genuinely needs both: writing only `.bashrc` misses login shells, and
- * writing only `.bash_profile` misses ordinary interactive ones.
+ * writing only the login file misses ordinary interactive ones.
+ *
+ * ⚠️ bash's login file is "the first that EXISTS", not always `.bash_profile` —
+ * see bashLoginFile() below for why creating the wrong one destroys the user's
+ * existing login config.
  *
  * ── fish SYNTAX ──────────────────────────────────────────────────────────────
  * fish is not POSIX; `export PATH="$INSTALL_DIR:$PATH"` is not its syntax. (fish
@@ -68,6 +72,29 @@ export function detectShell(env = process.env) {
 }
 
 /**
+ * bash's LOGIN startup file, chosen without shadowing anything.
+ *
+ * ⚠️ bash reads only the FIRST of `.bash_profile` → `.bash_login` → `.profile`.
+ * So creating `.bash_profile` on a machine whose login config lives in
+ * `.profile` (or `.bash_login`) silently stops that file from ever being read.
+ * Measured — a sentinel exported from `.profile` is visible to `bash -lic`, and
+ * becomes MISSING the moment an unrelated `.bash_profile` appears; same for
+ * `.bash_login`. That is destroying the user's environment to fix a PATH entry,
+ * which is far worse than the bug being fixed.
+ *
+ * So: append to whichever of the three already exists (that is the file bash is
+ * actually reading), and only fall back to CREATING `.bash_profile` when none of
+ * them exists — in which case there is nothing to shadow.
+ */
+function bashLoginFile(home) {
+  for (const name of ['.bash_profile', '.bash_login', '.profile']) {
+    const file = join(home, name);
+    if (existsSync(file)) return file;
+  }
+  return join(home, '.bash_profile');
+}
+
+/**
  * The startup files to write for a shell, plus the line to write into each.
  * Returns [] when we have nothing safe to say.
  */
@@ -78,13 +105,16 @@ export function pathEntryTargets(shell, installDir, home = homedir()) {
       // .zshenv is the only file read by non-interactive, interactive and login
       // zsh alike, so a script/ssh command finds botmux too.
       return [{ file: join(home, '.zshenv'), line: posix }];
-    case 'bash':
+    case 'bash': {
       // Disjoint coverage — see header. Both, or one of the two common ways of
-      // opening a terminal is left broken.
-      return [
-        { file: join(home, '.bashrc'), line: posix },
-        { file: join(home, '.bash_profile'), line: posix },
-      ];
+      // opening a terminal is left broken. The login half must not shadow (above).
+      const login = bashLoginFile(home);
+      const targets = [{ file: join(home, '.bashrc'), line: posix }];
+      // When bash's login file IS .bashrc-adjacent there is nothing more to add;
+      // dedupe so we never append the same line to the same file twice.
+      if (login !== join(home, '.bashrc')) targets.push({ file: login, line: posix });
+      return targets;
+    }
     case 'fish':
       return [{
         file: join(home, '.config', 'fish', 'conf.d', 'botmux.fish'),

--- a/scripts/postinstall-bin.mjs
+++ b/scripts/postinstall-bin.mjs
@@ -219,11 +219,47 @@ try {
   );
 }
 
-// ── PATH hint ─────────────────────────────────────────────────────────────────
-// Mirrors install.sh. Without ~/.botmux/bin on PATH the launcher we just wrote is
-// never the `botmux` the user's shell resolves.
-const pathEntries = (process.env.PATH ?? '').split(':');
-if (!pathEntries.includes(binDir)) {
-  console.log(`[botmux] add ${binDir} to your PATH so this launcher is the \`botmux\` your shell finds:`);
-  console.log(`[botmux]   echo 'export PATH="${binDir}:$PATH"' >> ~/.profile && . ~/.profile`);
+// ── PATH: write it, don't just suggest it ─────────────────────────────────────
+// This used to only PRINT `echo 'export PATH=…' >> ~/.profile`. Two problems:
+// the user had to act on it, and for zsh users the suggested file is WRONG —
+// zsh never reads ~/.profile (measured), so following the hint verbatim left
+// `botmux` still not found. There is no `bin` field any more, so PATH is the
+// only way this launcher becomes a command; we now write the right startup file
+// for the user's actual shell (bash/zsh/fish/other) and tell them what we did.
+//
+// ⚠️ FAIL-SOFT, and never `fail()`: the launcher is already installed and working
+// at this point, so a PATH edit that cannot happen must degrade to the printed
+// hint — not abort a successful install. That includes the sibling module simply
+// not being there: it ships via package.json `files`, and if a future edit drops
+// it (or a mirror repacks the tarball without it) the import throws. Guarding it
+// keeps `npm i -g botmux` succeeding either way.
+if (!(process.env.PATH ?? '').split(':').includes(binDir)) {
+  let ensurePathEntry = null;
+  try {
+    ({ ensurePathEntry } = await import('./install-path-entry.mjs'));
+  } catch (err) {
+    console.error(`[botmux] PATH helper unavailable (${err && err.message ? err.message : String(err)})`);
+  }
+  let written = [], skipped = [];
+  if (ensurePathEntry) {
+    try {
+      const r = ensurePathEntry({ installDir: binDir });
+      ({ written, skipped } = r);
+      for (const f of written) console.log(`[botmux] added ${binDir} to PATH in ${f} (${r.shell})`);
+      for (const f of skipped) console.log(`[botmux] ${f} already puts ${binDir} on PATH`);
+      for (const { file, error } of r.failed) console.error(`[botmux] could not update ${file}: ${error}`);
+    } catch (err) {
+      console.error(`[botmux] could not update your shell startup file: ${err && err.message ? err.message : String(err)}`);
+    }
+  }
+  if (written.length > 0) {
+    console.log('[botmux] open a new terminal (or re-source that file) and `botmux` will be on PATH');
+  } else if (skipped.length === 0) {
+    // Nothing written and nothing already present — fall back to telling them.
+    // Deliberately not naming a specific file here: the correct one depends on
+    // the shell, and naming the wrong one is what caused the original bug.
+    console.log(`[botmux] add ${binDir} to your PATH so this launcher is the \`botmux\` your shell finds`);
+  }
 }
+
+

--- a/scripts/postinstall-bin.mjs
+++ b/scripts/postinstall-bin.mjs
@@ -261,5 +261,3 @@ if (!(process.env.PATH ?? '').split(':').includes(binDir)) {
     console.log(`[botmux] add ${binDir} to your PATH so this launcher is the \`botmux\` your shell finds`);
   }
 }
-
-

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -417,6 +417,78 @@ function installClaudeSettings(
  *   - stdout 为空（passthrough：daemon 不可达 / 超时 / 非 botmux 会话）→ 不 reply，把问题
  *     留给 OpenCode 原生 picker（botmux web 终端里仍可人工作答）。
  */
+/**
+ * Injected into BOTH generated plugin templates (V1 and V2).
+ *
+ * ⚠️ Emit this wherever `loopbackSafeFetch` is CALLED. It was first added to the
+ * V2 template only, while the V1 fallback call was switched over too — the V1
+ * plugin then died with `ReferenceError: loopbackSafeFetch is not defined` the
+ * moment it took that path. "Changed the call, forgot the definition" is the
+ * classic generated-template defect, so the definition lives in one constant and
+ * is interpolated into every template that uses it.
+ *
+ * Why it exists at all: these plugins run inside OpenCode's **Bun** process, and
+ * Bun's `fetch` auto-uses `$http_proxy` while `no_proxy` is literal-match only
+ * (no CIDR, and `localhost` does not cover `127.0.0.1`). On a corporate dev box a
+ * request to the LOCAL serve is handed to the proxy — the ask reply fails AND the
+ * Basic password from the registration file is sent to the proxy. A generated file
+ * cannot import repo helpers, so this is a minimal inline version; remote,
+ * user-configurable URLs still use the native fetch.
+ */
+const LOOPBACK_SAFE_FETCH_SNIPPET = `
+// 本机 loopback 请求绝不能走全局 fetch。这段代码跑在 OpenCode 的 **Bun** 进程里，
+// 而 Bun 的 fetch 会自动使用 $http_proxy，且 no_proxy 只做字面量匹配（不解析 CIDR，
+// 也不把 localhost 当作覆盖 127.0.0.1）。公司内网开发机普遍 export 这种组合，于是
+// 打本机 serve 的请求被交给公司代理：不只是回答 ask 失败，注册文件里的 Basic 口令
+// 也会随请求发给代理。这里不能 import 仓库里的 helper（本文件是**生成**到插件目录的
+// 独立脚本），所以内联一份最小实现；远端可配置 URL 仍走原生 fetch，只有字面量
+// loopback 才切到 node:http（它完全无视代理 env）。
+function isLiteralLoopback(u) {
+  try {
+    const p = new URL(u);
+    // http: only — this helper is node:http, so claiming an https: URL is
+    // loopback-safe would pick a transport that cannot serve it.
+    if (p.protocol !== "http:") return false;
+    // URL.hostname keeps IPv6 bracketed; node:http wants the bare address.
+    const h = p.hostname.startsWith("[") && p.hostname.endsWith("]")
+      ? p.hostname.slice(1, -1) : p.hostname;
+    return h === "127.0.0.1" || h === "localhost" || h === "::1";
+  } catch { return false; }
+}
+async function loopbackSafeFetch(url, init) {
+  if (!isLiteralLoopback(url)) return fetch(url, init);
+  const http = await import("node:http");
+  const t = new URL(url);
+  return await new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: (() => {
+          const h = t.hostname.startsWith("[") && t.hostname.endsWith("]")
+            ? t.hostname.slice(1, -1) : t.hostname;
+          return h === "localhost" ? "127.0.0.1" : h;
+        })(),
+        port: t.port || 80, path: t.pathname + t.search,
+        method: (init && init.method) || "GET", headers: (init && init.headers) || {} },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(Buffer.from(c)));
+        res.on("end", () => {
+          const buf = Buffer.concat(chunks);
+          resolve({
+            ok: res.statusCode >= 200 && res.statusCode < 300,
+            status: res.statusCode,
+            text: async () => buf.toString("utf8"),
+            json: async () => JSON.parse(buf.toString("utf8")),
+          });
+        });
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    if (init && init.body) req.end(init.body); else req.end();
+  });
+}
+`;
+
 function buildOpenCodePlugin(parts: { cmd: string; args: string[] }): string {
   // 用 argv 形式嵌入（不拼 shell 字符串、不 split）：含空格/引号的路径也不会被拆坏。
   const cmdLit = JSON.stringify(parts.cmd);
@@ -473,6 +545,7 @@ function safeStr(x) {
   try { return String(JSON.stringify(x)).slice(0, 120); } catch { return String(x); }
 }
 
+${LOOPBACK_SAFE_FETCH_SNIPPET}
 async function postReply(client, serverUrl, id, answers) {
   const body = { answers };
   // 1) 经 client._client（带 directory 头 + 正确传输）。这是 daemon 多实例下唯一可达的路径：
@@ -502,7 +575,7 @@ async function postReply(client, serverUrl, id, answers) {
     } catch {}
     const url = base + "/question/" + id + "/reply";
     dbg("FETCH_POST url=" + url + " headers=" + Object.keys(headers).join(","));
-    const r = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });
+    const r = await loopbackSafeFetch(url, { method: "POST", headers, body: JSON.stringify(body) });
     let txt = ""; try { txt = await r.text(); } catch {}
     dbg("FETCH_POST_RESULT id=" + id + " status=" + r.status + " body=" + txt.slice(0, 150));
     return r.ok;
@@ -644,6 +717,7 @@ function readRegistration() {
 
 // 把答案回传给 OpenCode 2.0 解阻塞。必须带 x-opencode-directory 头（多 worktree
 // 路由），带注册文件里的 Basic auth。
+${LOOPBACK_SAFE_FETCH_SNIPPET}
 async function postReply(directory, sessionID, requestID, answers) {
   const reg = readRegistration();
   if (!reg) { dbg("NO_REGISTRATION id=" + requestID); return; }
@@ -656,7 +730,7 @@ async function postReply(directory, sessionID, requestID, answers) {
   const url = base + "/api/session/" + encodeURIComponent(sessionID) + "/question/" + encodeURIComponent(requestID) + "/reply";
   dbg("POST_REPLY id=" + requestID + " url=" + url);
   try {
-    const r = await fetch(url, { method: "POST", headers, body: JSON.stringify({ answers }) });
+    const r = await loopbackSafeFetch(url, { method: "POST", headers, body: JSON.stringify({ answers }) });
     let txt = ""; try { txt = await r.text(); } catch {}
     dbg("REPLY_DONE id=" + requestID + " status=" + r.status + " body=" + txt.slice(0, 150));
     if (!r.ok) dbg("REPLY_NON_OK id=" + requestID + " status=" + r.status + " body=" + txt.slice(0, 150));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,6 +194,7 @@ import {
   type BotCollaborationFactsByAppId,
 } from './cli/bots-list-output.js';
 import { ensureBotChatGrantMatrix, requestExactChatGrant } from './cli/exact-chat-grant-client.js';
+import { loopbackFetch } from './core/loopback-fetch.js';
 import {
   buildFooterAddressing,
   hasKnownBotMention,
@@ -4962,7 +4963,7 @@ async function postSessionCliIpc(
   } satisfies RequestInit;
   return hostSecret
     ? fetchDaemonIpc(ipcPort, path, init, hostSecret)
-    : fetch(`http://127.0.0.1:${ipcPort}${path}`, init);
+    : loopbackFetch(`http://127.0.0.1:${ipcPort}${path}`, init);
 }
 
 /** `botmux preview <port>` registers a reachable loopback Web service for the
@@ -9406,7 +9407,7 @@ async function cmdSend(rest: string[]): Promise<void> {
         try { secret = loadDaemonIpcSecret(); } catch { /* Seatbelt/read-isolated CLI */ }
         const res = secret
           ? await fetchDaemonIpc(attentionPort, '/api/attention', request, secret)
-          : await fetch(`http://127.0.0.1:${attentionPort}/api/attention`, request);
+          : await loopbackFetch(`http://127.0.0.1:${attentionPort}/api/attention`, request);
         if (!res.ok) throw new Error(`daemon HTTP ${res.status}`);
         attentionRaised = true;
         console.error(`🙋 已举手：本会话已进 dashboard「需要你」列（用户回复后自动撤下）`);
@@ -9530,7 +9531,7 @@ async function postCurrentSessionDaemonRoute(input: {
     relayDir,
     process.env.BOTMUX_ORIGIN_CHANNEL_ID,
   );
-  return fetch(`http://127.0.0.1:${port}${input.path}`, {
+  return loopbackFetch(`http://127.0.0.1:${port}${input.path}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
@@ -10751,7 +10752,7 @@ async function postAsk(body: Record<string, unknown>): Promise<import('./core/as
     }
     res = hostSecret
       ? await fetchDaemonIpc(daemon.ipcPort, '/api/asks', init, hostSecret)
-      : await fetch(`http://127.0.0.1:${daemon.ipcPort}/api/asks`, init);
+      : await loopbackFetch(`http://127.0.0.1:${daemon.ipcPort}/api/asks`, init);
   } catch (fetchErr) {
     // Socket refused / reset / timeout → daemon is down or restarting → retryable.
     const msg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
@@ -11255,7 +11256,7 @@ async function cmdSessionReady(): Promise<void> {
         try { hostSecret = loadDaemonIpcSecret(); } catch { /* Seatbelt/read-isolated CLI */ }
       }
       if (!hostSecret) {
-        await fetch(`http://127.0.0.1:${ipcPort}/api/session-ready`, init);
+        await loopbackFetch(`http://127.0.0.1:${ipcPort}/api/session-ready`, init);
       } else {
         await fetchDaemonIpc(ipcPort, '/api/session-ready', init, hostSecret);
       }
@@ -11356,7 +11357,7 @@ async function cmdUserPromptHook(): Promise<void> {
     const path = `/api/sessions/${encodeURIComponent(sessionId)}/prompt-ctx/claim`;
     const res = hostSecret
       ? await fetchDaemonIpc(ipcPort, path, init, hostSecret)
-      : await fetch(`http://127.0.0.1:${ipcPort}${path}`, init);
+      : await loopbackFetch(`http://127.0.0.1:${ipcPort}${path}`, init);
     if (res.status !== 200) process.exit(0);
     const data = await res.json() as { envelope?: unknown };
     const envelope = typeof data?.envelope === 'string' ? data.envelope : undefined;

--- a/src/cli/current-actor.ts
+++ b/src/cli/current-actor.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { loopbackFetchImpl } from '../core/loopback-fetch.js';
 
 export const CURRENT_ACTOR_SCHEMA = 'botmux.current-actor.v2' as const;
 export const CURRENT_ACTOR_ROUTE = '/api/current-actor';
@@ -151,7 +152,7 @@ export async function resolveCurrentActor(
   }
   let response: Response;
   try {
-    response = await (options.fetchImpl ?? fetch)(
+    response = await (options.fetchImpl ?? loopbackFetchImpl)(
       `http://127.0.0.1:${options.ipcPort}${CURRENT_ACTOR_ROUTE}`,
       {
         method: 'POST',

--- a/src/cli/dashboard-endpoint.ts
+++ b/src/cli/dashboard-endpoint.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { cliAuthBind, loadDashboardSecret, signCliAuth } from '../dashboard/auth.js';
+import { loopbackFetchImpl } from '../core/loopback-fetch.js';
 
 /**
  * Loopback HMAC client for the dashboard process's `/__cli/*` endpoints, used by
@@ -90,61 +91,6 @@ export function classifyDashboard401(bodyText: string): DashboardResult {
   };
 }
 
-/**
- * `fetch` for loopback only — **never** the global one.
- *
- * ⚠️ 不要「简化」成 `fetch`。Bun 的 `fetch` 会自动走 `$http_proxy`，而它**不认
- * `no_proxy` 里的 CIDR 写法**（`127.0.0.0/8` 这种）。公司内网开发机的 shell rc 普遍
- * 默认 export 一个 http_proxy + CIDR 形式的 no_proxy，于是这个**本机 loopback 请求
- * 被发到公司代理**，代理拒绝转发内网 IP，回一个 nginx HTML `403 Forbidden` ——
- * 用户看到的就是 `Dashboard lookup failed: 403 <html>…`，而 dashboard 其实活得好好的
- * （它的 `/__cli/*` 只回 JSON，从不回 HTML，所以 HTML 响应本身就是「被代理劫持」的指纹）。
- *
- * 实测（Bun 1.4.0，受控假代理 + 独立标记响应，含 `bun build --compile` 编译态）：
- *
- *   no_proxy=127.0.0.0/8 时          fetch → 403 经代理 ／ node:http → 直连 ✅
- *   fetch(…, {proxy:''/undefined/null})  → 仍然经代理（选项存在 ≠ 生效）
- *   启动后 delete process.env.http_proxy → 仍然经代理（Bun 启动时已快照代理配置）
- *
- * 所以能可靠禁掉代理的只剩「不走 fetch」：`node:http` 完全无视代理 env，Node 与 Bun
- * 下行为一致。同仓先例见 `src/cli/supervisor-shutdown-client.ts`（本机 IPC 也走 node:http）。
- */
-async function loopbackFetch(
-  url: string,
-  init: { method: string; headers: Record<string, string> },
-): Promise<Response> {
-  const { request } = await import('node:http');
-  const target = new URL(url);
-  return new Promise<Response>((resolve, reject) => {
-    const req = request(
-      {
-        // Dial the parsed host/port explicitly rather than handing node:http the
-        // URL, so no proxy-aware URL handling can re-target the request.
-        host: target.hostname,
-        port: target.port,
-        path: `${target.pathname}${target.search}`,
-        method: init.method,
-        headers: init.headers,
-      },
-      res => {
-        const chunks: Buffer[] = [];
-        res.on('data', (chunk: Buffer | string) => chunks.push(Buffer.from(chunk)));
-        res.on('end', () => resolve(new Response(Buffer.concat(chunks), {
-          status: res.statusCode ?? 0,
-          headers: Object.fromEntries(
-            Object.entries(res.headers)
-              .filter(([, v]) => typeof v === 'string')
-              .map(([k, v]) => [k, v as string]),
-          ),
-        })));
-        res.on('error', reject);
-      },
-    );
-    req.on('error', reject);
-    req.end();
-  });
-}
-
 /** Issue a single HMAC-authed request to one candidate port. */
 export async function requestDashboardAt(opts: {
   host: string;
@@ -155,7 +101,7 @@ export async function requestDashboardAt(opts: {
 }): Promise<DashboardResult> {
   const { host, port, path, secret } = opts;
   // Default is the proxy-immune loopback client above, NOT the global `fetch`.
-  const fetchImpl = opts.fetchImpl ?? (loopbackFetch as unknown as FetchImpl);
+  const fetchImpl = opts.fetchImpl ?? loopbackFetchImpl;
   // Bind the credential to method + path + the port we're dialing. A malicious
   // server handed these headers during discovery therefore can't forward them
   // to a different `/__cli/*` route or to the real dashboard on another port —
@@ -218,7 +164,7 @@ export async function callDashboard(opts: {
   const probeSpan = opts.probeSpan ?? 20;
   const persistPort = opts.persistPort ?? true;
   // Same reason as in requestDashboardAt: the default must stay proxy-immune.
-  const fetchImpl = opts.fetchImpl ?? (loopbackFetch as unknown as FetchImpl);
+  const fetchImpl = opts.fetchImpl ?? loopbackFetchImpl;
 
   const secretPath = join(opts.configDir, '.dashboard-secret');
   let secret: string | null;

--- a/src/cli/dashboard-endpoint.ts
+++ b/src/cli/dashboard-endpoint.ts
@@ -90,6 +90,61 @@ export function classifyDashboard401(bodyText: string): DashboardResult {
   };
 }
 
+/**
+ * `fetch` for loopback only — **never** the global one.
+ *
+ * ⚠️ 不要「简化」成 `fetch`。Bun 的 `fetch` 会自动走 `$http_proxy`，而它**不认
+ * `no_proxy` 里的 CIDR 写法**（`127.0.0.0/8` 这种）。公司内网开发机的 shell rc 普遍
+ * 默认 export 一个 http_proxy + CIDR 形式的 no_proxy，于是这个**本机 loopback 请求
+ * 被发到公司代理**，代理拒绝转发内网 IP，回一个 nginx HTML `403 Forbidden` ——
+ * 用户看到的就是 `Dashboard lookup failed: 403 <html>…`，而 dashboard 其实活得好好的
+ * （它的 `/__cli/*` 只回 JSON，从不回 HTML，所以 HTML 响应本身就是「被代理劫持」的指纹）。
+ *
+ * 实测（Bun 1.4.0，受控假代理 + 独立标记响应，含 `bun build --compile` 编译态）：
+ *
+ *   no_proxy=127.0.0.0/8 时          fetch → 403 经代理 ／ node:http → 直连 ✅
+ *   fetch(…, {proxy:''/undefined/null})  → 仍然经代理（选项存在 ≠ 生效）
+ *   启动后 delete process.env.http_proxy → 仍然经代理（Bun 启动时已快照代理配置）
+ *
+ * 所以能可靠禁掉代理的只剩「不走 fetch」：`node:http` 完全无视代理 env，Node 与 Bun
+ * 下行为一致。同仓先例见 `src/cli/supervisor-shutdown-client.ts`（本机 IPC 也走 node:http）。
+ */
+async function loopbackFetch(
+  url: string,
+  init: { method: string; headers: Record<string, string> },
+): Promise<Response> {
+  const { request } = await import('node:http');
+  const target = new URL(url);
+  return new Promise<Response>((resolve, reject) => {
+    const req = request(
+      {
+        // Dial the parsed host/port explicitly rather than handing node:http the
+        // URL, so no proxy-aware URL handling can re-target the request.
+        host: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        method: init.method,
+        headers: init.headers,
+      },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer | string) => chunks.push(Buffer.from(chunk)));
+        res.on('end', () => resolve(new Response(Buffer.concat(chunks), {
+          status: res.statusCode ?? 0,
+          headers: Object.fromEntries(
+            Object.entries(res.headers)
+              .filter(([, v]) => typeof v === 'string')
+              .map(([k, v]) => [k, v as string]),
+          ),
+        })));
+        res.on('error', reject);
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
 /** Issue a single HMAC-authed request to one candidate port. */
 export async function requestDashboardAt(opts: {
   host: string;
@@ -99,7 +154,8 @@ export async function requestDashboardAt(opts: {
   fetchImpl?: FetchImpl;
 }): Promise<DashboardResult> {
   const { host, port, path, secret } = opts;
-  const fetchImpl = opts.fetchImpl ?? fetch;
+  // Default is the proxy-immune loopback client above, NOT the global `fetch`.
+  const fetchImpl = opts.fetchImpl ?? (loopbackFetch as unknown as FetchImpl);
   // Bind the credential to method + path + the port we're dialing. A malicious
   // server handed these headers during discovery therefore can't forward them
   // to a different `/__cli/*` route or to the real dashboard on another port —
@@ -161,7 +217,8 @@ export async function callDashboard(opts: {
   const host = opts.host ?? '127.0.0.1';
   const probeSpan = opts.probeSpan ?? 20;
   const persistPort = opts.persistPort ?? true;
-  const fetchImpl = opts.fetchImpl ?? fetch;
+  // Same reason as in requestDashboardAt: the default must stay proxy-immune.
+  const fetchImpl = opts.fetchImpl ?? (loopbackFetch as unknown as FetchImpl);
 
   const secretPath = join(opts.configDir, '.dashboard-secret');
   let secret: string | null;

--- a/src/cli/exact-chat-grant-client.ts
+++ b/src/cli/exact-chat-grant-client.ts
@@ -1,4 +1,5 @@
 import { cliAuthBind, signCliAuth } from '../dashboard/auth.js';
+import { loopbackFetchImpl } from '../core/loopback-fetch.js';
 
 export interface ExactChatGrantDaemon {
   ipcPort: number;
@@ -35,7 +36,7 @@ export class ExactChatGrantClientError extends Error {
  */
 export async function requestExactChatGrant(
   input: ExactChatGrantClientInput,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = loopbackFetchImpl,
 ): Promise<Record<string, any>> {
   if (input.daemon.larkAppId !== input.receiverLarkAppId) {
     throw new ExactChatGrantClientError('receiver daemon mismatch');

--- a/src/cli/vc-agent.ts
+++ b/src/cli/vc-agent.ts
@@ -24,6 +24,7 @@ import { resolveSessionContext } from '../core/session-marker.js';
 import { fetchDaemonIpc } from '../core/daemon-ipc-auth.js';
 import { readManagedOriginCapability } from '../core/managed-origin-capability.js';
 import type { NormalizedVcMeetingItem } from '../vc-agent/types.js';
+import { loopbackFetch } from '../core/loopback-fetch.js';
 
 const VC_AGENT_SPEAK_MAX_TEXT_LENGTH = 200;
 
@@ -322,7 +323,7 @@ async function cmdRequestOutput(args: string[]): Promise<void> {
     ? receiverPortRaw
     : discoveredReceiver?.ipcPort;
   if (receiverSessionId && receiverAppId && receiverPort) {
-    const managedResponse = await fetch(`http://127.0.0.1:${receiverPort}/api/vc-meetings/action-request`, {
+    const managedResponse = await loopbackFetch(`http://127.0.0.1:${receiverPort}/api/vc-meetings/action-request`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({

--- a/src/core/daemon-ipc-auth.ts
+++ b/src/core/daemon-ipc-auth.ts
@@ -5,6 +5,7 @@ import {
   loadDashboardSecret,
   signCliAuth,
 } from '../dashboard/auth.js';
+import { loopbackFetch, type LoopbackFetchInit } from './loopback-fetch.js';
 
 const DEFAULT_SECRET_PATH = join(homedir(), '.botmux', '.dashboard-secret');
 
@@ -42,7 +43,15 @@ export function loadDaemonIpcSecret(secretPath = DEFAULT_SECRET_PATH): string {
   return secret;
 }
 
-/** Trusted-host fetch wrapper for daemon IPC. */
+/** Trusted-host fetch wrapper for daemon IPC.
+ *
+ * ⚠️ Uses {@link loopbackFetch}, never the global `fetch`: under Bun the global
+ * one routes 127.0.0.1 through `$http_proxy` whenever `no_proxy` does not name
+ * that literal address (CIDR and `localhost` do not count), and the corporate
+ * proxy answers an nginx HTML 403. Verified against this wrapper with a real Bun
+ * process and a stand-in proxy: global fetch → 403 from the proxy;
+ * `loopbackFetch` → straight to the daemon. See src/core/loopback-fetch.ts.
+ */
 export async function fetchDaemonIpc(
   port: number,
   path: string,
@@ -51,8 +60,10 @@ export async function fetchDaemonIpc(
 ): Promise<Response> {
   const resolvedSecret = secret ?? loadDaemonIpcSecret();
   const method = init.method ?? 'GET';
-  return fetch(`http://127.0.0.1:${port}${path}`, {
-    ...init,
+  return loopbackFetch(`http://127.0.0.1:${port}${path}`, {
+    method,
+    body: init.body as LoopbackFetchInit['body'],
+    signal: init.signal ?? undefined,
     headers: daemonIpcAuthHeaders({
       secret: resolvedSecret,
       port,

--- a/src/core/loopback-fetch.ts
+++ b/src/core/loopback-fetch.ts
@@ -206,12 +206,14 @@ export function loopbackFetch(
         },
         res => {
           const status = res.statusCode ?? 0;
-          // Fetch's null-body statuses are 101/204/205/304, and a HEAD response
-          // never carries one either. `new Response(stream, {status:205})` THROWS,
+          // Fetch's null-body statuses that can actually ARRIVE HERE are 204/205/304,
+          // plus any HEAD response. 101 is deliberately absent: node:http never calls
+          // this callback for it (it emits `upgrade` instead — handled below), so a
+          // `status === 101` branch here would be dead code that reads as covered. `new Response(stream, {status:205})` THROWS,
           // and it throws inside this async callback — on Node that escaped as an
           // uncaught exception and killed the process, while Bun happens to tolerate
           // 205, which is exactly why it went unnoticed.
-          const bodyless = status === 101 || status === 204 || status === 205
+          const bodyless = status === 204 || status === 205
             || status === 304 || method === 'HEAD';
           const stream = bodyless ? null : new ReadableStream<Uint8Array>({
             start(controller) {
@@ -263,6 +265,21 @@ export function loopbackFetch(
       finish(() => reject(err));
       return;
     }
+
+    // ⚠️ A 101 arrives as `upgrade`, NOT as a response. Without this listener the
+    // promise never settles: measured against a server answering 101, the call only
+    // ended when an external AbortSignal fired at 800ms (and `requestDashboardAt`
+    // passes no signal at all, so it would hang forever if the recorded port happened
+    // to be a WebSocket service). The native fetch rejects such a response in ~1ms;
+    // do the same, since a fetch-shaped client cannot express a protocol switch.
+    req.on('upgrade', (_res, socket) => {
+      socket.destroy();
+      req.destroy();
+      detachAbort();
+      finish(() => reject(new TypeError(
+        'loopbackFetch: server switched protocols (101); this client does not support upgrades',
+      )));
+    });
 
     // Only a failure BEFORE the response headers can reject the promise; once the
     // Response exists, later socket errors surface through the stream instead.

--- a/src/core/loopback-fetch.ts
+++ b/src/core/loopback-fetch.ts
@@ -166,7 +166,11 @@ export function loopbackFetch(
   // bracketed form through was rejected as `remote_host_forbidden`, i.e. a legal
   // IPv6 loopback URL could never be dialled (measured against a `::1` server).
   const host = normaliseLoopbackHost(target.hostname) as LiteralLoopbackHost;
-  const port = Number(target.port);
+  // `URL` normalises away a scheme's DEFAULT port, so both `http://127.0.0.1/x` and
+  // an explicit `http://127.0.0.1:80/x` yield `port === ''` — `Number('')` is 0 and
+  // was rejected as `invalid_port` (measured against a local server on :80, which the
+  // native fetch reaches fine). Fill in the scheme default.
+  const port = target.port ? Number(target.port) : 80;
   const method = (init.method ?? 'GET').toUpperCase();
   const headers = headerEntries(init.headers);
   const body = bodyToBuffer(init.body);
@@ -307,9 +311,24 @@ export function isLoopbackUrl(url: string): boolean {
   }
 }
 
-/** Strip the brackets `URL.hostname` keeps around IPv6 literals. */
+/**
+ * Canonicalise a hostname for the loopback allow-list.
+ *
+ *  · Strips the brackets `URL.hostname` keeps around IPv6 literals.
+ *  · Maps `localhost` to `127.0.0.1`.
+ *
+ * ⚠️ `localhost` USED to be rejected here, on the reasoning that "a DNS name is
+ * not a loopback guarantee". That was backwards: refusing it did not avoid a
+ * lookup, it pushed the request onto the GLOBAL fetch, which then proxied it —
+ * measured with a self-hosted TTS endpoint, the `Authorization: Bearer …` header
+ * arrived at the stand-in proxy. `localhost` is reserved for loopback by RFC 6761,
+ * and mapping it here means we dial the literal address and never resolve DNS at
+ * all, which is strictly safer than the alternative. Every OTHER hostname stays
+ * rejected — that is where the rebinding concern actually applies.
+ */
 function normaliseLoopbackHost(hostname: string): string {
-  return hostname.startsWith('[') && hostname.endsWith(']')
+  const bare = hostname.startsWith('[') && hostname.endsWith(']')
     ? hostname.slice(1, -1)
     : hostname;
+  return bare === 'localhost' ? '127.0.0.1' : bare;
 }

--- a/src/core/loopback-fetch.ts
+++ b/src/core/loopback-fetch.ts
@@ -1,0 +1,315 @@
+/**
+ * `fetch`-shaped client for **loopback-only** HTTP, built on `node:http`.
+ *
+ * ⚠️ WHY THIS EXISTS — DO NOT "SIMPLIFY" ANY CALLER BACK TO THE GLOBAL `fetch`.
+ *
+ * Bun's `fetch` automatically routes through `$http_proxy`, and its `no_proxy`
+ * handling is **literal-match only**: it does not parse CIDR notation and does
+ * not treat `localhost` as covering `127.0.0.1`. Corporate dev machines commonly
+ * export exactly that shape (`http_proxy=…` plus `no_proxy=…,127.0.0.0/8,…`), so
+ * a request to our OWN loopback port gets handed to the corporate proxy, which
+ * refuses to forward an internal address and answers with an nginx HTML
+ * `403 Forbidden`. The user sees a failure naming a service that is running
+ * perfectly well two ports away.
+ *
+ * Measured on Bun 1.4.0 (source AND `bun build --compile`), one fresh process per
+ * row because Bun snapshots proxy configuration at startup:
+ *
+ *   no_proxy unset / ""        → proxied
+ *   no_proxy=127.0.0.0/8       → proxied      ← the common corporate shape
+ *   no_proxy=localhost         → proxied      ← does NOT cover 127.0.0.1
+ *   no_proxy=127.0.0.1         → direct
+ *   no_proxy=*                 → direct
+ *
+ * And the obvious escapes do not work:
+ *
+ *   fetch(…, {proxy: ''|undefined|null})  → still proxied (option exists ≠ works)
+ *   delete process.env.http_proxy at run  → still proxied (startup snapshot)
+ *   setting  process.env.http_proxy later → still direct  (same reason)
+ *
+ * `node:http` ignores proxy environment variables entirely, in both Node and Bun,
+ * which is the only reliable way to guarantee a loopback dial stays loopback.
+ * Related precedent: `platform/platform-http.ts` (deliberately avoids undici) and
+ * `dashboard/hd2d-assets.ts` (the reverse case — it WANTS the proxy).
+ */
+
+import { Buffer } from 'node:buffer';
+import { requestLiteralLoopback, type LiteralLoopbackHost } from './loopback-target.js';
+
+/** The subset of RequestInit our loopback callers use. */
+export interface LoopbackFetchInit {
+  method?: string;
+  headers?: HeadersInit;
+  /** Accepts what `fetch` accepts; streams are the one thing we cannot forward. */
+  body?: BodyInit | null;
+  signal?: AbortSignal | null;
+}
+
+/** Normalise a fetch-style body to bytes. Streams are rejected loudly rather
+ *  than silently sent as "[object ReadableStream]". */
+function bodyToBuffer(body: BodyInit | null | undefined): Buffer | undefined {
+  if (body == null) return undefined;
+  if (typeof body === 'string') return Buffer.from(body);
+  if (Buffer.isBuffer(body)) return body;
+  if (body instanceof URLSearchParams) return Buffer.from(body.toString());
+  if (body instanceof ArrayBuffer) return Buffer.from(new Uint8Array(body));
+  if (ArrayBuffer.isView(body)) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  }
+  throw new TypeError('loopbackFetch: unsupported body type (streams/FormData are not forwarded)');
+}
+
+function headerEntries(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) return {};
+  // `Headers` (and anything iterable of pairs) normalises casing for us; a plain
+  // object is passed through as written.
+  const out: Record<string, string> = {};
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => { out[key] = value; });
+    return out;
+  }
+  if (Array.isArray(headers)) {
+    for (const [k, v] of headers) out[k] = String(v);
+    return out;
+  }
+  for (const [k, v] of Object.entries(headers)) out[k] = String(v);
+  return out;
+}
+
+/**
+ * The error an aborted request must fail with.
+ *
+ * ⚠️ Callers branch on `err.name === 'AbortError'` to tell "timed out" from
+ * "nothing listening" — e.g. daemon.ts returns 504 `wait_timeout` vs 503
+ * `daemon_offline`, and command-handler.ts reports `busy` vs `failed`. A plain
+ * `new Error('aborted')` (or node:http's own ECONNRESET) silently sends every
+ * timeout down the wrong branch. Measured against the global fetch these replace:
+ * it rejects with `name=AbortError`, while the first version of this module gave
+ * `name=Error, code=ECONNRESET`.
+ *
+ * `signal.reason` is what the platform puts there (a DOMException named
+ * AbortError, or whatever the caller passed to `abort(reason)`); we only
+ * synthesise an equivalent when it is somehow absent.
+ */
+function abortError(signal: AbortSignal | null | undefined): unknown {
+  const reason = signal?.reason;
+  if (reason !== undefined && reason !== null) return reason;
+  // Node and browsers both expose DOMException; fall back to a shaped Error.
+  if (typeof DOMException === 'function') {
+    return new DOMException('The operation was aborted.', 'AbortError');
+  }
+  const err = new Error('The operation was aborted.');
+  err.name = 'AbortError';
+  return err;
+}
+
+/**
+ * Issue one request to a literal loopback host and resolve a real `Response`, so
+ * call sites keep using `.ok` / `.status` / `.json()` / `.text()` unchanged.
+ *
+ * ⚠️ Resolves as soon as the response HEADERS arrive, with the body exposed as a
+ * `ReadableStream` — it must NOT buffer to completion first. `dashboard/aggregator.ts`
+ * subscribes to a never-ending SSE stream (`/api/events`) and reads frames off
+ * `res.body`; a buffer-all implementation never resolves for those callers and the
+ * whole session/event aggregation silently stops. Measured: a server that writes
+ * one frame and holds the connection open produced no Response at all until this
+ * was made streaming. `.text()`/`.json()` still work, because `Response` drains
+ * the stream for them.
+ *
+ * Rejects the way `fetch` does (a transport failure) rather than resolving a
+ * synthetic error status, because callers distinguish "no server there" from
+ * "server said no".
+ */
+/**
+ * Test-only transport override.
+ *
+ * ⚠️ Why this seam exists: several suites drive loopback code paths by replacing
+ * `globalThis.fetch`. Moving those call sites onto node:http silently bypassed
+ * that stub, so the tests began making REAL connections to ports like 4310/39003
+ * — `fetchMock` recorded 0 calls and the assertions failed for a reason unrelated
+ * to what they test. Rather than push every caller back onto the global fetch (the
+ * whole defect), the transport itself is injectable: production keeps node:http,
+ * tests install a mock here.
+ *
+ * Not for production use — `__setLoopbackTransportForTests(undefined)` restores the default.
+ */
+let transportOverride: ((url: string, init: LoopbackFetchInit) => Promise<Response>) | undefined;
+
+/** Install (or clear, with `undefined`) the test transport. Returns the previous one. */
+export function __setLoopbackTransportForTests(
+  next: ((url: string, init: LoopbackFetchInit) => Promise<Response>) | undefined,
+): ((url: string, init: LoopbackFetchInit) => Promise<Response>) | undefined {
+  const previous = transportOverride;
+  transportOverride = next;
+  return previous;
+}
+
+export function loopbackFetch(
+  url: string,
+  init: LoopbackFetchInit = {},
+): Promise<Response> {
+  if (transportOverride) return transportOverride(url, init);
+  const target = new URL(url);
+  // ⚠️ FAIL CLOSED on the scheme. This transport IS node:http, so an `https:` URL
+  // would be dialled as PLAINTEXT — measured: `loopbackFetch('https://127.0.0.1:P')`
+  // against a plain HTTP server returned `200 PLAIN`, i.e. a caller that believed it
+  // was using TLS would have sent its credentials in the clear. `isLoopbackUrl`
+  // already refuses https, but a public helper must not depend on callers routing
+  // through a predicate first.
+  if (target.protocol !== 'http:') {
+    return Promise.reject(new TypeError(
+      `loopbackFetch: only http: is supported (got ${target.protocol})`,
+    ));
+  }
+  // `URL.hostname` keeps IPv6 in brackets (`[::1]`), but node:http — and
+  // requestLiteralLoopback's allow-list — want the bare address. Passing the
+  // bracketed form through was rejected as `remote_host_forbidden`, i.e. a legal
+  // IPv6 loopback URL could never be dialled (measured against a `::1` server).
+  const host = normaliseLoopbackHost(target.hostname) as LiteralLoopbackHost;
+  const port = Number(target.port);
+  const method = (init.method ?? 'GET').toUpperCase();
+  const headers = headerEntries(init.headers);
+  const body = bodyToBuffer(init.body);
+  // A body without a length makes some servers wait for more; be explicit.
+  if (body && headers['content-length'] === undefined && headers['Content-Length'] === undefined) {
+    headers['content-length'] = String(body.byteLength);
+  }
+
+  return new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    const finish = (fn: () => void) => { if (!settled) { settled = true; fn(); } };
+    // Set once the signal fires, so the body stream can fail with the SAME
+    // AbortError instead of the socket's ECONNRESET.
+    let aborted: unknown;
+    // ⚠️ The abort listener MUST be removed once this request can no longer be
+    // aborted. `{ once: true }` only fires-and-forgets on a real abort; a request
+    // that simply COMPLETED left its listener attached, and `dashboard/aggregator.ts`
+    // reuses one AbortController across an unbounded SSE reconnect loop — measured,
+    // 12 completed requests left 12 listeners, each pinning a finished req/res and
+    // its closure, and a later abort would destroy every stale request in turn.
+    let detachAbort = () => {};
+
+    let req: ReturnType<typeof requestLiteralLoopback>;
+    try {
+      req = requestLiteralLoopback(
+        // Dial the parsed host/port explicitly (and validated as loopback) rather
+        // than handing over the URL, so nothing can re-target the request.
+        { host, port },
+        {
+          path: `${target.pathname}${target.search}`,
+          method,
+          headers,
+        },
+        res => {
+          const status = res.statusCode ?? 0;
+          // Fetch's null-body statuses are 101/204/205/304, and a HEAD response
+          // never carries one either. `new Response(stream, {status:205})` THROWS,
+          // and it throws inside this async callback — on Node that escaped as an
+          // uncaught exception and killed the process, while Bun happens to tolerate
+          // 205, which is exactly why it went unnoticed.
+          const bodyless = status === 101 || status === 204 || status === 205
+            || status === 304 || method === 'HEAD';
+          const stream = bodyless ? null : new ReadableStream<Uint8Array>({
+            start(controller) {
+              res.on('data', (chunk: Buffer | string) => {
+                try { controller.enqueue(new Uint8Array(Buffer.from(chunk))); }
+                catch { /* already closed by a cancel() */ }
+              });
+              res.on('end', () => {
+                detachAbort();
+                try { controller.close(); } catch { /* already closed */ }
+              });
+              res.on('error', err => {
+                detachAbort();
+                // An abort must surface as AbortError, not the ECONNRESET that
+                // destroying the socket produces.
+                try { controller.error(aborted ?? err); } catch { /* already errored */ }
+              });
+            },
+            // A consumer that stops reading (or aborts) must tear the socket down,
+            // otherwise a never-ending SSE keeps the connection and the process alive.
+            cancel() { detachAbort(); res.destroy(); req.destroy(); },
+          });
+          if (bodyless) detachAbort();
+          // Wrapped: any status the Response constructor refuses (an upstream
+          // sending something illegal) must reject this promise, never escape as an
+          // uncaught exception out of an HTTP event callback.
+          let response: Response;
+          try {
+            response = new Response(stream, {
+              status,
+              statusText: res.statusMessage ?? '',
+              headers: Object.fromEntries(
+                Object.entries(res.headers)
+                  .filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+              ),
+            });
+          } catch (err) {
+            detachAbort();
+            res.destroy();
+            finish(() => reject(err));
+            return;
+          }
+          finish(() => resolve(response));
+        },
+      );
+    } catch (err) {
+      // Invalid host/port (the loopback guard) — surface it, do not hang.
+      detachAbort();
+      finish(() => reject(err));
+      return;
+    }
+
+    // Only a failure BEFORE the response headers can reject the promise; once the
+    // Response exists, later socket errors surface through the stream instead.
+    req.on('error', err => { detachAbort(); finish(() => reject(aborted ?? err)); });
+    if (init.signal) {
+      const signal = init.signal;
+      const onAbort = () => {
+        aborted = abortError(signal);
+        req.destroy();
+        finish(() => reject(aborted));
+      };
+      if (signal.aborted) { onAbort(); return; }
+      signal.addEventListener('abort', onAbort, { once: true });
+      detachAbort = () => {
+        signal.removeEventListener('abort', onAbort);
+        detachAbort = () => {};
+      };
+    }
+    if (body) req.end(body); else req.end();
+  });
+}
+
+/** `typeof fetch`-compatible view, for defaulting an injectable `fetchImpl`. */
+export const loopbackFetchImpl = loopbackFetch as unknown as typeof fetch;
+
+/**
+ * Is this URL a literal loopback target, i.e. safe (and necessary) to send through
+ * {@link loopbackFetch}? For call sites whose base URL is configurable and may
+ * legitimately point at a remote host — those must keep using the global fetch,
+ * which handles TLS, redirects and real proxying.
+ *
+ * Literal only, deliberately: a DNS name that currently resolves to 127.0.0.1
+ * is not a loopback guarantee (it can be re-pointed), and `loopbackFetch`'s own
+ * guard would reject it anyway.
+ */
+export function isLoopbackUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    // `http:` only — this transport IS node:http, so reporting an `https:` URL as
+    // loopback-safe would steer a caller onto a transport that cannot serve it.
+    if (parsed.protocol !== 'http:') return false;
+    const host = normaliseLoopbackHost(parsed.hostname);
+    return host === '127.0.0.1' || host === '::1';
+  } catch {
+    return false;
+  }
+}
+
+/** Strip the brackets `URL.hostname` keeps around IPv6 literals. */
+function normaliseLoopbackHost(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+}

--- a/src/core/managed-origin-attestation.ts
+++ b/src/core/managed-origin-attestation.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { loopbackFetchImpl } from './loopback-fetch.js';
 import {
   closeSync,
   constants as fsConstants,
@@ -220,7 +221,7 @@ export async function attestManagedOrigin(input: {
   timer.unref?.();
   let response: Response;
   try {
-    response = await (input.fetchImpl ?? fetch)(
+    response = await (input.fetchImpl ?? loopbackFetchImpl)(
       `http://127.0.0.1:${port}${MANAGED_ORIGIN_ATTEST_ROUTE}`,
       {
         method: 'POST',

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -648,6 +648,7 @@ import {
   type VcMeetingSealedReceiverSessionBinding,
 } from './services/vc-meeting-im-routing.js';
 import { VC_MEETING_HUMAN_IM_OUTPUT_CONTRACT } from './services/vc-meeting-listener-output-protocol.js';
+import { loopbackFetch } from './core/loopback-fetch.js';
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -2818,7 +2819,7 @@ async function fetchVcMeetingDaemonJson(
       path,
       headers: vcAuthenticatedHeaders,
     });
-    const upstream = await fetch(`http://127.0.0.1:${daemon.ipcPort}${path}`, {
+    const upstream = await loopbackFetch(`http://127.0.0.1:${daemon.ipcPort}${path}`, {
       ...init,
       headers: authenticatedHeaders,
       signal: init.signal ?? controller.signal,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -242,6 +242,7 @@ import {
 } from './services/skill-registry-store.js';
 import { readSkillPackRegistry } from './services/skill-pack-store.js';
 import { dashboardSessionActionTimeoutMs, type DashboardSessionAction } from './dashboard/session-action-timeout.js';
+import { loopbackFetch } from './core/loopback-fetch.js';
 import {
   cloneSkillPack,
   createSkillPack,
@@ -2445,7 +2446,7 @@ async function proxyToDaemon(
   for (const [key, value] of Object.entries(authHeaders)) {
     headers.set(key, value);
   }
-  const upstream = await fetch(
+  const upstream = await loopbackFetch(
     `http://127.0.0.1:${d.ipcPort}${daemonPath}`,
     { ...init, headers },
   );

--- a/src/dashboard/aggregator.ts
+++ b/src/dashboard/aggregator.ts
@@ -1,6 +1,7 @@
 // src/dashboard/aggregator.ts
 import type { DaemonInfo } from './registry.js';
 import type { DashboardEvent } from '../core/dashboard-events.js';
+import { loopbackFetchImpl } from '../core/loopback-fetch.js';
 
 type Row = { sessionId: string; larkAppId: string; [k: string]: unknown };
 type Sched = { id: string; [k: string]: unknown };
@@ -184,7 +185,7 @@ export function subscribeDaemon(
   d: DaemonInfo,
   agg: Aggregator,
   onError: (e: Error) => void,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = loopbackFetchImpl,
   onConnected?: (signal: AbortSignal) => Promise<void> | void,
 ): () => void {
   const ctrl = new AbortController();

--- a/src/dashboard/daemon-internal-client.ts
+++ b/src/dashboard/daemon-internal-client.ts
@@ -26,6 +26,7 @@ import { randomBytes } from 'node:crypto';
 import { dashboardSecretPath } from '../core/dashboard-secret.js';
 import { loadDashboardSecret } from './auth.js';
 import { signDaemonRequest } from './daemon-internal-auth.js';
+import { isLoopbackUrl, loopbackFetchImpl } from '../core/loopback-fetch.js';
 
 const DEFAULT_DASHBOARD_URL = 'http://127.0.0.1:7891';
 const DEFAULT_RETRIES = 3;
@@ -123,7 +124,11 @@ export function createDaemonClient(opts: DaemonClientOptions): DaemonClient {
   const secret = opts.secret?.trim() ?? loadSecretFromFile(opts.secretPath ?? SECRET_PATH_DEFAULT);
   if (!secret) throw new Error('dashboard_secret_missing');
   const appId = opts.appId;
-  const fetchFn = opts.fetch ?? fetch;
+  // Loopback targets must NOT go through the global fetch: under Bun it routes
+  // 127.0.0.1 via $http_proxy unless no_proxy names that literal address, and the
+  // proxy can then both fail the call AND forge a well-formed reply. `dashboardUrl`
+  // is overridable, so dispatch on the resolved host rather than assuming loopback.
+  const fetchFn = opts.fetch ?? (isLoopbackUrl(dashboardUrl) ? loopbackFetchImpl : fetch);
   const now = opts.now ?? Date.now;
   const nonceFn = opts.randomNonce ?? defaultNonce;
   const defaultRetries = opts.retries ?? DEFAULT_RETRIES;

--- a/src/dashboard/groups-action-helpers.ts
+++ b/src/dashboard/groups-action-helpers.ts
@@ -8,6 +8,8 @@
  * response. Behaviour is byte-equivalent to the original inline implementation;
  * all IO flows through `deps`.
  */
+import { loopbackFetchImpl } from '../core/loopback-fetch.js';
+
 
 export interface DaemonHandle {
   larkAppId: string;
@@ -68,7 +70,7 @@ export async function addBotsToGroup(
   } catch {
     return err('bad_json', 400);
   }
-  const fetchFn = deps.fetch ?? fetch;
+  const fetchFn = deps.fetch ?? loopbackFetchImpl;
   let proxy: DaemonHandle | undefined;
   for (const d of deps.registryList()) {
     try {
@@ -140,7 +142,7 @@ export async function leaveGroup(
     : [];
   if (ids.length === 0) return err('larkAppIds_required', 400);
 
-  const fetchFn = deps.fetch ?? fetch;
+  const fetchFn = deps.fetch ?? loopbackFetchImpl;
   const result = await Promise.all(ids.map(async appId => {
     const d = deps.registryGetByAppId(appId);
     // Pre-proxy failure shapes do NOT carry `closedSessions` — matches the

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -7,6 +7,7 @@ import { logger } from '../utils/logger.js';
 import { fetchDaemonIpc, loadDaemonIpcSecret } from '../core/daemon-ipc-auth.js';
 import { resolveSessionContext } from '../core/session-marker.js';
 import { readManagedOriginCapability } from '../core/managed-origin-capability.js';
+import { loopbackFetch } from '../core/loopback-fetch.js';
 
 export const HOOK_EVENTS = [
   'topic.new',
@@ -513,7 +514,7 @@ export async function forwardEmitToDaemon(
       try { secret = loadDaemonIpcSecret(); } catch { /* Seatbelt/read-isolated CLI */ }
       const res = secret
         ? await fetchDaemonIpc(ipcPort, '/api/hooks/emit', request, secret)
-        : await fetch(`http://127.0.0.1:${ipcPort}/api/hooks/emit`, request);
+        : await loopbackFetch(`http://127.0.0.1:${ipcPort}/api/hooks/emit`, request);
       if (!res.ok) {
         logger.warn(`[hooks] CLI forward ${event} → daemon: HTTP ${res.status}`);
       }

--- a/src/services/voice/openai.ts
+++ b/src/services/voice/openai.ts
@@ -11,6 +11,7 @@
  */
 import type { Pcm } from './audio.js';
 import type { VoiceProviderEffectOptions } from './sami.js';
+import { isLoopbackUrl, loopbackFetch } from '../../core/loopback-fetch.js';
 
 export interface OpenAITtsConfig {
   baseUrl: string; // e.g. https://api.openai.com/v1 or http://127.0.0.1:8880/v1
@@ -48,7 +49,15 @@ export async function openaiSynthesizePcm(
   const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 60000);
   try {
     await effects.beforeProviderEffect?.();
-    const res = await fetch(url, {
+    // A self-hosted endpoint is the documented case here (the config hint literally
+    // suggests `http://127.0.0.1:8880/v1`), and this request carries the API key.
+    // Under Bun the global fetch proxies 127.0.0.1 whenever `no_proxy` does not name
+    // that literal address — measured: the `Authorization: Bearer …` header arrived
+    // at the proxy and the call failed with the proxy's 403. Dispatch on the resolved
+    // URL so a local endpoint bypasses the proxy while a remote one still gets the
+    // native fetch (TLS, redirects, real proxying).
+    const send = isLoopbackUrl(url) ? loopbackFetch : fetch;
+    const res = await send(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/services/worktree-slug-ai.ts
+++ b/src/services/worktree-slug-ai.ts
@@ -1,6 +1,7 @@
 import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
 import { slugFromWorktreeText } from './git-worktree.js';
+import { isLoopbackUrl, loopbackFetch } from '../core/loopback-fetch.js';
 
 const SYSTEM_PROMPT = `You generate short, stable git branch slugs for coding tasks.
 Return ONLY one lowercase ASCII slug, no markdown, no quotes.
@@ -48,7 +49,13 @@ export async function worktreeSlugFromContextAI(title?: string, firstPrompt?: st
   if (!c) return fallback;
   try {
     const url = `${c.baseUrl.replace(/\/+$/, '')}/chat/completions`;
-    const resp = await fetch(url, {
+    // Same hazard as the self-hosted TTS endpoint: `baseUrl` is user-configured and
+    // may well be a local model, while this request carries `Authorization: Bearer`.
+    // Under Bun the global fetch proxies 127.0.0.1 unless `no_proxy` names that
+    // literal address — measured with a canary, the token reached the proxy and the
+    // call then fell back silently. Dispatch on the resolved URL; remote stays native.
+    const send = isLoopbackUrl(url) ? loopbackFetch : fetch;
+    const resp = await send(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/workflows/v3/daemon-ipc-client.ts
+++ b/src/workflows/v3/daemon-ipc-client.ts
@@ -1,6 +1,7 @@
 /** Shared client for authenticated Workflow v3 daemon mutations. */
 
 import type { OnlineDaemonInfo } from '../../utils/daemon-discovery.js';
+import { loopbackFetchImpl } from '../../core/loopback-fetch.js';
 import {
   generateWorkflowDaemonIpcNonce,
   loadWorkflowDaemonIpcSecret,
@@ -84,7 +85,7 @@ export async function postWorkflowDaemonMutation(input: {
     timestamp,
     nonce,
   });
-  const fetchImpl = input.fetchImpl ?? fetch;
+  const fetchImpl = input.fetchImpl ?? loopbackFetchImpl;
   let response: Response;
   try {
     response = await fetchImpl(`http://127.0.0.1:${target.ipcPort}${pathWithQuery}`, {

--- a/src/workflows/v3/session-relay-client.ts
+++ b/src/workflows/v3/session-relay-client.ts
@@ -20,6 +20,7 @@ import { findAncestorSessionContext } from '../../core/session-marker.js';
 import type { WorkflowDaemonMutation, WorkflowDaemonMutationResponse } from './daemon-ipc-client.js';
 import { WorkflowDaemonMutationTransportError } from './daemon-ipc-client.js';
 import { V3_SESSION_RUN_MUTATION_ROUTE_PREFIX } from './session-relay.js';
+import { loopbackFetchImpl } from '../../core/loopback-fetch.js';
 
 export interface WorkflowSessionRelayContext {
   sessionId: string;
@@ -119,7 +120,7 @@ export async function postWorkflowSessionRunMutation(input: {
       ? { originDispatchAttempt: input.context.dispatchAttempt }
       : {}),
   });
-  const fetchImpl = input.fetchImpl ?? fetch;
+  const fetchImpl = input.fetchImpl ?? loopbackFetchImpl;
   let response: Response;
   try {
     response = await fetchImpl(`http://127.0.0.1:${ipcPort}${path}`, {

--- a/test/dashboard-endpoint.test.ts
+++ b/test/dashboard-endpoint.test.ts
@@ -305,3 +305,113 @@ describe('discovery credential binding (anti-forward)', () => {
 
 // Guard against `existsSync` import being tree-shaken in refactors.
 void existsSync;
+
+
+/**
+ * The loopback client must not honour `$http_proxy` — regression guard for
+ * `Dashboard lookup failed: 403 <html>… 403 Forbidden …`.
+ *
+ * ⚠️⚠️ WHY NOT JUST "call callDashboard with proxy env set and assert it worked":
+ * measured — that test is BORN TOOTHLESS. Vitest executes test bodies under
+ * **Node even when launched via `bun x vitest`** (probed: `runtime=node v22.21.1`,
+ * `execPath=…/node`), and Node's `fetch` ignores proxy env anyway. So reverting
+ * the production default back to the global `fetch` keeps such a test green:
+ * verified, 25/25 passed under BOTH `npx vitest` and `bun x vitest` with the fix
+ * reverted. The defect only exists in Bun's `fetch`, which no in-process vitest
+ * assertion can reach.
+ *
+ * Hence two guards that CAN bite:
+ *  1. A shape guard on the source — no runtime needed, so it holds in CI.
+ *  2. A real Bun child process (skipped when no bun binary is around), which is
+ *     the only way to observe the actual proxying behaviour.
+ */
+describe('loopback client ignores $http_proxy (403 nginx regression)', () => {
+  const ENDPOINT_SRC = join(__dirname, '..', 'src', 'cli', 'dashboard-endpoint.ts');
+
+  it('never falls back to the global fetch for the default client (shape guard)', () => {
+    const src = readFileSync(ENDPOINT_SRC, 'utf8');
+    // Both defaulting sites (requestDashboardAt + callDashboard) must resolve to
+    // the node:http client. `?? fetch` is exactly the regression: on Bun that
+    // routes a 127.0.0.1 request through $http_proxy when no_proxy is a CIDR.
+    const globalFetchFallbacks = src.match(/fetchImpl\s*\?\?\s*fetch\b/g) ?? [];
+    expect(globalFetchFallbacks).toEqual([]);
+    const loopbackDefaults = src.match(/fetchImpl\s*\?\?\s*\(loopbackFetch\b/g) ?? [];
+    expect(loopbackDefaults).toHaveLength(2);
+    // And the client itself must be built on node:http, not fetch.
+    expect(src).toMatch(/await import\(['"]node:http['"]\)/);
+  });
+
+  it('a real Bun process reaches the dashboard directly with a CIDR no_proxy', async () => {
+    const bun = [
+      process.env.BUN_PATH,
+      join(process.env.HOME ?? '/root', '.bun', 'bin', 'bun'),
+      '/root/.bun/bin/bun',
+    ].find(p => p && existsSync(p));
+    if (!bun) { expect(true).toBe(true); return; }   // no bun available; shape guard still covers CI
+
+    const { createServer } = await import('node:http');
+    const servers: import('node:http').Server[] = [];
+    const listen = async (h: import('node:http').RequestListener) => {
+      const s = createServer(h); servers.push(s);
+      await new Promise<void>(r => s.listen(0, '127.0.0.1', () => r()));
+      return (s.address() as { port: number }).port;
+    };
+    try {
+      let proxyHits = 0, directHits = 0;
+      const proxyPort = await listen((_q, s) => {
+        proxyHits++;
+        s.writeHead(403, { 'content-type': 'text/html' });
+        s.end('<html><head><title>403 Forbidden</title></head></html>');
+      });
+      const dashPort = await listen((_q, s) => {
+        directHits++;
+        s.writeHead(200, { 'content-type': 'application/json' });
+        s.end(JSON.stringify({ url: 'http://dash.local/?t=direct' }));
+      });
+      setPort(dashPort);
+
+      const snippet = `
+        const { callDashboard } = await import(${JSON.stringify(join(__dirname, '..', 'src', 'cli', 'dashboard-endpoint.ts'))});
+        const r = await callDashboard({ configDir: ${JSON.stringify(dir)}, defaultPort: ${dashPort}, path: '/__cli/current', probeSpan: 0 });
+        process.stdout.write(JSON.stringify({ runtime: typeof Bun !== 'undefined' ? 'bun' : 'node', r }));
+      `;
+      // ⚠️ MUST be async spawn, not spawnSync: spawnSync blocks this process's
+      // event loop, so the two servers above would never accept the child's
+      // connection — the child then times out and the test fails for a reason
+      // that has nothing to do with proxying. (Measured: spawnSync → 30s
+      // timeout, empty stdout.)
+      const { spawn } = await import('node:child_process');
+      const proxyUrl = `http://127.0.0.1:${proxyPort}`;
+      const stdout = await new Promise<string>((resolve, reject) => {
+        const child = spawn(bun, ['-e', snippet], {
+          env: {
+            ...process.env,
+            http_proxy: proxyUrl, HTTP_PROXY: proxyUrl,
+            https_proxy: proxyUrl, HTTPS_PROXY: proxyUrl,
+            // The CIDR form real shell rc files use — the one Bun's fetch ignores.
+            no_proxy: '127.0.0.0/8', NO_PROXY: '127.0.0.0/8',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let out = '', err = '';
+        child.stdout.on('data', d => { out += String(d); });
+        child.stderr.on('data', d => { err += String(d); });
+        const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error('bun child timed out')); }, 25_000);
+        child.on('error', e => { clearTimeout(timer); reject(e); });
+        child.on('close', code => {
+          clearTimeout(timer);
+          if (code !== 0) reject(new Error(`bun child exited ${code}: ${err.slice(0, 500)}`));
+          else resolve(out);
+        });
+      });
+      const parsed = JSON.parse(stdout || '{}');
+      // Prove the child really was Bun; otherwise this assertion means nothing.
+      expect(parsed.runtime).toBe('bun');
+      expect(proxyHits).toBe(0);
+      expect(directHits).toBe(1);
+      expect(parsed.r).toEqual({ ok: true, url: 'http://dash.local/?t=direct' });
+    } finally {
+      await Promise.all(servers.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
+    }
+  }, 40_000);
+});

--- a/test/dashboard-endpoint.test.ts
+++ b/test/dashboard-endpoint.test.ts
@@ -326,6 +326,21 @@ void existsSync;
  *     the only way to observe the actual proxying behaviour.
  */
 describe('loopback client ignores $http_proxy (403 nginx regression)', () => {
+  /**
+   * Locate a bun binary the way CI actually provides one: `oven-sh/setup-bun`
+   * only prepends it to PATH (it sets no BUN_PATH), so PATH is the source of
+   * truth. $BUN_PATH stays supported as an explicit override.
+   */
+  function resolveBun(): string | undefined {
+    if (process.env.BUN_PATH && existsSync(process.env.BUN_PATH)) return process.env.BUN_PATH;
+    for (const dir of (process.env.PATH ?? '').split(':')) {
+      if (!dir) continue;
+      const candidate = join(dir, 'bun');
+      if (existsSync(candidate)) return candidate;
+    }
+    return undefined;
+  }
+
   const ENDPOINT_SRC = join(__dirname, '..', 'src', 'cli', 'dashboard-endpoint.ts');
 
   it('never falls back to the global fetch for the default client (shape guard)', () => {
@@ -335,19 +350,38 @@ describe('loopback client ignores $http_proxy (403 nginx regression)', () => {
     // routes a 127.0.0.1 request through $http_proxy when no_proxy is a CIDR.
     const globalFetchFallbacks = src.match(/fetchImpl\s*\?\?\s*fetch\b/g) ?? [];
     expect(globalFetchFallbacks).toEqual([]);
-    const loopbackDefaults = src.match(/fetchImpl\s*\?\?\s*\(loopbackFetch\b/g) ?? [];
+    const loopbackDefaults = src.match(/fetchImpl\s*\?\?\s*loopbackFetchImpl\b/g) ?? [];
     expect(loopbackDefaults).toHaveLength(2);
-    // And the client itself must be built on node:http, not fetch.
-    expect(src).toMatch(/await import\(['"]node:http['"]\)/);
+    // …and the client it defaults to must itself be built on node:http.
+    const client = readFileSync(join(__dirname, '..', 'src', 'core', 'loopback-fetch.ts'), 'utf8');
+    expect(client).toMatch(/from 'node:buffer'|requestLiteralLoopback/);
+    expect(client).not.toMatch(/\bawait fetch\(|=\s*fetch\(/);
+  });
+
+  it('the daemon-IPC wrapper does not use the global fetch either', () => {
+    // Same defect, different wrapper: fetchDaemonIpc is the loopback client for
+    // 30+ call sites (resume/suspend/lang/term-link/dashboard→daemon). Verified
+    // with a real Bun process against a stand-in proxy: the global fetch returned
+    // the proxy's 403, loopbackFetch reached the daemon.
+    const ipc = readFileSync(join(__dirname, '..', 'src', 'core', 'daemon-ipc-auth.ts'), 'utf8');
+    expect(ipc).toContain('loopbackFetch(');
+    expect(ipc).not.toMatch(/return fetch\(|await fetch\(/);
   });
 
   it('a real Bun process reaches the dashboard directly with a CIDR no_proxy', async () => {
-    const bun = [
-      process.env.BUN_PATH,
-      join(process.env.HOME ?? '/root', '.bun', 'bin', 'bun'),
-      '/root/.bun/bin/bun',
-    ].find(p => p && existsSync(p));
-    if (!bun) { expect(true).toBe(true); return; }   // no bun available; shape guard still covers CI
+    const bun = resolveBun();
+    if (!bun) {
+      // ⚠️ Never silently pass in CI. This lookup used to check only $BUN_PATH,
+      // $HOME/.bun/bin/bun and a hardcoded /root/.bun/bin/bun — and
+      // test/unit-setup.ts rewrites process.env.HOME to an isolated temp dir
+      // before test modules load, so on a non-root GitHub runner all three miss
+      // and the real proxy assertion never ran while the suite stayed green
+      // (measured: found=NONE under the isolated HOME). setup-bun only puts bun
+      // on PATH, so PATH is what we resolve; if CI still cannot find it that is a
+      // broken workflow, not a reason to skip.
+      if (process.env.CI) throw new Error('bun not found on PATH; this test must not be skipped in CI');
+      return;
+    }
 
     const { createServer } = await import('node:http');
     const servers: import('node:http').Server[] = [];

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -542,3 +542,104 @@ describe('cleanupTraexAskHooks', () => {
     expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual(existing);
   });
 });
+
+/**
+ * The generated plugins must not reach a loopback service through the global
+ * `fetch`, and — the part a `toContain` check cannot see — the helper they call
+ * has to actually EXIST in each generated file.
+ *
+ * WHY THIS IS EXECUTED, NOT GREPPED: the helper was first interpolated into the
+ * V2 template only, while BOTH templates had their call switched over. The V1
+ * plugin then died with `ReferenceError: loopbackSafeFetch is not defined` on its
+ * fallback path — and every source-contains assertion stayed green, because the
+ * call site is present in both. "Changed the call, forgot the definition" is the
+ * characteristic generated-template defect, so these tests import the emitted
+ * file and run the function.
+ *
+ * The plugins run inside OpenCode's Bun process, where `fetch` auto-uses
+ * `$http_proxy` and `no_proxy` is literal-match only. For the V2 reply path that
+ * also means the Basic password from the registration file would be handed to the
+ * corporate proxy, not just a failed reply.
+ */
+describe('generated OpenCode plugins — loopback requests bypass the proxy', () => {
+  const CASES = [
+    { label: 'V1 (opencode-plugin)', cliId: 'opencode', format: 'opencode-plugin' as const },
+    { label: 'V2 (opencode2-plugin)', cliId: 'opencode', format: 'opencode2-plugin' as const },
+  ];
+
+  for (const { label, cliId, format } of CASES) {
+    it(`${label}: defines loopbackSafeFetch wherever it is called`, () => {
+      const dir = makeTmpDir();
+      const configPath = join(dir, 'plugin', 'botmux-ask.js');
+      installHook(cliId, { configPath, format }, '/usr/bin/node /x/cli.js hook opencode');
+      const src = readFileSync(configPath, 'utf-8');
+      // A call without a definition is the defect; assert on the PAIR.
+      const calls = (src.match(/loopbackSafeFetch\(/g) ?? []).length;
+      const defs = (src.match(/(?:async\s+)?function\s+loopbackSafeFetch\b/g) ?? []).length;
+      expect(calls).toBeGreaterThan(0);
+      expect(defs).toBe(1);
+      // And it must be built on node:http — that is the whole point.
+      expect(src).toContain("await import(\"node:http\")");
+      expect(src).toContain('isLiteralLoopback');
+    });
+
+    it(`${label}: the emitted helper RUNS and reaches a loopback server directly`, async () => {
+      const dir = makeTmpDir();
+      const configPath = join(dir, 'plugin', 'botmux-ask.js');
+      installHook(cliId, { configPath, format }, '/usr/bin/node /x/cli.js hook opencode');
+      const src = readFileSync(configPath, 'utf-8');
+
+      // Pull just the two helper functions out of the generated file and evaluate
+      // them. Importing the whole plugin would start its OpenCode wiring; this
+      // still executes the REAL emitted text, which is what the guard is about.
+      const from = src.indexOf('function isLiteralLoopback');
+      expect(from).toBeGreaterThan(-1);
+      const to = src.indexOf('\n}', src.indexOf('function loopbackSafeFetch'));
+      expect(to).toBeGreaterThan(from);
+      const helperSrc = src.slice(from, to + 2);
+
+      const { createServer } = await import('node:http');
+      const servers: import('node:http').Server[] = [];
+      try {
+        let direct = 0;
+        const server = createServer((_q, r) => {
+          direct++;
+          r.writeHead(200, { 'content-type': 'application/json' });
+          r.end('{"ok":true}');
+        });
+        servers.push(server);
+        await new Promise<void>(res => server.listen(0, '127.0.0.1', () => res()));
+        const port = (server.address() as { port: number }).port;
+
+        // `new Function` has no dynamic-import callback, so the generated
+        // `await import("node:http")` cannot resolve inside it. Hand the module in
+        // through a local `import` binding instead of rewriting the emitted text —
+        // the body under test stays byte-for-byte what we ship.
+        const nodeHttp = await import('node:http');
+        // eslint-disable-next-line no-new-func
+        const make = new Function('__import', `const _i = __import; ${helperSrc.replace(/await import\("node:http"\)/g, '_i("node:http")')}\nreturn { isLiteralLoopback, loopbackSafeFetch };`);
+        const { isLiteralLoopback, loopbackSafeFetch } = make(
+          (spec: string) => (spec === 'node:http' ? nodeHttp : (() => { throw new Error(`unexpected import ${spec}`); })()),
+        ) as {
+          isLiteralLoopback: (u: string) => boolean;
+          loopbackSafeFetch: (u: string, i?: unknown) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+        };
+
+        // Classification: loopback vs remote (remote must keep the native fetch).
+        expect(isLiteralLoopback(`http://127.0.0.1:${port}/x`)).toBe(true);
+        expect(isLiteralLoopback('http://localhost:1/x')).toBe(true);
+        expect(isLiteralLoopback('https://api.example.com/x')).toBe(false);
+
+        const res = await loopbackSafeFetch(`http://127.0.0.1:${port}/api/x`, {
+          method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}',
+        });
+        expect(res.ok).toBe(true);
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe('{"ok":true}');
+        expect(direct).toBe(1);
+      } finally {
+        await Promise.all(servers.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
+      }
+    });
+  }
+});

--- a/test/hook-runner.test.ts
+++ b/test/hook-runner.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { tsRunnerPrefix, tsEvalArgs } from './helpers/ts-runner.js';
+import { __setLoopbackTransportForTests } from '../src/core/loopback-fetch.js';
 
 import {
   filterMatches,
@@ -43,9 +44,12 @@ describe('parseHookCommand', () => {
 
 describe('managed hook forwarding', () => {
   it('uses only the frozen protected port and exact original tuple', async () => {
-    const originalFetch = globalThis.fetch;
+    // The forwarder deliberately uses the proxy-immune loopback transport (node:http),
+    // so stubbing `globalThis.fetch` no longer intercepts it — that stub made the
+    // test open a REAL connection to port 4310 and record zero calls. Inject the
+    // transport seam instead; the assertions below are unchanged.
     const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
-    globalThis.fetch = fetchMock as typeof fetch;
+    const originalTransport = __setLoopbackTransportForTests(fetchMock as never);
     try {
       await forwardEmitToDaemon(
         'outbound.send',
@@ -60,7 +64,7 @@ describe('managed hook forwarding', () => {
         },
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      __setLoopbackTransportForTests(originalTransport);
     }
 
     expect(fetchMock).toHaveBeenCalledOnce();
@@ -79,14 +83,14 @@ describe('managed hook forwarding', () => {
     const oldSession = process.env.BOTMUX_SESSION_ID;
     const oldApp = process.env.BOTMUX_LARK_APP_ID;
     const oldHooks = process.env.BOTMUX_HOOKS_JSON;
-    const originalFetch = globalThis.fetch;
     const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
     process.env.BOTMUX_SESSION_ID = '';
     process.env.BOTMUX_LARK_APP_ID = '';
     process.env.BOTMUX_HOOKS_JSON = JSON.stringify([
       { event: 'outbound.send', command: `/usr/bin/touch ${marker}` },
     ]);
-    globalThis.fetch = fetchMock as typeof fetch;
+    // Same reason as above: intercept the loopback transport, not globalThis.fetch.
+    const originalTransport = __setLoopbackTransportForTests(fetchMock as never);
     try {
       emitHookEvent('outbound.send', { content: 'managed' }, {
         managedOrigin: {
@@ -100,7 +104,7 @@ describe('managed hook forwarding', () => {
       await new Promise(resolve => setTimeout(resolve, 25));
       expect(existsSync(marker)).toBe(false);
     } finally {
-      globalThis.fetch = originalFetch;
+      __setLoopbackTransportForTests(originalTransport);
       if (oldSession === undefined) delete process.env.BOTMUX_SESSION_ID;
       else process.env.BOTMUX_SESSION_ID = oldSession;
       if (oldApp === undefined) delete process.env.BOTMUX_LARK_APP_ID;

--- a/test/install-path-entry.test.ts
+++ b/test/install-path-entry.test.ts
@@ -297,16 +297,18 @@ describe('install.sh stays in step with the shared module', () => {
     expect(fn.slice(0, 400)).toContain('.bash_login');
   });
 
-  it('its idempotence check is per-LINE, not two independent greps', () => {
-    // Two separate greps accept "dir named in a comment" + "unrelated PATH export
-    // on another line" and wrongly skip a machine that is not configured
-    // (reproduced). The dir and the assignment must be found on the SAME line,
-    // which here means piping the dir matches INTO the assignment match.
+  it('its idempotence check is per-LINE and quote-aware, not two independent greps', () => {
     const fn = sh.slice(sh.indexOf('path_line_present()'), sh.indexOf('bash_login_file()'));
-    expect(fn).toContain('grep -F "$INSTALL_DIR"');
-    expect(fn).toMatch(/grep -F "\$INSTALL_DIR"[^\n]*\n?[^\n]*\|/);
+    // (a) our own line is recognised by marker + the exact quoted dir …
+    expect(fn).toContain('grep -F "$MARKER"');
+    expect(fn).toContain('grep -Fq "$QUOTED_DIR"');
+    // (b) … and a hand-written line by whole-token comparison, skipping comments.
+    expect(fn).toContain('awk');
+    expect(fn).toMatch(/\^\[\[:space:\]\]\*#/);
     // The old form ANDed two whole-file greps; that must not come back.
     expect(fn).not.toMatch(/grep -q "\$INSTALL_DIR"[^\n]*&&/);
+    // Behaviour for all of this is covered by the end-to-end fixture below; these
+    // assertions only stop a refactor from quietly deleting one of the two halves.
   });
 
   it('carries the same marker so the two installers recognise each other\'s line', () => {
@@ -315,3 +317,371 @@ describe('install.sh stays in step with the shared module', () => {
 });
 
 void existsSync;
+
+describe('the emitted PATH statement is idempotent at RUNTIME', () => {
+  function have(bin: string): boolean {
+    try { execFileSync('command', ['-v', bin], { shell: true, stdio: 'ignore' }); return true; }
+    catch { return false; }
+  }
+
+  /**
+   * Count how many times installDir appears in PATH after `depth` nested shells.
+   *
+   * ⚠️ The inner script MUST be single-quoted. Wrapping it in double quotes (e.g.
+   * via JSON.stringify) lets the PARENT shell expand `$PATH` before the child ever
+   * runs, so the number printed is the parent's snapshot and the probe reports 1 no
+   * matter what — measured: with an unconditional prepend, the double-quoted form
+   * gave 1 at depth 2 while the single-quoted form correctly gave 2 (and 3 at
+   * depth 3). Nested shells DO re-read the rc file and DO keep growing PATH.
+   */
+  function occurrencesAtDepth(bin: string, flag: string, env: Record<string, string>, depth: number): number {
+    // Build inside-out, quoting with single quotes at every level.
+    let script = 'echo $PATH';
+    for (let i = 1; i < depth; i++) {
+      script = `${bin} ${flag} '${script.replace(/'/g, `'\\''`)}'`;
+    }
+    const out = execFileSync(bin, [flag, script], {
+      env: { PATH: '/usr/bin:/bin', ...env },
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 20_000,
+    });
+    return out.trim().split(':').filter(p => p === installDir).length;
+  }
+
+  function launcher() {
+    writeFileSync(join(installDir, 'botmux'), '#!/bin/sh\necho BOTMUX_OK\n', { mode: 0o755 });
+  }
+
+  /**
+   * Two independent ways the same defect shows up, both asserted:
+   *
+   *  · NESTED shells — each child re-reads the rc file, so an unconditional prepend
+   *    grows PATH once per level (measured against the old form: 2 at depth 2, 3 at
+   *    depth 3). See occurrencesAtDepth's note on why the inner script has to be
+   *    single-quoted, or the parent expands `$PATH` first and the probe is blind.
+   *  · RE-SOURCING inside ONE shell — the real-world case of a `.bash_profile` that
+   *    also sources `.bashrc`, or any tool that re-reads your env.
+   */
+  it('zsh: one occurrence when .zshenv is re-sourced, and when nested', () => {
+    if (!have('zsh')) return;
+    launcher();
+    ensurePathEntry({ installDir, home, shell: 'zsh', env: {} });
+    const rc = join(home, '.zshenv');
+    const out = execFileSync('zsh', [
+      '-c', `source ${JSON.stringify(rc)}; source ${JSON.stringify(rc)}; echo "$PATH"`,
+    ], { env: { PATH: '/usr/bin:/bin', HOME: home, ZDOTDIR: home }, encoding: 'utf8', timeout: 20_000 });
+    expect(out.trim().split(':').filter(p => p === installDir)).toHaveLength(1);
+    for (const depth of [1, 2, 3]) {
+      expect(occurrencesAtDepth('zsh', '-c', { HOME: home, ZDOTDIR: home }, depth)).toBe(1);
+    }
+  }, 40_000);
+
+  it('a POSIX shell: one occurrence when .profile is re-sourced, and when nested', () => {
+    if (!have('dash')) return;
+    launcher();
+    ensurePathEntry({ installDir, home, shell: 'other', env: {} });
+    const rc = join(home, '.profile');
+    const out = execFileSync('dash', [
+      '-lc', `. ${JSON.stringify(rc)}; . ${JSON.stringify(rc)}; echo "$PATH"`,
+    ], { env: { PATH: '/usr/bin:/bin', HOME: home }, encoding: 'utf8', timeout: 20_000 });
+    expect(out.trim().split(':').filter(p => p === installDir)).toHaveLength(1);
+    for (const depth of [1, 2, 3]) {
+      expect(occurrencesAtDepth('dash', '-lc', { HOME: home }, depth)).toBe(1);
+    }
+  }, 40_000);
+
+  it('bash: one occurrence even though .bashrc AND the login file both carry it', () => {
+    if (!have('bash')) return;
+    launcher();
+    ensurePathEntry({ installDir, home, shell: 'bash', env: {} });
+    // A login bash reads the login file; if it also sources .bashrc the statement
+    // runs twice in ONE shell — the guard has to hold for that too.
+    writeFileSync(join(home, '.bash_profile'),
+      `${readFileSync(join(home, '.bash_profile'), 'utf8')}\n. "$HOME/.bashrc"\n`);
+    for (const depth of [1, 2]) {
+      expect(occurrencesAtDepth('bash', '-lc', { HOME: home }, depth)).toBe(1);
+    }
+  }, 40_000);
+
+  it('fish: one occurrence even when conf.d is sourced twice in one shell', () => {
+    if (!have('fish')) return;
+    launcher();
+    ensurePathEntry({ installDir, home, shell: 'fish', env: {} });
+    const conf = join(home, '.config', 'fish', 'conf.d', 'botmux.fish');
+    // Sourcing the file twice in ONE shell is the sharpest probe here: 1 occurrence
+    // with the `contains` guard, 3 without it (measured).
+    const count = execFileSync('fish', [
+      '-c', `source ${JSON.stringify(conf)}; source ${JSON.stringify(conf)}; for p in $PATH; echo $p; end`,
+    ], {
+      env: { PATH: '/usr/bin:/bin', HOME: home },
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 20_000,
+    }).trim().split('\n').filter(p => p === installDir).length;
+    expect(count).toBe(1);
+    expect(execFileSync('fish', ['-c', 'botmux'], {
+      env: { PATH: '/usr/bin:/bin', HOME: home }, encoding: 'utf8', timeout: 20_000,
+    })).toContain('BOTMUX_OK');
+  }, 40_000);
+
+  it('still prepends when the directory is NOT yet on PATH (positive control)', () => {
+    if (!have('dash')) return;
+    launcher();
+    ensurePathEntry({ installDir, home, shell: 'other', env: {} });
+    // Guard against "made it idempotent by never adding anything".
+    expect(occurrencesAtDepth('dash', '-lc', { HOME: home }, 1)).toBe(1);
+    expect(execFileSync('dash', ['-lc', 'botmux'], {
+      env: { PATH: '/usr/bin:/bin', HOME: home }, encoding: 'utf8', timeout: 20_000,
+    })).toContain('BOTMUX_OK');
+  }, 40_000);
+
+  it('a directory with shell metacharacters is still not executed', () => {
+    if (!have('dash')) return;
+    const evil = join(home, `d $(touch ${join(home, 'PWNED_RT')})`);
+    mkdirSync(evil, { recursive: true });
+    writeFileSync(join(evil, 'botmux'), '#!/bin/sh\necho BOTMUX_OK\n', { mode: 0o755 });
+    ensurePathEntry({ installDir: evil, home, shell: 'other', env: {} });
+    execFileSync('dash', ['-lc', 'true'], { env: { PATH: '/usr/bin:/bin', HOME: home }, timeout: 20_000 });
+    expect(existsSync(join(home, 'PWNED_RT'))).toBe(false);
+  }, 40_000);
+});
+
+/**
+ * install.sh executed END-TO-END, offline.
+ *
+ * WHY A REAL RUN AND NOT MORE REGEX: this suite twice shipped a semantic drift
+ * between install.sh and install-path-entry.mjs that every source-text assertion
+ * missed — the two-independent-greps false positive, and awk's `-v` mangling of
+ * the quoted spelling (`q'\''bin` arriving as `q'''bin`) which silently appended a
+ * duplicate line on every re-install. Only running the script catches those, so
+ * the shell half gets behavioural coverage of the same cases the .mjs half has.
+ *
+ * Offline by construction: fake `uname`/`ldd`/`curl` on PATH, so nothing is
+ * downloaded and no network is touched.
+ */
+/**
+ * The emitted STATEMENT has to be idempotent too, not only the file write.
+ *
+ * An unconditional `export PATH=<dir>:$PATH` re-prepends on every shell startup, so
+ * nested shells — and a `.bash_profile` that sources `.bashrc` within one login —
+ * keep growing PATH. Measured before the fix: the same directory appeared twice at
+ * nesting depth 2. That is persistent environment pollution caused by us writing
+ * the rc file, so it needs a real-shell regression, not a source assertion.
+ */
+describe('install.sh — executed end to end (offline fixture)', () => {
+  /** Build a PATH containing only our fakes plus the real tools the script needs. */
+  function fakeBinDir(root: string): string {
+    const bin = join(root, 'fakebin');
+    mkdirSync(bin, { recursive: true });
+    const write = (name: string, body: string) => {
+      const p = join(bin, name);
+      writeFileSync(p, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+    };
+    write('uname', 'case "$1" in -s) echo Linux ;; -m) echo x86_64 ;; *) echo Linux ;; esac');
+    // Claim glibc so the script does not pick the -musl asset.
+    write('ldd', 'echo "ldd (GNU libc) 2.36"');
+    // `curl -fSL <url> -o <file>` writes a stand-in binary; the .sha256 fetch fails
+    // (exit 1) so the script takes its documented "no checksum published" path.
+    write('curl', [
+      'out=""; url=""',
+      'while [ $# -gt 0 ]; do case "$1" in -o) out="$2"; shift 2 ;; -*) shift ;; *) url="$1"; shift ;; esac; done',
+      'case "$url" in *.sha256) exit 1 ;; esac',
+      '[ -n "$out" ] || exit 1',
+      'printf "#!/bin/sh\\necho BOTMUX_OK\\n" > "$out"',
+    ].join('\n'));
+    return bin;
+  }
+
+  function runInstaller(opts: {
+    home: string;
+    shell: string;
+    installDir: string;
+    env?: Record<string, string>;
+  }): { status: number | null; stdout: string; stderr: string } {
+    const bin = fakeBinDir(opts.home);
+    const r = execFileSync('/bin/sh', [join(__dirname, '..', 'install.sh')], {
+      env: {
+        // A deliberately minimal environment: only what the script may rely on.
+        PATH: `${bin}:/usr/bin:/bin`,
+        HOME: opts.home,
+        SHELL: opts.shell,
+        BOTMUX_INSTALL_DIR: opts.installDir,
+        ...opts.env,
+      },
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 60_000,
+    });
+    return { status: 0, stdout: r, stderr: '' };
+  }
+
+  function runIn(shell: string, args: string[], env: Record<string, string>): string {
+    return execFileSync(shell, args, {
+      env: { PATH: '/usr/bin:/bin', ...env },
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 20_000,
+    });
+  }
+
+  it('installs the binary and makes zsh find it — honouring $ZDOTDIR', () => {
+    if (!existsSync('/usr/bin/zsh')) return;
+    const zdot = join(home, 'zdot');
+    mkdirSync(zdot, { recursive: true });
+    runInstaller({ home, shell: '/usr/bin/zsh', installDir, env: { ZDOTDIR: zdot } });
+
+    // The PATH line must land in $ZDOTDIR/.zshenv, NOT $HOME/.zshenv.
+    expect(existsSync(join(zdot, '.zshenv'))).toBe(true);
+    expect(existsSync(join(home, '.zshenv'))).toBe(false);
+    expect(runIn('/usr/bin/zsh', ['-c', 'botmux'], { HOME: home, ZDOTDIR: zdot })).toContain('BOTMUX_OK');
+  });
+
+  it('makes fish find it — honouring $XDG_CONFIG_HOME, with fish syntax', () => {
+    if (!existsSync('/usr/bin/fish')) return;
+    const xdg = join(home, 'xdg');
+    mkdirSync(xdg, { recursive: true });
+    runInstaller({ home, shell: '/usr/bin/fish', installDir, env: { XDG_CONFIG_HOME: xdg } });
+
+    const conf = join(xdg, 'fish', 'conf.d', 'botmux.fish');
+    expect(existsSync(conf)).toBe(true);
+    expect(readFileSync(conf, 'utf8')).toContain('set -gx PATH');
+    expect(runIn('/usr/bin/fish', ['-c', 'botmux'], { HOME: home, XDG_CONFIG_HOME: xdg })).toContain('BOTMUX_OK');
+  });
+
+  it('does not shadow an existing .profile for bash, and works in both modes', () => {
+    if (!existsSync('/bin/bash')) return;
+    writeFileSync(join(home, '.profile'), 'export SENTINEL_FROM_PROFILE=yes\n');
+    runInstaller({ home, shell: '/bin/bash', installDir });
+
+    // Creating .bash_profile here would make the sentinel unreachable.
+    expect(existsSync(join(home, '.bash_profile'))).toBe(false);
+    expect(runIn('/bin/bash', ['-lic', 'echo "S=${SENTINEL_FROM_PROFILE:-MISSING}"'], { HOME: home }))
+      .toContain('S=yes');
+    expect(runIn('/bin/bash', ['-lic', 'botmux'], { HOME: home })).toContain('BOTMUX_OK');
+    expect(runIn('/bin/bash', ['-ic', 'botmux'], { HOME: home })).toContain('BOTMUX_OK');
+  });
+
+  it('is idempotent — a second install leaves the rc file byte-identical', () => {
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    const after1 = readFileSync(join(home, '.profile'), 'utf8');
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    expect(readFileSync(join(home, '.profile'), 'utf8')).toBe(after1);
+    expect((after1.match(/added by botmux installer/g) ?? [])).toHaveLength(1);
+  });
+
+  it('is idempotent for an install dir containing a single quote', () => {
+    // The case awk's `-v` mangling broke: the written line is shell-quoted, so the
+    // raw bytes are absent from the file and a naive check re-appends every run.
+    const quoted = join(home, "q'bin");
+    mkdirSync(quoted, { recursive: true });
+    runInstaller({ home, shell: '/bin/dash', installDir: quoted });
+    runInstaller({ home, shell: '/bin/dash', installDir: quoted });
+    const body = readFileSync(join(home, '.profile'), 'utf8');
+    expect((body.match(/added by botmux installer/g) ?? [])).toHaveLength(1);
+    // …and the quoting must still work: sh resolves the command.
+    expect(runIn('/bin/dash', ['-lc', 'botmux'], { HOME: home })).toContain('BOTMUX_OK');
+  });
+
+  it('is idempotent when BOTMUX_INSTALL_DIR carries a trailing slash', () => {
+    runInstaller({ home, shell: '/bin/dash', installDir: `${installDir}/` });
+    runInstaller({ home, shell: '/bin/dash', installDir: `${installDir}/` });
+    const body = readFileSync(join(home, '.profile'), 'utf8');
+    expect((body.match(/added by botmux installer/g) ?? [])).toHaveLength(1);
+  });
+
+  it('preserves an existing rc file that lacks a trailing newline', () => {
+    writeFileSync(join(home, '.profile'), 'alias ll="ls -la"');   // no newline
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    const lines = readFileSync(join(home, '.profile'), 'utf8').split('\n');
+    expect(lines[0]).toBe('alias ll="ls -la"');
+    expect(lines[1]).toContain(installDir);
+  });
+
+  it('does not execute shell syntax present in the install dir', () => {
+    // The command-injection case: the line we write is evaluated on every startup.
+    const evil = join(home, 'dir $(touch ' + join(home, 'PWNED') + ')');
+    mkdirSync(evil, { recursive: true });
+    runInstaller({ home, shell: '/bin/dash', installDir: evil });
+    runIn('/bin/dash', ['-lc', 'true'], { HOME: home });
+    expect(existsSync(join(home, 'PWNED'))).toBe(false);
+  });
+
+  /**
+   * The RUNTIME idempotence guard has to hold for the shell installer too.
+   * Without this, reverting install.sh's statement to an unconditional prepend
+   * leaves the whole runtime group green (measured) — the .mjs tests all go through
+   * ensurePathEntry and never touch install.sh.
+   */
+  it('the statement it writes is idempotent at runtime (POSIX, re-sourced)', () => {
+    if (!existsSync('/bin/dash')) return;
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    // Re-sourcing in ONE shell is asserted alongside nesting: it is the real-world
+    // `.bash_profile` sources `.bashrc` case, and it stays discriminating regardless
+    // of how the nested probe is quoted.
+    const rc = join(home, '.profile');
+    const out = runIn('/bin/dash', [
+      '-lc', `. ${JSON.stringify(rc)}; . ${JSON.stringify(rc)}; echo "$PATH"`,
+    ], { HOME: home });
+    expect(out.trim().split(':').filter(p => p === installDir)).toHaveLength(1);
+    // …and nesting must still be clean.
+    // Single quotes: a double-quoted inner script would let this shell expand $PATH.
+    const nested = runIn('/bin/dash', ['-lc', "/bin/dash -lc 'echo $PATH'"], { HOME: home });
+    expect(nested.trim().split(':').filter(p => p === installDir)).toHaveLength(1);
+  }, 40_000);
+
+  it('the statement it writes is idempotent at runtime (fish, double source)', () => {
+    if (!existsSync('/usr/bin/fish')) return;
+    const xdg = join(home, 'xdg');
+    mkdirSync(xdg, { recursive: true });
+    runInstaller({ home, shell: '/usr/bin/fish', installDir, env: { XDG_CONFIG_HOME: xdg } });
+    const conf = join(xdg, 'fish', 'conf.d', 'botmux.fish');
+    // Source it twice in one shell — the sharpest probe for this guard (see the
+    // .mjs counterpart for the measured numbers).
+    const out = runIn('/usr/bin/fish', [
+      '-c', `source ${JSON.stringify(conf)}; source ${JSON.stringify(conf)}; for p in $PATH; echo $p; end`,
+    ], { HOME: home, XDG_CONFIG_HOME: xdg });
+    expect(out.trim().split('\n').filter(p => p === installDir)).toHaveLength(1);
+  }, 40_000);
+
+  it('adds the entry when only a SIBLING directory is on PATH', () => {
+    // `<installDir>-old` must not count as configured — otherwise the real
+    // directory is never added and the command stays missing.
+    writeFileSync(join(home, '.profile'), `export PATH="${installDir}-old:$PATH"\n`);
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    const body = readFileSync(join(home, '.profile'), 'utf8');
+    expect((body.match(/added by botmux installer/g) ?? [])).toHaveLength(1);
+  });
+
+  it('adds a working line back when OUR OWN generated line was commented out', () => {
+    // The marker is still on the line, so a marker-based fast path that forgets to
+    // skip comments reports "configured" and never restores a working entry —
+    // measured: install.sh left 0 active PATH lines while the .mjs half said false.
+    writeFileSync(join(home, '.profile'),
+      `# export PATH='${installDir}'":$PATH"  ${PATH_ENTRY_MARKER}\n`);
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    const active = readFileSync(join(home, '.profile'), 'utf8')
+      .split('\n').filter(l => l.trim() && !l.trim().startsWith('#'));
+    expect(active).toHaveLength(1);
+    expect(active[0]).toContain(installDir);
+    expect(runIn('/bin/dash', ['-lc', 'botmux'], { HOME: home })).toContain('BOTMUX_OK');
+  });
+
+  it('does not duplicate when our own generated line is present and ACTIVE', () => {
+    // Positive control for the test above: the marker fast path must still work.
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    const once = readFileSync(join(home, '.profile'), 'utf8');
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    expect(readFileSync(join(home, '.profile'), 'utf8')).toBe(once);
+  });
+
+  it('recognises a user line that differs only by a trailing slash', () => {
+    // Exercises the awk half's normalisation: dir passed WITH a trailing slash,
+    // the user's existing entry written WITHOUT one (or vice versa).
+    writeFileSync(join(home, '.profile'), `export PATH="${installDir}:$PATH"\n`);
+    const before = readFileSync(join(home, '.profile'), 'utf8');
+    runInstaller({ home, shell: '/bin/dash', installDir: `${installDir}/` });
+    expect(readFileSync(join(home, '.profile'), 'utf8')).toBe(before);
+  });
+
+  it('leaves the file alone when the directory is ALREADY on PATH', () => {
+    // Positive control for the two tests above: the predicate must still be able
+    // to say "already configured", or it would just always append.
+    writeFileSync(join(home, '.profile'), `export PATH="${installDir}:$PATH"\n`);
+    const before = readFileSync(join(home, '.profile'), 'utf8');
+    runInstaller({ home, shell: '/bin/dash', installDir });
+    expect(readFileSync(join(home, '.profile'), 'utf8')).toBe(before);
+  });
+});

--- a/test/install-path-entry.test.ts
+++ b/test/install-path-entry.test.ts
@@ -1,0 +1,240 @@
+/**
+ * PATH entry written by both installers (`npm i -g` postinstall and install.sh).
+ *
+ * THE BUG THIS GUARDS: `npm i -g botmux` succeeded but left `botmux: command not
+ * found`. There is no `bin` field any more, so the launcher at `~/.botmux/bin/botmux`
+ * is the only `botmux` there is — and both installers merely PRINTED
+ * `echo 'export PATH=…' >> ~/.profile`. **zsh never reads ~/.profile**, so a zsh
+ * user who followed that hint verbatim got a silently-ignored file.
+ *
+ * The per-shell file choices below are measured, not recalled (see the module
+ * header for the full matrix): zsh reads .zshenv in all three invocation modes;
+ * bash's login (.bash_profile) and interactive (.bashrc) files are disjoint, so
+ * both are needed; fish uses conf.d/*.fish and is not POSIX (`set -gx`).
+ *
+ * Run: npx vitest run test/install-path-entry.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import {
+  detectShell,
+  pathEntryTargets,
+  fileAlreadyHasEntry,
+  ensurePathEntry,
+  PATH_ENTRY_MARKER,
+} from '../scripts/install-path-entry.mjs';
+
+let home: string;
+let installDir: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'bmx-path-'));
+  installDir = join(home, '.botmux', 'bin');
+  mkdirSync(installDir, { recursive: true });
+});
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const rel = (f: string) => f.slice(home.length);
+
+describe('detectShell', () => {
+  it('reads the login shell from $SHELL', () => {
+    expect(detectShell({ SHELL: '/usr/bin/zsh' })).toBe('zsh');
+    expect(detectShell({ SHELL: '/bin/bash' })).toBe('bash');
+    expect(detectShell({ SHELL: '/usr/local/bin/fish' })).toBe('fish');
+    expect(detectShell({ SHELL: '/bin/dash' })).toBe('other');
+    expect(detectShell({})).toBe('unknown');
+  });
+
+  it('matches versioned/prefixed shell paths', () => {
+    expect(detectShell({ SHELL: '/opt/homebrew/bin/zsh-5.9' })).toBe('zsh');
+    expect(detectShell({ SHELL: '/usr/bin/bash' })).toBe('bash');
+  });
+});
+
+describe('pathEntryTargets', () => {
+  it('zsh gets .zshenv — the only file read by -c, -i AND -li alike', () => {
+    const t = pathEntryTargets('zsh', installDir, home);
+    expect(t.map(x => rel(x.file))).toEqual(['/.zshenv']);
+    // NOT .profile: that is the exact bug being fixed.
+    expect(t.map(x => rel(x.file))).not.toContain('/.profile');
+  });
+
+  it('bash gets BOTH .bashrc and .bash_profile (login vs interactive are disjoint)', () => {
+    const t = pathEntryTargets('bash', installDir, home);
+    expect(t.map(x => rel(x.file)).sort()).toEqual(['/.bash_profile', '/.bashrc']);
+  });
+
+  it('fish gets conf.d/botmux.fish with NATIVE fish syntax, not POSIX export', () => {
+    const t = pathEntryTargets('fish', installDir, home);
+    expect(rel(t[0].file)).toBe('/.config/fish/conf.d/botmux.fish');
+    expect(t[0].line).toContain('set -gx PATH');
+    expect(t[0].line).not.toContain('export ');
+  });
+
+  it('unknown/other shells fall back to .profile', () => {
+    for (const s of ['other', 'unknown']) {
+      expect(rel(pathEntryTargets(s, installDir, home)[0].file)).toBe('/.profile');
+    }
+  });
+
+  it('every generated line carries the installer marker and the install dir', () => {
+    for (const s of ['zsh', 'bash', 'fish', 'other']) {
+      for (const { line } of pathEntryTargets(s, installDir, home)) {
+        expect(line).toContain(PATH_ENTRY_MARKER);
+        expect(line).toContain(installDir);
+      }
+    }
+  });
+});
+
+describe('ensurePathEntry', () => {
+  it('creates the file when absent, and is idempotent on a second run', () => {
+    const first = ensurePathEntry({ installDir, home, shell: 'zsh' });
+    expect(first.written.map(rel)).toEqual(['/.zshenv']);
+    const body = readFileSync(join(home, '.zshenv'), 'utf8');
+    expect(body).toContain(installDir);
+
+    const second = ensurePathEntry({ installDir, home, shell: 'zsh' });
+    expect(second.written).toEqual([]);
+    expect(second.skipped.map(rel)).toEqual(['/.zshenv']);
+    // The file must not have grown a duplicate line.
+    expect(readFileSync(join(home, '.zshenv'), 'utf8')).toBe(body);
+  });
+
+  it('appends without destroying existing content, and never glues onto an unterminated line', () => {
+    // Deliberately NO trailing newline — the case that corrupts a naive append.
+    writeFileSync(join(home, '.zshenv'), 'alias ll="ls -la"');
+    ensurePathEntry({ installDir, home, shell: 'zsh' });
+    const lines = readFileSync(join(home, '.zshenv'), 'utf8').split('\n');
+    expect(lines[0]).toBe('alias ll="ls -la"');
+    expect(lines[1]).toContain(installDir);
+  });
+
+  it("respects a PATH line the user already wrote in their own style", () => {
+    writeFileSync(join(home, '.zshenv'), `path+=(${installDir})\n`);
+    const r = ensurePathEntry({ installDir, home, shell: 'zsh' });
+    expect(r.written).toEqual([]);
+    expect(r.skipped.map(rel)).toEqual(['/.zshenv']);
+  });
+
+  it('a mention of the dir that is NOT a PATH line does not count as handled', () => {
+    writeFileSync(join(home, '.zshenv'), `# I once installed things into ${installDir}\n`);
+    expect(fileAlreadyHasEntry(join(home, '.zshenv'), installDir)).toBe(false);
+    expect(ensurePathEntry({ installDir, home, shell: 'zsh' }).written.map(rel)).toEqual(['/.zshenv']);
+  });
+
+  it('reports a failure instead of throwing when the target cannot be written', () => {
+    // A file where the parent dir must be — mkdir/append both fail, install must not.
+    writeFileSync(join(home, '.config'), 'not a directory');
+    const r = ensurePathEntry({ installDir, home, shell: 'fish' });
+    expect(r.written).toEqual([]);
+    expect(r.failed).toHaveLength(1);
+    expect(r.failed[0].file).toContain('botmux.fish');
+  });
+});
+
+/**
+ * The payoff assertion: after writing, does the real shell actually FIND the
+ * command? Anything short of this can pass while the user still sees
+ * `command not found` — which is precisely how the original bug shipped.
+ */
+describe('the written file actually puts botmux on PATH (real shells)', () => {
+  function fakeLauncher() {
+    const p = join(installDir, 'botmux');
+    writeFileSync(p, '#!/bin/sh\necho BOTMUX_OK\n', { mode: 0o755 });
+    return p;
+  }
+  function have(bin: string): boolean {
+    try { execFileSync('command', ['-v', bin], { shell: true, stdio: 'ignore' }); return true; }
+    catch { return false; }
+  }
+  /** Run `botmux` through a shell, with HOME pointed at the fixture. */
+  function runIn(shell: string, args: string[]): string {
+    return execFileSync(shell, args, {
+      env: { ...process.env, HOME: home, ZDOTDIR: home, PATH: '/usr/bin:/bin' },
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 20_000,
+    });
+  }
+
+  it('zsh finds it in non-interactive mode (scripts and ssh commands)', () => {
+    if (!have('zsh')) return;
+    fakeLauncher();
+    ensurePathEntry({ installDir, home, shell: 'zsh' });
+    expect(runIn('zsh', ['-c', 'botmux'])).toContain('BOTMUX_OK');
+  });
+
+  it('bash finds it in BOTH interactive and login mode', () => {
+    if (!have('bash')) return;
+    fakeLauncher();
+    ensurePathEntry({ installDir, home, shell: 'bash' });
+    // Two different startup files answer these two invocations; that is why the
+    // implementation writes both.
+    expect(runIn('bash', ['-ic', 'botmux'])).toContain('BOTMUX_OK');
+    expect(runIn('bash', ['-lic', 'botmux'])).toContain('BOTMUX_OK');
+  });
+
+  it('fish finds it (native syntax really evaluates)', () => {
+    if (!have('fish')) return;
+    fakeLauncher();
+    ensurePathEntry({ installDir, home, shell: 'fish' });
+    expect(runIn('fish', ['-c', 'botmux'])).toContain('BOTMUX_OK');
+  });
+
+  it('a POSIX shell finds it via .profile', () => {
+    if (!have('dash')) return;
+    fakeLauncher();
+    ensurePathEntry({ installDir, home, shell: 'other' });
+    expect(runIn('dash', ['-lc', 'botmux'])).toContain('BOTMUX_OK');
+  });
+});
+
+// install.sh must keep the same per-shell mapping as the .mjs above; if one is
+// edited alone the two installers diverge and only one kind of user is fixed.
+describe('install.sh stays in step with the shared module', () => {
+  const sh = readFileSync(join(__dirname, '..', 'install.sh'), 'utf8');
+
+  /**
+   * The body of one `case` branch of the shell dispatch, so an assertion is about
+   * what that shell ACTUALLY writes.
+   *
+   * ⚠️ Do NOT weaken this back to `expect(sh).toContain('.zshenv')`: measured, a
+   * mutation that points install.sh's zsh branch at `.profile` (the original bug,
+   * reintroduced) still leaves the string `.zshenv` in the surrounding comments,
+   * so `toContain` stays green — an assertion satisfied by both the correct and
+   * the broken file has no teeth.
+   */
+  function caseBranch(pattern: string): string {
+    const start = sh.search(new RegExp(`^\\s*${pattern}\\)`, 'm'));
+    expect(start).toBeGreaterThan(-1);
+    const rest = sh.slice(start);
+    const end = rest.indexOf(';;');
+    expect(end).toBeGreaterThan(-1);
+    return rest.slice(0, end);
+  }
+
+  it('the zsh branch writes .zshenv, not .profile', () => {
+    const branch = caseBranch('\\*zsh\\*');
+    expect(branch).toContain('.zshenv');
+    expect(branch).not.toContain('.profile');
+  });
+
+  it('the bash branch writes BOTH .bashrc and .bash_profile', () => {
+    const branch = caseBranch('\\*bash\\*');
+    expect(branch).toContain('.bashrc');
+    expect(branch).toContain('.bash_profile');
+  });
+
+  it('the fish branch writes conf.d/botmux.fish using native fish syntax', () => {
+    const branch = caseBranch('\\*fish\\*');
+    expect(branch).toContain('conf.d/botmux.fish');
+    expect(branch).toContain('set -gx PATH');
+  });
+
+  it('carries the same marker so the two installers recognise each other\'s line', () => {
+    expect(sh).toContain(PATH_ENTRY_MARKER);
+  });
+});
+
+void existsSync;

--- a/test/install-path-entry.test.ts
+++ b/test/install-path-entry.test.ts
@@ -55,14 +55,14 @@ describe('detectShell', () => {
 
 describe('pathEntryTargets', () => {
   it('zsh gets .zshenv — the only file read by -c, -i AND -li alike', () => {
-    const t = pathEntryTargets('zsh', installDir, home);
+    const t = pathEntryTargets('zsh', installDir, home, {});
     expect(t.map(x => rel(x.file))).toEqual(['/.zshenv']);
     // NOT .profile: that is the exact bug being fixed.
     expect(t.map(x => rel(x.file))).not.toContain('/.profile');
   });
 
   it('bash gets BOTH .bashrc and a login file (login vs interactive are disjoint)', () => {
-    const t = pathEntryTargets('bash', installDir, home);
+    const t = pathEntryTargets('bash', installDir, home, {});
     expect(t.map(x => rel(x.file))).toContain('/.bashrc');
     expect(t).toHaveLength(2);
   });
@@ -76,7 +76,7 @@ describe('pathEntryTargets', () => {
    */
   describe('bash login file is chosen without shadowing', () => {
     const loginTarget = () =>
-      pathEntryTargets('bash', installDir, home).map(x => rel(x.file)).find(f => f !== '/.bashrc');
+      pathEntryTargets('bash', installDir, home, {}).map(x => rel(x.file)).find(f => f !== '/.bashrc');
 
     it('appends to .profile when that is the only login file present', () => {
       writeFileSync(join(home, '.profile'), 'export SENTINEL=yes\n');
@@ -100,13 +100,15 @@ describe('pathEntryTargets', () => {
 
     it('never writes the same file twice', () => {
       writeFileSync(join(home, '.profile'), '');
-      const files = pathEntryTargets('bash', installDir, home).map(x => x.file);
+      const files = pathEntryTargets('bash', installDir, home, {}).map(x => x.file);
       expect(new Set(files).size).toBe(files.length);
     });
   });
 
   it('fish gets conf.d/botmux.fish with NATIVE fish syntax, not POSIX export', () => {
-    const t = pathEntryTargets('fish', installDir, home);
+    // Explicit env: the HOST may have XDG_CONFIG_HOME set (CI does), which would
+    // legitimately relocate the file and make a hardcoded ~/.config path wrong.
+    const t = pathEntryTargets('fish', installDir, home, {});
     expect(rel(t[0].file)).toBe('/.config/fish/conf.d/botmux.fish');
     expect(t[0].line).toContain('set -gx PATH');
     expect(t[0].line).not.toContain('export ');
@@ -114,13 +116,13 @@ describe('pathEntryTargets', () => {
 
   it('unknown/other shells fall back to .profile', () => {
     for (const s of ['other', 'unknown']) {
-      expect(rel(pathEntryTargets(s, installDir, home)[0].file)).toBe('/.profile');
+      expect(rel(pathEntryTargets(s, installDir, home, {})[0].file)).toBe('/.profile');
     }
   });
 
   it('every generated line carries the installer marker and the install dir', () => {
     for (const s of ['zsh', 'bash', 'fish', 'other']) {
-      for (const { line } of pathEntryTargets(s, installDir, home)) {
+      for (const { line } of pathEntryTargets(s, installDir, home, {})) {
         expect(line).toContain(PATH_ENTRY_MARKER);
         expect(line).toContain(installDir);
       }
@@ -130,12 +132,12 @@ describe('pathEntryTargets', () => {
 
 describe('ensurePathEntry', () => {
   it('creates the file when absent, and is idempotent on a second run', () => {
-    const first = ensurePathEntry({ installDir, home, shell: 'zsh' });
+    const first = ensurePathEntry({ installDir, home, shell: 'zsh', env: {} });
     expect(first.written.map(rel)).toEqual(['/.zshenv']);
     const body = readFileSync(join(home, '.zshenv'), 'utf8');
     expect(body).toContain(installDir);
 
-    const second = ensurePathEntry({ installDir, home, shell: 'zsh' });
+    const second = ensurePathEntry({ installDir, home, shell: 'zsh', env: {} });
     expect(second.written).toEqual([]);
     expect(second.skipped.map(rel)).toEqual(['/.zshenv']);
     // The file must not have grown a duplicate line.
@@ -145,7 +147,7 @@ describe('ensurePathEntry', () => {
   it('appends without destroying existing content, and never glues onto an unterminated line', () => {
     // Deliberately NO trailing newline — the case that corrupts a naive append.
     writeFileSync(join(home, '.zshenv'), 'alias ll="ls -la"');
-    ensurePathEntry({ installDir, home, shell: 'zsh' });
+    ensurePathEntry({ installDir, home, shell: 'zsh', env: {} });
     const lines = readFileSync(join(home, '.zshenv'), 'utf8').split('\n');
     expect(lines[0]).toBe('alias ll="ls -la"');
     expect(lines[1]).toContain(installDir);
@@ -153,7 +155,7 @@ describe('ensurePathEntry', () => {
 
   it("respects a PATH line the user already wrote in their own style", () => {
     writeFileSync(join(home, '.zshenv'), `path+=(${installDir})\n`);
-    const r = ensurePathEntry({ installDir, home, shell: 'zsh' });
+    const r = ensurePathEntry({ installDir, home, shell: 'zsh', env: {} });
     expect(r.written).toEqual([]);
     expect(r.skipped.map(rel)).toEqual(['/.zshenv']);
   });
@@ -161,13 +163,13 @@ describe('ensurePathEntry', () => {
   it('a mention of the dir that is NOT a PATH line does not count as handled', () => {
     writeFileSync(join(home, '.zshenv'), `# I once installed things into ${installDir}\n`);
     expect(fileAlreadyHasEntry(join(home, '.zshenv'), installDir)).toBe(false);
-    expect(ensurePathEntry({ installDir, home, shell: 'zsh' }).written.map(rel)).toEqual(['/.zshenv']);
+    expect(ensurePathEntry({ installDir, home, shell: 'zsh', env: {} }).written.map(rel)).toEqual(['/.zshenv']);
   });
 
   it('reports a failure instead of throwing when the target cannot be written', () => {
     // A file where the parent dir must be — mkdir/append both fail, install must not.
     writeFileSync(join(home, '.config'), 'not a directory');
-    const r = ensurePathEntry({ installDir, home, shell: 'fish' });
+    const r = ensurePathEntry({ installDir, home, shell: 'fish', env: {} });
     expect(r.written).toEqual([]);
     expect(r.failed).toHaveLength(1);
     expect(r.failed[0].file).toContain('botmux.fish');
@@ -191,8 +193,12 @@ describe('the written file actually puts botmux on PATH (real shells)', () => {
   }
   /** Run `botmux` through a shell, with HOME pointed at the fixture. */
   function runIn(shell: string, args: string[]): string {
+    // ⚠️ Do NOT spread process.env: the host's XDG_CONFIG_HOME / ZDOTDIR would come
+    // along and send the shell looking somewhere other than where we wrote (CI sets
+    // XDG_CONFIG_HOME, so this passed locally and failed there). Pass only what the
+    // fixture defines.
     return execFileSync(shell, args, {
-      env: { ...process.env, HOME: home, ZDOTDIR: home, PATH: '/usr/bin:/bin' },
+      env: { HOME: home, ZDOTDIR: home, PATH: '/usr/bin:/bin' },
       encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 20_000,
     });
   }
@@ -200,7 +206,7 @@ describe('the written file actually puts botmux on PATH (real shells)', () => {
   it('zsh finds it in non-interactive mode (scripts and ssh commands)', () => {
     if (!have('zsh')) return;
     fakeLauncher();
-    ensurePathEntry({ installDir, home, shell: 'zsh' });
+    ensurePathEntry({ installDir, home, shell: 'zsh', env: {} });
     expect(runIn('zsh', ['-c', 'botmux'])).toContain('BOTMUX_OK');
   });
 
@@ -217,7 +223,7 @@ describe('the written file actually puts botmux on PATH (real shells)', () => {
   it('fish finds it (native syntax really evaluates)', () => {
     if (!have('fish')) return;
     fakeLauncher();
-    ensurePathEntry({ installDir, home, shell: 'fish' });
+    ensurePathEntry({ installDir, home, shell: 'fish', env: {} });
     expect(runIn('fish', ['-c', 'botmux'])).toContain('BOTMUX_OK');
   });
 

--- a/test/install-path-entry.test.ts
+++ b/test/install-path-entry.test.ts
@@ -61,9 +61,48 @@ describe('pathEntryTargets', () => {
     expect(t.map(x => rel(x.file))).not.toContain('/.profile');
   });
 
-  it('bash gets BOTH .bashrc and .bash_profile (login vs interactive are disjoint)', () => {
+  it('bash gets BOTH .bashrc and a login file (login vs interactive are disjoint)', () => {
     const t = pathEntryTargets('bash', installDir, home);
-    expect(t.map(x => rel(x.file)).sort()).toEqual(['/.bash_profile', '/.bashrc']);
+    expect(t.map(x => rel(x.file))).toContain('/.bashrc');
+    expect(t).toHaveLength(2);
+  });
+
+  /**
+   * bash reads only the FIRST of .bash_profile → .bash_login → .profile. Creating
+   * .bash_profile on a machine whose login config lives in .profile silently stops
+   * that file from ever being read again — measured with a sentinel: visible to
+   * `bash -lic` before, MISSING after. Fixing a PATH entry must not cost the user
+   * their existing login config.
+   */
+  describe('bash login file is chosen without shadowing', () => {
+    const loginTarget = () =>
+      pathEntryTargets('bash', installDir, home).map(x => rel(x.file)).find(f => f !== '/.bashrc');
+
+    it('appends to .profile when that is the only login file present', () => {
+      writeFileSync(join(home, '.profile'), 'export SENTINEL=yes\n');
+      expect(loginTarget()).toBe('/.profile');
+    });
+
+    it('appends to .bash_login when that is the one present', () => {
+      writeFileSync(join(home, '.bash_login'), 'export SENTINEL=yes\n');
+      expect(loginTarget()).toBe('/.bash_login');
+    });
+
+    it('prefers .bash_profile when it exists (bash reads it first)', () => {
+      writeFileSync(join(home, '.bash_profile'), '');
+      writeFileSync(join(home, '.profile'), '');
+      expect(loginTarget()).toBe('/.bash_profile');
+    });
+
+    it('creates .bash_profile only when none of the three exists (nothing to shadow)', () => {
+      expect(loginTarget()).toBe('/.bash_profile');
+    });
+
+    it('never writes the same file twice', () => {
+      writeFileSync(join(home, '.profile'), '');
+      const files = pathEntryTargets('bash', installDir, home).map(x => x.file);
+      expect(new Set(files).size).toBe(files.length);
+    });
   });
 
   it('fish gets conf.d/botmux.fish with NATIVE fish syntax, not POSIX export', () => {
@@ -182,6 +221,18 @@ describe('the written file actually puts botmux on PATH (real shells)', () => {
     expect(runIn('fish', ['-c', 'botmux'])).toContain('BOTMUX_OK');
   });
 
+  it('bash keeps reading a pre-existing .profile (no shadowing) AND finds the command', () => {
+    if (!have('bash')) return;
+    // The exact failure mode: login config in .profile, no .bash_profile.
+    writeFileSync(join(home, '.profile'), 'export SENTINEL_FROM_PROFILE=yes\n');
+    fakeLauncher();
+    ensurePathEntry({ installDir, home, shell: 'bash' });
+    // Creating .bash_profile here would make this sentinel MISSING.
+    expect(runIn('bash', ['-lic', 'echo "S=${SENTINEL_FROM_PROFILE:-MISSING}"'])).toContain('S=yes');
+    expect(runIn('bash', ['-lic', 'botmux'])).toContain('BOTMUX_OK');
+    expect(runIn('bash', ['-ic', 'botmux'])).toContain('BOTMUX_OK');
+  });
+
   it('a POSIX shell finds it via .profile', () => {
     if (!have('dash')) return;
     fakeLauncher();
@@ -220,16 +271,42 @@ describe('install.sh stays in step with the shared module', () => {
     expect(branch).not.toContain('.profile');
   });
 
-  it('the bash branch writes BOTH .bashrc and .bash_profile', () => {
+  it('the bash branch writes .bashrc plus a resolved login file', () => {
     const branch = caseBranch('\\*bash\\*');
     expect(branch).toContain('.bashrc');
-    expect(branch).toContain('.bash_profile');
+    // The login half is resolved at runtime (see the shadowing test below), so a
+    // literal .bash_profile must NOT appear here.
+    expect(branch).toContain('bash_login_file');
   });
 
   it('the fish branch writes conf.d/botmux.fish using native fish syntax', () => {
     const branch = caseBranch('\\*fish\\*');
     expect(branch).toContain('conf.d/botmux.fish');
     expect(branch).toContain('set -gx PATH');
+  });
+
+  it('the bash branch resolves its login file instead of hardcoding .bash_profile', () => {
+    const branch = caseBranch('\\*bash\\*');
+    // Must go through the resolver; a literal $HOME/.bash_profile here would
+    // shadow an existing .profile/.bash_login (see the module header).
+    expect(branch).toContain('bash_login_file');
+    expect(branch).not.toContain('$HOME/.bash_profile');
+    expect(sh).toContain('bash_login_file()');
+    // The resolver must consider all three, in bash's own order.
+    const fn = sh.slice(sh.indexOf('bash_login_file()'));
+    expect(fn.slice(0, 400)).toContain('.bash_login');
+  });
+
+  it('its idempotence check is per-LINE, not two independent greps', () => {
+    // Two separate greps accept "dir named in a comment" + "unrelated PATH export
+    // on another line" and wrongly skip a machine that is not configured
+    // (reproduced). The dir and the assignment must be found on the SAME line,
+    // which here means piping the dir matches INTO the assignment match.
+    const fn = sh.slice(sh.indexOf('path_line_present()'), sh.indexOf('bash_login_file()'));
+    expect(fn).toContain('grep -F "$INSTALL_DIR"');
+    expect(fn).toMatch(/grep -F "\$INSTALL_DIR"[^\n]*\n?[^\n]*\|/);
+    // The old form ANDed two whole-file greps; that must not come back.
+    expect(fn).not.toMatch(/grep -q "\$INSTALL_DIR"[^\n]*&&/);
   });
 
   it('carries the same marker so the two installers recognise each other\'s line', () => {

--- a/test/loopback-fetch.test.ts
+++ b/test/loopback-fetch.test.ts
@@ -268,6 +268,28 @@ describe('loopbackFetch — hosts and statuses that used to be mis-handled', () 
     expect(isLoopbackUrl(`http://localhost:${port}/x`)).toBe(true);
   }, 15_000);
 
+  it('rejects a 101 immediately instead of hanging forever', async () => {
+    // node:http delivers a 101 as an `upgrade` event, never to the response callback.
+    // Without an `upgrade` listener the promise never settles — measured: the call
+    // only ended when an external AbortSignal fired at 800ms, and requestDashboardAt
+    // passes no signal, so it would hang indefinitely if the recorded port happened
+    // to be a WebSocket service. The native fetch rejects in ~1ms; so must we.
+    const { createServer } = await import('node:http');
+    const server = createServer();
+    servers.push(server);
+    server.on('request', (_q, r) => {
+      r.socket.write('HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: x\r\n\r\n');
+    });
+    await new Promise<void>(r => server.listen(0, '127.0.0.1', () => r()));
+    const port = (server.address() as { port: number }).port;
+
+    const started = Date.now();
+    await expect(loopbackFetch(`http://127.0.0.1:${port}/x`)).rejects.toThrow(/switched protocols/);
+    // Assert on TIME, not just on rejecting: a test that only checks "it rejects"
+    // would also pass if the rejection came from vitest's own timeout.
+    expect(Date.now() - started).toBeLessThan(2_000);
+  }, 15_000);
+
   it('gives a HEAD response a null body', async () => {
     const port = await listen((_q, r) => { r.writeHead(200, { 'content-length': '5' }); r.end(); });
     const res = await loopbackFetch(`http://127.0.0.1:${port}/x`, { method: 'HEAD' });

--- a/test/loopback-fetch.test.ts
+++ b/test/loopback-fetch.test.ts
@@ -1,0 +1,269 @@
+/**
+ * `loopbackFetch` — the proxy-immune transport shared by every loopback caller
+ * (dashboard `/__cli/*`, daemon IPC, current-actor, managed-origin attestation,
+ * the dashboard's SSE aggregator, workflow v3 clients, …).
+ *
+ * Each block below is a defect that was REPRODUCED against an earlier version of
+ * this module, and each one failed in a way that ordinary tests do not notice:
+ *
+ *  · buffer-all body      → SSE callers never got a Response at all, so the
+ *                           dashboard's session/event aggregation silently stopped.
+ *  · plain `Error` on abort → callers branch on `name === 'AbortError'` to tell a
+ *                           timeout (504 wait_timeout / "busy") from an offline
+ *                           daemon (503 / "failed"); every timeout took the wrong
+ *                           branch.
+ *  · listener never removed → one AbortController is reused across an unbounded SSE
+ *                           reconnect loop; 12 completed requests left 12 listeners,
+ *                           each pinning a finished req/res.
+ *
+ * Run: npx vitest run test/loopback-fetch.test.ts
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type RequestListener, type Server } from 'node:http';
+import { getEventListeners } from 'node:events';
+import { loopbackFetch, isLoopbackUrl } from '../src/core/loopback-fetch.js';
+
+const servers: Server[] = [];
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
+});
+
+async function listen(handler: RequestListener): Promise<number> {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise<void>(r => server.listen(0, '127.0.0.1', () => r()));
+  return (server.address() as { port: number }).port;
+}
+
+describe('loopbackFetch — basic fetch compatibility', () => {
+  it('exposes ok/status/json/text like the global fetch', async () => {
+    const port = await listen((req, res) => {
+      if (req.url === '/json') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{"ok":true}');
+      } else {
+        res.writeHead(201);
+        res.end('hello');
+      }
+    });
+    const j = await loopbackFetch(`http://127.0.0.1:${port}/json`);
+    expect(j.ok).toBe(true);
+    expect(await j.json()).toEqual({ ok: true });
+
+    const t = await loopbackFetch(`http://127.0.0.1:${port}/text`);
+    expect(t.status).toBe(201);
+    expect(await t.text()).toBe('hello');
+  });
+
+  it('sends a body and reports non-2xx without throwing', async () => {
+    let seen = '';
+    const port = await listen((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', c => chunks.push(Buffer.from(c)));
+      req.on('end', () => {
+        seen = Buffer.concat(chunks).toString();
+        res.writeHead(418);
+        res.end('nope');
+      });
+    });
+    const r = await loopbackFetch(`http://127.0.0.1:${port}/p`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ a: 1 }),
+    });
+    expect(seen).toBe('{"a":1}');
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(418);
+  });
+
+  it('handles a 204 (a body there would make the Response constructor throw)', async () => {
+    const port = await listen((_req, res) => { res.writeHead(204); res.end(); });
+    const r = await loopbackFetch(`http://127.0.0.1:${port}/n`);
+    expect(r.status).toBe(204);
+    expect(r.body).toBeNull();
+  });
+
+  it('rejects when nothing is listening (callers distinguish this from a 4xx)', async () => {
+    // Port 1 on loopback is not bound in any sane environment.
+    await expect(loopbackFetch('http://127.0.0.1:1/x')).rejects.toBeTruthy();
+  });
+
+  it('refuses a non-loopback host rather than dialling it', async () => {
+    await expect(loopbackFetch('http://example.com/x')).rejects.toBeTruthy();
+  });
+});
+
+describe('loopbackFetch — streaming (SSE)', () => {
+  it('resolves on HEADERS and yields the first frame while the stream stays open', async () => {
+    // The regression: a buffer-all implementation waits for `end`, which never
+    // comes for SSE, so the caller hangs forever instead of reading frames.
+    const port = await listen((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      res.write('data: {"first":true}\n\n');
+      // Deliberately no res.end() — the connection is held open, like /api/events.
+    });
+    const r = await loopbackFetch(`http://127.0.0.1:${port}/api/events`);
+    expect(r.ok).toBe(true);
+    const reader = r.body!.getReader();
+    const { value } = await reader.read();
+    expect(Buffer.from(value!).toString()).toContain('"first":true');
+    await reader.cancel();
+  }, 15_000);
+
+  it('a consumer cancel tears the connection down instead of leaking it', async () => {
+    let closed = false;
+    const port = await listen((_req, res) => {
+      res.on('close', () => { closed = true; });
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.write('data: 1\n\n');
+    });
+    const r = await loopbackFetch(`http://127.0.0.1:${port}/api/events`);
+    const reader = r.body!.getReader();
+    await reader.read();
+    await reader.cancel();
+    // Give the socket teardown a tick to reach the server.
+    await new Promise(res => setTimeout(res, 200));
+    expect(closed).toBe(true);
+  }, 15_000);
+});
+
+describe('loopbackFetch — abort semantics', () => {
+  it('rejects with AbortError when aborted BEFORE the headers arrive', async () => {
+    const port = await listen(() => { /* never respond */ });
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 60);
+    // The exact property callers branch on — daemon.ts picks 504 vs 503 by it.
+    await expect(loopbackFetch(`http://127.0.0.1:${port}/x`, { signal: ctrl.signal }))
+      .rejects.toMatchObject({ name: 'AbortError' });
+  }, 15_000);
+
+  it('fails the BODY with AbortError too, not the socket ECONNRESET', async () => {
+    const port = await listen((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.write('partial');       // headers sent, body never finished
+    });
+    const ctrl = new AbortController();
+    const r = await loopbackFetch(`http://127.0.0.1:${port}/x`, { signal: ctrl.signal });
+    setTimeout(() => ctrl.abort(), 60);
+    await expect(r.text()).rejects.toMatchObject({ name: 'AbortError' });
+  }, 15_000);
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const port = await listen((_req, res) => { res.writeHead(200); res.end('late'); });
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(loopbackFetch(`http://127.0.0.1:${port}/x`, { signal: ctrl.signal }))
+      .rejects.toMatchObject({ name: 'AbortError' });
+  });
+});
+
+describe('loopbackFetch — abort listener lifecycle', () => {
+  /**
+   * `dashboard/aggregator.ts` reuses ONE AbortController across an unbounded SSE
+   * reconnect loop. With `{ once: true }` alone, a request that merely COMPLETED
+   * kept its listener, so the signal accumulated one per reconnect.
+   */
+  it('leaves no listener behind after repeated completed requests', async () => {
+    const port = await listen((_req, res) => { res.writeHead(200); res.end('ok'); });
+    const ctrl = new AbortController();
+    for (let i = 0; i < 12; i++) {
+      const r = await loopbackFetch(`http://127.0.0.1:${port}/x`, { signal: ctrl.signal });
+      await r.text();
+    }
+    expect(getEventListeners(ctrl.signal, 'abort')).toHaveLength(0);
+  }, 20_000);
+
+  it('leaves no listener behind after an SSE stream is cancelled', async () => {
+    const port = await listen((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.write('data: 1\n\n');
+    });
+    const ctrl = new AbortController();
+    const r = await loopbackFetch(`http://127.0.0.1:${port}/e`, { signal: ctrl.signal });
+    const reader = r.body!.getReader();
+    await reader.read();
+    await reader.cancel();
+    expect(getEventListeners(ctrl.signal, 'abort')).toHaveLength(0);
+  }, 15_000);
+
+  it('leaves no listener behind when the request fails before headers', async () => {
+    const ctrl = new AbortController();
+    await expect(loopbackFetch('http://127.0.0.1:1/x', { signal: ctrl.signal })).rejects.toBeTruthy();
+    expect(getEventListeners(ctrl.signal, 'abort')).toHaveLength(0);
+  });
+
+  it('still aborts correctly after the signal has been reused', async () => {
+    // Guard against "fixed the leak by never arming the listener".
+    const okPort = await listen((_req, res) => { res.writeHead(200); res.end('ok'); });
+    const ctrl = new AbortController();
+    for (let i = 0; i < 3; i++) {
+      const r = await loopbackFetch(`http://127.0.0.1:${okPort}/x`, { signal: ctrl.signal });
+      await r.text();
+    }
+    const deadPort = await listen(() => { /* never respond */ });
+    setTimeout(() => ctrl.abort(), 60);
+    await expect(loopbackFetch(`http://127.0.0.1:${deadPort}/y`, { signal: ctrl.signal }))
+      .rejects.toMatchObject({ name: 'AbortError' });
+  }, 20_000);
+});
+
+describe('loopbackFetch — hosts and statuses that used to be mis-handled', () => {
+  it('actually dials an IPv6 loopback server (brackets are stripped)', async () => {
+    // `URL.hostname` yields `[::1]`, which requestLiteralLoopback's allow-list
+    // rejects — so a legal IPv6 URL failed with `remote_host_forbidden` while
+    // isLoopbackUrl cheerfully reported true. Assert on a REAL request, not the
+    // predicate, or the contradiction stays invisible.
+    const server = createServer((_q, r) => { r.writeHead(200); r.end('v6ok'); });
+    servers.push(server);
+    await new Promise<void>(r => server.listen(0, '::1', () => r()));
+    const port = (server.address() as { port: number }).port;
+    const res = await loopbackFetch(`http://[::1]:${port}/x`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('v6ok');
+  }, 15_000);
+
+  it('does not crash on a 205 (a null-body status the constructor refuses)', async () => {
+    // `new Response(stream, {status:205})` throws, and it threw inside the HTTP
+    // response callback: on NODE that escaped as an uncaught exception and killed
+    // the process. Bun tolerates 205, which is why this needed an explicit test.
+    const port = await listen((_q, r) => { r.writeHead(205); r.end(); });
+    const res = await loopbackFetch(`http://127.0.0.1:${port}/x`);
+    expect(res.status).toBe(205);
+    expect(res.body).toBeNull();
+  });
+
+  it('REFUSES https rather than silently dialling it as plaintext', async () => {
+    // Measured against a plain HTTP server: the earlier implementation returned
+    // `200 PLAIN` for an `https://127.0.0.1:PORT` URL — a caller that believed it
+    // had TLS would have sent credentials in the clear. The helper must fail closed
+    // on its own, not rely on callers consulting isLoopbackUrl first.
+    const port = await listen((_q, r) => { r.writeHead(200); r.end('PLAIN'); });
+    await expect(loopbackFetch(`https://127.0.0.1:${port}/x`))
+      .rejects.toThrow(/only http:/);
+  });
+
+  it('gives a HEAD response a null body', async () => {
+    const port = await listen((_q, r) => { r.writeHead(200, { 'content-length': '5' }); r.end(); });
+    const res = await loopbackFetch(`http://127.0.0.1:${port}/x`, { method: 'HEAD' });
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
+  });
+});
+
+describe('isLoopbackUrl', () => {
+  it('accepts only literal loopback hosts over http', () => {
+    expect(isLoopbackUrl('http://127.0.0.1:7891/x')).toBe(true);
+    expect(isLoopbackUrl('http://[::1]:7891/x')).toBe(true);
+    // A DNS name is not a loopback guarantee even if it resolves there today.
+    expect(isLoopbackUrl('http://localhost:7891/x')).toBe(false);
+    expect(isLoopbackUrl('https://dash.example.com/x')).toBe(false);
+    expect(isLoopbackUrl('not a url')).toBe(false);
+  });
+
+  it('refuses https even on a loopback host (this transport is node:http)', () => {
+    // Reporting true here would steer daemon-internal-client onto a transport that
+    // cannot serve the URL — "judged safe but guaranteed to fail".
+    expect(isLoopbackUrl('https://127.0.0.1:7891/x')).toBe(false);
+    expect(isLoopbackUrl('https://[::1]:7891/x')).toBe(false);
+  });
+});

--- a/test/loopback-fetch.test.ts
+++ b/test/loopback-fetch.test.ts
@@ -242,6 +242,32 @@ describe('loopbackFetch — hosts and statuses that used to be mis-handled', () 
       .rejects.toThrow(/only http:/);
   });
 
+  it('derives port 80 when the URL omits it (URL drops the scheme default)', async () => {
+    // `new URL('http://127.0.0.1:80/x').port` is '' — for the implicit AND the
+    // explicit form. `Number('')` is 0, which the loopback guard rejected as
+    // `invalid_port`, so a service on the standard port was unreachable while the
+    // native fetch handled it fine.
+    expect(new URL('http://127.0.0.1:80/x').port).toBe('');   // the trap, pinned
+    // Whatever happens next (connect, refuse, whatever is on :80 here), it must not
+    // be a rejection about the port itself.
+    for (const url of ['http://127.0.0.1/x', 'http://127.0.0.1:80/x']) {
+      const outcome = await loopbackFetch(url).then(() => 'resolved', (e: Error) => e.message);
+      expect(outcome).not.toMatch(/invalid_port/);
+    }
+  }, 15_000);
+
+  it('accepts localhost by mapping it to the literal address', async () => {
+    // Rejecting `localhost` did not avoid a DNS lookup — it pushed the caller onto
+    // the global fetch, which then proxied the request (measured: a Bearer token
+    // reached the stand-in proxy). Mapping it here means we dial 127.0.0.1 directly
+    // and never resolve anything.
+    const port = await listen((_q, r) => { r.writeHead(200); r.end('via-localhost'); });
+    const res = await loopbackFetch(`http://localhost:${port}/x`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('via-localhost');
+    expect(isLoopbackUrl(`http://localhost:${port}/x`)).toBe(true);
+  }, 15_000);
+
   it('gives a HEAD response a null body', async () => {
     const port = await listen((_q, r) => { r.writeHead(200, { 'content-length': '5' }); r.end(); });
     const res = await loopbackFetch(`http://127.0.0.1:${port}/x`, { method: 'HEAD' });
@@ -255,7 +281,9 @@ describe('isLoopbackUrl', () => {
     expect(isLoopbackUrl('http://127.0.0.1:7891/x')).toBe(true);
     expect(isLoopbackUrl('http://[::1]:7891/x')).toBe(true);
     // A DNS name is not a loopback guarantee even if it resolves there today.
-    expect(isLoopbackUrl('http://localhost:7891/x')).toBe(false);
+    // localhost is reserved for loopback (RFC 6761) and we dial the literal address,
+    // so accepting it is strictly safer than pushing the caller onto a proxied fetch.
+    expect(isLoopbackUrl('http://localhost:7891/x')).toBe(true);
     expect(isLoopbackUrl('https://dash.example.com/x')).toBe(false);
     expect(isLoopbackUrl('not a url')).toBe(false);
   });

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -66,6 +66,22 @@ describe('package.json — lockfile safety and packaging', () => {
   it('the file named in `files` actually exists on disk', () => {
     expect(existsSync(POSTINSTALL)).toBe(true);
   });
+
+  it('ships the PATH helper too (postinstall imports it at install time)', () => {
+    // ⚠️ Without this the whole suite stays green while the published tarball
+    // silently regresses to "just print a PATH hint": the fixture copies the
+    // helper in directly rather than consulting the manifest, and the
+    // missing-helper case deliberately asserts fail-soft. So dropping this one
+    // `files` line would reintroduce the exact npm bug this PR fixes.
+    const helper = 'scripts/install-path-entry.mjs';
+    const shipped = manifest.files.some(
+      (f: string) => f === helper || f === 'scripts/' || f === 'scripts',
+    );
+    expect(shipped).toBe(true);
+    expect(existsSync(resolve(helper))).toBe(true);
+    // And postinstall must actually be the thing that pulls it in.
+    expect(readFileSync(POSTINSTALL, 'utf-8')).toContain('./install-path-entry.mjs');
+  });
 });
 
 describe('inject-optional-binaries — release-time version wiring', () => {
@@ -244,7 +260,8 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     expect(existsSync(join(r.home, '.zshenv'))).toBe(false);
   });
 
-  it('the written launcher actually runs and preserves argument boundaries', () => {    const r = runPostinstall({ global: 'true' });
+  it('the written launcher actually runs and preserves argument boundaries', () => {
+    const r = runPostinstall({ global: 'true' });
     const run = spawnSync(r.launcher, ['send', 'hello world'], { encoding: 'utf-8' });
     expect(run.status).toBe(0);
     expect(run.stdout).toBe('BINARY-GOT:send\nBINARY-GOT:hello world\n');

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -146,6 +146,12 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     global?: string;
     withSubpackage?: boolean;
     sourceCheckout?: boolean;
+    /** Omit scripts/install-path-entry.mjs, to prove the import is fail-soft. */
+    withoutPathHelper?: boolean;
+    /** Pretend binDir is already on PATH, so the PATH-writing branch is skipped. */
+    binDirOnPath?: boolean;
+    /** $SHELL for the child, which decides WHICH startup file gets the PATH line. */
+    shell?: string;
   }) {
     const base = tmp();
     const home = join(base, 'home');
@@ -153,6 +159,16 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     mkdirSync(home, { recursive: true });
     mkdirSync(join(pkg, 'scripts'), { recursive: true });
     writeFileSync(join(pkg, 'scripts', 'postinstall-bin.mjs'), readFileSync(POSTINSTALL));
+    // postinstall imports this sibling to write the PATH entry. It ships via
+    // package.json `files`, so the fixture must carry it too — otherwise this
+    // exercises a package layout we never publish. (`opts.withoutPathHelper`
+    // deliberately omits it, to prove the import is fail-soft.)
+    if (!opts.withoutPathHelper) {
+      writeFileSync(
+        join(pkg, 'scripts', 'install-path-entry.mjs'),
+        readFileSync(join(__dirname, '..', 'scripts', 'install-path-entry.mjs')),
+      );
+    }
     writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: 'botmux', version: '3.20.0' }));
 
     if (opts.sourceCheckout) {
@@ -173,13 +189,15 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
 
     const env: NodeJS.ProcessEnv = { PATH: process.env.PATH, HOME: home };
     if (opts.global !== undefined) env.npm_config_global = opts.global;
+    if (opts.binDirOnPath) env.PATH = `${join(home, '.botmux', 'bin')}:${process.env.PATH}`;
+    if (opts.shell) env.SHELL = opts.shell;
 
     const r = spawnSync(process.execPath, [join(pkg, 'scripts', 'postinstall-bin.mjs')], {
       encoding: 'utf-8',
       env,
     });
     const launcher = join(home, '.botmux', 'bin', 'botmux');
-    return { ...r, launcher, binary, wrote: existsSync(launcher) };
+    return { ...r, launcher, binary, home, wrote: existsSync(launcher) };
   }
 
   it('global install → writes a launcher that execs the platform binary', () => {
@@ -193,8 +211,31 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     expect(content).not.toMatch(/(^|\s)node(\s|$)/m);
   });
 
-  it('the written launcher actually runs and preserves argument boundaries', () => {
-    const r = runPostinstall({ global: 'true' });
+  /**
+   * PATH is the only thing that turns the launcher into a command (there is no
+   * `bin` field), so these two cover the reported "installed fine, still
+   * `command not found`" bug and its blast radius.
+   */
+  it('global install also puts binDir on PATH, in the file the user\'s shell reads', () => {
+    const r = runPostinstall({ global: 'true', shell: '/usr/bin/zsh' });
+    expect(r.status).toBe(0);
+    // zsh reads .zshenv, NOT .profile — writing .profile was the original bug.
+    const zshenv = join(r.home, '.zshenv');
+    expect(existsSync(zshenv)).toBe(true);
+    expect(readFileSync(zshenv, 'utf-8')).toContain(join(r.home, '.botmux', 'bin'));
+    expect(existsSync(join(r.home, '.profile'))).toBe(false);
+  });
+
+  it('a missing PATH helper degrades to a hint — it must NOT fail the install', () => {
+    // The launcher is already written by this point; aborting here would turn a
+    // working install into a failed one over a cosmetic step.
+    const r = runPostinstall({ global: 'true', withoutPathHelper: true });
+    expect(r.status).toBe(0);
+    expect(r.wrote).toBe(true);
+    expect(`${r.stdout}${r.stderr}`).toContain('PATH');
+  });
+
+  it('the written launcher actually runs and preserves argument boundaries', () => {    const r = runPostinstall({ global: 'true' });
     const run = spawnSync(r.launcher, ['send', 'hello world'], { encoding: 'utf-8' });
     expect(run.status).toBe(0);
     expect(run.stdout).toBe('BINARY-GOT:send\nBINARY-GOT:hello world\n');

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -235,6 +235,15 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     expect(`${r.stdout}${r.stderr}`).toContain('PATH');
   });
 
+  it('touches no startup file when binDir is already on PATH', () => {
+    // An upgrade on a machine that was set up long ago must not keep appending
+    // to (or even creating) rc files it has nothing to add to.
+    const r = runPostinstall({ global: 'true', shell: '/usr/bin/zsh', binDirOnPath: true });
+    expect(r.status).toBe(0);
+    expect(r.wrote).toBe(true);                        // launcher still written
+    expect(existsSync(join(r.home, '.zshenv'))).toBe(false);
+  });
+
   it('the written launcher actually runs and preserves argument boundaries', () => {    const r = runPostinstall({ global: 'true' });
     const run = spawnSync(r.launcher, ['send', 'hello world'], { encoding: 'utf-8' });
     expect(run.status).toBe(0);

--- a/test/report-session-relay.test.ts
+++ b/test/report-session-relay.test.ts
@@ -235,7 +235,11 @@ describe('report session relay wiring', () => {
   });
 
   it('falls back to the source daemon relay when the host secret is masked', () => {
-    expect(cliSource).toContain("fetch(`http://127.0.0.1:${port}${input.path}`");
+    // Must be the proxy-immune loopback client, not the global fetch: under Bun the
+    // latter routes 127.0.0.1 through $http_proxy whenever no_proxy does not name
+    // that literal address, and the corporate proxy answers an HTML 403.
+    expect(cliSource).toContain("loopbackFetch(`http://127.0.0.1:${port}${input.path}`");
+    expect(cliSource).not.toContain("await fetch(`http://127.0.0.1:${port}${input.path}`");
     expect(cliSource).toContain('originCapability: originClaim?.capability');
   });
 

--- a/test/vc-meeting-daemon-session.test.ts
+++ b/test/vc-meeting-daemon-session.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
+import { __setLoopbackTransportForTests } from '../src/core/loopback-fetch.js';
 
 const sentMessages = vi.hoisted(() => [] as Array<{ receiveId: string; msgType: string; content: string; uuid?: string }>);
 const patchedMessages = vi.hoisted(() => [] as Array<{ messageId: string; content: string }>);
@@ -49,6 +50,21 @@ const preparationRecords = vi.hoisted(() => [] as Array<{
 }>);
 const onlineDaemons = vi.hoisted(() => new Map<string, { larkAppId: string; ipcPort: number; pid?: number; lastHeartbeat?: number }>());
 const remoteFetchCalls = vi.hoisted(() => [] as Array<{ url: string; init?: RequestInit; body?: any }>);
+/**
+ * Install one mock for BOTH transports.
+ *
+ * Loopback callers were moved off the global `fetch` onto node:http (Bun's fetch
+ * silently proxies 127.0.0.1 when `no_proxy` does not list that literal address),
+ * so `vi.stubGlobal('fetch', …)` alone stopped intercepting them: these tests
+ * began opening REAL connections to ports like 4310/39003 and `remoteFetchCalls`
+ * stayed empty. Keep using the same mock for both so the assertions still see
+ * every request, remote and local alike.
+ */
+function stubAllFetch(mock: unknown): void {
+  vi.stubGlobal('fetch', mock);
+  __setLoopbackTransportForTests(mock as never);
+}
+
 const addBotToChatCalls = vi.hoisted(() => [] as Array<{ proxyLarkAppId: string; chatId: string; targetLarkAppIds: string[] }>);
 const addBotToChatFailures = vi.hoisted(() => ({ count: 0 }));
 const addBotToChatHolds = vi.hoisted(() => ({
@@ -912,6 +928,10 @@ describe('VC meeting daemon session lifecycle', () => {
     testDataDir = undefined;
     dataDirBeforeTest = undefined;
     vi.unstubAllGlobals();
+    // vi.unstubAllGlobals() knows nothing about the loopback transport seam, so it
+    // has to be cleared explicitly — otherwise a mock installed here leaks into
+    // every later test in the run.
+    __setLoopbackTransportForTests(undefined);
     delete process.env.BOTMUX_TIME_SCALE;
   });
 
@@ -3460,7 +3480,7 @@ describe('VC meeting daemon session lifecycle', () => {
       observeRemoteRegistration = resolve;
     });
     let remoteRegistrationBody: any;
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubAllFetch(vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       let body: any;
       try {
@@ -8174,7 +8194,7 @@ describe('VC meeting daemon session lifecycle', () => {
     });
     __vcMeetingAgentTest.setSelfDaemonLarkAppIdForTest(AGENT_APP_ID);
     __vcMeetingAgentTest.setCrossAppLocalReceiverForTest(false);
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubAllFetch(vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       const body = init?.body ? JSON.parse(String(init.body)) : undefined;
       remoteFetchCalls.push({ url, init, body });
@@ -8574,7 +8594,7 @@ describe('VC meeting daemon session lifecycle', () => {
       updatedAt: Date.now(),
       expiresAt: Date.now() + 60_000,
     });
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubAllFetch(vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       let body: any;
       try {
@@ -8902,7 +8922,7 @@ describe('VC meeting daemon session lifecycle', () => {
       ipcPort: 39001,
       lastHeartbeat: Date.now(),
     });
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubAllFetch(vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       let body: any;
       try {
@@ -9042,7 +9062,7 @@ describe('VC meeting daemon session lifecycle', () => {
       lastHeartbeat: Date.now(),
     });
     const deliveryBodies: any[] = [];
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubAllFetch(vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       const body = init?.body ? JSON.parse(String(init.body)) : undefined;
       remoteFetchCalls.push({ url, init, body });

--- a/test/voice-provider-fence.test.ts
+++ b/test/voice-provider-fence.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 const { FakeWebSocket } = vi.hoisted(() => {
   class FakeWebSocket {
@@ -187,4 +189,113 @@ describe('voice provider effect fences', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(pcm).toMatchObject({ data: Buffer.from([4, 5, 6]), sampleRate: 24000, channels: 1 });
   });
+});
+
+/**
+ * A self-hosted TTS endpoint must not have its API key handed to an HTTP proxy.
+ *
+ * `openaiSynthesizePcm` sends `Authorization: Bearer <apiKey>` to `cfg.baseUrl`, and
+ * a LOCAL endpoint is the documented case (the config hint suggests
+ * `http://127.0.0.1:8880/v1`). Under Bun the global `fetch` routes 127.0.0.1 through
+ * `$http_proxy` unless `no_proxy` names that literal address — CIDR does not count —
+ * so the request, key included, went to the corporate proxy. Reproduced with a
+ * canary token: `PROXY_HIT POST …/v1/audio/speech auth=Bearer SECRET_CANARY`.
+ *
+ * This has to run in a REAL Bun process: Bun snapshots proxy config at startup, and
+ * vitest's own worker is Node (whose fetch ignores proxy env entirely), so an
+ * in-process assertion cannot see the defect at all.
+ */
+describe('openaiSynthesizePcm — a local endpoint bypasses the proxy', () => {
+  function resolveBun(): string | undefined {
+    if (process.env.BUN_PATH && existsSync(process.env.BUN_PATH)) return process.env.BUN_PATH;
+    for (const dir of (process.env.PATH ?? '').split(':')) {
+      if (!dir) continue;
+      const candidate = join(dir, 'bun');
+      if (existsSync(candidate)) return candidate;
+    }
+    return undefined;
+  }
+
+  it('does not send the Bearer token to $http_proxy', async () => {
+    const bun = resolveBun();
+    if (!bun) {
+      // Never silently pass in CI — a skipped security regression is worse than none.
+      if (process.env.CI) throw new Error('bun not found on PATH; this test must not be skipped in CI');
+      return;
+    }
+
+    const { createServer } = await import('node:http');
+    const servers: import('node:http').Server[] = [];
+    const listen = async (h: import('node:http').RequestListener) => {
+      const s = createServer(h); servers.push(s);
+      await new Promise<void>(r => s.listen(0, '127.0.0.1', () => r()));
+      return (s.address() as { port: number }).port;
+    };
+    try {
+      let proxyHits = 0;
+      let leakedAuth = '';
+      let localHits = 0;
+      const proxyPort = await listen((req, res) => {
+        proxyHits++;
+        leakedAuth = String(req.headers.authorization ?? '');
+        res.writeHead(403, { 'content-type': 'text/html' });
+        res.end('<html><title>403 Forbidden</title></html>');
+      });
+      const ttsPort = await listen((_req, res) => {
+        localHits++;
+        res.writeHead(200, { 'content-type': 'audio/pcm' });
+        res.end(Buffer.alloc(16));
+      });
+
+      const modulePath = join(__dirname, '..', 'src', 'services', 'voice', 'openai.ts');
+      const snippet = `
+        const { openaiSynthesizePcm } = await import(${JSON.stringify(modulePath)});
+        try {
+          await openaiSynthesizePcm(
+            { baseUrl: 'http://127.0.0.1:${ttsPort}/v1', model: 'm', apiKey: 'SECRET_CANARY' },
+            'hi', { speaker: 'a' },
+          );
+          process.stdout.write(JSON.stringify({ runtime: typeof Bun !== 'undefined' ? 'bun' : 'node', ok: true }));
+        } catch (e) {
+          process.stdout.write(JSON.stringify({ runtime: typeof Bun !== 'undefined' ? 'bun' : 'node', err: String(e && e.message) }));
+        }
+      `;
+      const { spawn } = await import('node:child_process');
+      const proxyUrl = `http://127.0.0.1:${proxyPort}`;
+      const stdout = await new Promise<string>((resolve, reject) => {
+        // Async spawn: spawnSync would block this event loop and the servers above
+        // could never accept the child's connection.
+        const child = spawn(bun, ['-e', snippet], {
+          env: {
+            ...process.env,
+            http_proxy: proxyUrl, HTTP_PROXY: proxyUrl,
+            https_proxy: proxyUrl, HTTPS_PROXY: proxyUrl,
+            // The CIDR form real shell rc files use — the one Bun does not honour.
+            no_proxy: '127.0.0.0/8', NO_PROXY: '127.0.0.0/8',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let out = '', err = '';
+        child.stdout.on('data', d => { out += String(d); });
+        child.stderr.on('data', d => { err += String(d); });
+        const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error('bun child timed out')); }, 25_000);
+        child.on('error', e => { clearTimeout(timer); reject(e); });
+        child.on('close', code => {
+          clearTimeout(timer);
+          if (code !== 0) reject(new Error(`bun child exited ${code}: ${err.slice(0, 400)}`));
+          else resolve(out);
+        });
+      });
+
+      const parsed = JSON.parse(stdout || '{}');
+      // Prove the child really was Bun, or the assertions below mean nothing.
+      expect(parsed.runtime).toBe('bun');
+      expect(leakedAuth).toBe('');
+      expect(proxyHits).toBe(0);
+      expect(localHits).toBe(1);
+      expect(parsed.ok).toBe(true);
+    } finally {
+      await Promise.all(servers.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
+    }
+  }, 40_000);
 });

--- a/test/worktree-slug-ai.test.ts
+++ b/test/worktree-slug-ai.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { config } from '../src/config.js';
 import { worktreeSlugFromContextAI } from '../src/services/worktree-slug-ai.js';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 describe('worktreeSlugFromContextAI', () => {
   const original = { ...config.worktreeSlugAI };
@@ -66,4 +68,111 @@ describe('worktreeSlugFromContextAI', () => {
     await expect(worktreeSlugFromContextAI('repo test')).resolves.toBe('repo-test');
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
+});
+
+/**
+ * A LOCAL slug model must not have its API key handed to an HTTP proxy.
+ *
+ * `baseUrl` is user-configured and may point at a local model, while the request
+ * carries `Authorization: Bearer <apiKey>`. Under Bun the global `fetch` routes
+ * 127.0.0.1 through `$http_proxy` unless `no_proxy` names that literal address —
+ * CIDR does not count. Reproduced with a canary token:
+ *
+ *   PRE  → PROXY … auth=Bearer SLUG_SECRET_CANARY   (then a silent local fallback)
+ *   POST → LOCAL /v1/chat/completions                (the model's answer is used)
+ *
+ * The silent fallback is what made this invisible: the caller just gets a slightly
+ * worse slug and never learns the key went to the proxy.
+ *
+ * Must run in a REAL Bun process — Bun snapshots proxy config at startup, and
+ * vitest's worker is Node, whose fetch ignores proxy env entirely.
+ */
+describe('worktreeSlugFromContextAI — a local model bypasses the proxy', () => {
+  function resolveBun(): string | undefined {
+    if (process.env.BUN_PATH && existsSync(process.env.BUN_PATH)) return process.env.BUN_PATH;
+    for (const dir of (process.env.PATH ?? '').split(':')) {
+      if (!dir) continue;
+      const candidate = join(dir, 'bun');
+      if (existsSync(candidate)) return candidate;
+    }
+    return undefined;
+  }
+
+  it('does not send the Bearer token to $http_proxy', async () => {
+    const bun = resolveBun();
+    if (!bun) {
+      if (process.env.CI) throw new Error('bun not found on PATH; this test must not be skipped in CI');
+      return;
+    }
+
+    const { createServer } = await import('node:http');
+    const servers: import('node:http').Server[] = [];
+    const listen = async (h: import('node:http').RequestListener) => {
+      const s = createServer(h); servers.push(s);
+      await new Promise<void>(r => s.listen(0, '127.0.0.1', () => r()));
+      return (s.address() as { port: number }).port;
+    };
+    try {
+      let proxyHits = 0;
+      let leakedAuth = '';
+      let localHits = 0;
+      const proxyPort = await listen((req, res) => {
+        proxyHits++;
+        leakedAuth = String(req.headers.authorization ?? '');
+        res.writeHead(403); res.end('PROXY');
+      });
+      const modelPort = await listen((_req, res) => {
+        localHits++;
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ choices: [{ message: { content: 'my-slug' } }] }));
+      });
+
+      // Note the `.js` specifier for config: the module under test imports it that
+      // way, and a `.ts` import would be a DIFFERENT instance whose mutation the
+      // module never sees (measured — the probe silently exercised nothing).
+      const snippet = `
+        const m = await import(${JSON.stringify(join(__dirname, '..', 'src', 'services', 'worktree-slug-ai.ts'))});
+        const { config } = await import(${JSON.stringify(join(__dirname, '..', 'src', 'config.js'))});
+        config.worktreeSlugAI = {
+          enabled: true, baseUrl: 'http://127.0.0.1:${modelPort}/v1', model: 'm',
+          apiKey: 'SLUG_SECRET_CANARY', timeoutMs: 5000, extraHeaders: {}, extraBody: {},
+        };
+        const slug = await m.worktreeSlugFromContextAI('Some Feature Title', 'do the thing');
+        process.stdout.write(JSON.stringify({ runtime: typeof Bun !== 'undefined' ? 'bun' : 'node', slug }));
+      `;
+      const { spawn } = await import('node:child_process');
+      const proxyUrl = `http://127.0.0.1:${proxyPort}`;
+      const stdout = await new Promise<string>((resolve, reject) => {
+        const child = spawn(bun, ['-e', snippet], {
+          env: {
+            ...process.env,
+            http_proxy: proxyUrl, HTTP_PROXY: proxyUrl,
+            https_proxy: proxyUrl, HTTPS_PROXY: proxyUrl,
+            no_proxy: '127.0.0.0/8', NO_PROXY: '127.0.0.0/8',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let out = '', err = '';
+        child.stdout.on('data', d => { out += String(d); });
+        child.stderr.on('data', d => { err += String(d); });
+        const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error('bun child timed out')); }, 25_000);
+        child.on('error', e => { clearTimeout(timer); reject(e); });
+        child.on('close', code => {
+          clearTimeout(timer);
+          if (code !== 0) reject(new Error(`bun child exited ${code}: ${err.slice(0, 400)}`));
+          else resolve(out);
+        });
+      });
+
+      const parsed = JSON.parse(stdout || '{}');
+      expect(parsed.runtime).toBe('bun');
+      expect(leakedAuth).toBe('');
+      expect(proxyHits).toBe(0);
+      expect(localHits).toBe(1);
+      // The model's answer, not the local fallback ('some-feature-title').
+      expect(parsed.slug).toBe('my-slug');
+    } finally {
+      await Promise.all(servers.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
+    }
+  }, 40_000);
 });


### PR DESCRIPTION
修两个让**全新安装直接不可用**的问题，并在 review 过程中连带收口了同一根因的一批 loopback 请求。所有结论都先复现、再修、再变异验证。

## 一、`npm i -g botmux@latest` 成功，但 `botmux: command not found`

包内**没有 `bin` 字段**（随 Node fallback 一起移除），所以唯一的 `botmux` 命令是 postinstall 写到 `~/.botmux/bin/botmux` 的启动器 —— 必须靠 PATH 才能被找到。

现场证据：`npm ls -g` 显示 `botmux@3.18.3` 装得好好的，全局 `bin/` 里 claude/codex/relay 都有软链，**唯独没有 botmux**；启动器文件本身写成功了（169MB ELF，能跑）。

而两个安装器都只是**打印**一条建议 `echo 'export PATH="…"' >> ~/.profile`，而 **zsh 从不读 `~/.profile`** —— 照着做也没有效果。

顺便排除了一个怀疑：npm 11 给 postinstall 传的是 `npm_config_global="true"`，严格 guard **是过的**，启动器没被跳过。

### 改法：写入用户 shell 真正会读的文件

| shell | 目标文件 | 依据（全部实测） |
|---|---|---|
| zsh | `${ZDOTDIR:-$HOME}/.zshenv` | `-c`/`-i`/`-li` 三种模式**唯一都读**的文件；zsh 的 dotfile 目录受 `$ZDOTDIR` 控制 |
| bash | `~/.bashrc` **和**其 login 文件 | 交互与登录**互斥**；login 文件是 `.bash_profile` → `.bash_login` → `.profile` 中**第一个存在**的那个 |
| fish | `${XDG_CONFIG_HOME:-~/.config}/fish/conf.d/botmux.fish` | 三种模式都生效；fish 非 POSIX，用 `set -gx` |
| 其它/未知 | `~/.profile` | dash/sh/ksh 登录会读 |

**review 在这里抓出四个真问题，都已修**：

1. 🔴 **命令注入**：安装目录来自 `BOTMUX_INSTALL_DIR`，此前被插进双引号里 ⟹ 含 `$(...)` 的目录会在**每次开 shell 时执行**（实测真的创建了文件）。改为单引号并转义内嵌引号。
2. 🔴 **遮蔽既有登录配置**：无条件创建 `.bash_profile` 会让既有 `.profile`/`.bash_login` **永久不再被读取**（sentinel 实测由可见变 MISSING）。
3. **`$ZDOTDIR` / `$XDG_CONFIG_HOME` 被忽略** ⟹ 写出的文件 shell 根本不读。
4. **写进去的语句本身不幂等** ⟹ 嵌套 shell、以及 `.bash_profile` 又 source `.bashrc` 的单次登录里会反复追加。POSIX/zsh 用 `case` 判断，fish 用 `contains`。

幂等判据分两条：我们自己的行按已知语法识别（marker + 精确 quoted 形式），用户手写的行按**完整 PATH 元素**比较。任何把两种语法揉进一个 tokenizer 的写法都会被 shell quoting 打败。被注释掉的行不算生效；`<dir>-old`、`/backup<dir>`、`<dir>/child` 都不算已配置。

PATH 这一步失败**只降级为打印提示**，绝不让一次已装好启动器的安装失败。

## 二、`botmux dashboard` 报 nginx 的 `403 Forbidden`

根因：**Bun 的 `fetch` 会自动使用 `$http_proxy`，且 `no_proxy` 只做字面量匹配** —— 不解析 CIDR，也不认为 `localhost` 覆盖 `127.0.0.1`。内网机器普遍 export 这种组合，于是**本机 loopback 请求被发给公司代理**，代理拒绝转发内网地址并返回 HTML 403。

dashboard 自身完好：它的 `/__cli/*` **只返回 JSON**，所以**收到 HTML 本身就是「被代理劫持」的指纹**。

### 每档一个独立子进程实测（同进程内改 env 会被启动快照污染）

```
no_proxy 未设 / 空        → 走代理 ❌
no_proxy=127.0.0.0/8     → 走代理 ❌   ← 内网 shell rc 的常见写法
no_proxy=localhost       → 走代理 ❌
no_proxy=127.0.0.1       → 直连 ✅
no_proxy=*               → 直连 ✅
```

三条修法被实测排除（**存在 ≠ 生效**）：`{proxy:''}`/`undefined`/`null` 仍走代理；运行时增删 env 也无效（Bun 启动时即快照）。所以改用 **`node:http`**（Node 与 Bun 下都完全无视代理 env）。编译态（`bun build --compile`）也验了。

同仓先例：`supervisor-shutdown-client.ts`、`core/loopback-target.ts`、`platform/platform-http.ts`。反向先例 `dashboard/hd2d-assets.ts` 是**故意**要走代理的，未受影响。

## 迁移范围（准确表述）

新增 `src/core/loopback-fetch.ts`（建在既有 `requestLiteralLoopback` 之上），覆盖两类：

**(a) BotMux 内部 loopback**：`fetchDaemonIpc`（30+ 调用方）、dashboard-endpoint、**current-actor**、**managed-origin-attestation**、`daemon-internal-client`（按 host 分派）、aggregator、groups-action-helpers、workflow v3 两个 client、exact-chat-grant，以及 `cli.ts`(6 处)/`daemon.ts`/`vc-agent.ts`/`hook-runner.ts`/`dashboard.ts` 的 inline 直连。

**(b) 本轮补齐的 JSON 型自托管 OpenAI 请求**：`voice/openai.ts`（TTS）、`worktree-slug-ai.ts`。两者的 `baseUrl` 用户可配、请求带 `Authorization: Bearer`，按解析后的 url 分派，远端仍走原生 fetch。

⚠️ **我最初判断「`fetchDaemonIpc` 不用改」是错的**。当时的依据是 `botmux list` 在代理下正常，但那条路径压根没发出该请求 —— 是负对照，推不出结论。用真 Bun 进程直接调该 wrapper 得到 `status=403`。

**未纳入、列为后续安全审计项**：Riff 的 `baseUrl` 也允许本地（集成测试就用 127.0.0.1），但它涉及 FormData / 大附件，当前 helper 明确不支持，不能不评估就机械替换；SAMI override 同理。

### 两处安全后果（不只是可用性）

**身份边界**：`current-actor` 只按 JSON 形态信任响应，没有来源认证 ⟹ 代理能伪造一个「已验证」的真人身份。
```
经全局 fetch → 解析出攻击者构造的那个邮箱
经修复后     → 真实 owner 的邮箱
```

**凭据外泄**（canary 实证）：
```
TTS   改前 → PROXY_HIT POST …/v1/audio/speech auth=Bearer SECRET_CANARY
slug  改前 → PROXY … auth=Bearer SLUG_SECRET_CANARY，随后静默回退到本地 slug
      改后 → LOCAL /v1/chat/completions
```
slug 那条的静默回退正是它一直没被发现的原因：调用方只会拿到一个稍差的 slug。

### 传输层本身修掉的七处行为问题

1. **必须 headers 就绪即 resolve**，body 用 `ReadableStream` 桥接。此前 buffer 到 end，而 SSE 永不 end ⟹ dashboard 的会话/事件聚合会**永久停住**。
2. **abort 必须是 `AbortError`**（用 `signal.reason`），body 流以同一错误终止。此前是普通 Error/ECONNRESET，而 `daemon.ts` 靠 name 区分 504 `wait_timeout` 与 503 `daemon_offline`。
3. **abort listener 必须在请求终结时移除**。`{once:true}` 只覆盖真 abort，正常完成的请求会留下监听器，而 aggregator 在无界重连里复用同一个 controller ⟹ 12 次完成留下 12 个监听器。
4. **非 `http:` 一律拒绝**。此前 `https://127.0.0.1` 被静默降级成明文（实测返回 `200 PLAIN`）。
5. **101 立即 reject**。node:http 对 101 不调 response 回调而是发 `upgrade` 事件，此前 Promise 永不 settle ⟹ `requestDashboardAt` 不传 signal，若端口恰是 WebSocket 服务会**无限挂住**（实测靠 800ms 外部 abort 才结束，现在 9ms）。
6. **IPv6 去掉 `URL.hostname` 的方括号**，否则合法的 `[::1]` 被判 `remote_host_forbidden`。
7. **`http:` 默认端口补 80**（`URL` 会把 `:80` 规范成空串 ⟹ `Number('')` 为 0 被判非法），null-body 状态补 205 与 HEAD，`new Response` 包 try —— 205 在 Node 下会从事件回调逃逸成 uncaught exception 直接崩进程，而 Bun 恰好容忍，所以此前测不出来。

`localhost` 从「拒绝」改为「映射到 127.0.0.1」：拒绝它并不避免解析，只会把调用方推给会走代理的全局 fetch（上面的 key 泄漏正是这样发生的）。RFC 6761 保留 `localhost` 给 loopback，直接映射后我们连 DNS 都不查。

## 影响范围评估

- **跨平台**：PATH 逻辑在 Linux 上四种 shell 实测；macOS 同样适用（zsh 默认，`.zshenv` 同理）。传输层是纯 Node API，无平台分支。
- **跨会话类型**：受影响的是 CLI、daemon IPC、dashboard→daemon、workflow v3、VC、hook 转发这些**共用 loopback 路径**；话题会话/群会话/adopt 本身不区分。
- **跨 CLI**：`hook-installer.ts` 生成的 OpenCode V1/V2 插件各自内联一份等价 helper（生成文件无法 import 仓库模块），抽成常量插两次 —— 只改调用点漏掉定义会让 V1 在 fallback 时 `ReferenceError`。
- **测试接缝**：迁移会绕过测试替换 `globalThis.fetch` 的接缝，导致相关测试改打真实端口。传输层因此留一个 `__setLoopbackTransportForTests` 注入点；该 override 是模块级的，`vi.unstubAllGlobals()` 不认识它，**必须显式 teardown**，否则污染同一次运行的后续用例。

## 测试验证

```
npx tsc --noEmit                        → 0 错
install-path-entry                      → 49（含真跑 install.sh 的离线 fixture）
loopback-fetch                          → 23（新增）
其余相关组合（seam / 插件 / TTS / slug）   → 全绿
```

端到端：四种 shell × 两条安装路径，判据是**「shell 能否真的执行到 `botmux`」**而不是「文件写没写」。

`install.sh` 的离线 fixture：fake `uname`/`ldd`/`curl` 上 PATH（完全离线），临时 HOME/SHELL/ZDOTDIR/XDG，覆盖 ZDOTDIR、XDG+fish 语法、bash 不遮蔽 `.profile`（含 sentinel + login/interactive 两模式）、二次运行字节不变、单引号目录幂等、尾斜杠幂等、无尾换行保留、**注入不执行**、sibling/prefix/child 目录、注释掉的自有行与用户行、already-configured 正向对照、运行时 PATH 幂等。

**变异验证：把每个上述缺陷原样重现，全部转红。**

### 几处值得 reviewer 留意的测试方法学

- **vitest 的测试体始终在 Node 下执行**，即使用 `bun x vitest`（实测 `runtime=node`）。而 Node 的 fetch 本就不理代理 ⟹ 纯进程内断言对代理类缺陷**零区分力**（撤掉修复也全绿）。凡涉及 Bun 特有行为的，都真起一个 Bun 子进程**并断言子进程自报 Bun**。
- **CI 下找不到 bun 就直接失败**，不静默跳过：此前的查找逻辑读的是被 `test/unit-setup.ts` 改写过的 `HOME`，在非 root runner 上三个候选全落空 ⟹ 安全回归一行没跑而套件全绿。
- **测试不得依赖宿主环境变量**：CI 上 `XDG_CONFIG_HOME` 是设置的，导致两条硬编码路径断言本地绿、CI 红。已改为显式传入，并用 `XDG_CONFIG_HOME=… ZDOTDIR=… vitest` 模拟 CI 复验。
- **rc 幂等探针的嵌套命令内层必须单引号**，否则父 shell 先展开 `$PATH`，打印的是父层快照 ⟹ 探针恒为 1、天生无区分力。

全量单测残留的失败文件已**逐文件**与干净基线对照，数字完全一致，均为既有问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
