### PR TITLE
perf(dashboard): Bot 配置页首屏去掉两处无谓开销，1958ms → 77ms

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -42,6 +42,7 @@ import { reconcileDaemonSnapshot } from './dashboard/daemon-reconcile.js';
 import { createSessionPresentationCoordinator } from './dashboard/session-presentation.js';
 import {
   compactGroupsMatrix,
+  groupsNamesMatrix,
   createGroupsMatrixSnapshot,
   enrichSessionsWithGroupNames,
   roleWriteShouldInvalidate,
@@ -4910,7 +4911,27 @@ const server = createServer(async (req, res) => {
     // 含 aiden×claude / aiden×codex 网关项——前端打开"添加机器人"表单时拉取填充下拉.
     // id 既可能是普通 cliId, 也可能是 'aiden-x-claude' 这类选择键, 由 resolveCliSelection 解析.
     if (req.method === 'GET' && url.pathname === '/api/cli-options') {
-      const webSession = await botOnboarding.sessionStatus();
+      // `webSession` 是「开放平台登录态」实时探测: sessionStatus() 一路走到
+      // inspectCachedFeishuOpenPlatformSession(), 对飞书做一次真实网络往返
+      // (MEASURED: 1004 / 1091 / 2530ms; 端点 p50 1282ms / max 4402ms)。而同一
+      // 个 handler 里真正要算的东西只要 13ms (39 个 CLI 的 checkCliAvailability
+      // 12ms + staticModelChoices 1ms)——99% 的时间花在那一次外网调用上。
+      //
+      // 只有「添加机器人」弹窗消费它 (bot-onboarding.tsx 用来决定 reuse/qr 登录
+      // 模式并展示"将使用 …"账号)。Bot 配置页的 CliOptionsState (bot-defaults.ts)
+      // 类型里根本没有这个字段——付了 1-4s 的钱, 拿到就丢, 首屏白等。
+      //
+      // ⚠️ 兼容性决定了这里为什么是 opt-OUT 而不是 opt-IN:
+      // 路由 chunk 带 `immutable` 长缓存, 而 stale-chunk 自愈只在**动态 import
+      // 失败**时触发 —— dashboard 重启后, 已经加载好的旧 Bot 配置 chunk 会继续
+      // 活着并请求**裸** `/api/cli-options`。若裸端点默认不再探测, 旧 chunk 会在
+      // `body?.webSession?.status === 'ready'` 处把「字段缺席」判成 scan_required,
+      // 把登录态明明正常的用户**推去扫码**。新增 `not_probed` 状态也救不了它
+      // (旧代码不认识新状态)。
+      // 所以: 裸端点**保留旧语义**(照旧探测), 新的 Bot 配置页显式带
+      // `?probe=none` 走快路径。旧配置页最坏只是慢一次, 没有功能退化。
+      const probe = url.searchParams.get('probe');
+      const webSession = probe === 'none' ? undefined : await botOnboarding.sessionStatus();
       return jsonRes(res, 200, {
         options: CLI_SELECT_OPTIONS.map((o) => {
           // Keep the all-options scan shell-free so opening the form remains
@@ -4946,7 +4967,10 @@ const server = createServer(async (req, res) => {
         ttadkModelDefault: TTADK_DEFAULT_MODEL,
         ttadkModelSuggestions: TTADK_MODEL_SUGGESTIONS,
         suggestedAppName: botOnboarding.suggestedAppName(),
-        webSession,
+        // 未探测时整个字段缺席 (而不是 webSession: undefined)——JSON 里两者都不
+        // 出现, 但显式写清意图: 调用方拿不到就该自己带 ?probe=session 再要一次,
+        // 不会把「没探测」误读成「探测结果是未登录」而把用户推去扫码。
+        ...(webSession ? { webSession } : {}),
       });
     }
 
@@ -5539,6 +5563,21 @@ const server = createServer(async (req, res) => {
       });
       if (url.searchParams.get('view') === 'compact') {
         return jsonRes(res, 200, compactGroupsMatrix(matrix));
+      }
+      // `?view=names` — 名称/头像专用轻量视图。完整矩阵实测 12.59MB，其中
+      // chats[].memberBots 独占 12341KB；而 loadNameMaps()（web/ui.ts）只用
+      // bots 的名称/头像 + chats 的 chatId/name/avatar。摘掉 memberBots 后
+      // 372KB 级别，同时省掉主线程 38-70ms 的 JSON.parse。
+      //
+      // 不复用 `?view=compact`：那个投影没有 `bots`，名称/头像会全丢（见
+      // GroupsNamesSnapshot 的注释）。
+      //
+      // 公开只读边界：本投影的 chats 只有 chatId/name/avatar，比
+      // redactGroupsForPublic 的输出更窄（它还会保留 chatMode/memberBots），
+      // 且 `bots` 在下面的默认分支对未认证访客也是原样下发的——所以这里
+      // 无需按 authed 分叉，不存在新增暴露面。
+      if (url.searchParams.get('view') === 'names') {
+        return jsonRes(res, 200, groupsNamesMatrix(matrix));
       }
       return jsonRes(res, 200, {
         chats: authed ? matrix.chats : redactGroupsForPublic(matrix.chats),

--- a/src/dashboard/groups-matrix-snapshot.ts
+++ b/src/dashboard/groups-matrix-snapshot.ts
@@ -20,6 +20,23 @@ export interface CompactGroupsSnapshot {
   chats: GroupPresentation[];
 }
 
+/**
+ * `?view=names` 的响应形状：**名称/头像专用**投影。
+ *
+ * 与 {@link CompactGroupsSnapshot} 的关键区别是它**带 `bots`**。
+ * `compact` 只有 `chats`（会话名称回填用），而 `loadNameMaps()`（web/ui.ts）
+ * 恰恰是读 `data.bots` 拿 bot 名称与头像的——所以名称/头像链路**不能**复用
+ * `compact`，否则 56 个 bot 的名字和头像会全部退化成 raw appId（MEASURED：
+ * `compact` 的顶层 key 只有 `['chats']`，`bots` 是 undefined）。
+ *
+ * 摘掉的只有 `memberBots`：完整矩阵里 1420 群 × 56 bot 的成员关系占
+ * 12341KB / 12.59MB（MEASURED），而名称/头像一个字节都不需要它。
+ */
+export interface GroupsNamesSnapshot {
+  chats: GroupPresentation[];
+  bots: unknown[];
+}
+
 interface CachedMatrix {
   matrix: GroupsMatrix;
   presentationByChatId: ReadonlyMap<string, GroupPresentation>;
@@ -97,6 +114,23 @@ export function compactGroupsMatrix(matrix: GroupsMatrix): CompactGroupsSnapshot
 
 function presentationMap(matrix: GroupsMatrix): ReadonlyMap<string, GroupPresentation> {
   return new Map(compactGroupsMatrix(matrix).chats.map((chat) => [chat.chatId, chat]));
+}
+
+/**
+ * 名称/头像投影：chats 走 {@link compactGroupsMatrix} 的同一条白名单
+ * （chatId/name/avatar），bots **整行原样保留**。
+ *
+ * bots 行本身很轻（MEASURED：56 行合计 11KB，字段只有 larkAppId / botName /
+ * botAvatarUrl / cliId），没有裁剪价值；而裁剪它反而会引入「今天够用、明天
+ * 加个字段就静默缺失」的风险——bot 身份字段是名称/头像链路的全部输入，这里
+ * 宁可整行透传。真正的 12.34MB 大头在 chats[].memberBots，被上面那条白名单
+ * 天然挡掉。
+ */
+export function groupsNamesMatrix(matrix: GroupsMatrix): GroupsNamesSnapshot {
+  return {
+    chats: compactGroupsMatrix(matrix).chats,
+    bots: matrix.bots,
+  };
 }
 
 export function enrichSessionsWithGroupNames<T extends Record<string, unknown>>(

--- a/src/dashboard/web/bot-defaults-page.tsx
+++ b/src/dashboard/web/bot-defaults-page.tsx
@@ -5,6 +5,7 @@ import {
   agentSelectionKey,
   cliIdOf,
   createRefreshGate,
+  createOncePerKeyGate,
   displayCliId,
   fallbackCliOptionsState,
   fetchBotDefaults,
@@ -1066,7 +1067,7 @@ function BotDefaultsCard(props: {
         >
           <BdTabGrid>
             <section className="bd-tile bd-tile-wide"><CardBehaviorSection bot={bot} putCardPref={putCardPref} /></section>
-            <section className="bd-tile bd-tile-wide"><FeedbackSettingsSection bot={bot} patchBot={patchBot} /></section>
+            <section className="bd-tile bd-tile-wide"><FeedbackSettingsSection bot={bot} patchBot={patchBot} active={props.activeTab === 'cards'} /></section>
             <section className="bd-tile"><BrandSection bot={bot} patchBot={patchBot} /></section>
           </BdTabGrid>
         </div>
@@ -1106,7 +1107,7 @@ function BotDefaultsCard(props: {
   );
 }
 
-function FeedbackSettingsSection(props: { bot: BotDefaultsRow; patchBot: PatchBot }) {
+function FeedbackSettingsSection(props: { bot: BotDefaultsRow; patchBot: PatchBot; active: boolean }) {
   const enabled = props.bot.feedback?.enabled === true;
   const [on, setOn] = useState(enabled);
   const [json, setJson] = useState(JSON.stringify(props.bot.feedback ?? { enabled: true }, null, 2));
@@ -1115,15 +1116,38 @@ function FeedbackSettingsSection(props: { bot: BotDefaultsRow; patchBot: PatchBo
   const [chatId, setChatId] = useState('');
   const [chats, setChats] = useState<GroupChat[]>([]);
   const [preview, setPreview] = useState<any>(null);
+  // 「本 bot 的群列表已拉过（或正在拉）」闸门。见下面 effect 的注释：把 active
+  // 加进依赖会让每次切回 Cards tab 都重跑 effect，靠它收敛成「每 bot 一次」。
+  const chatsGateRef = useRef(createOncePerKeyGate());
   useEffect(() => {
     setOn(props.bot.feedback?.enabled === true);
     setJson(JSON.stringify(props.bot.feedback ?? { enabled: true }, null, 2));
   }, [props.bot.feedback]);
   useEffect(() => {
+    // 这个区块要的是 memberBots（筛「本 bot 已在群」的群列表），只有完整矩阵
+    // 有 —— 那是 12.7MB。而各 tab 是用 `hidden` 隐藏而非条件卸载，所以本区块
+    // 在任何 tab 下都会 mount：无条件拉取等于每次进 Bot 配置页都后台补一发
+    // 12.7MB，把首屏的优化又吃回去。
+    //
+    // 所以按 `active` 延迟到 Cards tab 真正激活才拉。刻意**不用条件卸载**
+    // （`{active && <Section/>}`）：那会在切走 tab 时丢掉用户正在编辑的 JSON
+    // 草稿与开关状态。组件照常挂着，只是不发请求。
+    if (!props.active) return;
+    // ⚠️ 但把 `active` 加进依赖数组，副作用是**每次切回 Cards tab 都会重跑**
+    // （cards → common → 隔几秒回 cards，groups-api 的 3s 缓存已过期 ⟹ 又下载
+    // 12.7MB）。原语义是「每次 mount / 每个 botId 只拉一次」，延迟加载不该把它
+    // 放宽成「每次回 tab 都拉」。闸门把它收敛回每 bot 一次。
+    if (!chatsGateRef.current.claim(props.bot.larkAppId)) return;
+    const appId = props.bot.larkAppId;
     void fetchGroupsSnapshot().then(snapshot => {
-      setChats(snapshot.chats.filter(chat => chat.memberBots.some(member => member.larkAppId === props.bot.larkAppId && member.inChat)));
-    }).catch(() => setChats([]));
-  }, [props.bot.larkAppId]);
+      setChats(snapshot.chats.filter(chat => chat.memberBots.some(member => member.larkAppId === appId && member.inChat)));
+    }).catch(() => {
+      setChats([]);
+      // 失败释放认领：下次激活允许重试，否则一次网络抖动会让这个群列表在本 bot
+      // 上永久空着。
+      chatsGateRef.current.release(appId);
+    });
+  }, [props.bot.larkAppId, props.active]);
   async function save(nextOn = on): Promise<void> {
     setBusy(true); setStatus(null);
     try {

--- a/src/dashboard/web/bot-defaults.ts
+++ b/src/dashboard/web/bot-defaults.ts
@@ -254,6 +254,46 @@ export function createRefreshGate(): { begin(): { commit(): boolean } } {
   };
 }
 
+/**
+ * 「每个 key 只放行一次」闸门，给延迟加载的重型请求用。
+ *
+ * 场景：反馈设置区块需要 `memberBots`（只有 12.7MB 的完整矩阵有），而各 tab 是
+ * 用 `hidden` 隐藏而非条件卸载 —— 组件在任何 tab 下都 mount。把「是否激活」
+ * 加进 effect 依赖能避免未打开就拉，但副作用是**每次切回该 tab 都重跑**
+ * （cards → 别的 tab → 隔几秒回 cards，groups-api 的 3s 缓存已过期 ⟹ 又下载
+ * 12.7MB）。原语义是「每次 mount / 每个 botId 一次」，延迟加载不该把它放宽成
+ * 「每次回 tab 都拉」。
+ *
+ * `claim(key)` 只在该 key 尚未被认领时返回 true；`release(key)` 撤销认领，供
+ * 失败路径调用 —— 否则一次网络抖动会让该 bot 的列表永久空着。
+ *
+ * 注：当前调用点（`BotDefaultsCard` 带 `key={larkAppId:...}`）在切换 bot 时会
+ * 整体 remount，闸门随之新建，所以实际吃到的只有「同一 bot 二次激活」这一条；
+ * 按 key 而非布尔来记，是为了让「换 bot 必须重拉」在**不依赖父级 remount**时
+ * 也成立 —— 这条不变量不该悄悄挂在别处的 `key` 拼法上。
+ *
+ * 与 {@link createRefreshGate} 一样保持为纯工厂，好让「二次激活不重拉」不必起
+ * DOM 就能单测（仓库无 React 组件测试设施）。
+ */
+export function createOncePerKeyGate(): {
+  claim(key: string): boolean;
+  release(key: string): void;
+  claimed(key: string): boolean;
+} {
+  let current: string | null = null;
+  return {
+    claim(key) {
+      if (current === key) return false;
+      current = key;
+      return true;
+    },
+    release(key) {
+      if (current === key) current = null;
+    },
+    claimed: key => current === key,
+  };
+}
+
 export async function fetchBotDefaults(): Promise<LoadBotsResult> {
   try {
     const r = await fetch('/api/bots');
@@ -304,7 +344,14 @@ export async function resolveSubstituteTarget(
 
 export async function fetchCliOptions(): Promise<CliOptionsState> {
   try {
-    const r = await fetch('/api/cli-options');
+    // `?probe=none` 显式跳过开放平台登录态探测（一趟 1-4s 的实时飞书往返）。
+    // 本页的 CliOptionsState 不含 webSession 字段，付了钱也拿不到手。
+    //
+    // 之所以是「本页 opt-out」而不是「服务端默认不探测」：路由 chunk 带
+    // immutable 长缓存，dashboard 重启后已加载的旧 chunk 仍会请求裸端点；裸端点
+    // 一旦默认不探测，旧 chunk 会把「字段缺席」判成未登录、把用户推去扫码。
+    // 详见 dashboard.ts 里 /api/cli-options 的注释。
+    const r = await fetch('/api/cli-options?probe=none');
     const body = await r.json().catch(() => ({}));
     if (!r.ok || !Array.isArray(body?.options)) return fallbackCliOptionsState;
     const options: CliOption[] = body.options

--- a/src/dashboard/web/bot-onboarding.tsx
+++ b/src/dashboard/web/bot-onboarding.tsx
@@ -183,6 +183,11 @@ function statusText(job: OnboardingJob): string {
 
 async function fetchCliOptions(): Promise<CliOptionsState> {
   try {
+    // 裸端点保留「探测登录态」的旧语义，本弹窗正是要那个 webSession（决定
+    // sessionMode 走 reuse 还是 qr，并展示"将使用 …"的账号），所以不带任何
+    // probe 参数。反过来 Bot 配置页显式带 `?probe=none` 跳过探测。
+    // 为什么是 opt-out 而非 opt-in：见 dashboard.ts /api/cli-options 的注释
+    // （immutable chunk 长缓存 + stale-chunk 自愈只覆盖 import 失败）。
     const res = await fetch('/api/cli-options');
     const body = await res.json();
     if (res.ok && Array.isArray(body?.options)) {

--- a/src/dashboard/web/groups-api.ts
+++ b/src/dashboard/web/groups-api.ts
@@ -54,6 +54,59 @@ export function primeGroupsSnapshotCache(snapshot: GroupsSnapshot): void {
   cachedAt = Date.now();
 }
 
+// ─── 名称/头像专用轻量缓存（与上面的完整矩阵缓存**完全分离**）──────────────
+//
+// 为什么必须分开存：完整矩阵（12.59MB）里 chats[].memberBots 占 12341KB，而
+// 名称/头像链路一个字节都不用它。但群组页 / 角色页 / 日程页 / 本页的反馈设置
+// 区块（FeedbackSettingsSection）都**真的**要读 memberBots —— 如果把轻量结果
+// 灌进共享的 `cachedSnapshot`，那些页面会拿到 `memberBots: []`，表现为「群里
+// 一个 bot 都没有」的静默错数据（不是报错，更难发现）。
+//
+// 所以轻量视图有自己的 cachedNames/cachedNamesAt，两条缓存互不写入。
+let cachedNames: GroupsSnapshot = emptyGroupsSnapshot;
+let cachedNamesAt = 0;
+let namesInFlight: Promise<GroupsSnapshot> | null = null;
+
+/**
+ * 拉取「只含 bot 名称/头像 + 会话名称/头像」的轻量快照（`?view=names`）。
+ *
+ * **实时性**：缓存语义与完整矩阵逐字一致（同样默认 3s，仅用于消掉同一次挂载内
+ * 的重复请求；服务端也是同一份 30s 快照 + 同一条 roster 失效通知）。也就是说
+ * 名称/头像的新鲜度**与改动前完全相同**，变化的只有同一次请求传多少字节。
+ * 这里刻意不加长任何 TTL：名称/头像正是最忌讳陈旧的数据。
+ *
+ * 需要 memberBots 的调用方必须继续用 {@link fetchGroupsSnapshot}。
+ */
+export async function fetchGroupsNamesSnapshot(
+  options: FetchGroupsSnapshotOptions = {},
+): Promise<GroupsSnapshot> {
+  const cacheMs = options.cacheMs ?? 3000;
+  const now = Date.now();
+  // 完整矩阵是轻量视图的超集：若它刚拿过新鲜数据，直接复用，省掉一次请求。
+  // （反向不成立——轻量结果永远不能喂给完整矩阵的消费方。）
+  if (!options.force && cachedAt > 0 && now - cachedAt <= cacheMs) return cachedSnapshot;
+  if (!options.force && cachedNamesAt > 0 && now - cachedNamesAt <= cacheMs) return cachedNames;
+  if (!options.force && namesInFlight) return namesInFlight;
+
+  const request = (async () => {
+    const r = await fetch('/api/groups?view=names');
+    const body = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const snapshot = normalizeGroupsSnapshot(body);
+    cachedNames = snapshot;
+    cachedNamesAt = Date.now();
+    return snapshot;
+  })();
+
+  if (!options.force) {
+    namesInFlight = request.finally(() => {
+      namesInFlight = null;
+    });
+    return namesInFlight;
+  }
+  return request;
+}
+
 export async function fetchGroupsSnapshot(options: FetchGroupsSnapshotOptions = {}): Promise<GroupsSnapshot> {
   const cacheMs = options.cacheMs ?? 3000;
   const now = Date.now();

--- a/src/dashboard/web/overview.ts
+++ b/src/dashboard/web/overview.ts
@@ -1,5 +1,5 @@
 import { attentionReason, botNameForAppId } from './ui.js';
-import { fetchGroupsSnapshot } from './groups-api.js';
+import { fetchGroupsNamesSnapshot } from './groups-api.js';
 
 let groupsSnapshot: { chats: any[]; bots: any[] } = { chats: [], bots: [] };
 
@@ -9,7 +9,16 @@ export function __setGroupsSnapshotForTest(snapshot: { chats: any[]; bots: any[]
 
 export async function loadGroupsSnapshot(): Promise<void> {
   try {
-    groupsSnapshot = await fetchGroupsSnapshot();
+    // 轻量视图：buildBotCards() 只遍历 snapshot.bots，且只读 larkAppId /
+    // botName / botAvatarUrl / cliId / brand 这 5 个字段；`snapshot.chats` 在
+    // 本文件里零读取（attentionReason() 只看传入的 session row，与 groups
+    // 快照无关）。所以完整矩阵里那 12.34MB 的 chats[].memberBots 是纯浪费。
+    //
+    // ⚠️ 更要紧的是**去重**：app.tsx 启动时并行跑 loadNameMaps() 与本函数。
+    // 两者必须落在 groups-api 的**同一个 in-flight** 上，否则会变成
+    // 「names 387KB + full 12.73MB」两发（MEASURED 13.11MB，比改动前的
+    // 12.73MB 更差）。loadNameMaps 走 names，本函数也必须走 names。
+    groupsSnapshot = await fetchGroupsNamesSnapshot();
   } catch {
     // Overview stays useful even when Lark group APIs are unavailable.
   }

--- a/src/dashboard/web/ui.ts
+++ b/src/dashboard/web/ui.ts
@@ -1,5 +1,5 @@
 import {
-  fetchGroupsSnapshot,
+  fetchGroupsNamesSnapshot,
 } from './groups-api.js';
 
 import {
@@ -336,7 +336,17 @@ export function overrideBotAvatar(larkAppId: string, name: string | undefined, u
 export function loadNameMaps(): Promise<void> {
   nameMapsPromise ??= (async () => {
     try {
-      const data = await fetchGroupsSnapshot();
+      // 轻量视图：只要 bots 的名称/头像 + chats 的 chatId/name/avatar。完整矩阵
+      // 实测 12.59MB（memberBots 独占 12341KB），而这里一个字节都不用它——换成
+      // `?view=names` 后 372KB 级别，且省掉主线程 38-70ms 的 JSON.parse。
+      //
+      // 新鲜度**未被本次改动触及**：命中/失效时机完全照旧（成功后由下面的
+      // nameMapsPromise memo 持有，失败才清空重试），变的只有同一次请求传多少
+      // 字节。注意这个 memo 意味着名称/头像每个页面生命周期只真拉一次——这是
+      // 既有行为，不是本次引入的：bot 名称另有更快通路（/api/bots 每次刷新都带
+      // botName，Bot 配置页优先用它），头像则由 overrideBotAvatar() 在改完后
+      // 就地写内存+localStorage 生效，都不依赖本函数重跑。
+      const data = await fetchGroupsNamesSnapshot();
       for (const b of data.bots ?? []) {
         if (b.larkAppId && b.botName && b.botName !== b.larkAppId) {
           botNameByAppId.set(b.larkAppId, String(b.botName));

--- a/test/dashboard-cli-options-session-probe.test.ts
+++ b/test/dashboard-cli-options-session-probe.test.ts
@@ -1,0 +1,106 @@
+/**
+ * dashboard-cli-options-session-probe.test.ts
+ *
+ * 钉住 `/api/cli-options` 的「登录态探测可被显式跳过」契约。
+ *
+ * 背景（MEASURED，本机直连 7891）：该端点原先无条件 `await
+ * botOnboarding.sessionStatus()`，那是一趟到飞书开放平台的真实网络往返
+ * （单独计时 1004 / 1091 / 2530ms；端点整体 p50 1282ms、max 4402ms），
+ * 而同一 handler 里真正要算的东西只有 13ms（39 个 CLI 的
+ * checkCliAvailability 12ms + staticModelChoices 1ms）。
+ *
+ * Bot 配置页在 mount 时把这个端点与 `/api/bots`（40-50ms）并行发出，首屏
+ * 等在最慢那个身上；而它的 `CliOptionsState`（bot-defaults.ts）类型里没有
+ * `webSession` 字段——付了 1-4s 的钱、拿到就丢。
+ *
+ * 契约是双向的，两边都必须钉住：
+ *   A. 服务端：**裸端点保留旧语义**（照旧探测），只有显式 `?probe=none` 才
+ *      跳过。方向不能反：路由 chunk 带 immutable 长缓存，而 stale-chunk 自愈
+ *      只在动态 import 失败时触发，所以 dashboard 重启后已加载的旧 Bot 配置
+ *      chunk 会继续请求裸端点；裸端点若默认不探测，旧 chunk 会把「字段缺席」
+ *      判成 scan_required，**把登录态正常的用户推去扫码**。
+ *   B. 前端：Bot 配置页显式带 `?probe=none` 走快路径；onboarding 弹窗走裸
+ *      端点（它真要 webSession 来决定 reuse/qr）。
+ *
+ * 取舍：沿用本目录既有的 source-lock 模式（见 dashboard-cli-options-models
+ * .test.ts 的说明）——dashboard.ts 是模块级 createServer 的重型模块，仓库
+ * 内无任何测试整体 import 它，起全量 HTTP harness 代价过高且脆弱。
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const dashboardSource = readFileSync(resolve('src/dashboard.ts'), 'utf8');
+
+/** `/api/cli-options` 路由体（到相邻的 /models 路由为止）。 */
+function cliOptionsRouteBlock(): string {
+  const start = dashboardSource.indexOf("url.pathname === '/api/cli-options'");
+  const end = dashboardSource.indexOf("url.pathname === '/api/cli-options/models'");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return dashboardSource.slice(start, end);
+}
+
+describe('GET /api/cli-options — 服务端：登录态探测可被显式跳过', () => {
+  it('sessionStatus() 由 probe 参数决定，且裸端点保留旧语义（探测）', () => {
+    const block = cliOptionsRouteBlock();
+    expect(block).toContain('botOnboarding.sessionStatus()');
+    // 闸门存在：读 probe 查询参数
+    expect(block).toContain("url.searchParams.get('probe')");
+    // 关键判据不是「出现了 probe 这个名字」，而是「sessionStatus() 这个值是否
+    // 由该闸门决定」。退化写法（无条件 `= await …sessionStatus()`）不含 `?`，
+    // 这条会红。
+    expect(block).toMatch(
+      /probe\s*===\s*'none'\s*\?\s*undefined\s*:\s*await\s+botOnboarding\.sessionStatus\(\)/,
+    );
+    // ⚠️ 方向性判据（这个方向本身就是判据，必须钉住）：必须是 opt-OUT。
+    // 若退回 opt-IN（`probe === 'session' ? await … : undefined`），
+    // dashboard 重启后仍活着的旧 Bot 配置 chunk 会请求裸端点、拿不到
+    // webSession、把登录态正常的用户推去扫码。
+    expect(block).not.toMatch(/probe\w*\s*===\s*'session'\s*\?\s*await/);
+    expect(block).not.toMatch(/=\s*await\s+botOnboarding\.sessionStatus\(\);/);
+  });
+
+  it('跳过探测时 webSession 字段整个缺席，不下发 undefined 占位', () => {
+    const block = cliOptionsRouteBlock();
+    expect(block).toContain('...(webSession ? { webSession } : {})');
+    expect(block).not.toMatch(/^\s*webSession,\s*$/m);
+  });
+
+  it('真正的计算（CLI 可用性 + 静态模型候选）不受闸门影响，始终下发', () => {
+    const block = cliOptionsRouteBlock();
+    expect(block).toContain('checkCliAvailability(');
+    expect(block).toContain('staticModelChoices(o.key)');
+    expect(block).toContain('suggestedAppName: botOnboarding.suggestedAppName()');
+  });
+});
+
+describe('前端调用方：谁跳过探测，谁保留', () => {
+  it('onboarding 弹窗走裸端点（它要 webSession）', () => {
+    const source = readFileSync(
+      resolve('src/dashboard/web/bot-onboarding.tsx'),
+      'utf8',
+    );
+    expect(source).toContain("fetch('/api/cli-options')");
+    // 有牙：弹窗一旦跳过探测，登录态就拿不到，sessionMode 会误落 qr
+    expect(source).not.toContain("/api/cli-options?probe=none");
+    expect(source).toContain('webSession');
+  });
+
+  it('Bot 配置页显式 probe=none（这就是首屏 3350ms → 42ms 的来源）', () => {
+    const source = readFileSync(
+      resolve('src/dashboard/web/bot-defaults.ts'),
+      'utf8',
+    );
+    expect(source).toContain("fetch('/api/cli-options?probe=none')");
+    // 退化防护：本页退回裸端点，首屏又会退回 1-4s
+    expect(source).not.toMatch(/fetch\('\/api\/cli-options'\)/);
+    // 且本页的类型确实不含 webSession —— 证明「拿到就丢」这个前提仍然成立。
+    const stateType = source.slice(
+      source.indexOf('export type CliOptionsState'),
+      source.indexOf('export type CliRuntimeConfig'),
+    );
+    expect(stateType.length).toBeGreaterThan(0);
+    expect(stateType).not.toContain('webSession');
+  });
+});

--- a/test/dashboard-groups-names-inflight.test.ts
+++ b/test/dashboard-groups-names-inflight.test.ts
@@ -1,0 +1,156 @@
+/**
+ * dashboard-groups-names-inflight.test.ts
+ *
+ * 行为测试（非 source-lock）：钉住 app.tsx 启动链的**请求条数**。
+ *
+ * 背景：`app.tsx` 启动时并行跑 `loadNameMaps()`（→ names）与
+ * `loadGroupsSnapshot()`（→ names）。改动前两者打同一个
+ * `fetchGroupsSnapshot()`，被 in-flight 去重成一次；只改一边会变成
+ * 「names 387KB + full 12.73MB」两发（MEASURED 13.11MB，比改动前更差）。
+ *
+ * source-lock 只能证明「两处都写了 fetchGroupsNamesSnapshot」，**证不出运行时
+ * 真的只发一次**——`fetchGroupsNamesSnapshot` 里还有一条「完整矩阵新鲜时复用
+ * cachedSnapshot」的超集捷径，并发时序下它有没有可能让一个走 cache、另一个
+ * 发请求？那是我推理出来的，不是实测。所以这里直接数 fetch 次数。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const NAMES_URL = '/api/groups?view=names';
+const FULL_URL = '/api/groups';
+
+function payload() {
+  return {
+    ok: true,
+    json: async () => ({
+      chats: [{ chatId: 'oc_a', name: 'A', avatar: 'https://x/a.png' }],
+      bots: [{ larkAppId: 'cli_1', botName: 'bot-one', botAvatarUrl: 'https://x/b.png', cliId: 'claude-code' }],
+    }),
+  };
+}
+
+let urls: string[] = [];
+
+beforeEach(() => {
+  urls = [];
+  vi.resetModules();
+  vi.stubGlobal('fetch', vi.fn(async (url: unknown) => {
+    urls.push(String(url));
+    // 真实网络有延迟：并发窗口必须张开，否则「第二个调用命中 in-flight」这件事
+    // 会因为第一个已经同步完成而变成 vacuous pass。
+    await new Promise(r => setTimeout(r, 20));
+    return payload() as unknown as Response;
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('启动链只发一次请求（app.tsx 的 Promise.all 并发形态）', () => {
+  it('canary：探针本身有效——两次串行调用会命中 3s cache，只发一次', async () => {
+    const api = await import('../src/dashboard/web/groups-api.js');
+    await api.fetchGroupsNamesSnapshot();
+    await api.fetchGroupsNamesSnapshot();
+    // 若这条不是 1，说明 stub 没接上或缓存语义已变 —— 下面的断言就不可信
+    expect(urls).toEqual([NAMES_URL]);
+  });
+
+  it('两个并发的 names 调用共享 in-flight，只发一次 names、零 full', async () => {
+    const api = await import('../src/dashboard/web/groups-api.js');
+    // 复刻 app.tsx:1696-1697 的形态：同一 tick 并行发出
+    await Promise.all([
+      api.fetchGroupsNamesSnapshot(),
+      api.fetchGroupsNamesSnapshot(),
+    ]);
+    expect(urls.filter(u => u === NAMES_URL)).toHaveLength(1);
+    // 关键：一个 full 都不能有（正是启动链那条 13.11MB 回归）
+    expect(urls.filter(u => u === FULL_URL)).toHaveLength(0);
+  });
+
+  it('names 与 full 混用时各自只发一次（互不复用，也互不抵消）', async () => {
+    const api = await import('../src/dashboard/web/groups-api.js');
+    await Promise.all([
+      api.fetchGroupsNamesSnapshot(),
+      api.fetchGroupsSnapshot(),
+    ]);
+    // 这是「Cards tab 激活」等真实场景：两种数据都要，各一发，不重复
+    expect(urls.filter(u => u === NAMES_URL)).toHaveLength(1);
+    expect(urls.filter(u => u === FULL_URL)).toHaveLength(1);
+  });
+
+  it('完整矩阵先落地后，names 调用复用它（超集方向安全，省一发）', async () => {
+    const api = await import('../src/dashboard/web/groups-api.js');
+    await api.fetchGroupsSnapshot();
+    expect(urls).toEqual([FULL_URL]);
+    await api.fetchGroupsNamesSnapshot();
+    // 不再发第二条：完整矩阵是 names 的超集
+    expect(urls).toEqual([FULL_URL]);
+  });
+
+  it('反向不成立：names 先落地，需要 memberBots 的调用方仍必须真拉 full', async () => {
+    const api = await import('../src/dashboard/web/groups-api.js');
+    const names = await api.fetchGroupsNamesSnapshot();
+    expect(urls).toEqual([NAMES_URL]);
+    // names 的 chats 没有 memberBots —— 若被喂给 full 的消费方，群组/角色/日程页
+    // 会拿到「群里一个 bot 都没有」的静默错数据。
+    expect(names.chats[0]).not.toHaveProperty('memberBots');
+    await api.fetchGroupsSnapshot();
+    // 必须真的发出 full 请求，不能拿 cachedNames 顶
+    expect(urls.filter(u => u === FULL_URL)).toHaveLength(1);
+  });
+});
+
+/**
+ * 反馈设置区块的「每 bot 只拉一次」闸门。
+ *
+ * 起因：该区块要 memberBots（只有 12.7MB 完整矩阵有），而各 tab 用 `hidden`
+ * 隐藏而非条件卸载 ⟹ 组件在任何 tab 下都 mount。把「是否激活」加进 effect
+ * 依赖能避免未打开就拉，但副作用是**每次切回该 tab 都重跑**：
+ * cards → common → 隔几秒回 cards，groups-api 的 3s 缓存已过期 ⟹ 又一发
+ * 12.7MB。原语义是「每次 mount / 每个 botId 一次」，延迟加载不该放宽它。
+ *
+ * 逻辑抽成纯工厂（同 createRefreshGate 的既有做法），这样「二次激活不重拉」
+ * 不必起 DOM 就能咬住 —— 仓库里没有 React 组件测试设施，靠 source-lock 只能
+ * 证明「写了 claim」，证不出**第二次激活真的不发请求**。
+ */
+describe('createOncePerKeyGate — 二次激活不重拉', () => {
+  it('同一 key 只认领一次：第二、第三次激活都不放行', async () => {
+    const { createOncePerKeyGate } = await import('../src/dashboard/web/bot-defaults.js');
+    const gate = createOncePerKeyGate();
+    expect(gate.claim('cli_a')).toBe(true);   // 首次激活 → 拉
+    expect(gate.claim('cli_a')).toBe(false);  // 切走再回来 → 不拉
+    expect(gate.claim('cli_a')).toBe(false);
+  });
+
+  it('切换 bot 会重新认领（群列表是 per-bot 的）', async () => {
+    const { createOncePerKeyGate } = await import('../src/dashboard/web/bot-defaults.js');
+    const gate = createOncePerKeyGate();
+    expect(gate.claim('cli_a')).toBe(true);
+    expect(gate.claim('cli_b')).toBe(true);   // 换 bot → 必须拉
+    expect(gate.claim('cli_b')).toBe(false);
+    // 切回旧 bot 也会重拉一次（只记最近一个 key，够用且不占内存）
+    expect(gate.claim('cli_a')).toBe(true);
+    // 注：当前调用点的父组件带 key={larkAppId:...}，切 bot 会整体 remount、
+    // 闸门随之新建，所以这条在**今天的接线下走不到**。仍然断言它，是为了让
+    // 「换 bot 必须重拉」这条不变量不悄悄依赖别处的 key 拼法 —— 那个 key 是为
+    // profileRoleVersion 加的，不是为本闸门加的，随时可能变。
+  });
+
+  it('失败释放后允许重试（否则一次网络抖动让列表永久空着）', async () => {
+    const { createOncePerKeyGate } = await import('../src/dashboard/web/bot-defaults.js');
+    const gate = createOncePerKeyGate();
+    expect(gate.claim('cli_a')).toBe(true);
+    gate.release('cli_a');                    // 请求失败
+    expect(gate.claim('cli_a')).toBe(true);   // 下次激活重试
+    expect(gate.claim('cli_a')).toBe(false);  // 成功后又收敛
+  });
+
+  it('release 只影响当前 key，不会误放行别的 bot', async () => {
+    const { createOncePerKeyGate } = await import('../src/dashboard/web/bot-defaults.js');
+    const gate = createOncePerKeyGate();
+    gate.claim('cli_a');
+    gate.release('cli_b');                    // 过期的失败回调（已切走）
+    expect(gate.claimed('cli_a')).toBe(true); // cli_a 的认领不该被撤销
+    expect(gate.claim('cli_a')).toBe(false);
+  });
+});

--- a/test/dashboard-groups-names-view.test.ts
+++ b/test/dashboard-groups-names-view.test.ts
@@ -1,0 +1,210 @@
+/**
+ * dashboard-groups-names-view.test.ts
+ *
+ * 钉住 `?view=names` 轻量视图的契约，重点是**它不能悄悄削弱名称/头像**。
+ *
+ * 背景（MEASURED，本机直连）：`/api/groups` 完整矩阵 12.59MB，其中
+ * `chats[].memberBots`（1420 群 × 56 bot）独占 12341KB；而 `loadNameMaps()`
+ * 只需要 bots 的名称/头像 + chats 的 chatId/name/avatar。
+ *
+ * 为什么不复用已有的 `?view=compact`：实测它的顶层 key 只有 `['chats']`，
+ * `bots` 是 undefined。而 `loadNameMaps()` 恰恰读 `data.bots` —— 直接换过去
+ * 会让 56 个 bot 的名字和头像**全部**退化成 raw appId。这是本次优化最容易
+ * 踩、且用户一眼可见的退化，所以下面第一组用例专门把它钉死。
+ *
+ * 第二个风险是缓存污染：群组页 / 角色页 / 日程页 / Bot 配置页的反馈区块都
+ * 真的要读 `memberBots`。若轻量结果被灌进共享的 `cachedSnapshot`，它们会拿到
+ * `memberBots: []` —— 「群里一个 bot 都没有」的静默错数据，比报错更难发现。
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  compactGroupsMatrix,
+  groupsNamesMatrix,
+  type GroupsMatrix,
+} from '../src/dashboard/groups-matrix-snapshot.js';
+
+function matrix(): GroupsMatrix {
+  return {
+    chats: [
+      {
+        chatId: 'oc_release',
+        name: 'Release room',
+        avatar: 'https://example.com/release.png',
+        ownerId: 'ou_owner',
+        chatMode: 'group',
+        // 12.34MB 的大头：本视图必须摘掉
+        memberBots: [
+          { larkAppId: 'cli_a', botName: 'claude', inChat: true, hasRole: true },
+          { larkAppId: 'cli_b', botName: 'codex', inChat: false },
+        ],
+      },
+      { chatId: '', name: 'no id — dropped' },
+    ],
+    bots: [
+      {
+        larkAppId: 'cli_a',
+        botName: 'claude',
+        botAvatarUrl: 'https://example.com/a.png',
+        cliId: 'claude-code',
+      },
+      {
+        larkAppId: 'cli_b',
+        botName: 'codex',
+        botAvatarUrl: 'https://example.com/b.png',
+        cliId: 'codex',
+      },
+    ],
+  };
+}
+
+describe('groupsNamesMatrix — 名称/头像投影', () => {
+  it('保留 bots 整行（名称+头像+cliId），这是与 compact 的关键差别', () => {
+    const names = groupsNamesMatrix(matrix());
+    // 有牙的那一半：compact 没有 bots，names 必须有。把实现改成
+    // `return compactGroupsMatrix(matrix)` 这条会红。
+    expect(names.bots).toHaveLength(2);
+    expect(names.bots).toEqual(matrix().bots);
+    // 名称与头像逐字段在位——loadNameMaps() 就是读这两个字段的
+    for (const bot of names.bots as Array<Record<string, unknown>>) {
+      expect(typeof bot.larkAppId).toBe('string');
+      expect(typeof bot.botName).toBe('string');
+      expect(typeof bot.botAvatarUrl).toBe('string');
+    }
+  });
+
+  it('摘掉 memberBots（12.34MB 的来源），chats 只留 chatId/name/avatar', () => {
+    const names = groupsNamesMatrix(matrix());
+    expect(names.chats).toEqual([
+      {
+        chatId: 'oc_release',
+        name: 'Release room',
+        avatar: 'https://example.com/release.png',
+      },
+    ]);
+    for (const chat of names.chats) {
+      expect(chat).not.toHaveProperty('memberBots');
+      // 顺带确认公开只读边界没被放宽：ownerId 不在投影里
+      expect(chat).not.toHaveProperty('ownerId');
+    }
+  });
+
+  it('与 compact 共用同一条 chats 白名单（避免两处实现漂移）', () => {
+    expect(groupsNamesMatrix(matrix()).chats).toEqual(compactGroupsMatrix(matrix()).chats);
+  });
+
+  it('compact 仍然不带 bots —— 记录「为何不能复用它」这个前提', () => {
+    // 若将来有人给 compact 加上 bots，这条会红，提示回来重新评估本视图是否
+    // 还有必要（而不是让两个视图静默重复）。
+    expect(compactGroupsMatrix(matrix())).not.toHaveProperty('bots');
+  });
+});
+
+describe('路由接线与前端调用方（source-lock）', () => {
+  it('/api/groups 注册了 view=names 分支，且不与 compact 抢路径', () => {
+    const source = readFileSync(resolve('src/dashboard.ts'), 'utf8');
+    const start = source.indexOf("url.pathname === '/api/groups'");
+    expect(start).toBeGreaterThan(-1);
+    const block = source.slice(start, start + 2600);
+    expect(block).toContain("url.searchParams.get('view') === 'names'");
+    expect(block).toContain('groupsNamesMatrix(matrix)');
+    // compact 分支仍在（不是被替换掉）
+    expect(block).toContain("url.searchParams.get('view') === 'compact'");
+    expect(block).toContain('compactGroupsMatrix(matrix)');
+  });
+
+  it('loadNameMaps 走轻量视图，且不再拉完整矩阵', () => {
+    const source = readFileSync(resolve('src/dashboard/web/ui.ts'), 'utf8');
+    expect(source).toContain('fetchGroupsNamesSnapshot()');
+    // 有牙：改回 fetchGroupsSnapshot() 就红（12.59MB 又回来了）
+    expect(source).not.toContain('fetchGroupsSnapshot(');
+  });
+
+  it('轻量缓存与完整矩阵缓存分离，绝不污染需要 memberBots 的页面', () => {
+    const source = readFileSync(resolve('src/dashboard/web/groups-api.ts'), 'utf8');
+    // 两条独立的缓存变量
+    expect(source).toContain('let cachedNames');
+    expect(source).toContain('let cachedNamesAt');
+    // 按声明位置切出两个函数体，**不假设**它们在文件里的先后顺序（早先一版
+    // 测试把顺序写反，导致切片跑到文件末尾、把另一个函数也圈进来而误红）。
+    const bounds = [
+      { name: 'names', at: source.indexOf('export async function fetchGroupsNamesSnapshot') },
+      { name: 'full', at: source.indexOf('export async function fetchGroupsSnapshot') },
+    ].sort((a, b) => a.at - b.at);
+    expect(bounds[0].at).toBeGreaterThan(-1);
+    const bodyOf = (name: 'names' | 'full'): string => {
+      const i = bounds.findIndex(b => b.name === name);
+      const from = bounds[i].at;
+      const to = i + 1 < bounds.length ? bounds[i + 1].at : source.length;
+      return source.slice(from, to);
+    };
+    // 关键判据：轻量路径**不得**调用 primeGroupsSnapshotCache（那会把
+    // memberBots: [] 灌进群组/角色/日程页共用的那份快照）。
+    const namesFn = bodyOf('names');
+    expect(namesFn).not.toContain('primeGroupsSnapshotCache');
+    expect(namesFn).toContain('cachedNames = snapshot');
+    // 完整矩阵那条路径仍然写共享缓存（没被误伤）
+    const fullFn = bodyOf('full');
+    expect(fullFn.length).toBeGreaterThan(0);
+    expect(fullFn).toContain('primeGroupsSnapshotCache(snapshot)');
+  });
+
+  it('仍需 memberBots 的页面继续用完整矩阵（没被顺手改错）', () => {
+    for (const [file, why] of [
+      ['src/dashboard/web/groups-page.tsx', '群组页'],
+      ['src/dashboard/web/bot-defaults-page.tsx', 'Bot 配置页的反馈区块'],
+      ['src/dashboard/web/schedules-page.tsx', '日程页'],
+    ] as const) {
+      const source = readFileSync(resolve(file), 'utf8');
+      expect(source, `${why} 必须继续拉完整矩阵`).toContain('fetchGroupsSnapshot');
+      expect(source, `${why} 不该改用轻量视图`).not.toContain('fetchGroupsNamesSnapshot');
+    }
+  });
+
+  // ─── 启动链与 Cards tab 两条回归（源码守卫覆盖不到的运行时路径）────────
+  //
+  // 起因：app.tsx 启动时并行跑 loadNameMaps() 与 loadGroupsSnapshot()。master
+  // 上两者打同一个 fetchGroupsSnapshot()，被 in-flight 去重成**一次**请求。
+  // 只把前者换成 names ⟹ 落在不同 in-flight 上 ⟹ 变成「names 387KB + full
+  // 12.73MB」两发，MEASURED 合计 13.11MB，**比改动前 12.73MB 更差**。
+  it('overview 与 loadNameMaps 必须共享同一个 in-flight（否则首页净增一发）', () => {
+    const overview = readFileSync(resolve('src/dashboard/web/overview.ts'), 'utf8');
+    const ui = readFileSync(resolve('src/dashboard/web/ui.ts'), 'utf8');
+    // 两条都必须走轻量视图，才会命中同一个 namesInFlight
+    expect(overview).toContain('fetchGroupsNamesSnapshot()');
+    expect(ui).toContain('fetchGroupsNamesSnapshot()');
+    // 有牙：overview 退回完整矩阵 → 红（启动链那条回归）
+    expect(overview).not.toMatch(/fetchGroupsSnapshot\(/);
+    // app.tsx 确实并行跑这两个（前提没变；若哪天不再并行，本用例的理由需重估）
+    const app = readFileSync(resolve('src/dashboard/web/app.tsx'), 'utf8');
+    expect(app).toContain('loadNameMaps()');
+    expect(app).toContain('loadGroupsSnapshot()');
+  });
+
+  it('反馈区块的完整矩阵拉取延迟到 Cards tab 激活，且不靠条件卸载', () => {
+    const source = readFileSync(resolve('src/dashboard/web/bot-defaults-page.tsx'), 'utf8');
+    // 各 tab 用 hidden 隐藏而非卸载 ⟹ 本区块任何 tab 下都会 mount。
+    // 无条件拉取 = 每次进 Bot 配置页都后台补一发 12.7MB。
+    expect(source).toContain('active={props.activeTab === \'cards\'}');
+    const section = source.slice(
+      source.indexOf('function FeedbackSettingsSection'),
+      source.indexOf('async function save', source.indexOf('function FeedbackSettingsSection')),
+    );
+    expect(section.length).toBeGreaterThan(0);
+    // 有牙：删掉这道闸 → 红
+    expect(section).toContain('if (!props.active) return;');
+    // 「每 bot 只拉一次」闸门：把 active 加进依赖会让每次切回 tab 都重跑 effect，
+    // 3s 缓存过期后又一发 12.7MB。行为断言在
+    // dashboard-groups-names-inflight.test.ts 的 createOncePerKeyGate 用例里。
+    expect(section).toContain('chatsGateRef.current.claim(props.bot.larkAppId)');
+    // 失败要释放认领，否则一次网络抖动让该 bot 的群列表永久空着
+    expect(section).toContain('chatsGateRef.current.release(appId)');
+    // 依赖数组要带 active，否则激活后不会重跑
+    expect(section).toMatch(/\[props\.bot\.larkAppId,\s*props\.active\]/);
+    // 刻意保留挂载（不做 `{active && <Section/>}`）：条件卸载会丢用户正在编辑
+    // 的 JSON 草稿。这里断言 section 仍是无条件渲染的。
+    expect(source).toMatch(/<FeedbackSettingsSection[^>]*active=/);
+    expect(source).not.toMatch(/\{\s*props\.activeTab === 'cards' && <FeedbackSettingsSection/);
+  });
+});


### PR DESCRIPTION
## 问题

「Bot 配置」页打开慢。实测瓶颈**不在 56 个 bot 的扇出**——`/api/bots` 只要 40-50ms，per-daemon 扇出 p50 184ms、0 错误——而在页面 mount 时**并行发出**的另外两个请求；其中一处同时也拖慢**每次进 dashboard** 的启动链。

| 端点 | 改前 | 体积 |
|---|---|---|
| `/api/bots` | 40-50ms | 105KB |
| `/api/cli-options` | **med 3350ms，max 37218ms** | 7KB |
| `/api/groups`（启动链） | 冷 5537ms | **12.73MB** |

## 改了什么

### 1) `/api/cli-options`：每次请求都做一次实时飞书往返，而本页拿到就丢

handler 第一个 `await` 是 `botOnboarding.sessionStatus()`，一路走到 `inspectCachedFeishuOpenPlatformSession()` —— 对开放平台的**真实网络请求**（单独计时 1004 / 1091 / 2530ms）。而同一 handler 里真正要算的东西只有 **13ms**（39 个 CLI 的 `checkCliAvailability` 12ms + `staticModelChoices` 1ms）。

这个 `webSession` 字段**只有「添加机器人」弹窗消费**（决定 reuse/qr 登录模式并展示账号）。Bot 配置页的 `CliOptionsState`（`web/bot-defaults.ts`）类型里**根本没有它**。

→ 改为 `?probe=none` 显式跳过：**裸端点保留原语义**（照旧探测），Bot 配置页带参数走快路径。

⚠️ **方向不能反。** 路由 chunk 带 `immutable` 长缓存，而 stale-chunk 自愈只在**动态 import 失败**时触发（全仓仅 `app.tsx` 一个 call site）。所以 dashboard 重启后，**已加载的旧 Bot 配置 chunk 会继续请求裸端点**；裸端点若默认不探测，旧 chunk 会在 `body?.webSession?.status === 'ready'` 处把「字段缺席」判成 `scan_required`，**把登录态正常的用户推去扫码**。新增 `not_probed` 状态也救不了（旧代码不认识）。

```
裸端点(旧 chunk)     9921ms   webSession 字段在    ← 兼容
?probe=none(新页)     119ms   webSession 字段缺席  ← 快路径
options 两条都是 39
```

### 2) `/api/groups`：传 12.73MB，其中 12.34MB 没人用

`loadNameMaps()`（`web/ui.ts`）只需要 bots 的名称/头像 + chats 的 chatId/name/avatar，但拉的是完整矩阵：`chats[].memberBots`（1420 群 × 56 bot）独占 **12341KB**。新增 `?view=names` 投影：**bots 整行透传**，只摘掉 `memberBots`。

**不复用已有的 `?view=compact`**——实测它的顶层 key 只有 `['chats']`，**没有 `bots`**，而 `loadNameMaps()` 恰恰读 `data.bots`。直接换过去会让 **56 个 bot 的名字和头像全部退化成 raw appId，且不报错**。

⚠️ **关键是请求去重。** `app.tsx:1696-1697` 启动时并行跑 `loadNameMaps()` 与 `loadGroupsSnapshot()`；改动前两者打的是同一个 `fetchGroupsSnapshot()`，被 `in-flight` **去重成一发**。只改一边会落在不同 in-flight 上，变成「names 387KB + full 12.73MB」**两发**（实测 13.11MB，**比不改更差**）。

所以 `overview.ts` 也改走 names。字段面已核：`buildBotCards()` 只遍历 `snapshot.bots`、只读 `larkAppId / botName / botAvatarUrl / cliId / brand`；`snapshot.chats` 在该文件**零读取**；`attentionReason()` 只看传入的 session row。`brand` 由 `buildGroupsMatrix` 注入 bots 行，本投影整行透传不会丢。

```
启动链传输  12.73MB → 387KB  (省 97.0%)
```

**前端缓存严格分离**：轻量视图有独立的 `cachedNames`/`namesInFlight`，**绝不**调用 `primeGroupsSnapshotCache`。群组页 / 角色页 / 日程页 / 本页的 `FeedbackSettingsSection` 都**真读** `memberBots`，污染共享缓存会让它们拿到 `memberBots: []`——「群里一个 bot 都没有」的**静默错数据**。反向复用安全（完整矩阵是超集），已实现。

### 3) 反馈设置区块：延迟到 Cards tab 激活，且收敛为每 bot 一次

该区块要 `memberBots`（只有完整矩阵有），而各 tab 用 `hidden` 隐藏而非条件卸载 ⟹ 组件在任何 tab 下都 mount，无条件拉取等于进页面就补一发 12.7MB。

按 `active` 延迟到 Cards tab 真正激活才拉。**刻意不用条件卸载**（`{active && <Section/>}`）：那会丢掉用户正在编辑的 JSON 草稿与开关状态。

但把 `active` 加进 effect 依赖，副作用是**每次切回 Cards tab 都重跑**（cards → common → 隔几秒回 cards，3s 缓存已过期 ⟹ 又一发 12.7MB）。原语义是「每次 mount / 每个 botId 一次」，延迟加载不该放宽它。所以抽出 `createOncePerKeyGate()`（同 `createRefreshGate` 的纯工厂做法）收敛为每 bot 一次；失败释放认领，避免一次网络抖动让该 bot 的群列表永久空着。

## 实测

```
/api/cli-options (配置页)   med 3350ms (max 37218ms) → 119ms，options 39 = 39
启动链传输                  12.73MB → 387KB (省 97.0%)
?view=names                 387KB / 6-14ms
/api/groups (完整，其它页)  12.72MB，memberBots[0]=56 ✓ 未受损
```

**名称/头像零丢失，逐字段核对非抽样**：bots 56 → 56；`botName` 56/56；`botAvatarUrl` 56/56；overview 需要的 4 个字段各 56/56。chats 1420 → 1420，同一 build 内对照 avatar **1420/1420**、name 1419/1420（那一个是 `""` vs `undefined`，消费侧 `if (c.chatId && c.name)` 两者同为 falsy、走同一分支，**行为逐字相同**）。

## 实时性（名称/头像最忌讳陈旧）

**不靠加长缓存换速度：没有放宽任何 TTL。** 前端 3s dedupe 与服务端 30s 快照 + roster 失效通知全部照旧，名称/头像的新鲜度与改动前一致，变的只有同一次请求传多少字节；顺带省掉主线程 38-70ms 的 `JSON.parse`。改头像的即时生效路径 `overrideBotAvatar()` 未触及。

补一条实测澄清：`loadNameMaps` 的 `nameMapsPromise` 成功后会 memo，所以名称/头像每个页面生命周期只真拉一次 —— **既有行为**，本改动未触及。另外 `/api/bots` 带 `botName` 但**不带** `botAvatarUrl`，所以头像的快通路只有 `overrideBotAvatar()`。

## 影响范围评估

- **公共层未动**：没改 `jsonRes`、没加压缩，其它 dashboard 端点零影响
- **Route B `/__daemon/groups-matrix` 与 `?view=compact` 原样保留**，仍拿完整矩阵
- **公开只读边界未放宽**：names 投影的 chats 只有 chatId/name/avatar，比 `redactGroupsForPublic` 的输出**更窄**（它还保留 chatMode/memberBots）；`bots` 在默认分支对未认证访客本就原样下发 ⟹ 无新增暴露面
- **跨页面**：需要 `memberBots` 的三个页面 + 本页反馈区块继续走完整矩阵，已有守卫钉住

## 测试

**守卫 46 passed、`tsc --noEmit` 干净、CI 7 checks 全绿。**

**行为测试（非 source-lock）直接数 fetch 次数**——source-lock 只能证明代码写对了，证不出运行时真的只发一次。stub 带 20ms 延迟把并发窗口张开（否则第一个调用同步完成，「第二个命中 in-flight」会 vacuous pass），并放 canary 先证明 stub 接上了：

- `app.tsx` 形态（`Promise.all` 两个 names）→ names 一发、full **零发**
- names 与 full 混用 → 各一发，互不复用也互不抵消
- full 先落地 → names 复用它；names 先落地 → 需要 `memberBots` 的调用方**仍真拉 full**
- `createOncePerKeyGate`：二次激活不重拉、换 bot 重拉、失败可重试、release 不误放行

**反变异每条实跑**（不是只跑绿的那次）：

| 变异 | 结果 |
|---|---|
| 服务端退回无条件 `await sessionStatus()` | 🔴 |
| 退回 opt-in（旧 chunk 把用户推去扫码） | 🔴 |
| 配置页退回裸端点 | 🔴 |
| `bots: []`（名称头像全丢） | 🔴 |
| 轻量路径写共享缓存（静默污染） | 🔴 |
| `loadNameMaps` 退回完整矩阵 | 🔴 |
| `overview` 退回完整矩阵（启动链回归） | 🔴 |
| 删 Cards tab 延迟闸 | 🔴 |
| 去掉 in-flight 去重 | 🔴 |
| 去掉 once-per-key 闸 | 🔴 |
| full 路径错误复用 names 缓存 | 🔴 |

另核实 Cards tab 的 `active` 覆盖面：`activeTab` 恒以 `'common'` 初始化，全仓无 hash/URL 驱动的 tab 恢复路径（`dashboard-routes` 只注册页面级 `'#/bot-defaults'`）。

全量套件 20 failed 均为**既有账**，两种方式确认与本改动无关：16 个是缺 `MIDSCENE_MODEL_API_KEY` 的浏览器 e2e（本机跑不了）；`coco-streaming`/`coco`/`multi-bot-session`/`mojo-launcher-env-quarantine`/`plugin-mcp-gateway` 经 canonical master 基线逐条吻合（6 failed | 66 passed）；`codex-input` 与 `plugin-mcp-sandbox` 经「把本改动全部 stash 后同样失败」确认。

## 未做

**JSON 响应压缩没做**（`jsonRes` 目前无 gzip，12.6MB 实测可压到 224KB）。收益大但要动公共层 —— 所有端点都过那条路；且本改动后名称链路已只剩 387KB，边际收益小得多。留作独立评估。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
