### PR TITLE
fix(bun-leg): 墙钟提到 4×per-test 并在 SIGKILL 时标注「失败数是下界」

### DIFF
--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -152,7 +152,16 @@ function loadDeferredSet(files) {
 const TEST_TIMEOUT_MS = 180_000;
 // Hard wall per file, above the per-test ceiling: a file that wedges (waiting on
 // a pty, a lock, a socket) must not hold the whole leg open.
-const FILE_WALL_MS = 240_000;
+//
+// MUST stay well above `2 × TEST_TIMEOUT_MS`. At the previous 240_000 the wall sat
+// BELOW two per-test timeouts (2 × 180_000 = 360_000), so a file with two or more
+// timing-out tests was SIGKILLed after printing only the FIRST one — making "one test
+// timed out" and "twenty-seven tests timed out" indistinguishable in the log. That is
+// not hypothetical: test/write-input.test.ts reported exactly 1 timeout here while a
+// locally uncapped run of the same file showed 13+, and the smaller number was read as
+// the real failure count. The wall's job is to stop a wedged file from holding the leg
+// open, not to truncate a file that is legitimately reporting many slow failures.
+const FILE_WALL_MS = TEST_TIMEOUT_MS * 4;
 
 const all = collectTestFiles(TEST_DIR).sort();
 
@@ -377,7 +386,9 @@ function runOne(file) {
     const cap = chunk => { if (out.length < 200_000) out += chunk; };
     child.stdout.on('data', cap);
     child.stderr.on('data', cap);
-    const wall = setTimeout(() => killTree(child, 'SIGKILL'), FILE_WALL_MS);
+    // Recorded so the close handler can say the output was CUT rather than complete.
+    let wallKilled = false;
+    const wall = setTimeout(() => { wallKilled = true; killTree(child, 'SIGKILL'); }, FILE_WALL_MS);
     child.on('error', err => {
       clearTimeout(wall);
       liveChildren.delete(child);
@@ -399,7 +410,17 @@ function runOne(file) {
       // A signal death (wall-clock kill, OOM) leaves code null — never let that
       // coerce into a pass.
       if (code !== 0) {
-        resolve({ file, ok: false, out, signal: signal ?? undefined });
+        // A wall-clock kill truncates the child's output mid-stream, so whatever
+        // failures it managed to print are a LOWER BOUND, not the total. Say so in the
+        // output itself: a reader (or a future me) counting `FAIL` lines from a killed
+        // file would otherwise report a number that is silently too small.
+        const truncated = wallKilled
+          ? `\n[runner] OUTPUT TRUNCATED: killed by the ${FILE_WALL_MS}ms per-file wall. `
+            + 'Any failure count from this file is a LOWER BOUND — the run did not finish. '
+            + `Re-run this file alone (optionally with a smaller --timeout than ${TEST_TIMEOUT_MS}ms) `
+            + 'to see the complete set.\n'
+          : '';
+        resolve({ file, ok: false, out: out + truncated, signal: signal ?? undefined });
         return;
       }
       // `bun test` exits 0 for a file that collected ZERO tests (measured — both


### PR DESCRIPTION
## 问题

```
TEST_TIMEOUT_MS = 180_000
FILE_WALL_MS    = 240_000      ← 小于 2 × 180_000
```

⟹ **任何文件只要有 ≥2 条用例超时,第 2 条还没打印出来,整个文件就被 SIGKILL 了。**
于是「1 条超时」与「27 条超时」在腿的输出里**完全不可区分**,读日志的人只会看到前者。

这不是假设。`test/write-input.test.ts` 在 CI 上报「1 条超时」,而本地不设外层 kill
重跑同一文件已打印出 **13+ 条**——我据此得出过「只剩 1 条真挂」的错误结论,并写进了 issue。
日志本身没说谎,但它把「被截断」呈现得和「跑完了」一模一样。

## 改动

1. `FILE_WALL_MS = TEST_TIMEOUT_MS * 4`——保证墙钟**始终**高于 2 条超时的耗时,
   不再随 `TEST_TIMEOUT_MS` 调整而失配。墙钟的职责是「拦住 wedge 住的文件」,
   不是「截断一个正在如实报告多条慢失败的文件」。
2. 被墙钟 kill 时,在该文件输出末尾追加一行明确提示:
   ```
   [runner] OUTPUT TRUNCATED: killed by the Nms per-file wall.
   Any failure count from this file is a LOWER BOUND — the run did not finish.
   Re-run this file alone (optionally with a smaller --timeout than Nms) to see the complete set.
   ```
   只在 `wallKilled` 时追加;正常失败退出不受影响。

**不改变任何测试的通过/失败结果**,只改「输出会不会误导读者」。

## 验证

- 造墙钟触发(临时把 `FILE_WALL_MS` 降到 4s + 一个 60s 挂起用例):提示**确实出现** ✅
- 反向:`--self-check` 正常跑完,提示出现 **0 次**(不误报) ✅
- `node scripts/run-bun-tests.mjs --self-check` 通过——**没有只用 `node --check`**,
  因为它对本文件的未定义绑定/TDZ 零区分力(见文件内 L219 注释记录的那次事故)
- 常量声明顺序已核:`TEST_TIMEOUT_MS`(L152) 在 `FILE_WALL_MS`(L164) 之前,无 TDZ

关联 #1181（该 issue 的判定一度被这个截断误导）

🤖 Generated with [Claude Code](https://claude.com/claude-code)