### PR TITLE
fix(npm): 不再发布无法运行的 Node 形态，堵住 node-pty 缺失崩溃

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,9 @@
   "version": "0.0.0",
   "description": "Bridge between IM platforms and AI coding CLIs \u2014 one topic, one CLI session with live streaming",
   "type": "module",
-  "main": "dist/index-daemon.js",
   "files": [
-    "dist/",
     "scripts/postinstall-bin.mjs",
     "scripts/install-path-entry.mjs",
-    "ecosystem.config.cjs",
     "README.md",
     "README.en.md",
     "LICENSE"

--- a/src/utils/install-info.ts
+++ b/src/utils/install-info.ts
@@ -4,9 +4,14 @@
  * a global package update against a daemon that runs from a git checkout
  * would not take effect and only risks confusion.
  *
- * npm publishes only `dist/` (+ a few root files; see package.json `files`),
- * never `.git` or `src/`, so the presence of either at the package root is a
- * reliable "running from source" signal.
+ * npm publishes neither `.git` nor `src/` (see package.json `files`), so the
+ * presence of either at the package root is a reliable "running from source"
+ * signal. That is the whole basis of the check, and it is unaffected by WHICH
+ * files the tarball does carry — this comment used to say "npm publishes only
+ * `dist/`", which stopped being true when `dist/` was dropped from `files` (it
+ * shipped a second, unrunnable Node CLI that imported node-pty, a package the
+ * manifest does not depend on). The predicate never depended on that; only the
+ * sentence did.
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -53,6 +53,66 @@ describe('package.json — lockfile safety and packaging', () => {
     }
   });
 
+  /**
+   * THE PUBLISHED TARBALL MUST NOT CARRY THE NODE FORM.
+   *
+   * #1047 removed the Node fallback by deleting `bin` and demoting node-pty to a
+   * devDependency — but `files` still shipped `dist/` (4221 files, 48 MB unpacked)
+   * plus an `ecosystem.config.cjs` whose `script` is `dist/index-daemon.js`. That
+   * left a complete, executable, `#!/usr/bin/env node`-shebanged CLI in the tarball
+   * whose module graph imports a package the manifest does not depend on.
+   *
+   * MEASURED on the real published botmux@3.18.8 — extracted, deps installed the way
+   * a global install does (`--omit=dev`, so node-pty is absent):
+   *   node dist/index-daemon.js
+   *   → Fatal error: ERR_MODULE_NOT_FOUND: Cannot find package 'node-pty'
+   *     imported from .../dist/adapters/backend/tmux-backend.js
+   * which is verbatim the error users reported on 3.18.7/3.18.8. The compiled
+   * binary in the platform subpackage embeds pty.node and is unaffected; only this
+   * shipped-but-unrunnable second copy of the CLI can produce it.
+   *
+   * ⚠️ ASSERTED AGAINST REAL `npm pack` OUTPUT, not against the `files` array.
+   * `files` is an input to a globbing/ignore-file algorithm, not the artifact: a
+   * modelled reading of it can be green while the tarball differs. So this asks npm
+   * itself what it would publish.
+   */
+  it('the PUBLISHED tarball ships no runnable Node form (the node-pty crash users hit)', () => {
+    const packed = spawnSync('npm', ['pack', '--dry-run', '--json'], {
+      encoding: 'utf-8',
+      cwd: resolve('.'),
+      timeout: 120_000,
+    });
+    // Never let an npm hiccup pass as "no dist/ in the tarball" — that is the
+    // vacuous-green direction for a test whose whole job is an absence claim.
+    expect(packed.error, `npm pack failed to run: ${packed.error?.message}`).toBeUndefined();
+    expect(packed.status, `npm pack exited ${packed.status}: ${packed.stderr}`).toBe(0);
+    const paths: string[] = JSON.parse(packed.stdout)[0].files.map((f: { path: string }) => f.path);
+    // Proof the probe saw a real file list, so the absence assertions below have
+    // something to be absent FROM.
+    expect(paths).toContain('package.json');
+    expect(paths).toContain('scripts/postinstall-bin.mjs');
+
+    // No second CLI. These three are the entry points a stale `exec node <path>`
+    // launcher, a systemd unit, or a hand-run `pm2 start` would land on.
+    for (const entry of ['dist/cli.js', 'dist/index-daemon.js', 'dist/worker.js']) {
+      expect(paths, `${entry} must not ship: it imports node-pty, which is not a dependency`).not.toContain(entry);
+    }
+    expect(paths.filter(p => p.startsWith('dist/'))).toEqual([]);
+    // The pm2 ecosystem file names dist/index-daemon.js as its `script`. Nothing in
+    // the source tree reads it (the supervisor replaced pm2), so its only remaining
+    // effect is telling a human to start the broken form by hand.
+    expect(paths).not.toContain('ecosystem.config.cjs');
+  });
+
+  it('declares no entry point that the tarball does not contain', () => {
+    // `main`/`bin` pointing into a dist/ that no longer ships would be a manifest
+    // that lies about itself: `require('botmux')` would resolve and then fail on a
+    // missing file. The package is a CLI delivered as a compiled binary, so it has
+    // no library entry point at all.
+    expect(manifest.bin).toBeUndefined();
+    expect(manifest.main).toBeUndefined();
+  });
+
   it('ships the postinstall script in `files` (otherwise npm i -g fails hard)', () => {
     expect(manifest.scripts.postinstall).toBe('node scripts/postinstall-bin.mjs');
     // Verified by packing+installing a probe: a missing postinstall target is not
@@ -332,6 +392,12 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     // Removing the runtime deps while leaving `bin` wired is the worst combination:
     // the fallback still resolves and then dies on `require('node-pty')`. Pin the
     // absence so a well-meaning re-add is caught here.
+    //
+    // ⚠️ `bin` was never the only way in. The tarball also shipped `dist/` itself,
+    // so a stale `exec node "<root>/dist/cli.js"` launcher left behind by a
+    // pre-#1047 install reached the same unrunnable CLI with no `bin` involved —
+    // that is the crash users hit on 3.18.7/3.18.8. `dist/` is out of `files` now
+    // (asserted against real `npm pack` output above); keep BOTH pins.
     const manifest = JSON.parse(readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf-8')) as {
       bin?: unknown;
       dependencies?: Record<string, string>;


### PR DESCRIPTION
## 问题

用户在 3.18.7 / 3.18.8 上报 daemon 与 worker 启动即死：

```
ERR_MODULE_NOT_FOUND: Cannot find package 'node-pty'
Worker process exited (code: 1)
```

手动补装 `node-pty@1.1.0` 后 restart 就恢复。

## 根因：是打包形态，不是依赖声明写错

第一直觉是「node-pty 被误放进 devDependencies，挪回 dependencies 就好」。**这个修法是错的**，会把 #1047 刻意解决的问题倒回去：node-pty 没有 linux 预编译产物，挂在 `dependencies` 上会让每次 `npm i -g` 都走 node-gyp，把整条编译工具链变成安装前提。编译版单文件二进制已经把 `pty.node` 嵌进去了，用户根本不需要装它。

真正的问题在 `files`。#1047 删掉了 `bin`、把 node-pty 降为 devDependency，但 `files` 里仍留着 `dist/` 和 `ecosystem.config.cjs`（后者的 `script` 正是 `dist/index-daemon.js`）。于是发布的 tarball 里始终躺着**第二份完整可执行的 Node 版 CLI**——mode 0755、带 `#!/usr/bin/env node`，而它的模块图 import 了一个主包并不依赖的包。

实测真实发布的 `botmux@3.18.8`（解包后按全局安装的方式装依赖，即 `--omit=dev`，所以 node-pty 不在）：

```
$ node dist/index-daemon.js
Fatal error: ERR_MODULE_NOT_FOUND: Cannot find package 'node-pty'
  imported from .../dist/adapters/backend/tmux-backend.js
```

与用户截图逐字一致。tarball 实际内容：4221 个文件、解包 39MB，其中 `dist/` 占 48MB（未压缩），而平台子包里的自包含二进制只有 2 个文件。

## 它是怎么被够到的

值得说清楚，因为这决定了修法：**当前源码里没有任何代码路径会在纯 npm 安装的机器上主动跑这份 Node 形态**。`resolveEntrySpawn` / `spawnWorker` / `autostart` / maintenance 重启全都按 `isStandaloneBinary()` 分支，编译态一律 re-exec 二进制自身。

它是通过**残留状态**被够到的：机器上早先装过 Node 形态（≤3.18.5 时代 `bin: dist/cli.js` 是常态，或 dev checkout 的 `use:here`），`~/.botmux/bin/botmux` 里留着 `exec node "<root>/dist/cli.js"`，或 systemd/launchd unit 的 ExecStart 钉着同一路径。升级把 `dist/` 换成新版，launcher 却没换，于是继续 exec 这份跑不起来的 CLI。

这正好解释了「手动补装 node-pty 后 restart 就好」：那是让**残留的 Node 形态**能跑起来，而不是把机器切回二进制——所以那台机器至今仍在跑 Node 形态。

## 改动

把 `dist/` 与 `ecosystem.config.cjs` 从 `files` 移出，并删掉指向 `dist/index-daemon.js` 的 `main`（tarball 不再含该文件，留着就是一句谎）。

少了这份副本，残留 launcher 会明确报文件不存在，而不是抛一个看不出所以然的 node-pty 模块错误；`npm i -g` 的产物也从 39MB 降到只剩 launcher 脚本 + README。

## 影响面

- **`ecosystem.config.cjs` 全仓零读取方**：pm2 已被 supervisor 取代（`fleet-runtime.ts` 注释写明「Mirrors what the old pm2 ecosystemConfig computed, minus pm2 itself」）；legacy pm2 reaper 只做 `jlist`/`delete`/`kill`，从不 start 或 resurrect；`test/pm2-existing-client.test.ts` 用的是自建 fixture。留着它的唯一作用是引导人手动 `pm2 start` 去跑坏的那份。
- **`main` 全仓零读取方**，`require('botmux')` 本来也不是使用方式。
- **桌面版确实跑 Node 形态**，但它的 `dist/` 是从**仓库 checkout** 复制的（`scripts/prepare-desktop-runtime.mjs`），node-pty 也按目录 copy 进去，完全不经过 npm tarball ⟹ 不受影响。
- **平台子包**（`botmux-linux-x64` 等）只含自包含二进制（实测 2 个文件、170MB），与 `dist/` 无关。
- **发布链不读 `files`**：`inject-optional-binaries` / `publish-npm-if-missing` / release.yml / ci.yml 全部无关。
- 跨平台：改的是 npm 打包清单，Linux/macOS 一致；不涉及任何 CLI 适配器、后端（PtyBackend/TmuxBackend）或会话类型。

## 验证

**复现**：真实 3.18.8 tarball + `--omit=dev` → 上述 node-pty 报错（见上）。

**修复形态**：把 `dist/` 与 ecosystem 从 tarball 移除后，用**真实发布的 3.18.8 二进制**作平台子包、在隔离 HOME 下跑真正的 `postinstall-bin.mjs`：

```
[botmux] launcher → .../node_modules/botmux-linux-x64/botmux
exit=0
$ cat $FAKEHOME/.botmux/bin/botmux
#!/bin/sh
exec ".../node_modules/botmux-linux-x64/botmux" "$@"
```

不含 `node`。（隔离 HOME 是刻意的：本机 `~/.botmux/bin/botmux` 是约 50 个 live daemon 共用的 launcher，探针绝不能碰它；跑完已核对它未被改动。）

**二进制不依赖被移除的文件**：在没有任何 `dist/` 的目录下跑真实 3.18.8 二进制，`--version` 输出 `3.18.8`。

**回归用例断言真实产物**：新增用例断言的是 `npm pack --dry-run --json` 的**实际输出**，而不是 `files` 数组——`files` 只是 glob/ignore 算法的输入，照它推断会与实际产物脱节。实测产出 6 个文件，无 `dist/`、无 `ecosystem.config.cjs`。

**反变异 5/5 全红**：

| # | 变异 | 结果 |
|---|---|---|
| 1 | `dist/` + ecosystem 复原（= 修复前状态） | 🔴 |
| 2 | 只复原 `ecosystem.config.cjs` | 🔴 |
| 3 | 重新加 `main` | 🔴 |
| 4 | 重新加 `bin` | 🔴（连带旧 SOURCE PIN 也红） |
| 5 | 把 `npm` 换成失败 stub | 🔴 报 `npm pack exited 127`，而非"没找到 dist"式假绿 |

第 5 条专门堵「绝对不存在」类断言的空转通道。每次变异都先 `cmp` 确认真写进文件，验完立即还原并 `cmp` 校验字节一致。

**测试**：`bun run build` 通过。`bun run test` 与**同一棵树**的基线做 A/B：

- 基线（stash 掉改动）：5 个失败文件
- 本改动：6 个失败文件，`19873 passed`
- 双向差集：PR-only 仅 `worker-riff-env.integration.test.ts`，反向为空

该文件零处引用打包相关标识符（`package.json`/`files`/`dist/`/`main` 全无匹配），是 15s 超时的真 spawn 集成测试；在带本改动的同一棵树上单独重跑 **2 passed** ⟹ 负载 flake，非本改动引入。

## 待确认

- ⏳ 合并后还需要**发版**才能到 npm 用户手上——这个修复只作用于新发布的 tarball。
- 🟠 残留 launcher 的自愈还没做（本 PR 只让失败可读）。后续可以让 postinstall 在检测到 launcher 内含 `exec node` 时无条件重写，以及在 standalone 启动时清理 ExecStart 里钉着 `dist/cli.js` 的 unit——想先听你意见再决定是否同 PR 处理。
- 🟠 顺带发现一个独立缺陷（未在本 PR 修）：`src/dashboard/managed-spawn.ts:42` 的 `spawn(process.execPath, [botmuxCliEntry(), …])` **没有 `isStandaloneBinary()` 分支**，编译态下 `botmuxCliEntry()` 返回不存在的 `/dist/cli.js`，二进制不认这个 token ⟹ 打印 help 并 exit 0，即 dashboard 的启停 bot 按钮在 npm 二进制安装上是静默空操作。与本次同类形态，建议单独开 issue。
