### PR TITLE
docs(bridge): 补 #1170 的 headless 用例，并写清失败终态为何是唯一泄漏口

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5893,20 +5893,32 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
     // A SYNTHESISED local turn has no Lark turn behind it: `local-*` /
     // `local-headless-*` ids are minted by the queue for transcript activity
     // that matched no pending mark (terminal-typed input, or — after a restart
-    // — replayed history whose original mark is long gone). Its FALLBACK is
-    // already suppressed unconditionally (shouldSuppressBridgeEmit returns true
-    // for isLocal in non-adopt), so letting its FAILURE terminal through means
-    // the daemon posts a 「本轮执行失败」card for a turn the user never sent —
-    // and, because the daemon stamps the card with `new Date()` and the
-    // session's *current* lastUserPrompt, that card names the wrong time and
-    // the wrong task. MEASURED: a provider_server_error from 10h earlier was
-    // re-surfaced as a fresh failure card on two consecutive daemon restarts.
+    // — replayed history whose original mark is long gone). Letting its FAILURE
+    // terminal through means the daemon posts a 「本轮执行失败」card for a turn
+    // the user never sent — and, because the daemon stamps the card with
+    // `new Date()` and the session's *current* lastUserPrompt, that card names
+    // the wrong time and the wrong task. MEASURED: a provider_server_error from
+    // 10h earlier was re-surfaced as a fresh failure card on two consecutive
+    // daemon restarts.
+    //
+    // Before this gate the FAILURE TERMINAL was the sole leak, in BOTH modes.
+    // The fallback loop above skips a failed turn at its very FIRST check
+    // (`terminalOutcome.status !== 'completed' → continue`), which is
+    // mode-independent and runs before `shouldSuppressBridgeEmit` — so a failed
+    // local turn never reaches that gate, in adopt or otherwise. (Note the
+    // fallback would have carried `final_output` answer text anyway, never a
+    // card; cards come only from the terminal side.)
+    //
+    // Applies in adopt mode too, deliberately: the cause is identical in both
+    // modes — a synthesised local turn has no Lark turn to notify — so the gate
+    // is not conditioned on adoptMode.
     //
     // Scoped deliberately to the failure arm: a local turn's `completed`
     // terminal stays, because that is what settles bookkeeping (dedupe claim,
     // durable-turn release, CoT finalize) without showing the user anything.
-    // Non-local turns are untouched — a real Lark turn that genuinely failed
-    // must still raise its card, which is the whole point of that path.
+    // Non-local turns are untouched — `isLocal` is set only by the two synthesis
+    // paths and never by `mark()` (journal-restored turns go through `mark()`
+    // too), so a real Lark turn that genuinely failed still raises its card.
     if (turn.isLocal && outcome && outcome.status !== 'completed') {
       log(`Bridge terminal suppressed for synthesised local turn ${turn.turnId.substring(0, 8)} `
         + `(${outcome.status}${outcome.errorCode ? `/${outcome.errorCode}` : ''}) — no Lark turn to notify`);

--- a/test/claude-turn-terminal-contract.test.ts
+++ b/test/claude-turn-terminal-contract.test.ts
@@ -330,6 +330,21 @@ describe('Claude durable turn terminal contract', () => {
       expect(h.emitted).toEqual([]);
     });
 
+    it('emits no terminal for a HEADLESS local turn that died with provider_server_error', () => {
+      // The other synthesis path: an assistant boundary arrives with no
+      // collecting context at all (a restart cut the stream and the user event
+      // was already absorbed), so the queue mints `local-headless-<uuid>`.
+      // Reviewed as logically covered by the same gate, but it had no sample of
+      // its own — and "covered by the same branch" is an argument, not a test.
+      const h = new ContractHarness();
+      h.ingest([
+        assistant('headless-a', 'partial work with no user event', 'tool_use'),
+        connectionLost('headless-err'),
+        turnDuration('headless-dur'),
+      ]);
+      expect(h.emitted).toEqual([]);
+    });
+
     it('still emits the failure for a REAL Lark turn — the card must not be lost', () => {
       // Positive control. Without this, the fix above could be "suppress
       // everything" and the suite would not notice.


### PR DESCRIPTION
#1170 复审时提出、但没赶上合并的两处收尾。**仅注释 + 测试，不动生产逻辑** ——
`emitReadyTurns` 的可执行代码与 master 逐字节相同（用「剥掉注释与空行后 diff」核对过）。

> **修订记录**：本 PR 第一版的 adopt 说法**是错的**，已由复审指出并改正。
> 我当时写「adopt 下不抑制 fallback，所以失败的 local turn 在 adopt 下也会出错卡」。
> 错在我只单独调用 `shouldSuppressBridgeEmit` 验了它的返回值，**没有验失败 turn
> 到不到得了它**。下面是改正后的说法。

## 1. 写清「为什么失败终态是唯一泄漏口」

这一点两个 mode **完全一样**，不需要按 `adoptMode` 分情况。fallback 循环的
**第一道**检查就与 mode 无关，且排在 `shouldSuppressBridgeEmit` **之前**：

```
worker.ts:5763  if (turn.terminalOutcome && turn.terminalOutcome.status !== 'completed') continue;
worker.ts:5765  if (turn.isLocal && shouldSuppressBridgeEmit(..., adoptMode)) ...
```

实测（把这两道检查按原序复刻，两个 mode 各跑一遍）：

| turn | adoptMode=false | adoptMode=true |
|---|---|---|
| **failed** local | `skipped@5763`（mode 无关） | `skipped@5763`（mode 无关） |
| completed local | `suppressed@5765` | `WOULD EMIT final_output` |

失败的 local turn 在 5763 就被 `continue` 掉，**根本到不了** 5765 —— adopt 与否都一样。
所以在本门之前，**失败终态是唯一的泄漏口，两个 mode 同理**，因此门刻意不按 adoptMode 分支。

补充一点：fallback 即便放行，携带的是 `final_output` 答案文本，**不是卡** ——
「本轮执行失败」卡只来自终态侧。

> **另一处已纠正的表述**：本 PR 早前版本曾写「门的条件是 5763 条件的真子集，
> 所以结构上恒不可达」。**这个推理是错的**：5763 与门位于**两个各自独立遍历
> `ready` 的循环**（5758 的 fallback 循环 / 5890 的 terminal 循环），5763 的
> `continue` 只跳过第一个循环，第二个循环照跑。**门是可达且承重的** —— 下面
> 两个变异能打红本身就是铁证（真不可达的话，动它不会有任何测试变红）。
> 「到不了 `shouldSuppressBridgeEmit`」这一条仍然成立，因为它就在第一个循环里。

顺带把「真实 Lark turn 不受影响」的理由写实，而不是只下结论：`isLocal` 只由两条
合成路径赋值，`mark()` 从不赋值，journal 恢复的 turn 也走 `mark()`。

## 2. 补 `local-headless-*` 用例

它与 `local-*` 共用同一个门，复审时判定「逻辑上已覆盖」——
但**「走同一分支」是论证，不是测试**。补一条真样本：assistant 边界在没有任何
collecting 上下文时到达（重启切断流、user 事件已被 absorb），队列合成 headless
turn，随后 api-error 让它拿到 failed 终态。

## 验证

- `bun run build` 通过；两个测试文件 **85/85**（新增 1 条）
- **差分变异**：移除 harness 的门 → **2 条**转红（`local-*` 与 `local-headless-*`
  各一条）。新用例有区分力，不是装饰
- ⚠️ **我的注释改动会移动字节下标**，而 `09d6388b8` 的位置断言按下标比较，
  所以专门重验它仍有判别力：把门**原样移到** `emitTurnTerminal(...)` 之后
  （真移动、非新增）→ 恰好 1 条转红（`expected 11924 to be less than 11504`）。
  没有这一步，我就只能说「测试还是绿的」，而那恰好也是断言失效时的表现

## 关于 #1170 的合并

那个 PR 在我 rebase 并修订描述期间就已合入（squash `242d386ca`），所以这两处
只能作为 follow-up。生产代码那侧无需补救：我在**真 master** 上用线上真实
transcript + 真实 journal 重跑过生产代码，**0 张幻影失败卡**，并确认把门移除后
测试会转红（门是真在承重的）。

另有一项 follow-up **未包含在本 PR**：`clearPending()` 同样不回收 journal。
影响面与 HOL-drop 不同（后面有 `markGenerationRetired()` disarm、jsonlPath 作用域、
24h 门、InflightInputTracker 重投兜底），最坏是重投一段 stale partial 而非幻影
失败卡，所以单独评估，不搭车。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

