### PR TITLE
fix(lark): 让私聊 /t 持续绑定独立会话

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -10,7 +10,7 @@ import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { join } from 'node:path';
 import { getBot, getAllBots, findOncallChat, getOwnerOpenId, loadBotConfigs, vcMeetingAgentConfigActive, type BotState } from '../../bot-registry.js';
 import { config, isVcMeetingAgentGloballyEnabled, vcMeetingAgentGlobalListenerBotAppId } from '../../config.js';
-import { getChatInfo, getChatMode, getCachedChatMode, getUserProfile, listChatMessagesUntil, resolveSiblingBotBySenderOpenId, replyMessage, sendMessage, sendUserMessage, isHumanOpenId, updateMessage } from './client.js';
+import { getChatInfo, getChatMode, getCachedChatMode, getMessageDetail, getUserProfile, listChatMessagesUntil, resolveSiblingBotBySenderOpenId, replyMessage, sendMessage, sendUserMessage, isHumanOpenId, updateMessage } from './client.js';
 import { logger } from '../../utils/logger.js';
 import { BoundedMap } from '../../utils/bounded-map.js';
 import { serializeByAnchor } from '../../utils/anchor-serializer.js';
@@ -64,6 +64,7 @@ import { resolveRegularGroupMode, resolveGroupMentionMode, type GroupMentionMode
 import { buildSummaryCommandPrompt, type SummaryChatKind, type SummaryCommandMatch, type SummaryCommandRuntimeContext } from './summary-command.js';
 import { DEFAULT_SUMMARY_PROMPT, summaryRangeFromBotConfig } from '../../services/summary-range-store.js';
 import { isSubstituteEnabledForChat } from '../../services/substitute-chat-toggle-store.js';
+import { isP2pForceTopicRoot, recordP2pForceTopicRoot } from '../../services/p2p-force-topic-store.js';
 import { evaluateMessageListener, resolveListenerSenderIdentity, buildListenerBotAppIdToOpenId, collectListenerBotAppIds, type MessageListenerMatch } from '../../services/message-listener.js';
 import {
   parseVcMeetingPushEvent,
@@ -2869,6 +2870,80 @@ type RoutingDecision = {
   source: RoutingSource;
 };
 
+const legacyP2pForceTopicChecks = new BoundedMap<string, Promise<boolean>>(1000);
+
+async function isExplicitP2pTopic(input: {
+  larkAppId: string;
+  chatId: string;
+  rootId: string;
+}): Promise<boolean> {
+  const { larkAppId, chatId, rootId } = input;
+  if (isP2pForceTopicRoot(larkAppId, rootId, chatId)) return true;
+
+  // Backward compatibility for /t topics created before the provenance store
+  // existed, including bare /t roots that intentionally have no Session. Active
+  // ownership is not sufficient evidence: p2pMode=thread sessions deliberately
+  // fold into chat after switching to chat mode. Verify the immutable root
+  // message once, then persist only roots whose text really began with /t or
+  // /topic. On lookup failure, preserve the historical flat routing.
+  const key = `${larkAppId}:${chatId}:${rootId}`;
+  const cached = legacyP2pForceTopicChecks.get(key);
+  if (cached) return cached;
+  const check = (async () => {
+    try {
+      const detail = await getMessageDetail(larkAppId, rootId, { userCardContent: false });
+      const root = detail?.items?.[0];
+      if (!root || (root.chat_id && root.chat_id !== chatId)) return false;
+      const rawText = extractMessageTextForRouting({
+        message_type: root.msg_type ?? root.message_type,
+        content: root.body?.content ?? root.content,
+        mentions: root.mentions,
+      });
+      if (!rawText) return false;
+      const stripped = stripLeadingMentions(rawText.trim(), root.mentions ?? []);
+      if (!parseForceTopicInvocation(stripped)) return false;
+      recordP2pForceTopicRoot(larkAppId, rootId, chatId);
+      return true;
+    } catch (err) {
+      logger.debug(`[routing] failed to verify legacy p2p topic root=${rootId.substring(0, 12)}: ${err}`);
+      legacyP2pForceTopicChecks.delete(key);
+      return false;
+    }
+  })();
+  legacyP2pForceTopicChecks.set(key, check);
+  return check;
+}
+
+async function promoteExplicitP2pTopicIfNeeded(input: {
+  larkAppId: string;
+  chatId: string;
+  chatType: 'group' | 'p2p';
+  message: any;
+  routing: { scope: 'thread' | 'chat'; anchor: string };
+  routingSource: RoutingSource;
+}): Promise<boolean> {
+  const { larkAppId, chatId, chatType, message, routing, routingSource } = input;
+  if (routingSource !== 'p2p'
+      || routing.scope !== 'chat'
+      || chatType !== 'p2p'
+      || !message.root_id
+      || !message.thread_id) {
+    return false;
+  }
+  if (!await isExplicitP2pTopic({
+    larkAppId, chatId, rootId: message.root_id,
+  })) {
+    return false;
+  }
+  routing.scope = 'thread';
+  routing.anchor = message.root_id;
+  logger.info(
+    `[routing] p2p topic root=${message.root_id.substring(0, 12)} is /t-created or actively owned; ` +
+    `continuing thread-scope instead of chat=${chatId.substring(0, 12)}`,
+  );
+  return true;
+}
+
 function regularGroupRouting(larkAppId: string, messageId: string, chatId: string): RoutingDecision {
   // Only `new-topic` forks a fresh thread-scope session for a TOP-LEVEL @.
   // `shared` stays chat-scope here (the topic fold happens post-routing, see
@@ -3783,6 +3858,16 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         }
         const decision = await decideRoutingWithSource(larkAppId, message);
         const ctx = { scope: decision.scope, anchor: decision.anchor };
+        // Legacy /t provenance backfill reads an immutable root message and may
+        // persist a marker. Keep that state mutation behind the same talk gate
+        // as delivery; an untrusted bot must not be able to populate the ledger
+        // even though the later delivery gate would still reject its turn.
+        const botTalk = evaluateBotTalk(larkAppId, chatId, senderOpenId, senderUnionId);
+        if (botTalk.allowed) {
+          await promoteExplicitP2pTopicIfNeeded({
+            larkAppId, chatId, chatType, message, routing: ctx, routingSource: decision.source,
+          });
+        }
         // Honor `/t` / `/topic` from bot senders too, aligning with the human
         // path so an explicit `@bot /t …` handoff seeds a fresh topic instead of
         // sticking to chat-scope. Applied BEFORE the gate (and the shared-topic
@@ -3801,7 +3886,6 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         // 结论（二者之间只有 fold / shared-seed 的路由计算，不改任何授权状态）。
         // 曾经这里是两条手抄的 OR 链，靠人肉保持同步；漏一处就是「能路由但不能 fold」
         // 或「fold 了却弹卡」的二次分裂。
-        const botTalk = evaluateBotTalk(larkAppId, chatId, senderOpenId, senderUnionId);
         let replyRootId = await maybeFoldMentionedRegularGroupThreadToChat({
           larkAppId, chatId, chatType, message, routing: ctx, forceTopicApplied: forcedTopic, mentionedThisBot: botTalk.allowed, ownsThreadSession,
           answeredRootAtTopLevel: root => handlers.chatSessionAnsweredRootAtTopLevel?.(root, chatId, larkAppId) ?? false,
@@ -3854,6 +3938,9 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
             await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data);
             return;
           }
+        }
+        if (chatType === 'p2p' && forcedTopic) {
+          recordP2pForceTopicRoot(larkAppId, messageId, chatId);
         }
         logger.info(`Bot-to-bot @mention detected (scope=${ctx.scope}): routing to handleThreadReply`);
         // Serialize per anchor — a sub-bot dispatched a /repo prime + kickoff
@@ -3931,6 +4018,21 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         anchor: decision.anchor,
       };
       let routingSource = decision.source;
+      // Default/chat-mode DMs normally stay in one flat chat-scope session, even
+      // when Lark supplies root_id + thread_id. An explicitly seeded topic (for
+      // example via /t) is the exception: an app-scoped /t provenance marker or
+      // an active session at that root makes later replies continue thread-scope
+      // instead of running in the unrelated DM chat context. The durable marker
+      // also covers bare /t, which intentionally materializes a topic without a
+      // Session. Match the chat as well as the complete root ID; ordinary DM
+      // topics retain the flat behavior.
+      // Legacy provenance backfill is a durable state mutation, so keep it
+      // behind the same permission gate as message delivery.
+      if (isAllowed && await promoteExplicitP2pTopicIfNeeded({
+        larkAppId, chatId, chatType, message, routing, routingSource,
+      })) {
+        routingSource = 'real-thread';
+      }
       let replyRootId: string | undefined;
       // 私聊 chat 模式：会话是扁平连续的(整段 DM 一个 chat-scope 会话),但如果这条
       // 消息本身是在某个已存在的话题里回复的(root_id+thread_id),可见回复必须落回
@@ -4438,6 +4540,14 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         if (before?.block) return;
         if (before?.anchorOverride) ctx.anchor = before.anchorOverride;
         ownsSession = handlers.isSessionOwner?.(ctx.anchor, larkAppId) ?? ownsSession;
+      }
+      // Record explicit DM /t intent before this message releases the raw
+      // per-chat routing lane and before handleNewTopic begins its async session
+      // registration. A back-to-back root-linked reply can therefore select the
+      // same canonical root immediately. This is intentionally after permission
+      // and beforeSessionTurn gates: rejected /t messages create no routing state.
+      if (chatType === 'p2p' && forceTopicApplied) {
+        recordP2pForceTopicRoot(larkAppId, messageId, chatId);
       }
       const payload = { data, ctx, ownsSession } satisfies PendingForwardTopicPayload;
       const groupMentionMode = resolveGroupMentionMode(larkAppId, chatId);

--- a/src/services/p2p-force-topic-store.ts
+++ b/src/services/p2p-force-topic-store.ts
@@ -1,0 +1,93 @@
+/**
+ * Durable, app-scoped provenance for DM topics explicitly materialized by /t.
+ *
+ * Default P2P routing deliberately folds root_id + thread_id replies into one
+ * chat-scope session. A /t-created topic is the exception, including a bare /t
+ * that intentionally creates no Session yet. Active-session ownership alone
+ * cannot represent that setup-only state and also has a short registration race,
+ * so the dispatcher records the explicit user intent before releasing its raw
+ * per-chat routing lane.
+ */
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { config } from '../config.js';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { logger } from '../utils/logger.js';
+
+const MAX_ROOTS_PER_APP = 10_000;
+
+type RootRecord = { chatId: string; createdAt: number };
+type RootStore = Record<string, RootRecord>;
+
+const caches = new Map<string, Map<string, RootRecord>>();
+
+function fileFor(larkAppId: string): string {
+  return join(config.session.dataDir, 'p2p-force-topic-roots', `${larkAppId}.json`);
+}
+
+function load(larkAppId: string): Map<string, RootRecord> {
+  const cached = caches.get(larkAppId);
+  if (cached) return cached;
+
+  const roots = new Map<string, RootRecord>();
+  const file = fileFor(larkAppId);
+  try {
+    if (existsSync(file)) {
+      const parsed = JSON.parse(readFileSync(file, 'utf-8')) as RootStore;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const entries = Object.entries(parsed)
+          .filter((entry): entry is [string, RootRecord] => {
+            const [rootId, record] = entry;
+            return !!rootId
+              && !!record
+              && typeof record === 'object'
+              && typeof record.chatId === 'string'
+              && record.chatId.length > 0
+              && typeof record.createdAt === 'number'
+              && Number.isFinite(record.createdAt);
+          })
+          .sort((a, b) => a[1].createdAt - b[1].createdAt)
+          .slice(-MAX_ROOTS_PER_APP);
+        for (const entry of entries) roots.set(...entry);
+      }
+    }
+  } catch (err) {
+    logger.warn(`[p2p-force-topic] failed to load ${file}: ${err}`);
+  }
+  caches.set(larkAppId, roots);
+  return roots;
+}
+
+function persist(larkAppId: string, roots: Map<string, RootRecord>): void {
+  const file = fileFor(larkAppId);
+  try {
+    mkdirSync(dirname(file), { recursive: true });
+    atomicWriteFileSync(file, `${JSON.stringify(Object.fromEntries(roots), null, 2)}\n`, { mode: 0o600 });
+  } catch (err) {
+    // Keep the in-process marker even if persistence is temporarily unavailable.
+    logger.warn(`[p2p-force-topic] failed to persist ${file}: ${err}`);
+  }
+}
+
+export function recordP2pForceTopicRoot(larkAppId: string, rootId: string, chatId: string): void {
+  if (!larkAppId || !rootId || !chatId) return;
+  const roots = load(larkAppId);
+  roots.delete(rootId);
+  roots.set(rootId, { chatId, createdAt: Date.now() });
+  while (roots.size > MAX_ROOTS_PER_APP) {
+    const oldest = roots.keys().next().value as string | undefined;
+    if (!oldest) break;
+    roots.delete(oldest);
+  }
+  persist(larkAppId, roots);
+}
+
+export function isP2pForceTopicRoot(larkAppId: string, rootId: string, chatId: string): boolean {
+  if (!larkAppId || !rootId || !chatId) return false;
+  return load(larkAppId).get(rootId)?.chatId === chatId;
+}
+
+/** Test-only: simulate a daemon restart without touching persisted files. */
+export function __resetP2pForceTopicRootsForTest(): void {
+  caches.clear();
+}

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -117,6 +117,18 @@ vi.mock('../src/services/substitute-chat-toggle-store.js', () => ({
   setSubstituteEnabledForChat: vi.fn(),
 }));
 
+const mockP2pForceTopicRoots = new Set<string>();
+const mockIsP2pForceTopicRoot = vi.fn((larkAppId: string, rootId: string, chatId: string) => (
+  mockP2pForceTopicRoots.has(`${larkAppId}:${chatId}:${rootId}`)
+));
+const mockRecordP2pForceTopicRoot = vi.fn((larkAppId: string, rootId: string, chatId: string) => {
+  mockP2pForceTopicRoots.add(`${larkAppId}:${chatId}:${rootId}`);
+});
+vi.mock('../src/services/p2p-force-topic-store.js', () => ({
+  isP2pForceTopicRoot: (...args: any[]) => mockIsP2pForceTopicRoot(...(args as [string, string, string])),
+  recordP2pForceTopicRoot: (...args: any[]) => mockRecordP2pForceTopicRoot(...(args as [string, string, string])),
+}));
+
 // Capture the registered event handlers from EventDispatcher.register()
 let capturedHandlers: Record<string, Function> = {};
 let capturedWsClientOptions: Record<string, any> | undefined;
@@ -173,6 +185,9 @@ const OTHER_BOT_APP_ID = 'app-bot-b';
 const USER_OPEN_ID = 'ou_user_123';
 
 beforeEach(() => {
+  mockP2pForceTopicRoots.clear();
+  mockIsP2pForceTopicRoot.mockClear();
+  mockRecordP2pForceTopicRoot.mockClear();
   __resetPeerCrossRefCacheForTest();
   mockCrossRefStatSync.mockReset().mockReturnValue({
     dev: 1, ino: 1, size: 1, mtimeMs: 1, ctimeMs: 1,
@@ -820,7 +835,7 @@ function setupBotState(opts?: {
 	  commandTriggers?: { enabled: boolean; commands: Array<{ cmd: string; prompt?: string }>; chats?: string[]; excludedChats?: string[] };
 	  chatReplyModes?: Record<string, 'chat' | 'new-topic' | 'shared' | 'chat-topic'>;
 	  chatMentionModes?: Record<string, 'always' | 'topic' | 'never' | 'ambient'>;
-	  p2pMode?: 'thread' | 'chat';
+	  p2pMode?: 'thread' | 'chat' | 'group';
 	  summaryRange?: { limit?: number; sinceHours?: number };
 	  summaryMemory?: boolean;
 	  summaryMemoryPath?: string;
@@ -1255,6 +1270,14 @@ describe('decideRouting — p2p p2pMode (thread | chat)', () => {
       .toEqual({ scope: 'thread', anchor: 'root-dm' });
   });
 
+  it('explicit group mode preserves per-message thread-shaped DM routing', async () => {
+    setupBotState({ p2pMode: 'group' });
+    expect(await decideRouting(MY_APP_ID, dm()))
+      .toEqual({ scope: 'thread', anchor: 'msg-dm' });
+    expect(await decideRouting(MY_APP_ID, dm({ root_id: 'root-dm', thread_id: 'root-dm' })))
+      .toEqual({ scope: 'thread', anchor: 'root-dm' });
+  });
+
   it('p2pMode=chat does NOT leak into group routing (gate is p2p-only): group real-thread stays thread-scope', async () => {
     setupBotState({ p2pMode: 'chat' });
     expect(await decideRouting(MY_APP_ID, { message_id: 'msg-g', chat_id: 'oc_g', chat_type: 'group', root_id: 'root-g', thread_id: 'root-g' }))
@@ -1305,6 +1328,545 @@ describe('decideRouting — p2p p2pMode (thread | chat)', () => {
       message_id: 'msg-nt-seed', chat_id: 'oc_group', chat_type: 'group',
       root_id: undefined, thread_id: 'omt_native_topic',
     })).toEqual({ scope: 'thread', anchor: 'msg-nt-seed' });
+  });
+});
+
+describe('im.message.receive_v1 — p2p chat-mode owned topic routing', () => {
+  let handlers: ReturnType<typeof makeHandlers>;
+
+  beforeEach(() => {
+    capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
+    _resetGrantPending();
+    setupBotState({ allowedUsers: [USER_OPEN_ID] });
+    handlers = makeHandlers();
+    mockFindOncallChat.mockReturnValue(undefined);
+    startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
+  });
+
+  it('continues a /t-created DM topic at its owned root instead of the existing chat session', async () => {
+    const chatId = 'oc_dm_with_topic';
+    const rootId = 'om_topic_root';
+    const ownedAnchors = new Set([chatId]);
+    handlers.isSessionOwner.mockImplementation((anchor: string, appId: string) => (
+      appId === MY_APP_ID && ownedAnchors.has(anchor)
+    ));
+    handlers.handleNewTopic.mockImplementation(async (_data: any, ctx: { anchor: string }) => {
+      ownedAnchors.add(ctx.anchor);
+    });
+    mockP2pForceTopicRoots.add(`${MY_APP_ID}:${chatId}:${rootId}`);
+
+    const topicSeed = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '/t keep this separate' }),
+      messageId: rootId,
+      chatId,
+      chatType: 'p2p',
+    });
+    await capturedHandlers['im.message.receive_v1'](topicSeed);
+    await flushEventWork();
+
+    expect(handlers.handleNewTopic).toHaveBeenCalledWith(topicSeed, expect.objectContaining({
+      scope: 'thread',
+      anchor: rootId,
+      larkAppId: MY_APP_ID,
+    }));
+
+    const followUp = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'continue inside the topic' }),
+      messageId: 'om_topic_follow_up',
+      rootId,
+      threadId: 'omt_dm_topic',
+      chatId,
+      chatType: 'p2p',
+    });
+    await capturedHandlers['im.message.receive_v1'](followUp);
+    await flushEventWork();
+
+    expect(mockIsP2pForceTopicRoot).toHaveBeenCalledWith(MY_APP_ID, rootId, chatId);
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(followUp, expect.objectContaining({
+      scope: 'thread',
+      anchor: rootId,
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it('records the /t root before dispatch so a back-to-back DM follow-up cannot race session registration', async () => {
+    const chatId = 'oc_dm_topic_race';
+    const rootId = 'om_topic_race_root';
+    let releaseSeed!: () => void;
+    const seedBlocked = new Promise<void>(resolve => { releaseSeed = resolve; });
+    let ownsRoot = false;
+    handlers.isSessionOwner.mockImplementation((anchor: string, appId: string) => (
+      appId === MY_APP_ID && (anchor === chatId || (anchor === rootId && ownsRoot))
+    ));
+    handlers.handleNewTopic.mockImplementation(async () => {
+      await seedBlocked;
+      ownsRoot = true;
+    });
+
+    const topicSeed = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '/t keep this separate' }),
+      messageId: rootId,
+      chatId,
+      chatType: 'p2p',
+    });
+    const followUp = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'arrived before the seed registered' }),
+      messageId: 'om_topic_race_follow_up',
+      rootId,
+      threadId: 'omt_dm_topic_race',
+      chatId,
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](topicSeed);
+    await capturedHandlers['im.message.receive_v1'](followUp);
+    await flushEventWork();
+
+    expect(mockRecordP2pForceTopicRoot).toHaveBeenCalledWith(MY_APP_ID, rootId, chatId);
+    expect(handlers.handleThreadReply).not.toHaveBeenCalledWith(followUp, expect.objectContaining({
+      scope: 'chat',
+      anchor: chatId,
+    }));
+
+    releaseSeed();
+    await flushEventWork();
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(followUp, expect.objectContaining({
+      scope: 'thread',
+      anchor: rootId,
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it('keeps a materialized bare /t DM topic isolated even when no active session exists yet', async () => {
+    const chatId = 'oc_dm_bare_topic';
+    const rootId = 'om_bare_topic_root';
+    handlers.isSessionOwner.mockImplementation((anchor: string, appId: string) => (
+      appId === MY_APP_ID && anchor === chatId
+    ));
+
+    const bareTopic = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '/t' }),
+      messageId: rootId,
+      chatId,
+      chatType: 'p2p',
+    });
+    await capturedHandlers['im.message.receive_v1'](bareTopic);
+    await flushEventWork();
+
+    const firstTask = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'first actual task in this topic' }),
+      messageId: 'om_bare_topic_task',
+      rootId,
+      threadId: 'omt_bare_dm_topic',
+      chatId,
+      chatType: 'p2p',
+    });
+    await capturedHandlers['im.message.receive_v1'](firstTask);
+    await flushEventWork();
+
+    expect(handlers.handleNewTopic).toHaveBeenCalledWith(firstTask, expect.objectContaining({
+      scope: 'thread',
+      anchor: rootId,
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it('keeps an unowned DM topic reply folded into the flat chat session', async () => {
+    const chatId = 'oc_dm_flat';
+    const rootId = 'om_unowned_topic_root';
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'ordinary DM reply' }),
+      messageId: 'om_unowned_topic_reply',
+      rootId,
+      threadId: 'omt_unowned_dm_topic',
+      chatId,
+      chatType: 'p2p',
+    });
+    handlers.isSessionOwner.mockImplementation((anchor: string, appId: string) => (
+      appId === MY_APP_ID && anchor === chatId
+    ));
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockIsP2pForceTopicRoot).toHaveBeenCalledWith(MY_APP_ID, rootId, chatId);
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'chat',
+      anchor: chatId,
+      replyRootId: rootId,
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it('migrates a pre-store /t root after verifying its immutable root message', async () => {
+    const chatId = 'oc_dm_legacy_force_topic';
+    const rootId = 'om_legacy_force_topic_root';
+    handlers.isSessionOwner.mockImplementation((anchor: string, appId: string) => (
+      appId === MY_APP_ID && (anchor === chatId || anchor === rootId)
+    ));
+    mockGetMessageDetail.mockResolvedValueOnce({
+      items: [{
+        chat_id: chatId,
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: '/t legacy task' }) },
+        mentions: [],
+      }],
+    });
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'continue legacy /t topic' }),
+      messageId: 'om_legacy_force_topic_reply',
+      rootId,
+      threadId: 'omt_legacy_force_topic',
+      chatId,
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    await vi.waitFor(() => {
+      expect(mockGetMessageDetail).toHaveBeenCalledWith(MY_APP_ID, rootId, { userCardContent: false });
+    });
+    expect(mockRecordP2pForceTopicRoot).toHaveBeenCalledWith(MY_APP_ID, rootId, chatId);
+    await vi.waitFor(() => {
+      expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+        scope: 'thread',
+        anchor: rootId,
+      }));
+    });
+  });
+
+  it('does not backfill a legacy /t marker for an unauthorized DM sender', async () => {
+    const chatId = 'oc_dm_legacy_unauthorized';
+    const rootId = 'om_legacy_unauthorized_root';
+    mockGetMessageDetail.mockResolvedValueOnce({
+      items: [{
+        chat_id: chatId,
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: '/t legacy task' }) },
+        mentions: [],
+      }],
+    });
+    const event = makeUserMessageEvent({
+      senderOpenId: 'ou_not_allowed',
+      content: JSON.stringify({ text: 'unauthorized legacy follow-up' }),
+      messageId: 'om_legacy_unauthorized_reply',
+      rootId,
+      threadId: 'omt_legacy_unauthorized',
+      chatId,
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockGetMessageDetail).not.toHaveBeenCalled();
+    expect(mockRecordP2pForceTopicRoot).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+
+  it('does not migrate a legacy /t root whose immutable message belongs to another chat', async () => {
+    const chatId = 'oc_dm_legacy_expected_chat';
+    const rootId = 'om_legacy_cross_chat_root';
+    handlers.isSessionOwner.mockImplementation((anchor: string, appId: string) => (
+      appId === MY_APP_ID && anchor === chatId
+    ));
+    mockGetMessageDetail.mockResolvedValueOnce({
+      items: [{
+        chat_id: 'oc_dm_legacy_other_chat',
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: '/t legacy task' }) },
+        mentions: [],
+      }],
+    });
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'cross-chat legacy follow-up' }),
+      messageId: 'om_legacy_cross_chat_reply',
+      rootId,
+      threadId: 'omt_legacy_cross_chat',
+      chatId,
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockRecordP2pForceTopicRoot).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+        scope: 'chat',
+        anchor: chatId,
+        replyRootId: rootId,
+      }));
+    });
+  });
+
+  it('does not consult legacy provenance for a DM quote bubble without thread_id', async () => {
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'quoted reply, not a topic' }),
+      messageId: 'om_dm_quote_bubble_reply',
+      rootId: 'om_dm_quote_bubble_root',
+      threadId: null,
+      chatId: 'oc_dm_quote_bubble',
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockGetMessageDetail).not.toHaveBeenCalled();
+    expect(mockRecordP2pForceTopicRoot).not.toHaveBeenCalled();
+  });
+
+  it('retries legacy /t verification after a transient root-message lookup failure', async () => {
+    const chatId = 'oc_dm_legacy_retry';
+    const rootId = 'om_legacy_retry_root';
+    mockGetMessageDetail
+      .mockRejectedValueOnce(new Error('temporary Lark API failure'))
+      .mockResolvedValueOnce({
+        items: [{
+          chat_id: chatId,
+          msg_type: 'text',
+          body: { content: JSON.stringify({ text: '/t retryable legacy task' }) },
+          mentions: [],
+        }],
+      });
+
+    const first = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'first follow-up during outage' }),
+      messageId: 'om_legacy_retry_first',
+      rootId,
+      threadId: 'omt_legacy_retry',
+      chatId,
+      chatType: 'p2p',
+    });
+    const second = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'second follow-up after recovery' }),
+      messageId: 'om_legacy_retry_second',
+      rootId,
+      threadId: 'omt_legacy_retry',
+      chatId,
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](first);
+    await flushEventWork();
+    await capturedHandlers['im.message.receive_v1'](second);
+    await flushEventWork();
+
+    expect(mockGetMessageDetail).toHaveBeenCalledTimes(2);
+    expect(mockRecordP2pForceTopicRoot).toHaveBeenCalledWith(MY_APP_ID, rootId, chatId);
+    await vi.waitFor(() => {
+      expect(handlers.handleNewTopic).toHaveBeenCalledWith(second, expect.objectContaining({
+        scope: 'thread',
+        anchor: rootId,
+      }));
+    });
+  });
+
+  it('lets an authorized bot sender continue a legacy /t DM topic', async () => {
+    setupBotState({ allowedUsers: [OTHER_BOT_OPEN_ID] });
+    const chatId = 'oc_dm_legacy_bot_sender';
+    const rootId = 'om_legacy_bot_sender_root';
+    mockGetMessageDetail.mockResolvedValueOnce({
+      items: [{
+        chat_id: chatId,
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: '/t delegated legacy task' }) },
+        mentions: [],
+      }],
+    });
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({ text: '@BotA continue delegated task' }),
+      messageId: 'om_legacy_bot_sender_reply',
+      rootId,
+      threadId: 'omt_legacy_bot_sender',
+      chatId,
+      chatType: 'p2p',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockRecordP2pForceTopicRoot).toHaveBeenCalledWith(MY_APP_ID, rootId, chatId);
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: rootId,
+    }));
+  });
+
+  it('does not backfill a legacy /t marker for an unauthorized bot sender', async () => {
+    setupBotState({ allowedUsers: [USER_OPEN_ID] });
+    mockResolveSiblingBot.mockResolvedValueOnce({ ok: false, reason: 'not_a_sibling' });
+    const chatId = 'oc_dm_legacy_bot_unauthorized';
+    const rootId = 'om_legacy_bot_unauthorized_root';
+    mockGetMessageDetail.mockResolvedValueOnce({
+      items: [{
+        chat_id: chatId,
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: '/t delegated legacy task' }) },
+        mentions: [],
+      }],
+    });
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({ text: '@BotA continue delegated task' }),
+      messageId: 'om_legacy_bot_unauthorized_reply',
+      rootId,
+      threadId: 'omt_legacy_bot_unauthorized',
+      chatId,
+      chatType: 'p2p',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockGetMessageDetail).not.toHaveBeenCalled();
+    expect(mockRecordP2pForceTopicRoot).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+
+  it('keeps an old thread-mode session flat after switching the DM to chat mode', async () => {
+    const chatId = 'oc_dm_old_thread_mode';
+    const rootId = 'om_old_thread_mode_root';
+    handlers.isSessionOwner.mockImplementation((anchor: string, appId: string) => (
+      appId === MY_APP_ID && (anchor === chatId || anchor === rootId)
+    ));
+    mockGetMessageDetail.mockResolvedValueOnce({
+      items: [{
+        chat_id: chatId,
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: 'ordinary old thread seed' }) },
+        mentions: [],
+      }],
+    });
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'must join the flat DM after mode switch' }),
+      messageId: 'om_old_thread_mode_reply',
+      rootId,
+      threadId: 'omt_old_thread_mode',
+      chatId,
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockRecordP2pForceTopicRoot).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'chat',
+      anchor: chatId,
+      replyRootId: rootId,
+    }));
+  });
+
+  it('does not record a rejected DM /t as a topic root', async () => {
+    const event = makeUserMessageEvent({
+      senderOpenId: 'ou_not_allowed',
+      content: JSON.stringify({ text: '/t should not reserve a root' }),
+      messageId: 'om_rejected_topic_root',
+      chatId: 'oc_dm_rejected_topic',
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockRecordP2pForceTopicRoot).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+
+  it('does not record a DM /t blocked by beforeSessionTurn', async () => {
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '/t blocked by hook' }),
+      messageId: 'om_hook_blocked_topic_root',
+      chatId: 'oc_dm_hook_blocked_topic',
+      chatType: 'p2p',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+    handlers.beforeSessionTurn = vi.fn(async () => ({ block: true }));
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockRecordP2pForceTopicRoot).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+
+  it('does not capture a DM topic owned only under another Lark app', async () => {
+    const chatId = 'oc_dm_cross_app';
+    const rootId = 'om_cross_app_topic_root';
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'reply to another app topic' }),
+      messageId: 'om_cross_app_topic_reply',
+      rootId,
+      threadId: 'omt_cross_app_dm_topic',
+      chatId,
+      chatType: 'p2p',
+    });
+    handlers.isSessionOwner.mockImplementation((anchor: string, appId: string) => (
+      (anchor === rootId && appId === OTHER_BOT_APP_ID)
+      || (anchor === chatId && appId === MY_APP_ID)
+    ));
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockIsP2pForceTopicRoot).toHaveBeenCalledWith(MY_APP_ID, rootId, chatId);
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'chat',
+      anchor: chatId,
+      replyRootId: rootId,
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it.each(['thread', 'group'] as const)('does not consult /t provenance in explicit p2pMode=%s', async p2pMode => {
+    setupBotState({ p2pMode, allowedUsers: [USER_OPEN_ID] });
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'explicit mode reply' }),
+      messageId: `om_${p2pMode}_reply`,
+      rootId: `om_${p2pMode}_root`,
+      threadId: `omt_${p2pMode}_topic`,
+      chatId: `oc_dm_${p2pMode}`,
+      chatType: 'p2p',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockIsP2pForceTopicRoot).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: `om_${p2pMode}_root`,
+    }));
   });
 });
 

--- a/test/p2p-force-topic-store.test.ts
+++ b/test/p2p-force-topic-store.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { config } from '../src/config.js';
+import {
+  __resetP2pForceTopicRootsForTest,
+  isP2pForceTopicRoot,
+  recordP2pForceTopicRoot,
+} from '../src/services/p2p-force-topic-store.js';
+
+describe('p2p-force-topic-store', () => {
+  let dataDir: string;
+  let previousDataDir: string;
+
+  beforeEach(() => {
+    previousDataDir = config.session.dataDir;
+    dataDir = mkdtempSync(join(tmpdir(), 'botmux-p2p-force-topic-'));
+    config.session.dataDir = dataDir;
+    __resetP2pForceTopicRootsForTest();
+  });
+
+  afterEach(() => {
+    config.session.dataDir = previousDataDir;
+    __resetP2pForceTopicRootsForTest();
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('persists an app-and-chat-scoped /t root across cache resets', () => {
+    recordP2pForceTopicRoot('app-a', 'om-root', 'oc-chat');
+
+    expect(isP2pForceTopicRoot('app-a', 'om-root', 'oc-chat')).toBe(true);
+    expect(isP2pForceTopicRoot('app-a', 'om-root', 'oc-other')).toBe(false);
+    expect(isP2pForceTopicRoot('app-b', 'om-root', 'oc-chat')).toBe(false);
+
+    __resetP2pForceTopicRootsForTest();
+    expect(isP2pForceTopicRoot('app-a', 'om-root', 'oc-chat')).toBe(true);
+  });
+
+  it('fails open for routing when persistence is unavailable but keeps the in-memory marker', () => {
+    vi.spyOn(JSON, 'stringify').mockImplementationOnce(() => { throw new Error('disk unavailable'); });
+
+    recordP2pForceTopicRoot('app-a', 'om-memory-root', 'oc-chat');
+
+    expect(isP2pForceTopicRoot('app-a', 'om-memory-root', 'oc-chat')).toBe(true);
+  });
+
+  it('ignores malformed persisted data', () => {
+    const file = join(dataDir, 'p2p-force-topic-roots', 'app-a.json');
+    mkdirSync(join(dataDir, 'p2p-force-topic-roots'), { recursive: true });
+    writeFileSync(file, '{not-json', 'utf-8');
+
+    expect(isP2pForceTopicRoot('app-a', 'om-invalid', 'oc-chat')).toBe(false);
+    expect(existsSync(file)).toBe(true);
+  });
+
+  it('refreshes an existing root before evicting the least-recently-recorded entry', () => {
+    const dir = join(dataDir, 'p2p-force-topic-roots');
+    const file = join(dir, 'app-a.json');
+    mkdirSync(dir, { recursive: true });
+    const initial = Object.fromEntries(Array.from({ length: 10_000 }, (_, i) => [
+      `om-root-${i}`,
+      { chatId: 'oc-chat', createdAt: i },
+    ]));
+    writeFileSync(file, JSON.stringify(initial), 'utf-8');
+
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(20_000)
+      .mockReturnValueOnce(20_001);
+    recordP2pForceTopicRoot('app-a', 'om-root-0', 'oc-chat');
+    recordP2pForceTopicRoot('app-a', 'om-root-new', 'oc-chat');
+
+    __resetP2pForceTopicRootsForTest();
+    expect(isP2pForceTopicRoot('app-a', 'om-root-0', 'oc-chat')).toBe(true);
+    expect(isP2pForceTopicRoot('app-a', 'om-root-1', 'oc-chat')).toBe(false);
+    expect(isP2pForceTopicRoot('app-a', 'om-root-new', 'oc-chat')).toBe(true);
+  });
+});


### PR DESCRIPTION
## 问题

默认 `p2pMode=chat` 下，`/t` 会正确创建独立的 thread-scope Session，但该话题中的后续回复会先被 P2P chat-mode 路由折叠到 `chatId`，从而在旧的私聊 chat-scope CLI 上下文中执行。可见回复仍会挂到正确话题，因此执行上下文错位不易察觉。

本 PR 的原始出发点是：群聊默认模式下，`/t` 创建的 thread 会使用独立 Session；私聊中同一个 `/t` 操作却只在首条消息建出 thread，后续消息又回到 DM 的共享 Session。这种同一显式命令在不同聊天形态下的差异容易让用户困惑。

## 已确认的产品语义与能力缺口

当前实现、回归测试以及 [PR #631](https://github.com/deepcoldy/botmux/pull/631) 共同确认：**私聊默认 `p2pMode=chat` 时，普通 `Reply in thread` 仍复用原 chat-scope Session，是明确设计而非偶发现象。**

其产品意图是：

- 私聊默认是一段连续对话，以 `chatId` 为唯一 Session 锚点，普通追问不因 UI 回复方式而丢失上下文；
- 飞书的“回复某条消息 / Reply in thread”既可能只是整理展示，也可能是客户端产生 thread-shaped 字段，不能自动解释成“启动新的 CLI 上下文”；
- 避免误点回复、旧 thread 或 thread → chat 模式切换意外分裂出多个 Session；
- 可见回复仍可落在原 thread 内，但展示落点与底层 Session 归属是两层机制。

同时，开发侧历史结论也指出：**在默认连续 DM 中，用户想偶尔用一次显式 `/t` 获得可持续的独立 thread Session，目前没有形成稳定契约，是合理的产品能力缺口。** 本 PR 正在补的是这个缺口，建议的优先级是：

`显式 /t 建立的 thread 绑定 > p2pMode=chat 默认折叠`

现有替代方案是在私聊执行 `/reply-mode topic`（即 `p2pMode=thread`），但这是该 bot 的全局私聊模式，会影响该 bot 的所有 1:1 DM，不等价于单次 `/t` 的局部 escape hatch。裸 `/t` 仍按既有设计只物化话题/选仓入口，等话题内首个真实任务或 `/repo` 再创建 Session。

## 当前产品形态

以下描述针对当前默认配置：

| 场景 | Session 语义 |
|---|---|
| 普通群中的 `/t` thread | 一个 thread 对应一个独立 Session |
| 普通群中用户原生“在话题中回复”创建的 thread | 默认 `chat-topic` 下，一个原生 topic 对应一个独立 Session |
| 私聊中的普通回复 / `Reply in thread` | 默认 `p2pMode=chat` 下复用整个 DM 的 chat-scope Session（明确设计） |
| 私聊中的 `/t` thread（本 PR 修复后） | 一个 `/t` root 对应一个独立 Session |

普通群还可通过 `/reply-mode chat|chat-topic|topic|new-topic` 改变上述行为；表格描述的是默认 `chat-topic`。

## 需要作者本人确认的产品决策

> **请自动化 / agent reviewer 不要自行替作者收敛这一选择；请明确 involve PR 作者本人确认后再决定是否合入或扩大实现范围。**

本 PR 当前选择“保留普通 DM thread 的连续会话语义，同时让显式 `/t` 成为局部独立 Session escape hatch”。这与上述既有产品意图兼容，但也形成一个用户可感知的边界：

- `/t` 创建的私聊 topic → 独立 Session；
- 普通 `Reply in thread` → 仍复用 DM Session。

开发侧判断认为这个区分是合理的：前者是显式的新上下文命令，后者主要是展示/回复行为。但它仍是一个需要作者本人确认的产品选择，因为飞书 UI 中两者最终都呈现为 thread，用户也可能预期“只要进入 topic 就隔离”。作者需要确认：

1. **接受本 PR 的局部 escape hatch 语义（当前实现）**：`p2pMode=chat` 保持整个 DM 连续，只有显式 `/t` 强制创建并持续绑定独立 Session。兼容性最好，也直接修复原始缺口。
2. **让所有私聊原生 topic 都独立**：把真正的飞书原生 topic 与 `/t` topic 都视为上下文边界，更接近普通群默认体验；但这会改变已确认的 `Reply in thread` 复用设计，需要可靠区分原生 topic 与引用/快捷回复并做更广回归。
3. **扩展 P2P 配置模型**：让“连续 DM”“原生 topic 隔离”“每条顶层消息独立”等行为由更明确的模式控制，而不是在 `/t` 上做单一特判；产品和迁移范围最大。

当前提交实现选项 1；是否接受这一显式命令与 UI thread 的差异，请由作者本人定案。

## 根因与历史证据

- [`fb58b0c3`](https://github.com/deepcoldy/botmux/commit/fb58b0c3482e58a0195e7e97f4ae74730719bc07) 引入 P2P `thread|chat` 模式，并明确要求 chat 分支先于 `root_id + thread_id` 判断，使 thread-shaped DM 回复仍折叠到一个连续会话。
- [PR #631](https://github.com/deepcoldy/botmux/pull/631) / [`e695d417`](https://github.com/deepcoldy/botmux/commit/e695d417b5435b7a6d3c7c869483b58f1a86a66c) 将私聊默认值从 `thread` 改为 `chat`（“整段 DM 共用一个连续会话”），同时将普通群默认改为 `chat-topic`（群内原生 topic 各自独立），并用回归测试锁定 DM thread reply 仍进入同一个 chat Session。
- [`13920429`](https://github.com/deepcoldy/botmux/commit/13920429f43408e8ba0a4e8a346bfcd720e667d3) 将 `/t` override 前移，使已有 chat owner 时仍可新开 thread，说明 `/t` 本身具有显式打破默认折叠的意图。
- [`a32acbcf`](https://github.com/deepcoldy/botmux/commit/a32acbcf8658dbf60e07becbe70e684f55a226e1) 所在的串行化设计意味着 raw chat ingress lane 在 canonical handler 入队后即可释放，不能等异步 Session 注册完成后再识别 `/t` root。
- [`574603c9`](https://github.com/deepcoldy/botmux/commit/574603c9d691470e29a646ce8cac5f56f7e5c00b) 保留 bare `/t` 只创建可见话题、暂不创建 Session 的行为，因此 active ownership 不能作为 `/t` 来源的唯一事实。

由此可知：普通 DM thread 折叠是明确设计；但 `/t` 是显式上下文命令，不能仅依赖瞬时 active owner 来判断其后续绑定。

## 当前实现

- 新增有界、持久化的 `/t` root provenance，以 `larkAppId + chatId + full rootId` 隔离。
- 在权限检查和 `beforeSessionTurn` 通过后、异步 `/t` Session 注册前记录 provenance，避免紧随 `/t` 的回复竞态。
- 默认/chat P2P 仅对已确认 provenance 的 `root_id + thread_id` 消息保留 thread scope；普通 DM thread 继续保持现有 chat-scope 折叠行为。
- bot sender 路径使用相同判定。
- 对升级前已存在的 `/t` root，首次遇到时读取不可变根消息，确认 `/t` 或 `/topic` 后按需补写 marker；读取失败保持原有 flat 行为并允许后续重试。
- marker 按 app 最多保留 10,000 条；落盘失败时保留进程内判定，坏文件安全回退。

## 回归覆盖

- `/t` 后续消息继续进入独立 thread Session；
- `/t` Session 注册被阻塞时的 back-to-back follow-up；
- bare `/t` 尚未创建 Session 时的首个任务；
- 普通未拥有 DM thread 与 thread → chat 模式切换；
- 升级前旧 `/t` root 的按需迁移；
- 未授权 `/t` 与 `beforeSessionTurn` 阻断不留下 marker；
- 跨 app/chat 隔离；
- 显式 `p2pMode=thread/group` 不依赖 provenance；
- provenance 持久化、缓存重载、写失败降级和坏文件。

## 验证

- `bun run test -- test/event-dispatcher.test.ts test/p2p-force-topic-store.test.ts test/message-quota-enforcement.test.ts test/daemon-rename-route.test.ts`：453 passed
- `bun run build`：通过（TypeScript、dashboard bundle 与产物审计均通过）
- `git diff --check`：通过
- 当前提交 GitHub CI：`build`、`bun-test`、`bun-binary`、`bun-binary-musl` 全部通过