### PR TITLE
feat(recovery): 增加普通会话持久恢复与存活看门狗

### DIFF
--- a/src/core/daemon-heartbeat.ts
+++ b/src/core/daemon-heartbeat.ts
@@ -18,6 +18,9 @@ export interface Heartbeat {
   larkAppId: string;
   busyCount: number;
   at: string; // ISO 8601
+  /** OS process identity for event-loop supervision. A stale file from the
+   * previous daemon generation must never keep its replacement "healthy". */
+  pid?: number;
 }
 
 /** A heartbeat older than this is treated as "daemon not reporting" → ignored.
@@ -28,12 +31,18 @@ export function heartbeatDirIn(dir: string): string {
   return join(dir, 'heartbeats');
 }
 
-export function writeHeartbeatTo(dir: string, larkAppId: string, busyCount: number, atIso: string): void {
+export function writeHeartbeatTo(
+  dir: string,
+  larkAppId: string,
+  busyCount: number,
+  atIso: string,
+  pid = process.pid,
+): void {
   const hbDir = heartbeatDirIn(dir);
   if (!existsSync(hbDir)) mkdirSync(hbDir, { recursive: true });
   const path = join(hbDir, `${sanitize(larkAppId)}.json`);
   const tmp = `${path}.${process.pid}.tmp`;
-  const beat: Heartbeat = { larkAppId, busyCount, at: atIso };
+  const beat: Heartbeat = { larkAppId, busyCount, at: atIso, pid };
   writeFileSync(tmp, JSON.stringify(beat));
   renameSync(tmp, path);
 }
@@ -59,13 +68,32 @@ export function anyDaemonBusyTo(dir: string, nowMs: number, freshMs: number = HE
 function readBeat(path: string): Heartbeat | null {
   try {
     const v = JSON.parse(readFileSync(path, 'utf-8'));
-    if (v && typeof v === 'object' && typeof v.busyCount === 'number' && typeof v.at === 'string') {
+    if (v
+      && typeof v === 'object'
+      && typeof v.larkAppId === 'string'
+      && typeof v.busyCount === 'number'
+      && typeof v.at === 'string'
+      && (v.pid === undefined || (Number.isSafeInteger(v.pid) && v.pid > 1))) {
       return v as Heartbeat;
     }
   } catch {
     /* corrupt/partial write → ignore */
   }
   return null;
+}
+
+/** Read one daemon's event-loop heartbeat with a parsed timestamp. Invalid,
+ * mismatched, corrupt, or legacy pid-less files are not liveness evidence. */
+export function readDaemonHeartbeatTo(
+  dir: string,
+  larkAppId: string,
+): { pid: number; atMs: number } | null {
+  const beat = readBeat(join(heartbeatDirIn(dir), `${sanitize(larkAppId)}.json`));
+  if (!beat || beat.larkAppId !== larkAppId) return null;
+  const atMs = Date.parse(beat.at);
+  return Number.isFinite(atMs) && beat.pid !== undefined
+    ? { pid: beat.pid, atMs }
+    : null;
 }
 
 /** App ids are already filesystem-safe (cli_…), but guard against separators. */

--- a/src/core/fleet-supervisor.ts
+++ b/src/core/fleet-supervisor.ts
@@ -27,6 +27,8 @@ import {
 } from './fleet-supervisor-policy.js';
 import { mutateFleetState, readFleetState } from './fleet-state-store.js';
 import type { FleetCommand } from './fleet-command-queue.js';
+import { readDaemonHeartbeatTo } from './daemon-heartbeat.js';
+import { daemonHeartbeatStatus } from './liveness-watchdog.js';
 
 export interface FleetBotSpec {
   /** botmux-<index> process name (or 'botmux-dashboard' for the dashboard). */
@@ -102,6 +104,14 @@ export interface FleetSupervisorOptions {
    *  can tail a specific bot — mirrors pm2's out_file/error_file. When unset
    *  (tests), children inherit the supervisor's stdio. */
   logDir?: string;
+  /** Independent event-loop watchdog for daemon members only. Dashboard and
+   * external plugin members do not publish this heartbeat and are excluded. */
+  heartbeat?: {
+    dataDir: string;
+    scanIntervalMs: number;
+    staleMs: number;
+    startupGraceMs: number;
+  };
   /** Injected for tests; defaults to console. */
   log?: (msg: string) => void;
 }
@@ -117,6 +127,9 @@ export class FleetSupervisor {
   /** Per-name generation the live child was spawned with — guards stale exits. */
   private readonly liveGeneration = new Map<string, number>();
   private readonly restartTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly childStartedAtMs = new Map<string, number>();
+  private readonly heartbeatKillInFlight = new Set<string>();
+  private heartbeatScanTimer?: ReturnType<typeof setInterval>;
   /** Names an operator explicitly stopped (stop-bot). Their SIGTERM would look
    *  like a crash to onChildExit, so we suppress the restart for exactly one exit
    *  and mark them stopped. Cleared when the bot is explicitly started again. */
@@ -200,6 +213,58 @@ export class FleetSupervisor {
     for (const name of toStart) {
       const spec = specByName.get(name);
       if (spec) this.spawnBot(spec, /* isRestart */ false);
+    }
+    this.ensureHeartbeatScanner();
+  }
+
+  private ensureHeartbeatScanner(): void {
+    const heartbeat = this.opts.heartbeat;
+    if (!heartbeat || this.heartbeatScanTimer || this.stopping) return;
+    const intervalMs = Math.max(10, heartbeat.scanIntervalMs);
+    this.heartbeatScanTimer = setInterval(() => this.scanDaemonHeartbeats(), intervalMs);
+    this.heartbeatScanTimer.unref?.();
+  }
+
+  private scanDaemonHeartbeats(nowMs = Date.now()): void {
+    const heartbeat = this.opts.heartbeat;
+    if (!heartbeat || this.stopping) return;
+    for (const [name, child] of this.children) {
+      const spec = this.knownSpecs.get(name);
+      if (!spec || spec.external || (spec.entry ?? 'daemon') !== 'daemon') continue;
+      if (this.explicitStop.has(name) || this.heartbeatKillInFlight.has(name)) continue;
+      const pid = child.pid ?? 0;
+      const startedAtMs = this.childStartedAtMs.get(name) ?? nowMs;
+      const status = daemonHeartbeatStatus({
+        nowMs,
+        startedAtMs,
+        expectedPid: pid,
+        heartbeat: readDaemonHeartbeatTo(heartbeat.dataDir, spec.appId),
+        startupGraceMs: heartbeat.startupGraceMs,
+        staleMs: heartbeat.staleMs,
+      });
+      if (status !== 'stalled') continue;
+      // Keep the ordinary crash/restart budget and generation policy as the
+      // single restart owner. This watchdog contributes only the missing exit.
+      this.heartbeatKillInFlight.add(name);
+      this.log(
+        `${name} daemon heartbeat stalled (pid ${pid}); SIGKILL so the existing `
+        + 'crash policy can restart the exact member',
+      );
+      try {
+        if (!child.kill('SIGKILL')) {
+          this.heartbeatKillInFlight.delete(name);
+          this.log(
+            `${name} heartbeat SIGKILL was not accepted; retaining supervision `
+            + 'and retrying on the next stale scan',
+          );
+        }
+      } catch (error) {
+        this.heartbeatKillInFlight.delete(name);
+        this.log(
+          `${name} heartbeat SIGKILL failed: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     }
   }
 
@@ -383,6 +448,7 @@ export class FleetSupervisor {
     }).procs.find((p) => p.name === spec.name)!.generation;
 
     this.children.set(spec.name, child);
+    this.childStartedAtMs.set(spec.name, Date.now());
     this.liveGeneration.set(spec.name, generation);
     this.log(`${isRestart ? 'restarted' : 'started'} ${spec.name} (pid ${child.pid}, gen ${generation})`);
 
@@ -398,6 +464,8 @@ export class FleetSupervisor {
     // exit must never mutate the newer generation's row or trigger a double spawn.
     if (this.liveGeneration.get(spec.name) !== generation) return;
     this.children.delete(spec.name);
+    this.childStartedAtMs.delete(spec.name);
+    this.heartbeatKillInFlight.delete(spec.name);
     if (this.stopping) return;
 
     // Explicit stop-bot: this exit is operator-intended, not a crash. Suppress the
@@ -462,6 +530,11 @@ export class FleetSupervisor {
    *  `status` reflects reality — onChildExit is short-circuited while stopping. */
   async stopAll(): Promise<void> {
     this.stopping = true;
+    if (this.heartbeatScanTimer) {
+      clearInterval(this.heartbeatScanTimer);
+      this.heartbeatScanTimer = undefined;
+    }
+    this.heartbeatKillInFlight.clear();
     for (const t of this.restartTimers.values()) clearTimeout(t);
     this.restartTimers.clear();
     const pending = [...this.children.entries()];

--- a/src/core/liveness-watchdog.ts
+++ b/src/core/liveness-watchdog.ts
@@ -1,0 +1,51 @@
+/** Pure event-loop liveness decisions shared by worker and fleet watchdogs. */
+
+export interface WorkerHeartbeatDecisionInput {
+  nowMs: number;
+  lastHeartbeatAtMs: number;
+  staleMs: number;
+}
+
+/** The exact lease boundary remains healthy; only strictly older beats stall. */
+export function workerHeartbeatStalled(input: WorkerHeartbeatDecisionInput): boolean {
+  if (!Number.isFinite(input.nowMs)
+    || !Number.isFinite(input.lastHeartbeatAtMs)
+    || !Number.isFinite(input.staleMs)
+    || input.staleMs < 0) return true;
+  return input.nowMs - input.lastHeartbeatAtMs > input.staleMs;
+}
+
+export type DaemonHeartbeatStatus = 'starting' | 'healthy' | 'stalled';
+
+export interface DaemonHeartbeatDecisionInput {
+  nowMs: number;
+  startedAtMs: number;
+  expectedPid: number;
+  heartbeat: { pid?: number; atMs: number } | null;
+  startupGraceMs: number;
+  staleMs: number;
+}
+
+/**
+ * A daemon must publish a heartbeat bound to its current OS pid. A fresh file
+ * left by the previous generation is not evidence that the replacement event
+ * loop is alive. Missing/mismatched evidence is tolerated only during startup.
+ */
+export function daemonHeartbeatStatus(input: DaemonHeartbeatDecisionInput): DaemonHeartbeatStatus {
+  const ageMs = input.nowMs - input.startedAtMs;
+  const inStartupGrace = Number.isFinite(ageMs)
+    && Number.isFinite(input.startupGraceMs)
+    && ageMs <= input.startupGraceMs;
+  const heartbeat = input.heartbeat;
+  const matchesCurrentProcess = !!heartbeat
+    && Number.isSafeInteger(input.expectedPid)
+    && input.expectedPid > 1
+    && heartbeat.pid === input.expectedPid;
+
+  if (!matchesCurrentProcess) return inStartupGrace ? 'starting' : 'stalled';
+  return workerHeartbeatStalled({
+    nowMs: input.nowMs,
+    lastHeartbeatAtMs: heartbeat.atMs,
+    staleMs: input.staleMs,
+  }) ? 'stalled' : 'healthy';
+}

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -388,6 +388,7 @@ import {
   type OrdinaryTurnRecoveryDispatch,
 } from '../services/ordinary-turn-recovery.js';
 import { turnRetryOffer, shouldNotifyTurnFailure } from '../services/turn-failure-notice.js';
+import { workerHeartbeatStalled } from './liveness-watchdog.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import { emitSessionLifecycleHook, emitSessionStateTransitionHook } from '../services/session-lifecycle-hooks.js';
 import { anchorUsageForDaemonSession, recordOwnershipForDaemonSession, recordUsageForDaemonSession, reconcileUsageForDaemonSession } from '../services/usage-ledger.js';
@@ -592,6 +593,70 @@ export interface WorkerPoolCallbacks {
   /** Re-check the per-bot resident-session cap after a process starts or an
    * over-cap busy session becomes idle. Optional for unit-test callers. */
   enforceLiveSessionCap?: () => void;
+  /** Ordinary Lark IM lifecycle write-ahead hooks. They are synchronous on
+   * purpose: a storage failure must stop the next side-effect boundary. */
+  onOrdinaryImInputReceived?: (
+    ds: DaemonSession,
+    context: { turnId: string; workerGeneration: number },
+  ) => void;
+  onOrdinaryImInputCommitted?: (
+    ds: DaemonSession,
+    context: { turnId: string; workerGeneration: number },
+  ) => void;
+  onOrdinaryImInputRejected?: (
+    ds: DaemonSession,
+    context: { turnId: string; workerGeneration: number; reason: string },
+  ) => void;
+  onOrdinaryImProgress?: (
+    ds: DaemonSession,
+    context: { turnId: string; workerGeneration: number; source: 'screen_update' | 'worker_heartbeat' },
+  ) => void;
+  /** Persist attention before the exact stuck generation is SIGKILLed. */
+  onWorkerHeartbeatStalled?: (
+    ds: DaemonSession,
+    context: {
+      sessionId: string;
+      workerGeneration: number;
+      turnId?: string;
+      lastHeartbeatAt: number;
+      detectedAt: number;
+    },
+  ) => void;
+  /** Write the complete ordinary Lark provider request before calling Lark. */
+  prepareOrdinaryFinalOutput?: (
+    ds: DaemonSession,
+    context: {
+      turnId: string;
+      delivery: {
+        rootId: string;
+        content: string;
+        msgType?: string;
+        turnId: string;
+        options?: {
+          uuid?: string;
+          quoteMessageId?: string;
+          suppressHook?: boolean;
+          replyTarget?: FrozenSessionReplyTarget;
+          placement?: 'auto' | 'chat' | 'topic';
+        };
+      };
+    },
+  ) => 'absent' | 'pending' | 'delivered';
+  completeOrdinaryFinalOutput?: (
+    ds: DaemonSession,
+    context: { turnId: string; providerMessageId: string },
+  ) => void;
+  /** Prepare one fail-closed attention notification before calling Lark, then
+   * settle it after the provider ACK. The returned UUID is shared with boot
+   * recovery so an ACK-lost retry cannot create a second visible warning. */
+  prepareOrdinaryAttention?: (
+    ds: DaemonSession,
+    context: { turnId: string; reason: string },
+  ) => { uuid: string } | undefined;
+  completeOrdinaryAttention?: (
+    ds: DaemonSession,
+    context: { turnId: string; providerMessageId: string },
+  ) => void;
   /** Durable consumers subscribe to transcript-backed turn completion here.
    *  Optional so ordinary sessions and tests keep their existing behavior. */
   onTurnTerminal?: (
@@ -1286,7 +1351,7 @@ function ordinaryTurnRecoveryWarning(
  *  一次性凭据（handler 用 turnId 逐字比对），没有它就只剩「去看 Web 终端」。
  *  记录缺失是正常情况——turn 在 prompt 被 wrap 前就死掉时 buildFailedTurnRecord
  *  返回 undefined。 */
-function buildSessionTurnFailedCard(
+export function buildSessionTurnFailedCard(
   ds: DaemonSession,
   opts: {
     status: 'failed' | 'ambiguous';
@@ -1364,6 +1429,7 @@ export function ensureOrdinaryTurnRecoveryAttached(
       }
     },
     warn: state => {
+      const cb = requireCallbacks();
       const warning = ordinaryTurnRecoveryWarning(state, localeForBot(ds.larkAppId));
       ds.agentAttention = {
         kind: 'blocked',
@@ -1376,21 +1442,56 @@ export function ensureOrdinaryTurnRecoveryAttached(
         errorCode: state.lastErrorCode,
         logicalTurnId: state.logicalTurnId,
       });
-      void requireCallbacks().sessionReply(
-        sessionAnchorId(ds),
-        buildSessionTurnFailedCard(ds, {
-          status: 'failed',
-          ...(state.lastErrorCode !== undefined ? { errorCode: state.lastErrorCode } : {}),
-          // recovery 走到 warn 一定是「自动续跑救不回来」，把已试次数摊给用户，
-          // 免得他以为系统什么都没做。
-          continuations: state.continuationsStarted,
-          // 这条路径的 retryable 已经在 coordinator 里判过并否掉了（否则不会
-          // warn），所以按钮的安全性交给 errorCode 白名单判断，不再谎称 safe。
-        }),
-        'interactive',
-        ds.larkAppId,
-        state.logicalTurnId,
-      ).catch(err => logger.error(
+      let attention: { uuid: string } | undefined;
+      try {
+        attention = cb.prepareOrdinaryAttention?.(ds, {
+          turnId: state.logicalTurnId,
+          reason: state.lastErrorCode ?? 'ordinary_turn_recovery_exhausted',
+        });
+      } catch (error) {
+        logger.error(
+          `[${tag(ds)}] Refused to send ordinary-turn recovery warning before durable attention: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+        );
+        return;
+      }
+      const card = buildSessionTurnFailedCard(ds, {
+        status: 'failed',
+        ...(state.lastErrorCode !== undefined ? { errorCode: state.lastErrorCode } : {}),
+        // recovery 走到 warn 一定是「自动续跑救不回来」，把已试次数摊给用户，
+        // 免得他以为系统什么都没做。
+        continuations: state.continuationsStarted,
+        // 这条路径的 retryable 已经在 coordinator 里判过并否掉了（否则不会
+        // warn），所以按钮的安全性交给 errorCode 白名单判断，不再谎称 safe。
+      });
+      // Keep the legacy five-argument call shape when the daemon has no
+      // durable-attention hook (notably old embedders and unit-test callers).
+      // Passing an explicit sixth `undefined` needlessly changes observable
+      // adapter behavior and breaks mocks that verify the compatibility seam.
+      const warningReply = attention
+        ? cb.sessionReply(
+            sessionAnchorId(ds),
+            card,
+            'interactive',
+            ds.larkAppId,
+            state.logicalTurnId,
+            attention,
+          )
+        : cb.sessionReply(
+            sessionAnchorId(ds),
+            card,
+            'interactive',
+            ds.larkAppId,
+            state.logicalTurnId,
+          );
+      void warningReply.then(providerMessageId => {
+        if (attention && providerMessageId) {
+          cb.completeOrdinaryAttention?.(ds, {
+            turnId: state.logicalTurnId,
+            providerMessageId,
+          });
+        }
+      }).catch(err => logger.error(
         `[${tag(ds)}] Failed to deliver ordinary-turn recovery warning: `
         + `${err instanceof Error ? err.message : String(err)}`,
       ));
@@ -6944,6 +7045,227 @@ const transferReplacementForkBypass = new WeakSet<DaemonSession>();
 // IPC transport and worker acknowledgement are separate stages. A transport
 // timeout may retry because the parent never confirmed enqueue; an ACK timeout
 // is only a delayed/ambiguous state because the child may still execute later.
+const WORKER_HEARTBEAT_STALE_MS = Math.max(
+  15_000,
+  Number(process.env.BOTMUX_WORKER_HEARTBEAT_STALE_MS) || 30_000,
+);
+const WORKER_HEARTBEAT_SCAN_MS = Math.max(
+  1_000,
+  Number(process.env.BOTMUX_WORKER_HEARTBEAT_SCAN_MS) || 5_000,
+);
+const WORKER_DURABLE_PROGRESS_INTERVAL_MS = 15_000;
+const WORKER_SETTLED_TURN_FENCE_LIMIT = 256;
+
+type WorkerHeartbeatLease = {
+  ds: DaemonSession;
+  worker: ChildProcess;
+  workerGeneration: number;
+  lastHeartbeatAt: number;
+  lastDurableProgressAt: number;
+  durableProgressTurnId?: string;
+  turnId?: string;
+  /** A terminal is stronger than delayed screen/heartbeat observations. Keep a
+   * bounded per-generation fence so those observations cannot revive a lease;
+   * only a later explicit worker receipt/commit may reopen the same turn. */
+  settledTurnIds: Set<string>;
+  handlingStall: boolean;
+};
+
+const workerHeartbeatLeases = new Map<ChildProcess, WorkerHeartbeatLease>();
+let workerHeartbeatScanTimer: ReturnType<typeof setInterval> | undefined;
+let workerHeartbeatLastScanAt: number | undefined;
+
+function ensureWorkerHeartbeatScanner(): void {
+  if (workerHeartbeatScanTimer) return;
+  workerHeartbeatLastScanAt = Date.now();
+  workerHeartbeatScanTimer = setInterval(() => scanWorkerHeartbeatLeases(), WORKER_HEARTBEAT_SCAN_MS);
+  workerHeartbeatScanTimer.unref?.();
+}
+
+function registerWorkerHeartbeatLease(
+  ds: DaemonSession,
+  worker: ChildProcess,
+  workerGeneration: number,
+): void {
+  const cb = requireCallbacks();
+  if (!cb.onWorkerHeartbeatStalled && !cb.onOrdinaryImProgress) return;
+  const now = Date.now();
+  workerHeartbeatLeases.set(worker, {
+    ds,
+    worker,
+    workerGeneration,
+    lastHeartbeatAt: now,
+    lastDurableProgressAt: now,
+    settledTurnIds: new Set(),
+    handlingStall: false,
+  });
+  worker.once('exit', () => workerHeartbeatLeases.delete(worker));
+  if (cb.onWorkerHeartbeatStalled) ensureWorkerHeartbeatScanner();
+}
+
+function updateWorkerHeartbeatTurn(
+  worker: ChildProcess,
+  turnId?: string,
+  source: 'observed' | 'explicit' = 'observed',
+): boolean {
+  const lease = workerHeartbeatLeases.get(worker);
+  if (!lease) return false;
+  if (turnId && source === 'observed' && lease.settledTurnIds.has(turnId)) {
+    return false;
+  }
+  if (turnId && source === 'explicit') lease.settledTurnIds.delete(turnId);
+  if (lease.turnId !== turnId) {
+    lease.durableProgressTurnId = undefined;
+    lease.lastDurableProgressAt = 0;
+  }
+  lease.turnId = turnId;
+  return true;
+}
+
+function clearWorkerHeartbeatTurn(worker: ChildProcess, turnId: string): void {
+  const lease = workerHeartbeatLeases.get(worker);
+  if (!lease) return;
+  lease.settledTurnIds.delete(turnId);
+  lease.settledTurnIds.add(turnId);
+  while (lease.settledTurnIds.size > WORKER_SETTLED_TURN_FENCE_LIMIT) {
+    const oldest = lease.settledTurnIds.values().next().value as string | undefined;
+    if (!oldest) break;
+    lease.settledTurnIds.delete(oldest);
+  }
+  if (lease.turnId !== turnId) return;
+  lease.turnId = undefined;
+  lease.durableProgressTurnId = undefined;
+  lease.lastDurableProgressAt = Date.now();
+}
+
+function persistOrdinaryImProgress(
+  worker: ChildProcess,
+  turnId: string,
+  source: 'screen_update' | 'worker_heartbeat',
+  now = Date.now(),
+): void {
+  if (!turnId.startsWith('om_')) return;
+  const lease = workerHeartbeatLeases.get(worker);
+  if (!lease) return;
+  const firstForTurn = lease.durableProgressTurnId !== turnId;
+  if (!firstForTurn
+    && now - lease.lastDurableProgressAt < WORKER_DURABLE_PROGRESS_INTERVAL_MS) return;
+  try {
+    requireCallbacks().onOrdinaryImProgress?.(lease.ds, {
+      turnId,
+      workerGeneration: lease.workerGeneration,
+      source,
+    });
+    lease.durableProgressTurnId = turnId;
+    lease.lastDurableProgressAt = now;
+  } catch (error) {
+    logger.error(
+      `[${tag(lease.ds)}] Failed to persist ordinary IM progress `
+      + `turn=${turnId.slice(0, 16)} source=${source}: `
+      + `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function observeWorkerHeartbeat(
+  worker: ChildProcess,
+  msg: Extract<WorkerToDaemon, { type: 'worker_heartbeat' }>,
+): void {
+  const lease = workerHeartbeatLeases.get(worker);
+  if (!lease) return;
+  const now = Date.now();
+  lease.lastHeartbeatAt = now;
+  if (msg.turnId) {
+    if (!updateWorkerHeartbeatTurn(worker, msg.turnId, 'observed')) return;
+    persistOrdinaryImProgress(worker, msg.turnId, 'worker_heartbeat', now);
+  }
+}
+
+function scanWorkerHeartbeatLeases(now = Date.now()): void {
+  const cb = requireCallbacks();
+  const previousScanAt = workerHeartbeatLastScanAt;
+  workerHeartbeatLastScanAt = now;
+  // Receipt-time heartbeats only distinguish a stuck worker while the daemon's
+  // own event loop is known to be sampling normally. If this scanner itself
+  // missed an entire stale window, the daemon may have been blocked and all
+  // child heartbeats may simply be queued behind it. Give every lease a fresh
+  // observation window; the independent fleet supervisor owns daemon stalls.
+  if (previousScanAt !== undefined && workerHeartbeatStalled({
+    nowMs: now,
+    lastHeartbeatAtMs: previousScanAt,
+    staleMs: WORKER_HEARTBEAT_STALE_MS,
+  })) {
+    for (const lease of workerHeartbeatLeases.values()) {
+      lease.lastHeartbeatAt = now;
+      lease.handlingStall = false;
+    }
+    logger.warn(
+      `[worker-heartbeat] scanner delayed for ${now - previousScanAt}ms; `
+      + 'resetting worker leases because daemon liveness was not established',
+    );
+    return;
+  }
+  for (const [worker, lease] of workerHeartbeatLeases) {
+    if (
+      lease.ds.worker !== worker
+      || worker.killed
+      || lease.ds.workerGeneration !== lease.workerGeneration
+      || lease.ds.session.workerGeneration !== lease.workerGeneration
+    ) {
+      workerHeartbeatLeases.delete(worker);
+      continue;
+    }
+    if (lease.handlingStall || !workerHeartbeatStalled({
+      nowMs: now,
+      lastHeartbeatAtMs: lease.lastHeartbeatAt,
+      staleMs: WORKER_HEARTBEAT_STALE_MS,
+    })) continue;
+
+    lease.handlingStall = true;
+    try {
+      // The callback is deliberately synchronous. If durable attention cannot
+      // be recorded, leave the process alive and retry the scan instead of
+      // killing away the only remaining evidence of an ambiguous turn.
+      cb.onWorkerHeartbeatStalled?.(lease.ds, {
+        sessionId: lease.ds.session.sessionId,
+        workerGeneration: lease.workerGeneration,
+        ...(lease.turnId ? { turnId: lease.turnId } : {}),
+        lastHeartbeatAt: lease.lastHeartbeatAt,
+        detectedAt: now,
+      });
+    } catch (error) {
+      lease.handlingStall = false;
+      logger.error(
+        `[${tag(lease.ds)}] Refused to kill stalled worker before durable attention: `
+        + `${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    try {
+      if (!worker.kill('SIGKILL')) {
+        lease.handlingStall = false;
+        logger.error(
+          `[${tag(lease.ds)}] Stalled-worker SIGKILL was not accepted; `
+          + `retaining lease generation=${lease.workerGeneration} `
+          + `turn=${lease.turnId?.slice(0, 16) ?? '-'} for retry`,
+        );
+        continue;
+      }
+      workerHeartbeatLeases.delete(worker);
+      logger.error(
+        `[${tag(lease.ds)}] Worker event loop stalled for ${now - lease.lastHeartbeatAt}ms; `
+        + `SIGKILL generation=${lease.workerGeneration} turn=${lease.turnId?.slice(0, 16) ?? '-'}`,
+      );
+    } catch (error) {
+      lease.handlingStall = false;
+      logger.error(
+        `[${tag(lease.ds)}] Stalled-worker SIGKILL failed; retaining lease for retry: `
+        + `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}
+
 const ORDINARY_IM_TRANSPORT_TIMEOUT_MS = 2_000;
 const ORDINARY_IM_ACK_SETTLEMENT_TIMEOUT_MS = 2_000;
 const ORDINARY_IM_MAX_ATTEMPTS = 2;
@@ -10806,6 +11128,7 @@ function setupWorkerHandlers(
     );
   const ownsLifecycleMutation = (): boolean =>
     ownsWorkerSession() && !isSessionTransferring(ds);
+  registerWorkerHeartbeatLease(ds, worker, workerGeneration);
   // A new worker generation is starting. As a backstop, invalidate any
   // stuck-warning card posted by the previous generation — explicit kill/suspend/
   // exit paths should already have done this, but fork/refork/takeover paths
@@ -11032,6 +11355,14 @@ function setupWorkerHandlers(
     }
     const effectiveCliId = sessionCliId(ds, botCfg);
     switch (msg.type) {
+      case 'worker_heartbeat': {
+        if (msg.sessionId && msg.sessionId !== ds.session.sessionId) {
+          logger.warn(`[${t}] Ignored worker_heartbeat with mismatched sessionId`);
+          break;
+        }
+        observeWorkerHeartbeat(worker, msg);
+        break;
+      }
       case 'persistent_backend_target': {
         ds.session.persistentBackendTarget = msg.target;
         sessionStore.updateSession(ds.session);
@@ -11046,6 +11377,15 @@ function setupWorkerHandlers(
           logger.warn(`[${t}] Ignored turn_input_received from stale worker generation`);
           break;
         }
+        updateWorkerHeartbeatTurn(worker, msg.turnId, 'explicit');
+        try {
+          cb.onOrdinaryImInputReceived?.(ds, { turnId: msg.turnId, workerGeneration });
+        } catch (error) {
+          logger.error(
+            `[${t}] Failed to persist ordinary IM receipt for ${msg.turnId.slice(0, 16)}: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
         acknowledgeOrdinaryImDeliveryReceipt(ds, msg.turnId, workerGeneration);
         break;
       }
@@ -11057,6 +11397,19 @@ function setupWorkerHandlers(
         ) {
           logger.warn(`[${t}] Ignored turn_input_rejected from stale worker generation`);
           break;
+        }
+        clearWorkerHeartbeatTurn(worker, msg.turnId);
+        try {
+          cb.onOrdinaryImInputRejected?.(ds, {
+            turnId: msg.turnId,
+            workerGeneration,
+            reason: msg.reason,
+          });
+        } catch (error) {
+          logger.error(
+            `[${t}] Failed to persist ordinary IM rejection for ${msg.turnId.slice(0, 16)}: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+          );
         }
         rejectOrdinaryImDelivery(ds, msg.turnId, workerGeneration, msg.reason);
         break;
@@ -11075,6 +11428,15 @@ function setupWorkerHandlers(
         }
         // Compatibility/fallback: a commit also proves receipt if the earlier
         // receipt ACK was delayed or dropped on the reverse IPC channel.
+        updateWorkerHeartbeatTurn(worker, msg.turnId, 'explicit');
+        try {
+          cb.onOrdinaryImInputCommitted?.(ds, { turnId: msg.turnId, workerGeneration });
+        } catch (error) {
+          logger.error(
+            `[${t}] Failed to persist ordinary IM commit for ${msg.turnId.slice(0, 16)}: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
         completeOrdinaryImDelivery(ds, msg.turnId, workerGeneration);
         if (recordDispatchInputCommit(ds.session, msg.turnId, workerGeneration)) {
           sessionStore.updateSession(ds.session);
@@ -11771,6 +12133,12 @@ function setupWorkerHandlers(
         updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenContent = msg.content;
         ds.lastScreenStatus = resolveUsageAwareScreenStatus(ds, msg.status, msg.usageLimit);
+        if (msg.turnId
+          && (ds.lastScreenStatus === 'working' || ds.lastScreenStatus === 'analyzing')) {
+          if (updateWorkerHeartbeatTurn(worker, msg.turnId, 'observed')) {
+            persistOrdinaryImProgress(worker, msg.turnId, 'screen_update');
+          }
+        }
         bumpStreamCardStatusRevision(ds);
         // A suspend that arrived mid-turn parked itself here. Defer until this
         // screen_update has finished using process state — suspendWorker nulls
@@ -12897,6 +13265,7 @@ function setupWorkerHandlers(
           );
           break;
         }
+        clearWorkerHeartbeatTurn(worker, msg.turnId);
         // Defense in depth: the worker sends a token-matched revoke before the
         // terminal IPC, but an older/mixed worker must still lose authority at
         // this exact terminal edge. Tuple-match prevents a late turn N event
@@ -13044,7 +13413,11 @@ function setupWorkerHandlers(
             turnId: msg.turnId,
           });
           try {
-            await scopedReply(
+            const attention = cb.prepareOrdinaryAttention?.(ds, {
+              turnId: msg.turnId,
+              reason: failureCode,
+            });
+            const providerMessageId = await scopedReply(
               buildSessionTurnFailedCard(ds, {
                 status: msg.status === 'ambiguous' ? 'ambiguous' : 'failed',
                 ...(msg.errorCode !== undefined ? { errorCode: msg.errorCode } : {}),
@@ -13052,7 +13425,14 @@ function setupWorkerHandlers(
               }),
               'interactive',
               msg.turnId,
+              attention,
             );
+            if (attention && providerMessageId) {
+              cb.completeOrdinaryAttention?.(ds, {
+                turnId: msg.turnId,
+                providerMessageId,
+              });
+            }
           } catch (err) {
             logger.error(
               `[${t}] Failed to deliver turn failure card: `
@@ -14399,7 +14779,7 @@ function deliverFinalOutput(
         onComplete?.(false);
         return;
       }
-      const deliveryReplyOptions = preparedListenerReply
+      const deliveryReplyOptions: WorkerSessionReplyOptions = preparedListenerReply
         ? {
             uuid: preparedListenerReply.providerKey,
             quoteMessageId: canonicalOutput.quoteTargetId,
@@ -14416,14 +14796,61 @@ function deliverFinalOutput(
               : {}),
           }
         : codexAppSettlementReply ?? { uuid: bridgeFinalOutputUuid(ds, msg) };
+      const scopedDeliveryReplyOptions: WorkerSessionReplyOptions = frozenReplyTarget && !managedReceiver
+        ? { ...deliveryReplyOptions, replyTarget: frozenReplyTarget }
+        : deliveryReplyOptions;
+      if (msg.turnId.startsWith('om_') && !managedReceiver) {
+        const prepared = cb.prepareOrdinaryFinalOutput?.(ds, {
+          turnId: msg.turnId,
+          delivery: {
+            rootId: sessionAnchorId(ds),
+            content: canonicalOutput.content,
+            msgType: canonicalOutput.msgType,
+            turnId: msg.replyTurnId ?? msg.turnId,
+            options: {
+              ...(scopedDeliveryReplyOptions.uuid
+                ? { uuid: scopedDeliveryReplyOptions.uuid }
+                : {}),
+              ...(scopedDeliveryReplyOptions.quoteMessageId
+                ? { quoteMessageId: scopedDeliveryReplyOptions.quoteMessageId }
+                : {}),
+              ...(scopedDeliveryReplyOptions.suppressHook
+                ? { suppressHook: true }
+                : {}),
+              ...(scopedDeliveryReplyOptions.replyTarget
+                ? { replyTarget: scopedDeliveryReplyOptions.replyTarget }
+                : {}),
+              ...(scopedDeliveryReplyOptions.placement
+                ? { placement: scopedDeliveryReplyOptions.placement }
+                : {}),
+            },
+          },
+        });
+        if (prepared === 'delivered') {
+          ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
+          logger.info(
+            `[${t}] Ordinary final_output already delivered durably `
+            + `(turn ${msg.turnId.substring(0, 8)})`,
+          );
+          onComplete?.(true);
+          return;
+        }
+      }
       const messageId = await scopedReply(
         canonicalOutput.content,
         canonicalOutput.msgType,
         msg.replyTurnId ?? msg.turnId,
-        frozenReplyTarget && !managedReceiver
-          ? { ...deliveryReplyOptions, replyTarget: frozenReplyTarget }
-          : deliveryReplyOptions,
+        scopedDeliveryReplyOptions,
       );
+      if (msg.turnId.startsWith('om_') && !managedReceiver && messageId) {
+        // Provider ACK precedes every best-effort auxiliary mutation below. If
+        // this durable completion write fails, the catch/retry path reuses the
+        // same provider UUID, closing the ACK-lost dual-write window.
+        cb.completeOrdinaryFinalOutput?.(ds, {
+          turnId: msg.turnId,
+          providerMessageId: messageId,
+        });
+      }
       if (!isStillOwned()) { onComplete?.(true); return; }
       recordPrimaryOutput(messageId);
       if (msg.turnId.startsWith('mlrp_turn_')) {
@@ -14487,6 +14914,13 @@ export const __testOnly_reserveWorkerGeneration = reserveWorkerGeneration;
 export const __testOnly_finishTurnReactions = finishTurnReactions;
 export const __testOnly_finalOutputDedupeKey = finalOutputDedupeKey;
 export const __testOnly_retireTerminalizedCodexAppLedgerEntriesForRecovery = retireTerminalizedCodexAppLedgerEntriesForRecovery;
+export const __testOnly_scanWorkerHeartbeatLeases = scanWorkerHeartbeatLeases;
+export function __testOnly_resetWorkerHeartbeatLeases(): void {
+  if (workerHeartbeatScanTimer) clearInterval(workerHeartbeatScanTimer);
+  workerHeartbeatScanTimer = undefined;
+  workerHeartbeatLastScanAt = undefined;
+  workerHeartbeatLeases.clear();
+}
 
 // ─── Fork adopt worker ──────────────────────────────────────────────────────
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -86,6 +86,30 @@ import { setDisplayNameRefresher, findConfigField, applyConfigField } from './se
 import { registerPinStreamingCardChangeHandler } from './services/pin-streaming-card-change.js';
 import { getSkillFeedbackStore } from './services/skill-feedback-store.js';
 import { enqueueTurnTerminal, drainTurnTerminalQueue } from './services/turn-completion-events.js';
+import {
+  markOrdinaryTurnAccepted,
+  markOrdinaryTurnAttention,
+  markOrdinaryTurnAttentionNotified,
+  markOrdinaryTurnCommitted,
+  markOrdinaryTurnHeartbeat,
+  markOrdinaryTurnIgnored,
+  markOrdinaryTurnOutputDelivered,
+  markOrdinaryTurnRejected,
+  markOrdinaryTurnReplayScheduled,
+  markOrdinaryTurnRouted,
+  markOrdinaryTurnRunning,
+  markOrdinaryTurnTerminal,
+  markOrdinaryTurnWorkerReceived,
+  limitOrdinaryTurnRecoveryPlanToClaimedBefore,
+  ordinaryTurnRecoveryUuid,
+  planOrdinaryTurnRecovery,
+  prepareOrdinaryTurnClaim,
+  prepareOrdinaryTurnOutput,
+  selectOrdinaryTurnAttentionForDelivery,
+  selectOrdinaryTurnPendingOutputForDelivery,
+  validateOrdinaryTurnClaim,
+  type OrdinaryTurnRecord,
+} from './services/ordinary-turn-ledger.js';
 import { FeedbackWebhookSecretStore, startFeedbackWebhookDispatcher } from './services/feedback-webhook-dispatcher.js';
 import { resolveRegularGroupMode } from './services/chat-reply-mode-store.js';
 import { renameBotOnOpenPlatform, changeBotAvatarOnOpenPlatform, readBotDescriptionsOnOpenPlatform, updateBotDescriptionsOnOpenPlatform } from './services/open-platform-rename.js';
@@ -198,6 +222,7 @@ import {
   sessionSupportsWebTerminal,
   readableTerminalUrlFor,
   findActiveBySessionId,
+  buildSessionTurnFailedCard,
   withActiveSessionKeyLock,
   getDaemonBootId,
   getDaemonStreamingCardUsageSnapshot,
@@ -5027,6 +5052,290 @@ const v3GateRunner = createV3GateRunner({
 // 每个 bot 的 EventHandlers，授权成功后重放消息时需要。
 // key = larkAppId，在 startLarkEventDispatcher 调用时写入。
 const botHandlers = new Map<string, EventHandlers>();
+
+const ORDINARY_TURN_RECOVERY_DRAIN_MS = 30_000;
+const ORDINARY_TURN_RECOVERY_SHUTDOWN_SETTLE_MS = 2_000;
+type OrdinaryTurnRecoveryDrainState = {
+  requested: boolean;
+  replayReceived: boolean;
+  replayClaimedBeforeMs?: number;
+  inFlight?: Promise<void>;
+};
+const ordinaryTurnRecoveryDrainStates = new Map<string, OrdinaryTurnRecoveryDrainState>();
+const ordinaryTurnRecoveryStoppingApps = new Set<string>();
+
+async function settleOrdinaryTurnRecoveryDrains(deadlineMs: number): Promise<boolean> {
+  const inFlight = [...ordinaryTurnRecoveryDrainStates.values()]
+    .map(state => state.inFlight)
+    .filter((promise): promise is Promise<void> => !!promise);
+  return waitAllWithin(inFlight, deadlineMs);
+}
+
+export const __testOnly_ordinaryTurnRecoveryDrainStates = ordinaryTurnRecoveryDrainStates;
+export const __testOnly_settleOrdinaryTurnRecoveryDrains = settleOrdinaryTurnRecoveryDrains;
+
+function ordinaryTurnAttentionReply(record: OrdinaryTurnRecord): {
+  anchor: string;
+  turnId: string;
+  options: WorkerSessionReplyOptions;
+} {
+  const routing = record.routing;
+  if (!routing) {
+    return {
+      anchor: record.messageId,
+      turnId: record.turnId ?? record.messageId,
+      options: {
+        uuid: ordinaryTurnRecoveryUuid('attention', record.larkAppId, record.messageId),
+        suppressHook: true,
+        replyTarget: { mode: 'thread', rootMessageId: record.messageId },
+      },
+    };
+  }
+  const replyTarget = routing.scope === 'thread'
+    ? { mode: 'thread' as const, rootMessageId: routing.anchor }
+    : routing.replyRootId
+      ? { mode: 'thread' as const, rootMessageId: routing.replyRootId }
+      : { mode: 'plain' as const, chatId: routing.chatId };
+  return {
+    anchor: routing.anchor,
+    turnId: record.turnId ?? record.messageId,
+    options: {
+      uuid: ordinaryTurnRecoveryUuid('attention', record.larkAppId, record.messageId),
+      // An ACK-lost recovery warning can be attempted again with the stable
+      // provider UUID. The local outbound hook is an independent side effect
+      // and must never be replayed by this daemon-owned recovery path.
+      suppressHook: true,
+      replyTarget,
+    },
+  };
+}
+
+export const __testOnly_ordinaryTurnAttentionReply = ordinaryTurnAttentionReply;
+
+function ordinaryTurnAttentionReason(record: OrdinaryTurnRecord): string {
+  if (record.attention?.reason) return record.attention.reason;
+  if (record.terminal) return `terminal_${record.terminal.status}`;
+  if (record.worker?.runningAt || record.worker?.heartbeatAt) return 'running_state_unknown_after_restart';
+  if (record.worker?.committedAt) return 'cli_commit_state_unknown_after_restart';
+  if (record.worker?.receivedAt) return 'worker_receipt_state_unknown_after_restart';
+  if (record.acceptedAt) return 'accepted_state_unknown_after_restart';
+  if (record.routedAt) return 'routed_state_unknown_after_restart';
+  return 'replay_schedule_state_unknown_after_restart';
+}
+
+function ordinaryTurnAttentionMessage(record: OrdinaryTurnRecord): {
+  content: string;
+  msgType: 'text' | 'interactive';
+} {
+  const reason = ordinaryTurnAttentionReason(record);
+  const ds = record.sessionId
+    ? findActiveBySessionId(record.sessionId)
+      ?? [...activeSessions.values()].find(candidate =>
+        candidate.session.sessionId === record.sessionId)
+    : undefined;
+  if (ds && ds.larkAppId === record.larkAppId && ds.session.status === 'active') {
+    const recovery = ds.session.ordinaryTurnRecovery;
+    const continuations = recovery?.logicalTurnId === (record.turnId ?? record.messageId)
+      ? recovery.continuationsStarted
+      : undefined;
+    return {
+      content: buildSessionTurnFailedCard(ds, {
+        status: record.terminal?.status === 'ambiguous' ? 'ambiguous' : 'failed',
+        errorCode: reason,
+        ...(continuations !== undefined ? { continuations } : {}),
+      }),
+      msgType: 'interactive',
+    };
+  }
+  return {
+    content: tr('daemon.ordinary_turn_attention_required', { reason }, localeForBot(record.larkAppId)),
+    msgType: 'text',
+  };
+}
+
+export const __testOnly_ordinaryTurnAttentionMessage = ordinaryTurnAttentionMessage;
+
+function ordinaryTurnPendingOutputReplyOptions(
+  record: OrdinaryTurnRecord,
+): WorkerSessionReplyOptions {
+  const delivery = record.output?.delivery;
+  if (!delivery) return { suppressHook: true };
+  return {
+    ...(delivery.options?.uuid
+      ? { uuid: delivery.options.uuid }
+      : { uuid: ordinaryTurnRecoveryUuid('output', record.larkAppId, record.messageId) }),
+    ...(delivery.options?.quoteMessageId
+      ? { quoteMessageId: delivery.options.quoteMessageId }
+      : {}),
+    // A pending output means a provider attempt may already have succeeded
+    // before its durable completion write. The stable provider UUID dedupes
+    // Lark, but the local outbound hook is a separate side effect; recovery
+    // must never emit it again.
+    suppressHook: true,
+    ...(delivery.options?.sourceSessionId
+      ? { sourceSessionId: delivery.options.sourceSessionId }
+      : {}),
+    ...(delivery.options?.replyTarget
+      ? { replyTarget: delivery.options.replyTarget }
+      : {}),
+    ...(delivery.options?.placement
+      ? { placement: delivery.options.placement }
+      : {}),
+  };
+}
+
+export const __testOnly_ordinaryTurnPendingOutputReplyOptions =
+  ordinaryTurnPendingOutputReplyOptions;
+
+async function deliverOrdinaryTurnPendingOutput(record: OrdinaryTurnRecord): Promise<void> {
+  const current = selectOrdinaryTurnPendingOutputForDelivery({
+    dataDir: config.session.dataDir,
+    larkAppId: record.larkAppId,
+    messageId: record.messageId,
+  });
+  const delivery = current?.output?.delivery;
+  if (!delivery) return;
+  const options = ordinaryTurnPendingOutputReplyOptions(current);
+  const providerMessageId = await sessionReply(
+    delivery.rootId,
+    delivery.content,
+    delivery.msgType,
+    current.larkAppId,
+    delivery.turnId,
+    options,
+  );
+  if (!providerMessageId) throw new Error('ordinary output provider returned an empty message id');
+  markOrdinaryTurnOutputDelivered({
+    dataDir: config.session.dataDir,
+    larkAppId: current.larkAppId,
+    turnId: current.turnId ?? current.messageId,
+    providerMessageId,
+  });
+}
+
+async function deliverOrdinaryTurnAttention(
+  record: OrdinaryTurnRecord,
+  allowInferred: boolean,
+): Promise<void> {
+  const current = selectOrdinaryTurnAttentionForDelivery({
+    dataDir: config.session.dataDir,
+    larkAppId: record.larkAppId,
+    messageId: record.messageId,
+    allowInferred,
+  });
+  if (!current) return;
+  const reason = ordinaryTurnAttentionReason(current);
+  markOrdinaryTurnAttention({
+    dataDir: config.session.dataDir,
+    larkAppId: current.larkAppId,
+    messageId: current.messageId,
+    reason,
+  });
+  const reply = ordinaryTurnAttentionReply(current);
+  const message = ordinaryTurnAttentionMessage(current);
+  const providerMessageId = await sessionReply(
+    reply.anchor,
+    message.content,
+    message.msgType,
+    current.larkAppId,
+    reply.turnId,
+    reply.options,
+  );
+  if (!providerMessageId) throw new Error('ordinary attention provider returned an empty message id');
+  markOrdinaryTurnAttentionNotified({
+    dataDir: config.session.dataDir,
+    larkAppId: current.larkAppId,
+    messageId: current.messageId,
+    providerMessageId,
+  });
+}
+
+function drainOrdinaryTurnRecovery(
+  larkAppId: string,
+  options: { replayReceived: boolean; replayClaimedBeforeMs?: number },
+): Promise<void> {
+  if (ordinaryTurnRecoveryStoppingApps.has(larkAppId)) {
+    return ordinaryTurnRecoveryDrainStates.get(larkAppId)?.inFlight ?? Promise.resolve();
+  }
+  const state = ordinaryTurnRecoveryDrainStates.get(larkAppId) ?? {
+    requested: false,
+    replayReceived: false,
+  };
+  ordinaryTurnRecoveryDrainStates.set(larkAppId, state);
+  state.requested = true;
+  if (options.replayReceived) {
+    state.replayReceived = true;
+    if (options.replayClaimedBeforeMs !== undefined) {
+      state.replayClaimedBeforeMs = state.replayClaimedBeforeMs === undefined
+        ? options.replayClaimedBeforeMs
+        : Math.max(state.replayClaimedBeforeMs, options.replayClaimedBeforeMs);
+    }
+  }
+  if (state.inFlight) return state.inFlight;
+
+  state.inFlight = (async () => {
+    while (state.requested && !ordinaryTurnRecoveryStoppingApps.has(larkAppId)) {
+      state.requested = false;
+      const replayReceived = state.replayReceived;
+      const replayClaimedBeforeMs = state.replayClaimedBeforeMs;
+      state.replayReceived = false;
+      state.replayClaimedBeforeMs = undefined;
+
+      const unboundedPlan = planOrdinaryTurnRecovery(config.session.dataDir, larkAppId);
+      const plan = replayReceived
+        ? limitOrdinaryTurnRecoveryPlanToClaimedBefore(unboundedPlan, replayClaimedBeforeMs)
+        : unboundedPlan;
+      if (replayReceived) {
+        const handlers = botHandlers.get(larkAppId);
+        for (const record of plan.replays) {
+          if (!handlers?.replayMessageEvent) {
+            logger.error(`[ordinary-turn] cannot replay ${record.messageId.slice(0, 12)}: dispatcher unavailable`);
+            continue;
+          }
+          markOrdinaryTurnReplayScheduled({
+            dataDir: config.session.dataDir,
+            larkAppId,
+            messageId: record.messageId,
+          });
+          handlers.replayMessageEvent(record.payload);
+          logger.warn(`[ordinary-turn] replay scheduled for received-only ${record.messageId.slice(0, 12)}`);
+        }
+      }
+      for (const record of plan.pendingOutputs) {
+        try {
+          await deliverOrdinaryTurnPendingOutput(record);
+        } catch (error) {
+          logger.error(
+            `[ordinary-turn] pending output retry failed ${record.messageId.slice(0, 12)}: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+      // Boot reconciliation may infer attention from an incomplete lifecycle
+      // left by the previous daemon generation. Periodic drains must not do so:
+      // an accepted/running row can be perfectly healthy in this live daemon.
+      // Outside boot, deliver only an explicitly persisted attention fence
+      // (worker event-loop stall, terminal failure, or payload conflict).
+      const attentions = replayReceived
+        ? plan.attentions
+        : plan.attentions.filter(record => !!record.attention);
+      for (const record of attentions) {
+        try {
+          await deliverOrdinaryTurnAttention(record, replayReceived);
+        } catch (error) {
+          logger.error(
+            `[ordinary-turn] attention delivery failed ${record.messageId.slice(0, 12)}: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+    }
+  })().finally(() => {
+    state.inFlight = undefined;
+    if (!state.requested) ordinaryTurnRecoveryDrainStates.delete(larkAppId);
+  });
+  return state.inFlight;
+}
 
 const codexNotifierStores = new Map<string, CodexNotifierEventStore>();
 const codexNotifierDeliveries = new Map<string, Promise<{ status: 'accepted'; messageId: string }>>();
@@ -17538,6 +17847,12 @@ function mergeVcMeetingApplicationContext(
 function markIngressAdmitted(ctx: RoutingContext): void {
   if (ctx.ingressAdmission) ctx.ingressAdmission.admitted = true;
   else ctx.ingressAdmission = { admitted: true };
+  markOrdinaryTurnAccepted({
+    dataDir: config.session.dataDir,
+    larkAppId: ctx.larkAppId,
+    messageId: ctx.messageId,
+    turnId: ctx.replyAnchorMessageId ?? ctx.messageId,
+  });
 }
 
 /**
@@ -17555,6 +17870,7 @@ function markIngressAdmitted(ctx: RoutingContext): void {
  */
 async function notifyOrdinaryIngressFailure(ctx: RoutingContext, err: unknown): Promise<never> {
   const replyAnchor = ctx.scope === 'thread' ? ctx.anchor : ctx.chatId;
+  const turnId = ctx.replyAnchorMessageId ?? ctx.messageId;
   const noticeKey = ctx.ingressAdmission?.admitted
     ? 'daemon.ordinary_ingress_admitted_reply_failed'
     : 'daemon.ordinary_ingress_failed';
@@ -17563,12 +17879,32 @@ async function notifyOrdinaryIngressFailure(ctx: RoutingContext, err: unknown): 
     ? `⚠️ ${err.message}\n\n可直接发给当前 agent：\n请帮我修复 botmux 的 CLI 选择配置：检查当前 bot 的 env、Riff 和 codexRpcInput 设置，移除与会话级 /cli <cliId> 选择冲突的配置；不要修改代码，完成后告诉我具体改了什么。`
     : tr(noticeKey, undefined, localeForBot(ctx.larkAppId));
   try {
-    await sessionReply(
+    const attention = markOrdinaryTurnAttention({
+      dataDir: config.session.dataDir,
+      larkAppId: ctx.larkAppId,
+      messageId: ctx.messageId,
+      reason: ctx.ingressAdmission?.admitted
+        ? 'ordinary_ingress_failed_after_accept'
+        : 'ordinary_ingress_failed_before_accept',
+    });
+    const providerMessageId = await sessionReply(
       replyAnchor,
       notice,
       'text',
       ctx.larkAppId,
+      turnId,
+      attention
+        ? { uuid: ordinaryTurnRecoveryUuid('attention', ctx.larkAppId, attention.messageId) }
+        : undefined,
     );
+    if (attention && providerMessageId) {
+      markOrdinaryTurnAttentionNotified({
+        dataDir: config.session.dataDir,
+        larkAppId: ctx.larkAppId,
+        messageId: attention.messageId,
+        providerMessageId,
+      });
+    }
   } catch (noticeErr) {
     logger.warn(
       `[${ctx.larkAppId}] ordinary ingress failure notice for ${ctx.messageId.substring(0, 12)} `
@@ -21951,8 +22287,114 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       });
     },
     enforceLiveSessionCap: () => enforceLiveSessionCap('session_change'),
+    onOrdinaryImInputReceived(ds, context) {
+      markOrdinaryTurnWorkerReceived({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        sessionId: ds.session.sessionId,
+        workerGeneration: context.workerGeneration,
+      });
+    },
+    onOrdinaryImInputCommitted(ds, context) {
+      markOrdinaryTurnCommitted({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        sessionId: ds.session.sessionId,
+        workerGeneration: context.workerGeneration,
+      });
+    },
+    onOrdinaryImInputRejected(ds, context) {
+      markOrdinaryTurnRejected({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        sessionId: ds.session.sessionId,
+        workerGeneration: context.workerGeneration,
+        reason: context.reason,
+      });
+    },
+    onOrdinaryImProgress(ds, context) {
+      const input = {
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        sessionId: ds.session.sessionId,
+        workerGeneration: context.workerGeneration,
+      };
+      if (context.source === 'screen_update') markOrdinaryTurnRunning(input);
+      else markOrdinaryTurnHeartbeat(input);
+    },
+    onWorkerHeartbeatStalled(ds, context) {
+      if (!context.turnId?.startsWith('om_')) return;
+      const record = markOrdinaryTurnAttention({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        reason: 'worker_event_loop_stalled',
+        now: context.detectedAt,
+      });
+      if (!record) {
+        throw new Error(
+          `ordinary turn ledger row missing for stalled turn ${context.turnId}`,
+        );
+      }
+      setImmediate(() => {
+        void drainOrdinaryTurnRecovery(ds.larkAppId, { replayReceived: false })
+          .catch(error => logger.error(
+            `[ordinary-turn] stalled-worker attention drain failed: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+          ));
+      });
+    },
+    prepareOrdinaryFinalOutput(ds, context) {
+      return prepareOrdinaryTurnOutput({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        delivery: context.delivery,
+      });
+    },
+    completeOrdinaryFinalOutput(ds, context) {
+      markOrdinaryTurnOutputDelivered({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        providerMessageId: context.providerMessageId,
+      });
+    },
+    prepareOrdinaryAttention(ds, context) {
+      const record = markOrdinaryTurnAttention({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        reason: context.reason,
+      });
+      return record
+        ? { uuid: ordinaryTurnRecoveryUuid('attention', ds.larkAppId, record.messageId) }
+        : undefined;
+    },
+    completeOrdinaryAttention(ds, context) {
+      markOrdinaryTurnAttentionNotified({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: context.turnId,
+        providerMessageId: context.providerMessageId,
+      });
+    },
     onQueuedActivationSubmitted,
     async onTurnTerminal(ds, terminal, context) {
+      markOrdinaryTurnTerminal({
+        dataDir: config.session.dataDir,
+        larkAppId: ds.larkAppId,
+        turnId: terminal.turnId,
+        status: terminal.status,
+        ...(terminal.errorCode ? { errorCode: terminal.errorCode } : {}),
+        ...(terminal.outputDisposition === 'nothing_to_send'
+          ? { outputDisposition: 'nothing_to_send' as const }
+          : {}),
+      });
       // VC reconcile first: it is in-memory and latency-sensitive, and must not
       // sit behind a synchronous SQLite write. (Master did only this enqueue.)
       const enqueued = vcMeetingTerminalReconciler?.enqueue(terminal, context);
@@ -22454,6 +22896,68 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     // Build the dispatcher now for authorization replay, but start it only
     // after restore has published every durable route owner.
     const botEventHandlers: EventHandlers = {
+      prepareMessageClaim: (data, messageId) => prepareOrdinaryTurnClaim({
+        dataDir: config.session.dataDir,
+        larkAppId: cfg.larkAppId,
+        messageId,
+        payload: data,
+      }) === 'created',
+      validateMessageClaim: (data, messageId) => {
+        validateOrdinaryTurnClaim({
+          dataDir: config.session.dataDir,
+          larkAppId: cfg.larkAppId,
+          messageId,
+          payload: data,
+        });
+      },
+      onMessageRouted: (_data, ctx) => {
+        markOrdinaryTurnRouted({
+          dataDir: config.session.dataDir,
+          larkAppId: cfg.larkAppId,
+          messageId: ctx.messageId,
+          routing: {
+            chatId: ctx.chatId,
+            scope: ctx.scope,
+            anchor: ctx.anchor,
+            ...(ctx.replyRootId ? { replyRootId: ctx.replyRootId } : {}),
+          },
+        });
+      },
+      onMessageHandled: (_data, ctx) => {
+        if (ctx.ingressAdmission?.admitted) return;
+        markOrdinaryTurnIgnored({
+          dataDir: config.session.dataDir,
+          larkAppId: cfg.larkAppId,
+          messageId: ctx.messageId,
+        });
+      },
+      onMessageIgnored: (_data, messageId) => {
+        markOrdinaryTurnIgnored({
+          dataDir: config.session.dataDir,
+          larkAppId: cfg.larkAppId,
+          messageId,
+        });
+      },
+      onMessageProcessingFailed: (_data, messageId) => {
+        const record = markOrdinaryTurnAttention({
+          dataDir: config.session.dataDir,
+          larkAppId: cfg.larkAppId,
+          messageId,
+          reason: 'ordinary_message_processing_failed',
+        });
+        if (!record) {
+          logger.error(
+            `[ordinary-turn] cannot persist processing failure for `
+            + `${messageId.substring(0, 12)}: claim missing`,
+          );
+          return;
+        }
+        void drainOrdinaryTurnRecovery(cfg.larkAppId, { replayReceived: false })
+          .catch(error => logger.error(
+            `[ordinary-turn] processing-failure attention drain failed: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+          ));
+      },
       handleCardAction: (data, appId) => withBotTurnAdmission(
         appId,
         () => handleCardAction(data, cardDeps, appId),
@@ -22560,7 +23064,28 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // after every durable owner is visible in the canonical registry.
   markIpcReady();
 
+  // Freeze the replay horizon before opening the WebSocket. A message claimed
+  // by this fresh daemon immediately after connect must never be mistaken for
+  // an orphan from the previous generation merely because its async routing
+  // callback has not run yet.
+  const ordinaryTurnRecoveryBootCutoffMs = Date.now();
   for (const startDispatcher of startEventDispatchers) startDispatcher();
+  let ordinaryTurnRecoveryTimer: ReturnType<typeof setInterval> | undefined;
+  if (!cfg.apiOnly) {
+    ordinaryTurnRecoveryStoppingApps.delete(cfg.larkAppId);
+    await drainOrdinaryTurnRecovery(cfg.larkAppId, {
+      replayReceived: true,
+      replayClaimedBeforeMs: ordinaryTurnRecoveryBootCutoffMs,
+    });
+    ordinaryTurnRecoveryTimer = setInterval(() => {
+      void drainOrdinaryTurnRecovery(cfg.larkAppId, { replayReceived: false })
+        .catch(error => logger.error(
+          `[ordinary-turn] periodic recovery drain failed: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+        ));
+    }, ORDINARY_TURN_RECOVERY_DRAIN_MS);
+    ordinaryTurnRecoveryTimer.unref?.();
+  }
 
   try {
     await reconcileVcMeetingManagedActionsOnBoot(cfg.larkAppId);
@@ -23077,6 +23602,28 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     // completed/failed/cancelled after the fact). Keep the queue and dispatcher
     // live through worker teardown.
     stopMaintenance();
+    ordinaryTurnRecoveryStoppingApps.add(cfg.larkAppId);
+    if (ordinaryTurnRecoveryTimer) {
+      clearInterval(ordinaryTurnRecoveryTimer);
+      ordinaryTurnRecoveryTimer = undefined;
+    }
+    const ordinaryTurnRecoveryDrain = ordinaryTurnRecoveryDrainStates.get(cfg.larkAppId);
+    if (ordinaryTurnRecoveryDrain) {
+      ordinaryTurnRecoveryDrain.requested = false;
+      ordinaryTurnRecoveryDrain.replayReceived = false;
+      ordinaryTurnRecoveryDrain.replayClaimedBeforeMs = undefined;
+    }
+    const ordinaryTurnRecoverySettled = await settleOrdinaryTurnRecoveryDrains(
+      Math.min(
+        shutdownDeadlineMs,
+        Date.now() + ORDINARY_TURN_RECOVERY_SHUTDOWN_SETTLE_MS,
+      ),
+    );
+    if (!ordinaryTurnRecoverySettled) {
+      logger.warn(
+        '[ordinary-turn] shutdown recovery drain timed out; durable rows remain for next boot',
+      );
+    }
     vcMeetingTerminalReconciler?.stop();
     clearInterval(vcMeetingDeliveryLeaseTimer);
     for (const timer of vcMeetingReceiverRecoveryTimers.values()) clearTimeout(timer);
@@ -23315,6 +23862,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     clearInterval(idleWorkerSweepTimer);
     clearInterval(sessionOwnerReminderTimer);
     clearInterval(docCommentPollTimer);
+    if (ordinaryTurnRecoveryTimer) clearInterval(ordinaryTurnRecoveryTimer);
     if (memoryDiagnostics) clearInterval(memoryDiagnostics);
     removeDaemonDescriptor(cfg.larkAppId);
     // Plain-exit path (uncaught fatal, manual process.exit) bypasses the

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1003,6 +1003,7 @@ export const messages: Record<string, string> = {
   'daemon.foreign_bot_mention_prefix': '[@mention from {botName}]',
   'daemon.ordinary_ingress_failed': '⚠️ This message did not reach the CLI. Please resend; if it keeps failing, `/close` and reopen the topic.',
   'daemon.ordinary_ingress_admitted_reply_failed': '⚠️ This message was received — do not resend it as-is (a resend would run it twice); the failure happened in a follow-up status reply or post-accept step. If nothing happens in this topic, `/close` and reopen the topic to continue.',
+  'daemon.ordinary_turn_attention_required': '⚠️ Botmux cannot safely determine this turn\'s state after an interruption ({reason}). To avoid duplicate execution, it was not replayed automatically. Check the Web Terminal and session state before continuing or retrying.',
   'daemon.cmd_needs_active_cli': '{cmd} needs an active CLI process; no running session in this topic.',
   'daemon.cmd_activation_pending': '{cmd} cannot be sent yet because the previous turn is still being submitted. Retry shortly.',
   'daemon.force_topic_ready': '💬 New topic created. Send a task in this topic, or use /repo first to choose a project.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1004,6 +1004,7 @@ export const messages: Record<string, string> = {
   'daemon.foreign_bot_mention_prefix': '[来自 {botName} 的 @mention]',
   'daemon.ordinary_ingress_failed': '⚠️ 这条消息没有送达 CLI，请重发一次；若持续失败，可 /close 后重开话题。',
   'daemon.ordinary_ingress_admitted_reply_failed': '⚠️ 这条消息已接收，请勿原样重发（重发会重复执行）；失败发生在接收之后的状态回复/收尾步骤。若话题迟迟没有动静，可 /close 后重开话题再继续。',
+  'daemon.ordinary_turn_attention_required': '⚠️ Botmux 检测到本轮在异常中断后状态无法安全确认（{reason}）。为避免重复执行，系统没有自动重放；请检查 Web 终端和会话状态，再决定继续或重试。',
   'daemon.cmd_needs_active_cli': '{cmd} 需要活跃的 CLI 进程，当前话题无运行中的会话。',
   'daemon.cmd_activation_pending': '{cmd} 暂不能发送：上一条消息仍在提交中，请稍后重试。',
   'daemon.force_topic_ready': '💬 新话题已创建。请在话题内发送任务，也可以先用 /repo 选择项目。',

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -2440,17 +2440,68 @@ function larkReceiveEventFromHistoryMessage(message: any, chatId: string): any {
   };
 }
 
+function notifyMessageProcessingFailed(
+  handlers: EventHandlers,
+  data: any,
+  messageId: string,
+): void {
+  try {
+    handlers.onMessageProcessingFailed?.(data, messageId);
+  } catch (error) {
+    logger.error(
+      `[ordinary-turn] failed to persist processing failure for `
+      + `${messageId.substring(0, 12)}: `
+      + `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function invokeMessageHandlerWithLifecycle(
+  handlers: EventHandlers,
+  data: any,
+  ctx: RoutingContext,
+  work: () => Promise<void>,
+): Promise<void> {
+  try {
+    // This is the last synchronous point before daemon routing can create a
+    // session, mutate command state, or enqueue CLI input. Persist the routed
+    // milestone first so a crash can never be mistaken for safe non-execution.
+    handlers.onMessageRouted?.(data, ctx);
+    await work();
+  } catch (error) {
+    notifyMessageProcessingFailed(handlers, data, ctx.messageId);
+    throw error;
+  }
+  // A successfully handled command/rejection/ignore path may intentionally
+  // never admit CLI work. Close that ledger row explicitly so a later daemon
+  // restart does not misclassify the completed non-CLI path as an orphan.
+  try { handlers.onMessageHandled?.(data, ctx); }
+  catch (error) {
+    logger.error(
+      `[ordinary-turn] failed to persist handled disposition for `
+      + `${ctx.messageId.substring(0, 12)}: `
+      + `${error instanceof Error ? error.message : String(error)}`,
+    );
+    notifyMessageProcessingFailed(handlers, data, ctx.messageId);
+  }
+}
+
 async function dispatchHumanMessageViaHandlers(
   larkAppId: string,
   handlers: EventHandlers,
   payload: PendingForwardTopicPayload,
   capMs?: number,
 ): Promise<void> {
-  await serializeByAnchor(payload.ctx.anchor, () => {
+  await serializeByAnchor(payload.ctx.anchor, async () => {
     const ownsSession = handlers.isSessionOwner?.(payload.ctx.anchor, larkAppId) ?? payload.ownsSession;
-    return ownsSession
-      ? handlers.handleThreadReply(payload.data, payload.ctx)
-      : handlers.handleNewTopic(payload.data, payload.ctx);
+    await invokeMessageHandlerWithLifecycle(
+      handlers,
+      payload.data,
+      payload.ctx,
+      () => ownsSession
+        ? handlers.handleThreadReply(payload.data, payload.ctx)
+        : handlers.handleNewTopic(payload.data, payload.ctx),
+    );
   }, capMs);
 }
 
@@ -2462,7 +2513,17 @@ async function dispatchPolledMessageListenerMatch(input: {
   chatId: string;
   messageId: string;
 }): Promise<void> {
-  if (!claimMessageOnce(input.larkAppId, input.messageId)) {
+  if (!claimMessageOnce(
+    input.larkAppId,
+    input.messageId,
+    Date.now(),
+    input.handlers.prepareMessageClaim
+      ? () => input.handlers.prepareMessageClaim!(input.data, input.messageId)
+      : undefined,
+    input.handlers.validateMessageClaim
+      ? () => input.handlers.validateMessageClaim!(input.data, input.messageId)
+      : undefined,
+  )) {
     logger.debug(`[message-listener:${input.larkAppId}] polled duplicate ignored msg=${input.messageId.substring(0, 12)}`);
     return;
   }
@@ -2574,6 +2635,25 @@ export interface EventHandlers {
   handleCardAction: (data: any, larkAppId: string) => Promise<any>;
   handleNewTopic: (data: any, ctx: RoutingContext) => Promise<void>;
   handleThreadReply: (data: any, ctx: RoutingContext) => Promise<void>;
+  /** Synchronous write-ahead hook invoked before the seen-message tombstone.
+   * false means this exact input intent already exists durably. Throwing keeps
+   * the WS event unacknowledged so Lark can redeliver after storage recovers. */
+  prepareMessageClaim?: (data: any, messageId: string) => boolean;
+  /** Synchronous payload-identity validation for a message id already present
+   * in the seen store. Must not synthesize a missing legacy ledger row. */
+  validateMessageClaim?: (data: any, messageId: string) => void;
+  /** Synchronous lifecycle write immediately before daemon routing starts. */
+  onMessageRouted?: (data: any, ctx: RoutingContext) => void;
+  /** Synchronous lifecycle closure after a routed handler returns normally.
+   * The daemon uses ctx.ingressAdmission to distinguish an asynchronous CLI
+   * turn from a completed command/rejection path. */
+  onMessageHandled?: (data: any, ctx: RoutingContext) => void;
+  /** Synchronous lifecycle closure for a claimed raw message that routing
+   * intentionally ignores before it enters an asynchronous handler. */
+  onMessageIgnored?: (data: any, messageId: string) => void;
+  /** Persist fail-closed attention when classification or a routed handler
+   * throws after the transport has already durably claimed the message. */
+  onMessageProcessingFailed?: (data: any, messageId: string) => void;
   /** 主动开工 — 场景①: fired when this bot is added to a chat
    *  (`im.chat.member.bot.added_v1`). The daemon decides whether to auto-start
    *  based on the bot's `autoStartOnGroupJoin` toggle + allowedUser membership.
@@ -3320,6 +3400,12 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     data: any,
     seedRoutingGate?: { ready: Promise<void>; complete: () => void },
   ): Promise<void> {
+    const rawLifecycleMessageId = data?.message?.message_id;
+    const lifecycleMessageId = typeof rawLifecycleMessageId === 'string' && rawLifecycleMessageId
+      ? rawLifecycleMessageId
+      : undefined;
+    let retainedForAsyncDispatch = false;
+    let processingFailed = false;
     try {
       const message = data.message;
       const sender = data.sender;
@@ -3388,8 +3474,14 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           // Serialize per anchor so back-to-back messages to the same thread
           // (e.g. dispatch's /repo prime + brief kickoff) don't interleave with
           // the first's async session-spawn. See anchor-serializer.ts.
-          void serializeByAnchor(ctx.anchor, () =>
-            handlers.handleThreadReply(data, { ...ctx, chatId, messageId, chatType, larkAppId }), 0)
+          retainedForAsyncDispatch = true;
+          const routeCtx: RoutingContext = { ...ctx, chatId, messageId, chatType, larkAppId };
+          void serializeByAnchor(ctx.anchor, () => invokeMessageHandlerWithLifecycle(
+            handlers,
+            data,
+            routeCtx,
+            () => handlers.handleThreadReply(data, routeCtx),
+          ), 0)
             .catch(err => logger.error(`Error handling message event: ${err}`));
           return;
         }
@@ -3443,6 +3535,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
             `[message-listener:${larkAppId}] matched bot-sender chat=${chatId.substring(0, 12)} ` +
             `msg=${messageId.substring(0, 12)} sender=${senderOpenId?.substring(0, 12) ?? '-'}`,
           );
+          retainedForAsyncDispatch = true;
           await dispatchHumanMessage(listenerRoutingContext({
             data,
             match: botMessageListener,
@@ -3538,6 +3631,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
                 `msg=${messageId.substring(0, 12)} sender=${senderOpenId?.substring(0, 12) ?? '-'} reason=${seedBotTalk.reason}`,
               );
               const seedCtx: RoutingContext = { chatId, messageId, chatType, larkAppId, scope: seedScope, anchor: seedAnchor };
+              retainedForAsyncDispatch = true;
               await dispatchHumanMessage({ data, ctx: seedCtx, ownsSession: false })
                 .catch(err => logger.error(`Error auto-starting on foreign-bot new topic: ${err}`));
               return;
@@ -3622,8 +3716,14 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         logger.info(`Bot-to-bot @mention detected (scope=${ctx.scope}): routing to handleThreadReply`);
         // Serialize per anchor — a sub-bot dispatched a /repo prime + kickoff
         // back-to-back into this thread must be handled in order, not raced.
-        void serializeByAnchor(ctx.anchor, () =>
-          handlers.handleThreadReply(data, { ...ctx, chatId, messageId, chatType, larkAppId, replyRootId }), 0)
+        retainedForAsyncDispatch = true;
+        const routeCtx: RoutingContext = { ...ctx, chatId, messageId, chatType, larkAppId, replyRootId };
+        void serializeByAnchor(ctx.anchor, () => invokeMessageHandlerWithLifecycle(
+          handlers,
+          data,
+          routeCtx,
+          () => handlers.handleThreadReply(data, routeCtx),
+        ), 0)
           .catch(err => logger.error(`Error handling bot @mention: ${err}`));
         return;
       }
@@ -4194,6 +4294,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         } catch (err) {
           logger.warn(`[forward-followup] failed to persist paired payload before dispatch: ${err}`);
         }
+        retainedForAsyncDispatch = true;
         void dispatchPersistedForwardFollowup(pairedForwardSeed.messageId, payload)
           .catch(err => logger.error(`Error handling paired message event: ${err}`));
         return;
@@ -4205,6 +4306,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         // current reply once session restoration is complete. Both calls append
         // synchronously to the same canonical FIFO; their handler completion is
         // deliberately not awaited by the raw lane.
+        retainedForAsyncDispatch = true;
         void sessionsReady.then(() => {
           void dispatchHumanMessage(stalePendingSeed.payload)
             .then(() => removeForwardFollowup(larkAppId, stalePendingSeed.messageId))
@@ -4227,11 +4329,27 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       // release the raw lane so independent topics in the same chat can run
       // concurrently. Same-anchor handlers remain strictly serialized by
       // dispatchHumanMessage's canonical queue.
+      retainedForAsyncDispatch = true;
       void dispatchHumanMessage(payload)
         .catch(err => logger.error(`Error handling message event: ${err}`));
     } catch (err) {
+      processingFailed = true;
       logger.error(`Error handling message event: ${err}`);
     } finally {
+      if (lifecycleMessageId && !retainedForAsyncDispatch) {
+        if (processingFailed) {
+          notifyMessageProcessingFailed(handlers, data, lifecycleMessageId);
+        } else {
+          try { handlers.onMessageIgnored?.(data, lifecycleMessageId); }
+          catch (error) {
+            logger.error(
+              `[ordinary-turn] failed to persist ignored disposition for `
+              + `${lifecycleMessageId.substring(0, 12)}: `
+              + `${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        }
+      }
       seedRoutingGate?.complete();
     }
   }
@@ -4323,7 +4441,17 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       const messageIdForKey = data?.message?.message_id;
       const eventKey = `im.message.receive_v1:${larkAppId}:${messageIdForKey ?? eventIdForKey(data) ?? unkeyableEventKey()}`;
       const claim = messageIdForKey
-        ? () => claimMessageOnce(larkAppId, messageIdForKey)
+        ? () => claimMessageOnce(
+            larkAppId,
+            messageIdForKey,
+            Date.now(),
+            handlers.prepareMessageClaim
+              ? () => handlers.prepareMessageClaim!(data, messageIdForKey)
+              : undefined,
+            handlers.validateMessageClaim
+              ? () => handlers.validateMessageClaim!(data, messageIdForKey)
+              : undefined,
+          )
         : () => claimEventOnce(eventKey);
       const rawMessage = data?.message;
       const ingressAnchor = rawMessageIngressAnchor(larkAppId, rawMessage);

--- a/src/index-supervisor.ts
+++ b/src/index-supervisor.ts
@@ -41,14 +41,28 @@ async function main(): Promise<void> {
   // the dashboard to add their first bot.
   const members = resolveFleetMembers();
   const botCount = resolveFleetBots().length;
+  const daemonEnv = resolveFleetDaemonEnv();
+  const positiveInt = (raw: string | undefined, fallback: number): number => {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+  };
 
   const supervisor = new FleetSupervisor({
     statePath: fleetStatePath(),
     distDir: fleetDistDir(),
-    daemonEnv: resolveFleetDaemonEnv(),
+    daemonEnv,
     cwd: configDir,
     daemonNodeArgs: fleetDaemonNodeArgs(),
     logDir: fleetLogDir(),
+    heartbeat: {
+      dataDir: daemonEnv.SESSION_DATA_DIR!,
+      scanIntervalMs: positiveInt(process.env.BOTMUX_DAEMON_HEARTBEAT_SCAN_MS, 5_000),
+      staleMs: positiveInt(process.env.BOTMUX_DAEMON_HEARTBEAT_STALE_MS, 45_000),
+      // Daemons publish the first beat only after their durable boot
+      // reconciliation and session restore. Keep that work outside the stale
+      // window while still detecting a wedged bootstrap in bounded time.
+      startupGraceMs: positiveInt(process.env.BOTMUX_DAEMON_HEARTBEAT_STARTUP_GRACE_MS, 180_000),
+    },
     log: (m) => logger.info(`[supervisor] ${m}`),
   });
 

--- a/src/services/ordinary-turn-ledger.ts
+++ b/src/services/ordinary-turn-ledger.ts
@@ -1,0 +1,739 @@
+/**
+ * Crash-durable lifecycle ledger for ordinary Lark IM turns.
+ *
+ * The record is written before the existing seen-message tombstone. Milestones
+ * are independent instead of one mutable enum because a worker can emit
+ * `final_output` before `turn_terminal`; a late terminal must never regress an
+ * already-delivered output. Only a received-only record is safe to replay.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { FrozenSessionReplyTarget } from '../types.js';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { computeInputHash } from '../utils/canonical-input-hash.js';
+import { logger } from '../utils/logger.js';
+
+const RECORD_VERSION = 1 as const;
+
+/** Keep settled rows as long as the seen-message tombstone can suppress a
+ * provider redelivery, then remove them so a genuinely old message id is not
+ * rejected forever and the ledger directory stays bounded by live work. */
+export const ORDINARY_TURN_LEDGER_RETENTION_MS = 8 * 60 * 60_000;
+/** Feishu's provider UUID dedupe lasts one hour. At or beyond that boundary an
+ * ACK-lost output is ambiguous and must become attention, never a blind send. */
+export const ORDINARY_TURN_PROVIDER_DEDUPE_MS = 60 * 60_000;
+
+export interface OrdinaryTurnRoutingSnapshot {
+  chatId: string;
+  scope: 'thread' | 'chat';
+  anchor: string;
+  replyRootId?: string;
+}
+
+export interface OrdinaryTurnOutputDelivery {
+  rootId: string;
+  content: string;
+  msgType?: string;
+  turnId: string;
+  options?: {
+    uuid?: string;
+    quoteMessageId?: string;
+    suppressHook?: boolean;
+    sourceSessionId?: string;
+    replyTarget?: FrozenSessionReplyTarget;
+    placement?: 'auto' | 'chat' | 'topic';
+  };
+}
+
+export interface OrdinaryTurnRecord {
+  version: typeof RECORD_VERSION;
+  larkAppId: string;
+  messageId: string;
+  payload: unknown;
+  payloadHash?: string;
+  claimedAt: string;
+  updatedAt: string;
+  replayScheduledAt?: string;
+  routedAt?: string;
+  routing?: OrdinaryTurnRoutingSnapshot;
+  acceptedAt?: string;
+  turnId?: string;
+  sessionId?: string;
+  worker?: {
+    generation: number;
+    receivedAt?: string;
+    committedAt?: string;
+    runningAt?: string;
+    heartbeatAt?: string;
+    rejectedAt?: string;
+    rejectionReason?: string;
+  };
+  terminal?: {
+    at: string;
+    status: 'completed' | 'failed' | 'cancelled' | 'ambiguous';
+    errorCode?: string;
+    outputDisposition?: 'nothing_to_send';
+  };
+  output?: {
+    status: 'pending' | 'delivered';
+    delivery: OrdinaryTurnOutputDelivery;
+    preparedAt: string;
+    deliveredAt?: string;
+    providerMessageId?: string;
+  };
+  attention?: {
+    requiredAt: string;
+    reason: string;
+    notifiedAt?: string;
+    providerMessageId?: string;
+  };
+}
+
+export interface OrdinaryTurnRecoveryPlan {
+  replays: OrdinaryTurnRecord[];
+  attentions: OrdinaryTurnRecord[];
+  pendingOutputs: OrdinaryTurnRecord[];
+}
+
+/** Limit boot reconciliation to rows that predate the dispatcher-open
+ * horizon. Strict comparison is intentional: a message claimed by the new
+ * daemon in the same clock millisecond as the cutoff belongs to the live
+ * generation and must not be replayed or warned concurrently. */
+export function limitOrdinaryTurnRecoveryPlanToClaimedBefore(
+  plan: OrdinaryTurnRecoveryPlan,
+  claimedBeforeMs: number | undefined,
+): OrdinaryTurnRecoveryPlan {
+  if (claimedBeforeMs === undefined) return plan;
+  const eligible = (record: OrdinaryTurnRecord): boolean => {
+    const claimedAt = Date.parse(record.claimedAt);
+    return Number.isFinite(claimedAt) && claimedAt < claimedBeforeMs;
+  };
+  return {
+    replays: plan.replays.filter(eligible),
+    attentions: plan.attentions.filter(eligible),
+    pendingOutputs: plan.pendingOutputs.filter(eligible),
+  };
+}
+
+type AppCache = Map<string, OrdinaryTurnRecord>;
+const caches = new Map<string, AppCache>();
+
+function iso(now: number): string {
+  return new Date(now).toISOString();
+}
+
+function safeSegment(value: string): string {
+  const prefix = value.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 64) || 'unknown';
+  const digest = createHash('sha256').update(value, 'utf8').digest('hex').slice(0, 12);
+  return `${prefix}-${digest}`;
+}
+
+/** Stable Lark idempotency token shared by live failure cards and boot replay.
+ * A provider ACK can be lost after the card was accepted; deriving from the
+ * durable record identity makes the retry collapse onto the same message. */
+export function ordinaryTurnRecoveryUuid(
+  kind: 'output' | 'attention',
+  larkAppId: string,
+  messageId: string,
+): string {
+  const digest = createHash('sha256')
+    .update(`${kind}\0${larkAppId}\0${messageId}`, 'utf8')
+    .digest('hex');
+  return `${kind === 'output' ? 'oo' : 'oa'}_${digest}`.slice(0, 50);
+}
+
+function appDir(dataDir: string, larkAppId: string): string {
+  return join(dataDir, 'ordinary-turn-ledger', safeSegment(larkAppId));
+}
+
+function recordPath(dataDir: string, larkAppId: string, messageId: string): string {
+  const digest = createHash('sha256').update(messageId, 'utf8').digest('hex');
+  return join(appDir(dataDir, larkAppId), `${digest}.json`);
+}
+
+function cacheKey(dataDir: string, larkAppId: string): string {
+  return `${resolve(dataDir)}\u0000${larkAppId}`;
+}
+
+function isRecord(value: unknown, larkAppId: string): value is OrdinaryTurnRecord {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Partial<OrdinaryTurnRecord>;
+  return record.version === RECORD_VERSION
+    && record.larkAppId === larkAppId
+    && typeof record.messageId === 'string'
+    && !!record.messageId
+    && typeof record.claimedAt === 'string'
+    && typeof record.updatedAt === 'string';
+}
+
+function load(dataDir: string, larkAppId: string): AppCache {
+  const key = cacheKey(dataDir, larkAppId);
+  const cached = caches.get(key);
+  if (cached) return cached;
+
+  const records: AppCache = new Map();
+  const dir = appDir(dataDir, larkAppId);
+  if (existsSync(dir)) {
+    let names: string[] = [];
+    try { names = readdirSync(dir).filter(name => name.endsWith('.json')).sort(); }
+    catch (error) {
+      logger.error(`[ordinary-turn-ledger] cannot scan ${dir}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    for (const name of names) {
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(join(dir, name), 'utf8'));
+        if (!isRecord(parsed, larkAppId)) {
+          logger.error(`[ordinary-turn-ledger] invalid record ignored: ${join(dir, name)}`);
+          continue;
+        }
+        const prior = records.get(parsed.messageId);
+        if (!prior || Date.parse(parsed.updatedAt) >= Date.parse(prior.updatedAt)) {
+          records.set(parsed.messageId, parsed);
+        }
+      } catch (error) {
+        logger.error(`[ordinary-turn-ledger] corrupt record ignored (${join(dir, name)}): ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+  caches.set(key, records);
+  return records;
+}
+
+function persist(dataDir: string, record: OrdinaryTurnRecord): void {
+  const dir = appDir(dataDir, record.larkAppId);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  atomicWriteFileSync(
+    recordPath(dataDir, record.larkAppId, record.messageId),
+    JSON.stringify(record),
+    { durable: true, mode: 0o600, followTargetSymlink: false },
+  );
+  load(dataDir, record.larkAppId).set(record.messageId, record);
+}
+
+function clone(record: OrdinaryTurnRecord): OrdinaryTurnRecord {
+  return structuredClone(record);
+}
+
+function resolvedAtMs(record: OrdinaryTurnRecord): number | undefined {
+  // A pending output remains unresolved until the user-facing ambiguity fence
+  // itself is durably notified. After that notification the provider request
+  // is deliberately abandoned (its one-hour UUID window has elapsed), so the
+  // row may be compacted once the normal retention horizon also passes.
+  if (record.output?.status === 'pending' && !record.attention?.notifiedAt) {
+    return undefined;
+  }
+  const value = record.output?.status === 'delivered'
+    ? record.output.deliveredAt ?? record.updatedAt
+    : record.attention?.notifiedAt
+      ? record.attention.notifiedAt
+      : record.terminal?.outputDisposition === 'nothing_to_send'
+        ? record.terminal.at
+        : undefined;
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/** Delete only positively settled rows older than the seen-store retention.
+ * Ambiguous work, pending output, and unnotified attention are deliberately
+ * retained without a size-based eviction: dropping them would recreate the
+ * silent-loss window this ledger exists to close. */
+export function compactOrdinaryTurnLedger(input: {
+  dataDir: string;
+  larkAppId: string;
+  now?: number;
+  retentionMs?: number;
+}): number {
+  const now = input.now ?? Date.now();
+  const retentionMs = input.retentionMs ?? ORDINARY_TURN_LEDGER_RETENTION_MS;
+  const records = load(input.dataDir, input.larkAppId);
+  let removed = 0;
+  for (const [messageId, record] of records) {
+    const resolvedAt = resolvedAtMs(record);
+    if (resolvedAt === undefined || now - resolvedAt < retentionMs) continue;
+    const file = recordPath(input.dataDir, input.larkAppId, messageId);
+    try {
+      unlinkSync(file);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT') {
+        logger.error(
+          `[ordinary-turn-ledger] cannot compact ${file}: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+        );
+        continue;
+      }
+    }
+    records.delete(messageId);
+    removed += 1;
+  }
+  return removed;
+}
+
+function findByTurnId(dataDir: string, larkAppId: string, turnId: string): OrdinaryTurnRecord | undefined {
+  const records = load(dataDir, larkAppId);
+  const matches: OrdinaryTurnRecord[] = [];
+  for (const record of records.values()) {
+    if (record.turnId !== turnId) continue;
+    matches.push(record);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `ordinary turn ambiguous turn id ${turnId}: `
+      + `${matches.map(record => record.messageId).sort().join(',')}`,
+    );
+  }
+  // A session-group reply anchor can equal another inbound message_id. Prefer
+  // the row that explicitly owns this turn id; exact message-id lookup is only
+  // the compatibility fallback for pre-accept milestones whose turnId is not
+  // stamped yet.
+  return matches[0] ?? records.get(turnId);
+}
+
+function update(
+  dataDir: string,
+  larkAppId: string,
+  messageId: string,
+  now: number,
+  mutate: (record: OrdinaryTurnRecord, at: string) => void,
+): OrdinaryTurnRecord | undefined {
+  const record = load(dataDir, larkAppId).get(messageId);
+  if (!record) return undefined;
+  const next = clone(record);
+  const at = iso(now);
+  mutate(next, at);
+  next.updatedAt = at;
+  persist(dataDir, next);
+  return clone(next);
+}
+
+function updateByTurnId(
+  dataDir: string,
+  larkAppId: string,
+  turnId: string,
+  now: number,
+  mutate: (record: OrdinaryTurnRecord, at: string) => void,
+): OrdinaryTurnRecord | undefined {
+  const record = findByTurnId(dataDir, larkAppId, turnId);
+  return record ? update(dataDir, larkAppId, record.messageId, now, mutate) : undefined;
+}
+
+export function prepareOrdinaryTurnClaim(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId: string;
+  payload: unknown;
+  now?: number;
+}): 'created' | 'duplicate' {
+  if (!input.messageId) throw new Error('ordinary turn claim requires messageId');
+  compactOrdinaryTurnLedger({
+    dataDir: input.dataDir,
+    larkAppId: input.larkAppId,
+    now: input.now,
+  });
+  const records = load(input.dataDir, input.larkAppId);
+  const existing = records.get(input.messageId);
+  if (existing) {
+    validateOrdinaryTurnClaim(input);
+    return 'duplicate';
+  }
+  const payloadHash = computeInputHash(input.payload);
+  const at = iso(input.now ?? Date.now());
+  persist(input.dataDir, {
+    version: RECORD_VERSION,
+    larkAppId: input.larkAppId,
+    messageId: input.messageId,
+    payload: structuredClone(input.payload),
+    payloadHash,
+    claimedAt: at,
+    updatedAt: at,
+  });
+  return 'created';
+}
+
+/** Validate a provider duplicate even when the seen-message tombstone already
+ * exists. Missing rows are legacy-compatible (do not synthesize replay work),
+ * while one message id carrying different intent is persisted as attention and
+ * rejected before ACK. */
+export function validateOrdinaryTurnClaim(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId: string;
+  payload: unknown;
+  now?: number;
+}): 'absent' | 'match' {
+  const existing = load(input.dataDir, input.larkAppId).get(input.messageId);
+  if (!existing) return 'absent';
+  const payloadHash = computeInputHash(input.payload);
+  const existingHash = existing.payloadHash ?? computeInputHash(existing.payload);
+  if (existingHash === payloadHash) return 'match';
+  update(
+    input.dataDir,
+    input.larkAppId,
+    input.messageId,
+    input.now ?? Date.now(),
+    (record, at) => {
+      record.payloadHash ??= existingHash;
+      record.attention ??= {
+        requiredAt: at,
+        reason: 'message_id_payload_conflict',
+      };
+    },
+  );
+  throw new Error(`ordinary message ${input.messageId} payload conflict`);
+}
+
+export function markOrdinaryTurnReplayScheduled(input: {
+  dataDir: string; larkAppId: string; messageId: string; now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return update(input.dataDir, input.larkAppId, input.messageId, input.now ?? Date.now(), (record, at) => {
+    record.replayScheduledAt ??= at;
+  });
+}
+
+export function markOrdinaryTurnRouted(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId: string;
+  routing: OrdinaryTurnRoutingSnapshot;
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return update(input.dataDir, input.larkAppId, input.messageId, input.now ?? Date.now(), (record, at) => {
+    const firstRealRoute = !record.routedAt && !record.acceptedAt && !record.worker;
+    if (firstRealRoute && record.terminal?.outputDisposition === 'nothing_to_send') {
+      delete record.terminal;
+    }
+    if (firstRealRoute && record.attention && !record.attention.notifiedAt) {
+      delete record.attention;
+    }
+    record.routedAt ??= at;
+    record.routing ??= structuredClone(input.routing);
+  });
+}
+
+/** Settle a claimed message that routing intentionally ignored or handled
+ * without admitting CLI work. This is message-id addressed on purpose: before
+ * acceptance there may be no turnId, and another row's turnId may equal this
+ * message id. */
+export function markOrdinaryTurnIgnored(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId: string;
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return update(input.dataDir, input.larkAppId, input.messageId, input.now ?? Date.now(), (record, at) => {
+    record.terminal = {
+      at,
+      status: 'completed',
+      outputDisposition: 'nothing_to_send',
+    };
+    if (record.attention && !record.attention.notifiedAt) delete record.attention;
+  });
+}
+
+export function markOrdinaryTurnAccepted(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId: string;
+  turnId: string;
+  sessionId?: string;
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return update(input.dataDir, input.larkAppId, input.messageId, input.now ?? Date.now(), (record, at) => {
+    record.acceptedAt ??= at;
+    record.turnId ??= input.turnId;
+    if (input.sessionId) record.sessionId ??= input.sessionId;
+  });
+}
+
+function workerMilestone(input: {
+  dataDir: string;
+  larkAppId: string;
+  turnId: string;
+  sessionId?: string;
+  workerGeneration: number;
+  now?: number;
+}, mutate: (worker: NonNullable<OrdinaryTurnRecord['worker']>, at: string) => void): OrdinaryTurnRecord | undefined {
+  return updateByTurnId(input.dataDir, input.larkAppId, input.turnId, input.now ?? Date.now(), (record, at) => {
+    record.turnId ??= input.turnId;
+    if (input.sessionId) record.sessionId ??= input.sessionId;
+    const worker = record.worker ?? { generation: input.workerGeneration };
+    if (worker.generation !== input.workerGeneration) {
+      record.attention ??= { requiredAt: at, reason: 'worker_generation_changed' };
+      return;
+    }
+    record.worker = worker;
+    mutate(worker, at);
+  });
+}
+
+export function markOrdinaryTurnWorkerReceived(input: {
+  dataDir: string; larkAppId: string; turnId: string; sessionId?: string; workerGeneration: number; now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return workerMilestone(input, (worker, at) => { worker.receivedAt ??= at; });
+}
+
+export function markOrdinaryTurnCommitted(input: {
+  dataDir: string; larkAppId: string; turnId: string; sessionId?: string; workerGeneration: number; now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return workerMilestone(input, (worker, at) => { worker.committedAt ??= at; });
+}
+
+export function markOrdinaryTurnRunning(input: {
+  dataDir: string; larkAppId: string; turnId: string; sessionId?: string; workerGeneration: number; now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return workerMilestone(input, (worker, at) => {
+    worker.runningAt ??= at;
+    worker.heartbeatAt = at;
+  });
+}
+
+export function markOrdinaryTurnHeartbeat(input: {
+  dataDir: string; larkAppId: string; turnId: string; sessionId?: string; workerGeneration: number; now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return workerMilestone(input, (worker, at) => { worker.heartbeatAt = at; });
+}
+
+export function markOrdinaryTurnRejected(input: {
+  dataDir: string; larkAppId: string; turnId: string; sessionId?: string; workerGeneration: number; reason: string; now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return workerMilestone(input, (worker, at) => {
+    worker.rejectedAt = at;
+    worker.rejectionReason = input.reason;
+  });
+}
+
+export function markOrdinaryTurnTerminal(input: {
+  dataDir: string;
+  larkAppId: string;
+  turnId: string;
+  status: 'completed' | 'failed' | 'cancelled' | 'ambiguous';
+  errorCode?: string;
+  outputDisposition?: 'nothing_to_send';
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return updateByTurnId(input.dataDir, input.larkAppId, input.turnId, input.now ?? Date.now(), (record, at) => {
+    record.terminal = {
+      at,
+      status: input.status,
+      ...(input.errorCode ? { errorCode: input.errorCode } : {}),
+      ...(input.outputDisposition ? { outputDisposition: input.outputDisposition } : {}),
+    };
+  });
+}
+
+export function prepareOrdinaryTurnOutput(input: {
+  dataDir: string;
+  larkAppId: string;
+  turnId: string;
+  delivery: OrdinaryTurnOutputDelivery;
+  now?: number;
+}): 'absent' | 'pending' | 'delivered' {
+  const record = findByTurnId(input.dataDir, input.larkAppId, input.turnId);
+  if (!record) return 'absent';
+  if (record.output?.status === 'delivered') return 'delivered';
+  if (record.output) {
+    if (JSON.stringify(record.output.delivery) !== JSON.stringify(input.delivery)) {
+      markOrdinaryTurnAttention({
+        dataDir: input.dataDir,
+        larkAppId: input.larkAppId,
+        turnId: input.turnId,
+        reason: 'final_output_payload_conflict',
+        now: input.now,
+      });
+      throw new Error(`ordinary turn ${input.turnId} final_output payload conflict`);
+    }
+    return 'pending';
+  }
+  update(input.dataDir, input.larkAppId, record.messageId, input.now ?? Date.now(), (next, at) => {
+    next.output = {
+      status: 'pending',
+      delivery: structuredClone(input.delivery),
+      preparedAt: at,
+    };
+  });
+  return 'pending';
+}
+
+export function markOrdinaryTurnOutputDelivered(input: {
+  dataDir: string;
+  larkAppId: string;
+  turnId: string;
+  providerMessageId: string;
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  return updateByTurnId(input.dataDir, input.larkAppId, input.turnId, input.now ?? Date.now(), (record, at) => {
+    if (!record.output) throw new Error(`ordinary turn ${input.turnId} output was not prepared`);
+    record.output.status = 'delivered';
+    record.output.deliveredAt = at;
+    record.output.providerMessageId = input.providerMessageId;
+  });
+}
+
+export function markOrdinaryTurnAttention(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId?: string;
+  turnId?: string;
+  reason: string;
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  const record = input.messageId
+    ? load(input.dataDir, input.larkAppId).get(input.messageId)
+    : input.turnId
+      ? findByTurnId(input.dataDir, input.larkAppId, input.turnId)
+      : undefined;
+  if (!record) return undefined;
+  return update(input.dataDir, input.larkAppId, record.messageId, input.now ?? Date.now(), (next, at) => {
+    next.attention ??= { requiredAt: at, reason: input.reason };
+  });
+}
+
+export function markOrdinaryTurnAttentionNotified(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId?: string;
+  turnId?: string;
+  providerMessageId: string;
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  const record = input.messageId
+    ? load(input.dataDir, input.larkAppId).get(input.messageId)
+    : input.turnId
+      ? findByTurnId(input.dataDir, input.larkAppId, input.turnId)
+      : undefined;
+  if (!record) return undefined;
+  return update(input.dataDir, input.larkAppId, record.messageId, input.now ?? Date.now(), (next, at) => {
+    if (!next.attention) throw new Error(`ordinary turn ${record.messageId} attention was not prepared`);
+    next.attention.notifiedAt = at;
+    next.attention.providerMessageId = input.providerMessageId;
+  });
+}
+
+function needsAttention(record: OrdinaryTurnRecord): boolean {
+  if (record.attention) return !record.attention.notifiedAt;
+  if (record.output?.status === 'delivered') return false;
+  if (record.output?.status === 'pending') return false;
+  if (record.terminal?.outputDisposition === 'nothing_to_send') return false;
+  return !!(
+    record.replayScheduledAt
+    || record.routedAt
+    || record.acceptedAt
+    || record.worker?.receivedAt
+    || record.worker?.committedAt
+    || record.worker?.runningAt
+    || record.terminal
+  );
+}
+
+function pendingOutputWithinProviderDedupeWindow(
+  record: OrdinaryTurnRecord,
+  now: number,
+): boolean {
+  if (record.output?.status !== 'pending') return false;
+  const preparedAt = Date.parse(record.output.preparedAt);
+  return Number.isFinite(preparedAt)
+    && now - preparedAt < ORDINARY_TURN_PROVIDER_DEDUPE_MS;
+}
+
+/** Re-read a pending output immediately before its provider call. Recovery
+ * planning and delivery are separated by awaits, while the live final-output
+ * path can settle the same row in between. The stable provider UUID closes the
+ * remaining check-to-send race, but a stale snapshot must not initiate a send
+ * after delivery already settled or the provider dedupe window expired. */
+export function selectOrdinaryTurnPendingOutputForDelivery(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId: string;
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  const record = load(input.dataDir, input.larkAppId).get(input.messageId);
+  if (!record || !pendingOutputWithinProviderDedupeWindow(record, input.now ?? Date.now())) {
+    return undefined;
+  }
+  return clone(record);
+}
+
+/** Re-read an attention candidate immediately before its provider call.
+ * Periodic drains may deliver only an explicit durable fence, whereas boot
+ * reconciliation may infer attention from an incomplete pre-boot lifecycle.
+ * An expired pending output is the one periodic inferred case: it must warn a
+ * human instead of crossing Feishu's one-hour UUID dedupe boundary. */
+export function selectOrdinaryTurnAttentionForDelivery(input: {
+  dataDir: string;
+  larkAppId: string;
+  messageId: string;
+  allowInferred: boolean;
+  now?: number;
+}): OrdinaryTurnRecord | undefined {
+  const now = input.now ?? Date.now();
+  const record = load(input.dataDir, input.larkAppId).get(input.messageId);
+  if (!record) return undefined;
+  if (record.output?.status === 'delivered'
+    || record.terminal?.outputDisposition === 'nothing_to_send'
+    || record.attention?.notifiedAt) {
+    return undefined;
+  }
+  if (record.output?.status === 'pending') {
+    if (pendingOutputWithinProviderDedupeWindow(record, now)) return undefined;
+    const attention = clone(record);
+    attention.attention ??= {
+      requiredAt: iso(now),
+      reason: 'pending_output_provider_dedupe_expired',
+    };
+    return attention;
+  }
+  if (record.attention) return clone(record);
+  if (!input.allowInferred || !needsAttention(record)) return undefined;
+  return clone(record);
+}
+
+export function planOrdinaryTurnRecovery(
+  dataDir: string,
+  larkAppId: string,
+  now = Date.now(),
+): OrdinaryTurnRecoveryPlan {
+  compactOrdinaryTurnLedger({ dataDir, larkAppId, now });
+  const plan: OrdinaryTurnRecoveryPlan = { replays: [], attentions: [], pendingOutputs: [] };
+  const records = [...load(dataDir, larkAppId).values()]
+    .sort((a, b) => Date.parse(a.claimedAt) - Date.parse(b.claimedAt));
+  for (const record of records) {
+    if (record.output?.status === 'pending') {
+      if (pendingOutputWithinProviderDedupeWindow(record, now)) {
+        plan.pendingOutputs.push(clone(record));
+      } else if (!record.attention?.notifiedAt) {
+        const attention = clone(record);
+        attention.attention ??= {
+          requiredAt: iso(now),
+          reason: 'pending_output_provider_dedupe_expired',
+        };
+        plan.attentions.push(attention);
+      }
+      continue;
+    }
+    if (record.output?.status === 'delivered'
+      || record.terminal?.outputDisposition === 'nothing_to_send'
+      || record.attention?.notifiedAt) continue;
+    if (needsAttention(record)) {
+      plan.attentions.push(clone(record));
+      continue;
+    }
+    plan.replays.push(clone(record));
+  }
+  return plan;
+}
+
+export function readOrdinaryTurnRecord(
+  dataDir: string,
+  larkAppId: string,
+  messageIdOrTurnId: string,
+): OrdinaryTurnRecord | undefined {
+  const record = load(dataDir, larkAppId).get(messageIdOrTurnId)
+    ?? findByTurnId(dataDir, larkAppId, messageIdOrTurnId);
+  return record ? clone(record) : undefined;
+}
+
+export function _resetOrdinaryTurnLedgerCacheForTest(): void {
+  caches.clear();
+}

--- a/src/services/seen-message-store.ts
+++ b/src/services/seen-message-store.ts
@@ -103,11 +103,28 @@ function pruneAndCap(map: Map<string, number>, now: number): void {
  * 8h 内重复命中（飞书重推 / at-least-once 重复）→ 返回 `false`（重投，应丢弃）。
  * 空 `messageId` 无法去重 → 永远 `true`（绝不因缺 id 而误吞真实消息）。
  */
-export function claimMessageOnce(larkAppId: string, messageId: string, now = Date.now()): boolean {
+export function claimMessageOnce(
+  larkAppId: string,
+  messageId: string,
+  now = Date.now(),
+  prepareClaim?: () => boolean,
+  validateExistingClaim?: () => void,
+): boolean {
   if (!messageId) return true;
   const cache = load(larkAppId);
   const exp = cache.map.get(messageId);
-  if (exp && exp > now) return false; // 命中未过期记录 → 重投
+  if (exp && exp > now) {
+    // Validate without creating a new ledger row: older seen tombstones may
+    // legitimately predate the ledger rollout, and backfilling one here would
+    // manufacture unsafe replay work for an already-processed message.
+    validateExistingClaim?.();
+    return false; // 命中未过期记录 → 重投
+  }
+  // Write the full durable input intent before publishing the payload-free seen
+  // tombstone. Throwing deliberately escapes the synchronous WS handler so no
+  // ACK is emitted; false means an earlier attempt already prepared the same
+  // durable turn (including ledger-written/seen-not-yet-written crash windows).
+  if (prepareClaim && !prepareClaim()) return false;
   pruneAndCap(cache.map, now);
   cache.map.set(messageId, now + TTL_MS);
   persist(larkAppId, cache.map);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1265,6 +1265,14 @@ export type WorkerToDaemon =
       turnId?: string;
       dispatchAttempt?: number;
     }
+  /** Event-loop liveness lease. Absence is the signal: a live OS process that
+   * stops emitting these is independently fenced by the daemon watchdog. */
+  | {
+      type: 'worker_heartbeat';
+      sessionId?: string;
+      turnId?: string;
+      dispatchAttempt?: number;
+    }
   | { type: 'persistent_backend_target'; target?: PersistentBackendTarget }
   /** The exact inbound turn is now durably owned by this worker generation's
    * CLI input queue. The daemon persists a root-bound receipt only after this

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18085,6 +18085,13 @@ function emitTurnTerminal(
     // fresh process behind the receiver's newer dispatch attempt.
     inflightInputs.onTurnComplete();
     durableTurnInFlight = false;
+    // Do not keep publishing the settled turn in the independent heartbeat.
+    // The next explicitly admitted input installs a fresh identity before it
+    // can reach the CLI; delayed screen/IPC observations are fenced daemon-side.
+    currentBotmuxTurnId = undefined;
+    currentBotmuxDispatchAttempt = undefined;
+    currentGatewayTrustedCaller = undefined;
+    currentVcMeetingImTurnOrigin = undefined;
     // The terminal may be emitted from inside an active flush continuation
     // (for example a synchronous hard-submit failure). Wake after that
     // continuation releases the mutex so queued work cannot remain stranded.
@@ -19709,6 +19716,23 @@ process.on('SIGTERM', () => shutdownWorkerForParentExit('SIGTERM'));
 process.on('SIGINT', () => shutdownWorkerForParentExit('SIGINT'));
 // If parent daemon dies, IPC channel closes — clean up
 process.on('disconnect', () => { log('Daemon disconnected'); shutdownWorkerForParentExit('IPC disconnect'); });
+
+// Independent worker event-loop lease. The daemon observes receipt time rather
+// than trusting a worker-authored clock. A process that is alive but blocked in
+// synchronous work cannot run this interval, so the daemon can persist an
+// attention fence and SIGKILL the exact generation instead of leaving a turn
+// silently stuck forever.
+const WORKER_HEARTBEAT_INTERVAL_MS = 5_000;
+setInterval(() => {
+  send({
+    type: 'worker_heartbeat',
+    ...(sessionId ? { sessionId } : {}),
+    ...(currentBotmuxTurnId ? { turnId: currentBotmuxTurnId } : {}),
+    ...(currentBotmuxDispatchAttempt !== undefined
+      ? { dispatchAttempt: currentBotmuxDispatchAttempt }
+      : {}),
+  });
+}, WORKER_HEARTBEAT_INTERVAL_MS).unref();
 
 // Watchdog: belt-and-braces parent-death detection. SIGTERM and 'disconnect'
 // should both reach us when the daemon dies, but if main thread is stuck in

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -40,6 +40,7 @@ vi.mock('../src/im/lark/doc-comment.js', () => ({
 vi.mock('../src/im/lark/card-builder.js', () => ({
   buildStreamingCard: vi.fn(() => '{}'),
   buildSessionCard: vi.fn(() => '{}'),
+  buildTurnFailedCard: vi.fn(() => '{}'),
   buildTuiPromptCard: vi.fn(() => '{}'),
   buildTuiPromptResolvedCard: vi.fn(() => '{}'),
   getCliDisplayName: vi.fn(() => 'Claude'),
@@ -105,6 +106,8 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 import {
   getDaemonReplyCardUsageSnapshot,
   initWorkerPool,
+  __testOnly_resetWorkerHeartbeatLeases,
+  __testOnly_scanWorkerHeartbeatLeases,
   __testOnly_setupWorkerHandlers,
   setActiveSessionsRegistry,
 } from '../src/core/worker-pool.js';
@@ -144,7 +147,8 @@ function makeDs(): DaemonSession {
   const fakeWorker = new EventEmitter() as any;
   fakeWorker.killed = false;
   fakeWorker.send = vi.fn();
-  fakeWorker.kill = vi.fn();
+  // Match ChildProcess.kill(): true means the signal was accepted.
+  fakeWorker.kill = vi.fn(() => true);
   fakeWorker.pid = 99999;
   fakeWorker.stdout = new EventEmitter();
   fakeWorker.stderr = new EventEmitter();
@@ -257,6 +261,7 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     setActiveSessionsRegistry(undefined);
     rmSync('/tmp/test-sessions', { recursive: true, force: true });
     clearMessageListenerRunPreviewStore();
+    __testOnly_resetWorkerHeartbeatLeases();
     vi.useRealTimers();
   });
 
@@ -2435,6 +2440,51 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(closeSession).not.toHaveBeenCalled();
   });
 
+  it('write-aheads an ordinary final output before every provider attempt and leaves it pending on exhaustion', async () => {
+    const order: string[] = [];
+    const sessionReply = vi.fn(async () => {
+      order.push('provider');
+      throw new Error('persistent');
+    });
+    const prepareOrdinaryFinalOutput = vi.fn(() => {
+      order.push('prepare');
+      return 'pending' as const;
+    });
+    const completeOrdinaryFinalOutput = vi.fn();
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      prepareOrdinaryFinalOutput,
+      completeOrdinaryFinalOutput,
+    });
+
+    const ds = makeDs();
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    __testOnly_deliverFinalOutput(ds, {
+      ...finalOutputMsg(),
+      turnId: 'om_outbox_turn',
+      lastUuid: 'ordinary-outbox-answer',
+    }, 'tag', 0, undefined, undefined, { mode: 'thread', rootMessageId: 'om_root' });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(15000);
+
+    expect(sessionReply).toHaveBeenCalledTimes(3);
+    expect(prepareOrdinaryFinalOutput).toHaveBeenCalledTimes(3);
+    expect(completeOrdinaryFinalOutput).not.toHaveBeenCalled();
+    expect(order).toEqual([
+      'prepare', 'provider',
+      'prepare', 'provider',
+      'prepare', 'provider',
+    ]);
+    const preparedUuids = prepareOrdinaryFinalOutput.mock.calls.map(call => call[1].delivery.options?.uuid);
+    expect(new Set(preparedUuids).size).toBe(1);
+    expect(preparedUuids[0]).toMatch(/^bf_[0-9a-f]{46}$/);
+  });
+
   it('MessageWithdrawnError aborts retries, commits dedup, and closes session', async () => {
     const sessionReply = vi.fn().mockRejectedValue(new MessageWithdrawnError('om_root'));
     const closeSession = vi.fn();
@@ -2525,6 +2575,10 @@ describe('Worker turn_terminal routing', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    __testOnly_resetWorkerHeartbeatLeases();
+  });
+
   it('routes a matching terminal receipt independently of final_output', async () => {
     const ds = makeDs();
     const onTurnTerminal = vi.fn(async () => {});
@@ -2548,6 +2602,195 @@ describe('Worker turn_terminal routing', () => {
 
     expect(onTurnTerminal).toHaveBeenCalledTimes(1);
     expect(onTurnTerminal).toHaveBeenCalledWith(ds, terminal, { workerGeneration: 1 });
+  });
+
+  it('persists exact-generation stall attention before SIGKILL and retries the fence if persistence fails', async () => {
+    const ds = makeDs();
+    const onWorkerHeartbeatStalled = vi.fn()
+      .mockImplementationOnce(() => { throw new Error('ledger unavailable'); })
+      .mockImplementation(() => {});
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      onWorkerHeartbeatStalled,
+    });
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+    const workerGeneration = ds.workerGeneration!;
+
+    (ds.worker as any).emit('message', {
+      type: 'worker_heartbeat',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_stalled_turn',
+    } satisfies Extract<WorkerToDaemon, { type: 'worker_heartbeat' }>);
+    await Promise.resolve();
+
+    const heartbeatObservedAt = Date.now();
+    __testOnly_scanWorkerHeartbeatLeases(heartbeatObservedAt + 5_000);
+    expect(onWorkerHeartbeatStalled).not.toHaveBeenCalled();
+    const firstDetectedAt = heartbeatObservedAt + 30_001;
+    __testOnly_scanWorkerHeartbeatLeases(firstDetectedAt);
+    expect(onWorkerHeartbeatStalled).toHaveBeenCalledWith(ds, {
+      sessionId: ds.session.sessionId,
+      workerGeneration,
+      turnId: 'om_stalled_turn',
+      lastHeartbeatAt: expect.any(Number),
+      detectedAt: firstDetectedAt,
+    });
+    expect((ds.worker as any).kill).not.toHaveBeenCalled();
+
+    const retryDetectedAt = firstDetectedAt + 1;
+    __testOnly_scanWorkerHeartbeatLeases(retryDetectedAt);
+    expect(onWorkerHeartbeatStalled).toHaveBeenCalledTimes(2);
+    expect((ds.worker as any).kill).toHaveBeenCalledOnce();
+    expect((ds.worker as any).kill).toHaveBeenCalledWith('SIGKILL');
+    expect(ds.workerGeneration).toBe(workerGeneration);
+    expect(ds.session.workerGeneration).toBe(workerGeneration);
+  });
+
+  it('retains the stalled-worker lease and retries when SIGKILL is not accepted', async () => {
+    const ds = makeDs();
+    const kill = vi.mocked((ds.worker as any).kill)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const onWorkerHeartbeatStalled = vi.fn();
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      onWorkerHeartbeatStalled,
+    });
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', {
+      type: 'worker_heartbeat',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_kill_retry_turn',
+    } satisfies Extract<WorkerToDaemon, { type: 'worker_heartbeat' }>);
+    await Promise.resolve();
+
+    const observedAt = Date.now();
+    __testOnly_scanWorkerHeartbeatLeases(observedAt + 5_000);
+    __testOnly_scanWorkerHeartbeatLeases(observedAt + 30_001);
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(onWorkerHeartbeatStalled).toHaveBeenCalledTimes(1);
+
+    __testOnly_scanWorkerHeartbeatLeases(observedAt + 30_002);
+    expect(kill).toHaveBeenCalledTimes(2);
+    expect(kill).toHaveBeenLastCalledWith('SIGKILL');
+    expect(onWorkerHeartbeatStalled).toHaveBeenCalledTimes(2);
+  });
+
+  it('fences late heartbeats after terminal until an explicit receipt reactivates the turn', async () => {
+    const ds = makeDs();
+    const onOrdinaryImProgress = vi.fn();
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      onOrdinaryImProgress,
+      onTurnTerminal: vi.fn(async () => {}),
+    });
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+    const heartbeat = {
+      type: 'worker_heartbeat',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_settled_heartbeat_turn',
+    } satisfies Extract<WorkerToDaemon, { type: 'worker_heartbeat' }>;
+
+    (ds.worker as any).emit('message', {
+      type: 'turn_input_received',
+      turnId: heartbeat.turnId,
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_input_received' }>);
+    (ds.worker as any).emit('message', heartbeat);
+    expect(onOrdinaryImProgress).toHaveBeenCalledTimes(1);
+
+    (ds.worker as any).emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: heartbeat.turnId,
+      status: 'completed',
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_terminal' }>);
+    await Promise.resolve();
+    onOrdinaryImProgress.mockClear();
+
+    (ds.worker as any).emit('message', heartbeat);
+    expect(onOrdinaryImProgress).not.toHaveBeenCalled();
+
+    (ds.worker as any).emit('message', {
+      type: 'turn_input_received',
+      turnId: heartbeat.turnId,
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_input_received' }>);
+    (ds.worker as any).emit('message', heartbeat);
+    expect(onOrdinaryImProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not blame every worker when the daemon-side scanner itself missed a stale window', () => {
+    const ds = makeDs();
+    const onWorkerHeartbeatStalled = vi.fn();
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      onWorkerHeartbeatStalled,
+    });
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+    const scannerReadyAt = Date.now();
+
+    __testOnly_scanWorkerHeartbeatLeases(scannerReadyAt + 31_000);
+
+    expect(onWorkerHeartbeatStalled).not.toHaveBeenCalled();
+    expect((ds.worker as any).kill).not.toHaveBeenCalled();
+  });
+
+  it('settles a durable failure-card attention only after ACK and reuses its UUID after ACK loss', async () => {
+    const sessionReply = vi.fn()
+      .mockRejectedValueOnce(new Error('accepted but ACK lost'))
+      .mockResolvedValueOnce('om_failure_card');
+    const prepareOrdinaryAttention = vi.fn(() => ({ uuid: 'oa_stable_attention_uuid' }));
+    const completeOrdinaryAttention = vi.fn();
+    const ds = makeDs();
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      prepareOrdinaryAttention,
+      completeOrdinaryAttention,
+    });
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+    const terminal = {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_failure_card_turn',
+      status: 'ambiguous',
+      errorCode: 'cli_exit',
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_terminal' }>;
+
+    (ds.worker as any).emit('message', terminal);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(prepareOrdinaryAttention).toHaveBeenCalledOnce();
+    expect(sessionReply).toHaveBeenCalledOnce();
+    expect(sessionReply.mock.calls[0][5]).toEqual({ uuid: 'oa_stable_attention_uuid' });
+    expect(completeOrdinaryAttention).not.toHaveBeenCalled();
+
+    (ds.worker as any).emit('message', terminal);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(prepareOrdinaryAttention).toHaveBeenCalledTimes(2);
+    expect(sessionReply).toHaveBeenCalledTimes(2);
+    expect(sessionReply.mock.calls.map(call => call[5]?.uuid))
+      .toEqual(['oa_stable_attention_uuid', 'oa_stable_attention_uuid']);
+    expect(completeOrdinaryAttention).toHaveBeenCalledOnce();
+    expect(completeOrdinaryAttention).toHaveBeenCalledWith(ds, {
+      turnId: 'om_failure_card_turn',
+      providerMessageId: 'om_failure_card',
+    });
   });
 
   it('captures silent fallback output and keeps the bounded legacy marker after terminal', async () => {

--- a/test/daemon-heartbeat.test.ts
+++ b/test/daemon-heartbeat.test.ts
@@ -7,6 +7,7 @@ import {
   anyDaemonBusyTo,
   heartbeatDirIn,
   HEARTBEAT_FRESH_MS,
+  readDaemonHeartbeatTo,
 } from '../src/core/daemon-heartbeat.js';
 
 const T0 = Date.parse('2026-06-07T04:00:00.000Z');
@@ -46,6 +47,21 @@ describe('daemon heartbeat / anyDaemonBusy', () => {
     writeHeartbeatTo(dir, 'cli_app_a', 3, iso(T0));
     writeHeartbeatTo(dir, 'cli_app_a', 0, iso(T0 + 1_000)); // overwrite same daemon
     expect(anyDaemonBusyTo(dir, T0 + 2_000)).toBe(false);
+  });
+
+  it('reads back the exact daemon pid and parsed timestamp for watchdog use', () => {
+    writeHeartbeatTo(dir, 'cli_app_a', 0, iso(T0), 4321);
+    expect(readDaemonHeartbeatTo(dir, 'cli_app_a')).toEqual({ pid: 4321, atMs: T0 });
+    expect(readDaemonHeartbeatTo(dir, 'cli_other')).toBeNull();
+  });
+
+  it('does not treat a legacy pid-less heartbeat as event-loop liveness proof', () => {
+    writeHeartbeatTo(dir, 'cli_app_a', 0, iso(T0), 4321);
+    writeFileSync(
+      join(heartbeatDirIn(dir), 'cli_app_a.json'),
+      JSON.stringify({ larkAppId: 'cli_app_a', busyCount: 0, at: iso(T0) }),
+    );
+    expect(readDaemonHeartbeatTo(dir, 'cli_app_a')).toBeNull();
   });
 
   it('tolerates a corrupt heartbeat file (ignored, no throw)', () => {

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -4987,6 +4987,8 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     setupBotState({ allowedUsers: [USER_OPEN_ID] }); // default = always
     mockGetChatMode.mockResolvedValue('group');
     handlers.isSessionOwner.mockReturnValue(false);
+    handlers.onMessageIgnored = vi.fn();
+    handlers.onMessageProcessingFailed = vi.fn();
     const event = makeUserMessageEvent({
       senderOpenId: USER_OPEN_ID,
       content: JSON.stringify({ text: 'no at-mention at all, top level' }),
@@ -5000,6 +5002,9 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(handlers.onMessageIgnored).toHaveBeenCalledOnce();
+    expect(handlers.onMessageIgnored).toHaveBeenCalledWith(event, 'msg-always-toplevel');
+    expect(handlers.onMessageProcessingFailed).not.toHaveBeenCalled();
   });
 
   // ── ambient tier — end-to-end gating across the three no-@ decision points ──
@@ -7830,6 +7835,77 @@ describe('im.message.receive_v1 — ack-safe duplicate delivery', () => {
     expect(handlers.handleNewTopic).toHaveBeenCalledTimes(1);
     release();
     await flushEventWork();
+  });
+
+  it('persists explicit processing failure when classification throws after durable claim', async () => {
+    handlers.prepareMessageClaim = vi.fn(() => true);
+    handlers.onMessageIgnored = vi.fn();
+    handlers.onMessageProcessingFailed = vi.fn();
+    mockGetChatMode.mockRejectedValueOnce(new Error('classification unavailable'));
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '@BotA classify this' }),
+      messageId: 'msg-classification-failed',
+      chatId: 'chat-classification-failed',
+      chatType: 'group',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    expect(handlers.prepareMessageClaim).toHaveBeenCalledWith(event, 'msg-classification-failed');
+    await flushEventWork();
+
+    expect(handlers.onMessageProcessingFailed).toHaveBeenCalledOnce();
+    expect(handlers.onMessageProcessingFailed).toHaveBeenCalledWith(event, 'msg-classification-failed');
+    expect(handlers.onMessageIgnored).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+
+  it('validates payload identity before suppressing a seen message-id duplicate', async () => {
+    handlers.prepareMessageClaim = vi.fn(() => true);
+    handlers.validateMessageClaim = vi.fn();
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '@BotA stable payload' }),
+      messageId: 'msg-seen-payload-validation',
+      chatId: 'chat-seen-payload-validation',
+      chatType: 'group',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+    await capturedHandlers['im.message.receive_v1'](event);
+
+    expect(handlers.prepareMessageClaim).toHaveBeenCalledOnce();
+    expect(handlers.validateMessageClaim).toHaveBeenCalledOnce();
+    expect(handlers.validateMessageClaim)
+      .toHaveBeenCalledWith(event, 'msg-seen-payload-validation');
+    expect(handlers.handleNewTopic).toHaveBeenCalledOnce();
+  });
+
+  it('routes direct async handler failures into the same durable attention hook', async () => {
+    handlers.onMessageRouted = vi.fn();
+    handlers.onMessageHandled = vi.fn();
+    handlers.onMessageProcessingFailed = vi.fn();
+    handlers.handleNewTopic.mockRejectedValueOnce(new Error('handler failed'));
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '@BotA run this' }),
+      messageId: 'msg-handler-failed',
+      chatId: 'chat-handler-failed',
+      chatType: 'group',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.onMessageRouted).toHaveBeenCalledOnce();
+    expect(handlers.onMessageProcessingFailed).toHaveBeenCalledOnce();
+    expect(handlers.onMessageProcessingFailed).toHaveBeenCalledWith(event, 'msg-handler-failed');
+    expect(handlers.onMessageHandled).not.toHaveBeenCalled();
   });
 
   it('reserves same-chat arrival order before the first async routing lookup', async () => {

--- a/test/fixtures/ordinary-turn-fault-child.ts
+++ b/test/fixtures/ordinary-turn-fault-child.ts
@@ -1,0 +1,83 @@
+/**
+ * Hard-exit fixture for the ordinary-turn ledger integration test.
+ *
+ * The parent launches this through test/helpers/ts-runner.ts under both Node
+ * and Bun. Every phase exits without cleanup after one exact durable boundary,
+ * modelling a daemon crash rather than an in-process cache reset.
+ */
+import { claimMessageOnce } from '../../src/services/seen-message-store.js';
+import {
+  markOrdinaryTurnAccepted,
+  markOrdinaryTurnCommitted,
+  markOrdinaryTurnRouted,
+  prepareOrdinaryTurnClaim,
+  prepareOrdinaryTurnOutput,
+} from '../../src/services/ordinary-turn-ledger.js';
+
+const [phase, dataDir] = process.argv.slice(2);
+if (!phase || !dataDir) throw new Error('usage: ordinary-turn-fault-child <phase> <dataDir>');
+
+const larkAppId = 'cli_fault_injection';
+const messageId = `om_fault_${phase}`;
+process.env.SESSION_DATA_DIR = dataDir;
+
+const payload = {
+  message: {
+    message_id: messageId,
+    chat_id: 'oc_fault',
+    chat_type: 'group',
+    content: JSON.stringify({ text: `fault phase ${phase}` }),
+  },
+  sender: { sender_id: { open_id: 'ou_fault' }, sender_type: 'user' },
+};
+
+const claimed = claimMessageOnce(larkAppId, messageId, Date.now(), () =>
+  prepareOrdinaryTurnClaim({ dataDir, larkAppId, messageId, payload }) === 'created');
+if (!claimed) throw new Error(`fixture failed to claim ${messageId}`);
+
+if (phase !== 'received') {
+  markOrdinaryTurnRouted({
+    dataDir,
+    larkAppId,
+    messageId,
+    routing: { chatId: 'oc_fault', scope: 'thread', anchor: messageId },
+  });
+  markOrdinaryTurnAccepted({
+    dataDir,
+    larkAppId,
+    messageId,
+    turnId: messageId,
+    sessionId: 'sid_fault',
+  });
+}
+
+if (phase === 'committed') {
+  markOrdinaryTurnCommitted({
+    dataDir,
+    larkAppId,
+    turnId: messageId,
+    sessionId: 'sid_fault',
+    workerGeneration: 7,
+  });
+} else if (phase === 'output') {
+  prepareOrdinaryTurnOutput({
+    dataDir,
+    larkAppId,
+    turnId: messageId,
+    delivery: {
+      rootId: messageId,
+      content: 'durable answer',
+      msgType: 'text',
+      turnId: messageId,
+      options: {
+        uuid: 'bf_fault_injection_uuid',
+        replyTarget: { mode: 'thread', rootMessageId: messageId },
+      },
+    },
+  });
+} else if (phase !== 'received') {
+  throw new Error(`unknown phase ${phase}`);
+}
+
+// Deliberately bypass normal cleanup/finalizers: this is the fault boundary.
+process.exit(73);

--- a/test/fleet-supervisor-heartbeat.integration.test.ts
+++ b/test/fleet-supervisor-heartbeat.integration.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FleetSupervisor, pidAlive } from '../src/core/fleet-supervisor.js';
+import { readFleetState } from '../src/core/fleet-state-store.js';
+
+const dirs: string[] = [];
+const pids: number[] = [];
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<boolean> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return true;
+    await delay(20);
+  }
+  return predicate();
+}
+
+afterEach(() => {
+  for (const pid of pids.splice(0)) {
+    if (pid > 1) try { process.kill(pid, 'SIGKILL'); } catch { /* gone */ }
+  }
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('FleetSupervisor daemon event-loop watchdog', () => {
+  it('retries a stalled daemon when ChildProcess.kill reports that SIGKILL was not accepted', () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-supervisor-kill-retry-'));
+    dirs.push(root);
+    const kill = vi.fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const child = { pid: 42_424, killed: false, kill };
+    const sup = new FleetSupervisor({
+      statePath: join(root, 'fleet.json'),
+      distDir: join(root, 'dist'),
+      daemonEnv: { SESSION_DATA_DIR: root },
+      cwd: root,
+      heartbeat: {
+        dataDir: root,
+        scanIntervalMs: 20,
+        staleMs: 50,
+        startupGraceMs: 10,
+      },
+      log: () => {},
+    });
+    const internal = sup as any;
+    internal.children.set('botmux-0', child);
+    internal.knownSpecs.set('botmux-0', {
+      name: 'botmux-0', appId: 'cli_hb', botIndex: 0,
+    });
+    internal.childStartedAtMs.set('botmux-0', 0);
+
+    internal.scanDaemonHeartbeats(1_000);
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(internal.heartbeatKillInFlight.has('botmux-0')).toBe(false);
+
+    internal.scanDaemonHeartbeats(1_001);
+    expect(kill).toHaveBeenCalledTimes(2);
+    expect(kill).toHaveBeenLastCalledWith('SIGKILL');
+    expect(internal.heartbeatKillInFlight.has('botmux-0')).toBe(true);
+  });
+
+  it('SIGKILLs and crash-restarts a live daemon whose heartbeat stops advancing', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-supervisor-heartbeat-'));
+    dirs.push(root);
+    const dist = join(root, 'dist');
+    mkdirSync(dist, { recursive: true });
+    const body = `
+      const fs = require('node:fs');
+      const path = require('node:path');
+      const dir = path.join(process.env.SESSION_DATA_DIR, 'heartbeats');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'cli_hb.json'), JSON.stringify({
+        larkAppId: 'cli_hb', busyCount: 0, at: new Date().toISOString(), pid: process.pid,
+      }));
+      process.on('SIGTERM', () => process.exit(90));
+      setInterval(() => {}, 1000);
+    `;
+    writeFileSync(join(dist, 'index-daemon.js'), body);
+    const statePath = join(root, 'fleet.json');
+    const sup = new FleetSupervisor({
+      statePath,
+      distDir: dist,
+      daemonEnv: { SESSION_DATA_DIR: root },
+      cwd: root,
+      policy: { maxRestarts: 10, restartDelayMs: 20 },
+      heartbeat: {
+        dataDir: root,
+        scanIntervalMs: 20,
+        staleMs: 80,
+        startupGraceMs: 40,
+      },
+      log: () => {},
+    });
+
+    try {
+      sup.start([{ name: 'botmux-0', appId: 'cli_hb', botIndex: 0 }]);
+      expect(await waitFor(() => existsSync(join(root, 'heartbeats', 'cli_hb.json')))).toBe(true);
+      const first = readFleetState(statePath)!.procs[0];
+      pids.push(first.pid);
+
+      const restarted = await waitFor(() => {
+        const current = readFleetState(statePath)?.procs[0];
+        return !!current
+          && current.status === 'online'
+          && current.generation >= 2
+          && current.pid > 1
+          && current.pid !== first.pid;
+      });
+      expect(restarted).toBe(true);
+      const currentPid = readFleetState(statePath)!.procs[0].pid;
+      pids.push(currentPid);
+      expect(pidAlive(first.pid)).toBe(false);
+      expect(pidAlive(currentPid)).toBe(true);
+    } finally {
+      // Stop the scanner/children before afterEach removes the heartbeat root;
+      // otherwise a failed assertion can race a live interval against rmSync.
+      await sup.stopAll();
+    }
+  });
+
+  it('excludes dashboard members that do not own daemon heartbeat files', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-supervisor-dashboard-heartbeat-'));
+    dirs.push(root);
+    const dist = join(root, 'dist');
+    mkdirSync(dist, { recursive: true });
+    writeFileSync(join(dist, 'index-dashboard.js'), 'setInterval(() => {}, 1000);');
+    const statePath = join(root, 'fleet.json');
+    const sup = new FleetSupervisor({
+      statePath,
+      distDir: dist,
+      daemonEnv: { SESSION_DATA_DIR: root },
+      cwd: root,
+      policy: { maxRestarts: 10, restartDelayMs: 20 },
+      heartbeat: {
+        dataDir: root,
+        scanIntervalMs: 20,
+        staleMs: 50,
+        startupGraceMs: 30,
+      },
+      log: () => {},
+    });
+
+    try {
+      sup.start([{ name: 'botmux-dashboard', appId: 'dashboard', botIndex: -1, entry: 'dashboard' }]);
+      const initial = readFleetState(statePath)!.procs[0];
+      pids.push(initial.pid);
+      await delay(150);
+      const current = readFleetState(statePath)!.procs[0];
+      expect(current.pid).toBe(initial.pid);
+      expect(current.generation).toBe(initial.generation);
+      expect(current.status).toBe('online');
+      expect(pidAlive(current.pid)).toBe(true);
+    } finally {
+      await sup.stopAll();
+    }
+  });
+});

--- a/test/liveness-watchdog.test.ts
+++ b/test/liveness-watchdog.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  daemonHeartbeatStatus,
+  workerHeartbeatStalled,
+} from '../src/core/liveness-watchdog.js';
+
+describe('event-loop liveness watchdog decisions', () => {
+  it('marks a worker stalled only after its heartbeat lease is strictly stale', () => {
+    expect(workerHeartbeatStalled({ nowMs: 20_000, lastHeartbeatAtMs: 10_000, staleMs: 10_000 })).toBe(false);
+    expect(workerHeartbeatStalled({ nowMs: 20_001, lastHeartbeatAtMs: 10_000, staleMs: 10_000 })).toBe(true);
+  });
+
+  it('gives a newly spawned daemon a startup grace before requiring a matching heartbeat', () => {
+    expect(daemonHeartbeatStatus({
+      nowMs: 10_000,
+      startedAtMs: 0,
+      expectedPid: 123,
+      heartbeat: null,
+      startupGraceMs: 10_000,
+      staleMs: 5_000,
+    })).toBe('starting');
+    expect(daemonHeartbeatStatus({
+      nowMs: 10_001,
+      startedAtMs: 0,
+      expectedPid: 123,
+      heartbeat: null,
+      startupGraceMs: 10_000,
+      staleMs: 5_000,
+    })).toBe('stalled');
+  });
+
+  it('rejects a fresh heartbeat left by the previous daemon pid', () => {
+    expect(daemonHeartbeatStatus({
+      nowMs: 20_000,
+      startedAtMs: 0,
+      expectedPid: 222,
+      heartbeat: { pid: 111, atMs: 19_999 },
+      startupGraceMs: 10_000,
+      staleMs: 5_000,
+    })).toBe('stalled');
+  });
+
+  it('distinguishes a fresh matching daemon heartbeat from a stale one', () => {
+    expect(daemonHeartbeatStatus({
+      nowMs: 20_000,
+      startedAtMs: 0,
+      expectedPid: 222,
+      heartbeat: { pid: 222, atMs: 15_000 },
+      startupGraceMs: 10_000,
+      staleMs: 5_000,
+    })).toBe('healthy');
+    expect(daemonHeartbeatStatus({
+      nowMs: 20_001,
+      startedAtMs: 0,
+      expectedPid: 222,
+      heartbeat: { pid: 222, atMs: 15_000 },
+      startupGraceMs: 10_000,
+      staleMs: 5_000,
+    })).toBe('stalled');
+  });
+});

--- a/test/ordinary-turn-ledger-process.integration.test.ts
+++ b/test/ordinary-turn-ledger-process.integration.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  _resetOrdinaryTurnLedgerCacheForTest,
+  planOrdinaryTurnRecovery,
+} from '../src/services/ordinary-turn-ledger.js';
+import { spawnSyncTsScript } from './helpers/ts-runner.js';
+
+const APP = 'cli_fault_injection';
+const FIXTURE = resolve('test/fixtures/ordinary-turn-fault-child.ts');
+let dataDir: string;
+
+function crashAt(phase: 'received' | 'committed' | 'output'): void {
+  const child = spawnSyncTsScript(FIXTURE, [phase, dataDir], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+  expect(child.status, `${child.stdout ?? ''}\n${child.stderr ?? ''}`).toBe(73);
+  _resetOrdinaryTurnLedgerCacheForTest();
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-ordinary-turn-process-'));
+  _resetOrdinaryTurnLedgerCacheForTest();
+});
+
+afterEach(() => {
+  _resetOrdinaryTurnLedgerCacheForTest();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('ordinary turn hard-crash recovery boundaries', () => {
+  it('replays a claim persisted before async routing even though seen was also persisted', () => {
+    crashAt('received');
+    const plan = planOrdinaryTurnRecovery(dataDir, APP);
+    expect(plan.replays.map(record => record.messageId)).toEqual(['om_fault_received']);
+    expect(plan.attentions).toEqual([]);
+  });
+
+  it('fails closed instead of replaying after the worker commit boundary', () => {
+    crashAt('committed');
+    const plan = planOrdinaryTurnRecovery(dataDir, APP);
+    expect(plan.replays).toEqual([]);
+    expect(plan.attentions.map(record => record.messageId)).toEqual(['om_fault_committed']);
+    expect(plan.attentions[0].worker).toMatchObject({ generation: 7, committedAt: expect.any(String) });
+  });
+
+  it('retains the exact provider UUID when the daemon dies before output ACK', () => {
+    crashAt('output');
+    const plan = planOrdinaryTurnRecovery(dataDir, APP);
+    expect(plan.pendingOutputs).toHaveLength(1);
+    expect(plan.pendingOutputs[0].output?.delivery.options?.uuid).toBe('bf_fault_injection_uuid');
+    expect(plan.replays).toEqual([]);
+  });
+});

--- a/test/ordinary-turn-ledger.test.ts
+++ b/test/ordinary-turn-ledger.test.ts
@@ -1,0 +1,698 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  _resetOrdinaryTurnLedgerCacheForTest,
+  compactOrdinaryTurnLedger,
+  limitOrdinaryTurnRecoveryPlanToClaimedBefore,
+  markOrdinaryTurnAccepted,
+  markOrdinaryTurnAttention,
+  markOrdinaryTurnAttentionNotified,
+  markOrdinaryTurnCommitted,
+  markOrdinaryTurnIgnored,
+  markOrdinaryTurnOutputDelivered,
+  markOrdinaryTurnReplayScheduled,
+  markOrdinaryTurnRouted,
+  markOrdinaryTurnRunning,
+  markOrdinaryTurnTerminal,
+  ordinaryTurnRecoveryUuid,
+  planOrdinaryTurnRecovery,
+  prepareOrdinaryTurnClaim,
+  prepareOrdinaryTurnOutput,
+  readOrdinaryTurnRecord,
+  selectOrdinaryTurnAttentionForDelivery,
+  selectOrdinaryTurnPendingOutputForDelivery,
+  ORDINARY_TURN_LEDGER_RETENTION_MS,
+  ORDINARY_TURN_PROVIDER_DEDUPE_MS,
+} from '../src/services/ordinary-turn-ledger.js';
+
+const APP = 'cli_ordinary_ledger';
+const T0 = Date.parse('2026-09-01T00:00:00.000Z');
+let dataDir: string;
+
+function prepare(messageId: string, now = T0): void {
+  expect(prepareOrdinaryTurnClaim({
+    dataDir,
+    larkAppId: APP,
+    messageId,
+    payload: {
+      message: {
+        message_id: messageId,
+        chat_id: 'oc_chat',
+        chat_type: 'group',
+        content: JSON.stringify({ text: 'do the thing' }),
+      },
+      sender: { sender_id: { open_id: 'ou_user' }, sender_type: 'user' },
+    },
+    now,
+  })).toBe('created');
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-ordinary-ledger-'));
+  _resetOrdinaryTurnLedgerCacheForTest();
+});
+
+afterEach(() => {
+  _resetOrdinaryTurnLedgerCacheForTest();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('ordinary turn durable ledger', () => {
+  it('dedupes canonical-equivalent payloads and fails closed on a message-id payload conflict', () => {
+    const messageId = 'om_payload_identity';
+    expect(prepareOrdinaryTurnClaim({
+      dataDir,
+      larkAppId: APP,
+      messageId,
+      payload: {
+        message: { message_id: messageId, content: '{"text":"first"}' },
+        sender: { sender_type: 'user', sender_id: { open_id: 'ou_user' } },
+      },
+      now: T0,
+    })).toBe('created');
+
+    expect(prepareOrdinaryTurnClaim({
+      dataDir,
+      larkAppId: APP,
+      messageId,
+      payload: {
+        sender: { sender_id: { open_id: 'ou_user' }, sender_type: 'user' },
+        message: { content: '{"text":"first"}', message_id: messageId },
+      },
+      now: T0 + 1,
+    })).toBe('duplicate');
+
+    expect(() => prepareOrdinaryTurnClaim({
+      dataDir,
+      larkAppId: APP,
+      messageId,
+      payload: {
+        message: { message_id: messageId, content: '{"text":"changed"}' },
+        sender: { sender_type: 'user', sender_id: { open_id: 'ou_user' } },
+      },
+      now: T0 + 2,
+    })).toThrow(/payload conflict/i);
+    expect(readOrdinaryTurnRecord(dataDir, APP, messageId)?.attention?.reason)
+      .toBe('message_id_payload_conflict');
+  });
+
+  it('derives one stable provider UUID for ACK-lost attention retries', () => {
+    const first = ordinaryTurnRecoveryUuid('attention', APP, 'om_attention_uuid');
+    expect(ordinaryTurnRecoveryUuid('attention', APP, 'om_attention_uuid')).toBe(first);
+    expect(first).toMatch(/^oa_[0-9a-f]{47}$/);
+    expect(ordinaryTurnRecoveryUuid('attention', APP, 'om_other')).not.toBe(first);
+    expect(ordinaryTurnRecoveryUuid('output', APP, 'om_attention_uuid')).not.toBe(first);
+  });
+
+  it('treats a notified attention as settled and never replays its original input', () => {
+    prepare('om_attention_settled');
+    markOrdinaryTurnAttention({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_attention_settled',
+      reason: 'payload_or_execution_ambiguous',
+      now: T0 + 1,
+    });
+    markOrdinaryTurnAttentionNotified({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_attention_settled',
+      providerMessageId: 'om_attention_card',
+      now: T0 + 2,
+    });
+
+    expect(planOrdinaryTurnRecovery(dataDir, APP, T0 + 3)).toEqual({
+      replays: [],
+      attentions: [],
+      pendingOutputs: [],
+    });
+  });
+
+  it('keeps boot replay, output, and attention work strictly before the dispatcher cutoff', () => {
+    prepare('om_before_cutoff', T0);
+    prepare('om_at_cutoff', T0 + 1);
+    const before = readOrdinaryTurnRecord(dataDir, APP, 'om_before_cutoff')!;
+    const equal = readOrdinaryTurnRecord(dataDir, APP, 'om_at_cutoff')!;
+    const bounded = limitOrdinaryTurnRecoveryPlanToClaimedBefore({
+      replays: [before, equal],
+      attentions: [before, equal],
+      pendingOutputs: [before, equal],
+    }, T0 + 1);
+
+    expect(bounded.replays.map(record => record.messageId)).toEqual(['om_before_cutoff']);
+    expect(bounded.attentions.map(record => record.messageId)).toEqual(['om_before_cutoff']);
+    expect(bounded.pendingOutputs.map(record => record.messageId)).toEqual(['om_before_cutoff']);
+  });
+
+  it('replays a received-only claim once, then fails closed if replay scheduling crashes', () => {
+    prepare('om_received_only');
+    _resetOrdinaryTurnLedgerCacheForTest(); // daemon crashed after claim, before work
+
+    let plan = planOrdinaryTurnRecovery(dataDir, APP, T0 + 10);
+    expect(plan.replays.map(record => record.messageId)).toEqual(['om_received_only']);
+    expect(plan.attentions).toEqual([]);
+
+    markOrdinaryTurnReplayScheduled({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_received_only',
+      now: T0 + 1,
+    });
+    _resetOrdinaryTurnLedgerCacheForTest(); // second crash after scheduling
+
+    plan = planOrdinaryTurnRecovery(dataDir, APP, T0 + 10);
+    expect(plan.replays).toEqual([]);
+    expect(plan.attentions.map(record => record.messageId)).toEqual(['om_received_only']);
+  });
+
+  it.each(['routed', 'accepted', 'committed', 'running'] as const)(
+    'never blind-replays a %s turn whose side effects may have started',
+    (stage) => {
+      const messageId = `om_${stage}`;
+      prepare(messageId);
+      markOrdinaryTurnRouted({
+        dataDir,
+        larkAppId: APP,
+        messageId,
+        routing: { chatId: 'oc_chat', scope: 'thread', anchor: messageId },
+        now: T0 + 1,
+      });
+      if (stage === 'accepted' || stage === 'committed' || stage === 'running') {
+        markOrdinaryTurnAccepted({
+          dataDir,
+          larkAppId: APP,
+          messageId,
+          turnId: messageId,
+          sessionId: 'session-1',
+          now: T0 + 2,
+        });
+      }
+      if (stage === 'committed' || stage === 'running') {
+        markOrdinaryTurnCommitted({
+          dataDir,
+          larkAppId: APP,
+          turnId: messageId,
+          sessionId: 'session-1',
+          workerGeneration: 4,
+          now: T0 + 3,
+        });
+      }
+      if (stage === 'running') {
+        markOrdinaryTurnRunning({
+          dataDir,
+          larkAppId: APP,
+          turnId: messageId,
+          workerGeneration: 4,
+          now: T0 + 4,
+        });
+      }
+
+      _resetOrdinaryTurnLedgerCacheForTest();
+      const plan = planOrdinaryTurnRecovery(dataDir, APP, T0 + 10);
+      expect(plan.replays).toEqual([]);
+      expect(plan.attentions.map(record => record.messageId)).toContain(messageId);
+    },
+  );
+
+  it('keeps a failed final output as a durable outbox item with the original provider uuid', () => {
+    prepare('om_outbox');
+    markOrdinaryTurnRouted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_outbox',
+      routing: { chatId: 'oc_chat', scope: 'thread', anchor: 'om_outbox' },
+      now: T0 + 1,
+    });
+    markOrdinaryTurnAccepted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_outbox',
+      turnId: 'om_outbox',
+      sessionId: 'session-1',
+      now: T0 + 2,
+    });
+
+    expect(prepareOrdinaryTurnOutput({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_outbox',
+      delivery: {
+        rootId: 'om_outbox',
+        content: '{"schema":"2.0"}',
+        msgType: 'interactive',
+        turnId: 'om_outbox',
+        options: {
+          uuid: 'bf_original_uuid',
+          replyTarget: { mode: 'thread', rootMessageId: 'om_outbox' },
+        },
+      },
+      now: T0 + 3,
+    })).toBe('pending');
+
+    _resetOrdinaryTurnLedgerCacheForTest(); // retry after daemon restart
+    let plan = planOrdinaryTurnRecovery(dataDir, APP, T0 + 10);
+    expect(plan.pendingOutputs).toHaveLength(1);
+    expect(plan.pendingOutputs[0].output?.delivery.options?.uuid).toBe('bf_original_uuid');
+
+    markOrdinaryTurnOutputDelivered({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_outbox',
+      providerMessageId: 'om_answer',
+      now: T0 + 4,
+    });
+    _resetOrdinaryTurnLedgerCacheForTest();
+    plan = planOrdinaryTurnRecovery(dataDir, APP, T0 + 10);
+    expect(plan.pendingOutputs).toEqual([]);
+    expect(plan.attentions).toEqual([]);
+  });
+
+  it('fails closed instead of retrying a pending output after the provider UUID dedupe window', () => {
+    prepare('om_expired_outbox');
+    markOrdinaryTurnAccepted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_expired_outbox',
+      turnId: 'om_expired_outbox',
+      now: T0 + 1,
+    });
+    prepareOrdinaryTurnOutput({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_expired_outbox',
+      delivery: {
+        rootId: 'om_expired_outbox',
+        content: 'possibly accepted already',
+        turnId: 'om_expired_outbox',
+        options: { uuid: 'bf_expiring_uuid' },
+      },
+      now: T0 + 2,
+    });
+
+    const withinWindow = planOrdinaryTurnRecovery(dataDir, APP, T0 + 59 * 60_000);
+    expect(withinWindow.pendingOutputs.map(record => record.messageId))
+      .toEqual(['om_expired_outbox']);
+
+    const expired = planOrdinaryTurnRecovery(dataDir, APP, T0 + 60 * 60_000 + 3);
+    expect(expired.pendingOutputs).toEqual([]);
+    expect(expired.attentions).toHaveLength(1);
+    expect(expired.attentions[0].attention?.reason)
+      .toBe('pending_output_provider_dedupe_expired');
+  });
+
+  it('compacts a pending output after its expired-dedupe attention is durably notified', () => {
+    prepare('om_expired_outbox_notified');
+    markOrdinaryTurnAccepted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_expired_outbox_notified',
+      turnId: 'om_expired_outbox_notified',
+      now: T0 + 1,
+    });
+    prepareOrdinaryTurnOutput({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_expired_outbox_notified',
+      delivery: {
+        rootId: 'om_expired_outbox_notified',
+        content: 'possibly accepted already',
+        turnId: 'om_expired_outbox_notified',
+        options: { uuid: 'bf_expired_notified' },
+      },
+      now: T0 + 2,
+    });
+    markOrdinaryTurnAttention({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_expired_outbox_notified',
+      reason: 'pending_output_provider_dedupe_expired',
+      now: T0 + ORDINARY_TURN_PROVIDER_DEDUPE_MS + 3,
+    });
+    markOrdinaryTurnAttentionNotified({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_expired_outbox_notified',
+      providerMessageId: 'om_attention_card',
+      now: T0 + ORDINARY_TURN_PROVIDER_DEDUPE_MS + 4,
+    });
+
+    expect(compactOrdinaryTurnLedger({
+      dataDir,
+      larkAppId: APP,
+      now: T0 + ORDINARY_TURN_PROVIDER_DEDUPE_MS + ORDINARY_TURN_LEDGER_RETENTION_MS + 5,
+    })).toBe(1);
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_expired_outbox_notified'))
+      .toBeUndefined();
+  });
+
+  it('revalidates a planned pending output before delivery and skips a live-settled row', () => {
+    prepare('om_stale_output_plan');
+    prepareOrdinaryTurnOutput({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_stale_output_plan',
+      delivery: {
+        rootId: 'om_stale_output_plan',
+        content: 'answer',
+        turnId: 'om_stale_output_plan',
+        options: { uuid: 'bf_stale_output_plan' },
+      },
+      now: T0 + 1,
+    });
+    expect(planOrdinaryTurnRecovery(dataDir, APP, T0 + 2).pendingOutputs).toHaveLength(1);
+
+    // The live final-output path wins after the drain took its plan snapshot.
+    markOrdinaryTurnOutputDelivered({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_stale_output_plan',
+      providerMessageId: 'om_live_answer',
+      now: T0 + 3,
+    });
+
+    expect(selectOrdinaryTurnPendingOutputForDelivery({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_stale_output_plan',
+      now: T0 + 4,
+    })).toBeUndefined();
+  });
+
+  it('rechecks the provider dedupe window after planning instead of sending a delayed output', () => {
+    prepare('om_delayed_output_plan');
+    prepareOrdinaryTurnOutput({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_delayed_output_plan',
+      delivery: {
+        rootId: 'om_delayed_output_plan',
+        content: 'possibly accepted',
+        turnId: 'om_delayed_output_plan',
+        options: { uuid: 'bf_delayed_output_plan' },
+      },
+      now: T0 + 1,
+    });
+    expect(planOrdinaryTurnRecovery(dataDir, APP, T0 + 2).pendingOutputs).toHaveLength(1);
+
+    expect(selectOrdinaryTurnPendingOutputForDelivery({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_delayed_output_plan',
+      now: T0 + 60 * 60_000 + 2,
+    })).toBeUndefined();
+    expect(selectOrdinaryTurnAttentionForDelivery({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_delayed_output_plan',
+      allowInferred: false,
+      now: T0 + 60 * 60_000 + 2,
+    })?.attention?.reason).toBe('pending_output_provider_dedupe_expired');
+  });
+
+  it('skips a stale periodic attention plan after the live path notifies or clears it', () => {
+    prepare('om_stale_attention_notified');
+    markOrdinaryTurnAttention({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_stale_attention_notified',
+      reason: 'fixture_attention',
+      now: T0 + 1,
+    });
+    expect(planOrdinaryTurnRecovery(dataDir, APP, T0 + 2).attentions).toHaveLength(1);
+    markOrdinaryTurnAttentionNotified({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_stale_attention_notified',
+      providerMessageId: 'om_live_attention',
+      now: T0 + 3,
+    });
+    expect(selectOrdinaryTurnAttentionForDelivery({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_stale_attention_notified',
+      allowInferred: false,
+      now: T0 + 4,
+    })).toBeUndefined();
+
+    prepare('om_stale_attention_cleared');
+    markOrdinaryTurnAttention({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_stale_attention_cleared',
+      reason: 'processing_failed_before_route',
+      now: T0 + 1,
+    });
+    markOrdinaryTurnRouted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_stale_attention_cleared',
+      routing: { chatId: 'oc_chat', scope: 'thread', anchor: 'om_stale_attention_cleared' },
+      now: T0 + 2,
+    });
+    expect(selectOrdinaryTurnAttentionForDelivery({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_stale_attention_cleared',
+      allowInferred: false,
+      now: T0 + 3,
+    })).toBeUndefined();
+    expect(selectOrdinaryTurnAttentionForDelivery({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_stale_attention_cleared',
+      allowInferred: true,
+      now: T0 + 3,
+    })?.messageId).toBe('om_stale_attention_cleared');
+  });
+
+  it('does not regress a delivered output when turn_terminal arrives later', () => {
+    prepare('om_output_before_terminal');
+    prepareOrdinaryTurnOutput({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_output_before_terminal',
+      delivery: {
+        rootId: 'om_output_before_terminal',
+        content: 'answer',
+        msgType: 'text',
+        turnId: 'om_output_before_terminal',
+        options: { uuid: 'bf_ordering' },
+      },
+      now: T0 + 1,
+    });
+    markOrdinaryTurnOutputDelivered({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_output_before_terminal',
+      providerMessageId: 'om_answer',
+      now: T0 + 2,
+    });
+    markOrdinaryTurnTerminal({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_output_before_terminal',
+      status: 'completed',
+      now: T0 + 3,
+    });
+
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_output_before_terminal')?.output).toMatchObject({
+      status: 'delivered',
+      providerMessageId: 'om_answer',
+    });
+    expect(planOrdinaryTurnRecovery(dataDir, APP, T0 + 10)).toMatchObject({
+      replays: [],
+      attentions: [],
+      pendingOutputs: [],
+    });
+  });
+
+  it('accepts positive nothing-to-send evidence as a terminal with no recovery action', () => {
+    prepare('om_silent');
+    markOrdinaryTurnRouted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_silent',
+      routing: { chatId: 'oc_chat', scope: 'thread', anchor: 'om_silent' },
+      now: T0 + 1,
+    });
+    markOrdinaryTurnTerminal({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_silent',
+      status: 'completed',
+      outputDisposition: 'nothing_to_send',
+      now: T0 + 2,
+    });
+
+    expect(planOrdinaryTurnRecovery(dataDir, APP, T0 + 10)).toMatchObject({
+      replays: [],
+      attentions: [],
+      pendingOutputs: [],
+    });
+  });
+
+  it('clears an earlier ignored settlement when authorization or a deferred flush later routes it', () => {
+    prepare('om_deferred');
+    markOrdinaryTurnIgnored({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_deferred',
+      now: T0 + 1,
+    });
+    expect(planOrdinaryTurnRecovery(dataDir, APP, T0 + 2)).toMatchObject({
+      replays: [],
+      attentions: [],
+      pendingOutputs: [],
+    });
+
+    markOrdinaryTurnRouted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_deferred',
+      routing: { chatId: 'oc_chat', scope: 'thread', anchor: 'om_deferred' },
+      now: T0 + 3,
+    });
+
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_deferred')?.terminal).toBeUndefined();
+    expect(planOrdinaryTurnRecovery(dataDir, APP, T0 + 4).attentions.map(record => record.messageId))
+      .toEqual(['om_deferred']);
+  });
+
+  it('updates the explicit turn owner before an exact message-id collision', () => {
+    prepare('om_colliding_anchor', T0);
+    prepare('om_actual_input', T0 + 1);
+    markOrdinaryTurnAccepted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_actual_input',
+      turnId: 'om_colliding_anchor',
+      sessionId: 'session-group-1',
+      now: T0 + 2,
+    });
+
+    markOrdinaryTurnTerminal({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_colliding_anchor',
+      status: 'failed',
+      errorCode: 'fixture_failure',
+      now: T0 + 3,
+    });
+
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_colliding_anchor')?.terminal).toBeUndefined();
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_actual_input')?.terminal).toMatchObject({
+      status: 'failed',
+      errorCode: 'fixture_failure',
+    });
+  });
+
+  it('fails closed when two ledger rows explicitly claim the same turn id', () => {
+    prepare('om_owner_a', T0);
+    prepare('om_owner_b', T0 + 1);
+    markOrdinaryTurnAccepted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_owner_a',
+      turnId: 'om_shared_turn',
+      now: T0 + 2,
+    });
+    markOrdinaryTurnAccepted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_owner_b',
+      turnId: 'om_shared_turn',
+      now: T0 + 3,
+    });
+
+    expect(() => markOrdinaryTurnTerminal({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_shared_turn',
+      status: 'failed',
+      now: T0 + 4,
+    })).toThrow(/ambiguous.*turn/i);
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_owner_a')?.terminal).toBeUndefined();
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_owner_b')?.terminal).toBeUndefined();
+  });
+
+  it('compacts only settled rows after retention and keeps every unresolved safety fence', () => {
+    prepare('om_delivered', T0);
+    prepareOrdinaryTurnOutput({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_delivered',
+      delivery: { rootId: 'om_delivered', content: 'done', turnId: 'om_delivered' },
+      now: T0 + 1,
+    });
+    markOrdinaryTurnOutputDelivered({
+      dataDir,
+      larkAppId: APP,
+      turnId: 'om_delivered',
+      providerMessageId: 'om_answer',
+      now: T0 + 2,
+    });
+
+    prepare('om_attention_notified', T0);
+    markOrdinaryTurnAttention({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_attention_notified',
+      reason: 'fixture_attention',
+      now: T0 + 1,
+    });
+    markOrdinaryTurnAttentionNotified({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_attention_notified',
+      providerMessageId: 'om_attention_card',
+      now: T0 + 2,
+    });
+
+    prepare('om_ignored', T0);
+    markOrdinaryTurnIgnored({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_ignored',
+      now: T0 + 2,
+    });
+
+    prepare('om_unresolved_route', T0);
+    markOrdinaryTurnRouted({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_unresolved_route',
+      routing: { chatId: 'oc_chat', scope: 'thread', anchor: 'om_unresolved_route' },
+      now: T0 + 2,
+    });
+    prepare('om_attention_pending', T0);
+    markOrdinaryTurnAttention({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_attention_pending',
+      reason: 'must_not_evict',
+      now: T0 + 2,
+    });
+
+    const compactAt = T0 + 2 + ORDINARY_TURN_LEDGER_RETENTION_MS;
+    expect(compactOrdinaryTurnLedger({ dataDir, larkAppId: APP, now: compactAt })).toBe(3);
+    _resetOrdinaryTurnLedgerCacheForTest();
+
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_delivered')).toBeUndefined();
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_attention_notified')).toBeUndefined();
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_ignored')).toBeUndefined();
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_unresolved_route')).toBeDefined();
+    expect(readOrdinaryTurnRecord(dataDir, APP, 'om_attention_pending')).toBeDefined();
+
+    // Once the matching seen-store TTL has elapsed, the same provider message
+    // id can create a fresh lifecycle instead of being rejected forever.
+    expect(prepareOrdinaryTurnClaim({
+      dataDir,
+      larkAppId: APP,
+      messageId: 'om_ignored',
+      payload: { message: { message_id: 'om_ignored' } },
+      now: compactAt + 1,
+    })).toBe('created');
+  });
+});

--- a/test/seen-message-store.test.ts
+++ b/test/seen-message-store.test.ts
@@ -35,6 +35,22 @@ describe('seen-message-store', () => {
     expect(claimMessageOnce(APP, 'om_1')).toBe(false);
   });
 
+  it('still runs a fail-closed payload validator for a seen duplicate', () => {
+    expect(claimMessageOnce(APP, 'om_conflict')).toBe(true);
+    const validateExisting = vi.fn(() => {
+      throw new Error('message-id payload conflict');
+    });
+
+    expect(() => claimMessageOnce(
+      APP,
+      'om_conflict',
+      Date.now(),
+      undefined,
+      validateExisting,
+    )).toThrow('message-id payload conflict');
+    expect(validateExisting).toHaveBeenCalledOnce();
+  });
+
   it('distinct message_ids are independent', () => {
     expect(claimMessageOnce(APP, 'om_a')).toBe(true);
     expect(claimMessageOnce(APP, 'om_b')).toBe(true);
@@ -81,6 +97,30 @@ describe('seen-message-store', () => {
     expect(claimMessageOnce('app-x', 'om_same')).toBe(true);
     expect(claimMessageOnce('app-y', 'om_same')).toBe(true);
     expect(claimMessageOnce('app-x', 'om_same')).toBe(false);
+  });
+
+  it('runs a durable prepare hook before publishing the seen tombstone', () => {
+    const order: string[] = [];
+    expect(claimMessageOnce(APP, 'om_prepared', Date.now(), () => {
+      order.push('prepared');
+      return true;
+    })).toBe(true);
+    expect(order).toEqual(['prepared']);
+    expect(existsSync(join(dataDir, 'dedup', `seen-messages-${APP}.json`))).toBe(true);
+  });
+
+  it('does not publish a seen tombstone when durable preparation fails', () => {
+    expect(() => claimMessageOnce(APP, 'om_prepare_failed', Date.now(), () => {
+      throw new Error('disk unavailable');
+    })).toThrow('disk unavailable');
+
+    // The event must remain claimable so the transport can redeliver it.
+    expect(claimMessageOnce(APP, 'om_prepare_failed')).toBe(true);
+  });
+
+  it('treats an already-prepared durable turn as a duplicate before seen persistence', () => {
+    expect(claimMessageOnce(APP, 'om_ledger_only', Date.now(), () => false)).toBe(false);
+    expect(existsSync(join(dataDir, 'dedup', `seen-messages-${APP}.json`))).toBe(false);
   });
 
   it('a corrupt store file is treated as empty (never throws, never drops)', () => {

--- a/test/session-reply-thread-anchor.test.ts
+++ b/test/session-reply-thread-anchor.test.ts
@@ -75,6 +75,7 @@ vi.mock('../src/services/vc-meeting-listener-topic-store.js', () => ({
 
 import { registerBot } from '../src/bot-registry.js';
 import { activeSessionKey, sessionKey } from '../src/core/types.js';
+import * as daemonModule from '../src/daemon.js';
 import { __testOnly_sessionReply as sessionReply, __testOnly_activeSessions as activeSessions } from '../src/daemon.js';
 import { MessageWithdrawnError } from '../src/im/lark/client.js';
 import type { DaemonSession } from '../src/core/types.js';
@@ -141,6 +142,90 @@ describe('sessionReply chat-scope chokepoint — shared fold-back anchoring', ()
     mocks.topicQueues.clear();
     activeSessions.clear();
     registerBot({ larkAppId: APP, larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_o'] });
+  });
+
+  it('forces pending-output recovery to suppress the independent outbound hook', () => {
+    const replyOptions = (daemonModule as any).__testOnly_ordinaryTurnPendingOutputReplyOptions({
+      larkAppId: APP,
+      messageId: 'om_pending_output',
+      output: {
+        delivery: {
+          rootId: CHAT,
+          content: 'already attempted output',
+          msgType: 'text',
+          turnId: 'om_pending_output',
+          options: { uuid: 'bf_stable_provider_uuid' },
+        },
+      },
+    });
+
+    expect(replyOptions).toMatchObject({
+      uuid: 'bf_stable_provider_uuid',
+      suppressHook: true,
+    });
+  });
+
+  it('forces attention recovery to suppress the independent outbound hook', () => {
+    const reply = (daemonModule as any).__testOnly_ordinaryTurnAttentionReply({
+      larkAppId: APP,
+      messageId: 'om_pending_attention',
+      turnId: 'om_pending_attention',
+      routing: {
+        chatId: CHAT,
+        scope: 'thread',
+        anchor: 'om_attention_root',
+      },
+    });
+
+    expect(reply.options).toMatchObject({
+      suppressHook: true,
+    });
+  });
+
+  it('uses the same actionable failure-card shape when a live session backs drain attention', () => {
+    const ds = seedSharedSession();
+    const message = (daemonModule as any).__testOnly_ordinaryTurnAttentionMessage({
+      larkAppId: APP,
+      messageId: 'om_attention_card_race',
+      turnId: 'om_attention_card_race',
+      sessionId: ds.session.sessionId,
+      attention: {
+        requiredAt: NOW,
+        reason: 'worker_event_loop_stalled',
+      },
+    });
+
+    expect(message.msgType).toBe('interactive');
+    expect(() => JSON.parse(message.content)).not.toThrow();
+  });
+
+  it('awaits an in-flight ordinary recovery drain at the shutdown fence', async () => {
+    const states = (daemonModule as any).__testOnly_ordinaryTurnRecoveryDrainStates as Map<
+      string,
+      { requested: boolean; replayReceived: boolean; inFlight?: Promise<void> }
+    >;
+    const settle = (daemonModule as any).__testOnly_settleOrdinaryTurnRecoveryDrains as
+      ((deadlineMs: number) => Promise<boolean>);
+    expect(states).toBeInstanceOf(Map);
+    expect(typeof settle).toBe('function');
+
+    let release!: () => void;
+    const inFlight = new Promise<void>(resolve => { release = resolve; });
+    states.set(APP, { requested: false, replayReceived: false, inFlight });
+    try {
+      let completed = false;
+      const waiting = settle(Date.now() + 1_000).then(result => {
+        completed = true;
+        return result;
+      });
+      await Promise.resolve();
+      expect(completed).toBe(false);
+      release();
+      await expect(waiting).resolves.toBe(true);
+    } finally {
+      states.delete(APP);
+      release();
+    }
   });
 
   it('repo-card-style send (interactive, NO turnId) threads into the shared topic, not top-level', async () => {


### PR DESCRIPTION
## 背景

普通飞书消息目前会在异步执行前进入持久化 seen store。若 daemon 在消息认领后、真正交给 CLI 或提交执行前退出，重投可能命中 seen 去重而被吞掉；同时，CLI/worker 进程仍存活但事件循环卡住时，现有进程存活检查无法识别任务已经停止推进。

本 PR 为普通会话补齐 daemon-owned 的持久生命周期、受限恢复和存活看门狗。核心原则是：只有能证明尚未执行的输入才自动重放；可能已经执行或可能产生外部副作用的状态一律 fail closed，转为一次稳定、可去重的人工关注提示。

## 改动

- 新增普通 turn ledger，持久化 `received → routed → accepted → worker received/committed/running → terminal → output delivered/attention`，并保存路由快照、worker generation 和稳定 provider UUID。
- 调整 Lark 入站顺序：先写完整输入意图，再发布 payload-free seen tombstone；消息 ID 与 payload 冲突时不再静默去重，而是持久化为 attention。
- 增加启动期与周期恢复：
  - 仅对 received-only 且明确未执行的输入做一次精确重放；
  - 对 provider 去重窗口内的 pending output 使用原 UUID 续投；
  - 对执行状态未知、输出 ACK 丢失或恢复失败的 turn 发出稳定 UUID 的 attention，禁止盲重放。
- 增加 worker event-loop heartbeat lease：按 session/worker generation/turn 做围栏，先持久化 attention，再 SIGKILL 确认卡死的精确 generation；kill 未被接受时保留 lease 供后续重试。
- 扩展 daemon heartbeat 与 fleet supervisor：校验 PID、启动宽限和陈旧阈值，仅监督实际拥有 heartbeat 的本地 daemon 成员；scanner 自身延迟时重置 lease，避免把 daemon 自身卡顿误判成 worker 卡死。
- 增加 graceful shutdown 的 recovery drain/fence，以及 final output/attention 的幂等落账与恢复测试。

## 影响面

- **模块**：`im/lark/event-dispatcher`、daemon 编排、`core/worker-pool`、daemon/fleet heartbeat、seen store、worker IPC。
- **会话类型**：主要作用于带 `om_` turn ID 的普通 Lark 会话；HTTP wait/async、文档评论、VC listener 等已有专用 reconcile 的 managed receiver 不走普通 output 恢复路径。
- **CLI / backend**：heartbeat 与 lifecycle 位于共享 worker/daemon 层，不绑定单一 CLI adapter；PTY/Tmux 的普通 turn 都会经过相同 generation fence。没有修改任何具体 CLI adapter。
- **平台**：实现使用现有 Node/Bun 文件与进程原语；本地在 macOS 验证，Linux 由仓库 CI 继续覆盖。外部 plugin/dashboard 成员因不拥有 daemon heartbeat 文件而不进入 supervisor kill 路径。
- **持久状态**：新增普通 turn ledger 文件；旧 seen tombstone 不反向合成 ledger，避免升级后把历史消息误当成待重放输入。

## 测试

- `npx --yes bun@1.4.0 run build`
  - PASS；runtime build ID `10fef427a915`
- `npx --yes bun@1.4.0 run test -- test/ordinary-turn-ledger.test.ts test/ordinary-turn-ledger-process.integration.test.ts test/ordinary-turn-recovery.test.ts test/liveness-watchdog.test.ts test/fleet-supervisor-heartbeat.integration.test.ts test/daemon-heartbeat.test.ts test/event-dispatcher.test.ts test/seen-message-store.test.ts test/bridge-final-output-retry.test.ts test/session-reply-thread-anchor.test.ts`
  - 10 files / 499 tests PASS
- `git diff --check HEAD^ HEAD`
  - PASS
- Bun 1.4.0 完整 unit suite（同一依赖树）
  - 候选：20,270 passed / 5 failed / 103 skipped
  - 当前 master 基线：20,218 passed / 7 failed / 103 skipped
  - 候选的 5 个失败签名全部属于基线已有集合，集中在 macOS `/var`/`/private/var` 路径规范化、Darwin 实机采样和 sandbox shim；本次 recovery/ledger/watchdog/outbox 测试无失败。因此结论是“没有新增稳定红项”，不是“全量全绿”。

## 已知边界

本 PR 尚未执行真实 Lark ACK/重投、daemon/主机重启、真实 event-loop hang、provider interruption、外部副作用去重或用户可见恢复 E2E，因此不把本地测试结果表述为线上问题已经解决。

仍保留以下非阻断改进项：静默 completed turn 的 attention/保留策略、seen 写失败后的进程内恢复、ledger 数量上限、不可达 reply anchor 的退避、升级前遗留 worker stall、`apiOnly` drain、结构化 payload 的 key-order 归一化，以及系统时钟回拨时的恢复窗口判断。
