### PR TITLE
fix(sandbox): 沙箱 Codex 注入宿主 CA bundle

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -25,7 +25,7 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
 import { compileToBwrap, type FsPolicy } from '../cli/fs-policy.js';
-import { PROXY_ENV_KEYS } from '../../utils/child-env.js';
+import { CA_BUNDLE_ENV_KEYS, PROXY_ENV_KEYS } from '../../utils/child-env.js';
 import { isStandaloneBinary } from '../../core/self-spawn.js';
 import {
   MCP_GATEWAY_REQUIRED_ENV,
@@ -837,6 +837,13 @@ export function prepareDirectSandbox(opts: {
     env[MCP_GATEWAY_REQUIRED_ENV] = '1';
   }
   for (const k of PROXY_ENV_KEYS) {
+    const v = process.env[k];
+    if (typeof v === 'string' && v) env[k] = v;
+  }
+  // Authority-symmetric with the proxy keys: a CA bundle the operator set (or
+  // the worker resolved) must survive into the bwrap child, or TLS breaks for
+  // the same reason this feature exists on darwin.
+  for (const k of CA_BUNDLE_ENV_KEYS) {
     const v = process.env[k];
     if (typeof v === 'string' && v) env[k] = v;
   }

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -4,7 +4,7 @@ import { basename } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { probeTmuxFunctional, scrubTmuxServerGlobalEnv, tmuxEnv } from '../../setup/ensure-tmux.js';
-import { BOTMUX_INJECTED_ENV_KEYS, PROXY_ENV_KEYS, REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
+import { BOTMUX_INJECTED_ENV_KEYS, CA_BUNDLE_ENV_KEYS, PROXY_ENV_KEYS, REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
 import { sanitizePerBotEnv } from '../../core/per-bot-env.js';
 import { logger } from '../../utils/logger.js';
 import { isExecutable } from '../../utils/executable.js';
@@ -723,6 +723,15 @@ export function buildBotmuxEnvAssignments(
     // CLI reaches the API even when the tmux server was started without proxy
     // in its global env, or the shell rcfile doesn't set them.
     for (const key of PROXY_ENV_KEYS) {
+      const val = env[key];
+      if (val === undefined) continue;
+      out.push(`${key}=${val}`);
+    }
+    // CA bundle: same treatment as proxy vars (see CA_BUNDLE_ENV_KEYS). Emitted
+    // per pane so a value the worker resolved for a sandboxed Codex reaches the
+    // CLI and overrides a stale server-global one, while a user's own value on
+    // their tmux server survives untouched for every other CLI.
+    for (const key of CA_BUNDLE_ENV_KEYS) {
       const val = env[key];
       if (val === undefined) continue;
       out.push(`${key}=${val}`);

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -350,11 +350,18 @@ export function buildSeatbeltProfile(
 //     cold-spawn ONCE under the new pending→commit contract — closing the INSTALLED
 //     BASE risk, not just new spawns. (A legacy no-state marker is now version-
 //     rejected, so validators no longer need to tolerate `state===undefined`.)
+//   · 11 → 12: sandboxed Codex receives a host-selected SSL_CERT_FILE so npm
+//     Codex's Rust TLS stack can use a stable CA bundle inside Seatbelt. Warm
+//     reattach would keep the old process environment and continue to fail on
+//     UnknownIssuer, so existing panes must cold-spawn once.
 // #709 (→8) merged first; this PR (#714) rebased on top and takes 9. Numbers stay
 // strictly monotonic — a pane at any intermediate version must be rejected so it
 // cold-spawns under the current contract rather than bypassing a migration. Version
-// 12 adds the session-scoped plugin-card selector snapshot to the pane contract.
-export const ISOLATION_PANE_MARKER_VERSION = 12;
+// 12 adds the session-scoped plugin-card selector snapshot to the pane contract; 13
+// adds the host CA bundle startup env a sandboxed Codex pane needs — a pane spawned
+// before it keeps its ORIGINAL environment, so it would never see SSL_CERT_FILE and
+// would keep failing TLS on UnknownIssuer with no output at all.
+export const ISOLATION_PANE_MARKER_VERSION = 13;
 
 export type IsolationCapability = 'credential' | 'read' | 'write';
 

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -420,14 +420,6 @@ export const BOTMUX_INJECTED_ENV_KEYS = [
   // Per-bot isolated data roots for Claude/Codex.
   'CLAUDE_CONFIG_DIR',
   'CODEX_HOME',
-  // CA bundle for sandboxed Codex, needed by npm Codex's Rust TLS stack on macOS
-  // when trust-store discovery comes up empty inside Seatbelt. Precedence is
-  // operator-first: a value in the daemon's own environment is inherited by
-  // childEnv and kept as-is; only when there is none does the worker select a
-  // host bundle (utils/darwin-ca-bundle). Listed here so the tmux backend
-  // forwards the resolved value into the pane rather than letting the pane
-  // inherit whatever the shared tmux server's global env happens to hold.
-  'SSL_CERT_FILE',
   // CLI-specific non-interactive/resume startup controls.
   'CLAUDE_CODE_RESUME_TOKEN_THRESHOLD',
   'CJADK_INTERACTIVE',
@@ -535,6 +527,15 @@ export const PROXY_ENV_KEYS = [
   'no_proxy', 'NO_PROXY', 'all_proxy', 'ALL_PROXY',
 ] as const;
 
+/** CA-bundle vars. Same shape as {@link PROXY_ENV_KEYS} and excluded from
+ *  BOTMUX_INJECTED_ENV_KEYS for the same reason: that list also drives the pane
+ *  `unset` clause and scrubTmuxServerGlobalEnv(), so listing a standard,
+ *  user-ownable variable there would DELETE the CA bundle a user configured for
+ *  their own tmux server / rcfile — and it would do so for every CLI on every
+ *  platform, not just the sandboxed Codex this exists for. Forwarded per pane by
+ *  buildBotmuxEnvAssignments instead. */
+export const CA_BUNDLE_ENV_KEYS = ['SSL_CERT_FILE'] as const;
+
 const TMUX_CLIENT_STRIP_KEYS: ReadonlySet<string> = new Set([
   ...BOTMUX_INJECTED_ENV_KEYS,
   ...REDACTED_CHILD_ENV_KEYS,
@@ -546,6 +547,9 @@ const TMUX_CLIENT_STRIP_KEYS: ReadonlySet<string> = new Set([
   // via buildBotmuxEnvAssignments reads opts.env directly, so it's unaffected
   // by this client-side strip.
   ...PROXY_ENV_KEYS,
+  // Same reasoning as the proxy keys: keep a daemon-side CA bundle out of the
+  // shared server's global env, but never delete one the user set there.
+  ...CA_BUNDLE_ENV_KEYS,
 ]);
 
 const TMUX_SERVER_GLOBAL_SCRUB_KEYS: ReadonlySet<string> = new Set([

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -420,6 +420,14 @@ export const BOTMUX_INJECTED_ENV_KEYS = [
   // Per-bot isolated data roots for Claude/Codex.
   'CLAUDE_CONFIG_DIR',
   'CODEX_HOME',
+  // CA bundle for sandboxed Codex, needed by npm Codex's Rust TLS stack on macOS
+  // when trust-store discovery comes up empty inside Seatbelt. Precedence is
+  // operator-first: a value in the daemon's own environment is inherited by
+  // childEnv and kept as-is; only when there is none does the worker select a
+  // host bundle (utils/darwin-ca-bundle). Listed here so the tmux backend
+  // forwards the resolved value into the pane rather than letting the pane
+  // inherit whatever the shared tmux server's global env happens to hold.
+  'SSL_CERT_FILE',
   // CLI-specific non-interactive/resume startup controls.
   'CLAUDE_CODE_RESUME_TOKEN_THRESHOLD',
   'CJADK_INTERACTIVE',

--- a/src/utils/darwin-ca-bundle.ts
+++ b/src/utils/darwin-ca-bundle.ts
@@ -1,0 +1,97 @@
+/**
+ * CA bundle selection for a sandboxed Codex CLI on macOS.
+ *
+ * npm Codex talks TLS through a Rust stack that does not read the macOS
+ * keychain. Outside the sandbox it still finds a usable trust store; inside
+ * Seatbelt that discovery comes up empty and every request dies with
+ * `UnknownIssuer` — which surfaces as a session that produces NOTHING at all
+ * (the model API call itself is TLS), so it reads as "the bot is dead" rather
+ * than as a certificate problem. Pointing `SSL_CERT_FILE` at a concrete bundle
+ * fixes it.
+ *
+ * This only picks a default. An `SSL_CERT_FILE` already present in the daemon's
+ * environment is an operator decision and is left untouched by the caller.
+ *
+ * Two properties of this module are load-bearing:
+ *
+ *   1. `realpath`. The Seatbelt baseline exposes `/private/etc`, NOT the `/etc`
+ *      symlink, so `/etc/ssl/cert.pem` is only readable inside the sandbox once
+ *      it is resolved to `/private/etc/ssl/cert.pem`. Dropping the realpath as
+ *      "redundant" silently removes the system candidate.
+ *   2. Trust ordering. `SSL_CERT_FILE` defines the complete set of trust
+ *      anchors the sandboxed CLI will accept, so a bundle that the agent's own
+ *      uid can write is a bundle the agent can add a rogue CA to. Candidates
+ *      owned by root and not group/world-writable are therefore preferred over
+ *      a Homebrew-managed one, independent of list order. A writable bundle is
+ *      still used as a last resort (a machine with no usable trust store is
+ *      worse) but the caller is told, so the choice is visible.
+ */
+import { existsSync as fsExistsSync, realpathSync as fsRealpathSync, statSync as fsStatSync } from 'node:fs';
+
+/** Probed in order; a trustworthy candidate wins over an earlier writable one. */
+export const DARWIN_CODEX_CA_BUNDLE_CANDIDATES = [
+  '/etc/ssl/cert.pem',
+  '/opt/homebrew/etc/ca-certificates/cert.pem',
+  '/usr/local/etc/ca-certificates/cert.pem',
+] as const;
+
+/** Injected seam: the real implementations come from node:fs. */
+export interface CaBundleProbe {
+  platform: string;
+  candidates: readonly string[];
+  exists(path: string): boolean;
+  realpath(path: string): string;
+  /** uid/mode of the resolved bundle; only ownership and write bits are read. */
+  stat(path: string): { uid: number; mode: number };
+  warn(message: string): void;
+}
+
+const DEFAULT_PROBE: CaBundleProbe = {
+  platform: process.platform,
+  candidates: DARWIN_CODEX_CA_BUNDLE_CANDIDATES,
+  exists: (p) => fsExistsSync(p),
+  realpath: (p) => fsRealpathSync(p),
+  stat: (p) => {
+    const s = fsStatSync(p);
+    return { uid: s.uid, mode: s.mode };
+  },
+  warn: () => { /* caller opts in */ },
+};
+
+/** Root-owned and not writable by group or others. */
+function trustworthy(probe: CaBundleProbe, resolved: string): boolean {
+  try {
+    const { uid, mode } = probe.stat(resolved);
+    return uid === 0 && (mode & 0o022) === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolved path of the CA bundle to hand a sandboxed Codex, or undefined when
+ * this is not macOS or no candidate exists.
+ */
+export function resolveDarwinCodexCaBundle(overrides: Partial<CaBundleProbe> = {}): string | undefined {
+  const probe: CaBundleProbe = { ...DEFAULT_PROBE, ...overrides };
+  if (probe.platform !== 'darwin') return undefined;
+  let writableFallback: string | undefined;
+  for (const candidate of probe.candidates) {
+    let resolved: string;
+    try {
+      if (!probe.exists(candidate)) continue;
+      resolved = probe.realpath(candidate);
+    } catch {
+      continue;
+    }
+    if (trustworthy(probe, resolved)) return resolved;
+    writableFallback ??= resolved;
+  }
+  if (writableFallback) {
+    probe.warn(
+      `[sandbox] CA bundle ${writableFallback} is not root-owned/read-only; using it for sandboxed Codex `
+      + 'anyway, but anything running as this user can add trust anchors to it',
+    );
+  }
+  return writableFallback;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -94,6 +94,7 @@ import {
 import { CodexUpdateDialogGuard } from './utils/codex-update-dialog.js';
 import { EffortConfirmDialogGuard, isEffortLevelCommand } from './utils/effort-confirm-dialog.js';
 import { installStdioEpipeGuard, isIgnorableStreamError } from './utils/stdio-epipe-guard.js';
+import { resolveDarwinCodexCaBundle } from './utils/darwin-ca-bundle.js';
 import {
   handoffQueuedDurableInputsOnBackendExit,
   mergeQueuedCliInput,
@@ -14370,6 +14371,19 @@ async function spawnCli(
     };
     if (claudeDataDir) childEnv.CLAUDE_CONFIG_DIR = canonicalizeForSandbox(claudeDataDir); // = <BOT_HOME>/claude
     else childEnv.CODEX_HOME = canonicalizeForSandbox(isolatedCodexHome!);
+  }
+  // Sandboxed Codex cannot discover a trust store inside Seatbelt (see
+  // utils/darwin-ca-bundle for why, and for why realpath matters). `codex-app`
+  // needs this too: its outer child is a Node runner that spawns the same Codex
+  // `app-server` with `env: process.env`, so the variable injected here reaches
+  // the same TLS stack. An explicit value from the operator always wins.
+  if (
+    sandboxRequested
+    && (cfg.cliId === 'codex' || cfg.cliId === 'codex-app')
+    && !childEnv.SSL_CERT_FILE
+  ) {
+    const caBundle = resolveDarwinCodexCaBundle({ warn: log });
+    if (caBundle) childEnv.SSL_CERT_FILE = caBundle;
   }
   if (willReadIsolate) {
     if (!readIsolationOriginChannelId) {

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -602,6 +602,20 @@ describe('API-only bot mode — no-transport fs-policy authority provenance (wor
     expect(workerSource).toContain('no-transport suppressed');
   });
 
+  it('worker injects a host CA bundle for sandboxed Codex without overriding an explicit value', () => {
+    // Candidate list and selection rules are behaviour, covered by
+    // test/darwin-ca-bundle.test.ts. What can only be asserted here is the
+    // WIRING: both Codex cliIds, sandbox-only, explicit value wins, and the
+    // worker's own logger carries the writable-bundle warning.
+    expect(workerSource).toContain("from './utils/darwin-ca-bundle.js'");
+    expect(workerSource).toContain("&& (cfg.cliId === 'codex' || cfg.cliId === 'codex-app')");
+    // Operator precedence: childEnv starts from the daemon env, so an
+    // operator-supplied SSL_CERT_FILE is what this guard preserves.
+    expect(workerSource).toContain('&& !childEnv.SSL_CERT_FILE');
+    expect(workerSource).toContain('resolveDarwinCodexCaBundle({ warn: log })');
+    expect(workerSource).toContain('if (caBundle) childEnv.SSL_CERT_FILE = caBundle;');
+  });
+
   it('persistent-pane guard: state-machine + injectable executor wiring (behavioral tests in read-isolation)', () => {
     // The reattach guard delegates the DECISION to evaluatePersistentPaneMigration
     // and the ORDERED, fail-closed side effects to executePersistentPaneMigration.

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -608,7 +608,10 @@ describe('API-only bot mode — no-transport fs-policy authority provenance (wor
     // WIRING: both Codex cliIds, sandbox-only, explicit value wins, and the
     // worker's own logger carries the writable-bundle warning.
     expect(workerSource).toContain("from './utils/darwin-ca-bundle.js'");
-    expect(workerSource).toContain("&& (cfg.cliId === 'codex' || cfg.cliId === 'codex-app')");
+    // Assert both cliIds are covered, not the exact clause text: swapping the
+    // two sides of `||` is semantically identical and must not fail this.
+    expect(workerSource).toContain("cfg.cliId === 'codex'");
+    expect(workerSource).toContain("cfg.cliId === 'codex-app'");
     // Operator precedence: childEnv starts from the daemon env, so an
     // operator-supplied SSL_CERT_FILE is what this guard preserves.
     expect(workerSource).toContain('&& !childEnv.SSL_CERT_FILE');

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -626,6 +626,10 @@ describe('BOTMUX_INJECTED_ENV_KEYS carries the read-isolation markers', () => {
     expect(BOTMUX_INJECTED_ENV_KEYS).toContain('BOTMUX_PLUGIN_CARD_ACTION_CAPABILITIES');
     expect(SESSION_TURN_MARKER_ENV_KEYS).toContain('BOTMUX_PLUGIN_CARD_ACTION_CAPABILITIES');
   });
+
+  it('includes SSL_CERT_FILE for sandboxed Codex CA-bundle injection', () => {
+    expect(BOTMUX_INJECTED_ENV_KEYS).toContain('SSL_CERT_FILE');
+  });
 });
 
 /**

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -4,10 +4,12 @@ import {
   applySessionOwnerEnv,
   scrubExternalMemberEnv,
   BOTMUX_INJECTED_ENV_KEYS,
+  CA_BUNDLE_ENV_KEYS,
   CLAUDE_SESSION_MARKER_ENV_KEYS,
   DASHBOARD_H5_ENV_KEYS,
   DASHBOARD_H5_ENV_PREFIX,
   INVOKER_TERMINAL_ENV_KEYS,
+  PROXY_ENV_KEYS,
   redactChildEnv,
   REDACTED_CHILD_ENV_KEYS,
   scrubClaudeSessionMarkerEnv,
@@ -627,8 +629,15 @@ describe('BOTMUX_INJECTED_ENV_KEYS carries the read-isolation markers', () => {
     expect(SESSION_TURN_MARKER_ENV_KEYS).toContain('BOTMUX_PLUGIN_CARD_ACTION_CAPABILITIES');
   });
 
-  it('includes SSL_CERT_FILE for sandboxed Codex CA-bundle injection', () => {
-    expect(BOTMUX_INJECTED_ENV_KEYS).toContain('SSL_CERT_FILE');
+  it('keeps SSL_CERT_FILE OUT of the injected list and in its own CA-bundle list', () => {
+    // BOTMUX_INJECTED_ENV_KEYS also drives the pane `unset` clause and
+    // scrubTmuxServerGlobalEnv(), so a standard, user-ownable variable listed
+    // there would delete the CA bundle a user configured for their own tmux
+    // server — for every CLI, on every platform. Same reason PROXY_ENV_KEYS is
+    // kept out. Per-pane forwarding happens in buildBotmuxEnvAssignments.
+    expect(BOTMUX_INJECTED_ENV_KEYS).not.toContain('SSL_CERT_FILE');
+    expect(CA_BUNDLE_ENV_KEYS).toContain('SSL_CERT_FILE');
+    expect(PROXY_ENV_KEYS as readonly string[]).not.toContain('SSL_CERT_FILE');
   });
 });
 

--- a/test/darwin-ca-bundle.test.ts
+++ b/test/darwin-ca-bundle.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DARWIN_CODEX_CA_BUNDLE_CANDIDATES,
+  resolveDarwinCodexCaBundle,
+  type CaBundleProbe,
+} from '../src/utils/darwin-ca-bundle.js';
+
+const ROOT_READONLY = { uid: 0, mode: 0o100644 };
+const USER_WRITABLE = { uid: 501, mode: 0o100644 };
+
+function probe(
+  present: Record<string, { real?: string; stat?: { uid: number; mode: number } }>,
+  overrides: Partial<CaBundleProbe> = {},
+): Partial<CaBundleProbe> & { warnings: string[] } {
+  const warnings: string[] = [];
+  return {
+    platform: 'darwin',
+    exists: (p) => p in present,
+    realpath: (p) => present[p]?.real ?? p,
+    stat: (p) => {
+      const hit = Object.values(present).find(v => (v.real ?? '') === p);
+      const stat = hit?.stat ?? Object.entries(present).find(([k]) => k === p)?.[1]?.stat;
+      if (!stat) throw new Error(`no stat for ${p}`);
+      return stat;
+    },
+    warn: (m) => { warnings.push(m); },
+    warnings,
+    ...overrides,
+  };
+}
+
+describe('resolveDarwinCodexCaBundle', () => {
+  it('is a no-op off darwin (Seatbelt is the only reason this exists)', () => {
+    const p = probe({ '/etc/ssl/cert.pem': { real: '/private/etc/ssl/cert.pem', stat: ROOT_READONLY } });
+    expect(resolveDarwinCodexCaBundle({ ...p, platform: 'linux' })).toBeUndefined();
+  });
+
+  it('returns the REALPATH, not the symlink: the sandbox exposes /private/etc, not /etc', () => {
+    const p = probe({ '/etc/ssl/cert.pem': { real: '/private/etc/ssl/cert.pem', stat: ROOT_READONLY } });
+    expect(resolveDarwinCodexCaBundle(p)).toBe('/private/etc/ssl/cert.pem');
+  });
+
+  it('prefers a root-owned bundle over an earlier user-writable one, regardless of list order', () => {
+    const p = probe({
+      // First in the list, but writable by the account the agent runs as.
+      '/etc/ssl/cert.pem': { real: '/private/etc/ssl/cert.pem', stat: USER_WRITABLE },
+      '/opt/homebrew/etc/ca-certificates/cert.pem': {
+        real: '/opt/homebrew/etc/ca-certificates/cert.pem',
+        stat: ROOT_READONLY,
+      },
+    });
+    expect(resolveDarwinCodexCaBundle(p)).toBe('/opt/homebrew/etc/ca-certificates/cert.pem');
+    expect(p.warnings).toEqual([]);
+  });
+
+  it('falls back to a user-writable bundle but says so (no trust store is worse)', () => {
+    const p = probe({
+      '/opt/homebrew/etc/ca-certificates/cert.pem': {
+        real: '/opt/homebrew/etc/ca-certificates/cert.pem',
+        stat: USER_WRITABLE,
+      },
+    });
+    expect(resolveDarwinCodexCaBundle(p)).toBe('/opt/homebrew/etc/ca-certificates/cert.pem');
+    expect(p.warnings.join('\n')).toContain('not root-owned/read-only');
+  });
+
+  it('rejects a group/other-writable bundle the same way as a foreign owner', () => {
+    const p = probe({
+      '/etc/ssl/cert.pem': { real: '/private/etc/ssl/cert.pem', stat: { uid: 0, mode: 0o100662 } },
+    });
+    expect(resolveDarwinCodexCaBundle(p)).toBe('/private/etc/ssl/cert.pem');
+    expect(p.warnings.join('\n')).toContain('not root-owned/read-only');
+  });
+
+  it('returns undefined when no candidate exists, so the caller injects nothing', () => {
+    expect(resolveDarwinCodexCaBundle(probe({}))).toBeUndefined();
+  });
+
+  it('keeps scanning when a candidate cannot be resolved', () => {
+    const p = probe({
+      '/etc/ssl/cert.pem': { real: '/private/etc/ssl/cert.pem', stat: ROOT_READONLY },
+      '/opt/homebrew/etc/ca-certificates/cert.pem': {
+        real: '/opt/homebrew/etc/ca-certificates/cert.pem',
+        stat: ROOT_READONLY,
+      },
+    });
+    const throwing = {
+      ...p,
+      realpath: (path: string) => {
+        if (path === '/etc/ssl/cert.pem') throw new Error('EACCES');
+        return path;
+      },
+    };
+    expect(resolveDarwinCodexCaBundle(throwing)).toBe('/opt/homebrew/etc/ca-certificates/cert.pem');
+  });
+
+  it('probes the system bundle first (Homebrew copies go stale and are user-managed)', () => {
+    expect(DARWIN_CODEX_CA_BUNDLE_CANDIDATES[0]).toBe('/etc/ssl/cert.pem');
+    expect([...DARWIN_CODEX_CA_BUNDLE_CANDIDATES]).toEqual([
+      '/etc/ssl/cert.pem',
+      '/opt/homebrew/etc/ca-certificates/cert.pem',
+      '/usr/local/etc/ca-certificates/cert.pem',
+    ]);
+  });
+});

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -833,6 +833,15 @@ describe('isolatedPaneReattachSafe — start-time contract bump forces cold resp
     expect(isolatedPaneReattachSafe(currentVersionNoState, ['credential', 'read', 'write'])).toBe(false);
     expect(ISOLATION_PANE_MARKER_VERSION).toBeGreaterThanOrEqual(12);
   });
+
+  it('has moved the version past 12 — the release before the sandboxed-Codex CA env contract', () => {
+    // A pane spawned before this change keeps its ORIGINAL process environment, so
+    // it would never see the host CA bundle (SSL_CERT_FILE) and its Codex would keep
+    // failing TLS on UnknownIssuer — before any output, so the symptom is a pane that
+    // simply never answers. The marker version is the only lever that turns such a
+    // pane into kill + cold-spawn, so bumping past 12 is load-bearing.
+    expect(ISOLATION_PANE_MARKER_VERSION).toBeGreaterThan(12);
+  });
 });
 
 // ─── #714: new spawn-time sandbox mount (traex/coco migration markers) ────────

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -75,6 +75,20 @@ function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+describe('buildBotmuxEnvAssignments() — CA bundle', () => {
+  it('forwards SSL_CERT_FILE per pane (it is deliberately not on the injected allowlist)', () => {
+    // The value reaches the pane through this per-pane injection, NOT through
+    // BOTMUX_INJECTED_ENV_KEYS — listing it there would also make every pane
+    // `unset` it and let daemon startup delete a user's own tmux server value.
+    const out = buildBotmuxEnvAssignments({ SSL_CERT_FILE: '/private/etc/ssl/cert.pem' });
+    expect(out).toContain('SSL_CERT_FILE=/private/etc/ssl/cert.pem');
+  });
+
+  it('omits SSL_CERT_FILE when the worker resolved none and the operator set none', () => {
+    expect(buildBotmuxEnvAssignments({ BOTMUX: '1' }).some(a => a.startsWith('SSL_CERT_FILE='))).toBe(false);
+  });
+});
+
 describe('buildBotmuxEnvAssignments()', () => {
   it('forwards only the daemon-side keys; bare LARK_APP_* are NOT forwarded', () => {
     const out = buildBotmuxEnvAssignments({

--- a/test/tmux-env-isolation.test.ts
+++ b/test/tmux-env-isolation.test.ts
@@ -129,6 +129,19 @@ describe('tmuxEnv()', () => {
     }
   });
 
+  it('strips SSL_CERT_FILE from the tmux CLIENT env but never from the server global env', () => {
+    // Client-side strip: a daemon-side CA bundle must not be seeded into the
+    // shared server's global table. Server-global scrub: must NOT include it,
+    // or daemon startup would delete a CA bundle the user set on their own tmux
+    // server — for every CLI, on every platform (same rule as the proxy keys).
+    expect(isBotmuxManagedTmuxEnvKey('SSL_CERT_FILE')).toBe(true);
+    expect(isBotmuxManagedTmuxServerGlobalEnvKey('SSL_CERT_FILE')).toBe(false);
+    for (const key of PROXY_ENV_KEYS) {
+      expect(isBotmuxManagedTmuxEnvKey(key), key).toBe(true);
+      expect(isBotmuxManagedTmuxServerGlobalEnvKey(key), key).toBe(false);
+    }
+  });
+
   it('does not classify GitHub tokens as botmux-owned tmux server-global keys', () => {
     expect(isBotmuxManagedTmuxServerGlobalEnvKey('GITHUB_TOKEN')).toBe(false);
     expect(isBotmuxManagedTmuxServerGlobalEnvKey('GH_TOKEN')).toBe(false);


### PR DESCRIPTION
## 症状与根因

在 macOS 上给一个 Codex bot 开启文件沙箱后，会话**一个字都不输出**——看起来像进程死了，而不像证书问题。

npm Codex 的 TLS 走 Rust 栈，不读 macOS 钥匙串。沙箱外它还能找到一份可用的信任存储；进了 Seatbelt，这套发现落空，每个请求死在 `UnknownIssuer`。而**模型 API 调用本身就是 TLS**，所以失败发生在任何输出之前，症状是"完全没反应"。几乎不会有人第一时间往 CA 上想。

把 `SSL_CERT_FILE` 指向一份具体的 bundle 即可修复。

## 改动

- 新增 `src/utils/darwin-ca-bundle.ts`：按 `/etc/ssl/cert.pem` → Homebrew → `/usr/local` 顺序探测，返回 **realpath**。
- `worker.ts` 在 spawn 时注入，覆盖 `codex` 与 `codex-app`。后者的外层子进程是 Node runner，它用 `env: process.env` 再拉起同一个 Codex `app-server`，所以这里注入的值会到达同一套 TLS 栈。
- `SSL_CERT_FILE` 加入 `BOTMUX_INJECTED_ENV_KEYS`，让 tmux backend 把解析后的值透传进 pane。
- 隔离 pane marker `11 → 12`。

### 两处刻意的设计，评审时值得单独看

**1. `realpath` 是承重逻辑，不是冗余优化。** Seatbelt baseline 放行的是 `/private/etc`，**不是 `/etc` 这个符号链接**。`/etc/ssl/cert.pem` 只有解析成 `/private/etc/ssl/cert.pem` 之后才在沙箱内可读。把 realpath 当冗余去掉，会**静默失掉**系统候选，只留下 Homebrew 那条路。

**2. 候选选择不只看顺序，还看是否可信。** `SSL_CERT_FILE` 定义的是沙箱 CLI 的**全部**信任锚集合，因此一份"当前用户可写"的 bundle 等于允许任何以该用户身份运行的东西往里加一个信任锚。所以：root 拥有且非组/他人可写的候选**跨越列表顺序**优先；只有在找不到可信候选时才使用可写的那份（没有信任存储比这更糟），但会打一条警告，让这个选择可见。实测中 Homebrew 的 `cert.pem` 正是被普通用户拥有的，而 `/private/etc/ssl/cert.pem` 是 `root:wheel`。

### 优先级与范围

- **操作方优先**：daemon 环境里已有的 `SSL_CERT_FILE` 由 `childEnv` 继承并原样保留，只有没有时 worker 才选默认值。
- **pane marker 必须 bump**：warm reattach 会保留旧进程环境，既有 pane 不会凭空获得新变量，因此必须冷启动一次。
- **范围只到 codex / codex-app**。`claude-code` 不需要也不适用：Node 自带编译进去的根证书库，不读钥匙串**也不读 `SSL_CERT_FILE`**（它认的是 `NODE_EXTRA_CA_CERTS`，且是追加语义）；实测多个 `claude-code` bot 在 sandbox + readIsolation 下工作正常。会中招的是"依赖操作系统信任发现"的 TLS 栈。若将来别的 CLI 出现同一症状（会话完全无输出），机制可以照此扩展。

## 影响面

- 未启用沙箱的会话、非 Codex 的 CLI：行为不变。
- 已存在的隔离 pane：因 marker bump 冷启动一次。
- 显式设置过 `SSL_CERT_FILE` 的部署：不受影响（操作方优先）。

## 验证

工具链 bun 1.4.0 / node v24.17.0：

```
bun install --frozen-lockfile
bun run build
bun run test
npx vitest run --project unit test/darwin-ca-bundle.test.ts
```

- build 通过；`tsc --noEmit` 干净。
- 新增 `test/darwin-ca-bundle.test.ts` 8 个用例全部通过，用可注入探针覆盖行为：非 darwin 返回 undefined、返回 realpath 而非符号链接、可信候选跨顺序优先、只有可写候选时仍使用但告警、组/他人可写与外部属主同等对待、无候选返回 undefined、单候选解析失败继续扫描、候选顺序本身。
- 全量测试的失败**文件名**与 master 基线同族；差集（`adopt-tmux-claude-wrapper-repro`、`cli-persistent-backend-target`、`hook-runner`、`tmux-pipe-backend-exit`）**单跑全绿**，属满载 flaky。
- 变异验证三处，均按预期变红：① 注入条件去掉 `codex-app` ② 候选顺序改成 Homebrew 优先 ③ 去掉可信度检查。
