### PR TITLE
fix(sandbox): 编译版的沙盒 shim 与 relay 回执按运行形态分流

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -26,6 +26,7 @@ import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
 import { compileToBwrap, type FsPolicy } from '../cli/fs-policy.js';
 import { PROXY_ENV_KEYS } from '../../utils/child-env.js';
+import { isStandaloneBinary } from '../../core/self-spawn.js';
 import {
   MCP_GATEWAY_REQUIRED_ENV,
   MCP_GATEWAY_SOCKET_ENV,
@@ -235,13 +236,71 @@ function canonical(p: string): string {
 }
 
 /** Absolute path to this build's compiled cli.js (dist/cli.js), derived from
- *  this module's own location (dist/adapters/backend/sandbox.js → ../../cli.js). */
+ *  this module's own location (dist/adapters/backend/sandbox.js → ../../cli.js).
+ *
+ *  ⚠️ NOT VALID IN A COMPILED BINARY. There is no cli.js on disk there: the module
+ *  graph lives in the virtual, process-private `/$bunfs/`, so both candidates
+ *  below resolve against `/$bunfs/root` and collapse onto the real filesystem
+ *  root — MEASURED inside a real compiled binary: `/cli.js` and `/dist/cli.js`,
+ *  neither existing. Callers must therefore go through `botmuxCliInvocation()` (a
+ *  child spawn) or `botmuxShimExecLine()` (a shim handed to another process)
+ *  rather than calling this directly. */
 function distCliJs(): string {
   const colocated = fileURLToPath(new URL('../../cli.js', import.meta.url));
   if (existsSync(colocated)) return colocated;
-  // `pnpm daemon` loads this module from src/ through tsx, while the trusted
+  // `bun run daemon` loads this module from src/ through tsx, while the trusted
   // sandbox shim must still execute the built CLI entrypoint.
   return fileURLToPath(new URL('../../../dist/cli.js', import.meta.url));
+}
+
+/**
+ * `#!/bin/sh` body for the in-sandbox `botmux` shim.
+ *
+ * WHY THIS CANNOT BE ONE FORM FOR BOTH RUNTIMES: the shim is written to the host
+ * disk, ro-bound into the sandbox at `/run/sbxbin`, and then executed by a
+ * DIFFERENT process inside that sandbox. Two things follow, both MEASURED:
+ *
+ *   • `/$bunfs/` is process-private — a child sees nothing there, so a compiled
+ *     binary emitting `exec node "/dist/cli.js"` produces a shim whose target does
+ *     not exist for the only process that will ever run it; and
+ *   • `sh` expands the unescaped `$bunfs` inside double quotes to the empty
+ *     string, so even the literal path is lost (`"/$bunfs/cli.js"` → `//cli.js`).
+ *
+ * Verified against a real binary: running the compiled form of this line prints
+ * the botmux HELP BANNER and exits 0, so an in-sandbox `botmux send` silently
+ * does nothing.
+ *
+ * The two runtimes genuinely need DIFFERENT values — the source form must name
+ * `dist/cli.js` (a compiled binary has no such file) and the compiled form must
+ * name the executable itself (`process.execPath`, a real on-disk path even under
+ * --compile). Collapsing them is not possible; the guard here is that each branch
+ * is exercised by a test, since a wrong shim fails silently.
+ *
+ * Also note the compiled form drops `node` entirely: re-introducing an
+ * interpreter dependency would defeat the point of the self-contained binary, and
+ * the sandbox policy does not expose a node.
+ */
+export function botmuxShimExecLine(): string {
+  if (isStandaloneBinary()) {
+    return `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} "$@"\n`;
+  }
+  return `#!/bin/sh\nexec node ${JSON.stringify(distCliJs())} "$@"\n`;
+}
+
+/**
+ * Command + leading args to run this build's CLI as a CHILD of the current
+ * process (used by the relay watcher to re-exec `botmux send` on the host).
+ *
+ * Same split as `src/core/self-spawn.ts`: under Node the script path is required
+ * (`node <dist/cli.js> send …`), while the compiled binary dispatches ordinary
+ * subcommands itself (`<binary> send …`) and must NOT be handed a script path —
+ * verified on a real binary that `<binary> "/dist/cli.js" send …` prints help and
+ * exits 0 instead of sending anything.
+ */
+export function botmuxCliInvocation(cliPathOverride?: string): { command: string; args: string[] } {
+  if (cliPathOverride) return { command: process.execPath, args: [cliPathOverride] };
+  if (isStandaloneBinary()) return { command: process.execPath, args: [] };
+  return { command: process.execPath, args: [distCliJs()] };
 }
 
 /** Is the file sandbox globally forced for this daemon? The real per-bot
@@ -624,7 +683,7 @@ export function prepareDirectSandbox(opts: {
   // `botmux` shim → THIS build's cli.js so in-sandbox `botmux send` hits relay
   // mode (and never needs bots.json, which the policy doesn't expose).
   const shim = join(shimBin, 'botmux');
-  writeFileSync(shim, `#!/bin/sh\nexec node ${JSON.stringify(distCliJs())} "$@"\n`);
+  writeFileSync(shim, botmuxShimExecLine());
   chmodSync(shim, 0o755);
 
   // usrmerge symlinks to replicate; deny rules that are FILES on the host need
@@ -1108,7 +1167,7 @@ export function startOutboxWatcher(
     cliPath?: string;
   } = {},
 ): () => void {
-  const cli = opts.cliPath ?? distCliJs();
+  const cliInvocation = botmuxCliInvocation(opts.cliPath);
   const authorize = opts.authorize;
   const inFlight = new Set<string>();
   // Host-private staging — a sibling of the outbox, NOT bound into the sandbox.
@@ -1232,7 +1291,7 @@ export function startOutboxWatcher(
       } else {
         delete requestEnv.BOTMUX_HOST_RELAY_REQUIRES_CODEX_APP_LEDGER;
       }
-      const child = spawn(process.execPath, [cli, 'send', ...hostArgs], { env: requestEnv });
+      const child = spawn(cliInvocation.command, [...cliInvocation.args, 'send', ...hostArgs], { env: requestEnv });
       let out = '', err = '';
       child.stdout.on('data', d => { out += d; });
       child.stderr.on('data', d => { err += d; });

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -751,11 +751,36 @@ export function prepareDirectSandbox(opts: {
   // Shim bin at a fixed path under the fresh /run tmpfs — appended after the
   // rule mounts (later mount wins over the tmpfs). PATH points here first.
   args.push('--ro-bind', shimBin, '/run/sbxbin');
+  // Overlay the shim onto every configured absolute `botmux` command path so an
+  // in-sandbox call by absolute path also reaches relay mode.
+  //
+  // ⚠️ EXCEPT when that path IS this executable. install.sh moves the compiled
+  // binary to `~/.botmux/bin/botmux` (install.sh:106) and the daemon runs from
+  // there, while `trustedBotmuxCommandPaths` defaults to exactly that path
+  // (gateway-installer.ts — `BOTMUX_BIN_PATH` has no writer anywhere, so the
+  // default is what production uses). Binding the shim over it makes the shim's
+  // own `exec "<process.execPath>"` resolve back to the shim: MEASURED with bwrap,
+  // the real binary never runs and the process ends in SILENT exit 0 (the kernel
+  // caps shebang recursion and gives up), i.e. an in-sandbox `botmux send` looks
+  // like it worked and sent nothing — the exact failure class this whole change
+  // exists to remove.
+  //
+  // Skipping the overlay is safe: `execPaths` always contains
+  // `dirname(canonical(process.execPath))` (worker.ts), so the real binary is
+  // already reachable inside the sandbox, and an absolute-path call lands on it
+  // directly. The PATH-shaped `botmux` still goes through `/run/sbxbin`, and relay
+  // mode is driven by env (BOTMUX_SANDBOX_OUTBOX etc.), not by which file answers
+  // the call. The npm layout — where the launcher and the platform binary are
+  // different files — still gets the overlay.
+  let selfExec: string | undefined;
+  try { selfExec = realpathSync(process.execPath); } catch { selfExec = undefined; }
   for (const rawTarget of [...new Set(opts.trustedBotmuxCommandPaths ?? [])]) {
     if (typeof rawTarget !== 'string' || !isAbsolute(rawTarget)) continue;
     const target = resolve(rawTarget);
     try {
       if (!lstatSync(target).isFile()) continue;
+      // Compare resolved paths: either side may be reached through a symlink.
+      if (selfExec !== undefined && realpathSync(target) === selfExec) continue;
       args.push('--ro-bind', shim, target);
     } catch { /* missing/stale config target — PATH shim remains available */ }
   }

--- a/test/sandbox-shim-compiled-form.test.ts
+++ b/test/sandbox-shim-compiled-form.test.ts
@@ -37,10 +37,10 @@
 
 import { describe, it, expect, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, chmodSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { botmuxShimExecLine, botmuxCliInvocation } from '../src/adapters/backend/sandbox.js';
+import { botmuxShimExecLine, botmuxCliInvocation, prepareDirectSandbox } from '../src/adapters/backend/sandbox.js';
 
 const REAL_ARGV1 = process.argv[1];
 function asCompiledBinary() { process.argv[1] = '/$bunfs/root/cli.js'; }
@@ -153,5 +153,73 @@ describe('relay host re-exec — botmuxCliInvocation', () => {
     expect(src).toContain('botmuxCliInvocation(opts.cliPath)');
     // And the shim writer must go through the helper too.
     expect(src).toContain('writeFileSync(shim, botmuxShimExecLine())');
+  });
+});
+
+/**
+ * INSTALL.SH LAYOUT — the shim must NOT be overlaid onto this executable.
+ *
+ * install.sh moves the compiled binary to `~/.botmux/bin/botmux` (install.sh:106)
+ * and the daemon runs from there, while `trustedBotmuxCommandPaths` defaults to
+ * exactly that path (gateway-installer.ts; `BOTMUX_BIN_PATH` has no writer
+ * anywhere in the repo, so the default IS the production value). Binding the shim
+ * over it makes the shim's own `exec "<process.execPath>"` resolve back to the
+ * shim.
+ *
+ * MEASURED with bwrap and a real compiled binary:
+ *   baseline (no shim overlay)      → `3.18.6-21-g…`     ✅
+ *   shim overlaid on the same path  → no output, exit 0  ❌
+ *
+ * Silent exit 0, because the kernel caps shebang recursion and simply gives up —
+ * so an in-sandbox `botmux send` looks like it worked and sent nothing. That is
+ * the same failure class this file exists to prevent, which is why it gets a
+ * dedicated case rather than a comment.
+ *
+ * WHY THE EARLIER CASES MISSED IT: the "shim actually runs" test above puts the
+ * stand-in binary at a DIFFERENT path — i.e. it only ever exercised the npm
+ * layout, where the launcher and the platform binary are separate files.
+ */
+describe('sandbox shim overlay — install.sh layout (shim path === exec target)', () => {
+  function overlayTargets(trusted: string): string[] {
+    const root = mkdtempSync(join(tmpdir(), 'sbx-overlay-'));
+    const proj = join(root, 'proj');
+    const home = join(root, 'home');
+    mkdirSync(proj, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    const spawn = prepareDirectSandbox({
+      sessionId: `s${Math.random().toString(16).slice(2, 8)}`,
+      dataDir: join(root, 'data'),
+      policy: { rules: [{ path: proj, access: 'readWrite' }], execPaths: [], denyDefault: true } as never,
+      chdir: proj,
+      home,
+      cliBin: '/bin/sh',
+      cliArgs: ['-c', 'true'],
+      trustedBotmuxCommandPaths: [trusted],
+    });
+    if (!spawn) return [];
+    const out: string[] = [];
+    for (let i = 0; i < spawn.args.length - 2; i++) {
+      if (spawn.args[i] === '--ro-bind' && String(spawn.args[i + 1]).endsWith('/shimbin/botmux')) {
+        out.push(String(spawn.args[i + 2]));
+      }
+    }
+    spawn.cleanup();
+    return out;
+  }
+
+  it('skips the overlay when the trusted path IS this executable (no self-recursion)', () => {
+    // The real binary stays reachable regardless: execPaths always contains
+    // dirname(canonical(process.execPath)) (worker.ts), so an absolute-path call
+    // lands on it directly, and PATH-shaped `botmux` still goes through
+    // /run/sbxbin.
+    expect(overlayTargets(process.execPath)).toEqual([]);
+  });
+
+  it('still overlays a DIFFERENT launcher path (npm layout unaffected)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sbx-npmlayout-'));
+    const launcher = join(dir, 'botmux');
+    writeFileSync(launcher, '#!/bin/sh\nexec /somewhere/botmux "$@"\n', { mode: 0o755 });
+    chmodSync(launcher, 0o755);
+    expect(overlayTargets(launcher)).toEqual([launcher]);
   });
 });

--- a/test/sandbox-shim-compiled-form.test.ts
+++ b/test/sandbox-shim-compiled-form.test.ts
@@ -1,0 +1,157 @@
+/**
+ * The in-sandbox `botmux` shim and the relay's host re-exec must work in BOTH
+ * runtime forms.
+ *
+ * WHY THIS FILE EXISTS: 91 test files mention the sandbox and NOT ONE asserted
+ * on the shim's contents or on how the relay re-execs the CLI. That is exactly
+ * why the compiled binary shipped a broken shim — the unit suite runs
+ * `node dist/*.js`, where `dist/cli.js` is right there on disk, so the failure
+ * only exists in a form nothing in the repo executed.
+ *
+ * THE SHIM IS THE HARDEST SHAPE IN THE REPO to get right, because the value
+ * crosses two boundaries after it is written:
+ *
+ *     daemon writes it → host disk → --ro-bind into /run/sbxbin → a DIFFERENT
+ *     process inside the sandbox execs it
+ *
+ * so `/$bunfs/` (process-private) is invisible at both later hops. MEASURED on a
+ * real compiled binary, the old line produced:
+ *
+ *     #!/bin/sh
+ *     exec node "/dist/cli.js" "$@"
+ *              ↑ does not exist   ↑ and re-introduces a hard node dependency
+ *
+ * and executing the `/$bunfs/`-flavoured variant through `sh` dies with
+ * MODULE_NOT_FOUND, because `sh` expands the unescaped `$bunfs` inside double
+ * quotes to the empty string (`"/$bunfs/cli.js"` → `//cli.js`).
+ *
+ * These two forms CANNOT be converged: the source form must name `dist/cli.js`
+ * (a compiled binary has no such file) and the compiled form must name the
+ * executable itself. So the contract is pinned per-branch instead, and the shim
+ * is EXECUTED rather than string-matched wherever that is possible.
+ *
+ * TEETH: `isStandaloneBinary()` runs for real — it keys off `process.argv[1]`
+ * starting with `/$bunfs/` (src/core/self-spawn.ts) — so pointing argv[1] there
+ * exercises the genuine branch rather than a mock.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { botmuxShimExecLine, botmuxCliInvocation } from '../src/adapters/backend/sandbox.js';
+
+const REAL_ARGV1 = process.argv[1];
+function asCompiledBinary() { process.argv[1] = '/$bunfs/root/cli.js'; }
+afterEach(() => { process.argv[1] = REAL_ARGV1; });
+
+describe('sandbox botmux shim — compiled binary form', () => {
+  it('never emits a /$bunfs/ path, and never re-introduces node', () => {
+    asCompiledBinary();
+    const shim = botmuxShimExecLine();
+    // The path is invisible to the process that will run this, AND `sh` would
+    // eat the `$bunfs` token anyway.
+    expect(shim).not.toContain('$bunfs');
+    // `node` as a command word — a path that merely contains "node" (e.g.
+    // /root/.../node-versions/...) must not produce a false pass.
+    expect(shim).not.toMatch(/(^|\s)node(\s|$)/m);
+  });
+
+  it('execs the binary itself, with argv forwarded', () => {
+    asCompiledBinary();
+    expect(botmuxShimExecLine()).toBe(`#!/bin/sh\nexec ${JSON.stringify(process.execPath)} "$@"\n`);
+  });
+
+  it('the emitted shim actually runs and forwards args (not merely string-matched)', () => {
+    asCompiledBinary();
+    const dir = mkdtempSync(join(tmpdir(), 'sbx-shim-'));
+    // Stand in for the compiled binary: echo argv back. The shim's shape is what
+    // is under test, so substituting the target is legitimate — what matters is
+    // that `exec <path> "$@"` parses, runs, and keeps arguments intact.
+    const fake = join(dir, 'botmux-fake');
+    writeFileSync(fake, '#!/bin/sh\nprintf "GOT:%s\\n" "$@"\n', { mode: 0o755 });
+    chmodSync(fake, 0o755);
+
+    const shim = join(dir, 'botmux');
+    writeFileSync(shim, botmuxShimExecLine().replace(JSON.stringify(process.execPath), JSON.stringify(fake)), { mode: 0o755 });
+    chmodSync(shim, 0o755);
+
+    const r = spawnSync(shim, ['send', 'hello world'], { encoding: 'utf-8' });
+    expect(r.status).toBe(0);
+    // Second argument survives as ONE argument despite the space.
+    expect(r.stdout).toBe('GOT:send\nGOT:hello world\n');
+  });
+
+  it('the OLD form dies when executed — the regression this pins', () => {
+    // Not a test of our code: a demonstration that the shape we no longer emit is
+    // genuinely broken, so the assertions above are load-bearing rather than
+    // stylistic. `sh` expands the unescaped $bunfs to empty → `//cli.js`.
+    const dir = mkdtempSync(join(tmpdir(), 'sbx-oldshim-'));
+    const old = join(dir, 'botmux');
+    writeFileSync(old, '#!/bin/sh\nexec node "/$bunfs/cli.js" "$@"\n', { mode: 0o755 });
+    chmodSync(old, 0o755);
+    const r = spawnSync(old, ['send', 'hi'], { encoding: 'utf-8' });
+    expect(r.status).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/cannot find module|MODULE_NOT_FOUND/i);
+  });
+});
+
+describe('sandbox botmux shim — Node form unchanged', () => {
+  it('keeps `exec node <dist/cli.js>` (verified byte-identical to pre-change)', () => {
+    const shim = botmuxShimExecLine();
+    expect(shim.startsWith('#!/bin/sh\nexec node "')).toBe(true);
+    expect(shim).toMatch(/[/\\]cli\.js" "\$@"\n$/);
+    expect(shim).not.toContain('$bunfs');
+  });
+
+  it('quotes the script path so a directory with spaces still works', () => {
+    // JSON.stringify is the quoting mechanism; assert the observable property
+    // rather than the implementation.
+    const shim = botmuxShimExecLine();
+    const m = /exec node (".*?") "\$@"/.exec(shim);
+    expect(m).not.toBeNull();
+    expect(() => JSON.parse(m![1])).not.toThrow();
+  });
+});
+
+describe('relay host re-exec — botmuxCliInvocation', () => {
+  it('compiled: no script argument, so the binary dispatches `send` itself', () => {
+    asCompiledBinary();
+    // MEASURED: `<binary> "/dist/cli.js" send …` prints the help banner and exits
+    // 0, i.e. the relayed send silently does nothing.
+    expect(botmuxCliInvocation()).toEqual({ command: process.execPath, args: [] });
+  });
+
+  it('Node: keeps the script argument (node cannot resolve `send` alone)', () => {
+    const { command, args } = botmuxCliInvocation();
+    expect(command).toBe(process.execPath);
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatch(/[/\\]cli\.js$/);
+  });
+
+  it('an explicit cliPath override wins in both forms (tests inject one)', () => {
+    expect(botmuxCliInvocation('/custom/cli.js')).toEqual({ command: process.execPath, args: ['/custom/cli.js'] });
+    asCompiledBinary();
+    expect(botmuxCliInvocation('/custom/cli.js')).toEqual({ command: process.execPath, args: ['/custom/cli.js'] });
+  });
+
+  it('the two forms differ exactly by the script argument', () => {
+    const nodeForm = botmuxCliInvocation();
+    asCompiledBinary();
+    const binForm = botmuxCliInvocation();
+    // Stated as a relation, so editing either branch alone breaks it.
+    expect(nodeForm.args).toHaveLength(binForm.args.length + 1);
+  });
+
+  it('SOURCE PIN: the relay spawn consumes the invocation, not a bare path', () => {
+    // The helper is only useful if the spawn site actually uses it; a future edit
+    // that reverts to `spawn(process.execPath, [cli, 'send', …])` would leave
+    // every assertion above passing while the bug returns.
+    const src = readFileSync(new URL('../src/adapters/backend/sandbox.ts', import.meta.url), 'utf-8');
+    expect(src).toContain("spawn(cliInvocation.command, [...cliInvocation.args, 'send'");
+    expect(src).toContain('botmuxCliInvocation(opts.cliPath)');
+    // And the shim writer must go through the helper too.
+    expect(src).toContain('writeFileSync(shim, botmuxShimExecLine())');
+  });
+});


### PR DESCRIPTION
Tier 3 未守卫点里最严重的一处：**沙盒内的 `botmux send` 在编译版下完全不工作，且静默无错**。

## 缺陷

沙盒里的 `botmux` shim（`sandbox.ts:627`）和 relay 的宿主侧 re-exec（`:1111`）都从 `distCliJs()` 取路径，而它从本模块位置往上推。编译版模块图在虚拟 `/$bunfs/`，两个候选**都塌进真实文件系统根** —— 真二进制内实测：

```
/cli.js        existsSync = false
/dist/cli.js   existsSync = false
```

**① shim — 两重独立失效**

编译态生成的文件内容实测是：

```sh
exec node "/dist/cli.js" "$@"
         ↑ 对将要执行它的进程不存在   ↑ 且重新引入 node 硬依赖
```

`/$bunfs/` 是**进程私有**的（子进程实测 `CHILD_NO_BUNFS`），而编译版的全部意义就是不需要装 node、沙盒策略也不暴露 node。把 `/$bunfs/` 那种形态交给 `sh`，实测直接 `MODULE_NOT_FOUND` —— 双引号内未转义的 `$bunfs` 被展开成空串，`"/$bunfs/cli.js"` 实际解析成 `//cli.js`。

**② relay** — `spawn(process.execPath, [cli, 'send', …])` 在编译态变成二进制用一个不存在的路径 re-exec 自己 ⟹ 实测**打印 help banner 后 exit 0**，`botmux send` 静默不生效。

## 为什么只能分流、不能收敛

shim 的内容在 daemon 里写死，然后：

```
daemon 写文件 → 宿主磁盘 → --ro-bind 到 /run/sbxbin → 沙盒内【另一个进程】exec 它
```

虚拟路径在后两跳都不存在。两种形态需要的**本来就是两个不同的值**：源码态必须给 `dist/cli.js` 的真实路径（编译版没有这个文件），编译态必须给二进制自身（`process.execPath`，编译态下也是真实磁盘路径）。

所以抽成两个具名 helper（`botmuxShimExecLine` / `botmuxCliInvocation`），把「哪种形态给什么」写在一处，并**给每个分支配测试** —— 写错的 shim 是静默失效，只能靠守卫兜住。`distCliJs()` 保留但加了「编译态无效、调用方必须走这两个 helper」的警示注释。

## 验证

| 项 | 结果 |
|---|---|
| 编译态 shim | `exec "<binary>" "$@"` —— 无 `$bunfs`、无 `node` |
| 真正执行它 | **进入 `send` 子命令**（而非 help） |
| 负向对照① 旧 shim 形态 | `MODULE_NOT_FOUND` ✓（预期坏） |
| 负向对照② 旧 relay 形状 | 打 help banner ✓（预期坏） |
| Node 态 | 与改动前**基线 diff 逐字相同** |

- 新增 **11 项测试**；**反变异四组全部转红**（shim 退回旧写法 / 编译态误留 node / invocation 编译态误留脚本路径 / Node 态误删脚本路径）。每次变异前都断言过**锚点唯一命中**，避免「没落点却当成通过」
- 其中一条用例把**旧形态真正执行一遍**，证明被替换的写法确实是坏的 —— 断言不是风格偏好
- 一条 **SOURCE PIN** 断言两个调用点确实经由 helper，防止将来改回裸路径时测试还全绿
- `bun run build` 通过；沙盒相关面 **114 项全绿**；编译态 smoke **8 项全绿**
- 单测 **19219 passed / 4 failed**，4 个失败已 stash 改动跑基线对照、逐字相同（mojo EACCES + MCP sandbox bwrap，本机既有）

## 影响范围

| 维度 | 评估 |
|---|---|
| 跨形态 | Node 态逐字未变；编译态是被修的那侧 |
| 沙盒安全面 | shim 内容变成 `process.execPath`，而它**已在沙盒策略允许的路径内**（daemon 自身的二进制）；未新增任何 bind、未放宽任何 deny 规则；`shimBin` 仍是 `--ro-bind` 到 `/run/sbxbin` |
| 公共层 | 只碰 `adapters/backend/sandbox.ts`；新增两个导出，`distCliJs()` 仅加注释 |
| 平台 | 这个文件只在 Linux 跑（macOS 走 Seatbelt，注释已说明）；判据不含平台特定假设 |

⚠️ 之前 91 个 sandbox 测试文件里**没有一个**断言过 shim 内容或 `distCliJs`，这是缺陷能存活的原因 —— 本 PR 补上了这条覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
