### PR TITLE
fix(update): npm 全局安装的平台包嵌在主包内，更新识别一直落到 unknown

### DIFF
--- a/src/core/binary-install-shape.ts
+++ b/src/core/binary-install-shape.ts
@@ -83,8 +83,34 @@ export function currentBinaryInstallShape(): BinaryInstallShape {
 }
 
 /**
- * Map a platform-subpackage binary path to the MAIN `botmux` package root beside
- * it (`…/node_modules/botmux-linux-x64/botmux` → `…/node_modules/botmux`).
+ * Map a platform-subpackage binary path to the MAIN `botmux` package root that
+ * owns it. TWO layouts occur in the wild and both are load-bearing:
+ *
+ *   nested  (npm)  …/node_modules/botmux/node_modules/botmux-linux-x64/botmux
+ *                  → …/node_modules/botmux          (the ENCLOSING package)
+ *   sibling (Bun)  …/node_modules/botmux-linux-x64/botmux
+ *                  → …/node_modules/botmux          (the package BESIDE it)
+ *
+ * ⚠️ ONLY THE SIBLING SHAPE USED TO BE HANDLED, and that was the whole of a real
+ * bug: npm 10 does NOT hoist a package's own dependencies to the global root, so
+ * `npm i -g botmux` puts the platform subpackage INSIDE the main package. The
+ * sibling rule then produced `…/node_modules/botmux/node_modules/botmux`, a
+ * directory that does not exist, so `detectGlobalInstallManager` said `unknown`,
+ * no install plan resolved, and every npm user got "当前安装方式无法安全自动更新"
+ * from `botmux update`, the dashboard button, and scheduled auto-update alike.
+ * MEASURED on a real `npm i -g botmux` (npm 10.9.4): the binary lives at
+ * `<prefix>/lib/node_modules/botmux/node_modules/botmux-linux-x64/botmux`, and
+ * peer globals nest the same way (pm2: 112 nested deps, http-server: 47).
+ *
+ * The sibling rule is NOT obsolete and must not be replaced: MEASURED on the same
+ * box, Bun's global tree HOISTS (a declared global package with dependencies has
+ * 0 entries in its own `node_modules`), so a Bun-installed platform subpackage
+ * really is a sibling. Hence both, distinguished purely and without touching the
+ * filesystem: in the nested layout the directory CONTAINING that `node_modules`
+ * is itself the main package (it is literally named `botmux`), so when that holds
+ * it is the answer; otherwise the main package sits beside the subpackage. No
+ * `existsSync` probe — this stays pure, and a guess that happens to be absent on
+ * one box would otherwise silently change the answer.
  *
  * WHY GO THROUGH THE MAIN PACKAGE instead of computing an npm `--prefix` here:
  * `resolveGlobalInstallPlan` already classifies that path shape into the right
@@ -99,7 +125,15 @@ export function currentBinaryInstallShape(): BinaryInstallShape {
 export function mainPackageRootForSubpackageBinary(execPath: string): string | null {
   const path = execPath.replace(/\\/g, '/').replace(/\/+$/, '');
   const m = /^(.*\/node_modules)\/botmux-(?:linux|darwin)-(?:x64|arm64)(?:-musl)?\/botmux$/.exec(path);
-  return m ? `${m[1]}/botmux` : null;
+  if (!m) return null;
+  const nodeModules = m[1];
+  // Nested (npm): the directory holding this `node_modules` is the main package.
+  // Anchored on `/botmux` so only the real main package matches — a subpackage
+  // nested under some OTHER package would not be ours to hand to the manager.
+  const enclosing = nodeModules.slice(0, -'/node_modules'.length);
+  if (/\/node_modules\/botmux$/.test(enclosing)) return enclosing;
+  // Sibling (Bun's hoisted global tree, and Windows npm).
+  return `${nodeModules}/botmux`;
 }
 
 /**

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -118,6 +118,55 @@ describe('classifyBinaryInstall — where the binary lives decides who updates i
 
     expect(mainPackageRootForSubpackageBinary('/home/u/.botmux/bin/botmux')).toBeNull();
   });
+
+  it("THE npm BUG: the platform package NESTS inside the main package, and that layout must resolve", () => {
+    // REGRESSION for the defect that shipped through 3.18.5→3.18.8: only the
+    // SIBLING layout was handled, but MEASURED on a real `npm i -g botmux`
+    // (npm 10.9.4) the platform subpackage lands INSIDE the main package, because
+    // npm does not hoist a package's own deps to the global root (peer globals
+    // nest identically: pm2 112 nested deps, http-server 47).
+    //
+    // Pre-fix this returned `…/node_modules/botmux/node_modules/botmux` — a
+    // directory that does not exist and matches no manager — so detect said
+    // `unknown`, the plan was null, and `botmux update` / the dashboard button /
+    // scheduled auto-update all reported "无法安全识别当前安装方式".
+    const nested = '/usr/lib/node_modules/botmux/node_modules/botmux-linux-x64/botmux';
+    const root = mainPackageRootForSubpackageBinary(nested);
+    // The MAIN package, NOT a second `botmux` below it.
+    expect(root).toBe('/usr/lib/node_modules/botmux');
+    expect(root).not.toBe('/usr/lib/node_modules/botmux/node_modules/botmux');
+    // End to end: it must reach npm with the prefix of the tree it came from.
+    // Verified against the real install on the dev box: this prefix is byte-equal
+    // to `npm prefix -g`.
+    expect(formatGlobalInstallCommand(tryResolveGlobalInstallPlan(root!, 'linux')!))
+      .toBe('npm install -g --prefix /usr botmux@latest');
+    // …and the strategy as a whole, which is what the three callers consume.
+    expect(resolveUpdateStrategy(true, nested, '/', {}, '/home/u'))
+      .toEqual({ kind: 'package-manager', packageRoot: '/usr/lib/node_modules/botmux' });
+    // The musl subpackage nests the same way.
+    expect(mainPackageRootForSubpackageBinary(
+      '/usr/lib/node_modules/botmux/node_modules/botmux-linux-x64-musl/botmux',
+    )).toBe('/usr/lib/node_modules/botmux');
+  });
+
+  it('the SIBLING layout still resolves — Bun hoists, so it is not obsolete', () => {
+    // Guard against "fixing" the nested case by REPLACING the sibling rule.
+    // MEASURED on the same box: Bun's global tree hoists (a declared global
+    // package with dependencies has 0 entries in its own node_modules), so a
+    // Bun-installed platform subpackage really is a sibling of the main package.
+    expect(mainPackageRootForSubpackageBinary('/root/.bun/install/global/node_modules/botmux-linux-x64/botmux'))
+      .toBe('/root/.bun/install/global/node_modules/botmux');
+    expect(mainPackageRootForSubpackageBinary('/usr/lib/node_modules/botmux-linux-x64/botmux'))
+      .toBe('/usr/lib/node_modules/botmux');
+  });
+
+  it('a subpackage nested under some OTHER package is not claimed as ours', () => {
+    // The nested rule is anchored on an enclosing package literally named
+    // `botmux`; a botmux platform binary vendored inside an unrelated dependency
+    // must not make us hand THAT package root to a global install command.
+    expect(mainPackageRootForSubpackageBinary('/app/node_modules/other/node_modules/botmux-linux-x64/botmux'))
+      .toBe('/app/node_modules/other/node_modules/botmux');
+  });
 });
 
 describe('resolveUpdateStrategy', () => {

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -151,13 +151,26 @@ describe('classifyBinaryInstall — where the binary lives decides who updates i
 
   it('the SIBLING layout still resolves — Bun hoists, so it is not obsolete', () => {
     // Guard against "fixing" the nested case by REPLACING the sibling rule.
-    // MEASURED on the same box: Bun's global tree hoists (a declared global
-    // package with dependencies has 0 entries in its own node_modules), so a
-    // Bun-installed platform subpackage really is a sibling of the main package.
+    // MEASURED on a real `bun add -g botmux` (bun 1.4.0): the platform subpackage
+    // botmux-linux-x64 is a real directory BESIDE the main package.
     expect(mainPackageRootForSubpackageBinary('/root/.bun/install/global/node_modules/botmux-linux-x64/botmux'))
       .toBe('/root/.bun/install/global/node_modules/botmux');
     expect(mainPackageRootForSubpackageBinary('/usr/lib/node_modules/botmux-linux-x64/botmux'))
       .toBe('/usr/lib/node_modules/botmux');
+  });
+
+  it('EITHER shape resolves to the same root, so no manager needs a layout promise', () => {
+    // Bun HOISTS BY DEFAULT but does not guarantee it: measured 38 nested
+    // node_modules inside one real bun global tree (it nests in place on a version
+    // conflict). So "bun ⇒ sibling" is the common case, not an invariant, and the
+    // mapping must not depend on which manager produced the path. Both shapes of
+    // the same install must land on the same main package root.
+    const nested = '/root/.bun/install/global/node_modules/botmux/node_modules/botmux-linux-x64/botmux';
+    const sibling = '/root/.bun/install/global/node_modules/botmux-linux-x64/botmux';
+    expect(mainPackageRootForSubpackageBinary(nested))
+      .toBe(mainPackageRootForSubpackageBinary(sibling));
+    expect(mainPackageRootForSubpackageBinary(nested))
+      .toBe('/root/.bun/install/global/node_modules/botmux');
   });
 
   it('a subpackage nested under some OTHER package is not claimed as ours', () => {


### PR DESCRIPTION
## 问题

`npm i -g botmux` 的用户，`botmux update`、Dashboard 更新按钮、定时自动更新**三处全部失效**，报「当前安装方式无法安全自动更新 / 无法安全识别当前安装方式（unknown）」。手动 `npm i -g botmux@latest` 仍可用，坏的只是**安装归属识别**这一环。

`3.18.7`、已发布的 `3.18.8`、以及当前 `master` 都含此缺陷。

## 根因

`mainPackageRootForSubpackageBinary()` 只处理了「平台子包与主包**同级**」这一种布局。但 npm 10 **不会**把一个包自己的依赖 hoist 到全局根，`npm i -g botmux` 实际把平台子包装在**主包内部**：

```
<prefix>/lib/node_modules/botmux/node_modules/botmux-linux-x64/botmux
```

按同级规则回推 ⟹ `<prefix>/lib/node_modules/botmux/node_modules/botmux`，这个目录**并不存在**，也不符合任何包管理器的布局规则。于是 `detectGlobalInstallManager` → `unknown`、`installPlan` → `null`、`updateSupported` → `false`。

原修复（#1078 / v3.18.5）只覆盖了同级的模拟路径，**测试恰好没有一条走真实的 npm 嵌套布局**，所以全绿掩盖了这个缺口。

## 改法

外层目录本身就叫 `botmux` 时，它就是主包（嵌套布局）；否则取同级。仍是**纯函数，不做 `existsSync` 探测** —— 某台机器上恰好不存在的路径不应该静默改变判定结果。

**⚠️ 同级布局不是废弃分支，必须保留。** 真装 `bun add -g botmux`（bun 1.4.0）确认平台子包 `botmux-linux-x64` 是主包的**同级真实目录**；Windows npm 亦然。只把同级换成嵌套会修一个坏一个 —— 这一点单独有回归用例守着。

⚠️ **一处措辞更正（复审指出）**：我原先写「bun 全局树是打平的（一个声明的全局包自己 `node_modules` 下 0 项）」——那个依据**只采样了一个包**就推成普适规则。实测同一棵真实 bun 全局树里有 **38 个嵌套 `node_modules`**（版本冲突时就地嵌套），所以「bun ⟹ 同级」是常见情况而**不是不变量**。结论方向不变，但判据换成更强的那条：**本函数对嵌套与同级两种形态解析到同一个正确主包根**，因此不依赖任何包管理器的布局承诺（已加用例断言这个等价性）。

## 影响面

三处入口（`cli.ts` 的 `cmdUpgrade`、`dashboard.ts` 的 `/api/update/status` 与 `/api/update/run`、`maintenance.ts` 的定时 tick）共用 `currentUpdateStrategy` → 本函数这一条路径，已 grep 全部 5 个调用点确认，**无第二处自行回推主包根**，故一处修复覆盖整个面。

- **Node 部署**：`resolveUpdateStrategy` 的 `!standalone` 分支逐字未变
- **curl（install.sh）形态**：仍返回 `null` → 走 self-replace，逐字未变
- **pnpm / yarn / Windows**：布局判定交回既有 `resolveGlobalInstallPlan`，未新增第二套规则

## 验证

**在真实发布的 3.18.8 上端到端复现并修复**（非推理）：

```
# 真装一遍到临时 prefix，确认布局确为嵌套
$ npm i -g botmux@3.18.8 --prefix /tmp/bmprobe/pfx
$ ls /tmp/bmprobe/pfx/lib/node_modules/botmux/node_modules/botmux-linux-x64/botmux   # ✅ 嵌套

# 用这个已发布二进制复现缺陷
$ .../botmux-linux-x64/botmux --version   → 3.18.8
$ .../botmux-linux-x64/botmux update      → ❌ 无法安全识别当前安装方式（unknown）

# 同一真实路径，修后
mainPackageRoot : /tmp/bmprobe/pfx/lib/node_modules/botmux
command         : npm install -g --prefix /tmp/bmprobe/pfx botmux@latest   # ✅ 正是它装进去的 prefix
```

- 本机真实全局安装上，推导出的 `--prefix` 与 `npm prefix -g` **逐字相等**；回推出的主包根**真实存在**（修复前那个不存在）
- npm 嵌套并非本机特例：同一全局根下 pm2 嵌 112 个依赖、http-server 嵌 47 个，而全局根仅 32 项 ⟹ npm 10 就是不 hoist
- 七种布局全部正确：npm 嵌套 / npm 同级 / bun 同级 / pnpm 虚拟 store / musl 嵌套 / curl 位置（null）/ 子包嵌在**非** botmux 包下
- 新增 4 条用例覆盖此前遗漏的真实嵌套布局，以及「两种形态解析到同一主包根」的等价性
- **反变异 4/4 全红**：① 还原成「仅认同级」（= 线上这个缺陷）红 1 ② 「仅认嵌套」（替换而非新增）红 6 ③ 去掉 `/botmux` 锚点红 1 —— 每条新用例都有独立区分力
- `bun run build` 通过
- `bun run test`：**19765 passed**。5 个失败文件与本改动无关，判据不是「看起来无关」而是**在同一棵树上撤销改动做 PRE/POST**：两侧均为 2 文件 / 4 用例失败、逐字相同（EACCES 类用例在 root 下本就不可能失败）；全量跑时多出的 3 条为本机高负载下的 `Hook timed out` / `Test timed out`

## 遗留

本 PR 只修「识别」。三处入口的其余行为（版本比较、重启、回退）未改动。


## 复审补充验证（真机，非模拟路径）

针对「我只用手搭路径验过 pnpm/bun」这个自陈的弱点，复审真装了三种包管理器（全部隔离 HOME/`--prefix`，未触碰共享 `~/.botmux`）：

| 包管理器 | 实测布局 | 本 PR 代码解析结果 |
|---|---|---|
| npm 10.9.4 | **嵌套**在主包内 | `npm install -g --prefix <与实装 prefix 逐字相等>` ✅ |
| pnpm 9.15.9 | `global/5/.pnpm/botmux-linux-x64@3.18.8/node_modules/botmux-linux-x64/botmux` | `pnpm add -g --global-dir …/pnpm/global` ✅ |
| bun 1.4.0 | 平台子包为主包**同级真实目录** | `bun add -g botmux@latest` ✅ |

另独立复核：`mainPackageRootForSubpackageBinary` 的唯一调用点就是 `resolveUpdateStrategy`，5 个 `currentUpdateStrategy` 调用点（cli×1、dashboard×3、maintenance×2）全部走这一条通路，无第二处自行回推主包根。scoped 包判死是正确的（下游 `detectGlobalInstallManager` 本身就要求主包根以 `/node_modules/botmux` 结尾，放宽锚点零收益只增误报面）。

## 发现的两个 pre-existing 缺陷（**不在本 PR 范围**，不改动，建议另开 issue）

1. 🔴 **pnpm 10+ / bun 1.2+ 默认不执行依赖的 postinstall**（实测 pnpm 11.24.0、bun 1.4.0 均 block；npm 不受影响）⟹ `pnpm add -g botmux` / `bun add -g botmux` 装完**不写 launcher，用户压根没有 `botmux` 命令**。比更新识别严重得多：是**装都装不上**。
2. 🟠 **pnpm 11 store-links 布局的编译版二进制无法 auto-update**：二进制真实路径在 `store/v11/links/@/botmux-linux-x64/…`，回推的主包根不匹配 `pnpmV11StoreMatch`（只认 `@/botmux/` 主包链接）⟹ unknown ⟹ fail-closed（安全但不能更新）。目前被第 1 条掩盖，是同一个 pnpm 11 缺口的两面。
