### PR TITLE
feat(cot): 思考气泡被重启中断时标注收尾，不再无声停住

### DIFF
--- a/src/core/shutdown-budgets.ts
+++ b/src/core/shutdown-budgets.ts
@@ -22,6 +22,20 @@ export const REMOTE_SHUTDOWN_BATCH_PERSIST_TIMEOUT_MS = 1_000;
 /** Scheduling/logging slack inside the supervisor-visible daemon budget. */
 export const DAEMON_SHUTDOWN_OVERHEAD_MS = 2_000;
 export const DAEMON_WORKER_EXIT_GRACE_MS = 3_000;
+
+/**
+ * Bound for settling live CoT thinking bubbles as「中断」on the graceful path.
+ *
+ * Deliberately NOT a new addend of DAEMON_SHUTDOWN_MAX_MS: that sum already
+ * sits exactly at its 28s assertion ceiling, so widening it would throw at
+ * module load. This is a sub-budget spent inside the existing envelope — the
+ * remote-drain phase it borrows from is entered only by remote backends
+ * (`shutdownBackendDisposition` → 'remote-drain-detach', i.e. riff/mojo),
+ * while pty/tmux sessions take 'detach'/'close' and never spend it. Every
+ * caller additionally clamps to the absolute shutdown deadline. Cosmetic work
+ * must never be the reason a shutdown misses its deadline.
+ */
+export const DAEMON_COT_SETTLE_MS = 2_000;
 export const DAEMON_SHUTDOWN_MAX_MS =
   BOT_TURN_MUTATION_SHUTDOWN_ACQUIRE_TIMEOUT_MS
   + REMOTE_SHUTDOWN_INITIAL_SNAPSHOT_TIMEOUT_MS

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -40,7 +40,7 @@ import {
   type OverloadCardBrowser,
 } from './core/host-overload-alert.js';
 import { registerOverloadNonce } from './im/lark/overload-nonce.js';
-import { sweepOrphanCotMessages } from './im/lark/cot-message.js';
+import { settleCotMessageForShutdown, sweepOrphanCotMessages } from './im/lark/cot-message.js';
 import { resolveBrowserTargets, detectRunningBrowsers } from './core/browser-restart.js';
 import { countHostOverload } from './im/lark/card-handler.js';
 import { startMaintenance, stopMaintenance } from './core/maintenance.js';
@@ -463,6 +463,7 @@ import {
 } from './core/remote-shutdown-detach.js';
 import {
   BOT_TURN_MUTATION_SHUTDOWN_ACQUIRE_TIMEOUT_MS,
+  DAEMON_COT_SETTLE_MS,
   DAEMON_SHUTDOWN_MAX_MS,
   DAEMON_WORKER_EXIT_GRACE_MS,
 } from './core/shutdown-budgets.js';
@@ -23039,6 +23040,26 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     }
 
     scheduler.stopScheduler();
+
+    // Settle live CoT thinking bubbles as「因重启中断」BEFORE tearing anything
+    // down. Two ordering constraints, both load-bearing:
+    //   • before worker teardown — the in-memory CoT state (cot_id/message_id)
+    //     lives in this process and is what lets us annotate at all; and
+    //   • before the bubble is completed — the API rejects every append after
+    //     a complete ("COT already in terminal state"), so a note added later
+    //     would silently never render.
+    // Bounded and fully self-catching: strictly cosmetic work must never delay
+    // or fail a shutdown, so it shares the shutdown deadline and swallows
+    // everything. The next generation's orphan sweep still covers whatever is
+    // missed here (SIGKILL, power loss, or a session added after this point).
+    try {
+      await waitAllWithin(
+        currentShutdownFleet.sessions.map(ds =>
+          settleCotMessageForShutdown(ds).catch(() => { /* cosmetic */ })),
+        Math.min(shutdownDeadlineMs, Date.now() + DAEMON_COT_SETTLE_MS),
+      );
+    } catch { /* cosmetic — never block shutdown */ }
+
     // NOTE: turn-terminal queue drain + webhook dispatcher stop are deliberately
     // deferred until AFTER workers have stopped producing (see below). Draining
     // here would close queue admission while worker terminal IPC handlers are

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1417,4 +1417,5 @@ export const messages: Record<string, string> = {
   'cot.tool.search': 'Search',
   'cot.tool.task': 'Manage tasks',
   'cot.tool.default': 'Call {name}',
+  'cot.interrupted': '⚠️ Interrupted by a service restart — this turn\'s thinking never finished',
 };

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1419,4 +1419,5 @@ export const messages: Record<string, string> = {
   'cot.tool.search': '搜索',
   'cot.tool.task': '任务管理',
   'cot.tool.default': '调用 {name}',
+  'cot.interrupted': '⚠️ 服务重启，本轮思考已中断',
 };

--- a/src/im/lark/cot-message.ts
+++ b/src/im/lark/cot-message.ts
@@ -125,6 +125,34 @@ export async function sweepOrphanCotMessages(selfLarkAppId: string): Promise<voi
       if (rec.larkAppId && rec.cotId && rec.messageId) {
         if (rec.larkAppId !== selfLarkAppId) continue; // sibling daemon's marker — leave it
         const c = getBotClient(rec.larkAppId);
+        // Annotate BEFORE terminating. Order is forced by the API, not a
+        // preference: once a CoT is completed every later append is rejected
+        // with "COT already in terminal state" (verified against the live
+        // endpoint), so a note added after the complete would silently never
+        // render. Best-effort — a failed note must still fall through to the
+        // complete below, since an un-terminated bubble spins on「执行中」
+        // forever, which is strictly worse than an unannotated one.
+        //
+        // The note ends in RUN_FINISHED, which already auto-completes the CoT
+        // server-side (verified: a later append is refused as terminal), so
+        // the complete below is redundant on the happy path. It is kept
+        // deliberately: it is idempotent, it is the ONLY terminator when the
+        // note fails, and dropping it would rewrite pre-existing assertions
+        // for a saving on a fire-and-forget startup path that blocks nothing.
+        try {
+          await c.request({
+            method: 'PUT',
+            url: '/open-apis/im/v1/message_cot',
+            data: {
+              cot_id: rec.cotId,
+              message_id: rec.messageId,
+              events: interruptedNoticeEvents(rec.larkAppId),
+            },
+            timeout: COT_REQUEST_TIMEOUT_MS,
+          } as any);
+        } catch (err) {
+          logger.warn(`[cot] orphan notice ${rec.cotId}: ${err instanceof Error ? err.message : String(err)}`);
+        }
         await c.request({
           method: 'POST',
           url: `/open-apis/im/v1/message_cot/complete/${encodeURIComponent(rec.cotId)}`,
@@ -166,6 +194,29 @@ export function cotEnabled(ds: DaemonSession): boolean {
 
 function ev(eventType: string, content: unknown): CotEvent {
   return { event_type: eventType, content: JSON.stringify(content), timestamp: Date.now() };
+}
+
+/**
+ * Terminal batch for a bubble the daemon is abandoning mid-turn: a visible
+ *「因重启中断」node followed by RUN_FINISHED(interrupted).
+ *
+ * Shared by both abandonment paths so they render identically:
+ *   - graceful shutdown (still holds the in-memory state), and
+ *   - the next generation's orphan sweep (only has the marker file).
+ *
+ * Callers MUST send this BEFORE terminating the CoT. Completing first is
+ * irreversible: a later append is rejected with "COT already in terminal
+ * state" (verified against the live endpoint), so the note would silently
+ * never appear.
+ */
+function interruptedNoticeEvents(larkAppId: string, lastReasoningId?: string): CotEvent[] {
+  const mid = `reasoning-interrupted-${lastReasoningId ?? 'orphan'}`;
+  return [
+    ev('REASONING_MESSAGE_START', { messageId: mid, role: 'reasoning' }),
+    ev('REASONING_MESSAGE_CONTENT', { messageId: mid, delta: t('cot.interrupted', {}, localeForBot(larkAppId)) }),
+    ev('REASONING_MESSAGE_END', { messageId: mid }),
+    ev('RUN_FINISHED', { threadId: 'cot-interrupted', runId: mid, status: 'interrupted' }),
+  ];
 }
 
 /**
@@ -420,6 +471,49 @@ export function handleCotThinkingUpdate(
   state.pendingEntries = msg.entries;
   void pump(ds, state);
   return true;
+}
+
+/**
+ * Settle this session's live bubble as「因重启中断」during a GRACEFUL daemon
+ * shutdown. Awaitable on purpose: shutdown must be able to hold its budget
+ * open until the note is actually delivered, unlike {@link abortCotMessage}
+ * (fire-and-forget, used on the worker-exit path where nothing awaits).
+ *
+ * Why this exists on top of the orphan sweep: the sweep is the NEXT
+ * generation's fallback and can only reach bubbles whose marker survived. It
+ * cannot annotate anything the current process still owns in memory before
+ * the marker is consumed, and it is skipped entirely when the daemon is
+ * SIGKILLed after this point. Annotating here covers the common path; the
+ * sweep covers SIGKILL / power loss.
+ *
+ * Clears the orphan marker on success so the next generation does not
+ * annotate the same bubble twice.
+ */
+export async function settleCotMessageForShutdown(ds: DaemonSession): Promise<void> {
+  const state = states.get(ds);
+  if (!state || state.settled || !state.cotId) return;
+  // A turn that is already finishing owns its own terminal batch: `pump` may be
+  // parked on an await with its `!state.settled` check already passed, so
+  // claiming the turn here would put a SECOND RUN_FINISHED on the wire (caught
+  // by the shutdown-vs-finalize race test). The pump also clears the orphan
+  // marker, so nothing is left spinning — leave it alone.
+  if (state.finishStatus) return;
+  state.settled = true; // claim it: a concurrent abort/finalize must not double-send
+  try {
+    if (!state.disabled) {
+      await apiAppend(ds, state, interruptedNoticeEvents(ds.larkAppId, state.lastReasoningId));
+    } else {
+      // A mid-turn failure already disabled pushes for this turn; appending
+      // would fail too. Just terminate so it stops spinning.
+      await apiComplete(ds, state, 'error');
+    }
+  } catch {
+    // Notice failed — still terminate, for the same reason the sweep does:
+    // an unannotated closed bubble beats one that spins forever.
+    try { await apiComplete(ds, state, 'error'); } catch { /* best-effort */ }
+  } finally {
+    clearCotOrphanMarker(state);
+  }
 }
 
 /**

--- a/test/cot-message.test.ts
+++ b/test/cot-message.test.ts
@@ -19,7 +19,7 @@ vi.mock('../src/bot-registry.js', () => ({
 import { mkdtempSync, existsSync, readdirSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { handleCotThinkingUpdate, finalizeCotMessage, abortCotMessage, sweepOrphanCotMessages } from '../src/im/lark/cot-message.js';
+import { handleCotThinkingUpdate, finalizeCotMessage, abortCotMessage, sweepOrphanCotMessages, settleCotMessageForShutdown } from '../src/im/lark/cot-message.js';
 import { getBot } from '../src/bot-registry.js';
 
 // Orphan markers land under config.session.dataDir — point it at a tmp dir so
@@ -383,6 +383,100 @@ describe('orphan markers & sweep (daemon restart mid-turn)', () => {
   it('sweep is a no-op without a marker directory', async () => {
     await expect(sweepOrphanCotMessages('app1')).resolves.toBeUndefined();
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it('sweep annotates the bubble as interrupted BEFORE completing it', async () => {
+    mkdirSync(orphanDir, { recursive: true });
+    writeFileSync(join(orphanDir, 'cot_prev.json'), JSON.stringify({ larkAppId: 'app1', cotId: 'cot_prev', messageId: 'om_prev' }));
+    await sweepOrphanCotMessages('app1');
+    // Order is forced by the API, not cosmetic preference: appending after a
+    // complete is rejected with "COT already in terminal state", so a note
+    // pushed afterwards would silently never render.
+    const kinds = request.mock.calls.map(([req]) => req.method === 'PUT' ? 'note' : 'complete');
+    expect(kinds).toEqual(['note', 'complete']);
+    const note = pushedEvents();
+    expect(note.some(e => e.type === 'REASONING_MESSAGE_CONTENT' && /重启/.test(e.content.delta))).toBe(true);
+    expect(note.at(-1)!.type).toBe('RUN_FINISHED');
+    expect(note.at(-1)!.content.status).toBe('interrupted');
+  });
+
+  it('sweep still completes the bubble when the interrupted note fails', async () => {
+    mkdirSync(orphanDir, { recursive: true });
+    writeFileSync(join(orphanDir, 'cot_prev.json'), JSON.stringify({ larkAppId: 'app1', cotId: 'cot_prev', messageId: 'om_prev' }));
+    request.mockImplementation(async (req: any) => {
+      if (req.method === 'PUT') throw new Error('append boom');
+      return { code: 0, data: {} };
+    });
+    await sweepOrphanCotMessages('app1');
+    // A failed note must never strand the bubble: an unannotated closed bubble
+    // beats one spinning on「执行中」forever.
+    expect(request.mock.calls.some(([req]) => String(req.url).includes('/message_cot/complete/cot_prev'))).toBe(true);
+    expect(readdirSync(orphanDir)).toEqual([]);
+  });
+});
+
+describe('settleCotMessageForShutdown (graceful daemon restart)', () => {
+  it('annotates the live bubble as interrupted and clears its marker', async () => {
+    const ds = makeDs();
+    handleCotThinkingUpdate(ds, upd([think('step 1')]));
+    await flush();
+    expect(existsSync(join(orphanDir, 'cot1.json'))).toBe(true);
+    await settleCotMessageForShutdown(ds);
+    const evs = pushedEvents();
+    expect(evs.some(e => e.type === 'REASONING_MESSAGE_CONTENT' && /重启/.test(e.content.delta))).toBe(true);
+    expect(evs.at(-1)!.type).toBe('RUN_FINISHED');
+    expect(evs.at(-1)!.content.status).toBe('interrupted');
+    // Marker cleared → the next generation's sweep must not annotate it twice.
+    expect(existsSync(join(orphanDir, 'cot1.json'))).toBe(false);
+  });
+
+  it('is idempotent and never double-settles against abort/finalize', async () => {
+    const ds = makeDs();
+    handleCotThinkingUpdate(ds, upd([think('step 1')]));
+    await flush();
+    await settleCotMessageForShutdown(ds);
+    const calls = request.mock.calls.length;
+    await settleCotMessageForShutdown(ds);
+    abortCotMessage(ds);
+    finalizeCotMessage(ds, 'om_turn1', 'completed');
+    await flush();
+    expect(request.mock.calls.length).toBe(calls);
+  });
+
+  it('no-ops when the session never created a bubble', async () => {
+    const ds = makeDs();
+    await settleCotMessageForShutdown(ds);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('leaves an already-finishing turn to its own pump (no second RUN_FINISHED)', async () => {
+    // The pump may be parked on an await with its `!state.settled` check
+    // already passed. Claiming the turn here would put a SECOND terminal batch
+    // on the wire — the bubble would show two "finished" events.
+    const ds = makeDs();
+    handleCotThinkingUpdate(ds, upd([think('step 1')]));
+    await flush();
+    finalizeCotMessage(ds, 'om_turn1', 'completed'); // sets finishStatus; pump in flight
+    await settleCotMessageForShutdown(ds);           // shutdown fires into that window
+    await flush();
+    const terminal = request.mock.calls.filter(([req]) =>
+      req.method === 'PUT' && req.data.events.some((e: any) => e.event_type === 'RUN_FINISHED'));
+    expect(terminal.length).toBe(1);
+    // The pump still owns cleanup, so nothing is left spinning.
+    expect(existsSync(join(orphanDir, 'cot1.json'))).toBe(false);
+  });
+
+  it('terminates a disabled bubble instead of appending to it', async () => {
+    const ds = makeDs();
+    request.mockImplementationOnce(async () => ({ code: 0, data: { cot_id: 'cot1', message_id: 'om_cot_msg1' } }))
+      .mockImplementationOnce(async () => { throw new Error('prologue boom'); });
+    handleCotThinkingUpdate(ds, upd([think('step 1')]));
+    await flush();
+    request.mockClear().mockImplementation(async () => ({ code: 0, data: {} }));
+    await settleCotMessageForShutdown(ds);
+    // Pushes are already failing for this turn — go straight to complete.
+    expect(request.mock.calls.every(([req]) => req.method === 'POST')).toBe(true);
+    expect(request.mock.calls.some(([req]) => String(req.url).includes('/message_cot/complete/'))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 问题

daemon 重启会让进行中的思考气泡「多出一个」：旧气泡被孤儿清扫直接 `complete` 掉、
停在「思考完成」，用户下一轮提问又新建一个从头再来——**旧的为什么停住，用户无从得知**。

线上 1623 条 `[cot] created` 里实锤 1 组（判据见下）：

```
06:37:30 created      cot=7680081201998072777  msg=om_…5c57a8…
06:52:40 orphan closed cot=7680081201998072777        ← 重启后被清扫关掉
06:53:08 created      cot=7680085231344372948  msg=om_…03f158…  ← 新气泡
```

两条 API 回查同源：`chat=oc_b9b8e5…` / `thread=omt_19f0977a110e5a78` /
`root=om_x100b6665b5fefc…`。

> **判据说明**：日志里 turn id 被截断成 12 字符，跨重启候选共 4 组，
> **只看前缀 4 组都像重复**；逐条查飞书 API 后只有 1 组是真的（另 3 组分别是
> 不同群、或同群但 root 锚点不同）。**必须 `chat_id` + `thread_id` + `root_id`
> 三者同时相同**才算同一回合。

**机制不是「同一回合重放两遍」**：重启时 `killStalePids` 已对旧 CLI 发 SIGTERM
（整个进程组）、所有会话 `worker: null` 重建，被打断那轮是真的结束了。
准确说是「旧的被静默关掉 + 用户重来一轮时另起一个」。

## 改动

不做续传（见下「为什么不做续传」），改为**收尾时标注**。两条路径各管一段：

| 路径 | 改动 | 覆盖 |
|---|---|---|
| 重启后兜底 | `sweepOrphanCotMessages`：从「直接 complete」改成「**先 append 标注 → 再 complete**」 | SIGKILL / 掉电 |
| 重启前优雅 | 新增 `settleCotMessageForShutdown`，接进 `shutdown()` | 绝大多数重启 |

## 两个顺序约束（都是 API 逼出来的，不是偏好）

1. **必须先标注、再终止**。CoT 一旦 complete，之后每次 append 都被拒：
   ```
   append AFTER complete: 10001 "COT already in terminal state"
   ```
   （对线上端点实测。顺序反了标注会**静默不出现**。）
   标注失败仍必须继续 complete——不终止的气泡会永远转圈，比不标注更糟。
2. **必须在 worker 销毁之前**。CoT 状态是进程内 `WeakMap`，worker 一销毁就没有
   `cot_id` 可用。故插在 `scheduler.stopScheduler()` 之后、worker teardown 之前
   （相对行 19 vs 130，中间隔 111 行）。

## 为什么不做「续传」

持久化 `sentCount` 后跳过已推送 entry 的方案**实测是坏的**：worker 是新进程、
`thinkingEntries` 从空重累，重启后发上来的是 `[e4,e5]` 而不是 `[e1..e5]`，
`pending.length(2) > sentCount(3)` 为假 ⟹ **一条都推不进去**，比现状更糟。

顺带纠正一个容易踩的认知：CoT observer 是 `ingest()` 的**逐次调用参数**而非 queue
状态，恢复路径 `worker.ts:4810` 只传 2 个参数 ⟹ **重放事件根本不进 CoT 通道**
（A/B 探针：带 observer `1` 次回调，不带 `0` 次）。

## 预算常量（差点炸全 fleet）

`DAEMON_COT_SETTLE_MS` 是既有预算**内部**的子预算，**不是** `DAEMON_SHUTDOWN_MAX_MS`
的新加数：该求和值当前**正好等于**文件底部断言的 28000 上限，并进去会
**模块加载即抛、所有 daemon 起不来**（变异实测输出 `Tests no tests`，
而 `tsc` 对此完全无感）。调用处再与绝对 `shutdownDeadlineMs` 取 min。

## 影响面

- **共用层**：动了 `shutdown()`（`daemon.ts`）与 `shutdown-budgets.ts`，但新增逻辑
  完全 self-catching + 有界，失败不影响关闭流程；预算求和值未变（实测 `MAX=28000`）。
- **跨 CLI**：CoT 通道对所有 CLI 共用，本改动只碰「气泡收尾」，不碰采集/投递。
- **跨后端**：`settleCotMessageForShutdown` 遍历的是 shutdown fleet（已按对象去重），
  pty/tmux/remote 一视同仁；借用的 remote-drain 时间窗只有 remote 后端会进入。
- **`/cot off` 交互**：判据用 `state.cotId` 而非 `cotEnabled()`——已存在的气泡即使
  中途被关开关也必须收尾，否则永远转圈（与 `abortCotMessage` 现有行为一致）。

## 测试

`test/cot-message.test.ts` **34 passed**（原 27 + 新 7）。

**反变异 6 个，全部被抓**（每个当场还原 + `cmp` 校验）：

| 变异 | 被抓 |
|---|---|
| 去掉标注、只 complete | ✅ |
| **complete 在前、标注在后** | ✅ |
| 标注失败后不兜底 complete | ✅ |
| 关闭标注后不清 marker | ✅ |
| 去掉并发占位 | ✅ |
| 常量并进预算求和 | ✅ 加载即抛 |

**其中一条来自自查发现的真 bug**：shutdown 撞上正在收尾的 turn 会**双发
`RUN_FINISHED`**——`pump` 在 `await` 之后才判 `!settled`，而占位是在那个 await
窗口里置的，pump 早已通过检查。修法是**让出而非抢占**（`finishStatus` 已设置就
直接返回，由 pump 自己收尾并清 marker）。这个 bug **单测和全量都跑不出来**，
需要「finalize 与 shutdown 撞进同一个 await 窗口」的特定时序。

**全量归属：零回归**（三条独立证据）

```
PR     failed files: 26   tests f/p/t = (23, 20092, 20160)
master failed files: 29   tests f/p/t = (26, 20058, 20153)
PR-only 1 · master-only 4 · 两边都失败 25
```

1. **master 比 PR 还红**（29 vs 26，master-only 4 个）⟹ 真回归不可能造成；
2. **PR-only 那个文件两次跑换了人**（`listen-with-probe` → `codex-app-threads`）
   ⟹ 失败在文件间游走 = flake 定义；
3. 两个 PR-only 单跑都全绿（6/6、11/11），对本次改动符号 `grep` **零引用**。

> 基线跑全程未碰工作树（`git status --porcelain` 保持 0），避免半新半旧的混合结果。

其他：`tsc --noEmit` exit 0；`shutdown-supervisor-contract` 12 passed；
i18n `cot.interrupted` 中英各一条，键数 1266/1266 对齐、无孤儿键。

## 尚未验证

**未在飞书实测**。触发条件就是「思考进行中时重启 daemon」，部署后一次重启即可验证；
但部署会让全部 bot 跑此分支的 build，故留给维护者决定时机。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 已知限制（复审补充，均为纯展示、不引入 spinner 或重复终态）

以下三个窄窗口会导致「气泡干净关闭但**没有中断标注**」，退化到本 PR 之前的现状，
不会造成气泡卡在「执行中」转圈，也不会重复终态。权衡后不修，记在此处避免后来人重推：

- **(a) settle 时 pump 正 park 在 `apiCreate`**（`cotId` 尚未落地）→ settle 判 `!state.cotId`
  直接 return 不认领。若 pump 随后在进程退出前跑完整个生命周期，气泡会干净关闭但无标注，
  且 marker 由 pump 自己清掉 ⟹ 下一代 sweep 也补不上。窗口约一个 HTTP RTT。
- **(b) remote drain 阶段**（最长 12s）worker 自崩或恰好收到 `turn_terminal`
  → `abortCotMessage` / `finalizeCotMessage` 先设 `finishStatus`
  → settle 走 `if (state.finishStatus) return` 让出 ⟹ 由 pump 收尾，无标注。
- **(c)** settle 的 note append 与 pump 的 entry append 落线顺序不定，最坏情况 pump 的
  晚到 entry 撞上已终态被拒 → 该 turn `disabled`（纯展示损失）。

失败面严格限于展示：最坏退回「现状 spinner」或「无标注关闭」；shutdown 本体被
try/catch + 有界预算夹死，不会被拖慢或拖挂。
