### PR TITLE
feat(feedback): 支持 reviewers 邮箱与 everyone audience

### DIFF
--- a/docs/feedback-capability-current-implementation.md
+++ b/docs/feedback-capability-current-implementation.md
@@ -72,11 +72,12 @@ Core 只接受三种语义：
 
 - 总开关默认关闭。
 - `apiOnly` bot 不展示反馈。
-- audience 的鉴权主体固定为 delivery 中保存的 requester subject。正常 final 路径优先使用精确 turn sender；当该身份不可得时，当前实现会退化到已确认的 session owner/footer recipient，因此不是所有路径都能保证等同于“本次消息发送者”。
+- `audience` 默认 `requester`：鉴权主体固定为 delivery 中保存的 requester subject。正常 final 路径优先使用精确 turn sender；当该身份不可得时，当前实现会退化到已确认的 session owner/footer recipient，因此不是所有路径都能保证等同于“本次消息发送者”。
+- `audience: "reviewers"` 用于 bot 触发的自动分析场景（如 Oncall/告警监听，本次 turn 的发送者是另一个 bot、没有单一真人 owner）：改由发送时冻结的 `reviewers` 名单鉴权，名单里任一可信真人身份点击即放行，与是否存在真人 requester 无关。**刻意不是“群内所有成员可反馈”**——每个名单项都必须是可在回调侧核验的真人身份。
 - `allowReselect` 默认 `false`；只有显式设置 `true` 才允许改选。
 - 说明框默认开启、非必填，默认最大 1000 字。
 - 负向原因默认可为空，由业务配置。
-- 新配置立即影响后续新卡，旧卡继续使用发送时快照。
+- 新配置立即影响后续新卡，旧卡继续使用发送时快照（`reviewers` 名单同样随 delivery 快照冻结）。
 
 ### 3.4 约束
 
@@ -84,6 +85,8 @@ Core 只接受三种语义：
 - 按钮 2–4 个，key 唯一，只允许 `[a-z0-9_-]+`。
 - 负向原因最多 6 个。
 - 说明最大长度 1–2000。
+- `audience` 仅接受 `requester` / `reviewers`。`reviewers` 名单每项必须是 `ou_`（app 内 open_id）或 `on_`（跨 app union_id），最多 50 项且不重复；这两类身份可在回调侧直接与平台核验后的 operator 比对、无需网络查询，因此 bot 发送者永远无法满足名单（不接受邮箱/手机号，避免落地即失效的“死配置”）。跨 app 场景应使用 `on_`（`ou_` 是 app-scoped、不可跨 app 复制）。
+- `audience: "reviewers"` 与 `reviewers` 名单必须同时成立：`reviewers` audience 缺名单、或 `requester` audience 却带名单，都会 fail closed（分层配置合并后仍按整体校验，任一层非法即不展示反馈）。
 - 不允许配置任意 Lark card JSON；配置仅包含受约束的领域字段。
 
 ## 4. 分层配置模型
@@ -145,6 +148,25 @@ built-in defaults
 }
 ```
 
+### 4.4 reviewers audience 示例
+
+用于 bot 触发的自动分析（本次 turn 发送者是另一个 bot、没有单一真人 owner），把可反馈人固定为一份可信名单：
+
+```json
+{
+  "feedback": {
+    "enabled": true,
+    "audience": "reviewers",
+    "reviewers": ["ou_oncall_lead", "on_cross_app_reviewer"],
+    "allowReselect": true
+  }
+}
+```
+
+- 名单项为 `ou_`（app 内 open_id）或 `on_`（跨 app union_id）；跨 app 用 `on_`。
+- 名单随 delivery 快照冻结：后续改名单只影响新卡，旧卡仍按发送时名单鉴权。
+- `audience` 与 `reviewers` 可分散在不同层（team/bot/chat）提供，合并后按整体校验；`reviewers` audience 缺名单会 fail closed。
+
 ## 5. 最终卡交互协议
 
 ### 5.1 展示边界
@@ -155,7 +177,7 @@ built-in defaults
 - 自定义卡；
 - 通知、语音、纯视频；
 - doc-comment、VC receiver、HTTP wait/async 等特殊 sink；
-- 无法证明 requester 身份的卡；
+- 无法证明 requester 身份的卡（仅 `requester` audience 需要；`reviewers` audience 由冻结名单鉴权，允许无真人 requester 的 bot 触发会话展示反馈）；
 - `apiOnly` bot；
 - card-off 纯文本模式。
 
@@ -171,7 +193,7 @@ botmux send --response-kind final ...
 ### 5.2 提交流程
 
 1. 用户点击一级按钮。
-2. Core 校验平台消息、app、可信 operator、requester-only 权限和策略快照。
+2. Core 校验平台消息、app、可信 operator、身份鉴权（`requester` audience 走 requester-only，`reviewers` audience 走冻结名单）和策略快照。
 3. SQLite 事务写入 immutable feedback revision；重复 callback key 幂等返回已有记录。
 4. 积极/推进选择直接返回同卡状态。
 5. 负向选择先同步 ACK，再异步 `message.patch` 原消息，避免复杂 form 在 callback response 中触发 Lark 错误。

--- a/docs/feedback-capability-current-implementation.md
+++ b/docs/feedback-capability-current-implementation.md
@@ -73,7 +73,8 @@ Core 只接受三种语义：
 - 总开关默认关闭。
 - `apiOnly` bot 不展示反馈。
 - `audience` 默认 `requester`：鉴权主体固定为 delivery 中保存的 requester subject。正常 final 路径优先使用精确 turn sender；当该身份不可得时，当前实现会退化到已确认的 session owner/footer recipient，因此不是所有路径都能保证等同于“本次消息发送者”。
-- `audience: "reviewers"` 用于 bot 触发的自动分析场景（如 Oncall/告警监听，本次 turn 的发送者是另一个 bot、没有单一真人 owner）：改由发送时冻结的 `reviewers` 名单鉴权，名单里任一可信真人身份点击即放行，与是否存在真人 requester 无关。**刻意不是“群内所有成员可反馈”**——每个名单项都必须是可在回调侧核验的真人身份。
+- `audience: "reviewers"` 用于 bot 触发的自动分析场景（如 Oncall/告警监听，本次 turn 的发送者是另一个 bot、没有单一真人 owner）：改由发送时冻结的 `reviewers` 名单鉴权，名单里任一可信真人身份点击即放行，与是否存在真人 requester 无关。名单可填写 `ou_`、`on_` 或完整邮箱；邮箱会在发卡时解析为当前应用的 `open_id`，回调仍保持零网络鉴权。
+- `audience: "everyone"` 允许任意具有平台核验 operator 身份的点击者反馈，不要求 requester，也不需要 `reviewers` 名单。该模式会扩大反馈写入范围，应只用于群成员都可信的场景。
 - `allowReselect` 默认 `false`；只有显式设置 `true` 才允许改选。
 - 说明框默认开启、非必填，默认最大 1000 字。
 - 负向原因默认可为空，由业务配置。
@@ -85,8 +86,8 @@ Core 只接受三种语义：
 - 按钮 2–4 个，key 唯一，只允许 `[a-z0-9_-]+`。
 - 负向原因最多 6 个。
 - 说明最大长度 1–2000。
-- `audience` 仅接受 `requester` / `reviewers`。`reviewers` 名单每项必须是 `ou_`（app 内 open_id）或 `on_`（跨 app union_id），最多 50 项且不重复；这两类身份可在回调侧直接与平台核验后的 operator 比对、无需网络查询，因此 bot 发送者永远无法满足名单（不接受邮箱/手机号，避免落地即失效的“死配置”）。跨 app 场景应使用 `on_`（`ou_` 是 app-scoped、不可跨 app 复制）。
-- `audience: "reviewers"` 与 `reviewers` 名单必须同时成立：`reviewers` audience 缺名单、或 `requester` audience 却带名单，都会 fail closed（分层配置合并后仍按整体校验，任一层非法即不展示反馈）。
+- `audience` 仅接受 `requester` / `reviewers` / `everyone`。`reviewers` 名单每项必须是 `ou_`（app 内 open_id）、`on_`（跨 app union_id）或完整邮箱，最多 50 项且不重复。邮箱在发送时用当前 bot 凭证解析为 `ou_` 后才写入策略快照；解析不到时丢弃该项，全部无法解析则 fail closed、不展示反馈。跨 app 场景应优先使用 `on_`（`ou_` 是 app-scoped、不可跨 app 复制）。
+- `audience: "reviewers"` 与 `reviewers` 名单必须同时成立：`reviewers` audience 缺名单，或 `requester` / `everyone` audience 却带名单，都会 fail closed（分层配置合并后仍按整体校验，任一层非法即不展示反馈）。
 - 不允许配置任意 Lark card JSON；配置仅包含受约束的领域字段。
 
 ## 4. 分层配置模型
@@ -157,15 +158,30 @@ built-in defaults
   "feedback": {
     "enabled": true,
     "audience": "reviewers",
-    "reviewers": ["ou_oncall_lead", "on_cross_app_reviewer"],
+    "reviewers": ["on_cross_app_reviewer", "oncall@example.com"],
     "allowReselect": true
   }
 }
 ```
 
-- 名单项为 `ou_`（app 内 open_id）或 `on_`（跨 app union_id）；跨 app 用 `on_`。
+- 名单项为 `ou_`（app 内 open_id）、`on_`（跨 app union_id）或完整邮箱；跨 app 优先用 `on_`。邮箱在发卡时解析为当前应用的 `ou_`，未解析成功的项不会写入快照。
 - 名单随 delivery 快照冻结：后续改名单只影响新卡，旧卡仍按发送时名单鉴权。
 - `audience` 与 `reviewers` 可分散在不同层（team/bot/chat）提供，合并后按整体校验；`reviewers` audience 缺名单会 fail closed。
+
+### 4.5 everyone audience 示例
+
+用于明确希望群内任意可识别成员都能点击反馈的场景：
+
+```json
+{
+  "feedback": {
+    "enabled": true,
+    "audience": "everyone"
+  }
+}
+```
+
+该模式不校验 requester 或名单，但仍要求回调携带飞书平台核验的 operator 身份；无法验证来源的回调继续 fail closed。
 
 ## 5. 最终卡交互协议
 
@@ -177,7 +193,7 @@ built-in defaults
 - 自定义卡；
 - 通知、语音、纯视频；
 - doc-comment、VC receiver、HTTP wait/async 等特殊 sink；
-- 无法证明 requester 身份的卡（仅 `requester` audience 需要；`reviewers` audience 由冻结名单鉴权，允许无真人 requester 的 bot 触发会话展示反馈）；
+- 无法证明 requester 身份的卡（仅 `requester` audience 需要；`reviewers` 由冻结名单鉴权，`everyone` 由平台 operator 身份鉴权，两者都允许无真人 requester 的 bot 触发会话展示反馈）；
 - `apiOnly` bot；
 - card-off 纯文本模式。
 
@@ -193,7 +209,7 @@ botmux send --response-kind final ...
 ### 5.2 提交流程
 
 1. 用户点击一级按钮。
-2. Core 校验平台消息、app、可信 operator、身份鉴权（`requester` audience 走 requester-only，`reviewers` audience 走冻结名单）和策略快照。
+2. Core 校验平台消息、app、可信 operator、身份鉴权（`requester` 走 requester-only，`reviewers` 走冻结名单，`everyone` 接受任意可验证 operator）和策略快照。
 3. SQLite 事务写入 immutable feedback revision；重复 callback key 幂等返回已有记录。
 4. 积极/推进选择直接返回同卡状态。
 5. 负向选择先同步 ACK，再异步 `message.patch` 原消息，避免复杂 form 在 callback response 中触发 Lark 错误。

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8987,7 +8987,11 @@ async function cmdSend(rest: string[]): Promise<void> {
     feedbackPolicy = undefined;
   }
   const feedbackRequesterSubjectId = replyTargetSenderOpenId ?? s.ownerOpenId;
-  if (feedbackPolicy && effectiveResponseKind === 'final' && !feedbackRequesterSubjectId) {
+  // `reviewers` audience gates clicks by its frozen allowlist, not by a human
+  // requester — this is the bot-triggered auto-analysis case (issue #1178) where
+  // the exact turn sender is another bot. Only the `requester` audience needs a
+  // resolvable human recipient to make its control clickable.
+  if (feedbackPolicy && effectiveResponseKind === 'final' && feedbackPolicy.audience === 'requester' && !feedbackRequesterSubjectId) {
     console.error('botmux send: 无法确认本次提问者身份，不能发送带反馈控件的最终回答');
     process.exit(2);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8986,11 +8986,34 @@ async function cmdSend(rest: string[]): Promise<void> {
   } catch {
     feedbackPolicy = undefined;
   }
+  // Freeze email reviewers into this bot's app-scoped open_id NOW, with
+  // the bot's own credentials, so the card callback can match network-free
+  // against the delivery snapshot. Pure ou_/on_ lists (and requester/everyone)
+  // skip the lookup. If resolution empties a reviewers list, fail closed (no
+  // feedback control) rather than ship a card nobody can click.
+  if (feedbackPolicy && effectiveResponseKind === 'final' && feedbackPolicy.audience === 'reviewers') {
+    try {
+      const { materializeFeedbackReviewers } = await import('./services/feedback-policy.js');
+      const { resolveAllowedUsersWithMap } = await import('./im/lark/client.js');
+      feedbackPolicy = await materializeFeedbackReviewers(feedbackPolicy, async entries => {
+        const { map } = await resolveAllowedUsersWithMap(s.larkAppId!, entries);
+        const resolved = new Map<string, string>();
+        for (const entry of entries) {
+          const id = map.get(entry);
+          if (id && id.startsWith('ou_')) resolved.set(entry, id);
+        }
+        return resolved;
+      });
+    } catch {
+      feedbackPolicy = undefined;
+    }
+    if (feedbackPolicy && feedbackPolicy.reviewers.length === 0) feedbackPolicy = undefined;
+  }
   const feedbackRequesterSubjectId = replyTargetSenderOpenId ?? s.ownerOpenId;
-  // `reviewers` audience gates clicks by its frozen allowlist, not by a human
-  // requester — this is the bot-triggered auto-analysis case (issue #1178) where
-  // the exact turn sender is another bot. Only the `requester` audience needs a
-  // resolvable human recipient to make its control clickable.
+  // `reviewers`/`everyone` audiences gate clicks without a human requester —
+  // this is the bot-triggered auto-analysis case (issue #1178) where the exact
+  // turn sender is another bot. Only the `requester` audience needs a resolvable
+  // human recipient to make its control clickable.
   if (feedbackPolicy && effectiveResponseKind === 'final' && feedbackPolicy.audience === 'requester' && !feedbackRequesterSubjectId) {
     console.error('botmux send: 无法确认本次提问者身份，不能发送带反馈控件的最终回答');
     process.exit(2);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -14597,15 +14597,37 @@ function deliverFinalOutput(
       // forkWorker snapshots the effective policy for this worker lifetime.
       // Keep daemon fallback delivery aligned with the same frozen policy the
       // worker/Riff environment received; live config applies on the next fork.
-      const feedbackPolicy = managedReceiver ? undefined : ds.feedbackPolicy;
+      let feedbackPolicy = managedReceiver ? undefined : ds.feedbackPolicy;
+      // Freeze email reviewers into this bot's app-scoped open_id so the
+      // card callback can match network-free against the delivery snapshot. Pure
+      // ou_/on_ lists (and requester/everyone) skip the lookup. If resolution
+      // empties the list, fail closed (drop the feedback control).
+      if (feedbackPolicy && feedbackPolicy.audience === 'reviewers') {
+        try {
+          const { materializeFeedbackReviewers } = await import('../services/feedback-policy.js');
+          const { resolveAllowedUsersWithMap } = await import('../im/lark/client.js');
+          feedbackPolicy = await materializeFeedbackReviewers(feedbackPolicy, async entries => {
+            const { map } = await resolveAllowedUsersWithMap(ds.larkAppId, entries);
+            const resolved = new Map<string, string>();
+            for (const entry of entries) {
+              const id = map.get(entry);
+              if (id && id.startsWith('ou_')) resolved.set(entry, id);
+            }
+            return resolved;
+          });
+        } catch {
+          feedbackPolicy = undefined;
+        }
+        if (feedbackPolicy && feedbackPolicy.reviewers.length === 0) feedbackPolicy = undefined;
+      }
       const feedbackRequesterSubjectId = recipientOpenId;
-      // `reviewers` audience is gated by its frozen allowlist, so the control is
-      // valid even for an ownerless bot-triggered session with no human
-      // recipient; `requester` audience still needs the recipient to be
+      // `reviewers`/`everyone` audiences gate clicks without a human requester,
+      // so the control is valid even for an ownerless bot-triggered session with
+      // no human recipient; `requester` audience still needs the recipient to be
       // clickable. Never re-derive an owner here — the ownerless session stays
       // ownerless (no @-loop back to the alerting bot).
       const feedback = feedbackPolicy
-        && (feedbackPolicy.audience === 'reviewers' || feedbackRequesterSubjectId)
+        && (feedbackPolicy.audience !== 'requester' || feedbackRequesterSubjectId)
         ? { policy: feedbackPolicy }
         : undefined;
       cardUsage ??= getDaemonReplyCardUsageSnapshot(ds, effectiveCliId);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -14599,7 +14599,15 @@ function deliverFinalOutput(
       // worker/Riff environment received; live config applies on the next fork.
       const feedbackPolicy = managedReceiver ? undefined : ds.feedbackPolicy;
       const feedbackRequesterSubjectId = recipientOpenId;
-      const feedback = feedbackPolicy && feedbackRequesterSubjectId ? { policy: feedbackPolicy } : undefined;
+      // `reviewers` audience is gated by its frozen allowlist, so the control is
+      // valid even for an ownerless bot-triggered session with no human
+      // recipient; `requester` audience still needs the recipient to be
+      // clickable. Never re-derive an owner here — the ownerless session stays
+      // ownerless (no @-loop back to the alerting bot).
+      const feedback = feedbackPolicy
+        && (feedbackPolicy.audience === 'reviewers' || feedbackRequesterSubjectId)
+        ? { policy: feedbackPolicy }
+        : undefined;
       cardUsage ??= getDaemonReplyCardUsageSnapshot(ds, effectiveCliId);
       const localTurnTitle = msg.kind === 'local-turn-headless'
         ? tr('card.local_turn_resumed', undefined, localeForBot(ds.larkAppId))

--- a/src/dashboard/web/team-federation.ts
+++ b/src/dashboard/web/team-federation.ts
@@ -44,7 +44,8 @@ export type TeamApiResult<T = any> = DashboardApiResult<T>;
 
 export interface FeedbackPolicyLayer {
   enabled?: boolean;
-  audience?: 'requester';
+  audience?: 'requester' | 'reviewers' | 'everyone';
+  reviewers?: unknown[];
   visibleSemantics?: unknown[];
   buttons?: unknown[];
   negativeFollowup?: { reasons?: unknown[]; comment?: { enabled?: boolean; required?: boolean; placeholder?: string; maxLength?: number } };

--- a/src/im/lark/skill-feedback-card.ts
+++ b/src/im/lark/skill-feedback-card.ts
@@ -85,11 +85,24 @@ export async function handleSkillFeedbackCardAction(data: CardActionData, larkAp
   let baseCard = delivery.baseCard;
   try { baseCard = await deps.loadBaseCard?.(platformMessageId) ?? baseCard; }
   catch { /* platform fetch is best-effort; the content-free template remains usable */ }
-  const operatorSubjectId = delivery.requesterSubjectId === operatorOpenId
-    ? operatorOpenId
-    : verifiedOperator.unionId ?? (data.operator?.union_id === undefined ? operatorOpenId : undefined);
-  if (!operatorSubjectId) return { toast: { type: 'error', content: '无法验证反馈来源，请重试' } };
-  if (delivery.requesterSubjectId && delivery.requesterSubjectId !== operatorSubjectId && delivery.requesterSubjectId !== operatorOpenId) return { toast: { type: 'error', content: '仅本次提问者可反馈' } };
+  // Identity gate. `reviewers` audience matches the platform-verified operator
+  // against the delivery's frozen allowlist (a per-delivery snapshot, so later
+  // config changes never re-gate an old card); `requester` keeps the original
+  // "only the addressed human" contract. Both fail closed when no trusted
+  // identity can be established — a bot sender exposes no listed human id.
+  let operatorSubjectId: string | undefined;
+  if (delivery.policy.audience === 'reviewers') {
+    const reviewers = new Set(delivery.policy.reviewers);
+    operatorSubjectId = [operatorOpenId, verifiedOperator.unionId]
+      .find((id): id is string => !!id && reviewers.has(id));
+    if (!operatorSubjectId) return { toast: { type: 'error', content: '仅指定的反馈人可反馈' } };
+  } else {
+    operatorSubjectId = delivery.requesterSubjectId === operatorOpenId
+      ? operatorOpenId
+      : verifiedOperator.unionId ?? (data.operator?.union_id === undefined ? operatorOpenId : undefined);
+    if (!operatorSubjectId) return { toast: { type: 'error', content: '无法验证反馈来源，请重试' } };
+    if (delivery.requesterSubjectId && delivery.requesterSubjectId !== operatorSubjectId && delivery.requesterSubjectId !== operatorOpenId) return { toast: { type: 'error', content: '仅本次提问者可反馈' } };
+  }
 
   const previous = deps.store.getLatestFeedback(delivery.deliveryId, operatorSubjectId);
   if (previous && !delivery.policy.allowReselect && action === 'feedback_submit') {

--- a/src/im/lark/skill-feedback-card.ts
+++ b/src/im/lark/skill-feedback-card.ts
@@ -85,17 +85,25 @@ export async function handleSkillFeedbackCardAction(data: CardActionData, larkAp
   let baseCard = delivery.baseCard;
   try { baseCard = await deps.loadBaseCard?.(platformMessageId) ?? baseCard; }
   catch { /* platform fetch is best-effort; the content-free template remains usable */ }
-  // Identity gate. `reviewers` audience matches the platform-verified operator
-  // against the delivery's frozen allowlist (a per-delivery snapshot, so later
-  // config changes never re-gate an old card); `requester` keeps the original
-  // "only the addressed human" contract. Both fail closed when no trusted
-  // identity can be established — a bot sender exposes no listed human id.
+  // Identity gate. `reviewers` matches the platform-verified operator against
+  // the delivery's frozen allowlist (a per-delivery snapshot of already-resolved
+  // ids, so later config changes never re-gate an old card and no network call
+  // happens here); `everyone` accepts any operator whose id the platform
+  // verified; `requester` keeps the original "only the addressed human"
+  // contract. All fail closed when no verifiable identity exists — a bot sender
+  // exposes no listed/verifiable human id.
   let operatorSubjectId: string | undefined;
   if (delivery.policy.audience === 'reviewers') {
     const reviewers = new Set(delivery.policy.reviewers);
     operatorSubjectId = [operatorOpenId, verifiedOperator.unionId]
       .find((id): id is string => !!id && reviewers.has(id));
     if (!operatorSubjectId) return { toast: { type: 'error', content: '仅指定的反馈人可反馈' } };
+  } else if (delivery.policy.audience === 'everyone') {
+    // Anyone may click, but we still key the feedback on a verified id so the
+    // record has a real subject and a bot cannot forge one. Prefer the
+    // cross-app union_id; fall back to the app-scoped open_id.
+    operatorSubjectId = verifiedOperator.unionId ?? operatorOpenId;
+    if (!operatorSubjectId) return { toast: { type: 'error', content: '无法验证反馈来源，请重试' } };
   } else {
     operatorSubjectId = delivery.requesterSubjectId === operatorOpenId
       ? operatorOpenId

--- a/src/services/feedback-policy-resolver.ts
+++ b/src/services/feedback-policy-resolver.ts
@@ -5,7 +5,7 @@ import { listTeamGroups } from './team-groups-store.js';
 
 export interface FeedbackPolicyLayer {
   enabled?: boolean;
-  audience?: 'requester' | 'reviewers';
+  audience?: 'requester' | 'reviewers' | 'everyone';
   reviewers?: unknown[];
   visibleSemantics?: unknown[];
   buttons?: unknown[];
@@ -40,7 +40,7 @@ export function normalizeFeedbackPolicyLayer(raw: unknown): FeedbackPolicyLayer 
   const input = record(raw, 'feedback');
   rejectUnknown(input, TOP_LEVEL, 'feedback');
   if (input.enabled !== undefined && typeof input.enabled !== 'boolean') throw new Error('feedback.enabled must be boolean');
-  if (input.audience !== undefined && input.audience !== 'requester' && input.audience !== 'reviewers') throw new Error('feedback.audience must be requester or reviewers');
+  if (input.audience !== undefined && input.audience !== 'requester' && input.audience !== 'reviewers' && input.audience !== 'everyone') throw new Error('feedback.audience must be requester, reviewers or everyone');
   if (input.allowReselect !== undefined && typeof input.allowReselect !== 'boolean') throw new Error('feedback.allowReselect must be boolean');
   if (input.reviewers !== undefined && !Array.isArray(input.reviewers)) throw new Error('feedback.reviewers must be an array');
   if (input.visibleSemantics !== undefined && !Array.isArray(input.visibleSemantics)) throw new Error('feedback.visibleSemantics must be an array');
@@ -69,7 +69,7 @@ export function normalizeFeedbackPolicyLayer(raw: unknown): FeedbackPolicyLayer 
 
   const layer: FeedbackPolicyLayer = {
     ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
-    ...(input.audience !== undefined ? { audience: input.audience as 'requester' | 'reviewers' } : {}),
+    ...(input.audience !== undefined ? { audience: input.audience as 'requester' | 'reviewers' | 'everyone' } : {}),
     ...(input.reviewers !== undefined ? { reviewers: structuredClone(input.reviewers) } : {}),
     ...(input.visibleSemantics !== undefined ? { visibleSemantics: structuredClone(input.visibleSemantics) } : {}),
     ...(input.buttons !== undefined ? { buttons: structuredClone(input.buttons) } : {}),

--- a/src/services/feedback-policy-resolver.ts
+++ b/src/services/feedback-policy-resolver.ts
@@ -1,11 +1,12 @@
 import type { BotConfig } from '../bot-registry.js';
-import { normalizeFeedbackPolicy, type FeedbackPolicy } from './feedback-policy.js';
+import { normalizeFeedbackPolicy, validateReviewerEntries, type FeedbackPolicy } from './feedback-policy.js';
 import { getTeam } from './team-store.js';
 import { listTeamGroups } from './team-groups-store.js';
 
 export interface FeedbackPolicyLayer {
   enabled?: boolean;
-  audience?: 'requester';
+  audience?: 'requester' | 'reviewers';
+  reviewers?: unknown[];
   visibleSemantics?: unknown[];
   buttons?: unknown[];
   negativeFollowup?: {
@@ -20,7 +21,7 @@ export interface FeedbackPolicyLayer {
   allowReselect?: boolean;
 }
 
-const TOP_LEVEL = new Set(['enabled', 'audience', 'visibleSemantics', 'buttons', 'negativeFollowup', 'allowReselect']);
+const TOP_LEVEL = new Set(['enabled', 'audience', 'reviewers', 'visibleSemantics', 'buttons', 'negativeFollowup', 'allowReselect']);
 const FOLLOWUP = new Set(['reasons', 'comment']);
 const COMMENT = new Set(['enabled', 'required', 'placeholder', 'maxLength']);
 
@@ -39,8 +40,9 @@ export function normalizeFeedbackPolicyLayer(raw: unknown): FeedbackPolicyLayer 
   const input = record(raw, 'feedback');
   rejectUnknown(input, TOP_LEVEL, 'feedback');
   if (input.enabled !== undefined && typeof input.enabled !== 'boolean') throw new Error('feedback.enabled must be boolean');
-  if (input.audience !== undefined && input.audience !== 'requester') throw new Error('feedback.audience must be requester');
+  if (input.audience !== undefined && input.audience !== 'requester' && input.audience !== 'reviewers') throw new Error('feedback.audience must be requester or reviewers');
   if (input.allowReselect !== undefined && typeof input.allowReselect !== 'boolean') throw new Error('feedback.allowReselect must be boolean');
+  if (input.reviewers !== undefined && !Array.isArray(input.reviewers)) throw new Error('feedback.reviewers must be an array');
   if (input.visibleSemantics !== undefined && !Array.isArray(input.visibleSemantics)) throw new Error('feedback.visibleSemantics must be an array');
   if (input.buttons !== undefined && !Array.isArray(input.buttons)) throw new Error('feedback.buttons must be an array');
 
@@ -67,18 +69,24 @@ export function normalizeFeedbackPolicyLayer(raw: unknown): FeedbackPolicyLayer 
 
   const layer: FeedbackPolicyLayer = {
     ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
-    ...(input.audience !== undefined ? { audience: input.audience as 'requester' } : {}),
+    ...(input.audience !== undefined ? { audience: input.audience as 'requester' | 'reviewers' } : {}),
+    ...(input.reviewers !== undefined ? { reviewers: structuredClone(input.reviewers) } : {}),
     ...(input.visibleSemantics !== undefined ? { visibleSemantics: structuredClone(input.visibleSemantics) } : {}),
     ...(input.buttons !== undefined ? { buttons: structuredClone(input.buttons) } : {}),
     ...(negativeFollowup !== undefined ? { negativeFollowup } : {}),
     ...(input.allowReselect !== undefined ? { allowReselect: input.allowReselect } : {}),
   };
 
+  // Validate the reviewer allowlist FORMAT here (a partial layer may carry
+  // `reviewers` without `audience`, or vice-versa — the cross-field coupling is
+  // enforced only on the merged effective policy). Other atomic values are
+  // validated by delegating to the full normalizer below.
+  if (layer.reviewers !== undefined) validateReviewerEntries(layer.reviewers);
   // Validate supplied atomic values without expanding this persisted layer with
   // defaults. Layers remain partial so a restart cannot turn inherited values
   // into stale bot/chat-owned copies.
   if (layer.visibleSemantics !== undefined || layer.buttons !== undefined || layer.negativeFollowup !== undefined) {
-    normalizeFeedbackPolicy({ enabled: true, ...layer });
+    normalizeFeedbackPolicy({ enabled: true, ...layer, audience: 'requester', reviewers: undefined });
   }
   return layer;
 }
@@ -86,7 +94,7 @@ export function normalizeFeedbackPolicyLayer(raw: unknown): FeedbackPolicyLayer 
 function mergeLayer(target: Record<string, unknown>, raw: FeedbackPolicyLayer | undefined): void {
   if (!raw) return;
   const layer = normalizeFeedbackPolicyLayer(raw);
-  for (const field of ['enabled', 'audience', 'visibleSemantics', 'buttons', 'allowReselect'] as const) {
+  for (const field of ['enabled', 'audience', 'reviewers', 'visibleSemantics', 'buttons', 'allowReselect'] as const) {
     if (layer[field] !== undefined) target[field] = structuredClone(layer[field]);
   }
   if (layer.negativeFollowup) {
@@ -112,7 +120,15 @@ export function resolveEffectiveFeedbackPolicy(input: {
   mergeLayer(merged, input.bot);
   mergeLayer(merged, input.chat);
   if (merged.enabled !== true) return undefined;
-  return structuredClone(normalizeFeedbackPolicy(merged));
+  // Individually-valid layers can still merge into an invalid whole — most
+  // notably `audience: 'reviewers'` with an empty reviewers allowlist once the
+  // layers are combined. Fail closed (feedback simply not shown) rather than
+  // letting the throw propagate to the unguarded worker-spawn delivery path.
+  try {
+    return structuredClone(normalizeFeedbackPolicy(merged));
+  } catch {
+    return undefined;
+  }
 }
 
 /** Resolve local hosted-team, bot, and bot-scoped chat layers at delivery time. */

--- a/src/services/feedback-policy.ts
+++ b/src/services/feedback-policy.ts
@@ -1,6 +1,17 @@
 export type FeedbackSemantic = 'positive' | 'progress' | 'negative';
 export type FeedbackButtonStyle = 'primary' | 'default' | 'danger';
 
+/**
+ * Who may click the feedback buttons.
+ *  - `requester`: default, backward-compatible. Only the exact person the
+ *    answer was addressed to (session owner / turn recipient) can click.
+ *  - `reviewers`: an explicit allowlist of trusted human identities. Used for
+ *    bot-triggered auto-analysis (Oncall/alert listeners) where the requester
+ *    is another bot and no single human owner exists. Deliberately NOT
+ *    "anyone in the chat" — every entry must be a verifiable human identity.
+ */
+export type FeedbackAudience = 'requester' | 'reviewers';
+
 export interface FeedbackButton {
   key: string;
   label: string;
@@ -12,7 +23,15 @@ export interface FeedbackReason { key: string; label: string }
 
 export interface FeedbackPolicy {
   enabled: true;
-  audience: 'requester';
+  audience: FeedbackAudience;
+  /**
+   * Trusted human identities allowed to click when `audience === 'reviewers'`.
+   * Entries are `ou_` (app-scoped open_id) or `on_` (cross-app union_id) and are
+   * matched at callback time against the platform-verified operator with no
+   * network lookup, so a bot sender can never satisfy an entry. Absent/empty for
+   * `requester`.
+   */
+  reviewers: string[];
   visibleSemantics: FeedbackSemantic[];
   buttons: FeedbackButton[];
   negativeFollowup: {
@@ -25,6 +44,7 @@ export interface FeedbackPolicy {
 export interface FeedbackPolicyInput {
   enabled?: boolean;
   audience?: unknown;
+  reviewers?: unknown;
   visibleSemantics?: unknown;
   buttons?: unknown;
   negativeFollowup?: unknown;
@@ -63,10 +83,63 @@ function semantic(value: unknown, path: string): FeedbackSemantic {
   return value;
 }
 
+/**
+ * A reviewer entry must be a platform-verifiable human identity. The card
+ * callback only ever exposes the operator's `ou_` (app-scoped open_id) and,
+ * when present/resolvable, `on_` (cross-app union_id). Matching those directly
+ * needs no network call and can never be satisfied by a bot sender. We
+ * deliberately accept ONLY `ou_`/`on_`: an email/mobile could not be matched at
+ * callback time without a lookup and would ship as silently-dead config. Per
+ * the app-scoped-open_id boundary, cross-app reviewers should use `on_`.
+ */
+function reviewerIdentity(value: unknown, path: string): string {
+  if (typeof value !== 'string') throw new Error(`${path} must be a string`);
+  const entry = value.trim();
+  if (entry.startsWith('ou_') || entry.startsWith('on_')) {
+    if (entry.length < 4) throw new Error(`${path} is not a valid open_id/union_id`);
+    return entry;
+  }
+  throw new Error(`${path} must be an ou_ open_id or on_ union_id`);
+}
+
+/**
+ * Format-only validation of a `reviewers` allowlist for a partial config layer,
+ * WITHOUT the cross-field `audience`⟺`reviewers` coupling that only the merged
+ * effective policy can decide (a split team/bot/chat config may legitimately set
+ * `audience` in one layer and `reviewers` in another).
+ */
+export function validateReviewerEntries(value: unknown, path = 'feedback.reviewers'): string[] {
+  if (!Array.isArray(value)) throw new Error(`${path} must be an array`);
+  if (value.length > 50) throw new Error(`${path} allows 0-50 entries`);
+  const reviewers = value.map((entry, index) => reviewerIdentity(entry, `${path}[${index}]`));
+  unique(reviewers, path);
+  return reviewers;
+}
+
 export function normalizeFeedbackPolicy(raw: unknown): FeedbackPolicy {
   const input = object(raw, 'feedback');
   if (input.enabled !== true) throw new Error('feedback.enabled must be true');
-  if (input.audience !== undefined && input.audience !== 'requester') throw new Error('feedback.audience must be requester');
+  if (input.audience !== undefined && input.audience !== 'requester' && input.audience !== 'reviewers') {
+    throw new Error('feedback.audience must be requester or reviewers');
+  }
+  const audience: FeedbackAudience = input.audience === 'reviewers' ? 'reviewers' : 'requester';
+
+  let reviewers: string[] = [];
+  if (input.reviewers !== undefined) {
+    reviewers = validateReviewerEntries(input.reviewers);
+  }
+  // `reviewers` audience is meaningless without at least one reviewer, and a
+  // silently-empty allowlist would render an un-clickable control. Fail closed
+  // at config time instead of shipping a dead button.
+  if (audience === 'reviewers' && reviewers.length === 0) {
+    throw new Error('feedback.audience "reviewers" requires a non-empty feedback.reviewers allowlist');
+  }
+  // A reviewers allowlist only has meaning under the reviewers audience; reject
+  // the combination rather than silently ignoring it (a requester-only card
+  // must never appear to have carried an allowlist).
+  if (audience === 'requester' && reviewers.length > 0) {
+    throw new Error('feedback.reviewers requires feedback.audience "reviewers"');
+  }
 
   let visibleSemantics = [...SEMANTICS];
   if (input.visibleSemantics !== undefined) {
@@ -114,7 +187,8 @@ export function normalizeFeedbackPolicy(raw: unknown): FeedbackPolicy {
   const placeholder = rawComment.placeholder === undefined ? '可以补充哪里需要改进' : text(rawComment.placeholder, 'feedback.negativeFollowup.comment.placeholder', 100);
   return {
     enabled: true,
-    audience: 'requester',
+    audience,
+    reviewers,
     allowReselect: input.allowReselect === true,
     visibleSemantics,
     buttons,

--- a/src/services/feedback-policy.ts
+++ b/src/services/feedback-policy.ts
@@ -7,10 +7,15 @@ export type FeedbackButtonStyle = 'primary' | 'default' | 'danger';
  *    answer was addressed to (session owner / turn recipient) can click.
  *  - `reviewers`: an explicit allowlist of trusted human identities. Used for
  *    bot-triggered auto-analysis (Oncall/alert listeners) where the requester
- *    is another bot and no single human owner exists. Deliberately NOT
- *    "anyone in the chat" — every entry must be a verifiable human identity.
+ *    is another bot and no single human owner exists. Entries may be `ou_`/`on_`
+ *    ids or a full email — emails are resolved to this bot's app-scoped
+ *    open_id at send time (the callback stays network-free) and frozen into the
+ *    delivery snapshot. Deliberately NOT "anyone in the chat".
+ *  - `everyone`: any operator whose identity the platform can verify may click.
+ *    An explicit escape hatch when a chat trusts every member to give feedback
+ *    (a bot sender still cannot forge a human id). No allowlist.
  */
-export type FeedbackAudience = 'requester' | 'reviewers';
+export type FeedbackAudience = 'requester' | 'reviewers' | 'everyone';
 
 export interface FeedbackButton {
   key: string;
@@ -26,10 +31,10 @@ export interface FeedbackPolicy {
   audience: FeedbackAudience;
   /**
    * Trusted human identities allowed to click when `audience === 'reviewers'`.
-   * Entries are `ou_` (app-scoped open_id) or `on_` (cross-app union_id) and are
-   * matched at callback time against the platform-verified operator with no
-   * network lookup, so a bot sender can never satisfy an entry. Absent/empty for
-   * `requester`.
+   * Config accepts `ou_`/`on_` ids and full email; email entries are
+   * resolved to this bot's app-scoped open_id at send time so the callback can
+   * match with no network lookup (a bot sender can never satisfy an entry).
+   * Absent/empty for `requester` and `everyone`.
    */
   reviewers: string[];
   visibleSemantics: FeedbackSemantic[];
@@ -84,13 +89,22 @@ function semantic(value: unknown, path: string): FeedbackSemantic {
 }
 
 /**
- * A reviewer entry must be a platform-verifiable human identity. The card
- * callback only ever exposes the operator's `ou_` (app-scoped open_id) and,
- * when present/resolvable, `on_` (cross-app union_id). Matching those directly
- * needs no network call and can never be satisfied by a bot sender. We
- * deliberately accept ONLY `ou_`/`on_`: an email/mobile could not be matched at
- * callback time without a lookup and would ship as silently-dead config. Per
- * the app-scoped-open_id boundary, cross-app reviewers should use `on_`.
+ * Reviewer-entry format checks. Kept in sync (deliberately, by value) with the
+ * canonical owner-allowedUsers email predicate in `setup/bot-config-editor.ts`;
+ * this module stays a dependency-free leaf (it is imported by the store,
+ * resolver, cli and worker-pool).
+ */
+const FULL_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * A reviewer entry must be a human identity this bot can prove.
+ *  - `ou_`/`on_` are matched directly against the platform-verified callback
+ *    operator with no network call — a bot sender can never satisfy one.
+ *  - A full email is human-readable and resolved to this bot's
+ *    app-scoped `ou_` at SEND time (see `materializeFeedbackReviewers`); the
+ *    callback still matches network-free against the frozen, resolved id.
+ * A bare prefix (e.g. "alice") is rejected — same rule as owner allowedUsers.
+ * Cross-app reviewers should prefer `on_` (an `ou_` is app-scoped).
  */
 function reviewerIdentity(value: unknown, path: string): string {
   if (typeof value !== 'string') throw new Error(`${path} must be a string`);
@@ -99,7 +113,8 @@ function reviewerIdentity(value: unknown, path: string): string {
     if (entry.length < 4) throw new Error(`${path} is not a valid open_id/union_id`);
     return entry;
   }
-  throw new Error(`${path} must be an ou_ open_id or on_ union_id`);
+  if (FULL_EMAIL_RE.test(entry)) return entry;
+  throw new Error(`${path} must be an ou_/on_ id or a full email`);
 }
 
 /**
@@ -119,10 +134,12 @@ export function validateReviewerEntries(value: unknown, path = 'feedback.reviewe
 export function normalizeFeedbackPolicy(raw: unknown): FeedbackPolicy {
   const input = object(raw, 'feedback');
   if (input.enabled !== true) throw new Error('feedback.enabled must be true');
-  if (input.audience !== undefined && input.audience !== 'requester' && input.audience !== 'reviewers') {
-    throw new Error('feedback.audience must be requester or reviewers');
+  if (input.audience !== undefined && input.audience !== 'requester' && input.audience !== 'reviewers' && input.audience !== 'everyone') {
+    throw new Error('feedback.audience must be requester, reviewers or everyone');
   }
-  const audience: FeedbackAudience = input.audience === 'reviewers' ? 'reviewers' : 'requester';
+  const audience: FeedbackAudience = input.audience === 'reviewers' || input.audience === 'everyone'
+    ? input.audience
+    : 'requester';
 
   let reviewers: string[] = [];
   if (input.reviewers !== undefined) {
@@ -135,9 +152,9 @@ export function normalizeFeedbackPolicy(raw: unknown): FeedbackPolicy {
     throw new Error('feedback.audience "reviewers" requires a non-empty feedback.reviewers allowlist');
   }
   // A reviewers allowlist only has meaning under the reviewers audience; reject
-  // the combination rather than silently ignoring it (a requester-only card
-  // must never appear to have carried an allowlist).
-  if (audience === 'requester' && reviewers.length > 0) {
+  // the combination rather than silently ignoring it (a requester-only or
+  // everyone card must never appear to have carried an allowlist).
+  if (audience !== 'reviewers' && reviewers.length > 0) {
     throw new Error('feedback.reviewers requires feedback.audience "reviewers"');
   }
 
@@ -202,4 +219,57 @@ export function normalizeFeedbackPolicy(raw: unknown): FeedbackPolicy {
 export function resolveFeedbackPolicy(raw: unknown, bot?: { apiOnly?: boolean }): FeedbackPolicy | undefined {
   if (bot?.apiOnly || !raw || typeof raw !== 'object' || Array.isArray(raw) || (raw as { enabled?: unknown }).enabled !== true) return undefined;
   return normalizeFeedbackPolicy(raw);
+}
+
+/** Whether an entry needs a send-time contact lookup to become a matchable id. */
+function isResolvableReviewerEntry(entry: string): boolean {
+  return !entry.startsWith('ou_') && !entry.startsWith('on_');
+}
+
+/**
+ * Freeze the `reviewers` allowlist into ids the network-free callback can match.
+ *
+ * Email entries are human-readable config but cannot be compared against
+ * a card operator without a contact lookup, so we resolve them ONCE here (at
+ * send time, with the bot's own app credentials) into this bot's app-scoped
+ * `ou_`, exactly like owner `allowedUsers`. `ou_`/`on_` pass through untouched.
+ *
+ * Fail closed by dropping only the entries this resolution could not prove:
+ *  - a resolver that maps an email to an `ou_` replaces that entry;
+ *  - an unresolved email is DROPPED (never shipped as a dead entry that
+ *    silently gates nothing, and never left as raw text the callback can't
+ *    match). If every entry drops, the caller sees an empty allowlist and must
+ *    fail closed (no clickable control) rather than emitting an open card.
+ *
+ * `resolve` receives the raw email entries and returns a map from the
+ * raw entry to a resolved `ou_` (missing key = unresolved). It is only called
+ * when there is something to resolve, so `everyone`/`requester` and pure-id
+ * `reviewers` policies never trigger a lookup.
+ */
+export async function materializeFeedbackReviewers(
+  policy: FeedbackPolicy,
+  resolve: (entries: string[]) => Promise<Map<string, string>>,
+): Promise<FeedbackPolicy> {
+  if (policy.audience !== 'reviewers') return policy;
+  const pending = policy.reviewers.filter(isResolvableReviewerEntry);
+  if (pending.length === 0) return policy;
+  let map: Map<string, string>;
+  try {
+    map = await resolve(pending);
+  } catch {
+    // A transient resolver failure must not silently widen or dead-gate the
+    // card. Drop the unresolved entries; keep any literal ids that need no
+    // lookup. An all-dropped result yields an empty allowlist (caller fails
+    // closed), never an open one.
+    map = new Map();
+  }
+  const seen = new Set<string>();
+  const reviewers: string[] = [];
+  for (const entry of policy.reviewers) {
+    const resolved = isResolvableReviewerEntry(entry) ? map.get(entry) : entry;
+    if (!resolved || seen.has(resolved)) continue;
+    seen.add(resolved);
+    reviewers.push(resolved);
+  }
+  return { ...policy, reviewers };
 }

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -18,9 +18,15 @@ const addReactionMock = vi.fn(async () => 'reaction_id');
 const replyToDocCommentMock = vi.fn(async () => {});
 const removeCommentReactionMock = vi.fn(async () => {});
 const updateSessionMock = vi.fn();
+const resolveAllowedUsersWithMapMock = vi.fn(async (_appId: string, entries: string[]) => ({
+  resolved: entries,
+  map: new Map(entries.map(entry => [entry, entry])),
+  entryStatus: new Map(entries.map(entry => [entry, 'resolved' as const])),
+}));
 vi.mock('../src/im/lark/client.js', () => ({
   updateMessage: (...args: any[]) => updateMessageMock(...args),
   addReaction: (...args: any[]) => addReactionMock(...args),
+  resolveAllowedUsersWithMap: (...args: any[]) => resolveAllowedUsersWithMapMock(...args),
   removeReaction: vi.fn(async () => {}),
   sendUserMessage: vi.fn(async () => {}),
   deleteMessage: vi.fn(async () => {}),
@@ -238,6 +244,11 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     await __testOnly_closeSkillFeedbackStores();
     vi.useFakeTimers();
     vi.clearAllMocks();
+    resolveAllowedUsersWithMapMock.mockImplementation(async (_appId: string, entries: string[]) => ({
+      resolved: entries,
+      map: new Map(entries.map(entry => [entry, entry])),
+      entryStatus: new Map(entries.map(entry => [entry, 'resolved' as const])),
+    }));
     vi.mocked(getBot).mockReturnValue({
       config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code' },
       resolvedAllowedUsers: [],
@@ -423,6 +434,73 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
     __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
     await vi.advanceTimersByTimeAsync(10);
+    expect(String(sessionReply.mock.calls[0][1])).not.toContain('botmux_feedback');
+  });
+
+  it('renders everyone feedback for an ownerless final output', async () => {
+    const sessionReply = vi.fn(async () => 'om_everyone_feedback');
+    initWorkerPool({ sessionReply, getSessionWorkingDir: () => '/tmp', getActiveCount: () => 1, closeSession: vi.fn() });
+    const ds = makeDs();
+    ds.feedbackPolicy = normalizeFeedbackPolicy({ enabled: true, audience: 'everyone' });
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    const { getSkillFeedbackStore } = await import('../src/services/skill-feedback-store.js');
+
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(String(sessionReply.mock.calls[0][1])).toContain('botmux_feedback');
+    expect((await getSkillFeedbackStore('/tmp/test-sessions'))
+      .findDeliveryByPlatformMessage('lark', ds.larkAppId, 'om_everyone_feedback'))
+      .toMatchObject({ policy: { audience: 'everyone', reviewers: [] } });
+  });
+
+  it('resolves an email reviewer before rendering and freezes only the open_id', async () => {
+    resolveAllowedUsersWithMapMock.mockResolvedValue({
+      resolved: ['ou_email_reviewer'],
+      map: new Map([['reviewer@example.com', 'ou_email_reviewer']]),
+      entryStatus: new Map([['reviewer@example.com', 'resolved' as const]]),
+    });
+    const sessionReply = vi.fn(async () => 'om_email_feedback');
+    initWorkerPool({ sessionReply, getSessionWorkingDir: () => '/tmp', getActiveCount: () => 1, closeSession: vi.fn() });
+    const ds = makeDs();
+    ds.feedbackPolicy = normalizeFeedbackPolicy({
+      enabled: true,
+      audience: 'reviewers',
+      reviewers: ['reviewer@example.com'],
+    });
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    const { getSkillFeedbackStore } = await import('../src/services/skill-feedback-store.js');
+
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(resolveAllowedUsersWithMapMock).toHaveBeenCalledWith('app_test', ['reviewer@example.com']);
+    expect(String(sessionReply.mock.calls[0][1])).toContain('botmux_feedback');
+    const delivery = (await getSkillFeedbackStore('/tmp/test-sessions'))
+      .findDeliveryByPlatformMessage('lark', ds.larkAppId, 'om_email_feedback');
+    expect(delivery?.policy?.reviewers).toEqual(['ou_email_reviewer']);
+    expect(JSON.stringify(delivery?.policy)).not.toContain('reviewer@example.com');
+  });
+
+  it('does not render a reviewers card when every email is unresolved', async () => {
+    resolveAllowedUsersWithMapMock.mockResolvedValue({
+      resolved: [],
+      map: new Map(),
+      entryStatus: new Map([['ghost@example.com', 'definitive' as const]]),
+    });
+    const sessionReply = vi.fn(async () => 'om_unresolved_feedback');
+    initWorkerPool({ sessionReply, getSessionWorkingDir: () => '/tmp', getActiveCount: () => 1, closeSession: vi.fn() });
+    const ds = makeDs();
+    ds.feedbackPolicy = normalizeFeedbackPolicy({
+      enabled: true,
+      audience: 'reviewers',
+      reviewers: ['ghost@example.com'],
+    });
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
     expect(String(sessionReply.mock.calls[0][1])).not.toContain('botmux_feedback');
   });
 

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -587,6 +587,11 @@ describe('cmdSend hook context wiring', () => {
     expect(cmdSend).toContain("const effectiveResponseKind = responseKind ?? 'progress'");
     expect(cmdSend).not.toContain('启用最终回答反馈后，必须显式指定 --response-kind progress|final');
     expect(cmdSend).toContain('无法确认本次提问者身份，不能发送带反馈控件的最终回答');
+    // The requester-identity gate is scoped to the `requester` audience only.
+    // `reviewers`/`everyone` authorize clicks without a human requester (a
+    // bot-triggered ownerless session), so re-widening this gate to every
+    // audience would silently make those cards unsendable.
+    expect(cmdSend).toContain("feedbackPolicy.audience === 'requester' && !feedbackRequesterSubjectId");
     expect(cmdSend).toContain('requesterSubjectId: feedbackRequesterSubjectId');
     expect(cmdSend).not.toContain("feedbackPolicy && responseKind === 'final'");
     expect(cmdSend).toContain("feedbackPolicy && effectiveResponseKind === 'final'");

--- a/test/feedback-policy-resolution.test.ts
+++ b/test/feedback-policy-resolution.test.ts
@@ -120,6 +120,36 @@ describe('feedback policy layered resolution', () => {
     expect(resolveFeedbackPolicyForDelivery({ dataDir, larkAppId: 'appB', chatId: 'sameChat', bot: botB })).toMatchObject({ allowReselect: true });
   });
 
+  it('merges a reviewers allowlist across layers and fails closed on an invalid merged whole', () => {
+    // audience and reviewers may legitimately arrive from different layers.
+    expect(resolveEffectiveFeedbackPolicy({
+      team: { enabled: true },
+      bot: { audience: 'reviewers' },
+      chat: { reviewers: ['ou_alice', 'on_bob'] },
+    })).toMatchObject({ enabled: true, audience: 'reviewers', reviewers: ['ou_alice', 'on_bob'] });
+
+    // A later layer atomically replaces the allowlist rather than concatenating.
+    expect(resolveEffectiveFeedbackPolicy({
+      team: { enabled: true, audience: 'reviewers', reviewers: ['ou_alice'] },
+      chat: { reviewers: ['ou_carol'] },
+    })).toMatchObject({ audience: 'reviewers', reviewers: ['ou_carol'] });
+
+    // Individually-valid layers can merge into an invalid whole (reviewers
+    // audience with an empty allowlist, or an allowlist without the audience) —
+    // fail closed instead of shipping a dead or mis-gated button.
+    expect(resolveEffectiveFeedbackPolicy({ team: { enabled: true, audience: 'reviewers' } })).toBeUndefined();
+    expect(resolveEffectiveFeedbackPolicy({ team: { enabled: true, reviewers: ['ou_alice'] } })).toBeUndefined();
+  });
+
+  it('format-validates a reviewers layer but leaves the audience coupling to the merged whole', () => {
+    // A partial layer may carry reviewers without audience (the coupling is only
+    // enforced once merged), but the entries must still be verifiable ids.
+    expect(normalizeFeedbackPolicyLayer({ reviewers: ['ou_alice', 'on_bob'] })).toMatchObject({ reviewers: ['ou_alice', 'on_bob'] });
+    expect(() => normalizeFeedbackPolicyLayer({ reviewers: ['alice@example.com'] })).toThrow(/open_id or on_ union_id/);
+    expect(() => normalizeFeedbackPolicyLayer({ reviewers: 'ou_alice' })).toThrow(/reviewers/);
+    expect(() => normalizeFeedbackPolicyLayer({ audience: 'anyone' })).toThrow(/audience/);
+  });
+
   it('traces the effective source chain and reports ambiguous local team bindings', () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'feedback-trace-'));
     const a = createTeam(dataDir, 'A');

--- a/test/feedback-policy-resolution.test.ts
+++ b/test/feedback-policy-resolution.test.ts
@@ -143,11 +143,24 @@ describe('feedback policy layered resolution', () => {
 
   it('format-validates a reviewers layer but leaves the audience coupling to the merged whole', () => {
     // A partial layer may carry reviewers without audience (the coupling is only
-    // enforced once merged), but the entries must still be verifiable ids.
-    expect(normalizeFeedbackPolicyLayer({ reviewers: ['ou_alice', 'on_bob'] })).toMatchObject({ reviewers: ['ou_alice', 'on_bob'] });
-    expect(() => normalizeFeedbackPolicyLayer({ reviewers: ['alice@example.com'] })).toThrow(/open_id or on_ union_id/);
+    // enforced once merged), but the entries must still be ids or full emails.
+    expect(normalizeFeedbackPolicyLayer({ reviewers: ['ou_alice', 'on_bob', 'alice@example.com'] })).toMatchObject({
+      reviewers: ['ou_alice', 'on_bob', 'alice@example.com'],
+    });
+    expect(() => normalizeFeedbackPolicyLayer({ reviewers: ['alice'] })).toThrow(/full email/);
     expect(() => normalizeFeedbackPolicyLayer({ reviewers: 'ou_alice' })).toThrow(/reviewers/);
     expect(() => normalizeFeedbackPolicyLayer({ audience: 'anyone' })).toThrow(/audience/);
+  });
+
+  it('allows everyone at any layer without a reviewers allowlist', () => {
+    expect(resolveEffectiveFeedbackPolicy({
+      team: { enabled: true },
+      chat: { audience: 'everyone' },
+    })).toMatchObject({ enabled: true, audience: 'everyone', reviewers: [] });
+    expect(resolveEffectiveFeedbackPolicy({
+      team: { enabled: true, audience: 'reviewers', reviewers: ['ou_alice'] },
+      chat: { audience: 'everyone', reviewers: [] },
+    })).toMatchObject({ audience: 'everyone', reviewers: [] });
   });
 
   it('traces the effective source chain and reports ambiguous local team bindings', () => {

--- a/test/feedback-policy.test.ts
+++ b/test/feedback-policy.test.ts
@@ -11,6 +11,7 @@ describe('feedback policy', () => {
     expect(normalizeFeedbackPolicy({ enabled: true })).toEqual({
       enabled: true,
       audience: 'requester',
+      reviewers: [],
       allowReselect: false,
       visibleSemantics: ['positive', 'progress', 'negative'],
       buttons: [
@@ -105,5 +106,37 @@ describe('feedback policy', () => {
 
   it('never resolves feedback for api-only bots', () => {
     expect(resolveFeedbackPolicy({ enabled: true }, { apiOnly: true })).toBeUndefined();
+  });
+
+  describe('reviewers audience', () => {
+    it('normalizes a reviewers allowlist and emits it verbatim', () => {
+      const policy = normalizeFeedbackPolicy({
+        enabled: true,
+        audience: 'reviewers',
+        reviewers: ['ou_alice', 'on_bob'],
+      });
+      expect(policy.audience).toBe('reviewers');
+      expect(policy.reviewers).toEqual(['ou_alice', 'on_bob']);
+    });
+
+    it('fails closed when the reviewers audience has an empty allowlist', () => {
+      expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers' })).toThrow(/non-empty/);
+      expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers', reviewers: [] })).toThrow(/non-empty/);
+    });
+
+    it('rejects a reviewers allowlist paired with the requester audience', () => {
+      expect(() => normalizeFeedbackPolicy({ enabled: true, reviewers: ['ou_alice'] })).toThrow(/reviewers/);
+      expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'requester', reviewers: ['ou_alice'] })).toThrow(/reviewers/);
+    });
+
+    it.each([
+      [{ enabled: true, audience: 'reviewers', reviewers: ['alice@example.com'] }, /open_id or on_ union_id/],
+      [{ enabled: true, audience: 'reviewers', reviewers: ['+8613800000000'] }, /open_id or on_ union_id/],
+      [{ enabled: true, audience: 'reviewers', reviewers: [123] }, /must be a string/],
+      [{ enabled: true, audience: 'reviewers', reviewers: ['ou_alice', 'ou_alice'] }, /unique/],
+      [{ enabled: true, audience: 'reviewers', reviewers: 'ou_alice' }, /must be an array/],
+    ])('rejects an unverifiable or malformed reviewers allowlist %#', (input, error) => {
+      expect(() => normalizeFeedbackPolicy(input)).toThrow(error);
+    });
   });
 });

--- a/test/feedback-policy.test.ts
+++ b/test/feedback-policy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeFeedbackPolicy, resolveFeedbackPolicy } from '../src/services/feedback-policy.js';
+import {
+  materializeFeedbackReviewers,
+  normalizeFeedbackPolicy,
+  resolveFeedbackPolicy,
+} from '../src/services/feedback-policy.js';
 
 describe('feedback policy', () => {
   it('is disabled when absent or not explicitly enabled', () => {
@@ -119,24 +123,80 @@ describe('feedback policy', () => {
       expect(policy.reviewers).toEqual(['ou_alice', 'on_bob']);
     });
 
+    it('accepts a full email reviewer entry (resolved to an id at send time)', () => {
+      const policy = normalizeFeedbackPolicy({
+        enabled: true,
+        audience: 'reviewers',
+        reviewers: ['alice@example.com', 'on_bob'],
+      });
+      expect(policy.reviewers).toEqual(['alice@example.com', 'on_bob']);
+    });
+
     it('fails closed when the reviewers audience has an empty allowlist', () => {
       expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers' })).toThrow(/non-empty/);
       expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers', reviewers: [] })).toThrow(/non-empty/);
     });
 
-    it('rejects a reviewers allowlist paired with the requester audience', () => {
+    it('rejects a reviewers allowlist paired with a non-reviewers audience', () => {
       expect(() => normalizeFeedbackPolicy({ enabled: true, reviewers: ['ou_alice'] })).toThrow(/reviewers/);
       expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'requester', reviewers: ['ou_alice'] })).toThrow(/reviewers/);
+      expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'everyone', reviewers: ['ou_alice'] })).toThrow(/reviewers/);
     });
 
     it.each([
-      [{ enabled: true, audience: 'reviewers', reviewers: ['alice@example.com'] }, /open_id or on_ union_id/],
-      [{ enabled: true, audience: 'reviewers', reviewers: ['+8613800000000'] }, /open_id or on_ union_id/],
+      [{ enabled: true, audience: 'reviewers', reviewers: ['alice'] }, /full email/],
+      [{ enabled: true, audience: 'reviewers', reviewers: ['13011112222'] }, /full email/],
       [{ enabled: true, audience: 'reviewers', reviewers: [123] }, /must be a string/],
       [{ enabled: true, audience: 'reviewers', reviewers: ['ou_alice', 'ou_alice'] }, /unique/],
       [{ enabled: true, audience: 'reviewers', reviewers: 'ou_alice' }, /must be an array/],
     ])('rejects an unverifiable or malformed reviewers allowlist %#', (input, error) => {
       expect(() => normalizeFeedbackPolicy(input)).toThrow(error);
+    });
+  });
+
+  describe('everyone audience', () => {
+    it('normalizes the everyone audience with no allowlist', () => {
+      const policy = normalizeFeedbackPolicy({ enabled: true, audience: 'everyone' });
+      expect(policy.audience).toBe('everyone');
+      expect(policy.reviewers).toEqual([]);
+    });
+  });
+
+  describe('materializeFeedbackReviewers', () => {
+    it('resolves email to an id, keeps ou_/on_, and dedupes', async () => {
+      const policy = normalizeFeedbackPolicy({
+        enabled: true,
+        audience: 'reviewers',
+        reviewers: ['alice@example.com', 'ou_bob', 'carol@example.com'],
+      });
+      const frozen = await materializeFeedbackReviewers(policy, async entries => {
+        expect(entries).toEqual(['alice@example.com', 'carol@example.com']);
+        return new Map([['alice@example.com', 'ou_bob'], ['carol@example.com', 'ou_carol']]);
+      });
+      // alice resolves to ou_bob which is already listed → deduped to one.
+      expect(frozen.reviewers).toEqual(['ou_bob', 'ou_carol']);
+    });
+
+    it('drops an unresolved email rather than shipping a dead entry', async () => {
+      const policy = normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers', reviewers: ['ghost@example.com', 'ou_bob'] });
+      const frozen = await materializeFeedbackReviewers(policy, async () => new Map());
+      expect(frozen.reviewers).toEqual(['ou_bob']);
+    });
+
+    it('fails closed to an empty list when the resolver throws', async () => {
+      const policy = normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers', reviewers: ['alice@example.com'] });
+      const frozen = await materializeFeedbackReviewers(policy, async () => { throw new Error('network'); });
+      expect(frozen.reviewers).toEqual([]);
+    });
+
+    it('never calls the resolver for pure-id, everyone or requester policies', async () => {
+      const resolve = async () => { throw new Error('should not be called'); };
+      const pureIds = normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers', reviewers: ['ou_a', 'on_b'] });
+      expect((await materializeFeedbackReviewers(pureIds, resolve)).reviewers).toEqual(['ou_a', 'on_b']);
+      const everyone = normalizeFeedbackPolicy({ enabled: true, audience: 'everyone' });
+      expect(await materializeFeedbackReviewers(everyone, resolve)).toBe(everyone);
+      const requester = normalizeFeedbackPolicy({ enabled: true });
+      expect(await materializeFeedbackReviewers(requester, resolve)).toBe(requester);
     });
   });
 });

--- a/test/skill-feedback-callback.test.ts
+++ b/test/skill-feedback-callback.test.ts
@@ -218,6 +218,28 @@ describe('feedback callback everyone audience', () => {
     store.close();
   });
 
+  it('lets a non-requester click a delivery that DOES carry a requester', async () => {
+    // The other everyone cases use ownerless deliveries, where the `requester`
+    // branch's fallback happens to admit any verified operator too — so they
+    // stay green even with the everyone branch deleted. Pin the one behaviour
+    // only `everyone` produces: a delivery addressed to someone specific is
+    // still clickable by a different member of the chat.
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-feedback-')); dirs.push(dataDir);
+    const store = await SkillFeedbackStore.open(dataDir);
+    const policy = normalizeFeedbackPolicy({ enabled: true, audience: 'everyone' });
+    const response = store.createResponse({ interactionId: 'int-everyone-owned', content: 'answer' });
+    const baseCard = { schema: '2.0', body: { elements: [{ tag: 'markdown', content: 'answer' }, { tag: 'column_set', element_id: 'botmux_feedback' }] } };
+    const delivery = store.createDelivery({ responseId: response.responseId, platform: 'lark', platformAppId: 'app', platformMessageId: 'om', policy, baseCard, requesterSubjectId: 'ou_asker' });
+    const result = await handleSkillFeedbackCardAction(
+      event({ action: 'feedback_submit', result: 'conclusive_usable' }, 'ou_someone_else'),
+      'app',
+      { store },
+    );
+    expect(result.card).toMatchObject({ type: 'raw' });
+    expect(store.getLatestFeedback(delivery.deliveryId, 'ou_someone_else')).toMatchObject({ result: 'conclusive_usable' });
+    store.close();
+  });
+
   it('still rejects a callback with no platform-verified operator identity', async () => {
     const { store } = await everyoneSetup();
     const input = event({ action: 'feedback_submit', result: 'conclusive_usable' });

--- a/test/skill-feedback-callback.test.ts
+++ b/test/skill-feedback-callback.test.ts
@@ -181,3 +181,49 @@ describe('feedback callback reviewers audience', () => {
     store.close();
   });
 });
+
+describe('feedback callback everyone audience', () => {
+  async function everyoneSetup() {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-feedback-')); dirs.push(dataDir);
+    const store = await SkillFeedbackStore.open(dataDir);
+    const policy = normalizeFeedbackPolicy({ enabled: true, audience: 'everyone' });
+    const response = store.createResponse({ interactionId: 'int-everyone', content: 'answer' });
+    const baseCard = { schema: '2.0', body: { elements: [{ tag: 'markdown', content: 'answer' }, { tag: 'column_set', element_id: 'botmux_feedback' }] } };
+    const delivery = store.createDelivery({ responseId: response.responseId, platform: 'lark', platformAppId: 'app', platformMessageId: 'om', policy, baseCard });
+    return { store, delivery };
+  }
+
+  it('lets any platform-identified operator click without a requester', async () => {
+    const { store, delivery } = await everyoneSetup();
+    const result = await handleSkillFeedbackCardAction(
+      event({ action: 'feedback_submit', result: 'conclusive_usable' }, 'ou_anyone'),
+      'app',
+      { store },
+    );
+    expect(result.card).toMatchObject({ type: 'raw' });
+    expect(store.getLatestFeedback(delivery.deliveryId, 'ou_anyone')).toMatchObject({ result: 'conclusive_usable' });
+    store.close();
+  });
+
+  it('prefers the verified union_id as the feedback subject', async () => {
+    const { store, delivery } = await everyoneSetup();
+    const result = await handleSkillFeedbackCardAction(
+      event({ action: 'feedback_submit', result: 'conclusive_usable' }, 'ou_anyone', undefined, 'on_anyone'),
+      'app',
+      { store },
+    );
+    expect(result.card).toMatchObject({ type: 'raw' });
+    expect(store.getLatestFeedback(delivery.deliveryId, 'on_anyone')).toMatchObject({ result: 'conclusive_usable' });
+    expect(store.getLatestFeedback(delivery.deliveryId, 'ou_anyone')).toBeUndefined();
+    store.close();
+  });
+
+  it('still rejects a callback with no platform-verified operator identity', async () => {
+    const { store } = await everyoneSetup();
+    const input = event({ action: 'feedback_submit', result: 'conclusive_usable' });
+    delete input.operator;
+    const result = await handleSkillFeedbackCardAction(input, 'app', { store });
+    expect(result.toast).toMatchObject({ type: 'error', content: '无法验证反馈来源，请重试' });
+    store.close();
+  });
+});

--- a/test/skill-feedback-callback.test.ts
+++ b/test/skill-feedback-callback.test.ts
@@ -142,3 +142,42 @@ describe('feedback callback state machine', () => {
     store.close();
   });
 });
+
+describe('feedback callback reviewers audience', () => {
+  async function reviewersSetup(reviewers: string[]) {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-feedback-')); dirs.push(dataDir);
+    const store = await SkillFeedbackStore.open(dataDir);
+    const policy = normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers', reviewers });
+    const response = store.createResponse({ interactionId: 'int-reviewers', content: 'answer' });
+    const baseCard = { schema: '2.0', body: { elements: [{ tag: 'markdown', content: 'answer' }, { tag: 'column_set', element_id: 'botmux_feedback' }] } };
+    // Bot-triggered auto-analysis has no human requester, so the delivery is
+    // ownerless — the allowlist is the only identity gate.
+    const delivery = store.createDelivery({ responseId: response.responseId, platform: 'lark', platformAppId: 'app', platformMessageId: 'om', policy, baseCard });
+    return { store, delivery };
+  }
+
+  it('lets a listed reviewer (by open_id) click even with no requester on the delivery', async () => {
+    const { store, delivery } = await reviewersSetup(['ou_reviewer']);
+    const result = await handleSkillFeedbackCardAction(event({ action: 'feedback_submit', result: 'conclusive_usable' }, 'ou_reviewer'), 'app', { store });
+    expect(result.card).toMatchObject({ type: 'raw' });
+    expect(store.getLatestFeedback(delivery.deliveryId, 'ou_reviewer')).toMatchObject({ result: 'conclusive_usable' });
+    store.close();
+  });
+
+  it('lets a listed reviewer (by cross-app union_id) click regardless of open_id', async () => {
+    const { store, delivery } = await reviewersSetup(['on_reviewer']);
+    const result = await handleSkillFeedbackCardAction(event({ action: 'feedback_submit', result: 'conclusive_usable' }, 'ou_whoever', undefined, 'on_reviewer'), 'app', { store });
+    expect(result.card).toMatchObject({ type: 'raw' });
+    expect(store.getLatestFeedback(delivery.deliveryId, 'on_reviewer')).toMatchObject({ result: 'conclusive_usable' });
+    store.close();
+  });
+
+  it('rejects a non-listed operator with the reviewers toast and mutates nothing', async () => {
+    const { store, delivery } = await reviewersSetup(['ou_reviewer']);
+    const result = await handleSkillFeedbackCardAction(event({ action: 'feedback_submit', result: 'conclusive_usable' }, 'ou_intruder'), 'app', { store });
+    expect(result.toast).toMatchObject({ type: 'error', content: '仅指定的反馈人可反馈' });
+    expect(store.listFeedbackRevisions(delivery.deliveryId, 'ou_intruder')).toHaveLength(0);
+    expect(store.listFeedbackRevisions(delivery.deliveryId, 'ou_reviewer')).toHaveLength(0);
+    store.close();
+  });
+});


### PR DESCRIPTION
## 背景

反馈卡默认 `audience=requester`，只有本次回答的精确接收者能点击。在 bot 触发的自动分析场景（Oncall / 告警监听等，见 #1178）中，本次 turn 的发送者可能是另一个 bot、没有单一真人 owner，导致群内真人点击反馈时被判「无权限」。

本 PR 新增两种按场景选择的 audience：

- `reviewers`：只允许可信名单中的用户点击；名单支持 `ou_`、`on_` 和完整邮箱。
- `everyone`：允许任意具有飞书平台核验 operator 身份的用户点击。

默认仍为 `requester`，旧配置和旧卡行为不变。

## 改动

- `FeedbackAudience` 扩展为 `requester | reviewers | everyone`。
- `reviewers` 最多 50 项且不重复，可配置：
  - `ou_`：当前 app 的 open_id；
  - `on_`：跨 app 稳定的 union_id；
  - 完整邮箱：发卡时通过当前 bot 凭证解析为本 app 的 `ou_`，再冻结进 delivery 快照。
- 邮箱不会进入回调鉴权路径或持久化快照：回调仍是零网络比对；邮箱无法解析时丢弃该项，全部无法解析则 fail closed、不展示反馈控件。
- `everyone` 不使用 requester 或 reviewers 名单，但仍要求卡片回调携带飞书平台核验的 operator 身份；无法验证来源继续 fail closed。
- `requester` / `everyone` 携带非空 `reviewers`、或 `reviewers` audience 缺名单，均 fail closed。
- CLI final send 与 daemon fallback 两条交付路径都会在发送前物化邮箱名单；ownerless 的 bot 触发会话可使用 `reviewers` / `everyone`，且不会回填 owner，避免 @-loop。
- 名单与 audience 随 delivery `policy_snapshot` 冻结，后续配置变化只影响新卡，无需 schema 变更。
- 同步 Dashboard 公共类型和 `docs/feedback-capability-current-implementation.md`。

## 配置示例

指定反馈人（支持邮箱）：

```json
{
  "feedback": {
    "enabled": true,
    "audience": "reviewers",
    "reviewers": ["on_cross_app_reviewer", "oncall@example.com"]
  }
}
```

所有可识别用户均可反馈：

```json
{
  "feedback": {
    "enabled": true,
    "audience": "everyone"
  }
}
```

## 影响面

- 飞书反馈卡策略、回调和两条 final-output 交付路径。
- 多 CLI / `PtyBackend` / `TmuxBackend` 共用同一策略，不依赖具体 CLI。
- 默认 `requester` 行为不变；`apiOnly`、非 final、自定义卡等既有展示边界不变。
- `everyone` 会扩大反馈写入范围，文档明确建议只用于群成员均可信的场景。

## 测试

- `bun run build`：通过。
- feedback / bridge 相关 14 个测试文件：**204 passed**。
- `test/bot-registry.test.ts`：**133 passed**。
- 新增覆盖：
  - 邮箱格式校验、发送时解析、去重、未解析 fail closed；
  - 快照只存解析后的 `ou_`，不存原始邮箱；
  - `everyone` ownerless 展示、任意 operator 放行、缺少可信 operator 拒绝；
  - team/bot/chat 分层合并及 Dashboard 类型。
