### PR TITLE
fix(opencode): 引入 SQLite 会话状态探测与 busyPattern，防止长耗时工具调用误判为等待输入

### DIFF
--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -202,6 +202,70 @@ export function sessionRowExists(cliSessionId: string, kind: OpenCodeDbKind = 'v
   });
 }
 
+/**
+ * 探测 OpenCode 会话当前是否处于执行中（工具调用中、模型推理中等）。
+ *
+ * 判 busy 准则（满足任一即为 busy）：
+ *  1. 存在属于该 session、状态为 `status: "running"` 的 tool part；
+ *  2. 该 session 最新的一条 assistant message 处于未完成状态（没有 completed 时间戳，
+ *     或 finish 仍为 "tool-calls" 且后续 step 尚未终态）。
+ */
+export function isOpenCodeSessionBusy(cliSessionId: string, kind: OpenCodeDbKind = 'v1'): boolean {
+  if (kind === 'v2') {
+    return withDb((db) => {
+      // 1. 检查是否存在 running 状态的 tool part
+      const runningTool = db.prepare(
+        "SELECT 1 AS busy FROM session_message " +
+        "WHERE session_id = ? " +
+        "  AND json_extract(data, '$.state.status') = 'running' " +
+        "LIMIT 1"
+      ).get(cliSessionId) as { busy?: number } | undefined;
+      if (runningTool?.busy) return true;
+
+      // 2. 检查最新 assistant message 是否处于未完成状态
+      const lastMsg = db.prepare(
+        "SELECT json_extract(data, '$.finish') AS finish, " +
+        "       json_extract(data, '$.time.completed') AS completed " +
+        "FROM session_message " +
+        "WHERE session_id = ? AND type = 'assistant' " +
+        "ORDER BY time_created DESC LIMIT 1"
+      ).get(cliSessionId) as { finish?: string; completed?: number } | undefined;
+
+      if (!lastMsg) return false;
+      if (lastMsg.completed === undefined || lastMsg.completed === null) return true;
+      if (lastMsg.finish === 'tool-calls') return true;
+      return false;
+    }) ?? false;
+  }
+
+  return withDb((db) => {
+    // 1. 检查是否存在 running 状态的 tool part
+    const runningTool = db.prepare(
+      "SELECT 1 AS busy FROM part " +
+      "WHERE session_id = ? " +
+      "  AND json_extract(data, '$.type') = 'tool' " +
+      "  AND json_extract(data, '$.state.status') = 'running' " +
+      "LIMIT 1"
+    ).get(cliSessionId) as { busy?: number } | undefined;
+    if (runningTool?.busy) return true;
+
+    // 2. 检查最新 assistant message 是否处于未完成状态
+    const lastMsg = db.prepare(
+      "SELECT json_extract(data, '$.finish') AS finish, " +
+      "       json_extract(data, '$.time.completed') AS completed " +
+      "FROM message " +
+      "WHERE session_id = ? " +
+      "  AND json_extract(data, '$.role') = 'assistant' " +
+      "ORDER BY time_created DESC LIMIT 1"
+    ).get(cliSessionId) as { finish?: string; completed?: number } | undefined;
+
+    if (!lastMsg) return false;
+    if (lastMsg.completed === undefined || lastMsg.completed === null) return true;
+    if (lastMsg.finish === 'tool-calls') return true;
+    return false;
+  }) ?? false;
+}
+
 /** Import path（/adopt 第二过滤器）共用实现：从当前存储层的会话表列出可续接的
  *  顶层会话（parent_id 非空的是子代理会话，跳过）。opencode2 与 opencode 共用
  *  同一库文件，kind 区分表空间。 */
@@ -344,6 +408,14 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
 
     completionPattern: undefined,   // quiescence only — no explicit completion marker
     readyPattern: undefined,        // Bubble Tea TUI — no reliable prompt indicator; rely on quiescence + spinner guard
+    busyPattern: /ctrl\+c to interrupt|esc to interrupt/i,
+    isSessionBusy({ sessionId, cliSessionId }) {
+      const sid = isOpenCodeSessionId(cliSessionId)
+        ? cliSessionId
+        : latestOpenCodeSessionForBotmuxSession(sessionId, 'v1');
+      if (!sid) return false;
+      return isOpenCodeSessionBusy(sid, 'v1');
+    },
     systemHints: BOTMUX_SHELL_HINTS,
     altScreen: true,                // Bubble Tea renders in alternate screen buffer
     readOnlyRemoteScroll: true,

--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -202,66 +202,70 @@ export function sessionRowExists(cliSessionId: string, kind: OpenCodeDbKind = 'v
   });
 }
 
+/** 会话忙碌态判断的时效窗口（毫秒）。超过此窗口未更新的异常/孤儿记录不判忙，避免进程异常终止导致死锁。 */
+export const OPENCODE_BUSY_FRESHNESS_MS = 120_000;
+
 /**
- * 探测 OpenCode 会话当前是否处于执行中（工具调用中、模型推理中等）。
+ * 探测 OpenCode 会话当前是否处于执行中（时效内的工具调用中或模型生成中）。
  *
- * 判 busy 准则（满足任一即为 busy）：
+ * 判 busy 准则（必须在 freshnessWindowMs 时效窗口内，满足任一即为 busy）：
  *  1. 存在属于该 session、状态为 `status: "running"` 的 tool part；
- *  2. 该 session 最新的一条 assistant message 处于未完成状态（没有 completed 时间戳，
- *     或 finish 仍为 "tool-calls" 且后续 step 尚未终态）。
+ *  2. 该 session 最新的一条 assistant message 处于未完成状态（没有 completed 时间戳）。
  */
-export function isOpenCodeSessionBusy(cliSessionId: string, kind: OpenCodeDbKind = 'v1'): boolean {
+export function isOpenCodeSessionBusy(
+  cliSessionId: string,
+  kind: OpenCodeDbKind = 'v1',
+  freshnessWindowMs: number = OPENCODE_BUSY_FRESHNESS_MS,
+): boolean {
+  const freshBaseline = Date.now() - freshnessWindowMs;
+
   if (kind === 'v2') {
     return withDb((db) => {
-      // 1. 检查是否存在 running 状态的 tool part
+      // 1. 检查是否存在时效内处于 running 状态的 tool part
       const runningTool = db.prepare(
         "SELECT 1 AS busy FROM session_message " +
-        "WHERE session_id = ? " +
+        "WHERE session_id = ? AND time_created > ? " +
         "  AND json_extract(data, '$.state.status') = 'running' " +
         "LIMIT 1"
-      ).get(cliSessionId) as { busy?: number } | undefined;
+      ).get(cliSessionId, freshBaseline) as { busy?: number } | undefined;
       if (runningTool?.busy) return true;
 
-      // 2. 检查最新 assistant message 是否处于未完成状态
+      // 2. 检查最新 assistant message 是否处于时效内的未完成态（无 completed 时间戳）
       const lastMsg = db.prepare(
-        "SELECT json_extract(data, '$.finish') AS finish, " +
-        "       json_extract(data, '$.time.completed') AS completed " +
+        "SELECT json_extract(data, '$.time.completed') AS completed " +
         "FROM session_message " +
-        "WHERE session_id = ? AND type = 'assistant' " +
+        "WHERE session_id = ? AND type = 'assistant' AND time_created > ? " +
         "ORDER BY time_created DESC LIMIT 1"
-      ).get(cliSessionId) as { finish?: string; completed?: number } | undefined;
+      ).get(cliSessionId, freshBaseline) as { completed?: number } | undefined;
 
       if (!lastMsg) return false;
       if (lastMsg.completed === undefined || lastMsg.completed === null) return true;
-      if (lastMsg.finish === 'tool-calls') return true;
       return false;
     }) ?? false;
   }
 
   return withDb((db) => {
-    // 1. 检查是否存在 running 状态的 tool part
+    // 1. 检查是否存在时效内处于 running 状态的 tool part
     const runningTool = db.prepare(
       "SELECT 1 AS busy FROM part " +
-      "WHERE session_id = ? " +
+      "WHERE session_id = ? AND time_created > ? " +
       "  AND json_extract(data, '$.type') = 'tool' " +
       "  AND json_extract(data, '$.state.status') = 'running' " +
       "LIMIT 1"
-    ).get(cliSessionId) as { busy?: number } | undefined;
+    ).get(cliSessionId, freshBaseline) as { busy?: number } | undefined;
     if (runningTool?.busy) return true;
 
-    // 2. 检查最新 assistant message 是否处于未完成状态
+    // 2. 检查最新 assistant message 是否处于时效内的未完成态（无 completed 时间戳）
     const lastMsg = db.prepare(
-      "SELECT json_extract(data, '$.finish') AS finish, " +
-      "       json_extract(data, '$.time.completed') AS completed " +
+      "SELECT json_extract(data, '$.time.completed') AS completed " +
       "FROM message " +
-      "WHERE session_id = ? " +
+      "WHERE session_id = ? AND time_created > ? " +
       "  AND json_extract(data, '$.role') = 'assistant' " +
       "ORDER BY time_created DESC LIMIT 1"
-    ).get(cliSessionId) as { finish?: string; completed?: number } | undefined;
+    ).get(cliSessionId, freshBaseline) as { completed?: number } | undefined;
 
     if (!lastMsg) return false;
     if (lastMsg.completed === undefined || lastMsg.completed === null) return true;
-    if (lastMsg.finish === 'tool-calls') return true;
     return false;
   }) ?? false;
 }
@@ -408,7 +412,7 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
 
     completionPattern: undefined,   // quiescence only — no explicit completion marker
     readyPattern: undefined,        // Bubble Tea TUI — no reliable prompt indicator; rely on quiescence + spinner guard
-    busyPattern: /ctrl\+c to interrupt|esc to interrupt/i,
+    busyPattern: undefined,
     isSessionBusy({ sessionId, cliSessionId }) {
       const sid = isOpenCodeSessionId(cliSessionId)
         ? cliSessionId

--- a/src/adapters/cli/opencode2.ts
+++ b/src/adapters/cli/opencode2.ts
@@ -3,6 +3,7 @@ import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import type { CliAdapter, PtyHandle, ResumableSession } from './types.js';
 import {
   detectOpenCodeSubmit,
+  isOpenCodeSessionBusy,
   isOpenCodeSessionId,
   latestOpenCodeSessionForBotmuxSession,
   listOpenCodeResumableSessions,
@@ -132,6 +133,14 @@ export function createOpenCode2Adapter(pathOverride?: string): CliAdapter {
 
     completionPattern: undefined,
     readyPattern: undefined,
+    busyPattern: /ctrl\+c to interrupt|esc to interrupt/i,
+    isSessionBusy({ sessionId, cliSessionId }) {
+      const sid = isOpenCodeSessionId(cliSessionId)
+        ? cliSessionId
+        : latestOpenCodeSessionForBotmuxSession(sessionId, 'v2');
+      if (!sid) return false;
+      return isOpenCodeSessionBusy(sid, 'v2');
+    },
     systemHints: BOTMUX_SHELL_HINTS,
     altScreen: true,                // V2 TUI 仍渲染在 alternate screen buffer（实测 \x1b[?1049h）
     readOnlyRemoteScroll: true,

--- a/src/adapters/cli/opencode2.ts
+++ b/src/adapters/cli/opencode2.ts
@@ -133,7 +133,7 @@ export function createOpenCode2Adapter(pathOverride?: string): CliAdapter {
 
     completionPattern: undefined,
     readyPattern: undefined,
-    busyPattern: /ctrl\+c to interrupt|esc to interrupt/i,
+    busyPattern: undefined,
     isSessionBusy({ sessionId, cliSessionId }) {
       const sid = isOpenCodeSessionId(cliSessionId)
         ? cliSessionId

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -365,6 +365,13 @@ export interface CliAdapter {
    *  the worker may safely let quiescence mark the session idle. */
   readonly busyPattern?: RegExp;
 
+  /**
+   * Optional runtime session busy check against the CLI's native state store
+   * (e.g. OpenCode SQLite db). When true, suppresses premature idle detection
+   * even if PTY output has quiesced.
+   */
+  readonly isSessionBusy?: (opts: { sessionId: string; cliSessionId?: string }) => boolean;
+
   /** Opt-in positive marker for an idle→working edge observed in PTY output.
    *  Kept separate from busyPattern because transcript/full-screen redraws may
    *  contain old busy text; existing adapters remain opt-out by default. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12206,7 +12206,7 @@ function busyProbeRegion(content: string): string {
 }
 
 function deferPromptReadyWhileBusy(source: string, be: SessionBackend): boolean {
-  const currentCliSid = lastInitConfig?.cliSessionId ?? lastSpawnEffectiveCliSessionId;
+  const currentCliSid = lastSpawnEffectiveCliSessionId ?? lastInitConfig?.cliSessionId;
   if (cliAdapter?.isSessionBusy && cliAdapter.isSessionBusy({ sessionId, cliSessionId: currentCliSid })) {
     log(`${source}: session state indicates active work (db busy); deferring prompt ready`);
     idleDetector?.reset();
@@ -12231,7 +12231,7 @@ function probeBusyPatternIdle(
   source: string,
   be: SessionBackend,
 ): boolean {
-  const currentCliSid = lastInitConfig?.cliSessionId ?? lastSpawnEffectiveCliSessionId;
+  const currentCliSid = lastSpawnEffectiveCliSessionId ?? lastInitConfig?.cliSessionId;
   if (cliAdapter?.isSessionBusy && cliAdapter.isSessionBusy({ sessionId, cliSessionId: currentCliSid })) {
     return false;
   }
@@ -12273,8 +12273,24 @@ function probeBusyPatternIdle(
       log(`${source} idle probe captureCurrentScreen failed: ${err.message}`);
     }
   } else if (cliAdapter?.isSessionBusy) {
-    log(`${source} idle probe: session state store no longer busy, marking prompt ready`);
-    markPromptReady();
+    if (!be.settleCurrentScreen) {
+      log(`${source} idle probe: session state store no longer busy, marking prompt ready`);
+      markPromptReady();
+      return true;
+    }
+    const revisionBeforeSettle = backendScreenRevision;
+    log(`${source} idle probe: session state store no longer busy, settling authoritative screen before prompt ready`);
+    void settleBackendScreenBeforeIdle(be, revisionBeforeSettle).then((settle) => {
+      if (!settle.proceed || backend !== be || isPromptReady) return;
+      if (backendScreenRevision !== revisionBeforeSettle) {
+        log(`${source} idle probe: authoritative screen changed during settle; deferring completion`);
+        return;
+      }
+      if (settle.degraded) {
+        log(`${source} idle probe: screen settle degraded; finalizing from the last successful snapshot`);
+      }
+      markPromptReady();
+    });
     return true;
   }
   return false;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12206,6 +12206,13 @@ function busyProbeRegion(content: string): string {
 }
 
 function deferPromptReadyWhileBusy(source: string, be: SessionBackend): boolean {
+  const currentCliSid = lastInitConfig?.cliSessionId ?? lastSpawnEffectiveCliSessionId;
+  if (cliAdapter?.isSessionBusy && cliAdapter.isSessionBusy({ sessionId, cliSessionId: currentCliSid })) {
+    log(`${source}: session state indicates active work (db busy); deferring prompt ready`);
+    idleDetector?.reset();
+    scheduleBusyPatternIdleProbe(source);
+    return true;
+  }
   if (!backendScreenEvidenceIsAuthoritativeForMutation() || !cliAdapter?.busyPattern) return false;
   try {
     const content = captureBackendScreen(be);
@@ -12224,14 +12231,18 @@ function probeBusyPatternIdle(
   source: string,
   be: SessionBackend,
 ): boolean {
-  if (!backendScreenEvidenceIsAuthoritativeForMutation()) {
-    log(`${source} idle probe skipped: backend screen geometry is not authoritative`);
+  const currentCliSid = lastInitConfig?.cliSessionId ?? lastSpawnEffectiveCliSessionId;
+  if (cliAdapter?.isSessionBusy && cliAdapter.isSessionBusy({ sessionId, cliSessionId: currentCliSid })) {
     return false;
   }
-  try {
-    const content = captureBackendScreen(be);
-    if (!content) return false;
-    if (cliAdapter?.busyPattern) {
+  if (cliAdapter?.busyPattern) {
+    if (!backendScreenEvidenceIsAuthoritativeForMutation()) {
+      log(`${source} idle probe skipped: backend screen geometry is not authoritative`);
+      return false;
+    }
+    try {
+      const content = captureBackendScreen(be);
+      if (!content) return false;
       if (cliAdapter.busyPattern.test(busyProbeRegion(content))) return false;
       if (!be.settleCurrentScreen) {
         log(`${source} idle probe: busy marker absent, marking prompt ready`);
@@ -12258,16 +12269,20 @@ function probeBusyPatternIdle(
         markPromptReady();
       });
       return true;
+    } catch (err: any) {
+      log(`${source} idle probe captureCurrentScreen failed: ${err.message}`);
     }
-  } catch (err: any) {
-    log(`${source} idle probe captureCurrentScreen failed: ${err.message}`);
+  } else if (cliAdapter?.isSessionBusy) {
+    log(`${source} idle probe: session state store no longer busy, marking prompt ready`);
+    markPromptReady();
+    return true;
   }
   return false;
 }
 
 function scheduleReattachIdleProbe(source: string, be: SessionBackend): void {
   stopReattachIdleProbe();
-  if (!cliAdapter?.busyPattern || (!be.captureCurrentScreen && !be.captureViewport)) return;
+  if ((!cliAdapter?.busyPattern && !cliAdapter?.isSessionBusy) || (!be.captureCurrentScreen && !be.captureViewport && !cliAdapter?.isSessionBusy)) return;
   reattachIdleProbeTimer = setTimeout(() => {
     reattachIdleProbeTimer = null;
     if (backend !== be || !awaitingFirstPrompt || isPromptReady) return;
@@ -12292,19 +12307,11 @@ function stopBusyPatternIdleProbe(): void {
 
 function scheduleBusyPatternIdleProbe(source: string): void {
   stopBusyPatternIdleProbe();
-  if (!cliAdapter?.busyPattern || !backend || !canCaptureBusyPatternScreen(backend)) return;
-  // Don't arm on a backend whose screen geometry is not authoritative for
-  // mutation (ZMX): probeBusyPatternIdle() bails at that same gate every tick
-  // and can never mark ready, so — with the attempt cap now removed — the timer
-  // would re-arm on `!isPromptReady` forever. On ZMX an alt-screen CLI's
-  // busy→idle redraw arrives as a screen-resync (reset-only, deliberately not
-  // fed to IdleDetector — see onBackendScreenResync), so screen quiescence never
-  // flips isPromptReady either; a Pi turn ending via a `terminate:true` custom
-  // tool (no assistant_final → no fireIdle) would then leave a live worker
-  // logging a skip line every IDLE_PROBE_INTERVAL_MS with no terminator. The
-  // authoritative screen-idle path (settle + drainBridgesThenMarkReady) already
-  // owns completion for these backends.
-  if (!backendScreenEvidenceIsAuthoritativeForMutation()) return;
+  if ((!cliAdapter?.busyPattern && !cliAdapter?.isSessionBusy) || !backend) return;
+  if (!cliAdapter?.isSessionBusy) {
+    if (!canCaptureBusyPatternScreen(backend)) return;
+    if (!backendScreenEvidenceIsAuthoritativeForMutation()) return;
+  }
 
   const tick = () => {
     busyPatternIdleProbeTimer = null;

--- a/test/opencode-busy-state.test.ts
+++ b/test/opencode-busy-state.test.ts
@@ -1,7 +1,7 @@
 /**
  * OpenCode busy state detection 单测：
- * 验证基于 SQLite 状态（part 表 running 状态、message 表 completed/finish 状态）
- * 对 OpenCode (V1) 和 OpenCode2 (V2) 会话忙碌态（工具执行中、模型思考中）的精准识别。
+ * 验证基于 SQLite 状态（part 表 running 状态、message 表 completed 状态）
+ * 以及时效窗口（freshness window）对 OpenCode (V1) 和 OpenCode2 (V2) 会话忙碌态的精准识别与死锁防范。
  *
  * Run:  npx vitest run test/opencode-busy-state.test.ts
  */
@@ -92,14 +92,15 @@ afterEach(() => {
 });
 
 describe('isOpenCodeSessionBusy V1', () => {
-  it('returns true when a tool part is running', () => {
+  it('returns true when a fresh tool part is running', () => {
     const db = openV1Db();
     const sid = 'ses_v1_running_tool';
     const mid = `msg_${++idSeq}`;
+    const now = Date.now();
     db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
-      .run(mid, sid, 1000, JSON.stringify({ role: 'assistant', time: { created: 1000 } }));
+      .run(mid, sid, now, JSON.stringify({ role: 'assistant', time: { created: now } }));
     db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
-      .run(`prt_${++idSeq}`, mid, sid, 1000, JSON.stringify({
+      .run(`prt_${++idSeq}`, mid, sid, now, JSON.stringify({
         type: 'tool',
         tool: 'bash',
         state: { status: 'running' },
@@ -109,44 +110,85 @@ describe('isOpenCodeSessionBusy V1', () => {
     expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(true);
   });
 
-  it('returns true when assistant message is not completed yet', () => {
+  it('returns true when a fresh assistant message is not completed yet', () => {
     const db = openV1Db();
     const sid = 'ses_v1_generating';
     const mid = `msg_${++idSeq}`;
+    const now = Date.now();
     db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
-      .run(mid, sid, 1000, JSON.stringify({ role: 'assistant', time: { created: 1000 } }));
+      .run(mid, sid, now, JSON.stringify({ role: 'assistant', time: { created: now } }));
     db.close();
 
     expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(true);
   });
 
-  it('returns true when assistant message finish is tool-calls', () => {
+  it('returns false for stale incomplete message (older than freshness window, e.g. crashed process)', () => {
     const db = openV1Db();
-    const sid = 'ses_v1_tool_calls';
+    const sid = 'ses_v1_stale_crash';
     const mid = `msg_${++idSeq}`;
+    // 10 分钟前的未完成消息
+    const staleTime = Date.now() - 600_000;
     db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
-      .run(mid, sid, 1000, JSON.stringify({
-        role: 'assistant',
-        finish: 'tool-calls',
-        time: { created: 1000, completed: 1500 },
+      .run(mid, sid, staleTime, JSON.stringify({ role: 'assistant', time: { created: staleTime } }));
+    db.close();
+
+    // 默认 2 分钟时效窗口，10 分钟前的不应判定为忙碌（防止死锁）
+    expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(false);
+  });
+
+  it('returns false for stale running tool (older than freshness window)', () => {
+    const db = openV1Db();
+    const sid = 'ses_v1_stale_tool';
+    const mid = `msg_${++idSeq}`;
+    const staleTime = Date.now() - 600_000;
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+      .run(mid, sid, staleTime, JSON.stringify({ role: 'assistant', time: { created: staleTime } }));
+    db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
+      .run(`prt_${++idSeq}`, mid, sid, staleTime, JSON.stringify({
+        type: 'tool',
+        tool: 'bash',
+        state: { status: 'running' },
       }));
     db.close();
 
-    expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(true);
+    expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(false);
   });
 
   it('returns false when assistant message is completed with finish stop and no running parts', () => {
     const db = openV1Db();
     const sid = 'ses_v1_done';
     const mid = `msg_${++idSeq}`;
+    const now = Date.now();
     db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
-      .run(mid, sid, 1000, JSON.stringify({
+      .run(mid, sid, now, JSON.stringify({
         role: 'assistant',
         finish: 'stop',
-        time: { created: 1000, completed: 2000 },
+        time: { created: now, completed: now + 500 },
       }));
     db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
-      .run(`prt_${++idSeq}`, mid, sid, 1000, JSON.stringify({
+      .run(`prt_${++idSeq}`, mid, sid, now, JSON.stringify({
+        type: 'tool',
+        tool: 'bash',
+        state: { status: 'completed' },
+      }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(false);
+  });
+
+  it('returns false when assistant message is completed even if finish is tool-calls (no running parts left)', () => {
+    const db = openV1Db();
+    const sid = 'ses_v1_completed_tool_calls';
+    const mid = `msg_${++idSeq}`;
+    const now = Date.now();
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+      .run(mid, sid, now, JSON.stringify({
+        role: 'assistant',
+        finish: 'tool-calls',
+        time: { created: now, completed: now + 500 },
+      }));
+    db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
+      .run(`prt_${++idSeq}`, mid, sid, now, JSON.stringify({
         type: 'tool',
         tool: 'bash',
         state: { status: 'completed' },
@@ -158,11 +200,12 @@ describe('isOpenCodeSessionBusy V1', () => {
 });
 
 describe('isOpenCodeSessionBusy V2', () => {
-  it('returns true when a tool part is running in session_message', () => {
+  it('returns true when a fresh tool part is running in session_message', () => {
     const db = openV2Db();
     const sid = 'ses_v2_running';
+    const now = Date.now();
     db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
-      .run(`msg_${++idSeq}`, sid, 'tool', 1000, 1000, JSON.stringify({
+      .run(`msg_${++idSeq}`, sid, 'tool', now, now, JSON.stringify({
         type: 'tool',
         state: { status: 'running' },
       }));
@@ -171,25 +214,40 @@ describe('isOpenCodeSessionBusy V2', () => {
     expect(isOpenCodeSessionBusy(sid, 'v2')).toBe(true);
   });
 
-  it('returns true when assistant message is incomplete in session_message', () => {
+  it('returns true when fresh assistant message is incomplete in session_message', () => {
     const db = openV2Db();
     const sid = 'ses_v2_incomp';
+    const now = Date.now();
     db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
-      .run(`msg_${++idSeq}`, sid, 'assistant', 1000, 1000, JSON.stringify({
-        time: { created: 1000 },
+      .run(`msg_${++idSeq}`, sid, 'assistant', now, now, JSON.stringify({
+        time: { created: now },
       }));
     db.close();
 
     expect(isOpenCodeSessionBusy(sid, 'v2')).toBe(true);
   });
 
+  it('returns false for stale incomplete message in V2', () => {
+    const db = openV2Db();
+    const sid = 'ses_v2_stale';
+    const staleTime = Date.now() - 600_000;
+    db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
+      .run(`msg_${++idSeq}`, sid, 'assistant', staleTime, staleTime, JSON.stringify({
+        time: { created: staleTime },
+      }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v2')).toBe(false);
+  });
+
   it('returns false when assistant message is completed in session_message', () => {
     const db = openV2Db();
     const sid = 'ses_v2_done';
+    const now = Date.now();
     db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
-      .run(`msg_${++idSeq}`, sid, 'assistant', 1000, 1000, JSON.stringify({
+      .run(`msg_${++idSeq}`, sid, 'assistant', now, now, JSON.stringify({
         finish: 'stop',
-        time: { created: 1000, completed: 2000 },
+        time: { created: now, completed: now + 500 },
       }));
     db.close();
 
@@ -203,17 +261,18 @@ describe('createOpenCodeAdapter isSessionBusy', () => {
     const sid = 'ses_adapterTest';
     const userMid = `msg_${++idSeq}`;
     const asstMid = `msg_${++idSeq}`;
+    const now = Date.now();
 
     db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
-      .run(userMid, sid, 900, JSON.stringify({ role: 'user' }));
+      .run(userMid, sid, now - 1000, JSON.stringify({ role: 'user' }));
     db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
-      .run(`prt_${++idSeq}`, userMid, sid, 900, JSON.stringify({
+      .run(`prt_${++idSeq}`, userMid, sid, now - 1000, JSON.stringify({
         type: 'text',
         text: `<session_id>${BOTMUX_SESSION_ID}</session_id>\n\nhello`,
       }));
 
     db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
-      .run(asstMid, sid, 1000, JSON.stringify({ role: 'assistant', time: { created: 1000 } }));
+      .run(asstMid, sid, now, JSON.stringify({ role: 'assistant', time: { created: now } }));
     db.close();
 
     const adapter = createOpenCodeAdapter();
@@ -231,14 +290,14 @@ describe('createOpenCode2Adapter isSessionBusy', () => {
   it('identifies busy state in V2 tables', () => {
     const db = openV2Db();
     const sid = 'ses_v2AdapterTest';
+    const now = Date.now();
     db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
-      .run(`msg_${++idSeq}`, sid, 'user', 900, 900, JSON.stringify({
+      .run(`msg_${++idSeq}`, sid, 'user', now - 1000, now - 1000, JSON.stringify({
         text: `<session_id>${BOTMUX_SESSION_ID}</session_id>`,
       }));
     db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
-      .run(`msg_${++idSeq}`, sid, 'assistant', 1000, 1000, JSON.stringify({
-        finish: 'tool-calls',
-        time: { created: 1000, completed: 1500 },
+      .run(`msg_${++idSeq}`, sid, 'assistant', now, now, JSON.stringify({
+        time: { created: now },
       }));
     db.close();
 

--- a/test/opencode-busy-state.test.ts
+++ b/test/opencode-busy-state.test.ts
@@ -31,13 +31,14 @@ function openV1Db(): DatabaseSync {
       directory TEXT NOT NULL,
       title TEXT NOT NULL DEFAULT '',
       time_created INTEGER NOT NULL,
-      time_updated INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL DEFAULT 0,
       time_archived INTEGER
     );
     CREATE TABLE IF NOT EXISTS message (
       id TEXT PRIMARY KEY,
       session_id TEXT NOT NULL,
       time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL DEFAULT 0,
       data TEXT NOT NULL
     );
     CREATE TABLE IF NOT EXISTS part (
@@ -45,6 +46,7 @@ function openV1Db(): DatabaseSync {
       message_id TEXT NOT NULL,
       session_id TEXT NOT NULL,
       time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL DEFAULT 0,
       data TEXT NOT NULL
     );
   `);

--- a/test/opencode-busy-state.test.ts
+++ b/test/opencode-busy-state.test.ts
@@ -1,0 +1,249 @@
+/**
+ * OpenCode busy state detection 单测：
+ * 验证基于 SQLite 状态（part 表 running 状态、message 表 completed/finish 状态）
+ * 对 OpenCode (V1) 和 OpenCode2 (V2) 会话忙碌态（工具执行中、模型思考中）的精准识别。
+ *
+ * Run:  npx vitest run test/opencode-busy-state.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+import { createOpenCodeAdapter, isOpenCodeSessionBusy } from '../src/adapters/cli/opencode.js';
+import { createOpenCode2Adapter } from '../src/adapters/cli/opencode2.js';
+import { opencodeDbPath } from '../src/services/opencode-paths.js';
+
+const BOTMUX_SESSION_ID = '0a1b2c3d-1111-4222-8333-444455556666';
+
+let tmpRoot: string;
+let savedXdg: string | undefined;
+
+function openV1Db(): DatabaseSync {
+  const dbPath = opencodeDbPath();
+  mkdirSync(join(dbPath, '..'), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session (
+      id TEXT PRIMARY KEY,
+      parent_id TEXT,
+      directory TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      time_archived INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+function openV2Db(): DatabaseSync {
+  const dbPath = opencodeDbPath();
+  mkdirSync(join(dbPath, '..'), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_v2 (
+      id TEXT PRIMARY KEY,
+      parent_id TEXT,
+      directory TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      time_archived INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS session_message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+let idSeq = 0;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'oc-busy-unit-'));
+  savedXdg = process.env.XDG_DATA_HOME;
+  process.env.XDG_DATA_HOME = tmpRoot;
+});
+
+afterEach(() => {
+  if (savedXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = savedXdg;
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('isOpenCodeSessionBusy V1', () => {
+  it('returns true when a tool part is running', () => {
+    const db = openV1Db();
+    const sid = 'ses_v1_running_tool';
+    const mid = `msg_${++idSeq}`;
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+      .run(mid, sid, 1000, JSON.stringify({ role: 'assistant', time: { created: 1000 } }));
+    db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
+      .run(`prt_${++idSeq}`, mid, sid, 1000, JSON.stringify({
+        type: 'tool',
+        tool: 'bash',
+        state: { status: 'running' },
+      }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(true);
+  });
+
+  it('returns true when assistant message is not completed yet', () => {
+    const db = openV1Db();
+    const sid = 'ses_v1_generating';
+    const mid = `msg_${++idSeq}`;
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+      .run(mid, sid, 1000, JSON.stringify({ role: 'assistant', time: { created: 1000 } }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(true);
+  });
+
+  it('returns true when assistant message finish is tool-calls', () => {
+    const db = openV1Db();
+    const sid = 'ses_v1_tool_calls';
+    const mid = `msg_${++idSeq}`;
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+      .run(mid, sid, 1000, JSON.stringify({
+        role: 'assistant',
+        finish: 'tool-calls',
+        time: { created: 1000, completed: 1500 },
+      }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(true);
+  });
+
+  it('returns false when assistant message is completed with finish stop and no running parts', () => {
+    const db = openV1Db();
+    const sid = 'ses_v1_done';
+    const mid = `msg_${++idSeq}`;
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+      .run(mid, sid, 1000, JSON.stringify({
+        role: 'assistant',
+        finish: 'stop',
+        time: { created: 1000, completed: 2000 },
+      }));
+    db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
+      .run(`prt_${++idSeq}`, mid, sid, 1000, JSON.stringify({
+        type: 'tool',
+        tool: 'bash',
+        state: { status: 'completed' },
+      }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v1')).toBe(false);
+  });
+});
+
+describe('isOpenCodeSessionBusy V2', () => {
+  it('returns true when a tool part is running in session_message', () => {
+    const db = openV2Db();
+    const sid = 'ses_v2_running';
+    db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
+      .run(`msg_${++idSeq}`, sid, 'tool', 1000, 1000, JSON.stringify({
+        type: 'tool',
+        state: { status: 'running' },
+      }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v2')).toBe(true);
+  });
+
+  it('returns true when assistant message is incomplete in session_message', () => {
+    const db = openV2Db();
+    const sid = 'ses_v2_incomp';
+    db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
+      .run(`msg_${++idSeq}`, sid, 'assistant', 1000, 1000, JSON.stringify({
+        time: { created: 1000 },
+      }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v2')).toBe(true);
+  });
+
+  it('returns false when assistant message is completed in session_message', () => {
+    const db = openV2Db();
+    const sid = 'ses_v2_done';
+    db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
+      .run(`msg_${++idSeq}`, sid, 'assistant', 1000, 1000, JSON.stringify({
+        finish: 'stop',
+        time: { created: 1000, completed: 2000 },
+      }));
+    db.close();
+
+    expect(isOpenCodeSessionBusy(sid, 'v2')).toBe(false);
+  });
+});
+
+describe('createOpenCodeAdapter isSessionBusy', () => {
+  it('identifies busy state using cliSessionId and fallback session id text lookup', () => {
+    const db = openV1Db();
+    const sid = 'ses_adapterTest';
+    const userMid = `msg_${++idSeq}`;
+    const asstMid = `msg_${++idSeq}`;
+
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+      .run(userMid, sid, 900, JSON.stringify({ role: 'user' }));
+    db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
+      .run(`prt_${++idSeq}`, userMid, sid, 900, JSON.stringify({
+        type: 'text',
+        text: `<session_id>${BOTMUX_SESSION_ID}</session_id>\n\nhello`,
+      }));
+
+    db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+      .run(asstMid, sid, 1000, JSON.stringify({ role: 'assistant', time: { created: 1000 } }));
+    db.close();
+
+    const adapter = createOpenCodeAdapter();
+    expect(adapter.isSessionBusy).toBeDefined();
+
+    // 1. Direct cliSessionId lookup
+    expect(adapter.isSessionBusy?.({ sessionId: 'dummy', cliSessionId: sid })).toBe(true);
+
+    // 2. Fallback via embedded botmux session id
+    expect(adapter.isSessionBusy?.({ sessionId: BOTMUX_SESSION_ID })).toBe(true);
+  });
+});
+
+describe('createOpenCode2Adapter isSessionBusy', () => {
+  it('identifies busy state in V2 tables', () => {
+    const db = openV2Db();
+    const sid = 'ses_v2AdapterTest';
+    db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
+      .run(`msg_${++idSeq}`, sid, 'user', 900, 900, JSON.stringify({
+        text: `<session_id>${BOTMUX_SESSION_ID}</session_id>`,
+      }));
+    db.prepare('INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?,?,?,?,?,?)')
+      .run(`msg_${++idSeq}`, sid, 'assistant', 1000, 1000, JSON.stringify({
+        finish: 'tool-calls',
+        time: { created: 1000, completed: 1500 },
+      }));
+    db.close();
+
+    const adapter = createOpenCode2Adapter();
+    expect(adapter.isSessionBusy).toBeDefined();
+    expect(adapter.isSessionBusy?.({ sessionId: BOTMUX_SESSION_ID })).toBe(true);
+  });
+});

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -694,7 +694,7 @@ describe('worker pipe initial screen ordering', () => {
     const helper = source.slice(helperStart, helperEnd);
 
     expect(helperStart).toBeGreaterThan(-1);
-    expect(helper).toContain('if (!cliAdapter?.busyPattern || (!be.captureCurrentScreen && !be.captureViewport)) return;');
+    expect(helper).toContain('if ((!cliAdapter?.busyPattern && !cliAdapter?.isSessionBusy) || (!be.captureCurrentScreen && !be.captureViewport && !cliAdapter?.isSessionBusy)) return;');
     expect(helper).toContain('if (backend !== be || !awaitingFirstPrompt || isPromptReady) return;');
     expect(helper).not.toContain('pendingMessages.length > 0');
   });

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -502,13 +502,16 @@ describe('worker structured-turn status wiring', () => {
     // the busy pattern, so a stale Working... in ZMX history can never block
     // a structured terminal; on a busy authoritative viewport it re-arms the
     // detector and reuses the busy-pattern probe until the marker clears.
+    // Non-visual session busy checks (isSessionBusy) run ahead of screen gates.
     const defer = functionSlice('deferPromptReadyWhileBusy', 'probeBusyPatternIdle');
+    const dbGate = defer.indexOf('cliAdapter?.isSessionBusy');
     const authoritativeGate = defer.indexOf('!backendScreenEvidenceIsAuthoritativeForMutation()');
     const busyTest = defer.indexOf('cliAdapter.busyPattern.test(');
-    expect(authoritativeGate).toBeGreaterThanOrEqual(0);
+    expect(dbGate).toBeGreaterThanOrEqual(0);
+    expect(authoritativeGate).toBeGreaterThan(dbGate);
     expect(busyTest).toBeGreaterThan(authoritativeGate);
-    expect(defer.indexOf('idleDetector?.reset()')).toBeGreaterThan(busyTest);
-    expect(defer.indexOf('scheduleBusyPatternIdleProbe(source)')).toBeGreaterThan(busyTest);
+    expect(defer.indexOf('idleDetector?.reset()', busyTest)).toBeGreaterThan(busyTest);
+    expect(defer.indexOf('scheduleBusyPatternIdleProbe(source)', busyTest)).toBeGreaterThan(busyTest);
 
     // The re-armed probe itself refuses to arm on non-authoritative backends,
     // so a deferred ZMX turn can never be pinned by the probe loop.


### PR DESCRIPTION
## 改了什么、为什么

在 OpenCode (V1/V2) 会话中，当 Agent 执行长耗时 Tool Call（如 Bash/网络请求）或进行模型深度思考（Thinking/Reasoning）时，PTY 终端输出会产生超过 2 秒的静默窗口。由于 OpenCode 此前仅依赖纯终端静默超时探测（`quiescence`），Botmux 的 `IdleDetector` 会误以为该轮交互已结束并提前触发 `markIdle()`，导致飞书卡片过早跳变为「等待输入」（而底层 OpenCode 仍在执行）。

### 解决方案
1. **适配器层声明 `isSessionBusy` 非视觉状态探针**：
   - 接入 SQLite 状态流探针 `isOpenCodeSessionBusy`：查询 `part` / `session_message` 表中是否存在时效窗口（默认 2 分钟 `OPENCODE_BUSY_FRESHNESS_MS = 120_000`）内处于 `status: "running"` 的 tool part，或最新 assistant 消息是否处于时效内未完成态（未填充 `completed` 时间戳）；
   - 增加时效窗口过滤（`time_created > freshBaseline`），彻底防御进程异常崩溃/强杀后残留孤儿未完成记录导致的死锁。
2. **Worker 层接入 `isSessionBusy` 拦截**：
   - `deferPromptReadyWhileBusy` 接入 `cliAdapter.isSessionBusy` 检查（按 `lastSpawnEffectiveCliSessionId ?? lastInitConfig?.cliSessionId` 优先级），当数据库判定会话仍处于 busy 时，自动拦截并调度 `scheduleBusyPatternIdleProbe` 轮询重检；
   - `probeBusyPatternIdle` 在数据库状态变为终态时安全触发权威屏幕 settle 并释放 `markPromptReady()`。
3. **单测与源码守卫**：
   - 新增 `test/opencode-busy-state.test.ts`，全量覆盖 OpenCode V1/V2 的 running tool、未完成消息、中间工具调用以及完成态判定逻辑，并覆盖时效窗口边界；
   - 同步更新既有源码守卫测试断言（`test/worker-pipe-initial-screen-order.test.ts` 和 `test/worker-structured-lifecycle-status.test.ts`）。

### 边界与后续演进说明
- **当前时效边界**：基于单轮开始时效窗口（120s）。由于 OpenCode 的 `message`/`part` 表持久化模型为开始与完成写入，超长单步任务（>120s）在窗口超期后会优雅降级回既有的静默探测机制；
- **后续演进方向**：在后续独立迭代中，可结合 OpenCode 1.17+ 的 `event` 表增量心跳与 worker PID 存活性检测做进一步延伸。

## 影响面
- 增强 OpenCode / OpenCode2 在长耗时工具调用及静默期的状态准确性，不影响其他 CLI 既有逻辑。