### PR TITLE
fix(test): 预览血缘用例脚本加孤儿看门狗，异常终止时自退

### DIFF
--- a/test/session-preview-ownership.test.ts
+++ b/test/session-preview-ownership.test.ts
@@ -316,7 +316,12 @@ describe.skipIf(process.platform !== 'linux')('P1-12 preview listener ownership 
     // itself, so ppid === 1 would never fire there. This test only asserts the
     // change-triggered exit; the reparenting target (init or subreaper) is
     // irrelevant to the criterion.
-    const WATCHDOG = 'const parent = process.ppid; setInterval(() => { if (process.ppid !== parent) process.exit(0); }, 100);';
+    // Reuse the SHARED watchdog (the same one injected into LISTEN_SCRIPT /
+    // REBIND_SCRIPT / GRANDCHILD_SCRIPT), sped up 10x so the test doesn't wait
+    // a full second per tick. Reusing the constant is load-bearing: if someone
+    // hollows out ORPHAN_WATCHDOG, this positive control fails too — an inline
+    // copy would prove "a watchdog works" but not "the scripts have one".
+    const WATCHDOG = ORPHAN_WATCHDOG.replace('1000);', '100);');
     const NO_WATCHDOG = 'setInterval(() => {}, 100);';
     // Each grandparent spawns a grandchild and exits after the grandchild has
     // started (1000ms, ~20x Node startup), so the grandchild records its

--- a/test/session-preview-ownership.test.ts
+++ b/test/session-preview-ownership.test.ts
@@ -27,11 +27,27 @@ import {
 } from '../src/core/session-preview.js';
 import { resolveSessionPreviewForProxy } from '../src/dashboard/preview-contract.js';
 
+/**
+ * Self-exit when reparented (the parent process died). Covers the residual
+ * where vitest is Ctrl-C'd / crashes and afterEach never runs: the detached
+ * children are in their own process group, so the terminal's SIGINT does not
+ * reach them, and without this they would survive forever (one leaked
+ * listener per aborted run).
+ *
+ * The criterion is "ppid CHANGED", not "ppid === 1": an ancestor that set
+ * PR_SET_CHILD_SUBREAPER reparents orphans to itself instead of init, so
+ * ppid would never become 1 there and the watchdog would silently never
+ * fire. "Changed" fires for init, a subreaper, or any other reparenting
+ * target. (Verified: with a subreaper ancestor, the orphaned grandchild's
+ * ppid is the subreaper's pid, not 1.)
+ */
+const ORPHAN_WATCHDOG = 'const __parent = process.ppid; setInterval(() => { if (process.ppid !== __parent) process.exit(0); }, 1000);';
+
 const LISTEN_SCRIPT = `
 const net = require('net');
 const s = net.createServer();
 s.listen(0, '127.0.0.1', () => console.log('port ' + s.address().port));
-setInterval(() => {}, 1000);
+${ORPHAN_WATCHDOG}
 `;
 
 /** 抢占一个指定端口号（模拟 dev server 退出后，别的本机进程拿到同一个号码）。 */
@@ -48,7 +64,7 @@ const attempt = () => {
   s.listen(port, '127.0.0.1', () => console.log('up'));
 };
 attempt();
-setInterval(() => {}, 1000);
+${ORPHAN_WATCHDOG}
 `;
 
 /** 起一个孙子进程去监听：验证血缘是按 ppid 链向下走的，不是只看直接子进程。 */
@@ -56,7 +72,7 @@ const GRANDCHILD_SCRIPT = `
 const cp = require('child_process');
 const g = cp.spawn(process.execPath, ['-e', process.argv[1]], { stdio: ['ignore', 'pipe', 'ignore'] });
 g.stdout.on('data', d => process.stdout.write(d));
-setInterval(() => {}, 1000);
+${ORPHAN_WATCHDOG}
 `;
 
 const children: ChildProcess[] = [];
@@ -292,6 +308,52 @@ describe.skipIf(process.platform !== 'linux')('P1-12 preview listener ownership 
       proof: { pid: 4242, procStart: '918273', inode: '556677' },
       procRoot: missingRoot,
     })).toBe('unverifiable');
+  });
+
+  it('orphan watchdog: a script self-exits when its parent dies', async () => {
+    // The watchdog criterion is "ppid CHANGED", not "ppid === 1" (see
+    // ORPHAN_WATCHDOG): a PR_SET_CHILD_SUBREAPER ancestor reparents orphans to
+    // itself, so ppid === 1 would never fire there. This test only asserts the
+    // change-triggered exit; the reparenting target (init or subreaper) is
+    // irrelevant to the criterion.
+    const WATCHDOG = 'const parent = process.ppid; setInterval(() => { if (process.ppid !== parent) process.exit(0); }, 100);';
+    const NO_WATCHDOG = 'setInterval(() => {}, 100);';
+    // Each grandparent spawns a grandchild and exits after the grandchild has
+    // started (1000ms, ~20x Node startup), so the grandchild records its
+    // ORIGINAL ppid before the reparenting.
+    const spawnAndExit = (grandchildScript: string) => startChild(`
+      const cp = require('child_process');
+      const g = cp.spawn(process.execPath, ['-e', ${JSON.stringify(grandchildScript)}], { stdio: 'ignore' });
+      console.log(g.pid);
+      setTimeout(() => process.exit(0), 1000);
+    `);
+    const watchdogGrandparent = spawnAndExit(WATCHDOG);
+    const noWatchdogGrandparent = spawnAndExit(NO_WATCHDOG);
+    const watchdogPid = Number(await waitForLine(watchdogGrandparent, /^\d+$/));
+    const noWatchdogPid = Number(await waitForLine(noWatchdogGrandparent, /^\d+$/));
+
+    const isAlive = (pid: number): boolean => {
+      try { process.kill(pid, 0); return true; } catch { return false; }
+    };
+
+    // Watchdog grandchild: ppid changed → exits within ~100ms of the grandparent's exit.
+    const watchdogExited = await new Promise<boolean>((resolve) => {
+      const start = Date.now();
+      const timer = setInterval(() => {
+        if (!isAlive(watchdogPid)) { clearInterval(timer); resolve(true); return; }
+        if (Date.now() - start > 5000) { clearInterval(timer); resolve(false); }
+      }, 50);
+      timer.unref?.();
+    });
+
+    // Negative control: without the watchdog, the grandchild survives the
+    // reparenting (proves the watchdog is load-bearing, not the OS cleaning up).
+    // Kill it before asserting so a failed assertion cannot leak it.
+    const noWatchdogSurvived = isAlive(noWatchdogPid);
+    try { process.kill(noWatchdogPid, 'SIGKILL'); } catch { /* already gone */ }
+
+    expect(watchdogExited).toBe(true);
+    expect(noWatchdogSurvived).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 改了什么

`test/session-preview-ownership.test.ts` 的三个常驻脚本（`LISTEN_SCRIPT` / `REBIND_SCRIPT` / `GRANDCHILD_SCRIPT`）原本靠 `setInterval(() => {}, 1000)` 保活。#1190 用 `detached` + 组杀回收了正常流程的孙子进程，但 **vitest 被 Ctrl-C / 崩溃时 afterEach 不跑**，detached 子进程在独立进程组里收不到信号，会带着 `setInterval` 永远跑下去。

本 PR 给三个脚本加孤儿看门狗：启动时记住原始 ppid，心跳里发现 ppid 变了（= 原父已死、自己被重新挂到 init 或 subreaper）就 `process.exit(0)`。

## 判据为什么是「ppid 变了」而不是「ppid === 1」

Linux 有 `PR_SET_CHILD_SUBREAPER`：祖先进程设了它之后，孤儿会重新挂到 subreaper 上而不是 init。实测确认：

```
prctl(PR_SET_CHILD_SUBREAPER, 1) rc=0
父进程退出后，孙子的 ppid = 2964630  ← 正是 subreaper 自己的 pid，不是 1
```

在设了 subreaper 的环境里，`ppid === 1` 永远不触发，看门狗静默失效——最难发现的失败形态（代码看着对、测试也能过，只在别人机器上不生效）。「ppid 变了」对 init、subreaper、任何重新挂接目标都成立。

本机 738 个孤儿全是 PPID=1，是因为进程链 `tmux(ppid=1) → claude → zsh → …` 没有中间 subreaper——「本机观测全为 1」不等于「语义上保证是 1」。

## 测试

新增 `orphan watchdog: a script self-exits when its parent dies`，含阳性 + 阴性对照：

| 对照 | 脚本 | 父死后 | 断言 |
| --- | --- | --- | --- |
| 阳性 | 带看门狗 | ppid 变 → ≤100ms 自退 | 进程已死 |
| 阴性 | 不带看门狗（`setInterval(() => {}, 100)`） | ppid 变但仍保活 | 进程仍活（证明是看门狗承重，不是 OS 清理） |

阴性对照的进程在断言前显式 kill，避免测试失败时泄漏。

- 9 passed（8 原有 + 1 新增），无孤儿残留
- `tsc --noEmit` 干净
- 只改测试，不碰生产代码

## 影响面

只影响 `test/session-preview-ownership.test.ts` 一个文件。看门狗在测试正常流程中不触发（父进程 vitest worker 活着，ppid 不变），只在异常终止时兜底。