### PR TITLE
fix(install): install.sh 的 PATH 守卫问错问题，装完新终端仍找不到 botmux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -211,50 +211,65 @@ append_path_line() {  # $1=file  $2=line
   printf '%s\n' "✓ added $INSTALL_DIR to PATH in $1"
 }
 
-case ":$PATH:" in
-  *":$INSTALL_DIR:"*) : ;;  # already on PATH
+# ⚠️ DO NOT WRAP THIS IN A `$PATH` CHECK. It used to be inside
+#   case ":$PATH:" in *":$INSTALL_DIR:"*) : ;;  # already on PATH
+# which asks "is INSTALL_DIR on the PATH of the process running the installer?" —
+# the wrong question. What decides whether `botmux` works is whether the user's
+# FUTURE shells get it, i.e. whether a startup file says so. The two come apart
+# whenever the installing shell has INSTALL_DIR on PATH transiently, and botmux
+# itself creates exactly that situation: the daemon prepends ~/.botmux/bin to the
+# PATH of every CLI session it spawns (5 × prependBotmuxBin). So running this
+# installer from inside a botmux session wrote NO startup file and printed NO
+# hint — exit 0, and `botmux` still missing from every new terminal. MEASURED
+# with an isolated HOME: with INSTALL_DIR pre-seeded onto PATH, not one startup
+# file was written; the same run without it correctly wrote two.
+#
+# This is the same defect #1117 fixed on the npm side; the guard rationale is
+# kept verbatim in scripts/postinstall-bin.mjs. Keep the two in step.
+#
+# Skipping the check costs nothing, because BOTH layers below are already
+# idempotent and neither depends on the current PATH:
+#   · path_line_present() — don't append a line the file already has
+#   · the emitted line itself — a `case` guard so re-sourcing cannot grow PATH
+# $PATH stays outside the quotes so it still expands; the dir cannot.
+# The STATEMENT must be idempotent too, not just the file write: an
+# unconditional prepend re-runs on every shell startup, so nested or
+# re-sourced shells keep growing PATH (measured: the dir appeared twice at
+# nesting depth 2). `case` is POSIX, needs no subshell, and the `:` padding
+# makes it an exact ELEMENT test so `<dir>-old` never satisfies it.
+posix_line="case \":\$PATH:\" in *:$QUOTED_DIR:*) ;; *) export PATH=$QUOTED_DIR\":\$PATH\" ;; esac  $MARKER"
+wrote=0
+case "$(basename "${SHELL:-}")" in
+  *zsh*)
+    # zsh reads its dotfiles from $ZDOTDIR when set, else $HOME. Writing
+    # $HOME/.zshenv on a ZDOTDIR machine produces a file zsh never reads.
+    f="${ZDOTDIR:-$HOME}/.zshenv"
+    if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
+    ;;
+  *fish*)
+    # fish's config dir is $XDG_CONFIG_HOME/fish, default ~/.config/fish.
+    f="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/botmux.fish"
+    if path_line_present "$f"; then wrote=1
+    # fish: `contains` is its own exact list-element test.
+    else append_path_line "$f" "contains $QUOTED_DIR \$PATH; or set -gx PATH $QUOTED_DIR \$PATH  $MARKER" && wrote=1; fi
+    ;;
+  *bash*)
+    # .bashrc (interactive) and the login file are disjoint; write both, but
+    # never CREATE a login file that would shadow an existing one.
+    for f in "$HOME/.bashrc" "$(bash_login_file)"; do
+      if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
+    done
+    ;;
   *)
-    # $PATH stays outside the quotes so it still expands; the dir cannot.
-    # The STATEMENT must be idempotent too, not just the file write: an
-    # unconditional prepend re-runs on every shell startup, so nested or
-    # re-sourced shells keep growing PATH (measured: the dir appeared twice at
-    # nesting depth 2). `case` is POSIX, needs no subshell, and the `:` padding
-    # makes it an exact ELEMENT test so `<dir>-old` never satisfies it.
-    posix_line="case \":\$PATH:\" in *:$QUOTED_DIR:*) ;; *) export PATH=$QUOTED_DIR\":\$PATH\" ;; esac  $MARKER"
-    wrote=0
-    case "$(basename "${SHELL:-}")" in
-      *zsh*)
-        # zsh reads its dotfiles from $ZDOTDIR when set, else $HOME. Writing
-        # $HOME/.zshenv on a ZDOTDIR machine produces a file zsh never reads.
-        f="${ZDOTDIR:-$HOME}/.zshenv"
-        if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
-        ;;
-      *fish*)
-        # fish's config dir is $XDG_CONFIG_HOME/fish, default ~/.config/fish.
-        f="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/botmux.fish"
-        if path_line_present "$f"; then wrote=1
-        # fish: `contains` is its own exact list-element test.
-        else append_path_line "$f" "contains $QUOTED_DIR \$PATH; or set -gx PATH $QUOTED_DIR \$PATH  $MARKER" && wrote=1; fi
-        ;;
-      *bash*)
-        # .bashrc (interactive) and the login file are disjoint; write both, but
-        # never CREATE a login file that would shadow an existing one.
-        for f in "$HOME/.bashrc" "$(bash_login_file)"; do
-          if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
-        done
-        ;;
-      *)
-        f="$HOME/.profile"
-        if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
-        ;;
-    esac
-    if [ "$wrote" = 1 ]; then
-      printf '%s\n' "  open a new terminal (or re-source that file) and \`botmux\` will be on PATH"
-    else
-      printf '\n%s\n' "Add $INSTALL_DIR to your PATH, e.g.:"
-      printf '  %s\n' "echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.profile && . ~/.profile"
-    fi
+    f="$HOME/.profile"
+    if path_line_present "$f"; then wrote=1; else append_path_line "$f" "$posix_line" && wrote=1; fi
     ;;
 esac
+if [ "$wrote" = 1 ]; then
+  printf '%s\n' "  open a new terminal (or re-source that file) and \`botmux\` will be on PATH"
+else
+  printf '\n%s\n' "Add $INSTALL_DIR to your PATH, e.g.:"
+  printf '  %s\n' "echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.profile && . ~/.profile"
+fi
 
 printf '\n%s\n' "Next: botmux setup"

--- a/test/install-sh-path-entry.test.ts
+++ b/test/install-sh-path-entry.test.ts
@@ -1,0 +1,279 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * install.sh (the `curl … | sh` installer) — writing the PATH entry.
+ *
+ * WHY THIS FILE EXISTS: since #1047 the npm package has no `bin` field, so the
+ * launcher at `$INSTALL_DIR/botmux` is the ONLY `botmux` command there is. If no
+ * startup file puts that directory on PATH, a fully successful install still
+ * leaves the user with `botmux: command not found` — and, because the installer
+ * exits 0 and prints nothing, with no indication of why.
+ *
+ * The bug this file pins: the block used to be wrapped in
+ *
+ *     case ":$PATH:" in *":$INSTALL_DIR:"*) : ;;   # already on PATH
+ *
+ * which asks whether the directory is on the PATH of the process RUNNING the
+ * installer. What decides whether `botmux` works is whether the user's FUTURE
+ * shells get it — a property of their startup files, not of this process. botmux
+ * itself drives the two apart: the daemon prepends `~/.botmux/bin` to the PATH of
+ * every CLI session it spawns, so installing from inside a botmux session hit the
+ * skip branch and wrote nothing at all. Same defect as #1117 on the npm side.
+ *
+ * These tests EXECUTE the real block extracted from install.sh against an isolated
+ * HOME. Asserting on the script's text instead would pass just as happily with the
+ * logic deleted — and, more to the point, the old code was textually reasonable;
+ * only its BEHAVIOUR under a pre-seeded PATH was wrong.
+ */
+const INSTALL_SH = resolve(import.meta.dirname, '../install.sh');
+const dirs: string[] = [];
+const tmp = () => {
+  const d = mkdtempSync(join(tmpdir(), 'botmux-install-path-'));
+  dirs.push(d);
+  return d;
+};
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+interface RunOpts {
+  /** Put INSTALL_DIR on the PATH of the installing process (the regression case). */
+  dirAlreadyOnPath?: boolean;
+  /** `$SHELL` basename the installer dispatches on. */
+  shell?: string;
+  /** Pre-existing files in the fake HOME, as relative path → contents. */
+  seed?: Record<string, string>;
+  /**
+   * Like `seed`, but the contents are built from the (per-run, temporary)
+   * INSTALL_DIR. Needed for the "user already added this directory themselves"
+   * case: a literal seed cannot name a directory that does not exist yet.
+   */
+  seedWithInstallDir?: Record<string, (installDir: string) => string>;
+  /** Run the block twice in the same HOME (idempotency). */
+  twice?: boolean;
+}
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  /** Relative path → contents, for every file in the fake HOME. */
+  files: Record<string, string>;
+  installDir: string;
+}
+
+/**
+ * Extract install.sh's PATH-writing section — the two helpers it calls, the
+ * quoting it depends on, and the section itself — and run it with a controlled
+ * HOME, SHELL and PATH.
+ *
+ * Extraction is anchored on shell-syntax landmarks (function definitions, the
+ * `sq=`…`QUOTED_DIR=` pair) rather than on comment text, so rewording a comment
+ * cannot silently empty the harness. `assertHarnessIsWellFormed` then proves the
+ * pieces actually arrived: without it, "no files written" would be produced both
+ * by the bug AND by a broken extraction, and the two are indistinguishable.
+ */
+function runPathBlock(opts: RunOpts = {}): RunResult {
+  const base = tmp();
+  const home = join(base, 'home');
+  const installDir = join(base, 'bin');
+  mkdirSync(home, { recursive: true });
+  mkdirSync(installDir, { recursive: true });
+
+  for (const [rel, contents] of Object.entries(opts.seed ?? {})) {
+    const target = join(home, rel);
+    mkdirSync(join(target, '..'), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  for (const [rel, build] of Object.entries(opts.seedWithInstallDir ?? {})) {
+    const target = join(home, rel);
+    mkdirSync(join(target, '..'), { recursive: true });
+    writeFileSync(target, build(installDir));
+  }
+
+  const src = readFileSync(INSTALL_SH, 'utf-8');
+  const lines = src.split('\n');
+  const lineIndex = (re: RegExp, what: string): number => {
+    const i = lines.findIndex(l => re.test(l));
+    expect(i, `install.sh must still contain ${what}`).toBeGreaterThanOrEqual(0);
+    return i;
+  };
+  const section = (startRe: RegExp, endRe: RegExp): string => {
+    const from = lineIndex(startRe, String(startRe));
+    const rel = lines.slice(from + 1).findIndex(l => endRe.test(l));
+    expect(rel, `install.sh must still contain ${endRe} after ${startRe}`).toBeGreaterThanOrEqual(0);
+    return lines.slice(from, from + rel + 2).join('\n');
+  };
+
+  // ⚠️ THE TAIL MUST BE TAKEN WHOLE, from the end of the last helper to EOF.
+  // An earlier version of this harness started at `posix_line=`, which made the
+  // tests BLIND to the very bug they exist for: a gate placed ABOVE that line
+  // (exactly where the original `case ":$PATH:"` sat) simply was not extracted,
+  // so re-introducing it left all of them green. Measured — the mutant survived.
+  // Anything between the helpers and EOF is part of the decision being tested.
+  const afterHelpers = lineIndex(/^append_path_line\(\)/, 'append_path_line()');
+  const helperEnd = afterHelpers + 1
+    + lines.slice(afterHelpers + 1).findIndex(l => /^\}/.test(l));
+  const tail = lines.slice(helperEnd + 1).join('\n');
+
+  const harness = [
+    'set -u',
+    `INSTALL_DIR="${installDir}"`,
+    "MARKER='# added by botmux installer'",
+    section(/^sq=/, /^QUOTED_DIR=/),
+    section(/^path_line_present\(\)/, /^\}/),
+    section(/^bash_login_file\(\)/, /^\}/),
+    section(/^append_path_line\(\)/, /^\}/),
+    tail,
+  ].join('\n');
+
+  const script = join(base, 'harness.sh');
+  writeFileSync(script, `${harness}\n`);
+  assertHarnessIsWellFormed(script, harness);
+
+  const path = opts.dirAlreadyOnPath ? `${installDir}:/usr/bin:/bin` : '/usr/bin:/bin';
+  const env = { PATH: path, HOME: home, SHELL: `/bin/${opts.shell ?? 'bash'}` };
+  let stdout = '';
+  let status = 0;
+  const once = () => {
+    try {
+      stdout += execFileSync('sh', [script], { encoding: 'utf-8', env });
+    } catch (err) {
+      const e = err as { status?: number; stdout?: string; stderr?: string };
+      status = e.status ?? 1;
+      stdout += `${e.stdout ?? ''}${e.stderr ?? ''}`;
+    }
+  };
+  once();
+  if (opts.twice) once();
+
+  return { status, stdout, files: readTree(home), installDir };
+}
+
+/**
+ * Guard against a vacuous run. "Zero startup files" is the exact symptom this
+ * file tests for, so a harness that failed to assemble would look like a PASS on
+ * the buggy branch and a FAIL on the fixed one — i.e. it would invert the result
+ * rather than error out. Prove the pieces are present before drawing conclusions.
+ */
+function assertHarnessIsWellFormed(script: string, harness: string): void {
+  execFileSync('sh', ['-n', script]);                 // parses as POSIX sh
+  expect(harness).toContain('append_path_line()');    // the writer
+  expect(harness).toContain('path_line_present()');   // the idempotency check
+  expect(harness).toContain('.zshenv');               // per-shell dispatch survived
+  expect(harness).toContain('posix_line=');           // the line being written
+}
+
+function readTree(root: string, prefix = ''): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) Object.assign(out, readTree(join(root, entry.name), rel));
+    else out[rel] = readFileSync(join(root, entry.name), 'utf-8');
+  }
+  return out;
+}
+
+describe('install.sh — PATH entry is written for the user\'s future shells', () => {
+  it('REGRESSION: writes the startup file even when INSTALL_DIR is already on the installing PATH', () => {
+    // THE BUG. botmux's own daemon prepends ~/.botmux/bin to every CLI session's
+    // PATH, so this is the shape of "user installs from inside a botmux session":
+    // the old `case ":$PATH:"` gate skipped everything and exited 0 silently, and
+    // `botmux` stayed missing from every new terminal.
+    const r = runPathBlock({ dirAlreadyOnPath: true, shell: 'bash' });
+
+    expect(Object.keys(r.files).sort()).toEqual(['.bash_profile', '.bashrc']);
+    for (const contents of Object.values(r.files)) {
+      expect(contents).toContain(r.installDir);
+      expect(contents).toContain('# added by botmux installer');
+    }
+    // And it must SAY so — a silent success is what made the original report
+    // ("installed, still command not found") so hard to act on.
+    expect(r.stdout).toContain('open a new terminal');
+  });
+
+  it('the pre-seeded PATH makes no difference: same files either way', () => {
+    // The A/B that isolates the variable. Before the fix these two disagreed
+    // (2 files vs 0); the property we now want is that PATH is simply irrelevant.
+    const on = runPathBlock({ dirAlreadyOnPath: true, shell: 'bash' });
+    const off = runPathBlock({ dirAlreadyOnPath: false, shell: 'bash' });
+    expect(Object.keys(on.files).sort()).toEqual(Object.keys(off.files).sort());
+  });
+
+  it('still writes the right file per shell', () => {
+    // zsh reads .zshenv in every invocation mode; bash needs BOTH .bashrc
+    // (interactive) and its login file; anything else falls back to .profile.
+    expect(Object.keys(runPathBlock({ shell: 'zsh' }).files)).toEqual(['.zshenv']);
+    expect(Object.keys(runPathBlock({ shell: 'bash' }).files).sort())
+      .toEqual(['.bash_profile', '.bashrc']);
+    expect(Object.keys(runPathBlock({ shell: 'ksh' }).files)).toEqual(['.profile']);
+  });
+
+  it('bash: appends to an EXISTING login file rather than creating .bash_profile', () => {
+    // bash's login file is the FIRST of .bash_profile → .bash_login → .profile
+    // that exists. Creating .bash_profile when the user's login config lives in
+    // .profile would stop that file from ever being read again.
+    const r = runPathBlock({ shell: 'bash', seed: { '.profile': 'export EDITOR=vi\n' } });
+    expect(Object.keys(r.files).sort()).toEqual(['.bashrc', '.profile']);
+    expect(r.files['.profile']).toContain('export EDITOR=vi');   // preserved
+    expect(r.files['.profile']).toContain(r.installDir);         // and extended
+  });
+
+  it('IDEMPOTENT: running twice does not append a second line', () => {
+    // Removing the PATH gate must not turn re-running the installer (the
+    // documented upgrade gesture) into PATH growth. Two independent layers
+    // prevent it: path_line_present() skips the append, and the emitted line
+    // guards itself with its own `case` so re-sourcing cannot grow $PATH.
+    const r = runPathBlock({ shell: 'bash', twice: true });
+    for (const contents of Object.values(r.files)) {
+      expect(contents.split('# added by botmux installer').length - 1).toBe(1);
+    }
+  });
+
+  it('respects a hand-written PATH line already naming this directory', () => {
+    // The user solved it themselves; adding a redundant second line would be
+    // noise. This needs the seed to name the SAME directory the run will use,
+    // which is why it goes through seedWithInstallDir — a literal seed would
+    // name some other run's tmp dir and the assertion would pass vacuously.
+    const r = runPathBlock({
+      shell: 'zsh',
+      seedWithInstallDir: { '.zshenv': dir => `export PATH="${dir}:$PATH"\n` },
+    });
+    expect(r.files['.zshenv']).not.toContain('# added by botmux installer');
+    expect(r.files['.zshenv'].trimEnd().split('\n')).toHaveLength(1);
+    // Treated as handled, so the user is told they are set — not given a fallback.
+    expect(r.stdout).toContain('open a new terminal');
+  });
+
+  it('a SIBLING/child directory in the startup file does not count as handled', () => {
+    // Substring matching produced measured false positives (`<dir>-old`,
+    // `/backup<dir>`, `<dir>/other`) that each left the real directory unwritten.
+    for (const suffix of ['-old', '/other']) {
+      const r = runPathBlock({
+        shell: 'zsh',
+        seedWithInstallDir: { '.zshenv': dir => `export PATH="${dir}${suffix}:$PATH"\n` },
+      });
+      expect(r.files['.zshenv'], `PATH containing <dir>${suffix} must not count`)
+        .toContain('# added by botmux installer');
+    }
+  });
+
+  it('SOURCE PIN: the block is not gated on the installing process\'s PATH', () => {
+    // Compare CODE ONLY: the fix deliberately KEEPS an explanatory comment quoting
+    // the old `case ":$PATH:"` gate, so matching the whole file would let this
+    // assertion trip over its own documentation.
+    const code = readFileSync(INSTALL_SH, 'utf-8')
+      .split('\n')
+      .filter(l => !/^\s*#/.test(l))
+      .join('\n');
+    // The emitted LINE still contains a `case ":$PATH:"` guard — that one is
+    // correct and load-bearing (it runs in the user's shell, not here). What must
+    // not exist is a gate around INSTALL_DIR deciding whether to write at all.
+    expect(code).not.toMatch(/case\s+":\$PATH:"\s+in\s*\n\s*\*":\$INSTALL_DIR:"\*/);
+    expect(code).toMatch(/posix_line=.*case .*PATH/);   // the self-guarding line survives
+    expect(code).toMatch(/path_line_present/);          // file-level idempotency survives
+  });
+});


### PR DESCRIPTION
## 问题

`install.sh` 在写启动文件前有一道闸：

```sh
case ":$PATH:" in
  *":$INSTALL_DIR:"*) : ;;  # already on PATH
```

它问的是「**执行安装那个进程**的 PATH 里有没有 `INSTALL_DIR`」，而决定 `botmux` 能不能用的是「**用户以后开的终端**有没有」——那是**启动文件的属性**，不是当前进程的属性。

这与 **#1117** 在 npm 侧（`scripts/postinstall-bin.mjs`）修掉的是**同一个错**，curl 侧当时没跟上。那边留了整段 `⚠️ DO NOT GATE THIS ON process.env.PATH` 的注释讲这件事。

**两者何时会分叉：botmux 自己就制造这个场景。** daemon 会把 `~/.botmux/bin` 前置进它 spawn 的**每个 CLI 会话**的 PATH（5 处 `prependBotmuxBin`）。所以在 botmux 会话里跑这个安装器 ⟹ 命中 skip 分支 ⟹ **零文件、零提示、exit 0**，而新终端里 `botmux` 依然 `command not found`。而自 #1047 起 npm 包没有 `bin` 字段，**那个 launcher 是唯一入口**，PATH 没配就等于没装上。

## 改法

删掉这层外壳，让写启动文件**无条件执行**。不需要这道闸，因为下面本来就有**两层各自独立的幂等**，且都不依赖当前 PATH：

| 层 | 作用 |
|---|---|
| `path_line_present()` | 文件里已有的行不再追加 |
| 写出去的那行自带 `case` 守卫 | 重复 source 也不会把 PATH 撑大 |

原注释整段保留并改写成「**为什么不能加这道闸**」，与 `postinstall-bin.mjs` 里同款说明保持一致——下一个人想「顺手优化一下」时能看到理由。

## 实测：四格 A/B（隔离 HOME）

|  | dir 不在 PATH | dir 已在 PATH |
|---|---|---|
| **修前** | 写 2 个文件 | **写 0 个（exit 0，无任何提示）← bug** |
| **修后** | 写 2 个文件 | 写 2 个文件 |

修后两列一致 = **PATH 不再影响结果**，这正是要的性质。

## 新增回归测试 `test/install-sh-path-entry.test.ts`（8 用例）

抽出 install.sh 里**真实的 PATH 段执行**，而不是断言脚本文本——原代码**文本上完全合理**，错的只是「预置 PATH 下的行为」，纯文本断言抓不到。做法沿用已有的 `install-sh-musl-asset.test.ts`。

### ⚠️ 第一版 harness 对本 bug 完全失明（实测，已修）

harness 起初从 `posix_line=` 开始抽。把闸**重新加回去**（就加在那行上面，正是原 bug 的位置）时 —— **8 个用例全绿**。因为那道闸根本没被抽进来。现改为**从最后一个 helper 之后一路取到 EOF**，任何位置的闸都在范围内。

另加 `assertHarnessIsWellFormed()`：本文件的症状**就是「零文件」**，而抽取失败也会产出零文件，**两者无法区分**（甚至会把结论反过来：buggy 分支看着像 PASS）。所以先证明 harness 语法合法、且真的含有 writer / 幂等检查 / per-shell 分发，再下结论。

### 反变异 6/6 全红

| 变异 | 结果 |
|---|---|
| M1 把 `$PATH` 闸加回去（**即本 bug**） | 2 failed |
| M2 per-shell 分发恒走 `.profile` | 4 failed |
| M3 `path_line_present` 恒 false | 2 failed |
| M4 写出的行丢掉自带 `case` 守卫 | 1 failed |
| M5 bash 只写 `.bashrc` 不写登录文件 | 3 failed |
| M6 awk 整元素比对改前缀比对（兄弟目录假阳性） | 1 failed |

每次变异后立即 `cp` 还原并 `cmp` 校验（`restored ✓`）。

⚠️ 按惯例声明边界：**反变异全红只证明守卫对我想到的那 6 种退化有牙**，不等于覆盖完备。欢迎 reviewer 补变异体。

## 影响面

只动 `install.sh` 的 PATH 段 + 新增一个测试文件，**不含 `src/` 变更**。不影响 npm / pnpm / bun 安装路径（那半边由 #1117 / #1119 / #1122 负责），也不影响任何平台 / CLI / 会话类型的运行时行为。

## 测试

- 新文件 **8/8 绿**；`sh -n install.sh` 语法通过。
- `install-sh-path-entry` + `install-sh-musl-asset` + `install-path-entry` + `npm-binary-distribution` 并集：**99 passed**。
- ⚠️ 其中 `npm-binary-distribution` 有 **2 条失败**（`THE bun/pnpm BUG: a global LAYOUT…` / `SAFETY: a LOCAL dependency install…`）。**已在干净 `origin/master` 的独立 worktree 上同样跑出 `2 failed | 33 passed`，逐字相同** ⟹ 属既有失败，与本 PR 无关（本 PR 没碰 `postinstall-bin.mjs`）。

相关：#1117（npm 侧同款修复）· #1128（文档改推 curl 为默认安装方式，其中已把本问题写成「已知限制」，本 PR 合入后应把那段删掉）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
