### PR TITLE
fix(lark-card): 移除页脚签名链接

### DIFF
--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -525,25 +525,27 @@ export function buildReplyCardFooter(opts: {
   }
   if (parts.length === 0) return null;
 
-  // The marker is a visible, versioned link that lets the parser identify a
-  // card's footer (and strip it before a bot-to-bot relay). It doubles as the
-  // first separator. But a BRAND-ONLY footer (no usage, no recipient — the
-  // common case now that usageDisplay defaults to the streaming card body and
-  // the reply-card footer is context-only) needs no marker: appending it renders
-  // a dangling "botmux ·". The default/repository brand is plain link text with
-  // no `@`, so it cannot trigger bot-to-bot pollution and does not need the
-  // ownership marker (the parser already treats a bare repo link as ordinary
-  // content, matching the long-standing "brand-only is undecidable, keep it"
-  // contract). Any footer carrying usage or a recipient is still signed.
+  // The marker lets the parser identify a card's footer (and strip it before a
+  // bot-to-bot relay). Keep it as invisible text beside the first ordinary
+  // separator: a Markdown-link marker makes Lark render the separator dot as a
+  // clickable Botmux website link. But a BRAND-ONLY footer (no usage or
+  // recipient — the common case now that usageDisplay defaults to the streaming
+  // card body and the reply-card footer is context-only) needs no marker:
+  // appending it renders a dangling "botmux ·". The default/repository brand is
+  // plain link text with no mention, so it cannot trigger bot-to-bot pollution
+  // and does not need the ownership marker (the parser already treats a bare
+  // repo link as ordinary content, matching the long-standing "brand-only is
+  // undecidable, keep it" contract). Any footer carrying usage or a recipient
+  // is still signed.
   const signMarker = hasUsage || hasRecipient;
   let signedContent: string;
   if (!signMarker) {
     signedContent = parts[0]; // brand-only — no marker
   } else if (parts.length > 1) {
-    signedContent = `${parts[0]} ${REPLY_CARD_FOOTER_MARKER} ${parts.slice(1).join(' · ')}`;
+    signedContent = `${parts[0]} ·${REPLY_CARD_FOOTER_MARKER} ${parts.slice(1).join(' · ')}`;
   } else {
     // usage-only / recipient-only (brand disabled) — still marked for parsing.
-    signedContent = `${parts[0]} ${REPLY_CARD_FOOTER_MARKER}`;
+    signedContent = `${parts[0]}${REPLY_CARD_FOOTER_MARKER}`;
   }
   const content = `<font color='grey'>${signedContent}</font>`;
   return {

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -3,6 +3,7 @@ import { getMessageDetail } from './client.js';
 import { logger } from '../../utils/logger.js';
 import {
   REPLY_CARD_FOOTER_ELEMENT_ID,
+  REPLY_CARD_FOOTER_MARKER,
   REPLY_CARD_HEADING_ELEMENT_ID_RE,
 } from './reply-card-footer-signature.js';
 import { hasBotmuxCallbackMarker } from './callback-button-marker.js';
@@ -769,9 +770,10 @@ export function extractAudioMeta(rawContent: string): { fileKey: string; duratio
 }
 
 /**
- * botmux-generated reply-card footer signature. New cards carry both a visible
- * versioned link marker and an exact element id. The canonical repository URL
- * is NOT a signature: it is valid body content. For pre-signature cards we
+ * botmux-generated reply-card footer signature. New cards carry both an
+ * invisible text marker and an exact element id. Older signed cards used a
+ * versioned link, which remains recognized for compatibility. The canonical
+ * repository URL is NOT a signature: it is valid body content. For pre-signature cards we
  * recognize only the exact old default-brand + recipient chrome shape; a
  * default-brand-only old card is intentionally preserved because it is
  * indistinguishable from an ordinary repository link.
@@ -820,9 +822,13 @@ function hasExactMarkerMarkdown(value: string): boolean {
   return false;
 }
 
+function hasCurrentFooterMarker(value: unknown): value is string {
+  return typeof value === 'string' && value.includes(REPLY_CARD_FOOTER_MARKER);
+}
+
 function isSignedFormatBFooterLine(line: string): boolean {
   const inner = greyFontInner(line);
-  return inner !== null && hasExactMarkerMarkdown(inner);
+  return inner !== null && (hasCurrentFooterMarker(inner) || hasExactMarkerMarkdown(inner));
 }
 
 /** Strict compatibility recognizer for Format A cards emitted before the
@@ -961,7 +967,14 @@ export function extractCardContent(rawContent: string, numberer?: ImgNumberer): 
           let inSignedFooter = false;
           for (const node of paragraph) {
             if (inSignedFooter) continue;
-            if (node.tag === 'text') { if (node.text) textNodes.push(node.text); }
+            if (node.tag === 'text') {
+              if (hasCurrentFooterMarker(node.text)) {
+                textNodes.push(node.text.slice(0, node.text.indexOf(REPLY_CARD_FOOTER_MARKER)));
+                inSignedFooter = true;
+                continue;
+              }
+              if (node.text) textNodes.push(node.text);
+            }
             else if (node.tag === 'a') {
               if (isBotmuxFooterMarkerAnchor(node.href, node.text)) {
                 inSignedFooter = true;
@@ -1468,8 +1481,8 @@ function extractElementText(el: any, parts: string[], imgLabel: (key: string) =>
   const tag = el.tag;
 
   // The public element id alone is not ownership proof: third-party cards may
-  // collide with it. New botmux footers carry the id plus the exact reserved
-  // marker; unexpected large text stays visible rather than being stripped.
+  // collide with it. New botmux footers carry the id plus the reserved text
+  // marker; legacy cards carry the exact reserved link marker.
   const elementText = el.text?.content ?? el.content;
   if (
     el.element_id === REPLY_CARD_FOOTER_ELEMENT_ID
@@ -1480,7 +1493,7 @@ function extractElementText(el: any, parts: string[], imgLabel: (key: string) =>
       || el.text_size === 'notation_small_v2'
     )
     && typeof elementText === 'string'
-    && hasExactMarkerMarkdown(elementText)
+    && (hasCurrentFooterMarker(elementText) || hasExactMarkerMarkdown(elementText))
   ) {
     return;
   }

--- a/src/im/lark/reply-card-footer-signature.ts
+++ b/src/im/lark/reply-card-footer-signature.ts
@@ -1,9 +1,13 @@
 /** Identity shared by reply-card producers and the card parser. Current cards
- * use an invisible text sentinel; the URL remains for parsing legacy cards. */
+ * use a multi-code-point invisible text sentinel. A single invisible separator
+ * can occur in ordinary text, so it is not sufficiently specific on its own.
+ *
+ * This differs from the historical zero-width Markdown link: Lark could drop
+ * that link while simplifying a card, whereas U+2063 plain text survives the
+ * round trip. Repeating the known-surviving character keeps the marker hidden
+ * while making an accidental match in user-authored text vanishingly unlikely. */
 export const REPLY_CARD_FOOTER_ELEMENT_ID = 'botmux_reply_footer';
-export const REPLY_CARD_FOOTER_MARKER_URL =
-  'https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1';
-export const REPLY_CARD_FOOTER_MARKER = '\u2063';
+export const REPLY_CARD_FOOTER_MARKER = '\u2063\u2063\u2063\u2063';
 
 /** Promoted H1/H2 heading widgets encode their original ATX level in the
  * element id. Lark strips `text_size` when a message is read back, so the id

--- a/src/im/lark/reply-card-footer-signature.ts
+++ b/src/im/lark/reply-card-footer-signature.ts
@@ -1,11 +1,9 @@
-/** Versioned identity shared by reply-card producers and the card parser.
- * The marker uses visible link text because Lark may discard zero-width links
- * while simplifying a card into Format A. */
+/** Identity shared by reply-card producers and the card parser. Current cards
+ * use an invisible text sentinel; the URL remains for parsing legacy cards. */
 export const REPLY_CARD_FOOTER_ELEMENT_ID = 'botmux_reply_footer';
 export const REPLY_CARD_FOOTER_MARKER_URL =
   'https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1';
-export const REPLY_CARD_FOOTER_MARKER =
-  `[·](${REPLY_CARD_FOOTER_MARKER_URL})`;
+export const REPLY_CARD_FOOTER_MARKER = '\u2063';
 
 /** Promoted H1/H2 heading widgets encode their original ATX level in the
  * element id. Lark strips `text_size` when a message is read back, so the id

--- a/test/md-card.test.ts
+++ b/test/md-card.test.ts
@@ -1207,14 +1207,18 @@ describe('buildReplyCardFooter', () => {
     expect(footer?.content).not.toContain('github.com/deepcoldy/bot%6Dux');
   });
 
-  it('signs a recipient-only footer with non-link text', () => {
+  it('does not render a separator or link when brand is disabled and only recipient remains', () => {
     const footer = buildReplyCardFooter({
       brand: '',
       recipientOpenIds: ['ou_abc'],
     });
     expect(footer?.content).toContain('⁣');
     expect(footer?.content).not.toContain('github.com/deepcoldy/bot%6Dux');
+    expect(footer?.content).not.toContain('·');
     expect(footer?.content).toContain('<at id=ou_abc></at>');
+    expect(footer?.content.replace('⁣', '')).toBe(
+      "<font color='grey'>发送给：<at id=ou_abc></at></font>",
+    );
   });
 
   it('signs a default-brand + usage footer with a plain separator', () => {

--- a/test/md-card.test.ts
+++ b/test/md-card.test.ts
@@ -1081,10 +1081,11 @@ describe('buildReplyCardFooter', () => {
     });
 
     expect(footer?.content).toContain(
-      'Acme [·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1) '
+      'Acme ·⁣ '
       + '上下文 12.3K · '
       + '发送给：<at id=ou_owner></at> <at id=ou_reviewer></at>',
     );
+    expect(footer?.content).not.toContain('github.com/deepcoldy/bot%6Dux');
     // Footer is context-only — the cumulative token line does not appear here.
     expect(footer?.content).not.toContain('Token');
     expect(footer?.content).not.toContain('\u200B');
@@ -1114,9 +1115,7 @@ describe('buildReplyCardFooter', () => {
       element_id: 'botmux_reply_footer',
     });
     expect(card.body.elements.at(-1).content).toContain('Sent to: <at id=ou_owner></at>');
-    expect(card.body.elements.at(-1).content).toContain(
-      '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)',
-    );
+    expect(card.body.elements.at(-1).content).not.toContain('github.com/deepcoldy/bot%6Dux');
   });
 
   it('rejects caller-supplied cards without schema-2 body elements', () => {
@@ -1199,35 +1198,32 @@ describe('buildReplyCardFooter', () => {
     );
   });
 
-  it('still signs a usage-only footer (brand disabled) with the versioned marker', () => {
+  it('signs a usage-only footer with non-link text', () => {
     const footer = buildReplyCardFooter({
       brand: '', // brand off
       usage: { context: { usedTokens: 5_000, windowTokens: 200_000, percentUsed: 2.5 }, tokens: null, turnTokens: null },
     });
-    expect(footer?.content).toContain(
-      '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)',
-    );
+    expect(footer?.content).toContain('⁣');
+    expect(footer?.content).not.toContain('github.com/deepcoldy/bot%6Dux');
   });
 
-  it('still signs a recipient-only footer (brand disabled) with the versioned marker', () => {
+  it('signs a recipient-only footer with non-link text', () => {
     const footer = buildReplyCardFooter({
       brand: '',
       recipientOpenIds: ['ou_abc'],
     });
-    expect(footer?.content).toContain(
-      '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)',
-    );
+    expect(footer?.content).toContain('⁣');
+    expect(footer?.content).not.toContain('github.com/deepcoldy/bot%6Dux');
     expect(footer?.content).toContain('<at id=ou_abc></at>');
   });
 
-  it('signs a default-brand + usage footer (marker as the first separator)', () => {
+  it('signs a default-brand + usage footer with a plain separator', () => {
     const footer = buildReplyCardFooter({
       usage: { context: { usedTokens: 5_000, windowTokens: 200_000, percentUsed: 2.5 }, tokens: null, turnTokens: null },
     });
     expect(footer?.content).toContain(DEFAULT_BRAND_LABEL);
-    expect(footer?.content).toContain(
-      '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)',
-    );
+    expect(footer?.content).toContain(`${DEFAULT_BRAND_LABEL} ·⁣ 上下文 5K/200K (3%)`);
+    expect(footer?.content).not.toContain('github.com/deepcoldy/bot%6Dux');
   });
 });
 

--- a/test/md-card.test.ts
+++ b/test/md-card.test.ts
@@ -26,6 +26,7 @@ import {
   extractFirstReplyCardHeading,
   hasMarkdown,
   normalizeLocalHomeLinks,
+  REPLY_CARD_FOOTER_MARKER,
 } from '../src/im/lark/md-card.js';
 
 function mdElements(out: any[]): Array<{ tag: 'markdown'; content: string }> {
@@ -1081,7 +1082,7 @@ describe('buildReplyCardFooter', () => {
     });
 
     expect(footer?.content).toContain(
-      'Acme ·⁣ '
+      `Acme ·${REPLY_CARD_FOOTER_MARKER} `
       + '上下文 12.3K · '
       + '发送给：<at id=ou_owner></at> <at id=ou_reviewer></at>',
     );
@@ -1216,7 +1217,7 @@ describe('buildReplyCardFooter', () => {
     expect(footer?.content).not.toContain('github.com/deepcoldy/bot%6Dux');
     expect(footer?.content).not.toContain('·');
     expect(footer?.content).toContain('<at id=ou_abc></at>');
-    expect(footer?.content.replace('⁣', '')).toBe(
+    expect(footer?.content.replaceAll(REPLY_CARD_FOOTER_MARKER, '')).toBe(
       "<font color='grey'>发送给：<at id=ou_abc></at></font>",
     );
   });
@@ -1226,7 +1227,9 @@ describe('buildReplyCardFooter', () => {
       usage: { context: { usedTokens: 5_000, windowTokens: 200_000, percentUsed: 2.5 }, tokens: null, turnTokens: null },
     });
     expect(footer?.content).toContain(DEFAULT_BRAND_LABEL);
-    expect(footer?.content).toContain(`${DEFAULT_BRAND_LABEL} ·⁣ 上下文 5K/200K (3%)`);
+    expect(footer?.content).toContain(
+      `${DEFAULT_BRAND_LABEL} ·${REPLY_CARD_FOOTER_MARKER} 上下文 5K/200K (3%)`,
+    );
     expect(footer?.content).not.toContain('github.com/deepcoldy/bot%6Dux');
   });
 });

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -915,6 +915,37 @@ describe('Interactive card parsing: botmux footer is stripped from prompt', () =
 // ─── Structural footer strip (brand-agnostic, for per-bot custom brands) ──
 
 describe('Interactive card parsing: footer stripped structurally (custom brand)', () => {
+  it('drops a current footer carrying the non-link text marker', () => {
+    const footer = buildReplyCardFooter({
+      brand: 'Acme',
+      recipientOpenIds: ['ou_owner'],
+    })!;
+    expect(footer.content).not.toContain('github.com/deepcoldy/bot%6Dux');
+
+    const card = {
+      schema: '2.0',
+      body: { elements: [
+        { tag: 'markdown', content: '正文内容' },
+        { tag: 'hr' },
+        footer.element,
+      ] },
+    };
+    expect(parseApiMessage(makeMsg('interactive', card)).content).toBe('正文内容');
+  });
+
+  it('drops the current text marker after Lark simplifies the card to Format A', () => {
+    const card = {
+      elements: [
+        [{ tag: 'text', text: '正文内容' }],
+        [
+          { tag: 'text', text: 'Acme ·⁣ 上下文 12.3K · 发送给：' },
+          { tag: 'at', user_name: 'Owner' },
+        ],
+      ],
+    };
+    expect(parseApiMessage(makeMsg('interactive', card)).content).toBe('正文内容');
+  });
+
   it.each([
     { name: 'without text_size', textSize: undefined },
     { name: 'with Card 2.0 notation', textSize: 'notation' },

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -7,8 +7,8 @@
  * Run:  pnpm vitest run test/message-parser.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { parseApiMessage, extractResources, parseEventMessage, stripLeadingMentions, createImgNumberer, cardContentHasUpgradeFallback, isPureCardUpgradeFallback, mergeCardText, wrapResolvedCardText, mentionOpenId, messageMentionsBot, extractPostAtParticipants, extractAudioMeta, AUDIO_PLACEHOLDER, CARD_EMBEDDED_PLACEHOLDER } from '../src/im/lark/message-parser.js';
-import { buildMarkdownCard, buildReplyCardFooter } from '../src/im/lark/md-card.js';
+import { parseApiMessage, extractCardContent, extractResources, parseEventMessage, stripLeadingMentions, createImgNumberer, cardContentHasUpgradeFallback, isPureCardUpgradeFallback, mergeCardText, wrapResolvedCardText, mentionOpenId, messageMentionsBot, extractPostAtParticipants, extractAudioMeta, AUDIO_PLACEHOLDER, CARD_EMBEDDED_PLACEHOLDER } from '../src/im/lark/message-parser.js';
+import { buildMarkdownCard, buildReplyCardFooter, REPLY_CARD_FOOTER_MARKER } from '../src/im/lark/md-card.js';
 import { stampBotmuxCallbackMarkers, hasBotmuxCallbackMarker, BOTMUX_CALLBACK_MARKER_KEY } from '../src/im/lark/callback-button-marker.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -671,6 +671,30 @@ describe('Interactive card parsing: botmux footer is stripped from prompt', () =
     expect(result.content).not.toContain('发送给');
   });
 
+  it('keeps a grey body line containing one U+2063 separator', () => {
+    const bodyLine = "<font color='grey'>注：U+2063 写作 a\u2063b</font>";
+    const raw = buildMarkdownCard(
+      ['结论如下', '', bodyLine, '', '请据此推进'].join('\n'),
+      'ou_owner',
+    );
+    const textB = extractCardContent(raw);
+    const result = mergeCardText(textB, textB);
+
+    expect(result).toContain('结论如下');
+    expect(result).toContain(bodyLine);
+    expect(result).toContain('请据此推进');
+    expect(result).not.toContain('发送给');
+  });
+
+  it('keeps a non-grey body line containing the full footer marker', () => {
+    const bodyLine = `正文包含不可见序列 a${REPLY_CARD_FOOTER_MARKER}b`;
+    const card = {
+      body: { elements: [{ tag: 'markdown', content: bodyLine }] },
+    };
+
+    expect(parseApiMessage(makeMsg('interactive', card)).content).toContain(bodyLine);
+  });
+
   it('round-trips standalone reply headings without losing section text', () => {
     const raw = buildMarkdownCard(
       '# 执行结果\n\n核心链路已验证。\n\n## 下一步\n\n请在飞书确认排版。',
@@ -938,12 +962,25 @@ describe('Interactive card parsing: footer stripped structurally (custom brand)'
       elements: [
         [{ tag: 'text', text: '正文内容' }],
         [
-          { tag: 'text', text: 'Acme ·⁣ 上下文 12.3K · 发送给：' },
+          { tag: 'text', text: `Acme ·${REPLY_CARD_FOOTER_MARKER} 上下文 12.3K · 发送给：` },
           { tag: 'at', user_name: 'Owner' },
         ],
       ],
     };
     expect(parseApiMessage(makeMsg('interactive', card)).content).toBe('正文内容');
+  });
+
+  it('keeps Format A body text containing only one U+2063 separator', () => {
+    const card = {
+      elements: [[
+        { tag: 'text', text: '正文 a\u2063b' },
+        { tag: 'text', text: ' 后续正文' },
+      ]],
+    };
+
+    expect(parseApiMessage(makeMsg('interactive', card)).content).toBe(
+      '正文 a\u2063b 后续正文',
+    );
   });
 
   it('drops a brand-disabled recipient-only footer without requiring a visible separator', () => {

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -946,6 +946,23 @@ describe('Interactive card parsing: footer stripped structurally (custom brand)'
     expect(parseApiMessage(makeMsg('interactive', card)).content).toBe('正文内容');
   });
 
+  it('drops a brand-disabled recipient-only footer without requiring a visible separator', () => {
+    const footer = buildReplyCardFooter({
+      brand: '',
+      recipientOpenIds: ['ou_owner'],
+    })!;
+    expect(footer.content).not.toContain('·');
+
+    const card = {
+      body: { elements: [
+        { tag: 'markdown', content: '正文内容' },
+        { tag: 'hr' },
+        footer.element,
+      ] },
+    };
+    expect(parseApiMessage(makeMsg('interactive', card)).content).toBe('正文内容');
+  });
+
   it.each([
     { name: 'without text_size', textSize: undefined },
     { name: 'with Card 2.0 notation', textSize: 'notation' },


### PR DESCRIPTION
## 问题

`brandLabel` 设为空时，回复卡片仍会显示一个可点击的分隔点。原因是 footer 为了让历史消息解析器识别页脚，有意用 Markdown 链接承载内部签名；在空品牌、仅有“发送给”时，这个签名点单独暴露，并指向 Botmux 仓库。

## 修复

- 将新卡片的页脚签名改为不可点击的文本哨兵。
- 空品牌、仅收件人 footer 不再渲染分隔点或链接，只显示“发送给”。
- 有多个可见 footer 分段时仍保留普通分隔点外观，但分隔点不可点击。
- 解析器同时支持新的文本签名和旧的链接签名，历史卡片仍可正确过滤页脚。
- 覆盖原始 schema 2.0 卡片、飞书简化后的 Format A，以及嵌套 footer 场景。

## 影响面

仅影响 Bot Session 回复卡片的页脚生成与历史卡片文本解析；不改变消息路由、权限或正文链接处理。

## 验证

- `bun x vitest run test/md-card.test.ts test/message-parser.test.ts`：287 passed
- `bun x vitest run test/daemon-rename-route.test.ts test/message-listener.test.ts`：111 passed
- `bun x tsc --noEmit --pretty false`：通过
- `git diff --check`：通过