### PR TITLE
test(bun): 单测切到 bun test 并加 home 围栏，堵住测试写脏真实用户目录

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,16 @@ jobs:
           bun-version: 1.4.0
       - run: bun install --frozen-lockfile
       - run: bun run build
+      # Exercise the runner itself before the 20-minute suite. `node --check` cannot
+      # catch a missing binding (a ReferenceError is a RUNTIME error, verified), so a
+      # commit that deleted two constants still printed `994 files` and then ran ZERO
+      # — the whole leg's cost with none of its value. This runs one file in ~6s and
+      # also asserts that no `bun` spawn escaped the home fence.
+      #
+      # NOT under continue-on-error semantics by accident: the job as a whole is
+      # advisory for now, but if this step fails the suite result below is meaningless,
+      # so it runs first and its failure is the one worth reading.
+      - run: bun run test:bun:self-check
       - run: bun run test:bun
 
   # The Bun single-file executable is a SHIPPED artifact (attached to every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,42 @@ jobs:
       - run: bun run test
       - run: bun run workflow-core:test
 
+  # Second runner leg: the SAME unit files executed on Bun instead of Node.
+  #
+  # WHY THIS IS NOT REDUNDANT WITH `bun run test` ABOVE: vitest forks Node
+  # workers even when launched through bun (measured — `bun x vitest` still
+  # reports process.versions.node), so every test BODY in the job above runs on
+  # Node. Bun-specific behaviour is therefore structurally invisible there: its
+  # `fetch` error taxonomy (which cannot distinguish a sent from an unsent
+  # request), its startup-frozen `os.homedir()`, `Bun.file`, compiled-binary
+  # paths. Bun is what ships the single-file executable, so those paths need a
+  # leg that actually runs on it.
+  #
+  # Non-blocking on purpose (for now): the shim in test/bun-test-shim.ts
+  # deliberately does not fake `vi.doMock`/`resetModules`/`importOriginal`, and
+  # scripts/run-bun-tests.mjs excludes the files needing them, but the remaining
+  # population has not yet had a full green baseline established across a CI
+  # runner's environment. Flip `continue-on-error` off once it holds green — a
+  # gate that is red for environmental reasons trains people to ignore it.
+  bun-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - run: bun run test:bun
+
   # The Bun single-file executable is a SHIPPED artifact (attached to every
   # GitHub Release), but until this job existed nothing built or ran it before a
   # tag push — so `bun build --compile` breakage was only discovered at release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,14 @@ jobs:
   # population has not yet had a full green baseline established across a CI
   # runner's environment. Flip `continue-on-error` off once it holds green — a
   # gate that is red for environmental reasons trains people to ignore it.
+  #
+  # The generous timeout is inherent to the design: the runner spawns ONE bun
+  # process PER FILE, because `bun test` otherwise runs every file in a single
+  # process and cross-file interference cascades (measured: 933 failures batched
+  # vs ~2% one-per-process). Startup cost therefore dominates the wall clock.
   bun-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     continue-on-error: true
 
     steps:

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -23,3 +23,20 @@
 # outright, but `.npmrc` is deliberately in `.gitignore` next to `.env` — real
 # ones carry `_authToken` lines — so it stays uncommitted on purpose.
 registry = "https://registry.npmjs.org/"
+
+# `bun test` reads NOTHING from vitest.config.ts, so the home-directory fence
+# mounted there via `setupFiles` does not apply here. Without these preloads a
+# `bun test` run writes into the developer's REAL home — measured: it overwrote a
+# live `~/.botmux/config.json` with this repo's own fixture. `src/` derives
+# ~/.claude, ~/.codex, ~/.gemini and more from `homedir()` too, so the exposure
+# is not limited to ~/.botmux.
+#
+# Order matters: the fence must install its `node:os` override before the shim
+# (whose `stubEnv` only re-points env vars, which alone does NOT move Bun's
+# startup-frozen `homedir()`).
+#
+# Scope check (measured): a `[test]` preload does NOT apply to `bun run`, so this
+# cannot follow the daemon or CLI into production.
+[test]
+preload = ["./test/bun-test-fence.ts", "./test/bun-test-shim.ts"]
+

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -39,4 +39,3 @@ registry = "https://registry.npmjs.org/"
 # cannot follow the daemon or CLI into production.
 [test]
 preload = ["./test/bun-test-fence.ts", "./test/bun-test-shim.ts"]
-

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:all": "vitest run",
     "test:e2e": "vitest run --project e2e",
     "test:bun": "node scripts/run-bun-tests.mjs",
+    "test:bun:self-check": "node scripts/run-bun-tests.mjs --self-check",
     "test:bench": "tsx scripts/bench-tests.ts",
     "test:codex": "vitest run --project e2e test/codex-input.e2e.ts",
     "test:gemini": "vitest run --project e2e test/gemini-input.e2e.ts",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test": "vitest run --project unit",
     "test:all": "vitest run",
     "test:e2e": "vitest run --project e2e",
+    "test:bun": "node scripts/run-bun-tests.mjs",
     "test:bench": "tsx scripts/bench-tests.ts",
     "test:codex": "vitest run --project e2e test/codex-input.e2e.ts",
     "test:gemini": "vitest run --project e2e test/gemini-input.e2e.ts",

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -62,6 +62,43 @@ function collectTestFiles(dir) {
   return found;
 }
 
+/**
+ * A scratch dir plus the env that confines a Bun process to it from BIRTH.
+ *
+ * Bun boots, resolves its preload's imports and touches its user-level caches
+ * BEFORE any of our JS runs, so an in-process fence cannot cover that window —
+ * only the spawn env can. Every `bun` this script starts must go through here;
+ * a single unfenced spawn writes into the developer's real home and defeats the
+ * whole point of the leg (measured: an unfenced probe left
+ * `.bun/install/cache/@t@/*.pile` in the inherited HOME).
+ *
+ * Returns the dir so the caller can delete it — `mkdtemp` never reuses a name,
+ * so a leaked one accumulates rather than being overwritten.
+ */
+function mintFencedEnv() {
+  const scratch = mkdtempSync(join(realTmpdir(), 'botmux-bun-child-'));
+  const childTmp = join(scratch, 'tmp');
+  const childHome = join(scratch, 'home');
+  mkdirSync(childTmp);
+  mkdirSync(childHome);
+
+  const env = {
+    ...process.env,
+    TMPDIR: childTmp,
+    TMP: childTmp,
+    TEMP: childTmp,
+    HOME: childHome,
+    USERPROFILE: childHome,
+  };
+  // Exact-path pointers at a live Botmux home never go through `homedir()`, so
+  // they have to be dropped in the spawn env too — not just in the preload.
+  // Mirrors test/helpers/fence-home-env.ts; kept here as well because that file
+  // only runs after Bun has started.
+  for (const name of ['BOTS_CONFIG', 'PM2_HOME', 'PLUGIN_PM2_HOME']) delete env[name];
+
+  return { scratch, env };
+}
+
 // The exclusion selectors live in test/helpers/bun-leg-selectors.ts so that a guard
 // can import and exercise the REAL logic (test/bun-runner-selectors.test.ts) instead
 // of a hand-copied duplicate that drifts. They are loaded through Bun because this
@@ -71,16 +108,28 @@ function collectTestFiles(dir) {
 // so it is already a hard dependency, and shelling out keeps the runner free of a
 // TS-transform requirement of its own.
 function loadDeferredSet(files) {
+  // The file list goes over STDIN, not argv. At 1159 files it is 42,604 bytes in a
+  // single argument: comfortably under Linux's MAX_ARG_STRLEN (131,072) but 130% of
+  // Windows' 32,767-character command-line limit, where it would fail outright — and
+  // the failure would grow in with the suite rather than showing up in review.
   const probe = [
     "const { isDeferredFromBunLeg } = await import('./test/helpers/bun-leg-selectors.ts');",
     "const { readFileSync } = await import('node:fs');",
     'const out = [];',
-    'for (const f of JSON.parse(process.argv[1] ?? "[]")) {',
-    '  if (isDeferredFromBunLeg(readFileSync(f, "utf8"))) out.push(f);',
+    "for (const f of JSON.parse(readFileSync(0, 'utf8') || '[]')) {",
+    "  if (isDeferredFromBunLeg(readFileSync(f, 'utf8'))) out.push(f);",
     '}',
     'process.stdout.write(JSON.stringify(out));',
   ].join('\n');
-  const res = spawnSync('bun', ['-e', probe, JSON.stringify(files)], { encoding: 'utf8' });
+  // This spawn happens BEFORE any test runs, so it is the first thing that could
+  // pollute the real home — fence it exactly like a test child.
+  const { scratch, env } = mintFencedEnv();
+  let res;
+  try {
+    res = spawnSync('bun', ['-e', probe], { encoding: 'utf8', input: JSON.stringify(files), env });
+  } finally {
+    removeScratch(scratch);
+  }
   if (res.status !== 0 || res.error) {
     console.error('Failed to evaluate the bun-leg selectors:');
     console.error(res.stderr || res.error?.message || `exit ${res.status}`);
@@ -94,19 +143,73 @@ function loadDeferredSet(files) {
   }
 }
 
+// Bun's per-test default is 5s, but the unit project runs at vitest's 30s and
+// individual files raise it further via `vi.setConfig({ testTimeout })` — up to
+// 180s for the mojo suites. `bun test` has no runtime equivalent for that
+// per-file call (the shim accepts it as a no-op), so the ceiling comes from the
+// CLI. A generous timeout cannot turn a failing test green; it only stops a slow
+// one from being cut short.
+const TEST_TIMEOUT_MS = 180_000;
+// Hard wall per file, above the per-test ceiling: a file that wedges (waiting on
+// a pty, a lock, a socket) must not hold the whole leg open.
+const FILE_WALL_MS = 240_000;
+
 const all = collectTestFiles(TEST_DIR).sort();
 
+// Snapshot the real home BEFORE the selector probe — the first `bun` this script
+// spawns, and therefore the first thing that can pollute it. Compared again after the
+// run in self-check mode.
+//
+// WHY AN ASSERTION AND NOT JUST THE FENCE: the fence is a spawn-env argument, and
+// dropping it is a one-token edit that changes NO output. Measured: removing `env`
+// from the probe's `spawnSync` left the run exit 0 and green while writing
+// `.bun/install/cache/@t@/*.pile` into the inherited home. The invariant this whole
+// leg exists to protect was therefore unguarded by the leg itself.
+function snapshotHome() {
+  const home = process.env.HOME ?? process.env.USERPROFILE;
+  if (!home) return null;
+  try {
+    return new Set(readdirSync(home));
+  } catch {
+    return null;
+  }
+}
+const homeBefore = snapshotHome();
+
 const deferred = loadDeferredSet(all);
-const runnable = all.filter(f => !deferred.has(f));
+const allRunnable = all.filter(f => !deferred.has(f));
 const skipped = all.filter(f => deferred.has(f));
 
-if (runnable.length === 0) {
+if (allRunnable.length === 0) {
   console.error('Refusing to report success: no runnable files were found. Is the test/ directory present?');
   process.exit(1);
 }
 
-const extraArgs = process.argv.slice(2);
+const extraArgs = process.argv.slice(2).filter(a => a !== '--self-check');
+// `--self-check` runs ONE trivially-passing file instead of the suite, so every code
+// path the real run needs — selector probe, fenced spawn env, per-file constants, the
+// close handler, the completeness accounting — actually EXECUTES in a few seconds.
+//
+// WHY THIS EXISTS: a commit of mine deleted `TEST_TIMEOUT_MS`/`FILE_WALL_MS` while
+// leaving their uses. `node --check` passes (a missing binding is a RUNTIME
+// ReferenceError, verified), the count line still printed `994 files`, and the leg then
+// ran **0 of 994** — caught only by CI, on a green-looking headline. The failure lives
+// inside `runOne`, so nothing short of launching a child can see it.
+const selfCheck = process.argv.includes('--self-check');
 const hasOwnTimeout = extraArgs.some(a => a === '--timeout' || a.startsWith('--timeout='));
+
+// In self-check mode, run the guard for the selectors themselves: it is fast, has no
+// external dependencies, and asserts a real result — so "the runner works" and "the
+// selectors work" are established by the same few seconds.
+const SELF_CHECK_FILE = 'test/bun-runner-selectors.test.ts';
+if (selfCheck && !allRunnable.includes(SELF_CHECK_FILE)) {
+  console.error(
+    `Refusing to self-check: ${SELF_CHECK_FILE} is not in the runnable set. `
+    + 'Either it was deleted or the selectors now defer it — both mean the leg is unguarded.',
+  );
+  process.exit(1);
+}
+const runnable = selfCheck ? [SELF_CHECK_FILE] : allRunnable;
 // Keep concurrency moderate: many of these files spawn real daemons, ptys and
 // bwrap sandboxes, and oversubscribing turns their internal timeouts into
 // spurious reds (measured on a busy host). But do not starve a small runner
@@ -119,8 +222,11 @@ const concurrency = Number.isFinite(envConcurrency) && envConcurrency > 0
   : Math.max(4, Math.min(8, Math.floor(availableParallelism() / 4)));
 
 console.log(
-  `bun test: ${runnable.length} files, one process each, ${concurrency} at a time `
-  + `(${skipped.length} deferred to vitest — module-registry APIs)`,
+  selfCheck
+    ? `bun test SELF-CHECK: 1 of ${allRunnable.length} runnable files (${SELF_CHECK_FILE}) — `
+      + 'exercising the runner itself, NOT a suite result'
+    : `bun test: ${runnable.length} files, one process each, ${concurrency} at a time `
+      + `(${skipped.length} deferred to vitest — module-registry APIs)`,
 );
 
 // Every child currently running, mapped to the scratch dir minted for it, so a
@@ -353,6 +459,31 @@ if (incomplete) {
     console.error('  no worker crashed, yet files are missing — results cannot be trusted');
   }
   process.exit(1);
+}
+
+// The home invariant, checked BEFORE the green summary for the same reason as
+// completeness: a headline nobody can contradict is worse than a loud failure.
+//
+// Self-check only. A full run legitimately touches the real home in ways this script
+// does not control (bun's own resolution caches during `bun install`, a test that
+// deliberately writes there), so asserting it for every run would be a flake generator.
+// Self-check spawns exactly two bun processes, both fenced, and nothing else — an
+// entry appearing there means a fence went missing.
+if (selfCheck && homeBefore) {
+  const homeAfter = snapshotHome();
+  const added = homeAfter ? [...homeAfter].filter(e => !homeBefore.has(e)) : [];
+  if (added.length > 0) {
+    console.error(
+      `\nbun test SELF-CHECK FAILED: the run wrote into the real home (${process.env.HOME}): `
+      + `${added.join(', ')}`,
+    );
+    console.error(
+      '  Every `bun` this script spawns must get its env from mintFencedEnv() — Bun touches '
+      + 'its user-level caches before any preload runs, so only the spawn env can prevent this.',
+    );
+    process.exit(1);
+  }
+  console.log('bun test SELF-CHECK: real home untouched ✓');
 }
 
 console.log(`\nbun test: ${runnable.length - failures.length}/${runnable.length} files green, ${failures.length} failing`);

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -156,25 +156,38 @@ const FILE_WALL_MS = 240_000;
 
 const all = collectTestFiles(TEST_DIR).sort();
 
-// Snapshot the real home BEFORE the selector probe — the first `bun` this script
-// spawns, and therefore the first thing that can pollute it. Compared again after the
-// run in self-check mode.
+// Parsed before anything spawns bun: the canary home below depends on it, and a `const`
+// read before its declaration is a TDZ ReferenceError — the same runtime-only failure
+// class that made an earlier commit run 0 of 994 files.
+const selfCheck = process.argv.includes('--self-check');
+
+// In self-check mode, point the RUNNER's own home at a fresh empty directory before
+// anything spawns bun. Every `bun` this script starts is supposed to get its env from
+// `mintFencedEnv()`; if one does not, it inherits this canary and writes `.bun` into
+// it, which a cheap top-level listing then catches.
 //
-// WHY AN ASSERTION AND NOT JUST THE FENCE: the fence is a spawn-env argument, and
-// dropping it is a one-token edit that changes NO output. Measured: removing `env`
-// from the probe's `spawnSync` left the run exit 0 and green while writing
-// `.bun/install/cache/@t@/*.pile` into the inherited home. The invariant this whole
-// leg exists to protect was therefore unguarded by the leg itself.
-function snapshotHome() {
-  const home = process.env.HOME ?? process.env.USERPROFILE;
-  if (!home) return null;
+// WHY NOT SNAPSHOT THE REAL HOME: that was the first attempt and it was vacuous. A
+// top-level name diff only sees a `.bun` that did not exist BEFORE — and CI runs
+// `setup-bun` + `bun install` earlier in the job, so `.bun` always exists by then, as
+// it does on any developer machine. Measured: with a pre-created empty `.bun/`, an
+// unfenced probe wrote `.bun/install/cache/@t@/*.pile` and the top-level diff was
+// EMPTY, so the check reported "untouched" and the fence mutation stayed green. A
+// recursive snapshot would fix the blindness but is slow and picks up concurrent
+// noise from anything else using the home. An empty canary makes the invariant
+// top-level and unambiguous, and never touches the live home at all.
+const canaryHome = selfCheck ? mkdtempSync(join(realTmpdir(), 'botmux-bun-canary-')) : null;
+if (canaryHome) {
+  process.env.HOME = canaryHome;
+  process.env.USERPROFILE = canaryHome;
+}
+function canaryEntries() {
+  if (!canaryHome) return [];
   try {
-    return new Set(readdirSync(home));
+    return readdirSync(canaryHome);
   } catch {
-    return null;
+    return [];
   }
 }
-const homeBefore = snapshotHome();
 
 const deferred = loadDeferredSet(all);
 const allRunnable = all.filter(f => !deferred.has(f));
@@ -195,7 +208,6 @@ const extraArgs = process.argv.slice(2).filter(a => a !== '--self-check');
 // ReferenceError, verified), the count line still printed `994 files`, and the leg then
 // ran **0 of 994** — caught only by CI, on a green-looking headline. The failure lives
 // inside `runOne`, so nothing short of launching a child can see it.
-const selfCheck = process.argv.includes('--self-check');
 const hasOwnTimeout = extraArgs.some(a => a === '--timeout' || a.startsWith('--timeout='));
 
 // In self-check mode, run the guard for the selectors themselves: it is fast, has no
@@ -308,6 +320,8 @@ for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
       // handler that normally removes them never runs.
       removeScratch(scratch);
     }
+    // Same for the canary: the check that normally deletes it is past the join.
+    if (canaryHome) removeScratch(canaryHome);
     process.exit(sig === 'SIGINT' ? 130 : 143);
   });
 }
@@ -461,29 +475,29 @@ if (incomplete) {
   process.exit(1);
 }
 
-// The home invariant, checked BEFORE the green summary for the same reason as
+// The fence invariant, checked BEFORE the green summary for the same reason as
 // completeness: a headline nobody can contradict is worse than a loud failure.
 //
-// Self-check only. A full run legitimately touches the real home in ways this script
-// does not control (bun's own resolution caches during `bun install`, a test that
-// deliberately writes there), so asserting it for every run would be a flake generator.
-// Self-check spawns exactly two bun processes, both fenced, and nothing else — an
-// entry appearing there means a fence went missing.
-if (selfCheck && homeBefore) {
-  const homeAfter = snapshotHome();
-  const added = homeAfter ? [...homeAfter].filter(e => !homeBefore.has(e)) : [];
-  if (added.length > 0) {
+// The canary home starts EMPTY and only this script's own bun spawns could write to
+// it, so any entry at all means a spawn inherited the runner's env instead of
+// `mintFencedEnv()`. No recursion needed, no live-home noise, no dependence on
+// whether the machine has used Bun before.
+if (canaryHome) {
+  const leaked = canaryEntries();
+  removeScratch(canaryHome);
+  if (leaked.length > 0) {
     console.error(
-      `\nbun test SELF-CHECK FAILED: the run wrote into the real home (${process.env.HOME}): `
-      + `${added.join(', ')}`,
+      `\nbun test SELF-CHECK FAILED: a bun spawn escaped the home fence and wrote `
+      + `${leaked.join(', ')} into the canary home.`,
     );
     console.error(
-      '  Every `bun` this script spawns must get its env from mintFencedEnv() — Bun touches '
-      + 'its user-level caches before any preload runs, so only the spawn env can prevent this.',
+      '  Every `bun` this script spawns must take its env from mintFencedEnv() — Bun '
+      + 'touches its user-level caches before any preload runs, so only the spawn env '
+      + 'can prevent this. On a real run that write lands in the developer\'s home.',
     );
     process.exit(1);
   }
-  console.log('bun test SELF-CHECK: real home untouched ✓');
+  console.log('bun test SELF-CHECK: every bun spawn stayed inside its fence ✓');
 }
 
 console.log(`\nbun test: ${runnable.length - failures.length}/${runnable.length} files green, ${failures.length} failing`);

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -100,6 +100,18 @@ const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimpo
 // other names alongside it).
 const IMPORTS_INJECT = /import\s*\{[^}]*\binject\b[^}]*\}\s*from\s*['"]vitest['"]/s;
 
+// The `vi.mock` factory's original-module callback is matched by SHAPE, not by
+// name. `importOriginal` and `importActual` are only conventions: one file in this
+// repo calls the parameter `orig`, and a name-based pattern sailed straight past it
+// — the file then failed in CI with `orig is not a function`, because Bun never
+// supplies that argument at all. Any single-parameter `vi.mock` factory is relying
+// on the same unsupported feature, whatever the parameter is called.
+//
+// A zero-parameter factory (`vi.mock('x', () => ({ … }))`) is the supported form and
+// must NOT match, so the parameter list has to be non-empty.
+const MOCK_FACTORY_TAKES_ORIGINAL =
+  /\bvi\s*\.\s*mock\s*\([^,]+,\s*(?:async\s*)?\(\s*[A-Za-z_$][\w$]*/;
+
 // Comments must not decide whether a file runs. Matching raw source means a file
 // that merely MENTIONS one of these names in prose gets silently skipped, and the
 // count line still looks healthy — the same shape of miss as the non-recursive
@@ -134,7 +146,7 @@ const runnable = [];
 const skipped = [];
 for (const file of all) {
   const source = stripComments(readFileSync(file, 'utf8'));
-  if (UNSUPPORTED.test(source) || IMPORTS_INJECT.test(source)) skipped.push(file);
+  if (UNSUPPORTED.test(source) || IMPORTS_INJECT.test(source) || MOCK_FACTORY_TAKES_ORIGINAL.test(source)) skipped.push(file);
   else runnable.push(file);
 }
 

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -62,93 +62,43 @@ function collectTestFiles(dir) {
   return found;
 }
 
-// Matches the APIs whose absence is a module-system gap rather than a missing
-// helper. Keep in sync with the "DELIBERATELY NOT SHIMMED" list in
-// test/bun-test-shim.ts.
+// The exclusion selectors live in test/helpers/bun-leg-selectors.ts so that a guard
+// can import and exercise the REAL logic (test/bun-runner-selectors.test.ts) instead
+// of a hand-copied duplicate that drifts. They are loaded through Bun because this
+// script runs under Node, which cannot import TypeScript directly.
 //
-// `importOriginal` / `importActual` also appear as the CALLBACK PARAMETER of a
-// `vi.mock` factory (`vi.mock('x', async (importActual) => …)`), which is the
-// same module-registry feature under a different spelling — matching the bare
-// identifier catches both that and any `vi.importActual(…)` call site. Anchoring
-// only on `vi.<name>` would miss the callback form entirely (measured: 2 files).
-//
-// `vi.hoisted` belongs here for the same class of reason: vitest's TRANSFORM
-// physically moves the callback above the static imports, so a fixture that reads
-// a global at import time sees what the callback set. A runtime shim can only run
-// the factory when the module body reaches it — i.e. AFTER the imports — so the
-// fixture sees nothing (measured: vitest passes that probe while an eager-factory
-// shim reports `missing`). That is module-evaluation ORDER, not a missing
-// function, so it is unsupported rather than faked.
-// `inject` is vitest's globalSetup→test value channel (`project.provide` /
-// `inject`). It is a NAMED EXPORT of the `vitest` module, and `bun test` resolves
-// `vitest` to its own `bun:test` — which has no such export, so the file dies at
-// import with `SyntaxError: Export named 'inject' not found`. A preload cannot
-// paper over it: `mock.module('vitest', … inject: … )` still fails, because the
-// static import is validated against `bun:test`'s real export list before any
-// mock applies (measured). Runner-config plumbing, not a missing helper.
-const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimportOriginal\b|\bimportActual\b/;
-
-// `inject` needs its OWN, anchored pattern. Adding a bare `\binject\b` to the
-// list above looks equivalent but silently deferred 20 innocent files — measured:
-// of the 21 files it newly excluded, exactly ONE actually imports `inject`; the
-// rest merely contain the English word in a test title ("does not inject …"), a
-// script name (`inject-optional-binaries.mjs`), a callback parameter, or a domain
-// term (`inject-queue-policy`). Same failure shape as the comment-matching bug
-// this file already guards against — and the population count looks perfectly
-// healthy while it happens. So match the thing that actually breaks: a NAMED
-// IMPORT of `inject` from `vitest` (the specifier list may span lines and carry
-// other names alongside it).
-const IMPORTS_INJECT = /import\s*\{[^}]*\binject\b[^}]*\}\s*from\s*['"]vitest['"]/s;
-
-// The `vi.mock` factory's original-module callback is matched by SHAPE, not by
-// name. `importOriginal` and `importActual` are only conventions: one file in this
-// repo calls the parameter `orig`, and a name-based pattern sailed straight past it
-// — the file then failed in CI with `orig is not a function`, because Bun never
-// supplies that argument at all. Any single-parameter `vi.mock` factory is relying
-// on the same unsupported feature, whatever the parameter is called.
-//
-// A zero-parameter factory (`vi.mock('x', () => ({ … }))`) is the supported form and
-// must NOT match, so the parameter list has to be non-empty.
-const MOCK_FACTORY_TAKES_ORIGINAL =
-  /\bvi\s*\.\s*mock\s*\([^,]+,\s*(?:async\s*)?\(\s*[A-Za-z_$][\w$]*/;
-
-// Comments must not decide whether a file runs. Matching raw source means a file
-// that merely MENTIONS one of these names in prose gets silently skipped, and the
-// count line still looks healthy — the same shape of miss as the non-recursive
-// scan above. This is not hypothetical: the parity guard in
-// test/bun-shim-parity.test.ts excluded ITSELF that way while explaining why the
-// hoisting helper is unsupported. Strip comments before testing.
-//
-// Deliberately simple: this is a skip-list heuristic over first-party test files,
-// not a parser. `//` inside a string literal would over-strip, which fails
-// CLOSED — the file stays in the leg and any real unsupported call there fails
-// loudly rather than being quietly dropped.
-function stripComments(source) {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+// Why a subprocess rather than a loader: this script is the thing that launches bun,
+// so it is already a hard dependency, and shelling out keeps the runner free of a
+// TS-transform requirement of its own.
+function loadDeferredSet(files) {
+  const probe = [
+    "const { isDeferredFromBunLeg } = await import('./test/helpers/bun-leg-selectors.ts');",
+    "const { readFileSync } = await import('node:fs');",
+    'const out = [];',
+    'for (const f of JSON.parse(process.argv[1] ?? "[]")) {',
+    '  if (isDeferredFromBunLeg(readFileSync(f, "utf8"))) out.push(f);',
+    '}',
+    'process.stdout.write(JSON.stringify(out));',
+  ].join('\n');
+  const res = spawnSync('bun', ['-e', probe, JSON.stringify(files)], { encoding: 'utf8' });
+  if (res.status !== 0 || res.error) {
+    console.error('Failed to evaluate the bun-leg selectors:');
+    console.error(res.stderr || res.error?.message || `exit ${res.status}`);
+    process.exit(1);
+  }
+  try {
+    return new Set(JSON.parse(res.stdout));
+  } catch {
+    console.error(`Selector probe returned unparseable output: ${res.stdout.slice(0, 200)}`);
+    process.exit(1);
+  }
 }
-
-// Bun's per-test default is 5s, but the unit project runs at vitest's 30s and
-// individual files raise it further via `vi.setConfig({ testTimeout })` — up to
-// 180s for the mojo suites. `bun test` has no runtime equivalent for that
-// per-file call (the shim accepts it as a no-op), so the ceiling comes from the
-// CLI. A generous timeout cannot turn a failing test green; it only stops a slow
-// one from being cut short.
-const TEST_TIMEOUT_MS = 180_000;
-// Hard wall per file, above the per-test ceiling: a file that wedges (waiting on
-// a pty, a lock, a socket) must not hold the whole leg open.
-const FILE_WALL_MS = 240_000;
 
 const all = collectTestFiles(TEST_DIR).sort();
 
-const runnable = [];
-const skipped = [];
-for (const file of all) {
-  const source = stripComments(readFileSync(file, 'utf8'));
-  if (UNSUPPORTED.test(source) || IMPORTS_INJECT.test(source) || MOCK_FACTORY_TAKES_ORIGINAL.test(source)) skipped.push(file);
-  else runnable.push(file);
-}
+const deferred = loadDeferredSet(all);
+const runnable = all.filter(f => !deferred.has(f));
+const skipped = all.filter(f => deferred.has(f));
 
 if (runnable.length === 0) {
   console.error('Refusing to report success: no runnable files were found. Is the test/ directory present?');

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -133,13 +133,13 @@ function loadDeferredSet(files) {
   if (res.status !== 0 || res.error) {
     console.error('Failed to evaluate the bun-leg selectors:');
     console.error(res.stderr || res.error?.message || `exit ${res.status}`);
-    process.exit(1);
+    exitCleanly(1);
   }
   try {
     return new Set(JSON.parse(res.stdout));
   } catch {
     console.error(`Selector probe returned unparseable output: ${res.stdout.slice(0, 200)}`);
-    process.exit(1);
+    exitCleanly(1);
   }
 }
 
@@ -188,6 +188,19 @@ function canaryEntries() {
     return [];
   }
 }
+/**
+ * Exit, always removing the canary first.
+ *
+ * Used by EVERY exit path past the canary's creation rather than by each one
+ * remembering to clean up: the failure exits (selector probe throwing, no runnable
+ * files, the guard being deferred, an incomplete join) are exactly the ones a person
+ * adding a new early return forgets, and each leak is a permanent `mkdtemp` directory
+ * — the same lifecycle gap that leaked 51 scratch dirs earlier in this work.
+ */
+function exitCleanly(code) {
+  if (canaryHome) removeScratch(canaryHome);
+  process.exit(code);
+}
 
 const deferred = loadDeferredSet(all);
 const allRunnable = all.filter(f => !deferred.has(f));
@@ -195,7 +208,7 @@ const skipped = all.filter(f => deferred.has(f));
 
 if (allRunnable.length === 0) {
   console.error('Refusing to report success: no runnable files were found. Is the test/ directory present?');
-  process.exit(1);
+  exitCleanly(1);
 }
 
 const extraArgs = process.argv.slice(2).filter(a => a !== '--self-check');
@@ -219,7 +232,7 @@ if (selfCheck && !allRunnable.includes(SELF_CHECK_FILE)) {
     `Refusing to self-check: ${SELF_CHECK_FILE} is not in the runnable set. `
     + 'Either it was deleted or the selectors now defer it — both mean the leg is unguarded.',
   );
-  process.exit(1);
+  exitCleanly(1);
 }
 const runnable = selfCheck ? [SELF_CHECK_FILE] : allRunnable;
 // Keep concurrency moderate: many of these files spawn real daemons, ptys and
@@ -343,28 +356,12 @@ function runOne(file) {
     // INHERITED home even on a fenced run. Setting HOME here means the fence
     // exists from process birth; the preload then narrows it further and installs
     // the in-process `node:os` override. Child processes inherit this too.
-    const scratch = mkdtempSync(join(realTmpdir(), 'botmux-bun-child-'));
-    const childTmp = join(scratch, 'tmp');
-    const childHome = join(scratch, 'home');
-    mkdirSync(childTmp);
-    mkdirSync(childHome);
-
-    const childEnv = {
-      ...process.env,
-      TMPDIR: childTmp,
-      TMP: childTmp,
-      TEMP: childTmp,
-      HOME: childHome,
-      USERPROFILE: childHome,
-    };
-    // Exact-path pointers at a live Botmux home never go through `homedir()`, so
-    // they have to be dropped in the spawn env too — not just in the preload.
-    // Mirrors test/helpers/fence-home-env.ts; kept here as well because that file
-    // only runs after Bun has started.
-    delete childEnv.BOTS_CONFIG;
-    delete childEnv.PM2_HOME;
-    delete childEnv.PLUGIN_PM2_HOME;
-
+    //
+    // Both this and the selector probe go through `mintFencedEnv()` — deliberately
+    // ONE definition. They were duplicated at first with identical values, which is
+    // the shape that rots: the next variable added to one copy silently leaves the
+    // other unfenced, and the self-check's own error text promises a single point.
+    const { scratch, env: childEnv } = mintFencedEnv();
     // `detached: true` puts the child in its OWN process group, so a kill can take
     // the whole tree — `child.kill()` alone signals only the Bun parent and leaves
     // servers/ptys it spawned running (measured: cancelling a run left `bun test`
@@ -472,7 +469,7 @@ if (incomplete) {
   if (workerErrors.length === 0) {
     console.error('  no worker crashed, yet files are missing — results cannot be trusted');
   }
-  process.exit(1);
+  exitCleanly(1);
 }
 
 // The fence invariant, checked BEFORE the green summary for the same reason as

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -166,7 +166,14 @@ console.log(
 const liveChildren = new Map();
 
 /**
- * Signal a child's whole process TREE, not just the Bun parent it points at.
+ * Signal a child's process GROUP — deliberately not called a "tree".
+ *
+ * A grandchild that calls `setsid()` or spawns with `detached: true` leaves this
+ * group and survives (measured: a fixture server with PID == PGID == SID outlived
+ * its group leader). Killing the group covers the common case — a test's spawned
+ * server or pty — and is what makes normal-close and cancellation sweeps work; it
+ * is not a guarantee against a descendant that deliberately detaches. Those are
+ * the test's own responsibility to clean up.
  *
  * POSIX: `detached: true` gave the child its own process group, and a negative pid
  * signals that whole group. Windows has no process groups in this sense and
@@ -278,6 +285,14 @@ function runOne(file) {
     child.on('close', (code, signal) => {
       clearTimeout(wall);
       liveChildren.delete(child);
+      // Sweep whatever is LEFT in the child's process group. A test that spawns a
+      // grandchild and only kills the intermediate process leaves the grandchild
+      // running when the Bun parent exits — measured with
+      // test/session-preview-ownership.test.ts, whose `LISTEN_SCRIPT` server
+      // survived a NORMAL file close as a PPID=1 process holding a port. Deleting
+      // the scratch dir without this made a directory-based check look clean while
+      // the process was still alive, so sweep BEFORE removing the evidence.
+      killTree(child, 'SIGKILL');
       rmSync(scratch, { recursive: true, force: true });
       // A signal death (wall-clock kill, OOM) leaves code null — never let that
       // coerce into a pass.

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -5,21 +5,38 @@
 // startup-frozen `os.homedir()`, `Bun.file`, compiled-binary paths) is invisible
 // to `bun run test` and can only regress silently there.
 //
+// ONE FILE PER PROCESS, deliberately. `bun test a.ts b.ts …` runs every file in
+// a SINGLE process (measured: two files report the same `process.pid`), unlike
+// vitest which forks a worker per file. Handing it the whole suite produces
+// cascading cross-file interference rather than real failures — measured on this
+// repo: 1010 files batched → 933 failures; the same files one-per-process → ~2%
+// red; and individual victims (`fleet-supervisor.integration`,
+// `ask-custom-reply-candidate`, `dashboard-ipc`) go 23/23, 8/8 and 170/171 green
+// in isolation while failing in the batch. A `vi.mock` of a shared module (e.g.
+// `utils/logger`) installed by one file stays installed for later files, so a
+// deliberately partial mock in file A becomes a `logger.isDebug is not a
+// function` crash in file Z. Per-process execution restores the isolation
+// boundary vitest gives for free.
+//
+// The cost is process startup per file (~21 min wall clock for this suite versus
+// a few minutes batched). That is the price of trustworthy results; a leg whose
+// failures are mostly artefacts is worse than no leg at all.
+//
 // A subset of files cannot run here yet: `vi.doMock` / `vi.doUnmock` /
-// `vi.resetModules` and the `importOriginal` callback are module-registry
-// semantics, not missing functions. `test/bun-test-shim.ts` deliberately does
-// NOT fake them — a fake would report success while silently not mocking, which
-// is worse than the current red. Those files keep running under vitest until
-// they are rewritten to use dependency injection.
+// `vi.resetModules` and the `importOriginal` / `importActual` mock-factory
+// callbacks are module-registry semantics, not missing functions.
+// `test/bun-test-shim.ts` deliberately does NOT fake them — a fake would report
+// success while silently not mocking, which is worse than the current red. Those
+// files keep running under vitest until they are rewritten to use dependency
+// injection.
 //
 // The exclusion list is COMPUTED, never hardcoded: a stale literal list would
 // quietly start skipping files (or fail on files that have since been fixed).
-// Adding a `vi.doMock` to any file automatically moves it out of this leg, and
-// removing one moves it back in.
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { availableParallelism } from 'node:os';
 
 const TEST_DIR = 'test';
 
@@ -34,6 +51,17 @@ const TEST_DIR = 'test';
 // only on `vi.<name>` would miss the callback form entirely (measured: 2 files).
 const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules)\b|\bimportOriginal\b|\bimportActual\b/;
 
+// Bun's per-test default is 5s, but the unit project runs at vitest's 30s and
+// individual files raise it further via `vi.setConfig({ testTimeout })` — up to
+// 180s for the mojo suites. `bun test` has no runtime equivalent for that
+// per-file call (the shim accepts it as a no-op), so the ceiling comes from the
+// CLI. A generous timeout cannot turn a failing test green; it only stops a slow
+// one from being cut short.
+const TEST_TIMEOUT_MS = 180_000;
+// Hard wall per file, above the per-test ceiling: a file that wedges (waiting on
+// a pty, a lock, a socket) must not hold the whole leg open.
+const FILE_WALL_MS = 240_000;
+
 const all = readdirSync(TEST_DIR)
   .filter(f => f.endsWith('.test.ts'))
   .map(f => join(TEST_DIR, f))
@@ -46,39 +74,73 @@ for (const file of all) {
   else runnable.push(file);
 }
 
-console.log(`bun test: ${runnable.length} files (${skipped.length} deferred to vitest — module-registry APIs)`);
-
 if (runnable.length === 0) {
   console.error('Refusing to report success: no runnable files were found. Is the test/ directory present?');
   process.exit(1);
 }
 
-// Pass an explicit file list rather than letting bun glob, so the deferred files
-// cannot sneak in via a future default-glob change.
-//
-// --timeout: Bun's per-test default is 5s, but the unit project runs at
-// vitest's 30s and individual files raise it further via `vi.setConfig({
-// testTimeout })` — up to 180s for the mojo suites. `bun test` has no runtime
-// equivalent for that per-file call (the shim accepts it as a no-op), so the
-// ceiling has to come from the CLI. Use the highest value any file asks for;
-// a generous timeout cannot turn a failing test green, it only stops a slow one
-// from being cut short. An explicit --timeout in argv wins over this default.
-const HIGHEST_FILE_TIMEOUT_MS = 180_000;
 const extraArgs = process.argv.slice(2);
-const timeoutArgs = extraArgs.some(a => a === '--timeout' || a.startsWith('--timeout='))
-  ? []
-  : [`--timeout=${HIGHEST_FILE_TIMEOUT_MS}`];
+const hasOwnTimeout = extraArgs.some(a => a === '--timeout' || a.startsWith('--timeout='));
+// Keep concurrency well under the core count: many of these files spawn real
+// daemons, ptys and bwrap sandboxes, and oversubscribing turns their internal
+// timeouts into spurious reds (measured on a busy host).
+const envConcurrency = Number.parseInt(process.env.BOTMUX_BUN_TEST_CONCURRENCY ?? '', 10);
+const concurrency = Number.isFinite(envConcurrency) && envConcurrency > 0
+  ? envConcurrency
+  : Math.max(2, Math.min(8, Math.floor(availableParallelism() / 8)));
 
-const res = spawnSync('bun', ['test', ...timeoutArgs, ...extraArgs, ...runnable], { stdio: 'inherit' });
+console.log(
+  `bun test: ${runnable.length} files, one process each, ${concurrency} at a time `
+  + `(${skipped.length} deferred to vitest — module-registry APIs)`,
+);
 
-if (res.error) {
-  console.error(`Failed to launch bun test: ${res.error.message}`);
+function runOne(file) {
+  return new Promise(resolve => {
+    const args = ['test', ...(hasOwnTimeout ? [] : [`--timeout=${TEST_TIMEOUT_MS}`]), ...extraArgs, file];
+    const child = spawn('bun', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    const cap = chunk => { if (out.length < 200_000) out += chunk; };
+    child.stdout.on('data', cap);
+    child.stderr.on('data', cap);
+    const wall = setTimeout(() => child.kill('SIGKILL'), FILE_WALL_MS);
+    child.on('error', err => {
+      clearTimeout(wall);
+      resolve({ file, ok: false, out: `failed to launch bun: ${err.message}` });
+    });
+    child.on('close', (code, signal) => {
+      clearTimeout(wall);
+      // A signal death (wall-clock kill, OOM) leaves code null — never let that
+      // coerce into a pass.
+      resolve({ file, ok: code === 0, out, signal: signal ?? undefined });
+    });
+  });
+}
+
+const queue = [...runnable];
+const failures = [];
+let done = 0;
+
+async function worker() {
+  for (;;) {
+    const file = queue.shift();
+    if (!file) return;
+    const res = await runOne(file);
+    done += 1;
+    if (!res.ok) {
+      failures.push(res);
+      process.stdout.write(`\nFAIL ${res.file}${res.signal ? ` (killed: ${res.signal})` : ''}\n${res.out}\n`);
+    }
+    if (done % 50 === 0 || done === runnable.length) {
+      process.stdout.write(`… ${done}/${runnable.length} files, ${failures.length} failing\n`);
+    }
+  }
+}
+
+await Promise.all(Array.from({ length: concurrency }, worker));
+
+console.log(`\nbun test: ${runnable.length - failures.length}/${runnable.length} files green, ${failures.length} failing`);
+if (failures.length > 0) {
+  console.log('Failing files:');
+  for (const f of failures) console.log(`  ${f.file}`);
   process.exit(1);
 }
-// A signal death (OOM, timeout kill) leaves status null — treat it as failure
-// rather than letting `undefined` coerce to a passing 0.
-if (res.status === null) {
-  console.error(`bun test terminated by signal ${res.signal ?? 'unknown'}`);
-  process.exit(1);
-}
-process.exit(res.status);

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -40,6 +40,28 @@ import { availableParallelism } from 'node:os';
 
 const TEST_DIR = 'test';
 
+// Mirror vitest's unit include/exclude exactly: `test/**/*.{test,spec}.ts`,
+// minus `test/e2e-browser/**` and `*.e2e.ts`. A non-recursive `readdirSync`
+// looked right but silently skipped every nested file (measured: 19 files under
+// test/desktop/), and the count line would have looked perfectly healthy — the
+// worst shape of a miss. Recurse so a newly added subdirectory joins this leg
+// automatically instead of quietly sitting out.
+const EXCLUDED_DIRS = new Set(['e2e-browser', 'node_modules', 'helpers', 'fixtures', '__snapshots__']);
+
+function collectTestFiles(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+      found.push(...collectTestFiles(full));
+    } else if (/\.(test|spec)\.ts$/.test(entry.name) && !entry.name.endsWith('.e2e.ts')) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
 // Matches the APIs whose absence is a module-system gap rather than a missing
 // helper. Keep in sync with the "DELIBERATELY NOT SHIMMED" list in
 // test/bun-test-shim.ts.
@@ -62,10 +84,7 @@ const TEST_TIMEOUT_MS = 180_000;
 // a pty, a lock, a socket) must not hold the whole leg open.
 const FILE_WALL_MS = 240_000;
 
-const all = readdirSync(TEST_DIR)
-  .filter(f => f.endsWith('.test.ts'))
-  .map(f => join(TEST_DIR, f))
-  .sort();
+const all = collectTestFiles(TEST_DIR).sort();
 
 const runnable = [];
 const skipped = [];
@@ -114,7 +133,24 @@ function runOne(file) {
       clearTimeout(wall);
       // A signal death (wall-clock kill, OOM) leaves code null — never let that
       // coerce into a pass.
-      resolve({ file, ok: code === 0, out, signal: signal ?? undefined });
+      if (code !== 0) {
+        resolve({ file, ok: false, out, signal: signal ?? undefined });
+        return;
+      }
+      // `bun test` exits 0 for a file that collected ZERO tests (measured — both
+      // an empty file and an all-`.skip` file exit 0). A file that silently ran
+      // nothing is indistinguishable from a passing one by exit code alone, so
+      // parse the count and fail closed. `Ran N tests` is bun's own summary line.
+      const ran = /^Ran (\d+) tests?/m.exec(out);
+      if (!ran) {
+        resolve({ file, ok: false, out: `${out}\n[runner] no "Ran N tests" summary — cannot confirm this file executed` });
+        return;
+      }
+      if (Number(ran[1]) === 0) {
+        resolve({ file, ok: false, out: `${out}\n[runner] collected 0 tests — a file that runs nothing must not report success` });
+        return;
+      }
+      resolve({ file, ok: true, out });
     });
   });
 }

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -49,8 +49,21 @@ if (runnable.length === 0) {
 
 // Pass an explicit file list rather than letting bun glob, so the deferred files
 // cannot sneak in via a future default-glob change.
+//
+// --timeout: Bun's per-test default is 5s, but the unit project runs at
+// vitest's 30s and individual files raise it further via `vi.setConfig({
+// testTimeout })` — up to 180s for the mojo suites. `bun test` has no runtime
+// equivalent for that per-file call (the shim accepts it as a no-op), so the
+// ceiling has to come from the CLI. Use the highest value any file asks for;
+// a generous timeout cannot turn a failing test green, it only stops a slow one
+// from being cut short. An explicit --timeout in argv wins over this default.
+const HIGHEST_FILE_TIMEOUT_MS = 180_000;
 const extraArgs = process.argv.slice(2);
-const res = spawnSync('bun', ['test', ...extraArgs, ...runnable], { stdio: 'inherit' });
+const timeoutArgs = extraArgs.some(a => a === '--timeout' || a.startsWith('--timeout='))
+  ? []
+  : [`--timeout=${HIGHEST_FILE_TIMEOUT_MS}`];
+
+const res = spawnSync('bun', ['test', ...timeoutArgs, ...extraArgs, ...runnable], { stdio: 'inherit' });
 
 if (res.error) {
   console.error(`Failed to launch bun test: ${res.error.message}`);

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -166,6 +166,29 @@ console.log(
 const liveChildren = new Map();
 
 /**
+ * Remove a scratch tree without ever taking the run down with it.
+ *
+ * `rmSync({ recursive: true, force: true })` still THROWS `ENOTEMPTY` when
+ * something creates a file mid-delete — `force` only suppresses "already gone".
+ * A process we just SIGKILLed has not necessarily reaped yet, so the sweep above
+ * races it, and an uncaught throw in a `close` handler killed a 994-file run at
+ * file 950 (measured). Retry briefly, then give up: a leftover temp dir is a
+ * nuisance, losing the whole run's results is not.
+ */
+function removeScratch(scratch) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      rmSync(scratch, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+      return;
+    } catch (err) {
+      if (attempt === 4) {
+        process.stderr.write(`[runner] could not remove ${scratch}: ${err?.code ?? err}\n`);
+      }
+    }
+  }
+}
+
+/**
  * Signal a child's process GROUP — deliberately not called a "tree".
  *
  * A grandchild that calls `setsid()` or spawns with `detached: true` leaves this
@@ -203,6 +226,16 @@ function killTree(child, signal) {
   try { child.kill(signal); } catch { /* already gone */ }
 }
 
+// Last-resort net: a throw inside an async close handler is an unhandled rejection
+// / uncaught exception that would take the whole run down and discard every result
+// gathered so far. Report it and keep going — the per-file verdicts are the point.
+process.on('uncaughtException', err => {
+  process.stderr.write(`[runner] ignoring uncaught error during bookkeeping: ${err?.stack ?? err}\n`);
+});
+process.on('unhandledRejection', err => {
+  process.stderr.write(`[runner] ignoring unhandled rejection during bookkeeping: ${err?.stack ?? err}\n`);
+});
+
 // Without this, killing the runner (Ctrl-C, an outer timeout, a supervisor) leaves
 // its `bun test` children orphaned to PID 1 — they keep holding ports and CPU and
 // corrupt whatever runs next. Reap the tree, then exit with the conventional code.
@@ -215,7 +248,7 @@ for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
       killTree(child, 'SIGKILL');
       // Cancellation is exactly when these would otherwise accumulate: the close
       // handler that normally removes them never runs.
-      try { rmSync(scratch, { recursive: true, force: true }); } catch { /* best effort */ }
+      removeScratch(scratch);
     }
     process.exit(sig === 'SIGINT' ? 130 : 143);
   });
@@ -279,7 +312,7 @@ function runOne(file) {
     child.on('error', err => {
       clearTimeout(wall);
       liveChildren.delete(child);
-      rmSync(scratch, { recursive: true, force: true });
+      removeScratch(scratch);
       resolve({ file, ok: false, out: `failed to launch bun: ${err.message}` });
     });
     child.on('close', (code, signal) => {
@@ -293,7 +326,7 @@ function runOne(file) {
       // the scratch dir without this made a directory-based check look clean while
       // the process was still alive, so sweep BEFORE removing the evidence.
       killTree(child, 'SIGKILL');
-      rmSync(scratch, { recursive: true, force: true });
+      removeScratch(scratch);
       // A signal death (wall-clock kill, OOM) leaves code null — never let that
       // coerce into a pass.
       if (code !== 0) {

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -226,16 +226,6 @@ function killTree(child, signal) {
   try { child.kill(signal); } catch { /* already gone */ }
 }
 
-// Last-resort net: a throw inside an async close handler is an unhandled rejection
-// / uncaught exception that would take the whole run down and discard every result
-// gathered so far. Report it and keep going — the per-file verdicts are the point.
-process.on('uncaughtException', err => {
-  process.stderr.write(`[runner] ignoring uncaught error during bookkeeping: ${err?.stack ?? err}\n`);
-});
-process.on('unhandledRejection', err => {
-  process.stderr.write(`[runner] ignoring unhandled rejection during bookkeeping: ${err?.stack ?? err}\n`);
-});
-
 // Without this, killing the runner (Ctrl-C, an outer timeout, a supervisor) leaves
 // its `bun test` children orphaned to PID 1 — they keep holding ports and CPU and
 // corrupt whatever runs next. Reap the tree, then exit with the conventional code.
@@ -371,11 +361,32 @@ async function worker() {
   }
 }
 
-await Promise.all(Array.from({ length: concurrency }, worker));
+// `allSettled`, so one worker blowing up does not discard the verdicts the others
+// already collected — but a rejected worker still FAILS the run. There is deliberately
+// NO global `uncaughtException` net: it could not distinguish a scratch-cleanup hiccup
+// from a bookkeeping bug, and swallowing the latter could let the process exit 0 with
+// an incomplete result set — trading a loud crash for a silent false green. Scratch
+// removal degrades locally (see removeScratch); everything else fails closed.
+const settled = await Promise.allSettled(Array.from({ length: concurrency }, worker));
+const workerErrors = settled.filter(r => r.status === 'rejected').map(r => r.reason);
 
 console.log(`\nbun test: ${runnable.length - failures.length}/${runnable.length} files green, ${failures.length} failing`);
 if (failures.length > 0) {
   console.log('Failing files:');
   for (const f of failures) console.log(`  ${f.file}`);
+}
+
+if (workerErrors.length > 0) {
+  console.error(`\n${workerErrors.length} worker(s) crashed — results are INCOMPLETE (${done}/${runnable.length} files ran):`);
+  for (const err of workerErrors) console.error(`  ${err?.stack ?? err}`);
   process.exit(1);
 }
+
+// Invariant: every runnable file must have produced a verdict. A count short of the
+// population means files were silently dropped, which must never read as success.
+if (done !== runnable.length) {
+  console.error(`\nRefusing to report success: only ${done} of ${runnable.length} files produced a verdict.`);
+  process.exit(1);
+}
+
+if (failures.length > 0) process.exit(1);

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -370,23 +370,28 @@ async function worker() {
 const settled = await Promise.allSettled(Array.from({ length: concurrency }, worker));
 const workerErrors = settled.filter(r => r.status === 'rejected').map(r => r.reason);
 
-console.log(`\nbun test: ${runnable.length - failures.length}/${runnable.length} files green, ${failures.length} failing`);
 if (failures.length > 0) {
-  console.log('Failing files:');
+  console.log('\nFailing files:');
   for (const f of failures) console.log(`  ${f.file}`);
 }
 
-if (workerErrors.length > 0) {
-  console.error(`\n${workerErrors.length} worker(s) crashed — results are INCOMPLETE (${done}/${runnable.length} files ran):`);
-  for (const err of workerErrors) console.error(`  ${err?.stack ?? err}`);
+// Completeness FIRST, then the summary. Printing "N/N files green" before checking
+// these would count files that never ran: a worker crash after 2 of 9 files still
+// showed a prominent `9/9 files green` with the INCOMPLETE notice below it — the
+// exit code was right but the headline contradicted it, and a human or a log
+// excerpt reads the headline.
+const incomplete = workerErrors.length > 0 || done !== runnable.length;
+if (incomplete) {
+  console.error(
+    `\nbun test: INCOMPLETE — ${done}/${runnable.length} files ran`
+    + `, ${done - failures.length} of those green, ${failures.length} failing`,
+  );
+  for (const err of workerErrors) console.error(`  worker crashed: ${err?.stack ?? err}`);
+  if (workerErrors.length === 0) {
+    console.error('  no worker crashed, yet files are missing — results cannot be trusted');
+  }
   process.exit(1);
 }
 
-// Invariant: every runnable file must have produced a verdict. A count short of the
-// population means files were silently dropped, which must never read as success.
-if (done !== runnable.length) {
-  console.error(`\nRefusing to report success: only ${done} of ${runnable.length} files produced a verdict.`);
-  process.exit(1);
-}
-
+console.log(`\nbun test: ${runnable.length - failures.length}/${runnable.length} files green, ${failures.length} failing`);
 if (failures.length > 0) process.exit(1);

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -23,20 +23,20 @@
 // failures are mostly artefacts is worse than no leg at all.
 //
 // A subset of files cannot run here yet: `vi.doMock` / `vi.doUnmock` /
-// `vi.resetModules` and the `importOriginal` / `importActual` mock-factory
-// callbacks are module-registry semantics, not missing functions.
-// `test/bun-test-shim.ts` deliberately does NOT fake them — a fake would report
-// success while silently not mocking, which is worse than the current red. Those
-// files keep running under vitest until they are rewritten to use dependency
-// injection.
+// `vi.resetModules`, the `importOriginal` / `importActual` mock-factory callbacks,
+// and `vi.hoisted` are module-registry or transform semantics, not missing
+// functions. `test/bun-test-shim.ts` deliberately does NOT fake them — a fake
+// would report success while silently not mocking (or, for `hoisted`, run the
+// factory too late), which is worse than the current red. Those files keep running
+// under vitest until they are rewritten to use dependency injection.
 //
 // The exclusion list is COMPUTED, never hardcoded: a stale literal list would
 // quietly start skipping files (or fail on files that have since been fixed).
 
-import { readdirSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
-import { availableParallelism } from 'node:os';
+import { availableParallelism, tmpdir as realTmpdir } from 'node:os';
 
 const TEST_DIR = 'test';
 
@@ -71,7 +71,32 @@ function collectTestFiles(dir) {
 // same module-registry feature under a different spelling — matching the bare
 // identifier catches both that and any `vi.importActual(…)` call site. Anchoring
 // only on `vi.<name>` would miss the callback form entirely (measured: 2 files).
-const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules)\b|\bimportOriginal\b|\bimportActual\b/;
+//
+// `vi.hoisted` belongs here for the same class of reason: vitest's TRANSFORM
+// physically moves the callback above the static imports, so a fixture that reads
+// a global at import time sees what the callback set. A runtime shim can only run
+// the factory when the module body reaches it — i.e. AFTER the imports — so the
+// fixture sees nothing (measured: vitest passes that probe while an eager-factory
+// shim reports `missing`). That is module-evaluation ORDER, not a missing
+// function, so it is unsupported rather than faked.
+const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimportOriginal\b|\bimportActual\b/;
+
+// Comments must not decide whether a file runs. Matching raw source means a file
+// that merely MENTIONS one of these names in prose gets silently skipped, and the
+// count line still looks healthy — the same shape of miss as the non-recursive
+// scan above. This is not hypothetical: the parity guard in
+// test/bun-shim-parity.test.ts excluded ITSELF that way while explaining why the
+// hoisting helper is unsupported. Strip comments before testing.
+//
+// Deliberately simple: this is a skip-list heuristic over first-party test files,
+// not a parser. `//` inside a string literal would over-strip, which fails
+// CLOSED — the file stays in the leg and any real unsupported call there fails
+// loudly rather than being quietly dropped.
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
 
 // Bun's per-test default is 5s, but the unit project runs at vitest's 30s and
 // individual files raise it further via `vi.setConfig({ testTimeout })` — up to
@@ -89,7 +114,7 @@ const all = collectTestFiles(TEST_DIR).sort();
 const runnable = [];
 const skipped = [];
 for (const file of all) {
-  if (UNSUPPORTED.test(readFileSync(file, 'utf8'))) skipped.push(file);
+  if (UNSUPPORTED.test(stripComments(readFileSync(file, 'utf8')))) skipped.push(file);
   else runnable.push(file);
 }
 
@@ -119,7 +144,43 @@ console.log(
 function runOne(file) {
   return new Promise(resolve => {
     const args = ['test', ...(hasOwnTimeout ? [] : [`--timeout=${TEST_TIMEOUT_MS}`]), ...extraArgs, file];
-    const child = spawn('bun', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    // Per-child scratch root, used for BOTH tmp and home.
+    //
+    // TMPDIR: most `tmpdir()` uses in `src/` go through `mkdtemp`, but a few derive
+    // a FIXED name — `botmux-codex-app-control-<uid>` (src/worker.ts) and
+    // `bmcp-<uid>-<sessionKey>` (core/plugins/mcp/host.ts) — which collide across
+    // concurrently running files under the same user. Not a home escape, just a
+    // concurrency flake surface.
+    //
+    // HOME: the preload fence cannot cover Bun's OWN startup. Bun boots, resolves
+    // and loads the preload's static imports, and touches its user-level caches
+    // BEFORE any of our JS runs — measured: `.bun/install/cache` appears in the
+    // INHERITED home even on a fenced run. Setting HOME here means the fence
+    // exists from process birth; the preload then narrows it further and installs
+    // the in-process `node:os` override. Child processes inherit this too.
+    const scratch = mkdtempSync(join(realTmpdir(), 'botmux-bun-child-'));
+    const childTmp = join(scratch, 'tmp');
+    const childHome = join(scratch, 'home');
+    mkdirSync(childTmp);
+    mkdirSync(childHome);
+
+    const childEnv = {
+      ...process.env,
+      TMPDIR: childTmp,
+      TMP: childTmp,
+      TEMP: childTmp,
+      HOME: childHome,
+      USERPROFILE: childHome,
+    };
+    // Exact-path pointers at a live Botmux home never go through `homedir()`, so
+    // they have to be dropped in the spawn env too — not just in the preload.
+    // Mirrors test/helpers/fence-home-env.ts; kept here as well because that file
+    // only runs after Bun has started.
+    delete childEnv.BOTS_CONFIG;
+    delete childEnv.PM2_HOME;
+    delete childEnv.PLUGIN_PM2_HOME;
+
+    const child = spawn('bun', args, { stdio: ['ignore', 'pipe', 'pipe'], env: childEnv });
     let out = '';
     const cap = chunk => { if (out.length < 200_000) out += chunk; };
     child.stdout.on('data', cap);
@@ -127,10 +188,12 @@ function runOne(file) {
     const wall = setTimeout(() => child.kill('SIGKILL'), FILE_WALL_MS);
     child.on('error', err => {
       clearTimeout(wall);
+      rmSync(scratch, { recursive: true, force: true });
       resolve({ file, ok: false, out: `failed to launch bun: ${err.message}` });
     });
     child.on('close', (code, signal) => {
       clearTimeout(wall);
+      rmSync(scratch, { recursive: true, force: true });
       // A signal death (wall-clock kill, OOM) leaves code null — never let that
       // coerce into a pass.
       if (code !== 0) {

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -86,7 +86,19 @@ function collectTestFiles(dir) {
 // paper over it: `mock.module('vitest', … inject: … )` still fails, because the
 // static import is validated against `bun:test`'s real export list before any
 // mock applies (measured). Runner-config plumbing, not a missing helper.
-const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimportOriginal\b|\bimportActual\b|\binject\b/;
+const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimportOriginal\b|\bimportActual\b/;
+
+// `inject` needs its OWN, anchored pattern. Adding a bare `\binject\b` to the
+// list above looks equivalent but silently deferred 20 innocent files — measured:
+// of the 21 files it newly excluded, exactly ONE actually imports `inject`; the
+// rest merely contain the English word in a test title ("does not inject …"), a
+// script name (`inject-optional-binaries.mjs`), a callback parameter, or a domain
+// term (`inject-queue-policy`). Same failure shape as the comment-matching bug
+// this file already guards against — and the population count looks perfectly
+// healthy while it happens. So match the thing that actually breaks: a NAMED
+// IMPORT of `inject` from `vitest` (the specifier list may span lines and carry
+// other names alongside it).
+const IMPORTS_INJECT = /import\s*\{[^}]*\binject\b[^}]*\}\s*from\s*['"]vitest['"]/s;
 
 // Comments must not decide whether a file runs. Matching raw source means a file
 // that merely MENTIONS one of these names in prose gets silently skipped, and the
@@ -121,7 +133,8 @@ const all = collectTestFiles(TEST_DIR).sort();
 const runnable = [];
 const skipped = [];
 for (const file of all) {
-  if (UNSUPPORTED.test(stripComments(readFileSync(file, 'utf8')))) skipped.push(file);
+  const source = stripComments(readFileSync(file, 'utf8'));
+  if (UNSUPPORTED.test(source) || IMPORTS_INJECT.test(source)) skipped.push(file);
   else runnable.push(file);
 }
 

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -81,13 +81,16 @@ if (runnable.length === 0) {
 
 const extraArgs = process.argv.slice(2);
 const hasOwnTimeout = extraArgs.some(a => a === '--timeout' || a.startsWith('--timeout='));
-// Keep concurrency well under the core count: many of these files spawn real
-// daemons, ptys and bwrap sandboxes, and oversubscribing turns their internal
-// timeouts into spurious reds (measured on a busy host).
+// Keep concurrency moderate: many of these files spawn real daemons, ptys and
+// bwrap sandboxes, and oversubscribing turns their internal timeouts into
+// spurious reds (measured on a busy host). But do not starve a small runner
+// either — one process per file means startup cost dominates, and a 4-core CI
+// box running 2 at a time cannot finish 1000+ files inside a sane job timeout.
+// Hence: at least 4, at most 8, scaled off the core count in between.
 const envConcurrency = Number.parseInt(process.env.BOTMUX_BUN_TEST_CONCURRENCY ?? '', 10);
 const concurrency = Number.isFinite(envConcurrency) && envConcurrency > 0
   ? envConcurrency
-  : Math.max(2, Math.min(8, Math.floor(availableParallelism() / 8)));
+  : Math.max(4, Math.min(8, Math.floor(availableParallelism() / 4)));
 
 console.log(
   `bun test: ${runnable.length} files, one process each, ${concurrency} at a time `

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -26,7 +26,13 @@ const TEST_DIR = 'test';
 // Matches the APIs whose absence is a module-system gap rather than a missing
 // helper. Keep in sync with the "DELIBERATELY NOT SHIMMED" list in
 // test/bun-test-shim.ts.
-const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules)\b|\bimportOriginal\b/;
+//
+// `importOriginal` / `importActual` also appear as the CALLBACK PARAMETER of a
+// `vi.mock` factory (`vi.mock('x', async (importActual) => …)`), which is the
+// same module-registry feature under a different spelling — matching the bare
+// identifier catches both that and any `vi.importActual(…)` call site. Anchoring
+// only on `vi.<name>` would miss the callback form entirely (measured: 2 files).
+const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules)\b|\bimportOriginal\b|\bimportActual\b/;
 
 const all = readdirSync(TEST_DIR)
   .filter(f => f.endsWith('.test.ts'))

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -161,6 +161,33 @@ console.log(
   + `(${skipped.length} deferred to vitest — module-registry APIs)`,
 );
 
+// Every child currently running, so a cancelled run can take them with it.
+const liveChildren = new Set();
+
+/** Signal a child's whole process group, falling back to the pid alone. */
+function killTree(child, signal) {
+  if (child.pid === undefined) return;
+  try {
+    // Negative pid targets the process group created by `detached: true`.
+    process.kill(-child.pid, signal);
+  } catch {
+    try { child.kill(signal); } catch { /* already gone */ }
+  }
+}
+
+// Without this, killing the runner (Ctrl-C, an outer timeout, a supervisor) leaves
+// its `bun test` children orphaned to PID 1 — they keep holding ports and CPU and
+// corrupt whatever runs next. Reap the tree, then exit with the conventional code.
+let shuttingDown = false;
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(sig, () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    for (const child of liveChildren) killTree(child, 'SIGKILL');
+    process.exit(sig === 'SIGINT' ? 130 : 143);
+  });
+}
+
 function runOne(file) {
   return new Promise(resolve => {
     const args = ['test', ...(hasOwnTimeout ? [] : [`--timeout=${TEST_TIMEOUT_MS}`]), ...extraArgs, file];
@@ -200,19 +227,31 @@ function runOne(file) {
     delete childEnv.PM2_HOME;
     delete childEnv.PLUGIN_PM2_HOME;
 
-    const child = spawn('bun', args, { stdio: ['ignore', 'pipe', 'pipe'], env: childEnv });
+    // `detached: true` puts the child in its OWN process group, so a kill can take
+    // the whole tree — `child.kill()` alone signals only the Bun parent and leaves
+    // servers/ptys it spawned running (measured: cancelling a run left `bun test`
+    // children with PPID=1 alive for minutes, competing for ports and load with the
+    // next run and silently poisoning its results).
+    const child = spawn('bun', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: childEnv,
+      detached: process.platform !== 'win32',
+    });
+    liveChildren.add(child);
     let out = '';
     const cap = chunk => { if (out.length < 200_000) out += chunk; };
     child.stdout.on('data', cap);
     child.stderr.on('data', cap);
-    const wall = setTimeout(() => child.kill('SIGKILL'), FILE_WALL_MS);
+    const wall = setTimeout(() => killTree(child, 'SIGKILL'), FILE_WALL_MS);
     child.on('error', err => {
       clearTimeout(wall);
+      liveChildren.delete(child);
       rmSync(scratch, { recursive: true, force: true });
       resolve({ file, ok: false, out: `failed to launch bun: ${err.message}` });
     });
     child.on('close', (code, signal) => {
       clearTimeout(wall);
+      liveChildren.delete(child);
       rmSync(scratch, { recursive: true, force: true });
       // A signal death (wall-clock kill, OOM) leaves code null — never let that
       // coerce into a pass.

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Run the unit suite on `bun test` — the only runner that executes test BODIES
+// on Bun. `vitest` forks Node workers even when launched via `bun x vitest`
+// (measured), so Bun-specific behaviour (its `fetch` error taxonomy, the
+// startup-frozen `os.homedir()`, `Bun.file`, compiled-binary paths) is invisible
+// to `bun run test` and can only regress silently there.
+//
+// A subset of files cannot run here yet: `vi.doMock` / `vi.doUnmock` /
+// `vi.resetModules` and the `importOriginal` callback are module-registry
+// semantics, not missing functions. `test/bun-test-shim.ts` deliberately does
+// NOT fake them — a fake would report success while silently not mocking, which
+// is worse than the current red. Those files keep running under vitest until
+// they are rewritten to use dependency injection.
+//
+// The exclusion list is COMPUTED, never hardcoded: a stale literal list would
+// quietly start skipping files (or fail on files that have since been fixed).
+// Adding a `vi.doMock` to any file automatically moves it out of this leg, and
+// removing one moves it back in.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const TEST_DIR = 'test';
+
+// Matches the APIs whose absence is a module-system gap rather than a missing
+// helper. Keep in sync with the "DELIBERATELY NOT SHIMMED" list in
+// test/bun-test-shim.ts.
+const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules)\b|\bimportOriginal\b/;
+
+const all = readdirSync(TEST_DIR)
+  .filter(f => f.endsWith('.test.ts'))
+  .map(f => join(TEST_DIR, f))
+  .sort();
+
+const runnable = [];
+const skipped = [];
+for (const file of all) {
+  if (UNSUPPORTED.test(readFileSync(file, 'utf8'))) skipped.push(file);
+  else runnable.push(file);
+}
+
+console.log(`bun test: ${runnable.length} files (${skipped.length} deferred to vitest — module-registry APIs)`);
+
+if (runnable.length === 0) {
+  console.error('Refusing to report success: no runnable files were found. Is the test/ directory present?');
+  process.exit(1);
+}
+
+// Pass an explicit file list rather than letting bun glob, so the deferred files
+// cannot sneak in via a future default-glob change.
+const extraArgs = process.argv.slice(2);
+const res = spawnSync('bun', ['test', ...extraArgs, ...runnable], { stdio: 'inherit' });
+
+if (res.error) {
+  console.error(`Failed to launch bun test: ${res.error.message}`);
+  process.exit(1);
+}
+// A signal death (OOM, timeout kill) leaves status null — treat it as failure
+// rather than letting `undefined` coerce to a passing 0.
+if (res.status === null) {
+  console.error(`bun test terminated by signal ${res.signal ?? 'unknown'}`);
+  process.exit(1);
+}
+process.exit(res.status);

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -35,7 +35,7 @@
 
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { availableParallelism, tmpdir as realTmpdir } from 'node:os';
 
 const TEST_DIR = 'test';
@@ -161,18 +161,39 @@ console.log(
   + `(${skipped.length} deferred to vitest — module-registry APIs)`,
 );
 
-// Every child currently running, so a cancelled run can take them with it.
-const liveChildren = new Set();
+// Every child currently running, mapped to the scratch dir minted for it, so a
+// cancelled run can take both the processes AND their temp trees with it.
+const liveChildren = new Map();
 
-/** Signal a child's whole process group, falling back to the pid alone. */
+/**
+ * Signal a child's whole process TREE, not just the Bun parent it points at.
+ *
+ * POSIX: `detached: true` gave the child its own process group, and a negative pid
+ * signals that whole group. Windows has no process groups in this sense and
+ * rejects a negative pid, so shell out to `taskkill /T` (which walks the child
+ * tree) and fall back to the direct kill only if that is unavailable — a bare
+ * `child.kill()` there would leave the servers and ptys the test spawned running.
+ */
 function killTree(child, signal) {
   if (child.pid === undefined) return;
-  try {
-    // Negative pid targets the process group created by `detached: true`.
-    process.kill(-child.pid, signal);
-  } catch {
-    try { child.kill(signal); } catch { /* already gone */ }
+  if (process.platform === 'win32') {
+    // `spawnSync` reports a missing/unstartable binary through the RETURN VALUE
+    // (`{ error: ENOENT, status: null }`), not by throwing — verified. Returning
+    // unconditionally here would treat "taskkill never ran" as success and skip the
+    // fallback entirely, so check both fields before trusting it.
+    let killed = false;
+    try {
+      const res = spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+      killed = !res.error && res.status === 0;
+    } catch { /* fall through to the direct kill below */ }
+    if (killed) return;
+  } else {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch { /* group already gone, or never created — fall through */ }
   }
+  try { child.kill(signal); } catch { /* already gone */ }
 }
 
 // Without this, killing the runner (Ctrl-C, an outer timeout, a supervisor) leaves
@@ -183,7 +204,12 @@ for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
   process.on(sig, () => {
     if (shuttingDown) return;
     shuttingDown = true;
-    for (const child of liveChildren) killTree(child, 'SIGKILL');
+    for (const [child, scratch] of liveChildren) {
+      killTree(child, 'SIGKILL');
+      // Cancellation is exactly when these would otherwise accumulate: the close
+      // handler that normally removes them never runs.
+      try { rmSync(scratch, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
     process.exit(sig === 'SIGINT' ? 130 : 143);
   });
 }
@@ -237,7 +263,7 @@ function runOne(file) {
       env: childEnv,
       detached: process.platform !== 'win32',
     });
-    liveChildren.add(child);
+    liveChildren.set(child, scratch);
     let out = '';
     const cap = chunk => { if (out.length < 200_000) out += chunk; };
     child.stdout.on('data', cap);

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -79,7 +79,14 @@ function collectTestFiles(dir) {
 // fixture sees nothing (measured: vitest passes that probe while an eager-factory
 // shim reports `missing`). That is module-evaluation ORDER, not a missing
 // function, so it is unsupported rather than faked.
-const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimportOriginal\b|\bimportActual\b/;
+// `inject` is vitest's globalSetup→test value channel (`project.provide` /
+// `inject`). It is a NAMED EXPORT of the `vitest` module, and `bun test` resolves
+// `vitest` to its own `bun:test` — which has no such export, so the file dies at
+// import with `SyntaxError: Export named 'inject' not found`. A preload cannot
+// paper over it: `mock.module('vitest', … inject: … )` still fails, because the
+// static import is validated against `bun:test`'s real export list before any
+// mock applies (measured). Runner-config plumbing, not a missing helper.
+const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimportOriginal\b|\bimportActual\b|\binject\b/;
 
 // Comments must not decide whether a file runs. Matching raw source means a file
 // that merely MENTIONS one of these names in prose gets silently skipped, and the

--- a/test/bun-runner-selectors.test.ts
+++ b/test/bun-runner-selectors.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the source-text selectors in `scripts/run-bun-tests.mjs` that decide which
+ * files the bun leg may run.
+ *
+ * WHY: a selector that is too narrow SILENTLY SKIPS files (the population count
+ * still looks healthy — this repo has already shipped that bug three times: a
+ * comment-matching over-exclusion, a bare `\binject\b` that deferred 20 innocent
+ * files, and a name-based mock-factory pattern that missed a callback spelled
+ * `orig`). One that is too broad quietly drops files that would otherwise run. Both
+ * failure modes are invisible in the summary line, so the selectors need their own
+ * two-sided guard.
+ *
+ * Kept as literal copies of the runner's regexes rather than imported: the runner is
+ * a plain `.mjs` script with top-level `await` and side effects at import time, so
+ * importing it here would execute a test run. The `keeps this in sync` case below is
+ * what catches drift between the two copies.
+ */
+
+const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimportOriginal\b|\bimportActual\b/;
+const IMPORTS_INJECT = /import\s*\{[^}]*\binject\b[^}]*\}\s*from\s*['"]vitest['"]/s;
+const MOCK_FACTORY_TAKES_ORIGINAL =
+  /\bvi\s*\.\s*mock\s*\([^,]+,\s*(?:async\s*)?\(\s*[A-Za-z_$][\w$]*/;
+
+function excluded(source: string): boolean {
+  return UNSUPPORTED.test(source) || IMPORTS_INJECT.test(source)
+    || MOCK_FACTORY_TAKES_ORIGINAL.test(source);
+}
+
+describe('bun runner exclusion selectors', () => {
+  it.each([
+    // The feature is defined by SHAPE — a factory that takes the original-module
+    // argument — not by what the parameter happens to be called.
+    ['vi.mock factory taking the original under the conventional name', "vi.mock('./x.js', async (importOriginal) => ({}));"],
+    ['…under a non-conventional name (the case that leaked to CI)', "vi.mock('./x.js', async (orig) => ({}));"],
+    ['…without async', "vi.mock('./x.js', (importOriginal) => ({}));"],
+    ['vi.doMock at all', "vi.doMock('./x.js', () => ({}));"],
+    ['vi.resetModules at all', 'vi.resetModules();'],
+    ['vi.hoisted at all', 'const v = vi.hoisted(() => 1);'],
+    ['a named import of inject from vitest', "import { it, inject } from 'vitest';"],
+  ])('excludes: %s', (_label, source) => {
+    expect(excluded(source)).toBe(true);
+  });
+
+  it.each([
+    // The supported form: a factory that does NOT ask for the original module.
+    ['zero-argument mock factory', "vi.mock('./x.js', () => ({ a: 1 }));"],
+    ['zero-argument async factory', "vi.mock('./x.js', async () => ({ a: 1 }));"],
+    ['bare vi.mock with no factory', "vi.mock('./x.js');"],
+    // Ordinary callbacks must not be mistaken for a mock factory.
+    ['an unrelated callback after a vi.mock', "vi.mock('./x.js');\narr.map((item) => item + 1);"],
+    ['vi.fn with a parameter', 'const f = vi.fn((a) => a);'],
+    ['spyOn mockImplementation', "vi.spyOn(o, 'm').mockImplementation((x) => x);"],
+    ['mockImplementation after a bare vi.mock', "vi.mock('./x.js');\nthing.mockImplementation((v) => v);"],
+    // Prose must never decide whether a file runs.
+    ['the word inject in a test title', "it('does not inject anything', () => {});"],
+    ['a script name containing inject', "const s = 'inject-optional-binaries.mjs';"],
+  ])('keeps runnable: %s', (_label, source) => {
+    expect(excluded(source)).toBe(false);
+  });
+
+  it('keeps this file in sync with the runner script', async () => {
+    const { readFileSync } = await import('node:fs');
+    const runner = readFileSync('scripts/run-bun-tests.mjs', 'utf8');
+    // If the runner's regexes are edited without updating the copies above, this
+    // fails — which is the point. Compare source text, not behaviour, so a changed
+    // pattern is caught even when both happen to agree on today's corpus.
+    for (const re of [UNSUPPORTED, IMPORTS_INJECT, MOCK_FACTORY_TAKES_ORIGINAL]) {
+      expect(runner).toContain(re.source);
+    }
+  });
+});

--- a/test/bun-runner-selectors.test.ts
+++ b/test/bun-runner-selectors.test.ts
@@ -38,6 +38,11 @@ describe('bun leg selectors — files that must be deferred', () => {
     ['vi.hoisted', 'const v = vi.hoisted(() => 1);'],
     // vitest's globalSetup→test channel, which bun:test does not export.
     ['a named import of inject from vitest', "import { it, inject } from 'vitest';"],
+    ['inject from a vitest subpath', "import { inject } from 'vitest/suite';"],
+    // An alias still pulls the export that does not exist, so the file still dies.
+    ['inject imported under an alias', "import { inject as get } from 'vitest';"],
+    // A mixed clause: the type specifier is erased, the value one is not.
+    ['a value inject beside a type specifier', "import { type Mock, inject } from 'vitest';"],
   ])('defers: %s', (_label, source) => {
     expect(isDeferredFromBunLeg(source)).toBe(true);
   });
@@ -59,6 +64,21 @@ describe('bun leg selectors — files that must stay runnable', () => {
     ['the word inject in a test title', "it('does not inject anything', () => {});"],
     ['a script name containing inject', "const s = 'inject-optional-binaries.mjs';"],
     ['a callback parameter named inject', 'register((inject) => inject());'],
+    // Only vitest's `inject` is missing under bun. A same-named export from any other
+    // module resolves normally, so deferring it would silently shrink the leg — the
+    // exact failure this guard exists to catch. An import-clause-only pattern
+    // deferred all three of these.
+    ['inject from a local module', "import { inject } from './dependency-injection.js';"],
+    ['inject from a DI package', "import { injectable, inject } from 'tsyringe';"],
+    ['inject from a node builtin', "import { inject } from 'node:test';"],
+    // `vitest-` is a different package; the specifier must match on a boundary.
+    ['inject from a package merely prefixed vitest', "import { inject } from 'vitest-helpers';"],
+    // Type-only imports are ERASED before execution, so the module never has to supply
+    // the export. Verified under Bun 1.4: both forms run to completion even when
+    // `vitest` cannot be resolved at runtime at all.
+    ['a type-only import clause', "import type { inject } from 'vitest';"],
+    ['an inline type specifier', "import { type inject } from 'vitest';"],
+    ['type-only inject beside a value import', "import { type inject, describe } from 'vitest';"],
   ])('keeps runnable: %s', (_label, source) => {
     expect(isDeferredFromBunLeg(source)).toBe(false);
   });

--- a/test/bun-runner-selectors.test.ts
+++ b/test/bun-runner-selectors.test.ts
@@ -1,73 +1,104 @@
 import { describe, expect, it } from 'vitest';
 
+import { isDeferredFromBunLeg, stripComments } from './helpers/bun-leg-selectors.js';
+
 /**
- * Guards the source-text selectors in `scripts/run-bun-tests.mjs` that decide which
- * files the bun leg may run.
+ * Guards the selectors that decide which files the `bun test` leg may run.
  *
- * WHY: a selector that is too narrow SILENTLY SKIPS files (the population count
- * still looks healthy — this repo has already shipped that bug three times: a
- * comment-matching over-exclusion, a bare `\binject\b` that deferred 20 innocent
- * files, and a name-based mock-factory pattern that missed a callback spelled
- * `orig`). One that is too broad quietly drops files that would otherwise run. Both
- * failure modes are invisible in the summary line, so the selectors need their own
- * two-sided guard.
+ * WHY THIS EXISTS: both directions of error are invisible in the runner's summary
+ * line. Too narrow and files are SILENTLY SKIPPED while the population count still
+ * looks healthy; too broad and files that would pass quietly sit out. This repo has
+ * shipped that bug three times — a comment match, a bare `\binject\b` that deferred
+ * 20 innocent files, and a name-based factory pattern that missed a callback spelled
+ * `orig` — so the selectors need a two-sided guard of their own.
  *
- * Kept as literal copies of the runner's regexes rather than imported: the runner is
- * a plain `.mjs` script with top-level `await` and side effects at import time, so
- * importing it here would execute a test run. The `keeps this in sync` case below is
- * what catches drift between the two copies.
+ * It imports the REAL selector rather than re-declaring the patterns. An earlier
+ * version copied them, which had two problems: the copy could drift, and the copied
+ * literals made this very file match its own exclusion rule — so it was deferred out
+ * of the leg it is supposed to guard, and only ever ran when invoked by hand. Passing
+ * sources in as arguments keeps every example inside a parameter, where a scan of the
+ * repository cannot see it.
  */
 
-const UNSUPPORTED = /\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b|\bimportOriginal\b|\bimportActual\b/;
-const IMPORTS_INJECT = /import\s*\{[^}]*\binject\b[^}]*\}\s*from\s*['"]vitest['"]/s;
-const MOCK_FACTORY_TAKES_ORIGINAL =
-  /\bvi\s*\.\s*mock\s*\([^,]+,\s*(?:async\s*)?\(\s*[A-Za-z_$][\w$]*/;
-
-function excluded(source: string): boolean {
-  return UNSUPPORTED.test(source) || IMPORTS_INJECT.test(source)
-    || MOCK_FACTORY_TAKES_ORIGINAL.test(source);
-}
-
-describe('bun runner exclusion selectors', () => {
+describe('bun leg selectors — files that must be deferred', () => {
   it.each([
-    // The feature is defined by SHAPE — a factory that takes the original-module
-    // argument — not by what the parameter happens to be called.
-    ['vi.mock factory taking the original under the conventional name', "vi.mock('./x.js', async (importOriginal) => ({}));"],
-    ['…under a non-conventional name (the case that leaked to CI)', "vi.mock('./x.js', async (orig) => ({}));"],
-    ['…without async', "vi.mock('./x.js', (importOriginal) => ({}));"],
-    ['vi.doMock at all', "vi.doMock('./x.js', () => ({}));"],
-    ['vi.resetModules at all', 'vi.resetModules();'],
-    ['vi.hoisted at all', 'const v = vi.hoisted(() => 1);'],
+    // The feature is defined by SHAPE — a factory that receives the original module —
+    // not by what the parameter is called. All four syntactic forms must match.
+    ['parenthesised arrow, conventional name', "vi.mock('./x.js', async (importOriginal) => ({}));"],
+    ['parenthesised arrow, other name', "vi.mock('./x.js', async (orig) => ({}));"],
+    ['parenless arrow (escaped a parens-only pattern)', "vi.mock('./x.js', async importOriginal => ({}));"],
+    ['parenless arrow, other name', "vi.mock('./x.js', orig => ({}));"],
+    ['function expression', "vi.mock('./x.js', function (orig) { return {}; });"],
+    ['async function expression', "vi.mock('./x.js', async function (orig) { return {}; });"],
+    ['no async keyword', "vi.mock('./x.js', (importOriginal) => ({}));"],
+    // Module-registry / transform APIs, by name.
+    ['vi.doMock', "vi.doMock('./x.js', () => ({}));"],
+    ['vi.doUnmock', "vi.doUnmock('./x.js');"],
+    ['vi.resetModules', 'vi.resetModules();'],
+    ['vi.hoisted', 'const v = vi.hoisted(() => 1);'],
+    // vitest's globalSetup→test channel, which bun:test does not export.
     ['a named import of inject from vitest', "import { it, inject } from 'vitest';"],
-  ])('excludes: %s', (_label, source) => {
-    expect(excluded(source)).toBe(true);
+  ])('defers: %s', (_label, source) => {
+    expect(isDeferredFromBunLeg(source)).toBe(true);
   });
+});
 
+describe('bun leg selectors — files that must stay runnable', () => {
   it.each([
-    // The supported form: a factory that does NOT ask for the original module.
-    ['zero-argument mock factory', "vi.mock('./x.js', () => ({ a: 1 }));"],
+    // The supported form: a factory that does not ask for the original module.
+    ['zero-argument factory', "vi.mock('./x.js', () => ({ a: 1 }));"],
     ['zero-argument async factory', "vi.mock('./x.js', async () => ({ a: 1 }));"],
+    ['zero-argument function expression', "vi.mock('./x.js', function () { return {}; });"],
     ['bare vi.mock with no factory', "vi.mock('./x.js');"],
     // Ordinary callbacks must not be mistaken for a mock factory.
     ['an unrelated callback after a vi.mock', "vi.mock('./x.js');\narr.map((item) => item + 1);"],
     ['vi.fn with a parameter', 'const f = vi.fn((a) => a);'],
     ['spyOn mockImplementation', "vi.spyOn(o, 'm').mockImplementation((x) => x);"],
     ['mockImplementation after a bare vi.mock', "vi.mock('./x.js');\nthing.mockImplementation((v) => v);"],
-    // Prose must never decide whether a file runs.
+    // Prose and identifiers must never decide whether a file runs.
     ['the word inject in a test title', "it('does not inject anything', () => {});"],
     ['a script name containing inject', "const s = 'inject-optional-binaries.mjs';"],
+    ['a callback parameter named inject', 'register((inject) => inject());'],
   ])('keeps runnable: %s', (_label, source) => {
-    expect(excluded(source)).toBe(false);
+    expect(isDeferredFromBunLeg(source)).toBe(false);
   });
 
-  it('keeps this file in sync with the runner script', async () => {
+  it('sees code that follows a template literal with a substitution', () => {
+    // Regression: scanning a `${…}` substitution needs `reScanTemplateToken`, or the
+    // `}` reads as a plain brace and the next backtick opens a NEW literal that
+    // swallows the rest of the file. That blanked real calls and wrongly promoted
+    // files into the leg — the defect is invisible unless the probe puts a template
+    // BEFORE the thing being detected.
+    const source = [
+      'const p = (id: string) => join(DIR, `token-${id}.json`);',
+      "vi.mock('node:fs', async (importOriginal) => ({}));",
+    ].join('\n');
+    expect(isDeferredFromBunLeg(source)).toBe(true);
+  });
+
+  it('still sees code after a plain template literal', () => {
+    const source = ["const s = `no substitution`;", 'vi.resetModules();'].join('\n');
+    expect(isDeferredFromBunLeg(source)).toBe(true);
+  });
+
+  it('ignores an unsupported API named only inside a comment', () => {
+    expect(isDeferredFromBunLeg('// this file once used vi.resetModules\nit("x", () => {});')).toBe(false);
+    expect(isDeferredFromBunLeg('/* vi.hoisted was removed */\nit("x", () => {});')).toBe(false);
+  });
+
+  it('strips comments but leaves code intact', () => {
+    expect(stripComments('const a = 1; // trailing\nconst b = 2;')).toContain('const b = 2;');
+    expect(stripComments('/* lead */ const c = 3;')).toContain('const c = 3;');
+    // A URL must survive: the `//` there is not a comment.
+    expect(stripComments("const u = 'https://example.com/x';")).toContain('https://example.com/x');
+  });
+});
+
+describe('bun leg selectors — this guard runs inside the leg it guards', () => {
+  it('is not deferred by its own rules', async () => {
     const { readFileSync } = await import('node:fs');
-    const runner = readFileSync('scripts/run-bun-tests.mjs', 'utf8');
-    // If the runner's regexes are edited without updating the copies above, this
-    // fails — which is the point. Compare source text, not behaviour, so a changed
-    // pattern is caught even when both happen to agree on today's corpus.
-    for (const re of [UNSUPPORTED, IMPORTS_INJECT, MOCK_FACTORY_TAKES_ORIGINAL]) {
-      expect(runner).toContain(re.source);
-    }
+    // The earlier copy-the-patterns version excluded itself, so it never ran in CI.
+    // Every example above lives in a function argument for exactly this reason.
+    expect(isDeferredFromBunLeg(readFileSync('test/bun-runner-selectors.test.ts', 'utf8'))).toBe(false);
   });
 });

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -336,6 +336,39 @@ describe('exact-path env overrides are cleared by the shared fence', () => {
   });
 });
 
+// `toHaveBeenCalledExactlyOnceWith` is shimmed under bun (vitest has it natively).
+// Its meaning is a CONJUNCTION — called exactly once, AND with these arguments — so
+// the guard has to cover the failing quadrants too: a shim that only compared
+// arguments would pass for a mock called three times whose first call matched, and
+// one that only counted calls would pass for a single wrong-argument call. The
+// repository's two production users only exercise the passing case, so without these
+// the count check could be deleted and CI would stay green.
+describe('toHaveBeenCalledExactlyOnceWith parity', () => {
+  it('passes when called exactly once with those arguments', () => {
+    const fn = vi.fn();
+    fn('a', 1);
+    expect(fn).toHaveBeenCalledExactlyOnceWith('a', 1);
+  });
+
+  it('FAILS when called twice, even though the first call matches', () => {
+    const fn = vi.fn();
+    fn('a', 1);
+    fn('a', 1);
+    expect(() => expect(fn).toHaveBeenCalledExactlyOnceWith('a', 1)).toThrow();
+  });
+
+  it('FAILS when called once with different arguments', () => {
+    const fn = vi.fn();
+    fn('b', 2);
+    expect(() => expect(fn).toHaveBeenCalledExactlyOnceWith('a', 1)).toThrow();
+  });
+
+  it('FAILS when never called at all', () => {
+    const fn = vi.fn();
+    expect(() => expect(fn).toHaveBeenCalledExactlyOnceWith('a', 1)).toThrow();
+  });
+});
+
 // `it.runIf(cond)` must behave exactly like `skipIf(!cond)`: Bun ships skipIf but
 // not runIf, and the shim inverts it. Asserting the ran/skipped split (rather
 // than just "did not crash") is what makes the equivalence testable.

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -75,6 +75,87 @@ describe('vi shim parity (vitest reference / bun shim)', () => {
     ).rejects.toThrow('distinctive-shim-parity-failure');
   });
 
+  // Real timers have their own deadline boundary, and it broke independently of
+  // the fake one: the sleep must be clamped to the REMAINING timeout, or the loop
+  // oversleeps and then accepts a condition that only became true afterwards
+  // (measured: interval 50 / timeout 30, condition at 40ms — vitest rejected at
+  // ~33ms while an unclamped shim resolved).
+  it('waitFor under real timers REJECTS a condition that arrives after the timeout', async () => {
+    let ready = false;
+    const timer = setTimeout(() => { ready = true; }, 40);
+    try {
+      await expect(
+        vi.waitFor(
+          () => { if (!ready) throw new Error('real-late-marker'); return 'too-late'; },
+          { interval: 50, timeout: 30 },
+        ),
+      ).rejects.toThrow('real-late-marker');
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  // Fake timers are a separate code path in the shim: vitest's waitFor pumps the
+  // faked clock itself, so a naive real `setTimeout` sleep deadlocks there. These
+  // four pin the boundary behaviour in both directions — the shim must neither
+  // hang nor accept a condition that only becomes true after the deadline.
+  it('waitFor under fake timers resolves when the condition arrives in time', async () => {
+    vi.useFakeTimers();
+    try {
+      let ready = false;
+      setTimeout(() => { ready = true; }, 50);
+      const got = await vi.waitFor(
+        () => { if (!ready) throw new Error('not yet'); return 'arrived'; },
+        { interval: 10, timeout: 500 },
+      );
+      expect(got).toBe('arrived');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('waitFor under fake timers REJECTS a condition that only arrives after the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      let ready = false;
+      setTimeout(() => { ready = true; }, 120);
+      await expect(
+        vi.waitFor(
+          () => { if (!ready) throw new Error('late-arrival-marker'); return 'too-late'; },
+          { interval: 10, timeout: 100 },
+        ),
+      ).rejects.toThrow('late-arrival-marker');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('waitFor under fake timers still observes a condition arriving exactly at the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      let ready = false;
+      setTimeout(() => { ready = true; }, 100);
+      const got = await vi.waitFor(
+        () => { if (!ready) throw new Error('not yet'); return 'boundary'; },
+        { interval: 10, timeout: 100 },
+      );
+      expect(got).toBe('boundary');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('waitFor under fake timers surfaces the last failure when never ready', async () => {
+    vi.useFakeTimers();
+    try {
+      await expect(
+        vi.waitFor(() => { throw new Error('fake-never-ready-marker'); }, { interval: 10, timeout: 60 }),
+      ).rejects.toThrow('fake-never-ready-marker');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('runAllTimersAsync settles a timer callback that awaits', async () => {
     vi.useFakeTimers();
     try {
@@ -99,11 +180,15 @@ describe('vi shim parity (vitest reference / bun shim)', () => {
     }
   });
 
-  // NOTE: `vi.hoisted` is intentionally NOT asserted here. vitest's transform
-  // physically hoists any `vi.hoisted(…)` call to the top of the module, above
-  // the imports — so merely mentioning it inside a test body makes the file
-  // unparseable under vitest ("Expected a semicolon … after a statement").
-  // Its shim is exercised implicitly by the 111 files that already use it.
+  // NOTE: the hoisting helper is intentionally NOT asserted here, for two
+  // reasons. (1) vitest's transform physically lifts that call to the top of the
+  // module, above the imports — so merely writing it inside a test body makes the
+  // file unparseable under vitest ("Expected a semicolon … after a statement").
+  // (2) scripts/run-bun-tests.mjs matches the bare identifier to decide which
+  // files the bun leg must skip, so even naming it in prose here would exclude
+  // THIS file from the very leg it is meant to guard. It is unsupported under
+  // bun, not shimmed — see the "DELIBERATELY NOT SHIMMED" list in
+  // test/bun-test-shim.ts.
 });
 
 // `it.runIf(cond)` must behave exactly like `skipIf(!cond)`: Bun ships skipIf but

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import osDefault from 'node:os';
+import { realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { homedir, userInfo } from 'node:os';
 
 /**
@@ -200,14 +202,36 @@ describe('vi shim parity (vitest reference / bun shim)', () => {
 // shape of the bun fence pointed `default` at the UNFENCED module. Assert the
 // cross-product so neither route can regress silently on either runner.
 describe('home fence parity (both override targets, both import forms)', () => {
-  it('homedir() and userInfo().homedir agree and are not the real home', () => {
-    expect(homedir()).not.toBe('/root');
-    expect(userInfo().homedir).toBe(homedir());
+  // Assert equality with the CURRENT fenced env, not inequality with one
+  // machine's home path. `not.toBe('/root')` would pass on a GitHub runner
+  // (`/home/runner`) or macOS (`/Users/...`) even if the fence were leaking
+  // entirely — a false green wherever this repo's CI actually runs.
+  const expectedHome = () => (process.platform === 'win32'
+    ? process.env.USERPROFILE
+    : process.env.HOME);
+
+  it('homedir() and userInfo().homedir both equal the fenced HOME', () => {
+    expect(expectedHome()).toBeTruthy();
+    expect(homedir()).toBe(expectedHome());
+    expect(userInfo().homedir).toBe(expectedHome());
+  });
+
+  // The assertion above only proves CONSISTENCY: both fences set `process.env.HOME`
+  // AND redirect `homedir()`, so comparing the two to each other still passes if
+  // the fence is removed entirely (measured — that mutation stayed green). Anchor
+  // containment on something the fence cannot move: the OS temp root. Both fences
+  // mint their disposable home under `tmpdir()`, and a leak to a real home
+  // (`/root`, `/home/runner`, `/Users/...`) is not under it — on any platform,
+  // which `not.toBe('/root')` could not claim.
+  it('the fenced home lives under the OS temp root, not a real user home', () => {
+    const home = homedir();
+    const tmpRoot = realpathSync(tmpdir());
+    expect(realpathSync(home).startsWith(tmpRoot)).toBe(true);
   });
 
   it('the default import sees the same fenced values as the named import', () => {
-    expect(osDefault.homedir()).toBe(homedir());
-    expect(osDefault.userInfo().homedir).toBe(homedir());
+    expect(osDefault.homedir()).toBe(expectedHome());
+    expect(osDefault.userInfo().homedir).toBe(expectedHome());
   });
 
   it('non-home fields of userInfo are left real', () => {
@@ -223,14 +247,14 @@ describe('home fence parity (both override targets, both import forms)', () => {
 describe.sequential('sequential parity', () => {
   const order: string[] = [];
 
-  it('first test yields, then finishes', async () => {
+  it.sequential('first test yields, then finishes', async () => {
     order.push('first-start');
     await new Promise(resolve => setTimeout(resolve, 30));
     order.push('first-end');
     expect(order).toEqual(['first-start', 'first-end']);
   });
 
-  it('second test starts only after the first fully finished', () => {
+  it.sequential('second test starts only after the first fully finished', () => {
     order.push('second');
     // Interleaving would give ['first-start', 'second', …] instead.
     expect(order).toEqual(['first-start', 'first-end', 'second']);

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Guards the `vi.*` / `it.*` helpers that `test/bun-test-shim.ts` fills in under
+ * `bun test`.
+ *
+ * WHY THIS FILE EXISTS: the shim's whole risk is *semantic drift* — a fill that
+ * returns without reproducing the real effect turns a loud failure into a silent
+ * false green. This repo already paid for that once (an ad-hoc `vi.stubEnv` shim
+ * made the suite green while it kept writing to the developer's real
+ * `~/.botmux`). So each shimmed behaviour is asserted here rather than assumed.
+ *
+ * Deliberately runs under BOTH runners: under vitest these assertions describe
+ * the reference semantics, and under `bun test` they check the shim reproduces
+ * them. A change that makes the two diverge fails on one side.
+ */
+
+describe('vi shim parity (vitest reference / bun shim)', () => {
+  it('stubEnv sets, stubEnv(undefined) deletes, unstubAllEnvs restores', () => {
+    process.env.BOTMUX_SHIM_PARITY_PRESET = 'orig';
+    delete process.env.BOTMUX_SHIM_PARITY_ABSENT;
+
+    vi.stubEnv('BOTMUX_SHIM_PARITY_PRESET', 'changed');
+    vi.stubEnv('BOTMUX_SHIM_PARITY_ABSENT', 'added');
+    expect(process.env.BOTMUX_SHIM_PARITY_PRESET).toBe('changed');
+    expect(process.env.BOTMUX_SHIM_PARITY_ABSENT).toBe('added');
+
+    // Passing undefined REMOVES the key rather than setting the string
+    // "undefined" — measured against vitest, and the reason the shim branches.
+    vi.stubEnv('BOTMUX_SHIM_PARITY_PRESET', undefined as unknown as string);
+    expect('BOTMUX_SHIM_PARITY_PRESET' in process.env).toBe(false);
+
+    vi.unstubAllEnvs();
+    expect(process.env.BOTMUX_SHIM_PARITY_PRESET).toBe('orig');
+    // A key that did not exist before stubbing is removed again, not left set.
+    expect('BOTMUX_SHIM_PARITY_ABSENT' in process.env).toBe(false);
+
+    delete process.env.BOTMUX_SHIM_PARITY_PRESET;
+  });
+
+  it('stubGlobal replaces and unstubAllGlobals restores or deletes', () => {
+    const g = globalThis as Record<string, unknown>;
+    g.botmuxShimParityExisting = 'before';
+    delete g.botmuxShimParityFresh;
+
+    vi.stubGlobal('botmuxShimParityExisting', 'after');
+    vi.stubGlobal('botmuxShimParityFresh', 'new');
+    expect(g.botmuxShimParityExisting).toBe('after');
+    expect(g.botmuxShimParityFresh).toBe('new');
+
+    vi.unstubAllGlobals();
+    expect(g.botmuxShimParityExisting).toBe('before');
+    expect('botmuxShimParityFresh' in g).toBe(false);
+
+    delete g.botmuxShimParityExisting;
+  });
+
+  it('waitFor resolves with the callback value once it stops throwing', async () => {
+    let ticks = 0;
+    const timer = setInterval(() => { ticks += 1; }, 5);
+    try {
+      const got = await vi.waitFor(
+        () => { if (ticks < 3) throw new Error('not yet'); return ticks; },
+        { timeout: 2_000, interval: 5 },
+      );
+      expect(got).toBeGreaterThanOrEqual(3);
+    } finally {
+      clearInterval(timer);
+    }
+  });
+
+  it('waitFor surfaces the LAST failure on timeout, not a generic message', async () => {
+    await expect(
+      vi.waitFor(() => { throw new Error('distinctive-shim-parity-failure'); }, { timeout: 60, interval: 10 }),
+    ).rejects.toThrow('distinctive-shim-parity-failure');
+  });
+
+  it('runAllTimersAsync settles a timer callback that awaits', async () => {
+    vi.useFakeTimers();
+    try {
+      const seen: string[] = [];
+      setTimeout(async () => { await Promise.resolve(); seen.push('fired'); }, 10);
+      await vi.runAllTimersAsync();
+      expect(seen).toEqual(['fired']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('advanceTimersByTimeAsync settles a timer callback that awaits', async () => {
+    vi.useFakeTimers();
+    try {
+      const seen: string[] = [];
+      setTimeout(async () => { await Promise.resolve(); seen.push('fired'); }, 10);
+      await vi.advanceTimersByTimeAsync(20);
+      expect(seen).toEqual(['fired']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // NOTE: `vi.hoisted` is intentionally NOT asserted here. vitest's transform
+  // physically hoists any `vi.hoisted(…)` call to the top of the module, above
+  // the imports — so merely mentioning it inside a test body makes the file
+  // unparseable under vitest ("Expected a semicolon … after a statement").
+  // Its shim is exercised implicitly by the 111 files that already use it.
+});
+
+// `it.runIf(cond)` must behave exactly like `skipIf(!cond)`: Bun ships skipIf but
+// not runIf, and the shim inverts it. Asserting the ran/skipped split (rather
+// than just "did not crash") is what makes the equivalence testable.
+const runIfRan: string[] = [];
+
+describe('it.runIf parity', () => {
+  it.runIf(true)('runs when the condition is true', () => {
+    runIfRan.push('true-branch');
+    expect(true).toBe(true);
+  });
+
+  it.runIf(false)('is skipped when the condition is false', () => {
+    runIfRan.push('false-branch');
+    expect(true).toBe(true);
+  });
+
+  it('observes exactly the true branch having run', () => {
+    expect(runIfRan).toEqual(['true-branch']);
+  });
+});
+
+describe.runIf(false)('describe.runIf(false) skips the whole block', () => {
+  it('must never run', () => {
+    runIfRan.push('block-branch');
+    expect(true).toBe(true);
+  });
+});

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -234,6 +234,20 @@ describe('home fence parity (both override targets, both import forms)', () => {
     expect(osDefault.userInfo().homedir).toBe(expectedHome());
   });
 
+  // The fence substitutes `homedir`, and must keep that field's ORIGINAL type:
+  // `userInfo({ encoding: 'buffer' })` returns Buffers under Node (Bun 1.4 returns
+  // strings for both overloads), so a hardcoded string produced a mixed
+  // `username: Buffer, homedir: string` object no runtime ever returns. Compare the
+  // two fields rather than asserting one concrete type, so this passes on either
+  // runtime and still fails if the substitution changes the shape.
+  it('userInfo({encoding:"buffer"}) keeps homedir the same type as username', () => {
+    const info = userInfo({ encoding: 'buffer' }) as unknown as { homedir: unknown; username: unknown };
+    expect(Buffer.isBuffer(info.homedir)).toBe(Buffer.isBuffer(info.username));
+    // …and whatever the type, it still points at the fenced home.
+    const asString = Buffer.isBuffer(info.homedir) ? info.homedir.toString() : String(info.homedir);
+    expect(asString).toBe(expectedHome());
+  });
+
   it('non-home fields of userInfo are left real', () => {
     expect(typeof userInfo().uid).toBe('number');
     expect(typeof userInfo().username).toBe('string');

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import osDefault from 'node:os';
+import { homedir, userInfo } from 'node:os';
 
 /**
  * Guards the `vi.*` / `it.*` helpers that `test/bun-test-shim.ts` fills in under
@@ -189,6 +191,50 @@ describe('vi shim parity (vitest reference / bun shim)', () => {
   // THIS file from the very leg it is meant to guard. It is unsupported under
   // bun, not shimmed — see the "DELIBERATELY NOT SHIMMED" list in
   // test/bun-test-shim.ts.
+});
+
+// The home fence has TWO override targets and TWO import forms; all four
+// combinations must land inside the fenced home. `userInfo().homedir` does not go
+// through `homedir()` (it leaked to the real `/root` before it was overridden),
+// and the default export is a separate binding from the namespace — an earlier
+// shape of the bun fence pointed `default` at the UNFENCED module. Assert the
+// cross-product so neither route can regress silently on either runner.
+describe('home fence parity (both override targets, both import forms)', () => {
+  it('homedir() and userInfo().homedir agree and are not the real home', () => {
+    expect(homedir()).not.toBe('/root');
+    expect(userInfo().homedir).toBe(homedir());
+  });
+
+  it('the default import sees the same fenced values as the named import', () => {
+    expect(osDefault.homedir()).toBe(homedir());
+    expect(osDefault.userInfo().homedir).toBe(homedir());
+  });
+
+  it('non-home fields of userInfo are left real', () => {
+    expect(typeof userInfo().uid).toBe('number');
+    expect(typeof userInfo().username).toBe('string');
+  });
+});
+
+// `.sequential` is shimmed under bun as an IDENTITY, which is only correct because
+// `bun test` runs tests sequentially by default. Assert that default directly, so
+// a future Bun release that makes concurrency the default turns this red instead
+// of letting the identity silently stop meaning what the caller asked for.
+describe.sequential('sequential parity', () => {
+  const order: string[] = [];
+
+  it('first test yields, then finishes', async () => {
+    order.push('first-start');
+    await new Promise(resolve => setTimeout(resolve, 30));
+    order.push('first-end');
+    expect(order).toEqual(['first-start', 'first-end']);
+  });
+
+  it('second test starts only after the first fully finished', () => {
+    order.push('second');
+    // Interleaving would give ['first-start', 'second', …] instead.
+    expect(order).toEqual(['first-start', 'first-end', 'second']);
+  });
 });
 
 // `it.runIf(cond)` must behave exactly like `skipIf(!cond)`: Bun ships skipIf but

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -275,6 +275,32 @@ describe.sequential('sequential parity', () => {
   });
 });
 
+// Exact-path env overrides that bypass `homedir()`/`userInfo()` and lead to real
+// writes (usage ledger, dashboard control audit, miramcp config + pidfile, the
+// core-only state dir). A value inherited from the caller's shell would have the
+// suite mutate live state, so both fences DELETE them. Asserting absence — rather
+// than "points somewhere safe" — matches the chosen contract: `resolveBotConfigPath`
+// fails closed on a set-but-missing path, so redirecting would change behaviour for
+// every test that never set the variable.
+describe('exact-path env overrides are cleared by both fences', () => {
+  const cleared = [
+    'BOTS_CONFIG',
+    'PM2_HOME',
+    'PLUGIN_PM2_HOME',
+    'BOTMUX_USAGE_DIR',
+    'BOTMUX_DASHBOARD_CONTROL_AUDIT_PATH',
+    'BOTMUX_CORE_STATE_DIR',
+    'MIRAMCP_CONFIG_PATH',
+    'MIRA_CONFIG_PATH',
+    'MIRAMCP_PID_FILE',
+  ] as const;
+
+  it('none of them is set inside a fenced run', () => {
+    const stillSet = cleared.filter(name => process.env[name] !== undefined);
+    expect(stillSet).toEqual([]);
+  });
+});
+
 // `it.runIf(cond)` must behave exactly like `skipIf(!cond)`: Bun ships skipIf but
 // not runIf, and the shim inverts it. Asserting the ran/skipped split (rather
 // than just "did not crash") is what makes the equivalence testable.

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -304,27 +304,29 @@ describe('exact-path env overrides are cleared by the shared fence', () => {
   ] as const;
 
   it('deletes every one of them even when the caller had them set', () => {
-    const saved = new Map<string, string | undefined>();
-    for (const name of cleared) {
-      saved.set(name, process.env[name]);
-      // A sentinel that looks like the live path these normally point at.
-      process.env[name] = `/root/.botmux/sentinel-${name}`;
-    }
+    // Drive the helper against a THROWAWAY env object, not `process.env`. The
+    // helper also rewrites the CLI homes (`CODEX_HOME`, `GROK_HOME`, …) and the
+    // `XDG_*`/Windows profile dirs, so snapshotting only the nine keys asserted
+    // here would leave any of those the caller had set pointing at the temp dir
+    // this test then deletes — a dangling path for every later test in the
+    // process. An isolated object sidesteps the whole restore problem.
+    const env: NodeJS.ProcessEnv = {};
+    for (const name of cleared) env[name] = `/root/.botmux/sentinel-${name}`;
+    // A CLI home too, to prove the isolation covers the keys this test does not
+    // assert on: it must be rewritten inside `env` and never touch process.env.
+    env.CODEX_HOME = '/root/.codex';
+    const before = process.env.CODEX_HOME;
+
+    const fencedHome = mkdtempSync(join(tmpdir(), 'fence-env-parity-'));
     try {
-      // Exercise the helper the two setup files share, on a throwaway home.
-      const fencedHome = mkdtempSync(join(tmpdir(), 'fence-env-parity-'));
-      try {
-        fenceHomeRootedEnv(fencedHome);
-        const stillSet = cleared.filter(name => process.env[name] !== undefined);
-        expect(stillSet).toEqual([]);
-      } finally {
-        rmSync(fencedHome, { recursive: true, force: true });
-      }
+      fenceHomeRootedEnv(fencedHome, env);
+      expect(cleared.filter(name => env[name] !== undefined)).toEqual([]);
+      // Redirected, not deleted — and inside the fence.
+      expect(env.CODEX_HOME).toBe(join(fencedHome, '.codex'));
+      // The live environment was not touched at all.
+      expect(process.env.CODEX_HOME).toBe(before);
     } finally {
-      for (const [name, original] of saved) {
-        if (original === undefined) delete process.env[name];
-        else process.env[name] = original;
-      }
+      rmSync(fencedHome, { recursive: true, force: true });
     }
   });
 

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import osDefault from 'node:os';
-import { realpathSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fenceHomeRootedEnv } from './helpers/fence-home-env.js';
 import { homedir, userInfo } from 'node:os';
 
 /**
@@ -282,7 +284,13 @@ describe.sequential('sequential parity', () => {
 // than "points somewhere safe" — matches the chosen contract: `resolveBotConfigPath`
 // fails closed on a set-but-missing path, so redirecting would change behaviour for
 // every test that never set the variable.
-describe('exact-path env overrides are cleared by both fences', () => {
+//
+// ⚠️ The test SEEDS the variables itself and calls the shared helper directly.
+// Merely asserting they are unset after setup is a zero-input guard: in CI (and any
+// clean shell) most of these are unset anyway, so deleting every `delete` from the
+// helper still passed — measured: fence fully disabled + clean env = 21/21 green.
+// Seeding is what gives the guard teeth on the machines that actually run it.
+describe('exact-path env overrides are cleared by the shared fence', () => {
   const cleared = [
     'BOTS_CONFIG',
     'PM2_HOME',
@@ -295,7 +303,32 @@ describe('exact-path env overrides are cleared by both fences', () => {
     'MIRAMCP_PID_FILE',
   ] as const;
 
-  it('none of them is set inside a fenced run', () => {
+  it('deletes every one of them even when the caller had them set', () => {
+    const saved = new Map<string, string | undefined>();
+    for (const name of cleared) {
+      saved.set(name, process.env[name]);
+      // A sentinel that looks like the live path these normally point at.
+      process.env[name] = `/root/.botmux/sentinel-${name}`;
+    }
+    try {
+      // Exercise the helper the two setup files share, on a throwaway home.
+      const fencedHome = mkdtempSync(join(tmpdir(), 'fence-env-parity-'));
+      try {
+        fenceHomeRootedEnv(fencedHome);
+        const stillSet = cleared.filter(name => process.env[name] !== undefined);
+        expect(stillSet).toEqual([]);
+      } finally {
+        rmSync(fencedHome, { recursive: true, force: true });
+      }
+    } finally {
+      for (const [name, original] of saved) {
+        if (original === undefined) delete process.env[name];
+        else process.env[name] = original;
+      }
+    }
+  });
+
+  it('and none of them is set inside the fenced run itself', () => {
     const stillSet = cleared.filter(name => process.env[name] !== undefined);
     expect(stillSet).toEqual([]);
   });

--- a/test/bun-test-fence.ts
+++ b/test/bun-test-fence.ts
@@ -66,11 +66,16 @@ fenceHomeRootedEnv(fileHome);
 const actualUserInfo = realOs.userInfo;
 const actualHomedir = realOs.homedir;
 
-mock.module('node:os', () => ({
+// Build the fenced surface ONCE, then hand the SAME object out as both the
+// namespace and the default export. Pointing `default` at the unfenced `realOs`
+// (an earlier shape here) contradicted the intent: a `import os from 'node:os'`
+// caller would read the real implementation. Measured on Bun 1.4.0 the default
+// import happens to resolve to the namespace anyway, so nothing in `src/` was
+// actually escaping — but relying on that is relying on a resolution detail, and
+// the code said one thing while meaning another. Now both routes are the fenced
+// object by construction.
+const fencedOs = {
   ...realOs,
-  // Bun resolves `import os from 'node:os'` through the default export, so a
-  // spread alone would leave default-import callers on the real implementation.
-  default: realOs,
   homedir: () => (process.platform === 'win32'
     ? process.env.USERPROFILE || actualHomedir()
     : process.env.HOME || actualHomedir()),
@@ -85,7 +90,9 @@ mock.module('node:os', () => ({
     const fenced = process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME;
     return fenced ? { ...info, homedir: fenced } : info;
   }) as typeof realOs.userInfo,
-}));
+};
+
+mock.module('node:os', () => ({ ...fencedOs, default: fencedOs }));
 
 // Mirrors the vitest fence: mojo mints per-session workspaces under the real
 // `~/.botmux/mojo-workspaces` unless redirected (observed live before the vitest

--- a/test/bun-test-fence.ts
+++ b/test/bun-test-fence.ts
@@ -53,14 +53,32 @@ mkdirSync(fileHome);
 process.env.HOME = fileHome;
 process.env.USERPROFILE = fileHome;
 
+// Bind the real implementations BEFORE installing the override. Reading them off
+// the namespace object inside the factory resolves back through the mocked
+// module, so `realOs.userInfo` would call the replacement and recurse forever
+// (measured: "Maximum call stack size exceeded").
+const actualUserInfo = realOs.userInfo;
+const actualHomedir = realOs.homedir;
+
 mock.module('node:os', () => ({
   ...realOs,
   // Bun resolves `import os from 'node:os'` through the default export, so a
   // spread alone would leave default-import callers on the real implementation.
   default: realOs,
   homedir: () => (process.platform === 'win32'
-    ? process.env.USERPROFILE || realOs.homedir()
-    : process.env.HOME || realOs.homedir()),
+    ? process.env.USERPROFILE || actualHomedir()
+    : process.env.HOME || actualHomedir()),
+  // `userInfo().homedir` is a SECOND route to the home directory and it does not
+  // go through `homedir()` — measured: with only `homedir` overridden,
+  // `userInfo().homedir` still returned the real `/root`. Four production call
+  // sites read it (src/cli.ts, src/worker.ts ×3), so leaving it unfenced would
+  // let those paths write outside the fence. Keep the real uid/username/shell
+  // fields intact and redirect only the home field.
+  userInfo: ((options?: { encoding?: string }) => {
+    const info = (actualUserInfo as (o?: unknown) => ReturnType<typeof realOs.userInfo>)(options);
+    const fenced = process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME;
+    return fenced ? { ...info, homedir: fenced } : info;
+  }) as typeof realOs.userInfo,
 }));
 
 // Mirrors the vitest fence: mojo mints per-session workspaces under the real

--- a/test/bun-test-fence.ts
+++ b/test/bun-test-fence.ts
@@ -85,10 +85,20 @@ const fencedOs = {
   // sites read it (src/cli.ts, src/worker.ts ×3), so leaving it unfenced would
   // let those paths write outside the fence. Keep the real uid/username/shell
   // fields intact and redirect only the home field.
+  // Preserve the field's ORIGINAL type. `userInfo({ encoding: 'buffer' })` returns
+  // Buffers for username/homedir/shell (Node does; Bun 1.4 returns strings for
+  // both overloads), so replacing `homedir` with a plain string produced a mixed
+  // `username: Buffer, homedir: string` object — a shape neither runtime ever
+  // returns, hidden by the `as typeof userInfo` cast. Mirror whatever the real call
+  // gave back.
   userInfo: ((options?: { encoding?: string }) => {
     const info = (actualUserInfo as (o?: unknown) => ReturnType<typeof realOs.userInfo>)(options);
     const fenced = process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME;
-    return fenced ? { ...info, homedir: fenced } : info;
+    if (!fenced) return info;
+    const homedir = Buffer.isBuffer((info as { homedir: unknown }).homedir)
+      ? Buffer.from(fenced)
+      : fenced;
+    return { ...info, homedir };
   }) as typeof realOs.userInfo,
 };
 

--- a/test/bun-test-fence.ts
+++ b/test/bun-test-fence.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, mock } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import * as realOs from 'node:os';
+import { fenceHomeRootedEnv } from './helpers/fence-home-env.js';
 
 /**
  * `bun test` counterpart of `test/unit-setup.ts`.
@@ -52,6 +53,11 @@ const fileHome = join(fileRoot, 'home');
 mkdirSync(fileHome);
 process.env.HOME = fileHome;
 process.env.USERPROFILE = fileHome;
+
+// HOME alone is not enough: BOTS_CONFIG / PM2_HOME and friends point straight at
+// a live home and bypass `homedir()` entirely (bot-registry treats BOTS_CONFIG as
+// the top of its chain). Redirect them into the fenced tree.
+fenceHomeRootedEnv(fileHome);
 
 // Bind the real implementations BEFORE installing the override. Reading them off
 // the namespace object inside the factory resolves back through the mocked

--- a/test/bun-test-fence.ts
+++ b/test/bun-test-fence.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeEach, mock } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import * as realOs from 'node:os';
+
+/**
+ * `bun test` counterpart of `test/unit-setup.ts`.
+ *
+ * WHY A SEPARATE FILE: the vitest fence is mounted through
+ * `vitest.config.ts` → `setupFiles`, which `bun test` never reads. Nothing else
+ * fences the home directory, and every `~/.botmux` path in `src/` is a hardcoded
+ * `join(homedir(), '.botmux', …)` with no env indirection (210 `homedir()` call
+ * sites across 111 files) — so an unfenced run writes straight into the
+ * developer's real home. That is not hypothetical: a `bun test` run overwrote a
+ * live `~/.botmux/config.json` with this repo's own test fixture, dropping
+ * `remoteAccess` and silently turning central-platform links back to localhost.
+ * The blast radius is wider than `~/.botmux`: `src/` also derives `~/.claude`,
+ * `~/.claude.json`, `~/.codex`, `~/.gemini`, `~/.dsh`, `~/.pm2` and more, so an
+ * unfenced run can corrupt the user's OTHER CLI configs too.
+ *
+ * WHY `mock.module` AND NOT JUST `process.env.HOME`: Bun snapshots
+ * `os.homedir()` before any JS runs, so assigning `process.env.HOME` here does
+ * NOT move `homedir()` in this process (measured — a preload that only sets the
+ * env still resolves to the real home). Overriding the module is what actually
+ * redirects in-process callers. The env assignment is still required: child
+ * processes inherit it and snapshot the fenced value at their own startup.
+ *
+ * Keep the mocked `homedir()` reading `process.env` on every call (not a
+ * captured constant) so a test that legitimately re-points HOME still works, and
+ * keep the win32 USERPROFILE rule so the override matches Node's POSIX
+ * behaviour rather than inventing a third semantic.
+ */
+
+const inheritedDataDir = process.env.SESSION_DATA_DIR;
+
+// One disposable root per test process. `bun test` has no globalSetup hook to
+// hand a shared parent down (vitest uses `unit-global-setup.ts` for that), so
+// each process mints its own under the real tmpdir — captured from the unmocked
+// module before the override is installed.
+const fileRoot = mkdtempSync(join(realOs.tmpdir(), 'botmux-bun-unit-'));
+
+const dataDir = join(fileRoot, 'data');
+mkdirSync(dataDir);
+process.env.SESSION_DATA_DIR = dataDir;
+
+const fileHome = join(fileRoot, 'home');
+mkdirSync(fileHome);
+process.env.HOME = fileHome;
+process.env.USERPROFILE = fileHome;
+
+mock.module('node:os', () => ({
+  ...realOs,
+  // Bun resolves `import os from 'node:os'` through the default export, so a
+  // spread alone would leave default-import callers on the real implementation.
+  default: realOs,
+  homedir: () => (process.platform === 'win32'
+    ? process.env.USERPROFILE || realOs.homedir()
+    : process.env.HOME || realOs.homedir()),
+}));
+
+// Mirrors the vitest fence: mojo mints per-session workspaces under the real
+// `~/.botmux/mojo-workspaces` unless redirected (observed live before the vitest
+// side was fenced). Tests that assert the path pass an explicit home instead.
+const mojoWorkspaceRoot = join(fileRoot, 'mojo-workspaces');
+mkdirSync(mojoWorkspaceRoot);
+process.env.BOTMUX_MOJO_WORKSPACE_ROOT = mojoWorkspaceRoot;
+
+// A preload runs before the test module, so a file-wide override made at module
+// scope or in beforeAll must be captured once and then repaired per test.
+let fileDataDir = '';
+beforeEach(() => {
+  if (!fileDataDir) {
+    const candidate = process.env.SESSION_DATA_DIR;
+    fileDataDir = candidate && candidate !== inheritedDataDir ? candidate : dataDir;
+  }
+  process.env.SESSION_DATA_DIR = fileDataDir;
+});
+
+afterAll(() => {
+  // Keep leaked async work fenced inside the managed root until the process
+  // exits; restoring the invoking environment here could briefly re-expose live
+  // Botmux data to a straggling write.
+  process.env.SESSION_DATA_DIR = dataDir;
+  rmSync(fileRoot, { recursive: true, force: true });
+});

--- a/test/bun-test-fence.ts
+++ b/test/bun-test-fence.ts
@@ -33,10 +33,15 @@ import * as realOs from 'node:os';
 
 const inheritedDataDir = process.env.SESSION_DATA_DIR;
 
-// One disposable root per test process. `bun test` has no globalSetup hook to
-// hand a shared parent down (vitest uses `unit-global-setup.ts` for that), so
-// each process mints its own under the real tmpdir — captured from the unmocked
-// module before the override is installed.
+// One disposable root per test PROCESS — note that `bun test` runs every file
+// it was given in a single process (measured: two files report the same
+// `process.pid`), unlike vitest which forks a worker per file. So this root is
+// shared by the whole invocation rather than per-file. That is fine for the
+// purpose here (keeping writes out of the real home) but it means `afterAll`
+// below fires once at the end, not between files. `bun test` also has no
+// globalSetup hook to hand a shared parent down (vitest uses
+// `unit-global-setup.ts` for that), so the root is minted here, under the real
+// tmpdir — captured from the unmocked module before the override is installed.
 const fileRoot = mkdtempSync(join(realOs.tmpdir(), 'botmux-bun-unit-'));
 
 const dataDir = join(fileRoot, 'data');

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -16,6 +16,16 @@ import { vi } from 'vitest';
  * `test/bun-test-fence.ts` overrides `node:os` itself; the shim alone would not
  * make an unfenced run safe.
  *
+ * KNOWN BUN DEFECTS that cannot be shimmed from here (documented so the resulting
+ * red is legible rather than mysterious):
+ *   `expect(promise).resolves.toSatisfy(fn)` — Bun calls the predicate with `{}`
+ *     instead of the resolved value. Measured: the SYNC form
+ *     `expect([1,2]).toSatisfy(fn)` receives the array correctly, so the defect is
+ *     in the `resolves` chain, not in `toSatisfy`. One file relies on it
+ *     (`test/remote-shutdown-detach.test.ts`, which fails with
+ *     `results.every is not a function`). Overriding a matcher cannot fix how the
+ *     runner threads the awaited value into it.
+ *
  * DELIBERATELY NOT SHIMMED — these are module-system semantics, not missing
  * functions, and any fake would silently not-mock while reporting success:
  *   `vi.doMock` / `vi.doUnmock`  — re-point a module mid-file

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -154,6 +154,43 @@ fill('setConfig', (config?: Record<string, unknown>) => {
 // wrong. Without it, 16 `it.runIf` + 5 `describe.runIf` files fail at collection
 // time with `it.runIf is not a function` (the whole mojo-* cluster).
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// `expect(fn).toHaveBeenCalledExactlyOnceWith(...)` — vitest has it, Bun does not
+// (measured). Its meaning is the conjunction of two matchers Bun DOES have, so this
+// is a mechanical composition rather than a reimplementation: called exactly once,
+// AND that one call had these arguments. Asserting both halves is what keeps it
+// honest — a shim that only checked arguments would pass for a mock called three
+// times whose first call matched.
+// ---------------------------------------------------------------------------
+const expectWithExtend = expect as unknown as {
+  extend?: (matchers: Record<string, unknown>) => void;
+};
+if (typeof expectWithExtend.extend === 'function') {
+  expectWithExtend.extend({
+    toHaveBeenCalledExactlyOnceWith(received: unknown, ...expected: unknown[]) {
+      const mock = (received as { mock?: { calls?: unknown[][] } })?.mock;
+      if (!mock || !Array.isArray(mock.calls)) {
+        return { pass: false, message: () => 'expected a mock function' };
+      }
+      const calls = mock.calls;
+      if (calls.length !== 1) {
+        return { pass: false, message: () => `expected exactly 1 call, received ${calls.length}` };
+      }
+      // Reuse the runner's own deep equality so the comparison semantics match
+      // `toHaveBeenCalledWith` instead of inventing a second notion of equality.
+      try {
+        expect(calls[0]).toEqual(expected);
+        return { pass: true, message: () => 'called exactly once with the expected arguments' };
+      } catch {
+        return {
+          pass: false,
+          message: () => `called once, but with ${JSON.stringify(calls[0])} instead of ${JSON.stringify(expected)}`,
+        };
+      }
+    },
+  });
+}
+
 /**
  * `it.sequential` / `describe.sequential` — vitest's opt-out of concurrent
  * execution. `bun test` already runs tests sequentially by default (measured: an

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -115,6 +115,40 @@ fill('advanceTimersByTimeAsync', async (ms: number) => {
   return vi;
 });
 
+// Same sync-to-async relationship as advanceTimersByTimeAsync. Bun has the sync
+// `runAllTimers`; the async variants additionally drain the microtask queue so a
+// timer callback that awaits can finish before the assertion runs.
+fill('runAllTimersAsync', async () => {
+  jest.runAllTimers();
+  await Promise.resolve();
+  return vi;
+});
+
+fill('runOnlyPendingTimersAsync', async () => {
+  jest.runOnlyPendingTimers();
+  await Promise.resolve();
+  return vi;
+});
+
+fill('advanceTimersToNextTimerAsync', async () => {
+  jest.advanceTimersToNextTimer();
+  await Promise.resolve();
+  return vi;
+});
+
+// vitest drains the microtask queue; there is no timer involvement.
+fill('runAllTicks', async () => {
+  await Promise.resolve();
+  return vi;
+});
+
+// Per-file config (only `testTimeout` is used here). `bun test` takes the
+// timeout as a CLI flag, so there is no runtime knob to forward this to —
+// accepting it as a no-op is safe for a TIMEOUT (a too-generous default cannot
+// turn a red into a green; it can only let a slow test finish). scripts/
+// run-bun-tests.mjs passes a matching --timeout so these files are not cut short.
+fill('setConfig', () => vi);
+
 // ---------------------------------------------------------------------------
 // vi.waitFor — poll until the callback stops throwing (or its promise rejects).
 // Mirrors vitest's default 1000ms timeout / 50ms interval and its behaviour of

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -23,6 +23,12 @@ import { vi } from 'vitest';
  *   `importOriginal` / `importActual` — the `vi.mock` factory's callback arg that
  *                                  yields the real module (runner-supplied, so
  *                                  no fill can provide it)
+ *   `vi.hoisted`                 — vitest's transform physically LIFTS the
+ *                                  callback above the static imports. A runtime
+ *                                  fill can only run it when the module body gets
+ *                                  there, i.e. after the imports, so a fixture
+ *                                  reading a global at import time sees nothing
+ *                                  (measured). Order, not a missing function.
  * Files using them stay red under `bun test` and keep running under vitest until
  * they are rewritten to use dependency injection. See `package.json:test:bun`.
  */
@@ -88,23 +94,8 @@ fill('unstubAllGlobals', () => {
 // Pass-throughs to a real Bun/jest implementation under a different name.
 // ---------------------------------------------------------------------------
 
-// `vi.hoisted` in vitest runs its factory before the module body. Bun's own
-// `mock.module` factories are already evaluated lazily at import time, so
-// running the factory eagerly here matches what callers depend on: the returned
-// value is available to a later `vi.mock` factory in the same file.
-fill('hoisted', <T>(factory: () => T): T => factory());
-
 // Type-only helper in vitest — the runtime value is the argument itself.
 fill('mocked', <T>(item: T): T => item);
-
-// `vi.importActual` bypasses the mock registry. Bun has no mock-aware resolver
-// to bypass: an un-mocked path imports the real module, and a path this process
-// HAS mocked cannot be un-mocked per-call. Kept only for the direct-call form
-// used by files that do not also mock the same specifier. The `vi.mock('x',
-// async (importActual) => …)` CALLBACK form is a different thing — that
-// parameter is supplied by the runner, not read off `vi`, so no fill can provide
-// it; scripts/run-bun-tests.mjs excludes those files instead.
-fill('importActual', (specifier: string) => import(specifier));
 
 fill('setSystemTime', (time?: string | number | Date) => {
   setSystemTime(time === undefined ? undefined : new Date(time));
@@ -128,30 +119,28 @@ fill('runAllTimersAsync', async () => {
   return vi;
 });
 
-fill('runOnlyPendingTimersAsync', async () => {
-  jest.runOnlyPendingTimers();
-  await Promise.resolve();
+// Per-file config. `bun test` takes the timeout as a CLI flag, so there is no
+// runtime knob to forward this to — and scripts/run-bun-tests.mjs already passes
+// a `--timeout` at least as large as anything a file asks for, so accepting
+// `testTimeout` as a no-op cannot turn a red into a green (a generous timeout only
+// lets a slow test finish).
+//
+// A blanket no-op would NOT be safe though: any OTHER option silently would not
+// apply, and the file would still go green. Accept exactly the key we have
+// verified is harmless and throw on anything else, so a future `vi.setConfig({
+// retry: 3 })` fails loudly here instead of quietly doing nothing.
+fill('setConfig', (config?: Record<string, unknown>) => {
+  for (const key of Object.keys(config ?? {})) {
+    if (key !== 'testTimeout') {
+      throw new Error(
+        `[bun-test-shim] vi.setConfig({ ${key} }) is not supported under bun test. `
+        + 'Only testTimeout is accepted (the runner passes a matching --timeout). '
+        + 'Add explicit support in test/bun-test-shim.ts rather than letting it no-op.',
+      );
+    }
+  }
   return vi;
 });
-
-fill('advanceTimersToNextTimerAsync', async () => {
-  jest.advanceTimersToNextTimer();
-  await Promise.resolve();
-  return vi;
-});
-
-// vitest drains the microtask queue; there is no timer involvement.
-fill('runAllTicks', async () => {
-  await Promise.resolve();
-  return vi;
-});
-
-// Per-file config (only `testTimeout` is used here). `bun test` takes the
-// timeout as a CLI flag, so there is no runtime knob to forward this to —
-// accepting it as a no-op is safe for a TIMEOUT (a too-generous default cannot
-// turn a red into a green; it can only let a slow test finish). scripts/
-// run-bun-tests.mjs passes a matching --timeout so these files are not cut short.
-fill('setConfig', () => vi);
 
 // ---------------------------------------------------------------------------
 // `it.runIf` / `describe.runIf` — Bun ships `skipIf` but not `runIf` (measured:
@@ -179,25 +168,110 @@ addRunIf(bunDescribe);
 
 // Mirrors vitest's default 1000ms timeout / 50ms interval and its behaviour of
 // surfacing the LAST failure, not a generic timeout message.
+//
+// ⚠️ FAKE TIMERS: vitest's waitFor ADVANCES fake timers by `interval` on each
+// poll. A naive `await new Promise(r => setTimeout(r, interval))` deadlocks
+// instead — once timers are faked nothing moves the clock, so the sleep never
+// resolves and the test dies on its own timeout (measured: vitest passes the same
+// probe while the naive shim hung to the 20s cap).
+//
+// There is no reliable way to ASK Bun whether timers are currently faked —
+// measured: `jest.now()` returns a number either way, and `setTimeout` keeps its
+// name and carries no `.mock` marker. So don't ask: TRY to advance, and treat the
+// "Fake timers are not active" throw as the signal to fall back to a real sleep.
+// The poll-count bound matters because a faked `Date.now()` need not advance, so
+// a wall-clock deadline alone could never expire.
 // ---------------------------------------------------------------------------
+
+/**
+ * Advance a faked clock. Returns false when timers are real (nothing to pump).
+ *
+ * Only "fake timers are not active" is treated as the real-timers signal; any
+ * other error is rethrown rather than silently reinterpreted as "timers are real"
+ * (which would send the caller down the wrong branch).
+ *
+ * ⚠️ KNOWN DIVERGENCE, not fixable from here: if a fired timer CALLBACK throws,
+ * vitest surfaces that error out of `waitFor`, but Bun's
+ * `jest.advanceTimersByTime` does not propagate it at all — measured directly:
+ * with a `setTimeout(() => { throw … })` pending, the advance call returns
+ * normally ("no-throw") and Bun reports the callback error through its own
+ * uncaught-error channel instead. So `waitFor` here rejects with the CONDITION's
+ * last error while vitest rejects with the timer's. A shim cannot invent an
+ * exception the runtime never delivers; the fix belongs in Bun. Documented rather
+ * than papered over, since the failure mode is a confusing diagnostic (wrong
+ * error text), not a silent pass.
+ */
+function tryAdvanceFakeTimers(ms: number): boolean {
+  try {
+    jest.advanceTimersByTime(ms);
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/fake timers are not active/i.test(message)) return false;
+    throw err;
+  }
+}
+
 fill('waitFor', async <T>(
   callback: () => T | Promise<T>,
   options?: number | { timeout?: number; interval?: number },
 ): Promise<T> => {
   const timeout = typeof options === 'number' ? options : options?.timeout ?? 1000;
   const interval = typeof options === 'number' ? 50 : options?.interval ?? 50;
+  const step = Math.max(1, interval);
   const deadline = Date.now() + timeout;
+  // Track how far the FAKE clock has been pumped. A faked `Date.now()` need not
+  // advance, so this is the only honest elapsed measure on that path — and it has
+  // to be a hard bound, not a generous one: with slack, a condition that only
+  // becomes true AFTER the timeout still got accepted on a later poll, so a
+  // caller expecting a rejection saw a resolve instead (measured against vitest).
+  let fakeElapsed = 0;
   let lastError: unknown;
+
   for (;;) {
     try {
       return await callback();
     } catch (err) {
       lastError = err;
     }
-    if (Date.now() >= deadline) {
-      throw lastError ?? new Error(`vi.waitFor timed out after ${timeout}ms`);
+    // Advancing returns false when timers are real (nothing to pump).
+    const faked = tryAdvanceFakeTimers(step);
+    if (faked) {
+      fakeElapsed += step;
+      // Stop as soon as the pumped time reaches the timeout. The probe above
+      // already ran for this tick, so the condition still gets its observation at
+      // exactly `timeout` — but never beyond it.
+      if (fakeElapsed >= timeout) {
+        try {
+          return await callback();
+        } catch (err) {
+          throw err ?? lastError;
+        }
+      }
+      // Let the just-fired timers' continuations settle before probing again.
+      await Promise.resolve();
+    } else {
+      // Real timers: the caller's timeout is wall-clock, so clamp the sleep to
+      // what is LEFT rather than always sleeping a full interval. Oversleeping
+      // past the deadline and then probing again accepted conditions that only
+      // became true after the timeout — measured: with interval 50 / timeout 30,
+      // a condition arriving at 40ms resolved here while vitest rejected at ~33ms.
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw lastError ?? new Error(`vi.waitFor timed out after ${timeout}ms`);
+      }
+      await new Promise(resolve => setTimeout(resolve, Math.min(step, remaining)));
+      // The sleep above ends at or before the deadline; one final probe at the
+      // boundary matches vitest's inclusive last observation, and anything later
+      // must not be observed at all.
+      if (Date.now() >= deadline) {
+        try {
+          return await callback();
+        } catch (err) {
+          throw err ?? lastError;
+        }
+      }
     }
-    await new Promise(resolve => setTimeout(resolve, interval));
   }
 });
 

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -1,0 +1,160 @@
+import { afterEach, expect, jest, mock, setSystemTime } from 'bun:test';
+import { vi } from 'vitest';
+
+/**
+ * Fills in the `vi.*` helpers `bun test` does not implement, for the subset
+ * whose vitest semantics can be reproduced exactly.
+ *
+ * ⚠️ READ BEFORE ADDING ANYTHING HERE. A shim that makes a call *return* without
+ * reproducing its *effect* converts a loud failure into a silent false green,
+ * which is strictly worse than the red it replaced. This repo has already paid
+ * for that once: `vi.stubEnv` threw under `bun test` (a red that correctly said
+ * "this run is not isolated"), an ad-hoc shim set the env var and let the suite
+ * go green — but Bun snapshots `os.homedir()` before any JS runs, so the tests
+ * kept writing to the developer's REAL home and overwrote a live
+ * `~/.botmux/config.json`. The env half of `stubEnv` is only safe here because
+ * `test/bun-test-fence.ts` overrides `node:os` itself; the shim alone would not
+ * make an unfenced run safe.
+ *
+ * DELIBERATELY NOT SHIMMED — these are module-system semantics, not missing
+ * functions, and any fake would silently not-mock while reporting success:
+ *   `vi.doMock` / `vi.doUnmock`  — re-point a module mid-file
+ *   `vi.resetModules`            — clear the module registry
+ *   `importOriginal`             — the callback arg that yields the real module
+ * Files using them stay red under `bun test` and keep running under vitest until
+ * they are rewritten to use dependency injection. See `package.json:test:bun`.
+ */
+
+const anyVi = vi as unknown as Record<string, unknown>;
+
+/** Install only when Bun lacks it, so a future Bun release wins automatically. */
+function fill(name: string, impl: unknown): void {
+  if (typeof anyVi[name] !== 'function') anyVi[name] = impl;
+}
+
+// ---------------------------------------------------------------------------
+// Env stubbing. Semantics measured against vitest (not assumed):
+//   stubEnv(k, 'v')      → sets
+//   stubEnv(k, undefined) → DELETES the key (`k in process.env === false`)
+//   unstubAllEnvs()      → restores pre-stub values; keys that did not exist
+//                          before are removed again
+// ---------------------------------------------------------------------------
+const savedEnv = new Map<string, string | undefined>();
+
+fill('stubEnv', (key: string, value: string | undefined) => {
+  if (!savedEnv.has(key)) savedEnv.set(key, process.env[key]);
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  return vi;
+});
+
+fill('unstubAllEnvs', () => {
+  for (const [key, original] of savedEnv) {
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  savedEnv.clear();
+  return vi;
+});
+
+// ---------------------------------------------------------------------------
+// Global stubbing — same restore-or-delete rule as the env pair, on globalThis.
+// ---------------------------------------------------------------------------
+const savedGlobals = new Map<string, { existed: boolean; value: unknown }>();
+
+fill('stubGlobal', (key: string, value: unknown) => {
+  if (!savedGlobals.has(key)) {
+    savedGlobals.set(key, {
+      existed: key in (globalThis as Record<string, unknown>),
+      value: (globalThis as Record<string, unknown>)[key],
+    });
+  }
+  (globalThis as Record<string, unknown>)[key] = value;
+  return vi;
+});
+
+fill('unstubAllGlobals', () => {
+  for (const [key, saved] of savedGlobals) {
+    if (saved.existed) (globalThis as Record<string, unknown>)[key] = saved.value;
+    else delete (globalThis as Record<string, unknown>)[key];
+  }
+  savedGlobals.clear();
+  return vi;
+});
+
+// ---------------------------------------------------------------------------
+// Pass-throughs to a real Bun/jest implementation under a different name.
+// ---------------------------------------------------------------------------
+
+// `vi.hoisted` in vitest runs its factory before the module body. Bun's own
+// `mock.module` factories are already evaluated lazily at import time, so
+// running the factory eagerly here matches what callers depend on: the returned
+// value is available to a later `vi.mock` factory in the same file.
+fill('hoisted', <T>(factory: () => T): T => factory());
+
+// Type-only helper in vitest — the runtime value is the argument itself.
+fill('mocked', <T>(item: T): T => item);
+
+// `vi.importActual` bypasses the mock registry. Bun has no mock-aware resolver
+// to bypass: an un-mocked path imports the real module, and a path this process
+// HAS mocked cannot be un-mocked per-call. Only safe because it is used in
+// files that do not also mock the same specifier — a file that does will get
+// the mocked copy and fail loudly on the assertion rather than silently pass.
+fill('importActual', (specifier: string) => import(specifier));
+
+fill('setSystemTime', (time?: string | number | Date) => {
+  setSystemTime(time === undefined ? undefined : new Date(time));
+  return vi;
+});
+
+// Bun implements the sync variant; vitest's async form awaits pending
+// microtasks between ticks so timer callbacks that resolve promises settle.
+fill('advanceTimersByTimeAsync', async (ms: number) => {
+  jest.advanceTimersByTime(ms);
+  await Promise.resolve();
+  return vi;
+});
+
+// ---------------------------------------------------------------------------
+// vi.waitFor — poll until the callback stops throwing (or its promise rejects).
+// Mirrors vitest's default 1000ms timeout / 50ms interval and its behaviour of
+// surfacing the LAST failure, not a generic timeout message.
+// ---------------------------------------------------------------------------
+fill('waitFor', async <T>(
+  callback: () => T | Promise<T>,
+  options?: number | { timeout?: number; interval?: number },
+): Promise<T> => {
+  const timeout = typeof options === 'number' ? options : options?.timeout ?? 1000;
+  const interval = typeof options === 'number' ? 50 : options?.interval ?? 50;
+  const deadline = Date.now() + timeout;
+  let lastError: unknown;
+  for (;;) {
+    try {
+      return await callback();
+    } catch (err) {
+      lastError = err;
+    }
+    if (Date.now() >= deadline) {
+      throw lastError ?? new Error(`vi.waitFor timed out after ${timeout}ms`);
+    }
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+});
+
+// Keep stubs from bleeding across tests within a file. vitest scopes them the
+// same way when `unstubEnvs`/`unstubGlobals` are configured; doing it here means
+// a file that stubs without restoring cannot poison its neighbours.
+afterEach(() => {
+  (anyVi.unstubAllEnvs as () => void)();
+  (anyVi.unstubAllGlobals as () => void)();
+});
+
+// `expect(...).toMatchObject` etc. already exist in Bun; assert the pieces this
+// shim depends on are really present so a Bun upgrade that moves them fails
+// here with a clear message instead of deep inside an unrelated test.
+if (typeof mock.module !== 'function') {
+  throw new Error('bun:test mock.module is unavailable — test/bun-test-fence.ts cannot fence node:os');
+}
+if (typeof expect !== 'function') {
+  throw new Error('bun:test expect is unavailable');
+}

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -23,6 +23,10 @@ import { vi } from 'vitest';
  *   `importOriginal` / `importActual` — the `vi.mock` factory's callback arg that
  *                                  yields the real module (runner-supplied, so
  *                                  no fill can provide it)
+ *   `inject`                     — vitest's globalSetup→test value channel. A
+ *                                  NAMED EXPORT of the `vitest` module that
+ *                                  `bun:test` does not have, so the static import
+ *                                  fails before any mock can apply (measured).
  *   `vi.hoisted`                 — vitest's transform physically LIFTS the
  *                                  callback above the static imports. A runtime
  *                                  fill can only run it when the module body gets
@@ -150,6 +154,28 @@ fill('setConfig', (config?: Record<string, unknown>) => {
 // wrong. Without it, 16 `it.runIf` + 5 `describe.runIf` files fail at collection
 // time with `it.runIf is not a function` (the whole mojo-* cluster).
 // ---------------------------------------------------------------------------
+/**
+ * `it.sequential` / `describe.sequential` — vitest's opt-out of concurrent
+ * execution. `bun test` already runs tests sequentially by default (measured: an
+ * async test fully finishes before the next one starts, `ORDER=a-start,a-end,b`),
+ * so requesting sequential execution is a no-op there and the modifier can be an
+ * identity pass-through. Note this is only safe BECAUSE of that default: Bun does
+ * expose a working `.concurrent`, and if a future release made concurrency the
+ * default this identity would silently stop meaning what the caller asked for.
+ */
+function addSequential(target: unknown): void {
+  const fn = target as Record<string, unknown>;
+  if (typeof fn !== 'function' && typeof fn !== 'object') return;
+  let missing = false;
+  try { missing = typeof fn.sequential !== 'function'; } catch { missing = true; }
+  if (!missing) return;
+  Object.defineProperty(fn, 'sequential', {
+    configurable: true,
+    writable: true,
+    value: fn,
+  });
+}
+
 function addRunIf(target: unknown): void {
   const fn = target as { runIf?: unknown; skipIf?: (cond: boolean) => unknown };
   if (typeof fn?.skipIf !== 'function') return;
@@ -165,6 +191,8 @@ function addRunIf(target: unknown): void {
 
 addRunIf(bunIt);
 addRunIf(bunDescribe);
+addSequential(bunIt);
+addSequential(bunDescribe);
 
 // Mirrors vitest's default 1000ms timeout / 50ms interval and its behaviour of
 // surfacing the LAST failure, not a generic timeout message.

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -182,9 +182,19 @@ fill('waitFor', async <T>(
 // and this repo's vitest.config.ts sets neither — so stubs persist across tests
 // within a file, and at least one file relies on that by stubbing in
 // `beforeAll` (test/fs-policy-bwrap.e2e.test.ts). Adding an `afterEach` reset
-// here would make the shim STRICTER than the runner it emulates and break those
-// files. Cross-file leakage is not a concern: `bun test` gives each file its own
-// process, and test/bun-test-fence.ts fences the home directory per process.
+// here would make the shim STRICTER than the runner it emulates and turn those
+// files red.
+//
+// ⚠️ The tradeoff is real and differs from vitest: `bun test` runs every file in
+// ONE process (measured — two files report the same `process.pid` and share one
+// fence dir), whereas vitest forks a worker per file. So a file that stubs an env
+// var and never restores it CAN leak into a later file in the same `bun test`
+// invocation, where under vitest it could not. Files are still fenced as a group
+// (test/bun-test-fence.ts redirects HOME for the whole process, so nothing
+// reaches the real home either way); what leaks is only test-visible state
+// between files. Matching vitest's per-file isolation would need a reset keyed to
+// file boundaries, which bun:test does not currently expose. Prefer fixing a
+// leaky file over adding a blanket reset that breaks the `beforeAll` pattern.
 
 // `expect(...).toMatchObject` etc. already exist in Bun; assert the pieces this
 // shim depends on are really present so a Bun upgrade that moves them fails

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -1,4 +1,4 @@
-import { expect, jest, mock, setSystemTime } from 'bun:test';
+import { describe as bunDescribe, expect, it as bunIt, jest, mock, setSystemTime } from 'bun:test';
 import { vi } from 'vitest';
 
 /**
@@ -20,7 +20,9 @@ import { vi } from 'vitest';
  * functions, and any fake would silently not-mock while reporting success:
  *   `vi.doMock` / `vi.doUnmock`  — re-point a module mid-file
  *   `vi.resetModules`            — clear the module registry
- *   `importOriginal`             — the callback arg that yields the real module
+ *   `importOriginal` / `importActual` — the `vi.mock` factory's callback arg that
+ *                                  yields the real module (runner-supplied, so
+ *                                  no fill can provide it)
  * Files using them stay red under `bun test` and keep running under vitest until
  * they are rewritten to use dependency injection. See `package.json:test:bun`.
  */
@@ -152,7 +154,29 @@ fill('runAllTicks', async () => {
 fill('setConfig', () => vi);
 
 // ---------------------------------------------------------------------------
-// vi.waitFor — poll until the callback stops throwing (or its promise rejects).
+// `it.runIf` / `describe.runIf` — Bun ships `skipIf` but not `runIf` (measured:
+// `skipIf` and `each` are present, `runIf` is not). `runIf(cond)` is exactly
+// `skipIf(!cond)`, so this is a mechanical inversion with no semantic guesswork —
+// unlike the module-registry APIs above, there is nothing here to get subtly
+// wrong. Without it, 16 `it.runIf` + 5 `describe.runIf` files fail at collection
+// time with `it.runIf is not a function` (the whole mojo-* cluster).
+// ---------------------------------------------------------------------------
+function addRunIf(target: unknown): void {
+  const fn = target as { runIf?: unknown; skipIf?: (cond: boolean) => unknown };
+  if (typeof fn?.skipIf !== 'function') return;
+  let missing = false;
+  try { missing = typeof fn.runIf !== 'function'; } catch { missing = true; }
+  if (!missing) return;
+  Object.defineProperty(fn, 'runIf', {
+    configurable: true,
+    writable: true,
+    value: (condition: boolean) => fn.skipIf!(!condition),
+  });
+}
+
+addRunIf(bunIt);
+addRunIf(bunDescribe);
+
 // Mirrors vitest's default 1000ms timeout / 50ms interval and its behaviour of
 // surfacing the LAST failure, not a generic timeout message.
 // ---------------------------------------------------------------------------

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, jest, mock, setSystemTime } from 'bun:test';
+import { expect, jest, mock, setSystemTime } from 'bun:test';
 import { vi } from 'vitest';
 
 /**
@@ -97,9 +97,11 @@ fill('mocked', <T>(item: T): T => item);
 
 // `vi.importActual` bypasses the mock registry. Bun has no mock-aware resolver
 // to bypass: an un-mocked path imports the real module, and a path this process
-// HAS mocked cannot be un-mocked per-call. Only safe because it is used in
-// files that do not also mock the same specifier — a file that does will get
-// the mocked copy and fail loudly on the assertion rather than silently pass.
+// HAS mocked cannot be un-mocked per-call. Kept only for the direct-call form
+// used by files that do not also mock the same specifier. The `vi.mock('x',
+// async (importActual) => …)` CALLBACK form is a different thing — that
+// parameter is supplied by the runner, not read off `vi`, so no fill can provide
+// it; scripts/run-bun-tests.mjs excludes those files instead.
 fill('importActual', (specifier: string) => import(specifier));
 
 fill('setSystemTime', (time?: string | number | Date) => {
@@ -175,13 +177,14 @@ fill('waitFor', async <T>(
   }
 });
 
-// Keep stubs from bleeding across tests within a file. vitest scopes them the
-// same way when `unstubEnvs`/`unstubGlobals` are configured; doing it here means
-// a file that stubs without restoring cannot poison its neighbours.
-afterEach(() => {
-  (anyVi.unstubAllEnvs as () => void)();
-  (anyVi.unstubAllGlobals as () => void)();
-});
+// NOTE: no automatic per-test unstub here, deliberately. vitest only clears
+// stubs between tests when `unstubEnvs`/`unstubGlobals` are enabled in config,
+// and this repo's vitest.config.ts sets neither — so stubs persist across tests
+// within a file, and at least one file relies on that by stubbing in
+// `beforeAll` (test/fs-policy-bwrap.e2e.test.ts). Adding an `afterEach` reset
+// here would make the shim STRICTER than the runner it emulates and break those
+// files. Cross-file leakage is not a concern: `bun test` gives each file its own
+// process, and test/bun-test-fence.ts fences the home directory per process.
 
 // `expect(...).toMatchObject` etc. already exist in Bun; assert the pieces this
 // shim depends on are really present so a Bun upgrade that moves them fails

--- a/test/capabilities.test.ts
+++ b/test/capabilities.test.ts
@@ -58,6 +58,12 @@ describe('botmux capabilities contract', () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe('');
     expect(JSON.parse(result.stdout)).toEqual(botmuxCapabilities());
-    expect(readdirSync(home)).toEqual([]);
+    // The claim under test is that BOTMUX writes no runtime state. `.bun` is the
+    // Bun runtime's own install cache (`.bun/install/cache`), minted by the
+    // interpreter that runs the script, not by botmux — under `bun test` the
+    // child is spawned with Bun, so it appears here. Filter that one entry
+    // rather than relaxing to a subset match, so any botmux-created file still
+    // fails this assertion.
+    expect(readdirSync(home).filter(entry => entry !== '.bun')).toEqual([]);
   });
 });

--- a/test/cli-root-help.test.ts
+++ b/test/cli-root-help.test.ts
@@ -89,7 +89,12 @@ describe('botmux root help workflow surface', () => {
 
       expect(stdout).toContain('botmux v');
       expect(stdout).toContain('restart     重启 daemon');
-      expect(readdirSync(home).sort()).toEqual(before);
+      // The claim under test is that BOTMUX mutates nothing in HOME. `.bun` is
+      // the Bun runtime's own install cache (`.bun/install/cache`), minted by the
+      // interpreter that runs the child — it appears when the suite runs under
+      // `bun test`, never under Node. Filter just that entry rather than
+      // weakening to a subset match, so any botmux-created file still fails.
+      expect(readdirSync(home).filter(entry => entry !== '.bun').sort()).toEqual(before);
       expect(readFileSync(sentinel, 'utf8')).toBe('untouched\n');
     } finally {
       rmSync(home, { recursive: true, force: true });

--- a/test/helpers/bun-leg-selectors.ts
+++ b/test/helpers/bun-leg-selectors.ts
@@ -1,0 +1,151 @@
+/**
+ * Which test files the `bun test` leg may run.
+ *
+ * Extracted from `scripts/run-bun-tests.mjs` so it can be imported by a guard
+ * without executing a test run, and so the guard tests the REAL selector instead of
+ * a hand-copied duplicate that can drift.
+ *
+ * The selectors are source-text patterns, not a parser. That is a deliberate
+ * trade-off — a full AST pass would be more precise but needs the TypeScript
+ * compiler in a path that runs before every leg — and it has a specific hazard
+ * worth naming: **a file that merely mentions these names in prose or in a string
+ * literal must not be excluded.** This repo has shipped that bug three times (a
+ * comment match, a bare `\binject\b` that deferred 20 innocent files, and a
+ * name-based factory pattern that missed a callback spelled `orig`), and each time
+ * the population count looked perfectly healthy while files silently sat out.
+ *
+ * Hence two rules here:
+ *   1. comments are stripped before matching, and
+ *   2. this module carries NO example strings of its own — the guard that exercises
+ *      it lives in `test/bun-runner-selectors.test.ts` and passes sources in as
+ *      arguments, so the examples cannot feed back into a scan of the repo.
+ */
+
+/** APIs whose absence is a module-registry or transform gap, not a missing helper. */
+const UNSUPPORTED_API = new RegExp(
+  String.raw`\bvi\s*\.\s*(doMock|doUnmock|resetModules|hoisted)\b`
+  // The `vi.mock` factory's original-module argument, referenced by its two
+  // conventional names. Matching the SHAPE (below) is what actually decides; these
+  // stay because a file can reference them without a factory call on the same line.
+  + String.raw`|\bimportOriginal\b|\bimportActual\b`,
+);
+
+/**
+ * `inject` is vitest's globalSetup→test channel and a NAMED EXPORT of `vitest`;
+ * `bun test` resolves `vitest` to `bun:test`, which has no such export, so the file
+ * dies at import. Anchored on the import — a bare `\binject\b` matched test titles,
+ * script names and callback parameters.
+ */
+// NOTE the specifier is matched loosely on purpose. `isDeferredFromBunLeg` blanks
+// string literals before matching (so a file can hold examples as data), which also
+// blanks `'vitest'` here — anchoring on the literal text would never fire. The
+// import CLAUSE is enough: a named `inject` binding from any module is the vitest
+// channel in practice, and the surrounding `import … from` shape keeps this from
+// matching an identifier that merely happens to be called `inject`.
+const IMPORTS_INJECT = /import\s*\{[^}]*\binject\b[^}]*\}\s*from\s*['"]?\s*/s;
+
+/**
+ * A `vi.mock` factory that TAKES the original-module argument, in every syntactic
+ * form: parenthesised arrow, parenless arrow, and function expression. Bun never
+ * supplies that argument, so any such factory fails regardless of the parameter's
+ * name — which is why this is matched by shape. A zero-argument factory is the
+ * supported form and must not match, so the parameter list has to be non-empty.
+ */
+const MOCK_FACTORY_TAKES_ORIGINAL = new RegExp(
+  String.raw`\bvi\s*\.\s*mock\s*\([^,]+,\s*(?:async\s+)?(?:`
+  + String.raw`\(\s*[A-Za-z_$][\w$]*`
+  + String.raw`|function\s*[A-Za-z_$\w$]*\s*\(\s*[A-Za-z_$][\w$]*`
+  + String.raw`|[A-Za-z_$][\w$]*\s*=>`
+  + String.raw`)`,
+);
+
+/**
+ * Remove comments so prose cannot decide whether a file runs.
+ *
+ * Deliberately simple: a `//` inside a string literal over-strips, which fails
+ * CLOSED — the file stays in the leg and a real unsupported call there fails loudly
+ * rather than being quietly dropped.
+ */
+export function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/**
+ * Blank out string and template literals, keeping the source's length and line
+ * structure so the patterns below still see real code at real offsets.
+ *
+ * WHY: the patterns are source-text matches, so a file that merely holds an example
+ * IN A STRING looks identical to one that calls the API. That is not hypothetical —
+ * the guard for these very selectors excluded ITSELF, because its table of test
+ * inputs contains `vi.mock('./x.js', async (importOriginal) => …)` as data. Scanning
+ * only real code is what lets a file describe the unsupported forms without being
+ * deferred for it.
+ *
+ * Uses the TypeScript scanner rather than a regex: quotes nest, escape, and appear
+ * inside template expressions, and a regex that tried to find "the end of a string"
+ * would be wrong in exactly the cases that matter.
+ */
+function blankLiterals(source: string): string {
+  // Imported lazily and defensively: this module is loaded by the runner through a
+  // one-line `bun -e` probe, and a missing devDependency must not take the leg down.
+  let ts: typeof import('typescript');
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    ts = require('typescript');
+  } catch {
+    // No scanner: fall back to the regex comment strip. Literals stay visible, so a
+    // file is at worst deferred — never wrongly promoted into the leg.
+    return stripComments(source);
+  }
+
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /* skipTrivia */ false,
+    ts.LanguageVariant.Standard,
+    source,
+  );
+  const out: string[] = [];
+  // Depth of `${ … }` substitutions we are inside, so the `}` that closes one can be
+  // rescanned as the continuation of its template.
+  let templateDepth = 0;
+  let token = scanner.scan();
+
+  while (token !== ts.SyntaxKind.EndOfFileToken) {
+    // ⚠️ A raw `scan()` treats the `}` closing a template substitution as an ordinary
+    // brace, so the following backtick opens a NEW template instead of ending the old
+    // one — measured: one 4205-character "literal" swallowed the rest of a 4881-byte
+    // file, blanking real `vi.mock` calls and silently promoting two files that do use
+    // a parameterised factory. `rescanTemplateToken` is the documented fix.
+    if (token === ts.SyntaxKind.CloseBraceToken && templateDepth > 0) {
+      token = scanner.reScanTemplateToken(/* isTaggedTemplate */ false);
+    }
+    if (token === ts.SyntaxKind.TemplateHead) templateDepth += 1;
+    else if (token === ts.SyntaxKind.TemplateTail && templateDepth > 0) templateDepth -= 1;
+
+    const text = scanner.getTokenText();
+    const isBlankable = token === ts.SyntaxKind.StringLiteral
+      || token === ts.SyntaxKind.NoSubstitutionTemplateLiteral
+      || token === ts.SyntaxKind.TemplateHead
+      || token === ts.SyntaxKind.TemplateMiddle
+      || token === ts.SyntaxKind.TemplateTail
+      // Comments are blanked here rather than by a prior regex pass: stripping them
+      // first left fragments that made the scanner mis-lex.
+      || token === ts.SyntaxKind.SingleLineCommentTrivia
+      || token === ts.SyntaxKind.MultiLineCommentTrivia;
+
+    // Keep newlines so line-anchored patterns keep their meaning; blank the rest.
+    out.push(isBlankable ? text.replace(/[^\n]/g, ' ') : text);
+    token = scanner.scan();
+  }
+  return out.join('');
+}
+
+/** True when the bun leg cannot run this file and it must stay on vitest. */
+export function isDeferredFromBunLeg(source: string): boolean {
+  const code = blankLiterals(source);
+  return UNSUPPORTED_API.test(code)
+    || IMPORTS_INJECT.test(code)
+    || MOCK_FACTORY_TAKES_ORIGINAL.test(code);
+}

--- a/test/helpers/bun-leg-selectors.ts
+++ b/test/helpers/bun-leg-selectors.ts
@@ -33,16 +33,14 @@ const UNSUPPORTED_API = new RegExp(
 /**
  * `inject` is vitest's globalSetup→test channel and a NAMED EXPORT of `vitest`;
  * `bun test` resolves `vitest` to `bun:test`, which has no such export, so the file
- * dies at import. Anchored on the import — a bare `\binject\b` matched test titles,
- * script names and callback parameters.
+ * dies at import. Detected by PARSING the import declarations (below) rather than by
+ * a source-text pattern: a bare `\binject\b` matched test titles, script names and
+ * callback parameters, and an import-clause-only pattern deferred every named
+ * `inject` import regardless of the module it came from — measured: `import { inject }
+ * from './dependency-injection.js'`, `'tsyringe'` and `'node:test'` were all excluded.
+ * Only the `vitest` channel is unavailable under bun, so only it may defer a file.
  */
-// NOTE the specifier is matched loosely on purpose. `isDeferredFromBunLeg` blanks
-// string literals before matching (so a file can hold examples as data), which also
-// blanks `'vitest'` here — anchoring on the literal text would never fire. The
-// import CLAUSE is enough: a named `inject` binding from any module is the vitest
-// channel in practice, and the surrounding `import … from` shape keeps this from
-// matching an identifier that merely happens to be called `inject`.
-const IMPORTS_INJECT = /import\s*\{[^}]*\binject\b[^}]*\}\s*from\s*['"]?\s*/s;
+const VITEST_MODULE = /^vitest(\/|$)/;
 
 /**
  * A `vi.mock` factory that TAKES the original-module argument, in every syntactic
@@ -73,33 +71,84 @@ export function stripComments(source: string): string {
 }
 
 /**
+ * Load the TypeScript compiler, or throw.
+ *
+ * There is deliberately NO fallback to a regex-only path. That fallback existed and
+ * looked safe — "literals stay visible, so a file is at worst deferred, never wrongly
+ * promoted" — but a diff of both paths over all 1159 files showed it over-deferred
+ * exactly ONE file: `test/bun-runner-selectors.test.ts`, the guard for these very
+ * selectors, whose test inputs hold `importOriginal` / `inject` / parameterised
+ * `vi.mock` as DATA. So the degraded path silently excluded the one file that would
+ * have caught the degradation, and `loadDeferredSet` still exited 0.
+ *
+ * In a test-SELECTION context, over-deferring is not the safe side: it is a false-green
+ * channel. Missing dependency ⟹ no trustworthy selection ⟹ stop the run.
+ */
+function loadTypeScript(): typeof import('typescript') {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('typescript');
+  } catch (err) {
+    throw new Error(
+      'bun-leg-selectors requires the `typescript` devDependency to decide which files '
+      + 'the bun leg may run. Refusing to guess: a regex-only fallback silently deferred '
+      + `this module's own guard. Original error: ${(err as Error)?.message ?? err}`,
+    );
+  }
+}
+
+/**
+ * Every module specifier this source imports `binding` from AT RUNTIME.
+ *
+ * Text matching cannot do this job: `blankLiterals` blanks `'vitest'` along with every
+ * other literal, so a pattern anchored on the specifier could never fire, and dropping
+ * the anchor deferred any named `inject` import from any module.
+ *
+ * Type-only imports are EXCLUDED — both `import type { inject }` and the inline
+ * `import { type inject }` form. They are erased before execution, so the module never
+ * has to provide the export; verified under Bun 1.4, where both forms run to completion
+ * against a `vitest` that cannot even be resolved at runtime. Counting them would defer
+ * a file that runs perfectly well, which is the silent-shrink failure this module's
+ * guard exists to prevent.
+ */
+function importedModulesWithNamedBinding(source: string, binding: string): string[] {
+  const ts = loadTypeScript();
+  const sf = ts.createSourceFile('probe.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const specifiers: string[] = [];
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt) || !ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    // `import type { … }` — the whole clause is erased.
+    if (stmt.importClause?.isTypeOnly) continue;
+    const named = stmt.importClause?.namedBindings;
+    if (!named || !ts.isNamedImports(named)) continue;
+    const hit = named.elements.some(el => {
+      // `import { type inject }` — this one specifier is erased, siblings are not.
+      if (el.isTypeOnly) return false;
+      // `import { inject as x }` still pulls the unavailable export, so match the
+      // PROPERTY name (what is imported) rather than the local alias.
+      return (el.propertyName ?? el.name).text === binding;
+    });
+    if (hit) specifiers.push(stmt.moduleSpecifier.text);
+  }
+  return specifiers;
+}
+
+/**
  * Blank out string and template literals, keeping the source's length and line
- * structure so the patterns below still see real code at real offsets.
+ * structure so the patterns still see real code at real offsets.
  *
  * WHY: the patterns are source-text matches, so a file that merely holds an example
  * IN A STRING looks identical to one that calls the API. That is not hypothetical —
  * the guard for these very selectors excluded ITSELF, because its table of test
- * inputs contains `vi.mock('./x.js', async (importOriginal) => …)` as data. Scanning
- * only real code is what lets a file describe the unsupported forms without being
- * deferred for it.
+ * inputs contains a parameterised `vi.mock` factory as data. Scanning only real code
+ * is what lets a file describe the unsupported forms without being deferred for it.
  *
  * Uses the TypeScript scanner rather than a regex: quotes nest, escape, and appear
  * inside template expressions, and a regex that tried to find "the end of a string"
  * would be wrong in exactly the cases that matter.
  */
 function blankLiterals(source: string): string {
-  // Imported lazily and defensively: this module is loaded by the runner through a
-  // one-line `bun -e` probe, and a missing devDependency must not take the leg down.
-  let ts: typeof import('typescript');
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    ts = require('typescript');
-  } catch {
-    // No scanner: fall back to the regex comment strip. Literals stay visible, so a
-    // file is at worst deferred — never wrongly promoted into the leg.
-    return stripComments(source);
-  }
-
+  const ts = loadTypeScript();
   const scanner = ts.createScanner(
     ts.ScriptTarget.Latest,
     /* skipTrivia */ false,
@@ -144,8 +193,11 @@ function blankLiterals(source: string): string {
 
 /** True when the bun leg cannot run this file and it must stay on vitest. */
 export function isDeferredFromBunLeg(source: string): boolean {
+  // Parsed, not text-matched: only `inject` FROM VITEST is unavailable under bun.
+  const injectsFromVitest = importedModulesWithNamedBinding(source, 'inject')
+    .some(spec => VITEST_MODULE.test(spec));
+  if (injectsFromVitest) return true;
+
   const code = blankLiterals(source);
-  return UNSUPPORTED_API.test(code)
-    || IMPORTS_INJECT.test(code)
-    || MOCK_FACTORY_TAKES_ORIGINAL.test(code);
+  return UNSUPPORTED_API.test(code) || MOCK_FACTORY_TAKES_ORIGINAL.test(code);
 }

--- a/test/helpers/fence-home-env.ts
+++ b/test/helpers/fence-home-env.ts
@@ -27,7 +27,15 @@ import { join } from 'node:path';
  * the `userInfo` gap existed precisely because one side was patched and the other
  * was not.
  */
-export function fenceHomeRootedEnv(fencedHome: string): void {
+/**
+ * @param env The environment to mutate. Defaults to the real `process.env`, which
+ *   is what both setup files want. Tests pass a throwaway object so they can
+ *   exercise the key list without touching (or having to restore) the live
+ *   environment — the helper rewrites CLI homes and `XDG_*` too, not just the
+ *   exact-path list, so a caller that snapshots only part of it leaves later tests
+ *   pointing at a deleted directory.
+ */
+export function fenceHomeRootedEnv(fencedHome: string, env: NodeJS.ProcessEnv = process.env): void {
   // Exact-path pointers into a Botmux home. Nothing here has a safe fenced
   // default worth inventing, so drop them and let home-derived resolution win.
   //
@@ -50,7 +58,7 @@ export function fenceHomeRootedEnv(fencedHome: string): void {
     'MIRA_CONFIG_PATH',
     'MIRAMCP_PID_FILE',
   ];
-  for (const name of exactPathOverrides) delete process.env[name];
+  for (const name of exactPathOverrides) delete env[name];
 
   // Per-CLI config homes that production reads directly (verified present in
   // `src/`: codex, claude, grok, traex, hermes, relay, lark-cli). Each bypasses
@@ -69,7 +77,7 @@ export function fenceHomeRootedEnv(fencedHome: string): void {
     ['LARKSUITE_CLI_DATA_DIR', join('.local', 'share', 'lark-cli')],
   ];
   for (const [name, relative] of cliHomes) {
-    if (process.env[name]) process.env[name] = join(fencedHome, relative);
+    if (env[name]) env[name] = join(fencedHome, relative);
   }
 
   // XDG + Windows profile dirs — defensive. Nothing in `src/` currently resolves a
@@ -84,6 +92,6 @@ export function fenceHomeRootedEnv(fencedHome: string): void {
     ['LOCALAPPDATA', join('AppData', 'Local')],
   ];
   for (const [name, relative] of xdg) {
-    if (process.env[name]) process.env[name] = join(fencedHome, relative);
+    if (env[name]) env[name] = join(fencedHome, relative);
   }
 }

--- a/test/helpers/fence-home-env.ts
+++ b/test/helpers/fence-home-env.ts
@@ -1,0 +1,71 @@
+import { join } from 'node:path';
+
+/**
+ * Neutralise the env vars that point DIRECTLY at a live Botmux/CLI home, so a
+ * test run cannot reach the caller's real data through them.
+ *
+ * WHY THIS IS SEPARATE FROM THE `homedir()` OVERRIDE: these are explicit escape
+ * hatches, not home-derivation APIs. `src/bot-registry.ts` treats `BOTS_CONFIG`
+ * as the TOP of its resolution chain — an exact file path that deliberately wins
+ * over anything derived from `homedir()` — and `src/cli/pm2-existing-client.ts`
+ * reads `PM2_HOME` the same way. Mocking `node:os` does nothing for either. In a
+ * normal Botmux shell these are already set to the live fleet (measured in a real
+ * session: `BOTS_CONFIG=/root/.botmux/bots.json`, `PM2_HOME=/root/.botmux/pm2`),
+ * so without this the fence's safety would depend on the runner's environment
+ * happening to be clean.
+ *
+ * DELETE rather than redirect, deliberately. Redirecting `BOTS_CONFIG` into the
+ * fenced home looks tidier but changes behaviour for every test that never set it:
+ * `resolveBotConfigPath()` THROWS when the var is set and the file is missing
+ * ("refusing to fall back to a different registry") instead of falling through to
+ * `<home>/.botmux/bots.json`. Deleting lets the normal resolution chain run, and
+ * that chain is already fenced because it derives from the mocked `homedir()`. A
+ * test that wants an exact path sets the var itself.
+ *
+ * Shared by both runners' setup files (`test/unit-setup.ts` for vitest,
+ * `test/bun-test-fence.ts` for `bun test`) so the two fences cannot drift apart —
+ * the `userInfo` gap existed precisely because one side was patched and the other
+ * was not.
+ */
+export function fenceHomeRootedEnv(fencedHome: string): void {
+  // Exact-path pointers into a Botmux home. Nothing here has a safe fenced
+  // default worth inventing, so drop them and let home-derived resolution win.
+  delete process.env.BOTS_CONFIG;
+  delete process.env.PM2_HOME;
+  delete process.env.PLUGIN_PM2_HOME;
+
+  // Per-CLI config homes that production reads directly (verified present in
+  // `src/`: codex, claude, grok, traex, hermes, relay, lark-cli). Each bypasses
+  // `homedir()`, so an inherited value would escape the fence. Only rewritten when
+  // the caller had one set — an unset value means the adapter derives its own
+  // default from the mocked `homedir()`, and inventing a path here could change
+  // what a test is asserting.
+  const cliHomes: Array<[string, string]> = [
+    ['CODEX_HOME', '.codex'],
+    ['CLAUDE_CONFIG_DIR', '.claude'],
+    ['GROK_HOME', '.grok'],
+    ['TRAE_HOME', '.trae'],
+    ['HERMES_HOME', '.hermes'],
+    ['HERMES_BOTMUX_SOURCE_HOME', '.hermes-source'],
+    ['RELAY_CONFIG_DIR', '.relay'],
+    ['LARKSUITE_CLI_DATA_DIR', join('.local', 'share', 'lark-cli')],
+  ];
+  for (const [name, relative] of cliHomes) {
+    if (process.env[name]) process.env[name] = join(fencedHome, relative);
+  }
+
+  // XDG + Windows profile dirs — defensive. Nothing in `src/` currently resolves a
+  // Botmux root from them, but they are the conventional way a spawned CLI gets
+  // pointed at a config tree, and a stray inherited value would escape the fence.
+  const xdg: Array<[string, string]> = [
+    ['XDG_CONFIG_HOME', '.config'],
+    ['XDG_DATA_HOME', join('.local', 'share')],
+    ['XDG_STATE_HOME', join('.local', 'state')],
+    ['XDG_CACHE_HOME', '.cache'],
+    ['APPDATA', join('AppData', 'Roaming')],
+    ['LOCALAPPDATA', join('AppData', 'Local')],
+  ];
+  for (const [name, relative] of xdg) {
+    if (process.env[name]) process.env[name] = join(fencedHome, relative);
+  }
+}

--- a/test/helpers/fence-home-env.ts
+++ b/test/helpers/fence-home-env.ts
@@ -30,9 +30,27 @@ import { join } from 'node:path';
 export function fenceHomeRootedEnv(fencedHome: string): void {
   // Exact-path pointers into a Botmux home. Nothing here has a safe fenced
   // default worth inventing, so drop them and let home-derived resolution win.
-  delete process.env.BOTS_CONFIG;
-  delete process.env.PM2_HOME;
-  delete process.env.PLUGIN_PM2_HOME;
+  //
+  // Every one of these is an exact FILE or DIRECTORY override that bypasses
+  // `homedir()`/`userInfo()` entirely, and every one leads to real writes — so a
+  // value inherited from the caller's shell would have the test mutate live state.
+  // Verified write paths behind each: usage-ledger mkdir/write/rename/append,
+  // control-audit mkdir+append (a key the daemon genuinely persists),
+  // mir-local-runtime read-modify-write+rename of the miramcp config and
+  // create/delete of its pidfile (and it can start a bridge process),
+  // index-core-only mkdir at module load which then becomes SESSION_DATA_DIR.
+  const exactPathOverrides = [
+    'BOTS_CONFIG',
+    'PM2_HOME',
+    'PLUGIN_PM2_HOME',
+    'BOTMUX_USAGE_DIR',
+    'BOTMUX_DASHBOARD_CONTROL_AUDIT_PATH',
+    'BOTMUX_CORE_STATE_DIR',
+    'MIRAMCP_CONFIG_PATH',
+    'MIRA_CONFIG_PATH',
+    'MIRAMCP_PID_FILE',
+  ];
+  for (const name of exactPathOverrides) delete process.env[name];
 
   // Per-CLI config homes that production reads directly (verified present in
   // `src/`: codex, claude, grok, traex, hermes, relay, lark-cli). Each bypasses

--- a/test/unit-setup.ts
+++ b/test/unit-setup.ts
@@ -41,9 +41,16 @@ vi.mock('node:os', async (importOriginal) => {
     // without this the fence leaks on exactly the paths that motivated it. Keep
     // the real uid/username/shell fields (those call sites use them too) and
     // redirect only the home field.
+    // Preserve the field's ORIGINAL type: `userInfo({ encoding: 'buffer' })`
+    // returns Buffers under Node, so substituting a plain string produced a mixed
+    // `username: Buffer, homedir: string` object that no runtime ever returns —
+    // and the `as typeof userInfo` cast hid the mismatch.
     userInfo: ((options?: { encoding?: string }) => {
       const info = (actual.userInfo as (o?: unknown) => ReturnType<typeof actual.userInfo>)(options);
-      return { ...info, homedir: fencedHome() };
+      const homedir = Buffer.isBuffer((info as { homedir: unknown }).homedir)
+        ? Buffer.from(fencedHome())
+        : fencedHome();
+      return { ...info, homedir };
     }) as typeof actual.userInfo,
   };
   // Hand the SAME fenced object out as the default export. Under vitest the

--- a/test/unit-setup.ts
+++ b/test/unit-setup.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterAll, beforeEach, inject, vi } from 'vitest';
+import { fenceHomeRootedEnv } from './helpers/fence-home-env.js';
 
 const inheritedDataDir = process.env.SESSION_DATA_DIR;
 const fileRoot = mkdtempSync(join(inject('unitSessionDataRoot'), 'file-'));
@@ -20,13 +21,30 @@ mkdirSync(fileHome);
 process.env.HOME = fileHome;
 process.env.USERPROFILE = fileHome;
 
+// Same reasoning as the bun fence: BOTS_CONFIG / PM2_HOME are explicit pointers
+// at a live home that never go through `homedir()`, and a normal Botmux shell has
+// them set to the real fleet.
+fenceHomeRootedEnv(fileHome);
+
 vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:os')>();
+  const fencedHome = () => (process.platform === 'win32'
+    ? process.env.USERPROFILE || actual.homedir()
+    : process.env.HOME || actual.homedir());
   return {
     ...actual,
-    homedir: () => process.platform === 'win32'
-      ? process.env.USERPROFILE || actual.homedir()
-      : process.env.HOME || actual.homedir(),
+    homedir: fencedHome,
+    // `userInfo().homedir` is a SECOND route to the home directory that does NOT
+    // go through `homedir()` — measured under this very fence: `homedir()`
+    // returned the temp home while `userInfo().homedir` still returned `/root`.
+    // Four production call sites read it (src/cli.ts, src/worker.ts ×3), so
+    // without this the fence leaks on exactly the paths that motivated it. Keep
+    // the real uid/username/shell fields (those call sites use them too) and
+    // redirect only the home field.
+    userInfo: ((options?: { encoding?: string }) => {
+      const info = (actual.userInfo as (o?: unknown) => ReturnType<typeof actual.userInfo>)(options);
+      return { ...info, homedir: fencedHome() };
+    }) as typeof actual.userInfo,
   };
 });
 

--- a/test/unit-setup.ts
+++ b/test/unit-setup.ts
@@ -31,7 +31,7 @@ vi.mock('node:os', async (importOriginal) => {
   const fencedHome = () => (process.platform === 'win32'
     ? process.env.USERPROFILE || actual.homedir()
     : process.env.HOME || actual.homedir());
-  return {
+  const fenced = {
     ...actual,
     homedir: fencedHome,
     // `userInfo().homedir` is a SECOND route to the home directory that does NOT
@@ -46,6 +46,13 @@ vi.mock('node:os', async (importOriginal) => {
       return { ...info, homedir: fencedHome() };
     }) as typeof actual.userInfo,
   };
+  // Hand the SAME fenced object out as the default export. Under vitest the
+  // default binding is separate from the namespace, and spreading `actual` alone
+  // carried the REAL module through as `default` — measured: with only the
+  // namespace fenced, `import os from 'node:os'; os.homedir()` returned `/root`
+  // while the named `homedir()` returned the temp home. Every `import os from
+  // 'node:os'` caller would have escaped the fence.
+  return { ...fenced, default: fenced };
 });
 
 // Same fencing for mojo's per-session isolated workspaces: without this, any


### PR DESCRIPTION
## 为什么

**起因是一次真实事故**：`~/.botmux/config.json` 被本仓库自己的测试 fixture 整体覆盖，`remoteAccess` 键整个消失，中心化平台链接静默退回 localhost。判据是 live 配置与 `test/global-config.test.ts:444` 的输出 `diff` 逐字节相同（含 `futureSetting: "keep-me"` 这个纯 fixture 词），而全仓写 `remoteAccess` 的两处都只写 `true`/boolean、**没有任何代码路径会删它** ⟹ 是整体覆盖不是「被关掉」。

根因**不是 Bun 带来的**，是结构性的：`src/` 里 `homedir()` 共 **210 处 / 111 个文件**，`~/.botmux` 全由硬编码 `join(homedir(), '.botmux', …)` 得出、无 env 间接层 ⟹ **唯一的隔离手段就是改 `HOME` 本身**。08-20 的 #950 已因同类问题打过补丁（注释原文：mojo 会 mint 目录到开发者真实 `~/.botmux/mojo-workspaces`，"observed live"），**早于 bun 迁移 7 天**。暴露面也不止 `~/.botmux`：`src/` 同样派生 `~/.claude`(16 处)、`~/.claude.json`、`~/.codex`、`~/.gemini`、`~/.dsh`、`~/.pm2` 等，本机这几个目录**都真实存在** ⟹ 最坏情况是写脏用户的其它 CLI 配置。

同时这是把单测跑在 Bun 上的前置条件：`bun test` 是**唯一**让测试体真正跑在 Bun 上的 runner（`bun x vitest` 也是 fork Node worker，实测），所以 Bun 特有形态——它的 `fetch` 错误分类分不清「已送达/未送达」、启动即冻结的 `os.homedir()`、编译态路径——在现有 `bun run test` 下**结构上不可见**。而单文件可执行文件正是 Bun 产出并随每个 Release 分发的。

## 改了什么

| 文件 | 作用 |
|---|---|
| `test/bun-test-fence.ts` | bun 侧 home 围栏（`mock.module('node:os')`） |
| `test/unit-setup.ts` | **vitest 侧围栏的同步加固**（详见影响面） |
| `test/helpers/fence-home-env.ts` | 两个 runner **共用**的 env 逃生通道收口 |
| `test/bun-test-shim.ts` | 补 `vi.*`/`it.*` 中**语义可等价复现**的部分 |
| `test/bun-shim-parity.test.ts` | 22 项语义对等回归网（24 collected，2 项按 `runIf(false)` 跳过），**两个 runner 下都跑** |
| `scripts/run-bun-tests.mjs` + `test:bun` | 一文件一进程的 runner |
| `bunfig.toml` | `[test] preload` 挂载围栏与 shim |
| `.github/workflows/ci.yml` | 新增 `bun-test` job（暂不阻塞） |
| `test/capabilities.test.ts`、`test/cli-root-help.test.ts` | 放行 Bun 自身的 `.bun` 缓存目录 |

### 关键设计决定

**1. 必须 `mock.module('node:os')`，只改 `process.env.HOME` 不够。** Bun 在任何 JS 执行前就快照了 `homedir()`（实测 preload 改 env 对本进程无效）。且必须**同时覆写 `userInfo()`**：`userInfo().homedir` 是第二条通往 home 的路、不经过 `homedir()`（只覆写后者时它仍返回真实 `/root`），生产侧 4 处读它。`default` 导出也要指向**同一个** fenced 对象——vitest 下实测 `import os from 'node:os'` 会返回 `/root`。

**2. 启动前就要围栏。** preload 覆盖不了 Bun **自身启动**：A/B 实测裸 `bun test` 会在**继承的 HOME** 下写出 `.bun/install/cache`；改为在 `spawn` env 里先设 `HOME`/`USERPROFILE`（并删掉 `BOTS_CONFIG`/`PM2_HOME`）后，同一目录**保持为空**。

**3. env 逃生通道要收口，且选择删除而非重定向。** 这类变量绕过 `homedir()`/`userInfo()` 直指精确路径，**且都通向真实写入**，共 9 个：`BOTS_CONFIG`（`bot-registry` 解析链顶端）、`PM2_HOME`/`PLUGIN_PM2_HOME`、`BOTMUX_USAGE_DIR`（usage ledger 的 mkdir/write/rename/append）、`BOTMUX_DASHBOARD_CONTROL_AUDIT_PATH`（mkdir+append，且是 daemon 真正持久化的配置键）、`BOTMUX_CORE_STATE_DIR`（模块加载即 mkdir，随后冻结成 `SESSION_DATA_DIR`）、`MIRAMCP_CONFIG_PATH`（read-modify-write + rename）、`MIRA_CONFIG_PATH`/`MIRAMCP_PID_FILE`（建目录、写/删 pidfile，条件满足还可能起 bridge 进程）。正常 botmux shell 里前两个本就指向真实 fleet。

选择删除是因为 `resolveBotConfigPath()` 对「env 已设但文件不存在」**fail closed 抛错、不回退**，重定向到围栏内一个不存在的文件会凭空改变所有未显式设置该变量的测试语义。CLI home 与 `XDG_*`/Windows profile dirs 则是**仅在调用者已设置时改写**（不无端造值）。`DSH_CORDIS_CONFIG` 核实为只读入口（`existsSync` 后直接返回路径、不写），未纳入。

**4. 一文件一进程，不批量。** `bun test a b c…` 把所有文件跑在**同一进程**（实测两文件同 `process.pid`），vitest 是每文件 fork worker。批量后果：

| 跑法 | 结果 |
|---|---|
| 1010 文件批量共进程（当时的 population） | **933 fail** |
| 同 60 文件批量 | 9 fail |
| 同 60 文件**一文件一进程** | **2 fail** |

机制是某文件 `vi.mock('utils/logger')` 只给部分方法，该 mock 在同进程内对后续文件持续生效 ⟹ 几百文件后炸 `logger.isDebug is not a function`。代价约 21 分钟墙钟，**一条失败大多是产物的腿比没有腿更糟**。

**5. 模块注册表 / transform 语义刻意不补 shim。** `doMock`/`doUnmock`/`resetModules`、`importOriginal`/`importActual` 回调、`vi.hoisted`（transform 物理提升，实测 eager-factory 的 shim 看到 `missing`）、`inject`（`vitest` 的命名导出，bun 解析到 `bun:test` ⟹ import 阶段就 SyntaxError，`mock.module` 也补不了）。假实现会「报成功但没 mock」，比红更糟。**165** 个文件因此留在 vitest（`inject` 已改为**真解析** import 声明：只认 `vitest` / `vitest/*`，并跳过 type-only —— `import type { inject }` 与 `import { type inject }` 运行期被擦除，实测 Bun 1.4 下二者在 `vitest` 根本无法解析时都能跑完）。
`setConfig` 只接受 `testTimeout`、其它 key 直接抛错，避免未来新增配置静默失效。

## 影响面

只动测试链路，**生产代码零改动**。

⚠️ **vitest 链路不是零改动**（早期描述如此，是错的）：`test/unit-setup.ts` 也改了——主门槛的围栏同样漏 `userInfo().homedir` 与 `default` 导出，同样需要收口 env 逃生通道。两个 runner 现在共用 `test/helpers/fence-home-env.ts`，正是为了避免"一侧补了另一侧没补"的漂移（`userInfo` 那条缺陷就是这么产生的）。这是**主门槛围栏的同步加固**。

`bun-test` job **故意 `continue-on-error: true`**：剩余缺口尚未收敛，一个因环境长期发红的门禁只会训练所有人忽略它。

## 验证

**围栏 A/B 有牙**（否则「CLEAN」可能是假绿）：

| | 结果 |
|---|---|
| 关掉围栏（preload 只留 shim） | 沙盒 home 被写出与事故现场**逐字节相同**的 fixture，16 项失败 |
| 打开围栏 | **35/35 绿，沙盒 home 干净** |
| 启动盲窗：裸 `bun test` | 继承的 HOME 出现 `.bun/install/cache` |
| 启动盲窗：经 runner | 同一目录 **0 entries** |

**parity 在两个 runner 下逐项一致**：bun **22 pass / 2 skip**、vitest **22 passed / 2 skipped**（24 collected，2 项由 `runIf(false)`/`describe.runIf(false)` 按设计跳过）。

其中**有反变异日志的关键边界**是这几条（改坏 ⟹ 守卫必红）：`stubEnv(undefined)` 的删键语义、`runIf` 的取反、`waitFor` fake 侧的 `+2` 松弛、`waitFor` real 侧未 clamp 的 sleep、`userInfo({encoding:'buffer'})` 的保型、home 围栏的收容锚点（含 `default` 导出）、`.bun` 过滤仍能发现真实写入，以及 **exact-path env 表的删除**——最后这条是新增的**自带 seed** 守卫（用例体内注入 sentinel + 独立 env 对象），反变异在**干净 env**（即 CI 条件）下做：整表移除 ⟹ 两侧各 1 fail，只删表里一项 ⟹ 1 fail。

其余项（如 `stubGlobal`/`unstubAllGlobals`、两个 async timer helper）**只有 parity 用例、未逐条反变异**——它们的等价性靠与 vitest 的逐项一致来支撑，不宣称已被变异证明。

⚠️ 其中 home 收容那条**做过判据修正**：先用 `not.toBe('/root')`（在 CI 的 `/home/runner`/macOS 上会假绿），改为断言等于 fenced env 后发现**仍是自指的**（围栏同时设 env 与 `homedir()`，删掉围栏照绿），最终锚在「fenced home 必须位于 `tmpdir()` 之下」——四象限验证：正常×tmp内=绿、正常×非tmp=绿（不误红）、删围栏×两种=红。

**runner 生命周期**：每 child 独立进程组；**normal close 与取消路径都先杀残余进程组再删 scratch**（先删 scratch 会毁掉证据、让目录检查假干净）。A/B：`session-preview-ownership`（其 `afterEach` 只杀中间层、不杀孙子）无 sweep ⟹ `8 pass` 但留 1 个 survivor；有 sweep ⟹ survivor 0。取消 runner ⟹ runners/bun test/scratch 全 0。
⚠️ 这是 process **group** 语义、不是 tree：`setsid` 的后代能逃组（实测一个 fixture server 的 `PID==PGID==SID`），列为**已知边界**（测试自清理责任），不声称做不到的保证。

**本地全量（历史样本，非当前状态）**：本地 994 全量实际跑在 **`03b4873d5`** 上——**947/994 文件绿（95.3%）、47 红**，`994/994` 全部产出判定，沙盒 home **完全为空**（连 Bun 自己的 `.bun` 都没有——启动盲窗修好后它也落进 per-child scratch 了）。

**CI 在当前 head `35728a630` 上的结果（权威口径）**：`bun-test` 启动 **994 runnable / 165 deferred / concurrency 4**，`self-check` 步骤 **PASS**（`every bun spawn stayed inside its fence ✓`），最终 **955/994 绿、39 红**，`994/994` 全部产出判定。runner 的异常口径**逐条 0 命中**：`bun test: INCOMPLETE` / `worker crashed:` / `[runner] could not remove` / `Refusing to report success` / `collected 0 tests` / `SELF-CHECK FAILED`。同 run 的主门槛 `build`（build + 全量 vitest + workflow-core）**SUCCESS**，`bun-binary` / `bun-binary-musl` 亦 **success**；`bun-test` job 因 39 红显示 failure，但带 job 级 `continue-on-error`，**整个 workflow conclusion = SUCCESS**。

**红名单的集合差分（`548c1b683` attempt 1 的 43 → 当前 39）**：当前 39 是旧 43 的**严格子集**，**新增红 0 个**；移出 4 个 —— `daemon-config-fence`、`codex-effort-wiring` 分别对应 matcher 修复与「正确 deferred」，另两个 `connector-store`、`tmux-startup-storm-recovery` **没有同路径的代码修复，记为环境样本差异，不冒充本分支的修复成果**。

⚠️ 取这组数字时踩到一个判据坑，记录下来：`548c1b683` 那个 run 有**两次 attempt**，attempt 2 是 cancelled。从 attempt 2 的日志里 grep 出来的是 **40** 个红且带一个「新增红」，与 attempt 1 的 43 矛盾 —— cancelled 的 run 日志是**残缺**的（没有 `Failing files:` 汇总块）。**引用某个 run 的数字前必须先确认它是哪个 attempt、且该 attempt 已完整结束。**

---

**下面这组是 `548c1b683` 的历史样本，保留用于对照，不代表当前状态。**

**CI 在 SHA `548c1b683` 上的结果（历史样本）**：`bun-test` 启动 **994 runnable / 164 deferred / concurrency 4**，最终 **951/994 绿、43 红、`994/994` 全部产出判定**；日志里 `INCOMPLETE` / `worker crashed` / `could not remove` / `Refusing to report success` **各 0 命中**，完整性汇总正确。同一 run 的主门槛 `build`（build + 全量 vitest + workflow-core）**SUCCESS**，`bun-binary` / `bun-binary-musl` 亦 **success**。

`bun-test` 这个 job 因 43 红显示 failure，但它带 job 级 `continue-on-error`，**整个 CI workflow 的 conclusion 是 SUCCESS**。

本地那轮（`03b4873d5`：947/994、47 红）单列作为历史记录，不与 CI 数字混写——两边有环境差异（本地/CI 的 tmux、bwrap、并发度都不同），这个差异本身也是这条腿暂不门禁化的理由。中间的 `5186badca`/`d69e075e4` 只改 runner 的 fail-closed join 与汇总顺序，用**定向反变异**验证（注入 worker throw ⟹ `INCOMPLETE — 2/9 files ran` 且 exit 1、full-green 标题 0 次；正常路径汇总照常）。

47 红的归因（本地 `03b4873d5` 那轮的历史记录）：
- **7 个**已在 `origin/master` 的失败集合内 ⟹ **既有账**（含 `worker-codex-app-turn-routing` 的 4 个 tmux durable-handoff 用例，独立复核确认 master 上同样以 `worker routing timeout` 失败）
- **40 个**在**当前分支的 vitest 下全绿** ⟹ 只能得出「不是主门槛回归」这一个结论。**根因仍待逐项收敛**（三分：围栏未重定向的真实资源 / runner-config 管道 / 真 Bun 运行时分叉），本 PR 未逐文件给出这份清单
  - 参考：这个池子里**历史上曾混入**下列已修掉的围栏/shim 缺口——`it.runIf`（缺失导致收集期整体崩，16+5 个文件）、`describe.sequential`、`userInfo().homedir` 未重定向（`managed-origin-*` 两文件由此转绿）、`inject` 的 import-time SyntaxError。它们已不在当前 40 之内，列在这里正是为了说明下一条

⚠️ **「vitest 绿 + Bun 红」不等于「Bun 缺口」**：补上 `userInfo` 围栏后有两个文件直接转绿，说明这个分类里混着围栏自身的漏洞。逐项判据是「这个红是否源于某个真实资源没被重定向」，而不是两个 runner 的结果之差。

**主门槛零回归**：全量 `bun run test` 的失败集与 `origin/master` 对照组逐项比对，本分支独有且能在隔离下复现的失败 = **0**。（过程中报的 11~13 红且数字每次变，查明是我自己的扫描把 load 拉到 57~75；那些文件单独跑 57/57 全绿。）

`tsc --noEmit -p tsconfig.json` exit 0（注意其 `include` 只有 `src/**/*`，新 test/ 文件不在覆盖内）。

## 已知遗留

- **165** 个模块注册表 / transform 语义文件需改写成依赖注入才能进 bun 腿（独立批次）
- 剩余 Bun 侧缺口待逐个收敛（真 tmux/bwrap 依赖、时序差异等）
- `advanceTimersByTime` 不传播定时器回调异常（实测 Bun 返回 no-throw、错误走它自己的 uncaught 通道）⟹ `waitFor` 带条件的 last error reject 而 vitest 带定时器的。表现是诊断文本不准、suite 仍会红，**不是静默通过**，如实记录在注释里
- `setsid` 逃组进程属测试自清理责任
- 更根本的修法是给 config dir 补 `BOTMUX_CONFIG_DIR` 之类 env 间接层，让隔离不再单点依赖 `HOME`——那 210 处硬编码是这类事故两次复发的真正原因（08-20 mojo、08-29 config.json）


---

## 后续加固（`548c1b683` → 当前 head）

首个全量样本之后的定向验证又发现 **5 个真缺陷**，其中 3 个是「全绿但实际没在守」的形态。逐条记录，因为每条都改变了「什么算验证过」：

**1. 🔴 启动盲窗在 selector probe 上回归。** `loadDeferredSet()` 的
`spawnSync('bun', …)` 没传 fenced env ⟹ 在**任何** per-child 围栏建立之前就往继承的真实 HOME 写
`.bun/install/cache/@t@/*.pile`。本 PR 的核心不变量在跑测试前就失守。
修法：抽 `mintFencedEnv()`，probe 与 per-file child **共用单点**。

**2. 🔴 围栏本身此前没有守卫。** 它只是个 spawn 参数，删掉是一个 token 的编辑、**输出零变化**：实测摘掉 `env` ⟹ 整轮 exit 0 全绿，同时污染 HOME。
⟹ 新增 `bun run test:bun:self-check`，跑完**断言围栏未被绕过**。

**3. 🔴 我第一版的 home 判据只在空 HOME 里有牙。** `snapshotHome()` 比对**顶层名字**，而 CI 前面刚跑过 `setup-bun` + `bun install`、开发机也几乎必有 `.bun/` ⟹ 污染发生在 `.bun` **内部**、顶层 diff 为空 ⟹ 谎报 `real home untouched ✓`。同形对照证明旧判据**真的空转**（exit 0 + 谎报，而真实 HOME 里落了 2 个文件）。
修法：self-check 把 runner 自己的 HOME 指到 Node 新建的**空 canary**，漏传 env ⟹ `.bun` 出现在**顶层** ⟹ 判据稳定转红，且完全不碰 live home。

**4. 🔴 `node --check` 抓不到「引用了不存在的绑定」。** 一次重构删掉了
`TEST_TIMEOUT_MS`/`FILE_WALL_MS` 的定义却留着引用：`--check` 照样 pass（缺绑定是**运行期** ReferenceError），计数行照样打印 `994 files`，然后**实际跑 0 个**。fail-closed 分支正确拦住了，但只有 CI 看得见。
⟹ self-check 用 1 个文件 ~6s 走完「选择器探针 → fenced spawn → per-file 常量 → close 处理器 → 完整性记账」整条路径，CI 里排在全量之前。

**5. 🟠 选择器的两类静默误排。**
- `inject` 旧实现只认 import 子句 ⟹ `./dependency-injection.js`、`tsyringe`、`node:test` 的命名 `inject` 全被误 defer（存量影响 0，属潜伏）。改为**真解析**，只认 `vitest` / `vitest/*`，跳过 type-only，别名 `inject as x` 仍算命中。
- 模板字面量扫描:裸 `scan()` 把结束替换的 `}` 当普通右花括号 ⟹ 后续反引号开新模板，实测一个 4881 字节文件里冒出 **4205 字符的单个「字面量」**，把真实 `vi.mock` 涂白 ⟹ 两个确实用带参工厂的文件被**误放行**。修法 `reScanTemplateToken()`。

**并且删掉了 `require('typescript')` 的 fallback，改 fail loud。** 原论证是「无 scanner ⟹ 字面量可见 ⟹ 只会多排除 ⟹ 安全侧」。用 fallback 路径对 1159 文件做全量 diff 证否：多排除 **1** 个、误放行 0 个，而那 1 个**恰好是选择器自己的守卫**（它把不支持写法当数据存着）⟹ 降级会静默排掉唯一能发现降级的文件且 exit 0。**在测试「选择」语境里，多排除不是安全侧，是假绿通道。**

### 反变异（全部在 HOME 预置 `.bun/install/cache` 下，即真实形态）

```
摘 probe 的 env          → exit 1 + wrote .bun into the canary home
摘 per-child 的 env      → exit 1（两处围栏各自有牙）
摘 TEST_TIMEOUT_MS 定义  → exit 1 + 0/1 files ran
旧顶层判据同形对照       → exit 0 且谎报 untouched（证明它空转）
clause 级 isTypeOnly     → 守卫 1 fail
specifier 级 isTypeOnly  → 守卫 2 fail
别名取 el.name           → 守卫 1 fail
vitest 正则放宽成子串    → 守卫 1 fail
摘 reScanTemplateToken   → 守卫 1 fail
```

四条早退路径的 canary 清理也逐条真跑（selector 抛错 / runnable=0 / guard 被 deferred / worker incomplete），`canary=0 child=0`。

守卫 38 pass / 0 fail（`bun test`）与 38 passed（vitest）两侧一致；`tsc --noEmit` 干净；population 994 runnable / 165 deferred，且守卫**自身在 runnable 内**（上一版它被自己的规则排除，只在手工调用时才跑过）。



