### PR TITLE
test(dashboard): 名册断言改切规则自身，避免相邻规则冒名顶替

### DIFF
--- a/test/dashboard-bot-defaults-layout.test.ts
+++ b/test/dashboard-bot-defaults-layout.test.ts
@@ -17,9 +17,16 @@ const i18n = readFileSync(new URL('../src/dashboard/web/i18n.ts', import.meta.ur
 // `.bd-roster-list` is declared TWICE — once at top level for desktop, once
 // inside @media (max-width: 980px). Every caller here wants the desktop rule,
 // which is the first match, so this takes the first and does not offer a
-// choice. Note this is no safety net for a rename: renaming the desktop rule
-// leaves the mobile copy as the first match, and what catches that is the
-// assertions failing against the wrong body.
+// choice.
+//
+// This is NOT a safety net for a rename, and the gap is only partial: rename
+// the desktop rule and the mobile copy becomes the first match. Only the
+// `align-content: start` assertion then fails, because the mobile body has no
+// such declaration; `min-height: 0`, `overflow-y: auto` and
+// `overscroll-behavior: contain` all happen to be present in the mobile body
+// too, so those three keep passing against the wrong rule. Measured, not
+// assumed. Pinning a declaration that both copies share needs a check the
+// slice cannot give you.
 //
 // These rule bodies contain no nested blocks, so the first `}` after the
 // selector is the closing brace. Throw rather than slice from -1.

--- a/test/dashboard-bot-defaults-layout.test.ts
+++ b/test/dashboard-bot-defaults-layout.test.ts
@@ -5,6 +5,32 @@ const page = readFileSync(new URL('../src/dashboard/web/bot-defaults-page.tsx', 
 const css = readFileSync(new URL('../src/dashboard/web/style.css', import.meta.url), 'utf8');
 const i18n = readFileSync(new URL('../src/dashboard/web/i18n.ts', import.meta.url), 'utf8');
 
+// Slice out ONE rule body, ending at its own closing brace.
+//
+// Bounding the slice on the *next* landmark instead (`@media`, the following
+// selector) makes the window wider than the rule: any declaration in a rule
+// that later gets inserted into that gap satisfies the assertions, while the
+// property they are meant to pin has already been deleted. Verified: dropping
+// `align-content: start` from .bd-roster-list and adding an unrelated rule
+// carrying it before the @media kept all assertions green.
+//
+// `.bd-roster-list` is declared TWICE — once at top level for desktop, once
+// inside @media (max-width: 980px). Every caller here wants the desktop rule,
+// which is the first match, so this takes the first and does not offer a
+// choice. Note this is no safety net for a rename: renaming the desktop rule
+// leaves the mobile copy as the first match, and what catches that is the
+// assertions failing against the wrong body.
+//
+// These rule bodies contain no nested blocks, so the first `}` after the
+// selector is the closing brace. Throw rather than slice from -1.
+function ruleBody(selector: string): string {
+  const start = css.indexOf(selector);
+  if (start === -1) throw new Error(`selector not found in style.css: ${selector}`);
+  const end = css.indexOf('}', start);
+  if (end === -1) throw new Error(`unterminated rule in style.css: ${selector}`);
+  return css.slice(start, end);
+}
+
 describe('bot defaults focused layout', () => {
   it('keeps every task panel mounted while hiding inactive categories', () => {
     for (const tab of ['common', 'sessions', 'security', 'cards', 'advanced']) {
@@ -50,14 +76,12 @@ describe('bot defaults focused layout', () => {
     expect(desktop).toMatch(/\.bd-roster\s*\{[\s\S]*?position:\s*static;[\s\S]*?height:\s*100%;/);
     expect(desktop).toMatch(/\.bd-detail\s*\{[\s\S]*?overflow-y:\s*auto;/);
 
-    const rosterStart = css.indexOf('.bot-defaults-page .bd-roster {');
-    const roster = css.slice(rosterStart, css.indexOf('.bot-defaults-page #bd-filters', rosterStart));
+    const roster = ruleBody('.bot-defaults-page .bd-roster {');
     expect(roster).toMatch(/grid-template-rows:\s*auto auto minmax\(0,\s*1fr\);/);
     expect(roster).toMatch(/overflow:\s*hidden;/);
     expect(roster).not.toMatch(/max-height:\s*calc\(100dvh/);
 
-    const listStart = css.indexOf('.bot-defaults-page .bd-roster-list {');
-    const list = css.slice(listStart, css.indexOf('@media (max-width: 980px)', listStart));
+    const list = ruleBody('.bot-defaults-page .bd-roster-list {');
     expect(list).toMatch(/min-height:\s*0;/);
     expect(list).toMatch(/overflow-y:\s*auto;/);
     expect(list).toMatch(/overscroll-behavior:\s*contain;/);
@@ -70,8 +94,7 @@ describe('bot defaults focused layout', () => {
     // per row instead of 54.4px, so the selected row rendered as a tall block
     // and the last row sank to the panel floor. align-content:start makes the
     // rows keep their content height and leaves the slack as empty space.
-    const listStart = css.indexOf('.bot-defaults-page .bd-roster-list {');
-    const list = css.slice(listStart, css.indexOf('@media (max-width: 980px)', listStart));
+    const list = ruleBody('.bot-defaults-page .bd-roster-list {');
     expect(list).toMatch(/align-content:\s*start;/);
   });
 

--- a/test/dashboard-bot-defaults-layout.test.ts
+++ b/test/dashboard-bot-defaults-layout.test.ts
@@ -30,6 +30,14 @@ const i18n = readFileSync(new URL('../src/dashboard/web/i18n.ts', import.meta.ur
 //
 // These rule bodies contain no nested blocks, so the first `}` after the
 // selector is the closing brace. Throw rather than slice from -1.
+//
+// Every rule assertion in this file goes through here. Leaving even one
+// landmark-bounded slice behind is what let the pattern spread in the first
+// place: the fill-height shell block used to be sliced as one 800-char window
+// spanning five rules, and deleting `overflow: hidden` from `main:has(...)`
+// alone kept every assertion green, because the very next rule carries the
+// same declaration and `[\s\S]*?` walked into it. That window needed no
+// planted decoy at all — the duplicates were already there.
 function ruleBody(selector: string): string {
   const start = css.indexOf(selector);
   if (start === -1) throw new Error(`selector not found in style.css: ${selector}`);
@@ -76,12 +84,14 @@ describe('bot defaults focused layout', () => {
     // sliding it up and clips #bd-filters. Desktop therefore uses the same
     // fill-height shell as roles-page: main does not scroll, both columns
     // stretch, the list and the detail pane are the scrollports.
-    const desktop = css.slice(css.indexOf('main:has(.bot-defaults-page)'), css.indexOf('main:has(.bot-defaults-page) .bd-detail') + 280);
-    expect(desktop).toMatch(/main:has\(\.bot-defaults-page\)\s*\{[\s\S]*?overflow:\s*hidden;/);
-    expect(desktop).toMatch(/\.bot-defaults-page\s*\{[\s\S]*?grid-template-rows:\s*auto minmax\(0,\s*1fr\);/);
-    expect(desktop).toMatch(/\.bd-layout\s*\{[\s\S]*?align-items:\s*stretch;/);
-    expect(desktop).toMatch(/\.bd-roster\s*\{[\s\S]*?position:\s*static;[\s\S]*?height:\s*100%;/);
-    expect(desktop).toMatch(/\.bd-detail\s*\{[\s\S]*?overflow-y:\s*auto;/);
+    const desktop = ruleBody('main:has(.bot-defaults-page) {');
+    expect(desktop).toMatch(/overflow:\s*hidden;/);
+    expect(ruleBody('main:has(.bot-defaults-page) .bot-defaults-page {')).toMatch(/grid-template-rows:\s*auto minmax\(0,\s*1fr\);/);
+    expect(ruleBody('main:has(.bot-defaults-page) .bd-layout {')).toMatch(/align-items:\s*stretch;/);
+    const shellRoster = ruleBody('main:has(.bot-defaults-page) .bd-roster {');
+    expect(shellRoster).toMatch(/position:\s*static;/);
+    expect(shellRoster).toMatch(/height:\s*100%;/);
+    expect(ruleBody('main:has(.bot-defaults-page) .bd-detail {')).toMatch(/overflow-y:\s*auto;/);
 
     const roster = ruleBody('.bot-defaults-page .bd-roster {');
     expect(roster).toMatch(/grid-template-rows:\s*auto auto minmax\(0,\s*1fr\);/);


### PR DESCRIPTION
关闭 #1159。

## 问题

`test/dashboard-bot-defaults-layout.test.ts` 里有三处断言要从 `style.css` 切出某条规则的规则体，但右边界取的是「下一个地标」而不是规则自己的闭合括号：

```js
// .bd-roster 取到 #bd-filters
const roster = css.slice(rosterStart, css.indexOf('.bot-defaults-page #bd-filters', rosterStart));
// .bd-roster-list 取到 @media
const list = css.slice(listStart, css.indexOf('@media (max-width: 980px)', listStart));
```

窗口因此比规则本身宽。今天只宽 3 个字符（`}\n\n`），但**落在这段间隙里的任何规则都能替被保护的属性作数** —— 断言会对着一个已经不存在的属性报绿。

## 可复现的失效

删掉 `.bd-roster-list` 里真实的 `align-content: start`，同时在窗口内插入一条无关规则：

```css
.bot-defaults-page .bd-decoy1 { align-content: start; }
```

→ **14/14 全绿**。被保护的属性其实已经没了。

`.bd-roster` 那处同样可复现（删 `overflow: hidden` 后插诱饵规则，同样全绿）。这一处是开 issue 之后才发现的：#1159 只提到 `.bd-roster-list` 的两处，实际是**三处**。

## 改法

三处统一走一个 `ruleBody()` helper，取到规则自身的第一个 `}`：

```js
function ruleBody(selector: string): string {
  const start = css.indexOf(selector);
  if (start === -1) throw new Error(`selector not found in style.css: ${selector}`);
  const end = css.indexOf('}', start);
  if (end === -1) throw new Error(`unterminated rule in style.css: ${selector}`);
  return css.slice(start, end);
}
```

- 前提已核对：这两条规则体内**无嵌套块**（`{` 计数为 0），所以第一个 `}` 就是闭合括号
- **共用一个 helper 而不是三处各改各的**：这个切片模式最早由 #1095 引入、后来被逐字复制到 #1158 的新断言，**重复正是它扩散的原因**；留两种写法下次还会再抄一遍
- 找不到选择器时抛错，不再从 `-1` 静默切片

helper 的注释里写明了一个**它不负责**的情况：`.bd-roster-list` 在 `style.css` 里声明了两次（桌面 + `@media` 移动端），改名桌面那条会让移动端那条变成第一个匹配 —— 这种情况不是 helper 兜住的，而是断言对着错误的规则体失败兜住的。写进注释以免后来者误以为 helper 提供了这层保护。

## 验证

**三处诱饵变异（删真声明 + 窗口内插同属性的无关规则）**：

| 变异 | 修复前 | 修复后 |
|---|---|---|
| D1 `.bd-roster-list` / `align-content: start` | 14/14 绿（被骗过） | **1 红** |
| D2 `.bd-roster` / `overflow: hidden` | 14/14 绿（被骗过） | **1 红** |
| D3 `.bd-roster-list` / `min-height: 0` | 14/14 绿（被骗过） | **1 红** |

**没有削弱既有断言的牙**（收窄边界最容易的翻车方式就是把别的断言一起弄没牙，所以逐条验了）：删除下列声明，每条都恰好 1 条用例转红 ——
`align-content: start` / `min-height: 0` / `overflow-y: auto` / `overscroll-behavior: contain` / `overflow: hidden` / `grid-template-rows: auto auto minmax(0, 1fr)`，**6/6 全红**。

**其它**：
- vitest 14/14、`bun test` 14/14（双 runner）
- 100 个 dashboard 测试文件：**1845 passed / 1 skipped**
- `bun run build` 通过

## 影响面

- **只改测试文件**，`style.css` 与生产代码**零改动**（`git diff` 可验）
- 不涉及 CLI / 后端 / 平台 / 会话类型差异；纯测试基础设施加固
- 无 UI 变化，故不附截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)