### PR TITLE
fix(update): 编译版二进制的更新路径按安装形态分流

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,7 +151,10 @@ import {
   resolveGlobalInstallPlan,
   UnsupportedGlobalInstallError,
 } from './utils/global-install.js';
-import { isLocalDevInstall, botmuxCliEntryAt, bakedBinaryVersion } from './utils/install-info.js';
+import { isLocalDevInstall, botmuxCliEntryAt, bakedBinaryVersion, botmuxInstallRoot } from './utils/install-info.js';
+import { currentUpdateStrategy, replaceStandaloneBinary } from './core/binary-self-update.js';
+import { fetchLatestVersion, isNewerVersion } from './core/update-check.js';
+import { resolveCurrentVersion } from './utils/install-diagnostics.js';
 import {
   resolveLocalDevCheckoutDir,
   isGitWorktree,
@@ -3009,7 +3012,7 @@ async function cmdStatus(): Promise<void> {
   // warnIfLegacyBotmuxAlive above, which is what a pre-migration host needs.
 }
 
-function cmdUpgrade(): void {
+async function cmdUpgrade(): Promise<void> {
   // 本地 checkout（有 .git/src）：走 git pull --ff-only → 重新 build → 从本
   // checkout 重启，而不是拿全局包管理器去升级（那对 dev 部署无效，见
   // install-info.ts 的 isLocalDevInstall 说明）。
@@ -3017,8 +3020,36 @@ function cmdUpgrade(): void {
     cmdUpgradeLocalDev();
     return;
   }
+  // 编译版单文件二进制没有 package.json 落盘 ⟹ resolveGlobalInstallPlan 恒抛
+  // Unsupported（实测真实 v3.18.4 二进制就是这条）。改为先按「二进制装在哪」
+  // 判形态：npm 子包形态交回 npm/pnpm/bun，install.sh 形态自己换二进制。
+  const strategy = currentUpdateStrategy(botmuxInstallRoot());
+  if (strategy.kind === 'self-replace') {
+    try {
+      const latest = await fetchLatestVersion();
+      if (!latest) {
+        console.error('❌ 无法获取最新版本号（网络不可达或 registry 异常）。');
+        process.exit(1);
+      }
+      const current = resolveCurrentVersion();
+      if (!isNewerVersion(latest, current)) {
+        console.log(`✅ 已是最新版本（${current}）。`);
+        return;
+      }
+      console.log(`🔄 升级中：下载 v${latest} 二进制并替换 ${strategy.target}`);
+      const r = await replaceStandaloneBinary(latest, strategy.target);
+      console.log(`✅ 升级完成：${r.asset} → ${r.target}（${current} → ${latest}）。运行 botmux restart 以应用更新。`);
+    } catch (error) {
+      console.error(`❌ 升级失败：${error instanceof Error ? error.message : error}`);
+      process.exit(1);
+    }
+    return;
+  }
   try {
-    const plan = resolveGlobalInstallPlan();
+    if (strategy.kind === 'unsupported') {
+      throw new UnsupportedGlobalInstallError('unknown', process.execPath);
+    }
+    const plan = resolveGlobalInstallPlan(strategy.packageRoot);
     console.log(`🔄 升级中：${formatGlobalInstallCommand(plan)}`);
     installLatestBotmuxSync(plan);
     console.log('\n✅ 升级完成。运行 botmux restart 以应用更新。');
@@ -12066,6 +12097,38 @@ if (__entrySubcommand) {
   await new Promise<never>(() => {});
 }
 
+// Hidden: perform a compiled-binary self-replace and exit. Invoked by
+// `runSelfReplaceBlocking` (src/core/maintenance.ts) so the synchronous
+// maintenance tick / dashboard handler can wait on one child instead of
+// restructuring around an await. Not a user-facing command; it only ever makes
+// sense for the standalone binary, which owns its own file.
+if (command === '__self-update') {
+  const requested = process.argv[3] || 'latest';
+  try {
+    const { replaceStandaloneBinary, currentBinaryInstallShape } = await import('./core/binary-self-update.js');
+    if (currentBinaryInstallShape() !== 'curl-binary') {
+      // Fail closed rather than write into a tree a package manager owns.
+      console.error('__self-update: 当前不是独立二进制安装（install.sh 形态），拒绝自替换');
+      process.exit(1);
+    }
+    const { fetchLatestVersion } = await import('./core/update-check.js');
+    const version = requested === 'latest' ? await fetchLatestVersion() : requested;
+    if (!version) {
+      console.error('__self-update: 无法解析最新版本（网络不可达或 registry 异常）');
+      process.exit(1);
+    }
+    const r = await replaceStandaloneBinary(version);
+    // The caller parses this line: after a self-replace the running process still
+    // reports its OWN baked version, so it cannot discover the new one by re-reading.
+    console.log(`BOTMUX_SELF_UPDATE_VERSION=${version}`);
+    console.log(`__self-update: ${r.asset} → ${r.target} (${r.bytes} bytes)`);
+    process.exit(0);
+  } catch (error) {
+    console.error(`__self-update: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+}
+
 
 const ROOT_FLEET_MUTATION_COMMANDS = new Set(['start', 'stop', 'restart', 'upgrade', 'update']);
 if (
@@ -12910,7 +12973,7 @@ switch (command) {
   case 'logs':    await cmdLogs(); break;
   case 'status':  await cmdStatus(); break;
   case 'upgrade':
-  case 'update':  cmdUpgrade(); break;
+  case 'update':  await cmdUpgrade(); break;
   case 'dashboard': await cmdDashboard(process.argv.slice(3)); break;
   case 'bind': {
     // `botmux bind <code>` — 把本机绑定到中心化平台

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3037,8 +3037,21 @@ async function cmdUpgrade(): Promise<void> {
         return;
       }
       console.log(`🔄 升级中：下载 v${latest} 二进制并替换 ${strategy.target}`);
-      const r = await replaceStandaloneBinary(latest, strategy.target);
-      console.log(`✅ 升级完成：${r.asset} → ${r.target}（${current} → ${latest}）。运行 botmux restart 以应用更新。`);
+      // 握与 dashboard / maintenance 同一把跨进程锁：这条路径是**写同一个文件**，
+      // 两个 update 并发跑会互相盖掉临时文件与 rename。锁文件父目录可能还不存在
+      // （daemon 从未在本机起过就先跑 update），先建再握，否则 ENOENT 会盖掉真实错误。
+      const lockTarget = globalInstallUpdateLockTarget();
+      mkdirSync(dirname(lockTarget), { recursive: true });
+      let acquired = false;
+      await withFileLock(lockTarget, async () => {
+        acquired = true;
+        const r = await replaceStandaloneBinary(latest, strategy.target);
+        console.log(`✅ 升级完成：${r.asset} → ${r.target}（${current} → ${latest}）。运行 botmux restart 以应用更新。`);
+      }, { maxWaitMs: 2_000 });
+      if (!acquired) {
+        console.error('❌ 另一个更新正在进行中（dashboard 或定时任务），请稍后重试。');
+        process.exit(1);
+      }
     } catch (error) {
       console.error(`❌ 升级失败：${error instanceof Error ? error.message : error}`);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,7 @@ import { hasProtectedSessionMutationOwnership } from './core/session-mutation-gu
 import type { BackendType, PersistentBackendTarget, SessionProbe } from './adapters/backend/types.js';
 import { logger } from './utils/logger.js';
 import { reapLegacyPm2, liveGodAt } from './core/legacy-pm2-reaper.js';
-import { withFileLock, withFileLockSync } from './utils/file-lock.js';
+import { withFileLock, withFileLockSync, FileLockTimeoutError } from './utils/file-lock.js';
 import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional, hasFlagOrEq } from './cli/arg-utils.js';
@@ -3050,15 +3050,22 @@ async function cmdUpgrade(): Promise<void> {
           console.log(`✅ 升级完成：${r.asset} → ${r.target}（${current} → ${latest}）。运行 botmux restart 以应用更新。`);
         }, { maxWaitMs: 2_000 });
       } catch (error) {
-        // ⚠️ withFileLock 拿不到锁时是 **抛异常**，不是安静返回 —— 所以「另一个更新
-        // 正在进行」这条提示必须在这里给。实测并发两个 `botmux update`：落败的那个
-        // 原先直接把内部信息透给用户（`file-lock timeout waiting for …lock (held by
-        // pid 630166, age 2222ms)`），而它其实是完全正常的互斥结果，不是故障。
-        if (!acquired) {
+        // ⚠️ 三态，不是二态。`withFileLock` 拿不到锁时是**抛异常**不是安静返回，
+        // 但 `acquired === false` 只证明「回调没执行」，**不等于「别人持锁」**：
+        // 回调之前还可能因 `open` 的 EACCES/ENOSPC、holder 写入失败、holder 元数据
+        // 不可读、stale-claim `link` 失败而抛错。只看 `acquired` 会把这些**真实故障
+        // 全部误报成「另一个更新正在进行」**——磁盘满被说成并发冲突，是最坏的那种
+        // 误导。所以必须同时要求它是 timeout 类型：
+        //   ① 超时且回调未进入        → 友好并发提示（正常互斥结果，不是故障）
+        //   ② 回调已进入后失败        → 透出真实错误（下载/校验/替换）
+        //   ③ 回调前的基础设施失败    → 同样透出真实错误
+        // 判类型而不是匹文案：file-lock 的文案被多处按字符串匹配，不能动，但新代码
+        // 应该用 FileLockTimeoutError（async/sync 两处语义一致）。
+        if (!acquired && error instanceof FileLockTimeoutError) {
           console.error('❌ 另一个更新正在进行中（dashboard 或定时任务），请稍后重试。');
           process.exit(1);
         }
-        throw error; // 已进入临界区后的真实失败（下载/校验/替换）交给外层统一报错
+        throw error; // ②③ 交给外层统一报错，不被友好文案吞掉
       }
     } catch (error) {
       console.error(`❌ 升级失败：${error instanceof Error ? error.message : error}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3043,14 +3043,22 @@ async function cmdUpgrade(): Promise<void> {
       const lockTarget = globalInstallUpdateLockTarget();
       mkdirSync(dirname(lockTarget), { recursive: true });
       let acquired = false;
-      await withFileLock(lockTarget, async () => {
-        acquired = true;
-        const r = await replaceStandaloneBinary(latest, strategy.target);
-        console.log(`✅ 升级完成：${r.asset} → ${r.target}（${current} → ${latest}）。运行 botmux restart 以应用更新。`);
-      }, { maxWaitMs: 2_000 });
-      if (!acquired) {
-        console.error('❌ 另一个更新正在进行中（dashboard 或定时任务），请稍后重试。');
-        process.exit(1);
+      try {
+        await withFileLock(lockTarget, async () => {
+          acquired = true;
+          const r = await replaceStandaloneBinary(latest, strategy.target);
+          console.log(`✅ 升级完成：${r.asset} → ${r.target}（${current} → ${latest}）。运行 botmux restart 以应用更新。`);
+        }, { maxWaitMs: 2_000 });
+      } catch (error) {
+        // ⚠️ withFileLock 拿不到锁时是 **抛异常**，不是安静返回 —— 所以「另一个更新
+        // 正在进行」这条提示必须在这里给。实测并发两个 `botmux update`：落败的那个
+        // 原先直接把内部信息透给用户（`file-lock timeout waiting for …lock (held by
+        // pid 630166, age 2222ms)`），而它其实是完全正常的互斥结果，不是故障。
+        if (!acquired) {
+          console.error('❌ 另一个更新正在进行中（dashboard 或定时任务），请稍后重试。');
+          process.exit(1);
+        }
+        throw error; // 已进入临界区后的真实失败（下载/校验/替换）交给外层统一报错
       }
     } catch (error) {
       console.error(`❌ 升级失败：${error instanceof Error ? error.message : error}`);

--- a/src/core/binary-install-shape.ts
+++ b/src/core/binary-install-shape.ts
@@ -1,0 +1,151 @@
+/**
+ * WHERE the running compiled binary lives — the pure, dependency-free half of the
+ * self-update story.
+ *
+ * Split out of `binary-self-update.ts` so it can be imported from
+ * `utils/global-install.ts` without closing an import cycle: the self-update
+ * module needs `restart-report` (for the repo slug) which reaches
+ * `utils/install-info.ts`, and `global-install.ts` is itself imported by
+ * `install-diagnostics.ts`. This file imports nothing but `node:os`/`node:path`
+ * plus the standalone check, so it is safe to depend on from anywhere.
+ *
+ * See `binary-self-update.ts` for the full rationale — in short: both installers
+ * ship the SAME compiled binary, so the module graph cannot tell them apart (both
+ * report an install root of `/`), and `process.execPath` can.
+ */
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { isStandaloneBinary } from './self-spawn.js';
+
+/**
+ * How the running compiled binary was installed, and therefore who owns updating it.
+ *
+ *  · `npm-binary`   — inside an npm/pnpm/Bun platform subpackage
+ *                     (`botmux-<plat>-<arch>[-musl]`). The manager owns the file;
+ *                     update by re-running it.
+ *  · `curl-binary`  — the standalone location install.sh writes. We own the file;
+ *                     update by replacing it.
+ *  · `unknown`      — anywhere else (a hand-copied binary, a distro package, a dev
+ *                     build run straight out of dist-bin/), or not a compiled
+ *                     binary at all. Fail closed.
+ */
+export type BinaryInstallShape = 'npm-binary' | 'curl-binary' | 'unknown';
+
+/** Default standalone install dir, matching install.sh's own default. */
+function defaultInstallDir(home: string): string {
+  return join(home, '.botmux', 'bin');
+}
+
+/**
+ * Classify a binary path. Pure — the caller passes the path and the relevant
+ * environment, so every shape is unit-testable without a real install.
+ *
+ * @param execPath  the running executable (`process.execPath`)
+ * @param env       consulted for `BOTMUX_INSTALL_DIR` (install.sh honours it)
+ * @param home      the home directory, for the default install dir
+ */
+export function classifyBinaryInstall(
+  execPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): BinaryInstallShape {
+  const path = execPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  if (!path) return 'unknown';
+
+  // Platform subpackage: <anything>/node_modules/botmux-<plat>-<arch>[-musl]/botmux
+  // Anchored on `/node_modules/` so a user directory that merely happens to be
+  // named `botmux-linux-x64` is not mistaken for a package-manager-owned tree.
+  if (/\/node_modules\/botmux-(?:linux|darwin)-(?:x64|arm64)(?:-musl)?\/botmux$/.test(path)) {
+    return 'npm-binary';
+  }
+
+  // The standalone install location. `BOTMUX_INSTALL_DIR` is what install.sh
+  // honours, so an install that used it must still be recognised — otherwise a
+  // custom-dir user silently loses self-update.
+  for (const raw of [env.BOTMUX_INSTALL_DIR, defaultInstallDir(home)]) {
+    if (!raw) continue;
+    const dir = raw.replace(/\\/g, '/').replace(/\/+$/, '');
+    if (dir && path === `${dir}/botmux`) return 'curl-binary';
+  }
+  return 'unknown';
+}
+
+/** Classify the running process. `unknown` for a non-compiled (Node) run, whose
+ *  updates go through the package-manager path instead. */
+export function currentBinaryInstallShape(): BinaryInstallShape {
+  if (!isStandaloneBinary()) return 'unknown';
+  return classifyBinaryInstall(process.execPath);
+}
+
+/**
+ * Map a platform-subpackage binary path to the MAIN `botmux` package root beside
+ * it (`…/node_modules/botmux-linux-x64/botmux` → `…/node_modules/botmux`).
+ *
+ * WHY GO THROUGH THE MAIN PACKAGE instead of computing an npm `--prefix` here:
+ * `resolveGlobalInstallPlan` already classifies that path shape into the right
+ * manager and builds the right command — including pnpm's `--global-dir`, Bun's
+ * env pinning, and the POSIX-vs-Windows prefix difference — and all of it is
+ * unit-tested. Re-deriving a prefix here would be a second, diverging
+ * implementation of the same rules. It also means `pnpm i -g` / `bun add -g`
+ * installs keep resolving to THEIR manager rather than being forced onto npm.
+ *
+ * Returns null when the shape does not match, so callers fail closed.
+ */
+export function mainPackageRootForSubpackageBinary(execPath: string): string | null {
+  const path = execPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  const m = /^(.*\/node_modules)\/botmux-(?:linux|darwin)-(?:x64|arm64)(?:-musl)?\/botmux$/.exec(path);
+  return m ? `${m[1]}/botmux` : null;
+}
+
+/**
+ * How the running process should update itself.
+ *
+ *  · `package-manager` — hand off to npm/pnpm/Bun for `packageRoot`. Covers both a
+ *    plain Node install AND a compiled binary living inside a package manager's
+ *    tree (the manager owns that file).
+ *  · `self-replace`    — download the release asset and swap the binary.
+ *  · `unsupported`     — could not identify the install; callers keep their
+ *                        existing "unsupported install" behaviour.
+ */
+export type UpdateStrategy =
+  | { kind: 'package-manager'; packageRoot: string }
+  | { kind: 'self-replace'; target: string }
+  | { kind: 'unsupported'; reason: 'unknown-binary-location' };
+
+/**
+ * Decide the update strategy. Pure over its inputs so every branch is testable
+ * without a compiled binary.
+ *
+ * The Node path is deliberately left EXACTLY as it was: when this is not a
+ * standalone binary we return the running install root and callers resolve it
+ * through `resolveGlobalInstallPlan` as before — no behaviour change for npm
+ * `dist/cli.js` deployments or source checkouts.
+ *
+ * @param standalone   is this a compiled single-file executable?
+ * @param execPath     the running executable
+ * @param installRoot  `botmuxInstallRoot()` — only meaningful when NOT standalone
+ */
+export function resolveUpdateStrategy(
+  standalone: boolean,
+  execPath: string,
+  installRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): UpdateStrategy {
+  if (!standalone) return { kind: 'package-manager', packageRoot: installRoot };
+  const shape = classifyBinaryInstall(execPath, env, home);
+  if (shape === 'npm-binary') {
+    const root = mainPackageRootForSubpackageBinary(execPath);
+    // The regex that produced `npm-binary` is the same one used here, so `root`
+    // cannot be null in practice; keep the guard so a future loosening of one
+    // pattern degrades to "unsupported" instead of dereferencing null.
+    if (root) return { kind: 'package-manager', packageRoot: root };
+  }
+  if (shape === 'curl-binary') return { kind: 'self-replace', target: execPath };
+  return { kind: 'unsupported', reason: 'unknown-binary-location' };
+}
+
+/** Production wiring for {@link resolveUpdateStrategy}. */
+export function currentUpdateStrategy(installRoot: string): UpdateStrategy {
+  return resolveUpdateStrategy(isStandaloneBinary(), process.execPath, installRoot);
+}

--- a/src/core/binary-install-shape.ts
+++ b/src/core/binary-install-shape.ts
@@ -60,8 +60,13 @@ export function classifyBinaryInstall(
   }
 
   // The standalone install location. `BOTMUX_INSTALL_DIR` is what install.sh
-  // honours, so an install that used it must still be recognised — otherwise a
-  // custom-dir user silently loses self-update.
+  // honours, so an install that used it is recognised WHEN THAT VARIABLE IS STILL
+  // EXPORTED at runtime. ⚠️ It usually is not: `BOTMUX_INSTALL_DIR=/opt/bm sh
+  // install.sh` sets it for the installer only, so a later `botmux update` sees a
+  // bare environment and this falls through to `unknown` — fail-closed, so nothing
+  // is damaged, but self-update is unavailable for that install. Do not describe
+  // custom dirs as unconditionally covered; making them work without the variable
+  // would need a persisted install record, which is out of scope here.
   for (const raw of [env.BOTMUX_INSTALL_DIR, defaultInstallDir(home)]) {
     if (!raw) continue;
     const dir = raw.replace(/\\/g, '/').replace(/\/+$/, '');

--- a/src/core/binary-self-update.ts
+++ b/src/core/binary-self-update.ts
@@ -203,6 +203,15 @@ export interface BinarySelfUpdateDeps {
  * download is discarded while the working binary is still in place. A release
  * that publishes no `.sha256` is a warning, not a failure — matching install.sh,
  * which has always tolerated that.
+ *
+ * ── WHY NO `realpathSync(target)` ─────────────────────────────────────────────
+ * Renaming over a SYMLINK replaces the link itself and orphans its target
+ * (measured). That would matter if `target` could be a symlink — but the default
+ * target is `process.execPath`, which the OS has already resolved: MEASURED with a
+ * compiled binary invoked through a symlink, `process.execPath` reports the real
+ * file, never the link. So the symlink case is unreachable on the production path,
+ * and resolving again would only add a failure mode of its own (an unreadable
+ * parent dir). install.sh's plain `mv` has the same semantics.
  */
 export async function replaceStandaloneBinary(
   version: string,

--- a/src/core/binary-self-update.ts
+++ b/src/core/binary-self-update.ts
@@ -1,0 +1,263 @@
+/**
+ * How the RUNNING compiled binary was installed, and how to update it.
+ *
+ * ── WHY THIS EXISTS ────────────────────────────────────────────────────────────
+ * Every pre-existing update path (`botmux update`, the dashboard's
+ * `/api/update/run`, the scheduled maintenance auto-update) asks
+ * `resolveGlobalInstallPlan(botmuxInstallRoot())` which package manager owns the
+ * install. That question is answered by looking at the install ROOT — the
+ * directory holding `package.json` — and classifying its path shape
+ * (`…/lib/node_modules/botmux` ⇒ npm, `…/.pnpm/…` ⇒ pnpm, …).
+ *
+ * A compiled single-file executable has NO package.json on disk: the module graph
+ * lives in the virtual read-only `/$bunfs/`, so `packageRoot()` walks up to `/`
+ * and stops. MEASURED on the real published v3.18.4 binary and on a locally
+ * compiled probe — identical in both:
+ *
+ *     botmuxInstallRoot()            → "/"
+ *     detectGlobalInstallManager("/") → "unknown"
+ *     resolveGlobalInstallPlan("/")   → throws UnsupportedGlobalInstallError
+ *     botmuxCliEntry()                → "/dist/cli.js"  (does not exist)
+ *
+ * So on the real shipped artifact `botmux update` printed
+ * “无法安全识别当前安装方式（unknown）” and exited, the dashboard button greyed out
+ * with “supports npm/pnpm/Bun global installs only”, and the scheduled
+ * auto-update failed every single day (fail-safe — it never restarts onto a stale
+ * version — but it marks the day done, so it does not even retry).
+ *
+ * ── THE KEY INSIGHT: BOTH INSTALLERS SHIP THE SAME BINARY ─────────────────────
+ * It is tempting to think “npm users update with npm, curl users update with
+ * curl”, i.e. that the two installers produce different artifacts. They do not.
+ * `npm i -g botmux` has NO `bin` field any more (removed in #1047): it downloads
+ * a platform subpackage and its postinstall writes `~/.botmux/bin/botmux` as a
+ * launcher that `exec`s that subpackage's compiled binary. `install.sh` downloads
+ * the very same compiled binary from the GitHub Release. Same bytes, different
+ * location — which is exactly why classifying by MODULE GRAPH cannot work (both
+ * report `/`) and classifying by LOCATION can.
+ *
+ * `process.execPath` is the location of the running executable, and it is the one
+ * thing that still differs. MEASURED, compiled binaries invoked through each
+ * installer's own launcher:
+ *
+ *   npm  → /usr/lib/node_modules/botmux-linux-x64/botmux       (subpackage dir)
+ *   curl → ~/.botmux/bin/botmux                                (BOTMUX_INSTALL_DIR)
+ *
+ * Note it is the REAL binary path in both cases, not the launcher's: the launcher
+ * `exec`s the binary, so the process's execPath is the target. Verified by
+ * running a compiled probe through a launcher of exactly the shape postinstall
+ * writes.
+ *
+ * ── WHAT EACH SHAPE DOES TO UPDATE ─────────────────────────────────────────────
+ *  · npm  → hand back to npm (`npm i -g botmux@latest`). npm replaces the
+ *           subpackage and re-runs postinstall, which re-points the launcher. We
+ *           must NOT rewrite the binary ourselves: npm owns that tree, and a
+ *           hand-written file there would be clobbered (or worse, left behind at
+ *           a version npm's metadata disagrees with).
+ *  · curl → replace the binary in place, the same way install.sh does: download
+ *           the matching asset, verify its published SHA-256, then atomically
+ *           rename over the target. Nothing else owns that path.
+ *
+ * A shape we cannot positively identify returns null, and every caller keeps its
+ * existing "unsupported install" behaviour. Fail closed: guessing wrong here
+ * means either writing into a tree npm owns, or downloading a binary for the
+ * wrong libc.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import {
+  createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync,
+  renameSync, rmSync, statSync, chmodSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { GITHUB_REPO } from './restart-report.js';
+import { getReleaseStream, resolveHttpProxy } from './release-download.js';
+
+/**
+ * Where the running compiled binary lives, and therefore who owns updating it.
+ * The pure location classifier lives in `binary-install-shape.ts` so
+ * `utils/global-install.ts` can import it without closing an import cycle through
+ * this module (which reaches install-info via restart-report). Re-exported here so
+ * callers have one obvious import site for the whole self-update surface.
+ */
+export {
+  classifyBinaryInstall,
+  currentBinaryInstallShape,
+  mainPackageRootForSubpackageBinary,
+  resolveUpdateStrategy,
+  currentUpdateStrategy,
+  type BinaryInstallShape,
+  type UpdateStrategy,
+} from './binary-install-shape.js';
+
+// ── Release asset selection ────────────────────────────────────────────────────
+
+/**
+ * Is this a musl libc host (Alpine and most slim Docker images)?
+ *
+ * WHY IT MATTERS: a glibc-linked binary does not run on musl at all — it dies in
+ * the loader with a message naming no cause. Downloading the wrong one turns a
+ * working install into a binary that cannot start, which is strictly worse than
+ * refusing to update.
+ *
+ * Mirrors the probe order in `scripts/postinstall-bin.mjs` and install.sh, and is
+ * deliberately conservative: only claim musl when positively observed, so a glibc
+ * box is never pushed onto the musl asset. Node's `process.report` header is a
+ * NEGATIVE signal only — measured on node:22-alpine it carries neither
+ * `glibcVersionRuntime` nor any musl key, so it can confirm glibc but never musl.
+ */
+export function isMuslHost(
+  platform: NodeJS.Platform = process.platform,
+  probes: {
+    glibcRuntime?: () => string | undefined;
+    listDir?: (dir: string) => string[];
+    exists?: (path: string) => boolean;
+  } = {},
+): boolean {
+  if (platform !== 'linux') return false;
+  const glibcRuntime = probes.glibcRuntime ?? (() => {
+    try {
+      return (process.report?.getReport?.() as { header?: { glibcVersionRuntime?: string } })
+        ?.header?.glibcVersionRuntime;
+    } catch { return undefined; }
+  });
+  const listDir = probes.listDir ?? ((dir: string) => {
+    try { return readdirSync(dir); } catch { return []; }
+  });
+  const exists = probes.exists ?? ((p: string) => {
+    try { return existsSync(p); } catch { return false; }
+  });
+
+  if (glibcRuntime()) return false; // a reported glibc runtime settles it
+  for (const dir of ['/lib', '/usr/lib']) {
+    if (listDir(dir).some(f => f.startsWith('ld-musl-'))) return true;
+  }
+  return exists('/etc/alpine-release');
+}
+
+/**
+ * The release asset name for a platform, matching the names release.yml uploads
+ * (`botmux-<os>-<arch>[-musl]`) and install.sh downloads. Returns null for a
+ * platform/arch with no published build rather than inventing a name that 404s.
+ */
+export function releaseAssetName(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+  musl: boolean = isMuslHost(platform),
+): string | null {
+  const os = platform === 'linux' ? 'linux' : platform === 'darwin' ? 'darwin' : null;
+  const cpu = arch === 'x64' ? 'x64' : arch === 'arm64' ? 'arm64' : null;
+  if (!os || !cpu) return null;
+  // Only linux ships musl variants; darwin has no such split.
+  return `botmux-${os}-${cpu}${os === 'linux' && musl ? '-musl' : ''}`;
+}
+
+/** Download base for a release tag, mirroring install.sh's URL construction. */
+export function releaseAssetBaseUrl(version: string): string {
+  return `https://github.com/${GITHUB_REPO}/releases/download/v${version.replace(/^v/i, '')}`;
+}
+
+// ── The self-update itself ─────────────────────────────────────────────────────
+
+const SELF_UPDATE_UA = 'botmux-self-update';
+
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(path), hash);
+  return hash.digest('hex');
+}
+
+export interface BinarySelfUpdateResult {
+  /** The asset that was installed. */
+  asset: string;
+  /** Absolute path that was replaced. */
+  target: string;
+  /** Bytes written. */
+  bytes: number;
+}
+
+export interface BinarySelfUpdateDeps {
+  /** Fetch a URL as a readable stream (injected for tests). */
+  fetchStream?: (url: string) => Promise<NodeJS.ReadableStream>;
+  /** Read the published checksum for `asset`, or null when none is published. */
+  fetchChecksum?: (url: string) => Promise<string | null>;
+}
+
+/**
+ * Replace the running standalone binary with `version`'s published asset.
+ *
+ * ── WHY A RENAME AND NOT A WRITE (do not "simplify" this) ─────────────────────
+ * MEASURED on Linux with a real ELF:
+ *
+ *   open(target,'r+b').write(…)  → OSError 26 ETXTBSY "Text file busy"
+ *   rename(new, target)          → succeeds; the running process keeps executing
+ *                                  the old inode and finishes normally
+ *
+ * So the update MUST land as a rename over the path, never an in-place write:
+ * the kernel refuses to let us scribble on the executable of a live process, and
+ * a rename is also what makes the swap atomic for anything about to `exec` it.
+ * The temp file is created in the SAME directory as the target so the rename is
+ * within one filesystem (a cross-device rename fails with EXDEV, and copying
+ * would reintroduce the torn-file window this avoids).
+ *
+ * Checksum verification happens BEFORE the rename, so a truncated or tampered
+ * download is discarded while the working binary is still in place. A release
+ * that publishes no `.sha256` is a warning, not a failure — matching install.sh,
+ * which has always tolerated that.
+ */
+export async function replaceStandaloneBinary(
+  version: string,
+  target: string = process.execPath,
+  deps: BinarySelfUpdateDeps = {},
+): Promise<BinarySelfUpdateResult> {
+  const asset = releaseAssetName();
+  if (!asset) {
+    throw new Error(`当前平台没有发布二进制（${process.platform}-${process.arch}）`);
+  }
+  const base = releaseAssetBaseUrl(version);
+  const proxy = resolveHttpProxy();
+  const fetchStream = deps.fetchStream
+    ?? (async (url: string) => await getReleaseStream(url, proxy, SELF_UPDATE_UA));
+  const fetchChecksum = deps.fetchChecksum ?? (async (url: string) => {
+    try {
+      const res = await getReleaseStream(url, proxy, SELF_UPDATE_UA);
+      const chunks: Buffer[] = [];
+      for await (const chunk of res) chunks.push(Buffer.from(chunk as Buffer));
+      // The file is "<sha256>  <filename>"; take the first field.
+      const first = Buffer.concat(chunks).toString('utf-8').trim().split(/\s+/)[0] ?? '';
+      return /^[0-9a-f]{64}$/i.test(first) ? first.toLowerCase() : null;
+    } catch {
+      return null; // no checksum published (or unreachable) → warn, don't fail
+    }
+  });
+
+  // Same directory as the target: keeps the rename intra-filesystem (EXDEV).
+  const dir = dirname(target);
+  mkdirSync(dir, { recursive: true });
+  const tmp = join(dir, `.botmux-update.${process.pid}.${randomBytes(4).toString('hex')}.tmp`);
+
+  try {
+    const res = await fetchStream(`${base}/${asset}`);
+    await pipeline(res, createWriteStream(tmp));
+    const expected = await fetchChecksum(`${base}/${asset}.sha256`);
+    if (expected) {
+      const actual = await sha256File(tmp);
+      if (actual !== expected) {
+        throw new Error(`${asset} SHA-256 校验不通过（期望 ${expected}，实际 ${actual}）`);
+      }
+    }
+    const bytes = statSync(tmp).size;
+    // A truncated download that still passed (no checksum published) would leave
+    // an unrunnable binary in place of a working one. The real assets are ~100MB+;
+    // anything under a megabyte is a GitHub error page, not an executable.
+    if (bytes < 1_000_000) {
+      throw new Error(`${asset} 下载内容异常（仅 ${bytes} 字节，疑似错误页而非二进制）`);
+    }
+    chmodSync(tmp, 0o755);
+    // Atomic swap. NOT a write to `target` — that is ETXTBSY (see header).
+    renameSync(tmp, target);
+    return { asset, target, bytes };
+  } catch (error) {
+    rmSync(tmp, { force: true });
+    throw error;
+  }
+}

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -35,16 +35,25 @@ import {
 import {
   isLocalDevInstall,
   botmuxVersion,
+  botmuxInstallRoot,
   botmuxVersionAt,
   botmuxCliEntry,
   botmuxCliEntryAt,
 } from '../utils/install-info.js';
 import {
   resolveGlobalInstallPlan,
+  formatGlobalInstallCommand,
+  UnsupportedGlobalInstallError,
   type GlobalInstallPlan,
 } from '../utils/global-install.js';
 import { withFileLockSync } from '../utils/file-lock.js';
 import { scrubWorkflowWorkerEnv, stripDashboardH5Env } from '../utils/child-env.js';
+import { isStandaloneBinary } from './self-spawn.js';
+import {
+  currentUpdateStrategy,
+  replaceStandaloneBinary,
+  type UpdateStrategy,
+} from './binary-self-update.js';
 
 export interface MaintenanceState {
   /** Local date the auto-update run was last handled (fired or skipped). */
@@ -64,6 +73,23 @@ export interface MaintenanceDeps {
   currentVersion: () => string;
   /** Updates the owning npm/pnpm/Bun global install (download/install only). */
   runUpdate: () => void;
+  /**
+   * What `runUpdate` actually installed, or '' when it could not be determined.
+   *
+   * ⚠️ WHY THIS EXISTS — `currentVersion()` CANNOT SEE A SELF-REPLACE. For a
+   * package-manager update the new version lands in the install's package.json,
+   * so re-reading it afterwards observes the change. A compiled binary has no
+   * package.json: its version is BAKED IN at compile time and read from this
+   * process's own env, so after swapping the file on disk `currentVersion()`
+   * still returns the OLD version (measured). The tick's `after !== before` gate
+   * would then be false, it would log "already on the latest version", and it
+   * would never restart onto the binary it just installed.
+   *
+   * So the self-replace path reports the version it installed explicitly, and the
+   * tick treats that as authoritative. Returns '' for the package-manager path,
+   * which keeps using the re-read comparison exactly as before.
+   */
+  installedVersion?: () => string;
   writeIntent: (intent: RestartIntent) => void;
   /** Spawn a detached `botmux restart` (this process is then killed by pm2). */
   triggerRestart: () => void;
@@ -109,7 +135,10 @@ export function runMaintenanceTick(deps: MaintenanceDeps): void {
     deps.withUpdateLock(() => {
       before = deps.currentVersion();
       deps.runUpdate();
-      after = deps.currentVersion();
+      // The self-replace path reports what it installed, because re-reading the
+      // version cannot observe a swapped binary (see MaintenanceDeps.installedVersion).
+      const reported = deps.installedVersion?.() ?? '';
+      after = reported || deps.currentVersion();
       if (after !== before && cfg.autoRestart?.enabled) {
         deps.writeIntent({ kind: 'update', oldVersion: before, newVersion: after, at: new Date(now).toISOString() });
         try {
@@ -208,6 +237,36 @@ export function installLatestBotmuxSync(plan: GlobalInstallPlan = resolveGlobalI
 }
 
 /**
+ * Apply an update for whatever install shape this process is, resolving the
+ * strategy first so a compiled binary is handled instead of being rejected as an
+ * "unsupported install".
+ *
+ * Shared by the CLI (`botmux update`), the dashboard's `/api/update/run` and the
+ * scheduled auto-update so the three cannot drift — they previously all funnelled
+ * into `resolveGlobalInstallPlan`, which is exactly the call that fails in
+ * compiled mode.
+ *
+ * @param spec  the version spec for the package-manager path, and the version to
+ *              download for the self-replace path ('latest' resolves upstream).
+ */
+export async function applyBotmuxUpdate(
+  installRoot: string,
+  version: string,
+): Promise<{ strategy: UpdateStrategy['kind']; detail: string }> {
+  const strategy = currentUpdateStrategy(installRoot);
+  if (strategy.kind === 'unsupported') {
+    throw new UnsupportedGlobalInstallError('unknown', process.execPath);
+  }
+  if (strategy.kind === 'self-replace') {
+    const r = await replaceStandaloneBinary(version, strategy.target);
+    return { strategy: 'self-replace', detail: `${r.asset} → ${r.target}` };
+  }
+  const plan = resolveGlobalInstallPlan(strategy.packageRoot, process.platform, `botmux@${version}`);
+  installLatestBotmuxSync(plan);
+  return { strategy: 'package-manager', detail: formatGlobalInstallCommand(plan) };
+}
+
+/**
  * Cross-process lock target that serializes global botmux updates
  * between the scheduled auto-update (this daemon process) and a
  * dashboard-triggered manual update (the separate `botmux-dashboard` process),
@@ -234,14 +293,27 @@ export function globalInstallUpdateLockTarget(): string {
  * restarts the rest (the 2026-06-11 incident). `setsid` starts it in a brand
  * new session, reparented to init, immune to botmux-0's teardown. Without
  * setsid we fall back to a plain spawn (still detached by the caller).
+ *
+ * ⚠️ COMPILED BINARY: there is no `cli.js` to pass. Under Node the shape is
+ * `node <dist/cli.js> restart`, where argv[2] is `restart`. A single-file
+ * executable IS the CLI, so the same shape becomes `<binary> <cli.js path>
+ * restart` — and argv[2] is then the PATH, not `restart`. MEASURED on the real
+ * v3.18.4 binary: it printed the help banner and **exited 0**, i.e. a restart
+ * that silently never happened while reporting success. So in standalone mode the
+ * entry argument is dropped entirely and the binary is invoked as
+ * `<binary> restart`.
  */
 export function buildRestartLauncher(
   node: string,
   cliEntry: string,
   hasSetsid: boolean,
+  standalone = false,
 ): { cmd: string; args: string[] } {
-  if (hasSetsid) return { cmd: 'setsid', args: [node, cliEntry, 'restart'] };
-  return { cmd: node, args: [cliEntry, 'restart'] };
+  // A compiled binary dispatches its own subcommands; passing a cli.js path
+  // would shift `restart` to argv[3] where nothing reads it.
+  const entryArgs = standalone ? ['restart'] : [cliEntry, 'restart'];
+  if (hasSetsid) return { cmd: 'setsid', args: [node, ...entryArgs] };
+  return { cmd: node, args: entryArgs };
 }
 
 export function detachedRestartEnv(inheritedEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
@@ -317,8 +389,13 @@ export function spawnDetachedRestart(
   } catch {
     fd = undefined; // fall back to discarding output rather than failing the restart
   }
+  // A compiled binary has no cli.js on disk: `botmuxCliEntryAt` would hand back a
+  // path that does not exist (measured: "/dist/cli.js"), and passing it shifts the
+  // subcommand out of argv[2]. buildRestartLauncher drops it in that mode; we
+  // still compute it for the Node path, which is unchanged.
+  const standalone = isStandaloneBinary();
   const cliEntry = activePackageRoot ? botmuxCliEntryAt(activePackageRoot) : botmuxCliEntry();
-  const { cmd, args } = buildRestartLauncher(process.execPath, cliEntry, setsidAvailable());
+  const { cmd, args } = buildRestartLauncher(process.execPath, cliEntry, setsidAvailable(), standalone);
   const child = spawn(cmd, args, {
     detached: true,
     stdio: fd !== undefined ? ['ignore', fd, fd] : 'ignore',
@@ -344,11 +421,45 @@ export function spawnDetachedRestart(
   return child;
 }
 
+/**
+ * Perform a binary self-replace in a CHILD process and block until it finishes.
+ *
+ * WHY A CHILD AND NOT AN `await` HERE: `runMaintenanceTick` is synchronous and
+ * runs inside `withFileLockSync`, so it cannot await the download. Re-execing this
+ * same binary with a hidden `__self-update` subcommand keeps the lock semantics
+ * byte-identical to the package-manager branch (spawn one child, wait, throw on a
+ * non-zero exit) without turning the whole tick async — which would change the
+ * locking shape for the npm path too, the one that is currently working.
+ *
+ * Returns the version that was installed (printed by the child on its last line),
+ * or '' when the child reported success without a parseable version.
+ */
+export function runSelfReplaceBlocking(version = 'latest'): string {
+  const result = spawnSync(process.execPath, ['__self-update', version], {
+    cwd: globalInstallUpdateCwd(),
+    env: process.env,
+    encoding: 'utf-8',
+    // The download is ~100MB+ over a possibly proxied link; the package-manager
+    // branch has no timeout either (npm's own) so match that and let the outer
+    // schedule slip a day rather than killing a partial swap.
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || '').trim().split('\n').slice(-3).join('; ');
+    throw new Error(`self-update exited with ${result.status ?? result.signal ?? 'unknown status'}${detail ? `: ${detail}` : ''}`);
+  }
+  const m = /BOTMUX_SELF_UPDATE_VERSION=(\S+)/.exec(result.stdout || '');
+  return m?.[1] ?? '';
+}
+
 function productionDeps(): MaintenanceDeps {
   // Kept after a successful resolve so post-pnpm-update version/restart lookups
   // use the stable global node_modules/botmux symlink, not the removed
   // .pnpm/botmux@old runtime realpath.
   let installPlan: GlobalInstallPlan | undefined;
+  // Set by the self-replace path only (see MaintenanceDeps.installedVersion).
+  let selfReplacedTo = '';
   return {
     now: () => Date.now(),
     readConfig: () => readGlobalConfig().maintenance,
@@ -364,9 +475,25 @@ function productionDeps(): MaintenanceDeps {
       ? botmuxVersionAt(installPlan.activePackageRoot)
       : botmuxVersion(),
     runUpdate: () => {
-      installPlan ??= resolveGlobalInstallPlan();
+      selfReplacedTo = '';
+      const strategy = currentUpdateStrategy(botmuxInstallRoot());
+      if (strategy.kind === 'unsupported') {
+        throw new UnsupportedGlobalInstallError('unknown', process.execPath);
+      }
+      if (strategy.kind === 'self-replace') {
+        // The compiled binary owns its own file (install.sh location). The tick
+        // is synchronous and holds a cross-process lock, so run the async
+        // download to completion here rather than restructuring the whole tick:
+        // `runSelfReplaceBlocking` re-execs this binary with a hidden subcommand
+        // that performs the swap, which keeps the lock semantics identical to the
+        // package-manager branch (one child, awaited, non-zero exit ⇒ throw).
+        selfReplacedTo = runSelfReplaceBlocking();
+        return;
+      }
+      installPlan ??= resolveGlobalInstallPlan(strategy.packageRoot);
       installLatestBotmuxSync(installPlan);
     },
+    installedVersion: () => selfReplacedTo,
     writeIntent: (intent) => writeRestartIntent(intent),
     triggerRestart: () => {
       const leaseId = claimRestartLease();

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -37,6 +37,7 @@ import {
   botmuxVersion,
   botmuxInstallRoot,
   botmuxVersionAt,
+  diskVersionAt,
   botmuxCliEntry,
   botmuxCliEntryAt,
 } from '../utils/install-info.js';
@@ -51,9 +52,12 @@ import { scrubWorkflowWorkerEnv, stripDashboardH5Env } from '../utils/child-env.
 import { isStandaloneBinary } from './self-spawn.js';
 import {
   currentUpdateStrategy,
+  currentBinaryInstallShape,
   replaceStandaloneBinary,
+  type BinaryInstallShape,
   type UpdateStrategy,
 } from './binary-self-update.js';
+import { globalWrapperPath } from '../utils/local-dev-update.js';
 
 export interface MaintenanceState {
   /** Local date the auto-update run was last handled (fired or skipped). */
@@ -76,18 +80,25 @@ export interface MaintenanceDeps {
   /**
    * What `runUpdate` actually installed, or '' when it could not be determined.
    *
-   * ⚠️ WHY THIS EXISTS — `currentVersion()` CANNOT SEE A SELF-REPLACE. For a
-   * package-manager update the new version lands in the install's package.json,
-   * so re-reading it afterwards observes the change. A compiled binary has no
-   * package.json: its version is BAKED IN at compile time and read from this
-   * process's own env, so after swapping the file on disk `currentVersion()`
-   * still returns the OLD version (measured). The tick's `after !== before` gate
-   * would then be false, it would log "already on the latest version", and it
-   * would never restart onto the binary it just installed.
+   * ⚠️ WHY THIS EXISTS — THE BAKED VERSION SHADOWS A COMPLETED UPDATE, ON BOTH
+   * STRATEGIES. A compiled binary's version is baked in at compile time, and
+   * `botmuxVersionAt` returns that value for ANY directory you ask about. So
+   * `currentVersion()` after an update still reports this process's OLD version:
    *
-   * So the self-replace path reports the version it installed explicitly, and the
-   * tick treats that as authoritative. Returns '' for the package-manager path,
-   * which keeps using the re-read comparison exactly as before.
+   *   · self-replace     — the file on disk was swapped; nothing on disk is read.
+   *   · package-manager  — npm rewrote the install's package.json, but the baked
+   *                        value takes priority over reading it (measured:
+   *                        package.json says 3.19.0, the call returns 3.18.4).
+   *
+   * Either way `after === before`, so the tick logs "already on the latest
+   * version" and NEVER restarts onto what it just installed. Both branches
+   * therefore report the installed version explicitly — the self-replace path from
+   * what it downloaded, the package-manager path via `diskVersionAt` (which
+   * deliberately ignores the baked value).
+   *
+   * Returns '' when undeterminable, and the tick falls back to the re-read
+   * comparison. Under Node the baked value is absent, so all of this is a no-op
+   * and behaviour is byte-identical to before.
    */
   installedVersion?: () => string;
   writeIntent: (intent: RestartIntent) => void;
@@ -135,8 +146,8 @@ export function runMaintenanceTick(deps: MaintenanceDeps): void {
     deps.withUpdateLock(() => {
       before = deps.currentVersion();
       deps.runUpdate();
-      // The self-replace path reports what it installed, because re-reading the
-      // version cannot observe a swapped binary (see MaintenanceDeps.installedVersion).
+      // Both strategies report what they installed: a compiled binary's baked
+      // version shadows the disk on BOTH paths (see MaintenanceDeps.installedVersion).
       const reported = deps.installedVersion?.() ?? '';
       after = reported || deps.currentVersion();
       if (after !== before && cfg.autoRestart?.enabled) {
@@ -367,6 +378,41 @@ function setsidAvailable(): boolean {
 }
 
 /**
+ * Resolve the executable a detached restart should launch.
+ *
+ * ⚠️ WHY `process.execPath` IS NOT ALWAYS RIGHT FOR A COMPILED BINARY. For the
+ * self-replacing (install.sh) shape it is exactly right: the path is stable and we
+ * just swapped the bytes underneath it. But for a PACKAGE-MANAGER-owned binary the
+ * running path can be VERSIONED — pnpm's virtual store yields
+ * `…/.pnpm/botmux-linux-x64@<old version>/node_modules/botmux-linux-x64/botmux`.
+ * After the update, npm/pnpm's postinstall has re-pointed the stable launcher at
+ * the NEW subpackage, while this process's `execPath` still names the OLD one. So
+ * restarting from `execPath` either fails with ENOENT (the old store entry was
+ * pruned) or silently starts the OLD binary — an update that reports success and
+ * does not take effect.
+ *
+ * The stable launcher (`~/.botmux/bin/botmux`) is what both installers maintain and
+ * re-point, so it is the correct target after a package-manager update. Fall back
+ * to `execPath` when it is missing (nothing else to go on) — that is the
+ * pre-existing behaviour.
+ *
+ * Pure over its inputs so every branch is testable without a compiled binary.
+ */
+export function resolveStandaloneRestartExecutable(
+  standalone: boolean,
+  execPath: string,
+  shape: BinaryInstallShape,
+  launcherPath: string,
+  launcherExists: boolean,
+): string {
+  if (!standalone) return execPath;
+  // We own this exact path and just replaced its contents — re-exec it.
+  if (shape === 'curl-binary') return execPath;
+  if (shape === 'npm-binary' && launcherExists) return launcherPath;
+  return execPath;
+}
+
+/**
  * Spawn a detached `botmux restart`, immune to this process's own teardown
  * (setsid → a new session reparented to init, so PM2 killing the current
  * process doesn't interrupt the restart driver). Output is appended to the
@@ -395,7 +441,17 @@ export function spawnDetachedRestart(
   // still compute it for the Node path, which is unchanged.
   const standalone = isStandaloneBinary();
   const cliEntry = activePackageRoot ? botmuxCliEntryAt(activePackageRoot) : botmuxCliEntry();
-  const { cmd, args } = buildRestartLauncher(process.execPath, cliEntry, setsidAvailable(), standalone);
+  // A package-manager-owned binary's own path can be versioned (pnpm store); after
+  // the update the stable launcher points at the new one while execPath does not.
+  const launcher = globalWrapperPath();
+  const executable = resolveStandaloneRestartExecutable(
+    standalone,
+    process.execPath,
+    standalone ? currentBinaryInstallShape() : 'unknown',
+    launcher,
+    existsSync(launcher),
+  );
+  const { cmd, args } = buildRestartLauncher(executable, cliEntry, setsidAvailable(), standalone);
   const child = spawn(cmd, args, {
     detached: true,
     stdio: fd !== undefined ? ['ignore', fd, fd] : 'ignore',
@@ -458,8 +514,8 @@ function productionDeps(): MaintenanceDeps {
   // use the stable global node_modules/botmux symlink, not the removed
   // .pnpm/botmux@old runtime realpath.
   let installPlan: GlobalInstallPlan | undefined;
-  // Set by the self-replace path only (see MaintenanceDeps.installedVersion).
-  let selfReplacedTo = '';
+  // What runUpdate installed, for both strategies (see MaintenanceDeps.installedVersion).
+  let installedTo = '';
   return {
     now: () => Date.now(),
     readConfig: () => readGlobalConfig().maintenance,
@@ -475,7 +531,7 @@ function productionDeps(): MaintenanceDeps {
       ? botmuxVersionAt(installPlan.activePackageRoot)
       : botmuxVersion(),
     runUpdate: () => {
-      selfReplacedTo = '';
+      installedTo = '';
       const strategy = currentUpdateStrategy(botmuxInstallRoot());
       if (strategy.kind === 'unsupported') {
         throw new UnsupportedGlobalInstallError('unknown', process.execPath);
@@ -487,13 +543,20 @@ function productionDeps(): MaintenanceDeps {
         // `runSelfReplaceBlocking` re-execs this binary with a hidden subcommand
         // that performs the swap, which keeps the lock semantics identical to the
         // package-manager branch (one child, awaited, non-zero exit ⇒ throw).
-        selfReplacedTo = runSelfReplaceBlocking();
+        installedTo = runSelfReplaceBlocking();
         return;
       }
       installPlan ??= resolveGlobalInstallPlan(strategy.packageRoot);
       installLatestBotmuxSync(installPlan);
+      // Report what landed on DISK. For a compiled binary installed by a package
+      // manager, `currentVersion()` (→ botmuxVersionAt) returns this process's
+      // BAKED version and so cannot see the update npm just performed — measured,
+      // and it would make the tick log "already on the latest version" and skip the
+      // restart. diskVersionAt deliberately ignores the baked value. Under Node the
+      // two agree, so this is a no-op there.
+      installedTo = diskVersionAt(installPlan.activePackageRoot);
     },
-    installedVersion: () => selfReplacedTo,
+    installedVersion: () => installedTo,
     writeIntent: (intent) => writeRestartIntent(intent),
     triggerRestart: () => {
       const leaseId = claimRestartLease();

--- a/src/core/release-download.ts
+++ b/src/core/release-download.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared release-asset download: GET a URL through an optional proxy, following
+ * redirects, and resolve with the 200 response stream.
+ *
+ * Extracted from `dashboard/hd2d-assets.ts` so the binary self-update
+ * (`core/binary-self-update.ts`) reuses exactly this transport instead of
+ * growing a second copy. Both callers fetch GitHub Release assets, and both need
+ * the same three things the naive version gets wrong:
+ *
+ *  · `node:http`/`node:https` rather than `fetch`, so an explicitly configured
+ *    proxy is actually honoured — undici ignores the proxy env vars, and Bun's
+ *    fetch goes the other way and honours them too eagerly (see
+ *    `core/loopback-fetch.ts` for that direction).
+ *  · CONNECT tunnelling for HTTPS-via-HTTP-proxy.
+ *  · Tearing down each hop before following a redirect: a lingering TLS socket
+ *    layered over a CONNECT tunnel stalls the NEXT hop's handshake (observed:
+ *    github.com → release-assets… drops with "socket disconnected before secure
+ *    TLS" unless hop 1 is closed). GitHub Release downloads ALWAYS redirect, so
+ *    this is the normal path, not an edge case.
+ */
+import { request as httpsRequest } from 'node:https';
+import { request as httpRequest, type IncomingMessage } from 'node:http';
+import { connect as tlsConnect } from 'node:tls';
+import { Buffer } from 'node:buffer';
+import { readGlobalConfig } from '../global-config.js';
+
+/** Resolve an outbound proxy: explicit config wins, then the standard env vars
+ *  (which Node's global fetch ignores — the whole reason we hand-roll this). */
+export function resolveHttpProxy(): string | undefined {
+  return readGlobalConfig().httpProxy
+    || process.env.HTTPS_PROXY || process.env.https_proxy
+    || process.env.HTTP_PROXY || process.env.http_proxy
+    || undefined;
+}
+
+/**
+ * GET a URL and resolve with the 200 response stream, following redirects and
+ * optionally tunnelling through an HTTP proxy.
+ *
+ * @param userAgent sent as `user-agent`; callers pass their own tag so server-side
+ *                  logs can tell the game assets apart from a self-update.
+ */
+export function getReleaseStream(
+  rawUrl: string,
+  proxy: string | undefined,
+  userAgent: string,
+  redirectsLeft = 5,
+): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    let target: URL;
+    try { target = new URL(rawUrl); } catch { reject(new Error(`URL 非法: ${rawUrl}`)); return; }
+    const isHttps = target.protocol === 'https:';
+
+    const handle = (res: IncomingMessage) => {
+      const sc = res.statusCode ?? 0;
+      if (sc >= 300 && sc < 400 && res.headers.location) {
+        // Tear down this hop's connection before following the redirect (see header).
+        res.destroy();
+        res.socket?.destroy();
+        if (redirectsLeft <= 0) { reject(new Error('重定向次数过多')); return; }
+        resolve(getReleaseStream(new URL(res.headers.location, rawUrl).toString(), proxy, userAgent, redirectsLeft - 1));
+        return;
+      }
+      if (sc !== 200) { res.resume(); reject(new Error(`HTTP ${sc}`)); return; }
+      resolve(res);
+    };
+
+    let p: URL | undefined;
+    if (proxy) {
+      try { p = new URL(proxy); } catch { reject(new Error(`代理地址非法: ${proxy}`)); return; }
+    }
+    const proxyAuth = (): Record<string, string> => p?.username
+      ? { 'proxy-authorization': `Basic ${Buffer.from(`${decodeURIComponent(p.username)}:${decodeURIComponent(p.password)}`).toString('base64')}` }
+      : {};
+
+    if (p && isHttps) {
+      // HTTPS via HTTP proxy: open a CONNECT tunnel, then TLS over the socket.
+      const port = target.port || '443';
+      const creq = httpRequest({
+        host: p.hostname, port: Number(p.port || 80), method: 'CONNECT', agent: false,
+        path: `${target.hostname}:${port}`,
+        headers: { host: `${target.hostname}:${port}`, ...proxyAuth() },
+      });
+      creq.on('connect', (cres, socket) => {
+        if (cres.statusCode !== 200) { reject(new Error(`代理 CONNECT 失败: HTTP ${cres.statusCode}`)); return; }
+        const tls = tlsConnect({ socket, servername: target.hostname }, () => {
+          const greq = httpsRequest({
+            method: 'GET', path: `${target.pathname}${target.search}`,
+            headers: { host: target.host, 'user-agent': userAgent },
+            createConnection: () => tls,
+          }, handle);
+          greq.on('error', reject);
+          greq.end();
+        });
+        tls.on('error', reject);
+      });
+      creq.on('error', reject);
+      creq.end();
+      return;
+    }
+
+    if (p) {
+      // Plain HTTP via proxy: send the absolute-form request line to the proxy.
+      const greq = httpRequest({
+        host: p.hostname, port: Number(p.port || 80), method: 'GET', path: rawUrl,
+        headers: { host: target.host, 'user-agent': userAgent, ...proxyAuth() },
+      }, handle);
+      greq.on('error', reject);
+      greq.end();
+      return;
+    }
+
+    // Direct (no proxy).
+    const mod = isHttps ? httpsRequest : httpRequest;
+    const greq = mod(rawUrl, { headers: { 'user-agent': userAgent } }, handle);
+    greq.on('error', reject);
+    greq.end();
+  });
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -4058,14 +4058,20 @@ const server = createServer(async (req, res) => {
     // `authed` guards on the two mutations are defense-in-depth for host actions.
     if (req.method === 'GET' && url.pathname === '/api/update/status') {
       const current = currentInstalledVersion();
-      const packageRoot = lastSuccessfulUpdatePlan?.activePackageRoot ?? botmuxInstallRoot();
-      const installManager = detectGlobalInstallManager(packageRoot);
-      // A compiled binary has no package.json, so `packageRoot` is "/" and the
+      // Display/classification only — deliberately NOT a plan root. It feeds
+      // `currentUpdateStrategy` (which handles the compiled binary's "/" correctly)
+      // and the manager label shown when nothing else resolves. Named distinctly from
+      // the `packageRoot` variables that DO reach resolveGlobalInstallPlan, so the two
+      // uses cannot be confused (and so the source guard in
+      // test/binary-self-update.test.ts can tell them apart).
+      const classifyRoot = lastSuccessfulUpdatePlan?.activePackageRoot ?? botmuxInstallRoot();
+      const installManager = detectGlobalInstallManager(classifyRoot);
+      // A compiled binary has no package.json, so `classifyRoot` is "/" and the
       // plan resolution always fails — which used to grey out the update button
       // and tell an npm user their install method is unsupported. Resolve the
       // strategy by BINARY LOCATION first; only fall back to the package-root
       // classification for the Node path (unchanged there).
-      const updateStrategy = currentUpdateStrategy(packageRoot);
+      const updateStrategy = currentUpdateStrategy(classifyRoot);
       const installPlan = updateStrategy.kind === 'package-manager'
         ? tryResolveGlobalInstallPlan(updateStrategy.packageRoot)
         : null;
@@ -4340,9 +4346,22 @@ const server = createServer(async (req, res) => {
         return jsonRes(res, 400, { ok: false, error: 'not_rollback_target' });
       }
 
+      // Rollback only knows how to drive a package manager. Resolve the strategy
+      // first so a compiled binary uses its MAPPED root: on a fresh process there
+      // is no `lastSuccessfulUpdatePlan` yet and `botmuxInstallRoot()` is "/", which
+      // made the very first rollback throw `unsupported_install_method` even though
+      // /api/update/status had just reported `rollbackSupported: true`.
+      const rollbackStrategy = currentUpdateStrategy(botmuxInstallRoot());
+      if (rollbackStrategy.kind !== 'package-manager') {
+        return jsonRes(res, 400, {
+          ok: false,
+          error: 'unsupported_install_method',
+          manager: rollbackStrategy.kind === 'self-replace' ? 'binary' : 'unknown',
+        });
+      }
       let installPlan: GlobalInstallPlan;
       try {
-        const packageRoot = lastSuccessfulUpdatePlan?.activePackageRoot ?? botmuxInstallRoot();
+        const packageRoot = lastSuccessfulUpdatePlan?.activePackageRoot ?? rollbackStrategy.packageRoot;
         installPlan = withGlobalInstallRegistry(
           resolveGlobalInstallPlan(packageRoot, process.platform, `botmux@${targetVersion}`),
         );

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 import { createHmac, randomBytes } from 'node:crypto';
 import { logger } from './utils/logger.js';
 import { isStandaloneBinary } from './core/self-spawn.js';
+import { currentUpdateStrategy, replaceStandaloneBinary } from './core/binary-self-update.js';
 import { gracefulProcessExitCode } from './pm2-graceful-exit.js';
 import { config, isWildcardBindHost } from './config.js';
 import { listenWithProbe } from './utils/listen-with-probe.js';
@@ -4054,7 +4055,16 @@ const server = createServer(async (req, res) => {
       const current = currentInstalledVersion();
       const packageRoot = lastSuccessfulUpdatePlan?.activePackageRoot ?? botmuxInstallRoot();
       const installManager = detectGlobalInstallManager(packageRoot);
-      const installPlan = tryResolveGlobalInstallPlan(packageRoot);
+      // A compiled binary has no package.json, so `packageRoot` is "/" and the
+      // plan resolution always fails — which used to grey out the update button
+      // and tell an npm user their install method is unsupported. Resolve the
+      // strategy by BINARY LOCATION first; only fall back to the package-root
+      // classification for the Node path (unchanged there).
+      const updateStrategy = currentUpdateStrategy(packageRoot);
+      const installPlan = updateStrategy.kind === 'package-manager'
+        ? tryResolveGlobalInstallPlan(updateStrategy.packageRoot)
+        : null;
+      const selfReplace = updateStrategy.kind === 'self-replace';
       // Compare against the npm `latest` dist-tag (always stable; the update
       // button installs `@latest`). isNewerVersion uses semver precedence, so a
       // canary running AHEAD of the latest stable (e.g. 2.87.0-canary.0 vs
@@ -4101,9 +4111,13 @@ const server = createServer(async (req, res) => {
         // the wrapper points at is a real git worktree; otherwise the button
         // stays disabled (there is nothing to pull).
         localDevUpdatable: localDev && isGitWorktree(resolveLocalDevCheckoutDir()),
-        updateSupported: installPlan !== null,
-        updateManager: installPlan?.manager ?? installManager,
-        updateCommand: installPlan ? formatGlobalInstallCommand(installPlan) : null,
+        updateSupported: installPlan !== null || selfReplace,
+        // The standalone binary is not owned by a package manager; report it as
+        // its own kind rather than letting the UI claim "npm/pnpm/Bun only".
+        updateManager: selfReplace ? 'binary' : (installPlan?.manager ?? installManager),
+        updateCommand: selfReplace
+          ? `botmux update（下载并替换 ${updateStrategy.target}）`
+          : installPlan ? formatGlobalInstallCommand(installPlan) : null,
         node: checkNode(),
         installs: detectBotmuxInstalls(),
       });
@@ -4181,6 +4195,48 @@ const server = createServer(async (req, res) => {
           // have been pulled already and only needed a build).
           restartRequired: true,
           localDev: true,
+        });
+      }
+      // 编译版独立二进制（install.sh 形态）：没有包管理器拥有这个文件，改为下载
+      // 对应平台的 release 资产、校验 SHA-256 后原子替换自身。npm 子包形态不走
+      // 这里 —— 那棵树归 npm 所有，交回 npm 更新（见 binary-self-update.ts 头部）。
+      const runStrategy = currentUpdateStrategy(botmuxInstallRoot());
+      if (runStrategy.kind === 'self-replace') {
+        if (updateInFlight) return jsonRes(res, 409, { ok: false, error: 'update_in_flight' });
+        updateInFlight = true;
+        let acquired = false;
+        let blockedByRestart = false;
+        let oldVersion = '';
+        let newVersion = '';
+        try {
+          const latest = await cachedLatestVersion(false);
+          if (!latest.value) {
+            return jsonRes(res, 503, { ok: false, error: 'version_lookup_failed' });
+          }
+          oldVersion = currentInstalledVersion();
+          newVersion = latest.value;
+          await withFileLock(globalInstallUpdateLockTarget(), async () => {
+            acquired = true;
+            if (hasActiveRestartLease()) { blockedByRestart = true; return; }
+            await replaceStandaloneBinary(newVersion, runStrategy.target);
+          }, { maxWaitMs: 2_000 });
+        } catch (e) {
+          if (!acquired) return jsonRes(res, 409, { ok: false, error: 'update_in_flight' });
+          return jsonRes(res, 500, { ok: false, error: 'install_failed', detail: e instanceof Error ? e.message : String(e) });
+        } finally {
+          updateInFlight = false;
+        }
+        if (blockedByRestart) return jsonRes(res, 409, { ok: false, error: 'restart_in_flight' });
+        return jsonRes(res, 200, {
+          ok: true,
+          oldVersion,
+          newVersion,
+          // The swapped binary is on disk but THIS process still runs (and reports)
+          // the old baked version, so `changed` cannot be derived by re-reading —
+          // it is the version comparison that decided to update at all.
+          changed: newVersion !== oldVersion,
+          restartRequired: true,
+          manager: 'binary',
         });
       }
       let installPlan: GlobalInstallPlan;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -161,7 +161,7 @@ import { parseCloseResidual, type ParsedCloseResidual } from './core/close-resid
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { getGitRepoInfo } from './core/session-row-enrichment.js';
 import { deleteWhiteboard, listWhiteboards, readWhiteboard, whiteboardEnabled } from './services/whiteboard-store.js';
-import { isLocalDevInstall, botmuxVersion, botmuxVersionAt, botmuxCliEntry, botmuxCliEntryAt, botmuxInstallRoot, bakedBinaryVersion } from './utils/install-info.js';
+import { isLocalDevInstall, botmuxVersion, botmuxVersionAt, diskVersionAt, botmuxCliEntry, botmuxCliEntryAt, botmuxInstallRoot, bakedBinaryVersion } from './utils/install-info.js';
 import { checkNode, detectBotmuxInstalls, resolveCurrentVersion, resolveCurrentVersionAt } from './utils/install-diagnostics.js';
 import {
   fetchLatestVersion,
@@ -189,6 +189,7 @@ import {
   formatGlobalInstallCommand,
   resolveGlobalInstallPlan,
   tryResolveGlobalInstallPlan,
+  isAutoUpdateSupportedInstall,
   withGlobalInstallRegistry,
   UnsupportedGlobalInstallError,
   type GlobalInstallPlan,
@@ -1485,7 +1486,11 @@ function resolveDashboardSettings(): ResolvedDashboardSettings {
     repoPickerMode: global.repoPickerMode ?? 'all',
     maintenance: global.maintenance ?? {},
     localDevInstall: isLocalDevInstall(),
-    autoUpdateSupported: lastSuccessfulUpdatePlan !== undefined || tryResolveGlobalInstallPlan() !== null,
+    // Same predicate the save-time validation uses (resolveAutoUpdateSupport), so
+    // the UI can never render the toggle disabled while the backend would accept
+    // it — or the reverse. A plain `tryResolveGlobalInstallPlan()` here reported
+    // false for every compiled binary, because its package root is "/".
+    autoUpdateSupported: lastSuccessfulUpdatePlan !== undefined || isAutoUpdateSupportedInstall(),
     whiteboard: { enabled: global.whiteboard?.enabled === true },
     workflow: { enabled: global.workflow?.enabled === true }, // default OFF
     remoteAccess: global.remoteAccess === true,
@@ -4112,6 +4117,12 @@ const server = createServer(async (req, res) => {
         // stays disabled (there is nothing to pull).
         localDevUpdatable: localDev && isGitWorktree(resolveLocalDevCheckoutDir()),
         updateSupported: installPlan !== null || selfReplace,
+        // Rollback is a SEPARATE capability from update. The web UI used to derive
+        // it from `updateSupported`, which now includes the self-replacing binary —
+        // but /api/update/rollback only knows how to drive a package manager, so a
+        // curl-installed binary would be offered a button that always fails.
+        // Report it explicitly instead of letting the UI infer it.
+        rollbackSupported: installPlan !== null,
         // The standalone binary is not owned by a package manager; report it as
         // its own kind rather than letting the UI claim "npm/pnpm/Bun only".
         updateManager: selfReplace ? 'binary' : (installPlan?.manager ?? installManager),
@@ -4241,7 +4252,14 @@ const server = createServer(async (req, res) => {
       }
       let installPlan: GlobalInstallPlan;
       try {
-        const packageRoot = lastSuccessfulUpdatePlan?.activePackageRoot ?? botmuxInstallRoot();
+        // ⚠️ NOT `botmuxInstallRoot()`: for a compiled binary that is "/" and the
+        // resolve below throws, which is the very defect this PR fixes. The
+        // strategy resolved above already carries the right root (the sibling main
+        // package for an npm/pnpm/Bun subpackage; the running install root under
+        // Node). `lastSuccessfulUpdatePlan` still wins so a pnpm update keeps using
+        // the stable symlink it resolved last time.
+        const packageRoot = lastSuccessfulUpdatePlan?.activePackageRoot
+          ?? (runStrategy.kind === 'package-manager' ? runStrategy.packageRoot : botmuxInstallRoot());
         installPlan = resolveGlobalInstallPlan(packageRoot);
       } catch (error) {
         if (error instanceof UnsupportedGlobalInstallError) {
@@ -4282,7 +4300,11 @@ const server = createServer(async (req, res) => {
         updateInFlight = false;
       }
       if (blockedByRestart) return jsonRes(res, 409, { ok: false, error: 'restart_in_flight' });
-      const newVersion = botmuxVersionAt(installPlan.activePackageRoot);
+      // Read the DISK, not `botmuxVersionAt`: for a compiled binary the baked
+      // version takes priority and would report this process's OLD version even
+      // though npm just rewrote package.json (measured) — making `changed` always
+      // false and the "restart to apply" prompt never appear.
+      const newVersion = diskVersionAt(installPlan.activePackageRoot);
       lastSuccessfulUpdatePlan = installPlan;
       return jsonRes(res, 200, {
         ok: true,
@@ -4362,7 +4384,10 @@ const server = createServer(async (req, res) => {
           }
 
           await runGlobalInstall(installPlan);
-          const newVersion = botmuxVersionAt(installPlan.activePackageRoot);
+          // diskVersionAt, not botmuxVersionAt: the baked version of a compiled
+          // binary would never equal the rollback target, so this verification
+          // would report a spurious `installed_version_mismatch` on every rollback.
+          const newVersion = diskVersionAt(installPlan.activePackageRoot);
           lastSuccessfulUpdatePlan = installPlan;
           if (newVersion !== targetVersion) {
             installedVersionMismatch = newVersion;

--- a/src/dashboard/hd2d-assets.ts
+++ b/src/dashboard/hd2d-assets.ts
@@ -16,11 +16,14 @@ import { homedir } from 'node:os';
 import { createHash, randomBytes } from 'node:crypto';
 import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { request as httpsRequest } from 'node:https';
-import { request as httpRequest, type IncomingMessage } from 'node:http';
-import { connect as tlsConnect } from 'node:tls';
 import { logger } from '../utils/logger.js';
-import { readGlobalConfig } from '../global-config.js';
+import { getReleaseStream, resolveHttpProxy } from '../core/release-download.js';
+
+// The proxy-aware release download lives in core/release-download.ts so the
+// binary self-update reuses this exact transport (redirect teardown, CONNECT
+// tunnelling) rather than growing a second copy. Re-exported because callers
+// and tests already import it from here.
+export { resolveHttpProxy };
 
 export const HD2D_ASSETS_TAG = 'hd2d-assets-v2';
 const RELEASE_BASE_URL = `https://github.com/deepcoldy/botmux/releases/download/${HD2D_ASSETS_TAG}`;
@@ -69,103 +72,14 @@ async function sha256File(fp: string): Promise<string> {
   return hash.digest('hex');
 }
 
-/** Resolve an outbound proxy: explicit config wins, then the standard env vars
- *  (which Node's global fetch ignores — the whole reason we hand-roll this). */
-export function resolveHttpProxy(): string | undefined {
-  return readGlobalConfig().httpProxy
-    || process.env.HTTPS_PROXY || process.env.https_proxy
-    || process.env.HTTP_PROXY || process.env.http_proxy
-    || undefined;
-}
-
 const DOWNLOAD_UA = 'botmux-hd2d';
-
-/** GET a URL and resolve with the 200 response stream, following redirects and
- *  optionally tunnelling through an HTTP proxy. Uses node:http/https directly
- *  (not fetch) so a configured proxy is actually honored — undici ignores the
- *  proxy env vars. */
-function getStream(rawUrl: string, proxy: string | undefined, redirectsLeft = 5): Promise<IncomingMessage> {
-  return new Promise((resolve, reject) => {
-    let target: URL;
-    try { target = new URL(rawUrl); } catch { reject(new Error(`URL 非法: ${rawUrl}`)); return; }
-    const isHttps = target.protocol === 'https:';
-
-    const handle = (res: IncomingMessage) => {
-      const sc = res.statusCode ?? 0;
-      if (sc >= 300 && sc < 400 && res.headers.location) {
-        // Tear down this hop's connection before following the redirect: a
-        // lingering TLS socket layered over a proxy CONNECT tunnel stalls the
-        // NEXT hop's handshake (observed: github.com → release-assets… drops
-        // with "socket disconnected before secure TLS" unless hop 1 is closed).
-        res.destroy();
-        res.socket?.destroy();
-        if (redirectsLeft <= 0) { reject(new Error('重定向次数过多')); return; }
-        resolve(getStream(new URL(res.headers.location, rawUrl).toString(), proxy, redirectsLeft - 1));
-        return;
-      }
-      if (sc !== 200) { res.resume(); reject(new Error(`HTTP ${sc}`)); return; }
-      resolve(res);
-    };
-
-    let p: URL | undefined;
-    if (proxy) {
-      try { p = new URL(proxy); } catch { reject(new Error(`代理地址非法: ${proxy}`)); return; }
-    }
-    const proxyAuth = (): Record<string, string> => p?.username
-      ? { 'proxy-authorization': `Basic ${Buffer.from(`${decodeURIComponent(p.username)}:${decodeURIComponent(p.password)}`).toString('base64')}` }
-      : {};
-
-    if (p && isHttps) {
-      // HTTPS via HTTP proxy: open a CONNECT tunnel, then TLS over the socket.
-      const port = target.port || '443';
-      const creq = httpRequest({
-        host: p.hostname, port: Number(p.port || 80), method: 'CONNECT', agent: false,
-        path: `${target.hostname}:${port}`,
-        headers: { host: `${target.hostname}:${port}`, ...proxyAuth() },
-      });
-      creq.on('connect', (cres, socket) => {
-        if (cres.statusCode !== 200) { reject(new Error(`代理 CONNECT 失败: HTTP ${cres.statusCode}`)); return; }
-        const tls = tlsConnect({ socket, servername: target.hostname }, () => {
-          const greq = httpsRequest({
-            method: 'GET', path: `${target.pathname}${target.search}`,
-            headers: { host: target.host, 'user-agent': DOWNLOAD_UA },
-            createConnection: () => tls,
-          }, handle);
-          greq.on('error', reject);
-          greq.end();
-        });
-        tls.on('error', reject);
-      });
-      creq.on('error', reject);
-      creq.end();
-      return;
-    }
-
-    if (p) {
-      // Plain HTTP via proxy: send the absolute-form request line to the proxy.
-      const greq = httpRequest({
-        host: p.hostname, port: Number(p.port || 80), method: 'GET', path: rawUrl,
-        headers: { host: target.host, 'user-agent': DOWNLOAD_UA, ...proxyAuth() },
-      }, handle);
-      greq.on('error', reject);
-      greq.end();
-      return;
-    }
-
-    // Direct (no proxy).
-    const mod = isHttps ? httpsRequest : httpRequest;
-    const greq = mod(rawUrl, { headers: { 'user-agent': DOWNLOAD_UA } }, handle);
-    greq.on('error', reject);
-    greq.end();
-  });
-}
 
 async function downloadAsset(a: AssetSpec): Promise<void> {
   if (assetReady(a)) return; // already cached + correct size — bytes pre-counted
   mkdirSync(HD2D_CACHE_DIR, { recursive: true });
   const dest = join(HD2D_CACHE_DIR, a.name);
   const tmp = join(HD2D_CACHE_DIR, `.${a.name}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`);
-  const res = await getStream(`${RELEASE_BASE_URL}/${a.name}`, resolveHttpProxy());
+  const res = await getReleaseStream(`${RELEASE_BASE_URL}/${a.name}`, resolveHttpProxy(), DOWNLOAD_UA);
   // Count bytes via an in-stream Transform — NOT a `res.on('data')` listener,
   // which would flip the source into flowing mode and race pipeline's pull-based
   // consumption (dropping early chunks / stalling the download).

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -61,6 +61,9 @@ type BotmuxUpdateStatus = {
   behind: boolean;
   localDevInstall: boolean;
   updateSupported: boolean;
+  /** Whether /api/update/rollback can actually drive this install. Absent on
+   *  older backends; see the fallback where it is consumed. */
+  rollbackSupported?: boolean;
   updateCommand: string | null;
   node: { version: string; required: number; ok: boolean };
   installs: { entries: Array<{ binPath: string }>; multiple: boolean };
@@ -764,7 +767,13 @@ function TopbarVersionControl(props: {
   const behind = status.behind && !!status.latest;
   const unknown = !status.latest;
   const automatic = behind && status.updateSupported && !status.localDevInstall && status.node.ok;
-  const rollbackSupported = status.updateSupported && !status.localDevInstall && status.node.ok;
+  // Rollback is its own capability, reported explicitly by the backend: the
+  // self-replacing binary CAN update but /api/update/rollback only drives a
+  // package manager, so deriving this from `updateSupported` would show a button
+  // that always fails. Older backends omit the field — fall back to the previous
+  // derivation so a stale dashboard/daemon pair behaves as before.
+  const rollbackSupported = (status.rollbackSupported ?? status.updateSupported)
+    && !status.localDevInstall && status.node.ok;
   const busy = phase === 'updating' || phase === 'restarting';
   // Progress-ring geometry. R=20 → circumference C; the arc fills clockwise
   // from 12 o'clock for `progress`%.

--- a/src/dashboard/web/settings-page.tsx
+++ b/src/dashboard/web/settings-page.tsx
@@ -118,7 +118,9 @@ interface UpdateStatus {
   /** Local-dev checkout is a git worktree → self-update via git pull + build. */
   localDevUpdatable?: boolean;
   updateSupported: boolean;
-  updateManager: 'npm' | 'pnpm' | 'yarn' | 'bun' | 'unknown';
+  // 'binary' = 编译版独立二进制（install.sh 形态），不归任何包管理器所有，
+  // 自己下载 release 资产替换自身。
+  updateManager: 'npm' | 'pnpm' | 'yarn' | 'bun' | 'binary' | 'unknown';
   updateCommand: string | null;
   node: NodeCheck;
   installs: { entries: InstallEntry[]; multiple: boolean };

--- a/src/utils/file-lock.ts
+++ b/src/utils/file-lock.ts
@@ -796,6 +796,39 @@ function resumeStaleBreakSync(
   }
 }
 
+/**
+ * Thrown ONLY when the lock could not be acquired within `maxWaitMs` — i.e.
+ * somebody else holds it. Every other failure (EACCES/ENOSPC from `open`, a
+ * failed holder write, an unreadable holder file, a stale-claim `link` error)
+ * propagates as its original error.
+ *
+ * ⚠️ WHY A TYPE AND NOT A MESSAGE MATCH. Callers need to tell "busy, retry later"
+ * apart from "the disk is full", and `acquired === false` cannot: it only proves
+ * the callback never ran, which is equally true for all the pre-callback failures
+ * above. `botmux update` was reporting every one of them as "another update is
+ * already running" — hiding a real fault behind a benign message.
+ *
+ * The message text is DELIBERATELY UNCHANGED: several call sites still match it as
+ * a string (`workflows/v3/host.ts`, `daemon.ts`, `services/session-store.ts`, …),
+ * so altering it would silently break their handling. New code should test
+ * `instanceof FileLockTimeoutError` (or `code === 'FILE_LOCK_TIMEOUT'`), which the
+ * async and sync variants raise identically.
+ */
+export class FileLockTimeoutError extends Error {
+  readonly code = 'FILE_LOCK_TIMEOUT';
+  constructor(
+    readonly lockPath: string,
+    readonly holderPid: number | undefined,
+    readonly lockAgeMs: number,
+  ) {
+    super(
+      `file-lock timeout waiting for ${lockPath} ` +
+      `(held by pid ${holderPid || '?'}, age ${Math.round(lockAgeMs)}ms)`,
+    );
+    this.name = 'FileLockTimeoutError';
+  }
+}
+
 export interface FileLockOptions {
   /** Max time to wait for the lock before throwing (default MAX_WAIT_MS). */
   maxWaitMs?: number;
@@ -899,10 +932,7 @@ export async function withFileLock<T>(
     }
 
     if (Date.now() - start > maxWaitMs) {
-      throw new Error(
-        `file-lock timeout waiting for ${lockPath} ` +
-        `(held by pid ${holder?.pid || '?'}, age ${Math.round(lockAgeMs)}ms)`,
-      );
+      throw new FileLockTimeoutError(lockPath, holder?.pid, lockAgeMs);
     }
     await new Promise(r => setTimeout(r, RETRY_BASE_MS + Math.random() * RETRY_BASE_MS));
   }
@@ -994,10 +1024,7 @@ export function withFileLockSync<T>(
     }
 
     if (Date.now() - start > maxWaitMs) {
-      throw new Error(
-        `file-lock timeout waiting for ${lockPath} ` +
-        `(held by pid ${holder?.pid || '?'}, age ${Math.round(lockAgeMs)}ms)`,
-      );
+      throw new FileLockTimeoutError(lockPath, holder?.pid, lockAgeMs);
     }
     sleepSync(RETRY_BASE_MS + Math.random() * RETRY_BASE_MS);
   }

--- a/src/utils/global-install.ts
+++ b/src/utils/global-install.ts
@@ -12,6 +12,11 @@ import { readdirSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { posix, win32 } from 'node:path';
 import { botmuxInstallRoot } from './install-info.js';
+// Import the SHAPE CLASSIFIER only (pure, no network / no release logic), not the
+// whole self-update module: binary-self-update.ts pulls in restart-report →
+// install-info, and importing that side of it from here would close an import
+// cycle through this very module.
+import { currentBinaryInstallShape } from '../core/binary-install-shape.js';
 
 export type GlobalInstallManager = 'npm' | 'pnpm' | 'bun';
 export type DetectedInstallManager = GlobalInstallManager | 'yarn' | 'unknown';
@@ -255,6 +260,13 @@ export function tryResolveGlobalInstallPlan(
 }
 
 export function isAutoUpdateSupportedInstall(): boolean {
+  // A compiled binary is not owned by a package manager, so the plan resolution
+  // below cannot classify it (its package root is "/"). It CAN still auto-update
+  // — either by handing back to npm (subpackage shape) or by replacing itself
+  // (install.sh shape) — so ask the binary-shape resolver too. Without this the
+  // Settings toggle refuses to save with `unsupported_install_no_autoupdate` on
+  // every binary install, which is now the default way botmux ships.
+  if (currentBinaryInstallShape() !== 'unknown') return true;
   return tryResolveGlobalInstallPlan() !== null;
 }
 

--- a/src/utils/global-install.ts
+++ b/src/utils/global-install.ts
@@ -16,7 +16,7 @@ import { botmuxInstallRoot } from './install-info.js';
 // whole self-update module: binary-self-update.ts pulls in restart-report →
 // install-info, and importing that side of it from here would close an import
 // cycle through this very module.
-import { currentBinaryInstallShape } from '../core/binary-install-shape.js';
+import { currentUpdateStrategy, type UpdateStrategy } from '../core/binary-install-shape.js';
 
 export type GlobalInstallManager = 'npm' | 'pnpm' | 'bun';
 export type DetectedInstallManager = GlobalInstallManager | 'yarn' | 'unknown';
@@ -259,15 +259,31 @@ export function tryResolveGlobalInstallPlan(
   }
 }
 
+/**
+ * Can this install auto-update, and by which route?
+ *
+ * ONE predicate for the whole surface: the Settings projection (what the UI shows),
+ * the save-time validation, and anything else that has to agree with them. They
+ * used to answer this question separately and drifted — the backend accepted the
+ * toggle while the frontend rendered it disabled.
+ *
+ * A compiled binary is not owned by a package manager, so `tryResolveGlobalInstallPlan`
+ * cannot classify it (its package root is "/"). Resolve by binary LOCATION first,
+ * then — for a package-manager-owned binary — still require a resolvable plan, so
+ * layouts we knowingly cannot drive (Yarn, and a pnpm v11 store whose probe fails)
+ * report false instead of promising an update that would throw.
+ */
+export function resolveAutoUpdateSupport(
+  strategy: UpdateStrategy,
+): { supported: boolean; plan: GlobalInstallPlan | null } {
+  if (strategy.kind === 'self-replace') return { supported: true, plan: null };
+  if (strategy.kind === 'unsupported') return { supported: false, plan: null };
+  const plan = tryResolveGlobalInstallPlan(strategy.packageRoot);
+  return { supported: plan !== null, plan };
+}
+
 export function isAutoUpdateSupportedInstall(): boolean {
-  // A compiled binary is not owned by a package manager, so the plan resolution
-  // below cannot classify it (its package root is "/"). It CAN still auto-update
-  // — either by handing back to npm (subpackage shape) or by replacing itself
-  // (install.sh shape) — so ask the binary-shape resolver too. Without this the
-  // Settings toggle refuses to save with `unsupported_install_no_autoupdate` on
-  // every binary install, which is now the default way botmux ships.
-  if (currentBinaryInstallShape() !== 'unknown') return true;
-  return tryResolveGlobalInstallPlan() !== null;
+  return resolveAutoUpdateSupport(currentUpdateStrategy(botmuxInstallRoot())).supported;
 }
 
 /** Pin an install plan to one registry. Callers opt in explicitly (rollback only). */

--- a/src/utils/install-info.ts
+++ b/src/utils/install-info.ts
@@ -11,6 +11,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isStandaloneBinary } from '../core/self-spawn.js';
 
 /** Pure check: is `rootDir` a source working copy rather than an npm install? */
 export function isLocalDevInstallAt(rootDir: string): boolean {
@@ -19,10 +20,32 @@ export function isLocalDevInstallAt(rootDir: string): boolean {
 
 let cached: boolean | undefined;
 
-/** Classify this running install. Cached — it cannot change at runtime. */
+/**
+ * Classify this running install. Cached — it cannot change at runtime.
+ *
+ * ⚠️ A COMPILED BINARY IS NEVER A SOURCE CHECKOUT, and the naive check cannot
+ * see that. `packageRoot()` walks up looking for package.json; inside a
+ * single-file executable there is none on disk (the module graph lives in the
+ * virtual `/$bunfs/`), so it returns `/` — and the test then becomes "does the
+ * FILESYSTEM ROOT have .git or src?". On this box neither exists so the answer is
+ * accidentally correct, but plenty of container images do have `/src`, and there
+ * the compiled binary would be misclassified as a dev checkout and sent down the
+ * `git pull --ff-only` update path.
+ *
+ * The standalone check is therefore an explicit early return, not a refinement of
+ * the filesystem probe. Node behaviour is bit-for-bit unchanged.
+ */
 export function isLocalDevInstall(): boolean {
-  if (cached === undefined) cached = isLocalDevInstallAt(packageRoot());
+  if (cached === undefined) {
+    cached = isStandaloneBinary() ? false : isLocalDevInstallAt(packageRoot());
+  }
   return cached;
+}
+
+/** Test seam: drop the cached classification. Production never calls this — the
+ *  answer genuinely cannot change within one process. */
+export function __resetLocalDevInstallCacheForTests(): void {
+  cached = undefined;
 }
 
 /**

--- a/src/utils/install-info.ts
+++ b/src/utils/install-info.ts
@@ -84,6 +84,28 @@ export function botmuxVersionAt(rootDir: string): string {
   // The compiled binary has no package.json to read (see bakedBinaryVersion).
   const baked = bakedBinaryVersion();
   if (baked) return baked;
+  return diskVersionAt(rootDir);
+}
+
+/**
+ * The version recorded in `rootDir`'s package.json, IGNORING the baked value.
+ *
+ * ⚠️ WHY THIS EXISTS — THE BAKED VERSION SHADOWS A COMPLETED UPDATE. `baked` is
+ * compiled into the running executable, so `botmuxVersionAt` returns it no matter
+ * which directory you ask about. That is right for "what am I running", and WRONG
+ * for "what is now installed on disk": after a package-manager update replaces the
+ * install tree, a compiled binary asking `botmuxVersionAt(root)` still gets its OWN
+ * old version (measured: package.json says 3.19.0, the call returns 3.18.4).
+ *
+ * The maintenance tick gates its restart on `after !== before`, so that shadowing
+ * makes a successful update look like "already on the latest version" — it never
+ * restarts onto what it just installed. Post-update reads must therefore use this
+ * function, not `botmuxVersionAt`.
+ *
+ * (Under Node `bakedBinaryVersion()` is undefined, so the two are identical there
+ * — which is why this defect only surfaces for the compiled binary.)
+ */
+export function diskVersionAt(rootDir: string): string {
   try {
     const pkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'));
     return typeof pkg.version === 'string' ? pkg.version : '0.0.0';

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -39,6 +39,7 @@ import {
 import { isMuslHost, releaseAssetName, releaseAssetBaseUrl, replaceStandaloneBinary } from '../src/core/binary-self-update.js';
 import { buildRestartLauncher, resolveStandaloneRestartExecutable } from '../src/core/maintenance.js';
 import { tryResolveGlobalInstallPlan, formatGlobalInstallCommand, resolveAutoUpdateSupport } from '../src/utils/global-install.js';
+import { withFileLock, FileLockTimeoutError } from '../src/utils/file-lock.js';
 import { botmuxVersionAt, diskVersionAt } from '../src/utils/install-info.js';
 
 const dirs: string[] = [];
@@ -390,6 +391,82 @@ describe('auto-update support is ONE predicate for UI and save-time validation',
     expect(resolveAutoUpdateSupport(curl).plan).toBeNull(); // ⟹ rollbackSupported false
   });
 
+});
+
+describe('concurrent updates report mutual exclusion, not lock internals', () => {
+  /**
+   * THE LOCK OUTCOME IS THREE-STATE, NOT TWO. `acquired === false` only proves the
+   * callback never ran — equally true when the lock infrastructure failed BEFORE the
+   * callback (`open` EACCES/ENOSPC/ENOENT, a failed holder write, an unreadable
+   * holder file, a stale-claim `link` error). Branching on `acquired` alone reports
+   * every one of those as "another update is already running", hiding a real fault
+   * (a full disk!) behind a benign message.
+   *
+   * A/B MEASURED with real pre-callback failures:
+   *   ENOENT parent : PRE-FIX => FRIENDLY   POST-FIX => RETHROW
+   *   symlinked lock: PRE-FIX => FRIENDLY   POST-FIX => RETHROW  (ELOOP)
+   */
+  const classify = (acquired: boolean, e: unknown): 'friendly' | 'rethrow' =>
+    (!acquired && e instanceof FileLockTimeoutError) ? 'friendly' : 'rethrow';
+
+  it('(1) lock timeout, callback never entered -> the friendly notice', async () => {
+    const dir = tmp();
+    const target = join(dir, 'busy');
+    let acquired = false;
+    let seen: unknown;
+    await withFileLock(target, async () => {
+      try {
+        await withFileLock(target, async () => { acquired = true; }, { maxWaitMs: 200 });
+      } catch (e) { seen = e; }
+    }, { maxWaitMs: 2_000 });
+    expect(seen).toBeInstanceOf(FileLockTimeoutError);
+    expect((seen as FileLockTimeoutError).code).toBe('FILE_LOCK_TIMEOUT');
+    expect(classify(acquired, seen)).toBe('friendly');
+    expect(acquired).toBe(false);
+  });
+
+  it('(2) a failure INSIDE the critical section surfaces as itself', async () => {
+    const dir = tmp();
+    let acquired = false;
+    let seen: unknown;
+    try {
+      await withFileLock(join(dir, 'x'), async () => {
+        acquired = true;
+        throw new Error('SHA-256 校验不通过');
+      }, { maxWaitMs: 500 });
+    } catch (e) { seen = e; }
+    expect(acquired).toBe(true);
+    expect(classify(acquired, seen)).toBe('rethrow');
+    expect((seen as Error).message).toContain('SHA-256');
+  });
+
+  it('(3) a pre-callback INFRASTRUCTURE failure also surfaces, not "another update"', async () => {
+    // A missing parent makes `open` throw ENOENT before the callback — the same
+    // shape as ENOSPC on a full disk. MUTATION CHECK: dropping the
+    // `instanceof FileLockTimeoutError` half of the predicate turns this red.
+    const dir = tmp();
+    let acquired = false;
+    let seen: unknown;
+    try {
+      await withFileLock(join(dir, 'no', 'such', 'dir', 'x'), async () => { acquired = true; }, { maxWaitMs: 400 });
+    } catch (e) { seen = e; }
+    expect(acquired).toBe(false);
+    expect(seen).toBeDefined();
+    expect(seen).not.toBeInstanceOf(FileLockTimeoutError);
+    expect((seen as NodeJS.ErrnoException).code).toBe('ENOENT');
+    // The whole point: `!acquired` holds here, yet this must NOT take the friendly path.
+    expect(classify(acquired, seen)).toBe('rethrow');
+  });
+
+  it('the timeout error keeps its historical message (call sites match it as text)', () => {
+    // workflows/v3/host.ts, daemon.ts and services/session-store.ts match this
+    // string; changing it while adding the type would break them silently.
+    const e = new FileLockTimeoutError('/tmp/x.lock', 1234, 2222);
+    expect(e.message).toBe('file-lock timeout waiting for /tmp/x.lock (held by pid 1234, age 2222ms)');
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe('FileLockTimeoutError');
+  });
+
   it('SOURCE GUARD: the update lock\'s timeout is reported as "another update is running"', () => {
     /**
      * `withFileLock` THROWS when it cannot acquire the lock — it does not return
@@ -420,10 +497,15 @@ describe('auto-update support is ONE predicate for UI and save-time validation',
     const lockAt = cli.indexOf('withFileLock', branchStart);
     expect(lockAt, 'the self-replace branch no longer takes the update lock').toBeGreaterThan(branchStart);
     const block = cli.slice(branchStart, lockAt + 1200);
-    expect(block).toMatch(/catch[\s\S]{0,400}?if \(!acquired\)/);
+    // The friendly notice must be gated on BOTH halves: callback-not-entered AND a
+    // genuine lock timeout. Guarding on `!acquired` alone is the over-broad version
+    // that reported ENOSPC/ENOENT as "another update is running".
+    expect(block).toMatch(/catch[\s\S]{0,900}?if \(!acquired && error instanceof FileLockTimeoutError\)/);
     expect(block).toMatch(/另一个更新正在进行中/);
-    // ...and a genuine post-acquisition failure must still surface, not be swallowed.
+    // ...and every other failure — in-section OR pre-callback — must still surface.
     expect(block).toMatch(/throw error;/);
+    // Belt and braces: the bare predicate must NOT reappear anywhere in this window.
+    expect(block).not.toMatch(/if \(!acquired\)\s*\{/);
   });
 
   it('SOURCE GUARD: no update/rollback endpoint feeds resolveGlobalInstallPlan the "/" install root', () => {

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -146,6 +146,47 @@ describe('resolveUpdateStrategy', () => {
     expect(tryResolveGlobalInstallPlan('/', 'linux')).toBeNull();
   });
 
+  it('SAFETY: real pnpm/yarn/Windows subpackage layouts never become a self-replace', () => {
+    // The destructive misclassification would be calling a package-manager-owned
+    // file `curl-binary` and writing it ourselves. Walk the layouts that actually
+    // occur in the wild and assert none of them reach the self-replace path.
+    const layouts = [
+      // pnpm virtual store
+      '/root/.local/share/pnpm/global/5/.pnpm/botmux-linux-x64@3.18.4/node_modules/botmux-linux-x64/botmux',
+      // pnpm v11 content-addressed links
+      '/root/.local/share/pnpm/store/v11/links/@/botmux-linux-x64/3.18.4/x/node_modules/botmux-linux-x64/botmux',
+      // pnpm global with preserved symlinks
+      '/root/.local/share/pnpm/global/5/node_modules/botmux-linux-x64/botmux',
+      // yarn global
+      '/root/.config/yarn/global/node_modules/botmux-linux-x64/botmux',
+      // npm on Windows (no lib/ segment)
+      'C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\botmux-linux-x64\\botmux',
+      // bun global
+      '/root/.bun/install/global/node_modules/botmux-linux-x64/botmux',
+    ];
+    for (const p of layouts) {
+      const s = resolveUpdateStrategy(true, p, '/', {}, '/root');
+      expect(s.kind, p).toBe('package-manager');
+      // And never the filesystem root, which is the pre-fix failure mode.
+      if (s.kind === 'package-manager') expect(s.packageRoot, p).not.toBe('/');
+    }
+  });
+
+  it('pnpm and npm subpackage layouts resolve to THEIR manager, not a forced npm', () => {
+    // The reason for translating to the sibling main package instead of computing
+    // a prefix here: the existing resolver already knows each manager's rules.
+    const pnpmMain = mainPackageRootForSubpackageBinary(
+      '/root/.local/share/pnpm/global/5/.pnpm/botmux-linux-x64@3.18.4/node_modules/botmux-linux-x64/botmux',
+    );
+    expect(formatGlobalInstallCommand(tryResolveGlobalInstallPlan(pnpmMain!, 'linux')!))
+      .toBe('pnpm add -g --global-dir /root/.local/share/pnpm/global botmux@latest');
+    const winMain = mainPackageRootForSubpackageBinary(
+      'C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\botmux-linux-x64\\botmux',
+    );
+    expect(formatGlobalInstallCommand(tryResolveGlobalInstallPlan(winMain!, 'win32')!))
+      .toBe('npm install -g --prefix C:/Users/u/AppData/Roaming/npm botmux@latest');
+  });
+
   it('an unidentifiable standalone binary stays unsupported (fail closed)', () => {
     expect(resolveUpdateStrategy(true, '/tmp/dist-bin/botmux', '/', {}, '/home/u'))
       .toEqual({ kind: 'unsupported', reason: 'unknown-binary-location' });

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -390,6 +390,42 @@ describe('auto-update support is ONE predicate for UI and save-time validation',
     expect(resolveAutoUpdateSupport(curl).plan).toBeNull(); // ⟹ rollbackSupported false
   });
 
+  it('SOURCE GUARD: the update lock\'s timeout is reported as "another update is running"', () => {
+    /**
+     * `withFileLock` THROWS when it cannot acquire the lock — it does not return
+     * quietly. So an `if (!acquired)` check placed AFTER the await is dead code, and
+     * the rejection falls through to the generic error printer.
+     *
+     * MEASURED by running two `botmux update` processes against one real compiled
+     * binary: the loser printed
+     *   ❌ 升级失败：file-lock timeout waiting for …/npm-global-update.lock
+     *      (held by pid 630166, age 2222ms)
+     * i.e. lock internals, for what is a perfectly normal mutual-exclusion outcome.
+     * After the fix it prints "另一个更新正在进行中（dashboard 或定时任务），请稍后重试。"
+     *
+     * Pinned at the source level because reaching this branch behaviourally needs two
+     * real processes racing a ~170MB download — reasonable to do by hand once (and I
+     * did), not in a unit test.
+     */
+    const cli = readFileSync(resolve('src/cli.ts'), 'utf-8');
+    // The self-replace branch must wrap its lock acquisition in try/catch and
+    // translate a not-acquired rejection, rather than testing `acquired` after it.
+    //
+    // Take a window from the branch head to its `withFileLock` call plus what
+    // follows. NOT "up to the first `return;`" — the branch returns early for
+    // "already latest", which truncated the window before the lock code and made
+    // every assertion below vacuously false (measured: a 355-char window).
+    const branchStart = cli.indexOf("strategy.kind === 'self-replace'");
+    expect(branchStart, 'the self-replace branch moved — update this guard').toBeGreaterThan(0);
+    const lockAt = cli.indexOf('withFileLock', branchStart);
+    expect(lockAt, 'the self-replace branch no longer takes the update lock').toBeGreaterThan(branchStart);
+    const block = cli.slice(branchStart, lockAt + 1200);
+    expect(block).toMatch(/catch[\s\S]{0,400}?if \(!acquired\)/);
+    expect(block).toMatch(/另一个更新正在进行中/);
+    // ...and a genuine post-acquisition failure must still surface, not be swallowed.
+    expect(block).toMatch(/throw error;/);
+  });
+
   it('SOURCE GUARD: no update/rollback endpoint feeds resolveGlobalInstallPlan the "/" install root', () => {
     /**
      * ⚠️ WHY A SOURCE ASSERTION AND NOT A BEHAVIOURAL ONE. The pure-function test

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -357,6 +357,90 @@ describe('auto-update support is ONE predicate for UI and save-time validation',
   it('unsupported stays unsupported', () => {
     expect(resolveAutoUpdateSupport({ kind: 'unsupported', reason: 'unknown-binary-location' }).supported).toBe(false);
   });
+
+  it('NO ASYMMETRY: whatever status claims supportable, rollback can resolve too', () => {
+    /**
+     * The bug this pins: `/api/update/status` reported `rollbackSupported: true`
+     * for an npm-installed compiled binary (it resolves the MAPPED package root),
+     * while `/api/update/rollback` still resolved from `botmuxInstallRoot()` — on a
+     * FRESH process there is no `lastSuccessfulUpdatePlan` yet, so that is "/" and
+     * the plan resolution throws. Net effect: the UI offers a rollback button whose
+     * first click always fails.
+     *
+     * Both endpoints must therefore start from the same strategy. Assert the two
+     * roots agree for every shape that claims support.
+     */
+    const npmBinary = resolveUpdateStrategy(
+      true, '/usr/lib/node_modules/botmux-linux-x64/botmux', '/', {}, '/home/u',
+    );
+    expect(npmBinary.kind).toBe('package-manager');
+    const support = resolveAutoUpdateSupport(npmBinary);
+    expect(support.supported).toBe(true);
+
+    // What rollback must use — the strategy's root, NOT the "/" install root.
+    const rollbackRoot = npmBinary.kind === 'package-manager' ? npmBinary.packageRoot : '';
+    expect(tryResolveGlobalInstallPlan(rollbackRoot, 'linux')).not.toBeNull();
+    // ...and the pre-fix root, to show the two really differ (the defect).
+    expect(tryResolveGlobalInstallPlan('/', 'linux')).toBeNull();
+
+    // A self-replacing binary is the reverse case: update supported, rollback NOT,
+    // which is why rollbackSupported is reported separately rather than derived.
+    const curl = resolveUpdateStrategy(true, '/home/u/.botmux/bin/botmux', '/', {}, '/home/u');
+    expect(resolveAutoUpdateSupport(curl).supported).toBe(true);
+    expect(resolveAutoUpdateSupport(curl).plan).toBeNull(); // ⟹ rollbackSupported false
+  });
+
+  it('SOURCE GUARD: no update/rollback endpoint feeds resolveGlobalInstallPlan the "/" install root', () => {
+    /**
+     * ⚠️ WHY A SOURCE ASSERTION AND NOT A BEHAVIOURAL ONE. The pure-function test
+     * above proves the two ROOTS differ, but it cannot see which one dashboard.ts
+     * actually passes — verified by mutating the rollback line back to
+     * `botmuxInstallRoot()` and watching every behavioural test stay green. Standing
+     * up the whole dashboard here (auth, sockets, a real package tree) to exercise
+     * one argument is not worth it, so pin the call sites instead.
+     *
+     * THE RULE IS NARROW ON PURPOSE: what must never happen is a root reaching
+     * `resolveGlobalInstallPlan`, because that is the call that throws on "/". Merely
+     * *computing* `botmuxInstallRoot()` is fine and still happens in
+     * /api/update/status, where it feeds `currentUpdateStrategy` (which handles "/"
+     * correctly) plus a display-only manager label. An earlier, broader version of
+     * this guard flagged that benign line and failed on clean master — a guard that
+     * fires on correct code gets deleted, so it is scoped to the plan calls.
+     */
+    const src = readFileSync(resolve('src/dashboard.ts'), 'utf-8');
+    // Every `resolveGlobalInstallPlan(<root>…)` call and the identifier it is given.
+    const roots = [...src.matchAll(/resolveGlobalInstallPlan\(\s*([A-Za-z_$][\w$]*)/g)].map(m => m[1]);
+    expect(roots.length, 'expected to find the plan call sites — did they get renamed?')
+      .toBeGreaterThanOrEqual(2);
+    for (const ident of roots) expect(ident).toBe('packageRoot');
+
+    /**
+     * Every plan call takes a `packageRoot`, and every `packageRoot` assignment must
+     * let the resolved strategy decide. The display-only root in /api/update/status
+     * is named `classifyRoot` precisely so it is outside this rule — it feeds
+     * `currentUpdateStrategy` (which handles "/" correctly) and a label, never a plan.
+     *
+     * A *guarded* `runStrategy.kind === 'package-manager' ? runStrategy.packageRoot :
+     * botmuxInstallRoot()` is correct: that ternary is the Node path, where the install
+     * root IS right. So the rule is "a strategy decides this root", not "the identifier
+     * is absent" — an earlier version asserted the latter and failed on clean code.
+     */
+    const assignments = [...src.matchAll(/const packageRoot =([\s\S]{0,220}?);/g)].map(m => m[1]);
+    expect(assignments.length, 'expected the plan-root assignments — were they renamed?')
+      .toBeGreaterThanOrEqual(2);
+    const offenders = assignments.filter(a => !/(runStrategy|rollbackStrategy)\.packageRoot/.test(a));
+    expect(
+      offenders.map(a => a.replace(/\s+/g, ' ').trim()),
+      'a plan root is chosen without consulting the resolved strategy — botmuxInstallRoot() '
+        + 'is "/" for every compiled binary and resolveGlobalInstallPlan throws on it.',
+    ).toEqual([]);
+    // Positive controls: the strategy-based fallbacks ARE present, so this guard is
+    // asserting against real code rather than passing on an empty search.
+    expect(src).toMatch(/runStrategy\.kind === 'package-manager' \? runStrategy\.packageRoot/);
+    expect(src).toMatch(/\?\?\s*rollbackStrategy\.packageRoot/);
+    // And rollback must refuse anything that is not package-manager driveable.
+    expect(src).toMatch(/rollbackStrategy\.kind !== 'package-manager'/);
+  });
 });
 
 describe('resolveStandaloneRestartExecutable — restart the NEW binary, not the old path', () => {

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Compiled-binary update paths: install-shape classification, the update-strategy
+ * decision, release-asset selection, and the atomic self-replace.
+ *
+ * ── WHY THIS FILE EXISTS ───────────────────────────────────────────────────────
+ * Every update entry point (`botmux update`, dashboard `/api/update/run`, the
+ * scheduled maintenance tick) used to route through
+ * `resolveGlobalInstallPlan(botmuxInstallRoot())`. A compiled single-file binary
+ * has no package.json on disk, so that root is `/` and the plan resolution always
+ * threw — MEASURED on the real published v3.18.4 binary:
+ *
+ *     $ ./botmux --version   → 3.18.4          (baked version works)
+ *     $ ./botmux update      → ❌ 无法安全识别当前安装方式（unknown）
+ *
+ * Since v3.18.x that binary is how botmux ships through BOTH installers, so the
+ * failure covered essentially every user.
+ *
+ * ── WHAT THESE TESTS HAVE TEETH ON ─────────────────────────────────────────────
+ * `vitest` bodies always run under Node, never as a compiled binary, so an
+ * assertion that merely calls the production entry point would exercise the Node
+ * branch and pass no matter what the compiled branch does. Every test below
+ * therefore drives the PURE functions with the standalone flag / execPath passed
+ * in explicitly, which is the only way to reach the compiled branch from Node.
+ * Each was checked by reverting the corresponding fix and confirming it goes red
+ * (see the mutation notes on the individual cases).
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import {
+  classifyBinaryInstall,
+  mainPackageRootForSubpackageBinary,
+  resolveUpdateStrategy,
+} from '../src/core/binary-install-shape.js';
+import { isMuslHost, releaseAssetName, releaseAssetBaseUrl, replaceStandaloneBinary } from '../src/core/binary-self-update.js';
+import { buildRestartLauncher } from '../src/core/maintenance.js';
+import { tryResolveGlobalInstallPlan, formatGlobalInstallCommand } from '../src/utils/global-install.js';
+
+const dirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), 'botmux-bin-update-'));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('classifyBinaryInstall — where the binary lives decides who updates it', () => {
+  it('an npm/pnpm/bun platform subpackage is package-manager owned', () => {
+    for (const p of [
+      '/usr/lib/node_modules/botmux-linux-x64/botmux',
+      '/usr/local/lib/node_modules/botmux-darwin-arm64/botmux',
+      '/usr/lib/node_modules/botmux-linux-arm64-musl/botmux',
+      '/home/u/.bun/install/global/node_modules/botmux-linux-x64/botmux',
+    ]) {
+      expect(classifyBinaryInstall(p, {}, '/home/u'), p).toBe('npm-binary');
+    }
+  });
+
+  it('install.sh\'s location is self-owned, including a custom BOTMUX_INSTALL_DIR', () => {
+    expect(classifyBinaryInstall('/home/u/.botmux/bin/botmux', {}, '/home/u')).toBe('curl-binary');
+    // install.sh honours BOTMUX_INSTALL_DIR; an install that used it must still be
+    // recognised or that user silently loses self-update.
+    expect(classifyBinaryInstall('/opt/bm/botmux', { BOTMUX_INSTALL_DIR: '/opt/bm' }, '/home/u')).toBe('curl-binary');
+    // A trailing slash names the same directory.
+    expect(classifyBinaryInstall('/opt/bm/botmux', { BOTMUX_INSTALL_DIR: '/opt/bm/' }, '/home/u')).toBe('curl-binary');
+  });
+
+  it('FAIL CLOSED: anything else is unknown, so no caller writes where it should not', () => {
+    for (const p of [
+      '/tmp/dist-bin/botmux',              // a local dev build
+      '/usr/bin/botmux',                   // a distro package
+      '/home/u/.botmux/bin/botmux-old',    // a backup beside the real one
+      '/home/u/Downloads/botmux',          // hand-downloaded
+      '',
+    ]) {
+      expect(classifyBinaryInstall(p, {}, '/home/u'), p).toBe('unknown');
+    }
+  });
+
+  it('a directory merely NAMED like a subpackage is not treated as one', () => {
+    // The pattern is anchored on /node_modules/ precisely so this is not a false
+    // positive — otherwise we would hand npm a prefix outside any npm tree.
+    expect(classifyBinaryInstall('/home/u/botmux-linux-x64/botmux', {}, '/home/u')).toBe('unknown');
+  });
+
+  it('the sibling package root translation reuses the tested plan resolver', () => {
+    // The point of translating to the MAIN package root (rather than computing an
+    // npm --prefix here) is that resolveGlobalInstallPlan already knows the
+    // per-manager rules. Assert the composition end to end, including that a Bun
+    // global resolves to BUN and is not forced onto npm.
+    const npmRoot = mainPackageRootForSubpackageBinary('/usr/lib/node_modules/botmux-linux-x64/botmux');
+    expect(npmRoot).toBe('/usr/lib/node_modules/botmux');
+    expect(formatGlobalInstallCommand(tryResolveGlobalInstallPlan(npmRoot!, 'linux')!))
+      .toBe('npm install -g --prefix /usr botmux@latest');
+
+    const bunRoot = mainPackageRootForSubpackageBinary('/home/u/.bun/install/global/node_modules/botmux-linux-x64/botmux');
+    expect(formatGlobalInstallCommand(tryResolveGlobalInstallPlan(bunRoot!, 'linux')!))
+      .toBe('bun add -g botmux@latest');
+
+    expect(mainPackageRootForSubpackageBinary('/home/u/.botmux/bin/botmux')).toBeNull();
+  });
+});
+
+describe('resolveUpdateStrategy', () => {
+  it('NODE PATH IS UNCHANGED: not standalone → the running install root, as before', () => {
+    // Regression guard for the deployments that currently work. Whatever execPath
+    // says, a Node run must still be classified by its package root.
+    expect(resolveUpdateStrategy(false, '/usr/bin/node', '/opt/botmux', {}, '/home/u'))
+      .toEqual({ kind: 'package-manager', packageRoot: '/opt/botmux' });
+  });
+
+  it('standalone in a package-manager tree → that manager, NOT a self-replace', () => {
+    // npm owns that file. Writing it ourselves would be clobbered by npm's next
+    // install, or leave a binary whose version npm's metadata disagrees with.
+    expect(resolveUpdateStrategy(true, '/usr/lib/node_modules/botmux-linux-x64/botmux', '/', {}, '/home/u'))
+      .toEqual({ kind: 'package-manager', packageRoot: '/usr/lib/node_modules/botmux' });
+  });
+
+  it('standalone at the install.sh location → self-replace that exact file', () => {
+    expect(resolveUpdateStrategy(true, '/home/u/.botmux/bin/botmux', '/', {}, '/home/u'))
+      .toEqual({ kind: 'self-replace', target: '/home/u/.botmux/bin/botmux' });
+  });
+
+  it('THE BUG: a standalone binary must never fall back to the "/" install root', () => {
+    // This is the whole defect in one assertion. Before the fix the compiled
+    // binary reached resolveGlobalInstallPlan("/") — measured to throw
+    // UnsupportedGlobalInstallError, which is what printed
+    // “无法安全识别当前安装方式（unknown）” on the real v3.18.4 binary.
+    //
+    // MUTATION CHECK: making the standalone branch fall through to
+    // `{kind:'package-manager', packageRoot: installRoot}` turns this red for both
+    // shapes below.
+    const npmShape = resolveUpdateStrategy(true, '/usr/lib/node_modules/botmux-linux-x64/botmux', '/', {}, '/home/u');
+    const curlShape = resolveUpdateStrategy(true, '/home/u/.botmux/bin/botmux', '/', {}, '/home/u');
+    for (const s of [npmShape, curlShape]) {
+      expect(s.kind).not.toBe('unsupported');
+      if (s.kind === 'package-manager') expect(s.packageRoot).not.toBe('/');
+    }
+    // And "/" must not be resolvable as a plan either — the premise of the bug.
+    expect(tryResolveGlobalInstallPlan('/', 'linux')).toBeNull();
+  });
+
+  it('an unidentifiable standalone binary stays unsupported (fail closed)', () => {
+    expect(resolveUpdateStrategy(true, '/tmp/dist-bin/botmux', '/', {}, '/home/u'))
+      .toEqual({ kind: 'unsupported', reason: 'unknown-binary-location' });
+  });
+});
+
+describe('release asset selection', () => {
+  it('musl is only claimed when positively observed', () => {
+    // The false-positive direction is the dangerous one: a glibc box handed the
+    // musl asset gets a binary that cannot start at all.
+    expect(isMuslHost('linux', { glibcRuntime: () => '2.36', listDir: () => ['ld-musl-x86_64.so.1'], exists: () => true }))
+      .toBe(false); // a reported glibc runtime settles it, even with musl files present
+    expect(isMuslHost('linux', { glibcRuntime: () => undefined, listDir: () => ['ld-musl-x86_64.so.1'], exists: () => false }))
+      .toBe(true);
+    expect(isMuslHost('linux', { glibcRuntime: () => undefined, listDir: () => [], exists: (p) => p === '/etc/alpine-release' }))
+      .toBe(true);
+    expect(isMuslHost('linux', { glibcRuntime: () => undefined, listDir: () => [], exists: () => false }))
+      .toBe(false); // never guess musl
+    expect(isMuslHost('darwin', { glibcRuntime: () => undefined, listDir: () => ['ld-musl-x86_64.so.1'], exists: () => true }))
+      .toBe(false); // darwin has no musl split
+  });
+
+  it('asset names match what release.yml uploads and install.sh downloads', () => {
+    expect(releaseAssetName('linux', 'x64', false)).toBe('botmux-linux-x64');
+    expect(releaseAssetName('linux', 'x64', true)).toBe('botmux-linux-x64-musl');
+    expect(releaseAssetName('linux', 'arm64', true)).toBe('botmux-linux-arm64-musl');
+    // musl must not leak onto darwin even if the flag is somehow true.
+    expect(releaseAssetName('darwin', 'arm64', true)).toBe('botmux-darwin-arm64');
+    // No published build → null rather than a name that 404s.
+    expect(releaseAssetName('win32', 'x64', false)).toBeNull();
+    expect(releaseAssetName('linux', 'riscv64', false)).toBeNull();
+  });
+
+  it('the asset names agree EXACTLY with install.sh (the two must not drift)', () => {
+    // install.sh is the other consumer of these names. If either side renames an
+    // asset the other silently 404s, so pin them against each other by executing
+    // install.sh's own construction rather than re-reading our own constant.
+    const sh = readFileSync(resolve('install.sh'), 'utf-8');
+    expect(sh).toMatch(/asset="botmux-\$\{os_tag\}-\$\{arch_tag\}"/);
+    expect(sh).toMatch(/asset="\$\{asset\}-musl"/);
+    for (const [os, arch] of [['linux', 'x64'], ['linux', 'arm64'], ['darwin', 'arm64']] as const) {
+      const built = execFileSync('sh', ['-c',
+        `os_tag=${os}; arch_tag=${arch}; asset="botmux-\${os_tag}-\${arch_tag}"; printf '%s' "$asset"`,
+      ], { encoding: 'utf-8' });
+      expect(releaseAssetName(os as NodeJS.Platform, arch, false)).toBe(built);
+    }
+  });
+
+  it('the download base is the tagged release, with exactly one v prefix', () => {
+    expect(releaseAssetBaseUrl('3.18.4'))
+      .toBe('https://github.com/deepcoldy/botmux/releases/download/v3.18.4');
+    // A caller that already has the "v" must not produce ".../vv3.18.4".
+    expect(releaseAssetBaseUrl('v3.18.4')).toBe(releaseAssetBaseUrl('3.18.4'));
+  });
+});
+
+describe('buildRestartLauncher — the compiled binary dispatches its own subcommand', () => {
+  it('Node path unchanged: node <cli.js> restart', () => {
+    expect(buildRestartLauncher('/usr/bin/node', '/opt/botmux/dist/cli.js', false, false))
+      .toEqual({ cmd: '/usr/bin/node', args: ['/opt/botmux/dist/cli.js', 'restart'] });
+    expect(buildRestartLauncher('/usr/bin/node', '/opt/botmux/dist/cli.js', true, false))
+      .toEqual({ cmd: 'setsid', args: ['/usr/bin/node', '/opt/botmux/dist/cli.js', 'restart'] });
+  });
+
+  it('THE BUG: standalone must not be handed a cli.js path — it lands in argv[2]', () => {
+    // MEASURED on the real v3.18.4 binary: `<binary> /dist/cli.js restart` makes
+    // argv[2] the PATH, so the CLI matched no command, printed the help banner and
+    // **exited 0** — a restart that silently never happened while reporting
+    // success. `restart` must therefore be the FIRST argument.
+    //
+    // MUTATION CHECK: reverting `entryArgs` to the unconditional
+    // `[cliEntry, 'restart']` turns both assertions red.
+    const direct = buildRestartLauncher('/home/u/.botmux/bin/botmux', '/dist/cli.js', false, true);
+    expect(direct).toEqual({ cmd: '/home/u/.botmux/bin/botmux', args: ['restart'] });
+    expect(direct.args[0]).toBe('restart');
+
+    const viaSetsid = buildRestartLauncher('/home/u/.botmux/bin/botmux', '/dist/cli.js', true, true);
+    expect(viaSetsid).toEqual({ cmd: 'setsid', args: ['/home/u/.botmux/bin/botmux', 'restart'] });
+    // Whatever the launcher shape, no argument may be a cli.js path.
+    for (const shape of [direct, viaSetsid]) {
+      expect(shape.args.some(a => a.endsWith('cli.js'))).toBe(false);
+    }
+  });
+});
+
+describe('replaceStandaloneBinary — atomic swap of a live executable', () => {
+  const BIG = 1_100_000; // over the "this is an error page, not a binary" floor
+
+  function fakeAsset(byte = 0x41, size = BIG): Buffer {
+    return Buffer.alloc(size, byte);
+  }
+  function sha256(buf: Buffer): string {
+    return createHash('sha256').update(buf).digest('hex');
+  }
+
+  it('verifies the published checksum and lands the new bytes', async () => {
+    const dir = tmp();
+    const target = join(dir, 'botmux');
+    writeFileSync(target, 'OLD BINARY', { mode: 0o755 });
+    const payload = fakeAsset();
+    const r = await replaceStandaloneBinary('3.99.0', target, {
+      fetchStream: async () => Readable.from([payload]),
+      fetchChecksum: async () => sha256(payload),
+    });
+    expect(r.bytes).toBe(BIG);
+    expect(statSync(target).size).toBe(BIG);
+    // Executable bit must be set or the launcher's `exec` fails at RUN time.
+    expect(statSync(target).mode & 0o111).not.toBe(0);
+  });
+
+  it('a checksum mismatch leaves the WORKING binary in place', async () => {
+    const dir = tmp();
+    const target = join(dir, 'botmux');
+    writeFileSync(target, 'OLD BINARY', { mode: 0o755 });
+    await expect(replaceStandaloneBinary('3.99.0', target, {
+      fetchStream: async () => Readable.from([fakeAsset()]),
+      fetchChecksum: async () => 'f'.repeat(64), // wrong on purpose
+    })).rejects.toThrow(/SHA-256/);
+    // The old binary must survive — a failed update must never brick the install.
+    expect(readFileSync(target, 'utf-8')).toBe('OLD BINARY');
+    // And no temp file may be left behind next to it.
+    expect(execFileSync('ls', ['-A', dir], { encoding: 'utf-8' }).trim().split('\n').sort())
+      .toEqual(['botmux']);
+  });
+
+  it('a truncated download (no checksum published) is rejected, not installed', async () => {
+    // GitHub serving an HTML error page is the real shape here: a few hundred
+    // bytes that would replace a working 100MB+ executable.
+    const dir = tmp();
+    const target = join(dir, 'botmux');
+    writeFileSync(target, 'OLD BINARY', { mode: 0o755 });
+    await expect(replaceStandaloneBinary('3.99.0', target, {
+      fetchStream: async () => Readable.from([Buffer.from('<html>404 Not Found</html>')]),
+      fetchChecksum: async () => null, // release published no .sha256
+    })).rejects.toThrow(/字节/);
+    expect(readFileSync(target, 'utf-8')).toBe('OLD BINARY');
+  });
+
+  it('a mid-download network failure leaves no temp file and no damage', async () => {
+    const dir = tmp();
+    const target = join(dir, 'botmux');
+    writeFileSync(target, 'OLD BINARY', { mode: 0o755 });
+    await expect(replaceStandaloneBinary('3.99.0', target, {
+      fetchStream: async () => new Readable({
+        read() { this.destroy(new Error('ECONNRESET')); },
+      }),
+      fetchChecksum: async () => null,
+    })).rejects.toThrow();
+    expect(readFileSync(target, 'utf-8')).toBe('OLD BINARY');
+    expect(execFileSync('ls', ['-A', dir], { encoding: 'utf-8' }).trim().split('\n').sort())
+      .toEqual(['botmux']);
+  });
+
+  it('the temp file is a SIBLING of the target (an EXDEV rename would fail)', async () => {
+    // The swap must be a rename within one filesystem. Writing to os.tmpdir() and
+    // renaming across devices fails with EXDEV, and copying instead would
+    // reintroduce the torn-file window the rename exists to avoid.
+    const dir = tmp();
+    const target = join(dir, 'nested', 'botmux');
+    mkdirSync(join(dir, 'nested'), { recursive: true });
+    writeFileSync(target, 'OLD', { mode: 0o755 });
+    const seen: string[] = [];
+    const payload = fakeAsset();
+    await replaceStandaloneBinary('3.99.0', target, {
+      fetchStream: async () => Readable.from([payload]),
+      // Sample AFTER the download has been written but BEFORE the rename:
+      // fetchChecksum runs in exactly that window. (Sampling from fetchStream
+      // instead sees nothing — the temp path is computed before the fetch but the
+      // file itself is only created by the pipeline that consumes the stream.)
+      fetchChecksum: async () => {
+        seen.push(...execFileSync('ls', ['-A', join(dir, 'nested')], { encoding: 'utf-8' }).trim().split('\n'));
+        return sha256(payload);
+      },
+    });
+    expect(seen.some(f => f.startsWith('.botmux-update.'))).toBe(true);
+    // ...and it must have been a sibling of the target, not in os.tmpdir().
+    expect(seen).toContain('botmux');
+    expect(statSync(target).size).toBe(BIG);
+  });
+
+  /**
+   * The load-bearing OS fact behind the whole design, asserted directly.
+   *
+   * MEASURED on Linux with a real ELF: writing into the executable of a LIVE
+   * process fails with ETXTBSY, while renaming a new file over the path succeeds
+   * and the running process keeps executing the old inode. If this ever stopped
+   * holding, `replaceStandaloneBinary` would need a different strategy — so pin
+   * the fact rather than only the code that relies on it.
+   */
+  it('OS FACT: in-place write on a running executable is ETXTBSY; rename is not', () => {
+    const dir = tmp();
+    const bin = join(dir, 'live');
+    // A real ELF, not a shell script: the kernel only holds the text lock for a
+    // mapped executable. (Measured: a #!/bin/sh script accepts the in-place write,
+    // which is exactly why a script is not a valid proxy for this test.)
+    execFileSync('cp', ['/bin/sleep', bin]);
+    chmodSync(bin, 0o755);
+    const child = spawnSync('sh', ['-c', `"${bin}" 2 & echo $!; sleep 0.4`], { encoding: 'utf-8' });
+    expect(child.status).toBe(0);
+
+    // (a) in-place write → ETXTBSY while it runs
+    const write = spawnSync(process.execPath, ['-e', `
+      try { require('fs').writeFileSync(${JSON.stringify(bin)}, 'X', {flag:'r+'}); console.log('WROTE'); }
+      catch (e) { console.log(e.code); }
+    `], { encoding: 'utf-8' });
+    // The child sleep may already have exited on a slow box; accept either the
+    // busy error or a clean write, but never a crash — the assertion that matters
+    // is (b), which must ALWAYS work.
+    expect(['ETXTBSY', 'WROTE']).toContain((write.stdout || '').trim());
+
+    // (b) rename over it → always allowed
+    const fresh = join(dir, 'fresh');
+    execFileSync('cp', ['/bin/echo', fresh]);
+    expect(() => execFileSync(process.execPath, ['-e',
+      `require('fs').renameSync(${JSON.stringify(fresh)}, ${JSON.stringify(bin)})`,
+    ])).not.toThrow();
+  });
+});

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -37,8 +37,9 @@ import {
   resolveUpdateStrategy,
 } from '../src/core/binary-install-shape.js';
 import { isMuslHost, releaseAssetName, releaseAssetBaseUrl, replaceStandaloneBinary } from '../src/core/binary-self-update.js';
-import { buildRestartLauncher } from '../src/core/maintenance.js';
-import { tryResolveGlobalInstallPlan, formatGlobalInstallCommand } from '../src/utils/global-install.js';
+import { buildRestartLauncher, resolveStandaloneRestartExecutable } from '../src/core/maintenance.js';
+import { tryResolveGlobalInstallPlan, formatGlobalInstallCommand, resolveAutoUpdateSupport } from '../src/utils/global-install.js';
+import { botmuxVersionAt, diskVersionAt } from '../src/utils/install-info.js';
 
 const dirs: string[] = [];
 function tmp(): string {
@@ -64,11 +65,22 @@ describe('classifyBinaryInstall — where the binary lives decides who updates i
 
   it('install.sh\'s location is self-owned, including a custom BOTMUX_INSTALL_DIR', () => {
     expect(classifyBinaryInstall('/home/u/.botmux/bin/botmux', {}, '/home/u')).toBe('curl-binary');
-    // install.sh honours BOTMUX_INSTALL_DIR; an install that used it must still be
-    // recognised or that user silently loses self-update.
+    // install.sh honours BOTMUX_INSTALL_DIR, and it is recognised WHEN STILL
+    // EXPORTED at runtime. It usually is not (the installer is normally invoked as
+    // `BOTMUX_INSTALL_DIR=… sh install.sh`, which does not persist it) — see the
+    // fail-closed case asserted below.
     expect(classifyBinaryInstall('/opt/bm/botmux', { BOTMUX_INSTALL_DIR: '/opt/bm' }, '/home/u')).toBe('curl-binary');
     // A trailing slash names the same directory.
     expect(classifyBinaryInstall('/opt/bm/botmux', { BOTMUX_INSTALL_DIR: '/opt/bm/' }, '/home/u')).toBe('curl-binary');
+  });
+
+  it('a custom-dir install without the env var at runtime fails CLOSED, not wrong', () => {
+    // The honest limitation: nothing is damaged (we never write), but self-update is
+    // unavailable for that install. Asserted so the behaviour is deliberate rather
+    // than an accident, and so the docs cannot drift into claiming full coverage.
+    expect(classifyBinaryInstall('/opt/bm/botmux', {}, '/home/u')).toBe('unknown');
+    expect(resolveUpdateStrategy(true, '/opt/bm/botmux', '/', {}, '/home/u'))
+      .toEqual({ kind: 'unsupported', reason: 'unknown-binary-location' });
   });
 
   it('FAIL CLOSED: anything else is unknown, so no caller writes where it should not', () => {
@@ -269,6 +281,110 @@ describe('buildRestartLauncher — the compiled binary dispatches its own subcom
     for (const shape of [direct, viaSetsid]) {
       expect(shape.args.some(a => a.endsWith('cli.js'))).toBe(false);
     }
+  });
+});
+
+describe('the baked version must not shadow a completed update (BOTH strategies)', () => {
+  /**
+   * `botmuxVersionAt` returns the compile-time baked version for ANY directory,
+   * which is right for "what am I running" and WRONG for "what is now installed".
+   * After a package-manager update rewrites the install's package.json, a compiled
+   * binary asking `botmuxVersionAt(root)` still gets its OWN old version — so the
+   * maintenance tick's `after !== before` gate stays false and it never restarts
+   * onto what it just installed, and the dashboard reports `changed: false`.
+   *
+   * `diskVersionAt` exists to bypass the baked value for exactly those post-update
+   * reads. MUTATION CHECK: making `diskVersionAt` delegate to `botmuxVersionAt`
+   * turns the first assertion red.
+   */
+  it('diskVersionAt reads package.json even when a baked version is present', () => {
+    const dir = tmp();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ version: '3.19.0' }));
+    const prev = process.env.BOTMUX_BAKED_VERSION;
+    process.env.BOTMUX_BAKED_VERSION = '3.18.4'; // as a compiled binary carries
+    try {
+      // The shadowing itself — this is the behaviour that caused the bug.
+      expect(botmuxVersionAt(dir)).toBe('3.18.4');
+      // ...and the bypass used by every post-update read.
+      expect(diskVersionAt(dir)).toBe('3.19.0');
+    } finally {
+      if (prev === undefined) delete process.env.BOTMUX_BAKED_VERSION;
+      else process.env.BOTMUX_BAKED_VERSION = prev;
+    }
+  });
+
+  it('under Node (no baked version) the two agree — so nothing changes there', () => {
+    const dir = tmp();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ version: '3.19.0' }));
+    const prev = process.env.BOTMUX_BAKED_VERSION;
+    delete process.env.BOTMUX_BAKED_VERSION;
+    try {
+      expect(diskVersionAt(dir)).toBe(botmuxVersionAt(dir));
+      expect(diskVersionAt(dir)).toBe('3.19.0');
+    } finally {
+      if (prev !== undefined) process.env.BOTMUX_BAKED_VERSION = prev;
+    }
+  });
+
+  it('an unreadable root degrades to 0.0.0, matching botmuxVersionAt', () => {
+    expect(diskVersionAt(join(tmp(), 'nope'))).toBe('0.0.0');
+  });
+});
+
+describe('auto-update support is ONE predicate for UI and save-time validation', () => {
+  // These used to be answered separately: the projection ran
+  // `tryResolveGlobalInstallPlan()` (false for every compiled binary, root "/")
+  // while the save path used the shape resolver — so the backend accepted a toggle
+  // the frontend rendered as disabled.
+  it('self-replace is supported without any package-manager plan', () => {
+    const r = resolveAutoUpdateSupport({ kind: 'self-replace', target: '/home/u/.botmux/bin/botmux' });
+    expect(r.supported).toBe(true);
+    expect(r.plan).toBeNull();
+  });
+
+  it('a package-manager binary is supported only when its plan resolves', () => {
+    expect(resolveAutoUpdateSupport({ kind: 'package-manager', packageRoot: '/usr/lib/node_modules/botmux' }).supported)
+      .toBe(true);
+    // Yarn is knowingly not driveable — promising support would offer an update
+    // that throws. (This is the case my first implementation got wrong by
+    // returning true for ANY npm-binary shape.)
+    expect(resolveAutoUpdateSupport({ kind: 'package-manager', packageRoot: '/root/.config/yarn/global/node_modules/botmux' }).supported)
+      .toBe(false);
+    // And the pre-fix compiled-binary root.
+    expect(resolveAutoUpdateSupport({ kind: 'package-manager', packageRoot: '/' }).supported).toBe(false);
+  });
+
+  it('unsupported stays unsupported', () => {
+    expect(resolveAutoUpdateSupport({ kind: 'unsupported', reason: 'unknown-binary-location' }).supported).toBe(false);
+  });
+});
+
+describe('resolveStandaloneRestartExecutable — restart the NEW binary, not the old path', () => {
+  const LAUNCHER = '/root/.botmux/bin/botmux';
+  // pnpm's virtual store puts the VERSION in the running path.
+  const PNPM_OLD = '/root/.local/share/pnpm/global/5/.pnpm/botmux-linux-x64@3.18.4/node_modules/botmux-linux-x64/botmux';
+
+  it('a package-manager binary restarts via the stable launcher', () => {
+    // After the update, postinstall re-pointed the launcher at the NEW subpackage
+    // while this process's execPath still names the OLD versioned one. Restarting
+    // from execPath would ENOENT (store entry pruned) or silently run the old
+    // binary — an update that reports success and does not take effect.
+    expect(resolveStandaloneRestartExecutable(true, PNPM_OLD, 'npm-binary', LAUNCHER, true)).toBe(LAUNCHER);
+  });
+
+  it('falls back to execPath when no launcher exists (pre-existing behaviour)', () => {
+    expect(resolveStandaloneRestartExecutable(true, PNPM_OLD, 'npm-binary', LAUNCHER, false)).toBe(PNPM_OLD);
+  });
+
+  it('a self-replaced binary keeps its own path — we swapped the bytes there', () => {
+    expect(resolveStandaloneRestartExecutable(true, LAUNCHER, 'curl-binary', LAUNCHER, true)).toBe(LAUNCHER);
+    // Even a curl install at a custom dir restarts itself, not the default launcher.
+    expect(resolveStandaloneRestartExecutable(true, '/opt/bm/botmux', 'curl-binary', LAUNCHER, true))
+      .toBe('/opt/bm/botmux');
+  });
+
+  it('NODE PATH UNCHANGED: never redirected away from execPath', () => {
+    expect(resolveStandaloneRestartExecutable(false, '/usr/bin/node', 'unknown', LAUNCHER, true)).toBe('/usr/bin/node');
   });
 });
 

--- a/test/maintenance.test.ts
+++ b/test/maintenance.test.ts
@@ -179,6 +179,79 @@ describe('runMaintenanceTick', () => {
   });
 });
 
+describe('runMaintenanceTick — a binary self-replace still triggers the restart', () => {
+  /**
+   * THE SUBTLE BUG THIS PINS. For a package-manager update the new version lands
+   * in the install's package.json, so re-reading it afterwards observes the
+   * change, and `after !== before` is what gates the restart.
+   *
+   * A compiled binary has NO package.json: its version is BAKED IN at compile time
+   * and read from the RUNNING process's own env. MEASURED: after swapping the file
+   * on disk, `currentVersion()` still returns the OLD version. So the naive tick
+   * computes `after === before`, logs "already on the latest version", and never
+   * restarts onto the binary it just installed — the update silently does not
+   * take effect until something else restarts the fleet.
+   *
+   * `installedVersion()` is therefore authoritative when set.
+   */
+  function selfReplaceDeps(reported: string, running = '3.18.4') {
+    const calls = { update: 0, restart: 0, intents: [] as RestartIntent[], logs: [] as string[] };
+    const deps: MaintenanceDeps = {
+      now: () => NOON,
+      readConfig: () => ({ autoUpdate: { enabled: true, time: '12:00' }, autoRestart: { enabled: true } }),
+      readState: () => ({}),
+      writeState: () => {},
+      anyBusy: () => false,
+      isLocalDev: () => false,
+      withUpdateLock: (fn) => fn(),
+      // Deliberately CONSTANT: a self-replace cannot change what this process reports.
+      currentVersion: () => running,
+      runUpdate: () => { calls.update++; },
+      installedVersion: () => reported,
+      writeIntent: (i) => { calls.intents.push(i); },
+      triggerRestart: () => { calls.restart++; },
+      log: (m) => { calls.logs.push(m); },
+    };
+    return { deps, calls };
+  }
+
+  it('restarts using the version the self-replace reported, not the re-read one', () => {
+    const { deps, calls } = selfReplaceDeps('3.19.0', '3.18.4');
+    runMaintenanceTick(deps);
+    expect(calls.update).toBe(1);
+    // MUTATION CHECK: dropping `installedVersion` from the tick (i.e. going back
+    // to `after = deps.currentVersion()`) makes both of these fail — restart 0 and
+    // no intent — which is exactly the silent no-op described above.
+    expect(calls.restart).toBe(1);
+    expect(calls.intents).toEqual([
+      { kind: 'update', oldVersion: '3.18.4', newVersion: '3.19.0', at: new Date(NOON).toISOString() },
+    ]);
+    expect(calls.logs.join('\n')).not.toMatch(/already on the latest/);
+  });
+
+  it('an unchanged version still means "already latest" (no spurious restart)', () => {
+    // The guard must not fire merely because installedVersion is populated.
+    const { deps, calls } = selfReplaceDeps('3.18.4', '3.18.4');
+    runMaintenanceTick(deps);
+    expect(calls.restart).toBe(0);
+    expect(calls.intents).toEqual([]);
+    expect(calls.logs.join('\n')).toMatch(/already on the latest/);
+  });
+
+  it('the package-manager path is unaffected: an empty report falls back to re-reading', () => {
+    // Regression guard for the currently-working npm path — it reports '' and must
+    // keep using the before/after comparison.
+    const { deps, calls } = makeDeps(
+      { autoUpdate: { enabled: true, time: '12:00' }, autoRestart: { enabled: true } },
+      { startVer: '2.64.0', installTo: '2.65.0' },
+    );
+    (deps as MaintenanceDeps).installedVersion = () => '';
+    runMaintenanceTick(deps);
+    expect(calls.restart).toBe(1);
+    expect(calls.intents[0]).toMatchObject({ oldVersion: '2.64.0', newVersion: '2.65.0' });
+  });
+});
+
 describe('buildRestartLauncher', () => {
   const NODE = '/usr/bin/node';
   const CLI = '/opt/botmux/dist/cli.js';


### PR DESCRIPTION
## 问题

`botmux update`、Dashboard 手动更新、定时自动更新三处在**编译版单文件二进制**下全部失效。在**真实发布的 v3.18.4 二进制**上端到端复现（不是推理）：

```
$ ./botmux --version
3.18.4                                   ← 版本号是对的（baked 生效）
$ ./botmux update
❌ 无法安全识别当前安装方式（unknown），请使用原包管理器手动更新 botmux。
```

自 v3.18.x 起这个二进制是 **npm 和 install.sh 两种装法的共同产物**，所以这条基本覆盖了所有用户。

## 根因

三处都走 `resolveGlobalInstallPlan(botmuxInstallRoot())`，而它按「install root 的**路径形态**」判包管理器。编译版没有 `package.json` 落盘（模块图在虚拟 `/$bunfs/`），`packageRoot()` 一路向上走到 `/` 才停。实测（真编译探针 + 真发布二进制，两边逐字相同）：

```json
{ "installRoot": "/", "detectedManager": "unknown", "planIsNull": true,
  "cliEntry": "/dist/cli.js", "cliEntryExists": false }
```

## 关键点：两种装法是**同一个二进制**

很容易以为「npm 用户走 npm 的更新、curl 用户走 curl 的更新」是两种产物之间的分流。**不是**——自 #1047 去掉 `bin` 字段后，`npm i -g botmux` 装的是平台子包里的编译版二进制，postinstall 写个 launcher `exec` 它；install.sh 下载的是**同一个**二进制。同样的字节，只是位置不同。

所以按**模块图**判形态必然失败（两边都是 `/`），按**位置**判才可行。`process.execPath` 正是那个还有区别的东西（实测，且是通过各自 launcher 调起来的真实形态）：

| 装法 | `process.execPath` |
|---|---|
| npm | `…/node_modules/botmux-linux-x64/botmux` |
| curl | `~/.botmux/bin/botmux`（`BOTMUX_INSTALL_DIR` 可改） |

## 改动

- **新增 `core/binary-install-shape.ts`**（纯函数、零依赖）：判形态 + 给出更新策略。npm 子包形态**翻译成同级主包根**后交回已有的 `resolveGlobalInstallPlan`，而不是重推一遍 npm prefix——后者会变成同一套规则的第二份实现，且会把 pnpm/bun 全局装错误地逼上 npm（实测翻译后 bun 全局仍正确解析成 `bun add -g`）。拆成独立叶子模块是为了让 `utils/global-install.ts` 能引它而不成环（双向实测无环）。
- **新增 `core/binary-self-update.ts`**：install.sh 形态自替换——下载资产 → 校验 SHA-256 → **原子 rename**。musl 判据与 install.sh / postinstall 同序，且只在**正向观测到**时才认 musl。
- **抽出 `core/release-download.ts`**：复用 hd2d 已有的「代理感知 + 重定向逐跳拆连接」下载逻辑，不再复制一份（规范化比对验证**移动前后语义逐字相同**，仅 UA 从模块常量变成参数）。
- 三处入口接上策略解析；新增 `resolveAutoUpdateSupport()` 作为**唯一判据**，供设置页 projection 与写入校验共用（否则前端画灰、后端放行）。

### 顺带修掉的同源缺陷

1. `isLocalDevInstall()` 编译态判的是「**`/`** 有没有 `.git`/`src`」。本机恰好都没有所以侥幸正确，但 `/src` 存在的镜像里编译版会被误判成源码 checkout，转去跑 `git pull --ff-only`。
2. `spawnDetachedRestart` 拼 `[cliEntry,'restart']`，编译态 `argv[2]` 是路径不是 `restart`。实测**打印 help 后 exit 0**，即「以为重启了其实没重启」。
3. **baked 版本遮蔽**：`botmuxVersionAt` 对**任何目录**都让 baked 值优先，所以自替换后、以及**包管理器装的编译版更新后**，`currentVersion()` 都仍报旧版本 ⟹ `after===before` ⟹ tick 报「已是最新」且不重启；dashboard `changed` 恒 false；rollback 更会**每次都报 `installed_version_mismatch`**。新增 `diskVersionAt()`（显式忽略 baked）供所有 post-install 读取使用。
4. **pnpm 版本化 store**：更新后 `process.execPath` 仍指旧版本路径 ⟹ ENOENT 或**由旧二进制拉起 supervisor**。新增 `resolveStandaloneRestartExecutable()`，包管理器形态走稳定 launcher。
5. **回退能力单独下发**：Web 原先用 `updateSupported` 推导 `rollbackSupported`，而 rollback 只会驱动包管理器 ⟹ curl 装的会看到必然失败的按钮。后端显式下发，且 rollback 端点也改为按策略解析根（否则 npm 编译版**首次回退**仍挂）。

## 影响面

动了 `core/` 公共层 + dashboard + cli 三处热路径，但**Node 形态全部逐字不变**：strategy 在非 standalone 时直接返回原 `installRoot`；`diskVersionAt` 在无 baked 值时与 `botmuxVersionAt` 等价。受影响的只有编译版二进制这一形态，也就是当前 npm / install.sh 的默认产物。

## 验证

- `tsc` 0 错；`bun run build` 过（含 dashboard bundle）。全量单测 **19058 passed / 8 failed**，4 个红文件用**干净基线 worktree（`61c46f932`）逐文件对照全部一致**⟹均为既有。其中 `plugin-mcp-sandbox` 在基线上因缺 `dist` 被 skip、在我这儿因有 `dist` 才跑起来，给基线补跑 `bun run build` 后同样 `2 failed | 1 passed`，确认与本 PR 无关。
- **真实二进制 A/B**：PRE（v3.18.4 发布版）`update` 报 unknown；POST 同样调用真的下载并替换成功，**替换后二进制 `--version` 输出 3.18.4**，目录内无残留临时文件。npm 形态实测走 `npm install -g --prefix … botmux@latest` 并真装进推导出的 prefix。`__self-update` 子命令（maintenance 侧驱动的那条）端到端通，且**从 npm 拥有的树里跑会 fail-closed 拒绝**、那个二进制字节数前后一致。
- 相关 11 个测试文件 **203 条全绿**；**14 组反变异全红**（restart argv / standalone 落回 installRoot / 去 `node_modules` 锚点 / 跳过校验和 / 去截断下限 / 失败不清理临时文件 / 临时文件挪 `tmpdir` / 默认认 musl / 去 `installedVersion` / `diskVersionAt` 退回 `botmuxVersionAt` / `autoUpdateSupport` 恒 true / 重启目标忽略 launcher / rollback 与 run 两处根各自改回 `botmuxInstallRoot()`）。
- 另实测钉住依赖的 OS 事实：运行中 ELF **就地写入 `ETXTBSY`**、**rename 覆盖成功且运行中进程存活**——这正是必须用 rename 而非写入的原因（shell 脚本不是有效替身，它接受就地写入，测试注释里写明了）。

## 已知限制（如实记录，未声称覆盖）

`BOTMUX_INSTALL_DIR` 只在**运行时仍导出**该变量时才被识别，而 `BOTMUX_INSTALL_DIR=… sh install.sh` 不会持久化它 ⟹ 之后会 fail-closed 成 `unknown`（不破坏任何文件，但自更新不可用）。已补断言把这个限制钉住，避免文档/实现漂移成「已无条件支持 custom dir」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
