### PR TITLE
fix(card): 失败卡不再把「重试可能有用」当成「什么都没执行」

### DIFF
--- a/src/services/turn-failure-notice.ts
+++ b/src/services/turn-failure-notice.ts
@@ -149,12 +149,27 @@ export function shouldNotifyTurnFailure(turn: TurnFailureNoticeInput): boolean {
 
 /**
  * How a retry may be offered:
- * - `safe`     — input provably never executed, or the CLI's own classifier
- *                said retryable. No duplicate-side-effect risk to warn about.
+ * - `safe`     — the input provably never executed. No duplicate-side-effect
+ *                risk to warn about.
  * - `caveated` — the turn may have executed before dying. Offer the button, but
  *                the card MUST warn that redoing it can repeat side effects.
  * - `none`     — do not offer retry (not a notifiable failure, or the CLI
  *                explicitly refused: re-sending cannot help).
+ *
+ * ⚠️ `retryable === true` DOES NOT MEAN `safe`. It used to, and that was a lie
+ * the card told users: the CLI's `retryable` answers "would retrying possibly
+ * help?", not "did anything run?". `provider_server_error` is the proof — it is
+ * raised for HTTP 5xx AND for `closed mid-response` / `connection reset`
+ * signatures (see claude-transcript.ts), i.e. the connection dying AFTER the
+ * model has already been running and calling tools. MEASURED in the wild: a turn
+ * that had already read state and sent several Lark messages died with
+ * `provider_server_error`, and the card announced「这一轮的输入没有送达 CLI，
+ * 没有任何已执行的操作」— every clause false, and it steered the user toward a
+ * verbatim replay that would redo those side effects.
+ *
+ * Only WHERE the failure happened can prove nothing ran, which is exactly what
+ * `PRE_EXECUTION_ERROR_CODES` enumerates. So that set is now the ONLY route to
+ * `safe`; `retryable` decides only whether a retry is worth offering at all.
  */
 export type TurnRetryOffer = 'safe' | 'caveated' | 'none';
 
@@ -164,8 +179,14 @@ export function turnRetryOffer(
   if (!shouldNotifyTurnFailure(turn)) return 'none';
   // An explicit refusal (auth failure, invalid request) outranks every
   // heuristic below: re-sending the same input provably cannot succeed.
+  // ⚠️ Checked BEFORE the pre-execution set on purpose: those codes are emitted
+  // without a `retryable` flag (worker.ts passes none), so this cannot swallow
+  // them — but a future call site that pairs a refusal with such a code means
+  // "do not re-send", and honouring the refusal is the conservative reading.
   if (turn.retryable === false) return 'none';
-  if (turn.retryable === true) return 'safe';
+  // Location, not retryability, is what proves nothing executed. See the note on
+  // TurnRetryOffer: `retryable === true` used to short-circuit to `safe` here and
+  // made the card claim "nothing was executed" for mid-response failures.
   if (turn.errorCode !== undefined && PRE_EXECUTION_ERROR_CODES.has(turn.errorCode)) return 'safe';
   return 'caveated';
 }

--- a/test/turn-failure-card.test.ts
+++ b/test/turn-failure-card.test.ts
@@ -142,10 +142,38 @@ describe('turnRetryOffer', () => {
     }
   });
 
-  it('offers a plain retry when the CLI explicitly authorised it', () => {
-    // provider_server_error / unexpected_eof — Claude's classifier said retryable.
-    expect(turnRetryOffer({ status: 'failed', errorCode: 'provider_server_error', retryable: true }))
-      .toBe('safe');
+  it('THE LIE: `retryable: true` must NOT be read as "nothing executed"', () => {
+    // REGRESSION for a card that told users a falsehood. `turnRetryOffer` used to
+    // short-circuit `retryable === true` to `safe`, and `safe` renders
+    //「这一轮的输入没有送达 CLI，没有任何已执行的操作，可以安全重试」.
+    //
+    // But the CLI's `retryable` answers "would retrying possibly help?", NOT "did
+    // anything run?". `provider_server_error` is raised for HTTP 5xx AND for
+    // `closed mid-response` / `connection reset` signatures (claude-transcript.ts),
+    // i.e. the connection dying AFTER the model has been running and calling
+    // tools. OBSERVED in production: a turn that had already read state and sent
+    // several Lark messages died with `provider_server_error`, and the card
+    // claimed nothing had executed — then offered a verbatim replay that would
+    // redo those side effects.
+    //
+    // Only WHERE the failure happened proves nothing ran, so these must caveat.
+    for (const errorCode of ['provider_server_error', 'provider_unexpected_eof']) {
+      expect(turnRetryOffer({ status: 'failed', errorCode, retryable: true }), errorCode)
+        .toBe('caveated');
+    }
+  });
+
+  it('a pre-execution code still yields `safe` — the fix must not caveat everything', () => {
+    // The counterweight: over-caveating would be its own regression (users get a
+    // scary side-effect warning, and the button degrades from replay to
+    // continue, for turns whose input demonstrably never reached the CLI).
+    // These codes are emitted WITHOUT a `retryable` flag (see worker.ts), which
+    // is why the refusal check above them cannot swallow them.
+    for (const errorCode of ['write_input_threw', 'adopt_write_input_threw',
+      'raw_input_write_failed', 'zmx_recovery_blocked_before_write',
+      'terminal_bridge_unavailable']) {
+      expect(turnRetryOffer({ status: 'failed', errorCode }), errorCode).toBe('safe');
+    }
   });
 
   it('refuses retry when the CLI explicitly said it cannot help', () => {


### PR DESCRIPTION
## 问题：卡上每一句都是假的

用户报告「明明没报错却显示本轮执行失败」。实际是**真失败了**，但**失败卡说的内容全是假的**：

```
⚠️ Claude 本轮执行失败
错误码：`provider_server_error`
这一轮的输入没有送达 CLI，没有任何已执行的操作，可以安全重试。
[🔄 重试这一轮]  ← 提交的是「原话重发」
```

**线上实证**：出这张卡的那一轮，会话**已经查过 npm registry、读过 `origin/master`、发出了多条 IM 消息**。所以：

1. 「输入没有送达 CLI」— 假
2. 「没有任何已执行的操作」— 假
3. 「可以安全重试」— 危险：按钮是**重发原话**，点下去会**重复那些副作用**

## 根因：把两个语义压进了同一个档位

`turnRetryOffer()`（`src/services/turn-failure-notice.ts`）里：
```ts
if (turn.retryable === true) return 'safe';   // ← 删掉的就是这行
```
而 `safe` 档位在卡上渲染的文案（`i18n/zh.ts` 的 `card.turn_failed.retry_safe`）明确断言「没执行过」。

**但 CLI 给的 `retryable` 回答的是「重试有没有可能成功」，不是「有没有东西已经跑了」。** `provider_server_error` 的判定条件（`claude-transcript.ts:130`）正好说明这点：

```ts
if (code === 'server_error'
  || (status >= 500 && status <= 599)
  || hasApiErrorSignature(ev, /connection\s+(reset|lost|closed)|econnreset
      |http2:\s*client\s+connection\s+lost|closed\s+mid-response|…/i)) {
  return { status: 'failed', errorCode: 'provider_server_error', retryable: true };
}
```
`closed mid-response`、`connection reset`、`http2 client connection lost` —— **全都是「模型已经在跑、连接中途断掉」**，副作用完全可能已经落地。

## 改法

**只有「失败发生在哪」能证明没跑过**，那正是 `PRE_EXECUTION_ERROR_CODES` 枚举的（输入连 CLI 都没写进去）。所以：

- `PRE_EXECUTION_ERROR_CODES` 成为**通向 `safe` 的唯一路径**
- `retryable` 只决定「值不值得给重试按钮」，不再决定「有没有副作用风险」
- `retryable === false` 的显式拒绝**仍然优先**（那些 pre-execution 码由 `worker.ts` 发出时**不带** retryable 标志，所以不会被这条吞掉 —— 已核）

**连带修正按钮语义**：`caveated` 提交的不再是原话，而是
`[BOTMUX_CONTINUE] 上一轮被异常中断，可能已完成了一部分。请确认现场后从中断处继续，不要重复已完成的操作；无法安全判断则停下并请求人工决策。`

## 修后行为（8 个码逐条实测）

| 错误码 | 修前 | 修后 |
|---|---|---|
| `provider_server_error` | ❌ `safe`（谎称没跑） | ✅ `caveated` |
| `provider_unexpected_eof` | ❌ `safe` | ✅ `caveated` |
| `cli_exit` | `caveated` | `caveated` |
| `write_input_threw` / `adopt_write_input_threw` / `raw_input_write_failed` / `zmx_recovery_blocked_before_write` / `terminal_bridge_unavailable` | `safe` | ✅ **仍是 `safe`** |
| `provider_invalid_request` 等显式拒绝 | `none` | `none` |

## ⚠️ 原有测试把缺陷写成了期望

原用例 `offers a plain retry when the CLI explicitly authorised it` 断言的正是
`turnRetryOffer({errorCode:'provider_server_error', retryable:true}) === 'safe'`
—— **正是它让整个套件在用户看到假卡片时保持绿色**。

已将其**反转**为「`retryable: true` 不得读成『没执行』」，并**新增反方向守卫**：5 个 pre-execution 码必须仍是 `safe`（否则过度警告会把真安全的轮也降级成 continue，那是另一个方向的回归）。

## 验证

- **反变异 2/2 全红**：① 还原 `if (turn.retryable === true) return 'safe'` → **1 红** ② 去掉 pre-execution 的 safe 通道（过度警告）→ **2 红**
- 变异后逐次 `cmp` 核对还原为 byte-identical
- `bun run build` ✅、`tsc --noEmit` ✅
- `test/turn-failure-card.test.ts` **48/48**；加上 `worker-structured-lifecycle-status` 共 **78/78**
- 影响面：`turnRetryOffer` 的消费点只有 `worker-pool.ts:1283`（构卡）与 `card-builder.ts`（渲染 + 按钮动作），两者共用同一 offer，不存在「卡上说能安全重试、按钮却给 continue」的分裂

## 遗留

- 本 PR 不动 `provider_server_error` 的**判定条件**本身（把 5xx 与 mid-response 断连合并成一个码是既有设计）。若要区分「请求根本没发出」与「响应中途断」，需要 provider 侧更细的信号，属另一件事。