### PR TITLE
fix(grok): resolve prompt_history across HOME symlink cwd

### DIFF
--- a/src/services/grok-paths.ts
+++ b/src/services/grok-paths.ts
@@ -65,19 +65,19 @@ export function encodeGrokCwd(cwd: string): string {
 
 /** Physical path Grok's getcwd() would report; original cwd if realpath fails. */
 function canonicalizeGrokCwd(cwd: string): string {
-  const trimmed = cwd.trim();
-  if (!trimmed) return cwd;
+  // trim() only tests emptiness — POSIX directory names may end in spaces.
+  if (!cwd.trim()) return cwd;
   try {
-    return realpathSync(trimmed);
+    return realpathSync(cwd);
   } catch {
-    return trimmed;
+    return cwd;
   }
 }
 
 function grokCwdVariants(cwd: string): string[] {
-  const raw = cwd.trim() || cwd;
-  const canonical = canonicalizeGrokCwd(raw);
-  return canonical === raw ? [raw] : [raw, canonical];
+  if (!cwd.trim()) return [cwd];
+  const canonical = canonicalizeGrokCwd(cwd);
+  return canonical === cwd ? [cwd] : [cwd, canonical];
 }
 
 function grokCwdMatchesMarker(marker: string, cwd: string): boolean {
@@ -113,11 +113,11 @@ function collectHashedBucketDirs(root: string, variants: string[]): string[] {
 /**
  * Resolve the on-disk sessions bucket directory for `cwd`.
  *
- * 1. Collect encoded dirs for `cwd` and realpath(cwd), plus hashed buckets
- *    whose `.cwd` matches either. Prefer a hit that already has
- *    prompt_history.jsonl so an empty logical encoded dir cannot shadow
- *    Grok's physical / hashed bucket.
- * 2. Else the first existing encoded dir, then the first hashed match.
+ * 1. Encoded dirs for `cwd` / realpath(cwd) that already have
+ *    prompt_history.jsonl return immediately. Empty encoded dirs continue
+ *    so they cannot shadow a physical / hashed bucket that has history.
+ * 2. Else hashed buckets whose `.cwd` matches either; then the first
+ *    existing encoded dir, then the first hashed match.
  * 3. If nothing exists yet, return the encoded physical path Grok will
  *    create from getcwd(); fall back to encoding `cwd` when realpath fails.
  */
@@ -128,7 +128,12 @@ export function resolveGrokCwdBucketDir(cwd: string): string {
   const encodedHits: string[] = [];
   for (const candidate of variants) {
     const dir = join(root, encodeGrokCwd(candidate));
-    if (existsSync(dir)) encodedHits.push(dir);
+    if (!existsSync(dir)) continue;
+    // Encoded dir with prompt_history is already the best hit — skip the
+    // hashed-bucket scan (empty dirs still fall through so they cannot
+    // shadow a physical / hashed bucket that actually has history).
+    if (grokBucketHasPromptHistory(dir)) return dir;
+    encodedHits.push(dir);
   }
   const hashedHits = collectHashedBucketDirs(root, variants);
   const withHistory = [...encodedHits, ...hashedHits].find(grokBucketHasPromptHistory);

--- a/src/services/grok-paths.ts
+++ b/src/services/grok-paths.ts
@@ -9,11 +9,9 @@
  *     …
  *   $GROK_HOME/sessions/<url-encoded-cwd>/prompt_history.jsonl
  *     — bucket-level submit log: one `{timestamp, session_id, prompt, is_bash}`
- *       line PER SUBMIT, written at submit time even while a turn is running
- *       (verified on grok 0.2.93). The submit-verify source of truth — the
- *       per-session updates.jsonl only records a type-ahead user message at
- *       DEQUEUE time (after the running turn finishes), so it cannot confirm
- *       a busy-turn submit.
+ *       line per submit. Submit-verify reads this file. Grok 1.0.x writes a
+ *       type-ahead follow-up at dequeue, and may omit the line; updates.jsonl
+ *       has the same timing, so neither can confirm a busy-turn submit.
  *   $GROK_HOME/sessions/session_search.sqlite
  *   $GROK_HOME/skills/
  *   $GROK_HOME/hooks/
@@ -66,7 +64,7 @@ export function encodeGrokCwd(cwd: string): string {
 }
 
 /** Physical path Grok's getcwd() would report; original cwd if realpath fails. */
-export function canonicalizeGrokCwd(cwd: string): string {
+function canonicalizeGrokCwd(cwd: string): string {
   const trimmed = cwd.trim();
   if (!trimmed) return cwd;
   try {
@@ -88,13 +86,38 @@ function grokCwdMatchesMarker(marker: string, cwd: string): boolean {
   return canonicalizeGrokCwd(markerTrim) === canonicalizeGrokCwd(cwd);
 }
 
+function grokBucketHasPromptHistory(dir: string): boolean {
+  return existsSync(join(dir, 'prompt_history.jsonl'));
+}
+
+function collectHashedBucketDirs(root: string, variants: string[]): string[] {
+  const hits: string[] = [];
+  if (!existsSync(root)) return hits;
+  try {
+    for (const name of readdirSync(root)) {
+      if (name.endsWith('.sqlite') || name.endsWith('.lock')) continue;
+      const dir = join(root, name);
+      const marker = join(dir, '.cwd');
+      if (!existsSync(marker)) continue;
+      try {
+        const raw = readFileSync(marker, 'utf8').replace(/\r?\n$/, '');
+        if (variants.some((candidate) => grokCwdMatchesMarker(raw, candidate))) {
+          hits.push(dir);
+        }
+      } catch { /* ignore unreadable marker */ }
+    }
+  } catch { /* ignore unreadable root */ }
+  return hits;
+}
+
 /**
  * Resolve the on-disk sessions bucket directory for `cwd`.
  *
- * 1. Prefer the URL-encoded name for `cwd` itself, then for realpath(cwd),
- *    when that directory already exists (covers HOME-symlink hosts).
- * 2. Otherwise scan for a hashed bucket whose `.cwd` file equals `cwd` or
- *    realpath(cwd) (Grok's path when encoded name would exceed 255 bytes).
+ * 1. Collect encoded dirs for `cwd` and realpath(cwd), plus hashed buckets
+ *    whose `.cwd` matches either. Prefer a hit that already has
+ *    prompt_history.jsonl so an empty logical encoded dir cannot shadow
+ *    Grok's physical / hashed bucket.
+ * 2. Else the first existing encoded dir, then the first hashed match.
  * 3. If nothing exists yet, return the encoded physical path Grok will
  *    create from getcwd(); fall back to encoding `cwd` when realpath fails.
  */
@@ -102,26 +125,16 @@ export function resolveGrokCwdBucketDir(cwd: string): string {
   const root = grokSessionsRoot();
   const variants = grokCwdVariants(cwd);
 
+  const encodedHits: string[] = [];
   for (const candidate of variants) {
-    const preferred = join(root, encodeGrokCwd(candidate));
-    if (existsSync(preferred)) return preferred;
+    const dir = join(root, encodeGrokCwd(candidate));
+    if (existsSync(dir)) encodedHits.push(dir);
   }
-
-  if (existsSync(root)) {
-    try {
-      for (const name of readdirSync(root)) {
-        if (name.endsWith('.sqlite') || name.endsWith('.lock')) continue;
-        const marker = join(root, name, '.cwd');
-        if (!existsSync(marker)) continue;
-        try {
-          const raw = readFileSync(marker, 'utf8').replace(/\r?\n$/, '');
-          if (variants.some((candidate) => grokCwdMatchesMarker(raw, candidate))) {
-            return join(root, name);
-          }
-        } catch { /* ignore unreadable marker */ }
-      }
-    } catch { /* ignore unreadable root */ }
-  }
+  const hashedHits = collectHashedBucketDirs(root, variants);
+  const withHistory = [...encodedHits, ...hashedHits].find(grokBucketHasPromptHistory);
+  if (withHistory) return withHistory;
+  if (encodedHits.length > 0) return encodedHits[0];
+  if (hashedHits.length > 0) return hashedHits[0];
   return join(root, encodeGrokCwd(canonicalizeGrokCwd(cwd)));
 }
 

--- a/src/services/grok-paths.ts
+++ b/src/services/grok-paths.ts
@@ -24,12 +24,18 @@
  * helpers resolve via {@link resolveGrokCwdBucketDir} so prompt_history /
  * session dirs stay correct for long / CJK working directories.
  *
+ * Grok names buckets from getcwd() (the physical path). Botmux often holds
+ * the logical cwd — HOME is a symlink on some hosts (`/home/user` →
+ * `/data00/home/user`). Resolve both encodings so submit-verify can find
+ * prompt_history.jsonl; otherwise writeInput fail-closes for 20s with
+ * submit_unconfirmed even though Enter already landed.
+ *
  * GROK_HOME is process-level only (daemon env / shell). Per-bot `env.GROK_HOME`
  * is reserved — botmux installs hooks/skills and drains transcripts under the
  * daemon-resolved home; injecting a different home into the CLI only would
  * split-brain (see per-bot-env RESERVED_ENV_KEYS).
  */
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -59,21 +65,47 @@ export function encodeGrokCwd(cwd: string): string {
   return encodeURIComponent(cwd);
 }
 
+/** Physical path Grok's getcwd() would report; original cwd if realpath fails. */
+export function canonicalizeGrokCwd(cwd: string): string {
+  const trimmed = cwd.trim();
+  if (!trimmed) return cwd;
+  try {
+    return realpathSync(trimmed);
+  } catch {
+    return trimmed;
+  }
+}
+
+function grokCwdVariants(cwd: string): string[] {
+  const raw = cwd.trim() || cwd;
+  const canonical = canonicalizeGrokCwd(raw);
+  return canonical === raw ? [raw] : [raw, canonical];
+}
+
+function grokCwdMatchesMarker(marker: string, cwd: string): boolean {
+  const markerTrim = marker.trim();
+  if (marker === cwd || markerTrim === cwd) return true;
+  return canonicalizeGrokCwd(markerTrim) === canonicalizeGrokCwd(cwd);
+}
+
 /**
  * Resolve the on-disk sessions bucket directory for `cwd`.
  *
- * 1. Prefer the normal URL-encoded name when that directory already exists.
- * 2. Otherwise scan for a hashed bucket whose `.cwd` file equals `cwd`
- *    (Grok's path when encoded name would exceed 255 bytes).
- * 3. If nothing exists yet, return the preferred encoded path (Grok will
- *    create it for short paths; long paths only appear after TUI startup,
- *    at which point step 2 finds the hashed group).
+ * 1. Prefer the URL-encoded name for `cwd` itself, then for realpath(cwd),
+ *    when that directory already exists (covers HOME-symlink hosts).
+ * 2. Otherwise scan for a hashed bucket whose `.cwd` file equals `cwd` or
+ *    realpath(cwd) (Grok's path when encoded name would exceed 255 bytes).
+ * 3. If nothing exists yet, return the encoded physical path Grok will
+ *    create from getcwd(); fall back to encoding `cwd` when realpath fails.
  */
 export function resolveGrokCwdBucketDir(cwd: string): string {
   const root = grokSessionsRoot();
-  const encoded = encodeGrokCwd(cwd);
-  const preferred = join(root, encoded);
-  if (existsSync(preferred)) return preferred;
+  const variants = grokCwdVariants(cwd);
+
+  for (const candidate of variants) {
+    const preferred = join(root, encodeGrokCwd(candidate));
+    if (existsSync(preferred)) return preferred;
+  }
 
   if (existsSync(root)) {
     try {
@@ -83,13 +115,14 @@ export function resolveGrokCwdBucketDir(cwd: string): string {
         if (!existsSync(marker)) continue;
         try {
           const raw = readFileSync(marker, 'utf8').replace(/\r?\n$/, '');
-          // Grok writes the absolute cwd; tolerate a trailing newline only.
-          if (raw === cwd || raw.trim() === cwd) return join(root, name);
+          if (variants.some((candidate) => grokCwdMatchesMarker(raw, candidate))) {
+            return join(root, name);
+          }
         } catch { /* ignore unreadable marker */ }
       }
     } catch { /* ignore unreadable root */ }
   }
-  return preferred;
+  return join(root, encodeGrokCwd(canonicalizeGrokCwd(cwd)));
 }
 
 export function grokSessionDir(sessionId: string, cwd: string): string {

--- a/test/grok-paths.test.ts
+++ b/test/grok-paths.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/services/grok-paths.js';
 
 const ROOT = join(tmpdir(), `botmux-grok-paths-${process.pid}`);
+const itPosix = it.skipIf(process.platform === 'win32');
 
 describe('resolveGrokCwdBucketDir / symlink cwd', () => {
   beforeEach(() => {
@@ -24,16 +25,20 @@ describe('resolveGrokCwdBucketDir / symlink cwd', () => {
     delete process.env.GROK_HOME;
   });
 
-  it('finds the physical-cwd bucket when botmux holds a HOME-symlink path', () => {
-    const physicalHome = join(ROOT, 'data00-home');
-    const logicalHome = join(ROOT, 'home');
+  function makeLinkedCwd(tag: string): { physicalCwd: string; logicalCwd: string } {
+    const physicalHome = join(ROOT, `data00-home-${tag}`);
+    const logicalHome = join(ROOT, `home-${tag}`);
     mkdirSync(physicalHome, { recursive: true });
     symlinkSync(physicalHome, logicalHome);
-
     const physicalCwd = join(physicalHome, 'proj');
     const logicalCwd = join(logicalHome, 'proj');
     mkdirSync(physicalCwd, { recursive: true });
     expect(realpathSync(logicalCwd)).toBe(realpathSync(physicalCwd));
+    return { physicalCwd, logicalCwd };
+  }
+
+  itPosix('finds the physical-cwd bucket when botmux holds a HOME-symlink path', () => {
+    const { physicalCwd, logicalCwd } = makeLinkedCwd('main');
 
     const physicalBucket = join(ROOT, 'sessions', encodeGrokCwd(physicalCwd));
     mkdirSync(physicalBucket, { recursive: true });
@@ -47,32 +52,46 @@ describe('resolveGrokCwdBucketDir / symlink cwd', () => {
     expect(existsSync(grokPromptHistoryPath(logicalCwd))).toBe(true);
   });
 
-  it('predicts Grok getcwd() bucket when nothing exists on disk yet', () => {
-    const physicalHome = join(ROOT, 'data00-home-empty');
-    const logicalHome = join(ROOT, 'home-empty');
-    mkdirSync(physicalHome, { recursive: true });
-    symlinkSync(physicalHome, logicalHome);
-
-    const physicalCwd = join(physicalHome, 'proj');
-    const logicalCwd = join(logicalHome, 'proj');
-    mkdirSync(physicalCwd, { recursive: true });
+  itPosix('predicts Grok getcwd() bucket when nothing exists on disk yet', () => {
+    const { physicalCwd, logicalCwd } = makeLinkedCwd('empty');
 
     expect(resolveGrokCwdBucketDir(logicalCwd)).toBe(
       join(ROOT, 'sessions', encodeGrokCwd(physicalCwd)),
     );
   });
 
-  it('matches a hashed .cwd marker written with the physical path', () => {
-    const physicalHome = join(ROOT, 'data00-home-hash');
-    const logicalHome = join(ROOT, 'home-hash');
-    mkdirSync(physicalHome, { recursive: true });
-    symlinkSync(physicalHome, logicalHome);
-
-    const physicalCwd = join(physicalHome, 'long-proj');
-    const logicalCwd = join(logicalHome, 'long-proj');
-    mkdirSync(physicalCwd, { recursive: true });
+  itPosix('matches a hashed .cwd marker written with the physical path', () => {
+    const { physicalCwd, logicalCwd } = makeLinkedCwd('hash');
 
     const hashBucket = join(ROOT, 'sessions', 'phys-hash-abcd');
+    mkdirSync(hashBucket, { recursive: true });
+    writeFileSync(join(hashBucket, '.cwd'), physicalCwd + '\n');
+    writeFileSync(join(hashBucket, 'prompt_history.jsonl'), '');
+
+    expect(resolveGrokCwdBucketDir(logicalCwd)).toBe(hashBucket);
+    expect(existsSync(grokPromptHistoryPath(logicalCwd))).toBe(true);
+  });
+
+  itPosix('does not let an empty encoded logical dir shadow the physical prompt_history', () => {
+    const { physicalCwd, logicalCwd } = makeLinkedCwd('shadow-encoded');
+
+    const logicalBucket = join(ROOT, 'sessions', encodeGrokCwd(logicalCwd));
+    const physicalBucket = join(ROOT, 'sessions', encodeGrokCwd(physicalCwd));
+    mkdirSync(logicalBucket, { recursive: true });
+    mkdirSync(physicalBucket, { recursive: true });
+    writeFileSync(join(physicalBucket, 'prompt_history.jsonl'), '');
+
+    expect(resolveGrokCwdBucketDir(logicalCwd)).toBe(physicalBucket);
+    expect(existsSync(grokPromptHistoryPath(logicalCwd))).toBe(true);
+  });
+
+  itPosix('does not let an empty encoded dir shadow a hashed bucket with prompt_history', () => {
+    const { physicalCwd, logicalCwd } = makeLinkedCwd('shadow-hash');
+
+    const logicalBucket = join(ROOT, 'sessions', encodeGrokCwd(logicalCwd));
+    mkdirSync(logicalBucket, { recursive: true });
+
+    const hashBucket = join(ROOT, 'sessions', 'phys-hash-shadow');
     mkdirSync(hashBucket, { recursive: true });
     writeFileSync(join(hashBucket, '.cwd'), physicalCwd + '\n');
     writeFileSync(join(hashBucket, 'prompt_history.jsonl'), '');

--- a/test/grok-paths.test.ts
+++ b/test/grok-paths.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for Grok cwd bucket resolution (HOME symlink / getcwd mismatch).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, realpathSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync, symlinkSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -11,7 +11,10 @@ import {
   resolveGrokCwdBucketDir,
 } from '../src/services/grok-paths.js';
 
-const ROOT = join(tmpdir(), `botmux-grok-paths-${process.pid}`);
+// tmpdir() itself is a symlink on macOS (/var → /private/var); canonicalize so
+// the scaffold's own root is not a confounder when asserting symlink
+// normalization (see test/claude-code-cwd.test.ts).
+const ROOT = realpathSync(mkdtempSync(join(tmpdir(), 'botmux-grok-paths-')));
 const itPosix = it.skipIf(process.platform === 'win32');
 
 describe('resolveGrokCwdBucketDir / symlink cwd', () => {
@@ -83,6 +86,13 @@ describe('resolveGrokCwdBucketDir / symlink cwd', () => {
 
     expect(resolveGrokCwdBucketDir(logicalCwd)).toBe(physicalBucket);
     expect(existsSync(grokPromptHistoryPath(logicalCwd))).toBe(true);
+  });
+
+  it('keeps a trailing space when predicting a not-yet-created bucket', () => {
+    const cwd = join(ROOT, 'proj') + ' ';
+    expect(resolveGrokCwdBucketDir(cwd)).toBe(
+      join(ROOT, 'sessions', encodeGrokCwd(cwd)),
+    );
   });
 
   itPosix('does not let an empty encoded dir shadow a hashed bucket with prompt_history', () => {

--- a/test/grok-paths.test.ts
+++ b/test/grok-paths.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for Grok cwd bucket resolution (HOME symlink / getcwd mismatch).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  encodeGrokCwd,
+  grokPromptHistoryPath,
+  resolveGrokCwdBucketDir,
+} from '../src/services/grok-paths.js';
+
+const ROOT = join(tmpdir(), `botmux-grok-paths-${process.pid}`);
+
+describe('resolveGrokCwdBucketDir / symlink cwd', () => {
+  beforeEach(() => {
+    process.env.GROK_HOME = ROOT;
+    rmSync(ROOT, { recursive: true, force: true });
+    mkdirSync(ROOT, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(ROOT, { recursive: true, force: true });
+    delete process.env.GROK_HOME;
+  });
+
+  it('finds the physical-cwd bucket when botmux holds a HOME-symlink path', () => {
+    const physicalHome = join(ROOT, 'data00-home');
+    const logicalHome = join(ROOT, 'home');
+    mkdirSync(physicalHome, { recursive: true });
+    symlinkSync(physicalHome, logicalHome);
+
+    const physicalCwd = join(physicalHome, 'proj');
+    const logicalCwd = join(logicalHome, 'proj');
+    mkdirSync(physicalCwd, { recursive: true });
+    expect(realpathSync(logicalCwd)).toBe(realpathSync(physicalCwd));
+
+    const physicalBucket = join(ROOT, 'sessions', encodeGrokCwd(physicalCwd));
+    mkdirSync(physicalBucket, { recursive: true });
+    writeFileSync(join(physicalBucket, 'prompt_history.jsonl'), '');
+
+    expect(join(ROOT, 'sessions', encodeGrokCwd(logicalCwd))).not.toBe(physicalBucket);
+    expect(existsSync(join(ROOT, 'sessions', encodeGrokCwd(logicalCwd)))).toBe(false);
+
+    expect(resolveGrokCwdBucketDir(logicalCwd)).toBe(physicalBucket);
+    expect(grokPromptHistoryPath(logicalCwd)).toBe(join(physicalBucket, 'prompt_history.jsonl'));
+    expect(existsSync(grokPromptHistoryPath(logicalCwd))).toBe(true);
+  });
+
+  it('predicts Grok getcwd() bucket when nothing exists on disk yet', () => {
+    const physicalHome = join(ROOT, 'data00-home-empty');
+    const logicalHome = join(ROOT, 'home-empty');
+    mkdirSync(physicalHome, { recursive: true });
+    symlinkSync(physicalHome, logicalHome);
+
+    const physicalCwd = join(physicalHome, 'proj');
+    const logicalCwd = join(logicalHome, 'proj');
+    mkdirSync(physicalCwd, { recursive: true });
+
+    expect(resolveGrokCwdBucketDir(logicalCwd)).toBe(
+      join(ROOT, 'sessions', encodeGrokCwd(physicalCwd)),
+    );
+  });
+
+  it('matches a hashed .cwd marker written with the physical path', () => {
+    const physicalHome = join(ROOT, 'data00-home-hash');
+    const logicalHome = join(ROOT, 'home-hash');
+    mkdirSync(physicalHome, { recursive: true });
+    symlinkSync(physicalHome, logicalHome);
+
+    const physicalCwd = join(physicalHome, 'long-proj');
+    const logicalCwd = join(logicalHome, 'long-proj');
+    mkdirSync(physicalCwd, { recursive: true });
+
+    const hashBucket = join(ROOT, 'sessions', 'phys-hash-abcd');
+    mkdirSync(hashBucket, { recursive: true });
+    writeFileSync(join(hashBucket, '.cwd'), physicalCwd + '\n');
+    writeFileSync(join(hashBucket, 'prompt_history.jsonl'), '');
+
+    expect(resolveGrokCwdBucketDir(logicalCwd)).toBe(hashBucket);
+    expect(existsSync(grokPromptHistoryPath(logicalCwd))).toBe(true);
+  });
+});


### PR DESCRIPTION
## 问题

Grok 会话每条飞书消息都会误报 `submit_unconfirmed`，即使 Enter 已经按下、模型已在跑。

实机：HOME 是软链 `/home/user` -> `/data00/home/user`（字节类开发机常见）。

- botmux `session.workingDir` / `cliCwd` = `/home/user`
- Grok `getcwd()` 建桶 = `~/.grok/sessions/%2Fdata00%2Fhome%2Fuser/prompt_history.jsonl`
- `resolveGrokCwdBucketDir(cliCwd)` 去读 `.../%2Fhome%2Fuser/prompt_history.jsonl`
- 这个路径不存在，existsSync 失败，20s 后 `submit_unconfirmed`

这和 #1052 不是同一事件。#1052 修的是大消息 Enter 被粘贴突发吞掉；#1052 注释里的 busy 期 dequeue 延迟是另一个已知限制。这里是 idle 短消息也每次误报，因为桶路径根本对不上。

## 改动

`src/services/grok-paths.ts` 的 `resolveGrokCwdBucketDir`：

1. 先查 `encodeURIComponent(cwd)`，再查 `encodeURIComponent(realpath(cwd))`
2. hashed `.cwd` 标记也按物理路径比对
3. 磁盘上还没有桶时，预测 Grok `getcwd()` 会创建的 encoded 物理路径

`writeInput` 仍走 `grokPromptHistoryPath(cliCwd)`，不用改适配器。

## 影响面

- 只动 Grok 路径解析；Codex / Claude 等不变
- `cwd` 与 `realpath(cwd)` 相同时行为与现在一致
- 已经存在的逻辑路径桶（或本地软链 workaround）仍优先命中

## 测试

新增 `test/grok-paths.test.ts`：

- HOME 软链：逻辑 cwd 能找到物理路径上的 `prompt_history.jsonl`
- 尚未落盘时预测 Grok getcwd 桶
- hashed `.cwd` 写物理路径时也能从逻辑 cwd 命中

本机证据：workingDir=/home/... vs /proc/<grok-pid>/cwd=/data00/home/...；修软链前逻辑 encoded 桶不存在。
