### PR TITLE
feat(card): 失败通知改交互卡片并补齐通用重试入口

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -30,7 +30,7 @@ import { spawnWorker, isStandaloneBinary, WORKER_ENTRY_SUBCOMMAND } from './self
 import { resolveSessionLaunchModel } from './session-model.js';
 import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, pickTurnReplyTarget, rehomeReplyTargetState, replyTargetKey } from './reply-target.js';
 import { updateMessage, deleteMessage, sendEphemeralCard, sendUserMessage, addReaction, removeReaction, getMessageChatId, MessageWithdrawnError } from '../im/lark/client.js';
-import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildTuiPromptFailedCard, buildRelayedFrozenCard, getCliDisplayName } from '../im/lark/card-builder.js';
+import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildTuiPromptFailedCard, buildRelayedFrozenCard, buildTurnFailedCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { codexServiceTierBadge } from '../services/codex-service-tier.js';
 import { cliModelSupportsReasoningEffort, isConfigurableReasoningCliId } from '../services/codex-reasoning-effort.js';
 import { RPC_CAPABLE_CLIS } from '../codex-rpc-lifecycle.js';
@@ -387,6 +387,7 @@ import {
   requireOrdinaryTurnRecoveryAttention,
   type OrdinaryTurnRecoveryDispatch,
 } from '../services/ordinary-turn-recovery.js';
+import { turnRetryOffer, shouldNotifyTurnFailure } from '../services/turn-failure-notice.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import { emitSessionLifecycleHook, emitSessionStateTransitionHook } from '../services/session-lifecycle-hooks.js';
 import { anchorUsageForDaemonSession, recordOwnershipForDaemonSession, recordUsageForDaemonSession, reconcileUsageForDaemonSession } from '../services/usage-ledger.js';
@@ -1259,6 +1260,54 @@ function ordinaryTurnRecoveryWarning(
   return tr('worker.ordinary_recovery_non_retryable', undefined, locale);
 }
 
+/** 构造一张通用失败卡。两条通知路径（recovery warn / claude 终态兜底）共用它，
+ *  以免同一件事在两处长得不一样。
+ *
+ *  重试按钮只在 `lastFailedTurn` 与本次失败**同一轮**时出现：那条记录是按钮的
+ *  一次性凭据（handler 用 turnId 逐字比对），没有它就只剩「去看 Web 终端」。
+ *  记录缺失是正常情况——turn 在 prompt 被 wrap 前就死掉时 buildFailedTurnRecord
+ *  返回 undefined。 */
+function buildSessionTurnFailedCard(
+  ds: DaemonSession,
+  opts: {
+    status: 'failed' | 'ambiguous';
+    errorCode?: string;
+    reason?: string;
+    continuations?: number;
+    retryable?: boolean;
+  },
+): string {
+  const botCfg = getBot(ds.larkAppId).config;
+  const effectiveCliId = sessionCliId(ds, botCfg);
+  const failedTurn = ds.session.lastFailedTurn;
+  const offer = turnRetryOffer({
+    status: opts.status,
+    ...(opts.errorCode !== undefined ? { errorCode: opts.errorCode } : {}),
+    ...(opts.retryable !== undefined ? { retryable: opts.retryable } : {}),
+  });
+  // 没有真人 footer 收件人时才回退 @ bot 管理员（与失败兜底通知同口径，且
+  // 绝不 @ bot——那会触发对方新一轮）。
+  const mentionOpenId = daemonCardFooterRecipientOpenId(ds, effectiveCliId)
+    ?? failureNoticeFallbackMentionOpenId(ds);
+  return buildTurnFailedCard({
+    rootId: sessionAnchorId(ds),
+    sessionId: ds.session.sessionId,
+    cliId: effectiveCliId,
+    cliName: sessionRuntimeDisplayName(ds) ?? getCliDisplayName(effectiveCliId),
+    status: opts.status,
+    ...(opts.errorCode !== undefined ? { errorCode: opts.errorCode } : {}),
+    ...(opts.reason !== undefined ? { reason: opts.reason } : {}),
+    failedAt: new Date(),
+    ...(failedTurn?.userPrompt !== undefined ? { task: failedTurn.userPrompt } : {}),
+    ...(opts.continuations !== undefined ? { continuations: opts.continuations } : {}),
+    retryOffer: offer,
+    ...(failedTurn ? { retryTurnId: failedTurn.turnId } : {}),
+    ...(mentionOpenId ? { mentionOpenId } : {}),
+    terminalUrl: readableTerminalUrlFor(ds),
+    locale: localeForBot(ds.larkAppId),
+  });
+}
+
 /** Attach the crash-safe timer owner for one eligible ordinary Claude/Lark
  * session. Session state is persisted; this runtime registry only owns timers. */
 export function ensureOrdinaryTurnRecoveryAttached(
@@ -1310,8 +1359,16 @@ export function ensureOrdinaryTurnRecoveryAttached(
       });
       void requireCallbacks().sessionReply(
         sessionAnchorId(ds),
-        warning,
-        'text',
+        buildSessionTurnFailedCard(ds, {
+          status: 'failed',
+          ...(state.lastErrorCode !== undefined ? { errorCode: state.lastErrorCode } : {}),
+          // recovery 走到 warn 一定是「自动续跑救不回来」，把已试次数摊给用户，
+          // 免得他以为系统什么都没做。
+          continuations: state.continuationsStarted,
+          // 这条路径的 retryable 已经在 coordinator 里判过并否掉了（否则不会
+          // warn），所以按钮的安全性交给 errorCode 白名单判断，不再谎称 safe。
+        }),
+        'interactive',
         ds.larkAppId,
         state.logicalTurnId,
       ).catch(err => logger.error(
@@ -12151,11 +12208,28 @@ function setupWorkerHandlers(
           }
         }
 
-        if (isClaudeProviderFailure
+        // 失败通知的 Lark 出口。原先只覆盖 claude 的 `provider_*` 终态，导致两个
+        // 缺口：
+        //  1. 结构化 CLI（codex/pi/…）的 `ambiguous` 终态——CLI 进程挂了、输入没
+        //     写进去——**一条消息都不发**（Channel B 的 gate 只放 `failed`），
+        //     卡片悄悄回到「等待输入」，与「正常干完」在用户眼里完全同形。
+        //  2. claude 的通知是纯文本，没有可操作入口。
+        // 现在统一走失败卡。仍然刻意**不**碰已经有可见卡片的路径：`failed` 的
+        // 结构化终态由 Channel B 的 final_output 卡承载（还带半截答案），在这里
+        // 再发一张就是重复通知。
+        const structuredFailedOwnsNotice = !isClaudeProviderFailure && msg.status === 'failed';
+        const shouldPostFailureCard = shouldNotifyTurnFailure({
+          status: msg.status,
+          ...(msg.errorCode !== undefined ? { errorCode: msg.errorCode } : {}),
+        })
+          && !structuredFailedOwnsNotice
           && !nonLarkFailureHandled
           && !recoveryHandled
-          && !managedAuxUiSuppressed(msg.turnId, msg.dispatchAttempt)) {
+          && !managedAuxUiSuppressed(msg.turnId, msg.dispatchAttempt);
+        if (shouldPostFailureCard) {
           const failureCode = msg.errorCode ?? msg.status;
+          // agentAttention / dashboard「需要你」仍用纯文本摘要：那一列渲染的是
+          // 文本，不是卡片。
           const warning = tr(
             'worker.claude_terminal_failure_unrecovered',
             { errorCode: failureCode },
@@ -12169,10 +12243,18 @@ function setupWorkerHandlers(
             turnId: msg.turnId,
           });
           try {
-            await scopedReply(warning, 'text', msg.turnId);
+            await scopedReply(
+              buildSessionTurnFailedCard(ds, {
+                status: msg.status === 'ambiguous' ? 'ambiguous' : 'failed',
+                ...(msg.errorCode !== undefined ? { errorCode: msg.errorCode } : {}),
+                ...(msg.retryable !== undefined ? { retryable: msg.retryable } : {}),
+              }),
+              'interactive',
+              msg.turnId,
+            );
           } catch (err) {
             logger.error(
-              `[${t}] Failed to deliver Claude terminal failure warning: `
+              `[${t}] Failed to deliver turn failure card: `
               + `${err instanceof Error ? err.message : String(err)}`,
             );
           }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -27,6 +27,7 @@ export const messages: Record<string, string> = {
   'card.btn.half_page_down': '⇟ Page ½ Down',
   'card.btn.send_custom': '📝 Send Custom Reply',
   'card.btn.retry_last_task': '🔁 Retry Last Task',
+  'card.btn.retry_turn': '🔁 Retry This Turn',
   'card.btn.stop': '⏹ Stop',
   'card.btn.compact': '🗜️ Compact',
 
@@ -906,6 +907,25 @@ export const messages: Record<string, string> = {
   'worker.ordinary_recovery_dispatch_interrupted': '⚠️ Botmux restarted while an automatic Claude continuation was being handed off, so its execution state is unknown. To avoid repeating external side effects, Botmux did not replay it. Check the Web Terminal, then send a message to continue.',
   'worker.ordinary_recovery_non_retryable': '⚠️ This Claude turn failed, and the current error cannot be retried safely. Botmux stopped automatic processing to avoid repeating external side effects. Check the Web Terminal and model-service status, then send a message to continue.',
   'worker.claude_terminal_failure_unrecovered': '⚠️ This Claude turn stopped with a model-service error ({errorCode}). This delivery channel did not start an automatic continuation. Check the Web Terminal, then retry or send a message to continue.',
+
+  // ─── Turn-failure card (generic failure card: @mention + retry button) ────
+  'card.turn_failed.title': '⚠️ {cliName} turn failed',
+  'card.turn_failed.title_ambiguous': '⚠️ {cliName} turn stopped unexpectedly',
+  'card.turn_failed.field_error': '**Error code**: {errorCode}',
+  'card.turn_failed.field_when': '**Failed at**: {when}',
+  'card.turn_failed.field_task': '**Task**: {task}',
+  'card.turn_failed.field_continuations': '**Auto-continuations**: {count} (still not recovered)',
+  'card.turn_failed.reason': '**Reason**: {reason}',
+  'card.turn_failed.retry_safe': 'This turn\'s input never reached the CLI, so **nothing was executed**. Retrying is safe.',
+  'card.turn_failed.retry_caveated': '⚠️ This turn **may have partially executed** (edited files, commits, messages sent). Retrying re-sends the original task **verbatim**, so completed actions may run again. If unsure, open the Web Terminal and check the current state first.',
+  'card.turn_failed.no_retry': 'Re-sending the same input cannot succeed for this error. Check the cause, then send a new message.',
+  'card.turn_failed.no_input': 'No re-sendable input was recorded for this turn (it stopped before submission). Send a new message instead.',
+
+  'card.action.retry_turn_missing': '⚠️ No input record found for this turn, so it cannot be retried. Send a new message instead.',
+  'card.action.retry_turn_stale': '⚠️ This card is out of date (the session failed again or was already retried). Use the latest card, or send a new message.',
+  'card.action.retry_turn_cooldown': '⏳ Retry is cooling down. Try again in {seconds}s.',
+  'card.action.retry_turn_submit_failed': '⚠️ Retry submission failed: the worker is not accepting input right now. Try again shortly.',
+  'card.action.retry_turn_success': '🔁 This turn has been resubmitted. Waiting for execution.',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────
   'setup.lark_create_app': 'First create a Lark app at: https://open.feishu.cn/app',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -28,6 +28,7 @@ export const messages: Record<string, string> = {
   'card.btn.send_custom': '📝 Send Custom Reply',
   'card.btn.retry_last_task': '🔁 Retry Last Task',
   'card.btn.retry_turn': '🔁 Retry This Turn',
+  'card.btn.continue_turn': '▶️ Continue This Turn',
   'card.btn.stop': '⏹ Stop',
   'card.btn.compact': '🗜️ Compact',
 
@@ -917,7 +918,7 @@ export const messages: Record<string, string> = {
   'card.turn_failed.field_continuations': '**Auto-continuations**: {count} (still not recovered)',
   'card.turn_failed.reason': '**Reason**: {reason}',
   'card.turn_failed.retry_safe': 'This turn\'s input never reached the CLI, so **nothing was executed**. Retrying is safe.',
-  'card.turn_failed.retry_caveated': '⚠️ This turn **may have partially executed** (edited files, commits, messages sent). Retrying re-sends the original task **verbatim**, so completed actions may run again. If unsure, open the Web Terminal and check the current state first.',
+  'card.turn_failed.retry_caveated': '⚠️ This turn **may have partially executed** (edited files, commits, messages sent). Continue does NOT replay it verbatim: the CLI is asked to **inspect the current state first**, work out how far it got, and resume from there — stopping and handing back to you if it cannot tell. Still worth a glance at the Web Terminal.',
   'card.turn_failed.no_retry': 'Re-sending the same input cannot succeed for this error. Check the cause, then send a new message.',
   'card.turn_failed.no_input': 'No re-sendable input was recorded for this turn (it stopped before submission). Send a new message instead.',
 
@@ -926,6 +927,7 @@ export const messages: Record<string, string> = {
   'card.action.retry_turn_cooldown': '⏳ Retry is cooling down. Try again in {seconds}s.',
   'card.action.retry_turn_submit_failed': '⚠️ Retry submission failed: the worker is not accepting input right now. Try again shortly.',
   'card.action.retry_turn_success': '🔁 This turn has been resubmitted. Waiting for execution.',
+  'card.action.continue_turn_success': '▶️ Asked the CLI to inspect the current state and resume from where it stopped. Waiting for execution.',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────
   'setup.lark_create_app': 'First create a Lark app at: https://open.feishu.cn/app',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -31,6 +31,7 @@ export const messages: Record<string, string> = {
   'card.btn.send_custom': '📝 发送自定义回复',
   'card.btn.retry_last_task': '🔁 重发上一条任务',
   'card.btn.retry_turn': '🔁 重试这一轮',
+  'card.btn.continue_turn': '▶️ 继续这一轮',
   'card.btn.stop': '⏹ 停止',
   'card.btn.compact': '🗜️ 压缩',
 
@@ -920,7 +921,7 @@ export const messages: Record<string, string> = {
   // 「没跑就挂了」——重发无副作用风险，可以放心点。
   'card.turn_failed.retry_safe': '这一轮的输入没有送达 CLI，**没有任何已执行的操作**，可以安全重试。',
   // 「跑到一半挂了」——重发会重跑，必须让用户自己判断。
-  'card.turn_failed.retry_caveated': '⚠️ 这一轮**可能已经执行了一部分**（改文件 / 提交 / 发消息等）。重试会把原任务**原样重发一遍**，已完成的操作可能重复执行。不确定时请先打开 Web 终端确认现场。',
+  'card.turn_failed.retry_caveated': '⚠️ 这一轮**可能已经执行了一部分**（改文件 / 提交 / 发消息等）。点「继续」不会原样重跑：会让 CLI **先读取当前现场**，判断做到哪一步，再从上次的进度接着做；判断不了会停下来交回你决定。仍建议先看一眼 Web 终端。',
   'card.turn_failed.no_retry': '当前错误重发同样的输入也无法成功，请检查后发送新的消息。',
   'card.turn_failed.no_input': '这一轮没有可重发的输入记录（任务在提交前就中断了），请直接发送新的消息。',
 
@@ -929,6 +930,7 @@ export const messages: Record<string, string> = {
   'card.action.retry_turn_cooldown': '⏳ 重试冷却中，请在 {seconds} 秒后再试。',
   'card.action.retry_turn_submit_failed': '⚠️ 重试提交失败：worker 当前不接受输入，请稍后再试。',
   'card.action.retry_turn_success': '🔁 已重新提交这一轮任务，请等待执行。',
+  'card.action.continue_turn_success': '▶️ 已请 CLI 读取现场后从上次的进度继续，请等待执行。',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────
   'setup.lark_create_app': '请先在飞书开放平台创建应用: https://open.feishu.cn/app',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -30,6 +30,7 @@ export const messages: Record<string, string> = {
   'card.btn.half_page_down': '⇟ 下半屏',
   'card.btn.send_custom': '📝 发送自定义回复',
   'card.btn.retry_last_task': '🔁 重发上一条任务',
+  'card.btn.retry_turn': '🔁 重试这一轮',
   'card.btn.stop': '⏹ 停止',
   'card.btn.compact': '🗜️ 压缩',
 
@@ -907,6 +908,27 @@ export const messages: Record<string, string> = {
   'worker.ordinary_recovery_dispatch_interrupted': '⚠️ Botmux 在自动续跑交接期间重启，当前执行状态无法确认。为避免重复外部操作，Botmux 没有重放本次续跑；请检查 Web 终端后，再发送一条消息继续。',
   'worker.ordinary_recovery_non_retryable': '⚠️ Claude 本轮执行失败，且当前错误不能安全自动续跑。为避免重复外部操作，Botmux 已停止自动处理；请检查 Web 终端和模型服务状态后，再发送一条消息继续。',
   'worker.claude_terminal_failure_unrecovered': '⚠️ Claude 本轮因模型服务错误中断（{errorCode}），当前投递通道未启动自动续跑。请检查 Web 终端后重试，或发送一条消息继续。',
+
+  // ─── Turn-failure card (通用失败卡：@人 + 重试按钮) ────────────────────────
+  'card.turn_failed.title': '⚠️ {cliName} 本轮执行失败',
+  'card.turn_failed.title_ambiguous': '⚠️ {cliName} 本轮异常中断',
+  'card.turn_failed.field_error': '**错误码**：{errorCode}',
+  'card.turn_failed.field_when': '**失败时刻**：{when}',
+  'card.turn_failed.field_task': '**任务**：{task}',
+  'card.turn_failed.field_continuations': '**已自动续跑**：{count} 次（仍未恢复）',
+  'card.turn_failed.reason': '**原因**：{reason}',
+  // 「没跑就挂了」——重发无副作用风险，可以放心点。
+  'card.turn_failed.retry_safe': '这一轮的输入没有送达 CLI，**没有任何已执行的操作**，可以安全重试。',
+  // 「跑到一半挂了」——重发会重跑，必须让用户自己判断。
+  'card.turn_failed.retry_caveated': '⚠️ 这一轮**可能已经执行了一部分**（改文件 / 提交 / 发消息等）。重试会把原任务**原样重发一遍**，已完成的操作可能重复执行。不确定时请先打开 Web 终端确认现场。',
+  'card.turn_failed.no_retry': '当前错误重发同样的输入也无法成功，请检查后发送新的消息。',
+  'card.turn_failed.no_input': '这一轮没有可重发的输入记录（任务在提交前就中断了），请直接发送新的消息。',
+
+  'card.action.retry_turn_missing': '⚠️ 找不到这一轮的输入记录，无法重试。请直接发送新的消息。',
+  'card.action.retry_turn_stale': '⚠️ 这张卡片已过期（会话后来又失败过或已重试）。请用最新那张卡片，或直接发送新的消息。',
+  'card.action.retry_turn_cooldown': '⏳ 重试冷却中，请在 {seconds} 秒后再试。',
+  'card.action.retry_turn_submit_failed': '⚠️ 重试提交失败：worker 当前不接受输入，请稍后再试。',
+  'card.action.retry_turn_success': '🔁 已重新提交这一轮任务，请等待执行。',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────
   'setup.lark_create_app': '请先在飞书开放平台创建应用: https://open.feishu.cn/app',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1852,10 +1852,26 @@ export function buildTurnFailedCard(o: TurnFailedCardOpts): string {
   if (canRetry) {
     actions.push({
       tag: 'button',
-      text: { tag: 'plain_text', content: t('card.btn.retry_turn', undefined, locale) },
+      text: {
+        tag: 'plain_text',
+        // 语义跟着动作走：没跑过 = 重试（重发原话）；跑过一半 = 继续（读现场后
+        // 从 checkpoint 接着做）。文案说错会让用户对副作用风险判断错。
+        content: t(
+          o.retryOffer === 'safe' ? 'card.btn.retry_turn' : 'card.btn.continue_turn',
+          undefined,
+          locale,
+        ),
+      },
       // caveated 用 default 而不是 primary：可能重复副作用的操作不该是视觉默认项。
       type: o.retryOffer === 'safe' ? 'primary' : 'default',
-      value: { action: 'retry_turn', turn_id: o.retryTurnId, ...actionBase },
+      value: {
+        action: 'retry_turn',
+        turn_id: o.retryTurnId,
+        // handler 据此决定提交「原话」还是「续跑指令」。渲染与执行读同一个
+        // retryOffer，卡上写的语义就是真正会发生的事。
+        mode: o.retryOffer === 'safe' ? 'resend' : 'continue',
+        ...actionBase,
+      },
     });
   }
   if (o.terminalUrl) {

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -6,6 +6,7 @@ import type { ZellijAdoptableSession } from '../../core/zellij-adopt-discovery.j
 import type { CodexAppThreadSummary } from '../../services/codex-app-threads.js';
 import type { DisplayMode, StreamStatus } from '../../types.js';
 import type { CliUsageLimitState } from '../../utils/cli-usage-limit.js';
+import type { TurnRetryOffer } from '../../services/turn-failure-notice.js';
 import { t, type Locale } from '../../i18n/index.js';
 import { cardUsageFooterSegment, cardUsageRuntimeSegment, type CardUsageSnapshot } from './md-card.js';
 import { readGlobalConfig } from '../../global-config.js';
@@ -1750,6 +1751,134 @@ export function buildAdoptBlockedCard(rootId: string, sessionId: string, cliId: 
     ],
   };
   return JSON.stringify(card);
+}
+
+export interface TurnFailedCardOpts {
+  rootId: string;
+  sessionId: string;
+  cliId: CliId | undefined;
+  cliName: string;
+  /** `ambiguous` softens the title: the turn may have run, we just can't tell. */
+  status: 'failed' | 'ambiguous';
+  errorCode?: string;
+  /** Human-safe failure summary from the CLI, when it provided one. */
+  reason?: string;
+  failedAt?: Date;
+  /** The user's own prompt, for "which task was this". Truncated + escaped. */
+  task?: string;
+  /** Auto-continuation count, when a recovery ladder ran and gave up. */
+  continuations?: number;
+  /** Retry affordance, decided by `turnRetryOffer` — the handler enforces the
+   *  same policy, so `none` must not render a button. */
+  retryOffer: TurnRetryOffer;
+  /** Pins the button to one specific failed turn; a stale card fails closed. */
+  retryTurnId?: string;
+  /** Human to @-mention in the body. Omitted → no mention (never @ a bot). */
+  mentionOpenId?: string;
+  terminalUrl?: string;
+  locale?: Locale;
+}
+
+/** 通用失败卡：一条失败通知同时承载「现在什么情况」与「可以怎么办」。
+ *
+ *  取代原先的纯文本通知（`worker.ordinary_recovery_*` / `claude_terminal_failure_unrecovered`），
+ *  并覆盖此前**完全静默**的 `ambiguous` 终态（CLI 崩溃 / 写入失败）——那类失败过去与
+ *  「正常干完」在用户眼里同形。
+ *
+ *  三条刻意的设计约束：
+ *  1. **errorCode 原样打出**。`ordinary_recovery_non_retryable` 是无条件兜底分支，
+ *     daemon 重启这类非模型错误也会落到那句「不能安全自动续跑」；把码摊开才能让
+ *     这种混淆可见，而不是继续被文案糊住。
+ *  2. **重试的副作用风险必须写在卡上**。`caveated` 时明说「可能已执行了一部分」——
+ *     `/retry` 是原样重发，不像自动续跑会带 checkpoint 提示。
+ *  3. **@人只在正文**（`lark_md`）。`plain_text` 标题会被 {@link plainTitle} 剥掉
+ *     `<at>`，放那儿等于不 @。 */
+export function buildTurnFailedCard(o: TurnFailedCardOpts): string {
+  const { locale } = o;
+  const actionBase = {
+    root_id: o.rootId,
+    session_id: o.sessionId,
+    cli_id: o.cliId ?? 'claude-code',
+  };
+  const titleKey = o.status === 'ambiguous'
+    ? 'card.turn_failed.title_ambiguous'
+    : 'card.turn_failed.title';
+
+  const lines: string[] = [];
+  // 先 @ 人再讲事：飞书的通知摘要只取前一段，@ 放最后会被截掉。
+  if (o.mentionOpenId) lines.push(`<at id=${o.mentionOpenId}></at>`);
+  // errorCode 是闭集常量（`cli_exit` / `provider_*` / `codexTaskFailureCode` 的
+  // 固定返回值），从不携带 provider 原文，所以用反引号包成行内代码而不是
+  // escapeMd —— 后者会把 `a_b_c` 里的下划线转义成可见的反斜杠，正是这类码最常
+  // 见的形态。仍然剥掉反引号与尖括号，避免任何一天码变成动态值时逃出代码段。
+  lines.push(t('card.turn_failed.field_error', {
+    errorCode: `\`${(o.errorCode ?? o.status).replace(/[`<>]/g, '')}\``,
+  }, locale));
+  if (o.reason) {
+    lines.push(t('card.turn_failed.reason', { reason: escapeMd(o.reason) }, locale));
+  }
+  if (o.failedAt) {
+    lines.push(t('card.turn_failed.field_when', {
+      when: o.failedAt.toLocaleString(locale === 'en' ? 'en-US' : 'zh-CN', { hour12: false }),
+    }, locale));
+  }
+  if (o.task) {
+    const trimmed = o.task.length > 80 ? `${o.task.slice(0, 80)}…` : o.task;
+    lines.push(t('card.turn_failed.field_task', { task: escapeMd(trimmed) }, locale));
+  }
+  if (o.continuations !== undefined && o.continuations > 0) {
+    lines.push(t('card.turn_failed.field_continuations', {
+      count: String(o.continuations),
+    }, locale));
+  }
+
+  const elements: any[] = [
+    { tag: 'markdown', content: lines.join('\n') },
+    { tag: 'hr' },
+  ];
+
+  // 重试建议与按钮由同一个 retryOffer 决定，避免「卡上说能重试但按钮不给」。
+  const canRetry = o.retryOffer !== 'none' && !!o.retryTurnId;
+  const adviceKey = o.retryOffer === 'none'
+    ? 'card.turn_failed.no_retry'
+    : !o.retryTurnId
+      ? 'card.turn_failed.no_input'
+      : o.retryOffer === 'safe'
+        ? 'card.turn_failed.retry_safe'
+        : 'card.turn_failed.retry_caveated';
+  elements.push({ tag: 'markdown', content: t(adviceKey, undefined, locale) });
+
+  const actions: any[] = [];
+  if (canRetry) {
+    actions.push({
+      tag: 'button',
+      text: { tag: 'plain_text', content: t('card.btn.retry_turn', undefined, locale) },
+      // caveated 用 default 而不是 primary：可能重复副作用的操作不该是视觉默认项。
+      type: o.retryOffer === 'safe' ? 'primary' : 'default',
+      value: { action: 'retry_turn', turn_id: o.retryTurnId, ...actionBase },
+    });
+  }
+  if (o.terminalUrl) {
+    actions.push({
+      tag: 'button',
+      text: { tag: 'plain_text', content: t('card.btn.open_terminal', undefined, locale) },
+      type: 'default',
+      multi_url: terminalMultiUrl(o.terminalUrl),
+    });
+  }
+  if (actions.length > 0) elements.push({ tag: 'action', actions });
+
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: {
+      title: {
+        tag: 'plain_text',
+        content: t(titleKey, { cliName: plainTitle(o.cliName) }, locale),
+      },
+      template: 'red',
+    },
+    elements,
+  });
 }
 
 /** 授权处置后的终态卡（无按钮，防重复点击）。 */

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -89,6 +89,7 @@ import { ttadkConfigModelChoices } from '../../setup/cli-selection.js';
 import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
 import { retryCooldownRemaining, markRetryAttempt } from '../../services/failed-turn-retry.js';
+import { buildTurnContinuePrompt } from '../../services/turn-failure-notice.js';
 import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-store.js';
 import { resumeStartsFresh } from '../../services/resume-fresh-policy.js';
 import { forkWorker, sendWorkerInput, sendWorkerSessionInput, killWorker, closeSession as closeWorkerPoolSession, teardownAuthoritativePersistentBackingBeforeClose, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, workerHasInitialized, sessionSupportsWebTerminal, readableTerminalUrlFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL, requestSessionRestart, isSessionTransferring, getDaemonStreamingCardUsageSnapshot, withActiveSessionKeyLock, buildStreamingCardJson, silentIdleCardFlag, type WorkerSessionReplyOptions } from '../../core/worker-pool.js';
@@ -2932,9 +2933,22 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       const retryCodexAppInput = failedTurn.codexAppInput
         ? (({ clientUserMessageId: _prior, ...input }) => input)(failedTurn.codexAppInput)
         : undefined;
+      // 提交什么由卡上的 mode 决定，而 mode 由渲染时的 retryOffer 决定，所以
+      // 「卡上写的语义」与「实际发生的事」永远一致：
+      //   resend   —— 输入证明没送达 CLI，零副作用，重发原话最干净可靠；
+      //   continue —— 可能已执行一部分，原样重发会重复副作用，改发续跑指令
+      //               （读现场 → 从 checkpoint 接着做 → 判断不了就交回人工）。
+      // 旧卡片没有 mode 字段：按 continue 处理（fail-safe —— 宁可让模型先看
+      // 现场，也不要在可能已执行过的轮次上闷头重发一遍）。
+      const continueMode = value?.mode !== 'resend';
+      const submittedContent = continueMode
+        ? buildTurnContinuePrompt(failedTurn.userPrompt || failedTurn.cliInput)
+        : failedTurn.cliInput;
       const retryInput = {
-        content: failedTurn.cliInput,
-        ...(retryCodexAppInput ? { codexAppInput: retryCodexAppInput } : {}),
+        content: submittedContent,
+        // codexAppInput 描述的是「原样重发那条结构化输入」。续跑发的是一条新指令，
+        // 带上旧 sidecar 会让 CLI 收到与正文不符的结构化载荷。
+        ...(!continueMode && retryCodexAppInput ? { codexAppInput: retryCodexAppInput } : {}),
       };
       let accepted = false;
       try {
@@ -2966,9 +2980,19 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       persistStreamCardState(ds);
       logger.info(
         `[${tag(ds)}] retry_turn re-injected turn ${failedTurn.turnId.slice(0, 8)} `
+        + `mode=${continueMode ? 'continue' : 'resend'} `
         + `(attempt #${ds.session.lastFailedTurn?.retryCount ?? 1})`,
       );
-      return { toast: { type: 'success', content: t('card.action.retry_turn_success', undefined, locDs) } };
+      return {
+        toast: {
+          type: 'success',
+          content: t(
+            continueMode ? 'card.action.continue_turn_success' : 'card.action.retry_turn_success',
+            undefined,
+            locDs,
+          ),
+        },
+      };
     }
 
     if (actionType === 'tui_keys' && ds) {

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -2941,8 +2941,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       // 旧卡片没有 mode 字段：按 continue 处理（fail-safe —— 宁可让模型先看
       // 现场，也不要在可能已执行过的轮次上闷头重发一遍）。
       const continueMode = value?.mode !== 'resend';
+      // 续跑不带原任务文本：这个 fork 走 resume（下面 ds.hasHistory），CLI 自己
+      // 就能读到原任务和它已经做过的事，重复一遍纯属浪费 token。
       const submittedContent = continueMode
-        ? buildTurnContinuePrompt(failedTurn.userPrompt || failedTurn.cliInput)
+        ? buildTurnContinuePrompt()
         : failedTurn.cliInput;
       const retryInput = {
         content: submittedContent,

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -2887,11 +2887,15 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
     // 失败卡的重试按钮。刻意不复用上面的 `retry_last_task`：那颗按钮的
     // `ds.usageLimit` 条件同时充当它的一次性安全阀（成功后 clearUsageLimitState
-    // 消费掉，所以连点第二次自然失效）。失败场景没有那个状态，于是这里用
-    // `lastFailedTurn.turnId` 做等价的一次性校验：
-    //   - 卡上的 turn_id 必须与当前记录的失败轮次逐字相同 ⟹ 历史失败卡点不动；
-    //   - 成功后 markRetryAttempt 起 10s cooldown ⟹ 同一张卡连点被挡住。
-    // 两条都 fail-closed：宁可让用户多发一条消息，也不重复提交可能带外部副作用
+    // 消费掉，所以连点第二次自然失效）。失败场景没有那个状态，于是这里换成两道
+    // 独立的门——注意**两道都不是一次性的**，`lastFailedTurn` 只写不删：
+    //   - turnId pin：卡上的 turn_id 必须与当前记录的失败轮次逐字相同。它挡的是
+    //     **历史卡片**——会话后来又失败过、记录被新的覆盖，旧卡就永久失效；同一
+    //     张卡在记录没被覆盖前，pin 一直是满足的。
+    //   - 10s cooldown（markRetryAttempt 盖 lastRetryAt）：挡的是**连点**。
+    //     冷却过后同一张卡可以再次提交，这是刻意的（与 `/retry` 同款，
+    //     failed-turn-retry.test 有用例钉住），因为一次重试也可能再失败。
+    // 两道都 fail-closed：宁可让用户多发一条消息，也不重复提交可能带外部副作用
     // 的任务。
     if (actionType === 'retry_turn' && ds) {
       const locDs = localeForBot(ds.larkAppId);
@@ -2907,8 +2911,8 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       if (!failedTurn) {
         return { toast: { type: 'warning', content: t('card.action.retry_turn_missing', undefined, locDs) } };
       }
-      // 一次性校验：卡片只对它自己那一轮有效。会话后来又失败过（记录被新的
-      // 覆盖）或这张卡已经重试过，都会在这里被拒。
+      // 轮次校验：卡片只对它自己那一轮有效。会话后来又失败过、记录被新的覆盖，
+      // 这张旧卡就永久失效。（「刚点过」不在这里挡，由下面的 cooldown 负责。）
       const clickedTurnId = value?.turn_id;
       if (!clickedTurnId || clickedTurnId !== failedTurn.turnId) {
         logger.info(
@@ -2968,9 +2972,8 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       if (!accepted) {
         return { toast: { type: 'warning', content: t('card.action.retry_turn_submit_failed', undefined, locDs) } };
       }
-      // Consume the one-shot only after acceptance: a rejected click must not
-      // burn the cooldown or the turnId pin (same post-acceptance ordering as
-      // /retry and retry_last_task).
+      // Start the cooldown only after acceptance: a rejected click must not
+      // burn it (same post-acceptance ordering as /retry and retry_last_task).
       markRetryAttempt(ds.session);
       rememberLastCliInput(ds, failedTurn.userPrompt, retryInput);
       sessionStore.updateSession(ds.session);

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -88,6 +88,7 @@ import { buildClosedSessionCard } from '../../core/closed-session-card.js';
 import { ttadkConfigModelChoices } from '../../setup/cli-selection.js';
 import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
+import { retryCooldownRemaining, markRetryAttempt } from '../../services/failed-turn-retry.js';
 import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-store.js';
 import { resumeStartsFresh } from '../../services/resume-fresh-policy.js';
 import { forkWorker, sendWorkerInput, sendWorkerSessionInput, killWorker, closeSession as closeWorkerPoolSession, teardownAuthoritativePersistentBackingBeforeClose, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, workerHasInitialized, sessionSupportsWebTerminal, readableTerminalUrlFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL, requestSessionRestart, isSessionTransferring, getDaemonStreamingCardUsageSnapshot, withActiveSessionKeyLock, buildStreamingCardJson, silentIdleCardFlag, type WorkerSessionReplyOptions } from '../../core/worker-pool.js';
@@ -1975,7 +1976,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     );
   }
 
-  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'repo_manual_submit', 'repo_worktree_submit', 'worktree_toggle_mode', 'retry_last_task', 'get_write_link', 'open_local_terminal', 'open_local_cli', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel', 'stop_turn', 'compact_session'].includes(value.action);
+  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'repo_manual_submit', 'repo_worktree_submit', 'worktree_toggle_mode', 'retry_last_task', 'retry_turn', 'get_write_link', 'open_local_terminal', 'open_local_cli', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel', 'stop_turn', 'compact_session'].includes(value.action);
   if (isSensitive) {
     const rootId = value?.root_id;
     // activeSessions is keyed by sessionKey(anchor, larkAppId) — `${anchor}::${larkAppId}`
@@ -2881,6 +2882,93 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         try { return JSON.parse(cardJson); } catch { /* fall through */ }
       }
       return;
+    }
+
+    // 失败卡的重试按钮。刻意不复用上面的 `retry_last_task`：那颗按钮的
+    // `ds.usageLimit` 条件同时充当它的一次性安全阀（成功后 clearUsageLimitState
+    // 消费掉，所以连点第二次自然失效）。失败场景没有那个状态，于是这里用
+    // `lastFailedTurn.turnId` 做等价的一次性校验：
+    //   - 卡上的 turn_id 必须与当前记录的失败轮次逐字相同 ⟹ 历史失败卡点不动；
+    //   - 成功后 markRetryAttempt 起 10s cooldown ⟹ 同一张卡连点被挡住。
+    // 两条都 fail-closed：宁可让用户多发一条消息，也不重复提交可能带外部副作用
+    // 的任务。
+    if (actionType === 'retry_turn' && ds) {
+      const locDs = localeForBot(ds.larkAppId);
+      if (isSessionTransferring(ds)) {
+        return {
+          toast: {
+            type: 'warning',
+            content: t('cmd.session.transfer_in_progress', undefined, locDs),
+          },
+        };
+      }
+      const failedTurn = ds.session.lastFailedTurn;
+      if (!failedTurn) {
+        return { toast: { type: 'warning', content: t('card.action.retry_turn_missing', undefined, locDs) } };
+      }
+      // 一次性校验：卡片只对它自己那一轮有效。会话后来又失败过（记录被新的
+      // 覆盖）或这张卡已经重试过，都会在这里被拒。
+      const clickedTurnId = value?.turn_id;
+      if (!clickedTurnId || clickedTurnId !== failedTurn.turnId) {
+        logger.info(
+          `[${tag(ds)}] retry_turn from stale card (clicked=${clickedTurnId?.slice(0, 8) ?? 'none'} `
+          + `current=${failedTurn.turnId.slice(0, 8)}) — refused`,
+        );
+        return { toast: { type: 'warning', content: t('card.action.retry_turn_stale', undefined, locDs) } };
+      }
+      const cooldownMs = retryCooldownRemaining(failedTurn);
+      if (cooldownMs > 0) {
+        return {
+          toast: {
+            type: 'warning',
+            content: t('card.action.retry_turn_cooldown', { seconds: Math.ceil(cooldownMs / 1000) }, locDs),
+          },
+        };
+      }
+      if ((!ds.worker || ds.worker.killed) && hasProtectedSessionMutationOwnership(ds)) {
+        return { toast: { type: 'warning', content: t('card.action.retry_turn_submit_failed', undefined, locDs) } };
+      }
+      // Strip clientUserMessageId to avoid dedup conflicts (same as /retry).
+      const retryCodexAppInput = failedTurn.codexAppInput
+        ? (({ clientUserMessageId: _prior, ...input }) => input)(failedTurn.codexAppInput)
+        : undefined;
+      const retryInput = {
+        content: failedTurn.cliInput,
+        ...(retryCodexAppInput ? { codexAppInput: retryCodexAppInput } : {}),
+      };
+      let accepted = false;
+      try {
+        if (ds.worker && !ds.worker.killed) accepted = sendWorkerInput(ds, retryInput);
+        else {
+          forkWorker(ds, retryInput, ds.hasHistory);
+          accepted = true;
+        }
+      } catch (err) {
+        logger.warn(
+          `[${tag(ds)}] retry_turn failed before acceptance: `
+          + `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      if (!accepted) {
+        return { toast: { type: 'warning', content: t('card.action.retry_turn_submit_failed', undefined, locDs) } };
+      }
+      // Consume the one-shot only after acceptance: a rejected click must not
+      // burn the cooldown or the turnId pin (same post-acceptance ordering as
+      // /retry and retry_last_task).
+      markRetryAttempt(ds.session);
+      rememberLastCliInput(ds, failedTurn.userPrompt, retryInput);
+      sessionStore.updateSession(ds.session);
+      ds.lastScreenStatus = 'working';
+      ds.streamCardPending = true;
+      ds.currentTurnTitle = (failedTurn.userPrompt || ds.currentTurnTitle || ds.session.title
+        || getCliDisplayName(sessionCliId(ds))).substring(0, 50);
+      ds.currentImageKey = undefined;
+      persistStreamCardState(ds);
+      logger.info(
+        `[${tag(ds)}] retry_turn re-injected turn ${failedTurn.turnId.slice(0, 8)} `
+        + `(attempt #${ds.session.lastFailedTurn?.retryCount ?? 1})`,
+      );
+      return { toast: { type: 'success', content: t('card.action.retry_turn_success', undefined, locDs) } };
     }
 
     if (actionType === 'tui_keys' && ds) {

--- a/src/services/turn-failure-notice.ts
+++ b/src/services/turn-failure-notice.ts
@@ -1,0 +1,135 @@
+/**
+ * Which turn failures deserve a user-visible, actionable notice — and which of
+ * those may offer a retry button.
+ *
+ * Two independent questions, deliberately kept apart:
+ *
+ * 1. **Should we notify at all?** A `failed` terminal always warrants a notice.
+ *    An `ambiguous` one does NOT: that bucket mixes genuine breakage the user
+ *    cannot see (the CLI process died, an input write threw) with interruptions
+ *    the user performed themselves (Esc → `*_turn_aborted`). Notifying on a
+ *    user's own Esc would manufacture exactly the alert noise this feature
+ *    exists to reduce, so proven user aborts stay silent.
+ *
+ * 2. **May we offer retry, and with what warning?** `retryable === true` is
+ *    single-sourced today (the Claude transcript classifier is its only
+ *    producer; every other CLI leaves it `undefined`), so a cross-CLI retry
+ *    affordance cannot lean on it. What generalises instead is whether the
+ *    failure is *pre-execution*: an input that never reached the CLI has no
+ *    side effects to duplicate, so re-sending it is unconditionally safe.
+ *
+ *    A turn that died mid-execution (`cli_exit`) is the harder case. It is NOT
+ *    safe-by-construction — the CLI may already have edited files, pushed a
+ *    commit or sent a message before dying, and `/retry` re-injects the ORIGINAL
+ *    input verbatim (unlike the recovery path, which sends a checkpoint-aware
+ *    prompt). Hiding retry there would strand the user; offering it silently
+ *    would risk duplicate side effects. So it is offered as `caveated`, and the
+ *    card must say so — the user is the only one who can judge whether the
+ *    partial work is safe to redo.
+ *
+ * Keeping this as pure functions (no session, no IPC) makes the policy testable
+ * without a live worker and gives the card builder and the click handler one
+ * shared source of truth — a button that renders must be one the handler
+ * honours.
+ */
+
+/** Terminal statuses that can carry a failure. Mirrors `turn_terminal`. */
+export type FailureNoticeStatus = 'failed' | 'ambiguous' | 'completed' | 'cancelled';
+
+/**
+ * Error codes proving the USER deliberately stopped this turn. These arrive as
+ * `ambiguous` because a stop can land after side effects began, so the audit
+ * semantics stay uncertain — but the user already knows the turn ended, so a
+ * notice would be pure noise.
+ *
+ * Membership requires direct evidence that the code is user-initiated: each of
+ * these is documented as an Esc/interrupt in its transcript adapter (see
+ * `pi-transcript.ts` "user interrupt (Esc)"). Codes that merely *sound*
+ * cancel-like are deliberately excluded — `provider_cancelled`, for instance,
+ * can be a server-side cancellation rather than a human keypress, and today it
+ * does produce a notice. Suppressing it on a guess would delete a real alert.
+ */
+const USER_ABORT_ERROR_CODES: ReadonlySet<string> = new Set([
+  'pi_turn_aborted',
+  'omp_turn_aborted',
+  'rpc_turn_aborted',
+]);
+
+/**
+ * Error codes proving the turn's input never reached the CLI. Nothing executed,
+ * so re-sending duplicates no external side effect.
+ */
+const PRE_EXECUTION_ERROR_CODES: ReadonlySet<string> = new Set([
+  'write_input_threw',
+  'adopt_write_input_threw',
+  'raw_input_write_failed',
+  'zmx_recovery_blocked_before_write',
+  'terminal_bridge_unavailable',
+  // Both recovery-handoff failures are pre-execution by construction: the
+  // continuation was never accepted (enqueue) or never reached the worker
+  // (delivery, see failOrdinaryImDelivery). Note the deliberate ABSENCE of
+  // `recovery_dispatch_interrupted` — the daemon restarted mid-handoff, so the
+  // turn's execution state is genuinely unknown and must stay caveated.
+  'recovery_enqueue_failed',
+  'recovery_delivery_failed',
+]);
+
+export interface TurnFailureNoticeInput {
+  status: FailureNoticeStatus;
+  errorCode?: string;
+}
+
+/**
+ * Whether this terminal deserves a user-visible failure notice.
+ *
+ * `failed` always qualifies. `ambiguous` qualifies unless it is a proven user
+ * abort: `cli_exit`, `write_input_threw` and friends are invisible today (the
+ * card silently returns to idle, indistinguishable from success), which is the
+ * gap this predicate closes.
+ */
+export function shouldNotifyTurnFailure(turn: TurnFailureNoticeInput): boolean {
+  if (turn.status === 'failed') return true;
+  if (turn.status !== 'ambiguous') return false;
+  // An abort with no code cannot be attributed to the user; surface the
+  // unattributable case rather than swallowing it.
+  return turn.errorCode === undefined || !USER_ABORT_ERROR_CODES.has(turn.errorCode);
+}
+
+/**
+ * How a retry may be offered:
+ * - `safe`     — input provably never executed, or the CLI's own classifier
+ *                said retryable. No duplicate-side-effect risk to warn about.
+ * - `caveated` — the turn may have executed before dying. Offer the button, but
+ *                the card MUST warn that redoing it can repeat side effects.
+ * - `none`     — do not offer retry (not a notifiable failure, or the CLI
+ *                explicitly refused: re-sending cannot help).
+ */
+export type TurnRetryOffer = 'safe' | 'caveated' | 'none';
+
+export function turnRetryOffer(
+  turn: TurnFailureNoticeInput & { retryable?: boolean },
+): TurnRetryOffer {
+  if (!shouldNotifyTurnFailure(turn)) return 'none';
+  // An explicit refusal (auth failure, invalid request) outranks every
+  // heuristic below: re-sending the same input provably cannot succeed.
+  if (turn.retryable === false) return 'none';
+  if (turn.retryable === true) return 'safe';
+  if (turn.errorCode !== undefined && PRE_EXECUTION_ERROR_CODES.has(turn.errorCode)) return 'safe';
+  return 'caveated';
+}
+
+/** Convenience for call sites that only need "is there a button at all". */
+export function mayOfferTurnRetry(
+  turn: TurnFailureNoticeInput & { retryable?: boolean },
+): boolean {
+  return turnRetryOffer(turn) !== 'none';
+}
+
+/** Test/introspection helpers. Copies, so callers cannot mutate the policy. */
+export function userAbortErrorCodes(): string[] {
+  return [...USER_ABORT_ERROR_CODES];
+}
+
+export function preExecutionErrorCodes(): string[] {
+  return [...PRE_EXECUTION_ERROR_CODES];
+}

--- a/src/services/turn-failure-notice.ts
+++ b/src/services/turn-failure-notice.ts
@@ -129,34 +129,33 @@ export function mayOfferTurnRetry(
  * What to actually submit when the user presses the failure card's button.
  *
  * `safe` → re-send the original input verbatim. Nothing executed, so restating
- * the request is the cleanest, most predictable thing we can do; asking the
- * model to infer state would be strictly worse.
+ * the request is the cleanest, most predictable thing we can do.
  *
  * `caveated` → the turn may have half-executed, so a verbatim re-send risks
- * repeating side effects. Submit a continue instruction instead: have the model
- * inspect the workspace and resume from the last verifiable checkpoint.
+ * repeating side effects. Submit a continue instruction instead.
  *
- * Deliberately NOT reusing `ORDINARY_TURN_RECOVERY_PROMPT`: its first line
- * asserts "上一执行因暂态 provider 故障中止", which is false for the codes that
- * land here (`cli_exit` is a dead CLI process, not a provider fault). Telling
- * the model a wrong cause invites it to look in the wrong place.
+ * Kept deliberately SHORT. The click lands on a session that resumes its own
+ * transcript (`forkWorker(..., ds.hasHistory)` → `--resume <id>`), so the model
+ * already has the original task and everything it did before dying. Restating
+ * the task, or explaining at length what "continue" means, would spend tokens
+ * re-teaching the model what it can already read. Verified in practice: a bare
+ * "继续" is enough to get a CLI to pick up where it stopped.
  *
- * The original task text is EMBEDDED rather than assumed to survive: after a
- * `cli_exit` the worker forks a fresh CLI, and if transcript resume does not
- * restore context, a bare "continue" would leave the model with nothing to
- * continue. Including the task makes this degrade gracefully either way.
+ * So this carries exactly the two things the transcript does NOT tell it:
+ *  1. that the previous turn was cut off mid-flight (the transcript just ends —
+ *     it cannot distinguish "interrupted" from "finished"), and
+ *  2. that work may already have landed, so completed side effects must not be
+ *     repeated. This is the one instruction worth the tokens: it is the whole
+ *     reason this is a continue rather than a replay.
+ *
+ * Also NOT reusing `ORDINARY_TURN_RECOVERY_PROMPT`: its first line asserts a
+ * transient provider fault, which is false for the codes that land here
+ * (`cli_exit` is a dead process). A wrong cause sends the model looking in the
+ * wrong place.
  */
-export function buildTurnContinuePrompt(originalPrompt: string): string {
-  return [
-    '[BOTMUX_CONTINUE]',
-    '上一轮执行被异常中断（CLI 进程退出或状态不明），可能已经完成了一部分工作。',
-    '请先读取当前会话与工作区状态，判断哪些步骤已经完成，然后从最后一个可验证的 checkpoint 继续；',
-    '不要重复已经完成的外部副作用（例如重复提交、重复发消息、重复写文件）。',
-    '若无法安全判断已完成到哪一步，请停止并说明你看到的现场，交回人工决策。',
-    '',
-    '原任务：',
-    originalPrompt,
-  ].join('\n');
+export function buildTurnContinuePrompt(): string {
+  return '[BOTMUX_CONTINUE] 上一轮被异常中断，可能已完成了一部分。'
+    + '请确认现场后从中断处继续，不要重复已完成的操作。';
 }
 
 /** Test/introspection helpers. Copies, so callers cannot mutate the policy. */

--- a/src/services/turn-failure-notice.ts
+++ b/src/services/turn-failure-notice.ts
@@ -6,10 +6,12 @@
  *
  * 1. **Should we notify at all?** A `failed` terminal always warrants a notice.
  *    An `ambiguous` one does NOT: that bucket mixes genuine breakage the user
- *    cannot see (the CLI process died, an input write threw) with interruptions
- *    the user performed themselves (Esc → `*_turn_aborted`). Notifying on a
- *    user's own Esc would manufacture exactly the alert noise this feature
- *    exists to reduce, so proven user aborts stay silent.
+ *    cannot see (the CLI process died, an input write threw) with endings the
+ *    user already knows about — an interruption they performed themselves
+ *    (Esc, or the card's ⏹ stop button, which sends `^C`), or a turn their own
+ *    newer message superseded. Notifying on those would manufacture exactly the
+ *    alert noise this feature exists to reduce, so they stay silent. An abort
+ *    that cannot be attributed to the user still surfaces.
  *
  * 2. **May we offer retry, and with what warning?** `retryable === true` is
  *    single-sourced today (the Claude transcript classifier is its only
@@ -44,10 +46,12 @@ export type FailureNoticeStatus = 'failed' | 'ambiguous' | 'completed' | 'cancel
  *
  * Membership requires direct evidence that the code is user-initiated: each of
  * these is documented as an Esc/interrupt in its transcript adapter (see
- * `pi-transcript.ts` "user interrupt (Esc)"). Codes that merely *sound*
- * cancel-like are deliberately excluded — `provider_cancelled`, for instance,
- * can be a server-side cancellation rather than a human keypress, and today it
- * does produce a notice. Suppressing it on a guess would delete a real alert.
+ * `pi-transcript.ts` "user interrupt (Esc)").
+ *
+ * Note the deliberate ABSENCE of `structured_turn_aborted`: that is the `??`
+ * fallback in `codex-bridge-queue.ts` for an abort carrying no code of its own,
+ * so it means "unattributable", not "the user did it". Unattributable aborts
+ * must surface — that is the same rule this module applies to a missing code.
  */
 const USER_ABORT_ERROR_CODES: ReadonlySet<string> = new Set([
   'pi_turn_aborted',
@@ -56,8 +60,60 @@ const USER_ABORT_ERROR_CODES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Adapters that encode the abort REASON into the code itself
+ * (`codex_turn_aborted:user_interrupt`, `traex_turn_aborted:interrupted_by_user_unsafe`),
+ * so the code is not a fixed string and cannot be matched by set membership.
+ *
+ * These are compared against the segment BEFORE the first `:` — not with
+ * `startsWith`, which would also swallow a hypothetical sibling like
+ * `codex_turn_aborted_by_policy`. The reason suffix is deliberately ignored:
+ * every `turn_aborted` record from these two adapters is a cancellation the
+ * user drove (via Esc, or the card's own ⏹ stop button, which sends `^C`),
+ * and the suffix only names which flavour.
+ */
+const USER_ABORT_ERROR_CODE_PREFIXES: readonly string[] = [
+  'codex_turn_aborted',
+  'traex_turn_aborted',
+];
+
+/**
+ * Codes proving a NEWER input replaced this turn — not a user abort, but not
+ * something to alarm about either: the user just sent the follow-up that
+ * superseded it, and the new turn owns delivery from here.
+ *
+ * Kept apart from `USER_ABORT_ERROR_CODES` because the cause differs: nobody
+ * pressed stop. `grok-transcript.ts` states the intent directly — a `send_now`
+ * cancel maps to `ambiguous` "instead of a user-visible failed card".
+ *
+ * Only the `ambiguous` arm is affected: Grok reuses `grok_turn_cancelled` for
+ * OTHER cancellations with status `failed`, and a `failed` terminal always
+ * notifies (see below), so those keep their card.
+ */
+const SUPERSEDED_BY_NEWER_INPUT_ERROR_CODES: ReadonlySet<string> = new Set([
+  'grok_turn_cancelled',
+]);
+
+/** Whether this code marks a cancellation the user themselves caused. */
+function isUserAbortErrorCode(errorCode: string): boolean {
+  if (USER_ABORT_ERROR_CODES.has(errorCode)) return true;
+  const head = errorCode.split(':')[0];
+  return USER_ABORT_ERROR_CODE_PREFIXES.includes(head);
+}
+
+/**
  * Error codes proving the turn's input never reached the CLI. Nothing executed,
  * so re-sending duplicates no external side effect.
+ *
+ * ⚠️ The three `recovery_*` codes are deliberately NOT here. They describe the
+ * fate of an automatic CONTINUATION, but the retry button re-injects whatever
+ * `lastFailedTurn` holds — and that record is only written from `turn_terminal`,
+ * which the recovery-handoff failures never emit (`failOrdinaryImDelivery`
+ * returns straight after `requireOrdinaryTurnRecoveryAttention`; the enqueue
+ * failure only commits state and warns). So the record still points at the
+ * ORIGINAL turn, whose progress these codes say nothing about. Worse, the
+ * ladder only dispatches a continuation for `failed && retryable === true`, so
+ * the original turn is by construction a transient fault mid-work — exactly the
+ * case that must stay `caveated`.
  */
 const PRE_EXECUTION_ERROR_CODES: ReadonlySet<string> = new Set([
   'write_input_threw',
@@ -65,13 +121,6 @@ const PRE_EXECUTION_ERROR_CODES: ReadonlySet<string> = new Set([
   'raw_input_write_failed',
   'zmx_recovery_blocked_before_write',
   'terminal_bridge_unavailable',
-  // Both recovery-handoff failures are pre-execution by construction: the
-  // continuation was never accepted (enqueue) or never reached the worker
-  // (delivery, see failOrdinaryImDelivery). Note the deliberate ABSENCE of
-  // `recovery_dispatch_interrupted` — the daemon restarted mid-handoff, so the
-  // turn's execution state is genuinely unknown and must stay caveated.
-  'recovery_enqueue_failed',
-  'recovery_delivery_failed',
 ]);
 
 export interface TurnFailureNoticeInput {
@@ -82,17 +131,20 @@ export interface TurnFailureNoticeInput {
 /**
  * Whether this terminal deserves a user-visible failure notice.
  *
- * `failed` always qualifies. `ambiguous` qualifies unless it is a proven user
- * abort: `cli_exit`, `write_input_threw` and friends are invisible today (the
- * card silently returns to idle, indistinguishable from success), which is the
- * gap this predicate closes.
+ * `failed` always qualifies. `ambiguous` qualifies unless the turn ended for a
+ * reason the user already knows about: they stopped it themselves, or their own
+ * newer message superseded it. `cli_exit`, `write_input_threw` and friends are
+ * invisible today (the card silently returns to idle, indistinguishable from
+ * success), which is the gap this predicate closes.
  */
 export function shouldNotifyTurnFailure(turn: TurnFailureNoticeInput): boolean {
   if (turn.status === 'failed') return true;
   if (turn.status !== 'ambiguous') return false;
   // An abort with no code cannot be attributed to the user; surface the
   // unattributable case rather than swallowing it.
-  return turn.errorCode === undefined || !USER_ABORT_ERROR_CODES.has(turn.errorCode);
+  if (turn.errorCode === undefined) return true;
+  if (isUserAbortErrorCode(turn.errorCode)) return false;
+  return !SUPERSEDED_BY_NEWER_INPUT_ERROR_CODES.has(turn.errorCode);
 }
 
 /**
@@ -141,12 +193,16 @@ export function mayOfferTurnRetry(
  * re-teaching the model what it can already read. Verified in practice: a bare
  * "继续" is enough to get a CLI to pick up where it stopped.
  *
- * So this carries exactly the two things the transcript does NOT tell it:
+ * So this carries exactly the three things the transcript does NOT tell it:
  *  1. that the previous turn was cut off mid-flight (the transcript just ends —
- *     it cannot distinguish "interrupted" from "finished"), and
+ *     it cannot distinguish "interrupted" from "finished"),
  *  2. that work may already have landed, so completed side effects must not be
  *     repeated. This is the one instruction worth the tokens: it is the whole
- *     reason this is a continue rather than a replay.
+ *     reason this is a continue rather than a replay, and
+ *  3. that stopping to ask a human is the correct move when the checkpoint
+ *     cannot be established safely. Without this the model's only options are
+ *     to guess or to redo, and both can duplicate an external side effect —
+ *     which is the exact risk this prompt exists to bound.
  *
  * Also NOT reusing `ORDINARY_TURN_RECOVERY_PROMPT`: its first line asserts a
  * transient provider fault, which is false for the codes that land here
@@ -155,12 +211,26 @@ export function mayOfferTurnRetry(
  */
 export function buildTurnContinuePrompt(): string {
   return '[BOTMUX_CONTINUE] 上一轮被异常中断，可能已完成了一部分。'
-    + '请确认现场后从中断处继续，不要重复已完成的操作。';
+    + '请确认现场后从中断处继续，不要重复已完成的操作；'
+    + '无法安全判断则停下并请求人工决策。';
 }
 
-/** Test/introspection helpers. Copies, so callers cannot mutate the policy. */
+/** Test/introspection helpers. Copies, so callers cannot mutate the policy.
+ *
+ *  A test that iterates one of these is asserting "the members are handled
+ *  consistently" — NOT that the set is complete. Completeness has to be pinned
+ *  with literal codes taken from the producing adapter's own tests; iterating
+ *  the set under test cannot fail when a code is missing from it. */
 export function userAbortErrorCodes(): string[] {
   return [...USER_ABORT_ERROR_CODES];
+}
+
+export function userAbortErrorCodePrefixes(): string[] {
+  return [...USER_ABORT_ERROR_CODE_PREFIXES];
+}
+
+export function supersededByNewerInputErrorCodes(): string[] {
+  return [...SUPERSEDED_BY_NEWER_INPUT_ERROR_CODES];
 }
 
 export function preExecutionErrorCodes(): string[] {

--- a/src/services/turn-failure-notice.ts
+++ b/src/services/turn-failure-notice.ts
@@ -125,6 +125,40 @@ export function mayOfferTurnRetry(
   return turnRetryOffer(turn) !== 'none';
 }
 
+/**
+ * What to actually submit when the user presses the failure card's button.
+ *
+ * `safe` → re-send the original input verbatim. Nothing executed, so restating
+ * the request is the cleanest, most predictable thing we can do; asking the
+ * model to infer state would be strictly worse.
+ *
+ * `caveated` → the turn may have half-executed, so a verbatim re-send risks
+ * repeating side effects. Submit a continue instruction instead: have the model
+ * inspect the workspace and resume from the last verifiable checkpoint.
+ *
+ * Deliberately NOT reusing `ORDINARY_TURN_RECOVERY_PROMPT`: its first line
+ * asserts "上一执行因暂态 provider 故障中止", which is false for the codes that
+ * land here (`cli_exit` is a dead CLI process, not a provider fault). Telling
+ * the model a wrong cause invites it to look in the wrong place.
+ *
+ * The original task text is EMBEDDED rather than assumed to survive: after a
+ * `cli_exit` the worker forks a fresh CLI, and if transcript resume does not
+ * restore context, a bare "continue" would leave the model with nothing to
+ * continue. Including the task makes this degrade gracefully either way.
+ */
+export function buildTurnContinuePrompt(originalPrompt: string): string {
+  return [
+    '[BOTMUX_CONTINUE]',
+    '上一轮执行被异常中断（CLI 进程退出或状态不明），可能已经完成了一部分工作。',
+    '请先读取当前会话与工作区状态，判断哪些步骤已经完成，然后从最后一个可验证的 checkpoint 继续；',
+    '不要重复已经完成的外部副作用（例如重复提交、重复发消息、重复写文件）。',
+    '若无法安全判断已完成到哪一步，请停止并说明你看到的现场，交回人工决策。',
+    '',
+    '原任务：',
+    originalPrompt,
+  ].join('\n');
+}
+
 /** Test/introspection helpers. Copies, so callers cannot mutate the policy. */
 export function userAbortErrorCodes(): string[] {
   return [...USER_ABORT_ERROR_CODES];

--- a/test/card-handler-retry-turn.test.ts
+++ b/test/card-handler-retry-turn.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Unit tests for the `retry_turn` failure-card action.
+ *
+ * The safety property under test is the ONE-SHOT INTERLOCK. The pre-existing
+ * `retry_last_task` button gets that property for free: it requires
+ * `ds.usageLimit`, which is consumed (`clearUsageLimitState`) on success, so a
+ * second click finds no state and refuses. A failure card has no such
+ * throwaway state, so `retry_turn` derives the same guarantee from
+ * `lastFailedTurn.turnId`:
+ *
+ *   - the clicked card carries the turnId it was built for;
+ *   - the handler resubmits only if that id still matches the session's
+ *     current failed turn.
+ *
+ * Both directions matter and both are tested: a matching id must actually
+ * resubmit (or the button is decorative), and a non-matching / absent id must
+ * refuse (or a stale card can re-run a task whose side effects already landed).
+ *
+ * Mocked surface follows card-handler-stop-compact.test.ts.
+ *
+ * Run: npx vitest run test/card-handler-retry-turn.test.ts
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ─── Mocks (before importing the module under test) ───────────────────────
+
+vi.mock('../src/im/lark/client.js', () => ({
+  updateMessage: vi.fn(),
+  deleteMessage: vi.fn(),
+  replyMessage: vi.fn(),
+  sendMessage: vi.fn(),
+  sendUserMessage: vi.fn(),
+  sendEphemeralCard: vi.fn(async () => 'om_eph'),
+  getMessageDetail: vi.fn(),
+  isHumanOpenId: vi.fn(() => true),
+  MessageWithdrawnError: class MessageWithdrawnError extends Error {},
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code' },
+    resolvedAllowedUsers: [],
+    botName: 'testbot',
+    botOpenId: 'ou_bot',
+  })),
+  getAllBots: vi.fn(() => []),
+  getOwnerOpenId: vi.fn(() => 'ou_owner'),
+  getBotClient: vi.fn(),
+}));
+
+vi.mock('../src/services/bot-config-store.js', () => ({
+  findConfigField: vi.fn(),
+  applyConfigField: vi.fn(async () => ({ ok: true, newText: 'on' })),
+  coerceConfigValue: vi.fn(),
+  getConfigCardData: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    web: { externalHost: 'localhost' },
+    session: { dataDir: '/tmp/test-sessions' },
+    daemon: { backendType: 'pty', cliId: 'claude-code' },
+  },
+}));
+
+const updateSessionMock = vi.fn();
+vi.mock('../src/services/session-store.js', () => ({
+  registerSessionBridgeSendMarkerCleanupFence: vi.fn(),
+  cleanupSessionBridgeSendMarkers: vi.fn(),
+  cleanupSessionBridgeSendMarkersNow: vi.fn(),
+  closeSession: vi.fn(),
+  updateSession: (...a: any[]) => updateSessionMock(...a),
+  createSession: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+const sendWorkerInputMock = vi.fn(() => true);
+const forkWorkerMock = vi.fn();
+const isSessionTransferringMock = vi.fn(() => false);
+const hasProtectedOwnershipMock = vi.fn(() => false);
+
+vi.mock('../src/core/worker-pool.js', () => ({
+  forkWorker: (...a: any[]) => forkWorkerMock(...a),
+  sendWorkerInput: (...a: any[]) => sendWorkerInputMock(...a),
+  sendWorkerSessionInput: vi.fn(),
+  killWorker: vi.fn(),
+  closeSession: vi.fn(async () => ({ ok: true, outcome: 'closed', alreadyClosed: false })),
+  teardownAuthoritativePersistentBackingBeforeClose: vi.fn(),
+  scheduleCardPatch: vi.fn(),
+  parkStreamCard: vi.fn(),
+  clearUsageLimitState: vi.fn(),
+  cardUsageLimit: vi.fn(() => undefined),
+  writableTerminalLinkFor: vi.fn(() => undefined),
+  workerHasInitialized: vi.fn(() => true),
+  sessionSupportsWebTerminal: vi.fn(() => true),
+  readableTerminalUrlFor: vi.fn(() => 'https://example.com/term'),
+  resolvePrivateCardAudience: vi.fn(() => []),
+  deliverWriteLinkCard: vi.fn(),
+  deliverEphemeralOrReply: vi.fn(),
+  CARD_POSTING_SENTINEL: '__posting__',
+  requestSessionRestart: vi.fn(),
+  isSessionTransferring: (...a: any[]) => isSessionTransferringMock(...a),
+  getDaemonStreamingCardUsageSnapshot: vi.fn(() => undefined),
+  withActiveSessionKeyLock: vi.fn(async (_m: any, _k: string, action: () => any) => action()),
+  buildStreamingCardJson: vi.fn(),
+  silentIdleCardFlag: vi.fn(() => false),
+}));
+
+const rememberLastCliInputMock = vi.fn();
+vi.mock('../src/core/session-manager.js', () => ({
+  getSessionWorkingDir: vi.fn(() => '/tmp'),
+  buildNewTopicCliInput: vi.fn(() => ({ content: 'mock-prompt' })),
+  getAvailableBots: vi.fn(async () => []),
+  persistStreamCardState: vi.fn(),
+  resumeSession: vi.fn(),
+  rememberLastCliInput: (...a: any[]) => rememberLastCliInputMock(...a),
+  ensureSessionWhiteboard: vi.fn(),
+}));
+
+vi.mock('../src/core/session-mutation-guard.js', () => ({
+  hasProtectedSessionMutationOwnership: (...a: any[]) => hasProtectedOwnershipMock(...a),
+}));
+
+vi.mock('../src/im/lark/event-dispatcher.js', () => ({
+  canOperate: vi.fn(() => true),
+  canTalk: vi.fn(() => true),
+}));
+
+vi.mock('../src/core/session-activity.js', () => ({
+  publishAttentionPatch: vi.fn(),
+  publishClosedSessionPatch: vi.fn(),
+  announcePendingRepoSession: vi.fn(),
+}));
+
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  loadFrozenCards: vi.fn(() => new Map()),
+  saveFrozenCards: vi.fn(),
+}));
+
+vi.mock('../src/services/local-cli-opener.js', () => ({
+  isLocalCliOpenCapable: vi.fn(() => false),
+  isLocalCliOpenConfigured: vi.fn(() => false),
+  isLocalCliOpenReady: vi.fn(() => false),
+  isLocalCliOpenEnabled: vi.fn(() => false),
+  localCliOpenMode: vi.fn(),
+  openLocalCliInIterm: vi.fn(),
+  preflightLocalCliOpen: vi.fn(() => ({ ok: false })),
+}));
+
+vi.mock('../src/global-config.js', () => ({
+  readGlobalConfig: vi.fn(() => ({})),
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────
+
+import { handleCardAction } from '../src/im/lark/card-handler.js';
+import { canOperate } from '../src/im/lark/event-dispatcher.js';
+import { sessionKey, type DaemonSession } from '../src/core/types.js';
+import type { Session, FailedTurnRecord } from '../src/types.js';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const LARK_APP_ID = 'cli_app_1';
+const OWNER = 'ou_owner_user';
+const ROOT = 'om_root_retry';
+const SID = 'sess-retry-1';
+const TURN = 'turn-aaaaaaaa-bbbb';
+
+function makeFailedTurn(over: Partial<FailedTurnRecord> = {}): FailedTurnRecord {
+  return {
+    turnId: TURN,
+    userPrompt: 'do the thing',
+    cliInput: 'wrapped: do the thing',
+    failedAt: new Date().toISOString(),
+    errorCode: 'cli_exit',
+    status: 'ambiguous',
+    retryCount: 0,
+    ...over,
+  };
+}
+
+function makeDs(over: Partial<DaemonSession> & { sessionOverrides?: Partial<Session> } = {}): DaemonSession {
+  const { sessionOverrides, ...dsOver } = over;
+  const session: Session = {
+    sessionId: SID,
+    chatId: 'oc_chat',
+    rootMessageId: ROOT,
+    title: 'retry task',
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    scope: 'thread',
+    chatType: 'group',
+    larkAppId: LARK_APP_ID,
+    ownerOpenId: OWNER,
+    workingDir: '/tmp/proj',
+    cliId: 'claude-code',
+    lastFailedTurn: makeFailedTurn(),
+    ...sessionOverrides,
+  } as Session;
+  return {
+    session,
+    worker: { killed: false },
+    workerPort: null,
+    workerToken: null,
+    larkAppId: LARK_APP_ID,
+    chatId: session.chatId,
+    chatType: 'group',
+    scope: 'thread',
+    spawnedAt: Date.now(),
+    cliVersion: '1.0.0',
+    lastMessageAt: Date.now(),
+    hasHistory: true,
+    workingDir: session.workingDir,
+    streamCardId: 'om_stream_card',
+    displayMode: 'hidden',
+    ...dsOver,
+  } as DaemonSession;
+}
+
+/** `turnId === null` omits turn_id entirely (an old card built before the pin). */
+function actionData(turnId: string | null = TURN): any {
+  return {
+    operator: { open_id: OWNER },
+    action: {
+      value: {
+        action: 'retry_turn',
+        root_id: ROOT,
+        session_id: SID,
+        ...(turnId === null ? {} : { turn_id: turnId }),
+      },
+    },
+    context: { open_message_id: 'om_clicked' },
+  };
+}
+
+function depsWith(ds: DaemonSession | undefined) {
+  const activeSessions = new Map<string, DaemonSession>();
+  if (ds) activeSessions.set(sessionKey(ROOT, LARK_APP_ID), ds);
+  return {
+    activeSessions,
+    sessionReply: vi.fn(async () => 'om_reply'),
+    lastRepoScan: new Map(),
+  } as any;
+}
+
+beforeEach(() => {
+  sendWorkerInputMock.mockReset();
+  sendWorkerInputMock.mockReturnValue(true);
+  forkWorkerMock.mockReset();
+  updateSessionMock.mockReset();
+  rememberLastCliInputMock.mockReset();
+  isSessionTransferringMock.mockReset();
+  isSessionTransferringMock.mockReturnValue(false);
+  hasProtectedOwnershipMock.mockReset();
+  hasProtectedOwnershipMock.mockReturnValue(false);
+  vi.mocked(canOperate).mockReset();
+  vi.mocked(canOperate).mockReturnValue(true);
+});
+
+describe('retry_turn — happy path', () => {
+  it('re-injects the recorded CLI input over the live worker', async () => {
+    const ds = makeDs();
+    const res = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock).toHaveBeenCalledTimes(1);
+    // The ORIGINAL wrapped input must be resent — not the display prompt.
+    expect(sendWorkerInputMock.mock.calls[0][1]).toMatchObject({
+      content: 'wrapped: do the thing',
+    });
+    expect(res?.toast?.type).toBe('success');
+  });
+
+  it('forks a worker when the session has none alive', async () => {
+    const ds = makeDs({ worker: undefined });
+    await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(forkWorkerMock).toHaveBeenCalledTimes(1);
+    expect(sendWorkerInputMock).not.toHaveBeenCalled();
+  });
+
+  it('strips clientUserMessageId so the resubmit cannot be deduped away', async () => {
+    const ds = makeDs({
+      sessionOverrides: {
+        lastFailedTurn: makeFailedTurn({
+          codexAppInput: { clientUserMessageId: 'prior-id', items: [] } as any,
+        }),
+      },
+    });
+    await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    const sent = sendWorkerInputMock.mock.calls[0][1];
+    expect(sent.codexAppInput).toBeDefined();
+    expect(sent.codexAppInput.clientUserMessageId).toBeUndefined();
+  });
+
+  it('stamps the retry attempt and persists it', async () => {
+    const ds = makeDs();
+    await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(ds.session.lastFailedTurn?.retryCount).toBe(1);
+    expect(ds.session.lastFailedTurn?.lastRetryAt).toBeTruthy();
+    expect(updateSessionMock).toHaveBeenCalled();
+  });
+});
+
+describe('retry_turn — the one-shot interlock', () => {
+  it('refuses a click whose turnId no longer matches the session', async () => {
+    // The session failed again after this card was posted; its record now
+    // points at a different turn. Resubmitting the OLD prompt here would run
+    // work the user has already moved past.
+    const ds = makeDs({
+      sessionOverrides: { lastFailedTurn: makeFailedTurn({ turnId: 'turn-newer-one' }) },
+    });
+    const res = await handleCardAction(actionData(TURN), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock).not.toHaveBeenCalled();
+    expect(forkWorkerMock).not.toHaveBeenCalled();
+    expect(res?.toast?.content).toMatch(/过期/);
+  });
+
+  it('refuses a click that carries no turnId at all', async () => {
+    // Fail closed: an unpinned click cannot be proven to belong to this turn.
+    const ds = makeDs();
+    const res = await handleCardAction(actionData(null), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock).not.toHaveBeenCalled();
+    expect(res?.toast?.content).toMatch(/过期/);
+  });
+
+  it('blocks a second click on the same card via the cooldown', async () => {
+    // This is the double-submit case the usageLimit state used to prevent for
+    // retry_last_task. First click succeeds and stamps lastRetryAt; the second
+    // must be refused rather than running the task twice.
+    const ds = makeDs();
+    const first = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(first?.toast?.type).toBe('success');
+    expect(sendWorkerInputMock).toHaveBeenCalledTimes(1);
+
+    const second = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock).toHaveBeenCalledTimes(1); // still 1 — not resent
+    expect(second?.toast?.content).toMatch(/冷却/);
+  });
+
+  it('allows a retry again once the cooldown has elapsed', async () => {
+    // The interlock must not become a permanent lockout: a genuinely stuck
+    // session has to remain retryable.
+    const ds = makeDs({
+      sessionOverrides: {
+        lastFailedTurn: makeFailedTurn({
+          retryCount: 1,
+          lastRetryAt: new Date(Date.now() - 60_000).toISOString(),
+        }),
+      },
+    });
+    const res = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock).toHaveBeenCalledTimes(1);
+    expect(res?.toast?.type).toBe('success');
+  });
+});
+
+describe('retry_turn — refusal branches', () => {
+  it('refuses when the session has no failed-turn record', async () => {
+    const ds = makeDs({ sessionOverrides: { lastFailedTurn: undefined } });
+    const res = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock).not.toHaveBeenCalled();
+    expect(res?.toast?.content).toMatch(/找不到/);
+  });
+
+  it('refuses while a session transfer is in flight', async () => {
+    isSessionTransferringMock.mockReturnValue(true);
+    const res = await handleCardAction(actionData(), depsWith(makeDs()), LARK_APP_ID);
+    expect(sendWorkerInputMock).not.toHaveBeenCalled();
+    expect(res?.toast?.type).toBe('warning');
+  });
+
+  it('refuses to fork over a protected session backing', async () => {
+    hasProtectedOwnershipMock.mockReturnValue(true);
+    const ds = makeDs({ worker: undefined });
+    const res = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(forkWorkerMock).not.toHaveBeenCalled();
+    expect(res?.toast?.content).toMatch(/提交失败/);
+  });
+
+  it('reports a rejected submission instead of claiming success', async () => {
+    sendWorkerInputMock.mockReturnValue(false);
+    const ds = makeDs();
+    const res = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(res?.toast?.content).toMatch(/提交失败/);
+    // A rejected click must NOT burn the one-shot — the user can try again.
+    expect(ds.session.lastFailedTurn?.retryCount).toBe(0);
+    expect(ds.session.lastFailedTurn?.lastRetryAt).toBeUndefined();
+  });
+
+  it('does not burn the one-shot when submission throws', async () => {
+    sendWorkerInputMock.mockImplementation(() => { throw new Error('ipc dead'); });
+    const ds = makeDs();
+    const res = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(res?.toast?.content).toMatch(/提交失败/);
+    expect(ds.session.lastFailedTurn?.retryCount).toBe(0);
+  });
+});
+
+describe('retry_turn — permission gate', () => {
+  it('is registered as a sensitive action in the source gate', () => {
+    // Source-lock: the isSensitive allowlist is a plain string array with no
+    // type-level enforcement, so an action dropped from it silently becomes
+    // clickable by anyone in the chat. Pin membership here.
+    const src = readFileSync(resolve(__dirname, '../src/im/lark/card-handler.ts'), 'utf8');
+    const line = src.split('\n').find(l => l.includes('const isSensitive'));
+    expect(line).toBeTruthy();
+    expect(line).toContain("'retry_turn'");
+  });
+
+  it('does not resubmit when canOperate denies the operator', async () => {
+    vi.mocked(canOperate).mockReturnValue(false);
+    const ds = makeDs();
+    await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock).not.toHaveBeenCalled();
+    expect(forkWorkerMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/card-handler-retry-turn.test.ts
+++ b/test/card-handler-retry-turn.test.ts
@@ -218,7 +218,7 @@ function makeDs(over: Partial<DaemonSession> & { sessionOverrides?: Partial<Sess
 }
 
 /** `turnId === null` omits turn_id entirely (an old card built before the pin). */
-function actionData(turnId: string | null = TURN): any {
+function actionData(turnId: string | null = TURN, mode: string | null = 'resend'): any {
   return {
     operator: { open_id: OWNER },
     action: {
@@ -227,6 +227,7 @@ function actionData(turnId: string | null = TURN): any {
         root_id: ROOT,
         session_id: SID,
         ...(turnId === null ? {} : { turn_id: turnId }),
+        ...(mode === null ? {} : { mode }),
       },
     },
     context: { open_message_id: 'om_clicked' },
@@ -258,15 +259,39 @@ beforeEach(() => {
 });
 
 describe('retry_turn — happy path', () => {
-  it('re-injects the recorded CLI input over the live worker', async () => {
+  it('re-injects the recorded CLI input verbatim in resend mode', async () => {
+    // resend is only offered when the input provably never reached the CLI, so
+    // restating the request verbatim is the cleanest thing we can do.
     const ds = makeDs();
-    const res = await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    const res = await handleCardAction(actionData(TURN, 'resend'), depsWith(ds), LARK_APP_ID);
     expect(sendWorkerInputMock).toHaveBeenCalledTimes(1);
-    // The ORIGINAL wrapped input must be resent — not the display prompt.
     expect(sendWorkerInputMock.mock.calls[0][1]).toMatchObject({
       content: 'wrapped: do the thing',
     });
     expect(res?.toast?.type).toBe('success');
+  });
+
+  it('submits a checkpoint-continue instruction in continue mode', async () => {
+    // The turn may have half-executed. Replaying the original prompt verbatim
+    // would risk repeating side effects, so the CLI is asked to inspect state
+    // and resume instead.
+    const ds = makeDs();
+    const res = await handleCardAction(actionData(TURN, 'continue'), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock).toHaveBeenCalledTimes(1);
+    const sent = sendWorkerInputMock.mock.calls[0][1].content as string;
+    expect(sent).toContain('[BOTMUX_CONTINUE]');
+    expect(sent).toContain('不要重复已经完成的外部副作用');
+    // The original task must be embedded: after a cli_exit the CLI is a fresh
+    // process, so a bare "continue" could leave it with nothing to continue.
+    expect(sent).toContain('do the thing');
+    expect(res?.toast?.type).toBe('success');
+  });
+
+  it('treats a card with no mode as continue (fail-safe for older cards)', async () => {
+    // Defaulting to resend would blindly replay a possibly-executed turn.
+    const ds = makeDs();
+    await handleCardAction(actionData(TURN, null), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock.mock.calls[0][1].content).toContain('[BOTMUX_CONTINUE]');
   });
 
   it('forks a worker when the session has none alive', async () => {
@@ -276,7 +301,7 @@ describe('retry_turn — happy path', () => {
     expect(sendWorkerInputMock).not.toHaveBeenCalled();
   });
 
-  it('strips clientUserMessageId so the resubmit cannot be deduped away', async () => {
+  it('strips clientUserMessageId so a resend cannot be deduped away', async () => {
     const ds = makeDs({
       sessionOverrides: {
         lastFailedTurn: makeFailedTurn({
@@ -284,10 +309,25 @@ describe('retry_turn — happy path', () => {
         }),
       },
     });
-    await handleCardAction(actionData(), depsWith(ds), LARK_APP_ID);
+    await handleCardAction(actionData(TURN, 'resend'), depsWith(ds), LARK_APP_ID);
     const sent = sendWorkerInputMock.mock.calls[0][1];
     expect(sent.codexAppInput).toBeDefined();
     expect(sent.codexAppInput.clientUserMessageId).toBeUndefined();
+  });
+
+  it('drops the codex-app sidecar in continue mode', async () => {
+    // The sidecar describes "replay THIS structured input". A continue turn is
+    // a different instruction, so carrying it would hand the CLI a structured
+    // payload that contradicts the text.
+    const ds = makeDs({
+      sessionOverrides: {
+        lastFailedTurn: makeFailedTurn({
+          codexAppInput: { clientUserMessageId: 'prior-id', items: [] } as any,
+        }),
+      },
+    });
+    await handleCardAction(actionData(TURN, 'continue'), depsWith(ds), LARK_APP_ID);
+    expect(sendWorkerInputMock.mock.calls[0][1].codexAppInput).toBeUndefined();
   });
 
   it('stamps the retry attempt and persists it', async () => {

--- a/test/card-handler-retry-turn.test.ts
+++ b/test/card-handler-retry-turn.test.ts
@@ -271,19 +271,20 @@ describe('retry_turn — happy path', () => {
     expect(res?.toast?.type).toBe('success');
   });
 
-  it('submits a checkpoint-continue instruction in continue mode', async () => {
+  it('submits a short continue instruction in continue mode', async () => {
     // The turn may have half-executed. Replaying the original prompt verbatim
-    // would risk repeating side effects, so the CLI is asked to inspect state
-    // and resume instead.
+    // would risk repeating side effects, so the CLI is told to continue and
+    // explicitly not redo finished work.
     const ds = makeDs();
     const res = await handleCardAction(actionData(TURN, 'continue'), depsWith(ds), LARK_APP_ID);
     expect(sendWorkerInputMock).toHaveBeenCalledTimes(1);
     const sent = sendWorkerInputMock.mock.calls[0][1].content as string;
     expect(sent).toContain('[BOTMUX_CONTINUE]');
-    expect(sent).toContain('不要重复已经完成的外部副作用');
-    // The original task must be embedded: after a cli_exit the CLI is a fresh
-    // process, so a bare "continue" could leave it with nothing to continue.
-    expect(sent).toContain('do the thing');
+    expect(sent).toContain('不要重复已完成的操作');
+    // The fork resumes the transcript, so the task text is already available to
+    // the model. Re-sending it here would just burn tokens.
+    expect(sent).not.toContain('do the thing');
+    expect(sent).not.toContain('wrapped:');
     expect(res?.toast?.type).toBe('success');
   });
 

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -635,6 +635,97 @@ describe('ordinary Claude semantic recovery', () => {
     }));
   });
 
+  // The failure card must not become a SECOND notice for a failure the user can
+  // already see. Structured-bridge CLIs (codex/pi/omp/grok/traex/ebsd) post
+  // their own `final_output` card on a `failed` terminal — one that also
+  // preserves any partial answer — so this path must stay out of their way and
+  // only cover what was previously SILENT.
+  it('does not double-notify a structured CLI whose failed turn already posted a card', async () => {
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId: 'codex' }));
+    const sessionReply = vi.fn(async () => 'om_x');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs({ sessionOverrides: { cliId: 'codex' } } as any);
+    forkWorker(ds, 'codex turn', 'om_codex');
+    const worker = forkMock.mock.results.at(-1)!.value;
+
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_codex',
+      status: 'failed',
+      errorCode: 'codex_task_failed',
+    });
+    // Let the terminal handler's async work settle. No fake timers in this
+    // describe block, so yield the real microtask/macrotask queue instead.
+    await new Promise(r => setTimeout(r, 50));
+
+    const cards = vi.mocked(sessionReply).mock.calls.filter(c => c[2] === 'interactive');
+    expect(cards).toHaveLength(0);
+  });
+
+  it('posts a card for a structured CLI turn that would otherwise be silent', async () => {
+    // `ambiguous` is the gap: the bridge gate only emits its own notice for
+    // `failed`, so a dead CLI / failed input write previously produced NOTHING
+    // and looked exactly like a clean finish.
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId: 'codex' }));
+    const sessionReply = vi.fn(async () => 'om_x');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs({ sessionOverrides: { cliId: 'codex' } } as any);
+    forkWorker(ds, 'codex turn', 'om_codex2');
+    const worker = forkMock.mock.results.at(-1)!.value;
+
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_codex2',
+      status: 'ambiguous',
+      errorCode: 'cli_exit',
+    });
+
+    await vi.waitFor(() => {
+      const cards = vi.mocked(sessionReply).mock.calls.filter(c => c[2] === 'interactive');
+      expect(cards).toHaveLength(1);
+      expect(cards[0][1]).toContain('cli_exit');
+    });
+  });
+
+  it('stays silent when the user aborted the turn themselves', async () => {
+    // Esc → `*_turn_aborted`. The user already knows; a card here would be the
+    // very alert noise this feature exists to reduce.
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId: 'codex' }));
+    const sessionReply = vi.fn(async () => 'om_x');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs({ sessionOverrides: { cliId: 'codex' } } as any);
+    forkWorker(ds, 'codex turn', 'om_codex3');
+    const worker = forkMock.mock.results.at(-1)!.value;
+
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_codex3',
+      status: 'ambiguous',
+      errorCode: 'rpc_turn_aborted',
+    });
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(vi.mocked(sessionReply).mock.calls.filter(c => c[2] === 'interactive')).toHaveLength(0);
+  });
+
   it('keeps turn N as recovery owner when type-ahead N+1 is admitted', async () => {
     vi.useFakeTimers();
     vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId: 'claude-code' }));

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -38,6 +38,15 @@ vi.mock('../src/im/lark/card-builder.js', () => ({
   buildTuiPromptCard: vi.fn(() => '{"type":"tui"}'),
   buildTuiPromptResolvedCard: vi.fn(() => '{"type":"tui-resolved"}'),
   getCliDisplayName: vi.fn(() => 'Codex'),
+  // Echo the inputs the failure-notice assertions care about (error code +
+  // retry action) rather than a fixed blob, so those assertions test the
+  // delivery path instead of this stub's literal.
+  buildTurnFailedCard: vi.fn((o: any) => JSON.stringify({
+    type: 'turn-failed',
+    errorCode: o.errorCode ?? o.status,
+    retryOffer: o.retryOffer,
+    action: o.retryOffer !== 'none' && o.retryTurnId ? 'retry_turn' : undefined,
+  })),
 }));
 
 vi.mock('../src/bot-registry.js', () => ({
@@ -70,6 +79,10 @@ vi.mock('../src/bot-registry.js', () => ({
     plugins: ['demo'],
     skills: { include: ['skill:deploy'] },
   }]),
+  // The failure card resolves a human to @-mention; with no allowlisted user
+  // configured here it must degrade to "nobody to mention" rather than throw.
+  getOwnerOpenId: vi.fn(() => undefined),
+  loadKnownBotOpenIdsForApp: vi.fn(() => new Set<string>()),
 }));
 
 vi.mock('../src/config.js', () => ({
@@ -512,14 +525,20 @@ describe('ordinary Claude semantic recovery', () => {
     await Promise.resolve();
 
     expect(sessionReply).toHaveBeenCalledTimes(1);
+    // The recovery notice is now an interactive failure card rather than plain
+    // text. This fixture never recorded a lastFailedTurn (no onTurnTerminal
+    // callback is wired here), so the card correctly offers NO retry button —
+    // there is no input to re-send. The raw error code must still be visible:
+    // it is the only thing distinguishing a real provider fault from the
+    // unconditional "cannot retry safely" fallback wording.
     expect(sessionReply).toHaveBeenCalledWith(
       'om_root',
-      expect.stringContaining('自动续跑 2 次'),
-      'text',
+      expect.stringContaining('provider_unexpected_eof'),
+      'interactive',
       'app_test',
       'om_original',
     );
-    expect(ds.agentAttention).toEqual(expect.objectContaining({
+    expect(vi.mocked(sessionReply).mock.calls[0][1]).not.toContain('retry_turn');    expect(ds.agentAttention).toEqual(expect.objectContaining({
       kind: 'blocked',
       reason: expect.stringContaining('自动续跑 2 次'),
     }));
@@ -597,10 +616,14 @@ describe('ordinary Claude semantic recovery', () => {
       retryable: true,
     });
 
+    // Adopt sessions have no recovery consumer, so this failure now surfaces as
+    // the interactive failure card. The raw error code stays visible in the
+    // card body — it is the only thing distinguishing a real provider fault
+    // from the unconditional "cannot retry safely" fallback wording.
     await vi.waitFor(() => expect(sessionReply).toHaveBeenCalledWith(
       'om_root',
       expect.stringContaining('provider_unexpected_eof'),
-      'text',
+      'interactive',
       'app_test',
       'om_adopted',
       undefined,
@@ -943,10 +966,13 @@ describe('ordinary Claude semantic recovery', () => {
         && message?.turnId?.startsWith('bmx-recovery-'));
     expect(recoverySends).toHaveLength(2);
     expect(sessionReply).toHaveBeenCalledTimes(1);
+    // Now an interactive failure card. `recovery_delivery_failed` is a
+    // pre-execution code (the continuation never reached the worker), so this
+    // card offers retry as provably safe.
     expect(sessionReply).toHaveBeenCalledWith(
       'om_root',
-      expect.stringContaining('未能送达 Worker'),
-      'text',
+      expect.stringContaining('recovery_delivery_failed'),
+      'interactive',
       'app_test',
       'om_original',
     );

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -700,8 +700,12 @@ describe('ordinary Claude semantic recovery', () => {
   });
 
   it('stays silent when the user aborted the turn themselves', async () => {
-    // Esc → `*_turn_aborted`. The user already knows; a card here would be the
-    // very alert noise this feature exists to reduce.
+    // Esc, or the card's own ⏹ stop button (which sends ^C). The user already
+    // knows; a card here would be the very alert noise this feature reduces.
+    //
+    // The code is the one a REAL codex session produces — reason-suffixed, per
+    // codex-transcript.ts. A fixed code from another adapter would pass while
+    // this session's actual abort code sailed through to a card.
     vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId: 'codex' }));
     const sessionReply = vi.fn(async () => 'om_x');
     initWorkerPool({
@@ -719,7 +723,7 @@ describe('ordinary Claude semantic recovery', () => {
       sessionId: ds.session.sessionId,
       turnId: 'om_codex3',
       status: 'ambiguous',
-      errorCode: 'rpc_turn_aborted',
+      errorCode: 'codex_turn_aborted:user_interrupt',
     });
     await new Promise(r => setTimeout(r, 50));
 
@@ -1057,9 +1061,10 @@ describe('ordinary Claude semantic recovery', () => {
         && message?.turnId?.startsWith('bmx-recovery-'));
     expect(recoverySends).toHaveLength(2);
     expect(sessionReply).toHaveBeenCalledTimes(1);
-    // Now an interactive failure card. `recovery_delivery_failed` is a
-    // pre-execution code (the continuation never reached the worker), so this
-    // card offers retry as provably safe.
+    // Now an interactive failure card. `recovery_delivery_failed` describes the
+    // CONTINUATION's fate, not the original turn's — and the button re-injects
+    // `lastFailedTurn`, which still points at the original turn (this path
+    // emits no turn_terminal). So the card must NOT advertise a safe resend.
     expect(sessionReply).toHaveBeenCalledWith(
       'om_root',
       expect.stringContaining('recovery_delivery_failed'),
@@ -1067,6 +1072,13 @@ describe('ordinary Claude semantic recovery', () => {
       'app_test',
       'om_original',
     );
+    // The builder is stubbed in this suite, so assert on the policy decision it
+    // was handed: `caveated`, never `safe`. A safe offer here would render a
+    // verbatim-resend button for a turn whose progress is unknown.
+    const recoveryCard = JSON.parse(
+      vi.mocked(sessionReply).mock.calls.find(c => c[2] === 'interactive')![1] as string,
+    );
+    expect(recoveryCard.retryOffer).toBe('caveated');
     expect(ds.session.ordinaryTurnRecovery).toEqual(expect.objectContaining({
       status: 'attention_required',
       lastErrorCode: 'recovery_delivery_failed',

--- a/test/turn-failure-card.test.ts
+++ b/test/turn-failure-card.test.ts
@@ -23,6 +23,8 @@ import {
   turnRetryOffer,
   mayOfferTurnRetry,
   userAbortErrorCodes,
+  userAbortErrorCodePrefixes,
+  supersededByNewerInputErrorCodes,
   preExecutionErrorCodes,
   buildTurnContinuePrompt,
 } from '../src/services/turn-failure-notice.js';
@@ -60,11 +62,64 @@ describe('shouldNotifyTurnFailure', () => {
   });
 
   it('stays silent on a user-initiated abort', () => {
-    // The user pressed Esc. They know. A card here would be pure noise — and
-    // noise is the thing this feature is meant to reduce.
-    for (const errorCode of userAbortErrorCodes()) {
+    // The user pressed Esc (or the card's ⏹ stop button, which sends ^C). They
+    // know. A card here would be pure noise — the thing this feature reduces.
+    //
+    // LITERALS, not `userAbortErrorCodes()`. Iterating the set under test only
+    // proves its members are handled consistently; it cannot fail when a code
+    // is MISSING from it. Each literal below is copied from the producing
+    // adapter's own test, so this goes red if an adapter's real code stops
+    // being matched. That is exactly the gap that shipped: the two `:`-suffixed
+    // codes could never match an exact-match Set.
+    for (const errorCode of [
+      'pi_turn_aborted',                              // pi-transcript.test.ts
+      'omp_turn_aborted',                             // omp-transcript.test.ts
+      'rpc_turn_aborted',                             // vc-meeting-delivery-receiver.test.ts
+      'codex_turn_aborted:user_interrupt',            // codex-transcript.test.ts:677
+      'traex_turn_aborted:interrupted_by_user_unsafe', // traex-transcript.test.ts:430
+    ]) {
       expect(shouldNotifyTurnFailure({ status: 'ambiguous', errorCode })).toBe(false);
+      expect(turnRetryOffer({ status: 'ambiguous', errorCode })).toBe('none');
     }
+  });
+
+  it('matches a reason-suffixed abort on its prefix, not by startsWith', () => {
+    // The reason is free text normalised into the code, so the suffix cannot be
+    // enumerated — only the segment before `:` is stable. `startsWith` would be
+    // too loose: it would also swallow a sibling code that merely shares the
+    // stem, which is a different terminal we have no evidence about.
+    for (const prefix of userAbortErrorCodePrefixes()) {
+      expect(shouldNotifyTurnFailure({ status: 'ambiguous', errorCode: `${prefix}:anything` }))
+        .toBe(false);
+      expect(shouldNotifyTurnFailure({ status: 'ambiguous', errorCode: prefix })).toBe(false);
+      // Same stem, different code ⟹ must still surface.
+      expect(shouldNotifyTurnFailure({ status: 'ambiguous', errorCode: `${prefix}_by_policy` }))
+        .toBe(true);
+    }
+  });
+
+  it('stays silent when a newer input superseded the turn', () => {
+    // grok `send_now`: the user's own follow-up aborted the previous turn and
+    // the new turn owns delivery. grok-transcript.ts states the intent — this
+    // maps to ambiguous "instead of a user-visible failed card".
+    expect(shouldNotifyTurnFailure({ status: 'ambiguous', errorCode: 'grok_turn_cancelled' }))
+      .toBe(false);
+    // But Grok reuses the SAME code for other cancellations as `failed`, and a
+    // failed terminal always notifies. Suppressing that would delete a real
+    // alert, so the two arms must not collapse.
+    expect(shouldNotifyTurnFailure({ status: 'failed', errorCode: 'grok_turn_cancelled' }))
+      .toBe(true);
+  });
+
+  it('surfaces an unattributable abort rather than guessing', () => {
+    // `structured_turn_aborted` is codex-bridge-queue's `??` fallback for an
+    // abort carrying no code of its own ⟹ it means "cannot attribute", not
+    // "the user did it". Same rule as a missing code: surface, do not swallow.
+    expect(shouldNotifyTurnFailure({ status: 'ambiguous', errorCode: 'structured_turn_aborted' }))
+      .toBe(true);
+    // And it must not have been quietly filed under either silent bucket.
+    expect(userAbortErrorCodes()).not.toContain('structured_turn_aborted');
+    expect(supersededByNewerInputErrorCodes()).not.toContain('structured_turn_aborted');
   });
 
   it('notifies on an ambiguous terminal with no error code', () => {
@@ -110,19 +165,40 @@ describe('turnRetryOffer', () => {
     expect(turnRetryOffer({ status: 'failed', errorCode: 'pi_turn_error' })).toBe('caveated');
   });
 
-  it('treats both recovery-handoff failures as safe but a mid-handoff restart as caveated', () => {
-    // enqueue/delivery failures prove the continuation never ran. A daemon
-    // restart DURING the handoff proves nothing — the turn may have been
-    // executing — so it must not be advertised as safe.
-    expect(turnRetryOffer({ status: 'failed', errorCode: 'recovery_enqueue_failed' })).toBe('safe');
-    expect(turnRetryOffer({ status: 'failed', errorCode: 'recovery_delivery_failed' })).toBe('safe');
-    expect(turnRetryOffer({ status: 'failed', errorCode: 'recovery_dispatch_interrupted' }))
-      .toBe('caveated');
+  it('keeps all three recovery-handoff failures caveated', () => {
+    // None of these can be advertised as safe. They describe the fate of the
+    // automatic CONTINUATION, but the button re-injects `lastFailedTurn`, and
+    // that record is only written from `turn_terminal` — which the enqueue and
+    // delivery failures never emit. So it still points at the ORIGINAL turn,
+    // whose progress these codes say nothing about. The ladder only dispatches
+    // a continuation for `failed && retryable === true`, so that original turn
+    // is by construction a transient fault MID-WORK.
+    for (const errorCode of [
+      'recovery_enqueue_failed',
+      'recovery_delivery_failed',
+      'recovery_dispatch_interrupted',
+    ]) {
+      expect(turnRetryOffer({ status: 'failed', errorCode })).toBe('caveated');
+    }
+    // Belt and braces: none of them may sit in the pre-execution whitelist,
+    // which is what made two of them `safe`.
+    for (const errorCode of preExecutionErrorCodes()) {
+      expect(errorCode.startsWith('recovery_')).toBe(false);
+    }
   });
 
   it('never offers retry for something it would not even notify about', () => {
     expect(turnRetryOffer({ status: 'completed' })).toBe('none');
-    for (const errorCode of userAbortErrorCodes()) {
+    // Literals again — see the abort test above for why iterating the set is
+    // not enough on its own.
+    for (const errorCode of [
+      'pi_turn_aborted',
+      'omp_turn_aborted',
+      'rpc_turn_aborted',
+      'codex_turn_aborted:user_interrupt',
+      'traex_turn_aborted:interrupted_by_user_unsafe',
+      'grok_turn_cancelled',
+    ]) {
       expect(turnRetryOffer({ status: 'ambiguous', errorCode })).toBe('none');
     }
   });
@@ -147,11 +223,19 @@ describe('turnRetryOffer', () => {
     }
   });
 
-  it('the two policy whitelists do not overlap', () => {
-    // An abort code that also counted as pre-execution would make a silenced
-    // failure sprout a retry button — contradictory. Pin the disjointness.
-    const aborts = new Set(userAbortErrorCodes());
-    for (const code of preExecutionErrorCodes()) expect(aborts.has(code)).toBe(false);
+  it('the policy whitelists do not overlap', () => {
+    // A silenced code that also counted as pre-execution would make a silenced
+    // failure sprout a retry button — contradictory. Pin the disjointness
+    // across BOTH silent buckets, and across the prefix form too.
+    const silent = new Set([...userAbortErrorCodes(), ...supersededByNewerInputErrorCodes()]);
+    for (const code of preExecutionErrorCodes()) {
+      expect(silent.has(code)).toBe(false);
+      expect(userAbortErrorCodePrefixes()).not.toContain(code.split(':')[0]);
+    }
+    // The two silent buckets describe different causes and must stay distinct.
+    for (const code of supersededByNewerInputErrorCodes()) {
+      expect(userAbortErrorCodes()).not.toContain(code);
+    }
   });
 });
 
@@ -184,6 +268,17 @@ describe('buildTurnContinuePrompt', () => {
     // The other thing resume does not convey — and the entire reason this is a
     // continue rather than a verbatim replay. Worth its tokens.
     expect(buildTurnContinuePrompt()).toContain('不要重复已完成的操作');
+  });
+
+  it('tells the model to stop and ask a human when it cannot judge safely', () => {
+    // The third thing resume cannot convey, and the one that bounds the risk:
+    // without it the model's only options are to guess or to redo, and both can
+    // duplicate an external side effect. This assertion exists because the
+    // handler comment promised this clause while the prompt did not carry it —
+    // a promise in a comment that nothing pins is not a behaviour.
+    const p = buildTurnContinuePrompt();
+    expect(p).toContain('人工决策');
+    expect(p).toContain('无法安全判断');
   });
 
   it('does not claim a provider fault', () => {

--- a/test/turn-failure-card.test.ts
+++ b/test/turn-failure-card.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Unit tests for the turn-failure notice policy and the failure card it drives.
+ *
+ * Two things are being pinned here, and they are different in kind:
+ *
+ *  1. `turn-failure-notice.ts` — the POLICY. Which terminals deserve a notice,
+ *     and which of those may offer retry. This is where the user-visible
+ *     tradeoffs live (don't nag on a user's own Esc; don't silently invite a
+ *     re-run of work that may already have shipped a commit).
+ *  2. `buildTurnFailedCard` — the RENDER. Crucially, it must never advertise an
+ *     affordance the policy denied: a button that renders is a button the
+ *     handler will honour, so builder and handler read the same predicate.
+ *
+ * Run: npx vitest run test/turn-failure-card.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { buildTurnFailedCard, type TurnFailedCardOpts } from '../src/im/lark/card-builder.js';
+import {
+  shouldNotifyTurnFailure,
+  turnRetryOffer,
+  mayOfferTurnRetry,
+  userAbortErrorCodes,
+  preExecutionErrorCodes,
+} from '../src/services/turn-failure-notice.js';
+import { globalConfigPath, invalidateGlobalConfigCache } from '../src/global-config.js';
+
+let cardTestHome: string;
+beforeEach(() => {
+  cardTestHome = mkdtempSync(join(tmpdir(), 'botmux-turn-failed-'));
+  vi.stubEnv('HOME', cardTestHome);
+  mkdirSync(dirname(globalConfigPath()), { recursive: true });
+  invalidateGlobalConfigCache();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  invalidateGlobalConfigCache();
+  rmSync(cardTestHome, { recursive: true, force: true });
+});
+
+// ─── Policy: which failures get a notice ────────────────────────────────────
+
+describe('shouldNotifyTurnFailure', () => {
+  it('notifies on every failed terminal', () => {
+    expect(shouldNotifyTurnFailure({ status: 'failed' })).toBe(true);
+    expect(shouldNotifyTurnFailure({ status: 'failed', errorCode: 'pi_turn_error' })).toBe(true);
+  });
+
+  it('notifies on ambiguous terminals that the user cannot see', () => {
+    // This is the gap the feature exists to close: today these post NOTHING,
+    // so a dead CLI is indistinguishable from a clean finish.
+    for (const errorCode of ['cli_exit', 'write_input_threw', 'adopt_write_input_threw',
+      'raw_input_write_failed', 'zmx_recovery_blocked_before_write']) {
+      expect(shouldNotifyTurnFailure({ status: 'ambiguous', errorCode })).toBe(true);
+    }
+  });
+
+  it('stays silent on a user-initiated abort', () => {
+    // The user pressed Esc. They know. A card here would be pure noise — and
+    // noise is the thing this feature is meant to reduce.
+    for (const errorCode of userAbortErrorCodes()) {
+      expect(shouldNotifyTurnFailure({ status: 'ambiguous', errorCode })).toBe(false);
+    }
+  });
+
+  it('notifies on an ambiguous terminal with no error code', () => {
+    // Unattributable: cannot prove the user did it, so surface rather than swallow.
+    expect(shouldNotifyTurnFailure({ status: 'ambiguous' })).toBe(true);
+  });
+
+  it('never notifies on completed or cancelled', () => {
+    expect(shouldNotifyTurnFailure({ status: 'completed' })).toBe(false);
+    expect(shouldNotifyTurnFailure({ status: 'cancelled' })).toBe(false);
+  });
+});
+
+// ─── Policy: when may we offer retry, and how loudly ────────────────────────
+
+describe('turnRetryOffer', () => {
+  it('offers a plain retry when the input never reached the CLI', () => {
+    for (const errorCode of preExecutionErrorCodes()) {
+      expect(turnRetryOffer({ status: 'ambiguous', errorCode })).toBe('safe');
+    }
+  });
+
+  it('offers a plain retry when the CLI explicitly authorised it', () => {
+    // provider_server_error / unexpected_eof — Claude's classifier said retryable.
+    expect(turnRetryOffer({ status: 'failed', errorCode: 'provider_server_error', retryable: true }))
+      .toBe('safe');
+  });
+
+  it('refuses retry when the CLI explicitly said it cannot help', () => {
+    // Auth/permission/invalid-request: re-sending the same bytes cannot succeed.
+    for (const errorCode of ['provider_authentication_failed', 'provider_permission_denied',
+      'provider_invalid_request', 'provider_cancelled']) {
+      expect(turnRetryOffer({ status: 'failed', errorCode, retryable: false })).toBe('none');
+    }
+  });
+
+  it('caveats retry for a turn that may have already executed', () => {
+    // cli_exit is the motivating case: the CLI may have pushed a commit before
+    // dying. We still offer the button (hiding it strands the user) but the
+    // card must warn — /retry re-sends the ORIGINAL input verbatim.
+    expect(turnRetryOffer({ status: 'ambiguous', errorCode: 'cli_exit' })).toBe('caveated');
+    expect(turnRetryOffer({ status: 'failed', errorCode: 'pi_turn_error' })).toBe('caveated');
+  });
+
+  it('treats both recovery-handoff failures as safe but a mid-handoff restart as caveated', () => {
+    // enqueue/delivery failures prove the continuation never ran. A daemon
+    // restart DURING the handoff proves nothing — the turn may have been
+    // executing — so it must not be advertised as safe.
+    expect(turnRetryOffer({ status: 'failed', errorCode: 'recovery_enqueue_failed' })).toBe('safe');
+    expect(turnRetryOffer({ status: 'failed', errorCode: 'recovery_delivery_failed' })).toBe('safe');
+    expect(turnRetryOffer({ status: 'failed', errorCode: 'recovery_dispatch_interrupted' }))
+      .toBe('caveated');
+  });
+
+  it('never offers retry for something it would not even notify about', () => {
+    expect(turnRetryOffer({ status: 'completed' })).toBe('none');
+    for (const errorCode of userAbortErrorCodes()) {
+      expect(turnRetryOffer({ status: 'ambiguous', errorCode })).toBe('none');
+    }
+  });
+
+  it('explicit refusal outranks the pre-execution heuristic', () => {
+    // A code that looks pre-execution but whose CLI said "do not retry" must
+    // not be upgraded to safe by the whitelist.
+    expect(turnRetryOffer({
+      status: 'failed', errorCode: 'terminal_bridge_unavailable', retryable: false,
+    })).toBe('none');
+  });
+
+  it('mayOfferTurnRetry agrees with turnRetryOffer', () => {
+    const cases = [
+      { status: 'failed' as const, errorCode: 'cli_exit' },
+      { status: 'ambiguous' as const, errorCode: 'write_input_threw' },
+      { status: 'completed' as const },
+      { status: 'ambiguous' as const, errorCode: 'pi_turn_aborted' },
+    ];
+    for (const c of cases) {
+      expect(mayOfferTurnRetry(c)).toBe(turnRetryOffer(c) !== 'none');
+    }
+  });
+
+  it('the two policy whitelists do not overlap', () => {
+    // An abort code that also counted as pre-execution would make a silenced
+    // failure sprout a retry button — contradictory. Pin the disjointness.
+    const aborts = new Set(userAbortErrorCodes());
+    for (const code of preExecutionErrorCodes()) expect(aborts.has(code)).toBe(false);
+  });
+});
+
+// ─── Render ─────────────────────────────────────────────────────────────────
+
+const BASE: TurnFailedCardOpts = {
+  rootId: 'om_root_fail',
+  sessionId: 'sess-fail',
+  cliId: 'claude-code',
+  cliName: 'Claude',
+  status: 'failed',
+  retryOffer: 'safe',
+  retryTurnId: 'turn-abc123',
+};
+
+function build(over: Partial<TurnFailedCardOpts> = {}): any {
+  return JSON.parse(buildTurnFailedCard({ ...BASE, ...over }));
+}
+
+function actions(card: any): any[] {
+  return card.elements.find((e: any) => e.tag === 'action')?.actions ?? [];
+}
+
+function bodyText(card: any): string {
+  return card.elements.filter((e: any) => e.tag === 'markdown')
+    .map((e: any) => e.content).join('\n');
+}
+
+describe('buildTurnFailedCard', () => {
+  it('renders a retry button pinned to the failing turn', () => {
+    const btn = actions(build()).find((a: any) => a.value?.action === 'retry_turn');
+    expect(btn).toBeTruthy();
+    // The turnId pin IS the one-shot credential: without it a stale card could
+    // resubmit a turn the session has long moved past.
+    expect(btn.value.turn_id).toBe('turn-abc123');
+    expect(btn.value.session_id).toBe('sess-fail');
+    expect(btn.value.root_id).toBe('om_root_fail');
+  });
+
+  it('omits the retry button when the policy denied retry', () => {
+    const card = build({ retryOffer: 'none' });
+    expect(actions(card).find((a: any) => a.value?.action === 'retry_turn')).toBeUndefined();
+    expect(bodyText(card)).toContain('无法成功');
+  });
+
+  it('omits the retry button when there is no input to re-send', () => {
+    // buildFailedTurnRecord returns undefined for a turn that died before its
+    // prompt was wrapped — a button would 100% fail on click.
+    const card = build({ retryTurnId: undefined });
+    expect(actions(card).find((a: any) => a.value?.action === 'retry_turn')).toBeUndefined();
+    expect(bodyText(card)).toContain('没有可重发的输入');
+  });
+
+  it('warns about duplicate side effects when the retry is caveated', () => {
+    const card = build({ retryOffer: 'caveated', errorCode: 'cli_exit' });
+    const btn = actions(card).find((a: any) => a.value?.action === 'retry_turn');
+    expect(btn).toBeTruthy();
+    // A possibly-destructive action must not be the visual default.
+    expect(btn.type).toBe('default');
+    expect(bodyText(card)).toContain('可能已经执行了一部分');
+  });
+
+  it('makes a provably-safe retry the primary action', () => {
+    const btn = actions(build({ retryOffer: 'safe' }))
+      .find((a: any) => a.value?.action === 'retry_turn');
+    expect(btn.type).toBe('primary');
+    expect(bodyText(build({ retryOffer: 'safe' }))).toContain('可以安全重试');
+  });
+
+  it('shows the raw error code', () => {
+    // ordinary_recovery_non_retryable is an unconditional fallback branch, so a
+    // daemon-restart reconciliation renders as "cannot retry safely" too. The
+    // code is the only thing that distinguishes them — it must be visible.
+    expect(bodyText(build({ errorCode: 'recovery_dispatch_interrupted' })))
+      .toContain('recovery_dispatch_interrupted');
+  });
+
+  it('falls back to the status when no error code exists', () => {
+    expect(bodyText(build({ errorCode: undefined, status: 'ambiguous' })))
+      .toContain('ambiguous');
+  });
+
+  it('mentions the human in the markdown body, not the plain_text title', () => {
+    const card = build({ mentionOpenId: 'ou_human' });
+    // plainTitle() strips <at> markup, so a mention in the header is a no-op.
+    expect(JSON.stringify(card.header)).not.toContain('ou_human');
+    expect(bodyText(card)).toContain('<at id=ou_human></at>');
+  });
+
+  it('omits the mention entirely when there is nobody safe to mention', () => {
+    expect(bodyText(build({ mentionOpenId: undefined }))).not.toContain('<at');
+  });
+
+  it('escapes a task string so it cannot forge a mention', () => {
+    const card = build({ task: '<at id=ou_victim></at> pwned', mentionOpenId: undefined });
+    expect(bodyText(card)).not.toContain('<at id=ou_victim></at>');
+  });
+
+  it('escapes the error code and reason too', () => {
+    const card = build({ errorCode: '<at id=ou_x></at>', reason: '<at id=ou_y></at>' });
+    const body = bodyText(card);
+    expect(body).not.toContain('<at id=ou_x></at>');
+    expect(body).not.toContain('<at id=ou_y></at>');
+  });
+
+  it('keeps underscores in an error code readable', () => {
+    // Error codes are closed-set constants and almost all contain underscores.
+    // Markdown-escaping them surfaced visible backslashes ("recovery\_dispatch\_…"),
+    // which is why they render as inline code instead. Assert the raw code is
+    // present verbatim — a regression to escapeMd() would break this.
+    const body = bodyText(build({ errorCode: 'recovery_dispatch_interrupted' }));
+    expect(body).toContain('recovery_dispatch_interrupted');
+    expect(body).not.toContain('\\_');
+  });
+
+  it('strips mention markup from a CLI name in the header', () => {
+    const card = build({ cliName: '<at id=ou_z></at>Claude' });
+    expect(JSON.stringify(card.header)).not.toContain('ou_z');
+  });
+
+  it('softens the title for an ambiguous terminal', () => {
+    // "failed" would overclaim: we genuinely do not know whether it ran.
+    const amb = build({ status: 'ambiguous' }).header.title.content;
+    const failed = build({ status: 'failed' }).header.title.content;
+    expect(amb).not.toBe(failed);
+    expect(amb).toContain('异常中断');
+  });
+
+  it('reports the auto-continuation count when a recovery ladder gave up', () => {
+    expect(bodyText(build({ continuations: 2 }))).toContain('2');
+  });
+
+  it('omits the continuation line when no continuations ran', () => {
+    expect(bodyText(build({ continuations: 0 }))).not.toContain('已自动续跑');
+    expect(bodyText(build({ continuations: undefined }))).not.toContain('已自动续跑');
+  });
+
+  it('truncates a long task instead of pasting a whole prompt into the card', () => {
+    const body = bodyText(build({ task: 'x'.repeat(400) }));
+    expect(body).toContain('…');
+    expect(body.length).toBeLessThan(400);
+  });
+
+  it('offers the terminal button only when a URL exists', () => {
+    expect(actions(build({ terminalUrl: 'https://example.com/t' })).length).toBe(2);
+    expect(actions(build({ terminalUrl: undefined })).length).toBe(1);
+  });
+
+  it('uses a red header so a failure is scannable in a busy chat', () => {
+    expect(build().header.template).toBe('red');
+  });
+
+  it('renders valid English too', () => {
+    const card = build({ locale: 'en', retryOffer: 'caveated' });
+    const body = bodyText(card);
+    // A missing en key silently falls back to Chinese — catch that here.
+    expect(body).toMatch(/may have partially executed/i);
+    expect(card.header.title.content).toMatch(/[A-Za-z]/);
+    expect(card.header.title.content).not.toMatch(/[一-龥]/);
+  });
+});

--- a/test/turn-failure-card.test.ts
+++ b/test/turn-failure-card.test.ts
@@ -24,6 +24,7 @@ import {
   mayOfferTurnRetry,
   userAbortErrorCodes,
   preExecutionErrorCodes,
+  buildTurnContinuePrompt,
 } from '../src/services/turn-failure-notice.js';
 import { globalConfigPath, invalidateGlobalConfigCache } from '../src/global-config.js';
 
@@ -102,8 +103,9 @@ describe('turnRetryOffer', () => {
 
   it('caveats retry for a turn that may have already executed', () => {
     // cli_exit is the motivating case: the CLI may have pushed a commit before
-    // dying. We still offer the button (hiding it strands the user) but the
-    // card must warn — /retry re-sends the ORIGINAL input verbatim.
+    // dying. We still offer the button (hiding it strands the user), but the
+    // card must warn AND the action switches to checkpoint-continue rather than
+    // replaying the original input verbatim.
     expect(turnRetryOffer({ status: 'ambiguous', errorCode: 'cli_exit' })).toBe('caveated');
     expect(turnRetryOffer({ status: 'failed', errorCode: 'pi_turn_error' })).toBe('caveated');
   });
@@ -150,6 +152,42 @@ describe('turnRetryOffer', () => {
     // failure sprout a retry button — contradictory. Pin the disjointness.
     const aborts = new Set(userAbortErrorCodes());
     for (const code of preExecutionErrorCodes()) expect(aborts.has(code)).toBe(false);
+  });
+});
+
+// ─── The continue prompt ────────────────────────────────────────────────────
+
+describe('buildTurnContinuePrompt', () => {
+  it('embeds the original task so a fresh CLI has something to continue', () => {
+    // After cli_exit the worker forks a NEW CLI process. If transcript resume
+    // does not restore context, a bare "continue" leaves the model guessing.
+    const p = buildTurnContinuePrompt('deploy the staging box');
+    expect(p).toContain('deploy the staging box');
+  });
+
+  it('instructs the model to inspect state before acting', () => {
+    const p = buildTurnContinuePrompt('x');
+    expect(p).toContain('读取当前会话与工作区状态');
+  });
+
+  it('forbids repeating completed side effects', () => {
+    // This is the whole reason continue exists instead of a verbatim replay.
+    expect(buildTurnContinuePrompt('x')).toContain('不要重复已经完成的外部副作用');
+  });
+
+  it('tells the model to stop and hand back when it cannot tell', () => {
+    expect(buildTurnContinuePrompt('x')).toContain('交回人工决策');
+  });
+
+  it('does not claim a provider fault', () => {
+    // The recovery ladder's prompt asserts a transient provider failure. That
+    // is false for cli_exit (a dead process), and naming a wrong cause sends
+    // the model looking in the wrong place.
+    expect(buildTurnContinuePrompt('x')).not.toContain('provider');
+  });
+
+  it('carries a machine-recognisable marker', () => {
+    expect(buildTurnContinuePrompt('x')).toContain('[BOTMUX_CONTINUE]');
   });
 });
 
@@ -210,6 +248,29 @@ describe('buildTurnFailedCard', () => {
     // A possibly-destructive action must not be the visual default.
     expect(btn.type).toBe('default');
     expect(bodyText(card)).toContain('可能已经执行了一部分');
+  });
+
+  it('labels and tags the caveated button as continue, not retry', () => {
+    // The button must promise what the handler will actually do: inspect state
+    // and resume, NOT replay the original prompt verbatim.
+    const btn = actions(build({ retryOffer: 'caveated' }))
+      .find((a: any) => a.value?.action === 'retry_turn');
+    expect(btn.value.mode).toBe('continue');
+    expect(btn.text.content).toContain('继续');
+    expect(btn.text.content).not.toContain('重试');
+  });
+
+  it('labels and tags the safe button as a resend', () => {
+    const btn = actions(build({ retryOffer: 'safe' }))
+      .find((a: any) => a.value?.action === 'retry_turn');
+    expect(btn.value.mode).toBe('resend');
+    expect(btn.text.content).toContain('重试');
+  });
+
+  it('does not promise a verbatim replay in the caveated body text', () => {
+    // Earlier wording said retry "re-sends the original task verbatim"; that
+    // became false once caveated switched to checkpoint-continue semantics.
+    expect(bodyText(build({ retryOffer: 'caveated' }))).not.toContain('原样重发');
   });
 
   it('makes a provably-safe retry the primary action', () => {

--- a/test/turn-failure-card.test.ts
+++ b/test/turn-failure-card.test.ts
@@ -158,36 +158,43 @@ describe('turnRetryOffer', () => {
 // ─── The continue prompt ────────────────────────────────────────────────────
 
 describe('buildTurnContinuePrompt', () => {
-  it('embeds the original task so a fresh CLI has something to continue', () => {
-    // After cli_exit the worker forks a NEW CLI process. If transcript resume
-    // does not restore context, a bare "continue" leaves the model guessing.
-    const p = buildTurnContinuePrompt('deploy the staging box');
-    expect(p).toContain('deploy the staging box');
+  it('stays short: the resumed transcript already carries the task', () => {
+    // The click forks with resume (`--resume <id>`), so the model can read the
+    // original request and everything it did before dying. Restating those
+    // would spend tokens re-teaching it what it can already see; verified in
+    // practice that a bare "继续" suffices to make a CLI pick up where it
+    // stopped. Keep a hard ceiling so this cannot quietly regrow.
+    const p = buildTurnContinuePrompt();
+    expect(p.length).toBeLessThan(80);
+    expect(p.split('\n')).toHaveLength(1);
   });
 
-  it('instructs the model to inspect state before acting', () => {
-    const p = buildTurnContinuePrompt('x');
-    expect(p).toContain('读取当前会话与工作区状态');
+  it('does not restate the original task', () => {
+    // Redundant with the resumed transcript.
+    expect(buildTurnContinuePrompt()).not.toContain('原任务');
   });
 
-  it('forbids repeating completed side effects', () => {
-    // This is the whole reason continue exists instead of a verbatim replay.
-    expect(buildTurnContinuePrompt('x')).toContain('不要重复已经完成的外部副作用');
+  it('says the previous turn was cut off', () => {
+    // The transcript just ends; it cannot distinguish interrupted from
+    // finished. This is one of the two things resume does NOT convey.
+    expect(buildTurnContinuePrompt()).toContain('中断');
   });
 
-  it('tells the model to stop and hand back when it cannot tell', () => {
-    expect(buildTurnContinuePrompt('x')).toContain('交回人工决策');
+  it('forbids repeating completed work', () => {
+    // The other thing resume does not convey — and the entire reason this is a
+    // continue rather than a verbatim replay. Worth its tokens.
+    expect(buildTurnContinuePrompt()).toContain('不要重复已完成的操作');
   });
 
   it('does not claim a provider fault', () => {
     // The recovery ladder's prompt asserts a transient provider failure. That
     // is false for cli_exit (a dead process), and naming a wrong cause sends
     // the model looking in the wrong place.
-    expect(buildTurnContinuePrompt('x')).not.toContain('provider');
+    expect(buildTurnContinuePrompt()).not.toContain('provider');
   });
 
   it('carries a machine-recognisable marker', () => {
-    expect(buildTurnContinuePrompt('x')).toContain('[BOTMUX_CONTINUE]');
+    expect(buildTurnContinuePrompt()).toContain('[BOTMUX_CONTINUE]');
   });
 });
 


### PR DESCRIPTION
## 改了什么

把「一轮执行失败」的通知从纯文本升级成交互卡片（带错误码/失败时刻/任务摘要/
已自动续跑次数 + @人 + 重试按钮），并补上此前**完全静默**的一类失败。

新增 `src/services/turn-failure-notice.ts` 作为纯策略单元，把两个独立问题分开：

1. **要不要通知**：`failed` 一律通知；`ambiguous` 仅在**不是用户主动中断**时通知。
2. **能不能给重试、要不要警告**：`safe`（输入证明没送达 CLI，或 CLI 自己判了
   retryable）/ `caveated`（可能已执行一部分，卡上必须写明重跑会重复副作用）/
   `none`（CLI 明确说重发也没用）。三个 `recovery_*` 码一律 `caveated`——它们描述
   的是自动**续跑**的命运，而按钮重发的是 `lastFailedTurn`，那条记录只在
   `turn_terminal` 写、这些路径都不发 terminal，所以它仍指向**原始轮**，而续跑只在
   `failed && retryable === true` 时才派 ⟹ 原始轮按构造就是「暂态故障中途挂掉」。

## 为什么

- **`ambiguous` 终态过去一条消息都不发**（`bridge-fallback-gate.ts` 只放 `failed`），
  卡片悄悄回到「等待输入」，与「正常干完」在用户眼里完全同形。`cli_exit`（CLI 进程
  挂了）、`write_input_threw`（输入没写进去）都落在这里——而这类恰恰最该重试
  （没跑成 = 重发无副作用风险）。
- **重试能力其实早就存在但接不上**：`retry_last_task` 按钮被硬门锁在用量限额场景，
  `/retry` 斜杠命令虽已跨 CLI 通用却无从发现。
- **用户主动按 Esc 不该收到告警**：`*_turn_aborted` 明确排除，否则每次手动停任务
  都会收到一张「失败了，要重试吗」+@人，反而制造噪音。
- **`retryable` 全仓库只有 claude transcript 一处赋值**，其余 CLI 全是 `undefined`，
  所以跨 CLI 的重试入口不能依赖它；能泛化的判据是「输入有没有送达 CLI」。

## 关键设计：重试按钮的两道门

不复用 `retry_last_task`：它的 `usageLimit` 条件同时充当一次性状态（成功后
`clearUsageLimitState` 消费掉，所以连点第二次自然失效）。失败场景没有那个状态，
直接放宽渲染条件等于**拆掉防重复提交**。新按钮 `retry_turn` 改用两道**互相独立**
的门，都 fail-closed（注意**两道都不是一次性的**，`lastFailedTurn` 只写不删）：

- **turnId pin**：卡上 `turn_id` 必须与当前记录的失败轮次逐字相同 ⟹ 挡的是**历史
  卡片**（会话后来又失败过、记录被覆盖，旧卡永久失效）；
- **10s cooldown**（`markRetryAttempt` 盖 `lastRetryAt`）⟹ 挡的是**连点**。冷却过后
  同一张卡可再次提交，这是刻意的——一次重试也可能再失败；
- 提交被拒/抛错时**不起** cooldown ⟹ 用户还能立刻再试。

`retry_turn` 已加入 `card-handler.ts` 的 `isSensitive` 名单（该名单是无类型约束的
字符串数组，漏加即任何人可点），并有 source-lock 用例钉住。

## 影响面

- **公共层**：`worker-pool.ts` 两处通知 call site（recovery warn / 终态兜底）、
  `card-builder.ts`、`card-handler.ts`、i18n 中英各 17 个新 key（已验证零缺失）。
- **CLI 家族**：claude 走新建卡；结构化 CLI（codex/pi/omp/grok/traex/ebsd）的
  `failed` 仍由既有 `final_output` 卡承载（**刻意不动**，那张卡还保留半截答案，
  在此再发一张就是重复通知），本次只补它们此前静默的 `ambiguous`。
- **pi/omp 暂不给重试按钮**：其 `stopReason:'error'` 描述的是单次模型请求而非整轮，
  实测 67.6% 之后同一轮仍在继续跑；在判据修正前给重试等于放大误报。
- **不受影响**：apiOnly / Wait-Mode / async-trigger / VC receiver 路径的既有分支
  未改动（`nonLarkFailureHandled` / `managedAuxUiSuppressed` 门保留）。

## 测试验证

```
npx tsc --noEmit                                 exit 0
bun run build                                    exit 0
test/turn-failure-card.test.ts                    47 passed
test/card-handler-retry-turn.test.ts              18 passed
test/session-lifecycle-start.test.ts             155 passed
相关回归 11 文件（codex/traex/pi/omp/grok transcript、
  ordinary-turn-recovery、bridge-fallback-gate、card-builder、
  command-retry、failed-turn-retry、stop-compact）    507 passed
bun test（本 PR 的 2 个文件）                      65 pass / 0 fail
```

CI（head `b5af87add`）：vitest 腿 **1161 files / 19855 passed / 0 failed**，本 PR
的 220 条（47+18+155）在 CI 上真跑过且全过。`bun-test` 腿红属**既有问题**：master
自身 40 个失败文件，本分支 39 个是其**真子集**（失败集合 `comm` 差分：只在本分支
红的为**空**，只在 master 红的 1 个）。

变异 7/7 全红（每条修法都先证明「写错会红」）：撤掉前缀匹配（4 红）、前缀改用
`startsWith`、两个 recovery 码恢复 `safe`（2 红）、**只修 delivery 留 enqueue**、
删掉人工兜底、静默不可归因码、折叠 grok 两侧。第 4 条是专为「修了一处≠修好了
信号」设的哨兵。

自测中由用例打出并修掉一处真问题：错误码被 markdown 转义成 `a\_b\_c`（改为行内
代码，因其为闭集常量、从不携带 provider 原文）。

## 待人工验证

卡片观感与按钮点击链路需在飞书实测（未部署 live）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
