### PR TITLE
fix(terminal): 底层 pane 被回收后唤醒 worker，而不是永久 502

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -2746,6 +2746,11 @@ export async function restoreActiveSessions(
   logger.info(`Restored ${active.length} session(s)${hasPersistentBackend ? '' : ', waiting for messages to resume'}`);
 }
 
+/** Re-attaching to a pane that is already alive: the worker only has to reconnect. */
+const TERMINAL_REATTACH_TIMEOUT_MS = 10_000;
+/** Cold wake: create the backing pane, boot the CLI, then report `ready`. */
+const TERMINAL_COLD_WAKE_TIMEOUT_MS = 40_000;
+
 /**
  * Resolve a session's live web-terminal worker port, WAKING the worker on demand
  * if needed.
@@ -2760,11 +2765,19 @@ export async function restoreActiveSessions(
  * worker to re-attach (empty prompt = no new turn, same as restart reattach) and
  * wait for it to report its port.
  *
+ * A pane that is definitively GONE is still serveable: `forkWorker` recreates
+ * it, which is exactly what an incoming message already does for the same
+ * session. Panes get reclaimed routinely — the idle-worker sweeper suspends
+ * worker + CLI + pane together once a session is over `maxLiveWorkers` — so
+ * refusing to wake on 'missing' makes the terminal 502 permanently for every
+ * dormant session. Adopted sessions are the exception (see below).
+ *
  * Returns the port, or undefined when there's nothing serveable (no live worker
- * possible: not active, non-persistent backend, or the pane is gone). The
- * `forkWorker` double-fork guard plus its synchronous `ds.worker` assignment make
- * concurrent calls (the terminal's HTML GET + WS upgrade arrive together) safe —
- * only the first forks; the rest just await the same `ds.workerPort`.
+ * possible: not active, non-persistent backend, an unprobeable pane, or an
+ * adopted session whose pane is gone). The `forkWorker` double-fork guard plus
+ * its synchronous `ds.worker` assignment make concurrent calls (the terminal's
+ * HTML GET + WS upgrade arrive together) safe — only the first forks; the rest
+ * just await the same `ds.workerPort`.
  */
 export async function ensureTerminalWorkerPort(ds: DaemonSession): Promise<number | undefined> {
   const frozenBackendType = ds.initConfig?.backendType ?? ds.session.backendType;
@@ -2776,31 +2789,49 @@ export async function ensureTerminalWorkerPort(ds: DaemonSession): Promise<numbe
 
   const backendType = getSessionPersistentBackendType(ds);
   if (!backendType) return undefined;
-  // Non-destructive read path: only wake a worker when the backing pane is
-  // CONFIRMED alive. 'missing' or 'unknown' both bail (a 502 the terminal
-  // retries) — same conservative stance as the old boolean check, with no risk
-  // of closing anything.
   const backendTarget = persistentBackendTargetForSession(ds)!;
-  if (probePersistentBackendTarget(backendTarget) !== 'exists') {
-    return undefined;
-  }
+  const paneProbe = probePersistentBackendTarget(backendTarget);
+  // 'unknown' is ignorance, not absence — the probe itself failed. Bail (a 502
+  // the terminal retries) rather than act on it; this is the one case where the
+  // old `!== 'exists'` stance was right.
+  if (paneProbe === 'unknown') return undefined;
+  const coldWake = paneProbe === 'missing';
+  // Adopted sessions are the exception to waking on 'missing': the wake below
+  // goes through `forkWorker`, NOT `forkAdoptWorker`, so it would create a fresh
+  // `bmx-*` pane and push wrapped input into a CLI the user never injected.
+  // Same hazard, same predicate as the idle sweeper's own exclusion
+  // (`idle-worker-sweeper.ts`: `!ds.adoptedFrom && !ds.session.adoptedFrom`) —
+  // both fields, because a restored adopt session only carries the persisted one.
+  if (coldWake && (ds.adoptedFrom || ds.session.adoptedFrom)) return undefined;
 
+  // Only a fork we perform here can be a cold start. If a worker is already
+  // live we are just waiting for its port, which is the re-attach budget no
+  // matter what the pane probe said.
+  let forkedCold = false;
   if (!ds.worker) {
-    logger.info(`[${ds.session.sessionId.substring(0, 8)}] terminal accessed with no live worker — waking to re-attach`);
+    logger.info(
+      `[${ds.session.sessionId.substring(0, 8)}] terminal accessed with no live worker — `
+      + (coldWake ? 'backing pane is gone, waking cold' : 'waking to re-attach'),
+    );
     // Lazy-wake is a fork boundary too. The central guard inside forkWorker
     // refuses (returns false) for a quarantined tail-only owner whose promotion
     // still fails — waking a blank worker beside an unpromoted tail would wedge
     // the FIFO gate. Report unavailable (the terminal retries / 502s) instead of
-    // blocking 10s for a port that will never arrive.
+    // blocking for a port that will never arrive.
     if (!forkWorker(ds, '', true)) {
       logger.warn(`[${ds.session.sessionId.substring(0, 8)}] terminal wake refused (quarantined tail-only owner); serving unavailable`);
       return undefined;
     }
+    forkedCold = coldWake;
   }
 
   // Wait (bounded) for the re-forked worker to report its HTTP port via `ready`.
   // Re-attach is fast (~1-2s in practice); 10s covers a slow CLI restart.
-  const deadlineMs = Date.now() + 10_000;
+  // A cold wake is a different, slower operation — it has to create the pane and
+  // boot the CLI before `ready` can be sent — so it gets its own bound instead
+  // of widening the re-attach one.
+  const deadlineMs = Date.now()
+    + (forkedCold ? TERMINAL_COLD_WAKE_TIMEOUT_MS : TERMINAL_REATTACH_TIMEOUT_MS);
   while (Date.now() < deadlineMs) {
     if (ds.workerPort) return ds.workerPort;
     await new Promise((r) => setTimeout(r, 100));

--- a/src/dashboard/terminal-front-proxy.ts
+++ b/src/dashboard/terminal-front-proxy.ts
@@ -16,8 +16,20 @@ import type {
 
 export const TERMINAL_CONTROL_HEADER = 'x-botmux-terminal-control';
 export { TERMINAL_VIEW_FORWARD_HEADER };
-/** Covers daemon wake-up (up to 10s) plus a bounded worker handshake. Cleared
- * as soon as response/upgrade headers arrive, so live streams stay unbounded. */
+/** Covers a daemon wake-up plus a bounded worker handshake. Cleared as soon as
+ * response/upgrade headers arrive, so live streams stay unbounded.
+ *
+ * Note this 30s is now SHORTER than the wake it has to cover:
+ * `ensureTerminalWorkerPort` allows up to 40s for a cold wake (create the pane,
+ * boot the CLI), and the daemon sends no bytes until it resolves, so the last
+ * 10s is unreachable through this hop. That is not a lost wake — the fork is
+ * not cancelled by the 502 that follows, so the first click starts it and a
+ * later one hits the fast `resolvePort` path. A dashboard talking to the daemon
+ * proxy directly has no such ceiling and can use the full 40s.
+ *
+ * Raising this is a separate change, not a follow-up to that one: it is armed
+ * on both the HTTP and the upgrade path, so it also bounds requests that have
+ * nothing to do with waking. */
 export const TERMINAL_UPSTREAM_RESPONSE_TIMEOUT_MS = 30_000;
 /**
  * P1-2：upgrade 请求收到非 101 回应 = 一次拒绝，不是长连接。清掉唯一那道计时器

--- a/test/terminal-cold-wake.test.ts
+++ b/test/terminal-cold-wake.test.ts
@@ -1,0 +1,185 @@
+/**
+ * `ensureTerminalWorkerPort` — a dormant session's web terminal must be able to
+ * cold-wake, instead of 502-ing forever.
+ *
+ * The backing pane being GONE is the normal state for most sessions on a box
+ * with a small `maxLiveWorkers`: the idle sweeper suspends worker + CLI + pane
+ * together. Refusing to wake on 'missing' therefore does not protect anything —
+ * it just makes `/s/{id}` permanently unavailable for every session but the
+ * live one. `forkWorker` recreates the pane, which is the same thing an
+ * incoming message already does.
+ *
+ * The two things that must NOT change with it:
+ *   · 'unknown' still bails — a failed probe is ignorance, not absence.
+ *   · adopted sessions still bail on 'missing' — waking one through
+ *     `forkWorker` would push wrapped input into a CLI the user never injected.
+ *
+ * Run:  bun run vitest run --project unit test/terminal-cold-wake.test.ts
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SessionProbe } from '../src/adapters/backend/types.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+const state = vi.hoisted(() => ({
+  probe: 'exists' as SessionProbe,
+  /** Not hardcoded to 'tmux': a mock pinned to one value quietly deletes the
+   *  branch it is pinning. `undefined` (no persistent backend) is a real
+   *  production path out of this function and needs its own cell. */
+  backendType: 'tmux' as string | undefined,
+  logs: [] as string[],
+  forkCalls: [] as unknown[][],
+  /** what the forked worker does: bind a port after `portAfterMs`, or never. */
+  portAfterMs: 0 as number | null,
+  forkResult: true,
+}));
+
+// The wake log line is the only field-observable difference between a cold wake
+// and a re-attach, and diagnosing this class of failure in production starts by
+// grepping for it (its ABSENCE is what proved the old gate never let anything
+// through). So it is asserted, not just printed.
+vi.mock('../src/utils/logger.js', () => ({
+  logger: {
+    info: (m: string) => { state.logs.push(m); },
+    warn: (m: string) => { state.logs.push(m); },
+    error: (m: string) => { state.logs.push(m); },
+    debug: () => {},
+  },
+}));
+
+vi.mock('../src/core/persistent-backend.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../src/core/persistent-backend.js')>(),
+  getSessionPersistentBackendType: vi.fn(() => state.backendType),
+  persistentBackendTargetForSession: vi.fn(() => ({ backendType: 'tmux', sessionName: 'bmx-test' })),
+  probePersistentBackendTarget: vi.fn(() => state.probe),
+}));
+
+vi.mock('../src/core/worker-pool.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../src/core/worker-pool.js')>(),
+  forkWorker: vi.fn((ds: DaemonSession, ...rest: unknown[]) => {
+    state.forkCalls.push([ds, ...rest]);
+    if (!state.forkResult) return false;
+    ds.worker = {} as DaemonSession['worker'];
+    if (state.portAfterMs !== null) {
+      setTimeout(() => { ds.workerPort = 47_111; }, state.portAfterMs);
+    }
+    return true;
+  }),
+}));
+
+const { ensureTerminalWorkerPort } = await import('../src/core/session-manager.js');
+
+function makeDs(overrides: Partial<DaemonSession> = {}): DaemonSession {
+  return {
+    session: { sessionId: 'sess-0001-cold-wake', status: 'active', backendType: 'tmux' },
+    worker: undefined,
+    workerPort: null,
+    ...overrides,
+  } as unknown as DaemonSession;
+}
+
+beforeEach(() => {
+  state.probe = 'exists';
+  state.backendType = 'tmux';
+  state.logs = [];
+  state.forkCalls = [];
+  state.portAfterMs = 0;
+  state.forkResult = true;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ensureTerminalWorkerPort — pane probe', () => {
+  it('a session with no persistent backend bails, and never reaches the probe', async () => {
+    state.backendType = undefined;
+    const ds = makeDs();
+    expect(await ensureTerminalWorkerPort(ds)).toBeUndefined();
+    expect(state.forkCalls.length).toBe(0);
+    expect(state.logs.filter(l => l.includes('terminal accessed with no live worker')).length).toBe(0);
+  });
+
+  it.each<[SessionProbe, boolean, string | undefined]>([
+    ['exists', true, 'waking to re-attach'],
+    // The regression this file exists for: before, 'missing' returned undefined
+    // and the terminal 502'd forever.
+    ['missing', true, 'backing pane is gone, waking cold'],
+    ['unknown', false, undefined],
+  ])('probe=%s → wakes: %s', async (probe, shouldWake, logMarker) => {
+    state.probe = probe;
+    const ds = makeDs();
+    const port = await ensureTerminalWorkerPort(ds);
+    expect(state.forkCalls.length).toBe(shouldWake ? 1 : 0);
+    expect(port).toBe(shouldWake ? 47_111 : undefined);
+    // Not just "a line was printed": the two wake kinds must stay
+    // distinguishable, and 'unknown' must stay silent about waking.
+    const wakeLines = state.logs.filter(l => l.includes('terminal accessed with no live worker'));
+    expect(wakeLines.length).toBe(shouldWake ? 1 : 0);
+    if (logMarker) expect(wakeLines[0]).toContain(logMarker);
+  });
+
+  it('an already-live worker is served without forking at all', async () => {
+    const ds = makeDs({ workerPort: 5000 });
+    expect(await ensureTerminalWorkerPort(ds)).toBe(5000);
+    expect(state.forkCalls.length).toBe(0);
+  });
+
+  it('a refused fork serves unavailable rather than waiting for a port', async () => {
+    state.probe = 'missing';
+    state.forkResult = false;
+    const ds = makeDs();
+    expect(await ensureTerminalWorkerPort(ds)).toBeUndefined();
+    expect(state.forkCalls.length).toBe(1);
+  });
+});
+
+describe('ensureTerminalWorkerPort — adopted sessions never cold-wake', () => {
+  // `forkWorker` (not `forkAdoptWorker`) would create a fresh bmx-* pane and
+  // push wrapped input into the user's own CLI. Both fields are checked because
+  // a restored adopt session only carries the persisted one — same predicate as
+  // `idle-worker-sweeper.ts`.
+  const adopted = { target: 'user-pane' } as unknown as DaemonSession['adoptedFrom'];
+
+  it.each<[string, Partial<DaemonSession>]>([
+    ['ds.adoptedFrom', { adoptedFrom: adopted }],
+    ['ds.session.adoptedFrom', {
+      session: {
+        sessionId: 'sess-0002-adopt', status: 'active', backendType: 'tmux', adoptedFrom: adopted,
+      } as unknown as DaemonSession['session'],
+    }],
+  ])('probe=missing + %s → bails, no fork', async (_label, overrides) => {
+    state.probe = 'missing';
+    const ds = makeDs(overrides);
+    expect(await ensureTerminalWorkerPort(ds)).toBeUndefined();
+    expect(state.forkCalls.length).toBe(0);
+  });
+
+  it('probe=exists + adopted still re-attaches (this change must not narrow that)', async () => {
+    state.probe = 'exists';
+    const ds = makeDs({ adoptedFrom: adopted });
+    expect(await ensureTerminalWorkerPort(ds)).toBe(47_111);
+    expect(state.forkCalls.length).toBe(1);
+  });
+});
+
+describe('ensureTerminalWorkerPort — the cold path gets its own budget', () => {
+  // Re-attach is a reconnect (~1-2s). A cold wake has to create the pane AND
+  // boot the CLI first, so the same 10s bound would time out on exactly the
+  // sessions this change is meant to serve. 20s is picked to sit between the
+  // two bounds: the re-attach budget must have expired, the cold one must not.
+  const BETWEEN = 20_000;
+
+  it.each<[SessionProbe, number | undefined]>([
+    ['exists', undefined],
+    ['missing', 47_111],
+  ])('probe=%s, port arrives at 20s → %s', async (probe, expected) => {
+    vi.useFakeTimers();
+    state.probe = probe;
+    state.portAfterMs = BETWEEN;
+    const ds = makeDs();
+    const pending = ensureTerminalWorkerPort(ds);
+    await vi.advanceTimersByTimeAsync(45_000);
+    expect(await pending).toBe(expected);
+  });
+});

--- a/test/terminal-cold-wake.test.ts
+++ b/test/terminal-cold-wake.test.ts
@@ -182,4 +182,35 @@ describe('ensureTerminalWorkerPort — the cold path gets its own budget', () =>
     await vi.advanceTimersByTimeAsync(45_000);
     expect(await pending).toBe(expected);
   });
+
+  // The budget comes from what ACTUALLY happened (`forkedCold`), not from what
+  // the probe said (`coldWake`). The two disagree in exactly one state, and it
+  // is a real window rather than a contrived one: the message path assigns
+  // `ds.worker` synchronously when it forks, and the worker child creates the
+  // pane only afterwards — a terminal opened in between sees a live worker and
+  // a missing pane. Nothing here cold-starts: we are waiting for a worker that
+  // is already booting, which is the re-attach case.
+  //
+  // Without this cell the distinction has no guard at all. Both reviewers
+  // independently changed `forkedCold` back to `coldWake` and got 11/11 green,
+  // i.e. the trap the PR description names ("that would hand the 40s budget to
+  // a session that never cold-started") was untested. Under that mutant this
+  // case returns 47_111 instead of undefined.
+  it('worker 已在（非本函数 fork）+ probe=missing → 仍走 re-attach 预算', async () => {
+    vi.useFakeTimers();
+    state.probe = 'missing';
+    // The port is scheduled by the test, not by the forkWorker mock: the whole
+    // point is that this call must NOT fork.
+    state.portAfterMs = null;
+    const ds = makeDs({ worker: {} as DaemonSession['worker'] });
+    setTimeout(() => { ds.workerPort = 47_111; }, BETWEEN);
+
+    const pending = ensureTerminalWorkerPort(ds);
+    await vi.advanceTimersByTimeAsync(45_000);
+
+    expect(await pending).toBeUndefined();
+    // Load-bearing: if this ever forks, `forkedCold` would legitimately be true
+    // and the case would be asserting something else entirely.
+    expect(state.forkCalls.length).toBe(0);
+  });
 });


### PR DESCRIPTION
## 问题

会话休眠过之后，Web 终端就再也打不开了，恒 502；而同一个会话收一条消息就能正常唤醒。

`ensureTerminalWorkerPort` 探测底层 pane，只要结果不是 `exists` 就直接返回 undefined。但 `SessionProbe` 的三个取值不是一回事：

- `unknown` = 探测本身失败了，这是无知不是缺席；
- `missing` = pane 确实没了 —— 而 pane 被回收是**常规路径**，不是异常。idle-worker-sweeper 会把 worker + CLI + pane 一起挂起。

所以每一个被 sweeper 收过一次的会话，Web 终端从此永久不可用。消息路径对同一个会话走的也是 `forkWorker`，一样会重建 pane —— 也就是说「pane 没了」这件事本身并不妨碍服务，只有终端这条路径把它当成了终局。

## 改动

`missing` 也唤醒，`unknown` 保持 bail，另加两处：

**1. adopt 会话例外。** 这里的唤醒走 `forkWorker` 而不是 `forkAdoptWorker`：对 adopt 会话它会新建一个 `bmx-*` pane，并把包装过的输入推给一个用户从没注入过的 CLI。谓词与 idle sweeper 自己的排除项逐字相同（`!ds.adoptedFrom && !ds.session.adoptedFrom`），两个字段都判 —— restore 回来的 adopt 会话只带持久化的那一个。

**2. 冷启单独给预算，而不是把 re-attach 的 10s 调大。** 这是两段不同的操作：re-attach 只要 worker 重连（10s 不动）；冷启要先建 pane、再启动 CLI，然后才谈得上 `ready`。10s 对冷启是必然超时。

预算取自「实际发生了哪一种」，不取自「探测说了什么」：只有本函数自己 fork 出来的那一次才算冷启（`forkedCold`）。worker 本来就活着时，无论 pane 探测结果如何，等的都是 re-attach —— 第一版补丁在这里用了 `coldWake`，那会把 40s 预算发给一个根本没冷启过的会话。

超时的失效方向不变：返回 undefined、终端 502 后重试，不破坏任何状态。

关于 CONTRIBUTING 的 timing 约定：40s 不是「把一个超时调大」，是给一段确实更慢、且在做实事的操作单独定界；被加宽的那条路径（re-attach）一个字没动。测试里用假定时器，没有 fixed sleep。

## 测试

新增 `test/terminal-cold-wake.test.ts`，11 例：

1. **pane 探测三态**各一例，并且断言唤醒**日志行**：`missing` 与 `exists` 必须打不同的标记，`unknown` 必须完全不打。那行日志是生产上区分冷启与 re-attach 的唯一可观测信号（它的**缺席**正是这个 bug 的诊断依据），所以它是被断言的，不是只被打印的。
2. **adopt 两个字段各一例**（`missing` 时 bail），外加一例 adopt + `exists` 仍然 re-attach —— 否则「adopt 一律不服务」也能让前两例转绿。
3. **两条预算各一例**：假定时器下让端口在 20 000 ms 到达，它落在 10s 与 40s 之间，于是 `exists` 必须返回 undefined、`missing` 必须拿到端口。
4. 另有：worker 已经活着时不再 fork；`forkWorker` 拒绝时立即返回 unavailable 而不是空等一个预算。
5. 没有持久化后端的会话直接 bail、连探测都不到 —— 这一格是**补的**：夹具原先把 `getSessionPersistentBackendType` 写死成 `'tmux'`，而那个写死**悄悄删掉了它所固定的那条分支**（`undefined` 是本函数一条真实的生产出口，却 0 例覆盖）。

验收（四格都跑过，不只是「新测试是绿的」）：

- **好输入必绿**：打上补丁 → 11 passed。
- **坏输入必红**：同一个测试文件放在**未打补丁的 master** 上 → 3 failed / 8 passed（`probe=missing → wakes`、`refused fork`、`missing 在 20s 拿到端口`）。这一格不需要造变异，没有补丁的世界就是现成的坏输入。
- **错误修法必红**：五个变异，命中互不重叠 ——
  - 删掉 adopt 守卫 → 2 failed（且只有那两格）
  - 删掉 `unknown` 的 bail → 1 failed（`probe=unknown`）
  - 把三元预算换成单一的 40s → 1 failed（`probe=exists` 那一格）
  - 把两个日志标记合并成一个 → 1 failed（`probe=missing`）—— 这个变异**不改变任何行为**，只毁掉诊断信号，它依然判红。
  - 删掉 `if (!backendType) return undefined;` → 1 failed（新补的那一格）
  每个变异都打了 diff 证明确实落地，跑完还原并 `cmp` 证明与变异前逐字节相同。

## 回归

`vitest run --project unit` 全量，同机、同一份 `node_modules`、与**同一个 base commit 的干净 worktree** 对照。跑了 5 次（干净 master 3 次 / 本分支 2 次）：

- 干净 master：3 failed / 3 failed / 4 failed（1157 文件，19684 例）
- 本分支：4 failed / 4 failed（1158 文件，19694 例 —— 多出来的 10 例是本 PR 的新文件（后来又加了第 11 例），两跑全绿）

**5 跑都失败的稳定集合**（与本 PR 无关，干净 master 上同样失败）：
`brand-template` · `claim-botmux-bin-binary` · `sandbox-shim-compiled-form`。

除此之外每跑至多多出 1 例，5 跑里出现了 3 次，**每次是不同的文件**：
`codex-app-threads`（本分支）· `tmux-pipe-backend-exit`（本分支）· `fleet-supervisor.integration`（**干净 master**）。三者都是起真子进程、等回收/清理的用例，单独跑各 2~3 次全绿。干净 master 上同样出现 ⇒ 是这台机器满载时的抖动，不是本 PR 引入的。

（n 很小，就报数：不宣称「无抖动」，只宣称抖动在两侧都出现、且不落在本 PR 碰过的模块上。）

## 已知缺口（明说）

40 000 这个数是**预算**，不是实测的冷启耗时上界 —— 没有测试能证明真实冷启一定在 40s 内完成。它只保证「10s 必然不够」这件事被修掉，且超时的后果与今天相同（502 + 重试）。
