### PR TITLE
fix(dashboard): 保留 TraeX backend variant 回显

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2629,7 +2629,7 @@ function configuredBrands(): Map<string, string | undefined> {
   return brandMapByAppId(loadBotConfigs);
 }
 
-function configuredBotAgentFields(): Map<string, { cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; reasoningEffort?: BotConfig['reasoningEffort']; turnTimeoutMs?: number; dshRuntime?: BotConfig['dshRuntime']; dshProfile?: string }> {
+function configuredBotAgentFields(): Map<string, { cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; modelBackendVariant?: BotConfig['modelBackendVariant']; reasoningEffort?: BotConfig['reasoningEffort']; turnTimeoutMs?: number; dshRuntime?: BotConfig['dshRuntime']; dshProfile?: string }> {
   try {
     return new Map(loadBotConfigs().map(b => [b.larkAppId, {
       cliId: b.cliId,
@@ -2640,6 +2640,7 @@ function configuredBotAgentFields(): Map<string, { cliId?: string; cliRuntime?: 
       cliPathOverride: b.cliRuntime ? undefined : b.cliPathOverride,
       wrapperCli: b.wrapperCli,
       model: b.model,
+      modelBackendVariant: b.modelBackendVariant,
       reasoningEffort: b.reasoningEffort,
       turnTimeoutMs: b.turnTimeoutMs,
       dshRuntime: b.dshRuntime,
@@ -2650,12 +2651,12 @@ function configuredBotAgentFields(): Map<string, { cliId?: string; cliRuntime?: 
   }
 }
 
-function withConfiguredCliId<T extends { larkAppId: string; cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; reasoningEffort?: BotConfig['reasoningEffort']; turnTimeoutMs?: number; dshRuntime?: BotConfig['dshRuntime']; dshProfile?: string }>(
+function withConfiguredCliId<T extends { larkAppId: string; cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; modelBackendVariant?: BotConfig['modelBackendVariant']; reasoningEffort?: BotConfig['reasoningEffort']; turnTimeoutMs?: number; dshRuntime?: BotConfig['dshRuntime']; dshProfile?: string }>(
   bot: T,
-  ids: Map<string, string> | Map<string, { cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string }>,
-): T & { cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; reasoningEffort?: BotConfig['reasoningEffort']; turnTimeoutMs?: number; dshRuntime?: BotConfig['dshRuntime'] } {
+  ids: Map<string, string> | Map<string, { cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; modelBackendVariant?: BotConfig['modelBackendVariant'] }>,
+): T & { cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; modelBackendVariant?: BotConfig['modelBackendVariant']; reasoningEffort?: BotConfig['reasoningEffort']; turnTimeoutMs?: number; dshRuntime?: BotConfig['dshRuntime'] } {
   const raw = ids.get(bot.larkAppId);
-  const fallback: { cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; reasoningEffort?: BotConfig['reasoningEffort']; turnTimeoutMs?: number; dshRuntime?: BotConfig['dshRuntime'] } | undefined = typeof raw === 'string' ? { cliId: raw } : raw;
+  const fallback: { cliId?: string; cliRuntime?: BotConfig['cliRuntime']; cliPathOverride?: string; wrapperCli?: string; model?: string; modelBackendVariant?: BotConfig['modelBackendVariant']; reasoningEffort?: BotConfig['reasoningEffort']; turnTimeoutMs?: number; dshRuntime?: BotConfig['dshRuntime'] } | undefined = typeof raw === 'string' ? { cliId: raw } : raw;
   return {
     ...bot,
     cliId: bot.cliId || fallback?.cliId,
@@ -2663,6 +2664,7 @@ function withConfiguredCliId<T extends { larkAppId: string; cliId?: string; cliR
     cliPathOverride: bot.cliPathOverride || fallback?.cliPathOverride,
     wrapperCli: bot.wrapperCli || fallback?.wrapperCli,
     model: bot.model || fallback?.model,
+    modelBackendVariant: bot.modelBackendVariant ?? fallback?.modelBackendVariant,
     reasoningEffort: bot.reasoningEffort || fallback?.reasoningEffort,
     turnTimeoutMs: bot.turnTimeoutMs ?? fallback?.turnTimeoutMs,
     dshRuntime: bot.dshRuntime ?? fallback?.dshRuntime,
@@ -6245,6 +6247,14 @@ const server = createServer(async (req, res) => {
               : d.cliPathOverride,
             wrapperCli: j.wrapperCli || d.wrapperCli,
             model: j.model || d.model,
+            // New daemons return explicit null when TraeX inherits its default.
+            // Keep that authoritative instead of reviving a stale bots.json
+            // fallback; older daemons omit the field and retain compatibility.
+            modelBackendVariant: Object.prototype.hasOwnProperty.call(j, 'modelBackendVariant')
+              ? (j.modelBackendVariant === 'standard' || j.modelBackendVariant === 'max'
+                ? j.modelBackendVariant
+                : undefined)
+              : d.modelBackendVariant,
             reasoningEffort: j.reasoningEffort || d.reasoningEffort,
             turnTimeoutMs: typeof j.turnTimeoutMs === 'number' ? j.turnTimeoutMs : d.turnTimeoutMs,
             dshRuntime: typeof j.dshRuntime === 'string' ? j.dshRuntime : d.dshRuntime,

--- a/src/dashboard/bot-payload.ts
+++ b/src/dashboard/bot-payload.ts
@@ -18,6 +18,7 @@ export interface DashboardBotDescriptor {
   cliPathOverride?: string;
   wrapperCli?: string;
   model?: string;
+  modelBackendVariant?: 'standard' | 'max';
   reasoningEffort?: string;
   /** dsh runner turn timeout (ms); dashboard exposes it for the dsh CLI only. */
   turnTimeoutMs?: number;
@@ -66,6 +67,7 @@ export function botDefaultsPayload(bot: DashboardBotDescriptor, j?: any, error?:
     ...(bot.cliPathOverride ? { cliPathOverride: bot.cliPathOverride } : {}),
     ...(bot.wrapperCli ? { wrapperCli: bot.wrapperCli } : {}),
     ...(bot.model ? { model: bot.model } : {}),
+    ...(bot.modelBackendVariant ? { modelBackendVariant: bot.modelBackendVariant } : {}),
     ...(bot.reasoningEffort ? { reasoningEffort: bot.reasoningEffort } : {}),
     ...(typeof bot.turnTimeoutMs === 'number' ? { turnTimeoutMs: bot.turnTimeoutMs } : {}),
     ...(bot.dshRuntime ? { dshRuntime: bot.dshRuntime } : {}),

--- a/test/dashboard-bot-agent-roundtrip.integration.test.ts
+++ b/test/dashboard-bot-agent-roundtrip.integration.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { once } from 'node:events';
+import { createServer as createNetServer } from 'node:net';
+import { join, resolve } from 'node:path';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import type { ChildProcess } from 'node:child_process';
+
+import { spawnTsScript } from './helpers/ts-runner.js';
+import { loadOrCreatePersistedToken } from '../src/dashboard/auth.js';
+
+const DASHBOARD_ENTRY = resolve('src/index-dashboard.ts');
+
+async function listen(server: Server): Promise<number> {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return (server.address() as import('node:net').AddressInfo).port;
+}
+
+async function reservePort(): Promise<number> {
+  const server = createNetServer();
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const port = (server.address() as import('node:net').AddressInfo).port;
+  await new Promise<void>(resolveClose => server.close(() => resolveClose()));
+  return port;
+}
+
+async function waitForDashboard(base: string, child: ChildProcess, logs: () => string): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`dashboard exited early\n${logs()}`);
+    }
+    try {
+      const response = await fetch(`${base}/__health`);
+      if (response.ok) return;
+    } catch {
+      // still booting
+    }
+    await new Promise(resolveSleep => setTimeout(resolveSleep, 100));
+  }
+  throw new Error(`timeout waiting for dashboard health\n${logs()}`);
+}
+
+async function stopChild(child: ChildProcess | undefined): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  await Promise.race([
+    once(child, 'close'),
+    new Promise(resolveTimeout => setTimeout(resolveTimeout, 10_000)),
+  ]);
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill('SIGKILL');
+    await once(child, 'close');
+  }
+}
+
+async function closeServer(server: Server | undefined): Promise<void> {
+  if (!server?.listening) return;
+  await new Promise<void>(resolveClose => server.close(() => resolveClose()));
+}
+
+describe('dashboard real HTTP route · Bot agent defaults round trip', () => {
+  let rootDir = '';
+  let fakeDaemon: Server | undefined;
+  let dashboardChild: ChildProcess | undefined;
+
+  afterEach(async () => {
+    await stopChild(dashboardChild);
+    dashboardChild = undefined;
+    await closeServer(fakeDaemon);
+    fakeDaemon = undefined;
+    if (rootDir) rmSync(rootDir, { recursive: true, force: true });
+    rootDir = '';
+  });
+
+  it('keeps TraeX modelBackendVariant after saving and reloading /api/bots', async () => {
+    rootDir = mkdtempSync(join(tmpdir(), 'botmux-dashboard-agent-roundtrip-'));
+    const homeDir = join(rootDir, 'home');
+    const botmuxDir = join(homeDir, '.botmux');
+    const dataDir = join(botmuxDir, 'data');
+    const registryDir = join(dataDir, 'dashboard-daemons');
+    const botsConfigPath = join(botmuxDir, 'bots.json');
+    const dashboardPort = await reservePort();
+    const appId = 'cli_traex_roundtrip';
+    mkdirSync(registryDir, { recursive: true });
+    writeFileSync(join(botmuxDir, '.dashboard-secret'), 'dashboard-secret-for-agent-roundtrip', { mode: 0o600 });
+    writeFileSync(join(botmuxDir, '.data-dir'), `${dataDir}\n`, { mode: 0o600 });
+    writeFileSync(botsConfigPath, JSON.stringify([{
+      larkAppId: appId,
+      larkAppSecret: 'secret',
+      botName: 'TraeX Bot',
+      cliId: 'traex',
+      model: 'GPT-5.6-Sol',
+      modelBackendVariant: 'standard',
+    }], null, 2));
+
+    // Start as an old daemon response (field omitted): /api/bots must fall back
+    // to bots.json. Later writes exercise new-daemon max and explicit-null data.
+    let modelBackendVariant: 'standard' | 'max' | null | undefined;
+    fakeDaemon = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      const url = req.url ?? '/';
+      if (req.method === 'GET' && url === '/api/bot-default-oncall') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          larkAppId: appId,
+          botName: 'TraeX Bot',
+          cliId: 'traex',
+          model: 'GPT-5.6-Sol',
+          modelBackendVariant,
+        }));
+        return;
+      }
+      if (req.method === 'PUT' && url === '/api/bot-agent') {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(chunk as Buffer);
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+        if (Object.prototype.hasOwnProperty.call(body, 'modelBackendVariant')) {
+          modelBackendVariant = body.modelBackendVariant === 'standard' || body.modelBackendVariant === 'max'
+            ? body.modelBackendVariant
+            : null;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: true,
+          cliId: 'traex',
+          model: 'GPT-5.6-Sol',
+          modelBackendVariant,
+        }));
+        return;
+      }
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, error: 'unexpected_route', method: req.method, url }));
+    });
+    const fakeDaemonPort = await listen(fakeDaemon);
+
+    writeFileSync(join(registryDir, `${appId}.json`), JSON.stringify({
+      larkAppId: appId,
+      botName: 'TraeX Bot',
+      cliId: 'traex',
+      botIndex: 0,
+      ipcPort: fakeDaemonPort,
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+    }));
+
+    const dashboardToken = loadOrCreatePersistedToken(join(botmuxDir, '.dashboard-token'));
+    dashboardChild = spawnTsScript(DASHBOARD_ENTRY, [], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        SESSION_DATA_DIR: dataDir,
+        BOTS_CONFIG: botsConfigPath,
+        BOTMUX_DASHBOARD_PORT: String(dashboardPort),
+        BOTMUX_DASHBOARD_HOST: '127.0.0.1',
+        BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    dashboardChild.stdout?.on('data', chunk => { stdout += String(chunk); });
+    let stderr = '';
+    dashboardChild.stderr?.on('data', chunk => { stderr += String(chunk); });
+    const logs = () => `${stdout}\n${stderr}`;
+    const base = `http://127.0.0.1:${dashboardPort}`;
+    const headers = { cookie: `botmux_dashboard_token=${dashboardToken}` };
+    await waitForDashboard(base, dashboardChild, logs);
+
+    const initial = await fetch(`${base}/api/bots`, { headers });
+    expect(initial.status, logs()).toBe(200);
+    expect(await initial.json()).toMatchObject({
+      bots: [{ larkAppId: appId, modelBackendVariant: 'standard' }],
+    });
+
+    const saved = await fetch(`${base}/api/bots/${encodeURIComponent(appId)}/agent`, {
+      method: 'PUT',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        cliId: 'traex',
+        model: 'GPT-5.6-Sol',
+        modelBackendVariant: 'max',
+      }),
+    });
+    expect(saved.status, logs()).toBe(200);
+    expect(await saved.json()).toMatchObject({ modelBackendVariant: 'max' });
+
+    const reloaded = await fetch(`${base}/api/bots`, { headers });
+    expect(reloaded.status, logs()).toBe(200);
+    expect(await reloaded.json()).toMatchObject({
+      bots: [{ larkAppId: appId, modelBackendVariant: 'max' }],
+    });
+
+    const cleared = await fetch(`${base}/api/bots/${encodeURIComponent(appId)}/agent`, {
+      method: 'PUT',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        cliId: 'traex',
+        model: 'GPT-5.6-Sol',
+        modelBackendVariant: '',
+      }),
+    });
+    expect(cleared.status, logs()).toBe(200);
+    expect(await cleared.json()).toMatchObject({ modelBackendVariant: null });
+
+    const afterClear = await fetch(`${base}/api/bots`, { headers });
+    expect(afterClear.status, logs()).toBe(200);
+    const afterClearBody = await afterClear.json() as { bots: Array<Record<string, unknown>> };
+    expect(afterClearBody.bots).toHaveLength(1);
+    expect(afterClearBody.bots[0]).not.toHaveProperty('modelBackendVariant');
+  }, 20_000);
+});

--- a/test/dashboard-bot-payload.test.ts
+++ b/test/dashboard-bot-payload.test.ts
@@ -7,14 +7,15 @@ describe('dashboard bot payload helpers', () => {
       {
         larkAppId: 'app_contract',
         botName: 'BotContract',
-        cliId: 'codex',
+        cliId: 'traex',
         cliRuntime: { id: 'vendor-codex', executable: 'vendor-codex' },
-        model: 'gpt-5',
+        model: 'GPT-5.6-Sol',
+        modelBackendVariant: 'max',
       },
       {},
     );
     const editableFields = [
-      'larkAppId', 'botName', 'cliId', 'cliRuntime', 'model', 'agentSelectionKey', 'online',
+      'larkAppId', 'botName', 'cliId', 'cliRuntime', 'model', 'modelBackendVariant', 'agentSelectionKey', 'online',
       'displayName', 'larkBotName',
       'defaultOncall', 'defaultWorkingDir', 'defaultWorkingDirAutoWorktree',
       'autoboundChatCount', 'brandLabel',


### PR DESCRIPTION
## 背景

这是 #1201 的 follow-up。#1201 已加入 TraeX Bot 级 Backend Variant 的配置、PTY/RPC 透传、session 冻结和 Dashboard 控件；本 PR 补齐其中遗漏的中央 Dashboard 读取/刷新回显链路。

TraeX Bot 在 Dashboard 保存 Backend Variant 后，daemon 的 `/api/bot-default-oncall` 会正确返回 `modelBackendVariant`，但中央 Dashboard 聚合 `/api/bots` 时没有继续投影该字段。页面依靠保存响应做的本地更新会暂时显示正确，刷新或重新打开后却回落为“继承默认”。

## 修改

- 将 `modelBackendVariant` 纳入中央 Dashboard 的 Bot agent 配置兜底字段和私有 Bot Defaults payload。
- 聚合 daemon 响应时区分字段缺失与显式 `null`：
  - 老 daemon 未返回字段时，兼容地使用 `bots.json` fallback；
  - 新 daemon 显式返回 `null` 时，以其为准，不复活 stale fallback。
- 新增真实 Dashboard HTTP round-trip 回归测试，覆盖：
  - 老 daemon 字段缺失时的 fallback；
  - 保存 `max` 后重新 GET `/api/bots` 仍正确回显；
  - 清回默认后重新 GET 不再出现旧 variant。

## 与 #1144 的关系

我们注意到 #1144 的最新 head 在解决原生子代理运行时策略时，也已经独立补入了 `modelBackendVariant` 的中央 Dashboard 聚合投影，因此两者在 `src/dashboard.ts` 和 payload contract 测试上存在少量重叠。

仍保留本 PR 的考虑是：

- 本 PR 是针对 #1201 回显缺口的 4 文件小修复，可以独立 review、验证和合入，不需要等待 #1144 的大范围功能改动。
- 本 PR 对 daemon 返回值做 `standard | max` 的严格过滤，并明确保留“字段缺失走旧 daemon fallback、显式 `null` 以 daemon 为准”的兼容语义。
- 本 PR 新增了 #1144 当前没有的真实 Dashboard HTTP round-trip 测试，覆盖旧 daemon fallback、保存后刷新以及清空后不复活旧值。

建议先合本 PR，再由 #1144 rebase 最新 `master`；消解冲突时同时保留本 PR 的 variant 语义/round-trip 测试和 #1144 的 `nativeSubagentRuntime` 字段。如果 #1144 先合，则可将上述严格校验与 round-trip 测试移植到 #1144 后关闭本 PR。

## 影响面

仅补齐 #1201 的受管理 Bot Defaults 聚合读取链路，不改变 TraeX PTY/RPC 启动参数、session 冻结语义、其他 CLI 或公开 roster payload。

## 验证

```bash
/data00/home/tan.yuanhong/.bun/bin/bun x vitest run --project unit \
  test/dashboard-bot-payload.test.ts \
  test/dashboard-bot-agent-roundtrip.integration.test.ts \
  test/dashboard-bot-defaults-cliid.test.ts \
  test/dashboard-ipc.test.ts
```

结果：4 个文件通过，271 个测试通过，1 个按既有条件跳过。

```bash
PATH=/data00/home/tan.yuanhong/.bun/bin:$PATH bun run build
```

结果：TypeScript、脚本类型检查、Dashboard bundle 与产物审计全部通过。
