### PR TITLE
fix(usage-limit): 改用「本轮真答出东西」判定旧限额横幅，不再每轮重新钉住「限额已达」

### DIFF
--- a/src/utils/usage-limit-tracker.ts
+++ b/src/utils/usage-limit-tracker.ts
@@ -7,7 +7,7 @@ import {
 
 /**
  * Per-turn usage-limit state machine. Owns the turn counter, the
- * "did this turn hit a limit" flag, the stale retry-ready banner suppression,
+ * "did this turn hit a limit" flag, the stale-banner suppression,
  * and the stickiness of authoritative STRUCTURED limits — so classify()'s
  * state writes are explicit method calls rather than hidden mutations of
  * module globals.
@@ -49,7 +49,30 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
 }): UsageLimitTracker<S> {
   let turnSeq = 0;
   let detectedTurn: number | undefined;
-  let suppressedRetryReadyKey: string | undefined;
+  /**
+   * usageLimitStateKey of a limit banner ALREADY on screen when this turn
+   * opened — i.e. a previous episode's leftover text, not evidence about this
+   * turn. classify() skips exactly that key so the stale banner cannot re-pin
+   * the card every turn.
+   *
+   * Deliberately NOT conditioned on retryReady. A CLI's banner carries only a
+   * wall-clock time ("try again at 8:45 PM"), and detectCliUsageLimit keeps a
+   * passed PM time on TODAY (see its comment) — so for most of the day a
+   * day-old banner parses as a FUTURE reset, i.e. retryReady === false. Codex
+   * prints that banner once and leaves it in the viewport forever (verified on
+   * live panes: never a second occurrence, even 20k lines back), so the
+   * "the CLI will reject the retry again and self-heal" assumption behind the
+   * retry-time rule does not hold there. Gating the suppression on retryReady
+   * therefore disarmed it precisely in the case it exists for: every new turn
+   * re-detected the same leftover text and re-pinned 「限额已达」 even after
+   * the CLI had answered normally — and, because clearUsageLimitState() also
+   * resets rateLimitNotifiedKey, re-sent the @owner "turn paused" ping each
+   * time. The state key (kind + retryAtMs + label) is the episode identity;
+   * retryReady is just a countdown flag on it, so a genuinely NEW limit —
+   * different reset clock, or a banner that appears mid-turn on a screen that
+   * started clean — has a different key (or none recorded) and still fires.
+   */
+  let staleBannerKey: string | undefined;
   // A STRUCTURED limit (transcript error record, Claude/Codex) is authoritative
   // and one-shot at the source (UUID-deduped emit). Re-emit it on every
   // classify() until the turn ends: a genuinely blocked CLI keeps its
@@ -65,16 +88,14 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
     currentTurn(): number {
       return turnSeq;
     },
-    // Open a new turn; remember any stale retry-ready banner still on screen so
-    // classify() doesn't re-flag it as a fresh limit this turn.
+    // Open a new turn; remember any limit banner still on screen so classify()
+    // doesn't re-flag that leftover text as a fresh limit this turn.
     beginTurn(snapshot: string): number {
       turnSeq++;
       detectedTurn = undefined;
       activeStructured = undefined;
       const current = detectCliUsageLimit(snapshot, undefined, { suppressRateKind: opts.isRateKindSuppressed() });
-      suppressedRetryReadyKey = current.limited && current.retryReady
-        ? usageLimitStateKey(current)
-        : undefined;
+      staleBannerKey = current.limited ? usageLimitStateKey(current) : undefined;
       return turnSeq;
     },
     // Map a runtime status to a usage-limit-aware status, recording whether this
@@ -107,11 +128,13 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
       }
 
       const key = usageLimitStateKey(detected);
-      if (detected.retryReady && key === suppressedRetryReadyKey) {
+      // Same episode as the banner that was already on screen at turn start —
+      // leftover text, not a fresh verdict about this turn.
+      if (key === staleBannerKey) {
         return { status };
       }
 
-      suppressedRetryReadyKey = undefined;
+      staleBannerKey = undefined;
       detectedTurn = turnSeq;
       return { status: 'limited', usageLimit: detected };
     },
@@ -122,10 +145,10 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
     // record) rather than screen text. Mirrors classify()'s state writes so
     // the tracker stays coherent: mark this turn as having hit a limit (read
     // by detectedThisTurn for the submit-confirmation recheck), clear any
-    // stale retry-ready suppression, and hold the state for re-emission until
+    // stale-banner suppression, and hold the state for re-emission until
     // the turn ends. The actual emit is done by the caller.
     noteStructuredLimit(state: CliUsageLimitState): void {
-      suppressedRetryReadyKey = undefined;
+      staleBannerKey = undefined;
       detectedTurn = turnSeq;
       activeStructured = { seq: turnSeq, state };
     },

--- a/src/utils/usage-limit-tracker.ts
+++ b/src/utils/usage-limit-tracker.ts
@@ -22,15 +22,50 @@ export interface UsageLimitTracker<S extends string = string> {
   detectedThisTurn(seq: number): boolean;
   noteStructuredLimit(state: CliUsageLimitState): void;
   /**
-   * A turn completed successfully (a harvested bridge final_output is being
-   * emitted). Clears the structured-limit latch so a stale limit is not
-   * re-emitted on the next classify(). Mirrors the daemon's final_output
-   * self-heal (worker-pool clears ds.usageLimit on a real harvested answer):
-   * in an adopted session the user can recover from a structured rate limit
-   * in their own terminal without triggering beginTurn(), so without this the
-   * latch would re-pin the card / Dashboard after the daemon already cleared.
+   * A turn reached its terminal and a bridge final_output is being emitted.
+   *
+   * `outcome` distinguishes a real model answer from a failure/notice fallback:
+   * the codex bridge routes BOTH through the same emit (`structuredFallbackKind`
+   * can be 'failed', whose content is failedBridgeFallbackContent — a notice,
+   * not an answer). Only 'answered' is positive evidence the CLI is not
+   * limit-blocked, so only that arms the stale-banner suppression. A 'failed'
+   * terminal must never arm it: a rate/usage refusal IS a failed terminal, and
+   * treating it as an answer would suppress the very banner it should surface.
+   *
+   * Both outcomes still clear the structured-limit re-emit latch, preserving the
+   * existing self-heal: in an adopted session the user can recover from a
+   * structured rate limit in their own terminal without triggering beginTurn(),
+   * and without this the latch would re-pin the card / Dashboard after the
+   * daemon already cleared it.
    */
-  noteTurnCompleted(): void;
+  noteTurnCompleted(outcome?: 'answered' | 'failed'): void;
+}
+
+/**
+ * Clock-free identity of a limit banner: what the SCREEN TEXT says, with no
+ * resolved timestamp in it. usageLimitStateKey embeds retryAtMs, which
+ * detectCliUsageLimit resolves against the current day — so one unchanged
+ * banner produces a different key before and after midnight. Any "is this the
+ * same banner I saw earlier?" comparison must therefore use this instead.
+ */
+function bannerTextIdentity(state: CliUsageLimitState): string {
+  return `${state.kind}:${state.retryLabel}`;
+}
+
+/** Whether a bridge turn's terminal is positive evidence the CLI produced an
+ *  answer (as opposed to a failure/ambiguous terminal). Keyed on
+ *  `terminalStatus` and NOT on `structuredFallbackKind`: the latter decides
+ *  WHICH fallback text to display and returns 'final' for a failed terminal
+ *  whenever the failed fallback is gated away — including the codex
+ *  rate-limit short-circuit (rateLimitHandled), i.e. precisely the limit case
+ *  that must never be read as success. `undefined` means the drainer recorded
+ *  no failure, which is the ordinary completed shape. */
+export function bridgeTurnOutcome(
+  turn: { terminalStatus?: 'failed' | 'ambiguous' | 'completed' },
+): 'answered' | 'failed' {
+  return turn.terminalStatus === undefined || turn.terminalStatus === 'completed'
+    ? 'answered'
+    : 'failed';
 }
 
 export function createUsageLimitTracker<S extends string = string>(opts: {
@@ -50,29 +85,57 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
   let turnSeq = 0;
   let detectedTurn: number | undefined;
   /**
-   * usageLimitStateKey of a limit banner ALREADY on screen when this turn
-   * opened — i.e. a previous episode's leftover text, not evidence about this
-   * turn. classify() skips exactly that key so the stale banner cannot re-pin
-   * the card every turn.
-   *
-   * Deliberately NOT conditioned on retryReady. A CLI's banner carries only a
-   * wall-clock time ("try again at 8:45 PM"), and detectCliUsageLimit keeps a
-   * passed PM time on TODAY (see its comment) — so for most of the day a
-   * day-old banner parses as a FUTURE reset, i.e. retryReady === false. Codex
-   * prints that banner once and leaves it in the viewport forever (verified on
-   * live panes: never a second occurrence, even 20k lines back), so the
-   * "the CLI will reject the retry again and self-heal" assumption behind the
-   * retry-time rule does not hold there. Gating the suppression on retryReady
-   * therefore disarmed it precisely in the case it exists for: every new turn
-   * re-detected the same leftover text and re-pinned 「限额已达」 even after
-   * the CLI had answered normally — and, because clearUsageLimitState() also
-   * resets rateLimitNotifiedKey, re-sent the @owner "turn paused" ping each
-   * time. The state key (kind + retryAtMs + label) is the episode identity;
-   * retryReady is just a countdown flag on it, so a genuinely NEW limit —
-   * different reset clock, or a banner that appears mid-turn on a screen that
-   * started clean — has a different key (or none recorded) and still fires.
+   * usageLimitStateKey of a retry-READY limit banner already on screen when this
+   * turn opened — a previous episode whose reset time has demonstrably passed,
+   * so it is definitionally leftover text. Unchanged from before; the
+   * answered-turn rule below is what was added.
    */
   let staleBannerKey: string | undefined;
+  /**
+   * Clock-free identity (bannerTextIdentity) of ANY limit banner already on
+   * screen when this turn opened, retry-ready or not. Consulted only once
+   * turnProducedAnswer is true — see that flag for why an answer is the
+   * discriminator, and why a key/text comparison alone could not be.
+   *
+   * Deliberately NOT usageLimitStateKey: that embeds retryAtMs, which
+   * detectCliUsageLimit resolves against "today", so one unchanged banner
+   * yields a different key after midnight and the suppression would silently
+   * lapse — re-pinning the card at 00:01 with no new input at all.
+   */
+  let preExistingBannerKey: string | undefined;
+  /**
+   * This turn produced a harvested answer (noteTurnCompleted).
+   *
+   * This is the discriminator for the reported bug: a session that had hit its
+   * limit stayed pinned at 「限额已达」 for every later turn, even after the CLI
+   * answered normally. Codex prints its limit banner ONCE and leaves it in the
+   * viewport indefinitely (verified on live panes: never a second occurrence,
+   * even 20k scrollback lines back), so on each new turn the screen scan
+   * re-detected that same leftover text and re-pinned the card — and because
+   * clearUsageLimitState() also resets rateLimitNotifiedKey, re-sent the @owner
+   * "turn paused" ping each time.
+   *
+   * An answer is POSITIVE evidence: a turn that is actually limit-blocked never
+   * yields a harvested final_output. So "the CLI answered this turn" + "this
+   * banner was already on screen when the turn opened" is sufficient to call the
+   * text leftover, whatever its clock says. Without an answer we never suppress,
+   * so a genuine re-refusal still reports — which matters because two weaker
+   * discriminators do NOT work here:
+   *
+   *  - Comparing the banner text/key alone cannot separate "leftover banner"
+   *    from "identical text from a fresh refusal".
+   *  - Requiring a NEW structured record does not work for `usage`: across all
+   *    1925 local rollouts, the 8 carrying a `usage_limit_exceeded`
+   *    task_complete each carry exactly ONE, including sessions that went on to
+   *    run 7 more turns / 12 more user messages afterwards. Unlike the 429 path
+   *    (one appended record per refusal), a usage refusal is recorded once.
+   *
+   * Consequence, deliberately: CLIs that never reach noteTurnCompleted (gemini
+   * is not in STRUCTURED_BRIDGE_ALWAYS_CLI_IDS) keep the previous behavior
+   * exactly. Those are the CLIs with no authoritative limit signal at all, where
+   * suppressing a repeated banner would risk hiding a real block.
+   */
+  let turnProducedAnswer = false;
   // A STRUCTURED limit (transcript error record, Claude/Codex) is authoritative
   // and one-shot at the source (UUID-deduped emit). Re-emit it on every
   // classify() until the turn ends: a genuinely blocked CLI keeps its
@@ -95,7 +158,11 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
       detectedTurn = undefined;
       activeStructured = undefined;
       const current = detectCliUsageLimit(snapshot, undefined, { suppressRateKind: opts.isRateKindSuppressed() });
-      staleBannerKey = current.limited ? usageLimitStateKey(current) : undefined;
+      preExistingBannerKey = current.limited ? bannerTextIdentity(current) : undefined;
+      staleBannerKey = current.limited && current.retryReady
+        ? usageLimitStateKey(current)
+        : undefined;
+      turnProducedAnswer = false;
       return turnSeq;
     },
     // Map a runtime status to a usage-limit-aware status, recording whether this
@@ -128,9 +195,15 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
       }
 
       const key = usageLimitStateKey(detected);
-      // Same episode as the banner that was already on screen at turn start —
-      // leftover text, not a fresh verdict about this turn.
-      if (key === staleBannerKey) {
+      // (a) master's rule: a banner already on screen whose reset time has
+      //     already passed is definitionally leftover.
+      // (b) the new rule: a banner that was ALREADY on screen when this turn
+      //     opened, on a turn where the CLI has since produced a real answer.
+      //     The answer is positive proof the limit is not blocking, so the
+      //     text is leftover no matter what its clock says. Without an
+      //     answer we never suppress — a genuine re-refusal still reports.
+      if (key === staleBannerKey
+        || (turnProducedAnswer && bannerTextIdentity(detected) === preExistingBannerKey)) {
         return { status };
       }
 
@@ -149,18 +222,31 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
     // the turn ends. The actual emit is done by the caller.
     noteStructuredLimit(state: CliUsageLimitState): void {
       staleBannerKey = undefined;
+      // An authoritative limit arriving AFTER this turn produced an answer
+      // (steered / multi-answer turns can interleave) supersedes that answer as
+      // evidence: the CLI is blocked NOW. Re-arm both suppressions off, or the
+      // answered-turn rule would keep swallowing the banner the structured
+      // signal is telling us to show.
+      preExistingBannerKey = undefined;
+      turnProducedAnswer = false;
       detectedTurn = turnSeq;
       activeStructured = { seq: turnSeq, state };
     },
-    // A successfully harvested turn (bridge final_output) is definitive
-    // evidence the CLI recovered from any structured limit that parked it.
-    // Drop the latch so the next classify() does not re-emit the stale limit
-    // — the daemon's final_output handler already cleared ds.usageLimit for
-    // the same recovery, and a re-emit would re-pin the card / Dashboard.
+    // A turn reached its terminal. Both outcomes drop the structured re-emit
+    // latch (the daemon's final_output handler already cleared ds.usageLimit for
+    // the same recovery, and a re-emit would re-pin the card / Dashboard), but
+    // only 'answered' is evidence the CLI is not limit-blocked.
     // detectedTurn is intentionally left as a historical fact (it self-clears
     // on the next beginTurn).
-    noteTurnCompleted(): void {
+    noteTurnCompleted(outcome: 'answered' | 'failed' = 'answered'): void {
       activeStructured = undefined;
+      // A failed terminal proves nothing about limits — a rate/usage refusal IS
+      // a failed terminal — so it must not arm the stale-banner suppression.
+      if (outcome !== 'answered') return;
+      // Positive evidence this turn is NOT limit-blocked: the CLI produced a
+      // harvested answer. Any limit banner that was already on screen when
+      // the turn opened is therefore leftover text from an earlier episode.
+      turnProducedAnswer = true;
     },
   };
 }

--- a/src/utils/usage-limit-tracker.ts
+++ b/src/utils/usage-limit-tracker.ts
@@ -22,21 +22,22 @@ export interface UsageLimitTracker<S extends string = string> {
   detectedThisTurn(seq: number): boolean;
   noteStructuredLimit(state: CliUsageLimitState): void;
   /**
-   * A turn reached its terminal and a bridge final_output is being emitted.
+   * A turn reached its terminal.
    *
-   * `outcome` distinguishes a real model answer from a failure/notice fallback:
-   * the codex bridge routes BOTH through the same emit (`structuredFallbackKind`
-   * can be 'failed', whose content is failedBridgeFallbackContent — a notice,
-   * not an answer). Only 'answered' is positive evidence the CLI is not
-   * limit-blocked, so only that arms the stale-banner suppression. A 'failed'
-   * terminal must never arm it: a rate/usage refusal IS a failed terminal, and
-   * treating it as an answer would suppress the very banner it should surface.
+   * `outcome` distinguishes a real model answer from a failure/ambiguous
+   * terminal, and ONLY 'answered' changes any state:
    *
-   * Both outcomes still clear the structured-limit re-emit latch, preserving the
-   * existing self-heal: in an adopted session the user can recover from a
-   * structured rate limit in their own terminal without triggering beginTurn(),
-   * and without this the latch would re-pin the card / Dashboard after the
-   * daemon already cleared it.
+   *  - 'answered' drops the structured-limit re-emit latch (preserving the
+   *    existing self-heal: in an adopted session the user can recover from a
+   *    structured rate limit in their own terminal without triggering
+   *    beginTurn(), and without this the latch would re-pin the card /
+   *    Dashboard after the daemon already cleared it) and arms the stale-banner
+   *    suppression.
+   *  - 'failed' is a NO-OP. A rate/usage refusal IS a failed terminal, so it is
+   *    evidence FOR a limit, never against one — it must neither arm the
+   *    suppression nor drop the latch. Dropping the latch on a failed terminal
+   *    would silence a real 429 whose screen-scan verdict is suppressed because
+   *    the structured signal is the authority (codex).
    */
   noteTurnCompleted(outcome?: 'answered' | 'failed'): void;
 }
@@ -232,17 +233,27 @@ export function createUsageLimitTracker<S extends string = string>(opts: {
       detectedTurn = turnSeq;
       activeStructured = { seq: turnSeq, state };
     },
-    // A turn reached its terminal. Both outcomes drop the structured re-emit
-    // latch (the daemon's final_output handler already cleared ds.usageLimit for
-    // the same recovery, and a re-emit would re-pin the card / Dashboard), but
-    // only 'answered' is evidence the CLI is not limit-blocked.
+    // A turn reached its terminal. Only 'answered' is evidence the CLI is not
+    // limit-blocked, and only 'answered' touches state at all — see below.
     // detectedTurn is intentionally left as a historical fact (it self-clears
     // on the next beginTurn).
     noteTurnCompleted(outcome: 'answered' | 'failed' = 'answered'): void {
-      activeStructured = undefined;
-      // A failed terminal proves nothing about limits — a rate/usage refusal IS
-      // a failed terminal — so it must not arm the stale-banner suppression.
+      // A failed/ambiguous terminal proves nothing about limits — a rate/usage
+      // refusal IS a failed terminal — so it must change NOTHING: it neither
+      // arms the stale-banner suppression nor drops the structured re-emit
+      // latch. Dropping the latch here would be actively harmful on the path
+      // this fix newly routes through: with a `botmux send` marker on the turn,
+      // a structured 429 sets activeStructured, then the gate branch reaches
+      // this call with outcome='failed'; clearing the latch would let the next
+      // `working` frame trigger the daemon's self-heal, and because codex's
+      // screen-scan `rate` verdict is suppressed (structured signal is the
+      // authority) nothing would ever re-report it — a real 429 gone silent.
       if (outcome !== 'answered') return;
+      // Only a real answer is evidence the CLI recovered, so only here do we
+      // drop the latch — the daemon's final_output handler already cleared
+      // ds.usageLimit for the same recovery, and a re-emit would re-pin the
+      // card / Dashboard.
+      activeStructured = undefined;
       // Positive evidence this turn is NOT limit-blocked: the CLI produced a
       // harvested answer. Any limit banner that was already on screen when
       // the turn opened is therefore leftover text from an earlier episode.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5760,6 +5760,10 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
     if (shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
       // Completed turn whose output went out via `botmux send` (or deliberate
       // silence) — see the codex bridge's twin for why this must arm here.
+      // Hardcoded 'answered' rather than bridgeTurnOutcome(turn): this queue has
+      // no failure terminal at all (no terminalStatus field), so reaching a ready
+      // turn here already means completed. The claude family's limits arrive via
+      // maybeEmitStructuredRateLimit → noteStructuredLimit, which revokes this.
       usageLimitTracker.noteTurnCompleted('answered');
       const reason = turn.isLocal ? 'local-typed' : 'model called botmux send within window';
       log(`Bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (${reason})`);
@@ -7354,14 +7358,22 @@ function emitReadyCodexTurns(): void {
         : fallbackKind === 'empty_completed'
           ? emptyCompletedBridgeFallbackContent()
           : '';
+    // Record the turn's outcome for the usage-limit tracker BEFORE the
+    // `!content` bail-out. A completed turn is positive evidence the CLI is not
+    // limit-blocked, and that is true whether or not there is fallback text to
+    // post: the ordinary shape here is "model answered via `botmux send`", which
+    // leaves `last_agent_message` empty (253 such success terminals across the
+    // 1925 local rollouts) and makes structuredFallbackKind return 'none' — so
+    // `content` is '' and every later statement is unreachable. Binding the
+    // outcome to the emit, or even to the gate branch below, therefore misses
+    // the most common success path of all. failed/ambiguous stay a no-op via
+    // bridgeTurnOutcome, so a limit refusal never reads as success.
+    const turnOutcome = bridgeTurnOutcome(turn);
+    if (!content || shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
+      usageLimitTracker.noteTurnCompleted(turnOutcome);
+    }
     if (!content) continue;
     if (shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
-      // The turn still COMPLETED — its content went out via `botmux send`, or it
-      // was a deliberate nothing-to-send. That is the ordinary success path, so
-      // it is positive evidence the CLI is not limit-blocked and must arm the
-      // stale-banner suppression HERE: the emit below is skipped on this path,
-      // so binding `answered` to the emit alone would miss the common case.
-      usageLimitTracker.noteTurnCompleted(bridgeTurnOutcome(turn));
       log(`Codex bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (gate)`);
       // Distinguish DELIBERATE SILENCE (bare nothing-to-send sentinel, no prose,
       // no send) from other suppression reasons (already `botmux send`-ed this
@@ -7397,7 +7409,7 @@ function emitReadyCodexTurns(): void {
       if (!fields) continue;
       // Harvested answer → drop the structured-limit re-emit latch (mirrors
       // the daemon's final_output self-heal; see emitReadyTurns).
-      usageLimitTracker.noteTurnCompleted(bridgeTurnOutcome(turn));
+      usageLimitTracker.noteTurnCompleted(turnOutcome);
       send({
         type: 'final_output',
         ...(sourceHermesSessionId ? { sourceHermesSessionId } : {}),
@@ -7410,7 +7422,7 @@ function emitReadyCodexTurns(): void {
       });
       continue;
     }
-    usageLimitTracker.noteTurnCompleted(bridgeTurnOutcome(turn));
+    usageLimitTracker.noteTurnCompleted(turnOutcome);
     send({
       type: 'final_output',
       ...(sourceHermesSessionId ? { sourceHermesSessionId } : {}),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -360,7 +360,7 @@ import {
 } from './utils/herdr-web-history.js';
 import { parseWorkerRequestUrl } from './utils/worker-http.js';
 import { structuredRateLimitState, isStructuredRateLimitAuthoritative, type CliUsageLimitState } from './utils/cli-usage-limit.js';
-import { createUsageLimitTracker } from './utils/usage-limit-tracker.js';
+import { bridgeTurnOutcome, createUsageLimitTracker } from './utils/usage-limit-tracker.js';
 import { uploadImageBuffer } from './utils/lark-upload.js';
 import { applySessionOwnerEnv, redactChildEnv, scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv } from './utils/child-env.js';
 import {
@@ -5758,6 +5758,9 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
 
     const gateInput = { markTimeMs: turn.markTimeMs, isLocal: turn.isLocal, finalText: assistantText };
     if (shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
+      // Completed turn whose output went out via `botmux send` (or deliberate
+      // silence) — see the codex bridge's twin for why this must arm here.
+      usageLimitTracker.noteTurnCompleted('answered');
       const reason = turn.isLocal ? 'local-typed' : 'model called botmux send within window';
       log(`Bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (${reason})`);
       // Positive silence evidence for the terminal — only a bare nothing-to-send
@@ -5802,7 +5805,7 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
         // limit that parked it — mirror the daemon's final_output self-heal
         // (worker-pool clears ds.usageLimit there) by dropping the tracker's
         // re-emit latch so the next classify() does not re-pin the card.
-        usageLimitTracker.noteTurnCompleted();
+        usageLimitTracker.noteTurnCompleted('answered');
         send({
           type: 'final_output',
           content: fields.content,
@@ -5817,7 +5820,7 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
       // Headless local turn — see formatHeadlessLocalTurnContent for context.
       const headlessContent = formatHeadlessLocalTurnContent(postText);
       if (!headlessContent) continue;
-      usageLimitTracker.noteTurnCompleted();
+      usageLimitTracker.noteTurnCompleted('answered');
       send({
         type: 'final_output',
         content: headlessContent,
@@ -5836,7 +5839,7 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
     const deliveredText = turn.restoredFromJournal
       ? `${t('worker.bridge_restored_turn_notice')}\n\n${postText}`
       : postText;
-    usageLimitTracker.noteTurnCompleted();
+    usageLimitTracker.noteTurnCompleted('answered');
     send({
       type: 'final_output',
       content: deliveredText,
@@ -7353,6 +7356,12 @@ function emitReadyCodexTurns(): void {
           : '';
     if (!content) continue;
     if (shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
+      // The turn still COMPLETED — its content went out via `botmux send`, or it
+      // was a deliberate nothing-to-send. That is the ordinary success path, so
+      // it is positive evidence the CLI is not limit-blocked and must arm the
+      // stale-banner suppression HERE: the emit below is skipped on this path,
+      // so binding `answered` to the emit alone would miss the common case.
+      usageLimitTracker.noteTurnCompleted(bridgeTurnOutcome(turn));
       log(`Codex bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (gate)`);
       // Distinguish DELIBERATE SILENCE (bare nothing-to-send sentinel, no prose,
       // no send) from other suppression reasons (already `botmux send`-ed this
@@ -7388,7 +7397,7 @@ function emitReadyCodexTurns(): void {
       if (!fields) continue;
       // Harvested answer → drop the structured-limit re-emit latch (mirrors
       // the daemon's final_output self-heal; see emitReadyTurns).
-      usageLimitTracker.noteTurnCompleted();
+      usageLimitTracker.noteTurnCompleted(bridgeTurnOutcome(turn));
       send({
         type: 'final_output',
         ...(sourceHermesSessionId ? { sourceHermesSessionId } : {}),
@@ -7401,7 +7410,7 @@ function emitReadyCodexTurns(): void {
       });
       continue;
     }
-    usageLimitTracker.noteTurnCompleted();
+    usageLimitTracker.noteTurnCompleted(bridgeTurnOutcome(turn));
     send({
       type: 'final_output',
       ...(sourceHermesSessionId ? { sourceHermesSessionId } : {}),

--- a/test/usage-limit-tracker.test.ts
+++ b/test/usage-limit-tracker.test.ts
@@ -13,8 +13,10 @@
  * Run: pnpm vitest run test/usage-limit-tracker.test.ts
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createUsageLimitTracker } from '../src/utils/usage-limit-tracker.js';
+import { bridgeTurnOutcome, createUsageLimitTracker } from '../src/utils/usage-limit-tracker.js';
 import { detectCliUsageLimit } from '../src/utils/cli-usage-limit.js';
+import { structuredFallbackKind } from '../src/services/bridge-fallback-gate.js';
+import { CODEX_RATE_LIMIT_ERROR_CODE } from '../src/services/codex-transcript.js';
 import type { CliUsageLimitState } from '../src/utils/cli-usage-limit.js';
 
 function structuredLimit(): CliUsageLimitState {
@@ -200,94 +202,180 @@ describe('usage-limit tracker — outputActive 门控（working 不等于输出�
 });
 
 describe('usage-limit tracker — 屏幕上的旧限额横幅不得每轮重新钉住卡片', () => {
-  // 线上真实横幅（Codex）。关键性质有两条：
+  // 线上真实横幅（Codex）。关键性质：
   //  ① 只带钟点不带日期 ⟹ detectCliUsageLimit 对「已过去的 PM 时间」刻意留在
   //     今天（见其注释），所以一天里 20:45 之前的任意时刻，这条隔夜横幅都被
   //     解析成「今天 20:45」这个未来时刻 ⟹ retryReady === false。
-  //  ② Codex 整个 pane 只打印一次就一直留在 viewport 里（实测 261 个 live
-  //     tmux 会话、-S -20000 深回滚，没有任何 pane 出现第二次），所以它不是
-  //     「CLI 又拒了一次」的活证据，而是一块不会消失的旧背景。
-  // 二者叠加：若过期横幅抑制只在 retryReady 时武装，它就恰好在最需要它的场景
-  // 里失效——每开一轮新会话都被同一条陈旧文案重新判成限额。
+  //  ② Codex 整个 pane 只打印一次就一直留在 viewport 里（实测 261 个 live tmux
+  //     会话、-S -20000 深回滚，没有任何 pane 出现第二次），所以它不是「CLI 又
+  //     拒了一次」的活证据，而是一块不会消失的旧背景。
+  // 判据不能只看横幅文本/key：那分不开「旧横幅」与「同文案的新拒绝」。也不能
+  // 要求「出现新的结构化记录」：实测全仓 1925 个 rollout 里，带
+  // usage_limit_exceeded task_complete 的 8 个**各自只有一条**，且其中有会话在
+  // 限额之后仍跑了 7 个 turn / 12 条用户消息——usage kind 的结构化信号只写一次。
+  // 所以用的是正向成功证据：本轮 CLI 真的答出了东西（noteTurnCompleted
+  // 'answered'）——被限额阻塞的轮次永远不会产出成功终态。
   const STALE_BANNER = "■ You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 8:45 PM.";
+  // 另一个 CLI 家族的「带明确重置时刻的 rate 限额」（仓库既有真路径，见
+  // cli-usage-limit.test.ts）。它走 parseMeridiemTime 拿固定钟点，不走 5 分钟
+  // 分桶，所以 key 不会自己递进——这类必须保持原语义，绝不能被抑制。
+  const GEMINI_RATE_BANNER = 'Rate limit exceeded. Try again at 10:36 PM.';
 
   // 把时钟钉在 8:45 PM 之前，让 retryReady 稳定为 false（回归的前提条件）。
-  // 不钉时钟的话，这个用例在每天 20:45 之后会因为 retryReady 变 true 而
-  // 「自己变绿」——那是最坏的一种假绿：它会在 CI 的某些时段掩盖真回归。
+  // 不钉时钟的话，用例在每天 20:45 之后会因为 retryReady 变 true 而「自己变
+  // 绿」——那是最坏的一种假绿：它会在 CI 的某些时段掩盖真回归。
   const beforeReset = new Date('2026-08-29T10:00:00-07:00');
   beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(beforeReset); });
   afterEach(() => { vi.useRealTimers(); });
 
-  function codexTracker() {
-    // codex：emitsStructuredRateLimit ⟹ suppressRateKind=true（rate 走结构化，
-    // 扫屏只留 usage 判定）；限额错误屏上 PTY 已静默 ⟹ outputActive=false。
-    return createUsageLimitTracker({
-      isRateKindSuppressed: () => true,
-      isOutputActive: () => false,
-    });
-  }
+  /** codex：emitsStructuredRateLimit ⟹ suppressRateKind=true（rate 走结构化，
+   *  扫屏只留 usage）；限额错误屏上 PTY 已静默 ⟹ outputActive=false。 */
+  const codexTracker = () => createUsageLimitTracker({
+    isRateKindSuppressed: () => true,
+    isOutputActive: () => false,
+  });
+  /** 非结构化 CLI（gemini/grok/traex…）：rate 扫屏在用，且没有结构化兜底。 */
+  const plainTracker = () => createUsageLimitTracker({
+    isRateKindSuppressed: () => false,
+    isOutputActive: () => false,
+  });
 
   it('前提校验：这条横幅在重置时刻之前确实解析为 retryReady=false', () => {
-    // 这不是被测行为，而是「上面两条性质」的自证。如果哪天解析规则改了、
-    // 这条横幅变成 retryReady=true，下面的回归用例就不再覆盖它声称的场景
-    // （会退化成一个恒真断言），必须由这条前提用例先红出来。
+    // 这不是被测行为，而是上面「性质①」的自证。如果哪天解析规则改了、这条横幅
+    // 变成 retryReady=true，下面的回归用例就不再覆盖它声称的场景（会退化成恒真
+    // 断言），必须由这条前提用例先红出来。
     const detected = detectCliUsageLimit(STALE_BANNER);
     expect(detected.limited).toBe(true);
     expect((detected as CliUsageLimitState).kind).toBe('usage');
     expect((detected as CliUsageLimitState).retryReady).toBe(false);
   });
 
-  it('新一轮开始时屏幕上就有横幅 ⟹ 本轮不再判限额（回归）', () => {
+  it('本轮真答完后，屏幕上的旧横幅不再判限额（回归）', () => {
     const tracker = codexTracker();
     // 第 1 轮：真限额命中（canary——若这里就不 limited，本用例什么都没测到）。
     tracker.beginTurn('');
     expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('limited');
 
-    // 第 2 轮：用户重新发消息。daemon 的 beginNewTurn 已清 ds.usageLimit，
-    // 但屏幕上那条横幅还在（Codex 不会重印、也不会自己消失）。
+    // 第 2 轮：用户重新发消息，屏幕上那条横幅还在（Codex 不重印也不消失）。
     const seq2 = tracker.beginTurn(STALE_BANNER);
-    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
-    expect(tracker.detectedThisTurn(seq2)).toBe(false);
-  });
-
-  it('CLI 正常答完一轮后，后续 idle tick 也不会被旧横幅重新钉住', () => {
-    // 完整还原线上症状：自愈路径（noteTurnCompleted + daemon 侧
-    // clearUsageLimitState）全都执行了，卡片却又被扫屏重新钉回 limited。
-    const tracker = codexTracker();
-    tracker.beginTurn(STALE_BANNER);
-    tracker.noteTurnCompleted();
+    tracker.noteTurnCompleted('answered');
     expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
     expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
     expect(tracker.classify(STALE_BANNER, 'stalled').status).toBe('stalled');
+    expect(tracker.detectedThisTurn(seq2)).toBe(false);
+  });
+
+  it('本轮尚未答出东西时，旧横幅照常判限额（不得 fail-open）', () => {
+    // 这是抑制的「有牙」边界：没有成功证据就不抑制，真限额仍然上报。
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('limited');
+  });
+
+  it('failed 终态不得置成功位（限额拒绝本身就是 failed 终态）', () => {
+    // codex bridge 的失败 fallback 与成功路径共用同一个出口，若把它当成功
+    // 证据，等于「用限额拒绝证明没被限额」。
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted('failed');
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('limited');
+  });
+
+  it('ambiguous 终态同样不得置成功位', () => {
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted('failed'); // bridgeTurnOutcome 把 ambiguous 映射到 failed
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('limited');
+  });
+
+  it('成功判据必须取终态，不能取 fallbackKind（失败+已send 的组合）', () => {
+    // structuredFallbackKind 决定「展示哪种 fallback」，不是终态：当失败 fallback
+    // 被 gate 掉（本轮已 botmux send / 命中 codex 限额短路 rateLimitHandled）时，
+    // 它会返回 'final'。此处以 bridge-fallback-gate 的真实返回值驱动，确认按
+    // fallbackKind 判会把 failed 终态误判成成功，而按 terminalStatus 判不会。
+    const failedButGated = structuredFallbackKind(
+      { turnId: 't', isLocal: false, finalText: 'x', markTimeMs: Date.now(),
+        terminalStatus: 'failed', terminalErrorCode: CODEX_RATE_LIMIT_ERROR_CODE } as any,
+      undefined, [], false, true,
+    );
+    // 真路径自证：这个组合下 fallbackKind 确实不是 'failed'。
+    expect(failedButGated).not.toBe('failed');
+
+    // 按终态判（worker 的 bridgeTurnOutcome 口径）：failed ⟹ 不置位 ⟹ 仍上报。
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted('failed');
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('limited');
+  });
+
+  it('已 botmux send（fallback 被 gate 掉）也算成功终态', () => {
+    // 最常见的成功路径：模型本轮已 botmux send，shouldSuppressBridgeEmit 会在
+    // final_output 之前 continue。若把成功证据绑在「是否又发了一条 final_output」
+    // 上，这条路径永远不置位，原横幅仍会每轮重钉——即本 bug 的主场景。
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted('answered');
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
   });
 
   it('抑制严格按 episode 收敛：干净开局时中途出现的限额仍要检出', () => {
-    // 反向校准：这条修法不能把「真限额」一起抑制掉。
     const tracker = codexTracker();
     tracker.beginTurn('干净屏幕，完全没有限额文案');
+    tracker.noteTurnCompleted('answered');
     const detected = tracker.classify(STALE_BANNER, 'idle');
     expect(detected.status).toBe('limited');
     expect(detected.usageLimit?.kind).toBe('usage');
   });
 
-  it('抑制只认同一 episode：换成另一个重置钟点即视为新限额', () => {
-    // usageLimitStateKey 含 retryAtMs + label，所以「另一次限额」自带不同 key。
+  it('抑制只认同一横幅：换成另一个重置钟点即视为新限额', () => {
     const tracker = codexTracker();
     tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted('answered');
     expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
-    const newEpisode = STALE_BANNER.replace('8:45 PM', '11:15 PM');
-    const detected = tracker.classify(newEpisode, 'idle');
+    const detected = tracker.classify(STALE_BANNER.replace('8:45 PM', '11:15 PM'), 'idle');
     expect(detected.status).toBe('limited');
     expect(detected.usageLimit?.retryLabel).toBe('11:15 PM');
   });
 
-  it('已抑制的 episode 不影响结构化限流重发', () => {
-    // 结构化信号是权威的：屏幕上有陈旧横幅时，它照样要能把卡片钉住。
+  it('横幅身份不含时钟：跨午夜不得因 retryAtMs 漂移而重新钉住', () => {
+    // usageLimitStateKey 含 retryAtMs，而 retryAtMs 是按「今天」解析的，所以同
+    // 一段屏幕文字在午夜前后会产生不同的 key。若用它当横幅身份，抑制会在 00:01
+    // 静默失效、在没有任何新输入的情况下把卡片重新钉住。
+    const tracker = codexTracker();
+    vi.setSystemTime(new Date('2026-08-29T23:59:00-07:00'));
+    tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted('answered');
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
+    vi.setSystemTime(new Date('2026-08-30T00:01:00-07:00'));
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
+  });
+
+  it('结构化限额到达后撤销成功抑制（权威信号优先）', () => {
+    // 成功答完之后又收到权威限额（steer / 多答交错）：CLI 现在确实被阻塞，
+    // 不能再让「本轮答过」把该显示的横幅继续吞掉。
     const tracker = codexTracker();
     tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted('answered');
     expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
     tracker.noteStructuredLimit(structuredLimit());
     expect(tracker.classify(STALE_BANNER, 'working').status).toBe('limited');
+  });
+
+  it('非结构化 CLI 的带钟点限额：重试仍被拒时必须继续上报', () => {
+    // 无结构化兜底的 CLI（gemini/grok/traex…）：其带明确钟点的限额走固定
+    // retryAtMs、不走 5 分钟分桶，key 不会自己递进。用户在真限额期间重试、
+    // CLI 以同文案再拒时，必须照报——否则真限额被静默到跨日。
+    const tracker = plainTracker();
+    tracker.beginTurn(GEMINI_RATE_BANNER);
+    expect(tracker.classify(GEMINI_RATE_BANNER, 'idle').status).toBe('limited');
+  });
+
+  it('非结构化 CLI 连续多轮重试都要上报', () => {
+    const tracker = plainTracker();
+    for (let turn = 0; turn < 5; turn++) {
+      tracker.beginTurn(GEMINI_RATE_BANNER);
+      expect(tracker.classify(GEMINI_RATE_BANNER, 'idle').status).toBe('limited');
+    }
   });
 
   it('working + 输出在进展时的既有门控不受影响', () => {
@@ -296,6 +384,34 @@ describe('usage-limit tracker — 屏幕上的旧限额横幅不得每轮重新�
       isOutputActive: () => true,
     });
     tracker.beginTurn('干净屏幕');
+    tracker.noteTurnCompleted('answered');
     expect(tracker.classify(STALE_BANNER, 'working').status).toBe('working');
+  });
+});
+
+describe('usage-limit tracker — bridgeTurnOutcome 按终态而非 fallbackKind 判成功', () => {
+  // 这个 predicate 是「本轮算不算答出东西」的唯一判据，worker 的三个 bridge
+  // 出口都调它。它必须只认终态：structuredFallbackKind 决定的是「展示哪种
+  // fallback 文案」，在失败 fallback 被 gate 掉时会对 failed 终态返回 'final'。
+  it('completed / undefined 终态算 answered', () => {
+    expect(bridgeTurnOutcome({ terminalStatus: 'completed' })).toBe('answered');
+    expect(bridgeTurnOutcome({})).toBe('answered');
+  });
+
+  it('failed / ambiguous 终态算 failed', () => {
+    expect(bridgeTurnOutcome({ terminalStatus: 'failed' })).toBe('failed');
+    expect(bridgeTurnOutcome({ terminalStatus: 'ambiguous' })).toBe('failed');
+  });
+
+  it('failed 终态 + 失败 fallback 被 gate 掉时，仍判 failed（真路径自证）', () => {
+    // 先用 bridge-fallback-gate 的真实返回值证明「按 fallbackKind 判会误判」，
+    // 再确认 bridgeTurnOutcome 不受它影响。缺了前半段，这条断言就无从判断自己
+    // 是否真的覆盖了那个绕过路径。
+    const turn = {
+      turnId: 't', isLocal: false, finalText: 'x', markTimeMs: Date.now(),
+      terminalStatus: 'failed' as const, terminalErrorCode: CODEX_RATE_LIMIT_ERROR_CODE,
+    };
+    expect(structuredFallbackKind(turn as any, undefined, [], false, true)).not.toBe('failed');
+    expect(bridgeTurnOutcome(turn)).toBe('failed');
   });
 });

--- a/test/usage-limit-tracker.test.ts
+++ b/test/usage-limit-tracker.test.ts
@@ -490,9 +490,12 @@ describe('usage-limit tracker — worker 接线不变量（源码守卫）', () 
     return workerSrc.slice(start, end);
   }
 
-  it('终态记录必须出现在 `if (!content) continue;` 之前', () => {
+  it('终态记录必须出现在「无 fallback 文案就 continue」那个 bail-out 之前', () => {
+    // 锚点刻意不绑变量名：按 `if (!<ident>) continue;` 这个**形状**匹配，所以把
+    // 局部变量 content 改名为 fallbackText 之类的正常重构不会让守卫误红（实测
+    // 过：写死 'if (!content)' 的版本一改名就红，那种守卫迟早被人删掉）。
     const body = codexEmitBody();
-    const bail = body.indexOf('if (!content) continue;');
+    const bail = body.search(/if \(!\w+\) continue;/);
     const record = body.indexOf('usageLimitTracker.noteTurnCompleted(');
     // 窗口自证：两个锚点都真的在这个函数体里找到了，否则断言是空真的。
     expect(bail).toBeGreaterThan(-1);
@@ -501,9 +504,12 @@ describe('usage-limit tracker — worker 接线不变量（源码守卫）', () 
   });
 
   it('该记录必须由 bridgeTurnOutcome 决定，不得写死 answered', () => {
+    // 只锁「用了这个 predicate」+「没写死成功位」这两点，不锁它的实参形状：
+    // `bridgeTurnOutcome(turn)` 与 `bridgeTurnOutcome({ terminalStatus: … })`
+    // 语义相同，守卫不该因为后者而误红（实测过绑 `(turn)` 会红）。这个 bridge
+    // 有失败终态，写死成功位会把限额拒绝读成成功。
     const body = codexEmitBody();
-    expect(body).toContain('bridgeTurnOutcome(turn)');
-    // 这个 bridge 有失败终态，写死成功位会把限额拒绝读成成功。
-    expect(body).not.toContain("noteTurnCompleted('answered')");
+    expect(body).toMatch(/bridgeTurnOutcome\(/);
+    expect(body).not.toMatch(/noteTurnCompleted\(\s*['"]answered['"]\s*\)/);
   });
 });

--- a/test/usage-limit-tracker.test.ts
+++ b/test/usage-limit-tracker.test.ts
@@ -281,6 +281,31 @@ describe('usage-limit tracker — 屏幕上的旧限额横幅不得每轮重新�
     expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('limited');
   });
 
+  it('failed 终态不得清结构化 latch（真 429 不得静默）', () => {
+    // 本 PR 在 gate 分支新增了 noteTurnCompleted 调用点，把 failed 终态接进了
+    // 「清 latch」这条路——而 master 上这条路根本不会被走到。真路径：本轮已有
+    // botmux send marker，结构化 429 先置 latch，随后 gate=true 带着 failed 终态
+    // 调到这里。若清了 latch，下一帧 working 会触发 daemon 自愈清限额，而 codex
+    // 的扫屏 rate 判定本来就被 suppress（结构化才是权威）⟹ 真 429 永久静默。
+    const tracker = codexTracker();
+    tracker.beginTurn('');
+    tracker.noteStructuredLimit(structuredLimit());
+    expect(tracker.classify('模型正常输出', 'working').status).toBe('limited');
+    tracker.noteTurnCompleted('failed');
+    expect(tracker.classify('模型正常输出', 'working').status).toBe('limited');
+    expect(tracker.classify('模型正常输出', 'idle').status).toBe('limited');
+  });
+
+  it('answered 终态仍清结构化 latch（既有自愈不变）', () => {
+    // 反向校准：failed 不清 latch 这条改动不能顺手把 answered 的自愈也关掉。
+    const tracker = codexTracker();
+    tracker.beginTurn('');
+    tracker.noteStructuredLimit(structuredLimit());
+    expect(tracker.classify('模型正常输出', 'working').status).toBe('limited');
+    tracker.noteTurnCompleted('answered');
+    expect(tracker.classify('模型正常输出', 'working').status).toBe('working');
+  });
+
   it('ambiguous 终态同样不得置成功位', () => {
     const tracker = codexTracker();
     tracker.beginTurn(STALE_BANNER);

--- a/test/usage-limit-tracker.test.ts
+++ b/test/usage-limit-tracker.test.ts
@@ -12,10 +12,11 @@
  *
  * Run: pnpm vitest run test/usage-limit-tracker.test.ts
  */
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { bridgeTurnOutcome, createUsageLimitTracker } from '../src/utils/usage-limit-tracker.js';
 import { detectCliUsageLimit } from '../src/utils/cli-usage-limit.js';
-import { structuredFallbackKind } from '../src/services/bridge-fallback-gate.js';
+import { shouldSuppressBridgeEmit, structuredFallbackKind } from '../src/services/bridge-fallback-gate.js';
 import { CODEX_RATE_LIMIT_ERROR_CODE } from '../src/services/codex-transcript.js';
 import type { CliUsageLimitState } from '../src/utils/cli-usage-limit.js';
 
@@ -343,6 +344,36 @@ describe('usage-limit tracker — 屏幕上的旧限额横幅不得每轮重新�
     expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
   });
 
+  it('Codex 静默成功（last_agent_message 空 + 已 send）也必须置成功位（接线回归）', () => {
+    // 这一格是 worker 侧的**接线**回归，不是两个纯函数各自的返回值：
+    // codex-transcript 会把空 last_agent_message 产成 assistant_final(text:'')，
+    // 而本轮有 in-window send marker 时 structuredFallbackKind 返回 'none' ⟹
+    // content='' ⟹ worker 的 `if (!content) continue` 先触发，gate 分支里的
+    // noteTurnCompleted 结构上不可达。这是最常见的成功形态（全仓 1925 个 rollout
+    // 里有 253 个这种成功终态），漏了它旧横幅照旧每轮重钉。
+    // 先用真函数自证这个组合确实走到 content='' 且 gate=true——否则本用例可能
+    // 在测一个根本不存在的形态。
+    const gateInput = { turnId: 't', isLocal: false, finalText: '', markTimeMs: 100 };
+    const markers = [{ sentAtMs: 150 }];
+    const kind = structuredFallbackKind(gateInput as any, undefined, markers, false, true);
+    expect(kind).toBe('none');                                    // ⟹ content 会是 ''
+    expect(shouldSuppressBridgeEmit(gateInput as any, undefined, markers, false)).toBe(true);
+
+    // worker 现在在 `!content` 分支上也记录终态（bridgeTurnOutcome 决定 answered/
+    // failed），所以同一条旧横幅不再被重新判成限额。
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted(bridgeTurnOutcome({}));             // 成功终态：无 terminalStatus
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
+  });
+
+  it('同一形态但终态是 failed 时仍须上报（不得因 content 空就当成功）', () => {
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted(bridgeTurnOutcome({ terminalStatus: 'failed' }));
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('limited');
+  });
+
   it('抑制严格按 episode 收敛：干净开局时中途出现的限额仍要检出', () => {
     const tracker = codexTracker();
     tracker.beginTurn('干净屏幕，完全没有限额文案');
@@ -438,5 +469,41 @@ describe('usage-limit tracker — bridgeTurnOutcome 按终态而非 fallbackKind
     };
     expect(structuredFallbackKind(turn as any, undefined, [], false, true)).not.toBe('failed');
     expect(bridgeTurnOutcome(turn)).toBe('failed');
+  });
+});
+
+describe('usage-limit tracker — worker 接线不变量（源码守卫）', () => {
+  // worker.ts 没有单测面，而这条缺陷是**语句顺序**：把终态记录放在
+  // `if (!content) continue;` 之后，它对「静默成功 + 已 botmux send」这一最常见
+  // 形态结构上不可达（content 恒为 ''）。行为用例咬不住顺序——实测把顺序改回
+  // 缺陷版本，35 条用例全绿——所以这条只能由源码守卫兜。
+  const workerSrc = readFileSync(
+    new URL('../src/worker.ts', import.meta.url), 'utf8',
+  );
+
+  /** emitReadyCodexTurns 的函数体（从签名到下一个顶层 function）。 */
+  function codexEmitBody(): string {
+    const start = workerSrc.indexOf('function emitReadyCodexTurns(');
+    expect(start).toBeGreaterThan(-1);          // 锚点自证：函数还在
+    const end = workerSrc.indexOf('\nfunction ', start + 1);
+    expect(end).toBeGreaterThan(start);
+    return workerSrc.slice(start, end);
+  }
+
+  it('终态记录必须出现在 `if (!content) continue;` 之前', () => {
+    const body = codexEmitBody();
+    const bail = body.indexOf('if (!content) continue;');
+    const record = body.indexOf('usageLimitTracker.noteTurnCompleted(');
+    // 窗口自证：两个锚点都真的在这个函数体里找到了，否则断言是空真的。
+    expect(bail).toBeGreaterThan(-1);
+    expect(record).toBeGreaterThan(-1);
+    expect(record).toBeLessThan(bail);
+  });
+
+  it('该记录必须由 bridgeTurnOutcome 决定，不得写死 answered', () => {
+    const body = codexEmitBody();
+    expect(body).toContain('bridgeTurnOutcome(turn)');
+    // 这个 bridge 有失败终态，写死成功位会把限额拒绝读成成功。
+    expect(body).not.toContain("noteTurnCompleted('answered')");
   });
 });

--- a/test/usage-limit-tracker.test.ts
+++ b/test/usage-limit-tracker.test.ts
@@ -509,7 +509,19 @@ describe('usage-limit tracker — worker 接线不变量（源码守卫）', () 
     // 语义相同，守卫不该因为后者而误红（实测过绑 `(turn)` 会红）。这个 bridge
     // 有失败终态，写死成功位会把限额拒绝读成成功。
     const body = codexEmitBody();
-    expect(body).toMatch(/bridgeTurnOutcome\(/);
-    expect(body).not.toMatch(/noteTurnCompleted\(\s*['"]answered['"]\s*\)/);
+    // 必须真正把 predicate 的结果喂给 tracker，而不是「函数体里某处出现过」：
+    // 先抓 noteTurnCompleted 的实参标识符，再证明那个标识符正是由
+    // bridgeTurnOutcome 赋值的。只 grep 两个名字都存在是**欠约束**的——实测把
+    // bridgeTurnOutcome 的结果弃用、另写一个恒为 'answered' 的同名局部变量，
+    // 那种守卫照样全绿。
+    const calls = [...body.matchAll(/noteTurnCompleted\(([^)]*)\)/g)].map(m => m[1].trim());
+    expect(calls.length).toBeGreaterThan(0);            // 锚点自证
+    for (const arg of calls) {
+      // 实参必须是个标识符（不是字面量），且该标识符由 bridgeTurnOutcome 赋值。
+      expect(arg).toMatch(/^[A-Za-z_$][\w$]*$/);
+      expect(body).toMatch(
+        new RegExp(`(?:const|let)\\s+${arg}[^=\\n]*=\\s*bridgeTurnOutcome\\(`),
+      );
+    }
   });
 });

--- a/test/usage-limit-tracker.test.ts
+++ b/test/usage-limit-tracker.test.ts
@@ -12,8 +12,9 @@
  *
  * Run: pnpm vitest run test/usage-limit-tracker.test.ts
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createUsageLimitTracker } from '../src/utils/usage-limit-tracker.js';
+import { detectCliUsageLimit } from '../src/utils/cli-usage-limit.js';
 import type { CliUsageLimitState } from '../src/utils/cli-usage-limit.js';
 
 function structuredLimit(): CliUsageLimitState {
@@ -195,5 +196,106 @@ describe('usage-limit tracker — outputActive 门控（working 不等于输出�
     tracker.beginTurn('');
     tracker.noteStructuredLimit(structuredLimit());
     expect(tracker.classify('output', 'working').status).toBe('limited');
+  });
+});
+
+describe('usage-limit tracker — 屏幕上的旧限额横幅不得每轮重新钉住卡片', () => {
+  // 线上真实横幅（Codex）。关键性质有两条：
+  //  ① 只带钟点不带日期 ⟹ detectCliUsageLimit 对「已过去的 PM 时间」刻意留在
+  //     今天（见其注释），所以一天里 20:45 之前的任意时刻，这条隔夜横幅都被
+  //     解析成「今天 20:45」这个未来时刻 ⟹ retryReady === false。
+  //  ② Codex 整个 pane 只打印一次就一直留在 viewport 里（实测 261 个 live
+  //     tmux 会话、-S -20000 深回滚，没有任何 pane 出现第二次），所以它不是
+  //     「CLI 又拒了一次」的活证据，而是一块不会消失的旧背景。
+  // 二者叠加：若过期横幅抑制只在 retryReady 时武装，它就恰好在最需要它的场景
+  // 里失效——每开一轮新会话都被同一条陈旧文案重新判成限额。
+  const STALE_BANNER = "■ You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 8:45 PM.";
+
+  // 把时钟钉在 8:45 PM 之前，让 retryReady 稳定为 false（回归的前提条件）。
+  // 不钉时钟的话，这个用例在每天 20:45 之后会因为 retryReady 变 true 而
+  // 「自己变绿」——那是最坏的一种假绿：它会在 CI 的某些时段掩盖真回归。
+  const beforeReset = new Date('2026-08-29T10:00:00-07:00');
+  beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(beforeReset); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  function codexTracker() {
+    // codex：emitsStructuredRateLimit ⟹ suppressRateKind=true（rate 走结构化，
+    // 扫屏只留 usage 判定）；限额错误屏上 PTY 已静默 ⟹ outputActive=false。
+    return createUsageLimitTracker({
+      isRateKindSuppressed: () => true,
+      isOutputActive: () => false,
+    });
+  }
+
+  it('前提校验：这条横幅在重置时刻之前确实解析为 retryReady=false', () => {
+    // 这不是被测行为，而是「上面两条性质」的自证。如果哪天解析规则改了、
+    // 这条横幅变成 retryReady=true，下面的回归用例就不再覆盖它声称的场景
+    // （会退化成一个恒真断言），必须由这条前提用例先红出来。
+    const detected = detectCliUsageLimit(STALE_BANNER);
+    expect(detected.limited).toBe(true);
+    expect((detected as CliUsageLimitState).kind).toBe('usage');
+    expect((detected as CliUsageLimitState).retryReady).toBe(false);
+  });
+
+  it('新一轮开始时屏幕上就有横幅 ⟹ 本轮不再判限额（回归）', () => {
+    const tracker = codexTracker();
+    // 第 1 轮：真限额命中（canary——若这里就不 limited，本用例什么都没测到）。
+    tracker.beginTurn('');
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('limited');
+
+    // 第 2 轮：用户重新发消息。daemon 的 beginNewTurn 已清 ds.usageLimit，
+    // 但屏幕上那条横幅还在（Codex 不会重印、也不会自己消失）。
+    const seq2 = tracker.beginTurn(STALE_BANNER);
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
+    expect(tracker.detectedThisTurn(seq2)).toBe(false);
+  });
+
+  it('CLI 正常答完一轮后，后续 idle tick 也不会被旧横幅重新钉住', () => {
+    // 完整还原线上症状：自愈路径（noteTurnCompleted + daemon 侧
+    // clearUsageLimitState）全都执行了，卡片却又被扫屏重新钉回 limited。
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    tracker.noteTurnCompleted();
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
+    expect(tracker.classify(STALE_BANNER, 'stalled').status).toBe('stalled');
+  });
+
+  it('抑制严格按 episode 收敛：干净开局时中途出现的限额仍要检出', () => {
+    // 反向校准：这条修法不能把「真限额」一起抑制掉。
+    const tracker = codexTracker();
+    tracker.beginTurn('干净屏幕，完全没有限额文案');
+    const detected = tracker.classify(STALE_BANNER, 'idle');
+    expect(detected.status).toBe('limited');
+    expect(detected.usageLimit?.kind).toBe('usage');
+  });
+
+  it('抑制只认同一 episode：换成另一个重置钟点即视为新限额', () => {
+    // usageLimitStateKey 含 retryAtMs + label，所以「另一次限额」自带不同 key。
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
+    const newEpisode = STALE_BANNER.replace('8:45 PM', '11:15 PM');
+    const detected = tracker.classify(newEpisode, 'idle');
+    expect(detected.status).toBe('limited');
+    expect(detected.usageLimit?.retryLabel).toBe('11:15 PM');
+  });
+
+  it('已抑制的 episode 不影响结构化限流重发', () => {
+    // 结构化信号是权威的：屏幕上有陈旧横幅时，它照样要能把卡片钉住。
+    const tracker = codexTracker();
+    tracker.beginTurn(STALE_BANNER);
+    expect(tracker.classify(STALE_BANNER, 'idle').status).toBe('idle');
+    tracker.noteStructuredLimit(structuredLimit());
+    expect(tracker.classify(STALE_BANNER, 'working').status).toBe('limited');
+  });
+
+  it('working + 输出在进展时的既有门控不受影响', () => {
+    const tracker = createUsageLimitTracker({
+      isRateKindSuppressed: () => true,
+      isOutputActive: () => true,
+    });
+    tracker.beginTurn('干净屏幕');
+    expect(tracker.classify(STALE_BANNER, 'working').status).toBe('working');
   });
 });


### PR DESCRIPTION
## 问题

已达限额的会话再次对话后，卡片一直停在「限额已达」，即使 CLI 已经正常答完这一轮。

**线上取证**：4 个 active 会话被钉住且 `retryAtMs` 已过期 **29 小时**，全部 `retryReady=false`（3 个在 `cli_a93955ad5038dbde`，1 个在 `cli_a93920dfc3b89bca`）。把真实 tmux viewport 喂进现网代码按真实时钟逐帧跑：新轮开始 `limited` → **CLI 真答完一轮之后仍 `limited`** → 之后每个 idle tick 都 `limited`。

副作用比卡片更糟：`clearUsageLimitState()` 会重置 `rateLimitNotifiedKey`，所以每轮都算一次新 episode ⟹ @owner 的「本轮任务已暂停」提醒**每轮重发**。

## 根因

三件事叠加：① 横幅只有钟点没有日期，`cli-usage-limit.ts:82` 对已过去的 PM 时间**刻意留在今天**（注释理由是「靠 CLI 再拒一次自愈」）⟹ Codex 的 `try again at 8:45 PM` 在 20:45 之前恒被解析成未来 ⟹ `retryReady=false`；② 过期横幅抑制**只在 `retryReady=true` 时武装**，恰好在最需要它的场景失效；③ Codex 横幅**只打印一次**就常驻 viewport（扫 261 个 live tmux 会话、`-S -20000` 深回滚，**零第二次**）⟹ ①所依赖的「再拒一次自愈」前提在 Codex 上不成立。

## 修法：用正向成功证据，而不是横幅身份

**只有当本轮确实产出成功终态时**，才把「开轮时就已在屏幕上」的同一条横幅视为陈旧。被限额阻塞的轮次永远不会产出成功终态，所以这是充分判据，且**不依赖横幅是否重印**。没有成功证据时一律照常上报。

两个更弱的判据均已实测排除：

| 候选判据 | 为什么不行 |
|---|---|
| 只比横幅文本 / `usageLimitStateKey` | 分不开「旧横幅」与「同文案的新拒绝」。**首版就是这个，被复审证伪**（见下） |
| 要求出现新的结构化记录 | 对 usage kind 不成立：全仓 **1925** 个 rollout 中带 `usage_limit_exceeded` task_complete 的 8 个**各自只有一条**，其中有会话在限额之后仍跑了 **7 个 turn / 12 条用户消息**。429 是每次拒绝追加一条，usage 只写一次 |

### 首版被证伪的回归（已修）

非结构化 CLI 的限额横幅也可能带明确钟点（仓库既有真路径 `Rate limit exceeded. Try again at 10:36 PM.`），走固定 `retryAtMs`、不走 5 分钟分桶 ⟹ key 不递进，且这类 CLI **没有任何结构化兜底**。master 对照：

```
                       HEAD(首版)                 MASTER
Gemini 重试仍被拒        idle    ❌               limited  ✅
连续五次重试             idle×5  ❌               limited×5 ✅
detectedThisTurn        false   ❌               true     ✅   ← 还喂给 submit-confirmation recheck
```

## 沿途修掉的三个同根缺陷

1. **成功证据必须绑「终态」，不能绑「是否又发了一条 final_output」。** 模型本轮已 `botmux send`（或 `NOTHING_TO_SEND`）时 `shouldSuppressBridgeEmit` 会在 emit 之前 `continue`，两个 bridge 同构。线上日志里这条路**每天都在跑**（`Codex bridge fallback suppressed for turn … (gate)`），若绑在 emit 上，Codex 的常规成功路径永远不置位——**即本 bug 的主场景，等于没修**。

2. **失败终态不得置成功位，且判据必须取 `terminalStatus` 而非 `structuredFallbackKind`。** 后者决定「展示哪种 fallback 文案」，当失败 fallback 被 gate 掉时会对 failed 终态返回 `'final'`，**其中包含 codex 限额短路 `rateLimitHandled` 这一格**——正是绝不能读成成功的那一格。真路径实测：
   ```
   kind=final   按fallbackKind判→answered ❌   terminalStatus=failed  (rate-limit code)
   kind=final   按fallbackKind判→answered ❌   terminalStatus=ambiguous
   ```
   判据收进 `bridgeTurnOutcome()`（`completed`/`undefined` → answered；`failed`/`ambiguous` → failed）。**刻意放在 tracker 模块而非 worker 内部**：退化它时 tracker 单测全绿（`worker.ts` 无单测面），说明这条接线零覆盖，所以移出来给它直接测试面。

3. **「同一条横幅」的身份不能含时钟。** `usageLimitStateKey` 含 `retryAtMs`，而 `retryAtMs` 按「今天」解析 ⟹ 同一段屏幕文字在午夜前后 key 不同，抑制会在 **00:01 静默失效**、在没有任何新输入的情况下把卡片重新钉住。改用 `bannerTextIdentity`（`kind + retryLabel`）。该漂移**在 master 上同样存在（既有缺陷）**，但首版把抑制窗口从「每天 20:45–24:00」扩到全天，**放大了它的触发面**，故一并修掉——归因是既有，影响面扩大是本 PR 的账。

4. **`failed` / `ambiguous` 终态必须完全不动状态——包括不清结构化 latch。** 清 latch 这个行为在 master 上早就存在，但 master 的 5 个 `noteTurnCompleted` 调用点里**没有 gate 分支**，所以 failed 终态从来到不了那个函数；本 PR 在 gate 分支新增调用点后它第一次流进来，一个既有行为就变成了用户可见缺陷：本轮已有 `botmux send` marker 时，结构化 429 先置 latch，随后 gate 带 failed 终态清掉它 ⟹ 下一帧 `working` 触发 daemon 自愈清限额，而 codex 扫屏 `rate` 本就被 suppress ⟹ **真 429 永久静默**，与本 PR 自己声明的「结构化粘性重发不变」直接矛盾。归因是既有行为，但**流经它的输入集合是本 PR 扩大的**，故按本仓判据记本 PR 的账。

5. **静默成功（`last_agent_message` 空 + 已 `botmux send`）此前结构上不可达。** codex 把空 `last_agent_message` 产成 `assistant_final(text:'')`，本轮有 in-window send marker 时 `structuredFallbackKind` 返回 `'none'` ⟹ `content=''` ⟹ `if (!content) continue` 先触发，gate 分支里的记录**永远执行不到**。真函数复现：`fallbackKind='none'` / `content=''` / `shouldSuppressBridgeEmit=true` ⟹ 可达性 `false`。**频次不是理论值**：全仓 1925 个 rollout 中成功 `task_complete` 的 `last_agent_message` 为空的有 **253** 个（非空 5495），约 4.4%；本仓 bot 每轮都走 `botmux send`，daemon 日志里 `Codex bridge fallback suppressed` 出现 **1646** 次。改为在 bail-out **之前**记录，条件为「无 fallback 文案 **或** gate 确认已投递」。

**⚠️ 这条暴露了一个覆盖空洞**：把语句顺序改回缺陷版本后，**35 条行为用例全绿**——「记录点在 bail-out 之前」这条接线在行为层零覆盖（纯函数返回值对、状态机对、接线错，照样绿）。故补 2 条**源码守卫**：记录必须早于 `if (!content) continue;`；必须由 `bridgeTurnOutcome` 决定而非写死 `'answered'`。守卫自带窗口自证（断言两个锚点确实在 `emitReadyCodexTurns` 函数体内找到，避免空真断言）。

另：`noteStructuredLimit` 会**撤销**本轮的成功抑制——权威限额在成功之后到达（steer / 多答交错）时 CLI 确实被阻塞，不能再让「本轮答过」把该显示的横幅吞掉。

## 实测验证

**十二格矩阵 + master 逐格对照**，HEAD 全部符合预期：

| | HEAD | MASTER |
|---|---|---|
| ① 目标 bug：横幅 + 本轮真答完 | `idle` ✅ | `limited` |
| ⑩ 已 `botmux send`（fallback 被 gate） | `idle` ✅ | `limited` |
| ③ 真被拒（无答案） | `limited` ✅ | `limited` |
| ⑪ failed / ambiguous 终态 | `limited` ✅ | `limited` |
| ④⑤ 非结构化 CLI 重试 / 连续五次 | `limited` ✅ | `limited` |
| ⑥ 干净开局中途真限额 | `limited` ✅ | `limited` |
| ⑦ 换钟点 = 新 episode | `limited` ✅ | `limited` |
| ⑧ working + 输出进展门控 | `working` ✅ | `working` |
| ⑨ 结构化限流仍重发 | `limited` ✅ | `limited` |
| 跨午夜（答过 / 未答过） | `idle` / `limited` ✅ | `limited` / `limited` |

**守卫有牙**，逐个退化验证：`bridgeTurnOutcome` 恒返回 answered → **2 红**；去掉 answered-turn 抑制 → **5 红**；让 failed 也清 latch → **1 红**；让 answered 不再清 latch（反向校准，防止修 failed 时顺手废掉既有自愈）→ **2 红**；退化接线顺序 → **1 红**；退化成写死 answered → **1 红**；干净树 → **37 绿**。

**用例把时钟钉死在 10:00**：否则每天 20:45 之后会因 `retryReady` 变 true 而**自己变绿**，在 CI 的某些时段掩盖真回归。另含一条**前提校验**用例——若解析规则改动使该横幅不再是 `retryReady=false`，回归用例就不再覆盖其声称的场景（退化成恒真断言），由前提用例先红出来。

**构建与测试**：`bun run build` 通过；限额相关 4 文件 **93/93**；因改动落在 `worker.ts` 共用路径，另跑 bridge / worker-wiring 8 文件 **311/311**。

## 影响面

`usage-limit-tracker` + `worker.ts` 两个 bridge 出口，**所有 CLI 共用**。按 `suppressRateKind` 分流实测（authoritative 3 个：claude-code / codex / genius；screen-scan 37 个）。既有的 `working`/`analyzing` 门控、`outputActive` 门控、结构化限流粘性重发均不变。`cli-usage-limit.ts` 未改动。

**已知局限（刻意）**：本修法对 `noteTurnCompleted` 不可达的 CLI 不生效（gemini 不在 `STRUCTURED_BRIDGE_ALWAYS_CLI_IDS`），那正是需要保持 master 语义的一批——是刻意的不修，不是漏修。

**后续**：codex `codex_error_info === 'usage_limit_exceeded'` 的权威 usage 分型值得单独补（能让 Dashboard / 退避拿到机器信号），但按上面实测它不能作为本修法的承重判据，拆独立 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)



