### PR TITLE
 fix(dsh-tui): 修复多行输入被拆成多轮

### DIFF
--- a/src/adapters/cli/dsh-tui.ts
+++ b/src/adapters/cli/dsh-tui.ts
@@ -6,6 +6,15 @@ import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+const BRACKETED_PASTE_START = '\x1b[200~';
+const BRACKETED_PASTE_END = '\x1b[201~';
+
+function sendBracketedPaste(pty: PtyHandle, content: string): boolean {
+  const framed = `${BRACKETED_PASTE_START}${content}${BRACKETED_PASTE_END}`;
+  if (pty.sendText) return pty.sendText(framed) !== false;
+  return pty.write(framed) !== false;
+}
+
 /**
  * dsh-tui adapter — PTY-driven full-screen TUI for DeepSeek Harness.
  *
@@ -72,21 +81,18 @@ export function createDshTuiAdapter(pathOverride?: string): CliAdapter {
       // Botmux prompts are often multiline, so inject them as bracketed paste
       // and press Enter exactly once after the whole draft is in the composer.
       try {
+        // Emit the markers ourselves instead of relying on backend pasteText():
+        // tmux/zellij wrap pasteText correctly, but herdr's pasteText is only a
+        // literal write. One explicit wire format keeps every backend equivalent.
+        const pasted = sendBracketedPaste(pty, content);
+        if (!pasted) return { submitted: false };
+
         if (pty.sendSpecialKeys) {
-          if (pty.pasteText) {
-            const pasted = pty.pasteText(content) as unknown;
-            if (pasted === false) return { submitted: false };
-          } else {
-            const written = pty.write(`\x1b[200~${content}\x1b[201~`);
-            if (written === false) return { submitted: false };
-          }
           await delay(200);
           const submitted = pty.sendSpecialKeys('Enter');
           if (submitted === false) return { submitted: false };
         } else {
-          const written = pty.write(`\x1b[200~${content}\x1b[201~`);
-          if (written === false) return { submitted: false };
-          await delay(200);
+          await delay(1000);
           const submitted = pty.write('\r');
           if (submitted === false) return { submitted: false };
         }

--- a/src/adapters/cli/dsh-tui.ts
+++ b/src/adapters/cli/dsh-tui.ts
@@ -68,14 +68,30 @@ export function createDshTuiAdapter(pathOverride?: string): CliAdapter {
     },
 
     async writeInput(pty: PtyHandle, content: string) {
-      if (pty.sendText && pty.sendSpecialKeys) {
-        pty.sendText(content);
-        await delay(200);
-        pty.sendSpecialKeys('Enter');
-      } else {
-        pty.write(content);
-        await delay(1000);
-        pty.write('\r');
+      // dsh-tui's Ink PromptInput treats ordinary newlines as submit keys.
+      // Botmux prompts are often multiline, so inject them as bracketed paste
+      // and press Enter exactly once after the whole draft is in the composer.
+      try {
+        if (pty.sendSpecialKeys) {
+          if (pty.pasteText) {
+            const pasted = pty.pasteText(content) as unknown;
+            if (pasted === false) return { submitted: false };
+          } else {
+            const written = pty.write(`\x1b[200~${content}\x1b[201~`);
+            if (written === false) return { submitted: false };
+          }
+          await delay(200);
+          const submitted = pty.sendSpecialKeys('Enter');
+          if (submitted === false) return { submitted: false };
+        } else {
+          const written = pty.write(`\x1b[200~${content}\x1b[201~`);
+          if (written === false) return { submitted: false };
+          await delay(200);
+          const submitted = pty.write('\r');
+          if (submitted === false) return { submitted: false };
+        }
+      } catch {
+        return { submitted: false };
       }
     },
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -858,16 +858,125 @@ describe('dsh-tui buildArgs (PTY TUI model)', () => {
     expect(adapter.authPaths).toContain('~/.dsh-tui');
   });
 
-  it('writeInput types text and presses Enter', async () => {
-    const sent: string[] = [];
-    const keys: string[][] = [];
+  it('writeInput pastes multiline text and presses one Enter', async () => {
+    const content = 'line1\nline2\nline3';
+    const sendText = vi.fn(() => true);
+    const pasteText = vi.fn(() => true);
+    const sendSpecialKeys = vi.fn(() => true);
     const pty = {
-      sendText: (t: string) => { sent.push(t); return true; },
-      sendSpecialKeys: (...k: string[]) => { keys.push(k); return true; },
+      write: vi.fn(() => true),
+      sendText,
+      pasteText,
+      sendSpecialKeys,
     } as unknown as PtyHandle;
-    await adapter.writeInput!(pty, 'hello tui');
-    expect(sent).toEqual(['hello tui']);
-    expect(keys).toEqual([['Enter']]);
+
+    const result = await adapter.writeInput!(pty, content);
+
+    expect(result).toBeUndefined();
+    expect(pasteText).toHaveBeenCalledOnce();
+    expect(pasteText).toHaveBeenCalledWith(content);
+    expect(sendText).not.toHaveBeenCalled();
+    expect(sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+
+  it('writeInput pastes a long botmux prompt as a single draft', async () => {
+    const content = [
+      '<botmux_routing>',
+      '你运行在飞书（Lark）会话中。用户在飞书阅读回复，看不到你的终端输出。',
+      '</botmux_routing>',
+      '',
+      '<user_message>',
+      '请处理这个多行请求',
+      '</user_message>',
+      '',
+      '<botmux_skills>',
+      '  <skill name="botmux-send">',
+      '    <description>向飞书话题发送消息。</description>',
+      '  </skill>',
+      '</botmux_skills>',
+    ].join('\n');
+    const sendText = vi.fn(() => true);
+    const pasteText = vi.fn(() => true);
+    const sendSpecialKeys = vi.fn(() => true);
+    const pty = {
+      write: vi.fn(() => true),
+      sendText,
+      pasteText,
+      sendSpecialKeys,
+    } as unknown as PtyHandle;
+
+    await adapter.writeInput!(pty, content);
+
+    expect(pasteText).toHaveBeenCalledTimes(1);
+    expect(pasteText).toHaveBeenCalledWith(content);
+    expect(sendText).not.toHaveBeenCalled();
+    expect(sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+
+  it('writeInput wraps bracketed paste when pasteText is unavailable', async () => {
+    const content = 'line1\nline2';
+    const write = vi.fn(() => true);
+    const sendSpecialKeys = vi.fn(() => true);
+    const pty = {
+      write,
+      sendText: vi.fn(() => true),
+      sendSpecialKeys,
+    } as unknown as PtyHandle;
+
+    const result = await adapter.writeInput!(pty, content);
+
+    expect(result).toBeUndefined();
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(`\x1b[200~${content}\x1b[201~`);
+    expect(pty.sendText).not.toHaveBeenCalled();
+    expect(sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+
+  it('writeInput wraps bracketed paste on raw PTY fallback', async () => {
+    const content = 'line1\nline2';
+    const write = vi.fn(() => true);
+    const pty = { write } as unknown as PtyHandle;
+
+    const result = await adapter.writeInput!(pty, content);
+
+    expect(result).toBeUndefined();
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(write).toHaveBeenNthCalledWith(1, `\x1b[200~${content}\x1b[201~`);
+    expect(write).toHaveBeenNthCalledWith(2, '\r');
+  });
+
+  it('writeInput returns submitted false when paste, write, or Enter is rejected', async () => {
+    await expect(adapter.writeInput!({
+      write: vi.fn(() => true),
+      pasteText: vi.fn(() => false),
+      sendSpecialKeys: vi.fn(() => true),
+    } as unknown as PtyHandle, 'paste rejected')).resolves.toEqual({ submitted: false });
+
+    await expect(adapter.writeInput!({
+      write: vi.fn(() => false),
+      sendSpecialKeys: vi.fn(() => true),
+    } as unknown as PtyHandle, 'write rejected')).resolves.toEqual({ submitted: false });
+
+    await expect(adapter.writeInput!({
+      write: vi.fn(() => false),
+    } as unknown as PtyHandle, 'raw write rejected')).resolves.toEqual({ submitted: false });
+
+    await expect(adapter.writeInput!({
+      write: vi.fn(() => true),
+      pasteText: vi.fn(() => true),
+      sendSpecialKeys: vi.fn(() => false),
+    } as unknown as PtyHandle, 'enter rejected')).resolves.toEqual({ submitted: false });
+  });
+
+  it('writeInput returns submitted false when paste throws', async () => {
+    await expect(adapter.writeInput!({
+      write: vi.fn(() => true),
+      pasteText: vi.fn(() => { throw new Error('paste failed'); }),
+      sendSpecialKeys: vi.fn(() => true),
+    } as unknown as PtyHandle, 'boom')).resolves.toEqual({ submitted: false });
   });
 });
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -858,7 +858,7 @@ describe('dsh-tui buildArgs (PTY TUI model)', () => {
     expect(adapter.authPaths).toContain('~/.dsh-tui');
   });
 
-  it('writeInput pastes multiline text and presses one Enter', async () => {
+  it('writeInput frames multiline text itself and presses one Enter', async () => {
     const content = 'line1\nline2\nline3';
     const sendText = vi.fn(() => true);
     const pasteText = vi.fn(() => true);
@@ -873,9 +873,9 @@ describe('dsh-tui buildArgs (PTY TUI model)', () => {
     const result = await adapter.writeInput!(pty, content);
 
     expect(result).toBeUndefined();
-    expect(pasteText).toHaveBeenCalledOnce();
-    expect(pasteText).toHaveBeenCalledWith(content);
-    expect(sendText).not.toHaveBeenCalled();
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(sendText).toHaveBeenCalledWith(`\x1b[200~${content}\x1b[201~`);
+    expect(pasteText).not.toHaveBeenCalled();
     expect(sendSpecialKeys).toHaveBeenCalledTimes(1);
     expect(sendSpecialKeys).toHaveBeenCalledWith('Enter');
   });
@@ -908,20 +908,39 @@ describe('dsh-tui buildArgs (PTY TUI model)', () => {
 
     await adapter.writeInput!(pty, content);
 
-    expect(pasteText).toHaveBeenCalledTimes(1);
-    expect(pasteText).toHaveBeenCalledWith(content);
-    expect(sendText).not.toHaveBeenCalled();
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(`\x1b[200~${content}\x1b[201~`);
+    expect(pasteText).not.toHaveBeenCalled();
     expect(sendSpecialKeys).toHaveBeenCalledTimes(1);
     expect(sendSpecialKeys).toHaveBeenCalledWith('Enter');
   });
 
-  it('writeInput wraps bracketed paste when pasteText is unavailable', async () => {
+  it('writeInput ignores void-returning pasteText and treats void sends as successful', async () => {
+    const content = 'line1\nline2';
+    const sendText = vi.fn(() => undefined);
+    const pasteText = vi.fn(() => undefined);
+    const sendSpecialKeys = vi.fn(() => undefined);
+    const pty = {
+      write: vi.fn(() => true),
+      sendText,
+      pasteText,
+      sendSpecialKeys,
+    } as unknown as PtyHandle;
+
+    const result = await adapter.writeInput!(pty, content);
+
+    expect(result).toBeUndefined();
+    expect(sendText).toHaveBeenCalledWith(`\x1b[200~${content}\x1b[201~`);
+    expect(pasteText).not.toHaveBeenCalled();
+    expect(sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+
+  it('writeInput wraps bracketed paste with write when sendText is unavailable', async () => {
     const content = 'line1\nline2';
     const write = vi.fn(() => true);
     const sendSpecialKeys = vi.fn(() => true);
     const pty = {
       write,
-      sendText: vi.fn(() => true),
       sendSpecialKeys,
     } as unknown as PtyHandle;
 
@@ -930,7 +949,6 @@ describe('dsh-tui buildArgs (PTY TUI model)', () => {
     expect(result).toBeUndefined();
     expect(write).toHaveBeenCalledTimes(1);
     expect(write).toHaveBeenCalledWith(`\x1b[200~${content}\x1b[201~`);
-    expect(pty.sendText).not.toHaveBeenCalled();
     expect(sendSpecialKeys).toHaveBeenCalledTimes(1);
     expect(sendSpecialKeys).toHaveBeenCalledWith('Enter');
   });
@@ -951,7 +969,7 @@ describe('dsh-tui buildArgs (PTY TUI model)', () => {
   it('writeInput returns submitted false when paste, write, or Enter is rejected', async () => {
     await expect(adapter.writeInput!({
       write: vi.fn(() => true),
-      pasteText: vi.fn(() => false),
+      sendText: vi.fn(() => false),
       sendSpecialKeys: vi.fn(() => true),
     } as unknown as PtyHandle, 'paste rejected')).resolves.toEqual({ submitted: false });
 
@@ -966,15 +984,15 @@ describe('dsh-tui buildArgs (PTY TUI model)', () => {
 
     await expect(adapter.writeInput!({
       write: vi.fn(() => true),
-      pasteText: vi.fn(() => true),
+      sendText: vi.fn(() => true),
       sendSpecialKeys: vi.fn(() => false),
     } as unknown as PtyHandle, 'enter rejected')).resolves.toEqual({ submitted: false });
   });
 
-  it('writeInput returns submitted false when paste throws', async () => {
+  it('writeInput returns submitted false when bracketed paste send throws', async () => {
     await expect(adapter.writeInput!({
       write: vi.fn(() => true),
-      pasteText: vi.fn(() => { throw new Error('paste failed'); }),
+      sendText: vi.fn(() => { throw new Error('paste failed'); }),
       sendSpecialKeys: vi.fn(() => true),
     } as unknown as PtyHandle, 'boom')).resolves.toEqual({ submitted: false });
   });


### PR DESCRIPTION
## 改动

- 将 `dsh-tui` adapter 的普通输入注入从 `sendText(content)` 改为 bracketed paste：优先使用 backend 的 `pasteText(content)`，无 `pasteText` 时手动写入 `\x1b[200~...\x1b[201~`。
- 保留完整 prompt 注入后的单次 Enter 提交，避免 prompt 内部换行被 dsh-tui 当作多次提交。
- 对 `pasteText` / fallback `write` / `sendSpecialKeys('Enter')` 返回 `false` 或抛错的情况返回 `{ submitted: false }`，复用 worker 现有提交失败提示链路。
- 补充 `dsh-tui` adapter 单测，覆盖多行正文、长 botmux 动态 prompt、无 `pasteText` fallback、raw PTY fallback，以及 backend 拒绝/异常路径。

## 为什么

`dsh-tui` 是 Ink TUI，普通输入里的 `\n` 会触发提交；而 botmux 首轮 prompt 经常会拼入 `<botmux_routing>` / `<identity>` / `<botmux_skills>` 等多行上下文。旧实现用 `sendText(content)` 注入多行 prompt，导致 prompt 被拆成多次提交，后半段在 dsh-tui working 状态下进入 queued 队列。

bracketed paste 会让 dsh-tui 把换行作为正文数据插入输入框，再由 botmux 最后发送的一次 Enter 完成提交，因此可以保证一个 botmux turn 对应一次 dsh-tui 提交。

## 影响面

- 影响：`dsh-tui` adapter 的输入提交路径。
- 不影响：headless `dsh` JSON-RPC runner、worker queue、ask-broker、飞书卡片逻辑、其他 CLI adapter。
- backend 兼容性：tmux / zellij / zmx / herdr 等优先走各自 `pasteText`；无 `pasteText` 的 raw PTY 路径使用手动 bracketed paste marker fallback。

## 测试

- `bun run test -- test/cli-adapters.test.ts`
  - 结果：`424 passed`
- `bun run build`
  - 结果：通过，包含 `tsc`、`typecheck:scripts`、dashboard bundle 和 dist audit。
