### PR TITLE
fix(dashboard): 版本检查跟随 npm 配置的 registry，修复镜像滞后时永久误报可升级

### DIFF
--- a/src/core/update-check.ts
+++ b/src/core/update-check.ts
@@ -19,7 +19,7 @@
  * failure (offline, rate-limited, registry hiccup) so the card degrades to
  * "couldn't check" rather than erroring. The version math is pure (unit tested).
  */
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { githubAuthHeaders, type GithubAuthResolveOptions } from './github-auth.js';
 import { GITHUB_REPO } from './restart-report.js';
 
@@ -164,7 +164,9 @@ export function registryPackumentUrl(base: string): string {
  */
 export function spawnNpmConfigRegistry(): Promise<string> {
   return new Promise(resolve => {
-    let child;
+    // Explicit type: settle() below references `child` from a closure created
+    // before the assignment, so `let child;`'s evolving-any can't be inferred.
+    let child: ChildProcess;
     let killTimer: NodeJS.Timeout | undefined;
     let graceTimer: NodeJS.Timeout | undefined;
     let settled = false;
@@ -173,6 +175,10 @@ export function spawnNpmConfigRegistry(): Promise<string> {
       settled = true;
       if (killTimer) clearTimeout(killTimer);
       if (graceTimer) clearTimeout(graceTimer);
+      // Release our read end and drop the data listener: a pipe-holding
+      // grandchild would otherwise keep the fd open AND keep `out` growing
+      // (unbounded memory) for as long as it writes to the dead pipe.
+      try { child.stdout?.destroy(); } catch { /* already closed */ }
       resolve(value);
     };
     try {
@@ -316,7 +322,7 @@ export function selectRollbackVersions(raw: unknown, current: string, max = 3): 
  * packument must match the source that pin installs from. Following the
  * configured registry here would break rollback for whitelists that don't
  * proxy botmux (lookup 503 → versions_unavailable) even though the pinned
- * public install would have worked.
+ * public install would have worked. (`opts.registry` does not apply here.)
  */
 export async function fetchRollbackVersions(
   current: string,

--- a/src/core/update-check.ts
+++ b/src/core/update-check.ts
@@ -3,13 +3,17 @@
  * release notes accumulated since the running version. Powers the Settings
  * "version & update" card (manual update flow) — see dashboard.ts /api/update/*.
  *
- * The registry lookups (`latest` + rollback packument) MUST go through the
- * registry npm is actually configured to use (`npm config get registry`): the
- * update button installs with the owning package manager, which resolves
- * through that same .npmrc family. Checking the public registry while
- * installing through a lagging mirror made the card advertise upgrades (and
- * rollback targets) that could never install. The public registry is only a
- * fallback for when the npm config can't be read (npm missing/unusual PATH).
+ * The `latest` lookup MUST go through the registry npm is actually configured
+ * to use (`npm config get registry`): the update button installs with the
+ * owning package manager, which resolves through that same .npmrc family.
+ * Checking the public registry while installing through a lagging mirror made
+ * the card advertise upgrades that could never install. The public registry is
+ * only a fallback for when the npm config can't be read (npm missing/unusual
+ * PATH). The ROLLBACK packument lookup, by contrast, deliberately stays
+ * public: the rollback install pins the registry to public too
+ * (`withGlobalInstallRegistry` in global-install.ts, rollback-only opt-in),
+ * and the allow-list validated against this packument must match the source
+ * that pin installs from.
  *
  * Every network call is best-effort: timeout-bounded and returns null / [] on
  * failure (offline, rate-limited, registry hiccup) so the card degrades to
@@ -179,11 +183,12 @@ let npmRegistryInFlight: Promise<string> | null = null;
  * read is NOT cached — a transient spawn failure at startup would otherwise
  * pin the fallback (public registry) forever, re-introducing the very
  * check/install mismatch this module exists to prevent. Retrying is naturally
- * rate-limited by the caller's version cache.
+ * rate-limited by the caller's version cache. The reader is injectable so
+ * tests can cover the cache policy itself (exported for tests only).
  */
-function resolveNpmRegistryBase(): Promise<string> {
+export function resolveNpmRegistryBase(read: () => Promise<string> = spawnNpmConfigRegistry): Promise<string> {
   if (npmRegistryBase) return Promise.resolve(npmRegistryBase);
-  npmRegistryInFlight ??= spawnNpmConfigRegistry()
+  npmRegistryInFlight ??= read()
     .then(raw => {
       const base = normalizeRegistryBase(raw);
       if (base) npmRegistryBase = base;
@@ -263,15 +268,23 @@ export function selectRollbackVersions(raw: unknown, current: string, max = 3): 
     }));
 }
 
-/** Fetch the packument (from the npm-configured registry) used to offer an
- *  allow-listed rollback target — same source the install would pull from. */
+/**
+ * Fetch the packument used to offer an allow-listed rollback target.
+ * Deliberately PUBLIC, not the npm-configured registry: the rollback install
+ * pins its registry to public too (`withGlobalInstallRegistry`, rollback-only
+ * opt-in in global-install.ts), and the allow-list validated against this
+ * packument must match the source that pin installs from. Following the
+ * configured registry here would break rollback for whitelists that don't
+ * proxy botmux (lookup 503 → versions_unavailable) even though the pinned
+ * public install would have worked.
+ */
 export async function fetchRollbackVersions(
   current: string,
   opts?: FetchOpts & { max?: number },
 ): Promise<RollbackVersionsResult> {
   const fetchImpl = opts?.fetchImpl ?? fetch;
   try {
-    const res = await fetchImpl(registryPackumentUrl(await effectiveRegistryBase(opts?.registry)), {
+    const res = await fetchImpl(registryPackumentUrl(PUBLIC_REGISTRY), {
       headers: { Accept: 'application/json', 'User-Agent': 'botmux' },
       signal: AbortSignal.timeout(opts?.timeoutMs ?? 8_000),
     });

--- a/src/core/update-check.ts
+++ b/src/core/update-check.ts
@@ -3,10 +3,19 @@
  * release notes accumulated since the running version. Powers the Settings
  * "version & update" card (manual update flow) — see dashboard.ts /api/update/*.
  *
+ * The registry lookups (`latest` + rollback packument) MUST go through the
+ * registry npm is actually configured to use (`npm config get registry`): the
+ * update button installs with the owning package manager, which resolves
+ * through that same .npmrc family. Checking the public registry while
+ * installing through a lagging mirror made the card advertise upgrades (and
+ * rollback targets) that could never install. The public registry is only a
+ * fallback for when the npm config can't be read (npm missing/unusual PATH).
+ *
  * Every network call is best-effort: timeout-bounded and returns null / [] on
  * failure (offline, rate-limited, registry hiccup) so the card degrades to
  * "couldn't check" rather than erroring. The version math is pure (unit tested).
  */
+import { spawn } from 'node:child_process';
 import { githubAuthHeaders, type GithubAuthResolveOptions } from './github-auth.js';
 import { GITHUB_REPO } from './restart-report.js';
 
@@ -102,24 +111,114 @@ function vtag(v: string): string {
   return v.startsWith('v') ? v : `v${v}`;
 }
 
-const REGISTRY_LATEST_URL = 'https://registry.npmjs.org/botmux/latest';
-const REGISTRY_PACKUMENT_URL = 'https://registry.npmjs.org/botmux';
+/** Fallback registry when the npm config can't be read (npm missing, odd PATH). */
+const PUBLIC_REGISTRY = 'https://registry.npmjs.org/';
+
+/**
+ * Normalize a raw registry value (`npm config get registry` output or a
+ * caller-supplied string) to a base URL with a trailing slash. npm prints the
+ * value as the last stdout line, but wrapper shims (nvm, corp-managed npm) may
+ * print banners first — so scan from the end and take the first line that
+ * parses as an http(s) URL. null when nothing does — garbage is never
+ * interpolated into a fetch target.
+ */
+export function normalizeRegistryBase(raw: string): string | null {
+  const lines = raw.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const v = lines[i].trim().replace(/^["']|["']$/g, '');
+    if (/^https?:\/\/\S+$/.test(v)) return v.endsWith('/') ? v : `${v}/`;
+  }
+  return null;
+}
+
+/** `GET {registry}botmux/latest` — the dist-tag manifest `@latest` installs. */
+export function registryLatestUrl(base: string): string {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  return `${b}botmux/latest`;
+}
+
+/** `GET {registry}botmux` — the packument behind the rollback picker. */
+export function registryPackumentUrl(base: string): string {
+  const b = base.endsWith('/') ? base : `${base}/`;
+  return `${b}botmux`;
+}
+
+/**
+ * Read `npm config get registry` (honors user/global/project .npmrc and
+ * NPM_CONFIG_REGISTRY). Async spawn — the dashboard must not block on npm CLI
+ * startup (~0.5-1s) — with a hard kill at 5s. Always resolves: '' on any
+ * failure so the caller can fall back to the public registry.
+ */
+function spawnNpmConfigRegistry(): Promise<string> {
+  return new Promise(resolve => {
+    let child;
+    try {
+      child = spawn('npm', ['config', 'get', 'registry'], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        shell: process.platform === 'win32', // resolve npm.cmd on Windows
+      });
+    } catch {
+      resolve('');
+      return;
+    }
+    let out = '';
+    const timer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already exited */ } }, 5_000);
+    child.stdout?.on('data', (d: Buffer) => { out += d.toString(); });
+    child.on('error', () => { clearTimeout(timer); resolve(''); });
+    child.on('close', () => { clearTimeout(timer); resolve(out); });
+  });
+}
+
+let npmRegistryBase: string | null = null;   // successful reads only
+let npmRegistryInFlight: Promise<string> | null = null;
+
+/**
+ * The registry base package-manager installs resolve through. A successful
+ * read is cached for the process lifetime (registry config rarely changes,
+ * and the update flow restarts the process anyway when it matters). A failed
+ * read is NOT cached — a transient spawn failure at startup would otherwise
+ * pin the fallback (public registry) forever, re-introducing the very
+ * check/install mismatch this module exists to prevent. Retrying is naturally
+ * rate-limited by the caller's version cache.
+ */
+function resolveNpmRegistryBase(): Promise<string> {
+  if (npmRegistryBase) return Promise.resolve(npmRegistryBase);
+  npmRegistryInFlight ??= spawnNpmConfigRegistry()
+    .then(raw => {
+      const base = normalizeRegistryBase(raw);
+      if (base) npmRegistryBase = base;
+      return base ?? PUBLIC_REGISTRY;
+    })
+    .finally(() => { npmRegistryInFlight = null; });
+  return npmRegistryInFlight;
+}
+
+/** Resolve the fetch base for a registry lookup: the opts override (tests)
+ *  when given, else the npm-configured registry with public fallback. */
+async function effectiveRegistryBase(registry?: string): Promise<string> {
+  return registry !== undefined
+    ? (normalizeRegistryBase(registry) ?? PUBLIC_REGISTRY)
+    : resolveNpmRegistryBase();
+}
 
 export interface FetchOpts {
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
   auth?: GithubAuthResolveOptions;
+  /** Registry base override (tests / callers that already know it). Invalid
+   *  values fall back to the public registry, mirroring runtime behavior. */
+  registry?: string;
 }
 
 /**
- * The npm registry's `latest` dist-tag version — the authoritative target for
- * both npm and pnpm updates. null on any failure (offline, non-200,
- * malformed body, or a version string we can't parse).
+ * The `latest` dist-tag version on the registry npm is configured to use —
+ * the authoritative target of a `@latest` update. null on any failure
+ * (offline, non-200, malformed body, or a version string we can't parse).
  */
 export async function fetchLatestVersion(opts?: FetchOpts): Promise<string | null> {
   const fetchImpl = opts?.fetchImpl ?? fetch;
   try {
-    const res = await fetchImpl(REGISTRY_LATEST_URL, {
+    const res = await fetchImpl(registryLatestUrl(await effectiveRegistryBase(opts?.registry)), {
       headers: { Accept: 'application/json', 'User-Agent': 'botmux' },
       signal: AbortSignal.timeout(opts?.timeoutMs ?? 8_000),
     });
@@ -164,14 +263,15 @@ export function selectRollbackVersions(raw: unknown, current: string, max = 3): 
     }));
 }
 
-/** Fetch the npm packument used to offer an allow-listed rollback target. */
+/** Fetch the packument (from the npm-configured registry) used to offer an
+ *  allow-listed rollback target — same source the install would pull from. */
 export async function fetchRollbackVersions(
   current: string,
   opts?: FetchOpts & { max?: number },
 ): Promise<RollbackVersionsResult> {
   const fetchImpl = opts?.fetchImpl ?? fetch;
   try {
-    const res = await fetchImpl(REGISTRY_PACKUMENT_URL, {
+    const res = await fetchImpl(registryPackumentUrl(await effectiveRegistryBase(opts?.registry)), {
       headers: { Accept: 'application/json', 'User-Agent': 'botmux' },
       signal: AbortSignal.timeout(opts?.timeoutMs ?? 8_000),
     });

--- a/src/core/update-check.ts
+++ b/src/core/update-check.ts
@@ -150,26 +150,66 @@ export function registryPackumentUrl(base: string): string {
 /**
  * Read `npm config get registry` (honors user/global/project .npmrc and
  * NPM_CONFIG_REGISTRY). Async spawn — the dashboard must not block on npm CLI
- * startup (~0.5-1s) — with a hard kill at 5s. Always resolves: '' on any
- * failure so the caller can fall back to the public registry.
+ * startup (~0.5-1s). Exported for tests only.
+ *
+ * Hang-hardened for wrapper shims (nvm, corp-managed npm): a shim may spawn a
+ * long-lived grandchild that inherits the stdout pipe. Killing only the shim
+ * then leaves the grandchild holding the pipe, 'close' never fires, and the
+ * promise would hang forever — pinning the module's in-flight guard and
+ * killing every later version check in the process. Two bounds instead:
+ * (1) shim exited but the pipe is still held → the output is already ours,
+ *     settle after a grace period WITHOUT killing the grandchild (it may be a
+ *     legitimate resident process the shim started for unrelated reasons);
+ * (2) npm itself hung → kill the whole process group (taskkill /T on Windows).
  */
-function spawnNpmConfigRegistry(): Promise<string> {
+export function spawnNpmConfigRegistry(): Promise<string> {
   return new Promise(resolve => {
     let child;
+    let killTimer: NodeJS.Timeout | undefined;
+    let graceTimer: NodeJS.Timeout | undefined;
+    let settled = false;
+    const settle = (value: string): void => {
+      if (settled) return;
+      settled = true;
+      if (killTimer) clearTimeout(killTimer);
+      if (graceTimer) clearTimeout(graceTimer);
+      resolve(value);
+    };
     try {
       child = spawn('npm', ['config', 'get', 'registry'], {
         stdio: ['ignore', 'pipe', 'ignore'],
         shell: process.platform === 'win32', // resolve npm.cmd on Windows
+        // Own process group (POSIX): a timeout kill then reaches the shim's
+        // descendants too, not just the shim itself.
+        detached: process.platform !== 'win32',
+        windowsHide: true,
       });
     } catch {
       resolve('');
       return;
     }
     let out = '';
-    const timer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already exited */ } }, 5_000);
     child.stdout?.on('data', (d: Buffer) => { out += d.toString(); });
-    child.on('error', () => { clearTimeout(timer); resolve(''); });
-    child.on('close', () => { clearTimeout(timer); resolve(out); });
+    child.on('error', () => settle(''));
+    // (2) The child itself is hung. Kill the group; 'exit' follows, and (1)
+    // below settles even if a setsid-style escapee still holds the pipe.
+    killTimer = setTimeout(() => {
+      try {
+        if (child.pid === undefined) return;
+        if (process.platform === 'win32') {
+          spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true });
+        } else {
+          process.kill(-child.pid, 'SIGKILL');
+        }
+      } catch { /* already gone */ }
+    }, 5_000).unref();
+    // (1) npm exited but 'close' hasn't fired → a grandchild holds the pipe.
+    // We already have the output; stop waiting instead of hanging forever.
+    child.on('exit', () => {
+      graceTimer = setTimeout(() => settle(out), 1_000).unref();
+    });
+    // Normal path: all stdio closed right after exit — settle immediately.
+    child.on('close', () => settle(out));
   });
 }
 

--- a/test/update-check.test.ts
+++ b/test/update-check.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeRegistryBase,
   registryLatestUrl,
   registryPackumentUrl,
+  resolveNpmRegistryBase,
 } from '../src/core/update-check.js';
 
 describe('parseVersion', () => {
@@ -141,6 +142,9 @@ describe('normalizeRegistryBase', () => {
   it('takes the last http(s) line — wrapper shims may print banners before the value', () => {
     expect(normalizeRegistryBase('nvm shim banner v1.2.3\nhttps://mirror.example.com\n')).toBe('https://mirror.example.com/');
     expect(normalizeRegistryBase('https://first.example.com\nnot a url\n')).toBe('https://first.example.com/');
+    // Direction lock: with TWO valid http(s) lines the LAST one wins — a
+    // from-the-front scan (the tempting wrong direction) returns the first.
+    expect(normalizeRegistryBase('https://first.example.com\nhttps://last.example.com\n')).toBe('https://last.example.com/');
   });
   it('null on non-http(s) garbage (never a fetch target)', () => {
     expect(normalizeRegistryBase('')).toBeNull();
@@ -187,6 +191,19 @@ describe('fetchLatestVersion', () => {
   });
 });
 
+describe('resolveNpmRegistryBase cache policy', () => {
+  // Mutates the module-level cache in a fixed sequence from a clean start
+  // (no other test caches a successful read), so it must stay one `it`.
+  it('falls back on failure WITHOUT caching, then caches the first success for the process lifetime', async () => {
+    // 1. Failed read → public fallback, and the failure must not be cached…
+    expect(await resolveNpmRegistryBase(async () => '')).toBe('https://registry.npmjs.org/');
+    // 2. …because the next call retries and picks up the real config.
+    expect(await resolveNpmRegistryBase(async () => 'nvm banner\nhttps://cache-check.example.com\n')).toBe('https://cache-check.example.com/');
+    // 3. A successful read IS cached — a later config change is not re-read.
+    expect(await resolveNpmRegistryBase(async () => 'https://other.example.com/')).toBe('https://cache-check.example.com/');
+  });
+});
+
 describe('rollback versions', () => {
   const packument = {
     versions: {
@@ -227,7 +244,6 @@ describe('rollback versions', () => {
 
   it('fetches and filters the registry packument', async () => {
     const out = await fetchRollbackVersions('3.0.0', {
-      registry: 'https://registry.npmjs.org/',
       fetchImpl: async () => jsonResponse(200, packument),
       max: 1,
     });
@@ -237,19 +253,19 @@ describe('rollback versions', () => {
     });
   });
 
-  it('queries the configured registry for the packument — same source the rollback install would pull from', async () => {
+  it('rollback packument stays PUBLIC — same source the pinned rollback install resolves from', async () => {
     let seen = '';
     const fetchImpl = async (url: unknown) => { seen = String(url); return jsonResponse(200, packument); };
-    await fetchRollbackVersions('3.0.0', { registry: 'https://mirror.example.com', fetchImpl });
-    expect(seen).toBe('https://mirror.example.com/botmux');
+    await fetchRollbackVersions('3.0.0', { fetchImpl });
+    expect(seen).toBe('https://registry.npmjs.org/botmux');
   });
 
   it('reports registry and malformed-response failures', async () => {
-    expect(await fetchRollbackVersions('3.0.0', { registry: 'https://registry.npmjs.org/', fetchImpl: async () => jsonResponse(503, {}) }))
+    expect(await fetchRollbackVersions('3.0.0', { fetchImpl: async () => jsonResponse(503, {}) }))
       .toEqual({ ok: false, versions: [] });
-    expect(await fetchRollbackVersions('3.0.0', { registry: 'https://registry.npmjs.org/', fetchImpl: async () => jsonResponse(200, {}) }))
+    expect(await fetchRollbackVersions('3.0.0', { fetchImpl: async () => jsonResponse(200, {}) }))
       .toEqual({ ok: false, versions: [] });
-    expect(await fetchRollbackVersions('3.0.0', { registry: 'https://registry.npmjs.org/', fetchImpl: async () => { throw new Error('offline'); } }))
+    expect(await fetchRollbackVersions('3.0.0', { fetchImpl: async () => { throw new Error('offline'); } }))
       .toEqual({ ok: false, versions: [] });
   });
 });

--- a/test/update-check.test.ts
+++ b/test/update-check.test.ts
@@ -10,6 +10,9 @@ import {
   selectRollbackVersions,
   fetchRollbackVersions,
   fetchReleasesSince,
+  normalizeRegistryBase,
+  registryLatestUrl,
+  registryPackumentUrl,
 } from '../src/core/update-check.js';
 
 describe('parseVersion', () => {
@@ -127,16 +130,60 @@ function jsonResponse(status: number, body: unknown): Response {
   return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
 }
 
+describe('normalizeRegistryBase', () => {
+  it('normalizes trailing slash, trims, strips matching quotes', () => {
+    expect(normalizeRegistryBase('https://mirror.example.com')).toBe('https://mirror.example.com/');
+    expect(normalizeRegistryBase('https://mirror.example.com/')).toBe('https://mirror.example.com/');
+    expect(normalizeRegistryBase('  https://mirror.example.com/\n')).toBe('https://mirror.example.com/');
+    expect(normalizeRegistryBase('"https://mirror.example.com"')).toBe('https://mirror.example.com/');
+    expect(normalizeRegistryBase('https://proxy.example.com/npm/')).toBe('https://proxy.example.com/npm/');
+  });
+  it('takes the last http(s) line — wrapper shims may print banners before the value', () => {
+    expect(normalizeRegistryBase('nvm shim banner v1.2.3\nhttps://mirror.example.com\n')).toBe('https://mirror.example.com/');
+    expect(normalizeRegistryBase('https://first.example.com\nnot a url\n')).toBe('https://first.example.com/');
+  });
+  it('null on non-http(s) garbage (never a fetch target)', () => {
+    expect(normalizeRegistryBase('')).toBeNull();
+    expect(normalizeRegistryBase('not a url')).toBeNull();
+    expect(normalizeRegistryBase('javascript:alert(1)')).toBeNull();
+    expect(normalizeRegistryBase('ftp://example.com')).toBeNull();
+  });
+});
+
+describe('registryLatestUrl / registryPackumentUrl', () => {
+  it('builds the packument URLs from a base with or without slash', () => {
+    expect(registryLatestUrl('https://mirror.example.com/')).toBe('https://mirror.example.com/botmux/latest');
+    expect(registryLatestUrl('https://mirror.example.com')).toBe('https://mirror.example.com/botmux/latest');
+    expect(registryPackumentUrl('https://mirror.example.com/')).toBe('https://mirror.example.com/botmux');
+    expect(registryPackumentUrl('https://mirror.example.com')).toBe('https://mirror.example.com/botmux');
+  });
+});
+
 describe('fetchLatestVersion', () => {
+  // registry is pinned so the tests never spawn `npm config get registry`.
   it('returns the registry version', async () => {
-    const v = await fetchLatestVersion({ fetchImpl: async () => jsonResponse(200, { version: '2.85.1' }) });
+    const v = await fetchLatestVersion({ registry: 'https://registry.npmjs.org/', fetchImpl: async () => jsonResponse(200, { version: '2.85.1' }) });
     expect(v).toBe('2.85.1');
   });
   it('null on non-200 / malformed / unparseable / throw', async () => {
-    expect(await fetchLatestVersion({ fetchImpl: async () => jsonResponse(503, {}) })).toBeNull();
-    expect(await fetchLatestVersion({ fetchImpl: async () => jsonResponse(200, {}) })).toBeNull();
-    expect(await fetchLatestVersion({ fetchImpl: async () => jsonResponse(200, { version: 'latest' }) })).toBeNull();
-    expect(await fetchLatestVersion({ fetchImpl: async () => { throw new Error('offline'); } })).toBeNull();
+    expect(await fetchLatestVersion({ registry: 'https://registry.npmjs.org/', fetchImpl: async () => jsonResponse(503, {}) })).toBeNull();
+    expect(await fetchLatestVersion({ registry: 'https://registry.npmjs.org/', fetchImpl: async () => jsonResponse(200, {}) })).toBeNull();
+    expect(await fetchLatestVersion({ registry: 'https://registry.npmjs.org/', fetchImpl: async () => jsonResponse(200, { version: 'latest' }) })).toBeNull();
+    expect(await fetchLatestVersion({ registry: 'https://registry.npmjs.org/', fetchImpl: async () => { throw new Error('offline'); } })).toBeNull();
+  });
+  it('queries the configured registry — the same source npm install resolves through', async () => {
+    let seen = '';
+    // `unknown` param: assignable to typeof fetch regardless of lib typings.
+    const fetchImpl = async (url: unknown) => { seen = String(url); return jsonResponse(200, { version: '2.85.1' }); };
+    const v = await fetchLatestVersion({ registry: 'https://mirror.example.com', fetchImpl });
+    expect(v).toBe('2.85.1');
+    expect(seen).toBe('https://mirror.example.com/botmux/latest');
+  });
+  it('falls back to the public registry when the configured value is garbage', async () => {
+    let seen = '';
+    const fetchImpl = async (url: unknown) => { seen = String(url); return jsonResponse(200, { version: '2.85.1' }); };
+    await fetchLatestVersion({ registry: 'garbage', fetchImpl });
+    expect(seen).toBe('https://registry.npmjs.org/botmux/latest');
   });
 });
 
@@ -180,6 +227,7 @@ describe('rollback versions', () => {
 
   it('fetches and filters the registry packument', async () => {
     const out = await fetchRollbackVersions('3.0.0', {
+      registry: 'https://registry.npmjs.org/',
       fetchImpl: async () => jsonResponse(200, packument),
       max: 1,
     });
@@ -189,12 +237,19 @@ describe('rollback versions', () => {
     });
   });
 
+  it('queries the configured registry for the packument — same source the rollback install would pull from', async () => {
+    let seen = '';
+    const fetchImpl = async (url: unknown) => { seen = String(url); return jsonResponse(200, packument); };
+    await fetchRollbackVersions('3.0.0', { registry: 'https://mirror.example.com', fetchImpl });
+    expect(seen).toBe('https://mirror.example.com/botmux');
+  });
+
   it('reports registry and malformed-response failures', async () => {
-    expect(await fetchRollbackVersions('3.0.0', { fetchImpl: async () => jsonResponse(503, {}) }))
+    expect(await fetchRollbackVersions('3.0.0', { registry: 'https://registry.npmjs.org/', fetchImpl: async () => jsonResponse(503, {}) }))
       .toEqual({ ok: false, versions: [] });
-    expect(await fetchRollbackVersions('3.0.0', { fetchImpl: async () => jsonResponse(200, {}) }))
+    expect(await fetchRollbackVersions('3.0.0', { registry: 'https://registry.npmjs.org/', fetchImpl: async () => jsonResponse(200, {}) }))
       .toEqual({ ok: false, versions: [] });
-    expect(await fetchRollbackVersions('3.0.0', { fetchImpl: async () => { throw new Error('offline'); } }))
+    expect(await fetchRollbackVersions('3.0.0', { registry: 'https://registry.npmjs.org/', fetchImpl: async () => { throw new Error('offline'); } }))
       .toEqual({ ok: false, versions: [] });
   });
 });

--- a/test/update-check.test.ts
+++ b/test/update-check.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   parseVersion,
   isStableVersion,
@@ -14,6 +17,7 @@ import {
   registryLatestUrl,
   registryPackumentUrl,
   resolveNpmRegistryBase,
+  spawnNpmConfigRegistry,
 } from '../src/core/update-check.js';
 
 describe('parseVersion', () => {
@@ -202,6 +206,40 @@ describe('resolveNpmRegistryBase cache policy', () => {
     // 3. A successful read IS cached — a later config change is not re-read.
     expect(await resolveNpmRegistryBase(async () => 'https://other.example.com/')).toBe('https://cache-check.example.com/');
   });
+});
+
+describe('spawnNpmConfigRegistry hang resistance', () => {
+  // Real-spawn regression test for the wrapper-shim hang: the shim prints the
+  // value and exits, leaving a 60s grandchild holding the inherited stdout
+  // pipe — 'close' never fires. On the pre-fix code this promise hangs until
+  // the vitest timeout (red); the exit-grace settle resolves ~1s after the
+  // shim exits with the full output (green).
+  (process.platform === 'win32' ? it.skip : it)('settles when a shim leaves a pipe-holding grandchild', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-npm-shim-'));
+    const shim = join(dir, 'npm');
+    const pidFile = join(dir, 'grandchild.pid');
+    writeFileSync(shim, '#!/bin/sh\n'
+      + 'echo "https://hang-check.example.com"\n'
+      + 'sleep 60 &\n'
+      + `echo $! > "${pidFile}"\n`
+      + 'exit 0\n', { mode: 0o755 });
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${dir}:${oldPath}`;
+    let grandchildPid: number | undefined;
+    try {
+      const started = Date.now();
+      const raw = await spawnNpmConfigRegistry();
+      const elapsed = Date.now() - started;
+      expect(raw).toBe('https://hang-check.example.com\n');
+      // Grace path (~1s), not the 5s kill path and not a hang.
+      expect(elapsed).toBeLessThan(4_000);
+      grandchildPid = Number(readFileSync(pidFile, 'utf8').trim()) || undefined;
+    } finally {
+      process.env.PATH = oldPath;
+      try { if (grandchildPid) process.kill(grandchildPid, 'SIGKILL'); } catch { /* already gone */ }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
 });
 
 describe('rollback versions', () => {

--- a/test/update-check.test.ts
+++ b/test/update-check.test.ts
@@ -225,7 +225,6 @@ describe('spawnNpmConfigRegistry hang resistance', () => {
       + 'exit 0\n', { mode: 0o755 });
     const oldPath = process.env.PATH;
     process.env.PATH = `${dir}:${oldPath}`;
-    let grandchildPid: number | undefined;
     try {
       const started = Date.now();
       const raw = await spawnNpmConfigRegistry();
@@ -233,10 +232,11 @@ describe('spawnNpmConfigRegistry hang resistance', () => {
       expect(raw).toBe('https://hang-check.example.com\n');
       // Grace path (~1s), not the 5s kill path and not a hang.
       expect(elapsed).toBeLessThan(4_000);
-      grandchildPid = Number(readFileSync(pidFile, 'utf8').trim()) || undefined;
     } finally {
       process.env.PATH = oldPath;
-      try { if (grandchildPid) process.kill(grandchildPid, 'SIGKILL'); } catch { /* already gone */ }
+      // Read the pid file in finally so the grandchild is cleaned up even
+      // when an assertion above failed (that's exactly the regression case).
+      try { process.kill(Number(readFileSync(pidFile, 'utf8').trim()), 'SIGKILL'); } catch { /* already gone */ }
       rmSync(dir, { recursive: true, force: true });
     }
   }, 15_000);


### PR DESCRIPTION
## 背景

「版本与更新」卡片的检查源硬编码 `registry.npmjs.org`，而升级实际由所属包管理器（npm/pnpm/Bun）按 `.npmrc` 解析 registry 后安装（`resolveGlobalInstallPlan` 不带 registry 钉子、继承环境）。两者不一致时（典型：npm 配了内网/国内镜像且同步滞后）会死循环——dashboard 永远提示「可升级到 vX.Y.Z」，点升级装到的却始终是镜像里的旧版。

## 改动

- `fetchLatestVersion` 改为运行时读 `npm config get registry` 后请求 `{registry}/botmux/latest`，与升级安装侧同源；读取失败/值非法兜底公网，失败不缓存（避免一次瞬时失败把错误来源钉死整个进程生命周期），成功进程级缓存
- `fetchRollbackVersions` 保持公网不动：回退安装侧 `withGlobalInstallRegistry` 是 rollback-only 的公网钉子，允许列表须与钉子实际安装的源一致（跟随配置源会让不代理 botmux 的白名单 registry 下回退直接 503，是回归）
- `spawnNpmConfigRegistry` 防 wrapper shim 挂起：shim 派生继承 stdout 管道的常驻孙进程时，`child.kill` 只杀 shim、`close` 永不触发、promise 永悬。两层兜底——exit 后 1s 宽限 settle（输出已拿到，不误杀可能是合法常驻进程的孙进程）；npm 自身挂死时 POSIX 组杀（`detached` + `kill(-pid)`，Windows `taskkill /T /F`）
- 配置源 HTTP 失败返回 null，不回退公网——回退会重新制造 check/install 不一致
- `normalizeRegistryBase` 从最后一行向前取第一个合法 http(s) URL（含双合法 URL 的方向锁定用例），兼容 wrapper shim 在 stdout 打 banner；垃圾值不会拼进 fetch URL
- 导出 `resolveNpmRegistryBase`（reader 可注入）与 `spawnNpmConfigRegistry`（仅测试用），覆盖缓存语义与真实 shim 挂起回归

## 验证

- `test/update-check.test.ts` 40/40 + `global-install` 24 = 64/64；`tsc --noEmit` 通过
- 变异验证：移除宽限 settle → shim 挂起用例红于 5012ms（`elapsed < 4s` 区分宽限路径与 5s 组杀兜底）；恢复后 ~1s 绿
- 沙箱 HOME + 独立端口起 `dist/dashboard.js`，`.npmrc` 指向一个停留在旧版本的 mock registry：`/api/update/status` 如实返回 mock 版本、mock 记录到请求命中，证明完整链路跟随 npm 配置（修复前该场景无视 `.npmrc` 报公网版本）