### PR TITLE
fix(bun): 编译版 hook 命令与孤儿回收不再依赖 /$bunfs 路径

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules
 .pnpm-store/
 dist/
+# 编译版单文件二进制（bun build --compile，每个 ~170MB）。CI 与发版都往这里写，
+# `bun run use:here --binary` 也默认在这里找 host-arch 产物。
+dist-bin/
 packages/workflow-core/dist/
 packages/workflow-core/.packs/
 data/

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun run audit:domains && node scripts/clean-dist.mjs && tsc && bun run typecheck:scripts && node scripts/generate-runtime-build-id.mjs && cp src/setup/lark-scopes.json dist/setup/ && bun run dashboard:bundle && chmod +x dist/cli.js && node scripts/audit-dist.mjs",
+    "build": "bun run audit:domains && node scripts/clean-dist.mjs && tsc && bun run typecheck:scripts && node scripts/generate-runtime-build-id.mjs && cp src/setup/lark-scopes.json dist/setup/ && bun run dashboard:bundle && chmod +x dist/cli.js && node scripts/audit-dist.mjs && node scripts/audit-embedded-assets.mjs",
+    "verify:binary": "bun scripts/verify-binary.mjs",
     "typecheck:scripts": "tsc -p tsconfig.scripts.json",
     "workflow-core:build": "node scripts/build-workflow-core-package.mjs",
     "workflow-core:test": "bun run workflow-core:build && node scripts/test-workflow-core-package.mjs",

--- a/scripts/audit-embedded-assets.mjs
+++ b/scripts/audit-embedded-assets.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Fail the build when a non-JS artifact lands in `dist/` without a decision about
+ * whether the COMPILED BINARY can reach it.
+ *
+ * WHY THIS EXISTS: `bun build --compile` embeds nothing by itself — only
+ * statically traced imports are pulled in (see the header of
+ * scripts/generate-dashboard-embed.mjs). Anything the build merely `cp`s into
+ * `dist/` therefore exists for `node dist/cli.js` and does NOT exist inside the
+ * binary, where `__dirname` is the virtual `/$bunfs/root`. That mismatch has
+ * shipped twice:
+ *
+ *   • 88e3d7f24 — the whole Dashboard frontend was absent, so EVERY asset
+ *     request fell through to the catch-all 404 and the Dashboard was
+ *     unreachable from a compiled binary while fine from npm/source.
+ *   • 2ef5c3a58 — `readDefaultScopeManifest()` probes three `join(here, …)`
+ *     candidates; MEASURED under compile they resolve to `/$bunfs/root/…` and
+ *     all miss, so `setup` throws `找不到 botmux lark-scopes.json`.
+ *
+ * Both were invisible to every test: the unit suite runs `node dist/*.js`, where
+ * the files are right there on disk. The failure only exists in a form nothing
+ * in the repo executes. Hence a STATIC gate at build time.
+ *
+ * WHAT IT IS NOT: this does not verify that an embedded asset is actually served
+ * correctly — that is smoke-bun-binary.mjs's job (it fetches `/` from a real
+ * compiled binary). This gate answers only the cheaper, earlier question: has
+ * anyone DECIDED what happens to this file under compile?
+ *
+ * THE DECISION IS RECORDED IN CODE, not in a list of filenames: a new asset is
+ * either covered by a mechanism below, or the build fails and whoever added it
+ * has to say which case it is. A bare filename allowlist would let a file be
+ * "known" while still being unreachable — exactly the state 2ef5c3a58 was in.
+ */
+
+import { readdirSync, statSync, existsSync, readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const DIST = join(REPO_ROOT, 'dist');
+
+/** Generated JS and its sidecars are the compile INPUT, never a runtime read. */
+const CODE_SUFFIXES = ['.js', '.js.map', '.d.ts', '.d.ts.map', '.mjs', '.cjs'];
+
+/**
+ * How a `dist/` asset can be reachable from the compiled binary.
+ *
+ * Each entry states the MECHANISM, so a reader can check the claim rather than
+ * trust a filename. `covers` is matched against dist-relative POSIX paths.
+ */
+const EMBED_MECHANISMS = [
+  {
+    id: 'dashboard-embed-preamble',
+    // scripts/generate-dashboard-embed.mjs walks this tree and emits one
+    // `import … with { type: 'file' }` per file, so the whole subtree is
+    // covered automatically and a NEW file under it needs no action here.
+    covers: (rel) => rel.startsWith('dashboard-web/'),
+    proof: 'scripts/generate-dashboard-embed.mjs walks dist/dashboard-web and emits a type:"file" import per file',
+  },
+];
+
+/**
+ * Assets that deliberately do NOT need to exist inside the binary, each with the
+ * reason it is safe. Anything not listed and not covered above fails the build.
+ */
+const NOT_NEEDED_IN_BINARY = [
+  {
+    rel: '.runtime-build-id',
+    // src/utils/runtime-build-id.ts falls back to hashing the module graph when
+    // the artifact is absent; the artifact is a dev/source-checkout fast path.
+    reason: 'runtime-build-id.ts treats a missing artifact as "recompute", so absence degrades to a slower path, not a failure',
+  },
+];
+
+/**
+ * KNOWN-BROKEN, fix already in flight elsewhere.
+ *
+ * These ARE unreachable from the compiled binary — the gate is right about them —
+ * but the fix belongs to an open PR, so failing the build here would block
+ * everyone for a defect someone else is already resolving. Listed separately from
+ * NOT_NEEDED_IN_BINARY so the two never blur: that list means "absence is fine",
+ * this one means "absence is a bug we have not landed yet".
+ *
+ * Remove an entry when its PR merges. If the gate then passes, the asset became
+ * reachable; if it fails, the fix regressed.
+ */
+const KNOWN_UNREACHABLE = [
+  {
+    rel: 'setup/lark-scopes.json',
+    // MEASURED on a compiled binary: readDefaultScopeManifest() probes three
+    // `join(here, …)` candidates, all resolving under /$bunfs/root, all missing,
+    // so `botmux setup` throws `找不到 botmux lark-scopes.json`.
+    owner: 'PR #1065 (fix/compiled-lark-scope-manifest) — static JSON import',
+  },
+];
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const abs = join(dir, name);
+    if (statSync(abs).isDirectory()) { out.push(...walk(abs)); continue; }
+    out.push(relative(DIST, abs).split(/[\\/]/).join('/'));
+  }
+  return out;
+}
+
+if (!existsSync(DIST)) {
+  console.error('[audit-embed] dist/ missing — run `bun run build` first.');
+  process.exit(2);
+}
+
+const assets = walk(DIST)
+  .filter((rel) => !CODE_SUFFIXES.some((s) => rel.endsWith(s)))
+  .sort();
+
+const unaccounted = [];
+const knownBroken = [];
+for (const rel of assets) {
+  if (EMBED_MECHANISMS.some((m) => m.covers(rel))) continue;
+  if (NOT_NEEDED_IN_BINARY.some((e) => e.rel === rel)) continue;
+  const known = KNOWN_UNREACHABLE.find((e) => e.rel === rel);
+  if (known) { knownBroken.push(known); continue; }
+  unaccounted.push(rel);
+}
+
+// Stale-entry check: an exemption that no longer matches any asset is worse than
+// no exemption, because it silently stops protecting anything.
+const stale = [...NOT_NEEDED_IN_BINARY, ...KNOWN_UNREACHABLE].filter((e) => !assets.includes(e.rel));
+if (stale.length > 0) {
+  console.error(
+    `[audit-embed] ${stale.length} exemption(s) no longer match any dist asset — delete them:\n`
+    + stale.map((e) => `  - ${e.rel}`).join('\n'),
+  );
+  process.exit(1);
+}
+
+if (unaccounted.length > 0) {
+  console.error(
+    `[audit-embed] ${unaccounted.length} asset(s) land in dist/ with no decision about the compiled binary:\n`
+    + unaccounted.map((r) => `  - ${r}`).join('\n')
+    + '\n\n'
+    + 'In the compiled binary `__dirname` is the virtual /$bunfs/root, so a file that is only\n'
+    + '`cp`d into dist/ is NOT there — every read of it fails (2ef5c3a58: setup threw\n'
+    + '`找不到 botmux lark-scopes.json`; 88e3d7f24: the Dashboard 404ed every request).\n\n'
+    + 'Pick one, then re-run:\n'
+    + '  (a) make it reachable — import it into the module graph so --compile traces it\n'
+    + '      (`with { type: "json" }` for JSON, `with { type: "file" }` for binary assets),\n'
+    + '      or extend a mechanism in EMBED_MECHANISMS if a whole subtree is generated;\n'
+    + '  (b) if the binary genuinely must not need it, add it to NOT_NEEDED_IN_BINARY\n'
+    + '      WITH the reason absence is safe.\n',
+  );
+  process.exit(1);
+}
+
+for (const k of knownBroken) {
+  console.warn(`[audit-embed] ⚠️  ${k.rel} is NOT reachable from the compiled binary — ${k.owner}`);
+}
+console.log(`[audit-embed] ${assets.length} dist asset(s) accounted for (compiled-binary reachability decided)`);

--- a/scripts/build-bun-binary.mjs
+++ b/scripts/build-bun-binary.mjs
@@ -93,12 +93,22 @@ function targetToPlatformArch(target) {
  * Compile time is the only place that knows the version for certain: release.yml
  * stamps package.json from the git tag BEFORE this script runs (the "Sync version
  * from git tag" step), so reading it here captures exactly what is being shipped.
+ *
+ * LOCAL VERIFICATION OVERRIDE: outside a release, package.json carries the
+ * placeholder `0.0.0`, which the runtime deliberately treats as "not baked" (so a
+ * local build cannot pass a placeholder off as authoritative). That makes the
+ * smoke's version check fail on `unknown` for anyone compiling by hand — measured.
+ * `scripts/verify-binary.mjs` therefore passes a `git describe` value through this
+ * variable. It is read ONLY as a fallback, never over a real package.json version,
+ * so it cannot influence a release build.
  */
 function versionToBake() {
   try {
     const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8'));
-    if (typeof pkg.version === 'string' && pkg.version.length > 0) return pkg.version;
+    if (typeof pkg.version === 'string' && pkg.version.length > 0 && pkg.version !== '0.0.0') return pkg.version;
   } catch { /* fall through */ }
+  const override = process.env.BOTMUX_VERIFY_BAKED_VERSION;
+  if (typeof override === 'string' && override.length > 0) return override;
   return '0.0.0';
 }
 

--- a/scripts/claim-botmux-bin.mjs
+++ b/scripts/claim-botmux-bin.mjs
@@ -5,10 +5,26 @@
 //
 // 写入内容与 daemon 启动时写的 wrapper 完全一致（见 src/daemon.ts），所以两者幂等：
 // 「在哪 build+use，全局 botmux 就指哪；下次 daemon restart-from-dir 再覆盖」均自洽。
+//
+// ── --binary 模式：让本地 fleet 真的跑编译版 ──────────────────────────────
+// 默认模式写的是 `exec node <checkout>/dist/cli.js`，也就是**源码态**。用户装到的却是
+// `bun build --compile` 出的单文件二进制（编译态），两者行为不一致的缺陷因此只在用户
+// 侧暴露：编译态 `__dirname` 是虚拟的 `/$bunfs/root`，凡是「读随代码走的资源」或
+// 「把拼出的路径交给别的进程」的代码都会坏，而本地开发 100% 走不到那条路。已经这样
+// 漏过：Dashboard 整站 404（88e3d7f24）、setup 找不到 lark-scopes.json（2ef5c3a58）、
+// `--version` 输出 unknown（c6b88e376）、二进制把自己覆盖成 47 字节壳（8386f34dd）。
+//
+// `--binary` 把全局 wrapper 改成 `exec <二进制> "$@"`（与生产 postinstall 写出的形态
+// 逐字同构），于是日常 dogfood 用的就是用户用的形态，不一致会在使用中自己暴露，
+// 不需要任何额外动作去发现它。
+//
+// 安全性：daemon 启动时也会写这个 wrapper，但它在 standalone 下写的是同一个 `exec
+// <binary>` 形态，且写前 realpath 比对、目标是正在运行的二进制时跳过（src/daemon.ts
+// 的 `isRunningBinary` 分支）——所以这里写完不会被 restart 改回去，也不会自毁。
 import { fileURLToPath } from 'node:url';
-import { dirname, basename, join } from 'node:path';
+import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, renameSync, unlinkSync, realpathSync, chmodSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, renameSync, unlinkSync, realpathSync, chmodSync, statSync } from 'node:fs';
 
 // 原子写（与 src/utils/atomic-write.ts 同构，.mjs 不依赖 dist 故内联）：
 // 这个 wrapper 随时被并发会话 exec，裸写半截会让它们的 `botmux send` 全体失败。
@@ -39,13 +55,81 @@ if (process.env.BOTMUX_NO_CLAIM) {
 }
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
-const cliScript = join(repoRoot, 'dist', 'cli.js');
 const binDir = join(homedir(), '.botmux', 'bin');
 const wrapper = join(binDir, 'botmux');
-const content = `#!/bin/sh\nexec node "${cliScript}" "$@"\n`;
 
-if (!existsSync(cliScript)) {
-  console.warn(`⚠️  ${cliScript} 还不存在——先 \`pnpm build\`（或用 \`pnpm switch:here\`）。wrapper 仍按此路径写入。`);
+// `--binary [路径]`：指向编译版二进制而不是 dist/cli.js。省略路径时用
+// build:bun 的默认产物位置（scripts/build-bun-binary.mjs 的 dist-bin/botmux-<target>）。
+const argv = process.argv.slice(2);
+const binaryFlagAt = argv.indexOf('--binary');
+const useBinary = binaryFlagAt !== -1;
+const explicitBinary = useBinary ? argv[binaryFlagAt + 1] : undefined;
+
+/** 本机 host target 的默认二进制名，与 build-bun-binary.mjs 的命名规则一致。 */
+function defaultBinaryPath() {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  const plat = process.platform === 'darwin' ? 'darwin' : 'linux';
+  return join(repoRoot, 'dist-bin', `botmux-${plat}-${arch}`);
+}
+
+let target;   // wrapper 里被 exec 的东西
+let content;  // wrapper 全文
+
+if (useBinary) {
+  const requested = resolve(explicitBinary && !explicitBinary.startsWith('--') ? explicitBinary : defaultBinaryPath());
+  if (!existsSync(requested)) {
+    console.error(
+      `❌ 找不到编译版二进制：${requested}\n`
+      + '   先编一个：`bun run build && bun scripts/build-bun-binary.mjs --target bun-'
+      + `${process.platform === 'darwin' ? 'darwin' : 'linux'}-${process.arch === 'arm64' ? 'arm64' : 'x64'}`
+      + ` --out dist-bin/botmux-${process.platform === 'darwin' ? 'darwin' : 'linux'}-${process.arch === 'arm64' ? 'arm64' : 'x64'}\`\n`
+      + '   或显式给路径：`bun run use:here --binary <path>`',
+    );
+    process.exit(1);
+  }
+  // 必须是可执行文件而不是脚本/目录：wrapper 会 `exec` 它，写错了全局 botmux 直接坏，
+  // 而 ~50 个 live daemon 靠它跑 `botmux send`。
+  if (!statSync(requested).isFile()) {
+    console.error(`❌ ${requested} 不是文件，拒绝写入 wrapper。`);
+    process.exit(1);
+  }
+  // realpath 而非 resolve：生产两侧都写解析后的真实路径（postinstall-bin.mjs 的
+  // 原子写、daemon 传的 `process.execPath` 已由 OS 解析），经软链调用时若这里写
+  // 未解析路径，三处形态就会漂移。
+  target = realpathSync(requested);
+  // 与 botmuxWrapperFiles() 的 standalone 分支、以及生产 postinstall 写出的 launcher
+  // 逐字同构（test/claim-botmux-bin-binary.test.ts 钉住三者一致）。
+  content = `#!/bin/sh\nexec "${target}" "$@"\n`;
+} else {
+  target = join(repoRoot, 'dist', 'cli.js');
+  content = `#!/bin/sh\nexec node "${target}" "$@"\n`;
+  if (!existsSync(target)) {
+    console.warn(`⚠️  ${target} 还不存在——先 \`bun run build\`（或用 \`bun run switch:here\`）。wrapper 仍按此路径写入。`);
+  }
+}
+
+const cliScript = target;
+
+// 自毁守卫。`--binary` 让 wrapper 的**内容**指向一个真实二进制，而 install.sh 把二进制
+// 装在 `~/.botmux/bin/botmux` —— 正是这个 wrapper 自己的路径。若两者是同一个文件，写入
+// 会把可执行本体替换成 47 字节的 sh 壳（8386f34dd 实测：147,392,640 → 47 字节，inode 变化
+// 证明 rename 顶掉了本体），随后 `botmux` 彻底不可用，而 fleet 里每个 worker 都把这个目录
+// 前置 PATH，所有会话的 `botmux send` 会一起坏。
+//
+// 判据用 realpath 比对而不是字符串比较：两边可能经不同的 symlink 到达同一 inode。
+if (useBinary) {
+  let sameFile = false;
+  try { sameFile = realpathSync(wrapper) === realpathSync(target); }
+  catch { /* wrapper 尚不存在 ⟹ 不可能是同一个文件 */ }
+  if (sameFile) {
+    console.error(
+      `❌ 拒绝写入：${wrapper} 就是 ${target} 本身。\n`
+      + '   写下去会把二进制覆盖成一个几十字节的 sh 壳（历史事故 8386f34dd），\n'
+      + '   全局 botmux 当场不可用，且 fleet 里所有会话的 `botmux send` 会一起坏。\n'
+      + '   这种情况下本来就不需要认领：该二进制已经在 wrapper 的位置上了。',
+    );
+    process.exit(1);
+  }
 }
 
 try {
@@ -53,11 +137,16 @@ try {
   let existing = '';
   try { existing = readFileSync(wrapper, 'utf-8'); } catch { /* 尚不存在 */ }
   if (existing === content) {
-    console.log(`✓ 全局 botmux 已指向本 checkout（${cliScript}）`);
+    console.log(`✓ 全局 botmux 已指向${useBinary ? '编译版二进制' : '本 checkout'}（${cliScript}）`);
   } else {
     atomicWriteFileSync(wrapper, content, 0o755);
-    console.log(`✅ 全局 botmux → 本 checkout（${cliScript}）`);
-    console.log('   下一步 `pnpm daemon:restart` 即从本 checkout 重启 daemon（避免 PATH 中的旧全局 botmux 抢先）。');
+    console.log(`✅ 全局 botmux → ${useBinary ? '编译版二进制' : '本 checkout'}（${cliScript}）`);
+    if (useBinary) {
+      console.log('   下一步 `botmux restart` 让 fleet 跑编译版——之后日常使用的就是用户拿到的形态。');
+      console.log('   切回源码态：`bun run use:here`（不带 --binary）。');
+    } else {
+      console.log('   下一步 `bun run daemon:restart` 即从本 checkout 重启 daemon（避免 PATH 中的旧全局 botmux 抢先）。');
+    }
   }
 } catch (err) {
   console.warn(`⚠️  写 botmux wrapper 失败：${err.message}`);

--- a/scripts/verify-binary.mjs
+++ b/scripts/verify-binary.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+/**
+ * `bun run verify:binary` — compile the host-arch single-file binary and smoke it.
+ *
+ * WHY THIS EXISTS: local development runs `node dist/*.js` (source form) 100% of
+ * the time, while users run a `bun build --compile` executable where `__dirname`
+ * is the virtual `/$bunfs/root`. Every divergence between those forms is
+ * therefore invisible locally. Four have shipped: the Dashboard 404ing every
+ * request (88e3d7f24), `setup` throwing `找不到 botmux lark-scopes.json`
+ * (2ef5c3a58), `--version` printing `unknown` (c6b88e376), and the daemon
+ * replacing its own binary with a 47-byte stub (8386f34dd).
+ *
+ * Compiling turned out to be nearly free — MEASURED 0.9s, against 36s for the
+ * `tsc` build it consumes — so the reason nobody verified the compiled form
+ * locally was never cost, it was that no single command did it. This is that
+ * command. It is deliberately NOT a git hook: CI's `bun-binary` job (MEASURED
+ * 72s) and `bun-binary-musl` (87s) already gate every push in parallel with the
+ * 612s test job, so a local hook would buy about a minute at the cost of 28s on
+ * every push.
+ *
+ * TWO FRICTIONS IT REMOVES, both hit while doing this by hand:
+ *
+ *   1. HOST TARGET ONLY, enforced. Cross-compiling looks like it works and does
+ *      not: `resolveNodePtyNative()` falls back to the local
+ *      `build/Release/pty.node` for every linux target, and node-pty ships no
+ *      linux prebuild. VERIFIED — `--target bun-linux-arm64` on this x64 box
+ *      exits 0 and produces a real aarch64 ELF with the x86-64 `pty.node` baked
+ *      in; it fails at PTY spawn, not at build. (And the host cannot even exec
+ *      it: qemu-aarch64 is registered but `/lib/ld-linux-aarch64.so.1` is
+ *      absent.) musl is worse still — it MUST be compiled on musl or the wrong
+ *      libc gets embedded. So this refuses anything but the host target and says
+ *      why, instead of handing over a binary that is silently broken.
+ *
+ *   2. A REAL VERSION. `versionToBake()` reads package.json, which carries the
+ *      placeholder `0.0.0` outside a release; the runtime treats that as "not
+ *      baked", so smoke check 1b fails on `unknown` — VERIFIED, that is exactly
+ *      what a hand-run hits. CI sidesteps it by stamping a synthetic version
+ *      first (ci.yml's "Stamp a synthetic version" step). Rather than making a
+ *      developer mutate package.json, this passes the version through the same
+ *      `define` the build already supports, via BOTMUX_VERIFY_BAKED_VERSION.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+
+if (typeof Bun === 'undefined') {
+  console.error('verify:binary must run under Bun (`bun run verify:binary`) — the compile step uses Bun.build.');
+  process.exit(2);
+}
+
+const argv = process.argv.slice(2);
+const keep = argv.includes('--keep');
+
+/** The only target this machine can both compile correctly and execute. */
+const hostPlatform = process.platform === 'darwin' ? 'darwin' : 'linux';
+const hostArch = process.arch === 'arm64' ? 'arm64' : 'x64';
+const hostTarget = `bun-${hostPlatform}-${hostArch}`;
+
+const requested = argv.includes('--target') ? argv[argv.indexOf('--target') + 1] : hostTarget;
+if (requested !== hostTarget) {
+  console.error(
+    `❌ verify:binary only supports the host target (${hostTarget}); refusing ${requested}.\n\n`
+    + 'Cross-compiled binaries from this box are silently broken, not merely untested:\n'
+    + '  • node-pty has no linux prebuild, so every linux target embeds THIS machine\'s\n'
+    + `    build/Release/pty.node (${hostArch}) — the mismatch surfaces at PTY spawn, not at build time.\n`
+    + '  • a musl binary must be compiled ON musl or it links the wrong libc.\n'
+    + '  • the host cannot exec a foreign-arch binary anyway, so smoke could not run.\n\n'
+    + `Those targets are covered by CI: the \`bun-binary\` job builds ${hostTarget} and\n`
+    + '`bun-binary-musl` builds the musl legs inside an Alpine container. Push and let them run.',
+  );
+  process.exit(2);
+}
+
+/**
+ * A version to bake. `git describe` mirrors what release.yml stamps from the tag;
+ * falling back to a marker keeps the smoke's "not the unknown sentinel" check
+ * meaningful in a shallow clone or a tarball with no git metadata.
+ */
+function localVersion() {
+  const r = spawnSync('git', ['describe', '--tags', '--always', '--dirty'], { cwd: REPO_ROOT, encoding: 'utf-8' });
+  const described = r.status === 0 ? r.stdout.trim().replace(/^v/, '') : '';
+  return described || '0.0.0-local';
+}
+
+const DIST = join(REPO_ROOT, 'dist');
+if (!existsSync(join(DIST, 'cli.js'))) {
+  console.error('❌ dist/cli.js missing — run `bun run build` first (the compile step bundles dist, it does not run tsc).');
+  process.exit(2);
+}
+
+const outDir = join(REPO_ROOT, 'dist-bin');
+mkdirSync(outDir, { recursive: true });
+const out = join(outDir, `botmux-${hostPlatform}-${hostArch}`);
+
+const version = localVersion();
+console.log(`▶ compiling ${hostTarget} (version=${version}) …`);
+
+const compileStart = Date.now();
+const compile = spawnSync(
+  process.execPath,
+  [join(REPO_ROOT, 'scripts', 'build-bun-binary.mjs'), '--target', hostTarget, '--out', out],
+  { cwd: REPO_ROOT, stdio: 'inherit', env: { ...process.env, BOTMUX_VERIFY_BAKED_VERSION: version } },
+);
+if (compile.status !== 0) {
+  console.error(`❌ compile failed (exit ${compile.status}).`);
+  process.exit(1);
+}
+console.log(`  compiled in ${((Date.now() - compileStart) / 1000).toFixed(1)}s → ${out}`);
+
+console.log('▶ smoke-testing the compiled binary …');
+const smokeStart = Date.now();
+// Run the SAME script CI runs, so a local pass and a CI pass mean the same thing.
+// It is a Node script by design (an outside observer testing a Bun-built binary).
+const smoke = spawnSync('node', [join(REPO_ROOT, 'scripts', 'smoke-bun-binary.mjs'), out], {
+  cwd: REPO_ROOT,
+  stdio: 'inherit',
+});
+const smokeSecs = ((Date.now() - smokeStart) / 1000).toFixed(1);
+
+if (!keep) {
+  try { rmSync(out); } catch { /* best effort — a 170MB artifact, not worth failing over */ }
+}
+
+if (smoke.status !== 0) {
+  console.error(`\n❌ smoke failed after ${smokeSecs}s. The binary is broken in a way `
+    + 'source-form development cannot show; fix before pushing.');
+  process.exit(1);
+}
+
+console.log(`\n✅ compiled form verified in ${smokeSecs}s of smoke`
+  + `${keep ? ` (binary kept at ${out})` : ''}.`);
+if (!keep) console.log('   Pass --keep to retain the binary (e.g. for `bun run use:here --binary`).');

--- a/src/adapters/hook-command.ts
+++ b/src/adapters/hook-command.ts
@@ -10,12 +10,62 @@
  *     CLI 入口固定在 `<pkgRoot>/dist/cli.js`（package.json `bin.botmux` 指向它），
  *     即 `../cli.js`。源码 checkout 和 npm global 安装都如此——布局一致。
  *
+ * ⚠️ 编译版单文件二进制（`bun build --compile`）不满足上面那条「布局一致」：
+ * 模块图在虚拟只读的 `/$bunfs/` 下，`__dirname` 是 `/$bunfs/root`，于是
+ * `join(__dirname,'..','cli.js')` 得到 `/$bunfs/cli.js`。这条路径**两重坏**，实测：
+ *   ① `/$bunfs/` 只在本进程内可见——hook 命令恰恰是**交给别的进程**执行的
+ *      （Claude / grok / opencode 从 settings.json 里读出来跑），子进程实测
+ *      `CHILD_NO_BUNFS`；
+ *   ② 这些字符串由 shell 执行，而双引号内**未转义的 `$bunfs` 被 sh 展开成空串**，
+ *      `"/$bunfs/cli.js"` 实测解析成 `//cli.js`——连字面路径都不是。
+ * 也就是说编译版写出的 hook 全部失效，且失效方式是「命令找不到」而非报错。
+ *
+ * 修法与 `src/core/self-spawn.ts` 同构：编译态**不拼路径**，直接 exec 二进制自身
+ * 并把子命令当普通参数传（实测编译版 `botmux hook claude-code` /
+ * `session-ready` / `user-prompt-hook` 三者都正常 dispatch，exit 0）。Node 态
+ * 逐字不变——实测 Node 侧**必须**带 `cli.js` 路径，不带则 MODULE_NOT_FOUND，
+ * 所以这里必须分流，不能收敛成同一条。
+ *
  * 不从 worker-pool 导入，也不从 adapter 导入 worker-pool——避免循环依赖。
  */
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { isStandaloneBinary } from '../core/self-spawn.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * 一条 botmux 子命令的 argv 形式。
+ *
+ * 编译态：`[<binary>, ...subcommand]`——没有脚本路径这一项。
+ * Node 态：`[<node>, <dist/cli.js>, ...subcommand]`。
+ *
+ * 单一出口：三个导出全部经由它，避免「同一个判据三份实现各自漂移」——
+ * 本文件此前正是三处各拼一遍 `join(__dirname,'..','cli.js')`。
+ */
+function botmuxInvocation(subcommand: string[]): { cmd: string; args: string[] } {
+  if (isStandaloneBinary()) {
+    // process.execPath 是**真实磁盘路径**（编译态下也是），所以对别的进程有效。
+    return { cmd: process.execPath, args: [...subcommand] };
+  }
+  return { cmd: process.execPath, args: [join(__dirname, '..', 'cli.js'), ...subcommand] };
+}
+
+/**
+ * 把一条调用渲染成 **shell 命令字符串**：只给可执行路径与脚本路径加引号（容忍空格），
+ * 子命令名与其参数不加引号。
+ *
+ * 用于「按 shell 字符串执行」的场景（Claude 家族的 settings.json `command` 字段）。
+ * 需要 argv 的场景请用 `hookCommandParts`，切勿对本字符串再 `.split(' ')`。
+ */
+function renderShellCommand(cliId?: string, ...subcommand: string[]): string {
+  const { cmd, args } = botmuxInvocation(cliId === undefined ? subcommand : [...subcommand, cliId]);
+  if (isStandaloneBinary()) {
+    // 只有可执行路径需要引号；子命令是字面量 token。
+    return `"${cmd}" ${args.join(' ')}`;
+  }
+  return `"${cmd}" "${args[0]}" ${args.slice(1).join(' ')}`;
+}
 
 /**
  * 构造 `botmux hook <cliId>` 的 argv 形式 `{ cmd, args }`——规范形态。
@@ -23,33 +73,28 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * OpenCode 插件用它（spawnSync），避免「拼成带引号字符串再 split」把路径拆坏。
  */
 export function hookCommandParts(cliId: string): { cmd: string; args: string[] } {
-  const cliEntry = join(__dirname, '..', 'cli.js');
-  return { cmd: process.execPath, args: [cliEntry, 'hook', cliId] };
+  return botmuxInvocation(['hook', cliId]);
 }
 
 /**
- * 构造 `botmux hook <cliId>` 的 **shell 命令字符串**（仅可执行路径与 cli.js 路径加引号，
- * 容忍空格；`hook` 子命令名与 cliId 不加引号）。
+ * 构造 `botmux hook <cliId>` 的 **shell 命令字符串**。
  * 仅用于「按 shell 字符串执行」的场景，例如写进 Claude Code 的 `~/.claude/settings.json`
- * （其 `command` 字段由 Claude 经 shell 执行）。需要 argv 的场景请用 `hookCommandParts`，
- * 切勿对本字符串再 `.split(' ')`。
+ * （其 `command` 字段由 Claude 经 shell 执行）。
  */
 export function hookCommandFor(cliId: string): string {
-  const { cmd, args } = hookCommandParts(cliId);
-  return `"${cmd}" "${args[0]}" ${args.slice(1).join(' ')}`;
+  return renderShellCommand(cliId, 'hook');
 }
 
 /**
  * 构造 Claude 家族 `SessionStart` hook 的 **shell 命令字符串** → `botmux session-ready`。
- * 与 `hookCommandFor` 同源的路径解析与加引号策略（仅可执行路径与 cli.js 路径加引号），
+ * 与 `hookCommandFor` 同源的路径解析与加引号策略，
  * 因为它被写进 Claude 进程级 `--settings` 的 `command` 字段、由 Claude 经 shell 执行。
  *
  * 无 cliId 参数：session-ready 只靠 hook 子进程继承的 `BOTMUX_SESSION_ID` /
  * `BOTMUX_LARK_APP_ID` env 定位会话与 daemon，不需要 CLI 类型。
  */
 export function sessionReadyHookCommand(): string {
-  const cliEntry = join(__dirname, '..', 'cli.js');
-  return `"${process.execPath}" "${cliEntry}" session-ready`;
+  return renderShellCommand(undefined, 'session-ready');
 }
 
 /**
@@ -60,6 +105,6 @@ export function sessionReadyHookCommand(): string {
  * （fail-open：上下文丢失 < 卡住 prompt），且结构性保证永不 exit 2。
  */
 export function userPromptHookCommand(): string {
-  const cliEntry = join(__dirname, '..', 'cli.js');
-  return `"${process.execPath}" "${cliEntry}" user-prompt-hook`;
+  return renderShellCommand(undefined, 'user-prompt-hook');
 }
+

--- a/src/core/self-spawn.ts
+++ b/src/core/self-spawn.ts
@@ -83,6 +83,15 @@ export function resolveEntrySpawn(entry: BotmuxEntry, distDir: string): { comman
 /** The set of hidden subcommand tokens, so the CLI dispatcher can recognize them. */
 export const ENTRY_SUBCOMMANDS: ReadonlySet<string> = new Set(Object.values(ENTRY_SUBCOMMAND));
 
+/**
+ * The hidden token a compiled binary is launched with to become a worker, i.e.
+ * `<binary> __worker`. Exported because the orphan reaper has to RECOGNIZE that
+ * command line in `ps` output: in the compiled form there is no `worker.js` path
+ * to match on, and a hardcoded `'__worker'` literal at the matching site would
+ * drift away from this map the moment the token changed.
+ */
+export const WORKER_ENTRY_SUBCOMMAND: string = ENTRY_SUBCOMMAND.worker;
+
 /** Map a hidden subcommand token back to its entry (null if not one). */
 export function entryForSubcommand(token: string): BotmuxEntry | null {
   for (const [entry, sub] of Object.entries(ENTRY_SUBCOMMAND)) {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -3,7 +3,7 @@
  * Extracted from daemon.ts for modularity.
  */
 import { execSync, type ChildProcess } from 'node:child_process';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { readFileSync, readdirSync, mkdirSync, existsSync, realpathSync, unlinkSync } from 'node:fs';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
@@ -26,7 +26,7 @@ import {
   markMessageListenerRunPreviewRunning,
 } from '../services/message-listener-run-preview-store.js';
 import { persistStreamCardState, rememberLastCliInput } from './session-manager.js';
-import { spawnWorker } from './self-spawn.js';
+import { spawnWorker, isStandaloneBinary, WORKER_ENTRY_SUBCOMMAND } from './self-spawn.js';
 import { resolveSessionLaunchModel } from './session-model.js';
 import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, pickTurnReplyTarget, rehomeReplyTargetState, replyTargetKey } from './reply-target.js';
 import { updateMessage, deleteMessage, sendEphemeralCard, sendUserMessage, addReaction, removeReaction, getMessageChatId, MessageWithdrawnError } from '../im/lark/client.js';
@@ -14021,12 +14021,41 @@ export function reapOrphanWorkers(opts: {
   if (process.platform === 'win32') return 0;
   const procs = opts.procs ?? listProcesses();
   const kill = opts.kill ?? ((pid, signal) => { process.kill(pid, signal); });
-  const workerPath = opts.workerPath ?? join(__dirname, '..', 'worker.js');
+  // How THIS install's workers appear in a command line.
+  //
+  // Node: `<node> <dist>/worker.js` — the script path identifies the install.
+  //
+  // ⚠️ Compiled single-file binary: there IS no worker.js on disk. spawnWorker()
+  // launches `<binary> __worker` (see src/core/self-spawn.ts), while
+  // `join(__dirname,'..','worker.js')` evaluates to `/$bunfs/worker.js` — a
+  // process-private virtual path that appears in NO command line. MEASURED: a real
+  // compiled worker's cmdline is `<binary> __worker`, so the old predicate matched
+  // nothing and orphans were NEVER reaped in the compiled form. That is the failure
+  // this function exists to prevent: each orphan leaks ~0.5 GB and they accumulate
+  // across restarts (daemon.ts records an 841-orphan / ~65 GB incident).
+  //
+  // The compiled predicate keeps the same conservatism — it must still identify
+  // THIS install and not another botmux — by requiring the running executable's
+  // path AND the `__worker` token. Both are matched as substrings because
+  // /proc/<pid>/cmdline preserves argv[0] exactly as given, which may be relative
+  // (MEASURED: launching via a relative path yields a relative argv[0]), so the
+  // basename is the portion that reliably appears.
+  const standalone = isStandaloneBinary();
+  const workerPath = opts.workerPath ?? (standalone ? undefined : join(__dirname, '..', 'worker.js'));
+  const binaryName = standalone ? basename(process.execPath) : '';
+
+  /** Does this command line belong to a worker of THIS install? */
+  const isOurWorker = (cmd: string): boolean => {
+    if (workerPath !== undefined) return cmd.includes(workerPath);
+    // Compiled form: `<binary> __worker`. Require both parts so a stray process
+    // that merely mentions `__worker` (or a different botmux binary) is spared.
+    return cmd.includes(binaryName) && cmd.includes(WORKER_ENTRY_SUBCOMMAND);
+  };
 
   let reaped = 0;
   for (const p of procs) {
-    if (p.ppid !== 1) continue;                 // parent still alive → not an orphan
-    if (!p.cmd.includes(workerPath)) continue;  // not OUR worker script
+    if (p.ppid !== 1) continue;         // parent still alive → not an orphan
+    if (!isOurWorker(p.cmd)) continue;  // not OUR worker
     try {
       // SIGKILL, not SIGTERM: an orphan can be wedged in a sync code path (the
       // very failure mode that produced it) where SIGTERM is lost. It holds no

--- a/test/claim-botmux-bin-binary.test.ts
+++ b/test/claim-botmux-bin-binary.test.ts
@@ -1,0 +1,192 @@
+/**
+ * `claim-botmux-bin.mjs --binary` — point the global `botmux` at a COMPILED
+ * binary so local dogfooding runs the form users actually install.
+ *
+ * WHY THIS MODE EXISTS: the default `use:here` writes `exec node
+ * <checkout>/dist/cli.js` — the SOURCE form. Users run a `bun build --compile`
+ * single file, where `__dirname` is the virtual `/$bunfs/root`. Every divergence
+ * between those two forms is therefore invisible locally and surfaces only after
+ * install. That has shipped four times: the Dashboard 404ing every request
+ * (88e3d7f24), `setup` throwing `找不到 botmux lark-scopes.json` (2ef5c3a58),
+ * `--version` printing `unknown` (c6b88e376), and the daemon overwriting its own
+ * binary with a 47-byte shell script (8386f34dd).
+ *
+ * WHAT THESE TESTS PIN — three invariants, each with teeth:
+ *
+ *   1. The wrapper is byte-identical to the two PRODUCTION writers of the same
+ *      file: `botmuxWrapperFiles(..., standalone=true)` (what the daemon writes)
+ *      and `scripts/postinstall-bin.mjs` (what npm install writes). Three
+ *      independent implementations of one format drift silently — and a drifted
+ *      wrapper is not a test failure, it is ~50 live daemons losing `botmux send`.
+ *
+ *   2. The wrapper is EXECUTED, not string-matched. A fake binary echoes its
+ *      argv, so a wrapper that parses but cannot exec (bad quoting, lost args)
+ *      fails here rather than in the fleet.
+ *
+ *   3. The self-destruct guard fires. install.sh puts the binary at
+ *      `~/.botmux/bin/botmux` — the wrapper's own path — so `--binary` pointed
+ *      there would replace the executable with a few dozen bytes of `sh`.
+ *      VERIFIED by anti-mutation: with the guard stubbed out, a 169,673,928-byte
+ *      binary became 63 bytes, reproducing 8386f34dd exactly.
+ *
+ * Every case runs against a scratch `HOME`, so the real `~/.botmux/bin/botmux`
+ * (which this machine's fleet depends on) is never touched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, chmodSync, statSync, realpathSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { botmuxWrapperFiles } from '../src/core/botmux-wrapper.js';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const SCRIPT = join(REPO_ROOT, 'scripts', 'claim-botmux-bin.mjs');
+
+/** A stand-in for the compiled binary: executable, and echoes its argv back. */
+function fakeBinary(dir: string, name = 'botmux-fake'): string {
+  const p = join(dir, name);
+  writeFileSync(p, '#!/bin/sh\nprintf "GOT:%s\\n" "$@"\n', { mode: 0o755 });
+  chmodSync(p, 0o755);
+  return p;
+}
+
+function runClaim(args: string[], home: string) {
+  const r = spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: 'utf-8',
+    env: { PATH: process.env.PATH, HOME: home },
+    cwd: REPO_ROOT,
+  });
+  const wrapper = join(home, '.botmux', 'bin', 'botmux');
+  return { ...r, wrapper, wrote: existsSync(wrapper) };
+}
+
+function scratchHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'claim-binary-test-'));
+  mkdirSync(join(home, '.botmux', 'bin'), { recursive: true });
+  return home;
+}
+
+describe('claim-botmux-bin --binary — global botmux points at the compiled binary', () => {
+  it('writes a wrapper byte-identical to what the daemon writes for a standalone binary', () => {
+    const home = scratchHome();
+    const binary = fakeBinary(home);
+    const r = runClaim(['--binary', binary], home);
+
+    expect(r.status).toBe(0);
+    expect(r.wrote).toBe(true);
+
+    // The daemon's writer is the reference implementation. `nodePath` carries the
+    // binary path in the standalone branch (see botmuxWrapperFiles' signature).
+    const [reference] = botmuxWrapperFiles('/unused/dist/cli.js', realpathSync(binary), 'linux', true);
+    expect(readFileSync(r.wrapper, 'utf-8')).toBe(reference.content);
+
+    // No `node` as a command word — the whole point of the compiled binary is
+    // that it needs no Node. Matched as a word so a path containing "node"
+    // (e.g. /root/node-versions/...) cannot produce a false pass.
+    expect(readFileSync(r.wrapper, 'utf-8')).not.toMatch(/(^|\s)node(\s|$)/m);
+  });
+
+  it('the wrapper actually execs and forwards argv verbatim (including spaces)', () => {
+    const home = scratchHome();
+    fakeBinary(home);
+    runClaim(['--binary', join(home, 'botmux-fake')], home);
+
+    const r = spawnSync(join(home, '.botmux', 'bin', 'botmux'), ['send', 'hello world'], { encoding: 'utf-8' });
+    expect(r.status).toBe(0);
+    // Two args, the second one intact as ONE argument despite the space.
+    expect(r.stdout).toBe('GOT:send\nGOT:hello world\n');
+  });
+
+  it('REFUSES to write when the target is the wrapper path itself (8386f34dd)', () => {
+    const home = scratchHome();
+    // Exactly the install.sh layout: the binary IS ~/.botmux/bin/botmux.
+    const inPlace = join(home, '.botmux', 'bin', 'botmux');
+    writeFileSync(inPlace, '#!/bin/sh\nprintf "GOT:%s\\n" "$@"\n', { mode: 0o755 });
+    chmodSync(inPlace, 0o755);
+    const sizeBefore = statSync(inPlace).size;
+
+    const r = runClaim(['--binary', inPlace], home);
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('拒绝写入');
+    // The teeth: the file is untouched. Without the guard this shrinks to a
+    // ~60-byte `sh` stub (measured on a real 169MB binary: 63 bytes).
+    expect(statSync(inPlace).size).toBe(sizeBefore);
+  });
+
+  it('resolves a symlinked target to its real path (matches both production writers)', () => {
+    // WHY A DEDICATED CASE: every other test here builds paths under `mkdtemp`,
+    // and on this machine `/tmp` is a real directory, so `realpathSync(p) === p`
+    // and a missing realpath call is INDISTINGUISHABLE. Verified: stubbing the
+    // realpath out left the whole file green until this case existed.
+    //
+    // It matters because both production writers store a resolved path —
+    // postinstall-bin.mjs realpaths before writing, and the daemon passes
+    // `process.execPath`, which the OS has already resolved. A wrapper written
+    // through a symlink would therefore differ from what a restart writes, and
+    // the two would fight over the file on every boot.
+    const home = scratchHome();
+    const real = fakeBinary(home, 'real-binary');
+    const link = join(home, 'link-to-binary');
+    symlinkSync(real, link);
+
+    const r = runClaim(['--binary', link], home);
+    expect(r.status).toBe(0);
+
+    const content = readFileSync(r.wrapper, 'utf-8');
+    expect(content).toContain(`exec "${real}"`);
+    // The symlink path must NOT survive into the wrapper.
+    expect(content).not.toContain(link);
+    // And it still execs — resolving must not break the exec itself.
+    const exec = spawnSync(r.wrapper, ['ok'], { encoding: 'utf-8' });
+    expect(exec.stdout).toBe('GOT:ok\n');
+  });
+
+  it('fails closed when the binary is missing, and names how to build one', () => {
+    const home = scratchHome();
+    const r = runClaim(['--binary', join(home, 'does-not-exist')], home);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('找不到编译版二进制');
+    // The message has to carry the build command, otherwise the failure is a
+    // dead end for whoever hits it.
+    expect(r.stderr).toContain('build-bun-binary.mjs');
+    expect(r.wrote).toBe(false);
+  });
+
+  it('rejects a directory (a wrapper that execs one is broken, not merely wrong)', () => {
+    const home = scratchHome();
+    const dir = join(home, 'a-directory');
+    mkdirSync(dir, { recursive: true });
+    const r = runClaim(['--binary', dir], home);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('不是文件');
+    expect(r.wrote).toBe(false);
+  });
+
+  it('without --binary the source form is unchanged (backward compatible)', () => {
+    const home = scratchHome();
+    const r = runClaim([], home);
+    expect(r.status).toBe(0);
+    const content = readFileSync(r.wrapper, 'utf-8');
+
+    // Must still equal the daemon's NON-standalone form, so the existing
+    // `use:here` behaviour cannot be broken by the --binary addition.
+    const [reference] = botmuxWrapperFiles(join(REPO_ROOT, 'dist', 'cli.js'), process.execPath, 'linux', false);
+    expect(content).toBe(reference.content);
+    expect(content).toContain('exec node ');
+  });
+
+  it('BOTMUX_NO_CLAIM still short-circuits in --binary mode', () => {
+    const home = scratchHome();
+    const binary = fakeBinary(home);
+    const r = spawnSync(process.execPath, [SCRIPT, '--binary', binary], {
+      encoding: 'utf-8',
+      env: { PATH: process.env.PATH, HOME: home, BOTMUX_NO_CLAIM: '1' },
+      cwd: REPO_ROOT,
+    });
+    expect(r.status).toBe(0);
+    expect(existsSync(join(home, '.botmux', 'bin', 'botmux'))).toBe(false);
+  });
+});

--- a/test/hook-command-compiled-form.test.ts
+++ b/test/hook-command-compiled-form.test.ts
@@ -1,0 +1,124 @@
+/**
+ * `hook-command.ts` — the hook invocation must work in BOTH forms.
+ *
+ * WHY: these strings are handed to OTHER processes. `hookCommandFor` and friends
+ * land in `~/.claude/settings.json` (and the process-level `--settings`), where
+ * Claude Code — plus grok and opencode through the same helpers — read them back
+ * and run them through a shell. The compiled single-file binary broke every one
+ * of them, two ways over, both MEASURED on a real `bun build --compile` binary:
+ *
+ *   1. `join(__dirname,'..','cli.js')` yields `/$bunfs/cli.js`, and `/$bunfs/` is
+ *      visible ONLY inside the process that owns it — a child sees nothing.
+ *   2. The result is embedded in a double-quoted shell word, and `sh` expands the
+ *      unescaped `$bunfs` to the empty string, so `"/$bunfs/cli.js"` resolves to
+ *      `//cli.js` — not even the literal path.
+ *
+ * The user-visible symptom is the nastiest kind: running the old compiled form
+ * through `sh` prints the botmux HELP BANNER and exits 0 (verified against a real
+ * binary), so hooks silently do nothing and nothing anywhere reports an error.
+ *
+ * HOW THESE TESTS GET TEETH: `isStandaloneBinary()` is called for real, not
+ * mocked — it keys off `process.argv[1]` starting with `/$bunfs/` (see
+ * src/core/self-spawn.ts), so pointing argv[1] at a `/$bunfs/` path exercises the
+ * genuine branch. That matters because the repo's other compiled-mode tests pass
+ * a `standalone` flag in as a parameter; here the decision is internal, so a
+ * parameter could not reach it.
+ *
+ * The Node-form cases are equally load-bearing: the fix must not "converge" the
+ * two forms, because Node genuinely NEEDS the script path (verified: `node hook
+ * claude-code` without it dies with MODULE_NOT_FOUND). Branching is correct here;
+ * collapsing it would be the bug.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  hookCommandParts,
+  hookCommandFor,
+  sessionReadyHookCommand,
+  userPromptHookCommand,
+} from '../src/adapters/hook-command.js';
+
+const REAL_ARGV1 = process.argv[1];
+
+/** Make `isStandaloneBinary()` report true the way a compiled binary does. */
+function asCompiledBinary() {
+  process.argv[1] = '/$bunfs/root/cli.js';
+}
+
+afterEach(() => { process.argv[1] = REAL_ARGV1; });
+
+describe('hook-command — compiled binary form', () => {
+  it('never emits a /$bunfs/ path (it does not exist outside the process)', () => {
+    asCompiledBinary();
+    const strings = [
+      hookCommandFor('claude-code'),
+      sessionReadyHookCommand(),
+      userPromptHookCommand(),
+      ...hookCommandParts('claude-code').args,
+      hookCommandParts('claude-code').cmd,
+    ];
+    for (const s of strings) expect(s).not.toContain('$bunfs');
+  });
+
+  it('drops the script path entirely and passes the subcommand to the binary', () => {
+    asCompiledBinary();
+    // The compiled binary dispatches ordinary subcommands itself — MEASURED:
+    // `<binary> hook claude-code`, `<binary> session-ready` and
+    // `<binary> user-prompt-hook` all run and exit 0 with no script argument.
+    expect(hookCommandParts('claude-code')).toEqual({
+      cmd: process.execPath,
+      args: ['hook', 'claude-code'],
+    });
+    expect(hookCommandFor('claude-code')).toBe(`"${process.execPath}" hook claude-code`);
+    expect(sessionReadyHookCommand()).toBe(`"${process.execPath}" session-ready`);
+    expect(userPromptHookCommand()).toBe(`"${process.execPath}" user-prompt-hook`);
+  });
+
+  it('survives a shell round-trip with the subcommand intact', () => {
+    asCompiledBinary();
+    // What `sh` actually does to the string is the whole failure mode, so assert
+    // on the post-expansion words rather than on the source text. `$bunfs` would
+    // vanish here; a real path does not.
+    const cmd = sessionReadyHookCommand();
+    const expanded = cmd.replace(/\$\w+/g, '');
+    expect(expanded).toBe(cmd);
+    expect(cmd.endsWith(' session-ready')).toBe(true);
+  });
+});
+
+describe('hook-command — Node form stays byte-identical', () => {
+  it('keeps the dist/cli.js script path (Node cannot resolve the subcommand alone)', () => {
+    // Guard against "converging" the branches: verified that `node hook
+    // claude-code` without the script path fails with MODULE_NOT_FOUND, so this
+    // path must keep the argument.
+    const parts = hookCommandParts('claude-code');
+    expect(parts.cmd).toBe(process.execPath);
+    expect(parts.args).toHaveLength(3);
+    expect(parts.args[0]).toMatch(/[/\\]cli\.js$/);
+    expect(parts.args.slice(1)).toEqual(['hook', 'claude-code']);
+  });
+
+  it('quotes the executable and the script, but not the subcommand tokens', () => {
+    const s = hookCommandFor('claude-code');
+    expect(s).toBe(`"${process.execPath}" "${hookCommandParts('claude-code').args[0]}" hook claude-code`);
+    // The trailing tokens are bare — callers must not re-split the string, but a
+    // shell has to see `hook` and the cliId as separate words.
+    expect(s.endsWith(' hook claude-code')).toBe(true);
+  });
+
+  it('session-ready and user-prompt-hook carry the script path too', () => {
+    const script = hookCommandParts('x').args[0];
+    expect(sessionReadyHookCommand()).toBe(`"${process.execPath}" "${script}" session-ready`);
+    expect(userPromptHookCommand()).toBe(`"${process.execPath}" "${script}" user-prompt-hook`);
+  });
+
+  it('the two forms differ exactly by the script argument', () => {
+    const nodeForm = hookCommandParts('claude-code');
+    asCompiledBinary();
+    const binForm = hookCommandParts('claude-code');
+    // Same subcommand, one fewer argument — states the contract as a relation so
+    // a future edit to either branch alone breaks it.
+    expect(nodeForm.args).toHaveLength(binForm.args.length + 1);
+    expect(nodeForm.args.slice(1)).toEqual(binForm.args);
+  });
+});

--- a/test/reap-orphan-workers.test.ts
+++ b/test/reap-orphan-workers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { reapOrphanWorkers, type ProcSnapshot } from '../src/core/worker-pool.js';
 
 // Absolute path of THIS install's worker script, as it appears in a worker's
@@ -51,5 +51,66 @@ describe('reapOrphanWorkers', () => {
     const killed: number[] = [];
     expect(reapOrphanWorkers({ procs, workerPath: WP, kill: (p) => killed.push(p) })).toBe(0);
     expect(killed).toEqual([]);
+  });
+});
+
+/**
+ * COMPILED SINGLE-FILE BINARY.
+ *
+ * The cases above all inject `workerPath`, so the DEFAULT branch — the one that
+ * decides how workers are identified in production — was never exercised. In the
+ * compiled form that default was `join(__dirname,'..','worker.js')` =
+ * `/$bunfs/worker.js`, a process-private virtual path that appears in no command
+ * line at all, so `cmd.includes(...)` matched nothing and orphans were NEVER
+ * reaped. MEASURED against a real compiled binary: a worker's actual cmdline is
+ * `<binary> __worker`.
+ *
+ * `isStandaloneBinary()` is exercised for real (not mocked) by pointing
+ * `process.argv[1]` at a `/$bunfs/` path, which is exactly the signal it keys off
+ * (src/core/self-spawn.ts). These cases deliberately pass NO `workerPath`.
+ */
+describe('reapOrphanWorkers — compiled binary form', () => {
+  const REAL_ARGV1 = process.argv[1];
+  const BIN = process.execPath;
+  const NAME = BIN.slice(BIN.lastIndexOf('/') + 1);
+
+  beforeEach(() => { process.argv[1] = '/$bunfs/root/cli.js'; });
+  afterEach(() => { process.argv[1] = REAL_ARGV1; });
+
+  it('reaps `<binary> __worker` orphans, which the worker.js predicate could never match', () => {
+    const killed: number[] = [];
+    const procs: ProcSnapshot[] = [
+      { pid: 200, ppid: 1, cmd: `${BIN} __worker` },        // orphan ✓
+      { pid: 201, ppid: 1, cmd: `${NAME} __worker` },       // relative argv[0] — MEASURED shape ✓
+      { pid: 202, ppid: 777, cmd: `${BIN} __worker` },      // live worker ✗
+    ];
+
+    const n = reapOrphanWorkers({ procs, kill: (pid) => killed.push(pid) });
+
+    expect(n).toBe(2);
+    expect(killed).toEqual([200, 201]);
+  });
+
+  it('still spares other installs and non-workers (conservatism is preserved)', () => {
+    const killed: number[] = [];
+    const procs: ProcSnapshot[] = [
+      { pid: 300, ppid: 1, cmd: '/opt/other-botmux/botmux __worker' }, // different install ✗
+      { pid: 301, ppid: 1, cmd: `${BIN} __supervisor` },              // another entry, not a worker ✗
+      { pid: 302, ppid: 1, cmd: `${BIN} start` },                     // ordinary CLI ✗
+      { pid: 303, ppid: 1, cmd: 'grep -r __worker src/' },            // merely mentions the token ✗
+    ];
+
+    expect(reapOrphanWorkers({ procs, kill: (p) => killed.push(p) })).toBe(0);
+    expect(killed).toEqual([]);
+  });
+
+  it('never matches a /$bunfs/ path (nothing on the system carries one)', () => {
+    const killed: number[] = [];
+    const procs: ProcSnapshot[] = [
+      { pid: 400, ppid: 1, cmd: `${BIN} /$bunfs/worker.js` },
+    ];
+    // The old default would have "matched" this synthetic line while matching no
+    // real one; the new predicate requires the __worker token instead.
+    expect(reapOrphanWorkers({ procs, kill: (p) => killed.push(p) })).toBe(0);
   });
 });


### PR DESCRIPTION
## 背景

编译版单文件二进制的模块图在虚拟只读的 `/$bunfs/` 下，`__dirname` 是 `/$bunfs/root`。**凡是把 `__dirname` 拼出的路径交给别的进程的代码，在编译态都是坏的**，而且坏法全是静默的——本地开发 100% 跑源码态（`node dist/*.js`），这类缺陷只在用户装完后暴露。

本 PR 收敛其中两处（均在真编译二进制上实测），并补三件让编译态可在本地验证的工具。

## 改了什么

### ① hook 命令 — `src/adapters/hook-command.ts`

三个函数各自拼 `join(__dirname,'..','cli.js')`，编译态得到 `/$bunfs/cli.js`，**两重独立失效**：

| | 失效原因 | 实测 |
|---|---|---|
| ① | `/$bunfs/` 只在本进程内可见，而 hook 命令恰恰交给**别的进程**执行 | 子进程看不到该路径 |
| ② | 字符串由 shell 执行，双引号内未转义的 `$bunfs` 被 sh 展开成空串 | `"/$bunfs/cli.js"` → `//cli.js` |

**用户侧症状最难查**：把旧形态交给 sh 实测**打印 help banner 并 exit 0** —— hook 静默不生效，且无人报错。

```
新形态: "…/botmux" session-ready          → exit 0（真执行）
旧形态: "…/botmux" "/$bunfs/cli.js" …     → 打印 help banner
```

影响面：这些字符串写进 `~/.claude/settings.json` 与进程级 `--settings`，喂 Claude / grok / opencode 三个家族。

**修法**与 `core/self-spawn.ts` 同构：编译态不拼路径，直接 exec 二进制自身、子命令当普通参数传（实测真二进制 `hook claude-code` / `session-ready` / `user-prompt-hook` 三者都正常 dispatch）。三处合并为单一出口，避免同一判据三份实现各自漂移。

**Node 态逐字不变** —— 与改动前输出做过基线 diff，零差异。这里**必须分流、不能收敛**：实测 Node 侧不带 `cli.js` 路径会 MODULE_NOT_FOUND。

### ② 孤儿 worker 回收 — `src/core/worker-pool.ts`

`reapOrphanWorkers()` 用 `p.cmd.includes(workerPath)` 认领本安装的 worker，而编译态 `workerPath` 是 `/$bunfs/worker.js` —— **一个不出现在任何命令行里的虚拟路径**。实测真编译 worker 的 cmdline 是 `<binary> __worker`，所以旧判据匹配不到任何东西，**编译版的孤儿从来没被回收过**（每个泄漏约 0.5 GB，跨重启累积；`daemon.ts` 记录过 841 孤儿 / ~65 GB 事故）。

改为编译态按「本二进制名 **+** `__worker` token」双重匹配，保持原有保守性 —— 去掉任一条件都会误杀（见下方反变异）。token 从 `self-spawn.ts` 新导出的 `WORKER_ENTRY_SUBCOMMAND` 取，不在匹配处硬编码字面量。

⚠️ 既有 4 个用例全部注入 `workerPath`，所以**默认分支（生产实际走的那条）此前零覆盖** —— 新增用例刻意不注入。

### ③ 配套工具

- **`bun run verify:binary`** —— 编译 + smoke 一条命令，实测 **27s**（编译本身仅 1.5s）。此前手工要拼三步，且必然卡在 `--version` 报 unknown（`versionToBake()` 只读 package.json 的占位 `0.0.0`，运行时按「未烤入」处理）；改为回退 `git describe`，**仅在占位时生效**，不影响发版（CI 戳 `0.0.0-ci.<N>`、发版戳 tag 名，都不是裸 `0.0.0`）。
  另**显式拒绝非 host target**：交叉编 `linux-arm64` 实测 exit 0 且产出真 aarch64 ELF，但嵌的是本机 x64 的 `pty.node`（node-pty 无 linux prebuild ⟹ 无条件回退本机那份），失败发生在 PTY spawn 而非 build；本机也缺 arm64 loader 无法执行。这些 target 由 CI 的 `bun-binary` / `bun-binary-musl` 覆盖。
- **`bun run use:here --binary`** —— 把全局 botmux 指向编译版，让本地 fleet 跑用户实际拿到的形态，形态差异在日常使用中自己暴露。wrapper 与两个生产写入方（daemon 的 `botmuxWrapperFiles` standalone 分支、npm postinstall）**逐字同构**，测试钉住三者一致。自带自毁守卫：install.sh 把二进制装在 wrapper 自己的路径上，指向那里会把本体覆盖成几十字节 sh 壳。
- **`scripts/audit-embedded-assets.mjs`**（挂进 `build`）—— 枚举 `dist/` 非 JS 资源，每个都必须有「编译态可达性」的决定。`dashboard-web/` 由 embed preamble 全目录 walk 覆盖；`setup/lark-scopes.json` 确实不可达，但**修复属另一个进行中的改动**，故显式记为已知项并打印警告、不阻塞 build（该项失效时闸门同样报错）。

## 影响范围

| 维度 | 评估 |
|---|---|
| 跨形态 | 源码态逐字不变（基线 diff 零差异）；编译态是被修的那侧 |
| 跨 CLI | `hook-command.ts` 是 Claude/grok/opencode 共用choke point，三者形态一致改动；未动 `adapters/cli/` 任何适配器 |
| 跨平台 | 判据用 `basename` 子串而非绝对路径（`/proc/<pid>/cmdline` 保留 argv[0] 原样，实测相对路径启动就是相对的）；`reapOrphanWorkers` 保留原有 win32 早退 |
| 公共层 | 动了 `core/self-spawn.ts`（**只新增一个导出**，未改任何既有函数）与 `core/worker-pool.ts`（只改 reaper 判据） |

## 验证

- `bun run build` 通过
- **单测 19100 passed / 4 failed** —— 4 个失败在 stash 掉本改动后跑基线**逐字相同**（MCP sandbox + mojo EACCES，既有失败）
- **编译态 smoke 7 项全绿**（真二进制，3.18.5-dirty）
- **反变异全部转红**：
  - hook 4 组：整体退回旧写法 / 编译态误留脚本路径 / Node 态误删脚本路径 / shell 渲染分支去掉
  - reaper 3 组：退回旧写法 / 去二进制名约束（会误杀别的安装）/ 去 token 约束（会误杀普通 CLI 命令）
  - `--binary` 4 组：**去自毁守卫后 169 MB 二进制实测变 63 字节**
- ⚠️ 其中「去 realpath」变异**第一轮全绿 = 无牙**，因为 `/tmp` 不是软链、`realpath` 与 `resolve` 恒等；补了显式软链用例后才咬住

🤖 Generated with [Claude Code](https://claude.com/claude-code)
