### PR TITLE
fix(install): bun 全局安装的 postinstall 读不到 npm_config_global，launcher 从不写入

### DIFF
--- a/scripts/postinstall-bin.mjs
+++ b/scripts/postinstall-bin.mjs
@@ -16,18 +16,49 @@
  *
  * ── THE GUARD (do not loosen this) ──────────────────────────────────────────────
  * We only write the launcher for a REAL global install. Empirically measured what
- * npm/pnpm expose to postinstall (not assumed — probed all three cases):
+ * each package manager exposes to postinstall (not assumed — probed every case):
  *
  *   `npm i -g botmux`                    → npm_config_global === "true"
  *   installed as someone's local dep     → npm_config_global ABSENT
  *   `pnpm install` INSIDE the botmux repo → npm_config_global ABSENT
+ *   `bun add -g botmux`                  → npm_config_global ABSENT (see below)
  *
  * The third case is the dangerous one: a repo-local `pnpm install` DOES run the
  * root package's postinstall. So a `!== "false"` style check would fire during
  * ordinary development and rewrite ~/.botmux/bin/botmux — hijacking the global
  * launcher of whatever fleet shares that HOME (on the dev box that is ~50 live
- * daemons). Hence the guard is a STRICT `=== "true"`, and there is a second,
+ * daemons). Hence the env check stays a STRICT `=== "true"`, and there is a second,
  * independent bail-out when we can see we are inside the source checkout.
+ *
+ * ⚠️ THE FOURTH CASE IS WHY THE ENV CHECK ALONE IS NOT ENOUGH. Bun does pass a few
+ * npm_* vars to lifecycle scripts — MEASURED with a probe package whose postinstall
+ * dumped its own env, the complete set is:
+ *
+ *   BUN_INSTALL, BUN_WHICH_IGNORE_CWD, npm_config_user_agent, npm_execpath,
+ *   npm_node_execpath
+ *
+ * — but `npm_config_global` is NOT among them, and that is the one this guard read.
+ * So for a perfectly real `bun add -g botmux` the check failed and this script
+ * exited 0 without writing anything. MEASURED end to end: `.bun/bin/` empty, no
+ * launcher, the platform binary sitting in the download cache, i.e. the user had NO
+ * `botmux` command at all. Worse, the obvious workaround did NOT help: `bun pm -g
+ * trust botmux` made bun report `1 script ran` while this script still wrote
+ * nothing, because the env check had already failed.
+ *
+ * ⚠️ TWO SEPARATE LAYERS — do not conflate them. (a) bun BLOCKS the script by
+ * default (`Blocked N postinstalls`); `bun pm trust` lifts that. (b) even once it
+ * runs, this guard killed it. Fixing (b) is what makes `bun pm trust` an actually
+ * working workaround. pnpm 10/11 is a different layer again: `onlyBuiltDependencies`
+ * means the script does not run at all, so this fix alone does not rescue pnpm —
+ * that needs approve-builds/onlyBuiltDependencies or a different mechanism.
+ *
+ * So the global check is: the env says global (npm/yarn), OR THE INSTALL LOCATION
+ * ITSELF says global. The location test reuses `detectGlobalInstallManager` —
+ * the repo's own classifier for these layouts, already unit-tested, and shipped in
+ * `dist/` (see package.json `files`) so the published package can import it. Do NOT
+ * hand-roll a second path matcher here: that is how the two answers drift apart.
+ * A source checkout classifies as `unknown` (verified), so this cannot reopen the
+ * repo-local hijack that guard 2 also covers.
  *
  * ── FAIL HARD WHEN THERE IS NO BINARY ──────────────────────────────────────────
  * This used to warn and exit 0, because `bin: {botmux: "dist/cli.js"}` gave every
@@ -48,7 +79,7 @@ import { dirname, join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 /** Abort the install with a reason. There is no Node fallback any more (see header). */
 function fail(reason, hint) {
@@ -102,10 +133,34 @@ function isMuslLinux() {
   return false;
 }
 
-// ── Guard 1: only a real `npm i -g` (strict equality; see header) ───────────────
-if (process.env.npm_config_global !== 'true') {
+// ── Guard 1: only a real global install ─────────────────────────────────────────
+// Two independent positive signals (see header). The env check is unchanged and
+// still strict; the location check is what makes `bun add -g` / `pnpm add -g` work,
+// since those provide no npm_config_* at all.
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = dirname(here); // scripts/ -> package root
+
+/**
+ * Does the install LOCATION say this is a package-manager-owned global tree?
+ * Reuses the repo's own classifier rather than a second hand-rolled path matcher.
+ * Returns false on any failure (missing dist/, an older layout, a load error) so a
+ * problem here can only make us MORE conservative, never less.
+ */
+async function locationSaysGlobal(root) {
+  try {
+    const { detectGlobalInstallManager } = await import(
+      pathToFileURL(join(root, 'dist', 'utils', 'global-install.js')).href
+    );
+    // A source checkout classifies as `unknown`, so this cannot fire in the repo.
+    return detectGlobalInstallManager(root) !== 'unknown';
+  } catch {
+    return false;
+  }
+}
+
+if (process.env.npm_config_global !== 'true' && !(await locationSaysGlobal(pkgRoot))) {
   // Silent: this is the overwhelmingly common case (dev installs, transitive
-  // installs). Noise here would appear on every `pnpm install` in the repo.
+  // installs). Noise here would appear on every `bun install` in the repo.
   process.exit(0);
 }
 
@@ -113,8 +168,6 @@ if (process.env.npm_config_global !== 'true') {
 // Defence in depth for guard 1. If the package directory we are running from is a
 // git checkout of botmux (has .git and src/), this is a developer environment, not
 // an installed package — the launcher must not be repointed.
-const here = dirname(fileURLToPath(import.meta.url));
-const pkgRoot = dirname(here); // scripts/ -> package root
 if (existsSync(join(pkgRoot, '.git')) && existsSync(join(pkgRoot, 'src'))) {
   process.exit(0);
 }

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, afterEach } from 'vitest';
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 /**
  * Pins the npm single-version binary distribution (PR #873).
@@ -172,13 +172,38 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     brokenBinary?: boolean;
     /** Existing shared launcher that a rejected update must preserve byte-for-byte. */
     existingLauncher?: string;
+    /**
+     * Place the fake package at this path RELATIVE to the tmp base, instead of
+     * `pkg/`. Used to reproduce a package-manager global layout (bun/pnpm), which
+     * is the only signal available when no `npm_config_*` is set at all.
+     */
+    pkgRelPath?: string;
+    /** Ship dist/utils/global-install.js, which guard 1's location check imports. */
+    withDistPredicate?: boolean;
   }) {
     const base = tmp();
     const home = join(base, 'home');
-    const pkg = join(base, 'pkg');
+    const pkg = join(base, opts.pkgRelPath ?? 'pkg');
     mkdirSync(home, { recursive: true });
     mkdirSync(join(pkg, 'scripts'), { recursive: true });
     writeFileSync(join(pkg, 'scripts', 'postinstall-bin.mjs'), readFileSync(POSTINSTALL));
+    // Guard 1's location check imports the repo's own layout classifier from
+    // `dist/` (it ships via package.json `files`). That module has a small import
+    // graph, so the fixture must carry ALL of it — a partial copy fails CLOSED and
+    // would make this test pass for the wrong reason. Verified against a real
+    // `bun add -g botmux` tree: all four files are present in the published package.
+    if (opts.withDistPredicate) {
+      for (const rel of [
+        join('utils', 'global-install.js'),
+        join('core', 'binary-install-shape.js'),
+        join('core', 'self-spawn.js'),
+        join('utils', 'install-info.js'),
+      ]) {
+        const dest = join(pkg, 'dist', rel);
+        mkdirSync(dirname(dest), { recursive: true });
+        writeFileSync(dest, readFileSync(join(__dirname, '..', 'dist', rel)));
+      }
+    }
     // postinstall imports this sibling to write the PATH entry. It ships via
     // package.json `files`, so the fixture must carry it too — otherwise this
     // exercises a package layout we never publish. (`opts.withoutPathHelper`
@@ -302,6 +327,51 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
 
   it('npm_config_global="false" → writes nothing', () => {
     const r = runPostinstall({ global: 'false' });
+    expect(r.status).toBe(0);
+    expect(r.wrote).toBe(false);
+  });
+
+  it('THE bun/pnpm BUG: a global LAYOUT with no npm_config_* still writes the launcher', () => {
+    // REGRESSION for a shipped defect: bun (and pnpm) pass NO `npm_config_*` to
+    // lifecycle scripts, so `npm_config_global` is absent for a perfectly real
+    // `bun add -g botmux`. The env-only guard exited 0 silently and wrote nothing —
+    // MEASURED end to end on a real `bun add -g botmux@3.18.8`: `.bun/bin/` empty,
+    // no launcher, the platform binary only in the download cache, so the user had
+    // NO `botmux` command at all. And `bun pm -g trust botmux` did NOT rescue it:
+    // bun reported `1 script ran` while this script still wrote nothing.
+    //
+    // Note `global` is deliberately NOT set — that is the whole point.
+    const r = runPostinstall({
+      pkgRelPath: join('home', '.bun', 'install', 'global', 'node_modules', 'botmux'),
+      withDistPredicate: true,
+    });
+    expect(r.status).toBe(0);
+    expect(r.wrote, r.stderr).toBe(true);
+    expect(readFileSync(r.launcher, 'utf-8')).toBe(`#!/bin/sh\nexec "${realpathSync(r.binary)}" "$@"\n`);
+  });
+
+  it('SAFETY: a LOCAL dependency install is not mistaken for a global one', () => {
+    // The counterweight to the case above. `node_modules/botmux` in someone's
+    // project must never repoint the shared launcher — that is the hijack the
+    // strict env guard existed to prevent, and the location check must not reopen
+    // it. The classifier requires a RECOGNISED GLOBAL layout, not merely a
+    // `/node_modules/botmux` suffix.
+    const r = runPostinstall({
+      pkgRelPath: join('proj', 'node_modules', 'botmux'),
+      withDistPredicate: true,
+    });
+    expect(r.status).toBe(0);
+    expect(r.wrote).toBe(false);
+  });
+
+  it('the location check is fail-CLOSED when dist/ is missing', () => {
+    // If the predicate cannot be loaded we must fall back to "not global", never to
+    // "assume global": a load failure has to make us MORE conservative. Same global
+    // layout as the bun case, minus the shipped classifier.
+    const r = runPostinstall({
+      pkgRelPath: join('home', '.bun', 'install', 'global', 'node_modules', 'botmux'),
+      withDistPredicate: false,
+    });
     expect(r.status).toBe(0);
     expect(r.wrote).toBe(false);
   });
@@ -465,5 +535,22 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     const src = readFileSync(POSTINSTALL, 'utf-8');
     expect(src).toContain("process.env.npm_config_global !== 'true'");
     expect(src).not.toContain("!== 'false'");
+  });
+
+  it('SOURCE PIN: the location check reuses the repo classifier, not a hand-rolled matcher', () => {
+    // The env check alone cannot see a `bun add -g` (no npm_config_* at all), so the
+    // guard also consults the install LOCATION. Pin that it goes through
+    // `detectGlobalInstallManager` — the repo's own already-tested classifier — and
+    // is compared against 'unknown'. A second hand-rolled path matcher here is how
+    // the two answers drift apart, which is the bug class this whole area keeps
+    // hitting. Comments are stripped so the docblock cannot satisfy the assertion.
+    const code = readFileSync(POSTINSTALL, 'utf-8')
+      .split('\n')
+      .filter(l => !/^\s*(\*|\/\/|\/\*)/.test(l))
+      .join('\n');
+    expect(code).toContain('detectGlobalInstallManager');
+    expect(code).toContain("!== 'unknown'");
+    // …and that it is actually consulted by guard 1, not merely defined.
+    expect(code).toMatch(/npm_config_global !== 'true'[\s\S]{0,80}locationSaysGlobal/);
   });
 });


### PR DESCRIPTION
## 问题

`bun add -g botmux` 装完后，**用户根本没有 `botmux` 命令**。真机复现（bun 1.4.0，真下载 86s，隔离 HOME）：

```
$ bun add -g botmux@3.18.8
265 packages installed [86.43s]
Blocked 2 postinstalls. Run `bun pm -g untrusted` for details.

$ ls ~/.bun/bin/           # 空
$ cat ~/.botmux/bin/botmux # 不存在
# 平台二进制只躺在下载缓存里
```

这比「更新识别失效」（#1112）严重得多：那个是装好了但更新不了，这个是**装了等于没装**。

## 这是两个独立故障，本 PR 修第二个

**① bun 默认 block 依赖的生命周期脚本**（`Blocked 2 postinstalls`）。属包管理器策略，`bun pm trust` 可解，本 PR 不动。

**② 即使脚本跑起来也没用** ← 本 PR 修这个。Guard 1 是 `npm_config_global !== 'true'` 就静默 `exit 0`，而 bun 传给生命周期脚本的 env 里**没有 `npm_config_global`**。

用探针包（postinstall 自己 dump env）实测，bun 给的完整集合是：
```
BUN_INSTALL  BUN_WHICH_IGNORE_CWD  npm_config_user_agent  npm_execpath  npm_node_execpath
```
有几个 `npm_*`，但**恰恰缺 Guard 1 读的那一个**。

⟹ 所以 `bun pm -g trust botmux` 会报 `1 script ran` 而 **launcher 依然没写** —— 看起来最自然的那个 workaround **是无效的**。只修 ① 用户仍然拿不到命令，这也是本 PR 必须存在的理由。

⚠️ **分层提醒**：pnpm 10/11 与 bun **不在同一层**。pnpm 的 `onlyBuiltDependencies` 让脚本**根本不跑**，本 PR 救不了它（需 approve-builds / `onlyBuiltDependencies` 或换机制）；bun 是「trust 能跑但 Guard 1 杀掉」，修好后 `bun pm trust` 才成为真正可用的 workaround。标题因此只写 bun。

## 改法

Guard 1 变成「**env 说是全局（npm/yarn）** 或 **安装位置本身说是全局**」。

位置判定**复用仓库自己的 `detectGlobalInstallManager`**（已被单测覆盖，且 `dist/` 随包发布，见 `package.json` 的 `files`），**不新写第二套路径匹配** —— 那正是这块反复出问题的根因（#1112 就是两套规则漂移的产物）。载入失败一律返回 `false`（**fail-closed**），只会更保守不会更宽松。

## ⚠️ Guard 1 原有职责必须保住

它防的是 **repo 内 `install` 改写共享 `~/.botmux/bin/botmux`**（本机 ~50 个 daemon 共用这一个文件；我在排查 #1112 时**亲手踩过这个坑**）。实测：

| 场景 | 分类结果 | 是否写 launcher |
|---|---|---|
| 源码 checkout（有 `.git`+`src/`） | `unknown` | ❌ 不写 |
| 普通本地依赖 `proj/node_modules/botmux` | `unknown` | ❌ 不写 |
| 非全局目录且**无** `.git`/`src`（Guard 2 盲区） | `unknown` | ❌ 不写（Guard 1 单独挡住） |
| npm 全局（`npm_config_global=true`） | — | ✅ 写（逐字未变） |
| bun 全局布局（无 env 信号） | `bun` | ✅ 写（**本 PR 修复点**） |

## 验证

**同一条命令的 A/B，真实 bun 全局安装**：

| | `bun pm -g trust botmux` 的结果 |
|---|---|
| 修前 | `1 script ran` → **launcher 未写**（静默无用） |
| 修后 | `1 script ran` → launcher 写入，`botmux --version` = **3.18.8** |

- npm 路径逐字未变（`npm_config_global=true` 仍单独成立，实测仍写 launcher）
- 每次验证都用隔离 HOME；核过共享 `~/.botmux/bin/botmux` **全程未被触碰**
- **反变异 3/3 全红**：① 去掉位置判定（即线上缺陷）→ 2 红 ② 放宽成「任何 `node_modules/botmux` 都算全局」（= 本地依赖劫持共享 launcher）→ 2 红 ③ 载入失败改 fail-open → 3 红
- 新增 3 条用例（bun 全局布局无 env / 本地依赖不误判 / 缺 `dist` 时 fail-closed）+ 1 条源码守卫（钉住「复用 classifier 而非手写匹配」）
- ⚠️ 测试夹具必须带**全部 4 个** `dist` 文件（`global-install` 有 3 个传递依赖）：只拷 1 个会 fail-closed，让用例**因为错误的原因通过**。这一点写进注释了，并核过真实发布包里 4 个都在
- `bun run build`、`tsc --noEmit` 通过；该测试文件 **29/29**

## 遗留（不在本 PR）

- pnpm 10/11 的脚本不执行问题（上面「分层」那条）
- 复审期间偶发一次 `cannot run on this host`（170MB 二进制在高负载下 30s probe 偏紧），重跑即过。fail-closed 本身对，但错误信息可以区分「probe 超时」与「二进制真不兼容」