### PR TITLE
fix(cli): 未知参数一律中止，不再穿透到全效果执行

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12342,23 +12342,48 @@ if (command === '__self-update') {
 
 
 const ROOT_FLEET_MUTATION_COMMANDS = new Set(['start', 'stop', 'restart', 'upgrade', 'update']);
+// Flags each fleet command legitimately accepts, on top of --help/-h.
+// This has to be an explicit table and cannot be inferred from the handler
+// signature: `cmdStart` / `cmdStop` / `cmdRestart` / `cmdUpgrade` are all
+// declared with zero parameters and still read `process.argv` directly.
+// `cmdStop` and `cmdRestart` pull `--with-plugin` out of it, and the same shape
+// exists elsewhere in this file — `cmdLogs` (`--lines` / `--no-follow` /
+// `--bot`), `cmdList` (`--plain`), `cmdSuspend`, `cmdSlash`. A zero-parameter
+// handler therefore says nothing about which flags a command accepts; the only
+// thing that does is this table, so a new flag must be added here as well.
+// `start` is deliberately empty: `startConfiguredFleet` unconditionally calls
+// `reconcilePluginServicesForCli(undefined, { autoOnly: true })`, so start
+// already brings auto plugin services up and `--with-plugin` would be a no-op
+// there — its meaning on stop/restart is "also tear the plugin service down",
+// and start has no tear-down phase.
+const FLEET_KNOWN_FLAGS: Record<string, readonly string[]> = {
+  start: [],
+  stop: ['--with-plugin'],
+  restart: ['--with-plugin'],
+  upgrade: [],
+  update: [],
+};
 if (ROOT_FLEET_MUTATION_COMMANDS.has(command ?? '')) {
   const fleetArgs = process.argv.slice(3);
   if (fleetArgs.some(arg => arg === '--help' || arg === '-h')) {
     showHelp();
     process.exit(0);
   }
-  // Fail closed on anything else. `cmdStart` / `cmdStop` / `cmdRestart` /
-  // `cmdUpgrade` are all declared with zero parameters, so every one of these
-  // commands accepts exactly one flag: --help. Without this branch an
-  // unrecognized flag falls through and the command runs at FULL effect —
-  // `botmux update --check` and `botmux update --dry-run` read like probes and
-  // upgrade the whole fleet. The failure is silent and one-directional: the
-  // user who typed a guess gets the most destructive interpretation of it,
-  // and the flags most likely to be guessed are exactly the read-only ones.
-  if (fleetArgs.length > 0) {
-    console.error(`未知参数: ${fleetArgs.join(' ')}`);
-    console.error(`  \`botmux ${command}\` 不接受任何参数（只有 --help）。`);
+  // Fail closed on anything else. Without this branch an unrecognized flag
+  // falls through and the command runs at FULL effect — `botmux update --check`
+  // and `botmux update --dry-run` read like probes and upgrade the whole fleet.
+  // The failure is silent and one-directional: the user who typed a guess gets
+  // the most destructive interpretation of it, and the flags most likely to be
+  // guessed are exactly the read-only ones.
+  // Exact set difference rather than `unknownFlags()`: that helper only reports
+  // tokens starting with `-`, so `botmux stop foo` would be waved through. None
+  // of these commands takes a positional argument either, so anything outside
+  // the table above is unknown, flag-shaped or not.
+  const knownFleetFlags = FLEET_KNOWN_FLAGS[command ?? ''] ?? [];
+  const unknownFleetArgs = fleetArgs.filter(arg => !knownFleetFlags.includes(arg));
+  if (unknownFleetArgs.length > 0) {
+    console.error(`未知参数: ${unknownFleetArgs.join(' ')}`);
+    console.error(`  \`botmux ${command}\` 只接受: ${['--help', ...knownFleetFlags].join(' ')}。`);
     console.error('  为避免把一个看起来像「只检查」的参数当成「执行」，这里直接中止，不做任何改动。');
     process.exit(2);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,7 +109,7 @@ import { reapLegacyPm2, liveGodAt } from './core/legacy-pm2-reaper.js';
 import { withFileLock, withFileLockSync, FileLockTimeoutError } from './utils/file-lock.js';
 import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
-import { firstPositional, hasFlagOrEq } from './cli/arg-utils.js';
+import { firstPositional, hasFlagOrEq, unknownFlags } from './cli/arg-utils.js';
 import { isColdResumeDormant, isRealManagedSession, sessionListDisposition } from './cli/session-list-liveness.js';
 import {
   computeSessionPickerLayout,
@@ -6910,6 +6910,21 @@ async function resolveSessionAppId(sessionIdArg: string | undefined): Promise<{ 
 }
 
 async function cmdHistory(rest: string[]): Promise<void> {
+  // Reject unrecognized flags BEFORE anything else. Every flag below is pulled
+  // out of argv by name; a flag that is not pulled is simply not there, so a
+  // typo or an invented flag used to be answered with the default behaviour and
+  // no diagnostic at all. `--thread` (there is no such flag; the spelling is
+  // `--scope thread`) came back as session scope, which for a thread-scope
+  // session is the same window — so the mistake was invisible in the output too.
+  const unknown = unknownFlags(rest, {
+    valueFlags: ['--limit', '--scope', '--session-id'],
+    boolFlags: ['--with-card-json'],
+  });
+  if (unknown.length > 0) {
+    console.error(`未知参数: ${unknown.join(' ')}`);
+    console.error('  botmux history [--limit <n>] [--scope session|thread|chat|ambient] [--session-id <id>] [--with-card-json]');
+    process.exit(2);
+  }
   // No-transport turn has no Feishu chat history to read — central hard gate.
   assertTurnTransportOrExit('history');
   // Read isolation: register this bot from its cred file so the Lark client is
@@ -12327,12 +12342,26 @@ if (command === '__self-update') {
 
 
 const ROOT_FLEET_MUTATION_COMMANDS = new Set(['start', 'stop', 'restart', 'upgrade', 'update']);
-if (
-  ROOT_FLEET_MUTATION_COMMANDS.has(command ?? '')
-  && process.argv.slice(3).some(arg => arg === '--help' || arg === '-h')
-) {
-  showHelp();
-  process.exit(0);
+if (ROOT_FLEET_MUTATION_COMMANDS.has(command ?? '')) {
+  const fleetArgs = process.argv.slice(3);
+  if (fleetArgs.some(arg => arg === '--help' || arg === '-h')) {
+    showHelp();
+    process.exit(0);
+  }
+  // Fail closed on anything else. `cmdStart` / `cmdStop` / `cmdRestart` /
+  // `cmdUpgrade` are all declared with zero parameters, so every one of these
+  // commands accepts exactly one flag: --help. Without this branch an
+  // unrecognized flag falls through and the command runs at FULL effect —
+  // `botmux update --check` and `botmux update --dry-run` read like probes and
+  // upgrade the whole fleet. The failure is silent and one-directional: the
+  // user who typed a guess gets the most destructive interpretation of it,
+  // and the flags most likely to be guessed are exactly the read-only ones.
+  if (fleetArgs.length > 0) {
+    console.error(`未知参数: ${fleetArgs.join(' ')}`);
+    console.error(`  \`botmux ${command}\` 不接受任何参数（只有 --help）。`);
+    console.error('  为避免把一个看起来像「只检查」的参数当成「执行」，这里直接中止，不做任何改动。');
+    process.exit(2);
+  }
 }
 
 // Workflow safety gate (Slice C0): a CLI invoked inside a workflow

--- a/src/cli/arg-utils.ts
+++ b/src/cli/arg-utils.ts
@@ -26,3 +26,34 @@ export function firstPositional(args: string[], flagsWithValue: string[]): strin
 export function hasFlagOrEq(args: string[], flag: string): boolean {
   return args.some(a => a === flag || a.startsWith(flag + '='));
 }
+
+/** The flag-looking tokens in `args` that this subcommand does not know.
+ *
+ *  Motivation: every parser in this file (and `argValue` / `argFlag` in cli.ts)
+ *  *pulls* the flags it wants out of argv and ignores the rest. That is fine
+ *  until the user's mental model of the flag set differs from the real one:
+ *  the misspelled or invented flag is then dropped in silence and the command
+ *  runs with its defaults, which is indistinguishable from the command having
+ *  understood the request. `botmux history --thread` reads as "read the thread"
+ *  and quietly returns the *session* scope instead.
+ *
+ *  Value tokens are skipped, so `--scope chat` does not report `chat`, and
+ *  `--scope=chat` is recognized in its `=` spelling too. Positional tokens are
+ *  deliberately NOT reported — only things that look like flags.
+ */
+export function unknownFlags(
+  args: readonly string[],
+  known: { valueFlags?: readonly string[]; boolFlags?: readonly string[] },
+): string[] {
+  const valueFlags = known.valueFlags ?? [];
+  const boolFlags = known.boolFlags ?? [];
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (valueFlags.includes(a)) { i++; continue; }                 // --flag value
+    if (valueFlags.some(f => a.startsWith(f + '='))) continue;     // --flag=value
+    if (boolFlags.includes(a)) continue;
+    if (a.startsWith('-')) out.push(a);
+  }
+  return out;
+}

--- a/test/cli-arg-utils.test.ts
+++ b/test/cli-arg-utils.test.ts
@@ -6,7 +6,7 @@
  * Run:  pnpm vitest run test/cli-arg-utils.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { firstPositional, hasFlagOrEq } from '../src/cli/arg-utils.js';
+import { firstPositional, hasFlagOrEq, unknownFlags } from '../src/cli/arg-utils.js';
 
 describe('firstPositional', () => {
   it('returns the first non-flag token in a plain positional list', () => {
@@ -59,5 +59,47 @@ describe('hasFlagOrEq', () => {
     // `--teammate` must not satisfy a `--team` check.
     expect(hasFlagOrEq(['--teammate', 'x'], '--team')).toBe(false);
     expect(hasFlagOrEq(['--teammate=x'], '--team')).toBe(false);
+  });
+});
+
+describe('unknownFlags', () => {
+  const KNOWN = { valueFlags: ['--limit', '--scope', '--session-id'], boolFlags: ['--with-card-json'] };
+
+  it('reports nothing for a fully recognized argv', () => {
+    expect(unknownFlags(['--limit', '10', '--scope', 'chat', '--with-card-json'], KNOWN)).toEqual([]);
+  });
+
+  it('recognizes the --flag=value spelling of a value flag', () => {
+    expect(unknownFlags(['--scope=chat', '--limit=10'], KNOWN)).toEqual([]);
+  });
+
+  it('reports an invented flag', () => {
+    // The real spelling is `--scope thread`. Before this check, `--thread` was
+    // dropped in silence and history answered with the session scope.
+    expect(unknownFlags(['--thread'], KNOWN)).toEqual(['--thread']);
+  });
+
+  it('does not mistake a value for a flag', () => {
+    expect(unknownFlags(['--scope', 'chat'], KNOWN)).toEqual([]);
+  });
+
+  it('does not mistake a negative numeric value for a flag', () => {
+    expect(unknownFlags(['--limit', '-5'], KNOWN)).toEqual([]);
+  });
+
+  it('does not accept a flag that merely shares a prefix with a known one', () => {
+    expect(unknownFlags(['--limitless'], KNOWN)).toEqual(['--limitless']);
+  });
+
+  it('reports every unknown flag, not just the first', () => {
+    expect(unknownFlags(['--thread', '--limit', '10', '--json'], KNOWN)).toEqual(['--thread', '--json']);
+  });
+
+  it('ignores positional tokens', () => {
+    expect(unknownFlags(['om_123', '--limit', '10'], KNOWN)).toEqual([]);
+  });
+
+  it('tolerates a value flag with no value at the end of argv', () => {
+    expect(unknownFlags(['--limit'], KNOWN)).toEqual([]);
   });
 });

--- a/test/cli-unknown-args.test.ts
+++ b/test/cli-unknown-args.test.ts
@@ -84,9 +84,13 @@ function runCli(args: string[]): { status: number | null; stdout: string; stderr
 }
 
 describe('fleet 变更类命令：未知参数一律中止', () => {
-  // 这五个命令在 dispatch 处都是零参数调用（`cmdStart()` / `cmdStop()` /
-  // `cmdRestart()` / `cmdUpgrade()`），所以「它们不接受任何参数」是由构造判定的，
-  // 不需要维护一张 flag 白名单。
+  // 放行哪些参数由 `FLEET_KNOWN_FLAGS` 这张显式的表决定，**不是**由「dispatch 处
+  // 零参数调用」推出来的。那条推论在本仓库不成立：`cmdStop()` / `cmdRestart()`
+  // 同样是零参数调用，却直接从全局 `process.argv` 里读 `--with-plugin`
+  // （`cmdLogs` / `cmdList` / `cmdSuspend` / `cmdSlash` 是同一个形状）。
+  // 函数签名管不住 `process.argv`，所以「这个命令接受哪些参数」只有那张表说了算。
+  // 下面「合法参数不被误杀」那一组就是这条推论的被试对象 —— 少了它，
+  // 把一个真参数闸掉的改动在这个文件里不会有任何一格变红。
   // 第三列是**这条命令进了 dispatch 之后打的第一行字**。断言它缺席，证明的是
   // 「根本没进去过」，而不只是「进去了但恰好失败了」—— PATH 为空时命令落进去
   // 也会失败、退出码同样非 0，所以只看退出码分不开这两件事。
@@ -122,6 +126,62 @@ describe('fleet 变更类命令：未知参数一律中止', () => {
     const r = runCli(['update', '--help']);
     expect(r.status).toBe(0);
     expect(r.stdout).toContain('botmux v');
+  });
+
+  // ── 合法参数不被误杀 ────────────────────────────────────────────────────
+  // `--with-plugin` 是 `stop` / `restart` 的正式参数：`cmdStop` (`process.argv
+  // .includes('--with-plugin')`) 与 `cmdRestart` 都读它，`showHelp()` 也在教用户
+  // 用它。一道只按「有没有多余 token」判断的闸会把它一起拒掉，而帮助里那一行仍在
+  // 宣传它 —— 那正是这道闸最容易犯的错，所以它必须在这里有被试对象。
+  //
+  // 判据不用退出码：`stop` 在空 HOME 下 rc=0、`restart` rc=1，两者都不为 2 只说明
+  // 「不是被这道闸拒的」，说明不了「进了 dispatch」。所以两条一起断言 ——
+  // 没有「未知参数」，且**打出了这条命令进 dispatch 之后的第一行字**。
+  // 这两个串同样是在 master 上实测出来的，与上面 it.each 第三列同源。
+  it.each([
+    ['stop', 'daemon 未在运行'],
+    ['restart', '未找到配置文件'],
+  ])('botmux %s --with-plugin 照常放行', (command, dispatchMarker) => {
+    const r = runCli([command, '--with-plugin']);
+    expect(r.stderr).not.toContain('未知参数');
+    expect(r.stdout + r.stderr).toContain(dispatchMarker);
+  });
+
+  // 白名单是**按命令**的，不是全局的：同一个 flag 在没声明它的命令上仍是未知参数。
+  // 少了这条，把 FLEET_KNOWN_FLAGS 摊平成一个全局集合不会有任何一格变红。
+  //
+  // `start --with-plugin` 落在这里是有意的，不是遗漏：`startConfiguredFleet` 无条件
+  // 调 `reconcilePluginServicesForCli(undefined, { autoOnly: true })`，start 本来就
+  // 永远拉起 auto plugin service；`--with-plugin` 在 stop/restart 上的语义是「额外
+  // 把 plugin service 也停掉」，start 没有「停」这一段，加上去是个不生效的参数。
+  it.each([
+    ['start', '未找到配置文件'],
+    ['update', '本地 checkout 更新'],
+  ])('botmux %s --with-plugin → rc=2（这条命令没声明它）', (command, dispatchMarker) => {
+    const r = runCli([command, '--with-plugin']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('未知参数');
+    expect(r.stderr).toContain('--with-plugin');
+    expect(r.stdout + r.stderr).not.toContain(dispatchMarker);
+  });
+
+  // 位置参数也要拦住。这一格不是顺带 —— 它排除了「用 `unknownFlags()` 实现这道闸」
+  // 这条改法：那个 helper 只报以 `-` 开头的 token（是为 `history om_xxx` 这类命令
+  // 设计的），照搬会让 `botmux stop foo` 静默通过，退回本 PR 之前的行为。
+  it('botmux stop foo → rc=2（位置参数同样是未知参数）', () => {
+    const r = runCli(['stop', 'foo']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('未知参数');
+    expect(r.stderr).toContain('foo');
+    expect(r.stdout + r.stderr).not.toContain('daemon 未在运行');
+  });
+
+  // 报错文案要按命令说出它到底接受什么，否则 stop/restart 上那句「只有 --help」
+  // 本身就是错的，用户会照着它把一个能用的参数当成不存在。
+  it('报错文案按命令列出可接受的参数', () => {
+    expect(runCli(['stop', '--force']).stderr).toContain('只接受: --help --with-plugin');
+    expect(runCli(['update', '--check']).stderr).toContain('只接受: --help');
+    expect(runCli(['update', '--check']).stderr).not.toContain('--with-plugin');
   });
 });
 

--- a/test/cli-unknown-args.test.ts
+++ b/test/cli-unknown-args.test.ts
@@ -1,0 +1,148 @@
+/**
+ * 不认识的参数必须让命令**停下**，不能被静默丢掉后按默认语义全效果执行。
+ *
+ * 这两组命令的解析方式都是「把要的参数从 argv 里拉出来，剩下的忽略」。
+ * 只要用户心里的参数集合和真实的不一致，拼错的或臆造的参数就会在无声中被丢掉，
+ * 而命令照常执行 —— 从输出上看，这和「命令听懂了」是同一个样子。
+ *
+ * 失效方向是单向的：
+ *   · `botmux update --check` / `--dry-run` 读起来都像「只看看」，实际会真的升级；
+ *   · `botmux history --thread`（正确写法是 `--scope thread`）会按 session scope
+ *     返回，而对一个 thread-scope 的会话来说那恰好是同一个窗口，连输出里都看不出来。
+ *
+ * Run:  bun run vitest run --project unit test/cli-unknown-args.test.ts
+ */
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { tsRunnerPrefix } from './helpers/ts-runner.js';
+
+const CLI = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+
+/** HOME 的递归快照：每个目录一条、每个文件一条「相对路径 + 内容 sha256 前 12 位」。
+ *  一条断言覆盖三个方向：新建 / 删除（路径集合变化）、就地改写（hash 变化）。
+ *  ⚠️ 只看顶层 `readdirSync` 是不够的：实测这些命令建的是 `.botmux/data/` 这类
+ *  **嵌套**路径，而往一个已存在的目录里写东西，顶层列表一个字都不会变。
+ *  夹具里放一个 `mutation-sentinel` 文件，是为了让「就地改写」这一维**有被试对象**
+ *  —— 没有任何既存文件时，那一维在构造上就没有主语，快照永远测不到它。
+ *  它是这条断言的输入，不是第二条断言。 */
+function snapshot(dir: string, root = dir, out: string[] = []): string[] {
+  for (const e of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) { out.push(relative(root, p) + '/'); snapshot(p, root, out); }
+    else if (e.isFile()) out.push(`${relative(root, p)}:${createHash('sha256').update(readFileSync(p)).digest('hex').slice(0, 12)}`);
+    else out.push(relative(root, p) + '?');
+  }
+  return out;
+}
+
+/** 在一个一次性 HOME 里跑 cli，返回 rc/stdout/stderr。
+ *  PATH 指向空目录：万一某天这道闸被拿掉，落进去的命令也找不到 git/包管理器，
+ *  不会真的动这台机器（既有的 cli-root-help 测试用的是同一个夹具）。 */
+function runCli(args: string[]): { status: number | null; stdout: string; stderr: string; homeUnchanged: boolean } {
+  const home = mkdtempSync(join(tmpdir(), 'botmux-unknown-arg-'));
+  const binDir = join(home, 'empty-bin');
+  mkdirSync(binDir);
+  writeFileSync(join(home, 'mutation-sentinel'), 'untouched\n');
+  try {
+    const env = {
+      ...process.env,
+      HOME: home,
+      PATH: binDir,
+      SESSION_DATA_DIR: join(home, '.botmux', 'data'),
+      BOTS_CONFIG: join(home, '.botmux', 'bots.json'),
+    };
+    delete env.BOTMUX_WORKFLOW;
+    const before = snapshot(home);
+    const { command: runner, prefixArgs } = tsRunnerPrefix();
+    let status: number | null = 0;
+    let stdout = '';
+    let stderr = '';
+    try {
+      stdout = execFileSync(runner, [...prefixArgs, CLI, ...args], { cwd: process.cwd(), env, encoding: 'utf-8' });
+    } catch (error) {
+      const e = error as { status?: number; stdout?: string; stderr?: string };
+      status = e.status ?? null;
+      stdout = e.stdout ?? '';
+      stderr = e.stderr ?? '';
+    }
+    return {
+      status,
+      stdout,
+      stderr,
+      homeUnchanged: JSON.stringify(snapshot(home)) === JSON.stringify(before),
+    };
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe('fleet 变更类命令：未知参数一律中止', () => {
+  // 这五个命令在 dispatch 处都是零参数调用（`cmdStart()` / `cmdStop()` /
+  // `cmdRestart()` / `cmdUpgrade()`），所以「它们不接受任何参数」是由构造判定的，
+  // 不需要维护一张 flag 白名单。
+  // 第三列是**这条命令进了 dispatch 之后打的第一行字**。断言它缺席，证明的是
+  // 「根本没进去过」，而不只是「进去了但恰好失败了」—— PATH 为空时命令落进去
+  // 也会失败、退出码同样非 0，所以只看退出码分不开这两件事。
+  //
+  // 这三个串不是猜的，是在**没有这道闸**的 master 上逐条实测出来的（同一套夹具）：
+  //   update / upgrade --check → rc=1，先打印「🔄 本地 checkout 更新：<repo>」，
+  //                              然后真的去跑 git（只因 PATH 为空才 ENOENT 收场）
+  //   restart / start          → rc=1，「❌ 未找到配置文件」
+  //   stop --force             → rc=0，「daemon 未在运行。」
+  it.each([
+    ['update', '--check', '本地 checkout 更新'],
+    ['update', '--dry-run', '本地 checkout 更新'],
+    ['update', '-n', '本地 checkout 更新'],
+    ['upgrade', '--check', '本地 checkout 更新'],
+    ['restart', '--now', '未找到配置文件'],
+    ['start', '--daemon', '未找到配置文件'],
+    ['stop', '--force', 'daemon 未在运行'],
+  ])('botmux %s %s → rc=2，不执行', (command, flag, dispatchMarker) => {
+    const r = runCli([command, flag]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('未知参数');
+    expect(r.stderr).toContain(flag);
+    expect(r.stdout + r.stderr).not.toContain(dispatchMarker);
+    // ⚠️ 这条断言的区分力**逐格不同**，同样是实测：没有这道闸时，
+    //    update / upgrade 会新建 `.botmux/`+`.botmux/data/`，stop 会新建 4 个目录
+    //    ⇒ 这四格上它真的会红；restart / start 在写任何东西之前就因缺配置退出
+    //    ⇒ 那两格上它**恒绿**，那两格的全部区分力在上面那行 dispatchMarker 上。
+    //    写在这儿是为了下一个人不要把「它一直是绿的」读成「它守住了什么」。
+    expect(r.homeUnchanged).toBe(true);
+  });
+
+  it('--help 仍然照常打印帮助（不能被这道闸误伤）', () => {
+    const r = runCli(['update', '--help']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('botmux v');
+  });
+});
+
+describe('botmux history：未知参数一律中止', () => {
+  it.each([
+    // 并不存在 `--thread`；正确写法是 `--scope thread`。
+    ['--thread'],
+    ['--json'],
+    // 与已知参数共享前缀，仍然算未知。
+    ['--limitless'],
+  ])('botmux history %s → rc=2', (flag) => {
+    const r = runCli(['history', flag]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('未知参数');
+    expect(r.stderr).toContain(flag);
+  });
+
+  it('认识的参数不会被这道闸挡住', () => {
+    // 这条用例只断言「没有被参数校验挡下」。它之后会撞上 transport / session 闸并
+    // 以别的方式退出（那些闸也用 rc=2），所以退出码在这里没有区分力，不拿它做判据。
+    const r = runCli(['history', '--limit', '10', '--scope', 'chat', '--with-card-json']);
+    expect(r.stderr).not.toContain('未知参数');
+  });
+});

--- a/test/cli-unknown-args.test.ts
+++ b/test/cli-unknown-args.test.ts
@@ -31,9 +31,19 @@ const CLI = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
  *  **嵌套**路径，而往一个已存在的目录里写东西，顶层列表一个字都不会变。
  *  夹具里放一个 `mutation-sentinel` 文件，是为了让「就地改写」这一维**有被试对象**
  *  —— 没有任何既存文件时，那一维在构造上就没有主语，快照永远测不到它。
- *  它是这条断言的输入，不是第二条断言。 */
+ *  它是这条断言的输入，不是第二条断言。
+ *
+ *  `.bun` 在**根一级**被跳过：那是 Bun 运行时自己的 install cache
+ *  （`.bun/install/cache/@t@/*.pile`），由跑子进程的**解释器**写入，与被测命令
+ *  无关 —— 只在本套件跑在 `bun test` 下时出现，Node 下永远没有。实测在
+ *  `bun test` 里它会铺开 300+ 个文件，把这条断言整片染红。
+ *  ⚠️ 只预置一个空 `.bun/` 目录**不够**：递归快照会看见里面新铺的整棵缓存树。
+ *  也不能靠 env 挡（实测 `BUN_INSTALL` / `BUN_INSTALL_CACHE_DIR` 都不改这个位置）。
+ *  所以按仓内既有做法过滤这一个条目（同 `test/cli-root-help.test.ts`），
+ *  而不是把断言弱化成子集匹配 —— 任何 botmux 自己创建的文件仍然会让它红。 */
 function snapshot(dir: string, root = dir, out: string[] = []): string[] {
   for (const e of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (dir === root && e.name === '.bun') continue;
     const p = join(dir, e.name);
     if (e.isDirectory()) { out.push(relative(root, p) + '/'); snapshot(p, root, out); }
     else if (e.isFile()) out.push(`${relative(root, p)}:${createHash('sha256').update(readFileSync(p)).digest('hex').slice(0, 12)}`);


### PR DESCRIPTION
## 问题

不认识的参数会被**静默丢掉**，命令随即按默认语义**全效果执行**。两处：

**1）`botmux update` / `upgrade` / `start` / `stop` / `restart`**

这五个命令目前只识别 `--help` / `-h`，其余任何参数都会穿过去：

```
botmux update --check      # 读起来像「只检查有没有新版本」
botmux update --dry-run    # 读起来像「只演练一遍」
botmux update -n           # 同上
```

三条**都会真的升级**（本地 checkout 形态下是 `git pull --ff-only` + 重新 build +
重启 daemon）。失效方向是单向的：猜错参数的人拿到的是这条命令**破坏性最大**的那个
解释，而最容易被猜出来的参数恰好全是只读语义的那几个。

`cmdUpgradeLocalDev` 自己的注释写的是 fail closed（「有未提交改动就中止，不偷偷
stash」）——这个 PR 只是把同一个原则前移一步：**参数没看懂就不要执行。**

**2）`botmux history`**

`cmdHistory` 用 `argValue(rest, '--limit' | '--scope' | '--session-id')` 把要的参数
**拉**出来，剩下的一律忽略。`--scope` 的**取值**是校验的，`--scope` 这个**名字**不是。
于是 `botmux history --thread`（并不存在这个参数，正确写法是 `--scope thread`）
不报错、不提示，直接按 session scope 返回——对一个 thread-scope 的会话来说
恰好是同一个窗口，所以连输出里都看不出来。

这一处的现有代码已经接受了同一条论证：`--limit` 的解析上方写着

> A stray `--limit 0` or a typo like `--limit abc` (→ NaN) must NOT silently
> dump the entire history.

——本 PR 把这条从「参数的值」推广到「参数的名字」。

## 修改

**`src/cli.ts`（fleet 命令）**：这五个命令在 dispatch 处都是零参数调用
（`cmdStart()` / `cmdStop()` / `cmdRestart()` / `cmdUpgrade()`），所以「它们不接受任何
参数」是可以由构造判定的，不需要维护一张 flag 白名单。`--help` 之外的任何参数 ⇒
打印 `未知参数: …` 并 `exit(2)`，不做任何改动。

**`src/cli/arg-utils.ts`**：新增 `unknownFlags(args, { valueFlags, boolFlags })`，
返回 argv 里「看起来是参数、但这个子命令不认识」的 token。会跳过取值参数的值，
支持 `--flag=value` 拼法，不报告位置参数。放在这个 side-effect-free 模块里，
可以直接做单元测试。

**`src/cli.ts`（`cmdHistory`）**：在**任何副作用之前**用它校验参数名，
不认识就 `未知参数: …` + `exit(2)` 并打印用法行。

`exit(2)` 与仓内既有的「用法/前置条件错误」惯例一致（如 `cmdServe`、
`requireWhiteboardEnabled`）。文案沿用仓内既有的 `未知参数: ` 前缀。

## 测试

- `test/cli-arg-utils.test.ts`：`unknownFlags` 的单元测试，含
  「不要把取值参数的值当成参数」「不要把 `-5` 当成参数」
  「共享前缀的 `--limitless` 仍算未知」「多个未知参数要全报」。
- `test/cli-unknown-args.test.ts`（新增）：端到端跑真实 CLI，覆盖两个改动点
  —— 舰队命令 7 例（`update --check` / `update --dry-run` / `update -n` /
  `upgrade --check` / `restart --now` / `start --daemon` / `stop --force`）与
  `history` 3 例（`--thread` / `--json` / `--limitless`）。每例断言 `rc=2`、
  stderr 含 `未知参数` 与那个参数本身、临时 HOME 的目录列表与哨兵文件**逐字节不变**。
  其中一条断言是承重的：stdout **不含** `本地 checkout 更新`
  ——`cmdUpgrade` 的本地分支第一件事就是打印这一行，所以它的缺席证明的是
  「根本没进去过」，而不只是「进去了但恰好失败了」。
  另有两条反向用例：`botmux update --help` 仍 `rc=0` 并打印版本；一条完全合法的
  `history` 调用不被拦（只断言 stderr 不含 `未知参数` —— rc 在这里没有区分力，
  `assertTurnTransportOrExit` 也会退 2）。
  ⚠️ 这个文件是**端到端**的，不是 `unknownFlags` 的单元测试：单元测试只能证明
  helper 自己对，证不了 `cmdHistory` 真的调用了它。

## 回归

macOS / node 22 / bun 1.4.0 上跑了 `bun run build && bun run test`
（`vitest --project unit`，19,710 例）与 `bun run workflow-core:test`。
把同一台机器上 `master` 的裸跑当对照，两次的失败集合**逐条相同**：
3 例，全部与本 PR 无关（`/var` 与 `/private/var` 的 realpath 差异、
路径里 `_` 的转义、install.sh 布局），在 `master` 上原样复现。
