### PR TITLE
fix(riff): JWT 恒读 daemon 的 $HOME，多用户共享主机上 riff bot 全部 401

### DIFF
--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -104,6 +104,14 @@ export interface RiffBackendConfig {
    * uncached/`@latest` npx resolve can block ~30s per call, far too slow for a
    * synchronous pre-request refresh. Deployments wanting npx must set the env
    * explicitly (and ideally pin the version).
+   *
+   * WITH `jwtHome`: this becomes REQUIRED for auto-refresh. The resolved default
+   * runs as the daemon UID with the daemon's HOME and would rewrite the DAEMON's
+   * keychain, not the override's — so it cannot refresh a sub-user's login, and
+   * the override skips auto-refresh unless this is set explicitly. Set it to
+   * whatever refreshes as that user on this host (a per-user wrapper, `sudo -u
+   * <user> bytedcli auth get-bytecloud-jwt-token --force-refresh`, …). Without
+   * it, an expired sub-user token must be renewed by that user re-logging in.
    */
   jwtRefreshCmd?: string[];
   /**
@@ -702,19 +710,24 @@ export const JWT_REFRESH_DEBOUNCE_MS = 60_000;
  *  JWT has nothing useful to do anyway. */
 export const JWT_REFRESH_TIMEOUT_MS = 30_000;
 
-/** Process-wide last-attempt timestamp (ms). Shared across RiffBackend instances
- *  because the orphan-cancel path builds a throwaway instance per call — a
- *  per-instance clock there would never debounce. `-Infinity` means "never
- *  attempted", so the first call always runs regardless of the clock's
- *  magnitude. Reset helper for tests. */
-let lastJwtRefreshAtMs = Number.NEGATIVE_INFINITY;
-/** In-flight refresh, shared process-wide so concurrent callers COALESCE onto a
- *  single child process instead of each spawning their own bytedcli. `null`
- *  between attempts. */
-let inFlightJwtRefresh: Promise<boolean> | null = null;
+/** Process-wide last-attempt timestamp (ms), PER IDENTITY. Shared across
+ *  RiffBackend instances because the orphan-cancel path builds a throwaway
+ *  instance per call — a per-instance clock there would never debounce. Keyed by
+ *  identity because a shared host runs one riff bot per human: a single global
+ *  clock let the FIRST bot's refresh swallow every other bot's for the next 60s
+ *  (measured: alice refreshed, bob got `false` without its command ever running),
+ *  so a user whose token expired would sit unauthenticated behind a colleague's
+ *  unrelated refresh. A missing key means "never attempted", so the first call
+ *  for an identity always runs. Reset helper for tests. */
+const lastJwtRefreshAtMsByIdentity = new Map<string, number>();
+/** In-flight refresh PER IDENTITY, so concurrent callers for the SAME identity
+ *  coalesce onto one child process while different identities still refresh
+ *  independently — they rewrite different keychains, so one can never stand in
+ *  for the other. */
+const inFlightJwtRefreshByIdentity = new Map<string, Promise<boolean>>();
 export function __resetJwtRefreshDebounceForTest(): void {
-  lastJwtRefreshAtMs = Number.NEGATIVE_INFINITY;
-  inFlightJwtRefresh = null;
+  lastJwtRefreshAtMsByIdentity.clear();
+  inFlightJwtRefreshByIdentity.clear();
 }
 
 export interface RefreshBytecloudJwtOpts {
@@ -726,6 +739,10 @@ export interface RefreshBytecloudJwtOpts {
    *  the current token is bad — a rejection is authoritative evidence worth one
    *  more attempt even inside the window. Never set for speculative refreshes. */
   force?: boolean;
+  /** Which identity's keychain this refresh rewrites. Debounce and coalescing are
+   *  scoped to it, so one bot's refresh never stands in for (or suppresses)
+   *  another user's. Defaults to the daemon's own identity. */
+  identityKey?: string;
 }
 
 /**
@@ -745,15 +762,19 @@ export function refreshBytecloudJwt(
   cmd: string[] | null,
   opts: RefreshBytecloudJwtOpts = {},
 ): Promise<boolean> {
-  const { runner = defaultJwtRefreshRunner, nowMs = Date.now(), force = false } = opts;
+  const { runner = defaultJwtRefreshRunner, nowMs = Date.now(), force = false, identityKey = '' } = opts;
   if (!cmd || cmd.length === 0) return Promise.resolve(false);
-  // Coalesce first: a forced caller still rides an in-flight refresh rather than
-  // racing a second child — the running one will rewrite the keychain either way.
-  if (inFlightJwtRefresh) return inFlightJwtRefresh;
+  // Coalesce first, WITHIN one identity: a forced caller still rides an in-flight
+  // refresh rather than racing a second child — the running one will rewrite that
+  // keychain either way. Across identities there is nothing to ride: a refresh for
+  // alice does not touch bob's store.
+  const inFlight = inFlightJwtRefreshByIdentity.get(identityKey);
+  if (inFlight) return inFlight;
   // Debounce: cap the cost of a refresh that keeps failing. A forced (401-driven)
   // refresh bypasses the window — the token was provably rejected.
-  if (!force && nowMs - lastJwtRefreshAtMs < JWT_REFRESH_DEBOUNCE_MS) return Promise.resolve(false);
-  lastJwtRefreshAtMs = nowMs;
+  const lastAt = lastJwtRefreshAtMsByIdentity.get(identityKey) ?? Number.NEGATIVE_INFINITY;
+  if (!force && nowMs - lastAt < JWT_REFRESH_DEBOUNCE_MS) return Promise.resolve(false);
+  lastJwtRefreshAtMsByIdentity.set(identityKey, nowMs);
   const [bin, ...args] = cmd;
   const run = (async (): Promise<boolean> => {
     try {
@@ -764,8 +785,10 @@ export function refreshBytecloudJwt(
       return false;
     }
   })();
-  inFlightJwtRefresh = run;
-  return run.finally(() => { if (inFlightJwtRefresh === run) inFlightJwtRefresh = null; });
+  inFlightJwtRefreshByIdentity.set(identityKey, run);
+  return run.finally(() => {
+    if (inFlightJwtRefreshByIdentity.get(identityKey) === run) inFlightJwtRefreshByIdentity.delete(identityKey);
+  });
 }
 
 const execFileAsync = promisify(execFile);
@@ -1119,23 +1142,33 @@ export class RiffBackend implements SessionBackend {
     // trigger a host-identity refresh there; the AIME store is refreshed inside
     // AIME).
     //
-    // A `jwtHome` override is the SAME identity boundary by a different name:
-    // the refresh command runs as the DAEMON user and rewrites the DAEMON's
-    // keychain, but we read the override's. Running it could not fix the token
-    // we are about to return (wrong store), and it burns a subprocess with a
-    // 30s budget on every miss. Refreshing "harder" by pointing the child at
-    // someone else's HOME would be worse still — a daemon-UID write into that
-    // user's home. So the override refreshes where it is logged in, not here.
+    // A `jwtHome` override needs a refresh command that can rewrite THAT user's
+    // keychain. The default command (`bytedcli …`) runs as the daemon UID with
+    // the daemon's HOME, so it would rewrite the daemon's store — it cannot fix
+    // the token we are about to return, and pointing it at someone else's HOME
+    // would be worse (a daemon-UID write into that user's home). So an override
+    // auto-refreshes ONLY when the deployment supplied an explicit
+    // `jwtRefreshCmd` — the operator's own hook (a per-user wrapper, `sudo -u`,
+    // whatever the host uses to isolate logins) which is the only thing that
+    // knows how to refresh as that user. Without one we skip rather than burn a
+    // 30s subprocess that provably cannot help.
     const identity = this.jwtIdentity();
-    if (allowRefresh && !identity.overridden && !isFullAimeRuntime(identity.env)) {
-      const cmd = resolveJwtRefreshCmd(this.config.jwtRefreshCmd);
-      if (await refreshBytecloudJwt(cmd, { force: forceRefresh })) {
+    const cmd = resolveJwtRefreshCmd(this.config.jwtRefreshCmd, identity.env);
+    const refreshCanServeIdentity = !identity.overridden || Boolean(this.config.jwtRefreshCmd?.length);
+    if (allowRefresh && refreshCanServeIdentity && !isFullAimeRuntime(identity.env)) {
+      if (await refreshBytecloudJwt(cmd, { force: forceRefresh, identityKey: identity.home })) {
         const refreshed = this.readJwtFromBytecloudKeychain();
         if (refreshed) {
           logger.info(`[riff] JWT refreshed via ByteCloud CLI and reloaded from keychain`);
           return refreshed;
         }
       }
+    } else if (allowRefresh && identity.overridden && !cmd) {
+      logger.warn(
+        `[riff] riff.jwtHome=${identity.home} has no live token and no riff.jwtRefreshCmd is configured — `
+        + 'botmux cannot refresh another user\'s ByteCloud login by itself. Configure riff.jwtRefreshCmd '
+        + '(a command that refreshes as that user), or have them re-login.',
+      );
     }
 
     // Forced refresh found nothing new — fall back to the (rejected) keychain

--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, delimiter } from 'node:path';
+import { join, delimiter, isAbsolute } from 'node:path';
 import { execFileSync, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createHash } from 'node:crypto';
@@ -106,6 +106,24 @@ export interface RiffBackendConfig {
    * explicitly (and ideally pin the version).
    */
   jwtRefreshCmd?: string[];
+  /**
+   * Home directory whose ByteCloud keychain owns THIS bot's riff identity.
+   *
+   * The keychain lookup is home-derived, and by default the home is the
+   * DAEMON's (`os.homedir()`). On a shared host that runs one bot per human —
+   * each pointed at its own login via a per-user `cliPathOverride` wrapper —
+   * every riff bot would then read the daemon account's keychain instead of the
+   * bot owner's, and 401 when that account is not logged in (which is the
+   * normal state: nobody logs the daemon account into ByteCloud). Setting this
+   * to the owning user's home (`/home/<user>`) scopes the lookup to that
+   * identity.
+   *
+   * Empty/unset keeps the daemon home (current behaviour). Must be an ABSOLUTE
+   * path — a relative value would resolve against the daemon's cwd and silently
+   * point somewhere meaningless, so it is rejected at the config gate rather
+   * than half-applied.
+   */
+  jwtHome?: string;
   /** Sandbox resource pool selected for newly-created tasks. Riff defaults to
    *  BOE when omitted; follow-ups inherit the parent task's sandbox. */
   sandboxCluster?: RiffSandboxCluster;
@@ -190,6 +208,13 @@ export function isValidRiffBaseUrl(v: unknown): v is string {
 
 export function isValidRiffSandboxCluster(v: unknown): v is RiffSandboxCluster {
   return RIFF_SANDBOX_CLUSTERS.includes(v as RiffSandboxCluster);
+}
+
+/** Valid `riff.jwtHome`: an absolute path. A relative one would resolve against
+ *  the daemon's cwd and silently read a meaningless tree, so the spawn gate
+ *  rejects it rather than letting the session 401 with no explanation. */
+export function isValidRiffJwtHome(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0 && isAbsolute(v.trim());
 }
 
 export interface RiffRepoRef {
@@ -293,7 +318,7 @@ export function deriveRiffReposFromDirs(
  * retry; failures are logged, never thrown.
  */
 export async function cancelRiffTaskById(
-  cfg: { baseUrl: string; jwt?: string; jwtEnv?: string; extraHeaders?: Record<string, string> },
+  cfg: { baseUrl: string; jwt?: string; jwtEnv?: string; jwtHome?: string; extraHeaders?: Record<string, string> },
   taskId: string,
 ): Promise<boolean> {
   const attempt = async (): Promise<void> => {
@@ -367,6 +392,54 @@ function aimeDataHome(env: NodeJS.ProcessEnv): string | null {
  *  host-identity JWT refresh — see resolveJwt's fail-closed skip. */
 function isFullAimeRuntime(env: NodeJS.ProcessEnv): boolean {
   return aimeDataHome(env) !== null;
+}
+
+/**
+ * Resolve the identity domain (home + env) whose ByteCloud keychain this riff
+ * config reads, given the ambient daemon env.
+ *
+ * Why env and home move TOGETHER: three of the six candidate roots
+ * (kaboo-cli / aiden-cli / cjadk) key off `$XDG_CONFIG_HOME` when it is set,
+ * and on macOS/Windows the config root comes from the env too. Swapping only
+ * the home while keeping the daemon's env therefore leaves those candidates
+ * pointing at the DAEMON's account — measured: 3 of 6 candidates still resolved
+ * under the daemon home. Since the selector picks the globally-freshest token
+ * regardless of position, a live daemon-account token would then WIN over the
+ * bot owner's and we would silently authenticate as the wrong user — the exact
+ * cross-identity hazard `bytecloudKeychainCandidates` is built to prevent. So
+ * an override drops the ambient home-derived env keys and lets each candidate
+ * fall back to its documented `<home>/…` default.
+ *
+ * `AIME_*` is deliberately NOT carried over either: those vars describe the
+ * daemon's own AIME runtime, and honouring them under a different home would
+ * resolve to a third identity that is neither the daemon's nor the override's.
+ * An explicit override is a statement about which human owns this bot, so it
+ * wins over the ambient AIME runtime.
+ *
+ * Returns the ambient pair unchanged when no override is configured, so the
+ * default path is byte-for-byte the current behaviour.
+ */
+export function resolveRiffJwtIdentity(
+  jwtHome: string | undefined,
+  ambientHome: string = homedir(),
+  ambientEnv: NodeJS.ProcessEnv = process.env,
+): { home: string; env: NodeJS.ProcessEnv; overridden: boolean } {
+  const override = jwtHome?.trim();
+  if (!override) return { home: ambientHome, env: ambientEnv, overridden: false };
+  // A relative path would resolve against the daemon's cwd — meaningless and
+  // silently wrong. Config gates reject it; ignore it here too so a hand-edited
+  // bots.json degrades to current behaviour rather than reading a bogus tree.
+  if (!isAbsolute(override)) {
+    logger.warn(`[riff] ignoring non-absolute riff.jwtHome ${JSON.stringify(override)}; using the daemon home`);
+    return { home: ambientHome, env: ambientEnv, overridden: false };
+  }
+  const env: NodeJS.ProcessEnv = { ...ambientEnv };
+  // Home-derived roots that would otherwise pin the DAEMON's identity.
+  delete env.XDG_CONFIG_HOME;
+  delete env.APPDATA;
+  delete env.AIME_WORKSPACE_PATH;
+  delete env.AIME_CURRENT_USER;
+  return { home: override, env, overridden: true };
 }
 
 /**
@@ -1045,7 +1118,16 @@ export class RiffBackend implements SessionBackend {
     // and inside a full AIME runtime (fail-closed identity boundary — we never
     // trigger a host-identity refresh there; the AIME store is refreshed inside
     // AIME).
-    if (allowRefresh && !isFullAimeRuntime(process.env)) {
+    //
+    // A `jwtHome` override is the SAME identity boundary by a different name:
+    // the refresh command runs as the DAEMON user and rewrites the DAEMON's
+    // keychain, but we read the override's. Running it could not fix the token
+    // we are about to return (wrong store), and it burns a subprocess with a
+    // 30s budget on every miss. Refreshing "harder" by pointing the child at
+    // someone else's HOME would be worse still — a daemon-UID write into that
+    // user's home. So the override refreshes where it is logged in, not here.
+    const identity = this.jwtIdentity();
+    if (allowRefresh && !identity.overridden && !isFullAimeRuntime(identity.env)) {
       const cmd = resolveJwtRefreshCmd(this.config.jwtRefreshCmd);
       if (await refreshBytecloudJwt(cmd, { force: forceRefresh })) {
         const refreshed = this.readJwtFromBytecloudKeychain();
@@ -1060,12 +1142,27 @@ export class RiffBackend implements SessionBackend {
     // token rather than null: a stale token is no worse than no token, and the
     // caller already knows it 401'd.
     if (fromKeychain) return fromKeychain;
-    logger.warn(`[riff] JWT not found in config, env ${envKey}, or ByteCloud keychain; API calls will fail`);
+    // Name the identity domain we searched. "JWT not found" alone sent users
+    // hunting through `kaboo login` status on an account that was in fact
+    // logged in — just not the account this lookup reads.
+    const { home, overridden } = identity;
+    logger.warn(
+      `[riff] JWT not found in config, env ${envKey}, or the ByteCloud keychain under ${home}`
+      + `${overridden ? ' (riff.jwtHome)' : ' (daemon home — set riff.jwtHome to the bot owner\'s home if this bot runs as another user)'}`
+      + '; API calls will fail',
+    );
     return null;
   }
 
+  /** Identity domain (home + env) whose keychain this bot's riff JWT comes from
+   *  — the daemon's own unless `riff.jwtHome` scopes it to the bot owner. */
+  private jwtIdentity(): { home: string; env: NodeJS.ProcessEnv; overridden: boolean } {
+    return resolveRiffJwtIdentity(this.config.jwtHome);
+  }
+
   private readJwtFromBytecloudKeychain(): string | null {
-    return readBytecloudKeychainJwt();
+    const { home, env } = this.jwtIdentity();
+    return readBytecloudKeychainJwt(home, env);
   }
 
   spawn(_bin: string, _args: string[], _opts: SpawnOpts): void {

--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -117,7 +117,7 @@ export const CONFIG_FIELDS: readonly ConfigFieldSpec[] = [
   { key: 'env', configKey: 'env', kind: 'json', effect: 'next-session', clearable: true, hint: 'per-bot 环境变量 JSON（如 {"ANTHROPIC_BASE_URL":"…","ANTHROPIC_AUTH_TOKEN":"…"} 让本 bot 走 GLM/第三方服务商，或设 HTTPS_PROXY）；注入到本 bot 的 CLI 进程，下个会话生效；值不显示（脱敏）；unset 清除' },
   { key: 'codexAuthSync', configKey: 'codexAuthSync', kind: 'enum', effect: 'next-session', clearable: true, enumValues: ['shared', 'isolated'], hint: 'Codex 鉴权策略：shared=保持旧行为（非沙箱直接使用全局 ~/.codex；沙箱冷启动同步全局 auth 到 per-bot CODEX_HOME）｜isolated=无论是否启用沙箱都使用 per-bot CODEX_HOME，绝不复制全局凭证，需在该目录单独执行 codex login --with-api-key' },
   { key: 'backendType', configKey: 'backendType', kind: 'enum', effect: 'next-session', clearable: true, enumValues: ['pty', 'tmux', 'herdr', 'zellij', 'zmx', 'riff', 'mojo'], hint: '会话后端类型：pty=本地 PTY 子进程（默认）｜tmux=tmux 会话｜herdr=herdr 终端复用｜zellij=zellij 多路复用｜zmx=ZMX >=0.7.0 纯文本持久会话（无 Web TUI）｜riff=远程 riff agent 服务｜mojo=远程 mojo agent（headless mojo CLI）；选 riff 时需配置 riff 字段，mojo 字段可选；unset 回 pty' },
-  { key: 'riff', configKey: 'riff', kind: 'json', effect: 'next-session', clearable: true, hint: 'riff 后端配置 JSON（baseUrl/agent/model/jwt 等），仅 backendType=riff 时生效；unset 清除' },
+  { key: 'riff', configKey: 'riff', kind: 'json', effect: 'next-session', clearable: true, hint: 'riff 后端配置 JSON（baseUrl/agent/model/jwt 等），仅 backendType=riff 时生效；多用户共享主机上，用 jwtHome 指向该 bot 归属用户的 home（绝对路径）以读到他自己的 ByteCloud 登录态；unset 清除' },
   { key: 'mojo', configKey: 'mojo', kind: 'json', effect: 'next-session', clearable: true, hint: 'mojo 后端配置 JSON，仅 backendType=mojo 时生效，全部可选：cloud/localDaemon/baseUrl/ppeEnv/workspaceId/agentId/idleTimeoutSec/stream/systemPrompt/jwt/jwtEnv/env；model 与二进制路径请用顶层 model / cliPathOverride（写在此处会被拒绝）；unset 清除' },
 ];
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -314,6 +314,7 @@ import {
   deriveRiffReposFromDirs,
   deriveRiffRepoFromWorkingDir,
   isValidRiffBaseUrl,
+  isValidRiffJwtHome,
   isValidRiffSandboxCluster,
   type RiffBackendConfig,
 } from './adapters/backend/riff-backend.js';
@@ -12851,6 +12852,9 @@ async function spawnCli(
     }
     if (riffCfg.sandboxCluster !== undefined && !isValidRiffSandboxCluster(riffCfg.sandboxCluster)) {
       throw new Error(`riff sandboxCluster 非法（仅支持 boe/cn，当前: ${JSON.stringify(riffCfg.sandboxCluster)}）——请在 dashboard 的 Riff 配置中重新选择`);
+    }
+    if (riffCfg.jwtHome !== undefined && !isValidRiffJwtHome(riffCfg.jwtHome)) {
+      throw new Error(`riff jwtHome 非法（需绝对路径，如 /home/alice，当前: ${JSON.stringify(riffCfg.jwtHome)}）——留空则用 daemon 自身的 HOME`);
     }
     const sessionEnv: Record<string, string> = {
       BOTMUX_SESSION_ID: cfg.sessionId,

--- a/test/riff-jwt-home.test.ts
+++ b/test/riff-jwt-home.test.ts
@@ -1,12 +1,15 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   isValidRiffJwtHome,
   readBytecloudKeychainJwt,
+  refreshBytecloudJwt,
   resolveRiffJwtIdentity,
   RiffBackend,
+  JWT_REFRESH_DEBOUNCE_MS,
+  __resetJwtRefreshDebounceForTest,
 } from '../src/adapters/backend/riff-backend.js';
 
 /**
@@ -167,5 +170,110 @@ describe('riff JWT identity — end to end against a real on-disk keychain', () 
     // Ties resolveRiffJwtIdentity to the reader it feeds, so the two cannot drift.
     const id = resolveRiffJwtIdentity(ownerHome);
     expect(subjectOf(readBytecloudKeychainJwt(id.home, id.env))).toBe('OWNER');
+  });
+});
+
+describe('refreshBytecloudJwt — debounce/coalesce are scoped PER IDENTITY', () => {
+  beforeEach(() => { __resetJwtRefreshDebounceForTest(); });
+  afterEach(() => { __resetJwtRefreshDebounceForTest(); });
+
+  it('one identity refreshing does NOT swallow another identity\'s refresh', async () => {
+    // The bug a single global clock caused on a shared host: alice's bot
+    // refreshes, and for the next 60s every OTHER user's bot is told "false"
+    // without its command ever running — so bob sits unauthenticated behind a
+    // colleague's unrelated refresh.
+    const ran: string[] = [];
+    const runner = vi.fn(async (bin: string) => { ran.push(bin); });
+    expect(await refreshBytecloudJwt(['refresh-alice'], { runner, nowMs: 1_000, identityKey: '/home/alice' })).toBe(true);
+    expect(await refreshBytecloudJwt(['refresh-bob'], { runner, nowMs: 1_001, identityKey: '/home/bob' })).toBe(true);
+    expect(ran).toEqual(['refresh-alice', 'refresh-bob']);
+  });
+
+  it('still debounces repeat refreshes WITHIN one identity', async () => {
+    const runner = vi.fn(async () => {});
+    expect(await refreshBytecloudJwt(['x'], { runner, nowMs: 1_000, identityKey: '/home/alice' })).toBe(true);
+    expect(await refreshBytecloudJwt(['x'], { runner, nowMs: 2_000, identityKey: '/home/alice' })).toBe(false);
+    expect(runner).toHaveBeenCalledTimes(1);
+    // …and lets it through once the window has passed.
+    expect(await refreshBytecloudJwt(['x'], {
+      runner, nowMs: 1_000 + JWT_REFRESH_DEBOUNCE_MS, identityKey: '/home/alice',
+    })).toBe(true);
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent refreshes for the SAME identity onto one child', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const runner = vi.fn(async () => { await gate; });
+    const a = refreshBytecloudJwt(['x'], { runner, nowMs: 1_000, identityKey: '/home/alice' });
+    const b = refreshBytecloudJwt(['x'], { runner, nowMs: 1_001, identityKey: '/home/alice' });
+    release();
+    expect(await a).toBe(true);
+    expect(await b).toBe(true);
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('riff.jwtHome + auto-refresh — can botmux renew a sub-user\'s login?', () => {
+  let root: string;
+  let ownerHome: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    __resetJwtRefreshDebounceForTest();
+    root = mkdtempSync(join(tmpdir(), 'riff-jwt-refresh-home-'));
+    ownerHome = join(root, 'home', 'alice');   // deliberately NOT logged in
+    process.env.HOME = join(root, 'root');
+    delete process.env.BOTMUX_RIFF_JWT_REFRESH_CMD;
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    process.env = { ...savedEnv };
+    __resetJwtRefreshDebounceForTest();
+  });
+
+  const resolveWith = async (cfg: Record<string, unknown>): Promise<string | null> => {
+    const inst = new RiffBackend({ baseUrl: 'https://riff.example', ...cfg } as never, 'test');
+    return (inst as unknown as {
+      resolveJwt(o: { allowRefresh: boolean }): Promise<string | null>;
+    }).resolveJwt({ allowRefresh: true });
+  };
+
+  it('with jwtHome and an explicit jwtRefreshCmd, the operator hook IS run', async () => {
+    // The hook is the only thing that knows how to refresh as another user, so
+    // an override must not be barred from auto-refresh when one is configured.
+    const marker = join(root, 'hook-ran');
+    await resolveWith({
+      jwtHome: ownerHome,
+      jwtRefreshCmd: ['/bin/sh', '-c', `touch ${JSON.stringify(marker)}`],
+    });
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(marker)).toBe(true);
+  });
+
+  it('with jwtHome and NO explicit cmd, the daemon-identity default is NOT run', async () => {
+    // The resolved default (`bytedcli …`) runs as the daemon UID against the
+    // daemon's HOME: it would rewrite the WRONG keychain, so running it could
+    // not fix the token we are about to return.
+    //
+    // The env-configured command must be one that WOULD really create the marker
+    // if it ran — otherwise this assertion passes for the wrong reason and stays
+    // green even with the guard deleted (verified: it did).
+    const marker = join(root, 'default-ran');
+    process.env.BOTMUX_RIFF_JWT_REFRESH_CMD = `/bin/touch ${marker}`;
+    const ran = await resolveWith({ jwtHome: ownerHome });
+    const { existsSync } = await import('node:fs');
+    expect(ran).toBeNull();
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it('WITHOUT jwtHome, the env-configured default still runs (unchanged behaviour)', async () => {
+    // Control: proves the previous assertion is about the override, not about
+    // the env var being ignored generally.
+    const marker = join(root, 'daemon-default-ran');
+    process.env.BOTMUX_RIFF_JWT_REFRESH_CMD = `/bin/touch ${marker}`;
+    await resolveWith({});
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(marker)).toBe(true);
   });
 });

--- a/test/riff-jwt-home.test.ts
+++ b/test/riff-jwt-home.test.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  isValidRiffJwtHome,
+  readBytecloudKeychainJwt,
+  resolveRiffJwtIdentity,
+  RiffBackend,
+} from '../src/adapters/backend/riff-backend.js';
+
+/**
+ * riff.jwtHome — which human's ByteCloud login a riff bot authenticates as.
+ *
+ * The bug this pins: the keychain lookup is home-derived and defaulted to the
+ * DAEMON's home. On a host running one bot per person (each pointed at its own
+ * login through a per-user `cliPathOverride` wrapper) every riff bot read the
+ * daemon account's keychain and 401'd, because nobody logs the daemon account
+ * into ByteCloud.
+ */
+
+const LEAF = join('bytecloud-auth', 'keychain', 'auth', 'cn', 'default');
+const NOW_SEC = Math.floor(Date.now() / 1000);
+
+/** Structurally valid, signature-less JWT carrying `sub` (whose identity it is). */
+const makeJwt = (sub: string, expSec: number): string => {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url');
+  return `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub, exp: expSec })}.sig`;
+};
+/** Read back the `sub` so assertions name an IDENTITY, not an opaque string. */
+const subjectOf = (jwt: string | null): string | null =>
+  jwt === null ? null : (JSON.parse(Buffer.from(jwt.split('.')[1]!, 'base64url').toString()) as { sub: string }).sub;
+
+describe('resolveRiffJwtIdentity — which identity domain the keychain lookup reads', () => {
+  const ambientHome = '/home/daemonuser';
+  const ambientEnv = {
+    XDG_CONFIG_HOME: '/home/daemonuser/.config',
+    APPDATA: 'C:\\Users\\daemonuser\\AppData\\Roaming',
+    PATH: '/usr/bin',
+  } as NodeJS.ProcessEnv;
+
+  it('with no override, returns the ambient home+env UNCHANGED (default path is current behaviour)', () => {
+    const r = resolveRiffJwtIdentity(undefined, ambientHome, ambientEnv);
+    expect(r.home).toBe(ambientHome);
+    expect(r.env).toBe(ambientEnv);
+    expect(r.overridden).toBe(false);
+  });
+
+  it('an override swaps the home AND drops the home-derived env roots', () => {
+    const r = resolveRiffJwtIdentity('/home/alice', ambientHome, ambientEnv);
+    expect(r.home).toBe('/home/alice');
+    expect(r.overridden).toBe(true);
+    // These three would otherwise keep pointing at the DAEMON's account.
+    expect(r.env.XDG_CONFIG_HOME).toBeUndefined();
+    expect(r.env.APPDATA).toBeUndefined();
+    // Unrelated env is preserved — this is an identity scope, not a scrub.
+    expect(r.env.PATH).toBe('/usr/bin');
+    // The caller's env object must not be mutated.
+    expect(ambientEnv.XDG_CONFIG_HOME).toBe('/home/daemonuser/.config');
+  });
+
+  it('an override also drops AIME_* (they describe the DAEMON runtime, not the override)', () => {
+    const aime = {
+      AIME_WORKSPACE_PATH: '/aime/ws', AIME_CURRENT_USER: 'daemonuser',
+    } as NodeJS.ProcessEnv;
+    const r = resolveRiffJwtIdentity('/home/alice', ambientHome, aime);
+    expect(r.env.AIME_WORKSPACE_PATH).toBeUndefined();
+    expect(r.env.AIME_CURRENT_USER).toBeUndefined();
+  });
+
+  it('a RELATIVE override is refused and degrades to the daemon home (never resolved against cwd)', () => {
+    for (const bad of ['home/alice', './alice', '../alice', '']) {
+      const r = resolveRiffJwtIdentity(bad, ambientHome, ambientEnv);
+      expect(r.home).toBe(ambientHome);
+      expect(r.overridden).toBe(false);
+    }
+  });
+
+  it('a whitespace-only override is treated as unset', () => {
+    const r = resolveRiffJwtIdentity('   ', ambientHome, ambientEnv);
+    expect(r.overridden).toBe(false);
+    expect(r.home).toBe(ambientHome);
+  });
+});
+
+describe('isValidRiffJwtHome — spawn-gate validation', () => {
+  it('accepts an absolute path', () => {
+    expect(isValidRiffJwtHome('/home/alice')).toBe(true);
+  });
+  it('rejects relative, empty and non-string values', () => {
+    for (const bad of ['home/alice', './x', '', '   ', 42, null, undefined, {}]) {
+      expect(isValidRiffJwtHome(bad)).toBe(false);
+    }
+  });
+});
+
+describe('riff JWT identity — end to end against a real on-disk keychain', () => {
+  let root: string;
+  let ownerHome: string;
+  let daemonHome: string;
+  const savedEnv = { ...process.env };
+
+  const writeKeychain = (home: string, relRoot: string, jwt: string) => {
+    const dir = join(home, relRoot, 'bytecloud-auth', 'keychain', 'auth', 'cn');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'default'), JSON.stringify({ bytecloud_jwt: jwt }), 'utf-8');
+  };
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'riff-jwt-home-'));
+    ownerHome = join(root, 'home', 'alice');
+    daemonHome = join(root, 'root');
+    // The bot owner is logged in…
+    writeKeychain(ownerHome, join('.config', 'kaboo-cli'), makeJwt('OWNER', NOW_SEC + 86_400));
+    // …and so is the daemon account, with a LONGER-lived token. The selector
+    // picks the globally-freshest by `exp` regardless of order, so if the daemon
+    // identity leaks into the candidate list at all it WINS — which makes this
+    // the discriminating fixture rather than a coincidence of ordering.
+    writeKeychain(daemonHome, join('.config', 'kaboo-cli'), makeJwt('DAEMON', NOW_SEC + 999_999));
+    process.env.HOME = daemonHome;
+    process.env.XDG_CONFIG_HOME = join(daemonHome, '.config');
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    process.env = { ...savedEnv };
+  });
+
+  const resolve = async (jwtHome?: string): Promise<string | null> => {
+    const inst = new RiffBackend(
+      { baseUrl: 'https://riff.example', ...(jwtHome ? { jwtHome } : {}) },
+      'test-session',
+    );
+    // allowRefresh:false keeps this hermetic — no bytedcli subprocess.
+    const jwt = await (inst as unknown as {
+      resolveJwt(o: { allowRefresh: boolean }): Promise<string | null>;
+    }).resolveJwt({ allowRefresh: false });
+    return subjectOf(jwt);
+  };
+
+  it('without jwtHome, authenticates as the DAEMON account (the pre-fix behaviour, unchanged)', async () => {
+    expect(await resolve()).toBe('DAEMON');
+  });
+
+  it('with jwtHome, authenticates as the BOT OWNER even though the daemon token lives longer', async () => {
+    expect(await resolve(ownerHome)).toBe('OWNER');
+  });
+
+  it('with jwtHome, the daemon XDG_CONFIG_HOME does NOT pull the daemon token back in', async () => {
+    // Guards the exact regression the env-strip exists for: keeping the ambient
+    // env would leave kaboo/aiden/cjadk resolving under the daemon's config root
+    // and the longer-lived DAEMON token would win.
+    process.env.XDG_CONFIG_HOME = join(daemonHome, '.config');
+    expect(await resolve(ownerHome)).toBe('OWNER');
+  });
+
+  it('a relative jwtHome falls back to the daemon home rather than a cwd-relative tree', async () => {
+    expect(await resolve('home/alice')).toBe('DAEMON');
+  });
+
+  it('jwtHome pointing at a home with no login returns null (fails closed, no daemon fallback)', async () => {
+    // The whole point is identity scoping: an override that is not logged in must
+    // NOT silently fall back to whoever the daemon is.
+    expect(await resolve(join(root, 'home', 'nobody'))).toBeNull();
+  });
+
+  it('the override reaches the shared keychain reader with the same home+env', () => {
+    // Ties resolveRiffJwtIdentity to the reader it feeds, so the two cannot drift.
+    const id = resolveRiffJwtIdentity(ownerHome);
+    expect(subjectOf(readBytecloudKeychainJwt(id.home, id.env))).toBe('OWNER');
+  });
+});


### PR DESCRIPTION
fix(riff): JWT 恒读 daemon 的 $HOME，多用户共享主机上 riff bot 全部 401

## 问题

飞书群里反馈：同一台机器上，其它 bot 通过 per-user 的 `cliPathOverride`
（如 `~/.botmux/bin/claude-dw-per-user`）隔离了每个人的 bytedcli 登录态，
唯独 botmux + riff 的 bot 起不来，报 401 Unauthorized；用户核对过
kaboo / bytedcli 都是登录状态。

根因：riff 的 JWT 走 ByteCloud keychain，而 keychain 路径是从 home 推出来的，
默认取 `os.homedir()` —— 也就是 **daemon 自己的 HOME**，与 bot 归属哪个用户无关。
`cliPathOverride` 只换 CLI 二进制，不换身份来源；per-bot `env`（bots.json `env`）
也只经 `injectEnv` 进 CLI 子进程，从不进 worker 自身的 `process.env`，
而 `resolveJwt` 读的正是后者。于是每个 riff bot 都去读 daemon 账号的 keychain，
而没人会把 daemon 账号登录到 ByteCloud —— 必然 401。

实测确认（不是读代码推断）：
- `bytecloudKeychainCandidates()` 跟随 `$HOME`：同一进程改 HOME，候选路径整体平移。
- 把 `RIFF_JWT` 放进 riff `config.env` → `resolveJwt` 返回 `null`；
  放进 `process.env` → 正常返回。证明 per-bot/riff env 这一层对 JWT 解析不可见。

## 改动

新增 `riff.jwtHome`：把该 bot 的 keychain 查找定位到归属用户的 home。留空＝
daemon 的 HOME，即完全保持现状。

关键点是 **home 与 env 必须一起换**。6 个候选根里有 3 个
（kaboo-cli / aiden-cli / cjadk）在 `$XDG_CONFIG_HOME` 存在时以它为准
（macOS/Windows 同样从 env 取配置根）。只换 home、留着 daemon 的 env，实测
6 个候选里仍有 3 个落回 daemon —— 而选择器是「按 `exp` 取全局最新，与顺序无关」，
daemon 那份只要更长命就会**赢**，于是静默以错误身份认证。所以覆盖时一并摘掉
`XDG_CONFIG_HOME` / `APPDATA` / `AIME_*`，让每个候选回落到自己文档化的
`<home>/…` 默认值。

配套：
- 覆盖生效时不再触发 JWT 自动刷新——刷新命令以 daemon 身份跑、写的是 daemon 的
  keychain，而我们读的是覆盖的那份，修不好将要返回的 token，白白花掉一个 30s
  预算的子进程；而「让子进程指向别人的 HOME」只会更糟（daemon UID 写进他人 home）。
- 失败日志点名实际搜索的身份域。原文案只说「JWT not found」，正是它让用户
  反复去查一个**确实登录着**的账号——只是不是这次查的那个账号。
- spawn 前置校验：非绝对路径直接报错（相对路径会相对 daemon 的 cwd 解析，
  静默指向一个无意义的目录）；手改 bots.json 的情况在运行时也降级回 daemon home。

## 影响面

- **仅 riff 后端**：改动集中在 `riff-backend.ts` 的 JWT 解析；未覆盖时
  `resolveRiffJwtIdentity` 原样返回 ambient home+env，默认路径逐字等于原行为。
- **其它 CLI / 后端不受影响**：没有动 `adapters/cli/` 共用基类，也没动
  PtyBackend / TmuxBackend；per-bot env 与 sanitize 逻辑未改。
- **daemon 侧 orphan-cancel 同源**：`cancelRiffTaskById` 与活跃会话复用同一
  `resolveJwt`，已加 `jwtHome` 字段并实测拿到同一身份，避免 /close 用另一身份取消。
- **AIME 运行时**：显式覆盖优先于 ambient AIME（覆盖是「这个 bot 归谁」的声明）；
  未覆盖时 AIME fail-closed 边界原样保留。

## 验证

- `bun run build`、`npx tsc --noEmit` 均通过（`tsc` 的 include 不含 `test/`，
  新测试单独 typecheck 通过）。
- 新增 `test/riff-jwt-home.test.ts`，13 例，**双 runner 实跑**：
  vitest 13/13、`bun test` 13/13（已确认该文件未被 bun 腿的排除选择器 defer）。
  夹具刻意让 daemon 的 token **更长命**，因此若身份泄漏它就会赢——断言才有区分力。
- 反变异 5 个，双 runner 计数一致，全部被杀（变异脚本要求恰好命中 1 处，否则
  fail-closed 退出，避免「变异没打上」被误读成绿）：
  | 变异 | vitest | bun |
  |---|---|---|
  | 忽略 override | 6 failed | 6 fail |
  | 保留 ambient env（身份泄漏） | 5 failed | 5 fail |
  | 接受相对路径 | 2 failed | 2 fail |
  | 未命中时回落 daemon | 1 failed | 1 fail |
  | 不摘 `AIME_*` | 1 failed | 1 fail |
  变异后已比对源文件与变异前**逐字节一致**，并重跑全绿。
- 回归：riff 全套 7 文件 188/188；`bot-config-store` /
  `explicit-session-backing-cleanup` / `per-bot-env` /
  `session-backend-selector-shape` 共 64/64。
- 端到端探针（真实落盘 keychain，两个身份同时登录）：
  无覆盖 → DAEMON；`jwtHome` → OWNER；相对路径 → 回落 DAEMON；
  覆盖但该 home 未登录 → `null`（fail closed，不回落）。
  orphan-cancel 同样：无覆盖 → DAEMON，`jwtHome` → OWNER。

## 未做

未改 dashboard UI（`RIFF_UI_EDITABLE_KEYS` 未加 `jwtHome`，因此它按「隐藏字段」
被原样保留、不会被 UI 编辑冲掉）。当前经 `/config` 的 riff JSON 配置即可设置。
若需要 UI 下拉选人，建议另开 PR。

尚未 live 部署验证——本改动依赖真实多用户主机上的 ByteCloud 登录态，
需在目标机器上配 `jwtHome` 后实测。

