### PR TITLE
fix(pi): 用 pi 自己的轮边界判定失败，中途重试不再误报网关故障

### DIFF
--- a/src/adapters/cli/pi-turn-boundary-extension.ts
+++ b/src/adapters/cli/pi-turn-boundary-extension.ts
@@ -55,6 +55,7 @@ export interface PiTurnBoundaryEntryData {
 }
 
 interface PiTurnBoundaryExtensionApi {
+  on(event: 'session_start', handler: (event: unknown) => void): void;
   on(event: 'agent_end', handler: (event: unknown) => void): void;
   on(event: 'agent_settled', handler: (event: unknown) => void): void;
   appendEntry(customType: string, data?: unknown): void;
@@ -76,6 +77,20 @@ export function lastAssistantStopReason(event: unknown): string | undefined {
 }
 
 export default function registerBotmuxTurnBoundaryExtension(pi: PiTurnBoundaryExtensionApi): void {
+  // Announce presence before any turn can run. The reader uses the first
+  // marker as proof that boundaries are coming, and until it sees one it must
+  // fall back to weaker heuristics (releasing a held error on the next user
+  // record). Without this announcement the session's FIRST turn has no such
+  // proof, so a steer landing in that turn's retry backoff would be misread as
+  // a new turn. `lastStopReason: null` carries no verdict — it only says
+  // "the extension is live here".
+  pi.on('session_start', () => {
+    try {
+      const data: PiTurnBoundaryEntryData = { lastStopReason: null };
+      pi.appendEntry(PI_TURN_BOUNDARY_CUSTOM_TYPE, data);
+    } catch { /* see the agent_settled handler */ }
+  });
+
   // Tracks the most recent agent run. Pi emits one `agent_end` per ATTEMPT
   // (retries included) and a single `agent_settled` once the turn is really
   // over, so the value standing at settle time is the outcome that decides

--- a/src/adapters/cli/pi-turn-boundary-extension.ts
+++ b/src/adapters/cli/pi-turn-boundary-extension.ts
@@ -1,0 +1,105 @@
+/**
+ * Pi turn-boundary extension.
+ *
+ * ## Why this exists
+ *
+ * Pi is an agent-loop CLI: its `stopReason` describes ONE model request, not
+ * the user turn. When a provider request fails transiently, Pi persists an
+ * assistant record with `stopReason:"error"` and then RETRIES inside the same
+ * turn — `agent-session.ts` even strips that record from the LLM context while
+ * deliberately keeping it in the session file ("Remove error message from agent
+ * state (keep in session for history)"). So a mid-turn `error` record is a
+ * historical breadcrumb, not a verdict.
+ *
+ * Reading those records as turn terminals made Botmux post a "model gateway
+ * failure" card — and @mention a human — for turns that went on to succeed.
+ * Measured over 231 real local sessions: 229 of 339 `error` records (67.6%)
+ * were followed by the SAME turn continuing.
+ *
+ * Neither the error text nor the record shape separates the two cases (the
+ * identical "EOF wait read" string appears 34x continuing and 1x ending; the
+ * field sets are byte-identical). Only Pi itself knows, and it already says so:
+ * `agent_settled` fires exactly once, after the whole retry / compaction /
+ * queued-continuation loop drains.
+ *
+ * ## What it writes
+ *
+ * On `agent_settled` we append ONE `custom` entry to Pi's own session JSONL —
+ * the very file the Botmux bridge already tails:
+ *
+ *   {"type":"custom","customType":"botmux-turn-settled","data":{"lastStopReason":"error"}}
+ *
+ * In-band placement is the point: the entry is ordered AFTER the assistant
+ * records of the turn it closes, so the reader never has to correlate two files
+ * by timestamp or worry about cross-file write races. `lastStopReason` is the
+ * stop reason of the last assistant message of the last agent run — `"error"`
+ * means the turn really ended in failure, anything else means it recovered.
+ *
+ * Custom entries never enter LLM context (`sessionEntryToContextMessages`
+ * returns [] for them), so this cannot perturb the model.
+ *
+ * Loaded per-invocation via `--extension`, so it applies ONLY to Pi processes
+ * Botmux spawns — a Pi the user starts by hand in a terminal is unaffected.
+ */
+
+export const PI_TURN_BOUNDARY_CUSTOM_TYPE = 'botmux-turn-settled';
+
+/** Value written when the settled turn's last agent run ended in a provider
+ *  error. The reader treats exactly this value as "report the failure". */
+export const PI_TURN_BOUNDARY_STOP_REASON_ERROR = 'error';
+
+export interface PiTurnBoundaryEntryData {
+  /** Stop reason of the final assistant message in the settled turn, or null
+   *  when the run produced no assistant message at all. */
+  lastStopReason: string | null;
+}
+
+interface PiTurnBoundaryExtensionApi {
+  on(event: 'agent_end', handler: (event: unknown) => void): void;
+  on(event: 'agent_settled', handler: (event: unknown) => void): void;
+  appendEntry(customType: string, data?: unknown): void;
+}
+
+/** Last assistant message's stopReason within one agent run, or undefined when
+ *  the run carried none. Exported for direct unit testing: the event payload
+ *  shape (`messages[]`, newest last) is the part most likely to drift with Pi
+ *  versions, and it must never throw inside a lifecycle handler. */
+export function lastAssistantStopReason(event: unknown): string | undefined {
+  const messages = (event as { messages?: unknown[] } | undefined)?.messages;
+  if (!Array.isArray(messages)) return undefined;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i] as { role?: unknown; stopReason?: unknown } | undefined;
+    if (!message || typeof message !== 'object' || message.role !== 'assistant') continue;
+    return typeof message.stopReason === 'string' ? message.stopReason : undefined;
+  }
+  return undefined;
+}
+
+export default function registerBotmuxTurnBoundaryExtension(pi: PiTurnBoundaryExtensionApi): void {
+  // Tracks the most recent agent run. Pi emits one `agent_end` per ATTEMPT
+  // (retries included) and a single `agent_settled` once the turn is really
+  // over, so the value standing at settle time is the outcome that decides
+  // whether this turn failed. Reset after each settle so a later turn can
+  // never inherit a previous turn's verdict.
+  let lastStopReason: string | undefined;
+
+  pi.on('agent_end', (event) => {
+    const stopReason = lastAssistantStopReason(event);
+    // An agent run with no assistant message leaves the previous attempt's
+    // reason standing: that is the retry shape (attempt N errored, attempt N+1
+    // produced nothing yet), and forgetting it would lose the failure.
+    if (stopReason !== undefined) lastStopReason = stopReason;
+  });
+
+  pi.on('agent_settled', () => {
+    const data: PiTurnBoundaryEntryData = { lastStopReason: lastStopReason ?? null };
+    lastStopReason = undefined;
+    try {
+      pi.appendEntry(PI_TURN_BOUNDARY_CUSTOM_TYPE, data);
+    } catch {
+      // Never let bookkeeping break the user's session. A missing boundary
+      // degrades to the reader's timeout backstop, which is the same state as
+      // an extension that failed to load at all.
+    }
+  });
+}

--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -1,9 +1,25 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import { preparePiInitialPromptArg } from './pi-initial-prompt.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 
 import { delay } from '../../utils/timing.js';
+
+/** Absolute path to the turn-boundary extension handed to Pi via `--extension`.
+ *  Mirrors `pi-initial-prompt.ts`'s resolver: prefer the compiled sibling, fall
+ *  back to the TypeScript source (Pi loads .ts directly, and that is the shape
+ *  a source-tree checkout ships). Resolved lazily at spawn time, not at module
+ *  load, so constructing the adapter never touches the filesystem. */
+export function piTurnBoundaryExtensionPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const compiled = resolve(here, 'pi-turn-boundary-extension.js');
+  if (existsSync(compiled)) return compiled;
+  return resolve(here, 'pi-turn-boundary-extension.ts');
+}
 
 /** Adapter for Pi coding-agent's native TUI (`pi`).
  *
@@ -83,6 +99,13 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
 
     buildArgs({ sessionId, initialPrompt, model }) {
       const args = [
+        // Pi's `stopReason:"error"` is a PER-REQUEST failure that its agent loop
+        // retries inside the same turn, so the transcript alone cannot say when
+        // a turn really ended. This extension appends Pi's own `agent_settled`
+        // boundary into the session JSONL the bridge already reads. Loaded on
+        // every Botmux-spawned Pi (a hand-started `pi` is unaffected, since the
+        // flag lives only in the argv we build). See pi-turn-boundary-extension.ts.
+        '--extension', piTurnBoundaryExtensionPath(),
         '--session-id', sessionId,
       ];
       if (model?.trim()) args.push('--model', model.trim());

--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -9,16 +9,59 @@ import type { CliAdapter, PtyHandle } from './types.js';
 
 import { delay } from '../../utils/timing.js';
 
-/** Absolute path to the turn-boundary extension handed to Pi via `--extension`.
- *  Mirrors `pi-initial-prompt.ts`'s resolver: prefer the compiled sibling, fall
- *  back to the TypeScript source (Pi loads .ts directly, and that is the shape
- *  a source-tree checkout ships). Resolved lazily at spawn time, not at module
- *  load, so constructing the adapter never touches the filesystem. */
-export function piTurnBoundaryExtensionPath(): string {
+/** Absolute path to the turn-boundary extension handed to Pi via `--extension`,
+ *  or `undefined` when no readable copy exists on disk.
+ *
+ *  Returning `undefined` matters more than it looks: Pi treats an unloadable
+ *  `--extension` as FATAL (`Failed to load extension … Extension path does not
+ *  exist` → exit 1), so handing it a path that is not really there would take
+ *  down every Pi session rather than merely lose the boundary marker. The
+ *  caller therefore omits the flag entirely in that case and the reader falls
+ *  back to its timeout backstop — degraded, not broken.
+ *
+ *  The case is real, not theoretical: inside a `bun build --compile` binary the
+ *  module graph lives in the virtual `/$bunfs/` root, so both `__dirname`-derived
+ *  candidates resolve to paths that exist only inside this process — measured
+ *  `/$bunfs/root/pi-turn-boundary-extension.{js,ts}`, neither present on disk.
+ *  See CLAUDE.md on why a `__dirname` path must never be handed to another
+ *  process. Resolved lazily at spawn time so constructing the adapter never
+ *  touches the filesystem. */
+export function piTurnBoundaryExtensionPath(): string | undefined {
   const here = dirname(fileURLToPath(import.meta.url));
-  const compiled = resolve(here, 'pi-turn-boundary-extension.js');
-  if (existsSync(compiled)) return compiled;
-  return resolve(here, 'pi-turn-boundary-extension.ts');
+  for (const candidate of [
+    resolve(here, 'pi-turn-boundary-extension.js'),
+    resolve(here, 'pi-turn-boundary-extension.ts'),
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** Launch argv for Pi. Split out from `buildArgs` so the extension-missing
+ *  branch is reachable in a test: that branch only happens inside a compiled
+ *  binary, which no test executes, and it is the branch whose regression kills
+ *  every Pi session. Taking the resolved path as a parameter lets a test drive
+ *  BOTH sides without stubbing the filesystem. */
+export function buildPiArgs(opts: {
+  sessionId: string;
+  initialPrompt?: string;
+  model?: string;
+  turnBoundaryExtension: string | undefined;
+}): string[] {
+  const args: string[] = [];
+  // Pi's `stopReason:"error"` is a PER-REQUEST failure that its agent loop
+  // retries inside the same turn, so the transcript alone cannot say when a
+  // turn really ended. This extension appends Pi's own `agent_settled` boundary
+  // into the session JSONL the bridge already reads. Present on every
+  // Botmux-spawned Pi (a hand-started `pi` is unaffected, since the flag lives
+  // only in the argv we build). See pi-turn-boundary-extension.ts.
+  if (opts.turnBoundaryExtension) args.push('--extension', opts.turnBoundaryExtension);
+  args.push('--session-id', opts.sessionId);
+  if (opts.model?.trim()) args.push('--model', opts.model.trim());
+  // Pi's interactive mode processes positional initial messages after TUI
+  // startup, avoiding stdin races while keeping the native TUI visible.
+  if (opts.initialPrompt) args.push(opts.initialPrompt);
+  return args;
 }
 
 /** Adapter for Pi coding-agent's native TUI (`pi`).
@@ -98,21 +141,12 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
     resolvedBin: bin,
 
     buildArgs({ sessionId, initialPrompt, model }) {
-      const args = [
-        // Pi's `stopReason:"error"` is a PER-REQUEST failure that its agent loop
-        // retries inside the same turn, so the transcript alone cannot say when
-        // a turn really ended. This extension appends Pi's own `agent_settled`
-        // boundary into the session JSONL the bridge already reads. Loaded on
-        // every Botmux-spawned Pi (a hand-started `pi` is unaffected, since the
-        // flag lives only in the argv we build). See pi-turn-boundary-extension.ts.
-        '--extension', piTurnBoundaryExtensionPath(),
-        '--session-id', sessionId,
-      ];
-      if (model?.trim()) args.push('--model', model.trim());
-      // Pi's interactive mode processes positional initial messages after TUI
-      // startup, avoiding stdin races while keeping the native TUI visible.
-      if (initialPrompt) args.push(initialPrompt);
-      return args;
+      return buildPiArgs({
+        sessionId,
+        initialPrompt,
+        model,
+        turnBoundaryExtension: piTurnBoundaryExtensionPath(),
+      });
     },
 
     buildResumeCommand({ sessionId }) {

--- a/src/services/pi-transcript.ts
+++ b/src/services/pi-transcript.ts
@@ -421,13 +421,13 @@ export function drainPiTranscript(
       // One marker proves the extension is live here; from now on the marker
       // (or the backstop) resolves holds, never a bare user record. Set before
       // the branch below so the session_start announcement counts too.
-      const firstMarker = !pending.markerSeen;
       pending.markerSeen = true;
-      // The session_start announcement carries no verdict (`lastStopReason:
-      // null` on the very first marker) — it must NOT be read as "this turn
-      // settled cleanly", or it would silently drop a held error. Only a
-      // marker that actually closes a turn resolves the hold.
-      if (firstMarker && boundary.lastStopReason === undefined) continue;
+      // A declaration marker (`lastStopReason: null`, written on session_start
+      // — including EVERY resume, which re-fires session_start) carries no
+      // verdict. It must NEVER be read as "this turn settled cleanly", or a
+      // second declaration after a mid-turn crash would silently drop a held
+      // error. Only a marker that actually closes a turn resolves the hold.
+      if (boundary.lastStopReason === undefined) continue;
       if (boundary.lastStopReason === PI_TURN_BOUNDARY_STOP_REASON_ERROR) {
         events.push(...flushHeldPiError(pending, sessionId));
       } else {

--- a/src/services/pi-transcript.ts
+++ b/src/services/pi-transcript.ts
@@ -280,6 +280,11 @@ interface PiPendingTurnState {
     errorMessage?: string;
     heldSinceMs?: number;
   };
+  /** Sticky: set once ANY turn-boundary marker is seen on this transcript.
+   *  Proves the boundary extension is live for this session, after which the
+   *  marker — not a user record — owns the release decision. See the
+   *  `role === 'user'` branch for why that matters (steer). */
+  markerSeen?: boolean;
 }
 
 const piPendingTurnCache = new Map<string, PiPendingTurnState>();
@@ -413,6 +418,16 @@ export function drainPiTranscript(
     // way; anything else means Pi recovered and the held error is dropped.
     const boundary = piTurnBoundaryStopReason(obj);
     if (boundary.present) {
+      // One marker proves the extension is live here; from now on the marker
+      // (or the backstop) resolves holds, never a bare user record. Set before
+      // the branch below so the session_start announcement counts too.
+      const firstMarker = !pending.markerSeen;
+      pending.markerSeen = true;
+      // The session_start announcement carries no verdict (`lastStopReason:
+      // null` on the very first marker) — it must NOT be read as "this turn
+      // settled cleanly", or it would silently drop a held error. Only a
+      // marker that actually closes a turn resolves the hold.
+      if (firstMarker && boundary.lastStopReason === undefined) continue;
       if (boundary.lastStopReason === PI_TURN_BOUNDARY_STOP_REASON_ERROR) {
         events.push(...flushHeldPiError(pending, sessionId));
       } else {
@@ -429,19 +444,35 @@ export function drainPiTranscript(
     if (role === 'user') {
       const content = joinTextContent(obj.message.content);
       if (!content) continue;
-      // A new user record is a turn boundary in its own right: whatever was
-      // still held belonged to the PREVIOUS turn, and that turn's last word was
-      // an error — so it really did fail and must be reported before this
-      // turn's events. Without this, a failed turn the user simply retyped
-      // after would be silently swallowed when the NEXT turn's terminal
-      // cleared the hold. Measured on real transcripts: 104 error records are
-      // immediately followed by a new user record.
+      // A user record can mean two very different things, and only one of them
+      // ends the held error's turn:
       //
-      // Steered input (Pi's Message Queue pulls a mid-turn submit into the
-      // SAME turn) writes its user record at DEQUEUE time — after the tool
-      // result that unblocked it, never between an error and its retry — so
-      // this cannot mistake a steer for a turn boundary.
-      events.push(...flushHeldPiError(pending, sessionId));
+      //   • A genuinely NEW turn — the previous turn's last word was an error,
+      //     so it really did fail and must be reported before this turn's
+      //     events. Without this the failure is swallowed when the NEXT turn's
+      //     terminal clears the hold. Measured on real transcripts: 104 error
+      //     records are immediately followed by a new user record.
+      //   • A STEER — input submitted while the turn was still running. Pi's
+      //     retry entry point re-reads the steering queue at the TOP of the
+      //     loop ("Check for steering messages at start", agent-loop.ts), so a
+      //     message that lands during the retry backoff (2s/4s/8s, up to 14s
+      //     per turn) writes its user record BETWEEN the error and its retry.
+      //     Flushing there posts a failure card for a turn that then succeeds —
+      //     exactly the false alarm this whole mechanism removes.
+      //
+      // We cannot tell them apart from the user record alone. But we do not
+      // have to: when the boundary extension is loaded the marker resolves
+      // every held error on its own, so this release is pure downside there —
+      // it can only mis-fire on a steer. It earns its keep ONLY on transcripts
+      // that will never produce a marker (adopt sessions, a compiled binary,
+      // sessions predating the extension), where it is the sole timely signal
+      // and the alternative is waiting out the 300s backstop.
+      //
+      // `markerSeen` is sticky per transcript: one marker proves the extension
+      // is live for this session, and from then on the boundary owns the
+      // decision. Before the first marker we keep releasing, so a
+      // marker-less session still reports its failures promptly.
+      if (!pending.markerSeen) events.push(...flushHeldPiError(pending, sessionId));
       events.push({
         uuid: `${path}:${lineStart}`,
         timestampMs,

--- a/src/services/pi-transcript.ts
+++ b/src/services/pi-transcript.ts
@@ -69,6 +69,10 @@ import { execSync } from 'node:child_process';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { codexTaskFailureCode, safeFailureSummary } from './codex-transcript.js';
+import {
+  PI_TURN_BOUNDARY_CUSTOM_TYPE,
+  PI_TURN_BOUNDARY_STOP_REASON_ERROR,
+} from '../adapters/cli/pi-turn-boundary-extension.js';
 
 const PI_SESSIONS_ROOT = join(homedir(), '.pi', 'agent', 'sessions');
 const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -245,13 +249,135 @@ export function findPiTranscriptByPid(pid: number): { path: string; cliSessionId
   return undefined;
 }
 
-export function drainPiTranscript(path: string, fromOffset: number): PiDrainResult {
+/** How long a held error may wait for its turn-boundary marker before the
+ *  reader gives up and reports it anyway.
+ *
+ *  The marker can legitimately never arrive: Pi was SIGKILLed mid-retry, the
+ *  extension failed to load, or the session predates it. Waiting forever would
+ *  turn a real outage into silence — strictly worse than today's false alarms,
+ *  because the user would never learn the turn died. So the hold is bounded.
+ *
+ *  Sized from the real distribution: across 231 local sessions, an error record
+ *  that was followed by the same turn continuing saw the next record within
+ *  18.8s at p50, 90.3s at p95 and 165.6s at the maximum. 300s clears that
+ *  maximum with room to spare, so a recovering turn is never reported early;
+ *  a genuinely dead turn is reported late rather than never. */
+export const PI_TURN_BOUNDARY_TIMEOUT_MS = 300_000;
+
+/** Per-transcript state that must survive across drain calls: a turn's records
+ *  routinely straddle two reads (the poller fires every second, Pi appends
+ *  whenever it likes). Keyed by transcript path and bounded, mirroring
+ *  `traexPendingAgentCache`. */
+interface PiPendingTurnState {
+  /** Newest `stopReason:"error"` record of the turn currently in flight, held
+   *  until we learn whether the turn recovered or really failed.
+   *  `heldSinceMs` is the drain clock at which the hold started (set on the
+   *  first drain that observes it, not on the record's own timestamp). */
+  error?: {
+    uuid: string;
+    timestampMs: number;
+    text: string;
+    errorMessage?: string;
+    heldSinceMs?: number;
+  };
+}
+
+const piPendingTurnCache = new Map<string, PiPendingTurnState>();
+const PI_PENDING_TURN_CACHE_MAX = 512;
+
+function piPendingTurnState(path: string): PiPendingTurnState {
+  let state = piPendingTurnCache.get(path);
+  if (!state) {
+    state = {};
+    piPendingTurnCache.set(path, state);
+    if (piPendingTurnCache.size > PI_PENDING_TURN_CACHE_MAX) {
+      const oldest = piPendingTurnCache.keys().next().value;
+      if (oldest !== undefined) piPendingTurnCache.delete(oldest);
+    }
+  }
+  return state;
+}
+
+/** Drop held state for a transcript. Exported so tests can assert a clean slate
+ *  without reaching into module internals. */
+export function resetPiPendingTurnState(path?: string): void {
+  if (path === undefined) piPendingTurnCache.clear();
+  else piPendingTurnCache.delete(path);
+}
+
+/** True when a session record is the turn-boundary marker appended by
+ *  `pi-turn-boundary-extension`. Kept structural (not a cast) because the file
+ *  is written by another process and may predate the extension. */
+function piTurnBoundaryStopReason(obj: any): { present: boolean; lastStopReason?: string } {
+  if (obj?.type !== 'custom' || obj.customType !== PI_TURN_BOUNDARY_CUSTOM_TYPE) {
+    return { present: false };
+  }
+  const raw = obj.data?.lastStopReason;
+  return { present: true, lastStopReason: typeof raw === 'string' ? raw : undefined };
+}
+
+/** Turn a held error into the turn's failure event and clear the hold. The one
+ *  place that shape is built, so the three release paths (boundary marker, new
+ *  user turn, timeout backstop) cannot drift apart. Returns [] when nothing is
+ *  held, so callers can splat it unconditionally. */
+function flushHeldPiError(
+  state: PiPendingTurnState,
+  sessionId: string | undefined,
+): PiBridgeEvent[] {
+  const held = state.error;
+  if (!held) return [];
+  state.error = undefined;
+  return [{
+    uuid: held.uuid,
+    timestampMs: held.timestampMs,
+    kind: 'assistant_final',
+    text: held.text,
+    sourceSessionId: sessionId,
+    ...piTerminalOutcome('error', held.errorMessage),
+  }];
+}
+
+/** Emit a held error whose boundary marker never arrived within
+ *  `PI_TURN_BOUNDARY_TIMEOUT_MS`. Called on EVERY drain — including the
+ *  no-new-bytes early return, which is precisely the shape of the case this
+ *  guards (Pi died mid-turn, so the file stops growing and the marker will
+ *  never be written). Anchored on the drain clock rather than the record's own
+ *  timestamp so a transcript replayed from an old file cannot fire it. */
+function flushPiPendingError(
+  path: string,
+  sessionId: string | undefined,
+  nowMs: number,
+): PiBridgeEvent[] {
+  const state = piPendingTurnCache.get(path);
+  const held = state?.error;
+  if (!state || !held) return [];
+  if (held.heldSinceMs === undefined) {
+    held.heldSinceMs = nowMs;
+    return [];
+  }
+  if (nowMs - held.heldSinceMs < PI_TURN_BOUNDARY_TIMEOUT_MS) return [];
+  return flushHeldPiError(state, sessionId);
+}
+
+export function drainPiTranscript(
+  path: string,
+  fromOffset: number,
+  /** Injectable clock for the held-error timeout. Tests pass a fixed value;
+   *  production uses wall clock. */
+  nowMs: number = Date.now(),
+): PiDrainResult {
   if (!existsSync(path)) return { events: [], newOffset: 0, pendingTail: '' };
   let size: number;
   try { size = statSync(path).size; } catch { return { events: [], newOffset: fromOffset, pendingTail: '' }; }
   let start = fromOffset;
   if (size < start) start = 0;
-  if (size === start) return { events: [], newOffset: start, pendingTail: '' };
+  if (size === start) {
+    return {
+      events: flushPiPendingError(path, piSessionIdFromPath(path), nowMs),
+      newOffset: start,
+      pendingTail: '',
+    };
+  }
 
   const len = size - start;
   const buf = Buffer.alloc(len);
@@ -266,6 +392,7 @@ export function drainPiTranscript(path: string, fromOffset: number): PiDrainResu
 
   const sessionId = piSessionIdFromPath(path);
   const events: PiBridgeEvent[] = [];
+  const pending = piPendingTurnState(path);
   let cursor = start;
   for (const line of completeText.split('\n')) {
     if (line.length === 0) {
@@ -277,6 +404,23 @@ export function drainPiTranscript(path: string, fromOffset: number): PiDrainResu
 
     let obj: any;
     try { obj = JSON.parse(line); } catch { continue; }
+
+    // Turn-boundary marker (our extension). Written on Pi's `agent_settled`,
+    // i.e. once no automatic retry / compaction retry / queued continuation
+    // remains — so it is ordered AFTER every assistant record of the turn it
+    // closes. This is the ONLY place a held error becomes a user-visible
+    // failure: `lastStopReason === 'error'` means the turn really ended that
+    // way; anything else means Pi recovered and the held error is dropped.
+    const boundary = piTurnBoundaryStopReason(obj);
+    if (boundary.present) {
+      if (boundary.lastStopReason === PI_TURN_BOUNDARY_STOP_REASON_ERROR) {
+        events.push(...flushHeldPiError(pending, sessionId));
+      } else {
+        pending.error = undefined;
+      }
+      continue;
+    }
+
     if (obj?.type !== 'message' || !obj.message || typeof obj.message !== 'object') continue;
     const ts = typeof obj.timestamp === 'string' ? Date.parse(obj.timestamp) : NaN;
     const timestampMs = Number.isFinite(ts) ? ts : Date.now();
@@ -285,6 +429,19 @@ export function drainPiTranscript(path: string, fromOffset: number): PiDrainResu
     if (role === 'user') {
       const content = joinTextContent(obj.message.content);
       if (!content) continue;
+      // A new user record is a turn boundary in its own right: whatever was
+      // still held belonged to the PREVIOUS turn, and that turn's last word was
+      // an error — so it really did fail and must be reported before this
+      // turn's events. Without this, a failed turn the user simply retyped
+      // after would be silently swallowed when the NEXT turn's terminal
+      // cleared the hold. Measured on real transcripts: 104 error records are
+      // immediately followed by a new user record.
+      //
+      // Steered input (Pi's Message Queue pulls a mid-turn submit into the
+      // SAME turn) writes its user record at DEQUEUE time — after the tool
+      // result that unblocked it, never between an error and its retry — so
+      // this cannot mistake a steer for a turn boundary.
+      events.push(...flushHeldPiError(pending, sessionId));
       events.push({
         uuid: `${path}:${lineStart}`,
         timestampMs,
@@ -308,9 +465,19 @@ export function drainPiTranscript(path: string, fromOffset: number): PiDrainResu
 
     // `toolUse` (and any missing/unknown reason) is mid-turn — the model is
     // still working; wait for the terminal record.
-    //   - `error`/`aborted` are HARD terminals: Pi's agent loop does
-    //     turn_end→agent_end→return regardless of content, so they MUST emit
+    //   - `aborted` is a HARD terminal: Pi's agent loop does
+    //     turn_end→agent_end→return regardless of content, so it MUST emit
     //     even empty, or the collecting head never closes.
+    //   - `error` is NOT a turn terminal on its own. Pi is an agent loop and
+    //     `stopReason` describes ONE model request: on a transient provider
+    //     failure Pi retries inside the SAME turn (agent-session.ts strips the
+    //     record from LLM context while deliberately keeping it in the session
+    //     file). Measured over 231 real local sessions, 229/339 error records
+    //     were followed by that same turn continuing. Treating one as terminal
+    //     posted a "gateway failure" card — and @mentioned a human — for turns
+    //     that then succeeded. So an error record is HELD: it closes the turn
+    //     only once the turn-boundary marker says the turn really settled that
+    //     way (see the `custom` branch above and `flushPiPendingError`).
     //   - `stop`/`length` end the turn ONLY when the message has NO tool calls.
     //     Both can carry tool calls mid-turn: agent-loop runs the batch and
     //     keeps looping unless it terminates (`length` → failToolCallsFrom-
@@ -327,10 +494,9 @@ export function drainPiTranscript(path: string, fromOffset: number): PiDrainResu
     // the started turn keeps the session projected busy until the next
     // ordinary user turn HOL-drops the unclosed collecting head. (botmux
     // ships no such tool.)
-    const isHardTerminal = stopReason === 'error' || stopReason === 'aborted';
+    const isHardTerminal = stopReason === 'aborted';
     const isTextTerminal = (stopReason === 'stop' || stopReason === 'length')
       && !hasToolCall(obj.message.content);
-    if (!isHardTerminal && !isTextTerminal) continue;
 
     // Provider error detail (verified on pi 0.84.2: lives on `message`, next to
     // stopReason; accept a top-level fallback mirroring the stopReason read).
@@ -341,6 +507,26 @@ export function drainPiTranscript(path: string, fromOffset: number): PiDrainResu
           ? obj.errorMessage
           : undefined;
 
+    if (stopReason === 'error') {
+      // Hold the newest error of this turn. If the turn recovers, the later
+      // `stop`/`length` terminal drops it; if the turn really failed, the
+      // boundary marker flushes exactly this one as the turn's failure. Any
+      // partial text stays attached so a failed turn can still show what the
+      // model managed to say.
+      pending.error = {
+        uuid: `${path}:${lineStart}`,
+        timestampMs,
+        text: joinTextContent(obj.message.content),
+        errorMessage,
+      };
+      continue;
+    }
+
+    if (!isHardTerminal && !isTextTerminal) continue;
+
+    // A real terminal supersedes any held error: the turn moved past it.
+    pending.error = undefined;
+
     events.push({
       uuid: `${path}:${lineStart}`,
       timestampMs,
@@ -350,6 +536,10 @@ export function drainPiTranscript(path: string, fromOffset: number): PiDrainResu
       ...piTerminalOutcome(stopReason as PiTerminalStopReason, errorMessage),
     });
   }
+
+  // A held error whose boundary marker is overdue is reported anyway, so a Pi
+  // that died mid-retry still surfaces its failure instead of going silent.
+  events.push(...flushPiPendingError(path, sessionId, nowMs));
 
   return { events, newOffset, pendingTail };
 }

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { homedir, tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, appendFileSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, appendFileSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { codexHome } from '../src/services/codex-paths.js';
 
 // ---------------------------------------------------------------------------
@@ -42,7 +42,7 @@ import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
 import { createMirAdapter } from '../src/adapters/cli/mir.js';
 import { createTraexAdapter } from '../src/adapters/cli/traex.js';
-import { createPiAdapter } from '../src/adapters/cli/pi.js';
+import { createPiAdapter, buildPiArgs, piTurnBoundaryExtensionPath } from '../src/adapters/cli/pi.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 import { createOhMyPiAdapter, ompSessionDir } from '../src/adapters/cli/oh-my-pi.js';
 import { assertEbsdPerBotEnv, createEbsdAdapter, ebsdBotmuxSessionDir } from '../src/adapters/cli/ebsd.js';
@@ -1215,6 +1215,24 @@ describe('pi buildArgs', () => {
     // Absolute: Pi resolves a relative --extension against ITS cwd, which is
     // the user's workspace, not ours.
     expect(isAbsolute(args[flagIdx + 1])).toBe(true);
+    // …and the path must really be there. Pi treats an unloadable extension as
+    // FATAL (exit 1), so a path we cannot back with a file would kill every Pi
+    // session instead of merely losing the marker.
+    expect(existsSync(args[flagIdx + 1])).toBe(true);
+  });
+
+  it('omits --extension rather than handing Pi a path that does not exist', () => {
+    // The compiled binary is the real case: its module graph lives in the
+    // virtual `/$bunfs/` root, so both `__dirname`-derived candidates resolve
+    // to paths that exist only inside that process. Measured directly against
+    // Pi 0.84.4: a missing `--extension` target aborts startup with
+    // `Failed to load extension … Extension path does not exist` and exit 1.
+    // Losing the boundary marker costs the reader's timeout backstop; a dead
+    // Pi costs the whole session — so this must fail OPEN.
+    expect(piTurnBoundaryExtensionPath()).toBeTruthy();
+    const args = buildPiArgs({ sessionId: 'sess-pi', turnBoundaryExtension: undefined });
+    expect(args).not.toContain('--extension');
+    expect(args).toEqual(['--session-id', 'sess-pi']);
   });
 
   it('pins the configured model instead of inheriting Pi defaults', () => {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { homedir, tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, appendFileSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { codexHome } from '../src/services/codex-paths.js';
 
@@ -1200,16 +1200,37 @@ describe('pi buildArgs', () => {
     expect(adapter.altScreen).toBe(true);
   });
 
+  it('loads the turn-boundary extension on every spawn so mid-turn retries are not read as failures', () => {
+    // Pi's `stopReason:"error"` is per-REQUEST and its loop retries inside the
+    // same turn, so the transcript alone cannot say when a turn ended. The
+    // reader depends on the boundary marker this extension appends — if the
+    // flag stops being passed, `pi-transcript` silently falls back to its
+    // timeout backstop and every transient blip becomes a late failure card.
+    // Asserted here (not only in the reader's own tests) because the policy
+    // being right is worthless if the wiring that feeds it is missing.
+    const args = adapter.buildArgs({ sessionId: 'sess-pi', resume: false });
+    const flagIdx = args.indexOf('--extension');
+    expect(flagIdx).toBeGreaterThanOrEqual(0);
+    expect(args[flagIdx + 1]).toMatch(/pi-turn-boundary-extension\.(?:js|ts)$/);
+    // Absolute: Pi resolves a relative --extension against ITS cwd, which is
+    // the user's workspace, not ours.
+    expect(isAbsolute(args[flagIdx + 1])).toBe(true);
+  });
+
   it('pins the configured model instead of inheriting Pi defaults', () => {
     const args = adapter.buildArgs({
       sessionId: 'sess-pi',
       resume: false,
       model: 'custom/long-context-model',
     });
-    expect(args).toEqual([
+    // Exact argv, minus the extension pair asserted by its own case above:
+    // keeps this case about the model flag while still proving nothing else
+    // crept into the launch line.
+    expect(args.slice(2)).toEqual([
       '--session-id', 'sess-pi',
       '--model', 'custom/long-context-model',
     ]);
+    expect(args[0]).toBe('--extension');
   });
 });
 

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -155,7 +155,11 @@ describe('initial prompt argv byte-limit fallback', () => {
       expect(prepared.initialPrompt).toMatch(/^@.+\.prompt\.md$/);
       expect(readFileSync(prepared.cleanupPaths![0]!, 'utf-8')).toBe(prompt);
       expect(deferInitialPrompt).toBe(false);
-      expect(args).toEqual(['--session-id', 'sess-pi-long', prepared.initialPrompt]);
+      // The turn-boundary extension leads every Pi launch line (see
+      // `pi buildArgs` in cli-adapters.test.ts); this case is about the @file
+      // prompt, so assert the rest exactly.
+      expect(args.slice(0, 1)).toEqual(['--extension']);
+      expect(args.slice(2)).toEqual(['--session-id', 'sess-pi-long', prepared.initialPrompt]);
       expect(args).not.toContain(prompt);
       expect(shouldQueue).toBe(false);
     } finally {

--- a/test/pi-initial-prompt.test.ts
+++ b/test/pi-initial-prompt.test.ts
@@ -107,7 +107,10 @@ describe('Pi initial prompt @file delivery', () => {
         sessionId: 'sess-long-adapter',
         initialPrompt: adapterPrepared.initialPrompt,
       });
-      expect(args).toEqual(['--session-id', 'sess-long-adapter', adapterPrepared.initialPrompt]);
+      // The turn-boundary extension leads every Pi launch line (asserted in
+      // `pi buildArgs`); the @file prompt still lands last.
+      expect(args[0]).toBe('--extension');
+      expect(args.slice(2)).toEqual(['--session-id', 'sess-long-adapter', adapterPrepared.initialPrompt]);
 
       expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(PI_INITIAL_PROMPT_ARG_BYTE_LIMIT);
       expect(Buffer.byteLength(adapterPrepared.initialPrompt, 'utf8')).toBeLessThan(prompt.length);

--- a/test/pi-transcript.test.ts
+++ b/test/pi-transcript.test.ts
@@ -333,6 +333,68 @@ describe('drainPiTranscript: turn terminal contract', () => {
     expect(fails[0].terminalErrorCode).toBe('codex_upstream_error');
   });
 
+  // ── Steer during retry backoff (found in review) ──────────────────────────
+  //
+  // Pi's retry entry re-reads the steering queue at the TOP of the loop
+  // ("Check for steering messages at start", agent-loop.ts), so input that
+  // lands during the 2s/4s/8s backoff writes its user record BETWEEN the error
+  // and its retry. Releasing a held error there posts a failure card for a turn
+  // that then succeeds — the exact false alarm this mechanism exists to remove.
+  // Botmux runs Pi with supportsTypeAhead, so this is a live path.
+
+  it('does not report a failure when a steer lands between an error and its retry', () => {
+    const path = writeTranscript([
+      sessionHeader(),
+      turnSettled(null, '2026-08-03T05:13:30.000Z'),   // session_start announce
+      userMsg('原始问题'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      userMsg('补一句（steer，落在 backoff 期间）', '2026-08-03T05:14:03.000Z'),
+      assistantFinal('stop', 'ANSWER', '2026-08-03T05:14:06.000Z'),
+      turnSettled('stop'),
+    ]);
+    const events = drainAll(path);
+    const finals = events.filter((e) => e.kind === 'assistant_final');
+    expect(finals).toHaveLength(1);
+    expect(finals[0].text).toBe('ANSWER');
+    expect(events.filter((e) => e.terminalStatus === 'failed')).toHaveLength(0);
+  });
+
+  it('still reports a first-turn failure even though the announce marker carries no verdict', () => {
+    // The session_start announcement uses lastStopReason:null purely to say
+    // "the extension is live". It must never be mistaken for "this turn ended
+    // cleanly", or a held error would be silently dropped.
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('原始问题'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      turnSettled(null, '2026-08-03T05:14:02.000Z'),   // announce arrives late
+      turnSettled('error', '2026-08-03T05:14:03.000Z'),
+    ]);
+    const fails = drainAll(path).filter((e) => e.terminalStatus === 'failed');
+    expect(fails).toHaveLength(1);
+    expect(fails[0].terminalErrorCode).toBe('codex_upstream_error');
+  });
+
+  it('without any marker, a failed turn the user simply retyped after is still reported', () => {
+    // Marker-less transcripts (adopt, compiled binary, sessions predating the
+    // extension) have no boundary to resolve the hold, and the NEXT turn's
+    // terminal would clear it — so the user record must still release. Measured
+    // on real transcripts: 104 error records are immediately followed by a new
+    // user record. Gating this on a marker silently swallowed 109 of 120 real
+    // failures when first attempted.
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('第一个问题'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      userMsg('（放弃，重新问）', '2026-08-03T05:20:00.000Z'),
+      assistantFinal('stop', 'ANSWER', '2026-08-03T05:20:10.000Z'),
+    ]);
+    const events = drainAll(path);
+    const fails = events.filter((e) => e.terminalStatus === 'failed');
+    expect(fails).toHaveLength(1);
+    expect(events.some((e) => e.text === 'ANSWER')).toBe(true);
+  });
+
   it('emits assistant_final on stopReason:length as a completed (truncated) answer', () => {
     const path = writeTranscript([
       sessionHeader(),

--- a/test/pi-transcript.test.ts
+++ b/test/pi-transcript.test.ts
@@ -395,6 +395,30 @@ describe('drainPiTranscript: turn terminal contract', () => {
     expect(events.some((e) => e.text === 'ANSWER')).toBe(true);
   });
 
+  it('a SECOND declaration marker (resume re-fires session_start) does not swallow a held failure', () => {
+    // `session_start` fires on every Pi start, resume included, so declaration
+    // markers are not unique. Guarding only the FIRST one let a later
+    // declaration fall through to the "turn settled cleanly" branch and drop
+    // the hold — turning "pi died mid-turn, then botmux resumed it" into a
+    // silently lost failure. Reported in review after the first-declaration-only
+    // guard shipped; verified against this exact shape.
+    const path = writeTranscript([
+      sessionHeader(),
+      turnSettled(null, '2026-08-03T05:13:30.000Z'),   // announce (first start)
+      userMsg('原始问题'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      turnSettled(null, '2026-08-03T05:14:30.000Z'),   // announce again (resume)
+    ]);
+    const t0 = 6_000_000;
+    const first = drainPiTranscript(path, 0, t0);
+    expect(first.events.filter((e) => e.terminalStatus === 'failed')).toHaveLength(0);
+    // The hold must survive the second declaration and still reach the backstop.
+    const late = drainPiTranscript(path, first.newOffset, t0 + PI_TURN_BOUNDARY_TIMEOUT_MS);
+    const fails = late.events.filter((e) => e.terminalStatus === 'failed');
+    expect(fails).toHaveLength(1);
+    expect(fails[0].terminalErrorCode).toBe('codex_upstream_error');
+  });
+
   it('emits assistant_final on stopReason:length as a completed (truncated) answer', () => {
     const path = writeTranscript([
       sessionHeader(),

--- a/test/pi-transcript.test.ts
+++ b/test/pi-transcript.test.ts
@@ -12,10 +12,11 @@
  *     tools → user2 → single assistant_final).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, appendFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { drainPiTranscript, type PiBridgeEvent } from '../src/services/pi-transcript.js';
+import { drainPiTranscript, resetPiPendingTurnState, PI_TURN_BOUNDARY_TIMEOUT_MS, type PiBridgeEvent } from '../src/services/pi-transcript.js';
+import { PI_TURN_BOUNDARY_CUSTOM_TYPE } from '../src/adapters/cli/pi-turn-boundary-extension.js';
 
 const ROOT = join(tmpdir(), `botmux-pi-transcript-test-${process.pid}`);
 const SESSION_ID = 'eef935b5-4201-4e59-8bc7-06f03aa3388c';
@@ -63,13 +64,22 @@ function assistantTerminalWithTool(stopReason: string, ts = '2026-08-03T05:13:50
   };
 }
 
+/** Turn-boundary marker written by pi-turn-boundary-extension on agent_settled.
+ *  `lastStopReason` is the final assistant stopReason of the settled turn. */
+function turnSettled(lastStopReason: string | null, ts = '2026-08-03T05:14:06.000Z') {
+  return { type: 'custom', timestamp: ts, customType: PI_TURN_BOUNDARY_CUSTOM_TYPE, data: { lastStopReason } };
+}
+
 function drainAll(path: string): PiBridgeEvent[] {
   return drainPiTranscript(path, 0).events;
 }
 
 describe('drainPiTranscript: turn terminal contract', () => {
-  beforeEach(() => { rmSync(ROOT, { recursive: true, force: true }); });
-  afterEach(() => { rmSync(ROOT, { recursive: true, force: true }); });
+  // Held-error state is keyed by transcript path and every case here reuses the
+  // same path, so it must be cleared or one case's held error leaks into the
+  // next and silently changes what is being asserted.
+  beforeEach(() => { rmSync(ROOT, { recursive: true, force: true }); resetPiPendingTurnState(); });
+  afterEach(() => { rmSync(ROOT, { recursive: true, force: true }); resetPiPendingTurnState(); });
 
   it('emits user + a single assistant_final on stopReason:stop (normal turn)', () => {
     const path = writeTranscript([
@@ -124,14 +134,16 @@ describe('drainPiTranscript: turn terminal contract', () => {
     expect(finals[0].terminalErrorCode).toBe('pi_turn_aborted');
   });
 
-  it('classifies a stopReason:error record via its errorMessage → failed/codex_upstream_error + redacted summary (model-gateway outage)', () => {
+  it('classifies a settled-as-error turn via its errorMessage → failed/codex_upstream_error + redacted summary (model-gateway outage)', () => {
     // Real captured shape (pi 0.84.2, live incident): the model gateway
-    // cancelled the stream mid-turn; errorMessage sits on `message`.
+    // cancelled the stream mid-turn; errorMessage sits on `message`. The
+    // boundary marker says the turn really ended that way, so it is reported.
     const path = writeTranscript([
       sessionHeader(),
       userMsg('trigger a backend error'),
       assistantFinal('error', '', '2026-08-03T05:14:05.000Z',
         'upstream stream error: rpc error: code = 1 desc = Cancelled by backend [biz error]'),
+      turnSettled('error'),
     ]);
     const finals = drainAll(path).filter((e) => e.kind === 'assistant_final');
     expect(finals).toHaveLength(1);
@@ -142,17 +154,146 @@ describe('drainPiTranscript: turn terminal contract', () => {
     expect(finals[0].terminalErrorSummary).toContain('Cancelled by backend');
   });
 
-  it('keeps failed/pi_turn_error (no summary) when the error record has NO errorMessage', () => {
+  it('keeps failed/pi_turn_error (no summary) when the settled-as-error record has NO errorMessage', () => {
     const path = writeTranscript([
       sessionHeader(),
       userMsg('trigger a backend error'),
       assistantFinal('error', '', '2026-08-03T05:14:05.000Z'),
+      turnSettled('error'),
     ]);
     const finals = drainAll(path).filter((e) => e.kind === 'assistant_final');
     expect(finals).toHaveLength(1);
     expect(finals[0].terminalStatus).toBe('failed');
     expect(finals[0].terminalErrorCode).toBe('pi_turn_error');
     expect(finals[0].terminalErrorSummary).toBeUndefined();
+  });
+
+  // ── The regression this whole mechanism exists for ────────────────────────
+  //
+  // Pi retries a transient provider failure INSIDE the same turn. Reading the
+  // error record as a terminal posted a gateway-failure card (and @mentioned a
+  // human) for a turn that then succeeded. Measured on 231 real sessions:
+  // 229/339 error records were followed by that same turn continuing.
+
+  it('does NOT emit a failure when a mid-turn error is followed by a successful answer', () => {
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('say PROBE_OK'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      assistantFinal('error', '', '2026-08-03T05:14:02.000Z', 'upstream stream error: service unavailable'),
+      assistantFinal('stop', 'PROBE_OK', '2026-08-03T05:14:03.000Z'),
+      turnSettled('stop'),
+    ]);
+    const finals = drainAll(path).filter((e) => e.kind === 'assistant_final');
+    // Exactly one final, and it is the ANSWER — not a failure card, and not
+    // one card per failed request attempt.
+    expect(finals).toHaveLength(1);
+    expect(finals[0].text).toBe('PROBE_OK');
+    expect(finals[0].terminalStatus).toBeUndefined();
+    expect(finals[0].terminalErrorCode).toBeUndefined();
+  });
+
+  it('reports only ONE failure for a turn whose every attempt errored', () => {
+    // Retry exhausted: 3 error records, one settled-as-error boundary. The user
+    // must be told once, not three times.
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('say PROBE_OK'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      assistantFinal('error', '', '2026-08-03T05:14:02.000Z', 'upstream stream error: service unavailable'),
+      assistantFinal('error', '', '2026-08-03T05:14:03.000Z', 'upstream stream error: service unavailable'),
+      turnSettled('error'),
+    ]);
+    const finals = drainAll(path).filter((e) => e.kind === 'assistant_final');
+    expect(finals).toHaveLength(1);
+    expect(finals[0].terminalStatus).toBe('failed');
+    // The newest attempt's detail is the one reported.
+    expect(finals[0].timestampMs).toBe(Date.parse('2026-08-03T05:14:03.000Z'));
+  });
+
+  it('holds an error across drains and resolves it on the LATER boundary (records straddle two reads)', () => {
+    // The poller reads whatever is on disk; a turn's records routinely span
+    // several drains. A held error must survive the gap.
+    const dir = join(ROOT, '--tmp-pi-probe--');
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `2026-08-03T05-13-01-270Z_${SESSION_ID}.jsonl`);
+    const head = [sessionHeader(), userMsg('say PROBE_OK'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable')];
+    writeFileSync(path, head.map((o) => JSON.stringify(o)).join('\n') + '\n');
+
+    const first = drainPiTranscript(path, 0);
+    expect(first.events.filter((e) => e.kind === 'assistant_final')).toHaveLength(0);
+
+    appendFileSync(path, [assistantFinal('stop', 'PROBE_OK', '2026-08-03T05:14:03.000Z'), turnSettled('stop')]
+      .map((o) => JSON.stringify(o)).join('\n') + '\n');
+    const second = drainPiTranscript(path, first.newOffset);
+    const finals = second.events.filter((e) => e.kind === 'assistant_final');
+    expect(finals).toHaveLength(1);
+    expect(finals[0].text).toBe('PROBE_OK');
+    expect(finals[0].terminalStatus).toBeUndefined();
+  });
+
+  it('reports a held error once the boundary is overdue, so a Pi killed mid-retry is not silent', () => {
+    // No boundary will ever arrive (Pi was SIGKILLed). Waiting forever would
+    // turn a real outage into silence — worse than the false alarm this change
+    // removes. The timeout is anchored on the drain clock.
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('say PROBE_OK'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+    ]);
+    const t0 = 1_000_000;
+    const first = drainPiTranscript(path, 0, t0);
+    expect(first.events.filter((e) => e.kind === 'assistant_final')).toHaveLength(0);
+
+    // Still within the window: nothing yet (and no new bytes on disk).
+    const early = drainPiTranscript(path, first.newOffset, t0 + PI_TURN_BOUNDARY_TIMEOUT_MS - 1);
+    expect(early.events).toHaveLength(0);
+
+    // Overdue → the failure surfaces even though the file never grew again.
+    const late = drainPiTranscript(path, first.newOffset, t0 + PI_TURN_BOUNDARY_TIMEOUT_MS);
+    const finals = late.events.filter((e) => e.kind === 'assistant_final');
+    expect(finals).toHaveLength(1);
+    expect(finals[0].terminalStatus).toBe('failed');
+    expect(finals[0].terminalErrorCode).toBe('codex_upstream_error');
+
+    // …and only once: the held state is cleared, not re-reported every drain.
+    const after = drainPiTranscript(path, late.newOffset, t0 + PI_TURN_BOUNDARY_TIMEOUT_MS * 3);
+    expect(after.events).toHaveLength(0);
+  });
+
+  it('drops a held error when the turn settles as anything other than error', () => {
+    // Defensive: a boundary whose lastStopReason is absent/unknown must not be
+    // read as failure. Only the explicit 'error' value reports.
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('say PROBE_OK'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      turnSettled(null),
+    ]);
+    expect(drainAll(path).filter((e) => e.kind === 'assistant_final')).toHaveLength(0);
+  });
+
+  it('a successful answer clears the held error even if the boundary never arrives', () => {
+    // Success first, boundary lost (Pi killed right after answering, or the
+    // extension failed to load). The backstop must NOT resurrect the earlier
+    // mid-turn error — that would reintroduce the exact false failure this
+    // change removes, just delayed by the timeout.
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('say PROBE_OK'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      assistantFinal('stop', 'PROBE_OK', '2026-08-03T05:14:03.000Z'),
+    ]);
+    const t0 = 2_000_000;
+    const first = drainPiTranscript(path, 0, t0);
+    const finals = first.events.filter((e) => e.kind === 'assistant_final');
+    expect(finals).toHaveLength(1);
+    expect(finals[0].text).toBe('PROBE_OK');
+
+    // Long past the timeout: still nothing — no phantom failure card.
+    const late = drainPiTranscript(path, first.newOffset, t0 + PI_TURN_BOUNDARY_TIMEOUT_MS * 3);
+    expect(late.events).toHaveLength(0);
   });
 
   it('emits assistant_final on stopReason:length as a completed (truncated) answer', () => {

--- a/test/pi-transcript.test.ts
+++ b/test/pi-transcript.test.ts
@@ -296,6 +296,43 @@ describe('drainPiTranscript: turn terminal contract', () => {
     expect(late.events).toHaveLength(0);
   });
 
+  // ── /adopt: a user-started Pi never receives --extension ──────────────────
+  //
+  // Those sessions produce NO boundary marker at all, so this is the shape the
+  // change degrades to when it gets no help from Pi. It must degrade to "late
+  // but correct", never to "wrong" or "silent".
+
+  it('without any boundary marker (adopt), a recovered turn still suppresses its mid-turn error', () => {
+    // Suppression here rides on the real terminal, not the marker — so adopt
+    // sessions get the false-alarm fix for free.
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('say PROBE_OK'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+      assistantFinal('stop', 'PROBE_OK', '2026-08-03T05:14:03.000Z'),
+    ]);
+    const t0 = 3_000_000;
+    const first = drainPiTranscript(path, 0, t0);
+    const late = drainPiTranscript(path, first.newOffset, t0 + PI_TURN_BOUNDARY_TIMEOUT_MS * 3);
+    const all = [...first.events, ...late.events];
+    expect(all.filter((e) => e.terminalStatus === 'failed')).toHaveLength(0);
+    expect(all.some((e) => e.text === 'PROBE_OK')).toBe(true);
+  });
+
+  it('without any boundary marker (adopt), a genuinely failed turn is still reported via the timeout', () => {
+    const path = writeTranscript([
+      sessionHeader(),
+      userMsg('say PROBE_OK'),
+      assistantFinal('error', '', '2026-08-03T05:14:01.000Z', 'upstream stream error: service unavailable'),
+    ]);
+    const t0 = 4_000_000;
+    const first = drainPiTranscript(path, 0, t0);
+    const late = drainPiTranscript(path, first.newOffset, t0 + PI_TURN_BOUNDARY_TIMEOUT_MS);
+    const fails = [...first.events, ...late.events].filter((e) => e.terminalStatus === 'failed');
+    expect(fails).toHaveLength(1);
+    expect(fails[0].terminalErrorCode).toBe('codex_upstream_error');
+  });
+
   it('emits assistant_final on stopReason:length as a completed (truncated) answer', () => {
     const path = writeTranscript([
       sessionHeader(),


### PR DESCRIPTION
## 问题

用户反馈：「pi 只是遇到一次报错，后面 retry 还是能继续跑的，但会报错 at 我」。

根因：pi 的 `stopReason:"error"` 描述的是**一次模型请求**失败，不是一轮对话失败。provider 暂态出错时 pi 的 agent loop 会在**同一轮内重试**。pi 源码是直接证据（`agent-session.ts`，把该记录从 LLM 上下文删掉却**刻意留在会话文件**）：

```js
// Remove error message from agent state (keep in session for history)
```

而 `pi-transcript.ts` 把这条记录当轮终态 ⟹ botmux 为一轮**后来成功的**对话发出「模型网关/上游服务故障」卡片并 @ 人。

**同一个文件其实已经知道 pi 是 agent loop**——`stop`/`length` 带 toolCall 时刻意不收尾，可 `error` 却跳过了同一个 gate。

### 事故复盘（真实数据）

某次 pi 复审任务，JSONL 与 daemon 日志对照：

| pi JSONL | daemon 日志 |
|---|---|
| 第 95 行 `stopReason=error` | `15:37:47.793 Bridge final_output forwarded`（就是那张 @人的卡） |
| **第 96 行接着 `toolUse`** | **`15:37:48.411 Explicit busy marker detected`（0.6s 后 pi 又忙了）** |
| 第 149 行 `stopReason=stop`，798 字真答案 | `15:46:54 Prompt detected (idle)` |

全程只有 1 条 user 记录 ⟹ 没有重发，就是同一轮跑完的。

### 为什么不能靠文案或结构判断

本机 231 个真实 session、339 条 error 记录：**229 条（67.6%）后面同一轮还在继续**。

- **文案不是判据**：同一句 `EOF wait read` 出现 35 次（34 次继续 / 1 次真结束）；`No available servers` 41 次（39/2）
- **结构也不是判据**：两种结局的记录字段集合逐项相同（`api`/`model`/`provider`/`usage.totalTokens==0` 全同形）

## 改法

pi 自己知道答案且早已暴露：`agent_settled` 在自动重试 / 压缩重试 / 排队续跑全部排空后**恰好触发一次**（上游 issue #6410 就是有人把 `agent_end` 当轮结束踩的坑，`willRetry`/`agent_settled` 正是为此而加）。

1. **新增 `pi-turn-boundary-extension.ts`**：`agent_settled` 时用 `pi.appendEntry()` 往 **pi 自己的 session JSONL**（桥本来就在读的那个文件）追加一条 `custom` 记录，带该轮最后一次 agent run 的 `lastStopReason`。**带内落位**，天然排在本轮 assistant 记录之后 ⟹ 无需 sidecar 文件、无需跨文件时间戳对齐、无写入顺序竞态。custom 记录不进 LLM 上下文。
2. **`pi.ts` 的 `buildArgs` 每次都带 `--extension`**。该参数是 per-invocation argv，只影响 botmux 拉起的 pi；**用户自己在终端敲的 `pi` 不受影响**（不写全局 `~/.pi/agent/extensions/`，也不写项目 `.pi/extensions/`）。复用仓库既有先例 `pi-initial-prompt.ts:82` 的同形写法。
3. **`pi-transcript.ts`：error 记录改为暂存**，三条释放路径：
   - 边界记录 `lastStopReason === 'error'` → **报**（真故障）
   - 出现真终态（stop/length/aborted）或**新的 user 记录** → 丢弃（已恢复 / 上一轮已翻篇）
   - **超时兜底 300s** → 仍然报。避免 pi 被 SIGKILL 时**真故障永远不报**——那比误报更糟。300s 取自实测分布（误报间隔 p50 18.8s / p95 90.3s / **最大 165.6s**）

liveness 未受影响：暂存不阻塞队列头关闭，type-ahead 不会 wedge。

## 影响面

- **仅 pi**。codex/traex/grok 读的是 `task_complete`/`turn_completed`，本就是真·每轮一次的边界记录，不受影响；共用的 `codexTaskFailureCode` 未改
- **`omp` 有同形缺陷**（`omp-transcript.ts` 的 error 分支逐字同构），本 PR **未**处理，避免一次改动跨两个 CLI
- **`/adopt` 会话**的 pi 由用户自己启动、argv 无 `--extension`，拿不到边界记录，走 300s 超时兜底。本次不处理（已与维护者确认）

## 验证

- `bun run build` exit 0，产物落到 `dist/adapters/cli/pi-turn-boundary-extension.js`
- `tsc --noEmit` exit 0
- pi 相关 **10 个测试文件 781/781 绿**

**真实二进制端到端**：起假网关（前 2 次 503 后正常），用 `dist/` 里的产物跑真 pi：
```
3: message role=user
4: message role=assistant stopReason=error     ← 改前发假卡 + @人
5: message role=assistant stopReason=error     ← 改前再发一张
6: message role=assistant stopReason=stop      ← 真答案
7: custom customType=botmux-turn-settled data={"lastStopReason": "stop"}
```
把这个**真实文件**喂给改后的 drainer → `events: user, assistant_final`，**0 张失败卡**，答案正常投递。

**231 个真实 session 离线回放**（与独立计算的 ground truth 比对）：

| | |
|---|---|
| 真故障 | **119 / 119 全部上报，一条不漏** |
| 误报 | **70 条全部抑制** |
| 结果 | **精确相等 ✅** |

**反变异 5 组全红**：
| 变异 | 结果 |
|---|---|
| 删除暂存（恢复旧行为） | RED（5 例） |
| 边界记录忽略 `lastStopReason` | RED |
| 真终态不清除暂存 | RED |
| 去掉超时兜底 | RED |
| 去掉「无新字节提前返回」那条兜底（正是 SIGKILL 的形态） | RED |

> ⚠️ 过程记录：首轮我构造的「恢复旧行为」变异**存活**了，核查后发现是变异本身无效（改的那行在 error 分支 `continue` 之后，结构上不可达），换成真正等价于旧行为的改法后 5 例转红。第 3 条变异首次也存活，补了「成功答案 + 边界丢失，超时后不得复活旧 error」这个用例才咬住——那正是本 PR 要消灭的误报被延迟重现的形态。


---

### 追加（`f0642e152`）：/adopt 降级行为的回归

`/adopt` 会话的 pi 由用户自己启动、argv 无 `--extension`，**永远拿不到边界记录**。这是本改动「完全得不到 pi 协助」时的形态，我补了两条用例钉住它必须降级成「晚报但正确」，而不是「报错」或「静默」：

| adopt 场景（无边界记录） | 行为 |
|---|---|
| 已恢复的轮 | **抑制仍然生效**（靠真终态而非边界记录）⟹ adopt 也白拿这次的误报修复 |
| 真故障的轮 | 靠 300s 超时兜底**仍然上报**，不会静默 |

反变异各自转红：去掉超时兜底 / 真终态不清除暂存。`pi-transcript` 用例数 18 → 20，全绿。


---

### 追加（`ce24d5355`）：自查编译态时发现并修掉**本 PR 自己引入的**一个更严重缺陷

自查「编译态（`bun build --compile`）下会怎样」时打出来的。**尚未合入，线上无影响**，但如果直接合了会比它要修的 bug 严重得多。

**pi 把加载不了的 `--extension` 当致命错误**——对 pi 0.84.4 实测：
```
Error: Failed to load extension "…": Extension path does not exist: …
exit code = 1
```

而编译态下模块图在虚拟 `/$bunfs/` 根里，`__dirname` 派生的两个候选**实测都指向进程外不存在的路径**：
```
/$bunfs/root/pi-turn-boundary-extension.js  exists: false
/$bunfs/root/pi-turn-boundary-extension.ts  exists: false
```
原实现在两者都不存在时**仍返回后者** ⟹ **编译版每个 pi 会话都会 exit 1 起不来**。

**改为 fail open**：解析不到就返回 `undefined`，调用方**整个省略该 flag**。丢掉边界记录只是退回读取侧的 300s 超时兜底（降级）；起不来是整个会话没了。

顺带把 argv 组装抽成可导入的 `buildPiArgs(opts)`：省略分支只在编译态发生、**没有任何测试会执行编译版**，把解析结果作为参数传入才能在用例里真正驱动那条分支，而不是只测「文件存在」这一侧。

反变异：让 `buildPiArgs` 无条件 push `--extension` → **转红**。
（另一个变异「解析器在都不存在时仍返回路径」在源码树下**等价**——文件真实存在、分支不可达，故不作为守卫依据。）

### 关于全量本地测试的 21 个失败

本机全量跑（19926 例）有 21 例失败，**与本 PR 无关**，已用对照证明：把工作树切到**干净 `origin/master`**（我的改动一行不剩）跑同一个文件，得到**逐字相同的 2 failed | 8 passed**。失败集中在 `test/multi-bot-session.e2e.ts` 等文件，不涉及本 PR 触碰的任何模块。CI 在干净环境下 7/7 全绿。


---

## 复审后的两轮实质修复（`370ce89fe` / `f49142011` + `7c85f143b`）

### ① 重试 backoff 期间的 steer 被误判成新轮 → 仍会误报

原实现在 user 记录处**无条件**释放暂存的 error，注释理由写的是「steer 的 user 记录在 dequeue 时写入，不会插在 error 与重试之间」。**这条对 tool-call 路径成立，对 error-retry 路径不成立**：pi 的重试入口 `runAgentLoopContinue` 直接进 `runLoop`，而 `runLoop` **开头**就读 steering 队列（源码注释原文 "Check for steering messages at start (user may have typed while waiting)"）。所以重试退避（2s/4s/8s，单轮累计最长 14s）期间到达的 steer，其 user 记录确实落在 error 与重试之间。

**修法**：按「本 transcript 是否见过边界记录」（`markerSeen`，transcript 级累计）分流——见过则边界记录独占释放权（steer 不再释放）；没见过则维持无条件释放（无扩展的老会话／adopt／编译态照常及时上报）。并让扩展在 `session_start` 追加一条 `lastStopReason: null` 的**声明记录**，使「扩展已加载」在首轮之前就成立，首轮 steer 也不误报。

> ⚠️ 中途走过一条**更糟的弯路**并已否决：先试的是「hold 之后见过边界才释放」，实测把 **120 个真故障打到只剩 11 个**——无边界会话里该条件永不成立 ⟹ user 处不释放 ⟹ 新轮 terminal 把暂存清掉 ⟹ 300s 兜底也永不触发，**失败被静默吞掉**。漏报比误报严重，故弃用。

### ② 声明记录不止一条：resume 会再写一条，吞掉暂存的失败

`session_start` **每次 pi 启动都触发，resume 也不例外**，所以声明记录不唯一。原守卫只跳过**第一条**声明，之后的声明会落入「本轮干净结束」分支把暂存清掉 ⟹「一轮失败 → pi 被 kill → botmux resume」场景下失败**静默丢失**。

**修法**：守卫从「按出现次序」改为「**按这条记录带不带判决**」——所有 `lastStopReason` 为 null 的声明一律不解析暂存，只有真正关闭一轮的 settle 记录（非 null）才能 flush 或 drop。

> 关于前提的诚实说明：「resume 会写第二条声明」是**按 `session_start` 的 API 语义推断**的；用真 pi 复现时 resume 那次跑超时（exit 124），**没有亲眼看到第二条声明写入**。已实测确认的是「**一旦**出现第二条声明，改前的 reader 会吞掉暂存」。新守卫按语义判本就更正确、且严格更安全，因此不依赖该前提成立。

### 验证（在最终 head 上重跑）

- **231 真实 session 回放**：真故障 **121/121 零漏报**、误报 **71 全抑制**，与独立 ground truth **精确相等**
- **真 pi 0.84.4 + `dist/` 产物端到端**：JSONL 得 `custom(null) → user → error → error → stop → custom(stop)`，声明记录确实排在首条 user 之前；喂给 reader **0 张失败卡**
- steer 三组（有前置边界／首轮 steer／首轮真失败）全部正确
- `pi-transcript` **24/24**、`cli-adapters` 439/439 绿；`tsc --noEmit`、`bun run build` exit 0
- **反变异**：user 无条件释放（缺陷①）／门反向（上面否决的弯路）／去掉声明守卫／**把守卫改回「仅跳过第一条」**（缺陷②）—— 四组全红
