### PR TITLE
fix(test): 组杀前先确认是进程组组长，去掉 detached 与 kill(-pid) 的隐式耦合

### DIFF
--- a/test/session-preview-ownership.test.ts
+++ b/test/session-preview-ownership.test.ts
@@ -12,7 +12,7 @@
 
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createServer, type Server } from 'node:net';
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -64,6 +64,39 @@ const tempRoots: string[] = [];
 let inProcessServer: Server | null = null;
 
 /**
+ * Is `pid` its own process-group LEADER (pgid === pid)?
+ *
+ * This is the precondition that makes the group kill below safe, and it is NOT
+ * self-evident from the call site: `process.kill(-N)` signals "the group whose
+ * pgid is N", not "pid N and its descendants". A child spawned WITHOUT
+ * `detached` sits in the PARENT's group, so `-childPid` names whatever group
+ * happens to carry that number — usually nothing (ESRCH), but a recycled pid
+ * that some `setsid` process once led can still have a live orphaned group, and
+ * then the kill lands on unrelated processes.
+ *
+ * `process.getpgid` does not exist on Node 22 or Bun 1.4 (verified on both), so
+ * the check reads field 5 of `/proc/<pid>/stat` — the fields after the `comm`
+ * parenthesis are (state, ppid, pgrp, …), and `comm` itself may contain spaces
+ * or parentheses, hence slicing from the LAST `)`.
+ *
+ * Unknown ⇒ false ⇒ the caller falls back to a single-process kill. That is the
+ * safe direction: the grandchild case is Linux-only, and on any platform where
+ * this cannot be answered there is no grandchild to reap.
+ */
+function isOwnGroupLeader(pid: number): boolean {
+  try {
+    const getpgid = (process as unknown as { getpgid?: (p: number) => number }).getpgid;
+    if (typeof getpgid === 'function') return getpgid(pid) === pid;
+    if (process.platform !== 'linux') return false;
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    const afterComm = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
+    return Number(afterComm[2]) === pid;
+  } catch {
+    return false; /* unreadable → treat as "not a leader" */
+  }
+}
+
+/**
  * Kill the child's whole PROCESS GROUP, not just the child.
  *
  * `GRANDCHILD_SCRIPT` deliberately spawns a grandchild (that is the point of the
@@ -72,17 +105,19 @@ let inProcessServer: Server | null = null;
  * one leaked listener per run, each holding a port and ~40MB. On this host that
  * had accumulated to 738 orphans / ~28GB PSS before it was noticed.
  *
- * `startChild` spawns detached, so each child is its own group leader and
- * `kill(-pid)` reaches the grandchildren too. The negative pid needs
- * `process.kill`; `child.kill()` only ever signals the one process.
+ * `startChild` spawns detached so each child leads its own group — but that
+ * coupling lives in a different function, so it is asserted here rather than
+ * assumed: a group kill is only issued for a confirmed group leader. The
+ * negative pid needs `process.kill`; `child.kill()` only ever signals the one
+ * process.
  */
 function killChildTree(child: ChildProcess): void {
   const pid = child.pid;
-  if (pid !== undefined) {
+  if (pid !== undefined && isOwnGroupLeader(pid)) {
     try {
       process.kill(-pid, 'SIGKILL');
       return;
-    } catch { /* group already gone, or platform without process groups */ }
+    } catch { /* group already gone */ }
   }
   try { child.kill('SIGKILL'); } catch { /* already gone */ }
 }


### PR DESCRIPTION
follow-up of #1190。

## 问题

#1190 让 `startChild` 以 `detached: true` spawn（子进程自成进程组），`killChildTree` 据此发 `process.kill(-pid, 'SIGKILL')` 连带回收孙子。**但这两者分处两个函数，中间没有任何东西保证前提成立。**

`process.kill(-N)` 的语义是「给 **pgid 等于 N** 的那个进程组发信号」，不是「给 pid N 及其后代发信号」。实测两种形态：

```
非 detached：child pid=2688472  pgid=2688449   leader=false   ← 属于父进程的组
detached   ：child pid=2688473  pgid=2688473   leader=true    ← 自成组
```

没有 `detached` 时，`-childPid` 指的是「组 id 恰好等于该数字的组」——通常不存在（ESRCH，静默回落），但**若该 pid 曾被某个 `setsid` 进程用过、且那个孤儿组仍有成员，信号就会打到无关进程组上**。

也就是说：未来任何人删掉 `detached` 而留下 `-pid`，缺陷会从「每轮泄漏一个进程」退化成「**可能误杀无关进程组**」——比原缺陷更坏。

## 改法

新增 `isOwnGroupLeader(pid)`，只有确认 `pgid === pid` 才发组杀，否则回落单进程 `child.kill()`。**把耦合从「靠人读注释」变成运行时可检。**

实现注意：`process.getpgid` 在 **Node 22 与 Bun 1.4 上都不存在**（两边实测均为 `undefined`），所以主路径读 `/proc/<pid>/stat` 的第 5 个字段；`comm` 可能含空格和括号，故从**最后一个** `)` 起切分。查不到或非 Linux 一律返回 `false` → 回落单杀，这是安全方向：孙子回收本就是 Linux-only 场景，其它平台没有孙子要收。

## 验证

同机，按 `PPID=1 且 environ 含 VITEST=true` 计数孤儿：

| 场景 | 孤儿数 | 说明 |
|---|---|---|
| 加固后跑该文件 | 0 → **0**（8 passed） | 守卫**没有误伤**组杀 |
| **变异对照**：强制 `isOwnGroupLeader` 恒 `false` | 0 → **1** | 守卫确实**承重、非惰性** |

变异对照是这个 PR 的关键证据：如果只验「加固后不泄漏」，无法区分「守卫正常工作」和「守卫是装饰、组杀本来就没被拦」。强制它返回 false 后泄漏立刻复现，证明这条分支真的在决定行为。

谓词三态实测：
```
非 detached 子进程 => false  (回落单杀)
detached   子进程 => true   (组杀)
不存在的 pid      => false  (安全回落)
```

`tsc --noEmit` 干净。

## 影响面

只改测试文件，不碰生产代码；**用例断言未改动**。

## 不在本 PR

pi 提的另一处硬化——「脚本自探 ppid 变 1 就自退」，用于治 vitest 被 Ctrl-C / 崩溃时 `afterEach` 不跑的残余泄漏——会改动脚本语义，按约定单开 follow-up，不与本 PR 混在一起。

🤖 Generated with [Claude Code](https://claude.com/claude-code)