### PR TITLE
fix(test): 修 21 个 bun 腿失败文件（双 runner 逐个验过；剩余失败实测 14）

### DIFF
--- a/test/adopt-tmux-claude-wrapper-repro.smoke.test.ts
+++ b/test/adopt-tmux-claude-wrapper-repro.smoke.test.ts
@@ -22,13 +22,15 @@
  *   The common, un-wrapped case. The shared-path fix must NOT disturb it: comm
  *   already names the CLI, so discovery keeps that pid and resolves sessionId.
  *
- * Skipped automatically when tmux is unavailable (e.g. CI without tmux).
+ * Skipped automatically when tmux OR a real node binary is unavailable (see
+ * `resolveRealNode` — the fixtures cannot present a `claude` comm without node).
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { homedir, tmpdir } from 'node:os';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, unlinkSync, accessSync, constants } from 'node:fs';
+import { join, delimiter } from 'node:path';
+import { isBunRuntime } from './helpers/ts-runner.js';
 import { discoverAdoptableSessions } from '../src/core/session-discovery.js';
 import { isProcessAlive } from '../src/core/session-liveness.js';
 
@@ -44,7 +46,70 @@ function tmuxAvailable(): boolean {
 }
 
 const hasTmux = tmuxAvailable();
-const nodeBin = process.execPath;
+
+/**
+ * A REAL node binary to interpret both tmux fixtures — deliberately NOT
+ * `process.execPath`.
+ *
+ * WHY (measured under bun 1.4.0 + node 22.21.1, `bun test` vs `vitest run`):
+ * this whole test identifies processes through /proc/<pid>/comm and argv, so the
+ * fixture's INTERPRETER decides whether discovery can see it at all. Under
+ * `bun test`, `process.execPath` is the bun binary, and that breaks the two
+ * fixtures in two INDEPENDENT ways:
+ *
+ *  1. `process.title = 'claude'` (the fixture below) is a NO-OP under bun.
+ *     Same one-liner, both runtimes: node → comm=`claude`; bun → comm=`bun.exe`.
+ *     So the DIRECT case can never present the comm=`claude` identity whose
+ *     `matchedByComm=true` path it exists to guard.
+ *  2. comm is `bun.exe`, not `bun`: `command -v bun` is a symlink into
+ *     `lib/node_modules/bun/bin/bun.exe`, and tmux execve's the RESOLVED path.
+ *     `COMM_ARGV_LAUNCHERS` (src/core/session-discovery.ts) lists 'bun' but not
+ *     'bun.exe', so processExecutableArgvSlots yields argv[0] only and the
+ *     argv-slot match never runs — the WRAPPED pane is not even discovered.
+ *
+ * Adding 'bun.exe' to COMM_ARGV_LAUNCHERS would NOT be enough (measured): it
+ * fixes DIRECT only. WRAPPED would stay red because findLaunchedCliPid resolves
+ * the real child by comm ONLY — deliberately not argv, since a launcher's argv
+ * carries the target name as a literal token — and a bun-spawned child's comm is
+ * never `claude`. Two independent blockers; the argv-set tweak addresses one.
+ *
+ * This is a FIXTURE-IDENTITY artifact, not a product bug: real claude-code is a
+ * node program whose comm is `claude`, which discovery already handles. So the
+ * fix belongs here, in the test, and supplies node rather than relaxing anything.
+ *
+ * NOTE: `resolveBunExecutable` from ./helpers/ts-runner.js is the wrong tool here
+ * — it finds bun, which is precisely the binary that cannot work.
+ */
+function resolveRealNode(): string | undefined {
+  // Under Node, the running interpreter IS node — cheapest and most faithful.
+  if (!isBunRuntime()) return process.execPath;
+  const names = process.platform === 'win32' ? ['node.exe', 'node'] : ['node'];
+  for (const segment of (process.env.PATH ?? '').split(delimiter)) {
+    if (!segment) continue;
+    for (const name of names) {
+      const candidate = join(segment, name);
+      try {
+        accessSync(candidate, constants.X_OK);
+        // Confirm it is really node, not a bun shim named `node`: bun defines a
+        // `Bun` global, node does not. Cheap and decisive.
+        const probe = spawnSync(candidate, ['-e', 'process.stdout.write(typeof Bun === "undefined" ? "node" : "bun")'], {
+          encoding: 'utf-8',
+          timeout: 10_000,
+        });
+        if (probe.status === 0 && probe.stdout?.trim() === 'node') return candidate;
+      } catch {
+        // Keep scanning PATH.
+      }
+    }
+  }
+  return undefined;
+}
+
+// CI is fine: the bun-test job runs actions/setup-node@v6 (node 22) BEFORE
+// oven-sh/setup-bun@v2, so a real node is on PATH there. When there genuinely is
+// none, SKIP explicitly rather than letting the two cases fail or fake-pass.
+const nodeBin = resolveRealNode();
+const canRun = hasTmux && nodeBin !== undefined;
 
 let dir: string;
 let fakeClaude: string;
@@ -77,7 +142,7 @@ function writeMeta(pid: number, sessionId: string, cwd: string): void {
 }
 
 beforeAll(async () => {
-  if (!hasTmux) return;
+  if (!canRun) return;
   dir = mkdtempSync(join(tmpdir(), 'bmx-adopt-repro-'));
   wrappedWorkDir = join(dir, 'wrapped-work');
   directWorkDir = join(dir, 'direct-work');
@@ -98,10 +163,15 @@ beforeAll(async () => {
 
   // ── Case A: wrapped (node → fake claude) ──────────────────────────────────
   const wrapJs = join(dir, 'wrap.js');
+  // The inner interpreter is the resolved node path, NOT `process.execPath`:
+  // wrap.js is itself run by node here, so its own `process.execPath` would be
+  // correct today — but pinning the path keeps the fixture's identity explicit
+  // and independent of who launched the wrapper. The spawned child must be node
+  // for `process.title='claude'` to take effect (see resolveRealNode above).
   writeFileSync(
     wrapJs,
     `const { spawn } = require('child_process');\n` +
-      `const c = spawn(process.execPath, [process.argv[2], '--pid-file', process.argv[4]], { stdio: 'ignore', cwd: process.argv[3] });\n` +
+      `const c = spawn(${JSON.stringify(nodeBin)}, [process.argv[2], '--pid-file', process.argv[4]], { stdio: 'ignore', cwd: process.argv[3] });\n` +
       `process.on('SIGTERM', () => { try { c.kill('SIGKILL'); } catch {} process.exit(0); });\n` +
       `setTimeout(() => {}, 600000);\n`,
   );
@@ -110,7 +180,7 @@ beforeAll(async () => {
   // thus carries the basename "claude", triggering the argv-match-on-wrapper.
   execFileSync('tmux', [
     'new-session', '-d', '-s', TMUX_WRAPPED, '-x', '200', '-y', '50',
-    nodeBin, wrapJs, fakeClaude, wrappedWorkDir, wrappedPidFile,
+    nodeBin!, wrapJs, fakeClaude, wrappedWorkDir, wrappedPidFile,
   ]);
 
   // ── Case B: direct (fake claude straight in the pane) ─────────────────────
@@ -119,7 +189,7 @@ beforeAll(async () => {
   const directPidFile = join(dir, 'direct-child.pid');
   execFileSync('tmux', [
     'new-session', '-d', '-s', TMUX_DIRECT, '-c', directWorkDir, '-x', '200', '-y', '50',
-    nodeBin, fakeClaude, '--pid-file', directPidFile,
+    nodeBin!, fakeClaude, '--pid-file', directPidFile,
   ]);
 
   wrappedClaudePid = await waitForPidFile(wrappedPidFile, 5000);
@@ -134,7 +204,7 @@ beforeAll(async () => {
 }, 30_000);
 
 afterAll(() => {
-  if (hasTmux) {
+  if (canRun) {
     for (const s of [TMUX_WRAPPED, TMUX_DIRECT]) {
       try { execFileSync('tmux', ['kill-session', '-t', s]); } catch { /* already gone */ }
     }
@@ -146,7 +216,7 @@ afterAll(() => {
 });
 
 describe('tmux /adopt claude-code sessionId resolution (PR#293 issue #1)', () => {
-  it.skipIf(!hasTmux)('WRAPPED: resolves the child-keyed sessionId under a node launcher (the bug)', () => {
+  it.skipIf(!canRun)('WRAPPED: resolves the child-keyed sessionId under a node launcher (the bug)', () => {
     expect(wrappedClaudePid, 'wrapped fake-claude child pid should have been captured').toBeDefined();
     const sessions = discoverAdoptableSessions('claude-code');
     const mine = sessions.find(s => s.cwd === wrappedWorkDir || s.tmuxTarget?.startsWith(TMUX_WRAPPED));
@@ -156,7 +226,7 @@ describe('tmux /adopt claude-code sessionId resolution (PR#293 issue #1)', () =>
     expect(mine!.sessionId).toBe(SID_WRAPPED);
   });
 
-  it.skipIf(!hasTmux)('DIRECT: still resolves sessionId for an un-wrapped claude (regression guard)', () => {
+  it.skipIf(!canRun)('DIRECT: still resolves sessionId for an un-wrapped claude (regression guard)', () => {
     expect(directClaudePid, 'direct fake-claude pid should have been captured').toBeDefined();
     const sessions = discoverAdoptableSessions('claude-code');
     const mine = sessions.find(s => s.cwd === directWorkDir || s.tmuxTarget?.startsWith(TMUX_DIRECT));

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1795,7 +1795,21 @@ describe('hermes buildArgs', () => {
     // Hermes must NOT arm the gate; its ❯ readyPattern (input box up in ~3.6s) is
     // the earliest reliable readiness signal.
     expect(adapter.injectsReadyHook).toBeFalsy();
-    expect(adapter.readyPattern?.source).toBe('❯');
+    // Compare against a regex *literal*'s .source, never a string literal: Bun's
+    // transpiler rewrites non-ASCII characters inside regex literals into \uXXXX
+    // escapes, so the production `/❯/` (hermes.ts) reports .source === '\\u276F'
+    // under `bun test` but '❯' under vitest/node+tsx. String literals and
+    // `new RegExp('❯')` are NOT rewritten, which is exactly why `toBe('❯')` was
+    // green in one runner and red in the other. Writing both sides as regex
+    // literals puts them through the same printer in whichever runner is active,
+    // so the assertion stays exact (verified: /❯|foo/, /›/ and /❯?/ each still
+    // fail under BOTH runners) without hard-coding either runner's escaping.
+    // Caveat for future refactors: this couples to *how* the pattern is built.
+    // If hermes.ts ever switches to the equivalent `new RegExp('❯')`, Bun stops
+    // escaping and this line goes red on the bun leg only — in that case compare
+    // behavior (`readyPattern.test('❯')`) instead of .source text. Same latent
+    // exposure applies to codex.ts's /›|\d+% left/ if anyone asserts its .source.
+    expect(adapter.readyPattern?.source).toBe(/❯/.source);
     expect(adapter.deferFirstPromptTimeoutUntilReady).toBe(true);
     expect(adapter.supportsTypeAhead).toBeFalsy();
   });

--- a/test/cli-update-alias.test.ts
+++ b/test/cli-update-alias.test.ts
@@ -26,7 +26,31 @@ function runCli(command: string): { status: number | null; stdout: string; stder
       HOME: home,
       USERPROFILE: home,
       SESSION_DATA_DIR: join(home, 'data'),
-      PATH: '',
+      // ⚠️ Must be a NON-EMPTY path to a directory that does not exist — NOT `PATH: ''`.
+      //
+      // The containment this test depends on is "the child cannot exec anything",
+      // which makes `cmdUpgrade` abort at its very first `git` call. `PATH: ''`
+      // delivers that under Node only: Bun substitutes a built-in default PATH for
+      // the EMPTY string specifically, so under `bun test` the child resolved
+      // /usr/bin and really ran git (measured: `PATH=''` → `git version 2.39.5`,
+      // execFileSync SUCCEEDED). A non-empty bogus PATH is not substituted and
+      // fails closed on both runtimes (bun: `Executable not found in $PATH: "git"`,
+      // node: `spawnSync git ENOENT`).
+      //
+      // This is not cosmetic. With git actually reachable, `upgrade` got past the
+      // ENOENT guard into the real update sequence, which made this test both
+      // state-dependent and destructive:
+      //   • the aborting error became the DIRTY-tree message, whose embedded
+      //     `git status --porcelain` file list is inside the stderr that
+      //     `expect(update).toEqual(upgrade)` compares — so a clean checkout that
+      //     is merely BEHIND its remote made call #1 print "Fast-forward" and
+      //     call #2 "Already up to date", failing toEqual; and any neighbour test
+      //     touching the tree between the two calls reddened it too (the bun leg
+      //     runs several files concurrently in this same repo root).
+      //   • on a clean checkout it executed a real `git pull --ff-only`, i.e. it
+      //     could fast-forward the very checkout under test (reproduced in a
+      //     throwaway lab clone: HEAD moved).
+      PATH: '/nonexistent-botmux-guard',
     },
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -41,8 +65,12 @@ describe('botmux update alias', () => {
     const update = runCli('update');
 
     // Running from this checkout (has .git/src) → the local-dev update branch.
-    // PATH='' makes it abort deterministically at `git status` (ENOENT) right
-    // after the banner, so the test never runs a real pull/build/restart.
+    // The unresolvable PATH above (see runCli) makes it abort deterministically
+    // at the first `git` exec, right after the banner, so the test never runs a
+    // real pull/build/restart. The exact error text differs per runtime
+    // (bun: "Executable not found in $PATH", node: "spawnSync git ENOENT") and
+    // lives only in stderr, which no assertion below inspects directly — the
+    // toEqual only requires the two calls to agree with each other.
     expect(upgrade.status).toBe(1);
     expect(upgrade.stdout).toContain('本地 checkout 更新');
     // The core contract: `update` is a pure alias of `upgrade`.

--- a/test/dashboard-create-session.test.ts
+++ b/test/dashboard-create-session.test.ts
@@ -766,10 +766,22 @@ describe('spawnDashboardSession — in_progress starts immediately', () => {
       coworkers: [{ name: 'Sub1', openId: 'ou_s1' }],
     });
     const [, prompt] = forkWorkerMock.mock.calls[0];
+    // ⚠️ bun:test 缺陷（vitest 无此问题）：`toMatchObject` 里放非对称匹配器
+    // （`expect.stringContaining` / `expect.any` / `expect.objectContaining`）时，
+    // bun 会把 **received 对象上的那个属性原地覆盖成匹配器实例**：断言之后
+    // `typeof prompt.content` 由 `'string'` 变成 `'object'`
+    // （`String(prompt.content)` === `'[object ExpectStringContaining]'`），嵌套属性同样受影响。
+    // 于是「先 toMatchObject 再回读同一个属性当字符串用」的写法会报
+    // `Received value must be an array type, or both received and expected values must be strings.`
+    // —— 这是 runner 差异，不是被测代码的问题（生产值确实是含两段文本的原始字符串）。
+    // 无法用 shim 兜掉：覆写一个匹配器没法把另一个匹配器已经改写掉的值还原回来。
+    // 修法：在非对称断言把它污染之前先把原始值快照下来，后续断言读快照。
+    // 两条断言本身逐字不变、强度不变（对真的缺失子串仍然会红）；vitest 下快照是 no-op。
+    const promptContent: string = prompt.content;
     expect(prompt).toMatchObject({
       content: expect.stringContaining('<botmux_lead_dispatch>'),
     });
-    expect(prompt.content).toContain('Sub1');
+    expect(promptContent).toContain('Sub1');
   });
 
   it('unpublishes and closes only the new row when fork pre-accept throws', async () => {
@@ -985,8 +997,12 @@ describe('activateQueuedSession', () => {
     expect(r.ok).toBe(true);
     expect(forkWorkerMock).toHaveBeenCalledTimes(1);
     const [, prompt] = forkWorkerMock.mock.calls[0];
+    // 同上（见「lead in_progress wraps the prompt with the dispatch preamble」处的详细说明）：
+    // bun:test 的 `toMatchObject` 遇到非对称匹配器会把 received 的该属性原地改写成匹配器实例，
+    // 所以必须在那条断言之前把 `prompt.content` 的原始字符串快照下来再回读。
+    const promptContent: string = prompt.content;
     expect(prompt).toMatchObject({ content: expect.stringContaining('排队的任务') });
-    expect(prompt.content).toContain('<botmux_lead_dispatch>'); // preamble survived park→activate
+    expect(promptContent).toContain('<botmux_lead_dispatch>'); // preamble survived park→activate
     expect(ds.session.queued).toBe(false);
     // The worker-pool ACK handler, not activation acceptance, clears this
     // exact replay source after adapter submission.

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -5797,6 +5797,18 @@ describe('role profile IPC routes', () => {
 
       expect(res.status).toBe(200);
       const body = await res.json();
+      // bun:test 的 toMatchObject 会把传入的 asymmetric matcher 实例**写回** received
+      // 对象（vitest 不会）：跑完下面这个 toMatchObject 后，在 bun 下
+      // `typeof body.runId === 'object'`（值变成 ExpectStringMatching 实例），
+      // 且两处 runId 被换成**两个不同**的 matcher 实例。于是原先写在 toMatchObject
+      // 之后的 `expect(body.results[0].runId).toBe(body.runId)` 实际是在比
+      // matcher-vs-matcher，Object.is 恒为 false —— 报错信息两侧还会打印得一模一样
+      // （`Expected: StringMatching /^mlrp_/` / `Received: StringMatching /^mlrp_/`），
+      // 极难看出问题。产品行为是对的（runId 确实一致，vitest 下同一份断言全绿）。
+      // 所以这里必须**先把两个 runId 快照成字符串**，再跑 toMatchObject，最后比快照，
+      // 让同一性检查读到真实字符串而不是被写回的 matcher 实例。
+      const expectedRunId = body.runId;
+      const resultRunId = body.results[0].runId;
       expect(body).toMatchObject({
         ok: true,
         runId: expect.stringMatching(/^mlrp_/),
@@ -5810,7 +5822,7 @@ describe('role profile IPC routes', () => {
           triggerId: expect.stringMatching(/^mlrp_turn_/),
         }],
       });
-      expect(body.results[0].runId).toBe(body.runId);
+      expect(resultRunId).toBe(expectedRunId);
       expect(messageChatSpy).toHaveBeenCalledWith('cli_listener_run', 'om_match_run');
       expect(forkSpy).toHaveBeenCalledTimes(1);
       expect(forkSpy.mock.calls[0][2]).toMatch(/^mlrp_turn_/);

--- a/test/desktop/desktop-pm2-apps.test.ts
+++ b/test/desktop/desktop-pm2-apps.test.ts
@@ -162,22 +162,46 @@ describe('desktop PM2 app listing', () => {
     await expect(promise).resolves.toEqual([]);
   });
 
+  // The next two tests must START the call, advance the fake timers, and only
+  // THEN build the `.rejects` assertion — never `expect(call).rejects` before the
+  // advance. Reason (bun-specific, measured on bun 1.4.0): bun's
+  // `expect(promise).rejects/.resolves` EAGERLY DRAINS THE EVENT LOOP while the
+  // assertion object is being CONSTRUCTED, so construction blocks until the
+  // promise settles (measured: `expect(p).resolves.toBe(...)` on a promise that
+  // settles in 300ms takes 301ms to construct, while `p.then(v => v)` takes 0ms).
+  // vitest's `.rejects` does not do this — it returns a thenable immediately
+  // (same probe under vitest: 1ms) — which is why the old shape was green there.
+  // Here the promise can only settle once `vi.advanceTimersByTimeAsync` fires the
+  // SUT's timeout timer, so constructing the assertion first deadlocks: the spin
+  // waits for a fake timer that only the not-yet-reached advance line can fire.
+  // And because it is a synchronous busy spin (bun at ~40-70% CPU, STAT=R), bun's
+  // own `--timeout` watchdog cannot interrupt it: the process is SIGKILLed with no
+  // summary line, which suppressed the OTHER 8 tests in this file too (bun
+  // reported 0 of 10 tests).
+  //
+  // The `void call.catch(() => undefined)` guard is required by the OTHER runner:
+  // once the assertion moves after the advance, the rejection is momentarily
+  // unobserved, and vitest then fails the run with "Vitest caught 2 unhandled
+  // errors ... might cause false positive tests" (measured with the guard deleted;
+  // bun alone did not complain). It attaches a no-op observer only — it asserts
+  // nothing, and every assertion below is unchanged and still awaited.
   it('rejects and kills PM2 discovery when it times out', async () => {
     vi.useFakeTimers();
     const child = childProcessStub();
     const spawn = vi.fn(() => child);
-    const promise = expect(listPm2Apps(paths, runtime, {
+    const call = listPm2Apps(paths, runtime, {
       ...runningPm2,
       existsSync: () => true,
       spawn: spawn as any,
       execPath: '/Electron',
       env: {},
       timeoutMs: 25,
-    })).rejects.toThrow('timed out');
+    });
+    void call.catch(() => undefined);
 
     await vi.advanceTimersByTimeAsync(25);
 
-    await promise;
+    await expect(call).rejects.toThrow('timed out');
     expect(child.kill).toHaveBeenCalled();
     vi.useRealTimers();
   });
@@ -186,19 +210,23 @@ describe('desktop PM2 app listing', () => {
     vi.useFakeTimers();
     const child = childProcessStub();
     const spawn = vi.fn(() => child);
-    const promise = expect(listPm2Apps(paths, runtime, {
+    // Same deferral as above (see the comment on the previous test). The
+    // `defaultPm2ListTimeoutMs - 1` / `+1` boundary check is unchanged: kill must
+    // still not have fired one tick BEFORE the deadline, only after it.
+    const call = listPm2Apps(paths, runtime, {
       ...runningPm2,
       existsSync: () => true,
       spawn: spawn as any,
       execPath: '/Electron',
       env: {},
-    })).rejects.toThrow(`PM2 jlist timed out after ${defaultPm2ListTimeoutMs}ms`);
+    });
+    void call.catch(() => undefined);
 
     await vi.advanceTimersByTimeAsync(defaultPm2ListTimeoutMs - 1);
     expect(child.kill).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
 
-    await promise;
+    await expect(call).rejects.toThrow(`PM2 jlist timed out after ${defaultPm2ListTimeoutMs}ms`);
     expect(child.kill).toHaveBeenCalled();
     vi.useRealTimers();
   });

--- a/test/device-isolation-activation.test.ts
+++ b/test/device-isolation-activation.test.ts
@@ -66,6 +66,32 @@ describe('device isolation activation freeze', () => {
     await vi.advanceTimersByTimeAsync(1_010);
     await vi.runAllTimersAsync();
     expect(currentDeviceIsolationFreezeLease()).toBeNull();
+    // The lease has now expired, so `flushDeferredSpawns()` has already run and
+    // QUEUED the callback via `setImmediate` (see device-isolation-activation.ts).
+    // Advancing fake timers is not enough to make it FIRE, because the two runners
+    // fake different globals — measured on this exact nesting (a `setImmediate`
+    // queued from inside a fired `setTimeout`):
+    //
+    //                                   bun 1.4.0   vitest 4.1.11
+    //   useFakeTimers replaces setTimeout      no             yes
+    //   useFakeTimers replaces setImmediate    no             yes
+    //   fired after advance/runAllTimers       NO             yes
+    //
+    // Under vitest the faked `setImmediate` is driven by `runAllTimersAsync`, so
+    // the assertion below passed without any extra yield. Under bun the real
+    // `setImmediate` is left untouched by `useFakeTimers`, and the shim's async
+    // timer fills end in `await Promise.resolve()` — microtasks only, which never
+    // reaches the check phase where `setImmediate` runs. Hence the callback stayed
+    // at 0 calls there.
+    //
+    // Dropping to REAL timers first and then yielding one macrotask is the only
+    // shape that is green on both. The order is load-bearing: awaiting
+    // `setImmediate` WHILE timers are still faked hangs vitest for the full
+    // timeout (measured: "Test timed out in 30000ms") because vitest's fake
+    // `setImmediate` has nothing left to advance it. So do NOT hoist this yield
+    // above `useRealTimers()`, and do not replace it with `Promise.resolve()`.
+    vi.useRealTimers();
+    await new Promise(resolve => setImmediate(resolve));
     expect(callback).toHaveBeenCalledOnce();
   });
 });

--- a/test/herdr-session-discovery.test.ts
+++ b/test/herdr-session-discovery.test.ts
@@ -36,6 +36,7 @@ vi.mock('node:os', () => ({
 }));
 
 import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, readlinkSync, realpathSync } from 'node:fs';
 import {
   discoverAdoptableSessions,
   validateAdoptTarget,
@@ -89,6 +90,31 @@ function installHerdrFixture(fx: HerdrFixture) {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // Re-pin every node:fs factory default by hand. `vi.fn(impl)` defaults declared
+  // in the `vi.mock('node:fs', …)` factory above do NOT survive this reset under
+  // `bun test`: Bun follows jest semantics, where resetAllMocks/mockReset WIPES the
+  // implementation to an undefined-returning stub, while vitest RESTORES the impl
+  // the fn was created with. Measured on this repo's harness with one fresh
+  // `vi.fn(() => 'IMPL')` per question: vitest 4/4 pass, bun 2 fail with
+  // `Received: undefined` after both `vi.resetAllMocks()` and `.mockReset()`
+  // (`vi.clearAllMocks()` preserves the impl under bun — the divergence is
+  // specific to the reset family).
+  //
+  // Without the re-pin, `readdirSync()` returns undefined instead of `[]`, and
+  // findUniqueClaudeSessionByCwd() in src/core/session-discovery.ts crashes on
+  // `for (const name of names)` — real fs either yields string[] or throws into
+  // its try/catch, so only a wiped mock can produce undefined there.
+  //
+  // All five are re-pinned, not just readdirSync: the reset wipes every mock in
+  // the factory, and readdirSync is merely the one that currently reaches an
+  // iteration site. Do NOT "simplify" this to vi.clearAllMocks() — that would
+  // also stop clearing per-test mockImplementation overrides (installHerdrFixture
+  // sets one in nearly every case), letting them leak between cases under vitest.
+  vi.mocked(existsSync).mockReturnValue(false);
+  vi.mocked(readdirSync).mockReturnValue([] as any);
+  vi.mocked(readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+  vi.mocked(readlinkSync).mockImplementation(() => { throw new Error('ENOENT'); });
+  vi.mocked(realpathSync).mockImplementation(((p: string) => p) as any);
   // No tmux: `tmux list-panes` throws → discoverAdoptableSessions falls back
   // to herdr-only enumeration.
   mockedExecSync.mockImplementation(() => { throw new Error('no tmux'); });

--- a/test/md-card.test.ts
+++ b/test/md-card.test.ts
@@ -1109,12 +1109,40 @@ describe('buildReplyCardFooter', () => {
 
     expect(card).not.toBe(original);
     expect(original.body.elements).toHaveLength(1);
+    // Read the footer string out BEFORE the `toMatchObject` below, and assert on
+    // this local rather than re-reading `.content` afterwards.
+    //
+    // WHY (bun 1.4.0 `expect().toMatchObject` limitation, measured — not a style
+    // preference): when the *expected* side holds an asymmetric matcher such as
+    // `expect.stringContaining(...)`, bun's `toMatchObject` **destructively
+    // overwrites the received object's own property** with the matcher, leaving
+    // `{}` behind. Measured on this exact element: before the matcher
+    // `typeof content === 'string'`; after it `typeof content === 'object'` and
+    // the value is `{}`, with the descriptor re-defined to
+    // `{value:{},writable:true,enumerable:true,configurable:true}` — a native
+    // low-level re-define that fires no Proxy set/defineProperty trap and
+    // silently defeats `Object.freeze` (the object even reports
+    // `Object.isFrozen === false` afterwards). So a *second* assertion reading
+    // the same property saw an object, not a string, and bun rejected it with
+    // the misleading "Received value must be an array type, or both received and
+    // expected values must be strings."
+    //
+    // vitest does NOT mutate the received object here (measured: the string is
+    // unchanged after the matcher), which is why this only ever failed on the
+    // bun leg. Hoisting the read keeps both runners green and, because the same
+    // string is still checked for the same substring, weakens nothing.
+    //
+    // Repo-wide caution for whoever touches a sibling test: any file that
+    // re-asserts on a property after passing it through `toMatchObject` with an
+    // asymmetric matcher hits this identically — and a truthiness/shape check on
+    // the clobbered `{}` can pass quietly instead of failing loudly.
+    const footerContent: string = card.body.elements.at(-1).content;
     expect(card.body.elements.at(-1)).toMatchObject({
       tag: 'markdown',
       element_id: 'botmux_reply_footer',
       content: expect.stringContaining('Sent to: <at id=ou_owner></at>'),
     });
-    expect(card.body.elements.at(-1).content).toContain(
+    expect(footerContent).toContain(
       '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)',
     );
   });

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { accessSync, chmodSync, constants, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { delimiter, dirname, join, resolve } from 'node:path';
 import { detectGlobalInstallManager } from '../src/utils/global-install.js';
 
 /**
@@ -31,6 +31,59 @@ import { detectGlobalInstallManager } from '../src/utils/global-install.js';
 const POSTINSTALL = resolve('scripts/postinstall-bin.mjs');
 const INJECT = resolve('scripts/inject-optional-binaries.mjs');
 const PLATFORMS = ['botmux-darwin-arm64', 'botmux-darwin-x64', 'botmux-linux-arm64', 'botmux-linux-x64'];
+
+/**
+ * A real `node` to run the scripts under test — NOT `process.execPath`.
+ *
+ * FIDELITY, not a workaround. Both scripts exercised in this file are invoked by
+ * production as `node`, never as the runtime running the tests:
+ *   · package.json  "postinstall": "node scripts/postinstall-bin.mjs"
+ *   · release.yml    run: node scripts/inject-optional-binaries.mjs "$VERSION"
+ * Under `bun test`, `process.execPath` is the BUN binary (measured:
+ * .../node_modules/bun/bin/bun.exe), so every spawn below was running these
+ * scripts on a runtime npm never uses. Under vitest it happened to be node, which
+ * is why the infidelity stayed invisible for so long.
+ *
+ * This is the same lesson as test/helpers/ts-runner.ts, which exists precisely
+ * because `process.execPath` is bun-only-broken for child spawns — the difference
+ * is that ts-runner wants "whatever runtime the test uses", while these two
+ * scripts have a runtime pinned by production, so here the answer is always node.
+ *
+ * IT ALSO REMOVES A TIMEOUT FLAKE, as a side effect of the higher fidelity rather
+ * than by masking it. Bun's startup dominates these ~20 short-lived children:
+ * MEASURED on the real global-install fixture (n=10 each) bun 611 ms/child vs node
+ * 40 ms/child, ~15x. On a loaded box that cost pushed two cases (the two whose
+ * fixture spawns most) into the 60 s per-test timeout, and bun logged `killed 1
+ * dangling process` immediately before each failure with a perfect
+ * dangling==fails correlation over 9 runs. No assertion or timeout was touched.
+ *
+ * ⚠️ Resolved by EXECUTION, not by name: bun ships a `node` shim on PATH in some
+ * setups, and picking that would silently reintroduce the bun runtime this exists
+ * to avoid. Each candidate must report `process.versions.bun === undefined`.
+ * Falls back to process.execPath only when no real node exists at all, so the file
+ * degrades to today's behaviour instead of failing to run. CI's bun-test job runs
+ * actions/setup-node, so a real node is present there too.
+ */
+const NODE = (() => {
+  const names = process.platform === 'win32' ? ['node.exe', 'node.cmd', 'node'] : ['node'];
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = join(dir, name);
+      try {
+        accessSync(candidate, constants.X_OK);
+      } catch {
+        continue; // Keep scanning PATH.
+      }
+      const probe = spawnSync(candidate, ['-p', 'process.versions.bun ?? "node"'], {
+        encoding: 'utf-8',
+        timeout: 30_000,
+      });
+      if (probe.status === 0 && probe.stdout.trim() === 'node') return candidate;
+    }
+  }
+  return process.execPath;
+})();
 
 const dirs: string[] = [];
 function tmp(): string {
@@ -155,7 +208,7 @@ describe('inject-optional-binaries — release-time version wiring', () => {
       join(dir, 'package.json'),
       `${JSON.stringify({ name: 'botmux', version: manifestVersion }, null, 2)}\n`,
     );
-    const r = spawnSync(process.execPath, [join(dir, 'scripts', 'inject-optional-binaries.mjs'), argVersion], {
+    const r = spawnSync(NODE, [join(dir, 'scripts', 'inject-optional-binaries.mjs'), argVersion], {
       encoding: 'utf-8',
     });
     const after = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
@@ -206,9 +259,9 @@ describe('inject-optional-binaries — release-time version wiring', () => {
     writeFileSync(join(dir, 'scripts', 'inject-optional-binaries.mjs'), readFileSync(INJECT));
     writeFileSync(join(dir, 'package.json'), `${JSON.stringify({ name: 'botmux', version: '3.20.0' }, null, 2)}\n`);
     const script = join(dir, 'scripts', 'inject-optional-binaries.mjs');
-    spawnSync(process.execPath, [script, '3.20.0'], { encoding: 'utf-8' });
+    spawnSync(NODE, [script, '3.20.0'], { encoding: 'utf-8' });
     const first = readFileSync(join(dir, 'package.json'), 'utf-8');
-    spawnSync(process.execPath, [script, '3.20.0'], { encoding: 'utf-8' });
+    spawnSync(NODE, [script, '3.20.0'], { encoding: 'utf-8' });
     expect(readFileSync(join(dir, 'package.json'), 'utf-8')).toBe(first);
   });
 });
@@ -311,7 +364,7 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     if (opts.binDirOnPath) env.PATH = `${join(home, '.botmux', 'bin')}:${process.env.PATH}`;
     if (opts.shell) env.SHELL = opts.shell;
 
-    const r = spawnSync(process.execPath, [join(pkg, 'scripts', 'postinstall-bin.mjs')], {
+    const r = spawnSync(NODE, [join(pkg, 'scripts', 'postinstall-bin.mjs')], {
       encoding: 'utf-8',
       env,
     });
@@ -604,7 +657,7 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     writeFileSync(join(pkg, 'scripts', 'postinstall-bin.mjs'), src);
     writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: 'botmux', version: '3.20.0' }));
 
-    const r = spawnSync(process.execPath, [join(pkg, 'scripts', 'postinstall-bin.mjs')], {
+    const r = spawnSync(NODE, [join(pkg, 'scripts', 'postinstall-bin.mjs')], {
       encoding: 'utf-8',
       env: { PATH: process.env.PATH, HOME: home, npm_config_global: 'true' },
     });

--- a/test/platform-bind-ip-family.test.ts
+++ b/test/platform-bind-ip-family.test.ts
@@ -28,18 +28,31 @@ const okRes = { status: 200, json: { machineId: 'm-1', machineToken: 'tok-1' } }
 const netErr = () => Object.assign(new Error('connect ENETUNREACH'), { code: 'ENETUNREACH' });
 const hostOnly = { isAgentContext: () => false };
 
+// 清理 process.exitCode 必须赋 `0`，不能赋 `undefined`。
+// 这是 Bun 的限制（实测 bun 1.4.0）：`process.exitCode` 的 setter 对 `undefined`
+// 是 no-op，赋值后读回来仍是旧值；赋 `0` 才真正清除。Node 两者都清除，所以
+// vitest 下写 `undefined` 看不出问题。
+//   node -e 'process.exitCode=2; process.exitCode=undefined' → 读到 undefined，exit 0
+//   bun  -e 'process.exitCode=2; process.exitCode=undefined' → 读到 2，        exit 2
+//   bun  -e 'process.exitCode=2; process.exitCode=0'         → 读到 0，        exit 0
+// 下面第 5 条用例走 src/platform/bind.ts 的 managed-agent 拒绝分支，那里正确地
+// 设了 `process.exitCode = 2`。若清理用 `undefined`，这个 2 会在 Bun 下一路活到
+// 进程退出：文件本身「5 pass 0 fail」，但 bun 进程 exit 2，而
+// scripts/run-bun-tests.mjs 的 `code !== 0` 判定在解析 `Ran N tests` 之前，
+// 于是零失败断言的文件会纯粹因为泄漏的退出码被判红。
+// 注意别改成 `delete process.exitCode`：Bun 下会抛 TypeError: Unable to delete property。
 describe('cmdBind 协议族兜底（不落盘 ipFamily）', () => {
   beforeEach(() => {
     postJson.mockReset();
     readPlatformBinding.mockReset().mockReturnValue(null);
     writePlatformBinding.mockReset();
-    process.exitCode = undefined;
+    process.exitCode = 0;
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    process.exitCode = undefined;
+    process.exitCode = 0;
   });
 
   it('默认路径成功：不写 ipFamily', async () => {

--- a/test/platform-tunnel-data-bridge.test.ts
+++ b/test/platform-tunnel-data-bridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { WebSocketServer, WebSocket, type RawData } from 'ws';
 import { createServer, type Server as NetServer } from 'node:net';
+import { createHash } from 'node:crypto';
 import { spawnSyncTsEvalWithRepoImports } from './helpers/ts-runner.js';
 import { bridgeDataChannel } from '../src/platform/tunnel-client.js';
 
@@ -26,13 +27,20 @@ import { bridgeDataChannel } from '../src/platform/tunnel-client.js';
  * and assert bytes make the round trip, against the PRODUCTION bridge imported from
  * `src/` (see the note above `startBridgingWsServer`).
  *
- * ⚠️ Scope, stated honestly: every test here runs on whatever runtime vitest uses,
- * which is Node — and `spawnSyncTsEvalWithRepoImports` children inherit that, so the
- * out-of-process test is Node too (MEASURED: the child reports `node v22.21.1`).
- * Nothing in this file executes under Bun. The Bun-specific facts that motivated the
- * fix (`createWebSocketStream` throws; `pause()`/`bufferedAmount`/`send()` callbacks
- * are all unusable; FIN-time `terminate()` truncates at volume) were measured by hand
- * and are guarded here by SOURCE-SHAPE assertions, not by behaviour.
+ * ⚠️ Scope, stated honestly: this file is run by BOTH runners — `bunx vitest run`
+ * (Node) and `bun test` (Bun) — and `spawnSyncTsEvalWithRepoImports` children inherit
+ * whichever parent runtime is in play (MEASURED under vitest: the child reports
+ * `node v22.21.1`). So the bridge here does get exercised on Bun, but only as far as
+ * Bun's BUILT-IN `ws` SHIM allows: `bun test` resolves `ws` to that shim rather than to
+ * `node_modules/ws` (MEASURED: `Bun.resolveSync('ws') === 'ws'`), and the shim differs
+ * from real `ws` in ways that silently defang harnesses built on ws-level controls —
+ * server sockets have no `pause`, and a paused raw socket keeps receiving frames and
+ * auto-ponging. The long note on the backpressure case documents one such trap and how
+ * that case is built to avoid it.
+ * The remaining Bun-specific facts that motivated the fix (`createWebSocketStream`
+ * throws; `bufferedAmount`/`pause()`/`send()` callbacks are all unusable; FIN-time
+ * `terminate()` truncates at volume) were measured by hand and are guarded here by
+ * SOURCE-SHAPE assertions, not by behaviour.
  */
 
 const servers: Array<NetServer | WebSocketServer> = [];
@@ -48,6 +56,13 @@ function toBuffer(data: RawData): Buffer {
   if (Array.isArray(data)) return Buffer.concat(data);
   return Buffer.from(data as ArrayBuffer);
 }
+
+/**
+ * RFC 6455 §1.3 handshake GUID. Needed because one case below completes a WebSocket
+ * upgrade by hand instead of using `ws` — see the long note on that case for why a
+ * `ws`-based stand-in cannot model a stalled peer under `bun test`.
+ */
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
 /**
  * The bridge under test is the PRODUCTION one, imported from src — not a copy.
@@ -268,7 +283,34 @@ describe('platform tunnel data bridge — flow control and shutdown', () => {
     // reflects real delivery. Without a working gate the bridge drains the local
     // dashboard as fast as it can and queues everything in memory: measured 400MB
     // read and 575MB RSS on Bun. With the gate it stops after a few MB.
+    //
+    // ⚠️ WHY THE PLATFORM STAND-IN BELOW IS A RAW `net` SERVER AND NOT A
+    // `WebSocketServer` — do NOT "simplify" it back; that form is INERT under `bun test`.
+    //
+    // This case used to accept the upgrade with `ws` and then call `req.socket.pause()`
+    // to model a platform that never reads. That holds under Node, but bun resolves `ws`
+    // to its own BUILT-IN SHIM (MEASURED: `Bun.resolveSync('ws') === 'ws'`, not
+    // `<repo>/node_modules/ws/index.js`, even though ws@8.21.3 is on disk). The shim
+    // handles the upgrade internally, so pausing `req.socket` does NOT stop frame
+    // delivery: the shim keeps reading and AUTO-PONGS. Production's gate then re-opened
+    // on that pong — correctly, it is evidence the peer consumed — and read the whole
+    // offer. MEASURED: 4 consecutive fenced bun runs, `readFromDashboard` exactly
+    // 67108864 (= the entire 64MB) every time, byte-identical when `-t` isolates this
+    // single case. And `req.socket.isPaused()` returns true under BOTH runtimes, which
+    // is precisely why the old harness read as correct while proving nothing.
+    //
+    // So the stall is now built WITHOUT ws: hand-complete the handshake (the one thing
+    // the bridge needs to reach readyState OPEN), drain incoming frames into the void,
+    // and never write a byte back. A pong is then structurally impossible in EITHER
+    // runtime, so the only thing that can stop the bridge is production's own gate.
+    // MEASURED with this stand-in, pongs=0 on both: bun holds 24.3-30.3MB (9 runs),
+    // node holds 12.3-14.5MB (3 runs), flat from 500ms through 8s, and the platform
+    // receives ~4MB — one watermark's worth — on both.
     const OFFER = 64 * 1024 * 1024;
+    // Mirrors production's WS_BACKPRESSURE_BYTES (src/platform/tunnel-client.ts), which
+    // is module-private; kept as a local so the bound below reads as a multiple of the
+    // watermark the gate actually uses rather than as a bare magic number.
+    const WATERMARK = 4 * 1024 * 1024;
     const block = Buffer.alloc(256 * 1024, 0xab);
     let readFromDashboard = 0;
 
@@ -287,26 +329,57 @@ describe('platform tunnel data bridge — flow control and shutdown', () => {
     await new Promise<void>((r) => srv.listen(0, '127.0.0.1', () => r()));
     const tcpPort = (srv.address() as { port: number }).port;
 
-    // Platform stand-in that NEVER reads: accept the upgrade, then pause the raw
-    // socket so nothing is consumed. Note this holds under Node (the runtime this
-    // suite runs on) — Bun's ws server ignores the pause, which is why production
-    // parity is argued from the client side, not from here.
-    const wss = new WebSocketServer({ port: 0, perMessageDeflate: false });
-    servers.push(wss);
-    await new Promise<void>((r) => wss.on('listening', () => r()));
-    wss.on('connection', (sock, req) => { sockets.push(sock); req.socket.pause(); });
-    const platformPort = (wss.address() as { port: number }).port;
+    // Platform stand-in that NEVER reads and CANNOT pong: a raw TCP server that
+    // completes the WebSocket handshake by hand (RFC 6455 §4.2.2 — echo back
+    // sha1(key + GUID), base64, as `Sec-WebSocket-Accept` with a 101), then swallows
+    // every frame and writes nothing ever again. No `ws` on this side means no shim
+    // autopong under bun (see the note above), so the gate is the only brake.
+    const platform = createServer((sock) => {
+      sock.on('error', () => { /* peer teardown is normal */ });
+      let upgraded = false;
+      let head = Buffer.alloc(0);
+      sock.on('data', (chunk) => {
+        if (upgraded) return; // frames go into the void — never a reply, hence never a pong
+        head = Buffer.concat([head, chunk]);
+        const end = head.indexOf('\r\n\r\n');
+        if (end < 0) return; // request headers still arriving
+        const key = /sec-websocket-key:[ \t]*(\S+)/i.exec(head.subarray(0, end).toString('latin1'))?.[1];
+        upgraded = true;
+        const accept = createHash('sha1').update(`${key}${WS_GUID}`).digest('base64');
+        sock.write(
+          'HTTP/1.1 101 Switching Protocols\r\n'
+          + 'Upgrade: websocket\r\n'
+          + 'Connection: Upgrade\r\n'
+          + `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+        );
+      });
+    });
+    servers.push(platform);
+    await new Promise<void>((r) => platform.listen(0, '127.0.0.1', () => r()));
+    const platformPort = (platform.address() as { port: number }).port;
 
     // The bridge under test: production function, platform side stalled.
     const winner = new WebSocket(`ws://127.0.0.1:${platformPort}`, { perMessageDeflate: false });
     sockets.push(winner);
+    let pongs = 0;
+    winner.on('pong', () => { pongs += 1; });
     await new Promise<void>((r, rej) => { winner.on('open', () => r()); winner.on('error', rej); });
     bridgeDataChannel(winner, tcpPort);
 
     await new Promise<void>((r) => setTimeout(r, 3_000));
-    // A working gate stops within a few multiples of the 4MB watermark. Without one
-    // the bridge swallows the entire 64MB offer.
-    expect(readFromDashboard).toBeLessThan(OFFER / 2);
+    // The stall must be the real thing: if a pong ever arrives the gate is SUPPOSED to
+    // re-open, so a byte bound alone could not tell "gate works" from "peer consumed".
+    expect(pongs).toBe(0);
+    // A working gate stops within a few multiples of the 4MB watermark. Without one the
+    // bridge swallows the entire 64MB offer.
+    //
+    // The bound is stated against the watermark, not as OFFER/2: bun holds 24.3-30.3MB
+    // against a 32MB half-offer, and leaning on a 1.7MB margin would make this case
+    // read as a threshold flake the first time scheduling shifted. 12x the watermark
+    // (48MB) sits clear of every measured hold on both runtimes while still being far
+    // below the 64MB a gateless bridge reads — MEASURED: deleting the gate gives the
+    // full 67108864, so the mutation this case exists to catch stays red.
+    expect(readFromDashboard).toBeLessThan(12 * WATERMARK);
   }, 30_000);
 
   it('reassembles a fragmented ws payload instead of dropping all but the first piece', async () => {

--- a/test/pm2-existing-client.test.ts
+++ b/test/pm2-existing-client.test.ts
@@ -1,24 +1,90 @@
 import { spawnSync } from 'node:child_process';
 import {
+  accessSync,
+  constants,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { runExistingPm2Command } from '../src/cli/pm2-existing.js';
 import { captureReadonlyPm2Jlist } from '../src/cli/pm2-readonly.js';
 import { inspectLinuxPm2GodOwnership } from '../src/core/pm2-lifecycle-owner.js';
+import { isBunRuntime } from './helpers/ts-runner.js';
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const PM2_PATH = join(PKG_ROOT, 'node_modules', 'pm2', 'bin', 'pm2');
 
-describe.runIf(process.platform === 'linux')('existing PM2 RPC mutation boundary', () => {
+/**
+ * A REAL Node executable for every PM2 child spawned by this file.
+ *
+ * WHY THIS IS NEEDED — `bun test` only; two INDEPENDENT blockers, both of which
+ * this one seam removes. Neither is a weakened assertion: the daemon really is
+ * unidentifiable, and the helper really cannot start, when the interpreter is bun.
+ *
+ * 1. PM2 advertises its God daemon ONLY via `process.title`
+ *    (`node_modules/pm2/lib/Daemon.js`: `process.title = … 'PM2 v' + version +
+ *    ': God Daemon (' + process.env.PM2_HOME + ')'` — the sole marker in the
+ *    whole package), and this repo identifies it by reading
+ *    `/proc/<pid>/cmdline`, requiring both `PM2 v` and `God Daemon (<home>)`
+ *    (`scanLinuxPm2GodPids` in `src/core/pm2-lifecycle-owner.ts`).
+ *    **Bun does not write a `process.title` assignment back into
+ *    `/proc/self/cmdline`; Node does.** Measured on one PM2_HOME with each
+ *    interpreter: node → `cmdline: PM2 v6.0.14: God Daemon (<home>)`; bun →
+ *    `cmdline: …/bun.exe …/pm2/lib/Daemon.js` (marker absent, `comm` just
+ *    `bun.exe`). Under `bun test` `process.execPath` is the bun binary and PM2's
+ *    `lib/Client.js` spawns the God with `var interpreter = process.execPath`, so
+ *    the God is a bun process carrying no marker → the scan matches no pid →
+ *    `inspectLinuxPm2GodOwnership` returns `{ kind: 'absent' }`, which is exactly
+ *    what the two `.not.toBe('absent')` assertions used to see.
+ *
+ * 2. Both production seams invoke their helper as `['--import','tsx', <…>.ts]`
+ *    (`src/cli/pm2-existing.ts`, `src/cli/pm2-readonly.ts`) — a Node-only form.
+ *    Measured: `bun --import tsx src/cli/pm2-existing-client.ts …` exits 1 with
+ *    `Cannot find module './cjs/index.cjs'`, while the node form works. So even
+ *    with the marker problem solved, the helper child cannot start under bun.
+ *
+ * The node path is threaded in through the seams that already exist for exactly
+ * this purpose (`nodePath` on `runExistingPm2Command` / `captureReadonlyPm2Jlist`,
+ * as `test/desktop/desktop-pm2-apps.test.ts` already does) — no production change.
+ *
+ * Under vitest the test body always runs on Node, so `process.execPath` is
+ * returned and every spawn is byte-for-byte what this file did before; the PATH
+ * scan is reached only under Bun. Same "resolve the shape from the runtime"
+ * pattern as `test/helpers/ts-runner.ts`, whose `isBunRuntime` is reused here.
+ */
+function resolveNodeExecutable(): string | undefined {
+  if (!isBunRuntime()) return process.execPath;
+  const name = process.platform === 'win32' ? 'node.exe' : 'node';
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, name);
+    try {
+      if (!statSync(candidate).isFile()) continue;
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Keep scanning PATH.
+    }
+  }
+  return undefined;
+}
+
+const NODE = resolveNodeExecutable();
+
+// No real Node on PATH ⇒ PM2's God cannot be made identifiable and the tsx
+// helper cannot start, so there is nothing this file can honestly assert. Skip
+// loudly instead of letting the assertions pass on a degraded daemon.
+describe.runIf(process.platform === 'linux' && NODE !== undefined)('existing PM2 RPC mutation boundary', () => {
+  const node = NODE!;
+
   let root = '';
   let pm2Home = '';
   let config = '';
@@ -31,7 +97,7 @@ describe.runIf(process.platform === 'linux')('existing PM2 RPC mutation boundary
     config = join(root, 'ecosystem.config.cjs');
     writeFileSync(script, 'setInterval(() => {}, 1000);\n');
     writeFileSync(config, `module.exports = { apps: [{ name: 'botmux-existing-fixture', script: ${JSON.stringify(script)} }] };\n`);
-    const boot = spawnSync(process.execPath, [PM2_PATH, 'status'], {
+    const boot = spawnSync(node, [PM2_PATH, 'status'], {
       env: { ...process.env, PM2_HOME: pm2Home },
       stdio: 'ignore',
       timeout: 10_000,
@@ -40,7 +106,7 @@ describe.runIf(process.platform === 'linux')('existing PM2 RPC mutation boundary
   });
 
   afterAll(() => {
-    spawnSync(process.execPath, [PM2_PATH, 'kill'], {
+    spawnSync(node, [PM2_PATH, 'kill'], {
       env: { ...process.env, PM2_HOME: pm2Home },
       stdio: 'ignore',
       timeout: 10_000,
@@ -62,9 +128,10 @@ describe.runIf(process.platform === 'linux')('existing PM2 RPC mutation boundary
       home: pm2Home,
       args: ['start', config],
       inherit: false,
+      nodePath: node,
       expectedGod: originalGod!,
     });
-    const apps = JSON.parse(captureReadonlyPm2Jlist({ pkgRoot: PKG_ROOT, home: pm2Home }));
+    const apps = JSON.parse(captureReadonlyPm2Jlist({ pkgRoot: PKG_ROOT, home: pm2Home, nodePath: node }));
     expect(apps.some((app: any) => app.name === 'botmux-existing-fixture')).toBe(true);
     expect(Number.parseInt(readFileSync(pidFile, 'utf8'), 10)).toBe(originalPid);
 
@@ -73,9 +140,10 @@ describe.runIf(process.platform === 'linux')('existing PM2 RPC mutation boundary
       home: pm2Home,
       args: ['delete', 'botmux-existing-fixture'],
       inherit: false,
+      nodePath: node,
       expectedGod: originalGod!,
     });
-    const killed = spawnSync(process.execPath, [PM2_PATH, 'kill'], {
+    const killed = spawnSync(node, [PM2_PATH, 'kill'], {
       env: { ...process.env, PM2_HOME: pm2Home },
       stdio: 'ignore',
       timeout: 10_000,
@@ -87,13 +155,14 @@ describe.runIf(process.platform === 'linux')('existing PM2 RPC mutation boundary
       home: pm2Home,
       args: ['start', config],
       inherit: false,
+      nodePath: node,
       expectedGod: originalGod!,
     })).toThrow(/no replacement daemon was created/);
     expect(existsSync(pidFile)).toBe(false);
   });
 
   it('rejects a replacement generation before applying the mutation', () => {
-    const boot = spawnSync(process.execPath, [PM2_PATH, 'status'], {
+    const boot = spawnSync(node, [PM2_PATH, 'status'], {
       env: { ...process.env, PM2_HOME: pm2Home },
       stdio: 'ignore',
       timeout: 10_000,
@@ -108,9 +177,10 @@ describe.runIf(process.platform === 'linux')('existing PM2 RPC mutation boundary
       home: pm2Home,
       args: ['start', config],
       inherit: false,
+      nodePath: node,
       expectedGod: { ...god!, startIdentity: `${god!.startIdentity}-replaced` },
     })).toThrow(/generation changed before mutation/);
-    const apps = JSON.parse(captureReadonlyPm2Jlist({ pkgRoot: PKG_ROOT, home: pm2Home }));
+    const apps = JSON.parse(captureReadonlyPm2Jlist({ pkgRoot: PKG_ROOT, home: pm2Home, nodePath: node }));
     expect(apps.some((app: any) => app.name === 'botmux-existing-fixture')).toBe(false);
   });
 });

--- a/test/remote-shutdown-detach.test.ts
+++ b/test/remote-shutdown-detach.test.ts
@@ -326,7 +326,21 @@ describe('Remote graceful daemon-shutdown detach coordinator', () => {
       type: 'remote_shutdown_result', requestId: secondAbortRequestId,
       phase: 'abort', ok: true, taskId: 'task-second',
     });
-    await expect(aborting).resolves.toSatisfy(
+    // Await BEFORE the matcher, not inside it: under `bun test` 1.4.0 the
+    // `.resolves` chain does not thread the awaited value into `toSatisfy`'s
+    // predicate — it hands it `{}` (measured: `keys=[]`), so the predicate died
+    // on `results.every is not a function`. The defect is in the `resolves`
+    // chain and not in `toSatisfy` itself: the SYNC form below receives the
+    // array correctly under both runners, and `resolves.toEqual` /
+    // `resolves.toHaveLength` thread their value fine under bun.
+    //
+    // This is NOT a cosmetic rewrite to silence a red. The old form had ZERO
+    // discriminating power under bun — it threw on GOOD data *and* on BAD data
+    // alike — and the same defect silently FALSE-GREENS any tolerant predicate
+    // (a `() => true` passes while receiving `{}`). The form below is measured
+    // to keep real teeth: it passes on all-ok and fails when any entry's
+    // `result.ok` is false. Do not restore `.resolves.toSatisfy` here.
+    expect(await aborting).toSatisfy(
       (results: Array<{ result: { ok: boolean } }>) => results.every(entry => entry.result.ok),
     );
     expect(first.ds.remoteShutdownState).toBeUndefined();

--- a/test/scheduler-silent-execute.test.ts
+++ b/test/scheduler-silent-execute.test.ts
@@ -678,12 +678,17 @@ describe('executeScheduledTask — live-session injection', () => {
     expect(store.size).toBe(1);
     expect(forkWorkerMock).toHaveBeenCalledTimes(1);
     const [, input, options] = forkWorkerMock.mock.calls[0];
+    // bun:test 的 toMatchObject 会**就地改写 received**：被非对称匹配器（这里的
+    // expect.stringMatching）命中的属性，断言后会变成 ExpectStringMatching 实例本身
+    // （vitest 不改写，所以同一份代码只在 bun 腿红）。turnId 随后要当 Map key 用，
+    // 所以必须在 toMatchObject 之前先取成局部 string，否则 has() 拿到的是对象、恒为 false。
+    const armedTurnId: string = options.turnId;
     expect(typeof input === 'string' ? input : input.content).toContain('检查服务状态，挂了才报警');
     expect(options).toMatchObject({
       resume: true,
       turnId: expect.stringMatching(/^schedule:task0001:/),
     });
-    expect(existing.silentScheduledTurns?.has(options.turnId)).toBe(true);
+    expect(existing.silentScheduledTurns?.has(armedTurnId)).toBe(true);
   });
 
   it('falls back from a rejected live injection by re-forking the same registered session', async () => {
@@ -703,11 +708,14 @@ describe('executeScheduledTask — live-session injection', () => {
     expect(store.size).toBe(1);
     expect(forkWorkerMock).toHaveBeenCalledTimes(1);
     const [, , options] = forkWorkerMock.mock.calls[0];
+    // 同上：bun:test 的 toMatchObject 会把被 expect.stringMatching 命中的 turnId
+    // 就地替换成匹配器实例，因此先取局部 string 再拿去查 Map。
+    const armedTurnId: string = options.turnId;
     expect(options).toMatchObject({
       resume: true,
       turnId: expect.stringMatching(/^schedule:task0001:/),
     });
-    expect(existing.silentScheduledTurns?.has(options.turnId)).toBe(true);
+    expect(existing.silentScheduledTurns?.has(armedTurnId)).toBe(true);
   });
 
   it('fails visibly instead of consuming a parked dashboard task', async () => {

--- a/test/session-discovery.smoke.test.ts
+++ b/test/session-discovery.smoke.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import {
   __testOnly_readComm,
   __testOnly_readCwd,
@@ -57,7 +57,26 @@ describe('readComm', () => {
     // Linux /proc/<pid>/comm 给短名 "node"；BSD ps 给完整路径，readComm
     // 已统一 basename，所以这里都不应包含 "/"。
     expect(comm).not.toContain('/');
-    expect(comm).toMatch(/^node/i);
+    // 断言 comm == 「spawn 时用的可执行文件的 basename」，而不是硬编码 /^node/i。
+    //
+    // 为什么必须这样写：target 子进程是用 `process.execPath` spawn 的（见
+    // beforeAll），所以它的运行时身份跟着**跑测试的 runner**变：
+    //   - vitest（测试体永远在 Node 里跑）→ execPath 是 node    → comm "node"
+    //   - `bun test`（bun 原生 runner）    → execPath 是 bun.exe → comm "bun.exe"
+    // 硬编码 /^node/i 等于假设 runner 一定是 Node，在 bun 腿上必红
+    // （实测 Received: "bun.exe"）—— 红的是这条断言，不是 readComm：同一个
+    // readComm 拿到真 node 子进程时照样返回 "node"。
+    //
+    // 用 slice(0, 15) 而不是完整 basename：Linux 的 /proc/<pid>/comm 截断在
+    // TASK_COMM_LEN=15（实测把 node 复制成 21 字符的 averyverylongnodename，
+    // comm 回来是 "averyverylongno"）。今天两个 runner 的名字是 4 / 7 字符，
+    // 比完整 basename 也能过，但钉死完整名会在将来任何长名字运行时上烂掉。
+    //
+    // 注意这是**收紧**不是放宽：精确 basename 相等严格强于 /^node/i 前缀匹配。
+    // 上面 toBeDefined() / not.toContain('/') 两条保持原样不动 —— 它们才是这个
+    // 文件存在的理由（macOS BSD `ps -o comm=` 返回完整路径的历史回归），且在
+    // bun 下本来就是绿的。
+    expect(comm).toBe(basename(process.execPath).slice(0, 15));
   });
 
   it('对不存在的 PID 返回 undefined', () => {

--- a/test/session-picker-responsive.test.ts
+++ b/test/session-picker-responsive.test.ts
@@ -4,13 +4,17 @@ import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { createServer } from 'node:http';
 import {
   chmodSync,
+  closeSync,
   mkdirSync,
   mkdtempSync,
+  readSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import { tsRunnerPrefix } from './helpers/ts-runner.js';
@@ -23,6 +27,129 @@ const tempDirs: string[] = [];
 const children: pty.IPty[] = [];
 
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// Bun-only workaround: node-pty's PTY reader delivers nothing under `bun test`
+// ---------------------------------------------------------------------------
+// WHICH RUNNER, WHICH LIMITATION: `bun test` (measured on bun 1.4.0), NOT vitest.
+// node-pty 1.1.0 reads the pty master via `new tty.ReadStream(term.fd)`
+// (node_modules/node-pty/lib/unixTerminal.js:93). Under Bun that object is
+// constructed WITHOUT a libuv TTY handle, so it performs a single read of
+// whatever is ALREADY buffered on the fd and then never re-polls it:
+//   bun 1.4.0  -> { ctor: 'ReadStream', _handle: undefined, isTTY: true }
+//   node 22.21 -> { ctor: 'ReadStream', _handle: 'TTY',     isTTY: true }
+// Two modes that predict oppositely pin it down: when the child writes at t=0
+// and the reader attaches at t=1000ms, bun delivers the buffered bytes (3/3
+// runs); when the reader attaches first and the child writes at t=1000ms, bun
+// delivers 0 bytes (3/3) while node delivers all of them. node-pty deliberately
+// swallows EAGAIN (unixTerminal.js ~98), so this surfaces as no error, no exit,
+// just permanent silence.
+//
+// That makes this file a deterministic red rather than a flake (0/8 fresh bun
+// runs delivered data): `botmux list` must load SQLite and lay out the table
+// before painting frame 1, so its first output ALWAYS lands in the
+// "arrives after attach" class -> renderCount() stays 0 and waitForRender(1)
+// fails. The picker itself is fine (`bun src/cli.ts list` over a pipe prints
+// the table), and the spawn side is fine too (calling pty.fork directly, the
+// child execs and a raw readSync on the master fd returns its output) — only
+// node-pty's reader fails to deliver.
+//
+// FIX: swap in a Readable that polls fs.readSync and treats EAGAIN as "no data
+// yet, retry". Measured under bun 1.4.0 on a real pty master fd: 10/10 chunks
+// written 300ms apart are received, exit codes still propagate, destroy()
+// still emits 'close', and pause()/resume() still gate delivery.
+//
+// WHY IT IS SCOPED THE WAY IT IS:
+//   * `typeof Bun` guard — under Node the real tty.ReadStream works and this
+//     must be a no-op, so vitest behaviour is bit-for-bit unchanged.
+//   * The swap wraps only the synchronous pty.spawn() call and is reverted in a
+//     `finally`. node-pty resolves `tty.ReadStream` lazily INSIDE the
+//     UnixTerminal constructor (verified: patching after node-pty is already
+//     imported still takes effect, and node-pty's own require('tty') is the
+//     same module object we mutate), so the patch does not need to precede the
+//     import and leaves nothing installed for other files or for `tty` users.
+//   * tty.ReadStream must never be constructed on this fd: once Bun builds one
+//     over it, raw access to that same fd is invalidated (fs.readSync then
+//     returns EBADF), so a "poll it afterwards" workaround on the object
+//     returned by pty.spawn() cannot work — the substitution has to happen at
+//     construction time.
+// Blast radius note: 35 test files import node-pty and any that waits on pty
+// output is red for this same reason; the general fix belongs in
+// test/bun-test-shim.ts, but this task is scoped to this one file.
+const IS_BUN = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+const POLL_INTERVAL_MS = 2;
+const PTY_READ_CHUNK = 1 << 16;
+
+class PolledPtyReadStream extends Readable {
+  private readonly _ptyFd: number;
+  private readonly _scratch: Buffer;
+  private _timer: ReturnType<typeof setTimeout> | undefined;
+  // node-pty and xterm both probe this; the real tty.ReadStream reports true.
+  public isTTY = true;
+
+  constructor(fd: number) {
+    super({ highWaterMark: PTY_READ_CHUNK, autoDestroy: true, emitClose: true });
+    this._ptyFd = fd;
+    this._scratch = Buffer.allocUnsafe(PTY_READ_CHUNK);
+  }
+
+  _read(): void { this._drain(); }
+
+  private _drain(): void {
+    if (this._timer !== undefined) return;
+    for (;;) {
+      let n: number;
+      try {
+        n = readSync(this._ptyFd, this._scratch, 0, this._scratch.length, null);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'EAGAIN') {
+          // Nothing buffered yet — the whole point of the workaround: come back
+          // and look again instead of giving up like the handle-less ReadStream.
+          this._timer = setTimeout(() => { this._timer = undefined; this._drain(); }, POLL_INTERVAL_MS);
+          this._timer.unref?.();
+          return;
+        }
+        // EIO is the normal "child hung up the pty" ending on Linux, and
+        // EBADF/ENXIO mean the fd is gone: end the stream so node-pty's
+        // 'close' handler runs and its deferred 'exit' fires.
+        if (code === 'EIO' || code === 'EBADF' || code === 'ENXIO') { this.push(null); return; }
+        this.destroy(err as Error);
+        return;
+      }
+      if (n === 0) { this.push(null); return; }
+      // Copy out of the reused scratch buffer before handing it downstream.
+      if (!this.push(Buffer.from(this._scratch.subarray(0, n)))) return; // respect backpressure (pause())
+    }
+  }
+
+  _destroy(err: Error | null, cb: (e: Error | null) => void): void {
+    if (this._timer !== undefined) { clearTimeout(this._timer); this._timer = undefined; }
+    try { closeSync(this._ptyFd); } catch { /* fd already reaped */ }
+    cb(err);
+  }
+
+  // node-pty's Terminal.end() forwards to the socket; tty.ReadStream has it via
+  // net.Socket, plain Readable does not.
+  end(): void { this.destroy(); }
+}
+
+/** pty.spawn, with the read path made to actually re-poll the fd under Bun. */
+function spawnPty(
+  command: string,
+  args: string[],
+  options: pty.IPtyForkOptions,
+): pty.IPty {
+  if (!IS_BUN) return pty.spawn(command, args, options);
+  const tty = createRequire(import.meta.url)('node:tty') as { ReadStream: unknown };
+  const original = tty.ReadStream;
+  tty.ReadStream = PolledPtyReadStream;
+  try {
+    return pty.spawn(command, args, options);
+  } finally {
+    tty.ReadStream = original;
+  }
+}
 
 afterEach(() => {
   for (const child of children.splice(0)) {
@@ -203,7 +330,7 @@ async function spawnPicker(
   // node-pty takes command and args separately, so build the runtime-aware
   // prefix by hand instead of going through the spawnTsScript wrapper.
   const { command, prefixArgs } = tsRunnerPrefix();
-  const child = pty.spawn(command, [...prefixArgs, CLI_PATH, 'list'], {
+  const child = spawnPty(command, [...prefixArgs, CLI_PATH, 'list'], {
     cwd: join(TEST_DIR, '..'),
     env,
     cols,

--- a/test/session-preview-proxy.test.ts
+++ b/test/session-preview-proxy.test.ts
@@ -1054,6 +1054,13 @@ describe('P1-2 preview 代理在客户端断开与非 101 拒绝路径上回收�
   const upstreamSockets = new Set<Socket>();
 
   afterEach(async () => {
+    // 假时钟的还原放在 afterEach 而**不是**用例内的 finally 里：bun test 在用例超时
+    // （timed out after Nms）时**不执行** finally，vitest 会执行。一旦某条用例将来又超时，
+    // finally 形态会把假时钟泄漏给同文件后续所有用例——它们各自 `await listen(...)`，而
+    // bun 假时钟下 listen 的回调永不触发（见下面那条用例的注释），于是「1 红」会连带成
+    // 「5 红」。两个 runner 的 afterEach 在超时后都仍会跑，所以这里是唯一可靠的还原点。
+    // 无条件调用是安全的：没装假时钟时 vitest 与 bun 都当 no-op（实测均不抛）。
+    vi.useRealTimers();
     for (const socket of probeClients) socket.destroy();
     probeClients.clear();
     // 泄漏用例失败时上游 socket 还挂着，server.close() 会一直等——先强拆再关。
@@ -1228,32 +1235,39 @@ describe('P1-2 preview 代理在客户端断开与非 101 拒绝路径上回收�
   });
 
   it('非 101 拒绝体超过总时限还没读完时，上游与浏览器两端一起销毁', async () => {
-    // 计时器必须在代理武装它**之前**换成假的，所以整段都跑在假 setTimeout 下；
-    // socket I/O 走的是真事件循环，不受影响。
+    // 建服务器/listen 必须留在**真时钟**下，只有「拨号 + 推进计时器」跑在假时钟下。
+    // 原因：bun 的假时钟下 `server.listen()` 的回调永不触发，`await new Promise(r =>
+    // server.listen(0, '127.0.0.1', r))` 就永不 settle，整条用例 60s 超时——实测同一文件
+    // 两条对照用例，真时钟 listen 拿到端口、假时钟下结果是 never。根因是 bun **忽略
+    // `toFake`**（实测：`setInterval` 明明被排除却照样被假掉），所以「socket I/O 走真事件
+    // 循环、不受影响」这个前提在 vitest 成立、在 bun 不成立。
+    //
+    // 这不违反下面那条原始约束：约束要的是「计时器必须在代理武装它**之前**换成假的」，
+    // 而代理武装 totalTimer 发生在 `upstream.on('response')`（preview-proxy.ts:576），也就是
+    // **拨号之后**；listen 早于拨号，把它移出假时钟窗口不影响该约束，用例要验的语义
+    // （超时后上游与浏览器两端一起销毁）一字未改。
+    const ctx = await startReclaimProbe();
+    // 计时器必须在代理武装它**之前**换成假的，所以拨号起整段都跑在假 setTimeout 下。
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
-    try {
-      const ctx = await startReclaimProbe();
-      const client = previewUpgrade(ctx.port, `${contentBase('s1')}/socket`);
-      const clientClosed = new Promise<void>(resolve => client.socket.on('close', () => resolve()));
-      await ctx.dialed;
+    // 还原写在本 describe 的 afterEach 里，不用 finally——bun 超时时不跑 finally（见上）。
+    const client = previewUpgrade(ctx.port, `${contentBase('s1')}/socket`);
+    const clientClosed = new Promise<void>(resolve => client.socket.on('close', () => resolve()));
+    await ctx.dialed;
 
-      const upstreamGone = ctx.upstreamClosed.then(() => true as const);
-      // 反复推进：上游 200 还在路上时推进是无害的，武装之后第一次推进就会触发。
-      for (let attempt = 0; attempt < 100; attempt++) {
-        vi.advanceTimersByTime(PREVIEW_UPGRADE_REJECTION_TIMEOUT_MS + 1_000);
-        const fired = await Promise.race([
-          upstreamGone,
-          new Promise<false>(resolve => { setImmediate(() => resolve(false)); }),
-        ]);
-        if (fired) break;
-      }
-      await upstreamGone;
-      await clientClosed;
-      expect(ctx.liveUpstream()).toBe(0);
-      expect(client.raw()).toBe('');
-    } finally {
-      vi.useRealTimers();
+    const upstreamGone = ctx.upstreamClosed.then(() => true as const);
+    // 反复推进：上游 200 还在路上时推进是无害的，武装之后第一次推进就会触发。
+    for (let attempt = 0; attempt < 100; attempt++) {
+      vi.advanceTimersByTime(PREVIEW_UPGRADE_REJECTION_TIMEOUT_MS + 1_000);
+      const fired = await Promise.race([
+        upstreamGone,
+        new Promise<false>(resolve => { setImmediate(() => resolve(false)); }),
+      ]);
+      if (fired) break;
     }
+    await upstreamGone;
+    await clientClosed;
+    expect(ctx.liveUpstream()).toBe(0);
+    expect(client.raw()).toBe('');
   });
 });
 

--- a/test/setup-verify-permissions.test.ts
+++ b/test/setup-verify-permissions.test.ts
@@ -7,9 +7,30 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 
 // 占位 mock — 单测里不真实调 Lark.Client. checkRequiredScopes / applyScopesUnverified
 // 单测都需要 mock 这个.
+//
+// ⚠️ 这两个 mock 必须声明在**模块顶层**（而不是工厂体内），且**不能**再靠工厂多返回
+// `__scopeListMock` 这类自造导出名把它们「偷运」给用例。两个 runner 的限制正好相反，
+// 只有下面这一种写法能同时满足（两条都是实测，不是推测）：
+//
+//   | 工厂返回的名字            | bun test          | vitest                                  |
+//   |---------------------------|-------------------|-----------------------------------------|
+//   | 自造名 `__scopeListMock`  | 🔴 静默丢弃       | ✅ 存在                                 |
+//   | 漏掉的真实导出 `WSClient` | ✅ 从真模块透传   | 🔴 No "WSClient" export defined on mock |
+//
+// 原因：vitest 把工厂返回的对象**整体当成模块**，多出来的键照样能读到；而 bun 做的是
+// 真 ESM 命名导出**链接**——它拿真模块的导出清单（本包 39 个）去连线，清单外的名字无处
+// 可落，于是 `(sdk as any).__scopeListMock === undefined`（连属性都不存在），用例在
+// `beforeEach` 里 `.mockReset()` 就抛 TypeError，26 条全被同一个 beforeEach 带崩。
+//
+// 另一半限制来自 vitest：它把 `vi.mock` 提升到所有 import 之上，工厂执行时下面这两个
+// 顶层 const **还没初始化**。所以工厂体内只能**惰性**引用它们——返回的是类本身，
+// `application` / `request` 是类字段初始化器，只在用例里 `new FakeClient()` 时才求值。
+// 若改成立即体（`() => ({ list: scopeListMock })` 这种在工厂返回时就解引用的形态），
+// vitest 下会直接 `Cannot access 'scopeListMock' before initialization`。
+const scopeListMock = vi.fn();
+const scopeApplyMock = vi.fn();
+
 vi.mock('@larksuiteoapi/node-sdk', () => {
-  const scopeListMock = vi.fn();
-  const scopeApplyMock = vi.fn();
   class FakeClient {
     application = { scope: { list: scopeListMock, apply: scopeApplyMock } };
     // checkRequiredScopes now reads scopes via client.request() (GET empty-body
@@ -18,17 +39,14 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
     request = (...args: unknown[]) => scopeListMock(...args);
     constructor(_: unknown) {}
   }
+  // 只返回**真实导出名**（verify-permissions.ts 只用到这三个）。
   return {
     Client: FakeClient,
     Domain: { Feishu: 0, Lark: 1 },
     LoggerLevel: { error: 0, fatal: 0 },
-    // 暴露 mock 函数给 test 直接拿到
-    __scopeListMock: scopeListMock,
-    __scopeApplyMock: scopeApplyMock,
   };
 });
 
-import * as sdk from '@larksuiteoapi/node-sdk';
 import {
   validateCredentials,
   readCriticalScopesFromApplicationInfo,
@@ -45,9 +63,6 @@ import {
   VC_MEETING_FEATURE_SCOPES,
 } from '../src/setup/verify-permissions.js';
 import { DOC_COMMENT_OAUTH_SCOPES } from '../src/utils/user-token.js';
-
-const scopeListMock = (sdk as any).__scopeListMock as ReturnType<typeof vi.fn>;
-const scopeApplyMock = (sdk as any).__scopeApplyMock as ReturnType<typeof vi.fn>;
 
 // fetch 在 verify-permissions.ts 里只在 validateCredentials 用. mock 掉.
 const fetchMock = vi.fn();

--- a/test/summary-command-window.test.ts
+++ b/test/summary-command-window.test.ts
@@ -11,6 +11,37 @@ import { describe, it, expect, vi } from 'vitest';
 const BOT_OPEN_ID = 'ou_thisbot';
 
 const chatPages: { newestFirst: any[] } = { newestFirst: [] };
+
+// Why these factories list names the SUT never imports:
+//
+// Bun's test runner performs REAL whole-graph ESM named-export linking; vitest
+// does not. So a `vi.mock` factory must satisfy every importer of the mocked
+// module that is reachable from the SUT — not just the SUT's own imports.
+// Under vitest the short factory (only the two `listChat*` names) passes; under
+// bun the same file dies during linking, before any `it` body runs, with
+// `SyntaxError: Export named 'getMessageDetail' not found`.
+//
+// The three extra names below are demanded by SIBLING modules in the graph:
+//   getMessageDetail    <- src/im/lark/message-parser.ts:2   (summary-command imports message-parser)
+//   getBot              <- src/services/summary-range-store.ts:2 (summary-command imports it for DEFAULT_SUMMARY_PROMPT)
+//   getLoadedConfigPath <- src/services/config-store.ts:6    (reached transitively)
+// Each one is load-bearing for bun: dropping any single one turns the run red
+// with that exact name in the error. The other names those two modules export
+// are demanded only by the mocked modules themselves, so they never reach the
+// linker and are deliberately NOT stubbed here.
+//
+// These three are LINK-ONLY: none of the 6 tests below ever calls them
+// (verified by making each stub throw — still 6 pass). Their bodies therefore
+// mirror the REAL contract for this test's state, so that if a future refactor
+// does reach one, it behaves like production instead of silently returning a
+// wrong-shaped value.
+//
+// Do NOT "simplify" this by spreading the real module
+// (`const actual = await import(...)` at top level, then `...actual`): vitest
+// hoists `vi.mock` above the imports, so the factory would dereference the
+// const before initialization -> `ReferenceError: Cannot access 'actual'
+// before initialization`. That trades a bun red for a vitest red. Explicit
+// names are the only form both runners accept.
 vi.mock('../src/im/lark/client.js', () => ({
   listChatMessagesUntil: vi.fn(async (_app: string, _chat: string, opts: any) => {
     const out: any[] = [];
@@ -21,10 +52,21 @@ vi.mock('../src/im/lark/client.js', () => ({
     return out.reverse();
   }),
   listThreadMessages: vi.fn(async () => []),
+  // Real shape: resolves to the message detail, or null when not found.
+  getMessageDetail: vi.fn(async () => null),
 }));
 
 vi.mock('../src/bot-registry.js', () => ({
   getBotOpenId: () => BOT_OPEN_ID,
+  // Real `getBot` THROWS for an unregistered bot, and callers rely on that
+  // (summary-range-store.ts:98 catches it to return `bot_not_registered`).
+  // No bot is registered in this test, so throwing IS the faithful answer —
+  // returning `undefined` here would turn that designed branch into a
+  // confusing downstream `reading 'config' of undefined`.
+  getBot: (larkAppId: string) => { throw new Error(`Bot not registered: ${larkAppId}`); },
+  // Real shape: `string | undefined`, undefined when no config has been loaded —
+  // which is this test's actual state.
+  getLoadedConfigPath: (): string | undefined => undefined,
 }));
 
 const { buildSummaryCommandPrompt } = await import('../src/im/lark/summary-command.js');

--- a/test/v3-host-runtime.test.ts
+++ b/test/v3-host-runtime.test.ts
@@ -701,7 +701,29 @@ describe('v3 host runtime', () => {
         },
         { baseDir: base, gateMode: 'blocking', resolvedWorkflowData: runtimeData },
       );
-      await vi.advanceTimersByTimeAsync(20_000);
+      // Pump the fake clock INCREMENTALLY (50ms steps) rather than as one
+      // `advanceTimersByTimeAsync(20_000)` jump. Identical 20s of virtual time
+      // under both runners — the assertions below are unchanged — but the loop
+      // is what makes this case runnable under `bun test`:
+      //
+      // The runtime re-arms its retry sleep one at a time:
+      //   `if (!settled) await new Promise((resolve) => setTimeout(resolve, 1_000));`
+      // (src/workflows/v3/shared-node-runtime.ts), so sleep N+1 only EXISTS
+      // after sleep N's continuation has run. vitest's advanceTimersByTimeAsync
+      // walks the timer queue tick by tick and drains microtasks between ticks,
+      // so a single 20s call releases the whole chain of ten deferrals. Bun
+      // implements no async variant, and test/bun-test-shim.ts:137 fills it with
+      // `jest.advanceTimersByTime(ms)` + ONE microtask drain: the full 20s is
+      // consumed in a single step, so only the FIRST sleep is released and the
+      // nine that follow are armed on a clock that never advances again.
+      // runWorkflow then never settles, and bun's own `--timeout` cannot rescue
+      // it because the awaited promise is pending on a frozen fake clock
+      // (measured: --timeout of 8s/10s/60s/180s all failed to interrupt; the
+      // process sat idle at 0% CPU). Stepping hands every re-armed sleep a live
+      // clock edge to land on, so both runners see the same ten deferrals.
+      for (let advanced = 0; advanced < 20_000; advanced += 50) {
+        await vi.advanceTimersByTimeAsync(50);
+      }
       await expect(running).resolves.toMatchObject({ reason: 'terminal', runStatus: 'blocked' });
       const events = readJournal(join(base, 'host-retry-budget', 'journal.ndjson'));
       expect(events.filter((event) => event.type === 'hostEffectRetryDeferred')).toHaveLength(10);


### PR DESCRIPTION
用 workflow 并行诊断 + 修复 CI 上 bun 腿的失败文件。基线取自 CI run 33592506564:
`bun test: 1016/1046 files green, 30 failing`(实核,非凭记忆)。

## 验收(独立复验,未采信 subagent 自报)

**bun 21/21 全绿**,每个都核了三件事:有 `Ran N tests` 汇总行(无汇总行=没跑完,
不能报数)、无 `killed: SIGKILL`/`OUTPUT TRUNCATED`(否则失败数只是下界)、
**实跑条数 == 声明条数**(只看「有没有 fail」会把「一条都没跑」读成「全过」)。

**vitest 21/21 条数逐位不变**:419/131/191+1skip/41/38/36/35/33/26/22/15/11/10/10/6/6/5/3/2/2/2。

**反作弊**:逐文件比对可执行 `expect(` 净变化,**无一文件断言总数减少**;
diff 里 `-expect(...)` 均为同一断言改写而非删除;timeout 未调大。

## 剩余失败是【实测】14,不是 30−21=9

跑完整 1046 文件量出来的,不是算术。拆开:

- **原 30 里仍红 9 个**:`debug-terminal`、6 个 worker/integration 类、
  `desktop-dashboard-compat`(#1179)、`write-input`(#1181)
- **原 30 之外另有 5 个**:`dashboard-launcher-supervised`、`mojo-launcher-env-quarantine`、
  `plugin-mcp-sandbox`、`session-store-bwrap`(四者今天已验 master 上 vitest 同样红,
  属 root/沙盒环境类)、以及 `whiteboard-cli`

`whiteboard-cli` 我没碰过。它的失败**与 #1179 无关**(我一度这么写,是错的:该文件的
`toMatchObject` 传的是普通字面量,没有任何 asymmetric matcher)。真实原因是它
`await import('../dist/services/whiteboard-store.js')` —— **依赖已构建产物**,而本
worktree 的 `dist` 是 08-31 打的、有 94 个 src 文件比它新。跑一次 `bun run build`
之后该文件 **12 pass 0 fail**。
⟹ 这是环境/构建新鲜度问题,不是测试或 bun 的问题;CI 每次跑都会先 build,所以 CI 上不会红。

**我修的 21 个在全量跑里全部保持绿**,无回归、无连带污染。

## ⚠️ 两个文件属「已改但无 agent 声称验证过」

`platform-bind-ip-family` / `platform-tunnel-data-bridge` 的 fix agent 中途 API 断连,
journal 只有 19 条 fixed 报告而工作区有 21 个改动。这两个我单独跑过(双 runner 均绿、
条数对得上),但「碰巧绿」≠「被验证过」——**复审请重点看这两个**。
若只读 workflow 返回值,它们会被当成「没动过」混进来。

零生产代码改动。


---
### 复审重点

1. **`platform-bind-ip-family` / `platform-tunnel-data-bridge`** —— 这两个的 fix agent 中途 API 断连，属「已改但无 agent 声称验证过」。我单独跑过（双 runner 均绿、条数对得上），但请把它们当成未复审项重点看：若只读 workflow 返回值，它们会被当成「没动过」混进来。

2. **反作弊核查** —— 我逐文件比对了可执行 `expect(` 净变化（无一文件减少）、确认 diff 里的 `-expect(...)` 都是同一断言改写而非删除、timeout 未被调大。但这是我自己做的核查，值得你独立验一遍。

3. **剩余 14 个的归属**（实测，非 30−21 算术）：原 30 里仍红 9 个（`debug-terminal` + 6 个 worker/integration + #1179 + #1181），另有 5 个原本不在 30 里——其中 4 个是本机 root/沙盒环境类（今天已验 master 上 vitest 同样红），`whiteboard-cli` 是 `dist` 过期（它 `await import('../dist/...')`，build 后即 12 pass 0 fail）。

关联：#1179（Bun toMatchObject 上游 bug）、#1181（write-input 跨用例污染）、#1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
