### PR TITLE
fix(clone): 补齐克隆排除字段并让表单显示真实生效配置

### DIFF
--- a/src/dashboard/bot-payload.ts
+++ b/src/dashboard/bot-payload.ts
@@ -81,6 +81,9 @@ export function botDefaultsPayload(bot: DashboardBotDescriptor, j?: any, error?:
     larkBotName: typeof j?.larkBotName === 'string' ? j.larkBotName : null,
     defaultOncall: j?.defaultOncall,
     defaultWorkingDir: typeof j?.defaultWorkingDir === 'string' ? j.defaultWorkingDir : null,
+    // 「仓库选择卡片」形态的工作目录。与 defaultWorkingDir 互斥（见 BotConfig）。
+    // 克隆弹窗要用它判断源 Bot 是哪种目录形态，才能预填出与克隆结果一致的表单。
+    workingDir: typeof j?.workingDir === 'string' ? j.workingDir : null,
     defaultWorkingDirAutoWorktree: j?.defaultWorkingDirAutoWorktree === true,
     autoboundChatCount: j?.autoboundChatCount ?? 0,
     brandLabel: j?.brandLabel ?? null,

--- a/src/dashboard/web/bot-defaults-page.tsx
+++ b/src/dashboard/web/bot-defaults-page.tsx
@@ -853,7 +853,19 @@ export function BotDefaultsPage() {
               }))}
               onChange={sourceAppId => {
                 setOnboardingBusy(true);
-                void openBotOnboarding(sourceAppId).finally(() => setOnboardingBusy(false));
+                // 把源 Bot 的 CLI / 目录 / model 一并带进弹窗预填：克隆时后端会用
+                // 源 Bot 覆盖这几项，表单必须显示真正会生效的值，否则用户白填。
+                const source = bots.find(bot => bot.larkAppId === sourceAppId);
+                const sourceDefaults = source
+                  ? {
+                      ...(source.cliId ? { cliId: source.cliId } : {}),
+                      ...(source.defaultWorkingDir
+                        ? { workingDir: source.defaultWorkingDir, dirMode: 'fixed' as const }
+                        : {}),
+                      ...(source.model ? { model: source.model } : {}),
+                    }
+                  : undefined;
+                void openBotOnboarding(sourceAppId, sourceDefaults).finally(() => setOnboardingBusy(false));
               }}
             />
           ) : null}

--- a/src/dashboard/web/bot-defaults-page.tsx
+++ b/src/dashboard/web/bot-defaults-page.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
-import { openBotOnboarding } from './bot-onboarding.js';
+import { cloneSourceDefaultsFrom, openBotOnboarding } from './bot-onboarding.js';
 import {
   agentSelectionKey,
   cliIdOf,
@@ -855,16 +855,10 @@ export function BotDefaultsPage() {
                 setOnboardingBusy(true);
                 // 把源 Bot 的 CLI / 目录 / model 一并带进弹窗预填：克隆时后端会用
                 // 源 Bot 覆盖这几项，表单必须显示真正会生效的值，否则用户白填。
-                const source = bots.find(bot => bot.larkAppId === sourceAppId);
-                const sourceDefaults = source
-                  ? {
-                      ...(source.cliId ? { cliId: source.cliId } : {}),
-                      ...(source.defaultWorkingDir
-                        ? { workingDir: source.defaultWorkingDir, dirMode: 'fixed' as const }
-                        : {}),
-                      ...(source.model ? { model: source.model } : {}),
-                    }
-                  : undefined;
+                // 映射规则（含目录两种互斥形态）见 cloneSourceDefaultsFrom。
+                const sourceDefaults = cloneSourceDefaultsFrom(
+                  bots.find(bot => bot.larkAppId === sourceAppId),
+                );
                 void openBotOnboarding(sourceAppId, sourceDefaults).finally(() => setOnboardingBusy(false));
               }}
             />

--- a/src/dashboard/web/bot-defaults.ts
+++ b/src/dashboard/web/bot-defaults.ts
@@ -68,6 +68,8 @@ export type BotDefaultsRow = {
   agentSelectionKey?: string;
   defaultOncall?: { enabled?: boolean; workingDir?: string; since?: number };
   defaultWorkingDir?: string | null;
+  /** 「仓库选择卡片」形态的工作目录，与 defaultWorkingDir 互斥。 */
+  workingDir?: string | null;
   defaultWorkingDirAutoWorktree?: boolean;
   autoboundChatCount?: number;
   brandLabel?: string | null;

--- a/src/dashboard/web/bot-onboarding.tsx
+++ b/src/dashboard/web/bot-onboarding.tsx
@@ -260,10 +260,36 @@ function normalizeFormForOptions(form: OnboardingFormState, cliState: CliOptions
 }
 
 /**
+ * 从克隆源 Bot 的配置行推出表单预填值。
+ *
+ * 目录必须按**源自己的形态**映射，不能一律 fixed：源只有 workingDir 时若按
+ * fixed 预填，目标会带上 defaultWorkingDir，而后端取目录是
+ * `defaultWorkingDir ?? workingDir` —— 目标那个 '~' 会反过来把源目录遮蔽掉，
+ * 新会话直接在 ~ 起，源的仓库目录静默丢失。
+ */
+export function cloneSourceDefaultsFrom(source: {
+  cliId?: string | null;
+  defaultWorkingDir?: string | null;
+  workingDir?: string | null;
+  model?: string | null;
+} | undefined): CloneSourceDefaults | undefined {
+  if (!source) return undefined;
+  return {
+    ...(source.cliId ? { cliId: source.cliId } : {}),
+    ...(source.defaultWorkingDir
+      ? { workingDir: source.defaultWorkingDir, dirMode: 'fixed' as const }
+      : source.workingDir
+        ? { workingDir: source.workingDir, dirMode: 'card' as const }
+        : {}),
+    ...(source.model ? { model: source.model } : {}),
+  };
+}
+
+/**
  * 把克隆源的配置铺进表单初值。只覆盖源上确实有值的项，其余保持普通新建的默认，
  * 这样表单展示的就是克隆真正会用的配置（cloneBotConfig 之后仍以源为准）。
  */
-function applyCloneDefaults(
+export function applyCloneDefaults(
   form: OnboardingFormState,
   defaults: CloneSourceDefaults | undefined,
 ): OnboardingFormState {

--- a/src/dashboard/web/bot-onboarding.tsx
+++ b/src/dashboard/web/bot-onboarding.tsx
@@ -7,7 +7,17 @@ import { confirm } from './confirm-modal.js';
 import { t } from './ui.js';
 
 export const OPEN_BOT_ONBOARDING_EVENT = 'botmux:open-bot-onboarding';
+
+/** 克隆源 Bot 里会被 cloneBotConfig 带过去、且表单里也有对应项的字段。 */
+export type CloneSourceDefaults = {
+  cliId?: string;
+  workingDir?: string;
+  dirMode?: 'card' | 'fixed';
+  model?: string;
+};
+
 let cloneSourceAppId: string | undefined;
+let cloneSourceDefaults: CloneSourceDefaults | undefined;
 
 type OnboardingStatus =
   | 'starting'
@@ -249,8 +259,35 @@ function normalizeFormForOptions(form: OnboardingFormState, cliState: CliOptions
   }, cliId, cliState);
 }
 
-export async function openBotOnboarding(sourceAppId?: string): Promise<void> {
+/**
+ * 把克隆源的配置铺进表单初值。只覆盖源上确实有值的项，其余保持普通新建的默认，
+ * 这样表单展示的就是克隆真正会用的配置（cloneBotConfig 之后仍以源为准）。
+ */
+function applyCloneDefaults(
+  form: OnboardingFormState,
+  defaults: CloneSourceDefaults | undefined,
+): OnboardingFormState {
+  if (!defaults) return form;
+  return {
+    ...form,
+    ...(defaults.cliId ? { cliId: defaults.cliId } : {}),
+    ...(defaults.workingDir ? { workingDir: defaults.workingDir } : {}),
+    ...(defaults.dirMode ? { dirMode: defaults.dirMode } : {}),
+    ...(defaults.model ? { model: defaults.model } : {}),
+  };
+}
+
+/**
+ * 克隆时用源 Bot 的配置预填表单：后端 cloneBotConfig 会用源 Bot 的
+ * cliId / 目录 / model 覆盖表单值，所以表单必须显示**真正会被使用的**那份，
+ * 否则用户填了却被静默丢弃（看到 claude-code，建出来却是源 Bot 的 codex）。
+ */
+export async function openBotOnboarding(
+  sourceAppId?: string,
+  sourceDefaults?: CloneSourceDefaults,
+): Promise<void> {
   cloneSourceAppId = sourceAppId;
+  cloneSourceDefaults = sourceAppId ? sourceDefaults : undefined;
   window.dispatchEvent(new Event(OPEN_BOT_ONBOARDING_EVENT));
 }
 
@@ -664,6 +701,7 @@ export function BotOnboardingDialog(props: { open: boolean; onClose(): void }): 
   const close = useCallback(() => {
     stopPolling();
     cloneSourceAppId = undefined;
+    cloneSourceDefaults = undefined;
     props.onClose();
   }, [props, stopPolling]);
 
@@ -700,7 +738,9 @@ export function BotOnboardingDialog(props: { open: boolean; onClose(): void }): 
     loadSeqRef.current = seq;
     const initialCliState = defaultCliOptionsState();
     setCliState(initialCliState);
-    setForm(defaultFormState());
+    // 克隆模式下用源 Bot 的值开局，让表单显示真正会生效的配置（后端克隆会用
+    // 源 Bot 覆盖这几项）；普通新建仍是原来的默认值。
+    setForm(applyCloneDefaults(defaultFormState(), cloneSourceDefaults));
     setSessionMode('checking');
     setView({ kind: 'form' });
     setSubmitting(false);

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -430,6 +430,55 @@ export function parseBotSelection(
 }
 
 /**
+ * 克隆时**不**复制的字段。分两类：
+ *  - 进程/激活态：`name` 是 pm2 进程名（启动期绑定），`apiOnly` 与四个
+ *    `activation*` 是上一次 onboarding 的中间态，复制过去会让新 Bot 以别人的
+ *    生命周期状态起步；`displayName` 复制会让名册里两个 Bot 同名难以区分。
+ *  - 实例态：按 **源应用的 chat_id / open_id** 建 key 的授权、绑定与账本。
+ *    chat_id 是租户级共享的，把它们带进新应用既无意义（多为死条目），又会
+ *    产生意外行为——例如 `oncallChats` 让新 Bot 在源绑定过的群里直接被
+ *    talk + 自动开工，`defaultOncallAutoboundChats` 则相反，会让该群的自动
+ *    绑定被误判成「已花掉」而不触发。
+ *
+ * 单一真源：回归测试直接 import 本常量，避免测试再抄一份清单后与实现漂移
+ * （新增实例态字段时两边都不报警）。新增此类字段请加在这里。
+ */
+export const CLONE_EXCLUDED_KEYS = [
+  'apiOnly',
+  'name',
+  'displayName',
+  'messageListeners',
+  'oncallChats',
+  'defaultOncallAutoboundChats',
+  'allowedChatGroups',
+  'chatGrants',
+  'globalGrants',
+  'quotaState',
+  'grantExpiryState',
+  'sessionGroup',
+  'chatReplyModes',
+  'chatFeedbackPolicies',
+  'noCardChats',
+  'activationPending',
+  'activationDeactivating',
+  'activationStarting',
+  'activationCommitted',
+] as const;
+
+/**
+ * 目标应用自己的身份字段：克隆后必须从 target 恢复。target 没有该字段时**删除**
+ * （而不是留下 source 的值）——`ou_` open_id 与 app secret 都是 app-scoped，
+ * 跨应用复制会把 owner 锁在门外。见 setup/owner-identity.ts。
+ */
+export const CLONE_IDENTITY_KEYS = [
+  'larkAppId',
+  'larkAppSecret',
+  'brand',
+  'allowedUsers',
+  'ownerOpenId',
+] as const;
+
+/**
  * 把源 Bot 的行为配置覆盖到刚创建的目标 Bot，同时保留目标应用自己的身份。
  * Dashboard 与 CLI clone 共用这里，避免两条入口各维护一份排除字段。
  */
@@ -439,29 +488,11 @@ export function cloneBotConfig(
 ): Record<string, any> {
   const cloned: Record<string, any> = { ...target, ...source };
 
-  for (const key of [
-    'apiOnly',
-    'name',
-    'displayName',
-    'messageListeners',
-    'oncallChats',
-    'allowedChatGroups',
-    'chatGrants',
-    'globalGrants',
-    'quotaState',
-    'grantExpiryState',
-    'sessionGroup',
-    'chatReplyModes',
-    'noCardChats',
-    'activationPending',
-    'activationDeactivating',
-    'activationStarting',
-    'activationCommitted',
-  ]) {
+  for (const key of CLONE_EXCLUDED_KEYS) {
     delete cloned[key];
   }
 
-  for (const key of ['larkAppId', 'larkAppSecret', 'brand', 'allowedUsers', 'ownerOpenId']) {
+  for (const key of CLONE_IDENTITY_KEYS) {
     if (Object.prototype.hasOwnProperty.call(target, key) && target[key] !== undefined) {
       cloned[key] = target[key];
     } else {

--- a/test/dashboard-bot-payload.test.ts
+++ b/test/dashboard-bot-payload.test.ts
@@ -271,6 +271,19 @@ describe('dashboard bot payload helpers', () => {
     expect(botDefaultsPayload(daemon, { defaultWorkingDir: 123 }).defaultWorkingDir).toBeNull();
   });
 
+  it('passes through workingDir (string) and normalizes missing to null', () => {
+    // 克隆弹窗靠这一行判断源 Bot 是 card 还是 fixed 目录形态。少了它，
+    // 只有 workingDir 的源会被按 fixed 预填，目标带上 defaultWorkingDir:'~'，
+    // 在后端 `defaultWorkingDir ?? workingDir` 里把源目录静默遮蔽掉。
+    const daemon = { larkAppId: 'app_a', botName: 'BotA', cliId: 'codex' };
+    expect(botDefaultsPayload(daemon, { workingDir: '/repo/my-project' })).toMatchObject({
+      workingDir: '/repo/my-project',
+    });
+    // Missing / non-string → null（fixed 形态的 bot 不带 workingDir）。
+    expect(botDefaultsPayload(daemon, {}).workingDir).toBeNull();
+    expect(botDefaultsPayload(daemon, { workingDir: 123 }).workingDir).toBeNull();
+  });
+
   it('defaults auto grant request cards on and preserves explicit off', () => {
     const daemon = { larkAppId: 'app_a', botName: 'BotA', cliId: 'codex' };
     expect(botDefaultsPayload(daemon, {})).toMatchObject({

--- a/test/dashboard-clone-prefill.test.ts
+++ b/test/dashboard-clone-prefill.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { cloneBotConfig } from '../src/setup/bot-config-editor.js';
+import { applyCloneDefaults, cloneSourceDefaultsFrom } from '../src/dashboard/web/bot-onboarding.js';
+
+/**
+ * Dashboard 克隆弹窗的表单预填。
+ *
+ * 后端 cloneBotConfig 会用源 Bot 覆盖 cliId / 目录 / model，所以表单必须显示
+ * **真正会生效的**那份，否则用户填了却被静默丢弃。目录尤其要区分两种互斥形态：
+ * 源只有 workingDir 时若仍按 fixed 预填，目标会带上 defaultWorkingDir，在后端
+ * `defaultWorkingDir ?? workingDir` 里反过来把源目录遮蔽掉（见最后一组用例）。
+ */
+const baseForm = {
+  appName: '',
+  cliId: 'claude-code',
+  workingDir: '~',
+  dirMode: 'fixed' as const,
+  model: '',
+};
+
+describe('clone 预填：applyCloneDefaults', () => {
+  it('没有克隆源时原样返回表单默认值', () => {
+    expect(applyCloneDefaults(baseForm as any, undefined)).toEqual(baseForm);
+  });
+
+  it('用源 Bot 的值覆盖，未提供的项保持表单默认', () => {
+    const next = applyCloneDefaults(baseForm as any, { cliId: 'codex', model: 'opus' });
+    expect(next.cliId).toBe('codex');
+    expect(next.model).toBe('opus');
+    // 源没给目录 → 保持默认，不臆造。
+    expect(next.workingDir).toBe('~');
+    expect(next.dirMode).toBe('fixed');
+  });
+
+  it('源是 card 形态时把 dirMode 一并带过来', () => {
+    const next = applyCloneDefaults(baseForm as any, { workingDir: '/repo/app', dirMode: 'card' });
+    expect(next.workingDir).toBe('/repo/app');
+    expect(next.dirMode).toBe('card');
+  });
+});
+
+describe('clone 预填：cloneSourceDefaultsFrom（源配置行 → 表单预填值）', () => {
+  it('没选到源时返回 undefined', () => {
+    expect(cloneSourceDefaultsFrom(undefined)).toBeUndefined();
+  });
+
+  it('源用 defaultWorkingDir → fixed 形态', () => {
+    expect(cloneSourceDefaultsFrom({ cliId: 'codex', defaultWorkingDir: '/repo/fixed-one' }))
+      .toEqual({ cliId: 'codex', workingDir: '/repo/fixed-one', dirMode: 'fixed' });
+  });
+
+  it('源只有 workingDir → card 形态（不能一律 fixed，否则源目录会被 ~ 遮蔽）', () => {
+    expect(cloneSourceDefaultsFrom({ cliId: 'codex', workingDir: '/repo/my-project' }))
+      .toEqual({ cliId: 'codex', workingDir: '/repo/my-project', dirMode: 'card' });
+  });
+
+  it('两个目录字段都在时以 defaultWorkingDir 为准（与后端取值顺序一致）', () => {
+    expect(cloneSourceDefaultsFrom({ defaultWorkingDir: '/repo/fixed', workingDir: '/repo/card' }))
+      .toEqual({ workingDir: '/repo/fixed', dirMode: 'fixed' });
+  });
+
+  it('源没有目录时不臆造目录项', () => {
+    expect(cloneSourceDefaultsFrom({ cliId: 'codex', model: 'opus' }))
+      .toEqual({ cliId: 'codex', model: 'opus' });
+  });
+
+  it('null/空串一律当作未设置', () => {
+    expect(cloneSourceDefaultsFrom({ cliId: null, defaultWorkingDir: null, workingDir: '', model: null }))
+      .toEqual({});
+  });
+});
+
+describe('clone 目录形态：源目录不能被目标的默认值遮蔽', () => {
+  /** 后端 run() 里决定新会话工作目录的那一步。 */
+  const effectiveDir = (bot: Record<string, any>): string =>
+    bot.defaultWorkingDir ?? bot.workingDir ?? '~';
+
+  /** 表单 dirMode 决定目标 bot 落哪个目录字段（与 bot-onboarding.run 一致）。 */
+  const targetFromForm = (dirMode: 'card' | 'fixed', dir: string): Record<string, any> => ({
+    larkAppId: 'cli_target',
+    larkAppSecret: 'target-secret',
+    ...(dirMode === 'fixed' ? { defaultWorkingDir: dir } : { workingDir: dir }),
+  });
+
+  it('源用 workingDir（card 形态）时，按源形态预填后目录不被遮蔽', () => {
+    const source = { larkAppId: 'cli_source', cliId: 'codex', workingDir: '/repo/my-project' };
+    // 走真实映射函数（而不是手喂 dirMode），这样「页面接线退回一律 fixed」也会被抓到。
+    const prefilled = applyCloneDefaults(baseForm as any, cloneSourceDefaultsFrom(source));
+    const bot = cloneBotConfig(source, targetFromForm(prefilled.dirMode, prefilled.workingDir));
+    expect(effectiveDir(bot)).toBe('/repo/my-project');
+  });
+
+  it('源用 defaultWorkingDir（fixed 形态）时同样保留源目录', () => {
+    const source = { larkAppId: 'cli_source', cliId: 'codex', defaultWorkingDir: '/repo/fixed-one' };
+    const prefilled = applyCloneDefaults(baseForm as any, cloneSourceDefaultsFrom(source));
+    const bot = cloneBotConfig(source, targetFromForm(prefilled.dirMode, prefilled.workingDir));
+    expect(effectiveDir(bot)).toBe('/repo/fixed-one');
+  });
+
+  it('回归：源只有 workingDir 却按 fixed 建目标时，源目录会被 ~ 遮蔽', () => {
+    // 这一条固定住 bug 本身的机制——修复是「按源形态预填」，而不是改 cloneBotConfig。
+    // 若哪天预填分支被删回「一律 fixed」，上面第一条会红，这条解释为什么。
+    const source = { larkAppId: 'cli_source', cliId: 'codex', workingDir: '/repo/my-project' };
+    const bot = cloneBotConfig(source, targetFromForm('fixed', '~'));
+    expect(bot.workingDir).toBe('/repo/my-project');
+    expect(effectiveDir(bot)).toBe('~');
+  });
+});

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -158,7 +158,7 @@ import { getPendingGrantLimits, _resetForTest as _resetGrantPending } from '../s
 import { logger } from '../src/utils/logger.js';
 import { config } from '../src/config.js';
 import { __resetPeerCrossRefCacheForTest } from '../src/services/peer-cross-ref-store.js';
-import { cloneBotConfig, cloneOwnerEntries } from '../src/setup/bot-config-editor.js';
+import { CLONE_EXCLUDED_KEYS, cloneBotConfig, cloneOwnerEntries } from '../src/setup/bot-config-editor.js';
 import { normalizeManagedOwnerEntries } from '../src/setup/owner-identity.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -5555,10 +5555,18 @@ describe('managed Agent clone owner boundary', () => {
     mockReadFileSync.mockReturnValue('{}');
   });
 
-  it('keeps the human owner operable without cloning source instance state', async () => {
-    const instanceKeys = [
+  it('pins the excluded-key list so a field cannot be silently dropped', () => {
+    // 下面那条用例用 CLONE_EXCLUDED_KEYS 驱动断言，好处是新增字段自动覆盖，
+    // 但代价是「从清单里删一个字段」会连带把它的断言一起删掉（自指盲区，
+    // 实测反向变异确认过）。所以这里额外用**字面量**钉死清单内容：删字段
+    // 必须在这条上红。新增字段时同步更新这份字面量即可。
+    expect([...CLONE_EXCLUDED_KEYS]).toEqual([
+      'apiOnly',
+      'name',
       'displayName',
+      'messageListeners',
       'oncallChats',
+      'defaultOncallAutoboundChats',
       'allowedChatGroups',
       'chatGrants',
       'globalGrants',
@@ -5566,13 +5574,26 @@ describe('managed Agent clone owner boundary', () => {
       'grantExpiryState',
       'sessionGroup',
       'chatReplyModes',
+      'chatFeedbackPolicies',
       'noCardChats',
-    ] as const;
+      'activationPending',
+      'activationDeactivating',
+      'activationStarting',
+      'activationCommitted',
+    ]);
+  });
+
+  it('keeps the human owner operable without cloning source instance state', async () => {
+    // 用实现导出的清单驱动：新增实例态字段时这条用例自动覆盖到。清单本身
+    // 被上一条字面量用例钉死，两条合起来堵住「加了不测」与「删了不红」。
+    // name 是 pm2 进程名（string），单独构造；其余用可辨识的对象值填充。
+    const instanceKeys = CLONE_EXCLUDED_KEYS.filter(key => key !== 'name');
     const source = {
       larkAppId: 'cli_source',
       larkAppSecret: 'source-secret',
       cliId: 'codex',
       allowedUsers: ['ou_source_owner', 'ou_stale_coowner'],
+      name: 'source-proc',
       ...Object.fromEntries(instanceKeys.map(key => [key, { source: key }])),
     };
     const owners = cloneOwnerEntries(source, 'cli_source', 'ou_source_owner');
@@ -5589,12 +5610,33 @@ describe('managed Agent clone owner boundary', () => {
       allowedUsers: normalized?.split(','),
     });
     expect(target.allowedUsers).toEqual(['on_human_owner']);
-    for (const key of instanceKeys) expect(target).not.toHaveProperty(key);
+    for (const key of CLONE_EXCLUDED_KEYS) expect(target).not.toHaveProperty(key);
+    // 行为配置仍照常克隆（否则「全删掉」也能让上面那条断言通过）。
+    expect(target.cliId).toBe('codex');
 
     // 目标 app 启动时会把 union_id 解析成自己视角下的 open_id。
     setupBotState({ configAllowedUsers: target.allowedUsers, allowedUsers: [USER_OPEN_ID] });
     expect(canOperate(MY_APP_ID, 'chat-A', USER_OPEN_ID)).toBe(true);
     expect(canOperate(MY_APP_ID, 'chat-A', 'ou_source_owner')).toBe(false);
+  });
+
+  it('never carries a source-app identity into the cloned bot', () => {
+    // ou_ open_id 与 app secret 都是 app-scoped：target 没有该字段时必须删除，
+    // 而不是把 source 的值留下来（那会把真人 owner 锁在新 Bot 外面）。
+    const source = {
+      larkAppId: 'cli_source',
+      larkAppSecret: 'source-secret',
+      brand: 'lark',
+      allowedUsers: ['ou_source_owner'],
+      ownerOpenId: 'ou_source_owner',
+      cliId: 'codex',
+    };
+    const target = cloneBotConfig(source, { larkAppId: 'cli_target', larkAppSecret: 'target-secret' });
+    expect(target.larkAppId).toBe('cli_target');
+    expect(target.larkAppSecret).toBe('target-secret');
+    for (const key of ['brand', 'allowedUsers', 'ownerOpenId']) {
+      expect(target).not.toHaveProperty(key);
+    }
   });
 });
 


### PR DESCRIPTION
## 改动

#972（一键克隆机器人）合入后的两处收尾。

### 1. 排除名单补上两个同类的按-chat_id 字段

`cloneBotConfig` 已经排除了一批实例态字段，但还漏了两个同类的：

- **`defaultOncallAutoboundChats`** — 源应用 chat_id 的 append-only「已自动绑定」账本。带进新应用后，新 Bot 日后进入与源共享的群时，该群的 `defaultOncall` 自动绑定会被误判成「已花掉」而不触发。
- **`chatFeedbackPolicies`** — 按源 chat_id 建 key 的反馈策略，对新应用是死条目。

两者都**无 owner / 权限泄漏**（`canOperate` 不读这些字段），属行为一致性问题。

同时把排除名单与身份字段提为导出常量 `CLONE_EXCLUDED_KEYS` / `CLONE_IDENTITY_KEYS`，回归测试直接 import，避免测试再抄一份清单后与实现漂移（新增实例态字段时两边都不报警）。

### 2. Dashboard 克隆模式预填表单

此前克隆弹窗的表单显示通用默认值（`claude-code` / `~`），而后端克隆会用源 Bot 的 `cliId` / 工作目录 / `model` 覆盖这几项——用户填了却被静默丢弃（看到 `claude-code`，建出来是源 Bot 的 `codex`）。现在选定模板后用源 Bot 的值预填，表单展示的即为真正会生效的配置。

## 影响

仅 clone 入口与其回归测试。**owner 身份边界逻辑未改动**（身份字段仍从目标应用恢复、目标缺省则删除）；普通「添加机器人」流程、CLI 其余命令、会话/后端逻辑均不变。

## 验证

- `bun run build`：通过。
- `event-dispatcher` / `setup-owner-identity` / `bot-config-editor` / `dashboard-bot-onboarding` / `bot-config-store` 五套 **485 测全绿**。
- 新增一条**字面量**用例钉死排除名单内容。原因：用常量驱动断言存在自指盲区——从清单里删一个字段会连带把它的断言一起删掉，实测反向变异确认过（删字段时用例仍全绿）。补上字面量用例后重跑三次反向变异，均如期变红：
  - 删 `defaultOncallAutoboundChats` → 红
  - 删 `chatFeedbackPolicies` → 红
  - 身份恢复清单不含 `allowedUsers`（源 open_id 会漏进新应用）→ 红（两条用例同时红）
