### PR TITLE
fix(setup): 开放平台写请求对「TLS 握手前断连」重试，改头像不再被一次网络抖动打挂

### DIFF
--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -1816,6 +1816,12 @@ export interface OpenPlatformAppSummary {
 export interface OpenPlatformApiClient {
   apiOrigin: string;
   postJson(path: string, body?: unknown): Promise<unknown>;
+  /**
+   * 语义幂等的 console POST（重复调用无副作用：设值型 switch、只读拉取）。
+   * 与 GET/HEAD 同权享受完整的瞬态错误退避重试，且**预算只在 fetchRaw 这一层**
+   * —— 调用方不要再在外面套第二轮 retry，那会与内层相乘（实测 3×3=9 次）。
+   */
+  postJsonIdempotent(path: string, body?: unknown): Promise<unknown>;
   postForm(path: string, body: FormData): Promise<unknown>;
 }
 
@@ -1855,7 +1861,9 @@ export async function createOpenPlatformApiClient(
     };
   }
 
-  const request = async (path: string, body?: BodyInit, contentType?: string): Promise<unknown> => {
+  const request = async (
+    path: string, body?: BodyInit, contentType?: string, opts: { idempotent?: boolean } = {},
+  ): Promise<unknown> => {
     const url = `${apiOrigin}${path}`;
     const response = await session.fetchRaw(fetcher, url, {
       method: 'POST',
@@ -1867,7 +1875,7 @@ export async function createOpenPlatformApiClient(
         ...(contentType ? { 'content-type': contentType } : {}),
       },
       body,
-    });
+    }, 10, opts);
     let data: any;
     try {
       data = await response.json();
@@ -1885,9 +1893,16 @@ export async function createOpenPlatformApiClient(
 
   const postJson = async (path: string, body?: unknown): Promise<unknown> =>
     request(path, body === undefined ? undefined : JSON.stringify(body), body === undefined ? undefined : 'application/json');
+  const postJsonIdempotent = async (path: string, body?: unknown): Promise<unknown> =>
+    request(
+      path,
+      body === undefined ? undefined : JSON.stringify(body),
+      body === undefined ? undefined : 'application/json',
+      { idempotent: true },
+    );
   const postForm = async (path: string, body: FormData): Promise<unknown> => request(path, body);
 
-  return { ok: true, client: { apiOrigin, postJson, postForm }, identity };
+  return { ok: true, client: { apiOrigin, postJson, postJsonIdempotent, postForm }, identity };
 }
 
 /**
@@ -2102,10 +2117,8 @@ export async function createOpenPlatformAppWithClient(
     // robot/event switch 都是幂等设值,故对宿主机↔飞书的瞬态网络抖动小步重试:
     // 一次 undici `fetch failed` 不该让「应用已建成但没启用能力」半途而废
     // (那会把用户丢进手动读 Secret + CLI 续跑的恢复路径)。
-    await retryIdempotentOnTransientNetworkError(() =>
-      client.postJson(`/developers/v1/robot/switch/${appId}`, { clientId: appId, enable: true }));
-    await retryIdempotentOnTransientNetworkError(() =>
-      client.postJson(`/developers/v1/event/switch/${appId}`, { clientId: appId, eventMode: 4 })); // WebSocket
+    await client.postJsonIdempotent(`/developers/v1/robot/switch/${appId}`, { clientId: appId, enable: true });
+    await client.postJsonIdempotent(`/developers/v1/event/switch/${appId}`, { clientId: appId, eventMode: 4 }); // WebSocket
 
     // 模板建出来的应用，「权限可访问的数据范围」出生就是 `mode:'all'`（console 上
     // 显示「全部」）——而这里紧接着就要发**第一个版本**。不先收窄，这一版就带着
@@ -2143,8 +2156,7 @@ export async function createOpenPlatformAppWithClient(
     // 读 Secret 是纯只读 POST(getAppSecret 同款,不触碰 reset),幂等可重试:
     // 应用已建成、已发布,唯独最后一步读 Secret 撞网络抖动而失败最可惜——
     // 重试让它自愈,而不是把整条链路判死。
-    const appSecret = await retryIdempotentOnTransientNetworkError(() =>
-      fetchOpenPlatformAppSecret(client, appId!));
+    const appSecret = await fetchOpenPlatformAppSecret(client, appId!, { idempotentRetry: true });
     return { appId, appSecret };
   } catch (err) {
     throw new CreatedOpenPlatformAppError(appId, err);
@@ -2312,8 +2324,13 @@ export async function listOpenPlatformApps(
 export async function fetchOpenPlatformAppSecret(
   client: OpenPlatformApiClient,
   clientId: string,
+  opts: { idempotentRetry?: boolean } = {},
 ): Promise<string> {
-  const payload = await client.postJson(`/developers/v1/secret/${clientId}`, {});
+  // 纯只读 POST（不触碰 reset）⟹ 语义幂等。建应用链路显式开启重试：应用已建成
+  // 已发布，唯独最后一步读 Secret 撞网络抖动最可惜。预算只在 fetchRaw 一层。
+  const payload = opts.idempotentRetry
+    ? await client.postJsonIdempotent(`/developers/v1/secret/${clientId}`, {})
+    : await client.postJson(`/developers/v1/secret/${clientId}`, {});
   const record = asRecord(payload);
   const secret = pickString(asRecord(record.data), ['secret']) ?? pickString(record, ['secret']);
   if (!secret) throw new Error('开放平台没有返回 secret 字段');
@@ -2477,37 +2494,66 @@ const TRANSIENT_FETCH_RETRY_DELAYS_MS = [300, 900];
 /**
  * 「TLS 握手完成之前连接就断了」——Node 内置 `_tls_wrap.js` 的 `onConnectEnd`
  * 唯一产出这句话（`ConnResetException`，code=ECONNRESET）。它的关键性质是
- * **可证明零副作用**，因此连非幂等写请求都能安全重放：
+ * **可证明零副作用**，因此连非幂等写请求都能安全重放。
  *
- *   • 结构上：该监听器在建 socket 时 `prependListener('end', onConnectEnd)` 挂上，
- *     并在 `onConnectSecure` 里 `removeListener('end', onConnectEnd)` 摘掉 ——
- *     所以它只可能在 `secureConnect` 之前触发。握手没完成 ⟹ 没有任何加密通道，
- *     HTTP 请求行 / 头 / body 一个字节都没能发出去。
+ * 证明链（Node + undici 的 dispatch 时序，**不是**「握手未完成 ⟹ 没有加密通道」
+ * —— 那个说法对 TLS 1.3 不成立：ServerHello 之后的握手消息已加密，协议还定义了
+ * 0-RTT early data。成立的是下面这条客户端实现约束）：
+ *   • undici 的 connector 只在 TLSSocket 的 `secureConnect` 监听器里回调
+ *     （`socket.setNoDelay(true).once('secureConnect', … cb(null, this))`），
+ *     HTTP client 拿到这个 socket 之后才 dispatch/write 请求；
+ *   • `onConnectEnd` 只在建 socket 时 `prependListener('end', …)` 挂上，并在
+ *     `onConnectSecure` 里摘掉。注意源码顺序是**先** `emit('secureConnect')`
+ *     **再** `removeListener`，所以不能说成「先摘监听器再交给 undici」；成立的是：
+ *     远端 FIN / `end` 只可能在后续 I/O 分派中被处理，而那时监听器已摘。因此这句
+ *     错误产出时，`secureConnect` 监听器没有成功走完 ⟹ undici 还没拿到可 dispatch
+ *     的连接 ⟹ 应用请求行 / 头 / body 未写出；
+ *   • Node 目前也没有让 fetch 走 TLS 0-RTT early data 的路径。
  *   • 实测（本机 TCP 抓包型探针）：服务端只收到 1583 字节且首字节 0x16
  *     （TLS handshake record），文本里 **不含** 请求方法、路径与 body 字段；
  *     对照组「握手完成后才断」收到 248 字节应用数据，且错误换成
  *     `UND_ERR_SOCKET / other side closed` —— 两类错误可靠可分。
  *
+ * 代理场景下「零字节」限定为**目标应用的 HTTP 请求**：HTTP proxy 的 CONNECT 可能
+ * 已经发给代理，但目标 POST 尚未通过隧道发出，故「无重复副作用」的结论仍成立。
+ *
  * ⚠️ 仅此一句话享受该待遇。`ECONNRESET` 本身**不够**：连接建成、请求已送达后
  * 被 RST 同样是 ECONNRESET，那种情况服务端可能已处理，重放会重复提交。
+ *
+ * ⚠️ 该形态绑定 Node/undici。Bun 原生 fetch 对同一真实故障抛的是顶层 `TypeError`
+ * （message `The socket connection was closed unexpectedly...`、code=ECONNRESET、
+ * **无 cause**），不满足本判据 ⟹ 不命中、不重试（保持旧行为）。这是已知的跨运行时
+ * 缺口而非安全问题；要覆盖 Bun 必须先为它的文案建立同等级的「只可能握手前」证明。
  */
 const PRE_TLS_DISCONNECT_MESSAGE =
   'Client network socket disconnected before secure TLS connection was established';
 
 /**
  * 传输层失败是否**可证明「请求未送达」**，即重放绝不会产生重复副作用。
- * 只认上面那一句 pre-TLS 断连（外层可能被 undici 包成
- * `TypeError('fetch failed', { cause })`，也可能藏在 happy-eyeballs 的
- * AggregateError 里，故顺 cause 链找）。
+ * 只认 {@link PRE_TLS_DISCONNECT_MESSAGE} 那一句（唯一可证明未送达的
+ * ECONNRESET）。外层会被 undici 包成 `TypeError('fetch failed', { cause })`，
+ * 故顺**单一 cause 链**找。
+ *
+ * ⚠️ 刻意**不支持 AggregateError**，这是有意收窄而非遗漏：
+ *   • 真实的 Node pre-TLS 断连本来就不是聚合体 —— `net.internalConnectMultiple`
+ *     只在**所有** TCP connect 尝试失败时才构造 `NodeAggregateError`（成员一律
+ *     来自 `createConnectionError(…, 'connect', …)`），而这句文案由
+ *     `_tls_wrap.onConnectEnd` 在某条腿 connect **成功之后**才可能产出，两者
+ *     互斥；
+ *   • 一旦支持聚合体，就要对 `.errors` 与 `AggregateError` 同样合法的 `.cause`
+ *     同时做全称量词检查，任一遗漏都是 fail-open（实测：
+ *     `new AggregateError([preTls], '', { cause: socketHangUp })` 会被放行）。
+ *     provably 的证明责任配不上这点收益。
+ *
+ * 同理，精确文案的节点若**自带 cause**，说明它不是我们证明过的那个
+ * `ConnResetException`（Node 构造它时不挂 cause），一律 fail-closed。
  */
 function isProvablyUnsentTransportError(err: unknown, depth = 0): boolean {
   if (depth > 4 || !(err instanceof Error)) return false;
   if (err.name === 'AbortError' || err.name === 'TimeoutError') return false;
+  if (err instanceof AggregateError) return false;
   if ((err as { code?: unknown }).code === 'ECONNRESET' && err.message === PRE_TLS_DISCONNECT_MESSAGE) {
-    return true;
-  }
-  if (err instanceof AggregateError && err.errors.some(item => isProvablyUnsentTransportError(item, depth + 1))) {
-    return true;
+    return err.cause === undefined;
   }
   return isProvablyUnsentTransportError((err as { cause?: unknown }).cause, depth + 1);
 }
@@ -2527,26 +2573,6 @@ function isLikelyTransientNetworkError(err: unknown, depth = 0): boolean {
     return err.cause === undefined || isLikelyTransientNetworkError(err.cause, depth + 1);
   }
   return isLikelyTransientNetworkError((err as { cause?: unknown }).cause, depth + 1);
-}
-
-// 对「幂等」console 请求复用 fetchRaw 的瞬态退避:传输层抖动(fetch failed /
-// ECONNRESET 等)时小步重试,一次网络毛刺不再中断整条链路。API 层拒绝
-// (OpenPlatformApiError、HTTP 非 2xx、code!=0)无 code / cause,isLikely… 判 false,
-// 只会立刻抛出而不会被重放。
-// ⚠️ 只能包装「重复调用无副作用」的请求。app_version/create、publish/commit 这类
-// 「传输失败即结果未知、重放会重复提交/撞版本号」的非幂等写操作绝不能用本包装
-// (与 fetchRaw 只对 GET/HEAD 重试同源:见其上方注释)。
-async function retryIdempotentOnTransientNetworkError<T>(fn: () => Promise<T>): Promise<T> {
-  for (let attempt = 0; ; attempt += 1) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (attempt >= TRANSIENT_FETCH_RETRY_DELAYS_MS.length || !isLikelyTransientNetworkError(err)) {
-        throw err;
-      }
-      await sleep(TRANSIENT_FETCH_RETRY_DELAYS_MS[attempt]);
-    }
-  }
 }
 
 class MutableCookieJar {
@@ -2574,7 +2600,13 @@ class MutableCookieJar {
     };
   }
 
-  async fetchRaw(fetcher: typeof fetch, url: string, init: RequestInit = {}, maxHops = 10): Promise<Response> {
+  async fetchRaw(
+    fetcher: typeof fetch,
+    url: string,
+    init: RequestInit = {},
+    maxHops = 10,
+    opts: { idempotent?: boolean } = {},
+  ): Promise<Response> {
     let current = url;
     let referer: string | undefined;
     // 幂等的 GET/HEAD：任意瞬态网络错误都可小步退避重试。
@@ -2583,8 +2615,12 @@ class MutableCookieJar {
     // 可证明请求一个字节都没发出去（见 isProvablyUnsentTransportError），重放
     // 不可能产生重复副作用；不放过它的代价是一次网络毛刺就让用户的改名/改头像
     // 整轮失败。
+    // `opts.idempotent` 让调用方声明「这个 POST 重复调用无副作用」（robot/event
+    // switch 设值、只读拉 Secret），从而与 GET/HEAD 同权：认全部瞬态错误。
+    // 关键是预算**只此一层**——历史上这三处在外层另包了一轮 retry，与内层相乘
+    // 成 9 次（实测 4.8s 退避）；预算集中在这里后总尝试恒为 3。
     const method = (init.method ?? 'GET').toUpperCase();
-    const retryable = method === 'GET' || method === 'HEAD';
+    const retryable = opts.idempotent === true || method === 'GET' || method === 'HEAD';
     for (let hop = 0; hop <= maxHops; hop += 1) {
       const headers = new Headers(init.headers);
       const cookieHeader = getCookieHeader(this.cookies, current);

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -2474,6 +2474,44 @@ const TRANSIENT_NETWORK_ERROR_CODES = new Set([
 
 const TRANSIENT_FETCH_RETRY_DELAYS_MS = [300, 900];
 
+/**
+ * 「TLS 握手完成之前连接就断了」——Node 内置 `_tls_wrap.js` 的 `onConnectEnd`
+ * 唯一产出这句话（`ConnResetException`，code=ECONNRESET）。它的关键性质是
+ * **可证明零副作用**，因此连非幂等写请求都能安全重放：
+ *
+ *   • 结构上：该监听器在建 socket 时 `prependListener('end', onConnectEnd)` 挂上，
+ *     并在 `onConnectSecure` 里 `removeListener('end', onConnectEnd)` 摘掉 ——
+ *     所以它只可能在 `secureConnect` 之前触发。握手没完成 ⟹ 没有任何加密通道，
+ *     HTTP 请求行 / 头 / body 一个字节都没能发出去。
+ *   • 实测（本机 TCP 抓包型探针）：服务端只收到 1583 字节且首字节 0x16
+ *     （TLS handshake record），文本里 **不含** 请求方法、路径与 body 字段；
+ *     对照组「握手完成后才断」收到 248 字节应用数据，且错误换成
+ *     `UND_ERR_SOCKET / other side closed` —— 两类错误可靠可分。
+ *
+ * ⚠️ 仅此一句话享受该待遇。`ECONNRESET` 本身**不够**：连接建成、请求已送达后
+ * 被 RST 同样是 ECONNRESET，那种情况服务端可能已处理，重放会重复提交。
+ */
+const PRE_TLS_DISCONNECT_MESSAGE =
+  'Client network socket disconnected before secure TLS connection was established';
+
+/**
+ * 传输层失败是否**可证明「请求未送达」**，即重放绝不会产生重复副作用。
+ * 只认上面那一句 pre-TLS 断连（外层可能被 undici 包成
+ * `TypeError('fetch failed', { cause })`，也可能藏在 happy-eyeballs 的
+ * AggregateError 里，故顺 cause 链找）。
+ */
+function isProvablyUnsentTransportError(err: unknown, depth = 0): boolean {
+  if (depth > 4 || !(err instanceof Error)) return false;
+  if (err.name === 'AbortError' || err.name === 'TimeoutError') return false;
+  if ((err as { code?: unknown }).code === 'ECONNRESET' && err.message === PRE_TLS_DISCONNECT_MESSAGE) {
+    return true;
+  }
+  if (err instanceof AggregateError && err.errors.some(item => isProvablyUnsentTransportError(item, depth + 1))) {
+    return true;
+  }
+  return isProvablyUnsentTransportError((err as { cause?: unknown }).cause, depth + 1);
+}
+
 function isLikelyTransientNetworkError(err: unknown, depth = 0): boolean {
   if (depth > 4 || !(err instanceof Error)) return false;
   // 调用方主动 abort / 超时不算网络抖动，重试会违背调用方意图。
@@ -2539,8 +2577,12 @@ class MutableCookieJar {
   async fetchRaw(fetcher: typeof fetch, url: string, init: RequestInit = {}, maxHops = 10): Promise<Response> {
     let current = url;
     let referer: string | undefined;
-    // 只有幂等的 GET/HEAD 允许瞬态网络错误重试：POST 全是 console 写操作或登录
-    // 流程，传输错误时服务端可能已 commit（结果未知），重试等于重复提交。
+    // 幂等的 GET/HEAD：任意瞬态网络错误都可小步退避重试。
+    // POST 全是 console 写操作或登录流程，传输错误时服务端可能已 commit（结果
+    // 未知），重试等于重复提交 —— 唯一例外是「TLS 握手完成前就断连」，那类错误
+    // 可证明请求一个字节都没发出去（见 isProvablyUnsentTransportError），重放
+    // 不可能产生重复副作用；不放过它的代价是一次网络毛刺就让用户的改名/改头像
+    // 整轮失败。
     const method = (init.method ?? 'GET').toUpperCase();
     const retryable = method === 'GET' || method === 'HEAD';
     for (let hop = 0; hop <= maxHops; hop += 1) {
@@ -2556,7 +2598,12 @@ class MutableCookieJar {
           response = await fetcher(current, { ...init, headers, redirect: 'manual' });
           break;
         } catch (err) {
-          if (!retryable || attempt >= TRANSIENT_FETCH_RETRY_DELAYS_MS.length || !isLikelyTransientNetworkError(err)) {
+          // 可重试 = 幂等方法遇任意瞬态错误，或任意方法遇「可证明未送达」的
+          // pre-TLS 断连。后者对写操作也安全（零字节送达 ⟹ 无副作用）。
+          const mayRetry = retryable
+            ? isLikelyTransientNetworkError(err)
+            : isProvablyUnsentTransportError(err);
+          if (attempt >= TRANSIENT_FETCH_RETRY_DELAYS_MS.length || !mayRetry) {
             throw err;
           }
           await sleep(TRANSIENT_FETCH_RETRY_DELAYS_MS[attempt]);

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -3201,6 +3201,149 @@ describe('console 页面读取的瞬态网络错误重试', () => {
   });
 });
 
+// 「TLS 握手完成之前就断连」是唯一可证明「请求一个字节都没发出去」的传输错误：
+// Node 内置 `_tls_wrap.js` 的 `onConnectEnd` 在建 socket 时挂上、在
+// `onConnectSecure` 里摘掉，所以它只会在握手完成前触发 ⟹ 没有加密通道 ⟹ 请求行/
+// 头/body 都没送出。因此连非幂等的 console 写操作也能安全重放；不重放的代价是
+// 用户的改名/改头像被一次网络毛刺整轮打挂（线上实测：改头像失败并把这句话原样
+// 抛给用户）。以下用例守住「该重试的重试、不该重试的绝不重试」两侧。
+describe('pre-TLS 断连：可证明未送达，写操作也重试', () => {
+  /** 与线上实测逐字一致的错误形态（外层 undici 包装 + cause 带 code）。 */
+  const preTlsDisconnect = () =>
+    new TypeError('fetch failed', {
+      cause: Object.assign(
+        new Error('Client network socket disconnected before secure TLS connection was established'),
+        { code: 'ECONNRESET' },
+      ),
+    });
+  /** 对照：握手已完成、请求已送达后才断 —— 服务端可能已处理，绝不能重放。 */
+  const afterRequestSent = () =>
+    new TypeError('fetch failed', {
+      cause: Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' }),
+    });
+
+  async function postWith(errFactory: () => Error, failTimes: number) {
+    let postAttempts = 0;
+    let failed = 0;
+    const bodies: string[] = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if ((init?.method ?? 'GET').toUpperCase() === 'POST') {
+        postAttempts += 1;
+        bodies.push(String(init?.body ?? ''));
+        if (failed < failTimes) { failed += 1; throw errFactory(); }
+        return new Response(JSON.stringify({ code: 0, data: { ok: true } }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (href === 'https://open.feishu.cn/app') return new Response(openPlatformPage(), { status: 200 });
+      throw new Error(`unexpected url: ${href}`);
+    }) as typeof fetch;
+
+    const clientResult = await createOpenPlatformApiClient([cookie()], { fetchImpl });
+    expect(clientResult.ok).toBe(true);
+    if (!clientResult.ok) throw new Error('client construction failed');
+    return { client: clientResult.client, attempts: () => postAttempts, bodies };
+  }
+
+  it('POST 写操作遇 pre-TLS 断连会重试，并把 body 原样重发', async () => {
+    const h = await postWith(preTlsDisconnect, 1);
+    await expect(h.client.postJson('/developers/v1/base_info/cli_x', { clientId: 'cli_x', name: '小助手' }))
+      .resolves.toMatchObject({ code: 0 });
+    expect(h.attempts()).toBe(2);
+    // 重发的必须是同一份 payload——否则会写出半截数据。
+    expect(h.bodies).toHaveLength(2);
+    expect(h.bodies[0]).toBe(h.bodies[1]);
+    expect(h.bodies[0]).toContain('"name":"小助手"');
+  });
+
+  it('POST 的 multipart 上传（改头像图片）同样重试且 FormData 可原样重发', async () => {
+    let postAttempts = 0;
+    const sizes: Array<number | string> = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if ((init?.method ?? 'GET').toUpperCase() === 'POST') {
+        postAttempts += 1;
+        const body = init?.body as FormData;
+        sizes.push(body instanceof FormData ? ((body.get('file') as Blob | null)?.size ?? 'MISSING') : 'NOT_FORM');
+        if (postAttempts === 1) throw preTlsDisconnect();
+        return new Response(JSON.stringify({ code: 0, data: { url: 'https://cdn/a.png' } }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (href === 'https://open.feishu.cn/app') return new Response(openPlatformPage(), { status: 200 });
+      throw new Error(`unexpected url: ${href}`);
+    }) as typeof fetch;
+
+    const clientResult = await createOpenPlatformApiClient([cookie()], { fetchImpl });
+    expect(clientResult.ok).toBe(true);
+    if (!clientResult.ok) return;
+    const form = new FormData();
+    form.append('file', new Blob([new Uint8Array(64).fill(7)], { type: 'image/png' }), 'avatar.png');
+    await expect(clientResult.client.postForm('/developers/v1/app/upload/image', form))
+      .resolves.toMatchObject({ code: 0 });
+    expect(postAttempts).toBe(2);
+    // 两次都带着完整的 64 字节图片——重发不能退化成空 body。
+    expect(sizes).toEqual([64, 64]);
+  });
+
+  it('重试耗尽后仍失败，并把这句 pre-TLS 断连原样透出给用户', async () => {
+    const h = await postWith(preTlsDisconnect, Number.POSITIVE_INFINITY);
+    await expect(h.client.postJson('/developers/v1/base_info/cli_x', {}))
+      .rejects.toThrow('fetch failed');
+    expect(h.attempts()).toBe(3); // 首次 + 2 次退避重试
+  });
+
+  it('对照：握手后断连（UND_ERR_SOCKET）的写操作绝不重试——结果未知不可重放', async () => {
+    const h = await postWith(afterRequestSent, 1);
+    await expect(h.client.postJson('/developers/v1/app_version/create/cli_x', {}))
+      .rejects.toThrow('fetch failed');
+    expect(h.attempts()).toBe(1);
+  });
+
+  it('对照：普通 ECONNRESET（非 pre-TLS 文案）的写操作也不重试——仅靠 code 判定不安全', async () => {
+    const genericReset = () => new TypeError('fetch failed', {
+      cause: Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+    });
+    const h = await postWith(genericReset, 1);
+    await expect(h.client.postJson('/developers/v1/publish/commit/cli_x/v1', {}))
+      .rejects.toThrow('fetch failed');
+    expect(h.attempts()).toBe(1);
+  });
+
+  // 判据必须是**整句精确匹配**，不能放宽成关键词包含。Node 内置的
+  // `ConnResetException` 有多条文案共用 code=ECONNRESET，其中 `socket hang up`
+  // （`_http_client.js`）是在请求**已发出之后**才抛的 —— 一旦用
+  // `includes('disconnected')` 之类的松匹配，或把别的 ConnResetException 文案
+  // 也算进来，写操作就会在「服务端可能已处理」的情况下被重放。
+  it.each([
+    ['socket hang up', 'ECONNRESET'],                                   // 请求已送达后
+    ['aborted', 'ECONNRESET'],                                          // 响应中途断
+    ['Client network socket disconnected', 'ECONNRESET'],               // 截断的近似文案
+    ['socket disconnected before secure TLS handshake', 'ECONNRESET'],  // 改写过的近似文案
+  ])('对照：ConnResetException 的其它文案 %j 不得被当成可重放', async (message, code) => {
+    const near = () => new TypeError('fetch failed', {
+      cause: Object.assign(new Error(message), { code }),
+    });
+    const h = await postWith(near, 1);
+    await expect(h.client.postJson('/developers/v1/app_version/create/cli_x', {}))
+      .rejects.toThrow('fetch failed');
+    expect(h.attempts()).toBe(1);
+  });
+
+  it('调用方主动 abort 即使裹在 pre-TLS 文案里也不重试（不违背调用方意图）', async () => {
+    const aborted = () => {
+      const e = new Error('Client network socket disconnected before secure TLS connection was established');
+      e.name = 'AbortError';
+      (e as any).code = 'ECONNRESET';
+      return new TypeError('fetch failed', { cause: e });
+    };
+    const h = await postWith(aborted, 1);
+    await expect(h.client.postJson('/developers/v1/base_info/cli_x', {})).rejects.toThrow('fetch failed');
+    expect(h.attempts()).toBe(1);
+  });
+});
+
 describe('safeErrorMessage', () => {
   it('展开 undici fetch failed 的 cause 链，露出真实网络错误', () => {
     const err = new TypeError('fetch failed', {

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -46,6 +46,7 @@ import {
   readStoredCookiesFromSessionFile,
   safeErrorMessage,
   selectPrivilegesNeedingAppAvailability,
+  type OpenPlatformApiClient,
   type StoredCookie,
   vcListenerEventGateError,
   writeRedirectWhitelist,
@@ -3341,6 +3342,120 @@ describe('pre-TLS 断连：可证明未送达，写操作也重试', () => {
     const h = await postWith(aborted, 1);
     await expect(h.client.postJson('/developers/v1/base_info/cli_x', {})).rejects.toThrow('fetch failed');
     expect(h.attempts()).toBe(1);
+  });
+
+  // AggregateError 一律不支持（有意收窄）：真实 Node pre-TLS 断连不是聚合体
+  // ——`net.internalConnectMultiple` 只在**所有** TCP connect 失败时构造
+  // NodeAggregateError，而这句文案由 `_tls_wrap.onConnectEnd` 在某条腿 connect
+  // **成功之后**才可能产出，两者互斥。支持聚合体就得对 `.errors` 与同样合法的
+  // `.cause` 都做全称量词检查，任一遗漏即 fail-open，证明责任配不上收益。
+  it.each([
+    ['全部成员都是 pre-TLS 文案', () => new AggregateError([
+      Object.assign(new Error('Client network socket disconnected before secure TLS connection was established'), { code: 'ECONNRESET' }),
+    ], '')],
+    ['混合成员（一条已送达）', () => new AggregateError([
+      Object.assign(new Error('Client network socket disconnected before secure TLS connection was established'), { code: 'ECONNRESET' }),
+      Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+    ], '')],
+    ['成员安全但 aggregate 自带不安全 cause', () => new AggregateError([
+      Object.assign(new Error('Client network socket disconnected before secure TLS connection was established'), { code: 'ECONNRESET' }),
+    ], '', { cause: Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }) })],
+    ['空 errors', () => new AggregateError([], '')],
+  ])('AggregateError（%s）的写操作一律不重试', async (_label, mk) => {
+    const h = await postWith(() => new TypeError('fetch failed', { cause: mk() }), 1);
+    await expect(h.client.postJson('/developers/v1/app_version/create/cli_x', {}))
+      .rejects.toThrow('fetch failed');
+    expect(h.attempts()).toBe(1);
+  });
+
+  it('精确文案节点自带 cause 时 fail-closed（Node 构造 ConnResetException 不挂 cause）', async () => {
+    const tampered = () => {
+      const leaf = Object.assign(
+        new Error('Client network socket disconnected before secure TLS connection was established'),
+        { code: 'ECONNRESET' },
+      );
+      (leaf as any).cause = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+      return new TypeError('fetch failed', { cause: leaf });
+    };
+    const h = await postWith(tampered, 1);
+    await expect(h.client.postJson('/developers/v1/publish/commit/cli_x/v1', {}))
+      .rejects.toThrow('fetch failed');
+    expect(h.attempts()).toBe(1);
+  });
+
+  // 运行时边界：本特判绑定 Node/undici 的错误形态。Bun 原生 fetch 对同一真实
+  // 故障（accept 后立即断）抛的是顶层 `TypeError`、message
+  // `The socket connection was closed unexpectedly...`、code=ECONNRESET、**无
+  // cause**，不满足精确文案 ⟹ 不会命中。这是**已知的跨运行时缺口**而非安全
+  // 问题（不重试 = 保持旧行为）；要覆盖 Bun 必须先为它的文案建立同等级
+  // 「只可能握手前」证明，不能只凭 code=ECONNRESET。本用例把该边界钉住，
+  // 避免日后有人误以为 Bun 路径已被覆盖。
+  it('Bun 原生 pre-TLS 错误形态（无 cause）不命中特判 —— 已知跨运行时缺口', async () => {
+    const bunShaped = () => Object.assign(
+      new TypeError('The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()'),
+      { code: 'ECONNRESET' },
+    );
+    const h = await postWith(bunShaped, 1);
+    await expect(h.client.postJson('/developers/v1/base_info/cli_x', {}))
+      .rejects.toThrow('socket connection was closed');
+    expect(h.attempts()).toBe(1);
+  });
+});
+
+// 语义幂等的 console POST（robot/event switch 设值、只读拉 Secret）与 GET/HEAD 同权
+// 认全部瞬态错误，但**预算只在 fetchRaw 这一层**。历史上这三处在外层另包了一轮
+// retry，与内层相乘成 3×3=9 次（实测 4.8s 退避）；更隐蔽的是**异构错误序列**——
+// 内层先遇 2 次 pre-TLS、第 3 次是普通 reset 时，外层看到的是普通 reset 于是又跑
+// 一轮，最坏仍能到 9。故断言各种序列下总尝试恒为 3。
+describe('语义幂等 POST 的统一重试预算（防乘法重试回归）', () => {
+  const PRE_TLS = 'Client network socket disconnected before secure TLS connection was established';
+  const preTls = () => new TypeError('fetch failed', {
+    cause: Object.assign(new Error(PRE_TLS), { code: 'ECONNRESET' }),
+  });
+  const genericReset = () => new TypeError('fetch failed', {
+    cause: Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+  });
+
+  /** 按序列逐次抛错（用尽后继续抛最后一个），返回真实发出的 POST 次数。 */
+  async function attemptsFor(
+    sequence: Array<() => Error>,
+    call: (client: OpenPlatformApiClient) => Promise<unknown>,
+  ): Promise<number> {
+    let posts = 0;
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if ((init?.method ?? 'GET').toUpperCase() === 'POST') {
+        const idx = posts;
+        posts += 1;
+        throw (sequence[idx] ?? sequence[sequence.length - 1])();
+      }
+      if (href === 'https://open.feishu.cn/app') return new Response(openPlatformPage(), { status: 200 });
+      throw new Error(`unexpected url: ${href}`);
+    }) as typeof fetch;
+    const clientResult = await createOpenPlatformApiClient([cookie()], { fetchImpl });
+    expect(clientResult.ok).toBe(true);
+    if (!clientResult.ok) throw new Error('client construction failed');
+    await expect(call(clientResult.client)).rejects.toThrow();
+    return posts;
+  }
+
+  it.each([
+    ['全部 pre-TLS', [preTls]],
+    ['全部普通 reset', [genericReset]],
+    // 这一格是真实乘法 bug 的形态：外层只按「最终错误」短路时守不住 3。
+    ['异构：pre-TLS, pre-TLS, 普通 reset…', [preTls, preTls, genericReset]],
+    ['异构：普通 reset, pre-TLS…', [genericReset, preTls]],
+  ])('postJsonIdempotent 在「%s」下总尝试恒为 3', async (_label, seq) => {
+    const posts = await attemptsFor(
+      seq,
+      client => client.postJsonIdempotent('/developers/v1/robot/switch/cli_x', { clientId: 'cli_x', enable: true }),
+    );
+    expect(posts).toBe(3);
+  });
+
+  it('普通 postJson 不因此变宽：pre-TLS 仍 3 次，普通 reset 仍 1 次', async () => {
+    expect(await attemptsFor([preTls], c => c.postJson('/developers/v1/app_version/create/cli_x', {}))).toBe(3);
+    expect(await attemptsFor([genericReset], c => c.postJson('/developers/v1/app_version/create/cli_x', {}))).toBe(1);
   });
 });
 

--- a/test/setup-pickers.test.ts
+++ b/test/setup-pickers.test.ts
@@ -94,6 +94,12 @@ function stubClient(responses: unknown[] | ((path: string, body: unknown) => unk
       calls.push({ path, body });
       return throwIfError(queue ? queue.shift() : (responses as (p: string, b: unknown) => unknown)(path, body));
     },
+    // 语义幂等的 POST（robot/event switch、读 Secret）走这条；stub 里与 postJson
+    // 同构记账，好让「调用了哪些 path」的既有断言不受实现分流影响。
+    async postJsonIdempotent(path: string, body?: unknown) {
+      calls.push({ path, body });
+      return throwIfError(queue ? queue.shift() : (responses as (p: string, b: unknown) => unknown)(path, body));
+    },
     async postForm(path: string, body: FormData) {
       calls.push({ path, body });
       return throwIfError(queue ? queue.shift() : (responses as (p: string, b: unknown) => unknown)(path, body));


### PR DESCRIPTION
## 现象

dashboard 改头像失败，并把这句原样抛给用户：

```
✗ 改头像失败：fetch failed: Client network socket disconnected before secure TLS connection was established (ECONNRESET)
```

## 根因：幂等性判据的粒度用错了

`MutableCookieJar.fetchRaw` 只让 GET/HEAD 重试瞬态网络错误，POST 一律不重试，理由写在注释里——「传输错误时服务端可能已 commit，结果未知，重试等于重复提交」。这个理由**对多数传输错误成立，但对「TLS 握手完成之前就断连」不成立**。

实测改头像链路 8 个请求，**7 个是 `attempts=1`（零重试）**，一次网络毛刺就让整轮失败：

| 步骤 | 修复前 |
|---|---|
| GET /app（csrf 页） | attempts=3 ✅ 有重试 |
| POST /app/:id（读 base_info） | attempts=1 ❌ |
| POST /visible/online | attempts=1 ❌ |
| POST /app_version/list | attempts=1 ❌ |
| POST /upload/image | attempts=1 ❌ |
| POST /base_info | attempts=1 ❌ |
| POST /app_version/create | attempts=1 ❌ |
| POST /publish/commit | attempts=1 ❌ |

## 安全性论证：为什么这一类连非幂等写都能重放

主张是「该错误可证明**目标应用的 HTTP 请求零字节送达** ⟹ 重放无重复副作用」。**这不能由「握手未完成 ⟹ 没有加密通道」推出** —— 那个说法对 TLS 1.3 并不成立（ServerHello 之后的握手消息已加密，协议还定义了 0-RTT early data）。成立的是下面这条 **Node/undici 客户端实现约束**：

1. undici 的 connector 只在 TLSSocket 的 `secureConnect` 监听器里回调（`socket.setNoDelay(true).once('secureConnect', … cb(null, this))`，`internal/deps/undici/undici` L2657-2663），HTTP client 拿到这个 socket 之后才 dispatch/write 请求；
2. 这句文案只由 `_tls_wrap.js` 的 `onConnectEnd` 产出（`ConnResetException`，L1732），该监听器建 socket 时 `prependListener('end', …)` 挂上（L1827）、在 `onConnectSecure` 里摘掉（L1724）。
   ⚠️ 源码顺序是**先** `emit('secureConnect')`（L1716）**再** `removeListener`（L1724），所以**不能**写成「先摘监听器再交给 undici」；成立的是：远端 FIN / `end` 只可能在后续 I/O 分派中被处理，而那时监听器已摘。因此这句错误产出时 `secureConnect` 监听器没有成功走完 ⟹ undici 还没拿到可 dispatch 的连接 ⟹ 应用请求行 / 头 / body 未写出；
3. Node 目前也没有让 fetch 走 TLS 0-RTT early data 的路径。

**TCP 层探针实证**：

| 场景 | 应用层字节 | 错误 |
|---|---|---|
| pre-TLS 断连（本 issue） | **0**（只收到 1583B，首字节 `0x16` = TLS ClientHello；文本内 `containsHttpVerb`/`containsPath`/`containsBody` 全 false） | `ECONNRESET` + 该文案 |
| 握手完成后才断（对照组） | **248** | `UND_ERR_SOCKET` / `other side closed` |
| 端口无人监听 | 0 | `ECONNREFUSED` |

**代理场景**：「零字节」限定为**目标应用的 HTTP 请求**——HTTP proxy 的 CONNECT 可能已发给代理，但目标 POST 尚未通过隧道发出，故「无重复副作用」结论仍成立。

### ⚠️ 只按 `code=ECONNRESET` 判定是不安全的

`ConnResetException` 有多条文案共用该 code，其中 **`socket hang up`**（`_http_client.js` 3 处）与 **`aborted`** 是在请求**已送达之后**才抛的。故判据是**整句精确匹配**，不用 `includes` / `startsWith`。

### AggregateError 一律拒绝（有意收窄）

- 真实 Node pre-TLS 断连**不是**聚合体：`net.internalConnectMultiple` 只在**所有** TCP connect 尝试失败时才构造 `NodeAggregateError`（L1128-1134，成员一律来自 `createConnectionError(…, 'connect', …)`），而这句文案要在某条腿 connect **成功之后**才可能产出，两者互斥。
- 一旦支持聚合体，就要对 `.errors` 与 `AggregateError` 同样合法的 `.cause` **同时**做全称量词检查，任一遗漏即 fail-open。实测 `new AggregateError([preTls], '', { cause: socketHangUp })` 会被放行。
- 同理，精确文案的节点**自带 cause** 时也 fail-closed：Node 构造 `ConnResetException` 不挂 cause，带了就说明不是我们证明过的那一个。

### Bun：已知的跨运行时缺口（不是安全问题）

Bun 原生 fetch 对同一真实故障（accept 后立即断）抛的是**顶层** `TypeError`、message `The socket connection was closed unexpectedly...`、`code=ECONNRESET`、**无 cause** ⟹ 不满足判据 ⟹ **不命中、不重试（保持旧行为）**。要覆盖 Bun 必须先为它的文案建立同等级的「只可能握手前」证明，不能只凭 code。已加用例把该边界钉住。

影响面参考：当前 live fleet **56 个 daemon 跑 Node、1 个跑 bun**。

## 重试预算：修掉 3×3=9 次的乘法重试

`robot/switch`、`event/switch`、读 Secret 三处原本在外层另包了一轮 `retryIdempotentOnTransientNetworkError`，与新增的 `fetchRaw` 内层退避**相乘**：

- 实测 **9 次请求、4.8s 累计退避**（每腿最坏还要等 undici 的 connect timeout）
- 更隐蔽的是**异构错误序列**：内层先遇 2 次 pre-TLS、第 3 次是普通 reset 时，只在外层按「最终错误」短路**仍守不住**——实测 **5 次**

改法：新增 `postJsonIdempotent` + `fetchRaw` 的 `opts.idempotent`。语义幂等 POST 与 GET/HEAD 同权认全部瞬态错误，但**预算只此一层**；三处外层 wrapper 删除（wrapper 随之成为死代码，一并移除）。

| 路径 | 错误序列 | 总尝试 |
|---|---|---|
| `postJsonIdempotent` | 全 pre-TLS | 3 ✅ |
| `postJsonIdempotent` | 全普通 reset | 3 ✅ |
| `postJsonIdempotent` | **异构** pre,pre,generic | 3 ✅（修前 5） |
| `postJson`（普通写） | pre-TLS | 3 |
| `postJson`（普通写） | 普通 reset | 1（不重试，行为不变） |

## 改动（3 个文件）

- `src/setup/open-platform-automation.ts`：新增 `PRE_TLS_DISCONNECT_MESSAGE` / `isProvablyUnsentTransportError()` / `postJsonIdempotent` / `fetchRaw(opts.idempotent)`；删除三处外层 wrapper 及随之死掉的 helper
- `test/setup-open-platform-automation.test.ts`：新增判据两侧 + 预算回归
- `test/setup-pickers.test.ts`：stub client 补 `postJsonIdempotent`（宽松字面量 stub，`tsc` 查不出，缺失时 2 个既有用例红）

## 影响面

改动落在共用 `fetchRaw`，波及**所有走 console 自动化的入口**：dashboard 改名 / 改头像 / 改描述、`setup` 建应用、权限自愈、VC 事件订阅检查、redirect 修复。安全性论证**与幂等性无关**（零字节送达），故对登录 / 建版等写路径同样成立；对既有「不该重试」的错误类**行为零变化**——既有那条「console POST 写操作不重试」用例（用普通 `read ECONNRESET`）**未改一字仍绿**。

## 验证

- `tsc --noEmit` 0；`bun run build` 0
- 相关 9 套件 **311 passed**；setup / dashboard / lark / open-platform / picker 宽回归 **34 文件 610 passed**
- **12 组反向变异全红**：

| 变异 | 结果 |
|---|---|
| 删 pre-TLS 写重试（回退旧行为） | 🔴 2 |
| 判据只看 `code` | 🔴 8 |
| 文案松匹配 `includes('disconnected')` | 🔴 2 |
| 文案改 `startsWith` | 🔴 1 |
| 不排除 `AbortError` | 🔴 1 |
| 不顺 cause 链 | 🔴 3 |
| 重试丢 body | 🔴 2 |
| 恢复 AggregateError `some()` | 🔴 3 |
| 精确文案带 cause 不再 fail-closed | 🔴 1 |
| `idempotent` 不透传给 `fetchRaw` | 🔴 2 |
| `idempotent` 丢掉通用瞬态错误 | 🔴 4 |
| **恢复外层乘法重试**（本轮真实 bug 形态） | 🔴 4 |

- **body 可原样重发已实测**（Node 与 Bun 各自独立 server + 自证注入生效）：`FormData` 重发收到完整字节、JSON 两次逐字相同
- **真网络 e2e**：注入一次 pre-TLS 后 POST 拿到 `OpenPlatformApiError HTTP 400` + 真实服务端 payload ⟹ 重试确实把请求送达 `open.feishu.cn`，而非只在 mock 里成立

### 过程中两处自身失误（记录以便复核）

1. 第一版「哪步没防护」探针给出 **8/8 全失败**（连该有重试的 GET 也失败）——加控制组后发现是**我编错了 fixture**（写 `visibleSuggest`，真实响应形态是 `whiteList`/`blackList`）。
2. 重跑变异时出现**一轮 11/11 全绿**——是变异 runner 把测试文件参数丢了（变量在父 shell、每次调用是新 shell），vitest 跑了默认全量集。手工复核变异 #1 立刻红。已给 runner 加自证门（必须命中「2 文件」否则判探针无效）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
