### PR TITLE
feat(identity): trusted caller 带上本轮 sender 类型

### DIFF
--- a/src/core/plugins/mcp/gateway.ts
+++ b/src/core/plugins/mcp/gateway.ts
@@ -515,6 +515,10 @@ export class PluginMcpGateway {
       // unrelated (possibly remote) plugin learns about the caller.
       ...(caller?.source ? { source: caller.source } : {}),
       ...(caller?.taskId ? { taskId: caller.taskId } : {}),
+      // Whether a human or a bot opened this turn. Same local-only rule as the
+      // two fields above: a plugin that maps the caller onto real access needs
+      // it, an unrelated HTTP-transport server does not.
+      ...(caller?.senderType ? { senderType: caller.senderType } : {}),
       ...(identity?.turnId ? { turnId: identity.turnId } : {}),
       ...(identity?.dispatchAttempt !== undefined ? { dispatchAttempt: identity.dispatchAttempt } : {}),
     };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -134,12 +134,23 @@ function trustedCallerForTurn(
   larkAppId: string,
   senderOpenId?: string,
   senderUnionId?: string,
+  /** Three-state: true = provably a bot (platform `sender_type` app/bot, OR a
+   *  known peer via the cross-ref foreign-bot signal), false = provably human
+   *  (`sender_type === 'user'`), undefined = cannot tell. Pass
+   *  {@link senderIsBotTriState} rather than a bare `sender_type` comparison:
+   *  that check alone reads a cross-ref-identified peer bot as `'user'`, and
+   *  `'user'` is the value a consumer maps onto a real person's access — writing
+   *  it for a bot turn actively vouches for it, which is worse than absent.
+   *  undefined leaves the field off so a consumer treats the turn as unknown
+   *  rather than as "human". */
+  senderIsBot?: boolean,
 ): TrustedCaller | undefined {
   if (!senderOpenId && !senderUnionId) return undefined;
   return {
     ...(senderOpenId ? { requestUserOpenId: senderOpenId } : {}),
     ...(senderUnionId ? { requestUserUnionId: senderUnionId } : {}),
     requestLarkAppId: larkAppId,
+    ...(senderIsBot === undefined ? {} : { senderType: senderIsBot ? 'bot' as const : 'user' as const }),
   };
 }
 export type { DaemonSession } from './core/types.js';
@@ -17818,7 +17829,7 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
 
   // senderOpenId 已在上方（force-topic grant 限制前）声明；这里只补 master 新增的 senderUnionId。
   const senderUnionId: string | undefined = data.sender?.sender_id?.union_id;
-  const trustedCaller = trustedCallerForTurn(larkAppId, senderOpenId, senderUnionId);
+  const trustedCaller = trustedCallerForTurn(larkAppId, senderOpenId, senderUnionId, senderIsBotTriState(parsed.senderType, isForeignBotSender));
   // union_id 信任腿（canOperate/evaluateTalk 的 teamBot）只对**飞书盖章的 bot 发送方**
   // 生效：平台 roster 是成员机器自报的，若不锁 sender_type，恶意成员把某个真人的
   // union_id 报成"自家 bot"，那个真人就会在全团队机器上被当队友 bot 放行（talk +
@@ -19289,7 +19300,7 @@ async function handleThreadReplyAdmitted(
   // 类型的话，把真人 union_id 报成 bot 就能让真人在全团队被当队友 bot 放行
   //（talk + operate）。与旧联邦 team-bots「学习入口限 bot sender」同一不变量。
   const threadTeamTrustUnionId = (isBotSenderType || isForeignBot) ? threadSenderUnionId : undefined;
-  const threadTrustedCaller = trustedCallerForTurn(larkAppId, threadSenderOpenId, threadSenderUnionId);
+  const threadTrustedCaller = trustedCallerForTurn(larkAppId, threadSenderOpenId, threadSenderUnionId, senderIsBotTriState(parsed.senderType, isForeignBot));
   const threadChatId = ctxChatId ?? data?.message?.chat_id;
   const clearAgentAttentionForHumanInbound = (): void => {
     if (isForeignBot || isBotSenderType) return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,21 @@ export interface TrustedCaller {
   source?: 'schedule_creator';
   /** Scheduled task id — set only alongside `source: 'schedule_creator'`. */
   taskId?: string;
+  /** Type of the sender whose message opened this turn. Absent when no inbound
+   *  message opened it (a daemon-fired scheduled turn — `source` says what that
+   *  is instead), when the host cannot tell what opened it (platform
+   *  `sender_type` missing or an unrecognised value AND the sender is not a
+   *  known peer), and for turns minted before this field existed. Absent is
+   *  therefore "unknown", never "human" — treat only `'user'` as a person.
+   *
+   *  A consumer cannot infer this from the identity itself: a bot's turn carries
+   *  a perfectly valid `requestUserUnionId` (its own), so "someone asked" and
+   *  "a bot triggered itself" are indistinguishable without it. Anything that
+   *  maps the caller onto a real person's access — database accounts, approval
+   *  gates, audit attribution — needs to tell those apart, otherwise a bot that
+   *  happens to hold such a mapping becomes a way for anyone who can make it
+   *  speak to borrow that access, with the audit trail pointing at the bot. */
+  senderType?: 'user' | 'bot';
 }
 
 export interface VcMeetingConsumerProfileFilter {

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -790,6 +790,33 @@ describe('core-only entrypoint hardening (codex 4 P1s — source lock)', () => {
     expect(entrySource).not.toContain('if (!process.env.BOTMUX_WORKER_HTTP_HOST');
   });
 
+  it('stamps the turn sender type onto the trusted caller at both IM entry points', () => {
+    // A bot's turn carries a perfectly valid union_id (its own), so a consumer
+    // cannot tell "a person asked" from "a bot triggered itself" unless the host
+    // says which it was. Both inbound paths must therefore pass it — a missed
+    // one silently degrades to "unknown" exactly where a bot could slip through.
+    expect(daemonSource).toContain('senderIsBot?: boolean,');
+    expect(daemonSource).toContain("senderType: senderIsBot ? 'bot' as const : 'user' as const");
+    // Pin the SEMANTICS, not the argument's spelling: every call must pass a
+    // non-empty 4th argument, and it must be the tri-state helper rather than a
+    // bare `sender_type` comparison — that one reads a cross-ref-identified peer
+    // bot as `'user'`, i.e. it vouches for a bot turn as a person.
+    const trustedCallerArgs = [...daemonSource.matchAll(/trustedCallerForTurn\(([^;]*?)\);/g)]
+      .map(m => m[1].split(',').map(part => part.trim()));
+    expect(trustedCallerArgs.length).toBe(2);
+    for (const args of trustedCallerArgs) {
+      expect(args.length).toBeGreaterThanOrEqual(4);
+      const senderTypeArg = args.slice(3).join(', ');
+      expect(senderTypeArg).not.toBe('');
+      expect(senderTypeArg).toContain('senderIsBotTriState(');
+      expect(senderTypeArg).not.toMatch(/^isBotSenderType\)?$/);
+      // ...and the cross-ref leg must actually be wired in: passing a literal
+      // `false` there keeps the helper name but drops peer-bot recognition,
+      // which is the exact case a bare `sender_type` check already missed.
+      expect(senderTypeArg).toContain('isForeignBot');
+    }
+  });
+
   it('P1-2: entrypoint strips BOTS_CONFIG so no worker fork inherits it', () => {
     // The parser ignores BOTS_CONFIG for identity, but the raw env is inherited by
     // forked workers — an agent could cat $BOTS_CONFIG. Delete it after dotenv,

--- a/test/plugin-mcp-gateway.test.ts
+++ b/test/plugin-mcp-gateway.test.ts
@@ -207,6 +207,7 @@ describe('plugin MCP Gateway', () => {
             requestLarkAppId: 'cli_trusted',
             source: 'schedule_creator',
             taskId: 'task_123',
+            senderType: 'user',
           },
           turnId: 'om_turn',
           dispatchAttempt: 2,
@@ -235,6 +236,7 @@ describe('plugin MCP Gateway', () => {
     expect(text).toContain('"requestLarkAppId":"cli_trusted"');
     expect(text).toContain('"source":"schedule_creator"');
     expect(text).toContain('"taskId":"task_123"');
+    expect(text).toContain('"senderType":"user"');
     expect(text).toContain('"turnId":"om_turn"');
     expect(text).toContain('"dispatchAttempt":2');
     expect(text).toContain('"customTrace":"keep-me"');
@@ -310,6 +312,7 @@ describe('plugin MCP Gateway', () => {
             requestLarkAppId: 'cli_trusted',
             source: 'schedule_creator',
             taskId: 'task_123',
+            senderType: 'user',
           },
           turnId: 'om_trusted',
           dispatchAttempt: 2,
@@ -329,6 +332,7 @@ describe('plugin MCP Gateway', () => {
     // HTTP-transport MCP server, so they must not start carrying it.
     expect(trusted.get('x-botmux-trusted-source')).toBeNull();
     expect(trusted.get('x-botmux-task-id')).toBeNull();
+    expect(trusted.get('x-botmux-trusted-sender-type')).toBeNull();
   });
 
   it('uses the session MCP runtime snapshot without reading the global plugin registry', async () => {


### PR DESCRIPTION
## 问题

一个 bot 触发的 turn，携带的是**完全合法**的 `requestUserUnionId`——它自己的。于是在下游看来，「有人刚问了一句」和「某个 bot 自己触发了一轮」**一模一样**。

对只做审计的消费方，这最多是归属不准；但对**把 caller 映射到真人权限**的消费方（数据库账号映射、审批门、按人限权的查询），这是一条实打实的提权通道：**谁能让那个 bot 说话，谁就借用了它的那份权限**，而审计只会记到 bot。定时任务、bot 之间的交棒、bot 的自主追问都会走到这条路径。

消费方无法自行推断，因为身份本身没有携带这个信息。只有宿主知道。

## 改动

- `TrustedCaller` 增加 `senderType?: 'user' | 'bot'`。
- `trustedCallerForTurn` 增加可选形参 `senderIsBot`（三态 `boolean | undefined`）；两个 IM 入口传入已有的 **`senderIsBotTriState(parsed.senderType, isForeignBotSender / isForeignBot)`**。
  - 为什么不是裸的 `isBotSenderType`：仓库判「本轮是不是 bot 发的」的既有口径是**双轨**——平台 `sender_type` **加上** cross-ref 的 peer-bot 兜底。只取第一轨会把 cross-ref 认出来的 peer bot 写成 `'user'`，而 `'user'` 正是消费方用来映射真人权限的值：**给一个 bot 轮盖上 `'user'` 是主动替它背书，严格比字段缺席更糟**。cross-ref 那一跳只可能产出 `'bot'` 或不影响结果，**永不产出 `'user'`**，所以复用三态 helper 是单向收紧，不扩大信任边界（与 `threadTeamTrustUnionId` 那条「授予 team-bot 信任所以必须平台盖章」的腿方向相反）。
- **拿不准就不填**：helper 返回 `undefined` 时字段缺席，消费方按「未知」处理，而不是被默认成「人」。`TrustedCaller.senderType` 的文档写明**缺席 = 未知，永远不等于人**。
- **定时轮刻意不填**：那一轮没有 inbound 消息，语义由已有的 `source: 'schedule_creator'` 承担（`senderType` 描述的是"谁的消息开启了这一轮"）。因此消费方的判据是 `source === 'schedule_creator'` 或 `senderType === 'user'`。
- Gateway 只把它放进本地 `_meta.botmuxTrustedCaller`，**不进 `x-botmux-trusted-*` 头**——那组头会发给所有 HTTP transport 的 MCP server，与 `source` / `taskId` 同规则。

## 影响面

纯增量：字段可选，既有消费方不受影响；未升级的部署字段缺席，消费方按未知处理。HTTP transport 插件可见的信息不变。

## 验证

工具链 bun 1.4.0 / node v24.17.0，基线 rebase 到 master `7bd2e974d`：

```
bun run build
npx tsc --noEmit
npx vitest run test/api-only-mode-wiring.test.ts test/plugin-mcp-gateway.test.ts test/daemon-turn-reply-sender-wiring.test.ts
bun test  test/api-only-mode-wiring.test.ts test/plugin-mcp-gateway.test.ts test/daemon-turn-reply-sender-wiring.test.ts
```

- `tsc --noEmit` 干净；build 通过；上述三个测试文件 vitest **88/88**、`bun test` **88/88**。
- wiring 断言钉的是**语义**而不是实参拼写：正则抓出**所有** `trustedCallerForTurn(` 调用，断言恰好 2 处、每处第 4 个实参非空、含 `senderIsBotTriState(`、**且含 `isForeignBot`**（后者防的是「helper 名字还在、cross-ref 腿被换成字面量 `false`」这种保留形态却抽掉语义的改动）。gateway 用例钉住 `_meta` 带 `senderType`、HTTP 头不带。
- **变异验证 4 处，基线绿、全部按预期变红**：
  1. 入口 A 退回 `isBotSenderType`
  2. 入口 B 退回 `isBotSenderType`
  3. 入口 A 保留 helper、cross-ref 传 `false`
  4. 入口 B 删掉整个第 4 实参
- CI：门禁 `build` 绿；`bun-test` 是 `continue-on-error: true` 的非门禁任务，与 master 同基线**逐文件相同、PR-only = 0**。`bun-binary` 曾出现一次 `dashboard port … never served within 20000ms` 的红，同一 commit 上 `bun-binary-musl` 的同一项冒烟是绿的，重跑后转绿——环境/时序抖动，本 PR 不触碰 dashboard / HTTP / supervisor。
