### PR TITLE
feat(dispatch): 建立目标端启动传输与恢复链路

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -23,6 +23,7 @@ import type { BotSkillPolicy, SkillSelector } from './core/skills/types.js';
 import { normalizeStartupCommandList } from './core/startup-commands.js';
 import { DAEMON_COMMANDS } from './core/passthrough-commands.js';
 import { sanitizePerBotEnv } from './core/per-bot-env.js';
+import { normalizeDispatchLaunchPolicy } from './core/dispatch-launch-contract.js';
 import { resolveBotmuxConfigDir, resolveBotsConfigFile, type BotsConfigProvenance } from './core/config-dir.js';
 import { normalizeSubstituteMode } from './services/substitute-mode-normalize.js';
 import { normalizeCommandTriggers } from './services/command-trigger-normalize.js';
@@ -1370,6 +1371,8 @@ export interface BotConfig {
    * 缺省 / false 保持原有飞书 bot 行为字节不变。
    */
   apiOnly?: boolean;
+  /** Internal, opt-in target policy for dispatch launch IPC. Absent/disabled fails closed. */
+  dispatchLaunchPolicy?: import('./core/dispatch-launch-contract.js').DispatchLaunchPolicyV1;
   /** Final-answer feedback policy. Missing/disabled is intentionally inert. */
   feedback?: FeedbackPolicyInput | FeedbackPolicy;
   /** Per-chat final-answer feedback overrides, scoped to this bot app id. */
@@ -1771,6 +1774,8 @@ export interface BotConfig {
    * used 达到 limit 后自动收回**对应 scope** 的授权并删除本记录。纯 talk-only。
    */
   quotaState?: { [quotaKey: string]: { limit: number; used: number } };
+  /** Internal exactly-once receipts for dispatch-launch quota charges. */
+  dispatchLaunchQuotaReceipts?: { [receiptId: string]: { allow: boolean; chargedAt: string } };
   /**
    * scope-aware 授权绝对过期时间。缺少对应记录表示永久授权；旧配置因此保持兼容。
    * key 与 quotaState 相同，便于授权、撤销和到期回收在同一 scope 上原子处理。
@@ -3328,6 +3333,20 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       if (Object.keys(out).length > 0) quotaState = out;
     }
 
+    let dispatchLaunchQuotaReceipts: { [k: string]: { allow: boolean; chargedAt: string } } | undefined;
+    if (entry.dispatchLaunchQuotaReceipts && typeof entry.dispatchLaunchQuotaReceipts === 'object'
+        && !Array.isArray(entry.dispatchLaunchQuotaReceipts)) {
+      const out: { [k: string]: { allow: boolean; chargedAt: string } } = {};
+      for (const [key, value] of Object.entries(entry.dispatchLaunchQuotaReceipts)) {
+        if (!/^quota_[0-9a-f]{32}$/.test(key) || !value || typeof value !== 'object') continue;
+        const allow = (value as any).allow;
+        const chargedAt = (value as any).chargedAt;
+        if (typeof allow !== 'boolean' || typeof chargedAt !== 'string' || !Number.isFinite(Date.parse(chargedAt))) continue;
+        out[key] = { allow, chargedAt };
+      }
+      if (Object.keys(out).length > 0) dispatchLaunchQuotaReceipts = out;
+    }
+
     let grantExpiryState: { [k: string]: { expiresAt: number } } | undefined;
     if (entry.grantExpiryState && typeof entry.grantExpiryState === 'object' && !Array.isArray(entry.grantExpiryState)) {
       const out: { [k: string]: { expiresAt: number } } = {};
@@ -3483,6 +3502,18 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       // upload etc. already degrade gracefully on an empty secret.
       larkAppSecret: entry.larkAppSecret ?? '',
       apiOnly: entry.apiOnly === true || undefined,
+      dispatchLaunchPolicy: (() => {
+        if (!entry.dispatchLaunchPolicy || typeof entry.dispatchLaunchPolicy !== 'object') return undefined;
+        try {
+          return normalizeDispatchLaunchPolicy(entry.dispatchLaunchPolicy);
+        } catch (error) {
+          logger.warn(
+            `[bot-registry:${entry.larkAppId}] ignoring invalid dispatchLaunchPolicy: `
+            + `${error instanceof Error ? error.message : String(error)}`,
+          );
+          return undefined;
+        }
+      })(),
       feedback: entry.feedback === undefined
         ? undefined
         : normalizeFeedbackPolicyLayer(entry.feedback),
@@ -3592,6 +3623,7 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       messageQuota,
       grantDefaultDurationMs,
       quotaState,
+      dispatchLaunchQuotaReceipts,
       grantExpiryState,
       restrictGrantCommands: entry.restrictGrantCommands === true || undefined,
       // Default is ON, so only explicit false is meaningful/persisted.

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -8,6 +8,7 @@ import { logger } from '../utils/logger.js';
 import { cliAuthBind, loadDashboardSecret, verifyHmac } from '../dashboard/auth.js';
 import { UnsafeHostAuthorityFileError } from '../platform/secure-host-file.js';
 import { WORKFLOW_DAEMON_IPC_ROUTE_PREFIX } from '../workflows/v3/daemon-ipc-auth.js';
+import { DISPATCH_LAUNCH_IPC_ROUTE_PREFIX } from './dispatch-launch-ipc-auth.js';
 import { V3_SESSION_RUN_MUTATION_ROUTE_PREFIX } from '../workflows/v3/session-relay.js';
 import { REPORT_SESSION_RELAY_ROUTE } from './report-session-relay.js';
 import { DISPATCH_REPORT_REGISTER_ROUTE } from './dispatch-report-binding.js';
@@ -763,7 +764,19 @@ function routeIsCoreOnlyPublic(method: string, pathname: string): boolean {
   return false;
 }
 
-function routeHasNarrowUntrustedAuth(method: string, pathname: string): boolean {
+export function routeHasNarrowUntrustedAuth(method: string, pathname: string): boolean {
+  // Dispatch-launch daemon traffic carries its own full-envelope HMAC bound to
+  // the target app, bound port, boot instance, method, path and exact body.
+  // Let those handlers authenticate it instead of requiring the unrelated
+  // dashboard trusted-host envelope first.
+  const dispatchMatch = pathname.match(new RegExp(
+    `^${DISPATCH_LAUNCH_IPC_ROUTE_PREFIX}/(dl_[0-9a-f]{32})(?:/(prepare|start|cancel))?$`,
+  ));
+  if (dispatchMatch) {
+    const action = dispatchMatch[2];
+    if ((method === 'GET' && action === undefined)
+        || (method === 'POST' && action !== undefined)) return true;
+  }
   // The receiver action endpoint performs its own rotating worker-capability
   // verification and then enters the durable action ledger. Keeping this one
   // aperture is what preserves managed meeting actions from inside bwrap.

--- a/src/core/dispatch-launch-admission-store.ts
+++ b/src/core/dispatch-launch-admission-store.ts
@@ -1,0 +1,162 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { withFileLockSync } from '../utils/file-lock.js';
+import {
+  DISPATCH_LAUNCH_ID_RE,
+  parseDispatchLaunchAdmissionReceipt,
+  type DispatchLaunchAdmissionReceiptV1,
+} from './dispatch-launch-contract.js';
+
+function ownerDirectory(dataDir: string, targetLarkAppId: string): string {
+  return join(
+    dataDir,
+    'dispatch-launch',
+    'admissions',
+    createHash('sha256').update(targetLarkAppId).digest('hex'),
+  );
+}
+
+function receiptPath(dataDir: string, targetLarkAppId: string, dispatchId: string): string {
+  if (!DISPATCH_LAUNCH_ID_RE.test(dispatchId)) throw new Error('invalid dispatch launch id');
+  return join(ownerDirectory(dataDir, targetLarkAppId), `${dispatchId}.json`);
+}
+
+function readReceipt(path: string): DispatchLaunchAdmissionReceiptV1 | undefined {
+  if (!existsSync(path)) return undefined;
+  return parseDispatchLaunchAdmissionReceipt(JSON.parse(readFileSync(path, 'utf8')));
+}
+
+function writeReceipt(path: string, receipt: DispatchLaunchAdmissionReceiptV1): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  atomicWriteFileSync(path, `${JSON.stringify(receipt, null, 2)}\n`, {
+    mode: 0o600,
+    durable: true,
+    followTargetSymlink: false,
+  });
+}
+
+function immutableIdentity(receipt: DispatchLaunchAdmissionReceiptV1): string {
+  return JSON.stringify({
+    dispatchId: receipt.dispatchId,
+    sourceLarkAppId: receipt.sourceLarkAppId,
+    sourceSessionId: receipt.sourceSessionId,
+    sourceTurnId: receipt.sourceTurnId,
+    callerUnionId: receipt.callerUnionId,
+    sourceOpenId: receipt.sourceOpenId,
+    chatType: receipt.chatType,
+    talkReason: receipt.talkReason,
+    quotaKey: receipt.quotaKey,
+    grantChatId: receipt.grantChatId,
+    chatId: receipt.chatId,
+    targetLarkAppId: receipt.targetLarkAppId,
+    policyDigest: receipt.policyDigest,
+    effectiveOverride: receipt.effectiveOverride,
+    launchIdentity: receipt.launchIdentity,
+    talkAuthorizationReceiptId: receipt.talkAuthorizationReceiptId,
+    quotaReceiptId: receipt.quotaReceiptId,
+    workingDir: receipt.workingDir,
+    capacityReservationId: receipt.capacityReservationId,
+    createdAt: receipt.createdAt,
+  });
+}
+
+export class DispatchLaunchAdmissionConflictError extends Error {
+  constructor(message: string, public readonly current?: DispatchLaunchAdmissionReceiptV1) {
+    super(message);
+    this.name = 'DispatchLaunchAdmissionConflictError';
+  }
+}
+
+export interface DispatchLaunchAdmissionStore {
+  get(dispatchId: string): DispatchLaunchAdmissionReceiptV1 | undefined;
+  authorize(receipt: DispatchLaunchAdmissionReceiptV1): { created: boolean; receipt: DispatchLaunchAdmissionReceiptV1 };
+  commit(dispatchId: string, committedAt: string): DispatchLaunchAdmissionReceiptV1;
+  release(dispatchId: string, releasedAt: string): DispatchLaunchAdmissionReceiptV1;
+  listAuthorized(): DispatchLaunchAdmissionReceiptV1[];
+}
+
+/** Target-owned durable receipt. Admission side effects are keyed by dispatchId. */
+export function createDispatchLaunchAdmissionStore(input: {
+  dataDir: string;
+  targetLarkAppId: string;
+}): DispatchLaunchAdmissionStore {
+  const directory = ownerDirectory(input.dataDir, input.targetLarkAppId);
+  const pathFor = (dispatchId: string): string => receiptPath(input.dataDir, input.targetLarkAppId, dispatchId);
+  const assertOwner = (receipt: DispatchLaunchAdmissionReceiptV1): void => {
+    if (receipt.targetLarkAppId !== input.targetLarkAppId) {
+      throw new DispatchLaunchAdmissionConflictError('admission receipt does not belong to this target');
+    }
+  };
+
+  const settle = (dispatchId: string, state: 'committed' | 'released', at: string) => {
+    const path = pathFor(dispatchId);
+    return withFileLockSync(path, () => {
+      const current = readReceipt(path);
+      if (!current) throw new DispatchLaunchAdmissionConflictError('admission receipt does not exist');
+      assertOwner(current);
+      if (current.state === state) return current;
+      if (current.state !== 'authorized') {
+        throw new DispatchLaunchAdmissionConflictError(`cannot ${state} a ${current.state} admission`, current);
+      }
+      const next = parseDispatchLaunchAdmissionReceipt({
+        ...current,
+        state,
+        ...(state === 'committed' ? { committedAt: at } : { releasedAt: at }),
+      });
+      writeReceipt(path, next);
+      return next;
+    });
+  };
+
+  return {
+    get(dispatchId) {
+      const receipt = readReceipt(pathFor(dispatchId));
+      if (receipt) assertOwner(receipt);
+      return receipt;
+    },
+    authorize(rawReceipt) {
+      const receipt = parseDispatchLaunchAdmissionReceipt(rawReceipt);
+      assertOwner(receipt);
+      if (receipt.state !== 'authorized') {
+        throw new DispatchLaunchAdmissionConflictError('new admission receipt must be authorized');
+      }
+      const path = pathFor(receipt.dispatchId);
+      mkdirSync(directory, { recursive: true, mode: 0o700 });
+      return withFileLockSync(path, () => {
+        const existing = readReceipt(path);
+        if (existing) {
+          assertOwner(existing);
+          if (immutableIdentity(existing) !== immutableIdentity(receipt)) {
+            throw new DispatchLaunchAdmissionConflictError(
+              'dispatch id already belongs to a different admission', existing,
+            );
+          }
+          return { created: false, receipt: existing };
+        }
+        writeReceipt(path, receipt);
+        return { created: true, receipt };
+      });
+    },
+    commit(dispatchId, committedAt) {
+      return settle(dispatchId, 'committed', committedAt);
+    },
+    release(dispatchId, releasedAt) {
+      return settle(dispatchId, 'released', releasedAt);
+    },
+    listAuthorized() {
+      if (!existsSync(directory)) return [];
+      const receipts: DispatchLaunchAdmissionReceiptV1[] = [];
+      for (const name of readdirSync(directory).sort()) {
+        if (!name.endsWith('.json')) continue;
+        const receipt = readReceipt(join(directory, name));
+        if (!receipt) continue;
+        assertOwner(receipt);
+        if (receipt.state === 'authorized') receipts.push(receipt);
+      }
+      return receipts;
+    },
+  };
+}

--- a/src/core/dispatch-launch-contract.ts
+++ b/src/core/dispatch-launch-contract.ts
@@ -8,10 +8,7 @@ import {
   type CodexReasoningEffort,
 } from '../services/codex-reasoning-effort.js';
 
-/**
- * Data-only contract for a future target-daemon-authoritative dispatch launch.
- * Nothing in this module is connected to a command, route, or worker launch.
- */
+/** Versioned contract for the internal target-daemon-authoritative dispatch launch path. */
 export const DISPATCH_LAUNCH_PROTOCOL = 'v1' as const;
 export const DISPATCH_LAUNCH_SCHEMA_VERSION = 1 as const;
 export const DISPATCH_LAUNCH_POLICY_SCHEMA_VERSION = 1 as const;
@@ -193,6 +190,7 @@ interface DispatchLaunchOperationBaseV1 {
   sourceLarkAppId: string;
   sourceSessionId: string;
   sourceTurnId: string;
+  callerUnionId?: string;
   targetLarkAppId: string;
   chatId: string;
   kickoff: CanonicalDispatchLaunchKickoff;
@@ -268,9 +266,18 @@ export interface DispatchLaunchAdmissionReceiptV1 {
   sourceTurnId: string;
   /** Cross-app stable caller identity; never substitute an app-scoped open_id. */
   callerUnionId?: string;
+  /** Target-app-scoped identity resolved from live chat membership. */
+  sourceOpenId?: string;
+  chatType?: 'group' | 'p2p';
+  /** Frozen authorization facts; optional for receipts written by older builds. */
+  talkReason?: string;
+  quotaKey?: string;
+  grantChatId?: string;
   chatId: string;
   targetLarkAppId: string;
   policyDigest: string;
+  effectiveOverride?: DispatchLaunchEffectiveOverride;
+  launchIdentity?: DispatchLaunchIdentityV1;
   talkAuthorizationReceiptId: string;
   quotaReceiptId: string;
   workingDir: string;
@@ -423,6 +430,10 @@ const dispatchLaunchOperationBaseShape = {
   sourceLarkAppId: larkAppIdSchema,
   sourceSessionId: identifierSchema,
   sourceTurnId: identifierSchema,
+  callerUnionId: nonEmptyString
+    .max(DISPATCH_LAUNCH_CONTROL_LIMITS.callerUnionIdChars)
+    .regex(/^on_[A-Za-z0-9]+$/, 'must be a Lark union_id')
+    .optional(),
   targetLarkAppId: larkAppIdSchema,
   chatId: identifierSchema,
   kickoff: canonicalKickoffSchema,
@@ -563,9 +574,16 @@ export const DispatchLaunchAdmissionReceiptSchema = z.object({
     .max(DISPATCH_LAUNCH_CONTROL_LIMITS.callerUnionIdChars)
     .regex(/^on_[A-Za-z0-9]+$/, 'must be a Lark union_id')
     .optional(),
+  sourceOpenId: nonEmptyString.max(DISPATCH_LAUNCH_CONTROL_LIMITS.identifierChars).optional(),
+  chatType: z.enum(['group', 'p2p']).optional(),
+  talkReason: identifierSchema.optional(),
+  quotaKey: controlledString(DISPATCH_LAUNCH_CONTROL_LIMITS.identifierChars).optional(),
+  grantChatId: identifierSchema.optional(),
   chatId: identifierSchema,
   targetLarkAppId: larkAppIdSchema,
   policyDigest: digestSchema,
+  effectiveOverride: effectiveOverrideSchema.optional(),
+  launchIdentity: launchIdentitySchema.optional(),
   talkAuthorizationReceiptId: identifierSchema,
   quotaReceiptId: identifierSchema,
   workingDir: controlledString(DISPATCH_LAUNCH_CONTROL_LIMITS.workingDirChars),
@@ -830,8 +848,14 @@ export function parseDispatchLaunchAdmissionReceipt(raw: unknown): DispatchLaunc
   if (parsed.state === 'committed' && parsed.committedAt === undefined) {
     throw new Error('invalid dispatch launch admission receipt: committedAt is required');
   }
+  if (parsed.state === 'committed' && parsed.releasedAt !== undefined) {
+    throw new Error('invalid dispatch launch admission receipt: committed receipt must not be released');
+  }
   if (parsed.state === 'released' && parsed.releasedAt === undefined) {
     throw new Error('invalid dispatch launch admission receipt: releasedAt is required');
+  }
+  if (parsed.state === 'released' && parsed.committedAt !== undefined) {
+    throw new Error('invalid dispatch launch admission receipt: released receipt must not be committed');
   }
   return parsed;
 }

--- a/src/core/dispatch-launch-contract.ts
+++ b/src/core/dispatch-launch-contract.ts
@@ -103,6 +103,11 @@ export interface CanonicalDispatchLaunchKickoff {
 export interface DispatchLaunchPolicyV1 {
   schemaVersion: typeof DISPATCH_LAUNCH_POLICY_SCHEMA_VERSION;
   enabled: boolean;
+  /**
+   * Same-host source daemons trusted to request launches and attest the optional
+   * human caller union_id. The target accepts that testimony only through the
+   * authenticated dispatch-launch IPC transport; it is not a bot-trust claim.
+   */
   allowedSourceAppIds: string[];
   allowedModels: string[];
   allowedReasoningEfforts: CodexReasoningEffort[];
@@ -128,7 +133,12 @@ export interface DispatchLaunchPrepareRequestV1 {
     larkAppId: string;
     sessionId: string;
     turnId: string;
-    /** Cross-app stable caller identity; source-app open_id is intentionally not transported. */
+    /**
+     * Source-daemon testimony about the human behind this bot-triggered turn.
+     * The target may accept it only after same-host IPC authentication and an
+     * allowedSourceAppIds policy match. It MUST NOT be used as the source bot's
+     * union_id for bot-talk/team trust; source-app open_id is not transported.
+     */
     callerUnionId?: string;
   };
   targetLarkAppId: string;
@@ -190,6 +200,7 @@ interface DispatchLaunchOperationBaseV1 {
   sourceLarkAppId: string;
   sourceSessionId: string;
   sourceTurnId: string;
+  /** Frozen source testimony; never a target-verified bot identity. */
   callerUnionId?: string;
   targetLarkAppId: string;
   chatId: string;
@@ -264,7 +275,7 @@ export interface DispatchLaunchAdmissionReceiptV1 {
   sourceLarkAppId: string;
   sourceSessionId: string;
   sourceTurnId: string;
-  /** Cross-app stable caller identity; never substitute an app-scoped open_id. */
+  /** Frozen source testimony accepted through the allowed source app trust anchor. */
   callerUnionId?: string;
   /** Target-app-scoped identity resolved from live chat membership. */
   sourceOpenId?: string;

--- a/src/core/dispatch-launch-identity.ts
+++ b/src/core/dispatch-launch-identity.ts
@@ -1,0 +1,46 @@
+import { createHash } from 'node:crypto';
+
+import type { BotConfig } from '../bot-registry.js';
+import { config } from '../config.js';
+import { canonicalJson } from '../utils/canonical-input-hash.js';
+import { resolveCliRuntime, snapshotCliRuntime } from '../adapters/cli/runtime.js';
+import { resolvePairedSpawnBackendType } from './persistent-backend.js';
+import { dispatchLaunchPolicyDigest, type DispatchLaunchIdentityV1 } from './dispatch-launch-contract.js';
+
+function digest(value: unknown): string {
+  return `sha256:${createHash('sha256').update(canonicalJson(value), 'utf8').digest('hex')}`;
+}
+
+/** Freeze exactly the target-controlled launch inputs supported by dispatch launch v1. */
+export function resolveDispatchLaunchIdentity(bot: BotConfig): DispatchLaunchIdentityV1 {
+  const policy = bot.dispatchLaunchPolicy;
+  if (!policy) throw new Error('dispatch launch policy is unavailable');
+  if (bot.cliId !== 'codex' || bot.codexRpcInput === true || bot.existingAppServer !== undefined) {
+    throw new Error('dispatch launch v1 supports only the official Codex TUI');
+  }
+  const runtime = resolveCliRuntime({
+    cliId: bot.cliId, cliRuntime: bot.cliRuntime, cliPathOverride: bot.cliPathOverride,
+    context: 'dispatch launch target',
+  });
+  const backendType = resolvePairedSpawnBackendType(
+    bot.cliId, undefined, bot.backendType, config.daemon.backendType,
+  );
+  if (!['pty', 'tmux', 'herdr', 'zellij', 'zmx'].includes(backendType)) {
+    throw new Error('dispatch launch v1 requires a supported local session backend');
+  }
+  return {
+    cliId: 'codex',
+    cliRuntimeDigest: digest(snapshotCliRuntime(runtime)),
+    executable: runtime?.executable ?? bot.cliPathOverride ?? 'codex',
+    ...(bot.wrapperCli ? { wrapperCli: bot.wrapperCli } : {}),
+    backendType: backendType as DispatchLaunchIdentityV1['backendType'],
+    codexRpcInput: false,
+    existingAppServer: false,
+    botConfigDigest: digest({
+      cliId: bot.cliId, cliRuntime: snapshotCliRuntime(runtime), wrapperCli: bot.wrapperCli ?? null,
+      backendType, model: bot.model ?? null, reasoningEffort: bot.reasoningEffort ?? null,
+      workingDir: bot.defaultWorkingDir ?? bot.workingDir ?? null,
+    }),
+    policyDigest: dispatchLaunchPolicyDigest(policy),
+  };
+}

--- a/src/core/dispatch-launch-ipc-auth.ts
+++ b/src/core/dispatch-launch-ipc-auth.ts
@@ -1,4 +1,8 @@
-import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import type { IncomingMessage } from 'node:http';
+
+import { dashboardSecretPath } from './dashboard-secret.js';
+import { loadDashboardSecret } from '../dashboard/auth.js';
 
 export const DISPATCH_LAUNCH_IPC_DOMAIN = 'botmux-dispatch-launch-ipc/v1';
 export const DISPATCH_LAUNCH_IPC_RESPONSE_DOMAIN = 'botmux-dispatch-launch-ipc/v1/response';
@@ -6,6 +10,7 @@ export const DISPATCH_LAUNCH_IPC_ROUTE_PREFIX = '/__dispatch-launch-ipc/v1/opera
 export const DISPATCH_LAUNCH_IPC_TS_WINDOW_MS = 60_000;
 export const DISPATCH_LAUNCH_IPC_NONCE_TTL_MS = 10 * 60_000;
 export const DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES = 80 * 1024;
+export const DISPATCH_LAUNCH_IPC_BODY_READ_TIMEOUT_MS = 5_000;
 export const DISPATCH_LAUNCH_IPC_HEADERS = {
   timestamp: 'x-botmux-dispatch-launch-ipc-ts',
   nonce: 'x-botmux-dispatch-launch-ipc-nonce',
@@ -14,6 +19,7 @@ export const DISPATCH_LAUNCH_IPC_HEADERS = {
 } as const;
 
 const B64URL_32_BYTES_RE = /^[A-Za-z0-9_-]{43}$/;
+const CANONICAL_EPOCH_MS_RE = /^(?:0|[1-9][0-9]{0,15})$/;
 
 export interface DispatchLaunchIpcTarget {
   larkAppId: string;
@@ -41,6 +47,44 @@ export interface DispatchLaunchIpcResponseSignInput {
   target: DispatchLaunchIpcTarget;
 }
 
+export interface DispatchLaunchIpcClock {
+  now(): number;
+}
+
+export interface DispatchLaunchIpcNonceStore {
+  has(nonce: string): boolean;
+  add(nonce: string, expiresAt: number): void;
+  size(): number;
+}
+
+export type DispatchLaunchIpcVerifyReason =
+  | 'remote_not_loopback'
+  | 'missing_or_malformed_header'
+  | 'timestamp_out_of_window'
+  | 'target_identity_unavailable'
+  | 'body_too_large'
+  | 'body_length_mismatch'
+  | 'body_read_timeout'
+  | 'body_read_failed'
+  | 'body_not_utf8'
+  | 'signature_mismatch'
+  | 'replay';
+
+export type DispatchLaunchIpcVerifyResult =
+  | { ok: true; bodyRaw: string; nonce: string; target: DispatchLaunchIpcTarget }
+  | { ok: false; reason: DispatchLaunchIpcVerifyReason; httpStatus: number };
+
+export interface DispatchLaunchIpcVerifyOptions {
+  secret: string;
+  target: Omit<DispatchLaunchIpcTarget, 'ipcPort'>;
+  nonceStore: DispatchLaunchIpcNonceStore;
+  clock?: DispatchLaunchIpcClock;
+  maxBodyBytes?: number;
+  bodyReadTimeoutMs?: number;
+}
+
+export const dispatchLaunchIpcRealClock: DispatchLaunchIpcClock = { now: () => Date.now() };
+
 function bodyBytes(body: string | Uint8Array): Buffer {
   return typeof body === 'string' ? Buffer.from(body, 'utf8') : Buffer.from(body);
 }
@@ -57,6 +101,87 @@ function validTarget(target: DispatchLaunchIpcTarget): boolean {
 function wireEqual(provided: string | undefined, expected: string): boolean {
   if (!provided || !B64URL_32_BYTES_RE.test(provided) || !B64URL_32_BYTES_RE.test(expected)) return false;
   return timingSafeEqual(Buffer.from(provided, 'base64url'), Buffer.from(expected, 'base64url'));
+}
+
+export function createDispatchLaunchIpcNonceStore(
+  clock: DispatchLaunchIpcClock = dispatchLaunchIpcRealClock,
+): DispatchLaunchIpcNonceStore {
+  const entries = new Map<string, number>();
+  const gc = (): void => {
+    const now = clock.now();
+    for (const [nonce, expiresAt] of entries) {
+      if (expiresAt <= now) entries.delete(nonce);
+    }
+  };
+  return {
+    has(nonce) { gc(); return entries.has(nonce); },
+    add(nonce, expiresAt) { entries.set(nonce, expiresAt); },
+    size() { gc(); return entries.size; },
+  };
+}
+
+function headerString(req: IncomingMessage, name: string): string | undefined {
+  const value = req.headers[name];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function isLoopback(address: string | undefined): boolean {
+  return address === '127.0.0.1' || address === '::1' || Boolean(address?.endsWith('::ffff:127.0.0.1'));
+}
+
+async function readBoundedBody(
+  req: IncomingMessage,
+  maxBytes: number,
+  timeoutMs: number,
+): Promise<
+  | { ok: true; bytes: Buffer }
+  | { ok: false; reason: 'body_too_large' | 'body_length_mismatch' | 'body_read_timeout' | 'body_read_failed' }
+> {
+  const contentLength = headerString(req, 'content-length');
+  const transferEncoding = headerString(req, 'transfer-encoding');
+  if (contentLength !== undefined && transferEncoding !== undefined) {
+    return { ok: false, reason: 'body_length_mismatch' };
+  }
+  let declaredLength: number | undefined;
+  if (contentLength !== undefined) {
+    if (!/^(?:0|[1-9][0-9]*)$/.test(contentLength)) {
+      return { ok: false, reason: 'body_length_mismatch' };
+    }
+    declaredLength = Number(contentLength);
+    if (declaredLength > maxBytes) return { ok: false, reason: 'body_too_large' };
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    req.destroy(new Error('dispatch launch IPC body read timeout'));
+  }, timeoutMs);
+  timer.unref?.();
+  try {
+    for await (const chunk of req) {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
+      total += bytes.length;
+      if (total > maxBytes) return { ok: false, reason: 'body_too_large' };
+      chunks.push(bytes);
+    }
+  } catch {
+    return { ok: false, reason: timedOut ? 'body_read_timeout' : 'body_read_failed' };
+  } finally {
+    clearTimeout(timer);
+  }
+  if (declaredLength !== undefined && declaredLength !== total) {
+    return { ok: false, reason: 'body_length_mismatch' };
+  }
+  return { ok: true, bytes: Buffer.concat(chunks, total) };
+}
+
+function decodeUtf8Strict(bytes: Buffer): string | null {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
 }
 
 /** Exact request bytes, target identity and daemon boot are all in the HMAC audience. */
@@ -142,4 +267,94 @@ export function verifyDispatchLaunchIpcResponseSignature(input: DispatchLaunchIp
   } catch {
     return false;
   }
+}
+
+/** Read and authenticate an inbound request exactly once. */
+export async function verifyDispatchLaunchIpcRequest(
+  req: IncomingMessage,
+  options: DispatchLaunchIpcVerifyOptions,
+): Promise<DispatchLaunchIpcVerifyResult> {
+  if (!isLoopback(req.socket?.remoteAddress)) {
+    return { ok: false, reason: 'remote_not_loopback', httpStatus: 403 };
+  }
+  const timestamp = headerString(req, DISPATCH_LAUNCH_IPC_HEADERS.timestamp);
+  const nonce = headerString(req, DISPATCH_LAUNCH_IPC_HEADERS.nonce);
+  const signature = headerString(req, DISPATCH_LAUNCH_IPC_HEADERS.signature);
+  if (!timestamp || !CANONICAL_EPOCH_MS_RE.test(timestamp) || String(Number(timestamp)) !== timestamp
+      || !nonce || !B64URL_32_BYTES_RE.test(nonce)
+      || !signature || !B64URL_32_BYTES_RE.test(signature)) {
+    return { ok: false, reason: 'missing_or_malformed_header', httpStatus: 401 };
+  }
+  const clock = options.clock ?? dispatchLaunchIpcRealClock;
+  if (Math.abs(clock.now() - Number(timestamp)) > DISPATCH_LAUNCH_IPC_TS_WINDOW_MS) {
+    return { ok: false, reason: 'timestamp_out_of_window', httpStatus: 401 };
+  }
+  const target: DispatchLaunchIpcTarget = {
+    ...options.target,
+    ipcPort: typeof req.socket?.localPort === 'number' ? req.socket.localPort : 0,
+  };
+  if (!validTarget(target)) {
+    return { ok: false, reason: 'target_identity_unavailable', httpStatus: 503 };
+  }
+  const read = await readBoundedBody(
+    req,
+    options.maxBodyBytes ?? DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES,
+    options.bodyReadTimeoutMs ?? DISPATCH_LAUNCH_IPC_BODY_READ_TIMEOUT_MS,
+  );
+  if (!read.ok) {
+    return {
+      ok: false,
+      reason: read.reason,
+      httpStatus: read.reason === 'body_too_large' ? 413 : read.reason === 'body_read_timeout' ? 408 : 400,
+    };
+  }
+  const bodyRaw = decodeUtf8Strict(read.bytes);
+  if (bodyRaw === null) return { ok: false, reason: 'body_not_utf8', httpStatus: 400 };
+  if (options.nonceStore.has(nonce)) return { ok: false, reason: 'replay', httpStatus: 401 };
+  if (!verifyDispatchLaunchIpcRequestSignature({
+    secret: options.secret,
+    timestamp,
+    nonce,
+    method: req.method ?? 'GET',
+    pathWithQuery: req.url ?? '/',
+    body: read.bytes,
+    target,
+    signature,
+  })) {
+    return { ok: false, reason: 'signature_mismatch', httpStatus: 401 };
+  }
+  options.nonceStore.add(nonce, clock.now() + DISPATCH_LAUNCH_IPC_NONCE_TTL_MS);
+  return { ok: true, bodyRaw, nonce, target };
+}
+
+export function generateDispatchLaunchIpcNonce(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+export function loadDispatchLaunchIpcSecret(secretPath = dashboardSecretPath()): string {
+  const secret = loadDashboardSecret(secretPath);
+  if (!secret) throw new Error('dispatch launch IPC secret is unavailable');
+  return secret;
+}
+
+export function dispatchLaunchIpcHeaders(input: {
+  secret: string;
+  method: string;
+  pathWithQuery: string;
+  bodyRaw: string;
+  target: DispatchLaunchIpcTarget;
+  timestamp?: string;
+  nonce?: string;
+}): Record<string, string> {
+  const timestamp = input.timestamp ?? String(Date.now());
+  const nonce = input.nonce ?? generateDispatchLaunchIpcNonce();
+  const signature = signDispatchLaunchIpcRequest({
+    secret: input.secret, timestamp, nonce, method: input.method,
+    pathWithQuery: input.pathWithQuery, body: input.bodyRaw, target: input.target,
+  });
+  return {
+    'X-Botmux-Dispatch-Launch-Ipc-Ts': timestamp,
+    'X-Botmux-Dispatch-Launch-Ipc-Nonce': nonce,
+    'X-Botmux-Dispatch-Launch-Ipc-Signature': signature,
+  };
 }

--- a/src/core/dispatch-launch-ipc-body.ts
+++ b/src/core/dispatch-launch-ipc-body.ts
@@ -1,0 +1,45 @@
+import {
+  parseDispatchLaunchCancelRequest,
+  parseDispatchLaunchPrepareRequest,
+  parseDispatchLaunchStartRequest,
+  type DispatchLaunchCancelRequestV1,
+  type DispatchLaunchPrepareRequestV1,
+  type DispatchLaunchStartRequestV1,
+} from './dispatch-launch-contract.js';
+
+export type DispatchLaunchIpcMutation = 'prepare' | 'start' | 'cancel';
+
+export type DispatchLaunchIpcBody =
+  | { mutation: 'prepare'; value: DispatchLaunchPrepareRequestV1 }
+  | { mutation: 'start'; value: DispatchLaunchStartRequestV1 }
+  | { mutation: 'cancel'; value: DispatchLaunchCancelRequestV1 };
+
+export type DispatchLaunchIpcBodyResult =
+  | { ok: true; body: DispatchLaunchIpcBody }
+  | { ok: false; error: 'bad_json' | 'bad_body' };
+
+/** Parse only canonical JSON, so the bytes authenticated by HMAC have one meaning. */
+export function parseDispatchLaunchIpcBody(
+  mutation: DispatchLaunchIpcMutation,
+  bodyRaw: string,
+): DispatchLaunchIpcBodyResult {
+  let parsed: unknown;
+  if (!bodyRaw) return { ok: false, error: 'bad_json' };
+  try {
+    parsed = JSON.parse(bodyRaw) as unknown;
+  } catch {
+    return { ok: false, error: 'bad_json' };
+  }
+  if (JSON.stringify(parsed) !== bodyRaw) return { ok: false, error: 'bad_json' };
+  try {
+    if (mutation === 'prepare') {
+      return { ok: true, body: { mutation, value: parseDispatchLaunchPrepareRequest(parsed) } };
+    }
+    if (mutation === 'start') {
+      return { ok: true, body: { mutation, value: parseDispatchLaunchStartRequest(parsed) } };
+    }
+    return { ok: true, body: { mutation, value: parseDispatchLaunchCancelRequest(parsed) } };
+  } catch {
+    return { ok: false, error: 'bad_body' };
+  }
+}

--- a/src/core/dispatch-launch-ipc-client.ts
+++ b/src/core/dispatch-launch-ipc-client.ts
@@ -1,0 +1,96 @@
+import type { OnlineDaemonInfo } from '../utils/daemon-discovery.js';
+import { loopbackFetchImpl } from './loopback-fetch.js';
+import {
+  DISPATCH_LAUNCH_IPC_HEADERS,
+  DISPATCH_LAUNCH_IPC_ROUTE_PREFIX,
+  dispatchLaunchIpcHeaders,
+  generateDispatchLaunchIpcNonce,
+  loadDispatchLaunchIpcSecret,
+  verifyDispatchLaunchIpcResponseSignature,
+  type DispatchLaunchIpcTarget,
+} from './dispatch-launch-ipc-auth.js';
+import type { DispatchLaunchIpcMutation } from './dispatch-launch-ipc-body.js';
+
+export interface DispatchLaunchIpcResponse {
+  ok: boolean;
+  status: number;
+  bodyRaw: string;
+}
+
+export class DispatchLaunchIpcTransportError extends Error {
+  constructor(message: string, public readonly causeValue?: unknown) {
+    super(message);
+    this.name = 'DispatchLaunchIpcTransportError';
+  }
+}
+
+export function dispatchLaunchIpcTarget(
+  daemon: Pick<OnlineDaemonInfo, 'larkAppId' | 'ipcPort' | 'bootInstanceId' | 'dispatchLaunchIpcProtocol'>,
+): DispatchLaunchIpcTarget {
+  if (daemon.dispatchLaunchIpcProtocol !== 'v1' || !daemon.bootInstanceId) {
+    throw new DispatchLaunchIpcTransportError(
+      `daemon ${daemon.larkAppId} does not advertise dispatch launch IPC v1`,
+    );
+  }
+  return {
+    larkAppId: daemon.larkAppId,
+    ipcPort: daemon.ipcPort,
+    bootInstanceId: daemon.bootInstanceId,
+  };
+}
+
+export function dispatchLaunchIpcPath(dispatchId: string, action?: DispatchLaunchIpcMutation): string {
+  if (!/^dl_[0-9a-f]{32}$/.test(dispatchId)) {
+    throw new DispatchLaunchIpcTransportError('invalid dispatch launch id');
+  }
+  const base = `${DISPATCH_LAUNCH_IPC_ROUTE_PREFIX}/${encodeURIComponent(dispatchId)}`;
+  return action ? `${base}/${action}` : base;
+}
+
+/** One authenticated attempt. Callers reconcile an uncertain response through GET query. */
+export async function requestDispatchLaunchIpc(input: {
+  daemon: Pick<OnlineDaemonInfo, 'larkAppId' | 'ipcPort' | 'bootInstanceId' | 'dispatchLaunchIpcProtocol'>;
+  dispatchId: string;
+  action?: DispatchLaunchIpcMutation;
+  body?: unknown;
+  secret?: string;
+  secretPath?: string;
+  fetchImpl?: typeof fetch;
+  timestamp?: string;
+  nonce?: string;
+}): Promise<DispatchLaunchIpcResponse> {
+  const target = dispatchLaunchIpcTarget(input.daemon);
+  const secret = input.secret ?? loadDispatchLaunchIpcSecret(input.secretPath);
+  const pathWithQuery = dispatchLaunchIpcPath(input.dispatchId, input.action);
+  const method = input.action ? 'POST' : 'GET';
+  const bodyRaw = input.action ? JSON.stringify(input.body ?? {}) : '';
+  const nonce = input.nonce ?? generateDispatchLaunchIpcNonce();
+  const headers = dispatchLaunchIpcHeaders({
+    secret, method, pathWithQuery, bodyRaw, target,
+    timestamp: input.timestamp, nonce,
+  });
+  let response: Response;
+  try {
+    response = await (input.fetchImpl ?? loopbackFetchImpl)(
+      `http://127.0.0.1:${target.ipcPort}${pathWithQuery}`,
+      {
+        method,
+        headers: { 'content-type': 'application/json', ...headers },
+        ...(input.action ? { body: bodyRaw } : {}),
+      },
+    );
+  } catch (error) {
+    throw new DispatchLaunchIpcTransportError(
+      `cannot connect to dispatch launch daemon on port ${target.ipcPort}`, error,
+    );
+  }
+  const responseBodyRaw = await response.text();
+  if (!verifyDispatchLaunchIpcResponseSignature({
+    secret, requestNonce: nonce, method, pathWithQuery, status: response.status,
+    body: responseBodyRaw, target,
+    signature: response.headers.get(DISPATCH_LAUNCH_IPC_HEADERS.responseSignature) ?? undefined,
+  })) {
+    throw new DispatchLaunchIpcTransportError('dispatch launch daemon response authentication failed');
+  }
+  return { ok: response.ok, status: response.status, bodyRaw: responseBodyRaw };
+}

--- a/src/core/dispatch-launch-operation-store.ts
+++ b/src/core/dispatch-launch-operation-store.ts
@@ -1,0 +1,189 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { withFileLockSync } from '../utils/file-lock.js';
+import {
+  DISPATCH_LAUNCH_ID_RE,
+  parseDispatchLaunchOperation,
+  type DispatchLaunchOperationV1,
+  type DispatchLaunchOperationState,
+} from './dispatch-launch-contract.js';
+
+const TERMINAL_STATES = new Set<DispatchLaunchOperationState>([
+  'succeeded', 'failed', 'cancelled', 'delivery_unknown',
+]);
+
+const ALLOWED_TRANSITIONS: Readonly<Record<DispatchLaunchOperationState, readonly DispatchLaunchOperationState[]>> = {
+  created: ['preparing', 'failed', 'cancelled'],
+  preparing: ['prepared', 'failed', 'cancelled'],
+  prepared: ['starting', 'failed', 'cancelled'],
+  // Same-state checkpoints durably publish root/session/generation one at a
+  // time. They are what makes recovery safe at every external side-effect.
+  starting: ['starting', 'awaiting_proof', 'failed', 'cancelled', 'delivery_unknown'],
+  awaiting_proof: ['succeeded', 'failed', 'cancelled', 'delivery_unknown'],
+  succeeded: [],
+  failed: [],
+  cancelled: [],
+  delivery_unknown: [],
+};
+
+function ownerDirectory(dataDir: string, ownerLarkAppId: string): string {
+  return join(
+    dataDir,
+    'dispatch-launch',
+    'operations',
+    createHash('sha256').update(ownerLarkAppId).digest('hex'),
+  );
+}
+
+function operationPath(dataDir: string, ownerLarkAppId: string, dispatchId: string): string {
+  if (!DISPATCH_LAUNCH_ID_RE.test(dispatchId)) throw new Error('invalid dispatch launch id');
+  return join(ownerDirectory(dataDir, ownerLarkAppId), `${dispatchId}.json`);
+}
+
+function readOperation(path: string): DispatchLaunchOperationV1 | undefined {
+  if (!existsSync(path)) return undefined;
+  return parseDispatchLaunchOperation(JSON.parse(readFileSync(path, 'utf8')));
+}
+
+function writeOperation(path: string, operation: DispatchLaunchOperationV1): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  atomicWriteFileSync(path, `${JSON.stringify(operation, null, 2)}\n`, {
+    mode: 0o600,
+    durable: true,
+    followTargetSymlink: false,
+  });
+}
+
+function sameIdentity(left: DispatchLaunchOperationV1, right: DispatchLaunchOperationV1): boolean {
+  return left.dispatchId === right.dispatchId
+    && left.owner === right.owner
+    && left.sourceLarkAppId === right.sourceLarkAppId
+    && left.sourceSessionId === right.sourceSessionId
+    && left.sourceTurnId === right.sourceTurnId
+    && left.callerUnionId === right.callerUnionId
+    && left.targetLarkAppId === right.targetLarkAppId
+    && left.chatId === right.chatId
+    && left.kickoff.digest === right.kickoff.digest
+    && JSON.stringify(left.requestedOverride) === JSON.stringify(right.requestedOverride)
+    && left.expiresAt === right.expiresAt;
+}
+
+function samePreparedIdentity(left: DispatchLaunchOperationV1, right: DispatchLaunchOperationV1): boolean {
+  if (!('effectiveOverride' in left) || left.effectiveOverride === undefined) return true;
+  return 'effectiveOverride' in right
+    && right.effectiveOverride !== undefined
+    && JSON.stringify(left.effectiveOverride) === JSON.stringify(right.effectiveOverride)
+    && JSON.stringify(left.launchIdentity) === JSON.stringify(right.launchIdentity);
+}
+
+export class DispatchLaunchOperationConflictError extends Error {
+  constructor(message: string, public readonly current?: DispatchLaunchOperationV1) {
+    super(message);
+    this.name = 'DispatchLaunchOperationConflictError';
+  }
+}
+
+export interface DispatchLaunchOperationStore {
+  get(dispatchId: string): DispatchLaunchOperationV1 | undefined;
+  create(operation: DispatchLaunchOperationV1): { created: boolean; operation: DispatchLaunchOperationV1 };
+  transition(input: {
+    dispatchId: string;
+    expectedState: DispatchLaunchOperationState | readonly DispatchLaunchOperationState[];
+    next: DispatchLaunchOperationV1;
+  }): DispatchLaunchOperationV1;
+  listRecoverable(): DispatchLaunchOperationV1[];
+}
+
+/** Durable, per-owner CAS store. A daemon must construct this only for its own app id. */
+export function createDispatchLaunchOperationStore(input: {
+  dataDir: string;
+  ownerLarkAppId: string;
+}): DispatchLaunchOperationStore {
+  const directory = ownerDirectory(input.dataDir, input.ownerLarkAppId);
+  const pathFor = (dispatchId: string): string => operationPath(input.dataDir, input.ownerLarkAppId, dispatchId);
+  const assertOwner = (operation: DispatchLaunchOperationV1): void => {
+    if (operation.owner !== 'source' && operation.owner !== 'target') {
+      throw new DispatchLaunchOperationConflictError('operation owner is invalid');
+    }
+    const expectedOwner = operation.owner === 'source'
+      ? operation.sourceLarkAppId
+      : operation.targetLarkAppId;
+    if (expectedOwner !== input.ownerLarkAppId) {
+      throw new DispatchLaunchOperationConflictError('operation does not belong to this daemon');
+    }
+  };
+
+  return {
+    get(dispatchId) {
+      const operation = readOperation(pathFor(dispatchId));
+      if (operation) assertOwner(operation);
+      return operation;
+    },
+    create(rawOperation) {
+      const operation = parseDispatchLaunchOperation(rawOperation);
+      assertOwner(operation);
+      const path = pathFor(operation.dispatchId);
+      mkdirSync(directory, { recursive: true, mode: 0o700 });
+      return withFileLockSync(path, () => {
+        const existing = readOperation(path);
+        if (existing) {
+          assertOwner(existing);
+          if (!sameIdentity(existing, operation)) {
+            throw new DispatchLaunchOperationConflictError(
+              'dispatch id already belongs to a different operation', existing,
+            );
+          }
+          return { created: false, operation: existing };
+        }
+        writeOperation(path, operation);
+        return { created: true, operation };
+      });
+    },
+    transition({ dispatchId, expectedState, next: rawNext }) {
+      const next = parseDispatchLaunchOperation(rawNext);
+      assertOwner(next);
+      if (next.dispatchId !== dispatchId) {
+        throw new DispatchLaunchOperationConflictError('transition changed dispatch id');
+      }
+      const expectedStates = Array.isArray(expectedState) ? expectedState : [expectedState];
+      const path = pathFor(dispatchId);
+      return withFileLockSync(path, () => {
+        const current = readOperation(path);
+        if (!current) throw new DispatchLaunchOperationConflictError('operation does not exist');
+        assertOwner(current);
+        if (!sameIdentity(current, next)) {
+          throw new DispatchLaunchOperationConflictError('transition changed immutable operation identity', current);
+        }
+        if (!samePreparedIdentity(current, next)) {
+          throw new DispatchLaunchOperationConflictError('transition changed prepared launch identity', current);
+        }
+        if (!expectedStates.includes(current.state)) {
+          throw new DispatchLaunchOperationConflictError(`expected state ${expectedStates.join('|')}, got ${current.state}`, current);
+        }
+        if (!ALLOWED_TRANSITIONS[current.state].includes(next.state)) {
+          throw new DispatchLaunchOperationConflictError(`illegal transition ${current.state} -> ${next.state}`, current);
+        }
+        if (Date.parse(next.updatedAt) < Date.parse(current.updatedAt)) {
+          throw new DispatchLaunchOperationConflictError('updatedAt moved backwards', current);
+        }
+        writeOperation(path, next);
+        return next;
+      });
+    },
+    listRecoverable() {
+      if (!existsSync(directory)) return [];
+      const operations: DispatchLaunchOperationV1[] = [];
+      for (const name of readdirSync(directory).sort()) {
+        if (!name.endsWith('.json')) continue;
+        const operation = readOperation(join(directory, name));
+        if (!operation) continue;
+        assertOwner(operation);
+        if (!TERMINAL_STATES.has(operation.state)) operations.push(operation);
+      }
+      return operations;
+    },
+  };
+}

--- a/src/core/dispatch-launch-source.ts
+++ b/src/core/dispatch-launch-source.ts
@@ -1,0 +1,171 @@
+import {
+  DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION,
+  DISPATCH_LAUNCH_SCHEMA_VERSION,
+  dispatchLaunchIdentityDigest,
+  parseDispatchLaunchOperation,
+  type DispatchLaunchFailure,
+  type DispatchLaunchOperationV1,
+  type DispatchLaunchPrepareRequestV1,
+} from './dispatch-launch-contract.js';
+import type { DispatchLaunchOperationStore } from './dispatch-launch-operation-store.js';
+import { requestDispatchLaunchIpc, type DispatchLaunchIpcResponse } from './dispatch-launch-ipc-client.js';
+import type { OnlineDaemonInfo } from '../utils/daemon-discovery.js';
+
+export interface DispatchLaunchSourceDependencies {
+  sourceLarkAppId: string;
+  store: DispatchLaunchOperationStore;
+  targetDaemon: Pick<OnlineDaemonInfo, 'larkAppId' | 'ipcPort' | 'bootInstanceId' | 'dispatchLaunchIpcProtocol'>;
+  now(): Date;
+  request?(input: Parameters<typeof requestDispatchLaunchIpc>[0]): Promise<DispatchLaunchIpcResponse>;
+}
+
+function decodeResponse(response: DispatchLaunchIpcResponse):
+  | { ok: true; operation: DispatchLaunchOperationV1 }
+  | DispatchLaunchFailure {
+  const raw = JSON.parse(response.bodyRaw) as unknown;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('invalid dispatch launch IPC response');
+  const value = raw as Record<string, unknown>;
+  if (value.ok === true) return { ok: true, operation: parseDispatchLaunchOperation(value.operation) };
+  if (value.ok === false && typeof value.errorCode === 'string' && typeof value.message === 'string') {
+    return value as unknown as DispatchLaunchFailure;
+  }
+  throw new Error('invalid dispatch launch IPC response');
+}
+
+/** Durable source-side driver. Transport errors intentionally leave a recoverable state. */
+export interface DispatchLaunchSourceCoordinator {
+  create(request: DispatchLaunchPrepareRequestV1): DispatchLaunchOperationV1;
+  prepare(request: DispatchLaunchPrepareRequestV1): Promise<{ ok: true; operation: DispatchLaunchOperationV1 } | DispatchLaunchFailure>;
+  start(dispatchId: string): Promise<{ ok: true; operation: DispatchLaunchOperationV1 } | DispatchLaunchFailure>;
+  query(dispatchId: string): Promise<{ ok: true; operation: DispatchLaunchOperationV1 } | DispatchLaunchFailure>;
+  recover(): Promise<void>;
+}
+
+export function createDispatchLaunchSourceCoordinator(deps: DispatchLaunchSourceDependencies): DispatchLaunchSourceCoordinator {
+  const invoke = deps.request ?? requestDispatchLaunchIpc;
+  const validateRequestAuthority = (request: DispatchLaunchPrepareRequestV1): void => {
+    if (request.source.larkAppId !== deps.sourceLarkAppId) {
+      throw new Error('dispatch launch source app id mismatch');
+    }
+    if (request.targetLarkAppId !== deps.targetDaemon.larkAppId) {
+      throw new Error('dispatch launch target descriptor mismatch');
+    }
+    if (deps.targetDaemon.dispatchLaunchIpcProtocol !== 'v1' || !deps.targetDaemon.bootInstanceId) {
+      throw new Error('dispatch launch target does not advertise IPC v1');
+    }
+  };
+  const toSource = (target: DispatchLaunchOperationV1, current: DispatchLaunchOperationV1): DispatchLaunchOperationV1 => ({
+    ...target, owner: 'source', createdAt: current.createdAt, updatedAt: deps.now().toISOString(),
+  });
+  const validatePeer = (target: DispatchLaunchOperationV1, source: DispatchLaunchOperationV1): void => {
+    if (target.owner !== 'target' || target.dispatchId !== source.dispatchId
+        || target.sourceLarkAppId !== source.sourceLarkAppId
+        || target.sourceSessionId !== source.sourceSessionId
+        || target.sourceTurnId !== source.sourceTurnId
+        || target.targetLarkAppId !== source.targetLarkAppId
+        || target.chatId !== source.chatId || target.kickoff.digest !== source.kickoff.digest) {
+      throw new Error('target operation identity mismatch');
+    }
+  };
+  const create = (request: DispatchLaunchPrepareRequestV1): DispatchLaunchOperationV1 => {
+    validateRequestAuthority(request);
+    return deps.store.create({
+      schemaVersion: DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION, dispatchId: request.dispatchId, owner: 'source',
+      sourceLarkAppId: request.source.larkAppId, sourceSessionId: request.source.sessionId,
+      sourceTurnId: request.source.turnId, ...(request.source.callerUnionId ? { callerUnionId: request.source.callerUnionId } : {}),
+      targetLarkAppId: request.targetLarkAppId, chatId: request.chatId, kickoff: request.kickoff,
+      requestedOverride: request.requestedOverride, createdAt: deps.now().toISOString(),
+      updatedAt: deps.now().toISOString(), expiresAt: request.expiresAt, state: 'created',
+    }).operation;
+  };
+
+  const query = async (dispatchId: string) => {
+    const source = deps.store.get(dispatchId);
+    if (!source) return { ok: false as const, errorCode: 'OPERATION_NOT_FOUND' as const, message: 'operation does not exist' };
+    if (source.targetLarkAppId !== deps.targetDaemon.larkAppId) {
+      throw new Error('dispatch launch target descriptor mismatch');
+    }
+    const result = decodeResponse(await invoke({ daemon: deps.targetDaemon, dispatchId }));
+    if (result.ok) validatePeer(result.operation, source);
+    return result;
+  };
+
+  const prepare = async (request: DispatchLaunchPrepareRequestV1) => {
+    let operation = create(request);
+    if (operation.state === 'created') operation = deps.store.transition({
+      dispatchId: operation.dispatchId, expectedState: 'created',
+      next: { ...operation, state: 'preparing', updatedAt: deps.now().toISOString() },
+    });
+    if (operation.state !== 'preparing') return { ok: true as const, operation };
+    const result = decodeResponse(await invoke({ daemon: deps.targetDaemon, dispatchId: request.dispatchId, action: 'prepare', body: request }));
+    if (!result.ok) {
+      deps.store.transition({
+        dispatchId: operation.dispatchId, expectedState: 'preparing',
+        next: { ...operation, state: 'failed', errorCode: result.errorCode, updatedAt: deps.now().toISOString() },
+      });
+      return result;
+    }
+    validatePeer(result.operation, operation);
+    if (result.operation.state !== 'prepared') throw new Error(`target prepare returned ${result.operation.state}`);
+    return { ok: true as const, operation: deps.store.transition({
+      dispatchId: operation.dispatchId, expectedState: 'preparing', next: toSource(result.operation, operation),
+    }) };
+  };
+
+  const start = async (dispatchId: string) => {
+    let operation = deps.store.get(dispatchId);
+    if (!operation) return { ok: false as const, errorCode: 'OPERATION_NOT_FOUND' as const, message: 'operation does not exist' };
+    if (operation.state === 'awaiting_proof' || ['succeeded', 'failed', 'cancelled', 'delivery_unknown'].includes(operation.state)) {
+      return { ok: true as const, operation };
+    }
+    if (operation.state !== 'prepared' && operation.state !== 'starting') {
+      return { ok: false as const, errorCode: 'OPERATION_CONFLICT' as const, message: `operation is ${operation.state}` };
+    }
+    if (operation.targetLarkAppId !== deps.targetDaemon.larkAppId) {
+      throw new Error('dispatch launch target descriptor mismatch');
+    }
+    let startable = operation as Extract<DispatchLaunchOperationV1, { state: 'prepared' | 'starting' }>;
+    if (operation.state === 'prepared') operation = deps.store.transition({
+      dispatchId, expectedState: 'prepared', next: { ...operation, state: 'starting', updatedAt: deps.now().toISOString() },
+    });
+    startable = operation as Extract<DispatchLaunchOperationV1, { state: 'prepared' | 'starting' }>;
+    const result = decodeResponse(await invoke({
+      daemon: deps.targetDaemon, dispatchId, action: 'start', body: {
+        schemaVersion: DISPATCH_LAUNCH_SCHEMA_VERSION, protocol: 'v1', dispatchId,
+        kickoffDigest: startable.kickoff.digest, policyDigest: startable.launchIdentity.policyDigest,
+        launchIdentityDigest: dispatchLaunchIdentityDigest(startable.launchIdentity),
+      },
+    }));
+    if (!result.ok) {
+      deps.store.transition({
+        dispatchId, expectedState: 'starting',
+        next: { ...operation, state: 'failed', errorCode: result.errorCode, updatedAt: deps.now().toISOString() },
+      });
+      return result;
+    }
+    validatePeer(result.operation, operation);
+    if (result.operation.state !== 'awaiting_proof' && !['failed', 'cancelled', 'delivery_unknown'].includes(result.operation.state)) {
+      throw new Error(`target start returned ${result.operation.state}`);
+    }
+    return { ok: true as const, operation: deps.store.transition({
+      dispatchId, expectedState: 'starting', next: toSource(result.operation, operation),
+    }) };
+  };
+
+  const recover = async (): Promise<void> => {
+    for (const operation of deps.store.listRecoverable()) {
+      if (operation.state === 'created' || operation.state === 'preparing') {
+        await prepare({
+          schemaVersion: DISPATCH_LAUNCH_SCHEMA_VERSION, protocol: 'v1', dispatchId: operation.dispatchId,
+          source: { larkAppId: operation.sourceLarkAppId, sessionId: operation.sourceSessionId, turnId: operation.sourceTurnId,
+            ...(operation.callerUnionId ? { callerUnionId: operation.callerUnionId } : {}) },
+          targetLarkAppId: operation.targetLarkAppId, chatId: operation.chatId, kickoff: operation.kickoff,
+          requestedOverride: operation.requestedOverride, expiresAt: operation.expiresAt,
+        });
+      } else if (operation.state === 'prepared' || operation.state === 'starting') {
+        await start(operation.dispatchId);
+      }
+    }
+  };
+  return { create, prepare, start, query, recover };
+}

--- a/src/core/dispatch-launch-target.ts
+++ b/src/core/dispatch-launch-target.ts
@@ -1,0 +1,323 @@
+import { createHash } from 'node:crypto';
+
+import {
+  DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION,
+  DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION,
+  dispatchLaunchIdentityDigest,
+  evaluateDispatchLaunchPolicy,
+  resolveDispatchLaunchOverride,
+  type DispatchLaunchFailure,
+  type DispatchLaunchIdentityV1,
+  type DispatchLaunchOperationV1,
+  type DispatchLaunchPrepareRequestV1,
+  type DispatchLaunchStartRequestV1,
+} from './dispatch-launch-contract.js';
+import type { DispatchLaunchAdmissionStore } from './dispatch-launch-admission-store.js';
+import type { DispatchLaunchOperationStore } from './dispatch-launch-operation-store.js';
+
+export const DISPATCH_LAUNCH_PROVIDER_IDEMPOTENCY_MS = 60 * 60_000;
+
+export interface DispatchLaunchTargetConfig {
+  larkAppId: string;
+  cliId: string;
+  model?: string;
+  reasoningEffort?: import('../services/codex-reasoning-effort.js').CodexReasoningEffort;
+  policy?: import('./dispatch-launch-contract.js').DispatchLaunchPolicyV1;
+}
+
+export interface DispatchLaunchTargetDependencies {
+  target: DispatchLaunchTargetConfig;
+  operationStore: DispatchLaunchOperationStore;
+  admissionStore: DispatchLaunchAdmissionStore;
+  now(): Date;
+  resolveIdentity(): DispatchLaunchIdentityV1;
+  resolveWorkingDir(chatId: string): Promise<string | undefined> | string | undefined;
+  resolveChatType(chatId: string): Promise<'group' | 'p2p' | undefined>;
+  capacityAvailable(): boolean;
+  resolveSourceOpenId(chatId: string, sourceLarkAppId: string): Promise<string>;
+  authorizeTalk(chatId: string, sourceOpenId: string, callerUnionId?: string): {
+    allowed: boolean;
+    reason: string;
+    quotaKey?: string;
+    grantChatId?: string;
+  };
+  consumeQuotaOnce(input: {
+    receiptId: string;
+    quotaKey: string;
+    grantChatId?: string;
+    sourceOpenId: string;
+  }): Promise<{ allow: boolean }>;
+  ensureRoot(input: {
+    operation: DispatchLaunchOperationV1;
+    providerUuid: string;
+  }): Promise<string>;
+  ensureSession(input: {
+    operation: DispatchLaunchOperationV1;
+    rootMessageId: string;
+    sourceOpenId: string;
+  }): Promise<{ sessionId: string }>;
+  ensureWorker(input: {
+    operation: DispatchLaunchOperationV1;
+    rootMessageId: string;
+    sessionId: string;
+    sourceOpenId: string;
+  }): Promise<{ kickoffTurnId: string; workerGeneration: number }>;
+  cancelSession?(dispatchId: string, sessionId?: string): Promise<void>;
+}
+
+export type DispatchLaunchTargetResult =
+  | { ok: true; operation: DispatchLaunchOperationV1 }
+  | DispatchLaunchFailure;
+
+type StartingOperation = Extract<DispatchLaunchOperationV1, { state: 'starting' }>;
+
+function stableId(prefix: string, dispatchId: string): string {
+  return `${prefix}_${createHash('sha256').update(dispatchId).digest('hex').slice(0, 32)}`;
+}
+
+function fail(errorCode: DispatchLaunchFailure['errorCode'], message: string): DispatchLaunchFailure {
+  return { ok: false, errorCode, message };
+}
+
+function terminal(operation: DispatchLaunchOperationV1): boolean {
+  return ['succeeded', 'failed', 'cancelled', 'delivery_unknown'].includes(operation.state);
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/** Target-authoritative prepare/start state machine. External effects are injected for tests. */
+export function createDispatchLaunchTargetCoordinator(deps: DispatchLaunchTargetDependencies) {
+  const failOperation = (
+    operation: DispatchLaunchOperationV1,
+    errorCode: DispatchLaunchFailure['errorCode'],
+  ): DispatchLaunchOperationV1 => {
+    if (terminal(operation)) return operation;
+    return deps.operationStore.transition({
+      dispatchId: operation.dispatchId,
+      expectedState: operation.state,
+      next: { ...operation, state: errorCode === 'DELIVERY_UNKNOWN' ? 'delivery_unknown' : 'failed', errorCode, updatedAt: deps.now().toISOString() } as DispatchLaunchOperationV1,
+    });
+  };
+
+  const prepare = async (request: DispatchLaunchPrepareRequestV1): Promise<DispatchLaunchTargetResult> => {
+    if (request.targetLarkAppId !== deps.target.larkAppId) return fail('BAD_REQUEST', 'target app id mismatch');
+    if (Date.parse(request.expiresAt) <= deps.now().getTime()) return fail('OPERATION_EXPIRED', 'operation has expired');
+
+    const existing = deps.operationStore.get(request.dispatchId);
+    const initial: DispatchLaunchOperationV1 = {
+      schemaVersion: DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION,
+      dispatchId: request.dispatchId,
+      owner: 'target',
+      sourceLarkAppId: request.source.larkAppId,
+      sourceSessionId: request.source.sessionId,
+      sourceTurnId: request.source.turnId,
+      ...(request.source.callerUnionId ? { callerUnionId: request.source.callerUnionId } : {}),
+      targetLarkAppId: request.targetLarkAppId,
+      chatId: request.chatId,
+      kickoff: request.kickoff,
+      requestedOverride: request.requestedOverride,
+      createdAt: existing?.createdAt ?? deps.now().toISOString(),
+      updatedAt: deps.now().toISOString(),
+      expiresAt: request.expiresAt,
+      state: 'preparing',
+    };
+    const created = deps.operationStore.create(initial).operation;
+    if (created.state === 'prepared' || created.state === 'starting' || created.state === 'awaiting_proof' || terminal(created)) {
+      return { ok: true, operation: created };
+    }
+
+    const resolved = resolveDispatchLaunchOverride({
+      cliId: deps.target.cliId, requested: request.requestedOverride,
+      targetModel: deps.target.model, targetReasoningEffort: deps.target.reasoningEffort,
+    });
+    if (!resolved.ok) { failOperation(created, resolved.errorCode); return resolved; }
+    const policy = evaluateDispatchLaunchPolicy({
+      policy: deps.target.policy, sourceLarkAppId: request.source.larkAppId, effective: resolved.effective,
+    });
+    if (!policy.ok) { failOperation(created, policy.errorCode); return policy; }
+    let identity: DispatchLaunchIdentityV1;
+    try { identity = deps.resolveIdentity(); }
+    catch (error) { failOperation(created, 'UNSUPPORTED_HARNESS'); return fail('UNSUPPORTED_HARNESS', error instanceof Error ? error.message : String(error)); }
+    if (identity.policyDigest !== policy.policyDigest) {
+      failOperation(created, 'POLICY_CHANGED');
+      return fail('POLICY_CHANGED', 'resolved launch identity does not match target policy');
+    }
+
+    const existingAdmission = deps.admissionStore.get(request.dispatchId);
+    if (created.state === 'preparing' && existingAdmission) {
+      if (existingAdmission.state === 'authorized') {
+        const receipt = existingAdmission;
+        const receiptMatches = receipt.sourceLarkAppId === request.source.larkAppId
+          && receipt.sourceSessionId === request.source.sessionId
+          && receipt.sourceTurnId === request.source.turnId
+          && receipt.callerUnionId === request.source.callerUnionId
+          && typeof receipt.sourceOpenId === 'string'
+          && (receipt.chatType === 'group' || receipt.chatType === 'p2p')
+          && typeof receipt.talkReason === 'string'
+          && typeof receipt.workingDir === 'string' && receipt.workingDir.length > 0
+          && receipt.chatId === request.chatId
+          && receipt.targetLarkAppId === request.targetLarkAppId
+          && receipt.policyDigest === policy.policyDigest
+          && sameJson(receipt.effectiveOverride, resolved.effective)
+          && sameJson(receipt.launchIdentity, identity);
+        if (!receiptMatches) {
+          failOperation(created, 'OPERATION_CONFLICT');
+          return fail('OPERATION_CONFLICT', 'admission receipt does not match the prepared launch authority');
+        }
+        const prepared = deps.operationStore.transition({
+          dispatchId: request.dispatchId, expectedState: 'preparing',
+          next: { ...created, state: 'prepared', effectiveOverride: resolved.effective, launchIdentity: identity, updatedAt: deps.now().toISOString() },
+        });
+        return { ok: true, operation: prepared };
+      }
+      failOperation(created, 'OPERATION_CONFLICT');
+      return fail('OPERATION_CONFLICT', `admission receipt is already ${existingAdmission.state}`);
+    }
+
+    if (!deps.capacityAvailable()) {
+      failOperation(created, 'CAPACITY_UNAVAILABLE');
+      return fail('CAPACITY_UNAVAILABLE', 'target has no launch capacity');
+    }
+    const workingDir = await deps.resolveWorkingDir(request.chatId);
+    if (!workingDir) { failOperation(created, 'WORKDIR_REQUIRED'); return fail('WORKDIR_REQUIRED', 'target has no concrete working directory'); }
+    const chatType = await deps.resolveChatType(request.chatId);
+    if (!chatType) { failOperation(created, 'TARGET_CHAT_UNSUPPORTED'); return fail('TARGET_CHAT_UNSUPPORTED', 'target chat type cannot be confirmed'); }
+
+    let sourceOpenId: string;
+    try { sourceOpenId = await deps.resolveSourceOpenId(request.chatId, request.source.larkAppId); }
+    catch { failOperation(created, 'TARGET_NOT_IN_CHAT'); return fail('TARGET_NOT_IN_CHAT', 'source identity cannot be bound in target chat'); }
+    const talk = deps.authorizeTalk(request.chatId, sourceOpenId);
+    if (!talk.allowed) { failOperation(created, 'UNAUTHORIZED_SOURCE'); return fail('UNAUTHORIZED_SOURCE', 'source bot is not allowed to talk to target'); }
+
+    deps.admissionStore.authorize({
+      schemaVersion: DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION, dispatchId: request.dispatchId, state: 'authorized',
+      sourceLarkAppId: request.source.larkAppId, sourceSessionId: request.source.sessionId,
+      sourceTurnId: request.source.turnId, ...(request.source.callerUnionId ? { callerUnionId: request.source.callerUnionId } : {}),
+      sourceOpenId, chatType, talkReason: talk.reason, ...(talk.quotaKey ? { quotaKey: talk.quotaKey } : {}),
+      ...(talk.grantChatId ? { grantChatId: talk.grantChatId } : {}), chatId: request.chatId,
+      targetLarkAppId: request.targetLarkAppId, policyDigest: policy.policyDigest,
+      effectiveOverride: resolved.effective, launchIdentity: identity,
+      talkAuthorizationReceiptId: stableId('talk', request.dispatchId),
+      quotaReceiptId: stableId('quota', request.dispatchId), workingDir,
+      capacityReservationId: stableId('capacity', request.dispatchId),
+      createdAt: existingAdmission?.createdAt ?? deps.now().toISOString(),
+    });
+    const prepared = deps.operationStore.transition({
+      dispatchId: request.dispatchId, expectedState: ['created', 'preparing'],
+      next: { ...created, state: 'prepared', effectiveOverride: resolved.effective, launchIdentity: identity, updatedAt: deps.now().toISOString() },
+    });
+    return { ok: true, operation: prepared };
+  };
+
+  const start = async (request: DispatchLaunchStartRequestV1): Promise<DispatchLaunchTargetResult> => {
+    let operation = deps.operationStore.get(request.dispatchId);
+    if (!operation) return fail('OPERATION_NOT_FOUND', 'operation does not exist');
+    if (terminal(operation) || operation.state === 'awaiting_proof') return { ok: true, operation };
+    if (operation.state !== 'prepared' && operation.state !== 'starting') return fail('OPERATION_CONFLICT', `operation is ${operation.state}`);
+    if (Date.parse(operation.expiresAt) <= deps.now().getTime()) {
+      operation = failOperation(operation, 'OPERATION_EXPIRED');
+      return { ok: true, operation };
+    }
+    if (request.kickoffDigest !== operation.kickoff.digest
+        || request.policyDigest !== operation.launchIdentity.policyDigest
+        || request.launchIdentityDigest !== dispatchLaunchIdentityDigest(operation.launchIdentity)) {
+      return fail('OPERATION_CONFLICT', 'start request does not match prepared operation');
+    }
+    let currentIdentity: DispatchLaunchIdentityV1;
+    try { currentIdentity = deps.resolveIdentity(); } catch { return fail('LAUNCH_IDENTITY_CHANGED', 'target launch identity is unavailable'); }
+    if (dispatchLaunchIdentityDigest(currentIdentity) !== request.launchIdentityDigest) {
+      operation = failOperation(operation, currentIdentity.policyDigest === request.policyDigest ? 'LAUNCH_IDENTITY_CHANGED' : 'POLICY_CHANGED');
+      return { ok: true, operation };
+    }
+    if (operation.state === 'prepared') {
+      operation = deps.operationStore.transition({
+        dispatchId: operation.dispatchId, expectedState: 'prepared',
+        next: { ...operation, state: 'starting', updatedAt: deps.now().toISOString() },
+      });
+    }
+    let starting = operation as StartingOperation;
+    const admission = deps.admissionStore.get(starting.dispatchId);
+    if (!admission || admission.state === 'released' || !admission.sourceOpenId) {
+      operation = failOperation(starting, 'UNAUTHORIZED_SOURCE');
+      return { ok: true, operation };
+    }
+    if (admission.state === 'authorized') {
+      if (admission.quotaKey) {
+        const quota = await deps.consumeQuotaOnce({
+          receiptId: admission.quotaReceiptId, quotaKey: admission.quotaKey,
+          grantChatId: admission.grantChatId, sourceOpenId: admission.sourceOpenId,
+        });
+        if (!quota.allow) {
+          deps.admissionStore.release(starting.dispatchId, deps.now().toISOString());
+          operation = failOperation(starting, 'UNAUTHORIZED_SOURCE');
+          return { ok: true, operation };
+        }
+      }
+      deps.admissionStore.commit(starting.dispatchId, deps.now().toISOString());
+    }
+
+    if (!starting.rootMessageId) {
+      if (deps.now().getTime() - Date.parse(starting.updatedAt) >= DISPATCH_LAUNCH_PROVIDER_IDEMPOTENCY_MS) {
+        operation = failOperation(starting, 'DELIVERY_UNKNOWN');
+        return { ok: true, operation };
+      }
+      const rootMessageId = await deps.ensureRoot({ operation: starting, providerUuid: stableId('dl', starting.dispatchId) });
+      starting = deps.operationStore.transition({
+        dispatchId: starting.dispatchId, expectedState: 'starting',
+        next: { ...starting, rootMessageId, updatedAt: deps.now().toISOString() },
+      }) as StartingOperation;
+    }
+    const rootMessageId = starting.rootMessageId!;
+    if (!starting.targetSessionId) {
+      const session = await deps.ensureSession({ operation: starting, rootMessageId, sourceOpenId: admission.sourceOpenId });
+      starting = deps.operationStore.transition({
+        dispatchId: starting.dispatchId, expectedState: 'starting',
+        next: { ...starting, targetSessionId: session.sessionId, updatedAt: deps.now().toISOString() },
+      }) as StartingOperation;
+    }
+    if (!starting.kickoffTurnId || !starting.workerGeneration) {
+      const worker = await deps.ensureWorker({
+        operation: starting, rootMessageId, sessionId: starting.targetSessionId!, sourceOpenId: admission.sourceOpenId,
+      });
+      starting = deps.operationStore.transition({
+        dispatchId: starting.dispatchId, expectedState: 'starting',
+        next: { ...starting, kickoffTurnId: worker.kickoffTurnId, workerGeneration: worker.workerGeneration, updatedAt: deps.now().toISOString() },
+      }) as StartingOperation;
+    }
+    operation = deps.operationStore.transition({
+      dispatchId: starting.dispatchId, expectedState: 'starting',
+      next: { ...starting, state: 'awaiting_proof', updatedAt: deps.now().toISOString() } as DispatchLaunchOperationV1,
+    });
+    return { ok: true, operation };
+  };
+
+  const cancel = async (dispatchId: string): Promise<DispatchLaunchTargetResult> => {
+    const operation = deps.operationStore.get(dispatchId);
+    if (!operation) return fail('OPERATION_NOT_FOUND', 'operation does not exist');
+    if (terminal(operation)) return { ok: true, operation };
+    if (operation.state === 'awaiting_proof') {
+      if (deps.cancelSession) await deps.cancelSession(dispatchId, operation.targetSessionId);
+      const cancelled = deps.operationStore.transition({
+        dispatchId, expectedState: 'awaiting_proof',
+        next: { ...operation, state: 'cancelled', errorCode: 'CANCELLED', updatedAt: deps.now().toISOString() },
+      });
+      return { ok: true, operation: cancelled };
+    }
+    const admission = deps.admissionStore.get(dispatchId);
+    if (admission?.state === 'authorized') deps.admissionStore.release(dispatchId, deps.now().toISOString());
+    if (operation.state === 'starting' && deps.cancelSession) {
+      await deps.cancelSession(dispatchId, operation.targetSessionId);
+    }
+    const cancelled = deps.operationStore.transition({
+      dispatchId, expectedState: operation.state,
+      next: { ...operation, state: 'cancelled', errorCode: 'CANCELLED', updatedAt: deps.now().toISOString() } as DispatchLaunchOperationV1,
+    });
+    return { ok: true, operation: cancelled };
+  };
+
+  return { prepare, start, cancel, query: (dispatchId: string) => deps.operationStore.get(dispatchId) };
+}
+
+export type DispatchLaunchTargetCoordinator = ReturnType<typeof createDispatchLaunchTargetCoordinator>;

--- a/src/core/dispatch-launch-target.ts
+++ b/src/core/dispatch-launch-target.ts
@@ -35,7 +35,8 @@ export interface DispatchLaunchTargetDependencies {
   resolveChatType(chatId: string): Promise<'group' | 'p2p' | undefined>;
   capacityAvailable(): boolean;
   resolveSourceOpenId(chatId: string, sourceLarkAppId: string): Promise<string>;
-  authorizeTalk(chatId: string, sourceOpenId: string, callerUnionId?: string): {
+  /** Authorize the target-app-scoped source bot identity only. */
+  authorizeTalk(chatId: string, sourceOpenId: string): {
     allowed: boolean;
     reason: string;
     quotaKey?: string;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -56,7 +56,7 @@ import {
 } from './core/supervisor-shutdown-protocol.js';
 import { readSupervisorProcessStartIdentity } from './core/process-start-identity.js';
 import { statSync } from 'node:fs';
-import { addReaction, deleteMessage, getChatContext, getChatMode, getChatNameAndMode, getMessageChatId, listChatMemberOpenIds, MessageWithdrawnError, patchCardStreamElement, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateCardStreamElementContent, updateMessage, type EntryResolveStatus } from './im/lark/client.js';
+import { addReaction, deleteMessage, getChatContext, getChatMode, getChatModeStrict, getChatNameAndMode, getMessageChatId, listChatMemberOpenIds, MessageWithdrawnError, patchCardStreamElement, replyMessage, resolveAllowedUsersWithMap, resolveCurrentChatBotOpenIdsByLarkAppIds, sendMessage, sendUserMessage, updateCardStreamElementContent, updateMessage, type EntryResolveStatus } from './im/lark/client.js';
 import { resolveGroupJoinPrompt, waitForAllowedUserInChat } from './core/auto-start.js';
 import {
   loadBotConfigAtIndex,
@@ -304,7 +304,7 @@ import { SLASH_COMMAND_SHAPE } from './core/passthrough-commands.js';
 import type { CommandHandlerDeps } from './core/command-handler.js';
 import { findInheritablePeer } from './core/inherit-peer.js';
 import { isCallbackUrl, handleCallbackUrl } from './utils/user-token.js';
-import { consumeQuota, removeChatGrant, removeGlobalGrant } from './services/grant-store.js';
+import { consumeDispatchLaunchQuotaOnce, consumeQuota, removeChatGrant, removeGlobalGrant } from './services/grant-store.js';
 import { abortCharge, commitCharge, beginCharge } from './services/quota-dedup.js';
 import {
   getSessionWorkingDir,
@@ -344,6 +344,24 @@ import { claimInitialUserTurn, isInitialUserTurnPending, releaseInitialUserTurn 
 import { applyQueuedCodexAppLegacyFallback, mergeQueuedCodexAppTurn } from './core/session-create.js';
 import { fillNativeTopicId } from './core/native-topic-id.js';
 import { findOnlineDaemon, listOnlineDaemons } from './utils/daemon-discovery.js';
+import {
+  DISPATCH_LAUNCH_ID_RE,
+  dispatchLaunchIdentityDigest,
+  type DispatchLaunchOperationV1,
+} from './core/dispatch-launch-contract.js';
+import { createDispatchLaunchOperationStore } from './core/dispatch-launch-operation-store.js';
+import { createDispatchLaunchAdmissionStore } from './core/dispatch-launch-admission-store.js';
+import { resolveDispatchLaunchIdentity } from './core/dispatch-launch-identity.js';
+import { createDispatchLaunchTargetCoordinator, type DispatchLaunchTargetCoordinator } from './core/dispatch-launch-target.js';
+import { parseDispatchLaunchIpcBody, type DispatchLaunchIpcMutation } from './core/dispatch-launch-ipc-body.js';
+import {
+  createDispatchLaunchIpcNonceStore,
+  DISPATCH_LAUNCH_IPC_HEADERS,
+  DISPATCH_LAUNCH_IPC_ROUTE_PREFIX,
+  loadDispatchLaunchIpcSecret,
+  signDispatchLaunchIpcResponse,
+  verifyDispatchLaunchIpcRequest,
+} from './core/dispatch-launch-ipc-auth.js';
 import { beginReplyTargetTurn, buildTurnParticipantsFrom, chatSessionAnsweredRootAtTopLevel, fallbackTurnId, isSubstituteTurn, pickTurnReplyTarget, resolveInboundReplyTarget, resolveSessionReplyTarget, syncReplyTargetState } from './core/reply-target.js';
 import { readDeferredTopicBinding } from './core/deferred-topic-binding.js';
 import {
@@ -480,6 +498,8 @@ import {
  *  humanGate cold-attach + start to runs this bot owns (codex blocker #1). */
 let selfV3LarkAppId: string | undefined;
 let selfV3BootInstanceId: string | undefined;
+let dispatchLaunchTargetCoordinator: DispatchLaunchTargetCoordinator | undefined;
+const dispatchLaunchIpcNonces = createDispatchLaunchIpcNonceStore();
 /** Generic daemon identity used by internal receiver endpoints. Unlike the
  *  VC listener switch, every agent daemon may receive a fenced membership. */
 let selfDaemonLarkAppId: string | undefined;
@@ -4233,6 +4253,8 @@ interface DaemonDescriptor {
   bootInstanceId: string;
   /** Full-envelope Workflow mutation protocol supported by this process. */
   workflowIpcProtocol: 'v1';
+  /** Present only when the target explicitly enables the internal launch policy. */
+  dispatchLaunchIpcProtocol?: 'v1';
   /** Exact supervisor protocol this in-memory daemon will execute on signal.
    * Absent until the SIGTERM/SIGINT handlers and all captured state are ready. */
   supervisorShutdownProtocol?: SupervisorShutdownProtocol;
@@ -5902,6 +5924,85 @@ function workflowDaemonMutationRoute<K extends WorkflowDaemonMutation>(
     );
   });
 }
+
+function dispatchLaunchReply(
+  req: IncomingMessage,
+  res: ServerResponse,
+  status: number,
+  payload: unknown,
+  secret: string,
+  nonce: string,
+  target: { larkAppId: string; ipcPort: number; bootInstanceId: string },
+): void {
+  const responseBody = JSON.stringify(payload);
+  const signature = signDispatchLaunchIpcResponse({
+    secret, requestNonce: nonce, method: req.method ?? 'GET',
+    pathWithQuery: req.url ?? '/', status, body: responseBody, target,
+  });
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    [DISPATCH_LAUNCH_IPC_HEADERS.responseSignature]: signature,
+  });
+  res.end(responseBody);
+}
+
+async function dispatchLaunchIpcRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  params: Record<string, string>,
+  action?: DispatchLaunchIpcMutation,
+): Promise<void> {
+  if (!dispatchLaunchTargetCoordinator || !selfV3LarkAppId || !selfV3BootInstanceId) {
+    return jsonRes(res, 404, { ok: false, error: 'not_found' });
+  }
+  let secret: string;
+  try { secret = loadDispatchLaunchIpcSecret(); }
+  catch { return jsonRes(res, 503, { ok: false, error: 'dispatch_launch_ipc_auth_unavailable' }); }
+  const verified = await verifyDispatchLaunchIpcRequest(req, {
+    secret,
+    target: { larkAppId: selfV3LarkAppId, bootInstanceId: selfV3BootInstanceId },
+    nonceStore: dispatchLaunchIpcNonces,
+  });
+  if (!verified.ok) {
+    logger.warn(`[dispatch-launch-ipc] rejected ${action ?? 'query'}: ${verified.reason}`);
+    return jsonRes(res, verified.httpStatus, { ok: false, error: 'dispatch_launch_ipc_unauthorized' });
+  }
+  const reply = (status: number, payload: unknown): void =>
+    dispatchLaunchReply(req, res, status, payload, secret, verified.nonce, verified.target);
+  if (!DISPATCH_LAUNCH_ID_RE.test(params.dispatchId ?? '')) {
+    return reply(400, { ok: false, errorCode: 'BAD_REQUEST' });
+  }
+  try {
+    if (!action) {
+      const operation = dispatchLaunchTargetCoordinator.query(params.dispatchId);
+      return operation ? reply(200, { ok: true, operation }) : reply(404, { ok: false, errorCode: 'OPERATION_NOT_FOUND' });
+    }
+    const parsed = parseDispatchLaunchIpcBody(action, verified.bodyRaw);
+    if (!parsed.ok || parsed.body.value.dispatchId !== params.dispatchId) {
+      return reply(400, { ok: false, errorCode: 'BAD_REQUEST' });
+    }
+    const result = action === 'prepare'
+      ? await dispatchLaunchTargetCoordinator.prepare(parsed.body.value as import('./core/dispatch-launch-contract.js').DispatchLaunchPrepareRequestV1)
+      : action === 'start'
+        ? await withBotTurnMutation(selfV3LarkAppId, () => dispatchLaunchTargetCoordinator!.start(
+            parsed.body.value as import('./core/dispatch-launch-contract.js').DispatchLaunchStartRequestV1,
+          ))
+        : await withBotTurnMutation(selfV3LarkAppId, () => dispatchLaunchTargetCoordinator!.cancel(params.dispatchId));
+    return reply(result.ok ? 200 : result.errorCode === 'OPERATION_NOT_FOUND' ? 404 : 409, result);
+  } catch (error) {
+    logger.error(`[dispatch-launch-ipc] ${action ?? 'query'} failed: ${error instanceof Error ? error.message : String(error)}`);
+    return reply(500, { ok: false, errorCode: 'INTERNAL_ERROR' });
+  }
+}
+
+ipcRoute('POST', `${DISPATCH_LAUNCH_IPC_ROUTE_PREFIX}/:dispatchId/prepare`,
+  (req, res, params) => dispatchLaunchIpcRoute(req, res, params, 'prepare'));
+ipcRoute('POST', `${DISPATCH_LAUNCH_IPC_ROUTE_PREFIX}/:dispatchId/start`,
+  (req, res, params) => dispatchLaunchIpcRoute(req, res, params, 'start'));
+ipcRoute('POST', `${DISPATCH_LAUNCH_IPC_ROUTE_PREFIX}/:dispatchId/cancel`,
+  (req, res, params) => dispatchLaunchIpcRoute(req, res, params, 'cancel'));
+ipcRoute('GET', `${DISPATCH_LAUNCH_IPC_ROUTE_PREFIX}/:dispatchId`,
+  (req, res, params) => dispatchLaunchIpcRoute(req, res, params));
 
 // Thin zero-I/O tombstones for old dashboard/cards/automation clients. Keeping
 // these explicit routes prevents stale callers from mistaking a generic 404 or
@@ -22224,6 +22325,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     startedAt: Date.now(),
     bootInstanceId: getDaemonBootId(),
     workflowIpcProtocol: 'v1',
+    ...(cfg.dispatchLaunchPolicy?.enabled === true ? { dispatchLaunchIpcProtocol: 'v1' as const } : {}),
     lastHeartbeat: Date.now(),
     // Dashboard create-group only consumes app-scoped open_ids — publish ONLY
     // ou_ entries. Before the resolution below runs, the list may still hold raw
@@ -22555,6 +22657,143 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // so dashboard IPC and other consumers can list/lookup live sessions.
   setActiveSessionsRegistry(activeSessions);
   registerPinStreamingCardChangeHandler(reconcileBotStreamingCardPins);
+
+  if (cfg.dispatchLaunchPolicy?.enabled === true) {
+    const operationStore = createDispatchLaunchOperationStore({
+      dataDir: config.session.dataDir, ownerLarkAppId: cfg.larkAppId,
+    });
+    const admissionStore = createDispatchLaunchAdmissionStore({
+      dataDir: config.session.dataDir, targetLarkAppId: cfg.larkAppId,
+    });
+    dispatchLaunchTargetCoordinator = createDispatchLaunchTargetCoordinator({
+      target: {
+        larkAppId: cfg.larkAppId, cliId: cfg.cliId, model: cfg.model,
+        reasoningEffort: cfg.reasoningEffort, policy: cfg.dispatchLaunchPolicy,
+      },
+      operationStore, admissionStore, now: () => new Date(),
+      resolveIdentity: () => resolveDispatchLaunchIdentity(getBot(cfg.larkAppId).config),
+      resolveWorkingDir: (chatId) => {
+        const candidate = findOncallChat(cfg.larkAppId, chatId)?.workingDir
+          ?? effectiveDefaultWorkingDir(cfg) ?? cfg.workingDir;
+        if (!candidate) return undefined;
+        const checked = validateWorkingDir(candidate);
+        return checked.ok ? checked.resolvedPath : undefined;
+      },
+      resolveChatType: async (chatId) => {
+        const mode = await getChatModeStrict(cfg.larkAppId, chatId);
+        return mode === 'unknown' ? undefined : mode === 'p2p' ? 'p2p' : 'group';
+      },
+      capacityAvailable: () => {
+        const cap = cfg.maxLiveWorkers ?? DEFAULT_MAX_LIVE_WORKERS;
+        return cap <= 0 || [...activeSessions.values()].filter(ds => !!ds.worker && !ds.worker.killed).length < cap;
+      },
+      resolveSourceOpenId: async (chatId, sourceLarkAppId) => {
+        const resolved = await resolveCurrentChatBotOpenIdsByLarkAppIds(cfg.larkAppId, chatId, [sourceLarkAppId]);
+        const mapping = resolved.ok ? resolved.mappings[0] : undefined;
+        if (!mapping) throw new Error(resolved.ok ? 'source identity missing' : resolved.message);
+        return mapping.subjectOpenId;
+      },
+      authorizeTalk: (chatId, sourceOpenId, callerUnionId) =>
+        evaluateBotTalk(cfg.larkAppId, chatId, sourceOpenId, callerUnionId),
+      consumeQuotaOnce: ({ receiptId, quotaKey, grantChatId, sourceOpenId }) =>
+        consumeDispatchLaunchQuotaOnce({
+          larkAppId: cfg.larkAppId, receiptId, quotaKey, sourceOpenId,
+          ...(grantChatId ? { grantChatId } : {}),
+        }),
+      ensureRoot: async ({ operation, providerUuid }) => {
+        const existing = sessionStore.listSessions().find(session =>
+          session.status === 'active' && session.dispatchLaunchId === operation.dispatchId);
+        if (existing) return existing.rootMessageId;
+        return sendMessage(
+          cfg.larkAppId, operation.chatId,
+          `📋 子项目：${operation.kickoff.payload.title}`, 'text', providerUuid,
+        );
+      },
+      ensureSession: async ({ operation, rootMessageId, sourceOpenId }) => {
+        const existing = sessionStore.listSessions().find(session =>
+          session.status === 'active' && session.dispatchLaunchId === operation.dispatchId);
+        if (existing) {
+          if (existing.rootMessageId !== rootMessageId || existing.chatId !== operation.chatId) {
+            throw new Error('dispatch launch session conflicts with persisted operation');
+          }
+          existing.lastCallerOpenId = sourceOpenId;
+          sessionStore.updateSession(existing);
+          return { sessionId: existing.sessionId };
+        }
+        const rootOwners = sessionStore.findActiveSessionsByRoot(rootMessageId);
+        if (rootOwners.length > 0) throw new Error('dispatch launch root is already owned');
+        const admission = admissionStore.get(operation.dispatchId);
+        if (!admission) throw new Error('dispatch launch admission is missing');
+        const session = sessionStore.createDispatchLaunchSession({
+          dispatchId: operation.dispatchId, chatId: operation.chatId, rootMessageId,
+          title: operation.kickoff.payload.title, chatType: admission.chatType ?? 'group',
+          workingDir: admission.workingDir, larkAppId: cfg.larkAppId,
+        });
+        session.queued = true;
+        session.queuedPrompt = operation.kickoff.payload.brief;
+        session.lastCallerOpenId = sourceOpenId;
+        sessionStore.updateSession(session);
+        return { sessionId: session.sessionId };
+      },
+      ensureWorker: async ({ operation, rootMessageId, sessionId, sourceOpenId }) => {
+        let ds = findActiveBySessionId(sessionId);
+        if (!ds) {
+          const session = sessionStore.getSession(sessionId);
+          if (!session || session.status !== 'active' || session.dispatchLaunchId !== operation.dispatchId) {
+            throw new Error('dispatch launch session is unavailable');
+          }
+          const now = Date.now();
+          ds = {
+            session, worker: null, workerPort: null, workerToken: null, larkAppId: cfg.larkAppId,
+            chatId: operation.chatId, chatType: session.chatType ?? 'group', scope: 'thread',
+            spawnedAt: Date.parse(session.createdAt) || now, cliVersion: 'unknown', lastMessageAt: now,
+            hasHistory: false, workingDir: session.workingDir, ownerOpenId: undefined,
+          };
+          const registration = await claimNewDaemonSession(activeSessions, ds);
+          if (!registration.accepted && registration.owner.session.sessionId !== sessionId) {
+            throw new Error('dispatch launch session route is owned by another session');
+          }
+          ds = registration.owner;
+        }
+        if (ds.workerGeneration && ds.worker && !ds.worker.killed) {
+          return { kickoffTurnId: operation.sourceTurnId, workerGeneration: ds.workerGeneration };
+        }
+        const prompt = [
+          operation.kickoff.payload.role ? `角色：${operation.kickoff.payload.role}` : '',
+          operation.kickoff.payload.brief,
+        ].filter(Boolean).join('\n\n');
+        const sender = { openId: sourceOpenId, type: 'bot' as const, name: operation.kickoff.payload.sourceDisplay };
+        beginReplyTargetTurn(ds, rootMessageId, operation.sourceTurnId, new Date().toISOString(), {
+          senderOpenId: sourceOpenId, participants: [{ openId: sourceOpenId, name: sender.name, isBot: true }],
+          participantsIncomplete: false, inThread: true,
+        });
+        sessionStore.updateSession(ds.session);
+        const input = buildNewTopicCliInput(
+          prompt, sessionId, cfg.cliId, cfg.cliPathOverride, undefined, undefined,
+          await getAvailableBots(cfg.larkAppId, operation.chatId),
+          undefined, { name: getBot(cfg.larkAppId).botName, openId: getBot(cfg.larkAppId).botOpenId },
+          localeForBot(cfg.larkAppId), sender,
+          { larkAppId: cfg.larkAppId, chatId: operation.chatId, trustedCaller: trustedCallerForTurn(cfg.larkAppId, sourceOpenId, operation.callerUnionId, true) },
+        );
+        if (!forkWorker(ds, input, { turnId: operation.sourceTurnId, trustedCaller: input.trustedCaller })) {
+          throw new Error('dispatch launch worker fork was rejected');
+        }
+        if (!ds.workerGeneration) throw new Error('dispatch launch worker generation was not reserved');
+        return { kickoffTurnId: operation.sourceTurnId, workerGeneration: ds.workerGeneration };
+      },
+      cancelSession: async (dispatchId, sessionId) => {
+        const persisted = sessionId
+          ? sessionStore.getSession(sessionId)
+          : sessionStore.listSessions().find(session => session.status === 'active' && session.dispatchLaunchId === dispatchId);
+        if (!persisted) return;
+        const ds = findActiveBySessionId(persisted.sessionId);
+        if (ds) await closeSessionHelper(persisted.sessionId);
+        else sessionStore.closeSession(persisted.sessionId);
+      },
+    });
+  } else {
+    dispatchLaunchTargetCoordinator = undefined;
+  }
 
   // Idempotency boot reconcile — MUST run before startIpcServer binds (a normal
   // fleet has no core-only readiness gate, so a live /api/trigger could otherwise
@@ -23038,6 +23277,28 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       sessionsRestored = true;
     },
   });
+
+  // Recover target-owned launch operations only after the canonical session
+  // registry exists. Start is checkpointed, so re-entry resumes at the first
+  // missing effect; an expired prepared operation is terminalized instead.
+  if (dispatchLaunchTargetCoordinator && cfg.dispatchLaunchPolicy?.enabled === true) {
+    const operationStore = createDispatchLaunchOperationStore({
+      dataDir: config.session.dataDir, ownerLarkAppId: cfg.larkAppId,
+    });
+    for (const operation of operationStore.listRecoverable()) {
+      if (operation.state !== 'prepared' && operation.state !== 'starting') continue;
+      try {
+        const result = await dispatchLaunchTargetCoordinator.start({
+          schemaVersion: 1, protocol: 'v1', dispatchId: operation.dispatchId,
+          kickoffDigest: operation.kickoff.digest, policyDigest: operation.launchIdentity.policyDigest,
+          launchIdentityDigest: dispatchLaunchIdentityDigest(operation.launchIdentity),
+        });
+        if (!result.ok) logger.warn(`[dispatch-launch] recovery rejected ${operation.dispatchId}: ${result.errorCode}`);
+      } catch (error) {
+        logger.error(`[dispatch-launch] recovery failed ${operation.dispatchId}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
 
   // Close CoT thinking bubbles orphaned by the previous daemon generation
   // (created mid-turn, never settled — their in-memory state died with the

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -347,7 +347,6 @@ import { findOnlineDaemon, listOnlineDaemons } from './utils/daemon-discovery.js
 import {
   DISPATCH_LAUNCH_ID_RE,
   dispatchLaunchIdentityDigest,
-  type DispatchLaunchOperationV1,
 } from './core/dispatch-launch-contract.js';
 import { createDispatchLaunchOperationStore } from './core/dispatch-launch-operation-store.js';
 import { createDispatchLaunchAdmissionStore } from './core/dispatch-launch-admission-store.js';
@@ -22693,8 +22692,11 @@ export async function startDaemon(botIndex?: number): Promise<void> {
         if (!mapping) throw new Error(resolved.ok ? 'source identity missing' : resolved.message);
         return mapping.subjectOpenId;
       },
-      authorizeTalk: (chatId, sourceOpenId, callerUnionId) =>
-        evaluateBotTalk(cfg.larkAppId, chatId, sourceOpenId, callerUnionId),
+      // callerUnionId is source testimony about the human behind the dispatch,
+      // never the source bot's Lark-stamped union_id. Passing it into
+      // evaluateBotTalk would incorrectly activate the team-bot trust leg.
+      authorizeTalk: (chatId, sourceOpenId) =>
+        evaluateBotTalk(cfg.larkAppId, chatId, sourceOpenId),
       consumeQuotaOnce: ({ receiptId, quotaKey, grantChatId, sourceOpenId }) =>
         consumeDispatchLaunchQuotaOnce({
           larkAppId: cfg.larkAppId, receiptId, quotaKey, sourceOpenId,
@@ -22768,12 +22770,18 @@ export async function startDaemon(botIndex?: number): Promise<void> {
           participantsIncomplete: false, inThread: true,
         });
         sessionStore.updateSession(ds.session);
+        // The authenticated + policy-allowlisted source daemon is the trust
+        // anchor for callerUnionId. Preserve it as human-caller testimony while
+        // marking the immediate trigger as a bot; it must never feed bot-talk.
+        const dispatchTrustedCaller = trustedCallerForTurn(
+          cfg.larkAppId, sourceOpenId, operation.callerUnionId, true,
+        );
         const input = buildNewTopicCliInput(
           prompt, sessionId, cfg.cliId, cfg.cliPathOverride, undefined, undefined,
           await getAvailableBots(cfg.larkAppId, operation.chatId),
           undefined, { name: getBot(cfg.larkAppId).botName, openId: getBot(cfg.larkAppId).botOpenId },
           localeForBot(cfg.larkAppId), sender,
-          { larkAppId: cfg.larkAppId, chatId: operation.chatId, trustedCaller: trustedCallerForTurn(cfg.larkAppId, sourceOpenId, operation.callerUnionId, true) },
+          { larkAppId: cfg.larkAppId, chatId: operation.chatId, trustedCaller: dispatchTrustedCaller },
         );
         if (!forkWorker(ds, input, { turnId: operation.sourceTurnId, trustedCaller: input.trustedCaller })) {
           throw new Error('dispatch launch worker fork was rejected');
@@ -22787,7 +22795,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
           : sessionStore.listSessions().find(session => session.status === 'active' && session.dispatchLaunchId === dispatchId);
         if (!persisted) return;
         const ds = findActiveBySessionId(persisted.sessionId);
-        if (ds) await closeSessionHelper(persisted.sessionId);
+        if (ds) {
+          await closeSessionForBackgroundCleanup(persisted.sessionId, 'dispatch launch cancel');
+        }
         else sessionStore.closeSession(persisted.sessionId);
       },
     });

--- a/src/services/grant-store.ts
+++ b/src/services/grant-store.ts
@@ -375,6 +375,73 @@ export async function consumeQuota(
 }
 
 /**
+ * Atomically charge one dispatch launch at most once. The durable receipt and
+ * quota increment share the bots.json RMW lock, closing the crash window
+ * between an irreversible charge and admission-store commit.
+ */
+export async function consumeDispatchLaunchQuotaOnce(
+  input: { larkAppId: string; quotaKey: string; receiptId: string; sourceOpenId: string; grantChatId?: string },
+): Promise<{ allow: boolean }> {
+  const { larkAppId, quotaKey, receiptId, sourceOpenId, grantChatId } = input;
+  const bot = getBot(larkAppId);
+  const chargedAt = new Date().toISOString();
+  const r = await rmwBotEntry<{ allow: boolean; receipts: Record<string, { allow: boolean; chargedAt: string }>; quota?: QuotaRec }>(
+    larkAppId,
+    (entry) => {
+      const receipts = entry.dispatchLaunchQuotaReceipts
+        && typeof entry.dispatchLaunchQuotaReceipts === 'object'
+        && !Array.isArray(entry.dispatchLaunchQuotaReceipts)
+        ? { ...entry.dispatchLaunchQuotaReceipts }
+        : {};
+      const existing = receipts[receiptId];
+      if (existing && typeof existing.allow === 'boolean') {
+        return { write: false, result: { allow: existing.allow, receipts } };
+      }
+      const rec = getQuotaMap(entry)?.[quotaKey];
+      const chatGrantMatches = grantChatId !== undefined
+        && quotaKey === chatQuotaKey(grantChatId, sourceOpenId)
+        && Array.isArray(entry.chatGrants?.[grantChatId])
+        && entry.chatGrants[grantChatId].includes(sourceOpenId);
+      const globalGrantMatches = grantChatId === undefined
+        && quotaKey === globalQuotaKey(sourceOpenId)
+        && Array.isArray(entry.globalGrants)
+        && entry.globalGrants.includes(sourceOpenId);
+      const allow = (chatGrantMatches || globalGrantMatches) && (!rec || rec.used < rec.limit);
+      let quota: QuotaRec | undefined;
+      if (allow && rec) {
+        quota = { limit: rec.limit, used: rec.used + 1 };
+        entry.quotaState = { ...(getQuotaMap(entry) ?? {}), [quotaKey]: quota };
+        if (quota.used >= quota.limit) {
+          if (quotaKey.startsWith('chat:') && grantChatId && Array.isArray(entry.chatGrants?.[grantChatId])) {
+            entry.chatGrants[grantChatId] = entry.chatGrants[grantChatId].filter((id: string) => id !== sourceOpenId);
+            if (entry.chatGrants[grantChatId].length === 0) delete entry.chatGrants[grantChatId];
+          } else if (quotaKey.startsWith('global:') && Array.isArray(entry.globalGrants)) {
+            entry.globalGrants = entry.globalGrants.filter((id: string) => id !== sourceOpenId);
+          }
+          setQuotaRecord(entry, quotaKey, null);
+          setExpiryRecord(entry, quotaKey, null);
+        }
+      }
+      receipts[receiptId] = { allow, chargedAt };
+      entry.dispatchLaunchQuotaReceipts = receipts;
+      return { write: true, result: { allow, receipts, ...(quota ? { quota } : {}) } };
+    },
+  );
+  if (!r.ok) throw new Error(`dispatch launch quota RMW failed: ${r.reason}`);
+  bot.config.dispatchLaunchQuotaReceipts = r.result.receipts;
+  if (r.result.quota && r.result.quota.used === r.result.quota.limit) {
+    setQuotaRecord(bot.config, quotaKey, null);
+    setExpiryRecord(bot.config, quotaKey, null);
+    if (quotaKey.startsWith('chat:') && grantChatId && bot.config.chatGrants?.[grantChatId]) {
+      bot.config.chatGrants[grantChatId] = bot.config.chatGrants[grantChatId].filter(id => id !== sourceOpenId);
+    } else if (quotaKey.startsWith('global:')) {
+      bot.config.globalGrants = bot.config.globalGrants?.filter(id => id !== sourceOpenId);
+    }
+  } else if (r.result.quota) setQuotaRecord(bot.config, quotaKey, r.result.quota);
+  return { allow: r.result.allow };
+}
+
+/**
  * 整群 talk 授权：把 chatId 加入 allowedChatGroups（"talk-open 的 chat_id 列表"）。
  * 命中后该 chat 任何成员都过 canTalk（见 event-dispatcher.canTalk），不授 canOperate。
  */

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -1652,6 +1652,29 @@ export function createSession(
   return session;
 }
 
+/** Create the target-side dispatch session with its durable owner marker in one row write. */
+export function createDispatchLaunchSession(input: {
+  dispatchId: string;
+  chatId: string;
+  rootMessageId: string;
+  title: string;
+  chatType: 'group' | 'p2p';
+  workingDir: string;
+  larkAppId: string;
+}): Session {
+  loadForWrite();
+  const session: Session = {
+    sessionId: randomUUID(), dispatchLaunchId: input.dispatchId, chatId: input.chatId,
+    chatType: input.chatType, rootMessageId: input.rootMessageId, scope: 'thread',
+    title: input.title, status: 'active', createdAt: new Date().toISOString(),
+    workingDir: input.workingDir, larkAppId: input.larkAppId,
+  };
+  sessions.set(session.sessionId, session);
+  persistRow(session);
+  logger.info(`Created dispatch launch session ${session.sessionId} (thread: ${input.rootMessageId})`);
+  return session;
+}
+
 export function getSession(sessionId: string): Session | undefined {
   load();
   return sessions.get(sessionId) ?? findInOtherFiles(sessionId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,6 +263,8 @@ export interface FailedTurnRecord {
 
 export interface Session {
   sessionId: string;
+  /** Internal target-side owner for an idempotent dispatch-launch session. */
+  dispatchLaunchId?: string;
   /** Build fingerprint of the last fresh owned Codex App runner that became ready. */
   runnerBuildId?: string;
   chatId: string;

--- a/src/utils/daemon-discovery.ts
+++ b/src/utils/daemon-discovery.ts
@@ -23,6 +23,8 @@ export interface OnlineDaemonInfo {
   bootInstanceId?: string;
   /** Auth protocol advertised atomically with bootInstanceId + ipcPort. */
   workflowIpcProtocol?: string;
+  /** Internal target-authoritative dispatch launch protocol. */
+  dispatchLaunchIpcProtocol?: 'v1';
   botName?: string;
   cliId?: string;
   pid?: number;
@@ -83,6 +85,9 @@ export function listOnlineDaemons(dataDir?: string): OnlineDaemonInfo[] {
           : {}),
         ...(typeof d.workflowIpcProtocol === 'string' && d.workflowIpcProtocol
           ? { workflowIpcProtocol: d.workflowIpcProtocol }
+          : {}),
+        ...(d.dispatchLaunchIpcProtocol === 'v1'
+          ? { dispatchLaunchIpcProtocol: d.dispatchLaunchIpcProtocol }
           : {}),
         ...(typeof d.botName === 'string' && d.botName.trim() ? { botName: d.botName.trim() } : {}),
         ...(typeof d.cliId === 'string' && d.cliId.trim() ? { cliId: d.cliId.trim() } : {}),

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -830,7 +830,7 @@ describe('core-only entrypoint hardening (codex 4 P1s — source lock)', () => {
     expect(entrySource).not.toContain('if (!process.env.BOTMUX_WORKER_HTTP_HOST');
   });
 
-  it('stamps the turn sender type onto the trusted caller at both IM entry points', () => {
+  it('stamps proven sender type at IM entries and source testimony at dispatch launch', () => {
     // A bot's turn carries a perfectly valid union_id (its own), so a consumer
     // cannot tell "a person asked" from "a bot triggered itself" unless the host
     // says which it was. Both inbound paths must therefore pass it — a missed
@@ -843,8 +843,8 @@ describe('core-only entrypoint hardening (codex 4 P1s — source lock)', () => {
     // bot as `'user'`, i.e. it vouches for a bot turn as a person.
     const trustedCallerArgs = [...daemonSource.matchAll(/trustedCallerForTurn\(([^;]*?)\);/g)]
       .map(m => m[1].split(',').map(part => part.trim()));
-    expect(trustedCallerArgs.length).toBe(2);
-    for (const args of trustedCallerArgs) {
+    expect(trustedCallerArgs.length).toBe(3);
+    for (const args of trustedCallerArgs.slice(0, 2)) {
       expect(args.length).toBeGreaterThanOrEqual(4);
       const senderTypeArg = args.slice(3).join(', ');
       expect(senderTypeArg).not.toBe('');
@@ -855,6 +855,16 @@ describe('core-only entrypoint hardening (codex 4 P1s — source lock)', () => {
       // which is the exact case a bare `sender_type` check already missed.
       expect(senderTypeArg).toContain('isForeignBot');
     }
+    // Dispatch launch is not an IM event on the target app: its same-host HMAC
+    // authenticated and policy-allowlisted source daemon attests the human
+    // caller union_id, while the immediate trigger is known to be that bot.
+    const dispatchArgs = trustedCallerArgs[2]!;
+    expect(dispatchArgs.slice(0, 3).join(', ')).toContain('operation.callerUnionId');
+    expect(dispatchArgs[3]).toBe('true');
+    expect(daemonSource).toContain('trustedCaller: dispatchTrustedCaller');
+    // The source testimony must never be reused as evaluateBotTalk's bot union.
+    expect(daemonSource).toContain('evaluateBotTalk(cfg.larkAppId, chatId, sourceOpenId)');
+    expect(daemonSource).not.toContain('evaluateBotTalk(cfg.larkAppId, chatId, sourceOpenId, callerUnionId)');
   });
 
   it('P1-2: entrypoint strips BOTS_CONFIG so no worker fork inherits it', () => {

--- a/test/close-consumer-matrix.test.ts
+++ b/test/close-consumer-matrix.test.ts
@@ -162,6 +162,11 @@ const CONSUMERS: Record<string, Rule> = {
     why: 'Deferred-schedule settlement injection: settlement returns close_refused '
       + 'rather than closed.',
   },
+  'daemon.ts::cancelSession::closeSessionForBackgroundCleanup': {
+    category: 'background',
+    why: 'Authenticated dispatch-launch cancel has no direct UI surface; the '
+      + 'background wrapper logs any refusal or residual remote session.',
+  },
   'daemon.ts::failCloseIdempotentTurnIfConvergenceWriteFailed::runIdempotencyFailClose': {
     category: 'background',
     why: 'Typed consumer: refusal never claims fail-closed, residual uses the '

--- a/test/daemon-discovery.test.ts
+++ b/test/daemon-discovery.test.ts
@@ -50,6 +50,7 @@ describe('daemon discovery', () => {
       ipcPort: 7956,
       bootInstanceId,
       workflowIpcProtocol: 'v1',
+      dispatchLaunchIpcProtocol: 'v1',
       botName: 'codex-loopy',
       cliId: 'codex',
       pid: 123,
@@ -61,6 +62,7 @@ describe('daemon discovery', () => {
       ipcPort: 7956,
       bootInstanceId,
       workflowIpcProtocol: 'v1',
+      dispatchLaunchIpcProtocol: 'v1',
       botName: 'codex-loopy',
       cliId: 'codex',
     })]);

--- a/test/dispatch-launch-ipc-auth.test.ts
+++ b/test/dispatch-launch-ipc-auth.test.ts
@@ -141,11 +141,20 @@ describe('dispatch launch IPC request verifier', () => {
     await expect(verify(makeRequest({
       headers: { 'content-length': String(DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES + 1) },
     }))).resolves.toEqual({ ok: false, reason: 'body_too_large', httpStatus: 413 });
+    const streamedOversize = Buffer.alloc(DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES + 1, 0x61);
+    await expect(verify(makeRequest({ body: streamedOversize, signedBody: streamedOversize })))
+      .resolves.toEqual({ ok: false, reason: 'body_too_large', httpStatus: 413 });
     await expect(verify(makeRequest({
       headers: { 'content-length': '2', 'transfer-encoding': 'chunked' },
     }))).resolves.toEqual({ ok: false, reason: 'body_length_mismatch', httpStatus: 400 });
     const invalid = Buffer.from([0xc3, 0x28]);
     await expect(verify(makeRequest({ body: invalid, signedBody: invalid }))).resolves
       .toEqual({ ok: false, reason: 'body_not_utf8', httpStatus: 400 });
+  });
+
+  it('rejects timestamps outside the accepted clock window', async () => {
+    await expect(verify(makeRequest({
+      headers: { [DISPATCH_LAUNCH_IPC_HEADERS.timestamp]: String(NOW - 60_001) },
+    }))).resolves.toEqual({ ok: false, reason: 'timestamp_out_of_window', httpStatus: 401 });
   });
 });

--- a/test/dispatch-launch-ipc-auth.test.ts
+++ b/test/dispatch-launch-ipc-auth.test.ts
@@ -1,12 +1,20 @@
+import type { IncomingMessage } from 'node:http';
+import { Readable } from 'node:stream';
+
 import { describe, expect, it } from 'vitest';
 
 import {
   DISPATCH_LAUNCH_IPC_DOMAIN,
+  DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES,
+  DISPATCH_LAUNCH_IPC_HEADERS,
   canonicalDispatchLaunchIpcMaterial,
+  createDispatchLaunchIpcNonceStore,
   signDispatchLaunchIpcRequest,
   signDispatchLaunchIpcResponse,
   verifyDispatchLaunchIpcRequestSignature,
   verifyDispatchLaunchIpcResponseSignature,
+  verifyDispatchLaunchIpcRequest,
+  type DispatchLaunchIpcClock,
 } from '../src/core/dispatch-launch-ipc-auth.js';
 
 const target = {
@@ -23,6 +31,41 @@ const request = {
   body: '{"dispatchId":"dl_x"}',
   target,
 };
+const NOW = Number(request.timestamp);
+const clock: DispatchLaunchIpcClock = { now: () => NOW };
+
+function makeRequest(input: {
+  body?: string | Uint8Array; headers?: Record<string, string | string[] | undefined>;
+  remoteAddress?: string; localPort?: number; signedBody?: string | Uint8Array;
+  signedPath?: string; signedTarget?: typeof target; nonce?: string;
+} = {}): IncomingMessage {
+  const body = input.body ?? request.body;
+  const bytes = typeof body === 'string' ? Buffer.from(body) : Buffer.from(body);
+  const nonce = input.nonce ?? request.nonce;
+  const signature = signDispatchLaunchIpcRequest({
+    ...request, nonce, body: input.signedBody ?? bytes,
+    pathWithQuery: input.signedPath ?? request.pathWithQuery,
+    target: input.signedTarget ?? target,
+  });
+  return Object.assign(Readable.from([bytes]), {
+    method: request.method, url: request.pathWithQuery,
+    headers: {
+      [DISPATCH_LAUNCH_IPC_HEADERS.timestamp]: request.timestamp,
+      [DISPATCH_LAUNCH_IPC_HEADERS.nonce]: nonce,
+      [DISPATCH_LAUNCH_IPC_HEADERS.signature]: signature,
+      ...input.headers,
+    },
+    socket: { remoteAddress: input.remoteAddress ?? '127.0.0.1', localPort: input.localPort ?? target.ipcPort },
+  }) as unknown as IncomingMessage;
+}
+
+function verify(req: IncomingMessage, store = createDispatchLaunchIpcNonceStore(clock)) {
+  return verifyDispatchLaunchIpcRequest(req, {
+    secret: request.secret,
+    target: { larkAppId: target.larkAppId, bootInstanceId: target.bootInstanceId },
+    nonceStore: store, clock,
+  });
+}
 
 describe('dispatch launch IPC signing contract', () => {
   it('uses a dedicated domain and binds exact request bytes plus target boot', () => {
@@ -69,5 +112,40 @@ describe('dispatch launch IPC signing contract', () => {
       pathWithQuery: request.pathWithQuery, status: 99, body: '{}', target,
       signature: 'X'.repeat(43),
     })).toBe(false);
+  });
+});
+
+describe('dispatch launch IPC request verifier', () => {
+  it('accepts exact bytes once and rejects a replay', async () => {
+    const store = createDispatchLaunchIpcNonceStore(clock);
+    await expect(verify(makeRequest(), store)).resolves.toEqual({
+      ok: true, bodyRaw: request.body, nonce: request.nonce, target,
+    });
+    await expect(verify(makeRequest(), store)).resolves.toEqual({
+      ok: false, reason: 'replay', httpStatus: 401,
+    });
+  });
+
+  it('rejects peer, path, target, and body tampering', async () => {
+    await expect(verify(makeRequest({ remoteAddress: '192.0.2.1' }))).resolves
+      .toEqual({ ok: false, reason: 'remote_not_loopback', httpStatus: 403 });
+    await expect(verify(makeRequest({ signedPath: '/wrong' }))).resolves
+      .toEqual({ ok: false, reason: 'signature_mismatch', httpStatus: 401 });
+    await expect(verify(makeRequest({ signedTarget: { ...target, ipcPort: 4101 } }))).resolves
+      .toEqual({ ok: false, reason: 'signature_mismatch', httpStatus: 401 });
+    await expect(verify(makeRequest({ body: '{}', signedBody: '{"different":true}' }))).resolves
+      .toEqual({ ok: false, reason: 'signature_mismatch', httpStatus: 401 });
+  });
+
+  it('bounds body bytes and rejects framing ambiguity or invalid UTF-8', async () => {
+    await expect(verify(makeRequest({
+      headers: { 'content-length': String(DISPATCH_LAUNCH_IPC_BODY_LIMIT_BYTES + 1) },
+    }))).resolves.toEqual({ ok: false, reason: 'body_too_large', httpStatus: 413 });
+    await expect(verify(makeRequest({
+      headers: { 'content-length': '2', 'transfer-encoding': 'chunked' },
+    }))).resolves.toEqual({ ok: false, reason: 'body_length_mismatch', httpStatus: 400 });
+    const invalid = Buffer.from([0xc3, 0x28]);
+    await expect(verify(makeRequest({ body: invalid, signedBody: invalid }))).resolves
+      .toEqual({ ok: false, reason: 'body_not_utf8', httpStatus: 400 });
   });
 });

--- a/test/dispatch-launch-ipc-body.test.ts
+++ b/test/dispatch-launch-ipc-body.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DISPATCH_LAUNCH_SCHEMA_VERSION,
+  canonicalizeDispatchLaunchKickoff,
+} from '../src/core/dispatch-launch-contract.js';
+import { parseDispatchLaunchIpcBody } from '../src/core/dispatch-launch-ipc-body.js';
+
+const dispatchId = `dl_${'a'.repeat(32)}`;
+const digest = `sha256:${'b'.repeat(64)}`;
+
+describe('dispatch launch IPC body parser', () => {
+  it('accepts only canonical prepare JSON and binds route id through the contract body', () => {
+    const request = {
+      schemaVersion: DISPATCH_LAUNCH_SCHEMA_VERSION, protocol: 'v1' as const, dispatchId,
+      source: { larkAppId: 'cli_source', sessionId: 'session', turnId: 'turn' },
+      targetLarkAppId: 'cli_target', chatId: 'oc_chat',
+      kickoff: canonicalizeDispatchLaunchKickoff({
+        title: 'Task', brief: 'Brief', sourceDisplay: 'Source', targetLarkAppId: 'cli_target',
+      }),
+      requestedOverride: { model: 'gpt-5.6-sol' },
+      expiresAt: '2026-09-03T10:05:00.000Z',
+    };
+    expect(parseDispatchLaunchIpcBody('prepare', JSON.stringify(request))).toEqual({
+      ok: true, body: { mutation: 'prepare', value: request },
+    });
+    expect(parseDispatchLaunchIpcBody('prepare', ` ${JSON.stringify(request)}`))
+      .toEqual({ ok: false, error: 'bad_json' });
+    expect(parseDispatchLaunchIpcBody('prepare', JSON.stringify({ ...request, unknown: true })))
+      .toEqual({ ok: false, error: 'bad_body' });
+  });
+
+  it('validates strict start and cancel bodies', () => {
+    const start = {
+      schemaVersion: DISPATCH_LAUNCH_SCHEMA_VERSION, protocol: 'v1' as const, dispatchId,
+      kickoffDigest: digest, policyDigest: digest, launchIdentityDigest: digest,
+    };
+    expect(parseDispatchLaunchIpcBody('start', JSON.stringify(start))).toMatchObject({ ok: true });
+    expect(parseDispatchLaunchIpcBody('cancel', JSON.stringify({
+      schemaVersion: DISPATCH_LAUNCH_SCHEMA_VERSION, protocol: 'v1', dispatchId, reason: 'cancelled',
+    }))).toMatchObject({ ok: true });
+    expect(parseDispatchLaunchIpcBody('start', '{}')).toEqual({ ok: false, error: 'bad_body' });
+  });
+});

--- a/test/dispatch-launch-ipc-client.test.ts
+++ b/test/dispatch-launch-ipc-client.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  dispatchLaunchIpcHeaders,
+  signDispatchLaunchIpcResponse,
+} from '../src/core/dispatch-launch-ipc-auth.js';
+import {
+  DispatchLaunchIpcTransportError,
+  dispatchLaunchIpcPath,
+  dispatchLaunchIpcTarget,
+  requestDispatchLaunchIpc,
+} from '../src/core/dispatch-launch-ipc-client.js';
+
+const SECRET = 'secret';
+const NONCE = 'n'.repeat(43);
+const TIMESTAMP = '1700000000123';
+const dispatchId = `dl_${'a'.repeat(32)}`;
+const daemon = {
+  larkAppId: 'cli_target', ipcPort: 32123, bootInstanceId: 'b'.repeat(43),
+  dispatchLaunchIpcProtocol: 'v1' as const,
+};
+
+function response(bodyRaw: string, status: number, pathWithQuery: string): Response {
+  return new Response(bodyRaw, {
+    status,
+    headers: {
+      'X-Botmux-Dispatch-Launch-Ipc-Response-Signature': signDispatchLaunchIpcResponse({
+        secret: SECRET, requestNonce: NONCE, method: 'POST', pathWithQuery, status,
+        body: bodyRaw, target: daemon,
+      }),
+    },
+  });
+}
+
+describe('dispatch launch IPC client', () => {
+  it('fails closed when the target descriptor does not advertise v1', () => {
+    expect(() => dispatchLaunchIpcTarget({ ...daemon, dispatchLaunchIpcProtocol: undefined }))
+      .toThrow(DispatchLaunchIpcTransportError);
+    expect(() => dispatchLaunchIpcPath('../other', 'start')).toThrow('invalid dispatch launch id');
+  });
+
+  it('signs exact request bytes and verifies the response without retrying', async () => {
+    const path = dispatchLaunchIpcPath(dispatchId, 'start');
+    const body = { dispatchId, value: 'x' };
+    const fetchImpl = vi.fn().mockResolvedValue(response('{"ok":true}', 202, path));
+    await expect(requestDispatchLaunchIpc({
+      daemon, dispatchId, action: 'start', body, secret: SECRET, nonce: NONCE,
+      timestamp: TIMESTAMP, fetchImpl,
+    })).resolves.toEqual({ ok: true, status: 202, bodyRaw: '{"ok":true}' });
+    const expectedHeaders = dispatchLaunchIpcHeaders({
+      secret: SECRET, method: 'POST', pathWithQuery: path, bodyRaw: JSON.stringify(body),
+      target: daemon, nonce: NONCE, timestamp: TIMESTAMP,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledWith(`http://127.0.0.1:${daemon.ipcPort}${path}`, {
+      method: 'POST', headers: { 'content-type': 'application/json', ...expectedHeaders },
+      body: JSON.stringify(body),
+    });
+  });
+
+  it('rejects unsigned/tampered responses and does not transport-retry', async () => {
+    await expect(requestDispatchLaunchIpc({
+      daemon, dispatchId, action: 'cancel', secret: SECRET, nonce: NONCE,
+      fetchImpl: vi.fn().mockResolvedValue(new Response('{"ok":true}', { status: 200 })),
+    })).rejects.toThrow(/authentication failed/);
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('reset'));
+    await expect(requestDispatchLaunchIpc({
+      daemon, dispatchId, action: 'prepare', secret: SECRET, fetchImpl,
+    })).rejects.toBeInstanceOf(DispatchLaunchIpcTransportError);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+});

--- a/test/dispatch-launch-route-aperture.test.ts
+++ b/test/dispatch-launch-route-aperture.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { routeHasNarrowUntrustedAuth } from '../src/core/dashboard-ipc-server.js';
+
+describe('dispatch launch IPC narrow authentication aperture', () => {
+  const id = `dl_${'a'.repeat(32)}`;
+
+  it('allows only GET/POST under the dedicated signed route prefix', () => {
+    expect(routeHasNarrowUntrustedAuth('POST', `/__dispatch-launch-ipc/v1/operations/${id}/prepare`)).toBe(true);
+    expect(routeHasNarrowUntrustedAuth('GET', `/__dispatch-launch-ipc/v1/operations/${id}`)).toBe(true);
+    expect(routeHasNarrowUntrustedAuth('DELETE', `/__dispatch-launch-ipc/v1/operations/${id}`)).toBe(false);
+    expect(routeHasNarrowUntrustedAuth('POST', `/__dispatch-launch-ipc/v1/operations/${id}`)).toBe(false);
+    expect(routeHasNarrowUntrustedAuth('GET', `/__dispatch-launch-ipc/v1/operations/${id}/prepare`)).toBe(false);
+    expect(routeHasNarrowUntrustedAuth('POST', `/__dispatch-launch-ipc/v1/operations/${id}/unknown`)).toBe(false);
+    expect(routeHasNarrowUntrustedAuth('POST', '/__dispatch-launch-ipc/v1/operations/not-an-id/prepare')).toBe(false);
+    expect(routeHasNarrowUntrustedAuth('POST', '/__dispatch-launch-ipc/v1/not-operations/x')).toBe(false);
+  });
+});

--- a/test/dispatch-launch-source.test.ts
+++ b/test/dispatch-launch-source.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION, DISPATCH_LAUNCH_SCHEMA_VERSION,
+  canonicalizeDispatchLaunchKickoff, dispatchLaunchPolicyDigest, type DispatchLaunchIdentityV1,
+  type DispatchLaunchPrepareRequestV1,
+} from '../src/core/dispatch-launch-contract.js';
+import { createDispatchLaunchOperationStore } from '../src/core/dispatch-launch-operation-store.js';
+import { createDispatchLaunchSourceCoordinator } from '../src/core/dispatch-launch-source.js';
+
+const dispatchId = `dl_${'2'.repeat(32)}`;
+const policy = { schemaVersion: 1 as const, enabled: true, allowedSourceAppIds: ['cli_source'], allowedModels: ['gpt'], allowedReasoningEfforts: ['high' as const] };
+const identity: DispatchLaunchIdentityV1 = {
+  cliId: 'codex', cliRuntimeDigest: `sha256:${'a'.repeat(64)}`, executable: 'codex', backendType: 'pty',
+  codexRpcInput: false, existingAppServer: false, botConfigDigest: `sha256:${'b'.repeat(64)}`,
+  policyDigest: dispatchLaunchPolicyDigest(policy),
+};
+const prepareRequest: DispatchLaunchPrepareRequestV1 = {
+  schemaVersion: DISPATCH_LAUNCH_SCHEMA_VERSION, protocol: 'v1', dispatchId,
+  source: { larkAppId: 'cli_source', sessionId: 'source-session', turnId: 'source-turn' },
+  targetLarkAppId: 'cli_target', chatId: 'oc_chat',
+  kickoff: canonicalizeDispatchLaunchKickoff({ title: 'Task', brief: 'Brief', sourceDisplay: 'Source', targetLarkAppId: 'cli_target' }),
+  requestedOverride: { model: 'gpt', reasoningEffort: 'high' }, expiresAt: '2026-09-03T11:00:00.000Z',
+};
+
+describe('dispatch launch source coordinator', () => {
+  it('persists source-owned prepare/start observations and recovers through query-safe calls', async () => {
+    const store = createDispatchLaunchOperationStore({
+      dataDir: mkdtempSync(join(tmpdir(), 'dispatch-source-')), ownerLarkAppId: 'cli_source',
+    });
+    const request = vi.fn(async (input: any) => {
+      const source = store.get(dispatchId)!;
+      const operation = input.action === 'prepare'
+        ? { ...source, owner: 'target' as const, state: 'prepared' as const, effectiveOverride: { model: 'gpt', reasoningEffort: 'high' as const }, launchIdentity: identity }
+        : { ...source, owner: 'target' as const, state: 'awaiting_proof' as const, effectiveOverride: { model: 'gpt', reasoningEffort: 'high' as const }, launchIdentity: identity, rootMessageId: 'om_root', targetSessionId: 'target-session', kickoffTurnId: 'source-turn', workerGeneration: 1 };
+      return { ok: true, status: 200, bodyRaw: JSON.stringify({ ok: true, operation: { ...operation, schemaVersion: DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION } }) };
+    });
+    const coordinator = createDispatchLaunchSourceCoordinator({
+      sourceLarkAppId: 'cli_source', store, targetDaemon: { larkAppId: 'cli_target', ipcPort: 9000, bootInstanceId: 'A'.repeat(43), dispatchLaunchIpcProtocol: 'v1' },
+      now: () => new Date('2026-09-03T10:00:00.000Z'), request,
+    });
+    expect(await coordinator.prepare(prepareRequest)).toMatchObject({ ok: true, operation: { owner: 'source', state: 'prepared' } });
+    expect(await coordinator.start(dispatchId)).toMatchObject({ ok: true, operation: { owner: 'source', state: 'awaiting_proof' } });
+    expect(store.get(dispatchId)).toMatchObject({ state: 'awaiting_proof', rootMessageId: 'om_root' });
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps preparing durable when transport fails so recovery can retry', async () => {
+    const store = createDispatchLaunchOperationStore({
+      dataDir: mkdtempSync(join(tmpdir(), 'dispatch-source-')), ownerLarkAppId: 'cli_source',
+    });
+    const coordinator = createDispatchLaunchSourceCoordinator({
+      sourceLarkAppId: 'cli_source', store, targetDaemon: { larkAppId: 'cli_target', ipcPort: 9000, bootInstanceId: 'A'.repeat(43), dispatchLaunchIpcProtocol: 'v1' },
+      now: () => new Date('2026-09-03T10:00:00.000Z'), request: async () => { throw new Error('connection lost'); },
+    });
+    await expect(coordinator.prepare(prepareRequest)).rejects.toThrow('connection lost');
+    expect(store.get(dispatchId)?.state).toBe('preparing');
+  });
+
+  it('rejects requests that do not belong to the source daemon or target descriptor', async () => {
+    const store = createDispatchLaunchOperationStore({
+      dataDir: mkdtempSync(join(tmpdir(), 'dispatch-source-')), ownerLarkAppId: 'cli_source',
+    });
+    const request = vi.fn();
+    const coordinator = createDispatchLaunchSourceCoordinator({
+      sourceLarkAppId: 'cli_source', store,
+      targetDaemon: { larkAppId: 'cli_target', ipcPort: 9000, bootInstanceId: 'A'.repeat(43), dispatchLaunchIpcProtocol: 'v1' },
+      now: () => new Date('2026-09-03T10:00:00.000Z'), request,
+    });
+    expect(() => coordinator.create({
+      ...prepareRequest, source: { ...prepareRequest.source, larkAppId: 'cli_other' },
+    })).toThrow('source app id mismatch');
+    await expect(coordinator.prepare({
+      ...prepareRequest, targetLarkAppId: 'cli_other',
+    })).rejects.toThrow('target descriptor mismatch');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('rejects a query response whose target-owned identity does not match the source record', async () => {
+    const store = createDispatchLaunchOperationStore({
+      dataDir: mkdtempSync(join(tmpdir(), 'dispatch-source-')), ownerLarkAppId: 'cli_source',
+    });
+    const coordinator = createDispatchLaunchSourceCoordinator({
+      sourceLarkAppId: 'cli_source', store,
+      targetDaemon: { larkAppId: 'cli_target', ipcPort: 9000, bootInstanceId: 'A'.repeat(43), dispatchLaunchIpcProtocol: 'v1' },
+      now: () => new Date('2026-09-03T10:00:00.000Z'),
+      request: async () => ({
+        ok: true, status: 200, bodyRaw: JSON.stringify({
+          ok: true, operation: { ...store.get(dispatchId), owner: 'target', chatId: 'oc_other' },
+        }),
+      }),
+    });
+    coordinator.create(prepareRequest);
+    await expect(coordinator.query(dispatchId)).rejects.toThrow('target operation identity mismatch');
+  });
+});

--- a/test/dispatch-launch-store.test.ts
+++ b/test/dispatch-launch-store.test.ts
@@ -1,0 +1,155 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION,
+  DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION,
+  canonicalizeDispatchLaunchKickoff,
+  type DispatchLaunchAdmissionReceiptV1,
+  type DispatchLaunchOperationV1,
+} from '../src/core/dispatch-launch-contract.js';
+import {
+  DispatchLaunchAdmissionConflictError,
+  createDispatchLaunchAdmissionStore,
+} from '../src/core/dispatch-launch-admission-store.js';
+import {
+  DispatchLaunchOperationConflictError,
+  createDispatchLaunchOperationStore,
+} from '../src/core/dispatch-launch-operation-store.js';
+
+const NOW = '2026-09-03T10:00:00.000Z';
+const LATER = '2026-09-03T10:05:00.000Z';
+const SHA = `sha256:${'a'.repeat(64)}`;
+const DISPATCH_ID = `dl_${'b'.repeat(32)}`;
+
+function operation(state: DispatchLaunchOperationV1['state'] = 'created'): DispatchLaunchOperationV1 {
+  const base = {
+    schemaVersion: DISPATCH_LAUNCH_OPERATION_SCHEMA_VERSION,
+    dispatchId: DISPATCH_ID,
+    owner: 'source' as const,
+    sourceLarkAppId: 'cli_source',
+    sourceSessionId: 'source-session',
+    sourceTurnId: 'source-turn',
+    targetLarkAppId: 'cli_target',
+    chatId: 'oc_chat',
+    kickoff: canonicalizeDispatchLaunchKickoff({
+      title: 'Task', brief: 'Do it', sourceDisplay: 'Source', targetLarkAppId: 'cli_target',
+    }),
+    requestedOverride: { model: 'gpt-5.6-sol', reasoningEffort: 'high' as const },
+    createdAt: NOW, updatedAt: NOW, expiresAt: LATER,
+  };
+  if (state === 'created' || state === 'preparing') return { ...base, state };
+  const admitted = {
+    ...base, state,
+    effectiveOverride: { model: 'gpt-5.6-sol', reasoningEffort: 'high' as const },
+    launchIdentity: {
+      cliId: 'codex' as const, cliRuntimeDigest: SHA, executable: 'codex',
+      backendType: 'pty' as const, codexRpcInput: false as const, existingAppServer: false as const,
+      botConfigDigest: SHA, policyDigest: SHA,
+    },
+  };
+  if (state === 'prepared' || state === 'starting') return admitted;
+  if (state === 'failed') return { ...admitted, state, errorCode: 'INTERNAL_ERROR' };
+  throw new Error(`unsupported test state ${state}`);
+}
+
+function receipt(): DispatchLaunchAdmissionReceiptV1 {
+  return {
+    schemaVersion: DISPATCH_LAUNCH_ADMISSION_SCHEMA_VERSION,
+    dispatchId: DISPATCH_ID, state: 'authorized', sourceLarkAppId: 'cli_source',
+    sourceSessionId: 'source-session', sourceTurnId: 'source-turn', callerUnionId: 'on_caller',
+    sourceOpenId: 'ou_source', chatType: 'group', talkReason: 'chatGrant',
+    chatId: 'oc_chat', targetLarkAppId: 'cli_target', policyDigest: SHA,
+    effectiveOverride: { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+    launchIdentity: operation('prepared').launchIdentity,
+    talkAuthorizationReceiptId: 'talk-receipt', quotaReceiptId: 'quota-receipt',
+    workingDir: '/repo', capacityReservationId: 'capacity-receipt', createdAt: NOW,
+  };
+}
+
+describe('dispatch launch operation store', () => {
+  it('creates idempotently, persists CAS transitions, and enumerates only recoverable operations', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'dispatch-operation-'));
+    const store = createDispatchLaunchOperationStore({ dataDir, ownerLarkAppId: 'cli_source' });
+    expect(store.create(operation())).toMatchObject({ created: true });
+    expect(store.create(operation())).toMatchObject({ created: false });
+    const preparing = { ...operation(), state: 'preparing' as const, updatedAt: '2026-09-03T10:00:01.000Z' };
+    store.transition({ dispatchId: DISPATCH_ID, expectedState: 'created', next: preparing });
+    expect(store.listRecoverable()).toEqual([preparing]);
+    const failed = {
+      ...preparing, state: 'failed' as const, errorCode: 'INTERNAL_ERROR' as const,
+      updatedAt: '2026-09-03T10:00:02.000Z',
+    };
+    store.transition({ dispatchId: DISPATCH_ID, expectedState: 'preparing', next: failed });
+    expect(store.listRecoverable()).toEqual([]);
+  });
+
+  it('rejects owner, identity, illegal transition, stale state, and post-prepare tuple changes', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'dispatch-operation-'));
+    const store = createDispatchLaunchOperationStore({ dataDir, ownerLarkAppId: 'cli_source' });
+    expect(() => store.create({ ...operation(), sourceLarkAppId: 'cli_other' }))
+      .toThrow(DispatchLaunchOperationConflictError);
+    store.create(operation());
+    expect(() => store.create({ ...operation(), chatId: 'oc_other' }))
+      .toThrow(DispatchLaunchOperationConflictError);
+    expect(() => store.transition({ dispatchId: DISPATCH_ID, expectedState: 'prepared', next: operation('preparing') }))
+      .toThrow(DispatchLaunchOperationConflictError);
+
+    const preparing = { ...operation(), state: 'preparing' as const, updatedAt: '2026-09-03T10:00:01.000Z' };
+    store.transition({ dispatchId: DISPATCH_ID, expectedState: 'created', next: preparing });
+    const prepared = { ...operation('prepared'), updatedAt: '2026-09-03T10:00:02.000Z' };
+    store.transition({ dispatchId: DISPATCH_ID, expectedState: 'preparing', next: prepared });
+    const changed = {
+      ...operation('starting'),
+      launchIdentity: {
+        ...operation('starting').launchIdentity,
+        executable: '/other/codex',
+      },
+      updatedAt: '2026-09-03T10:00:03.000Z',
+    };
+    expect(() => store.transition({ dispatchId: DISPATCH_ID, expectedState: 'prepared', next: changed }))
+      .toThrow(/prepared launch identity/);
+  });
+
+  it('fails closed when a persisted record is corrupt', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'dispatch-operation-'));
+    const store = createDispatchLaunchOperationStore({ dataDir, ownerLarkAppId: 'cli_source' });
+    store.create(operation());
+    const ownerDir = join(
+      dataDir, 'dispatch-launch', 'operations',
+      createHash('sha256').update('cli_source').digest('hex'),
+    );
+    writeFileSync(join(ownerDir, `${DISPATCH_ID}.json`), '{broken');
+    expect(() => store.get(DISPATCH_ID)).toThrow();
+  });
+});
+
+describe('dispatch launch admission store', () => {
+  it('authorizes and settles exactly once while preserving immutable identity', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'dispatch-admission-'));
+    const store = createDispatchLaunchAdmissionStore({ dataDir, targetLarkAppId: 'cli_target' });
+    expect(store.authorize(receipt())).toMatchObject({ created: true });
+    expect(store.authorize(receipt())).toMatchObject({ created: false });
+    expect(store.listAuthorized()).toHaveLength(1);
+    const committed = store.commit(DISPATCH_ID, '2026-09-03T10:00:01.000Z');
+    expect(committed).toMatchObject({ state: 'committed', committedAt: '2026-09-03T10:00:01.000Z' });
+    expect(store.commit(DISPATCH_ID, '2026-09-03T10:00:02.000Z')).toEqual(committed);
+    expect(store.listAuthorized()).toEqual([]);
+    expect(() => store.release(DISPATCH_ID, '2026-09-03T10:00:03.000Z'))
+      .toThrow(DispatchLaunchAdmissionConflictError);
+  });
+
+  it('rejects foreign targets and dispatch-id reuse with different admission data', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'dispatch-admission-'));
+    const store = createDispatchLaunchAdmissionStore({ dataDir, targetLarkAppId: 'cli_target' });
+    expect(() => store.authorize({ ...receipt(), targetLarkAppId: 'cli_other' }))
+      .toThrow(DispatchLaunchAdmissionConflictError);
+    store.authorize(receipt());
+    expect(() => store.authorize({ ...receipt(), workingDir: '/other' }))
+      .toThrow(DispatchLaunchAdmissionConflictError);
+  });
+});

--- a/test/dispatch-launch-target.test.ts
+++ b/test/dispatch-launch-target.test.ts
@@ -49,6 +49,7 @@ function setup() {
     root: vi.fn(async () => 'om_root'),
     session: vi.fn(async () => ({ sessionId: 'target-session' })),
     worker: vi.fn(async () => ({ kickoffTurnId: 'source-turn', workerGeneration: 1 })),
+    authorizeTalk: vi.fn(() => ({ allowed: true, reason: 'chatGrant', quotaKey: 'chat:oc_chat:ou_source', grantChatId: 'oc_chat' })),
   };
   const now = vi.fn(() => new Date('2026-09-03T10:00:00.000Z'));
   const coordinator = createDispatchLaunchTargetCoordinator({
@@ -56,7 +57,7 @@ function setup() {
     operationStore, admissionStore, now, resolveIdentity: () => identity,
     resolveWorkingDir: () => '/repo', resolveChatType: async () => 'group', capacityAvailable: () => true,
     resolveSourceOpenId: async () => 'ou_source',
-    authorizeTalk: () => ({ allowed: true, reason: 'chatGrant', quotaKey: 'chat:oc_chat:ou_source', grantChatId: 'oc_chat' }),
+    authorizeTalk: effects.authorizeTalk,
     consumeQuotaOnce: effects.quota, ensureRoot: effects.root, ensureSession: effects.session, ensureWorker: effects.worker,
   });
   return { coordinator, operationStore, admissionStore, effects, now };
@@ -97,6 +98,15 @@ describe('dispatch launch target coordinator', () => {
     expect(await coordinator.prepare(denied)).toMatchObject({ ok: false, errorCode: 'UNAUTHORIZED_SOURCE' });
     expect(operationStore.get(DISPATCH_ID)?.state).toBe('failed');
     expect(admissionStore.get(DISPATCH_ID)).toBeUndefined();
+  });
+
+  it('never uses source-attested caller union id as the bot-talk trust identity', async () => {
+    const { coordinator, effects } = setup();
+    const withCaller = request();
+    withCaller.source.callerUnionId = 'on_human';
+    expect(await coordinator.prepare(withCaller)).toMatchObject({ ok: true, operation: { state: 'prepared' } });
+    expect(effects.authorizeTalk).toHaveBeenCalledWith('oc_chat', 'ou_source');
+    expect(effects.authorizeTalk.mock.calls[0]).toHaveLength(2);
   });
 
   it('expires a prepared operation without running side effects', async () => {

--- a/test/dispatch-launch-target.test.ts
+++ b/test/dispatch-launch-target.test.ts
@@ -1,0 +1,158 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DISPATCH_LAUNCH_SCHEMA_VERSION,
+  canonicalizeDispatchLaunchKickoff,
+  dispatchLaunchIdentityDigest,
+  dispatchLaunchPolicyDigest,
+  type DispatchLaunchIdentityV1,
+  type DispatchLaunchPrepareRequestV1,
+} from '../src/core/dispatch-launch-contract.js';
+import { createDispatchLaunchAdmissionStore } from '../src/core/dispatch-launch-admission-store.js';
+import { createDispatchLaunchOperationStore } from '../src/core/dispatch-launch-operation-store.js';
+import { createDispatchLaunchTargetCoordinator } from '../src/core/dispatch-launch-target.js';
+
+const DISPATCH_ID = `dl_${'1'.repeat(32)}`;
+const SHA = `sha256:${'a'.repeat(64)}`;
+const policy = {
+  schemaVersion: 1 as const, enabled: true, allowedSourceAppIds: ['cli_source'],
+  allowedModels: ['gpt-5.6-sol'], allowedReasoningEfforts: ['high' as const],
+};
+const identity: DispatchLaunchIdentityV1 = {
+  cliId: 'codex', cliRuntimeDigest: SHA, executable: 'codex', backendType: 'pty',
+  codexRpcInput: false, existingAppServer: false, botConfigDigest: SHA,
+  policyDigest: dispatchLaunchPolicyDigest(policy),
+};
+
+function request(expiresAt = '2026-09-03T11:00:00.000Z'): DispatchLaunchPrepareRequestV1 {
+  return {
+    schemaVersion: DISPATCH_LAUNCH_SCHEMA_VERSION, protocol: 'v1', dispatchId: DISPATCH_ID,
+    source: { larkAppId: 'cli_source', sessionId: 'source-session', turnId: 'source-turn' },
+    targetLarkAppId: 'cli_target', chatId: 'oc_chat',
+    kickoff: canonicalizeDispatchLaunchKickoff({
+      title: 'Task', brief: 'Implement it', sourceDisplay: 'Source', targetLarkAppId: 'cli_target',
+    }),
+    requestedOverride: { model: 'gpt-5.6-sol', reasoningEffort: 'high' }, expiresAt,
+  };
+}
+
+function setup() {
+  const dataDir = mkdtempSync(join(tmpdir(), 'dispatch-target-'));
+  const operationStore = createDispatchLaunchOperationStore({ dataDir, ownerLarkAppId: 'cli_target' });
+  const admissionStore = createDispatchLaunchAdmissionStore({ dataDir, targetLarkAppId: 'cli_target' });
+  const effects = {
+    quota: vi.fn(async () => ({ allow: true })),
+    root: vi.fn(async () => 'om_root'),
+    session: vi.fn(async () => ({ sessionId: 'target-session' })),
+    worker: vi.fn(async () => ({ kickoffTurnId: 'source-turn', workerGeneration: 1 })),
+  };
+  const now = vi.fn(() => new Date('2026-09-03T10:00:00.000Z'));
+  const coordinator = createDispatchLaunchTargetCoordinator({
+    target: { larkAppId: 'cli_target', cliId: 'codex', model: 'gpt-5.6-sol', reasoningEffort: 'high', policy },
+    operationStore, admissionStore, now, resolveIdentity: () => identity,
+    resolveWorkingDir: () => '/repo', resolveChatType: async () => 'group', capacityAvailable: () => true,
+    resolveSourceOpenId: async () => 'ou_source',
+    authorizeTalk: () => ({ allowed: true, reason: 'chatGrant', quotaKey: 'chat:oc_chat:ou_source', grantChatId: 'oc_chat' }),
+    consumeQuotaOnce: effects.quota, ensureRoot: effects.root, ensureSession: effects.session, ensureWorker: effects.worker,
+  });
+  return { coordinator, operationStore, admissionStore, effects, now };
+}
+
+describe('dispatch launch target coordinator', () => {
+  it('prepares and starts idempotently through durable side-effect checkpoints', async () => {
+    const { coordinator, admissionStore, effects } = setup();
+    const prepared = await coordinator.prepare(request());
+    expect(prepared).toMatchObject({ ok: true, operation: { state: 'prepared' } });
+    expect(await coordinator.prepare(request())).toEqual(prepared);
+    const operation = prepared.ok ? prepared.operation : undefined;
+    expect(operation && 'launchIdentity' in operation).toBe(true);
+    const started = await coordinator.start({
+      schemaVersion: 1, protocol: 'v1', dispatchId: DISPATCH_ID,
+      kickoffDigest: request().kickoff.digest, policyDigest: identity.policyDigest,
+      launchIdentityDigest: dispatchLaunchIdentityDigest(identity),
+    });
+    expect(started).toMatchObject({
+      ok: true, operation: { state: 'awaiting_proof', rootMessageId: 'om_root', targetSessionId: 'target-session', workerGeneration: 1 },
+    });
+    expect(admissionStore.get(DISPATCH_ID)?.state).toBe('committed');
+    expect(await coordinator.start({
+      schemaVersion: 1, protocol: 'v1', dispatchId: DISPATCH_ID,
+      kickoffDigest: request().kickoff.digest, policyDigest: identity.policyDigest,
+      launchIdentityDigest: dispatchLaunchIdentityDigest(identity),
+    })).toEqual(started);
+    expect(effects.quota).toHaveBeenCalledTimes(1);
+    expect(effects.root).toHaveBeenCalledTimes(1);
+    expect(effects.session).toHaveBeenCalledTimes(1);
+    expect(effects.worker).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed before admission when target policy denies the source', async () => {
+    const { coordinator, admissionStore, operationStore } = setup();
+    const denied = request();
+    denied.source.larkAppId = 'cli_other';
+    expect(await coordinator.prepare(denied)).toMatchObject({ ok: false, errorCode: 'UNAUTHORIZED_SOURCE' });
+    expect(operationStore.get(DISPATCH_ID)?.state).toBe('failed');
+    expect(admissionStore.get(DISPATCH_ID)).toBeUndefined();
+  });
+
+  it('expires a prepared operation without running side effects', async () => {
+    const { coordinator, effects, now } = setup();
+    const prepared = await coordinator.prepare(request('2026-09-03T10:01:00.000Z'));
+    expect(prepared.ok).toBe(true);
+    now.mockReturnValue(new Date('2026-09-03T10:02:00.000Z'));
+    const started = await coordinator.start({
+      schemaVersion: 1, protocol: 'v1', dispatchId: DISPATCH_ID, kickoffDigest: request().kickoff.digest,
+      policyDigest: identity.policyDigest, launchIdentityDigest: dispatchLaunchIdentityDigest(identity),
+    });
+    expect(started).toMatchObject({ ok: true, operation: { state: 'failed', errorCode: 'OPERATION_EXPIRED' } });
+    expect(effects.root).not.toHaveBeenCalled();
+  });
+
+  it('recovers a crash between durable admission and prepared transition', async () => {
+    const { coordinator, admissionStore, operationStore } = setup();
+    const base = request();
+    operationStore.create({
+      schemaVersion: 1, dispatchId: DISPATCH_ID, owner: 'target', sourceLarkAppId: 'cli_source',
+      sourceSessionId: 'source-session', sourceTurnId: 'source-turn', targetLarkAppId: 'cli_target',
+      chatId: 'oc_chat', kickoff: base.kickoff, requestedOverride: base.requestedOverride,
+      createdAt: '2026-09-03T10:00:00.000Z', updatedAt: '2026-09-03T10:00:00.000Z',
+      expiresAt: base.expiresAt, state: 'preparing',
+    });
+    admissionStore.authorize({
+      schemaVersion: 1, dispatchId: DISPATCH_ID, state: 'authorized', sourceLarkAppId: 'cli_source',
+      sourceSessionId: 'source-session', sourceTurnId: 'source-turn', sourceOpenId: 'ou_source',
+      chatType: 'group', talkReason: 'chatGrant', chatId: 'oc_chat', targetLarkAppId: 'cli_target',
+      policyDigest: identity.policyDigest, effectiveOverride: { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+      launchIdentity: identity, talkAuthorizationReceiptId: 'talk-receipt', quotaReceiptId: 'quota-receipt',
+      workingDir: '/repo', capacityReservationId: 'capacity-receipt', createdAt: '2026-09-03T10:00:00.000Z',
+    });
+    expect(await coordinator.prepare(base)).toMatchObject({ ok: true, operation: { state: 'prepared' } });
+  });
+
+  it('fails closed when a recovery receipt does not match the current frozen launch identity', async () => {
+    const { coordinator, admissionStore, operationStore } = setup();
+    const base = request();
+    operationStore.create({
+      schemaVersion: 1, dispatchId: DISPATCH_ID, owner: 'target', sourceLarkAppId: 'cli_source',
+      sourceSessionId: 'source-session', sourceTurnId: 'source-turn', targetLarkAppId: 'cli_target',
+      chatId: 'oc_chat', kickoff: base.kickoff, requestedOverride: base.requestedOverride,
+      createdAt: '2026-09-03T10:00:00.000Z', updatedAt: '2026-09-03T10:00:00.000Z',
+      expiresAt: base.expiresAt, state: 'preparing',
+    });
+    admissionStore.authorize({
+      schemaVersion: 1, dispatchId: DISPATCH_ID, state: 'authorized', sourceLarkAppId: 'cli_source',
+      sourceSessionId: 'source-session', sourceTurnId: 'source-turn', sourceOpenId: 'ou_source',
+      chatType: 'group', talkReason: 'chatGrant', chatId: 'oc_chat', targetLarkAppId: 'cli_target',
+      policyDigest: identity.policyDigest, effectiveOverride: { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+      launchIdentity: { ...identity, executable: '/stale/codex' },
+      talkAuthorizationReceiptId: 'talk-receipt', quotaReceiptId: 'quota-receipt',
+      workingDir: '/repo', capacityReservationId: 'capacity-receipt', createdAt: '2026-09-03T10:00:00.000Z',
+    });
+    expect(await coordinator.prepare(base)).toMatchObject({ ok: false, errorCode: 'OPERATION_CONFLICT' });
+    expect(operationStore.get(DISPATCH_ID)).toMatchObject({ state: 'failed', errorCode: 'OPERATION_CONFLICT' });
+  });
+});

--- a/test/grant-store.test.ts
+++ b/test/grant-store.test.ts
@@ -152,6 +152,71 @@ describe('grant-store', () => {
 });
 
 describe('grant-store message quota', () => {
+  it('charges a dispatch launch receipt exactly once across repeated calls', async () => {
+    const quotaKey = 'chat:oc_1:ou_g';
+    writeConfig({
+      allowedUsers: ['ou_owner'],
+      chatGrants: { oc_1: ['ou_g'] },
+      quotaState: { [quotaKey]: { limit: 3, used: 0 } },
+    });
+    const { registry, store } = await freshModules();
+    const input = {
+      larkAppId: 'a1', quotaKey, receiptId: `quota_${'1'.repeat(32)}`, sourceOpenId: 'ou_g', grantChatId: 'oc_1',
+    };
+    expect(await store.consumeDispatchLaunchQuotaOnce(input)).toEqual({ allow: true });
+    expect(await store.consumeDispatchLaunchQuotaOnce(input)).toEqual({ allow: true });
+    expect(readConfig().quotaState[quotaKey]).toEqual({ limit: 3, used: 1 });
+    expect(readConfig().dispatchLaunchQuotaReceipts[`quota_${'1'.repeat(32)}`]).toMatchObject({ allow: true });
+    expect(registry.getBot('a1').config.quotaState?.[quotaKey]).toEqual({ limit: 3, used: 1 });
+  });
+
+  it('persists a denied dispatch receipt without changing exhausted quota', async () => {
+    const quotaKey = 'chat:oc_1:ou_g';
+    writeConfig({
+      allowedUsers: ['ou_owner'],
+      chatGrants: { oc_1: ['ou_g'] },
+      quotaState: { [quotaKey]: { limit: 2, used: 2 } },
+    });
+    const { store } = await freshModules();
+    const input = {
+      larkAppId: 'a1', quotaKey, receiptId: `quota_${'2'.repeat(32)}`, sourceOpenId: 'ou_g', grantChatId: 'oc_1',
+    };
+    expect(await store.consumeDispatchLaunchQuotaOnce(input)).toEqual({ allow: false });
+    expect(await store.consumeDispatchLaunchQuotaOnce(input)).toEqual({ allow: false });
+    expect(readConfig().quotaState[quotaKey]).toEqual({ limit: 2, used: 2 });
+    expect(readConfig().dispatchLaunchQuotaReceipts[`quota_${'2'.repeat(32)}`]).toMatchObject({ allow: false });
+  });
+
+  it('fails closed when the frozen dispatch quota key no longer has its grant', async () => {
+    const quotaKey = 'chat:oc_1:ou_g';
+    writeConfig({ allowedUsers: ['ou_owner'] });
+    const { store } = await freshModules();
+    expect(await store.consumeDispatchLaunchQuotaOnce({
+      larkAppId: 'a1', quotaKey, receiptId: `quota_${'4'.repeat(32)}`, sourceOpenId: 'ou_g', grantChatId: 'oc_1',
+    })).toEqual({ allow: false });
+    expect(readConfig().dispatchLaunchQuotaReceipts[`quota_${'4'.repeat(32)}`]).toMatchObject({ allow: false });
+    expect(readConfig().quotaState).toBeUndefined();
+  });
+
+  it('atomically exhausts finite dispatch quota and revokes the matching chat grant', async () => {
+    const quotaKey = 'chat:oc_1:ou_g';
+    writeConfig({
+      allowedUsers: ['ou_owner'],
+      chatGrants: { oc_1: ['ou_g', 'ou_other'] },
+      quotaState: { [quotaKey]: { limit: 1, used: 0 } },
+      grantExpiryState: { [quotaKey]: { expiresAt: Date.now() + 60_000 } },
+    });
+    const { registry, store } = await freshModules();
+    expect(await store.consumeDispatchLaunchQuotaOnce({
+      larkAppId: 'a1', quotaKey, receiptId: `quota_${'3'.repeat(32)}`, sourceOpenId: 'ou_g', grantChatId: 'oc_1',
+    })).toEqual({ allow: true });
+    expect(readConfig().chatGrants).toEqual({ oc_1: ['ou_other'] });
+    expect(readConfig().quotaState).toBeUndefined();
+    expect(readConfig().grantExpiryState).toBeUndefined();
+    expect(registry.getBot('a1').config.chatGrants).toEqual({ oc_1: ['ou_other'] });
+    expect(registry.getBot('a1').config.dispatchLaunchQuotaReceipts?.[`quota_${'3'.repeat(32)}`]).toMatchObject({ allow: true });
+  });
+
   it('persists expiry and re-granting as permanent clears only the expiry record', async () => {
     writeConfig({ allowedUsers: ['ou_owner'] });
     const { registry, store } = await freshModules();


### PR DESCRIPTION
## 背景与最终目标

这是 #1206 的第二阶段。最终目标是在多话题协作中，让 source bot 为一次派发请求 session-scoped model / reasoning effort，同时由 target daemon 独立完成策略、授权、运行身份和实际启动裁决。

本 PR 只建立内部、默认关闭的 target-authoritative transport 与恢复链路：不新增公开命令，不让现有 `dispatch` 接受 override，也不发布面向用户的 capability。

## 本 PR 做了什么

### 1. 持久 operation 与 admission

- 新增 source/target 分属的 operation store，以 `dispatchId` 为键并通过文件锁、原子写和 CAS 状态迁移持久化。
- 新增 target-owned admission receipt，冻结 source/chat/target、talk authorization、workingDir、policy、effective override 和 launch identity。
- 重试必须匹配原始身份；恢复时 receipt 与当前 request、policy、launch identity 不一致会 fail closed。
- target 启动恢复在 IPC ready 之前顺序收敛 `prepared` / `starting` operation；不确定的 provider 窗口进入 `delivery_unknown`，不会盲目重放。

### 2. 同机签名 IPC

新增内部 v1 routes：

- `POST /__dispatch-launch-ipc/v1/operations/:dispatchId/prepare`
- `POST /__dispatch-launch-ipc/v1/operations/:dispatchId/start`
- `GET /__dispatch-launch-ipc/v1/operations/:dispatchId`
- `POST /__dispatch-launch-ipc/v1/operations/:dispatchId/cancel`

安全边界包括：

- 仅 loopback；
- request/response 独立 HMAC domain；
- 签名绑定 target app、实际监听 port、boot instance、method、path、status 和原始 body；
- 60 秒 timestamp window、nonce replay protection、80 KiB body 上限、严格 framing/UTF-8/canonical JSON、5 秒读取超时；
- dashboard HMAC 只为上述精确 method/path 组合开窄孔，route handler 再执行专用完整认证。

目标 daemon 只有在 `dispatchLaunchPolicy.enabled === true` 时才注册 coordinator，并在 descriptor 声明 `dispatchLaunchIpcProtocol: v1`；旧 daemon 或未启用 target 因缺少协议声明而拒绝。

### 3. Target-authoritative admission 与幂等启动

prepare 由 target 实时决定：

- 目标 app、协议与过期时间；
- Codex TUI harness/runtime/backend identity；
- target policy 允许的 source/model/reasoning effort；
- 当前 chat membership 与 bot-talk authorization；
- workingDir 与 worker capacity。

start 使用冻结 tuple，并按持久 checkpoint 依次完成：

- quota receipt 与额度扣减在同一个 `bots.json` RMW 锁内提交，重复 start 只收费一次；授权已撤销时 fail closed；
- 用稳定 provider UUID 幂等创建 Lark root；
- 创建带 `dispatchLaunchId` 的 fresh thread session，并在首次 worker ACK 前持久化 kickoff；
- 幂等恢复 root/session/worker generation；
- cancel 可以释放未提交 admission 或关闭已创建 session。

本阶段只推进到 `awaiting_proof`，不会伪造最终成功。

## 向后兼容与适配成本

- 新 bot config、session、daemon descriptor 和 receipt 字段均为 optional。
- feature gate 缺省关闭；旧 bot、旧 harness、旧 session 和现有 `dispatch` 调用保持原行为，无迁移要求。
- v1 只支持同一 data dir 下通过 loopback 发现的 daemon；不改变跨机器行为。
- v1 仅接受官方 Codex TUI，其他 harness 会明确拒绝，不会降级成默认模型执行。

## 验证

```bash
PATH=/data00/home/tan.yuanhong/.bun/bin:$PATH bun run test -- \
  test/dispatch-launch-contract.test.ts \
  test/dispatch-launch-store.test.ts \
  test/dispatch-launch-ipc-auth.test.ts \
  test/dispatch-launch-ipc-body.test.ts \
  test/dispatch-launch-ipc-client.test.ts \
  test/dispatch-launch-target.test.ts \
  test/dispatch-launch-source.test.ts \
  test/dispatch-launch-route-aperture.test.ts \
  test/daemon-discovery.test.ts \
  test/bot-registry.test.ts \
  test/grant-store.test.ts
```

结果：11 个测试文件、221 项测试全部通过。

```bash
PATH=/data00/home/tan.yuanhong/.bun/bin:$PATH bun run build
```

结果：domain audit、TypeScript、scripts typecheck、dashboard bundle、dist audit 和 embedded asset audit 全部通过。

## Follow-up PR

### PR 3：统一 resolver、运行时证明与正式入口

- 将 session-scoped override 接入首次启动、restart、restore 和 fork 的统一 launch resolver；
- 记录并校验同一 kickoff turn、同一 worker generation 的 input committed 与 runtime observed；
- 只有实际 model/reasoning effort 与冻结 effective tuple 一致时才进入 `succeeded`；
- 完成故障注入覆盖后开放独立 `botmux dispatch-launch --model ... --reasoning-effort ...` 并发布 capability。

### 后续扩展

- 多目标 fan-out；
- Codex App/RPC、TraeX、Grok 等 harness；
- 跨机器 discovery、密钥分发与网络信任；
- fleet 基线成熟后，再评估为原 `dispatch` 增加 override 别名。
