### PR TITLE
feat(fork): 支持 TraeX 会话分身

### DIFF
--- a/docs-site/docs/en/slash-commands.md
+++ b/docs-site/docs/en/slash-commands.md
@@ -14,11 +14,11 @@ Just send these commands directly in a topic, and the daemon intercepts and hand
 | `/retry` | Retry the most recent failed or interrupted turn (10s cooldown) |
 | `/restart` | Restart the CLI process (preserving the session context) |
 | `/close` | Close the session and send a recoverable card (including the CLI's own resume command) |
-| `/fork <task>` | Fork the current session with full context into a new sub-topic of the same topic group; the source session keeps running untouched (Claude family / Codex terminal only) |
+| `/fork <task>` | Fork the current session with full context into a new sub-topic of the same topic group; the source session keeps running untouched (Claude family, Codex terminal, or TraeX terminal mode) |
 | `/forklist` | Re-post the current session's forked-task panel with live/closed status and links to the child topics |
 | `/fork --create <group name>` | Clone the current session into a freshly-created group instead of a sub-topic |
 | `/rename <title>` | Rename this Botmux session and sync the running Codex/Claude native session name |
-| `/fork --create <new group name>` | Clone the current idle session into a newly-created group while leaving the source session untouched (Claude family / Codex terminal mode; invoke inside the source session's topic) |
+| `/fork --create <new group name>` | Clone the current idle session into a newly-created group while leaving the source session untouched (Claude family, Codex terminal, or TraeX terminal mode; Hybrid RPC / external app-server sessions are unsupported; invoke inside the source session) |
 | `/card` | Manually summon the current session's streaming card (can summon and restore live refresh even when streaming is off; in private-card mode, sends a static snapshot visible only to authorized users instead). `/card off` and `/card on` toggle streaming cards for this chat; `/card pin off`, `/card pin on`, and `/card pin status` control the per-chat streaming-card Pin override |
 | `/cot` | Thinking-process message switch: `/cot off` mutes this chat's thinking bubble, `/cot on` restores it, `/cot show` summons a one-off peek at the current turn's bubble while the switches are off, `/cot status` reports the state (bot-level master switch `thinkingCard`, on by default; claude-code / codex only) |
 | `/term` | Get the operable (write-enabled) terminal link for this session, delivered privately to the owner (visible-to-you in-chat, falling back to DM in topic/p2p — never exposed in the group) |

--- a/docs-site/docs/zh/slash-commands.md
+++ b/docs-site/docs/zh/slash-commands.md
@@ -14,11 +14,11 @@
 | `/retry` | 重试最近一个失败或被中断的 turn（10s 冷却） |
 | `/restart` | 重启 CLI 进程（保留 session 上下文） |
 | `/close` | 关闭会话并发送可恢复卡片（含 CLI 自身 resume 命令） |
-| `/fork <任务>` | 继承当前会话的完整上下文，在同一话题群新建并行子话题；源会话原样继续（仅 Claude 系 / Codex 终端模式） |
+| `/fork <任务>` | 继承当前会话的完整上下文，在同一话题群新建并行子话题；源会话原样继续（Claude 系 / Codex 或 TraeX 终端模式） |
 | `/forklist` | 重发当前会话的分身任务面板，显示运行/结束状态和子话题链接 |
 | `/fork --create <群名>` | 不建子话题，改为把当前会话分身到一个新建群 |
 | `/rename <标题>` | 重命名当前 Botmux 会话，并同步运行中的 Codex/Claude 原生会话名 |
-| `/fork --create <新群名>` | 把当前空闲会话分身到一个新建群，源会话原样保留继续（仅 Claude 系 / Codex 终端模式；需在源会话所在话题内发起） |
+| `/fork --create <新群名>` | 把当前空闲会话分身到一个新建群，源会话原样保留继续（Claude 系 / Codex 或 TraeX 终端模式；Hybrid RPC / 外部 app-server 会话不支持；需在源会话内发起） |
 | `/card` | 手动召唤当前会话的流式卡片（关流式时也能召唤并恢复实时刷新；私密卡片模式下改发仅授权人可见的静态快照）。`/card off`、`/card on` 控制本群是否出流式卡；`/card pin off`、`/card pin on`、`/card pin status` 控制当前群的流式卡片置顶开关 |
 | `/cot` | 思考过程消息开关：`/cot off` 关闭本群的思考气泡，`/cot on` 恢复，`/cot show` 在开关关闭时临时召唤一次当前回合的思考气泡，`/cot status` 查看状态（bot 级总开关 `thinkingCard` 默认 on；仅 claude-code / codex 支持） |
 | `/term` | 获取当前会话的「可操作终端」（带写权限）链接，私密发给 owner（群内仅你可见，话题/单聊回退私信，不在群里暴露） |

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -227,7 +227,7 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
     sandboxReadonlyPaths: () => [...TRAE_MIGRATION_DONE_MARKERS],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
-    buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, reasoningEffort, modelBackendVariant, disableCliBypass, bypassHookTrust, remoteWsUrl, remoteThreadId, shellSubprocessEnv, nativeSubagentRuntimeHookCommand }) {
+    buildArgs({ sessionId, resume, resumeSessionId, forkSession, workingDir, model, reasoningEffort, modelBackendVariant, disableCliBypass, bypassHookTrust, remoteWsUrl, remoteThreadId, shellSubprocessEnv, nativeSubagentRuntimeHookCommand }) {
       // Hybrid RPC input mode (codex-family): attach the TUI to the botmux-owned
       // app-server thread; input flows via JSON-RPC (see codex-rpc-engine + worker)
       // instead of a drop-prone paste. TRAE CLI shares codex's --remote/resume
@@ -270,7 +270,11 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
 
       const traeSessionId = resumeSessionId ?? findTraexSessionIdByBotmuxSessionId(sessionId);
       if (!traeSessionId) return baseArgs;
-      return ['resume', ...baseArgs, traeSessionId];
+      // Session fork: TraeX exposes the same native subcommand shape as Codex
+      // (`traecli fork <id>`). It mints a new thread while leaving the source
+      // untouched. The worker sets forkSession only for a fork child's first
+      // spawn; later restarts use ordinary resume against the child's new id.
+      return [forkSession ? 'fork' : 'resume', ...baseArgs, traeSessionId];
     },
 
     buildResumeCommand({ sessionId, cliSessionId }) {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -8569,13 +8569,13 @@ export async function transferSession(
 
 /** Backends whose conversation state is a local, copyable transcript file and
  *  whose CLI exposes a native "fork/branch this session" primitive that botmux
- *  can drive at cold spawn (Claude family / Grok: `--fork-session`; Codex terminal:
- *  `codex fork <id>`). App-server backends (codex-app, or a codex CLI running in
+ *  can drive at cold spawn (Claude family / Grok: `--fork-session`; Codex/TraeX
+ *  terminal: `<cli> fork <id>`). App-server backends (codex-app, or a Codex-family CLI running in
  *  Hybrid RPC mode) keep state in a live app-server process + SQLite and have no
  *  byte-level fork we can reproduce — they are refused. Riff / other pure-remote
  *  backends have no local rollout to fork either. */
 const FORK_CAPABLE_CLI_IDS: ReadonlySet<CliId> = new Set<CliId>([
-  'claude-code', 'seed', 'relay', 'codex', 'grok',
+  'claude-code', 'seed', 'relay', 'codex', 'traex', 'grok',
 ]);
 
 /** True when this session can be byte-level forked via a CLI-native primitive.
@@ -8591,7 +8591,7 @@ export function isForkCapableSession(ds: DaemonSession): boolean {
   // unrelated/empty local session, so refuse rather than claiming a copy was
   // made. A future server-side thread/fork primitive can add an explicit path.
   if (ds.session.existingAppServerEndpoint) return false;
-  // Codex terminal mode is forkable; Codex under Hybrid RPC input is not (the
+  // Codex/TraeX terminal mode is forkable; Hybrid RPC input is not (the
   // thread is an app-server live session, no local rollout to `codex fork`).
   //
   // Read BOTH the live config AND the SPAWN-TIME truth (ds.initConfig): a pane
@@ -8603,7 +8603,8 @@ export function isForkCapableSession(ds: DaemonSession): boolean {
   // and let `/fork` run `codex fork` against a rollout that does not exist.
   // ORing the frozen init flag closes that window (over-refuse, never leak).
   const rpcAtSpawn = ds.initConfig?.codexRpcInput === true;
-  if (cliId === 'codex' && (rpcAtSpawn || botCfg.codexRpcInput === true || config.codexRpcInputDefault)) {
+  if ((cliId === 'codex' || cliId === 'traex')
+    && (rpcAtSpawn || botCfg.codexRpcInput === true || config.codexRpcInputDefault)) {
     return false;
   }
   return true;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -686,7 +686,7 @@ export const messages: Record<string, string> = {
   'cmd.fork.no_source_here': '⚠️ No active session to fork here. Invoke /fork **inside the thread the session lives in** (the topic where you normally @ the bot), not at the group top level.',
   'cmd.fork.not_owner': '⚠️ Only the session owner can fork it.',
   'cmd.fork.wrong_bot': '⚠️ Fork can only clone the current session to **this same bot** (the clone must run the same CLI). No need to @ another bot; just `/fork --create <new group name>` — it defaults to the current bot.',
-  'cmd.fork.unsupported_backend': 'ℹ️ The current {cli} session does not support fork yet (only Claude family / Codex terminal mode; Codex App, RPC-enabled Codex, and pure-remote backends run an app-server live session with no byte-level copy).',
+  'cmd.fork.unsupported_backend': 'ℹ️ The current {cli} session does not support fork yet (supported: Claude family and Codex / TraeX terminal modes; Codex App, RPC-enabled Codex / TraeX, and pure-remote backends run an app-server live session with no byte-level copy).',
   'cmd.fork.mid_turn': '⚠️ The session is mid-turn and cannot be forked. Wait until it is idle, then /fork.',
   'cmd.fork.not_started_yet': '⚠️ The session has not really started (no repo / CLI not up / no context) and cannot be forked.',
   'cmd.fork.adopt_not_forkable': '⚠️ This session was adopted from an external CLI and cannot be forked.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -684,7 +684,7 @@ export const messages: Record<string, string> = {
   'cmd.fork.no_source_here': '⚠️ 这里没有可 fork 的活跃会话。/fork 要在**会话所在的那个话题里**发起（就是你平时 @ 机器人聊天的那条话题），不要在群顶层发。',
   'cmd.fork.not_owner': '⚠️ 只有会话发起人能 fork 它。',
   'cmd.fork.wrong_bot': '⚠️ fork 只能把当前会话复制给**当前这个机器人**（分身要跑同一个 CLI）。不用 @ 别的机器人；直接 `/fork --create <新群名>` 即可，会默认用当前机器人。',
-  'cmd.fork.unsupported_backend': 'ℹ️ 当前 {cli} 会话暂不支持 fork（目前仅 Claude 系 / Codex 终端模式；Codex App、开启 RPC 的 Codex、纯远端后端走 app-server 活会话，无法字节级复制）。',
+  'cmd.fork.unsupported_backend': 'ℹ️ 当前 {cli} 会话暂不支持 fork（目前支持 Claude 系、Codex / TraeX 终端模式；Codex App、开启 RPC 的 Codex / TraeX、纯远端后端走 app-server 活会话，无法字节级复制）。',
   'cmd.fork.mid_turn': '⚠️ 会话正在处理中（mid-turn），无法 fork。请等它空闲（idle）后再发 /fork。',
   'cmd.fork.not_started_yet': '⚠️ 会话还没真正跑起来（没选仓库 / CLI 没起 / 无上下文），无法 fork。',
   'cmd.fork.adopt_not_forkable': '⚠️ 该会话是 /adopt 接入的外部会话，无法 fork。',

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -528,6 +528,32 @@ describe('codex buildArgs', () => {
     ]);
   });
 
+  it('traex native fork branches the source session instead of resuming it', () => {
+    const traex = createTraexAdapter('/bin/traecli');
+    const args = traex.buildArgs({
+      sessionId: 'botmux-child',
+      resume: true,
+      resumeSessionId: 'traex-parent',
+      forkSession: true,
+      workingDir: '/workspace',
+    });
+    expect(args[0]).toBe('fork');
+    expect(args.at(-1)).toBe('traex-parent');
+    expect(args).toContain('/workspace');
+  });
+
+  it('traex restarts a completed fork child with ordinary resume', () => {
+    const traex = createTraexAdapter('/bin/traecli');
+    const args = traex.buildArgs({
+      sessionId: 'botmux-child',
+      resume: true,
+      resumeSessionId: 'traex-child',
+      forkSession: false,
+    });
+    expect(args[0]).toBe('resume');
+    expect(args.at(-1)).toBe('traex-child');
+  });
+
   it('does not inject a stale turn id into Codex shell environment policy', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-4', resume: false });
     expect(args.join('\n')).not.toContain('BOTMUX_TURN_ID');

--- a/test/fork-session.test.ts
+++ b/test/fork-session.test.ts
@@ -154,8 +154,8 @@ describe('isForkCapableSession', () => {
     } as any);
   });
 
-  it('accepts claude-code / seed / relay / codex / grok (terminal)', () => {
-    for (const cliId of ['claude-code', 'seed', 'relay', 'codex', 'grok'] as const) {
+  it('accepts claude-code / seed / relay / codex / traex / grok (terminal)', () => {
+    for (const cliId of ['claude-code', 'seed', 'relay', 'codex', 'traex', 'grok'] as const) {
       const ds = makeSourceDs({ cliId });
       expect(isForkCapableSession(ds)).toBe(true);
     }
@@ -177,6 +177,15 @@ describe('isForkCapableSession', () => {
       botName: 'TestBot',
     } as any);
     const ds = makeSourceDs({ cliId: 'codex' });
+    expect(isForkCapableSession(ds)).toBe(false);
+  });
+
+  it('refuses a traex session running under Hybrid RPC input', () => {
+    vi.mocked(getBot).mockReturnValue({
+      config: { cliId: 'traex', larkAppId: 'cli_app_test', codexRpcInput: true },
+      botName: 'TestBot',
+    } as any);
+    const ds = makeSourceDs({ cliId: 'traex' });
     expect(isForkCapableSession(ds)).toBe(false);
   });
 


### PR DESCRIPTION
## 改了什么

- 将 `traex` 纳入 `/fork <任务>` 与 `/fork --create <群名>` 的可分身 CLI 范围。
- TraeX 分身子会话首次启动时调用原生 `fork <source-session-id>`，由 CLI 创建独立 thread；捕获新 session id 后，后续重启恢复该 child，而不是继续 fork 父会话。
- TraeX Hybrid RPC 与外部 app-server 会话继续 fail closed，避免拿本地 rollout fork 远端活会话。
- 更新中英文提示、斜杠命令文档与回归测试。

## 为什么

BotMux 已有完整的 TraeX adapter，且 TRAE CLI 2.0 的 `traecli`/`traex` 提供原生 `fork` 子命令，但 `/fork` 的能力白名单没有包含 `traex`，adapter 也没有消费 worker 下发的 `forkSession` 标记。只放开白名单会把 child 错误启动成 `resume`，让两个 BotMux 会话续写同一个 TraeX thread。

本改动复用现有 session fork 生命周期：child 首次冷启动执行原生 fork，现有 transcript bridge 回写 CLI 新 id，并清除一次性的 `pendingForkSession` 标记。

## 影响面

- CLI：仅新增 TraeX 终端模式；Claude 系、Codex、Grok 的现有分身参数不变。
- 后端：本地 PTY/Tmux 等终端会话可用；Hybrid RPC、外部 app-server、纯远端与 adopt 会话仍拒绝。
- 会话类型：`/fork <任务>` 子话题分身与 `/fork --create <群名>` 新群分身共用同一能力门，因此同步获得支持。
- 平台：不新增路径、shell 或平台特有逻辑；使用 TraeX 跨平台 CLI 子命令。

## 验证

### 本地定向验证

- `bunx vitest run --project unit test/fork-session.test.ts test/cli-adapters.test.ts`
  - 2 个测试文件通过
  - 448 个测试通过
- `bun run build`
  - TypeScript、scripts typecheck、Dashboard bundle 与 dist audit 全部通过
- `bun run switch:here && bun run daemon:restart`
  - supervisor、daemon、dashboard 在线
  - 5 个已有 TraeX 会话恢复成功
  - daemon 日志确认当前 CLI 为 TraeX 0.201.6，实际入口为 `traecli`

### 真实 TraeX fork / resume smoke

- 使用当前安装的 `traecli 0.201.6` 从现有父 session 执行原生 `fork`，成功创建独立 child session。
- child 的 `session_meta.forked_from_id` 精确指向父 session，且继承工作目录。
- child 独立完成一轮 prompt；child rollout 新增记录，父 rollout 的修改时间和大小保持不变，确认没有误续写父会话。
- 终止 child 进程后通过 `traecli resume <child-session-id>` 冷启动，成功恢复 child 的 smoke 对话；父 TraeX 进程始终存活。
- 临时 smoke tmux pane 已清理；未创建飞书测试群。

### CI

GitHub Actions 已触发完整 CI，以远端检查结果作为合入门槛。
