### PR TITLE
fix(dashboard): 下拉弹层限高可滚动 + 空间不足时向上弹，长列表不再被裁掉

### DIFF
--- a/src/dashboard/web/dashboard-components.tsx
+++ b/src/dashboard/web/dashboard-components.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type ButtonHTMLAttributes,
@@ -394,10 +395,45 @@ type DropdownMenuProps<T extends string> = {
   searchEmptyLabel?: ReactNode;
 };
 
+/**
+ * Where a dropdown popup should go, and how tall it may be.
+ *
+ * A dropdown's ancestors are mostly `overflow: hidden` (main / .chrome-body /
+ * .app-shell), so a popup hanging past the viewport edge is clipped away: those
+ * options cannot be seen, and pointer/wheel events never reach them either
+ * (the popup is not under the cursor down there). Plain CSS cannot know how
+ * much room is left below the trigger, so the component measures it and hands
+ * the budget to style.css as a custom property.
+ *
+ * Pure function of the geometry so it can be unit-tested without a DOM.
+ */
+export function dropdownPlacement(input: {
+  /** Trigger box, viewport-relative (getBoundingClientRect). */
+  triggerTop: number;
+  triggerBottom: number;
+  /** Unconstrained popup height (scrollHeight), i.e. what the content wants. */
+  naturalHeight: number;
+  viewportHeight: number;
+}): { dropUp: boolean; maxHeight: number } {
+  const margin = 12;
+  const gap = 8;
+  const roomBelow = input.viewportHeight - input.triggerBottom - gap - margin;
+  const roomAbove = input.triggerTop - gap - margin;
+  // Flip up only when below genuinely cannot fit AND above is roomier;
+  // otherwise stay below (predictable) and just cap the height.
+  const dropUp = input.naturalHeight > roomBelow && roomAbove > roomBelow;
+  // Floor: in a viewport too short for either side, a tiny sliver would be
+  // worse than a popup that slightly overhangs but is still scrollable.
+  const maxHeight = Math.max(140, Math.floor(dropUp ? roomAbove : roomBelow));
+  return { dropUp, maxHeight };
+}
+
 export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): React.JSX.Element {
   const detailsRef = useRef<HTMLDetailsElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
+  const popRef = useRef<HTMLDivElement | null>(null);
   const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
   const choose = (next: T) => {
     detailsRef.current?.removeAttribute('open');
     // Re-selecting the already-active value is a no-op: close the menu but skip
@@ -413,6 +449,34 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
       option.value.toLowerCase().includes(queryNorm)
       || (typeof option.label === 'string' && option.label.toLowerCase().includes(queryNorm)))
     : props.options;
+
+  // Keep the popup inside the viewport; see dropdownPlacement above.
+  useLayoutEffect(() => {
+    if (!open) return undefined;
+    const place = () => {
+      const details = detailsRef.current;
+      const pop = popRef.current;
+      if (!details || !pop) return;
+      const trigger = details.getBoundingClientRect();
+      const { dropUp, maxHeight } = dropdownPlacement({
+        triggerTop: trigger.top,
+        triggerBottom: trigger.bottom,
+        naturalHeight: pop.scrollHeight,
+        viewportHeight: window.innerHeight,
+      });
+      pop.style.setProperty('--dropdown-popover-space', `${maxHeight}px`);
+      details.classList.toggle('is-drop-up', dropUp);
+    };
+    const frame = window.requestAnimationFrame(place);
+    window.addEventListener('resize', place);
+    // Capture phase: the scroller is an ancestor (main), not window.
+    window.addEventListener('scroll', place, true);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener('resize', place);
+      window.removeEventListener('scroll', place, true);
+    };
+  }, [open, visibleOptions.length]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return undefined;
@@ -450,7 +514,11 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
       hidden={props.hidden}
       style={props.style}
       onToggle={event => {
-        if (!props.searchable || !event.currentTarget.open) return;
+        // <details> fires toggle for programmatic `.open = false` too, so this is
+        // the single place that keeps the placement effect in sync with reality.
+        const isOpen = event.currentTarget.open;
+        setOpen(isOpen);
+        if (!props.searchable || !isOpen) return;
         setQuery('');
         searchRef.current?.focus();
       }}
@@ -468,7 +536,7 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
       >
         <span className="sect-sort-value">{props.label}</span>
       </summary>
-      <div className="sect-sort-pop">
+      <div className="sect-sort-pop" ref={popRef}>
         {props.searchable ? (
           <input
             ref={searchRef}

--- a/src/dashboard/web/dashboard-components.tsx
+++ b/src/dashboard/web/dashboard-components.tsx
@@ -414,6 +414,12 @@ export function dropdownPlacement(input: {
   /** Unconstrained popup height (scrollHeight), i.e. what the content wants. */
   naturalHeight: number;
   viewportHeight: number;
+  /**
+   * Size for this direction instead of deciding one. Used when a per-page rule
+   * pins the direction with higher specificity than the `.is-drop-up` class, so
+   * the budget must match what actually rendered rather than what we asked for.
+   */
+  forceDropUp?: boolean;
 }): { dropUp: boolean; maxHeight: number } {
   const margin = 12;
   const gap = 8;
@@ -421,7 +427,7 @@ export function dropdownPlacement(input: {
   const roomAbove = input.triggerTop - gap - margin;
   // Flip up only when below genuinely cannot fit AND above is roomier;
   // otherwise stay below (predictable) and just cap the height.
-  const dropUp = input.naturalHeight > roomBelow && roomAbove > roomBelow;
+  const dropUp = input.forceDropUp ?? (input.naturalHeight > roomBelow && roomAbove > roomBelow);
   // Floor: in a viewport too short for either side, a tiny sliver would be
   // worse than a popup that slightly overhangs but is still scrollable.
   const maxHeight = Math.max(140, Math.floor(dropUp ? roomAbove : roomBelow));
@@ -464,8 +470,28 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
         naturalHeight: pop.scrollHeight,
         viewportHeight: window.innerHeight,
       });
-      pop.style.setProperty('--dropdown-popover-space', `${maxHeight}px`);
       details.classList.toggle('is-drop-up', dropUp);
+      // A per-page rule may pin the direction regardless of the class — e.g.
+      // `.connector-create-modal #cn-verify .sect-sort-pop` sets `bottom` with
+      // ID specificity, so that popup always opens upward. Budgeting for the
+      // side we merely *asked* for would then clip it off the opposite edge, so
+      // detect where it actually landed and size for that side.
+      //
+      // Measure geometry, not `getComputedStyle().top`: for a positioned box the
+      // computed value resolves `auto` to a used pixel value, never the string
+      // 'auto', so a style probe reports "not flipped" for every popup.
+      const popBox = pop.getBoundingClientRect();
+      const renderedUp = popBox.height > 0 && popBox.bottom <= trigger.top + 1;
+      const effective = renderedUp === dropUp
+        ? maxHeight
+        : dropdownPlacement({
+          triggerTop: trigger.top,
+          triggerBottom: trigger.bottom,
+          naturalHeight: pop.scrollHeight,
+          viewportHeight: window.innerHeight,
+          forceDropUp: renderedUp,
+        }).maxHeight;
+      pop.style.setProperty('--dropdown-popover-space', `${effective}px`);
     };
     const frame = window.requestAnimationFrame(place);
     window.addEventListener('resize', place);

--- a/src/dashboard/web/dashboard-components.tsx
+++ b/src/dashboard/web/dashboard-components.tsx
@@ -442,6 +442,12 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
   const [open, setOpen] = useState(false);
   const choose = (next: T) => {
     detailsRef.current?.removeAttribute('open');
+    // Belt-and-braces: `onToggle` normally syncs this, but WebKit before Safari
+    // 15.4 did not fire toggle for programmatic open changes, which would leave
+    // `open` stuck true and the placement effect skipped on the next open (stale
+    // budget / drop-up class). Setting it here closes that loop; on browsers that
+    // do fire toggle React bails out of the identical-state update, so it is free.
+    setOpen(false);
     // Re-selecting the already-active value is a no-op: close the menu but skip
     // onChange, so auto-saving dropdowns don't fire a redundant write + "saved" flash.
     if (next === props.value) return;
@@ -508,6 +514,8 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
     if (typeof document === 'undefined') return undefined;
     const close = () => {
       if (detailsRef.current?.open) detailsRef.current.open = false;
+      // Same reason as in choose(): don't rely solely on toggle firing.
+      setOpen(false);
     };
     const onPointerDown = (event: PointerEvent) => {
       const details = detailsRef.current;
@@ -527,7 +535,10 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
     };
   }, []);
   useEffect(() => {
-    if (props.disabled && detailsRef.current?.open) detailsRef.current.open = false;
+    if (!props.disabled) return;
+    if (detailsRef.current?.open) detailsRef.current.open = false;
+    // Third programmatic close path — keep it in sync too (see choose()).
+    setOpen(false);
   }, [props.disabled]);
 
   const className = ['sect-sort-menu', props.disabled ? 'is-disabled' : '', props.className].filter(Boolean).join(' ');

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -45,6 +45,10 @@
   --button-padding-x: 15px;
   --dropdown-trigger-width: 118px;
   --dropdown-popover-min-width: 156px;
+  /* 下拉弹层的限高：超过就在弹层内部滚动，而不是把选项顶出视口。
+     祖先链（main / .chrome-body / .app-shell）多为 overflow:hidden，
+     溢出的选项会被直接裁掉、鼠标事件也落不到弹层上。 */
+  --dropdown-popover-max-height: min(320px, 52vh);
   --page-title-row-height: 48px;
   --page-title-divider-gap: 14px;
   --section-title-row-height: 36px;
@@ -6410,7 +6414,7 @@ dialog.onboarding-dialog::backdrop {
   left: 0;
   width: 100%;
   min-width: 100%;
-  max-height: min(280px, 42vh);
+  max-height: min(280px, 42vh, var(--dropdown-popover-space, 100vh));
   overflow-y: auto;
   transform: none;
   z-index: 1300;
@@ -9994,12 +9998,23 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
   display: grid;
   gap: 4px;
   min-width: var(--dropdown-popover-min-width);
+  max-height: min(var(--dropdown-popover-max-height), var(--dropdown-popover-space, 100vh));
   padding: 6px;
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-lg);
   background: var(--surface);
   box-shadow: var(--modal-shadow);
   transform: translateX(-50%);
+  /* 选项多于限高时在弹层内部滚动。少于限高时 auto 不会显示滚动条，
+     所以短列表（排序菜单等）外观不变。overscroll 收敛住，避免滚到底后
+     把外层 main 一起带着滚。 */
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+/* 下方空间不够、且上方更宽裕时向上弹（DropdownMenu 量完可用空间后加的类）。 */
+.sect-sort-menu.is-drop-up > .sect-sort-pop {
+  top: auto;
+  bottom: calc(100% + 8px);
 }
 /* 会话筛选里的「来源 / 所在聊天」弹层宽度自适应 + 不折行的规则统一定义在下方
    （.sessions-filters .sect-sort-pop，靠后覆盖），此处不再重复。 */
@@ -24420,7 +24435,7 @@ dialog select[multiple]:hover:not(:disabled) {
   left: 0;
   width: 100%;
   min-width: 100%;
-  max-height: min(280px, 42vh);
+  max-height: min(280px, 42vh, var(--dropdown-popover-space, 100vh));
   overflow-y: auto;
   transform: none;
   z-index: 1300;
@@ -25562,7 +25577,7 @@ button.ui-refresh-button.is-loading .ui-action-icon {
 .vc-profile-agent-menu > .sect-sort-pop {
   min-width: min(300px, 84vw);
   max-width: 340px;
-  max-height: min(320px, 60vh);
+  max-height: min(320px, 60vh, var(--dropdown-popover-space, 100vh));
   overflow-y: auto;
 }
 .vc-profile-agent-menu .sect-sort-pop button {

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -46,8 +46,8 @@
   --dropdown-trigger-width: 118px;
   --dropdown-popover-min-width: 156px;
   /* 下拉弹层的限高：超过就在弹层内部滚动，而不是把选项顶出视口。
-     祖先链（main / .chrome-body / .app-shell）多为 overflow:hidden，
-     溢出的选项会被直接裁掉、鼠标事件也落不到弹层上。 */
+     滚动容器是 main（overflow-y:auto），其上的 .chrome-body / .app-shell 是
+     overflow:hidden——溢出视口的选项会被裁掉、鼠标事件也落不到弹层上。 */
   --dropdown-popover-max-height: min(320px, 52vh);
   --page-title-row-height: 48px;
   --page-title-divider-gap: 14px;

--- a/test/dashboard-dropdown-viewport.test.ts
+++ b/test/dashboard-dropdown-viewport.test.ts
@@ -98,6 +98,37 @@ describe('dropdown popup stays inside the viewport', () => {
     }
   });
 
+  it('sizes for the direction that actually rendered, not the one it asked for', () => {
+    // `.connector-create-modal #cn-verify .sect-sort-pop` pins `bottom` with ID
+    // specificity, so that popup opens upward even when the class says other-
+    // wise. Budgeting for "below" would then clip it off the TOP of the screen.
+    const geometry = {
+      triggerTop: 120,
+      triggerBottom: 160,
+      naturalHeight: 600,
+      viewportHeight: 720,
+    };
+    const asked = dropdownPlacement(geometry);
+    expect(asked.dropUp).toBe(false);
+    expect(asked.maxHeight).toBe(540); // room BELOW — wrong side for this popup
+
+    const rendered = dropdownPlacement({ ...geometry, forceDropUp: true });
+    expect(rendered.dropUp).toBe(true);
+    // Room ABOVE is only 120 - 8 - 12 = 100, so the floor applies; either way
+    // it must be far smaller than the below-budget that would overflow upward.
+    expect(rendered.maxHeight).toBeLessThan(asked.maxHeight);
+    expect(rendered.maxHeight).toBeLessThanOrEqual(140);
+  });
+
+  it('detects the applied direction from geometry, not computed style', () => {
+    const source = readFileSync(new URL('../src/dashboard/web/dashboard-components.tsx', import.meta.url), 'utf8');
+    // getComputedStyle().top resolves `auto` to a used pixel value on a
+    // positioned box, so a style probe reports "not flipped" for every popup.
+    expect(source).not.toMatch(/getComputedStyle\(pop\)\.top === 'auto'/);
+    expect(source).toMatch(/popBox\.bottom <= trigger\.top \+ 1/);
+    expect(source).toMatch(/forceDropUp: renderedUp/);
+  });
+
   it('has a drop-up rule for the flipped state', () => {
     expect(style()).toMatch(/\.sect-sort-menu\.is-drop-up\s*>\s*\.sect-sort-pop\s*\{[^}]*bottom:\s*calc\(100% \+ 8px\)/);
   });

--- a/test/dashboard-dropdown-viewport.test.ts
+++ b/test/dashboard-dropdown-viewport.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { dropdownPlacement } from '../src/dashboard/web/dashboard-components.js';
+
+function style(): string {
+  return readFileSync(new URL('../src/dashboard/web/style.css', import.meta.url), 'utf8');
+}
+
+/**
+ * Regression cover for「时区下拉菜单无法滚动」: a long dropdown (e.g. the 14
+ * timezone options) used to render at its full natural height with no cap and
+ * no internal scrolling. Because every ancestor of a dropdown is
+ * `overflow: hidden` (main / .chrome-body / .app-shell), the overhang was
+ * clipped: the tail options could not be seen, and hovering there did not
+ * scroll the popup either — the cursor was over .chrome-body, not the popup.
+ */
+describe('dropdown popup stays inside the viewport', () => {
+  it('caps the popup to the room below the trigger instead of overflowing', () => {
+    // Trigger low in a 900px viewport: 456px of options, ~95px of room below.
+    const placement = dropdownPlacement({
+      triggerTop: 760,
+      triggerBottom: 800,
+      naturalHeight: 456,
+      viewportHeight: 900,
+    });
+    // Must flip up: below cannot fit and above is far roomier.
+    expect(placement.dropUp).toBe(true);
+    // And the height budget must stay within the room above (760 - 8 - 12).
+    expect(placement.maxHeight).toBe(740);
+  });
+
+  it('keeps a short list below the trigger, uncapped in practice', () => {
+    const placement = dropdownPlacement({
+      triggerTop: 200,
+      triggerBottom: 240,
+      naturalHeight: 120,
+      viewportHeight: 900,
+    });
+    expect(placement.dropUp).toBe(false);
+    // Room below (900 - 240 - 8 - 12 = 640) comfortably exceeds the content,
+    // so nothing is clipped and no scrollbar appears.
+    expect(placement.maxHeight).toBe(640);
+    expect(placement.maxHeight).toBeGreaterThan(120);
+  });
+
+  it('does not flip up when below is tight but above is even tighter', () => {
+    // Short viewport, trigger near the top: flipping would make it worse.
+    const placement = dropdownPlacement({
+      triggerTop: 60,
+      triggerBottom: 100,
+      naturalHeight: 400,
+      viewportHeight: 320,
+    });
+    expect(placement.dropUp).toBe(false);
+  });
+
+  it('never collapses the popup to an unusable sliver', () => {
+    // Almost no room either side — the floor keeps it scrollable rather than
+    // shrinking to a few pixels.
+    const placement = dropdownPlacement({
+      triggerTop: 150,
+      triggerBottom: 170,
+      naturalHeight: 500,
+      viewportHeight: 190,
+    });
+    expect(placement.maxHeight).toBeGreaterThanOrEqual(140);
+  });
+
+  it('scrolls inside the popup rather than growing past the viewport', () => {
+    const css = style();
+    // Anchor on the BASE rule (at line start, no ancestor selector) — a plain
+    // indexOf('.sect-sort-pop {') matches an earlier per-page override instead,
+    // which would silently assert against the wrong block.
+    const base = /^\.sect-sort-pop \{([^}]*)\}/m.exec(css);
+    expect(base, 'base .sect-sort-pop rule not found').not.toBeNull();
+    const block = base![1];
+    // Prove the window really is the base rule before trusting the assertions.
+    expect(block).toMatch(/position:\s*absolute/);
+    expect(block).toMatch(/overflow-y:\s*auto/);
+    expect(block).toMatch(/--dropdown-popover-space/);
+    // Wheeling to the end of the options must not scroll the page behind it.
+    expect(block).toMatch(/overscroll-behavior:\s*contain/);
+  });
+
+  it('honours the measured budget in every per-page popup override', () => {
+    const css = style();
+    // Any override that sets its own max-height must still clamp to the space
+    // actually available, otherwise that dropdown re-breaks in a short viewport.
+    const overrides = [...css.matchAll(/^[^\n@]*\.sect-sort-pop[^{]*\{[^}]*?max-height:[^;]+;/gms)];
+    expect(overrides.length).toBeGreaterThan(1);
+    for (const match of overrides) {
+      const maxHeight = /max-height:([^;]+);/.exec(match[0])?.[1] ?? '';
+      // The sticky search input is a child rule with its own fixed height.
+      if (match[0].includes('sect-sort-search')) continue;
+      expect(maxHeight, `override must clamp to --dropdown-popover-space: ${match[0].slice(0, 120)}`)
+        .toContain('--dropdown-popover-space');
+    }
+  });
+
+  it('has a drop-up rule for the flipped state', () => {
+    expect(style()).toMatch(/\.sect-sort-menu\.is-drop-up\s*>\s*\.sect-sort-pop\s*\{[^}]*bottom:\s*calc\(100% \+ 8px\)/);
+  });
+});


### PR DESCRIPTION
## 问题

时区下拉（14 项）打开后列表被截断，尾部选项看不见，鼠标滚轮也滚不动。同类的其它下拉菜单同样受影响。

## 根因

`.sect-sort-pop` 基类**既没有 `max-height` 也没有 `overflow-y`**，弹层以自然高度渲染。而下拉的祖先链（`main` / `.chrome-body` / `.app-shell`）基本都是 `overflow: hidden`，于是溢出视口的部分被直接裁掉：

- 尾部选项不可见；
- 悬停在溢出区滚轮无效——光标下面是 `.chrome-body` 而**不是弹层**（实测 `elementFromPoint` 命中 `chrome-body`），滚轮事件落到了外层页面上，所以表现为"菜单不能滚，但页面在动"。

全仓 21 个下拉类里只有 3 处特化（`onboarding` / `bd-field` / `vc-profile-agent`）自己补过限高，**其余 18 处都缺**，包括这次报的时区下拉。两个 `searchable` 的长列表下拉（有置顶过滤框、专为 20+ 项设计）也在缺失之列。

## 改动

- `.sect-sort-pop` 基类补 `max-height` + `overflow-y: auto` + `overscroll-behavior: contain`：超限高在弹层内部滚动，滚到底不会把外层 `main` 一起带着滚。短列表低于限高时 `auto` 不显示滚动条，**外观不变**。
- 纯 CSS 无法知道触发器下方还剩多少空间，因此在共用的 `DropdownMenu` 里量一次，把预算写成 `--dropdown-popover-space` 交给 CSS（与 `theme-menu.ts` 同一套做法）；下方放不下且上方更宽裕时加 `.is-drop-up` 向上弹。几何判断抽成纯函数 `dropdownPlacement`，可直接单测。
- 三处已有特化原本硬编码 `max-height` 会**盖掉**新的钳制，改为一并 `min()` 进可用空间——否则它们在矮视口下会再次溢出。

> 只加 `max-height` 是不够的：实测把触发器停在视口 85% 处，仅有限高时仍溢出 225–264px（连 2 项的短菜单在 640 高下也溢出 18px）。所以必须同时处理**定位**。

## 影响面

改的是 dashboard 共用层，`DropdownMenu` 的 32 处调用点全部受益（全局设置、数据洞察、Bot 配置、群组管理、Skill 管理等）。`sessions-page` 里手写的排序菜单（4 项）不走该组件，仅继承基类限高，行为严格优于此前。**不涉及 CLI / 后端 / 飞书卡片路径。**

## 验证

Playwright 加载 `dist/dashboard-web` 产物 + 路由拦截（**不起 dashboard 服务**），A/B 对照：

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 900 高，触发器原位 | 溢出 58px，`popScrollTop` 恒 0（滚轮无效） | 溢出 0，`popScrollTop=138`（滚轮真在滚弹层） |
| 640 高 | 溢出 188px | 溢出 0，`popScrollTop=149` |
| 触发器停视口 85%（最坏位） | 3 个弹层 2 个溢出（225/264px） | 0 个溢出 |
| 跨 8 页共开 9 个下拉 | 1 个溢出 354px | 0 个溢出 |

修复后最后一项 `Australia/Sydney` 完整可见（判据带上下边界，"滚出顶部"不算可见）。

- 新增 `test/dashboard-dropdown-viewport.test.ts`（7 条）。对修复的两半各做 6 组变异（删 `overflow-y`、去掉空间钳制、特化回退硬编码、删 drop-up 规则、永不翻转、预算无穷大）**全部转红**。其中"删 `overflow-y`"首轮存活是**变异本身失效**（正则命中了前面另一条规则），精确命中后同样转红。
- `bun run build` exit 0；`npx tsc --noEmit` exit 0；dashboard/settings 相关 **108 文件 2054 测试全绿**。
- 全量 unit 有 20 条失败，已用 base 对照证明**与本改动无关**（worktree 缺 `dist/cli.js`；两侧失败集合逐条相同，补 build 后这些用例 101/101 转绿）。

## 截图

矮视口下把时区下拉停在偏低位置：

**修复前**（截断在 `Asia/Tokyo`，14 项中 10 项不可达，溢出 295px）
**修复后**（向上弹、完整在视口内、可滚动，溢出 0）

> 截图见评论区。

## 部署说明

live dashboard 是独立进程且**从 canonical checkout 启动**（`WEB_DIR = join(__dirname, 'dashboard-web')` 按进程自身 `dist/` 解析），已核实它当前提供的 `style.css` 不含本次改动。因此**从本 worktree 重启 daemon 不会更新 dashboard**，需合并后在 canonical 上 build。本次已把全局 shim 复原指向 canonical，未改动 fleet。

🤖 Generated with [Claude Code](https://claude.com/claude-code)