### PR TITLE
fix(test): 补齐 vc-agent spawnSync mock 的返回类型，消除 3 条隐形类型报错

### DIFF
--- a/test/vc-agent-polling-source.test.ts
+++ b/test/vc-agent-polling-source.test.ts
@@ -20,9 +20,35 @@ vi.mock('node:child_process', () => {
   return { ...actual, spawnSync: vi.fn() };
 });
 
-import { spawnSync } from 'node:child_process';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 
 const spawnSyncMock = vi.mocked(spawnSync);
+
+/**
+ * A complete `SpawnSyncReturns` from just the fields a test cares about.
+ *
+ * `vi.mocked(spawnSync)` carries the REAL signature, so `mockReturnValue` demands
+ * every field — `pid`, `output` and `signal` included. The previous mock was a bare
+ * `vi.fn()` with no signature, which accepted these partial literals silently; the
+ * literals were always incomplete, the looseness just hid it. Neither runner checks
+ * types at runtime, and `tsc --noEmit -p tsconfig.json` only includes `src`, so this
+ * shows up nowhere but the editor. Filling the fields here keeps each call site
+ * stating only what it is actually asserting on.
+ */
+function spawnResult(
+  partial: Partial<SpawnSyncReturns<string>> & Pick<SpawnSyncReturns<string>, 'status'>,
+): SpawnSyncReturns<string> {
+  const stdout = partial.stdout ?? '';
+  const stderr = partial.stderr ?? '';
+  return {
+    pid: 4242,
+    output: [null, stdout, stderr],
+    stdout,
+    stderr,
+    signal: null,
+    ...partial,
+  };
+}
 
 import {
   fetchMeetingEventsAsBot,
@@ -35,7 +61,7 @@ describe('vc agent polling source process bounds', () => {
   });
 
   it('passes an explicit timeout to synchronous lark-cli execution', () => {
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: '{}', stderr: '' });
+    spawnSyncMock.mockReturnValue(spawnResult({ status: 0, stdout: '{}' }));
 
     expect(runLarkCliJson(['vc', '+meeting-events'], { timeoutMs: 12_345 })).toEqual({});
     expect(spawnSyncMock).toHaveBeenCalledWith('lark-cli', ['vc', '+meeting-events'], expect.objectContaining({
@@ -46,18 +72,17 @@ describe('vc agent polling source process bounds', () => {
 
   it('reports a bounded timeout instead of treating it as an ordinary exit', () => {
     const error = Object.assign(new Error('spawnSync lark-cli ETIMEDOUT'), { code: 'ETIMEDOUT' });
-    spawnSyncMock.mockReturnValue({ status: null, stdout: '', stderr: '', error });
+    spawnSyncMock.mockReturnValue(spawnResult({ status: null, error }));
 
     expect(() => runLarkCliJson(['vc', '+meeting-events'], { timeoutMs: 500 }))
       .toThrow('timed out after 500ms');
   });
 
   it('forwards the restore timeout through meeting event polling', () => {
-    spawnSyncMock.mockReturnValue({
+    spawnSyncMock.mockReturnValue(spawnResult({
       status: 0,
       stdout: JSON.stringify({ meeting: { id: 'm1' }, events: [] }),
-      stderr: '',
-    });
+    }));
 
     expect(fetchMeetingEventsAsBot({ meetingId: 'm1', timeoutMs: 7_000 }).batch.meeting.id).toBe('m1');
     expect(spawnSyncMock).toHaveBeenCalledWith('lark-cli', expect.arrayContaining([


### PR DESCRIPTION
#1143 把这个文件的 mock 从裸 `vi.fn()` 改成 `vi.mocked(spawnSync)` 之后,mock 继承了
真实签名,于是 `mockReturnValue` 要求补齐 `pid` / `output` / `signal`:

    TS2345: '{ status; stdout; stderr }' is missing the following properties
    from type 'SpawnSyncReturns<...>': pid, output, signal   ×3

⚠️ 这 3 条报错**此前就客观存在**——那些字面量一直是不完整的,只是裸 `vi.fn()` 没有签名、
把它们静默接受了。不是 #1143 制造了缺陷,是 #1143 让它可见。

## 为什么 CI 看不见,IDE 却飘红

`tsconfig.json` 的 `include` 只有 `src`,`tsc --noEmit -p tsconfig.json` **根本不覆盖
test/**;两个 runner 又都在运行时抹掉类型。所以这 3 条只在编辑器里出现,任何 CI 腿都不会红。

## 修法

加一个 `spawnResult()` 小工厂补齐必填字段,调用点只写它真正断言的东西,可读性不降。

## 验证

- 类型:`tsc --noEmit` 单文件 → 0 报错(修前 3 条)
- 行为:bun `3 pass 0 fail`、vitest `3 passed`,与修前逐位一致
- 反变异:把工厂里的 `...partial` 去掉(即忽略调用方传入的 status/stdout)
  → 两个 runner **各 3 条全红**,还原后全绿 ⟹ 这个工厂不是摆设

---
这是 #1143 复审时同侪指出的 2 条非阻断问题之一（另一条是 PR 描述里「腿 1020→1029」是旧 base 上的数，实际应为 1025→1034，差值 +9 不变；那条只是描述，已在合并后的记录里更正）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)