### PR TITLE
fix(bridge): 重启后不再把历史 provider 错误重放成「本轮执行失败」

### DIFF
--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -164,6 +164,21 @@ export class BridgeTurnQueue {
   private seen = new Set<string>();
   private queue: BridgePendingTurn[] = [];
   private collecting: BridgePendingTurn | null = null;
+  /** Lark turns removed by the head-of-line drop, awaiting journal cleanup by
+   *  the worker. This queue is pure (no fs), so it cannot clear the durable
+   *  journal itself — it reports, the worker retires. Same contract as
+   *  `pruneExpired`'s return value, just accumulated because the drop happens
+   *  deep inside ingest() rather than at an explicit call boundary. */
+  private droppedNeedingJournalClear: BridgePendingTurn[] = [];
+
+  /** Hand over (and forget) the turns dropped head-of-line since the last
+   *  call. The worker drains this after every ingest and clears each one's
+   *  journal entry; leaving them would let a later restart re-mark a turn
+   *  that can never complete. */
+  takeDroppedNeedingJournalClear(): BridgePendingTurn[] {
+    if (this.droppedNeedingJournalClear.length === 0) return [];
+    return this.droppedNeedingJournalClear.splice(0);
+  }
 
   /** Register events as historical — their uuids are now considered seen
    *  but no attribution happens. Used at attach time to baseline. */
@@ -425,6 +440,15 @@ export class BridgeTurnQueue {
       && this.collecting.assistantUuids.length === 0) {
       const idx = this.queue.indexOf(this.collecting);
       if (idx >= 0) this.queue.splice(idx, 1);
+      // This turn will never reach drainEmittable, which is where the worker
+      // retires its durable journal entry. Record it so the worker can clear
+      // the journal here too — otherwise the entry survives, and every later
+      // restart re-marks it and replays the same stretch of transcript. That
+      // is not hypothetical: one entry was restored on six consecutive
+      // restarts, twice resurfacing a hours-old provider error as a fresh
+      // 「本轮执行失败」card. Local turns are skipped: they are synthesised by
+      // this queue and never had a journal entry to begin with.
+      if (!this.collecting.isLocal) this.droppedNeedingJournalClear.push(this.collecting);
       this.collecting = null;
     }
     const tsParsed = ev.timestamp ? Date.parse(ev.timestamp) : NaN;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5719,6 +5719,15 @@ function bridgeDrainAndMaybeEmit(): void {
  *  Caches per-path drains so a batch of turns from the same file only reads
  *  the transcript once (O(jsonl size) per distinct path). */
 function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
+  // Retire the journal entries of turns the queue dropped head-of-line. These
+  // never reach `ready`, so this must run BEFORE the empty-`ready` early return
+  // below — a drop very often coincides with a tick that emits nothing.
+  for (const dropped of bridgeQueue.takeDroppedNeedingJournalClear()) {
+    journalBridgeTurnClear(dropped.turnId, dropped.dispatchAttempt);
+    if (dropped.contentFingerprint) bridgeFingerprintScanLastMs.delete(dropped.contentFingerprint);
+    log(`Bridge journal cleared for head-of-line dropped turn ${dropped.turnId.substring(0, 8)} `
+      + `— it produced no assistant text and a newer turn started`);
+  }
   const ready = bridgeQueue.drainEmittable(opts.explicitTerminalOnly
     ? { explicitTerminalOnly: true }
     : {
@@ -5881,6 +5890,28 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
   for (const turn of ready) {
     if (turn.rateLimited) continue;
     const outcome = turn.terminalOutcome;
+    // A SYNTHESISED local turn has no Lark turn behind it: `local-*` /
+    // `local-headless-*` ids are minted by the queue for transcript activity
+    // that matched no pending mark (terminal-typed input, or — after a restart
+    // — replayed history whose original mark is long gone). Its FALLBACK is
+    // already suppressed unconditionally (shouldSuppressBridgeEmit returns true
+    // for isLocal in non-adopt), so letting its FAILURE terminal through means
+    // the daemon posts a 「本轮执行失败」card for a turn the user never sent —
+    // and, because the daemon stamps the card with `new Date()` and the
+    // session's *current* lastUserPrompt, that card names the wrong time and
+    // the wrong task. MEASURED: a provider_server_error from 10h earlier was
+    // re-surfaced as a fresh failure card on two consecutive daemon restarts.
+    //
+    // Scoped deliberately to the failure arm: a local turn's `completed`
+    // terminal stays, because that is what settles bookkeeping (dedupe claim,
+    // durable-turn release, CoT finalize) without showing the user anything.
+    // Non-local turns are untouched — a real Lark turn that genuinely failed
+    // must still raise its card, which is the whole point of that path.
+    if (turn.isLocal && outcome && outcome.status !== 'completed') {
+      log(`Bridge terminal suppressed for synthesised local turn ${turn.turnId.substring(0, 8)} `
+        + `(${outcome.status}${outcome.errorCode ? `/${outcome.errorCode}` : ''}) — no Lark turn to notify`);
+      continue;
+    }
     emitTurnTerminal(
       turn.turnId,
       outcome?.status ?? 'completed',

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -13,6 +13,7 @@
  *     yet (e.g. Claude is still in tool-use mid-turn)
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { BridgeTurnQueue, makeFingerprint, isTruncatedMatch } from '../src/services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from '../src/services/bridge-fallback-gate.js';
 import type { TranscriptEvent } from '../src/services/claude-transcript.js';
@@ -1147,6 +1148,86 @@ describe('BridgeTurnQueue', () => {
       expect(ready[0].isLocal).toBe(true); // emitted, not dropped
       const t1 = q.peek().find(t => t.turnId === 't1');
       expect(t1?.started).toBe(false); // mark untouched
+    });
+  });
+
+  /**
+   * Head-of-line drop must report the turn so the worker can retire its
+   * durable journal entry.
+   *
+   * The bug: `handleTurnStart` spliced a text-less collecting turn out of the
+   * queue, so it never reached `drainEmittable` — the ONLY place the worker
+   * clears the journal. The entry survived, and every later restart re-marked
+   * it and re-drained the transcript from its recorded offset. MEASURED on a
+   * live session: one entry restored across six consecutive restarts, twice
+   * resurfacing an hours-old provider error as a fresh 「本轮执行失败」card.
+   *
+   * These assert the REPORTING contract only (the queue is pure — it cannot
+   * touch the filesystem). Worker-side wiring is asserted separately.
+   */
+  describe('head-of-line drop → journal cleanup reporting', () => {
+    it('reports a Lark turn dropped head-of-line so its journal entry can be retired', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('lark-1', makeFingerprint('first message'), 100, makeFingerprintFull('first message'));
+      // The turn starts but Claude never writes assistant text for it...
+      q.ingest([user('u1', 'first message')]);
+      expect(q.peek()[0].started).toBe(true);
+      expect(q.takeDroppedNeedingJournalClear()).toEqual([]); // nothing dropped yet
+      // ...then a newer turn-start arrives → head-of-line drop.
+      q.ingest([user('u2', 'second message')]);
+      const dropped = q.takeDroppedNeedingJournalClear();
+      expect(dropped.map(t => t.turnId)).toEqual(['lark-1']);
+      // The turn really is gone from the queue (this is what made it unreachable).
+      expect(q.peek().some(t => t.turnId === 'lark-1')).toBe(false);
+    });
+
+    it('is drain-once: a second take returns nothing', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('lark-1', makeFingerprint('first message'), 100, makeFingerprintFull('first message'));
+      q.ingest([user('u1', 'first message')]);
+      q.ingest([user('u2', 'second message')]);
+      expect(q.takeDroppedNeedingJournalClear()).toHaveLength(1);
+      // Without this, the worker would re-clear (harmless) or re-log forever.
+      expect(q.takeDroppedNeedingJournalClear()).toEqual([]);
+    });
+
+    it('does NOT report synthesised local turns — they never had a journal entry', () => {
+      const q = new BridgeTurnQueue();
+      // A local turn is synthesised by the queue itself (no Lark mark behind
+      // it), so reporting one would make the worker clear an entry it never
+      // wrote — and `local-<uuid>` can collide with nothing, so the clear
+      // would be a silent no-op that still burns a journal read+write.
+      q.ingest([user('local-u1', 'typed in the terminal')]);
+      expect(q.peek()[0].isLocal).toBe(true);
+      q.ingest([user('local-u2', 'typed again')]);
+      expect(q.takeDroppedNeedingJournalClear()).toEqual([]);
+    });
+
+    it('does NOT report a turn that produced assistant text (it drains normally)', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('lark-1', makeFingerprint('first message'), 100, makeFingerprintFull('first message'));
+      q.ingest([user('u1', 'first message'), assistant('a1', 'a real answer')]);
+      q.ingest([user('u2', 'second message')]);
+      // It has text, so it stays queued and the worker retires its journal
+      // entry the normal way, at drainEmittable.
+      expect(q.takeDroppedNeedingJournalClear()).toEqual([]);
+      expect(q.drainEmittable({ terminalBoundary: true }).map(t => t.turnId)).toContain('lark-1');
+    });
+
+    it('worker.ts drains the report BEFORE the empty-ready early return', () => {
+      // Wiring, not policy: a queue that reports perfectly is inert if nobody
+      // drains it. Ordering matters — a head-of-line drop usually lands on a
+      // tick that emits nothing, so draining after `if (ready.length === 0)
+      // return;` would skip exactly the case this fix exists for.
+      const source = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+      const fn = source.slice(source.indexOf('function emitReadyTurns('));
+      const drainAt = fn.indexOf('takeDroppedNeedingJournalClear()');
+      const earlyReturnAt = fn.indexOf('if (ready.length === 0) return;');
+      expect(drainAt).toBeGreaterThan(-1);
+      expect(earlyReturnAt).toBeGreaterThan(-1);
+      expect(drainAt).toBeLessThan(earlyReturnAt);
+      // ...and it must actually retire the journal entry, not just log.
+      expect(fn.slice(drainAt, earlyReturnAt)).toContain('journalBridgeTurnClear(');
     });
   });
 });

--- a/test/claude-turn-terminal-contract.test.ts
+++ b/test/claude-turn-terminal-contract.test.ts
@@ -53,6 +53,10 @@ class ContractHarness {
     for (const turn of this.queue.drainEmittable({ explicitTerminalOnly: true })) {
       if (turn.rateLimited) continue;
       const outcome = turn.terminalOutcome;
+      // Mirrors worker.ts emitReadyTurns: a SYNTHESISED local turn has no Lark
+      // turn behind it, so its failure must not reach the daemon (which would
+      // render a user-facing 「本轮执行失败」card for a turn nobody sent).
+      if (turn.isLocal && outcome && outcome.status !== 'completed') continue;
       this.emit(
         turn.turnId,
         turn.dispatchAttempt!,
@@ -275,5 +279,100 @@ describe('Claude durable turn terminal contract', () => {
     expect(source).toContain("'terminal_bridge_unavailable'");
     expect(source).toMatch(/emitTurnTerminal\([\s\S]*?'ambiguous',[\s\S]*?'cli_exit'/);
     expect(source).toContain('requireExplicitTerminalForDurable: true');
+  });
+
+  /**
+   * A synthesised local turn must never raise a user-visible failure.
+   *
+   * `local-*` / `local-headless-*` ids are minted by the attribution queue for
+   * transcript activity that matched no pending Lark mark — terminal-typed
+   * input, or (after a restart) replayed history whose original mark is gone.
+   * Its transcript FALLBACK is already suppressed unconditionally, but its
+   * TERMINAL used to flow straight through, and the daemon renders any
+   * non-completed terminal as a 「本轮执行失败」card stamped `new Date()` plus
+   * the session's CURRENT lastUserPrompt — so the card named the wrong time
+   * and the wrong task.
+   *
+   * MEASURED on a live session: a `provider_server_error` recorded at 09:17
+   * was re-surfaced as a fresh failure card at 16:44 and again the next day at
+   * 04:32, both times at a daemon restart. The production log is unambiguous —
+   * 33 local turns logged "suppressed" on that tick and the failing one logged
+   * nothing at all, because it took the early `continue` before the gate.
+   */
+  describe('synthesised local turns raise no user-visible failure', () => {
+    /** The exact shape claude writes when a stream dies mid-response. */
+    function connectionLost(uuid: string): TranscriptEvent {
+      return {
+        type: 'assistant',
+        uuid,
+        isApiErrorMessage: true,
+        error: 'server_error',
+        message: {
+          role: 'assistant',
+          stop_reason: 'stop_sequence',
+          content: [{
+            type: 'text',
+            text: 'API Error: Connection lost mid-response. The response above may be incomplete.',
+          }],
+        },
+      } as TranscriptEvent;
+    }
+
+    it('emits no terminal for a local turn that died with provider_server_error', () => {
+      const h = new ContractHarness();
+      // No mark() at all → the user event synthesises a local turn.
+      h.ingest([
+        user('local-u', 'something typed straight into the pane'),
+        assistant('local-a', 'partial work', 'tool_use'),
+        connectionLost('local-err'),
+        turnDuration('local-dur'),
+      ]);
+      expect(h.emitted).toEqual([]);
+    });
+
+    it('still emits the failure for a REAL Lark turn — the card must not be lost', () => {
+      // Positive control. Without this, the fix above could be "suppress
+      // everything" and the suite would not notice.
+      const h = new ContractHarness();
+      h.mark('delivery-1', 'a real lark prompt', 1);
+      h.ingest([
+        user('u1', 'a real lark prompt'),
+        assistant('a1', 'partial work', 'tool_use'),
+        connectionLost('err-1'),
+        turnDuration('dur-1'),
+      ]);
+      expect(h.emitted).toEqual([{
+        turnId: 'delivery-1',
+        dispatchAttempt: 1,
+        status: 'failed',
+        errorCode: 'provider_server_error',
+        retryable: true,
+      }]);
+    });
+
+    it('still emits a local turn\'s COMPLETED terminal (bookkeeping, invisible to the user)', () => {
+      // The gate is scoped to the failure arm only: a completed local terminal
+      // settles the dedupe claim / durable release / CoT finalize and shows the
+      // user nothing, so suppressing it too would be a silent behaviour change.
+      const h = new ContractHarness();
+      h.ingest([
+        user('local-u', 'typed in the pane'),
+        assistant('local-a', 'done', 'end_turn'),
+      ]);
+      expect(h.emitted).toHaveLength(1);
+      expect(h.emitted[0].status).toBe('completed');
+      expect(h.emitted[0].turnId.startsWith('local-')).toBe(true);
+    });
+
+    it('worker.ts gates the terminal on isLocal, not only the fallback', () => {
+      const source = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+      // The guard must live in the TERMINAL loop. Anchored on the log line so a
+      // refactor that drops the gate fails here rather than silently reopening
+      // the card path.
+      expect(source).toContain('Bridge terminal suppressed for synthesised local turn');
+      expect(source).toMatch(
+        /if \(turn\.isLocal && outcome && outcome\.status !== 'completed'\) \{/,
+      );
+    });
   });
 });

--- a/test/claude-turn-terminal-contract.test.ts
+++ b/test/claude-turn-terminal-contract.test.ts
@@ -373,6 +373,21 @@ describe('Claude durable turn terminal contract', () => {
       expect(source).toMatch(
         /if \(turn\.isLocal && outcome && outcome\.status !== 'completed'\) \{/,
       );
+      // ORDER, not merely presence. Keeping every byte of the gate but moving
+      // it one call later — below emitTurnTerminal — resurrects the phantom
+      // card exactly (the failure terminal ships, then the gate logs and
+      // `continue`s into nothing), and every string assertion above stays
+      // green. Both indices are pinned > -1 first: toBeLessThan(-1, n) passes
+      // silently, so a slice that missed the function would fake a pass.
+      const fn = source.slice(
+        source.indexOf('function emitReadyTurns('),
+        source.indexOf('function drainPathInto('),
+      );
+      const gateAt = fn.indexOf('Bridge terminal suppressed for synthesised local turn');
+      const emitAt = fn.indexOf('emitTurnTerminal(');
+      expect(gateAt).toBeGreaterThan(-1);
+      expect(emitAt).toBeGreaterThan(-1);
+      expect(gateAt).toBeLessThan(emitAt);
     });
   });
 });


### PR DESCRIPTION
## 问题

用户报障：一个**没有任何异常**的会话，在两次 daemon 重启时各收到一张
「⚠️ Claude 本轮执行失败 `provider_server_error`」卡。

卡上三处都对不上：失败时刻是**发卡瞬间**、任务是当时残留的另一条消息、
而那条真错误发生在 **10 小时前**。

不是误判逻辑写错，是**同一条历史错误在每次重启时被重放**。

| 卡片显示 | 实际 |
|---|---|
| `2026/8/31 09:44:35` | 重启瞬间（UTC `16:44:35`，按 daemon 宿主 PDT 渲染） |
| `2026/8/31 21:32:42` | 下一次重启（UTC `04:32:42`） |
| — | 真错误在 UTC `09:17:09` |

## 根因（两个独立缺陷叠加）

**1. 合成的 local turn 会发出用户可见的失败终态**

`local-*` / `local-headless-*` 是归因队列给「匹配不上任何 pending mark 的
transcript 活动」造的 id —— 终端手敲的输入，或重启后被重放的历史。它的
fallback 早已被无条件抑制（`shouldSuppressBridgeEmit` 对 isLocal 恒 true），
但**终态**直通 daemon，而 daemon 会把任何非 completed 终态渲染成失败卡，
并盖上 `new Date()` 与会话**当前**的 lastUserPrompt。

线上日志是直接证据：重启那一刻 33 个 local turn 打了 `suppressed` 日志，
而出事那个 `local-f1938d86` **一条都没有** —— 它在抑制门之前就被 `continue` 掉了。

**2. head-of-line drop 不回收 journal ⟹ 每次重启重放同一段**

`handleTurnStart` 把「没产出任何文本」的 collecting turn 从队列摘除时，它就
再也到不了 `drainEmittable` —— 而那是 worker 唯一清 journal 的地方。entry 残留，
之后每次重启都重新 mark 并从记录的 offset 重新 drain。那条 entry 在 6 次重启里
被反复 restore，**到今天仍躺在 journal 文件里**。

## 修法

- 终态循环里只对**失败**一侧设门。completed 终态保留（负责 dedupe claim /
  durable release / CoT finalize，对用户不可见），真实 Lark turn 完全不受影响。
- 队列是纯函数（不碰 fs），所以由它**上报**、worker **回收** —— 与
  `pruneExpired` 的返回值同一套契约。drain 放在 `ready.length === 0` 早返回
  **之前**：HOL-drop 往往正好落在一个什么都不 emit 的 tick 上。

## 刻意不改的一处（请复审重点看这里）

`bridge-turn-queue.ts` 里 api-error 用 `=` 覆盖已有终态，看着像 bug（同文件
另外两处都是 `??=`），**但它是对的**，我一开始判错了，靠证据纠回来：

- 那条 `end_turn` 的 `output_tokens = 1`，而文本有 147 字符 —— 不可能；
- 在 60 个 transcript 里搜这个形态（`end_turn` + `output_tokens=1` + 长文本）：
  出现 2 次，**两次都紧跟 api-error，脱离 api-error 出现 0 次**；
- token 数正常的那几例，尾巴全是 `Let me verify...` / `Let me report...`
  —— 宣告了下一步却从未执行；
- claude 自己标了 `truncatedAfterOutput: true`，文案也写着 "may be incomplete"。

即 `end_turn` 是**流被切断时补写的**，不是真完成。改成 `??=` 会把真正的中途
中断判成成功 —— 方向反了，会**制造**漏报。

## 影响面

仅 claude-code 的 Lark fallback bridge。`adapters/cli/` 未改动，其余 20+ CLI
走 codex/structured bridge，不经过这两处。PtyBackend / TmuxBackend 共用同一条
worker 归因路径，行为一致；adopt 会话不受影响（local turn 在 adopt 下本就照常
投递，改动只在失败终态一侧）。

## 验证

- `bun run build` 通过
- 两个测试文件 **84/84** 通过（新增 9 条）
- **差分变异 3/3 全部打红**：
  | 变异 | 结果 |
  |---|---|
  | 移除 isLocal 终态门 | 1 红 |
  | HOL-drop 停止上报 | 2 红 |
  | 把 journal drain 移到早返回之后（**真移动，非新增**） | 1 红 |
- **用线上真实 transcript + 真实 journal 跑生产代码复现**：修复前 36 个 turn 中
  恰好 1 个 `isLocal` 且 failed，两次重启逐位一致；修复后 **0 张失败卡**
- 阳性对照已打：真正的 mid-flight 中断（前面没有 end_turn）仍正确判 failed，
  失败卡照常发出 —— 修法不是「一律抑制」
- 全量 `bun run test`：本分支 6 failed / **同一 commit 的干净 base 同样 6 failed**，
  双向差集各 1 条（本侧 `listen-with-probe` 单跑 6/6 绿且只 import `node:http`，
  够不到改动文件；base 侧 `v3-daemon-run`），负载 flake 特征
  ⚠️ 注意：base **未 build 时 `plugin-mcp-sandbox` 是 skip 而非 pass**
  （`describe.skipIf(!existsSync(builtCli))`），build 后同样 2 红，为 pre-existing

## 未做

未 live 部署验证 —— 触发条件是 daemon 重启且 journal 里有残留 entry，
不便在生产上刻意制造。判据用的是「线上真实 transcript 重放 + 变异」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
