### PR TITLE
feat(dispatch): 为启动覆盖建立兼容与协议基础

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,6 +117,7 @@ import { withFileLock, withFileLockSync, FileLockTimeoutError } from './utils/fi
 import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional, hasFlagOrEq, unknownFlags } from './cli/arg-utils.js';
+import { parseDispatchArgs } from './cli/dispatch-args.js';
 import { isColdResumeDormant, isRealManagedSession, sessionListDisposition } from './cli/session-list-liveness.js';
 import {
   computeSessionPickerLayout,
@@ -10045,7 +10046,18 @@ async function postCurrentSessionDaemonRoute(input: {
 }
 
 async function cmdDispatch(rest: string[]): Promise<void> {
-  if (rest.includes('--help') || rest.includes('-h')) {
+  const parsedArgs = parseDispatchArgs(rest);
+  if (!parsedArgs.ok) {
+    console.error(JSON.stringify({
+      success: false,
+      errorCode: parsedArgs.errorCode,
+      detail: parsedArgs.error,
+      ...(parsedArgs.option ? { option: parsedArgs.option } : {}),
+    }));
+    process.exit(2);
+  }
+  const dispatchArgs = parsedArgs.value;
+  if (dispatchArgs.help) {
     console.log(`botmux dispatch — 开子项目话题、把 bot 拉进去协作（含 repo 预设 / 待命 / 追加）
 
 用法:
@@ -10088,18 +10100,18 @@ async function cmdDispatch(rest: string[]): Promise<void> {
   assertTurnTransportOrExit('dispatch');
 
   process.env.SESSION_DATA_DIR ??= resolveDataDir();
-  const sessionIdArg = argValue(rest, '--session-id');
-  const title = argValue(rest, '--title') ?? '';
-  const briefFile = argValue(rest, '--brief-file');
-  const overrideChatId = argValue(rest, '--chat-id');
-  const repo = argValue(rest, '--repo');
-  const intoRoot = argValue(rest, '--into');
-  const standby = rest.includes('--standby');
-  const steer = rest.includes('--steer');
-  const botSpecs = argValues(rest, '--bot');
-  const botAppSpecs = argValues(rest, '--bot-app');
+  const sessionIdArg = dispatchArgs.sessionId;
+  const title = dispatchArgs.title ?? '';
+  const briefFile = dispatchArgs.briefFile;
+  const overrideChatId = dispatchArgs.chatId;
+  const repo = dispatchArgs.repo;
+  const intoRoot = dispatchArgs.into;
+  const standby = dispatchArgs.standby;
+  const steer = dispatchArgs.steer;
+  const botSpecs = dispatchArgs.bots;
+  const botAppSpecs = dispatchArgs.botApps;
 
-  let brief = argValue(rest, '--brief') ?? '';
+  let brief = dispatchArgs.brief ?? '';
   if (briefFile) {
     if (!existsSync(briefFile)) { console.error(`文件不存在: ${briefFile}`); process.exit(1); }
     brief = readFileSync(briefFile, 'utf-8');

--- a/src/cli/dispatch-args.ts
+++ b/src/cli/dispatch-args.ts
@@ -88,7 +88,10 @@ export function parseDispatchArgs(args: readonly string[]): DispatchArgsResult {
     const repeatableKey = REPEATABLE_VALUE_FLAGS.get(flag);
     if (singletonKey || repeatableKey) {
       const optionValue = equals >= 0 ? token.slice(equals + 1) : args[index + 1];
-      if (optionValue === undefined || optionValue === '' || (equals < 0 && optionValue.startsWith('-'))) {
+      // Preserve argValue's historical treatment of dash-prefixed values. A
+      // quoted Markdown list (`--brief '- item'`) and values such as `-x` are
+      // data, not proof that this option was omitted.
+      if (optionValue === undefined || optionValue === '') {
         return fail('OPTION_VALUE_REQUIRED', `${flag} requires a value`, flag);
       }
       if (equals < 0) index += 1;

--- a/src/cli/dispatch-args.ts
+++ b/src/cli/dispatch-args.ts
@@ -1,0 +1,118 @@
+/** Strict, side-effect-free argv parsing for `botmux dispatch`. */
+
+export interface DispatchArgs {
+  help: boolean;
+  sessionId?: string;
+  title?: string;
+  brief?: string;
+  briefFile?: string;
+  chatId?: string;
+  repo?: string;
+  into?: string;
+  standby: boolean;
+  steer: boolean;
+  bots: string[];
+  botApps: string[];
+}
+
+export type DispatchArgsErrorCode =
+  | 'UNKNOWN_OPTION'
+  | 'UNEXPECTED_ARGUMENT'
+  | 'OPTION_VALUE_REQUIRED';
+
+export type DispatchArgsResult =
+  | { ok: true; value: DispatchArgs }
+  | { ok: false; errorCode: DispatchArgsErrorCode; error: string; option?: string };
+
+const VALUE_FLAGS = new Map<string, keyof Pick<DispatchArgs,
+  'sessionId' | 'title' | 'brief' | 'briefFile' | 'chatId' | 'repo' | 'into'
+>>([
+  ['--session-id', 'sessionId'],
+  ['--title', 'title'],
+  ['--brief', 'brief'],
+  ['--brief-file', 'briefFile'],
+  ['--chat-id', 'chatId'],
+  ['--repo', 'repo'],
+  ['--into', 'into'],
+]);
+
+const REPEATABLE_VALUE_FLAGS = new Map<string, 'bots' | 'botApps'>([
+  ['--bot', 'bots'],
+  ['--bot-app', 'botApps'],
+]);
+
+const BOOLEAN_FLAGS = new Map<string, 'standby' | 'steer' | 'help'>([
+  ['--standby', 'standby'],
+  ['--steer', 'steer'],
+  ['--help', 'help'],
+  ['-h', 'help'],
+]);
+
+function fail(
+  errorCode: DispatchArgsErrorCode,
+  error: string,
+  option?: string,
+): DispatchArgsResult {
+  return { ok: false, errorCode, error, ...(option ? { option } : {}) };
+}
+
+/**
+ * Outside the legacy help short-circuit, parse every token exactly once.
+ * Historically cmdDispatch pulled out known options and silently ignored the
+ * rest. That is unsafe for launch controls: an older binary could ignore a
+ * model flag and dispatch with its default.
+ */
+export function parseDispatchArgs(args: readonly string[]): DispatchArgsResult {
+  const value: DispatchArgs = {
+    help: false,
+    standby: false,
+    steer: false,
+    bots: [],
+    botApps: [],
+  };
+
+  // Preserve the historical help short-circuit exactly: help has always been
+  // safe to invoke alongside incomplete or future arguments because cmdDispatch
+  // returned before inspecting anything else.
+  if (args.includes('--help') || args.includes('-h')) {
+    value.help = true;
+    return { ok: true, value };
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]!;
+    const equals = token.indexOf('=');
+    const flag = equals >= 0 ? token.slice(0, equals) : token;
+
+    const singletonKey = VALUE_FLAGS.get(flag);
+    const repeatableKey = REPEATABLE_VALUE_FLAGS.get(flag);
+    if (singletonKey || repeatableKey) {
+      const optionValue = equals >= 0 ? token.slice(equals + 1) : args[index + 1];
+      if (optionValue === undefined || optionValue === '' || (equals < 0 && optionValue.startsWith('-'))) {
+        return fail('OPTION_VALUE_REQUIRED', `${flag} requires a value`, flag);
+      }
+      if (equals < 0) index += 1;
+      if (singletonKey) {
+        // argValue historically returned the first occurrence. Keep that
+        // precedence while still consuming and validating every token.
+        if (value[singletonKey] === undefined) value[singletonKey] = optionValue;
+      } else {
+        value[repeatableKey!].push(optionValue);
+      }
+      continue;
+    }
+
+    const booleanKey = BOOLEAN_FLAGS.get(flag);
+    if (booleanKey && equals < 0) {
+      value[booleanKey] = true;
+      continue;
+    }
+
+    if (token.startsWith('-')) {
+      return fail('UNKNOWN_OPTION', `unknown option: ${flag}`, flag);
+    }
+    return fail('UNEXPECTED_ARGUMENT', `unexpected positional argument: ${token}`);
+  }
+
+  return { ok: true, value };
+}

--- a/src/cli/dispatch-args.ts
+++ b/src/cli/dispatch-args.ts
@@ -91,7 +91,7 @@ export function parseDispatchArgs(args: readonly string[]): DispatchArgsResult {
       // Preserve argValue's historical treatment of dash-prefixed values. A
       // quoted Markdown list (`--brief '- item'`) and values such as `-x` are
       // data, not proof that this option was omitted.
-      if (optionValue === undefined || optionValue === '') {
+      if (optionValue === undefined) {
         return fail('OPTION_VALUE_REQUIRED', `${flag} requires a value`, flag);
       }
       if (equals < 0) index += 1;

--- a/src/core/dispatch-launch-contract.ts
+++ b/src/core/dispatch-launch-contract.ts
@@ -1,0 +1,669 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+import { canonicalJson } from '../utils/canonical-input-hash.js';
+import {
+  CODEX_REASONING_EFFORTS,
+  cliModelSupportsReasoningEffort,
+  type CodexReasoningEffort,
+} from '../services/codex-reasoning-effort.js';
+
+/**
+ * Data-only contract for a future target-daemon-authoritative dispatch launch.
+ * Nothing in this module is connected to a command, route, or worker launch.
+ */
+export const DISPATCH_LAUNCH_PROTOCOL = 'v1' as const;
+export const DISPATCH_LAUNCH_SCHEMA_VERSION = 1 as const;
+export const DISPATCH_LAUNCH_POLICY_SCHEMA_VERSION = 1 as const;
+export const DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION = 1 as const;
+export const DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION = 1 as const;
+export const DISPATCH_LAUNCH_OVERRIDE_SCHEMA_VERSION = 1 as const;
+
+export const DISPATCH_LAUNCH_ID_RE = /^dl_[0-9a-f]{32}$/;
+export const DISPATCH_LAUNCH_DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+
+export const DISPATCH_LAUNCH_KICKOFF_LIMITS = {
+  titleBytes: 512,
+  briefBytes: 64 * 1024,
+  roleBytes: 256,
+  sourceDisplayBytes: 512,
+  totalBytes: 72 * 1024,
+} as const;
+
+export const DISPATCH_LAUNCH_ERROR_CODES = [
+  'BAD_REQUEST',
+  'PROTOCOL_UNSUPPORTED',
+  'UNAUTHORIZED_SOURCE',
+  'POLICY_DENIED',
+  'TARGET_NOT_IN_CHAT',
+  'TARGET_CHAT_UNSUPPORTED',
+  'UNSUPPORTED_HARNESS',
+  'MODEL_REQUIRED_FOR_OVERRIDE',
+  'MODEL_UNSUPPORTED',
+  'REASONING_EFFORT_UNSUPPORTED',
+  'INVALID_MODEL_EFFORT_COMBINATION',
+  'WORKDIR_REQUIRED',
+  'CAPACITY_UNAVAILABLE',
+  'POLICY_CHANGED',
+  'LAUNCH_IDENTITY_CHANGED',
+  'ROOT_CONFLICT',
+  'OPERATION_NOT_FOUND',
+  'OPERATION_CONFLICT',
+  'OPERATION_EXPIRED',
+  'DELIVERY_UNKNOWN',
+  'INPUT_COMMIT_TIMEOUT',
+  'RUNTIME_NOT_PROVABLE',
+  'RUNTIME_MISMATCH',
+  'CANCELLED',
+  'INTERNAL_ERROR',
+] as const;
+
+export type DispatchLaunchErrorCode = typeof DISPATCH_LAUNCH_ERROR_CODES[number];
+
+export interface DispatchLaunchFailure {
+  ok: false;
+  errorCode: DispatchLaunchErrorCode;
+  message: string;
+}
+
+export interface DispatchLaunchRequestedOverride {
+  model?: string;
+  reasoningEffort?: CodexReasoningEffort;
+}
+
+export interface DispatchLaunchEffectiveOverride {
+  model: string;
+  /** Missing means no explicit effort is passed; Botmux never guesses the CLI default. */
+  reasoningEffort?: CodexReasoningEffort;
+}
+
+export interface DispatchLaunchKickoffPayloadV1 {
+  schemaVersion: typeof DISPATCH_LAUNCH_SCHEMA_VERSION;
+  protocol: typeof DISPATCH_LAUNCH_PROTOCOL;
+  title: string;
+  brief: string;
+  role?: string;
+  sourceDisplay: string;
+  targetLarkAppId: string;
+}
+
+export interface CanonicalDispatchLaunchKickoff {
+  payload: DispatchLaunchKickoffPayloadV1;
+  canonicalJson: string;
+  byteLength: number;
+  digest: string;
+}
+
+export interface DispatchLaunchPolicyV1 {
+  schemaVersion: typeof DISPATCH_LAUNCH_POLICY_SCHEMA_VERSION;
+  enabled: boolean;
+  allowedSourceAppIds: string[];
+  allowedModels: string[];
+  allowedReasoningEfforts: CodexReasoningEffort[];
+}
+
+export interface DispatchLaunchIdentityV1 {
+  cliId: string;
+  cliRuntimeDigest: string;
+  executable: string;
+  wrapperCli?: string;
+  backendType: string;
+  codexRpcInput: boolean;
+  existingAppServer: boolean;
+  botConfigDigest: string;
+  policyDigest: string;
+}
+
+export interface DispatchLaunchPrepareRequestV1 {
+  schemaVersion: typeof DISPATCH_LAUNCH_SCHEMA_VERSION;
+  protocol: typeof DISPATCH_LAUNCH_PROTOCOL;
+  dispatchId: string;
+  source: {
+    larkAppId: string;
+    sessionId: string;
+    turnId: string;
+    callerOpenId?: string;
+  };
+  targetLarkAppId: string;
+  chatId: string;
+  kickoff: CanonicalDispatchLaunchKickoff;
+  requestedOverride: DispatchLaunchRequestedOverride;
+  expiresAt: string;
+}
+
+export interface DispatchLaunchStartRequestV1 {
+  schemaVersion: typeof DISPATCH_LAUNCH_SCHEMA_VERSION;
+  protocol: typeof DISPATCH_LAUNCH_PROTOCOL;
+  dispatchId: string;
+  kickoffDigest: string;
+  policyDigest: string;
+  launchIdentityDigest: string;
+}
+
+export interface DispatchLaunchCancelRequestV1 {
+  schemaVersion: typeof DISPATCH_LAUNCH_SCHEMA_VERSION;
+  protocol: typeof DISPATCH_LAUNCH_PROTOCOL;
+  dispatchId: string;
+  reason: string;
+}
+
+export interface DispatchLaunchTurnFactV1 {
+  sessionId: string;
+  kickoffTurnId: string;
+  workerGeneration: number;
+  observedAt: string;
+}
+
+export interface DispatchLaunchProofV1 {
+  inputCommitted: DispatchLaunchTurnFactV1;
+  runtimeObserved: DispatchLaunchTurnFactV1 & {
+    model: string;
+    reasoningEffort?: CodexReasoningEffort;
+    /** Set only after the adapter's explicit alias/equivalence rules pass. */
+    equivalentToEffectiveOverride: true;
+  };
+}
+
+export const DISPATCH_LAUNCH_OPERATION_STATES = [
+  'created',
+  'preparing',
+  'prepared',
+  'starting',
+  'awaiting_proof',
+  'succeeded',
+  'failed',
+  'cancelled',
+  'delivery_unknown',
+] as const;
+
+export type DispatchLaunchOperationState = typeof DISPATCH_LAUNCH_OPERATION_STATES[number];
+
+export interface DispatchLaunchOperationV1 {
+  schemaVersion: typeof DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION;
+  dispatchId: string;
+  owner: 'source' | 'target';
+  state: DispatchLaunchOperationState;
+  sourceLarkAppId: string;
+  sourceSessionId: string;
+  sourceTurnId: string;
+  targetLarkAppId: string;
+  chatId: string;
+  kickoff: CanonicalDispatchLaunchKickoff;
+  requestedOverride: DispatchLaunchRequestedOverride;
+  effectiveOverride?: DispatchLaunchEffectiveOverride;
+  launchIdentity?: DispatchLaunchIdentityV1;
+  rootMessageId?: string;
+  targetSessionId?: string;
+  kickoffTurnId?: string;
+  workerGeneration?: number;
+  proof?: DispatchLaunchProofV1;
+  errorCode?: DispatchLaunchErrorCode;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string;
+}
+
+export interface DispatchLaunchAdmissionReceiptV1 {
+  schemaVersion: typeof DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION;
+  dispatchId: string;
+  state: 'authorized' | 'committed' | 'released';
+  sourceLarkAppId: string;
+  sourceSessionId: string;
+  sourceTurnId: string;
+  callerOpenId?: string;
+  chatId: string;
+  targetLarkAppId: string;
+  policyDigest: string;
+  talkAuthorizationReceiptId: string;
+  quotaReceiptId: string;
+  workingDir: string;
+  capacityReservationId: string;
+  createdAt: string;
+  committedAt?: string;
+  releasedAt?: string;
+}
+
+export interface DispatchLaunchOverrideSnapshotV1 {
+  schemaVersion: typeof DISPATCH_LAUNCH_OVERRIDE_SCHEMA_VERSION;
+  provenanceId: string;
+  dispatchId?: string;
+  inheritedFromDispatchId?: string;
+  effective: DispatchLaunchEffectiveOverride;
+  launchIdentity: DispatchLaunchIdentityV1;
+  createdAt: string;
+}
+
+const nonEmptyString = z.string().trim().min(1);
+const larkAppIdSchema = nonEmptyString.regex(/^cli_[A-Za-z0-9]+$/);
+const dispatchIdSchema = z.string().regex(DISPATCH_LAUNCH_ID_RE);
+const digestSchema = z.string().regex(DISPATCH_LAUNCH_DIGEST_RE);
+const timestampSchema = z.string().datetime({ offset: true });
+const reasoningEffortSchema = z.enum(CODEX_REASONING_EFFORTS);
+
+const requestedOverrideSchema = z.object({
+  model: nonEmptyString.optional(),
+  reasoningEffort: reasoningEffortSchema.optional(),
+}).strict();
+
+const effectiveOverrideSchema = z.object({
+  model: nonEmptyString,
+  reasoningEffort: reasoningEffortSchema.optional(),
+}).strict();
+
+const kickoffPayloadSchema = z.object({
+  schemaVersion: z.literal(DISPATCH_LAUNCH_SCHEMA_VERSION),
+  protocol: z.literal(DISPATCH_LAUNCH_PROTOCOL),
+  title: z.string(),
+  brief: z.string(),
+  role: z.string().optional(),
+  sourceDisplay: z.string(),
+  targetLarkAppId: larkAppIdSchema,
+}).strict();
+
+const canonicalKickoffSchema = z.object({
+  payload: kickoffPayloadSchema,
+  canonicalJson: z.string(),
+  byteLength: z.number().int().nonnegative().max(DISPATCH_LAUNCH_KICKOFF_LIMITS.totalBytes),
+  digest: digestSchema,
+}).strict();
+
+const launchIdentitySchema = z.object({
+  cliId: nonEmptyString,
+  cliRuntimeDigest: digestSchema,
+  executable: nonEmptyString,
+  wrapperCli: nonEmptyString.optional(),
+  backendType: nonEmptyString,
+  codexRpcInput: z.boolean(),
+  existingAppServer: z.boolean(),
+  botConfigDigest: digestSchema,
+  policyDigest: digestSchema,
+}).strict();
+
+const turnFactSchema = z.object({
+  sessionId: nonEmptyString,
+  kickoffTurnId: nonEmptyString,
+  workerGeneration: z.number().int().nonnegative(),
+  observedAt: timestampSchema,
+}).strict();
+
+const proofSchema = z.object({
+  inputCommitted: turnFactSchema,
+  runtimeObserved: turnFactSchema.extend({
+    model: nonEmptyString,
+    reasoningEffort: reasoningEffortSchema.optional(),
+    equivalentToEffectiveOverride: z.literal(true),
+  }).strict(),
+}).strict().superRefine((value, context) => {
+  const left = value.inputCommitted;
+  const right = value.runtimeObserved;
+  if (left.sessionId !== right.sessionId
+      || left.kickoffTurnId !== right.kickoffTurnId
+      || left.workerGeneration !== right.workerGeneration) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'input and runtime proof must identify the same session, kickoff turn and worker generation',
+    });
+  }
+});
+
+export const DispatchLaunchPrepareRequestSchema = z.object({
+  schemaVersion: z.literal(DISPATCH_LAUNCH_SCHEMA_VERSION),
+  protocol: z.literal(DISPATCH_LAUNCH_PROTOCOL),
+  dispatchId: dispatchIdSchema,
+  source: z.object({
+    larkAppId: larkAppIdSchema,
+    sessionId: nonEmptyString,
+    turnId: nonEmptyString,
+    callerOpenId: nonEmptyString.optional(),
+  }).strict(),
+  targetLarkAppId: larkAppIdSchema,
+  chatId: nonEmptyString,
+  kickoff: canonicalKickoffSchema,
+  requestedOverride: requestedOverrideSchema,
+  expiresAt: timestampSchema,
+}).strict();
+
+export const DispatchLaunchStartRequestSchema = z.object({
+  schemaVersion: z.literal(DISPATCH_LAUNCH_SCHEMA_VERSION),
+  protocol: z.literal(DISPATCH_LAUNCH_PROTOCOL),
+  dispatchId: dispatchIdSchema,
+  kickoffDigest: digestSchema,
+  policyDigest: digestSchema,
+  launchIdentityDigest: digestSchema,
+}).strict();
+
+export const DispatchLaunchCancelRequestSchema = z.object({
+  schemaVersion: z.literal(DISPATCH_LAUNCH_SCHEMA_VERSION),
+  protocol: z.literal(DISPATCH_LAUNCH_PROTOCOL),
+  dispatchId: dispatchIdSchema,
+  reason: nonEmptyString.max(1024),
+}).strict();
+
+export const DispatchLaunchPolicySchema = z.object({
+  schemaVersion: z.literal(DISPATCH_LAUNCH_POLICY_SCHEMA_VERSION),
+  enabled: z.boolean(),
+  allowedSourceAppIds: z.array(larkAppIdSchema).max(256),
+  allowedModels: z.array(nonEmptyString).max(256),
+  allowedReasoningEfforts: z.array(reasoningEffortSchema).max(CODEX_REASONING_EFFORTS.length),
+}).strict();
+
+export const DispatchLaunchOperationSchema = z.object({
+  schemaVersion: z.literal(DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION),
+  dispatchId: dispatchIdSchema,
+  owner: z.enum(['source', 'target']),
+  state: z.enum(DISPATCH_LAUNCH_OPERATION_STATES),
+  sourceLarkAppId: larkAppIdSchema,
+  sourceSessionId: nonEmptyString,
+  sourceTurnId: nonEmptyString,
+  targetLarkAppId: larkAppIdSchema,
+  chatId: nonEmptyString,
+  kickoff: canonicalKickoffSchema,
+  requestedOverride: requestedOverrideSchema,
+  effectiveOverride: effectiveOverrideSchema.optional(),
+  launchIdentity: launchIdentitySchema.optional(),
+  rootMessageId: nonEmptyString.optional(),
+  targetSessionId: nonEmptyString.optional(),
+  kickoffTurnId: nonEmptyString.optional(),
+  workerGeneration: z.number().int().nonnegative().optional(),
+  proof: proofSchema.optional(),
+  errorCode: z.enum(DISPATCH_LAUNCH_ERROR_CODES).optional(),
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+  expiresAt: timestampSchema,
+}).strict();
+
+export const DispatchLaunchAdmissionReceiptSchema = z.object({
+  schemaVersion: z.literal(DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION),
+  dispatchId: dispatchIdSchema,
+  state: z.enum(['authorized', 'committed', 'released']),
+  sourceLarkAppId: larkAppIdSchema,
+  sourceSessionId: nonEmptyString,
+  sourceTurnId: nonEmptyString,
+  callerOpenId: nonEmptyString.optional(),
+  chatId: nonEmptyString,
+  targetLarkAppId: larkAppIdSchema,
+  policyDigest: digestSchema,
+  talkAuthorizationReceiptId: nonEmptyString,
+  quotaReceiptId: nonEmptyString,
+  workingDir: nonEmptyString,
+  capacityReservationId: nonEmptyString,
+  createdAt: timestampSchema,
+  committedAt: timestampSchema.optional(),
+  releasedAt: timestampSchema.optional(),
+}).strict();
+
+export const DispatchLaunchOverrideSnapshotSchema = z.object({
+  schemaVersion: z.literal(DISPATCH_LAUNCH_OVERRIDE_SCHEMA_VERSION),
+  provenanceId: nonEmptyString,
+  dispatchId: dispatchIdSchema.optional(),
+  inheritedFromDispatchId: dispatchIdSchema.optional(),
+  effective: effectiveOverrideSchema,
+  launchIdentity: launchIdentitySchema,
+  createdAt: timestampSchema,
+}).strict().superRefine((value, context) => {
+  if ((value.dispatchId === undefined) === (value.inheritedFromDispatchId === undefined)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'exactly one of dispatchId or inheritedFromDispatchId is required',
+    });
+  }
+});
+
+function normalizeLf(value: string): string {
+  return value.replace(/\r\n?/g, '\n');
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function requiredText(value: string, field: string, limit: number): string {
+  const normalized = normalizeLf(value);
+  if (!normalized.trim()) throw new Error(`${field} must not be empty`);
+  if (normalized.includes('\0')) throw new Error(`${field} must not contain NUL`);
+  if (byteLength(normalized) > limit) throw new Error(`${field} exceeds ${limit} UTF-8 bytes`);
+  return normalized;
+}
+
+function optionalText(value: string | undefined, field: string, limit: number): string | undefined {
+  if (value === undefined) return undefined;
+  const normalized = normalizeLf(value);
+  if (!normalized.trim()) return undefined;
+  if (normalized.includes('\0')) throw new Error(`${field} must not contain NUL`);
+  if (byteLength(normalized) > limit) throw new Error(`${field} exceeds ${limit} UTF-8 bytes`);
+  return normalized;
+}
+
+/** Create a path-safe, globally unique id before any transport side effect. */
+export function createDispatchLaunchId(): string {
+  return `dl_${randomUUID().replaceAll('-', '')}`;
+}
+
+/**
+ * Canonicalize protocol-owned semantic input. Lark rendering, mentions and
+ * delivery markers deliberately do not participate in this digest.
+ */
+export function canonicalizeDispatchLaunchKickoff(
+  input: Omit<DispatchLaunchKickoffPayloadV1, 'schemaVersion' | 'protocol'>,
+): CanonicalDispatchLaunchKickoff {
+  const role = optionalText(input.role, 'role', DISPATCH_LAUNCH_KICKOFF_LIMITS.roleBytes);
+  const payload: DispatchLaunchKickoffPayloadV1 = {
+    schemaVersion: DISPATCH_LAUNCH_SCHEMA_VERSION,
+    protocol: DISPATCH_LAUNCH_PROTOCOL,
+    title: requiredText(input.title, 'title', DISPATCH_LAUNCH_KICKOFF_LIMITS.titleBytes),
+    brief: requiredText(input.brief, 'brief', DISPATCH_LAUNCH_KICKOFF_LIMITS.briefBytes),
+    ...(role ? { role } : {}),
+    sourceDisplay: requiredText(
+      input.sourceDisplay,
+      'sourceDisplay',
+      DISPATCH_LAUNCH_KICKOFF_LIMITS.sourceDisplayBytes,
+    ),
+    targetLarkAppId: larkAppIdSchema.parse(input.targetLarkAppId),
+  };
+  const encoded = canonicalJson(payload);
+  const encodedBytes = byteLength(encoded);
+  if (encodedBytes > DISPATCH_LAUNCH_KICKOFF_LIMITS.totalBytes) {
+    throw new Error(`canonical kickoff exceeds ${DISPATCH_LAUNCH_KICKOFF_LIMITS.totalBytes} UTF-8 bytes`);
+  }
+  return {
+    payload,
+    canonicalJson: encoded,
+    byteLength: encodedBytes,
+    digest: `sha256:${createHash('sha256').update(encoded, 'utf8').digest('hex')}`,
+  };
+}
+
+export function resolveDispatchLaunchOverride(input: {
+  cliId: string;
+  requested: DispatchLaunchRequestedOverride;
+  targetModel?: string;
+  targetReasoningEffort?: CodexReasoningEffort;
+}): { ok: true; effective: DispatchLaunchEffectiveOverride } | DispatchLaunchFailure {
+  const requestedModel = input.requested.model?.trim();
+  if (input.requested.model !== undefined && !requestedModel) {
+    return { ok: false, errorCode: 'BAD_REQUEST', message: 'requested model must not be empty' };
+  }
+  if (!requestedModel && input.requested.reasoningEffort === undefined) {
+    return { ok: false, errorCode: 'BAD_REQUEST', message: 'at least one launch override is required' };
+  }
+  if (input.cliId !== 'codex') {
+    return { ok: false, errorCode: 'UNSUPPORTED_HARNESS', message: 'v1 supports only the official Codex TUI' };
+  }
+  const effectiveModel = requestedModel ?? input.targetModel?.trim();
+  if (!effectiveModel) {
+    return {
+      ok: false,
+      errorCode: 'MODEL_REQUIRED_FOR_OVERRIDE',
+      message: 'a concrete effective model is required for any launch override',
+    };
+  }
+  const effectiveEffort = input.requested.reasoningEffort ?? input.targetReasoningEffort;
+  if (effectiveEffort !== undefined
+      && !cliModelSupportsReasoningEffort(input.cliId, effectiveModel, effectiveEffort)) {
+    return {
+      ok: false,
+      errorCode: 'INVALID_MODEL_EFFORT_COMBINATION',
+      message: `reasoning effort ${effectiveEffort} is not supported by ${effectiveModel}`,
+    };
+  }
+  return {
+    ok: true,
+    effective: {
+      model: effectiveModel,
+      ...(effectiveEffort !== undefined ? { reasoningEffort: effectiveEffort } : {}),
+    },
+  };
+}
+
+function normalizedUnique(values: readonly string[]): string[] {
+  return [...new Set(values.map(value => value.trim()).filter(Boolean))].sort();
+}
+
+export function normalizeDispatchLaunchPolicy(raw: unknown): DispatchLaunchPolicyV1 {
+  const parsed = DispatchLaunchPolicySchema.parse(raw);
+  return {
+    ...parsed,
+    allowedSourceAppIds: normalizedUnique(parsed.allowedSourceAppIds),
+    allowedModels: normalizedUnique(parsed.allowedModels),
+    allowedReasoningEfforts: [...new Set(parsed.allowedReasoningEfforts)].sort() as CodexReasoningEffort[],
+  };
+}
+
+export function dispatchLaunchPolicyDigest(policy: DispatchLaunchPolicyV1): string {
+  const normalized = normalizeDispatchLaunchPolicy(policy);
+  return `sha256:${createHash('sha256').update(canonicalJson(normalized), 'utf8').digest('hex')}`;
+}
+
+export function dispatchLaunchIdentityDigest(identity: DispatchLaunchIdentityV1): string {
+  const parsed = launchIdentitySchema.parse(identity);
+  return `sha256:${createHash('sha256').update(canonicalJson(parsed), 'utf8').digest('hex')}`;
+}
+
+/** Missing, disabled and non-matching target policy all fail closed. */
+export function evaluateDispatchLaunchPolicy(input: {
+  policy?: DispatchLaunchPolicyV1;
+  sourceLarkAppId: string;
+  effective: DispatchLaunchEffectiveOverride;
+}): { ok: true; policyDigest: string } | DispatchLaunchFailure {
+  if (input.policy === undefined) {
+    return { ok: false, errorCode: 'POLICY_DENIED', message: 'target has no dispatch launch policy' };
+  }
+  const policy = normalizeDispatchLaunchPolicy(input.policy);
+  if (!policy.enabled) {
+    return { ok: false, errorCode: 'POLICY_DENIED', message: 'dispatch launch is disabled by target policy' };
+  }
+  if (!policy.allowedSourceAppIds.includes(input.sourceLarkAppId)) {
+    return { ok: false, errorCode: 'UNAUTHORIZED_SOURCE', message: 'source app is not allowed by target policy' };
+  }
+  if (!policy.allowedModels.includes(input.effective.model)) {
+    return { ok: false, errorCode: 'MODEL_UNSUPPORTED', message: 'effective model is not allowed by target policy' };
+  }
+  if (input.effective.reasoningEffort !== undefined
+      && !policy.allowedReasoningEfforts.includes(input.effective.reasoningEffort)) {
+    return {
+      ok: false,
+      errorCode: 'REASONING_EFFORT_UNSUPPORTED',
+      message: 'effective reasoning effort is not allowed by target policy',
+    };
+  }
+  return { ok: true, policyDigest: dispatchLaunchPolicyDigest(policy) };
+}
+
+function parsedOrThrow<T>(schema: z.ZodType<T>, raw: unknown, label: string): T {
+  const result = schema.safeParse(raw);
+  if (!result.success) throw new Error(`invalid ${label}: ${result.error.issues.map(issue => issue.message).join('; ')}`);
+  return result.data;
+}
+
+export function parseDispatchLaunchOperation(raw: unknown): DispatchLaunchOperationV1 {
+  const parsed = parsedOrThrow(DispatchLaunchOperationSchema, raw, 'dispatch launch operation');
+  const recomputed = canonicalizeDispatchLaunchKickoff({
+    title: parsed.kickoff.payload.title,
+    brief: parsed.kickoff.payload.brief,
+    role: parsed.kickoff.payload.role,
+    sourceDisplay: parsed.kickoff.payload.sourceDisplay,
+    targetLarkAppId: parsed.kickoff.payload.targetLarkAppId,
+  });
+  if (recomputed.canonicalJson !== parsed.kickoff.canonicalJson
+      || recomputed.byteLength !== parsed.kickoff.byteLength
+      || recomputed.digest !== parsed.kickoff.digest) {
+    throw new Error('invalid dispatch launch operation: kickoff canonicalization mismatch');
+  }
+  if (Date.parse(parsed.updatedAt) < Date.parse(parsed.createdAt)) {
+    throw new Error('invalid dispatch launch operation: updatedAt precedes createdAt');
+  }
+  if (Date.parse(parsed.expiresAt) <= Date.parse(parsed.createdAt)) {
+    throw new Error('invalid dispatch launch operation: expiresAt must follow createdAt');
+  }
+  if (parsed.state === 'succeeded' && parsed.proof === undefined) {
+    throw new Error('invalid dispatch launch operation: succeeded operation requires turn-bound proof');
+  }
+  if (parsed.state === 'succeeded') {
+    const fact = parsed.proof!.inputCommitted;
+    if (parsed.targetSessionId === undefined
+        || parsed.kickoffTurnId === undefined
+        || parsed.workerGeneration === undefined
+        || parsed.effectiveOverride === undefined) {
+      throw new Error('invalid dispatch launch operation: succeeded operation requires launch identity fields');
+    }
+    if (fact.sessionId !== parsed.targetSessionId
+        || fact.kickoffTurnId !== parsed.kickoffTurnId
+        || fact.workerGeneration !== parsed.workerGeneration) {
+      throw new Error('invalid dispatch launch operation: proof does not match operation launch identity');
+    }
+  }
+  if ((parsed.state === 'failed' || parsed.state === 'delivery_unknown') && parsed.errorCode === undefined) {
+    throw new Error('invalid dispatch launch operation: failed operation requires an error code');
+  }
+  return parsed;
+}
+
+export function parseDispatchLaunchPrepareRequest(raw: unknown): DispatchLaunchPrepareRequestV1 {
+  const parsed = parsedOrThrow(DispatchLaunchPrepareRequestSchema, raw, 'dispatch launch prepare request');
+  const recomputed = canonicalizeDispatchLaunchKickoff({
+    title: parsed.kickoff.payload.title,
+    brief: parsed.kickoff.payload.brief,
+    role: parsed.kickoff.payload.role,
+    sourceDisplay: parsed.kickoff.payload.sourceDisplay,
+    targetLarkAppId: parsed.kickoff.payload.targetLarkAppId,
+  });
+  if (recomputed.digest !== parsed.kickoff.digest
+      || recomputed.canonicalJson !== parsed.kickoff.canonicalJson
+      || recomputed.byteLength !== parsed.kickoff.byteLength) {
+    throw new Error('invalid dispatch launch prepare request: kickoff canonicalization mismatch');
+  }
+  if (parsed.targetLarkAppId !== parsed.kickoff.payload.targetLarkAppId) {
+    throw new Error('invalid dispatch launch prepare request: target identity mismatch');
+  }
+  return parsed;
+}
+
+export function parseDispatchLaunchStartRequest(raw: unknown): DispatchLaunchStartRequestV1 {
+  return parsedOrThrow(DispatchLaunchStartRequestSchema, raw, 'dispatch launch start request');
+}
+
+export function parseDispatchLaunchCancelRequest(raw: unknown): DispatchLaunchCancelRequestV1 {
+  return parsedOrThrow(DispatchLaunchCancelRequestSchema, raw, 'dispatch launch cancel request');
+}
+
+export function parseDispatchLaunchAdmissionReceipt(raw: unknown): DispatchLaunchAdmissionReceiptV1 {
+  const parsed = parsedOrThrow(DispatchLaunchAdmissionReceiptSchema, raw, 'dispatch launch admission receipt');
+  if (parsed.state === 'authorized' && (parsed.committedAt !== undefined || parsed.releasedAt !== undefined)) {
+    throw new Error('invalid dispatch launch admission receipt: authorized receipt must be unsettled');
+  }
+  if (parsed.state === 'committed' && parsed.committedAt === undefined) {
+    throw new Error('invalid dispatch launch admission receipt: committedAt is required');
+  }
+  if (parsed.state === 'released' && parsed.releasedAt === undefined) {
+    throw new Error('invalid dispatch launch admission receipt: releasedAt is required');
+  }
+  return parsed;
+}
+
+export function parseDispatchLaunchOverrideSnapshot(raw: unknown): DispatchLaunchOverrideSnapshotV1 {
+  return parsedOrThrow(
+    DispatchLaunchOverrideSnapshotSchema,
+    raw,
+    'dispatch launch override snapshot',
+  );
+}

--- a/src/core/dispatch-launch-contract.ts
+++ b/src/core/dispatch-launch-contract.ts
@@ -30,6 +30,16 @@ export const DISPATCH_LAUNCH_KICKOFF_LIMITS = {
   totalBytes: 72 * 1024,
 } as const;
 
+export const DISPATCH_LAUNCH_CONTROL_LIMITS = {
+  larkAppIdChars: 256,
+  identifierChars: 512,
+  callerUnionIdChars: 256,
+  modelChars: 512,
+  executableChars: 4096,
+  wrapperChars: 4096,
+  workingDirChars: 16 * 1024,
+} as const;
+
 export const DISPATCH_LAUNCH_ERROR_CODES = [
   'BAD_REQUEST',
   'PROTOCOL_UNSUPPORTED',
@@ -89,7 +99,6 @@ export interface DispatchLaunchKickoffPayloadV1 {
 
 export interface CanonicalDispatchLaunchKickoff {
   payload: DispatchLaunchKickoffPayloadV1;
-  canonicalJson: string;
   byteLength: number;
   digest: string;
 }
@@ -103,13 +112,13 @@ export interface DispatchLaunchPolicyV1 {
 }
 
 export interface DispatchLaunchIdentityV1 {
-  cliId: string;
+  cliId: 'codex';
   cliRuntimeDigest: string;
   executable: string;
   wrapperCli?: string;
-  backendType: string;
-  codexRpcInput: boolean;
-  existingAppServer: boolean;
+  backendType: 'pty' | 'tmux' | 'herdr' | 'zellij' | 'zmx';
+  codexRpcInput: false;
+  existingAppServer: false;
   botConfigDigest: string;
   policyDigest: string;
 }
@@ -122,7 +131,8 @@ export interface DispatchLaunchPrepareRequestV1 {
     larkAppId: string;
     sessionId: string;
     turnId: string;
-    callerOpenId?: string;
+    /** Cross-app stable caller identity; source-app open_id is intentionally not transported. */
+    callerUnionId?: string;
   };
   targetLarkAppId: string;
   chatId: string;
@@ -159,8 +169,6 @@ export interface DispatchLaunchProofV1 {
   runtimeObserved: DispatchLaunchTurnFactV1 & {
     model: string;
     reasoningEffort?: CodexReasoningEffort;
-    /** Set only after the adapter's explicit alias/equivalence rules pass. */
-    equivalentToEffectiveOverride: true;
   };
 }
 
@@ -178,11 +186,10 @@ export const DISPATCH_LAUNCH_OPERATION_STATES = [
 
 export type DispatchLaunchOperationState = typeof DISPATCH_LAUNCH_OPERATION_STATES[number];
 
-export interface DispatchLaunchOperationV1 {
+interface DispatchLaunchOperationBaseV1 {
   schemaVersion: typeof DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION;
   dispatchId: string;
   owner: 'source' | 'target';
-  state: DispatchLaunchOperationState;
   sourceLarkAppId: string;
   sourceSessionId: string;
   sourceTurnId: string;
@@ -190,18 +197,67 @@ export interface DispatchLaunchOperationV1 {
   chatId: string;
   kickoff: CanonicalDispatchLaunchKickoff;
   requestedOverride: DispatchLaunchRequestedOverride;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string;
+}
+
+type DispatchLaunchPreAdmissionOperationV1 = DispatchLaunchOperationBaseV1 & {
+  state: 'created' | 'preparing';
+};
+
+type DispatchLaunchPreparedOperationV1 = DispatchLaunchOperationBaseV1 & {
+  state: 'prepared';
+  effectiveOverride: DispatchLaunchEffectiveOverride;
+  launchIdentity: DispatchLaunchIdentityV1;
+};
+
+type DispatchLaunchStartingOperationV1 = DispatchLaunchOperationBaseV1 & {
+  state: 'starting';
+  effectiveOverride: DispatchLaunchEffectiveOverride;
+  launchIdentity: DispatchLaunchIdentityV1;
+  rootMessageId?: string;
+  targetSessionId?: string;
+  kickoffTurnId?: string;
+  workerGeneration?: number;
+};
+
+type DispatchLaunchLaunchedOperationV1 = DispatchLaunchOperationBaseV1 & {
+  effectiveOverride: DispatchLaunchEffectiveOverride;
+  launchIdentity: DispatchLaunchIdentityV1;
+  rootMessageId: string;
+  targetSessionId: string;
+  kickoffTurnId: string;
+  workerGeneration: number;
+};
+
+type DispatchLaunchAwaitingProofOperationV1 = DispatchLaunchLaunchedOperationV1 & {
+  state: 'awaiting_proof';
+};
+
+type DispatchLaunchSucceededOperationV1 = DispatchLaunchLaunchedOperationV1 & {
+  state: 'succeeded';
+  proof: DispatchLaunchProofV1;
+};
+
+type DispatchLaunchUnsuccessfulOperationV1 = DispatchLaunchOperationBaseV1 & {
+  state: 'failed' | 'cancelled' | 'delivery_unknown';
+  errorCode: DispatchLaunchErrorCode;
   effectiveOverride?: DispatchLaunchEffectiveOverride;
   launchIdentity?: DispatchLaunchIdentityV1;
   rootMessageId?: string;
   targetSessionId?: string;
   kickoffTurnId?: string;
   workerGeneration?: number;
-  proof?: DispatchLaunchProofV1;
-  errorCode?: DispatchLaunchErrorCode;
-  createdAt: string;
-  updatedAt: string;
-  expiresAt: string;
-}
+};
+
+export type DispatchLaunchOperationV1 =
+  | DispatchLaunchPreAdmissionOperationV1
+  | DispatchLaunchPreparedOperationV1
+  | DispatchLaunchStartingOperationV1
+  | DispatchLaunchAwaitingProofOperationV1
+  | DispatchLaunchSucceededOperationV1
+  | DispatchLaunchUnsuccessfulOperationV1;
 
 export interface DispatchLaunchAdmissionReceiptV1 {
   schemaVersion: typeof DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION;
@@ -210,7 +266,8 @@ export interface DispatchLaunchAdmissionReceiptV1 {
   sourceLarkAppId: string;
   sourceSessionId: string;
   sourceTurnId: string;
-  callerOpenId?: string;
+  /** Cross-app stable caller identity; never substitute an app-scoped open_id. */
+  callerUnionId?: string;
   chatId: string;
   targetLarkAppId: string;
   policyDigest: string;
@@ -234,19 +291,30 @@ export interface DispatchLaunchOverrideSnapshotV1 {
 }
 
 const nonEmptyString = z.string().trim().min(1);
-const larkAppIdSchema = nonEmptyString.regex(/^cli_[A-Za-z0-9]+$/);
+const identifierSchema = nonEmptyString
+  .max(DISPATCH_LAUNCH_CONTROL_LIMITS.identifierChars)
+  .regex(/^[A-Za-z0-9_.:-]+$/, 'must be a protocol-safe identifier');
+const controlledString = (max: number) => nonEmptyString.max(max)
+  .refine(value => !/[\u0000-\u001f\u007f]/.test(value), 'must not contain control characters');
+const larkAppIdSchema = nonEmptyString
+  .max(DISPATCH_LAUNCH_CONTROL_LIMITS.larkAppIdChars)
+  .regex(/^cli_[A-Za-z0-9]+$/);
 const dispatchIdSchema = z.string().regex(DISPATCH_LAUNCH_ID_RE);
 const digestSchema = z.string().regex(DISPATCH_LAUNCH_DIGEST_RE);
 const timestampSchema = z.string().datetime({ offset: true });
 const reasoningEffortSchema = z.enum(CODEX_REASONING_EFFORTS);
+const modelSchema = controlledString(DISPATCH_LAUNCH_CONTROL_LIMITS.modelChars);
 
 const requestedOverrideSchema = z.object({
-  model: nonEmptyString.optional(),
+  model: modelSchema.optional(),
   reasoningEffort: reasoningEffortSchema.optional(),
-}).strict();
+}).strict().refine(
+  value => value.model !== undefined || value.reasoningEffort !== undefined,
+  'at least one launch override is required',
+);
 
 const effectiveOverrideSchema = z.object({
-  model: nonEmptyString,
+  model: modelSchema,
   reasoningEffort: reasoningEffortSchema.optional(),
 }).strict();
 
@@ -262,36 +330,34 @@ const kickoffPayloadSchema = z.object({
 
 const canonicalKickoffSchema = z.object({
   payload: kickoffPayloadSchema,
-  canonicalJson: z.string(),
   byteLength: z.number().int().nonnegative().max(DISPATCH_LAUNCH_KICKOFF_LIMITS.totalBytes),
   digest: digestSchema,
 }).strict();
 
 const launchIdentitySchema = z.object({
-  cliId: nonEmptyString,
+  cliId: z.literal('codex'),
   cliRuntimeDigest: digestSchema,
-  executable: nonEmptyString,
-  wrapperCli: nonEmptyString.optional(),
-  backendType: nonEmptyString,
-  codexRpcInput: z.boolean(),
-  existingAppServer: z.boolean(),
+  executable: controlledString(DISPATCH_LAUNCH_CONTROL_LIMITS.executableChars),
+  wrapperCli: controlledString(DISPATCH_LAUNCH_CONTROL_LIMITS.wrapperChars).optional(),
+  backendType: z.enum(['pty', 'tmux', 'herdr', 'zellij', 'zmx']),
+  codexRpcInput: z.literal(false),
+  existingAppServer: z.literal(false),
   botConfigDigest: digestSchema,
   policyDigest: digestSchema,
 }).strict();
 
 const turnFactSchema = z.object({
-  sessionId: nonEmptyString,
-  kickoffTurnId: nonEmptyString,
-  workerGeneration: z.number().int().nonnegative(),
+  sessionId: identifierSchema,
+  kickoffTurnId: identifierSchema,
+  workerGeneration: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   observedAt: timestampSchema,
 }).strict();
 
 const proofSchema = z.object({
   inputCommitted: turnFactSchema,
   runtimeObserved: turnFactSchema.extend({
-    model: nonEmptyString,
+    model: modelSchema,
     reasoningEffort: reasoningEffortSchema.optional(),
-    equivalentToEffectiveOverride: z.literal(true),
   }).strict(),
 }).strict().superRefine((value, context) => {
   const left = value.inputCommitted;
@@ -312,12 +378,15 @@ export const DispatchLaunchPrepareRequestSchema = z.object({
   dispatchId: dispatchIdSchema,
   source: z.object({
     larkAppId: larkAppIdSchema,
-    sessionId: nonEmptyString,
-    turnId: nonEmptyString,
-    callerOpenId: nonEmptyString.optional(),
+    sessionId: identifierSchema,
+    turnId: identifierSchema,
+    callerUnionId: nonEmptyString
+      .max(DISPATCH_LAUNCH_CONTROL_LIMITS.callerUnionIdChars)
+      .regex(/^on_[A-Za-z0-9]+$/, 'must be a Lark union_id')
+      .optional(),
   }).strict(),
   targetLarkAppId: larkAppIdSchema,
-  chatId: nonEmptyString,
+  chatId: identifierSchema,
   kickoff: canonicalKickoffSchema,
   requestedOverride: requestedOverrideSchema,
   expiresAt: timestampSchema,
@@ -353,40 +422,95 @@ export const DispatchLaunchOperationSchema = z.object({
   owner: z.enum(['source', 'target']),
   state: z.enum(DISPATCH_LAUNCH_OPERATION_STATES),
   sourceLarkAppId: larkAppIdSchema,
-  sourceSessionId: nonEmptyString,
-  sourceTurnId: nonEmptyString,
+  sourceSessionId: identifierSchema,
+  sourceTurnId: identifierSchema,
   targetLarkAppId: larkAppIdSchema,
-  chatId: nonEmptyString,
+  chatId: identifierSchema,
   kickoff: canonicalKickoffSchema,
   requestedOverride: requestedOverrideSchema,
   effectiveOverride: effectiveOverrideSchema.optional(),
   launchIdentity: launchIdentitySchema.optional(),
-  rootMessageId: nonEmptyString.optional(),
-  targetSessionId: nonEmptyString.optional(),
-  kickoffTurnId: nonEmptyString.optional(),
-  workerGeneration: z.number().int().nonnegative().optional(),
+  rootMessageId: identifierSchema.optional(),
+  targetSessionId: identifierSchema.optional(),
+  kickoffTurnId: identifierSchema.optional(),
+  workerGeneration: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional(),
   proof: proofSchema.optional(),
   errorCode: z.enum(DISPATCH_LAUNCH_ERROR_CODES).optional(),
   createdAt: timestampSchema,
   updatedAt: timestampSchema,
   expiresAt: timestampSchema,
-}).strict();
+}).strict().superRefine((value, context) => {
+  const requireField = (field: keyof typeof value): void => {
+    if (value[field] === undefined) {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: [field], message: `${field} is required in ${value.state}` });
+    }
+  };
+  const forbidField = (field: keyof typeof value): void => {
+    if (value[field] !== undefined) {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: [field], message: `${field} is forbidden in ${value.state}` });
+    }
+  };
+  const launchFields = ['effectiveOverride', 'launchIdentity'] as const;
+  const runtimeFields = ['rootMessageId', 'targetSessionId', 'kickoffTurnId', 'workerGeneration'] as const;
+  if ((value.effectiveOverride === undefined) !== (value.launchIdentity === undefined)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'effectiveOverride and launchIdentity must be present or absent together',
+    });
+  }
+  if (value.targetSessionId !== undefined && value.rootMessageId === undefined) requireField('rootMessageId');
+  if (value.kickoffTurnId !== undefined && value.targetSessionId === undefined) requireField('targetSessionId');
+  if (value.workerGeneration !== undefined && value.kickoffTurnId === undefined) requireField('kickoffTurnId');
+
+  if (value.state === 'created' || value.state === 'preparing') {
+    for (const field of [...launchFields, ...runtimeFields, 'proof', 'errorCode'] as const) forbidField(field);
+  } else if (value.state === 'prepared') {
+    for (const field of launchFields) requireField(field);
+    for (const field of [...runtimeFields, 'proof', 'errorCode'] as const) forbidField(field);
+  } else if (value.state === 'starting') {
+    for (const field of launchFields) requireField(field);
+    forbidField('proof');
+    forbidField('errorCode');
+  } else if (value.state === 'awaiting_proof' || value.state === 'succeeded') {
+    for (const field of [...launchFields, ...runtimeFields] as const) requireField(field);
+    if (value.state === 'awaiting_proof') forbidField('proof');
+    else requireField('proof');
+    forbidField('errorCode');
+  } else {
+    forbidField('proof');
+    if (value.state === 'cancelled' && value.errorCode !== 'CANCELLED') {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: ['errorCode'], message: 'cancelled requires CANCELLED' });
+    }
+    if (value.state === 'delivery_unknown' && value.errorCode !== 'DELIVERY_UNKNOWN') {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: ['errorCode'], message: 'delivery_unknown requires DELIVERY_UNKNOWN' });
+    }
+    if (value.state === 'failed') {
+      requireField('errorCode');
+      if (value.errorCode === 'CANCELLED' || value.errorCode === 'DELIVERY_UNKNOWN') {
+        context.addIssue({ code: z.ZodIssueCode.custom, path: ['errorCode'], message: 'failed has a contradictory terminal error code' });
+      }
+    }
+  }
+});
 
 export const DispatchLaunchAdmissionReceiptSchema = z.object({
   schemaVersion: z.literal(DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION),
   dispatchId: dispatchIdSchema,
   state: z.enum(['authorized', 'committed', 'released']),
   sourceLarkAppId: larkAppIdSchema,
-  sourceSessionId: nonEmptyString,
-  sourceTurnId: nonEmptyString,
-  callerOpenId: nonEmptyString.optional(),
-  chatId: nonEmptyString,
+  sourceSessionId: identifierSchema,
+  sourceTurnId: identifierSchema,
+  callerUnionId: nonEmptyString
+    .max(DISPATCH_LAUNCH_CONTROL_LIMITS.callerUnionIdChars)
+    .regex(/^on_[A-Za-z0-9]+$/, 'must be a Lark union_id')
+    .optional(),
+  chatId: identifierSchema,
   targetLarkAppId: larkAppIdSchema,
   policyDigest: digestSchema,
-  talkAuthorizationReceiptId: nonEmptyString,
-  quotaReceiptId: nonEmptyString,
-  workingDir: nonEmptyString,
-  capacityReservationId: nonEmptyString,
+  talkAuthorizationReceiptId: identifierSchema,
+  quotaReceiptId: identifierSchema,
+  workingDir: controlledString(DISPATCH_LAUNCH_CONTROL_LIMITS.workingDirChars),
+  capacityReservationId: identifierSchema,
   createdAt: timestampSchema,
   committedAt: timestampSchema.optional(),
   releasedAt: timestampSchema.optional(),
@@ -467,7 +591,6 @@ export function canonicalizeDispatchLaunchKickoff(
   }
   return {
     payload,
-    canonicalJson: encoded,
     byteLength: encodedBytes,
     digest: `sha256:${createHash('sha256').update(encoded, 'utf8').digest('hex')}`,
   };
@@ -584,8 +707,7 @@ export function parseDispatchLaunchOperation(raw: unknown): DispatchLaunchOperat
     sourceDisplay: parsed.kickoff.payload.sourceDisplay,
     targetLarkAppId: parsed.kickoff.payload.targetLarkAppId,
   });
-  if (recomputed.canonicalJson !== parsed.kickoff.canonicalJson
-      || recomputed.byteLength !== parsed.kickoff.byteLength
+  if (recomputed.byteLength !== parsed.kickoff.byteLength
       || recomputed.digest !== parsed.kickoff.digest) {
     throw new Error('invalid dispatch launch operation: kickoff canonicalization mismatch');
   }
@@ -595,25 +717,20 @@ export function parseDispatchLaunchOperation(raw: unknown): DispatchLaunchOperat
   if (Date.parse(parsed.expiresAt) <= Date.parse(parsed.createdAt)) {
     throw new Error('invalid dispatch launch operation: expiresAt must follow createdAt');
   }
-  if (parsed.state === 'succeeded' && parsed.proof === undefined) {
-    throw new Error('invalid dispatch launch operation: succeeded operation requires turn-bound proof');
-  }
   if (parsed.state === 'succeeded') {
     const fact = parsed.proof!.inputCommitted;
-    if (parsed.targetSessionId === undefined
-        || parsed.kickoffTurnId === undefined
-        || parsed.workerGeneration === undefined
-        || parsed.effectiveOverride === undefined) {
-      throw new Error('invalid dispatch launch operation: succeeded operation requires launch identity fields');
-    }
     if (fact.sessionId !== parsed.targetSessionId
         || fact.kickoffTurnId !== parsed.kickoffTurnId
         || fact.workerGeneration !== parsed.workerGeneration) {
       throw new Error('invalid dispatch launch operation: proof does not match operation launch identity');
     }
+    if (!dispatchLaunchTupleEquivalent(parsed.proof!.runtimeObserved, parsed.effectiveOverride!)) {
+      throw new Error('invalid dispatch launch operation: runtime proof does not match effective override');
+    }
   }
-  if ((parsed.state === 'failed' || parsed.state === 'delivery_unknown') && parsed.errorCode === undefined) {
-    throw new Error('invalid dispatch launch operation: failed operation requires an error code');
+  if (parsed.effectiveOverride !== undefined
+      && !dispatchLaunchRequestedOverrideSatisfied(parsed.requestedOverride, parsed.effectiveOverride)) {
+    throw new Error('invalid dispatch launch operation: effective override does not satisfy requested override');
   }
   return parsed;
 }
@@ -628,7 +745,6 @@ export function parseDispatchLaunchPrepareRequest(raw: unknown): DispatchLaunchP
     targetLarkAppId: parsed.kickoff.payload.targetLarkAppId,
   });
   if (recomputed.digest !== parsed.kickoff.digest
-      || recomputed.canonicalJson !== parsed.kickoff.canonicalJson
       || recomputed.byteLength !== parsed.kickoff.byteLength) {
     throw new Error('invalid dispatch launch prepare request: kickoff canonicalization mismatch');
   }
@@ -666,4 +782,26 @@ export function parseDispatchLaunchOverrideSnapshot(raw: unknown): DispatchLaunc
     raw,
     'dispatch launch override snapshot',
   );
+}
+
+/**
+ * v1 recognizes no model aliases: equivalence is deliberately exact after
+ * trimming. An adapter may add an explicit canonical alias table in PR 3.
+ */
+export function dispatchLaunchTupleEquivalent(
+  observed: { model: string; reasoningEffort?: CodexReasoningEffort },
+  effective: DispatchLaunchEffectiveOverride,
+): boolean {
+  if (observed.model.trim() !== effective.model.trim()) return false;
+  return observed.reasoningEffort === effective.reasoningEffort;
+}
+
+export function dispatchLaunchRequestedOverrideSatisfied(
+  requested: DispatchLaunchRequestedOverride,
+  effective: DispatchLaunchEffectiveOverride,
+): boolean {
+  if (requested.model !== undefined && requested.model.trim() !== effective.model.trim()) return false;
+  if (requested.reasoningEffort !== undefined
+      && requested.reasoningEffort !== effective.reasoningEffort) return false;
+  return true;
 }

--- a/src/core/dispatch-launch-contract.ts
+++ b/src/core/dispatch-launch-contract.ts
@@ -416,11 +416,10 @@ export const DispatchLaunchPolicySchema = z.object({
   allowedReasoningEfforts: z.array(reasoningEffortSchema).max(CODEX_REASONING_EFFORTS.length),
 }).strict();
 
-export const DispatchLaunchOperationSchema = z.object({
+const dispatchLaunchOperationBaseShape = {
   schemaVersion: z.literal(DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION),
   dispatchId: dispatchIdSchema,
   owner: z.enum(['source', 'target']),
-  state: z.enum(DISPATCH_LAUNCH_OPERATION_STATES),
   sourceLarkAppId: larkAppIdSchema,
   sourceSessionId: identifierSchema,
   sourceTurnId: identifierSchema,
@@ -428,68 +427,128 @@ export const DispatchLaunchOperationSchema = z.object({
   chatId: identifierSchema,
   kickoff: canonicalKickoffSchema,
   requestedOverride: requestedOverrideSchema,
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+  expiresAt: timestampSchema,
+} as const;
+
+const dispatchLaunchFieldsShape = {
+  effectiveOverride: effectiveOverrideSchema,
+  launchIdentity: launchIdentitySchema,
+} as const;
+
+const dispatchLaunchRuntimeFieldsShape = {
+  rootMessageId: identifierSchema,
+  targetSessionId: identifierSchema,
+  kickoffTurnId: identifierSchema,
+  workerGeneration: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+} as const;
+
+const dispatchLaunchOptionalTerminalFieldsShape = {
   effectiveOverride: effectiveOverrideSchema.optional(),
   launchIdentity: launchIdentitySchema.optional(),
   rootMessageId: identifierSchema.optional(),
   targetSessionId: identifierSchema.optional(),
   kickoffTurnId: identifierSchema.optional(),
   workerGeneration: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional(),
-  proof: proofSchema.optional(),
-  errorCode: z.enum(DISPATCH_LAUNCH_ERROR_CODES).optional(),
-  createdAt: timestampSchema,
-  updatedAt: timestampSchema,
-  expiresAt: timestampSchema,
-}).strict().superRefine((value, context) => {
-  const requireField = (field: keyof typeof value): void => {
-    if (value[field] === undefined) {
-      context.addIssue({ code: z.ZodIssueCode.custom, path: [field], message: `${field} is required in ${value.state}` });
-    }
-  };
-  const forbidField = (field: keyof typeof value): void => {
-    if (value[field] !== undefined) {
-      context.addIssue({ code: z.ZodIssueCode.custom, path: [field], message: `${field} is forbidden in ${value.state}` });
-    }
-  };
-  const launchFields = ['effectiveOverride', 'launchIdentity'] as const;
-  const runtimeFields = ['rootMessageId', 'targetSessionId', 'kickoffTurnId', 'workerGeneration'] as const;
-  if ((value.effectiveOverride === undefined) !== (value.launchIdentity === undefined)) {
+} as const;
+
+const dispatchLaunchCreatedSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('created'),
+}).strict();
+
+const dispatchLaunchPreparingSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('preparing'),
+}).strict();
+
+const dispatchLaunchPreparedSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('prepared'),
+  ...dispatchLaunchFieldsShape,
+}).strict();
+
+const dispatchLaunchStartingSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('starting'),
+  ...dispatchLaunchFieldsShape,
+  rootMessageId: identifierSchema.optional(),
+  targetSessionId: identifierSchema.optional(),
+  kickoffTurnId: identifierSchema.optional(),
+  workerGeneration: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional(),
+}).strict();
+
+const dispatchLaunchAwaitingProofSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('awaiting_proof'),
+  ...dispatchLaunchFieldsShape,
+  ...dispatchLaunchRuntimeFieldsShape,
+}).strict();
+
+const dispatchLaunchSucceededSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('succeeded'),
+  ...dispatchLaunchFieldsShape,
+  ...dispatchLaunchRuntimeFieldsShape,
+  proof: proofSchema,
+}).strict();
+
+const dispatchLaunchFailedSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('failed'),
+  errorCode: z.enum(DISPATCH_LAUNCH_ERROR_CODES),
+  ...dispatchLaunchOptionalTerminalFieldsShape,
+}).strict();
+
+const dispatchLaunchCancelledSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('cancelled'),
+  errorCode: z.literal('CANCELLED'),
+  ...dispatchLaunchOptionalTerminalFieldsShape,
+}).strict();
+
+const dispatchLaunchDeliveryUnknownSchema = z.object({
+  ...dispatchLaunchOperationBaseShape,
+  state: z.literal('delivery_unknown'),
+  errorCode: z.literal('DELIVERY_UNKNOWN'),
+  ...dispatchLaunchOptionalTerminalFieldsShape,
+}).strict();
+
+export const DispatchLaunchOperationSchema = z.discriminatedUnion('state', [
+  dispatchLaunchCreatedSchema,
+  dispatchLaunchPreparingSchema,
+  dispatchLaunchPreparedSchema,
+  dispatchLaunchStartingSchema,
+  dispatchLaunchAwaitingProofSchema,
+  dispatchLaunchSucceededSchema,
+  dispatchLaunchFailedSchema,
+  dispatchLaunchCancelledSchema,
+  dispatchLaunchDeliveryUnknownSchema,
+]).superRefine((value, context) => {
+  const effectiveOverride = 'effectiveOverride' in value ? value.effectiveOverride : undefined;
+  const launchIdentity = 'launchIdentity' in value ? value.launchIdentity : undefined;
+  if ((effectiveOverride === undefined) !== (launchIdentity === undefined)) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
       message: 'effectiveOverride and launchIdentity must be present or absent together',
     });
   }
-  if (value.targetSessionId !== undefined && value.rootMessageId === undefined) requireField('rootMessageId');
-  if (value.kickoffTurnId !== undefined && value.targetSessionId === undefined) requireField('targetSessionId');
-  if (value.workerGeneration !== undefined && value.kickoffTurnId === undefined) requireField('kickoffTurnId');
-
-  if (value.state === 'created' || value.state === 'preparing') {
-    for (const field of [...launchFields, ...runtimeFields, 'proof', 'errorCode'] as const) forbidField(field);
-  } else if (value.state === 'prepared') {
-    for (const field of launchFields) requireField(field);
-    for (const field of [...runtimeFields, 'proof', 'errorCode'] as const) forbidField(field);
-  } else if (value.state === 'starting') {
-    for (const field of launchFields) requireField(field);
-    forbidField('proof');
-    forbidField('errorCode');
-  } else if (value.state === 'awaiting_proof' || value.state === 'succeeded') {
-    for (const field of [...launchFields, ...runtimeFields] as const) requireField(field);
-    if (value.state === 'awaiting_proof') forbidField('proof');
-    else requireField('proof');
-    forbidField('errorCode');
-  } else {
-    forbidField('proof');
-    if (value.state === 'cancelled' && value.errorCode !== 'CANCELLED') {
-      context.addIssue({ code: z.ZodIssueCode.custom, path: ['errorCode'], message: 'cancelled requires CANCELLED' });
-    }
-    if (value.state === 'delivery_unknown' && value.errorCode !== 'DELIVERY_UNKNOWN') {
-      context.addIssue({ code: z.ZodIssueCode.custom, path: ['errorCode'], message: 'delivery_unknown requires DELIVERY_UNKNOWN' });
-    }
-    if (value.state === 'failed') {
-      requireField('errorCode');
-      if (value.errorCode === 'CANCELLED' || value.errorCode === 'DELIVERY_UNKNOWN') {
-        context.addIssue({ code: z.ZodIssueCode.custom, path: ['errorCode'], message: 'failed has a contradictory terminal error code' });
-      }
-    }
+  if ('targetSessionId' in value && value.targetSessionId !== undefined
+      && (!('rootMessageId' in value) || value.rootMessageId === undefined)) {
+    context.addIssue({ code: z.ZodIssueCode.custom, path: ['rootMessageId'], message: 'rootMessageId is required before targetSessionId' });
+  }
+  if ('kickoffTurnId' in value && value.kickoffTurnId !== undefined
+      && (!('targetSessionId' in value) || value.targetSessionId === undefined)) {
+    context.addIssue({ code: z.ZodIssueCode.custom, path: ['targetSessionId'], message: 'targetSessionId is required before kickoffTurnId' });
+  }
+  if ('workerGeneration' in value && value.workerGeneration !== undefined
+      && (!('kickoffTurnId' in value) || value.kickoffTurnId === undefined)) {
+    context.addIssue({ code: z.ZodIssueCode.custom, path: ['kickoffTurnId'], message: 'kickoffTurnId is required before workerGeneration' });
+  }
+  if (value.state === 'failed'
+      && (value.errorCode === 'CANCELLED' || value.errorCode === 'DELIVERY_UNKNOWN')) {
+    context.addIssue({ code: z.ZodIssueCode.custom, path: ['errorCode'], message: 'failed has a contradictory terminal error code' });
   }
 });
 
@@ -728,8 +787,9 @@ export function parseDispatchLaunchOperation(raw: unknown): DispatchLaunchOperat
       throw new Error('invalid dispatch launch operation: runtime proof does not match effective override');
     }
   }
-  if (parsed.effectiveOverride !== undefined
-      && !dispatchLaunchRequestedOverrideSatisfied(parsed.requestedOverride, parsed.effectiveOverride)) {
+  const effectiveOverride = 'effectiveOverride' in parsed ? parsed.effectiveOverride : undefined;
+  if (effectiveOverride !== undefined
+      && !dispatchLaunchRequestedOverrideSatisfied(parsed.requestedOverride, effectiveOverride)) {
     throw new Error('invalid dispatch launch operation: effective override does not satisfy requested override');
   }
   return parsed;

--- a/src/core/dispatch-launch-ipc-auth.ts
+++ b/src/core/dispatch-launch-ipc-auth.ts
@@ -86,13 +86,21 @@ export function signDispatchLaunchIpcRequest(input: DispatchLaunchIpcSignInput):
     .digest('base64url');
 }
 
-/** Cryptographic check only; PR 2's route must additionally enforce time window and nonce replay state. */
+/**
+ * Total cryptographic guard: malformed wire input is a normal false result,
+ * never an exception. PR 2's route must additionally enforce timestamp window
+ * and nonce replay state.
+ */
 export function verifyDispatchLaunchIpcRequestSignature(input: DispatchLaunchIpcSignInput & {
   signature: string | undefined;
 }): boolean {
   if (!input.signature) return false;
-  const expected = signDispatchLaunchIpcRequest(input);
-  return wireEqual(input.signature, expected);
+  try {
+    const expected = signDispatchLaunchIpcRequest(input);
+    return wireEqual(input.signature, expected);
+  } catch {
+    return false;
+  }
 }
 
 export function canonicalDispatchLaunchIpcResponseMaterial(
@@ -128,6 +136,10 @@ export function verifyDispatchLaunchIpcResponseSignature(input: DispatchLaunchIp
   signature: string | undefined;
 }): boolean {
   if (!input.signature) return false;
-  const expected = signDispatchLaunchIpcResponse(input);
-  return wireEqual(input.signature, expected);
+  try {
+    const expected = signDispatchLaunchIpcResponse(input);
+    return wireEqual(input.signature, expected);
+  } catch {
+    return false;
+  }
 }

--- a/src/core/dispatch-launch-ipc-auth.ts
+++ b/src/core/dispatch-launch-ipc-auth.ts
@@ -1,0 +1,133 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+export const DISPATCH_LAUNCH_IPC_DOMAIN = 'botmux-dispatch-launch-ipc/v1';
+export const DISPATCH_LAUNCH_IPC_RESPONSE_DOMAIN = 'botmux-dispatch-launch-ipc/v1/response';
+export const DISPATCH_LAUNCH_IPC_ROUTE_PREFIX = '/__dispatch-launch-ipc/v1/operations';
+export const DISPATCH_LAUNCH_IPC_TS_WINDOW_MS = 60_000;
+export const DISPATCH_LAUNCH_IPC_NONCE_TTL_MS = 10 * 60_000;
+export const DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES = 80 * 1024;
+export const DISPATCH_LAUNCH_IPC_HEADERS = {
+  timestamp: 'x-botmux-dispatch-launch-ipc-ts',
+  nonce: 'x-botmux-dispatch-launch-ipc-nonce',
+  signature: 'x-botmux-dispatch-launch-ipc-signature',
+  responseSignature: 'x-botmux-dispatch-launch-ipc-response-signature',
+} as const;
+
+const B64URL_32_BYTES_RE = /^[A-Za-z0-9_-]{43}$/;
+
+export interface DispatchLaunchIpcTarget {
+  larkAppId: string;
+  ipcPort: number;
+  bootInstanceId: string;
+}
+
+export interface DispatchLaunchIpcSignInput {
+  secret: string;
+  timestamp: string;
+  nonce: string;
+  method: string;
+  pathWithQuery: string;
+  body: string | Uint8Array;
+  target: DispatchLaunchIpcTarget;
+}
+
+export interface DispatchLaunchIpcResponseSignInput {
+  secret: string;
+  requestNonce: string;
+  method: string;
+  pathWithQuery: string;
+  status: number;
+  body: string | Uint8Array;
+  target: DispatchLaunchIpcTarget;
+}
+
+function bodyBytes(body: string | Uint8Array): Buffer {
+  return typeof body === 'string' ? Buffer.from(body, 'utf8') : Buffer.from(body);
+}
+
+function validTarget(target: DispatchLaunchIpcTarget): boolean {
+  return Boolean(target.larkAppId)
+    && !/[\r\n\0]/.test(target.larkAppId)
+    && Number.isInteger(target.ipcPort)
+    && target.ipcPort >= 1
+    && target.ipcPort <= 65_535
+    && B64URL_32_BYTES_RE.test(target.bootInstanceId);
+}
+
+function wireEqual(provided: string | undefined, expected: string): boolean {
+  if (!provided || !B64URL_32_BYTES_RE.test(provided) || !B64URL_32_BYTES_RE.test(expected)) return false;
+  return timingSafeEqual(Buffer.from(provided, 'base64url'), Buffer.from(expected, 'base64url'));
+}
+
+/** Exact request bytes, target identity and daemon boot are all in the HMAC audience. */
+export function canonicalDispatchLaunchIpcMaterial(
+  input: Omit<DispatchLaunchIpcSignInput, 'secret'>,
+): string {
+  const bodySha256 = createHash('sha256').update(bodyBytes(input.body)).digest('hex');
+  return JSON.stringify([
+    DISPATCH_LAUNCH_IPC_DOMAIN,
+    input.timestamp,
+    input.nonce,
+    input.method.toUpperCase(),
+    input.pathWithQuery,
+    bodySha256,
+    input.target.larkAppId,
+    String(input.target.ipcPort),
+    input.target.bootInstanceId,
+  ]);
+}
+
+export function signDispatchLaunchIpcRequest(input: DispatchLaunchIpcSignInput): string {
+  if (!input.secret) throw new Error('dispatch launch IPC secret is empty');
+  if (!B64URL_32_BYTES_RE.test(input.nonce)) throw new Error('dispatch launch IPC nonce is invalid');
+  if (!validTarget(input.target)) throw new Error('dispatch launch IPC target descriptor is invalid');
+  return createHmac('sha256', input.secret)
+    .update(canonicalDispatchLaunchIpcMaterial(input), 'utf8')
+    .digest('base64url');
+}
+
+/** Cryptographic check only; PR 2's route must additionally enforce time window and nonce replay state. */
+export function verifyDispatchLaunchIpcRequestSignature(input: DispatchLaunchIpcSignInput & {
+  signature: string | undefined;
+}): boolean {
+  if (!input.signature) return false;
+  const expected = signDispatchLaunchIpcRequest(input);
+  return wireEqual(input.signature, expected);
+}
+
+export function canonicalDispatchLaunchIpcResponseMaterial(
+  input: Omit<DispatchLaunchIpcResponseSignInput, 'secret'>,
+): string {
+  const bodySha256 = createHash('sha256').update(bodyBytes(input.body)).digest('hex');
+  return JSON.stringify([
+    DISPATCH_LAUNCH_IPC_RESPONSE_DOMAIN,
+    input.requestNonce,
+    input.method.toUpperCase(),
+    input.pathWithQuery,
+    String(input.status),
+    bodySha256,
+    input.target.larkAppId,
+    String(input.target.ipcPort),
+    input.target.bootInstanceId,
+  ]);
+}
+
+export function signDispatchLaunchIpcResponse(input: DispatchLaunchIpcResponseSignInput): string {
+  if (!input.secret) throw new Error('dispatch launch IPC secret is empty');
+  if (!B64URL_32_BYTES_RE.test(input.requestNonce)) throw new Error('dispatch launch IPC request nonce is invalid');
+  if (!Number.isInteger(input.status) || input.status < 100 || input.status > 599) {
+    throw new Error('dispatch launch IPC response status is invalid');
+  }
+  if (!validTarget(input.target)) throw new Error('dispatch launch IPC target descriptor is invalid');
+  return createHmac('sha256', input.secret)
+    .update(canonicalDispatchLaunchIpcResponseMaterial(input), 'utf8')
+    .digest('base64url');
+}
+
+export function verifyDispatchLaunchIpcResponseSignature(input: DispatchLaunchIpcResponseSignInput & {
+  signature: string | undefined;
+}): boolean {
+  if (!input.signature) return false;
+  const expected = signDispatchLaunchIpcResponse(input);
+  return wireEqual(input.signature, expected);
+}

--- a/test/dispatch-args.test.ts
+++ b/test/dispatch-args.test.ts
@@ -42,6 +42,15 @@ describe('parseDispatchArgs', () => {
     expect(result).toMatchObject({ ok: true, value: { brief: '  keep me  ' } });
   });
 
+  it('preserves legacy dash-prefixed values in space-separated form', () => {
+    expect(parseDispatchArgs(['--brief', '- item one']))
+      .toMatchObject({ ok: true, value: { brief: '- item one' } });
+    expect(parseDispatchArgs(['--brief', '-x']))
+      .toMatchObject({ ok: true, value: { brief: '-x' } });
+    expect(parseDispatchArgs(['--title', '-x']))
+      .toMatchObject({ ok: true, value: { title: '-x' } });
+  });
+
   it.each([
     ['--model', ['--model', 'gpt-5']],
     ['--reasoning-effort', ['--reasoning-effort', 'high']],

--- a/test/dispatch-args.test.ts
+++ b/test/dispatch-args.test.ts
@@ -42,6 +42,11 @@ describe('parseDispatchArgs', () => {
     expect(result).toMatchObject({ ok: true, value: { brief: '  keep me  ' } });
   });
 
+  it('preserves explicit empty values for downstream legacy validation and fallback', () => {
+    expect(parseDispatchArgs(['--title', '', '--brief=', '--repo=']))
+      .toMatchObject({ ok: true, value: { title: '', brief: '', repo: '' } });
+  });
+
   it('preserves legacy dash-prefixed values in space-separated form', () => {
     expect(parseDispatchArgs(['--brief', '- item one']))
       .toMatchObject({ ok: true, value: { brief: '- item one' } });
@@ -72,7 +77,7 @@ describe('parseDispatchArgs', () => {
     });
   });
 
-  it.each(['--title', '--bot-app', '--brief-file='])(
+  it.each(['--title', '--bot-app'])(
     'rejects missing value for %s',
     (option) => {
       const result = parseDispatchArgs([option]);

--- a/test/dispatch-args.test.ts
+++ b/test/dispatch-args.test.ts
@@ -1,0 +1,115 @@
+import { type SpawnSyncReturns } from 'node:child_process';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { parseDispatchArgs } from '../src/cli/dispatch-args.js';
+import { spawnSyncTsScript } from './helpers/ts-runner.js';
+
+describe('parseDispatchArgs', () => {
+  it('preserves every documented legacy option and both value spellings', () => {
+    expect(parseDispatchArgs([
+      '--title=task',
+      '--bot-app', 'cli_worker:coder',
+      '--bot-app=cli_reviewer:reviewer',
+      '--bot', 'ou_legacy:Legacy:observer',
+      '--brief-file=/tmp/brief.md',
+      '--chat-id', 'oc_chat',
+      '--repo=/repo',
+      '--into', 'om_root',
+      '--session-id=sid',
+      '--standby',
+      '--steer',
+    ])).toEqual({
+      ok: true,
+      value: {
+        help: false,
+        title: 'task',
+        botApps: ['cli_worker:coder', 'cli_reviewer:reviewer'],
+        bots: ['ou_legacy:Legacy:observer'],
+        briefFile: '/tmp/brief.md',
+        chatId: 'oc_chat',
+        repo: '/repo',
+        into: 'om_root',
+        sessionId: 'sid',
+        standby: true,
+        steer: true,
+      },
+    });
+  });
+
+  it('keeps --brief text verbatim', () => {
+    const result = parseDispatchArgs(['--title', 't', '--bot-app', 'cli_a', '--brief', '  keep me  ']);
+    expect(result).toMatchObject({ ok: true, value: { brief: '  keep me  ' } });
+  });
+
+  it.each([
+    ['--model', ['--model', 'gpt-5']],
+    ['--reasoning-effort', ['--reasoning-effort', 'high']],
+    ['--mdoel', ['--mdoel', 'gpt-5']],
+    ['--unknown=value', ['--unknown=value']],
+  ])(
+    'rejects unknown option %s instead of silently dispatching',
+    (_label, optionArgs) => {
+      const result = parseDispatchArgs(['--title', 't', '--bot-app', 'cli_a', '--brief', 'b', ...optionArgs]);
+      expect(result).toMatchObject({ ok: false, errorCode: 'UNKNOWN_OPTION' });
+    },
+  );
+
+  it('rejects positional arguments', () => {
+    expect(parseDispatchArgs(['--title', 't', 'stray'])).toEqual({
+      ok: false,
+      errorCode: 'UNEXPECTED_ARGUMENT',
+      error: 'unexpected positional argument: stray',
+    });
+  });
+
+  it.each(['--title', '--bot-app', '--brief-file='])(
+    'rejects missing value for %s',
+    (option) => {
+      const result = parseDispatchArgs([option]);
+      expect(result).toMatchObject({ ok: false, errorCode: 'OPTION_VALUE_REQUIRED' });
+    },
+  );
+
+  it('preserves first-wins singleton and idempotent boolean behavior', () => {
+    expect(parseDispatchArgs(['--title', 'a', '--title', 'b']))
+      .toMatchObject({ ok: true, value: { title: 'a' } });
+    expect(parseDispatchArgs(['--standby', '--standby', '--steer', '--steer']))
+      .toMatchObject({ ok: true, value: { standby: true, steer: true } });
+  });
+
+  it('preserves repeatable bot flags', () => {
+    expect(parseDispatchArgs(['--bot-app', 'cli_a', '--bot-app', 'cli_b']))
+      .toMatchObject({ ok: true, value: { botApps: ['cli_a', 'cli_b'] } });
+  });
+
+  it('keeps both brief sources so cmdDispatch retains brief-file precedence', () => {
+    expect(parseDispatchArgs(['--brief', 'inline', '--brief-file', '/tmp/brief']))
+      .toMatchObject({
+        ok: true,
+        value: { brief: 'inline', briefFile: '/tmp/brief' },
+      });
+  });
+
+  it('preserves help short-circuit even alongside incomplete or unknown arguments', () => {
+    expect(parseDispatchArgs(['--help', '--title'])).toMatchObject({ ok: true, value: { help: true } });
+    expect(parseDispatchArgs(['--unknown', '-h'])).toMatchObject({ ok: true, value: { help: true } });
+  });
+
+  it('rejects unknown options at the CLI boundary before transport setup', () => {
+    const result = spawnSyncTsScript(
+      resolve('src/cli.ts'),
+      ['dispatch', '--title', 'task', '--model', 'gpt-5'],
+      { cwd: resolve('.'), encoding: 'utf8' },
+    ) as SpawnSyncReturns<string>;
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(JSON.parse(result.stderr)).toEqual({
+      success: false,
+      errorCode: 'UNKNOWN_OPTION',
+      detail: 'unknown option: --model',
+      option: '--model',
+    });
+  });
+});

--- a/test/dispatch-launch-contract.test.ts
+++ b/test/dispatch-launch-contract.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION,
+  DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION,
+  DISPATCH_LAUNCH_OVERRIDE_SCHEMA_VERSION,
+  DISPATCH_LAUNCH_POLICY_SCHEMA_VERSION,
+  canonicalizeDispatchLaunchKickoff,
+  dispatchLaunchIdentityDigest,
+  dispatchLaunchPolicyDigest,
+  evaluateDispatchLaunchPolicy,
+  normalizeDispatchLaunchPolicy,
+  parseDispatchLaunchAdmissionReceipt,
+  parseDispatchLaunchOperation,
+  parseDispatchLaunchOverrideSnapshot,
+  parseDispatchLaunchPrepareRequest,
+  resolveDispatchLaunchOverride,
+  type DispatchLaunchIdentityV1,
+  type DispatchLaunchOperationV1,
+  type DispatchLaunchPolicyV1,
+} from '../src/core/dispatch-launch-contract.js';
+
+const SHA = `sha256:${'a'.repeat(64)}`;
+const NOW = '2026-09-02T12:00:00.000Z';
+const LATER = '2026-09-02T12:05:00.000Z';
+
+const identity: DispatchLaunchIdentityV1 = {
+  cliId: 'codex',
+  cliRuntimeDigest: SHA,
+  executable: 'codex',
+  backendType: 'pty',
+  codexRpcInput: false,
+  existingAppServer: false,
+  botConfigDigest: SHA,
+  policyDigest: SHA,
+};
+
+function policy(overrides: Partial<DispatchLaunchPolicyV1> = {}): DispatchLaunchPolicyV1 {
+  return {
+    schemaVersion: DISPATCH_LAUNCH_POLICY_SCHEMA_VERSION,
+    enabled: true,
+    allowedSourceAppIds: ['cli_source'],
+    allowedModels: ['gpt-5.6-sol'],
+    allowedReasoningEfforts: ['high'],
+    ...overrides,
+  };
+}
+
+function operation(): DispatchLaunchOperationV1 {
+  return {
+    schemaVersion: DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION,
+    dispatchId: `dl_${'a'.repeat(32)}`,
+    owner: 'source',
+    state: 'prepared',
+    sourceLarkAppId: 'cli_source',
+    sourceSessionId: 'source-session',
+    sourceTurnId: 'source-turn',
+    targetLarkAppId: 'cli_target',
+    chatId: 'oc_chat',
+    kickoff: canonicalizeDispatchLaunchKickoff({
+      title: 'Task',
+      brief: 'Do the work',
+      sourceDisplay: 'Coordinator',
+      targetLarkAppId: 'cli_target',
+    }),
+    requestedOverride: { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+    effectiveOverride: { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+    launchIdentity: identity,
+    createdAt: NOW,
+    updatedAt: NOW,
+    expiresAt: LATER,
+  };
+}
+
+describe('dispatch launch canonical kickoff', () => {
+  it('normalizes newlines and produces stable canonical bytes', () => {
+    const crlf = canonicalizeDispatchLaunchKickoff({
+      title: 'Task\r\nOne',
+      brief: 'A\rB\r\nC',
+      role: ' coder ',
+      sourceDisplay: 'Source',
+      targetLarkAppId: 'cli_target',
+    });
+    const lf = canonicalizeDispatchLaunchKickoff({
+      title: 'Task\nOne',
+      brief: 'A\nB\nC',
+      role: ' coder ',
+      sourceDisplay: 'Source',
+      targetLarkAppId: 'cli_target',
+    });
+    expect(crlf).toEqual(lf);
+    expect(crlf.canonicalJson).not.toContain('\r');
+    expect(crlf.byteLength).toBe(Buffer.byteLength(crlf.canonicalJson, 'utf8'));
+  });
+
+  it('rejects empty, NUL-containing and oversized semantic fields', () => {
+    const base = { brief: 'Brief', sourceDisplay: 'Source', targetLarkAppId: 'cli_target' };
+    expect(() => canonicalizeDispatchLaunchKickoff({ ...base, title: '  ' })).toThrow('must not be empty');
+    expect(() => canonicalizeDispatchLaunchKickoff({ ...base, title: 'a\0b' })).toThrow('NUL');
+    expect(() => canonicalizeDispatchLaunchKickoff({ ...base, title: 'x'.repeat(513) })).toThrow('512');
+  });
+});
+
+describe('dispatch launch override and policy', () => {
+  it('requires a concrete model for every override', () => {
+    expect(resolveDispatchLaunchOverride({
+      cliId: 'codex',
+      requested: { reasoningEffort: 'high' },
+    })).toMatchObject({ ok: false, errorCode: 'MODEL_REQUIRED_FOR_OVERRIDE' });
+
+    expect(resolveDispatchLaunchOverride({
+      cliId: 'codex',
+      requested: { reasoningEffort: 'high' },
+      targetModel: 'gpt-5.6-sol',
+    })).toEqual({
+      ok: true,
+      effective: { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+    });
+  });
+
+  it('does not guess an effort and rejects unsupported v1 harnesses or tuples', () => {
+    expect(resolveDispatchLaunchOverride({
+      cliId: 'codex',
+      requested: { model: 'gpt-5.6-sol' },
+    })).toEqual({ ok: true, effective: { model: 'gpt-5.6-sol' } });
+    expect(resolveDispatchLaunchOverride({
+      cliId: 'codex-app',
+      requested: { model: 'gpt-5.6-sol' },
+    })).toMatchObject({ ok: false, errorCode: 'UNSUPPORTED_HARNESS' });
+    expect(resolveDispatchLaunchOverride({
+      cliId: 'codex',
+      requested: { model: 'gpt-5.5', reasoningEffort: 'ultra' },
+    })).toMatchObject({ ok: false, errorCode: 'INVALID_MODEL_EFFORT_COMBINATION' });
+  });
+
+  it('normalizes policy deterministically and defaults to explicit deny decisions', () => {
+    const normalized = normalizeDispatchLaunchPolicy(policy({
+      allowedSourceAppIds: ['cli_source', 'cli_source'],
+      allowedModels: ['gpt-5.6-sol', 'gpt-5.6-sol'],
+    }));
+    expect(normalized.allowedSourceAppIds).toEqual(['cli_source']);
+    expect(dispatchLaunchPolicyDigest(normalized)).toBe(dispatchLaunchPolicyDigest(normalized));
+    expect(evaluateDispatchLaunchPolicy({
+      sourceLarkAppId: 'cli_source',
+      effective: { model: 'gpt-5.6-sol' },
+    })).toMatchObject({ ok: false, errorCode: 'POLICY_DENIED' });
+    expect(evaluateDispatchLaunchPolicy({
+      policy: normalized,
+      sourceLarkAppId: 'cli_source',
+      effective: { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+    })).toMatchObject({ ok: true, policyDigest: expect.stringMatching(/^sha256:/) });
+    expect(evaluateDispatchLaunchPolicy({
+      policy: normalized,
+      sourceLarkAppId: 'cli_other',
+      effective: { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+    })).toMatchObject({ ok: false, errorCode: 'UNAUTHORIZED_SOURCE' });
+    expect(evaluateDispatchLaunchPolicy({
+      policy: policy({ enabled: false }),
+      sourceLarkAppId: 'cli_source',
+      effective: { model: 'gpt-5.6-sol' },
+    })).toMatchObject({ ok: false, errorCode: 'POLICY_DENIED' });
+    expect(dispatchLaunchIdentityDigest(identity)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});
+
+describe('dispatch launch versioned codecs', () => {
+  it('rejects unknown fields and canonical kickoff tampering', () => {
+    expect(() => parseDispatchLaunchOperation({ ...operation(), unknown: true })).toThrow('Unrecognized key');
+    const tampered = operation();
+    tampered.kickoff.digest = `sha256:${'b'.repeat(64)}`;
+    expect(() => parseDispatchLaunchOperation(tampered)).toThrow('canonicalization mismatch');
+  });
+
+  it('requires same-turn, same-generation proof before success', () => {
+    expect(() => parseDispatchLaunchOperation({ ...operation(), state: 'succeeded' })).toThrow('requires turn-bound proof');
+    const mismatched = {
+      ...operation(),
+      state: 'succeeded',
+      targetSessionId: 's',
+      kickoffTurnId: 't',
+      workerGeneration: 3,
+      proof: {
+        inputCommitted: { sessionId: 's', kickoffTurnId: 't', workerGeneration: 3, observedAt: NOW },
+        runtimeObserved: {
+          sessionId: 's', kickoffTurnId: 'other', workerGeneration: 3, observedAt: NOW, model: 'gpt-5.6-sol',
+          equivalentToEffectiveOverride: true,
+        },
+      },
+    };
+    expect(() => parseDispatchLaunchOperation(mismatched)).toThrow('same session, kickoff turn and worker generation');
+
+    const succeeded = {
+      ...mismatched,
+      proof: {
+        ...mismatched.proof,
+        runtimeObserved: {
+          ...mismatched.proof.runtimeObserved,
+          kickoffTurnId: 't',
+        },
+      },
+    };
+    expect(parseDispatchLaunchOperation(succeeded).state).toBe('succeeded');
+    expect(() => parseDispatchLaunchOperation({ ...succeeded, kickoffTurnId: 'other' }))
+      .toThrow('proof does not match operation launch identity');
+  });
+
+  it('validates prepare target binding, admission settlement and fork provenance', () => {
+    const base = operation();
+    expect(parseDispatchLaunchPrepareRequest({
+      schemaVersion: 1,
+      protocol: 'v1',
+      dispatchId: base.dispatchId,
+      source: { larkAppId: 'cli_source', sessionId: 's', turnId: 't' },
+      targetLarkAppId: 'cli_target',
+      chatId: 'oc_chat',
+      kickoff: base.kickoff,
+      requestedOverride: base.requestedOverride,
+      expiresAt: LATER,
+    }).targetLarkAppId).toBe('cli_target');
+
+    expect(() => parseDispatchLaunchAdmissionReceipt({
+      schemaVersion: DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION,
+      dispatchId: base.dispatchId,
+      state: 'committed',
+      sourceLarkAppId: 'cli_source', sourceSessionId: 's', sourceTurnId: 't',
+      chatId: 'oc_chat', targetLarkAppId: 'cli_target', policyDigest: SHA,
+      talkAuthorizationReceiptId: 'talk', quotaReceiptId: 'quota', workingDir: '/repo',
+      capacityReservationId: 'slot', createdAt: NOW,
+    })).toThrow('committedAt is required');
+
+    expect(() => parseDispatchLaunchOverrideSnapshot({
+      schemaVersion: DISPATCH_LAUNCH_OVERRIDE_SCHEMA_VERSION,
+      provenanceId: 'provenance',
+      dispatchId: base.dispatchId,
+      inheritedFromDispatchId: base.dispatchId,
+      effective: base.effectiveOverride,
+      launchIdentity: identity,
+      createdAt: NOW,
+    })).toThrow('exactly one');
+  });
+});

--- a/test/dispatch-launch-contract.test.ts
+++ b/test/dispatch-launch-contract.test.ts
@@ -209,7 +209,7 @@ describe('dispatch launch versioned codecs', () => {
   });
 
   it('requires same-turn, same-generation proof before success', () => {
-    expect(() => parseDispatchLaunchOperation({ ...operation(), state: 'succeeded' })).toThrow('required in succeeded');
+    expect(() => parseDispatchLaunchOperation({ ...operation(), state: 'succeeded' })).toThrow('Required');
     const mismatched = {
       ...operation(),
       state: 'succeeded',
@@ -328,19 +328,19 @@ describe('dispatch launch versioned codecs', () => {
     expect(parseDispatchLaunchOperation({ ...common, state: 'created' }).state).toBe('created');
     expect(() => parseDispatchLaunchOperation({
       ...common, state: 'created', effectiveOverride: prepared.effectiveOverride,
-    })).toThrow('forbidden in created');
+    })).toThrow('Unrecognized key');
     expect(() => parseDispatchLaunchOperation({ ...common, state: 'prepared' }))
-      .toThrow('required in prepared');
+      .toThrow('Required');
     expect(() => parseDispatchLaunchOperation({
       ...prepared, state: 'prepared', rootMessageId: 'root',
-    })).toThrow('forbidden in prepared');
+    })).toThrow('Unrecognized key');
     expect(() => parseDispatchLaunchOperation({ ...common, state: 'cancelled', errorCode: 'BAD_REQUEST' }))
-      .toThrow('cancelled requires CANCELLED');
+      .toThrow('expected \"CANCELLED\"');
     expect(parseDispatchLaunchOperation({ ...common, state: 'cancelled', errorCode: 'CANCELLED' }).state)
       .toBe('cancelled');
     expect(() => parseDispatchLaunchOperation({
       ...common, state: 'delivery_unknown', errorCode: 'INTERNAL_ERROR',
-    })).toThrow('delivery_unknown requires DELIVERY_UNKNOWN');
+    })).toThrow('expected \"DELIVERY_UNKNOWN\"');
     expect(() => parseDispatchLaunchOperation({ ...common, state: 'failed', errorCode: 'CANCELLED' }))
       .toThrow('contradictory terminal error code');
     expect(() => parseDispatchLaunchOperation({
@@ -363,6 +363,27 @@ describe('dispatch launch versioned codecs', () => {
     expect(() => parseDispatchLaunchPrepareRequest({
       ...request, source: { larkAppId: 'cli_source', sessionId: 's', turnId: 't', callerOpenId: 'ou_user' },
     })).toThrow('Unrecognized key');
+  });
+
+  it('rejects prepare payload tampering and target identity mismatch', () => {
+    const base = operation();
+    const request = {
+      schemaVersion: 1, protocol: 'v1', dispatchId: base.dispatchId,
+      source: { larkAppId: 'cli_source', sessionId: 's', turnId: 't' },
+      targetLarkAppId: 'cli_target', chatId: 'oc_chat', kickoff: base.kickoff,
+      requestedOverride: base.requestedOverride, expiresAt: LATER,
+    };
+    expect(() => parseDispatchLaunchPrepareRequest({
+      ...request,
+      kickoff: {
+        ...request.kickoff,
+        payload: { ...request.kickoff.payload, brief: 'EVIL INJECTED BRIEF' },
+      },
+    })).toThrow('kickoff canonicalization mismatch');
+    expect(() => parseDispatchLaunchPrepareRequest({
+      ...request,
+      targetLarkAppId: 'cli_other',
+    })).toThrow('target identity mismatch');
   });
 
   it('validates prepare target binding, admission settlement and fork provenance', () => {
@@ -388,6 +409,15 @@ describe('dispatch launch versioned codecs', () => {
       talkAuthorizationReceiptId: 'talk', quotaReceiptId: 'quota', workingDir: '/repo',
       capacityReservationId: 'slot', createdAt: NOW,
     })).toThrow('committedAt is required');
+    expect(() => parseDispatchLaunchAdmissionReceipt({
+      schemaVersion: DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION,
+      dispatchId: base.dispatchId,
+      state: 'authorized',
+      sourceLarkAppId: 'cli_source', sourceSessionId: 's', sourceTurnId: 't',
+      chatId: 'oc_chat', targetLarkAppId: 'cli_target', policyDigest: SHA,
+      talkAuthorizationReceiptId: 'talk', quotaReceiptId: 'quota', workingDir: '/repo',
+      capacityReservationId: 'slot', createdAt: NOW, committedAt: LATER,
+    })).toThrow('authorized receipt must be unsettled');
 
     expect(() => parseDispatchLaunchOverrideSnapshot({
       schemaVersion: DISPATCH_LAUNCH_OVERRIDE_SCHEMA_VERSION,

--- a/test/dispatch-launch-contract.test.ts
+++ b/test/dispatch-launch-contract.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION,
+  DISPATCH_LAUNCH_CONTROL_LIMITS,
   DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION,
   DISPATCH_LAUNCH_OVERRIDE_SCHEMA_VERSION,
   DISPATCH_LAUNCH_POLICY_SCHEMA_VERSION,
+  DISPATCH_LAUNCH_KICKOFF_LIMITS,
   canonicalizeDispatchLaunchKickoff,
   dispatchLaunchIdentityDigest,
   dispatchLaunchPolicyDigest,
@@ -19,6 +21,7 @@ import {
   type DispatchLaunchOperationV1,
   type DispatchLaunchPolicyV1,
 } from '../src/core/dispatch-launch-contract.js';
+import { DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES } from '../src/core/dispatch-launch-ipc-auth.js';
 
 const SHA = `sha256:${'a'.repeat(64)}`;
 const NOW = '2026-09-02T12:00:00.000Z';
@@ -89,8 +92,9 @@ describe('dispatch launch canonical kickoff', () => {
       targetLarkAppId: 'cli_target',
     });
     expect(crlf).toEqual(lf);
-    expect(crlf.canonicalJson).not.toContain('\r');
-    expect(crlf.byteLength).toBe(Buffer.byteLength(crlf.canonicalJson, 'utf8'));
+    expect(crlf.payload.title).not.toContain('\r');
+    expect(crlf.payload.brief).not.toContain('\r');
+    expect(crlf).not.toHaveProperty('canonicalJson');
   });
 
   it('rejects empty, NUL-containing and oversized semantic fields', () => {
@@ -98,6 +102,39 @@ describe('dispatch launch canonical kickoff', () => {
     expect(() => canonicalizeDispatchLaunchKickoff({ ...base, title: '  ' })).toThrow('must not be empty');
     expect(() => canonicalizeDispatchLaunchKickoff({ ...base, title: 'a\0b' })).toThrow('NUL');
     expect(() => canonicalizeDispatchLaunchKickoff({ ...base, title: 'x'.repeat(513) })).toThrow('512');
+  });
+
+  it('keeps a maximum legal prepare request below the IPC body limit', () => {
+    const kickoff = canonicalizeDispatchLaunchKickoff({
+      title: 't'.repeat(DISPATCH_LAUNCH_KICKOFF_LIMITS.titleBytes),
+      brief: 'b'.repeat(DISPATCH_LAUNCH_KICKOFF_LIMITS.briefBytes),
+      role: 'r'.repeat(DISPATCH_LAUNCH_KICKOFF_LIMITS.roleBytes),
+      sourceDisplay: 's'.repeat(DISPATCH_LAUNCH_KICKOFF_LIMITS.sourceDisplayBytes),
+      targetLarkAppId: `cli_${'a'.repeat(DISPATCH_LAUNCH_CONTROL_LIMITS.larkAppIdChars - 4)}`,
+    });
+    const prepare = {
+      schemaVersion: 1,
+      protocol: 'v1',
+      dispatchId: `dl_${'a'.repeat(32)}`,
+      source: {
+        larkAppId: `cli_${'b'.repeat(DISPATCH_LAUNCH_CONTROL_LIMITS.larkAppIdChars - 4)}`,
+        sessionId: 's'.repeat(DISPATCH_LAUNCH_CONTROL_LIMITS.identifierChars),
+        turnId: 't'.repeat(DISPATCH_LAUNCH_CONTROL_LIMITS.identifierChars),
+        callerUnionId: `on_${'u'.repeat(DISPATCH_LAUNCH_CONTROL_LIMITS.callerUnionIdChars - 3)}`,
+      },
+      targetLarkAppId: kickoff.payload.targetLarkAppId,
+      chatId: 'c'.repeat(DISPATCH_LAUNCH_CONTROL_LIMITS.identifierChars),
+      kickoff,
+      requestedOverride: {
+        model: 'm'.repeat(DISPATCH_LAUNCH_CONTROL_LIMITS.modelChars),
+        reasoningEffort: 'ultra',
+      },
+      expiresAt: LATER,
+    };
+    expect(parseDispatchLaunchPrepareRequest(prepare)).toEqual(prepare);
+    expect(Buffer.byteLength(JSON.stringify(prepare), 'utf8')).toBeLessThanOrEqual(
+      DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES,
+    );
   });
 });
 
@@ -172,10 +209,11 @@ describe('dispatch launch versioned codecs', () => {
   });
 
   it('requires same-turn, same-generation proof before success', () => {
-    expect(() => parseDispatchLaunchOperation({ ...operation(), state: 'succeeded' })).toThrow('requires turn-bound proof');
+    expect(() => parseDispatchLaunchOperation({ ...operation(), state: 'succeeded' })).toThrow('required in succeeded');
     const mismatched = {
       ...operation(),
       state: 'succeeded',
+      rootMessageId: 'root',
       targetSessionId: 's',
       kickoffTurnId: 't',
       workerGeneration: 3,
@@ -183,7 +221,7 @@ describe('dispatch launch versioned codecs', () => {
         inputCommitted: { sessionId: 's', kickoffTurnId: 't', workerGeneration: 3, observedAt: NOW },
         runtimeObserved: {
           sessionId: 's', kickoffTurnId: 'other', workerGeneration: 3, observedAt: NOW, model: 'gpt-5.6-sol',
-          equivalentToEffectiveOverride: true,
+          reasoningEffort: 'high',
         },
       },
     };
@@ -202,6 +240,129 @@ describe('dispatch launch versioned codecs', () => {
     expect(parseDispatchLaunchOperation(succeeded).state).toBe('succeeded');
     expect(() => parseDispatchLaunchOperation({ ...succeeded, kickoffTurnId: 'other' }))
       .toThrow('proof does not match operation launch identity');
+  });
+
+  it.each([
+    ['model mismatch', { model: 'wrong-model', reasoningEffort: 'high' }],
+    ['effort missing', { model: 'gpt-5.6-sol' }],
+    ['effort mismatch', { model: 'gpt-5.6-sol', reasoningEffort: 'low' }],
+  ])('rejects succeeded runtime proof with %s', (_label, runtime) => {
+    const base = operation();
+    expect(() => parseDispatchLaunchOperation({
+      ...base,
+      state: 'succeeded',
+      rootMessageId: 'root', targetSessionId: 's', kickoffTurnId: 't', workerGeneration: 1,
+      proof: {
+        inputCommitted: { sessionId: 's', kickoffTurnId: 't', workerGeneration: 1, observedAt: NOW },
+        runtimeObserved: {
+          sessionId: 's', kickoffTurnId: 't', workerGeneration: 1, observedAt: NOW, ...runtime,
+        },
+      },
+    })).toThrow('runtime proof does not match effective override');
+  });
+
+  it('rejects an observed effort when the effective tuple has none', () => {
+    const base = operation();
+    expect(() => parseDispatchLaunchOperation({
+      ...base,
+      requestedOverride: { model: 'gpt-5.6-sol' },
+      effectiveOverride: { model: 'gpt-5.6-sol' },
+      state: 'succeeded',
+      rootMessageId: 'root', targetSessionId: 's', kickoffTurnId: 't', workerGeneration: 1,
+      proof: {
+        inputCommitted: { sessionId: 's', kickoffTurnId: 't', workerGeneration: 1, observedAt: NOW },
+        runtimeObserved: {
+          sessionId: 's', kickoffTurnId: 't', workerGeneration: 1, observedAt: NOW,
+          model: 'gpt-5.6-sol', reasoningEffort: 'high',
+        },
+      },
+    })).toThrow('runtime proof does not match effective override');
+  });
+
+  it('accepts a fully matching tuple with no explicit effort', () => {
+    const base = operation();
+    expect(parseDispatchLaunchOperation({
+      ...base,
+      requestedOverride: { model: 'gpt-5.6-sol' },
+      effectiveOverride: { model: 'gpt-5.6-sol' },
+      state: 'succeeded',
+      rootMessageId: 'root', targetSessionId: 's', kickoffTurnId: 't', workerGeneration: 1,
+      proof: {
+        inputCommitted: { sessionId: 's', kickoffTurnId: 't', workerGeneration: 1, observedAt: NOW },
+        runtimeObserved: {
+          sessionId: 's', kickoffTurnId: 't', workerGeneration: 1, observedAt: NOW, model: 'gpt-5.6-sol',
+        },
+      },
+    }).state).toBe('succeeded');
+  });
+
+  it('rejects requested/effective drift, unsupported identity, and invalid generations', () => {
+    expect(() => parseDispatchLaunchOperation({
+      ...operation(), effectiveOverride: { model: 'other', reasoningEffort: 'high' },
+    })).toThrow('effective override does not satisfy requested override');
+    expect(() => parseDispatchLaunchOperation({
+      ...operation(), launchIdentity: { ...identity, cliId: 'traex' },
+    })).toThrow('Invalid literal value');
+    expect(() => parseDispatchLaunchOperation({
+      ...operation(), launchIdentity: { ...identity, codexRpcInput: true },
+    })).toThrow('Invalid literal value');
+    expect(() => parseDispatchLaunchOperation({
+      ...operation(), state: 'awaiting_proof', rootMessageId: 'r', targetSessionId: 's',
+      kickoffTurnId: 't', workerGeneration: 0,
+    })).toThrow('greater than 0');
+    expect(() => parseDispatchLaunchOperation({
+      ...operation(), state: 'awaiting_proof', rootMessageId: 'r', targetSessionId: 's',
+      kickoffTurnId: 't', workerGeneration: Number.MAX_SAFE_INTEGER + 1,
+    })).toThrow('less than or equal');
+  });
+
+  it('enforces state-specific required and forbidden fields', () => {
+    const prepared = operation();
+    const common = {
+      schemaVersion: prepared.schemaVersion, dispatchId: prepared.dispatchId, owner: prepared.owner,
+      sourceLarkAppId: prepared.sourceLarkAppId, sourceSessionId: prepared.sourceSessionId,
+      sourceTurnId: prepared.sourceTurnId, targetLarkAppId: prepared.targetLarkAppId, chatId: prepared.chatId,
+      kickoff: prepared.kickoff, requestedOverride: prepared.requestedOverride,
+      createdAt: prepared.createdAt, updatedAt: prepared.updatedAt, expiresAt: prepared.expiresAt,
+    };
+    expect(parseDispatchLaunchOperation({ ...common, state: 'created' }).state).toBe('created');
+    expect(() => parseDispatchLaunchOperation({
+      ...common, state: 'created', effectiveOverride: prepared.effectiveOverride,
+    })).toThrow('forbidden in created');
+    expect(() => parseDispatchLaunchOperation({ ...common, state: 'prepared' }))
+      .toThrow('required in prepared');
+    expect(() => parseDispatchLaunchOperation({
+      ...prepared, state: 'prepared', rootMessageId: 'root',
+    })).toThrow('forbidden in prepared');
+    expect(() => parseDispatchLaunchOperation({ ...common, state: 'cancelled', errorCode: 'BAD_REQUEST' }))
+      .toThrow('cancelled requires CANCELLED');
+    expect(parseDispatchLaunchOperation({ ...common, state: 'cancelled', errorCode: 'CANCELLED' }).state)
+      .toBe('cancelled');
+    expect(() => parseDispatchLaunchOperation({
+      ...common, state: 'delivery_unknown', errorCode: 'INTERNAL_ERROR',
+    })).toThrow('delivery_unknown requires DELIVERY_UNKNOWN');
+    expect(() => parseDispatchLaunchOperation({ ...common, state: 'failed', errorCode: 'CANCELLED' }))
+      .toThrow('contradictory terminal error code');
+    expect(() => parseDispatchLaunchOperation({
+      ...common, state: 'failed', errorCode: 'INTERNAL_ERROR', effectiveOverride: prepared.effectiveOverride,
+    })).toThrow('present or absent together');
+    expect(() => parseDispatchLaunchOperation({
+      ...common, state: 'failed', errorCode: 'INTERNAL_ERROR', targetSessionId: 'session',
+    })).toThrow('rootMessageId is required');
+  });
+
+  it('uses cross-app union identity and rejects app-scoped caller open ids', () => {
+    const base = operation();
+    const request = {
+      schemaVersion: 1, protocol: 'v1', dispatchId: base.dispatchId,
+      source: { larkAppId: 'cli_source', sessionId: 's', turnId: 't', callerUnionId: 'on_user' },
+      targetLarkAppId: 'cli_target', chatId: 'oc_chat', kickoff: base.kickoff,
+      requestedOverride: base.requestedOverride, expiresAt: LATER,
+    };
+    expect(parseDispatchLaunchPrepareRequest(request).source.callerUnionId).toBe('on_user');
+    expect(() => parseDispatchLaunchPrepareRequest({
+      ...request, source: { larkAppId: 'cli_source', sessionId: 's', turnId: 't', callerOpenId: 'ou_user' },
+    })).toThrow('Unrecognized key');
   });
 
   it('validates prepare target binding, admission settlement and fork provenance', () => {

--- a/test/dispatch-launch-ipc-auth.test.ts
+++ b/test/dispatch-launch-ipc-auth.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DISPATCH_LAUNCH_IPC_DOMAIN,
+  canonicalDispatchLaunchIpcMaterial,
+  signDispatchLaunchIpcRequest,
+  signDispatchLaunchIpcResponse,
+  verifyDispatchLaunchIpcRequestSignature,
+  verifyDispatchLaunchIpcResponseSignature,
+} from '../src/core/dispatch-launch-ipc-auth.js';
+
+const target = {
+  larkAppId: 'cli_target',
+  ipcPort: 4100,
+  bootInstanceId: 'A'.repeat(43),
+};
+const request = {
+  secret: 'secret',
+  timestamp: '1788350400000',
+  nonce: 'B'.repeat(43),
+  method: 'POST',
+  pathWithQuery: '/__dispatch-launch-ipc/v1/operations/dl_x/prepare',
+  body: '{"dispatchId":"dl_x"}',
+  target,
+};
+
+describe('dispatch launch IPC signing contract', () => {
+  it('uses a dedicated domain and binds exact request bytes plus target boot', () => {
+    expect(canonicalDispatchLaunchIpcMaterial(request)).toContain(DISPATCH_LAUNCH_IPC_DOMAIN);
+    const signature = signDispatchLaunchIpcRequest(request);
+    expect(verifyDispatchLaunchIpcRequestSignature({ ...request, signature })).toBe(true);
+    expect(verifyDispatchLaunchIpcRequestSignature({ ...request, body: '{}', signature })).toBe(false);
+    expect(verifyDispatchLaunchIpcRequestSignature({
+      ...request, target: { ...target, bootInstanceId: 'C'.repeat(43) }, signature,
+    })).toBe(false);
+  });
+
+  it('signs responses in a separate domain and binds status and request nonce', () => {
+    const response = {
+      secret: request.secret,
+      requestNonce: request.nonce,
+      method: request.method,
+      pathWithQuery: request.pathWithQuery,
+      status: 200,
+      body: '{"ok":true}',
+      target,
+    };
+    const signature = signDispatchLaunchIpcResponse(response);
+    expect(verifyDispatchLaunchIpcResponseSignature({ ...response, signature })).toBe(true);
+    expect(verifyDispatchLaunchIpcResponseSignature({ ...response, status: 409, signature })).toBe(false);
+    expect(verifyDispatchLaunchIpcResponseSignature({
+      ...response, requestNonce: 'D'.repeat(43), signature,
+    })).toBe(false);
+  });
+
+  it('rejects malformed target audiences and nonces', () => {
+    expect(() => signDispatchLaunchIpcRequest({ ...request, nonce: 'short' })).toThrow('nonce');
+    expect(() => signDispatchLaunchIpcRequest({
+      ...request, target: { ...target, ipcPort: 0 },
+    })).toThrow('target descriptor');
+  });
+});

--- a/test/dispatch-launch-ipc-auth.test.ts
+++ b/test/dispatch-launch-ipc-auth.test.ts
@@ -58,5 +58,16 @@ describe('dispatch launch IPC signing contract', () => {
     expect(() => signDispatchLaunchIpcRequest({
       ...request, target: { ...target, ipcPort: 0 },
     })).toThrow('target descriptor');
+    expect(verifyDispatchLaunchIpcRequestSignature({
+      ...request, nonce: 'short', signature: 'X'.repeat(43),
+    })).toBe(false);
+    expect(verifyDispatchLaunchIpcRequestSignature({
+      ...request, target: { ...target, ipcPort: 0 }, signature: 'X'.repeat(43),
+    })).toBe(false);
+    expect(verifyDispatchLaunchIpcResponseSignature({
+      secret: request.secret, requestNonce: 'short', method: 'POST',
+      pathWithQuery: request.pathWithQuery, status: 99, body: '{}', target,
+      signature: 'X'.repeat(43),
+    })).toBe(false);
   });
 });


### PR DESCRIPTION
## 背景与最终目标

目标是在多话题协作中，让发起方能够为一次派发安全地选择目标子 agent 的 session-scoped model / reasoning effort，同时满足两条强约束：

- 显式 override 不能被旧版本静默忽略后按默认模型执行；
- 只有同一 kickoff turn、同一 worker generation 的输入提交和运行时观测都成立时，才能报告成功。

这项能力横跨 CLI 兼容、source/target daemon 协议、授权与额度、session 启动/恢复和 Codex 运行时证明。为避免中间版本暴露不完整能力，本 PR 只提交兼容与协议基座，不开放 `dispatch-launch`、不发布 capability，也不接入 daemon route 或 worker 启动路径。

## 本 PR 做了什么

### 1. 让现有 `dispatch` 对未知参数 fail closed

新增消费式参数解析器，在任何网络、文件或 daemon 副作用之前拒绝：

- 未知 option（包括当前尚未开放的 `--model` / `--reasoning-effort`）；
- 非预期位置参数；
- 已知 option 缺值。

同时保留既有合法行为：

- `--help` / `-h` 仍优先短路；
- 单值参数重复时仍取第一个；
- 布尔参数重复仍幂等；
- `--bot` / `--bot-app` 仍可重复；
- 同时传 `--brief` 和 `--brief-file` 时仍由文件覆盖内联内容。

这为未来独立入口提供防误用基线，但不会把 `dispatch --model` 变成公开接口。

### 2. 定义未接入运行时的 v1 数据契约

新增纯数据模块，定义并严格校验：

- stable error codes；
- prepare/start/cancel request schema；
- target-side 默认拒绝 policy 及 deterministic digest；
- requested/effective override 解析，要求任一 override 都能冻结具体 model；
- launch identity digest；
- source/target operation、admission receipt、session override snapshot 的 versioned codec；
- `/fork` 只继承 effective tuple、不复用原 dispatch identity 的 provenance 结构；
- 成功 operation 必须具有绑定同一 session、kickoff turn、worker generation 的 `inputCommitted` 与 `runtimeObserved` proof。

v1 contract 当前只接受官方 Codex TUI；Codex App/RPC、TraeX、Grok 等不会被误判为已经支持。

### 3. 固化 canonical payload 与独立 IPC 签名域

- kickoff 语义内容统一为 UTF-8、LF 换行和 canonical JSON；
- title/brief/role/source display/target app/protocol version 参与 digest；
- Lark 渲染、mention、delivery marker 不参与 digest；
- 设置逐字段及总字节上限；
- dispatch launch IPC 使用独立 domain/header/route namespace；
- HMAC 覆盖完整 body、method/path、target app/port 和 `bootInstanceId`；
- response 使用独立签名域，并绑定 request nonce 与 status。

时间窗、nonce replay store、route handler 和持久状态机会在 transport PR 中接入；当前签名模块只提供明确命名的 cryptographic primitive，避免被误当成完整 admission verifier。

## 向后兼容与影响范围

- 已有合法 `botmux dispatch` 调用保持参数取值、投递和输出语义不变。
- 旧 bot 配置、旧 session、所有现有 harness 均无迁移要求。
- 唯一有意变化是过去被静默忽略的未知参数/位置参数现在会以机器可读错误和 exit code 2 失败。
- 未修改 daemon descriptor、capabilities、bot config、session schema、Lark routing、worker、adapter、后端或已有 operation store。
- 未新增公开命令或运行时 feature，因此本 PR 合入后用户不能发起 launch override。

## 验证

```bash
PATH=/data00/home/tan.yuanhong/.bun/bin:$PATH bun run test -- \
  test/dispatch.test.ts \
  test/dispatch-lifecycle.test.ts \
  test/dispatch-registry.test.ts \
  test/dispatch-report-binding.test.ts \
  test/exact-chat-grant-client.test.ts \
  test/trigger-session-root-message.test.ts \
  test/session-launch-model.test.ts \
  test/capabilities.test.ts \
  test/dispatch-args.test.ts \
  test/dispatch-launch-contract.test.ts \
  test/dispatch-launch-ipc-auth.test.ts
```

结果：11 个测试文件、194 项测试全部通过。

```bash
PATH=/data00/home/tan.yuanhong/.bun/bin:$PATH bun run build
```

结果：TypeScript、scripts typecheck、dashboard bundle 与产物审计全部通过。

## Follow-up PR

### PR 2：内部 target-authoritative transport 与恢复

- source daemon 成为 operation 的唯一 writer，并恢复非终态 operation；
- target daemon 提供签名的 prepare/start/query/cancel；
- 接入 timestamp/nonce 防重放、target policy、现有 bot-talk authorization 与 quota exactly-once；
- target 直接创建 Lark root 和 fresh thread session，不依赖 Lark `@` 入站触发 launch；
- 接入 workingDir/capacity reservation、幂等 Lark UUID、durable recovery 与 `delivery_unknown`；
- 仅内部 feature gate 使用，不开放普通用户入口。

### PR 3：统一 launch resolver、强运行时证明与正式开放

- session-scoped override 接入首次启动、restart、restore 和 fork；
- Codex runtime observation 绑定 kickoff turn 与 worker generation；
- 以 `inputCommitted && runtimeObserved` 且 effective tuple 等价作为成功条件；
- 完成故障注入覆盖后开放独立 `botmux dispatch-launch --model ... --reasoning-effort ...`，并发布 capability。

### 后续扩展（不阻塞 v1）

- 多目标 fan-out；
- Codex App/RPC、TraeX、Grok 等 harness；
- pending repo、容量排队和异步模式；
- fleet 基线成熟后，再考虑为原 `dispatch` 增加 `--model` / `--reasoning-effort` 别名。
