### PR TITLE
refactor(worker): 收敛四份 no-transport inline 谓词到中央 larkTransportEnabled

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -751,9 +751,16 @@ export function isHttpVirtualSession(chatId: string | undefined | null): boolean
  * reply / card / roster seam should fail-closed on `!larkTransportEnabled(...)`
  * instead of re-deriving the condition, so a new no-Feishu surface is covered
  * everywhere by construction. `doc:` sessions keep their own dedicated routing
- * (comment API), so they are intentionally NOT folded in here. */
+ * (comment API), so they are intentionally NOT folded in here.
+ *
+ * `chatId` is REQUIRED-but-nullable on purpose: a caller holding an optional
+ * chatId may pass `undefined`/`null` (tolerated — see isHttpVirtualSession),
+ * but OMITTING the key entirely stays a compile error. This is a fail-closed
+ * gate, and a forgotten `chatId` would land on the permissive side (an
+ * apiOnly-less object would read as "transport enabled"), so the missing-key
+ * case must not typecheck. Do not relax to `chatId?:`. */
 export function larkTransportEnabled(
-  ds: { chatId?: string | null; apiOnly?: boolean },
+  ds: { chatId: string | null | undefined; apiOnly?: boolean },
 ): boolean {
   if (ds.apiOnly === true) return false;
   if (isHttpVirtualSession(ds.chatId)) return false;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -735,8 +735,12 @@ export function isDocNativeSession(ds: Pick<DaemonSession, 'scope' | 'chatId'>):
  * `asyncReturnSessionId`) whose `chatId` is a synthetic `http_async_*` /
  * `http_wait_*` address, NOT a real Lark chat. Any Feishu chat API call
  * targeting it (sendMessage / card / reply / roster probe) would fail — these
- * sessions are request/response only and must never touch Lark transport. */
-export function isHttpVirtualSession(chatId: string): boolean {
+ * sessions are request/response only and must never touch Lark transport.
+ * Tolerates a nullish chatId (returns false — a missing surface is not an
+ * HTTP virtual chat), so callers converging onto this predicate can pass an
+ * optional chatId without a separate `?.` guard. */
+export function isHttpVirtualSession(chatId: string | undefined | null): boolean {
+  if (!chatId) return false;
   return chatId.startsWith('http_async_') || chatId.startsWith('http_wait_');
 }
 
@@ -749,7 +753,7 @@ export function isHttpVirtualSession(chatId: string): boolean {
  * everywhere by construction. `doc:` sessions keep their own dedicated routing
  * (comment API), so they are intentionally NOT folded in here. */
 export function larkTransportEnabled(
-  ds: Pick<DaemonSession, 'chatId'> & { apiOnly?: boolean },
+  ds: { chatId?: string | null; apiOnly?: boolean },
 ): boolean {
   if (ds.apiOnly === true) return false;
   if (isHttpVirtualSession(ds.chatId)) return false;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -58,6 +58,9 @@ import { rawCommandWriteOptionsFor } from './core/raw-command-write-options.js';
 import { publishCliSessionIdToDaemon } from './core/cli-session-id-publisher.js';
 import { readProcessStartIdentity } from './core/session-marker.js';
 import { roleLibraryRoot, roleLibrarySubtree } from './core/role-library.js';
+// Central no-transport predicate. Aliased because a local `const larkTransportEnabled`
+// (the role-library gate) already binds that name in one function scope.
+import { larkTransportEnabled as sessionLarkTransportEnabled } from './core/types.js';
 import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, extractCotEntries, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint, type BridgePendingTurn } from './services/bridge-turn-queue.js';
 import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, structuredFallbackKind, stripTrailingOaiMemoryCitation, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
@@ -12827,9 +12830,7 @@ async function spawnCli(
     // otherwise override the frozen values, restoring send capability for a
     // core-only bot or an HTTP virtual session. The host-owned session context
     // is authoritative here — these keys cannot be overridden from config.
-    const noTransport = cfg.apiOnly === true
-      || cfg.chatId?.startsWith('http_async_') === true
-      || cfg.chatId?.startsWith('http_wait_') === true;
+    const noTransport = !sessionLarkTransportEnabled({ chatId: cfg.chatId, apiOnly: cfg.apiOnly });
     if (noTransport) {
       delete mergedEnv.BOTMUX_LARK_APP_SECRET;
       mergedEnv.BOTMUX_API_ONLY = '1';
@@ -13182,11 +13183,8 @@ async function spawnCli(
   // no-transport (apiOnly bot OR HTTP virtual chat) is the ONLY session shape the
   // removed force-isolation rule ever confined; the policy-off migration arm is
   // scoped to it so an ordinary transport-enabled chat is never subjected to the
-  // tombstone requirement (no false kills). Computed locally — the merge-scoped
-  // `noTransport` above is out of scope here.
-  const noTransportSession = cfg.apiOnly === true
-    || cfg.chatId?.startsWith('http_async_') === true
-    || cfg.chatId?.startsWith('http_wait_') === true;
+  // tombstone requirement (no false kills).
+  const noTransportSession = !sessionLarkTransportEnabled({ chatId: cfg.chatId, apiOnly: cfg.apiOnly });
   const isolationCapableBackend = effectiveBackendType === 'tmux';
   // Existence via no-follow probes so a planted/tampered leaf still counts as
   // present (→ triggers cleanup / conservative kill) and can never be used to
@@ -14516,9 +14514,7 @@ async function spawnCli(
     // (buildFsPolicy independently re-gates roleLibrarySubtree on larkTransport;
     // this mirror keeps the worker from resolving/diagnosing a subtree the policy
     // will discard.)
-    const larkTransportEnabled = !(cfg.apiOnly === true
-      || cfg.chatId?.startsWith('http_async_') === true
-      || cfg.chatId?.startsWith('http_wait_') === true);
+    const larkTransportEnabled = sessionLarkTransportEnabled({ chatId: cfg.chatId, apiOnly: cfg.apiOnly });
     // Own role-library subtree, plus the ONE diagnosable failure mode of keying it
     // on appId: a deployment that named the per-bot dir something else (the layout
     // pre-2026-07 runbooks used) gets no rule, and "the role system EPERMs" is
@@ -18250,9 +18246,7 @@ process.on('message', async (raw: unknown) => {
       // a NORMAL bot whose turn runs in an HTTP virtual session (chatId is
       // http_async_*/http_wait_*): it has real creds so apiOnly is false, but the
       // synthetic chat has no card to attach a screenshot to.
-      apiOnlyForUpload = msg.apiOnly === true
-        || msg.chatId?.startsWith('http_async_') === true
-        || msg.chatId?.startsWith('http_wait_') === true;
+      apiOnlyForUpload = !sessionLarkTransportEnabled({ chatId: msg.chatId, apiOnly: msg.apiOnly });
       // brand 决定截图上传打哪个域（feishu / larksuite）。缺省 feishu。
       larkBrandForUpload = msg.brand === 'lark' ? 'lark' : 'feishu';
       // Resolve render dimensions BEFORE startScreenUpdates() — the

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -17,6 +17,12 @@ import { describe, expect, it } from 'vitest';
 const daemonSource = readFileSync(resolve('src/daemon.ts'), 'utf8');
 const registrySource = readFileSync(resolve('src/bot-registry.ts'), 'utf8');
 
+/** Drop whole-line `//` comments so a commented-out copy of the correct code
+ *  cannot satisfy a source-lock while the live statement is broken. */
+function stripLineComments(source: string): string {
+  return source.split('\n').filter(line => !/^\s*\/\//.test(line)).join('\n');
+}
+
 function region(source: string, startMarker: string, endMarker: string): string {
   const start = source.indexOf(startMarker);
   const end = source.indexOf(endMarker, start);
@@ -449,8 +455,16 @@ describe('API-only bot mode — non-client direct-Feishu paths (source lock)', (
     // The gate is derived from the CENTRAL larkTransportEnabled predicate keyed on
     // the init message (msg.chatId/msg.apiOnly), NOT ambient/cfg — so a normal bot
     // in an HTTP virtual session (real creds, apiOnly=false) is still disabled.
-    const workerSource = readFileSync(resolve('src/worker.ts'), 'utf8');
-    expect(workerSource).toContain('apiOnlyForUpload = !sessionLarkTransportEnabled({ chatId: msg.chatId, apiOnly: msg.apiOnly })');
+    // Matched STRUCTURALLY (predicate + both keys), not as one exact sentence:
+    // an equivalent reformat (property reorder, prettier line-wrap) must not turn
+    // this guard red, or the next person deletes it instead of fixing the code.
+    // Each fragment is unique in worker.ts, so the trio still pins this one site.
+    // Line comments are stripped first: a commented-out copy of the correct call
+    // must not satisfy the guard while the live code is broken.
+    const workerSource = stripLineComments(readFileSync(resolve('src/worker.ts'), 'utf8'));
+    expect(workerSource).toMatch(/apiOnlyForUpload\s*=\s*!sessionLarkTransportEnabled\(/);
+    expect(workerSource).toMatch(/chatId:\s*msg\.chatId/);
+    expect(workerSource).toMatch(/apiOnly:\s*msg\.apiOnly/);
     expect(workerSource).toContain("if (apiOnlyForUpload)");
     // worker-pool forwards apiOnly on the init message (both fork sites).
     const wpSource = readFileSync(resolve('src/core/worker-pool.ts'), 'utf8');

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -446,9 +446,11 @@ describe('API-only bot mode — non-client direct-Feishu paths (source lock)', (
     // The worker uploads via its OWN client (utils/lark-upload), bypassing the
     // daemon getBot gate, so the no-transport capability must ride the init
     // message. Covers apiOnly bot AND a normal bot in an HTTP virtual session.
+    // The gate is derived from the CENTRAL larkTransportEnabled predicate keyed on
+    // the init message (msg.chatId/msg.apiOnly), NOT ambient/cfg — so a normal bot
+    // in an HTTP virtual session (real creds, apiOnly=false) is still disabled.
     const workerSource = readFileSync(resolve('src/worker.ts'), 'utf8');
-    expect(workerSource).toContain('apiOnlyForUpload = msg.apiOnly === true');
-    expect(workerSource).toContain("msg.chatId?.startsWith('http_async_')");
+    expect(workerSource).toContain('apiOnlyForUpload = !sessionLarkTransportEnabled({ chatId: msg.chatId, apiOnly: msg.apiOnly })');
     expect(workerSource).toContain("if (apiOnlyForUpload)");
     // worker-pool forwards apiOnly on the init message (both fork sites).
     const wpSource = readFileSync(resolve('src/core/worker-pool.ts'), 'utf8');

--- a/test/api-only-transport-boundary.test.ts
+++ b/test/api-only-transport-boundary.test.ts
@@ -28,6 +28,8 @@ vi.mock('../src/services/groups-store.js', async (importOriginal) => {
 import { triggerSessionTurn } from '../src/core/trigger-session.js';
 import type { TriggerRequest } from '../src/services/trigger-types.js';
 import { larkTransportEnabled, isHttpVirtualSession, type DaemonSession } from '../src/core/types.js';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 const APP = 'local_riff';
 
@@ -75,6 +77,21 @@ describe('larkTransportEnabled — central no-Feishu predicate', () => {
     // A nullish chatId with a non-apiOnly bot ⇒ transport still enabled (no crash).
     expect(larkTransportEnabled({ chatId: undefined, apiOnly: false })).toBe(true);
     expect(larkTransportEnabled({ chatId: undefined, apiOnly: true })).toBe(false);
+  });
+  it('keeps `chatId` a REQUIRED key so omitting it cannot silently fail open', () => {
+    // Tolerating a nullish VALUE (above) must not become tolerating a missing KEY.
+    // This is a fail-closed gate: `larkTransportEnabled({ apiOnly: false })` would
+    // read as "transport enabled", so the omission has to be a compile error.
+    // Asserted on the source because a type-level mistake cannot be caught at
+    // runtime — the signature must stay `chatId: string | null | undefined`.
+    const src = readFileSync(resolve('src/core/types.ts'), 'utf8');
+    const sig = /export function larkTransportEnabled\(\s*ds:\s*\{([^}]*)\}/.exec(src);
+    expect(sig, 'larkTransportEnabled signature not found').not.toBeNull();
+    // `chatId:` (required), NOT `chatId?:` (optional).
+    expect(sig![1]).toMatch(/\bchatId\s*:/);
+    expect(sig![1]).not.toMatch(/\bchatId\s*\?\s*:/);
+    // …and the nullable value form is still there, so the tolerance above holds.
+    expect(sig![1]).toMatch(/\bchatId\s*:\s*string\s*\|\s*null\s*\|\s*undefined/);
   });
 });
 

--- a/test/api-only-transport-boundary.test.ts
+++ b/test/api-only-transport-boundary.test.ts
@@ -66,6 +66,16 @@ describe('larkTransportEnabled — central no-Feishu predicate', () => {
     expect(isHttpVirtualSession('oc_real')).toBe(false);
     expect(isHttpVirtualSession('doc:tok')).toBe(false);
   });
+  it('tolerates a nullish chatId (a missing surface is not an HTTP virtual chat)', () => {
+    // Hardened when converging worker.ts's four inline copies onto this predicate:
+    // one site (screenshot-upload gate) fed a `msg.chatId` that could be undefined,
+    // and inline code guarded with `?.` — so the central helper must not throw.
+    expect(isHttpVirtualSession(undefined)).toBe(false);
+    expect(isHttpVirtualSession(null)).toBe(false);
+    // A nullish chatId with a non-apiOnly bot ⇒ transport still enabled (no crash).
+    expect(larkTransportEnabled({ chatId: undefined, apiOnly: false })).toBe(true);
+    expect(larkTransportEnabled({ chatId: undefined, apiOnly: true })).toBe(false);
+  });
 });
 
 describe('triggerSessionTurn — apiOnly request-shape fail-closed', () => {


### PR DESCRIPTION
## 背景
worker.ts 有**四处**各自 inline 重写 no-transport 判定（`apiOnly || http_async_ || http_wait_`），既有技术债、彼此 byte 等价但有漂移风险——#1098 复审时暴露：任一处漏改都会让 no-Feishu 边界在某条 seam 上失效。收敛到 `core/types` 的中央谓词 `larkTransportEnabled`，单一真值来源。

## 四处收敛
| 站点 | 用途 | 入参 |
|---|---|---|
| `spawnCli` noTransport | env 冻结 | `cfg` |
| `spawnCli` noTransportSession | 持久化 pane guard | `cfg` |
| `spawnCli` larkTransportEnabled 局部 | role-library gate | `cfg` |
| init handler apiOnlyForUpload | 截图上传门 | **★`msg`（非 cfg）** |

★ 上传门用 `msg.chatId`/`msg.apiOnly`：HTTP 虚拟会话有真 creds 故 `apiOnly=false` 但无卡可贴截图，入参必须走 `msg.*`。

## 细节
- worker.ts 无 `core/types` 导入，且 `spawnCli` 内已有 local `const larkTransportEnabled`（role-lib gate）占名 → **aliased import** `sessionLarkTransportEnabled` 避免遮蔽；该 local 名保留（被 `buildFsPolicy` 以对象简写 `larkTransportEnabled,` 消费，改名会连带改消费方）。
- `isHttpVirtualSession`/`larkTransportEnabled` 加 **nullish chatId 容忍**（`!chatId → false`）：上传门喂的 `msg.chatId` 原 inline 用 `?.` 防御过 undefined，中央谓词此前对 undefined 会 throw，收敛后须容忍以保持等价（且移除后续 caller 的隐藏 footgun）。`larkTransportEnabled` 入参类型 `Pick<DaemonSession,'chatId'>` → `{ chatId?; apiOnly? }`，对现有 caller 是加宽、无行为变化。

## 不在本 PR 范围
`cli.ts` 另有 `currentTurnHasNoTransport`/`assertSessionTransportOrExit` 两处同类 inline，但那是 botmux CLI 瘦壳进程（非 worker/daemon）、不便引 daemon 类型，属独立边界，留后续。

## 影响面
- **仅 worker/daemon 进程**；纯重构、无行为变化（除 undefined-chatId 从 throw 变 false，属修复潜在 footgun）。
- 所有现有 `larkTransportEnabled` caller（daemon.ts / worker-pool.ts 多处）不受影响——入参类型加宽。

## 测试
- `test/api-only-transport-boundary.test.ts`：新增 nullish chatId 容忍断言（undefined/null→false 不 throw）；既有 apiOnly/http-virtual 真值表全绿。
- `test/api-only-mode-wiring.test.ts`：截图上传门 source-lock 从 inline 字面更新为收敛后形态（仍锁"keyed on msg.* + apiOnly/虚拟会话都覆盖 + if(apiOnlyForUpload) gate"的安全意图）。
- 全量：api-only 套件 + fs-policy + session-lifecycle + team-roster 等 ~250 例绿；`tsc` 无新增错误。其余三处 source-lock（cli.ts×2、worker-pool adoptSandboxBlocked）指向未改代码仍通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)