### PR TITLE
fix(traex): 支持原生会话改名

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -417,6 +417,7 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
     // composer exists, so the worker's 15s soft fallback must wait for the
     // prompt marker. A hard cap in the worker still prevents permanent hangs.
     deferFirstPromptTimeoutUntilReady: true,
+    buildSessionRenameCommand: (title) => `/rename ${title}`,
     altScreen: false,
     skillsDir: '~/.trae/skills',
     // Curated subset — the full catalogue has 27 models. `traex debug models`

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1243,6 +1243,10 @@ function sessionCliId(ds: DaemonSession, botCfg: { cliId: CliId }): CliId {
   return ds.session.cliLaunchSnapshot?.cliId ?? ds.session.cliId ?? botCfg.cliId;
 }
 
+function supportsBotmuxLarkNativeSessionTitle(cliId: CliId): boolean {
+  return cliId === 'codex' || cliId === 'traex';
+}
+
 function ordinaryTurnRecoveryEligible(
   ds: DaemonSession,
   botCfg = getBot(ds.larkAppId).config,
@@ -9244,7 +9248,8 @@ export function sendWorkerInput(
   const transferGate = transferInputGates.get(ds);
   if ((!ds.worker || ds.worker.killed) && !transferGate) return false;
   const normalized = typeof payload === 'string' ? { content: payload } : payload;
-  const effectiveCliId = ds.session.cliId ?? getBot(ds.larkAppId).config.cliId;
+  const bot = getBot(ds.larkAppId);
+  const effectiveCliId = sessionCliId(ds, bot.config);
   const effectiveTurnId = turnId ?? (effectiveCliId === 'codex-app'
     ? `codex-app-dispatch-${randomUUID()}`
     : undefined);
@@ -9255,8 +9260,7 @@ export function sendWorkerInput(
   let nativeSessionTitlePrompt: string | undefined;
   let nativeSessionTitle: string | undefined;
   if (ds.session.nativeSessionTitleAwaitingContent && !ds.session.nativeSessionTitleUserDefined && !ds.adoptedFrom) {
-    const bot = getBot(ds.larkAppId);
-    if (effectiveCliId === 'codex') {
+    if (supportsBotmuxLarkNativeSessionTitle(effectiveCliId)) {
       nativeSessionTitlePrompt = extractBotmuxLarkNativeSessionTitlePrompt(
         normalized.codexAppInput?.text ?? normalized.content,
         bot.botName ? [{ name: bot.botName }] : undefined,
@@ -10344,7 +10348,7 @@ export function forkWorker(
   ensureCliEnv(agentCfg.cliId, agentCfg.cliPathOverride);
   let nativeSessionTitle: string | undefined;
   let nativeSessionTitlePrompt: string | undefined;
-  if (agentCfg.cliId === 'codex' && !isSharedAdoptSession(ds)) {
+  if (supportsBotmuxLarkNativeSessionTitle(agentCfg.cliId) && !isSharedAdoptSession(ds)) {
     const isFreshNativeSession = !resume && !ds.session.cliSessionId;
     const titlePrompt = extractBotmuxLarkNativeSessionTitlePrompt(
       promptPayload.codexAppInput?.text ?? prompt,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1130,6 +1130,8 @@ export interface CodexAppGenerationCommit {
 export interface CliTurnPayload {
   content: string;
   codexAppInput?: CodexAppTurnInput;
+  nativeSessionTitle?: string;
+  nativeSessionTitlePrompt?: string;
   trustedCaller?: TrustedCaller;
   /** Frozen steer authorization (codex-app ordered pre-final steer). Computed
    * ONCE by the daemon at admission (real human interactive turn only) and COPIED

--- a/src/utils/pending-input-queue.ts
+++ b/src/utils/pending-input-queue.ts
@@ -17,6 +17,13 @@ export interface PendingCliInput {
   vcMeetingImTurnOrigin?: VcMeetingImTurnOrigin;
   trustedCaller?: TrustedCaller;
   codexAppInput?: CodexAppTurnInput;
+  /** Best-effort CLI-native title to apply after this exact user input has
+   * reached the CLI. Used by terminal Codex-family CLIs so their resume picker
+   * does not fall back to Botmux's injected routing envelope. */
+  nativeSessionTitle?: string;
+  /** Source text for Codex App semantic title generation. Plain TUI adapters
+   * keep only nativeSessionTitle and ignore this prompt. */
+  nativeSessionTitlePrompt?: string;
   /**
    * mojo only: the credential snapshot that arrived WITH this turn.
    *
@@ -95,6 +102,8 @@ export function mergeQueuedCliInput(
     || tail.queuedActivationToken || next.queuedActivationToken
     || tail.vcMeetingImTurnOrigin || next.vcMeetingImTurnOrigin
     || tail.codexAppInput || next.codexAppInput
+    || tail.nativeSessionTitle || next.nativeSessionTitle
+    || tail.nativeSessionTitlePrompt || next.nativeSessionTitlePrompt
     || tail.logicalContent || next.logicalContent) return false;
   tail.content = `${tail.content}\n\n${next.content}`;
   tail.turnId = next.turnId ?? tail.turnId;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1047,6 +1047,34 @@ async function syncFreshCodexNativeSessionTitle(
   }
 }
 
+function queuePostSubmitNativeSessionTitle(title: string | undefined): boolean {
+  const cfg = lastInitConfig;
+  const trimmed = title?.trim();
+  if (!cfg || cfg.adoptMode || !trimmed) return false;
+  if (!supportsPostSubmitRenameSessionTitle(cfg.cliId)) return false;
+  if (codexRpcEngine || remoteWsUrl) return false;
+  if (!cliAdapter?.buildSessionRenameCommand) return false;
+  if (effectiveBackendType === 'riff' || effectiveBackendType === 'mojo') return false;
+  nativeSessionTitleRevision += 1;
+  nativeSessionTitleAppliedThreadId = undefined;
+  cfg.nativeSessionTitle = trimmed;
+  cfg.nativeSessionTitlePrompt = undefined;
+  stopNativeSessionTitleSync();
+  pendingSessionRename = trimmed;
+  log(`Queued automatic native session rename after first user input (${cliName()}): ${trimmed}`);
+  const kick = setTimeout(() => void flushPending(), 0);
+  kick.unref?.();
+  return true;
+}
+
+function maybeQueuePostSubmitNativeSessionTitle(item: PendingCliInput): boolean {
+  if (!item.nativeSessionTitle) return false;
+  const queued = queuePostSubmitNativeSessionTitle(item.nativeSessionTitle);
+  item.nativeSessionTitle = undefined;
+  item.nativeSessionTitlePrompt = undefined;
+  return queued;
+}
+
 /** 在 resume 首条输入前记录 updatedAt，后续用其确认历史派生标题已完成回写。 */
 async function captureCodexResumeTitleBaseline(threadId: string, engine?: CodexRpcEngine): Promise<void> {
   const cfg = lastInitConfig;
@@ -2118,6 +2146,10 @@ function cliName(): string {
     : undefined)
     ?? CLI_DISPLAY_NAMES[lastInitConfig?.cliId ?? '']
     ?? 'CLI';
+}
+
+function supportsPostSubmitRenameSessionTitle(cliId: string | undefined): boolean {
+  return cliId === 'traex';
 }
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
@@ -10721,7 +10753,7 @@ function scheduleSubmitFailureNotify(
   bridgeTurnId?: string,
   failureReason?: string,
   turnSeq = usageLimitTracker.currentTurn(),
-  turnIdentity?: Pick<PendingCliInput, 'turnId' | 'dispatchAttempt'>,
+  turnIdentity?: Pick<PendingCliInput, 'turnId' | 'dispatchAttempt' | 'nativeSessionTitle'>,
   durableTerminalStatus: 'failed' | 'ambiguous' = 'failed',
   structuredTarget = false,
 ): void {
@@ -10803,6 +10835,7 @@ function scheduleSubmitFailureNotify(
 
     switch (action.kind) {
       case 'suppress-confirmed':
+        queuePostSubmitNativeSessionTitle(turnIdentity?.nativeSessionTitle);
         if (cliSessionId) {
           persistCliSessionId(cliSessionId);
           if (codexBridgeFallbackActive()) codexBridgeNotifyCliSessionId(cliSessionId);
@@ -11698,6 +11731,9 @@ async function flushPending(): Promise<void> {
         && result?.submitted !== false) {
         rememberBounded(submittedCodexAppReplyTurnIds, item.turnId);
       }
+      const queuedPostSubmitNativeTitle = result?.submitted !== false
+        ? maybeQueuePostSubmitNativeSessionTitle(item)
+        : false;
       // Persist any sessionId the adapter observed via authoritative sources
       // (Claude's pid file, Codex's history). Done independently of submit
       // outcome — the rotation is real even when the current Enter didn't
@@ -11807,6 +11843,7 @@ async function flushPending(): Promise<void> {
           activationToken: item.queuedActivationToken,
         });
       }
+      if (queuedPostSubmitNativeTitle) break;
       // All structured bridges now drain every pending message in one flush:
       // Claude's BridgeTurnQueue handles `attachment(queued_command)` events
       // identically to `role:user`; CoCo parks queued submits in its TUI queue
@@ -11870,6 +11907,8 @@ function sendToPty(
     replyTurnId?: string;
     trustedCaller?: import('./types.js').TrustedCaller;
     vcMeetingImTurnOrigin?: VcMeetingImTurnOrigin;
+    nativeSessionTitle?: string;
+    nativeSessionTitlePrompt?: string;
     /** mojo credential snapshot delivered with this turn; applied at write time. */
     mojoLivePatch?: MojoLivePatch;
     /** At-most-once (idempotency lease): tag this keyed input so a CLI exit never
@@ -11889,6 +11928,8 @@ function sendToPty(
     ...(opts.queuedActivationToken ? { queuedActivationToken: opts.queuedActivationToken } : {}),
     ...(opts.mojoLivePatch ? { mojoLivePatch: opts.mojoLivePatch } : {}),
     ...(opts.codexAppInput ? { codexAppInput: opts.codexAppInput } : {}),
+    ...(opts.nativeSessionTitle ? { nativeSessionTitle: opts.nativeSessionTitle } : {}),
+    ...(opts.nativeSessionTitlePrompt ? { nativeSessionTitlePrompt: opts.nativeSessionTitlePrompt } : {}),
     ...(opts.trustedCaller ? { trustedCaller: opts.trustedCaller } : {}),
     ...(opts.dispatchAttempt !== undefined ? { dispatchAttempt: opts.dispatchAttempt } : {}),
     ...(opts.atMostOnce ? { noReplay: true } : {}),
@@ -18544,6 +18585,8 @@ process.on('message', async (raw: unknown) => {
             vcMeetingImTurnOrigin: entry.vcMeetingImTurnOrigin,
             trustedCaller: msg.trustedCaller,
           }));
+        const initialNativeSessionTitle = msg.nativeSessionTitle;
+        const initialNativeSessionTitlePrompt = msg.nativeSessionTitlePrompt;
         let initialInputCommitted = false;
         if (shouldQueueInitialPrompt({
           hasPrompt: !!msg.prompt,
@@ -18577,6 +18620,8 @@ process.on('message', async (raw: unknown) => {
             // group root — accepted[0] — to be steerable). Without this the first
             // turn of a codex-app session could never absorb a follow-up steer.
             ...(msg.codexAppSteerable ? { codexAppSteerable: true } : {}),
+            ...(initialNativeSessionTitle ? { nativeSessionTitle: initialNativeSessionTitle } : {}),
+            ...(initialNativeSessionTitlePrompt ? { nativeSessionTitlePrompt: initialNativeSessionTitlePrompt } : {}),
             // At-most-once (idempotency lease): tag the KEYED init prompt so a CLI
             // exit never replays it onto the auto-restarted CLI — while leaving a
             // later plain follow-up turn on the same http_async_ session intact
@@ -18705,6 +18750,7 @@ process.on('message', async (raw: unknown) => {
       // Cancel any active tmux copy-mode scroll so user input reaches the CLI.
       if (tmuxScrolledHalfPages > 0 && !messageAdoptMode) exitTmuxScrollMode();
       let content = msg.content;
+      const postSubmitNativeSessionTitle = msg.nativeSessionTitle;
       let codexAppInput = msg.codexAppInput;
       if (deferredPluginSkillCatalog && !lastInitConfig?.adoptMode) {
         content = `${content}\n\n${deferredPluginSkillCatalog}`;
@@ -18753,6 +18799,7 @@ process.on('message', async (raw: unknown) => {
           vcMeetingImTurnOrigin: msg.vcMeetingImTurnOrigin,
           trustedCaller: msg.trustedCaller,
           codexAppInput,
+          nativeSessionTitle: postSubmitNativeSessionTitle,
         };
         // process.on('message') does not serialize async listeners. Hold the
         // per-worker queue across transcript mark + complete adapter write so
@@ -18784,6 +18831,8 @@ process.on('message', async (raw: unknown) => {
           trustedCaller: msg.trustedCaller,
           // Applied when THIS item is written, not on receipt.
           ...(msg.mojoLivePatch ? { mojoLivePatch: msg.mojoLivePatch } : {}),
+          ...(postSubmitNativeSessionTitle ? { nativeSessionTitle: postSubmitNativeSessionTitle } : {}),
+          ...(msg.nativeSessionTitlePrompt ? { nativeSessionTitlePrompt: msg.nativeSessionTitlePrompt } : {}),
         });
         if (inputCommitted) acknowledgeTurnInputCommitted(msg.turnId);
         else if (ordinaryImTurnId) rejectOrdinaryImTurn(ordinaryImTurnId, 'cli_input_unavailable');

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -2550,9 +2550,11 @@ describe('buildResumeCommand', () => {
 });
 
 describe('native session rename capability', () => {
-  it('is declared only by the verified Codex, Claude Code, and Grok adapters', () => {
+  it('is declared only by the verified Codex-family, Claude Code, and Grok adapters', () => {
     expect(createCodexAdapter('/bin/codex').buildSessionRenameCommand?.('新的标题'))
       .toBe('/rename 新的标题');
+    expect(createTraexAdapter('/bin/traex').buildSessionRenameCommand?.('TraeX 标题'))
+      .toBe('/rename TraeX 标题');
     expect(createClaudeCodeAdapter('/bin/claude').buildSessionRenameCommand?.('new title'))
       .toBe('/rename new title');
     expect(createGrokAdapter('/usr/bin/grok').buildSessionRenameCommand?.('新标题'))

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -2977,10 +2977,13 @@ describe('handleCommand', () => {
       expect(replyContent).toContain('Agent 当前未运行');
     });
 
-    it('requests native rename from a live Codex worker without restarting it', async () => {
+    it.each([
+      ['codex', '/bin/codex'],
+      ['traex', '/bin/traex'],
+    ] as const)('requests native rename from a live %s worker without restarting it', async (cliId, cliPathOverride) => {
       const send = vi.fn();
       const ds = makeDaemonSession({
-        session: makeSession({ cliId: 'codex', cliPathOverride: '/bin/codex' }),
+        session: makeSession({ cliId, cliPathOverride }),
         worker: { killed: false, connected: true, send } as any,
       });
       const deps = makeDeps(ds);
@@ -2993,7 +2996,7 @@ describe('handleCommand', () => {
       expect(ds.session.nativeSessionTitle).toBe('Native 同步');
       expect(ds.session.nativeSessionTitleUserDefined).toBe(true);
       const replyContent = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
-      expect(replyContent).toContain('已向 codex 发送原生改名请求');
+      expect(replyContent).toContain(`已向 ${cliId} 发送原生改名请求`);
     });
   });
 

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -2067,7 +2067,10 @@ describe('GET /api/sessions/:sessionId/usage', () => {
 });
 
 describe('POST /api/sessions/:sessionId/rename', () => {
-  it('updates the canonical title and requests native sync from a live Codex worker', async () => {
+  it.each([
+    ['codex', '/bin/codex'],
+    ['traex', '/bin/traex'],
+  ] as const)('updates the canonical title and requests native sync from a live %s worker', async (cliId, cliPathOverride) => {
     const dataDir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-session-rename-'));
     const prevDataDir = config.session.dataDir;
     const events: any[] = [];
@@ -2078,8 +2081,8 @@ describe('POST /api/sessions/:sessionId/rename', () => {
       config.session.dataDir = dataDir;
       sessionStore.init();
       const session = sessionStore.createSession('oc_rename', 'om_rename', 'Old title', 'group');
-      session.cliId = 'codex';
-      session.cliPathOverride = '/bin/codex';
+      session.cliId = cliId;
+      session.cliPathOverride = cliPathOverride;
       session.backendType = 'tmux';
       sessionStore.updateSession(session);
 

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -3508,10 +3508,15 @@ describe('session.start lifecycle integration', () => {
     }));
   });
 
-  it('passes the persisted Lark topic title to a fresh Codex worker before its first prompt', () => {
+  it.each([
+    ['codex'],
+    ['traex'],
+  ] as const)('passes the persisted Lark topic title to a fresh %s worker before its first prompt', (cliId) => {
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId, wrapperCli: undefined }));
     const ds = makeDs({
       session: {
         ...makeDs().session,
+        cliId,
         title: '@TestBot 排查这个 TTP logid',
         nativeSessionTitle: '[BotMux·Lark] 排查这个 TTP logid',
       },
@@ -3532,10 +3537,15 @@ describe('session.start lifecycle integration', () => {
     }));
   });
 
-  it('waits when a fresh Codex topic only contains the bot mention', () => {
+  it.each([
+    ['codex'],
+    ['traex'],
+  ] as const)('waits when a fresh %s topic only contains the bot mention', (cliId) => {
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId, wrapperCli: undefined }));
     const ds = makeDs({
       session: {
         ...makeDs().session,
+        cliId,
         title: '@@TestBot',
         nativeSessionTitle: '[BotMux·Lark] @@TestBot',
         chatDisplayName: 'BotMux 标题优化群',
@@ -3556,10 +3566,15 @@ describe('session.start lifecycle integration', () => {
     expect(ds.session.nativeSessionTitleAwaitingContent).toBe(true);
   });
 
-  it('reapplies the group fallback when a pending Codex worker restarts before any content', () => {
+  it.each([
+    ['codex'],
+    ['traex'],
+  ] as const)('reapplies the group fallback when a pending %s worker restarts before any content', (cliId) => {
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId, wrapperCli: undefined }));
     const ds = makeDs({
       session: {
         ...makeDs().session,
+        cliId,
         nativeSessionTitle: '[BotMux·Lark] BotMux 标题优化群',
         nativeSessionTitleAwaitingContent: true,
         chatDisplayName: 'BotMux 标题优化群',
@@ -3577,13 +3592,17 @@ describe('session.start lifecycle integration', () => {
     expect(ds.session.nativeSessionTitleAwaitingContent).toBe(true);
   });
 
-  it('consumes only the first meaningful follow-up for a pending Codex title', () => {
+  it.each([
+    ['codex'],
+    ['traex'],
+  ] as const)('consumes only the first meaningful follow-up for a pending %s title', (cliId) => {
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId, wrapperCli: undefined }));
     const worker = makeFakeWorker();
     const ds = makeDs({
       worker,
       session: {
         ...makeDs().session,
-        cliId: 'codex',
+        cliId,
         nativeSessionTitle: '[BotMux·Lark] 新话题',
         nativeSessionTitleAwaitingContent: true,
       },
@@ -3616,10 +3635,15 @@ describe('session.start lifecycle integration', () => {
     });
   });
 
-  it('consumes a pending Codex title when a stopped worker resumes', () => {
+  it.each([
+    ['codex'],
+    ['traex'],
+  ] as const)('consumes a pending %s title when a stopped worker resumes', (cliId) => {
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId, wrapperCli: undefined }));
     const ds = makeDs({
       session: {
         ...makeDs().session,
+        cliId,
         cliSessionId: 'codex-native-pending',
         nativeSessionTitle: '[BotMux·Lark] 新话题',
         nativeSessionTitleAwaitingContent: true,
@@ -3637,10 +3661,15 @@ describe('session.start lifecycle integration', () => {
     expect(ds.session.nativeSessionTitleAwaitingContent).toBeUndefined();
   });
 
-  it('passes the pending fallback when a stopped Codex worker has no native session id yet', () => {
+  it.each([
+    ['codex'],
+    ['traex'],
+  ] as const)('passes the pending fallback when a stopped %s worker has no native session id yet', (cliId) => {
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId, wrapperCli: undefined }));
     const ds = makeDs({
       session: {
         ...makeDs().session,
+        cliId,
         nativeSessionTitle: '[BotMux·Lark] 新话题',
         nativeSessionTitleAwaitingContent: true,
       },

--- a/test/session-rename-worker.test.ts
+++ b/test/session-rename-worker.test.ts
@@ -35,6 +35,21 @@ describe('worker native session rename queue', () => {
     expect(flushRegion).toContain('syncFreshCodexNativeSessionTitle(threadId, codexRpcEngine)');
   });
 
+  it('keeps Codex native title sync codex-only', () => {
+    const syncStart = workerSource.indexOf('async function syncFreshCodexNativeSessionTitle(');
+    const syncEnd = workerSource.indexOf('/** 在 resume 首条输入前记录', syncStart);
+    const syncRegion = workerSource.slice(syncStart, syncEnd);
+    const flushStart = workerSource.indexOf('async function flushPending()');
+    const flushEnd = workerSource.indexOf('\nfunction sendToPty(', flushStart);
+    const flushRegion = workerSource.slice(flushStart, flushEnd);
+
+    expect(workerSource).not.toContain('function supportsCodexAppNativeSessionTitle(');
+    expect(syncRegion).toContain("cfg.cliId !== 'codex'");
+    expect(syncRegion).toContain("createCliAdapterSync('codex'");
+    expect(syncRegion).toContain('generateCodexAppThreadTitle({');
+    expect(flushRegion).toContain("lastInitConfig?.cliId === 'codex'");
+  });
+
   it('captures the resume metadata baseline without applying the title before the first append', () => {
     const region = caseRegion('init');
     expect(region).toContain('await prepareCodexNativeTitleGeneration(msg, codexRpcEngine)');
@@ -97,6 +112,34 @@ describe('worker native session rename queue', () => {
     expect(region).toContain('lastInitConfig.nativeSessionTitlePrompt = msg.nativeSessionTitlePrompt');
     expect(region).toContain('stopNativeSessionTitleSync()');
     expect(region).toContain('void syncFreshCodexNativeSessionTitle(threadId, codexRpcEngine)');
+  });
+
+  it('queues TraeX automatic titles only after the tagged user input submits', () => {
+    const flushStart = workerSource.indexOf('async function flushPending()');
+    const flushEnd = workerSource.indexOf('\nfunction sendToPty(', flushStart);
+    const flushRegion = workerSource.slice(flushStart, flushEnd);
+    const helperStart = workerSource.indexOf('function queuePostSubmitNativeSessionTitle(');
+    const helperEnd = workerSource.indexOf('\n/** 在 resume 首条输入前记录', helperStart);
+    const helperRegion = workerSource.slice(helperStart, helperEnd);
+
+    expect(helperRegion).toContain("supportsPostSubmitRenameSessionTitle(cfg.cliId)");
+    expect(helperRegion).toContain('pendingSessionRename = trimmed');
+    expect(flushRegion.indexOf('() => writeAdapter.writeInput('))
+      .toBeLessThan(flushRegion.indexOf('maybeQueuePostSubmitNativeSessionTitle(item)'));
+    expect(flushRegion).toContain('if (queuedPostSubmitNativeTitle) break');
+  });
+
+  it('keeps deferred submit recheck able to queue a TraeX automatic title', () => {
+    const helperStart = workerSource.indexOf('function scheduleSubmitFailureNotify(');
+    const helperEnd = workerSource.indexOf('\nfunction dropExactReceiptHandle', helperStart);
+    const helperRegion = workerSource.slice(helperStart, helperEnd);
+    const suppressIdx = helperRegion.indexOf("case 'suppress-confirmed':");
+    const queueIdx = helperRegion.indexOf('queuePostSubmitNativeSessionTitle(turnIdentity?.nativeSessionTitle)', suppressIdx);
+    const persistIdx = helperRegion.indexOf('persistCliSessionId(cliSessionId)', suppressIdx);
+
+    expect(suppressIdx).toBeGreaterThanOrEqual(0);
+    expect(queueIdx).toBeGreaterThan(suppressIdx);
+    expect(queueIdx).toBeLessThan(persistIdx);
   });
 
   it('queues rename IPC without opening a renderer or usage turn', () => {

--- a/test/session-rename.test.ts
+++ b/test/session-rename.test.ts
@@ -37,6 +37,7 @@ function liveWorker(send = vi.fn()): any {
 describe('requestAgentSessionRename', () => {
   it.each([
     ['codex', '/bin/codex'],
+    ['traex', '/bin/traex'],
     ['claude-code', '/bin/claude'],
   ] as const)('sends the dedicated IPC for live %s sessions', (cliId, cliPathOverride) => {
     const send = vi.fn();

--- a/test/worker-ordinary-im-init-concurrency.integration.test.ts
+++ b/test/worker-ordinary-im-init-concurrency.integration.test.ts
@@ -59,7 +59,10 @@ setInterval(() => {}, 1_000);
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     });
     children.add(child);
-    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.on('message', raw => {
+      messages.push(raw as WorkerToDaemon);
+      logs.push(`[ipc] ${JSON.stringify(raw)}\n`);
+    });
     child.stdout?.on('data', chunk => logs.push(chunk.toString()));
     child.stderr?.on('data', chunk => logs.push(chunk.toString()));
 
@@ -186,6 +189,208 @@ if (process.argv.includes('app-server')) {
     expect(messages).not.toContainEqual(expect.objectContaining({
       type: 'turn_input_rejected',
       turnId: 'om_followup_order',
+    }));
+  }, 20_000);
+
+  it('renames a TraeX native session only after the first Lark prompt is submitted', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-traex-native-title-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    const traeHome = join(root, 'trae-home');
+    const inputLog = join(root, 'stdin.log');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(join(traeHome, 'cli'), { recursive: true });
+    const firstPrompt = '<botmux_routing>hidden</botmux_routing>\n<user_message>@TestBot 排查标题问题</user_message>';
+    const fakeTraex = join(root, 'fake-traex');
+    writeFileSync(fakeTraex, `#!/usr/bin/env node
+const fs = require('node:fs');
+const inputLog = ${JSON.stringify(inputLog)};
+const historyPath = ${JSON.stringify(join(traeHome, 'cli', 'history.jsonl'))};
+const firstPrompt = ${JSON.stringify(firstPrompt)};
+let submittedFirstPrompt = false;
+process.on('uncaughtException', error => {
+  fs.appendFileSync(inputLog, 'ERR:' + (error && error.stack || error) + '\\n');
+  process.exit(42);
+});
+function submitHistory(text) {
+  fs.appendFileSync(inputLog, text + '\\n---SUBMIT---\\n');
+  fs.appendFileSync(historyPath, JSON.stringify({ session_id: 'traex-native-title', ts: Date.now(), text }) + '\\n');
+  setTimeout(() => process.stdout.write('›\\n'), 50);
+}
+setTimeout(() => process.stdout.write('›\\n'), 200);
+process.stdin.on('data', chunk => {
+  const text = chunk.toString();
+  fs.appendFileSync(inputLog, text);
+  if (!submittedFirstPrompt && text.includes('<user_message>@TestBot 排查标题问题</user_message>')) {
+    submittedFirstPrompt = true;
+    submitHistory(firstPrompt);
+  }
+  if (text.includes('/rename [BotMux·Lark] 排查标题问题')) {
+    setTimeout(() => process.stdout.write('›\\n'), 50);
+  }
+});
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakeTraex, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawnNodeTsScript(resolve('src/worker.ts'), [], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        TRAE_HOME: traeHome,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-traex-native-title',
+        BOTMUX_TIME_SCALE: '0.05',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => {
+      messages.push(raw as WorkerToDaemon);
+      logs.push(`[ipc] ${JSON.stringify(raw)}\n`);
+    });
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-traex-native-title',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'traex',
+      cliPathOverride: fakeTraex,
+      backendType: 'pty',
+      prompt: firstPrompt,
+      nativeSessionTitle: '[BotMux·Lark] 排查标题问题',
+      nativeSessionTitlePrompt: '排查标题问题',
+      queuedActivationToken: 'activation-title-token',
+      env: { FAKE_INPUT_LOG: inputLog, TRAE_HOME: traeHome },
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_initial',
+    } satisfies DaemonToWorker);
+
+    await waitFor(() => {
+      if (!existsSync(inputLog)) return false;
+      const input = readFileSync(inputLog, 'utf8');
+      return input.includes('<user_message>@TestBot 排查标题问题</user_message>')
+        && input.includes('/rename [BotMux·Lark] 排查标题问题')
+        && messages.some(message => message.type === 'queued_activation_submitted');
+    }, logs, 14_000);
+
+    const input = readFileSync(inputLog, 'utf8');
+    expect(input).toContain('<botmux_routing>hidden</botmux_routing>');
+    expect(input.indexOf('<user_message>@TestBot 排查标题问题</user_message>'))
+      .toBeLessThan(input.indexOf('/rename [BotMux·Lark] 排查标题问题'));
+    expect(messages).toContainEqual({
+      type: 'queued_activation_submitted',
+      sessionId: 'sid-traex-native-title',
+      activationToken: 'activation-title-token',
+    });
+    expect(messages).toContainEqual({ type: 'turn_input_committed', turnId: 'om_initial' });
+    expect(messages).not.toContainEqual(expect.objectContaining({
+      type: 'turn_input_rejected',
+      turnId: 'om_initial',
+    }));
+  }, 20_000);
+
+  it('does not rename a TraeX native session when the tagged prompt is not submitted', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-traex-native-title-fail-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    const traeHome = join(root, 'trae-home');
+    const inputLog = join(root, 'stdin.log');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(join(traeHome, 'cli'), { recursive: true });
+    const firstPrompt = '<botmux_routing>hidden</botmux_routing>\n<user_message>@TestBot 排查失败提交</user_message>';
+    const fakeTraex = join(root, 'fake-traex-fail');
+    writeFileSync(fakeTraex, `#!/usr/bin/env node
+const fs = require('node:fs');
+const inputLog = ${JSON.stringify(inputLog)};
+setTimeout(() => process.stdout.write('›\\n'), 200);
+process.stdin.on('data', chunk => {
+  const text = chunk.toString();
+  fs.appendFileSync(inputLog, text);
+  if (text.includes('<user_message>@TestBot 排查失败提交</user_message>')) {
+    setTimeout(() => process.stdout.write('›\\n'), 50);
+    setTimeout(() => process.stdout.write('›\\n'), 1000);
+  }
+  if (text.includes('/rename [BotMux·Lark] 排查失败提交')) {
+    setTimeout(() => process.stdout.write('›\\n'), 50);
+  }
+});
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakeTraex, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawnNodeTsScript(resolve('src/worker.ts'), [], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        TRAE_HOME: traeHome,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-traex-native-title-fail',
+        BOTMUX_TIME_SCALE: '0.05',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => {
+      messages.push(raw as WorkerToDaemon);
+      logs.push(`[ipc] ${JSON.stringify(raw)}\n`);
+    });
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-traex-native-title-fail',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'traex',
+      cliPathOverride: fakeTraex,
+      backendType: 'pty',
+      prompt: firstPrompt,
+      nativeSessionTitle: '[BotMux·Lark] 排查失败提交',
+      nativeSessionTitlePrompt: '排查失败提交',
+      env: { FAKE_INPUT_LOG: inputLog, TRAE_HOME: traeHome },
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_initial_fail',
+    } satisfies DaemonToWorker);
+
+    await waitFor(() => {
+      if (!existsSync(inputLog)) return false;
+      return readFileSync(inputLog, 'utf8').includes('<user_message>@TestBot 排查失败提交</user_message>');
+    }, logs, 10_000);
+
+    child.send({
+      type: 'message',
+      content: '<user_message>后续消息不应抢走标题</user_message>',
+      turnId: 'om_followup_after_failed_submit',
+    } satisfies DaemonToWorker);
+
+    await new Promise(resolve => setTimeout(resolve, 5_000));
+
+    const input = readFileSync(inputLog, 'utf8');
+    expect(input).toContain('<user_message>@TestBot 排查失败提交</user_message>');
+    expect(input).not.toContain('/rename [BotMux·Lark] 排查失败提交');
+    expect(messages).toContainEqual({ type: 'turn_input_committed', turnId: 'om_initial_fail' });
+    expect(messages).not.toContainEqual(expect.objectContaining({
+      type: 'turn_input_rejected',
+      turnId: 'om_initial_fail',
     }));
   }, 20_000);
 });

--- a/test/worker-queue-merge.test.ts
+++ b/test/worker-queue-merge.test.ts
@@ -60,6 +60,29 @@ describe('mergeQueuedCliInput', () => {
     })).toBe(false);
   });
 
+  it('never merges a turn that carries an automatic native title', () => {
+    const pending = [{
+      content: '<user_message>@Bot first task</user_message>',
+      nativeSessionTitle: '[BotMux·Lark] first task',
+      nativeSessionTitlePrompt: 'first task',
+      turnId: 't1',
+    }];
+
+    expect(mergeQueuedCliInput(pending, { content: 'second task', turnId: 't2' })).toBe(false);
+    expect(pending).toEqual([{
+      content: '<user_message>@Bot first task</user_message>',
+      nativeSessionTitle: '[BotMux·Lark] first task',
+      nativeSessionTitlePrompt: 'first task',
+      turnId: 't1',
+    }]);
+
+    expect(mergeQueuedCliInput([{ content: 'ordinary', turnId: 't1' }], {
+      content: '<user_message>@Bot first task</user_message>',
+      nativeSessionTitle: '[BotMux·Lark] first task',
+      turnId: 't2',
+    })).toBe(false);
+  });
+
   it('never merges queued explicit meeting IM turns or batches them on one live origin', () => {
     const pending = [{ content: 'human A', turnId: 'im-1', vcMeetingImTurnOrigin: imOrigin }];
     expect(mergeQueuedCliInput(pending, {


### PR DESCRIPTION
本次改动为 TraeX 补齐 Botmux 会话标题同步能力，避免 TraeX 原生 resume picker 把 Botmux 注入的首轮路由包作为会话标题。
为 TraeX adapter 声明原生 /rename 能力，使 dashboard / 命令侧显式重命名可以同步到 TraeX 原生会话。
daemon 侧复用现有 Botmux Lark native title 生成逻辑，把 nativeSessionTitle / nativeSessionTitlePrompt sidecar 传给 TraeX worker。
worker 侧对 TraeX 采用 post-submit rename：首条真实用户输入成功提交后，再排队执行 /rename [BotMux·Lark] ...，避免 /rename 抢在业务首轮之前写入原生会话。
保持 Codex native title sync 原有路径为 codex-only，TraeX 普通 TUI 不复用 Codex semantic title generation。
修复 TraeX 自动 rename 与 queued activation 的顺序问题：先发送 queued_activation_submitted ACK，再中断当前 batch 去执行 rename，避免 daemon 卡在 activation pending。
扩展 pending input 类型和 merge 规则，带 native title sidecar 的 turn 不参与普通消息合并，避免标题绑定到错误输入。