### PR TITLE
fix(lark): 话题历史取最新 N 条，不再取最早 N 条

### DIFF
--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1784,7 +1784,22 @@ async function listByChatFilter(c: any, chatId: string, rootMessageId: string, p
   } while (pageToken);
 
   allMessages.sort((a, b) => (a.create_time ?? '').localeCompare(b.create_time ?? ''));
-  return unlimited ? allMessages : allMessages.slice(0, pageSize);
+  // Take the TAIL, matching `listByThread` above and the chat-scope sibling.
+  // The loop above pages in Desc order and breaks on `>= pageSize`, so a single
+  // 50-item page can overshoot: what we hold is the newest N+k. After the
+  // ascending sort, `slice(0, pageSize)` would hand back the OLDEST N of those
+  // — i.e. silently drop the newest k, which is exactly the end the caller
+  // asked for. `limit > 50` always pages, and the dashboard history popover
+  // defaults to 80 (`src/core/dashboard-ipc-server.ts`), so this is the common
+  // path, not a corner.
+  //
+  // ⚠️ `Math.max(0, …)` is load-bearing, not defensive dressing: when fewer
+  // than `pageSize` messages were collected — a thread shorter than the limit,
+  // which is the NORMAL case — `allMessages.length - pageSize` is negative and
+  // `slice(negative)` counts from the end, dropping the OLDEST messages
+  // instead. Without the guard this trades a rare bug for a common one.
+  // Same idiom as `filterAmbientChatMessages` above.
+  return unlimited ? allMessages : allMessages.slice(Math.max(0, allMessages.length - pageSize));
 }
 
 /**

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1565,7 +1565,14 @@ function wantsUnlimitedMessages(pageSize: number): boolean {
   return pageSize <= 0 || !Number.isFinite(pageSize);
 }
 
-/** List thread messages using container_id_type="thread" (fast path). */
+/** List thread-container messages, most-recent first but returned chronologically
+ *  (oldest → newest, capped at `pageSize`). Fast path for `botmux history` in a
+ *  topic session — same contract as `listChatMessages` below, and for the same
+ *  reason: the caller asked for `pageSize` messages of *context*, which is the
+ *  tail of the thread, not its head. A thread that has outgrown `pageSize` used
+ *  to come back as its oldest N here while the chat-scope sibling returned its
+ *  newest N — and the two ends are indistinguishable downstream, because both
+ *  are N real messages in chronological order. */
 async function listByThread(c: any, threadId: string, pageSize: number): Promise<any[]> {
   const allMessages: any[] = [];
   let pageToken: string | undefined;
@@ -1576,7 +1583,8 @@ async function listByThread(c: any, threadId: string, pageSize: number): Promise
       container_id_type: 'thread',
       container_id: threadId,
       page_size: unlimited ? LARK_MESSAGE_LIST_MAX_PAGE : Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
-      sort_type: 'ByCreateTimeAsc',
+      // Page in Desc order so a long thread yields its TAIL; reversed below.
+      sort_type: 'ByCreateTimeDesc',
       with_sender_name: 'true',
       ...(pageToken ? { page_token: pageToken } : {}),
     });
@@ -1593,7 +1601,8 @@ async function listByThread(c: any, threadId: string, pageSize: number): Promise
     if (!unlimited && allMessages.length >= pageSize) break;
   } while (pageToken);
 
-  return unlimited ? allMessages : allMessages.slice(0, pageSize);
+  // Cap to pageSize newest, then reverse to chronological for the caller.
+  return (unlimited ? allMessages : allMessages.slice(0, pageSize)).reverse();
 }
 
 /** List chat-container messages, most-recent first but returned chronologically

--- a/src/im/lark/topic-root-context.ts
+++ b/src/im/lark/topic-root-context.ts
@@ -18,8 +18,9 @@
  * root to resolve thread_id, then pulls up to 50 *full* message bodies — and
  * when thread_id can't be resolved it falls back to paging the *whole chat*
  * (potentially the entire large-group history) to filter by root_id. On top of
- * that, the Asc+50 cap means the "count" is only a floor (the oldest 50), so
- * printing it as an exact total is misleading. Since the daemon gate has
+ * that, the 50-per-page cap means the "count" is only a floor (as of the
+ * Desc-paging fix, the newest 50), so printing it as an exact total is
+ * misleading. Since the daemon gate has
  * *already* proven this is a topic reply, we don't need a network call at all:
  * emit the hint unconditionally and let the CLI decide whether to run
  * `botmux history` (thread-scope by default → walks this very thread, with its

--- a/test/history-thread-window.test.ts
+++ b/test/history-thread-window.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `botmux history --limit N` in a thread session must return the thread's
+ * TAIL (the newest N, chronologically), not its head.
+ *
+ * Why this exists: an agent reading its own history to answer "what was just
+ * decided" has no way to tell WHICH END of the thread it received — both ends
+ * come back as N real, time-ordered messages. The only quantity that separates
+ * the two worlds is the endpoint, and nothing in the output names it. A wrong
+ * endpoint therefore does not look like an error; it looks like a short thread.
+ *
+ * The invariant is already written down for the sibling container: see
+ * `listChatMessages` — "We page in Desc order so a long-running chat returns
+ * its TAIL, not its head — that's the context the caller wants." The thread
+ * container is the same command (`botmux history`) serving the same caller, so
+ * it owes the same window.
+ *
+ * The sharper half is INSIDE `listThreadMessages`: it has two branches — the
+ * `container_id_type=thread` fast path and the chat-scan fallback used when
+ * `resolveThreadId` cannot resolve a thread id. Which branch runs depends only
+ * on whether one Lark call succeeded, so the two must return the same window
+ * for the same input. The last case below pins exactly that.
+ *
+ * Run:  bun run vitest run test/history-thread-window.test.ts
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const state = {
+    /** Whether message.get resolves a thread_id (fast path) or not (fallback). */
+    threadIdResolvable: true,
+    /** Every message in the synthetic thread, oldest -> newest. */
+    thread: [] as any[],
+    /** Requested sort_type per messages.list call, for the pagination assertions. */
+    listCalls: [] as Array<{ container: string; sort: string; pageSize: number }>,
+  };
+
+  const ROOT = 'om_root';
+
+  class MockClient {
+    async request({ url, params }: { url: string; params?: any }) {
+      // message.get — used by resolveThreadId
+      if (/\/open-apis\/im\/v1\/messages\/[^/]+$/.test(url)) {
+        return {
+          code: 0,
+          data: { items: [{ message_id: ROOT, thread_id: state.threadIdResolvable ? 'omt_x' : undefined }] },
+        };
+      }
+      // messages.list — thread container or chat container
+      if (url === '/open-apis/im/v1/messages') {
+        const sort = params?.sort_type ?? 'ByCreateTimeAsc';
+        const pageSize = Number(params?.page_size ?? 50);
+        state.listCalls.push({ container: params?.container_id_type, sort, pageSize });
+        const ordered = sort === 'ByCreateTimeDesc'
+          ? [...state.thread].reverse()
+          : [...state.thread];
+        const offset = params?.page_token ? Number(params.page_token) : 0;
+        const items = ordered.slice(offset, offset + pageSize);
+        const next = offset + pageSize;
+        return {
+          code: 0,
+          data: {
+            items,
+            page_token: next < ordered.length ? String(next) : undefined,
+          },
+        };
+      }
+      throw new Error(`unexpected url in mock: ${url}`);
+    }
+  }
+
+  return { state, MockClient, ROOT };
+});
+const { state, MockClient, ROOT } = hoisted;
+
+vi.mock('../src/config.js', () => ({
+  config: { session: { get dataDir() { return '/tmp/botmux-test'; } } },
+}));
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../src/utils/user-token.js', () => ({ resolveUserToken: vi.fn() }));
+vi.mock('../src/bot-registry.js', () => ({
+  loadBotConfigs: vi.fn(() => []),
+  getBotClient: vi.fn(() => new MockClient()),
+}));
+vi.mock('@larksuiteoapi/node-sdk', () => ({ LoggerLevel: { error: 4 }, Client: MockClient }));
+
+/** Build a thread of `n` messages, oldest -> newest, ids m01..mNN. */
+function buildThread(n: number) {
+  state.thread = Array.from({ length: n }, (_, i) => ({
+    message_id: `m${String(i + 1).padStart(2, '0')}`,
+    root_id: ROOT,
+    create_time: String(1_700_000_000_000 + i * 1000),
+  }));
+}
+const ids = (msgs: any[]) => msgs.map(m => m.message_id);
+
+describe('botmux history — thread window endpoint', () => {
+  beforeEach(() => {
+    state.listCalls = [];
+    state.threadIdResolvable = true;
+    buildThread(12);
+  });
+
+  it('fast path (container_id_type=thread) returns the newest N, chronologically', async () => {
+    const { listThreadMessages } = await import('../src/im/lark/client.js');
+    const out = await listThreadMessages('cli_x', 'oc_x', ROOT, 3);
+    // The tail — NOT m01,m02,m03.
+    expect(ids(out)).toEqual(['m10', 'm11', 'm12']);
+  });
+
+  it('fallback path (chat scan filtered by root_id) returns the same newest N', async () => {
+    state.threadIdResolvable = false;
+    const { listThreadMessages } = await import('../src/im/lark/client.js');
+    const out = await listThreadMessages('cli_x', 'oc_x', ROOT, 3);
+    expect(ids(out)).toEqual(['m10', 'm11', 'm12']);
+  });
+
+  it('both branches return the same window for the same input', async () => {
+    const { listThreadMessages } = await import('../src/im/lark/client.js');
+    state.threadIdResolvable = true;
+    const fast = ids(await listThreadMessages('cli_x', 'oc_x', ROOT, 5));
+    state.threadIdResolvable = false;
+    const fallback = ids(await listThreadMessages('cli_x', 'oc_x', ROOT, 5));
+    // Which branch runs depends only on whether one Lark call succeeded.
+    // If these ever disagree, the caller silently gets a different window
+    // depending on the health of an unrelated request.
+    expect(fast).toEqual(fallback);
+  });
+
+  it('a limit at or above the thread length returns the whole thread', async () => {
+    const { listThreadMessages } = await import('../src/im/lark/client.js');
+    const out = await listThreadMessages('cli_x', 'oc_x', ROOT, 50);
+    expect(ids(out)).toEqual(ids(state.thread));
+  });
+
+  it('pageSize <= 0 still means unlimited for internal callers', async () => {
+    const { listThreadMessages } = await import('../src/im/lark/client.js');
+    const out = await listThreadMessages('cli_x', 'oc_x', ROOT, 0);
+    expect(ids(out)).toEqual(ids(state.thread));
+  });
+});

--- a/test/history-thread-window.test.ts
+++ b/test/history-thread-window.test.ts
@@ -128,6 +128,45 @@ describe('botmux history — thread window endpoint', () => {
     expect(fast).toEqual(fallback);
   });
 
+  // ── 跨页：上面每一条都落在单页内（12 条，limit 均 ≤ 12），`page_token` 循环
+  //    与跨页截断零覆盖，而那正是 Desc + reverse 最容易出错的地方。
+  //    这两条必须成对：单独任何一条都挡不住另一种错法。
+  //      · 只补「长于 limit」→ 放过 `slice(len - pageSize)` 的负索引错法
+  //      · 只补「短于 limit」→ 放过当前的 overshoot
+  //    两条同时在，`slice(Math.max(0, len - pageSize))` 是唯一双绿的写法。
+  it('长于 limit：跨页时两条分支返回同一个窗口，且含最新一条', async () => {
+    buildThread(120);
+    const { listThreadMessages } = await import('../src/im/lark/client.js');
+    state.threadIdResolvable = true;
+    const fast = ids(await listThreadMessages('cli_x', 'oc_x', ROOT, 80));
+    state.threadIdResolvable = false;
+    const fallback = ids(await listThreadMessages('cli_x', 'oc_x', ROOT, 80));
+
+    // limit 80 > 单页上限 50 ⇒ 必然多页；dashboard 历史弹窗的默认 limit 正是 80。
+    expect(fast).toHaveLength(80);
+    expect(fast).toEqual(fallback);
+    // 尾部窗口：含最新一条，不含最早那批。断言「最新一条在」是这条用例的本体 ——
+    // 回退路径的 overshoot 恰恰是把最新的 k 条静默换成更老的 k 条，而条数不变，
+    // 所以只断言长度和「两分支相等」都抓不到它（错法下两分支会不等，但若有人
+    // 把两条分支改成同一种错法，长度断言仍然全绿）。
+    expect(fast[fast.length - 1]).toBe('m120');
+    expect(fast[0]).toBe('m41');
+    expect(fast).not.toContain('m01');
+  });
+
+  it('短于 limit（回退路径）：条数不足时最早一条不能丢', async () => {
+    buildThread(3);
+    // ⚠️ 必须走回退路径。快路径的 thread 容器里只有本话题消息，`length < pageSize`
+    //    时两种写法恰好同解，这条用例会**假绿** —— 它的区分力全部依赖 mock 的
+    //    message.get 不返回 thread_id 这一行。
+    state.threadIdResolvable = false;
+    const { listThreadMessages } = await import('../src/im/lark/client.js');
+    const out = await listThreadMessages('cli_x', 'oc_x', ROOT, 5);
+
+    // 3 - 5 = -2；`slice(-2)` 会从尾部重新起算，m01 消失。
+    expect(ids(out)).toEqual(['m01', 'm02', 'm03']);
+  });
+
   it('a limit at or above the thread length returns the whole thread', async () => {
     const { listThreadMessages } = await import('../src/im/lark/client.js');
     const out = await listThreadMessages('cli_x', 'oc_x', ROOT, 50);


### PR DESCRIPTION
## 问题

在话题（thread）会话里，`botmux history --limit N` 返回的是这个话题**最早**的 N 条，
而不是**最近**的 N 条。

## 根因：`listThreadMessages` 内部两条分支取的是相反的两端

`listThreadMessages` 会先用 `resolveThreadId` 解析 `thread_id`，然后二选一：

| 分支 | 条件 | `sort_type` | 实际返回 |
|---|---|---|---|
| `listByThread`（快路径） | `thread_id` 解析成功 | `ByCreateTimeAsc` | 话题**开头** N 条 |
| `listByChatFilter`（回退） | 解析失败，扫整个会话再按 `root_id` 过滤 | `ByCreateTimeDesc` → 过滤 → 升序 → `slice(0, N)` | 话题**结尾** N 条 |

也就是说，同一个 `botmux history --limit N`，在同一个话题上，返回哪一端**只取决于
中间那一次 Lark `message.get` 有没有成功**。这两条分支之间的分歧本身就是缺陷，
不需要跟别的容器比较就能成立。

## 正确契约已经写在同容器的兄弟函数上

`listChatMessages` 的注释已经把这件事说清楚了：

> We page in Desc order so a long-running chat returns its TAIL, not its head —
> that's the context the caller wants.

`listChatMessages`（chat 容器）和 `listByThread`（thread 容器）服务的是**同一个命令**
（`botmux history`）的**同一个调用者**，`--limit` 的语义也一样，所以它们应当给出同一端。

另外，仓库里已经有一处记下了这个缺陷的症状（`src/im/lark/topic-root-context.ts` 的
文件注释）：

> the Asc+50 cap means the "count" is only a floor (the oldest 50), so printing
> it as an exact total is misleading

——那处的处理方式是**绕开**（改成不做这次网络调用），源头没有修。

## 为什么这个 bug 不容易被发现

取错端的输出**不像出错**：两端都是 N 条真实的、时间正序的消息，返回值里没有任何字段
说明这是哪一端。所以一个长话题取到头部时，读起来就是「这个话题很短」。
对以 `botmux history` 为唯一上下文来源的 agent 来说，失效方向是单向的：
它读到的是最陈旧的那一段，却以为自己读到了全部。

## 修改

把 `listByThread` 改成与 `listChatMessages` 逐字一致的分页与截断方式：
`sort_type: 'ByCreateTimeDesc'`，取够 `pageSize` 后 `.reverse()` 还原成时间正序。

调用点影响面（全仓 3 处）：

- `cmdHistory`（`botmux history`）—— 要的就是尾部，本次修复
- dashboard IPC 的 history —— 同上
- `summary-command` —— 传的是 `pageSize = 0`（unlimited），取全量，
  `reverse()` 前后都是时间正序，**行为不变**

## 测试

新增 `test/history-thread-window.test.ts`。几点刻意的取舍：

- 断言落在**返回了哪几条消息**（`message_id`）上，不落在请求参数上——
  断言 `sort_type` 等于某个字符串只能测「代码长什么样」，测不到「取回了哪一端」。
- mock 真的按 `sort_type` 排序、真的实现 `page_token` 分页，所以它对两条分支都成立。
- 其中一条用例断言**两条分支必须返回同一个窗口** —— 它们的分歧才是这个 bug 的本体。
- 修复前：快路径与「两条分支一致」两条用例为红，回退路径那条为绿（它本来就是对的）。
- 另外把两种**错误修法**各跑了一次，确认判据能把它们分开：
  只加 `.reverse()` 不改 `sort_type` → 4 红 1 绿；只改 `sort_type` 不加 `.reverse()` → 4 红 1 绿。

## 回归

macOS / node 22 / bun 1.4.0 上跑了 `bun run build && bun run test`
（`vitest --project unit`，19,710 例）与 `bun run workflow-core:test`。
把同一台机器上 `master` 的裸跑当对照，两次的失败集合**逐条相同**：
3 例，全部与本 PR 无关（`/var` 与 `/private/var` 的 realpath 差异、
路径里 `_` 的转义、install.sh 布局），在 `master` 上原样复现。
