### PR TITLE
fix(release): 固定 Linux glibc 基线并保护不兼容升级

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,63 +70,20 @@ jobs:
   # legible at a glance and does not mask unit-test results.
   bun-binary:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-      # Bun is the package manager as well as the runtime here (packageManager:
-      # bun@1.4.0), so this pin governs BOTH `bun install` and the compiled
-      # artifact. CI must exercise the exact Bun that builds what ships.
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.4.0
-
-      # The platform's own install compiles node-pty's build/Release/pty.node for
-      # this OS/arch, which the embed plugin bundles into the binary. That only
-      # happens because node-pty is in `trustedDependencies` — bun does NOT run a
-      # dependency's lifecycle scripts otherwise, and without pty.node there is no
-      # PTY and no working compiled binary.
-      - run: bun install --frozen-lockfile
-
-      - name: Stamp a synthetic version (mirrors the release job)
-        # WHY THIS EXISTS: the compiled binary has no package.json on disk, so the
-        # build BAKES the version in at compile time by reading package.json —
-        # and in the repo that file carries the unbuilt `0.0.0` placeholder, which
-        # the runtime deliberately treats as "nothing baked" (a locally-compiled
-        # dev binary must not report 0.0.0 as authoritative). Compiling straight
-        # from the placeholder therefore yields `--version: unknown`, which is the
-        # exact regression the smoke gate below exists to catch.
-        #
-        # release.yml stamps the real version from the git tag BEFORE compiling
-        # ("Sync version from git tag"). CI has no tag, so stamp a synthetic one
-        # here — same ORDER as release, so this job exercises the same shape the
-        # shipped artifact is built with instead of a placeholder-only path that
-        # can never satisfy the gate.
-        #
-        # Runs after `bun install --frozen-lockfile` on purpose: `npm version`
-        # rewrites package.json, and bun's frozen-lockfile check must see the
-        # committed file. The workspace is ephemeral, so nothing is committed back.
-        run: npm version "0.0.0-ci.${{ github.run_number }}" --no-git-tag-version --allow-same-version
-
-      - run: bun run build
-
-      - name: Compile the host-arch Bun binary
-        run: bun scripts/build-bun-binary.mjs --target bun-linux-x64 --out dist-bin/botmux-linux-x64
-
-      - name: Smoke-test the compiled binary
-        # Runs from a scratch HOME with an empty bots.json — no Feishu
-        # credentials, no live fleet, no interference with anything on the runner.
-        #
-        # The empty bots.json is why checks 1-4 cannot reach the daemon: it refuses
-        # to start with 0 bots ("Invalid BOTMUX_BOT_INDEX=0"), so writePidFile —
-        # and the wrapper write that once overwrote the binary itself — is
-        # structurally unreachable. Check 5 in the script covers that path directly
-        # instead of booting a credentialed bot.
-        run: node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64
+      - name: Build and smoke on the supported glibc 2.28 floor
+        # node-pty is compiled on the build host. ubuntu-latest raised the embedded
+        # native to GLIBC_2.34, even though Node 22 and Bun still run on 2.28.
+        # Build inside manylinux_2_28 and execute the full smoke there so the PR
+        # gate is byte-for-byte the same compatibility boundary as release.
+        run: |
+          scripts/build-linux-glibc-baseline.sh \
+            bun-linux-x64 dist-bin/botmux-linux-x64 \
+            "0.0.0-ci.${{ github.run_number }}"
 
   # The musl (Alpine) binary, gated on PRs — not only at release time.
   #
@@ -257,4 +214,3 @@ jobs:
           for f in botmux-*; do sha256sum "$f" > "$f.sha256"; done
           ls -la
           echo "✅ host user wrote checksums into a container-produced directory"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -615,8 +615,8 @@ jobs:
     # `pty.node` (and macOS `spawn-helper`) must match the target OS. Bun can
     # cross-compile the JS + runtime, but the embedded `.node` has to be the one
     # `bun install` compiled ON that OS. So we build each OS's binaries on its
-    # own native runner (linux -> ubuntu, darwin -> macos-14), where build/Release
-    # is correct; each runner emits both of its architectures.
+    # own native architecture. Linux compiles inside manylinux_2_28 so the embedded
+    # native stays compatible with Node 22's glibc floor; darwin uses macos-14.
     needs: [preflight]
     # WHY a per-OS **and per-arch** matrix: node-pty's native `pty.node` (and
     # macOS `spawn-helper`) must match the target. Bun can cross-compile the JS +
@@ -634,7 +634,7 @@ jobs:
     # same leg — and with the release order inverted, `binary-subpackages` and
     # `release` both `needs` this job, so the whole publish chain stalled.
     # Hence linux-arm64 gets its own native arm64 runner (`ubuntu-24.04-arm`,
-    # GA and free for public repos).
+    # GA and free for public repos), which runs the aarch64 manylinux container.
     strategy:
       fail-fast: false
       matrix:
@@ -642,12 +642,15 @@ jobs:
           - os: ubuntu-latest
             targets: bun-linux-x64
             artifact: linux-x64
+            glibc_baseline: '2.28'
           - os: ubuntu-24.04-arm
             targets: bun-linux-arm64
             artifact: linux-arm64
+            glibc_baseline: '2.28'
           - os: macos-14
             targets: bun-darwin-x64 bun-darwin-arm64
             artifact: darwin
+            glibc_baseline: ''
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -657,21 +660,35 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
+        if: matrix.glibc_baseline == ''
         with:
           node-version: 22
       - uses: oven-sh/setup-bun@v2
+        if: matrix.glibc_baseline == ''
         with:
           bun-version: 1.4.0
       # --frozen-lockfile + the platform's own install compiles node-pty's
       # build/Release/pty.node for THIS OS/arch, which the embed plugin bundles.
-      - run: bun install --frozen-lockfile
+      - if: matrix.glibc_baseline == ''
+        run: bun install --frozen-lockfile
 
       - name: Sync version from git tag to package.json
+        if: matrix.glibc_baseline == ''
         run: npm version "${RELEASE_TAG#v}" --no-git-tag-version --allow-same-version
 
-      - run: bun run build
+      - if: matrix.glibc_baseline == ''
+        run: bun run build
+
+      - name: Build Linux binary on the glibc 2.28 floor
+        if: matrix.glibc_baseline != ''
+        run: |
+          target="${{ matrix.targets }}"
+          scripts/build-linux-glibc-baseline.sh \
+            "$target" "dist-bin/botmux-${target#bun-}" \
+            "${RELEASE_TAG#v}"
 
       - name: Compile Bun single-file executables
+        if: matrix.glibc_baseline == ''
         # Build each target this runner is responsible for. The script fails
         # closed if a target's native (pty.node) is absent rather than shipping a
         # broken binary.
@@ -682,6 +699,7 @@ jobs:
           done
 
       - name: Smoke-test the host-arch binary
+        if: matrix.glibc_baseline == ''
         # Each leg executes the binary it just built for its OWN arch, so with the
         # per-arch matrix every linux target is now genuinely run (linux-x64 on the
         # x64 runner, linux-arm64 on the arm64 runner). Only darwin still has one

--- a/install.sh
+++ b/install.sh
@@ -100,10 +100,22 @@ else
   printf '%s\n' "⚠ no checksum published for $asset; skipping verification"
 fi
 
-# ── Install ───────────────────────────────────────────────────────────────────
+# ── Probe + atomically install ────────────────────────────────────────────────
+# os/arch/libc selection cannot express the minimum glibc symbol version. Run the
+# exact candidate before replacing a working installation: `--version` loads the
+# embedded node-pty native, so a GLIBC_x.y mismatch surfaces here without starting
+# a daemon or touching bot data. Stage on the destination filesystem so the final
+# rename is atomic even when /tmp and $INSTALL_DIR are different mounts.
 mkdir -p "$INSTALL_DIR"
 chmod +x "$tmp/$asset"
-mv "$tmp/$asset" "$INSTALL_DIR/botmux"
+candidate="$INSTALL_DIR/.botmux-install-$$"
+cp "$tmp/$asset" "$candidate"
+chmod +x "$candidate"
+trap 'rm -rf "$tmp"; rm -f "$candidate"' EXIT
+if ! probe_output="$("$candidate" --version 2>&1)"; then
+  err "downloaded $asset cannot run on this host; existing botmux was preserved: $probe_output"
+fi
+mv "$candidate" "$INSTALL_DIR/botmux"
 printf '%s\n' "✅ installed botmux → $INSTALL_DIR/botmux"
 
 # ── PATH: write it, don't just suggest it ─────────────────────────────────────

--- a/scripts/build-linux-glibc-baseline.sh
+++ b/scripts/build-linux-glibc-baseline.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# Build a Linux release binary inside the oldest supported glibc runtime.
+#
+# node-pty has no Linux prebuild, so its install script compiles pty.node against
+# the BUILDER's libc. Building on ubuntu-latest silently raised the shipped
+# binary's floor to GLIBC_2.34. Node 22 itself supports glibc 2.28, so keep that as
+# Botmux's explicit Linux floor and smoke the complete binary inside the same
+# manylinux_2_28 environment before it can become a release artifact.
+set -eu
+
+target="${1:-}"
+out="${2:-}"
+version="${3:-}"
+[ -n "$target" ] && [ -n "$out" ] && [ -n "$version" ] || {
+  echo "usage: $0 bun-linux-{x64|arm64} <output> <version>" >&2
+  exit 2
+}
+
+case "$target" in
+  bun-linux-x64)
+    image="quay.io/pypa/manylinux_2_28_x86_64:latest"
+    node_arch="x64"
+    expected_uname="x86_64"
+    ;;
+  bun-linux-arm64)
+    image="quay.io/pypa/manylinux_2_28_aarch64:latest"
+    node_arch="arm64"
+    expected_uname="aarch64"
+    ;;
+  *)
+    echo "unsupported target: $target" >&2
+    exit 2
+    ;;
+esac
+
+command -v docker >/dev/null 2>&1 || {
+  echo "docker is required for the glibc 2.28 release build" >&2
+  exit 1
+}
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+case "$out" in
+  /*) out_abs="$out" ;;
+  *) out_abs="$repo_root/$out" ;;
+esac
+out_dir="$(dirname -- "$out_abs")"
+out_name="$(basename -- "$out_abs")"
+mkdir -p "$out_dir"
+
+docker run --rm \
+  -v "$repo_root:/src:ro" \
+  -v "$out_dir:/out" \
+  -e BUILD_TARGET="$target" \
+  -e BUILD_VERSION="$version" \
+  -e OUTPUT_NAME="$out_name" \
+  -e NODE_ARCH="$node_arch" \
+  -e EXPECTED_UNAME="$expected_uname" \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
+  "$image" /bin/bash -euo pipefail -c '
+    [ "$(uname -m)" = "$EXPECTED_UNAME" ] || {
+      echo "runner/image architecture mismatch: expected $EXPECTED_UNAME, got $(uname -m)" >&2
+      exit 1
+    }
+    getconf GNU_LIBC_VERSION | grep -qx "glibc 2.28" || {
+      echo "REFUSING: build container is not glibc 2.28" >&2
+      getconf GNU_LIBC_VERSION >&2
+      exit 1
+    }
+
+    work=/tmp/botmux-build
+    mkdir -p "$work"
+    tar -C /src --exclude=.git --exclude=node_modules --exclude=dist --exclude=dist-bin -cf - . \
+      | tar -C "$work" -xf -
+    cd "$work"
+    rm -rf node_modules dist dist-bin
+
+    node_version=22.22.3
+    curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz
+    mkdir -p /opt/node
+    tar -xJf /tmp/node.tar.xz -C /opt/node --strip-components=1
+    export PATH="/opt/node/bin:$PATH"
+    node --version
+    npm install -g bun@1.4.0 --loglevel=error
+    bun --version
+
+    # Compiles node-pty on glibc 2.28; trustedDependencies makes this lifecycle
+    # script run under Bun. Stamp only after the frozen install, mirroring release.
+    bun install --frozen-lockfile
+    npm version "$BUILD_VERSION" --no-git-tag-version --allow-same-version
+    bun run build
+
+    native=node_modules/node-pty/build/Release/pty.node
+    test -f "$native" || { echo "node-pty native missing: $native" >&2; exit 1; }
+    highest="$(readelf --version-info "$native" | grep -o "GLIBC_[0-9.]*" | sort -Vu | tail -1)"
+    [ -n "$highest" ] || { echo "no GLIBC symbol version found in $native" >&2; exit 1; }
+    [ "$(printf "%s\n" "$highest" GLIBC_2.28 | sort -V | tail -1)" = GLIBC_2.28 ] || {
+      echo "REFUSING: $native requires $highest (maximum supported is GLIBC_2.28)" >&2
+      exit 1
+    }
+    echo "node-pty glibc floor OK: highest required symbol is $highest"
+
+    mkdir -p dist-bin
+    bun scripts/build-bun-binary.mjs --target "$BUILD_TARGET" --out "dist-bin/$OUTPUT_NAME"
+    node scripts/smoke-bun-binary.mjs "dist-bin/$OUTPUT_NAME"
+    cp "dist-bin/$OUTPUT_NAME" "/out/$OUTPUT_NAME"
+    chown "$HOST_UID:$HOST_GID" "/out/$OUTPUT_NAME" 2>/dev/null || true
+  '
+
+echo "built $out_abs on glibc 2.28"

--- a/scripts/postinstall-bin.mjs
+++ b/scripts/postinstall-bin.mjs
@@ -47,6 +47,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, chmodS
 import { dirname, join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 /** Abort the install with a reason. There is no Node fallback any more (see header). */
@@ -169,6 +170,30 @@ try {
   const mode = statSync(binary).mode;
   if ((mode & 0o111) === 0) chmodSync(binary, 0o755);
 } catch { /* best effort; the exec below will surface a real problem */ }
+
+// Do not activate a platform package merely because npm selected the right
+// os/cpu/libc tuple. That metadata cannot express a glibc symbol-version floor:
+// a binary built on Ubuntu 24.04 is still "linux-x64 + glibc", yet its embedded
+// node-pty native may require GLIBC_2.34 and die on Debian 10 (glibc 2.28).
+//
+// Probe the exact candidate before touching the shared launcher. `--version`
+// loads the complete compiled module graph (including node-pty), but starts no
+// daemon and writes no bot data. A failed global npm update can then roll back
+// while every already-running daemon and every shell keeps using the old launcher.
+const probe = spawnSync(binary, ['--version'], {
+  encoding: 'utf-8',
+  timeout: 30_000,
+  env: { ...process.env, BOTMUX_INSTALL_PROBE: '1' },
+});
+if (probe.error || probe.status !== 0) {
+  const raw = probe.error?.message || probe.stderr || probe.stdout || `exit ${probe.status ?? probe.signal ?? 'unknown'}`;
+  const detail = String(raw).trim().split('\n').slice(0, 8).join(' | ');
+  fail(
+    `${SUBPACKAGE} cannot run on this host; the existing botmux launcher was not changed.`,
+    `${detail || 'candidate probe failed'}. Install a compatible release or upgrade the host OS; `
+      + 'do not replace glibc in-place on a live machine.',
+  );
+}
 
 // ── Write the single launcher ──────────────────────────────────────────────────
 // Same path + same atomic-write discipline as the daemon and `pnpm use:here` use

--- a/src/core/binary-self-update.ts
+++ b/src/core/binary-self-update.ts
@@ -68,6 +68,7 @@ import {
   renameSync, rmSync, statSync, chmodSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { pipeline } from 'node:stream/promises';
 import { GITHUB_REPO } from './restart-report.js';
 import { getReleaseStream, resolveHttpProxy } from './release-download.js';
@@ -180,6 +181,8 @@ export interface BinarySelfUpdateDeps {
   fetchStream?: (url: string) => Promise<NodeJS.ReadableStream>;
   /** Read the published checksum for `asset`, or null when none is published. */
   fetchChecksum?: (url: string) => Promise<string | null>;
+  /** Execute the downloaded candidate before activation (injected for tests). */
+  probeBinary?: (path: string) => { status: number | null; signal?: NodeJS.Signals | null; error?: Error; stderr?: string | Buffer | null };
 }
 
 /**
@@ -238,6 +241,11 @@ export async function replaceStandaloneBinary(
       return null; // no checksum published (or unreachable) → warn, don't fail
     }
   });
+  const probeBinary = deps.probeBinary ?? ((path: string) => spawnSync(path, ['--version'], {
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, BOTMUX_INSTALL_PROBE: '1' },
+  }));
 
   // Same directory as the target: keeps the rename intra-filesystem (EXDEV).
   const dir = dirname(target);
@@ -262,6 +270,17 @@ export async function replaceStandaloneBinary(
       throw new Error(`${asset} 下载内容异常（仅 ${bytes} 字节，疑似错误页而非二进制）`);
     }
     chmodSync(tmp, 0o755);
+    // Asset name + checksum prove identity, not runtime compatibility. In
+    // particular, npm's `libc: glibc` cannot express a GLIBC symbol-version
+    // floor; an embedded native built on a newer distro can still fail at dlopen.
+    // Probe the complete module graph before the atomic rename so self-update has
+    // the same fail-safe contract as npm postinstall and install.sh.
+    const probe = probeBinary(tmp);
+    if (probe.error || probe.status !== 0) {
+      const raw = probe.error?.message || probe.stderr || `exit ${probe.status ?? probe.signal ?? 'unknown'}`;
+      const detail = String(raw).trim().split('\n').slice(0, 8).join(' | ');
+      throw new Error(`${asset} 与当前主机不兼容，保留现有版本：${detail || 'candidate probe failed'}`);
+    }
     // Atomic swap. NOT a write to `target` — that is ETXTBSY (see header).
     renameSync(tmp, target);
     return { asset, target, bytes };

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -592,6 +592,7 @@ describe('resolveStandaloneRestartExecutable — restart the NEW binary, not the
 
 describe('replaceStandaloneBinary — atomic swap of a live executable', () => {
   const BIG = 1_100_000; // over the "this is an error page, not a binary" floor
+  const probeOk = () => ({ status: 0 });
 
   function fakeAsset(byte = 0x41, size = BIG): Buffer {
     return Buffer.alloc(size, byte);
@@ -608,6 +609,7 @@ describe('replaceStandaloneBinary — atomic swap of a live executable', () => {
     const r = await replaceStandaloneBinary('3.99.0', target, {
       fetchStream: async () => Readable.from([payload]),
       fetchChecksum: async () => sha256(payload),
+      probeBinary: probeOk,
     });
     expect(r.bytes).toBe(BIG);
     expect(statSync(target).size).toBe(BIG);
@@ -658,6 +660,21 @@ describe('replaceStandaloneBinary — atomic swap of a live executable', () => {
       .toEqual(['botmux']);
   });
 
+  it('an unloadable candidate is rejected before rename and leaves the working binary intact', async () => {
+    const dir = tmp();
+    const target = join(dir, 'botmux');
+    writeFileSync(target, 'OLD BINARY', { mode: 0o755 });
+    const payload = fakeAsset();
+    await expect(replaceStandaloneBinary('3.99.0', target, {
+      fetchStream: async () => Readable.from([payload]),
+      fetchChecksum: async () => sha256(payload),
+      probeBinary: () => ({ status: 1, stderr: 'GLIBC_2.34 not found' }),
+    })).rejects.toThrow(/GLIBC_2\.34/);
+    expect(readFileSync(target, 'utf-8')).toBe('OLD BINARY');
+    expect(execFileSync('ls', ['-A', dir], { encoding: 'utf-8' }).trim().split('\n').sort())
+      .toEqual(['botmux']);
+  });
+
   it('the temp file is a SIBLING of the target (an EXDEV rename would fail)', async () => {
     // The swap must be a rename within one filesystem. Writing to os.tmpdir() and
     // renaming across devices fails with EXDEV, and copying instead would
@@ -678,6 +695,7 @@ describe('replaceStandaloneBinary — atomic swap of a live executable', () => {
         seen.push(...execFileSync('ls', ['-A', join(dir, 'nested')], { encoding: 'utf-8' }).trim().split('\n'));
         return sha256(payload);
       },
+      probeBinary: probeOk,
     });
     expect(seen.some(f => f.startsWith('.botmux-update.'))).toBe(true);
     // ...and it must have been a sibling of the target, not in os.tmpdir().

--- a/test/ci-glibc-baseline-gate.test.ts
+++ b/test/ci-glibc-baseline-gate.test.ts
@@ -70,8 +70,16 @@ describe('scripts/build-linux-glibc-baseline.sh — the floor is built AND prove
     // tag, or a local run on the dev box, would produce a higher-floor native while
     // every log line still said "glibc baseline". The assertion is that the runtime
     // libc is CHECKED, not that any particular image supplies it.
-    expect(BUILDER_CODE).toMatch(/getconf GNU_LIBC_VERSION/);
-    expect(BUILDER_CODE).toContain(`glibc ${FLOOR}`);
+    //
+    // ANCHOR THE FLOOR TO THE CHECK ITSELF, not to the file (measured): a bare
+    // `toContain('glibc 2.28')` is satisfied by the REFUSING **message** and by the
+    // header comment, so weakening the comparison to `grep -q "glibc 2"` — which
+    // accepts 2.9, 2.17, 2.29, anything — left all 10 assertions green. Requiring
+    // the literal to appear in the matcher invocation that follows `getconf` closes
+    // that, while still tolerating a different matcher (grep/awk) or extra flags.
+    expect(BUILDER_CODE).toMatch(
+      new RegExp(`getconf GNU_LIBC_VERSION[\\s\\S]{0,200}?(?:grep|awk)[^\\n]*glibc ${FLOOR.replace('.', '\\.')}`),
+    );
   });
 
   it('MECHANISM: asserts the embedded native does not exceed the floor', () => {

--- a/test/ci-glibc-baseline-gate.test.ts
+++ b/test/ci-glibc-baseline-gate.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The Linux glibc FLOOR is a shipped-artifact property that nothing in the
+ * packaging metadata can express.
+ *
+ * `pty.node` is embedded into the binary at compile time and node-pty has no linux
+ * prebuild, so it is compiled against whatever glibc the BUILDER runs. When
+ * `ubuntu-latest` moved to 24.04 the shipped floor silently rose to GLIBC_2.34 —
+ * nothing failed at build time, nothing failed on the runner, and the binary died
+ * at dlopen on any host older than that (Debian 10 / CentOS 8, both still inside
+ * Node 22's own glibc 2.28 support window).
+ *
+ * Two properties therefore have to hold, and neither is visible in a normal test:
+ *   1. PRODUCTION: Linux binaries are built on glibc 2.28 and the embedded native's
+ *      highest required GLIBC symbol is asserted before it can be published.
+ *   2. PARITY: the PR gate exercises the same boundary as release, so a floor
+ *      regression is caught on the PR that causes it rather than after publish.
+ *
+ * WHAT THESE TESTS DEFEND: not the YAML's shape, but the claim "a Linux release
+ * cannot ship a native whose glibc floor exceeds 2.28, and the PR gate proves it".
+ * Every assertion corresponds to a change that would leave the rest of the suite
+ * green while silently un-gating the floor:
+ *   • ci.yml stops using the baseline builder  → back to release-only discovery
+ *   • release.yml stops using it (e.g. every
+ *     `glibc_baseline` blanked back to '')     → Linux ships from ubuntu-latest
+ *                                                again, which is THIS bug
+ *   • the readelf floor assertion goes away    → builds on 2.28 but no longer
+ *                                                proves what it produced
+ *   • the built binary is never executed       → compiles but the native is never
+ *                                                dlopen'd, and dlopen is the
+ *                                                failure mode
+ *
+ * MEASURED, and the reason this file exists: blanking all three `glibc_baseline`
+ * values in release.yml reverts Linux releases to the broken path, and the 27
+ * install/release/binary suites stay at 471/471 green.
+ *
+ * Deliberately parsed as text rather than YAML, and with comments stripped: the
+ * assertions are about specific commands being present, and neither a structurally
+ * valid file that runs something else nor prose ABOUT the gate can satisfy them.
+ *
+ * Sibling suite: test/ci-musl-gate.test.ts guards the structurally identical
+ * "wrong libc embedded in a shipped native" hazard for musl. Its MECHANISM vs MEANS
+ * note applies here too — assert the invariant (built on the floor, floor proven,
+ * binary executed), not the means (docker, manylinux, a particular image).
+ */
+
+const CI = readFileSync(resolve(import.meta.dirname, '../.github/workflows/ci.yml'), 'utf-8');
+const RELEASE = readFileSync(resolve(import.meta.dirname, '../.github/workflows/release.yml'), 'utf-8');
+const BUILDER = readFileSync(resolve(import.meta.dirname, '../scripts/build-linux-glibc-baseline.sh'), 'utf-8');
+
+/** Strip `#` comments so a claim can never be satisfied by prose ABOUT the claim. */
+const stripComments = (text: string) => text
+  .split('\n')
+  .map((line) => line.replace(/(^|\s)#.*$/, '$1'))
+  .join('\n');
+
+const CI_CODE = stripComments(CI);
+const RELEASE_CODE = stripComments(RELEASE);
+const BUILDER_CODE = stripComments(BUILDER);
+
+/** The floor is a single number in three places; drift between them is the hazard. */
+const FLOOR = '2.28';
+
+describe('scripts/build-linux-glibc-baseline.sh — the floor is built AND proven', () => {
+  it('MECHANISM: refuses to build unless the environment really is the floor', () => {
+    // Without this the script is just "build somewhere and hope": a bumped image
+    // tag, or a local run on the dev box, would produce a higher-floor native while
+    // every log line still said "glibc baseline". The assertion is that the runtime
+    // libc is CHECKED, not that any particular image supplies it.
+    expect(BUILDER_CODE).toMatch(/getconf GNU_LIBC_VERSION/);
+    expect(BUILDER_CODE).toContain(`glibc ${FLOOR}`);
+  });
+
+  it('MECHANISM: asserts the embedded native does not exceed the floor', () => {
+    // THE load-bearing assertion. Building on 2.28 makes the right native *likely*;
+    // reading the symbol versions back out of the artifact is what makes it PROVEN.
+    // (`libc: glibc` in npm metadata cannot express this, which is the whole reason
+    // the floor regressed unnoticed.)
+    expect(BUILDER_CODE).toMatch(/readelf[\s\S]*GLIBC_/);
+    expect(BUILDER_CODE).toMatch(/pty\.node/);
+    // The comparison must be against the floor, and must FAIL CLOSED. Anchor on the
+    // refusal, not on the arithmetic: `sort -V` is one valid way to compare, and
+    // pinning it would be a means-level assertion.
+    expect(BUILDER_CODE).toMatch(/REFUSING[\s\S]*GLIBC_2\.28|GLIBC_2\.28[\s\S]{0,200}exit 1/);
+  });
+
+  it('EXECUTES the binary it produced, in the same environment', () => {
+    // Compiling proves the native was found; only RUNNING it proves the native
+    // loads. dist/cli.js statically imports node-pty through the backends and
+    // node-pty dlopens at module scope, so "the binary ran at all" already covers
+    // dlopen — which is precisely the failure this suite exists for.
+    expect(BUILDER_CODE).toMatch(/smoke-bun-binary\.mjs/);
+  });
+
+  it('the floor assertion runs BEFORE the artifact leaves the container', () => {
+    // Order is the difference between a gate and a report. If readelf ran after the
+    // binary were copied out, a bad native could still reach /out.
+    //
+    // ANCHOR CAREFULLY (measured): the first `/out/` in this file is the `docker run
+    // -v "$out_dir:/out"` mount argument, which sits near the TOP — above readelf.
+    // An assertion using indexOf('/out/') therefore compares against the mount, not
+    // the copy, and stays green when the readelf block is moved after the copy (the
+    // exact defect this test names). Anchor on the copy command itself.
+    const readelfAt = BUILDER_CODE.indexOf('readelf');
+    const copyOut = BUILDER_CODE.search(/cp\s+"dist-bin\/\$OUTPUT_NAME"/);
+    expect(readelfAt).toBeGreaterThan(-1);
+    expect(copyOut, 'the copy-out command was not found — re-anchor this test').toBeGreaterThan(-1);
+    expect(copyOut).toBeGreaterThan(readelfAt);
+  });
+});
+
+describe('ci.yml — the glibc floor is gated on PRs, not only at release', () => {
+  it('the Linux binary job builds through the baseline builder', () => {
+    // Not "a job exists": the job must route through the floor-enforcing builder.
+    // A `bun scripts/build-bun-binary.mjs` straight on ubuntu-latest is the shape
+    // that shipped GLIBC_2.34, and it would satisfy any weaker assertion.
+    const job = CI_CODE.slice(CI_CODE.indexOf('\n  bun-binary:'));
+    const jobOnly = job.slice(0, job.indexOf('\n  bun-binary-musl:'));
+    expect(jobOnly).toContain('scripts/build-linux-glibc-baseline.sh');
+  });
+
+  it('PARITY: the PR gate and the release use the SAME builder script', () => {
+    // The actual invariant. Parity is what stops the PR gate from being left behind
+    // on a weaker path while the release moves on (or vice versa).
+    expect(CI_CODE).toContain('scripts/build-linux-glibc-baseline.sh');
+    expect(RELEASE_CODE).toContain('scripts/build-linux-glibc-baseline.sh');
+  });
+});
+
+describe('release.yml — every Linux leg stays on the floor', () => {
+  it('THE REGRESSION THIS PINS: no Linux leg builds off the baseline path', () => {
+    // MEASURED: blanking the three `glibc_baseline` values reverts Linux releases to
+    // ubuntu-latest — this exact bug — with 471/471 unrelated tests still green.
+    //
+    // Asserted per-leg rather than "the string appears somewhere", because the file
+    // also contains the darwin leg (which legitimately has no floor) and the musl
+    // legs. A single occurrence proves nothing about the leg that ships glibc x64.
+    const job = RELEASE_CODE.slice(RELEASE_CODE.indexOf('\n  bun-binaries:'));
+    const matrix = job.slice(job.indexOf('include:'), job.indexOf('runs-on:'));
+
+    for (const target of ['bun-linux-x64', 'bun-linux-arm64']) {
+      // Each linux target's matrix entry must carry the floor. Entries are separated
+      // by `- os:`, so slice the one that names this target.
+      const entries = matrix.split(/-\s+os:/).filter((e) => e.includes(target));
+      expect(entries, `no matrix entry builds ${target}`).toHaveLength(1);
+      // Quote-agnostic on purpose: '2.28', "2.28" and bare 2.28 are the same YAML
+      // value, so pinning one style would fail a correct file (measured — an earlier
+      // version of this assertion went red on `"2.28"`). What must hold is that the
+      // value is the floor and is NOT empty.
+      expect(entries[0], `${target} is not pinned to the glibc floor`)
+        .toMatch(new RegExp(`glibc_baseline:\\s*['"]?${FLOOR.replace('.', '\\.')}['"]?\\s*$`, 'm'));
+    }
+  });
+
+  it('darwin is deliberately NOT on the glibc path (it has no glibc)', () => {
+    // Guards the opposite error: a blanket floor would send macOS through a Linux
+    // container. Documents that the empty value is intentional, so a future reader
+    // does not "fix" it into '2.28'.
+    const job = RELEASE_CODE.slice(RELEASE_CODE.indexOf('\n  bun-binaries:'));
+    const matrix = job.slice(job.indexOf('include:'), job.indexOf('runs-on:'));
+    const darwin = matrix.split(/-\s+os:/).filter((e) => e.includes('bun-darwin'));
+    expect(darwin).toHaveLength(1);
+    expect(darwin[0]).toMatch(/glibc_baseline:\s*''/);
+  });
+
+  it('the two build paths are mutually exclusive (no leg builds twice or zero times)', () => {
+    // The legs are selected by `if: matrix.glibc_baseline == ''` / `!= ''`. If both
+    // guards were ever written the same way, a linux leg would either run the
+    // ubuntu-latest compile as well (shipping whichever artifact landed last) or run
+    // neither and publish nothing.
+    const job = RELEASE_CODE.slice(RELEASE_CODE.indexOf('\n  bun-binaries:'));
+    expect(job).toMatch(/if:\s*matrix\.glibc_baseline == ''/);
+    expect(job).toMatch(/if:\s*matrix\.glibc_baseline != ''/);
+  });
+
+  it('the glibc legs still feed the publish chain (else Linux ships unbuilt)', () => {
+    // `binary-subpackages` packs these artifacts into the npm subpackages. npm treats
+    // a missing optional dep as a silent no-op, so an unbuilt linux artifact does not
+    // fail the publish — it produces a botmux that has no binary on Linux.
+    const subpackages = RELEASE_CODE.slice(RELEASE_CODE.indexOf('binary-subpackages:'));
+    const needsLine = subpackages.slice(0, subpackages.indexOf('runs-on'));
+    expect(needsLine).toContain('bun-binaries');
+  });
+});

--- a/test/install-path-entry.test.ts
+++ b/test/install-path-entry.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import {
   detectShell,
   pathEntryTargets,
@@ -490,7 +490,7 @@ describe('install.sh — executed end to end (offline fixture)', () => {
       'while [ $# -gt 0 ]; do case "$1" in -o) out="$2"; shift 2 ;; -*) shift ;; *) url="$1"; shift ;; esac; done',
       'case "$url" in *.sha256) exit 1 ;; esac',
       '[ -n "$out" ] || exit 1',
-      'printf "#!/bin/sh\\necho BOTMUX_OK\\n" > "$out"',
+      'printf "#!/bin/sh\\nif [ \\\"${BOTMUX_FIXTURE_BINARY_FAIL:-}\\\" = true ]; then echo GLIBC_2.34-not-found >&2; exit 42; fi\\necho BOTMUX_OK\\n" > "$out"',
     ].join('\n'));
     return bin;
   }
@@ -533,6 +533,22 @@ describe('install.sh — executed end to end (offline fixture)', () => {
     expect(existsSync(join(zdot, '.zshenv'))).toBe(true);
     expect(existsSync(join(home, '.zshenv'))).toBe(false);
     expect(runIn('/usr/bin/zsh', ['-c', 'botmux'], { HOME: home, ZDOTDIR: zdot })).toContain('BOTMUX_OK');
+  });
+
+  it('probes before replacement and preserves an existing binary on failure', () => {
+    const installed = join(installDir, 'botmux');
+    writeFileSync(installed, '#!/bin/sh\necho PREVIOUS_WORKING_BOTMUX\n', { mode: 0o755 });
+    const bin = fakeBinDir(home);
+    const r = spawnSync('/bin/sh', [join(__dirname, '..', 'install.sh')], {
+      env: {
+        PATH: `${bin}:/usr/bin:/bin`, HOME: home, SHELL: '/bin/dash',
+        BOTMUX_INSTALL_DIR: installDir, BOTMUX_FIXTURE_BINARY_FAIL: 'true',
+      },
+      encoding: 'utf8', timeout: 60_000,
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('cannot run on this host');
+    expect(execFileSync(installed, { encoding: 'utf8' })).toContain('PREVIOUS_WORKING_BOTMUX');
   });
 
   it('makes fish find it — honouring $XDG_CONFIG_HOME, with fish syntax', () => {

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -168,6 +168,10 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     binDirOnPath?: boolean;
     /** $SHELL for the child, which decides WHICH startup file gets the PATH line. */
     shell?: string;
+    /** Candidate exits non-zero even for --version (for libc/runtime rejection). */
+    brokenBinary?: boolean;
+    /** Existing shared launcher that a rejected update must preserve byte-for-byte. */
+    existingLauncher?: string;
   }) {
     const base = tmp();
     const home = join(base, 'home');
@@ -199,8 +203,16 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
       writeFileSync(join(sub, 'package.json'), JSON.stringify({ name: `botmux-${process.platform}-${process.arch}`, version: '3.20.0' }));
       binary = join(sub, 'botmux');
       // Echoes argv so the launcher can be executed, not merely string-matched.
-      writeFileSync(binary, '#!/bin/sh\nprintf "BINARY-GOT:%s\\n" "$@"\n', { mode: 0o755 });
+      writeFileSync(binary, opts.brokenBinary
+        ? '#!/bin/sh\necho "GLIBC_2.34 not found" >&2\nexit 42\n'
+        : '#!/bin/sh\nprintf "BINARY-GOT:%s\\n" "$@"\n', { mode: 0o755 });
       chmodSync(binary, 0o755);
+    }
+
+    const launcher = join(home, '.botmux', 'bin', 'botmux');
+    if (opts.existingLauncher !== undefined) {
+      mkdirSync(join(home, '.botmux', 'bin'), { recursive: true });
+      writeFileSync(launcher, opts.existingLauncher, { mode: 0o755 });
     }
 
     const env: NodeJS.ProcessEnv = { PATH: process.env.PATH, HOME: home };
@@ -212,7 +224,6 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
       encoding: 'utf-8',
       env,
     });
-    const launcher = join(home, '.botmux', 'bin', 'botmux');
     return { ...r, launcher, binary, home, wrote: existsSync(launcher) };
   }
 
@@ -265,6 +276,19 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     const run = spawnSync(r.launcher, ['send', 'hello world'], { encoding: 'utf-8' });
     expect(run.status).toBe(0);
     expect(run.stdout).toBe('BINARY-GOT:send\nBINARY-GOT:hello world\n');
+  });
+
+  it('rejects an unloadable candidate before changing the existing launcher', () => {
+    const previous = '#!/bin/sh\necho PREVIOUS_WORKING_BOTMUX\n';
+    const r = runPostinstall({
+      global: 'true',
+      brokenBinary: true,
+      existingLauncher: previous,
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('cannot run on this host');
+    expect(r.stderr).toContain('GLIBC_2.34 not found');
+    expect(readFileSync(r.launcher, 'utf-8')).toBe(previous);
   });
 
   it('npm_config_global ABSENT → writes nothing (this is `pnpm install` in the repo!)', () => {


### PR DESCRIPTION
## 背景 / 动机

#1047 去掉 Node fallback 后，npm 安装和单文件安装统一依赖自包含平台二进制，避免用户机器现场编译 `node-pty`。这个方向本身是对的，但 Linux 发布物在 `ubuntu-latest` 编译，嵌入的 `pty.node` 会继承构建机 libc：当前产物要求 `GLIBC_2.34`，在仍满足 Node 22 官方运行基线的 glibc 2.28 主机上会在加载阶段失败。

同时，npm 的 `os/cpu/libc=glibc` 元数据无法表达最低 GLIBC symbol version；安装器仅校验平台、文件和 checksum，会把一个无法启动的候选版本替换到现有可用版本上。

## 改动

- Linux x64/arm64 发布物统一在 `manylinux_2_28` 原生架构容器中安装依赖、编译 `node-pty`、构建并执行完整 binary smoke。
- 发布前用 `readelf` 断言 `pty.node` 的最高 GLIBC symbol 不超过 `GLIBC_2.28`；CI 使用同一脚本，防止发布流程漂移。
- npm postinstall、`install.sh`、standalone self-update 均在替换现有 launcher/binary 前执行候选版本 `--version` 探测；失败时删除候选并保留工作版本。
- 新增三个失败回归用例，覆盖候选二进制报 `GLIBC_2.34 not found` 时不破坏现有安装。

## 默认值 / 兼容性依据

继续保持 #1047 的“无 Node fallback、无需 node-gyp/Python/gcc”安装模型。Linux glibc 基线明确固定为 2.28，与项目使用的 Node 22 Linux 基线一致；musl 继续走独立发布物，macOS 构建路径不变。

## 测试覆盖

- npm 全局安装拒绝不可运行的平台包，并逐字节保留旧 launcher。
- curl 安装拒绝不可运行的下载物，并保留旧 binary。
- standalone self-update 在 atomic rename 前拒绝不可运行候选，且清理临时文件。
- 远端 glibc 2.28 Linux 环境完成真实依赖安装、完整构建、二进制编译与 smoke；`pty.node` 实测最高要求为 `GLIBC_2.28`。

## 验证

- `node node_modules/vitest/vitest.mjs run test/npm-binary-distribution.test.ts test/install-path-entry.test.ts test/install-sh-musl-asset.test.ts test/binary-self-update.test.ts`：125 passed，1 skipped
- `npx --yes bun@1.4.0 run build`：通过
- glibc 2.28 x64 远端 Linux：完整 binary smoke 通过
- `sh -n install.sh scripts/build-linux-glibc-baseline.sh`：通过
- `git diff --check`：通过

## 影响范围

影响 Linux glibc 发布构建，以及 npm/curl/self-update 三条升级激活路径。候选探测只运行 `--version`，不启动 daemon、不读取或修改 bot 数据。macOS、Linux musl、CLI 适配器、PTY/Tmux 后端、会话和 IM 路由逻辑均未改变。
