### PR TITLE
fix(update): 自更新跨 Node→二进制形态后重启驱动必死，CLI 子命令派生收口形态感知

### DIFF
--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -313,16 +313,24 @@ export function globalInstallUpdateLockTarget(): string {
  * that silently never happened while reporting success. So in standalone mode the
  * entry argument is dropped entirely and the binary is invoked as
  * `<binary> restart`.
+ *
+ * ⚠️ THE LAUNCHER SHIM IS THE SAME CASE. `selfDispatching` is not a synonym for
+ * "compiled": `~/.botmux/bin/botmux` forwards `"$@"` to whatever form is installed,
+ * so it too takes the subcommand as its FIRST argument. Handing it a cli.js path
+ * reproduces the identical argv shift — help banner, exit 0, no restart — which is
+ * why the Node branch of {@link resolveStandaloneRestartExecutable} must pair its
+ * launcher target with `selfDispatching: true`.
  */
 export function buildRestartLauncher(
   node: string,
   cliEntry: string,
   hasSetsid: boolean,
-  standalone = false,
+  selfDispatching = false,
 ): { cmd: string; args: string[] } {
-  // A compiled binary dispatches its own subcommands; passing a cli.js path
-  // would shift `restart` to argv[3] where nothing reads it.
-  const entryArgs = standalone ? ['restart'] : [cliEntry, 'restart'];
+  // Anything that dispatches its own subcommands (a compiled binary, or the
+  // launcher shim that forwards "$@") must NOT be handed a cli.js path: it would
+  // shift `restart` to argv[3] where nothing reads it.
+  const entryArgs = selfDispatching ? ['restart'] : [cliEntry, 'restart'];
   if (hasSetsid) return { cmd: 'setsid', args: [node, ...entryArgs] };
   return { cmd: node, args: entryArgs };
 }
@@ -396,6 +404,25 @@ function setsidAvailable(): boolean {
  * to `execPath` when it is missing (nothing else to go on) — that is the
  * pre-existing behaviour.
  *
+ * ⚠️⚠️ AND `execPath` IS NOT RIGHT FOR A **NODE** PROCESS EITHER, WHEN THE UPDATE
+ * IT JUST INSTALLED CHANGED THE RUNTIME FORM. This branch used to be an
+ * unconditional `if (!standalone) return execPath`, i.e. `node <root>/dist/cli.js
+ * restart`. Since 3.18.0 the npm package ships the CLI as a platform-subpackage
+ * BINARY: `bin` is gone, `node-pty` left `dependencies`, and postinstall points the
+ * launcher at the binary — but `dist/` is still published and still statically
+ * imports `node-pty` (MEASURED on the published 3.18.8 tarball: 4 import chains
+ * from `dist/cli.js`, 5 from `dist/worker.js`). So after a Node-form daemon
+ * auto-updates itself across that boundary, the very next thing it does is spawn
+ * `node <root>/dist/cli.js restart` — and npm has just PRUNED node-pty from that
+ * tree (MEASURED, 3.17.0 → 3.18.6: "removed 2 packages"). The driver dies on
+ * `ERR_MODULE_NOT_FOUND` and the fleet never comes back, having reported
+ * "restarting to apply".
+ *
+ * The launcher is the right target in exactly the same way and for the same
+ * reason as the npm-binary case: it is the one path the installer re-points to
+ * whatever form is now correct. Prefer it whenever it exists, and keep `execPath`
+ * as the fallback so a host without a launcher behaves as before.
+ *
  * Pure over its inputs so every branch is testable without a compiled binary.
  */
 export function resolveStandaloneRestartExecutable(
@@ -404,12 +431,48 @@ export function resolveStandaloneRestartExecutable(
   shape: BinaryInstallShape,
   launcherPath: string,
   launcherExists: boolean,
+  /** A local-dev checkout runs its own tree and must keep using `execPath`: the
+   *  launcher may point at an entirely different checkout, and `cmdUpgradeLocalDev`
+   *  deliberately restarts the tree it just built. */
+  localDev = false,
 ): string {
-  if (!standalone) return execPath;
+  if (!standalone) {
+    // Node form: the launcher tracks the installed form across an update that
+    // replaced Node-with-dist by a compiled binary. Not for a dev checkout.
+    if (!localDev && launcherExists) return launcherPath;
+    return execPath;
+  }
   // We own this exact path and just replaced its contents — re-exec it.
   if (shape === 'curl-binary') return execPath;
   if (shape === 'npm-binary' && launcherExists) return launcherPath;
   return execPath;
+}
+
+/**
+ * The complete restart target: WHICH executable, and whether that executable
+ * dispatches its own subcommands (so it must NOT be handed a `cli.js` path).
+ *
+ * These two decisions are returned together on purpose. They are one invariant —
+ * "the launcher shim and the compiled binary both take the subcommand as their
+ * first argument" — and computing them at separate call sites is precisely how
+ * they drift: picking the launcher as the target while still passing the Node
+ * shape re-creates the argv shift that makes a restart print the help banner and
+ * exit 0. Pure over its inputs, so the PAIRING is unit-testable rather than only
+ * each half.
+ */
+export function resolveRestartInvocation(
+  standalone: boolean,
+  execPath: string,
+  shape: BinaryInstallShape,
+  launcherPath: string,
+  launcherExists: boolean,
+  localDev = false,
+): { executable: string; selfDispatching: boolean } {
+  const executable = resolveStandaloneRestartExecutable(
+    standalone, execPath, shape, launcherPath, launcherExists, localDev,
+  );
+  // The compiled binary IS the CLI; the launcher shim `exec`s it with "$@".
+  return { executable, selfDispatching: standalone || executable === launcherPath };
 }
 
 /**
@@ -443,15 +506,18 @@ export function spawnDetachedRestart(
   const cliEntry = activePackageRoot ? botmuxCliEntryAt(activePackageRoot) : botmuxCliEntry();
   // A package-manager-owned binary's own path can be versioned (pnpm store); after
   // the update the stable launcher points at the new one while execPath does not.
+  // The Node form needs it too, for the 3.18 Node→binary transition (see below).
   const launcher = globalWrapperPath();
-  const executable = resolveStandaloneRestartExecutable(
+  // Target and calling convention resolved TOGETHER — see resolveRestartInvocation.
+  const { executable, selfDispatching } = resolveRestartInvocation(
     standalone,
     process.execPath,
     standalone ? currentBinaryInstallShape() : 'unknown',
     launcher,
     existsSync(launcher),
+    isLocalDevInstall(),
   );
-  const { cmd, args } = buildRestartLauncher(executable, cliEntry, setsidAvailable(), standalone);
+  const { cmd, args } = buildRestartLauncher(executable, cliEntry, setsidAvailable(), selfDispatching);
   const child = spawn(cmd, args, {
     detached: true,
     stdio: fd !== undefined ? ['ignore', fd, fd] : 'ignore',

--- a/src/core/self-spawn.ts
+++ b/src/core/self-spawn.ts
@@ -137,6 +137,37 @@ export function resolveEntrySpawn(entry: BotmuxEntry, distDir: string): { comman
   return { command: process.execPath, args: [join(distDir, ENTRY_SCRIPT[entry])] };
 }
 
+/**
+ * Resolve the command + args to run one of OUR OWN ordinary CLI subcommands
+ * (`start-bot`, `restart`, …) as a child process.
+ *
+ * This is the `resolveEntrySpawn` rule applied to the public CLI rather than to a
+ * hidden entry token, and it exists because getting it wrong FAILS SILENTLY.
+ * Under Node the shape is `node <dist/cli.js> <sub…>`; a single-file executable IS
+ * the CLI, so passing a script path shifts the subcommand one slot right, where
+ * nothing reads it. MEASURED on the real v3.18.8 binary — the compiled form of
+ * `spawn(execPath, [botmuxCliEntry(), 'start-bot', appId, '--json'])` is
+ *
+ *     <binary> /dist/cli.js start-bot <appId> --json
+ *
+ * (`botmuxCliEntry()` yields `/dist/cli.js` because `packageRoot()` walks up from
+ * `/$bunfs/` to `/`), and the binary PRINTS THE HELP BANNER AND EXITS 0. A caller
+ * that reads `code === 0` as success — `dashboard/managed-spawn.ts` does — reports
+ * the operation as having worked while nothing happened at all.
+ *
+ * `scriptPath` is supplied by the caller (each has its own resolution order) and is
+ * unused in the compiled branch, exactly as in {@link runnerArgv0}.
+ */
+export function resolveCliSpawn(
+  scriptPath: string,
+  subcommand: readonly string[],
+): { command: string; args: string[] } {
+  if (isStandaloneBinary()) {
+    return { command: process.execPath, args: [...subcommand] };
+  }
+  return { command: process.execPath, args: [scriptPath, ...subcommand] };
+}
+
 /** The set of hidden subcommand tokens, so the CLI dispatcher can recognize them. */
 export const ENTRY_SUBCOMMANDS: ReadonlySet<string> = new Set(Object.values(ENTRY_SUBCOMMAND));
 

--- a/src/dashboard/managed-spawn.ts
+++ b/src/dashboard/managed-spawn.ts
@@ -17,6 +17,7 @@
 // ports and starts probes), so nothing inside it is reachable from a unit test.
 import { spawn } from 'node:child_process';
 import { botmuxCliEntry } from '../utils/install-info.js';
+import { resolveCliSpawn } from '../core/self-spawn.js';
 import { globalInstallUpdateCwd } from '../core/maintenance.js';
 import { redactChildEnv } from '../utils/child-env.js';
 import type { GlobalInstallPlan } from '../utils/global-install.js';
@@ -39,7 +40,8 @@ function spawnBotLifecycleCli(
     let settled = false;
     const done = (r: BotLifecycleSpawnResult) => { if (!settled) { settled = true; resolve(r); } };
     try {
-      const child = spawn(process.execPath, [botmuxCliEntry(), verb, appId, '--json'], {
+      const { command, args } = resolveCliSpawn(botmuxCliEntry(), [verb, appId, '--json']);
+      const child = spawn(command, args, {
         stdio: ['ignore', 'pipe', 'pipe'],
         // NOT process.env: this child re-enters the botmux CLI, which invokes
         // pm2 — pm2 bakes the caller env into the managed app and into

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -37,7 +37,7 @@ import {
   resolveUpdateStrategy,
 } from '../src/core/binary-install-shape.js';
 import { isMuslHost, releaseAssetName, releaseAssetBaseUrl, replaceStandaloneBinary } from '../src/core/binary-self-update.js';
-import { buildRestartLauncher, resolveStandaloneRestartExecutable } from '../src/core/maintenance.js';
+import { buildRestartLauncher, resolveStandaloneRestartExecutable, resolveRestartInvocation } from '../src/core/maintenance.js';
 import { tryResolveGlobalInstallPlan, formatGlobalInstallCommand, resolveAutoUpdateSupport } from '../src/utils/global-install.js';
 import { withFileLock, FileLockTimeoutError } from '../src/utils/file-lock.js';
 import { botmuxVersionAt, diskVersionAt } from '../src/utils/install-info.js';
@@ -262,6 +262,23 @@ describe('buildRestartLauncher — the compiled binary dispatches its own subcom
       .toEqual({ cmd: '/usr/bin/node', args: ['/opt/botmux/dist/cli.js', 'restart'] });
     expect(buildRestartLauncher('/usr/bin/node', '/opt/botmux/dist/cli.js', true, false))
       .toEqual({ cmd: 'setsid', args: ['/usr/bin/node', '/opt/botmux/dist/cli.js', 'restart'] });
+  });
+
+  it('THE LAUNCHER SHIM IS SELF-DISPATCHING TOO — `$@` makes the subcommand argv[1]', () => {
+    // `~/.botmux/bin/botmux` is `exec "<installed form>" "$@"`, so it forwards its
+    // FIRST argument as the subcommand exactly like the compiled binary does.
+    // Handing it a cli.js path reproduces the identical shift: help banner, exit 0,
+    // no restart. This is the case the Node branch of
+    // resolveStandaloneRestartExecutable now produces, so it must be covered even
+    // though `standalone` is false there.
+    //
+    // The PAIRING of target+convention is asserted against resolveRestartInvocation
+    // below; this case pins the rendering half.
+    const LAUNCHER = '/root/.botmux/bin/botmux';
+    expect(buildRestartLauncher(LAUNCHER, '/opt/botmux/dist/cli.js', false, true))
+      .toEqual({ cmd: LAUNCHER, args: ['restart'] });
+    expect(buildRestartLauncher(LAUNCHER, '/opt/botmux/dist/cli.js', true, true))
+      .toEqual({ cmd: 'setsid', args: [LAUNCHER, 'restart'] });
   });
 
   it('THE BUG: standalone must not be handed a cli.js path — it lands in argv[2]', () => {
@@ -585,8 +602,70 @@ describe('resolveStandaloneRestartExecutable — restart the NEW binary, not the
       .toBe('/opt/bm/botmux');
   });
 
-  it('NODE PATH UNCHANGED: never redirected away from execPath', () => {
-    expect(resolveStandaloneRestartExecutable(false, '/usr/bin/node', 'unknown', LAUNCHER, true)).toBe('/usr/bin/node');
+  it('NODE PATH: prefers the launcher, which tracks the installed form across an update', () => {
+    // Since 3.18.0 the npm package ships the CLI as a platform-subpackage BINARY:
+    // `bin` is gone, node-pty left `dependencies`, and postinstall points the
+    // launcher at the binary — but `dist/` is still published and still statically
+    // imports node-pty. So a Node-form daemon that auto-updates ACROSS that
+    // boundary can no longer run `node <root>/dist/cli.js`: npm pruned node-pty
+    // from that tree. Restarting via the launcher is what survives the transition.
+    expect(resolveStandaloneRestartExecutable(false, '/usr/bin/node', 'unknown', LAUNCHER, true)).toBe(LAUNCHER);
+  });
+
+  it('NODE PATH: falls back to execPath when there is no launcher (pre-existing behaviour)', () => {
+    expect(resolveStandaloneRestartExecutable(false, '/usr/bin/node', 'unknown', LAUNCHER, false))
+      .toBe('/usr/bin/node');
+  });
+
+  it('NODE PATH: a local-dev checkout keeps execPath even when a launcher exists', () => {
+    // The launcher may point at an entirely different checkout (`use:here` claims
+    // it globally), while a dev restart must re-run the tree it just built.
+    expect(resolveStandaloneRestartExecutable(false, '/usr/bin/node', 'unknown', LAUNCHER, true, true))
+      .toBe('/usr/bin/node');
+  });
+});
+
+describe('resolveRestartInvocation — target and calling convention must agree', () => {
+  const LAUNCHER = '/root/.botmux/bin/botmux';
+  const NODE = '/usr/bin/node';
+  const PNPM_OLD = '/root/.local/share/pnpm/global/5/.pnpm/botmux-linux-x64@3.18.4/node_modules/botmux-linux-x64/botmux';
+
+  // THE INVARIANT, stated once: whenever the chosen target is the launcher shim,
+  // the invocation must be self-dispatching — the shim forwards "$@", so a cli.js
+  // path would land where the subcommand belongs (help banner, exit 0, no
+  // restart). Deriving these two halves separately is exactly how they drift, so
+  // this asserts the PAIR, which a test of either half alone cannot do.
+  //
+  // MUTATION CHECK: computing `selfDispatching` as bare `standalone` (i.e.
+  // dropping `|| executable === launcherPath`) turns the two Node-form launcher
+  // cases below red.
+  it('every case that targets the launcher is marked self-dispatching', () => {
+    const cases = [
+      // Node form crossing the 3.18 Node→binary boundary.
+      resolveRestartInvocation(false, NODE, 'unknown', LAUNCHER, true),
+      // Compiled binary owned by a package manager (versioned execPath).
+      resolveRestartInvocation(true, PNPM_OLD, 'npm-binary', LAUNCHER, true),
+    ];
+    for (const r of cases) {
+      expect(r.executable).toBe(LAUNCHER);
+      expect(r.selfDispatching).toBe(true);
+    }
+  });
+
+  it('a Node target keeps the Node calling convention (cli.js path required)', () => {
+    // No launcher on this host → execPath, which genuinely NEEDS the script path.
+    expect(resolveRestartInvocation(false, NODE, 'unknown', LAUNCHER, false))
+      .toEqual({ executable: NODE, selfDispatching: false });
+    // Local-dev checkout: execPath even though a launcher exists.
+    expect(resolveRestartInvocation(false, NODE, 'unknown', LAUNCHER, true, true))
+      .toEqual({ executable: NODE, selfDispatching: false });
+  });
+
+  it('a self-replaced binary targets itself and still self-dispatches', () => {
+    // curl-binary at a custom dir: not the launcher path, but still the compiled
+    // CLI — so `standalone` alone must keep it self-dispatching.
+    expect(resolveRestartInvocation(true, '/opt/bm/botmux', 'curl-binary', LAUNCHER, true))
+      .toEqual({ executable: '/opt/bm/botmux', selfDispatching: true });
   });
 });
 

--- a/test/cli-subcommand-spawn-form.test.ts
+++ b/test/cli-subcommand-spawn-form.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `resolveCliSpawn` — spawning OUR OWN ordinary CLI subcommands must work in both
+ * runtime forms.
+ *
+ * WHY THIS NEEDED ITS OWN HELPER (and its own test): the repo already routes the
+ * hidden entry tokens (`__worker`, `__daemon`, …) through `resolveEntrySpawn` and
+ * the adapter runners through `runnerArgv0`, both form-aware. But a third shape —
+ * "re-enter the public CLI as a child" — was still hand-rolled as
+ * `spawn(process.execPath, [botmuxCliEntry(), …])`, which is the Node form
+ * hardcoded.
+ *
+ * The compiled binary turns that into `<binary> /dist/cli.js start-bot <appId>
+ * --json` (`botmuxCliEntry()` resolves to `/dist/cli.js` because `packageRoot()`
+ * walks from `/$bunfs/` up to `/`). MEASURED on the real published v3.18.8
+ * binary: that argv PRINTS THE HELP BANNER AND EXITS 0, while the correct shape
+ * `<binary> start-bot <appId> --json` exits 1 with a real JSON result. The caller
+ * in `dashboard/managed-spawn.ts` treats `code === 0` as success, so the failure
+ * mode is a dashboard that reports "bot 已上线" having done nothing whatsoever.
+ *
+ * TEETH: `isStandaloneBinary()` runs for real (it keys off `process.argv[1]`
+ * starting with `/$bunfs/`), so these exercise the genuine branch rather than a
+ * `standalone` parameter threaded in by the test.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveCliSpawn } from '../src/core/self-spawn.js';
+
+const REAL_ARGV1 = process.argv[1];
+
+/** Make `isStandaloneBinary()` report true the way a compiled binary does. */
+function asCompiledBinary() {
+  process.argv[1] = '/$bunfs/root/cli.js';
+}
+
+afterEach(() => { process.argv[1] = REAL_ARGV1; });
+
+describe('resolveCliSpawn', () => {
+  it('Node form keeps the script path — it genuinely needs it', () => {
+    const { command, args } = resolveCliSpawn('/opt/botmux/dist/cli.js', ['start-bot', 'cli_x', '--json']);
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['/opt/botmux/dist/cli.js', 'start-bot', 'cli_x', '--json']);
+  });
+
+  it('THE BUG: compiled form must put the subcommand FIRST, not a cli.js path', () => {
+    // MUTATION CHECK: dropping the standalone branch (always prefixing
+    // scriptPath) makes both assertions below red.
+    asCompiledBinary();
+    const { command, args } = resolveCliSpawn('/dist/cli.js', ['start-bot', 'cli_x', '--json']);
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['start-bot', 'cli_x', '--json']);
+    // The specific poison: a path where argv[1] should be. On the real binary this
+    // is what produced "help banner + exit 0".
+    expect(args[0]).not.toContain('cli.js');
+  });
+
+  it('never leaks a /$bunfs/ path to the child (it does not exist outside us)', () => {
+    asCompiledBinary();
+    const { command, args } = resolveCliSpawn('/$bunfs/root/cli.js', ['stop-bot', 'cli_x']);
+    for (const s of [command, ...args]) expect(s).not.toContain('$bunfs');
+  });
+
+  it('passes the subcommand through verbatim, including flags and empty lists', () => {
+    expect(resolveCliSpawn('/x/cli.js', []).args).toEqual(['/x/cli.js']);
+    asCompiledBinary();
+    expect(resolveCliSpawn('/x/cli.js', []).args).toEqual([]);
+  });
+});

--- a/test/dashboard-managed-spawn.test.ts
+++ b/test/dashboard-managed-spawn.test.ts
@@ -89,6 +89,54 @@ describe('dashboard host children run on a redacted env', () => {
     expectNoSecrets(spawnedEnv());
   });
 
+  /**
+   * WIRING, not policy. `resolveCliSpawn` is unit-tested on its own
+   * (test/cli-subcommand-spawn-form.test.ts), but a correct helper that this
+   * module does not actually call is worth nothing — and that is exactly the
+   * shape the bug had: the helper's job was done inline, hardcoded to the Node
+   * form. Note the cases above assert `args.slice(1)`, which cannot see the
+   * difference: dropping or keeping a leading cli.js path leaves the tail
+   * identical. These assert args[0].
+   *
+   * MEASURED on the real published v3.18.8 binary — the broken argv
+   * `<binary> /dist/cli.js start-bot <appId> --json` prints the help banner and
+   * exits 0, while the correct one exits 1 with a JSON result. `code === 0` is
+   * how this module decides success, so the dashboard reported "已上线" for a
+   * bot it never started.
+   */
+  it('WIRING: the Node form passes a cli.js path as argv[0]', async () => {
+    const { spawnStartBotLive } = await import('../src/dashboard/managed-spawn.js');
+    await spawnStartBotLive('cli_target');
+
+    const [command, args] = childProcess.spawn.mock.calls[0] as [string, string[], unknown];
+    expect(command).toBe(process.execPath);
+    expect(args[0]).toMatch(/cli\.js$/);
+    expect(args.slice(1)).toEqual(['start-bot', 'cli_target', '--json']);
+  });
+
+  it('WIRING: the compiled form must NOT — the subcommand has to be argv[0]', async () => {
+    // isStandaloneBinary() keys off process.argv[1] (src/core/self-spawn.ts), so
+    // this drives the genuine branch rather than a flag threaded in by the test.
+    //
+    // MUTATION CHECK: reverting this module to the inline
+    // `spawn(process.execPath, [botmuxCliEntry(), verb, …])` turns this red.
+    const realArgv1 = process.argv[1];
+    process.argv[1] = '/$bunfs/root/cli.js';
+    try {
+      const { spawnStartBotLive } = await import('../src/dashboard/managed-spawn.js');
+      await spawnStartBotLive('cli_target');
+
+      const [command, args] = childProcess.spawn.mock.calls[0] as [string, string[], unknown];
+      expect(command).toBe(process.execPath);
+      expect(args).toEqual(['start-bot', 'cli_target', '--json']);
+      // The specific poison: a path where the subcommand belongs.
+      expect(args[0]).not.toContain('cli.js');
+      for (const s of args) expect(s).not.toContain('$bunfs');
+    } finally {
+      process.argv[1] = realArgv1;
+    }
+  });
+
   it('the global install (and every npm lifecycle script it runs) sees no secrets', async () => {
     const { runGlobalInstall } = await import('../src/dashboard/managed-spawn.js');
     await runGlobalInstall({


### PR DESCRIPTION
## 问题

用户报「最近自动更新后都不能用了」，报错是：

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'node-pty'
  imported from <pkg>/dist/adapters/backend/tmux-backend.js
```

**这不是缺依赖，补装 `node-pty` 是错的方向。** 3.18.0（#1047）起 npm 包换了运行形态：删 `bin`、`node-pty` 移出 `dependencies`、postinstall 把 `~/.botmux/bin/botmux` 改写成指向平台子包二进制。但 **`dist/` 仍随包发布，且仍然静态 import `node-pty`**（实测已发布的 3.18.8 tarball：`dist/cli.js` 4 条静态 import 链、`dist/worker.js` 5 条、`dist/daemon.js` 4 条，全部通向 `node-pty`）。

于是**任何「以 Node 形态派生自己」的调用点，在升级后都变成必死路径**。

## 三个缺陷（全部在隔离 HOME+prefix 的 lab 里用真实发布包复现，非推理）

### 1. 🔴 定时自更新会把自己更新成一个再也起不来的形态

`spawnDetachedRestart` 的 Node 分支是无条件 `node <activePackageRoot>/dist/cli.js restart`。而 npm 升级**刚刚把 node-pty 从那棵树里剪掉**（实测 3.17.0 → 3.18.6：`removed 2 packages`，node-pty ABSENT）。真实 3.18.8 安装树上跑这条 argv：

```
exit=1  Cannot find package 'node-pty'
```

日志停在 `auto-update: 3.18.6 → 3.18.8, restarting to apply` 之后，**fleet 再也起不来，且没有任何东西报错**。standalone 分支早已改走 launcher（#1078 的 `resolveStandaloneRestartExecutable`），Node 分支被漏掉了。

### 2. 🔴 只改 target 不改调用约定会更糟——静默成功

`~/.botmux/bin/botmux` 是 `exec "<installed form>" "$@"`，它**和编译版二进制一样自派发**：首参就是子命令。所以把 cli.js 路径传给它会复现同一个 argv 位移。三方 A/B（真实 3.18.8 安装树）：

| 形态 | exit | 结果 |
|---|---|---|
| 修复前 `node <root>/dist/cli.js restart` | 1 | `Cannot find package 'node-pty'` |
| **只改 target** `<launcher> <cli.js> restart` | **0** | **打 help banner，重启从未发生** |
| 修复后 `<launcher> restart` | 0 | 真正执行 |

中间那行是最坏的：**exit 0 = 谎报成功**。所以 target 与调用约定必须一起决定，收敛到 `resolveRestartInvocation`——分开算正是两者漂移的成因。

### 3. 🔴 dashboard `start-bot/stop-bot` 在编译态谎报「已上线」

`managed-spawn.ts` 写死 `spawn(execPath, [botmuxCliEntry(), verb, …])`。编译态下 `botmuxCliEntry()` 是 `/dist/cli.js`（`packageRoot()` 从 `/$bunfs/` 走到 `/`），实测真二进制：

```
<binary> /dist/cli.js start-bot <appId> --json   → 打 help banner，exit 0
<binary> start-bot <appId> --json                → exit 1 + 真实 JSON 结果
```

而该模块**按 `code === 0` 判成功** ⟹ dashboard 报「bot 已上线」，实际什么都没做。新增 `resolveCliSpawn` 收口，与既有 `resolveEntrySpawn` / `runnerArgv0` 同构。

## 影响面

- **跨形态**：Node 部署（无 launcher 时逐字不变）、curl 二进制（`curl-binary` 分支逐字不变）、npm 二进制（原有行为不变）、本地 dev checkout（新增 `localDev` 逃生，避免抢用可能指向别的 checkout 的 launcher）
- **跨入口**：`spawnDetachedRestart` 的 3 个调用点（maintenance tick、dashboard 两处）共用同一路径，一处修复覆盖全部
- **未动**：`cli.ts:3239` 的 `cmdUpgradeLocalDev` 保持原样——它被 `isLocalDevInstall()` 门住（编译态恒 false），且**刻意**要重启它刚 build 的那棵树

### ⚠️ 补充：全仓枚举后发现另外 4 处同类形态分歧（本 PR 未修，已开 #1120 跟踪）

上面「一处修复覆盖全部」只对**重入自己 CLI**这一类成立。全仓枚举后另有 **4 处**把**脚本路径/Node 参数**交给 `execPath`，在编译态同样失效（二进制把首参当子命令 ⟹ 打 help + exit 0）：

⚠️ 第 4 处是复审同侪发现的，**我第一版 grep 漏了**：我搜的是 `spawn(process.execPath` 这个形状，而它是 **shell 字符串拼接**。改用不依赖调用形状的判据（「`process.execPath` 与某个 cli 入口在同一文件共现」）可以捞到它，我用该判据复查了全部 13 个共现文件，其余（`sandbox.ts`、`autostart.ts`、`hook-command.ts`、`dashboard/autostart-api.ts`、`daemon.ts` 等）**均已形态感知**，确认没有第 5 处。

| 位置 | 形态 | 编译态实测后果 |
|---|---|---|
| `cli/supervisor-shutdown-client.ts:68` | `execPath -e '<inline script>'` | 打 help、**stdout 非 JSON** ⟹ `JSON.parse` 抛 `invalid supervisor shutdown response transport` |
| `adapters/backend/zellij-backend.ts:524` | `execPath <probe.js> <sock> <pids>` | 打 help ⟹ `Number(stdout)` = `NaN` ⟹ 不在 candidates 里 ⟹ `break` → `null`。🔴**比我起初判断的更严重**：`findServerPid` 返 null ⟹ `zellij-adopt-discovery.ts:219` `continue`（不被 /adopt 发现）、`:282` 返 `false`；而 restore 消费方 `session-manager.ts:2159` 把 `false` 判成 `'missing'` ⟹ **`closeSession`**。即升级到编译态后，已有 zellij adopt 会话会被**静默关闭**——不是「少功能」，是丢会话。仅 Linux + 编译态 + zellij |
| `cli/pm2-readonly.ts:40,62` | `execPath <helper.js>` / `--import tsx <helper.ts>` | help 文本当 jlist ⟹ `pm2_jlist_json_not_found`（fail-closed），仅 legacy plugin pm2 god 存活时可达 |
| **`services/local-cli-opener.ts:286`** | `shellQuote(execPath) shellQuote(CLI_ENTRYPOINT) __zmx-attach-managed …`（**shell 字符串，非 spawn**） | 🔴**不 fail-closed，与本 PR 修的同形状**：实测 `<binary> /$bunfs/root/cli.js __zmx-attach-managed …` → help + **exit 0**，而函数返回 `{ok:true}` ⟹ attach 静默没发生却报成功。且该串交给 shell，`sh` 把未转义的 `$bunfs` 展开成空 ⟹ 实际是 `//root/cli.js`（实测）。可达性：编译态 + zmx + `dashboard.enableLocalCliOpen=true`（opt-in） |

**为什么不在本 PR 修**：四处分属 supervisor / zellij / plugin-pm2 / local-cli-opener 四个互不相干子系统，且修法各不相同（`-e` 那处要的是「编译态换一条 IPC 路径」，不是改 argv），混进来会让这个以「静默成功」为主线的 PR 失焦。**建议另开 issue 统一收口**（`-e` 那处需要的是「编译态换一条 IPC 路径」而不是改 argv，不是同一个修法）。

已开 **#1120** 跟踪这 4 处（含各自的可达性、fail-closed 分级与建议修法），另附一条与形态无关的潜伏 flake（`connector-store` 同毫秒时间戳）。

如实说明两处更正：
1. PR 初稿写「3 个调用点已 grep 全部确认」，那句的**范围只是「`spawnDetachedRestart` 的调用点」**，不足以支撑「全仓无第 4 处」。
2. 补做全仓枚举时我搜的是 `spawn(process.execPath` 这个**调用形状**，因而**漏了 `local-cli-opener`**（它是 shell 字符串拼接）——由复审同侪指出，我已实测复现确认。有效判据必须**不依赖调用形状**，见 #1120 末尾记录的共现搜索。
- **core-only 不受影响**：`startMaintenance()` 被 `idx === 0 && !coreOnly` 门住

## 验证

**端到端（真实发布的 3.18.8，隔离 HOME + prefix，未碰生产 `~/.botmux`）**：上表三方 A/B；另复现了用户的原始故障——3.17.0 + 旧 wrapper → `npm i -g botmux@3.18.8 --ignore-scripts` → 打出与用户截图**逐字相同**的那句报错。

**反变异 5 处全红**（每次变异后先 `cmp` 确认真改到文件，跑完立即还原并再 `cmp` 校验）：

| 变异 | 结果 |
|---|---|
| 去掉 `resolveCliSpawn` 的 standalone 分支 | 3 failed |
| Node 分支退回无条件 `execPath` | 1 failed |
| `selfDispatching` 算成裸 `standalone` | 1 failed |
| 去掉 `localDev` 逃生 | 2 failed |
| `managed-spawn` 退回硬编码 Node 形态 | 1 failed |

⚠️ 后两条第一版**没抓到**，如实记录：第 3 条的判定在调用点，纯函数用例够不到 ⟹ 抽出 `resolveRestartInvocation` 让「target + 调用约定」这一对本身可测；第 5 条现有用例断言的是 `args.slice(1)`，**丢不丢首个 cli.js 路径它看不出来** ⟹ 新增两条断言 `args[0]` 的 wiring 用例。两条补完后才转红。

**测试**：`tsc --noEmit` exit 0；受影响 6 个测试文件 PRE 95 passed → POST 107 passed（+12 新增，零回归）。

⚠️ **全量 unit 的失败数不可直接采信**：本机 load average 123–249，同一 commit 两次跑分别是 `285 failed` 与 `20 failed`（同 SHA 大幅回落 ⟹ 负载 flake，真回归应当确定性复现）。归因改用同一批文件的 PRE/POST 差分：7 个残留失败文件在基线与本分支上**逐字相同**（均 `16 failed | 47 passed | 69 skipped`）⟹ 全部先于本 PR 存在，本 PR 新增红 0。

## CI 结果与归因（`bun-test` 是已知红腿，`continue-on-error` ⟹ run 顶层会显示绿）

`build`（含 tsc + vitest）、`bun-binary`、`bun-binary-musl`、CodeQL、3×Analyze **全 pass**。

`bun-test` 红，但**红是 master 既有的**。按 per-job 取数 + 失败文件集**双向差集**归因（不看绝对数、不看 run 顶层结论）：

| | master run `33368429448`（SHA `62514fed8`，顶层 success 但该 job 为 FAILURE） | 本 PR run `33369777373` |
|---|---|---|
| 汇总 | `962/998 files green, 36 failing` | `962/999 files green, 37 failing` |

- **master 有、PR 没有**：空
- **PR 有、master 没有**：仅 `test/connector-store.test.ts` 一个

该文件**与本 PR 零交集**，且不 import 本 PR 改的任何模块（只 import `services/connector-store.js`）。CI 日志给出确定性根因，是**同毫秒时间戳竞态**，不是我引入的回归：

```
50 | const second = upsertConnector({ ...first, name: 'Renamed' }, dir);
52 | expect(second.updatedAt).not.toBe(first.updatedAt);
error: Expected: not "2026-08-31T07:47:22.077Z"
```

两次 `upsertConnector` 之间无延时，而 `updatedAt` 取自毫秒精度的 `new Date().toISOString()`（`connector-store.ts:160`）——runner 够快时两次落在同一毫秒，断言必挂。本机 bun 跑该文件 3 pass / 0 fail。**这是一个潜伏 flake，建议另开 issue 修**（改成注入时钟或断言 `>=`），不属于本 PR。

文件总数 998→999 即本 PR 新增的 `test/cli-subcommand-spawn-form.test.ts`。另：我改的 3 个测试文件与 master 的 36 个红文件**交集为空**；其中 `dashboard-managed-spawn.test.ts` 用 `vi.hoisted`，经真实选择器 `isDeferredFromBunLeg` 判定为 **deferred**（不在 bun 腿运行，故不会进红名单）；另两个非 deferred 文件本机 bun 下 **53 pass / 0 fail**。

## 未在本 PR 处理（结构性，需另开）

**npm 包里发的 `dist/` 是不可运行的残骸**，用户吃到的是裸 `ERR_MODULE_NOT_FOUND`。我原打算在 `cli.js` 加一句人能读懂的 fail-fast，**实测证明这条路走不通**：ESM 静态 import 先于模块体求值，preflight 永远来不及打印（最小复现验证过）。真正的选项是「从 `files` 去掉 `dist/`」或「构建期把裸 import 改成惰性 require」，两者都需要先评估对 desktop runtime 的影响，不适合塞进本 PR。

另：`botmux update` 对 npm 用户曾恒报 `unknown`，修复在 **#1112**，已合入 master（`a5ff26f42`），与本 PR 正交。（本行原写「#1112（OPEN 未合）」，那是撰写时的状态，已过时。）






