### PR TITLE
fix(dashboard): Bot 配置名册改为满高分栏，避免搜索框被挤出视口

### DIFF
--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -540,6 +540,46 @@ main:has(.groups-page) .groups-matrix-section > #g-loading {
   }
 }
 
+/* Bot 配置桌面：整页吃满 main，名册和详情各占一列。名册若只靠
+   sticky + 100dvh 估算限高，往往会比 main 可视区高出一截——钉住之后
+   仍会被含块底边往上挤，搜索框就从视口顶被切掉。窄屏仍走整页滚动。 */
+@media (min-width: 981px) {
+  main:has(.bot-defaults-page) {
+    padding-bottom: 0;
+    overflow: hidden;
+  }
+
+  main:has(.bot-defaults-page) .bot-defaults-page {
+    height: 100%;
+    min-height: 0;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
+  }
+
+  main:has(.bot-defaults-page) .bd-layout {
+    height: 100%;
+    min-height: 0;
+    align-items: stretch;
+  }
+
+  main:has(.bot-defaults-page) .bd-roster {
+    position: static;
+    top: auto;
+    height: 100%;
+    max-height: none;
+    min-height: 0;
+  }
+
+  main:has(.bot-defaults-page) .bd-detail {
+    height: 100%;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+}
+
 @keyframes dashboard-page-enter {
   from {
     opacity: 0;
@@ -23431,7 +23471,11 @@ dialog select[multiple]:hover:not(:disabled) {
 }
 
 .bot-defaults-page .bd-roster {
+  /* Search/count stay put; the list row is the scrollport. Desktop height
+     comes from the fill-height shell (main:has); mobile caps it below. */
   top: 0;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  overflow: hidden;
 }
 
 .bot-defaults-page #bd-filters {
@@ -23487,6 +23531,9 @@ dialog select[multiple]:hover:not(:disabled) {
   display: grid;
   gap: 3px;
   min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 @media (max-width: 980px) {

--- a/test/dashboard-bot-defaults-layout.test.ts
+++ b/test/dashboard-bot-defaults-layout.test.ts
@@ -37,6 +37,32 @@ describe('bot defaults focused layout', () => {
     expect(css).toMatch(/\.bot-defaults-page \.bd-tab-grid > \.bd-tile-wide\s*\{[\s\S]*?grid-column:\s*1 \/ -1;/);
   });
 
+  it('fills the desktop main so the roster cannot be shoved under the search box', () => {
+    // A sticky roster sized with 100dvh is usually a few pixels taller than
+    // main's client box. Once pinned, the containing-block floor keeps
+    // sliding it up and clips #bd-filters. Desktop therefore uses the same
+    // fill-height shell as roles-page: main does not scroll, both columns
+    // stretch, the list and the detail pane are the scrollports.
+    const desktop = css.slice(css.indexOf('main:has(.bot-defaults-page)'), css.indexOf('main:has(.bot-defaults-page) .bd-detail') + 280);
+    expect(desktop).toMatch(/main:has\(\.bot-defaults-page\)\s*\{[\s\S]*?overflow:\s*hidden;/);
+    expect(desktop).toMatch(/\.bot-defaults-page\s*\{[\s\S]*?grid-template-rows:\s*auto minmax\(0,\s*1fr\);/);
+    expect(desktop).toMatch(/\.bd-layout\s*\{[\s\S]*?align-items:\s*stretch;/);
+    expect(desktop).toMatch(/\.bd-roster\s*\{[\s\S]*?position:\s*static;[\s\S]*?height:\s*100%;/);
+    expect(desktop).toMatch(/\.bd-detail\s*\{[\s\S]*?overflow-y:\s*auto;/);
+
+    const rosterStart = css.indexOf('.bot-defaults-page .bd-roster {');
+    const roster = css.slice(rosterStart, css.indexOf('.bot-defaults-page #bd-filters', rosterStart));
+    expect(roster).toMatch(/grid-template-rows:\s*auto auto minmax\(0,\s*1fr\);/);
+    expect(roster).toMatch(/overflow:\s*hidden;/);
+    expect(roster).not.toMatch(/max-height:\s*calc\(100dvh/);
+
+    const listStart = css.indexOf('.bot-defaults-page .bd-roster-list {');
+    const list = css.slice(listStart, css.indexOf('@media (max-width: 980px)', listStart));
+    expect(list).toMatch(/min-height:\s*0;/);
+    expect(list).toMatch(/overflow-y:\s*auto;/);
+    expect(list).toMatch(/overscroll-behavior:\s*contain;/);
+  });
+
   it('keeps the mobile roster bounded with a real scrollport instead of clipping', () => {
     // Grid auto rows keep max-content height, so the list row must be
     // forced into the remaining space (minmax(0,1fr) + min-height:0) or


### PR DESCRIPTION
## Summary
- Bot 配置桌面端不再用 sticky + `100dvh` 估高钉左侧名册：估高通常比 `main` 可视区高出一截，滚到一定位置后整列仍会被含块底边往上挤，搜索框被切掉。
- 改为与角色页相同的满高分栏：`main` 不再整页滚动，名册与详情各占一列并各自内部滚动；档案头仍在详情列内 sticky。窄屏继续走整页滚动 + 名册限高内部滚。
- 布局单测锁住桌面满高壳与名册列表滚动口，并保持原有窄屏断言。

## 影响面
- 只动 Dashboard「Bot 配置」页桌面布局（≥981px）和对应 CSS 单测。
- 不改 CLI / 会话后端 / 飞书消息路径。窄屏（≤980px）规则未改语义。

## Test plan
- [x] `bun run test -- test/dashboard-bot-defaults-layout.test.ts`（13 passed）
- [x] 桌面视口：右侧详情滚到「Profile 角色」时，左侧搜索框完整可见、位置不变
- [x] 名册列表可单独滚动并点选另一个机器人
- [ ] 强制刷新线上 Dashboard Bot 配置页，复验搜索框不再被挤出
- [ ] 窄屏（≤980px）名册仍限高、列表可内部滚动


Made with [Cursor](https://cursor.com)