### PR TITLE
fix(backend): fifo teardown 唤醒阻塞 read，修 worker 卡死在 process.exit

### DIFF
--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -198,6 +198,9 @@ export class TmuxPipeBackend implements SessionBackend {
   private readonly paneTarget: string;
   private readonly fifoPath: string;
   private readStream: fs.ReadStream | null = null;
+  /** Read end of the fifo, kept so teardown can close it explicitly.
+   *  `createReadStream(..., { autoClose: false })` never closes it for us. */
+  private fifoFd: number | null = null;
   /** Streaming UTF-8 decoder. The fifo read emits raw Buffer chunks at libuv's
    *  64KB highWaterMark boundary, which can fall in the middle of a multi-byte
    *  character (CJK = 3 bytes, box-drawing = 3 bytes, emoji = 4 bytes). Decoding
@@ -321,6 +324,7 @@ export class TmuxPipeBackend implements SessionBackend {
     // exact bug ate the bridge final_output pipeline on first ship: an
     // strace showed worker only read its IPC fd, never the fifo.)
     const fd = fs.openSync(this.fifoPath, fs.constants.O_RDWR);
+    this.fifoFd = fd;
     this.readStream = fs.createReadStream('', { fd, autoClose: false, highWaterMark: 64 * 1024 });
 
     this.readStream.on('data', (chunk) => {
@@ -577,11 +581,7 @@ export class TmuxPipeBackend implements SessionBackend {
       } catch { /* pane may already be gone — benign */ }
       this.pipeAttached = false;
     }
-    if (this.readStream) {
-      try { this.readStream.destroy(); } catch { /* already closed */ }
-      this.readStream = null;
-    }
-    try { fs.unlinkSync(this.fifoPath); } catch { /* already gone */ }
+    this.teardownFifoReader();
   }
 
   destroySession(): void {
@@ -846,6 +846,47 @@ export class TmuxPipeBackend implements SessionBackend {
     }
   }
 
+  /**
+   * Tear down the fifo reader so this process can actually exit.
+   *
+   * `readStream.destroy()` alone is NOT enough, and getting this wrong wedges
+   * the whole worker: libuv services the (deliberately blocking, see spawn())
+   * fifo read from its threadpool, and destroy() only detaches the JS stream —
+   * the threadpool thread stays parked inside the kernel `read()`. Because we
+   * hold the fifo O_RDWR, a writer always exists, so that read never sees EOF
+   * and never returns. `process.exit()` then blocks forever in
+   * uv__threadpool_cleanup joining that thread, with the event loop already
+   * stopped so the process cannot even self-kill on a timer. Observed in
+   * production as every worker of a daemon stuck mid-exit: the daemon still
+   * considered them live and kept delivering turns, so each message came back
+   * as "Worker 未能接收这条消息" (worker.input_delivery_failed) forever.
+   *
+   * The wake-up byte is what unblocks that read. It goes through a SEPARATE
+   * O_WRONLY|O_NONBLOCK fd rather than our own O_RDWR one on purpose: at
+   * teardown nobody is draining the pipe any more, so if tmux left it full a
+   * blocking write would hang exactly like the bug we are fixing (verified —
+   * a blocking write here reproduces the wedge, the non-blocking one returns
+   * EAGAIN and we simply move on; the reader is being torn down regardless).
+   * The byte is never observed by callers: the stream is destroyed first, so
+   * it is read by nobody and dies with the fifo on the unlink below.
+   */
+  private teardownFifoReader(): void {
+    if (this.readStream) {
+      try { this.readStream.destroy(); } catch { /* already closed */ }
+      this.readStream = null;
+    }
+    try {
+      const wakeFd = fs.openSync(this.fifoPath, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+      try { fs.writeSync(wakeFd, '\0'); } catch { /* EAGAIN when full — the read is already unblocked */ }
+      fs.closeSync(wakeFd);
+    } catch { /* fifo already unlinked/gone — nothing parked on it */ }
+    if (this.fifoFd !== null) {
+      try { fs.closeSync(this.fifoFd); } catch { /* already closed */ }
+      this.fifoFd = null;
+    }
+    try { fs.unlinkSync(this.fifoPath); } catch { /* already gone */ }
+  }
+
   private handlePaneExit(): void {
     if (this.exited) return;
     this.exited = true;
@@ -856,11 +897,7 @@ export class TmuxPipeBackend implements SessionBackend {
       } catch { /* pane may already be gone — benign */ }
       this.pipeAttached = false;
     }
-    if (this.readStream) {
-      try { this.readStream.destroy(); } catch { /* already closed */ }
-      this.readStream = null;
-    }
-    try { fs.unlinkSync(this.fifoPath); } catch { /* already gone */ }
+    this.teardownFifoReader();
     this.fireExit(1, null);
   }
 

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -375,13 +375,31 @@ export class TmuxPipeBackend implements SessionBackend {
     // Acquire the wake-up write end NOW, while the pathname exists and the fd
     // table has room. Teardown must never need to allocate anything.
     // O_NONBLOCK so a full pipe fails with EAGAIN instead of parking here.
+    //
+    // FAIL CLOSED if this fails. Without a wake fd the reader can be unblocked
+    // by nobody — not teardown, not the exit hook — so continuing would build
+    // exactly the unkillable reader this whole fix exists to prevent (verified:
+    // a wake-open failure alone re-wedges the process). This is also the only
+    // moment where bailing is safe: the read stream does not exist yet, so no
+    // read is parked and there is nothing to unblock. The failure modes all
+    // mean the session is doomed anyway — EMFILE will sink the following
+    // execSync(tmux …) too, and ENOENT means the fifo pathname is already gone.
     try {
+      // Test seam: the fail-closed path below is only reachable when this open
+      // fails, and EMFILE/ENOENT cannot be provoked from a test without
+      // destabilising the whole process. Env-gated, so production never reads it.
+      if (process.env.BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL === '1') {
+        const injected: NodeJS.ErrnoException = new Error('EMFILE: injected by test');
+        injected.code = 'EMFILE';
+        throw injected;
+      }
       this.fifoWakeFd = fs.openSync(this.fifoPath, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
-    } catch {
-      // Extremely unlikely (we hold the read end, so no ENXIO). Losing the wake
-      // fd only costs the unblock path, so keep the session working rather than
-      // failing the spawn; teardown degrades to best-effort.
+    } catch (err) {
       this.fifoWakeFd = null;
+      try { fs.closeSync(fd); } catch { /* best effort */ }
+      this.fifoFd = null;
+      try { fs.unlinkSync(this.fifoPath); } catch { /* best effort */ }
+      throw err;
     }
     this.readStream = fs.createReadStream('', { fd, autoClose: false, highWaterMark: 64 * 1024 });
     // From here on a parked read can wedge process exit, so make this reader
@@ -949,15 +967,17 @@ export class TmuxPipeBackend implements SessionBackend {
   /**
    * Last-resort unblock for the process-exit hook.
    *
-   * Only writes the wake-up byte — no unlink, no stream teardown, nothing that
-   * could throw or block. The single job is to let the parked threadpool read
-   * return so uv__threadpool_cleanup can join it; the process is already on its
-   * way out, so the fifo file itself is the OS's problem. Safe to call after a
-   * real teardown (fifoWakeFd is null by then) and safe to call twice.
+   * Writes the wake-up byte so the parked threadpool read can return and
+   * uv__threadpool_cleanup can join it, then unlinks the fifo: a named fifo is
+   * a filesystem object and outlives the process, so skipping this would strew
+   * /tmp with botmux-pipe-* on every exit that bypasses teardown. Deliberately
+   * minimal otherwise — no stream teardown, nothing that could block. Safe
+   * after a real teardown (fifoWakeFd is null by then) and safe to call twice.
    */
   wakeFifoReaderForExit(): void {
     if (this.fifoWakeFd === null) return;
     try { fs.writeSync(this.fifoWakeFd, '\0'); } catch { /* already unblocked */ }
+    try { fs.unlinkSync(this.fifoPath); } catch { /* already gone */ }
   }
 
   private teardownFifoReader(): void {

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -192,6 +192,41 @@ export function tmuxLifecycleInitialDelayMs(target: string): number {
   return 1000 + ((hash >>> 0) % 750);
 }
 
+/**
+ * Every backend with a live fifo reader, so process exit can unblock them all.
+ *
+ * A parked fifo read wedges `process.exit()` forever in uv__threadpool_cleanup
+ * (see teardownFifoReader for the full mechanism), and several production exit
+ * paths never call kill(): sendFatalWorkerErrorAndExit(), the
+ * uncaughtException / unhandledRejection handlers, and the
+ * existing-App-Server parent-exit branch all exit directly. Making the fix
+ * depend on every caller remembering to tear down first would leave the
+ * original wedge reachable, so the backend registers itself here and the
+ * process-exit hook below is the backstop. Entries are removed on teardown, so
+ * a normally-closed backend leaves nothing behind.
+ */
+const liveFifoReaders = new Set<TmuxPipeBackend>();
+let fifoExitHookInstalled = false;
+
+function installFifoExitHook(): void {
+  if (fifoExitHookInstalled) return;
+  fifoExitHookInstalled = true;
+  // 'exit' only admits synchronous work — which is exactly what this is: one
+  // write() plus close() per reader. Cannot be an async cleanup.
+  process.on('exit', () => {
+    for (const backend of liveFifoReaders) {
+      try { backend.wakeFifoReaderForExit(); } catch { /* best-effort */ }
+    }
+  });
+}
+
+/** Live fifo readers awaiting the exit-hook wake. Test-only: lets a regression
+ *  assert that a failed spawn deregistered itself, which "the process exited"
+ *  cannot show once the exit hook is in place. */
+export function __testOnly_liveFifoReaderCount(): number {
+  return liveFifoReaders.size;
+}
+
 export class TmuxPipeBackend implements SessionBackend {
   readonly supportsRawCommandPasteLine = true;
   /** Real tmux pane address (e.g. "0:2.0") or botmux session name (bmx-*). */
@@ -201,6 +236,18 @@ export class TmuxPipeBackend implements SessionBackend {
   /** Read end of the fifo, kept so teardown can close it explicitly.
    *  `createReadStream(..., { autoClose: false })` never closes it for us. */
   private fifoFd: number | null = null;
+  /** Set once teardownFifoReader() has run, so the reader's own EBADF-on-close
+   *  (see the 'error' handler) is recognised as expected teardown noise. Not
+   *  `exited`: the spawn-failure path tears the reader down without ever
+   *  marking the backend exited. */
+  private fifoTornDown = false;
+  /** Write end, opened at spawn() and held for the lifetime of the reader.
+   *  Teardown writes one byte here to unblock the parked read (see
+   *  teardownFifoReader). Acquired UP FRONT on purpose: opening it at teardown
+   *  instead would need the pathname to still exist and a spare fd at the worst
+   *  possible moment — both verified to fail and re-wedge the process (fifo
+   *  already unlinked → ENOENT; fd table exhausted → EMFILE). */
+  private fifoWakeFd: number | null = null;
   /** Streaming UTF-8 decoder. The fifo read emits raw Buffer chunks at libuv's
    *  64KB highWaterMark boundary, which can fall in the middle of a multi-byte
    *  character (CJK = 3 bytes, box-drawing = 3 bytes, emoji = 4 bytes). Decoding
@@ -325,7 +372,22 @@ export class TmuxPipeBackend implements SessionBackend {
     // strace showed worker only read its IPC fd, never the fifo.)
     const fd = fs.openSync(this.fifoPath, fs.constants.O_RDWR);
     this.fifoFd = fd;
+    // Acquire the wake-up write end NOW, while the pathname exists and the fd
+    // table has room. Teardown must never need to allocate anything.
+    // O_NONBLOCK so a full pipe fails with EAGAIN instead of parking here.
+    try {
+      this.fifoWakeFd = fs.openSync(this.fifoPath, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+    } catch {
+      // Extremely unlikely (we hold the read end, so no ENXIO). Losing the wake
+      // fd only costs the unblock path, so keep the session working rather than
+      // failing the spawn; teardown degrades to best-effort.
+      this.fifoWakeFd = null;
+    }
     this.readStream = fs.createReadStream('', { fd, autoClose: false, highWaterMark: 64 * 1024 });
+    // From here on a parked read can wedge process exit, so make this reader
+    // reachable from the exit hook even if nothing ever calls kill().
+    installFifoExitHook();
+    liveFifoReaders.add(this);
 
     this.readStream.on('data', (chunk) => {
       // StringDecoder reassembles multi-byte chars split across chunk
@@ -341,6 +403,12 @@ export class TmuxPipeBackend implements SessionBackend {
       }
     });
     this.readStream.on('error', (err: any) => {
+      // Teardown noise, not a fault: destroy() closes the read fd itself when
+      // no read is in flight (despite autoClose:false), so our own backstop
+      // close races it and the stream reports EBADF on a reader we are
+      // deliberately dismantling. Logging it would put a scary line in every
+      // worker's stderr on every normal close.
+      if (this.fifoTornDown && err?.code === 'EBADF') return;
       // Errors are best-effort logged via the worker's stderr (we can't
       // pull a logger in a backend without circular imports). Don't fire
       // exit — the user's CLI is still alive, we just lost realtime view.
@@ -367,6 +435,12 @@ export class TmuxPipeBackend implements SessionBackend {
         break;
       } catch (err: any) {
         if (!isRetryableStartupTmuxFailure(err) || attempt >= STARTUP_TMUX_RETRY_DELAYS_MS.length) {
+          // The fifo reader is already live (step 2) with a blocking read parked
+          // on it. Throwing out of spawn() without this leaves that read alive
+          // forever and wedges the process at exit exactly like the bug
+          // teardownFifoReader() exists to prevent — the caller only sees a
+          // failed spawn and has no handle to clean up.
+          this.teardownFifoReader();
           this.fireExit(1, null);
           throw err;
         }
@@ -862,27 +936,56 @@ export class TmuxPipeBackend implements SessionBackend {
    * as "Worker 未能接收这条消息" (worker.input_delivery_failed) forever.
    *
    * The wake-up byte is what unblocks that read. It goes through a SEPARATE
-   * O_WRONLY|O_NONBLOCK fd rather than our own O_RDWR one on purpose: at
-   * teardown nobody is draining the pipe any more, so if tmux left it full a
-   * blocking write would hang exactly like the bug we are fixing (verified —
-   * a blocking write here reproduces the wedge, the non-blocking one returns
-   * EAGAIN and we simply move on; the reader is being torn down regardless).
-   * The byte is never observed by callers: the stream is destroyed first, so
-   * it is read by nobody and dies with the fifo on the unlink below.
+   * write fd (never our own O_RDWR one) opened back in spawn(): at teardown
+   * nobody is draining the pipe any more, so if tmux left it full a blocking
+   * write would hang exactly like the bug we are fixing (verified). That fd is
+   * acquired UP FRONT rather than here because teardown is precisely when
+   * acquiring one can fail — the fifo may already be unlinked (ENOENT) or the
+   * fd table exhausted (EMFILE), and both were verified to re-wedge the
+   * process while the old code silently swallowed the error. The byte is never
+   * observed by callers: the stream is destroyed first, so nothing reads it and
+   * it dies with the fifo on the unlink below.
    */
+  /**
+   * Last-resort unblock for the process-exit hook.
+   *
+   * Only writes the wake-up byte — no unlink, no stream teardown, nothing that
+   * could throw or block. The single job is to let the parked threadpool read
+   * return so uv__threadpool_cleanup can join it; the process is already on its
+   * way out, so the fifo file itself is the OS's problem. Safe to call after a
+   * real teardown (fifoWakeFd is null by then) and safe to call twice.
+   */
+  wakeFifoReaderForExit(): void {
+    if (this.fifoWakeFd === null) return;
+    try { fs.writeSync(this.fifoWakeFd, '\0'); } catch { /* already unblocked */ }
+  }
+
   private teardownFifoReader(): void {
+    liveFifoReaders.delete(this);
+    this.fifoTornDown = true;
     if (this.readStream) {
       try { this.readStream.destroy(); } catch { /* already closed */ }
       this.readStream = null;
     }
-    try {
-      const wakeFd = fs.openSync(this.fifoPath, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
-      try { fs.writeSync(wakeFd, '\0'); } catch { /* EAGAIN when full — the read is already unblocked */ }
-      fs.closeSync(wakeFd);
-    } catch { /* fifo already unlinked/gone — nothing parked on it */ }
+    if (this.fifoWakeFd !== null) {
+      // EAGAIN (pipe full) is fine: a full pipe means the read already has data
+      // to return, so it is not parked. Any other error is equally non-fatal —
+      // we are tearing down regardless.
+      try { fs.writeSync(this.fifoWakeFd, '\0'); } catch { /* already unblocked */ }
+      try { fs.closeSync(this.fifoWakeFd); } catch { /* already closed */ }
+      this.fifoWakeFd = null;
+    }
     if (this.fifoFd !== null) {
-      try { fs.closeSync(this.fifoFd); } catch { /* already closed */ }
+      // Closing the read fd is nominally ours (autoClose:false), but destroy()
+      // DOES close it itself when no read is in flight — verified: after a
+      // synchronous destroy() the fd is already EBADF. So this close is a
+      // best-effort backstop for the in-flight case, and EBADF here is the
+      // normal, expected outcome rather than a fault. Clear the field first so
+      // a late 'error' handler re-entering teardown cannot close it twice (by
+      // then the number could name a freshly-opened unrelated file).
+      const fd = this.fifoFd;
       this.fifoFd = null;
+      try { fs.closeSync(fd); } catch { /* stream already closed it */ }
     }
     try { fs.unlinkSync(this.fifoPath); } catch { /* already gone */ }
   }

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -212,7 +212,7 @@ function installFifoExitHook(): void {
   if (fifoExitHookInstalled) return;
   fifoExitHookInstalled = true;
   // 'exit' only admits synchronous work — which is exactly what this is: one
-  // write() plus close() per reader. Cannot be an async cleanup.
+  // write() plus one unlink() per reader. Cannot be an async cleanup.
   process.on('exit', () => {
     for (const backend of liveFifoReaders) {
       try { backend.wakeFifoReaderForExit(); } catch { /* best-effort */ }
@@ -387,7 +387,9 @@ export class TmuxPipeBackend implements SessionBackend {
     try {
       // Test seam: the fail-closed path below is only reachable when this open
       // fails, and EMFILE/ENOENT cannot be provoked from a test without
-      // destabilising the whole process. Env-gated, so production never reads it.
+      // destabilising the whole process. The env var is read on every spawn but
+      // is only ever set by this repo's own test, so production behaviour is
+      // unchanged.
       if (process.env.BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL === '1') {
         const injected: NodeJS.ErrnoException = new Error('EMFILE: injected by test');
         injected.code = 'EMFILE';

--- a/test/fixtures/tmux-pipe-exit-fixture.ts
+++ b/test/fixtures/tmux-pipe-exit-fixture.ts
@@ -1,0 +1,76 @@
+/**
+ * Fixture for tmux-pipe-backend-exit.test.ts — run as a CHILD process.
+ *
+ * Exercises the REAL TmuxPipeBackend fifo lifecycle (spawn → kill) and then
+ * lets the process exit naturally. The parent asserts the child actually
+ * exits: the bug under test wedges `process.exit()` forever, which is
+ * invisible in-process and therefore cannot be caught by an in-test assertion.
+ *
+ * tmux itself is neutralized by a fake `tmux` executable the parent puts first
+ * on PATH, so nothing here touches the real tmux server (the production code
+ * targets the DEFAULT socket, shared with every live daemon on the machine).
+ * Everything else — mkfifo, the O_RDWR open, the libuv read stream, the
+ * teardown — is the real production path.
+ *
+ * argv[2] selects the teardown variant so the parent can run reverse mutations:
+ *   real     — the shipped kill() path
+ *   paneexit — the OTHER teardown site, handlePaneExit(); without this a fix
+ *              applied to only one of the two sites would look complete
+ *   full     — pipe deliberately full at teardown (tmux left output behind and
+ *              the reader is no longer draining). Distinguishes a NON-BLOCKING
+ *              wake-up write from a blocking one: a blocking write on our own
+ *              O_RDWR fd hangs here, recreating the very bug being fixed
+ *   nowake   — reproduces the pre-fix teardown (destroy + unlink, no wake-up
+ *              byte) and MUST hang, proving the harness has teeth
+ */
+import fs from 'node:fs';
+import { TmuxPipeBackend } from '../../src/adapters/backend/tmux-pipe-backend.js';
+
+const mode = process.argv[2] ?? 'real';
+
+const backend = new TmuxPipeBackend('bmx-exit-fixture');
+backend.spawn('/bin/true', [], { cwd: process.cwd(), cols: 80, rows: 24, env: {} });
+
+// Prove the fifo reader is actually live before tearing it down — otherwise a
+// spawn() that silently failed to open the fifo would make this test pass for
+// the wrong reason (no blocked read to wedge on in the first place).
+const fifoFd = (backend as unknown as { fifoFd: number | null }).fifoFd;
+const readStream = (backend as unknown as { readStream: unknown }).readStream;
+if (typeof fifoFd !== 'number' || !readStream) {
+  process.stdout.write('FIXTURE_NO_FIFO\n');
+  process.exit(2);
+}
+const fifoPath = (backend as unknown as { fifoPath: string }).fifoPath;
+
+// Give libuv a moment to park a threadpool read on the fifo. Without a read in
+// flight there is nothing to wedge and both variants would exit cleanly.
+setTimeout(() => {
+  if (mode === 'full') {
+    // Fill the pipe (Linux default 64KB) BEFORE teardown. The reader is about
+    // to stop draining, so a blocking wake-up write would park here forever —
+    // which is what separates the correct non-blocking write from the naive one.
+    try {
+      const stuffFd = fs.openSync(fifoPath, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+      try { for (;;) fs.writeSync(stuffFd, Buffer.alloc(4096, 0x41)); }
+      catch { /* EAGAIN — pipe is now full, which is the point */ }
+      fs.closeSync(stuffFd);
+    } catch { /* best effort */ }
+  }
+  process.stdout.write('TEARDOWN\n');
+  if (mode === 'nowake') {
+    // Pre-fix teardown, inlined: destroy the stream and unlink, but never wake
+    // the parked read. This is the reverse mutation — it must hang.
+    (backend as unknown as { readStream: { destroy(): void } | null }).readStream?.destroy();
+    (backend as unknown as { readStream: unknown }).readStream = null;
+    try { fs.closeSync(fifoFd); } catch { /* already closed */ }
+    try { fs.unlinkSync(fifoPath); } catch { /* already gone */ }
+  } else if (mode === 'paneexit') {
+    // The other teardown site. Private, and reached in production when the
+    // lifecycle watcher notices the pane vanished.
+    (backend as unknown as { handlePaneExit(): void }).handlePaneExit();
+  } else {
+    backend.kill();
+  }
+  process.stdout.write('EXITING\n');
+  process.exit(0);
+}, 250);

--- a/test/fixtures/tmux-pipe-exit-fixture.ts
+++ b/test/fixtures/tmux-pipe-exit-fixture.ts
@@ -131,7 +131,13 @@ setTimeout(() => {
   }
   if (mode === 'emfile') {
     // Exhaust the fd table so an on-demand wake fd open would get EMFILE.
-    // The parent lowers RLIMIT_NOFILE so this stays cheap and bounded.
+    //
+    // Just open until the OS refuses. No `ulimit` shell wrapper (threading
+    // interpreter paths through a shell string is what CodeQL flags) and no
+    // setrlimit (neither Node nor Bun exposes one — verified, and an optional
+    // call would have silently no-op'd). Cost is bounded by RLIMIT_NOFILE and
+    // measured at ~2-4s even with this box's 1M soft limit; every fd points at
+    // /dev/null and the process exits moments later.
     for (;;) {
       try { fs.openSync('/dev/null', 'r'); } catch { break; }
     }

--- a/test/fixtures/tmux-pipe-exit-fixture.ts
+++ b/test/fixtures/tmux-pipe-exit-fixture.ts
@@ -20,13 +20,59 @@
  *              the reader is no longer draining). Distinguishes a NON-BLOCKING
  *              wake-up write from a blocking one: a blocking write on our own
  *              O_RDWR fd hangs here, recreating the very bug being fixed
+ *   spawnfail— `tmux pipe-pane` fails terminally AFTER the fifo reader is live.
+ *              spawn() throws, and the caller has no backend handle to clean
+ *              up, so spawn() itself must tear the reader down
+ *   unlinked — the fifo pathname is gone before teardown. A teardown that only
+ *              opens its wake fd on demand gets ENOENT here and fails open
+ *   emfile   — fd table exhausted before teardown; an on-demand wake fd open
+ *              gets EMFILE. Both this and `unlinked` are why the wake fd is
+ *              acquired at spawn() instead
+ *   directexit— live backend, kill() NEVER called, straight to process.exit().
+ *              Covers sendFatalWorkerErrorAndExit / uncaughtException /
+ *              parent-exit, which all bypass both teardown sites
  *   nowake   — reproduces the pre-fix teardown (destroy + unlink, no wake-up
  *              byte) and MUST hang, proving the harness has teeth
  */
 import fs from 'node:fs';
-import { TmuxPipeBackend } from '../../src/adapters/backend/tmux-pipe-backend.js';
+import { TmuxPipeBackend, __testOnly_liveFifoReaderCount as readerRegistrySize } from '../../src/adapters/backend/tmux-pipe-backend.js';
 
 const mode = process.argv[2] ?? 'real';
+
+// The spawn-failure path is exercised before anything else: it asserts on
+// spawn() itself throwing, so it never reaches the shared teardown block below.
+if (mode === 'spawnfail') {
+  // The parent points PATH at a `tmux` that fails pipe-pane with a
+  // non-retryable (pane-gone) error, so spawn() throws after opening the fifo.
+  const failing = new TmuxPipeBackend('bmx-exit-fixture');
+  let threw = false;
+  try {
+    failing.spawn('/bin/true', [], { cwd: process.cwd(), cols: 80, rows: 24, env: {} });
+  } catch {
+    threw = true;
+  }
+  process.stdout.write(threw ? 'SPAWN_THREW\n' : 'SPAWN_DID_NOT_THROW\n');
+  // Did spawn() clean up after itself? The exit-hook backstop would let this
+  // process exit either way, so exit alone cannot tell a tidy spawn from a
+  // leaky one. Assert on the observable leak instead: after a failed spawn no
+  // reader may remain registered, and the fifo must be gone from disk.
+  const leakedReaders = readerRegistrySize();
+  const fifoLeft = fs.existsSync((failing as unknown as { fifoPath: string }).fifoPath);
+  process.stdout.write(`LEAKED_READERS=${leakedReaders} FIFO_LEFT=${fifoLeft}\n`);
+  // Yield first. libuv only parks the blocking fifo read on a threadpool
+  // thread after one event-loop turn, and spawn() throws synchronously — exit
+  // in the same tick and even a leaked reader cannot wedge, which would make
+  // this case pass against the leak it exists to catch (verified: without this
+  // delay the missing-teardown mutation survives). In production the caller
+  // always returns to the loop after a failed spawn, so the wait is realistic,
+  // not a contrivance to force a failure.
+  setTimeout(() => {
+    process.stdout.write('EXITING\n');
+    process.exit(0);
+  }, 250);
+}
+
+if (mode !== 'spawnfail') {
 
 const backend = new TmuxPipeBackend('bmx-exit-fixture');
 backend.spawn('/bin/true', [], { cwd: process.cwd(), cols: 80, rows: 24, env: {} });
@@ -45,6 +91,26 @@ const fifoPath = (backend as unknown as { fifoPath: string }).fifoPath;
 // Give libuv a moment to park a threadpool read on the fifo. Without a read in
 // flight there is nothing to wedge and both variants would exit cleanly.
 setTimeout(() => {
+  if (mode === 'directexit') {
+    // No teardown at all — the exit-hook backstop is the only thing that can
+    // save this process. Mirrors sendFatalWorkerErrorAndExit and the
+    // uncaughtException / parent-exit handlers.
+    process.stdout.write('DIRECT_EXIT\n');
+    process.stdout.write('EXITING\n');
+    process.exit(0);
+  }
+  if (mode === 'unlinked') {
+    // Someone removed the fifo first (stale-tmp sweeper, operator, a racing
+    // teardown). A wake fd opened on demand would now get ENOENT.
+    try { fs.unlinkSync(fifoPath); } catch { /* already gone */ }
+  }
+  if (mode === 'emfile') {
+    // Exhaust the fd table so an on-demand wake fd open would get EMFILE.
+    // The parent lowers RLIMIT_NOFILE so this stays cheap and bounded.
+    for (;;) {
+      try { fs.openSync('/dev/null', 'r'); } catch { break; }
+    }
+  }
   if (mode === 'full') {
     // Fill the pipe (Linux default 64KB) BEFORE teardown. The reader is about
     // to stop draining, so a blocking wake-up write would park here forever —
@@ -60,6 +126,14 @@ setTimeout(() => {
   if (mode === 'nowake') {
     // Pre-fix teardown, inlined: destroy the stream and unlink, but never wake
     // the parked read. This is the reverse mutation — it must hang.
+    //
+    // The exit-hook backstop would otherwise rescue even this, so drop the
+    // wake fd first to simulate its absence. That is the point of the case: it
+    // proves a read really is parked and really does wedge exit, so every
+    // other case in this file is passing for the right reason.
+    const wakeFd = (backend as unknown as { fifoWakeFd: number | null }).fifoWakeFd;
+    (backend as unknown as { fifoWakeFd: number | null }).fifoWakeFd = null;
+    if (wakeFd !== null) { try { fs.closeSync(wakeFd); } catch { /* already closed */ } }
     (backend as unknown as { readStream: { destroy(): void } | null }).readStream?.destroy();
     (backend as unknown as { readStream: unknown }).readStream = null;
     try { fs.closeSync(fifoFd); } catch { /* already closed */ }
@@ -72,5 +146,14 @@ setTimeout(() => {
     backend.kill();
   }
   process.stdout.write('EXITING\n');
+  // Same reasoning as the spawn-failure case: with the exit hook in place,
+  // "the process exited" no longer distinguishes a teardown that ran from one
+  // that did not. Report the observable cleanup so each teardown site is
+  // judged on its own work rather than on the backstop's.
+  process.stdout.write(
+    `LEAKED_READERS=${readerRegistrySize()} FIFO_LEFT=${fs.existsSync(fifoPath)}\n`,
+  );
   process.exit(0);
 }, 250);
+
+}

--- a/test/fixtures/tmux-pipe-exit-fixture.ts
+++ b/test/fixtures/tmux-pipe-exit-fixture.ts
@@ -31,6 +31,10 @@
  *   directexit— live backend, kill() NEVER called, straight to process.exit().
  *              Covers sendFatalWorkerErrorAndExit / uncaughtException /
  *              parent-exit, which all bypass both teardown sites
+ *   wakefail — the wake-fd open fails during spawn(). Without a wake fd the
+ *              reader can never be unblocked, so spawn() must fail closed
+ *              rather than hand back a backend nothing can rescue.
+ *              BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL drives the injection.
  *   nowake   — reproduces the pre-fix teardown (destroy + unlink, no wake-up
  *              byte) and MUST hang, proving the harness has teeth
  */
@@ -72,7 +76,28 @@ if (mode === 'spawnfail') {
   }, 250);
 }
 
-if (mode !== 'spawnfail') {
+if (mode === 'wakefail') {
+  // The parent sets BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL=1. Without a wake fd the
+  // reader is unrescuable, so spawn() must fail closed and leave nothing behind
+  // rather than return a backend that will wedge the process at exit.
+  const doomed = new TmuxPipeBackend('bmx-exit-fixture');
+  let threw = false;
+  try {
+    doomed.spawn('/bin/true', [], { cwd: process.cwd(), cols: 80, rows: 24, env: {} });
+  } catch {
+    threw = true;
+  }
+  const fifoLeft = fs.existsSync((doomed as unknown as { fifoPath: string }).fifoPath);
+  process.stdout.write(`SPAWN_THREW=${threw} LEAKED_READERS=${readerRegistrySize()} FIFO_LEFT=${fifoLeft}\n`);
+  // Same reason as the spawnfail case: give libuv a turn to park a read, so a
+  // fail-open regression actually gets the chance to wedge this process.
+  setTimeout(() => {
+    process.stdout.write('EXITING\n');
+    process.exit(0);
+  }, 250);
+}
+
+if (mode !== 'spawnfail' && mode !== 'wakefail') {
 
 const backend = new TmuxPipeBackend('bmx-exit-fixture');
 backend.spawn('/bin/true', [], { cwd: process.cwd(), cols: 80, rows: 24, env: {} });

--- a/test/fixtures/tmux-pipe-exit-fixture.ts
+++ b/test/fixtures/tmux-pipe-exit-fixture.ts
@@ -132,12 +132,12 @@ setTimeout(() => {
   if (mode === 'emfile') {
     // Exhaust the fd table so an on-demand wake fd open would get EMFILE.
     //
-    // Just open until the OS refuses. No `ulimit` shell wrapper (threading
-    // interpreter paths through a shell string is what CodeQL flags) and no
-    // setrlimit (neither Node nor Bun exposes one — verified, and an optional
-    // call would have silently no-op'd). Cost is bounded by RLIMIT_NOFILE and
-    // measured at ~2-4s even with this box's 1M soft limit; every fd points at
-    // /dev/null and the process exits moments later.
+    // The parent runs this mode behind a static `ulimit -n 128` wrapper, and it
+    // MUST: unbounded, this box's 1M-fd limit means opening ~a million files,
+    // which burns kernel file objects and can push the shared host toward a
+    // global ENFILE while ~275 live daemon workers are running beside the tests.
+    // (An in-process setrlimit would be tidier, but neither Node nor Bun
+    // exposes one — verified; an optional call would have silently no-op'd.)
     for (;;) {
       try { fs.openSync('/dev/null', 'r'); } catch { break; }
     }

--- a/test/tmux-pipe-backend-exit.test.ts
+++ b/test/tmux-pipe-backend-exit.test.ts
@@ -25,7 +25,7 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync, readdirSync } from 'node
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
-import { spawnTsScript, tsRunnerPrefix } from './helpers/ts-runner.js';
+import { spawnTsScript, tsRunnerPrefix, isBunRuntime } from './helpers/ts-runner.js';
 
 const FIXTURE = resolve(__dirname, 'fixtures/tmux-pipe-exit-fixture.ts');
 // Generous vs. the ~250ms the fixture needs: on a loaded box a slow start must
@@ -37,7 +37,7 @@ let fakeBinDir: string;
 let failingBinDir: string;
 
 /** Run the fixture; resolve with how it ended. `timedOut` means it wedged. */
-type FixtureMode = 'real' | 'nowake' | 'paneexit' | 'full' | 'spawnfail' | 'unlinked' | 'emfile' | 'directexit';
+type FixtureMode = 'real' | 'nowake' | 'paneexit' | 'full' | 'spawnfail' | 'unlinked' | 'emfile' | 'directexit' | 'wakefail';
 
 async function runFixture(mode: FixtureMode): Promise<{
   timedOut: boolean;
@@ -45,6 +45,7 @@ async function runFixture(mode: FixtureMode): Promise<{
   stdout: string;
 }> {
   const bin = mode === 'spawnfail' ? failingBinDir : fakeBinDir;
+  const extraEnv = mode === 'wakefail' ? { BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL: '1' } : {};
   // The emfile case needs a small fd table to exhaust. `sh -c 'ulimit -n …'`
   // is the portable way to lower RLIMIT_NOFILE for a child; 128 leaves room
   // for the runtime's own startup while still being quick to fill.
@@ -52,11 +53,11 @@ async function runFixture(mode: FixtureMode): Promise<{
     ? spawn(
       '/bin/sh',
       ['-c', `ulimit -n 128; exec "$0" "$@"`, tsRunnerPrefix().command, ...tsRunnerPrefix().prefixArgs, FIXTURE, mode],
-      { stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` } },
+      { stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, ...extraEnv, PATH: `${bin}:${process.env.PATH ?? ''}` } },
     )
     : spawnTsScript(FIXTURE, [mode], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
+      env: { ...process.env, ...extraEnv, PATH: `${bin}:${process.env.PATH ?? ''}` },
     });
   let stdout = '';
   child.stdout?.on('data', (b) => { stdout += String(b); });
@@ -166,12 +167,18 @@ describe('TmuxPipeBackend fifo teardown', () => {
   // Fixing only the teardown sites would leave the original wedge reachable, so
   // the module installs a process-exit hook. This is its regression.
   it('lets the process exit with a LIVE backend and no teardown call at all', async () => {
+    const before = new Set(readdirSync(tmpdir()).filter((f) => f.startsWith('botmux-pipe-')));
     const r = await runFixture('directexit');
 
     expect(r.stdout).toContain('DIRECT_EXIT');
     expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
     expect(r.timedOut).toBe(false);
     expect(r.code).toBe(0);
+    // A named fifo is a filesystem object and outlives the process, so the exit
+    // hook has to unlink as well as wake — otherwise every teardown-bypassing
+    // exit strews /tmp with botmux-pipe-*.
+    const after = readdirSync(tmpdir()).filter((f) => f.startsWith('botmux-pipe-'));
+    expect(after.filter((f) => !before.has(f))).toEqual([]);
   }, EXIT_TIMEOUT_MS + 15_000);
 
   // Blocker found in review: acquiring the wake fd lazily AT teardown fails in
@@ -194,11 +201,31 @@ describe('TmuxPipeBackend fifo teardown', () => {
     expect(r.code).toBe(0);
   }, EXIT_TIMEOUT_MS + 15_000);
 
+  // Blocker found in review: without a wake fd the reader can be unblocked by
+  // NOBODY — not teardown, not the exit hook. Returning a backend in that state
+  // hands back a process that is already doomed to wedge, so spawn() must fail
+  // closed. The window is safe because the read stream does not exist yet.
+  it('fails closed (and leaves nothing behind) when the wake fd cannot be opened', async () => {
+    const r = await runFixture('wakefail');
+
+    expect(r.stdout).toContain('SPAWN_THREW=true LEAKED_READERS=0 FIFO_LEFT=false');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
   // Reverse mutation. Without this the tests above prove nothing: if the fifo
   // read were never actually parked, every variant would exit cleanly and they
   // would pass against the broken code too. This asserts the harness has teeth
   // by reproducing the pre-fix teardown and requiring it to hang.
-  it('reproduces the wedge when the wake-up byte is omitted', async () => {
+  //
+  // NODE ONLY. The wedge is a Node/libuv property — a blocking threadpool read
+  // that uv__threadpool_cleanup must join at exit. Bun's runtime ends the
+  // pending read on destroy()+close, so it never wedges and this expectation is
+  // simply false there (verified: 8/9 under `bunx --bun vitest`, this the only
+  // failure). The production bug is Node's, so skipping keeps the assertion
+  // honest instead of asserting one runtime's behaviour of the other; the eight
+  // positive cases still run under both.
+  it.skipIf(isBunRuntime())('reproduces the wedge when the wake-up byte is omitted', async () => {
     const r = await runFixture('nowake');
 
     expect(r.stdout).toContain('TEARDOWN');

--- a/test/tmux-pipe-backend-exit.test.ts
+++ b/test/tmux-pipe-backend-exit.test.ts
@@ -24,7 +24,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { spawnTsScript } from './helpers/ts-runner.js';
+import { spawn } from 'node:child_process';
+import { spawnTsScript, tsRunnerPrefix } from './helpers/ts-runner.js';
 
 const FIXTURE = resolve(__dirname, 'fixtures/tmux-pipe-exit-fixture.ts');
 // Generous vs. the ~250ms the fixture needs: on a loaded box a slow start must
@@ -33,17 +34,30 @@ const FIXTURE = resolve(__dirname, 'fixtures/tmux-pipe-exit-fixture.ts');
 const EXIT_TIMEOUT_MS = 20_000;
 
 let fakeBinDir: string;
+let failingBinDir: string;
 
 /** Run the fixture; resolve with how it ended. `timedOut` means it wedged. */
-async function runFixture(mode: 'real' | 'nowake' | 'paneexit' | 'full'): Promise<{
+type FixtureMode = 'real' | 'nowake' | 'paneexit' | 'full' | 'spawnfail' | 'unlinked' | 'emfile' | 'directexit';
+
+async function runFixture(mode: FixtureMode): Promise<{
   timedOut: boolean;
   code: number | null;
   stdout: string;
 }> {
-  const child = spawnTsScript(FIXTURE, [mode], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH ?? ''}` },
-  });
+  const bin = mode === 'spawnfail' ? failingBinDir : fakeBinDir;
+  // The emfile case needs a small fd table to exhaust. `sh -c 'ulimit -n …'`
+  // is the portable way to lower RLIMIT_NOFILE for a child; 128 leaves room
+  // for the runtime's own startup while still being quick to fill.
+  const child = mode === 'emfile'
+    ? spawn(
+      '/bin/sh',
+      ['-c', `ulimit -n 128; exec "$0" "$@"`, tsRunnerPrefix().command, ...tsRunnerPrefix().prefixArgs, FIXTURE, mode],
+      { stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` } },
+    )
+    : spawnTsScript(FIXTURE, [mode], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
+    });
   let stdout = '';
   child.stdout?.on('data', (b) => { stdout += String(b); });
   child.stderr?.on('data', (b) => { stdout += String(b); });
@@ -66,10 +80,27 @@ beforeAll(() => {
   // `pipe-pane` must succeed (exit 0) or spawn() throws before a fifo exists.
   writeFileSync(fake, '#!/bin/sh\nexit 0\n');
   chmodSync(fake, 0o755);
+
+  // A tmux whose pipe-pane fails NON-retryably, so spawn() gives up at once
+  // instead of sleeping through the retry ladder: a numeric exit status plus
+  // stderr that is not a server-level error reads as "the server answered and
+  // deterministically rejected" (isRetryableStartupTmuxFailure).
+  failingBinDir = mkdtempSync(join(tmpdir(), 'botmux-failing-tmux-'));
+  const failing = join(failingBinDir, 'tmux');
+  writeFileSync(
+    failing,
+    '#!/bin/sh\n'
+    + 'case "$1" in\n'
+    + "  pipe-pane) echo \"can't find pane: bmx-exit-fixture\" >&2; exit 1 ;;\n"
+    + '  *) exit 0 ;;\n'
+    + 'esac\n',
+  );
+  chmodSync(failing, 0o755);
 });
 
 afterAll(() => {
   rmSync(fakeBinDir, { recursive: true, force: true });
+  rmSync(failingBinDir, { recursive: true, force: true });
 });
 
 describe('TmuxPipeBackend fifo teardown', () => {
@@ -81,6 +112,7 @@ describe('TmuxPipeBackend fifo teardown', () => {
     expect(r.stdout).toContain('TEARDOWN');
     expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
     expect(r.stdout).toContain('EXITING');
+    expect(r.stdout).toContain('LEAKED_READERS=0 FIFO_LEFT=false');
     expect(r.timedOut).toBe(false);
     expect(r.code).toBe(0);
   }, EXIT_TIMEOUT_MS + 15_000);
@@ -94,6 +126,7 @@ describe('TmuxPipeBackend fifo teardown', () => {
     expect(r.stdout).toContain('TEARDOWN');
     expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
     expect(r.stdout).toContain('EXITING');
+    expect(r.stdout).toContain('LEAKED_READERS=0 FIFO_LEFT=false');
     expect(r.timedOut).toBe(false);
     expect(r.code).toBe(0);
   }, EXIT_TIMEOUT_MS + 15_000);
@@ -106,6 +139,57 @@ describe('TmuxPipeBackend fifo teardown', () => {
 
     expect(r.stdout).toContain('TEARDOWN');
     expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
+  // A THIRD wedge path, distinct from the two teardown sites: spawn() opens the
+  // fifo (step 2) before attaching pipe-pane (step 3). If step 3 fails
+  // terminally, spawn() throws — and the caller never got a backend handle, so
+  // nobody can call kill(). spawn() has to clean up after itself or the parked
+  // read outlives the failed spawn and wedges exit.
+  it('lets the process exit when spawn() fails after opening the fifo', async () => {
+    const r = await runFixture('spawnfail');
+
+    expect(r.stdout).toContain('SPAWN_THREW');
+    // Exit alone cannot judge this any more — the exit hook would rescue a
+    // leaked reader too. Assert the cleanup itself: nothing left registered,
+    // no fifo left on disk.
+    expect(r.stdout).toContain('LEAKED_READERS=0 FIFO_LEFT=false');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
+  // Blocker found in review: several production exit paths never call kill() —
+  // sendFatalWorkerErrorAndExit(), the uncaughtException / unhandledRejection
+  // handlers, and the existing-App-Server parent-exit branch all exit directly.
+  // Fixing only the teardown sites would leave the original wedge reachable, so
+  // the module installs a process-exit hook. This is its regression.
+  it('lets the process exit with a LIVE backend and no teardown call at all', async () => {
+    const r = await runFixture('directexit');
+
+    expect(r.stdout).toContain('DIRECT_EXIT');
+    expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
+  // Blocker found in review: acquiring the wake fd lazily AT teardown fails in
+  // exactly the states teardown has to survive. Both of these were verified to
+  // re-wedge the process while the error was silently swallowed, which is why
+  // the fd is opened up front in spawn().
+  it('still exits when the fifo was unlinked before teardown', async () => {
+    const r = await runFixture('unlinked');
+
+    expect(r.stdout).toContain('TEARDOWN');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
+  it('still exits when the fd table is exhausted at teardown (EMFILE)', async () => {
+    const r = await runFixture('emfile');
+
+    expect(r.stdout).toContain('TEARDOWN');
     expect(r.timedOut).toBe(false);
     expect(r.code).toBe(0);
   }, EXIT_TIMEOUT_MS + 15_000);

--- a/test/tmux-pipe-backend-exit.test.ts
+++ b/test/tmux-pipe-backend-exit.test.ts
@@ -24,8 +24,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { spawn } from 'node:child_process';
-import { spawnTsScript, tsRunnerPrefix, isBunRuntime } from './helpers/ts-runner.js';
+import { spawnTsScript, isBunRuntime } from './helpers/ts-runner.js';
 
 const FIXTURE = resolve(__dirname, 'fixtures/tmux-pipe-exit-fixture.ts');
 // Generous vs. the ~250ms the fixture needs: on a loaded box a slow start must
@@ -46,19 +45,14 @@ async function runFixture(mode: FixtureMode): Promise<{
 }> {
   const bin = mode === 'spawnfail' ? failingBinDir : fakeBinDir;
   const extraEnv = mode === 'wakefail' ? { BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL: '1' } : {};
-  // The emfile case needs a small fd table to exhaust. `sh -c 'ulimit -n …'`
-  // is the portable way to lower RLIMIT_NOFILE for a child; 128 leaves room
-  // for the runtime's own startup while still being quick to fill.
-  const child = mode === 'emfile'
-    ? spawn(
-      '/bin/sh',
-      ['-c', `ulimit -n 128; exec "$0" "$@"`, tsRunnerPrefix().command, ...tsRunnerPrefix().prefixArgs, FIXTURE, mode],
-      { stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, ...extraEnv, PATH: `${bin}:${process.env.PATH ?? ''}` } },
-    )
-    : spawnTsScript(FIXTURE, [mode], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, ...extraEnv, PATH: `${bin}:${process.env.PATH ?? ''}` },
-    });
+  // No `sh -c 'ulimit -n …'` wrapper: threading interpreter paths through a
+  // shell string is what CodeQL flags as a command built from environment
+  // values, and it buys nothing here — the emfile fixture just opens fds until
+  // the OS refuses, which exhausts whatever limit the process happens to have.
+  const child = spawnTsScript(FIXTURE, [mode], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, ...extraEnv, PATH: `${bin}:${process.env.PATH ?? ''}` },
+  });
   let stdout = '';
   child.stdout?.on('data', (b) => { stdout += String(b); });
   child.stderr?.on('data', (b) => { stdout += String(b); });

--- a/test/tmux-pipe-backend-exit.test.ts
+++ b/test/tmux-pipe-backend-exit.test.ts
@@ -24,7 +24,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { spawnTsScript, isBunRuntime } from './helpers/ts-runner.js';
+import { spawn } from 'node:child_process';
+import { spawnTsScript, tsRunnerPrefix, isBunRuntime } from './helpers/ts-runner.js';
 
 const FIXTURE = resolve(__dirname, 'fixtures/tmux-pipe-exit-fixture.ts');
 // Generous vs. the ~250ms the fixture needs: on a loaded box a slow start must
@@ -34,6 +35,9 @@ const EXIT_TIMEOUT_MS = 20_000;
 
 let fakeBinDir: string;
 let failingBinDir: string;
+/** Static `ulimit -n 128; exec "$@"` wrapper — see the emfile note in runFixture. */
+let fdLimitWrapper: string;
+let wrapperDir: string;
 
 /** Run the fixture; resolve with how it ended. `timedOut` means it wedged. */
 type FixtureMode = 'real' | 'nowake' | 'paneexit' | 'full' | 'spawnfail' | 'unlinked' | 'emfile' | 'directexit' | 'wakefail';
@@ -45,14 +49,25 @@ async function runFixture(mode: FixtureMode): Promise<{
 }> {
   const bin = mode === 'spawnfail' ? failingBinDir : fakeBinDir;
   const extraEnv = mode === 'wakefail' ? { BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL: '1' } : {};
-  // No `sh -c 'ulimit -n …'` wrapper: threading interpreter paths through a
-  // shell string is what CodeQL flags as a command built from environment
-  // values, and it buys nothing here — the emfile fixture just opens fds until
-  // the OS refuses, which exhausts whatever limit the process happens to have.
-  const child = spawnTsScript(FIXTURE, [mode], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, ...extraEnv, PATH: `${bin}:${process.env.PATH ?? ''}` },
-  });
+  // The emfile case fills the fd table, so it MUST run under a low
+  // RLIMIT_NOFILE. This box allows 1,048,576 fds: opening a million of them
+  // burns kernel file objects, can push the shared host toward a global ENFILE,
+  // and would disturb the ~275 live daemon workers running alongside the tests.
+  //
+  // The limit is applied by a STATIC wrapper script (`ulimit -n 128; exec "$@"`)
+  // rather than an inline `sh -c` string. Same effect, but nothing dynamic is
+  // ever concatenated into shell source — the interpreter path arrives as a
+  // quoted argv element — which is what CodeQL flagged about the inline form.
+  const child = mode === 'emfile'
+    ? spawn(
+      fdLimitWrapper,
+      [tsRunnerPrefix().command, ...tsRunnerPrefix().prefixArgs, FIXTURE, mode],
+      { stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, ...extraEnv, PATH: `${bin}:${process.env.PATH ?? ''}` } },
+    )
+    : spawnTsScript(FIXTURE, [mode], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...extraEnv, PATH: `${bin}:${process.env.PATH ?? ''}` },
+    });
   let stdout = '';
   child.stdout?.on('data', (b) => { stdout += String(b); });
   child.stderr?.on('data', (b) => { stdout += String(b); });
@@ -91,11 +106,20 @@ beforeAll(() => {
     + 'esac\n',
   );
   chmodSync(failing, 0o755);
+
+  // Static wrapper: constant script body, everything dynamic arrives as argv.
+  // Its own dir, NOT fakeBinDir — that one goes on the child's PATH and must
+  // hold only the fake `tmux`.
+  wrapperDir = mkdtempSync(join(tmpdir(), 'botmux-fdlimit-'));
+  fdLimitWrapper = join(wrapperDir, 'with-low-fd-limit.sh');
+  writeFileSync(fdLimitWrapper, '#!/bin/sh\nulimit -n 128\nexec "$@"\n');
+  chmodSync(fdLimitWrapper, 0o755);
 });
 
 afterAll(() => {
   rmSync(fakeBinDir, { recursive: true, force: true });
   rmSync(failingBinDir, { recursive: true, force: true });
+  rmSync(wrapperDir, { recursive: true, force: true });
 });
 
 describe('TmuxPipeBackend fifo teardown', () => {

--- a/test/tmux-pipe-backend-exit.test.ts
+++ b/test/tmux-pipe-backend-exit.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression: tearing down the fifo reader must not wedge process exit.
+ *
+ * THE BUG (production incident): TmuxPipeBackend opens its fifo O_RDWR and
+ * reads it with a libuv threadpool read that is deliberately BLOCKING (see the
+ * O_NONBLOCK rationale in spawn()). `readStream.destroy()` detaches the JS
+ * stream but leaves that thread parked inside the kernel `read()`, and since we
+ * hold the write end ourselves the read never sees EOF. `process.exit()` then
+ * blocks forever in uv__threadpool_cleanup joining the thread — with the event
+ * loop already stopped, so the process cannot self-kill on a timer. Every
+ * worker of one daemon ended up stuck mid-exit; the daemon still believed they
+ * were live and kept delivering turns, so every user message came back as
+ * "Worker 未能接收这条消息" (worker.input_delivery_failed), permanently.
+ *
+ * WHY A CHILD PROCESS: the failure IS "the process never exits". Nothing
+ * in-process can observe it — an in-test assertion would itself hang. So the
+ * only honest probe is to spawn a real process and assert it terminates.
+ *
+ * WHY tmux IS FAKED: the production code targets the DEFAULT tmux socket,
+ * shared with every live daemon on this machine. A fake `tmux` first on PATH
+ * keeps the real fifo/read/teardown path intact while touching no real server.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnTsScript } from './helpers/ts-runner.js';
+
+const FIXTURE = resolve(__dirname, 'fixtures/tmux-pipe-exit-fixture.ts');
+// Generous vs. the ~250ms the fixture needs: on a loaded box a slow start must
+// not look like a wedge. The wedged variant hangs forever, so a false PASS is
+// impossible in the other direction.
+const EXIT_TIMEOUT_MS = 20_000;
+
+let fakeBinDir: string;
+
+/** Run the fixture; resolve with how it ended. `timedOut` means it wedged. */
+async function runFixture(mode: 'real' | 'nowake' | 'paneexit' | 'full'): Promise<{
+  timedOut: boolean;
+  code: number | null;
+  stdout: string;
+}> {
+  const child = spawnTsScript(FIXTURE, [mode], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH ?? ''}` },
+  });
+  let stdout = '';
+  child.stdout?.on('data', (b) => { stdout += String(b); });
+  child.stderr?.on('data', (b) => { stdout += String(b); });
+
+  return await new Promise((resolvePromise) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      resolvePromise({ timedOut: true, code: null, stdout });
+    }, EXIT_TIMEOUT_MS);
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      resolvePromise({ timedOut: false, code, stdout });
+    });
+  });
+}
+
+beforeAll(() => {
+  fakeBinDir = mkdtempSync(join(tmpdir(), 'botmux-fake-tmux-'));
+  const fake = join(fakeBinDir, 'tmux');
+  // `pipe-pane` must succeed (exit 0) or spawn() throws before a fifo exists.
+  writeFileSync(fake, '#!/bin/sh\nexit 0\n');
+  chmodSync(fake, 0o755);
+});
+
+afterAll(() => {
+  rmSync(fakeBinDir, { recursive: true, force: true });
+});
+
+describe('TmuxPipeBackend fifo teardown', () => {
+  it('lets the process exit after kill() (does not wedge in uv_thread_join)', async () => {
+    const r = await runFixture('real');
+
+    // Order matters: assert the fixture got far enough BEFORE judging the exit,
+    // so a fixture that died early can never masquerade as a clean pass.
+    expect(r.stdout).toContain('TEARDOWN');
+    expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
+    expect(r.stdout).toContain('EXITING');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
+  // The OTHER teardown site. kill() and handlePaneExit() each own a copy of
+  // this logic, so a fix landed on only one of them would still ship the bug
+  // on the pane-vanished path.
+  it('lets the process exit after handlePaneExit() too', async () => {
+    const r = await runFixture('paneexit');
+
+    expect(r.stdout).toContain('TEARDOWN');
+    expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
+    expect(r.stdout).toContain('EXITING');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
+  // The wake-up write MUST be non-blocking. At teardown nobody drains the pipe,
+  // so if tmux left it full a blocking write parks forever — the same wedge,
+  // moved one line down. Only this case tells the two implementations apart.
+  it('still exits when the pipe is full at teardown (wake-up write must not block)', async () => {
+    const r = await runFixture('full');
+
+    expect(r.stdout).toContain('TEARDOWN');
+    expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
+  // Reverse mutation. Without this the tests above prove nothing: if the fifo
+  // read were never actually parked, every variant would exit cleanly and they
+  // would pass against the broken code too. This asserts the harness has teeth
+  // by reproducing the pre-fix teardown and requiring it to hang.
+  it('reproduces the wedge when the wake-up byte is omitted', async () => {
+    const r = await runFixture('nowake');
+
+    expect(r.stdout).toContain('TEARDOWN');
+    // It reaches process.exit(0) and prints EXITING, then never dies — that is
+    // exactly the production signature, so the wedge is the timeout, not a
+    // missing line.
+    expect(r.timedOut).toBe(true);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
+  it('leaves no fifo behind after teardown', async () => {
+    const before = new Set(readdirSync(tmpdir()).filter((f) => f.startsWith('botmux-pipe-')));
+    const r = await runFixture('real');
+    expect(r.timedOut).toBe(false);
+    const after = readdirSync(tmpdir()).filter((f) => f.startsWith('botmux-pipe-'));
+    expect(after.filter((f) => !before.has(f))).toEqual([]);
+  }, EXIT_TIMEOUT_MS + 15_000);
+});


### PR DESCRIPTION
## 问题

线上一个 daemon 的**全部 26 个 worker 卡死在退出途中**，表现为用户每发一条消息都收到：

> ⚠️ Worker 未能接收这条消息。Botmux 已在同一 Worker 上自动重试，但仍未完成接收；为避免跨进程重复执行，没有继续重投。请重发本条消息。

报错本身只是症状：daemon 投递后等 worker 的同步 receipt ACK，2s 超时、重试 2 次都等不到，又因飞书事件已被 dedup 认领、不敢跨进程重投，只能让用户重发。

## 根因

`TmuxPipeBackend` 的 fifo 以 `O_RDWR` 打开、且**刻意不加 `O_NONBLOCK`**（见 `spawn()` 里的既有注释：加了会让 libuv 首个 read 拿 EAGAIN 直接把流搞死）。libuv 因此在线程池里发起**内核阻塞式 `read()`**。

而 teardown 只做了 `readStream.destroy()` + `unlinkSync`：

1. `destroy()` 只摘掉 JS 层的流，**唤不醒已经陷在内核 `read()` 里的那个线程**
2. 又因为我们自己握着写端（O_RDWR），fifo **永远不会 EOF**，那次 read 永不返回
3. `process.exit()` 走到 `uv__threadpool_cleanup` 要 join 全部线程 ⟹ 主线程 futex 卡死。此时**事件循环已停，进程连定时器自杀都做不到**

生产进程实抓的 native 栈：

```
#0  futex_wait
#5  uv_thread_join
#6  uv__threadpool_cleanup
#7  node::DefaultProcessExitHandlerInternal
#8  node::Environment::Exit          ← process.exit() 进来的
```

futex 的 `expected=<tid>` 直接点名罪魁线程，该线程停在 `read(fd=24)`；`fd 24 -> /tmp/botmux-pipe-*.fifo (deleted)`，fdinfo flags `02100002` = O_RDWR。

**为什么没有兜底救回来**：daemon 侧的 `armWorkerKillBackstop`（SIGTERM→SIGKILL）只在 close / suspend / retire 三条路径 arm，而这批 worker **不在任何一条上**——它们是自己走到 exit 卡住的（26 个里 0 个出现过 `Suspend requested`，全仓 0 次 `did not exit after SIGTERM`）。daemon 眼里它们仍是活 worker ⟹ 照常投递、照常超时、照常报错，**该会话进入永久坏态**。

## 修法

teardown 时先经一个**独立的 `O_WRONLY|O_NONBLOCK` fd** 写 1 字节把 parked 的 read 唤醒，再 destroy / close / unlink。`kill()` 与 `handlePaneExit()` 两处收敛为共用的 `teardownFifoReader()`。

**为什么必须是非阻塞 fd、而不是复用自己那个 O_RDWR fd**：teardown 时已经没人排空管道，若 tmux 残留把管道写满，**阻塞写会原地挂住，等于把同一个 bug 挪下一行**。这一点不是推理，是实测出来的——我最初想到的修法（`closeSync(fd)`）和第二个（在原 fd 上阻塞写）都被实跑推翻，见下面 MUT-C。

## 验证

新增 `test/tmux-pipe-backend-exit.test.ts`（5 例）。

**为什么用真子进程**：故障形态就是「进程不退出」，进程内断言自身也会挂，所以夹具跑在真子进程里，由父进程断言其确实终止。
**为什么假掉 tmux**：生产代码打的是**默认 socket**，与本机全部 live daemon 共用，测试绝不能碰——用 PATH 最前的假 `tmux` 挡掉，其余（mkfifo / O_RDWR open / libuv 读流 / teardown）全是真实生产路径。

覆盖：`kill()` 路径、`handlePaneExit()` 路径、**管道写满时仍能退出**、反变异（去掉唤醒字节必须挂）、fifo 不残留。

| 项 | 结果 |
|---|---|
| `bun run build` | exit 0 |
| 新测试 | **5 passed (5)** |
| MUT-A 删掉唤醒字节 | **3 failed** ✅ |
| MUT-B 只修 `kill()`、`handlePaneExit` 退回旧写法 | **1 failed** ✅ |
| MUT-C 唤醒改用自己的 O_RDWR fd 阻塞写 | **1 failed** ✅ |
| MUT-D 唤醒写到 `/dev/null` | **3 failed** ✅ |
| 合法重构对照（唤醒抽成独立私有方法） | **仍 5 passed**（守卫不过拟合）✅ |
| 邻近 backend 套件（8 文件） | **174 passed** |

> MUT-B / MUT-C 最初是**存活**的——当时用例只覆盖了 `kill()` 且从不填满管道。据此补了 `paneexit` 和 `full` 两例，两条变异才转红。

全量 unit 另有 `mojo-launcher-env-quarantine` / `plugin-mcp-sandbox` 共 4 例失败，**带与不带本改动逐字相同**（已做 HEAD 对照），属既有失败，非本 PR 引入。

## 影响面

只动 `TmuxPipeBackend`（tmux pipe 后端，Linux daemon 的默认运行形态）。`PtyBackend` / `TmuxBackend` / `ZmxBackend` / 远端后端（riff / mojo）均无 fifo 读端，不受影响。两个 teardown 站点已收敛为一处，不存在「只修一半」。

## 遗留（不在本 PR）

1. **存量止血**：线上那 26 个已卡死的 worker 本 PR 救不回来（它们跑的是旧代码），需要 SIGKILL 后由 daemon 冷恢复。tmux 会话 26/26 存活，上下文不丢。
2. **兜底加固**：worker 自行 exit 的路径目前没有任何 watchdog；daemon 侧也可考虑 receipt 连续超时 N 次后判定 worker 已废、强制换新，而不是无限重复报同一条错。
