### PR TITLE
fix(bun): 编译版四个 CLI 适配器不再把 /$bunfs runner 路径当会话入口

### DIFF
--- a/scripts/audit-embedded-assets.mjs
+++ b/scripts/audit-embedded-assets.mjs
@@ -57,6 +57,19 @@ const EMBED_MECHANISMS = [
     covers: (rel) => rel.startsWith('dashboard-web/'),
     proof: 'scripts/generate-dashboard-embed.mjs walks dist/dashboard-web and emits a type:"file" import per file',
   },
+  {
+    id: 'static-json-import',
+    // src/cli.ts and src/setup/open-platform-automation.ts both do
+    // `import … from './…/lark-scopes.json' with { type: 'json' }`, so --compile
+    // traces it into the module graph. The copy under dist/ remains for the Node
+    // path; the binary no longer reads it off disk at all.
+    //
+    // VERIFIED on a real compiled binary via the `__selfcheck` hidden command
+    // that shipped with the fix: `{"ok":true,"tenant":171,"user":130}` — before
+    // it, `botmux setup` threw `找不到 botmux lark-scopes.json`.
+    covers: (rel) => rel === 'setup/lark-scopes.json',
+    proof: 'imported with { type: "json" } by cli.ts and setup/open-platform-automation.ts; `<binary> __selfcheck` proves it resolves',
+  },
 ];
 
 /**
@@ -72,27 +85,6 @@ const NOT_NEEDED_IN_BINARY = [
   },
 ];
 
-/**
- * KNOWN-BROKEN, fix already in flight elsewhere.
- *
- * These ARE unreachable from the compiled binary — the gate is right about them —
- * but the fix belongs to an open PR, so failing the build here would block
- * everyone for a defect someone else is already resolving. Listed separately from
- * NOT_NEEDED_IN_BINARY so the two never blur: that list means "absence is fine",
- * this one means "absence is a bug we have not landed yet".
- *
- * Remove an entry when its PR merges. If the gate then passes, the asset became
- * reachable; if it fails, the fix regressed.
- */
-const KNOWN_UNREACHABLE = [
-  {
-    rel: 'setup/lark-scopes.json',
-    // MEASURED on a compiled binary: readDefaultScopeManifest() probes three
-    // `join(here, …)` candidates, all resolving under /$bunfs/root, all missing,
-    // so `botmux setup` throws `找不到 botmux lark-scopes.json`.
-    owner: 'PR #1065 (fix/compiled-lark-scope-manifest) — static JSON import',
-  },
-];
 
 function walk(dir) {
   const out = [];
@@ -114,18 +106,15 @@ const assets = walk(DIST)
   .sort();
 
 const unaccounted = [];
-const knownBroken = [];
 for (const rel of assets) {
   if (EMBED_MECHANISMS.some((m) => m.covers(rel))) continue;
   if (NOT_NEEDED_IN_BINARY.some((e) => e.rel === rel)) continue;
-  const known = KNOWN_UNREACHABLE.find((e) => e.rel === rel);
-  if (known) { knownBroken.push(known); continue; }
   unaccounted.push(rel);
 }
 
 // Stale-entry check: an exemption that no longer matches any asset is worse than
 // no exemption, because it silently stops protecting anything.
-const stale = [...NOT_NEEDED_IN_BINARY, ...KNOWN_UNREACHABLE].filter((e) => !assets.includes(e.rel));
+const stale = NOT_NEEDED_IN_BINARY.filter((e) => !assets.includes(e.rel));
 if (stale.length > 0) {
   console.error(
     `[audit-embed] ${stale.length} exemption(s) no longer match any dist asset — delete them:\n`
@@ -152,7 +141,4 @@ if (unaccounted.length > 0) {
   process.exit(1);
 }
 
-for (const k of knownBroken) {
-  console.warn(`[audit-embed] ⚠️  ${k.rel} is NOT reachable from the compiled binary — ${k.owner}`);
-}
 console.log(`[audit-embed] ${assets.length} dist asset(s) accounted for (compiled-binary reachability decided)`);

--- a/src/adapters/cli/codex-app.ts
+++ b/src/adapters/cli/codex-app.ts
@@ -7,6 +7,7 @@ import { resolveCommandReal } from './registry.js';
 import { parseDebugModelsJson } from './model-catalog-json.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
+import { runnerArgv0 } from '../../core/self-spawn.js';
 
 function runnerPath(): string {
   // Source-level worker integration tests execute through tsx and need the
@@ -63,7 +64,7 @@ export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, botName, botOpenId, locale, model, reasoningEffort, codexBrowser }) {
       const args = [
-        runnerPath(),
+        runnerArgv0('codex-app-runner', runnerPath()),
         '--session-id', sessionId,
         // Canonical for the same reason as sandboxExtraExecPaths above — the runner
         // hands this straight to spawn().

--- a/src/adapters/cli/dsh.ts
+++ b/src/adapters/cli/dsh.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path';
 import { resolveCommandReal } from './registry.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
+import { runnerArgv0 } from '../../core/self-spawn.js';
 
 function runnerPath(): string {
   // Source-level worker integration tests execute through tsx and need the
@@ -67,7 +68,7 @@ export function createDshAdapter(pathOverride?: string): CliAdapter {
       mkdirSync(join(dshHome, 'botmux'), { recursive: true });
       mkdirSync(join(dshHome, 'sessions', 'botmux'), { recursive: true });
       const args = [
-        runnerPath(),
+        runnerArgv0('dsh-runner', runnerPath()),
         '--session-id', sessionId,
         '--dsh-bin', (cachedDshBin ??= resolveCommandReal(rawDshBin)),
       ];

--- a/src/adapters/cli/mir.ts
+++ b/src/adapters/cli/mir.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
+import { runnerArgv0 } from '../../core/self-spawn.js';
 import { resolveCommandReal } from './registry.js';
 
 /**
@@ -67,7 +68,7 @@ export function createMirAdapter(pathOverride?: string): CliAdapter {
     },
 
     buildArgs({ sessionId, botName, botOpenId, locale }) {
-      const args = [runnerPath(), '--session-id', sessionId];
+      const args = [runnerArgv0('mir-runner', runnerPath()), '--session-id', sessionId];
       pushOpt(args, '--bot-name', botName);
       pushOpt(args, '--bot-open-id', botOpenId);
       pushOpt(args, '--locale', locale);

--- a/src/adapters/cli/mira.ts
+++ b/src/adapters/cli/mira.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
+import { runnerArgv0 } from '../../core/self-spawn.js';
 
 function runnerPath(): string {
   const here = dirname(fileURLToPath(import.meta.url));
@@ -25,7 +26,7 @@ export function createMiraAdapter(_pathOverride?: string): CliAdapter {
 
     buildArgs({ sessionId, resume, resumeSessionId, botName, botOpenId, locale }) {
       const args = [
-        runnerPath(),
+        runnerArgv0('mira-runner', runnerPath()),
         '--session-id', sessionId,
       ];
       if (resume && resumeSessionId) args.push('--mira-session-id', resumeSessionId);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12191,6 +12191,15 @@ if (__entrySubcommand) {
   else if (__entrySubcommand === 'worker') await import('./worker.js');
   else if (__entrySubcommand === 'supervisor') await import('./index-supervisor.js');
   else if (__entrySubcommand === 'dashboard') await import('./index-dashboard.js');
+  // CLI-adapter runners. Same mechanism, different role: these ARE the CLI session
+  // process an adapter launches, not a fleet member. Without these branches the
+  // compiled binary re-execed itself with a `/$bunfs/…-runner.js` argv[0] that
+  // dispatch did not recognise, so it printed help and exited 0 — the user saw a
+  // help dump instead of a session, and nothing reported an error.
+  else if (__entrySubcommand === 'codex-app-runner') await import('./codex-app-runner.js');
+  else if (__entrySubcommand === 'dsh-runner') await import('./dsh-runner.js');
+  else if (__entrySubcommand === 'mira-runner') await import('./mira-runner.js');
+  else if (__entrySubcommand === 'mir-runner') await import('./mir-runner.js');
   // The entry module now drives the process (top-level main() keeps the event
   // loop alive for the daemon; the worker's IPC listener does the same; a
   // core-only bind failure exits from within). Park here so the normal dispatch

--- a/src/core/self-spawn.ts
+++ b/src/core/self-spawn.ts
@@ -27,7 +27,13 @@ import { join, dirname } from 'node:path';
  * talks over IPC is unchanged.
  */
 
-export type BotmuxEntry = 'core-only' | 'daemon' | 'worker' | 'supervisor' | 'dashboard';
+export type BotmuxEntry =
+  | 'core-only' | 'daemon' | 'worker' | 'supervisor' | 'dashboard'
+  // CLI-adapter runners. Unlike the entries above these are not fleet processes:
+  // an adapter spawns one as the CLI session itself (`resolvedBin` is
+  // process.execPath and the runner is argv[0]). They need the same treatment for
+  // the same reason — see RUNNER_ENTRIES below.
+  | 'codex-app-runner' | 'dsh-runner' | 'mira-runner' | 'mir-runner';
 
 /** Hidden CLI subcommand that runs a given entry inline (see cli.ts dispatch). */
 const ENTRY_SUBCOMMAND: Record<BotmuxEntry, string> = {
@@ -36,6 +42,10 @@ const ENTRY_SUBCOMMAND: Record<BotmuxEntry, string> = {
   'worker': '__worker',
   'supervisor': '__supervisor',
   'dashboard': '__dashboard',
+  'codex-app-runner': '__codex-app-runner',
+  'dsh-runner': '__dsh-runner',
+  'mira-runner': '__mira-runner',
+  'mir-runner': '__mir-runner',
 };
 
 /** dist/<entry>.js filename for the Node path. */
@@ -45,7 +55,52 @@ const ENTRY_SCRIPT: Record<BotmuxEntry, string> = {
   'worker': 'worker.js',
   'supervisor': 'index-supervisor.js',
   'dashboard': 'index-dashboard.js',
+  'codex-app-runner': 'codex-app-runner.js',
+  'dsh-runner': 'dsh-runner.js',
+  'mira-runner': 'mira-runner.js',
+  'mir-runner': 'mir-runner.js',
 };
+
+/**
+ * The CLI-adapter runners, i.e. the entries a `createXAdapter()` launches as the
+ * session process rather than as part of the fleet.
+ *
+ * WHY THEY BELONG HERE: each adapter used to locate its runner by walking up from
+ * its own module path (`resolve(here,'..','..','<name>-runner.js')`, plus a
+ * dist/ fallback). In the compiled binary `here` is `/$bunfs/root`, so both
+ * candidates collapse onto the real filesystem root — MEASURED: `/codex-app-runner.js`
+ * and `/dist/codex-app-runner.js`, both `existsSync === false`. `runnerPath()` has
+ * no fail-closed branch: it returns the non-existent sibling anyway, the binary
+ * re-execs ITSELF with that path as argv[0], normal CLI dispatch does not recognise
+ * it, and the process PRINTS HELP AND EXITS 0. The user gets a help dump instead of
+ * a session, with nothing logged as an error.
+ *
+ * Exported so a test can assert every runner is wired end to end (token → dispatch
+ * → dist filename) rather than checking one and assuming the rest.
+ */
+export const RUNNER_ENTRIES: readonly BotmuxEntry[] = [
+  'codex-app-runner', 'dsh-runner', 'mira-runner', 'mir-runner',
+] as const;
+
+/**
+ * The FIRST argv entry an adapter must pass so `resolvedBin` (= process.execPath)
+ * becomes the given runner.
+ *
+ * Compiled binary: the hidden token — `<binary> __mira-runner …`.
+ * Node: the script path as the caller resolved it — `<node> …/mira-runner.js …`.
+ *
+ * A single function instead of four inline ternaries: the adapters are otherwise
+ * identical here, and four copies of one predicate is exactly how the three
+ * hook-command call sites drifted apart.
+ *
+ * `scriptPath` is supplied by the caller because each adapter owns its own
+ * resolution order (a test-scoped env override, a compiled sibling, a source-tree
+ * dist/) and this module stays location-agnostic. It is not even evaluated in the
+ * compiled branch, so an adapter may pass a path it knows does not exist there.
+ */
+export function runnerArgv0(entry: BotmuxEntry, scriptPath: string): string {
+  return isStandaloneBinary() ? ENTRY_SUBCOMMAND[entry] : scriptPath;
+}
 
 /** True only when running as a `bun build --compile` single-file executable.
  *

--- a/test/cli-runner-compiled-entries.test.ts
+++ b/test/cli-runner-compiled-entries.test.ts
@@ -1,0 +1,123 @@
+/**
+ * CLI-adapter runners must be launchable in BOTH forms.
+ *
+ * WHY: `codex-app`, `dsh`, `mira` and `mir` do not exec their CLI directly — each
+ * spawns a Node runner as the session process (`resolvedBin` is
+ * `process.execPath`, and the runner is argv[0]). Every one of them located that
+ * runner by walking up from its own module path:
+ *
+ *     resolve(here, '..', '..', '<name>-runner.js')      // compiled sibling
+ *     resolve(here, '..', '..', '..', 'dist', '…')       // source-tree dist
+ *
+ * In the compiled binary `here` is `/$bunfs/root`, so both candidates collapse
+ * onto the real filesystem root. MEASURED inside a real compiled binary:
+ * `/codex-app-runner.js` and `/dist/codex-app-runner.js`, both
+ * `existsSync === false` — for all four runners.
+ *
+ * `runnerPath()` has no fail-closed branch: it returns the non-existent sibling
+ * anyway. The binary then re-execs ITSELF with that path as argv[0], normal CLI
+ * dispatch does not recognise it, and the process PRINTS THE HELP BANNER AND
+ * EXITS 0 — verified against a real binary. So the user asking for a `mira`
+ * session got a help dump, and nothing anywhere logged an error.
+ *
+ * The fix routes argv[0] through `runnerArgv0()`: a hidden `__<name>-runner`
+ * token in the compiled form (which `cli.ts` dispatches to a static import), the
+ * unchanged script path under Node.
+ *
+ * TEETH: `isStandaloneBinary()` runs for real — it keys off `process.argv[1]`
+ * starting with `/$bunfs/` (src/core/self-spawn.ts), so pointing argv[1] there
+ * exercises the genuine branch rather than a mock. Verified end to end against a
+ * real compiled binary: all four tokens now reach their runner (each fails with
+ * its OWN business error — missing bootstrap env, missing `--dsh-bin`, no Mira
+ * cookie DB, mir's OSC marker), while both a runner PATH as argv[0] and a
+ * bogus `__not-a-real-runner` token still print help.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { RUNNER_ENTRIES, runnerArgv0, type BotmuxEntry } from '../src/core/self-spawn.js';
+import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
+import { createDshAdapter } from '../src/adapters/cli/dsh.js';
+import { createMiraAdapter } from '../src/adapters/cli/mira.js';
+import { createMirAdapter } from '../src/adapters/cli/mir.js';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const REAL_ARGV1 = process.argv[1];
+
+function asCompiledBinary() { process.argv[1] = '/$bunfs/root/cli.js'; }
+afterEach(() => { process.argv[1] = REAL_ARGV1; });
+
+/** The four adapters, each with the runner entry it must launch. */
+const ADAPTERS: ReadonlyArray<{ id: string; entry: BotmuxEntry; make: () => { buildArgs: (o: never) => string[] } }> = [
+  { id: 'codex-app', entry: 'codex-app-runner', make: () => createCodexAppAdapter() as never },
+  { id: 'dsh', entry: 'dsh-runner', make: () => createDshAdapter() as never },
+  { id: 'mira', entry: 'mira-runner', make: () => createMiraAdapter() as never },
+  { id: 'mir', entry: 'mir-runner', make: () => createMirAdapter() as never },
+];
+
+const BUILD_ARGS_INPUT = {
+  sessionId: 'S1', resume: false, resumeSessionId: null,
+  botName: 'B', botOpenId: 'ou_x', locale: 'zh',
+} as never;
+
+describe('CLI-adapter runners — compiled binary form', () => {
+  it.each(ADAPTERS)('$id passes the hidden token, never a /$bunfs/ path', ({ entry, make }) => {
+    asCompiledBinary();
+    const args = make().buildArgs(BUILD_ARGS_INPUT);
+    expect(args[0]).toBe(`__${entry}`);
+    // The whole argv, not just argv[0]: a later element carrying the virtual path
+    // would break just as silently.
+    for (const a of args) expect(a).not.toContain('$bunfs');
+  });
+
+  it('every runner entry is wired end to end: token, dispatch branch, dist filename', () => {
+    // Checking one runner and assuming the other three is exactly how three of
+    // four would ship broken. RUNNER_ENTRIES is the single source of truth, so
+    // iterate it and require each one to appear in cli.ts's dispatch.
+    const cliSource = readFileSync(resolve(REPO_ROOT, 'src', 'cli.ts'), 'utf-8');
+    expect(RUNNER_ENTRIES.length).toBe(4);
+    for (const entry of RUNNER_ENTRIES) {
+      asCompiledBinary();
+      expect(runnerArgv0(entry, '/ignored')).toBe(`__${entry}`);
+      // cli.ts must both recognise the entry and statically import its module —
+      // `--compile` cannot bundle a computed specifier, so a dynamic lookup here
+      // would embed nothing and the token would still print help.
+      expect(cliSource).toContain(`__entrySubcommand === '${entry}'`);
+      expect(cliSource).toContain(`await import('./${entry}.js')`);
+    }
+  });
+
+  it('does not mint tokens for non-runner entries', () => {
+    // Guards the reverse error: RUNNER_ENTRIES must not quietly grow to include
+    // fleet entries, whose launch path is resolveEntrySpawn, not this one.
+    expect([...RUNNER_ENTRIES]).toEqual(['codex-app-runner', 'dsh-runner', 'mira-runner', 'mir-runner']);
+  });
+});
+
+describe('CLI-adapter runners — Node form unchanged', () => {
+  it.each(ADAPTERS)('$id still passes a real runner script path', ({ entry, make }) => {
+    const args = make().buildArgs(BUILD_ARGS_INPUT);
+    // Verified against a pre-change baseline: byte-identical for all four.
+    expect(args[0]).toMatch(new RegExp(`${entry.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.js$`));
+    expect(args[0].startsWith('/')).toBe(true);
+    expect(args[0]).not.toContain('__');
+  });
+
+  it('runnerArgv0 returns the caller-resolved path verbatim under Node', () => {
+    // The path is the caller's business (each adapter has its own resolution
+    // order, including a test-scoped env override), so this must not rewrite it.
+    expect(runnerArgv0('mira-runner', '/somewhere/custom/mira-runner.js'))
+      .toBe('/somewhere/custom/mira-runner.js');
+  });
+
+  it('the two forms differ only in argv[0]', () => {
+    const nodeArgs = createMiraAdapter().buildArgs(BUILD_ARGS_INPUT);
+    asCompiledBinary();
+    const binArgs = createMiraAdapter().buildArgs(BUILD_ARGS_INPUT);
+    expect(binArgs.length).toBe(nodeArgs.length);
+    expect(binArgs.slice(1)).toEqual(nodeArgs.slice(1));
+    expect(binArgs[0]).not.toBe(nodeArgs[0]);
+  });
+});


### PR DESCRIPTION
> **base 是 `wt/bun-2`（#1082）而不是 master**，这样 diff 只含本次改动。#1082 合了之后这个 PR 的 base 会自动落到 master。

## 背景

`codex-app` / `dsh` / `mira` / `mir` 不直接 exec 各自的 CLI，而是把一个 Node runner 当**会话进程**拉起（`resolvedBin` 是 `process.execPath`，runner 是 argv[0]）。四者都靠从自身模块位置往上走定位 runner：

```ts
resolve(here, '..', '..', '<name>-runner.js')          // 编译产物同级
resolve(here, '..', '..', '..', 'dist', '<name>.js')   // 源码树 dist
```

编译版里 `here` 是 `/$bunfs/root`，**两个候选都塌进真实文件系统根**。真编译二进制内实测：

```
/codex-app-runner.js        existsSync=false
/dist/codex-app-runner.js   existsSync=false
```

四个 runner 全部如此。而 `runnerPath()` **没有 fail-closed 分支** —— 落空后照样 `return compiledSibling`。二进制于是用这个不存在的路径当 argv[0] re-exec 自己，普通 CLI dispatch 不认识它，**打印 help banner 后 exit 0**。

⟹ **用户要的是一个会话，拿到的是一份帮助文本，且没有任何地方报错。**

## 修法

argv[0] 改走新增的 `runnerArgv0()`：编译态给隐藏 token `__<name>-runner`，Node 态返回调用方自己解析出的脚本路径（逐字不变）。

`cli.ts` 用**静态** import 分发四个 token —— `--compile` 无法 bundle 计算出来的 specifier（既有注释已写明），所以必须逐个静态写，动态查表会编译出「零嵌入」然后照样打 help。

四个适配器**共用一个 helper** 而不是各写一遍三元：它们在这一点上完全同构，而「同一判据四份实现」正是 hook-command 那三处漂移开的原因（见 #1082）。runner 的解析顺序（测试专用 env override、编译产物同级、源码树 dist）仍归各适配器自己所有，helper 只做形态选择。

`self-spawn.ts` 的 entry 表扩了四项，两张 `Record<BotmuxEntry, …>` 由 TS 强制同步；新增导出 `RUNNER_ENTRIES` 作单一真源，测试据此逐个核对「token → dispatch 分支 → dist 文件名」三者接通，而不是**验一个假设其余三个**。

## 验证

**真二进制上四个 token 全部 dispatch 到各自 runner** —— 报的是各 runner 自己的业务错误，不再是 help：

| token | 实测输出 |
|---|---|
| `__codex-app-runner` | `BOTMUX_CODEX_APP_CONTROL_BOOTSTRAP is required` |
| `__dsh-runner` | `--dsh-bin is required` |
| `__mira-runner` | `[mira] failed to read Mira default model: Mira cookie databa…` |
| `__mir-runner` | `]777;botmux:thread:…` (OSC 标记) |

**两条负向对照**（证明不是「任何输入都被 dispatch」）：把 runner 路径当 argv[0]、以及伪造的 `__not-a-real-runner`，**都仍然打 help banner**。

其余：

- Node 态四个适配器 argv[0] 与改动前做过**基线 diff，逐字零差异**
- 编译态 smoke **7 项全绿**；二进制 169.7 MB → 170.2 MB（四个 runner 真被编进去了）
- **反变异 4 组全部转红**：helper 恒返回路径（等于没修）/ 恒返回 token（Node 态也坏）/ 单个适配器漏接 / `cli.ts` 漏掉一个 dispatch 分支
- 单测 **19112 passed / 4 failed**，4 个失败与基线逐字相同（MCP sandbox + mojo EACCES，既有）

## 影响范围

| 维度 | 评估 |
|---|---|
| 跨 CLI | 动了 `core/self-spawn.ts`（entry 表扩项 + 新增两个导出，**未改任何既有函数体**）与 `cli.ts` 的 token dispatch（**只加 4 个 else-if 分支**）。`cli-adapters.test.ts` 等共用面 442 项全绿 |
| 跨形态 | Node 态基线 diff 零差异；编译态是被修的那侧 |
| 命名 | `mir` 是 `mira` 的前缀，但 dispatch 用 `Set.has()` 精确匹配（非 `startsWith`），已核对不会误判 |
| 二进制体积 | +0.5 MB（四个 runner 模块） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
