### PR TITLE
feat(send): --mention 支持按邮箱/用户名 @ 群内任意成员（默认关，带群成员校验）

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1947,6 +1947,17 @@ export interface BotConfig {
    */
   regularGroupMentionMode?: 'always' | 'topic' | 'never' | 'ambient';
   /**
+   * 允许 `botmux send --mention` @ 群内任意成员（用邮箱 / username / union_id /
+   * open_id 指定），而不仅是本轮触发者（--mention-back）。默认 false：关闭时
+   * --mention 只接受字面 open_id，传入邮箱等非 open_id 标识会被拒绝，避免模型
+   * 自主决定 @ 谁时“乱发”。开启后：
+   *   1. --mention 的每个值先经 resolveAllowedUsersWithMap 解析成本 app open_id；
+   *   2. 解析结果再与目标群的成员列表（listChatMemberOpenIds）做交集校验，
+   *      只有确实在群里的人才会被 @，不在群里的直接拒绝发送。
+   * 是否开放由配置该 bot 的人决定（孙晓雪/李嘉瑞 #mention 讨论）。
+   */
+  allowArbitraryMention?: boolean;
+  /**
    * Regular-group substitute trigger. When enabled, an @mention of one of the
    * configured people is treated as an address to this bot when the sender can
    * talk to the bot. Matching currently uses mention open_id / user_id / union_id;
@@ -3333,6 +3344,9 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
         ? entry.autoStartOnGroupJoinSeed
         : undefined,
       autoStartOnNewTopic: entry.autoStartOnNewTopic === true || undefined,
+      // 默认 OFF：只有显式 true 有意义/落盘。开启后 `botmux send --mention`
+      // 才能用邮箱/username 等标识 @ 群内任意成员（见 BotConfig 上的说明）。
+      allowArbitraryMention: entry.allowArbitraryMention === true || undefined,
       messageListeners,
       worktreeMultiPicker: entry.worktreeMultiPicker === true || undefined,
       // Per-bot regular-group default mode. Default is 'chat-topic' (顶层平铺

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1947,14 +1947,14 @@ export interface BotConfig {
    */
   regularGroupMentionMode?: 'always' | 'topic' | 'never' | 'ambient';
   /**
-   * 允许 `botmux send --mention` @ 群内任意成员（用邮箱 / username / union_id /
+   * 允许 `botmux send --mention` @ 群内任意成员（用完整邮箱 / 手机号 / union_id /
    * open_id 指定），而不仅是本轮触发者（--mention-back）。默认 false：关闭时
    * --mention 只接受字面 open_id，传入邮箱等非 open_id 标识会被拒绝，避免模型
    * 自主决定 @ 谁时“乱发”。开启后：
    *   1. --mention 的每个值先经 resolveAllowedUsersWithMap 解析成本 app open_id；
    *   2. 解析结果再与目标群的成员列表（listChatMemberOpenIds）做交集校验，
    *      只有确实在群里的人才会被 @，不在群里的直接拒绝发送。
-   * 是否开放由配置该 bot 的人决定（孙晓雪/李嘉瑞 #mention 讨论）。
+   * 是否开放由配置该 bot 的人决定。
    */
   allowArbitraryMention?: boolean;
   /**
@@ -3345,7 +3345,7 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
         : undefined,
       autoStartOnNewTopic: entry.autoStartOnNewTopic === true || undefined,
       // 默认 OFF：只有显式 true 有意义/落盘。开启后 `botmux send --mention`
-      // 才能用邮箱/username 等标识 @ 群内任意成员（见 BotConfig 上的说明）。
+      // 才能用完整邮箱/手机号等标识 @ 群内任意成员（见 BotConfig 上的说明）。
       allowArbitraryMention: entry.allowArbitraryMention === true || undefined,
       messageListeners,
       worktreeMultiPicker: entry.worktreeMultiPicker === true || undefined,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6168,7 +6168,7 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
        --card-json <json>              直接发送飞书/Lark interactive 卡片 JSON 字符串
        --response-kind progress|final|auxiliary  可选；未声明按 progress/非 final，只有 final 挂反馈
        --mention <id:name>             @提及（可重复）。id 默认是 open_id；bot 配置开启
-                                       allowArbitraryMention 后也可传邮箱/用户名/union_id，
+                                       allowArbitraryMention 后也可传完整邮箱/手机号/union_id，
                                        自动解析并校验其为目标群成员，否则拒发
        --mention-back                  @回本轮触发消息的发送者（open_id 自动取自会话）
        --no-mention                    明确声明本条不@任何人
@@ -7250,6 +7250,7 @@ import {
   shouldDropAfterTheFactTopicQuote,
   validateMentionDecision,
   classifyMentionIdentifiers,
+  outsidersForMembership,
   mentionBackAmbiguity,
   mentionBackAmbiguityError,
   parseAttentionFlag,
@@ -8615,6 +8616,12 @@ async function cmdSend(rest: string[]): Promise<void> {
     try {
       // @ 落点：--mention-back → 回 @ 原评论人；--mention <open_id[:name]> → @ 指定人；
       // 否则（--no-mention / 无）不 @。文档评论里靠 person 元素渲染 @，仅首块加。
+      //
+      // 注意：这条文档评论路径在 allowArbitraryMention 闸之外（闸在下方 group
+      // 发送分支里）。这里直接取 mentionArgs[0] 冒号前的原文当 open_id 用，不做
+      // 解析/群成员校验。风险较低：文档评论的权限模型是文档权限而非群成员，且
+      // 传非 open_id（邮箱等）进去会被飞书侧拒绝渲染 person 元素（fail-closed）。
+      // 但「默认关」这个开关在此路径上不生效，若将来放开需一并过 gate。
       let docMentionOpenId: string | undefined;
       if (mentionBack) docMentionOpenId = exactDocTarget.replyToOpenId;
       else if (mentionArgs.length > 0) {
@@ -8668,13 +8675,13 @@ async function cmdSend(rest: string[]): Promise<void> {
 
   // Parse mentions: "identifier:Display Name" or bare "identifier".
   // `identifier` is a literal open_id (ou_…) by default. When the bot config
-  // enables `allowArbitraryMention`, it may also be an email / username /
-  // union_id (on_…) / mobile — those are resolved to this app's open_id after
-  // bot registration (see the resolveArbitraryMentions block below), then gated
-  // against the target chat's membership so an agent can only @ people who are
-  // actually in the group. With the switch off, non-open_id identifiers are
-  // rejected (default-deny: the model can't @ arbitrary people).
-  // Splitting on the FIRST ':' is safe: open_id / union_id / email / username
+  // enables `allowArbitraryMention`, it may also be a full email / union_id
+  // (on_…) / mobile — those are resolved to this app's open_id after bot
+  // registration (see the resolve block below), then gated against the target
+  // chat's membership so an agent can only @ people who are actually in the
+  // group. With the switch off, non-open_id identifiers are rejected
+  // (default-deny: the model can't @ arbitrary people).
+  // Splitting on the FIRST ':' is safe: open_id / union_id / email / mobile
   // never contain ':', only the optional trailing Display Name might.
   const mentions: Array<{ open_id: string; name: string }> = [];
   const rawMentions: Array<{ identifier: string; name: string }> = [];
@@ -8724,12 +8731,12 @@ async function cmdSend(rest: string[]): Promise<void> {
   // Turn each raw --mention identifier into a { open_id, name } entry.
   //   • Literal open_id (ou_…): kept as-is, always allowed (pre-existing
   //     behavior — an agent that already has an app-scoped open_id is trusted).
-  //   • Anything else (email / username / union_id / mobile): only when the bot
-  //     config sets `allowArbitraryMention: true`. Resolve via the existing
+  //   • Anything else (email / union_id / mobile): only when the bot config
+  //     sets `allowArbitraryMention: true`. Resolve via the existing
   //     resolveAllowedUsersWithMap (email→open_id etc.), then require the
   //     resolved open_id to be a member of the destination chat. This is the
-  //     safety门 孙晓雪 asked for: default-deny, and even when opened, an agent
-  //     can only @ people who are actually in the group.
+  //     safety gate: default-deny, and even when opened, an agent can only @
+  //     people who are actually in the group.
   {
     const mentionChatId = overrideChatId ?? s.chatId;
     const arbitraryAllowed = (() => {
@@ -8739,10 +8746,13 @@ async function cmdSend(rest: string[]): Promise<void> {
     const classified = classifyMentionIdentifiers(rawMentions, arbitraryAllowed);
     if (!classified.ok) { console.error(classified.error); process.exit(2); }
 
-    // open_id entries pass through untouched.
-    for (const r of classified.openIdMentions) {
-      mentions.push({ open_id: r.identifier, name: r.name });
-    }
+    // Resolved open_id per non-open_id identifier, filled by the block below.
+    // Kept separate from the push loop so we can emit `mentions` in the ORIGINAL
+    // command-line order (rawMentions) rather than "open_ids first, resolved
+    // second" — that order leaks into atPrefix / atSummary / mentioned[] / the
+    // footer, so a mixed `--mention email:A --mention ou_b --mention email:C`
+    // must stay A, b, C.
+    const resolvedOpenId = new Map<string, string>();
 
     const nonOpenId = classified.toResolve;
     if (nonOpenId.length > 0) {
@@ -8769,17 +8779,25 @@ async function cmdSend(rest: string[]): Promise<void> {
         );
         process.exit(2);
       }
-      const outsiders = nonOpenId.filter(r => !memberIds.has(map.get(r.identifier)!));
+      const outsiders = outsidersForMembership(
+        nonOpenId.map(r => ({ identifier: r.identifier, openId: map.get(r.identifier)! })),
+        memberIds,
+      );
       if (outsiders.length > 0) {
         console.error(
           `--mention 拒绝：以下用户不在目标群里，不能 @：` +
-          outsiders.map(r => `${r.identifier}→${map.get(r.identifier)}`).join(', '),
+          outsiders.map(o => `${o.identifier}→${o.openId}`).join(', '),
         );
         process.exit(2);
       }
-      for (const r of nonOpenId) {
-        mentions.push({ open_id: map.get(r.identifier)!, name: r.name });
-      }
+      for (const r of nonOpenId) resolvedOpenId.set(r.identifier, map.get(r.identifier)!);
+    }
+
+    // Emit in original command-line order: literal open_ids pass through, the
+    // rest use their resolved open_id.
+    for (const r of rawMentions) {
+      const openId = r.identifier.startsWith('ou_') ? r.identifier : resolvedOpenId.get(r.identifier);
+      if (openId) mentions.push({ open_id: openId, name: r.name });
     }
   }
   // ───────────────────────────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6167,7 +6167,9 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
        --card-file <path>              直接发送飞书/Lark interactive 卡片 JSON
        --card-json <json>              直接发送飞书/Lark interactive 卡片 JSON 字符串
        --response-kind progress|final|auxiliary  可选；未声明按 progress/非 final，只有 final 挂反馈
-       --mention <open_id:name>        @提及（可重复）
+       --mention <id:name>             @提及（可重复）。id 默认是 open_id；bot 配置开启
+                                       allowArbitraryMention 后也可传邮箱/用户名/union_id，
+                                       自动解析并校验其为目标群成员，否则拒发
        --mention-back                  @回本轮触发消息的发送者（open_id 自动取自会话）
        --no-mention                    明确声明本条不@任何人
        --quote <message_id>            指定引用某条消息（普通群，默认引用本轮触发消息）
@@ -7247,6 +7249,7 @@ import {
   resolveQuoteTarget,
   shouldDropAfterTheFactTopicQuote,
   validateMentionDecision,
+  classifyMentionIdentifiers,
   mentionBackAmbiguity,
   mentionBackAmbiguityError,
   parseAttentionFlag,
@@ -8663,17 +8666,24 @@ async function cmdSend(rest: string[]): Promise<void> {
     return;
   }
 
-  // Parse mentions: "open_id:Display Name" or bare "open_id"
-  // Bare form appends a trailing <at id=...> to the message and still writes
-  // a bot-mention signal — useful when the sender doesn't know the target's
-  // display name or just wants to notify without inline substitution.
+  // Parse mentions: "identifier:Display Name" or bare "identifier".
+  // `identifier` is a literal open_id (ou_…) by default. When the bot config
+  // enables `allowArbitraryMention`, it may also be an email / username /
+  // union_id (on_…) / mobile — those are resolved to this app's open_id after
+  // bot registration (see the resolveArbitraryMentions block below), then gated
+  // against the target chat's membership so an agent can only @ people who are
+  // actually in the group. With the switch off, non-open_id identifiers are
+  // rejected (default-deny: the model can't @ arbitrary people).
+  // Splitting on the FIRST ':' is safe: open_id / union_id / email / username
+  // never contain ':', only the optional trailing Display Name might.
   const mentions: Array<{ open_id: string; name: string }> = [];
+  const rawMentions: Array<{ identifier: string; name: string }> = [];
   for (const m of mentionArgs) {
     const idx = m.indexOf(':');
     if (idx > 0) {
-      mentions.push({ open_id: m.slice(0, idx), name: m.slice(idx + 1) });
+      rawMentions.push({ identifier: m.slice(0, idx).trim(), name: m.slice(idx + 1) });
     } else if (m.trim()) {
-      mentions.push({ open_id: m.trim(), name: '' });
+      rawMentions.push({ identifier: m.trim(), name: '' });
     }
   }
   const replyTargetSenderOpenId = explicitVcMeetingImOrigin?.replyTargetSenderOpenId
@@ -8709,6 +8719,70 @@ async function cmdSend(rest: string[]): Promise<void> {
   const { resolveRegularGroupMode } = await import('./services/chat-reply-mode-store.js');
   try { for (const cfg of loadBotConfigs()) registerBot(cfg); } catch { /* */ }
   if (envPinnedRiffBot) { try { registerBot(envPinnedRiffBot); } catch { /* */ } }
+
+  // ── --mention resolution + group-membership gate ──────────────────────────
+  // Turn each raw --mention identifier into a { open_id, name } entry.
+  //   • Literal open_id (ou_…): kept as-is, always allowed (pre-existing
+  //     behavior — an agent that already has an app-scoped open_id is trusted).
+  //   • Anything else (email / username / union_id / mobile): only when the bot
+  //     config sets `allowArbitraryMention: true`. Resolve via the existing
+  //     resolveAllowedUsersWithMap (email→open_id etc.), then require the
+  //     resolved open_id to be a member of the destination chat. This is the
+  //     safety门 孙晓雪 asked for: default-deny, and even when opened, an agent
+  //     can only @ people who are actually in the group.
+  {
+    const mentionChatId = overrideChatId ?? s.chatId;
+    const arbitraryAllowed = (() => {
+      try { return getBot(s.larkAppId).config.allowArbitraryMention === true; }
+      catch { return false; }
+    })();
+    const classified = classifyMentionIdentifiers(rawMentions, arbitraryAllowed);
+    if (!classified.ok) { console.error(classified.error); process.exit(2); }
+
+    // open_id entries pass through untouched.
+    for (const r of classified.openIdMentions) {
+      mentions.push({ open_id: r.identifier, name: r.name });
+    }
+
+    const nonOpenId = classified.toResolve;
+    if (nonOpenId.length > 0) {
+      const { resolveAllowedUsersWithMap, listChatMemberOpenIds } = await import('./im/lark/client.js');
+      const { map, errored } = await resolveAllowedUsersWithMap(
+        s.larkAppId, nonOpenId.map(r => r.identifier),
+      );
+      const unresolved = nonOpenId.filter(r => !map.get(r.identifier));
+      if (unresolved.length > 0) {
+        console.error(
+          `--mention 无法解析这些标识为群内 open_id：${unresolved.map(r => r.identifier).join(', ')}` +
+          (errored ? `（部分为临时失败，可稍后重试）` : `（不存在或本 bot 不可见）`),
+        );
+        process.exit(2);
+      }
+      // Membership gate: only @ people actually in the destination chat.
+      let memberIds: Set<string>;
+      try {
+        memberIds = new Set(await listChatMemberOpenIds(s.larkAppId, mentionChatId));
+      } catch (err: any) {
+        console.error(
+          `--mention 群成员校验失败（无法读取群 ${mentionChatId} 成员，可能缺 im:chat 成员读取权限）：` +
+          `${err?.message ?? err}`,
+        );
+        process.exit(2);
+      }
+      const outsiders = nonOpenId.filter(r => !memberIds.has(map.get(r.identifier)!));
+      if (outsiders.length > 0) {
+        console.error(
+          `--mention 拒绝：以下用户不在目标群里，不能 @：` +
+          outsiders.map(r => `${r.identifier}→${map.get(r.identifier)}`).join(', '),
+        );
+        process.exit(2);
+      }
+      for (const r of nonOpenId) {
+        mentions.push({ open_id: map.get(r.identifier)!, name: r.name });
+      }
+    }
+  }
+  // ───────────────────────────────────────────────────────────────────────────
   let feedbackPolicy: ReturnType<typeof resolveFeedbackPolicyForDelivery>;
   let feedbackWebhookDestinations: import('./services/feedback-outbox.js').FeedbackWebhookDestination[] | undefined;
   try {

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -661,12 +661,16 @@ export async function getChatInfo(larkAppId: string, chatId: string): Promise<{ 
  * Throws on API failure (e.g. missing `im:chat`/member-read scope) so the
  * caller can decide how to degrade — it does NOT swallow errors, because a
  * silent empty list would look like "no allowedUser present" and wrongly
- * suppress auto-start.
+ * suppress auto-start. For the same reason it also throws when the member list
+ * exceeds the page cap (>2000 members) and is still `has_more`: a silently
+ * truncated list would make members past the cap look like "not in the chat"
+ * (wrong-answer fail-open), so a truncation is surfaced as an error instead.
  */
 export async function listChatMemberOpenIds(larkAppId: string, chatId: string): Promise<string[]> {
   const c = getBotClient(larkAppId);
   const openIds: string[] = [];
   let pageToken: string | undefined;
+  let truncated = false;
   // Hard page cap as a runaway guard (100 members/page × 20 = 2000 members).
   for (let page = 0; page < 20; page++) {
     const params: Record<string, string> = { member_id_type: 'open_id', page_size: '100' };
@@ -681,6 +685,15 @@ export async function listChatMemberOpenIds(larkAppId: string, chatId: string): 
     }
     if (!res.data?.has_more || !res.data?.page_token) break;
     pageToken = res.data.page_token;
+    // Hit the cap with more pages remaining → the list is incomplete. Fail
+    // closed rather than return a truncated list (see docstring).
+    if (page === 19) truncated = true;
+  }
+  if (truncated) {
+    throw new Error(
+      `Chat ${chatId} has more than 2000 members; member list truncated at the page cap. ` +
+      `Refusing to return an incomplete list (would misjudge members past the cap as "not in chat").`,
+    );
   }
   return openIds;
 }

--- a/src/services/send-policy.ts
+++ b/src/services/send-policy.ts
@@ -179,6 +179,54 @@ export function neutralizeLarkAtTags(content: string): string {
     .replace(/<\/at\s*>/giu, match => `＜${match.slice(1, -1)}＞`);
 }
 
+export interface RawMention {
+  /** open_id (ou_…), or an email / username / union_id / mobile when the bot
+   *  enables arbitrary mention. */
+  identifier: string;
+  /** optional display name for inline <at> substitution */
+  name: string;
+}
+
+export interface MentionClassifyResult {
+  ok: boolean;
+  /** present when !ok — message to print before exit(2) */
+  error?: string;
+  /** literal open_id entries — always allowed, pass through untouched */
+  openIdMentions: RawMention[];
+  /** non-open_id entries that must be resolved + membership-gated (empty unless
+   *  the switch is on) */
+  toResolve: RawMention[];
+}
+
+/**
+ * Pure gate for `botmux send --mention` identifiers. Splits literal open_ids
+ * (always allowed) from non-open_id identifiers (email / username / union_id /
+ * mobile). Non-open_id identifiers are only permitted when the bot config sets
+ * `allowArbitraryMention`; otherwise this returns ok:false so the caller can
+ * reject before doing any Lark I/O. The actual email→open_id resolution and
+ * group-membership check are async side effects the caller performs on
+ * `toResolve`. Keeping the decision here makes it unit-testable without Lark.
+ */
+export function classifyMentionIdentifiers(
+  raw: RawMention[],
+  allowArbitraryMention: boolean,
+): MentionClassifyResult {
+  const openIdMentions = raw.filter(r => r.identifier.startsWith('ou_'));
+  const nonOpenId = raw.filter(r => !r.identifier.startsWith('ou_'));
+  if (nonOpenId.length > 0 && !allowArbitraryMention) {
+    return {
+      ok: false,
+      error:
+        `--mention 只接受字面 open_id（ou_…）；不支持用邮箱/用户名 @ 任意人。\n` +
+        `如需按邮箱/用户名 @ 群内成员，请在该 bot 配置里设 allowArbitraryMention: true。\n` +
+        `无法解析的项：${nonOpenId.map(r => r.identifier).join(', ')}`,
+      openIdMentions,
+      toResolve: [],
+    };
+  }
+  return { ok: true, openIdMentions, toResolve: nonOpenId };
+}
+
 export interface MentionDecisionArgs {
   /** config.send.requireMentionDecision */
   enabled: boolean;

--- a/src/services/send-policy.ts
+++ b/src/services/send-policy.ts
@@ -180,7 +180,7 @@ export function neutralizeLarkAtTags(content: string): string {
 }
 
 export interface RawMention {
-  /** open_id (ou_…), or an email / username / union_id / mobile when the bot
+  /** open_id (ou_…), or a full email / union_id / mobile when the bot
    *  enables arbitrary mention. */
   identifier: string;
   /** optional display name for inline <at> substitution */
@@ -200,7 +200,7 @@ export interface MentionClassifyResult {
 
 /**
  * Pure gate for `botmux send --mention` identifiers. Splits literal open_ids
- * (always allowed) from non-open_id identifiers (email / username / union_id /
+ * (always allowed) from non-open_id identifiers (email / union_id /
  * mobile). Non-open_id identifiers are only permitted when the bot config sets
  * `allowArbitraryMention`; otherwise this returns ok:false so the caller can
  * reject before doing any Lark I/O. The actual email→open_id resolution and
@@ -217,14 +217,30 @@ export function classifyMentionIdentifiers(
     return {
       ok: false,
       error:
-        `--mention 只接受字面 open_id（ou_…）；不支持用邮箱/用户名 @ 任意人。\n` +
-        `如需按邮箱/用户名 @ 群内成员，请在该 bot 配置里设 allowArbitraryMention: true。\n` +
+        `--mention 只接受字面 open_id（ou_…）；不支持用邮箱 @ 任意人。\n` +
+        `如需按完整邮箱/手机号/union_id @ 群内成员，请在该 bot 配置里设 allowArbitraryMention: true。\n` +
         `无法解析的项：${nonOpenId.map(r => r.identifier).join(', ')}`,
       openIdMentions,
       toResolve: [],
     };
   }
   return { ok: true, openIdMentions, toResolve: nonOpenId };
+}
+
+/**
+ * Pure group-membership gate for resolved --mention targets. Given the resolved
+ * open_id per non-open_id identifier and the set of open_ids that are actually
+ * members of the destination chat, return the identifiers whose resolved open_id
+ * is NOT a member (the ones that must be rejected). Extracted from cmdSend so the
+ * "in-group passes / out-of-group rejected" contract is unit-testable without
+ * Lark I/O — a mutation that deletes the check (always [] ) or reverses it
+ * (`has` instead of `!has`) must make these tests fail.
+ */
+export function outsidersForMembership(
+  resolved: Array<{ identifier: string; openId: string }>,
+  memberIds: Set<string>,
+): Array<{ identifier: string; openId: string }> {
+  return resolved.filter(r => !memberIds.has(r.openId));
 }
 
 export interface MentionDecisionArgs {

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -215,6 +215,34 @@ describe('parseBotConfigsFromText — brand', () => {
     }
   });
 
+  // allowArbitraryMention is a SAFETY switch (gates whether an agent may @
+  // arbitrary group members via email). Default MUST be off, and only a literal
+  // boolean `true` may turn it on — a mutation that flips normalization to
+  // `!== false` (default-open) or accepts the string "true" must fail here.
+  it('sets allowArbitraryMention only for a literal boolean true', () => {
+    const [cfg] = mod.parseBotConfigsFromText(JSON.stringify([
+      { larkAppId: 'a', larkAppSecret: 's', allowArbitraryMention: true },
+    ]));
+    expect(cfg.allowArbitraryMention).toBe(true);
+  });
+
+  it('defaults allowArbitraryMention to NOT-true (undefined) when unset', () => {
+    const [cfg] = mod.parseBotConfigsFromText(JSON.stringify([
+      { larkAppId: 'a', larkAppSecret: 's' },
+    ]));
+    expect(cfg.allowArbitraryMention).not.toBe(true);
+    expect(cfg.allowArbitraryMention).toBeUndefined();
+  });
+
+  it('keeps allowArbitraryMention NOT-true for false / "true" / 1 / {} (never default-open)', () => {
+    for (const val of [false, 'true', 1, {}] as const) {
+      const [cfg] = mod.parseBotConfigsFromText(JSON.stringify([
+        { larkAppId: 'a', larkAppSecret: 's', allowArbitraryMention: val },
+      ]));
+      expect(cfg.allowArbitraryMention).not.toBe(true);
+    }
+  });
+
   it('keeps only a valid sessionOwnerReminder configuration', () => {
     const reminder = {
       enabled: true,

--- a/test/send-policy.test.ts
+++ b/test/send-policy.test.ts
@@ -3,6 +3,7 @@ import {
   resolveQuoteTarget,
   shouldDropAfterTheFactTopicQuote,
   validateMentionDecision,
+  classifyMentionIdentifiers,
   mentionBackAmbiguity,
   mentionBackAmbiguityError,
   parseAttentionFlag,
@@ -414,5 +415,41 @@ describe('shouldDropAfterTheFactTopicQuote', () => {
     expect(shouldDropAfterTheFactTopicQuote({
       ...base, quotedTurnInThread: false, currentThreadId: '   ',
     })).toBe(false);
+  });
+});
+
+describe('classifyMentionIdentifiers', () => {
+  const oid = { identifier: 'ou_abc', name: 'Alice' };
+  const email = { identifier: 'bob@bytedance.com', name: 'Bob' };
+  const union = { identifier: 'on_xyz', name: '' };
+
+  it('passes literal open_ids through regardless of the switch', () => {
+    const r = classifyMentionIdentifiers([oid], false);
+    expect(r.ok).toBe(true);
+    expect(r.openIdMentions).toEqual([oid]);
+    expect(r.toResolve).toEqual([]);
+  });
+
+  it('rejects non-open_id identifiers when the switch is off', () => {
+    const r = classifyMentionIdentifiers([oid, email], false);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('allowArbitraryMention');
+    expect(r.error).toContain('bob@bytedance.com');
+    // open_ids are still surfaced so callers could partially proceed if desired
+    expect(r.openIdMentions).toEqual([oid]);
+  });
+
+  it('routes non-open_id identifiers to resolution when the switch is on', () => {
+    const r = classifyMentionIdentifiers([oid, email, union], true);
+    expect(r.ok).toBe(true);
+    expect(r.openIdMentions).toEqual([oid]);
+    expect(r.toResolve).toEqual([email, union]);
+  });
+
+  it('is a no-op for an empty mention list', () => {
+    const r = classifyMentionIdentifiers([], false);
+    expect(r.ok).toBe(true);
+    expect(r.openIdMentions).toEqual([]);
+    expect(r.toResolve).toEqual([]);
   });
 });

--- a/test/send-policy.test.ts
+++ b/test/send-policy.test.ts
@@ -4,6 +4,7 @@ import {
   shouldDropAfterTheFactTopicQuote,
   validateMentionDecision,
   classifyMentionIdentifiers,
+  outsidersForMembership,
   mentionBackAmbiguity,
   mentionBackAmbiguityError,
   parseAttentionFlag,
@@ -451,5 +452,33 @@ describe('classifyMentionIdentifiers', () => {
     expect(r.ok).toBe(true);
     expect(r.openIdMentions).toEqual([]);
     expect(r.toResolve).toEqual([]);
+  });
+});
+
+describe('outsidersForMembership', () => {
+  const members = new Set(['ou_alice', 'ou_bob']);
+
+  it('returns empty when every resolved open_id is a member (in-group passes)', () => {
+    const out = outsidersForMembership(
+      [{ identifier: 'a@x.com', openId: 'ou_alice' }, { identifier: 'b@x.com', openId: 'ou_bob' }],
+      members,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('flags a resolved open_id that is NOT a member (out-of-group rejected)', () => {
+    const out = outsidersForMembership(
+      [{ identifier: 'a@x.com', openId: 'ou_alice' }, { identifier: 'c@x.com', openId: 'ou_carol' }],
+      members,
+    );
+    expect(out).toEqual([{ identifier: 'c@x.com', openId: 'ou_carol' }]);
+  });
+
+  it('flags everyone when the member set is empty (gate has teeth)', () => {
+    const out = outsidersForMembership(
+      [{ identifier: 'a@x.com', openId: 'ou_alice' }],
+      new Set<string>(),
+    );
+    expect(out).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## 背景

`botmux send --mention` 此前只接受字面 open_id，无法让 agent（报警 / 任务分发等场景）@ 本轮触发者（`--mention-back`）以外的人。底层 `resolveAllowedUsersWithMap` 已能把邮箱 / username / union_id / mobile 解析成 open_id，但 send 入口没接线，且缺乏防“模型乱发”的安全边界。

## 改动

- **新增 bot 级开关 `allowArbitraryMention`（默认 `false`）**。关闭时 `--mention` 只接受 `ou_` 开头的字面 open_id，传入邮箱等其它标识直接拒绝并提示如何开启 —— 默认 deny，避免模型自主 @ 任意人。
- **开启后**，`--mention` 的非 open_id 值：
  1. 先经 `resolveAllowedUsersWithMap` 解析成本 app open_id；
  2. 再与目标群成员列表（`listChatMemberOpenIds`）做交集校验，**只有确实在群里的人才会被 @**，不在群里的直接拒发；
  3. 解析失败 / 成员读取失败都明确报错退出（exit 2），不静默降级。
- 决策逻辑抽到 `send-policy.ts` 的纯函数 `classifyMentionIdentifiers`，附单测；I/O（解析 + 成员列表）留在 `cmdSend`。
- 更新 `--mention` 帮助文本与 `bots.json` 归一化白名单。

**不含**：发送后从飞书回读校验 mentioned 是否真的 @ 到（按需求本期不做）。

## 自测

- `tsc --noEmit`：0 error
- 相关单测全过：`send-policy` / `inline-mentions` / `mention-mode-command` / `cli-send-dispatch` 共 119 项通过（含新增 4 项 `classifyMentionIdentifiers` 单测）
- 全量 unit 套件因本地环境缺 bun / node-pty 原生模块无法编译而未跑（与本改动无关；同样的 4 项 `cli-send-hook-context` 失败在 master 基线上一致存在，为环境问题）。建议 CI / bun 环境补跑全量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)