### PR TITLE
fix(install): PATH 守卫改问启动文件，修复装完新终端找不到 botmux

### DIFF
--- a/scripts/postinstall-bin.mjs
+++ b/scripts/postinstall-bin.mjs
@@ -252,13 +252,31 @@ try {
 // only way this launcher becomes a command; we now write the right startup file
 // for the user's actual shell (bash/zsh/fish/other) and tell them what we did.
 //
+// ⚠️ DO NOT GATE THIS ON `process.env.PATH`. It used to be wrapped in
+// `if (!process.env.PATH.split(':').includes(binDir))`, which asks "is binDir on
+// the PATH of the process running the install?" — the wrong question. What decides
+// whether `botmux` works is whether the user's FUTURE shells get it, i.e. whether a
+// startup file says so. The two come apart whenever the installing shell has binDir
+// on PATH transiently, and botmux itself creates that situation: the daemon
+// prepends `~/.botmux/bin` to every CLI session's PATH (five `prependBotmuxBin`
+// call sites in worker.ts / worker-pool.ts). So `npm i -g botmux` run from inside a
+// botmux session — or any shell that merely exported the dir — wrote NO startup
+// file, printed NO hint, and exited 0; the next terminal then had no `botmux` at
+// all, because there is no `bin` field to fall back on. MEASURED with the real
+// script against an isolated HOME, changing only PATH:
+//   PATH without binDir → writes ~/.zshenv + "open a new terminal" hint
+//   PATH with    binDir → zero files, zero output, exit 0   ← the reported bug
+// `ensurePathEntry` already asks the right question per file (`fileAlreadyHasEntry`,
+// which also recognises a line the user wrote by hand) and reports those as
+// `skipped`, so this outer check was redundant as well as wrong.
+//
 // ⚠️ FAIL-SOFT, and never `fail()`: the launcher is already installed and working
 // at this point, so a PATH edit that cannot happen must degrade to the printed
 // hint — not abort a successful install. That includes the sibling module simply
 // not being there: it ships via package.json `files`, and if a future edit drops
 // it (or a mirror repacks the tarball without it) the import throws. Guarding it
 // keeps `npm i -g botmux` succeeding either way.
-if (!(process.env.PATH ?? '').split(':').includes(binDir)) {
+{
   let ensurePathEntry = null;
   try {
     ({ ensurePathEntry } = await import('./install-path-entry.mjs'));

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -164,7 +164,8 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     sourceCheckout?: boolean;
     /** Omit scripts/install-path-entry.mjs, to prove the import is fail-soft. */
     withoutPathHelper?: boolean;
-    /** Pretend binDir is already on PATH, so the PATH-writing branch is skipped. */
+    /** Pretend binDir is already on the INSTALLING process's PATH. Note this must
+     *  NOT suppress the startup-file write — see the test that pins it. */
     binDirOnPath?: boolean;
     /** $SHELL for the child, which decides WHICH startup file gets the PATH line. */
     shell?: string;
@@ -172,9 +173,13 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     brokenBinary?: boolean;
     /** Existing shared launcher that a rejected update must preserve byte-for-byte. */
     existingLauncher?: string;
+    /** Run against an EXISTING home from a previous call, the way an upgrade does.
+     *  Needed to exercise idempotence across two installs (the startup file has to
+     *  survive between them, which a fresh tmp home cannot show). */
+    reuseHome?: string;
   }) {
     const base = tmp();
-    const home = join(base, 'home');
+    const home = opts.reuseHome ?? join(base, 'home');
     const pkg = join(base, 'pkg');
     mkdirSync(home, { recursive: true });
     mkdirSync(join(pkg, 'scripts'), { recursive: true });
@@ -262,13 +267,71 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     expect(`${r.stdout}${r.stderr}`).toContain('PATH');
   });
 
-  it('touches no startup file when binDir is already on PATH', () => {
-    // An upgrade on a machine that was set up long ago must not keep appending
-    // to (or even creating) rc files it has nothing to add to.
+  /**
+   * WRITES THE STARTUP FILE EVEN WHEN binDir IS ALREADY ON THE INSTALLING SHELL'S
+   * PATH — this replaces a test that asserted the opposite and thereby pinned a bug.
+   *
+   * The old contract ("touches no startup file when binDir is already on PATH") was
+   * reasoned from upgrade noise: "an upgrade on a machine set up long ago must not
+   * keep appending to rc files". The goal is right; the SIGNAL was wrong. It gated
+   * on `process.env.PATH`, i.e. the PATH of the process running the install, while
+   * what actually decides whether `botmux` works is whether the user's FUTURE shells
+   * get it — a property of the startup FILE.
+   *
+   * Those come apart, and botmux itself pulls them apart: the daemon prepends
+   * `~/.botmux/bin` to every CLI session's PATH (five `prependBotmuxBin` call sites
+   * in worker.ts / worker-pool.ts). So `npm i -g botmux` run from inside a botmux
+   * session hit the gate, wrote NOTHING, printed NOTHING, exited 0 — and since there
+   * is no `bin` field to fall back on, the user's next terminal had no `botmux` at
+   * all. That is the reported "3.18.8 更新之后找不到 botmux 命令", still reproducing
+   * after `exec zsh -l` because the file the login shell reads was never written.
+   *
+   * Idempotence is still required — it is just enforced where the real answer lives:
+   * `ensurePathEntry` consults `fileAlreadyHasEntry` per file (which also recognises
+   * a line the user wrote by hand) and reports those as `skipped`. The next test
+   * pins that, so "does not append twice" survives without the wrong gate.
+   */
+  it('writes the startup file even when the INSTALLING shell already has binDir on PATH', () => {
     const r = runPostinstall({ global: 'true', shell: '/usr/bin/zsh', binDirOnPath: true });
     expect(r.status).toBe(0);
     expect(r.wrote).toBe(true);                        // launcher still written
-    expect(existsSync(join(r.home, '.zshenv'))).toBe(false);
+    // The whole point: a transiently-correct PATH must not suppress the file that
+    // makes it permanent.
+    const zshenv = join(r.home, '.zshenv');
+    expect(existsSync(zshenv), 'binDir on the installer PATH must not suppress the startup file').toBe(true);
+    expect(readFileSync(zshenv, 'utf-8')).toContain(join(r.home, '.botmux', 'bin'));
+    // And the user is told, so they know to open a new terminal.
+    expect(r.stdout).toContain('open a new terminal');
+  });
+
+  it('does not append twice when the startup file already carries the entry', () => {
+    // The idempotence the old PATH gate was reaching for, asserted on the signal
+    // that actually governs it. Two installs in the SAME home: the second must
+    // report `skipped` and leave exactly one marker line.
+    const first = runPostinstall({ global: 'true', shell: '/usr/bin/zsh' });
+    expect(first.status).toBe(0);
+    const zshenv = join(first.home, '.zshenv');
+    expect(existsSync(zshenv)).toBe(true);
+    const markers = (text: string) => text.split('\n').filter(l => l.includes('# added by botmux installer')).length;
+    expect(markers(readFileSync(zshenv, 'utf-8'))).toBe(1);
+
+    // Re-run against the very same HOME (reuseHome), as an upgrade would.
+    const second = runPostinstall({ global: 'true', shell: '/usr/bin/zsh', reuseHome: first.home });
+    expect(second.status).toBe(0);
+    expect(markers(readFileSync(zshenv, 'utf-8')), 'a re-install must not append a second PATH line').toBe(1);
+    expect(second.stdout).toContain('already puts');
+  });
+
+  it('SOURCE PIN: the PATH step is not gated on the installing process\'s own PATH', () => {
+    // Behavioural coverage above needs the fixture to stage binDir on PATH; this
+    // pins the absence of the wrong predicate directly, so a re-add is caught even
+    // if someone reshapes the fixture. `process.env.PATH` may legitimately appear
+    // elsewhere in the file (it is passed through to the probe spawn), so match the
+    // specific gate shape that caused the bug: a membership test of binDir in it.
+    const src = readFileSync(POSTINSTALL, 'utf-8');
+    const code = src.split('\n').filter(l => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+    expect(code).not.toMatch(/process\.env\.PATH[^\n]*\.includes\(\s*binDir\s*\)/);
+    expect(code).not.toMatch(/if\s*\(\s*!\s*\(?\s*process\.env\.PATH/);
   });
 
   it('the written launcher actually runs and preserves argument boundaries', () => {


### PR DESCRIPTION
## 问题

用户报 3.18.8 更新后 `botmux: command not found`。让他重开登录 shell 后（截图里是 `exec zsh -l`）**依然找不到**。

`exec zsh -l` 会读 `.zshenv`，所以「重开 shell 没生效」只有一种解释：**那一行从来没被写进去过**。

## 根因：守卫问错了问题

`scripts/postinstall-bin.mjs` 末尾的 PATH 步骤原本包在这道闸里：

```js
if (!(process.env.PATH ?? '').split(':').includes(binDir)) { …写启动文件… }
```

它问的是「binDir 在不在**执行安装的这个进程**的 PATH 上」。但真正决定 `botmux` 能不能用的是「**用户以后开的终端**会不会有它」——那是**启动文件**的属性，不是当前进程 env 的属性。

两者会分开，而**botmux 自己就在制造这种分开**：daemon 会把 `~/.botmux/bin` 前置到每个 CLI 会话的 PATH（`worker.ts` / `worker-pool.ts` 共 5 处 `prependBotmuxBin`）。

于是在 botmux 会话里（或任何临时 export 过该目录的 shell）跑 `npm i -g botmux` → postinstall 命中这道闸 → **零文件、零提示、exit 0**。而 3.18.6 起已经没有 `bin` 字段（#1047 随 Node 降级路径一起删掉），`~/.botmux/bin/botmux` 是**唯一**的 botmux 命令 ⟹ 下一个终端里它根本不存在。

本机就是活证据：`~/.botmux/bin` 在当前会话 PATH 里出现 3 次，而 `.zshenv`/`.zshrc`/`.profile` **没有一个**带 botmux 的 PATH 行。

A/B 复现（真实脚本 + 隔离 HOME，只改 PATH 一个变量）：

| | 安装时 PATH | 结果 |
|---|---|---|
| A 普通 shell | 不含 binDir | ✅ 写入 `~/.zshenv` + 打印 "open a new terminal" |
| B botmux 会话内 | 含 binDir | ❌ **零文件、零输出、exit 0** ← 用户报的现象 |

## 改动

去掉这道外层闸。`ensurePathEntry` 本来就**逐文件**问对了问题（`fileAlreadyHasEntry`，且能识别用户手写的 PATH 行）并把这类文件报成 `skipped` —— 所以那道闸不仅**问错**，而且**冗余**。

`scripts/install-path-entry.mjs` **一行未改**：它的判据本来就是对的。

## ⚠️ 顺带改掉一条把 bug 钉成预期行为的测试

原用例 `touches no startup file when binDir is already on PATH` 断言的正是这个 bug。它的出发点（「老机器升级不该反复往 rc 文件里追加」）**是对的**，但挂在了错误的信号上。

所以幂等性改由「启动文件里有没有」来保证，并新增一条**同 HOME 连装两次**的用例专门钉它（marker 计数保持 1、第二次报 `already puts`）。另加一条 source pin 防止那道闸被重新加回来。

## 验证

**反变异 4/4 全红**：

| # | 变异 | 结果 |
|---|---|---|
| 1 | 复原那道 PATH 闸（= 修复前状态） | 🔴 behavioral + source pin **两条同时红** |
| 2 | 让 `fileAlreadyHasEntry` 恒 false | 🔴 只打红新增的幂等用例 ⟹ **老闸的真实关切仍被守住** |
| 3 | 删掉 "open a new terminal" 提示 | 🔴 |
| 4 | 只把文件记进 `written` 而不真写（静默空操作） | 🔴 打红 3 条 |

第 2 条是关键：它证明我不是「拆掉一道闸就完事」，而是把它保护的性质迁到了正确的信号上。每次变异先 `cmp` 确认真写进文件，验完立即还原并 `cmp` 校验字节一致。

**测试**：`bun run build` 通过。`bun run test` 与**同一棵树**的基线做双向差集：

- **PR-only 为空**（零新增失败）
- 反向 7 个（基线红、本改动绿）

两个方向都有失败 ⟹ 本机负载 flake，**绝对失败数不可作基线**，只有差集有意义。

## 影响面

- 只影响 `npm i -g botmux` 的 postinstall；不改 launcher 内容、不改二进制选择逻辑、不碰 `install.sh`（standalone 安装器有自己的 PATH 处理）。
- 跨平台：zsh / bash / fish / 未知 shell 的目标文件选择逻辑未动；bash 双写（`.bashrc` + 登录文件）与 `ZDOTDIR` / `XDG_CONFIG_HOME` 处理均保持原样。
- 不涉及任何 CLI 适配器、后端或会话类型。

## 关系与遗留

- 与 **#1115**（npm 不再发布跑不起来的 Node 形态）是**两个独立缺陷**，故分开提：一个是打包形态、一个是 PATH 守卫问错问题。两者都源于 #1047「删掉 `bin`」之后「`~/.botmux/bin/botmux` 成为唯一入口」这个新前提没有被完全贯彻。
- ⏳ 合并后需**发版**才能到用户手上。已经装坏的机器：重装一次即可（这次会正确写入启动文件），或手动把 `~/.botmux/bin` 加进 PATH。
