### PR TITLE
feat(card): 支持会话级 CardKit 流式卡片与运行态桥接

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -144,6 +144,24 @@ import {
 } from './core/shutdown-budgets.js';
 import { describeSendFailure, dispatchPrimaryMessage, findStdinAliasAttachment, normalizeInteractiveCardInput, sendFileAttachments, sendVideoAttachments, shouldSendAsPureVideo, validateSlashSend, validateVideoAttachments } from './cli/send-dispatch.js';
 import { buildCardPatchSuccessOutput, CARD_COMMAND_USAGE, CARD_PATCH_USAGE, cardPatchArgsWantHelp, executeCardPatch, parseCardPatchArgs, readCardPatchInput } from './cli/card-dispatch.js';
+import {
+  buildCardStreamSuccessOutput,
+  CARD_STREAM_USAGE,
+  cardMessageRouteFromDetail,
+  cardStreamArgsWantHelp,
+  executeCardStreamFinish,
+  executeCardStreamOpen,
+  executeCardStreamReanchor,
+  executeCardStreamSnapshot,
+  executeCardStreamWrite,
+  mapCardStreamError,
+  parseCardStreamArgs,
+  readCardStreamContent,
+} from './cli/card-stream-dispatch.js';
+import { parseCardRuntimeStatusArgs } from './cli/card-runtime-status-dispatch.js';
+import { readCardStreamUsageSnapshot } from './cli/card-stream-usage.js';
+import { CardStreamStore } from './services/card-stream-store.js';
+import { CardRuntimeStatusBridge } from './services/card-runtime-status-bridge.js';
 import { dispatchDeferredTopicSend, reusableDeferredTopicRoot, type DeferredScheduleRunData } from './cli/deferred-topic-send.js';
 import { readDeferredTopicBinding } from './core/deferred-topic-binding.js';
 import { resolveDaemonEnv } from './cli/daemon-lifecycle-env.js';
@@ -6165,6 +6183,8 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
                        原地更新之前用 send --card-file/--card-json 发出的自定义卡片
                        （不发新消息、不换群/话题）；messageId 取自 send 成功输出的 .messageId，
                        卡片安全校验与 send 相同；[--session-id <sid>] 可手动指定会话
+  card stream open|write|snapshot|reanchor|bind-runtime|unbind-runtime|finish ...
+                       CardKit 原生文本流式更新与 daemon 运行状态绑定；详见 botmux card stream --help
   bots list                            列出当前群聊中的机器人（含 open_id）
   bots invite --chat <chatId> --team <id> --agent <appId>...
                                        往「已存在的团队群」补人：把同团队、已 opt-in 的 agent + 各自 owner 一起拉进；
@@ -9940,7 +9960,7 @@ async function cmdSend(rest: string[]): Promise<void> {
   }
 }
 
-// ─── Card subcommand (patch a previously-sent custom card in place) ───
+// ─── Card subcommands (whole-card patch + native CardKit streaming) ───
 
 async function cmdCard(rest: string[]): Promise<void> {
   const sub = rest[0] ?? '';
@@ -9948,13 +9968,233 @@ async function cmdCard(rest: string[]): Promise<void> {
     console.log(CARD_COMMAND_USAGE);
     return;
   }
-  if (sub !== 'patch') {
+  if (sub !== 'patch' && sub !== 'stream') {
     console.error(
       `未知 card 子命令: ${sub}\n` +
-      `用法: botmux card patch --message-id <om_xxx> (--card-file <path> | --card-json <json>) [--session-id <sid>]`,
+      '可用: patch | stream',
     );
     process.exit(2);
   }
+
+  if (sub === 'stream') {
+    const args = rest.slice(1);
+    if (args.length === 0 || cardStreamArgsWantHelp(args)) {
+      console.log(CARD_STREAM_USAGE);
+      return;
+    }
+    assertTurnTransportOrExit('card stream');
+    await registerSelfFromCredFile();
+
+    if (args[0] === 'bind-runtime' || args[0] === 'unbind-runtime') {
+      const runtimeParsed = parseCardRuntimeStatusArgs(args);
+      if (!runtimeParsed.ok) {
+        console.error(`botmux card stream: ${runtimeParsed.error}`);
+        process.exit(2);
+      }
+      try {
+        const { sid, larkAppId, session } = await resolveSessionAppId(runtimeParsed.sessionId);
+        assertSessionTransportOrExit({ chatId: session.chatId, larkAppId }, 'card stream runtime');
+        const { patchCardStreamElement, updateCardStreamElementContent } = await import('./im/lark/client.js');
+        const streamStore = new CardStreamStore(resolveDataDir());
+        const runtimeBridge = new CardRuntimeStatusBridge(resolveDataDir(), streamStore, {
+          updateContent: input => updateCardStreamElementContent(
+            input.larkAppId,
+            input.cardId,
+            input.elementId,
+            input.content,
+            input.sequence,
+            input.uuid,
+          ),
+          patchElement: input => patchCardStreamElement(
+            input.larkAppId,
+            input.cardId,
+            input.elementId,
+            input.partialElement,
+            input.sequence,
+            input.uuid,
+          ),
+        });
+        const authority = { sessionId: sid, larkAppId, chatId: session.chatId };
+        if (runtimeParsed.operation === 'bind-runtime') {
+          await runtimeBridge.bind({
+            streamId: runtimeParsed.streamId,
+            authority,
+            statusElementId: runtimeParsed.statusElementId,
+            imageElementId: runtimeParsed.imageElementId,
+            activeImageKey: runtimeParsed.activeImageKey,
+            inactiveImageKey: runtimeParsed.inactiveImageKey,
+            labels: runtimeParsed.labels,
+          });
+          console.log(JSON.stringify({
+            success: true,
+            operation: 'bind-runtime',
+            streamId: runtimeParsed.streamId,
+            sessionId: sid,
+          }));
+        } else {
+          const unbound = await runtimeBridge.unbind(runtimeParsed.streamId, authority);
+          console.log(JSON.stringify({
+            success: true,
+            operation: 'unbind-runtime',
+            streamId: runtimeParsed.streamId,
+            sessionId: sid,
+            unbound,
+          }));
+        }
+      } catch (err) {
+        const mapped = mapCardStreamError(err);
+        console.error(`botmux card stream: ${mapped.error}`);
+        process.exit(mapped.exitCode);
+      }
+      return;
+    }
+
+    const parsed = parseCardStreamArgs(args);
+    if (!parsed.ok) {
+      console.error(`botmux card stream: ${parsed.error}`);
+      process.exit(2);
+    }
+    const contentInput = parsed.operation === 'write'
+      ? readCardStreamContent(parsed.content, parsed.contentFile)
+      : undefined;
+    if (contentInput && !contentInput.ok) {
+      console.error(`botmux card stream: ${contentInput.error}`);
+      process.exit(contentInput.exitCode);
+    }
+
+    const { sid, larkAppId, session } = await resolveSessionAppId(parsed.sessionId);
+    assertSessionTransportOrExit({ chatId: session.chatId, larkAppId }, 'card stream');
+    const store = new CardStreamStore(resolveDataDir());
+    const authority = { sessionId: sid, larkAppId, chatId: session.chatId };
+    const currentTurnId = session.currentReplyTarget?.turnId ?? session.quoteTargetId;
+
+    if (parsed.operation === 'snapshot') {
+      const outcome = await executeCardStreamSnapshot({ store }, {
+        streamId: parsed.streamId,
+        authority,
+        readUsage: () => readCardStreamUsageSnapshot(session, larkAppId),
+        currentTurnId,
+      });
+      if (!outcome.ok) {
+        console.error(`botmux card stream: ${outcome.error}`);
+        process.exit(outcome.exitCode);
+      }
+      console.log(buildCardStreamSuccessOutput(outcome, sid));
+      return;
+    }
+
+    const {
+      deleteMessage,
+      getMessageDetail,
+      patchCardStreamElement,
+      resolveCardKitId,
+      updateCardStreamElementContent,
+      updateCardStreamingSettings,
+    } = await import('./im/lark/client.js');
+    const runtimeBridge = new CardRuntimeStatusBridge(resolveDataDir(), store, {
+      updateContent: input => updateCardStreamElementContent(
+        input.larkAppId,
+        input.cardId,
+        input.elementId,
+        input.content,
+        input.sequence,
+        input.uuid,
+      ),
+      patchElement: input => patchCardStreamElement(
+        input.larkAppId,
+        input.cardId,
+        input.elementId,
+        input.partialElement,
+        input.sequence,
+        input.uuid,
+      ),
+    });
+    const deps = {
+      store,
+      getMessageRoute: async (appId: string, messageId: string) =>
+        cardMessageRouteFromDetail(
+          await getMessageDetail(appId, messageId, { userCardContent: false }),
+          messageId,
+        ),
+      resolveCardId: resolveCardKitId,
+      updateSettings: async (input: {
+        larkAppId: string;
+        cardId: string;
+        streamingMode: boolean;
+        sequence: number;
+        uuid: string;
+        summary?: string;
+        print?: { frequencyMs: number; step: number; strategy: 'fast' };
+      }) => updateCardStreamingSettings(input.larkAppId, input.cardId, input),
+      updateElementContent: async (input: {
+        larkAppId: string;
+        cardId: string;
+        elementId: string;
+        content: string;
+        sequence: number;
+        uuid: string;
+      }) => updateCardStreamElementContent(
+        input.larkAppId,
+        input.cardId,
+        input.elementId,
+        input.content,
+        input.sequence,
+        input.uuid,
+      ),
+      moveRuntimeBinding: (previousStreamId: string, currentStreamId: string) =>
+        runtimeBridge.reanchor(previousStreamId, currentStreamId, authority),
+      deleteMessage,
+    };
+    const outcome = parsed.operation === 'open'
+      ? await executeCardStreamOpen(deps, {
+          binding: {
+            ...authority,
+            messageId: parsed.messageId,
+            ...(currentTurnId ? { anchorTurnId: currentTurnId } : {}),
+          },
+          sessionRoute: {
+            chatId: session.chatId,
+            rootMessageId: session.rootMessageId,
+            scope: session.scope,
+          },
+          summary: parsed.summary,
+        })
+      : parsed.operation === 'reanchor'
+        ? await executeCardStreamReanchor(deps, {
+            streamId: parsed.streamId,
+            authority,
+            nextBinding: {
+              ...authority,
+              messageId: parsed.messageId,
+              ...(currentTurnId ? { anchorTurnId: currentTurnId } : {}),
+            },
+            sessionRoute: {
+              chatId: session.chatId,
+              rootMessageId: session.rootMessageId,
+              scope: session.scope,
+            },
+            summary: parsed.summary,
+          })
+      : parsed.operation === 'write'
+        ? await executeCardStreamWrite(deps, {
+            streamId: parsed.streamId,
+            authority,
+            elementId: parsed.elementId,
+            content: contentInput!.content,
+          })
+        : await executeCardStreamFinish(deps, {
+            streamId: parsed.streamId,
+            authority,
+            summary: parsed.summary,
+          });
+    if (!outcome.ok) {
+      console.error(`botmux card stream: ${outcome.error}`);
+      process.exit(outcome.exitCode);
+    }
+    console.log(buildCardStreamSuccessOutput(outcome, sid));
+    return;
+  }
+
   const args = rest.slice(1);
   // Help wins over the missing-arg validation and the transport gates below.
   if (cardPatchArgsWantHelp(args)) {

--- a/src/cli/card-dispatch.ts
+++ b/src/cli/card-dispatch.ts
@@ -52,7 +52,11 @@ export const CARD_COMMAND_USAGE = `botmux card — 卡片相关命令
   botmux card patch --message-id <om_xxx> (--card-file <path> | --card-json <json>) [--session-id <sid>]
       原地更新之前用 send --card-file/--card-json 发出的自定义卡片
       （不发新消息、不换群/话题）；messageId 取自 send 成功输出的 .messageId，
-      卡片安全校验与 send 相同；[--session-id <sid>] 可手动指定会话`;
+      卡片安全校验与 send 相同；[--session-id <sid>] 可手动指定会话
+
+  botmux card stream open|write|snapshot|reanchor|finish ...
+      使用 CardKit 原生文本流式更新（打字机效果）；运行
+      botmux card stream --help 查看完整流程`;
 
 /** True when `botmux card patch` argv asks for help. Help wins over the
  *  missing-arg validation (cli.ts checks this before parseCardPatchArgs). */

--- a/src/cli/card-runtime-status-dispatch.ts
+++ b/src/cli/card-runtime-status-dispatch.ts
@@ -1,0 +1,91 @@
+import type { ScreenStatus } from '../types.js';
+
+const STREAM_ID_RE = /^cs_[0-9a-f]{32}$/;
+const ELEMENT_ID_RE = /^[A-Za-z][A-Za-z0-9_-]{0,19}$/;
+const IMAGE_KEY_RE = /^img_[A-Za-z0-9_-]{8,256}$/;
+
+function flagValue(args: string[], flag: string): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === flag && i + 1 < args.length) return args[i + 1];
+    if (arg.startsWith(`${flag}=`)) return arg.slice(flag.length + 1);
+  }
+  return undefined;
+}
+
+function required(args: string[], flag: string): { ok: true; value: string } | { ok: false; error: string } {
+  const value = flagValue(args, flag);
+  if (!value || value.startsWith('--')) return { ok: false, error: `${flag} 需要参数` };
+  return { ok: true, value };
+}
+
+export type CardRuntimeStatusParsedArgs =
+  | {
+      ok: true;
+      operation: 'bind-runtime';
+      streamId: string;
+      statusElementId: string;
+      imageElementId: string;
+      activeImageKey: string;
+      inactiveImageKey: string;
+      labels?: Partial<Record<ScreenStatus, string>>;
+      sessionId?: string;
+    }
+  | { ok: true; operation: 'unbind-runtime'; streamId: string; sessionId?: string }
+  | { ok: false; error: string };
+
+export function parseCardRuntimeStatusArgs(args: string[]): CardRuntimeStatusParsedArgs {
+  const operation = args[0];
+  if (operation !== 'bind-runtime' && operation !== 'unbind-runtime') {
+    return { ok: false, error: '需要子命令 bind-runtime 或 unbind-runtime' };
+  }
+  const stream = required(args, '--stream-id');
+  if (!stream.ok) return stream;
+  if (!STREAM_ID_RE.test(stream.value)) return { ok: false, error: `streamId 格式无效: ${stream.value}` };
+  const sessionId = flagValue(args, '--session-id');
+  if (operation === 'unbind-runtime') {
+    return { ok: true, operation, streamId: stream.value, ...(sessionId ? { sessionId } : {}) };
+  }
+
+  const statusElement = required(args, '--status-element-id');
+  if (!statusElement.ok) return statusElement;
+  const imageElement = required(args, '--image-element-id');
+  if (!imageElement.ok) return imageElement;
+  const activeImage = required(args, '--active-image-key');
+  if (!activeImage.ok) return activeImage;
+  const inactiveImage = required(args, '--inactive-image-key');
+  if (!inactiveImage.ok) return inactiveImage;
+  if (!ELEMENT_ID_RE.test(statusElement.value)) return { ok: false, error: 'status element id 格式无效' };
+  if (!ELEMENT_ID_RE.test(imageElement.value)) return { ok: false, error: 'image element id 格式无效' };
+  if (!IMAGE_KEY_RE.test(activeImage.value)) return { ok: false, error: 'active image key 格式无效' };
+  if (!IMAGE_KEY_RE.test(inactiveImage.value)) return { ok: false, error: 'inactive image key 格式无效' };
+
+  let labels: Partial<Record<ScreenStatus, string>> | undefined;
+  const labelsJson = flagValue(args, '--labels-json');
+  if (labelsJson !== undefined) {
+    let parsed: unknown;
+    try { parsed = JSON.parse(labelsJson); } catch { return { ok: false, error: '--labels-json 必须是 JSON object' }; }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { ok: false, error: '--labels-json 必须是 JSON object' };
+    }
+    const allowed = new Set<ScreenStatus>(['working', 'analyzing', 'idle', 'stalled', 'limited']);
+    labels = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!allowed.has(key as ScreenStatus) || typeof value !== 'string') {
+        return { ok: false, error: `--labels-json 含无效字段: ${key}` };
+      }
+      labels[key as ScreenStatus] = value;
+    }
+  }
+  return {
+    ok: true,
+    operation,
+    streamId: stream.value,
+    statusElementId: statusElement.value,
+    imageElementId: imageElement.value,
+    activeImageKey: activeImage.value,
+    inactiveImageKey: inactiveImage.value,
+    ...(labels ? { labels } : {}),
+    ...(sessionId ? { sessionId } : {}),
+  };
+}

--- a/src/cli/card-stream-dispatch.ts
+++ b/src/cli/card-stream-dispatch.ts
@@ -1,0 +1,590 @@
+import { existsSync, readFileSync } from 'node:fs';
+import type {
+  CardStreamAuthority,
+  CardStreamBinding,
+  CardStreamFinishResult,
+  CardStreamOpenResult,
+  CardStreamRecord,
+  CardStreamSequenceLease,
+} from '../services/card-stream-store.js';
+
+const STREAM_ID_RE = /^cs_[0-9a-f]{32}$/;
+const ELEMENT_ID_RE = /^[A-Za-z][A-Za-z0-9_-]{0,19}$/;
+const MAX_STREAM_CONTENT_CHARS = 30_000;
+const MAX_SUMMARY_CHARS = 50;
+
+export const CARD_STREAM_USAGE = `botmux card stream — 原生 CardKit 流式更新
+
+用法:
+  botmux card stream open --message-id <om_xxx> [--summary <text>] [--session-id <sid>]
+  botmux card stream write --stream-id <cs_xxx> --element-id <id> (--content <text> | --content-file <path|->) [--session-id <sid>]
+  botmux card stream snapshot --stream-id <cs_xxx> [--session-id <sid>]
+  botmux card stream reanchor --stream-id <cs_xxx> --message-id <om_xxx> [--summary <text>] [--session-id <sid>]
+  botmux card stream bind-runtime --stream-id <cs_xxx> --status-element-id <id> --image-element-id <id>
+      --active-image-key <img_xxx> --inactive-image-key <img_xxx> [--labels-json <json>] [--session-id <sid>]
+  botmux card stream unbind-runtime --stream-id <cs_xxx> [--session-id <sid>]
+  botmux card stream finish --stream-id <cs_xxx> [--summary <text>] [--session-id <sid>]
+
+流程:
+  1. 用 botmux send --card-file 发一张 Card 2.0 卡片；要流式写入的 markdown/plain_text
+     组件必须设置唯一 element_id（字母开头，最多 20 字符）。
+  2. stream open 把 messageId 绑定为当前会话独享的 streamId，并开启原生打字机模式。
+  3. stream write 每次传该 element 的完整最新内容；新增后缀会以打字机效果出现。
+  4. snapshot 读取当前会话原生累计 Token 四桶快照；无可靠数据时返回 usage:null，不估算。
+  5. reanchor 把活动流迁移到新卡片，迁移成功后拒绝旧流迟到写入并尽力撤回旧消息。
+  6. 可选 bind-runtime：让 daemon 的 working/analyzing/idle/stalled/limited 状态驱动指定元素。
+  7. stream finish 关闭流式光标并更新会话列表摘要。
+
+说明:
+  --content-file - 从 stdin 读取多行内容。单次内容最多 ${MAX_STREAM_CONTENT_CHARS} 字符。
+  streamId 绑定 session / bot / chat；不能跨会话或跨机器人复用。`;
+
+export function cardStreamArgsWantHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
+function flagPresentButValueMissing(args: string[], flag: string): boolean {
+  const i = args.findIndex(a => a === flag || a.startsWith(`${flag}=`));
+  if (i < 0) return false;
+  if (args[i].startsWith(`${flag}=`)) return args[i].slice(flag.length + 1) === '';
+  const next = args[i + 1];
+  return next === undefined || (next.startsWith('-') && next !== '-');
+}
+
+function flagValue(args: string[], flag: string): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === flag && i + 1 < args.length) return args[i + 1];
+    if (arg.startsWith(`${flag}=`)) return arg.slice(flag.length + 1);
+  }
+  return undefined;
+}
+
+function optionalSessionId(args: string[]): { ok: true; sessionId?: string } | { ok: false; error: string } {
+  if (flagPresentButValueMissing(args, '--session-id')) {
+    return { ok: false, error: '--session-id 需要会话 id 参数' };
+  }
+  const sessionId = flagValue(args, '--session-id');
+  return { ok: true, ...(sessionId ? { sessionId } : {}) };
+}
+
+function optionalSummary(args: string[]): { ok: true; summary?: string } | { ok: false; error: string } {
+  if (flagPresentButValueMissing(args, '--summary')) {
+    return { ok: false, error: '--summary 需要文本参数' };
+  }
+  const summary = flagValue(args, '--summary');
+  if (summary !== undefined && summary.length > MAX_SUMMARY_CHARS) {
+    return { ok: false, error: `--summary 最多 ${MAX_SUMMARY_CHARS} 字符` };
+  }
+  return { ok: true, ...(summary !== undefined ? { summary } : {}) };
+}
+
+export type CardStreamParsedArgs =
+  | { ok: true; operation: 'open'; messageId: string; summary?: string; sessionId?: string }
+  | {
+      ok: true;
+      operation: 'write';
+      streamId: string;
+      elementId: string;
+      content?: string;
+      contentFile?: string;
+      sessionId?: string;
+    }
+  | { ok: true; operation: 'snapshot'; streamId: string; sessionId?: string }
+  | { ok: true; operation: 'reanchor'; streamId: string; messageId: string; summary?: string; sessionId?: string }
+  | { ok: true; operation: 'finish'; streamId: string; summary?: string; sessionId?: string }
+  | { ok: false; error: string };
+
+export function parseCardStreamArgs(args: string[]): CardStreamParsedArgs {
+  const operation = args[0];
+  const flags = args.slice(1);
+  if (operation !== 'open' && operation !== 'write' && operation !== 'snapshot' && operation !== 'reanchor' && operation !== 'finish') {
+    return { ok: false, error: '需要子命令 open、write、snapshot、reanchor 或 finish' };
+  }
+  const session = optionalSessionId(flags);
+  if (!session.ok) return session;
+  const sessionFields = session.sessionId ? { sessionId: session.sessionId } : {};
+
+  if (operation === 'open') {
+    if (flagPresentButValueMissing(flags, '--message-id')) {
+      return { ok: false, error: '--message-id 需要消息 id 参数（om_ 开头）' };
+    }
+    const messageId = flagValue(flags, '--message-id');
+    if (!messageId) return { ok: false, error: '缺少必填参数 --message-id <om_xxx>' };
+    if (!messageId.startsWith('om_')) {
+      return { ok: false, error: `messageId 格式无效: ${messageId}（需以 om_ 开头）` };
+    }
+    const summary = optionalSummary(flags);
+    if (!summary.ok) return summary;
+    return {
+      ok: true,
+      operation,
+      messageId,
+      ...(summary.summary !== undefined ? { summary: summary.summary } : {}),
+      ...sessionFields,
+    };
+  }
+
+  if (flagPresentButValueMissing(flags, '--stream-id')) {
+    return { ok: false, error: '--stream-id 需要 cs_ 开头的流 id' };
+  }
+  const streamId = flagValue(flags, '--stream-id');
+  if (!streamId) return { ok: false, error: '缺少必填参数 --stream-id <cs_xxx>' };
+  if (!STREAM_ID_RE.test(streamId)) {
+    return { ok: false, error: `streamId 格式无效: ${streamId}` };
+  }
+
+  if (operation === 'snapshot') {
+    return { ok: true, operation, streamId, ...sessionFields };
+  }
+
+  if (operation === 'reanchor') {
+    if (flagPresentButValueMissing(flags, '--message-id')) {
+      return { ok: false, error: '--message-id 需要消息 id 参数（om_ 开头）' };
+    }
+    const messageId = flagValue(flags, '--message-id');
+    if (!messageId?.startsWith('om_')) {
+      return { ok: false, error: 'reanchor 缺少有效的 --message-id <om_xxx>' };
+    }
+    const summary = optionalSummary(flags);
+    if (!summary.ok) return summary;
+    return {
+      ok: true,
+      operation,
+      streamId,
+      messageId,
+      ...(summary.summary !== undefined ? { summary: summary.summary } : {}),
+      ...sessionFields,
+    };
+  }
+
+  if (operation === 'finish') {
+    const summary = optionalSummary(flags);
+    if (!summary.ok) return summary;
+    return {
+      ok: true,
+      operation,
+      streamId,
+      ...(summary.summary !== undefined ? { summary: summary.summary } : {}),
+      ...sessionFields,
+    };
+  }
+
+  if (flagPresentButValueMissing(flags, '--element-id')) {
+    return { ok: false, error: '--element-id 需要组件 id 参数' };
+  }
+  const elementId = flagValue(flags, '--element-id');
+  if (!elementId) return { ok: false, error: '缺少必填参数 --element-id <id>' };
+  if (!ELEMENT_ID_RE.test(elementId)) {
+    return { ok: false, error: 'elementId 格式无效：需字母开头，仅含字母/数字/_/-，最多 20 字符' };
+  }
+  if (flagPresentButValueMissing(flags, '--content')) {
+    return { ok: false, error: '--content 需要文本参数' };
+  }
+  if (flagPresentButValueMissing(flags, '--content-file')) {
+    return { ok: false, error: '--content-file 需要路径或 -' };
+  }
+  const content = flagValue(flags, '--content');
+  const contentFile = flagValue(flags, '--content-file');
+  if (content !== undefined && contentFile !== undefined) {
+    return { ok: false, error: '--content 与 --content-file 不能同时使用' };
+  }
+  if (content === undefined && contentFile === undefined) {
+    return { ok: false, error: '需要 --content <text> 或 --content-file <path|-> 之一' };
+  }
+  return {
+    ok: true,
+    operation,
+    streamId,
+    elementId,
+    ...(content !== undefined ? { content } : {}),
+    ...(contentFile !== undefined ? { contentFile } : {}),
+    ...sessionFields,
+  };
+}
+
+export type CardStreamContentInput =
+  | { ok: true; content: string }
+  | { ok: false; exitCode: number; error: string };
+
+export function readCardStreamContent(
+  content: string | undefined,
+  contentFile: string | undefined,
+): CardStreamContentInput {
+  let value: string;
+  try {
+    if (content !== undefined) value = content;
+    else if (contentFile === '-') value = readFileSync(0, 'utf-8');
+    else {
+      const path = contentFile!;
+      if (!existsSync(path)) return { ok: false, exitCode: 1, error: `文件不存在: ${path}` };
+      value = readFileSync(path, 'utf-8');
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      exitCode: 1,
+      error: `读取流内容失败: ${(err as Error)?.message ?? String(err)}`,
+    };
+  }
+  if (value.length > MAX_STREAM_CONTENT_CHARS) {
+    return { ok: false, exitCode: 2, error: `流内容超过 ${MAX_STREAM_CONTENT_CHARS} 字符` };
+  }
+  return { ok: true, content: value };
+}
+
+export interface CardMessageRoute {
+  messageId: string;
+  chatId?: string;
+  rootMessageId?: string;
+  messageType?: string;
+}
+
+export interface CardStreamSessionRoute {
+  chatId: string;
+  rootMessageId: string;
+  scope?: 'thread' | 'chat';
+}
+
+/** Normalize the response shapes returned by im.v1.message.get. */
+export function cardMessageRouteFromDetail(detail: any, messageId: string): CardMessageRoute {
+  const item = detail?.items?.[0] ?? detail?.message ?? detail ?? {};
+  return {
+    messageId: typeof item.message_id === 'string' ? item.message_id : messageId,
+    ...(typeof item.chat_id === 'string' ? { chatId: item.chat_id } : {}),
+    ...(typeof item.root_id === 'string' ? { rootMessageId: item.root_id } : {}),
+    ...(typeof item.msg_type === 'string' ? { messageType: item.msg_type } : {}),
+  };
+}
+
+export function cardMessageBelongsToSession(
+  route: CardMessageRoute,
+  session: CardStreamSessionRoute,
+): { ok: true } | { ok: false; error: string } {
+  if (!route.chatId) return { ok: false, error: '无法确认目标消息所在群，拒绝打开卡片流' };
+  if (route.chatId !== session.chatId) return { ok: false, error: '目标消息不属于当前会话所在群' };
+  if (route.messageType && route.messageType !== 'interactive') {
+    return { ok: false, error: '目标消息不是 interactive 卡片' };
+  }
+  if (session.scope !== 'chat') {
+    const sameRoot = route.messageId === session.rootMessageId || route.rootMessageId === session.rootMessageId;
+    if (!sameRoot) return { ok: false, error: '目标消息不属于当前话题' };
+  }
+  return { ok: true };
+}
+
+export interface CardStreamStoreLike {
+  open(
+    binding: CardStreamBinding,
+    cardId: string,
+    callback: (lease: CardStreamSequenceLease) => Promise<void>,
+  ): Promise<CardStreamOpenResult>;
+  write(
+    streamId: string,
+    authority: CardStreamAuthority,
+    callback: (lease: CardStreamSequenceLease) => Promise<void>,
+  ): Promise<CardStreamRecord>;
+  inspect(streamId: string, authority: CardStreamAuthority): Promise<CardStreamRecord>;
+  reanchor(
+    streamId: string,
+    authority: CardStreamAuthority,
+    nextBinding: CardStreamBinding,
+    nextCardId: string,
+    callback: (lease: CardStreamSequenceLease) => Promise<void>,
+  ): Promise<{ previous: CardStreamRecord; current: CardStreamRecord }>;
+  finish(
+    streamId: string,
+    authority: CardStreamAuthority,
+    callback: (lease: CardStreamSequenceLease) => Promise<void>,
+  ): Promise<CardStreamFinishResult>;
+}
+
+export interface CardStreamUsageSnapshot {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  totalTokens: number;
+}
+
+export interface CardStreamDeps {
+  store: CardStreamStoreLike;
+  getMessageRoute: (larkAppId: string, messageId: string) => Promise<CardMessageRoute>;
+  resolveCardId: (larkAppId: string, messageId: string) => Promise<string>;
+  updateSettings: (input: {
+    larkAppId: string;
+    cardId: string;
+    streamingMode: boolean;
+    sequence: number;
+    uuid: string;
+    summary?: string;
+    print?: { frequencyMs: number; step: number; strategy: 'fast' };
+  }) => Promise<void>;
+  updateElementContent: (input: {
+    larkAppId: string;
+    cardId: string;
+    elementId: string;
+    content: string;
+    sequence: number;
+    uuid: string;
+  }) => Promise<void>;
+  moveRuntimeBinding: (
+    previousStreamId: string,
+    currentStreamId: string,
+    authority: CardStreamAuthority,
+  ) => Promise<boolean>;
+  deleteMessage: (larkAppId: string, messageId: string) => Promise<boolean>;
+}
+
+export type CardStreamOutcome =
+  | {
+      ok: true;
+      operation: 'open';
+      streamId: string;
+      messageId: string;
+      sequence: number;
+      alreadyOpen: boolean;
+    }
+  | { ok: true; operation: 'write'; streamId: string; elementId: string; sequence: number }
+  | {
+      ok: true;
+      operation: 'snapshot';
+      streamId: string;
+      capturedAt: string;
+      usage: CardStreamUsageSnapshot | null;
+      anchorTurnId?: string;
+      currentTurnId?: string;
+    }
+  | {
+      ok: true;
+      operation: 'reanchor';
+      previousStreamId: string;
+      streamId: string;
+      previousMessageId: string;
+      messageId: string;
+      sequence: number;
+      runtimeRebound: boolean;
+      previousMessageRecalled: boolean;
+      anchorTurnId?: string;
+    }
+  | { ok: true; operation: 'finish'; streamId: string; sequence: number; alreadyFinished: boolean }
+  | { ok: false; exitCode: number; error: string };
+
+export async function executeCardStreamOpen(
+  deps: CardStreamDeps,
+  opts: {
+    binding: CardStreamBinding;
+    sessionRoute: CardStreamSessionRoute;
+    summary?: string;
+  },
+): Promise<CardStreamOutcome> {
+  try {
+    const route = await deps.getMessageRoute(opts.binding.larkAppId, opts.binding.messageId);
+    const ownership = cardMessageBelongsToSession(route, opts.sessionRoute);
+    if (!ownership.ok) return { ok: false, exitCode: 2, error: ownership.error };
+    const cardId = await deps.resolveCardId(opts.binding.larkAppId, opts.binding.messageId);
+    const result = await deps.store.open(opts.binding, cardId, async lease => {
+      await deps.updateSettings({
+        larkAppId: opts.binding.larkAppId,
+        ...lease,
+        streamingMode: true,
+        ...(opts.summary !== undefined ? { summary: opts.summary } : {}),
+        print: { frequencyMs: 70, step: 1, strategy: 'fast' },
+      });
+    });
+    return {
+      ok: true,
+      operation: 'open',
+      streamId: result.record.streamId,
+      messageId: result.record.messageId,
+      sequence: result.record.sequence,
+      alreadyOpen: result.alreadyOpen,
+      ...(result.record.anchorTurnId ? { anchorTurnId: result.record.anchorTurnId } : {}),
+    };
+  } catch (err) {
+    return { ok: false, ...mapCardStreamError(err) };
+  }
+}
+
+export async function executeCardStreamWrite(
+  deps: CardStreamDeps,
+  opts: {
+    streamId: string;
+    authority: CardStreamAuthority;
+    elementId: string;
+    content: string;
+  },
+): Promise<CardStreamOutcome> {
+  try {
+    const record = await deps.store.write(opts.streamId, opts.authority, async lease => {
+      await deps.updateElementContent({
+        larkAppId: opts.authority.larkAppId,
+        ...lease,
+        elementId: opts.elementId,
+        content: opts.content,
+      });
+    });
+    return {
+      ok: true,
+      operation: 'write',
+      streamId: record.streamId,
+      elementId: opts.elementId,
+      sequence: record.sequence,
+    };
+  } catch (err) {
+    return { ok: false, ...mapCardStreamError(err) };
+  }
+}
+
+export async function executeCardStreamSnapshot(
+  deps: Pick<CardStreamDeps, 'store'>,
+  opts: {
+    streamId: string;
+    authority: CardStreamAuthority;
+    readUsage: () => CardStreamUsageSnapshot | null | Promise<CardStreamUsageSnapshot | null>;
+    currentTurnId?: string;
+    now?: () => Date;
+  },
+): Promise<CardStreamOutcome> {
+  try {
+    const record = await deps.store.inspect(opts.streamId, opts.authority);
+    const usage = await opts.readUsage();
+    return {
+      ok: true,
+      operation: 'snapshot',
+      streamId: opts.streamId,
+      capturedAt: (opts.now?.() ?? new Date()).toISOString(),
+      usage,
+      ...(record.anchorTurnId ? { anchorTurnId: record.anchorTurnId } : {}),
+      ...(opts.currentTurnId ? { currentTurnId: opts.currentTurnId } : {}),
+    };
+  } catch (err) {
+    return { ok: false, ...mapCardStreamError(err) };
+  }
+}
+
+export async function executeCardStreamReanchor(
+  deps: CardStreamDeps,
+  opts: {
+    streamId: string;
+    nextBinding: CardStreamBinding;
+    authority: CardStreamAuthority;
+    sessionRoute: CardStreamSessionRoute;
+    summary?: string;
+  },
+): Promise<CardStreamOutcome> {
+  try {
+    const route = await deps.getMessageRoute(opts.nextBinding.larkAppId, opts.nextBinding.messageId);
+    const ownership = cardMessageBelongsToSession(route, opts.sessionRoute);
+    if (!ownership.ok) return { ok: false, exitCode: 2, error: ownership.error };
+    const cardId = await deps.resolveCardId(opts.nextBinding.larkAppId, opts.nextBinding.messageId);
+    const moved = await deps.store.reanchor(
+      opts.streamId,
+      opts.authority,
+      opts.nextBinding,
+      cardId,
+      async lease => deps.updateSettings({
+        larkAppId: opts.nextBinding.larkAppId,
+        ...lease,
+        streamingMode: true,
+        ...(opts.summary !== undefined ? { summary: opts.summary } : {}),
+        print: { frequencyMs: 70, step: 1, strategy: 'fast' },
+      }),
+    );
+    let runtimeRebound = false;
+    try {
+      runtimeRebound = await deps.moveRuntimeBinding(
+        moved.previous.streamId,
+        moved.current.streamId,
+        opts.authority,
+      );
+    } catch { /* the stream remains usable without runtime decoration */ }
+    let previousMessageRecalled = false;
+    try {
+      previousMessageRecalled = await deps.deleteMessage(
+        opts.authority.larkAppId,
+        moved.previous.messageId,
+      );
+    } catch { /* old stream is fenced even when Lark recall fails */ }
+    return {
+      ok: true,
+      operation: 'reanchor',
+      previousStreamId: moved.previous.streamId,
+      streamId: moved.current.streamId,
+      previousMessageId: moved.previous.messageId,
+      messageId: moved.current.messageId,
+      sequence: moved.current.sequence,
+      runtimeRebound,
+      previousMessageRecalled,
+      ...(moved.current.anchorTurnId ? { anchorTurnId: moved.current.anchorTurnId } : {}),
+    };
+  } catch (err) {
+    return { ok: false, ...mapCardStreamError(err) };
+  }
+}
+
+export async function executeCardStreamFinish(
+  deps: CardStreamDeps,
+  opts: { streamId: string; authority: CardStreamAuthority; summary?: string },
+): Promise<CardStreamOutcome> {
+  try {
+    const result = await deps.store.finish(opts.streamId, opts.authority, async lease => {
+      await deps.updateSettings({
+        larkAppId: opts.authority.larkAppId,
+        ...lease,
+        streamingMode: false,
+        ...(opts.summary !== undefined ? { summary: opts.summary } : {}),
+      });
+    });
+    return {
+      ok: true,
+      operation: 'finish',
+      streamId: result.record.streamId,
+      sequence: result.record.sequence,
+      alreadyFinished: result.alreadyFinished,
+    };
+  } catch (err) {
+    return { ok: false, ...mapCardStreamError(err) };
+  }
+}
+
+function extractLarkBusinessError(err: unknown): { code: unknown; msg: string } | undefined {
+  const data = (err as { response?: { data?: unknown } } | null | undefined)?.response?.data;
+  let parsed: unknown = data;
+  if (typeof data === 'string') {
+    try { parsed = JSON.parse(data); } catch { return undefined; }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+  const msg = (parsed as { msg?: unknown }).msg;
+  if (typeof msg !== 'string' || !msg) return undefined;
+  return { code: (parsed as { code?: unknown }).code, msg };
+}
+
+export function mapCardStreamError(err: unknown): { exitCode: number; error: string } {
+  const name = (err as { name?: string } | null | undefined)?.name;
+  if (name === 'CardStreamStoreError') {
+    return { exitCode: 2, error: (err as Error).message };
+  }
+  if (name === 'CardRuntimeStatusBridgeError') {
+    return { exitCode: 2, error: (err as Error).message };
+  }
+  if ((err as { code?: string } | null | undefined)?.code === 'FILE_LOCK_TIMEOUT') {
+    return { exitCode: 1, error: '卡片流暂时忙，请稍后重试' };
+  }
+  if (name === 'MessageWithdrawnError') return { exitCode: 1, error: '消息已撤回，无法操作卡片流' };
+  if (name === 'LarkTransportDisabledError') {
+    return { exitCode: 2, error: '当前会话 Bot 无飞书连接（core-only/apiOnly），无法操作卡片流' };
+  }
+  const biz = extractLarkBusinessError(err);
+  if (biz) {
+    const code = biz.code !== undefined ? ` (code: ${biz.code})` : '';
+    return { exitCode: 1, error: `CardKit 更新失败: ${biz.msg}${code}` };
+  }
+  const message = (err as { message?: string } | null | undefined)?.message ?? String(err);
+  return { exitCode: 1, error: `CardKit 更新失败: ${message}` };
+}
+
+export function buildCardStreamSuccessOutput(outcome: Exclude<CardStreamOutcome, { ok: false }>, sessionId: string): string {
+  const { ok: _ok, ...fields } = outcome;
+  return JSON.stringify({ success: true, ...fields, sessionId });
+}

--- a/src/cli/card-stream-usage.ts
+++ b/src/cli/card-stream-usage.ts
@@ -1,0 +1,46 @@
+import type { CliId } from '../adapters/cli/types.js';
+import {
+  getSessionUsageSnapshot,
+  type SessionUsageSnapshot,
+  type SessionTokenUsageQuery,
+} from '../core/cost-calculator.js';
+import type { CardStreamUsageSnapshot } from './card-stream-dispatch.js';
+
+export interface CardStreamUsageSession {
+  sessionId: string;
+  cliId?: string;
+  cliSessionId?: string;
+  workingDir?: string;
+  adoptedFrom?: { cliId?: string; sessionId?: string; cwd?: string };
+}
+
+/**
+ * Read native cumulative usage for an explicitly-authorized custom CardKit
+ * stream. This is intentionally independent from `usageDisplay`: that setting
+ * controls Botmux's built-in reply/control cards, while `card stream snapshot`
+ * is an opt-in capability consumed by the custom card that owns the stream.
+ */
+export function readCardStreamUsageSnapshot(
+  session: CardStreamUsageSession,
+  larkAppId: string,
+  reader: (query: SessionTokenUsageQuery) => SessionUsageSnapshot = getSessionUsageSnapshot,
+): CardStreamUsageSnapshot | null {
+  const snapshot = reader({
+    cliId: (session.cliId ?? session.adoptedFrom?.cliId ?? 'unknown') as CliId | 'unknown',
+    sessionId: session.sessionId,
+    cliSessionId: session.cliSessionId ?? session.adoptedFrom?.sessionId,
+    cwd: session.workingDir ?? session.adoptedFrom?.cwd,
+    larkAppId,
+    fresh: true,
+  });
+  const usage = snapshot.tokens;
+  if (!usage) return null;
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    cacheReadTokens: usage.cacheReadTokens,
+    cacheCreateTokens: usage.cacheCreateTokens,
+    totalTokens: usage.inputTokens + usage.outputTokens
+      + usage.cacheReadTokens + usage.cacheCreateTokens,
+  };
+}

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -592,6 +592,13 @@ export interface WorkerPoolCallbacks {
   /** Re-check the per-bot resident-session cap after a process starts or an
    * over-cap busy session becomes idle. Optional for unit-test callers. */
   enforceLiveSessionCap?: () => void;
+  /** Publish the worker's latest coarse runtime status to an optional external
+   * card sink. Called on every accepted screen update; the sink owns dedupe and
+   * backpressure so the worker path stays non-blocking. */
+  onScreenStatus?: (
+    ds: DaemonSession,
+    context: { prevStatus: StreamStatus | undefined; status: ScreenStatus; turnId?: string },
+  ) => void | Promise<void>;
   /** Durable consumers subscribe to transcript-backed turn completion here.
    *  Optional so ordinary sessions and tests keep their existing behavior. */
   onTurnTerminal?: (
@@ -11929,6 +11936,18 @@ function setupWorkerHandlers(
         ds.lastScreenContent = msg.content;
         ds.lastScreenStatus = resolveUsageAwareScreenStatus(ds, msg.status, msg.usageLimit);
         bumpStreamCardStatusRevision(ds);
+        try {
+          const published = cb.onScreenStatus?.(ds, {
+            prevStatus,
+            status: ds.lastScreenStatus as ScreenStatus,
+            turnId: msg.turnId,
+          });
+          void Promise.resolve(published).catch((err: any) => {
+            logger.debug(`[${t}] runtime status card bridge failed: ${err?.message ?? err}`);
+          });
+        } catch (err: any) {
+          logger.debug(`[${t}] runtime status card bridge threw: ${err?.message ?? err}`);
+        }
         // A suspend that arrived mid-turn parked itself here. Defer until this
         // screen_update has finished using process state — suspendWorker nulls
         // `worker` + `lastScreenStatus`, which everything below still reads

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -56,7 +56,7 @@ import {
 } from './core/supervisor-shutdown-protocol.js';
 import { readSupervisorProcessStartIdentity } from './core/process-start-identity.js';
 import { statSync } from 'node:fs';
-import { addReaction, deleteMessage, getChatContext, getChatMode, getChatNameAndMode, getMessageChatId, listChatMemberOpenIds, MessageWithdrawnError, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage, type EntryResolveStatus } from './im/lark/client.js';
+import { addReaction, deleteMessage, getChatContext, getChatMode, getChatNameAndMode, getMessageChatId, listChatMemberOpenIds, MessageWithdrawnError, patchCardStreamElement, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateCardStreamElementContent, updateMessage, type EntryResolveStatus } from './im/lark/client.js';
 import { resolveGroupJoinPrompt, waitForAllowedUserInChat } from './core/auto-start.js';
 import {
   loadBotConfigAtIndex,
@@ -85,6 +85,8 @@ import {
 import { setDisplayNameRefresher, findConfigField, applyConfigField } from './services/bot-config-store.js';
 import { registerPinStreamingCardChangeHandler } from './services/pin-streaming-card-change.js';
 import { getSkillFeedbackStore } from './services/skill-feedback-store.js';
+import { CardStreamStore } from './services/card-stream-store.js';
+import { CardRuntimeStatusBridge } from './services/card-runtime-status-bridge.js';
 import { enqueueTurnTerminal, drainTurnTerminalQueue } from './services/turn-completion-events.js';
 import { FeedbackWebhookSecretStore, startFeedbackWebhookDispatcher } from './services/feedback-webhook-dispatcher.js';
 import { resolveRegularGroupMode } from './services/chat-reply-mode-store.js';
@@ -21946,6 +21948,28 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       );
     }
   };
+  const cardRuntimeStatusBridge = new CardRuntimeStatusBridge(
+    config.session.dataDir,
+    new CardStreamStore(config.session.dataDir),
+    {
+      updateContent: input => updateCardStreamElementContent(
+        input.larkAppId,
+        input.cardId,
+        input.elementId,
+        input.content,
+        input.sequence,
+        input.uuid,
+      ),
+      patchElement: input => patchCardStreamElement(
+        input.larkAppId,
+        input.cardId,
+        input.elementId,
+        input.partialElement,
+        input.sequence,
+        input.uuid,
+      ),
+    },
+  );
   // Initialise worker pool with daemon callbacks
   initWorkerPool({
     sessionReply,
@@ -21977,6 +22001,13 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       });
     },
     enforceLiveSessionCap: () => enforceLiveSessionCap('session_change'),
+    onScreenStatus(ds, context) {
+      return cardRuntimeStatusBridge.publish({
+        sessionId: ds.session.sessionId,
+        larkAppId: ds.larkAppId,
+        status: context.status,
+      }).then(() => undefined);
+    },
     onQueuedActivationSubmitted,
     async onTurnTerminal(ds, terminal, context) {
       // VC reconcile first: it is in-memory and latency-sensitive, and must not

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1142,6 +1142,121 @@ export async function updateMessage(larkAppId: string, messageId: string, cardJs
   });
 }
 
+export interface CardStreamingSettings {
+  streamingMode: boolean;
+  sequence: number;
+  uuid: string;
+  summary?: string;
+  /** Applied when opening a stream. Omitted when only finalizing it. */
+  print?: {
+    frequencyMs: number;
+    step: number;
+    strategy: 'fast';
+  };
+}
+
+/** Convert a sent interactive message into its CardKit entity id. */
+export async function resolveCardKitId(larkAppId: string, messageId: string): Promise<string> {
+  assertLarkTransport(larkAppId, 'resolveCardKitId');
+  return executeWithLarkGate(larkAppId, 'resolveCardKitId', async () => {
+    const c = getBotClient(larkAppId);
+    let res: any;
+    try {
+      res = await c.cardkit.v1.card.idConvert({ data: { message_id: messageId } });
+    } catch (err: any) {
+      if (getLarkErrorCode(err) === LARK_CODE_MESSAGE_WITHDRAWN) {
+        throw new MessageWithdrawnError(messageId);
+      }
+      throw err;
+    }
+    if (res.code !== 0) {
+      if (res.code === LARK_CODE_MESSAGE_WITHDRAWN) throw new MessageWithdrawnError(messageId);
+      throw new Error(`Failed to resolve CardKit id: ${res.msg} (code: ${res.code})`);
+    }
+    const cardId = res.data?.card_id;
+    if (!cardId) throw new Error('CardKit id conversion returned no card_id');
+    return cardId;
+  });
+}
+
+/** Enable/finalize native CardKit streaming without replacing the whole card. */
+export async function updateCardStreamingSettings(
+  larkAppId: string,
+  cardId: string,
+  settings: CardStreamingSettings,
+): Promise<void> {
+  assertLarkTransport(larkAppId, 'updateCardStreamingSettings');
+  return executeWithLarkGate(larkAppId, 'updateCardStreamingSettings', async () => {
+    const c = getBotClient(larkAppId);
+    const config: Record<string, unknown> = {
+      streaming_mode: settings.streamingMode,
+      ...(settings.summary !== undefined ? { summary: { content: settings.summary } } : {}),
+      ...(settings.print ? {
+        streaming_config: {
+          print_frequency_ms: { default: settings.print.frequencyMs },
+          print_step: { default: settings.print.step },
+          print_strategy: settings.print.strategy,
+        },
+      } : {}),
+    };
+    const res: any = await c.cardkit.v1.card.settings({
+      path: { card_id: cardId },
+      data: {
+        settings: JSON.stringify({ config }),
+        sequence: settings.sequence,
+        uuid: settings.uuid,
+      },
+    });
+    if (res.code !== 0) {
+      throw new Error(`Failed to update CardKit streaming settings: ${res.msg} (code: ${res.code})`);
+    }
+  });
+}
+
+/** Replace one text element's full content using CardKit's typewriter API. */
+export async function updateCardStreamElementContent(
+  larkAppId: string,
+  cardId: string,
+  elementId: string,
+  content: string,
+  sequence: number,
+  uuid: string,
+): Promise<void> {
+  assertLarkTransport(larkAppId, 'updateCardStreamElementContent');
+  return executeWithLarkGate(larkAppId, 'updateCardStreamElementContent', async () => {
+    const c = getBotClient(larkAppId);
+    const res: any = await c.cardkit.v1.cardElement.content({
+      path: { card_id: cardId, element_id: elementId },
+      data: { content, sequence, uuid },
+    });
+    if (res.code !== 0) {
+      throw new Error(`Failed to stream CardKit element content: ${res.msg} (code: ${res.code})`);
+    }
+  });
+}
+
+/** Patch properties on one existing CardKit element without replacing the card. */
+export async function patchCardStreamElement(
+  larkAppId: string,
+  cardId: string,
+  elementId: string,
+  partialElement: Record<string, unknown>,
+  sequence: number,
+  uuid: string,
+): Promise<void> {
+  assertLarkTransport(larkAppId, 'patchCardStreamElement');
+  return executeWithLarkGate(larkAppId, 'patchCardStreamElement', async () => {
+    const c = getBotClient(larkAppId);
+    const res: any = await c.cardkit.v1.cardElement.patch({
+      path: { card_id: cardId, element_id: elementId },
+      data: { partial_element: JSON.stringify(partialElement), sequence, uuid },
+    });
+    if (res.code !== 0) {
+      throw new Error(`Failed to patch CardKit element: ${res.msg} (code: ${res.code})`);
+    }
+  });
+}
+
 export async function getMessageDetail(
   larkAppId: string,
   messageId: string,

--- a/src/services/card-runtime-status-bridge.ts
+++ b/src/services/card-runtime-status-bridge.ts
@@ -1,0 +1,341 @@
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ScreenStatus } from '../types.js';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { withFileLock } from '../utils/file-lock.js';
+import {
+  CardStreamStore,
+  type CardStreamAuthority,
+  type CardStreamSequenceLease,
+} from './card-stream-store.js';
+
+const SCHEMA_VERSION = 1;
+const ELEMENT_ID_RE = /^[A-Za-z][A-Za-z0-9_-]{0,19}$/;
+const IMAGE_KEY_RE = /^img_[A-Za-z0-9_-]{8,256}$/;
+const LABEL_MAX_CHARS = 32;
+
+const DEFAULT_LABELS: Record<ScreenStatus, string> = {
+  working: '执行中',
+  analyzing: '思考中',
+  idle: '等待下一步',
+  stalled: '可能卡住',
+  limited: '等待额度',
+};
+
+const STATUS_COLOR: Record<ScreenStatus, 'blue' | 'turquoise' | 'grey' | 'orange'> = {
+  working: 'blue',
+  analyzing: 'turquoise',
+  idle: 'grey',
+  stalled: 'orange',
+  limited: 'orange',
+};
+
+function activeStatus(status: ScreenStatus): boolean {
+  return status === 'working' || status === 'analyzing';
+}
+
+function escapeCardText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizeLabel(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value.replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!normalized) return fallback;
+  return Array.from(normalized).slice(0, LABEL_MAX_CHARS).join('');
+}
+
+function normalizeLabels(value: Partial<Record<ScreenStatus, string>> | undefined): Record<ScreenStatus, string> {
+  return {
+    working: normalizeLabel(value?.working, DEFAULT_LABELS.working),
+    analyzing: normalizeLabel(value?.analyzing, DEFAULT_LABELS.analyzing),
+    idle: normalizeLabel(value?.idle, DEFAULT_LABELS.idle),
+    stalled: normalizeLabel(value?.stalled, DEFAULT_LABELS.stalled),
+    limited: normalizeLabel(value?.limited, DEFAULT_LABELS.limited),
+  };
+}
+
+export interface CardRuntimeStatusBindingInput {
+  streamId: string;
+  authority: CardStreamAuthority;
+  statusElementId: string;
+  imageElementId: string;
+  activeImageKey: string;
+  inactiveImageKey: string;
+  labels?: Partial<Record<ScreenStatus, string>>;
+}
+
+interface CardRuntimeStatusBindingRecord extends CardRuntimeStatusBindingInput {
+  schemaVersion: typeof SCHEMA_VERSION;
+  labels: Record<ScreenStatus, string>;
+  lastStatus?: ScreenStatus;
+  lastImageKey?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CardRuntimeStatusLarkAdapter {
+  updateContent(input: CardStreamSequenceLease & {
+    larkAppId: string;
+    elementId: string;
+    content: string;
+  }): Promise<void>;
+  patchElement(input: CardStreamSequenceLease & {
+    larkAppId: string;
+    elementId: string;
+    partialElement: Record<string, unknown>;
+  }): Promise<void>;
+}
+
+export class CardRuntimeStatusBridgeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CardRuntimeStatusBridgeError';
+  }
+}
+
+function assertElementId(value: string, label: string): void {
+  if (!ELEMENT_ID_RE.test(value)) {
+    throw new CardRuntimeStatusBridgeError(`${label} 格式无效：需字母开头且最多 20 字符`);
+  }
+}
+
+function assertImageKey(value: string, label: string): void {
+  if (!IMAGE_KEY_RE.test(value)) throw new CardRuntimeStatusBridgeError(`${label} 格式无效`);
+}
+
+function isScreenStatus(value: unknown): value is ScreenStatus {
+  return value === 'working' || value === 'analyzing' || value === 'idle'
+    || value === 'stalled' || value === 'limited';
+}
+
+function parseRecord(raw: string): CardRuntimeStatusBindingRecord {
+  let value: unknown;
+  try { value = JSON.parse(raw); } catch { throw new CardRuntimeStatusBridgeError('runtime status binding 文件损坏'); }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new CardRuntimeStatusBridgeError('runtime status binding 格式无效');
+  }
+  const record = value as Partial<CardRuntimeStatusBindingRecord>;
+  if (
+    record.schemaVersion !== SCHEMA_VERSION
+    || typeof record.streamId !== 'string'
+    || !record.authority
+    || typeof record.authority.sessionId !== 'string'
+    || typeof record.authority.larkAppId !== 'string'
+    || typeof record.authority.chatId !== 'string'
+    || typeof record.statusElementId !== 'string'
+    || typeof record.imageElementId !== 'string'
+    || typeof record.activeImageKey !== 'string'
+    || typeof record.inactiveImageKey !== 'string'
+    || !record.labels
+    || typeof record.createdAt !== 'string'
+    || typeof record.updatedAt !== 'string'
+    || (record.lastStatus !== undefined && !isScreenStatus(record.lastStatus))
+  ) {
+    throw new CardRuntimeStatusBridgeError('runtime status binding 字段无效');
+  }
+  assertElementId(record.statusElementId, 'statusElementId');
+  assertElementId(record.imageElementId, 'imageElementId');
+  assertImageKey(record.activeImageKey, 'activeImageKey');
+  assertImageKey(record.inactiveImageKey, 'inactiveImageKey');
+  return {
+    ...record as CardRuntimeStatusBindingRecord,
+    labels: normalizeLabels(record.labels),
+  };
+}
+
+export class CardRuntimeStatusBridge {
+  private readonly dir: string;
+  private readonly pendingStatuses = new Map<string, ScreenStatus>();
+  private readonly publishRuns = new Map<string, Promise<boolean>>();
+
+  constructor(
+    dataDir: string,
+    private readonly streams: CardStreamStore,
+    private readonly lark: CardRuntimeStatusLarkAdapter,
+  ) {
+    this.dir = join(dataDir, 'card-runtime-status');
+  }
+
+  async bind(input: CardRuntimeStatusBindingInput): Promise<void> {
+    assertElementId(input.statusElementId, 'statusElementId');
+    assertElementId(input.imageElementId, 'imageElementId');
+    assertImageKey(input.activeImageKey, 'activeImageKey');
+    assertImageKey(input.inactiveImageKey, 'inactiveImageKey');
+    const stream = await this.streams.inspect(input.streamId, input.authority);
+    if (stream.status !== 'open') throw new CardRuntimeStatusBridgeError('只能绑定仍在打开的卡片流');
+    const path = this.pathFor(input.authority.larkAppId, input.authority.sessionId);
+    this.ensureDirectory();
+    await withFileLock(path, async () => {
+      const now = new Date().toISOString();
+      const record: CardRuntimeStatusBindingRecord = {
+        schemaVersion: SCHEMA_VERSION,
+        ...input,
+        labels: normalizeLabels(input.labels),
+        createdAt: now,
+        updatedAt: now,
+      };
+      this.write(path, record);
+    });
+  }
+
+  async reanchor(
+    previousStreamId: string,
+    currentStreamId: string,
+    authority: CardStreamAuthority,
+  ): Promise<boolean> {
+    const path = this.pathFor(authority.larkAppId, authority.sessionId);
+    this.ensureDirectory();
+    return withFileLock(path, async () => {
+      if (!existsSync(path)) return false;
+      const record = this.read(path);
+      this.assertAuthority(record, authority);
+      if (record.streamId !== previousStreamId) {
+        throw new CardRuntimeStatusBridgeError('runtime status binding 与旧 streamId 不匹配');
+      }
+      const current = await this.streams.inspect(currentStreamId, authority);
+      if (current.status !== 'open') {
+        throw new CardRuntimeStatusBridgeError('只能迁移到仍在打开的卡片流');
+      }
+      this.write(path, {
+        ...record,
+        streamId: currentStreamId,
+        lastStatus: undefined,
+        lastImageKey: undefined,
+        updatedAt: new Date().toISOString(),
+      });
+      return true;
+    });
+  }
+
+  async unbind(streamId: string, authority: CardStreamAuthority): Promise<boolean> {
+    const path = this.pathFor(authority.larkAppId, authority.sessionId);
+    this.ensureDirectory();
+    return withFileLock(path, async () => {
+      if (!existsSync(path)) return false;
+      const record = this.read(path);
+      this.assertAuthority(record, authority);
+      if (record.streamId !== streamId) throw new CardRuntimeStatusBridgeError('runtime status binding 与 streamId 不匹配');
+      try {
+        const stream = await this.streams.inspect(record.streamId, record.authority);
+        if (stream.status === 'open' && record.lastImageKey !== record.inactiveImageKey) {
+          await this.streams.write(record.streamId, record.authority, lease => this.lark.patchElement({
+            ...lease,
+            larkAppId: record.authority.larkAppId,
+            elementId: record.imageElementId,
+            partialElement: { img_key: record.inactiveImageKey },
+          }));
+        }
+      } finally {
+        // Provider-side streaming can time out before Botmux's local store sees
+        // a finish. Always remove this binding after authority is verified so a
+        // dead stream cannot keep receiving daemon status publishes forever.
+        if (existsSync(path)) unlinkSync(path);
+      }
+      return true;
+    });
+  }
+
+  async publish(input: { sessionId: string; larkAppId: string; status: ScreenStatus }): Promise<boolean> {
+    const key = `${input.larkAppId}\0${input.sessionId}`;
+    this.pendingStatuses.set(key, input.status);
+    const running = this.publishRuns.get(key);
+    if (running) return running;
+    const run = this.drainPublishes(key, input.larkAppId, input.sessionId);
+    this.publishRuns.set(key, run);
+    try { return await run; } finally { this.publishRuns.delete(key); }
+  }
+
+  private async drainPublishes(key: string, larkAppId: string, sessionId: string): Promise<boolean> {
+    let changed = false;
+    while (this.pendingStatuses.has(key)) {
+      const status = this.pendingStatuses.get(key)!;
+      this.pendingStatuses.delete(key);
+      changed = await this.publishOnce({ sessionId, larkAppId, status }) || changed;
+    }
+    return changed;
+  }
+
+  private async publishOnce(input: { sessionId: string; larkAppId: string; status: ScreenStatus }): Promise<boolean> {
+    const path = this.pathFor(input.larkAppId, input.sessionId);
+    if (!existsSync(path)) return false;
+    this.ensureDirectory();
+    return withFileLock(path, async () => {
+      if (!existsSync(path)) return false;
+      const record = this.read(path);
+      if (record.authority.sessionId !== input.sessionId || record.authority.larkAppId !== input.larkAppId) {
+        throw new CardRuntimeStatusBridgeError('runtime status binding authority 不匹配');
+      }
+      const stream = await this.streams.inspect(record.streamId, record.authority);
+      if (stream.status !== 'open') {
+        unlinkSync(path);
+        return false;
+      }
+      const desiredImageKey = activeStatus(input.status) ? record.activeImageKey : record.inactiveImageKey;
+      if (record.lastStatus === input.status && record.lastImageKey === desiredImageKey) return false;
+
+      const content = `<text_tag color='${STATUS_COLOR[input.status]}'>${escapeCardText(record.labels[input.status])}</text_tag>`;
+      await this.streams.write(record.streamId, record.authority, lease => this.lark.updateContent({
+        ...lease,
+        larkAppId: record.authority.larkAppId,
+        elementId: record.statusElementId,
+        content,
+      }));
+      if (record.lastImageKey !== desiredImageKey) {
+        await this.streams.write(record.streamId, record.authority, lease => this.lark.patchElement({
+          ...lease,
+          larkAppId: record.authority.larkAppId,
+          elementId: record.imageElementId,
+          partialElement: { img_key: desiredImageKey },
+        }));
+      }
+
+      this.write(path, {
+        ...record,
+        lastStatus: input.status,
+        lastImageKey: desiredImageKey,
+        updatedAt: new Date().toISOString(),
+      });
+      return true;
+    });
+  }
+
+  private ensureDirectory(): void {
+    mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    const stat = lstatSync(this.dir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new CardRuntimeStatusBridgeError('card-runtime-status 目录不安全');
+    }
+  }
+
+  private pathFor(larkAppId: string, sessionId: string): string {
+    const digest = createHash('sha256').update(`${larkAppId}\0${sessionId}`).digest('hex').slice(0, 32);
+    return join(this.dir, `${digest}.json`);
+  }
+
+  private read(path: string): CardRuntimeStatusBindingRecord {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new CardRuntimeStatusBridgeError('runtime status binding 文件不安全');
+    return parseRecord(readFileSync(path, 'utf-8'));
+  }
+
+  private write(path: string, record: CardRuntimeStatusBindingRecord): void {
+    atomicWriteFileSync(path, `${JSON.stringify(record)}\n`, { mode: 0o600, followTargetSymlink: false });
+  }
+
+  private assertAuthority(record: CardRuntimeStatusBindingRecord, authority: CardStreamAuthority): void {
+    if (
+      record.authority.sessionId !== authority.sessionId
+      || record.authority.larkAppId !== authority.larkAppId
+      || record.authority.chatId !== authority.chatId
+    ) {
+      throw new CardRuntimeStatusBridgeError('当前会话无权操作 runtime status binding');
+    }
+  }
+}

--- a/src/services/card-stream-store.ts
+++ b/src/services/card-stream-store.ts
@@ -1,0 +1,364 @@
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { withFileLock } from '../utils/file-lock.js';
+
+const CARD_STREAM_SCHEMA_VERSION = 1;
+const STREAM_ID_RE = /^cs_[0-9a-f]{32}$/;
+
+export type CardStreamStatus = 'opening' | 'open' | 'finished' | 'superseded';
+
+export interface CardStreamBinding {
+  sessionId: string;
+  larkAppId: string;
+  chatId: string;
+  messageId: string;
+  anchorTurnId?: string;
+}
+
+export type CardStreamAuthority = Pick<CardStreamBinding, 'sessionId' | 'larkAppId' | 'chatId'>;
+
+export interface CardStreamRecord extends CardStreamBinding {
+  schemaVersion: typeof CARD_STREAM_SCHEMA_VERSION;
+  streamId: string;
+  cardId: string;
+  status: CardStreamStatus;
+  sequence: number;
+  supersededByStreamId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class CardStreamStoreError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CardStreamStoreError';
+  }
+}
+
+export interface CardStreamSequenceLease {
+  cardId: string;
+  sequence: number;
+  uuid: string;
+}
+
+export interface CardStreamOpenResult {
+  record: CardStreamRecord;
+  alreadyOpen: boolean;
+}
+
+export interface CardStreamFinishResult {
+  record: CardStreamRecord;
+  alreadyFinished: boolean;
+}
+
+export interface CardStreamReanchorResult {
+  previous: CardStreamRecord;
+  current: CardStreamRecord;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function parseRecord(raw: string, expectedStreamId: string): CardStreamRecord {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new CardStreamStoreError(`流状态文件损坏: ${expectedStreamId}`);
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new CardStreamStoreError(`流状态文件格式无效: ${expectedStreamId}`);
+  }
+  const record = value as Partial<CardStreamRecord>;
+  if (
+    record.schemaVersion !== CARD_STREAM_SCHEMA_VERSION ||
+    record.streamId !== expectedStreamId ||
+    !nonEmptyString(record.sessionId) ||
+    !nonEmptyString(record.larkAppId) ||
+    !nonEmptyString(record.chatId) ||
+    !nonEmptyString(record.messageId) ||
+    !nonEmptyString(record.cardId) ||
+    !['opening', 'open', 'finished', 'superseded'].includes(String(record.status)) ||
+    !Number.isSafeInteger(record.sequence) ||
+    (record.sequence as number) < 0 ||
+    !nonEmptyString(record.createdAt) ||
+    !nonEmptyString(record.updatedAt) ||
+    (record.anchorTurnId !== undefined && !nonEmptyString(record.anchorTurnId)) ||
+    (record.supersededByStreamId !== undefined && !STREAM_ID_RE.test(record.supersededByStreamId))
+  ) {
+    throw new CardStreamStoreError(`流状态文件字段无效: ${expectedStreamId}`);
+  }
+  return record as CardStreamRecord;
+}
+
+function assertAuthority(record: CardStreamRecord, authority: CardStreamAuthority): void {
+  if (
+    record.sessionId !== authority.sessionId ||
+    record.larkAppId !== authority.larkAppId ||
+    record.chatId !== authority.chatId
+  ) {
+    throw new CardStreamStoreError('当前会话无权操作这个卡片流');
+  }
+}
+
+function assertSameBinding(record: CardStreamRecord, binding: CardStreamBinding, cardId: string): void {
+  assertAuthority(record, binding);
+  if (record.messageId !== binding.messageId || record.cardId !== cardId) {
+    throw new CardStreamStoreError('目标消息与已有卡片流绑定不一致');
+  }
+  if (record.anchorTurnId && binding.anchorTurnId && record.anchorTurnId !== binding.anchorTurnId) {
+    throw new CardStreamStoreError('目标消息属于另一个 turn，请使用 stream reanchor');
+  }
+}
+
+function nextSequence(record: CardStreamRecord): number {
+  const next = record.sequence + 1;
+  if (!Number.isSafeInteger(next)) throw new CardStreamStoreError('卡片流 sequence 已耗尽');
+  return next;
+}
+
+/**
+ * Persistent authority + sequence ledger for CardKit streams.
+ *
+ * Each provider write reserves its sequence on disk before making the network
+ * call, while holding the per-stream file lock. A crash can therefore skip a
+ * sequence but can never reuse or reorder one. CardKit only requires strictly
+ * increasing sequences, so a skipped value is safe; reuse is not.
+ */
+export class CardStreamStore {
+  private readonly streamsDir: string;
+
+  constructor(dataDir: string) {
+    if (!dataDir.trim()) throw new CardStreamStoreError('缺少 Botmux data dir');
+    this.streamsDir = join(dataDir, 'card-streams');
+  }
+
+  static streamIdFor(binding: CardStreamBinding): string {
+    const digest = createHash('sha256')
+      .update([
+        String(CARD_STREAM_SCHEMA_VERSION),
+        binding.sessionId,
+        binding.larkAppId,
+        binding.chatId,
+        binding.messageId,
+      ].join('\0'))
+      .digest('hex')
+      .slice(0, 32);
+    return `cs_${digest}`;
+  }
+
+  async open(
+    binding: CardStreamBinding,
+    cardId: string,
+    enableStreaming: (lease: CardStreamSequenceLease) => Promise<void>,
+  ): Promise<CardStreamOpenResult> {
+    const streamId = CardStreamStore.streamIdFor(binding);
+    const path = this.pathFor(streamId);
+    this.ensureDirectory();
+    return withFileLock(path, async () => {
+      const now = new Date().toISOString();
+      let record: CardStreamRecord;
+      if (existsSync(path)) {
+        record = this.readRecord(path, streamId);
+        assertSameBinding(record, binding, cardId);
+        if (record.status === 'finished' || record.status === 'superseded') {
+          throw new CardStreamStoreError('这个卡片流已经结束，不能重新打开');
+        }
+        if (record.status === 'open') {
+          if (!record.anchorTurnId && binding.anchorTurnId) {
+            record = { ...record, anchorTurnId: binding.anchorTurnId, updatedAt: now };
+            this.writeRecord(path, record);
+          }
+          return { record, alreadyOpen: true };
+        }
+      } else {
+        record = {
+          schemaVersion: CARD_STREAM_SCHEMA_VERSION,
+          streamId,
+          ...binding,
+          cardId,
+          status: 'opening',
+          sequence: 0,
+          createdAt: now,
+          updatedAt: now,
+        };
+        this.writeRecord(path, record);
+      }
+
+      const sequence = nextSequence(record);
+      record = { ...record, sequence, updatedAt: now };
+      this.writeRecord(path, record);
+      await enableStreaming({ cardId, sequence, uuid: this.uuidFor(streamId, sequence) });
+      record = { ...record, status: 'open', updatedAt: new Date().toISOString() };
+      this.writeRecord(path, record);
+      return { record, alreadyOpen: false };
+    });
+  }
+
+  async write(
+    streamId: string,
+    authority: CardStreamAuthority,
+    writeContent: (lease: CardStreamSequenceLease) => Promise<void>,
+  ): Promise<CardStreamRecord> {
+    const path = this.pathFor(streamId);
+    this.ensureDirectory();
+    return withFileLock(path, async () => {
+      const record = this.readRequired(path, streamId);
+      assertAuthority(record, authority);
+      if (record.status === 'opening') {
+        throw new CardStreamStoreError('卡片流仍在打开中，请先重试 stream open');
+      }
+      if (record.status === 'finished') {
+        throw new CardStreamStoreError('卡片流已经结束，不能继续写入');
+      }
+      if (record.status === 'superseded') {
+        throw new CardStreamStoreError('卡片流已经迁移，拒绝迟到写入');
+      }
+      const sequence = nextSequence(record);
+      const reserved = { ...record, sequence, updatedAt: new Date().toISOString() };
+      this.writeRecord(path, reserved);
+      await writeContent({
+        cardId: record.cardId,
+        sequence,
+        uuid: this.uuidFor(streamId, sequence),
+      });
+      const committed = { ...reserved, updatedAt: new Date().toISOString() };
+      this.writeRecord(path, committed);
+      return committed;
+    });
+  }
+
+  async inspect(
+    streamId: string,
+    authority: CardStreamAuthority,
+  ): Promise<CardStreamRecord> {
+    const path = this.pathFor(streamId);
+    this.ensureDirectory();
+    return withFileLock(path, async () => {
+      const record = this.readRequired(path, streamId);
+      assertAuthority(record, authority);
+      return record;
+    });
+  }
+
+  async finish(
+    streamId: string,
+    authority: CardStreamAuthority,
+    disableStreaming: (lease: CardStreamSequenceLease) => Promise<void>,
+  ): Promise<CardStreamFinishResult> {
+    const path = this.pathFor(streamId);
+    this.ensureDirectory();
+    return withFileLock(path, async () => {
+      const record = this.readRequired(path, streamId);
+      assertAuthority(record, authority);
+      if (record.status === 'finished') return { record, alreadyFinished: true };
+      if (record.status === 'superseded') {
+        throw new CardStreamStoreError('卡片流已经迁移，不能结束旧流');
+      }
+      if (record.status === 'opening') {
+        throw new CardStreamStoreError('卡片流仍在打开中，请先重试 stream open');
+      }
+      const sequence = nextSequence(record);
+      const reserved = { ...record, sequence, updatedAt: new Date().toISOString() };
+      this.writeRecord(path, reserved);
+      await disableStreaming({
+        cardId: record.cardId,
+        sequence,
+        uuid: this.uuidFor(streamId, sequence),
+      });
+      const finished: CardStreamRecord = {
+        ...reserved,
+        status: 'finished',
+        updatedAt: new Date().toISOString(),
+      };
+      this.writeRecord(path, finished);
+      return { record: finished, alreadyFinished: false };
+    });
+  }
+
+  /**
+   * Open the replacement card while holding the old stream lock, then fence the
+   * old stream before exposing the new binding. A late writer queued on the old
+   * lock observes `superseded` and can never mutate the replacement card.
+   */
+  async reanchor(
+    streamId: string,
+    authority: CardStreamAuthority,
+    nextBinding: CardStreamBinding,
+    nextCardId: string,
+    enableStreaming: (lease: CardStreamSequenceLease) => Promise<void>,
+  ): Promise<CardStreamReanchorResult> {
+    const path = this.pathFor(streamId);
+    this.ensureDirectory();
+    return withFileLock(path, async () => {
+      const previous = this.readRequired(path, streamId);
+      assertAuthority(previous, authority);
+      if (previous.status !== 'open') {
+        throw new CardStreamStoreError(
+          previous.status === 'superseded' ? '卡片流已经迁移' : '只能迁移仍在打开的卡片流',
+        );
+      }
+      if (
+        nextBinding.sessionId !== authority.sessionId
+        || nextBinding.larkAppId !== authority.larkAppId
+        || nextBinding.chatId !== authority.chatId
+      ) {
+        throw new CardStreamStoreError('新卡片必须属于同一会话、Bot 和群聊');
+      }
+      if (nextBinding.messageId === previous.messageId) {
+        throw new CardStreamStoreError('reanchor 需要一个新的消息 id');
+      }
+
+      const opened = await this.open(nextBinding, nextCardId, enableStreaming);
+      const superseded: CardStreamRecord = {
+        ...previous,
+        status: 'superseded',
+        supersededByStreamId: opened.record.streamId,
+        updatedAt: new Date().toISOString(),
+      };
+      this.writeRecord(path, superseded);
+      return { previous: superseded, current: opened.record };
+    });
+  }
+
+  private pathFor(streamId: string): string {
+    if (!STREAM_ID_RE.test(streamId)) throw new CardStreamStoreError(`streamId 格式无效: ${streamId}`);
+    return join(this.streamsDir, `${streamId}.json`);
+  }
+
+  private ensureDirectory(): void {
+    mkdirSync(this.streamsDir, { recursive: true, mode: 0o700 });
+    const stat = lstatSync(this.streamsDir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new CardStreamStoreError('card-streams 状态目录不安全');
+    }
+  }
+
+  private readRequired(path: string, streamId: string): CardStreamRecord {
+    this.ensureDirectory();
+    if (!existsSync(path)) throw new CardStreamStoreError(`未找到卡片流: ${streamId}`);
+    return this.readRecord(path, streamId);
+  }
+
+  private readRecord(path: string, streamId: string): CardStreamRecord {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new CardStreamStoreError(`流状态文件不安全: ${streamId}`);
+    }
+    return parseRecord(readFileSync(path, 'utf-8'), streamId);
+  }
+
+  private writeRecord(path: string, record: CardStreamRecord): void {
+    atomicWriteFileSync(path, `${JSON.stringify(record)}\n`, {
+      mode: 0o600,
+      followTargetSymlink: false,
+    });
+  }
+
+  private uuidFor(streamId: string, sequence: number): string {
+    return `bmx_${streamId.slice(3, 19)}_${sequence}`;
+  }
+}

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -270,7 +270,7 @@ JSON 格式，与 \`botmux history\` 的单条消息字段一致，并附带 \`r
 
 export const SEND_SKILL = `---
 name: botmux-send
-description: 向飞书话题发送消息。用户在飞书上阅读看不到终端输出，需要用户看到的内容（关键结论、方案、最终结果、进度更新）必须通过 botmux send 发送。支持图文混排（图片穿插在 markdown 正文中）、文本、图片/文件附件、原始 interactive 卡片 JSON（发出后可用 botmux card patch 按 messageId 原地更新）、@mention。**当你自主执行任务撞到只有人类才能解除的硬阻碍、无法靠自己继续时（需要授权/凭证、要人拍不可逆决策、缺访问权限、需求歧义自己定不了），回消息时带 \`--attention\` 举手**——既把"我卡在哪、需要你做什么"发给用户，又把本会话标进 dashboard「需要你」列，让人一眼看到哪个任务卡住、为什么卡。
+description: 向飞书话题发送消息。用户在飞书上阅读看不到终端输出，需要用户看到的内容（关键结论、方案、最终结果、进度更新）必须通过 botmux send 发送。支持图文混排（图片穿插在 markdown 正文中）、文本、图片/文件附件、原始 interactive 卡片 JSON（发出后可用 botmux card patch 原地更新，或用 botmux card stream 做原生打字机流式更新）、@mention。**当你自主执行任务撞到只有人类才能解除的硬阻碍、无法靠自己继续时（需要授权/凭证、要人拍不可逆决策、缺访问权限、需求歧义自己定不了），回消息时带 \`--attention\` 举手**——既把"我卡在哪、需要你做什么"发给用户，又把本会话标进 dashboard「需要你」列，让人一眼看到哪个任务卡住、为什么卡。
 ---
 
 # botmux-send — 向飞书话题发送消息
@@ -473,6 +473,24 @@ botmux card patch --message-id "$MID" --card-json '{"schema":"2.0","body":{"dire
 安全边界与上面的 \`send --card-file/--card-json\` **完全相同**：只允许纯展示元素 + open_url 按钮，任何回调控件都会被拒绝。Bot 身份从会话上下文解析，不提供 \`--bot\` 类显式指定；飞书本身也禁止跨应用 patch 别人的卡片。
 
 成功 stdout 一行 JSON \`{"success":true,"messageId":"om_xxx","sessionId":"..."}\`。参数错误（缺 \`--message-id\`、卡片输入未二选一、messageId 非 \`om_\` 开头、含回调控件、JSON 非法）exit 2；\`--card-file\` 不存在、消息已撤回、飞书 API 报错 exit 1，stderr 透出原因。
+
+#### 原生打字机流式更新：\`botmux card stream\`
+
+需要连续输出感时，不要高频整卡 \`patch\`。先发送 Card 2.0 卡片，并给需要流式写入的 \`markdown\` 或 \`plain_text\` 组件设置唯一 \`element_id\`（字母开头、最多 20 字符），然后用 CardKit 原生流：
+
+\`\`\`bash
+MID=$(botmux send --card-file /tmp/progress.json --no-mention | jq -r .messageId)
+OPEN=$(botmux card stream open --message-id "$MID" --summary "执行中")
+STREAM_ID=$(printf '%s' "$OPEN" | jq -r .streamId)
+
+# write 传该 element 的完整最新内容；新增后缀由飞书原生打字机动画呈现
+botmux card stream write --stream-id "$STREAM_ID" --element-id work_log --content-file /tmp/work-log.md
+botmux card stream finish --stream-id "$STREAM_ID" --summary "已完成"
+\`\`\`
+
+如果同一任务需要跟随较新的用户输入，先用当前完整卡片内容发出新卡，再调用 \`stream reanchor --stream-id <旧流> --message-id <新卡>\`。Botmux 会在新流就绪后拒绝旧流的迟到写入、迁移已绑定的运行状态，并尽力撤回旧消息。成功输出会返回新的 \`messageId\` / \`streamId\`，调用方必须立即更新自己的持久化状态。是否跟随新输入由调用 Skill 决定，Core 不自动撤回任意卡片。
+
+多行内容也可用 \`--content-file -\` 从 stdin 读取。核心命令只负责 transport、会话归属、顺序与幂等；阶段、公开工作摘要、工具事件和 UI 语义应由机器人自己的 Skill 决定。不要把模型私有原始 CoT 写进卡片，只展示可公开、可验证的工作摘要。
 
 ### @mention 其他机器人协作
 

--- a/test/card-runtime-status-bridge.test.ts
+++ b/test/card-runtime-status-bridge.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CardStreamStore, type CardStreamBinding } from '../src/services/card-stream-store.js';
+import { CardRuntimeStatusBridge } from '../src/services/card-runtime-status-bridge.js';
+
+const binding: CardStreamBinding = {
+  sessionId: 'sid_runtime',
+  larkAppId: 'cli_app',
+  chatId: 'oc_chat',
+  messageId: 'om_card',
+};
+
+async function harness(run: (input: {
+  bridge: CardRuntimeStatusBridge;
+  streamId: string;
+  updates: any[];
+  patches: any[];
+  updateContent: ReturnType<typeof vi.fn>;
+  patchElement: ReturnType<typeof vi.fn>;
+  streams: CardStreamStore;
+  dir: string;
+}) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'botmux-card-runtime-'));
+  try {
+    const streams = new CardStreamStore(dir);
+    const opened = await streams.open(binding, 'card_1', async () => undefined);
+    const updates: any[] = [];
+    const patches: any[] = [];
+    const updateContent = vi.fn(async input => { updates.push(input); });
+    const patchElement = vi.fn(async input => { patches.push(input); });
+    const bridge = new CardRuntimeStatusBridge(dir, streams, {
+      updateContent,
+      patchElement,
+    });
+    await run({ bridge, streamId: opened.record.streamId, updates, patches, updateContent, patchElement, streams, dir });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('CardRuntimeStatusBridge', () => {
+  it('drives text + animated/static image from real runtime status and deduplicates repeats', async () => harness(async ({ bridge, streamId, updates, patches }) => {
+    await bridge.bind({
+      streamId,
+      authority: binding,
+      statusElementId: 'status_badge',
+      imageElementId: 'loader_img',
+      activeImageKey: 'img_active_12345678',
+      inactiveImageKey: 'img_inactive_12345678',
+      labels: { working: '正在执行', stalled: '可能卡住' },
+    });
+
+    expect(await bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'working' })).toBe(true);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      elementId: 'status_badge',
+      content: "<text_tag color='blue'>正在执行</text_tag>",
+      sequence: 2,
+    });
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toMatchObject({
+      elementId: 'loader_img',
+      partialElement: { img_key: 'img_active_12345678' },
+      sequence: 3,
+    });
+
+    expect(await bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'working' })).toBe(false);
+    expect(updates).toHaveLength(1);
+    expect(patches).toHaveLength(1);
+
+    expect(await bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'stalled' })).toBe(true);
+    expect(updates.at(-1)).toMatchObject({
+      content: "<text_tag color='orange'>可能卡住</text_tag>",
+      sequence: 4,
+    });
+    expect(patches.at(-1)).toMatchObject({
+      partialElement: { img_key: 'img_inactive_12345678' },
+      sequence: 5,
+    });
+  }));
+
+  it('stops the loader and removes the binding so later screen updates are inert', async () => harness(async ({ bridge, streamId, updates, patches }) => {
+    await bridge.bind({
+      streamId,
+      authority: binding,
+      statusElementId: 'status_badge',
+      imageElementId: 'loader_img',
+      activeImageKey: 'img_active_12345678',
+      inactiveImageKey: 'img_inactive_12345678',
+    });
+    expect(await bridge.unbind(streamId, binding)).toBe(true);
+    expect(patches.at(-1)).toMatchObject({ partialElement: { img_key: 'img_inactive_12345678' } });
+    expect(await bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'working' })).toBe(false);
+    expect(updates).toHaveLength(0);
+  }));
+
+  it('removes a stale runtime binding even when the provider rejects the final inactive image patch', async () => harness(async ({ bridge, streamId, updates, patchElement }) => {
+    await bridge.bind({
+      streamId,
+      authority: binding,
+      statusElementId: 'status_badge',
+      imageElementId: 'loader_img',
+      activeImageKey: 'img_active_12345678',
+      inactiveImageKey: 'img_inactive_12345678',
+    });
+    await bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'working' });
+    patchElement.mockRejectedValueOnce(new Error('card streaming timeout'));
+    await expect(bridge.unbind(streamId, binding)).rejects.toThrow('card streaming timeout');
+    expect(await bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'idle' })).toBe(false);
+    expect(updates).toHaveLength(1);
+  }));
+
+  it('coalesces a burst and publishes only the first and newest queued statuses', async () => harness(async ({
+    bridge,
+    streamId,
+    updates,
+    updateContent,
+  }) => {
+    await bridge.bind({
+      streamId,
+      authority: binding,
+      statusElementId: 'status_badge',
+      imageElementId: 'loader_img',
+      activeImageKey: 'img_active_12345678',
+      inactiveImageKey: 'img_inactive_12345678',
+    });
+    let markFirstEntered!: () => void;
+    let releaseFirst!: () => void;
+    const firstEntered = new Promise<void>(resolve => { markFirstEntered = resolve; });
+    const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+    updateContent.mockImplementationOnce(async input => {
+      updates.push(input);
+      markFirstEntered();
+      await firstGate;
+    });
+
+    const first = bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'working' });
+    await firstEntered;
+    const second = bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'analyzing' });
+    const third = bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'limited' });
+    releaseFirst();
+    await Promise.all([first, second, third]);
+
+    expect(updates.map(update => update.content)).toEqual([
+      "<text_tag color='blue'>执行中</text_tag>",
+      "<text_tag color='orange'>等待额度</text_tag>",
+    ]);
+  }));
+
+  it('deletes a stale runtime binding after the stream reaches a terminal state', async () => harness(async ({
+    bridge,
+    streamId,
+    updates,
+    streams,
+    dir,
+  }) => {
+    await bridge.bind({
+      streamId,
+      authority: binding,
+      statusElementId: 'status_badge',
+      imageElementId: 'loader_img',
+      activeImageKey: 'img_active_12345678',
+      inactiveImageKey: 'img_inactive_12345678',
+    });
+    await streams.finish(streamId, binding, async () => undefined);
+
+    expect(await bridge.publish({
+      sessionId: binding.sessionId,
+      larkAppId: binding.larkAppId,
+      status: 'working',
+    })).toBe(false);
+    expect(readdirSync(join(dir, 'card-runtime-status')).filter(name => name.endsWith('.json'))).toEqual([]);
+    expect(updates).toHaveLength(0);
+  }));
+
+  it('moves an existing runtime binding to the replacement stream', async () => harness(async ({ bridge, streamId, updates, streams }) => {
+    await bridge.bind({
+      streamId,
+      authority: binding,
+      statusElementId: 'status_badge',
+      imageElementId: 'loader_img',
+      activeImageKey: 'img_active_12345678',
+      inactiveImageKey: 'img_inactive_12345678',
+    });
+    const moved = await streams.reanchor(
+      streamId,
+      binding,
+      { ...binding, messageId: 'om_card_2', anchorTurnId: 'turn_2' },
+      'card_2',
+      async () => undefined,
+    );
+    expect(await bridge.reanchor(streamId, moved.current.streamId, binding)).toBe(true);
+    expect(await bridge.publish({ sessionId: binding.sessionId, larkAppId: binding.larkAppId, status: 'working' })).toBe(true);
+    expect(updates.at(-1)).toMatchObject({ cardId: 'card_2', elementId: 'status_badge' });
+  }));
+});

--- a/test/card-stream-store.test.ts
+++ b/test/card-stream-store.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  CardStreamStore,
+  CardStreamStoreError,
+  type CardStreamBinding,
+} from '../src/services/card-stream-store.js';
+
+const binding: CardStreamBinding = {
+  sessionId: 'sid_1',
+  larkAppId: 'cli_app',
+  chatId: 'oc_chat',
+  messageId: 'om_card',
+};
+
+function withStore(run: (store: CardStreamStore, dir: string) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'botmux-card-stream-'));
+  return run(new CardStreamStore(dir), dir).finally(() => rmSync(dir, { recursive: true, force: true }));
+}
+
+describe('CardStreamStore', () => {
+  it('opens deterministically and persists an app/session/chat binding', async () => withStore(async (store, dir) => {
+    const enable = vi.fn(async () => undefined);
+    const first = await store.open(binding, 'card_1', enable);
+    const second = await store.open(binding, 'card_1', enable);
+
+    expect(first.alreadyOpen).toBe(false);
+    expect(second.alreadyOpen).toBe(true);
+    expect(second.record.streamId).toBe(CardStreamStore.streamIdFor(binding));
+    expect(second.record).toMatchObject({ ...binding, cardId: 'card_1', status: 'open', sequence: 1 });
+    expect(enable).toHaveBeenCalledTimes(1);
+    expect(enable).toHaveBeenCalledWith(expect.objectContaining({ cardId: 'card_1', sequence: 1 }));
+
+    const persisted = JSON.parse(readFileSync(
+      join(dir, 'card-streams', `${second.record.streamId}.json`),
+      'utf-8',
+    ));
+    expect(persisted).toMatchObject({ ...binding, status: 'open', sequence: 1 });
+  }));
+
+  it('reserves strictly increasing sequences for writes and finish', async () => withStore(async store => {
+    const opened = await store.open(binding, 'card_1', async () => undefined);
+    const seen: number[] = [];
+    const firstWrite = await store.write(opened.record.streamId, binding, async lease => {
+      seen.push(lease.sequence);
+    });
+    const secondWrite = await store.write(opened.record.streamId, binding, async lease => {
+      seen.push(lease.sequence);
+    });
+    const finished = await store.finish(opened.record.streamId, binding, async lease => {
+      seen.push(lease.sequence);
+    });
+
+    expect(seen).toEqual([2, 3, 4]);
+    expect(firstWrite.sequence).toBe(2);
+    expect(secondWrite.sequence).toBe(3);
+    expect(finished.record).toMatchObject({ status: 'finished', sequence: 4 });
+  }));
+
+  it('consumes a sequence when a provider write fails so it is never reused', async () => withStore(async store => {
+    const opened = await store.open(binding, 'card_1', async () => undefined);
+    await expect(store.write(opened.record.streamId, binding, async lease => {
+      expect(lease.sequence).toBe(2);
+      throw new Error('network lost');
+    })).rejects.toThrow('network lost');
+
+    const recovered = await store.write(opened.record.streamId, binding, async lease => {
+      expect(lease.sequence).toBe(3);
+    });
+    expect(recovered.sequence).toBe(3);
+  }));
+
+  it('serializes concurrent writes so provider calls cannot arrive out of order', async () => withStore(async store => {
+    const opened = await store.open(binding, 'card_1', async () => undefined);
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+
+    const first = store.write(opened.record.streamId, binding, async lease => {
+      order.push(`start-${lease.sequence}`);
+      await firstGate;
+      order.push(`end-${lease.sequence}`);
+    });
+    await new Promise(resolve => setTimeout(resolve, 30));
+    const second = store.write(opened.record.streamId, binding, async lease => {
+      order.push(`start-${lease.sequence}`);
+      order.push(`end-${lease.sequence}`);
+    });
+    await new Promise(resolve => setTimeout(resolve, 30));
+    expect(order).toEqual(['start-2']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(['start-2', 'end-2', 'start-3', 'end-3']);
+  }));
+
+  it('rejects cross-session, cross-bot, and cross-chat access', async () => withStore(async store => {
+    const opened = await store.open(binding, 'card_1', async () => undefined);
+    for (const authority of [
+      { ...binding, sessionId: 'sid_other' },
+      { ...binding, larkAppId: 'cli_other' },
+      { ...binding, chatId: 'oc_other' },
+    ]) {
+      await expect(store.write(opened.record.streamId, authority, async () => undefined))
+        .rejects.toBeInstanceOf(CardStreamStoreError);
+    }
+  }));
+
+  it('makes finish idempotent and rejects writes after finish', async () => withStore(async store => {
+    const opened = await store.open(binding, 'card_1', async () => undefined);
+    const disable = vi.fn(async () => undefined);
+    const first = await store.finish(opened.record.streamId, binding, disable);
+    const second = await store.finish(opened.record.streamId, binding, disable);
+    expect(first.alreadyFinished).toBe(false);
+    expect(second.alreadyFinished).toBe(true);
+    expect(disable).toHaveBeenCalledTimes(1);
+    await expect(store.write(opened.record.streamId, binding, async () => undefined))
+      .rejects.toThrow('已经结束');
+  }));
+
+  it('reanchors to a new message before fencing every late write to the old stream', async () => withStore(async store => {
+    const opened = await store.open({ ...binding, anchorTurnId: 'turn_1' }, 'card_1', async () => undefined);
+    const nextBinding = { ...binding, messageId: 'om_card_2', anchorTurnId: 'turn_2' };
+    const enabled: number[] = [];
+    const moved = await store.reanchor(
+      opened.record.streamId,
+      binding,
+      nextBinding,
+      'card_2',
+      async lease => { enabled.push(lease.sequence); },
+    );
+
+    expect(enabled).toEqual([1]);
+    expect(moved.previous).toMatchObject({
+      streamId: opened.record.streamId,
+      status: 'superseded',
+      supersededByStreamId: moved.current.streamId,
+    });
+    expect(moved.current).toMatchObject({
+      ...nextBinding,
+      cardId: 'card_2',
+      status: 'open',
+      sequence: 1,
+    });
+    await expect(store.write(opened.record.streamId, binding, async () => undefined))
+      .rejects.toThrow('已经迁移');
+    expect((await store.write(moved.current.streamId, binding, async () => undefined)).sequence).toBe(2);
+  }));
+
+  it('rejects reanchor to the same message and cross-authority targets', async () => withStore(async store => {
+    const opened = await store.open(binding, 'card_1', async () => undefined);
+    await expect(store.reanchor(
+      opened.record.streamId,
+      binding,
+      binding,
+      'card_1',
+      async () => undefined,
+    )).rejects.toThrow('新的消息');
+    await expect(store.reanchor(
+      opened.record.streamId,
+      binding,
+      { ...binding, messageId: 'om_other', chatId: 'oc_other' },
+      'card_2',
+      async () => undefined,
+    )).rejects.toThrow('同一会话');
+  }));
+
+  it('rejects path traversal and missing stream ids before touching provider state', async () => withStore(async store => {
+    await expect(store.write('../escape', binding, async () => undefined)).rejects.toThrow('格式无效');
+    await expect(store.write('cs_00000000000000000000000000000000', binding, async () => undefined))
+      .rejects.toThrow('未找到卡片流');
+  }));
+});

--- a/test/cli-card-dispatch.test.ts
+++ b/test/cli-card-dispatch.test.ts
@@ -336,6 +336,7 @@ describe('card patch --help', () => {
   it('prints the card command usage with the patch subcommand on `card --help` / no subcommand', () => {
     expect(CARD_COMMAND_USAGE).toContain('botmux card');
     expect(CARD_COMMAND_USAGE).toContain('patch');
+    expect(CARD_COMMAND_USAGE).toContain('stream');
     expect(CARD_COMMAND_USAGE).toContain('--message-id');
     expect(CARD_COMMAND_USAGE).toContain('原地更新');
   });

--- a/test/cli-card-stream-dispatch.test.ts
+++ b/test/cli-card-stream-dispatch.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildCardStreamSuccessOutput,
+  CARD_STREAM_USAGE,
+  cardMessageBelongsToSession,
+  cardMessageRouteFromDetail,
+  cardStreamArgsWantHelp,
+  executeCardStreamFinish,
+  executeCardStreamOpen,
+  executeCardStreamReanchor,
+  executeCardStreamSnapshot,
+  executeCardStreamWrite,
+  mapCardStreamError,
+  parseCardStreamArgs,
+  readCardStreamContent,
+  type CardStreamDeps,
+} from '../src/cli/card-stream-dispatch.js';
+import type { CardStreamRecord } from '../src/services/card-stream-store.js';
+import { parseCardRuntimeStatusArgs } from '../src/cli/card-runtime-status-dispatch.js';
+
+const STREAM_ID = 'cs_0123456789abcdef0123456789abcdef';
+const baseRecord: CardStreamRecord = {
+  schemaVersion: 1,
+  streamId: STREAM_ID,
+  sessionId: 'sid_1',
+  larkAppId: 'cli_app',
+  chatId: 'oc_chat',
+  messageId: 'om_card',
+  cardId: 'card_1',
+  status: 'open',
+  sequence: 1,
+  createdAt: '2026-08-30T00:00:00.000Z',
+  updatedAt: '2026-08-30T00:00:00.000Z',
+};
+
+function deps(overrides: Partial<CardStreamDeps> = {}): CardStreamDeps {
+  return {
+    store: {
+      open: vi.fn(async (_binding, _cardId, callback) => {
+        await callback({ cardId: 'card_1', sequence: 1, uuid: 'uuid_1' });
+        return { record: baseRecord, alreadyOpen: false };
+      }),
+      write: vi.fn(async (_streamId, _authority, callback) => {
+        await callback({ cardId: 'card_1', sequence: 2, uuid: 'uuid_2' });
+        return { ...baseRecord, sequence: 2 };
+      }),
+      inspect: vi.fn(async () => baseRecord),
+      reanchor: vi.fn(async (_streamId, _authority, nextBinding, _cardId, callback) => {
+        await callback({ cardId: 'card_2', sequence: 1, uuid: 'uuid_new_1' });
+        return {
+          previous: { ...baseRecord, status: 'superseded', supersededByStreamId: 'cs_11111111111111111111111111111111' },
+          current: {
+            ...baseRecord,
+            ...nextBinding,
+            streamId: 'cs_11111111111111111111111111111111',
+            cardId: 'card_2',
+            sequence: 1,
+          },
+        };
+      }),
+      finish: vi.fn(async (_streamId, _authority, callback) => {
+        await callback({ cardId: 'card_1', sequence: 2, uuid: 'uuid_2' });
+        return { record: { ...baseRecord, status: 'finished', sequence: 2 }, alreadyFinished: false };
+      }),
+    },
+    getMessageRoute: vi.fn(async () => ({
+      messageId: 'om_card', chatId: 'oc_chat', rootMessageId: 'om_root', messageType: 'interactive',
+    })),
+    resolveCardId: vi.fn(async () => 'card_1'),
+    updateSettings: vi.fn(async () => undefined),
+    updateElementContent: vi.fn(async () => undefined),
+    moveRuntimeBinding: vi.fn(async () => true),
+    deleteMessage: vi.fn(async () => true),
+    ...overrides,
+  };
+}
+
+describe('parseCardStreamArgs', () => {
+  it('parses open, write, snapshot, and finish', () => {
+    expect(parseCardStreamArgs(['open', '--message-id', 'om_1', '--summary', '进行中']))
+      .toEqual({ ok: true, operation: 'open', messageId: 'om_1', summary: '进行中' });
+    expect(parseCardStreamArgs([
+      'write', '--stream-id', STREAM_ID, '--element-id', 'work_log', '--content-file', '-', '--session-id', 'sid_1',
+    ])).toEqual({
+      ok: true,
+      operation: 'write',
+      streamId: STREAM_ID,
+      elementId: 'work_log',
+      contentFile: '-',
+      sessionId: 'sid_1',
+    });
+    expect(parseCardStreamArgs(['finish', '--stream-id', STREAM_ID, '--summary=完成']))
+      .toEqual({ ok: true, operation: 'finish', streamId: STREAM_ID, summary: '完成' });
+    expect(parseCardStreamArgs(['snapshot', '--stream-id', STREAM_ID, '--session-id', 'sid_1']))
+      .toEqual({ ok: true, operation: 'snapshot', streamId: STREAM_ID, sessionId: 'sid_1' });
+    expect(parseCardStreamArgs([
+      'reanchor', '--stream-id', STREAM_ID, '--message-id', 'om_2', '--summary', '继续执行',
+    ])).toEqual({
+      ok: true,
+      operation: 'reanchor',
+      streamId: STREAM_ID,
+      messageId: 'om_2',
+      summary: '继续执行',
+    });
+  });
+
+  it('rejects malformed ids, an invalid element id, and ambiguous content input', () => {
+    expect(parseCardStreamArgs(['open', '--message-id', 'bad']).ok).toBe(false);
+    expect(parseCardStreamArgs(['write', '--stream-id', '../x', '--element-id', 'main', '--content', 'x']).ok).toBe(false);
+    expect(parseCardStreamArgs([
+      'write', '--stream-id', STREAM_ID, '--element-id', '1bad', '--content', 'x',
+    ]).ok).toBe(false);
+    expect(parseCardStreamArgs([
+      'write', '--stream-id', STREAM_ID, '--element-id', 'main', '--content', 'x', '--content-file', '/x',
+    ]).ok).toBe(false);
+  });
+
+  it('rejects content-free writes and overlong summaries', () => {
+    expect(parseCardStreamArgs(['write', '--stream-id', STREAM_ID, '--element-id', 'main']).ok).toBe(false);
+    const result = parseCardStreamArgs(['finish', '--stream-id', STREAM_ID, '--summary', 'x'.repeat(51)]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('50');
+  });
+});
+
+describe('parseCardRuntimeStatusArgs', () => {
+  it('parses bind/unbind runtime status commands', () => {
+    expect(parseCardRuntimeStatusArgs([
+      'bind-runtime',
+      '--stream-id', STREAM_ID,
+      '--status-element-id', 'status_badge',
+      '--image-element-id', 'loader_img',
+      '--active-image-key', 'img_active_12345678',
+      '--inactive-image-key', 'img_inactive_12345678',
+      '--labels-json', '{"working":"执行中"}',
+      '--session-id', 'sid_1',
+    ])).toEqual({
+      ok: true,
+      operation: 'bind-runtime',
+      streamId: STREAM_ID,
+      statusElementId: 'status_badge',
+      imageElementId: 'loader_img',
+      activeImageKey: 'img_active_12345678',
+      inactiveImageKey: 'img_inactive_12345678',
+      labels: { working: '执行中' },
+      sessionId: 'sid_1',
+    });
+    expect(parseCardRuntimeStatusArgs([
+      'unbind-runtime', '--stream-id', STREAM_ID,
+    ])).toEqual({ ok: true, operation: 'unbind-runtime', streamId: STREAM_ID });
+  });
+
+  it('rejects unsafe element/image ids and malformed labels', () => {
+    expect(parseCardRuntimeStatusArgs([
+      'bind-runtime', '--stream-id', STREAM_ID,
+      '--status-element-id', '../bad', '--image-element-id', 'loader_img',
+      '--active-image-key', 'img_active_12345678', '--inactive-image-key', 'img_inactive_12345678',
+    ]).ok).toBe(false);
+    expect(parseCardRuntimeStatusArgs([
+      'bind-runtime', '--stream-id', STREAM_ID,
+      '--status-element-id', 'status_badge', '--image-element-id', 'loader_img',
+      '--active-image-key', 'bad', '--inactive-image-key', 'img_inactive_12345678',
+    ]).ok).toBe(false);
+    expect(parseCardRuntimeStatusArgs([
+      'bind-runtime', '--stream-id', STREAM_ID,
+      '--status-element-id', 'status_badge', '--image-element-id', 'loader_img',
+      '--active-image-key', 'img_active_12345678', '--inactive-image-key', 'img_inactive_12345678',
+      '--labels-json', '{"unknown":"x"}',
+    ]).ok).toBe(false);
+  });
+});
+
+describe('readCardStreamContent', () => {
+  it('passes inline content and reads a file', () => {
+    expect(readCardStreamContent('hello', undefined)).toEqual({ ok: true, content: 'hello' });
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-stream-content-'));
+    try {
+      const file = join(dir, 'content.md');
+      writeFileSync(file, 'line 1\nline 2', 'utf-8');
+      expect(readCardStreamContent(undefined, file)).toEqual({ ok: true, content: 'line 1\nline 2' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('maps a missing file and oversized content clearly', () => {
+    expect(readCardStreamContent(undefined, '/missing/card-stream.md'))
+      .toEqual({ ok: false, exitCode: 1, error: expect.stringContaining('文件不存在') });
+    expect(readCardStreamContent('x'.repeat(30_001), undefined))
+      .toEqual({ ok: false, exitCode: 2, error: expect.stringContaining('30000') });
+  });
+});
+
+describe('card message ownership', () => {
+  it('normalizes the Lark detail response', () => {
+    expect(cardMessageRouteFromDetail({ items: [{
+      message_id: 'om_1', chat_id: 'oc_1', root_id: 'om_root', msg_type: 'interactive',
+    }] }, 'om_fallback')).toEqual({
+      messageId: 'om_1', chatId: 'oc_1', rootMessageId: 'om_root', messageType: 'interactive',
+    });
+  });
+
+  it('requires same chat and same thread for thread sessions', () => {
+    const session = { chatId: 'oc_1', rootMessageId: 'om_root', scope: 'thread' as const };
+    expect(cardMessageBelongsToSession({
+      messageId: 'om_card', chatId: 'oc_1', rootMessageId: 'om_root', messageType: 'interactive',
+    }, session)).toEqual({ ok: true });
+    expect(cardMessageBelongsToSession({
+      messageId: 'om_card', chatId: 'oc_other', rootMessageId: 'om_root', messageType: 'interactive',
+    }, session).ok).toBe(false);
+    expect(cardMessageBelongsToSession({
+      messageId: 'om_card', chatId: 'oc_1', rootMessageId: 'om_other', messageType: 'interactive',
+    }, session).ok).toBe(false);
+    expect(cardMessageBelongsToSession({
+      messageId: 'om_card', chatId: 'oc_1', rootMessageId: 'om_root', messageType: 'text',
+    }, session).ok).toBe(false);
+  });
+
+  it('allows any interactive card in the same chat for chat-scope sessions', () => {
+    expect(cardMessageBelongsToSession({
+      messageId: 'om_card', chatId: 'oc_1', rootMessageId: 'om_other', messageType: 'interactive',
+    }, { chatId: 'oc_1', rootMessageId: 'om_root', scope: 'chat' })).toEqual({ ok: true });
+  });
+});
+
+describe('CardKit stream execution', () => {
+  const binding = { sessionId: 'sid_1', larkAppId: 'cli_app', chatId: 'oc_chat', messageId: 'om_card' };
+  const sessionRoute = { chatId: 'oc_chat', rootMessageId: 'om_root', scope: 'thread' as const };
+  const authority = { sessionId: 'sid_1', larkAppId: 'cli_app', chatId: 'oc_chat' };
+
+  it('opens with native typewriter settings after route validation', async () => {
+    const d = deps();
+    const outcome = await executeCardStreamOpen(d, { binding, sessionRoute, summary: '进行中' });
+    expect(outcome).toEqual({
+      ok: true,
+      operation: 'open',
+      streamId: STREAM_ID,
+      messageId: 'om_card',
+      sequence: 1,
+      alreadyOpen: false,
+    });
+    expect(d.resolveCardId).toHaveBeenCalledWith('cli_app', 'om_card');
+    expect(d.updateSettings).toHaveBeenCalledWith({
+      larkAppId: 'cli_app',
+      cardId: 'card_1',
+      sequence: 1,
+      uuid: 'uuid_1',
+      streamingMode: true,
+      summary: '进行中',
+      print: { frequencyMs: 70, step: 1, strategy: 'fast' },
+    });
+  });
+
+  it('fails closed before CardKit conversion when the message is outside the session', async () => {
+    const d = deps({
+      getMessageRoute: vi.fn(async () => ({ messageId: 'om_card', chatId: 'oc_other', messageType: 'interactive' })),
+    });
+    const outcome = await executeCardStreamOpen(d, { binding, sessionRoute });
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.exitCode).toBe(2);
+    expect(d.resolveCardId).not.toHaveBeenCalled();
+  });
+
+  it('writes the full element snapshot with the store-issued sequence', async () => {
+    const d = deps();
+    const outcome = await executeCardStreamWrite(d, {
+      streamId: STREAM_ID,
+      authority,
+      elementId: 'work_log',
+      content: '正在读取代码…',
+    });
+    expect(outcome).toEqual({
+      ok: true, operation: 'write', streamId: STREAM_ID, elementId: 'work_log', sequence: 2,
+    });
+    expect(d.updateElementContent).toHaveBeenCalledWith({
+      larkAppId: 'cli_app',
+      cardId: 'card_1',
+      sequence: 2,
+      uuid: 'uuid_2',
+      elementId: 'work_log',
+      content: '正在读取代码…',
+    });
+  });
+
+  it('finishes the stream and updates the preview summary', async () => {
+    const d = deps();
+    const outcome = await executeCardStreamFinish(d, { streamId: STREAM_ID, authority, summary: '已完成' });
+    expect(outcome).toEqual({
+      ok: true, operation: 'finish', streamId: STREAM_ID, sequence: 2, alreadyFinished: false,
+    });
+    expect(d.updateSettings).toHaveBeenCalledWith({
+      larkAppId: 'cli_app',
+      cardId: 'card_1',
+      sequence: 2,
+      uuid: 'uuid_2',
+      streamingMode: false,
+      summary: '已完成',
+    });
+  });
+
+  it('reads a session-authorized native usage snapshot without estimating missing data', async () => {
+    const d = deps();
+    const usage = {
+      inputTokens: 120,
+      outputTokens: 30,
+      cacheReadTokens: 50,
+      cacheCreateTokens: 10,
+      totalTokens: 210,
+    };
+    const outcome = await executeCardStreamSnapshot(d, {
+      streamId: STREAM_ID,
+      authority,
+      readUsage: () => usage,
+      currentTurnId: 'turn_2',
+      now: () => new Date('2026-08-31T01:02:03.000Z'),
+    });
+    expect(outcome).toEqual({
+      ok: true,
+      operation: 'snapshot',
+      streamId: STREAM_ID,
+      capturedAt: '2026-08-31T01:02:03.000Z',
+      usage,
+      currentTurnId: 'turn_2',
+    });
+    expect(d.store.inspect).toHaveBeenCalledWith(STREAM_ID, authority);
+
+    const unavailable = await executeCardStreamSnapshot(d, {
+      streamId: STREAM_ID,
+      authority,
+      readUsage: () => null,
+    });
+    expect(unavailable.ok).toBe(true);
+    if (unavailable.ok && unavailable.operation === 'snapshot') {
+      expect(unavailable.usage).toBeNull();
+    }
+  });
+
+  it('reanchors only after the replacement card is validated and fences the old stream', async () => {
+    const order: string[] = [];
+    const d = deps({
+      getMessageRoute: vi.fn(async () => ({
+        messageId: 'om_card_2', chatId: 'oc_chat', rootMessageId: 'om_root', messageType: 'interactive',
+      })),
+      resolveCardId: vi.fn(async () => 'card_2'),
+    });
+    vi.mocked(d.store.reanchor).mockImplementation(async (_streamId, _authority, nextBinding, _cardId, callback) => {
+      await callback({ cardId: 'card_2', sequence: 1, uuid: 'uuid_new_1' });
+      order.push('fence');
+      return {
+        previous: { ...baseRecord, status: 'superseded', supersededByStreamId: 'cs_11111111111111111111111111111111' },
+        current: {
+          ...baseRecord,
+          ...nextBinding,
+          streamId: 'cs_11111111111111111111111111111111',
+          cardId: 'card_2',
+          sequence: 1,
+        },
+      };
+    });
+    vi.mocked(d.moveRuntimeBinding).mockImplementation(async () => {
+      order.push('runtime');
+      return true;
+    });
+    vi.mocked(d.deleteMessage).mockImplementation(async () => {
+      order.push('recall');
+      return true;
+    });
+    const outcome = await executeCardStreamReanchor(d, {
+      streamId: STREAM_ID,
+      authority,
+      nextBinding: {
+        ...authority,
+        messageId: 'om_card_2',
+        anchorTurnId: 'turn_2',
+      },
+      sessionRoute,
+      summary: '继续执行',
+    });
+    expect(outcome).toEqual({
+      ok: true,
+      operation: 'reanchor',
+      previousStreamId: STREAM_ID,
+      streamId: 'cs_11111111111111111111111111111111',
+      previousMessageId: 'om_card',
+      messageId: 'om_card_2',
+      sequence: 1,
+      runtimeRebound: true,
+      previousMessageRecalled: true,
+      anchorTurnId: 'turn_2',
+    });
+    expect(d.store.reanchor).toHaveBeenCalled();
+    expect(d.moveRuntimeBinding).toHaveBeenCalledWith(
+      STREAM_ID,
+      'cs_11111111111111111111111111111111',
+      authority,
+    );
+    expect(d.deleteMessage).toHaveBeenCalledWith('cli_app', 'om_card');
+    expect(order).toEqual(['fence', 'runtime', 'recall']);
+  });
+
+  it('maps provider business errors without hiding the Feishu code', async () => {
+    const d = deps({
+      updateElementContent: vi.fn(async () => {
+        throw { response: { data: { code: 300100, msg: 'sequence invalid' } } };
+      }),
+    });
+    const outcome = await executeCardStreamWrite(d, {
+      streamId: STREAM_ID, authority, elementId: 'work_log', content: 'x',
+    });
+    expect(outcome).toEqual({
+      ok: false,
+      exitCode: 1,
+      error: 'CardKit 更新失败: sequence invalid (code: 300100)',
+    });
+  });
+});
+
+describe('help and output', () => {
+  it('documents the three-step lifecycle and stdin', () => {
+    expect(cardStreamArgsWantHelp(['--help'])).toBe(true);
+    expect(CARD_STREAM_USAGE).toContain('stream open');
+    expect(CARD_STREAM_USAGE).toContain('stream write');
+    expect(CARD_STREAM_USAGE).toContain('stream snapshot');
+    expect(CARD_STREAM_USAGE).toContain('stream reanchor');
+    expect(CARD_STREAM_USAGE).toContain('bind-runtime');
+    expect(CARD_STREAM_USAGE).toContain('unbind-runtime');
+    expect(CARD_STREAM_USAGE).toContain('stream finish');
+    expect(CARD_STREAM_USAGE).toContain('--content-file -');
+  });
+
+  it('emits machine-readable JSON without the internal ok field', () => {
+    expect(buildCardStreamSuccessOutput({
+      ok: true,
+      operation: 'write',
+      streamId: STREAM_ID,
+      elementId: 'work_log',
+      sequence: 2,
+    }, 'sid_1')).toBe(JSON.stringify({
+      success: true,
+      operation: 'write',
+      streamId: STREAM_ID,
+      elementId: 'work_log',
+      sequence: 2,
+      sessionId: 'sid_1',
+    }));
+  });
+});
+
+describe('runtime error mapping', () => {
+  it('maps runtime binding errors without leaking stacks or local lock paths', () => {
+    const runtime = Object.assign(new Error('runtime status binding 与 streamId 不匹配'), {
+      name: 'CardRuntimeStatusBridgeError',
+    });
+    expect(mapCardStreamError(runtime)).toEqual({
+      exitCode: 2,
+      error: 'runtime status binding 与 streamId 不匹配',
+    });
+
+    const lock = Object.assign(new Error('file-lock timeout waiting for /private/path/card.json.lock'), {
+      code: 'FILE_LOCK_TIMEOUT',
+    });
+    expect(mapCardStreamError(lock)).toEqual({
+      exitCode: 1,
+      error: '卡片流暂时忙，请稍后重试',
+    });
+  });
+});

--- a/test/cli-card-stream-usage.test.ts
+++ b/test/cli-card-stream-usage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readCardStreamUsageSnapshot } from '../src/cli/card-stream-usage.js';
+
+describe('readCardStreamUsageSnapshot', () => {
+  it('returns four native buckets for an explicit custom stream without built-in card display gating', () => {
+    const reader = vi.fn(() => ({
+      context: null,
+      turnTokens: null,
+      tokens: {
+        in: 160,
+        out: 20,
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 50,
+        cacheCreateTokens: 10,
+        model: 'test',
+        turns: 1,
+      },
+    }));
+    const usage = readCardStreamUsageSnapshot({
+      sessionId: 'sid_1',
+      cliId: 'codex',
+      cliSessionId: 'native_1',
+      workingDir: '/repo',
+    }, 'cli_app', reader);
+
+    expect(reader).toHaveBeenCalledWith({
+      cliId: 'codex',
+      sessionId: 'sid_1',
+      cliSessionId: 'native_1',
+      cwd: '/repo',
+      larkAppId: 'cli_app',
+      fresh: true,
+    });
+    expect(usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 50,
+      cacheCreateTokens: 10,
+      totalTokens: 180,
+    });
+  });
+
+  it('returns null when the native reader has no usage instead of estimating', () => {
+    expect(readCardStreamUsageSnapshot({ sessionId: 'sid_1' }, 'cli_app', () => ({
+      context: null,
+      tokens: null,
+      turnTokens: null,
+    }))).toBeNull();
+  });
+});

--- a/test/lark-transport-boundary.test.ts
+++ b/test/lark-transport-boundary.test.ts
@@ -22,6 +22,18 @@ const fakeClient = {
       messageReaction: { create: vi.fn(async () => ({ code: 0, data: { reaction_id: 'r' } })), delete: vi.fn(async () => ({ code: 0 })) },
     },
   },
+  cardkit: {
+    v1: {
+      card: {
+        idConvert: vi.fn(async () => ({ code: 0, data: { card_id: 'card_x' } })),
+        settings: vi.fn(async () => ({ code: 0 })),
+      },
+      cardElement: {
+        content: vi.fn(async () => ({ code: 0 })),
+        patch: vi.fn(async () => ({ code: 0 })),
+      },
+    },
+  },
 };
 vi.mock('../src/bot-registry.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/bot-registry.js')>();
@@ -44,6 +56,7 @@ vi.mock('../src/bot-registry.js', async (importOriginal) => {
 import {
   sendMessage, replyMessage, updateMessage, deleteMessage,
   pinMessage, unpinMessage,
+  resolveCardKitId, updateCardStreamingSettings, updateCardStreamElementContent, patchCardStreamElement,
   addReaction, removeReaction, sendUserMessage, sendEphemeralCard,
   deleteEphemeralCard, uploadImage, uploadFile,
   LarkTransportDisabledError,
@@ -64,6 +77,16 @@ describe('assertLarkTransport — bot-level outbound gate', () => {
     await expect(sendMessage(APIONLY, 'oc', 'hi')).rejects.toBeInstanceOf(LarkTransportDisabledError);
     await expect(replyMessage(APIONLY, 'om', 'hi')).rejects.toBeInstanceOf(LarkTransportDisabledError);
     await expect(updateMessage(APIONLY, 'om', '{}')).rejects.toBeInstanceOf(LarkTransportDisabledError);
+    await expect(resolveCardKitId(APIONLY, 'om')).rejects.toBeInstanceOf(LarkTransportDisabledError);
+    await expect(updateCardStreamingSettings(APIONLY, 'card', {
+      streamingMode: true, sequence: 1, uuid: 'u',
+    })).rejects.toBeInstanceOf(LarkTransportDisabledError);
+    await expect(updateCardStreamElementContent(
+      APIONLY, 'card', 'main', 'text', 2, 'u2',
+    )).rejects.toBeInstanceOf(LarkTransportDisabledError);
+    await expect(patchCardStreamElement(
+      APIONLY, 'card', 'loader', { img_key: 'img_x' }, 3, 'u3',
+    )).rejects.toBeInstanceOf(LarkTransportDisabledError);
     await expect(deleteMessage(APIONLY, 'om')).rejects.toBeInstanceOf(LarkTransportDisabledError);
     await expect(pinMessage(APIONLY, 'om')).rejects.toBeInstanceOf(LarkTransportDisabledError);
     await expect(unpinMessage(APIONLY, 'om')).rejects.toBeInstanceOf(LarkTransportDisabledError);
@@ -82,7 +105,46 @@ describe('assertLarkTransport — bot-level outbound gate', () => {
     getBotMock.mockReturnValue(bot(false));
     await expect(sendMessage(NORMAL, 'oc', 'hi')).resolves.toBeDefined();
     await expect(updateMessage(NORMAL, 'om', '{}')).resolves.toBeUndefined();
+    await expect(resolveCardKitId(NORMAL, 'om')).resolves.toBe('card_x');
+    await expect(updateCardStreamingSettings(NORMAL, 'card_x', {
+      streamingMode: true,
+      sequence: 1,
+      uuid: 'u1',
+      print: { frequencyMs: 70, step: 1, strategy: 'fast' },
+    })).resolves.toBeUndefined();
+    await expect(updateCardStreamElementContent(
+      NORMAL, 'card_x', 'main', 'text', 2, 'u2',
+    )).resolves.toBeUndefined();
+    await expect(patchCardStreamElement(
+      NORMAL, 'card_x', 'loader', { img_key: 'img_x' }, 3, 'u3',
+    )).resolves.toBeUndefined();
     expect(fakeClient.im.v1.message.create).toHaveBeenCalled();
     expect(fakeClient.im.v1.message.patch).toHaveBeenCalled();
+    expect(fakeClient.cardkit.v1.card.idConvert).toHaveBeenCalledWith({ data: { message_id: 'om' } });
+    expect(fakeClient.cardkit.v1.card.settings).toHaveBeenCalledWith({
+      path: { card_id: 'card_x' },
+      data: {
+        settings: JSON.stringify({
+          config: {
+            streaming_mode: true,
+            streaming_config: {
+              print_frequency_ms: { default: 70 },
+              print_step: { default: 1 },
+              print_strategy: 'fast',
+            },
+          },
+        }),
+        sequence: 1,
+        uuid: 'u1',
+      },
+    });
+    expect(fakeClient.cardkit.v1.cardElement.content).toHaveBeenCalledWith({
+      path: { card_id: 'card_x', element_id: 'main' },
+      data: { content: 'text', sequence: 2, uuid: 'u2' },
+    });
+    expect(fakeClient.cardkit.v1.cardElement.patch).toHaveBeenCalledWith({
+      path: { card_id: 'card_x', element_id: 'loader' },
+      data: { partial_element: JSON.stringify({ img_key: 'img_x' }), sequence: 3, uuid: 'u3' },
+    });
   });
 });

--- a/test/usage-limit-sticky-recovery.test.ts
+++ b/test/usage-limit-sticky-recovery.test.ts
@@ -172,4 +172,25 @@ describe('usage-limit sticky state self-heal', () => {
     expect(ds.usageLimit).toBeDefined();
     expect(ds.lastScreenStatus).toBe('limited');
   });
+
+  it('publishes every accepted screen status to the external runtime-card sink even when default cards are off', async () => {
+    const onScreenStatus = vi.fn(async () => undefined);
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      onScreenStatus,
+    });
+    const worker = makeFakeWorker();
+    const ds = makeDs({ worker, workerPort: 9999 });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', { type: 'screen_update', content: 'busy', status: 'working' });
+    worker.emit('message', { type: 'screen_update', content: 'still busy', status: 'working' });
+    worker.emit('message', { type: 'screen_update', content: 'stuck', status: 'stalled' });
+    await flush();
+
+    expect(onScreenStatus.mock.calls.map(call => call[1].status)).toEqual(['working', 'working', 'stalled']);
+  });
 });


### PR DESCRIPTION
Closes #1136

## 背景

Botmux 现在可以发送飞书卡片，也可以整卡更新。但如果上层 Skill 想做一张“任务执行中持续变化”的卡片，还缺少一套安全、通用的底层能力：

- 整卡 patch 看起来是突然跳变，不能使用 CardKit 原生打字机效果。
- Skill 不应该自己维护 CardKit sequence，也不应该绕过 Botmux 直接拿飞书凭证。
- 卡片里的“执行中 / 思考中 / 可能卡住”应该来自 daemon 的真实状态，而不是由 Skill 猜。
- Token 用量应该来自当前 Session 的原生记录，没有数据就不显示。
- 用户中途补充输入后，活动卡片需要移动到最新消息后面；如果 Skill 自己撤回、重发，容易留下旧流继续写入。

## 目标

这次改动只提供通用 Core 能力，不提交任何具体的进度卡 UI。

上层调用方可以：

1. 对一张已经发出的 Card 2.0 卡片开启 streaming。
2. 按 element_id 持续写入内容。
3. 可选绑定 daemon 运行状态。
4. 读取当前 Session 的原生 Token 快照。
5. 把活动 stream 安全迁移到一张新卡片。
6. 完成后关闭 streaming。

## 使用方式

新增命令：

- botmux card stream open
- botmux card stream write
- botmux card stream snapshot
- botmux card stream bind-runtime
- botmux card stream unbind-runtime
- botmux card stream reanchor
- botmux card stream finish

典型流程：

1. 先用 botmux send 发一张 Card 2.0 卡片。
2. open 将消息转换为 CardKit stream。
3. write 持续更新指定元素。
4. 需要时绑定 daemon 状态或读取 Token。
5. 用户有新输入时，调用方先发新卡，再用 reanchor 迁移活动流。
6. finish 关闭 streaming。

## 具体实现

### CardStreamStore

新增持久化 stream ledger：

- stream 绑定 sessionId、larkAppId、chatId、messageId。
- sequence 在 provider 请求前持久化并递增。
- 同一 stream 的并发写入通过文件锁串行化。
- provider 请求失败时 sequence 也不会复用。
- finished / superseded 流拒绝后续写入。

### Lark CardKit Adapter

在 Lark client 中补充：

- message_id → card_id 转换。
- 开启/关闭 streaming settings。
- 更新文本元素完整内容。
- patch 指定元素属性。

所有请求继续经过现有 Lark transport gate。

### Runtime Status Bridge

daemon 可以把真实运行状态写到调用方指定的元素：

- working
- analyzing
- idle
- stalled
- limited

Bridge 会去重重复状态、合并 burst 更新，并在 unbind 或过期流出现时清理 binding。Core 只写调用方指定的 element_id，不理解任务阶段和 UI 文案。

### Token Snapshot

snapshot 复用 Botmux 已有的 transcript/usage reader，返回：

- inputTokens
- outputTokens
- cacheReadTokens
- cacheCreateTokens
- totalTokens

没有可靠数据时返回 null，不做估算。这个显式的自定义 stream 能力与内置回复卡的 usageDisplay 设置相互独立。

### Reanchor

reanchor 的顺序是：

1. 校验新卡仍属于当前 Session 和话题。
2. 先打开新 stream。
3. 把旧 stream 标记为 superseded。
4. 迁移 runtime binding。
5. best-effort 撤回旧消息。
6. 返回新的 messageId / streamId。

这样即使旧消息撤回失败，它也已经不能继续写；旧 turn 的迟到写入会明确失败。

## 兼容性与影响面

这是增量能力：

- 不改变 botmux send。
- 不改变 card patch。
- 不改变现有 Session 的状态机。
- 不使用 card stream 的 Bot 行为保持不变。
- worker-pool 只新增一个可选 onScreenStatus callback。
- daemon 未发现 runtime binding 时快速 no-op。
- stream 和 runtime binding 使用独立状态目录。

涉及公共层：CLI、worker-pool、daemon、Lark client。PTY/Tmux、不同 Agent CLI 和普通/话题会话共用同一套会话权限校验；功能本身不依赖具体 CLI。

## 非目标

- 不在 Core 中生成任务阶段。
- 不决定什么时候 reanchor。
- 不提交进度卡 UI、block 样式或通知策略。
- 不展示模型私有 CoT。
- 不实现逐秒计时器。

## 测试覆盖

基于最新 origin/master 的干净 worktree 验证：

- CardStreamStore：确定性 streamId、sequence 单调性、失败不复用、并发串行、权限隔离、finish 幂等、reanchor 和旧流 fencing。
- CLI dispatch：参数校验、同群/同话题校验、open/write/snapshot/reanchor/finish、provider/runtime/文件锁错误映射。
- Runtime bridge：状态去重、loader 切换、确定性 burst coalescing、超时解绑、过期 binding 自清理、binding 迁移。
- Token snapshot：四桶归一化、无数据返回 null。
- Lark transport boundary：CardKit API 仍受 transport gate 保护。
- usage-limit 回归：新增 screen status callback 不改变既有 usage-limit 状态机。

实际结果：

- 7 个定向测试文件通过。
- 73 个定向测试通过。
- 主工程 TypeScript typecheck 通过。
- scripts TypeScript typecheck 通过。
- 按 package.json build 脚本逐项执行等价构建、dashboard bundle、dist audit 和 embedded assets audit，全部通过。
- 在本地 4 Bot fleet 做过 open/write/finish、runtime status、Token snapshot 和 provider stream timeout cleanup 的 live canary。
- reanchor 的顺序、旧流 fencing 和 binding 迁移有自动化测试；具体产品卡片 UI 不在本 PR 中，因此不附产品 UI 截图。