### PR TITLE
fix(web-terminal): Claude 只读 Web 终端恢复滚轮翻页

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -1175,6 +1175,11 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       : undefined,
     systemHints: [],
     altScreen: false,
+    // Claude Code (及 seed 同源 fork) 的 TUI 自管重绘整段 transcript，xterm/tmux
+    // 两边都无 scrollback；只读 Web 终端要把滚轮转成 SGR wheel 发回 CLI 才能翻页。
+    // 只读滚动走 worker 侧严格校验 + 限流的 `type:'scroll'` 通路（见 web-terminal-scroll.ts），
+    // 与 write 权限完全隔离，安全上与 opencode 一致。
+    readOnlyRemoteScroll: true,
     // Skills are injected per-session via --plugin-dir (see buildArgs), NOT
     // installed into the global ~/.claude/skills — so they never leak into the
     // user's standalone `claude`. pluginDir is consumed by ensurePluginSkills.

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -2380,6 +2380,14 @@ describe('altScreen property', () => {
     expect(createClaudeCodeAdapter('/bin/claude').altScreen).toBe(false);
   });
 
+  it('claude-code read-only viewers may forward wheel-only scroll', () => {
+    // Claude's TUI self-manages its transcript (no xterm/tmux scrollback), so the
+    // read-only web terminal can only page history by forwarding SGR wheel events
+    // back to the CLI. This opt-in gates that narrow, rate-limited `type:'scroll'`
+    // path (worker.ts / web-terminal-scroll.ts), mirroring opencode.
+    expect(createClaudeCodeAdapter('/bin/claude').readOnlyRemoteScroll).toBe(true);
+  });
+
   it('aiden does not use alt screen', () => {
     expect(createAidenAdapter('/bin/aiden').altScreen).toBe(false);
   });


### PR DESCRIPTION
## 背景

Claude Code 的只读 Web 终端无法上下滚动，滚不出历史。

## 根因

Claude Code（及 seed 同源 fork）的 TUI 跑在备用屏 + 鼠标上报，xterm/tmux 两边都无 scrollback，整段对话由 CLI 自管重绘。只读 Web 终端要看历史，必须把滚轮转成 SGR wheel 事件发回 CLI 让它自滚 transcript。

这条只读滚动通路的历史：

- #306（b629e32e）建立：服务端对未鉴权连接只放行滚轮序列、`_fwdScroll` 无 `hasToken` 门 → 只读也能滚。
- #470（fa9914f2）在收紧只读输入安全时整体关闭：`_fwdScroll` 加 `hasToken` 门、服务端 read-only input 一律丢弃 → Claude 只读终端从此滚不动。
- #871（3cae0522）以「`readOnlyRemoteScroll` 显式 opt-in + 独立 `type:'scroll'` 严格校验 + 限流」重建安全通路，但只给 opencode/opencode2 开了开关，Claude 一直没被补上。

## 改动

给 claude-code 适配器（`createClaudeFamilyAdapter`，覆盖 `claude-code`/`seed`）补上 `readOnlyRemoteScroll: true`，对齐 opencode，走 worker 侧严格校验 + 限流的 `type:'scroll'` 通路，与 write 权限完全隔离。

## 影响面

- 仅 Claude 家族（`claude-code` / `seed`）只读 Web 终端。
- opencode、tmux/zellij attach、可写终端路径均不受影响。
- 门禁链路（#871 已铺好）：`parseReadOnlyRemoteScrollPayload` 严格只认滚轮序列、`ReadOnlyRemoteScrollLimiter` 会话级限流、`backend.write` 只对经校验 wheel 放行。Claude 是「坐标无关」型 CLI，滚轮落在任意格子都能滚。

## 验证

```
vitest test/cli-adapters.test.ts
vitest test/web-terminal-scroll.test.ts
vitest test/web-terminal-scroll-rate-limit.test.ts
vitest test/web-terminal-touch-scroll.test.ts
```

合计 **444 tests passed**。