### PR TITLE
fix(dashboard): Bot 配置名册搜索后行高不再被拉伸

### DIFF
--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -23542,9 +23542,14 @@ dialog select[multiple]:hover:not(:disabled) {
   box-shadow: none;
 }
 
+/* align-content:start 不能省：桌面名册被 fill-height 壳撑满，列表这一行拿到
+   整段剩余高度。grid 默认 align-content:normal(=stretch) 会把这点余量摊给
+   每个自动行——搜索只剩两三个结果时，行高从 54px 拉成几百 px，选中项变成一
+   整块色带、末位被推到面板底部。列表只按内容排、余量留白，才是名册该有的样子。 */
 .bot-defaults-page .bd-roster-list {
   display: grid;
   gap: 3px;
+  align-content: start;
   min-width: 0;
   min-height: 0;
   overflow-y: auto;

--- a/test/dashboard-bot-defaults-layout.test.ts
+++ b/test/dashboard-bot-defaults-layout.test.ts
@@ -63,6 +63,18 @@ describe('bot defaults focused layout', () => {
     expect(list).toMatch(/overscroll-behavior:\s*contain;/);
   });
 
+  it('keeps roster rows at their natural height when the filter leaves only a few', () => {
+    // The desktop shell hands the list row the whole remaining column height.
+    // A grid defaults to align-content:normal (=stretch), which splits that
+    // slack across the auto rows: filtering 56 bots down to 2 measured 348px
+    // per row instead of 54.4px, so the selected row rendered as a tall block
+    // and the last row sank to the panel floor. align-content:start makes the
+    // rows keep their content height and leaves the slack as empty space.
+    const listStart = css.indexOf('.bot-defaults-page .bd-roster-list {');
+    const list = css.slice(listStart, css.indexOf('@media (max-width: 980px)', listStart));
+    expect(list).toMatch(/align-content:\s*start;/);
+  });
+
   it('keeps the mobile roster bounded with a real scrollport instead of clipping', () => {
     // Grid auto rows keep max-content height, so the list row must be
     // forced into the remaining space (minmax(0,1fr) + min-height:0) or


### PR DESCRIPTION
## 问题

Bot 配置页左侧名册，搜索把 56 个机器人过滤到只剩两三个时，行会被拉成几百像素高——选中项渲染成一整块色带，最后一行沉到面板底部。

## 根因

桌面 fill-height 壳（`main:has(.bot-defaults-page)`，≥981px）把整列剩余高度交给 `.bd-roster-list` 这一行，而 grid 默认 `align-content: normal`（等同 `stretch`）会把这段余量**平摊给每个自动行**。

结果是行高与结果条数成反比：

| 结果条数 | 修复前行高 | 修复后行高 |
|---|---|---|
| 2 | **348px** | 54.4px |
| 12 | 55.5px | 54.4px |
| 56 | 54.4px（已溢出，无余量可摊） | 54.4px |

条数越少摊到的余量越多，所以只有搜索后条数很少时才明显；12 条时其实也被拉了 1px，只是肉眼看不出来。

## 改法

`.bot-defaults-page .bd-roster-list` 加一条 `align-content: start`，让行保持内容高度、余量留白。与同为 fill-height 页的 `.schedules-list`（`style.css:14105`）已有写法一致。

## 影响面

- 只加一条属性到 `.bot-defaults-page .bd-roster-list`（桌面 ≥981px 规则），**未改 DOM**
- **未改** 980px 以下移动端分支：移动端列表本就按内容高度排，实测 2 条 / 20 条结果的行高改动前后均为 54.4px，无变化
- `.bd-roster` 名册组件只在 Bot 配置页使用（`grep` 过 `src/dashboard/web/`，无其它引用），其它页面 / 会话类型不受影响
- 纯 CSS 视觉层，不涉及 CLI / 后端 / 平台差异

## 验证

Chromium 无头 + 仓库**真实** `style.css`（不是手写简化样式），复刻页面 DOM 结构，1440x900：

- 修复前 n=2：行高 **348px**，复现问题形态（选中行高 348px、末位行 top 从 168 掉到 519）
- 修复后 n=2：**54.4px**，两行紧贴列表顶部
- 修复后 n=12：54.4px；n=56：54.4px 且 `scrollHeight` 3212 > 视口 699，**滚动仍正常**（没把滚动改没）
- 移动端 500x900：n=2 / n=20 改动前后均为 54.4px

新增回归用例并做了**反变异**（证明它有牙，而不是恒绿）：

- 删掉 `align-content: start` → 恰好 **1 条用例转红**（正是新增那条），其余 13 条不受影响
- 恢复后 **14/14 绿**

其它：

- `bun run build` 通过
- 98 个 dashboard 测试文件：**1827 passed / 1 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
