### PR TITLE
fix(trigger): no-transport 会话网关掉 routing/reminder 的 usage_silence，哨兵迁移到 http_response_mode

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -830,7 +830,7 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       return discoverClaudeFamilySessions(variant.dataDir, limit, exclude);
     },
 
-    buildArgs({ sessionId, resume, resumeSessionId, forkSession, botName, botOpenId, locale, model, disableCliBypass, skillPluginDir }) {
+    buildArgs({ sessionId, resume, resumeSessionId, forkSession, botName, botOpenId, locale, model, disableCliBypass, skillPluginDir, noTransport }) {
       const args: string[] = [];
       if (resume) {
         args.push('--resume', resumeSessionId ?? sessionId);
@@ -890,7 +890,7 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       // `claude` never surfaces/mis-fires `botmux send` etc.
       args.push('--plugin-dir', CLAUDE_PLUGIN_DIR);
       if (skillPluginDir) args.push('--plugin-dir', skillPluginDir);
-      args.push('--append-system-prompt', buildBotmuxSystemPromptText({ locale, botName, botOpenId }));
+      args.push('--append-system-prompt', buildBotmuxSystemPromptText({ locale, botName, botOpenId, noTransport }));
       return args;
     },
 

--- a/src/adapters/cli/genius.ts
+++ b/src/adapters/cli/genius.ts
@@ -102,7 +102,7 @@ export function createGeniusAdapter(pathOverride?: string): CliAdapter {
       }
     },
 
-    buildArgs({ sessionId, resume, resumeSessionId, botName, botOpenId, larkAppId, locale, model, disableCliBypass, workingDir, skillPluginDir }) {
+    buildArgs({ sessionId, resume, resumeSessionId, botName, botOpenId, larkAppId, locale, model, disableCliBypass, workingDir, skillPluginDir, noTransport }) {
       const args: string[] = [];
       if (workingDir) args.push('--add-dir', workingDir);
       if (resume) {
@@ -135,6 +135,7 @@ export function createGeniusAdapter(pathOverride?: string): CliAdapter {
         locale,
         botName,
         botOpenId,
+        noTransport,
         builtinSkillBlock: builtinSkillBlockForInjectsSessionContext(larkAppId, locale, {
           asksViaHook: false,
           whiteboardEnabled: whiteboardEnabled(),

--- a/src/adapters/cli/grok.ts
+++ b/src/adapters/cli/grok.ts
@@ -136,6 +136,7 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
       botOpenId,
       locale,
       larkAppId,
+      noTransport,
     }) {
       const args: string[] = [];
       if (!disableCliBypass) {
@@ -189,6 +190,7 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
           locale,
           botName,
           botOpenId,
+          noTransport,
           builtinSkillBlock: builtinSkillBlockForInjectsSessionContext(larkAppId, locale, {
             asksViaHook: false,
             whiteboardEnabled: whiteboardEnabled(),

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -156,8 +156,10 @@ export function buildBotmuxSystemPromptText(opts: {
    *  request/response turn has no Feishu channel and no other bots to coordinate
    *  with, so those rules are noise, and `usage_silence` in particular CONFLICTS
    *  with the per-turn <botmux_http_response_mode> ("output only the final answer").
-   *  Only the prompt-injection defense survives (still relevant: untrusted event
-   *  data rides in the same prompt). The nothing-to-send sentinel semantics live
+   *  Inside <botmux_routing> only the prompt-injection defense survives (still
+   *  relevant: untrusted event data rides in the same prompt); <identity> keeps
+   *  its name/open_id and drops only its routing_rules. The nothing-to-send
+   *  sentinel semantics live
    *  SOLELY in <botmux_http_response_mode> now (see trigger-session.ts) — do NOT
    *  reintroduce a sentinel line here. Computed daemon-side as
    *  `!larkTransportEnabled({chatId, apiOnly})` and threaded through buildArgs. */
@@ -212,10 +214,9 @@ export function buildBotmuxSystemPromptText(opts: {
   // unaffected — the `- ` prefix lives only at this composition site.
   const [heredocRule, heredocExample] = multilineHeredocLines(locale).map(escapeXmlTagLikeTokens);
   // No-transport: collapse the routing block to just the hidden-context defense.
-  // The identity block (which for a no-transport bot is usually absent anyway,
-  // and whose routing_rules are @/collaboration semantics) is left as-is — a
-  // separate block, not the confirmed usage_silence conflict; gate it only if a
-  // follow-up shows it also misleads HTTP turns.
+  // The identity block's routing_rules carry the same @/collaboration semantics
+  // and are gated on the SAME flag — see identityBlock above, which keeps the
+  // harmless name/open_id and drops only the rules.
   const routingInner = noTransport
     ? [hiddenContextDefense(locale)]
     : [

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -74,7 +74,18 @@ function hiddenContextDefense(locale?: Locale): string {
   return escapeXmlText(text);
 }
 
-export function buildBotmuxShellHints(locale?: Locale): string[] {
+export function buildBotmuxShellHints(locale?: Locale, noTransport?: boolean): string[] {
+  // No-transport session (apiOnly core-only bot OR HTTP virtual chat): drop the
+  // whole send/@/helpers/silence collaboration block — same rationale as the
+  // system-prompt path in buildBotmuxSystemPromptText. `ai.shell.when_to_send`
+  // is the shell-path twin of `ai.routing.usage_silence` and carries the same
+  // BOTMUX_NOTHING_TO_SEND sentence, which conflicts with the per-turn
+  // <botmux_http_response_mode>; the sentinel semantics live solely there now.
+  // Only the hidden-context defense survives (untrusted event data still rides
+  // in the same prompt). Whiteboard collaboration is likewise dropped.
+  if (noTransport) {
+    return [hiddenContextDefense(locale)].map(escapeXmlTagLikeTokens);
+  }
   const workflowHint = workflowDiscoveryHint(locale);
   const hints = [
     t('ai.shell.intro', undefined, locale),
@@ -140,8 +151,19 @@ export function buildBotmuxSystemPromptText(opts: {
    *  mode — appended after the routing/identity blocks. Claude Code delivers
    *  skills via --plugin-dir and passes nothing here. */
   builtinSkillBlock?: string;
+  /** No-transport session (apiOnly core-only bot OR HTTP virtual chat): the whole
+   *  send/@/helpers/silence collaboration block is dropped — a program
+   *  request/response turn has no Feishu channel and no other bots to coordinate
+   *  with, so those rules are noise, and `usage_silence` in particular CONFLICTS
+   *  with the per-turn <botmux_http_response_mode> ("output only the final answer").
+   *  Only the prompt-injection defense survives (still relevant: untrusted event
+   *  data rides in the same prompt). The nothing-to-send sentinel semantics live
+   *  SOLELY in <botmux_http_response_mode> now (see trigger-session.ts) — do NOT
+   *  reintroduce a sentinel line here. Computed daemon-side as
+   *  `!larkTransportEnabled({chatId, apiOnly})` and threaded through buildArgs. */
+  noTransport?: boolean;
 }): string {
-  const { locale, botName, botOpenId, builtinSkillBlock } = opts;
+  const { locale, botName, botOpenId, builtinSkillBlock, noTransport } = opts;
   const unknown = t('ai.identity.unknown', undefined, locale);
   const workflowHint = workflowDiscoveryHint(locale);
   const prose = (key: string): string =>
@@ -175,26 +197,36 @@ export function buildBotmuxSystemPromptText(opts: {
   // i18n key stays bullet-free so the paragraph-style shell-hints path is
   // unaffected — the `- ` prefix lives only at this composition site.
   const [heredocRule, heredocExample] = multilineHeredocLines(locale).map(escapeXmlTagLikeTokens);
+  // No-transport: collapse the routing block to just the hidden-context defense.
+  // The identity block (which for a no-transport bot is usually absent anyway,
+  // and whose routing_rules are @/collaboration semantics) is left as-is — a
+  // separate block, not the confirmed usage_silence conflict; gate it only if a
+  // follow-up shows it also misleads HTTP turns.
+  const routingInner = noTransport
+    ? [hiddenContextDefense(locale)]
+    : [
+      prose('ai.routing.intro'),
+      '',
+      prose('ai.routing.usage_send'),
+      `- ${heredocRule}`,
+      heredocExample,
+      prose('ai.routing.usage_mention_gate'),
+      prose('ai.routing.usage_attachments'),
+      prose('ai.routing.usage_helpers'),
+      prose('ai.routing.usage_silence'),
+      escapeXmlTagLikeTokens(feedbackResponseKindHint(locale)),
+      // Experimental anti-resend guidance — opt-in via dashboard Settings
+      // (dashboard.noVisibleOutputHint). Default OFF ⇒ this block is byte-for-byte
+      // the pre-feature baseline. Live-read so a toggle applies to the next session.
+      ...(noVisibleOutputHintOn() ? [prose('ai.routing.no_visible_output_ok')] : []),
+      // Workflow discovery — omitted when the machine-wide workflow switch is off.
+      ...(workflowHint ? [escapeXmlTagLikeTokens(workflowHint)] : []),
+      hiddenContextDefense(locale),
+      ...whiteboardRouting,
+    ];
   return [
     '<botmux_routing>',
-    prose('ai.routing.intro'),
-    '',
-    prose('ai.routing.usage_send'),
-    `- ${heredocRule}`,
-    heredocExample,
-    prose('ai.routing.usage_mention_gate'),
-    prose('ai.routing.usage_attachments'),
-    prose('ai.routing.usage_helpers'),
-    prose('ai.routing.usage_silence'),
-    escapeXmlTagLikeTokens(feedbackResponseKindHint(locale)),
-    // Experimental anti-resend guidance — opt-in via dashboard Settings
-    // (dashboard.noVisibleOutputHint). Default OFF ⇒ this block is byte-for-byte
-    // the pre-feature baseline. Live-read so a toggle applies to the next session.
-    ...(noVisibleOutputHintOn() ? [prose('ai.routing.no_visible_output_ok')] : []),
-    // Workflow discovery — omitted when the machine-wide workflow switch is off.
-    ...(workflowHint ? [escapeXmlTagLikeTokens(workflowHint)] : []),
-    hiddenContextDefense(locale),
-    ...whiteboardRouting,
+    ...routingInner,
     '</botmux_routing>',
     ...identityBlock,
     ...(builtinSkillBlock ? ['', builtinSkillBlock] : []),

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -168,6 +168,16 @@ export function buildBotmuxSystemPromptText(opts: {
   const workflowHint = workflowDiscoveryHint(locale);
   const prose = (key: string): string =>
     escapeXmlTagLikeTokens(t(key, undefined, locale));
+  // identity carries the bot's name/open_id PLUS routing_rules that are the same
+  // @/collaboration/silence semantics gated out of routingInner above. For a
+  // no-transport session these routing_rules are noise and `rule_silent_when_other`
+  // has slight tension with http_response_mode — so drop the rules but KEEP the
+  // name/open_id (a program task may legitimately reference who it is; those are
+  // harmless facts, not collaboration directives). NOTE: `botName`/`botOpenId` are
+  // passed unconditionally from cfg (worker.ts) even for a NORMAL bot serving an
+  // HTTP task (R1) — so this block IS injected there; gating only routingInner
+  // would leave the same @-rules leaking via identity. Mirrors the session-manager
+  // non-injects path (short_routing) which is gated the same way.
   const identityBlock =
     botName || botOpenId
       ? [
@@ -175,13 +185,17 @@ export function buildBotmuxSystemPromptText(opts: {
         '<identity>',
         `  <name>${botName ?? unknown}</name>`,
         `  <open_id>${botOpenId ?? unknown}</open_id>`,
-        '  <routing_rules>',
-        `    ${prose('ai.identity.routing_intro')}`,
-        `    ${prose('ai.identity.rule_own_part')}`,
-        `    ${prose('ai.identity.rule_silent_when_other')}`,
-        `    ${prose('ai.identity.rule_no_proactive_pull')}`,
-        `    ${prose('ai.identity.mention_must')}`,
-        '  </routing_rules>',
+        ...(noTransport
+          ? []
+          : [
+            '  <routing_rules>',
+            `    ${prose('ai.identity.routing_intro')}`,
+            `    ${prose('ai.identity.rule_own_part')}`,
+            `    ${prose('ai.identity.rule_silent_when_other')}`,
+            `    ${prose('ai.identity.rule_no_proactive_pull')}`,
+            `    ${prose('ai.identity.mention_must')}`,
+            '  </routing_rules>',
+          ]),
         '</identity>',
       ]
       : [];

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -144,6 +144,16 @@ export interface CliAdapter {
      *  their per-bot built-in skill injection mode for the system-prompt catalog;
      *  inline-prompt CLIs get theirs from session-manager instead. */
     larkAppId?: string;
+    /** No-transport session (apiOnly core-only bot OR HTTP virtual chat, i.e.
+     *  `!larkTransportEnabled({chatId, apiOnly})`). injectsSessionContext adapters
+     *  that build the routing block via `buildBotmuxSystemPromptText`
+     *  (claude-code / genius / grok) forward this so the send/@/silence
+     *  collaboration block is dropped for a program request/response turn — where
+     *  it is both noise and (for usage_silence) a conflict with the per-turn
+     *  <botmux_http_response_mode>. Non-injects CLIs get the same gate via
+     *  session-manager's buildBotmuxShellHints. Adapters without a routing block
+     *  ignore it. */
+    noTransport?: boolean;
     /** UI / response language for prompts injected into the CLI (e.g. zh / en). */
     locale?: import('../../i18n/index.js').Locale;
     /** Optional model name from BotConfig.model. Adapters whose CLI accepts a

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -948,7 +948,7 @@ export function ensureSessionWhiteboard(ds: DaemonSession): void {
   }
 }
 
-function renderWhiteboardBlock(opts?: { whiteboardId?: string }): string {
+function renderWhiteboardBlock(opts?: { whiteboardId?: string; noTransport?: boolean }): string {
   if (!whiteboardEnabled() || !opts?.whiteboardId) return '';
   const meta = getWhiteboard(opts.whiteboardId);
   if (!meta || meta.archived) return '';
@@ -959,7 +959,13 @@ function renderWhiteboardBlock(opts?: { whiteboardId?: string }): string {
     escapeXmlTagLikeTokens('更新状态：`botmux whiteboard update --id ' + id + ' --expected-updated-at <上次 read 的 updatedAt> <内容>`。'),
     '更新前先用 `read --json` 拿到当前内容与 updatedAt，融合新信息后整体重写为一份完整的当前状态（默认中文；代码标识/命令/错误信息可保留原文），并用 `--expected-updated-at` 回传 read 到的版本号做并发冲突检测。',
     '若更新报 `whiteboard_cas_mismatch`，说明期间有其它 agent 改过白板——重新 `read --json` 拿最新内容与 updatedAt，再次融合重写。',
-    '不要直接读写本地文件；不要写密钥/隐私；用户可见结论仍必须 `botmux send`。',
+    // no-transport（apiOnly bot / HTTP 虚拟会话）：末句的「仍必须 botmux send」是本 PR
+    // 要消除的那条矛盾指令的又一个出口——send 在这类会话里被 assertTurnTransportOrExit
+    // 硬拦（exit 2），而 <botmux_http_response_mode> 又明说不要 send。白板块在首轮与
+    // 续轮都无条件注入，所以这里必须同样 gate；隐私/本地文件两条与传输无关，保留。
+    opts.noTransport
+      ? '不要直接读写本地文件；不要写密钥/隐私。'
+      : '不要直接读写本地文件；不要写密钥/隐私；用户可见结论仍必须 `botmux send`。',
     '</whiteboard>',
   ].join('\n');
 }
@@ -1154,7 +1160,10 @@ export function buildNewTopicPrompt(
   }
 
   const roleBlock = renderRoleContextBlock(opts?.larkAppId, opts?.chatId);
-  const whiteboardBlock = renderWhiteboardBlock({ whiteboardId: opts?.whiteboardId });
+  const whiteboardBlock = renderWhiteboardBlock({
+    whiteboardId: opts?.whiteboardId,
+    noTransport: sessionIsNoTransport(opts?.larkAppId, opts?.chatId),
+  });
   const summaryMemoryBlock = renderSummaryMemoryBlock(opts?.larkAppId);
   const chatContextPolicyBlock = renderChatContextPolicyBlock(opts?.chatContext, locale);
   const chatContextBlock = renderChatContextBlock(opts?.chatContext);
@@ -1255,7 +1264,10 @@ export function buildNewTopicCliInput(
   // clean input when the caller also preserved their matching raw texts.
   if (cliId !== 'codex-app' || (followUps && followUps.length > 0 && !opts?.codexAppFollowUps)) return { content };
   const roleBlock = renderRoleContextBlock(opts?.larkAppId, opts?.chatId);
-  const whiteboardBlock = renderWhiteboardBlock({ whiteboardId: opts?.whiteboardId });
+  const whiteboardBlock = renderWhiteboardBlock({
+    whiteboardId: opts?.whiteboardId,
+    noTransport: sessionIsNoTransport(opts?.larkAppId, opts?.chatId),
+  });
   const summaryMemoryBlock = renderSummaryMemoryBlock(opts?.larkAppId);
   const senderBlock = renderSenderTag(sender, opts?.larkAppId);
   const substitutePolicyBlock = renderSubstitutePolicy(opts?.substituteTrigger);
@@ -1332,7 +1344,10 @@ function buildFollowUpBlocks(
 ): Array<{ key: FollowUpBlockKey; text: string }> {
   const blocks: Array<{ key: FollowUpBlockKey; text: string }> = [];
   const roleBlock = renderRoleContextBlock(opts?.larkAppId, opts?.chatId, { followUp: true });
-  const whiteboardBlock = renderWhiteboardBlock({ whiteboardId: opts?.whiteboardId });
+  const whiteboardBlock = renderWhiteboardBlock({
+    whiteboardId: opts?.whiteboardId,
+    noTransport: sessionIsNoTransport(opts?.larkAppId, opts?.chatId),
+  });
   const summaryMemoryBlock = renderSummaryMemoryBlock(opts?.larkAppId);
   const skipSessionId = opts?.isAdoptMode || (opts?.cliId
     ? createCliAdapterSync(opts.cliId, opts.cliPathOverride).injectsSessionContext
@@ -1527,7 +1542,10 @@ export function buildFollowUpCliInput(
   const legacyContent = buildFollowUpContent(content, sessionId, opts);
   if (opts?.cliId !== 'codex-app' || opts.isAdoptMode) return { content: legacyContent };
   const roleBlock = renderRoleContextBlock(opts.larkAppId, opts.chatId, { followUp: true });
-  const whiteboardBlock = renderWhiteboardBlock({ whiteboardId: opts.whiteboardId });
+  const whiteboardBlock = renderWhiteboardBlock({
+    whiteboardId: opts.whiteboardId,
+    noTransport: sessionIsNoTransport(opts.larkAppId, opts.chatId),
+  });
   const summaryMemoryBlock = renderSummaryMemoryBlock(opts.larkAppId);
   const senderBlock = renderSenderTag(opts.sender, opts.larkAppId);
   const substitutePolicyBlock = renderSubstitutePolicy(opts.substituteTrigger);

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -66,6 +66,7 @@ import {
   sessionKey,
   sessionAnchorId,
   storedSessionAnchorId,
+  larkTransportEnabled,
 } from './types.js';
 import type { DaemonSession } from './types.js';
 import { stagePendingRepoSetup, persistPendingRepoCardMessageId, restorePendingRepoRuntime } from './pending-repo-journal.js';
@@ -1064,6 +1065,22 @@ function buildCodexAppTurnInput(opts: {
   };
 }
 
+/** No-transport session predicate for prompt assembly: apiOnly core-only bot OR
+ *  HTTP virtual chat (`http_async_*` / `http_wait_*`). When true the send/@/
+ *  silence collaboration routing block is dropped — a program request/response
+ *  turn has no Feishu channel, and `usage_silence` in particular CONFLICTS with
+ *  the per-turn <botmux_http_response_mode>. Bot lookup is best-effort: an
+ *  unknown/unloaded larkAppId can't prove apiOnly, so we fall back to the chatId
+ *  test alone (an http-virtual chat is no-transport regardless of bot config). */
+function sessionIsNoTransport(larkAppId?: string, chatId?: string): boolean {
+  if (!chatId) return false;
+  let apiOnly: boolean | undefined;
+  if (larkAppId) {
+    try { apiOnly = getBot(larkAppId).config.apiOnly; } catch { apiOnly = undefined; }
+  }
+  return !larkTransportEnabled({ chatId, apiOnly });
+}
+
 export function buildNewTopicPrompt(
   userMessage: string,
   sessionId: string,
@@ -1086,7 +1103,11 @@ export function buildNewTopicPrompt(
   // (Claude Code builds its own via --append-system-prompt). Source hints
   // freshly from i18n so they respect the resolved locale instead of the
   // static `adapter.systemHints` array that was baked at module load.
-  const hints = adapter.injectsSessionContext ? [] : buildBotmuxShellHints(locale);
+  // No-transport sessions (apiOnly bot / HTTP virtual chat) get the collapsed
+  // hints (hidden-context defense only) — same gate as buildBotmuxSystemPromptText.
+  const hints = adapter.injectsSessionContext
+    ? []
+    : buildBotmuxShellHints(locale, sessionIsNoTransport(opts?.larkAppId, opts?.chatId));
 
   const routingBlock = hints.length > 0
     ? `<botmux_routing>\n${hints.join('\n')}\n</botmux_routing>`
@@ -1326,9 +1347,19 @@ function buildFollowUpBlocks(
     // applies to the next follow-up turn without a daemon restart.
     // hook 模式（#794）：reminder 经 system-reminder 离带注入，命令式措辞可能触发
     // 模型的注入防御被表面化，改用描述式的 reminder_hook。
-    const reminderKey = hookMode
-      ? 'ai.followup.reminder_hook'
-      : config.noVisibleOutputHint ? 'ai.followup.reminder_no_resend' : 'ai.followup.reminder';
+    //
+    // No-transport 续轮（apiOnly bot / HTTP 虚拟会话）：换成不含 send/@/哨兵的极简
+    // 提示（reminder_no_transport）。★ 这个判定必须落在 KEY 选择这一步、而非 inline
+    // 组装处：buildFollowUpCliInput 的 hook 模式（resolveEnvelopeInjectionMode==='hook'）
+    // 同样调本函数、但把 reminder 走 per-turn sidecar；只在 inline 分支 gate 会让 hook
+    // 模式的续轮 reminder 从 sidecar 漏出去。哨兵语义只在本轮内容的
+    // <botmux_http_response_mode> 出现一次（迁移不删，#808 async settle 依赖它）。
+    const noTransport = sessionIsNoTransport(opts?.larkAppId, opts?.chatId);
+    const reminderKey = noTransport
+      ? 'ai.followup.reminder_no_transport'
+      : hookMode
+        ? 'ai.followup.reminder_hook'
+        : config.noVisibleOutputHint ? 'ai.followup.reminder_no_resend' : 'ai.followup.reminder';
     const reminder = t(reminderKey, undefined, opts?.locale);
     blocks.push({ key: 'reminder', text: `<botmux_reminder>${reminder}</botmux_reminder>` });
   }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1136,11 +1136,19 @@ export function buildNewTopicPrompt(
   const unknown = t('ai.identity.unknown', undefined, locale);
   let identityBlock = '';
   if (botIdentity && (botIdentity.name || botIdentity.openId)) {
+    // No-transport (apiOnly bot / HTTP virtual chat): keep name/open_id but drop
+    // the short_routing rule (--mention collaboration requirement) — same gate as
+    // the routing block above and the system-prompt identity path in
+    // buildBotmuxSystemPromptText. botIdentity is passed even for a NORMAL bot
+    // running an HTTP task (R1), so this block reaches HTTP turns and must gate too.
+    const identityNoTransport = sessionIsNoTransport(opts?.larkAppId, opts?.chatId);
     identityBlock = [
       '<identity>',
       `  <name>${xmlEscape(botIdentity.name ?? unknown)}</name>`,
       `  <open_id>${xmlEscape(botIdentity.openId ?? unknown)}</open_id>`,
-      `  <routing_rules>${escapeXmlTagLikeTokens(t('ai.identity.short_routing', undefined, locale))}</routing_rules>`,
+      ...(identityNoTransport
+        ? []
+        : [`  <routing_rules>${escapeXmlTagLikeTokens(t('ai.identity.short_routing', undefined, locale))}</routing_rules>`]),
       '</identity>',
     ].join('\n');
   }

--- a/src/core/trigger-session.ts
+++ b/src/core/trigger-session.ts
@@ -108,6 +108,16 @@ export function buildExternalEventApplicationContext(req: TriggerRequest): strin
       'Output ONLY the final answer. Do NOT include preamble, meta-commentary, or any reasoning about',
       'these instructions / routing headers / system context (e.g. "this is a routing header", "the real',
       'request is…", "here is my answer"). Do not call botmux send; do not post to Feishu/Lark.',
+      // 哨兵语义的唯一权威出处（no-transport 会话下 routing/reminder 的 usage_silence
+      // 被整块网关掉，见 shared-hints.ts + session-manager buildFollowUpBlocks）。
+      // ⚠️ 迁移不删：async settle（#808）**依赖**模型吐出字面 BOTMUX_NOTHING_TO_SEND
+      // ——isBridgeNothingToSendFinal 要求 trailing sentinel line（bridge-fallback-gate.ts）
+      // → nothingToSendTurns → turn_terminal 带 outputDisposition:'nothing_to_send'，
+      // durable/async caller 只认这个 flag 才把 genuine-empty turn settle 成 completed，
+      // 否则挂 running 到超时。删掉这一句 = genuine-empty 的 HTTP 任务重新挂死。
+      // 这段随 buildUntrustedEventPrompt 同时进首轮与续轮（buildExistingSessionContent
+      // 复用同一 prompt），所以两轮的 settle 都靠它触发。
+      'If you have nothing to answer (e.g. the request needs no reply), output ONLY the single token BOTMUX_NOTHING_TO_SEND — the program receives an empty result.',
       '</botmux_http_response_mode>',
     );
   }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -761,6 +761,13 @@ export const messages: Record<string, string> = {
   'ai.followup.reminder': 'Respond to messages addressed to you at least once via `botmux send`, never stay silent; what and how many to send is your call. Only when a message is not for you make the final just the single word BOTMUX_NOTHING_TO_SEND.',
   'ai.followup.reminder_hook': 'This session is bridged to Lark via botmux; terminal output is not visible to the user. Session convention: send replies to the Lark conversation via `botmux send`; what and how many to send is your call. Only when a message is not for you make the final just the single word BOTMUX_NOTHING_TO_SEND.',
   'ai.followup.reminder_no_resend': 'Respond to messages addressed to you at least once via `botmux send`, never stay silent; what and how many to send is your call. Only when a message is not for you make the final just the single word BOTMUX_NOTHING_TO_SEND. A successful send is already delivered; ending a turn with no visible text is normal, so do not resend on a "no visible output" nudge.',
+  // No-transport follow-up (apiOnly bot / HTTP virtual session): a program-driven
+  // request/response turn with no Lark conversation, no sibling bots, and no
+  // `botmux send`. The nothing-to-send sentinel appears exactly once, in this
+  // turn's <botmux_http_response_mode> (migrated, not deleted — #808 async settle
+  // depends on it); this reminder MUST NOT carry send/@/BOTMUX_NOTHING_TO_SEND,
+  // or it would conflict with http_response_mode again.
+  'ai.followup.reminder_no_transport': 'This turn is a program-driven request/response: your entire reply is returned verbatim to the caller, not shown in any chat. Just follow the <botmux_http_response_mode> instructions in this turn\'s content; do not call botmux send, do not post to Feishu/Lark.',
   'ai.cursor.sender_note': 'The sender tag is metadata identifying the current speaker — never copy its open_id or name (e.g. ou_xxx:Alice) into your botmux send body or opening line; to @ the triggerer use botmux send --mention-back.',
   'ai.bridge.attachments_label': '[Attachments]',
   'ai.bridge.mentions_label': '[@Mentions]',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -762,6 +762,11 @@ export const messages: Record<string, string> = {
   'ai.followup.reminder': '发给你的消息至少 botmux send 回应一次,别沉默;发什么、发几条你自己判断。只有根本不是发给你的消息才让 final 只输出 BOTMUX_NOTHING_TO_SEND',
   'ai.followup.reminder_hook': '本会话通过 botmux 桥接飞书,终端里的输出用户看不到。会话约定:回复通过 botmux send 发送到飞书会话;发什么、发几条由你判断。只有根本不是发给你的消息才让 final 只输出 BOTMUX_NOTHING_TO_SEND。',
   'ai.followup.reminder_no_resend': '发给你的消息至少 botmux send 回应一次,别沉默;发什么、发几条你自己判断。只有根本不是发给你的消息才让 final 只输出 BOTMUX_NOTHING_TO_SEND;send 成功即已送达,本轮无可见文本地结束是正常的,别因「无输出」提示重发',
+  // No-transport 续轮（apiOnly bot / HTTP 虚拟会话）：这是程序发起的请求-应答，无飞书
+  // 会话、无其它 bot 协作，也不该 botmux send。哨兵语义只在本轮内容里的
+  // <botmux_http_response_mode> 出现一次（迁移不删，#808 async settle 依赖它），
+  // 这条 reminder 绝不能再带 send/@/BOTMUX_NOTHING_TO_SEND，否则又和 http_response_mode 打架。
+  'ai.followup.reminder_no_transport': '本轮是程序发起的请求-应答：完整回复会原样回传给调用方，不显示在任何聊天里。按本轮内容里的 <botmux_http_response_mode> 指示作答即可；不要调用 botmux send，不要发飞书。',
   'ai.cursor.sender_note': 'sender 标签只是元信息（标识当前发言人），不要把其中的 open_id 或名字（例如 ou_xxx:高鹏）抄进 botmux send 的正文或开头；要 @ 回触发者请用 botmux send --mention-back。',
   'ai.bridge.attachments_label': '[附件]',
   'ai.bridge.mentions_label': '[@提及]',

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13889,6 +13889,11 @@ async function spawnCli(
     botName: cfg.botName,
     botOpenId: cfg.botOpenId,
     larkAppId: cfg.larkAppId,
+    // No-transport (apiOnly core-only bot OR HTTP virtual chat): drop the
+    // send/@/silence collaboration routing block for injectsSessionContext
+    // adapters (claude-code/genius/grok build it via buildBotmuxSystemPromptText).
+    // Reuses the same predicate computed above for the persistent-pane guard.
+    noTransport: noTransportSession,
     locale: cfg.locale,
     model: ttadkGateway ? undefined : cfg.model,
     // dsh runner only; other adapters ignore the field.

--- a/test/bridge-input.test.ts
+++ b/test/bridge-input.test.ts
@@ -4,7 +4,25 @@
  * unaware) — it must not see <session_id>, <botmux_reminder>, or any "use
  * botmux send" hints.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// Whiteboard is opt-in (global config, default OFF), so the <whiteboard> block
+// would never render here and the no-transport whiteboard-gate cases below would
+// pass VACUOUSLY. Force it on — and note those cases assert the baseline (real
+// Feishu session) DOES carry the send directive, so a broken gate actually fails.
+vi.mock('../src/services/whiteboard-store.js', () => ({
+  whiteboardEnabled: vi.fn(() => true),
+  getWhiteboard: vi.fn((id: string) => ({
+    id,
+    title: 'Whiteboard: repo',
+    scope: 'project',
+    createdAt: '2026-08-30T00:00:00.000Z',
+    updatedAt: '2026-08-30T00:00:00.000Z',
+  })),
+  ensureDefaultWhiteboard: vi.fn(),
+  whiteboardBoardPath: vi.fn((id: string) => `/tmp/test-sessions/whiteboards/${id}/board.md`),
+}));
+
 import { buildBridgeInputContent, buildFollowUpContent, buildNewTopicPrompt } from '../src/core/session-manager.js';
 import type { LarkAttachment, LarkMention } from '../src/types.js';
 
@@ -192,5 +210,54 @@ describe('buildBridgeInputContent', () => {
     );
     expect(out).toContain('<routing_rules>');
     expect(out).toContain('botmux send --mention');
+  });
+  // ── no-transport whiteboard gate (#1098 follow-up): the <whiteboard> block's
+  //    last line carried「用户可见结论仍必须 `botmux send`」unconditionally, which is
+  //    the SAME conflicting directive this PR removes from routing/reminder —
+  //    `botmux send` is hard-refused in these sessions (assertTurnTransportOrExit
+  //    → exit 2) while <botmux_http_response_mode> says not to send. The block is
+  //    injected on BOTH the first turn and follow-ups, so both must be gated. The
+  //    privacy / no-local-file rules are transport-independent and must SURVIVE.
+  it('drops the whiteboard send directive for a no-transport session, keeps the privacy rules', () => {
+    const followUp = buildFollowUpContent('hi', 'sid-wb', {
+      isAdoptMode: false,
+      cliId: 'codex',
+      chatId: 'http_async_wb',
+      whiteboardId: 'wb-1',
+    });
+    const firstTurn = buildNewTopicPrompt(
+      'hi', 'sid-wb2', 'codex', undefined, undefined, undefined, undefined, undefined,
+      undefined, 'zh', undefined,
+      { larkAppId: 'app-wb', chatId: 'http_async_wb', whiteboardId: 'wb-1' },
+    );
+    for (const out of [followUp, firstTurn]) {
+      // The whiteboard block itself is still delivered (it is real, usable context)…
+      expect(out).toContain('<whiteboard id="wb-1">');
+      expect(out).toContain('botmux whiteboard read');
+      // …but its trailing line no longer ORDERS a send. Assert on the block itself:
+      // the no-transport reminder legitimately contains「不要调用 botmux send」(a
+      // prohibition), so a prompt-wide `not.toContain('botmux send')` would match
+      // that and fail for the wrong reason.
+      const wb = /<whiteboard id="wb-1">([\s\S]*?)<\/whiteboard>/.exec(out)?.[1] ?? '';
+      expect(wb).not.toContain('botmux send');
+      // Transport-independent rules survive inside the block.
+      expect(wb).toContain('不要写密钥/隐私');
+      expect(wb).toContain('不要直接读写本地文件');
+    }
+  });
+
+  it('keeps the whiteboard send directive for a real Feishu session (baseline has discriminating power)', () => {
+    const out = buildFollowUpContent('hi', 'sid-wb3', {
+      isAdoptMode: false,
+      cliId: 'codex',
+      chatId: 'oc_realchat',
+      whiteboardId: 'wb-1',
+    });
+    expect(out).toContain('<whiteboard id="wb-1">');
+    // Guards the negative: without the gate this line is present INSIDE the block,
+    // so the assertion above can actually fail if the gate is reverted. Scoped to
+    // the block for the same reason (a prompt-wide match would hit the reminder).
+    const wb = /<whiteboard id="wb-1">([\s\S]*?)<\/whiteboard>/.exec(out)?.[1] ?? '';
+    expect(wb).toContain('botmux send');
   });
 });

--- a/test/bridge-input.test.ts
+++ b/test/bridge-input.test.ts
@@ -5,7 +5,7 @@
  * botmux send" hints.
  */
 import { describe, it, expect } from 'vitest';
-import { buildBridgeInputContent, buildFollowUpContent } from '../src/core/session-manager.js';
+import { buildBridgeInputContent, buildFollowUpContent, buildNewTopicPrompt } from '../src/core/session-manager.js';
 import type { LarkAttachment, LarkMention } from '../src/types.js';
 
 describe('buildBridgeInputContent', () => {
@@ -165,5 +165,32 @@ describe('buildBridgeInputContent', () => {
     });
     expect(out).toContain('<botmux_reminder>');
     expect(out).toContain('BOTMUX_NOTHING_TO_SEND');
+  });
+
+  // ── no-transport identity gate (质量①, codex #1098 review): the non-injects
+  //    first-turn <identity> block carries short_routing (the --mention collab
+  //    requirement). For an HTTP virtual session it must keep name/open_id but
+  //    drop routing_rules — botIdentity reaches HTTP turns even for a normal bot.
+  it('drops the identity routing_rules for an HTTP virtual first turn, keeps name/open_id', () => {
+    const out = buildNewTopicPrompt(
+      'hi', 'sid-http', 'codex', undefined, undefined, undefined, undefined, undefined,
+      { name: 'MyBot', openId: 'ou_abc' }, 'en', undefined,
+      { larkAppId: 'app1', chatId: 'http_async_x' },
+    );
+    expect(out).toContain('<identity>');
+    expect(out).toContain('<name>MyBot</name>');
+    expect(out).toContain('<open_id>ou_abc</open_id>');
+    expect(out).not.toContain('<routing_rules>');
+    expect(out).not.toContain('botmux send'); // no --mention directive leaks
+  });
+
+  it('keeps the identity routing_rules for a real Feishu first turn', () => {
+    const out = buildNewTopicPrompt(
+      'hi', 'sid-real', 'codex', undefined, undefined, undefined, undefined, undefined,
+      { name: 'MyBot', openId: 'ou_abc' }, 'en', undefined,
+      { larkAppId: 'app1', chatId: 'oc_realchat' },
+    );
+    expect(out).toContain('<routing_rules>');
+    expect(out).toContain('botmux send --mention');
   });
 });

--- a/test/bridge-input.test.ts
+++ b/test/bridge-input.test.ts
@@ -131,4 +131,39 @@ describe('buildBridgeInputContent', () => {
     // baseline: confirms the test for buildBridgeInputContent is meaningful
     expect(out).toContain('botmux_reminder');
   });
+
+  // ── no-transport follow-up reminder (质量①, 3rd injection site): an HTTP
+  //    virtual session (http_async_*/http_wait_*) — the follow-up path #71's
+  //    turnIdempotencyKey opens — must NOT get the send/@/silence reminder, which
+  //    carries the BOTMUX_NOTHING_TO_SEND sentence that conflicts with the
+  //    per-turn <botmux_http_response_mode>. The chatId test alone proves
+  //    no-transport (no bot lookup needed), so this works without a registry mock.
+  it('swaps the follow-up reminder to the no-transport variant for an HTTP virtual session', () => {
+    const out = buildFollowUpContent('hi', 'sid-http', {
+      isAdoptMode: false,
+      cliId: 'codex',
+      chatId: 'http_async_abc123',
+    });
+    // Reminder block is still present…
+    expect(out).toContain('<botmux_reminder>');
+    // …but carries NO sentinel semantics (the conflict we removed) and no
+    // "reply via botmux send" directive. It only *prohibits* send (为程序任务防止
+    // 误发飞书), which is a negative instruction — assert the sentinel + the
+    // positive "respond via send" phrasing are gone, not the bare token.
+    expect(out).not.toContain('BOTMUX_NOTHING_TO_SEND');
+    expect(out).not.toContain('回应一次'); // zh "respond at least once via send"
+    expect(out).toContain('不要调用 botmux send'); // explicit prohibition retained
+    // It points the model at the per-turn http_response_mode block instead.
+    expect(out).toContain('botmux_http_response_mode');
+  });
+
+  it('keeps the standard reminder (with sentinel) for a real Feishu follow-up', () => {
+    const out = buildFollowUpContent('hi', 'sid-real', {
+      isAdoptMode: false,
+      cliId: 'codex',
+      chatId: 'oc_realchat',
+    });
+    expect(out).toContain('<botmux_reminder>');
+    expect(out).toContain('BOTMUX_NOTHING_TO_SEND');
+  });
 });

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -285,6 +285,24 @@ describe('claude-code buildArgs', () => {
     expect(sys).toContain('</botmux_routing>');
   });
 
+  it('keeps identity name/open_id but drops the @-collaboration routing_rules for no-transport', () => {
+    // codex #1098 review: identityBlock carries the same @/silence/collaboration
+    // semantics as routingInner and IS injected even for a NORMAL bot on an HTTP
+    // task (botName/botOpenId passed unconditionally, R1). Gate it too — keep the
+    // harmless name/open_id facts, drop only the routing_rules.
+    const on = buildBotmuxSystemPromptText({ locale: 'en', botName: 'Bot', botOpenId: 'ou_x', noTransport: true });
+    expect(on).toContain('<identity>');
+    expect(on).toContain('<name>Bot</name>');
+    expect(on).toContain('<open_id>ou_x</open_id>');
+    expect(on).not.toContain('<routing_rules>');
+    expect(on).not.toContain('MUST');       // mention_must gone
+    expect(on).not.toContain('botmux send'); // no --mention directive anywhere
+    // Transport-enabled keeps the full identity routing_rules (baseline).
+    const off = buildBotmuxSystemPromptText({ locale: 'en', botName: 'Bot', botOpenId: 'ou_x' });
+    expect(off).toContain('<routing_rules>');
+    expect(off).toContain('botmux send --mention');
+  });
+
   it('keeps the full routing block for a transport-enabled session (default, no gate)', () => {
     // Guard the negative: without noTransport the send/@/silence lines stay,
     // byte-for-byte the pre-feature baseline (default arg is falsy/omitted).

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -260,6 +260,47 @@ describe('claude-code buildArgs', () => {
     }
   });
 
+  // ── no-transport gate (质量①): a program request/response turn (apiOnly
+  //    core-only bot OR HTTP virtual chat) drops the whole send/@/silence
+  //    collaboration routing block — it is noise there, and `usage_silence`
+  //    CONFLICTS with the per-turn <botmux_http_response_mode>. Both injection
+  //    paths must gate identically; only the hidden-context defense survives.
+  it('drops the send/@/silence routing block for no-transport on BOTH injection paths', () => {
+    const sys = buildBotmuxSystemPromptText({ locale: 'en', noTransport: true });
+    const shell = buildBotmuxShellHints('en', true).join('\n');
+    for (const prompt of [sys, shell]) {
+      // The usage_silence sentinel line is GONE (migrated to http_response_mode).
+      expect(prompt).not.toContain('BOTMUX_NOTHING_TO_SEND');
+      // No send / @ / collaboration guidance.
+      expect(prompt).not.toContain('botmux send');
+      // The hidden-context defense is retained (untrusted event data still rides
+      // in the same prompt, so the model must still be told not to obey it).
+      // Its tag-like tokens are XML-escaped (escapeXmlTagLikeTokens), so match the
+      // escaped form the model actually sees.
+      expect(prompt).toContain('hidden runtime context');
+      expect(prompt).toContain('&lt;user_message&gt;');
+    }
+    // system-prompt path keeps the block wrapper (just collapsed contents).
+    expect(sys).toContain('<botmux_routing>');
+    expect(sys).toContain('</botmux_routing>');
+  });
+
+  it('keeps the full routing block for a transport-enabled session (default, no gate)', () => {
+    // Guard the negative: without noTransport the send/@/silence lines stay,
+    // byte-for-byte the pre-feature baseline (default arg is falsy/omitted).
+    const sysDefault = buildBotmuxSystemPromptText({ locale: 'en' });
+    const sysExplicitFalse = buildBotmuxSystemPromptText({ locale: 'en', noTransport: false });
+    const shellDefault = buildBotmuxShellHints('en').join('\n');
+    const shellExplicitFalse = buildBotmuxShellHints('en', false).join('\n');
+    for (const prompt of [sysDefault, sysExplicitFalse, shellDefault, shellExplicitFalse]) {
+      expect(prompt).toContain('BOTMUX_NOTHING_TO_SEND');
+      expect(prompt).toContain('botmux send');
+    }
+    // Omitting the arg and passing false must be identical (no accidental gate).
+    expect(sysDefault).toBe(sysExplicitFalse);
+    expect(shellDefault).toBe(shellExplicitFalse);
+  });
+
   it('passes configured model with --model', () => {
     const args = adapter.buildArgs({ sessionId: 's', resume: false, model: 'opus' });
     const idx = args.indexOf('--model');

--- a/test/trigger-api.test.ts
+++ b/test/trigger-api.test.ts
@@ -327,6 +327,49 @@ describe('trigger request contract', () => {
     expect(prompt).toContain('Do not call botmux send');
   });
 
+  // ── sentinel migration (质量①, #808 hard constraint): the nothing-to-send
+  //    sentinel lives SOLELY in <botmux_http_response_mode> now (routing/reminder
+  //    usage_silence is gated off for no-transport). This is a MIGRATION, NOT a
+  //    deletion: async settle depends on the model emitting the literal
+  //    BOTMUX_NOTHING_TO_SEND — isBridgeNothingToSendFinal requires a trailing
+  //    sentinel line → nothingToSendTurns → turn_terminal outputDisposition
+  //    'nothing_to_send', which is the ONLY signal that settles a genuine-empty
+  //    async turn to completed (else it hangs `running` until timeout). If this
+  //    test goes red because the sentinel line was removed "to fix the conflict",
+  //    that reintroduces the #808 hang — restore it, do not delete it.
+  it('carries the nothing-to-send sentinel inside http_response_mode for async turns', () => {
+    const req = request();
+    (req as any).instruction = 'Do the task.';
+    (req.options as any) = { asyncReturnSessionId: true };
+    const prompt = buildUntrustedEventPrompt(req, 'trg_async');
+    expect(prompt).toContain('<botmux_http_response_mode');
+    expect(prompt).toContain('BOTMUX_NOTHING_TO_SEND');
+    // The sentinel must sit INSIDE the response-mode block, not leak elsewhere.
+    const modeStart = prompt.indexOf('<botmux_http_response_mode');
+    const modeEnd = prompt.indexOf('</botmux_http_response_mode>');
+    const sentinelIdx = prompt.indexOf('BOTMUX_NOTHING_TO_SEND');
+    expect(sentinelIdx).toBeGreaterThan(modeStart);
+    expect(sentinelIdx).toBeLessThan(modeEnd);
+  });
+
+  it('carries the sentinel for wait-mode turns too (settle path covers both async + wait)', () => {
+    const req = request();
+    (req as any).instruction = 'Do the task.';
+    (req.options as any) = { waitForFinalOutput: true, timeoutMs: 120_000 };
+    const prompt = buildUntrustedEventPrompt(req, 'trg_wait');
+    expect(prompt).toContain('<botmux_http_response_mode');
+    expect(prompt).toContain('BOTMUX_NOTHING_TO_SEND');
+  });
+
+  it('emits NO sentinel for a plain (non-async/non-wait) webhook — no response-mode block at all', () => {
+    const req = request();
+    (req as any).instruction = 'Do a thing.';
+    (req.options as any) = {};
+    const prompt = buildUntrustedEventPrompt(req, 'trg_plain');
+    expect(prompt).not.toContain('<botmux_http_response_mode');
+    expect(prompt).not.toContain('BOTMUX_NOTHING_TO_SEND');
+  });
+
   it('no response-mode block without wait/async options (plain webhook delivery)', () => {
     const req = request();
     (req as any).instruction = 'Do a thing.';


### PR DESCRIPTION
## 背景
纯程序 HTTP 任务（`/api/trigger` asyncReturnSessionId）的 prompt 里，daemon 组装的 `usage_silence`（"不是发给你的就只输出 `BOTMUX_NOTHING_TO_SEND`"）与 per-turn 的 `<botmux_http_response_mode>`（"整段 verbatim 回程序、只输出最终答案"）语义打架：程序任务无飞书会话、无其它 bot 协作，整套 send/@/silence 规则都是噪音。

## 改动
no-transport 会话（apiOnly core-only bot **或** HTTP 虚拟会话 `http_async_*`/`http_wait_*`，判定 = `!larkTransportEnabled({chatId, apiOnly})`）下把整块 routing 协作规则网关掉，只保留 hidden-context-defense（untrusted 事件数据同 prompt，仍需防注入）。三处注入点全覆盖：

| 注入点 | 轮次 | CLI | gate 位置 |
|---|---|---|---|
| `buildBotmuxSystemPromptText` | 首轮 | claude-code/genius/grok | buildArgs 新增 `noTransport` 字段（worker 复用既有 `noTransportSession`） |
| `buildBotmuxShellHints` | 首轮 | codex/gemini 等 | session-manager 侧 gate |
| `buildFollowUpBlocks` reminder | 续轮 | 所有非 Mira | ★reminder key 选择处（非 inline 组装处，覆盖 hook 模式 sidecar） |

续轮正是 #71 `turnIdempotencyKey` 打开的路径；gate 落在 key 选择处是因为 hook 模式同样调该函数但把 reminder 走 sidecar，只 gate inline 会漏。

## ⚠️ 哨兵迁移不删（硬约束）
哨兵语义从 `usage_silence` 迁移到 `<botmux_http_response_mode>` 内一句，全程只出现一次。**迁移不是删除**：async settle（#808）依赖模型吐出字面 `BOTMUX_NOTHING_TO_SEND`——`isBridgeNothingToSendFinal` 要 trailing sentinel line → `nothingToSendTurns` → `turn_terminal` 带 `outputDisposition:'nothing_to_send'`，durable/async caller 只认这个 flag 才把 genuine-empty turn settle 成 completed，否则挂 `running` 到超时。该块随 `buildUntrustedEventPrompt` 同进首轮与续轮（`buildExistingSessionContent` 复用同一 prompt），两轮 settle 都靠它。删那句 = genuine-empty HTTP 任务重新挂死。

## 影响面
- **跨 CLI**：改了 shared-hints（3 个 injects CLI 共用）+ session-manager 组装（其余 20+ CLI 的 envelope 路径），已在两族验证；默认 `noTransport` 省略/false 时两路径 byte-for-byte 等同改前基线。
- **跨会话类型**：仅 no-transport 走新分支，普通飞书话题/群会话不受影响。
- **codex-app**（默认 apiOnly CLI）本就不经这两个函数注入 routing，无此冲突、不在改动面。

## 测试
- `test/cli-adapters.test.ts`：no-transport 两路径剥离 send/@/哨兵、留 hidden-context；默认/显式 false 保持全量 routing。
- `test/trigger-api.test.ts`：哨兵在 http_response_mode 内、async+wait 都带、plain webhook 不带。
- `test/bridge-input.test.ts`：HTTP 虚拟会话续轮 reminder 换 no_transport 变体（无哨兵、指向 http_response_mode）；真实飞书续轮仍带哨兵。
- 回归：session-lifecycle / codex-app-clean-prompt / initial-user-turn / turn-idempotency / async-terminal-settle 等 267 例全绿；`tsc` 无新增错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)