### PR TITLE
fix(adopt): 展示 TraeX 原生会话标题

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -12,6 +12,7 @@ import {
   traexHistorySize,
   findTraexRolloutSetByPid,
   traexHistorySidIsOwned,
+  readTraexThreadMetadataIndex,
 } from '../../services/traex-transcript.js';
 import { discoverRolloutSessions } from '../../services/resumable-session-discovery.js';
 import { delay } from '../../utils/timing.js';
@@ -273,7 +274,17 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
     /** Import path: TRAE writes Codex-family rollout files under
      *  `<TRAE_HOME>/cli/sessions`. */
     listResumableSessions({ limit, exclude }) {
-      return discoverRolloutSessions(traeSessionsRoot(), limit, exclude);
+      const nativeMetadata = readTraexThreadMetadataIndex();
+      const metadataById = new Map([...nativeMetadata].map(([id, metadata]) => [id, {
+        title: metadata.title,
+        firstUserMessage: metadata.firstUserMessage,
+        cwd: metadata.cwd,
+        lastActivityAt: metadata.updatedAtMs,
+      }]));
+      return discoverRolloutSessions(traeSessionsRoot(), limit, exclude, {
+        dialect: 'traex',
+        metadataById,
+      });
     },
 
     async writeInput(pty: PtyHandle, content: string) {

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -12,7 +12,7 @@ import type { CliId } from '../adapters/cli/types.js';
 import { executableBasename } from '../adapters/cli/runtime.js';
 import { findCodexRolloutByPid } from '../services/codex-transcript.js';
 import { findCocoSessionByPid } from '../services/coco-transcript.js';
-import { findTraexRolloutByPid } from '../services/traex-transcript.js';
+import { findTraexRolloutByPid, readTraexThreadTitle } from '../services/traex-transcript.js';
 import { tmuxEnv } from '../setup/ensure-tmux.js';
 
 // macOS 没有 /proc，所以走 ps/lsof/pgrep 兜底。Linux 仍优先走 /proc 快路径。
@@ -32,6 +32,7 @@ export interface AdoptableSession {
   herdrTerminalId?: string;
   cliId: CliId;              // recognized CLI type
   sessionId?: string;        // CLI session ID
+  title?: string;            // CLI-native title when the backend exposes one
   cwd: string;               // CLI working directory
   startedAt?: number;        // epoch ms
   paneCols: number;          // current pane width
@@ -865,6 +866,9 @@ function discoverHerdrAdoptableSessions(filterCliId?: CliId, filterExecutable?: 
       const claudeMeta = cliId === 'claude-code'
         ? (cliPid ? readClaudeSessionMeta(cliPid) : undefined) ?? findUniqueClaudeSessionByCwd(cwd)
         : undefined;
+      const title = cliId === 'traex' && sessionId
+        ? readTraexThreadTitle(sessionId)
+        : undefined;
       discoveredPaneIds.add(paneId);
       results.push({
         source: 'herdr',
@@ -876,6 +880,7 @@ function discoverHerdrAdoptableSessions(filterCliId?: CliId, filterExecutable?: 
         cliPid,
         cliId,
         sessionId: sessionId ?? claudeMeta?.sessionId,
+        title,
         cwd,
         startedAt: claudeMeta?.startedAt ?? (cliPid ? readProcessStartTime(cliPid) : undefined),
         paneCols: 200,
@@ -903,6 +908,9 @@ function discoverHerdrAdoptableSessions(filterCliId?: CliId, filterExecutable?: 
       else if (process.cliId === 'codex') sessionId = findCodexRolloutByPid(process.pid)?.cliSessionId;
       else if (process.cliId === 'coco') sessionId = findCocoSessionByPid(process.pid)?.sessionId;
       const claudeMeta = process.cliId === 'claude-code' ? readClaudeSessionMeta(process.pid) : undefined;
+      const title = process.cliId === 'traex' && sessionId
+        ? readTraexThreadTitle(sessionId)
+        : undefined;
       results.push({
         source: 'herdr',
         herdrSessionName: sessionName,
@@ -913,6 +921,7 @@ function discoverHerdrAdoptableSessions(filterCliId?: CliId, filterExecutable?: 
         cliPid: process.pid,
         cliId: process.cliId,
         sessionId: sessionId ?? claudeMeta?.sessionId,
+        title,
         cwd,
         startedAt: claudeMeta?.startedAt ?? readProcessStartTime(process.pid),
         paneCols: 200,
@@ -1005,6 +1014,7 @@ function resolveAdoptableSessionForPane(
 
   // 5. Try to read CLI session metadata
   let sessionId: string | undefined;
+  let title: string | undefined;
   let startedAt: number | undefined;
   if (match.cliId === 'claude-code') {
     const meta = readClaudeSessionMeta(cliPid);
@@ -1030,7 +1040,10 @@ function resolveAdoptableSessionForPane(
     // path matcher (~/.trae/cli/sessions/...). Worker-side re-probes by
     // pid as a fallback, so undefined here is acceptable.
     const rollout = findTraexRolloutByPid(cliPid);
-    if (rollout) sessionId = rollout.cliSessionId;
+    if (rollout) {
+      sessionId = rollout.cliSessionId;
+      title = readTraexThreadTitle(sessionId);
+    }
   }
 
   // 5b. Fall back to the CLI process's own start time for uptime. Without
@@ -1051,6 +1064,7 @@ function resolveAdoptableSessionForPane(
     cliPid,
     cliId: match.cliId,
     sessionId,
+    title,
     cwd,
     startedAt,
     paneCols: dims.cols,

--- a/src/core/zellij-adopt-discovery.ts
+++ b/src/core/zellij-adopt-discovery.ts
@@ -21,7 +21,7 @@ import {
 } from './session-discovery.js';
 import { findCodexRolloutByPid } from '../services/codex-transcript.js';
 import { findCocoSessionByPid } from '../services/coco-transcript.js';
-import { findTraexRolloutByPid } from '../services/traex-transcript.js';
+import { findTraexRolloutByPid, readTraexThreadTitle } from '../services/traex-transcript.js';
 import { findServerPid } from '../adapters/backend/zellij-backend.js';
 import {
   listLiveSessions, parseListPanesJson, type ListedPane,
@@ -38,6 +38,7 @@ export interface ZellijAdoptableSession {
   cliPid: number;          // resolved CLI process pid
   cliId: CliId;
   sessionId?: string;      // CLI-native session id (claude/codex/coco)
+  title?: string;          // CLI-native title when available
   cwd: string;             // CLI working directory
   startedAt?: number;      // epoch ms (claude only)
   paneCols: number;
@@ -177,7 +178,7 @@ function paneDimensions(session: string, paneId: string): { cols: number; rows: 
   }
 }
 
-function resolveSessionId(cliId: CliId, pid: number): { sessionId?: string; startedAt?: number } {
+function resolveSessionId(cliId: CliId, pid: number): { sessionId?: string; title?: string; startedAt?: number } {
   if (cliId === 'claude-code') {
     const meta = readClaudeSessionMeta(pid);
     return { sessionId: meta?.sessionId, startedAt: meta?.startedAt };
@@ -192,7 +193,10 @@ function resolveSessionId(cliId: CliId, pid: number): { sessionId?: string; star
   }
   if (cliId === 'traex') {
     const rollout = findTraexRolloutByPid(pid);
-    return { sessionId: rollout?.cliSessionId };
+    return {
+      sessionId: rollout?.cliSessionId,
+      title: rollout?.cliSessionId ? readTraexThreadTitle(rollout.cliSessionId) : undefined,
+    };
   }
   return {};
 }
@@ -248,13 +252,14 @@ export function discoverAdoptableZellijSessions(
       const dims = paneDimensions(session, terminals[i]!.paneId);
       if (!dims) continue;
 
-      const { sessionId, startedAt } = resolveSessionId(cli.cliId, cli.pid);
+      const { sessionId, title, startedAt } = resolveSessionId(cli.cliId, cli.pid);
       results.push({
         zellijSession: session,
         zellijPaneId: terminals[i]!.paneId,
         cliPid: cli.pid,
         cliId: cli.cliId,
         sessionId,
+        title,
         cwd: cli.cwd ?? '',
         // Same uptime fallback as the tmux path: only Claude carries startedAt
         // from its session JSON, so derive it from the process for everyone else.

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -2396,7 +2396,7 @@ export function buildAdoptEntries(
       kind: 'live' as const,
       cliId: s.cliId,
       ...(customName && s.cliId === resumeCliId ? { cliDisplayName: customName } : {}),
-      title: project,
+      title: s.title || project,
       project,
       cwd: s.cwd,
       sessionId: s.sessionId,

--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -485,24 +485,88 @@ function rolloutResponseItemText(payload: Record<string, unknown>): string {
   return parts.join('').trim();
 }
 
-/** Parse one Codex/TRAE rollout. `session_meta` carries the resume id + cwd.
- *  Title preference: the first `event_msg`/`user_message` (legacy format); when
- *  absent (Codex >=0.147), the first non-synthetic `response_item` role:user
- *  message — skipping the startup preamble and botmux-injected turns (which mark
- *  the whole session botmux-origin, same as the user_message path). Streamed
- *  line by line, stopping once id + cwd + title are found. */
+/** TraeX 0.201.7 persists the canonical conversation stream inside
+ *  history_mutation.payload.items. Return every user message in one append so
+ *  the synthetic startup item can be skipped before the real prompt. */
+function rolloutHistoryMutationUserTexts(payload: Record<string, unknown>): string[] {
+  if ((payload.operation !== 'append' && payload.operation !== 'replace')
+    || !Array.isArray(payload.items)) return [];
+  const texts: string[] = [];
+  for (const item of payload.items) {
+    const message = asRecord(item);
+    if (message?.type !== 'message' || message.role !== 'user') continue;
+    const text = rolloutResponseItemText(message);
+    if (text) texts.push(text);
+  }
+  return texts;
+}
+
+/** TraeX 0.201.4 mirrors genuine user input as item_completed/UserMessage. */
+function rolloutCompletedUserText(payload: Record<string, unknown>): string {
+  const item = asRecord(payload.item);
+  if (item?.type !== 'UserMessage' || !Array.isArray(item.content)) return '';
+  const parts: string[] = [];
+  for (const block of item.content) {
+    const text = asRecord(block);
+    if (text?.type === 'text' && typeof text.text === 'string') parts.push(text.text);
+  }
+  return parts.join('').trim();
+}
+
+export interface RolloutSessionMetadata {
+  title?: string;
+  firstUserMessage?: string;
+  cwd?: string;
+  lastActivityAt?: number;
+}
+
+export interface RolloutDiscoveryOptions {
+  /** TraeX writes canonical user turns in history_mutation (0.201.7) or
+   *  item_completed/UserMessage (0.201.4). Top-level response_item role:user
+   *  records are only a final compatibility fallback for that dialect. */
+  dialect?: 'codex' | 'traex';
+  /** Native index metadata keyed by session id. TraeX's state DB title wins
+   *  over a title inferred from the first prompt, preserving /rename. */
+  metadataById?: ReadonlyMap<string, RolloutSessionMetadata>;
+}
+
+/** Parse one Codex/TRAE rollout. session_meta carries the resume id + cwd.
+ *  Codex titles come from event_msg/user_message or response_item role:user.
+ *  TraeX additionally uses its canonical history_mutation or item_completed
+ *  user record; response_item stays a weak fallback because TraeX also writes
+ *  runtime injections there. Native index metadata may override the inferred
+ *  title while the canonical first prompt still decides botmux ownership. */
 async function parseRolloutTranscript(
   path: string,
   mtimeMs: number,
   exclude?: ReadonlySet<string>,
+  options: RolloutDiscoveryOptions = {},
 ): Promise<ResumableSession | null> {
   // Accumulate into an object — closure mutation of plain `let` defeats TS's
   // control-flow narrowing at the post-loop guard; object properties keep their
   // declared type.
-  const acc: { id: string | null; cwd: string | null; title: string; fallbackTitle: string; botmux: boolean } = {
-    id: null, cwd: null, title: '', fallbackTitle: '', botmux: false,
+  const acc: {
+    id: string | null;
+    cwd: string | null;
+    title: string;
+    fallbackTitle: string;
+    weakTitle: string;
+    botmux: boolean;
+    weakBotmux: boolean;
+  } = {
+    id: null, cwd: null, title: '', fallbackTitle: '', weakTitle: '', botmux: false, weakBotmux: false,
   };
   let excluded = false;
+  let nativeMetadata: RolloutSessionMetadata | undefined;
+  const recordCanonicalUserText = (text: string): boolean | undefined => {
+    if (!text || isSyntheticPreamble(text)) return;
+    if (isBotmuxInjected(text)) {
+      acc.botmux = true;
+      return true;
+    }
+    if (!acc.fallbackTitle) acc.fallbackTitle = truncateTitle(text);
+    return Boolean(acc.id && acc.cwd && acc.fallbackTitle);
+  };
   await forEachJsonLine(path, (rec) => {
     const payload = asRecord(rec.payload);
     if (rec.type === 'session_meta' && payload) {
@@ -511,11 +575,26 @@ async function parseRolloutTranscript(
         // The resume id lives on the very first line; bail immediately on a
         // live session so excluded rollouts cost a single line read.
         if (exclude?.has(payload.id)) { excluded = true; return true; }
+        nativeMetadata = options.metadataById?.get(payload.id);
       }
-      if (typeof payload.cwd === 'string') acc.cwd = payload.cwd;
+      if (typeof payload.cwd === 'string') acc.cwd = nativeMetadata?.cwd || payload.cwd;
+      if (nativeMetadata?.firstUserMessage) {
+        const stop = recordCanonicalUserText(nativeMetadata.firstUserMessage.trim());
+        if (stop) return true;
+      }
     } else if (rec.type === 'event_msg' && payload?.type === 'user_message' && typeof payload.message === 'string') {
       if (isBotmuxInjected(payload.message)) { acc.botmux = true; return true; } // botmux-origin → drop
       if (!acc.title) acc.title = truncateTitle(payload.message);
+    } else if (options.dialect === 'traex'
+      && rec.type === 'event_msg'
+      && payload?.type === 'item_completed') {
+      const stop = recordCanonicalUserText(rolloutCompletedUserText(payload));
+      if (stop) return true;
+    } else if (options.dialect === 'traex' && rec.type === 'history_mutation' && payload) {
+      for (const text of rolloutHistoryMutationUserTexts(payload)) {
+        const stop = recordCanonicalUserText(text);
+        if (stop) return true;
+      }
     } else if (rec.type === 'response_item' && payload?.type === 'message' && payload.role === 'user') {
       // New-format (>=0.147) fallback title source. The first meaningful user
       // turn determines origin, mirroring parseClaudeTranscript: a synthetic
@@ -525,25 +604,40 @@ async function parseRolloutTranscript(
       const text = rolloutResponseItemText(payload);
       if (!text) return; // empty / non-text content — not a title candidate
       if (isSyntheticPreamble(text)) return; // startup preamble, not a user turn
-      if (isBotmuxInjected(text)) { acc.botmux = true; return true; } // botmux-origin → drop
-      if (!acc.fallbackTitle) acc.fallbackTitle = truncateTitle(text);
+      if (isBotmuxInjected(text)) {
+        if (options.dialect !== 'traex') {
+          acc.botmux = true;
+          return true;
+        }
+        acc.weakBotmux = true;
+      } else if (!acc.weakTitle) {
+        acc.weakTitle = truncateTitle(text);
+      }
       // 新格式（>=0.147）rollout 没有 event_msg/user_message，acc.title 永远
       // 为空：不含 fallbackTitle 会扫满 MAX_HEAD_LINES_PER_FILE。首个真实用户
       // 回合即定 origin（与 legacy 路径「id+cwd+title 齐即停扫」一致）；混合
       // 格式文件中 legacy 条目按时间序在前，acc.title 会先命中早退，不受影响。
-      if (acc.id && acc.cwd && acc.fallbackTitle) return true;
+      if (options.dialect !== 'traex' && acc.id && acc.cwd && acc.weakTitle) return true;
     }
     return Boolean(acc.id && acc.cwd && acc.title);
   });
-  const title = acc.title || acc.fallbackTitle;
-  if (excluded || acc.botmux || !acc.id || !acc.cwd || !title) return null;
-  return { cliSessionId: acc.id, cwd: acc.cwd, title, lastActivityAt: mtimeMs };
+  const inferredTitle = acc.title || acc.fallbackTitle || acc.weakTitle;
+  const title = truncateTitle(nativeMetadata?.title ?? inferredTitle);
+  const botmux = acc.botmux || (!acc.title && !acc.fallbackTitle && acc.weakBotmux);
+  if (excluded || botmux || !acc.id || !acc.cwd || !title) return null;
+  return {
+    cliSessionId: acc.id,
+    cwd: nativeMetadata?.cwd || acc.cwd,
+    title,
+    lastActivityAt: nativeMetadata?.lastActivityAt ?? mtimeMs,
+  };
 }
 
 export async function discoverRolloutSessions(
   sessionsRoot: string,
   limit: number,
   exclude?: ReadonlySet<string>,
+  options: RolloutDiscoveryOptions = {},
 ): Promise<ResumableSession[]> {
   // The resume id is inside the file (not the filename), so we can't pre-filter
   // by name. Instead walk most-recent-first and parse until `limit` non-excluded
@@ -553,7 +647,7 @@ export async function discoverRolloutSessions(
   const out: ResumableSession[] = [];
   for (const f of files) {
     if (out.length >= limit) break;
-    const s = await parseRolloutTranscript(f.path, f.mtimeMs, exclude);
+    const s = await parseRolloutTranscript(f.path, f.mtimeMs, exclude, options);
     if (s) out.push(s);
   }
   return out;

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -99,11 +99,11 @@ type DatabaseSyncLike = {
   close(): void;
 };
 type StatementSyncLike = {
+  get(...params: unknown[]): any;
   all(...params: unknown[]): any[];
 };
 
-function withTraeDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
-  const dbPath = traeStateDbPath();
+function withTraeDb<T>(fn: (db: DatabaseSyncLike) => T, dbPath = traeStateDbPath()): T | null {
   if (!existsSync(dbPath)) return null;
   // Runtime-agnostic open: `node:sqlite` on Node, `bun:sqlite` on the compiled
   // single-file binary. This MUST NOT go back to requiring `node:sqlite`
@@ -117,7 +117,7 @@ function withTraeDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
   // logic had moved here from the traex adapter — where the Bun fix lived. A
   // clean merge is not a correct merge; re-check this call whenever the file
   // moves again.
-  const db = openDatabaseSyncNow(dbPath) as DatabaseSyncLike | null;
+  const db = openDatabaseSyncNow(dbPath, { readOnly: true }) as DatabaseSyncLike | null;
   if (!db) return null;
   try {
     return fn(db);
@@ -126,6 +126,91 @@ function withTraeDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
   } finally {
     try { db.close(); } catch { /* ignore */ }
   }
+}
+
+export interface TraexThreadMetadata {
+  id: string;
+  title?: string;
+  firstUserMessage?: string;
+  cwd?: string;
+  rolloutPath?: string;
+  updatedAtMs?: number;
+}
+
+type TraexThreadMetadataRow = {
+  id?: unknown;
+  title?: unknown;
+  firstUserMessage?: unknown;
+  cwd?: unknown;
+  rolloutPath?: unknown;
+  updatedAt?: unknown;
+};
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function traexUpdatedAtMs(value: unknown): number | undefined {
+  const timestamp = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return undefined;
+  return timestamp >= 1_000_000_000_000 ? timestamp : timestamp * 1000;
+}
+
+function normalizeTraexThreadMetadata(
+  row: TraexThreadMetadataRow | undefined,
+): TraexThreadMetadata | undefined {
+  const id = nonEmptyString(row?.id);
+  if (!id) return undefined;
+  const title = nonEmptyString(row?.title);
+  const firstUserMessage = nonEmptyString(row?.firstUserMessage);
+  const cwd = nonEmptyString(row?.cwd);
+  const rolloutPath = nonEmptyString(row?.rolloutPath);
+  const updatedAtMs = traexUpdatedAtMs(row?.updatedAt);
+  return {
+    id,
+    ...(title ? { title } : {}),
+    ...(firstUserMessage ? { firstUserMessage } : {}),
+    ...(cwd ? { cwd } : {}),
+    ...(rolloutPath ? { rolloutPath } : {}),
+    ...(updatedAtMs ? { updatedAtMs } : {}),
+  };
+}
+
+const TRAEX_THREAD_METADATA_SELECT =
+  'SELECT id, title, first_user_message AS firstUserMessage, cwd, ' +
+  'rollout_path AS rolloutPath, updated_at AS updatedAt FROM threads';
+
+/** Read TraeX's authoritative resume-picker metadata. The title column is what
+ *  TraeX itself shows in resume, including names assigned through /rename.
+ *  Best-effort: older/missing/corrupt databases return an empty map and callers
+ *  fall back to parsing rollout JSONL. */
+export function readTraexThreadMetadataIndex(
+  dbPath = traeStateDbPath(),
+): ReadonlyMap<string, TraexThreadMetadata> {
+  return withTraeDb((db) => {
+    const rows = db.prepare(TRAEX_THREAD_METADATA_SELECT).all() as TraexThreadMetadataRow[];
+    const out = new Map<string, TraexThreadMetadata>();
+    for (const row of rows) {
+      const metadata = normalizeTraexThreadMetadata(row);
+      if (metadata) out.set(metadata.id, metadata);
+    }
+    return out;
+  }, dbPath) ?? new Map<string, TraexThreadMetadata>();
+}
+
+/** Resolve one live TraeX session's native title for the /adopt picker. */
+export function readTraexThreadTitle(
+  cliSessionId: string,
+  dbPath = traeStateDbPath(),
+): string | undefined {
+  if (!cliSessionId) return undefined;
+  return withTraeDb((db) => {
+    const row = db.prepare(TRAEX_THREAD_METADATA_SELECT + ' WHERE id = ? LIMIT 1')
+      .get(cliSessionId) as TraexThreadMetadataRow | undefined;
+    const title = normalizeTraexThreadMetadata(row)?.title?.replace(/\s+/g, ' ').trim();
+    if (!title) return undefined;
+    return title.length > 80 ? title.slice(0, 79) + '…' : title;
+  }, dbPath) ?? undefined;
 }
 
 type TraexRolloutKind = 'user' | 'internal' | 'legacy' | 'empty' | 'pending';

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -113,6 +113,25 @@ describe('buildAdoptSelectCard (V2 picker)', () => {
     expect(texts[0]).not.toContain('Session ID:');
   });
 
+  it('renders a native title for a live TraeX session instead of the project directory', () => {
+    const card = parse(buildAdoptSelectCard([{
+      source: 'tmux',
+      tmuxTarget: 'traex:0.0',
+      cliPid: 42,
+      cliId: 'traex',
+      sessionId: 'traex-session-id',
+      title: 'Investigate rollout title metadata',
+      cwd: '/Users/test/project-dir',
+      paneCols: 120,
+      paneRows: 40,
+    }], 'om_root', 'en'));
+
+    const texts = cardTexts(card);
+    expect(texts).toHaveLength(1);
+    expect(texts[0]).toContain('Investigate rollout title metadata');
+    expect(texts[0]).not.toMatch(/^\*\*project-dir\*\*/);
+  });
+
   it('renders a resume (history) session card with a hidden session id and a resume: key', () => {
     const card = parse(buildAdoptSelectCard(
       [],

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -530,6 +530,110 @@ describe('discoverRolloutSessions (codex / traex)', () => {
     ]);
     expect(await discoverRolloutSessions(sessionsRoot, 10)).toEqual([]);
   });
+
+  it('reads TraeX 0.201.7 user messages from history_mutation records', async () => {
+    writeRollout('2026/08/29', 'rollout-traex-history-mutation.jsonl', [
+      { type: 'session_meta', payload: { id: 'traex-history-mutation', cwd: '/root/traex' } },
+      { type: 'history_mutation', payload: { operation: 'append', items: [
+        { type: 'message', role: 'developer', content: [{ type: 'input_text', text: '<permissions instructions>...</permissions instructions>' }] },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '# AGENTS.md instructions for /root/traex\n\n<INSTRUCTIONS>repo guide</INSTRUCTIONS>' }] },
+      ] } },
+      { type: 'history_mutation', payload: { operation: 'append', items: [
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'show the native TraeX title' }] },
+      ] } },
+    ]);
+
+    const out = await discoverRolloutSessions(sessionsRoot, 10, undefined, { dialect: 'traex' });
+    expect(out).toEqual([
+      expect.objectContaining({
+        cliSessionId: 'traex-history-mutation',
+        cwd: '/root/traex',
+        title: 'show the native TraeX title',
+      }),
+    ]);
+  });
+
+  it('reads compacted TraeX history from a history_mutation replace snapshot', async () => {
+    writeRollout('2026/08/29', 'rollout-traex-history-replace.jsonl', [
+      { type: 'session_meta', payload: { id: 'traex-history-replace', cwd: '/root/traex' } },
+      { type: 'history_mutation', payload: { operation: 'replace', items: [
+        { type: 'message', role: 'developer', content: [{ type: 'input_text', text: '<permissions instructions>...</permissions instructions>' }] },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: '# AGENTS.md instructions for /root/traex' }] },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'resume this compacted conversation' }] },
+      ] } },
+    ]);
+
+    const out = await discoverRolloutSessions(sessionsRoot, 10, undefined, { dialect: 'traex' });
+    expect(out).toEqual([
+      expect.objectContaining({
+        cliSessionId: 'traex-history-replace',
+        title: 'resume this compacted conversation',
+      }),
+    ]);
+  });
+
+  it('drops botmux-origin TraeX history_mutation sessions', async () => {
+    writeRollout('2026/08/29', 'rollout-traex-botmux.jsonl', [
+      { type: 'session_meta', payload: { id: 'traex-botmux', cwd: '/root/traex' } },
+      { type: 'history_mutation', payload: { operation: 'append', items: [
+        { type: 'message', role: 'user', content: [{
+          type: 'input_text',
+          text: '<botmux_routing>route through Lark</botmux_routing>\n<session_id>botmux-id</session_id>\n<user_message>hello</user_message>',
+        }] },
+      ] } },
+    ]);
+
+    expect(await discoverRolloutSessions(sessionsRoot, 10, undefined, { dialect: 'traex' })).toEqual([]);
+  });
+
+  it('prefers TraeX native index title and activity metadata over inferred rollout values', async () => {
+    writeRollout('2026/08/29', 'rollout-traex-renamed.jsonl', [
+      { type: 'session_meta', payload: { id: 'traex-renamed', cwd: '/old/cwd' } },
+      { type: 'history_mutation', payload: { operation: 'append', items: [
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'original prompt' }] },
+      ] } },
+    ]);
+    const metadataById = new Map([['traex-renamed', {
+      title: 'Renamed in TraeX',
+      firstUserMessage: 'original prompt',
+      cwd: '/current/cwd',
+      lastActivityAt: 1_787_900_000_000,
+    }]]);
+
+    const out = await discoverRolloutSessions(sessionsRoot, 10, undefined, {
+      dialect: 'traex',
+      metadataById,
+    });
+    expect(out).toEqual([{
+      cliSessionId: 'traex-renamed',
+      cwd: '/current/cwd',
+      title: 'Renamed in TraeX',
+      lastActivityAt: 1_787_900_000_000,
+    }]);
+  });
+
+  it('still drops botmux-owned TraeX sessions when the native index has a title', async () => {
+    writeRollout('2026/08/29', 'rollout-traex-native-botmux.jsonl', [
+      { type: 'session_meta', payload: { id: 'traex-native-botmux', cwd: '/root/traex' } },
+      { type: 'history_mutation', payload: { operation: 'append', items: [{
+        type: 'message',
+        role: 'user',
+        content: [{
+          type: 'input_text',
+          text: '<session_id>botmux-id</session_id>\n<user_message>hello</user_message>',
+        }],
+      }] } },
+    ]);
+    const metadataById = new Map([['traex-native-botmux', {
+      title: 'Native title must not bypass ownership filtering',
+      firstUserMessage: '<session_id>botmux-id</session_id>\n<user_message>hello</user_message>',
+    }]]);
+
+    expect(await discoverRolloutSessions(sessionsRoot, 10, undefined, {
+      dialect: 'traex',
+      metadataById,
+    })).toEqual([]);
+  });
 });
 
 describe('discoverAntigravitySessions', () => {

--- a/test/traex-adapter-submit.test.ts
+++ b/test/traex-adapter-submit.test.ts
@@ -3,6 +3,7 @@ import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'n
 import { spawn, type ChildProcess } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 import type { PtyHandle } from '../src/adapters/cli/types.js';
 
@@ -302,5 +303,42 @@ describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
 
     expect(adapter.asksViaHook).toBe(false);
     expect(adapter.hookInstall).toBeUndefined();
+  });
+
+  it('lists TraeX history_mutation sessions with the native indexed title', async () => {
+    const sessionsDir = join(traeHome, 'cli', 'sessions', '2026', '08', '29');
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(join(sessionsDir, 'rollout-2026-08-29T10-00-00-' + SID_1 + '.jsonl'), [
+      JSON.stringify({ type: 'session_meta', payload: { id: SID_1, cwd: '/old/project' } }),
+      JSON.stringify({ type: 'history_mutation', payload: { operation: 'append', items: [{
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'the original prompt' }],
+      }] } }),
+      '',
+    ].join('\n'));
+
+    const db = new DatabaseSync(join(traeHome, 'cli', 'state_5.sqlite'));
+    db.exec([
+      'CREATE TABLE threads (',
+      '  id TEXT PRIMARY KEY,',
+      '  title TEXT NOT NULL,',
+      '  first_user_message TEXT NOT NULL,',
+      '  cwd TEXT NOT NULL,',
+      '  rollout_path TEXT NOT NULL,',
+      '  updated_at INTEGER NOT NULL',
+      ');',
+      "INSERT INTO threads VALUES ('" + SID_1 + "', 'Native TraeX title', 'the original prompt', '/current/project', '/tmp/rollout.jsonl', 1787900000);",
+    ].join('\n'));
+    db.close();
+
+    const rows = await createTraexAdapter('/bin/traex').listResumableSessions!({ limit: 10 });
+
+    expect(rows).toEqual([{
+      cliSessionId: SID_1,
+      cwd: '/current/project',
+      title: 'Native TraeX title',
+      lastActivityAt: 1_787_900_000_000,
+    }]);
   });
 });

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
 import { CODEX_CONNECTION_ERROR_CODE, CODEX_RATE_LIMIT_ERROR_CODE } from '../src/services/codex-transcript.js';
 import {
@@ -15,6 +16,8 @@ import {
   traexHistoryMatchDelta,
   traexHistorySize,
   traexHistorySidIsOwned,
+  readTraexThreadMetadataIndex,
+  readTraexThreadTitle,
 } from '../src/services/traex-transcript.js';
 
 const SID = '00000000-0000-7000-8000-000000000001';
@@ -1045,5 +1048,40 @@ describe('traexHistorySidIsOwned (ownership gate predicate)', () => {
 
   it('fails closed on an empty set (pid holds no TRAE rollout)', () => {
     expect(traexHistorySidIsOwned(OWNED, new Set())).toBe(false);
+  });
+});
+
+describe('TraeX native thread metadata', () => {
+  it('reads authoritative titles and normalises second timestamps to milliseconds', () => {
+    const dbPath = join(dir, 'state_5.sqlite');
+    const db = new DatabaseSync(dbPath);
+    db.exec([
+      'CREATE TABLE threads (',
+      '  id TEXT PRIMARY KEY,',
+      '  title TEXT NOT NULL,',
+      '  first_user_message TEXT NOT NULL,',
+      '  cwd TEXT NOT NULL,',
+      '  rollout_path TEXT NOT NULL,',
+      '  updated_at INTEGER NOT NULL',
+      ');',
+      "INSERT INTO threads VALUES ('traex-native-id', 'Native renamed title', 'original prompt', '/root/current', '/root/rollout.jsonl', 1787900000);",
+    ].join('\n'));
+    db.close();
+
+    expect(readTraexThreadMetadataIndex(dbPath).get('traex-native-id')).toEqual({
+      id: 'traex-native-id',
+      title: 'Native renamed title',
+      firstUserMessage: 'original prompt',
+      cwd: '/root/current',
+      rolloutPath: '/root/rollout.jsonl',
+      updatedAtMs: 1_787_900_000_000,
+    });
+    expect(readTraexThreadTitle('traex-native-id', dbPath)).toBe('Native renamed title');
+  });
+
+  it('returns empty metadata when the state DB is absent', () => {
+    const dbPath = join(dir, 'missing-state.sqlite');
+    expect(readTraexThreadMetadataIndex(dbPath).size).toBe(0);
+    expect(readTraexThreadTitle('missing', dbPath)).toBeUndefined();
   });
 });


### PR DESCRIPTION
修复 /adopt 接入 TraeX 会话时历史标题缺失或退化为工作目录的问题。

## 问题

TraeX 0.201.7 将规范用户消息写在 history_mutation.payload.items[]，但 resume discovery 仍只识别旧的 event_msg/user_message 与顶层 response_item role=user。因此大部分新版 TraeX rollout 无法进入历史候选。同时 live 候选始终用 cwd 末级目录作为标题，没有利用 TraeX state_5.sqlite 中的 threads.title。

## 改动

- TraeX resume discovery 支持 history_mutation 的 append / replace 快照，以及 0.201.4 的 item_completed/UserMessage。
- 从 TraeX state_5.sqlite 只读加载 threads 元数据，原生 title（包括 /rename）优先于首条 prompt 推断值。
- live tmux / Herdr / Zellij TraeX 候选通过 session id 补充原生标题；缺失时继续回退到项目目录。
- 保留 Botmux-origin 会话过滤，并覆盖 native title 不得绕过该过滤的回归场景。

## 影响面

- 解析扩展通过 dialect=traex 隔离，Codex 及其他 CLI 的既有解析路径不变。
- SQLite 读取为只读、best-effort；数据库缺失、旧 schema 或读取失败时回退 rollout 解析。
- 只影响 /adopt 的候选发现与展示，不改变 resume/adopt 执行语义。
- 卡片布局没有变化，仅把 TraeX live 候选标题从项目目录替换为原生会话标题，因此未附 UI 截图。

## 验证

- bun run build：通过。
- 定向单测：6 个文件、417 项全部通过。
- 完整 unit suite：18,864 项通过；并行构建导致 4 个依赖 dist/cli.js 的 suite 首轮失败，构建后重跑均通过；另有 1 个与本改动无关的 Pi/tmux 集成测试在 15 秒超时，单独重跑仍超时。
- 本机真实 TraeX 0.201.7 数据：新版实现识别 27 个历史候选，标题异常数 0；修复前同一 parser 只能识别 4 个。
