### PR TITLE
feat(schedule): 注入定时任务创建人身份

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -833,6 +833,7 @@ async function handleScheduleCommand(
   deps: CommandHandlerDeps,
   larkAppId?: string,
   senderOpenId?: string,
+  senderUnionId?: string,
 ): Promise<void> {
   const { activeSessions } = deps;
   const sessionReply = (rid: string, content: string, msgType?: string) =>
@@ -858,7 +859,13 @@ async function handleScheduleCommand(
       const nextStr = next ? t('schedule.next_label', { time: next.toLocaleString(timeLocale, { timeZone }) }, loc) : '';
       const lastStr = task.lastRunAt ? t('schedule.last_label', { time: new Date(task.lastRunAt).toLocaleString(timeLocale, { timeZone }) }, loc) : '';
       const display = task.parsed?.display ?? task.schedule;
-      return `${status} [${task.id}] ${display} | ${task.name}${task.silent ? ' 🔇' : ''}\n   prompt: ${task.prompt.substring(0, 50)}${task.prompt.length > 50 ? '...' : ''}${nextStr}${lastStr}`;
+      // Whose identity this task's turns run as. Worth a line of its own: with
+      // it absent the task still runs, but identity-bound tools fail closed,
+      // and that is otherwise only discoverable at fire time.
+      const runAsStr = task.ownerUnionId
+        ? `\n   runAs: ${task.ownerOpenId ?? task.ownerUnionId}`
+        : '\n   runAs: —（无创建人身份，按身份鉴权的工具会 fail-closed）';
+      return `${status} [${task.id}] ${display} | ${task.name}${task.silent ? ' 🔇' : ''}\n   prompt: ${task.prompt.substring(0, 50)}${task.prompt.length > 50 ? '...' : ''}${runAsStr}${nextStr}${lastStr}`;
     });
     await sessionReply(rootId, `${t('schedule.list_header', { count: tasks.length }, loc)}\n\n${lines.join('\n\n')}`);
     return;
@@ -950,6 +957,11 @@ async function handleScheduleCommand(
       // allowed at every run mutation; the default non-sandbox route does
       // not re-check membership.
       ownerOpenId: senderOpenId,
+      // union_id is the tenant-stable half of the same identity; it is what a
+      // scheduled turn presents to per-user backends. Only stamped for human
+      // creators (see the call site) — a task created by a bot deliberately
+      // keeps no user identity.
+      ownerUnionId: senderUnionId,
       deliver: 'origin',
       silent,
     });
@@ -2611,7 +2623,15 @@ export async function handleCommand(
       case '/schedule': {
         const scheduleArgs = message.content.replace(/^\/schedule\s*/, '');
         const chatId = ds?.chatId!;
-        await handleScheduleCommand(scheduleArgs, rootId, chatId, deps, larkAppId, message.senderId);
+        await handleScheduleCommand(
+          scheduleArgs, rootId, chatId, deps, larkAppId, message.senderId,
+          // Non-human senders (bots, and anything else Lark reports as an app)
+          // must not hand their own identity to a task: a bot-created task that
+          // could query as itself would let any caller of that bot borrow its
+          // access, with the audit trail pointing at the bot. Withholding the
+          // union_id here is what makes such a task fail closed later.
+          message.senderType === 'user' ? message.senderUnionId : undefined,
+        );
         logger.info(`[${logTag}] Schedule command handled`);
         break;
       }

--- a/src/core/plugins/mcp/gateway.ts
+++ b/src/core/plugins/mcp/gateway.ts
@@ -508,6 +508,13 @@ export class PluginMcpGateway {
       ...(caller?.requestUserOpenId ? { requestUserOpenId: caller.requestUserOpenId } : {}),
       ...(caller?.requestUserUnionId ? { requestUserUnionId: caller.requestUserUnionId } : {}),
       ...(caller?.requestLarkAppId ? { requestLarkAppId: caller.requestLarkAppId } : {}),
+      // Provenance travels with the identity so a plugin can tell "a human just
+      // asked" from "a scheduled task is running as them". Deliberately NOT
+      // mirrored into the `x-botmux-trusted-*` HTTP headers: those go to every
+      // HTTP-transport MCP server, and widening what they carry widens what an
+      // unrelated (possibly remote) plugin learns about the caller.
+      ...(caller?.source ? { source: caller.source } : {}),
+      ...(caller?.taskId ? { taskId: caller.taskId } : {}),
       ...(identity?.turnId ? { turnId: identity.turnId } : {}),
       ...(identity?.dispatchAttempt !== undefined ? { dispatchAttempt: identity.dispatchAttempt } : {}),
     };

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -580,6 +580,9 @@ export function addTask(params: {
    *  scheduled-turn-provenance). Absent for CLI-created tasks without a
    *  resolvable creator — those keep the historical behavior. */
   ownerOpenId?: string;
+  /** Creator's Lark union_id (tenant-stable). Stamped only for human creators;
+   *  a task without it runs its scheduled turns with no user identity. */
+  ownerUnionId?: string;
   parsed?: ParsedSchedule;
   repeat?: { times: number | null; completed: number };
   deliver?: 'origin' | 'local' | 'new-topic';
@@ -615,6 +618,7 @@ export function addTask(params: {
     creatorRootMessageId: params.creatorRootMessageId,
     creatorLarkAppId: params.creatorLarkAppId,
     ownerOpenId: params.ownerOpenId,
+    ownerUnionId: params.ownerUnionId,
     nextRunAt,
     repeat: params.repeat,
     // Delivery shape is now expressed by scope/rootMessageId. Persist only the

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1254,6 +1254,9 @@ export function buildNewTopicCliInput(
     codexAppFollowUps?: string[];
     codexAppFollowUpContexts?: string[];
     chatContext?: ChatContext;
+    /** Host-resolved identity for this turn. Only the caller knows where the
+     *  turn came from, so it is passed in rather than derived here. */
+    trustedCaller?: CliTurnPayload['trustedCaller'];
   },
 ): CliTurnPayload {
   const content = buildNewTopicPrompt(
@@ -1262,7 +1265,9 @@ export function buildNewTopicCliInput(
   );
   // Legacy pending buffers contain enriched strings. Only materialize those as
   // clean input when the caller also preserved their matching raw texts.
-  if (cliId !== 'codex-app' || (followUps && followUps.length > 0 && !opts?.codexAppFollowUps)) return { content };
+  if (cliId !== 'codex-app' || (followUps && followUps.length > 0 && !opts?.codexAppFollowUps)) {
+    return { content, ...(opts?.trustedCaller ? { trustedCaller: opts.trustedCaller } : {}) };
+  }
   const roleBlock = renderRoleContextBlock(opts?.larkAppId, opts?.chatId);
   const whiteboardBlock = renderWhiteboardBlock({
     whiteboardId: opts?.whiteboardId,
@@ -1279,6 +1284,7 @@ export function buildNewTopicCliInput(
   const chatContextBlock = renderChatContextBlock(opts?.chatContext);
   return {
     content,
+    ...(opts?.trustedCaller ? { trustedCaller: opts.trustedCaller } : {}),
     codexAppInput: buildCodexAppTurnInput({
       text: [opts?.codexAppText ?? userMessage, ...(opts?.codexAppFollowUps ?? [])].join('\n\n'),
       roleBlock: [roleBlock, summaryMemoryBlock].filter(Boolean).join('\n\n'),
@@ -1334,6 +1340,8 @@ type FollowUpOpts = {
    *  hook 模式下 sidecar 按 (turnId, fingerprint) 绑定，claim 时按权威 turnId 精确取。
    *  缺失时无法做 turn 绑定，回退 inline（避免 reminder 被剥离却无 sidecar 可领）。 */
   turnId?: string;
+  /** Host-resolved identity for this turn (see buildNewTopicCliInput). */
+  trustedCaller?: CliTurnPayload['trustedCaller'];
 };
 
 function buildFollowUpBlocks(
@@ -1535,12 +1543,14 @@ export function buildFollowUpCliInput(
       .join('\n\n');
     if (hookEnvelope && hookEnvelope.length <= HOOK_ENVELOPE_MAX_CHARS) {
       writePromptContext(sessionId, hookTurnId, ptyText, hookEnvelope);
-      return { content: ptyText };
+      return { content: ptyText, ...(opts?.trustedCaller ? { trustedCaller: opts.trustedCaller } : {}) };
     }
     // 无 envelope（理论上不会发生：claude-code 必有 reminder）或超限 → 回退 inline。
   }
   const legacyContent = buildFollowUpContent(content, sessionId, opts);
-  if (opts?.cliId !== 'codex-app' || opts.isAdoptMode) return { content: legacyContent };
+  if (opts?.cliId !== 'codex-app' || opts.isAdoptMode) {
+    return { content: legacyContent, ...(opts?.trustedCaller ? { trustedCaller: opts.trustedCaller } : {}) };
+  }
   const roleBlock = renderRoleContextBlock(opts.larkAppId, opts.chatId, { followUp: true });
   const whiteboardBlock = renderWhiteboardBlock({
     whiteboardId: opts.whiteboardId,
@@ -1554,6 +1564,7 @@ export function buildFollowUpCliInput(
   const mentionBlock = renderMentionBlock(opts.mentions);
   return {
     content: legacyContent,
+    ...(opts?.trustedCaller ? { trustedCaller: opts.trustedCaller } : {}),
     codexAppInput: buildCodexAppTurnInput({
       text: opts.codexAppText ?? content,
       roleBlock: [roleBlock, summaryMemoryBlock].filter(Boolean).join('\n\n'),
@@ -3199,6 +3210,32 @@ export function resolveScheduledTaskExecutionPosition(
   return task.scope !== 'chat' && task.rootMessageId ? 'topic' : 'top-level';
 }
 
+/**
+ * Identity a scheduled turn runs as: the task's creator, as captured at
+ * creation time. The turn itself is authenticated by the daemon-minted
+ * `schedule:<taskId>:<uuid>` turn id (see scheduled-turn-provenance) — this
+ * only decides WHICH identity that authenticated turn carries.
+ *
+ * Returns undefined when the task has no creator union_id (legacy tasks,
+ * CLI-created tasks, bot-created tasks). That is deliberate and is the whole
+ * fail-closed story: with no identity on the turn, identity-bound tools refuse
+ * to run instead of falling back to the bot's own access, while everything that
+ * does not need a user identity keeps working.
+ */
+function trustedCallerForScheduledTask(
+  task: ScheduledTask,
+  larkAppId: string,
+): CliTurnPayload['trustedCaller'] | undefined {
+  if (!task.ownerUnionId) return undefined;
+  return {
+    ...(task.ownerOpenId ? { requestUserOpenId: task.ownerOpenId } : {}),
+    requestUserUnionId: task.ownerUnionId,
+    requestLarkAppId: task.creatorLarkAppId ?? task.larkAppId ?? larkAppId,
+    source: 'schedule_creator',
+    taskId: task.id,
+  };
+}
+
 async function buildScheduledTargetNotice(params: {
   kind: 'chat' | 'thread';
   taskName: string;
@@ -3271,6 +3308,7 @@ export async function executeScheduledTask(
   // silent-output suppression, this identifies the exact shared-topic reply
   // target when a chat-scope session already has another turn queued.
   const scheduledTurnId = `schedule:${task.id}:${randomUUID()}`;
+  const scheduledTrustedCaller = trustedCallerForScheduledTask(task, larkAppId);
 
   // Decide where to route the "🕐 task started" notification and where the
   // session conversation lands.
@@ -3504,6 +3542,7 @@ export async function executeScheduledTask(
           whiteboardId: existing.session.whiteboardId,
           sessionBackendType: existing.session.backendType,
           turnId: scheduledTurnId,
+          trustedCaller: scheduledTrustedCaller,
         });
         rememberLastCliInput(existing, task.prompt, input);
         if (silent) armSilentScheduledTurn(existing, scheduledTurnId);
@@ -3592,7 +3631,7 @@ export async function executeScheduledTask(
       sessionStore.updateSession(ds.session);
     }
     ensureSessionWhiteboard(ds);
-    const prompt = buildNewTopicCliInput(firePrompt, session.sessionId, ds.session.cliLaunchSnapshot?.cliId ?? session.cliId ?? bot.config.cliId, ds.session.cliLaunchSnapshot?.cliPathOverride ?? session.cliPathOverride ?? bot.config.cliPathOverride, undefined, undefined, undefined, undefined, { name: bot.botName, openId: bot.botOpenId }, localeForBot(larkAppId), undefined, { larkAppId, chatId: task.chatId, whiteboardId: ds.session.whiteboardId });
+    const prompt = buildNewTopicCliInput(firePrompt, session.sessionId, ds.session.cliLaunchSnapshot?.cliId ?? session.cliId ?? bot.config.cliId, ds.session.cliLaunchSnapshot?.cliPathOverride ?? session.cliPathOverride ?? bot.config.cliPathOverride, undefined, undefined, undefined, undefined, { name: bot.botName, openId: bot.botOpenId }, localeForBot(larkAppId), undefined, { larkAppId, chatId: task.chatId, whiteboardId: ds.session.whiteboardId, trustedCaller: scheduledTrustedCaller });
     // Compare-and-set registration (master): a concurrent creator/restore may
     // have claimed this anchor between the scratch cleanup above and here.
     // Refuse to overwrite the live occupant, retire THIS rejected candidate's

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -3548,7 +3548,18 @@ export async function executeScheduledTask(
         if (silent) armSilentScheduledTurn(existing, scheduledTurnId);
         if (existing.worker && !existing.worker.killed) {
           try {
-            if (sendWorkerInput(existing, input, scheduledTurnId)) {
+            // sendWorkerInput reads the identity from OPTS, never from the
+            // payload (unlike forkWorker, which reads payload ?? opts). Passing
+            // it on `input` alone type-checks and then silently drops it — and
+            // this is the steady-state path for a recurring task (first fire
+            // creates the session, every later fire injects into it), so the
+            // failure shape would be "worked once, silently identity-less after".
+            if (sendWorkerInput(
+              existing,
+              input,
+              scheduledTurnId,
+              scheduledTrustedCaller ? { trustedCaller: scheduledTrustedCaller } : {},
+            )) {
               logger.info(`[scheduler] Task "${task.name}" injected into live session ${existing.session.sessionId}${silent ? ' (silent)' : ''}`);
               return;
             }

--- a/src/services/schedule-store.ts
+++ b/src/services/schedule-store.ts
@@ -258,6 +258,13 @@ function migrate(raw: any): ScheduledTask | null {
     creatorChatId: raw.creatorChatId,
     creatorRootMessageId: raw.creatorRootMessageId,
     creatorLarkAppId: raw.creatorLarkAppId,
+    // Creator identity is rebuilt field-by-field like everything else here, so
+    // it has to be listed explicitly: without these two lines `createTask`
+    // persists them but every reload (daemon restart, external `schedule add`
+    // bumping the file version) drops them, and the task silently degrades to
+    // "no creator".
+    ownerOpenId: raw.ownerOpenId,
+    ownerUnionId: raw.ownerUnionId,
     enabled: raw.enabled !== false,
     createdAt: raw.createdAt,
     lastRunAt: raw.lastRunAt,
@@ -471,6 +478,7 @@ export function createTask(params: {
   creatorRootMessageId?: string;
   creatorLarkAppId?: string;
   ownerOpenId?: string;
+  ownerUnionId?: string;
   nextRunAt?: string;
   repeat?: { times: number | null; completed: number };
   deliver?: 'origin' | 'local' | 'new-topic';
@@ -525,6 +533,7 @@ export function createTask(params: {
       creatorRootMessageId: params.creatorRootMessageId,
       creatorLarkAppId: params.creatorLarkAppId,
       ownerOpenId: params.ownerOpenId,
+      ownerUnionId: params.ownerUnionId,
       enabled: true,
       createdAt: new Date().toISOString(),
       nextRunAt: params.nextRunAt,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,15 @@ export interface TrustedCaller {
   requestUserOpenId?: string;
   requestUserUnionId?: string;
   requestLarkAppId?: string;
+  /** Where this identity came from. Absent = the ordinary IM path (the sender of
+   *  the inbound message that opened this turn). `'schedule_creator'` = a
+   *  daemon-fired scheduled turn running as the task's creator; `taskId` names
+   *  the task. Consumers that must distinguish "a human asked just now" from
+   *  "someone's scheduled task is running" (audit trails, approval gates) read
+   *  this instead of inferring it. */
+  source?: 'schedule_creator';
+  /** Scheduled task id — set only alongside `source: 'schedule_creator'`. */
+  taskId?: string;
 }
 
 export interface VcMeetingConsumerProfileFilter {
@@ -932,6 +941,15 @@ export interface ScheduledTask {
    *  creator — those keep the historical behavior (scheduled turns cannot
    *  run Saved Workflows). */
   ownerOpenId?: string;
+  /** Creator's Lark `union_id`, captured next to `ownerOpenId`. Stable across
+   *  apps within a tenant (unlike `ownerOpenId`, which is app-scoped), so it is
+   *  the identity a scheduled turn presents to per-user backends. Stamped only
+   *  when the creating message came from a human sender; absent for legacy
+   *  tasks, CLI-created tasks and bot-created tasks — a scheduled turn without
+   *  it carries no user identity at all (see `trustedCallerForScheduledTask`),
+   *  which is what keeps identity-bound tools fail-closed instead of silently
+   *  running as the bot. */
+  ownerUnionId?: string;
   enabled: boolean;
   createdAt: string;
   lastRunAt?: string;

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -4428,6 +4428,61 @@ describe('handleCommand', () => {
       // The adopt topic root must not be retained as a bookmark.
       expect(callArgs.rootMessageId).toBeUndefined();
     });
+
+    it('stamps the human creator identity (open_id + tenant-stable union_id)', async () => {
+      vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue({
+        parsed: { kind: 'cron', expr: '0 9 * * *', display: '每日 09:00' },
+        prompt: '生成日报',
+        name: '生成日报',
+      });
+      vi.mocked(scheduler.extractScheduleModifiers).mockImplementation((prompt: string) => ({
+        deliver: 'origin' as const,
+        silent: false,
+        prompt,
+      }));
+      vi.mocked(scheduler.addTask).mockReturnValue({ id: 'task-human' } as any);
+      vi.mocked(scheduler.getNextRun).mockReturnValue(new Date('2026-03-28T09:00:00+08:00'));
+
+      const deps = makeDeps(makeDaemonSession());
+      await handleCommand('/schedule', ROOT_ID, makeLarkMessage('/schedule 每日9:00 生成日报', {
+        senderId: 'ou_creator',
+        senderUnionId: 'on_creator',
+        senderType: 'user',
+      }), deps, LARK_APP_ID);
+
+      const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.ownerOpenId).toBe('ou_creator');
+      expect(callArgs.ownerUnionId).toBe('on_creator');
+    });
+
+    it('withholds the union_id when the creating sender is not a human', async () => {
+      // A bot-created task must not be able to run as the bot: without a
+      // union_id the scheduled turn carries no identity at all, so
+      // identity-bound tools fail closed instead of borrowing the bot's access.
+      vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue({
+        parsed: { kind: 'cron', expr: '0 9 * * *', display: '每日 09:00' },
+        prompt: '生成日报',
+        name: '生成日报',
+      });
+      vi.mocked(scheduler.extractScheduleModifiers).mockImplementation((prompt: string) => ({
+        deliver: 'origin' as const,
+        silent: false,
+        prompt,
+      }));
+      vi.mocked(scheduler.addTask).mockReturnValue({ id: 'task-bot' } as any);
+      vi.mocked(scheduler.getNextRun).mockReturnValue(new Date('2026-03-28T09:00:00+08:00'));
+
+      const deps = makeDeps(makeDaemonSession());
+      await handleCommand('/schedule', ROOT_ID, makeLarkMessage('/schedule 每日9:00 生成日报', {
+        senderId: 'ou_bot_sender',
+        senderUnionId: 'on_bot_sender',
+        senderType: 'app',
+      }), deps, LARK_APP_ID);
+
+      const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.ownerOpenId).toBe('ou_bot_sender');
+      expect(callArgs.ownerUnionId).toBeUndefined();
+    });
   });
 
   // ─── /login ─────────────────────────────────────────────────────────────

--- a/test/plugin-mcp-gateway.test.ts
+++ b/test/plugin-mcp-gateway.test.ts
@@ -205,6 +205,8 @@ describe('plugin MCP Gateway', () => {
             requestUserOpenId: 'ou_trusted',
             requestUserUnionId: 'on_trusted',
             requestLarkAppId: 'cli_trusted',
+            source: 'schedule_creator',
+            taskId: 'task_123',
           },
           turnId: 'om_turn',
           dispatchAttempt: 2,
@@ -231,6 +233,8 @@ describe('plugin MCP Gateway', () => {
     expect(text).toContain('"requestUserOpenId":"ou_trusted"');
     expect(text).toContain('"requestUserUnionId":"on_trusted"');
     expect(text).toContain('"requestLarkAppId":"cli_trusted"');
+    expect(text).toContain('"source":"schedule_creator"');
+    expect(text).toContain('"taskId":"task_123"');
     expect(text).toContain('"turnId":"om_turn"');
     expect(text).toContain('"dispatchAttempt":2');
     expect(text).toContain('"customTrace":"keep-me"');
@@ -304,6 +308,8 @@ describe('plugin MCP Gateway', () => {
             requestUserOpenId: 'ou_trusted',
             requestUserUnionId: 'on_trusted',
             requestLarkAppId: 'cli_trusted',
+            source: 'schedule_creator',
+            taskId: 'task_123',
           },
           turnId: 'om_trusted',
           dispatchAttempt: 2,
@@ -319,6 +325,10 @@ describe('plugin MCP Gateway', () => {
     expect(trusted.get('x-botmux-trusted-app-id')).toBe('cli_trusted');
     expect(trusted.get('x-botmux-turn-id')).toBe('om_trusted');
     expect(trusted.get('x-botmux-dispatch-attempt')).toBe('2');
+    // Provenance stays on the local `_meta` path only: these headers reach every
+    // HTTP-transport MCP server, so they must not start carrying it.
+    expect(trusted.get('x-botmux-trusted-source')).toBeNull();
+    expect(trusted.get('x-botmux-task-id')).toBeNull();
   });
 
   it('uses the session MCP runtime snapshot without reading the global plugin registry', async () => {

--- a/test/schedule-store-idempotency.test.ts
+++ b/test/schedule-store-idempotency.test.ts
@@ -152,6 +152,30 @@ describe('createTask — id provided, task exists with identical canonical input
     expect(second.repeat?.completed).toBe(1);
   });
 
+  it('keeps creator identity out of the canonical input so the same id stays idempotent', async () => {
+    const { createTask } = await freshImport();
+    const id = 'wf_owner_identity';
+    const first = createTask({ ...BASE_PARAMS, id, ownerOpenId: 'ou_old', ownerUnionId: 'on_old' });
+    const second = createTask({ ...BASE_PARAMS, id, ownerOpenId: 'ou_new', ownerUnionId: 'on_new' });
+    // Creator identity is audit metadata, not task input: a re-create with a
+    // different creator must return the existing task untouched rather than
+    // conflict — and must not quietly re-stamp whose identity it runs as.
+    expect(second.id).toBe(first.id);
+    expect(second.ownerUnionId).toBe('on_old');
+  });
+
+  it('rehydrates creator identity from disk (it is rebuilt field-by-field on load)', async () => {
+    const { createTask } = await freshImport();
+    createTask({ ...BASE_PARAMS, id: 'wf_owner_reload', ownerOpenId: 'ou_creator', ownerUnionId: 'on_creator' });
+    // Every read path rebuilds the task from the raw JSON, so a field that is
+    // written but not copied there survives only until the next reload. Without
+    // this the task silently loses its creator on daemon restart.
+    const reload = await freshImport();
+    const task = reload.getTask('wf_owner_reload');
+    expect(task?.ownerOpenId).toBe('ou_creator');
+    expect(task?.ownerUnionId).toBe('on_creator');
+  });
+
   it('treats chatType as canonical because it changes future session semantics', async () => {
     const { createTask, IdempotencyConflictError } = await freshImport();
     const id = 'wf_chattype';

--- a/test/scheduler-silent-execute.test.ts
+++ b/test/scheduler-silent-execute.test.ts
@@ -550,6 +550,50 @@ describe('executeScheduledTask — live-session injection', () => {
     expect(content).toContain('<botmux_silent_schedule');
   });
 
+  it('live injection carries the creator identity in OPTS (sendWorkerInput never reads the payload)', async () => {
+    // sendWorkerInput reads trustedCaller from its 4th argument only; forkWorker
+    // reads payload ?? opts. Putting the identity on the payload type-checks and
+    // is then silently dropped — and this is the path every recurring fire after
+    // the first one takes, so the bug would read as "worked once, then quietly
+    // ran without identity".
+    const active = new Map<string, DaemonSession>();
+    const existing = liveSession('idle');
+    active.set(sessionKey(ROOT, APP), existing);
+
+    await executeScheduledTask(baseTask({
+      rootMessageId: ROOT,
+      scope: 'thread',
+      ownerOpenId: 'ou_creator',
+      ownerUnionId: 'on_creator',
+    }), active, refreshCliVersion);
+
+    expect(sendWorkerInputMock).toHaveBeenCalledTimes(1);
+    expect(sendWorkerInputMock.mock.calls[0][3]).toEqual({
+      trustedCaller: {
+        requestUserOpenId: 'ou_creator',
+        requestUserUnionId: 'on_creator',
+        requestLarkAppId: APP,
+        source: 'schedule_creator',
+        taskId: 'task0001',
+      },
+    });
+  });
+
+  it('live injection passes no identity when the task has no creator union_id', async () => {
+    const active = new Map<string, DaemonSession>();
+    const existing = liveSession('idle');
+    active.set(sessionKey(ROOT, APP), existing);
+
+    await executeScheduledTask(baseTask({
+      rootMessageId: ROOT,
+      scope: 'thread',
+      ownerOpenId: 'ou_creator',
+    }), active, refreshCliVersion);
+
+    // Byte-for-byte the pre-change behaviour for legacy/bot-created tasks.
+    expect(sendWorkerInputMock.mock.calls[0][3]).toEqual({});
+  });
+
   it('riff-backed claude-code session: scheduled fire stays inline（锁 sessionBackendType 传参）', async () => {
     // review 要求：executeScheduledTask → buildFollowUpCliInput 必须传 sessionBackendType。
     // 删掉该实参，旧代码（&& 短路）会让 riff 会话误进 hook 模式（reminder 不在 PTY 文本里，

--- a/test/scheduler-silent-execute.test.ts
+++ b/test/scheduler-silent-execute.test.ts
@@ -181,6 +181,10 @@ function forkedTurnId(): string {
   return forkWorkerMock.mock.calls[0][2];
 }
 
+function forkedPayload(): any {
+  return forkWorkerMock.mock.calls[0][1];
+}
+
 beforeEach(() => {
   store.clear();
   sessionSeq = 0;
@@ -216,6 +220,37 @@ describe('executeScheduledTask — silent thread fire', () => {
     expect(input).toContain('检查服务状态，挂了才报警');
     // dashboard-facing lastUserPrompt keeps the raw task prompt (no hint blob)
     expect(ds.lastUserPrompt).toBe('检查服务状态，挂了才报警');
+  });
+
+  it('runs the turn as the task creator: identity + schedule_creator provenance on the payload', async () => {
+    const active = new Map<string, DaemonSession>();
+    await executeScheduledTask(baseTask({
+      rootMessageId: ROOT,
+      scope: 'thread',
+      ownerOpenId: 'ou_creator',
+      ownerUnionId: 'on_creator',
+    }), active, refreshCliVersion);
+
+    expect(forkedPayload().trustedCaller).toEqual({
+      requestUserOpenId: 'ou_creator',
+      requestUserUnionId: 'on_creator',
+      requestLarkAppId: APP,
+      source: 'schedule_creator',
+      taskId: 'task0001',
+    });
+  });
+
+  it('carries no identity when the task has no creator union_id (fail closed, not "runs as the bot")', async () => {
+    const active = new Map<string, DaemonSession>();
+    // ownerOpenId alone is what legacy tasks and bot-created tasks have. It is
+    // app-scoped and deliberately not enough to act as that user.
+    await executeScheduledTask(baseTask({
+      rootMessageId: ROOT,
+      scope: 'thread',
+      ownerOpenId: 'ou_creator',
+    }), active, refreshCliVersion);
+
+    expect(forkedPayload().trustedCaller).toBeUndefined();
   });
 
   it('loud fire (control): banner reply posted in-thread, no silent flag, no hint', async () => {


### PR DESCRIPTION
## 背景

定时任务触发的那一轮没有人类 inbound 消息，`trustedCallerForTurn` 拿不到 sender，因此这一轮对下游是「无身份」的。需要按人鉴权的能力（MCP 插件、任何触达外部权限资源的工具）只能二选一：拒绝执行，或者退回以 bot 自身的访问权执行——后者意味着任何能触发该 bot 的人都能借道它的权限，而审计只记到 bot，责任链断裂。

master 其实已经做了一半：

- `ScheduledTask.ownerOpenId` 在 `/schedule` 创建时就已落盘；
- `scheduled-turn-provenance` 用 daemon 每次触发铸造的 `schedule:<taskId>:<uuid>` 证明「这一轮确实是该任务被 daemon 触发」（现有消费方是 Saved Workflow 命令鉴权）。

缺的是两处：open_id 之外的**租户内稳定**标识，以及把这份身份交到本轮 trusted caller 上。本 PR 只补这两处，不引入新的身份概念。

（一个具体的消费场景：按调用者身份映射数据库账号的 MCP 插件，可以据此让定时报表以创建人的库权限执行、审计记到人；但改动本身与任何具体插件无关。）

## 改动

- `ScheduledTask` / `scheduleTask` / `createTask` 增加 `ownerUnionId`，与既有 `ownerOpenId` 同组语义，命名对齐 `Session.ownerUnionId`。open_id 按 app 隔离，union_id 租户内稳定，后者才是按人鉴权的后端可用的标识。
- `/schedule` 创建时从宿主消息的 sender 捕获，**只在 `senderType === 'user'` 时落 union_id**。bot 创建的任务刻意不带可复用身份，否则等于给「谁能让这个 bot 说话」开一条权限提升通道。
- 触发时按任务创建人构造**本轮** trusted caller，标 `source=schedule_creator` + `taskId`；没有 `ownerUnionId` 就**不注入**，让按身份鉴权的工具 fail-closed，同时不影响该任务里不需要用户身份的能力。turn 本身的认证仍然由既有 provenance 机制负责，本 PR 不改动它。
- `source` / `taskId` 只进本地 `_meta.botmuxTrustedCaller`，**不进 `x-botmux-trusted-*` HTTP 头**：那组头会发给所有 HTTP transport 的 MCP server，扩大它携带的信息等于扩大无关（可能是远端）插件能学到的调用者信息。已加断言把这条钉住。
- `schedule list` 增加 runAs：任务以谁的身份执行，此前只能在触发失败时才发现。
- `ownerUnionId` 属于审计/溯源元数据，**不进 `canonicalScheduleInput`**——否则同一任务换个创建人重建会被判成不同任务，破坏幂等语义。

### 顺带修一个装载期丢字段的问题

`schedule-store.ts` 的 `migrate()` 逐字段重建任务对象，而 `ownerOpenId` 不在复制列表里。因此 `createTask` 写进磁盘的创建人，在**每次重新装载**（daemon 重启、外部 `schedule add` 抬高文件版本）之后就被丢弃，任务静默退化成「无创建人」——scheduled-turn provenance 的鉴权在重启后随之失效。两个字段一并补上，并加回归用例。

## 影响面

- 存量任务没有 `ownerUnionId`，行为与今天完全一致（不注入身份），不需要迁移；
- 新建任务多带一个字段，`schedule list` 多一行 runAs；
- 已有的 `x-botmux-trusted-*` 头与 HTTP transport 插件的可见信息**不变**。

## 验证

工具链：bun 1.4.0 / node v24.17.0

```
bun install --frozen-lockfile
bun run build
bun run test
```

- build 通过；
- 全量测试的失败**文件名**与 master 基线一致，差集 5 个（`dashboard-launcher-supervised`、`hook-runner`、`mojo-residual-close-admission`、`tmux-pipe-backend-exit`、`worker-terminal-read-auth`）**单跑全绿**，属满载 flaky（反向亦然：基线里失败的 `codex-app-threads` 这次未失败）；
- 变异验证三处，均按预期变红：
  1. 摘掉触发时的身份注入 → `test/scheduler-silent-execute.test.ts` 红；
  2. 摘掉创建时捕获 union_id → `test/command-handler.test.ts` 的「stamps the human creator identity」红；
  3. 摘掉装载期字段补齐 → `test/schedule-store-idempotency.test.ts` 的 rehydration 回归用例红。
