### PR TITLE
fix(test): 会话预览血缘用例改杀进程组，止住每轮泄漏一个常驻监听进程

### DIFF
--- a/test/session-preview-ownership.test.ts
+++ b/test/session-preview-ownership.test.ts
@@ -63,10 +63,32 @@ const children: ChildProcess[] = [];
 const tempRoots: string[] = [];
 let inProcessServer: Server | null = null;
 
-afterEach(async () => {
-  for (const child of children.splice(0)) {
-    try { child.kill('SIGKILL'); } catch { /* already gone */ }
+/**
+ * Kill the child's whole PROCESS GROUP, not just the child.
+ *
+ * `GRANDCHILD_SCRIPT` deliberately spawns a grandchild (that is the point of the
+ * lineage test), and both scripts hold an idle `setInterval`. Killing only the
+ * direct child left every grandchild reparented to init and running forever:
+ * one leaked listener per run, each holding a port and ~40MB. On this host that
+ * had accumulated to 738 orphans / ~28GB PSS before it was noticed.
+ *
+ * `startChild` spawns detached, so each child is its own group leader and
+ * `kill(-pid)` reaches the grandchildren too. The negative pid needs
+ * `process.kill`; `child.kill()` only ever signals the one process.
+ */
+function killChildTree(child: ChildProcess): void {
+  const pid = child.pid;
+  if (pid !== undefined) {
+    try {
+      process.kill(-pid, 'SIGKILL');
+      return;
+    } catch { /* group already gone, or platform without process groups */ }
   }
+  try { child.kill('SIGKILL'); } catch { /* already gone */ }
+}
+
+afterEach(async () => {
+  for (const child of children.splice(0)) killChildTree(child);
   for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
   if (inProcessServer) {
     await new Promise<void>(resolve => inProcessServer!.close(() => resolve()));
@@ -77,6 +99,10 @@ afterEach(async () => {
 function startChild(script: string, args: string[] = []): ChildProcess {
   const child = spawn(process.execPath, ['-e', script, ...args], {
     stdio: ['ignore', 'pipe', 'ignore'],
+    // Own process group, so afterEach can reap the grandchildren too
+    // (see killChildTree). Not unref'd: these children stay tracked in
+    // `children` and are killed explicitly.
+    detached: true,
   });
   children.push(child);
   return child;


### PR DESCRIPTION
## 改了什么

`test/session-preview-ownership.test.ts` 的 `afterEach` 只对**直接子进程**发 SIGKILL：

```ts
for (const child of children.splice(0)) {
  try { child.kill('SIGKILL'); } catch { /* already gone */ }
}
```

而同文件的 `GRANDCHILD_SCRIPT` 会再 `cp.spawn` 一个**孙子进程**去监听端口 —— 这正是该用例要验证的东西（血缘按 ppid 链向下走，不是只看直接子进程），**用例逻辑本身没有问题**。问题在清理：父进程被杀后，孙子被 init 收养，而脚本末尾的 `setInterval(() => {}, 1000)` 让它永不退出。

于是**每跑一次该文件就漏一个常驻进程**，每个占着一个随机高位端口和约 40MB 内存。

## 为什么这么改

- `startChild` 加 `detached: true`：让每个子进程自成**进程组**，组长就是它自己。
- `afterEach` 改走 `process.kill(-pid, 'SIGKILL')`：负号 pid 表示「整个进程组」，孙子一并回收。
- 负号 pid **必须**用 `process.kill`——`child.kill()` 只会 signal 单个进程，拿不到组。
- 取不到 pid、或平台没有进程组语义时，回落到原来的 `child.kill('SIGKILL')`。

**用例断言一行未改**，只改清理与 spawn 方式。

## 验证

同一台机器，按 `PPID=1 且 environ 含 VITEST=true` 计数孤儿进程：

| 场景 | 孤儿数变化 | 用例 |
|---|---|---|
| **修复后**跑该文件 | 3 → **3**（零泄漏） | 8 passed |
| **阳性对照**（把本改动 stash 掉再跑同一文件） | 3 → **4** | 8 passed |

阳性对照确认了两件事：泄漏**真实存在**，且**正是本改动关闭的**——不是环境差异或计数口径造成的假绿。

`tsc --noEmit` 干净。

## 影响面

- **只改测试文件**，不碰任何生产代码。
- `detached: true` 仅作用于该文件自己 spawn 的子进程；它们仍登记在 `children` 里被显式回收，不会脱离用例生命周期（没有 `unref`）。
- 不影响其它测试文件、不改共用 helper。

## 存量说明（与本 PR 无关，仅供参考）

本机此前已累积 **738** 个同类孤儿，约 **28GB**（PSS 口径；RSS 会把多进程共享页重复计入而偏大约 25%）。该存量已在本改动之外单独清理完毕，不在本 PR 范围内。
另有一批 `gemini --yolo` 孤儿**来源不同**，本 PR 未处理。

## 已知未覆盖

按「spawn + setInterval + 只 kill 一层」的模式 grep，还有十余个测试文件形态相似，但**模式匹配不能证明泄漏**——只有 before/after 孤儿计数能。本次清理出的 738 个里 473 个是本文件这个 `net.createServer` 形状，故先修这一处；其余需要逐个实测确认后另行处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)