### PR TITLE
docs(install): 默认推荐 curl 单文件安装，npm 降为备选并修正 Node 前提

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/botmux"><img src="https://img.shields.io/npm/v/botmux.svg" alt="npm"></a>
-  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node >= 22">
+  <img src="https://img.shields.io/badge/binary-no%20Node%20required-brightgreen.svg" alt="self-contained binary, no Node required">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT"></a>
   <a href="https://github.com/deepcoldy/botmux"><img src="https://img.shields.io/github/stars/deepcoldy/botmux.svg?style=social" alt="Stars"></a>
 </p>
@@ -39,10 +39,29 @@ A daemon watches Lark messages and spawns an isolated session process for each n
 > About 5 minutes: a single Lark QR scan in `botmux setup` creates the app, configures all permissions, and publishes a version in one flow (add `--no-open-platform-auto` to only create the app and skip the permission + publish automation, which you then complete manually; creating the app manually / pasting credentials is a separate option inside setup).
 
 ```bash
-npm install -g botmux        # requires Node >= 22
+curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh
 botmux setup                 # one scan to create the app → pick a CLI → pick a working dir (permissions + publish auto-configured)
 botmux start                 # start the daemon (botmux autostart enable for auto-start on boot)
 ```
+
+> botmux ships as a **self-contained single-file binary** with its runtime embedded — **neither installing nor running it needs Node on the machine** (whatever the AI coding CLI you bridge needs is its own matter). It installs to `~/.botmux/bin/botmux` (override with `BOTMUX_INSTALL_DIR`), picks the right binary for your OS/arch, verifies its SHA-256, and adds `~/.botmux/bin` to the startup file your shell actually reads (zsh / bash / fish each get the correct one), so **a new terminal has the command**.
+>
+> Nothing native is compiled during install (no Python / node-gyp / compiler): the PTY is already inside the binary. Supported: linux / macOS × x64 / arm64, with musl builds selected automatically on Alpine and similar. **On Windows, install inside WSL2** — the daemon needs PTY / tmux / Unix signals and does not run on native Windows; WSL2 reports as linux and is a fully supported first-class environment. An unsupported platform, or a binary that cannot run on this host, **fails with an explicit error and leaves your existing install untouched** rather than leaving you with a command that won't start.
+>
+> To upgrade: `botmux upgrade` (replaces the binary in place), or just **re-run the curl command** — also an in-place upgrade, and it won't append a second PATH line.
+
+<details>
+<summary>Already living in the Node ecosystem? npm works too (same binary)</summary>
+
+```bash
+npm install -g botmux        # requires Node >= 22 to run the install itself
+```
+
+The npm package carries **the same self-contained binary** (only the one matching your os/arch is installed); its postinstall points `~/.botmux/bin/botmux` at it and writes PATH the same way. So you end up with exactly **one** botmux version — no more "two Node versions each carrying their own global botmux, fighting each other / no idea which one I just updated".
+
+The only difference is **who installs it and who upgrades it later**: the npm path needs Node ≥ 22 to run the install itself and hands upgrades back to `npm i -g botmux@latest`; the curl path never touches Node. Once running, the two are identical — same binary, same commands.
+
+</details>
 
 Then DM the bot, or run `botmux dashboard` to create a group, and start chatting. Full steps (Lark international, manual permission / publish setup after `--no-open-platform-auto`, troubleshooting) are in the **[5-Minute Quickstart](https://deepcoldy.github.io/botmux/en/quickstart)**.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/botmux"><img src="https://img.shields.io/npm/v/botmux.svg" alt="npm"></a>
-  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node >= 22">
+  <img src="https://img.shields.io/badge/binary-no%20Node%20required-brightgreen.svg" alt="self-contained binary, no Node required">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT"></a>
   <a href="https://github.com/deepcoldy/botmux"><img src="https://img.shields.io/github/stars/deepcoldy/botmux.svg?style=social" alt="Stars"></a>
 </p>
@@ -39,27 +39,27 @@ Daemon 监听飞书消息，为每个新会话自动 spawn 一个独立的会话
 > 约 5 分钟：`botmux setup` 一次飞书扫码就连续建好应用、配全权限、发版（加 `--no-open-platform-auto` 则只建应用、跳过权限与发版的自动配置，之后需手动完成；手动创建 / 粘贴凭证是 setup 里的另一个选项）。
 
 ```bash
-npm install -g botmux        # 需要 Node >= 22 装包本身
+curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh
 botmux setup                 # 一次扫码建应用 → 选 CLI → 选工作目录（自动配权限 + 发版）
 botmux start                 # 启动 daemon（botmux autostart enable 设开机自启）
 ```
 
-> npm 包内已经带了对应平台的**自包含二进制**（按 os/arch 只装匹配的那一个），安装时会把 `~/.botmux/bin/botmux` 指向它。所以装完只有**一个** botmux 版本，不再出现「装了两个 Node 版本、各自带一份全局 botmux 互相打架 / 不知道更新了哪个」。把 `~/.botmux/bin` 放进 PATH 即可（安装日志会提示命令）。
+> botmux 本体是一个**自包含单文件二进制**，运行时已嵌在里面——**装它和跑它都不需要机器上有 Node**（你要接的 AI 编程 CLI 自己需要什么另算）。装到 `~/.botmux/bin/botmux`（`BOTMUX_INSTALL_DIR` 可改），按 OS/arch 自动选对应二进制、校验 SHA-256，并把 `~/.botmux/bin` 写进你当前 shell 的启动文件（zsh / bash / fish 各写对的那个），**开个新终端就能用**。
 >
-> 安装过程**不编译任何原生模块**（不需要 Python / node-gyp / 编译器）：要跑的 PTY 已经嵌在那个二进制里，npm 只是把它放到位。支持 linux / macOS × x64 / arm64；**Windows 请在 WSL2 里安装**（WSL 报告为 linux，是完整支持的一等环境）。不在支持列表里的平台会在安装时**明确报错**，而不是装上一个跑不起来的命令。
+> 安装过程**不编译任何原生模块**（不需要 Python / node-gyp / 编译器）：PTY 已经嵌在二进制里。支持 linux / macOS × x64 / arm64（Alpine 等 musl 环境自动选 musl 版）；**Windows 请在 WSL2 里安装**（daemon 依赖 PTY / tmux / Unix 信号，原生 Windows 跑不了；WSL2 报告为 linux，是完整支持的一等环境）。平台不在列表里、或下下来的二进制在本机跑不起来，安装会**明确报错并保留原有版本**，而不是装上一个起不来的命令。
+>
+> 升级：`botmux upgrade`（原地换二进制），或**重跑一遍上面那条 curl 命令**——同样原地升级，不会重复往启动文件里追加 PATH。
 
 <details>
-<summary>不想装 Node？直接下单文件可执行（连装包都不需要 Node）</summary>
-
-同一个自包含二进制也可以脱离 npm 直接下载，**自带运行时、不依赖机器上的任何 Node**。macOS / Linux：
+<summary>已经在用 Node 生态？也可以走 npm（同一个二进制）</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh
-botmux setup
-botmux start
+npm install -g botmux        # 需要 Node >= 22 装包本身
 ```
 
-装到 `~/.botmux/bin/botmux`（`BOTMUX_INSTALL_DIR` 可改），自动按 OS/arch 拉对应二进制并校验 SHA-256。命令用法与 npm 版完全一致。**Windows 请在 WSL2 里安装**（daemon 依赖 PTY / tmux / Unix 信号，原生 Windows 跑不了；WSL2 报告为 linux，完整支持）。
+npm 包内带的是**同一个自包含二进制**（按 os/arch 只装匹配的那一个），postinstall 把 `~/.botmux/bin/botmux` 指向它并同样写 PATH。所以装完只有**一个** botmux 版本，不再出现「装了两个 Node 版本、各自带一份全局 botmux 互相打架 / 不知道更新了哪个」。
+
+区别只在**谁来装、以后谁来升**：npm 路径需要 Node ≥ 22 才能执行安装本身，升级交回 `npm i -g botmux@latest`；curl 路径全程不碰 Node。跑起来之后两者完全一致——同样的二进制、同样的命令。
 
 </details>
 

--- a/docs-site/docs/en/about.mdx
+++ b/docs-site/docs/en/about.mdx
@@ -5,7 +5,8 @@ botmux — a bridge between Lark topic groups ↔ AI coding CLIs. Open source un
 ## Links
 
 - **GitHub**: [github.com/deepcoldy/botmux](https://github.com/deepcoldy/botmux)
-- **npm**: `npm install -g botmux` · [npmjs.com/package/botmux](https://www.npmjs.com/package/botmux)
+- **Install**: `curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh` (self-contained binary, no Node required)
+- **npm** (alternative, needs Node ≥ 22): `npm install -g botmux` · [npmjs.com/package/botmux](https://www.npmjs.com/package/botmux)
 - **Contributing guide**: [CONTRIBUTING.md](https://github.com/deepcoldy/botmux/blob/master/CONTRIBUTING.md)
 - **License**: [MIT](https://github.com/deepcoldy/botmux/blob/master/LICENSE)
 

--- a/docs-site/docs/en/faq.md
+++ b/docs-site/docs/en/faq.md
@@ -140,7 +140,7 @@ It hasn't been verified on native Windows, but WSL2 should be fine.
 
 ## How do I upgrade?
 
-`botmux upgrade`. The `botmux` wrapper version inside sessions always stays in sync with the daemon, so it doesn't need to be upgraded separately.
+`botmux upgrade` — it routes by how you installed: a curl install gets its binary replaced in place, an npm install is handed back to `npm i -g botmux@latest`. curl users can equally just re-run the install command (also an in-place upgrade, and it won't write a second PATH line). The `botmux` wrapper version inside sessions always stays in sync with the daemon, so it doesn't need to be upgraded separately. Run `botmux restart` afterwards to pick up the new version.
 
 ## CoCo loses messages while busy?
 

--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -4,7 +4,7 @@
 
 botmux is a bridge: a persistent **daemon** listens to Lark messages and automatically launches a dedicated AI coding CLI process (Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity, etc.) for each new topic. It renders terminal output into Lark **streaming cards** in real time, and provides an interactive **Web Terminal**. Phone, computer, and Lark stay in sync — wherever you are, your coding session follows.
 
-> Project: <https://github.com/deepcoldy/botmux> ｜ npm: `npm install -g botmux`
+> Project: <https://github.com/deepcoldy/botmux> ｜ Install: `curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh` (self-contained binary, no Node required; `npm i -g botmux` also works)
 
 ## Design philosophy: not an SDK wrapper — bridge the CLI directly
 

--- a/docs-site/docs/en/pitfalls.md
+++ b/docs-site/docs/en/pitfalls.md
@@ -8,7 +8,8 @@
 
 ## Environment / Installation
 
-- **Node too old**: v18 and similar lack a built-in global `fetch`, so `botmux setup` throws `fetch is not defined` / `fetch failed` and won't write `bots.json`. → Upgrade to **Node ≥ 22**.
+- **`botmux: command not found` right after installing**: `~/.botmux/bin` isn't on PATH. Both install routes write your shell's startup file, but **you need a new terminal (or to source it) for it to take effect**. ⚠️ Known limitation: if `~/.botmux/bin` already happens to be on the *installing process's* PATH — **which is exactly the case when you install from inside a botmux CLI session**, since the daemon injects it into every session's PATH — `install.sh` concludes there is nothing to do and **writes no startup file**, so a new terminal still can't find it. → Install from an **ordinary terminal**, or add `export PATH="$HOME/.botmux/bin:$PATH"` to your startup file by hand.
+- **Node too old** (npm install path only): v18 and similar lack a built-in global `fetch`, so the `npm i -g botmux` postinstall or `botmux setup` throws `fetch is not defined` / `fetch failed`. → Upgrade to **Node ≥ 22**, or switch to the curl install (self-contained binary, no Node needed).
 - **First launch stuck on a manual confirmation**: On first run, a CLI (such as Claude Code) pops up a "trust this directory / bypass permissions" confirmation. If nobody has clicked through it, it hangs and reports a `tmux send-keys` error. → Confirm it manually once, and it won't appear again.
 
 ## Lost environment variables (high frequency)

--- a/docs-site/docs/en/plugins.md
+++ b/docs-site/docs/en/plugins.md
@@ -43,11 +43,16 @@ publisher.
 
 ## Create a project
 
-Botmux currently requires Node.js 22 or newer. Install Botmux, then run the
-generator:
+Plugin **development** requires Node.js 22 or newer with `npm` on your `PATH` —
+the generator shells out to npm to scaffold, install, and test the project. (This
+is a requirement of plugin development specifically; botmux itself is a
+self-contained binary and needs no Node — see [Quickstart](/en/quickstart).)
+
+Install botmux by whichever route you prefer, then run the generator:
 
 ```bash
-npm install -g botmux@latest
+curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh
+# or, if you'd rather install through npm: npm install -g botmux@latest
 
 botmux plugin init my-plugin
 cd botmux-plugin-my-plugin

--- a/docs-site/docs/en/prerequisites.md
+++ b/docs-site/docs/en/prerequisites.md
@@ -1,16 +1,17 @@
 # Prerequisites
 
-Before installing botmux, make sure these are in place — **many "installed but won't connect / sessions won't start" issues trace back to a missing prerequisite here** (Node version, CLI not logged in, not on PATH).
+Before installing botmux, make sure these are in place — **many "installed but won't connect / sessions won't start" issues trace back to a missing prerequisite here** (CLI not logged in, tmux missing, not on PATH).
 
 **Applies to**: any machine that will run the botmux daemon (dev machine / devbox / server).
 **Doesn't apply**: if you only @ a bot in a group someone else already set up — you don't need to install anything locally.
 
 ## Runtime environment
 
-- **Node.js ≥ 22** (`node -v` to check; below 22 causes native-module / syntax errors).
+- **botmux itself: no Node required.** The default [curl install](/en/quickstart) delivers a self-contained single-file binary with its runtime embedded. **Node ≥ 22 is required only on the npm install path** — that's a requirement of running `npm i -g`, not of running botmux. (Plugin-development commands like `botmux plugin init` shell out to npm and need Node too.)
 - **AI coding CLI / local agent app**: at least one **installed and authenticated**, with the executable on your `PATH`:
   - `claude` (Claude Code), `codex`, `cursor-agent` (Cursor), `gemini`, `opencode`, `coco` (Trae / CoCo), `agy` (Antigravity), `hermes`, etc. (full `cliId` list in [CLI Adapters](/en/adapters)).
   - ⚠️ botmux is only a bridge — it doesn't manage login. **Run the CLI once in a terminal to confirm it can chat** before wiring it into botmux.
+  - ⚠️ Those CLIs have their own runtime requirements: many ship as npm packages (`claude` / `codex` / `gemini`, …) and still need Node to install. "botmux needs no Node" is about botmux itself.
 - **tmux ≥ 3.x** (**the default backend — strongly recommended to install**): **in the default configuration** the session backend is tmux, so you need it to start sessions — when tmux isn't available botmux **no longer silently downgrades to pty**; it hard-gates the session and posts a card asking you to install tmux (see [tmux Session Persistence](/en/tmux)). To run a tmux-free environment, pick an explicit backend: `BACKEND_TYPE=pty` / per-bot `backendType` (`pty`/`herdr`/`zellij`) — pty doesn't survive daemon restarts; herdr/zellij need their own binaries. (riff is a cloud agent and doesn't occupy a local backend.)
 
 ## Recommended deployment
@@ -19,7 +20,8 @@ Deploy on an **always-on dev machine / devbox** (rather than a laptop), so the d
 
 ## Common failures
 
-- `node -v` < 22 → upgrade Node (install 22+ via nvm / fnm; make sure the botmux shell's startup file picks it up).
+- `botmux: command not found` right after installing → `~/.botmux/bin` isn't on PATH yet. The installer writes your shell's startup file, but **you need a new terminal for it to take effect**; if it's still missing, see [Common Pitfalls](/en/pitfalls).
+- Installing via npm with `node -v` < 22 → upgrade Node (22+ via nvm / fnm), or switch to the curl install and skip Node entirely.
 - CLI not on PATH / not logged in → sessions won't start or the first message gets no response; get the CLI working manually first, then see [FAQ · session won't start](/en/faq).
 - CLI installed but botmux can't find it → PATH not effective in a non-interactive shell, see [Common Pitfalls](/en/pitfalls).
 

--- a/docs-site/docs/en/quickstart.md
+++ b/docs-site/docs/en/quickstart.md
@@ -1,16 +1,22 @@
 # 5-minute quick setup
 
-> 💡 **TL;DR**: `npm i -g botmux` → `botmux setup` (**a single Lark QR scan** creates the app + configures all permissions + publishes) → `botmux start` → `botmux autostart enable` → add the bot to a group and start chatting.
+> 💡 **TL;DR**: `curl -fsSL .../install.sh | sh` → `botmux setup` (**a single Lark QR scan** creates the app + configures all permissions + publishes) → `botmux start` → `botmux autostart enable` → add the bot to a group and start chatting.
 
-**Before you start**: confirm the [Prerequisites](/en/prerequisites) (Node ≥ 22, target CLI installed and logged in) — a missing prerequisite here is the most common cause of "installed but won't connect."
+**Before you start**: confirm the [Prerequisites](/en/prerequisites) (target CLI installed and logged in, tmux) — a missing prerequisite here is the most common cause of "installed but won't connect."
 
 ## Step 1 · Install
 
 ```bash
-npm install -g botmux
+curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh
 ```
 
-Requires **Node.js ≥ 22**, with at least one AI coding CLI already installed and signed in locally (`claude` / `codex` / `cursor-agent` / `gemini` / `opencode` / `coco` / `agy`, etc.). **The default session backend is tmux (≥3.x), so install it** — when it's unavailable botmux hard-gates with a card instead of silently downgrading to pty; only pick an explicit backend (`BACKEND_TYPE=pty` or per-bot `backendType`: `pty`/`herdr`/`zellij`) if you truly need a tmux-free environment (riff is a cloud agent and doesn't occupy a local backend).
+botmux is a **self-contained single-file binary** with its runtime embedded — **neither installing nor running it needs Node**. It installs to `~/.botmux/bin/botmux` (override with `BOTMUX_INSTALL_DIR`), picks the binary for your OS/arch, verifies its SHA-256, and adds `~/.botmux/bin` to the startup file your shell actually reads (zsh / bash / fish each get the correct one), so **a new terminal has the command**. Supported: linux / macOS × x64 / arm64, with musl builds selected automatically on Alpine and similar. **On Windows, install inside WSL2.**
+
+> 🔁 **Upgrading**: `botmux upgrade` (replaces the binary in place), or just re-run the curl command — also an in-place upgrade, and it won't append a second PATH line. To install a specific version: `BOTMUX_VERSION=v3.18.8 curl … | sh`.
+
+> 📦 **npm works too** (`npm install -g botmux`, needs Node ≥ 22 to run the install itself): the npm package carries **the same self-contained binary** (verified byte-identical to the GitHub Release asset by SHA-256; only the one matching your os/arch is installed), and its postinstall points `~/.botmux/bin/botmux` at it and writes PATH the same way. The only difference is **who installs it and who upgrades it later**: the npm path needs Node and hands upgrades back to `npm i -g botmux@latest`; the curl path never touches Node. Once running, the two are identical.
+
+Running botmux itself needs no Node, but you do need **at least one AI coding CLI installed and signed in locally** (`claude` / `codex` / `cursor-agent` / `gemini` / `opencode` / `coco` / `agy`, etc. — each with its own runtime requirements). **The default session backend is tmux (≥3.x), so install it** — when it's unavailable botmux hard-gates with a card instead of silently downgrading to pty; only pick an explicit backend (`BACKEND_TYPE=pty` or per-bot `backendType`: `pty`/`herdr`/`zellij`) if you truly need a tmux-free environment (riff is a cloud agent and doesn't occupy a local backend).
 
 ## Step 2 · Configure (`botmux setup`)
 

--- a/docs-site/docs/en/skill-cli.md
+++ b/docs-site/docs/en/skill-cli.md
@@ -22,7 +22,7 @@ A `botmux send` **must carry an @-decision**, or it refuses to send: `--mention 
 
 ## Wrapper Mechanism
 
-In-session commands rely on the wrapper script at `~/.botmux/bin/botmux` — **written automatically by the daemon at startup** and added to the worker's PATH. The wrapper is an extremely thin `exec node <this daemon's dist/cli.js>` shim, so its **version always matches the daemon** and no separate `npm i -g` is needed. (Dev helpers like `bun run use:here` re-point it manually with identical, idempotent content.)
+In-session commands rely on `~/.botmux/bin/botmux` — **maintained automatically by the daemon at startup** and added to the worker's PATH, so its **version always matches the daemon** and no separate install is needed. What it points at depends on how the daemon itself is running: with a curl install that path **is the self-contained binary** (the daemon detects this and skips rewriting, so it never overwrites itself with a script); with an npm install it's a one-line `exec "<binary inside the platform subpackage>"` shim; in a source checkout it's `exec node <this daemon's dist/cli.js>`. (Dev helpers like `bun run use:here` re-point it manually with identical, idempotent content.)
 
 Session info is inferred automatically from **ancestor-process markers**: when the worker launches the CLI it writes a marker keyed by the child PID (carrying sessionId / turnId), and the agent's commands walk up the process tree to the nearest marker to know which session they belong to — so the agent never passes a session id. If the process tree is broken (detached / `setsid` / deeply nested), it falls back to the `BOTMUX_SESSION_ID` environment variable.
 

--- a/docs-site/docs/zh/about.mdx
+++ b/docs-site/docs/zh/about.mdx
@@ -5,7 +5,8 @@ botmux —— 飞书话题群 ↔ AI 编程 CLI 桥接。MIT 协议开源。
 ## 链接
 
 - **GitHub**：[github.com/deepcoldy/botmux](https://github.com/deepcoldy/botmux)
-- **npm**：`npm install -g botmux` · [npmjs.com/package/botmux](https://www.npmjs.com/package/botmux)
+- **安装**：`curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh`（自包含二进制，不需要 Node）
+- **npm**（备选，需 Node ≥ 22）：`npm install -g botmux` · [npmjs.com/package/botmux](https://www.npmjs.com/package/botmux)
 - **贡献指南**：[CONTRIBUTING.md](https://github.com/deepcoldy/botmux/blob/master/CONTRIBUTING.md)
 - **许可证**：[MIT](https://github.com/deepcoldy/botmux/blob/master/LICENSE)
 

--- a/docs-site/docs/zh/faq.md
+++ b/docs-site/docs/zh/faq.md
@@ -140,7 +140,7 @@ v2.95.0 起 botmux 会检测这种"会话没真正起来"的情况并发一张�
 
 ## 怎么升级？
 
-`botmux upgrade`。会话内的 `botmux` wrapper 版本始终跟 daemon 一致，无需单独升级。
+`botmux upgrade`——它会按你的安装方式自动选路：curl 安装的原地换二进制，npm 安装的交回 `npm i -g botmux@latest`。curl 用户也可以直接重跑一遍安装命令（同样是原地升级，不会重复写 PATH）。会话内的 `botmux` wrapper 版本始终跟 daemon 一致，无需单独升级。升级后记得 `botmux restart` 让新版本生效。
 
 ## CoCo 忙时发消息丢失？
 

--- a/docs-site/docs/zh/index.md
+++ b/docs-site/docs/zh/index.md
@@ -4,7 +4,7 @@
 
 botmux 是一座桥：一个常驻 **daemon** 监听飞书消息，为每个新话题自动启动一个独立的 AI 编程 CLI 进程（Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity 等），把终端输出实时渲染成飞书**流式卡片**，并提供一个可交互的 **Web 终端**。手机、电脑、飞书三端同步——人在哪儿，编程会话就跟到哪儿。
 
-> 项目地址：<https://github.com/deepcoldy/botmux> ｜ npm：`npm install -g botmux`
+> 项目地址：<https://github.com/deepcoldy/botmux> ｜ 安装：`curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh`（自包含二进制，不需要 Node；也可 `npm i -g botmux`）
 
 ## 设计理念：不做 SDK wrapper，直接桥接 CLI
 

--- a/docs-site/docs/zh/pitfalls.md
+++ b/docs-site/docs/zh/pitfalls.md
@@ -8,7 +8,8 @@
 
 ## 环境 / 安装
 
-- **Node 太老**：v18 等没内置全局 `fetch`，`botmux setup` 会报 `fetch is not defined` / `fetch failed` 且不写 `bots.json`。→ 升级到 **Node ≥ 22**。
+- **装完 `botmux: command not found`**：`~/.botmux/bin` 没进 PATH。两种安装方式都会写你当前 shell 的启动文件，但**要开个新终端（或 source 一下）才生效**。⚠️ 已知限制：如果执行安装时 `~/.botmux/bin` 恰好已在当前进程的 PATH 里（**在 botmux 自己的 CLI 会话里装就是这种情况**——daemon 会把它注入每个会话的 PATH），`install.sh` 会认为无需处理而**不写启动文件**，于是新终端里仍然找不到。→ 在**普通终端**里装，或手动把 `export PATH="$HOME/.botmux/bin:$PATH"` 加进启动文件。
+- **Node 太老**（仅 npm 安装路径）：v18 等没内置全局 `fetch`，`npm i -g botmux` 的 postinstall 或 `botmux setup` 会报 `fetch is not defined` / `fetch failed`。→ 升级到 **Node ≥ 22**，或改用 curl 安装方式（自包含二进制，不需要 Node）。
 - **首次启动卡在人工确认**：CLI（如 Claude Code）首次会弹"信任目录 / bypass 权限"确认，没人工点过会卡住、报 `tmux send-keys` 错。→ 首次手动确认一次，之后不再出现。
 
 ## 环境变量丢失（高频）

--- a/docs-site/docs/zh/plugins.md
+++ b/docs-site/docs/zh/plugins.md
@@ -36,10 +36,15 @@ scripts**。安装第三方插件仍等同于信任其发布者。
 
 ## 创建项目
 
-Botmux 当前要求 Node.js 22 或更高版本。安装 Botmux 后运行生成器：
+插件**开发**需要 Node.js 22 或更高版本，且 `npm` 在 `PATH` 中——生成器会调用 npm
+来搭脚手架、装依赖、跑测试。（这是插件开发本身的要求；botmux 自己是自包含二进制，
+不需要 Node，见 [快速接入](/quickstart)。）
+
+按你习惯的方式装好 botmux，然后运行生成器：
 
 ```bash
-npm install -g botmux@latest
+curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh
+# 或者走 npm 安装：npm install -g botmux@latest
 
 botmux plugin init my-plugin
 cd botmux-plugin-my-plugin

--- a/docs-site/docs/zh/prerequisites.md
+++ b/docs-site/docs/zh/prerequisites.md
@@ -1,16 +1,17 @@
 # 前置要求
 
-装 botmux 之前，先确认这几样齐了——**「装完连不上 / 会话起不来」很多都是这里缺件**（Node 版本、CLI 没登录、PATH 里找不到）。
+装 botmux 之前，先确认这几样齐了——**「装完连不上 / 会话起不来」很多都是这里缺件**（CLI 没登录、tmux 没装、PATH 里找不到）。
 
 **适用**：任何要跑 botmux daemon 的机器（开发机 / devbox / 服务器）。
 **不适用**：你只是在别人已部署好的群里 @ 机器人用——那不需要本机装任何东西。
 
 ## 运行环境
 
-- **Node.js ≥ 22**（`node -v` 确认；低于 22 会有原生模块 / 语法报错）。
+- **botmux 本身：不需要 Node**。默认的 [curl 安装方式](/quickstart)装的是自包含单文件二进制，运行时已嵌在里面。**只有走 npm 安装路径时才要 Node ≥ 22**——那是执行 `npm i -g` 本身的要求，不是跑 botmux 的要求。（`botmux plugin init` 这类插件开发命令会调用 npm，也需要 Node。）
 - **AI 编程 CLI / 本地 Agent 应用**：至少一种**已安装并完成认证**、可执行文件在 `PATH` 中：
   - `claude`（Claude Code）、`codex`、`cursor-agent`（Cursor）、`gemini`、`opencode`、`coco`（Trae / CoCo）、`agy`（Antigravity）、`hermes` 等（完整 `cliId` 见 [多 CLI 适配器](/adapters)）。
   - ⚠️ botmux 只是桥接层，不代管登录——**先在终端里手动跑一次该 CLI 确认能对话**，再接 botmux。
+  - ⚠️ 这些 CLI 自己的运行时要求另算：不少是 npm 包（`claude` / `codex` / `gemini` 等），装它们仍然要 Node。「botmux 不需要 Node」说的是 botmux 自己。
 - **tmux ≥ 3.x**（**默认后端，强烈建议装**）：**默认配置下**会话后端就是 tmux，装了才能起会话——tmux 不可用时 botmux **不再静默降级 pty**，而是硬拦截并弹卡提示装 tmux（见 [tmux 会话常驻](/tmux)）。要跑无 tmux 环境，可显式选别的后端：`BACKEND_TYPE=pty` / per-bot `backendType`（`pty`/`herdr`/`zellij`）——pty 不跨 daemon 重启存活；herdr/zellij 需各自二进制。（riff 是云 Agent，不占本地后端。）
 
 ## 推荐部署形态
@@ -19,7 +20,8 @@
 
 ## 常见失败
 
-- `node -v` < 22 → 升级 Node（nvm / fnm 装 22+，注意让 botmux 所在 shell 的启动文件能读到）。
+- 装完 `botmux: command not found` → `~/.botmux/bin` 没进 PATH。安装器会写你当前 shell 的启动文件，但**要开个新终端才生效**；仍然找不到就看 [常见踩坑](/pitfalls)。
+- 走 npm 安装且 `node -v` < 22 → 升级 Node（nvm / fnm 装 22+），或直接改用 curl 安装方式，绕开 Node。
 - CLI 没在 PATH / 没登录 → 会话起不来或首条消息无响应；先手动跑通 CLI，再看 [FAQ · 会话起不来](/faq)。
 - 装了 CLI 但 botmux 找不到 → PATH 在非交互 shell 里没生效，见 [常见踩坑](/pitfalls)。
 

--- a/docs-site/docs/zh/quickstart.md
+++ b/docs-site/docs/zh/quickstart.md
@@ -1,16 +1,22 @@
 # 5 分钟快速接入
 
-> 💡 **TL;DR**：`npm i -g botmux` → `botmux setup`（**一次飞书扫码**连续建应用 + 配全权限 + 发版）→ `botmux start` → `botmux autostart enable` → 拉机器人进群开聊。
+> 💡 **TL;DR**：`curl -fsSL .../install.sh | sh` → `botmux setup`（**一次飞书扫码**连续建应用 + 配全权限 + 发版）→ `botmux start` → `botmux autostart enable` → 拉机器人进群开聊。
 
-**开始前**：先确认 [前置要求](/prerequisites)（Node ≥ 22、目标 CLI 已装并登录）——这里缺件是「装完连不上」最常见的原因。
+**开始前**：先确认 [前置要求](/prerequisites)（目标 CLI 已装并登录、tmux）——这里缺件是「装完连不上」最常见的原因。
 
 ## Step 1 · 安装
 
 ```bash
-npm install -g botmux
+curl -fsSL https://raw.githubusercontent.com/deepcoldy/botmux/master/install.sh | sh
 ```
 
-要求 **Node.js ≥ 22**，且本地已安装并登录好至少一种 AI 编程 CLI（`claude` / `codex` / `cursor-agent` / `gemini` / `opencode` / `coco` / `agy` 等）。**默认会话后端是 tmux（≥3.x），需装好**——不可用时会硬拦截弹卡、不再自动降级 pty；确需无 tmux 环境才用 `BACKEND_TYPE=pty` 或 per-bot `backendType`（`pty`/`herdr`/`zellij`）等显式后端（riff 是云 Agent，不占本地后端）。
+botmux 是**自包含单文件二进制**，运行时已嵌在里面——**装它和跑它都不需要机器上有 Node**。装到 `~/.botmux/bin/botmux`（`BOTMUX_INSTALL_DIR` 可改），按 OS/arch 自动选二进制、校验 SHA-256，并把 `~/.botmux/bin` 写进你当前 shell 的启动文件（zsh / bash / fish 各写对的那个），**开个新终端就能用**。支持 linux / macOS × x64 / arm64（Alpine 等 musl 环境自动选 musl 版）；**Windows 请在 WSL2 里装**。
+
+> 🔁 **升级**：`botmux upgrade`（原地换二进制），或重跑一遍上面那条 curl 命令——同样原地升级，不会重复往启动文件追加 PATH。装指定版本：`BOTMUX_VERSION=v3.18.8 curl … | sh`。
+
+> 📦 **也可以走 npm**（`npm install -g botmux`，需 Node ≥ 22 才能执行安装本身）：npm 包内带的是**同一个自包含二进制**（实测与 GitHub Release 资产 SHA-256 逐字节相同，按 os/arch 只装匹配的那一个），postinstall 把 `~/.botmux/bin/botmux` 指向它并同样写 PATH。区别只在**谁来装、以后谁来升**：npm 路径需要 Node，升级交回 `npm i -g botmux@latest`；curl 路径全程不碰 Node。跑起来之后两者完全一致。
+
+跑 botmux 本身不需要 Node，但**本地要装好并登录至少一种 AI 编程 CLI**（`claude` / `codex` / `cursor-agent` / `gemini` / `opencode` / `coco` / `agy` 等，它们各自的运行时要求另算）。**默认会话后端是 tmux（≥3.x），需装好**——不可用时会硬拦截弹卡、不再自动降级 pty；确需无 tmux 环境才用 `BACKEND_TYPE=pty` 或 per-bot `backendType`（`pty`/`herdr`/`zellij`）等显式后端（riff 是云 Agent，不占本地后端）。
 
 ## Step 2 · 配置（`botmux setup`）
 

--- a/docs-site/docs/zh/skill-cli.md
+++ b/docs-site/docs/zh/skill-cli.md
@@ -22,7 +22,7 @@ CLI 进入 botmux 会话时，自动获得 `~/.botmux/bin` 在 PATH 中，以及
 
 ## wrapper 机制
 
-会话内命令依赖 `~/.botmux/bin/botmux` 这个 wrapper 脚本——**daemon 启动时自动写入**并加入 worker 的 PATH。wrapper 是个极薄的 `exec node <本 daemon 的 dist/cli.js>` shim，所以**版本永远跟 daemon 一致**，不需要单独 `npm i -g`。（`bun run use:here` 之类是开发期手动改指向，与启动写入同内容、幂等。）
+会话内命令依赖 `~/.botmux/bin/botmux`——**daemon 启动时自动维护**并加入 worker 的 PATH，所以**版本永远跟 daemon 一致**，不需要单独装一份。它指向什么取决于 daemon 自己是怎么跑的：curl 安装时这个路径**就是那个自包含二进制本身**（daemon 识别出来后跳过改写，不会把自己覆盖成脚本）；npm 安装时是一行 `exec "<平台子包里的二进制>"` 的极薄 shim；源码开发态则是 `exec node <本 daemon 的 dist/cli.js>`。（`bun run use:here` 之类是开发期手动改指向，与启动写入同内容、幂等。）
 
 session 信息通过**祖先进程标记**自动推断：worker 启动 CLI 时按子进程 PID 写一份标记（含 sessionId / turnId），agent 侧的命令沿进程树向上找到最近的标记即知道自己属于哪个会话——所以 agent 无需手动传 session id。进程树被打断（detached / `setsid` / 深层嵌套）时回落到 `BOTMUX_SESSION_ID` 环境变量兜底。
 


### PR DESCRIPTION
## 背景

botmux 3.18.x 起本体是**自包含单文件二进制**（PTY 已嵌入），curl 安装路径**装它和跑它都不需要机器上有 Node**。但文档仍把 npm 摆在首位、curl 藏在折叠块里，并把 `Node >= 22` 列为运行环境第一条前提。

## 改了什么

**README.md / README.en.md** — 5 分钟接入首屏换成 curl（原本折叠着的那条提到主位），npm 收进折叠块；首屏徽章 `node >= 22` → `no Node required`（该徽章位置最容易被读成硬性前提）。

**docs-site zh/en 各 8 篇** — `quickstart` / `prerequisites` / `index` / `about` / `plugins` / `pitfalls` / `faq` / `skill-cli`。

## 为什么不只是换个命令

**① `prerequisites` 的前提本身是错的。** 原文把 `Node.js ≥ 22` 列为运行环境第一条。这对默认（curl）路径**不成立**，只对 npm 安装路径与 `botmux plugin init`（会 shell 出 npm）成立，已按此改写。

**② 同时补了反向澄清。** 要接的 CLI（`claude` / `codex` / `gemini` 等）自身多为 npm 包，装它们**仍然需要 Node**。「botmux 不需要 Node」只说 botmux 自己——不写清楚容易被读成整机免 Node，这是比原文更糟的误导。

**③ `skill-cli` 的 wrapper 描述只覆盖了一种形态。** 原文只写 `exec node <dist/cli.js>`，那是**源码开发态**。已按 curl / npm / 源码三态分别说明（curl 态该路径**就是二进制本身**，daemon 识别后跳过改写，不会把自己覆盖成脚本）。

## 影响面

**纯文档，零 `src/` 变更**，不影响任何平台 / CLI / 会话类型的行为。

docs-site 的 `.md` **未引入裸 HTML**：该目录 `.md` 现存 0 处裸 HTML（只有 `.mdx` 里有），所以原先写的 `<details>` 折叠块改用这些文件本来就在用的引用块写法。README 里的 `<details>` 是原文既有、GitHub 正常渲染，保留。

⚠️ **docs-site 未能本地 build 验证**：`docs-site/node_modules` 不存在，而按 CLAUDE.md 铁律 worktree 里不能跑 install。上述「不引入裸 HTML」即是为此降低风险。

## 实测验证

均在隔离 HOME + `BOTMUX_INSTALL_DIR` 下进行，**全程未触碰共享 launcher**（事后核 `~/.botmux/bin/botmux` sha256 与会话开始时逐字相同）。

| 文档里的说法 | 判据 | 结果 |
|---|---|---|
| 不需要 Node | 构造真正无 `node`/`npm`/`bun` 的 PATH 跑 `--version` + `setup list --json` | ✅ 均通过 |
| 「同一个二进制」 | `npm pack botmux-linux-x64@3.18.9` 解出的 binary vs GitHub Release 资产 sha256 | ✅ 逐字节相同 `6627a1a0…` |
| 重跑 curl = 原地升级 | 钉 `v3.18.8` → 重跑 → 版本 / inode / PATH 行数 | ✅ `3.18.8`→`3.18.9`，inode 变化，PATH 行仍为 1 |
| musl 自动选型 | 伪造 `ldd` 双向对照 | ✅ musl 主机选 `-musl`，glibc 主机不选 |
| 不支持平台明确报错 | 伪造 `uname -m` 为 sparc64 | ✅ exit 1，且**预置的旧安装 sha256 不变** |
| 二进制跑不起来时保留原版 | 造坏 ELF 走它自己的 staging 探测 | ✅ 拒绝替换，旧版本仍可执行 |
| 各 shell 写对启动文件 | 分别以 zsh / bash 跑真实 install.sh | ✅ zsh→`.zshenv`，bash→`.bashrc` + 登录文件；fish→`conf.d/botmux.fish`（经 `pathEntryTargets` 核对） |

⚠️ **一处自我修正**：第一次测「不需要 Node」我用的是 `PATH=/usr/bin:/bin`，而**那里面就有 `/usr/bin/node`** — 等于没测。重做（软链只放 sh/env/ls/cat/uname，确认 `node`/`npm`/`bun` 三者皆 ABSENT）后结论才成立。

## 🔴 顺带发现一个真 bug（本 PR 只如实记录，不在此修）

`install.sh:215` 用 `case ":$PATH:"` 判断是否需要写启动文件 —— **问的是「执行安装那个进程的 PATH」，而该问「用户以后开的终端」**。这与 **#1117** 在 npm 侧修掉的是**同一个错**，curl 侧没跟上（`postinstall-bin.mjs:255` 有一整段 `⚠️ DO NOT GATE THIS ON process.env.PATH` 的注释专门讲这件事）。

后果：当 `~/.botmux/bin` 已在当前 PATH 中时 —— **在 botmux 自己的 CLI 会话里安装就是这种情况**，daemon 会把它注入每个会话的 PATH（`prependBotmuxBin`，5 处调用）—— 安装**零文件零提示 exit 0**，新终端里仍 `command not found`。

实测复现：隔离 HOME + 把 install dir 预置进 PATH ⟹ `$HOME` 下**一个启动文件都没写**（对照组：同样条件但不预置 PATH，正常写出两个文件）。

已在 `pitfalls` 双语中写成「已知限制 + 绕法」，没有假装它不存在。**修法建议**：把 `install-path-entry.mjs` 那套「问启动文件」的判据搬到 `install.sh`（#1117 已有现成范式与反变异用例可抄）—— 需要的话我另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
