### PR TITLE
fix(test): bun 下 clearAllTimers 未装 fake timers 时不再抛错

### DIFF
--- a/test/bun-shim-parity.test.ts
+++ b/test/bun-shim-parity.test.ts
@@ -186,6 +186,45 @@ describe('vi shim parity (vitest reference / bun shim)', () => {
     }
   });
 
+  it('clearAllTimers is a NO-OP when fake timers were never installed', () => {
+    // REGRESSION for the single largest cause of the bun-test leg being red.
+    // Bun's `vi.clearAllTimers` THROWS `Fake timers are not active. Call
+    // useFakeTimers() first.` when no fake timers are installed; vitest treats
+    // the same call as a no-op. An unconditional `vi.clearAllTimers()` in an
+    // `afterEach` is an extremely common teardown, so under bun the test BODY
+    // passed and only the teardown threw — MEASURED on
+    // test/recall-frozen-cards.test.ts: 10 pass / 50 fail before, 60 pass / 0
+    // fail after, and the whole-leg failing-file count went 39 → 38 with nothing
+    // newly failing (same machine, same command, only the shim swapped).
+    //
+    // This case runs under BOTH runners, so it pins the shim to vitest's real
+    // behaviour rather than to what we believe it to be.
+    expect(() => vi.clearAllTimers()).not.toThrow();
+  });
+
+  it('clearAllTimers is also a no-op AFTER useRealTimers, and still works while faking', () => {
+    // The other two positions around the flag we track. Installing then
+    // uninstalling must return to the no-op state (otherwise a file that fakes
+    // timers in one test and clears in a later teardown starts throwing again),
+    // and while fake timers ARE installed the call must still reach through and
+    // actually clear — a shim that always swallowed would silently leak timers
+    // into the next test, which is worse than the throw it replaced.
+    vi.useFakeTimers();
+    vi.useRealTimers();
+    expect(() => vi.clearAllTimers()).not.toThrow();
+
+    vi.useFakeTimers();
+    try {
+      const seen: string[] = [];
+      setTimeout(() => seen.push('should-not-fire'), 10);
+      vi.clearAllTimers();
+      vi.advanceTimersByTime(50);
+      expect(seen).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // NOTE: the hoisting helper is intentionally NOT asserted here, for two
   // reasons. (1) vitest's transform physically lifts that call to the top of the
   // module, above the imports — so merely writing it inside a test body makes the

--- a/test/bun-test-shim.ts
+++ b/test/bun-test-shim.ts
@@ -149,6 +149,55 @@ fill('runAllTimersAsync', async () => {
   return vi;
 });
 
+// ---------------------------------------------------------------------------
+// `clearAllTimers` when fake timers were never installed.
+//
+// ⚠️ This one is an OVERRIDE, not a `fill`: Bun DOES define
+// `vi.clearAllTimers`, so `fill` would skip it — and Bun's implementation
+// THROWS `Fake timers are not active. Call useFakeTimers() first.` when no fake
+// timers are installed. vitest treats the same call as a no-op.
+//
+// MEASURED, the two runners on one 4-line file (`vi.clearAllTimers()` with no
+// `useFakeTimers`, and again after `useRealTimers`):
+//     vitest   → 2 passed
+//     bun test → 2 failed
+//
+// This is not a theoretical gap: an unconditional `vi.clearAllTimers()` in an
+// `afterEach` is the single largest cause of the bun-test leg being red — 50 of
+// its failures in one CI run, e.g. test/recall-frozen-cards.test.ts:189, where
+// the test body itself passed and only the teardown threw.
+//
+// We track installation ourselves because neither runner exposes "are fake
+// timers active?". Erring toward CALLING through is deliberate: if our flag ever
+// disagrees with reality, a spurious call throws loudly (visible) rather than a
+// skipped clear leaking timers into the next test (silent cross-test pollution).
+let fakeTimersInstalled = false;
+const realUseFakeTimers = anyVi.useFakeTimers as ((...a: unknown[]) => unknown) | undefined;
+const realUseRealTimers = anyVi.useRealTimers as ((...a: unknown[]) => unknown) | undefined;
+if (typeof realUseFakeTimers === 'function') {
+  anyVi.useFakeTimers = (...args: unknown[]) => {
+    const r = realUseFakeTimers(...args);
+    fakeTimersInstalled = true;
+    return r === undefined ? vi : r;
+  };
+}
+if (typeof realUseRealTimers === 'function') {
+  anyVi.useRealTimers = (...args: unknown[]) => {
+    const r = realUseRealTimers(...args);
+    fakeTimersInstalled = false;
+    return r === undefined ? vi : r;
+  };
+}
+const realClearAllTimers = anyVi.clearAllTimers as ((...a: unknown[]) => unknown) | undefined;
+anyVi.clearAllTimers = (...args: unknown[]) => {
+  // No fake timers installed ⇒ there is nothing to clear, which is exactly what
+  // vitest does. Swallowing here cannot hide a real failure: the only thing
+  // Bun's version would have done is throw.
+  if (!fakeTimersInstalled) return vi;
+  const r = realClearAllTimers?.(...args);
+  return r === undefined ? vi : r;
+};
+
 // Per-file config. `bun test` takes the timeout as a CLI flag, so there is no
 // runtime knob to forward this to — and scripts/run-bun-tests.mjs already passes
 // a `--timeout` at least as large as anything a file asks for, so accepting


### PR DESCRIPTION
## 问题

`vi.clearAllTimers()` 在**没装过 fake timers** 时：

| 运行时 | 行为 |
|---|---|
| vitest | no-op |
| bun | **抛** `Fake timers are not active. Call useFakeTimers() first.` |

而「`afterEach` 里无条件 `vi.clearAllTimers()`」是极常见的收尾写法 ⟹ 在 bun 腿上**测试体本身通过、只有收尾炸掉**，一个文件里几十条用例集体变红。

**这是 `bun-test` 腿最大的单一红因**：某次 CI 的失败里有 **50 条**来自这一个缺口（例 `test/recall-frozen-cards.test.ts:189`——那里测试体全过，只有 teardown 抛）。

两个运行时对同一段 4 行代码实测：**vitest 2 passed / bun 2 failed**。

## 改法

在 `test/bun-test-shim.ts` 里做 **override，而不是 `fill`** —— Bun **确实定义**了 `vi.clearAllTimers`，而 `fill()` 只填「缺失的函数」，会直接跳过它（这是个很容易写出无效补丁的坑）。

因为两个运行时都不暴露「当前是否装着 fake timers」，shim 自己跟踪：包一层 `useFakeTimers` / `useRealTimers` 记状态。

- **没装过** → no-op（与 vitest 一致）
- **装着** → 穿透到 Bun 的真实实现

⚠️ **刻意不「一律吞掉」**：那样会让定时器泄漏进下一个测试（静默跨测试污染），比它替换掉的那个抛错更糟。宁可在状态判断出错时**大声抛**（可见），也不要静默不清。

## 效果（同一台机器、同一条命令、只切换 shim）

```
单文件 recall-frozen-cards ： 10 pass / 50 fail  →  60 pass / 0 fail
全量腿失败文件数           ： 39  →  38
失败集合差分               ： 恰好修好 recall-frozen-cards，零新增失败
```

⚠️ **注意计量单位**：这条腿的分母是**文件数**。一个文件里 50 条用例全挂也只算 **1 个失败文件** ⟹「修掉 50 条用例」对应的是「失败文件 −1」，不是 −50。（我第一次汇报时把用例数和文件数并列了，这里明确一下，免得读者误判收益规模。）

## 测试

新增 2 条到 `test/bun-shim-parity.test.ts` —— 该文件**在两个运行时下都跑**，所以它把 shim 钉在 vitest 的**真实行为**上，而不是钉在我们以为的行为上：

1. 未装 fake timers 时 `clearAllTimers()` 不抛
2. `useRealTimers()` 之后仍不抛，**且装着 fake timers 时必须真的清掉**（`setTimeout` → `clearAllTimers` → `advanceTimersByTime(50)` 后回调没跑）

**反变异 2/2 全红**：
- 去掉 override（= 现状缺陷）→ **2 红**
- 改成「一律吞掉」（= 定时器泄漏那种退化）→ **1 红**

`vitest 33 passed` / `bun test 33 pass 0 fail` / `tsc --noEmit` 通过。

## 这只是这条腿的一部分（剩下的不在本 PR）

剩余 38 个失败文件分两类，**都不是 shim 能修的**，我不会为了让腿变绿而把它们塞进 deferred（那等于删掉信号）：

1. **模块注册表语义**：`vi.mock` 工厂声明「真实模块没有的额外导出」（`__scopeListMock` 这种）在 Bun 下拿不到。我探清了边界，避免过度排除：
   - 零参工厂 + 替换**真实**导出 → bun **也 OK**（不能排除，会误伤）
   - 零参工厂 + **额外**导出 → bun 拿不到（只有这种要排除）

   现有 deferred 判据只认「工厂**接收原模块参数**」的形态，所以漏掉了这一类。
2. **环境敏感的真 spawn / tmux / 端口类**（`dashboard-ipc`、`debug-terminal`、`pm2-*`、`plugin-mcp-sandbox` …），本机高负载下尤其易红。

后续怎么处理属于**范围决策**（继续精确 defer，还是把这条腿缩窄到真正需要 Bun 语义的文件），不在本 PR 里定。