### PR TITLE
fix(sandbox): 沙盒 bot 读得到插件 registry，读路径不再被写锁挡死

### DIFF
--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -354,6 +354,15 @@ function commonHomeBaseline(h: string): FsRule[] {
     rw(`${h}/.cache`), rw(`${h}/.npm`), rw(`${h}/.local/state`),
     // The daemon-written botmux wrapper (head of PATH) + skill plugin dir.
     ro(`${h}/.botmux/bin`), ro(`${h}/.botmux/claude-plugin`),
+    // Installed-plugin registry. Secret-free BY CONTRACT: `assertPublicPluginRegistry`
+    // refuses to persist a record carrying `command`/`env`/`url`/`headers`, and a
+    // plugin's real MCP descriptor lives in its own `private/mcp.json` — which stays
+    // denied with the rest of `~/.botmux`. Without this hole a sandboxed bot cannot
+    // answer "which plugins am I running": `botmux plugin list` EPERMs before it reads
+    // anything, because the registry read serializes on a lock file next to the
+    // registry (`plugins-registry.json.lock`) under a deny-by-default `~/.botmux`.
+    // Read-only is the whole grant — install/enable stay host-side operations.
+    ro(`${h}/.botmux/plugins-registry.json`),
     // Crown jewels — most are already unreachable via deny-by-default; these
     // explicit denies guard the ones that could fall under an allowed tree
     // (workingDir = $HOME, a broad user readOnly, …). Defence-in-depth.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13197,6 +13197,30 @@ async function removePluginSkillRegistryEntries(pluginId: string): Promise<void>
   }
 }
 
+/** The per-machine enabled set lives in `~/.botmux/config.json`, which the file
+ *  sandbox deliberately does NOT expose (it can hold voice credentials), so
+ *  `readGlobalConfig()` returns `{}` there — indistinguishable from "read fine,
+ *  nothing enabled". Printing a bare id in that case would assert a fact we did
+ *  not observe, so classify the read: `undefined` = could not read it.
+ *
+ *  ANY read failure counts, ENOENT included, because the two sandbox backends hide
+ *  the file differently: seatbelt leaves it in place and denies the read (EPERM),
+ *  while bwrap never binds it into the fresh tmpfs at all (ENOENT). Keying on the
+ *  errno would make this work on macOS and silently do nothing on Linux — where the
+ *  daemon actually runs. The cost is a host that has plugins installed but no
+ *  config file yet, which now prints `enabled?` instead of a bare id: still true
+ *  (nothing IS enabled and we claim nothing), just less specific — the right side
+ *  to err on when the alternative is asserting "not enabled" from a file we never
+ *  read. */
+function readEnabledPluginIdsOrUnknown(): Set<string> | undefined {
+  try {
+    readFileSync(globalConfigPath(), 'utf-8');
+  } catch {
+    return undefined;
+  }
+  return new Set(readGlobalConfig().plugins ?? []);
+}
+
 function assertPluginInstalled(pluginId: string): void {
   const { plugins } = readPluginRegistryCached();
   if (!plugins[pluginId]) {
@@ -13392,12 +13416,15 @@ async function cmdPlugin(args: string[]): Promise<void> {
       console.log('暂无已安装插件。');
       return;
     }
-    const globalPlugins = new Set(readGlobalConfig().plugins ?? []);
+    const globalPlugins = readEnabledPluginIdsOrUnknown();
     for (const plugin of plugins) {
-      const flags = [
-        globalPlugins.has(plugin.id) ? 'enabled' : '',
-      ].filter(Boolean).join(' ');
+      const flags = globalPlugins === undefined
+        ? 'enabled?'
+        : (globalPlugins.has(plugin.id) ? 'enabled' : '');
       console.log(`${plugin.id}\t${plugin.packageName}@${plugin.version}${flags ? `\t${flags}` : ''}`);
+    }
+    if (globalPlugins === undefined) {
+      console.log(`（enabled? = 未知：本会话没有 ${globalConfigPath()} 的读权限，启用状态无法观测）`);
     }
     return;
   }

--- a/src/services/plugin-registry-store.ts
+++ b/src/services/plugin-registry-store.ts
@@ -19,11 +19,9 @@ function registryLockTarget(): string {
   return pluginRegistryPath();
 }
 
-function parsePluginRegistry(): PluginRegistryFile {
-  const file = pluginRegistryPath();
-  if (!existsSync(file)) return { schemaVersion: 1, plugins: {} };
+function parsePluginRegistryText(text: string): PluginRegistryFile {
   try {
-    const parsed = JSON.parse(readFileSync(file, 'utf-8'));
+    const parsed = JSON.parse(text);
     const rawPlugins = parsed?.plugins && typeof parsed.plugins === 'object' && !Array.isArray(parsed.plugins)
       ? parsed.plugins as Record<string, unknown>
       : {};
@@ -37,6 +35,16 @@ function parsePluginRegistry(): PluginRegistryFile {
       plugins[id] = record;
     }
     return { schemaVersion: 1, plugins };
+  } catch {
+    return { schemaVersion: 1, plugins: {} };
+  }
+}
+
+function parsePluginRegistry(): PluginRegistryFile {
+  const file = pluginRegistryPath();
+  if (!existsSync(file)) return { schemaVersion: 1, plugins: {} };
+  try {
+    return parsePluginRegistryText(readFileSync(file, 'utf-8'));
   } catch {
     return { schemaVersion: 1, plugins: {} };
   }
@@ -111,8 +119,93 @@ function readPluginRegistryUnlocked(): PluginRegistryFile {
   return migrateLegacyPluginMcpDescriptors(parsePluginRegistry());
 }
 
+/** The lock could not be CREATED because this process has no write authority
+ *  over `~/.botmux` — the sandboxed-bot case: its fs policy exposes
+ *  `plugins-registry.json` read-only, so `open('<registry>.lock', 'wx')` (or the
+ *  `ensurePluginRegistryDir` mkdir before it) fails outright. Deliberately does
+ *  NOT include EEXIST (another holder — `withFileLockSync` waits that out) or
+ *  `FILE_LOCK_TIMEOUT` (busy): both keep their current behaviour, because both
+ *  mean a writer exists and retrying is the right answer. */
+function isUnwritableLockError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'EPERM' || code === 'EACCES' || code === 'EROFS';
+}
+
+/** Read for a caller that cannot take the lock. Two deliberate differences from
+ *  `readPluginRegistryUnlocked()`:
+ *
+ *  - It does NOT run the lazy legacy migration. That migration WRITES (moves an
+ *    inline MCP descriptor into the plugin's private file and rewrites the
+ *    registry), which is exactly what this caller has no authority to do. Legacy
+ *    records are projected to their public shape instead — a reader that cannot
+ *    perform the migration must not be handed the `command`/`env`/`url`/`headers`
+ *    fields the migration exists to move OUT of the registry. Validation stays
+ *    identical to the migrating path, so an invalid record still throws rather
+ *    than being served in a shape no consumer expects.
+ *  - It does NOT reuse `parsePluginRegistry`'s `existsSync` probe, which returns
+ *    false for an UNREADABLE file too: that would report a denied registry as
+ *    "no plugins installed" — byte-identical to a clean host, and silence is the
+ *    worst answer for a bot asking which plugins it is running. Only ENOENT is
+ *    empty; every other read failure propagates. */
+function readPluginRegistryReadOnly(): PluginRegistryFile {
+  let text: string;
+  try {
+    text = readFileSync(pluginRegistryPath(), 'utf-8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { schemaVersion: 1, plugins: {} };
+    throw error;
+  }
+  const registry = parsePluginRegistryText(text);
+  for (const record of Object.values(registry.plugins)) {
+    const mcp = (record.contributions as { mcp?: unknown } | undefined)?.mcp;
+    if (mcp === undefined) continue;
+    if (isPluginMcpServer(mcp)) {
+      if (mcp.name !== record.id) throw new Error(`invalid_legacy_plugin_mcp_descriptor:${record.id}`);
+      record.contributions = { ...record.contributions, mcp: publicPluginMcpContribution(mcp) };
+      continue;
+    }
+    if (!isPluginMcpContribution(mcp) || hasPrivateMcpFields(mcp)) {
+      throw new Error(`invalid_plugin_mcp_contribution:${record.id}`);
+    }
+  }
+  return registry;
+}
+
+/** The lock was created fine, but the LAZY MIGRATION inside it could not write.
+ *  This is the Linux/bwrap shape: `~/.botmux` is a fresh tmpfs (the ro-bind of the
+ *  registry auto-creates its parent), so `open(lock,'wx')` SUCCEEDS and the
+ *  migrating path runs — then `atomicWriteFileSync`'s rename onto the read-only
+ *  bind fails with EBUSY. Same for a private descriptor write under a read-only
+ *  plugin dir (EACCES/EPERM). Without this, a sandboxed bot with a legacy registry
+ *  gets an EBUSY instead of an answer.
+ *
+ *  `migrateLegacyPluginMcpDescriptors` re-wraps everything it catches, so the errno
+ *  is on `.cause`, NOT on the top level — checking `error.code` here would match
+ *  nothing. Requiring `cause.code` is also exactly what separates "we cannot write"
+ *  from "this record is invalid": `invalid_plugin_mcp_contribution` /
+ *  `invalid_legacy_plugin_mcp_descriptor` arrive wrapped in the same prefix but
+ *  carry no errno, so they keep propagating — swallowing those would destroy the
+ *  one check that stops private descriptor fields reaching a caller. */
+function isUnwritableMigrationError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (!error.message.startsWith('plugin_mcp_registry_migration_failed:')) return false;
+  const code = (error.cause as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES' || code === 'EROFS';
+}
+
 export function readPluginRegistry(): PluginRegistryFile {
-  return withFileLockSync(registryLockTarget(), () => readPluginRegistryUnlocked(), { maxWaitMs: 30_000 });
+  try {
+    return withFileLockSync(registryLockTarget(), () => readPluginRegistryUnlocked(), { maxWaitMs: 30_000 });
+  } catch (error) {
+    // A reader with no write authority degrades to the non-migrating read above —
+    // whether it was the LOCK it could not create (seatbelt: `~/.botmux` denied)
+    // or the MIGRATION it could not write (bwrap: lock fine, registry read-only).
+    // Writers (`writePluginRegistry` / `upsertInstalledPlugin` /
+    // `removeInstalledPlugin`) deliberately keep throwing: they genuinely cannot
+    // do their job here, and a silent no-op write is far worse than an EPERM.
+    if (!isUnwritableLockError(error) && !isUnwritableMigrationError(error)) throw error;
+    return readPluginRegistryReadOnly();
+  }
 }
 
 export function writePluginRegistry(registry: PluginRegistryFile): void {

--- a/test/plugin-registry-sandbox-read.test.ts
+++ b/test/plugin-registry-sandbox-read.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pluginRegistryPath } from '../src/core/plugins/paths.js';
+import {
+  readPluginRegistry,
+  removeInstalledPlugin,
+  upsertInstalledPlugin,
+  writePluginRegistry,
+} from '../src/services/plugin-registry-store.js';
+import { accessForPath, buildFsPolicy, type FsPolicyContext } from '../src/adapters/cli/fs-policy.js';
+import { resolve } from 'node:path';
+import type { InstalledPluginRecord } from '../src/core/plugins/types.js';
+
+/**
+ * A sandboxed bot gets `~/.botmux/plugins-registry.json` read-only and nothing
+ * else under `~/.botmux`. Before this fix `botmux plugin list` died with
+ * `EPERM: operation not permitted, open '.../plugins-registry.json.lock'`,
+ * because the READ path serializes on a lock file it has no authority to create.
+ *
+ * The tests below reproduce that with filesystem modes rather than a real
+ * sandbox: a `~/.botmux` that is `r-x` (0o500) denies the lock create exactly
+ * the way the seatbelt/bwrap policy does, while leaving the registry readable.
+ */
+const record = (id: string, contributions?: unknown): InstalledPluginRecord => ({
+  id,
+  packageName: `@botmux/plugin-${id}`,
+  version: '1.0.0',
+  manifest: { schemaVersion: 1, id },
+  ...(contributions === undefined ? {} : { contributions }),
+} as InstalledPluginRecord);
+
+describe('plugin registry reads survive a read-only ~/.botmux (sandboxed bot)', () => {
+  let home: string;
+  let botmuxHome: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'botmux-plugin-ro-'));
+    vi.stubEnv('HOME', home);
+    botmuxHome = join(home, '.botmux');
+    mkdirSync(botmuxHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Restore write access before cleanup, else rmSync cannot unlink.
+    try { chmodSync(botmuxHome, 0o700); } catch { /* already gone */ }
+    try { chmodSync(pluginRegistryPath(), 0o600); } catch { /* may not exist */ }
+    vi.unstubAllEnvs();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  /** Freeze `~/.botmux` the way the sandbox does: readable + traversable, not writable. */
+  const freezeBotmuxHome = () => chmodSync(botmuxHome, 0o500);
+
+  it('lists installed plugins when the lock file cannot be created', () => {
+    upsertInstalledPlugin(record('data-mcp'));
+    freezeBotmuxHome();
+
+    // Sanity: the condition under test is really "cannot create the lock".
+    expect(() => writeFileSync(`${pluginRegistryPath()}.lock`, '')).toThrow();
+
+    expect(Object.keys(readPluginRegistry().plugins)).toEqual(['data-mcp']);
+    expect(existsSync(`${pluginRegistryPath()}.lock`)).toBe(false);
+  });
+
+  it('reports an empty registry only when the file is genuinely absent', () => {
+    freezeBotmuxHome();
+    expect(readPluginRegistry().plugins).toEqual({});
+  });
+
+  it('never answers "no plugins installed" for an UNREADABLE registry', () => {
+    upsertInstalledPlugin(record('data-mcp'));
+    chmodSync(pluginRegistryPath(), 0o000);
+    freezeBotmuxHome();
+
+    // The silent-zero answer is the bug: it is byte-identical to a clean host.
+    expect(() => readPluginRegistry()).toThrow(/EACCES|EPERM/);
+  });
+
+  it('projects a legacy inline MCP descriptor to its public shape, leaking no command/env', () => {
+    upsertInstalledPlugin(record('data-mcp'));
+    // Hand-write the pre-migration shape: the whole server descriptor inline.
+    writeFileSync(pluginRegistryPath(), JSON.stringify({
+      schemaVersion: 1,
+      plugins: {
+        'data-mcp': {
+          ...record('data-mcp'),
+          contributions: {
+            mcp: { name: 'data-mcp', transport: 'stdio', command: ['node', 'server.js'], env: { TOKEN: 's3cret' } },
+          },
+        },
+      },
+    }));
+    freezeBotmuxHome();
+
+    const mcp = (readPluginRegistry().plugins['data-mcp']!.contributions as { mcp: Record<string, unknown> }).mcp;
+    expect(mcp.name).toBe('data-mcp');
+    expect(mcp.privateRef).toBe('private/mcp.json');
+    expect(mcp.command).toBeUndefined();
+    expect(mcp.env).toBeUndefined();
+    // The registry on disk is untouched — the degraded read never migrates.
+    expect(readFileSync(pluginRegistryPath(), 'utf-8')).toContain('s3cret');
+  });
+
+  it('refuses a record whose public-shaped mcp still carries private fields', () => {
+    // The other half of the anti-leak check: `privateRef` present (so it passes the
+    // public-shape test) AND `env` present. The degraded read must NOT hand this
+    // record to a caller that has no authority to migrate it — this is the only
+    // gate stopping a private descriptor field from being served.
+    upsertInstalledPlugin(record('data-mcp'));
+    writeFileSync(pluginRegistryPath(), JSON.stringify({
+      schemaVersion: 1,
+      plugins: {
+        'data-mcp': {
+          ...record('data-mcp'),
+          contributions: {
+            mcp: { name: 'data-mcp', transport: 'stdio', privateRef: 'private/mcp.json', env: { TOKEN: 's3cret' } },
+          },
+        },
+      },
+    }));
+    freezeBotmuxHome();
+
+    expect(() => readPluginRegistry()).toThrow(/invalid_plugin_mcp_contribution/);
+  });
+
+  it('degrades when the lock is fine but the MIGRATION cannot write (bwrap shape)', () => {
+    // Linux/bwrap: `~/.botmux` is writable (the ro-bind auto-creates it), so the lock
+    // IS created and the migrating path runs — then the WRITE fails. Reproduced by
+    // leaving `~/.botmux` writable and freezing the plugin dir so the migration cannot
+    // create the private dir it wants to move the descriptor into.
+    //
+    // Freezing `plugins/<id>/private` itself does NOT work: `assertPrivateStorageLayout`
+    // chmods an existing private dir back to 0o700, so the write would succeed and this
+    // test would silently re-test the happy path. Freeze the PARENT and leave `private`
+    // absent — mkdir inside a 0o500 dir fails, and nothing can chmod what it never made.
+    upsertInstalledPlugin(record('data-mcp'));
+    writeFileSync(pluginRegistryPath(), JSON.stringify({
+      schemaVersion: 1,
+      plugins: {
+        'data-mcp': {
+          ...record('data-mcp'),
+          contributions: {
+            mcp: { name: 'data-mcp', transport: 'stdio', command: ['node', 'server.js'], env: { TOKEN: 's3cret' } },
+          },
+        },
+      },
+    }));
+    const pluginDir = join(botmuxHome, 'plugins', 'data-mcp');
+    mkdirSync(pluginDir, { recursive: true });
+    chmodSync(pluginDir, 0o500);
+
+    try {
+      // Sanity: the lock really is creatable — otherwise this would re-test the
+      // EPERM path instead of the migration path.
+      writeFileSync(`${pluginRegistryPath()}.lock`, '');
+      rmSync(`${pluginRegistryPath()}.lock`);
+
+      const mcp = (readPluginRegistry().plugins['data-mcp']!.contributions as { mcp: Record<string, unknown> }).mcp;
+      expect(mcp.privateRef).toBe('private/mcp.json');
+      expect(mcp.command).toBeUndefined();
+      expect(mcp.env).toBeUndefined();
+      // The distinguishing assertion: a SUCCESSFUL migration would have rewritten the
+      // registry without the secret. It is still there, so what we just read really is
+      // the non-migrating projection.
+      expect(readFileSync(pluginRegistryPath(), 'utf-8')).toContain('s3cret');
+    } finally {
+      chmodSync(pluginDir, 0o700);
+    }
+  });
+
+  it('degrades ONLY for unwritability — a security-relevant layout error still surfaces', () => {
+    // The degrade must not become a blanket catch for everything the migration can
+    // throw. `unsafe_plugin_private_dir` means someone replaced the private dir with
+    // a symlink; that has to reach the caller, not be quietly replaced by a
+    // projection. It arrives wrapped in the same `plugin_mcp_registry_migration_failed:`
+    // prefix as the writability failures, so only the errno on `.cause` tells them
+    // apart.
+    upsertInstalledPlugin(record('data-mcp'));
+    writeFileSync(pluginRegistryPath(), JSON.stringify({
+      schemaVersion: 1,
+      plugins: {
+        'data-mcp': {
+          ...record('data-mcp'),
+          contributions: {
+            mcp: { name: 'data-mcp', transport: 'stdio', command: ['node', 'server.js'] },
+          },
+        },
+      },
+    }));
+    const pluginDir = join(botmuxHome, 'plugins', 'data-mcp');
+    const elsewhere = join(home, 'elsewhere');
+    mkdirSync(pluginDir, { recursive: true });
+    mkdirSync(elsewhere, { recursive: true });
+    symlinkSync(elsewhere, join(pluginDir, 'private'));
+
+    expect(() => readPluginRegistry()).toThrow(/unsafe_plugin_private_dir/);
+  });
+
+  it('keeps writers fail-loud under the same condition', () => {
+    upsertInstalledPlugin(record('data-mcp'));
+    freezeBotmuxHome();
+
+    expect(() => upsertInstalledPlugin(record('other'))).toThrow(/EACCES|EPERM/);
+    expect(() => removeInstalledPlugin('data-mcp')).toThrow(/EACCES|EPERM/);
+    expect(() => writePluginRegistry({ schemaVersion: 1, plugins: {} })).toThrow(/EACCES|EPERM/);
+  });
+});
+
+describe('fs-policy exposes the plugin registry read-only', () => {
+  const ctx = (o: Partial<FsPolicyContext> = {}): FsPolicyContext => ({
+    platform: 'darwin',
+    homeDir: '/Users/u',
+    botmuxHome: '/Users/u/.botmux',
+    sessionDataDir: '/Users/u/.botmux/data',
+    sessionId: 's',
+    workingDir: '/Users/u/proj',
+    currentAppId: 'cli_self',
+    botHome: '/Users/u/.botmux/bots/cli_self',
+    redirectedCliData: true,
+    ...o,
+  });
+
+  for (const platform of ['darwin', 'linux'] as const) {
+    it(`grants readOnly on ${platform} while the rest of ~/.botmux stays denied`, () => {
+      const p = buildFsPolicy(ctx({ platform }));
+      expect(accessForPath(p.rules, '/Users/u/.botmux/plugins-registry.json').access).toBe('readOnly');
+      // The neighbours that must NOT come along: the private descriptor store and
+      // the bots config / dashboard HMAC sitting in the same directory.
+      expect(accessForPath(p.rules, '/Users/u/.botmux/plugins/data-mcp/private/mcp.json').access).not.toBe('readOnly');
+      expect(accessForPath(p.rules, '/Users/u/.botmux/bots.json').access).not.toBe('readOnly');
+      expect(accessForPath(p.rules, '/Users/u/.botmux/.dashboard-secret').access).not.toBe('readOnly');
+    });
+  }
+});
+
+/**
+ * Making the registry readable is only half the answer for `botmux plugin list`:
+ * the per-machine ENABLED set lives in `~/.botmux/config.json`, which the sandbox
+ * deliberately keeps denied (it can hold voice credentials). `readGlobalConfig()`
+ * swallows EPERM and returns {}, so a naive listing would print every plugin
+ * WITHOUT the `enabled` flag — asserting "not enabled" from an unread file. The
+ * listing must say "unknown" instead.
+ *
+ * Source-lock (cli.ts's plugin branch is not separately importable): pinned by
+ * SEMANTICS, not by identifier spelling, so a correct refactor stays green.
+ */
+describe('plugin list distinguishes "not enabled" from "could not read the enabled set"', () => {
+  const cliSource = readFileSync(resolve('src/cli.ts'), 'utf-8');
+
+  it('classifies ANY unreadable global config as unknown, not just the deny errnos', () => {
+    const fn = cliSource.slice(cliSource.indexOf('function readEnabledPluginIdsOrUnknown'));
+    const body = fn.slice(0, fn.indexOf('\n}\n') + 2);
+    // Reads the global config path, not some other file.
+    expect(body).toMatch(/readFileSync\(globalConfigPath\(\)/);
+    // Every read failure is "unknown". Keying on the errno is the bug: seatbelt
+    // denies the read (EPERM) while bwrap never binds the file in (ENOENT), so an
+    // errno filter works on macOS and silently does nothing on Linux.
+    expect(body).toMatch(/catch\s*\{\s*return undefined;?\s*\}/);
+    expect(body).not.toMatch(/EPERM|EACCES|ENOENT|\.code/);
+  });
+
+  it('the listing consumes the classifier and surfaces the unknown state', () => {
+    const listBranch = cliSource.slice(cliSource.indexOf("if (sub === 'list' || sub === 'ls')"));
+    const body = listBranch.slice(0, listBranch.indexOf('\n  if (sub ==='));
+    // No direct readGlobalConfig() in the listing — that is the call that cannot
+    // tell denied from empty.
+    expect(body).not.toMatch(/readGlobalConfig\(\)/);
+    // The unknown state must be visible in the output, not silently dropped.
+    expect(body).toContain('enabled?');
+    expect(body).toMatch(/undefined/);
+  });
+});


### PR DESCRIPTION
## 问题

沙盒 bot 跑 `botmux plugin list` 必挂：

```
EPERM: operation not permitted, open '~/.botmux/plugins-registry.json.lock'
```

在一台真机上撞到的（沙盒 bot 被问「你装了哪些插件」，答不出来）。两个原因叠加，缺一不可：

1. **fs 策略里没有这个文件。** `~/.botmux` 是 deny-by-default，只开了 `bin` 与 `claude-plugin` 两个只读洞（`fs-policy.ts` 的 `commonHomeBaseline`），`plugins-registry.json` 不在其中。
2. **读路径要写。** `readPluginRegistry()` 是纯读语义，却包在 `withFileLockSync` 里 —— 而这把锁**不是多余的**：`readPluginRegistryUnlocked()` = `migrateLegacyPluginMcpDescriptors(parsePluginRegistry())`，它顺带做 legacy 迁移（把内联的 MCP descriptor 搬进插件自己的 `private/mcp.json` 并重写 registry）。所以锁不能直接摘。

于是即使只把文件读权限开出去，读路径仍会先去建锁文件，然后 EPERM。两侧必须一起补。

## 改动

**`plugin list`** —— 区分「读到了、没启用」与「读不到启用状态」。

启用集合来自 `~/.botmux/config.json`，那个文件沙盒里**刻意不暴露**（可能存放语音凭据），`readGlobalConfig()` 在那里静默返回 `{}`。只把 registry 打开的话，列表会把每个插件都印成没有 `enabled` 标记 —— 等于**用一个没读到的文件断言「未启用」**，和下面 registry 那条 `existsSync` 的毛病是同一个。改成未知时印 `enabled?` 并附一行原因。

**分类器按「读失败」判，不按 errno**（评审指出的第二处）：两个后端藏这个文件的方式不一样 —— seatbelt 留着文件、拒绝读（`EPERM`），bwrap **压根不把它 bind 进新 tmpfs**（`ENOENT`）。按 errno 过滤会让这个特性只在 macOS 生效，而在 daemon 实际运行的 Linux 上静默失效。代价是「装了插件但还没有 config 文件」的机器现在印 `enabled?` 而不是裸 id —— 那句话仍然为真（确实没有启用，而我们没有断言任何东西），只是不够具体；在「用一个没读到的文件断言未启用」面前，这是该倒向的一边。


**`fs-policy.ts`** —— 把 `~/.botmux/plugins-registry.json` 作为只读洞暴露，紧挨现有那两个洞。

依据是这个文件**按契约不含密钥**：`assertPublicPluginRegistry()` 拒绝持有 `command`/`env`/`url`/`headers` 的记录落盘，真实 descriptor 存在插件自己的 `private/mcp.json`，那个继续随 `~/.botmux` 一起 deny。只读是全部授权，install/enable 仍然只能宿主侧做。

**`plugin-registry-store.ts`** —— 锁**建不出来**时，读路径降级为不加锁、不迁移的读。

**两种"写不动"的形态都覆盖**（评审指出我原来只覆盖了一种）：
- **seatbelt**：锁**建不出来** —— `EPERM`/`EACCES`/`EROFS`。
- **bwrap**：`~/.botmux` 是 ro-bind 注册表时自动生成的**可写** tmpfs，锁**建得出来**、迁移的 rename 落到只读绑定上才炸（`EBUSY`）。这个 errno 挂在 **`.cause`** 上 —— 迁移把错误重新包了一层，顶层 `.code` 是 `undefined`，所以按 `error.code` 判会一个都匹配不到。
- `EEXIST`（有人持锁，`withFileLockSync` 自己会等）与 `FILE_LOCK_TIMEOUT`（忙）行为完全不变 —— 那两种情况确实存在写者，重试才是对的。
- **只对写不动降级。** `unsafe_plugin_private_dir`（有人把私有目录换成了符号链接）这类布局/安全错误，与非法记录一样裹在同一个 `plugin_mcp_registry_migration_failed:` 前缀里，**只有 `cause` 上的 errno 能把它们分开** —— 它们必须继续上抛。
- **写路径（`writePluginRegistry` / `upsertInstalledPlugin` / `removeInstalledPlugin`）保持 fail-loud。** 它们在这里真的做不了事，静默空写比 EPERM 糟得多。

降级读有两处刻意设计，都写在代码注释里：

- **不跑迁移，改为把 legacy 记录投影成公开形状。** 一个没有写权限、做不了迁移的读者，不该反而拿到迁移正要移走的私有字段。校验与迁移路径逐条相同（name 不匹配、非 contribution、带私有字段一律抛），只是不写盘。
- **不复用 `parsePluginRegistry` 的 `existsSync` 探测。** 它对**读不到**的文件同样返回 `false`，会把被拒绝的 registry 报成「没装插件」—— 和干净机器的输出一模一样。只有 `ENOENT` 算空，其余读失败一律上抛。这条是这个 PR 里我最在意的一处：静默的零比报错难查得多。

## 验证

`tsc --noEmit` exit 0。

基线（先验基线，再做变异）：`plugin-registry-sandbox-read` / `fs-policy` / `plugin-manifest-store` / `plugin-mcp-gateway` 四个文件 vitest **157/157 全绿**；新文件 `bun test` **7/7**（+2 条 source-lock）。

新测试用文件权限复现沙盒条件（`~/.botmux` 置成 `0o500`：可读可遍历、不可写），比起 mock 更接近真实策略；其中一条会先断言「锁文件确实建不出来」，避免测试在条件没生效的情况下假绿。

十一处变异，每处都从提交态出发、跑完 `git checkout -- src` 并 `git diff --quiet` 自检已复原：

| 变异 | 结果 |
|---|---|
| 摘掉 fs-policy 的只读洞 | 2 red（darwin + linux） |
| 去掉降级（锁失败一律上抛） | 3 red |
| 降级读改用 `parsePluginRegistry`（`existsSync` 吞掉不可读） | 2 red |
| 降级读不做公开投影（legacy 原样透出） | 1 red |
| 把降级也套到写路径上 | 1 red |
| 列表退回直接用 `readGlobalConfig()` | 1 red |
| 分类器把 deny 也当成「空集」 | 1 red |
| 迁移写不动时不降级（只认锁错误） | 1 red |
| 迁移判定读顶层 `.code` 而非 `.cause.code` | 1 red |
| 降级不校验 `cause`（把布局/安全错误一起吞掉） | 1 red |
| 分类器退回只认 `EPERM`/`EACCES`（漏掉 Linux 的 `ENOENT`） | 1 red |

## 一处留给维护者定的取舍

只读洞放在 `commonHomeBaseline`，因此它和现有的 `~/.botmux/bin`、`~/.botmux/claude-plugin` 一样**对 no-transport（apiOnly）轮次也生效** —— baseline 规则不经 `dropAuthority`，且比 authority-root 的整目录 deny 更深，按最深前缀胜出。我按既有两个洞的先例对齐了行为；如果希望 no-transport 轮次一个洞都不开，把这条改成 `larkTransport` 门控的 `internal` push 即可，我照改。
