### PR TITLE
fix(dashboard): avoid eager token scans in session list

### DIFF
--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -6,6 +6,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { logger } from '../utils/logger.js';
 import type { CliId } from '../adapters/cli/types.js';
+import type { SessionTokenUsageSnapshot } from '../types.js';
 import { findAidenLatestCheckpointByBotmuxSessionId, findAidenLatestCheckpointBySessionId } from '../services/aiden-checkpoints.js';
 import {
   __resetTranscriptResolverCacheForTest,
@@ -31,7 +32,7 @@ export interface SessionCost {
   turns: number;
 }
 
-export interface SessionTokenUsage extends SessionCost {
+export interface SessionTokenUsage extends SessionCost, SessionTokenUsageSnapshot {
   in: number;
   out: number;
 }

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1027,16 +1027,16 @@ export { composeRowFromActive, composeRowFromClosed, composeRowFromPersistedActi
 // holder.
 export function setBotName(name: string): void { setRowsBotName(name); }
 
-function composeDashboardSessionRows(): SessionRow[] {
-  const active = listActiveSessions().map((ds) => composeRowFromActive(ds));
+function composeDashboardSessionRows(opts?: { includeTokenUsage?: boolean }): SessionRow[] {
+  const active = listActiveSessions().map((ds) => composeRowFromActive(ds, opts));
   const activeIds = new Set(active.map(row => row.sessionId));
   const persisted = sessionStore.listSessions();
   const unregisteredActive = persisted
     .filter(session => session.status === 'active' && !activeIds.has(session.sessionId))
-    .map(composeRowFromPersistedActive);
+    .map(session => composeRowFromPersistedActive(session, opts));
   const closed = persisted
     .filter(session => session.status === 'closed' && !activeIds.has(session.sessionId))
-    .map(composeRowFromClosed);
+    .map(session => composeRowFromClosed(session, opts));
   return [...active, ...unregisteredActive, ...closed];
 }
 
@@ -1120,7 +1120,7 @@ ipcRoute('GET', '/api/sessions', (_req, res) => {
   // Runtime active first, then persisted active rows that restore deliberately
   // left detached, then closed history. Persisted-active must never be projected
   // through composeRowFromClosed: teardown uncertainty is not a close.
-  jsonRes(res, 200, { sessions: composeDashboardSessionRows() });
+  jsonRes(res, 200, { sessions: composeDashboardSessionRows({ includeTokenUsage: false }) });
 });
 
 ipcRoute('GET', '/api/sessions/:sessionId', (_req, res, params) => {

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -2424,7 +2424,7 @@ ipcRoute('GET', '/api/sessions/:sessionId/insight/turn/:turnIndex', (req, res, p
 ipcRoute('GET', '/api/insights/summary', async (req, res) => {
   const url = new URL(req.url ?? '/', 'http://localhost');
   const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') ?? '200', 10) || 200, 1), 500);
-  const rows = composeDashboardSessionRows();
+  const rows = composeDashboardSessionRows({ includeTokenUsage: false });
   const overview = await buildSafeInsightOverview(rows.map(row => {
     const session = findSessionRecord(row.sessionId);
     return {

--- a/src/core/dashboard-rows.ts
+++ b/src/core/dashboard-rows.ts
@@ -212,7 +212,26 @@ function sessionRuntimeFields(s: Session): Pick<SessionRow, 'runtimeId' | 'runti
   return {};
 }
 
-export function composeRowFromActive(ds: DaemonSession, opts?: { fresh?: boolean }): SessionRow {
+export interface DashboardRowOptions {
+  fresh?: boolean;
+  /**
+   * Expensive native transcript/token scan. Dashboard list snapshots can contain
+   * thousands of historical rows, so callers that only need routing/status
+   * metadata should leave this off and use the per-session detail endpoint for
+   * on-demand usage.
+   */
+  includeTokenUsage?: boolean;
+}
+
+function maybeSessionTokenUsage(
+  s: Session,
+  workingDir: string | undefined,
+  opts?: DashboardRowOptions,
+): SessionTokenUsage | null {
+  return opts?.includeTokenUsage === false ? null : sessionTokenUsage(s, workingDir);
+}
+
+export function composeRowFromActive(ds: DaemonSession, opts?: DashboardRowOptions): SessionRow {
   const brand = getBotBrand(ds.larkAppId);
   const topicLink = sessionThreadLink(ds.session, brand);
   return {
@@ -273,7 +292,7 @@ export function composeRowFromActive(ds: DaemonSession, opts?: { fresh?: boolean
     agentAttention: ds.agentAttention
       ? { kind: ds.agentAttention.kind, reason: ds.agentAttention.reason, at: ds.agentAttention.at }
       : undefined,
-    tokenUsage: sessionTokenUsage(ds.session, ds.workingDir),
+    tokenUsage: maybeSessionTokenUsage(ds.session, ds.workingDir, opts),
     openTodos: sessionOpenTodos(ds.session, ds.workingDir, opts?.fresh),
     ...(ds.worker?.pid !== undefined ? { workerPid: ds.worker.pid } : {}),
     ...(ds.adoptedFrom?.originalCliPid !== undefined ? { adoptCliPid: ds.adoptedFrom.originalCliPid } : {}),
@@ -281,7 +300,7 @@ export function composeRowFromActive(ds: DaemonSession, opts?: { fresh?: boolean
   };
 }
 
-export function composeRowFromClosed(s: Session): SessionRow {
+export function composeRowFromClosed(s: Session, opts?: DashboardRowOptions): SessionRow {
   const brand = getBotBrand(s.larkAppId ?? '');
   const topicLink = sessionThreadLink(s, brand);
   return {
@@ -315,7 +334,7 @@ export function composeRowFromClosed(s: Session): SessionRow {
     previewTarget: safeSessionPreviewTarget(s.previewTarget),
     feishuChatLink: feishuChatLink(s.chatId, brand),
     ...(topicLink ? { feishuThreadLink: topicLink } : {}),
-    tokenUsage: sessionTokenUsage(s),
+    tokenUsage: maybeSessionTokenUsage(s, undefined, opts),
     ...buildSessionMessagePreview(s),
   };
 }
@@ -328,7 +347,7 @@ export function composeRowFromClosed(s: Session): SessionRow {
  * dashboard presents it as dormant, with no terminal port, so operators can
  * see and explicitly retry closing it without an unsafe resume affordance.
  */
-export function composeRowFromPersistedActive(s: Session): SessionRow {
+export function composeRowFromPersistedActive(s: Session, opts?: DashboardRowOptions): SessionRow {
   const brand = getBotBrand(s.larkAppId ?? '');
   const topicLink = sessionThreadLink(s, brand);
   return {
@@ -363,7 +382,7 @@ export function composeRowFromPersistedActive(s: Session): SessionRow {
     queued: !!s.queued,
     hasHistory: !!(s.cliId || s.lastCliInput || s.backendType || s.adoptedFrom),
     quarantined: !!s.restoreQuarantinedAt,
-    tokenUsage: sessionTokenUsage(s),
+    tokenUsage: maybeSessionTokenUsage(s, undefined, opts),
     ...buildSessionMessagePreview(s),
   };
 }

--- a/src/core/dashboard-rows.ts
+++ b/src/core/dashboard-rows.ts
@@ -227,7 +227,9 @@ function maybeSessionTokenUsage(
   s: Session,
   workingDir: string | undefined,
   opts?: DashboardRowOptions,
+  opts2?: { usePersistedSnapshot?: boolean },
 ): SessionTokenUsage | null {
+  if (opts2?.usePersistedSnapshot && s.tokenUsage !== undefined) return s.tokenUsage;
   return opts?.includeTokenUsage === false ? null : sessionTokenUsage(s, workingDir);
 }
 
@@ -334,7 +336,7 @@ export function composeRowFromClosed(s: Session, opts?: DashboardRowOptions): Se
     previewTarget: safeSessionPreviewTarget(s.previewTarget),
     feishuChatLink: feishuChatLink(s.chatId, brand),
     ...(topicLink ? { feishuThreadLink: topicLink } : {}),
-    tokenUsage: maybeSessionTokenUsage(s, undefined, opts),
+    tokenUsage: maybeSessionTokenUsage(s, undefined, opts, { usePersistedSnapshot: true }),
     ...buildSessionMessagePreview(s),
   };
 }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -375,7 +375,7 @@ import {
   publishSessionPreviewCleared,
   takeSessionPreviewTarget,
 } from './session-preview-registry.js';
-import { composeRowFromActive, composeRowFromClosed } from './dashboard-rows.js';
+import { composeRowFromActive } from './dashboard-rows.js';
 import { publishAttentionPatch, publishClosedSessionPatch } from './session-activity.js';
 import {
   attachOrdinaryTurnRecovery,
@@ -6366,7 +6366,7 @@ export async function closeSession(
     publishClosedSessionPatch(
       sessionId,
       after?.closedAt ? Date.parse(after.closedAt) : undefined,
-      { tokenUsage: after ? composeRowFromClosed(after).tokenUsage : null },
+      { tokenUsage: after?.tokenUsage ?? null },
     );
   }
 

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -5,6 +5,7 @@ import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
 import { withFileLockSync } from '../utils/file-lock.js';
 import { cleanupMaterializedDashboardImages } from '../core/dashboard-images.js';
+import { getSessionTokenUsage } from '../core/cost-calculator.js';
 import { deleteFrozenCards } from './frozen-card-store.js';
 import { removePromptContextDir } from './prompt-context-store.js';
 import {
@@ -1861,11 +1862,25 @@ export function closeSession(
     const priorDashboardAttachments = session.dashboardAttachments;
     // Durable first: build the closed row, commit it, and only then merge it
     // into the live object. A failed write leaves the session exactly as it
-    // was, which is what the hand-written field-by-field restore used to
-    // approximate.
+    // was, including any prior tokenUsage snapshot.
     const next: Session = { ...session };
     next.status = 'closed';
     next.closedAt = new Date().toISOString();
+    try {
+      const tokenUsage = getSessionTokenUsage({
+        cliId: session.cliId ?? 'unknown',
+        sessionId: session.sessionId,
+        cliSessionId: session.cliSessionId,
+        cwd: session.workingDir,
+        larkAppId: session.larkAppId,
+        fresh: true,
+      });
+      if (tokenUsage !== null) next.tokenUsage = tokenUsage;
+      else if (next.tokenUsage === undefined) next.tokenUsage = null;
+    } catch (err: any) {
+      logger.warn(`Failed to snapshot token usage for session ${sessionId}: ${err?.message ?? err}`);
+      if (next.tokenUsage === undefined) next.tokenUsage = null;
+    }
     next.dashboardAttachments = undefined;
     next.queuedAttachments = undefined;
     // `previewTarget` is a live loopback (host, port) the session's agent
@@ -1938,7 +1953,9 @@ export function reactivateClosedSession(
   if (session.status !== 'closed') return { ok: false, error: 'not_closed' };
 
   // Durable first (see closeSession): the reactivated row is committed before
-  // it is merged into the live object, so a failed write is a no-op.
+  // it is merged into the live object, so a failed write is a no-op. Reactivate
+  // starts a new lifecycle, so the previous close-time token snapshot must not
+  // survive into the active row or the next close.
   const next: Session = { ...session };
   next.status = 'active';
   next.closedAt = undefined;
@@ -1960,11 +1977,13 @@ export function reactivateClosedSession(
   next.pendingRepoSetup = undefined;
   next.previewTarget = undefined;
   next.mojoCloseJournal = undefined;
+  next.tokenUsage = undefined;
 
   persistRow(next);
   Object.assign(session, next);
   return { ok: true, session };
 }
+
 
 export function updateSessionPid(sessionId: string, pid: number | null): void {
   loadForWrite();

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,17 @@ export interface VcMeetingImTurnOrigin {
   replyTargetSenderOpenId?: string;
 }
 
+export interface SessionTokenUsageSnapshot {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  model: string;
+  turns: number;
+  in: number;
+  out: number;
+}
+
 export interface TrustedCaller {
   requestUserOpenId?: string;
   requestUserUnionId?: string;
@@ -364,6 +375,9 @@ export interface Session {
   /** Last user/bot/scheduler input that was routed into this session. */
   lastMessageAt?: string;
   closedAt?: string;
+  /** Last cumulative token usage persisted at close time. Dashboard list
+   *  reads this durable snapshot without rescanning historical transcripts. */
+  tokenUsage?: SessionTokenUsageSnapshot | null;
   /**
    * Restore/runtime ownership quarantine. Set when botmux cannot prove that an
    * existing external/persistent target is safe to attach or tear down, and

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -25,6 +25,7 @@ import * as sandboxStore from '../src/services/sandbox-store.js';
 import * as workerPool from '../src/core/worker-pool.js';
 import * as scheduler from '../src/core/scheduler.js';
 import * as botRegistry from '../src/bot-registry.js';
+import * as costCalculator from '../src/core/cost-calculator.js';
 import { clearMessageListenerRunPreviewStore, markMessageListenerRunPreviewReplied } from '../src/services/message-listener-run-preview-store.js';
 import * as persistentBackend from '../src/core/persistent-backend.js';
 import { __testOnly_resetBotRegistry, getBot, loadBotConfigs, registerBot } from '../src/bot-registry.js';
@@ -1904,6 +1905,42 @@ describe('GET /api/sessions', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(Array.isArray(body.sessions)).toBe(true);
+  });
+
+  it('does not scan transcripts while composing the bulk sessions list', async () => {
+    const ipcSource = readFileSync(join(process.cwd(), 'src/core/dashboard-ipc-server.ts'), 'utf8');
+    expect(ipcSource).toContain('composeDashboardSessionRows({ includeTokenUsage: false })');
+
+    const dataDir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-token-list-'));
+    const prevConfigDataDir = config.session.dataDir;
+    const usageSpy = vi.spyOn(costCalculator, 'getSessionTokenUsage').mockImplementation(() => {
+      throw new Error('bulk sessions list must not scan token usage');
+    });
+    try {
+      config.session.dataDir = dataDir;
+      sessionStore.init('cli_token_list');
+      workerPool.setActiveSessionsRegistry(new Map());
+      const session = sessionStore.createSession('oc_token_list', 'om_token_list', 'Token List', 'group');
+      session.larkAppId = 'cli_token_list';
+      session.scope = 'thread';
+      session.cliId = 'claude-code';
+      session.workingDir = '/repo';
+      sessionStore.updateSession(session);
+
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions`);
+
+      expect(res.status).toBe(200);
+      const listed = (await res.json()).sessions.find((row: any) => row.sessionId === session.sessionId);
+      expect(listed).toMatchObject({ sessionId: session.sessionId, tokenUsage: null });
+      expect(usageSpy).not.toHaveBeenCalled();
+    } finally {
+      usageSpy.mockRestore();
+      workerPool.setActiveSessionsRegistry(new Map());
+      sessionStore.init();
+      config.session.dataDir = prevConfigDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 
   it('shows an unregistered quarantined active row as dormant in list and detail', async () => {

--- a/test/dashboard-token-usage-row.test.ts
+++ b/test/dashboard-token-usage-row.test.ts
@@ -94,6 +94,22 @@ describe('dashboard SessionRow token usage', () => {
     });
   });
 
+  it('can skip expensive token scans for bulk session list snapshots', () => {
+    const active = composeRowFromActive(makeDs(), { includeTokenUsage: false });
+    const persisted = composeRowFromPersistedActive({
+      ...makeDs().session,
+      status: 'active',
+    }, { includeTokenUsage: false });
+    const closed = composeRowFromClosed({
+      ...makeDs().session,
+      status: 'closed',
+    }, { includeTokenUsage: false });
+
+    expect(active.tokenUsage).toBeNull();
+    expect(persisted.tokenUsage).toBeNull();
+    expect(closed.tokenUsage).toBeNull();
+  });
+
   it('carries chatType for active and closed rows', () => {
     const active = makeDs();
     active.chatType = 'p2p';

--- a/test/dashboard-token-usage-row.test.ts
+++ b/test/dashboard-token-usage-row.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { DaemonSession } from '../src/core/types.js';
 
 vi.mock('../src/core/cost-calculator.js', () => ({
@@ -16,6 +18,10 @@ vi.mock('../src/core/cost-calculator.js', () => ({
 
 import { getSessionTokenUsage } from '../src/core/cost-calculator.js';
 import { composeRowFromActive, composeRowFromClosed, composeRowFromPersistedActive } from '../src/core/dashboard-rows.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function makeDs(): DaemonSession {
   return {
@@ -108,6 +114,144 @@ describe('dashboard SessionRow token usage', () => {
     expect(active.tokenUsage).toBeNull();
     expect(persisted.tokenUsage).toBeNull();
     expect(closed.tokenUsage).toBeNull();
+    expect(getSessionTokenUsage).not.toHaveBeenCalled();
+  });
+
+  it('keeps closed token usage visible even when bulk scans are disabled', () => {
+    const tokenUsage = {
+      in: 12,
+      out: 3,
+      inputTokens: 10,
+      outputTokens: 3,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 1,
+      model: 'persisted-model',
+    };
+    const row = composeRowFromClosed({
+      ...makeDs().session,
+      status: 'closed',
+      tokenUsage,
+    }, { includeTokenUsage: false });
+
+    expect(row.tokenUsage).toEqual(tokenUsage);
+    expect(getSessionTokenUsage).not.toHaveBeenCalled();
+  });
+
+  it('does not expose stale token usage for persisted active rows in bulk list mode', () => {
+    const row = composeRowFromPersistedActive({
+      ...makeDs().session,
+      status: 'active',
+      tokenUsage: {
+        in: 12,
+        out: 3,
+        inputTokens: 10,
+        outputTokens: 3,
+        cacheReadTokens: 2,
+        cacheCreateTokens: 0,
+        turns: 1,
+        model: 'stale-active-model',
+      },
+    }, { includeTokenUsage: false });
+
+    expect(row.tokenUsage).toBeNull();
+    expect(getSessionTokenUsage).not.toHaveBeenCalled();
+  });
+
+  it('does not let a persisted active detail row short-circuit on a stale snapshot', () => {
+    const row = composeRowFromPersistedActive({
+      ...makeDs().session,
+      status: 'active',
+      workingDir: '/repo',
+      tokenUsage: {
+        in: 12,
+        out: 3,
+        inputTokens: 10,
+        outputTokens: 3,
+        cacheReadTokens: 2,
+        cacheCreateTokens: 0,
+        turns: 1,
+        model: 'stale-active-model',
+      },
+    });
+
+    expect(getSessionTokenUsage).toHaveBeenCalledWith({
+      cliId: 'claude-code',
+      sessionId: 'sess-1',
+      cliSessionId: 'cli-sess-1',
+      cwd: '/repo',
+    });
+    expect(row.tokenUsage).toEqual({
+      in: 1234,
+      out: 567,
+      inputTokens: 1200,
+      outputTokens: 567,
+      cacheReadTokens: 30,
+      cacheCreateTokens: 4,
+      turns: 3,
+      model: 'test-model',
+    });
+  });
+
+  it('does not let an active runtime row short-circuit on a stale persisted snapshot', () => {
+    const staleTokenUsage = {
+      in: 12,
+      out: 3,
+      inputTokens: 10,
+      outputTokens: 3,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 1,
+      model: 'stale-closed-model',
+    };
+    const ds = makeDs();
+    ds.session.tokenUsage = staleTokenUsage;
+
+    const row = composeRowFromActive(ds);
+
+    expect(getSessionTokenUsage).toHaveBeenCalledWith({
+      cliId: 'claude-code',
+      sessionId: 'sess-1',
+      cliSessionId: 'cli-sess-1',
+      cwd: '/repo',
+    });
+    expect(row.tokenUsage).toEqual({
+      in: 1234,
+      out: 567,
+      inputTokens: 1200,
+      outputTokens: 567,
+      cacheReadTokens: 30,
+      cacheCreateTokens: 4,
+      turns: 3,
+      model: 'test-model',
+    });
+  });
+
+  it('still skips active runtime token scans in bulk list mode even if a stale snapshot exists', () => {
+    const ds = makeDs();
+    ds.session.tokenUsage = {
+      in: 12,
+      out: 3,
+      inputTokens: 10,
+      outputTokens: 3,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 1,
+      model: 'stale-closed-model',
+    };
+
+    const row = composeRowFromActive(ds, { includeTokenUsage: false });
+
+    expect(row.tokenUsage).toBeNull();
+    expect(getSessionTokenUsage).not.toHaveBeenCalled();
+  });
+
+  it('worker-pool close publishes the durable token usage snapshot directly', () => {
+    const source = readFileSync(join(process.cwd(), 'src/core/worker-pool.ts'), 'utf8');
+
+    expect(source).toContain('{ tokenUsage: after?.tokenUsage ?? null }');
+    expect(source).not.toContain("import { composeRowFromActive, composeRowFromClosed }");
+    expect(source).not.toContain('composeRowFromClosed(after).tokenUsage');
   });
 
   it('carries chatType for active and closed rows', () => {

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -14,6 +14,9 @@ import { tmpdir } from 'os';
 // ─── Mocks ────────────────────────────────────────────────────────────────
 
 const fsControl = vi.hoisted(() => ({ failSessionWrite: false, failReaddir: false }));
+const costCalculatorMock = vi.hoisted(() => ({
+  getSessionTokenUsage: vi.fn(() => null),
+}));
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return {
@@ -59,6 +62,8 @@ const mockDeleteFrozenCards = vi.fn();
 vi.mock('../src/services/frozen-card-store.js', () => ({
   deleteFrozenCards: (...args: any[]) => mockDeleteFrozenCards(...args),
 }));
+
+vi.mock('../src/core/cost-calculator.js', () => costCalculatorMock);
 
 // Import the module under test after mocks are set up
 import {
@@ -129,6 +134,8 @@ function readPersistedRows(dir: string, appId?: string): Record<string, any> {
 beforeEach(() => {
   tempDir = makeTempDir();
   fsControl.failSessionWrite = false;
+  costCalculatorMock.getSessionTokenUsage.mockReset();
+  costCalculatorMock.getSessionTokenUsage.mockReturnValue(null);
   __testOnly_setBeforeRowPersist(undefined);
   mockDeleteFrozenCards.mockReset();
   // Reset module state for each test
@@ -563,6 +570,94 @@ describe('closeSession()', () => {
     expect(reloaded!.closedAt).toBeDefined();
   });
 
+  it('snapshots token usage in the same durable close write', () => {
+    const tokenUsage = {
+      in: 20,
+      out: 5,
+      inputTokens: 18,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 2,
+      model: 'claude-test',
+    };
+    costCalculatorMock.getSessionTokenUsage.mockReturnValue(tokenUsage);
+    const session = createSession('chat1', 'root1', 'Close With Usage');
+    session.cliId = 'claude-code';
+    session.cliSessionId = 'native-1';
+    session.workingDir = '/repo';
+    session.larkAppId = 'cli_app';
+    updateSession(session);
+
+    closeSession(session.sessionId);
+
+    expect(costCalculatorMock.getSessionTokenUsage).toHaveBeenCalledWith({
+      cliId: 'claude-code',
+      sessionId: session.sessionId,
+      cliSessionId: 'native-1',
+      cwd: '/repo',
+      larkAppId: 'cli_app',
+      fresh: true,
+    });
+    expect(getSession(session.sessionId)?.tokenUsage).toEqual(tokenUsage);
+    init();
+    expect(getSession(session.sessionId)?.tokenUsage).toEqual(tokenUsage);
+    expect(readPersistedRows(tempDir)[session.sessionId].tokenUsage).toEqual(tokenUsage);
+  });
+
+  it('preserves existing token usage when close-time usage scan returns empty', () => {
+    const existingTokenUsage = {
+      in: 20,
+      out: 5,
+      inputTokens: 18,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 2,
+      model: 'previous-model',
+    };
+    costCalculatorMock.getSessionTokenUsage.mockReturnValue(null);
+    const session = createSession('chat1', 'root1', 'Close With Existing Usage');
+    session.tokenUsage = existingTokenUsage;
+    updateSession(session);
+
+    closeSession(session.sessionId);
+
+    expect(getSession(session.sessionId)).toMatchObject({
+      status: 'closed',
+      tokenUsage: existingTokenUsage,
+    });
+    init();
+    expect(getSession(session.sessionId)?.tokenUsage).toEqual(existingTokenUsage);
+  });
+
+  it('does not fail close or overwrite existing token usage when close-time scan throws', () => {
+    const existingTokenUsage = {
+      in: 20,
+      out: 5,
+      inputTokens: 18,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 2,
+      model: 'previous-model',
+    };
+    costCalculatorMock.getSessionTokenUsage.mockImplementation(() => {
+      throw new Error('transcript unavailable');
+    });
+    const session = createSession('chat1', 'root1', 'Close With Throwing Usage');
+    session.tokenUsage = existingTokenUsage;
+    updateSession(session);
+
+    expect(() => closeSession(session.sessionId)).not.toThrow();
+    expect(getSession(session.sessionId)).toMatchObject({
+      status: 'closed',
+      tokenUsage: existingTokenUsage,
+    });
+    init();
+    expect(getSession(session.sessionId)?.tokenUsage).toEqual(existingTokenUsage);
+  });
+
   it('clears Riff lineage atomically with the durable closed row', () => {
     const session = createSession('chat1', 'root1', 'Close Riff');
     session.backendType = 'riff';
@@ -942,6 +1037,118 @@ describe('reactivateClosedSession()', () => {
     const reloaded = getSession(session.sessionId)!;
     expect(reloaded.status).toBe('active');
     expect(reloaded.previewTarget).toBeUndefined();
+  });
+
+  it('clears a closed token usage snapshot when starting a new lifecycle', () => {
+    const session = createSession('chat1', 'root1', 'Legacy Closed Usage');
+    closeSession(session.sessionId);
+    const legacy = getSession(session.sessionId)!;
+    legacy.tokenUsage = {
+      in: 20,
+      out: 5,
+      inputTokens: 18,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 2,
+      model: 'closed-lifecycle',
+    };
+    updateSession(legacy);
+
+    const result = reactivateClosedSession(session.sessionId);
+    expect(result.ok).toBe(true);
+
+    init();
+    const reloaded = getSession(session.sessionId)!;
+    expect(reloaded.status).toBe('active');
+    expect(reloaded.closedAt).toBeUndefined();
+    expect(reloaded.tokenUsage).toBeUndefined();
+  });
+
+  it('restores token usage if reactivation persistence fails', () => {
+    const existingTokenUsage = {
+      in: 20,
+      out: 5,
+      inputTokens: 18,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 2,
+      model: 'closed-lifecycle',
+    };
+    const session = createSession('chat1', 'root1', 'Legacy Closed Usage Rollback');
+    closeSession(session.sessionId);
+    const legacy = getSession(session.sessionId)!;
+    legacy.tokenUsage = existingTokenUsage;
+    updateSession(legacy);
+    __testOnly_setBeforeRowPersist(() => { throw new Error('simulated reactivate write failure'); });
+
+    expect(() => reactivateClosedSession(session.sessionId)).toThrow(/simulated reactivate write failure/);
+    expect(getSession(session.sessionId)).toMatchObject({
+      status: 'closed',
+      tokenUsage: existingTokenUsage,
+    });
+
+    __testOnly_setBeforeRowPersist(undefined);
+    init();
+    expect(getSession(session.sessionId)).toMatchObject({
+      status: 'closed',
+      tokenUsage: existingTokenUsage,
+    });
+  });
+
+  it('does not carry a previous lifecycle token snapshot into a second close', () => {
+    const session = createSession('chat1', 'root1', 'Second Lifecycle Usage');
+    closeSession(session.sessionId);
+    const legacy = getSession(session.sessionId)!;
+    legacy.tokenUsage = {
+      in: 20,
+      out: 5,
+      inputTokens: 18,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 2,
+      model: 'closed-lifecycle',
+    };
+    updateSession(legacy);
+
+    expect(reactivateClosedSession(session.sessionId).ok).toBe(true);
+    costCalculatorMock.getSessionTokenUsage.mockReturnValue(null);
+    closeSession(session.sessionId);
+
+    expect(getSession(session.sessionId)).toMatchObject({
+      status: 'closed',
+      tokenUsage: null,
+    });
+  });
+
+  it('does not restore a previous lifecycle token snapshot when the second close scan throws', () => {
+    const session = createSession('chat1', 'root1', 'Second Lifecycle Throwing Usage');
+    closeSession(session.sessionId);
+    const legacy = getSession(session.sessionId)!;
+    legacy.tokenUsage = {
+      in: 20,
+      out: 5,
+      inputTokens: 18,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      cacheCreateTokens: 0,
+      turns: 2,
+      model: 'closed-lifecycle',
+    };
+    updateSession(legacy);
+
+    expect(reactivateClosedSession(session.sessionId).ok).toBe(true);
+    costCalculatorMock.getSessionTokenUsage.mockImplementation(() => {
+      throw new Error('new lifecycle transcript unavailable');
+    });
+    closeSession(session.sessionId);
+
+    expect(getSession(session.sessionId)).toMatchObject({
+      status: 'closed',
+      tokenUsage: null,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add an `includeTokenUsage` dashboard row option so callers can skip expensive transcript/token scanning
- make `/api/sessions` omit token usage for the session-list snapshot path
- add regression coverage for active, persisted-active, and closed rows with token scanning disabled

## Why
On a bot with a large session store, the dashboard session-list endpoint eagerly computed token usage for every row. Profiling showed the daemon main thread dominated by `/api/sessions` row composition and repeated transcript lookup/stat/readdir work:

`composeDashboardSessionRows` → `composeRowFromClosed` → `sessionTokenUsage` → `getSessionTokenUsage` → `readSessionUsage` → `resolveSessionTranscriptPath` → `findTraexRolloutBySessionId`

This can starve normal bot message handling. The list endpoint does not need per-row token usage; detail/lifecycle paths can still include it by default.

## Tests
- `bun test test/dashboard-token-usage-row.test.ts test/dashboard-resource-row.test.ts`
