### PR TITLE
feat(cot): 思考气泡的工具节点显示命令行，输出代码块带语言高亮

### DIFF
--- a/src/im/lark/cot-message.ts
+++ b/src/im/lark/cot-message.ts
@@ -472,9 +472,11 @@ function resultLanguage(toolName: string | undefined, subject: string | undefine
   // `exec` is matched as a WHOLE word, not a substring: `execute_sql` /
   // `execute_python` are ordinary tools whose output is not shell.
   if (n.includes('bash') || n.includes('shell') || n.includes('command') || /(^|[^a-z])exec([^a-z]|$)/.test(n)) return 'bash';
-  // Fetch tools return a rendered page/summary, not the file the URL names —
-  // a `.json`/`.html` URL would otherwise mislabel prose as that language.
-  if (n.includes('fetch') || n.includes('search')) return undefined;
+  // Search/fetch tools return matches or a rendered page — never the file the
+  // subject names. Without this, a `.json` URL or a `readme\.md` grep pattern
+  // would label prose or match-lists as that language. Mirrors the same family
+  // that toolMeta groups under the search icon.
+  if (n.includes('fetch') || n.includes('search') || n.includes('grep') || n.includes('glob')) return undefined;
   // File tools: the subject is the path, so the extension names the language.
   const ext = subject?.match(/\.([A-Za-z0-9]+)\s*$/)?.[1]?.toLowerCase();
   return ext ? COT_EXT_LANGUAGES[ext] : undefined;

--- a/src/im/lark/cot-message.ts
+++ b/src/im/lark/cot-message.ts
@@ -20,8 +20,11 @@
  *      transcript order, append-only); this module pushes each unseen entry
  *      as its own node — thinking as a reasoning message (START/CONTENT/END
  *      with a distinct messageId), tool calls as TOOL_CALL_START/ARGS/END,
- *      tool output as TOOL_CALL_RESULT. Single in-flight PUT per session,
- *      latest-wins.
+ *      tool output as TOOL_CALL_RESULT. The client does not render
+ *      TOOL_CALL_ARGS (verified by live A/B: sending full args and sending
+ *      none render identically), so the command line / file path travels in
+ *      TOOL_CALL_START.title — see {@link toolTitleSubject}. Single
+ *      in-flight PUT per session, latest-wins.
  *   3. `turn_terminal` → final PUT: REASONING_END / RUN_FINISHED.
  *      RUN_FINISHED auto-completes the CoT server-side (verified: later
  *      appends fail with "COT already in terminal state"), so no separate
@@ -67,6 +70,9 @@ interface CotState {
   pendingEntries?: CotEntry[];
   /** messageId of the most recent reasoning node — parent for tool calls. */
   lastReasoningId?: string;
+  /** toolCallId → highlight language, resolved when the CALL is seen (a
+   *  tool_result entry has no tool name) and consumed by its result. */
+  resultLanguages?: Map<string, string>;
   pumping: boolean;
   /** Set when turn_terminal arrives; consumed by the pump's final flush. */
   finishStatus?: 'done' | 'interrupted';
@@ -319,12 +325,18 @@ function reasoningId(state: CotState, index: number): string {
   return `reasoning-${state.turnId}-${index + 1}`;
 }
 
+/** Longest tool subject rendered after the category label. The title is a
+ *  single unwrapped line in the bubble, so this is a layout bound, not a
+ *  data bound — much tighter than COT_TOOL_ARGS_MAX_CHARS (600), which sizes
+ *  a payload that turned out never to be rendered at all. */
+const COT_TOOL_TITLE_SUBJECT_MAX_CHARS = 80;
+
 /** Built-in Feishu CoT icon + i18n label key for a CLI tool name. The label
  *  becomes the node's `title` (the bubble shows a readable category like
- *  「执行命令」 instead of `Bash ({"command":…})`; the raw tool name and args
- *  stay in the expanded detail). Matches by lowercase substring so it works
- *  across Claude's Bash/Read/Grep and MCP-style names without a per-CLI
- *  table. */
+ *  「执行命令」 instead of `Bash ({"command":…})`; the concrete subject —
+ *  command line, file path — is appended by {@link toolTitle}). Matches by
+ *  lowercase substring so it works across Claude's Bash/Read/Grep and
+ *  MCP-style names without a per-CLI table. */
 function toolMeta(name: string): { icon: string; labelKey: string } {
   const n = name.toLowerCase();
   if (n.includes('bash') || n.includes('shell') || n.includes('command')) return { icon: 'bash', labelKey: 'cot.tool.bash' };
@@ -333,6 +345,95 @@ function toolMeta(name: string): { icon: string; labelKey: string } {
   if (n.includes('grep') || n.includes('glob') || n.includes('search') || n.includes('fetch')) return { icon: 'search', labelKey: 'cot.tool.search' };
   if (n.includes('task') || n.includes('todo') || n.includes('plan')) return { icon: 'task', labelKey: 'cot.tool.task' };
   return { icon: 'default', labelKey: 'cot.tool.default' };
+}
+
+/**
+ * The one-line subject shown after the category label — the actual command
+ * for a shell call, the path for a file op.
+ *
+ * Why this lives in the title at all: Feishu's CoT renderer does NOT draw
+ * TOOL_CALL_ARGS. Verified by a live A/B in a real chat — a node sending the
+ * full JSON args and a control node sending no args event whatsoever render
+ * identically, and reshaping the payload (bare string, `{type:'code'}`
+ * envelope) changes nothing. A second TOOL_CALL_RESULT on the same call is
+ * dropped too, so the title is the only surviving carrier. The args event is
+ * still sent — it costs nothing and a future client may render it.
+ *
+ * `args` is whatever the CLI produced: a JSON object string for Claude
+ * (`{"command":…}` / `{"file_path":…}`), but Codex's dominant `custom_tool_call`
+ * ships a raw non-JSON script string. Anything unparseable falls back to the
+ * raw text, and anything we can't make sense of returns '' so the caller
+ * keeps today's bare label rather than rendering something like `[object
+ * Object]`.
+ */
+function toolTitleSubject(args: string): string {
+  const raw = args.trim();
+  if (raw.length === 0) return '';
+  let subject = raw;
+  if (raw.startsWith('{')) {
+    let parsed: unknown;
+    try { parsed = JSON.parse(raw); } catch { parsed = undefined; }
+    // Looks like JSON but isn't parseable (truncated by the transcript's own
+    // arg cap, most likely): showing the broken fragment as the subject is
+    // worse than showing nothing, so degrade to the bare label.
+    if (!parsed || typeof parsed !== 'object') return '';
+    const o = parsed as Record<string, unknown>;
+    // Ordered by how well the field identifies the call to a human reader.
+    // `command` covers Claude's Bash and Codex's local_shell_call action.
+    const pick = ['command', 'cmd', 'file_path', 'path', 'pattern', 'query', 'url', 'skill', 'subject']
+      .map(k => o[k])
+      .find(v => (typeof v === 'string' && v.trim().length > 0) || Array.isArray(v));
+    if (pick === undefined) return '';
+    // local_shell_call renders `command` as ["bash","-lc","…"] — the last
+    // element is the script; joining the argv would bury it in boilerplate.
+    subject = Array.isArray(pick)
+      ? String(pick[pick.length - 1] ?? '').trim()
+      : String(pick).trim();
+    if (subject.length === 0) return '';
+  }
+  // Multi-line scripts must collapse: the title is one unwrapped line.
+  const oneLine = subject.replace(/\s+/g, ' ').trim();
+  if (oneLine.length === 0) return '';
+  return oneLine.length > COT_TOOL_TITLE_SUBJECT_MAX_CHARS
+    ? `${oneLine.slice(0, COT_TOOL_TITLE_SUBJECT_MAX_CHARS)}…`
+    : oneLine;
+}
+
+/** Category label plus the concrete subject when one can be extracted. */
+function toolTitle(ds: DaemonSession, entry: { name: string; args: string }, labelKey: string, subject: string): string {
+  const label = t(labelKey, { name: entry.name }, localeForBot(ds.larkAppId));
+  return subject.length > 0 ? `${label} · ${subject}` : label;
+}
+
+/**
+ * Syntax-highlighting language for a tool's output code block.
+ *
+ * Verified live: the renderer echoes `language` VERBATIM and performs no
+ * auto-detection of its own — a made-up value renders as that literal string
+ * in the block header, and unmistakably-Python content with no language set
+ * still reads「plaintext」. So this must be a WHITELIST, never a passthrough
+ * of the file extension: sending `mjs`/`yml`/`tsx` unmapped would print those
+ * as the label. Anything unrecognised returns undefined → the field is
+ * omitted → the block falls back to「plaintext」, i.e. today's rendering.
+ */
+const COT_EXT_LANGUAGES: Record<string, string> = {
+  ts: 'typescript', tsx: 'typescript', mts: 'typescript', cts: 'typescript',
+  js: 'javascript', jsx: 'javascript', mjs: 'javascript', cjs: 'javascript',
+  py: 'python', rb: 'ruby', go: 'go', rs: 'rust', java: 'java', kt: 'kotlin',
+  c: 'c', h: 'c', cc: 'cpp', cpp: 'cpp', hpp: 'cpp', cs: 'csharp', swift: 'swift',
+  php: 'php', sh: 'bash', bash: 'bash', zsh: 'bash', fish: 'bash',
+  json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'toml', xml: 'xml',
+  html: 'html', css: 'css', scss: 'scss', sql: 'sql', md: 'markdown',
+};
+
+function resultLanguage(toolName: string | undefined, subject: string | undefined): string | undefined {
+  if (!toolName) return undefined;
+  const n = toolName.toLowerCase();
+  // Shell output is shell-shaped regardless of what the command touched.
+  if (n.includes('bash') || n.includes('shell') || n.includes('command') || n.includes('exec')) return 'bash';
+  // File tools: the subject is the path, so the extension names the language.
+  const ext = subject?.match(/\.([A-Za-z0-9]+)\s*$/)?.[1]?.toLowerCase();
+  return ext ? COT_EXT_LANGUAGES[ext] : undefined;
 }
 
 /** AG-UI events for one CoT entry. Thinking → a complete reasoning message
@@ -350,11 +451,20 @@ function entryEvents(ds: DaemonSession, state: CotState, entry: CotEntry, index:
   }
   if (entry.kind === 'tool_call') {
     const meta = toolMeta(entry.name);
+    const subject = toolTitleSubject(entry.args);
+    // A tool_result entry carries only {id, result} — no tool name — so the
+    // language has to be resolved here, while the call's name and subject are
+    // in hand, and remembered for the matching result.
+    const lang = resultLanguage(entry.name, subject);
+    if (lang) {
+      if (!state.resultLanguages) state.resultLanguages = new Map();
+      state.resultLanguages.set(entry.id, lang);
+    }
     return [
       ev('TOOL_CALL_START', {
         toolCallId: entry.id,
         icon: meta.icon,
-        title: t(meta.labelKey, { name: entry.name }, localeForBot(ds.larkAppId)),
+        title: toolTitle(ds, entry, meta.labelKey, subject),
         toolCallName: entry.name,
         ...(state.lastReasoningId ? { parentMessageId: state.lastReasoningId } : {}),
       }),
@@ -363,12 +473,13 @@ function entryEvents(ds: DaemonSession, state: CotState, entry: CotEntry, index:
     ];
   }
   if (entry.result.length === 0) return [];
+  const language = state.resultLanguages?.get(entry.id);
   return [
     ev('TOOL_CALL_RESULT', {
       messageId: `tr-${entry.id}`,
       toolCallId: entry.id,
       role: 'tool',
-      content: JSON.stringify({ type: 'code', code: entry.result }),
+      content: JSON.stringify({ type: 'code', ...(language ? { language } : {}), code: entry.result }),
     }),
   ];
 }

--- a/src/im/lark/cot-message.ts
+++ b/src/im/lark/cot-message.ts
@@ -348,55 +348,95 @@ function toolMeta(name: string): { icon: string; labelKey: string } {
 }
 
 /**
- * The one-line subject shown after the category label — the actual command
- * for a shell call, the path for a file op.
+ * The one-line subject for a tool call, in two forms.
  *
- * Why this lives in the title at all: Feishu's CoT renderer does NOT draw
- * TOOL_CALL_ARGS. Verified by a live A/B in a real chat — a node sending the
- * full JSON args and a control node sending no args event whatsoever render
- * identically, and reshaping the payload (bare string, `{type:'code'}`
+ * `full` is the whole single-line subject; `display` is `full` bounded to the
+ * title's layout limit. They are separate because truncation is a RENDERING
+ * concern and must not feed logic: resolving the highlight language off the
+ * display string silently loses the extension of any path longer than the
+ * cap (an 86-char `.ts` path degrades to plaintext), which is a bug reported
+ * against the first version of this change.
+ *
+ * Why the subject lives in the title at all: Feishu's CoT renderer does NOT
+ * draw TOOL_CALL_ARGS. Verified by a live A/B in a real chat — a node sending
+ * the full JSON args and a control node sending no args event whatsoever
+ * render identically, and reshaping the payload (bare string, `{type:'code'}`
  * envelope) changes nothing. A second TOOL_CALL_RESULT on the same call is
  * dropped too, so the title is the only surviving carrier. The args event is
  * still sent — it costs nothing and a future client may render it.
  *
  * `args` is whatever the CLI produced: a JSON object string for Claude
- * (`{"command":…}` / `{"file_path":…}`), but Codex's dominant `custom_tool_call`
- * ships a raw non-JSON script string. Anything unparseable falls back to the
- * raw text, and anything we can't make sense of returns '' so the caller
- * keeps today's bare label rather than rendering something like `[object
- * Object]`.
+ * (`{"command":…}` / `{"file_path":…}`), but Codex's dominant
+ * `custom_tool_call` ships a raw non-JSON script string, which is used as-is.
+ * Text that LOOKS like JSON but will not parse is treated as truncated: the
+ * priority fields are recovered by regex where possible (the transcript layer
+ * hard-cuts args at 600 chars, which mangles Write/Edit payloads whose
+ * `content` dwarfs the path, yet leaves the leading `"file_path":"…"` intact),
+ * and only a total miss yields ''. Every "no usable subject" path returns ''
+ * so the caller keeps the bare category label — exactly the pre-change
+ * rendering.
  */
-function toolTitleSubject(args: string): string {
+interface ToolSubject { display: string; full: string }
+
+/** Fields ordered by how well each identifies the call to a human reader.
+ *  `command` covers Claude's Bash and Codex's local_shell_call action;
+ *  `description`/`prompt` catch sub-agent and task-style calls that carry no
+ *  path or command of their own. */
+const COT_SUBJECT_FIELDS = [
+  'command', 'cmd', 'file_path', 'path', 'pattern', 'query', 'url', 'skill', 'subject',
+  'description', 'prompt',
+] as const;
+
+function toolTitleSubject(args: string): ToolSubject {
+  const none: ToolSubject = { display: '', full: '' };
   const raw = args.trim();
-  if (raw.length === 0) return '';
+  if (raw.length === 0) return none;
   let subject = raw;
   if (raw.startsWith('{')) {
     let parsed: unknown;
     try { parsed = JSON.parse(raw); } catch { parsed = undefined; }
-    // Looks like JSON but isn't parseable (truncated by the transcript's own
-    // arg cap, most likely): showing the broken fragment as the subject is
-    // worse than showing nothing, so degrade to the bare label.
-    if (!parsed || typeof parsed !== 'object') return '';
-    const o = parsed as Record<string, unknown>;
-    // Ordered by how well the field identifies the call to a human reader.
-    // `command` covers Claude's Bash and Codex's local_shell_call action.
-    const pick = ['command', 'cmd', 'file_path', 'path', 'pattern', 'query', 'url', 'skill', 'subject']
-      .map(k => o[k])
-      .find(v => (typeof v === 'string' && v.trim().length > 0) || Array.isArray(v));
-    if (pick === undefined) return '';
-    // local_shell_call renders `command` as ["bash","-lc","…"] — the last
-    // element is the script; joining the argv would bury it in boilerplate.
-    subject = Array.isArray(pick)
-      ? String(pick[pick.length - 1] ?? '').trim()
-      : String(pick).trim();
-    if (subject.length === 0) return '';
+    if (parsed && typeof parsed === 'object') {
+      const o = parsed as Record<string, unknown>;
+      const pick = COT_SUBJECT_FIELDS
+        .map(k => o[k])
+        .find(v => (typeof v === 'string' && v.trim().length > 0) || Array.isArray(v));
+      if (pick === undefined) return none;
+      // local_shell_call renders `command` as ["bash","-lc","…"] — the last
+      // element is the script; joining the argv would bury it in boilerplate.
+      subject = Array.isArray(pick)
+        ? String(pick[pick.length - 1] ?? '').trim()
+        : String(pick).trim();
+      if (subject.length === 0) return none;
+    } else {
+      // Truncated JSON: rendering the raw `{"command":` fragment is worse than
+      // rendering nothing, but the leading fields usually survive the cut, so
+      // recover one by regex before giving up.
+      const recovered = recoverSubjectFromTruncatedJson(raw);
+      if (recovered === undefined) return none;
+      subject = recovered;
+    }
   }
   // Multi-line scripts must collapse: the title is one unwrapped line.
-  const oneLine = subject.replace(/\s+/g, ' ').trim();
-  if (oneLine.length === 0) return '';
-  return oneLine.length > COT_TOOL_TITLE_SUBJECT_MAX_CHARS
-    ? `${oneLine.slice(0, COT_TOOL_TITLE_SUBJECT_MAX_CHARS)}…`
-    : oneLine;
+  const full = subject.replace(/\s+/g, ' ').trim();
+  if (full.length === 0) return none;
+  const display = full.length > COT_TOOL_TITLE_SUBJECT_MAX_CHARS
+    ? `${full.slice(0, COT_TOOL_TITLE_SUBJECT_MAX_CHARS)}…`
+    : full;
+  return { display, full };
+}
+
+/** Pull the first priority field out of JSON that was cut mid-payload. Only
+ *  complete `"key":"value"` pairs match, so a value truncated mid-string is
+ *  skipped rather than shown half-rendered. */
+function recoverSubjectFromTruncatedJson(raw: string): string | undefined {
+  for (const key of COT_SUBJECT_FIELDS) {
+    const m = raw.match(new RegExp(`"${key}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"`));
+    if (!m) continue;
+    let value: string;
+    try { value = JSON.parse(`"${m[1]}"`); } catch { continue; } // bad escape → skip
+    if (value.trim().length > 0) return value.trim();
+  }
+  return undefined;
 }
 
 /** Category label plus the concrete subject when one can be extracted. */
@@ -404,7 +444,6 @@ function toolTitle(ds: DaemonSession, entry: { name: string; args: string }, lab
   const label = t(labelKey, { name: entry.name }, localeForBot(ds.larkAppId));
   return subject.length > 0 ? `${label} · ${subject}` : label;
 }
-
 /**
  * Syntax-highlighting language for a tool's output code block.
  *
@@ -430,7 +469,12 @@ function resultLanguage(toolName: string | undefined, subject: string | undefine
   if (!toolName) return undefined;
   const n = toolName.toLowerCase();
   // Shell output is shell-shaped regardless of what the command touched.
-  if (n.includes('bash') || n.includes('shell') || n.includes('command') || n.includes('exec')) return 'bash';
+  // `exec` is matched as a WHOLE word, not a substring: `execute_sql` /
+  // `execute_python` are ordinary tools whose output is not shell.
+  if (n.includes('bash') || n.includes('shell') || n.includes('command') || /(^|[^a-z])exec([^a-z]|$)/.test(n)) return 'bash';
+  // Fetch tools return a rendered page/summary, not the file the URL names —
+  // a `.json`/`.html` URL would otherwise mislabel prose as that language.
+  if (n.includes('fetch') || n.includes('search')) return undefined;
   // File tools: the subject is the path, so the extension names the language.
   const ext = subject?.match(/\.([A-Za-z0-9]+)\s*$/)?.[1]?.toLowerCase();
   return ext ? COT_EXT_LANGUAGES[ext] : undefined;
@@ -454,8 +498,10 @@ function entryEvents(ds: DaemonSession, state: CotState, entry: CotEntry, index:
     const subject = toolTitleSubject(entry.args);
     // A tool_result entry carries only {id, result} — no tool name — so the
     // language has to be resolved here, while the call's name and subject are
-    // in hand, and remembered for the matching result.
-    const lang = resultLanguage(entry.name, subject);
+    // in hand, and remembered for the matching result. Detection uses the
+    // UNTRUNCATED subject: a path longer than the title cap still ends in its
+    // extension, which the display string has already lost to the ellipsis.
+    const lang = resultLanguage(entry.name, subject.full);
     if (lang) {
       if (!state.resultLanguages) state.resultLanguages = new Map();
       state.resultLanguages.set(entry.id, lang);
@@ -464,7 +510,7 @@ function entryEvents(ds: DaemonSession, state: CotState, entry: CotEntry, index:
       ev('TOOL_CALL_START', {
         toolCallId: entry.id,
         icon: meta.icon,
-        title: toolTitle(ds, entry, meta.labelKey, subject),
+        title: toolTitle(ds, entry, meta.labelKey, subject.display),
         toolCallName: entry.name,
         ...(state.lastReasoningId ? { parentMessageId: state.lastReasoningId } : {}),
       }),

--- a/test/cot-message.test.ts
+++ b/test/cot-message.test.ts
@@ -194,20 +194,136 @@ describe('handleCotThinkingUpdate', () => {
     const start1 = events.find(e => e.type === 'TOOL_CALL_START' && e.content.toolCallId === 'toolu_1')!;
     expect(start1.content.icon).toBe('bash');
     expect(start1.content.toolCallName).toBe('Bash');
-    // Category label shown in the bubble instead of raw name+args.
-    expect(start1.content.title).toBeTruthy();
-    expect(start1.content.title).not.toContain('{');
+    // Category label PLUS the concrete command — the renderer ignores
+    // TOOL_CALL_ARGS, so the title is the only place the command shows up.
+    expect(start1.content.title).toContain('ls');
+    expect(start1.content.title).not.toContain('{'); // never the raw JSON blob
     expect(start1.content.parentMessageId).toBeDefined(); // attached to the preceding thinking node
     const args = events.find(e => e.type === 'TOOL_CALL_ARGS')!;
     expect(args.content).toEqual({ toolCallId: 'toolu_1', delta: '{"command":"ls"}' });
     const result = events.find(e => e.type === 'TOOL_CALL_RESULT')!;
     expect(result.content.toolCallId).toBe('toolu_1');
-    expect(JSON.parse(result.content.content)).toEqual({ type: 'code', code: 'file-a\nfile-b' });
+    // Shell output is tagged `bash` so the block highlights instead of
+    // reading「plaintext」(the renderer never infers this on its own).
+    expect(JSON.parse(result.content.content)).toEqual({ type: 'code', language: 'bash', code: 'file-a\nfile-b' });
     // Empty args → no TOOL_CALL_ARGS event, but START/END still sent.
     const start2 = events.find(e => e.type === 'TOOL_CALL_START' && e.content.toolCallId === 'toolu_2')!;
     expect(start2.content.icon).toBe('search');
     expect(events.filter(e => e.type === 'TOOL_CALL_ARGS').length).toBe(1);
     expect(events.filter(e => e.type === 'TOOL_CALL_END').map(e => e.content.toolCallId)).toEqual(['toolu_1', 'toolu_2']);
+  });
+
+  /**
+   * The title is the ONLY carrier the Feishu CoT renderer draws for a tool
+   * call: a live A/B showed a node with full TOOL_CALL_ARGS and a control
+   * node with no args event at all rendering identically. Each case below is
+   * a real shape harvested from on-disk transcripts, not an invented one.
+   */
+  it('carries the tool subject in the title across both CLIs\' arg shapes', async () => {
+    const ds = makeDs();
+    const titleOf = (id: string): string =>
+      pushedEvents().find(e => e.type === 'TOOL_CALL_START' && e.content.toolCallId === id)!.content.title;
+
+    handleCotThinkingUpdate(ds, upd([
+      // Claude Bash — by far the most common call (~1900 in local transcripts).
+      { kind: 'tool_call', id: 't1', name: 'Bash', args: '{"command":"git log --oneline -5","description":"recent commits"}' },
+      // Claude file ops key off file_path, not command.
+      { kind: 'tool_call', id: 't2', name: 'Read', args: '{"file_path":"/root/iserver/botmux/src/daemon.ts","limit":50}' },
+      // Codex local_shell_call: command is argv; the script is the last element.
+      { kind: 'tool_call', id: 't3', name: 'shell', args: '{"command":["bash","-lc","pnpm run build"]}' },
+      // Codex custom_tool_call ships a RAW non-JSON string — must not be dropped.
+      { kind: 'tool_call', id: 't4', name: 'exec', args: 'await tools.exec_command({ cmd: "free -h" })' },
+      // Multi-line script collapses to one line (the title never wraps).
+      { kind: 'tool_call', id: 't5', name: 'Bash', args: '{"command":"line one\\nline two\\n  line three"}' },
+    ]));
+    await flush();
+
+    expect(titleOf('t1')).toContain('git log --oneline -5');
+    expect(titleOf('t1')).not.toContain('recent commits'); // description is not the subject
+    expect(titleOf('t2')).toContain('/root/iserver/botmux/src/daemon.ts');
+    expect(titleOf('t3')).toContain('pnpm run build');
+    expect(titleOf('t3')).not.toContain('bash'); // argv boilerplate stripped
+    expect(titleOf('t4')).toContain('free -h');
+    expect(titleOf('t5')).toBe('执行命令 · line one line two line three');
+  });
+
+  it('falls back to the bare category label when no subject can be extracted', async () => {
+    const ds = makeDs();
+    const titleOf = (id: string): string =>
+      pushedEvents().find(e => e.type === 'TOOL_CALL_START' && e.content.toolCallId === id)!.content.title;
+
+    handleCotThinkingUpdate(ds, upd([
+      { kind: 'tool_call', id: 'n1', name: 'TaskList', args: '' },            // no args at all
+      { kind: 'tool_call', id: 'n2', name: 'TaskUpdate', args: '{"taskId":"1","status":"done"}' }, // no known field
+      { kind: 'tool_call', id: 'n3', name: 'Bash', args: '{"command":"   "}' },  // whitespace-only
+      { kind: 'tool_call', id: 'n4', name: 'Bash', args: '{"command":' },        // truncated/invalid JSON
+    ]));
+    await flush();
+
+    // Degrades to exactly today's rendering — never '[object Object]' or a
+    // dangling separator.
+    expect(titleOf('n1')).toBe('任务管理');
+    expect(titleOf('n2')).toBe('任务管理');
+    expect(titleOf('n3')).toBe('执行命令');
+    expect(titleOf('n4')).toBe('执行命令'); // broken JSON fragment never shown
+    for (const id of ['n1', 'n2', 'n3', 'n4']) {
+      expect(titleOf(id)).not.toContain('·');
+      expect(titleOf(id)).not.toContain('object Object');
+    }
+  });
+
+  /**
+   * The renderer echoes `language` verbatim and never auto-detects (verified
+   * live: a bogus value prints as-is; Python content with no language set
+   * still reads "plaintext"). So the mapping must be a whitelist, and an
+   * unmapped tool must omit the field rather than pass an extension through.
+   */
+  it('tags result code blocks with a whitelisted language, omitting it when unknown', async () => {
+    const ds = makeDs();
+    const resultFor = (id: string): any =>
+      JSON.parse(pushedEvents().find(e => e.type === 'TOOL_CALL_RESULT' && e.content.toolCallId === id)!.content.content);
+
+    handleCotThinkingUpdate(ds, upd([
+      { kind: 'tool_call', id: 'g1', name: 'Bash', args: '{"command":"ls -la"}' },
+      { kind: 'tool_result', id: 'g1', result: 'total 0' },
+      { kind: 'tool_call', id: 'g2', name: 'Read', args: '{"file_path":"/a/b/daemon.ts"}' },
+      { kind: 'tool_result', id: 'g2', result: 'export const x = 1;' },
+      { kind: 'tool_call', id: 'g3', name: 'Read', args: '{"file_path":"/a/b/conf.yml"}' },
+      { kind: 'tool_result', id: 'g3', result: 'key: value' },
+      // Extension with no whitelist entry: must NOT leak "wat" as the label.
+      { kind: 'tool_call', id: 'g4', name: 'Read', args: '{"file_path":"/a/b/notes.wat"}' },
+      { kind: 'tool_result', id: 'g4', result: 'blah' },
+      // No file, no shell → no language at all (renders as plaintext).
+      { kind: 'tool_call', id: 'g5', name: 'TaskUpdate', args: '{"taskId":"1"}' },
+      { kind: 'tool_result', id: 'g5', result: 'Updated task #1' },
+    ]));
+    await flush();
+
+    expect(resultFor('g1')).toEqual({ type: 'code', language: 'bash', code: 'total 0' });
+    expect(resultFor('g2').language).toBe('typescript');
+    expect(resultFor('g3').language).toBe('yaml');
+    // Unmapped / inapplicable → field absent entirely, never a bogus label.
+    expect(resultFor('g4')).toEqual({ type: 'code', code: 'blah' });
+    expect(resultFor('g5')).toEqual({ type: 'code', code: 'Updated task #1' });
+    expect(resultFor('g4').language).toBeUndefined();
+    expect(resultFor('g5').language).toBeUndefined();
+  });
+
+  it('bounds an overlong command so the title stays one readable line', async () => {
+    const ds = makeDs();
+    const long = `echo ${'x'.repeat(500)}`;
+    handleCotThinkingUpdate(ds, upd([
+      { kind: 'tool_call', id: 'L1', name: 'Bash', args: JSON.stringify({ command: long }) },
+    ]));
+    await flush();
+    const title = pushedEvents().find(e => e.type === 'TOOL_CALL_START')!.content.title as string;
+    expect(title.length).toBeLessThan(120);
+    expect(title.endsWith('…')).toBe(true);
+    expect(title).toContain('echo xxx');
+    // The untruncated args still go out on the wire — cheap, and a future
+    // client may render them.
+    const args = pushedEvents().find(e => e.type === 'TOOL_CALL_ARGS')!;
+    expect(args.content.delta).toContain('x'.repeat(500));
   });
 
   it('coalesces bursts to the latest entry list (single in-flight pump)', async () => {

--- a/test/cot-message.test.ts
+++ b/test/cot-message.test.ts
@@ -392,6 +392,28 @@ describe('handleCotThinkingUpdate', () => {
     expect(bodyOf('S').language).toBeUndefined(); // not "bash"
   });
 
+  it('does not highlight search results by the pattern\'s extension', async () => {
+    const ds = makeDs();
+    handleCotThinkingUpdate(ds, upd([
+      // A pattern ending in an extension says what to FIND; the result is a
+      // match list, not a file of that type.
+      { kind: 'tool_call', id: 'G', name: 'Grep', args: JSON.stringify({ pattern: 'readme\\.md' }) },
+      { kind: 'tool_result', id: 'G', result: 'docs/readme.md:1:# Title' },
+      { kind: 'tool_call', id: 'B', name: 'Glob', args: JSON.stringify({ pattern: 'src/**/*.ts' }) },
+      { kind: 'tool_result', id: 'B', result: 'src/daemon.ts\nsrc/worker.ts' },
+    ]));
+    await flush();
+    const bodyOf = (id: string): any =>
+      JSON.parse(pushedEvents().find(e => e.type === 'TOOL_CALL_RESULT' && e.content.toolCallId === id)!.content.content);
+    const titleOf = (id: string): string =>
+      pushedEvents().find(e => e.type === 'TOOL_CALL_START' && e.content.toolCallId === id)!.content.title;
+    expect(bodyOf('G').language).toBeUndefined(); // not "markdown"
+    expect(bodyOf('B').language).toBeUndefined(); // not "typescript"
+    // The pattern still shows in the title — only the highlight is suppressed.
+    expect(titleOf('G')).toContain('readme');
+    expect(titleOf('B')).toContain('src/**/*.ts');
+  });
+
   it('bounds an overlong command so the title stays one readable line', async () => {
     const ds = makeDs();
     const long = `echo ${'x'.repeat(500)}`;

--- a/test/cot-message.test.ts
+++ b/test/cot-message.test.ts
@@ -309,6 +309,89 @@ describe('handleCotThinkingUpdate', () => {
     expect(resultFor('g5').language).toBeUndefined();
   });
 
+  /**
+   * Regression: truncation is a rendering concern and must not feed logic.
+   * The first version resolved the language off the DISPLAY string, so any
+   * path longer than the 80-char title cap lost its extension to the ellipsis
+   * and silently fell back to plaintext.
+   */
+  it('detects the language from the untruncated path, not the shortened title', async () => {
+    const ds = makeDs();
+    const longPath = '/root/iserver/botmux/src/very/deeply/nested/directory/structure/that/goes/on/module.ts';
+    expect(longPath.length).toBeGreaterThan(80); // the case only bites past the cap
+    handleCotThinkingUpdate(ds, upd([
+      { kind: 'tool_call', id: 'L', name: 'Read', args: JSON.stringify({ file_path: longPath }) },
+      { kind: 'tool_result', id: 'L', result: 'export const x = 1;' },
+    ]));
+    await flush();
+    const title = pushedEvents().find(e => e.type === 'TOOL_CALL_START')!.content.title as string;
+    const body = JSON.parse(pushedEvents().find(e => e.type === 'TOOL_CALL_RESULT')!.content.content);
+    expect(title.endsWith('…')).toBe(true);   // still bounded for layout
+    expect(title).not.toContain('.ts');        // extension really is cut from the title
+    expect(body.language).toBe('typescript');  // …yet detection still sees it
+  });
+
+  /**
+   * The transcript layer hard-cuts args at 600 chars, so a Write/Edit whose
+   * `content` dwarfs the path arrives as unparseable JSON. The leading
+   * `"file_path":"…"` survives that cut, so recover it rather than showing a
+   * bare label.
+   */
+  it('recovers a subject by regex when oversized args arrive truncated', async () => {
+    const ds = makeDs();
+    const path = '/root/iserver/botmux/src/core/worker-pool.ts';
+    const full = JSON.stringify({ file_path: path, content: 'x'.repeat(2000) });
+    const truncated = full.slice(0, 600); // exactly what truncateForCot does
+    expect(() => JSON.parse(truncated)).toThrow(); // precondition: really broken
+
+    handleCotThinkingUpdate(ds, upd([
+      { kind: 'tool_call', id: 'W', name: 'Write', args: truncated },
+      { kind: 'tool_result', id: 'W', result: 'ok' },
+      // A value cut mid-string must NOT be shown half-rendered.
+      { kind: 'tool_call', id: 'W2', name: 'Write', args: '{"file_path":"/a/b/unterminat' },
+      { kind: 'tool_result', id: 'W2', result: 'ok' },
+    ]));
+    await flush();
+    const titleOf = (id: string): string =>
+      pushedEvents().find(e => e.type === 'TOOL_CALL_START' && e.content.toolCallId === id)!.content.title;
+    const bodyOf = (id: string): any =>
+      JSON.parse(pushedEvents().find(e => e.type === 'TOOL_CALL_RESULT' && e.content.toolCallId === id)!.content.content);
+
+    expect(titleOf('W')).toContain(path);
+    expect(titleOf('W')).not.toContain('{');       // never the JSON fragment
+    expect(bodyOf('W').language).toBe('typescript'); // recovery feeds detection too
+    // Incomplete pair → no match → bare label, exactly as before.
+    expect(titleOf('W2')).toBe('编辑文件');
+    expect(bodyOf('W2').language).toBeUndefined();
+  });
+
+  it('keeps sub-agent and fetch style calls honest', async () => {
+    const ds = makeDs();
+    handleCotThinkingUpdate(ds, upd([
+      // description/prompt are the only identifying fields a Task call has.
+      { kind: 'tool_call', id: 'T', name: 'TaskCreate', args: JSON.stringify({ subject: '跑一遍回归', activeForm: '跑回归' }) },
+      { kind: 'tool_result', id: 'T', result: 'created' },
+      { kind: 'tool_call', id: 'A', name: 'Agent', args: JSON.stringify({ description: 'Find the auth flow', subagent_type: 'Explore' }) },
+      { kind: 'tool_result', id: 'A', result: 'found' },
+      // A .json URL must not label fetched prose as json.
+      { kind: 'tool_call', id: 'F', name: 'WebFetch', args: JSON.stringify({ url: 'https://example.com/api/spec.json' }) },
+      { kind: 'tool_result', id: 'F', result: 'The page describes…' },
+      // execute_* is not a shell despite containing "exec".
+      { kind: 'tool_call', id: 'S', name: 'execute_sql', args: JSON.stringify({ query: 'select 1' }) },
+      { kind: 'tool_result', id: 'S', result: '1' },
+    ]));
+    await flush();
+    const titleOf = (id: string): string =>
+      pushedEvents().find(e => e.type === 'TOOL_CALL_START' && e.content.toolCallId === id)!.content.title;
+    const bodyOf = (id: string): any =>
+      JSON.parse(pushedEvents().find(e => e.type === 'TOOL_CALL_RESULT' && e.content.toolCallId === id)!.content.content);
+
+    expect(titleOf('T')).toContain('跑一遍回归');
+    expect(titleOf('A')).toContain('Find the auth flow');
+    expect(bodyOf('F').language).toBeUndefined(); // not "json"
+    expect(bodyOf('S').language).toBeUndefined(); // not "bash"
+  });
+
   it('bounds an overlong command so the title stays one readable line', async () => {
     const ds = makeDs();
     const long = `echo ${'x'.repeat(500)}`;


### PR DESCRIPTION
## 问题

CoT 思考气泡里的工具节点，此前只显示分类标题（「执行命令」）和命令输出，**看不到到底执行了什么命令、读了哪个文件**。输出代码块的框头也一律是 `plaintext`，没有语法高亮。

修改前气泡里的工具节点（示意，据真机截图转录）：

```
任务已完成
 已调用 1 次工具
 </> 执行命令                       ← 只有分类标题，命令本身不可见
 ┌─ plaintext ───────────────┐
 │ e65735cef feat(cot): ...  │      ← 只有输出
 │ done                      │
 └───────────────────────────┘
```

## 根因（真机实测，非推断）

**不是我们少发了数据**——`TOOL_CALL_ARGS` 一直带着完整的命令，是**飞书 CoT 渲染器根本不渲染这个事件**。

用六个变体发到真实群里肉眼对照，关键是**对照组 F：完全不发 `TOOL_CALL_ARGS`**：

| 变体 | 做法 | 能看到命令？ |
|---|---|---|
| A | args = 完整 JSON（**修改前的写法**） | ❌ |
| B | args = 裸命令字符串 | ❌ |
| C | 命令拼进 `title` | ✅ **唯一一个** |
| D | 额外发第二个 `TOOL_CALL_RESULT` 装命令 | ❌ |
| E | args 套 `{type:'code'}` 信封 | ❌ |
| F | **对照组：不发 args** | ❌ |

**A 与 F 渲染结果逐像素一致**，是全部证据的支点：「args 格式不对」与「args 压根不渲染」两个假说在这一对上**预测相反**，故有区分力。B/E 顺带排除了「换个 args 形状就好」。另外 D 说明**同一工具节点只认第一个 `TOOL_CALL_RESULT`**，第二个会被丢弃。

⟹ 命令行只能走 `TOOL_CALL_START.title`。

> ⚠️ 六个变体 API **全部返回 `code=0`**，`message.get` 读回来也只有 `"Completed"`——服务端不吐事件列表。**这类展示问题只能肉眼验收，返回码零信息量。**

## 改了什么

### 1. 标题带上「主语」（命令 / 文件路径）

`toolTitleSubject` 从 args 提取最能标识这次调用的字段。两个 CLI 的形态不同，都按**本机 transcript 实际统计**处理，不是猜的：

- **claude-code**：JSON 对象 → `command`（`Bash` 占压倒多数）/ `file_path` 等
- **codex**：`custom_tool_call` 的 `input` 是**裸字符串不是 JSON**；`local_shell_call` 是 `["bash","-lc","真正的脚本"]` → **取末元素**，否则标题被 argv 样板淹没

边界处理：
- 标题是**单行不折行**，故另设 **80 字符**上限——没有复用 `COT_TOOL_ARGS_MAX_CHARS = 600`，那个常量量的是**从未被渲染过**的载荷
- 多行脚本 `\s+` 压成一行
- **取不出主语就退回纯标题**，不留 `任务管理 · ` 这种空尾巴
- **看着像 JSON 但 parse 不了**（被上游 600 字符截断成 `{"command":`）同样退回纯标题——显示碎片比不显示更糟（这条是**测试抓出来的实现缺陷**，初版会把碎片显示出来）

### 2. 输出代码块带语言高亮

给 `TOOL_CALL_RESULT` 补 `language`：shell 输出给 `bash`，文件按扩展名走**白名单**映射，未命中则**不写该字段**（退回 `plaintext`，即修改前的样子）。

**为什么必须白名单而不是透传扩展名**——同样是实测出来的。第一轮 `language:'bash'` 与 `lang:'bash'` 看起来都生效，但这**推不出字段被读取**（也可能是渲染器按内容自己猜，而我发的正好是 shell 输出）。于是做了**两假说预测相反**的第二轮：内容不变，只把声明的语言改成内容明显不是的——

| 变体 | 「字段生效」预测 | 「自动识别」预测 | 实际 |
|---|---|---|---|
| `language:'python'` + shell 内容 | python | bash | ✅ **python** |
| `lang:'python'` + 同内容 | python | bash | ✅ **python** |
| `language:'zzznotalang'` | 原样 / plaintext | bash | ✅ **zzznotalang** |
| 不写语言 + 纯 Python 内容 | plaintext | python | ✅ **plaintext** |

四条全落在「字段生效」列：`zzznotalang` **被原样回显**（渲染器不校验、更不会猜出这个词），纯 Python 内容不写语言仍是 `plaintext`（**完全不看内容**）。

⟹ 任意字符串会原样显示为标签，所以 `.mjs` / `.yml` / `.tsx` **不能直接透传**，否则框头会写着「mjs」。

实现上一个不明显的点：`tool_result` 条目**只有 `{id, result}`，不带工具名**，所以语言必须在 **tool_call 那一刻**解析并按 id 记住，结果到达时再取。

## 效果

修改后（示意，据真机截图转录）：

```
任务已完成
 已调用 1 次工具
 </> 执行命令 · git log --oneline -5      ← 命令直接可见
 ┌─ bash ────────────────────┐            ← 框头是 bash，正文带语法高亮
 │ e65735cef feat(cot): ...  │
 │ done                      │
 └───────────────────────────┘
```

编译产物实际产出的标题（非预期值，是从 build 抓出来的）：

```
执行命令 · git log --oneline -5 && echo done
读取文件 · /root/iserver/botmux/src/im/lark/cot-message.ts
执行命令 · bun run build                          ← codex argv 取末元素
调用 exec · await tools.exec_command({ cmd: "free -h" })   ← codex 裸字符串
执行命令 · echo xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…   ← 超长截断
任务管理                                          ← 无主语，退回纯标题
执行命令 · line one line two line three           ← 多行压成一行
```

语言标签：`git log` → **bash**；`.ts` → **typescript**；`package.json` → **json**；`.wat`（白名单外）与 `TaskUpdate`（非文件非 shell）→ **plaintext**（不写字段）。

## 影响面

仅 daemon 侧 CoT 展示层（`src/im/lark/cot-message.ts`），**纯 cosmetic**，全链路自兜错误、不触碰 turn 结算。

- **跨 CLI**：claude-code 与 codex 两条 transcript 链路都覆盖并各自验证；其余 CLI 本就不产生 thinking 通道，行为不变。未改动 `adapters/cli/` 任何共用层
- **跨后端 / 会话类型**：改动只在 daemon 收到 `thinking_update` 之后的事件构造，与 PtyBackend / TmuxBackend、话题会话 / 群会话无关
- **降级路径**：取不出主语、语言未命中白名单时，**逐字退回修改前的渲染**

## 验证

- `npx tsc --noEmit` — 0 错
- `bun run build` — 通过
- `vitest run test/cot-message.test.ts test/thinking-transcript.test.ts test/codex-transcript.test.ts test/codex-bridge-queue.test.ts` — **209 passed**
- **反变异 7 项，全部有用例变红**（每次变异后当场还原并 `cmp` 校验）：
  1. 标题退回纯 label → 3 红
  2. 去掉换行压缩 → 1 红
  3. 去掉长度上限 → 1 红
  4. argv 改成整体 join → 1 红
  5. 去掉坏 JSON 防护 → 1 红
  6. 白名单改成扩展名透传 → 1 红
  7. 去掉 shell→bash → 2 红
- **真机端到端**：把真实工具调用数据喂给**编译产物**（非手写探针）发到飞书，标题与语言高亮均符合预期，白名单外的两例正确退回 plaintext
- 已 rebase 到最新 master（`a22f1c3bd`）后重跑上述全部验证

### 一项等价变异（说明，非遗漏）

`...(language ? { language } : {})` 改成直接写 `language` 后测试**不红**。查证为**等价变异**：`JSON.stringify` 会丢弃值为 `undefined` 的键，两种写法产出字节完全相同（已实跑对比）。故未为其补测试用例。

## 复审后追加的修正

复审提出两项真问题 + 三处误判，均已修（见 `70bca1c73` / `dc5154161`）：

- 🔴 **语言检测此前用的是已截断的标题串**：路径超过 80 字符时扩展名被省略号
  切掉 → 检测不到 → 退回 plaintext。86 字符的 `.ts` 路径实测复现（修前
  `undefined`、修后 `typescript`）。改为 `toolTitleSubject` 返回
  `{display, full}`：`display` 供标题、`full` 供检测。
  **截断是渲染层的事实，不能喂给逻辑。**
  自测漏掉的原因也记在这里：**原有用例全是短路径，永远跨不过截断线**，
  那条分支在测试里根本不存在。
- 🟡 **args 被上游硬切 600 字符后 JSON 解析失败 → 无主语**：Write/Edit 的
  `content` 一大必然触发。改为解析失败时用正则从原始串兜底提取优先级字段；
  **只匹配完整的 `"键":"值"` 对**，值本身被切断则跳过（显示半截路径比不显示更糟）。
- 优先级表补 `description` / `prompt`（子代理 / 任务类调用此前只有裸标签）
- `exec` 由子串改为**全词**匹配（`execute_sql` / `execute_python` 不再被当成 shell）
- `fetch` / `search` / `grep` / `glob` 类**不按 subject 的扩展名标语言**：返回的是
  正文或匹配列表，不是该扩展名指向的文件（与 `toolMeta` 的同族分组对齐）

追加反变异 6 项（检测改回截断串、去掉正则兜底、`exec` 改回子串、去掉 fetch
守卫、去掉 `description`/`prompt`、守卫退回不含 grep/glob）**全部变红**；
并**复跑既有变异**确认重构后仍有牙（重构动了 `toolTitleSubject` 的结构，
上一轮的「全红」结论对新代码不再自动成立）。共 **213 用例全绿**。

两处已知残留，权衡后不修（均为化妆品级，且降级 = 现状）：
1. 正则兜底的理论假阳性：JSON 被截断且某字符串**值**内含 `"command":"ls"`
   这类字面量并排在真字段之前时，会被当成主语。触发条件苛刻，代价是一行怪标题；
   要消除需引入括号配平级别的部分解析，风险高于收益。
2. 被截断的 `local_shell_call` **argv 数组**救不回来（正则只匹配字符串值）→
   退回裸标签，即修改前的行为。

### CI `bun-test`

该腿在 master 上本就常红，且挂 `continue-on-error`（故顶层 run 的
`success` 不可作为判据）。与 master 做**失败文件集合双向差分**：
**本 PR 独有 0 个**（PR 36 个 ⊂ master 37 个，差集仅 master 侧的
`connector-store` 同毫秒 `updatedAt` flake）。

## 备注：该接口无公开文档

`message_cot` 的**整个文档章节**（brief / create / update / complete）均返回 **403「This document is not public」**，页面 `<head>` 里标着 "pure markdown version, better for ai" 的 `.md` 同样 403。本 PR 所有关于字段行为的结论**均来自真机实测**。
