### PR TITLE
fix(env): 补齐 supervisor/dashboard 启动期环境变量清理，追平 daemon

### DIFF
--- a/src/index-dashboard.ts
+++ b/src/index-dashboard.ts
@@ -14,7 +14,13 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { existsSync } from 'node:fs';
 import { installStdioEpipeGuard } from './utils/stdio-epipe-guard.js';
-import { scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv, scrubWorkflowWorkerEnv } from './utils/child-env.js';
+import {
+  scrubClaudeSessionMarkerEnv,
+  scrubInvokerTerminalEnv,
+  scrubSessionCliHomeEnv,
+  scrubSessionTurnMarkerEnv,
+  scrubWorkflowWorkerEnv,
+} from './utils/child-env.js';
 import { loadDashboardEnvFile } from './utils/dashboard-env.js';
 
 // Same pipe topology as the daemon: under pm2 the dashboard's stdout/stderr are
@@ -55,9 +61,14 @@ loadDashboardEnvFile(existsSync(globalEnv) ? globalEnv : '.env');
 //    sets no app id.
 //  - BOTMUX_OWNER_OPEN_ID/__OWNER_OPEN_ID: app-scoped owner identity of the
 //    issuing session; stale by definition here.
-for (const k of ['BOTMUX_SESSION_ID', 'BOTMUX_LARK_APP_ID', 'BOTMUX_CHAT_ID', 'BOTMUX_CHAT_TYPE', 'BOTMUX_ROOT_MESSAGE_ID', 'BOTMUX_OWNER_OPEN_ID', '__OWNER_OPEN_ID']) {
-  delete process.env[k];
-}
+// Turn-scoped session identity and capabilities of the invoking bot session
+// (routing ids, MCP gateway socket, sandbox verdicts, ...) — same canonical
+// list index-daemon.ts scrubs. The hand-picked 7-key subset this used to be
+// had fallen behind that list (e.g. BOTMUX_MCP_GATEWAY_SOCKET, IS_SANDBOX
+// were never in it), silently letting a growing set of session-only values
+// ride into every child this process forks (debug terminals, start/stop-bot
+// CLI runs, the detached update/restart driver).
+scrubSessionTurnMarkerEnv(process.env);
 // CLAUDE_CONFIG_DIR / CODEX_HOME: per-session CLI data roots. No dashboard
 // consumer; inherited into a debug-terminal CLI they redirect it into the
 // leaking bot's home.
@@ -71,6 +82,11 @@ scrubClaudeSessionMarkerEnv(process.env);
 // dist/dashboard.js directly, bypassing this entry; doing it here as well keeps
 // the new boundary complete without relying on that legacy call.
 scrubWorkflowWorkerEnv(process.env);
+// Invoker-terminal fingerprints (NO_COLOR=1 / CODEX_CI=1 / PAGER=cat from a
+// non-interactive restart shell): inherited into a forked debug terminal they
+// render it colorless. Re-pin TERM after, same constant index-daemon.ts uses.
+scrubInvokerTerminalEnv(process.env);
+process.env.TERM = 'xterm-256color';
 // Deliberately NOT scrubbed, unlike index-daemon.ts: the Feishu H5 family
 // (BOTMUX_DASHBOARD_FEISHU_H5_*). The dashboard process is its single
 // legitimate consumer — delivering it is this entry point's purpose. The

--- a/src/index-supervisor.ts
+++ b/src/index-supervisor.ts
@@ -34,6 +34,12 @@ dotenvConfig({ path: existsSync(globalEnv) ? globalEnv : '.env' });
 // process's env into every supervised member, so an unstripped secret would
 // sit in this long-lived process for its whole life and ride into every bot
 // daemon (which then strips it again at its own boot).
+//
+// This also cuts the ambient-env inheritance path into the dashboard
+// (supervisor is its parent; daemon is not). That's intentional: aligned
+// with the long-standing scrubPm2CallerEnv convention on the pm2 path; the
+// supervisor form never had this boundary before. The documented channel
+// remains ~/.botmux/.env — the dashboard loads that file itself.
 stripDashboardH5Env(process.env);
 // A supervisor is never a session (mirror index-daemon): a `botmux
 // start/restart` issued from inside a bot session leaks that session's

--- a/src/index-supervisor.ts
+++ b/src/index-supervisor.ts
@@ -12,7 +12,14 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { existsSync, readFileSync } from 'node:fs';
 import { installStdioEpipeGuard } from './utils/stdio-epipe-guard.js';
-import { scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv, scrubWorkflowWorkerEnv } from './utils/child-env.js';
+import {
+  scrubClaudeSessionMarkerEnv,
+  scrubInvokerTerminalEnv,
+  scrubSessionCliHomeEnv,
+  scrubSessionTurnMarkerEnv,
+  scrubWorkflowWorkerEnv,
+  stripDashboardH5Env,
+} from './utils/child-env.js';
 
 installStdioEpipeGuard();
 
@@ -20,13 +27,27 @@ const configDir = join(homedir(), '.botmux');
 const globalEnv = join(configDir, '.env');
 dotenvConfig({ path: existsSync(globalEnv) ? globalEnv : '.env' });
 
-// A supervisor is never a session (mirror index-daemon): scrub leaked identity.
-for (const k of ['BOTMUX_SESSION_ID', 'BOTMUX_LARK_APP_ID', 'BOTMUX_CHAT_ID', 'BOTMUX_CHAT_TYPE', 'BOTMUX_ROOT_MESSAGE_ID', 'BOTMUX_OWNER_OPEN_ID', '__OWNER_OPEN_ID']) {
-  delete process.env[k];
-}
+// The dotenv load above pulls in ~/.botmux/.env WHOLESALE, same as
+// index-daemon.ts — including the Dashboard-only Feishu H5 login family. The
+// supervisor is not that family's consumer (the dashboard reloads it itself
+// via index-dashboard.ts), and resolveFleetDaemonEnv() below spreads this
+// process's env into every supervised member, so an unstripped secret would
+// sit in this long-lived process for its whole life and ride into every bot
+// daemon (which then strips it again at its own boot).
+stripDashboardH5Env(process.env);
+// A supervisor is never a session (mirror index-daemon): a `botmux
+// start/restart` issued from inside a bot session leaks that session's
+// identity/capabilities into this long-lived process, and
+// resolveFleetDaemonEnv() bakes whatever remains here into every daemon
+// child's starting env for the supervisor's whole lifetime. Match
+// index-daemon.ts's boot scrub exactly (rather than a hand-picked subset of
+// keys) so this boundary can't silently fall behind the next key added there.
+scrubSessionTurnMarkerEnv(process.env);
 scrubSessionCliHomeEnv(process.env);
 scrubClaudeSessionMarkerEnv(process.env);
 scrubWorkflowWorkerEnv(process.env);
+scrubInvokerTerminalEnv(process.env);
+process.env.TERM = 'xterm-256color';
 
 async function main(): Promise<void> {
   const { FleetSupervisor } = await import('./core/fleet-supervisor.js');

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -259,6 +259,18 @@ describe('stripDashboardH5Env()', () => {
     expect(stripAt).toBeGreaterThan(dotenvAt);
   });
 
+  it('is also called by index-supervisor.ts after its own wholesale dotenv (source pin)', () => {
+    // index-supervisor.ts dotenv-loads the same ~/.botmux/.env wholesale as
+    // index-daemon.ts, and resolveFleetDaemonEnv() spreads this process's env
+    // into every supervised member — an unstripped secret would sit in this
+    // long-lived process and ride into every bot daemon and the dashboard.
+    const src = readFileSync(new URL('../src/index-supervisor.ts', import.meta.url), 'utf-8');
+    const dotenvAt = src.indexOf('dotenvConfig(');
+    const stripAt = src.indexOf('stripDashboardH5Env(process.env)');
+    expect(dotenvAt).toBeGreaterThan(-1);
+    expect(stripAt).toBeGreaterThan(dotenvAt);
+  });
+
   it('is called by detachedRestartEnv so a dashboard-spawned restart drops the family (source pin)', () => {
     const src = readFileSync(new URL('../src/core/maintenance.ts', import.meta.url), 'utf-8');
     const fn = src.slice(src.indexOf('export function detachedRestartEnv('));
@@ -595,6 +607,22 @@ describe('session CLI home scrub call sites', () => {
     // TERM-less — the zmx backend's sessions inherit that env verbatim (no
     // node-pty `name` to force TERM) and their CLIs render colorless.
     expect(read('index-daemon.ts')).toContain("process.env.TERM = 'xterm-256color'");
+  });
+
+  it('the fleet supervisor and dashboard entry also scrub invoker-terminal fingerprints and turn markers', () => {
+    // Same two key families as the daemon-boot pin above, at the two other
+    // long-lived boundaries: resolveFleetDaemonEnv() bakes the supervisor's
+    // own (post-scrub) process.env into every daemon child + the dashboard,
+    // and the dashboard entry forks debug terminals / start-stop-bot CLI runs
+    // straight from its own process.env. Both used to scrub only a hand-picked
+    // 7-key subset of session identity and never touched invoker-terminal
+    // fingerprints at all — the gap this test closes.
+    for (const rel of ['index-supervisor.ts', 'index-dashboard.ts']) {
+      const src = read(rel);
+      expect(src, rel).toContain('scrubInvokerTerminalEnv(process.env)');
+      expect(src, rel).toContain('scrubSessionTurnMarkerEnv(process.env)');
+      expect(src, rel).toContain("process.env.TERM = 'xterm-256color'");
+    }
   });
 
   it('worker-pool strips the PM2 sentinel when forking a worker (source pin)', () => {

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -8,6 +8,21 @@ import { detectGlobalInstallManager } from '../src/utils/global-install.js';
 
 const NODE_BIN = resolveNodeExecutable() ?? process.execPath;
 
+/**
+ * `npm pack --dry-run --json` changed its top-level shape across npm majors:
+ * older npm (bundled with Node 22, what CI runs) prints a single-element
+ * ARRAY — `[{ name, files, ... }]`; npm 12+ prints an OBJECT keyed by package
+ * name — `{ "botmux": { files, ... } }` — MEASURED on npm 12.0.1. A probe that
+ * only reads `[0]` silently gets `undefined` on the newer shape instead of a
+ * loud parse error, which is exactly backwards for a test whose job is
+ * asserting an absence (see the tarball test below). Support both so this
+ * probe means the same thing on every npm major that ships it.
+ */
+function parseNpmPackReport(stdout: string, packageName: string): { files: Array<{ path: string }> } {
+  const parsed = JSON.parse(stdout);
+  return Array.isArray(parsed) ? parsed[0] : parsed[packageName];
+}
+
 function runNodeScript(script: string, env: NodeJS.ProcessEnv) {
   const r = spawnSync(NODE_BIN, [script], { encoding: 'utf-8', env });
   const decode = (v: unknown): string => {
@@ -106,7 +121,7 @@ describe('package.json — lockfile safety and packaging', () => {
     // vacuous-green direction for a test whose whole job is an absence claim.
     expect(packed.error, `npm pack failed to run: ${packed.error?.message}`).toBeUndefined();
     expect(packed.status, `npm pack exited ${packed.status}: ${packed.stderr}`).toBe(0);
-    const paths: string[] = JSON.parse(packed.stdout)[0].files.map((f: { path: string }) => f.path);
+    const paths: string[] = parseNpmPackReport(packed.stdout, manifest.name).files.map((f: { path: string }) => f.path);
     // Proof the probe saw a real file list, so the absence assertions below have
     // something to be absent FROM.
     expect(paths).toContain('package.json');
@@ -122,6 +137,14 @@ describe('package.json — lockfile safety and packaging', () => {
     // the source tree reads it (the supervisor replaced pm2), so its only remaining
     // effect is telling a human to start the broken form by hand.
     expect(paths).not.toContain('ecosystem.config.cjs');
+  });
+
+  it('parseNpmPackReport() reads both npm-major shapes of `npm pack --json`', () => {
+    const files = [{ path: 'package.json', size: 1, mode: 420 }];
+    // Array shape: older npm (Node 22's bundled npm, what CI runs).
+    expect(parseNpmPackReport(JSON.stringify([{ name: 'botmux', files }]), 'botmux').files).toEqual(files);
+    // Object-keyed-by-name shape: npm 12+ — MEASURED on npm 12.0.1.
+    expect(parseNpmPackReport(JSON.stringify({ botmux: { name: 'botmux', files } }), 'botmux').files).toEqual(files);
   });
 
   it('declares no entry point that the tarball does not contain', () => {


### PR DESCRIPTION
## 背景

延续 #877（pm2 时代「非交互式 shell 重启导致环境变量串号」）的思路。fleet-supervisor 迁移（#873）把 daemon 一侧的清理边界原样搬了过去，但 `index-supervisor.ts` / `index-dashboard.ts` 只带了旧版 7 个 key 的手写清单，没跟上 `index-daemon.ts` 后来新增的两类清理：

- `scrubInvokerTerminalEnv`（`NO_COLOR`/`CODEX_CI`/`PAGER` 等终端指纹——从非交互 shell 发起重启会把整个 fleet 的 TUI 都变成无色）
- `scrubSessionTurnMarkerEnv`（比手写清单大得多，新增了 `BOTMUX_MCP_GATEWAY_SOCKET`、`IS_SANDBOX`、`BOTMUX_SEND_RELAY` 等后来才加的会话态 key）

这两个函数目前只在 `index-daemon.ts` 里调用。

`index-supervisor.ts` 还额外发现一处：它和 `index-daemon.ts` 一样整份 dotenv 加载 `~/.botmux/.env`，却没有像 daemon 那样 `stripDashboardH5Env`——飞书 H5 登录的 `APP_SECRET` 会在 supervisor 这个长驻进程里白白多待一份。各 bot daemon 自己启动时会再清一遍（不会真正传导到 worker），但 supervisor 自身没有必要持有它。

顺手带上一个不相关但同天发现的小修复：`test/npm-binary-distribution.test.ts` 里 `npm pack --dry-run --json` 的解析没兼容新版 npm 的输出形状（见下）。

## 改动

- `index-supervisor.ts`：三个手写 key 换成 `scrubSessionTurnMarkerEnv`，新增 `scrubInvokerTerminalEnv` + `TERM` 重钉 + `stripDashboardH5Env`，与 `index-daemon.ts` 完全对齐
- `index-dashboard.ts`：同样追平（H5 一项照旧保留不清——dashboard 是它唯一合法消费方）
- `test/child-env.test.ts`：原有 source-pin 测试只覆盖了 `index-daemon.ts`，没延伸到 supervisor/dashboard，是这个缺口能悄悄存在的原因；新增两组断言把三个入口一起钉住
- `test/npm-binary-distribution.test.ts`：`npm pack --dry-run --json` 的顶层结构随 npm 大版本变过——老版本（CI 用的 Node 22 自带 npm）打印单元素数组 `[{ name, files, ... }]`；npm 12+（本机 npm 12.0.1 实测）打印以包名为 key 的对象 `{ "botmux": { files, ... } }`。测试原来只按 `[0]` 取，撞上新形状时静默读到 `undefined`。抽出 `parseNpmPackReport()` 两种形状都认，并加了一组合成 JSON 的用例钉住两种形状，不依赖本机装的是哪个 npm 大版本。

## 影响面

- env scrub 部分：仅 daemon/dashboard/supervisor 三个进程边界的启动期环境变量处理，不改会话路由、worker spawn 或任何业务逻辑。三个入口都是长驻进程，`resolveFleetDaemonEnv()` 会把 supervisor 清理后的 `process.env` 原样铺给每个被监管成员，所以这里补齐一次，对整条 fleet 都生效。
- npm pack 解析部分：仅测试代码，不改生产逻辑。

## 测试

- `bun run build` 通过
- `bunx vitest run test/child-env.test.ts test/index-dashboard-entry.test.ts test/daemon-lifecycle-env.test.ts test/dashboard-launcher-supervised.test.ts test/fleet-supervisor.test.ts test/maintenance.test.ts test/dashboard-chat-pin-route.integration.test.ts test/npm-binary-distribution.test.ts` —— 8 文件全绿，180 用例（1 个 linux-only 用例在 macOS 上按设计 skip）