### PR TITLE
test(cli): 固化 chat-scope receipt 并补 send 诊断

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8345,6 +8345,13 @@ async function cmdSend(rest: string[]): Promise<void> {
     replyLayout = undefined;
   }
 
+  const sessionIdSource = sessionIdArg
+    ? 'arg'
+    : ancestorCtx?.sessionId
+      ? 'ancestor'
+      : process.env.BOTMUX_SESSION_ID
+        ? 'env'
+        : 'none';
   const sid = sessionIdArg ?? ancestorCtx?.sessionId ?? process.env.BOTMUX_SESSION_ID ?? null;
   if (!sid) {
     console.error('无法推断 session-id。请在 Lark 话题内的 CLI 会话中运行，或传 --session-id <id>。');
@@ -8378,7 +8385,23 @@ async function cmdSend(rest: string[]): Promise<void> {
     }
   }
 
-  if (!s) { console.error(`未找到 session ${sid}`); process.exit(1); }
+  if (!s) {
+    console.error(
+      '[botmux send diagnostic] session_lookup_miss'
+      + ` sessionId=${sid}`
+      + ` source=${sessionIdSource}`
+      + ` dataDir=${sendDataDir}`
+      + ` envSessionId=${process.env.BOTMUX_SESSION_ID ?? '-'}`
+      + ` envLarkAppId=${process.env.BOTMUX_LARK_APP_ID ?? '-'}`
+      + ` originSessionId=${originSessionId ?? '-'}`
+      + ` loadedSessions=${sessions.size}`
+      + ` relayDir=${relayDir ? 'present' : 'absent'}`
+      + ` readIsolation=${isolatedSendRequired ? 'required' : kernelReadIsolationDetected ? 'detected' : 'off'}`
+      + ` capability=${isolatedCapabilityCtx ? 'present' : 'absent'}`,
+    );
+    console.error(`未找到 session ${sid}`);
+    process.exit(1);
+  }
   if (!s.larkAppId) { console.error(`session ${sid} 缺少 larkAppId`); process.exit(1); }
   const replyStyle = resolveReplyStyle(resolveReplyStyleConfig(s.larkAppId));
   if (replyLayout && !replyStyle.layout) {

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -53,6 +53,46 @@ describe('cmdSend hook context wiring', () => {
     expect(cmdSend).toContain('发送失败: ${describeSendFailure(err)}');
   });
 
+  it('prints only whitelisted session lookup diagnostics before send exits missing-session', () => {
+    const cmdSendStart = cliSource.indexOf('async function cmdSend(');
+    const cmdDispatchStart = cliSource.indexOf('async function cmdDispatch(', cmdSendStart);
+    const cmdSend = cliSource.slice(cmdSendStart, cmdDispatchStart);
+
+    expect(cmdSend).toContain('[botmux send diagnostic] session_lookup_miss');
+    expect(cmdSend).toContain('source=${sessionIdSource}');
+    expect(cmdSend).toContain('dataDir=${sendDataDir}');
+    expect(cmdSend).toContain('envSessionId=${process.env.BOTMUX_SESSION_ID ??');
+    expect(cmdSend).toContain('envLarkAppId=${process.env.BOTMUX_LARK_APP_ID ??');
+    expect(cmdSend).toContain('originSessionId=${originSessionId ??');
+    expect(cmdSend).toContain('loadedSessions=${sessions.size}');
+    expect(cmdSend).toContain("relayDir=${relayDir ? 'present' : 'absent'}");
+    expect(cmdSend).toContain('readIsolation=${isolatedSendRequired ?');
+    expect(cmdSend).toContain("capability=${isolatedCapabilityCtx ? 'present' : 'absent'}");
+
+    const diagnosticStart = cmdSend.indexOf('session_lookup_miss');
+    expect(diagnosticStart).toBeGreaterThanOrEqual(0);
+    const missingSessionAt = cmdSend.indexOf('未找到 session', diagnosticStart);
+    expect(missingSessionAt).toBeGreaterThan(diagnosticStart);
+    const diagnosticBlock = cmdSend.slice(diagnosticStart, missingSessionAt);
+
+    expect([...diagnosticBlock.matchAll(/\$\{([^}]*)\}/g)].map(m => m[1].trim())).toEqual([
+      'sid',
+      'sessionIdSource',
+      'sendDataDir',
+      "process.env.BOTMUX_SESSION_ID ?? '-'",
+      "process.env.BOTMUX_LARK_APP_ID ?? '-'",
+      "originSessionId ?? '-'",
+      'sessions.size',
+      "relayDir ? 'present' : 'absent'",
+      "isolatedSendRequired ? 'required' : kernelReadIsolationDetected ? 'detected' : 'off'",
+      "isolatedCapabilityCtx ? 'present' : 'absent'",
+    ]);
+    expect([...diagnosticBlock.matchAll(/process\.env(\.[A-Za-z0-9_]+)?/g)].map(m => m[0])).toEqual([
+      'process.env.BOTMUX_SESSION_ID',
+      'process.env.BOTMUX_LARK_APP_ID',
+    ]);
+  });
+
   it('parses and relays an explicit layout before building the canonical reply card', () => {
     const cmdSendStart = cliSource.indexOf('async function cmdSend(');
     const cmdDispatchStart = cliSource.indexOf('async function cmdDispatch(', cmdSendStart);

--- a/test/dispatch.test.ts
+++ b/test/dispatch.test.ts
@@ -994,6 +994,26 @@ describe('acceptedDispatchBotAppIds', () => {
     })).toEqual(['cli_repo']);
   });
 
+  it('keeps a rootless ordinary chat-scope turn unbound instead of falling back to a stale session root', () => {
+    const session = {
+      larkAppId: 'cli_repo',
+      chatId: 'oc_target',
+      rootMessageId: 'om_stale_trace_root',
+      scope: 'chat' as const,
+      status: 'active',
+      pid: workerPid,
+      workerGeneration,
+    };
+
+    expect(recordDispatchInputCommit(
+      session,
+      turnId,
+      workerGeneration,
+      '2026-07-14T09:00:01.000Z',
+    )).toBe(false);
+    expect(session.dispatchInputReceipts).toBeUndefined();
+  });
+
   it('rejects a receipt from the previous worker generation after replacement', () => {
     const session = {
       larkAppId: 'cli_repo',

--- a/test/scheduler-silent-execute.test.ts
+++ b/test/scheduler-silent-execute.test.ts
@@ -149,6 +149,7 @@ vi.mock('../src/adapters/hook-installer.js', () => ({
 }));
 
 import { executeScheduledTask, rememberLastCliInput } from '../src/core/session-manager.js';
+import { recordDispatchInputCommit } from '../src/core/dispatch.js';
 import { sessionKey } from '../src/core/types.js';
 
 const APP = 'cli_app_test';
@@ -262,6 +263,9 @@ describe('executeScheduledTask — silent thread fire', () => {
     expect(ds.silentScheduledTurns).toBeUndefined();
     expect(forkedTurnId()).toMatch(/^schedule:task0001:/);
     expect(forkedCliInput()).not.toContain('<botmux_silent_schedule');
+    // Unit-level check: dispatch receipts require a live worker generation.
+    ds.session.workerGeneration = 1;
+    expect(recordDispatchInputCommit(ds.session, forkedTurnId(), 1)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 背景

chat-scope 会话的 `session.rootMessageId` 可能只是历史留痕或陈旧根消息，不能作为当前 turn 的可证明回复目标。实测中，chat-scope 轮次如果缺少 per-turn reply target，会产生 `Ignored unbound input commit`；该问题面覆盖普通 IM turn 与 schedule turn。thread-scope schedule 对照样本未触发该路径。

本 PR 不修复上述 A 问题。原因是可用的新 Lark message id 通常来自启动 banner，但把 banner 绑定到 chat-scope turn 会同时更新 `currentReplyTarget`，从而改变 `chat` / `chat-topic` 等模式的可见回复位置。这属于产品/维护者需要明确的路由语义，不应在本 PR 隐式拍板。

另一个独立现象是 `botmux send` 偶发找不到目标 session。该现象尚未形成稳定对照，本 PR 只补充白名单诊断日志，不声称修复。

## 改动

- 增加 `recordDispatchInputCommit` 回归测试，固化 chat-scope ordinary turn 不得回退使用陈旧 `session.rootMessageId`。
- 补充 thread-scope silent schedule 的既有路径覆盖，确认其 dispatch receipt 仍可基于 thread root 记录成功。
- `botmux send` 找不到 session 时，额外打印限定诊断字段：session id 来源、data dir、env session/app id、origin session、加载到的 session 数、relay/read-isolation/capability 状态。
- 增加诊断块白名单 source-lock：同时钉死 `${...}` 输出表达式列表和允许读取的 `process.env.*` 字段，防止展开环境变量、直接 secret 访问、无插值拼接或别名插值进入诊断输出。

## 未解决问题

- A：chat-scope rootless turn 的写入侧允许没有 `rootMessageId`，但 `recordDispatchInputCommit` 会 fail-closed。后续需要单独 issue 请维护者决定：
  - 是否允许 `chat` / `chat-topic` 定时输出挂到启动 banner 下；
  - 是否拆出“只写 dispatch receipt、不更新 `currentReplyTarget`”的路径；
  - 或者是否让读侧接受某些 rootless receipt。
- banner 发送失败时没有可绑定的新 message id；silent + chat-scope 也不会发送 banner。这两格本 PR 均不处理。
- 普通 rootless chat-scope IM turn 的 unbound 现象已被观察到，本 PR 只用 guard 测试防止错误兜底，不声称解释或修复 IM 路径。
- B：`botmux send` 找不到 session 的根因仍需结合失败进程当时的白名单快照继续定位。

## 影响面

- 不改变 schedule 路由逻辑，不改变 `beginReplyTargetTurn` 行为，不改变 `dispatch.ts` 的 chat-scope guard。
- 只影响 `botmux send` 缺失 session 时的错误诊断输出，以及相关测试覆盖。
- 诊断输出限定为非密钥字段，不输出完整环境变量、token、remote URL 或响应体。

## 验证

- `bun run test -- test/cli-send-hook-context.test.ts -t "prints only whitelisted session lookup diagnostics"`：1 passed
- `bun run test -- test/scheduler-silent-execute.test.ts test/dispatch.test.ts test/cli-send-hook-context.test.ts test/session-lifecycle-start.test.ts`：312 passed
- `bun node_modules/typescript/bin/tsc --noEmit`：passed
- `bun run build`：passed
- 变异验证：以下 5 类临时泄漏形态均按预期被 source-lock 拦截，临时改动均已恢复：
  - `JSON.stringify(process.env)`：红
  - `${process.env.BOTMUX_LARK_APP_SECRET}`：红
  - `JSON.stringify({ ...process.env })`：红
  - `+ ' secret=' + process.env.SECRET`：红
  - `${envAlias.SECRET}`：红
- B 只读对照：同一工作副本 cwd 下，`~/.botmux/bin/botmux history --limit 1` 与 `node dist/cli.js history --limit 1` 均 exit 0；此前 `send` 失败不能定性为稳定入口/二进制差异。

## 已知测试限制

- source-lock 是静态守卫，能覆盖顺手加入的环境变量展开、直接访问、无插值拼接和插值别名；别名 + `+` 拼接同时绕过仍需要数据流分析，不在本 PR 范围内。
