### PR TITLE
fix(autostart): 编译版按运行形态渲染启动路径，并修 dashboard 就绪判定过早报错

### DIFF
--- a/src/autostart.ts
+++ b/src/autostart.ts
@@ -9,15 +9,19 @@
  * Windows — installs a per-user Task Scheduler task, or falls back to the
  *            current user's Startup folder if task registration is denied.
  *
- * The unit invokes `node <PKG_ROOT>/dist/cli.js start`, which goes through
- * the same pm2 path as `botmux start`. PATH from the install-time shell is
- * captured into the unit so node-pty / claude / codex resolve correctly when
- * launchd or systemd starts us with a minimal environment.
+ * The boot hook runs `botmux start`, the same path as a manual `botmux start`.
+ * HOW it names botmux depends on the runtime shape — `node <PKG_ROOT>/dist/cli.js`
+ * for a Node install, the compiled binary itself when there is no cli.js on disk;
+ * see {@link launchProgram}, and do not reintroduce a `dist/cli.js` path that is
+ * only correct for one of them. PATH from the install-time shell is captured into
+ * the unit so node-pty / claude / codex resolve correctly when launchd or systemd
+ * starts us with a minimal environment.
  */
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync, readFileSync } from 'node:fs';
 import { homedir, userInfo } from 'node:os';
 import { join, dirname } from 'node:path';
+import { isStandaloneBinary } from './core/self-spawn.js';
 
 export interface AutostartOpts {
   /** Absolute path to the botmux package root (one level up from dist/). */
@@ -26,6 +30,16 @@ export interface AutostartOpts {
   configDir: string;
   /** Absolute path to the daemon log dir (used for launchd stdout/err). */
   logDir: string;
+  /**
+   * Runtime shape override, for tests. Production leaves this unset and the
+   * answer comes from `isStandaloneBinary()`; the boot-hook renderers are pure
+   * functions of their inputs so both shapes can be asserted without building a
+   * real compiled binary. See {@link launchProgram}.
+   */
+  standalone?: boolean;
+  /** Executable to name in the boot hook, for tests. Defaults to
+   *  `process.execPath` (the Node binary, or the compiled binary itself). */
+  execPath?: string;
 }
 
 /** Minimal registration state used by the Dashboard toggle. */
@@ -36,6 +50,41 @@ export interface AutostartState {
 
 const LABEL = 'com.botmux.daemon';
 const SERVICE_NAME = 'botmux.service';
+
+/**
+ * Env marker the generated boot hooks set on themselves, so `botmux start` can
+ * tell it was launched at boot rather than by a person.
+ *
+ * WHY OUR OWN MARKER: systemd's `INVOCATION_ID` would match ANY systemd-run
+ * process, not specifically our boot hook, and launchd/Windows set nothing
+ * comparable — this works identically on all three.
+ *
+ * MUST BE CONSUMED AND DELETED by whoever reads it (see `cmdStart`). The fleet
+ * spawns the supervisor with `{...process.env}`, and daemons/workers/session CLIs
+ * inherit from there; a marker left in the environment would make any later
+ * `botmux start` in a descendant look like a boot hook and silently skip the
+ * autostart refresh and the dashboard hint.
+ */
+export const AUTOSTART_UNIT_ENV = 'BOTMUX_AUTOSTART_UNIT';
+
+/**
+ * Read the boot-hook marker and REMOVE it, whatever it held.
+ *
+ * Must be called before anything that can spawn a child or await: the fleet
+ * supervisor is spawned with `{...process.env}` and daemons/workers/session CLIs
+ * inherit from there, so a marker left in place would make a later `botmux start`
+ * in any descendant look like a boot hook. Dependency probes/installers run as
+ * children too, so "consume on entry" has to mean the very first statement.
+ *
+ * Deleting even on a non-'1' value is deliberate — the marker is single-use, and
+ * leaving a stray unrecognised value behind would keep leaking to children.
+ */
+export function consumeAutostartUnitMarker(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[AUTOSTART_UNIT_ENV];
+  delete env[AUTOSTART_UNIT_ENV];
+  return raw === '1';
+}
+
 const WINDOWS_TASK_NAME = 'botmux-daemon';
 
 function platform(): 'macos' | 'linux' | 'windows' | 'unsupported' {
@@ -57,17 +106,49 @@ function unitPath(): string {
   return join(homedir(), '.config', 'systemd', 'user', SERVICE_NAME);
 }
 
-function nodeBin(): string {
-  // process.execPath is the Node binary that's currently running cli.js.
-  // Using its absolute path means launchd/systemd doesn't have to resolve
-  // `node` from a stripped PATH (and we keep the same Node version the
-  // user installed botmux under, which matters for native modules like
-  // node-pty).
-  return process.execPath;
+/**
+ * The program arguments (executable first) that run botmux from a boot hook.
+ * Callers append the subcommand (`start` / `stop`).
+ *
+ * NODE: `process.execPath` is the Node binary currently running cli.js, and the
+ * script is `<pkgRoot>/dist/cli.js`. Using absolute paths means launchd/systemd
+ * doesn't have to resolve `node` from a stripped PATH (and we keep the same Node
+ * version the user installed botmux under, which matters for native modules like
+ * node-pty).
+ *
+ * COMPILED BINARY: there is NO `dist/cli.js` on disk. The module graph lives in
+ * the virtual, read-only `/$bunfs/`, so `join(pkgRoot,'dist','cli.js')` — pkgRoot
+ * being `__dirname`-derived — yields a path that does not exist outside this
+ * process. That is the documented `__dirname` hazard in CLAUDE.md, and a boot
+ * hook is exactly the "path handed to another process" case it warns about.
+ *
+ * It FAILED SILENTLY, which is why this went unnoticed (MEASURED on a devbox
+ * running the npm-installed compiled binary): the written unit was
+ * `ExecStart=<binary> /$bunfs/dist/cli.js start`, and the binary parses that
+ * bogus path as its subcommand token, does not recognise it, prints the help
+ * text and exits 0. systemd sees success, `start` is swallowed as an argument,
+ * and no daemon ever comes up — so the fleet does not return after a reboot and
+ * nothing anywhere reports an error. `botmux restart` re-synced the unit on every
+ * run, keeping the broken path fresh.
+ *
+ * The binary re-execs itself for every other child process (`resolveEntrySpawn`
+ * in core/self-spawn.ts); a boot hook is the same shape, so it does the same
+ * thing — and `process.execPath` IS the real on-disk binary in compiled mode
+ * (verified: argv[1] is `/$bunfs/root/<name>` while execPath is the true path).
+ */
+export function launchProgram(opts: AutostartOpts): string[] {
+  const exec = opts.execPath ?? process.execPath;
+  const standalone = opts.standalone ?? isStandaloneBinary();
+  if (standalone) return [exec];
+  return [exec, join(opts.pkgRoot, 'dist', 'cli.js')];
 }
 
-function cliJs(opts: AutostartOpts): string {
-  return join(opts.pkgRoot, 'dist', 'cli.js');
+/** {@link launchProgram} plus `sub`, rendered as one command line. `quote`
+ *  wraps each element in double quotes (Windows .bat; systemd/launchd keep the
+ *  historical unquoted/array forms). */
+export function launchCommand(opts: AutostartOpts, sub: string, quote = false): string {
+  const parts = [...launchProgram(opts), sub];
+  return (quote ? parts.map((p) => `"${p}"`) : parts).join(' ');
 }
 
 function currentPath(): string {
@@ -83,9 +164,13 @@ function currentPath(): string {
 
 // ─── macOS (launchd) ─────────────────────────────────────────────────────────
 
-function plistContent(opts: AutostartOpts): string {
-  const node = escapeXml(nodeBin());
-  const cli = escapeXml(cliJs(opts));
+export function plistContent(opts: AutostartOpts): string {
+  // ProgramArguments is an array, so render one <string> per element: the
+  // compiled binary contributes ONE element (itself), a Node install two
+  // (node + dist/cli.js). See launchProgram.
+  const program = launchProgram(opts)
+    .map((p) => `        <string>${escapeXml(p)}</string>`)
+    .join('\n');
   const cwd = escapeXml(opts.configDir);
   const path = escapeXml(currentPath());
   const outLog = escapeXml(join(opts.logDir, 'autostart-out.log'));
@@ -98,8 +183,7 @@ function plistContent(opts: AutostartOpts): string {
     <string>${LABEL}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>${node}</string>
-        <string>${cli}</string>
+${program}
         <string>start</string>
     </array>
     <key>RunAtLoad</key>
@@ -112,6 +196,8 @@ function plistContent(opts: AutostartOpts): string {
     <dict>
         <key>PATH</key>
         <string>${path}</string>
+        <key>${AUTOSTART_UNIT_ENV}</key>
+        <string>1</string>
     </dict>
     <key>StandardOutPath</key>
     <string>${outLog}</string>
@@ -202,10 +288,11 @@ function statusMac(): void {
 
 // ─── Linux (user systemd) ────────────────────────────────────────────────────
 
-function unitContent(opts: AutostartOpts): string {
-  // Type=oneshot + RemainAfterExit=yes because `botmux start` calls pm2
-  // start which forks and returns immediately; without RemainAfterExit
-  // systemd would consider the unit "inactive (dead)" right after launch.
+export function unitContent(opts: AutostartOpts): string {
+  // Type=oneshot + RemainAfterExit=yes because `botmux start` hands the fleet to
+  // the built-in supervisor, which is spawned detached and outlives the starting
+  // process — `botmux start` then returns. Without RemainAfterExit systemd would
+  // consider the unit "inactive (dead)" right after launch.
   return `[Unit]
 Description=botmux daemon (IM <-> AI coding CLI bridge)
 After=network-online.target
@@ -216,8 +303,9 @@ Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=${opts.configDir}
 Environment=PATH=${currentPath()}
-ExecStart=${nodeBin()} ${cliJs(opts)} start
-ExecStop=${nodeBin()} ${cliJs(opts)} stop
+Environment=${AUTOSTART_UNIT_ENV}=1
+ExecStart=${launchCommand(opts, 'start')}
+ExecStop=${launchCommand(opts, 'stop')}
 
 [Install]
 WantedBy=default.target
@@ -243,7 +331,7 @@ function enableLinux(opts: AutostartOpts): void {
     console.error(`❌ 当前会话连不上 user systemd（缺少 DBus / 容器环境）。`);
     console.error(``);
     console.error(`   回退方案：把下面这条写入系统级 cron / rc.local / 你常用的 init：`);
-    console.error(`     ${nodeBin()} ${cliJs(opts)} start`);
+    console.error(`     ${launchCommand(opts, 'start')}`);
     console.error(``);
     console.error(`   或在有 systemd --user 的桌面环境里再次运行 botmux autostart enable。`);
     process.exit(1);
@@ -358,7 +446,7 @@ function windowsLogPath(opts: AutostartOpts, name: string): string {
   return join(opts.logDir, name);
 }
 
-function windowsScriptContent(opts: AutostartOpts): string {
+export function windowsScriptContent(opts: AutostartOpts): string {
   const path = escapeCmdValue(currentPath());
   const cwd = opts.configDir;
   const outLog = windowsLogPath(opts, 'autostart-out.log');
@@ -366,8 +454,9 @@ function windowsScriptContent(opts: AutostartOpts): string {
   return `@echo off
 setlocal
 set "PATH=${path}"
+set "${AUTOSTART_UNIT_ENV}=1"
 cd /d "${cwd}"
-"${nodeBin()}" "${cliJs(opts)}" start >> "${outLog}" 2>> "${errLog}"
+${launchCommand(opts, 'start', true)} >> "${outLog}" 2>> "${errLog}"
 `;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import { acceptedDispatchBotAppIds, activeConversationBotOpenIds, buildDispatchC
 import { withBotSteerDirective } from './core/bot-steer-directive.js';
 import { pickTurnReplyTarget, collectTurnWindowParticipants } from './core/reply-target.js';
 import {
+  consumeAutostartUnitMarker,
   enableAutostart,
   disableAutostart,
   autostartStatus,
@@ -142,9 +143,13 @@ import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from './platform/bi
 import { isRemoteAccessEnabled } from './global-config.js';
 import {
   DASHBOARD_COMMAND_USAGE,
+  dashboardComingUpFromState,
+  dashboardFailureIsTerminal,
   executeDashboardCommand,
   formatDashboardFallbackFailure,
   formatDashboardSuccessLines,
+  formatDashboardUnreachable,
+  shouldKeepWaitingForDashboard,
 } from './cli/dashboard-command.js';
 import { globalInstallUpdateLockTarget, globalInstallUpdateLockTargetIn, installLatestBotmuxSync } from './core/maintenance.js';
 import {
@@ -2315,6 +2320,9 @@ function preflightNodeSanity(): void {
 }
 
 async function cmdStart(): Promise<void> {
+  // FIRST STATEMENT, before any await or dependency probe: those run as child
+  // processes and would inherit the marker. See consumeAutostartUnitMarker.
+  const bootHookStart = consumeAutostartUnitMarker();
   // `--systemd-service` and the PM2-God ownership gating that used to live here
   // are gone with pm2 itself: the built-in supervisor owns single-owner exclusion
   // via fleet-state (pid + kill-0 under the fleet mutation lock), so there is no
@@ -2328,7 +2336,9 @@ async function cmdStart(): Promise<void> {
   await ensureSystemDependencies();
 
   const botsForCheck = await preflightConfiguredBotCredentials();
-  await startConfiguredFleet(botsForCheck);
+  // The boot hook marks itself so purely presentational waiting can be skipped
+  // there (see startConfiguredFleet).
+  await startConfiguredFleet(botsForCheck, { bootHookStart });
 }
 
 /** Validate before systemd handoff so a predictable failure cannot stop the old fleet. */
@@ -2365,7 +2375,7 @@ async function preflightConfiguredBotCredentials() {
 
 async function startConfiguredFleet(
   botsForCheck: ReturnType<typeof loadBotsJson>,
-  options: { systemdServiceStart?: boolean } = {},
+  options: { bootHookStart?: boolean } = {},
 ): Promise<void> {
 
   await withFileLock(PM2_FLEET_MUTATION_LOCK_TARGET, async () => {
@@ -2403,17 +2413,27 @@ async function startConfiguredFleet(
   console.log(`\n✅ daemon 已启动${count > 1 ? ` (${count} 个机器人, 每个独立进程)` : ''}`);
   console.log(`   日志: botmux logs`);
   console.log(`   状态: botmux status`);
-  // If the user previously enabled autostart, sync the unit file in case
-  // node/cli.js paths changed since (nvm switch, npm upgrade, etc.).
-  // A Type=forking unit necessarily has a live start Job/activating state
-  // until this ExecStart child returns. The parent repair transaction already
-  // wrote and daemon-reloaded the unit; self-refresh here would reject that
-  // expected in-flight state and make every systemd start fail.
-  if (!options.systemdServiceStart
+  // If the user previously enabled autostart, sync the unit file in case the
+  // launch paths changed since (nvm switch, npm upgrade, a move between the Node
+  // and compiled forms).
+  // NOT UNDER THE BOOT HOOK ITSELF: the unit is `Type=oneshot` with
+  // `RemainAfterExit=yes`, so this ExecStart child IS the start job — rewriting
+  // and `daemon-reload`ing the very unit that is mid-transaction is at best
+  // pointless and at worst makes the start fail.
+  if (!options.bootHookStart
       && refreshAutostart({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR })) {
-    console.log(`   autostart 主 unit 已同步到当前 Node/cli.js 路径`);
+    console.log(`   autostart 主 unit 已同步到当前启动路径`);
   }
-  await printDashboardHintWithRetry();
+  // NOT UNDER systemd. Nobody reads a dashboard link at boot, and this poll waits
+  // up to DASHBOARD_READY_WAIT_MS (90s) — exactly the DefaultTimeoutStartUSec on a
+  // stock user manager (VERIFIED: `systemctl --user show -p
+  // DefaultTimeoutStartUSec` → 1min 30s), with the credential preflight, legacy
+  // reap and plugin reconcile already spent before we get here. A slow fleet would
+  // push this Type=oneshot unit past that deadline; systemd would call the start a
+  // failure and, under the default KillMode=control-group, take the freshly
+  // started supervisor down with the unit — so fixing the unit's path would be
+  // undone by waiting inside it. Purely presentational: skip it.
+  if (!options.bootHookStart) await printDashboardHintWithRetry();
 }
 
 /**
@@ -2593,11 +2613,18 @@ async function cmdRestart(): Promise<void> {
 
     await reconcilePluginServicesForCli(undefined, { autoOnly: true });
     if (refreshAutostart({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR })) {
-      console.log(`autostart 主 unit 已同步到当前 Node/cli.js 路径`);
+      console.log(`autostart 主 unit 已同步到当前启动路径`);
     }
     console.log('✅ daemon 已重启');
-    await printDashboardHintWithRetry();
   }, { maxWaitMs: 5_000 });
+  // OUTSIDE THE FLEET MUTATION LOCK, deliberately. This poll waits up to
+  // DASHBOARD_READY_WAIT_MS (90s) and reads nothing the lock protects — it only
+  // asks the dashboard for a link. Holding the lock across it would block every
+  // other fleet mutation (`start`, `stop`, `start-bot`, plugin reconcile) for that
+  // whole time, and those callers give up after 5s with a lock timeout. The
+  // restart itself, its health gate, the plugin reconcile and the autostart sync
+  // all stay inside.
+  await printDashboardHintWithRetry();
 }
 
 
@@ -3191,21 +3218,68 @@ async function ensureDevboxDashboardExportForCurrentPort(): Promise<void> {
 }
 
 /**
+ * Is the supervisor going to have a dashboard answering shortly — i.e. is one
+ * running, or scheduled to be? Answers "is it worth waiting", so the question is
+ * about the SUPERVISOR'S INTENT, not about a pid existing at this instant.
+ *
+ * A pid-only check was wrong in a way that reproduced the very bug this helps fix:
+ * after a crash the supervisor records `status='launching', pid=0` and holds a
+ * restart timer (fleet-supervisor.ts, handleExit), so during that backoff a
+ * pid-based check says "not live", the poll stops, and `botmux dashboard` advises a
+ * restart — while the supervisor was about to bring it back on its own.
+ *
+ *  • No live supervisor → nothing will start anything. false.
+ *  • `launching` → true even with pid 0: that IS the supervisor saying "coming up".
+ *  • `online` → the recorded pid must really be alive; an `online` row can outlive
+ *    the process it names (a crash between state writes, or a stale state file).
+ *  • `stopped` / `errored` → the supervisor has given up. false.
+ *  • No row yet → `null`, meaning "cannot tell yet": a just-started supervisor has
+ *    not written the dashboard row, which must not be read as "never will".
+ *
+ * `fleet-runtime` is imported dynamically to match every other use of it in this
+ * file — it pulls in the supervisor machinery, which the CLI deliberately keeps
+ * off its startup path.
+ */
+async function dashboardMemberComingUp(): Promise<boolean | null> {
+  try {
+    const { fleetStatePath, DASHBOARD_PROCESS_NAME } = await import('./core/fleet-runtime.js');
+    const { readFleetState } = await import('./core/fleet-state-store.js');
+    // The mapping itself lives in dashboard-command.ts as a pure function so it is
+    // unit testable; this wrapper only supplies the I/O (state file + pid probe).
+    return dashboardComingUpFromState(
+      readFleetState(fleetStatePath()),
+      DASHBOARD_PROCESS_NAME,
+      (pid) => { try { process.kill(pid, 0); return true; } catch { return false; } },
+    );
+  } catch {
+    return null;                                   // unreadable → cannot tell
+  }
+}
+
+/**
  * Best-effort dashboard hint printed after start/restart. Reads the LIVE link
  * via /__cli/current (non-rotating) so an already-shared URL is preserved.
- * Retries for a few seconds since the dashboard process boots after the daemon;
- * if it still isn't ready, prints a soft fallback so the user isn't blocked.
+ * Retries since the dashboard process boots after the daemon; if it still isn't
+ * ready, prints a soft fallback so the user isn't blocked.
+ *
+ * BUDGET AND STOP CONDITIONS live in `cli/dashboard-command.ts`
+ * (`DASHBOARD_READY_WAIT_MS`, `shouldKeepWaitingForDashboard`) so they are unit
+ * testable and shared with the `botmux dashboard` message below — the two used to
+ * disagree, which is how an operator got told to restart a healthy, still-booting
+ * dashboard. The wait is bounded by LIVENESS as well as by the clock, so a fleet
+ * with the dashboard disabled or already crashed falls through in one tick instead
+ * of hanging for the whole budget. A fast boot is unaffected — the loop returns the
+ * moment the dashboard answers.
  */
 async function printDashboardHintWithRetry(): Promise<void> {
-  const maxWaitMs = 6000;
   const stepMs = 500;
   const started = Date.now();
   let last: Awaited<ReturnType<typeof callDashboardEndpoint>> | null = null;
   // 只在轮询之前做一次：导出结果与「dashboard 起没起来」无关，放在循环体里每轮都会
   // 重新 spawn 一次 merlin-cli，而失败路径最坏每轮付满 5s 超时——本函数自己的预算
-  // 才 6s，实测会把 start/restart 的这段拖到近两倍。
+  // 撑不住，实测会把 start/restart 的这段拖到近两倍。
   await ensureDevboxDashboardExportForCurrentPort();
-  while (Date.now() - started < maxWaitMs) {
+  for (;;) {
     last = await callDashboardEndpoint('/__cli/current');
     if (last.ok) {
       console.log(`   面板: botmux dashboard (${last.url})`);
@@ -3213,11 +3287,14 @@ async function printDashboardHintWithRetry(): Promise<void> {
       if (last.localUrl) console.log(`   本地直连(平台异常时可用): ${last.localUrl}`);
       return;
     }
-    // Terminal states — file-backed secret/token won't appear mid-poll, unlike
-    // a not-yet-listening port. `wrong-service` means the port file points at a
-    // non-dashboard server and discovery already failed to find it, so retrying
-    // won't help either. Don't spin on any of them.
-    if (last.reason === 'no-secret' || last.reason === 'no-active-token' || last.reason === 'wrong-service') break;
+    const keepWaiting = shouldKeepWaitingForDashboard({
+      elapsedMs: Date.now() - started,
+      failure: last,
+      // Only asked when a retry is otherwise possible, so a fast boot never pays
+      // for reading the fleet state.
+      comingUp: dashboardFailureIsTerminal(last) ? false : await dashboardMemberComingUp(),
+    });
+    if (!keepWaiting) break;
     await new Promise(r => setTimeout(r, stepMs));
   }
   // Soft fallback
@@ -3264,12 +3341,19 @@ async function cmdDashboard(args: string[]): Promise<void> {
   const recordedPort = (existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : '')
     || process.env.BOTMUX_DASHBOARD_PORT
     || '7891';
-  if (r.reason === 'no-secret') {
+  // Every non-terminal failure shape is reachable while the dashboard is still
+  // booting, so ask ONCE whether a dashboard member is actually live and let that
+  // decide the advice. Telling the operator to restart a healthy, still-booting
+  // dashboard throws away the boot that was about to succeed — see
+  // dashboardFailureIsTerminal for why `no-secret`/`wrong-service` are transient.
+  const stillComingUp = dashboardFailureIsTerminal(r) ? false : await dashboardMemberComingUp();
+  if (stillComingUp !== false) {
+    console.error(formatDashboardUnreachable(recordedPort, stillComingUp));
+    if (r.reason === 'wrong-service' && r.detail) console.error(`  详情: ${r.detail}`);
+  } else if (r.reason === 'no-secret') {
     console.error('Dashboard not initialised. Run `botmux restart` first.');
   } else if (r.reason === 'unreachable') {
-    console.error(
-      `dashboard process not reachable on 127.0.0.1:${recordedPort} — \`botmux restart\` will start it`,
-    );
+    console.error(formatDashboardUnreachable(recordedPort, false));
   } else if (r.reason === 'wrong-service') {
     // 127.0.0.1:<port> answered, but it isn't the dashboard (typically the
     // daemon IPC server holding a port the stale .dashboard-port points at),

--- a/src/cli/dashboard-command.ts
+++ b/src/cli/dashboard-command.ts
@@ -42,6 +42,157 @@ export function formatDashboardSuccessLines(result: Extract<DashboardResult, { o
   return lines;
 }
 
+/**
+ * How long `start`/`restart` should keep waiting for the dashboard to answer, and
+ * what to tell an operator who asks for the link while it is still coming up.
+ *
+ * SIZED FROM A REAL FLEET, not from how long a boot "should" take. The budget was
+ * 6s; MEASURED on a 13-member fleet the dashboard needed ~45s from supervisor
+ * start to answering (supervisor up at 14:23:04, `.dashboard-port` written at
+ * 14:23:49). So every `restart` there ended in the "still booting" fallback, and
+ * the operator's natural next step — `botmux dashboard` — printed
+ * "not reachable ... `botmux restart` will start it": advice that would restart a
+ * daemon which was in fact coming up fine, throwing away the boot about to
+ * succeed.
+ */
+export const DASHBOARD_READY_WAIT_MS = 90_000;
+
+/**
+ * How long to keep polling before the liveness gate may end the wait.
+ *
+ * A just-started supervisor has not written its dashboard row yet, so the very
+ * first observation can legitimately be "cannot tell" — which must not be read as
+ * "nothing is coming up". This is the old whole-budget value, so the previous
+ * behaviour is preserved for that initial stretch and the gate only starts cutting
+ * waits short once the state file has had time to appear.
+ */
+export const DASHBOARD_LIVENESS_GRACE_MS = 6_000;
+
+/**
+ * Failure reasons that prove we REACHED the dashboard, so waiting cannot change
+ * them. This is the "did we get an answer from the dashboard itself" question —
+ * NOT "is this backed by a file", which is the distinction an earlier version got
+ * wrong in both directions:
+ *
+ *  • `no-secret` looks file-backed and permanent, but `.dashboard-secret` is
+ *    created BY the dashboard during its own boot (`loadOrCreateSecret()`, called
+ *    at module scope in dashboard.ts). On a fresh install the supervisor has a live
+ *    dashboard pid well before that line runs, so the first poll legitimately sees
+ *    `no-secret` and it resolves on its own moments later.
+ *  • `wrong-service` is not permanent either: another service can hold the recorded
+ *    port while the dashboard has not bound its own yet, which makes discovery fail
+ *    now and succeed once it binds.
+ *
+ * Treating either as terminal ended the poll early and then told the operator to
+ * restart a dashboard that was coming up fine — the same misdiagnosis this module
+ * fixes for `unreachable`.
+ *
+ * Terminal is therefore "we got an answer FROM the dashboard": `no-active-token`
+ * (it is up, it just has no token yet) and `http-error`. The latter is exactly how
+ * `dashboard-endpoint.ts:reachedDashboard()` classifies it — a 500 or a malformed
+ * body means the dashboard replied, so waiting changes nothing, and leaving it out
+ * would spend the full 90s budget on a live dashboard that answers 500 forever.
+ */
+export function dashboardFailureIsTerminal(failure: Extract<DashboardResult, { ok: false }>): boolean {
+  return failure.reason === 'no-active-token' || failure.reason === 'http-error';
+}
+
+/**
+ * Map an observed fleet state to "is a dashboard coming up?" — the OBSERVATION
+ * half of the readiness decision, kept pure so it is testable.
+ *
+ * This used to live inline in `cli.ts` where nothing could reach it, and the
+ * `launching` branch in particular is the whole point of the fix: the supervisor
+ * records `status='launching', pid=0` while a crashed member is in restart
+ * backoff, so a pid-based check called that "not live", ended the poll, and then
+ * advised restarting a dashboard the supervisor was already bringing back.
+ *
+ * Tri-state on purpose — `null` is "cannot tell yet", NOT "no":
+ *  • no state file, or the dashboard row not written yet → null
+ *  • no live supervisor → false (nobody left to start anything)
+ *  • stopped / errored → false (the supervisor has given up)
+ *  • launching → true (pid is 0 BY DESIGN here; never pid-check this state)
+ *  • online → only true if the pid is actually alive
+ *
+ * @param state  parsed fleet state, or null when absent/unreadable
+ * @param pidAlive  liveness probe, injected so tests need no real processes
+ */
+export function dashboardComingUpFromState(
+  state: {
+    supervisorPid?: number;
+    procs?: ReadonlyArray<{ name: string; pid?: number; status?: string }>;
+  } | null,
+  dashboardProcessName: string,
+  pidAlive: (pid: number) => boolean,
+): boolean | null {
+  if (!state) return null;
+  const sup = state.supervisorPid;
+  const supervisorAlive = Number.isSafeInteger(sup) && (sup as number) > 1 && pidAlive(sup as number);
+  if (!supervisorAlive) return false;
+  const proc = state.procs?.find((p) => p.name === dashboardProcessName);
+  if (!proc) return null;
+  if (proc.status === 'stopped' || proc.status === 'errored') return false;
+  if (proc.status === 'launching') return true;
+  if (!Number.isSafeInteger(proc.pid) || (proc.pid as number) <= 1) return false;
+  return pidAlive(proc.pid as number);
+}
+
+/**
+ * Should the readiness poll take another turn?
+ *
+ * Three independent bounds, and all of them matter:
+ *  • the clock — liveness alone would spin forever on a member that is up but
+ *    never binds its port;
+ *  • whether the failure is terminal — no point polling an answer that will not
+ *    change;
+ *  • whether a dashboard is coming up — the clock alone would spend the (now much
+ *    larger) budget in full on a fleet that has no dashboard member, or whose
+ *    dashboard the supervisor has given up on.
+ *
+ * `comingUp` is deliberately TRI-STATE. `null` means "cannot tell yet" (no state
+ * file, or the supervisor has not written the dashboard row), which is normal in
+ * the first moments and must not end the wait; before
+ * DASHBOARD_LIVENESS_GRACE_MS it keeps waiting, after it stops rather than hold
+ * the full budget on a fleet whose state never appears.
+ */
+export function shouldKeepWaitingForDashboard(input: {
+  elapsedMs: number;
+  budgetMs?: number;
+  graceMs?: number;
+  failure: Extract<DashboardResult, { ok: false }>;
+  /** true = running or scheduled; false = definitely not; null = cannot tell yet. */
+  comingUp: boolean | null;
+}): boolean {
+  if (input.elapsedMs >= (input.budgetMs ?? DASHBOARD_READY_WAIT_MS)) return false;
+  if (dashboardFailureIsTerminal(input.failure)) return false;
+  if (input.comingUp === null) {
+    return input.elapsedMs < (input.graceMs ?? DASHBOARD_LIVENESS_GRACE_MS);
+  }
+  return input.comingUp;
+}
+
+/**
+ * The message for a failure that may just mean "not up yet" — the one an operator
+ * sees from `botmux dashboard`.
+ *
+ * "Run restart" is right ONLY when nothing is coming up. With a live dashboard
+ * member, nothing is broken and a restart would throw away a boot that is about to
+ * succeed, so say "wait" instead. Covers every non-terminal shape, because they
+ * are all reachable while the dashboard is still booting: the port not listening
+ * yet (`unreachable`), the secret not written yet (`no-secret` — the dashboard
+ * creates it itself), and the port not bound yet so discovery finds someone else
+ * on the recorded one (`wrong-service`). See DASHBOARD_READY_WAIT_MS.
+ */
+export function formatDashboardUnreachable(port: string | number, comingUp: boolean | null): string {
+  // `null` ("cannot tell yet") is treated as coming up: the honest advice when we
+  // do not know is "wait and retry", never "restart".
+  if (comingUp !== false) {
+    return `dashboard 正在启动中，还没开始在 127.0.0.1:${port} 上应答（大 fleet 可能要几十秒）。`
+      + '稍等几秒后重新运行 `botmux dashboard` 即可，不需要 restart。';
+  }
+  return `dashboard process not reachable on 127.0.0.1:${port} — \`botmux restart\` will start it`;
+}
+
 export function formatDashboardFallbackFailure(
   action: 'current' | 'rotate',
   failure: Extract<DashboardResult, { ok: false }>,

--- a/src/dashboard/autostart-api.ts
+++ b/src/dashboard/autostart-api.ts
@@ -1,9 +1,9 @@
 import { execFile } from 'node:child_process';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
 import { promisify } from 'node:util';
 import {
   inspectAutostart,
+  launchProgram,
   type AutostartOpts,
   type AutostartState,
 } from '../autostart.js';
@@ -38,12 +38,26 @@ function isTimeoutError(error: unknown): boolean {
   return value.code === 'ETIMEDOUT' || value.killed === true;
 }
 
+/**
+ * Run `botmux autostart enable|disable` as a child process.
+ *
+ * GOES THROUGH `launchProgram`, which is the same helper the unit/plist writers
+ * use, because this had the identical `__dirname` bug: a hardcoded
+ * `[process.execPath, join(pkgRoot,'dist','cli.js'), 'autostart', …]`. Inside the
+ * compiled binary `process.execPath` IS the botmux binary and there is no
+ * `dist/cli.js` on disk (pkgRoot resolves into the virtual `/$bunfs/`), so the
+ * bogus path was parsed as an unknown subcommand: the binary printed help and
+ * exited 0. The controller then re-read an unchanged state and reported
+ * `command_failed`, leaving the Dashboard's autostart toggle permanently dead in
+ * the shipped build. Node still runs `node <pkgRoot>/dist/cli.js autostart …`.
+ */
 function defaultRunner(opts: AutostartOpts): RunAutostart {
   return async enabled => {
+    const [command, ...programArgs] = launchProgram(opts);
     try {
       await execFileAsync(
-        process.execPath,
-        [join(opts.pkgRoot, 'dist', 'cli.js'), 'autostart', enabled ? 'enable' : 'disable'],
+        command,
+        [...programArgs, 'autostart', enabled ? 'enable' : 'disable'],
         {
           cwd: homedir(),
           encoding: 'utf8',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -935,7 +935,7 @@ export const messages: Record<string, string> = {
   'start.daemon_started_suffix': ' ({count} bots, each in its own process)',
   'start.logs_hint': '   Logs: botmux logs',
   'start.status_hint': '   Status: botmux status',
-  'start.autostart_synced': '   autostart unit synced to current Node/cli.js paths',
+  'start.autostart_synced': '   autostart unit synced to current launch path',
 
   // ─── Daemon runtime notices ──────────────────────────────────────────────
   'daemon.auto_start_join_title': 'Proactive start (joined chat)',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -936,7 +936,7 @@ export const messages: Record<string, string> = {
   'start.daemon_started_suffix': ' ({count} 个机器人, 每个独立进程)',
   'start.logs_hint': '   日志: botmux logs',
   'start.status_hint': '   状态: botmux status',
-  'start.autostart_synced': '   autostart unit 已同步到当前 Node/cli.js 路径',
+  'start.autostart_synced': '   autostart unit 已同步到当前启动路径',
 
   // ─── Daemon runtime notices ──────────────────────────────────────────────
   'daemon.auto_start_join_title': '主动开工（入群）',

--- a/test/autostart-standalone-path.test.ts
+++ b/test/autostart-standalone-path.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AUTOSTART_UNIT_ENV,
+  consumeAutostartUnitMarker,
+  launchProgram, launchCommand, unitContent, plistContent, windowsScriptContent,
+  type AutostartOpts,
+} from '../src/autostart.js';
+import { createDashboardAutostartController } from '../src/dashboard/autostart-api.js';
+
+/**
+ * Regression tests for the autostart boot hook under the COMPILED BINARY.
+ *
+ * THE BUG (observed in production, on a devbox running the npm-installed
+ * compiled binary): every boot hook was rendered as
+ * `<exe> <pkgRoot>/dist/cli.js start`, with pkgRoot derived from `__dirname`.
+ * Inside a compiled binary the module graph lives in the virtual, read-only
+ * `/$bunfs/`, so the written systemd unit was literally
+ *
+ *     ExecStart=/…/botmux-linux-x64/botmux /$bunfs/dist/cli.js start
+ *
+ * and `/$bunfs` does not exist outside the process (`ls /$bunfs` → ENOENT).
+ *
+ * IT FAILED SILENTLY, which is why it went unnoticed: the binary treats the
+ * bogus path as its subcommand token, does not recognise it, prints help and
+ * EXITS 0. systemd records success while `start` is swallowed as an argument and
+ * no daemon ever starts — the fleet does not come back after a reboot, with no
+ * error anywhere. `botmux restart` re-synced the unit each run, so the broken
+ * path stayed fresh.
+ *
+ * This is the same `__dirname` hazard as the wrapper self-destruct covered by
+ * `wrapper-standalone-guard.test.ts`; these tests cover the boot-hook renderers,
+ * which had NO coverage of either runtime shape.
+ */
+
+const tempDirs: string[] = [];
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), 'botmux-autostart-'));
+  tempDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tempDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/** pkgRoot as it really looks inside a compiled binary (the value that produced
+ *  the broken unit in production). */
+const BUNFS_PKG_ROOT = '/$bunfs';
+const BINARY = '/home/u/.local/lib/node_modules/botmux/node_modules/botmux-linux-x64/botmux';
+const NODE = '/usr/bin/node';
+const NODE_PKG_ROOT = '/opt/botmux';
+
+function opts(over: Partial<AutostartOpts> = {}): AutostartOpts {
+  return {
+    pkgRoot: BUNFS_PKG_ROOT,
+    configDir: '/home/u/.botmux',
+    logDir: '/home/u/.botmux/logs',
+    standalone: true,
+    execPath: BINARY,
+    ...over,
+  };
+}
+
+/** The Node-install shape, for the backward-compatibility assertions. */
+function nodeOpts(over: Partial<AutostartOpts> = {}): AutostartOpts {
+  return opts({ pkgRoot: NODE_PKG_ROOT, standalone: false, execPath: NODE, ...over });
+}
+
+describe('autostart boot hook — compiled binary (standalone) shape', () => {
+  it('execs the binary itself: no /$bunfs path, no dist/cli.js', () => {
+    expect(launchProgram(opts())).toEqual([BINARY]);
+    const cmd = launchCommand(opts(), 'start');
+    expect(cmd).not.toContain('$bunfs');
+    expect(cmd).not.toContain('cli.js');
+    expect(cmd).toBe(`${BINARY} start`);
+  });
+
+  it('renders no /$bunfs into the systemd unit (ExecStart AND ExecStop)', () => {
+    const unit = unitContent(opts());
+    expect(unit).not.toContain('$bunfs');
+    expect(unit).not.toContain('cli.js');
+    expect(unit).toContain(`ExecStart=${BINARY} start`);
+    // ExecStop was broken the same way and is just as load-bearing: a bad path
+    // there makes `systemctl --user stop botmux` a no-op that reports success.
+    expect(unit).toContain(`ExecStop=${BINARY} stop`);
+  });
+
+  it('renders no /$bunfs into the launchd plist or the Windows startup script', () => {
+    const plist = plistContent(opts());
+    expect(plist).not.toContain('$bunfs');
+    expect(plist).not.toContain('cli.js');
+    // ProgramArguments is an array: exactly the binary, then the subcommand.
+    expect(plist).toContain(`        <string>${BINARY}</string>\n        <string>start</string>`);
+
+    const bat = windowsScriptContent(opts());
+    expect(bat).not.toContain('$bunfs');
+    expect(bat).not.toContain('cli.js');
+    expect(bat).toContain(`"${BINARY}" "start"`);
+  });
+
+  it('injects the boot marker into all three artifacts', () => {
+    // `botmux start` needs to know it was launched at boot so it can skip the
+    // purely presentational dashboard wait — that wait is up to 90s, exactly the
+    // stock `DefaultTimeoutStartUSec` (VERIFIED: `systemctl --user show -p
+    // DefaultTimeoutStartUSec` → 1min 30s), and our unit sets no TimeoutStartSec,
+    // so blocking inside it would make systemd fail the start and (default
+    // KillMode=control-group) take the supervisor down with it.
+    expect(unitContent(opts())).toContain(`Environment=${AUTOSTART_UNIT_ENV}=1`);
+    expect(plistContent(opts()))
+      .toContain(`<key>${AUTOSTART_UNIT_ENV}</key>\n        <string>1</string>`);
+    expect(windowsScriptContent(opts())).toContain(`set "${AUTOSTART_UNIT_ENV}=1"`);
+    // Same on the Node shape: the hazard is about boot, not about runtime form.
+    expect(unitContent(nodeOpts())).toContain(`Environment=${AUTOSTART_UNIT_ENV}=1`);
+  });
+
+  it('the rendered ExecStart actually starts botmux (not: prints help and exits 0)', () => {
+    // THE HEART OF THE BUG. A string assertion alone would have passed even in
+    // production, because the broken command was still a well-formed command
+    // line — it just did the wrong thing and reported success. So run it.
+    //
+    // The stand-in binary behaves like the real one where it matters: it accepts
+    // `start` and rejects anything else with help-on-stdout + exit 0, which is
+    // exactly what made the failure invisible to systemd.
+    const dir = tmp();
+    const fakeBinary = join(dir, 'botmux');
+    writeFileSync(fakeBinary, [
+      '#!/bin/sh',
+      'if [ "$1" = "start" ]; then echo "DAEMON_STARTED"; exit 0; fi',
+      'echo "botmux — usage: botmux <command>"',   // help text, like the real CLI
+      'exit 0',                                    // ...and a SUCCESS exit code
+    ].join('\n'), { mode: 0o755 });
+    chmodSync(fakeBinary, 0o755);
+
+    const execStart = unitContent(opts({ execPath: fakeBinary }))
+      .split('\n').find((l) => l.startsWith('ExecStart='))!.slice('ExecStart='.length);
+    const r = spawnSync('/bin/sh', ['-c', execStart], { encoding: 'utf-8' });
+
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('DAEMON_STARTED');
+    // The pre-fix command line hit this branch — and still exited 0.
+    expect(r.stdout).not.toContain('usage');
+  });
+
+  it('proves the stand-in reproduces the silent failure (control for the test above)', () => {
+    // Without this, "DAEMON_STARTED" could pass for a reason unrelated to the
+    // fix. Feed the fake binary the PRE-FIX argv and show it is the documented
+    // silent failure: help text, no daemon, exit 0.
+    const dir = tmp();
+    const fakeBinary = join(dir, 'botmux');
+    writeFileSync(fakeBinary, [
+      '#!/bin/sh',
+      'if [ "$1" = "start" ]; then echo "DAEMON_STARTED"; exit 0; fi',
+      'echo "botmux — usage: botmux <command>"',
+      'exit 0',
+    ].join('\n'), { mode: 0o755 });
+    chmodSync(fakeBinary, 0o755);
+
+    // Quoted so this test observes the real argv shape rather than sh's own
+    // expansion of `$bunfs` (unquoted, sh would expand it to the empty string —
+    // a second, independent way the old unit was wrong).
+    const r = spawnSync('/bin/sh', ['-c', `${fakeBinary} '/$bunfs/dist/cli.js' start`], { encoding: 'utf-8' });
+    expect(r.status).toBe(0);              // systemd saw success...
+    expect(r.stdout).toContain('usage');   // ...while botmux only printed help
+    expect(r.stdout).not.toContain('DAEMON_STARTED');
+  });
+});
+
+describe('Dashboard autostart toggle — the same __dirname bug, second call site', () => {
+  // `defaultRunner()` hardcoded `[process.execPath, join(pkgRoot,'dist','cli.js'),
+  // 'autostart', …]`. In the compiled binary `process.execPath` IS the botmux
+  // binary and there is no cli.js on disk, so the bogus path became an unknown
+  // subcommand: help printed, exit 0, state unchanged, and the controller reported
+  // `command_failed` — the Dashboard's autostart toggle was simply dead in the
+  // shipped build. Exercised through the CONTROLLER with its real default runner,
+  // because the bug lived in the runner, not in the helper it now calls.
+  // FIXTURE CONTRACT: the controller no-ops when already in the target state and
+  // then re-reads to confirm the state flipped, so `inspect` must be driven by the
+  // RUNNER'S REAL SIDE EFFECT — here, the argv log the fake binary writes. Each case
+  // gets its own tmp dir and its own log, and each starts in the state OPPOSITE to
+  // its target. If the runner is ever changed to not write that file, these tests
+  // would stop exercising it, so keep the side effect and the `enabled` predicate in
+  // step.
+  function fakeBotmux(dir: string, argvLog: string): string {
+    const bin = join(dir, 'botmux');
+    writeFileSync(bin, [
+      '#!/bin/sh',
+      `printf '%s\\n' "$@" >> ${JSON.stringify(argvLog)}`,
+      // Behave like the real CLI: only `autostart` is a known subcommand here.
+      'if [ "$1" != "autostart" ]; then echo "usage: botmux <command>"; exit 0; fi',
+      'exit 0',
+    ].join('\n'), { mode: 0o755 });
+    chmodSync(bin, 0o755);
+    return bin;
+  }
+
+  it('standalone: invokes `<binary> autostart enable`, with no /$bunfs and no cli.js', async () => {
+    const dir = tmp();
+    const argvLog = join(dir, 'argv.log');
+    const bin = fakeBotmux(dir, argvLog);
+    // Model the real flow: the controller no-ops if already in the target state,
+    // and after running it re-reads and fails unless the state FLIPPED. So the
+    // first read reports the old value; the fake binary flips it by writing argv.
+    const controller = createDashboardAutostartController({
+      // No `run` override: this must go through the real defaultRunner.
+      opts: opts({ execPath: bin }),
+      inspect: () => ({ supported: true, enabled: existsSync(argvLog) }),
+    });
+
+    await controller.setEnabled(true);
+
+    const argv = readFileSync(argvLog, 'utf-8').trim().split('\n');
+    expect(argv).toEqual(['autostart', 'enable']);   // no cli.js argument at all
+    expect(argv.join(' ')).not.toContain('$bunfs');
+  });
+
+  it('standalone: disable maps to `<binary> autostart disable`', async () => {
+    const dir = tmp();
+    const argvLog = join(dir, 'argv.log');
+    const bin = fakeBotmux(dir, argvLog);
+    const controller = createDashboardAutostartController({
+      opts: opts({ execPath: bin }),
+      inspect: () => ({ supported: true, enabled: !existsSync(argvLog) }),
+    });
+
+    await controller.setEnabled(false);
+
+    expect(readFileSync(argvLog, 'utf-8').trim().split('\n')).toEqual(['autostart', 'disable']);
+  });
+
+  it('Node: still invokes `node <pkgRoot>/dist/cli.js autostart enable`', async () => {
+    // The path that already worked must keep working — the fix must not "succeed"
+    // by breaking it.
+    const dir = tmp();
+    const argvLog = join(dir, 'argv.log');
+    const bin = fakeBotmux(dir, argvLog);
+    const controller = createDashboardAutostartController({
+      opts: nodeOpts({ execPath: bin }),
+      inspect: () => ({ supported: true, enabled: existsSync(argvLog) }),
+    });
+
+    await controller.setEnabled(true);
+
+    expect(readFileSync(argvLog, 'utf-8').trim().split('\n'))
+      .toEqual([`${NODE_PKG_ROOT}/dist/cli.js`, 'autostart', 'enable']);
+  });
+});
+
+describe('autostart boot hook — Node install shape stays unchanged', () => {
+  // The fix must not "work" by breaking the path that was already correct.
+  it('still runs `node <pkgRoot>/dist/cli.js`', () => {
+    expect(launchProgram(nodeOpts())).toEqual([NODE, `${NODE_PKG_ROOT}/dist/cli.js`]);
+    expect(launchCommand(nodeOpts(), 'start')).toBe(`${NODE} ${NODE_PKG_ROOT}/dist/cli.js start`);
+  });
+
+  it('unit, plist and .bat all keep the two-element program', () => {
+    expect(unitContent(nodeOpts()))
+      .toContain(`ExecStart=${NODE} ${NODE_PKG_ROOT}/dist/cli.js start`);
+    expect(unitContent(nodeOpts()))
+      .toContain(`ExecStop=${NODE} ${NODE_PKG_ROOT}/dist/cli.js stop`);
+    expect(plistContent(nodeOpts()))
+      .toContain(`        <string>${NODE}</string>\n        <string>${NODE_PKG_ROOT}/dist/cli.js</string>`);
+    expect(windowsScriptContent(nodeOpts()))
+      .toContain(`"${NODE}" "${NODE_PKG_ROOT}/dist/cli.js" "start"`);
+  });
+});
+
+describe('boot-hook marker is consumed on entry, not after dependency probes', () => {
+  it("returns true and deletes the key when the value is '1'", () => {
+    const env: NodeJS.ProcessEnv = { [AUTOSTART_UNIT_ENV]: '1', OTHER: 'keep' };
+    expect(consumeAutostartUnitMarker(env)).toBe(true);
+    expect(AUTOSTART_UNIT_ENV in env).toBe(false);
+    expect(env.OTHER).toBe('keep');
+  });
+
+  it('returns false but STILL deletes the key for any other value', () => {
+    // A stray unrecognised value must not keep leaking to children either.
+    for (const v of ['0', 'true', '', 'yes', '11']) {
+      const env: NodeJS.ProcessEnv = { [AUTOSTART_UNIT_ENV]: v };
+      expect(consumeAutostartUnitMarker(env)).toBe(false);
+      expect(AUTOSTART_UNIT_ENV in env).toBe(false);
+    }
+  });
+
+  it('returns false and stays a no-op when the key is absent', () => {
+    const env: NodeJS.ProcessEnv = { OTHER: 'keep' };
+    expect(consumeAutostartUnitMarker(env)).toBe(false);
+    expect(AUTOSTART_UNIT_ENV in env).toBe(false);
+    expect(env.OTHER).toBe('keep');
+  });
+
+  it('cmdStart consumes the marker before its first await / dependency probe', () => {
+    // Structural guard: dependency probes and installers run as CHILD processes,
+    // so they would inherit a marker consumed after them. Assert on source order.
+    const src = readFileSync(join(import.meta.dirname, '..', 'src', 'cli.ts'), 'utf8');
+    const start = src.indexOf('async function cmdStart(): Promise<void> {');
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf('\n}', start);
+    expect(end).toBeGreaterThan(start);
+
+    // STRIP COMMENTS FIRST. Both needles occur in this function's own comments:
+    // matching those would find `await` in the prose (false failure) and the
+    // helper's name in "see consumeAutostartUnitMarker" (false PASS, which is the
+    // dangerous direction — it would satisfy the guard without a real call).
+    const body = src.slice(start, end)
+      .split('\n')
+      .map((l) => l.replace(/\/\/.*$/, ''))
+      .join('\n');
+
+    const consumeAt = body.indexOf('consumeAutostartUnitMarker(');
+    expect(consumeAt, 'cmdStart must call consumeAutostartUnitMarker').toBeGreaterThan(-1);
+
+    const firstAwaitAt = body.indexOf('await ');
+    expect(firstAwaitAt, 'cmdStart is expected to await something').toBeGreaterThan(-1);
+    expect(consumeAt).toBeLessThan(firstAwaitAt);
+
+    // And specifically before the dependency probe that spawns children.
+    const depsAt = body.indexOf('ensureSystemDependencies(');
+    expect(depsAt).toBeGreaterThan(-1);
+    expect(consumeAt).toBeLessThan(depsAt);
+  });
+});

--- a/test/dashboard-readiness-race.test.ts
+++ b/test/dashboard-readiness-race.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DASHBOARD_LIVENESS_GRACE_MS,
+  DASHBOARD_READY_WAIT_MS,
+  dashboardComingUpFromState,
+  dashboardFailureIsTerminal,
+  formatDashboardUnreachable,
+  shouldKeepWaitingForDashboard,
+} from '../src/cli/dashboard-command.js';
+import type { DashboardResult } from '../src/cli/dashboard-endpoint.js';
+
+/**
+ * Regression tests for the dashboard readiness race.
+ *
+ * OBSERVED IN PRODUCTION on a 13-member fleet: `botmux restart` waited 6s for the
+ * dashboard, but the dashboard needed ~45s to start answering (supervisor up at
+ * 14:23:04, `.dashboard-port` written at 14:23:49). So restart always printed its
+ * "still booting" fallback, and the operator's natural next step —
+ * `botmux dashboard` — reported
+ *
+ *     dashboard process not reachable on 127.0.0.1:7891 — `botmux restart` will start it
+ *
+ * Following that advice restarts a daemon that is coming up perfectly well,
+ * throwing away the boot that was about to finish. Nothing was broken; the
+ * waiting policy and the message were.
+ */
+
+function failure(reason: Extract<DashboardResult, { ok: false }>['reason']):
+  Extract<DashboardResult, { ok: false }> {
+  return { ok: false, reason };
+}
+
+describe('dashboard readiness budget', () => {
+  it('is long enough for a real fleet (the measured boot was ~45s)', () => {
+    // Pin the property, not the constant: the old 6s silently made every large
+    // fleet take the failure path.
+    expect(DASHBOARD_READY_WAIT_MS).toBeGreaterThanOrEqual(45_000);
+  });
+
+  it('keeps waiting while the dashboard member is live and unreachable', () => {
+    // The exact shape of the production race: 10s in, port not up yet, process
+    // alive and booting.
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: 10_000,
+      failure: failure('unreachable'),
+      comingUp: true,
+    })).toBe(true);
+    // ...and still at 44s, where the old 6s budget had long since given up.
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: 44_000,
+      failure: failure('unreachable'),
+      comingUp: true,
+    })).toBe(true);
+  });
+
+  it('stops immediately when no dashboard member is live', () => {
+    // Otherwise the enlarged budget would be spent in full on a fleet whose
+    // dashboard is disabled or already dead — a 90s hang on every start/restart.
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: 0,
+      failure: failure('unreachable'),
+      comingUp: false,
+    })).toBe(false);
+  });
+
+  it('stops at the budget even if the member never binds its port', () => {
+    // Liveness alone would spin forever on a member that is up but not listening.
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: DASHBOARD_READY_WAIT_MS,
+      failure: failure('unreachable'),
+      comingUp: true,
+    })).toBe(false);
+  });
+
+  it('does not spin on failures that waiting cannot fix', () => {
+    // Terminal = the dashboard ANSWERED. `no-active-token` (up, no token yet) and
+    // `http-error` (a 500 or malformed body — `reachedDashboard()` in
+    // dashboard-endpoint.ts classifies it as reached). Polling either changes
+    // nothing, and omitting `http-error` would burn the whole 90s budget on a live
+    // dashboard that answers 500 forever.
+    for (const reason of ['no-active-token', 'http-error'] as const) {
+      expect(dashboardFailureIsTerminal(failure(reason))).toBe(true);
+      expect(shouldKeepWaitingForDashboard({
+        elapsedMs: 0,
+        failure: failure(reason),
+        comingUp: true,   // live, and it STILL must not retry
+      })).toBe(false);
+    }
+  });
+
+  it('keeps waiting through a FRESH-INSTALL no-secret while the member is live', () => {
+    // `.dashboard-secret` is created by the dashboard ITSELF during boot
+    // (loadOrCreateSecret() at module scope in dashboard.ts), so on a fresh install
+    // the supervisor has a live dashboard pid well before that line runs. Treating
+    // this as terminal ended the poll early and then advised a restart of a
+    // perfectly healthy, still-booting dashboard.
+    expect(dashboardFailureIsTerminal(failure('no-secret'))).toBe(false);
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: 2_000,
+      failure: failure('no-secret'),
+      comingUp: true,
+    })).toBe(true);
+    // ...but with no live member it really is "not initialised" — stop at once.
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: 2_000,
+      failure: failure('no-secret'),
+      comingUp: false,
+    })).toBe(false);
+  });
+
+  it('treats a `launching` member with pid 0 as coming up', () => {
+    // The supervisor records `status='launching', pid=0` while a crashed member is
+    // in restart backoff (fleet-supervisor.ts handleExit). A pid-based check called
+    // that "not live", ended the poll, and then advised a restart — of a dashboard
+    // the supervisor was about to bring back itself. `comingUp` is the supervisor's
+    // INTENT, so that state is `true` and this predicate must keep waiting.
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: 20_000,
+      failure: failure('unreachable'),
+      comingUp: true,
+    })).toBe(true);
+  });
+
+  it('keeps waiting through the initial "cannot tell yet" (no state/row written)', () => {
+    // A just-started supervisor has not written the dashboard row, so the first
+    // observation is legitimately unknown. Reading that as "nothing is coming up"
+    // would end the wait at t=0 on every single start.
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: 0,
+      failure: failure('unreachable'),
+      comingUp: null,
+    })).toBe(true);
+    // ...but unknown forever must not hold the full 90s budget: after the grace
+    // window it stops, preserving the old whole-budget behaviour for that stretch.
+    expect(shouldKeepWaitingForDashboard({
+      elapsedMs: DASHBOARD_LIVENESS_GRACE_MS,
+      failure: failure('unreachable'),
+      comingUp: null,
+    })).toBe(false);
+    expect(DASHBOARD_LIVENESS_GRACE_MS).toBeLessThan(DASHBOARD_READY_WAIT_MS);
+  });
+});
+
+describe('`botmux dashboard` unreachable message', () => {
+  it('does not tell the operator to restart a dashboard that is coming up', () => {
+    const msg = formatDashboardUnreachable(7891, true);
+    // Must not INSTRUCT a restart. A bare `not.toContain('restart')` is wrong
+    // here — this message legitimately says "不需要 restart" ("no restart
+    // needed"), so match the instruction form the old text used instead.
+    expect(msg).not.toContain('botmux restart` will start it');
+    expect(msg).not.toMatch(/运行\s*`?botmux restart/);
+    expect(msg).toContain('不需要 restart');   // ...it says the opposite, explicitly
+    expect(msg).toContain('7891');
+    expect(msg).toContain('启动中');            // "still starting"
+  });
+
+  it('still says to restart when nothing is coming up', () => {
+    // The advice is correct in this case and must not be lost.
+    const msg = formatDashboardUnreachable(7891, false);
+    expect(msg).toContain('botmux restart');
+    expect(msg).toContain('not reachable');
+    expect(msg).toContain('7891');
+  });
+
+  it('the two cases are actually different messages', () => {
+    // Guards against a refactor that collapses them and silently restores the
+    // misleading advice for the booting case.
+    expect(formatDashboardUnreachable(7891, true))
+      .not.toBe(formatDashboardUnreachable(7891, false));
+  });
+
+  it('"cannot tell" gets the wait-and-retry advice, not restart', () => {
+    // When we do not know, the honest advice is "wait", never "restart" — the
+    // restart is the destructive option.
+    expect(formatDashboardUnreachable(7891, null))
+      .toBe(formatDashboardUnreachable(7891, true));
+  });
+});
+
+/**
+ * The OBSERVATION half: fleet state → "is a dashboard coming up?".
+ *
+ * The suite above only covered the waiting POLICY, with `comingUp` hand-fed. That
+ * left the mapping itself unpinned — inverting the `launching` branch (the very
+ * regression this PR fixes) kept every test green. These are table-driven over the
+ * real function, with an injected pid probe so no real processes are needed.
+ */
+describe('dashboardComingUpFromState — observation mapping', () => {
+  const NAME = 'botmux-dashboard';
+  const ALIVE = () => true;
+  const DEAD = () => false;
+  /** Alive for the supervisor, dead for anything else — separates the two probes. */
+  const onlySupervisor = (supPid: number) => (pid: number) => pid === supPid;
+
+  const cases: Array<{
+    label: string;
+    state: Parameters<typeof dashboardComingUpFromState>[0];
+    pidAlive: (pid: number) => boolean;
+    want: boolean | null;
+  }> = [
+    { label: 'no state file at all → null (cannot tell)',
+      state: null, pidAlive: ALIVE, want: null },
+    { label: 'supervisor pid dead → false (nobody left to start anything)',
+      state: { supervisorPid: 4242, procs: [{ name: NAME, pid: 99, status: 'online' }] },
+      pidAlive: DEAD, want: false },
+    { label: 'supervisor pid absent/bogus → false',
+      state: { supervisorPid: 0, procs: [{ name: NAME, pid: 99, status: 'online' }] },
+      pidAlive: ALIVE, want: false },
+    { label: 'dashboard row not written yet → null (cannot tell)',
+      state: { supervisorPid: 10, procs: [{ name: 'botmux-daemon', pid: 11, status: 'online' }] },
+      pidAlive: ALIVE, want: null },
+    { label: 'empty procs array → null (cannot tell)',
+      state: { supervisorPid: 10, procs: [] }, pidAlive: ALIVE, want: null },
+    // THE FIX. pid is 0 by design during restart backoff; a pid check says "dead".
+    { label: 'launching with pid 0 → true, WITHOUT consulting the pid',
+      state: { supervisorPid: 10, procs: [{ name: NAME, pid: 0, status: 'launching' }] },
+      pidAlive: onlySupervisor(10), want: true },
+    { label: 'online with a live pid → true',
+      state: { supervisorPid: 10, procs: [{ name: NAME, pid: 77, status: 'online' }] },
+      pidAlive: ALIVE, want: true },
+    { label: 'online but the pid is dead → false',
+      state: { supervisorPid: 10, procs: [{ name: NAME, pid: 77, status: 'online' }] },
+      pidAlive: onlySupervisor(10), want: false },
+    { label: 'online with pid 0 → false (online is not enough on its own)',
+      state: { supervisorPid: 10, procs: [{ name: NAME, pid: 0, status: 'online' }] },
+      pidAlive: ALIVE, want: false },
+    { label: 'stopped → false (supervisor is not bringing it back)',
+      state: { supervisorPid: 10, procs: [{ name: NAME, pid: 77, status: 'stopped' }] },
+      pidAlive: ALIVE, want: false },
+    { label: 'errored → false (supervisor gave up)',
+      state: { supervisorPid: 10, procs: [{ name: NAME, pid: 77, status: 'errored' }] },
+      pidAlive: ALIVE, want: false },
+  ];
+
+  for (const c of cases) {
+    it(c.label, () => {
+      expect(dashboardComingUpFromState(c.state, NAME, c.pidAlive)).toBe(c.want);
+    });
+  }
+
+  it('distinguishes null from false — they drive OPPOSITE waiting decisions', () => {
+    // Not interchangeable: within the grace window `null` keeps waiting while
+    // `false` stops. Collapsing them would resurrect the original bug.
+    const early = { elapsedMs: 1_000, failure: failure('unreachable') };
+    expect(shouldKeepWaitingForDashboard({ ...early, comingUp: null })).toBe(true);
+    expect(shouldKeepWaitingForDashboard({ ...early, comingUp: false })).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

在一台 devbox 上跑编译版单文件二进制时遇到两个问题，排查后是两个独立缺陷：

```
$ botmux restart
...
$ botmux dashboard
✗ Dashboard 不可达（http://127.0.0.1:xxxx）
```

## 问题一：编译版的开机自启永远拉不起来，而且没有任何报错

`autostart` 把开机自启命令硬编码成 `[process.execPath, <pkgRoot>/dist/cli.js]`。
编译版单文件二进制里 **`dist/cli.js` 不落磁盘** —— 模块图在虚拟只读的 `/$bunfs/` 下，
`__dirname` 是 `/$bunfs/root`。于是写进 systemd unit 的 `ExecStart`、launchd plist 的
`ProgramArguments`、Windows `.bat` 全部指向一个**进程外不存在的路径**。

症状：**重启机器后 fleet 不回来，且日志里没有线索**。用户只看到服务没起。

改为单一判据 `launchProgram()`：

```ts
export function launchProgram(opts: AutostartOpts): string[] {
  const exec = opts.execPath ?? process.execPath;
  const standalone = opts.standalone ?? isStandaloneBinary();
  if (standalone) return [exec];           // 二进制自身就是入口
  return [exec, join(opts.pkgRoot, 'dist', 'cli.js')];
}
```

原先有 **5 个各自拼路径的调用点**（`ExecStart`、`ExecStop`、plist 数组、`.bat`、
无 systemd 时的兜底提示），现在共用这一个函数，不会再各自漂移。

**同源的第二处**：Dashboard 的自启开关走 `src/dashboard/autostart-api.ts` 的
`defaultRunner()`，里面是同一个硬编码。不一并修的话，在编译版上从 Dashboard 打开自启
会写出同样坏的 unit。

## 问题二：`botmux dashboard` 在服务正常启动中时就报不可达

就绪等待预算短于 systemd 的 `DefaultTimeoutStartUSec`（本机 `1min 30s`），dashboard
成员还在**正常启动窗口内**就被判成失败。另外 `printDashboardHintWithRetry()` 被包在
fleet mutation 文件锁里，把锁一直按到提示重试结束。

- 就绪预算对齐到 `DASHBOARD_READY_WAIT_MS = 90_000`，并加 `DASHBOARD_LIVENESS_GRACE_MS` 宽限
- 新增 `dashboardMemberComingUp()` **三态**判定（是 / 否 / 无法确定）：fleet 崩溃重启退避期
  成员是 `status='launching', pid=0`，**这不是失败**
- `dashboardFailureIsTerminal()` 区分**终态失败**（`no-active-token`、`http-error`）与
  **瞬态**（`no-secret`、`wrong-service`），只有前者立即停等
- 提示重试移出 fleet 锁
- 开机自启路径（`BOTMUX_AUTOSTART_UNIT=1`）跳过自启同步与提示重试 —— 开机时无人在终端
  看提示，而同步自启会与刚拉起它的 unit 相互干扰

## 两个缺陷的触发条件**不同**（同一份报告里的两个症状，不共享前置条件）

- **问题一只咬编译版安装**。非编译态渲染出的路径本来就是对的 —— 实测把修复后的
  `unitContent()` 喂本机（Node 形态）真实参数，与**当前已装的 live systemd unit** 做
  **整文件** diff，只有两处差异：① 新增的 `Environment=BOTMUX_AUTOSTART_UNIT=1`（本 PR
  预期新增）；② `PATH` 里一个 `fnm_multishells/<shell-id>/bin` 段不同 —— 该值由安装时
  所在 shell 的 PATH 捕获，每次调用本就不同，且本 PR **未改动** `currentPath()`。
  `ExecStart` / `ExecStop` 逐字相同，即**启动 argv 对非编译态是恒等变换**。这也解释了
  为什么跑 Node 安装的机器从没报过这个问题。
- **问题二咬所有安装形态**。master 上是 `printDashboardHintWithRetry()` 里
  `const maxWaitMs = 6000` **硬编码**，与是否编译版、与 `/$bunfs` 无关。只要 fleet 大到
  dashboard 启动超过 6s，就必然走失败分支并给出「运行 `botmux restart`」的错误建议
  （实测那台机器 dashboard 需要约 45s 才开始应答）。

## 影响面

- **跨形态**：编译版二进制 / `dist/cli.js` 两态都验。判形态用 `isStandaloneBinary()`，
  不拼 `__dirname` 路径
- **跨平台**：systemd（Linux，daemon 实际运行环境）/ launchd（macOS）/ Windows `.bat`
  三条渲染路径共用同一判据。本机只能真跑 systemd 那条，另两条以渲染内容断言
- **未触及**：CLI 适配器、会话后端（`PtyBackend` / `TmuxBackend`）、飞书消息路径均无改动；
  话题会话 / 群会话 / adopt-restore 不受影响
- **i18n**：`start.autostart_synced` 原文写死「Node/cli.js 路径」，编译态没有这两者，
  改为「启动路径」（中英同步）

## 验证

```
bun run build                         → 通过（tsc + 产物审计）
bun run build:bun                     → 通过，产出 170MB 独立 ELF

npx vitest run test/autostart-standalone-path.test.ts \
              test/dashboard-readiness-race.test.ts
  Test Files  2 passed (2)
       Tests  39 passed (39)          exit=0
  （autostart 15 条 + dashboard 24 条）
```

### 测试不只断言字符串

autostart 那套里，关键一条把渲染出的 `ExecStart` **真的 spawn 起来**打到一个替身
二进制（未知子命令时打印帮助并 exit 0），并配一条**对照用例**喂修复前的 argv ——
「断言了一个字符串」和「这条命令真能执行」是两件事。

Dashboard 自启的用例**不 mock `run`**，直接用真的 `defaultRunner`，状态由 runner 的真实
副作用（argv 日志文件是否存在）驱动，而不是由测试自己摆的返回值驱动。

### 开机标记的消费时机

boot marker（`BOTMUX_AUTOSTART_UNIT=1`）抽成 `consumeAutostartUnitMarker()`，在 `cmdStart`
的**第一条语句**读取并删除，早于任何 `await` 与依赖探测 —— 依赖探测/安装会起**子进程**，
它们会继承尚未删除的标记；fleet supervisor 更是以 `{...process.env}` spawn，daemon /
worker / 会话 CLI 逐层继承，残留标记会让后代里任何一次 `botmux start` 都被误判成开机启动。
非 `'1'` 的值也一律删除（标记是一次性的，留着只会继续泄漏）。

4 条用例覆盖：值为 `1` → true 且键已删；其它值/空值 → false 且键仍删除；键缺失 → false
且不误删其它变量；外加一条**结构断言**保证 `cmdStart` 在首个 `await` 与依赖探测之前调用它。

两次变异验证这条结构断言有牙：

| 变异 | 改动 | 结果 |
|---|---|---|
| MUT-A | 把消费移到 `ensureSystemDependencies()` **之后** | 🔴 红（`expected 265 to be less than 207`） |
| MUT-B | 删掉真实调用，只留注释里的同名提及 | 🔴 红（`expected -1 to be greater than -1`） |

MUT-B 是**假绿方向**：断言若不先剥注释，就会「找到」注释里的函数名而放行。第一版确实
踩了这个坑（它同时把注释里的 `await` 当成首个 await），已改为先剥行注释再匹配。

顺带修正 `unitContent` 一段过时注释：它说 `botmux start` 调 `pm2 start`，实际现在交给
内置 supervisor（detached spawn 后 `start` 即返回）。

### 观测映射：从零区分力改为表驱动 + 变异验证

原先「`launching` + pid 0 视为正在启动」这条用例只是把 `comingUp: true` **手工喂给**
`shouldKeepWaitingForDashboard()`，全仓没有任何测试引用真正的实现。实测：把实现里
`if (proc.status === 'launching') return true` 改成 `false`，**27 条依然全绿** ——
标题声称钉住的回归其实没钉住，而这正是本 PR 的核心修复。

已把「fleet state + pidAlive → boolean|null」抽成纯函数
`dashboardComingUpFromState(state, name, pidAlive)`（放在 `dashboard-command.ts`），
`cli.ts` 只负责喂 I/O。表驱动覆盖 11 种状态：

| 状态 | 期望 |
|---|---|
| 无 state 文件 | `null`（无法判断） |
| supervisor pid 死 / 非法 | `false` |
| dashboard row 未写 / procs 空 | `null` |
| **`launching` + pid 0** | **`true`，且不查 pid** |
| `online` + pid 活 | `true` |
| `online` + pid 死 / pid 0 | `false` |
| `stopped` / `errored` | `false` |

外加一条断言 `null` 与 `false` **不可互换**（宽限窗内前者继续等、后者立即停）。

**7 条变异全部被咬红**：

| 变异 | 结果 |
|---|---|
| `launching` → `false` | 🔴 |
| 删掉 `launching` 分支 | 🔴 |
| 无 state → `false`（而非 `null`） | 🔴 |
| row 缺失 → `false` | 🔴 |
| supervisor 死 → `true` | 🔴 |
| 去掉 `errored` 判定 | 🔴 |
| `online` 跳过 pid 存活检查 | 🔴 |

### 真编译版 A/B（带正向对照）

用当刻源码 `bun run build:bun` 出真二进制（核对 mtime 晚于全部 4 个源文件，避免拿到旧产物），
对同一个子命令喂两种 argv：

| | argv | 结果 |
|---|---|---|
| 对照（修复前） | `<binary> '/$bunfs/root/dist/cli.js' list` | 打印**帮助**，没走到子命令 |
| 处理（修复后） | `<binary> list` | 打印**真实会话表** |

⚠️ **两者 exit code 都是 0** —— 只看退出码会把这条测试判成绿。所以断言架在输出内容上
（对照 `fleet_table=0 / help_banner=1`，处理 `fleet_table=1 / help_banner=0`）。

渲染层同时核对：

```
PROGRAM_STANDALONE=["/usr/local/bin/botmux"]
PROGRAM_NODE=["/usr/bin/node","/opt/pkgroot/dist/cli.js"]
UNIT| Environment=BOTMUX_AUTOSTART_UNIT=1
UNIT| ExecStart=/usr/local/bin/botmux start
UNIT| ExecStop=/usr/local/bin/botmux stop
```
