### PR TITLE
feat(ask): 无权限者点 ask 卡片改弹授权卡，授权后需再点一次

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1288,6 +1288,8 @@ export const messages: Record<string, string> = {
   'card.ask.title': 'botmux ask',
   'card.ask.title_done': 'botmux ask · done',
   'card.ask.toast.unauthorized': "You're not allowed to answer this ask",
+  'card.ask.toast.grant_requested': 'Access requested from the owner — click again once approved',
+  'card.ask.toast.grant_pending': 'Your access request is pending — click again once the owner approves',
   'card.ask.toast.already_settled': 'This ask was already answered or closed',
   'card.ask.toast.stale': '⚠️ This ask is no longer valid',
   'card.ask.custom_reply': 'Custom reply',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1290,6 +1290,7 @@ export const messages: Record<string, string> = {
   'card.ask.toast.unauthorized': "You're not allowed to answer this ask",
   'card.ask.toast.grant_requested': 'Access requested from the owner — click again once approved',
   'card.ask.toast.grant_pending': 'Your access request is pending — click again once the owner approves',
+  'card.ask.toast.grant_denied': 'The owner declined your access request — reach out to them directly if you need to answer',
   'card.ask.toast.already_settled': 'This ask was already answered or closed',
   'card.ask.toast.stale': '⚠️ This ask is no longer valid',
   'card.ask.custom_reply': 'Custom reply',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1290,6 +1290,8 @@ export const messages: Record<string, string> = {
   // 取决于点了哪个按钮，授权通过不会自动替用户作答（与对话路径的重放语义不同）。
   'card.ask.toast.grant_requested': '已向 owner 申请授权，通过后请再点一次',
   'card.ask.toast.grant_pending': '授权申请已提交，等 owner 处理后再点一次',
+  // 与 grant_pending 分开：owner 已明确拒绝、还在冷却期内，不能谎报成「等 owner 处理」。
+  'card.ask.toast.grant_denied': 'owner 已拒绝你的授权申请，如需答复请直接联系 ta',
   'card.ask.toast.already_settled': '这个 ask 已经被回答或结束',
   'card.ask.toast.stale': '⚠️ 此 ask 已失效',
   'card.ask.custom_reply': '自定义回复',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1286,6 +1286,10 @@ export const messages: Record<string, string> = {
   'card.ask.title': 'botmux ask',
   'card.ask.title_done': 'botmux ask 已结束',
   'card.ask.toast.unauthorized': '你没有权限回答这个 ask',
+  // 未授权点击已升级成向 owner 申请授权。措辞必须点明「通过后要再点一次」——ask 的答案
+  // 取决于点了哪个按钮，授权通过不会自动替用户作答（与对话路径的重放语义不同）。
+  'card.ask.toast.grant_requested': '已向 owner 申请授权，通过后请再点一次',
+  'card.ask.toast.grant_pending': '授权申请已提交，等 owner 处理后再点一次',
   'card.ask.toast.already_settled': '这个 ask 已经被回答或结束',
   'card.ask.toast.stale': '⚠️ 此 ask 已失效',
   'card.ask.custom_reply': '自定义回复',

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -9,6 +9,7 @@ import { getAskSnapshot, submitAsk, toggleAsk, tryResolveAsk } from '../../core/
 import { logger } from '../../utils/logger.js';
 import { t, localeForBot, type Locale } from '../../i18n/index.js';
 import { replyMessage, sendMessage, updateMessage } from './client.js';
+import { requestGrantForAskClicker } from './ask-grant-request.js';
 
 /** 旧单选即答动作（保留兼容旧卡片回调；Task 5 新增 ask_submit 路径）。 */
 export const ASK_SELECT_ACTION = 'ask_select';
@@ -33,6 +34,11 @@ export interface AskCardDispatcherDeps {
   sendMessage?: typeof sendMessage;
   replyMessage?: typeof replyMessage;
   updateMessage?: typeof updateMessage;
+}
+
+/** 点击处理的可注入依赖。目前只有「未授权 → 弹授权卡」这一路（供单测替换）。 */
+export interface AskCardActionDeps {
+  requestGrant?: typeof requestGrantForAskClicker;
 }
 
 export function createLarkAskCardDispatcher(
@@ -178,6 +184,7 @@ export function isAskCardAction(action?: string): boolean {
 
 export async function handleAskCardAction(
   data: AskCardActionData,
+  deps: AskCardActionDeps = {},
 ): Promise<{ toast: { type: string; content: string } } | Record<string, unknown> | undefined> {
   const value = data.action?.value;
   const action = asString(value?.action);
@@ -193,6 +200,13 @@ export async function handleAskCardAction(
     return staleToast(locale);
   }
 
+  /** unauthorized 不再是死胡同：复用对话路径的授权卡向 owner 申请，toast 告诉点击者
+   *  「已申请、通过后再点一次」。其余 outcome 原样交给 toastForOutcome。 */
+  const outcomeResponse = (outcome: AskClickOutcome) =>
+    outcome === 'unauthorized'
+      ? escalateUnauthorized(askId, by, locale, deps)
+      : toastForOutcome(outcome, locale);
+
   // 旧单选即答路径：按钮直接携带 key，调用 tryResolveAsk（单问单选便捷封装）。
   // accepted 时直接返回终态卡片，让飞书在回调响应里同步替换——不依赖 onSettle 异步 PATCH
   // （异步 PATCH 在飞书侧常因回调已返回而被忽略，导致卡片停在未作答态）。
@@ -200,7 +214,7 @@ export async function handleAskCardAction(
     const selected = asString(value?.key);
     if (!selected) return staleToast(locale);
     const outcome = tryResolveAsk({ askId, nonce, selected, by });
-    if (outcome !== 'accepted') return toastForOutcome(outcome, locale);
+    if (outcome !== 'accepted') return outcomeResponse(outcome);
     return settledCardResponse(askId, {
       kind: 'answered',
       answers: [[selected]],
@@ -215,7 +229,7 @@ export async function handleAskCardAction(
     const key = asString(value?.key);
     if (!Number.isInteger(questionIndex) || !key) return staleToast(locale);
     const outcome = toggleAsk({ askId, nonce, questionIndex, key, by });
-    if (outcome !== 'toggled') return toastForOutcome(outcome, locale);
+    if (outcome !== 'toggled') return outcomeResponse(outcome);
     const updated = getAskSnapshot(askId);
     if (!updated) return staleToast(locale);
     return JSON.parse(buildAskCard(updated)) as Record<string, unknown>;
@@ -235,7 +249,7 @@ export async function handleAskCardAction(
       const selections = parseFormSelections(formValue, questionCount);
       const outcome = submitAsk({ askId, nonce, by, selections, confirmEmpty });
       if (outcome === 'needs_empty_confirm') return armEmptyConfirmResponse(askId, locale);
-      if (outcome !== 'accepted') return toastForOutcome(outcome, locale);
+      if (outcome !== 'accepted') return outcomeResponse(outcome);
       return settledCardResponse(askId, {
         kind: 'answered',
         answers: selections,
@@ -249,7 +263,7 @@ export async function handleAskCardAction(
     // 预检（否则会绕过 nonce/canTalk，且需重复 mixed-question 规则）。
     const outcome = submitAsk({ askId, nonce, by, confirmEmpty });
     if (outcome === 'needs_empty_confirm') return armEmptyConfirmResponse(askId, locale);
-    if (outcome !== 'accepted') return toastForOutcome(outcome, locale);
+    if (outcome !== 'accepted') return outcomeResponse(outcome);
     const updated = getAskSnapshot(askId);
     const answers = updated?.selections ?? updated?.questions.map(() => []) ?? [];
     return settledCardResponse(askId, {
@@ -489,6 +503,45 @@ export function parseFormSelections(
     result.push(keys);
   }
   return result;
+}
+
+/**
+ * 点击者没有答复权限时，向 owner 弹一张授权卡（复用对话路径那套 grant 卡 + pending 表），
+ * 并把 toast 从死胡同「你没有权限」换成「已申请授权，通过后再点一次」。
+ *
+ * **授权通过后仍需再点一次**：ask 的答案取决于点的是哪个按钮，daemon 无从代替用户决定，
+ * 所以不像对话路径那样重放触发消息（ask-grant-request 故意不挂 messageData）。这里
+ * 也不动 broker 状态——unauthorized 本来就不改 ask，ask 保持 pending 等着被再点。
+ *
+ * ask 已失效（快照没了）时不发卡：授权也救不回一个不存在的 ask，直接回 stale。
+ */
+function escalateUnauthorized(
+  askId: string,
+  clickerOpenId: string,
+  locale: Locale | undefined,
+  deps: AskCardActionDeps,
+): { toast: { type: string; content: string } } {
+  const ask = getAskSnapshot(askId);
+  if (!ask) return staleToast(locale);
+  const requestGrant = deps.requestGrant ?? requestGrantForAskClicker;
+  const outcome = requestGrant(
+    {
+      larkAppId: ask.larkAppId,
+      chatId: ask.chatId,
+      cardMessageId: ask.cardMessageId,
+      rootMessageId: ask.rootMessageId,
+    },
+    clickerOpenId,
+  );
+  switch (outcome) {
+    case 'sent':
+      return { toast: { type: 'info', content: t('card.ask.toast.grant_requested', undefined, locale) } };
+    case 'pending':
+      return { toast: { type: 'info', content: t('card.ask.toast.grant_pending', undefined, locale) } };
+    case 'unavailable':
+      // 发不出授权卡（开放模式无 owner / owner 关了自动发卡）→ 回落原文案。
+      return { toast: { type: 'warning', content: t('card.ask.toast.unauthorized', undefined, locale) } };
+  }
 }
 
 function toastForOutcome(outcome: AskClickOutcome, locale?: Locale): { toast: { type: string; content: string } } | undefined {

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -204,7 +204,7 @@ export async function handleAskCardAction(
    *  「已申请、通过后再点一次」。其余 outcome 原样交给 toastForOutcome。 */
   const outcomeResponse = (outcome: AskClickOutcome) =>
     outcome === 'unauthorized'
-      ? escalateUnauthorized(askId, by, locale, deps)
+      ? escalateUnauthorized(askId, nonce, by, locale, deps)
       : toastForOutcome(outcome, locale);
 
   // 旧单选即答路径：按钮直接携带 key，调用 tryResolveAsk（单问单选便捷封装）。
@@ -513,16 +513,20 @@ export function parseFormSelections(
  * 所以不像对话路径那样重放触发消息（ask-grant-request 故意不挂 messageData）。这里
  * 也不动 broker 状态——unauthorized 本来就不改 ask，ask 保持 pending 等着被再点。
  *
- * ask 已失效（快照没了）时不发卡：授权也救不回一个不存在的 ask，直接回 stale。
+ * ask 已失效 / 已 settle / nonce 不匹配时不发卡：授权也救不回一个已结束或不存在的 ask。
+ * 这几条正常由 broker 先判（它的门序是 stale → already_settled → unauthorized），这里
+ * 再自查一遍是纵深防御——把「不为已决的 ask 骚扰 owner」从对 broker 内部顺序的隐式依赖
+ * 变成本函数自己的显式前置条件（pi review F2）。
  */
 function escalateUnauthorized(
   askId: string,
+  nonce: string,
   clickerOpenId: string,
   locale: Locale | undefined,
   deps: AskCardActionDeps,
 ): { toast: { type: string; content: string } } {
   const ask = getAskSnapshot(askId);
-  if (!ask) return staleToast(locale);
+  if (!ask || ask.settled || ask.nonce !== nonce) return staleToast(locale);
   const requestGrant = deps.requestGrant ?? requestGrantForAskClicker;
   const outcome = requestGrant(
     {
@@ -538,6 +542,9 @@ function escalateUnauthorized(
       return { toast: { type: 'info', content: t('card.ask.toast.grant_requested', undefined, locale) } };
     case 'pending':
       return { toast: { type: 'info', content: t('card.ask.toast.grant_pending', undefined, locale) } };
+    case 'denied':
+      // owner 已明确拒绝，还在冷却期 —— 说实话，别谎报「等 owner 处理」。
+      return { toast: { type: 'warning', content: t('card.ask.toast.grant_denied', undefined, locale) } };
     case 'unavailable':
       // 发不出授权卡（开放模式无 owner / owner 关了自动发卡）→ 回落原文案。
       return { toast: { type: 'warning', content: t('card.ask.toast.unauthorized', undefined, locale) } };

--- a/src/im/lark/ask-grant-request.ts
+++ b/src/im/lark/ask-grant-request.ts
@@ -27,14 +27,17 @@ import { listObservedBots } from '../../services/observed-bots-store.js';
 import { logger } from '../../utils/logger.js';
 import { buildGrantCard } from './card-builder.js';
 import { getUserProfile, replyMessage, sendMessage } from './client.js';
-import { clearPending, isThrottled, openPending } from './grant-pending.js';
+import { clearPending, openPending, throttleReason } from './grant-pending.js';
 
 /** 本次升级的结论。调用方据此选 toast 文案。 */
 export type AskGrantRequestOutcome =
   /** 已开卡并在后台发送 → 告诉点击者「已申请授权，通过后再点一次」。 */
   | 'sent'
-  /** 该 (bot, chat, 点击者) 已有未处置的申请、或处于拒绝冷却期 → 不重复发卡。 */
+  /** 该 (bot, chat, 点击者) 已有未处置的申请 → 让他等 owner 处理。 */
   | 'pending'
+  /** owner 已经拒绝过，还在 10 分钟冷却期内 → 必须跟 pending 分开说，
+   *  否则会把「已被拒绝」说成「等 owner 处理」（pi review F1）。 */
+  | 'denied'
   /** 发不了（未配 owner 的开放模式 / bot 关了 autoGrantRequestCards / bot 未注册）
    *  → 调用方回落到原本的「你没有权限回答这个 ask」。 */
   | 'unavailable';
@@ -51,7 +54,7 @@ export interface AskGrantRequestTarget {
 
 export interface AskGrantRequestDeps {
   getOwnerOpenId?: typeof getOwnerOpenId;
-  isThrottled?: typeof isThrottled;
+  throttleReason?: typeof throttleReason;
   openPending?: typeof openPending;
   clearPending?: typeof clearPending;
   /** 读 bot 配置（额度/有效期默认值 + autoGrantRequestCards 开关）。 */
@@ -78,7 +81,7 @@ export function requestGrantForAskClicker(
   deps: AskGrantRequestDeps = {},
 ): AskGrantRequestOutcome {
   const ownerOf = deps.getOwnerOpenId ?? getOwnerOpenId;
-  const throttled = deps.isThrottled ?? isThrottled;
+  const reasonOf = deps.throttleReason ?? throttleReason;
   const open = deps.openPending ?? openPending;
   const clear = deps.clearPending ?? clearPending;
   const readConfig = deps.getBotConfig ?? ((appId: string) => getBot(appId).config);
@@ -93,7 +96,9 @@ export function requestGrantForAskClicker(
     const owner = ownerOf(larkAppId);
     // 开放模式（没配 owner）没人能处置这张卡 —— 不发，回落原 toast。
     if (!owner) return 'unavailable';
-    if (throttled(larkAppId, chatId, clickerOpenId)) return 'pending';
+    // 节流原因要如实透出：owner 已拒绝（denied 冷却）不能说成「等 owner 处理」。
+    const throttled = reasonOf(larkAppId, chatId, clickerOpenId);
+    if (throttled) return throttled;
 
     const quota = botConfig.messageQuota?.defaultLimit ?? DEFAULT_GRANT_QUOTA;
     const durationMs = botConfig.grantDefaultDurationMs ?? DEFAULT_GRANT_DURATION_MS;

--- a/src/im/lark/ask-grant-request.ts
+++ b/src/im/lark/ask-grant-request.ts
@@ -1,0 +1,162 @@
+/**
+ * 无权限者点 `botmux ask` 卡片按钮时，弹授权申请卡给 owner（复用对话路径那套授权卡）。
+ *
+ * 与「对话弹授权卡」（event-dispatcher 的 maybeSendGrantRequestCard，入口 A）的关系：
+ * 卡片、pending/nonce 表、owner 处置分支、落库全部复用，**唯一区别是不重放**——
+ *
+ *   对话路径：openPending 挂上触发消息（messageData），owner 授权后 replayGrantedMessage
+ *             重放那条消息，用户无需再 @ 一遍。
+ *   ask 路径：故意不挂 messageData（getPendingMessage → undefined → 不触发重放），
+ *             因为「点按钮」不是一条可重放的消息：ask 的答案取决于点的是哪个选项，
+ *             daemon 侧无从代替用户决定。所以授权通过后**仍需用户再点一次**按钮。
+ *             ask 在此期间保持 pending（broker 对 unauthorized 不改状态），再点即生效。
+ *
+ * ACK 预算：card.action.trigger 只有 3s（botmux 用 2500ms 抢答，见 event-dispatcher
+ * 的 CARD_ACTION_ACK_TIMEOUT_MS），超时飞书会自己弹「未在线/超时未响应」盖掉我们的
+ * toast。所以本模块**同步决策、异步发卡**：判定（配置/owner/节流）和 openPending 都是
+ * 纯内存同步操作，取名字 + 发卡走 fire-and-forget，调用方拿到结论立刻 ACK。
+ */
+import { getBot, getOwnerOpenId } from '../../bot-registry.js';
+import { config } from '../../config.js';
+import { localeForBot } from '../../i18n/index.js';
+import {
+  DEFAULT_GRANT_DURATION_MS,
+  DEFAULT_GRANT_QUOTA,
+} from '../../services/grant-policy.js';
+import { listObservedBots } from '../../services/observed-bots-store.js';
+import { logger } from '../../utils/logger.js';
+import { buildGrantCard } from './card-builder.js';
+import { getUserProfile, replyMessage, sendMessage } from './client.js';
+import { clearPending, isThrottled, openPending } from './grant-pending.js';
+
+/** 本次升级的结论。调用方据此选 toast 文案。 */
+export type AskGrantRequestOutcome =
+  /** 已开卡并在后台发送 → 告诉点击者「已申请授权，通过后再点一次」。 */
+  | 'sent'
+  /** 该 (bot, chat, 点击者) 已有未处置的申请、或处于拒绝冷却期 → 不重复发卡。 */
+  | 'pending'
+  /** 发不了（未配 owner 的开放模式 / bot 关了 autoGrantRequestCards / bot 未注册）
+   *  → 调用方回落到原本的「你没有权限回答这个 ask」。 */
+  | 'unavailable';
+
+/** ask 卡片定位所需的最小字段（取自 PendingAsk 快照）。 */
+export interface AskGrantRequestTarget {
+  larkAppId: string;
+  chatId: string;
+  /** ask 卡片自身的 message_id：授权卡回复到它下面，跟问题贴在一起。 */
+  cardMessageId?: string;
+  /** thread-scope 时为话题根 `om_`；chat-scope 时为 null。决定是否 reply_in_thread。 */
+  rootMessageId: string | null;
+}
+
+export interface AskGrantRequestDeps {
+  getOwnerOpenId?: typeof getOwnerOpenId;
+  isThrottled?: typeof isThrottled;
+  openPending?: typeof openPending;
+  clearPending?: typeof clearPending;
+  /** 读 bot 配置（额度/有效期默认值 + autoGrantRequestCards 开关）。 */
+  getBotConfig?: (larkAppId: string) => {
+    autoGrantRequestCards?: boolean;
+    messageQuota?: { defaultLimit?: number };
+    grantDefaultDurationMs?: number;
+  };
+  /** 展示名解析（异步，不在 ACK 路径上）。 */
+  resolveTargetName?: (larkAppId: string, chatId: string, openId: string) => Promise<string>;
+  /** 实际投递授权卡（异步，不在 ACK 路径上）。 */
+  deliverCard?: (target: AskGrantRequestTarget, cardJson: string) => Promise<void>;
+}
+
+/**
+ * 同步决定要不要为这个点击者申请授权，并（若要）在后台把授权卡发出去。
+ *
+ * 返回值只反映**同步**判定；发卡失败会在后台 clearPending，让点击者下次再点能重试
+ * （与对话路径发卡失败的处理一致，避免被节流永久压死、owner 永远看不到卡）。
+ */
+export function requestGrantForAskClicker(
+  ask: AskGrantRequestTarget,
+  clickerOpenId: string,
+  deps: AskGrantRequestDeps = {},
+): AskGrantRequestOutcome {
+  const ownerOf = deps.getOwnerOpenId ?? getOwnerOpenId;
+  const throttled = deps.isThrottled ?? isThrottled;
+  const open = deps.openPending ?? openPending;
+  const clear = deps.clearPending ?? clearPending;
+  const readConfig = deps.getBotConfig ?? ((appId: string) => getBot(appId).config);
+  const resolveName = deps.resolveTargetName ?? defaultResolveTargetName;
+  const deliver = deps.deliverCard ?? defaultDeliverCard;
+
+  const { larkAppId, chatId } = ask;
+  try {
+    const botConfig = readConfig(larkAppId);
+    // 与对话路径同一个开关：owner 关了就一律不弹卡。
+    if (botConfig.autoGrantRequestCards === false) return 'unavailable';
+    const owner = ownerOf(larkAppId);
+    // 开放模式（没配 owner）没人能处置这张卡 —— 不发，回落原 toast。
+    if (!owner) return 'unavailable';
+    if (throttled(larkAppId, chatId, clickerOpenId)) return 'pending';
+
+    const quota = botConfig.messageQuota?.defaultLimit ?? DEFAULT_GRANT_QUOTA;
+    const durationMs = botConfig.grantDefaultDurationMs ?? DEFAULT_GRANT_DURATION_MS;
+    // 第 5 个参数 messageData 故意留空：授权通过后不重放，用户再点一次按钮即可（见文件头）。
+    const nonce = open(larkAppId, chatId, clickerOpenId, quota, undefined, durationMs);
+
+    // 取名字 + 发卡都不在 ACK 路径上：失败只回滚 pending，不影响本次 toast。
+    void (async () => {
+      try {
+        const name = await resolveName(larkAppId, chatId, clickerOpenId);
+        const cardJson = buildGrantCard(
+          {
+            ownerOpenId: owner,
+            targets: [{ openId: clickerOpenId, name }],
+            chatId,
+            nonce,
+            mode: 'request',
+            quota,
+            durationMs,
+          },
+          localeForBot(larkAppId),
+        );
+        await deliver(ask, cardJson);
+      } catch (err) {
+        clear(larkAppId, chatId, clickerOpenId);
+        logger.debug(`ask grant request card send failed: ${err}`);
+      }
+    })();
+
+    return 'sent';
+  } catch (err) {
+    // bot 未注册（getBot 抛）等异常一律降级：ask 点击链路绝不能因为升级授权而挂掉。
+    logger.debug(`ask grant request skipped: ${err}`);
+    return 'unavailable';
+  }
+}
+
+/** 名字优先级：observed-bots 花名册（/introduce 登记过的 bot）→ 通讯录 → 截短 open_id。
+ *  卡片回调没有 mentions，所以拿不到对话路径那条「本消息 mentions」的免费来源。 */
+async function defaultResolveTargetName(
+  larkAppId: string,
+  chatId: string,
+  openId: string,
+): Promise<string> {
+  const observedName = listObservedBots(config.session.dataDir, larkAppId, chatId)
+    .find(b => b.openId === openId)?.name;
+  if (observedName) return observedName;
+  const profileName = (await getUserProfile(larkAppId, openId).catch(() => null))?.name;
+  if (profileName) return profileName;
+  return `${openId.slice(0, 10)}…${openId.slice(-4)}`;
+}
+
+/** 把授权卡贴到 ask 卡片下面：thread-scope 走 reply_in_thread 留在话题里，
+ *  chat-scope 引用回复 ask 卡片，都拿不到锚点时退回群里直发。 */
+async function defaultDeliverCard(ask: AskGrantRequestTarget, cardJson: string): Promise<void> {
+  // rootMessageId 在 chat-scope 下其实是 chat_id（oc_）而非 message_id，按前缀判真话题。
+  const inThread = typeof ask.rootMessageId === 'string' && ask.rootMessageId.startsWith('om_');
+  const anchor = ask.cardMessageId?.startsWith('om_')
+    ? ask.cardMessageId
+    : (inThread ? ask.rootMessageId! : undefined);
+  if (anchor) {
+    await replyMessage(ask.larkAppId, anchor, cardJson, 'interactive', inThread);
+    return;
+  }
+  await sendMessage(ask.larkAppId, ask.chatId, cardJson, 'interactive');
+}

--- a/src/im/lark/grant-pending.ts
+++ b/src/im/lark/grant-pending.ts
@@ -133,23 +133,44 @@ export function markDenied(larkAppId: string, chatId: string, target: string): v
   table.set(key(larkAppId, chatId, target), { state: 'denied', ts: now });
 }
 
-/** 入口 A 节流判断：pending 中、或 denied 冷却未过 → true（静默不发卡）。 */
+/** 入口 A 节流判断：pending 中、或 denied 冷却未过 → true（静默不发卡）。
+ *  只需要「要不要发卡」的布尔（对话路径静默丢弃，无需区分原因）；要给用户回话、
+ *  需要区分「等 owner 处理」和「已被拒绝」时用 throttleReason。 */
 export function isThrottled(larkAppId: string, chatId: string, target: string): boolean {
+  return throttleReason(larkAppId, chatId, target) !== null;
+}
+
+/**
+ * 节流原因（null = 未节流，可发卡）。
+ *
+ * 与 isThrottled 的关系：后者是本函数的布尔化封装。拆开是因为两者的**消费方式**不同——
+ * 对话路径（maybeSendGrantRequestCard）节流时静默 return，用户看不到任何反馈，所以
+ * pending 与 denied 混成一个 true 无害；而 ask 卡片点击必须回一句 toast，混用会在
+ * owner **已经拒绝**后仍告诉点击者「等 owner 处理」，把已决事项说成待决（pi review F1）。
+ *
+ * 顺带回收无效条目（与旧 isThrottled 行为一致，不能丢）：废弃的 pending 过 24h、
+ * 冷却已过的 denied，都即时删除，让同一发送方能重新申请。
+ */
+export function throttleReason(
+  larkAppId: string,
+  chatId: string,
+  target: string,
+): 'pending' | 'denied' | null {
   const k = key(larkAppId, chatId, target);
   const e = table.get(k);
-  if (!e) return false;
+  if (!e) return null;
   if (e.state === 'pending') {
     // 废弃 pending（owner 一直没处置，或发卡失败残留）过 stale 窗口 → 本 key 即时回收，
     // 让同一发送方能重新申请。否则只有「别的 target 触发全表 prune」或 daemon 重启才会清，
     // 单一发送方反复 @ 会被永久静默压死、owner 永远看不到卡片。与下面 denied 的回收同构。
-    if (Date.now() - e.ts < STALE_PENDING_MS) return true;
+    if (Date.now() - e.ts < STALE_PENDING_MS) return 'pending';
     table.delete(k);
-    return false;
+    return null;
   }
   // 冷却已过的 denied 不再节流，且无任何用途 → 顺手删除，避免「每个被拒用户」永久占位。
-  if (Date.now() - e.ts < DENY_COOLDOWN_MS) return true;
+  if (Date.now() - e.ts < DENY_COOLDOWN_MS) return 'denied';
   table.delete(k);
-  return false;
+  return null;
 }
 
 export function _resetForTest(): void { table.clear(); lastPrunedAt = 0; }

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -257,7 +257,10 @@ describe('handleAskCardAction', () => {
     await expect(promise).resolves.toMatchObject({ kind: 'answered', answers: [['deploy']], by: 'ou_owner' });
   });
 
-  it('旧单选路径 ask_select：非授权人返回 warning toast', async () => {
+  // 未授权点击现在会先尝试弹授权卡（见 test/ask-unauthorized-grant.test.ts）。本用例的
+  // 'cli_ask' 未 registerBot → 升级模块取不到 bot 配置，降级成 'unavailable' 回落到
+  // 原「没有权限」文案。这条断言因此同时锁住了「升级失败绝不吞掉反馈」的降级契约。
+  it('旧单选路径 ask_select：非授权人返回 warning toast（授权卡发不出时的降级）', async () => {
     let captured: PendingAsk | undefined;
     setCardDispatcher({
       async send(ask) {

--- a/test/ask-unauthorized-grant.test.ts
+++ b/test/ask-unauthorized-grant.test.ts
@@ -21,7 +21,7 @@ import {
   requestGrantForAskClicker,
   type AskGrantRequestDeps,
 } from '../src/im/lark/ask-grant-request.js';
-import { _resetForTest as _resetPending, isThrottled } from '../src/im/lark/grant-pending.js';
+import { _resetForTest as _resetPending, isThrottled, markDenied } from '../src/im/lark/grant-pending.js';
 import { DEFAULT_GRANT_QUOTA, DEFAULT_GRANT_DURATION_MS } from '../src/services/grant-policy.js';
 
 const ASK = {
@@ -94,6 +94,17 @@ describe('requestGrantForAskClicker', () => {
     expect(requestGrantForAskClicker(ASK, 'ou_pm', okDeps())).toBe('sent');
     const deliverCard = vi.fn(async () => {});
     expect(requestGrantForAskClicker(ASK, 'ou_pm', okDeps({ deliverCard }))).toBe('pending');
+    expect(deliverCard).not.toHaveBeenCalled();
+  });
+
+  // pi review F1：owner 点过「拒绝」后处于 10min 冷却期，必须与 pending 区分开——
+  // 否则会把「已被拒绝」这件已决的事说成「等 owner 处理」。
+  it('owner 拒绝后的冷却期 → denied（不再混报成 pending）', () => {
+    expect(requestGrantForAskClicker(ASK, 'ou_pm', okDeps())).toBe('sent');
+    markDenied('cli_ask', 'oc_chat', 'ou_pm');
+    const deliverCard = vi.fn(async () => {});
+    expect(requestGrantForAskClicker(ASK, 'ou_pm', okDeps({ deliverCard }))).toBe('denied');
+    // 冷却期内同样不重复骚扰 owner
     expect(deliverCard).not.toHaveBeenCalled();
   });
 
@@ -237,5 +248,64 @@ describe('ask 卡片点击：unauthorized → 授权卡', () => {
     const res: any = await click(askId, 'wrong-nonce', 'ou_pm', { requestGrant });
     expect(res.toast.content).toContain('失效');
     expect(requestGrant).not.toHaveBeenCalled();
+  });
+
+  it('owner 拒绝过 → toast 说实话（已拒绝），不是「等 owner 处理」', async () => {
+    const { askId, nonce } = await seedAsk();
+    const res: any = await click(askId, nonce, 'ou_pm', { requestGrant: () => 'denied' as const });
+    expect(res.toast.type).toBe('warning');
+    expect(res.toast.content).toContain('已拒绝');
+    expect(res.toast.content).not.toContain('等 owner 处理');
+  });
+
+  // pi review F2 的纵深防御：即便 broker 门序哪天被改成先判鉴权，escalateUnauthorized
+  // 自己也会拦住「为已 settle / nonce 不匹配的 ask 去要授权」。这里用桩把 broker
+  // 强行改成「先返回 unauthorized」，验证升级仍不发卡。
+  it('纵深防御：broker 若先报 unauthorized，已 settle 的 ask 也不会去要授权', async () => {
+    const { askId, nonce } = await seedAsk();
+    await click(askId, nonce, 'ou_owner');          // 先被 owner 答掉
+    const broker = await import('../src/core/ask-broker.js');
+    const spy = vi.spyOn(broker, 'tryResolveAsk').mockReturnValue('unauthorized');
+    try {
+      const requestGrant = vi.fn(() => 'sent' as const);
+      const res: any = await click(askId, nonce, 'ou_pm', { requestGrant });
+      expect(res.toast.content).toContain('失效');
+      expect(requestGrant).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // pi 提的 nit：toggle / submit 走的是同一个 outcomeResponse 闭包，但没端到端测过。
+  it('多问卡（toggle 路径）未授权点击同样升级发卡', async () => {
+    let cap: { askId: string; nonce: string } | undefined;
+    setCardDispatcher({
+      async send(a) { cap = { askId: a.askId, nonce: a.nonce }; return { messageId: 'om_askcard' }; },
+    });
+    registerAsk({
+      larkAppId: 'cli_ask', chatId: 'oc_chat', rootMessageId: 'om_root', sessionId: 's2',
+      questions: [
+        { prompt: 'q1', options: [{ key: 'a', label: 'A' }], multiSelect: true },
+        { prompt: 'q2', options: [{ key: 'b', label: 'B' }], multiSelect: false },
+      ],
+      timeoutMs: 10_000,
+    });
+    await vi.waitFor(() => expect(cap).toBeDefined());
+    const requestGrant = vi.fn(() => 'sent' as const);
+
+    // toggle
+    const toggled: any = await handleAskCardAction(
+      { operator: { open_id: 'ou_pm' }, action: { value: { action: 'ask_toggle', ask_id: cap!.askId, nonce: cap!.nonce, question_index: '0', key: 'a' } } },
+      { requestGrant },
+    );
+    expect(toggled.toast.content).toContain('再点一次');
+
+    // submit
+    const submitted: any = await handleAskCardAction(
+      { operator: { open_id: 'ou_pm' }, action: { value: { action: 'ask_submit', ask_id: cap!.askId, nonce: cap!.nonce } } },
+      { requestGrant },
+    );
+    expect(submitted.toast.content).toContain('再点一次');
+    expect(requestGrant).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/ask-unauthorized-grant.test.ts
+++ b/test/ask-unauthorized-grant.test.ts
@@ -1,0 +1,241 @@
+/**
+ * 无权限者点 ask 卡片 → 弹授权卡（复用对话路径的 grant 卡）。
+ * Run: pnpm vitest run test/ask-unauthorized-grant.test.ts
+ *
+ * 覆盖两层：
+ *  1. ask-grant-request 模块本身（发卡判定 / 不重放 / 节流 / 失败回滚）
+ *  2. ask-card 点击链路：unauthorized → 升级发卡 + 新 toast，且 ask 仍 pending，
+ *     owner 授权后**再点一次**才作答（申晗要的关键区别）。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  _resetForTest as _resetBroker,
+  registerAsk,
+  setCanTalkChecker,
+  setCardDispatcher,
+  _getPending,
+} from '../src/core/ask-broker.js';
+import { ASK_SELECT_ACTION, handleAskCardAction } from '../src/im/lark/ask-card.js';
+import {
+  requestGrantForAskClicker,
+  type AskGrantRequestDeps,
+} from '../src/im/lark/ask-grant-request.js';
+import { _resetForTest as _resetPending, isThrottled } from '../src/im/lark/grant-pending.js';
+import { DEFAULT_GRANT_QUOTA, DEFAULT_GRANT_DURATION_MS } from '../src/services/grant-policy.js';
+
+const ASK = {
+  larkAppId: 'cli_ask',
+  chatId: 'oc_chat',
+  cardMessageId: 'om_askcard',
+  rootMessageId: 'om_root' as string | null,
+};
+
+beforeEach(() => {
+  _resetPending();
+  setCanTalkChecker((_app, _chat, openId) => openId === 'ou_owner');
+});
+afterEach(() => {
+  _resetBroker();
+  _resetPending();
+});
+
+/** 默认可发卡的依赖：有 owner、开关默认开、发卡成功。 */
+function okDeps(over: Partial<AskGrantRequestDeps> = {}): AskGrantRequestDeps {
+  return {
+    getOwnerOpenId: () => 'ou_owner',
+    getBotConfig: () => ({}),
+    resolveTargetName: async () => '产品负责人',
+    deliverCard: async () => {},
+    ...over,
+  };
+}
+
+describe('requestGrantForAskClicker', () => {
+  it('有 owner 且未节流 → sent，并开出 pending（后续同人被节流）', () => {
+    expect(requestGrantForAskClicker(ASK, 'ou_pm', okDeps())).toBe('sent');
+    expect(isThrottled('cli_ask', 'oc_chat', 'ou_pm')).toBe(true);
+  });
+
+  it('关键区别：openPending 不挂 messageData —— 授权后不重放，需再点一次', () => {
+    const openPending = vi.fn(() => 'n1');
+    requestGrantForAskClicker(ASK, 'ou_pm', okDeps({ openPending: openPending as any }));
+    expect(openPending).toHaveBeenCalledTimes(1);
+    const args = openPending.mock.calls[0] as unknown[];
+    // 签名：(appId, chatId, target, quota, messageData, durationMs)
+    expect(args[0]).toBe('cli_ask');
+    expect(args[1]).toBe('oc_chat');
+    expect(args[2]).toBe('ou_pm');
+    expect(args[3]).toBe(DEFAULT_GRANT_QUOTA);
+    // 第 5 个参数必须为空：对话路径挂消息用于重放，ask 路径故意不挂。
+    expect(args[4]).toBeUndefined();
+    expect(args[5]).toBe(DEFAULT_GRANT_DURATION_MS);
+  });
+
+  it('卡片以 request 模式发出（成员不能自助申请全局）', async () => {
+    let sent: string | undefined;
+    requestGrantForAskClicker(ASK, 'ou_pm', okDeps({
+      deliverCard: async (_t, json) => { sent = json; },
+    }));
+    await vi.waitFor(() => expect(sent).toBeDefined());
+    const card = JSON.parse(sent!);
+    const flat = JSON.stringify(card);
+    expect(flat).toContain('<at id=ou_owner></at>');
+    expect(flat).toContain('产品负责人');
+    expect(flat).toContain('grant_chat');
+    expect(flat).toContain('grant_deny');
+    // request 模式无「全局授权」按钮。
+    expect(flat).not.toContain('grant_global');
+    // 目标是点击者本人。
+    expect(flat).toContain('ou_pm');
+  });
+
+  it('已 pending / 冷却期 → pending（不重复发卡）', () => {
+    expect(requestGrantForAskClicker(ASK, 'ou_pm', okDeps())).toBe('sent');
+    const deliverCard = vi.fn(async () => {});
+    expect(requestGrantForAskClicker(ASK, 'ou_pm', okDeps({ deliverCard }))).toBe('pending');
+    expect(deliverCard).not.toHaveBeenCalled();
+  });
+
+  it('开放模式（无 owner）→ unavailable', () => {
+    expect(requestGrantForAskClicker(ASK, 'ou_pm', okDeps({ getOwnerOpenId: () => undefined }))).toBe('unavailable');
+    expect(isThrottled('cli_ask', 'oc_chat', 'ou_pm')).toBe(false);
+  });
+
+  it('owner 关掉 autoGrantRequestCards → unavailable（沿用对话路径同一个开关）', () => {
+    const outcome = requestGrantForAskClicker(ASK, 'ou_pm', okDeps({
+      getBotConfig: () => ({ autoGrantRequestCards: false }),
+    }));
+    expect(outcome).toBe('unavailable');
+    expect(isThrottled('cli_ask', 'oc_chat', 'ou_pm')).toBe(false);
+  });
+
+  it('bot 未注册（getBotConfig 抛）→ unavailable，不让 ask 点击链路挂掉', () => {
+    const outcome = requestGrantForAskClicker(ASK, 'ou_pm', okDeps({
+      getBotConfig: () => { throw new Error('Bot not registered: cli_ask'); },
+    }));
+    expect(outcome).toBe('unavailable');
+  });
+
+  it('发卡失败 → 后台清掉 pending，下次再点能重试', async () => {
+    requestGrantForAskClicker(ASK, 'ou_pm', okDeps({
+      deliverCard: async () => { throw new Error('lark 500'); },
+    }));
+    await vi.waitFor(() => expect(isThrottled('cli_ask', 'oc_chat', 'ou_pm')).toBe(false));
+  });
+
+  it('chat-scope（rootMessageId 非 om_）仍投递：锚到 ask 卡片本身', async () => {
+    let anchored: unknown;
+    requestGrantForAskClicker(
+      { ...ASK, rootMessageId: null },
+      'ou_pm',
+      okDeps({ deliverCard: async (target) => { anchored = target.cardMessageId; } }),
+    );
+    await vi.waitFor(() => expect(anchored).toBe('om_askcard'));
+  });
+});
+
+describe('ask 卡片点击：unauthorized → 授权卡', () => {
+  /** 注册一个 pending ask，返回其 askId/nonce。 */
+  async function seedAsk() {
+    let captured: { askId: string; nonce: string } | undefined;
+    setCardDispatcher({
+      async send(ask) {
+        captured = { askId: ask.askId, nonce: ask.nonce };
+        return { messageId: 'om_askcard' };
+      },
+    });
+    const promise = registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      questions: [{
+        prompt: '要发布吗？',
+        options: [{ key: 'deploy', label: '发布' }, { key: 'rollback', label: '回滚' }],
+        multiSelect: false,
+      }],
+      timeoutMs: 10_000,
+    });
+    await vi.waitFor(() => expect(captured).toBeDefined());
+    return { ...captured!, promise };
+  }
+
+  const click = (askId: string, nonce: string, by: string, deps?: any) =>
+    handleAskCardAction(
+      { operator: { open_id: by }, action: { value: { action: ASK_SELECT_ACTION, ask_id: askId, nonce, key: 'deploy' } } },
+      deps,
+    );
+
+  it('非授权人点击 → 发授权卡 + toast 提示「通过后再点一次」', async () => {
+    const { askId, nonce } = await seedAsk();
+    const requestGrant = vi.fn(() => 'sent' as const);
+    const res: any = await click(askId, nonce, 'ou_pm', { requestGrant });
+    expect(res.toast.content).toContain('再点一次');
+    // 授权卡带的是这个 ask 的 chat / 卡片锚点，target 是点击者。
+    expect(requestGrant).toHaveBeenCalledWith(
+      expect.objectContaining({ larkAppId: 'cli_ask', chatId: 'oc_chat', cardMessageId: 'om_askcard' }),
+      'ou_pm',
+    );
+  });
+
+  it('重复点击（已在申请中）→ toast 说等 owner 处理，不重复发卡', async () => {
+    const { askId, nonce } = await seedAsk();
+    const res: any = await click(askId, nonce, 'ou_pm', { requestGrant: () => 'pending' as const });
+    expect(res.toast.content).toContain('等 owner');
+  });
+
+  it('发不出授权卡（无 owner / 开关关闭）→ 回落原「没有权限」文案', async () => {
+    const { askId, nonce } = await seedAsk();
+    const res: any = await click(askId, nonce, 'ou_pm', { requestGrant: () => 'unavailable' as const });
+    expect(res.toast.type).toBe('warning');
+    expect(res.toast.content).toContain('没有权限');
+  });
+
+  it('核心语义：升级发卡不动 ask —— 授权通过后要再点一次才作答', async () => {
+    const { askId, nonce, promise } = await seedAsk();
+    // ① 无权限点击：发卡，ask 不被 settle、也不被消耗
+    const first: any = await click(askId, nonce, 'ou_pm', { requestGrant: () => 'sent' as const });
+    expect(first.toast.content).toContain('再点一次');
+    expect(_getPending(askId)?.settled).toBe(false);
+
+    // ② owner 授权（这里直接放行该 open_id，等价 chatGrant 落库后 canTalk 通过）
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner' || openId === 'ou_pm');
+
+    // ③ 授权本身不作答：没有第二次点击，ask 依旧 pending
+    expect(_getPending(askId)?.settled).toBe(false);
+
+    // ④ 再点一次 → 这次真的作答
+    const second: any = await click(askId, nonce, 'ou_pm');
+    expect(second?.toast).toBeUndefined();
+    await expect(promise).resolves.toMatchObject({
+      kind: 'answered', answers: [['deploy']], by: 'ou_pm',
+    });
+  });
+
+  it('ask 已失效时不发卡（授权也救不回不存在的 ask）', async () => {
+    const requestGrant = vi.fn(() => 'sent' as const);
+    const res: any = await click('ask-gone', 'n-gone', 'ou_pm', { requestGrant });
+    expect(res.toast.content).toContain('失效');
+    expect(requestGrant).not.toHaveBeenCalled();
+  });
+
+  it('已被别人答掉的 ask：非授权人再点不发卡（broker 的 already_settled 先于 unauthorized）', async () => {
+    const { askId, nonce } = await seedAsk();
+    // owner 先把它答掉
+    await click(askId, nonce, 'ou_owner');
+    const requestGrant = vi.fn(() => 'sent' as const);
+    const res: any = await click(askId, nonce, 'ou_pm', { requestGrant });
+    // 落到 already_settled，不该为一个已结束的 ask 去骚扰 owner 要授权
+    expect(res.toast.content).toContain('已经被回答');
+    expect(requestGrant).not.toHaveBeenCalled();
+  });
+
+  it('nonce 不匹配（重启前的旧卡）不发卡：走 stale，不是 unauthorized', async () => {
+    const { askId } = await seedAsk();
+    const requestGrant = vi.fn(() => 'sent' as const);
+    const res: any = await click(askId, 'wrong-nonce', 'ou_pm', { requestGrant });
+    expect(res.toast.content).toContain('失效');
+    expect(requestGrant).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 改了什么

非授权人点 `botmux ask` 卡片按钮，原本只得到一句「你没有权限回答这个 ask」——死胡同：点击者不知道该找谁，owner 也不知道有人想答。现在改成**弹一张授权卡给 owner**，复用「对话弹授权卡」那一整套：

| 复用 | 位置 |
|---|---|
| 卡片本体 | `buildGrantCard(..., mode:'request')` — 没有新卡片类型 |
| nonce 防重放 + 节流 | `grant-pending.ts` 的 `openPending` / `isThrottled` / `clearPending` |
| owner 处置分支 | `card-handler.ts` 现有 `grant_chat` / `grant_deny` — 没有新 action |
| 落库 | `grant-store.ts` 的 `addChatGrant`（talk-only，不碰 allowedUsers） |

因为 key 是 `(appId, chatId, target)`，ask 触发的申请和消息触发的申请天然共享同一份去重/节流，不会一人两卡。

## 与对话路径的唯一区别：不重放

对话路径把触发消息挂在 pending 上（`openPending` 第 5 个参数 `messageData`），owner 一授权就 `replayGrantedMessage` 重放那条消息，用户不用再 @ 一遍。

**ask 这边故意不挂**，所以授权通过后**用户仍需再点一次按钮**（申晗明确要的行为）。理由：「点按钮」不是一条可重放的消息——答案取决于点的是哪个选项，daemon 无从代替用户决定。`unauthorized` 本来就不改 broker 状态，所以 ask 全程保持 pending，等着被再点一次。

## toast 三态（原来只有一句）

| 情况 | 文案 |
|---|---|
| 卡已发出 | 已向 owner 申请授权，通过后请再点一次 |
| 已在申请中 / 拒绝冷却期 | 授权申请已提交，等 owner 处理后再点一次 |
| 发不出（开放模式无 owner / owner 关了 `autoGrantRequestCards`） | 回落原「你没有权限回答这个 ask」 |

最后一行是刻意的降级契约：升级失败绝不静默吞掉反馈。

## ACK 预算（3s）

`card.action.trigger` 只有 3s，botmux 用 `CARD_ACTION_ACK_TIMEOUT_MS=2500` 抢答，超时飞书会自己弹「未在线/超时未响应」盖掉我们的 toast。所以本模块**同步决策、异步发卡**：判定（配置/owner/节流）+ `openPending` 全是纯内存同步操作；取展示名（可能查通讯录）和投递卡片走 fire-and-forget，失败回滚 pending 让点击者下次能重试。实测同步段 0ms。

## 影响范围评估

- **只碰 ask 卡片点击的 unauthorized 分支**。`accepted` / `toggled` / `already_settled` / `stale` / `needs_empty_confirm` 全部原样走 `toastForOutcome`。
- broker 的门序是 `stale` → `already_settled` → `unauthorized`，所以**已被答掉的 ask、nonce 不匹配的旧卡都不会**去骚扰 owner 要授权（各有单测锁住）。
- `handleAskCardAction` 新增的 `deps` 参数有默认值 `{}`，唯一生产调用方 `card-handler.ts:1356` 无需改动。
- 对话路径（`maybeSendGrantRequestCard`）、owner `/grant` 路径、`grant-card`/`grant-pending`/`grant-store` 本体**零改动**。
- 跨 CLI / 跨后端 / 跨会话类型：ask 是 IM 层通用能力，不碰 `adapters/`，thread-scope 与 chat-scope 都覆盖（`rootMessageId` 按 `om_` 前缀判真话题，chat-scope 锚到 ask 卡片本身）。
- bot 未注册等异常一律 catch 成 `unavailable` 降级——ask 点击链路绝不因为「顺手申请授权」而挂掉。

## 测试验证

```
$ bun run build
✅ 绿（tsc + typecheck:scripts + dashboard:bundle + audit-dist + audit-embedded-assets 全过）

$ npx vitest run test/ask-unauthorized-grant.test.ts
✅ Test Files 1 passed | Tests 16 passed

$ npx vitest run test/ask-card.test.ts test/ask-broker.test.ts test/grant-card.test.ts \
    test/grant-pending.test.ts test/card-handler-grant.test.ts test/card-handler-grant-partial.test.ts \
    test/grant-gates.test.ts test/grant-command.test.ts test/grant-store.test.ts test/ask-api.test.ts
✅ Test Files 10 passed | Tests 243 passed
```

新增 16 项覆盖：`sent`/`pending`/`unavailable` 三态、**`openPending` 第 5 参数必须为空（不重放）**、request 模式无 `grant_global` 按钮、节流不重复发卡、发卡失败回滚 pending、chat-scope 锚点、bot 未注册降级，以及核心语义那条——

```
✓ 核心语义：升级发卡不动 ask —— 授权通过后要再点一次才作答
```
（无权限点击 → 发卡且 ask 未 settle → 放行 canTalk → **仍未 settle** → 再点一次才 resolve 出 `answers:[['deploy']]`）

另外拿真 bot（`registerBot` + `apiOnly` 绕开 Lark client）跑过端到端探针，确认走真实 `buildGrantCard` 产出的就是那张 🔑 使用授权卡：正确 `@owner`、展示名解析、`grant_chat`/`grant_deny` 在、request 模式**没有** `grant_global`、锚在 ask 卡片下、重复点被节流、同步返回 0ms。

## UI 示意

卡片就是现有的 🔑 使用授权卡，`buildGrantCard` **未改一行**，故无新 UI：

```
🔑 使用授权
发送方 产品负责人 申请在本群使用我。@申晗 是否允许 ta 在本群与我对话？
有效期 [1 小时 ▾]      消息额度 [3]
[授权本群对话]  [拒绝]
```

## 授权口径：保留 chatGrant，不做 run 内授权（已定）

授权卡默认给的是「1 小时 / 3 条」的**对话权**（chatGrant）——owner 点一次授权，对方顺带获得在本群跟 bot 说话的权限。经 reviewer(pi) 核对，**保留此口径**，理由：

1. **语义没有错位**：ask 答复权本来就是 canTalk（`ask-broker.ts` 的 `isAuthorizedToAnswer → canTalkChecker`），系统里**不存在**更窄的「答这一个 ask」权限。chatGrant 批的就是 broker 查的那个权限。
2. **需求就是复用**：原始需求是「复用对话弹授权卡的逻辑」。v3-revisit 式 run 内授权 = 新卡 + 新 handler + broker 里新的 per-ask 授权记录，那不是复用，是另一个 PR 的体量。
3. **owner 知情同意**：卡面明摆着有效期/额度，按钮写「授权本群对话」，且能当场改。
4. **可审计可撤销**：走现有 `/grant` 体系；run 内临时授权反而得另做撤销工具。
5. **额度不会造成预期落差**（pi 查证）：`grantNotExpired` 只看时间不看额度，额度在消息消费时才扣——所以「3 条」并不限制答 ask，owner 实际批的就是「1 小时对话权」，与卡面一致。

**什么时候才该做窄口径**：等 owner 真实反馈「我只想让他答这一个 ask」时，在 `isAuthorizedToAnswer` 里并一条 per-ask 允许记录。那是新需求，不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
