### PR TITLE
fix(claude-hook): 去重识别改用子命令签名，覆盖打包二进制命令

### DIFF
--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -111,13 +111,27 @@ function botmuxHookSuffix(hookCommand: string): string {
  * ⚠️ 旧实现用 `command.includes('cli.js')` 来识别 botmux hook——这在 Node 态成立
  * （命令是 `"<node>" "<...>/dist/cli.js" <subcommand>`），但**编译态（单文件二进制）**
  * 下 `renderShellCommand` 写的是打包二进制路径 `"<...>/botmux-linux-x64/botmux" <subcommand>`，
- * 根本不含 `cli.js`。旧判据因此把已装 hook 误判为「未安装」，三条去重全部失效、重复追加，
- * 最终在 settings.json 里堆出重复 hook。
+ * 根本不含 `cli.js`。旧判据因此把已装 hook 误判为「未安装」。
+ *
+ * 后果分两种，别记成「三条一起失效」（实测口径）：
+ *   - `session-ready` / `user-prompt-hook`：**每次安装都追加一条**。而 installHook 在
+ *     read-isolation 路径下**每次冷 spawn 都会跑**（worker.ts `provisionIsolatedBotHome`），
+ *     所以编译态盒子每开一个会话就 +1、无上限；已堆坏的盒子再装一次只会继续涨。
+ *   - ask（`hook <cliId>`）：**通常不叠**——`isBotmuxAskHookGroup` 还有一条
+ *     `e.command === hookCommand` 精确匹配分支，命令字符串不变时由它兜住；只有命令
+ *     形态发生变化（如二进制↔Node 互切）时才会叠加。
  *
  * 稳定、与运行时形态无关的信号是 **子命令尾签名**（`hook <cliId>` / `session-ready` /
  * `user-prompt-hook`），加上调用目标名：Node 态是脚本 `cli.js`，编译态是可执行文件
  * `botmux`（`botmux-linux-x64/botmux` 的 basename 同为 `botmux`；Windows 上为 `botmux.exe`）。
  * 两者取其一即视为同一条 botmux hook，无论它指向哪个安装路径、由 node 还是打包二进制执行。
+ *
+ * ⚠️ basename 白名单**故意只认这三个字面量**，不要放宽成 `botmux-*` 前缀匹配：那会把
+ * 第三方同前缀程序（`botmux-helper` / `botmux-wrapper` 等）也当成自己的 hook 删掉。
+ * 已知未覆盖形态：本地 `bun run use:here --binary` 指向的 `dist-bin/botmux-<plat>-<arch>`
+ * （basename 带平台后缀）。生产两条安装路径都落在 `botmux` 上（npm 平台子包
+ * `…/node_modules/botmux-<plat>-<arch>/botmux`、install.sh 的 `~/.botmux/bin/botmux`），
+ * 故仅影响开发机；真要覆盖须**枚举死平台后缀**而非放宽为任意后缀。
  */
 function isBotmuxHookCommand(command: string, suffix: string): boolean {
   const trimmed = command.trimEnd();

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -106,21 +106,46 @@ function botmuxHookSuffix(hookCommand: string): string {
 }
 
 /**
+ * 判断一条命令字符串是否是「botmux 自己发起的 hook 调用」。
+ *
+ * ⚠️ 旧实现用 `command.includes('cli.js')` 来识别 botmux hook——这在 Node 态成立
+ * （命令是 `"<node>" "<...>/dist/cli.js" <subcommand>`），但**编译态（单文件二进制）**
+ * 下 `renderShellCommand` 写的是打包二进制路径 `"<...>/botmux-linux-x64/botmux" <subcommand>`，
+ * 根本不含 `cli.js`。旧判据因此把已装 hook 误判为「未安装」，三条去重全部失效、重复追加，
+ * 最终在 settings.json 里堆出重复 hook。
+ *
+ * 稳定、与运行时形态无关的信号是 **子命令尾签名**（`hook <cliId>` / `session-ready` /
+ * `user-prompt-hook`），加上调用目标名：Node 态是脚本 `cli.js`，编译态是可执行文件
+ * `botmux`（`botmux-linux-x64/botmux` 的 basename 同为 `botmux`；Windows 上为 `botmux.exe`）。
+ * 两者取其一即视为同一条 botmux hook，无论它指向哪个安装路径、由 node 还是打包二进制执行。
+ */
+function isBotmuxHookCommand(command: string, suffix: string): boolean {
+  const trimmed = command.trimEnd();
+  if (!trimmed.endsWith(suffix)) return false;
+  // 子命令之前紧邻的是调用目标（脚本/可执行名），去掉可能包裹它的尾部引号。
+  const target = trimmed.slice(0, trimmed.length - suffix.length).trimEnd().replace(/["']+$/, '');
+  if (!target) return false;
+  const slash = Math.max(target.lastIndexOf('/'), target.lastIndexOf('\\'));
+  const basename = target.slice(slash + 1);
+  return basename === 'cli.js' || basename === 'botmux' || basename === 'botmux.exe';
+}
+
+/**
  * 判断某个 hook group 是否是 botmux ask hook（用于幂等替换）。
  *
  * 不能只按命令字符串完全相等比对：同一台机器上 dev 源码 checkout 与 npm global
  * 安装的 cli.js 绝对路径不同，命令字符串就不同，会导致两条 botmux hook 同时残留、
  * 同一次 AskUserQuestion 触发两次 → 飞书发出两张卡。
- * 因此结构化识别：命令引用了 botmux 的 `cli.js` 且尾部是相同的 `hook <cliId>` 签名，
- * 即视为 botmux hook，无论它指向哪个安装路径。
+ * 因此结构化识别：命令是 botmux 自己发起的调用（cli.js 脚本或打包二进制 `botmux`）、
+ * 且尾部是相同的 `hook <cliId>` 签名，即视为 botmux hook，无论它指向哪个安装路径、
+ * 由 node 还是打包二进制执行。
  */
 function isBotmuxAskHookGroup(group: ClaudeHookGroup, hookCommand: string): boolean {
   const suffix = botmuxHookSuffix(hookCommand); // e.g. "hook claude-code"
   return group.hooks.some(
     (e) =>
       e.type === 'command' &&
-      (e.command === hookCommand ||
-        (e.command.includes('cli.js') && e.command.trimEnd().endsWith(suffix))),
+      (e.command === hookCommand || isBotmuxHookCommand(e.command, suffix)),
   );
 }
 
@@ -143,8 +168,7 @@ function isBotmuxTraexAskHookEntry(entry: unknown): boolean {
     && typeof entry === 'object'
     && (entry as ClaudeHookEntry).type === 'command'
     && typeof (entry as ClaudeHookEntry).command === 'string'
-    && (entry as ClaudeHookEntry).command.includes('cli.js')
-    && (entry as ClaudeHookEntry).command.trimEnd().endsWith('hook traex');
+    && isBotmuxHookCommand((entry as ClaudeHookEntry).command, 'hook traex');
 }
 
 /**
@@ -192,7 +216,7 @@ export function cleanupTraexAskHooks(configPaths: readonly string[]): void {
 
 /**
  * 判断某 hook group 是否是 botmux SessionStart 就绪 hook（用于幂等替换）。
- * 同 ask hook：结构化识别（命令引用 botmux 的 cli.js 且尾部是 `session-ready`），
+ * 同 ask hook：结构化识别（命令是 botmux 自己发起的调用且尾部是 `session-ready`），
  * 不按完整字符串比对——dev checkout 与 npm global 的 cli.js 绝对路径不同。
  */
 function isBotmuxReadyHookGroup(group: ClaudeHookGroup): boolean {
@@ -201,8 +225,7 @@ function isBotmuxReadyHookGroup(group: ClaudeHookGroup): boolean {
       !!e &&
       e.type === 'command' &&
       typeof e.command === 'string' &&
-      e.command.includes('cli.js') &&
-      e.command.trimEnd().endsWith('session-ready'),
+      isBotmuxHookCommand(e.command, 'session-ready'),
   );
 }
 
@@ -215,7 +238,7 @@ function removeBotmuxReadyHookGroups(hooks: Record<string, ClaudeHookGroup[]>, e
 
 /**
  * 判断某 hook group 是否是 botmux UserPromptSubmit 上下文 hook（用于幂等替换）。
- * 与 ready hook 同策略：结构化识别（命令引用 botmux 的 cli.js 且尾部是
+ * 与 ready hook 同策略：结构化识别（命令是 botmux 自己发起的调用且尾部是
  * `user-prompt-hook`），不按完整字符串比对。
  */
 function isBotmuxPromptHookGroup(group: ClaudeHookGroup): boolean {
@@ -224,8 +247,7 @@ function isBotmuxPromptHookGroup(group: ClaudeHookGroup): boolean {
       !!e &&
       e.type === 'command' &&
       typeof e.command === 'string' &&
-      e.command.includes('cli.js') &&
-      e.command.trimEnd().endsWith('user-prompt-hook'),
+      isBotmuxHookCommand(e.command, 'user-prompt-hook'),
   );
 }
 

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -227,6 +227,59 @@ describe('installHook — claude-settings', () => {
     expect(ups.some((g) => g.hooks?.some((e: any) => e.command.endsWith('user-prompt-hook')))).toBe(true);
   });
 
+  it('(i2) 打包二进制命令（不含 cli.js）在重装时被去重，不重复追加', () => {
+    // 编译态单文件二进制写入的命令是打包二进制路径，根本不含 cli.js。
+    // 旧判据 `command.includes('cli.js')` 会把它永远误判为「未安装」，每次叠加一条。
+    const binAsk = '"/opt/botmux/node_modules/botmux-linux-x64/botmux" hook claude-code';
+    const binReady = '"/opt/botmux/node_modules/botmux-linux-x64/botmux" session-ready';
+    const binPrompt = '"/opt/botmux/node_modules/botmux-linux-x64/botmux" user-prompt-hook';
+
+    const hookInstall = {
+      configPath,
+      format: 'claude-settings' as const,
+      sessionStartCommand: binReady,
+      userPromptSubmitCommand: binPrompt,
+    };
+    installHook('claude-code', hookInstall, binAsk);
+    const afterFirst = readFileSync(configPath, 'utf-8');
+
+    // 再装一次（幂等），内容与首次完全一致 → 说明三条去重都认出了二进制命令
+    installHook('claude-code', hookInstall, binAsk);
+    const afterSecond = readFileSync(configPath, 'utf-8');
+    expect(afterSecond).toBe(afterFirst);
+
+    const settings = JSON.parse(afterFirst);
+    const asks: any[] = settings.hooks?.PreToolUse ?? [];
+    const askGroups = asks.filter((g) => g.matcher === 'AskUserQuestion');
+    expect(askGroups.length).toBe(1);
+    expect(askGroups[0].hooks[0].command).toBe(binAsk);
+
+    const ss: any[] = settings.hooks?.SessionStart ?? [];
+    expect(ss).toHaveLength(1);
+    expect(ss[0].hooks[0].command).toBe(binReady);
+
+    const ups: any[] = settings.hooks?.UserPromptSubmit ?? [];
+    expect(ups).toHaveLength(1);
+    expect(ups[0].hooks[0].command).toBe(binPrompt);
+
+    // preflight 也应认出二进制命令
+    expect(hasInstalledPromptHook(hookInstall)).toBe(true);
+  });
+
+  it('(i3) 打包二进制命令替换旧的 Node cli.js 命令（同一条 hook，两种形态互相去重）', () => {
+    const binAsk = '"/opt/botmux/node_modules/botmux-linux-x64/botmux" hook claude-code';
+    // 先装 Node 态（含 cli.js）
+    installHook('claude-code', { configPath, format: 'claude-settings' }, '/usr/bin/node /path/to/cli.js hook claude-code');
+    // 再用打包二进制命令重装，应替换旧的而非叠加
+    installHook('claude-code', { configPath, format: 'claude-settings' }, binAsk);
+
+    const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const asks: any[] = settings.hooks?.PreToolUse ?? [];
+    const askGroups = asks.filter((g) => g.matcher === 'AskUserQuestion');
+    expect(askGroups.length).toBe(1);
+    expect(askGroups[0].hooks[0].command).toBe(binAsk);
+  });
+
   it('read-isolation inherits only the global Claude env map and refreshes rotated auth', () => {
     const globalPath = join(tmpDir, '.claude-global', 'settings.json');
     mkdirSync(join(tmpDir, '.claude-global'), { recursive: true });

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -266,18 +266,59 @@ describe('installHook — claude-settings', () => {
     expect(hasInstalledPromptHook(hookInstall)).toBe(true);
   });
 
-  it('(i3) 打包二进制命令替换旧的 Node cli.js 命令（同一条 hook，两种形态互相去重）', () => {
+  it('(i3) Node cli.js 命令替换旧的打包二进制命令（两种形态互相去重）', () => {
+    // ⚠️ 方向很重要：这里必须 **先装二进制、再装 Node**。
+    // 反过来（先 Node 后二进制）旧判据 `includes('cli.js')` 也能认出被替换的旧条目
+    // （它含 cli.js），那条用例在**未修复的代码上照样绿** —— 测不到本次修复。
+    // 只有本方向能打死旧判据：旧条目是二进制命令、不含 cli.js，旧判据认不出 →
+    // 不删旧的、直接追加 → PreToolUse 变 2 条（实测 master 如此）。
     const binAsk = '"/opt/botmux/node_modules/botmux-linux-x64/botmux" hook claude-code';
-    // 先装 Node 态（含 cli.js）
-    installHook('claude-code', { configPath, format: 'claude-settings' }, '/usr/bin/node /path/to/cli.js hook claude-code');
-    // 再用打包二进制命令重装，应替换旧的而非叠加
+    const nodeAsk = '/usr/bin/node /path/to/cli.js hook claude-code';
+    // 先装编译态（不含 cli.js）
     installHook('claude-code', { configPath, format: 'claude-settings' }, binAsk);
+    // 再用 Node 态命令重装，应替换旧的而非叠加
+    installHook('claude-code', { configPath, format: 'claude-settings' }, nodeAsk);
 
     const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
     const asks: any[] = settings.hooks?.PreToolUse ?? [];
     const askGroups = asks.filter((g) => g.matcher === 'AskUserQuestion');
     expect(askGroups.length).toBe(1);
-    expect(askGroups[0].hooks[0].command).toBe(binAsk);
+    expect(askGroups[0].hooks[0].command).toBe(nodeAsk);
+  });
+
+  it('(i4) 已堆叠的重复条目在一次安装后收敛为单条（存量自愈）', () => {
+    // 线上失效形态不是「装两次多一条」，而是 installHook 在 read-isolation 路径下
+    // **每次冷 spawn 都跑**（worker.ts provisionIsolatedBotHome），编译态盒子每开一个
+    // 会话就 +1、无上限。所以真正要守的性质是：**已经堆坏的 settings.json，装一次就收敛回 1**。
+    // 实测未修复的代码在此场景下不仅不收敛，还会继续叠（5 条 → 6 条）。
+    const bin = '/opt/botmux/node_modules/botmux-linux-x64/botmux';
+    const binAsk = `"${bin}" hook claude-code`;
+    const binReady = `"${bin}" session-ready`;
+    const binPrompt = `"${bin}" user-prompt-hook`;
+
+    // 预置一份已经堆了 5 条重复 botmux 条目的 settings.json（模拟存量机器）
+    const stacked = (cmd: string) => Array.from({ length: 5 }, () => ({ hooks: [{ type: 'command', command: cmd }] }));
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      hooks: {
+        PreToolUse: Array.from({ length: 5 }, () => ({ matcher: 'AskUserQuestion', hooks: [{ type: 'command', command: binAsk }] })),
+        SessionStart: stacked(binReady),
+        UserPromptSubmit: stacked(binPrompt),
+      },
+    }, null, 2));
+
+    installHook('claude-code', {
+      configPath,
+      format: 'claude-settings',
+      sessionStartCommand: binReady,
+      userPromptSubmitCommand: binPrompt,
+    }, binAsk);
+
+    const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const askGroups = (settings.hooks?.PreToolUse ?? []).filter((g: any) => g.matcher === 'AskUserQuestion');
+    expect(askGroups).toHaveLength(1);
+    expect(settings.hooks?.SessionStart ?? []).toHaveLength(1);
+    expect(settings.hooks?.UserPromptSubmit ?? []).toHaveLength(1);
   });
 
   it('read-isolation inherits only the global Claude env map and refreshes rotated auth', () => {


### PR DESCRIPTION
## 改了什么

修复 Claude 家族 hook 去重逻辑在**打包二进制（单文件编译）形态**下失效、导致 `~/.claude/settings.json` 中 hook 重复叠加的问题。

## 根因

三条 hook 去重识别（PreToolUse `hook <cliId>` / SessionStart `session-ready` / UserPromptSubmit `user-prompt-hook`）都把「botmux 自己的 hook」等同于「命令里含 `cli.js`」。

而编译态（打包二进制）实际写入的命令是 `.../node_modules/botmux-linux-x64/botmux <子命令>`，**根本不含 `cli.js`**，于是旧判据把它误判为「未安装」。

**后果分两种**（实测口径，此前描述写成「三条全部失效」并不准确）：

- **`session-ready` / `user-prompt-hook`：每次安装都追加一条。** 而 `installHook` 在 read-isolation 路径下**每次冷 spawn 都会跑**（`worker.ts` `provisionIsolatedBotHome`），所以编译态盒子**每开一个会话就 +1、无上限**；已经堆坏的盒子再装一次只会继续涨（实测 5 条 → 6 条）。
- **ask（`hook <cliId>`）：通常不叠。** `isBotmuxAskHookGroup` 还有一条 `e.command === hookCommand` 精确匹配分支兜底，命令字符串不变时由它救住；只有命令形态发生变化（二进制 ↔ Node 互切）时才会叠加。

重复 hook 会导致同一次事件触发多次（如重复 AskUserQuestion 卡片）。

## 修复

在 `src/adapters/hook-installer.ts` 新增与运行时形态无关的 `isBotmuxHookCommand(command, suffix)`：

- 按**子命令尾签名**（`hook <cliId>` / `session-ready` / `user-prompt-hook`）识别；
- 调用目标 basename 是 `cli.js`（Node 态脚本）或 `botmux` / `botmux.exe`（打包二进制）即视为同一条 botmux hook；
- Node 态与编译态、dev checkout 与 npm global 之间互相去重。

四条调用点（ask / ready / prompt 三个谓词 + TRAE legacy 清理 `isBotmuxTraexAskHookEntry`）统一改走此判据。

**basename 白名单故意只认三个字面量**，不放宽成 `botmux-*` 前缀匹配——那会把第三方同前缀程序（`botmux-helper` / `botmux-wrapper` 等）也当成自己的 hook 删掉。已知未覆盖形态：本地 `bun run use:here --binary` 指向的 `dist-bin/botmux-<plat>-<arch>`（basename 带平台后缀）。生产两条安装路径都落在 `botmux` 上（npm 平台子包 `…/node_modules/botmux-<plat>-<arch>/botmux`、install.sh 的 `~/.botmux/bin/botmux`），故仅影响开发机；真要覆盖须**枚举死平台后缀**而非放宽为任意后缀。

## 影响面

仅影响 Claude 家族 `claude-settings` hook 的幂等去重识别与 TRAE legacy hook 清理，**不改变 hook 的实际写入命令与内容**。

- `claude-settings` 格式仅 Claude 家族（claude-code / seed / relay，经 `createClaudeFamilyAdapter`）使用；OpenCode 插件走 argv parts + 整文件内容幂等、Grok 整文件覆写，均不经过这些谓词，不受影响。
- TRAE 的 `cleanupTraexAskHooks`：旧 node 态条目（basename `cli.js` + 尾 `hook traex`）新判据仍认得，清理行为不变。
- 升级后的行为变化（非回归）：此前编译态盒子的 prompt preflight 恒为 false → 走 inline；修复后切回 hook 模式，与 Node 态盒子行为对齐。

## 测试

`bun test test/hook-installer.test.ts` → 27 pass / 0 fail；hook 相关 10 个测试文件 149 pass / 0 fail；`bun run build`、`tsc --noEmit` 均通过。

新增三条回归用例：

- `(i2)`：打包二进制命令（不含 `cli.js`）三事件二次安装幂等、不重复追加，preflight 正确返回 true。
- `(i3)`：**先装二进制、再装 Node `cli.js` 命令**，两种形态互相去重只留一条。方向是刻意选的——反过来（先 Node 后二进制）时被替换的旧条目含 `cli.js`，旧判据本来就认得，那个方向在未修复的代码上照样绿、测不到本次修复。
- `(i4)`：**存量自愈**——预置 5 条重复条目，装一次后三个事件各收敛为单条。守的是这个修复对线上存量机器最直接的价值（未修复时该场景不仅不收敛，还会继续叠）。

**反变异验证**：把 `isBotmuxHookCommand` 换回旧实现 `includes('cli.js')`，`(i2)`/`(i3)`/`(i4)` 三条全部转红，确认均非惰性用例。

**命令形态探针**（13 种）：npm 平台子包、curl 安装、musl、Node `dist/cli.js`、路径含空格、单/双引号、不加引号、Windows `.exe` 共 9 种正确识别；`dist-bin` 开发形态、用户自有 hook、basename 形似的第三方程序（`botmux-helper`）、外部 sh-wrapped hook 共 4 种正确不误伤。
