### PR TITLE
fix(setup): 明确区分两代 TRAE CLI

### DIFF
--- a/src/dashboard/web/bot-defaults.ts
+++ b/src/dashboard/web/bot-defaults.ts
@@ -158,7 +158,7 @@ export type LoadBotsResult = {
 export const fallbackCliOptions: CliOption[] = [
   { id: 'claude-code', label: 'Claude' },
   { id: 'codex', label: 'Codex' },
-  { id: 'traex', label: 'traex' },
+  { id: 'traex', label: 'TRAE CLI 2.0' },
 ];
 
 export const fallbackCliOptionsState: CliOptionsState = {

--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -77,12 +77,22 @@ const CODEX_APP: CliSelectOption = { key: 'codex-app', label: 'Codex App', cliId
 const CODEX_VARIANTS: ReadonlyArray<CliSelectOption> = [CODEX_NATIVE, CODEX_APP];
 
 // ─── TRAE 选项 ───────────────────────────────────────────────────────────────
-// TRAE 家族合并成一个「TRAE (CoCo)」二级菜单（都是原生 cliId，无 wrapperCli）：
-//   - TRAE CLI (CoCo) → cliId `coco`  ：Trae CLI 的 CoCo 形态
-//   - traex           → cliId `traex` ：TRAE CLI（traecli）
-const TRAE_COCO: CliSelectOption = { key: 'coco', label: 'TRAE CLI（CoCo）', cliId: 'coco' };
-const TRAE_X: CliSelectOption = { key: 'traex', label: 'traex', cliId: 'traex' };
-const TRAE_VARIANTS: ReadonlyArray<CliSelectOption> = [TRAE_COCO, TRAE_X];
+// 新旧两代 TRAE CLI 是不同协议的 adapter，合并展示但不能混用 cliId：
+//   - TRAE CLI 2.0 → cliId `traex`：当前版本；共存期用不冲突的 `traex` 启动，
+//                    面向用户的正式命令名 `traecli` 作为选择 alias 接受
+//   - TRAE CLI 1.0 → cliId `coco` ：旧版 Coco，保留用于已有配置与历史 session
+// 新版必须排在前面，避免安装当前 TRAE CLI 后误选 legacy adapter。
+const TRAE_X: CliSelectOption = {
+  key: 'traex',
+  label: 'TRAE CLI 2.0（推荐；traex / traecli）',
+  cliId: 'traex',
+};
+const TRAE_COCO: CliSelectOption = {
+  key: 'coco',
+  label: 'TRAE CLI 1.0 / Coco（旧版，已停止维护）',
+  cliId: 'coco',
+};
+const TRAE_VARIANTS: ReadonlyArray<CliSelectOption> = [TRAE_X, TRAE_COCO];
 
 // ─── OpenCode 选项 ──────────────────────────────────────────────────────────
 // OpenCode 与 OpenCode 2 合并成一个「OpenCode」二级菜单（都是原生 cliId，无
@@ -169,8 +179,9 @@ export const CLI_SELECT_TREE: ReadonlyArray<CliSelectGroup> = [
     // codex + codex-app collapse into one「Codex」二级菜单 at codex's position.
     if (o.id === 'codex') return [{ key: 'codex', label: 'Codex', children: CODEX_VARIANTS }];
     if (o.id === 'codex-app') return [];
-    // coco + traex collapse into one「TRAE (CoCo)」二级菜单 at coco's position.
-    if (o.id === 'coco') return [{ key: 'trae', label: 'TRAE (CoCo)', children: TRAE_VARIANTS }];
+    // coco + traex collapse into one「TRAE CLI」submenu at coco's position.
+    // Keep the underlying CLI_OPTIONS / numeric cliId mapping untouched.
+    if (o.id === 'coco') return [{ key: 'trae', label: 'TRAE CLI', children: TRAE_VARIANTS }];
     if (o.id === 'traex') return [];
     // Pi and Oh My Pi are kept as adjacent leaves (emitted together at pi's spot).
     if (o.id === 'pi') return [
@@ -197,7 +208,7 @@ export const CLI_SELECT_OPTIONS: ReadonlyArray<CliSelectOption> = [
     if (o.id === 'mir') return [];               // already included via MIRA_VARIANTS
     if (o.id === 'codex') return CODEX_VARIANTS;  // expands to Codex + Codex App
     if (o.id === 'codex-app') return [];
-    if (o.id === 'coco') return TRAE_VARIANTS;    // expands to TRAE CLI (CoCo) + traex
+    if (o.id === 'coco') return TRAE_VARIANTS;    // expands to TRAE CLI 2.0 + legacy Coco
     if (o.id === 'traex') return [];
     if (o.id === 'pi') return [PI_OPTION, OHMYPI_OPTION];  // Pi + Oh My Pi adjacent
     if (o.id === 'oh-my-pi') return [];
@@ -213,9 +224,18 @@ const OPTION_BY_KEY: ReadonlyMap<string, CliSelectOption> = new Map(
   CLI_SELECT_OPTIONS.map((o) => [o.key, o]),
 );
 
+/**
+ * 用户文档中的命令名到稳定选择键的 alias。alias 只参与输入解析，不生成重复菜单项；
+ * Bot 配置仍落已有 cliId，避免迁移 adapter 注册、配置和历史 session。
+ */
+export const CLI_SELECTION_ALIASES: Readonly<Record<string, string>> = {
+  traecli: 'traex',
+};
+
 /** 按 key 查选项；非法 key 返回 undefined。 */
 export function lookupCliSelection(key: string): CliSelectOption | undefined {
-  return OPTION_BY_KEY.get(key.trim());
+  const normalized = key.trim();
+  return OPTION_BY_KEY.get(CLI_SELECTION_ALIASES[normalized] ?? normalized);
 }
 
 /** 反查：由一个 bot 现有的 cliId + wrapperCli 得到对应的选择键（供编辑时高亮默认）。 */
@@ -233,8 +253,9 @@ export function selectionKeyForBot(cliId: string, wrapperCli?: string): string {
 export function resolveCliSelection(key: string): ResolvedCliSelection {
   const opt = lookupCliSelection(key);
   if (!opt) {
+    const legalKeys = [...CLI_SELECT_OPTIONS.map((o) => o.key), ...Object.keys(CLI_SELECTION_ALIASES)];
     throw new Error(
-      `未知 CLI 选择项 "${key}"。合法值：${CLI_SELECT_OPTIONS.map((o) => o.key).join(', ')}`,
+      `未知 CLI 选择项 "${key}"。合法值：${legalKeys.join(', ')}`,
     );
   }
   return opt.wrapperCli ? { cliId: opt.cliId, wrapperCli: opt.wrapperCli } : { cliId: opt.cliId };

--- a/src/setup/interactive-select.ts
+++ b/src/setup/interactive-select.ts
@@ -215,8 +215,8 @@ export async function pickChoice(
 }
 
 /**
- * 级联 CLI 选择器：顶层列出所有 CLI（Aiden 带 ▸），选 Aiden 进二级菜单
- * （原生 / × Claude / × Codex）。返回选择键（CLI_SELECT_OPTIONS 的 key），
+ * 级联 CLI 选择器：顶层列出所有 CLI，带变体的 CLI 进入二级菜单。
+ * 返回选择键（CLI_SELECT_OPTIONS 的 key），
  * 取消返回 null。
  *
  * 非 TTY 回退：打印带序号的扁平列表，用 readline 读「序号 / key」。
@@ -237,7 +237,8 @@ export async function pickCliSelection(
     const byNum = CLI_SELECT_OPTIONS[Number(ans) - 1];
     if (byNum) return byNum.key;
     const byKey = CLI_SELECT_OPTIONS.find((o) => o.key === ans);
-    return byKey ? byKey.key : ans; // 透传：让上层 resolveCliSelection 抛错给出明确提示
+    // 未命中时透传：resolveCliSelection 会解析 traecli 等 alias，或给出明确错误。
+    return byKey ? byKey.key : ans;
   }
 
   // ── TTY：级联 ──
@@ -248,7 +249,7 @@ export async function pickCliSelection(
       hint: g.children ? '' : g.option?.key,
       submenu: !!g.children,
     }));
-    const ti = await interactiveSelect({ title, items: topItems, footer: '选 Aiden 进入子菜单（× Claude / × Codex）' });
+    const ti = await interactiveSelect({ title, items: topItems, footer: '带 ▸ 的项目可进入子菜单选择具体版本或形态' });
     if (ti === null) return null;
     const group = CLI_SELECT_TREE[ti];
     if (group.option) return group.option.key;

--- a/src/setup/setup-args.ts
+++ b/src/setup/setup-args.ts
@@ -14,7 +14,7 @@ import {
   hasOwnerEntry,
   type BotConfigEditInput,
 } from './bot-config-editor.js';
-import { CLI_SELECT_OPTIONS, resolveCliSelection } from './cli-selection.js';
+import { CLI_SELECT_OPTIONS, CLI_SELECTION_ALIASES, resolveCliSelection } from './cli-selection.js';
 import type { CliRuntimeConfig } from '../adapters/cli/runtime.js';
 
 /** add / edit 共用的 bot 字段 flag（原始字符串，'-' 表示清空，语义同 TUI 编辑）。 */
@@ -123,7 +123,8 @@ export const SETUP_CLI_USAGE = `botmux setup — 脚本化（非 TUI）用法
   --app-id <cli_xxx>         飞书应用 App ID（edit 时改绑另一个应用）
   --app-secret <secret>      App Secret
   --cli <key>                CLI 适配器：cliId 或网关键（claude-code / codex /
-                             aiden-x-claude / ttadk-x-codex …）
+                             traecli / aiden-x-claude / ttadk-x-codex …；
+                             traecli 映射到 TRAE CLI 2.0（内部 cliId=traex）
   --cli-path <path>          CLI 可执行文件路径覆盖
   --cli-runtime <JSON|->     Codex-compatible runtime 描述；JSON 含 id、
                              displayName、executable、update，传 - 清空
@@ -390,7 +391,7 @@ export function editInputFromFlags(flags: SetupBotFlags): BotConfigEditInput {
 
 /** 合法 --cli 取值（报错提示用）。 */
 export function cliSelectionKeys(): string[] {
-  return CLI_SELECT_OPTIONS.map(o => o.key);
+  return [...CLI_SELECT_OPTIONS.map(o => o.key), ...Object.keys(CLI_SELECTION_ALIASES)];
 }
 
 /** list --json 输出前的 secret 脱敏（CLI 输出可能被贴进聊天/日志）。 */

--- a/test/bot-config-editor.test.ts
+++ b/test/bot-config-editor.test.ts
@@ -520,6 +520,7 @@ describe('resolveCliId', () => {
     // 序号以 src/setup/bot-config-editor.ts 的 CLI_ID_CHOICES 为准；
     // 新 CLI 一律追加尾部，历史序号保持稳定（脚本化 setup 依赖）。
     expect(resolveCliId('1')).toBe('claude-code');
+    expect(resolveCliId('3')).toBe('coco');
     expect(resolveCliId('4')).toBe('codex');
     expect(resolveCliId('7')).toBe('opencode');
     expect(resolveCliId('9')).toBe('mtr');

--- a/test/cli-selection.test.ts
+++ b/test/cli-selection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CLI_SELECT_OPTIONS,
   CLI_SELECT_TREE,
+  CLI_SELECTION_ALIASES,
   resolveCliSelection,
   lookupCliSelection,
   selectionKeyForBot,
@@ -62,15 +63,28 @@ describe('CLI_SELECT_OPTIONS / CLI_SELECT_TREE', () => {
     expect(resolveCliSelection('codex-app')).toEqual({ cliId: 'codex-app' });
   });
 
-  it('cascades TRAE (CoCo) into one submenu of coco + traex (no top-level coco/traex)', () => {
+  it('cascades TRAE CLI into a current-first submenu without changing adapter ids', () => {
     const trae = CLI_SELECT_TREE.find((g) => g.key === 'trae');
-    expect(trae?.label).toBe('TRAE (CoCo)');
-    expect(trae?.children?.map((c) => c.key)).toEqual(['coco', 'traex']);
+    expect(trae?.label).toBe('TRAE CLI');
+    expect(trae?.children?.map((c) => c.key)).toEqual(['traex', 'coco']);
+    expect(trae?.children?.map((c) => c.label)).toEqual([
+      'TRAE CLI 2.0（推荐；traex / traecli）',
+      'TRAE CLI 1.0 / Coco（旧版，已停止维护）',
+    ]);
     expect(trae?.option).toBeUndefined();
     expect(CLI_SELECT_TREE.find((g) => g.key === 'coco')).toBeUndefined();
     expect(CLI_SELECT_TREE.find((g) => g.key === 'traex')).toBeUndefined();
     expect(resolveCliSelection('coco')).toEqual({ cliId: 'coco' });
     expect(resolveCliSelection('traex')).toEqual({ cliId: 'traex' });
+    const flatKeys = CLI_SELECT_OPTIONS.map((o) => o.key);
+    expect(flatKeys.indexOf('traex')).toBe(flatKeys.indexOf('coco') - 1);
+  });
+
+  it('keeps traecli as an input-only alias of the TRAE CLI 2.0 adapter', () => {
+    expect(CLI_SELECTION_ALIASES).toMatchObject({ traecli: 'traex' });
+    expect(CLI_SELECT_OPTIONS.map((o) => o.key)).not.toContain('traecli');
+    expect(lookupCliSelection('traecli')).toBe(lookupCliSelection('traex'));
+    expect(resolveCliSelection('traecli')).toEqual({ cliId: 'traex' });
   });
 
   it('keeps Pi and Oh My Pi as adjacent top-level leaves', () => {

--- a/test/setup-args.test.ts
+++ b/test/setup-args.test.ts
@@ -6,6 +6,7 @@ import {
   maskAppSecret,
   parseSetupCommand,
   SETUP_CLI_USAGE,
+  cliSelectionKeys,
 } from '../src/setup/setup-args.js';
 import { applyBotConfigEdits } from '../src/setup/bot-config-editor.js';
 
@@ -212,6 +213,19 @@ describe('buildBotFromAddFlags', () => {
     const bot = buildBotFromAddFlags({ ...REQUIRED, cli: 'aiden-x-claude' });
     expect(bot.cliId).toBe('claude-code');
     expect(bot.wrapperCli).toBe('aiden x claude');
+  });
+
+  it('accepts the documented traecli command name as TRAE CLI 2.0', () => {
+    expect(cliSelectionKeys()).toContain('traecli');
+    expect(SETUP_CLI_USAGE).toContain('traecli 映射到 TRAE CLI 2.0');
+    expect(buildBotFromAddFlags({ ...REQUIRED, cli: 'traecli' })).toMatchObject({
+      cliId: 'traex',
+    });
+    expect(editInputFromFlags({ cli: 'traecli' })).toEqual({
+      cliChoice: 'traex',
+      wrapperCli: null,
+      cliRuntime: null,
+    });
   });
 
   it('builds a Codex-compatible runtime from --cli-runtime JSON', () => {


### PR DESCRIPTION
## 背景

TRAE CLI 的产品与命令名经历了从 Coco / TRAE CLI 1.0 到 TRAE CLI 2.0（TraeX）的演进。当前安装入口使用 `traecli`，但 BotMux setup 仍把 `TRAE (CoCo)` 作为入口，并将旧 `coco` adapter 排在新版 `traex` 前面，用户很容易在安装新版后误选旧协议。

## 改动

- 将 setup 顶层选项统一命名为 `TRAE CLI`。
- 二级菜单优先展示 `TRAE CLI 2.0（推荐；traex / traecli）`，并明确标记 `TRAE CLI 1.0 / Coco` 为停止维护的旧版。
- 新增输入别名 `traecli -> traex`，支持 scripted setup 使用正式命令名，同时保持内部 `cliId=traex` 不变。
- 保留 `coco` / `traex` 两个既有 cliId，不迁移现有配置或历史 session。
- 保持历史数字映射不变：`3 -> coco`、`14 -> traex`。
- 同步 Dashboard 离线 fallback 的展示名称。

## 影响面

- 影响交互式 setup、scripted `setup add/edit --cli` 和 Dashboard 离线 CLI 标签。
- 不修改 adapter 启动命令、可执行文件探测或运行时协议。
- 不影响已有 Bot 配置、历史 session、其它 CLI、后端或 IM 平台。

## 验证

- `bun run build`：通过。
- `bun run test -- test/cli-selection.test.ts test/setup-args.test.ts test/cli-availability.test.ts test/bot-config-editor.test.ts`：4 个文件、184 项测试全部通过。
- `bun run test`：20,309 项通过、19 项跳过；`test/plugin-mcp-sandbox.test.ts` 的 2 个 MCP/bwrap 集成场景因 `MCP error -32000: Connection closed` 失败，单独复跑结果一致，与本次 setup 选择逻辑无交集。
- `bun run daemon:restart`：通过。
