### PR TITLE
fix(install): 位置判定内联进 postinstall，修掉「import 发布包里不存在的 dist/」

### DIFF
--- a/scripts/postinstall-bin.mjs
+++ b/scripts/postinstall-bin.mjs
@@ -53,12 +53,11 @@
  * that needs approve-builds/onlyBuiltDependencies or a different mechanism.
  *
  * So the global check is: the env says global (npm/yarn), OR THE INSTALL LOCATION
- * ITSELF says global. The location test reuses `detectGlobalInstallManager` —
- * the repo's own classifier for these layouts, already unit-tested, and shipped in
- * `dist/` (see package.json `files`) so the published package can import it. Do NOT
- * hand-roll a second path matcher here: that is how the two answers drift apart.
- * A source checkout classifies as `unknown` (verified), so this cannot reopen the
- * repo-local hijack that guard 2 also covers.
+ * ITSELF says global. The layout list is INLINED in `locationSaysGlobal` below —
+ * see the ⚠️ notes there for why importing the repo's classifier from `dist/` was
+ * dead code in the published package, and why the inlined version is deliberately
+ * stricter on Windows. A source checkout matches no global layout (verified), so
+ * this cannot reopen the repo-local hijack that guard 2 also covers.
  *
  * ── FAIL HARD WHEN THERE IS NO BINARY ──────────────────────────────────────────
  * This used to warn and exit 0, because `bin: {botmux: "dist/cli.js"}` gave every
@@ -79,7 +78,7 @@ import { dirname, join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 
 /** Abort the install with a reason. There is no Node fallback any more (see header). */
 function fail(reason, hint) {
@@ -142,23 +141,53 @@ const pkgRoot = dirname(here); // scripts/ -> package root
 
 /**
  * Does the install LOCATION say this is a package-manager-owned global tree?
- * Reuses the repo's own classifier rather than a second hand-rolled path matcher.
- * Returns false on any failure (missing dist/, an older layout, a load error) so a
- * problem here can only make us MORE conservative, never less.
+ *
+ * ⚠️ WHY THIS IS INLINED INSTEAD OF IMPORTING THE REPO'S CLASSIFIER. The first
+ * version did `await import('./dist/utils/global-install.js')` to reuse
+ * `detectGlobalInstallManager`. That was DEAD CODE in the published package: #1115
+ * removed `dist/` from `package.json` `files`, so the import always ENOENTs, the
+ * catch returned false, and the guard silently fell back to env-only — leaving
+ * `bun add -g botmux` exactly as broken as before. MEASURED, not reasoned:
+ *
+ *   git archive origin/master | tar x && npm pack
+ *   tar tzf botmux-*.tgz | grep -c '^package/dist/'    → 0
+ *
+ * and end to end, a real `bun add -g <that tarball>` then running this script the
+ * way bun does: exit 0, no launcher. This file is a standalone script with no build
+ * step, and neither `dist/` nor `src/` is published, so being SELF-CONTAINED is its
+ * natural form — inlining is not a compromise here.
+ *
+ * ⚠️ AND IT IS DELIBERATELY STRICTER THAN `detectGlobalInstallManager`. That
+ * function ends with `platform === 'win32' ? 'npm' : 'unknown'`, so on Windows it
+ * cannot tell a global install from a LOCAL dependency — MEASURED:
+ *
+ *   detectGlobalInstallManager('C:/projects/myapp/node_modules/botmux', 'win32') → 'npm'
+ *
+ * Harmless where it is used today (a wrong `npm i -g` merely reinstalls), but in
+ * THIS file it would mean a Windows local dependency repoints the shared
+ * `~/.botmux/bin/botmux` — the exact hijack guard 1 exists to prevent. So the list
+ * below recognises only KNOWN GLOBAL layouts and has no platform fallback. Windows
+ * npm globals are unaffected: they arrive with `npm_config_global=true` and never
+ * reach this check.
+ *
+ * The layout patterns mirror `detectGlobalInstallManager`'s; a source guard in
+ * test/npm-binary-distribution.test.ts pins the two in agreement over a matrix of
+ * real global paths, so the duplication cannot drift unnoticed.
  */
-async function locationSaysGlobal(root) {
-  try {
-    const { detectGlobalInstallManager } = await import(
-      pathToFileURL(join(root, 'dist', 'utils', 'global-install.js')).href
-    );
-    // A source checkout classifies as `unknown`, so this cannot fire in the repo.
-    return detectGlobalInstallManager(root) !== 'unknown';
-  } catch {
-    return false;
-  }
+function locationSaysGlobal(root) {
+  const r = root.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  // Every global layout below ends at the main package; anything else is not ours.
+  if (!r.endsWith('/node_modules/botmux')) return false;
+  return r.endsWith('/lib/node_modules/botmux')                    // npm, POSIX
+    || r.includes('/.bun/install/global/node_modules/botmux')      // bun
+    || r.includes('/bun/install/global/node_modules/botmux')       // bun, custom BUN_INSTALL
+    || r.includes('/.pnpm/')                                       // pnpm virtual store
+    || /\/pnpm\/global\/[^/]+\/node_modules\/botmux$/.test(r)      // pnpm 9 global
+    || /\/pnpm\/global\/v\d+\/[^/]+\/node_modules\/botmux$/.test(r) // pnpm 11 global
+    || /\/pnpm\/store\/v\d+\/links\/@\/botmux\//.test(r);          // pnpm 11 store links
 }
 
-if (process.env.npm_config_global !== 'true' && !(await locationSaysGlobal(pkgRoot))) {
+if (process.env.npm_config_global !== 'true' && !locationSaysGlobal(pkgRoot)) {
   // Silent: this is the overwhelmingly common case (dev installs, transitive
   // installs). Noise here would appear on every `bun install` in the repo.
   process.exit(0);

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, 
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
+import { detectGlobalInstallManager } from '../src/utils/global-install.js';
 
 /**
  * Pins the npm single-version binary distribution (PR #873).
@@ -487,16 +488,21 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     expect(r.wrote).toBe(false);
   });
 
-  it('the location check is fail-CLOSED when dist/ is missing', () => {
-    // If the predicate cannot be loaded we must fall back to "not global", never to
-    // "assume global": a load failure has to make us MORE conservative. Same global
-    // layout as the bun case, minus the shipped classifier.
+  it('THE PUBLISHED SHAPE: works with NO dist/ present, because that is what npm ships', () => {
+    // This case previously asserted the opposite ("fail-closed when dist/ is
+    // missing"), which encoded the very defect: the check imported
+    // `dist/utils/global-install.js`, #1115 removed `dist/` from package.json
+    // `files`, so in the real published package the import ENOENTed and the guard
+    // fell back to env-only — `bun add -g botmux` stayed broken while the suite was
+    // green. The layout list is inlined now, so the published shape (no dist/ at
+    // all) MUST work. Verified end to end against a real `npm pack` tarball
+    // installed with `bun add -g`.
     const r = runPostinstall({
       pkgRelPath: join('home', '.bun', 'install', 'global', 'node_modules', 'botmux'),
-      withDistPredicate: false,
+      withDistPredicate: false, // ← exactly what the registry serves
     });
     expect(r.status).toBe(0);
-    expect(r.wrote).toBe(false);
+    expect(r.wrote, r.stderr).toBe(true);
   });
 
   it('inside a source checkout (.git + src/) → writes nothing even when global', () => {
@@ -666,20 +672,89 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     expect(src).not.toContain("!== 'false'");
   });
 
-  it('SOURCE PIN: the location check reuses the repo classifier, not a hand-rolled matcher', () => {
-    // The env check alone cannot see a `bun add -g` (no npm_config_* at all), so the
-    // guard also consults the install LOCATION. Pin that it goes through
-    // `detectGlobalInstallManager` — the repo's own already-tested classifier — and
-    // is compared against 'unknown'. A second hand-rolled path matcher here is how
-    // the two answers drift apart, which is the bug class this whole area keeps
-    // hitting. Comments are stripped so the docblock cannot satisfy the assertion.
+  it('SOURCE PIN: the location check is SELF-CONTAINED (no dist/ import — it is not published)', () => {
+    // The first version of this guard imported `dist/utils/global-install.js` to
+    // reuse the repo classifier. That was DEAD CODE in the published package: #1115
+    // removed `dist/` from package.json `files`, so the import always ENOENTed, the
+    // catch returned false, and the guard fell back to env-only — leaving
+    // `bun add -g` exactly as broken as before. Pin that this file never again
+    // depends on anything outside its own published set.
     const code = readFileSync(POSTINSTALL, 'utf-8')
       .split('\n')
       .filter(l => !/^\s*(\*|\/\/|\/\*)/.test(l))
       .join('\n');
-    expect(code).toContain('detectGlobalInstallManager');
-    expect(code).toContain("!== 'unknown'");
-    // …and that it is actually consulted by guard 1, not merely defined.
-    expect(code).toMatch(/npm_config_global !== 'true'[\s\S]{0,80}locationSaysGlobal/);
+    // `./install-path-entry.mjs` is the ONLY sibling it may import — that one ships.
+    const imports = [...code.matchAll(/import\s*\(?\s*['"]([^'"]+)['"]/g)].map(m => m[1]);
+    for (const spec of imports) {
+      if (spec.startsWith('node:')) continue;
+      expect(spec, `postinstall must not import ${spec} — check package.json files`)
+        .toBe('./install-path-entry.mjs');
+    }
+    expect(code).not.toContain('dist/');
+    // …and the guard actually consults the location check, not merely defines it.
+    expect(code).toMatch(/npm_config_global !== 'true'[\s\S]{0,60}locationSaysGlobal/);
+  });
+
+  it('PARITY: the inlined layout list agrees with detectGlobalInstallManager on real global paths', () => {
+    // The inlined copy is a SECOND implementation of the same rules, which is how
+    // two answers drift apart. Rather than trusting a comment, execute both over a
+    // matrix of layouts that actually occur and require the same verdict.
+    //
+    // Extract the inlined predicate from the shipped script and run it for real, so
+    // this cannot pass by merely finding similar-looking source text.
+    const src = readFileSync(POSTINSTALL, 'utf-8');
+    const fn = src.match(/function locationSaysGlobal\(root\) \{[\s\S]*?\n\}/)?.[0];
+    expect(fn, 'locationSaysGlobal not found in postinstall').toBeTruthy();
+    // eslint-disable-next-line no-new-func
+    const inlined = new Function(`${fn}; return locationSaysGlobal;`)() as (r: string) => boolean;
+
+    const GLOBAL_LAYOUTS = [
+      '/usr/lib/node_modules/botmux',
+      '/usr/local/lib/node_modules/botmux',
+      '/root/.bun/install/global/node_modules/botmux',
+      '/root/.local/share/pnpm/global/5/.pnpm/botmux@3.18.9/node_modules/botmux',
+      '/root/.local/share/pnpm/global/5/node_modules/botmux',
+      '/root/.local/share/pnpm/global/v11/abc/node_modules/botmux',
+      '/root/.local/share/pnpm/store/v11/links/@/botmux/3.18.9/x/node_modules/botmux',
+    ];
+    for (const p of GLOBAL_LAYOUTS) {
+      expect(inlined(p), `inlined said NOT global: ${p}`).toBe(true);
+      expect(detectGlobalInstallManager(p, 'linux'), `classifier said unknown: ${p}`)
+        .not.toBe('unknown');
+    }
+
+    const NON_GLOBAL = [
+      '/app/node_modules/botmux',                  // a local dependency
+      '/root/iserver/botmux',                      // a source checkout
+      '/app/node_modules/other/node_modules/botmux',
+      '/home/u/.botmux/bin',                       // the launcher dir, not a package
+    ];
+    for (const p of NON_GLOBAL) {
+      expect(inlined(p), `inlined claimed global: ${p}`).toBe(false);
+      expect(detectGlobalInstallManager(p, 'linux'), `classifier claimed known: ${p}`)
+        .toBe('unknown');
+    }
+  });
+
+  it('STRICTER THAN THE CLASSIFIER: a Windows LOCAL dependency must not count as global', () => {
+    // `detectGlobalInstallManager` ends with `platform === 'win32' ? 'npm' : 'unknown'`,
+    // so on Windows it cannot distinguish a global install from a local dependency —
+    // MEASURED: detectGlobalInstallManager('C:/projects/myapp/node_modules/botmux',
+    // 'win32') === 'npm'. That is harmless where it is used today (a wrong
+    // `npm i -g` just reinstalls), but in postinstall it would let a Windows LOCAL
+    // dependency repoint the shared ~/.botmux/bin/botmux — the exact hijack guard 1
+    // exists to prevent. So the inlined version has NO platform fallback.
+    const src = readFileSync(POSTINSTALL, 'utf-8');
+    const fn = src.match(/function locationSaysGlobal\(root\) \{[\s\S]*?\n\}/)?.[0]!;
+    // eslint-disable-next-line no-new-func
+    const inlined = new Function(`${fn}; return locationSaysGlobal;`)() as (r: string) => boolean;
+
+    const winLocal = 'C:/projects/myapp/node_modules/botmux';
+    // The divergence is deliberate: document it by asserting BOTH sides.
+    expect(detectGlobalInstallManager(winLocal, 'win32')).toBe('npm'); // the hazard
+    expect(inlined(winLocal)).toBe(false);                             // we refuse it
+    expect(inlined('C:\\projects\\myapp\\node_modules\\botmux')).toBe(false); // backslashes too
+    // A real Windows npm global is unaffected: it arrives with npm_config_global=true
+    // and never reaches this check, which the behavioural test above covers.
   });
 });


### PR DESCRIPTION
## 问题：#1119 在发布形态下等于没生效

#1119 给 Guard 1 加了「安装位置是否是全局布局」这条判定，实现是
`await import('./dist/utils/global-install.js')` 复用仓库自己的分类器。

**但 #1115 已经把 `dist/` 从 `package.json` 的 `files` 里移除了**（不再发布 Node 形态）⟹ 发布包里那个 import 必然 ENOENT ⟹ `catch` 返回 false ⟹ Guard 1 退回成只看 env ⟹ **`bun add -g botmux` 与修之前一样没有 `botmux` 命令**。

fail-closed 那一层是对的（不崩、不误写），但**修复本身是死代码**。

**判据是真打包，不是读代码**：
```
$ git archive origin/master | tar x && npm pack
$ tar tzf botmux-*.tgz | grep -c '^package/dist/'
0
```
已发布的 **3.18.9 实测同样只有 6 个文件**（LICENSE / package.json / 2×README / 2×scripts），零 `dist`。端到端也验了：真 `bun add -g <该 tarball>` → 按 bun 的方式跑 postinstall → `EXIT=0`、无 launcher。

诊断收窄到唯一原因：把那个安装路径喂给分类器返回 **`bun`** ⟹ **判定逻辑本身是对的**，唯一阻塞就是模块在运行现场不存在。

## 改法：内联，不是妥协

把布局判定内联进 `postinstall-bin.mjs`。它是**无构建步骤的独立脚本**，`dist/` 与 `src/` 都不发布 ⟹ **自包含是它的天然形态**。

对比「把 4 个 dist 文件加回 `files`」：技术上可行，但与 #1115「不发布 Node 形态」的意图冲突，不该在这个修复里动别人 PR 的意图。

## ⚠️ 内联版**故意比 `detectGlobalInstallManager` 更严格**（复审抓到，我复现确认）

那个函数结尾是 `platform === 'win32' ? 'npm' : 'unknown'`，所以在 Windows 上**分不清全局安装和本地依赖**。实测：

```js
detectGlobalInstallManager('C:/projects/myapp/node_modules/botmux', 'win32')  // → 'npm'
detectGlobalInstallManager('C:/Users/u/AppData/Roaming/npm/node_modules/botmux', 'win32') // → 'npm'
```

在 update 路径无害（顶多多重装一次），但**在 postinstall 里就是 Windows 本地依赖改写共享 `~/.botmux/bin/botmux`** —— 正是 Guard 1 存在的理由。所以内联版**只认已知全局布局、无平台兜底**。Windows npm 全局带 `npm_config_global=true`，不经过这条检查，不受影响。

> 顺带：这个 Windows 误判在**已合的 #1119 里就存在**（它直接调分类器），只是因为 `dist/` 加载不到而**当前不可达** —— 一旦 `dist/` 恢复发布就会变成活的。这也是选内联而非「加回 files」的又一个理由。

## 验证

**端到端，发布形态，零手工 `cp`**：
```
git archive HEAD | tar x && npm pack        →  tarball 内 dist 条目 = 0
bun add -g <tarball>                        →  Blocked（bun 策略，预期）
node scripts/postinstall-bin.mjs（无 npm_config_*）
  → [botmux] launcher → …/botmux-linux-x64/botmux
  → [botmux] added …/.botmux/bin to PATH in …/.zshenv
  → launcher 可执行，输出正确
```
（中途一次 `no prebuilt binary package` 是我本地 tarball 版本为 `0.0.0`、没有平台子包所致 —— **Guard 1 已经放行、脚本走到了二进制查找并大声失败**，补上平台子包即写入 launcher。）

- 全程隔离 HOME；核过共享 `~/.botmux/bin/botmux` **未被触碰**
- **反变异 3/3 全红**：① 加回 win32 兜底（= Windows 劫持）→ 1 红 ② 去掉 bun 布局（= 原缺陷）→ 3 红 ③ 改回 import `dist/`（= 本次的死代码缺陷）→ 3 红
- `bun run build`、`tsc --noEmit` 通过；该测试文件 **35/35**

## 测试改动

- 🔴 **把原「缺 dist 时 fail-closed」那条反转成「发布形态（无 dist）必须能工作」** —— 原来那条**恰恰把缺陷写成了期望**，正是它让套件在真实用户坏掉时保持绿色
- **PARITY 矩阵**：从发布脚本里**抽出内联函数真跑**（不是比源码文本），与 `detectGlobalInstallManager` 在 **7 种真实全局布局 + 4 种非全局路径**上逐条比对结论 ⟹ 两套实现漂移有测试兜底
- **Windows 分歧用例**：**同时断言两侧**（分类器给 `'npm'`、内联版给 `false`），把这处刻意的不一致钉成文档而不是注释里的口头承诺
- **源码守卫**：postinstall 除 `node:*` 与 `./install-path-entry.mjs` 外**不得 import 任何东西**，且源码不得出现 `dist/` ⟹ 防止再次依赖发布包里没有的文件

## 遗留（不在本 PR）

- 🟠 `detectGlobalInstallManager` 的 win32 兜底对本地依赖误判，建议在 update 路径也收窄（pre-existing，不急）
- 🟠 pnpm 10/11 的脚本根本不跑（`onlyBuiltDependencies`），需 `pnpm approve-builds -g botmux` 两步走，文档待补