### PR TITLE
fix(sandbox): 将跨 Bot dispatch 收口到宿主 relay

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -961,7 +961,7 @@ export function sweepOrphanSandboxes(dataDir: string, activeSessionIds: Set<stri
   }
 }
 
-// ─────────────────────── botmux send relay (unchanged) ───────────────────────
+// ─────────────────────── botmux send / dispatch relay ───────────────────────
 
 // Relay request schema (written by cli.ts relaySend, validated here). The
 // watcher NEVER executes sandbox-supplied argv — it rebuilds the command from
@@ -969,6 +969,7 @@ export function sweepOrphanSandboxes(dataDir: string, activeSessionIds: Set<stri
 // write any outbox file, so everything here is treated as untrusted.
 //   { contentFile: <basename>, preparedContentFile?: <basename>, cardFile?: <basename>, ... }
 export interface RelayRequest {
+  command?: unknown;
   contentFile?: unknown;
   preparedContentFile?: unknown;
   cardFile?: unknown;
@@ -989,6 +990,7 @@ const RELAY_FLAGS_NOVAL = new Set(['--mention-back', '--no-mention', '--no-quote
 const RELAY_FLAGS_VAL = new Set(['--mention', '--quote', '--response-kind']);
 
 export interface ValidatedRelay {
+  command: 'send' | 'dispatch';
   contentName: string;
   preparedContentName?: string;
   cardName?: string;
@@ -1045,11 +1047,45 @@ export function validateRelayRequest(req: RelayRequest): { ok: true; value: Vali
     if (!safeName(a)) return { ok: false, error: 'video cover must be a plain outbox basename' };
     videoCoverNames.push(a);
   }
+  const command = req.command === undefined || req.command === 'send'
+    ? 'send'
+    : req.command === 'dispatch'
+      ? 'dispatch'
+      : null;
+  if (command === null) return { ok: false, error: 'command must be send or dispatch' };
+  if (command === 'dispatch' && (
+    preparedContentName !== undefined
+    || cardName !== undefined
+    || attachmentNames.length > 0
+    || videoNames.length > 0
+    || videoCoverNames.length > 0
+  )) {
+    return { ok: false, error: 'dispatch relay does not accept cards or attachments' };
+  }
   const flags: string[] = [];
   const rawFlags = Array.isArray(req.flags) ? req.flags : [];
+  const dispatchValueFlags = new Set(['--title', '--bot-app', '--chat-id', '--into']);
   for (let i = 0; i < rawFlags.length; i++) {
     const f = rawFlags[i];
     if (typeof f !== 'string') return { ok: false, error: 'flag must be a string' };
+    if (command === 'dispatch') {
+      if (f === '--steer') { flags.push(f); continue; }
+      if (!dispatchValueFlags.has(f)) return { ok: false, error: `dispatch flag not allowed: ${f}` };
+      const v = rawFlags[i + 1];
+      if (typeof v !== 'string' || !v || v.startsWith('--') || v.length > 512) {
+        return { ok: false, error: `dispatch flag ${f} needs a bounded string value` };
+      }
+      if (f === '--bot-app' && !/^cli_[A-Za-z0-9_-]{1,128}(?::[^\0]{1,200})?$/.test(v)) {
+        return { ok: false, error: 'dispatch --bot-app must be a stable app id' };
+      }
+      if (f === '--chat-id' && !/^oc_[A-Za-z0-9_-]{1,128}$/.test(v)) {
+        return { ok: false, error: 'dispatch --chat-id is invalid' };
+      }
+      if (f === '--into' && !/^om_[A-Za-z0-9_-]{1,128}$/.test(v)) {
+        return { ok: false, error: 'dispatch --into is invalid' };
+      }
+      flags.push(f, v); i++; continue;
+    }
     if (RELAY_FLAGS_NOVAL.has(f)) { flags.push(f); continue; }
     if (RELAY_FLAGS_VAL.has(f)) {
       const v = rawFlags[i + 1];
@@ -1092,6 +1128,7 @@ export function validateRelayRequest(req: RelayRequest): { ok: true; value: Vali
   return {
     ok: true,
     value: {
+      command,
       contentName: req.contentFile,
       preparedContentName,
       cardName,
@@ -1283,10 +1320,12 @@ export function startOutboxWatcher(
 
       const hostArgs = [
         ...v.value.flags,
-        ...(cardPath ? ['--card-file', cardPath] : ['--content-file', contentDest]),
-        ...attPaths.flatMap(a => ['--files', a]),
-        ...videoPaths.flatMap(a => ['--videos', a]),
-        ...videoCoverPaths.flatMap(a => ['--video-covers', a]),
+        ...(v.value.command === 'dispatch'
+          ? ['--brief-file', contentDest]
+          : cardPath ? ['--card-file', cardPath] : ['--content-file', contentDest]),
+        ...(v.value.command === 'send' ? attPaths.flatMap(a => ['--files', a]) : []),
+        ...(v.value.command === 'send' ? videoPaths.flatMap(a => ['--videos', a]) : []),
+        ...(v.value.command === 'send' ? videoCoverPaths.flatMap(a => ['--video-covers', a]) : []),
         '--session-id', sessionId,  // forced — sandbox cannot target another session
       ];
       // Fail closed: a durable origin (turnId/dispatchAttempt) may come ONLY
@@ -1316,7 +1355,7 @@ export function startOutboxWatcher(
       } else {
         delete requestEnv.BOTMUX_HOST_RELAY_REQUIRES_CODEX_APP_LEDGER;
       }
-      const child = spawn(cliInvocation.command, [...cliInvocation.args, 'send', ...hostArgs], { env: requestEnv });
+      const child = spawn(cliInvocation.command, [...cliInvocation.args, v.value.command, ...hostArgs], { env: requestEnv });
       let out = '', err = '';
       child.stdout.on('data', d => { out += d; });
       child.stderr.on('data', d => { err += d; });

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -1064,7 +1064,7 @@ export function validateRelayRequest(req: RelayRequest): { ok: true; value: Vali
   }
   const flags: string[] = [];
   const rawFlags = Array.isArray(req.flags) ? req.flags : [];
-  const dispatchValueFlags = new Set(['--title', '--bot-app', '--chat-id', '--into']);
+  const dispatchValueFlags = new Set(['--title', '--bot-app', '--chat-id']);
   for (let i = 0; i < rawFlags.length; i++) {
     const f = rawFlags[i];
     if (typeof f !== 'string') return { ok: false, error: 'flag must be a string' };
@@ -1080,9 +1080,6 @@ export function validateRelayRequest(req: RelayRequest): { ok: true; value: Vali
       }
       if (f === '--chat-id' && !/^oc_[A-Za-z0-9_-]{1,128}$/.test(v)) {
         return { ok: false, error: 'dispatch --chat-id is invalid' };
-      }
-      if (f === '--into' && !/^om_[A-Za-z0-9_-]{1,128}$/.test(v)) {
-        return { ok: false, error: 'dispatch --into is invalid' };
       }
       flags.push(f, v); i++; continue;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,7 +42,13 @@ import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { ENTRY_SUBCOMMANDS, entryForSubcommand, resolveEntrySpawn } from './core/self-spawn.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { acceptedDispatchBotAppIds, activeConversationBotOpenIds, buildDispatchCompletionBrief, parseDispatchBotSpec, buildDispatchMessages, buildRepoPrimeText, buildReportContent, eligibleAutoMentionAliases, foldableChatSessionAppIds, offTopicSubBotTopic, resolveReportPlacement, resolveReportRecipient, resolveSendTarget, threadRootForReachability } from './core/dispatch.js';
-import { updateDispatchRegistry } from './core/dispatch-registry.js';
+import {
+  persistDispatchLifecycle as persistDispatchLifecycleRecord,
+  type DispatchAcceptanceState,
+  type DispatchLifecycleStatus,
+  type DispatchReceiptState,
+  type DispatchTransportState,
+} from './core/dispatch-lifecycle.js';
 import { withBotSteerDirective } from './core/bot-steer-directive.js';
 import { pickTurnReplyTarget, collectTurnWindowParticipants } from './core/reply-target.js';
 import {
@@ -7445,7 +7451,7 @@ async function relayDispatch(rest: string[], relayDir: string): Promise<void> {
     process.exit(2);
   }
   const allowedFlags = new Set([
-    '--title', '--bot-app', '--chat-id', '--into', '--steer',
+    '--title', '--bot-app', '--chat-id', '--steer',
     '--brief', '--brief-file', '--session-id',
   ]);
   const unsupportedFlags = [...new Set(rest
@@ -7467,13 +7473,13 @@ async function relayDispatch(rest: string[], relayDir: string): Promise<void> {
   let brief = argValue(rest, '--brief') ?? '';
   if (briefFile) {
     if (!existsSync(briefFile)) {
-      console.error(JSON.stringify({ success: false, sourceSessionId: sid, errorCode: 'ROUTING_NOT_SUPPORTED', detail: `brief file not found: ${briefFile}` }));
+      console.error(JSON.stringify({ success: false, sourceSessionId: sid, errorCode: 'BRIEF_FILE_NOT_FOUND', detail: `brief file not found: ${briefFile}` }));
       process.exit(1);
     }
     brief = readFileSync(briefFile, 'utf8');
   }
   const flags: string[] = [];
-  for (const flag of ['--title', '--bot-app', '--chat-id', '--into'] as const) {
+  for (const flag of ['--title', '--bot-app', '--chat-id'] as const) {
     for (const value of argValues(rest, flag)) flags.push(flag, value);
   }
   if (rest.includes('--steer')) flags.push('--steer');
@@ -7509,7 +7515,7 @@ async function relayDispatch(rest: string[], relayDir: string): Promise<void> {
     success: false,
     sourceSessionId: sid,
     transportState: 'failed',
-    acceptanceState: 'timed_out',
+    acceptanceState: 'not_requested',
     errorCode: 'TRANSPORT_FAILED',
     detail: 'daemon relay response timed out after 120s',
   }));
@@ -7519,35 +7525,22 @@ async function relayDispatch(rest: string[], relayDir: string): Promise<void> {
 async function persistDispatchLifecycle(input: {
   dispatchRoot: string;
   sourceSessionId: string;
-  status: 'dispatched' | 'accepted' | 'failed' | 'timed_out';
+  status: DispatchLifecycleStatus;
+  transportState: DispatchTransportState;
+  acceptanceState: DispatchAcceptanceState;
   errorCode?: string | null;
   acceptedBotAppIds?: readonly string[];
   missingBotAppIds?: readonly string[];
-}): Promise<void> {
+}): Promise<DispatchReceiptState> {
   try {
-    await updateDispatchRegistry(join(resolveDataDir(), 'orchestrate-dispatch.json'), registry => {
-      const raw = registry[input.dispatchRoot];
-      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return;
-      const entry = raw as Record<string, unknown>;
-      if (entry.orchSessionId !== input.sourceSessionId) return;
-      const now = new Date().toISOString();
-      entry.status = input.status;
-      entry.transportState = 'dispatched';
-      entry.acceptanceState = input.status === 'failed'
-        ? 'failed'
-        : input.status === 'timed_out'
-        ? 'timed_out'
-        : input.status === 'accepted' ? 'accepted' : 'requested';
-      entry.errorCode = input.errorCode
-        ?? (input.status === 'timed_out' ? 'ACCEPTANCE_TIMEOUT' : null);
-      if (input.acceptedBotAppIds) entry.acceptedBotAppIds = [...input.acceptedBotAppIds];
-      if (input.missingBotAppIds) entry.missingBotAppIds = [...input.missingBotAppIds];
-      if (input.status === 'accepted') entry.acceptedAt = now;
-      if (input.status === 'failed' || input.status === 'timed_out') entry.failedAt = now;
-      entry.updatedAt = now;
-    });
+    return await persistDispatchLifecycleRecord({ dataDir: resolveDataDir(), ...input });
   } catch (error) {
     console.error(`dispatch lifecycle persistence failed: ${error instanceof Error ? error.message : String(error)}`);
+    return {
+      transportState: input.transportState,
+      acceptanceState: input.acceptanceState,
+      errorCode: input.errorCode ?? null,
+    };
   }
 }
 
@@ -10133,18 +10126,27 @@ async function cmdDispatch(rest: string[]): Promise<void> {
           })
         : undefined;
       const accepted = !acceptance || acceptance.missingBotAppIds.length === 0;
-      await persistDispatchLifecycle({
+      const acceptanceState: DispatchAcceptanceState = !acceptance
+        ? 'not_requested'
+        : accepted ? 'accepted' : 'timed_out';
+      const lifecycleStatus: DispatchLifecycleStatus = !acceptance
+        ? 'dispatched'
+        : accepted ? 'accepted' : 'timed_out';
+      const errorCode = !acceptance || accepted ? null : 'ACCEPTANCE_TIMEOUT';
+      const receiptState = await persistDispatchLifecycle({
         dispatchRoot: intoRoot,
         sourceSessionId: sid,
-        status: !acceptance ? 'dispatched' : accepted ? 'accepted' : 'timed_out',
+        status: lifecycleStatus,
+        transportState: 'dispatched',
+        acceptanceState,
+        errorCode,
         acceptedBotAppIds: acceptance?.acceptedBotAppIds,
         missingBotAppIds: acceptance?.missingBotAppIds,
       });
       console.log(JSON.stringify({
         success: accepted, taskSent: true, mode: 'into', sourceSessionId: sid,
         targetAppIds: parsedBotApps.map(item => item.appId),
-        transportState: 'dispatched', acceptanceState: !acceptance ? 'not_requested' : accepted ? 'accepted' : 'timed_out',
-        errorCode: !acceptance || accepted ? null : 'ACCEPTANCE_TIMEOUT', threadRootId: intoRoot,
+        ...receiptState, threadRootId: intoRoot,
         kickoffMessageId: kickoffId, chatId: targetChatId, bots: built.mentionedOpenIds,
         collaborationReady: parsedBotApps.length > 0,
         ...(acceptance ? {
@@ -10169,6 +10171,7 @@ async function cmdDispatch(rest: string[]): Promise<void> {
         seedText: built.seedText,
         targetChatId,
         targetAppIds: parsedBotApps.map(item => item.appId),
+        acceptanceRequested: !standby && parsedBotApps.length > 0,
         title: title.trim(),
         bots: built.mentionedOpenIds,
       },
@@ -10224,10 +10227,20 @@ async function cmdDispatch(rest: string[]): Promise<void> {
     }
 
     const accepted = !acceptance || acceptance.missingBotAppIds.length === 0;
-    await persistDispatchLifecycle({
+    const acceptanceState: DispatchAcceptanceState = standby || !acceptance
+      ? 'not_requested'
+      : accepted ? 'accepted' : 'timed_out';
+    const lifecycleStatus: DispatchLifecycleStatus = standby || !acceptance
+      ? 'dispatched'
+      : accepted ? 'accepted' : 'timed_out';
+    const errorCode = !acceptance || accepted ? null : 'ACCEPTANCE_TIMEOUT';
+    const receiptState = await persistDispatchLifecycle({
       dispatchRoot: seedId,
       sourceSessionId: sid,
-      status: standby || !acceptance ? 'dispatched' : accepted ? 'accepted' : 'timed_out',
+      status: lifecycleStatus,
+      transportState: 'dispatched',
+      acceptanceState,
+      errorCode,
       acceptedBotAppIds: acceptance?.acceptedBotAppIds,
       missingBotAppIds: acceptance?.missingBotAppIds,
     });
@@ -10235,9 +10248,7 @@ async function cmdDispatch(rest: string[]): Promise<void> {
       success: accepted,
       sourceSessionId: sid,
       targetAppIds: parsedBotApps.map(item => item.appId),
-      transportState: 'dispatched',
-      acceptanceState: standby || !acceptance ? 'not_requested' : accepted ? 'accepted' : 'timed_out',
-      errorCode: !acceptance || accepted ? null : 'ACCEPTANCE_TIMEOUT',
+      ...receiptState,
       taskSent: !standby,
       mode: standby ? 'standby' : 'dispatch',
       seedMessageId: seedId,
@@ -10256,15 +10267,30 @@ async function cmdDispatch(rest: string[]): Promise<void> {
     }));
     if (!accepted) process.exitCode = 1;
   } catch (err: any) {
+    let receiptState: DispatchReceiptState = {
+      transportState: 'failed',
+      acceptanceState: 'failed',
+      errorCode: 'TRANSPORT_FAILED',
+    };
     if (dispatchRootForLifecycle) {
-      await persistDispatchLifecycle({
+      receiptState = await persistDispatchLifecycle({
         dispatchRoot: dispatchRootForLifecycle,
         sourceSessionId: sid,
         status: 'failed',
+        transportState: 'failed',
+        acceptanceState: 'failed',
         errorCode: 'TRANSPORT_FAILED',
       });
     }
-    console.error(`dispatch 失败: ${err.message}`);
+    console.error(JSON.stringify({
+      success: false,
+      sourceSessionId: sid,
+      targetAppIds: parsedBotApps.map(item => item.appId),
+      chatId: targetChatId,
+      threadRootId: dispatchRootForLifecycle ?? null,
+      ...receiptState,
+      detail: err?.message ?? String(err),
+    }));
     process.exit(1);
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,7 @@ import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { ENTRY_SUBCOMMANDS, entryForSubcommand, resolveEntrySpawn } from './core/self-spawn.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { acceptedDispatchBotAppIds, activeConversationBotOpenIds, buildDispatchCompletionBrief, parseDispatchBotSpec, buildDispatchMessages, buildRepoPrimeText, buildReportContent, eligibleAutoMentionAliases, foldableChatSessionAppIds, offTopicSubBotTopic, resolveReportPlacement, resolveReportRecipient, resolveSendTarget, threadRootForReachability } from './core/dispatch.js';
+import { updateDispatchRegistry } from './core/dispatch-registry.js';
 import { withBotSteerDirective } from './core/bot-steer-directive.js';
 import { pickTurnReplyTarget, collectTurnWindowParticipants } from './core/reply-target.js';
 import {
@@ -7270,6 +7271,18 @@ async function relaySend(
   rest: string[],
   relayDir: string,
 ): Promise<void> {
+  const unsupportedRouting = ['--chat-id', '--into', '--top-level']
+    .filter(flag => rest.some(token => token === flag || token.startsWith(`${flag}=`)));
+  if (unsupportedRouting.length > 0) {
+    console.error(JSON.stringify({
+      success: false,
+      transportState: 'failed',
+      acceptanceState: 'not_requested',
+      errorCode: 'ROUTING_NOT_SUPPORTED',
+      detail: `sandbox send does not support routing flags: ${unsupportedRouting.join(', ')}; use botmux dispatch --bot-app for cross-bot delivery`,
+    }));
+    process.exit(2);
+  }
   const sid = argValue(rest, '--session-id') ?? process.env.BOTMUX_SESSION_ID;
   if (!sid) { console.error('relay: 无法确定 session-id'); process.exit(1); }
   const cardJsonArg = argValue(rest, '--card-json');
@@ -7404,6 +7417,138 @@ async function relaySend(
   }
   console.error('relay: 等待 daemon 投递超时（120s）');
   process.exit(1);
+}
+
+/**
+ * Relay a sandboxed cross-bot dispatch to the owning worker. The sandbox only
+ * contributes a bounded target app/chat plus task text; the watcher forces the
+ * live source session id and re-runs this exact build outside bwrap. This avoids
+ * reading a file bind that can become stale after the session store's atomic
+ * rename, without exposing the store or any bot credentials to the sandbox.
+ */
+async function relayDispatch(rest: string[], relayDir: string): Promise<void> {
+  const requestedSid = argValue(rest, '--session-id');
+  const sid = process.env.BOTMUX_SESSION_ID;
+  if (!sid) {
+    console.error(JSON.stringify({ success: false, errorCode: 'SOURCE_SESSION_NOT_FOUND' }));
+    process.exit(1);
+  }
+  if (requestedSid && requestedSid !== sid) {
+    console.error(JSON.stringify({
+      success: false,
+      sourceSessionId: sid,
+      transportState: 'failed',
+      acceptanceState: 'not_requested',
+      errorCode: 'SOURCE_SESSION_NOT_AUTHORIZED',
+      detail: 'sandbox dispatch can only use the worker-bound source session',
+    }));
+    process.exit(2);
+  }
+  const allowedFlags = new Set([
+    '--title', '--bot-app', '--chat-id', '--into', '--steer',
+    '--brief', '--brief-file', '--session-id',
+  ]);
+  const unsupportedFlags = [...new Set(rest
+    .filter(token => token.startsWith('--'))
+    .map(token => token.split('=', 1)[0]!)
+    .filter(flag => !allowedFlags.has(flag)))];
+  if (unsupportedFlags.length > 0) {
+    console.error(JSON.stringify({
+      success: false,
+      sourceSessionId: sid,
+      transportState: 'failed',
+      acceptanceState: 'not_requested',
+      errorCode: 'ROUTING_NOT_SUPPORTED',
+      detail: `sandbox dispatch does not support: ${unsupportedFlags.join(', ')}; use --bot-app with a stable Lark App ID`,
+    }));
+    process.exit(2);
+  }
+  const briefFile = argValue(rest, '--brief-file');
+  let brief = argValue(rest, '--brief') ?? '';
+  if (briefFile) {
+    if (!existsSync(briefFile)) {
+      console.error(JSON.stringify({ success: false, sourceSessionId: sid, errorCode: 'ROUTING_NOT_SUPPORTED', detail: `brief file not found: ${briefFile}` }));
+      process.exit(1);
+    }
+    brief = readFileSync(briefFile, 'utf8');
+  }
+  const flags: string[] = [];
+  for (const flag of ['--title', '--bot-app', '--chat-id', '--into'] as const) {
+    for (const value of argValues(rest, flag)) flags.push(flag, value);
+  }
+  if (rest.includes('--steer')) flags.push('--steer');
+  const id = randomBytes(8).toString('hex');
+  const contentBase = `${id}.content`;
+  const contentPath = join(relayDir, contentBase);
+  writeFileSync(contentPath, brief);
+  const originCapability = readManagedOriginCapability(
+    resolveDataDir(), sid, relayDir, process.env.BOTMUX_ORIGIN_CHANNEL_ID,
+  )?.capability;
+  atomicWriteFileSync(join(relayDir, `${id}.req.json`), JSON.stringify({
+    command: 'dispatch',
+    contentFile: contentBase,
+    flags,
+    ...(originCapability ? { originCapability } : {}),
+  }));
+  const resPath = join(relayDir, `${id}.res.json`);
+  const deadlineMs = Date.now() + 120_000;
+  while (Date.now() < deadlineMs) {
+    if (existsSync(resPath)) {
+      try {
+        const res = JSON.parse(readFileSync(resPath, 'utf8')) as { code?: number; stdout?: string; stderr?: string };
+        try { unlinkSync(resPath); } catch { /* */ }
+        try { unlinkSync(contentPath); } catch { /* */ }
+        if (res.stdout) process.stdout.write(res.stdout);
+        if (res.stderr) process.stderr.write(res.stderr);
+        process.exit(res.code ?? 1);
+      } catch { /* atomic response should be complete; retry defensively */ }
+    }
+    await new Promise(resolve => setTimeout(resolve, 150));
+  }
+  console.error(JSON.stringify({
+    success: false,
+    sourceSessionId: sid,
+    transportState: 'failed',
+    acceptanceState: 'timed_out',
+    errorCode: 'TRANSPORT_FAILED',
+    detail: 'daemon relay response timed out after 120s',
+  }));
+  process.exit(1);
+}
+
+async function persistDispatchLifecycle(input: {
+  dispatchRoot: string;
+  sourceSessionId: string;
+  status: 'dispatched' | 'accepted' | 'failed' | 'timed_out';
+  errorCode?: string | null;
+  acceptedBotAppIds?: readonly string[];
+  missingBotAppIds?: readonly string[];
+}): Promise<void> {
+  try {
+    await updateDispatchRegistry(join(resolveDataDir(), 'orchestrate-dispatch.json'), registry => {
+      const raw = registry[input.dispatchRoot];
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return;
+      const entry = raw as Record<string, unknown>;
+      if (entry.orchSessionId !== input.sourceSessionId) return;
+      const now = new Date().toISOString();
+      entry.status = input.status;
+      entry.transportState = 'dispatched';
+      entry.acceptanceState = input.status === 'failed'
+        ? 'failed'
+        : input.status === 'timed_out'
+        ? 'timed_out'
+        : input.status === 'accepted' ? 'accepted' : 'requested';
+      entry.errorCode = input.errorCode
+        ?? (input.status === 'timed_out' ? 'ACCEPTANCE_TIMEOUT' : null);
+      if (input.acceptedBotAppIds) entry.acceptedBotAppIds = [...input.acceptedBotAppIds];
+      if (input.missingBotAppIds) entry.missingBotAppIds = [...input.missingBotAppIds];
+      if (input.status === 'accepted') entry.acceptedAt = now;
+      if (input.status === 'failed' || input.status === 'timed_out') entry.failedAt = now;
+      entry.updatedAt = now;
+    });
+  } catch (error) {
+    console.error(`dispatch lifecycle persistence failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 /** True if the running bot (by daemon-injected larkAppId) is core-only
@@ -9802,6 +9947,11 @@ async function cmdDispatch(rest: string[]): Promise<void> {
   --session-id <id>     指定来源会话（默认自动推断）`);
     return;
   }
+  const dispatchRelayDir = process.env.BOTMUX_SEND_RELAY;
+  if (dispatchRelayDir) {
+    await relayDispatch(rest, dispatchRelayDir);
+    return;
+  }
   // dispatch opens a real Feishu topic + pulls bots into a chat (a write). A
   // no-transport turn has no Feishu chat to dispatch into — central hard gate.
   assertTurnTransportOrExit('dispatch');
@@ -9967,6 +10117,7 @@ async function cmdDispatch(rest: string[]): Promise<void> {
     ? JSON.stringify({ zh_cn: { title: '', content: built.threadContent } })
     : undefined;
 
+  let dispatchRootForLifecycle = intoRoot;
   try {
     // --into: append into an existing thread (activate standby bots / coordinate).
     if (intoRoot) {
@@ -9982,8 +10133,18 @@ async function cmdDispatch(rest: string[]): Promise<void> {
           })
         : undefined;
       const accepted = !acceptance || acceptance.missingBotAppIds.length === 0;
+      await persistDispatchLifecycle({
+        dispatchRoot: intoRoot,
+        sourceSessionId: sid,
+        status: !acceptance ? 'dispatched' : accepted ? 'accepted' : 'timed_out',
+        acceptedBotAppIds: acceptance?.acceptedBotAppIds,
+        missingBotAppIds: acceptance?.missingBotAppIds,
+      });
       console.log(JSON.stringify({
-        success: accepted, taskSent: true, mode: 'into', threadRootId: intoRoot,
+        success: accepted, taskSent: true, mode: 'into', sourceSessionId: sid,
+        targetAppIds: parsedBotApps.map(item => item.appId),
+        transportState: 'dispatched', acceptanceState: !acceptance ? 'not_requested' : accepted ? 'accepted' : 'timed_out',
+        errorCode: !acceptance || accepted ? null : 'ACCEPTANCE_TIMEOUT', threadRootId: intoRoot,
         kickoffMessageId: kickoffId, chatId: targetChatId, bots: built.mentionedOpenIds,
         collaborationReady: parsedBotApps.length > 0,
         ...(acceptance ? {
@@ -10022,6 +10183,7 @@ async function cmdDispatch(rest: string[]): Promise<void> {
     if (typeof seedId !== 'string' || !seedId) {
       throw new Error('dispatch report binding registration did not return a seed id');
     }
+    dispatchRootForLifecycle = seedId;
 
     // 2. Optional repo prime — a plain TEXT message "@bot /repo <path>" (like a
     //    human types) so each sub-bot spawns idle in that dir (no repo-select
@@ -10062,8 +10224,20 @@ async function cmdDispatch(rest: string[]): Promise<void> {
     }
 
     const accepted = !acceptance || acceptance.missingBotAppIds.length === 0;
+    await persistDispatchLifecycle({
+      dispatchRoot: seedId,
+      sourceSessionId: sid,
+      status: standby || !acceptance ? 'dispatched' : accepted ? 'accepted' : 'timed_out',
+      acceptedBotAppIds: acceptance?.acceptedBotAppIds,
+      missingBotAppIds: acceptance?.missingBotAppIds,
+    });
     console.log(JSON.stringify({
       success: accepted,
+      sourceSessionId: sid,
+      targetAppIds: parsedBotApps.map(item => item.appId),
+      transportState: 'dispatched',
+      acceptanceState: standby || !acceptance ? 'not_requested' : accepted ? 'accepted' : 'timed_out',
+      errorCode: !acceptance || accepted ? null : 'ACCEPTANCE_TIMEOUT',
       taskSent: !standby,
       mode: standby ? 'standby' : 'dispatch',
       seedMessageId: seedId,
@@ -10082,6 +10256,14 @@ async function cmdDispatch(rest: string[]): Promise<void> {
     }));
     if (!accepted) process.exitCode = 1;
   } catch (err: any) {
+    if (dispatchRootForLifecycle) {
+      await persistDispatchLifecycle({
+        dispatchRoot: dispatchRootForLifecycle,
+        sourceSessionId: sid,
+        status: 'failed',
+        errorCode: 'TRANSPORT_FAILED',
+      });
+    }
     console.error(`dispatch 失败: ${err.message}`);
     process.exit(1);
   }

--- a/src/core/dispatch-lifecycle.ts
+++ b/src/core/dispatch-lifecycle.ts
@@ -1,0 +1,93 @@
+import { join } from 'node:path';
+import { updateDispatchRegistry } from './dispatch-registry.js';
+
+export type DispatchLifecycleStatus = 'dispatched' | 'accepted' | 'failed' | 'timed_out';
+export type DispatchTransportState = 'dispatched' | 'failed';
+export type DispatchAcceptanceState = 'requested' | 'not_requested' | 'accepted' | 'failed' | 'timed_out';
+
+export interface DispatchLifecycleUpdate {
+  dataDir: string;
+  dispatchRoot: string;
+  sourceSessionId: string;
+  status: DispatchLifecycleStatus;
+  transportState: DispatchTransportState;
+  acceptanceState: DispatchAcceptanceState;
+  errorCode?: string | null;
+  acceptedBotAppIds?: readonly string[];
+  missingBotAppIds?: readonly string[];
+  now?: string;
+}
+
+export interface DispatchReceiptState {
+  transportState: DispatchTransportState;
+  acceptanceState: DispatchAcceptanceState;
+  errorCode: string | null;
+}
+
+export function dispatchReceiptState(input: Pick<DispatchLifecycleUpdate,
+  'transportState' | 'acceptanceState' | 'errorCode'>): DispatchReceiptState {
+  return {
+    transportState: input.transportState,
+    acceptanceState: input.acceptanceState,
+    errorCode: input.errorCode ?? null,
+  };
+}
+
+export function initialDispatchLifecycle(acceptanceRequested: boolean): {
+  status: 'dispatched';
+  transportState: 'dispatched';
+  acceptanceState: 'requested' | 'not_requested';
+  errorCode: null;
+} {
+  return {
+    status: 'dispatched',
+    transportState: 'dispatched',
+    acceptanceState: acceptanceRequested ? 'requested' : 'not_requested',
+    errorCode: null,
+  };
+}
+
+function validateLifecycle(input: DispatchLifecycleUpdate): void {
+  if (input.status === 'failed' && input.transportState !== 'failed') {
+    throw new Error('failed dispatch lifecycle requires failed transport');
+  }
+  if (input.status !== 'failed' && input.transportState !== 'dispatched') {
+    throw new Error(`${input.status} dispatch lifecycle requires dispatched transport`);
+  }
+  if (input.status === 'accepted' && input.acceptanceState !== 'accepted') {
+    throw new Error('accepted dispatch lifecycle requires accepted acceptance state');
+  }
+  if (input.status === 'timed_out' && input.acceptanceState !== 'timed_out') {
+    throw new Error('timed_out dispatch lifecycle requires timed_out acceptance state');
+  }
+  if (input.status === 'failed' && input.acceptanceState !== 'failed') {
+    throw new Error('failed dispatch lifecycle requires failed acceptance state');
+  }
+  if (input.status === 'dispatched'
+    && input.acceptanceState !== 'requested'
+    && input.acceptanceState !== 'not_requested') {
+    throw new Error('dispatched lifecycle requires requested or not_requested acceptance state');
+  }
+}
+
+/** Persist one internally-consistent handoff state for dashboard/control-plane readers. */
+export async function persistDispatchLifecycle(input: DispatchLifecycleUpdate): Promise<DispatchReceiptState> {
+  validateLifecycle(input);
+  await updateDispatchRegistry(join(input.dataDir, 'orchestrate-dispatch.json'), registry => {
+    const raw = registry[input.dispatchRoot];
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return;
+    const entry = raw as Record<string, unknown>;
+    if (entry.orchSessionId !== input.sourceSessionId) return;
+    const now = input.now ?? new Date().toISOString();
+    entry.status = input.status;
+    entry.transportState = input.transportState;
+    entry.acceptanceState = input.acceptanceState;
+    entry.errorCode = input.errorCode ?? null;
+    if (input.acceptedBotAppIds) entry.acceptedBotAppIds = [...input.acceptedBotAppIds];
+    if (input.missingBotAppIds) entry.missingBotAppIds = [...input.missingBotAppIds];
+    if (input.status === 'accepted') entry.acceptedAt = now;
+    if (input.status === 'failed' || input.status === 'timed_out') entry.failedAt = now;
+    entry.updatedAt = now;
+  });
+  return dispatchReceiptState(input);
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5893,7 +5893,12 @@ ipcRoute('POST', DISPATCH_REPORT_REGISTER_ROUTE, async (req, res) => {
         targetAppIds: stringArray(body?.targetAppIds),
         title,
         bots: stringArray(body?.bots),
+        status: 'dispatched',
+        transportState: 'dispatched',
+        acceptanceState: 'requested',
+        errorCode: null,
         createdAt: issuedAt,
+        updatedAt: issuedAt,
         reportBinding,
       },
     );

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -237,6 +237,7 @@ import {
   DISPATCH_REPORT_REGISTER_ROUTE,
 } from './core/dispatch-report-binding.js';
 import { recordDispatchRegistryEntry } from './core/dispatch-registry.js';
+import { initialDispatchLifecycle } from './core/dispatch-lifecycle.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
 import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, EXISTING_SESSION_ONLY_DAEMON_COMMANDS, resolvePassthroughCommands, resolveAdapterDefaultPassthroughCommands, handleCommand, handleCardCommand, handleCotCommand, handleTermLinkCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
 import { docWatchCommandNeedsSession } from './core/doc-watch-command.js';
@@ -5824,6 +5825,7 @@ ipcRoute('POST', DISPATCH_REPORT_REGISTER_ROUTE, async (req, res) => {
   const sessionId = typeof body?.sessionId === 'string' ? body.sessionId.trim() : '';
   const seedText = typeof body?.seedText === 'string' ? body.seedText.trim() : '';
   const targetChatId = typeof body?.targetChatId === 'string' ? body.targetChatId.trim() : '';
+  const acceptanceRequested = body?.acceptanceRequested === true;
   const title = typeof body?.title === 'string' ? body.title.trim().slice(0, 200) : '';
   if (!sessionId) return jsonRes(res, 400, { ok: false, error: 'missing_session_id' });
   if (!seedText) {
@@ -5893,10 +5895,7 @@ ipcRoute('POST', DISPATCH_REPORT_REGISTER_ROUTE, async (req, res) => {
         targetAppIds: stringArray(body?.targetAppIds),
         title,
         bots: stringArray(body?.bots),
-        status: 'dispatched',
-        transportState: 'dispatched',
-        acceptanceState: 'requested',
-        errorCode: null,
+        ...initialDispatchLifecycle(acceptanceRequested),
         createdAt: issuedAt,
         updatedAt: issuedAt,
         reportBinding,

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -518,6 +518,19 @@ botmux send --top-level "📢 重要更新：xxx"
 botmux send --top-level --chat-id oc_xxxxxxxxxxxx "📦 自动推送内容..."
 \`\`\`
 
+文件 sandbox 内不会把跨群/顶层路由静默降级：上述
+\`send --chat-id/--top-level\` 会明确返回
+\`ROUTING_NOT_SUPPORTED\`。跨 Bot 投递请改用稳定 App ID 的受管派单：
+
+\`\`\`bash
+botmux dispatch --chat-id oc_xxxxxxxxxxxx --bot-app cli_xxxxxxxxxxxx \\
+  --title "子任务" --brief "任务内容"
+\`\`\`
+
+sandbox dispatch 暂不支持
+\`--into\`；需要追加既有话题时由宿主侧会话执行，避免把已校验群与实际
+\`om_\` 线程拆成两个独立授权目标。
+
 \`--top-level\` 模式下不会附加"发送给：@xxx / cc：xxx" 那行 footer（顶层广播没有特定收件人）。oncall 寻址也会跳过。
 
 ## 参数

--- a/test/dispatch-lifecycle.test.ts
+++ b/test/dispatch-lifecycle.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initialDispatchLifecycle, persistDispatchLifecycle } from '../src/core/dispatch-lifecycle.js';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const dataDir = mkdtempSync(join(tmpdir(), 'botmux-dispatch-lifecycle-'));
+  roots.push(dataDir);
+  const path = join(dataDir, 'orchestrate-dispatch.json');
+  writeFileSync(path, JSON.stringify({ om_root: { orchSessionId: 'source' } }));
+  return { dataDir, path };
+}
+
+describe('dispatch lifecycle persistence', () => {
+  it('initializes acceptance only when the dispatch requested it', () => {
+    expect(initialDispatchLifecycle(true)).toEqual({
+      status: 'dispatched',
+      transportState: 'dispatched',
+      acceptanceState: 'requested',
+      errorCode: null,
+    });
+    expect(initialDispatchLifecycle(false)).toEqual({
+      status: 'dispatched',
+      transportState: 'dispatched',
+      acceptanceState: 'not_requested',
+      errorCode: null,
+    });
+  });
+
+  it('records a transport failure without claiming dispatch or acceptance', async () => {
+    const { dataDir, path } = fixture();
+    const receipt = await persistDispatchLifecycle({
+      dataDir,
+      dispatchRoot: 'om_root',
+      sourceSessionId: 'source',
+      status: 'failed',
+      transportState: 'failed',
+      acceptanceState: 'failed',
+      errorCode: 'TRANSPORT_FAILED',
+      now: '2026-08-31T00:00:00.000Z',
+    });
+    expect(JSON.parse(readFileSync(path, 'utf8')).om_root).toMatchObject({
+      status: 'failed',
+      transportState: 'failed',
+      acceptanceState: 'failed',
+      errorCode: 'TRANSPORT_FAILED',
+      failedAt: '2026-08-31T00:00:00.000Z',
+      updatedAt: '2026-08-31T00:00:00.000Z',
+    });
+    expect(receipt).toEqual({
+      transportState: 'failed',
+      acceptanceState: 'failed',
+      errorCode: 'TRANSPORT_FAILED',
+    });
+  });
+
+  it('keeps no-acceptance and acceptance-timeout states distinct', async () => {
+    const { dataDir, path } = fixture();
+    await persistDispatchLifecycle({
+      dataDir,
+      dispatchRoot: 'om_root',
+      sourceSessionId: 'source',
+      status: 'dispatched',
+      transportState: 'dispatched',
+      acceptanceState: 'not_requested',
+      errorCode: null,
+    });
+    expect(JSON.parse(readFileSync(path, 'utf8')).om_root).toMatchObject({
+      status: 'dispatched',
+      transportState: 'dispatched',
+      acceptanceState: 'not_requested',
+      errorCode: null,
+    });
+
+    await persistDispatchLifecycle({
+      dataDir,
+      dispatchRoot: 'om_root',
+      sourceSessionId: 'source',
+      status: 'timed_out',
+      transportState: 'dispatched',
+      acceptanceState: 'timed_out',
+      errorCode: 'ACCEPTANCE_TIMEOUT',
+    });
+    expect(JSON.parse(readFileSync(path, 'utf8')).om_root).toMatchObject({
+      status: 'timed_out',
+      transportState: 'dispatched',
+      acceptanceState: 'timed_out',
+      errorCode: 'ACCEPTANCE_TIMEOUT',
+    });
+  });
+
+  it('rejects contradictory transport and lifecycle states before mutation', async () => {
+    const { dataDir, path } = fixture();
+    await expect(persistDispatchLifecycle({
+      dataDir,
+      dispatchRoot: 'om_root',
+      sourceSessionId: 'source',
+      status: 'failed',
+      transportState: 'dispatched',
+      acceptanceState: 'failed',
+      errorCode: 'TRANSPORT_FAILED',
+    })).rejects.toThrow('failed dispatch lifecycle requires failed transport');
+    expect(JSON.parse(readFileSync(path, 'utf8')).om_root).toEqual({ orchSessionId: 'source' });
+  });
+});

--- a/test/sandbox-dispatch-routing.test.ts
+++ b/test/sandbox-dispatch-routing.test.ts
@@ -1,49 +1,236 @@
-import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startOutboxWatcher } from '../src/adapters/backend/sandbox.js';
+import {
+  RELAY_ORIGIN_CAPABILITY_BASENAME,
+  replaceManagedOriginCapabilityFile,
+} from '../src/core/managed-origin-capability.js';
+import { spawnTsScript } from './helpers/ts-runner.js';
 
-const cliSource = readFileSync(new URL('../src/cli.ts', import.meta.url), 'utf8');
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const roots: string[] = [];
 
-describe('sandbox dispatch routing invariants', () => {
-  it('relays dispatch before any source session-store lookup', () => {
-    const start = cliSource.indexOf('async function cmdDispatch(');
-    const end = cliSource.indexOf('async function cmdReport(', start);
-    const source = cliSource.slice(start, end);
-    expect(source.indexOf('await relayDispatch(rest, dispatchRelayDir)')).toBeGreaterThan(0);
-    expect(source.indexOf('await relayDispatch(rest, dispatchRelayDir)'))
-      .toBeLessThan(source.indexOf('const sessions = loadSessions()'));
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawnTsScript(join(__dirname, '..', 'src', 'cli.ts'), args, {
+      cwd: join(__dirname, '..'),
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => { stdout += String(chunk); });
+    child.stderr.on('data', chunk => { stderr += String(chunk); });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`CLI timed out: ${stderr}`));
+    }, 10_000);
+    child.on('error', reject);
+    child.on('close', code => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr });
+    });
   });
+}
 
-  it('fails sandbox send routing instead of silently dropping it', () => {
-    const start = cliSource.indexOf('async function relaySend(');
-    const end = cliSource.indexOf('async function relayDispatch(', start);
-    const source = cliSource.slice(start, end);
-    expect(source).toContain("['--chat-id', '--into', '--top-level']");
-    expect(source).toContain("errorCode: 'ROUTING_NOT_SUPPORTED'");
-    expect(source.indexOf("errorCode: 'ROUTING_NOT_SUPPORTED'"))
-      .toBeLessThan(source.indexOf('writeFileSync(cfile, content)'));
-  });
+function errorReceipt(stderr: string): Record<string, unknown> {
+  const line = stderr.trim().split('\n').filter(Boolean).at(-1);
+  if (!line) throw new Error('missing stderr receipt');
+  return JSON.parse(line) as Record<string, unknown>;
+}
 
-  it('emits verifiable source, target, transport and acceptance receipts', () => {
-    const start = cliSource.indexOf('async function cmdDispatch(');
-    const end = cliSource.indexOf('async function cmdReport(', start);
-    const source = cliSource.slice(start, end);
-    for (const field of [
-      'sourceSessionId',
-      'targetAppIds',
-      'chatId',
-      'threadRootId',
-      'transportState',
-      'acceptanceState',
-      'errorCode',
-    ]) {
-      expect(source).toContain(field);
+describe('sandbox dispatch CLI routing', () => {
+  it('dispatches through the host watcher without any readable Session Store', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-dispatch-cli-relay-'));
+    roots.push(root);
+    const dataDir = join(root, 'data');
+    const outbox = join(root, 'outbox');
+    mkdirSync(dataDir);
+    mkdirSync(outbox);
+    const capability = 'ab'.repeat(32);
+    replaceManagedOriginCapabilityFile(
+      join(outbox, RELAY_ORIGIN_CAPABILITY_BASENAME),
+      JSON.stringify({ token: capability, turnId: 'turn-live', dispatchAttempt: 1 }),
+    );
+    const calls = join(root, 'calls.jsonl');
+    const fixture = join(root, 'dispatch-host.mjs');
+    writeFileSync(fixture, `
+      import { appendFileSync, readFileSync } from 'node:fs';
+      const argv = process.argv.slice(2);
+      const value = flag => argv[argv.indexOf(flag) + 1];
+      const result = {
+        command: argv[0],
+        sessionId: value('--session-id'),
+        chatId: value('--chat-id'),
+        targetAppId: value('--bot-app'),
+        brief: readFileSync(value('--brief-file'), 'utf8'),
+      };
+      appendFileSync(${JSON.stringify(calls)}, JSON.stringify(result) + '\\n');
+      process.stdout.write(JSON.stringify(result));
+    `);
+    const stop = startOutboxWatcher(outbox, { ...process.env }, 'source-session', {
+      cliPath: fixture,
+      authorize: claim => claim.capability === capability
+        ? { ok: true, origin: { turnId: 'turn-live', dispatchAttempt: 1 } }
+        : { ok: false, error: 'stale capability' },
+    });
+    try {
+      const result = await runCli([
+        'dispatch', '--session-id', 'source-session', '--title', 'work',
+        '--bot-app', 'cli_target', '--chat-id', 'oc_target', '--brief', 'bounded task',
+      ], {
+        ...process.env,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'source-session',
+        BOTMUX_SEND_RELAY: outbox,
+        BOTMUX_WORKFLOW: '',
+      });
+      expect(result.code, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        command: 'dispatch',
+        sessionId: 'source-session',
+        chatId: 'oc_target',
+        targetAppId: 'cli_target',
+        brief: 'bounded task',
+      });
+      expect(readFileSync(calls, 'utf8').trim().split('\n')).toHaveLength(1);
+      expect(readdirSync(dataDir)).toEqual([]);
+    } finally {
+      stop();
     }
   });
 
-  it('persists accepted and timed-out lifecycle states for control-plane readers', () => {
-    expect(cliSource).toContain('async function persistDispatchLifecycle(');
-    expect(cliSource).toContain("status: 'dispatched' | 'accepted' | 'failed' | 'timed_out'");
-    expect(cliSource).toContain("status: 'failed'");
-    expect(cliSource).toContain("errorCode: 'TRANSPORT_FAILED'");
+  it('rejects a forged source session before writing an outbox request', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-dispatch-cli-source-'));
+    roots.push(root);
+    const outbox = join(root, 'outbox');
+    mkdirSync(outbox);
+    const result = await runCli([
+      'dispatch', '--session-id', 'forged-session', '--title', 'work',
+      '--bot-app', 'cli_target', '--chat-id', 'oc_target', '--brief', 'task',
+    ], {
+      ...process.env,
+      SESSION_DATA_DIR: join(root, 'data'),
+      BOTMUX_SESSION_ID: 'source-session',
+      BOTMUX_SEND_RELAY: outbox,
+      BOTMUX_WORKFLOW: '',
+    });
+    expect(result.code).toBe(2);
+    expect(errorReceipt(result.stderr)).toMatchObject({
+      success: false,
+      sourceSessionId: 'source-session',
+      errorCode: 'SOURCE_SESSION_NOT_AUTHORIZED',
+    });
+    expect(readdirSync(outbox).some(name => name.endsWith('.req.json'))).toBe(false);
+  });
+
+  it('rejects sandbox --into because its thread is not bound to the validated chat', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-dispatch-cli-into-'));
+    roots.push(root);
+    const outbox = join(root, 'outbox');
+    mkdirSync(outbox);
+    const result = await runCli([
+      'dispatch', '--session-id', 'source-session', '--into', 'om_other',
+      '--bot-app', 'cli_target', '--brief', 'task',
+    ], {
+      ...process.env,
+      SESSION_DATA_DIR: join(root, 'data'),
+      BOTMUX_SESSION_ID: 'source-session',
+      BOTMUX_SEND_RELAY: outbox,
+      BOTMUX_WORKFLOW: '',
+    });
+    expect(result.code).toBe(2);
+    expect(errorReceipt(result.stderr)).toMatchObject({
+      success: false,
+      errorCode: 'ROUTING_NOT_SUPPORTED',
+    });
+    expect(String(errorReceipt(result.stderr).detail)).toContain('--into');
+    expect(readdirSync(outbox).some(name => name.endsWith('.req.json'))).toBe(false);
+  });
+
+  it('fails sandbox send routing with exit 2 and no relay request', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-send-cli-routing-'));
+    roots.push(root);
+    const dataDir = join(root, 'data');
+    const outbox = join(root, 'outbox');
+    mkdirSync(dataDir);
+    mkdirSync(outbox);
+    replaceManagedOriginCapabilityFile(
+      join(outbox, RELAY_ORIGIN_CAPABILITY_BASENAME),
+      JSON.stringify({ token: 'cd'.repeat(32), turnId: 'turn-live', dispatchAttempt: 1 }),
+    );
+    writeFileSync(join(dataDir, 'sessions-app-a.json'), JSON.stringify({
+      session: {
+        sessionId: 'session', chatId: 'oc_source', rootMessageId: 'om_source',
+        title: 'source', status: 'active', createdAt: new Date(0).toISOString(),
+        larkAppId: 'app-a', cliId: 'codex-app',
+        codexAppDispatchLedger: [{
+          dispatchId: 'dispatch-live', turnId: 'turn-live', dispatchAttempt: 1,
+          state: 'prepared', content: 'prompt', deliverySink: 'lark',
+        }],
+      },
+    }));
+    const result = await runCli([
+      'send', 'must not send', '--session-id', 'session', '--chat-id', 'oc_target',
+      '--top-level', '--no-mention',
+    ], {
+      ...process.env,
+      SESSION_DATA_DIR: dataDir,
+      BOTMUX_SESSION_ID: 'session',
+      BOTMUX_SEND_RELAY: outbox,
+      BOTMUX_WORKFLOW: '',
+    });
+    expect(result.code).toBe(2);
+    expect(errorReceipt(result.stderr)).toMatchObject({
+      success: false,
+      transportState: 'failed',
+      acceptanceState: 'not_requested',
+      errorCode: 'ROUTING_NOT_SUPPORTED',
+    });
+    expect(readdirSync(outbox).some(name => name.endsWith('.req.json'))).toBe(false);
+  });
+
+  it('returns BRIEF_FILE_NOT_FOUND for a missing sandbox brief', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-dispatch-cli-brief-'));
+    roots.push(root);
+    const outbox = join(root, 'outbox');
+    mkdirSync(outbox);
+    const missing = join(root, 'missing.md');
+    expect(existsSync(missing)).toBe(false);
+    const result = await runCli([
+      'dispatch', '--session-id', 'source-session', '--title', 'work',
+      '--bot-app', 'cli_target', '--chat-id', 'oc_target', '--brief-file', missing,
+    ], {
+      ...process.env,
+      SESSION_DATA_DIR: join(root, 'data'),
+      BOTMUX_SESSION_ID: 'source-session',
+      BOTMUX_SEND_RELAY: outbox,
+      BOTMUX_WORKFLOW: '',
+    });
+    expect(result.code).toBe(1);
+    expect(errorReceipt(result.stderr)).toMatchObject({
+      success: false,
+      errorCode: 'BRIEF_FILE_NOT_FOUND',
+    });
+    expect(readdirSync(outbox).some(name => name.endsWith('.req.json'))).toBe(false);
   });
 });

--- a/test/sandbox-dispatch-routing.test.ts
+++ b/test/sandbox-dispatch-routing.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const cliSource = readFileSync(new URL('../src/cli.ts', import.meta.url), 'utf8');
+
+describe('sandbox dispatch routing invariants', () => {
+  it('relays dispatch before any source session-store lookup', () => {
+    const start = cliSource.indexOf('async function cmdDispatch(');
+    const end = cliSource.indexOf('async function cmdReport(', start);
+    const source = cliSource.slice(start, end);
+    expect(source.indexOf('await relayDispatch(rest, dispatchRelayDir)')).toBeGreaterThan(0);
+    expect(source.indexOf('await relayDispatch(rest, dispatchRelayDir)'))
+      .toBeLessThan(source.indexOf('const sessions = loadSessions()'));
+  });
+
+  it('fails sandbox send routing instead of silently dropping it', () => {
+    const start = cliSource.indexOf('async function relaySend(');
+    const end = cliSource.indexOf('async function relayDispatch(', start);
+    const source = cliSource.slice(start, end);
+    expect(source).toContain("['--chat-id', '--into', '--top-level']");
+    expect(source).toContain("errorCode: 'ROUTING_NOT_SUPPORTED'");
+    expect(source.indexOf("errorCode: 'ROUTING_NOT_SUPPORTED'"))
+      .toBeLessThan(source.indexOf('writeFileSync(cfile, content)'));
+  });
+
+  it('emits verifiable source, target, transport and acceptance receipts', () => {
+    const start = cliSource.indexOf('async function cmdDispatch(');
+    const end = cliSource.indexOf('async function cmdReport(', start);
+    const source = cliSource.slice(start, end);
+    for (const field of [
+      'sourceSessionId',
+      'targetAppIds',
+      'chatId',
+      'threadRootId',
+      'transportState',
+      'acceptanceState',
+      'errorCode',
+    ]) {
+      expect(source).toContain(field);
+    }
+  });
+
+  it('persists accepted and timed-out lifecycle states for control-plane readers', () => {
+    expect(cliSource).toContain('async function persistDispatchLifecycle(');
+    expect(cliSource).toContain("status: 'dispatched' | 'accepted' | 'failed' | 'timed_out'");
+    expect(cliSource).toContain("status: 'failed'");
+    expect(cliSource).toContain("errorCode: 'TRANSPORT_FAILED'");
+  });
+});

--- a/test/sandbox-relay-watcher.test.ts
+++ b/test/sandbox-relay-watcher.test.ts
@@ -81,6 +81,33 @@ describe('sandbox relay watcher host handoff', () => {
     }
   });
 
+  it('rejects a hand-written dispatch --into request at the watcher boundary', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-relay-dispatch-into-'));
+    roots.push(root);
+    const outbox = join(root, 'outbox');
+    mkdirSync(outbox);
+    const fixture = join(root, 'should-not-run.mjs');
+    writeFileSync(fixture, `process.stdout.write('ran');`);
+    const id = 'dispatch-into-reject';
+    writeFileSync(join(outbox, `${id}.content`), 'task');
+    writeFileSync(join(outbox, `${id}.req.json`), JSON.stringify({
+      command: 'dispatch',
+      contentFile: `${id}.content`,
+      flags: ['--bot-app', 'cli_target', '--into', 'om_other'],
+    }));
+    const stop = startOutboxWatcher(outbox, { ...process.env }, 'forced-source', { cliPath: fixture });
+    try {
+      const responsePath = join(outbox, `${id}.res.json`);
+      await vi.waitFor(() => expect(existsSync(responsePath)).toBe(true), { timeout: 5_000 });
+      const response = JSON.parse(readFileSync(responsePath, 'utf8')) as { code: number; stdout: string; stderr: string };
+      expect(response.code).toBe(1);
+      expect(response.stdout).toBe('');
+      expect(response.stderr).toContain('dispatch flag not allowed: --into');
+    } finally {
+      stop();
+    }
+  });
+
   it('materializes prepared card bytes and passes only the private path to the host child', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-relay-watcher-'));
     roots.push(root);

--- a/test/sandbox-relay-watcher.test.ts
+++ b/test/sandbox-relay-watcher.test.ts
@@ -20,6 +20,67 @@ afterEach(() => {
 });
 
 describe('sandbox relay watcher host handoff', () => {
+  it('re-execs dispatch on the host with a forced source session and bounded routing', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-relay-dispatch-'));
+    roots.push(root);
+    const outbox = join(root, 'outbox');
+    mkdirSync(outbox);
+    const fixture = join(root, 'dispatch-echo.mjs');
+    writeFileSync(fixture, `
+      import { readFileSync } from 'node:fs';
+      const argv = process.argv.slice(2);
+      const value = flag => argv[argv.indexOf(flag) + 1];
+      process.stdout.write(JSON.stringify({ command: argv[0], argv, sessionId: value('--session-id'), brief: readFileSync(value('--brief-file'), 'utf8') }));
+    `);
+    const id = 'dispatch-1';
+    writeFileSync(join(outbox, `${id}.content`), 'bounded task');
+    writeFileSync(join(outbox, `${id}.req.json`), JSON.stringify({
+      command: 'dispatch',
+      contentFile: `${id}.content`,
+      flags: ['--title', 'work', '--bot-app', 'cli_target', '--chat-id', 'oc_target'],
+    }));
+    const stop = startOutboxWatcher(outbox, { ...process.env }, 'forced-source', { cliPath: fixture });
+    try {
+      const responsePath = join(outbox, `${id}.res.json`);
+      await vi.waitFor(() => expect(existsSync(responsePath)).toBe(true), { timeout: 5_000 });
+      const response = JSON.parse(readFileSync(responsePath, 'utf8')) as { code: number; stdout: string; stderr: string };
+      expect(response.code, response.stderr).toBe(0);
+      const child = JSON.parse(response.stdout) as { command: string; argv: string[]; sessionId: string; brief: string };
+      expect(child.command).toBe('dispatch');
+      expect(child.sessionId).toBe('forced-source');
+      expect(child.brief).toBe('bounded task');
+      expect(child.argv).toContain('cli_target');
+      expect(child.argv).toContain('oc_target');
+    } finally {
+      stop();
+    }
+  });
+
+  it('rejects forged or legacy dispatch targets before spawning the host child', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-relay-dispatch-reject-'));
+    roots.push(root);
+    const outbox = join(root, 'outbox');
+    mkdirSync(outbox);
+    const fixture = join(root, 'should-not-run.mjs');
+    writeFileSync(fixture, `process.stdout.write('ran');`);
+    const id = 'dispatch-reject';
+    writeFileSync(join(outbox, `${id}.content`), 'task');
+    writeFileSync(join(outbox, `${id}.req.json`), JSON.stringify({
+      command: 'dispatch', contentFile: `${id}.content`, flags: ['--bot', 'friendly-name'],
+    }));
+    const stop = startOutboxWatcher(outbox, { ...process.env }, 'forced-source', { cliPath: fixture });
+    try {
+      const responsePath = join(outbox, `${id}.res.json`);
+      await vi.waitFor(() => expect(existsSync(responsePath)).toBe(true), { timeout: 5_000 });
+      const response = JSON.parse(readFileSync(responsePath, 'utf8')) as { code: number; stdout: string; stderr: string };
+      expect(response.code).toBe(1);
+      expect(response.stdout).toBe('');
+      expect(response.stderr).toContain('dispatch flag not allowed');
+    } finally {
+      stop();
+    }
+  });
+
   it('materializes prepared card bytes and passes only the private path to the host child', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-relay-watcher-'));
     roots.push(root);

--- a/test/sandbox-shim-compiled-form.test.ts
+++ b/test/sandbox-shim-compiled-form.test.ts
@@ -149,7 +149,7 @@ describe('relay host re-exec — botmuxCliInvocation', () => {
     // that reverts to `spawn(process.execPath, [cli, 'send', …])` would leave
     // every assertion above passing while the bug returns.
     const src = readFileSync(new URL('../src/adapters/backend/sandbox.ts', import.meta.url), 'utf-8');
-    expect(src).toContain("spawn(cliInvocation.command, [...cliInvocation.args, 'send'");
+    expect(src).toContain('spawn(cliInvocation.command, [...cliInvocation.args, v.value.command,');
     expect(src).toContain('botmuxCliInvocation(opts.cliPath)');
     // And the shim writer must go through the helper too.
     expect(src).toContain('writeFileSync(shim, botmuxShimExecLine())');


### PR DESCRIPTION
## 改了什么

- sandbox 内的 `botmux dispatch` 不再读取精确挂载的 Session 文件，改由当前 worker 的 outbox relay 在宿主侧执行。
- worker 强制绑定来源 Session；sandbox 只可提交受限的 `--bot-app`、目标群和任务正文，伪造 Session 或 legacy `--bot` 会被拒绝。
- sandbox `botmux send` 遇到 `--chat-id`、`--into`、`--top-level` 时返回非零状态和结构化 `ROUTING_NOT_SUPPORTED`，不再静默丢弃路由参数。
- sandbox dispatch 暂不开放 `--into`，避免已校验的 chat 与实际 `om_` 线程失去结构性绑定。
- dispatch 回执补齐来源 Session、目标 App、实际群/话题、transport/acceptance 状态和错误码。
- dispatch registry 持久化 `dispatched / accepted / failed / timed_out`、时间与错误码，并与 stdout 回执复用同一状态对象。

## 为什么

Linux bwrap 把 `sessions-<appId>.json` 作为精确文件挂载。Session Store 通过临时文件加原子 rename 更新后，已运行 sandbox 仍可能看到旧 inode；路径词法别名与规范路径不一致会进一步放大该问题。宿主和 Dashboard 能看到 Session 时，sandbox 内的 `dispatch` 仍可能报「未找到 session」。

同一路径下，旧 `relaySend` 明确丢弃跨群/顶层路由参数，却镜像宿主侧成功退出码，导致调用方误报已投递到目标群。

## 安全边界

- 不挂载完整 Session Store，不暴露 Bot App Secret。
- 来源 Session ID 由 worker 强制注入；sandbox 不能选择其他 Session。
- watcher 从结构化请求重建参数，不执行 sandbox 提供的原始 argv。
- 目标 App 与群做格式和参数白名单校验；sandbox `--into` fail closed。
- 不支持的 send/dispatch 路由明确 fail closed。

## 影响面

影响开启本地文件 sandbox 的 CLI 会话，覆盖 PTY 与持久 pane 的冷启动、重新附着及 daemon 重启后 watcher 重建路径。非 sandbox 的 dispatch/send 主路径保持不变；普通 send relay 的既有展示参数与附件行为保持不变。

## 验证

Focused：6 个主测试文件，44 项通过、0 项失败；另跑编译形态 SOURCE PIN 1 项通过。

```text
test/sandbox-relay-watcher.test.ts
test/sandbox-dispatch-routing.test.ts
test/dispatch-lifecycle.test.ts
test/cli-send-hook-context.test.ts
test/dispatch-registry.test.ts
test/report-daemon-ipc-auth-wiring.test.ts
test/sandbox-shim-compiled-form.test.ts -t "SOURCE PIN"
```

新增 routing 测试均执行真实 CLI 子进程，覆盖 relay-before-session-lookup、来源 Session 强制绑定、`--into` 拒绝、send 路由 exit 2 且不写 req、缺失 brief 的精确错误码。生命周期测试对真实 registry 文件执行更新，验证 failed transport 不会落成 dispatched，并验证 registry/receipt 口径一致。

`tsc --noEmit` 在当前共享依赖环境仍仅报 master 已有的 `yaml` 缺包及其派生 implicit-any；本 PR 文件无新增类型错误。

## 尚未验证

- 尚未在 Linux + bwrap 现场完成真实飞书端到端投递。
- Dashboard UI 的 handoff 行与独立 `requested → running → completed` 事件不在本 PR；本 PR 先提供可验证回执和持久化 `dispatched / accepted / failed / timed_out` 数据，后续再接控制面展示。
