### PR TITLE
fix(test): 收敛 bun 腿的确定性红——空数组 each 行吞参数（3 处）+ AST 守卫

### DIFF
--- a/test/bot-description-schema.test.ts
+++ b/test/bot-description-schema.test.ts
@@ -12,7 +12,12 @@ describe('normalizeBotDescriptions', () => {
     });
   });
 
-  it.each([null, [], 'text', {}, { zh: 'x' }, { __proto__: 'x' }])(
+  // Rows are wrapped in tuples on purpose. A BARE `[]` row spreads to ZERO arguments,
+  // and a callback that declares a parameter then looks like it wants a `done`
+  // callback — `bun test` waits for one and the case dies at the timeout (measured:
+  // 180s, on a synchronous body that cannot hang). vitest passes the empty array
+  // through as the single argument instead. `[[]]` is unambiguous under both.
+  it.each([[null], [[]], ['text'], [{}], [{ zh: 'x' }], [{ __proto__: 'x' }]])(
     'rejects a malformed map: %j',
     value => expect(normalizeBotDescriptions(value)).toMatchObject({ ok: false }),
   );

--- a/test/budget-tracker.test.ts
+++ b/test/budget-tracker.test.ts
@@ -82,7 +82,10 @@ describe('parseBudgetConfig', () => {
     expect(parseBudgetConfig({ monthlyCny: 100, hardStop: 'yes' })?.hardStop).toBe(false);
   });
 
-  it.each([null, undefined, 'str', [], 42, true])('returns null for garbage input (%s)', (raw) => {
+  // Tuple-wrapped: a bare `[]` row spreads to zero arguments, so a callback with a
+  // declared parameter reads as wanting a `done` callback and `bun test` hangs until
+  // the timeout. See the same note in test/bot-description-schema.test.ts.
+  it.each([[null], [undefined], ['str'], [[]], [42], [true]])('returns null for garbage input (%s)', (raw) => {
     expect(parseBudgetConfig(raw)).toBeNull();
   });
 });

--- a/test/bun-runner-selectors.test.ts
+++ b/test/bun-runner-selectors.test.ts
@@ -122,3 +122,62 @@ describe('bun leg selectors — this guard runs inside the leg it guards', () =>
     expect(isDeferredFromBunLeg(readFileSync('test/bun-runner-selectors.test.ts', 'utf8'))).toBe(false);
   });
 });
+
+describe('no test file may use a bare empty-array each row', () => {
+  it('finds none across the whole suite', async () => {
+    // A BARE `[]` row in `it.each([...])` spreads to ZERO arguments under `bun test`, so
+    // a callback declaring a parameter looks like it wants a `done` callback: the runner
+    // waits and the case dies at the timeout. Three files had it, each burning the full
+    // 180s ceiling on a body that cannot hang, which reads as a deadlock rather than as
+    // bad data. Writing `[[]]` is unambiguous under both runners.
+    //
+    // Scanned with the TypeScript AST, not a regex: a text pattern for this missed
+    // `test/model-pricing.test.ts` (the row sat among other bare values), and a
+    // silently-incomplete scan is exactly how the third instance survived the first fix.
+    const ts = await import('typescript');
+    const { readdirSync, readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    const excluded = new Set(['e2e-browser', 'node_modules', 'fixtures', '__snapshots__']);
+    const walk = (dir: string): string[] => {
+      const out: string[] = [];
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (!excluded.has(entry.name)) out.push(...walk(full));
+        } else if (/\.(test|spec)\.ts$/.test(entry.name)) {
+          out.push(full);
+        }
+      }
+      return out;
+    };
+
+    const files = walk('test');
+    // Guard the guard: an empty file list would make this pass vacuously.
+    expect(files.length).toBeGreaterThan(500);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8');
+      const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+      const visit = (node: import('typescript').Node): void => {
+        if (ts.isCallExpression(node)
+          && ts.isPropertyAccessExpression(node.expression)
+          && node.expression.name.text === 'each') {
+          for (const arg of node.arguments) {
+            if (!ts.isArrayLiteralExpression(arg)) continue;
+            for (const el of arg.elements) {
+              if (ts.isArrayLiteralExpression(el) && el.elements.length === 0) {
+                const { line } = sf.getLineAndCharacterOfPosition(el.getStart(sf));
+                offenders.push(`${file}:${line + 1}`);
+              }
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(sf);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/test/bun-runner-selectors.test.ts
+++ b/test/bun-runner-selectors.test.ts
@@ -134,6 +134,11 @@ describe('no test file may use a bare empty-array each row', () => {
     // Scanned with the TypeScript AST, not a regex: a text pattern for this missed
     // `test/model-pricing.test.ts` (the row sat among other bare values), and a
     // silently-incomplete scan is exactly how the third instance survived the first fix.
+    //
+    // NOT COVERED, by nature: rows passed as an identifier or a call
+    // (`it.each(ALL_CLI_IDS)`, `it.each(PLAIN_ADAPTERS.filter(...))` — 28 sites) hide the
+    // row shape behind a value this scan cannot resolve without a type checker. Those are
+    // out of reach here, not overlooked. Everything expressible as a literal IS covered.
     const ts = await import('typescript');
     const { readdirSync, readFileSync } = await import('node:fs');
     const { join } = await import('node:path');
@@ -157,6 +162,22 @@ describe('no test file may use a bare empty-array each row', () => {
     expect(files.length).toBeGreaterThan(500);
 
     const offenders: string[] = [];
+    // Type-only wrappers (`as const`, `satisfies T`, `(…)`, `!`) leave the array
+    // untouched at runtime, so the defect fires through them identically — but each
+    // hides the literal behind a different node and would slip past a bare
+    // `isArrayLiteralExpression` check. Measured: `as const` alone wraps 87 of the 231
+    // `.each` sites here (51 files), so skipping them would blind this scan to most of
+    // the repo while still reporting green.
+    const unwrap = (node: import('typescript').Node): import('typescript').Node => {
+      let current = node;
+      while (ts.isAsExpression(current)
+        || ts.isSatisfiesExpression(current)
+        || ts.isParenthesizedExpression(current)
+        || ts.isNonNullExpression(current)) {
+        current = current.expression;
+      }
+      return current;
+    };
     for (const file of files) {
       const source = readFileSync(file, 'utf8');
       const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
@@ -164,11 +185,15 @@ describe('no test file may use a bare empty-array each row', () => {
         if (ts.isCallExpression(node)
           && ts.isPropertyAccessExpression(node.expression)
           && node.expression.name.text === 'each') {
-          for (const arg of node.arguments) {
+          for (const rawArg of node.arguments) {
+            const arg = unwrap(rawArg);
             if (!ts.isArrayLiteralExpression(arg)) continue;
-            for (const el of arg.elements) {
+            for (const rawEl of arg.elements) {
+              const el = unwrap(rawEl);
               if (ts.isArrayLiteralExpression(el) && el.elements.length === 0) {
-                const { line } = sf.getLineAndCharacterOfPosition(el.getStart(sf));
+                // Report the row as WRITTEN, so the line points at the source text a
+                // reader has to edit rather than at the unwrapped inner node.
+                const { line } = sf.getLineAndCharacterOfPosition(rawEl.getStart(sf));
                 offenders.push(`${file}:${line + 1}`);
               }
             }

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -396,3 +396,39 @@ describe.runIf(false)('describe.runIf(false) skips the whole block', () => {
     expect(true).toBe(true);
   });
 });
+
+// A tuple-wrapped `it.each` row must deliver its value on BOTH runners, including when
+// the value is an empty array.
+//
+// WHY THIS IS HERE: a BARE `[]` row (`it.each([null, [], 'x'])`) spreads to zero
+// arguments under `bun test`, so a callback declaring a parameter reads as wanting a
+// `done` callback — the runner waits for one and the case dies at the timeout. Two real
+// files hit it (`bot-description-schema`, `budget-tracker`) and each burned the full
+// 180s ceiling on a synchronous body, which presents as a hang rather than as bad data.
+//
+// The guard asserts the SUPPORTED form rather than the broken one: a test that expects
+// a timeout would take the timeout to pass. `[[]]` is unambiguous under both runners,
+// so this stays green while pinning the value that must arrive.
+const eachRowsSeen: unknown[] = [];
+describe('it.each row delivery', () => {
+  it.each([[null], [[]], ['text'], [{ a: 1 }]])('delivers row %j as one argument', value => {
+    eachRowsSeen.push(value);
+    // `undefined` is what a zero-argument spread produces — the failure mode itself.
+    expect(wasDelivered(value)).toBe(true);
+  });
+
+  it('saw every row, with the empty array intact', () => {
+    expect(eachRowsSeen).toHaveLength(4);
+    expect(eachRowsSeen[0]).toBeNull();
+    // The empty array must arrive AS an empty array, not as `undefined` or a spread.
+    expect(Array.isArray(eachRowsSeen[1])).toBe(true);
+    expect(eachRowsSeen[1]).toEqual([]);
+    expect(eachRowsSeen[2]).toBe('text');
+    expect(eachRowsSeen[3]).toEqual({ a: 1 });
+  });
+});
+
+/** True when the row reached the callback at all; `undefined` means it did not. */
+function wasDelivered(value: unknown): boolean {
+  return value !== undefined;
+}

--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -402,9 +402,14 @@ describe.runIf(false)('describe.runIf(false) skips the whole block', () => {
 //
 // WHY THIS IS HERE: a BARE `[]` row (`it.each([null, [], 'x'])`) spreads to zero
 // arguments under `bun test`, so a callback declaring a parameter reads as wanting a
-// `done` callback — the runner waits for one and the case dies at the timeout. Two real
-// files hit it (`bot-description-schema`, `budget-tracker`) and each burned the full
-// 180s ceiling on a synchronous body, which presents as a hang rather than as bad data.
+// `done` callback — the runner waits for one and the case dies at the timeout. Three
+// real files hit it (`bot-description-schema`, `budget-tracker`, `model-pricing`) and
+// each burned the full 180s ceiling on a synchronous body, which presents as a hang
+// rather than as bad data.
+//
+// This guard pins the DELIVERY SEMANTICS for the rows below; it cannot see a new
+// offender in another file (its rows are its own). Repo-wide recurrence is caught by
+// the AST scan in `test/bun-runner-selectors.test.ts`.
 //
 // The guard asserts the SUPPORTED form rather than the broken one: a test that expects
 // a timeout would take the timeout to pass. `[[]]` is unambiguous under both runners,

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -30,10 +30,17 @@ import { vi } from 'vitest';
  *     looks like it wants a `done` callback, so the runner waits for one and the case
  *     dies at the timeout — measured: 180s on a body that is fully synchronous and
  *     cannot hang, which makes it read as a hang rather than as bad data. vitest
- *     passes the empty array through as the single argument instead. Cannot be shimmed:
- *     `it.each` is the runner's own, and the arity check happens before any of our code.
- *     WRITE `[[]]` — a tuple-wrapped row is unambiguous under both runners. Guarded by
- *     `test/bun-shim-parity.test.ts` so the divergence cannot come back unnoticed.
+ *     passes the empty array through as the single argument instead.
+ *     NOT shimmed by CHOICE, not by impossibility: wrapping `.each` to rewrite a bare
+ *     `[]` row into `[[]]` before the runner sees it does work (measured: the hang goes
+ *     away and multi-element, tuple-wrapped and bare-value rows all still arrive
+ *     unchanged). It is rejected because it would also rewrite a table whose rows are
+ *     ALL bare `[]` — vitest calls those with ZERO arguments (measured), and a wrap that
+ *     silently changed that would be exactly the kind of quiet mismatch this file
+ *     refuses below. WRITE `[[]]` instead — unambiguous under both runners, and visible
+ *     to the reader. Repo-wide recurrence is caught by the AST scan in
+ *     `test/bun-runner-selectors.test.ts` (`test/bun-shim-parity.test.ts` pins the
+ *     delivery semantics, but only for its own rows).
  *
  * DELIBERATELY NOT SHIMMED — these are module-system semantics, not missing
  * functions, and any fake would silently not-mock while reporting success:

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -25,6 +25,15 @@ import { vi } from 'vitest';
  *     (`test/remote-shutdown-detach.test.ts`, which fails with
  *     `results.every is not a function`). Overriding a matcher cannot fix how the
  *     runner threads the awaited value into it.
+ *   An `it.each` row that is a BARE EMPTY ARRAY (`it.each([null, [], 'x'])`) spreads
+ *     to ZERO arguments under `bun test`. A callback that declares a parameter then
+ *     looks like it wants a `done` callback, so the runner waits for one and the case
+ *     dies at the timeout — measured: 180s on a body that is fully synchronous and
+ *     cannot hang, which makes it read as a hang rather than as bad data. vitest
+ *     passes the empty array through as the single argument instead. Cannot be shimmed:
+ *     `it.each` is the runner's own, and the arity check happens before any of our code.
+ *     WRITE `[[]]` — a tuple-wrapped row is unambiguous under both runners. Guarded by
+ *     `test/bun-shim-parity.test.ts` so the divergence cannot come back unnoticed.
  *
  * DELIBERATELY NOT SHIMMED — these are module-system semantics, not missing
  * functions, and any fake would silently not-mock while reporting success:

--- a/test/model-pricing.test.ts
+++ b/test/model-pricing.test.ts
@@ -58,7 +58,10 @@ describe('normalizePricingOverrides', () => {
     });
   });
 
-  it.each([null, undefined, 'string', 42, true, []])('returns undefined for non-object input %j', (raw) => {
+  // Tuple-wrapped rows: a bare `[]` row spreads to zero arguments, so a callback with a
+  // declared parameter reads as wanting a `done` callback and `bun test` hangs until the
+  // timeout. See the note in test/bun-test-shim.ts under KNOWN BUN DEFECTS.
+  it.each([[null], [undefined], ['string'], [42], [true], [[]]])('returns undefined for non-object input %j', (raw) => {
     expect(normalizePricingOverrides(raw)).toBeUndefined();
   });
 


### PR DESCRIPTION
#1105 合入后 `bun test` 腿有 39 个确定性红。这个 PR 收掉第一类，并给它加上防回归的守卫。

## 根因

`it.each([null, [], 'text', {}])` 里那个**裸的空数组行**在 `bun test` 下 spread 成
**零个参数**。回调声明了形参，于是运行器认为它想要一个 `done` 回调，就一直等 ——
用例最终死在超时上。

症状极具误导性：三个文件各烧满 **180 秒**上限，而它们的用例体是**完全同步的**、
根本不可能挂起。读日志会以为是死锁或环境问题，不会想到是数据行的形状。vitest 把
空数组原样当作单个参数传进去，所以这些文件在门禁上一直是绿的 —— 这条差异只有真
在 Bun 上跑测试体才看得见。

**不从 shim 修是取舍，不是做不到**（初版写成「无法从 shim 修，arity 判断发生在我们
代码之前」，那是个技术上错误的论据）：这个 shim 本来就在原地 patch `bunIt`
（`addRunIf` / `addSequential`），同样包住 `.each` 把裸 `[]` 归一化成 `[[]]` 实测**可行
且零破坏**（挂起消失；多元素、元组包裹、纯裸值三种行形态全部原样到达）。真正的理由是
**它会改掉一处真实 vitest 语义**：当整张表每行都是裸 `[]` 时 vitest 用**零参数**调用回调，
wrap 会让它收到一个 `[]` —— 正是本文件 `DELIBERATELY NOT SHIMMED` 段落拒绝的那种静默
不一致。所以选择显式写 `[[]]`：两个运行器下都无歧义，且读代码的人不需要知道背后有个
wrap 在动数据。

## 改动

- `bot-description-schema`、`budget-tracker`、`model-pricing` 三处 each 行改为元组包裹
- `bun-test-shim.ts` 的 KNOWN BUN DEFECTS 补这条（含 180s 实测与判据）
- `bun-shim-parity.test.ts` 加守卫，钉住「行必须被投递、空数组要原样到达」
- `bun-runner-selectors.test.ts` 加 **AST 全量扫描**守卫

⚠️ **为什么用 AST 而不是正则**：我第一版用正则找，漏了 `model-pricing` —— 它那个裸
`[]` 夹在其它裸值中间。**「静默不完整的扫描」正是第三处能活下来的原因**，所以守卫
遍历 `<it|test|describe>.each([...])` 的数组实参，报出任何长度为 0 的元素及其
`文件:行号`。

守卫断言**受支持的形态而非坏形态**：一条「期望超时」的用例得真的等满超时才能通过。

## 验证

三个文件两侧全绿、条数一致：

| 文件 | bun test | vitest |
|---|---|---|
| bot-description-schema | 9 pass / 0 fail | — |
| budget-tracker | 42 pass / 0 fail | 51 passed（前两者合计） |
| model-pricing | 29 pass / 0 fail | 29 passed |

**断言仍有牙**（反变异，证明不是空过）：
- `normalizeBotDescriptions` 改成无条件 `ok: true` ⟹ bun 1 pass / **8 fail**、vitest **8 failed**
- `normalizePricingOverrides` 改成无条件返回 `{}` ⟹ bun 18 pass / **11 fail**

**守卫本身有牙**（两个方向）：
- 种一个裸 `[]` 行的临时文件 ⟹ **1 fail**，错误里直接给出 `test/tmp-planted-offender.test.ts:3`
- 把文件清单过滤成空（模拟扫描空转）⟹ **1 fail**，由 `expect(files.length).toBeGreaterThan(500)` 兜住
- parity 守卫：`[[]]` 改回裸 `[]` ⟹ **2 fail**；空数组断言改成 `toEqual([99])` ⟹ **1 fail**

其它：`tsc --noEmit` 干净；选择器守卫 39 pass / 0 fail（bun）、39 passed（vitest）；
AST 扫描当前全量 0 处违规。

## 影响面

只动测试文件与测试基建，不碰 `src/` 运行时逻辑（反变异时临时改过 impl，已还原并确认
`git status` 干净）。跨 CLI / 跨后端 / 跨平台均无影响。

## 遗留

剩余 36 个红需继续分桶收敛。已确认其中一部分是**并发 artifact 而非真红**：单独跑
`cli-update-alias`、`npm-binary-distribution`、`platform-bind-ip-family` 均全绿，只在
CI 并发下失败 —— 这类要按「同一文件单独跑是否复现」区分，不能一律当代码缺陷修。


---

## 后续修复（第三个 commit `d63d01759`）

审核发现守卫本身有一个**静默盲区**，已补：

- **AST 扫描补齐类型层包裹**：原扫描只在实参是**裸数组字面量**时下钻，`as const` /
  `satisfies T` / `(…)` / `!` 会让整块行数组变成另一种节点而被跳过 —— 而缺陷在这四种
  写法下**照样触发**（四种各自实测在 bun 下等 `done` 回调到超时）。占比实测：`as const`
  单独就包住 231 个 `.each` 站点里的 **87 个（51 文件）**，即守卫对仓库多数写法失明却
  照样报绿 —— 正是这条守卫注释自己点名要防的「静默不完整的扫描」。行号仍取**写下的那
  一行**，指向读者要改的源码文本。
- **注释点明能力边界**：标识符/调用表达式实参（`it.each(ALL_CLI_IDS)` 等 28 处）不做
  类型解析无法判定行形状，属结构性不可达 —— 写明它是「够不到」而非「漏掉」，免得后来
  人当成全覆盖。
- **两处注释与代码不符**：`bun-shim-parity.test.ts` 的「Two real files」→ **三处**
  （`model-pricing` 第二个 commit 才修）；并写明该守卫只钉自己那几行的投递语义，
  **防复发靠 AST 扫描**（实测：在另一个文件种 offender，parity 守卫 31 pass / 0 fail 看不见）。
- **`bun-test-shim.ts` 的「Cannot be shimmed」改成「能做，但代价是 X，所以不做」**
  （见上文订正）—— 留着错的理由会让后来人以为此路不通而不再评估。

**验证（变异矩阵 4/4）**：四种包裹各种一个 offender + 一个裸行 ⟹ 全部报出且行号逐个
准确（`:3 :4 :5 :6 :7`）；把 `unwrap` 掐成恒等 ⟹ 同一个 `as const` offender **溜过去
（39/0 全绿）**，恢复后被抓（1 fail）⟹ 证明 `unwrap` 是承重的；文件清单过滤成空 ⟹ 被
`toBeGreaterThan(500)` 兜住（`Received: 0`）。

**在与最新 master 的真实合并树上重验过**（master 已前进到 `4cb1365b0`，含 #1106/#1108/#1110，
新增 5 个测试文件、`.each` 裸数组站点 115→118）：AST 守卫 bun **39/0**、vitest **39 passed**；
parity 守卫 bun 31 pass/2 skip、vitest 31 passed；三个目标文件 bun **9/42/29** 全绿；
五文件 vitest **150 passed | 2 skipped**；`tsc --noEmit` 干净。
