### PR TITLE
fix(fleet): 孤儿回收按绝对路径认领本安装，不再跨安装误杀

### DIFF
--- a/src/adapters/hook-command.ts
+++ b/src/adapters/hook-command.ts
@@ -43,8 +43,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * 单一出口：三个导出全部经由它，避免「同一个判据三份实现各自漂移」——
  * 本文件此前正是三处各拼一遍 `join(__dirname,'..','cli.js')`。
  */
-function botmuxInvocation(subcommand: string[]): { cmd: string; args: string[] } {
-  if (isStandaloneBinary()) {
+function botmuxInvocation(
+  subcommand: string[],
+  standalone: boolean = isStandaloneBinary(),
+): { cmd: string; args: string[] } {
+  if (standalone) {
     // process.execPath 是**真实磁盘路径**（编译态下也是），所以对别的进程有效。
     return { cmd: process.execPath, args: [...subcommand] };
   }
@@ -59,8 +62,12 @@ function botmuxInvocation(subcommand: string[]): { cmd: string; args: string[] }
  * 需要 argv 的场景请用 `hookCommandParts`，切勿对本字符串再 `.split(' ')`。
  */
 function renderShellCommand(cliId?: string, ...subcommand: string[]): string {
-  const { cmd, args } = botmuxInvocation(cliId === undefined ? subcommand : [...subcommand, cliId]);
-  if (isStandaloneBinary()) {
+  // 判一次形态两处用：`botmuxInvocation` 决定 argv 里有没有脚本路径，这里决定给不给
+  // 它加引号——两者必须看到同一个答案，各调一次 `isStandaloneBinary()` 只是让同一个
+  // 判据有两个求值点。
+  const standalone = isStandaloneBinary();
+  const { cmd, args } = botmuxInvocation(cliId === undefined ? subcommand : [...subcommand, cliId], standalone);
+  if (standalone) {
     // 只有可执行路径需要引号；子命令是字面量 token。
     return `"${cmd}" ${args.join(' ')}`;
   }

--- a/src/core/self-spawn.ts
+++ b/src/core/self-spawn.ts
@@ -95,8 +95,10 @@ export const RUNNER_ENTRIES: readonly BotmuxEntry[] = [
  *
  * `scriptPath` is supplied by the caller because each adapter owns its own
  * resolution order (a test-scoped env override, a compiled sibling, a source-tree
- * dist/) and this module stays location-agnostic. It is not even evaluated in the
- * compiled branch, so an adapter may pass a path it knows does not exist there.
+ * dist/) and this module stays location-agnostic. Its VALUE is unused in the
+ * compiled branch — the argument is still evaluated, as JS is strict about that,
+ * so an adapter may pass a path it knows does not exist there but must not put a
+ * side effect in the expression that produces it.
  */
 export function runnerArgv0(entry: BotmuxEntry, scriptPath: string): string {
   return isStandaloneBinary() ? ENTRY_SUBCOMMAND[entry] : scriptPath;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -13992,6 +13992,20 @@ export function listProcesses(): ProcSnapshot[] {
 }
 
 /**
+ * This executable's absolute, symlink-resolved path.
+ *
+ * `process.execPath` is already absolute and kernel-resolved, so this is normally
+ * a no-op; realpath is applied anyway so a comparison against a `/proc` argv[0]
+ * cannot be defeated by the daemon having been started through a symlink (a
+ * released install commonly sits behind `~/.botmux/bin/botmux`). Falls back to the
+ * raw value when the path cannot be resolved — a failed realpath must not turn the
+ * reaper into a no-op.
+ */
+function canonicalExecPath(): string {
+  try { return realpathSync(process.execPath); } catch { return process.execPath; }
+}
+
+/**
  * Reap worker processes orphaned by a previous daemon that died WITHOUT running
  * its graceful shutdown — SIGKILL, OOM, or an uncaught crash. The shutdown()
  * path in daemon.ts already SIGKILLs stragglers on SIGTERM, but a hard kill
@@ -14034,22 +14048,40 @@ export function reapOrphanWorkers(opts: {
   // this function exists to prevent: each orphan leaks ~0.5 GB and they accumulate
   // across restarts (daemon.ts records an 841-orphan / ~65 GB incident).
   //
-  // The compiled predicate keeps the same conservatism — it must still identify
-  // THIS install and not another botmux — by requiring the running executable's
-  // path AND the `__worker` token. Both are matched as substrings because
-  // /proc/<pid>/cmdline preserves argv[0] exactly as given, which may be relative
-  // (MEASURED: launching via a relative path yields a relative argv[0]), so the
-  // basename is the portion that reliably appears.
+  // The compiled predicate must keep the SAME conservatism the worker.js path had:
+  // it identified this install by an ABSOLUTE path, so another botmux install's
+  // orphans could never match. A basename-only check loses that — every released
+  // install names its binary `botmux`, so install A would reap install B's
+  // orphans (verified: with a same-named binary at a different absolute path, a
+  // basename check reaps it).
+  //
+  // So match on the absolute path when the command line carries one. That is the
+  // normal case for OUR workers: spawnWorker launches them via
+  // `resolveEntrySpawn` → `process.execPath`, which the kernel has already
+  // resolved to an absolute path (MEASURED in /proc/<pid>/cmdline:
+  // `/…/botmux-linux-x64 __worker`). Only a RELATIVE argv[0] — a binary started
+  // by a bare PATH lookup, which our own spawns never produce — falls back to the
+  // basename, where cross-install ambiguity is unavoidable but the process was
+  // also not started the way we start ours.
   const standalone = isStandaloneBinary();
   const workerPath = opts.workerPath ?? (standalone ? undefined : join(__dirname, '..', 'worker.js'));
-  const binaryName = standalone ? basename(process.execPath) : '';
+  const selfBinary = standalone ? canonicalExecPath() : '';
+  const selfBinaryName = standalone ? basename(selfBinary) : '';
 
   /** Does this command line belong to a worker of THIS install? */
   const isOurWorker = (cmd: string): boolean => {
     if (workerPath !== undefined) return cmd.includes(workerPath);
-    // Compiled form: `<binary> __worker`. Require both parts so a stray process
-    // that merely mentions `__worker` (or a different botmux binary) is spared.
-    return cmd.includes(binaryName) && cmd.includes(WORKER_ENTRY_SUBCOMMAND);
+    // Compiled form: `<binary> __worker`. The token alone is not enough — a
+    // process merely mentioning `__worker` (a grep, another install) must be
+    // spared.
+    if (!cmd.includes(WORKER_ENTRY_SUBCOMMAND)) return false;
+    const argv0 = cmd.split(/\s+/, 1)[0] ?? '';
+    // Absolute argv[0] → require the exact executable, so a same-named binary
+    // from a different install is not ours.
+    if (argv0.startsWith('/')) return argv0 === selfBinary;
+    // Relative argv[0] (never produced by our own spawns) → basename is all
+    // there is to compare.
+    return basename(argv0) === selfBinaryName;
   };
 
   let reaped = 0;

--- a/test/reap-orphan-workers.test.ts
+++ b/test/reap-orphan-workers.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { basename } from 'node:path';
+import { realpathSync } from 'node:fs';
 import { reapOrphanWorkers, type ProcSnapshot } from '../src/core/worker-pool.js';
 
 // Absolute path of THIS install's worker script, as it appears in a worker's
@@ -94,14 +96,58 @@ describe('reapOrphanWorkers — compiled binary form', () => {
   it('still spares other installs and non-workers (conservatism is preserved)', () => {
     const killed: number[] = [];
     const procs: ProcSnapshot[] = [
-      { pid: 300, ppid: 1, cmd: '/opt/other-botmux/botmux __worker' }, // different install ✗
-      { pid: 301, ppid: 1, cmd: `${BIN} __supervisor` },              // another entry, not a worker ✗
-      { pid: 302, ppid: 1, cmd: `${BIN} start` },                     // ordinary CLI ✗
-      { pid: 303, ppid: 1, cmd: 'grep -r __worker src/' },            // merely mentions the token ✗
+      { pid: 301, ppid: 1, cmd: `${BIN} __supervisor` },   // another entry, not a worker ✗
+      { pid: 302, ppid: 1, cmd: `${BIN} start` },          // ordinary CLI ✗
+      { pid: 303, ppid: 1, cmd: 'grep -r __worker src/' }, // merely mentions the token ✗
     ];
 
     expect(reapOrphanWorkers({ procs, kill: (p) => killed.push(p) })).toBe(0);
     expect(killed).toEqual([]);
+  });
+
+  /**
+   * CROSS-INSTALL PRECISION.
+   *
+   * The worker.js predicate identified this install by an ABSOLUTE path, so another
+   * botmux install's orphans could never match it. A basename-only compiled
+   * predicate silently loses that: every released install names its binary
+   * `botmux`, so install A would reap install B's orphans — each leaking ~0.5 GB
+   * and, worse, killing live-looking processes that belong to somebody else's
+   * daemon.
+   *
+   * The earlier version of this file appeared to cover the case with a literal
+   * `/opt/other-botmux/botmux __worker`, but that only passed BY ACCIDENT: under
+   * vitest `basename(process.execPath)` is `node`, which that string does not
+   * contain. Deriving the name from `process.execPath` is what gives the case
+   * teeth — VERIFIED that the basename-only predicate reaps pid 400 here.
+   */
+  it('spares a SAME-NAMED binary from a different install (absolute argv[0] must match exactly)', () => {
+    const killed: number[] = [];
+    const sameName = basename(BIN);
+    const procs: ProcSnapshot[] = [
+      { pid: 400, ppid: 1, cmd: `/opt/other-install/${sameName} __worker` },        // ✗ not ours
+      { pid: 401, ppid: 1, cmd: `/usr/local/lib/botmux/${sameName} __worker` },     // ✗ not ours
+      { pid: 402, ppid: 1, cmd: `${realpathSync(BIN)} __worker` },                  // ✓ ours
+    ];
+
+    const n = reapOrphanWorkers({ procs, kill: (p) => killed.push(p) });
+
+    expect(killed).toEqual([402]);
+    expect(n).toBe(1);
+  });
+
+  it('a relative argv[0] still matches by basename (our spawns never produce one)', () => {
+    // spawnWorker goes through process.execPath, which the kernel resolves to an
+    // absolute path, so this branch only sees processes started by a bare PATH
+    // lookup. Cross-install ambiguity is unavoidable there — but such a process
+    // was also not started the way we start ours, so matching by name is the most
+    // that can be said, and dropping the branch would leave those orphans forever.
+    const killed: number[] = [];
+    const procs: ProcSnapshot[] = [
+      { pid: 500, ppid: 1, cmd: `${basename(BIN)} __worker` },
+    ];
+    expect(reapOrphanWorkers({ procs, kill: (p) => killed.push(p) })).toBe(1);
+    expect(killed).toEqual([500]);
   });
 
   it('never matches a /$bunfs/ path (nothing on the system carries one)', () => {


### PR DESCRIPTION
修复复审在 #1082 / #1084 上发现的 3 项。**发现 ① 是 #1082 引入的退化，我已复现并证伪原判据**；②③ 是注释与结构清理。

## ① 实质 · 孤儿回收会跨安装误杀 — `src/core/worker-pool.ts`

`worker.js` 路径判据是用**绝对路径**认领本安装的，另一个 botmux 安装的孤儿永远匹配不上。而 #1082 把编译态改成 `cmd.includes(basename(process.execPath))` 之后这条保证没了 —— 发版安装的二进制都叫 `botmux`，于是 A 安装的 daemon 会把 B 安装的孤儿一起 SIGKILL。

**实测证伪**（让 `isStandaloneBinary()` 为真，喂一条同名但不同安装的 cmdline）：

| | `/opt/other-install/<同名> __worker` | `<realpath(execPath)> __worker` |
|---|---|---|
| 旧判据 | **`reaped=1`（真调了 kill）** | reaped=1 |
| 本 PR | `reaped=0` ✓ | reaped=1 ✓ |

**原有用例为什么没拦住**：它写的是字面量 `/opt/other-botmux/botmux __worker`，而 vitest 下 `basename(process.execPath)` 是 **`node`** —— 那条字符串不含 `node`，所以「别的安装被放过」只是**巧合**。新用例从 `process.execPath` 派生同名二进制才有区分力：**把判据退回 basename-only，新用例立刻红（实测 1 failed）**，符合「旧代码必须红」的要求。

**修法**：`/proc/<pid>/cmdline` 保留 argv[0] 原样，而本安装的 worker 由 `spawnWorker` → `resolveEntrySpawn` 经 `process.execPath` 拉起，内核已解析成绝对路径（实测 cmdline 为 `/…/botmux-linux-x64 __worker`）。所以：

- argv[0] 以 `/` 开头 → 按本二进制 realpath **精确相等**匹配
- 相对 argv[0]（裸 PATH 启动，我们自己的 spawn 不会产生）→ 退回 basename

保留后一个分支的理由写进注释了：那种情况跨安装歧义无法消除，但它也不是按我们的方式起的，而删掉该分支会让这类孤儿**永远不被回收**。

新增 `canonicalExecPath()`：`process.execPath` 本就绝对且已解析，realpath 是为了「daemon 经软链启动」（发版安装常在 `~/.botmux/bin/botmux` 之后）；解析失败回退原值，不让一次 realpath 失败把 reaper 变成 no-op。

## ② nit · 注释不准 — `src/core/self-spawn.ts`

`runnerArgv0` 的 doc 原写 `scriptPath`「not even evaluated in the compiled branch」。不准确：JS 实参严格求值，只是**返回值**不被使用。改为如实表述，并写清由此产生的约束 —— 产生该实参的表达式不能带副作用（当前 4 个 `runnerPath()` 都是纯的）。

## ③ nit · 重复求值 — `src/adapters/hook-command.ts`

`renderShellCommand` 与 `botmuxInvocation` 各自调一次 `isStandaloneBinary()`。改为判一次、显式传下去，并注明两处必须看到同一个答案的原因（一处决定 argv 里有没有脚本路径，一处决定加不加引号）。

## 验证

- `bun run build` 通过；`tsc` 零错误
- 相关面 **470 项全绿**（reaper / hook-command ×3 / cli-runner / cli-adapters）
- 编译态 smoke **8 项全绿**；真二进制上 hook 三个子命令 exit 0、runner token 仍正常 dispatch
- 单测 **19219 passed / 4 failed** —— 4 个失败与基线逐字相同（mojo EACCES + MCP sandbox bwrap，本机既有；已 stash 改动跑过基线对照）
- ⚠️ 中途一次全量出现 7 failed / 33 skipped，重跑回到 4 failed / 11 skipped，是高负载下真 spawn 进程套件的 flake

## 影响范围

| 维度 | 评估 |
|---|---|
| 跨形态 | Node 态判据逐字未变（仍走 `workerPath` 分支）；只改编译态分支 |
| 跨安装 | 本 PR 的**目的**就是修这一维：同机多安装不再互相误杀 |
| 公共层 | `core/worker-pool.ts`（只改 reaper 判据 + 新增一个私有 helper）、`core/self-spawn.ts`（**仅注释**）、`adapters/hook-command.ts`（参数透传，行为不变） |

未混入的改动：sandbox shim 那处（`sandbox.ts:627/1111`）是独立的大改，按要求保持原样、单独成 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
