### PR TITLE
fix(session-store): 恢复被孤儿 WAL 打坏的 SQLite 会话库并改为 fail-closed

### DIFF
--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync, copyFileSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { config } from '../config.js';
@@ -552,12 +552,218 @@ function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
   }
 }
 
+// ─── Orphaned import sidecar recovery ────────────────────────────────────────
+// A pre-fix import built `<db>.tmp` in WAL mode and published only the main
+// file with `renameSync`. Under Bun, `close()` skips the WAL checkpoint while a
+// prepared statement is still alive, so the schema and every row stayed in
+// `<db>.tmp-wal` while the published `.db` was a bare 4096-byte header. That
+// import path now uses DELETE mode (it cannot produce this shape any more), but
+// stores already poisoned by it stay broken forever: the import/cleanup branch
+// below is gated on `!existsSync(dbFp)` and the poisoned `.db` DOES exist, so
+// nothing ever looks at the orphans again.
+//
+// DETECTION uses the orphaned `<db>.tmp*` sidecars and nothing else. Verified
+// alternatives and why they are unusable:
+//   • `PRAGMA quick_check` / `integrity_check` return `ok` on a poisoned store
+//     (the file is structurally fine, its content simply never merged) — zero
+//     discriminating power against a legitimately empty store.
+//   • "the `sessions` table is missing" self-erases: `openDbForOwnStore` runs
+//     `CREATE TABLE IF NOT EXISTS`, so the very first open destroys the
+//     evidence. Measured going false→true across two opens while the `.tmp*`
+//     orphans persisted.
+// The orphan predicate cannot fire on a healthy store: the import builds on
+// `<db>.tmp` and only `renameSync`s it into place as the last step, under the
+// same lock, and its branch requires `.db` to be ABSENT. So ".db exists AND
+// .tmp* exists" is unreachable in a normal timeline — it is always crash
+// residue. A scan of 56 live production stores found zero `.tmp*` leftovers
+// (healthy stores carry only `-wal`/`-shm`), i.e. no false-positive surface.
+const IMPORT_TMP_SIDECAR_SUFFIXES = ['', '-journal', '-wal', '-shm'] as const;
+
+/** Every orphaned `<db>.tmp*` path a crashed pre-fix import may have left: the
+ *  temporary shell itself plus any of its journals. */
+function orphanedImportSidecars(dbFp: string): string[] {
+  return IMPORT_TMP_SIDECAR_SUFFIXES
+    .map(suffix => `${dbFp}.tmp${suffix}`)
+    .filter(path => existsSync(path));
+}
+
+/**
+ * Rows stranded in an orphaned import WAL, read WITHOUT touching the originals.
+ *
+ * ⚠️ DO NOT "recover" by renaming `<db>.tmp-wal` onto `<db>-wal` in place. A
+ * `-wal` is REPLACE semantics, not merge: once anything has opened the poisoned
+ * store, `CREATE TABLE IF NOT EXISTS` gives it a usable empty table and new
+ * sessions accumulate in the store's OWN `-wal`. Measured on Bun 1.4.0 — the
+ * in-place rename overwrites that live WAL and ALSO fails to replay (the
+ * orphan's frames describe the original bare shell, which the live writes have
+ * since moved past): a store holding 3 fresh sessions went to 0 rows and the 40
+ * stranded ones did not come back either. Net data destruction.
+ *
+ * So replay happens on a private COPY, and the caller merges the result without
+ * overwriting anything live. A damaged orphan degrades safely — truncated
+ * replays as 0 rows, garbled/zeroed/`-wal`-less shapes throw `no such table` —
+ * verified on both engines, never yielding half-parsed rows.
+ */
+function readStrandedImportRows(dbFp: string): [string, Session][] {
+  const walFp = `${dbFp}.tmp-wal`;
+  if (!existsSync(walFp)) return [];
+  const scratchFp = `${dbFp}.recover-${process.pid}-${randomUUID()}`;
+  const scratchPaths = ['', '-journal', '-wal', '-shm'].map(suffix => `${scratchFp}${suffix}`);
+  const dropScratch = (): void => {
+    for (const path of scratchPaths) {
+      try { unlinkSync(path); } catch { /* nothing to drop */ }
+    }
+  };
+  try {
+    // The published `.db` is the exact shell those WAL frames were written
+    // against, so it is the shell the replay must run on.
+    copyFileSync(dbFp, scratchFp);
+    copyFileSync(walFp, `${scratchFp}-wal`);
+    const db = openDatabaseSyncOrThrow(scratchFp);
+    try {
+      db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+      const rows = db.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
+      const entries: [string, Session][] = [];
+      for (const r of rows) {
+        try { entries.push([r.session_id, JSON.parse(r.row) as Session]); } catch { /* skip unparseable row */ }
+      }
+      return entries;
+    } finally {
+      db.close();
+    }
+  } finally {
+    dropScratch();
+  }
+}
+
+/**
+ * Repair a store poisoned by a crashed pre-fix import, in place, and report how
+ * many rows were rescued. MUST be called with the store's JSON file lock held —
+ * the same lock the import, daemon saves and offline CLI mutations use.
+ *
+ * TWO sources are merged, because neither alone is sufficient:
+ *   • the orphaned WAL — the only copy of anything written after the JSON was
+ *     frozen, and the only source at all if the JSON has since been removed;
+ *   • the frozen JSON — the import read exclusively from it, so it is a superset
+ *     of the stranded rows and the only source that survives a DAMAGED orphan.
+ * A partially-written orphan is precisely why both are needed: truncating one
+ * replays as "schema, zero rows" without any error, so trusting the orphan alone
+ * would delete it and report a healthy EMPTY store — the very silent-loss bug
+ * this function exists to end.
+ *
+ * Because of that silent shape, discarding the orphans requires POSITIVE
+ * ATTESTATION that the merge actually saw the store's contents — one of:
+ *   • the orphan replayed at least one row (the WAL demonstrably replayed), or
+ *   • a frozen snapshot was readable (its rows, or an existing-but-empty file,
+ *     attest an empty store; the import could only ever have copied from it).
+ * With no attestation at all, "zero rows" is indistinguishable from "damaged,
+ * contents unknown", so recovery fails closed and KEEPS the orphans for manual
+ * rescue instead of quietly certifying an empty store.
+ *
+ * Merge policy is `INSERT OR IGNORE`: rows that exist live always win. Both
+ * sources predate every live write by construction, so preferring live rows
+ * cannot lose newer state. Verified: 40 stranded + 3 live → 43, both kept.
+ *
+ * Orphans are removed only after the merge commits, so a crash mid-recovery
+ * leaves the store exactly as recoverable as it was before.
+ */
+function recoverPoisonedSqliteStore(dbFp: string, jsonFp: string): number {
+  let stranded: [string, Session][] = [];
+  try {
+    stranded = readStrandedImportRows(dbFp);
+  } catch (err) {
+    logger.error(`Could not replay the orphaned import WAL for ${dbFp}: ${err}`);
+  }
+
+  let frozen: [string, Session][] = [];
+  let frozenAttests = false;
+  try {
+    frozen = readJsonEntriesForImport(jsonFp);
+    // An existing snapshot file attests even when it holds no rows; a resolved
+    // legacy snapshot attests through the rows it contributed.
+    frozenAttests = frozen.length > 0 || existsSync(jsonFp);
+  } catch (err) {
+    logger.error(`Could not read the frozen JSON snapshot for ${dbFp}: ${err}`);
+  }
+
+  if (stranded.length === 0 && !frozenAttests) {
+    throw new Error(
+      `cannot recover ${dbFp}: the orphaned import WAL yielded no rows and no frozen JSON snapshot `
+      + 'could attest the store contents',
+    );
+  }
+
+  const db = openDbForOwnStore(dbFp);
+  let merged = 0;
+  try {
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      const insert = db.prepare('INSERT OR IGNORE INTO sessions (session_id, status, row) VALUES (?, ?, ?)');
+      for (const [key, value] of [...stranded, ...frozen]) {
+        const result = insert.run(key, sessionStatusText(value), JSON.stringify(value));
+        if (Number(result.changes) > 0) merged++;
+      }
+      db.exec('COMMIT');
+    } catch (err) {
+      try { db.exec('ROLLBACK'); } catch { /* txn already gone */ }
+      throw err;
+    }
+  } finally {
+    db.close();
+  }
+  // Committed: the orphans are now redundant. Removing them is what makes the
+  // store test healthy again, so it must not be skipped — but a failure here is
+  // not data loss (the next start simply re-runs an idempotent merge).
+  for (const path of orphanedImportSidecars(dbFp)) {
+    try { unlinkSync(path); } catch { /* best-effort orphan cleanup */ }
+  }
+  return merged;
+}
+
 // Sessions persisted before 2026-04-29 lack `cliId`; consumers must fall back to 'unknown' at the render boundary.
 function load(): void {
   if (loaded) return;
   ensureDir();
   const dbFp = getDbPath();
   const jsonFp = getFilePath();
+
+  // A poisoned store must never be mistaken for an empty one. Recover it before
+  // anything reads it, or fail closed so listSessionsStrict() throws instead of
+  // answering "there are no durable sessions".
+  if (existsSync(dbFp) && orphanedImportSidecars(dbFp).length > 0) {
+    if (!sqliteBootstrapAllowed) {
+      // A worker must not repair a store its still-running daemon owns. Report
+      // unavailable rather than serve the truncated view.
+      loadFailure = new Error(
+        `session store ${dbFp} has orphaned import sidecars (${orphanedImportSidecars(dbFp).join(', ')}); `
+        + 'a non-owning process may not recover it',
+      );
+      logger.error(`Refusing to load poisoned session store as a non-owner: ${loadFailure.message}`);
+      sessions = new Map();
+      loaded = true;
+      return;
+    }
+    try {
+      withFileLockSync(jsonFp, () => {
+        // Re-check under the lock: another owning process may have just fixed it.
+        if (orphanedImportSidecars(dbFp).length === 0) return;
+        const recovered = recoverPoisonedSqliteStore(dbFp, jsonFp);
+        logger.warn(
+          `Recovered ${recovered} session row(s) stranded by a crashed SQLite import into ${dbFp}; `
+          + 'removed the orphaned .tmp sidecars',
+        );
+      });
+    } catch (err) {
+      if (isTransientStoreContentionError(err)) throw err;
+      // Fail closed: the rows are still on disk, but this process cannot prove
+      // what the store holds, so it must not report an empty projection.
+      logger.error(`Failed to recover poisoned session store ${dbFp}: ${err}`);
+      loadFailure = err instanceof Error ? err : new Error(String(err));
+      sessions = new Map();
+      loaded = true;
+      return;
+    }
+  }
 
   if (!existsSync(dbFp) && sqliteBootstrapAllowed) {
     // First start on the SQLite engine: import this store's JSON rows (or

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, readdirSync, unlinkSync, copyFileSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
 import { withFileLockSync } from '../utils/file-lock.js';
@@ -65,6 +65,18 @@ type SqliteDatabaseLike = DatabaseSyncLike;
 
 const SQLITE_BUSY_TIMEOUT_MS = 3000;
 const SQLITE_NODE_VERSION_HINT = 'Node ≥ 22.13.0（23.x 需 ≥ 23.4.0）';
+
+// Recovery receipts: written in the SAME transaction as the merge, so
+// "this orphan's rows are already in the main file" becomes a durable fact
+// instead of something re-derived from a replay whose observations are
+// timing-dependent. Keyed by the orphan WAL's content digest.
+const RECOVERY_RECEIPTS_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS import_recovery_receipts (
+  orphan_digest TEXT PRIMARY KEY,
+  merged_at TEXT NOT NULL,
+  merged_rows INTEGER NOT NULL
+);
+`;
 
 const SESSIONS_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS sessions (
@@ -479,23 +491,33 @@ function parseSessionsProjectionStrict(raw: string, fp: string): Record<string, 
   return value as Record<string, Session>;
 }
 
-/** The JSON rows today's load()/migration would have produced for this store:
- *  the per-bot file's entries when it exists, else the legacy `sessions.json`
- *  rows belonging to this bot; scope repair applied, legacy card fields
- *  stripped, closed rows included. Parse failures degrade to an empty store —
- *  exactly like the previous loader. */
-function readJsonEntriesForImport(jsonFp: string): [string, Session][] {
+/** Which snapshot file a recovery/import read actually resolved. `none` means no
+ *  readable snapshot existed at all — distinct from "a readable snapshot that
+ *  legitimately holds zero rows for this bot", which IS evidence. */
+type FrozenSnapshotSource = 'per-bot' | 'legacy' | 'none';
+
+/** The JSON rows today's load()/migration would have produced for this store,
+ *  plus WHICH file they came from. The source matters to recovery: a legacy
+ *  `sessions.json` that parses fine but filters down to zero rows for this bot
+ *  proves the store held nothing, whereas a missing file proves nothing. */
+function readFrozenSnapshotForImport(jsonFp: string): {
+  entries: [string, Session][];
+  source: FrozenSnapshotSource;
+} {
   let entries: [string, Session][] = [];
+  let source: FrozenSnapshotSource = 'none';
   if (existsSync(jsonFp)) {
     const data = parseSessionsProjectionStrict(readFileSync(jsonFp, 'utf-8'), jsonFp);
     entries = Object.entries(data);
+    source = 'per-bot';
   } else if (currentAppId) {
     const legacyFp = join(config.session.dataDir, 'sessions.json');
-    if (!existsSync(legacyFp)) return [];
+    if (!existsSync(legacyFp)) return { entries: [], source: 'none' };
     const data = parseSessionsProjectionStrict(readFileSync(legacyFp, 'utf-8'), legacyFp);
     entries = Object.entries(data).filter(([, v]) => v?.larkAppId === currentAppId);
+    source = 'legacy';
   } else {
-    return [];
+    return { entries: [], source: 'none' };
   }
   for (const [, value] of entries) {
     if (value && typeof value === 'object') {
@@ -503,7 +525,16 @@ function readJsonEntriesForImport(jsonFp: string): [string, Session][] {
       stripLegacyPendingCardFields(value as unknown as Record<string, unknown>);
     }
   }
-  return entries;
+  return { entries, source };
+}
+
+/** The JSON rows today's load()/migration would have produced for this store:
+ *  the per-bot file's entries when it exists, else the legacy `sessions.json`
+ *  rows belonging to this bot; scope repair applied, legacy card fields
+ *  stripped, closed rows included. Parse failures degrade to an empty store —
+ *  exactly like the previous loader. */
+function readJsonEntriesForImport(jsonFp: string): [string, Session][] {
+  return readFrozenSnapshotForImport(jsonFp).entries;
 }
 
 /** One-shot deterministic import: build the store at `<db>.tmp`, commit, then
@@ -579,6 +610,47 @@ function importJsonStoreToSqlite(dbFp: string, jsonFp: string): number {
 // (healthy stores carry only `-wal`/`-shm`), i.e. no false-positive surface.
 const IMPORT_TMP_SIDECAR_SUFFIXES = ['', '-journal', '-wal', '-shm'] as const;
 
+/** No source could attest what a poisoned store held, so recovery refused to
+ *  touch it. Distinct class so the fail-closed path reads as a deliberate
+ *  refusal rather than an I/O accident. */
+class SessionStoreRecoveryUnattestedError extends Error {
+  override readonly name = 'SessionStoreRecoveryUnattestedError';
+}
+
+/** Content digest of an orphaned WAL, used as its recovery-receipt key. The
+ *  bytes are what identify it: a different crash produces different frames, and
+ *  a WAL we already merged keeps the same digest until it is finally removed. */
+function orphanWalDigest(walFp: string): string | undefined {
+  try {
+    return createHash('sha256').update(readFileSync(walFp)).digest('hex');
+  } catch {
+    return undefined;
+  }
+}
+
+/** Whether a previous recovery pass already committed THIS orphan's rows.
+ *
+ *  STRICTLY read-only: SELECT and nothing else. It must not create the receipts
+ *  table — a bare `CREATE TABLE IF NOT EXISTS` grows the main file (measured
+ *  12288 → 20480 bytes), and this runs BEFORE the archive is taken, so writing
+ *  here would leave the archived shell no longer paired with the WAL frames it
+ *  is meant to preserve. A missing table simply means "no proof". */
+function hasPriorReceipt(dbFp: string, walDigest: string | undefined): boolean {
+  if (!walDigest) return false;
+  try {
+    const db = openDatabaseSyncOrThrow(dbFp, { readOnly: true });
+    try {
+      return db.prepare('SELECT 1 FROM import_recovery_receipts WHERE orphan_digest = ?')
+        .get(walDigest) !== undefined;
+    } finally {
+      db.close();
+    }
+  } catch {
+    // No table yet, or an unreadable store: either way, nothing is proven.
+    return false;
+  }
+}
+
 /** Every orphaned `<db>.tmp*` path a crashed pre-fix import may have left: the
  *  temporary shell itself plus any of its journals. */
 function orphanedImportSidecars(dbFp: string): string[] {
@@ -600,21 +672,79 @@ function orphanedImportSidecars(dbFp: string): string[] {
  * stranded ones did not come back either. Net data destruction.
  *
  * So replay happens on a private COPY, and the caller merges the result without
- * overwriting anything live. A damaged orphan degrades safely — truncated
- * replays as 0 rows, garbled/zeroed/`-wal`-less shapes throw `no such table` —
- * verified on both engines, never yielding half-parsed rows.
+ * overwriting anything live. A damaged orphan never yields half-parsed rows, but
+ * it does NOT reliably announce itself either: measured shapes include throwing
+ * `no such table` (no usable shell at all), replaying zero rows (frames accepted
+ * but the transaction never committed), and — the dangerous one — quietly echoing
+ * whatever the MAIN file already holds. Damage is therefore not detectable from
+ * the returned rows; see the composite warning below.
+ *
+ * ⚠️ THE SCRATCH VIEW IS A COMPOSITE, not a picture of the WAL. It is "current
+ * main file + orphan WAL", and SQLite silently IGNORES an orphan whose header is
+ * invalid. So rows coming back prove nothing about the orphan: a store whose old
+ * code wrote new sessions and checkpointed them into the main file replays those
+ * live rows even when the orphan is entirely unreadable. Counting rows (or
+ * checking they all parse) therefore cannot answer "did the WAL replay" — it
+ * measures the wrong file.
+ *
+ * `walReplayed` answers that question with `PRAGMA wal_checkpoint(PASSIVE)`,
+ * which reports how many WAL frames the engine actually ACCEPTED. Measured on
+ * Bun 1.4.0 and Node 22.21.1 alike, against a 40-row orphan beside 3 live rows
+ * already checkpointed into the main file:
+ *
+ *   intact orphan       → `{busy:0, log:17, checkpointed:17}`, SELECT sees 40
+ *   header zeroed       → `{busy:0, log:0,  checkpointed:0}`,  SELECT sees 3 (live only)
+ *   truncated to 20 KiB → `{busy:0, log:3,  checkpointed:3}`,  SELECT sees 0
+ *
+ * `log > 0` is what rules out the dangerous blind spot — the middle row, where
+ * the WAL contributed NOTHING and the rows on screen are pure live main. It is
+ * still not a completeness proof (the third row accepted 3 frames yet lost every
+ * row), so it is paired with "the replay produced parseable rows". Anything not
+ * proven replayed is archived rather than deleted.
+ *
+ * A differential replay of the shell WITHOUT the orphan is layered on top, so a
+ * future engine that reports frames it then discards still cannot pass. That
+ * comparison uses whole rows rather than ids: a valid orphan may UPDATE a row the
+ * shell already carries, which an id-only diff would miss.
  */
-function readStrandedImportRows(dbFp: string): [string, Session][] {
+function readStrandedImportRows(dbFp: string): {
+  entries: [string, Session][];
+  walReplayed: boolean;
+} {
   const walFp = `${dbFp}.tmp-wal`;
-  if (!existsSync(walFp)) return [];
+  if (!existsSync(walFp)) return { entries: [], walReplayed: false };
   const scratchFp = `${dbFp}.recover-${process.pid}-${randomUUID()}`;
-  const scratchPaths = ['', '-journal', '-wal', '-shm'].map(suffix => `${scratchFp}${suffix}`);
+  const baseFp = `${dbFp}.recoverbase-${process.pid}-${randomUUID()}`;
+  const scratchPaths = ['', '-journal', '-wal', '-shm'].flatMap(suffix => [
+    `${scratchFp}${suffix}`,
+    `${baseFp}${suffix}`,
+  ]);
   const dropScratch = (): void => {
     for (const path of scratchPaths) {
       try { unlinkSync(path); } catch { /* nothing to drop */ }
     }
   };
+  /** session_id → row the shell exposes on its own (no orphan attached). Full
+   *  rows, not just ids: a valid orphan may UPDATE an id the shell already has,
+   *  and comparing ids alone would score that as "the WAL contributed nothing". */
+  const readBaselineRows = (): Map<string, string> => {
+    copyFileSync(dbFp, baseFp);
+    try {
+      const db = openDatabaseSyncOrThrow(baseFp);
+      try {
+        db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+        const rows = db.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
+        return new Map(rows.map(r => [r.session_id, r.row]));
+      } finally {
+        db.close();
+      }
+    } catch {
+      // A bare shell with no table is the normal baseline for a poisoned store.
+      return new Map();
+    }
+  };
   try {
+    const baselineRows = readBaselineRows();
     // The published `.db` is the exact shell those WAL frames were written
     // against, so it is the shell the replay must run on.
     copyFileSync(dbFp, scratchFp);
@@ -622,12 +752,34 @@ function readStrandedImportRows(dbFp: string): [string, Session][] {
     const db = openDatabaseSyncOrThrow(scratchFp);
     try {
       db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+      // Must run BEFORE the SELECT: it reports the frames the engine accepted
+      // from this orphan, which is the only direct evidence the WAL was used.
+      let acceptedFrames = 0;
+      try {
+        const checkpoint = db.prepare('PRAGMA wal_checkpoint(PASSIVE)').get() as { log?: number | bigint } | undefined;
+        acceptedFrames = Number(checkpoint?.log ?? 0);
+      } catch {
+        // Treat an unavailable pragma as "cannot prove the WAL replayed".
+        acceptedFrames = 0;
+      }
       const rows = db.prepare('SELECT session_id, row FROM sessions').all() as { session_id: string; row: string }[];
       const entries: [string, Session][] = [];
+      let unparseable = 0;
+      let beyondBaseline = 0;
       for (const r of rows) {
-        try { entries.push([r.session_id, JSON.parse(r.row) as Session]); } catch { /* skip unparseable row */ }
+        if (baselineRows.get(r.session_id) !== r.row) beyondBaseline++;
+        try { entries.push([r.session_id, JSON.parse(r.row) as Session]); } catch { unparseable++; }
       }
-      return entries;
+      // "The orphan demonstrably replayed": SQLite accepted frames from it AND
+      // it contributed rows the shell did not already have, with nothing corrupt.
+      //
+      // Deliberately NOT extended to "the row sets happen to match, so a previous
+      // pass must have merged it". That inference is timing-dependent — a
+      // truncated orphan beside live rows can produce an identical-looking
+      // observation while its real rows are unaccounted for — so the retry path
+      // is answered by a durable RECEIPT instead (see recoverPoisonedSqliteStore).
+      const walReplayed = acceptedFrames > 0 && unparseable === 0 && beyondBaseline > 0;
+      return { entries, walReplayed };
     } finally {
       db.close();
     }
@@ -644,33 +796,79 @@ function readStrandedImportRows(dbFp: string): [string, Session][] {
  * TWO sources are merged, because neither alone is sufficient:
  *   • the orphaned WAL — the only copy of anything written after the JSON was
  *     frozen, and the only source at all if the JSON has since been removed;
- *   • the frozen JSON — the import read exclusively from it, so it is a superset
- *     of the stranded rows and the only source that survives a DAMAGED orphan.
+ *   • the frozen JSON — the import read exclusively from it, so it is normally a
+ *     superset of the stranded rows, and the only source that survives a DAMAGED
+ *     orphan. "Normally": the file can later be trimmed or partially restored,
+ *     so it is not treated as authoritative on its own.
  * A partially-written orphan is precisely why both are needed: truncating one
  * replays as "schema, zero rows" without any error, so trusting the orphan alone
  * would delete it and report a healthy EMPTY store — the very silent-loss bug
  * this function exists to end.
  *
- * Because of that silent shape, discarding the orphans requires POSITIVE
- * ATTESTATION that the merge actually saw the store's contents — one of:
- *   • the orphan replayed at least one row (the WAL demonstrably replayed), or
- *   • a frozen snapshot was readable (its rows, or an existing-but-empty file,
- *     attest an empty store; the import could only ever have copied from it).
- * With no attestation at all, "zero rows" is indistinguishable from "damaged,
- * contents unknown", so recovery fails closed and KEEPS the orphans for manual
- * rescue instead of quietly certifying an empty store.
+ * Two independent decisions come out of that, and conflating them is what makes
+ * this subtle:
+ *
+ * 1. MAY WE PROCEED AT ALL? Only with POSITIVE ATTESTATION of what the store
+ *    held. Three things can supply it:
+ *      • the orphan demonstrably replayed rows;
+ *      • a snapshot file was actually READ — about the source, not the row
+ *        count: a legacy `sessions.json` that parses and filters down to zero
+ *        rows for this bot proves the store held nothing, while a MISSING file
+ *        proves nothing at all;
+ *      • a RECEIPT for this exact orphan digest, written by an earlier pass in
+ *        the same transaction as its merge — the only proof that survives a
+ *        crash, and the one that lets an interrupted cleanup finish.
+ *    With none of them, "zero rows" is indistinguishable from "damaged, contents
+ *    unknown", so recovery refuses and keeps the orphans for manual rescue.
+ *
+ * 2. MAY WE DESTROY THE ORPHAN? Only when its contents are accounted for. Frame
+ *    counts cannot establish that: a WAL truncated mid-transaction still gets
+ *    frames ACCEPTED (its schema prefix) while contributing no data rows at all,
+ *    because the missing commit frame means SQLite exposes none of that
+ *    transaction. Equally, "we merged something" is not proof nothing was lost —
+ *    with a trimmed snapshot beside a damaged orphan, both sources can be missing
+ *    the same session and the merge silently converges on an incomplete store.
+ *    When completeness cannot be proven, the
+ *    pair is ARCHIVED rather than deleted — `<db>.unrecovered-<ts>.db` plus its
+ *    `-wal`: the ORIGINAL bytes, kept beside the shell they belong to, for
+ *    forensics or a manual salvage attempt.
+ *
+ *    It is deliberately NOT a promise that the couple replays. Measured: a WAL
+ *    truncated mid-transaction hands back zero rows, because the missing commit
+ *    frame means SQLite exposes no partial transaction at all — the damage lost
+ *    those rows, not the archiving. What archiving guarantees is that nothing is
+ *    thrown away: whatever a human can still extract remains extractable.
+ *
+ *    Archiving, rather than leaving the file in place, is also what makes the
+ *    store usable again. The orphan path IS the poison predicate, so keeping
+ *    `<db>.tmp-wal` there would re-enter recovery on every single start and leave
+ *    every `owner:false` worker permanently fail-closed. And the shell is copied
+ *    BEFORE the merge, since the merge advances the live database — a shell
+ *    copied afterwards would no longer be the one those frames were written
+ *    against.
  *
  * Merge policy is `INSERT OR IGNORE`: rows that exist live always win. Both
  * sources predate every live write by construction, so preferring live rows
  * cannot lose newer state. Verified: 40 stranded + 3 live → 43, both kept.
  *
  * Orphans are removed only after the merge commits, so a crash mid-recovery
- * leaves the store exactly as recoverable as it was before.
+ * leaves the store exactly as recoverable as it was before. The `.tmp-wal` is
+ * deleted LAST, so a crash mid-cleanup always leaves the still-authoritative
+ * file behind rather than a stray sidecar with the evidence already gone.
  */
-function recoverPoisonedSqliteStore(dbFp: string, jsonFp: string): number {
+function recoverPoisonedSqliteStore(dbFp: string, jsonFp: string): {
+  merged: number;
+  archivedEvidence?: string;
+} {
+  const walFp = `${dbFp}.tmp-wal`;
+  const walPresent = existsSync(walFp);
+  const walDigest = walPresent ? orphanWalDigest(walFp) : undefined;
   let stranded: [string, Session][] = [];
+  let walReplayed = false;
   try {
-    stranded = readStrandedImportRows(dbFp);
+    const replay = readStrandedImportRows(dbFp);
+    stranded = replay.entries;
+    walReplayed = replay.walReplayed;
   } catch (err) {
     logger.error(`Could not replay the orphaned import WAL for ${dbFp}: ${err}`);
   }
@@ -678,19 +876,44 @@ function recoverPoisonedSqliteStore(dbFp: string, jsonFp: string): number {
   let frozen: [string, Session][] = [];
   let frozenAttests = false;
   try {
-    frozen = readJsonEntriesForImport(jsonFp);
-    // An existing snapshot file attests even when it holds no rows; a resolved
-    // legacy snapshot attests through the rows it contributed.
-    frozenAttests = frozen.length > 0 || existsSync(jsonFp);
+    const snapshot = readFrozenSnapshotForImport(jsonFp);
+    frozen = snapshot.entries;
+    // A snapshot that was actually READ attests, even when it resolves to zero
+    // rows for this bot — that is a positive statement about the store. Only
+    // `none` (no readable file anywhere) fails to attest.
+    frozenAttests = snapshot.source !== 'none';
   } catch (err) {
     logger.error(`Could not read the frozen JSON snapshot for ${dbFp}: ${err}`);
   }
 
-  if (stranded.length === 0 && !frozenAttests) {
-    throw new Error(
-      `cannot recover ${dbFp}: the orphaned import WAL yielded no rows and no frozen JSON snapshot `
-      + 'could attest the store contents',
+  // The composite view can echo rows that live only in the MAIN file, so
+  // `stranded.length` is not evidence about the orphan. Proceeding requires the
+  // orphan to have demonstrably replayed, or a snapshot to have been read.
+  const priorReceipt = hasPriorReceipt(dbFp, walDigest);
+  if (!walReplayed && !frozenAttests && !priorReceipt) {
+    throw new SessionStoreRecoveryUnattestedError(
+      `cannot recover ${dbFp}: the orphaned import WAL could not be proven to have replayed and no frozen `
+      + 'JSON snapshot could attest the store contents',
     );
+  }
+
+  // Archive BEFORE the merge: the shell must be the one those WAL frames were
+  // written against, and the merge is about to change it. A receipt (checked in
+  // the transaction below) can still spare an archive on the retry path, so this
+  // decision is revisited there rather than being final here.
+  let archivedEvidence: string | undefined;
+  if (walPresent && !walReplayed && !priorReceipt) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const archiveFp = `${dbFp}.unrecovered-${stamp}.db`;
+    try {
+      copyFileSync(dbFp, archiveFp);
+      copyFileSync(walFp, `${archiveFp}-wal`);
+      archivedEvidence = archiveFp;
+    } catch (err) {
+      // Could not preserve the couple — do NOT delete the original below.
+      logger.error(`Could not archive the unrecovered import WAL for ${dbFp}: ${err}`);
+      throw err;
+    }
   }
 
   const db = openDbForOwnStore(dbFp);
@@ -698,10 +921,19 @@ function recoverPoisonedSqliteStore(dbFp: string, jsonFp: string): number {
   try {
     db.exec('BEGIN IMMEDIATE');
     try {
+      // Inside the transaction, so the schema write cannot advance the shell
+      // before the archive above was taken.
+      db.exec(RECOVERY_RECEIPTS_SCHEMA_SQL);
       const insert = db.prepare('INSERT OR IGNORE INTO sessions (session_id, status, row) VALUES (?, ?, ?)');
       for (const [key, value] of [...stranded, ...frozen]) {
         const result = insert.run(key, sessionStatusText(value), JSON.stringify(value));
         if (Number(result.changes) > 0) merged++;
+      }
+      // Record the receipt in the SAME transaction as the rows: either both land
+      // or neither does, so a receipt can never claim a merge that did not commit.
+      if (walDigest && walReplayed) {
+        db.prepare('INSERT OR IGNORE INTO import_recovery_receipts (orphan_digest, merged_at, merged_rows) VALUES (?, ?, ?)')
+          .run(walDigest, new Date().toISOString(), merged);
       }
       db.exec('COMMIT');
     } catch (err) {
@@ -711,13 +943,45 @@ function recoverPoisonedSqliteStore(dbFp: string, jsonFp: string): number {
   } finally {
     db.close();
   }
-  // Committed: the orphans are now redundant. Removing them is what makes the
-  // store test healthy again, so it must not be skipped — but a failure here is
-  // not data loss (the next start simply re-runs an idempotent merge).
+  // Committed, and anything unproven is archived under a name the poison
+  // predicate ignores, so the originals can go.
+  //
+  // ORDER IS A CORRECTNESS PROPERTY, not tidiness. `<db>.tmp-wal` is the only
+  // sidecar that carries rows, so it is deleted LAST and only once every other
+  // sidecar is provably gone. That makes "just a lone `.tmp-shm`" unreachable —
+  // neither a successful recovery nor a crash midway through cleanup can produce
+  // it — which is what lets a lone `-shm` keep counting as a poisoned store
+  // instead of being waved through as a healthy empty one. If any earlier unlink
+  // fails, the WAL stays: the store still tests as poisoned and the next start
+  // re-runs an idempotent merge.
+  let sidecarsCleared = true;
   for (const path of orphanedImportSidecars(dbFp)) {
-    try { unlinkSync(path); } catch { /* best-effort orphan cleanup */ }
+    if (path === walFp) continue;
+    try {
+      unlinkSync(path);
+    } catch (err) {
+      sidecarsCleared = false;
+      logger.error(`Could not remove orphaned import sidecar ${path}: ${err}`);
+    }
   }
-  return merged;
+  // The WAL may go once its contents are accounted for, which happens three ways:
+  //   • this pass replayed it (its rows are now merged);
+  //   • a receipt proves an earlier pass committed them (interrupted-cleanup retry);
+  //   • it was ARCHIVED — the original bytes are preserved elsewhere, which is
+  //     the whole point of archiving. (A failed copy throws above, so reaching
+  //     here with `archivedEvidence` set means the copy succeeded.)
+  const walAccountedFor = walReplayed || priorReceipt || archivedEvidence !== undefined;
+  if (walPresent && sidecarsCleared && walAccountedFor) {
+    try { unlinkSync(walFp); } catch (err) {
+      logger.error(`Could not remove the orphaned import WAL ${walFp}: ${err}`);
+    }
+  } else if (walPresent && !archivedEvidence) {
+    // Neither replayed nor receipted, and not archived either: leave it exactly
+    // where it is. The store keeps testing as poisoned, which is the honest
+    // state — its contents are unaccounted for.
+    logger.warn(`Leaving ${walFp} in place: its rows are not accounted for.`);
+  }
+  return { merged, archivedEvidence };
 }
 
 // Sessions persisted before 2026-04-29 lack `cliId`; consumers must fall back to 'unknown' at the render boundary.
@@ -747,11 +1011,23 @@ function load(): void {
       withFileLockSync(jsonFp, () => {
         // Re-check under the lock: another owning process may have just fixed it.
         if (orphanedImportSidecars(dbFp).length === 0) return;
-        const recovered = recoverPoisonedSqliteStore(dbFp, jsonFp);
-        logger.warn(
-          `Recovered ${recovered} session row(s) stranded by a crashed SQLite import into ${dbFp}; `
-          + 'removed the orphaned .tmp sidecars',
-        );
+        const { merged, archivedEvidence } = recoverPoisonedSqliteStore(dbFp, jsonFp);
+        if (archivedEvidence) {
+          // The merge committed, but the orphan could not be proven to have
+          // replayed, so a matched shell+WAL couple was archived under a name
+          // the poison predicate ignores. Say so loudly: the store is usable,
+          // yet a human may still want to replay that couple by hand.
+          logger.warn(
+            `Recovered ${merged} session row(s) stranded by a crashed SQLite import into ${dbFp}, but the `
+            + `orphaned WAL could not be proven to have replayed — archived the matching shell+WAL couple to `
+            + `${archivedEvidence}(-wal) for manual inspection. Delete it once you are satisfied nothing is missing.`,
+          );
+        } else {
+          logger.warn(
+            `Recovered ${merged} session row(s) stranded by a crashed SQLite import into ${dbFp}; `
+            + 'removed the orphaned .tmp sidecars',
+          );
+        }
       });
     } catch (err) {
       if (isTransientStoreContentionError(err)) throw err;

--- a/test/session-store-sqlite-poisoned-recovery.test.ts
+++ b/test/session-store-sqlite-poisoned-recovery.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
+  closeSync,
   mkdtempSync,
   mkdirSync,
+  openSync,
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   truncateSync,
   writeFileSync,
+  writeSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -41,6 +45,17 @@ function pinnedBunVersion(): string {
 }
 
 const SESSION_ROWS = 40;
+/** A poisoned publish leaves the main file as a bare SQLite header. */
+const POISONED_SHELL_BYTES = 4096;
+
+/** Invalidate a WAL by zeroing its 32-byte header. SQLite then IGNORES the file
+ *  entirely (verified: `PRAGMA wal_checkpoint(PASSIVE)` reports `log:0`) while
+ *  every byte of data stays on disk — the shape that makes "the replay returned
+ *  rows" a lie about the orphan. */
+function zeroWalHeader(walPath: string): void {
+  const fd = openSync(walPath, 'r+');
+  try { writeSync(fd, Buffer.alloc(32, 0), 0, 32, 0); } finally { closeSync(fd); }
+}
 
 function frozenJsonRows(): Record<string, unknown> {
   const rows: Record<string, unknown> = {};
@@ -70,7 +85,8 @@ const POISON_FIXTURE_SOURCE = String.raw`
   const { Database } = require('bun:sqlite');
   const { mkdirSync, existsSync, renameSync, statSync } = require('node:fs');
   const { join } = require('node:path');
-  const [dataDir, appId, repoRoot] = process.argv.slice(2);
+  const [dataDir, appId, repoRoot, rowCountArg] = process.argv.slice(2);
+  const rowCount = rowCountArg === undefined || rowCountArg === '' ? ${SESSION_ROWS} : Number(rowCountArg);
 
   const probeDir = join(dataDir, '__schema_probe');
   mkdirSync(probeDir, { recursive: true });
@@ -97,7 +113,7 @@ const POISON_FIXTURE_SOURCE = String.raw`
   for (const stmt of ddl) tmp.exec(stmt);
   tmp.exec('BEGIN');
   const insert = tmp.prepare('INSERT OR REPLACE INTO sessions (session_id, status, row) VALUES (?, ?, ?)');
-  for (let i = 0; i < ${SESSION_ROWS}; i++) {
+  for (let i = 0; i < rowCount; i++) {
     insert.run('s' + i, 'active', JSON.stringify({ sessionId: 's' + i, chatId: 'oc_chat',
       rootMessageId: 'om_s' + i, title: 't' + i, status: 'active',
       createdAt: '2026-01-01T00:00:00.000Z', scope: 'topic' }));
@@ -112,6 +128,7 @@ const POISON_FIXTURE_SOURCE = String.raw`
   console.log('FIXTURE ' + JSON.stringify({
     runtime: typeof Bun === 'undefined' ? 'node' : 'bun',
     bunVersion: typeof Bun === 'undefined' ? null : Bun.version,
+    rowCount,
     db: size(dbFp),
     tmpWal: size(dbFp + '.tmp-wal'),
   }));
@@ -130,7 +147,7 @@ const POISON_FIXTURE_SOURCE = String.raw`
 const LIVE_WRITE_SOURCE = String.raw`
   const { Database } = require('bun:sqlite');
   const { join } = require('node:path');
-  const [dataDir, appId, rowsJson] = process.argv.slice(2);
+  const [dataDir, appId, rowsJson, checkpointMode] = process.argv.slice(2);
   const rows = JSON.parse(rowsJson);
   const dbFp = join(dataDir, 'session-stores', appId, 'sessions.db');
   const db = new Database(dbFp);
@@ -145,12 +162,33 @@ const LIVE_WRITE_SOURCE = String.raw`
       rootMessageId: 'om_' + row.id, title: row.title, status: 'active',
       createdAt: '2026-02-02T00:00:00.000Z', scope: 'topic' }));
   }
+  // Fold those writes into the MAIN file, so a later replay can echo them back
+  // even when the orphan WAL is unreadable. Read from the SINGLE destructuring
+  // above: a second argv read would not be substituted by the caller (which
+  // replaces the FIRST occurrence only) and would silently see the real child
+  // argv instead.
+  if (checkpointMode === 'checkpoint') db.prepare('PRAGMA wal_checkpoint(TRUNCATE)').get();
   const written = db.prepare('SELECT count(*) c FROM sessions').get().c;
   db.close();
+  // Prove the rows really are in the MAIN file (not just its -wal): reopening a
+  // copy of the main file alone must still see them. Must run AFTER close(), or
+  // the copy would be taken while this writer still holds the database.
+  const { copyFileSync, unlinkSync } = require('node:fs');
+  const mainProbe = dbFp + '.mainprobe';
+  for (const suffix of ['', '-wal', '-shm']) { try { unlinkSync(mainProbe + suffix); } catch {} }
+  copyFileSync(dbFp, mainProbe);
+  let mainOnlyRows = -1;
+  try {
+    const probe = new Database(mainProbe);
+    mainOnlyRows = probe.prepare('SELECT count(*) c FROM sessions').get().c;
+    probe.close();
+  } catch { mainOnlyRows = -1; }
+  for (const suffix of ['', '-wal', '-shm']) { try { unlinkSync(mainProbe + suffix); } catch {} }
   console.log('LIVEWRITE ' + JSON.stringify({
     runtime: typeof Bun === 'undefined' ? 'node' : 'bun',
     seenBefore,
     written,
+    mainOnlyRows,
   }));
 `;
 
@@ -173,7 +211,10 @@ const LOAD_PROBE_SOURCE = String.raw`
   console.log('PROBE ' + JSON.stringify(out));
 `;
 
-type FixtureReport = { runtime: string; bunVersion: string | null; db: number | null; tmpWal: number | null };
+type FixtureReport = {
+  runtime: string; bunVersion: string | null; rowCount: number;
+  db: number | null; tmpWal: number | null;
+};
 type ProbeReport = {
   runtime: string;
   bunVersion: string | null;
@@ -223,12 +264,12 @@ describe('recovering a session store poisoned by a crashed SQLite import', () =>
   function poison(
     dataDir: string,
     home: string,
-    opts: { liveRows?: { id: string; title: string }[] } = {},
+    opts: { liveRows?: { id: string; title: string }[]; checkpoint?: boolean; rows?: number } = {},
   ): FixtureReport {
     const env = { HOME: home, SESSION_DATA_DIR: dataDir };
     const source = POISON_FIXTURE_SOURCE.replace(
       'process.argv.slice(2)',
-      JSON.stringify([dataDir, 'appA', process.cwd()]),
+      JSON.stringify([dataDir, 'appA', process.cwd(), String(opts.rows ?? SESSION_ROWS)]),
     );
     const child = runBunChild(source, env);
     const report = parseTagged<FixtureReport>(child.stdout, child.stderr, 'FIXTURE');
@@ -247,18 +288,25 @@ describe('recovering a session store poisoned by a crashed SQLite import', () =>
       // Separate process on purpose — see LIVE_WRITE_SOURCE.
       const liveSource = LIVE_WRITE_SOURCE.replace(
         'process.argv.slice(2)',
-        JSON.stringify([dataDir, 'appA', JSON.stringify(opts.liveRows)]),
+        JSON.stringify([dataDir, 'appA', JSON.stringify(opts.liveRows), opts.checkpoint ? 'checkpoint' : '']),
       );
       const liveChild = runBunChild(liveSource, env);
       expect(liveChild.status, `live-write step failed:\n${liveChild.stderr}`).toBe(0);
-      const liveReport = parseTagged<{ runtime: string; seenBefore: number; written: number }>(
-        liveChild.stdout, liveChild.stderr, 'LIVEWRITE',
-      );
+      const liveReport = parseTagged<{
+        runtime: string; seenBefore: number; written: number; mainOnlyRows: number;
+      }>(liveChild.stdout, liveChild.stderr, 'LIVEWRITE');
       expect(liveReport.runtime).toBe('bun');
       // Proof the poisoned store really did serve an EMPTY table to the writer:
       // it saw none of the stranded rows, and afterwards holds only the fresh ones.
       expect(liveReport.seenBefore).toBe(0);
       expect(liveReport.written).toBe(opts.liveRows.length);
+      if (opts.checkpoint) {
+        // Positive proof the fixture reproduces the live-MAIN blind spot: the
+        // rows are readable from a copy of the main file with NO sidecars, so a
+        // later replay echoes them even when the orphan WAL is unreadable. If
+        // this ever stops holding, the case below silently tests nothing.
+        expect(liveReport.mainOnlyRows).toBe(opts.liveRows.length);
+      }
       // ...and the orphan still holds the real data.
       expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp')).sort())
         .toEqual(['sessions.db.tmp-shm', 'sessions.db.tmp-wal']);
@@ -391,22 +439,222 @@ describe('recovering a session store poisoned by a crashed SQLite import', () =>
     });
   });
 
-  it('re-runs an idempotent merge when a previous cleanup left a stray sidecar', () => {
+  it('treats a lone leftover .tmp-shm as still poisoned rather than a healthy empty store', () => {
     withDirs((dataDir, home) => {
+      // A lone `.tmp-shm` must stay a poison signal. It is tempting to wave it
+      // through — it carries no rows — but if a real poisoned store's WAL is
+      // deleted out from under it, ignoring the `-shm` would load an EMPTY store
+      // and call it healthy. With no snapshot to attest, that must fail closed.
+      poison(dataDir, home);
+      expect(load(dataDir, home).strict).toBe(SESSION_ROWS);
+      writeFileSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-shm'), Buffer.alloc(32_768));
+
+      const after = load(dataDir, home);
+      expect(after.strict).toBe('THREW:SessionStoreUnavailableError');
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp')).length)
+        .toBeGreaterThan(0);
+    });
+  });
+
+  it('converges on a lone leftover .tmp-shm when a snapshot can still attest', () => {
+    withDirs((dataDir, home) => {
+      // Same ambiguous shape, but here a readable snapshot says what the store
+      // held, so recovery may safely proceed, merge nothing new, and clear it.
       poison(dataDir, home);
       writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
       expect(load(dataDir, home).strict).toBe(SESSION_ROWS);
-
-      // A crash between the two unlinkSync calls leaves one orphan behind. The
-      // next start must re-detect it and converge WITHOUT losing the rows the
-      // first pass already merged (the merge is idempotent) — and must not
-      // strand the store as permanently unhealthy either.
       writeFileSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-shm'), Buffer.alloc(32_768));
 
       const after = load(dataDir, home);
       expect(after.visible).toBe(SESSION_ROWS);
       expect(after.strict).toBe(SESSION_ROWS);
       expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp'))).toEqual([]);
+    });
+  });
+
+  it('never produces a shm-only leftover when cleanup succeeds', () => {
+    withDirs((dataDir, home) => {
+      // The invariant behind the case above: a completed recovery removes the
+      // row-bearing WAL LAST, so it can never leave the ambiguous shm-only shape
+      // that would otherwise have to be treated as benign.
+      poison(dataDir, home);
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
+      expect(load(dataDir, home).strict).toBe(SESSION_ROWS);
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp'))).toEqual([]);
+    });
+  });
+
+  it('archives the orphan instead of deleting it when the WAL cannot be proven to have replayed', () => {
+    withDirs((dataDir, home) => {
+      poison(dataDir, home);
+      // Both sources degrade at once, each missing the SAME session: a truncated
+      // orphan (replays a prefix, no error) beside a snapshot that no longer has
+      // s7. The merge converges on an incomplete store, so the orphan's bytes
+      // must be preserved for forensics — under a name that does NOT re-trigger
+      // recovery, or every later start would re-recover and every worker would
+      // fail closed. Preservation is the promise; replayability is not (a WAL
+      // truncated mid-transaction yields no rows at all, before or after).
+      truncateSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-wal'), 20_000);
+      const orphanWalBytesBefore = statSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-wal')).size;
+      const trimmed = frozenJsonRows();
+      delete trimmed.s7;
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(trimmed));
+
+      const after = load(dataDir, home);
+      expect(after.strict).toBe(SESSION_ROWS - 1);
+      expect(after.ids).not.toContain('s7');
+      const names = readdirSync(join(dataDir, 'session-stores', 'appA'));
+      // Evidence kept: the ORIGINAL orphan bytes beside the shell they pair with.
+      const archiveDb = names.filter(n => /\.unrecovered-.*\.db$/.test(n));
+      expect(archiveDb).toHaveLength(1);
+      expect(names.filter(n => /\.unrecovered-.*\.db-wal$/.test(n))).toHaveLength(1);
+      // ...and "kept" only means something if the BYTES survived and the shell
+      // still matches. A truncated orphan may well replay nothing (measured: 0
+      // rows both before and after recovery — the damage, not the archiving, is
+      // what lost them), so the honest property to pin is preservation: every
+      // byte of the orphan is still there, paired with the pre-merge shell.
+      // Asserting "it replays N rows" would be asserting the damage away.
+      const archiveWalBytes = statSync(join(dataDir, 'session-stores', 'appA', `${archiveDb[0]}-wal`)).size;
+      expect(archiveWalBytes).toBe(orphanWalBytesBefore);
+      // The archived shell must be the pre-merge one: the merge adds rows to the
+      // live database, so a shell copied afterwards would no longer pair with
+      // these WAL frames. It is therefore strictly smaller than the live file.
+      const archiveShellBytes = statSync(join(dataDir, 'session-stores', 'appA', archiveDb[0])).size;
+      expect(archiveShellBytes).toBe(POISONED_SHELL_BYTES);
+      expect(statSync(join(dataDir, 'session-stores', 'appA', 'sessions.db')).size)
+        .toBeGreaterThan(archiveShellBytes);
+      // ...and the poison predicate no longer fires, so the store stays usable.
+      expect(names.filter(n => n.includes('.tmp'))).toEqual([]);
+      expect(load(dataDir, home).strict).toBe(SESSION_ROWS - 1);
+    });
+  });
+
+  it('does not mistake rows living in the main file for a replayed orphan WAL', () => {
+    withDirs((dataDir, home) => {
+      // The scratch replay is a COMPOSITE of "main file + orphan WAL", and
+      // SQLite silently ignores an orphan with an invalid header. Old code that
+      // wrote new sessions and checkpointed them into the main file therefore
+      // makes the replay return rows even when the orphan is unreadable —
+      // "we got rows" must not be read as "the WAL replayed", or the still-
+      // stranded originals get deleted as redundant.
+      poison(dataDir, home, { liveRows: [{ id: 'NEW0', title: 'live 0' }], checkpoint: true });
+      zeroWalHeader(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-wal'));
+
+      const after = load(dataDir, home);
+      // No snapshot and no provable replay ⟹ refuse, keep everything.
+      expect(after.strict).toBe('THREW:SessionStoreUnavailableError');
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp-wal')))
+        .toEqual(['sessions.db.tmp-wal']);
+    });
+  });
+
+  it('accepts a readable legacy snapshot that holds zero rows for this bot', () => {
+    withDirs((dataDir, home) => {
+      // A store whose import legitimately had NOTHING to copy: the poisoned
+      // shell carries only schema. The only snapshot is a flat legacy file whose
+      // rows all belong to a DIFFERENT app, so it filters down to zero rows here
+      // — yet it was READ, which positively attests this bot held nothing.
+      // Judging attestation by row count instead of by "which source resolved"
+      // would wrongly report the store unavailable forever.
+      const report = poison(dataDir, home, { rows: 0 });
+      expect(report.rowCount).toBe(0);
+      writeFileSync(join(dataDir, 'sessions.json'), JSON.stringify({
+        OTHERBOT: {
+          sessionId: 'OTHERBOT', larkAppId: 'appZ', chatId: 'oc_other', rootMessageId: 'om_other',
+          title: 'someone else', status: 'active', createdAt: '2026-01-01T00:00:00.000Z', scope: 'topic',
+        },
+      }));
+
+      const after = load(dataDir, home);
+      expect(after.strict).toBe(0);
+      expect(after.ids).toEqual([]);
+      // ...and the poison signal is cleared, so this does not re-recover forever.
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp'))).toEqual([]);
+    });
+  });
+
+  it('keeps the row-bearing WAL when an earlier sidecar cannot be removed', () => {
+    withDirs((dataDir, home) => {
+      // Cleanup order is the invariant that makes "lone .tmp-shm" unreachable as
+      // benign residue. Force the FIRST unlink to fail (a directory cannot be
+      // unlinked, even by root) and the row-bearing WAL must survive: the store
+      // still tests as poisoned and the next start retries, instead of decaying
+      // into the ambiguous shm-only shape with the evidence already gone.
+      poison(dataDir, home);
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
+      const storeDir = join(dataDir, 'session-stores', 'appA');
+      rmSync(join(storeDir, 'sessions.db.tmp-shm'), { force: true });
+      mkdirSync(join(storeDir, 'sessions.db.tmp-shm'), { recursive: true });
+
+      const after = load(dataDir, home);
+      // The merge itself still commits — the rows are rescued either way.
+      expect(after.strict).toBe(SESSION_ROWS);
+      // ...but the WAL is deliberately NOT deleted while a sibling remains.
+      expect(readdirSync(storeDir)).toContain('sessions.db.tmp-wal');
+    });
+  });
+
+  it('finishes an interrupted cleanup on the next start with no snapshot to lean on', () => {
+    withDirs((dataDir, home) => {
+      // The retry path, with every crutch removed: NO snapshot at all, so the
+      // only thing that can authorise finishing the job is a durable record that
+      // the previous pass already merged this orphan's rows.
+      //
+      // Deriving that from a replay observation is not sound — a truncated orphan
+      // beside live rows can look identical to "already merged" — so the merge
+      // writes a RECEIPT keyed by the orphan's content digest, in the same
+      // transaction as the rows. Without it this store would fail closed forever
+      // even though its 40 rows are safely in the main file.
+      poison(dataDir, home);
+      const storeDir = join(dataDir, 'session-stores', 'appA');
+      // Block the first cleanup: a directory cannot be unlinked, even by root.
+      rmSync(join(storeDir, 'sessions.db.tmp-shm'), { force: true });
+      mkdirSync(join(storeDir, 'sessions.db.tmp-shm'), { recursive: true });
+
+      expect(load(dataDir, home).strict).toBe(SESSION_ROWS);
+      // Cleanup was interrupted, so the row-bearing WAL is still there.
+      expect(readdirSync(storeDir)).toContain('sessions.db.tmp-wal');
+
+      // Unblock and restart: this must converge, not refuse.
+      rmSync(join(storeDir, 'sessions.db.tmp-shm'), { recursive: true, force: true });
+      const retry = load(dataDir, home);
+      expect(retry.visible).toBe(SESSION_ROWS);
+      expect(retry.strict).toBe(SESSION_ROWS);
+      expect(readdirSync(storeDir).filter(n => n.includes('.tmp'))).toEqual([]);
+      // No evidence needed archiving: the rows were accounted for, not lost.
+      expect(readdirSync(storeDir).filter(n => n.includes('unrecovered'))).toEqual([]);
+      // ...and it stays converged.
+      expect(load(dataDir, home).strict).toBe(SESSION_ROWS);
+    });
+  });
+
+  it('keeps the receipt usable across repeated interrupted cleanups', () => {
+    withDirs((dataDir, home) => {
+      // Interrupt cleanup TWICE with no snapshot anywhere. Each restart must
+      // still find the receipt written by the first successful merge, so the
+      // store converges instead of refusing. Reading that receipt must also not
+      // write to the store — a `CREATE TABLE` on the read path would grow the
+      // main file (measured 12288 → 20480 bytes) before the archive is taken,
+      // leaving any archived shell no longer paired with its WAL frames.
+      poison(dataDir, home);
+      const storeDir = join(dataDir, 'session-stores', 'appA');
+      const blocker = join(storeDir, 'sessions.db.tmp-shm');
+      rmSync(blocker, { force: true });
+      mkdirSync(blocker, { recursive: true });
+      expect(load(dataDir, home).strict).toBe(SESSION_ROWS);
+      expect(readdirSync(storeDir)).toContain('sessions.db.tmp-wal');
+
+      // Second start, still blocked: must not lose rows and must not archive.
+      const blocked = load(dataDir, home);
+      expect(blocked.strict).toBe(SESSION_ROWS);
+      expect(readdirSync(storeDir).filter(n => n.includes('unrecovered'))).toEqual([]);
+
+      // Unblock: converges, nothing archived, nothing lost.
+      rmSync(blocker, { recursive: true, force: true });
+      const done = load(dataDir, home);
+      expect(done.strict).toBe(SESSION_ROWS);
+      expect(readdirSync(storeDir).filter(n => n.includes('.tmp'))).toEqual([]);
+      expect(readdirSync(storeDir).filter(n => n.includes('unrecovered'))).toEqual([]);
     });
   });
 
@@ -423,6 +671,25 @@ describe('recovering a session store poisoned by a crashed SQLite import', () =>
       // The orphans stay on disk so the rows remain manually rescuable.
       expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp')).length)
         .toBeGreaterThan(0);
+    });
+  });
+
+  it('refuses when a partly-accepted orphan sits beside rows already in the main file', () => {
+    withDirs((dataDir, home) => {
+      // The shape that tempts a shortcut: SQLite accepts some frames from the
+      // orphan (so "was the WAL looked at?" says yes) while the rows on screen
+      // come from the main file. It is NOT evidence that a previous pass merged
+      // this orphan — only a receipt is — so this must refuse and keep the file.
+      //
+      // Truncated at 20 KiB, not header-zeroed: that keeps `acceptedFrames > 0`,
+      // which is precisely what distinguishes this from the header-zero case and
+      // stops a single relaxed condition from passing both.
+      poison(dataDir, home, { liveRows: [{ id: 'NEW0', title: 'live 0' }], checkpoint: true });
+      truncateSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-wal'), 20_480);
+
+      const after = load(dataDir, home);
+      expect(after.strict).toBe('THREW:SessionStoreUnavailableError');
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA'))).toContain('sessions.db.tmp-wal');
     });
   });
 

--- a/test/session-store-sqlite-poisoned-recovery.test.ts
+++ b/test/session-store-sqlite-poisoned-recovery.test.ts
@@ -366,6 +366,50 @@ describe('recovering a session store poisoned by a crashed SQLite import', () =>
     });
   });
 
+  it('rescues rows from the LEGACY snapshot without pulling in another bot rows', () => {
+    withDirs((dataDir, home) => {
+      poison(dataDir, home);
+      // Damage the orphan so only a snapshot can rescue, and provide ONLY the
+      // legacy flat `sessions.json` (no per-bot file). Recovery must resolve it
+      // the same way the import does — filtered by larkAppId, so a sibling
+      // bot's rows can never leak into this store.
+      truncateSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-wal'), 20_000);
+      const legacy: Record<string, unknown> = {};
+      for (const [id, row] of Object.entries(frozenJsonRows())) {
+        legacy[id] = { ...(row as Record<string, unknown>), larkAppId: 'appA' };
+      }
+      legacy.OTHERBOT = {
+        sessionId: 'OTHERBOT', larkAppId: 'appZ', chatId: 'oc_other', rootMessageId: 'om_other',
+        title: 'someone else', status: 'active', createdAt: '2026-01-01T00:00:00.000Z', scope: 'topic',
+      };
+      writeFileSync(join(dataDir, 'sessions.json'), JSON.stringify(legacy));
+
+      const after = load(dataDir, home);
+      expect(after.visible).toBe(SESSION_ROWS);
+      expect(after.strict).toBe(SESSION_ROWS);
+      expect(after.ids).not.toContain('OTHERBOT');
+    });
+  });
+
+  it('re-runs an idempotent merge when a previous cleanup left a stray sidecar', () => {
+    withDirs((dataDir, home) => {
+      poison(dataDir, home);
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
+      expect(load(dataDir, home).strict).toBe(SESSION_ROWS);
+
+      // A crash between the two unlinkSync calls leaves one orphan behind. The
+      // next start must re-detect it and converge WITHOUT losing the rows the
+      // first pass already merged (the merge is idempotent) — and must not
+      // strand the store as permanently unhealthy either.
+      writeFileSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-shm'), Buffer.alloc(32_768));
+
+      const after = load(dataDir, home);
+      expect(after.visible).toBe(SESSION_ROWS);
+      expect(after.strict).toBe(SESSION_ROWS);
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp'))).toEqual([]);
+    });
+  });
+
   it('fails closed when a damaged orphan leaves the contents unattested', () => {
     withDirs((dataDir, home) => {
       poison(dataDir, home);

--- a/test/session-store-sqlite-poisoned-recovery.test.ts
+++ b/test/session-store-sqlite-poisoned-recovery.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSyncBunTsEvalWithRepoImports } from './helpers/ts-runner.js';
+
+/**
+ * Recovery of a session store POISONED by the pre-fix WAL import (see
+ * session-store-sqlite-bun-import.test.ts for the bug that produced them).
+ *
+ * WHY THESE RUN UNDER A REAL BUN CHILD. The poisoned shape only exists on Bun:
+ * `db.close()` there skips the WAL checkpoint while a prepared statement is
+ * still alive, so the rows stay in `<db>.tmp-wal` and `renameSync` publishes a
+ * bare 4096-byte header. vitest's test body ALWAYS executes under Node (even
+ * via `bun x vitest`), where all four close shapes checkpoint correctly — so an
+ * in-process assertion here would be structurally incapable of reproducing the
+ * fixture, and would pass against a completely broken implementation. Every
+ * case below therefore builds the fixture and exercises production `load()`
+ * inside a spawned Bun process that reports its own runtime back.
+ *
+ * The fixture kills itself with SIGKILL on purpose: Bun settles the WAL along
+ * still-open fds at clean exit, which would repair the store before the test
+ * could observe it.
+ */
+
+function pinnedBunVersion(): string {
+  const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as {
+    packageManager?: string;
+  };
+  const match = /^bun@(.+)$/.exec(pkg.packageManager ?? '');
+  if (!match) throw new Error(`packageManager is not pinned to Bun: ${pkg.packageManager}`);
+  return match[1];
+}
+
+const SESSION_ROWS = 40;
+
+function frozenJsonRows(): Record<string, unknown> {
+  const rows: Record<string, unknown> = {};
+  for (let i = 0; i < SESSION_ROWS; i++) {
+    rows[`s${i}`] = {
+      sessionId: `s${i}`,
+      chatId: 'oc_chat',
+      rootMessageId: `om_s${i}`,
+      title: `t${i}`,
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      scope: 'topic',
+    };
+  }
+  return rows;
+}
+
+/**
+ * Reproduce the poisoned store the way the pre-fix import produced it: build
+ * `<db>.tmp` in WAL mode, close WITHOUT finalizing the insert statement, publish
+ * with `renameSync`, then SIGKILL before Bun can settle the WAL.
+ *
+ * The schema is harvested from a store PRODUCTION code just created, so this
+ * fixture cannot drift away from SESSIONS_SCHEMA_SQL.
+ */
+const POISON_FIXTURE_SOURCE = String.raw`
+  const { Database } = require('bun:sqlite');
+  const { mkdirSync, existsSync, renameSync, statSync } = require('node:fs');
+  const { join } = require('node:path');
+  const [dataDir, appId, repoRoot] = process.argv.slice(2);
+
+  const probeDir = join(dataDir, '__schema_probe');
+  mkdirSync(probeDir, { recursive: true });
+  process.env.SESSION_DATA_DIR = probeDir;
+  const store = await import(join(repoRoot, 'src', 'services', 'session-store.ts'));
+  store.init('probe');
+  store.listSessions();
+  const probeDb = join(probeDir, 'session-stores', 'probe', 'sessions.db');
+  const probe = new Database(probeDb, { readonly: true });
+  const ddl = probe.prepare("SELECT sql FROM sqlite_master WHERE sql IS NOT NULL").all().map(r => r.sql + ';');
+  probe.close();
+  if (!ddl.some(s => /CREATE TABLE\s+sessions/i.test(s))) {
+    throw new Error('failed to harvest the production sessions schema: ' + JSON.stringify(ddl));
+  }
+
+  const storeDir = join(dataDir, 'session-stores', appId);
+  mkdirSync(storeDir, { recursive: true });
+  const dbFp = join(storeDir, 'sessions.db');
+  const tmpFp = dbFp + '.tmp';
+  const tmp = new Database(tmpFp);
+  tmp.exec('PRAGMA busy_timeout = 3000;');
+  tmp.exec('PRAGMA journal_mode = WAL;');
+  tmp.exec('PRAGMA synchronous = NORMAL;');
+  for (const stmt of ddl) tmp.exec(stmt);
+  tmp.exec('BEGIN');
+  const insert = tmp.prepare('INSERT OR REPLACE INTO sessions (session_id, status, row) VALUES (?, ?, ?)');
+  for (let i = 0; i < ${SESSION_ROWS}; i++) {
+    insert.run('s' + i, 'active', JSON.stringify({ sessionId: 's' + i, chatId: 'oc_chat',
+      rootMessageId: 'om_s' + i, title: 't' + i, status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z', scope: 'topic' }));
+  }
+  tmp.exec('COMMIT');
+  // Deliberately NOT insert.finalize(): that live statement is what makes Bun
+  // skip the checkpoint, stranding every row in <db>.tmp-wal.
+  tmp.close();
+  renameSync(tmpFp, dbFp);
+
+  const size = (p) => existsSync(p) ? statSync(p).size : null;
+  console.log('FIXTURE ' + JSON.stringify({
+    runtime: typeof Bun === 'undefined' ? 'node' : 'bun',
+    bunVersion: typeof Bun === 'undefined' ? null : Bun.version,
+    db: size(dbFp),
+    tmpWal: size(dbFp + '.tmp-wal'),
+  }));
+  process.kill(process.pid, 'SIGKILL');
+`;
+
+/**
+ * What the OLD code did on every start after the poisoning: open the poisoned
+ * store — `CREATE TABLE IF NOT EXISTS` hands it a usable EMPTY table — and write
+ * brand-new sessions into the store's own `-wal`.
+ *
+ * This must run in a SEPARATE process from the poisoning: the publishing process
+ * still holds fds on the pre-rename inode, and reopening the same path there
+ * fails with `disk I/O error` instead of reproducing the real timeline.
+ */
+const LIVE_WRITE_SOURCE = String.raw`
+  const { Database } = require('bun:sqlite');
+  const { join } = require('node:path');
+  const [dataDir, appId, rowsJson] = process.argv.slice(2);
+  const rows = JSON.parse(rowsJson);
+  const dbFp = join(dataDir, 'session-stores', appId, 'sessions.db');
+  const db = new Database(dbFp);
+  db.exec('PRAGMA busy_timeout = 3000;');
+  db.exec('PRAGMA journal_mode = WAL;');
+  db.exec('PRAGMA synchronous = NORMAL;');
+  db.exec("CREATE TABLE IF NOT EXISTS sessions (session_id TEXT PRIMARY KEY, status TEXT NOT NULL, row TEXT NOT NULL, chat_id TEXT GENERATED ALWAYS AS (json_extract(row, '$.chatId')) VIRTUAL, root_message_id TEXT GENERATED ALWAYS AS (json_extract(row, '$.rootMessageId')) VIRTUAL, scope TEXT GENERATED ALWAYS AS (json_extract(row, '$.scope')) VIRTUAL);");
+  const seenBefore = db.prepare('SELECT count(*) c FROM sessions').get().c;
+  const ins = db.prepare('INSERT OR REPLACE INTO sessions (session_id, status, row) VALUES (?, ?, ?)');
+  for (const row of rows) {
+    ins.run(row.id, 'active', JSON.stringify({ sessionId: row.id, chatId: 'oc_chat',
+      rootMessageId: 'om_' + row.id, title: row.title, status: 'active',
+      createdAt: '2026-02-02T00:00:00.000Z', scope: 'topic' }));
+  }
+  const written = db.prepare('SELECT count(*) c FROM sessions').get().c;
+  db.close();
+  console.log('LIVEWRITE ' + JSON.stringify({
+    runtime: typeof Bun === 'undefined' ? 'node' : 'bun',
+    seenBefore,
+    written,
+  }));
+`;
+
+/** Load the store through production code and report what it exposes. */
+const LOAD_PROBE_SOURCE = String.raw`
+  const { join } = require('node:path');
+  const [repoRoot, appId, ownerMode] = process.argv.slice(2);
+  const store = await import(join(repoRoot, 'src', 'services', 'session-store.ts'));
+  const out = {
+    runtime: typeof Bun === 'undefined' ? 'node' : 'bun',
+    bunVersion: typeof Bun === 'undefined' ? null : Bun.version,
+  };
+  store.init(appId, ownerMode === 'worker' ? { owner: false } : {});
+  try { out.visible = store.listSessions().length; }
+  catch (err) { out.visible = 'THREW:' + err.name; }
+  try { out.strict = store.listSessionsStrict().length; }
+  catch (err) { out.strict = 'THREW:' + err.name; }
+  out.ids = store.listSessions().map(s => s.sessionId).sort();
+  out.titles = Object.fromEntries(store.listSessions().map(s => [s.sessionId, s.title]));
+  console.log('PROBE ' + JSON.stringify(out));
+`;
+
+type FixtureReport = { runtime: string; bunVersion: string | null; db: number | null; tmpWal: number | null };
+type ProbeReport = {
+  runtime: string;
+  bunVersion: string | null;
+  visible: number | string;
+  strict: number | string;
+  ids: string[];
+  titles: Record<string, string>;
+};
+
+function runBunChild(source: string, env: Record<string, string>): {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+} {
+  const child = spawnSyncBunTsEvalWithRepoImports(source, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  if (child.error) throw child.error;
+  return {
+    stdout: String(child.stdout ?? ''),
+    stderr: String(child.stderr ?? ''),
+    status: child.status,
+  };
+}
+
+function parseTagged<T>(stdout: string, stderr: string, tag: string): T {
+  const line = stdout.split('\n').findLast(l => l.trim().startsWith(`${tag} `));
+  expect(line, `Bun child produced no ${tag} line.\nstdout:\n${stdout}\nstderr:\n${stderr}`).toBeTruthy();
+  return JSON.parse(line!.slice(line!.indexOf('{'))) as T;
+}
+
+describe('recovering a session store poisoned by a crashed SQLite import', () => {
+  function withDirs(fn: (dataDir: string, home: string) => void): void {
+    const dataDir = mkdtempSync(join(tmpdir(), 'sqlite-poison-'));
+    const home = mkdtempSync(join(tmpdir(), 'sqlite-poison-home-'));
+    try {
+      fn(dataDir, home);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  /** Build the poisoned fixture and assert it really is the broken shape. */
+  function poison(
+    dataDir: string,
+    home: string,
+    opts: { liveRows?: { id: string; title: string }[] } = {},
+  ): FixtureReport {
+    const env = { HOME: home, SESSION_DATA_DIR: dataDir };
+    const source = POISON_FIXTURE_SOURCE.replace(
+      'process.argv.slice(2)',
+      JSON.stringify([dataDir, 'appA', process.cwd()]),
+    );
+    const child = runBunChild(source, env);
+    const report = parseTagged<FixtureReport>(child.stdout, child.stderr, 'FIXTURE');
+    // The fixture must have run under Bun on the pinned version, or it proves
+    // nothing about the Bun-only defect.
+    expect(report.runtime).toBe('bun');
+    expect(report.bunVersion).toBe(pinnedBunVersion());
+    // Positive proof the fixture is the poisoned shape and not a healthy store:
+    // a bare header plus an orphaned WAL holding everything.
+    expect(report.db).toBe(4096);
+    expect(report.tmpWal).toBeGreaterThan(4096);
+    expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp')).sort())
+      .toEqual(['sessions.db.tmp-shm', 'sessions.db.tmp-wal']);
+
+    if (opts.liveRows?.length) {
+      // Separate process on purpose — see LIVE_WRITE_SOURCE.
+      const liveSource = LIVE_WRITE_SOURCE.replace(
+        'process.argv.slice(2)',
+        JSON.stringify([dataDir, 'appA', JSON.stringify(opts.liveRows)]),
+      );
+      const liveChild = runBunChild(liveSource, env);
+      expect(liveChild.status, `live-write step failed:\n${liveChild.stderr}`).toBe(0);
+      const liveReport = parseTagged<{ runtime: string; seenBefore: number; written: number }>(
+        liveChild.stdout, liveChild.stderr, 'LIVEWRITE',
+      );
+      expect(liveReport.runtime).toBe('bun');
+      // Proof the poisoned store really did serve an EMPTY table to the writer:
+      // it saw none of the stranded rows, and afterwards holds only the fresh ones.
+      expect(liveReport.seenBefore).toBe(0);
+      expect(liveReport.written).toBe(opts.liveRows.length);
+      // ...and the orphan still holds the real data.
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp')).sort())
+        .toEqual(['sessions.db.tmp-shm', 'sessions.db.tmp-wal']);
+    }
+    return report;
+  }
+
+  function load(dataDir: string, home: string, ownerMode: 'owner' | 'worker' = 'owner'): ProbeReport {
+    const source = LOAD_PROBE_SOURCE.replace(
+      'process.argv.slice(2)',
+      JSON.stringify([process.cwd(), 'appA', ownerMode]),
+    );
+    const child = runBunChild(source, { HOME: home, SESSION_DATA_DIR: dataDir });
+    expect(child.status, `probe failed:\n${child.stderr}`).toBe(0);
+    const report = parseTagged<ProbeReport>(child.stdout, child.stderr, 'PROBE');
+    expect(report.runtime).toBe('bun');
+    expect(report.bunVersion).toBe(pinnedBunVersion());
+    return report;
+  }
+
+  it('rescues the stranded rows instead of reporting a healthy empty store', () => {
+    withDirs((dataDir, home) => {
+      poison(dataDir, home);
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
+
+      const after = load(dataDir, home);
+      // Before the fix this store loaded 0 rows and listSessionsStrict() did
+      // NOT throw — a silent, self-certifying total loss of every session.
+      expect(after.visible).toBe(SESSION_ROWS);
+      expect(after.strict).toBe(SESSION_ROWS);
+      // The orphans are consumed, so the store stops testing as poisoned.
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp'))).toEqual([]);
+
+      // Recovery is idempotent: a second start neither loses nor duplicates.
+      const again = load(dataDir, home);
+      expect(again.visible).toBe(SESSION_ROWS);
+      expect(again.strict).toBe(SESSION_ROWS);
+    });
+  });
+
+  it('keeps rows written into the poisoned store while rescuing the stranded ones', () => {
+    withDirs((dataDir, home) => {
+      // The realistic production state: old code opened the poisoned store on
+      // every start and accumulated brand-new sessions in its own -wal. One of
+      // them deliberately REUSES a stranded session id with different content,
+      // which is the only shape that can tell the merge policy apart.
+      poison(dataDir, home, {
+        liveRows: [
+          { id: 'NEW0', title: 'live 0' },
+          { id: 'NEW1', title: 'live 1' },
+          { id: 's0', title: 'live edit of a stranded id' },
+        ],
+      });
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
+
+      const after = load(dataDir, home);
+      // Renaming <db>.tmp-wal onto <db>-wal (the "let SQLite self-heal"
+      // approach) is REPLACE, not merge: measured, it drops the live rows AND
+      // fails to replay the stranded ones. Both sets must survive.
+      expect(after.visible).toBe(SESSION_ROWS + 2);
+      expect(after.strict).toBe(SESSION_ROWS + 2);
+      expect(after.ids.filter(id => id.startsWith('NEW'))).toEqual(['NEW0', 'NEW1']);
+      expect(after.ids.filter(id => /^s\d+$/.test(id))).toHaveLength(SESSION_ROWS);
+      // The live row wins on a colliding id: recovery may only ADD what was
+      // stranded, never overwrite state written after the poisoning.
+      expect(after.titles.s0).toBe('live edit of a stranded id');
+      // ...while a non-colliding stranded row is restored from the orphan.
+      expect(after.titles.s1).toBe('t1');
+    });
+  });
+
+  it('rescues the rows from the frozen snapshot when the orphan is damaged', () => {
+    withDirs((dataDir, home) => {
+      poison(dataDir, home);
+      // The orphan replays as "schema, zero rows" with NO error — so if the
+      // frozen snapshot were not also merged, recovery would delete the orphan
+      // and certify an empty store.
+      truncateSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-wal'), 20_000);
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
+
+      const after = load(dataDir, home);
+      expect(after.visible).toBe(SESSION_ROWS);
+      expect(after.strict).toBe(SESSION_ROWS);
+      expect(after.titles.s0).toBe('t0');
+    });
+  });
+
+  it('rescues rows the orphan holds but the frozen snapshot never had', () => {
+    withDirs((dataDir, home) => {
+      poison(dataDir, home);
+      // The frozen snapshot is NOT always a superset in practice: the import
+      // reads it, but the file can later be edited, trimmed, or partially
+      // restored from a backup. Here it is missing one session the orphan
+      // holds, so only the orphan can supply it — the case that proves the
+      // orphaned WAL is actually being replayed rather than ignored.
+      const trimmed = frozenJsonRows();
+      delete trimmed.s7;
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(trimmed));
+
+      const after = load(dataDir, home);
+      expect(after.visible).toBe(SESSION_ROWS);
+      expect(after.strict).toBe(SESSION_ROWS);
+      expect(after.ids).toContain('s7');
+      expect(after.titles.s7).toBe('t7');
+    });
+  });
+
+  it('fails closed when a damaged orphan leaves the contents unattested', () => {
+    withDirs((dataDir, home) => {
+      poison(dataDir, home);
+      // A truncated orphan replays as "schema, zero rows" WITHOUT an error, and
+      // no frozen snapshot exists to attest the store — indistinguishable from
+      // a legitimately empty store, so it must not be certified as one.
+      truncateSync(join(dataDir, 'session-stores', 'appA', 'sessions.db.tmp-wal'), 20_000);
+
+      const after = load(dataDir, home);
+      expect(after.strict).toBe('THREW:SessionStoreUnavailableError');
+      // The orphans stay on disk so the rows remain manually rescuable.
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp')).length)
+        .toBeGreaterThan(0);
+    });
+  });
+
+  it('refuses to recover a poisoned store from a non-owning process', () => {
+    withDirs((dataDir, home) => {
+      poison(dataDir, home);
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
+
+      // A worker must not repair a store its still-running daemon owns; it also
+      // must not serve the truncated view as if it were the whole store.
+      const worker = load(dataDir, home, 'worker');
+      expect(worker.strict).toBe('THREW:SessionStoreUnavailableError');
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp')).length)
+        .toBeGreaterThan(0);
+
+      // The owning daemon still repairs it afterwards.
+      const owner = load(dataDir, home, 'owner');
+      expect(owner.strict).toBe(SESSION_ROWS);
+    });
+  });
+
+  it('leaves a healthy store untouched', () => {
+    withDirs((dataDir, home) => {
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, 'sessions-appA.json'), JSON.stringify(frozenJsonRows()));
+
+      // Normal first start: imports, and no recovery path may interfere.
+      const first = load(dataDir, home);
+      expect(first.visible).toBe(SESSION_ROWS);
+      expect(first.strict).toBe(SESSION_ROWS);
+      const second = load(dataDir, home);
+      expect(second.strict).toBe(SESSION_ROWS);
+      expect(readdirSync(join(dataDir, 'session-stores', 'appA')).filter(n => n.includes('.tmp'))).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## 问题

PR #1073 修好了**产生**这类坏库的根因（临时库 `journal_mode` 由 WAL 改 DELETE），但它**只阻止新坏库产生，不修已经坏掉的库**。

一个已被打坏的 store 形如：

```
sessions.db          4096 字节（纯文件头，空壳）
sessions.db.tmp-wal  70072 字节（schema + 全部数据都在这）
sessions.db.tmp-shm  32768 字节
```

当前代码对它的行为（实测复现）：

- `listSessions()` 返回 **0**
- **`listSessionsStrict()` 不抛** ⟹ 该 store 被判定为 **HEALTHY**
- 旁边冻结的 `sessions-<appId>.json` 数据完好，但**不会被回读**
- 孤儿 sidecar 不会被清理

即：**静默丢掉全部会话，而且系统认为一切正常** —— 与 `listSessionsStrict()` 自己的文档承诺（「决定删除/退休/重配资源的门不该看到 legacy empty-on-error 行为」）相悖。

两个成因叠加：① 导入与 pre-import 清理都在 `load()` 的 `if (!existsSync(dbFp) && sqliteBootstrapAllowed)` 之内，而坏库的 `.db` **是存在的**，整个分支被跳过；② `loadFailure` 只在「打不开/查不动」时设置，坏库能 open、`journal_mode` 能过、`SELECT` 也能过（表是空的），于是 strict 门不触发。

## 改动

### 检测：只用孤儿 sidecar 判据

判据是「`.db` 存在 **且** `<dbFp>.tmp*` 孤儿存在」。另两个候选实测不可用（已写进代码注释）：

| 判据 | 打坏的库 | 合法空库 | 结论 |
|---|---|---|---|
| `PRAGMA quick_check` / `integrity_check` | `ok` | `ok` | ❌ 零区分力（文件结构没坏，只是内容没并进来） |
| 存在 `<dbFp>.tmp*` 孤儿 | 有 | 无 | ✅ 持久判据 → 用这个 |
| `sessions` 表是否存在 | false→**true** | true | ⚠️ 被 `CREATE TABLE IF NOT EXISTS` 自掩蔽，损坏后首次打开即销毁证据 |

不会误伤：导入在 `<dbFp>.tmp` 上构建、只在最后一步 `renameSync` 让 `.db` 落位，而该分支的门是 `!existsSync(dbFp)` ⟹「`.db` 存在且 `.tmp*` 存在」在正常时序下不可达。生产 56 个 live store 扫过 **0 个**有 `.tmp*` 残留。

### 恢复：scratch 副本重放 + 合并（**不就地改名**）

⚠️ **「把 `.tmp-wal` 改名成 `-wal` 让 SQLite 自愈」这条路实测会毁数据，没有采用。** `-wal` 是**替换**而非合并语义：库被打坏后旧代码照样能开（`CREATE TABLE IF NOT EXISTS` 给它一张空表）并把新会话写进**自己的** `-wal`；就地改名会覆盖掉那个活 WAL，而孤儿帧描述的是**原始空壳**、与被写过的库对不上：

| 场景 | 就地改名 | 本 PR |
|---|---|---|
| 纯空壳（从未被写过） | 40 行恢复 | 40 行恢复 |
| **已被旧代码写入 3 条新会话** | **3 → 0，40 也没回来（净毁数据）** | **43 行（40 救回 + 3 保住）** |

实现上把 `.db` 与 `.tmp-wal` **复制**到 scratch 让 SQLite 在副本上重放，再把搁浅行 `INSERT OR IGNORE` 合并进活库（**活行永远赢**），全程只读原孤儿文件。

### 两个独立决策：能否动手 / 能否毁掉证据

这两件事必须分开判，混在一起正是缺陷的来源。

**① 能否动手** —— 需要**正向作证**这个 store 当时装了什么，三者之一：
- 孤儿确有重放出行；
- **快照被读到** —— 看的是「解析了哪个来源」，不是行数：legacy `sessions.json` 解析成功但按 `larkAppId` 过滤后本 bot 为 0 行，这**证明**该 bot 当时确实没有会话；而文件根本不存在则什么都没证明；
- 该孤儿 digest 的 **receipt**（见下）。

三者皆无时「0 行」与「已损坏、内容未知」无法区分，于是 fail-closed 并**保留孤儿**供人工抢救。

**② 能否毁掉孤儿** —— 需要证明它的内容已被交代清楚：
- `PRAGMA wal_checkpoint(PASSIVE)` 的 `log`（引擎**真正接受**的帧数；Bun 1.4.0 与 Node 22.21.1 实测一致：完整孤儿 `log=17`、header 清零 `log=0`、截断 20KiB `log=3`）；
- 与「同一 shell **不挂** WAL」做**整行差分**（不只比 id：合法孤儿可能原地更新已有 id）；
- 全部行可解析。

⚠️ **帧被接受 ≠ 有数据行**：单事务缺 commit 帧时 SQLite 接受 schema 帧却**一行都不给**（实测 `log=3, SELECT=0`）。⚠️ **scratch 是「当前主库 + 孤儿 WAL」的合成视图**，而 SQLite 会**静默忽略** header 损坏的孤儿 ⟹ 旧代码写入并 checkpoint 过的主库行会冒充「WAL 重放成功」。这两条是「只看行数」判据必然踩空的原因。

证不了完整时**归档而非删除**：`<db>.unrecovered-<ts>.db` + `-wal`，即原始字节配上**合并前**的 shell。归档名**不触发**坏库判据 —— 若把证据留在原路径，每次启动都会重新恢复，且所有 `owner:false` worker 永久 fail-closed。归档只承诺**字节保全**，不承诺可直接重放（截断孤儿本就 0 行）。

### 清理顺序是正确性，不是整洁

唯一带数据的 `.tmp-wal` **最后删**，且前置 sidecar 全部删成功才删它 ⟹「只剩 `.tmp-shm`」不可能由成功恢复或中途崩溃产生，因此它可以继续当作坏库信号。（此前为了消歧曾把 lone `-shm` 排除出判据，等于把「WAL 被外部删掉的真坏库」放行成健康空库。）

### 跨崩溃收敛：receipt

清理被打断（前置 unlink 失败）后，下次启动必须能收尾。用「composite 与 baseline 行集相等」去推断「上次已合并」是**时序相关**的、不可靠；改为在**与合并同一个事务**里写一条 receipt（key = 孤儿 WAL 的 SHA-256），要么和行一起落地要么都不落地。读 receipt **严格只读**（`CREATE TABLE` 会把主库从 12288 涨到 20480 字节，而它跑在归档之前，会让归档 shell 不再与 WAL 配对）。

### fail-closed

无法证实时设 `loadFailure`，让 `listSessionsStrict()` 正常抛 `SessionStoreUnavailableError`。非 owner 进程（worker）不修库、直接报 unavailable。恢复全程在**既有的文件锁内**（与导入/daemon save/离线 CLI 写者同一把锁），锁内二次确认。

## 影响面

`src/services/session-store.ts` 属**全 fleet 公共层**，逐项排查：

- **入口极窄**：只在「`.db` 存在 **且** `.tmp*` 孤儿存在」时进入。健康库（只有 `-wal`/`-shm`）与首次导入路径（`.db` 不存在）**都不经过**；健康库连开两次实测行数不变、无新增文件。
- **跨运行时**：Bun（坏库唯一能产生的形态）与 **Node（fleet 实际在跑的运行时）**都实测恢复成功、健康库都不误伤。
- **跨会话类型**：owner（daemon）恢复、worker（`owner:false`）fail-closed 两条路径分别实测。
- **并发**：4 个 owner 进程并发打开同一坏库 —— 唯一进程执行恢复，其余看到已修好的库，40 distinct 行、无残留 scratch 与锁文件。
- **新增一张表** `import_recovery_receipts`（`CREATE TABLE IF NOT EXISTS`，仅恢复路径写入），不影响 `sessions` 的读写。
- **未改** #1073 已修好的 `importJsonStoreToSqlite` DELETE 模式逻辑。
- **线上目前没有受影响的库**（fleet 跑 Node，56 个 store 全干净），因此不紧急；优先正确性与不误伤，没有为「顺手清理」扩大删除面。

## 测试与实跑结果

该缺陷是 **Bun 专属**，而 **vitest 测试体永远跑在 Node 上**（即使 `bun x vitest`）⟹ 纯 in-process 断言天生测不到。`test/session-store-sqlite-poisoned-recovery.test.ts` 共 **18 例**，全部在真 Bun 子进程里造坏库并跑生产 `load()`：子进程自报 `runtime` 与 `Bun.version` 并断言等于 `packageManager` 的 pin；夹具 schema 从**生产代码刚建出来的库**里 harvest（避免与 `SESSIONS_SCHEMA_SQL` 漂移）；并**正向自证**夹具确实是坏态（4096 字节空壳 + 孤儿 WAL、live 行确实落在主库）。

坏库复现：WAL 建临时库 → 写行 → **不 finalize 语句** → `close()` → `renameSync` → **SIGKILL**（干净退出时 Bun 会沿 fd 补 checkpoint，坏态复现不出来）。

```
bun run build        exit=0
bun x tsc --noEmit   exit=0
git diff --check     clean
恢复矩阵              18 passed (18)
session-store 四文件   128 passed (128)
```

**反变异 14 组**（每组撤掉一处修复后必须转红，两侧 M0 绿）：作证判据换回行数 / legacy 作证退回 `frozen.length` / `walReplayed` 换回行数 / 从不归档 / 无条件删 WAL / receipt 不写 / receipt 不读 / receipt 读改成读写 / 两个来源各自删掉 / `OR IGNORE`→`OR REPLACE` / worker 可修库 / 归档名改成会触发判据的 `.tmp-keep` / legacy `appId` 过滤删掉 —— **全部转红**。

另有 2 组如实标注为**等价变异**而非覆盖缺口：重新装回「行集相等即视为已合并」仍全绿，因为实测扫过 12 档截断，`acceptedFrames>0` 与 `composite==baseline>0` 在可达输入上**互斥**（接受帧后 schema 替换掉表 ⟹ composite 归 0）；该条件仍未保留，收敛改由 receipt 负责。

**全量测试**：`19565 passed / 5 failed / 11 skipped`。失败 5 条均与本改动无关 —— 4 条为既有失败（`mojo-launcher-env-quarantine` 的 EACCES 两条，root 不受文件权限限制；`plugin-mcp-sandbox` 的 bwrap 两条）；第 5 条 `listen-with-probe` 为并发端口竞争（断言 `expected 16103 to be 16102`，即期望的 `busy+1` 被另一个并发用例抢走），单文件隔离重跑 3/3 绿。用 `--reporter=json` 直接确认本文件 `status: passed (18 cases)`（vitest 文本输出只列失败/慢文件，不能靠「没出现」推断跑过）。

本 PR 经同侪复审多轮，五处阻断（legacy 零行漏证、双来源同时退化互相掩护、主库行冒充 WAL 重放、lone `-shm` 判据被放宽、中断清理无法收敛）均已修复并各自补上精确回归用例。
