### PR TITLE
fix(release): release 校验 preflight 钉住的 master，消除会永久烧掉版号的 TOCTOU

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,11 @@ jobs:
     outputs:
       tag: ${{ steps.dist_tag.outputs.tag }}
       prerelease: ${{ steps.dist_tag.outputs.prerelease }}
+      # The origin/master SHA the ancestry guard below actually validated against.
+      # `release` re-checks against THIS value rather than re-fetching, so a commit
+      # landing on master mid-run cannot flip the verdict after the platform
+      # subpackages are already on npm (issue #1150).
+      master_sha: ${{ steps.master_ancestry.outputs.master_sha }}
     steps:
       - uses: actions/checkout@v6
         # fetch-depth: 0 —— 「stable 必须包含最新 master」那道闸要跑
@@ -233,6 +238,7 @@ jobs:
         # 使失败/无 Release 的 tag 不再截断下一版 changelog）——发版闸本身当时拒得没错。
         # 注意竞态：若打完 tag 后、本 job fetch 前 master 又前进了，这里会判定 tag 落后而
         # fail（fail-closed，安全方向）——重新 fetch master 后在新 HEAD 上重打 tag 即可。
+        id: master_ancestry
         if: steps.dist_tag.outputs.tag == 'latest'
         run: |
           git fetch origin master --quiet
@@ -243,6 +249,10 @@ jobs:
             exit 1
           fi
           echo "OK: tagged commit contains origin/master ($(git rev-parse --short origin/master))."
+          # PIN the exact master this verdict was computed against, so `release`
+          # can re-check the SAME fact instead of re-reading a moving ref. See the
+          # TOCTOU note on the release-side guard below.
+          echo "master_sha=$(git rev-parse origin/master)" >> "$GITHUB_OUTPUT"
 
   # ── MAIN PACKAGE PUBLISH — DELIBERATELY LAST ─────────────────────────────────
   # Publishes `botmux-workflow-core` + the main `botmux` package, then creates
@@ -392,15 +402,46 @@ jobs:
         # 注意竞态：若打完 tag 后、本 job fetch 前 master 又前进了，这里会判定 tag 落后而
         # fail（fail-closed，安全方向）——重新 fetch master 后在新 HEAD 上重打 tag 即可。
         if: steps.dist_tag.outputs.tag == 'latest'
+        env:
+          # ⚠️ TOCTOU (issue #1150): re-reading `origin/master` HERE is what burned
+          # v3.18.10. `binary-subpackages` publishes the six platform packages BEFORE
+          # this job — and it must, because the main package declares OPTIONAL deps on
+          # them and an unresolvable optional dep is a silent npm no-op that would
+          # install a binary-less main package. Those publishes are irreversible.
+          #
+          # Measured timeline of the lost release, all UTC:
+          #   09:53:46  preflight ancestry OK   (origin/master = 61620be7, the tag itself)
+          #   09:56:22  six subpackages PUBLISHED to npm        <- irreversible
+          #   09:57:47  def4275b (#1128) lands on master        <- inside the window
+          #   09:58:33  this guard REFUSES      (origin/master = def4275b)
+          #
+          # Same guard, same run, opposite verdicts, 4m47s apart — the tag never moved.
+          # Retrying cannot recover: re-tagging changes the code, so rebuilt binaries
+          # hash differently and publish-npm-if-missing.mjs correctly refuses to
+          # overwrite a published version with different content. 3.18.10 was burned.
+          #
+          # So this job re-checks the SHA preflight PINNED, not whatever master is now.
+          # The guard keeps its meaning — the tag must contain the master that was
+          # current when this release was ADMITTED — while the verdict stays immutable
+          # for the rest of the run. A commit landing mid-release belongs to the next
+          # release, not to a burned version number.
+          PINNED_MASTER: ${{ needs.preflight.outputs.master_sha }}
         run: |
-          git fetch origin master --quiet
-          if ! git merge-base --is-ancestor origin/master HEAD; then
-            echo "REFUSING: tagged commit $(git rev-parse --short HEAD) does not contain the latest origin/master ($(git rev-parse --short origin/master))."
+          if [ -z "$PINNED_MASTER" ]; then
+            echo "REFUSING: preflight pinned no master SHA, so this job cannot re-check the"
+            echo "same fact preflight admitted. Failing closed rather than re-reading a ref"
+            echo "that may have moved since (issue #1150)."
+            exit 1
+          fi
+          # Fetch by SHA — the pinned commit is not necessarily master's tip any more.
+          git fetch origin "$PINNED_MASTER" --quiet
+          if ! git merge-base --is-ancestor "$PINNED_MASTER" HEAD; then
+            echo "REFUSING: tagged commit $(git rev-parse --short HEAD) does not contain the master preflight admitted ($(git rev-parse --short "$PINNED_MASTER"))."
             echo "Stable (latest) releases must be tagged on master, or on a branch rebased onto the latest master."
             echo "Fix: rebase/merge onto origin/master then re-tag — or use a -canary/-beta/-rc suffix to publish off-master for testing."
             exit 1
           fi
-          echo "OK: tagged commit contains origin/master ($(git rev-parse --short origin/master))."
+          echo "OK: tagged commit contains the master preflight admitted ($(git rev-parse --short "$PINNED_MASTER"))."
 
       - run: bun run build
 

--- a/test/release-ancestry-pin.test.ts
+++ b/test/release-ancestry-pin.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { load as parseYaml } from 'js-yaml';
+
+/**
+ * The release pipeline must never re-derive its admission decision from a MUTABLE
+ * ref after it has already published something irreversible.
+ *
+ * WHAT BURNED v3.18.10 (issue #1150). `binary-subpackages` publishes the six
+ * platform packages to npm BEFORE the `release` job runs — and it must, because the
+ * main package declares OPTIONAL dependencies on them and npm treats an
+ * unresolvable optional dep as a silent no-op, so publishing the main package first
+ * installs a binary-less package without error. Both `preflight` and `release` then
+ * ran the same "stable must contain the latest master" guard, and each did its own
+ * `git fetch origin master`. Measured, all UTC:
+ *
+ *   09:53:46  preflight ancestry OK   (origin/master = 61620be7, the tag itself)
+ *   09:56:22  six subpackages PUBLISHED to npm        <- irreversible
+ *   09:57:47  def4275b (#1128) lands on master        <- inside the window
+ *   09:58:33  release ancestry REFUSES (origin/master = def4275b)
+ *
+ * Same guard, same run, opposite verdicts, 4m47s apart; the tag never moved.
+ * Recovery was impossible: re-tagging changes the code, so the rebuilt binaries hash
+ * differently and `publish-npm-if-missing.mjs` correctly refuses to overwrite a
+ * published version with different content. 3.18.10 is permanently a hollow version
+ * on npm — six subpackages, no main package — and we skipped to 3.18.11.
+ *
+ * WHAT THESE TESTS DEFEND: not the YAML's shape, but the claim "the release job's
+ * admission decision is the one preflight already made". Each assertion below
+ * corresponds to a regression that would silently restore the version-burning
+ * behaviour while every other check stays green:
+ *   • release re-reads origin/master        -> the original TOCTOU, verbatim
+ *   • preflight stops pinning the SHA       -> nothing for release to check against
+ *   • release stops failing closed on empty -> a missing pin silently admits
+ *
+ * Note the asymmetry that makes this worth pinning in a test: the failure is
+ * invisible in CI (no workflow linting exists in this repo) and shows up only on a
+ * real tag push, at which point a version number is already gone.
+ */
+
+const RELEASE_PATH = resolve(import.meta.dirname, '../.github/workflows/release.yml');
+const RELEASE = readFileSync(RELEASE_PATH, 'utf-8');
+
+/**
+ * Strip `#` comments so a claim can never be satisfied by prose ABOUT the claim.
+ * This file's own guard comments quote `origin/master` and `git fetch origin master`
+ * repeatedly while explaining the bug; without stripping, the "does not re-read"
+ * assertion would be satisfied by the very comment warning against re-reading.
+ */
+const stripComments = (yaml: string): string => yaml
+  .split('\n')
+  .map((line) => line.replace(/(^|\s)#.*$/, '$1'))
+  .join('\n');
+
+interface WorkflowStep {
+  name?: string;
+  id?: string;
+  if?: string;
+  env?: Record<string, string>;
+  run?: string;
+}
+interface Workflow {
+  jobs: Record<string, { outputs?: Record<string, string>; steps?: WorkflowStep[] }>;
+}
+
+const workflow = parseYaml(RELEASE) as Workflow;
+
+const GUARD_NAME = 'Guard — stable release must contain the latest master';
+
+function guardStep(job: string): WorkflowStep {
+  const steps = workflow.jobs[job]?.steps ?? [];
+  const step = steps.find((s) => s.name === GUARD_NAME);
+  if (!step) throw new Error(`no step named "${GUARD_NAME}" in job "${job}"`);
+  return step;
+}
+
+describe('release pipeline — the ancestry verdict must be immutable within a run', () => {
+  it('publishes the platform subpackages BEFORE the main release job', () => {
+    // Not a preference — the ordering constraint is what makes the TOCTOU dangerous,
+    // and it is load-bearing (optional deps are a silent npm no-op if missing). If a
+    // future change inverts this, the pinning below stops being necessary and this
+    // test should be revisited rather than deleted.
+    const subpackages = (workflow.jobs['binary-subpackages'] as { needs?: string[] })?.needs ?? [];
+    const release = (workflow.jobs.release as { needs?: string[] })?.needs ?? [];
+    expect(subpackages).not.toContain('release');
+    expect(release).toContain('binary-subpackages');
+  });
+
+  it('preflight pins the exact origin/master SHA its guard validated', () => {
+    const step = guardStep('preflight');
+    expect(step.id).toBe('master_ancestry');
+    // The pin has to be the resolved SHA, written to the step's output.
+    expect(stripComments(step.run ?? '')).toMatch(/master_sha=\$\(git rev-parse origin\/master\)/);
+    expect(workflow.jobs.preflight?.outputs?.master_sha)
+      .toBe('${{ steps.master_ancestry.outputs.master_sha }}');
+  });
+
+  it('release verifies the pinned SHA and never re-reads origin/master', () => {
+    const step = guardStep('release');
+    expect(step.env?.PINNED_MASTER).toBe('${{ needs.preflight.outputs.master_sha }}');
+
+    const body = stripComments(step.run ?? '');
+    // The decisive assertion: the ancestry check must be against the pinned value.
+    expect(body).toMatch(/git merge-base --is-ancestor "\$PINNED_MASTER" HEAD/);
+    // …and must not consult the live ref. `git fetch origin master` and
+    // `merge-base … origin/master` are the two shapes that reintroduce the bug.
+    expect(body).not.toMatch(/git fetch origin master\b/);
+    expect(body).not.toMatch(/--is-ancestor origin\/master/);
+  });
+
+  it('release fails closed when preflight pinned nothing', () => {
+    // An empty pin must stop the release, NOT fall back to reading the live ref.
+    // Without this, a refactor that drops the preflight output would restore the
+    // original behaviour silently.
+    const body = stripComments(guardStep('release').run ?? '');
+    expect(body).toMatch(/if \[ -z "\$PINNED_MASTER" \]; then/);
+    const failClosed = body.slice(body.indexOf('if [ -z "$PINNED_MASTER" ]'));
+    expect(failClosed).toMatch(/exit 1/);
+  });
+
+  it('both sides of the pin are gated on the same condition', () => {
+    // If these two `if:`s ever diverge, either a stable release runs the check with
+    // no pin (fails closed — noisy but safe), or a prerelease pins a SHA nothing
+    // reads (harmless). Pinning them together keeps the pairing honest.
+    expect(guardStep('preflight').if).toBe("steps.dist_tag.outputs.tag == 'latest'");
+    expect(guardStep('release').if).toBe("steps.dist_tag.outputs.tag == 'latest'");
+  });
+});


### PR DESCRIPTION
修 #1150。

## 问题

`binary-subpackages` 把 6 个平台子包发上 npm 之后,`release` 才跑「stable 必须包含最新
master」那道闸。两个 job 各自 `git fetch origin master` **重读一次活动引用**,于是同一道闸
在同一次 run 里可以给出相反结论——而子包已经发出去了,不可逆。

v3.18.10 实测(UTC):

    09:53:46  preflight ancestry OK   (origin/master = 61620be7,即 tag 自己)
    09:56:22  6 个子包发布成功                      ← 不可逆
    09:57:47  def4275b (#1128) 落 master           ← 落在窗口内
    09:58:33  release ancestry REFUSE (origin/master = def4275b)

危险窗口 4分47秒,tag 自始至终没动过。重试也救不回来:重打 tag 就改了代码,编出的二进制
哈希不同,`publish-npm-if-missing.mjs` 会正确拒绝用不同内容覆盖同名版本。3.18.10 就此报废,
只能跳号发 3.18.11,npm 上永久留下「只有 6 个子包、没有主包」的空洞版号。

## 为什么不能改成 `binary-subpackages: needs: release`

那是 issue 里列的方案 1,**不能用**。job 自己的注释写明了原因:主包对这 6 个子包声明的是
**optional dependencies**,而 npm 对解析不了的 optional dep 是**静默 no-op**——主包先发就会
装出一个没有二进制的主包,且不报错。发布顺序本身是对的,错的是「闸读了会变的东西」。

## 修法

`preflight` 把它**实际校验过**的那个 `origin/master` SHA 钉下来并 export;`release` 改为
校验这个钉住的 SHA,不再重读 `origin/master`。闸的语义不变——tag 仍必须包含「本次发布被
准入时」的 master——但结论在一次 run 内不可变。发布中途落地的 commit 属于下一次发布,
不该烧掉一个版号。

`release` 侧 fetch 改为**按 SHA fetch**(钉住的 commit 未必还是 master tip)。
钉住的值为空时 **fail-closed**(exit 1),不退回重读活动引用。

## 验证

把 release 那一步的 shell 抽出来真跑,四种情形各自因**自己的理由**退出:

| HEAD | PINNED_MASTER | 结果 |
|---|---|---|
| 61620be7c (v3.18.10 tag) | 空 | exit 1 `REFUSING: preflight pinned no master SHA` |
| 61620be7c | 61620be7c(preflight 真钉的值) | **exit 0** `OK: contains the master preflight admitted` |
| 61620be7c | def4275b(竞态中落地的 commit) | exit 1 `does not contain the master preflight admitted` |
| 2802b44e7 (真正落后的 commit) | 61620be7c | exit 1 `does not contain...` ← **守卫仍有牙** |

第 2 行就是被烧掉的那次:旧逻辑 REFUSE、新逻辑 PASS。
第 4 行确认这次改动**没有**削弱守卫:真正落后的 tag 照样拒,且它在 preflight 就会被拦下,
子包根本不会发。

反变异:把 `master_sha` 输出改成空串 → release 步骤 exit 1(不是静默放行),已还原。
`yaml.safe_load` 解析通过,10 个 job 结构不变。

Closes #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)