### PR TITLE
fix(dashboard): 端口文件指向无人监听的端口时也自愈，否则永久卡死

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,7 +148,7 @@ import {
   DASHBOARD_COMMAND_USAGE,
   dashboardComingUpFromState,
   dashboardFailureIsTerminal,
-  executeDashboardCommand,
+  executeDashboardCliCommand,
   formatDashboardFallbackFailure,
   formatDashboardSuccessLines,
   formatDashboardUnreachable,
@@ -3243,13 +3243,24 @@ function cmdUpgradeLocalDev(): void {
  * over {@link callDashboard}, which handles 404 disambiguation and self-heals a
  * stale `.dashboard-port` that points at the wrong service (e.g. daemon IPC).
  * See `src/cli/dashboard-endpoint.ts` for the why.
+ *
+ * `rescanWhenUnreachable` extends that self-heal to a recorded port with NOTHING
+ * listening on it. It must stay opt-in: during boot `unreachable` is the normal
+ * state and is resolved by retrying the same port, so scanning the range on every
+ * poll tick would be pure waste. `executeDashboardCliCommand` passes it for the
+ * one-shot `botmux dashboard`; the readiness poll below must NOT.
  */
-async function callDashboardEndpoint(path: DashboardEndpoint): Promise<DashboardResult> {
+async function callDashboardEndpoint(
+  path: DashboardEndpoint,
+  opts: { rescanWhenUnreachable?: boolean; requestTimeoutMs?: number } = {},
+): Promise<DashboardResult> {
   return callDashboard({
     configDir: CONFIG_DIR,
     defaultPort: 7891,
     envPort: process.env.BOTMUX_DASHBOARD_PORT,
     path,
+    rescanWhenUnreachable: opts.rescanWhenUnreachable,
+    requestTimeoutMs: opts.requestTimeoutMs,
   });
 }
 
@@ -3335,7 +3346,11 @@ async function printDashboardHintWithRetry(): Promise<void> {
   // 撑不住，实测会把 start/restart 的这段拖到近两倍。
   await ensureDevboxDashboardExportForCurrentPort();
   for (;;) {
-    last = await callDashboardEndpoint('/__cli/current');
+    // Bounded per request (NOT opted into rescanning): this loop's own budget is
+    // only consulted below, after the await returns, so a recorded port that
+    // accepts the connection and never answers would hang here forever and never
+    // reach that check. See requestTimeoutMs in dashboard-endpoint.ts.
+    last = await callDashboardEndpoint('/__cli/current', { requestTimeoutMs: stepMs * 4 });
     if (last.ok) {
       console.log(`   面板: botmux dashboard (${last.url})`);
       // 走中心化平台链接时，附带本地直连兜底，平台异常也能直接 ip:port 访问。
@@ -3373,7 +3388,11 @@ async function cmdDashboard(args: string[]): Promise<void> {
     && !args.some(arg => ['--help', '-h', 'help'].includes(arg.toLowerCase()))
     && (rawAction === undefined || rawAction === 'current' || rawAction === 'rotate');
   if (resolvesEndpoint) await ensureDevboxDashboardExportForCurrentPort();
-  const execution = await executeDashboardCommand(args, callDashboardEndpoint);
+  // The opt-in for a dead recorded port lives INSIDE executeDashboardCliCommand
+  // so it is directly testable (see its doc comment for why source-regex guards
+  // were not). `printDashboardHintWithRetry()` deliberately does not use this
+  // wrapper — a 500ms poll must never scan the probe range per tick.
+  const execution = await executeDashboardCliCommand(args, callDashboardEndpoint);
   if (execution.kind === 'help') {
     console.log(DASHBOARD_COMMAND_USAGE);
     return;

--- a/src/cli/dashboard-command.ts
+++ b/src/cli/dashboard-command.ts
@@ -251,3 +251,28 @@ export async function executeDashboardCommand(
   }
   return { kind: 'endpoint', action, result: ensured };
 }
+
+/**
+ * `botmux dashboard`'s execution path, as ONE importable unit.
+ *
+ * Why this exists rather than inline wiring in `cli.ts`: the opt-in below is the
+ * whole fix for a dead `.dashboard-port`, and `cli.ts` exports nothing testable,
+ * so the only way to check it was a source-text assertion. Two such assertions
+ * were written and both were wrong — the first false-RED on a legitimate
+ * extract-to-local refactor, the second stayed GREEN when the flag-carrying call
+ * was fully disconnected from the caller actually passed down (flag present,
+ * command executed, wiring severed). A regex over nested callbacks cannot express
+ * "this options object reaches that caller"; a function can.
+ *
+ * `rescanWhenUnreachable: true` is correct HERE and only here: this is a one-shot
+ * human command, so at worst it scans the probe range once per invocation. The
+ * 500ms readiness poll must keep the default (false) or it would scan every tick.
+ *
+ * @param callEndpoint the raw endpoint caller; this wrapper is what adds the opt-in
+ */
+export async function executeDashboardCliCommand(
+  args: readonly string[],
+  callEndpoint: (path: DashboardEndpoint, opts: { rescanWhenUnreachable: boolean }) => Promise<DashboardResult>,
+): Promise<DashboardCommandExecution> {
+  return executeDashboardCommand(args, (path) => callEndpoint(path, { rescanWhenUnreachable: true }));
+}

--- a/src/cli/dashboard-endpoint.ts
+++ b/src/cli/dashboard-endpoint.ts
@@ -98,6 +98,14 @@ export async function requestDashboardAt(opts: {
   path: DashboardEndpoint;
   secret: string;
   fetchImpl?: FetchImpl;
+  /**
+   * Abort the request after this long. REQUIRED for discovery: a local service
+   * that accepts the TCP connection but never sends HTTP headers would otherwise
+   * hang the whole serial probe loop forever (`loopbackFetch` sets no request
+   * timeout of its own), so a single stalled port could permanently wedge
+   * `botmux dashboard` before it ever reaches the real dashboard.
+   */
+  timeoutMs?: number;
 }): Promise<DashboardResult> {
   const { host, port, path, secret } = opts;
   // Default is the proxy-immune loopback client above, NOT the global `fetch`.
@@ -109,31 +117,58 @@ export async function requestDashboardAt(opts: {
   // mismatches the signature (and the attacker can't re-sign without the secret).
   const { ts, nonce, sig } = signCliAuth(secret, cliAuthBind('POST', path, port));
 
-  let res: Response;
+  const ac = opts.timeoutMs === undefined ? null : new AbortController();
+  const timer = ac ? setTimeout(() => ac.abort(), opts.timeoutMs) : null;
   try {
-    res = await fetchImpl(`http://${host}:${port}${path}`, {
+    // The timeout must span the WHOLE exchange, not just the headers: a fetch
+    // resolves its Response as soon as headers arrive, so a server that sends
+    // `200 application/json` and then stalls mid-body would hang forever in
+    // `.text()`/`.json()` below. MEASURED: with the timer cleared right after the
+    // fetch, exactly that shape wedged the CLI (outer timeout, rc=124).
+    const res = await fetchImpl(`http://${host}:${port}${path}`, {
       method: 'POST',
       headers: {
         'X-Botmux-Cli-Ts': ts,
         'X-Botmux-Cli-Nonce': nonce,
         'X-Botmux-Cli-Auth': sig,
       },
+      ...(ac ? { signal: ac.signal } : {}),
     });
+    // Read the body ONCE, and never swallow a failed read. Every status branch used
+    // to do `.text().catch(() => '')`, which turns an ABORTED body into a normal
+    // empty body — so a server answering `500 headers` + a body that never
+    // completes was classified `http-error`. That matters beyond the label:
+    // `reachedDashboard(http-error)` is true, so rediscovery STOPS and the stale
+    // port file is kept, letting one stalled service permanently block self-heal.
+    // MEASURED: recorded port returning `500` + partial body → `http-error` in
+    // 305ms, port file unchanged, real dashboard never probed.
+    //
+    // A COMPLETE body still classifies normally even when malformed; only an
+    // aborted/failed read escapes to the catch below as `unreachable`.
+    const raw = await res.text();
+    if (res.status === 404) return classifyDashboard404(path, raw);
+    if (res.status === 401) return classifyDashboard401(raw);
+    if (!res.ok) {
+      return { ok: false, reason: 'http-error', detail: `${res.status} ${raw}` };
+    }
+    // reload-binding 不返回 url，200 即成功（仅用于「捅一下 daemon 重连」）
+    if (path === '/__cli/reload-binding') return { ok: true, url: '' };
+    let body: { url?: string; localUrl?: string } = {};
+    try { body = JSON.parse(raw) as { url?: string; localUrl?: string }; } catch { body = {}; }
+    if (!body.url) return { ok: false, reason: 'http-error', detail: 'malformed response (no url)' };
+    // localUrl is present only when the dashboard link routes through the central
+    // platform — a direct host:port fallback for when the platform is down.
+    return { ok: true, url: body.url, localUrl: body.localUrl };
   } catch {
+    // Includes the abort and a body that never completes: for our purposes a
+    // stalled port is indistinguishable from a dead one, and both must let the
+    // probe loop move on. A malformed-but-COMPLETE body never lands here — it is
+    // classified above, because only the `.text()` read itself can reject.
     return { ok: false, reason: 'unreachable' };
+  } finally {
+    // Always clear it — a live timer would keep the CLI's event loop alive.
+    if (timer) clearTimeout(timer);
   }
-  if (res.status === 404) return classifyDashboard404(path, await res.text().catch(() => ''));
-  if (res.status === 401) return classifyDashboard401(await res.text().catch(() => ''));
-  if (!res.ok) {
-    return { ok: false, reason: 'http-error', detail: `${res.status} ${await res.text().catch(() => '')}` };
-  }
-  // reload-binding 不返回 url，200 即成功（仅用于「捅一下 daemon 重连」）
-  if (path === '/__cli/reload-binding') return { ok: true, url: '' };
-  const body = await res.json().catch(() => ({})) as { url?: string; localUrl?: string };
-  if (!body.url) return { ok: false, reason: 'http-error', detail: 'malformed response (no url)' };
-  // localUrl is present only when the dashboard link routes through the central
-  // platform — a direct host:port fallback for when the platform is down.
-  return { ok: true, url: body.url, localUrl: body.localUrl };
 }
 
 /** A result that proves we actually reached the dashboard (vs. wrong port). */
@@ -141,8 +176,41 @@ function reachedDashboard(r: DashboardResult): boolean {
   return r.ok || (!r.ok && (r.reason === 'no-active-token' || r.reason === 'http-error'));
 }
 
-function shouldRediscover(r: DashboardResult): boolean {
-  return !r.ok && (r.reason === 'wrong-service' || r.reason === 'auth-failed');
+/**
+ * Should a failure on the recorded port trigger a probe-range rescan?
+ *
+ * `wrong-service` / `auth-failed` mean SOMETHING answered but is not our
+ * dashboard, so the recorded port is provably wrong and scanning is safe.
+ *
+ * `unreachable` is ambiguous — it is BOTH "dashboard still booting" (retry the
+ * same port; scanning would be wasted work every tick) AND "the recorded port is
+ * a dead value nobody listens on" (retrying can never succeed, so without a scan
+ * the port file stays wrong forever). MEASURED on a box where `.dashboard-port`
+ * held 7893 while the live dashboard was on 7891 with 0 processes on 7893: every
+ * `botmux dashboard` failed, and the existing self-heal never ran because it is
+ * gated on someone answering.
+ *
+ * `allowUnreachableRescan` is how the caller separates the two: a one-shot human
+ * command passes true (at worst one scan per invocation); the 500ms readiness poll
+ * leaves it false. It is deliberately NOT derived from "is the dashboard coming
+ * up?" — that answers `true` for `online` + live pid too, which is exactly the
+ * measured failure, so such a gate would never fire on the real bug.
+ */
+/**
+ * Per-probe cap. Loopback only, so a healthy dashboard answers in milliseconds;
+ * this exists purely to survive a port that accepts TCP and never replies.
+ */
+export const DISCOVERY_PROBE_TIMEOUT_MS = 2_000;
+/**
+ * Cap for the WHOLE serial scan. Without it, `probeSpan × probeTimeout`
+ * (21 × 2s) would be the worst case on a host full of stalled loopback services.
+ */
+export const DISCOVERY_TOTAL_BUDGET_MS = 8_000;
+
+function shouldRediscover(r: DashboardResult, allowUnreachableRescan = false): boolean {
+  if (r.ok) return false;
+  if (r.reason === 'wrong-service' || r.reason === 'auth-failed') return true;
+  return allowUnreachableRescan && r.reason === 'unreachable';
 }
 
 /**
@@ -159,6 +227,34 @@ export async function callDashboard(opts: {
   persistPort?: boolean;
   path: DashboardEndpoint;
   fetchImpl?: FetchImpl;
+  /**
+   * Allow a rescan when the recorded port is simply not listening.
+   *
+   * Pass true for a ONE-SHOT human command (`botmux dashboard`), which is what
+   * `executeDashboardCliCommand` does. Leave it false for the 500ms readiness
+   * poll, where `unreachable` is the normal booting state and scanning the range
+   * every tick would be pure waste.
+   *
+   * NOT gated on "the dashboard is not coming up": that observation is `true` for
+   * both `launching` AND `online` + live pid, and the measured failure was the
+   * latter (dashboard healthy on another port), so such a gate would never fire
+   * on the bug this exists for.
+   */
+  rescanWhenUnreachable?: boolean;
+  /** Override the per-probe timeout (default DISCOVERY_PROBE_TIMEOUT_MS). */
+  probeTimeoutMs?: number;
+  /**
+   * Bound the FIRST (recorded-port) request even without opting into a rescan.
+   *
+   * The readiness poll needs this: its 90s budget is only consulted AFTER
+   * `await callDashboard(...)` returns, so a recorded port that accepts the
+   * connection and never answers makes the first await hang forever — the outer
+   * budget and the retry loop are both unreachable. Bounding the request is the
+   * only thing that can interrupt it.
+   */
+  requestTimeoutMs?: number;
+  /** Override the whole-scan budget (default DISCOVERY_TOTAL_BUDGET_MS). */
+  discoveryBudgetMs?: number;
 }): Promise<DashboardResult> {
   const host = opts.host ?? '127.0.0.1';
   const probeSpan = opts.probeSpan ?? 20;
@@ -181,33 +277,79 @@ export async function callDashboard(opts: {
     || String(opts.defaultPort);
   const candidate = Number(recorded);
 
+  const probeTimeoutMs = opts.probeTimeoutMs ?? DISCOVERY_PROBE_TIMEOUT_MS;
+
   // 1. Try the recorded port. A success — or any state that proves we reached
   //    the dashboard (no-active-token / http-error) — is returned as-is.
-  const first = await requestDashboardAt({ host, port: candidate, path: opts.path, secret, fetchImpl });
+  //
+  //    This hop must be bounded whenever the caller can't otherwise interrupt it.
+  //    An opted-in one-shot command gets `probeTimeoutMs`; the readiness poll
+  //    passes `requestTimeoutMs` explicitly, because its own 90s budget is only
+  //    checked AFTER this await returns — so a recorded port that accepts and never
+  //    answers would hang the first iteration forever, with the outer budget and
+  //    the retry loop both unreachable. Callers that pass neither stay unbounded.
+  const firstTimeoutMs = opts.requestTimeoutMs
+    ?? (opts.rescanWhenUnreachable ? probeTimeoutMs : undefined);
+  const first = await requestDashboardAt({
+    host, port: candidate, path: opts.path, secret, fetchImpl,
+    ...(firstTimeoutMs === undefined ? {} : { timeoutMs: firstTimeoutMs }),
+  });
   if (reachedDashboard(first)) return first;
 
-  // 2. Rediscover only when some server answered on the recorded loopback port
-  //    but failed dashboard identity checks: explicit wrong-service 404, or a
-  //    sig_mismatch from a shadow/stale dashboard. (`unreachable` during boot
-  //    resolves by retrying the same port, not by scanning — so we leave it to
-  //    the caller's retry loop.)
-  if (!shouldRediscover(first)) return first;
+  // 2. Rediscover when the recorded port provably cannot be the dashboard:
+  //    something answered but failed identity checks (wrong-service 404 /
+  //    sig_mismatch), or — when the caller opted in, i.e. a one-shot human
+  //    command — nothing is listening there at all (a dead recorded port, which
+  //    retrying the same port can never fix).
+  if (!shouldRediscover(first, opts.rescanWhenUnreachable)) return first;
 
   const base = Number(opts.envPort || opts.defaultPort);
+  // TWO bounds, and both are needed. Per-probe alone degrades to
+  // `probeSpan × timeout` (21 × 2s ≈ 42s) because the loop is serial; a total
+  // deadline alone would let one stalled port consume the entire budget before
+  // any other candidate is tried. MEASURED without either: a local service that
+  // accepts TCP and never answers made `callDashboard` hang forever.
+  const deadline = Date.now() + (opts.discoveryBudgetMs ?? DISCOVERY_TOTAL_BUDGET_MS);
   for (let p = base; p <= base + probeSpan; p++) {
     if (p === candidate) continue;
+    // Out of budget: stop and report the ORIGINAL failure. Never invent a reason,
+    // and never rewrite the port file on the way out.
+    //
+    // This `break` and the `Math.min` clamp below have DISTINCT jobs:
+    //  • the break stops ISSUING probes once the budget is gone — after the
+    //    deadline no further connection or HMAC probe may be attempted at all;
+    //  • the clamp bounds the DURATION of a probe that is still allowed to start,
+    //    so the last one cannot overrun the budget by a full probeTimeoutMs.
+    // Wall-clock alone cannot tell them apart (deleting either leaves a 900ms
+    // budget at ~910ms, because a negative `remaining` clamps to a ~0ms timeout and
+    // probes then fail instantly). Each is pinned by its own test with a criterion
+    // that DOES discriminate: call-count for the break, and `budget <
+    // probeTimeoutMs` for the clamp. See dashboard-endpoint.test.ts.
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
     // Probe read-only (`/__cli/current`) so discovery never mints a token on a
     // server we're merely identifying. Only the real dashboard can answer the
     // HMAC-gated route as `ok` or `no-active-token`.
-    const probe = await requestDashboardAt({ host, port: p, path: '/__cli/current', secret, fetchImpl });
+    // Clamp to what is LEFT, or the last probe could overrun the budget by a full
+    // probeTimeoutMs (checking the deadline before the probe bounds when we start,
+    // not when we finish) — making the "total budget" a soft target rather than a cap.
+    const probe = await requestDashboardAt({
+      host, port: p, path: '/__cli/current', secret, fetchImpl,
+      timeoutMs: Math.min(probeTimeoutMs, remaining),
+    });
     if (probe.ok || (!probe.ok && probe.reason === 'no-active-token')) {
       if (persistPort) {
         try { atomicWriteFileSync(portFile, String(p)); } catch { /* best-effort self-heal */ }
       }
-      // Found the dashboard — perform the actually-requested op on its port.
-      return requestDashboardAt({ host, port: p, path: opts.path, secret, fetchImpl });
+      // Found the dashboard — perform the actually-requested op on its port. The
+      // real request gets its own fresh timeout: it is not discovery, and it must
+      // not inherit whatever the scan already spent.
+      return requestDashboardAt({
+        host, port: p, path: opts.path, secret, fetchImpl, timeoutMs: probeTimeoutMs,
+      });
     }
   }
-  // No dashboard found in the probe range; surface the original wrong-service.
+  // No dashboard found in the probe range; surface the original failure
+  // (wrong-service, auth-failed, or unreachable) rather than inventing one.
   return first;
 }

--- a/test/dashboard-endpoint.test.ts
+++ b/test/dashboard-endpoint.test.ts
@@ -22,7 +22,9 @@ import {
   classifyDashboard401,
   callDashboard,
   type DashboardEndpoint,
+  type DashboardResult,
 } from '../src/cli/dashboard-endpoint.js';
+import { executeDashboardCommand, executeDashboardCliCommand } from '../src/cli/dashboard-command.js';
 import { verifyHmac, cliAuthBind, signCliAuth } from '../src/dashboard/auth.js';
 
 const SECRET = Buffer.from('test-secret').toString('base64url');
@@ -203,6 +205,47 @@ describe('callDashboard', () => {
     });
     expect(r).toEqual({ ok: false, reason: 'unreachable' });
     expect(calls).toBe(1); // only the recorded port — no range scan on unreachable
+  });
+
+  it('rescans an unreachable recorded port ONLY when the caller opts in, and heals the file', async () => {
+    // MEASURED on a live box: `.dashboard-port` held 7893 while the dashboard was
+    // on 7891 with NOTHING listening on 7893. Nobody answering means `unreachable`,
+    // which the default path deliberately does not scan (see the test above), so
+    // the file stayed wrong forever and every `botmux dashboard` failed. The
+    // one-shot CLI command opts in unconditionally; the 500ms poll never does.
+    setPort(7893);
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/current',
+      rescanWhenUnreachable: true,
+      fetchImpl: makeFetch({ 7891: { kind: 'dashboard', hasToken: true } }),
+    });
+    expect(r).toEqual({ ok: true, url: 'http://host:7891/?t=current' });
+    // ...and the dead recorded port is healed, so the next call needs no rescan.
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe('7891');
+  });
+
+  it('opting in still reports unreachable when no dashboard exists in the range', async () => {
+    // Fail-closed: an opt-in rescan that finds nothing must surface the ORIGINAL
+    // unreachable, not invent a different reason — and must not corrupt the file.
+    setPort(7893);
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/current',
+      rescanWhenUnreachable: true,
+      fetchImpl: makeFetch({}),   // nothing listening anywhere
+    });
+    expect(r).toEqual({ ok: false, reason: 'unreachable' });
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe('7893');
+  });
+
+  it('the opt-in flag does not change wrong-service behaviour (already scanned before)', async () => {
+    // Guards against the flag accidentally becoming the ONLY path to a rescan.
+    setPort(7893);
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/current',
+      fetchImpl: makeFetch({ 7893: { kind: 'ipc' }, 7901: { kind: 'dashboard', hasToken: true } }),
+    });
+    expect(r).toEqual({ ok: true, url: 'http://host:7901/?t=current' });
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe('7901');
   });
 
   it('does not mint a token during discovery (probes /__cli/current, not rotate)', async () => {
@@ -448,4 +491,526 @@ describe('loopback client ignores $http_proxy (403 nginx regression)', () => {
       await Promise.all(servers.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
     }
   }, 40_000);
+});
+
+/**
+ * The CLI's dead-port recovery re-runs the WHOLE `dashboard` command through a
+ * rescan-enabled caller (rather than guessing which endpoint the action maps to,
+ * since `current` has a /__cli/current → /__cli/ensure → legacy-rotate ladder).
+ *
+ * That raises a fair objection: does re-running `rotate` mint the token TWICE?
+ * It cannot, and the reason is the gate itself — recovery only fires when the
+ * first attempt returned `unreachable`, i.e. nothing answered on the recorded
+ * port, so no dashboard performed any rotation. This pins that property, because
+ * widening the gate to a reason that DID reach a dashboard would silently start
+ * invalidating a freshly-issued link.
+ */
+describe('PRODUCTION WIRING: `botmux dashboard` recovers the measured failure', () => {
+  /**
+   * THE EXACT FAILURE THIS PR EXISTS FOR, driven through the shape the CLI uses.
+   *
+   * MEASURED on a live box:
+   *   - fleet state: dashboard member `online` with a LIVE pid
+   *     ⟹ "is a dashboard coming up?" answers TRUE
+   *   - `.dashboard-port` = 7893, with NOTHING listening there ⟹ `unreachable`
+   *   - the real dashboard was serving on 7891
+   *
+   * An earlier version of this fix gated the rescan on `stillComingUp === false`.
+   * That predicate is TRUE here (online + live pid), so the rescan would never
+   * have fired on the very input it was written for — the lower layer had the
+   * capability and the production path never enabled it. `botmux dashboard` is a
+   * one-shot human command, so it opts in from the first call; only the 500ms
+   * readiness poll keeps the default (no per-tick scanning).
+   */
+  it('opts in from the first call, so online+live-pid + dead recorded port still heals', async () => {
+    setPort(7893);
+    const cliCaller = (path: DashboardEndpoint) => callDashboard({
+      configDir: dir, defaultPort: 7891, path,
+      rescanWhenUnreachable: true,          // what cmdDashboard passes
+      fetchImpl: makeFetch({ 7891: { kind: 'dashboard', hasToken: true } }),
+    });
+    const execution = await executeDashboardCommand([], cliCaller);
+    expect(execution.kind).toBe('endpoint');
+    if (execution.kind === 'endpoint') {
+      expect(execution.result).toEqual({ ok: true, url: 'http://host:7891/?t=current' });
+    }
+    // The dead port is healed, so subsequent calls need no scan at all.
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe('7891');
+  });
+
+  it('the CLI wrapper itself passes the opt-in (behavioural, no source regex)', async () => {
+    // Directly exercise the unit `cmdDashboard` calls. Two earlier source-text
+    // guards were both wrong: one false-RED on extract-to-local, the other stayed
+    // GREEN when a flag-carrying call was disconnected from the caller passed down.
+    const seen: Array<{ path: string; opts: { rescanWhenUnreachable: boolean } }> = [];
+    const execution = await executeDashboardCliCommand([], async (path, opts) => {
+      seen.push({ path, opts });
+      return { ok: true, url: 'http://host:7891/?t=current' };
+    });
+    expect(execution.kind).toBe('endpoint');
+    expect(seen.length).toBeGreaterThan(0);
+    // EVERY endpoint call the wrapper makes must carry the opt-in — not just one.
+    for (const c of seen) expect(c.opts).toEqual({ rescanWhenUnreachable: true });
+  });
+
+  it('the wrapper opts in on the rotate path too', async () => {
+    const seen: Array<{ rescanWhenUnreachable: boolean }> = [];
+    await executeDashboardCliCommand(['rotate'], async (_path, opts) => {
+      seen.push(opts);
+      return { ok: true, url: 'http://host:7891/?t=fresh' };
+    });
+    expect(seen).toEqual([{ rescanWhenUnreachable: true }]);
+  });
+
+  it('the wrapper opts in across the current → ensure fallback ladder', async () => {
+    // `current` can walk /__cli/current → /__cli/ensure; a wrapper that only
+    // opted in on the first hop would leave the ladder unhealed.
+    const paths: string[] = [];
+    await executeDashboardCliCommand(['current'], async (path, opts) => {
+      paths.push(path);
+      expect(opts).toEqual({ rescanWhenUnreachable: true });
+      if (path === '/__cli/current') return { ok: false, reason: 'no-active-token' };
+      return { ok: true, url: 'http://host:7891/?t=created' };
+    });
+    expect(paths).toContain('/__cli/current');
+    expect(paths).toContain('/__cli/ensure');
+  });
+
+  it('cmdDashboard goes through the wrapper (minimal source pin, no nested parsing)', () => {
+    // The behavioural tests above prove the WRAPPER opts in; they cannot see
+    // cli.ts choosing the raw helper instead (VERIFIED: that swap left them all
+    // green). cli.ts exports no cmdDashboard, so pin exactly one fact — which
+    // function it calls — rather than parsing a nested callback's options object.
+    // That earlier, more ambitious regex was wrong twice; this asserts one name.
+    const src = readFileSync(join(import.meta.dirname, '..', 'src', 'cli.ts'), 'utf8');
+    const start = src.indexOf('async function cmdDashboard(');
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf('\n}', start);
+    const body = src.slice(start, end)
+      .split('\n').map(l => l.replace(/\/\/.*$/, '')).join('\n');   // strip comments: they name both fns
+    expect(body).toContain('executeDashboardCliCommand(');
+    // ...and must NOT reach past the wrapper to the un-opted-in helper.
+    expect(body).not.toMatch(/[^i]executeDashboardCommand\(/);
+  });
+
+  it('printDashboardHintWithRetry bounds its request (its own budget cannot interrupt a hung await)', () => {
+    // Its 90s budget is only consulted AFTER `await callDashboardEndpoint(...)`
+    // returns, so a recorded port that accepts and never answers hangs the first
+    // iteration forever — the outer budget and the retry loop are both unreachable.
+    // Bounding the request is the ONLY thing that can interrupt it. Source-pinned
+    // because cli.ts exports nothing here; the value itself is checked behaviourally
+    // by `requestTimeoutMs` tests above.
+    const src = readFileSync(join(import.meta.dirname, '..', 'src', 'cli.ts'), 'utf8');
+    const start = src.indexOf('async function printDashboardHintWithRetry(');
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf('\n}', start);
+    const body = src.slice(start, end)
+      .split('\n').map(l => l.replace(/\/\/.*$/, '')).join('\n');
+    expect(body).toMatch(/callDashboardEndpoint\([^)]*\{[^}]*requestTimeoutMs/);
+  });
+
+  it('printDashboardHintWithRetry does NOT opt in (minimal source pin)', () => {
+    // The behavioural tests below only show that the RAW helper passes one
+    // argument; they cannot see the production poll adding the flag itself
+    // (VERIFIED: adding `{ rescanWhenUnreachable: true }` to the poll's own call
+    // left all 179 tests green). A 500ms poll that scanned the probe range every
+    // tick would turn every boot into repeated port scans, so pin it directly.
+    const src = readFileSync(join(import.meta.dirname, '..', 'src', 'cli.ts'), 'utf8');
+    const start = src.indexOf('async function printDashboardHintWithRetry(');
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf('\n}', start);
+    expect(end).toBeGreaterThan(start);
+    const body = src.slice(start, end)
+      .split('\n').map(l => l.replace(/\/\/.*$/, '')).join('\n');   // its comments name the flag
+    expect(body).toContain('callDashboardEndpoint(');
+    expect(body).not.toContain('rescanWhenUnreachable');
+    // ...and it must not route through the CLI wrapper, which always opts in.
+    expect(body).not.toContain('executeDashboardCliCommand');
+  });
+
+  it('the raw command helper does NOT opt in (the readiness poll shape)', async () => {
+    // executeDashboardCommand takes a single-arg caller: the poll passes
+    // callDashboardEndpoint directly, so no options object reaches callDashboard
+    // and the default (no scanning on unreachable) applies.
+    const argCounts: number[] = [];
+    await executeDashboardCommand([], async function (...received: unknown[]) {
+      argCounts.push(received.length);
+      return { ok: true, url: 'http://host:7891/?t=current' };
+    });
+    // Exactly one argument (the path) — no options object, hence no opt-in.
+    expect(argCounts.length).toBeGreaterThan(0);
+    for (const n of argCounts) expect(n).toBe(1);
+  });
+
+  it('the readiness poll shape (opt-in OFF) still does NOT scan', async () => {
+    // Same inputs, minus the opt-in: proves the flag is what makes the difference,
+    // and that the boot poll keeps its no-scan behaviour.
+    setPort(7893);
+    let calls = 0;
+    const base = makeFetch({ 7891: { kind: 'dashboard', hasToken: true } });
+    const counting = (async (...a: Parameters<typeof fetch>) => { calls++; return base(...a); }) as typeof fetch;
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/current', fetchImpl: counting,
+    });
+    expect(r).toEqual({ ok: false, reason: 'unreachable' });
+    expect(calls).toBe(1);
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe('7893');
+  });
+});
+
+describe('dead-port recovery has no duplicate token side effect', () => {
+  it('rotate is served exactly once — the recovery is a single opt-in call', async () => {
+    // Production makes ONE opt-in call (an earlier draft ran a default call then
+    // re-ran the whole command; that gate is gone). So the guarantee is simply
+    // that the wrapper does not multiply rotations: the dead recorded port is
+    // skipped inside callDashboard's rescan, and only the real dashboard serves.
+    setPort(7893);
+    let servedRotations = 0;
+    const fetchImpl = makeFetch({ 7891: { kind: 'dashboard', hasToken: true } });
+    const counting = (async (input: string, init?: RequestInit) => {
+      const u = new URL(input);
+      // Count only rotations a LIVE dashboard serves. The first attempt targets
+      // the dead recorded port 7893 and throws ECONNREFUSED — it reaches nothing,
+      // so it mints nothing. Counting attempts instead of served requests would
+      // report 2 and wrongly look like a double rotation.
+      if (u.pathname === '/__cli/rotate' && u.port === '7891') servedRotations++;
+      return fetchImpl(input, init);
+    }) as unknown as typeof fetch;
+
+    const execution = await executeDashboardCliCommand(['rotate'], (path, opts) => callDashboard({
+      configDir: dir, defaultPort: 7891, path, fetchImpl: counting,
+      rescanWhenUnreachable: opts.rescanWhenUnreachable,
+    }));
+    expect(execution.kind).toBe('endpoint');
+    if (execution.kind === 'endpoint') expect(execution.result.ok).toBe(true);
+    // Exactly one rotation reached a real dashboard, and the port file is healed.
+    expect(servedRotations).toBe(1);
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe('7891');
+  });
+
+  it('discovery probes read-only, so a rescan never mints a token on a stranger', async () => {
+    // The rescan identifies candidates via /__cli/current (read-only) before
+    // issuing the requested op, so scanning cannot rotate someone else's token.
+    setPort(7893);
+    const seen: string[] = [];
+    const base = makeFetch({ 7891: { kind: 'dashboard', hasToken: true } });
+    const spy = (async (input: string, init?: RequestInit) => {
+      const u = new URL(input);
+      seen.push(`${u.port} ${u.pathname}`);
+      return base(input, init);
+    }) as unknown as typeof fetch;
+    await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/rotate',
+      rescanWhenUnreachable: true, fetchImpl: spy,
+    });
+    const hits = seen.filter(x => x.startsWith('7891 '));
+    expect(hits[0]).toBe('7891 /__cli/current');
+    expect(hits).toContain('7891 /__cli/rotate');
+  });
+});
+
+/**
+ * REAL TRANSPORT: discovery must be bounded.
+ *
+ * `loopbackFetch` sets no request timeout, and the probe loop is serial, so a
+ * local service that accepts the TCP connection and never sends HTTP headers used
+ * to hang `callDashboard` FOREVER (MEASURED: outer `timeout` returned rc=124 with
+ * no result). This PR is what feeds ordinary `unreachable` human commands into
+ * that scan, so an input that used to fail fast could instead wedge permanently.
+ * These use real sockets — a mocked fetch cannot express "accepts and stalls".
+ */
+describe('discovery is bounded (real sockets)', () => {
+  const stalls: import('node:net').Server[] = [];
+  const httpServers: import('node:http').Server[] = [];
+  const liveSockets: import('node:net').Socket[] = [];
+  afterEach(async () => {
+    // `close()` only stops accepting; it RESOLVES ONLY AFTER existing connections
+    // end — and a stalled socket never ends on its own, so the hook would hang
+    // (observed: "Hook timed out in 10000ms"). Destroy held sockets first.
+    for (const sock of liveSockets.splice(0)) sock.destroy();
+    await Promise.all(stalls.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
+    await Promise.all(httpServers.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
+  });
+
+  /** A socket that accepts and never replies — the pathological case. */
+  async function stalledPort(): Promise<number> {
+    const { createServer } = await import('node:net');
+    const s = createServer((sock) => { liveSockets.push(sock); });  // accept, say nothing
+    stalls.push(s);
+    await new Promise<void>(r => s.listen(0, '127.0.0.1', () => r()));
+    return (s.address() as import('node:net').AddressInfo).port;
+  }
+
+  it('skips a stalled candidate within budget and still finds the real dashboard', async () => {
+    // Ordering must be deterministic AND race-free. Earlier attempts (retrying
+    // random OS ports; binding realPort-1) both flaked — one leaked listeners and
+    // shifted the scan span, the other raced for a specific port. Instead: claim
+    // TWO adjacent ports up front by probing pairs, so the stall is provably the
+    // first candidate and the dashboard the second.
+    const { createServer: netServer } = await import('node:net');
+    const { createServer: httpServer } = await import('node:http');
+
+    let stalled = -1, realPort = -1;
+    for (let attempt = 0; attempt < 12 && realPort < 0; attempt++) {
+      const probe = netServer();
+      await new Promise<void>(r => probe.listen(0, '127.0.0.1', () => r()));
+      const lo = (probe.address() as import('node:net').AddressInfo).port;
+      await new Promise<void>(r => probe.close(() => r()));
+
+      const stall = netServer((sock) => { liveSockets.push(sock); });
+      const real = httpServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ url: 'http://127.0.0.1/?t=found' }));
+      });
+      try {
+        await new Promise<void>((res, rej) => {
+          stall.once('error', rej); stall.listen(lo, '127.0.0.1', () => res());
+        });
+        await new Promise<void>((res, rej) => {
+          real.once('error', rej); real.listen(lo + 1, '127.0.0.1', () => res());
+        });
+        stalls.push(stall); httpServers.push(real);
+        stalled = lo; realPort = lo + 1;
+      } catch {
+        // One of the pair was taken — release both and try another pair.
+        await new Promise<void>(r => stall.close(() => r())).catch(() => {});
+        await new Promise<void>(r => real.close(() => r())).catch(() => {});
+      }
+    }
+    // FAIL LOUD. A bare `return` here reports as PASSED in vitest (verified), so a
+    // CI port race would silently count this as green with zero behaviour checked.
+    expect(realPort, 'fixture could not claim an adjacent port pair after 12 tries').toBeGreaterThan(0);
+
+    setPort(realPort + 1_000);                 // recorded port: nobody listening
+    const t0 = Date.now();
+    const r = await callDashboard({
+      configDir: dir, defaultPort: stalled, probeSpan: 1, path: '/__cli/current',
+      rescanWhenUnreachable: true, probeTimeoutMs: 300, discoveryBudgetMs: 5_000,
+    });
+    const elapsed = Date.now() - t0;
+    expect(r.ok).toBe(true);
+    expect(elapsed).toBeLessThan(5_000);
+    // ...and the port file is healed to the dashboard actually found.
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe(String(realPort));
+  }, 40_000);
+
+  it('bounds a server that sends headers then stalls MID-BODY, and still finds the dashboard', async () => {
+    // A fetch resolves its Response as soon as HEADERS arrive, so clearing the
+    // timeout right after the fetch leaves `.text()`/`.json()` unbounded. MEASURED
+    // against that shape: rc=124, permanently wedged — per-probe AND total budget
+    // both bypassed. "Sends no headers at all" does NOT cover this.
+    const { createServer: netServer } = await import('node:net');
+    const { createServer: httpServer } = await import('node:http');
+
+    let stalledPortNum = -1, realPort = -1;
+    for (let attempt = 0; attempt < 12 && realPort < 0; attempt++) {
+      const probe = netServer();
+      await new Promise<void>(r => probe.listen(0, '127.0.0.1', () => r()));
+      const lo = (probe.address() as import('node:net').AddressInfo).port;
+      await new Promise<void>(r => probe.close(() => r()));
+
+      // Full 200 JSON headers, then one '{' and silence forever.
+      const stall = netServer((sock) => {
+        liveSockets.push(sock);
+        sock.on('data', () => {
+          sock.write('HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 100\r\n\r\n{');
+        });
+      });
+      const real = httpServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ url: 'http://127.0.0.1/?t=found' }));
+      });
+      try {
+        await new Promise<void>((res, rej) => { stall.once('error', rej); stall.listen(lo, '127.0.0.1', () => res()); });
+        await new Promise<void>((res, rej) => { real.once('error', rej); real.listen(lo + 1, '127.0.0.1', () => res()); });
+        stalls.push(stall); httpServers.push(real);
+        stalledPortNum = lo; realPort = lo + 1;
+      } catch {
+        await new Promise<void>(r => stall.close(() => r()));
+        await new Promise<void>(r => real.close(() => r()));
+      }
+    }
+    expect(realPort, 'fixture could not claim an adjacent port pair').toBeGreaterThan(0);
+    expect(stalledPortNum).toBeLessThan(realPort);   // stall must be probed first
+
+    setPort(realPort + 1_000);                       // recorded port: nobody there
+    const t0 = Date.now();
+    const r = await callDashboard({
+      configDir: dir, defaultPort: stalledPortNum, probeSpan: 1, path: '/__cli/current',
+      rescanWhenUnreachable: true, probeTimeoutMs: 300, discoveryBudgetMs: 3_000,
+    });
+    const elapsed = Date.now() - t0;
+    expect(r.ok).toBe(true);                         // moved past the body-stall
+    expect(elapsed).toBeLessThan(3_000);
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe(String(realPort));
+  }, 40_000);
+
+  it('bounds the FIRST recorded-port request too (opted-in callers only)', async () => {
+    // If `.dashboard-port` itself points at an accept-and-stall service, an
+    // unbounded first request hangs before discovery even begins — so a
+    // "bounded command" must include this hop, not just the scan.
+    const stalled = await stalledPort();
+    setPort(stalled);                                // recorded port IS the stall
+    const t0 = Date.now();
+    const r = await callDashboard({
+      configDir: dir, defaultPort: stalled + 500, probeSpan: 0, path: '/__cli/current',
+      rescanWhenUnreachable: true, probeTimeoutMs: 300, discoveryBudgetMs: 1_000,
+    });
+    const elapsed = Date.now() - t0;
+    expect(r).toEqual({ ok: false, reason: 'unreachable' });
+    expect(elapsed).toBeLessThan(2_000);
+  }, 40_000);
+
+  it('a 500 with an ABORTED body does not block self-heal (abort must not read as http-error)', async () => {
+    // Every status branch used to do `.text().catch(() => '')`, turning an aborted
+    // body into an empty one. So `500 headers` + a body that never completes was
+    // classified `http-error` — and `reachedDashboard(http-error)` is TRUE, so
+    // rediscovery STOPPED and the stale port file survived. MEASURED before the
+    // fix: `{reason:'http-error', detail:'500 '}` in 305ms, port file unchanged,
+    // real dashboard never probed. A one-line label bug that silently defeats the
+    // whole feature.
+    const { createServer: netServer } = await import('node:net');
+    const { createServer: httpServer } = await import('node:http');
+    const stall = netServer((sock) => {
+      liveSockets.push(sock);
+      sock.on('data', () => {
+        sock.write('HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: 100\r\n\r\nhalf');
+      });
+    });
+    stalls.push(stall);
+    await new Promise<void>(r => stall.listen(0, '127.0.0.1', () => r()));
+    const stallPort = (stall.address() as import('node:net').AddressInfo).port;
+
+    const real = httpServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ url: 'http://127.0.0.1/?t=found' }));
+    });
+    httpServers.push(real);
+    await new Promise<void>(r => real.listen(0, '127.0.0.1', () => r()));
+    const realPort = (real.address() as import('node:net').AddressInfo).port;
+
+    setPort(stallPort);                       // recorded port IS the 500-staller
+    const r = await callDashboard({
+      configDir: dir, defaultPort: realPort, probeSpan: 0, path: '/__cli/current',
+      rescanWhenUnreachable: true, probeTimeoutMs: 300, discoveryBudgetMs: 2_000,
+    });
+    expect(r.ok).toBe(true);                  // rediscovery ran and succeeded
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe(String(realPort));
+  }, 40_000);
+
+  it('a COMPLETE malformed body still classifies normally (abort fix must not over-reach)', async () => {
+    // The counterpart: only an aborted read may become `unreachable`. A body that
+    // finishes but is not valid JSON must remain http-error, as before.
+    setPort(7891);
+    const fetchImpl = (async () => new Response('not json at all', { status: 200 })) as unknown as typeof fetch;
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/current', fetchImpl,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('http-error');
+  });
+
+  it('the deadline STOPS issuing probes (clamp alone would still connect)', async () => {
+    // Separable from the clamp, using CALL COUNT rather than wall clock: after the
+    // budget expires the loop must issue no further requests. With `break` removed
+    // but the clamp kept, the loop keeps calling fetchImpl with a ~0ms timeout —
+    // elapsed time looks fine, but budgeted-out connections are still attempted.
+    setPort(7893);
+    let calls = 0;
+    const slow = (async (input: string) => {
+      calls++;
+      await new Promise(r => setTimeout(r, 250));   // each probe eats the budget
+      void input;
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    await callDashboard({
+      configDir: dir, defaultPort: 7891, probeSpan: 20, path: '/__cli/current',
+      rescanWhenUnreachable: true, fetchImpl: slow,
+      probeTimeoutMs: 5_000, discoveryBudgetMs: 600,
+    });
+    // 1 recorded-port attempt + ~2-3 probes inside a 600ms budget. Far below the
+    // 21 the loop would attempt if the deadline never stopped it.
+    expect(calls).toBeLessThan(8);
+    expect(calls).toBeGreaterThan(1);
+  }, 30_000);
+
+  it('the clamp caps the LAST probe so the budget is not overrun by a full timeout', async () => {
+    // Separable from the break, per codex's construction: pick
+    // `budget < probeTimeout`, so the deadline expires DURING the first probe. With
+    // the clamp the probe is cut at `remaining`; without it, that probe runs the
+    // full probeTimeoutMs and the total overruns by nearly a whole timeout.
+    const stalled = await stalledPort();
+    setPort(stalled + 700);                    // recorded port: nobody listening
+    const t0 = Date.now();
+    const r = await callDashboard({
+      configDir: dir, defaultPort: stalled, probeSpan: 1, path: '/__cli/current',
+      rescanWhenUnreachable: true,
+      probeTimeoutMs: 3_000,                   // >> budget on purpose
+      discoveryBudgetMs: 400,
+    });
+    const elapsed = Date.now() - t0;
+    expect(r).toEqual({ ok: false, reason: 'unreachable' });
+    // Clamped: ~400ms. Unclamped: ~3s (the stall runs the full probe timeout).
+    expect(elapsed).toBeLessThan(1_500);
+  }, 30_000);
+
+  it('the TOTAL budget bounds a span of many stalled ports, not just each probe', async () => {
+    // Per-probe alone degrades to `stalled_count × probeTimeout` because the loop
+    // is serial. A single stalled port cannot show this (the other candidates are
+    // dead and fail instantly, so the deadline never binds — an earlier version of
+    // this test made exactly that mistake and the mutation survived). Fill MANY
+    // adjacent ports with stalled listeners so the serial cost is real.
+    const { createServer: netServer } = await import('node:net');
+    const probe = netServer();
+    await new Promise<void>(r => probe.listen(0, '127.0.0.1', () => r()));
+    const lo = (probe.address() as import('node:net').AddressInfo).port;
+    await new Promise<void>(r => probe.close(() => r()));
+
+    let bound = 0;
+    for (let i = 0; i < 10; i++) {
+      const st = netServer((sock) => { liveSockets.push(sock); });
+      try {
+        await new Promise<void>((res, rej) => {
+          st.once('error', rej); st.listen(lo + i, '127.0.0.1', () => res());
+        });
+        stalls.push(st); bound++;
+      } catch { /* that port was taken; keep going */ }
+    }
+    // FAIL LOUD (see above): silently passing would make the deadline mutation
+    // toothless in CI, which is the one place it most needs teeth.
+    expect(bound, `fixture bound only ${bound} stalled ports; need >= 6 for the serial cost to show`).toBeGreaterThanOrEqual(6);
+
+    setPort(lo + 900);                          // recorded port: nobody listening
+    const t0 = Date.now();
+    const r = await callDashboard({
+      configDir: dir, defaultPort: lo, probeSpan: 10, path: '/__cli/current',
+      rescanWhenUnreachable: true, probeTimeoutMs: 300, discoveryBudgetMs: 900,
+    });
+    const elapsed = Date.now() - t0;
+    expect(r).toEqual({ ok: false, reason: 'unreachable' });
+    // The budget is a HARD cap: the loop stops issuing probes at the deadline AND
+    // clamps the last probe to the time remaining. This wall-clock threshold catches
+    // the two bounds together (with 10 stalled ports and budget=900ms: ~910ms with
+    // either in place, ~3.0s with both gone). Each bound ALSO has its own test with
+    // a criterion that discriminates it individually — call-count for the deadline
+    // break, `budget < probeTimeoutMs` for the clamp — so a single-bound regression
+    // is caught there, not here.
+    expect(elapsed).toBeLessThan(1_400);
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe(String(lo + 900));
+  }, 40_000);
+
+  it('returns the original unreachable within budget with one stall and the rest down', async () => {
+    const a = await stalledPort();
+    setPort(a + 5);                  // recorded port: nobody listening
+    const t0 = Date.now();
+    const r = await callDashboard({
+      configDir: dir, defaultPort: a, probeSpan: 3, path: '/__cli/current',
+      rescanWhenUnreachable: true, probeTimeoutMs: 300, discoveryBudgetMs: 2_000,
+    });
+    const elapsed = Date.now() - t0;
+    expect(r).toEqual({ ok: false, reason: 'unreachable' });
+    expect(elapsed).toBeLessThan(4_000);
+    // fail-closed: a fruitless scan must not rewrite the port file.
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe(String(a + 5));
+  }, 30_000);
 });


### PR DESCRIPTION
## 问题

`~/.botmux/.dashboard-port` 记录的端口一旦失效，且**该端口上没有任何进程监听**，
`botmux dashboard` 会永久失败，而现有自愈机制**永不触发**。

实测：

| | |
|---|---|
| 活着的 dashboard 实际监听 | 7891（`curl` → 401，可达） |
| `.dashboard-port` 记录 | 7893（`curl` → 000，无人监听） |
| fleet state 里 dashboard 成员 | `online`，pid 真活 |
| 全部日志 `listening on …:7891` / `…:7893` | 371 次 / **0 次** |

## 根因

`dashboard-endpoint.ts` 已有自愈：记录端口不对时在探测范围内 HMAC 扫描，找到真
dashboard 后回写端口文件。但判据是

```ts
return !r.ok && (r.reason === 'wrong-service' || r.reason === 'auth-failed');
```

即**只有「有人应答但身份不对」才扫描**。「没人监听」得到 `unreachable`
⟹ 自愈永不运行 ⟹ 端口文件永久停在死值。

`unreachable` **一个 reason 混了两种状态**：
- dashboard 还在启动中 —— 靠重试**同一端口**解决，扫描是每个轮询 tick 的纯浪费；
- 记录端口是死值 —— 重试同一端口**永不可能成功**，不扫描就永久坏。

## 改法

`dashboard-endpoint.ts` 加 opt-in 参数 `rescanWhenUnreachable`，默认 `false`：

```ts
function shouldRediscover(r, allowUnreachableRescan = false) {
  if (r.ok) return false;
  if (r.reason === 'wrong-service' || r.reason === 'auth-failed') return true;
  return allowUnreachableRescan && r.reason === 'unreachable';
}
```

`botmux dashboard` 是**一次性人工命令**，不是 500ms 轮询，所以**从第一次调用就 opt-in**；
最坏情况是用户每次手动执行时扫一遍探测范围。`printDashboardHintWithRetry()` 保持默认
`false`，轮询绝不每 tick 扫。

⚠️ **不能把门槛设成「已确认 dashboard 不在启动中」**（`stillComingUp === false`）：
观测态的 `true` 同时包含 `launching`（可能尚未 bind）与 `online + pid 活`（**正是本故障
的真实形态**），用那个判据扫描在**本故障的逐字输入上永不触发**。

接线本身抽成**可导入的** `executeDashboardCliCommand(args, callEndpoint)`
（`cli/dashboard-command.ts`），由它唯一地接上 opt-in，`cmdDashboard` 只调用它。
这样「能力」与「接线」都能用**行为测试**验证，不必解析源码里的嵌套 callback。

## 扫描必须有界（否则 `botmux dashboard` 可永久挂住）

`loopbackFetch` 不设 request timeout，探测循环又是串行的。所以探测范围里只要有一个本地
服务**接受 TCP 但永不返回 HTTP headers**，扫描就永久停在那里。实测（修复前）：外层
`timeout` 返回 **rc=124，无任何返回值**。本 PR 正是把普通 `unreachable` 的人工命令送进
这个扫描，因此原本快速失败的输入会变成**无限挂住** —— 属于本 PR 引入的退化，必须一起修。

三处都要有界：

- **每个 probe** 一个 `AbortSignal`（`DISCOVERY_PROBE_TIMEOUT_MS = 2s`），且**覆盖整个
  交换过程**：fetch 在收到 **headers** 就 resolve Response，所以只包住 fetch、之后再
  `.text()`/`.json()` 的写法，遇到「200 headers + 半个 body 后永不结束」仍会永久挂住
  （实测 rc=124）。timer 现在包到分类收尾，`finally` 里 `clearTimeout`（活 timer 会吊住
  CLI 的 event loop）。⚠️ body 读取用 `.text()` 后再 `JSON.parse`，**不**用
  `.json().catch()` —— 后者会把 abort 一起吞掉，把 stall 误报成 malformed；完整但非法的
  body 仍返回 `http-error`。
- **body 读取只做一次，且任何 status 分支都不吞失败**。原先 404/401/非 2xx 三条都是
  `.text().catch(() => '')`，会把**被中断**的 body 当成空 body ⟹ 「`500` headers + 半个
  body 后 stall」被判成 `http-error`。这不只是标签错：`reachedDashboard(http-error)` 为
  **真** ⟹ **rediscovery 直接终止**、端口文件保持陈旧，一个 stall 服务就能永久挡住自愈。
  实测修复前 305ms 返回 `{reason:'http-error'}`、端口文件未变、真 dashboard 从未被探测。
  改为先读一次 `.text()` 再按 status 分类：**完整**但非法的 body 仍走原分类，只有**被
  中断**的读取落到 `unreachable`。
- **首次 recorded-port 请求**也有界。opt-in 的一次性命令用 `probeTimeoutMs`；**轮询侧显式
  传 `requestTimeoutMs`** —— 它那 90s 预算只在 `await` **返回之后**才检查，所以 recorded
  端口 accept-and-stall 时第一轮 await 永不返回，外层预算与重试**都不可达**，只有给单次
  请求设界才能中断它。
- **整次 discovery** 一个总预算（`DISCOVERY_TOTAL_BUDGET_MS = 8s`）：循环在发 probe 前
  检查 deadline 并 `break`，**且**把该 probe 的 timeout 夹到 `remaining` —— 只检查不夹，
  最后一个 probe 能把总时长拖到 `budget + probeTimeout`。

超预算时返回**原始** failure，不伪造 reason、不改写端口文件。

⚠️ 这两道界**用墙钟时间无法互相区分**（10 个 stalled 端口 + budget=900ms 时单删任一道
都是 ~910ms，因为 `remaining` 变负会夹出 ~0ms timeout），但**语义可分，且各自单测**：
- 删 `break`（留夹取）⟹ 预算耗尽后**仍在发起连接/HMAC probe**，只是 timeout ≈ 0。
  用**注入 fetch 计调用数**咬住（预算内 < 8 次，而无 break 会走满 21 次）。
- 删夹取（留 `break`）⟹ 取 `budget < probeTimeout`，deadline 在**首个 probe 期间**到期，
  该 probe 会跑满整个 `probeTimeoutMs`。实测夹取 ~400ms / 不夹取 ~3s。

## 影响面

- **另外 3 个调用方（`platform/bind.ts` ×2、desktop `runtime-service.ts` ×1）均未 opt-in**
  ⟹ 它们的 `unreachable` **不会触发扫描**，端口解析行为不变。
  ⚠️ 但**不是「逐字不变」**：本 PR 同时重构了**所有 status 分支的 body 读取**（只读一次、
  不吞失败），并给 `requestDashboardAt` 增加了 timeout 能力。对它们的可观察影响是：
  一个**被中断**的 body 现在报 `unreachable` 而非 `http-error`（这正是本次修的缺陷）；
  完整 body 的分类与超时默认值（不传即无界）都不变。
- 只影响 CLI 侧端口解析的失败分支；dashboard 进程本身、写端口文件的逻辑一行未改
- **fail-closed**：opt-in 扫描无果时返回**原始** `unreachable`，不伪造 reason、
  不改写端口文件
- 未触及：CLI 适配器、会话后端、飞书消息路径，及 daemon 侧读端口的其余 6 处

## 验证

```
bun run build → 通过

npx vitest run test/dashboard-endpoint.test.ts test/dashboard-command.test.ts \
  test/dashboard-command-c1.test.ts test/dashboard-readiness-race.test.ts \
  test/autostart-standalone-path.test.ts test/devbox-dashboard-export.test.ts \
  test/daemon-internal-client-wrapper.test.ts test/dashboard-ipc-port-range.test.ts
  Test Files  8 passed (8)
       Tests  190 passed (190)    exit=0
  （dashboard-endpoint 49 / dashboard-command 31 / devbox-export 25 /
    readiness-race 24 / command-c1 23 / internal-client 22 / autostart 15 / ipc-range 1）
```

用例覆盖：本故障逐字形态（`online`+pid 活 / 记录 7893 无人监听 / 真 dashboard 7891）
经 CLI 路径后成功并**回写 7891**；opt-in 无果时仍报原始 `unreachable` 且端口文件不被
污染；opt-in 不改变 `wrong-service` 既有行为；wrapper 在 `rotate` 与
`current → ensure` 回退阶梯上**每一跳都带 opt-in**；扫描用只读 `/__cli/current` 识别，
不会在陌生服务上签发 token；真 dashboard 只服务**一次** rotate。

**接线用行为测试而非源码正则钉住**：直接调用 wrapper、用 fake endpoint 记录收到的
options。仅保留**一条**最小源码断言（`cli.ts` 无可导出的 `cmdDashboard`）：`cmdDashboard`
必须调 wrapper、且不得越过它直接用未 opt-in 的原始 helper。

**变异矩阵：15 条，全部咬红**（每条先核对变异真的落地才跑）：

| 变异 | 结果 |
|---|---|
| 撤掉修复（`unreachable` 永不扫描） | 🔴 |
| 忽略参数、`unreachable` 一律扫描（启动中退化） | 🔴 |
| 判据去掉 `wrong-service` | 🔴 |
| 扫描无果时伪造 `wrong-service` | 🔴 |
| wrapper 里 opt-in 改成 `false` | 🔴 |
| **wrapper 里带 flag 的调用与真正传下去的 caller 断开** | 🔴 |
| **`cmdDashboard` 越过 wrapper 直接用原始 helper** | 🔴 |
| **启动轮询自己加上 opt-in（每 tick 扫描）** | 🔴 |
| **删掉 per-probe timeout（stall 端口挂死扫描）** | 🔴 |
| **timer 只包到 headers（body stall 挂死）** | 🔴 |
| **首跳不传 timeout（recorded 端口即 stall 时挂死）** | 🔴 |
| **单独去掉 deadline `break`（用调用数咬住）** | 🔴 |
| **单独去掉 `remaining` 夹取（budget < probeTimeout）** | 🔴 |
| **404/401/非 2xx 重新用 `.catch` 吞掉 abort** | 🔴 |
| **轮询丢掉 `requestTimeoutMs`** | 🔴 |

合法重构（多行排版、caller 抽成局部变量）保持全绿。

有界性用**真 socket**验证（mock fetch 无法表达「接受连接但不应答」）：stall 端口排在真
dashboard **之前**仍能在预算内跳过并找到它；**全部候选 stall/dead** 时在预算内返回原始
`unreachable` 且不改端口文件；**多个 stalled 端口的宽 span** 由总预算兜住。
最后一条尤其重要 —— 第一版只造了**一个** stall 端口，其余候选是死端口、瞬间失败，
**总预算根本不生效，删掉它变异照样全绿**；实测同一 span 有 deadline 1.2s / 无 deadline
2.4s，阈值取 1.8s 才真正咬住。

socket 夹具**全部 fail-loud**：原先建不成夹具就 `return`，而 vitest 里**裸 `return`
计为 PASSED 而非 skipped**（已单独验证），CI 上端口竞争会让最关键的两条静默计入 passed
却一行行为没验。现在改成带诊断信息的 `expect`。

时序类用例反复跑过 3 轮全绿（此前两版夹具分别因「随机端口重试泄漏 listener」和
「抢固定端口」而 flaky，现改为**成对占用相邻端口**，失败即 skip 而不是断言竞态）。

⚠️ 这套判据是**推翻两版源码正则**后才成立的：第一版钉死内联箭头排版，合法的
extract-to-local 会**误红**；第二版放宽后只是「同一函数体内共现」，把带 flag 的调用与
真正传下去的 caller **完全断开仍然全绿**。行为测试从结构上排除了这两类。


## 已知边界（本 PR **不**处理，如实列出）

`.dashboard-port` 本身还有更深的设计问题，属于另一件事：

- **从不删除**：优雅退出 / SIGTERM / 绑定失败 `process.exit(1)` / fleet supervisor
  回收成员，全都不清理它 ⟹ 进程死后文件永久陈旧；
- **无锁、last-writer-wins**：两个 dashboard 实例可共存（探测机制正是为此存在），
  第二个无条件覆盖文件且**赢**；崩溃的第二个会把所有读者永久指偏。同目录的
  `.dashboard-secret` / `.dashboard-token` 都走 `withLeafLock` 的可线性化 get-or-create，
  只有端口文件是裸写；
- **内容不含 liveness 信息**：只有一个裸整数，没有 pid / boot id / 时间戳，
  所以**任何读者都无法判断它是否还有效**。同目录的 `devbox-dashboard-export.json`
  存了 `port` 便于读者自行判陈旧，是可参考的先例；
- 另有 **6 个读取点**（`workbench-link.ts`、`daemon.ts`、
  `daemon-internal-client-wrapper.ts`、`devbox-dashboard-export.ts`、`smoke.ts`、
  `cli.ts` 的短链导出）**完全不做校验**，直接拿整数拼 URL。

本 PR 只做**最小、可验证**的一件事：让已存在的自愈机制覆盖「没人监听」这种情况。
上面那些需要改文件格式或生命周期，应单独设计与验证。
