### PR TITLE
feat(voice): add MiniMax TTS engine

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -3267,15 +3267,14 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
     const commandTriggers = normalizeCommandTriggers(entry.commandTriggers);
     const vcMeetingAgent = normalizeVcMeetingAgentConfig(entry.vcMeetingAgent);
 
-    // voice：per-bot 语音引擎覆盖。结构化保留（engine ∈ sami|openai，sami/openai
-    // 为对象，speaker/rate 透传，asr 为对象）；非对象或 engine 非法 → undefined。
-    // 深度校验（凭证是否可用 / asr 是否 enabled）在 resolveVoiceConfig /
-    // resolveAsrConfig 做，这里只挡明显垃圾。
+    // Preserve a structured per-bot voice override. Deep credential and ASR
+    // validation remains in the voice service; this parser only rejects an
+    // unknown engine and obviously malformed nested values.
     let voice: VoiceConfig | undefined;
     const rawVoice = entry.voice;
     if (rawVoice && typeof rawVoice === 'object' && !Array.isArray(rawVoice)) {
       const eng = (rawVoice as any).engine;
-      if (eng === undefined || eng === 'sami' || eng === 'openai') {
+      if (eng === undefined || eng === 'sami' || eng === 'openai' || eng === 'minimax') {
         const v: VoiceConfig = {};
         if (eng) v.engine = eng;
         if (typeof (rawVoice as any).speaker === 'string') v.speaker = (rawVoice as any).speaker;
@@ -3284,6 +3283,12 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
         if (s && typeof s === 'object') v.sami = { accessKey: s.accessKey, secretKey: s.secretKey, appkey: s.appkey, tokenUrl: s.tokenUrl, wsUrl: s.wsUrl };
         const o = (rawVoice as any).openai;
         if (o && typeof o === 'object') v.openai = { baseUrl: o.baseUrl, apiKey: o.apiKey, model: o.model };
+        const m = (rawVoice as any).minimax;
+        if (m && typeof m === 'object') v.minimax = {
+          apiKey: typeof m.apiKey === 'string' ? m.apiKey : undefined,
+          model: typeof m.model === 'string' ? m.model : undefined,
+          region: m.region === 'cn' ? 'cn' : m.region === 'global' ? 'global' : undefined,
+        };
         const a = (rawVoice as any).asr;
         if (a && typeof a === 'object') v.asr = {
           enabled: a.enabled === true,
@@ -3293,7 +3298,7 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
           ...(typeof a.timeoutMs === 'number' ? { timeoutMs: a.timeoutMs } : {}),
           ...(typeof a.language === 'string' ? { language: a.language } : {}),
         };
-        if (v.engine || v.sami || v.openai || v.speaker || v.asr) voice = v;
+        if (v.engine || v.sami || v.openai || v.minimax || v.speaker || v.asr) voice = v;
       }
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12942,7 +12942,12 @@ if (process.env.BOTMUX_WORKFLOW === '1') {
 async function cmdVoiceSetup(args: string[]): Promise<void> {
   const sub = (args[0] ?? '').toLowerCase();
   const { readGlobalConfig, mergeGlobalConfig } = await import('./global-config.js');
-  const { DEFAULT_SAMI_SPEAKER, DEFAULT_OPENAI_SPEAKER } = await import('./services/voice/index.js');
+  const {
+    DEFAULT_SAMI_SPEAKER,
+    DEFAULT_OPENAI_SPEAKER,
+    DEFAULT_MINIMAX_SPEAKER,
+    DEFAULT_MINIMAX_TTS_MODEL,
+  } = await import('./services/voice/index.js');
   const mask = (s?: string) => (s ? `${s.slice(0, 4)}***` : '(未设)');
 
   if (sub === 'status') {
@@ -12954,6 +12959,7 @@ async function cmdVoiceSetup(args: string[]): Promise<void> {
     if (typeof v.rate === 'number') console.log(`  语速: ${v.rate}`);
     if (v.sami) console.log(`  SAMI: accessKey=${mask(v.sami.accessKey)} secretKey=${mask(v.sami.secretKey)} appkey=${v.sami.appkey ?? '(未设)'}${v.sami.tokenUrl ? ` tokenUrl=${v.sami.tokenUrl}` : ''}`);
     if (v.openai) console.log(`  OpenAI: baseUrl=${v.openai.baseUrl ?? '(未设)'} model=${v.openai.model ?? '(未设)'} apiKey=${mask(v.openai.apiKey)}`);
+    if (v.minimax) console.log(`  MiniMax: region=${v.minimax.region ?? 'global'} model=${v.minimax.model ?? DEFAULT_MINIMAX_TTS_MODEL} apiKey=${mask(v.minimax.apiKey)}`);
     return;
   }
   if (sub === 'disable' || sub === 'off') {
@@ -13018,9 +13024,20 @@ async function cmdVoiceSetup(args: string[]): Promise<void> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
     console.log('🔊 配置语音总结（高级功能）。写入全局 ~/.botmux/config.json，重启后生效。\n');
+    console.log('Additional engine: [3] MiniMax');
     const eng = (await ask(rl, '选择 TTS 引擎  [1] SAMI（需 AK/SK/appkey）  [2] OpenAI 兼容（自带 baseUrl/key）: ')).trim();
     const voice: Record<string, any> = {};
-    if (eng === '2' || /openai/i.test(eng)) {
+    if (eng === '3' || /minimax/i.test(eng)) {
+      voice.engine = 'minimax';
+      const apiKey = (await ask(rl, 'MiniMax API key: ')).trim();
+      if (!apiKey) { console.error('MiniMax API key is required; no configuration was written.'); return; }
+      const regionAnswer = (await ask(rl, 'Region [1] Global [2] China (default 1): ')).trim();
+      const region = regionAnswer === '2' || /^(cn|china)$/i.test(regionAnswer) ? 'cn' : 'global';
+      const model = (await ask(rl, `Model (default ${DEFAULT_MINIMAX_TTS_MODEL}): `)).trim() || DEFAULT_MINIMAX_TTS_MODEL;
+      voice.minimax = { apiKey, region, model };
+      const sp = (await ask(rl, `Voice id (default ${DEFAULT_MINIMAX_SPEAKER}): `)).trim();
+      if (sp) voice.speaker = sp;
+    } else if (eng === '2' || /openai/i.test(eng)) {
       voice.engine = 'openai';
       const baseUrl = (await ask(rl, 'baseUrl（如 https://api.openai.com/v1，自托管如 http://127.0.0.1:8880/v1）: ')).trim();
       const apiKey = (await ask(rl, 'apiKey（无则留空）: ')).trim();

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -315,9 +315,9 @@ export interface DashboardGlobalConfig {
 function readVoice(raw: unknown): VoiceConfig | undefined {
   if (!raw || typeof raw !== 'object') return undefined;
   const v = raw as Record<string, unknown>;
-  const engineOk = v.engine === 'sami' || v.engine === 'openai' || v.engine === undefined;
+  const engineOk = v.engine === 'sami' || v.engine === 'openai' || v.engine === 'minimax' || v.engine === undefined;
   if (!engineOk) return undefined;
-  if (!v.sami && !v.openai && !v.engine && !v.asr) return undefined;
+  if (!v.sami && !v.openai && !v.minimax && !v.engine && !v.asr) return undefined;
   return v as VoiceConfig;
 }
 

--- a/src/services/voice/index.ts
+++ b/src/services/voice/index.ts
@@ -4,13 +4,17 @@
  * (gates the "🔊 语音总结" button), and synthesize text → a ready-to-send
  * ogg/opus file.
  *
- * Engine is pluggable behind a tiny contract (text → PCM): `sami` (in-tree
- * JSON-over-WS, internal) and `openai` (OpenAI-compatible HTTP, open-source
- * default). Neither pulls a heavyweight dependency into the package.
+ * Engines are pluggable behind a tiny text-to-PCM contract and do not add
+ * heavyweight dependencies to the package.
  */
 import { encodePcmToOpus, toSpoken, type OpusResult, type Pcm } from './audio.js';
 import { samiSynthesizePcm, type SamiCreds, type VoiceProviderEffectOptions } from './sami.js';
 import { openaiSynthesizePcm, type OpenAITtsConfig } from './openai.js';
+import {
+  minimaxSynthesizePcm,
+  DEFAULT_MINIMAX_SPEAKER,
+  type MiniMaxTtsConfig,
+} from './minimax.js';
 import type { ResolvedAsrConfig } from './asr.js';
 import { readGlobalConfig } from '../../global-config.js';
 import { loadBotConfigs } from '../../bot-registry.js';
@@ -18,6 +22,12 @@ import type { VoiceConfig, VoiceEngine, VoiceAsrConfig } from './types.js';
 
 export type { VoiceConfig, VoiceEngine, VoiceAsrConfig } from './types.js';
 export type { ResolvedAsrConfig } from './asr.js';
+export {
+  DEFAULT_MINIMAX_SPEAKER,
+  DEFAULT_MINIMAX_TTS_MODEL,
+  MINIMAX_CN_TTS_ENDPOINT,
+  MINIMAX_GLOBAL_TTS_ENDPOINT,
+} from './minimax.js';
 
 /** Default SAMI voice — 灿灿 (bigtts), the product-chosen default. */
 export const DEFAULT_SAMI_SPEAKER = 'zh_female_cancan_mars_bigtts';
@@ -31,19 +41,22 @@ function mergeVoice(base: VoiceConfig | undefined, over: VoiceConfig | undefined
     ...over,
     sami: { ...base?.sami, ...over?.sami },
     openai: { ...base?.openai, ...over?.openai },
+    minimax: { ...base?.minimax, ...over?.minimax },
   };
 }
 
 function hasUsableCreds(v: VoiceConfig | undefined): VoiceConfig | null {
   if (!v) return null;
-  const engine = v.engine ?? (v.sami ? 'sami' : v.openai ? 'openai' : undefined);
+  const engine = v.engine ?? (v.sami ? 'sami' : v.openai ? 'openai' : v.minimax ? 'minimax' : undefined);
   if (!engine) return null;
   if (engine === 'sami') {
     const { accessKey, secretKey, appkey } = v.sami ?? {};
     if (!accessKey || !secretKey || !appkey) return null;
-  } else {
+  } else if (engine === 'openai') {
     const { baseUrl, model } = v.openai ?? {};
     if (!baseUrl || !model) return null;
+  } else if (!v.minimax?.apiKey) {
+    return null;
   }
   return { ...v, engine };
 }
@@ -123,7 +136,9 @@ export function isAsrConfigured(larkAppId?: string): boolean {
 
 function effectiveSpeaker(v: VoiceConfig): string {
   if (v.speaker) return v.speaker;
-  return v.engine === 'openai' ? DEFAULT_OPENAI_SPEAKER : DEFAULT_SAMI_SPEAKER;
+  if (v.engine === 'openai') return DEFAULT_OPENAI_SPEAKER;
+  if (v.engine === 'minimax') return DEFAULT_MINIMAX_SPEAKER;
+  return DEFAULT_SAMI_SPEAKER;
 }
 
 /**
@@ -136,14 +151,18 @@ export async function synthesizeVoicePcmForMessage(
   effects: VoiceProviderEffectOptions = {},
 ): Promise<Pcm> {
   const cfg = resolveVoiceConfig(larkAppId);
-  if (!cfg) throw new Error('未配置语音引擎：在 ~/.botmux/config.json 的 voice 块或 bots.json 里配置 SAMI / OpenAI 兼容引擎。');
+  if (!cfg) throw new Error('No usable voice engine is configured in config.json or bots.json.');
   const spoken = toSpoken(text);
   if (!spoken) throw new Error('精简后没有可朗读的内容');
   const speaker = effectiveSpeaker(cfg);
 
-  return cfg.engine === 'openai'
-    ? await openaiSynthesizePcm(cfg.openai as OpenAITtsConfig, spoken, { speaker, rate: cfg.rate }, effects)
-    : await samiSynthesizePcm(cfg.sami as SamiCreds, spoken, { speaker, rate: cfg.rate }, effects);
+  if (cfg.engine === 'openai') {
+    return await openaiSynthesizePcm(cfg.openai as OpenAITtsConfig, spoken, { speaker, rate: cfg.rate }, effects);
+  }
+  if (cfg.engine === 'minimax') {
+    return await minimaxSynthesizePcm(cfg.minimax as MiniMaxTtsConfig, spoken, { speaker, rate: cfg.rate }, effects);
+  }
+  return await samiSynthesizePcm(cfg.sami as SamiCreds, spoken, { speaker, rate: cfg.rate }, effects);
 }
 
 /**

--- a/src/services/voice/minimax.ts
+++ b/src/services/voice/minimax.ts
@@ -1,0 +1,133 @@
+/**
+ * MiniMax T2A v2 adapter.
+ *
+ * The synchronous API returns JSON with hex-encoded audio. Requesting mono PCM
+ * keeps the engine boundary identical to the rest of the voice pipeline.
+ */
+import type { Pcm } from './audio.js';
+import type { VoiceProviderEffectOptions } from './sami.js';
+
+export const MINIMAX_GLOBAL_TTS_ENDPOINT = 'https://api.minimax.io/v1/t2a_v2';
+export const MINIMAX_CN_TTS_ENDPOINT = 'https://api.minimaxi.com/v1/t2a_v2';
+export const DEFAULT_MINIMAX_TTS_MODEL = 'speech-2.8-hd';
+export const DEFAULT_MINIMAX_SPEAKER = 'female-shaonv';
+
+const MINIMAX_PCM_SAMPLE_RATE = 24000;
+const MINIMAX_PCM_CHANNELS = 1;
+
+export interface MiniMaxTtsConfig {
+  apiKey: string;
+  model?: string;
+  region?: 'global' | 'cn';
+}
+
+export interface MiniMaxSynthOpts {
+  speaker: string;
+  rate?: number;
+  timeoutMs?: number;
+}
+
+interface MiniMaxTtsResponse {
+  data?: {
+    audio?: unknown;
+    status?: unknown;
+  } | null;
+  extra_info?: {
+    audio_sample_rate?: unknown;
+    audio_channel?: unknown;
+    audio_format?: unknown;
+  };
+  base_resp?: {
+    status_code?: unknown;
+    status_msg?: unknown;
+  };
+}
+
+function endpointForRegion(region: MiniMaxTtsConfig['region']): string {
+  return region === 'cn' ? MINIMAX_CN_TTS_ENDPOINT : MINIMAX_GLOBAL_TTS_ENDPOINT;
+}
+
+function numericMetadata(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export async function minimaxSynthesizePcm(
+  cfg: MiniMaxTtsConfig,
+  text: string,
+  opts: MiniMaxSynthOpts,
+  effects: VoiceProviderEffectOptions = {},
+): Promise<Pcm> {
+  const clean = text.trim();
+  if (!clean) throw new Error('No text was provided for speech synthesis.');
+  if (!cfg.apiKey) throw new Error('MiniMax TTS requires an API key.');
+
+  const body = {
+    model: cfg.model?.trim() || DEFAULT_MINIMAX_TTS_MODEL,
+    text: clean,
+    stream: false,
+    output_format: 'hex',
+    voice_setting: {
+      voice_id: opts.speaker,
+      speed: Math.max(0.5, Math.min(2, opts.rate ?? 1)),
+      vol: 1,
+      pitch: 0,
+    },
+    audio_setting: {
+      sample_rate: MINIMAX_PCM_SAMPLE_RATE,
+      format: 'pcm',
+      channel: MINIMAX_PCM_CHANNELS,
+    },
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 60000);
+  try {
+    await effects.beforeProviderEffect?.();
+    const res = await fetch(endpointForRegion(cfg.region), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${cfg.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`MiniMax TTS HTTP ${res.status}: ${detail.slice(0, 200)}`);
+    }
+
+    const payload = await res.json() as MiniMaxTtsResponse;
+    const statusCode = payload.base_resp?.status_code;
+    if (statusCode !== 0) {
+      const statusMessage = typeof payload.base_resp?.status_msg === 'string'
+        ? payload.base_resp.status_msg
+        : 'unknown error';
+      throw new Error(`MiniMax TTS error ${String(statusCode)}: ${statusMessage}`);
+    }
+    if (payload.data?.status !== 2) {
+      throw new Error(`MiniMax TTS returned incomplete audio status ${String(payload.data?.status)}.`);
+    }
+    if (payload.extra_info?.audio_format !== undefined && payload.extra_info.audio_format !== 'pcm') {
+      throw new Error(`MiniMax TTS returned unexpected audio format ${String(payload.extra_info.audio_format)}.`);
+    }
+
+    const audio = payload.data?.audio;
+    if (typeof audio !== 'string' || audio.length === 0 || audio.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(audio)) {
+      throw new Error('MiniMax TTS returned invalid hex audio.');
+    }
+    const data = Buffer.from(audio, 'hex');
+    if (data.length === 0) throw new Error('MiniMax TTS returned empty audio.');
+
+    return {
+      data,
+      sampleRate: numericMetadata(payload.extra_info?.audio_sample_rate, MINIMAX_PCM_SAMPLE_RATE),
+      channels: numericMetadata(payload.extra_info?.audio_channel, MINIMAX_PCM_CHANNELS),
+    };
+  } catch (error: any) {
+    if (error?.name === 'AbortError') throw new Error('MiniMax TTS synthesis timed out.');
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/services/voice/types.ts
+++ b/src/services/voice/types.ts
@@ -3,7 +3,7 @@
  * bot-registry.ts can import them (type-only) without a runtime import cycle
  * with the engine adapters in ./index.ts.
  */
-export type VoiceEngine = 'sami' | 'openai';
+export type VoiceEngine = 'sami' | 'openai' | 'minimax';
 
 export interface VoiceSamiCreds {
   accessKey?: string;
@@ -19,6 +19,13 @@ export interface VoiceOpenAIConfig {
   baseUrl?: string;
   apiKey?: string;
   model?: string;
+}
+
+export interface VoiceMiniMaxConfig {
+  apiKey?: string;
+  model?: string;
+  /** Selects the matching official API endpoint. Defaults to `global`. */
+  region?: 'global' | 'cn';
 }
 
 /** ASR (语音转文字) 配置，走 OpenAI 兼容 `POST {baseUrl}/audio/transcriptions`
@@ -39,12 +46,13 @@ export interface VoiceAsrConfig {
  *  bots.json. A per-bot block is merged over the global one. */
 export interface VoiceConfig {
   engine?: VoiceEngine;
-  /** Default speaker/voice id (SAMI speaker or OpenAI `voice`). */
+  /** Default speaker or voice id for the selected engine. */
   speaker?: string;
   /** Speech rate multiplier (1.0 = normal). */
   rate?: number;
   sami?: VoiceSamiCreds;
   openai?: VoiceOpenAIConfig;
+  minimax?: VoiceMiniMaxConfig;
   /** 语音消息转写（ASR）。与 TTS 字段相互独立：可只配 ASR 不配 TTS。 */
   asr?: VoiceAsrConfig;
 }

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -66,6 +66,27 @@ function makeCfg(overrides: Record<string, unknown> = {}) {
   };
 }
 
+describe('voice configuration', () => {
+  it('preserves a MiniMax per-bot override', async () => {
+    const mod = await freshImport();
+    const [config] = mod.parseBotConfigsFromText(JSON.stringify([
+      makeCfg({
+        voice: {
+          engine: 'minimax',
+          speaker: 'voice-id',
+          minimax: { apiKey: 'key', model: 'speech-2.8-hd', region: 'cn' },
+        },
+      }),
+    ]));
+
+    expect(config.voice).toEqual({
+      engine: 'minimax',
+      speaker: 'voice-id',
+      minimax: { apiKey: 'key', model: 'speech-2.8-hd', region: 'cn' },
+    });
+  });
+});
+
 // ─── registerBot ──────────────────────────────────────────────────────────
 
 describe('registerBot', () => {

--- a/test/global-config.test.ts
+++ b/test/global-config.test.ts
@@ -68,6 +68,23 @@ describe('global dashboard config', () => {
     expect(readGlobalConfig().dashboard).toEqual({ chatBotDiscovery: false });
   });
 
+  it('reads a MiniMax voice engine configuration', () => {
+    writeFileSync(globalConfigPath(), JSON.stringify({
+      voice: {
+        engine: 'minimax',
+        speaker: 'voice-id',
+        minimax: { apiKey: 'key', model: 'speech-2.8-hd', region: 'cn' },
+      },
+    }));
+    invalidateGlobalConfigCache();
+
+    expect(readGlobalConfig().voice).toEqual({
+      engine: 'minimax',
+      speaker: 'voice-id',
+      minimax: { apiKey: 'key', model: 'speech-2.8-hd', region: 'cn' },
+    });
+  });
+
   it('reads dashboard.noVisibleOutputHint as a boolean (on)', () => {
     writeFileSync(globalConfigPath(), JSON.stringify({
       dashboard: { noVisibleOutputHint: true },

--- a/test/minimax-tts.test.ts
+++ b/test/minimax-tts.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MINIMAX_SPEAKER,
+  DEFAULT_MINIMAX_TTS_MODEL,
+  MINIMAX_CN_TTS_ENDPOINT,
+  MINIMAX_GLOBAL_TTS_ENDPOINT,
+  minimaxSynthesizePcm,
+} from '../src/services/voice/minimax.js';
+
+function successResponse(audio = '00017fff8000'): Response {
+  return new Response(JSON.stringify({
+    data: { audio, status: 2 },
+    extra_info: { audio_sample_rate: 24000, audio_channel: 1, audio_format: 'pcm' },
+    base_resp: { status_code: 0, status_msg: 'success' },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+describe('MiniMax TTS adapter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sends the T2A v2 PCM request and decodes hex audio', async () => {
+    const order: string[] = [];
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+      order.push('fetch');
+      return successResponse();
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await minimaxSynthesizePcm(
+      { apiKey: 'test-key' },
+      ' hello ',
+      { speaker: DEFAULT_MINIMAX_SPEAKER, rate: 1.25 },
+      { beforeProviderEffect: () => { order.push('fence'); } },
+    );
+
+    expect(order).toEqual(['fence', 'fetch']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(MINIMAX_GLOBAL_TTS_ENDPOINT);
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toMatchObject({
+      Authorization: 'Bearer test-key',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      model: DEFAULT_MINIMAX_TTS_MODEL,
+      text: 'hello',
+      stream: false,
+      output_format: 'hex',
+      voice_setting: {
+        voice_id: DEFAULT_MINIMAX_SPEAKER,
+        speed: 1.25,
+        vol: 1,
+        pitch: 0,
+      },
+      audio_setting: {
+        sample_rate: 24000,
+        format: 'pcm',
+        channel: 1,
+      },
+    });
+    expect(result).toEqual({
+      data: Buffer.from('00017fff8000', 'hex'),
+      sampleRate: 24000,
+      channels: 1,
+    });
+  });
+
+  it('selects the China endpoint and forwards an explicit model', async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => successResponse('0102'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await minimaxSynthesizePcm(
+      { apiKey: 'test-key', region: 'cn', model: 'custom-speech-model' },
+      'hello',
+      { speaker: 'custom-voice' },
+    );
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(MINIMAX_CN_TTS_ENDPOINT);
+    expect(JSON.parse(String(init?.body))).toMatchObject({ model: 'custom-speech-model' });
+  });
+
+  it('rejects provider errors and malformed audio', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: null,
+      base_resp: { status_code: 1004, status_msg: 'invalid request' },
+    }), { status: 200 })));
+    await expect(minimaxSynthesizePcm(
+      { apiKey: 'test-key' },
+      'hello',
+      { speaker: DEFAULT_MINIMAX_SPEAKER },
+    )).rejects.toThrow('MiniMax TTS error 1004');
+
+    vi.stubGlobal('fetch', vi.fn(async () => successResponse('not-hex')));
+    await expect(minimaxSynthesizePcm(
+      { apiKey: 'test-key' },
+      'hello',
+      { speaker: DEFAULT_MINIMAX_SPEAKER },
+    )).rejects.toThrow('invalid hex audio');
+  });
+});

--- a/test/voice-config.test.ts
+++ b/test/voice-config.test.ts
@@ -24,6 +24,12 @@ describe('evaluateVoiceConfig — button gating', () => {
     expect(ok?.engine).toBe('openai');
   });
 
+  it('MiniMax needs an API key and accepts the built-in endpoint and model defaults', () => {
+    expect(evaluateVoiceConfig({ engine: 'minimax', minimax: {} }, undefined)).toBeNull();
+    const ok = evaluateVoiceConfig({ engine: 'minimax', minimax: { apiKey: 'key', region: 'cn' } }, undefined);
+    expect(ok).toMatchObject({ engine: 'minimax', minimax: { apiKey: 'key', region: 'cn' } });
+  });
+
   it('infers engine from creds when engine omitted', () => {
     const v = evaluateVoiceConfig({ sami: { accessKey: 'a', secretKey: 'b', appkey: 'c' } }, undefined);
     expect(v?.engine).toBe('sami');


### PR DESCRIPTION
Reason: Add native MiniMax T2A v2 support to the voice engine registry.

- add a synchronous T2A adapter with global and China endpoint selection, PCM requests, and hex audio decoding
- wire MiniMax into global and per-bot configuration, runtime dispatch, and interactive setup
- cover request construction, response validation, and configuration parsing

Checks:
- `bunx bun@1.4.0 run test -- test/minimax-tts.test.ts test/voice-config.test.ts test/global-config.test.ts test/bot-registry.test.ts`
- `bunx bun@1.4.0 run build`
