### PR TITLE
fix(test): 补齐 vc-agent 三处 SpawnSyncReturns 字面量缺失字段

### DIFF
--- a/test/vc-agent-polling-source.test.ts
+++ b/test/vc-agent-polling-source.test.ts
@@ -21,8 +21,32 @@ vi.mock('node:child_process', () => {
 });
 
 import { spawnSync } from 'node:child_process';
+import type { SpawnSyncReturns } from 'node:child_process';
 
 const spawnSyncMock = vi.mocked(spawnSync);
+
+/**
+ * A complete `SpawnSyncReturns<string>`, so the literals below typecheck.
+ *
+ * WHY THIS APPEARED: the mock used to be an untyped `vi.fn()`, so a partial
+ * literal was invisible to tsc. `vi.mocked(spawnSync)` inherits the REAL
+ * signature, which requires `pid`/`output`/`signal` too. The fields are filled
+ * with inert values — no assertion reads them; only `status`/`stdout`/`stderr`
+ * (and `error`) drive the code under test.
+ *
+ * NOT widened to `as any`: the whole point of `vi.mocked` here is that a wrong
+ * payload shape becomes a compile error rather than a runtime surprise.
+ */
+function spawnResult(
+  partial: Partial<SpawnSyncReturns<string>> & Pick<SpawnSyncReturns<string>, 'status' | 'stdout' | 'stderr'>,
+): SpawnSyncReturns<string> {
+  return {
+    pid: 0,
+    output: [null, partial.stdout, partial.stderr],
+    signal: null,
+    ...partial,
+  };
+}
 
 import {
   fetchMeetingEventsAsBot,
@@ -35,7 +59,7 @@ describe('vc agent polling source process bounds', () => {
   });
 
   it('passes an explicit timeout to synchronous lark-cli execution', () => {
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: '{}', stderr: '' });
+    spawnSyncMock.mockReturnValue(spawnResult({ status: 0, stdout: '{}', stderr: '' }));
 
     expect(runLarkCliJson(['vc', '+meeting-events'], { timeoutMs: 12_345 })).toEqual({});
     expect(spawnSyncMock).toHaveBeenCalledWith('lark-cli', ['vc', '+meeting-events'], expect.objectContaining({
@@ -46,18 +70,18 @@ describe('vc agent polling source process bounds', () => {
 
   it('reports a bounded timeout instead of treating it as an ordinary exit', () => {
     const error = Object.assign(new Error('spawnSync lark-cli ETIMEDOUT'), { code: 'ETIMEDOUT' });
-    spawnSyncMock.mockReturnValue({ status: null, stdout: '', stderr: '', error });
+    spawnSyncMock.mockReturnValue(spawnResult({ status: null, stdout: '', stderr: '', error }));
 
     expect(() => runLarkCliJson(['vc', '+meeting-events'], { timeoutMs: 500 }))
       .toThrow('timed out after 500ms');
   });
 
   it('forwards the restore timeout through meeting event polling', () => {
-    spawnSyncMock.mockReturnValue({
+    spawnSyncMock.mockReturnValue(spawnResult({
       status: 0,
       stdout: JSON.stringify({ meeting: { id: 'm1' }, events: [] }),
       stderr: '',
-    });
+    }));
 
     expect(fetchMeetingEventsAsBot({ meetingId: 'm1', timeoutMs: 7_000 }).batch.meeting.id).toBe('m1');
     expect(spawnSyncMock).toHaveBeenCalledWith('lark-cli', expect.arrayContaining([


### PR DESCRIPTION
## 改了什么

`test/vc-agent-polling-source.test.ts` 里三处 `spawnSyncMock.mockReturnValue({...})` 的字面量补齐 `pid`/`output`/`signal`，通过一个 `spawnResult()` helper 统一填。

## 为什么

#1143 把这个文件的 `vi.hoisted(() => vi.fn())` 换成「工厂内造 mock + `vi.mocked(spawnSync)` 取回」后，mock 从**无类型**变成**继承 `spawnSync` 的真实签名**，于是把三处本就不完整的 `SpawnSyncReturns` 字面量暴露了出来：

```
test/vc-agent-polling-source.test.ts(38,35): error TS2345
test/vc-agent-polling-source.test.ts(49,35): error TS2345
test/vc-agent-polling-source.test.ts(56,35): error TS2345
```

**不影响任何测试**——两个 runner 都抹类型，迁移前后都是 3/3 绿。但 IDE 会飘红，而且 `tsconfig.json` 的 `include` 只有 `src/**/*`，`tsc --noEmit` **覆盖不到 `test/`**，所以 CI 也拦不住，只能靠人眼发现。

### 为什么不放宽 mock 类型

放宽成 `as any` 等于把 `vi.mocked` 刚带来的「payload 形状写错就是编译错误」这点收益又扔掉。helper 补的三个字段都是惰性值（`pid: 0` / `signal: null` / `output` 由 stdout+stderr 拼出），**没有任何断言读它们**——真正驱动被测代码的只有 `status`/`stdout`/`stderr`（和 `error`）。

## 影响面

只动 `test/` 下 1 个文件，**零生产代码改动**。不涉及跨 CLI / 跨后端 / 跨平台 / 跨会话类型——被 mock 的模块、断言语义、用例名与条数均未改变。

## 实际测试验证

| 项 | 结果 |
|---|---|
| typecheck（把 include 扩到 `test/**/*` 再跑） | 该文件 **3 条告警 → 0** |
| vitest | **3/3 绿**（用例名与条数未变） |
| bun 腿 | **3/3 绿** |
| 反变异 | 在 `src/vc-agent/polling-source.ts` 里废掉显式 timeout 传参：**修前修后同为 vitest RED(3) / bun RED(3)** ⟹ 断言的牙没被 helper 削弱 |
| bun 腿可跑集 | `isDeferredFromBunLeg` = `false`，与 master 一致，文件未掉出 |
| `bun run build` | 绿 |

反变异这条是关键：helper 如果把不该兜的东西兜住了，废掉 timeout 传参应该会从「红」变「绿」。实测红绿与失败条数**逐位相同**，说明 helper 只补了类型、没有改变运行时行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)