### PR TITLE
fix(grant): 授权申请卡优先 @ 当前群内管理员

### DIFF
--- a/docs-site/docs/en/bots-json.md
+++ b/docs-site/docs/en/bots-json.md
@@ -196,7 +196,7 @@ This option addresses one narrow gap: Codex running through Botmux's app-server 
 
 | Field | Description |
 |------|------|
-| `ownerOpenId` | Explicit primary owner `ou_xxx` for this bot. When omitted, defaults to the first resolved `ou_xxx` user in `allowedUsers`. When multiple administrators are configured, grant request cards prioritize @mentioning administrators who are currently present in the chat (avoiding pinging people outside the chat) |
+| `ownerOpenId` | Explicit primary owner `ou_xxx` for this bot. It participates in runtime authorization only while it remains in the resolved `allowedUsers` list; after removal or resolution failure, permissions follow the resolved allowlist, while the raw value is retained only as a DM fallback for resolution failures. When omitted, ownership defaults to the first resolved `ou_xxx` user. When multiple administrators are configured, grant request cards prioritize @mentioning administrators who are currently present in the chat (avoiding pinging people outside the chat) |
 | `allowedUsers` | The operate-permission list. Prefer a **full email**, mobile number, or `on_xxx`; an `ou_xxx` is valid only for the same app that issued it and must never be copied across Bots. When `allowedChatGroups` is configured, at least one is required to serve as owner |
 | `allowedChatGroups` | Conversable groups (`oc_xxx`). Any member of the group can converse (only `canTalk`); sensitive operations are still controlled by `allowedUsers` |
 | `p2pOpen` | When `true`, any user within the Lark app's availability scope may DM this bot (only `canTalk`). Group behavior is unchanged and sensitive operations still require `allowedUsers`. Always configure at least one `allowedUsers` owner |

--- a/docs-site/docs/en/bots-json.md
+++ b/docs-site/docs/en/bots-json.md
@@ -196,6 +196,7 @@ This option addresses one narrow gap: Codex running through Botmux's app-server 
 
 | Field | Description |
 |------|------|
+| `ownerOpenId` | Explicit primary owner `ou_xxx` for this bot. When omitted, defaults to the first resolved `ou_xxx` user in `allowedUsers`. When multiple administrators are configured, grant request cards prioritize @mentioning administrators who are currently present in the chat (avoiding pinging people outside the chat) |
 | `allowedUsers` | The operate-permission list. Prefer a **full email**, mobile number, or `on_xxx`; an `ou_xxx` is valid only for the same app that issued it and must never be copied across Bots. When `allowedChatGroups` is configured, at least one is required to serve as owner |
 | `allowedChatGroups` | Conversable groups (`oc_xxx`). Any member of the group can converse (only `canTalk`); sensitive operations are still controlled by `allowedUsers` |
 | `p2pOpen` | When `true`, any user within the Lark app's availability scope may DM this bot (only `canTalk`). Group behavior is unchanged and sensitive operations still require `allowedUsers`. Always configure at least one `allowedUsers` owner |

--- a/docs-site/docs/zh/bots-json.md
+++ b/docs-site/docs/zh/bots-json.md
@@ -195,6 +195,7 @@
 
 | 字段 | 说明 |
 |------|------|
+| `ownerOpenId` | 显式指定该 bot 的主管理员 `ou_xxx`。未指定时默认取 `allowedUsers` 中解析出的首个 `ou_xxx` 用户作为主 owner。当配置了多位管理员时，群内授权申请卡会优先 @ 当前群内的管理员（避免 ping 群外人员） |
 | `allowedUsers` | 操作权名单。推荐使用**完整邮箱**、手机号或 `on_xxx`；`ou_xxx` 只能用于签发它的同一应用，禁止跨 Bot 复制。配了 `allowedChatGroups` 时至少要有一个作为 owner |
 | `allowedChatGroups` | 可对话群（`oc_xxx`）。群内任何成员可对话（仅 `canTalk`），敏感操作仍由 `allowedUsers` 控制 |
 | `p2pOpen` | `true` 时允许飞书应用可用范围内的任何用户私聊该 bot（仅 `canTalk`）；群聊不受影响，敏感操作仍只认 `allowedUsers`。建议始终同时配置至少一个 `allowedUsers` owner |

--- a/docs-site/docs/zh/bots-json.md
+++ b/docs-site/docs/zh/bots-json.md
@@ -195,7 +195,7 @@
 
 | 字段 | 说明 |
 |------|------|
-| `ownerOpenId` | 显式指定该 bot 的主管理员 `ou_xxx`。未指定时默认取 `allowedUsers` 中解析出的首个 `ou_xxx` 用户作为主 owner。当配置了多位管理员时，群内授权申请卡会优先 @ 当前群内的管理员（避免 ping 群外人员） |
+| `ownerOpenId` | 显式指定该 bot 的主管理员 `ou_xxx`。它只有在仍存在于 `allowedUsers` 的解析结果中时才参与运行时权限判定；被移除或解析失败后权限会跟随解析出的 allowlist，原始值仅用于解析失败时的 DM 兜底。未指定时默认取解析出的首个 `ou_xxx` 用户。当配置了多位管理员时，群内授权申请卡会优先 @ 当前群内的管理员（避免 ping 群外人员） |
 | `allowedUsers` | 操作权名单。推荐使用**完整邮箱**、手机号或 `on_xxx`；`ou_xxx` 只能用于签发它的同一应用，禁止跨 Bot 复制。配了 `allowedChatGroups` 时至少要有一个作为 owner |
 | `allowedChatGroups` | 可对话群（`oc_xxx`）。群内任何成员可对话（仅 `canTalk`），敏感操作仍由 `allowedUsers` 控制 |
 | `p2pOpen` | `true` 时允许飞书应用可用范围内的任何用户私聊该 bot（仅 `canTalk`）；群聊不受影响，敏感操作仍只认 `allowedUsers`。建议始终同时配置至少一个 `allowedUsers` owner |

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1660,7 +1660,9 @@ export interface BotConfig {
    *   1. a fail-safe DM recipient for allowedUsers-resolve failure notices, so
    *      the owner is reachable even when the resolve that would have produced
    *      their open_id is the very thing that failed (cold-start race);
-   *   2. an always-available owner anchor for runtime permission checks.
+   *   2. an explicit owner priority, but only while that identity is still
+   *      present in the resolved allowlist. Runtime permissions remain
+   *      fail-closed when the allowlist removes or cannot resolve this entry.
    * Optional: bots created before this field, or via paths without a scanner
    * identity, simply have none and fall back to the resolved allowlist.
    */
@@ -2466,27 +2468,42 @@ export function getBotUploadClient(larkAppId: string): Lark.Client {
   return bot.uploadClient;
 }
 
-/** Owner = bot 首个已授权 open_id，与「缺权限警告私信对象」同口径（见 admin 解析）。 */
-export function getOwnerOpenId(larkAppId: string): string | undefined {
+/**
+ * Return the raw setup-time owner identity for DM fallback paths only.
+ *
+ * This value is deliberately not an authorization result: it can outlive an
+ * allowlist edit or a transient contact-resolution failure. Callers that gate
+ * runtime actions must use getOwnerOpenId() or the resolved allowlist instead.
+ */
+export function getConfiguredOwnerOpenId(larkAppId: string): string | undefined {
   const bot = bots.get(larkAppId);
   if (!bot) return undefined;
   if (bot.config.ownerOpenId && typeof bot.config.ownerOpenId === 'string' && bot.config.ownerOpenId.startsWith('ou_')) {
     return bot.config.ownerOpenId;
   }
+  return undefined;
+}
+
+/**
+ * Current permission owner: explicit ownerOpenId keeps priority only while it
+ * is still in the resolved allowlist. Once removed or unresolved, ownership
+ * follows the first resolved ou_ entry, matching legacy allowlist semantics.
+ */
+export function getOwnerOpenId(larkAppId: string): string | undefined {
+  const bot = bots.get(larkAppId);
+  if (!bot) return undefined;
+  const configuredOwner = getConfiguredOwnerOpenId(larkAppId);
+  if (configuredOwner && bot.resolvedAllowedUsers.includes(configuredOwner)) {
+    return configuredOwner;
+  }
   return bot.resolvedAllowedUsers.find(u => u.startsWith('ou_'));
 }
 
-/** Admins = all resolved allowedUsers + explicit ownerOpenId, matching `/botconfig`'s permission model. */
+/** Admins = only resolved allowedUsers, matching `/botconfig`'s fail-closed permission model. */
 export function getDashboardAdminOpenIds(larkAppId: string): string[] {
   const bot = bots.get(larkAppId);
   if (!bot) return [];
-  const list = [...(bot.resolvedAllowedUsers ?? [])];
-  if (bot.config.ownerOpenId && typeof bot.config.ownerOpenId === 'string' && bot.config.ownerOpenId.startsWith('ou_')) {
-    if (!list.includes(bot.config.ownerOpenId)) {
-      list.unshift(bot.config.ownerOpenId);
-    }
-  }
-  return list;
+  return [...(bot.resolvedAllowedUsers ?? [])].filter(u => typeof u === 'string' && u.startsWith('ou_'));
 }
 
 /**

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -2476,9 +2476,17 @@ export function getOwnerOpenId(larkAppId: string): string | undefined {
   return bot.resolvedAllowedUsers.find(u => u.startsWith('ou_'));
 }
 
-/** Admins = all resolved allowedUsers, matching `/botconfig`'s permission model. */
+/** Admins = all resolved allowedUsers + explicit ownerOpenId, matching `/botconfig`'s permission model. */
 export function getDashboardAdminOpenIds(larkAppId: string): string[] {
-  return [...(bots.get(larkAppId)?.resolvedAllowedUsers ?? [])];
+  const bot = bots.get(larkAppId);
+  if (!bot) return [];
+  const list = [...(bot.resolvedAllowedUsers ?? [])];
+  if (bot.config.ownerOpenId && typeof bot.config.ownerOpenId === 'string' && bot.config.ownerOpenId.startsWith('ou_')) {
+    if (!list.includes(bot.config.ownerOpenId)) {
+      list.unshift(bot.config.ownerOpenId);
+    }
+  }
+  return list;
 }
 
 /**

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -2468,7 +2468,12 @@ export function getBotUploadClient(larkAppId: string): Lark.Client {
 
 /** Owner = bot 首个已授权 open_id，与「缺权限警告私信对象」同口径（见 admin 解析）。 */
 export function getOwnerOpenId(larkAppId: string): string | undefined {
-  return bots.get(larkAppId)?.resolvedAllowedUsers.find(u => u.startsWith('ou_'));
+  const bot = bots.get(larkAppId);
+  if (!bot) return undefined;
+  if (bot.config.ownerOpenId && typeof bot.config.ownerOpenId === 'string' && bot.config.ownerOpenId.startsWith('ou_')) {
+    return bot.config.ownerOpenId;
+  }
+  return bot.resolvedAllowedUsers.find(u => u.startsWith('ou_'));
 }
 
 /** Admins = all resolved allowedUsers, matching `/botconfig`'s permission model. */

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -65,6 +65,7 @@ import {
   registerBot,
   getBot,
   getAllBots,
+  getConfiguredOwnerOpenId,
   getOwnerOpenId,
   getDashboardAdminOpenIds,
   findOncallChat,
@@ -4307,10 +4308,7 @@ function notifyAllowedUsersResolveFailure(
   // captured at setup — a raw ou_ that never needs resolving, so it survives
   // the contact-API outage. Appended (not replacing) so a partial resolve still
   // reaches every recovered owner too.
-  let staticOwner: string | undefined;
-  try {
-    staticOwner = getBot(larkAppId).config.ownerOpenId;
-  } catch { /* bot gone mid-flight — nothing to fall back to */ }
+  const staticOwner = getConfiguredOwnerOpenId(larkAppId);
   if (staticOwner && staticOwner.startsWith('ou_') && !unique.includes(staticOwner)) {
     unique.push(staticOwner);
   }
@@ -5709,8 +5707,9 @@ export const __testOnly_clearPendingRepoStateForNotifierAdopt = clearPendingRepo
 export const __testOnly_adoptCodexNotifierEvent = adoptCodexNotifierEvent;
 
 const handleCodexNotifierCardAction = createCodexNotifierCardActionHandler({
-  getExpectedOwnerOpenId: larkAppId =>
-    getOwnerOpenId(larkAppId) ?? resolvePrimaryOwnerOpenId(larkAppId),
+  // Authorization must use the resolved runtime owner only. The raw fallback
+  // used by notification delivery is intentionally not available here.
+  getExpectedOwnerOpenId: getOwnerOpenId,
   getEventRecord: (larkAppId, eventId) => codexNotifierStore(larkAppId).get(eventId),
   readConfig: () => readGlobalConfig().codexNotifier,
   openAppThread: openCodexAppThread,
@@ -6351,6 +6350,7 @@ for (const sessionRelayMutation of V3_SESSION_RUN_MUTATIONS) {
           const hasAllowlist = (bot.config.allowedUsers?.length ?? 0) > 0
             || (bot.config.allowedChatGroups?.length ?? 0) > 0
             || (bot.config.globalGrants?.length ?? 0) > 0
+            || !!bot.config.ownerOpenId
             || bot.config.p2pOpen === true;
           if (!hasAllowlist) return true;
           return getDashboardAdminOpenIds(larkAppId).includes(ownerOpenId);
@@ -21743,7 +21743,8 @@ function resolvePrimaryOwnerOpenId(larkAppId: string): string | undefined {
     const bot = getBot(larkAppId);
     const resolved = (bot.resolvedAllowedUsers ?? []).find(u => typeof u === 'string' && u.startsWith('ou_'));
     if (resolved) return resolved;
-    return (bot.config.allowedUsers ?? []).find(u => typeof u === 'string' && u.startsWith('ou_'));
+    return getConfiguredOwnerOpenId(larkAppId)
+      ?? (bot.config.allowedUsers ?? []).find(u => typeof u === 'string' && u.startsWith('ou_'));
   } catch {
     return undefined;
   }
@@ -21935,7 +21936,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       if (!budget) return;
       const alert = trackBudgetSpend(record.larkAppId, record.costCny, { budget });
       if (alert) {
-        const ownerOpenId = bot?.config?.ownerOpenId;
+        const ownerOpenId = getConfiguredOwnerOpenId(record.larkAppId);
         if (ownerOpenId) {
           sendUserMessage(record.larkAppId, ownerOpenId, formatBudgetAlert(alert), 'text')
             .catch(err => logger.warn(`[budget] failed to send alert to owner: ${err}`));

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -117,8 +117,8 @@ export const messages: Record<string, string> = {
   'card.grant.duration_permanent': 'Never',
   'card.grant.quota_label': 'Message quota',
   'card.grant.quota_placeholder': 'Blank means unlimited',
-  'card.grant.note': 'Access is revoked when either limit is reached. Grants talk access only (this chat or global); /restart, /close, terminal write and other sensitive ops remain limited to allowedUsers (owner).',
-  'card.grant.toast_owner_only': 'Only the owner can do this',
+  'card.grant.note': 'Access is revoked when either limit is reached. Grants talk access only (this chat or global); /restart, /close, terminal write and other sensitive ops remain limited to allowedUsers (bot admins).',
+  'card.grant.toast_owner_only': 'Only a bot admin can do this',
   'card.grant.toast_expired': 'This request has expired',
   'card.grant.toast_bad_limit': 'Invalid grant limit',
   'card.grant.toast_bad_quota': 'Enter a whole-number message quota from 1 to 1000, or leave it blank for unlimited',
@@ -143,13 +143,13 @@ export const messages: Record<string, string> = {
   'cmd.grant_restricted': '⚠️ This grant only allows plain conversation — commands like {cmd} are not permitted. Ask the owner to lift the restriction.',
 
   // /grant, /revoke command replies
-  'cmd.grant.owner_only': 'Only the owner can use /grant.',
+  'cmd.grant.owner_only': 'Only a bot admin can use /grant.',
   'cmd.grant.usage': 'Usage: @bot /grant @someone [N] (let them talk to me in this chat — you can @ several people/bots at once; with a number, grants an N-message quota) | @bot /grant (let every member of this chat talk). Talk-only; sensitive ops stay governed by allowedUsers.',
   'cmd.grant.bad_quota': '⚠️ Bad quota. Usage: @bot /grant @someone 5 (grant a 5-message quota; must be a positive integer). Omit the number to use the card default.',
   'cmd.grant.chat_done': '✅ Everyone in this chat can now talk to me (just @-mention me). Sensitive ops still limited to allowedUsers.',
   'cmd.grant.chat_already': 'ℹ️ This chat is already open to talk; nothing to do.',
   'cmd.grant.chat_failed': '⚠️ Grant failed: {reason}',
-  'cmd.revoke.owner_only': 'Only the owner can use /revoke.',
+  'cmd.revoke.owner_only': 'Only a bot admin can use /revoke.',
   'cmd.revoke.usage': 'Usage: @bot /revoke @someone (revoke their talk access in this chat — you can @ several people/bots at once) | @bot /revoke (revoke the whole-chat talk grant).',
   'cmd.revoke.chat_done': '✅ Revoked the whole-chat talk grant for this chat.',
   'cmd.revoke.chat_none': 'ℹ️ This chat has no whole-chat talk grant.',
@@ -167,7 +167,7 @@ export const messages: Record<string, string> = {
   'cmd.revoke.multi_failed': '⚠️ {name} — revoke failed: {reason}',
 
   // /invite (pull an out-of-chat bot into this chat, owner only)
-  'cmd.invite.owner_only': '⚠️ Only the owner can use /invite.',
+  'cmd.invite.owner_only': '⚠️ Only a bot admin can use /invite.',
   'cmd.invite.p2p': '⚠️ Bots cannot be added in a DM — use /invite inside a group chat.',
   'cmd.invite.usage': 'Usage: @me /invite @bot-to-add (multiple allowed), or @me /invite --app cli_xxx',
   'cmd.invite.header': '🤝 /invite results:',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -120,8 +120,8 @@ export const messages: Record<string, string> = {
   'card.grant.duration_permanent': '永久',
   'card.grant.quota_label': '消息额度（条）',
   'card.grant.quota_placeholder': '留空不限',
-  'card.grant.note': '有效期或消息额度任一先到即自动收回授权。仅授予对话权（本群或全局）；/restart、/close、终端写入等敏感操作仍仅限 allowedUsers（owner）。',
-  'card.grant.toast_owner_only': '仅 owner 可操作',
+  'card.grant.note': '有效期或消息额度任一先到即自动收回授权。仅授予对话权（本群或全局）；/restart、/close、终端写入等敏感操作仍仅限 allowedUsers（Bot 管理员）。',
+  'card.grant.toast_owner_only': '仅 Bot 管理员可操作',
   'card.grant.toast_expired': '该授权请求已失效',
   'card.grant.toast_bad_limit': '授权限制参数无效',
   'card.grant.toast_bad_quota': '消息额度请输入 1–1000 的整数，留空表示不限',
@@ -146,13 +146,13 @@ export const messages: Record<string, string> = {
   'cmd.grant_restricted': '⚠️ 当前授权仅允许普通对话，不能使用 {cmd} 等命令。如需放开请联系 owner。',
 
   // /grant、/revoke 命令回执
-  'cmd.grant.owner_only': '仅 owner 可使用 /grant。',
+  'cmd.grant.owner_only': '仅 Bot 管理员可使用 /grant。',
   'cmd.grant.usage': '用法：@机器人 /grant @某人 [条数]（授权 ta 在本群与我对话，可一次 @ 多人/多 bot；带数字则给 N 条消息额度）｜@机器人 /grant（授权本群所有成员对话）。仅授对话权，敏感操作仍由 allowedUsers 控制。',
   'cmd.grant.bad_quota': '⚠️ 额度格式不对。用法：@机器人 /grant @某人 5（给 5 条消息额度，须为正整数）；不带数字则使用卡片默认额度。',
   'cmd.grant.chat_done': '✅ 已授权本群所有成员与我对话（@ 我即可）。敏感操作仍仅限 allowedUsers。',
   'cmd.grant.chat_already': 'ℹ️ 本群已是授权状态，无需重复授权。',
   'cmd.grant.chat_failed': '⚠️ 授权失败：{reason}',
-  'cmd.revoke.owner_only': '仅 owner 可使用 /revoke。',
+  'cmd.revoke.owner_only': '仅 Bot 管理员可使用 /revoke。',
   'cmd.revoke.usage': '用法：@机器人 /revoke @某人（撤销 ta 的本群对话权，可一次 @ 多人/多 bot）｜@机器人 /revoke（撤销本群整群对话授权）。',
   'cmd.revoke.chat_done': '✅ 已撤销本群整群对话授权。',
   'cmd.revoke.chat_none': 'ℹ️ 本群当前没有整群对话授权。',
@@ -170,7 +170,7 @@ export const messages: Record<string, string> = {
   'cmd.revoke.multi_failed': '⚠️ {name} —— 撤销失败：{reason}',
 
   // /invite（把群外 bot 拉进本群，owner 专用）
-  'cmd.invite.owner_only': '⚠️ 仅 owner 可以使用 /invite。',
+  'cmd.invite.owner_only': '⚠️ 仅 Bot 管理员可以使用 /invite。',
   'cmd.invite.p2p': '⚠️ 私聊里不能拉机器人，请在群里使用 /invite。',
   'cmd.invite.usage': '用法：@我 /invite @要拉进群的机器人（可多个），或 @我 /invite --app cli_xxx',
   'cmd.invite.header': '🤝 /invite 结果：',

--- a/src/im/lark/ask-grant-request.ts
+++ b/src/im/lark/ask-grant-request.ts
@@ -28,6 +28,7 @@ import { logger } from '../../utils/logger.js';
 import { buildGrantCard } from './card-builder.js';
 import { getUserProfile, replyMessage, sendMessage } from './client.js';
 import { clearPending, openPending, throttleReason } from './grant-pending.js';
+import { resolveGrantApprover } from './grant-owner.js';
 
 /** 本次升级的结论。调用方据此选 toast 文案。 */
 export type AskGrantRequestOutcome =
@@ -67,6 +68,8 @@ export interface AskGrantRequestDeps {
   resolveTargetName?: (larkAppId: string, chatId: string, openId: string) => Promise<string>;
   /** 实际投递授权卡（异步，不在 ACK 路径上）。 */
   deliverCard?: (target: AskGrantRequestTarget, cardJson: string) => Promise<void>;
+  /** 群内审批人解析（异步，不在 ACK 路径上）。 */
+  resolveGrantApprover?: typeof resolveGrantApprover;
 }
 
 /**
@@ -87,6 +90,7 @@ export function requestGrantForAskClicker(
   const readConfig = deps.getBotConfig ?? ((appId: string) => getBot(appId).config);
   const resolveName = deps.resolveTargetName ?? defaultResolveTargetName;
   const deliver = deps.deliverCard ?? defaultDeliverCard;
+  const approverResolver = deps.resolveGrantApprover ?? resolveGrantApprover;
 
   const { larkAppId, chatId } = ask;
   try {
@@ -108,10 +112,13 @@ export function requestGrantForAskClicker(
     // 取名字 + 发卡都不在 ACK 路径上：失败只回滚 pending，不影响本次 toast。
     void (async () => {
       try {
-        const name = await resolveName(larkAppId, chatId, clickerOpenId);
+        const [name, approver] = await Promise.all([
+          resolveName(larkAppId, chatId, clickerOpenId),
+          approverResolver(larkAppId, chatId).catch(() => undefined),
+        ]);
         const cardJson = buildGrantCard(
           {
-            ownerOpenId: owner,
+            ownerOpenId: approver ?? owner,
             targets: [{ openId: clickerOpenId, name }],
             chatId,
             nonce,

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -10,6 +10,7 @@ import { config } from '../../config.js';
 import { getBot, getAllBots, getOwnerOpenId } from '../../bot-registry.js';
 import { resolveHiddenStreamingCardButtons } from './streaming-card-buttons.js';
 import { canOperate, canTalk, canRunDaemonCommand } from './event-dispatcher.js';
+import { isBotAdmin } from './grant-owner.js';
 import { updateMessage, deleteMessage, replyMessage, sendMessage, sendUserMessage, sendEphemeralCard, getMessageDetail, isHumanOpenId, resolveUserUnionId as defaultResolveUserUnionId } from './client.js';
 import { buildSessionCard, buildStreamingCard, buildTuiPromptCard, buildTuiPromptProcessingCard, buildGrantResultCard, getCliDisplayName, truncateContent, buildConfigCard, buildConfigQuotaCard, buildConfigTextCard, CONFIG_UNSET, buildRepoSelectCard } from './card-builder.js';
 import { codexServiceTierBadge } from '../../services/codex-service-tier.js';
@@ -1077,8 +1078,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return { toast: { type: 'info', content: '该操作已执行过' } };
   }
   if (value?.action && (value.action === OVERLOAD_ACTION_CLEAN_STOPPED || value.action === OVERLOAD_ACTION_SUSPEND_IDLE) && larkAppId) {
-    const owner = getOwnerOpenId(larkAppId);
-    if (!operatorOpenId || operatorOpenId !== owner) {
+    if (!operatorOpenId || !isBotAdmin(larkAppId, operatorOpenId)) {
       logger.info(`Overload action "${value.action}" blocked for non-owner: ${operatorOpenId}`);
       return { toast: { type: 'error', content: '仅管理员可操作' } };
     }
@@ -1125,8 +1125,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   // owner 强闸门 + 按 bundleId 分开的一次性 nonce 核销（可分别重启 Arc/Chrome/Edge，
   // 各一次）。重启在本机 daemon 直接执行（浏览器就跑在本机），不跨 daemon 扇出。
   if (value?.action === OVERLOAD_ACTION_RESTART_BROWSER && larkAppId) {
-    const owner = getOwnerOpenId(larkAppId);
-    if (!operatorOpenId || operatorOpenId !== owner) {
+    if (!operatorOpenId || !isBotAdmin(larkAppId, operatorOpenId)) {
       logger.info(`Overload browser-restart blocked for non-owner: ${operatorOpenId}`);
       return { toast: { type: 'error', content: '仅管理员可操作' } };
     }
@@ -1208,9 +1207,8 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     || value.action === 'grant_set_quota'
   ) && larkAppId) {
     const loc = localeForBot(larkAppId);
-    const owner = getOwnerOpenId(larkAppId);
-    // owner 强闸门：必须是当前 app 的 owner 本人（比 canOperate 更严）
-    if (!operatorOpenId || operatorOpenId !== owner) {
+    // 管理员强闸门：必须是当前 app 的管理员（owner 或 co-owner / allowedUsers）
+    if (!operatorOpenId || !isBotAdmin(larkAppId, operatorOpenId)) {
       logger.info(`Grant action "${value.action}" blocked for non-owner: ${operatorOpenId}`);
       return { toast: { type: 'error', content: t('card.grant.toast_owner_only', undefined, loc) } };
     }

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -1078,9 +1078,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return { toast: { type: 'info', content: '该操作已执行过' } };
   }
   if (value?.action && (value.action === OVERLOAD_ACTION_CLEAN_STOPPED || value.action === OVERLOAD_ACTION_SUSPEND_IDLE) && larkAppId) {
-    if (!operatorOpenId || !isBotAdmin(larkAppId, operatorOpenId)) {
+    const owner = getOwnerOpenId(larkAppId);
+    if (!operatorOpenId || operatorOpenId !== owner) {
       logger.info(`Overload action "${value.action}" blocked for non-owner: ${operatorOpenId}`);
-      return { toast: { type: 'error', content: '仅管理员可操作' } };
+      return { toast: { type: 'error', content: '仅 owner 可操作' } };
     }
     // Parse the card state carried on the button. Missing/corrupt → treat as a
     // stale card (daemon restart drops the nonce too).
@@ -1125,9 +1126,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   // owner 强闸门 + 按 bundleId 分开的一次性 nonce 核销（可分别重启 Arc/Chrome/Edge，
   // 各一次）。重启在本机 daemon 直接执行（浏览器就跑在本机），不跨 daemon 扇出。
   if (value?.action === OVERLOAD_ACTION_RESTART_BROWSER && larkAppId) {
-    if (!operatorOpenId || !isBotAdmin(larkAppId, operatorOpenId)) {
+    const owner = getOwnerOpenId(larkAppId);
+    if (!operatorOpenId || operatorOpenId !== owner) {
       logger.info(`Overload browser-restart blocked for non-owner: ${operatorOpenId}`);
-      return { toast: { type: 'error', content: '仅管理员可操作' } };
+      return { toast: { type: 'error', content: '仅 owner 可操作' } };
     }
     const bundleId = typeof value.bundleId === 'string' ? value.bundleId : '';
     if (!bundleId) return { toast: { type: 'error', content: '按钮缺少 bundleId' } };

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1904,7 +1904,7 @@ export function evaluateTalk(
   // allowedChatGroups 是"talk-open 的 chat_id 列表"：当前消息来自其中之一即放行（仅 canTalk）。
   // 成员关系隐含在"能在该 chat 发言"里 —— 退群者发不了言自动失权，新人进群即生效，无需成员快照。
   const allowedUsers = bot.resolvedAllowedUsers;
-  if (senderOpenId && (allowedUsers.includes(senderOpenId) || bot.config.ownerOpenId === senderOpenId)) return { allowed: true, reason: 'allowedUser' };
+  if (senderOpenId && allowedUsers.includes(senderOpenId)) return { allowed: true, reason: 'allowedUser' };
   // 会话群专用腿，**必须排在 oncall 之前**：会话群里的 oncall 绑定只是出生时为了
   // 承载 workingDir 写下的，不能当作 talk 来源（详见 evaluateSessionGroupTalk）。
   // 命中会话群时无论表不表态，都不再回落 oncall 腿。
@@ -2100,7 +2100,7 @@ export function canOperate(
   // 要堵的洞。注意 globalGrants 只进 hasAllowlist 判定，operate 命中仍只认 allowedUsers。
   // 用原始配置判定（hasConfiguredAllowlist）：配了 owner 但解析为空时 fail-closed, 不 fail-open。
   if (!hasConfiguredAllowlist(bot)) return true;
-  return !!senderOpenId && (allowedUsers.includes(senderOpenId) || bot.config.ownerOpenId === senderOpenId);
+  return !!senderOpenId && allowedUsers.includes(senderOpenId);
 }
 
 /**

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -48,6 +48,7 @@ import { tryHandleMentionModeCommand } from './mention-mode-command.js';
 import { tryHandleSubstituteCommand } from './substitute-command.js';
 import { buildGrantCard } from './card-builder.js';
 import { openPending, isThrottled, clearPending } from './grant-pending.js';
+import { resolveGrantApprover } from './grant-owner.js';
 import { localeForBot, t } from '../../i18n/index.js';
 import {
   chatQuotaKey,
@@ -1870,6 +1871,7 @@ function hasConfiguredAllowlist(bot: ReturnType<typeof getBot>): boolean {
   return (bot.config.allowedUsers?.length ?? 0) > 0
     || (bot.config.allowedChatGroups?.length ?? 0) > 0
     || (bot.config.globalGrants?.length ?? 0) > 0
+    || !!bot.config.ownerOpenId
     // p2pOpen 也是一次显式的权限边界声明：配了它 = 进入限制态。否则「只配 p2pOpen、
     // 没配 allowedUsers」会 fall through 到 open 模式，把**群聊**和 **canOperate** 一起
     // 放开（陌生人能 /restart /cd），与 p2pOpen「只开私聊 talk」的语义正好相反。
@@ -1902,7 +1904,7 @@ export function evaluateTalk(
   // allowedChatGroups 是"talk-open 的 chat_id 列表"：当前消息来自其中之一即放行（仅 canTalk）。
   // 成员关系隐含在"能在该 chat 发言"里 —— 退群者发不了言自动失权，新人进群即生效，无需成员快照。
   const allowedUsers = bot.resolvedAllowedUsers;
-  if (senderOpenId && allowedUsers.includes(senderOpenId)) return { allowed: true, reason: 'allowedUser' };
+  if (senderOpenId && (allowedUsers.includes(senderOpenId) || bot.config.ownerOpenId === senderOpenId)) return { allowed: true, reason: 'allowedUser' };
   // 会话群专用腿，**必须排在 oncall 之前**：会话群里的 oncall 绑定只是出生时为了
   // 承载 workingDir 写下的，不能当作 talk 来源（详见 evaluateSessionGroupTalk）。
   // 命中会话群时无论表不表态，都不再回落 oncall 腿。
@@ -2098,7 +2100,7 @@ export function canOperate(
   // 要堵的洞。注意 globalGrants 只进 hasAllowlist 判定，operate 命中仍只认 allowedUsers。
   // 用原始配置判定（hasConfiguredAllowlist）：配了 owner 但解析为空时 fail-closed, 不 fail-open。
   if (!hasConfiguredAllowlist(bot)) return true;
-  return !!senderOpenId && allowedUsers.includes(senderOpenId);
+  return !!senderOpenId && (allowedUsers.includes(senderOpenId) || bot.config.ownerOpenId === senderOpenId);
 }
 
 /**
@@ -2157,6 +2159,7 @@ async function maybeSendGrantRequestCard(
   const owner = getOwnerOpenId(larkAppId);
   if (!owner || !requesterOpenId) return;
   if (isThrottled(larkAppId, chatId, requesterOpenId)) return;
+  const approverPromise = resolveGrantApprover(larkAppId, chatId, message).catch(() => undefined);
   // 名字优先级：本消息 mentions（真人发送方、被 @ 目标都在此）→ observed-bots 花名册
   // （/introduce 登记过的 (open_id,name)）→ 裸 open_id 兜底。外部 bot 发送方不在自己
   // 消息的 mentions 里（那是 @ 目标），只靠 mentions 会让 owner 只看到 open_id。
@@ -2169,6 +2172,7 @@ async function maybeSendGrantRequestCard(
     : (await getUserProfile(larkAppId, requesterOpenId).catch(() => null))?.name;
   const shortRequester = `${requesterOpenId.slice(0, 10)}…${requesterOpenId.slice(-4)}`;
   const name = mentionName ?? observedName ?? profileName ?? shortRequester;
+  const approver = (await approverPromise) ?? owner;
   // 把原始消息事件挂在 pending 上：授权成功后可重放，用户无需再 @ 一遍。
   const botConfig = getBot(larkAppId).config;
   const quota = botConfig.messageQuota?.defaultLimit ?? DEFAULT_GRANT_QUOTA;
@@ -2183,7 +2187,7 @@ async function maybeSendGrantRequestCard(
   );
   const card = buildGrantCard(
     {
-      ownerOpenId: owner,
+      ownerOpenId: approver,
       targets: [{ openId: requesterOpenId, name: String(name) }],
       chatId,
       nonce,

--- a/src/im/lark/grant-command.ts
+++ b/src/im/lark/grant-command.ts
@@ -5,6 +5,7 @@
  * 且解析 target 时排除 bot 自身。
  */
 import { getOwnerOpenId, getBotOpenId, getBot } from '../../bot-registry.js';
+import { isBotAdmin } from './grant-owner.js';
 import { isBotMentioned, extractMessageTextForRouting } from './event-dispatcher.js';
 import { stripLeadingMentions } from './message-parser.js';
 import { buildGrantCard } from './card-builder.js';
@@ -114,9 +115,9 @@ export async function tryHandleGrantCommand(
   const messageId = message.message_id;
   const chatId = message.chat_id;
 
-  // owner 强闸门
+  // owner / admin 强闸门
   const owner = getOwnerOpenId(larkAppId);
-  if (!senderOpenId || senderOpenId !== owner) {
+  if (!senderOpenId || !isBotAdmin(larkAppId, senderOpenId)) {
     await replyMessage(larkAppId, messageId, t(isGrant ? 'cmd.grant.owner_only' : 'cmd.revoke.owner_only', undefined, loc))
       .catch(err => logger.debug(`grant owner_only reply failed: ${err}`));
     return true;
@@ -222,7 +223,7 @@ export async function tryHandleGrantCommand(
   );
   const card = buildGrantCard(
     {
-      ownerOpenId: owner!,
+      ownerOpenId: senderOpenId ?? owner!,
       targets,
       chatId,
       nonce,

--- a/src/im/lark/grant-owner.ts
+++ b/src/im/lark/grant-owner.ts
@@ -92,7 +92,7 @@ export interface ResolveGrantApproverDeps {
 
 /**
  * 决定在特定会话中，授权申请卡应该 @ 哪位管理员处置。
- * 
+ *
  * 策略：
  * 1. 获取该 bot 的所有管理员候选人（按配置顺序：ownerOpenId、resolvedAllowedUsers 等）。
  * 2. 若只有一个管理员（或无群 chatId / 非群聊），直接取该唯一/全局管理员（零额外网络开销）。

--- a/src/im/lark/grant-owner.ts
+++ b/src/im/lark/grant-owner.ts
@@ -2,7 +2,8 @@
  * 授权卡处置人（approver / owner）解析与管理员判定。
  *
  * 核心设计：
- * 1. 管理员（owner / co-owners）：取 bot 配置的 static ownerOpenId 与 resolvedAllowedUsers 中的全部 ou_。
+ * 1. 管理员（owner / co-owners）：只取 resolvedAllowedUsers 中已解析出的 ou_。
+ *    raw ownerOpenId 仅用于解析失败时的 DM 兜底，不得绕过 allowlist 闸门。
  * 2. 群内授权申请卡（maybeSendGrantRequestCard / requestGrantForAskClicker）：
  *    若群里有管理员，优先 @ 当前群内的管理员（按配置优先级排序）；
  *    避免在群 A 里触发授权时，@ 了一个根本不在本群的管理员打扰对方，导致群内可见的管理员反而收不到提醒。
@@ -15,23 +16,13 @@ import { logger } from '../../utils/logger.js';
 import { BoundedMap } from '../../utils/bounded-map.js';
 
 /**
- * 获取 bot 的所有管理员 open_id 候选列表（保持优先级顺序）：
- * 1. 配置中显式指定的 ownerOpenId（若为 ou_）
- * 2. resolvedAllowedUsers 中的所有 ou_ 用户（已通过飞书联系人真实性校验，保持 fail-closed）
+ * 获取 bot 的所有管理员 open_id 候选列表（保持 allowlist 优先级顺序）。
+ * 只有 resolvedAllowedUsers 中已解析出的 ou_ 才能成为管理员，保持 fail-closed。
  */
 export function getBotAdminOpenIds(larkAppId: string): string[] {
   try {
     const bot = getBot(larkAppId);
-    const out: string[] = [];
-    if (bot.config.ownerOpenId && typeof bot.config.ownerOpenId === 'string' && bot.config.ownerOpenId.startsWith('ou_')) {
-      out.push(bot.config.ownerOpenId);
-    }
-    for (const u of (bot.resolvedAllowedUsers ?? [])) {
-      if (typeof u === 'string' && u.startsWith('ou_') && !out.includes(u)) {
-        out.push(u);
-      }
-    }
-    return out;
+    return [...new Set((bot.resolvedAllowedUsers ?? []).filter(u => typeof u === 'string' && u.startsWith('ou_')))];
   } catch {
     return [];
   }
@@ -94,7 +85,8 @@ export interface ResolveGrantApproverDeps {
  * 决定在特定会话中，授权申请卡应该 @ 哪位管理员处置。
  *
  * 策略：
- * 1. 获取该 bot 的所有管理员候选人（按配置顺序：ownerOpenId、resolvedAllowedUsers 等）。
+ * 1. 获取该 bot 的所有管理员候选人（按 resolvedAllowedUsers 配置顺序；显式
+ *    ownerOpenId 只有仍在该解析结果中时才提升优先级）。
  * 2. 若只有一个管理员（或无群 chatId / 非群聊），直接取该唯一/全局管理员（零额外网络开销）。
  * 3. 若为群聊且有多个候选管理员：
  *    - 优先检查传入 message 中的 mentions，若直接包含了某位候选管理员，且其在群中，立即可用；
@@ -118,8 +110,9 @@ export async function resolveGrantApprover(
   const fallbackOwner = owner ?? candidates[0];
   if (!fallbackOwner) return undefined;
 
-  // 只有一个候选人或非群聊，无需网络往返，直接返回
-  const isLarkChat = chatId && (chatId.startsWith('oc_') || deps.listChatMemberOpenIds !== undefined);
+  // 只有一个候选人或非群聊，无需网络往返，直接返回。测试依赖不能改变
+  // 生产判据，否则测试会覆盖生产永远走不到的分支。
+  const isLarkChat = typeof chatId === 'string' && chatId.startsWith('oc_');
   if (candidates.length <= 1 || !isLarkChat) {
     return fallbackOwner;
   }

--- a/src/im/lark/grant-owner.ts
+++ b/src/im/lark/grant-owner.ts
@@ -17,8 +17,7 @@ import { BoundedMap } from '../../utils/bounded-map.js';
 /**
  * 获取 bot 的所有管理员 open_id 候选列表（保持优先级顺序）：
  * 1. 配置中显式指定的 ownerOpenId（若为 ou_）
- * 2. resolvedAllowedUsers 中的所有 ou_ 用户
- * 3. raw allowedUsers 中以 ou_ 开头的用户（防解析延迟兜底）
+ * 2. resolvedAllowedUsers 中的所有 ou_ 用户（已通过飞书联系人真实性校验，保持 fail-closed）
  */
 export function getBotAdminOpenIds(larkAppId: string): string[] {
   try {
@@ -28,11 +27,6 @@ export function getBotAdminOpenIds(larkAppId: string): string[] {
       out.push(bot.config.ownerOpenId);
     }
     for (const u of (bot.resolvedAllowedUsers ?? [])) {
-      if (typeof u === 'string' && u.startsWith('ou_') && !out.includes(u)) {
-        out.push(u);
-      }
-    }
-    for (const u of (bot.config.allowedUsers ?? [])) {
       if (typeof u === 'string' && u.startsWith('ou_') && !out.includes(u)) {
         out.push(u);
       }

--- a/src/im/lark/grant-owner.ts
+++ b/src/im/lark/grant-owner.ts
@@ -1,0 +1,157 @@
+/**
+ * 授权卡处置人（approver / owner）解析与管理员判定。
+ *
+ * 核心设计：
+ * 1. 管理员（owner / co-owners）：取 bot 配置的 static ownerOpenId 与 resolvedAllowedUsers 中的全部 ou_。
+ * 2. 群内授权申请卡（maybeSendGrantRequestCard / requestGrantForAskClicker）：
+ *    若群里有管理员，优先 @ 当前群内的管理员（按配置优先级排序）；
+ *    避免在群 A 里触发授权时，@ 了一个根本不在本群的管理员打扰对方，导致群内可见的管理员反而收不到提醒。
+ *    若群内无任何管理员或非群聊，回落至全局主 owner。
+ * 3. 授权卡操作闸门与 /grant 权限闸门：允许该 bot 的任意有效管理员（owner 或 co-owner）处置。
+ */
+import { getBot, getOwnerOpenId } from '../../bot-registry.js';
+import { listChatMemberOpenIds } from './client.js';
+import { logger } from '../../utils/logger.js';
+import { BoundedMap } from '../../utils/bounded-map.js';
+
+/**
+ * 获取 bot 的所有管理员 open_id 候选列表（保持优先级顺序）：
+ * 1. 配置中显式指定的 ownerOpenId（若为 ou_）
+ * 2. resolvedAllowedUsers 中的所有 ou_ 用户
+ * 3. raw allowedUsers 中以 ou_ 开头的用户（防解析延迟兜底）
+ */
+export function getBotAdminOpenIds(larkAppId: string): string[] {
+  try {
+    const bot = getBot(larkAppId);
+    const out: string[] = [];
+    if (bot.config.ownerOpenId && typeof bot.config.ownerOpenId === 'string' && bot.config.ownerOpenId.startsWith('ou_')) {
+      out.push(bot.config.ownerOpenId);
+    }
+    for (const u of (bot.resolvedAllowedUsers ?? [])) {
+      if (typeof u === 'string' && u.startsWith('ou_') && !out.includes(u)) {
+        out.push(u);
+      }
+    }
+    for (const u of (bot.config.allowedUsers ?? [])) {
+      if (typeof u === 'string' && u.startsWith('ou_') && !out.includes(u)) {
+        out.push(u);
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 校验 openId 是否为当前 bot 的有效管理员（owner 或 co-owner）。
+ */
+export function isBotAdmin(larkAppId: string, openId: string | undefined): boolean {
+  if (!openId) return false;
+  return getBotAdminOpenIds(larkAppId).includes(openId);
+}
+
+interface MemberCacheEntry {
+  members: Set<string>;
+  expiresAt: number;
+}
+const chatMemberCache = new BoundedMap<string, MemberCacheEntry>(1000);
+const inFlightRequests = new Map<string, Promise<string[]>>();
+const CACHE_TTL_MS = 60_000;
+
+export function clearChatMemberCache(): void {
+  chatMemberCache.clear();
+  inFlightRequests.clear();
+}
+
+async function getChatMemberSet(
+  larkAppId: string,
+  chatId: string,
+  fetcher: (larkAppId: string, chatId: string) => Promise<string[]>,
+): Promise<Set<string>> {
+  const cacheKey = `${larkAppId}:${chatId}`;
+  const now = Date.now();
+  const cached = chatMemberCache.get(cacheKey);
+  if (cached && now < cached.expiresAt) {
+    return cached.members;
+  }
+
+  let inFlight = inFlightRequests.get(cacheKey);
+  if (!inFlight) {
+    inFlight = fetcher(larkAppId, chatId).finally(() => {
+      inFlightRequests.delete(cacheKey);
+    });
+    inFlightRequests.set(cacheKey, inFlight);
+  }
+
+  const list = await inFlight;
+  const set = new Set(list);
+  chatMemberCache.set(cacheKey, { members: set, expiresAt: Date.now() + CACHE_TTL_MS });
+  return set;
+}
+
+export interface ResolveGrantApproverDeps {
+  listChatMemberOpenIds?: (larkAppId: string, chatId: string) => Promise<string[]>;
+  getBotAdminOpenIds?: (larkAppId: string) => string[];
+  getOwnerOpenId?: (larkAppId: string) => string | undefined;
+}
+
+/**
+ * 决定在特定会话中，授权申请卡应该 @ 哪位管理员处置。
+ * 
+ * 策略：
+ * 1. 获取该 bot 的所有管理员候选人（按配置顺序：ownerOpenId、resolvedAllowedUsers 等）。
+ * 2. 若只有一个管理员（或无群 chatId / 非群聊），直接取该唯一/全局管理员（零额外网络开销）。
+ * 3. 若为群聊且有多个候选管理员：
+ *    - 优先检查传入 message 中的 mentions，若直接包含了某位候选管理员，且其在群中，立即可用；
+ *    - 查询该群的群成员列表（带 60s 内存缓存与并发收敛），从候选管理员中按优先级挑出首个“当前群成员”；
+ *    - 若候选管理员中有且仅有部分在群里，命中第一个在群管理员（例如：主 owner 不在群，但 co-owner 在群，则 @ co-owner，避免 ping 群外人员）；
+ *    - 若所有管理员均不在当前群（或查群成员失败），兜底回落至全局主 owner。
+ */
+export async function resolveGrantApprover(
+  larkAppId: string,
+  chatId?: string,
+  message?: any,
+  deps: ResolveGrantApproverDeps = {},
+): Promise<string | undefined> {
+  const getAdmins = deps.getBotAdminOpenIds ?? getBotAdminOpenIds;
+  const getOwner = deps.getOwnerOpenId ?? getOwnerOpenId;
+  const listMembers = deps.listChatMemberOpenIds ?? listChatMemberOpenIds;
+
+  const owner = getOwner(larkAppId);
+  const adminCandidates = getAdmins(larkAppId);
+  const candidates = owner && !adminCandidates.includes(owner) ? [owner, ...adminCandidates] : adminCandidates;
+  const fallbackOwner = owner ?? candidates[0];
+  if (!fallbackOwner) return undefined;
+
+  // 只有一个候选人或非群聊，无需网络往返，直接返回
+  const isLarkChat = chatId && (chatId.startsWith('oc_') || deps.listChatMemberOpenIds !== undefined);
+  if (candidates.length <= 1 || !isLarkChat) {
+    return fallbackOwner;
+  }
+
+  // 快速路径：如果消息显式 @ 了候选管理员之一，飞书群里只能 @ 群成员，优先命中
+  if (message?.mentions && Array.isArray(message.mentions)) {
+    const mentionedOpenIds = new Set<string>();
+    for (const m of message.mentions) {
+      const openId = m?.id?.open_id ?? m?.open_id;
+      if (typeof openId === 'string') mentionedOpenIds.add(openId);
+    }
+    const mentionedAdmin = candidates.find(admin => mentionedOpenIds.has(admin));
+    if (mentionedAdmin) {
+      return mentionedAdmin;
+    }
+  }
+
+  try {
+    const memberSet = await getChatMemberSet(larkAppId, chatId, listMembers);
+    const inChatAdmin = candidates.find(admin => memberSet.has(admin));
+    if (inChatAdmin) {
+      return inChatAdmin;
+    }
+  } catch (err) {
+    logger.debug(`[grant] Failed to list chat members for ${chatId}: ${err}`);
+  }
+
+  return fallbackOwner;
+}

--- a/src/im/lark/invite-command.ts
+++ b/src/im/lark/invite-command.ts
@@ -25,6 +25,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getOwnerOpenId, getBotOpenId } from '../../bot-registry.js';
+import { isBotAdmin } from './grant-owner.js';
 import { config } from '../../config.js';
 import { isBotMentioned, extractMessageTextForRouting } from './event-dispatcher.js';
 import { stripLeadingMentions } from './message-parser.js';
@@ -148,9 +149,9 @@ export async function tryHandleInviteCommand(
   // 多 bot 群：必须明确 @ 当前 bot 才由本 daemon 处理；否则吞掉（不喂 CLI）。
   if (!isBotMentioned(larkAppId, message, senderOpenId)) return true;
 
-  // owner 强闸门（对齐 /grant）。
+  // owner / admin 强闸门（对齐 /grant）。
   const owner = getOwnerOpenId(larkAppId);
-  if (!senderOpenId || senderOpenId !== owner) {
+  if (!senderOpenId || !isBotAdmin(larkAppId, senderOpenId)) {
     await reply('cmd.invite.owner_only');
     return true;
   }

--- a/src/im/lark/invite-command.ts
+++ b/src/im/lark/invite-command.ts
@@ -24,7 +24,7 @@
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getOwnerOpenId, getBotOpenId } from '../../bot-registry.js';
+import { getBotOpenId } from '../../bot-registry.js';
 import { isBotAdmin } from './grant-owner.js';
 import { config } from '../../config.js';
 import { isBotMentioned, extractMessageTextForRouting } from './event-dispatcher.js';
@@ -150,7 +150,6 @@ export async function tryHandleInviteCommand(
   if (!isBotMentioned(larkAppId, message, senderOpenId)) return true;
 
   // owner / admin 强闸门（对齐 /grant）。
-  const owner = getOwnerOpenId(larkAppId);
   if (!senderOpenId || !isBotAdmin(larkAppId, senderOpenId)) {
     await reply('cmd.invite.owner_only');
     return true;

--- a/test/bot-registry-grant.test.ts
+++ b/test/bot-registry-grant.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseBotConfigsFromText, getOwnerOpenId, getDashboardAdminOpenIds, registerBot } from '../src/bot-registry.js';
+import { parseBotConfigsFromText, getConfiguredOwnerOpenId, getOwnerOpenId, getDashboardAdminOpenIds, registerBot } from '../src/bot-registry.js';
 import { GRANT_DURATION_OPTIONS } from '../src/services/grant-policy.js';
 
 describe('bot-registry grant additions', () => {
@@ -159,7 +159,7 @@ describe('bot-registry grant additions', () => {
     expect(getOwnerOpenId('a3')).toBeUndefined();
   });
 
-  it('getOwnerOpenId prioritizes explicit ownerOpenId over resolvedAllowedUsers', () => {
+  it('getOwnerOpenId prioritizes explicit ownerOpenId while it remains allowed', () => {
     const bot = registerBot({
       larkAppId: 'a4',
       larkAppSecret: 's',
@@ -167,20 +167,35 @@ describe('bot-registry grant additions', () => {
       ownerOpenId: 'ou_owner_explicit',
       allowedUsers: ['ou_first', 'ou_second'],
     });
-    bot.resolvedAllowedUsers = ['ou_first', 'ou_second'];
+    bot.resolvedAllowedUsers = ['ou_first', 'ou_owner_explicit', 'ou_second'];
     expect(getOwnerOpenId('a4')).toBe('ou_owner_explicit');
   });
 
-  it('getDashboardAdminOpenIds includes explicit ownerOpenId and resolvedAllowedUsers', () => {
+  it('falls back to the resolved allowlist after explicit owner removal', () => {
     const bot = registerBot({
       larkAppId: 'a5',
       larkAppSecret: 's',
       cliId: 'claude-code',
       ownerOpenId: 'ou_owner_explicit',
-      allowedUsers: ['ou_first'],
+      allowedUsers: ['ou_first', 'ou_second'],
     });
-    bot.resolvedAllowedUsers = ['ou_first'];
-    expect(getDashboardAdminOpenIds('a5')).toEqual(['ou_owner_explicit', 'ou_first']);
+    bot.resolvedAllowedUsers = ['ou_second'];
+    expect(getOwnerOpenId('a5')).toBe('ou_second');
+    expect(getDashboardAdminOpenIds('a5')).toEqual(['ou_second']);
+  });
+
+  it('keeps raw explicit owner available only for DM fallback', () => {
+    const bot = registerBot({
+      larkAppId: 'a6',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      ownerOpenId: 'ou_owner_explicit',
+      allowedUsers: ['ou_second'],
+    });
+    bot.resolvedAllowedUsers = ['ou_second'];
+    expect(getConfiguredOwnerOpenId('a6')).toBe('ou_owner_explicit');
+    expect(getOwnerOpenId('a6')).toBe('ou_second');
+    expect(getDashboardAdminOpenIds('a6')).toEqual(['ou_second']);
   });
 
   it('parses messageQuota.defaultLimit only when a positive integer', () => {

--- a/test/bot-registry-grant.test.ts
+++ b/test/bot-registry-grant.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseBotConfigsFromText, getOwnerOpenId, registerBot } from '../src/bot-registry.js';
+import { parseBotConfigsFromText, getOwnerOpenId, getDashboardAdminOpenIds, registerBot } from '../src/bot-registry.js';
 import { GRANT_DURATION_OPTIONS } from '../src/services/grant-policy.js';
 
 describe('bot-registry grant additions', () => {
@@ -157,6 +157,30 @@ describe('bot-registry grant additions', () => {
   it('getOwnerOpenId undefined when no resolved ou_', () => {
     registerBot({ larkAppId: 'a3', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['x@y.com'] });
     expect(getOwnerOpenId('a3')).toBeUndefined();
+  });
+
+  it('getOwnerOpenId prioritizes explicit ownerOpenId over resolvedAllowedUsers', () => {
+    const bot = registerBot({
+      larkAppId: 'a4',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      ownerOpenId: 'ou_owner_explicit',
+      allowedUsers: ['ou_first', 'ou_second'],
+    });
+    bot.resolvedAllowedUsers = ['ou_first', 'ou_second'];
+    expect(getOwnerOpenId('a4')).toBe('ou_owner_explicit');
+  });
+
+  it('getDashboardAdminOpenIds includes explicit ownerOpenId and resolvedAllowedUsers', () => {
+    const bot = registerBot({
+      larkAppId: 'a5',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      ownerOpenId: 'ou_owner_explicit',
+      allowedUsers: ['ou_first'],
+    });
+    bot.resolvedAllowedUsers = ['ou_first'];
+    expect(getDashboardAdminOpenIds('a5')).toEqual(['ou_owner_explicit', 'ou_first']);
   });
 
   it('parses messageQuota.defaultLimit only when a positive integer', () => {

--- a/test/card-handler-browser-restart.test.ts
+++ b/test/card-handler-browser-restart.test.ts
@@ -71,7 +71,7 @@ describe('overload card — restart browser action', () => {
       action: { value: { action: OVERLOAD_ACTION_RESTART_BROWSER, bundleId: 'com.google.Chrome', st: JSON.stringify(st) } },
     }, deps, 'cli_alert');
     expect(restartBrowserMock).not.toHaveBeenCalled();
-    expect(JSON.stringify(result)).toContain('仅管理员可操作');
+    expect(JSON.stringify(result)).toContain('仅 owner 可操作');
   });
 
   it('is one-shot per (nonce, bundleId): a second Arc click is rejected, but Chrome still works', async () => {

--- a/test/card-handler-grant.test.ts
+++ b/test/card-handler-grant.test.ts
@@ -309,4 +309,14 @@ describe('card-handler grant actions', () => {
     const [, , , entries] = recordObservedMock.mock.calls.at(-1)!;
     expect(entries).toEqual([{ openId: 'ou_bot2', name: 'Codex' }]);  // 真人 ou_human 被剔除
   });
+
+  it('co-owner in allowedUsers (not first owner) can also grant access', async () => {
+    const { registry, pending, handler } = await fresh();
+    const bot = registry.getBot('h1');
+    bot.resolvedAllowedUsers = ['ou_owner', 'ou_coowner'];
+    const nonce = pending.openPending('h1', 'oc_1', 'ou_g');
+    const res = await handler.handleCardAction(action('grant_chat', { operator: 'ou_coowner', nonce }), deps, 'h1');
+    expect(res?.toast?.type).toBeUndefined();
+    expect(registry.getBot('h1').config.chatGrants).toEqual({ oc_1: ['ou_g'] });
+  });
 });

--- a/test/card-handler-overload.test.ts
+++ b/test/card-handler-overload.test.ts
@@ -170,4 +170,31 @@ describe('host-overload card actions across bot-scoped daemons', () => {
     // The nonce must be released so the owner can click the button again.
     expect(claimOverloadNonce(state.nonce, OVERLOAD_ACTION_CLEAN_STOPPED)).toBe(true);
   });
+
+  it('blocks non-owner from running overload sweep', async () => {
+    const state: OverloadCardState = {
+      nonce: 'nonce-non-owner',
+      load15: 30, cpu: 10, mem: 0.95, reasons: ['load'],
+      stopped: 5, idle: 9, cleanedN: -1, suspendedN: -1,
+    };
+    registerOverloadNonce(state.nonce);
+
+    const result = await handleCardAction({
+      operator: { open_id: 'ou_coowner' },
+      action: {
+        value: {
+          action: OVERLOAD_ACTION_CLEAN_STOPPED,
+          st: JSON.stringify(state),
+        },
+      },
+    }, {
+      activeSessions: new Map(),
+      sessionReply: vi.fn(async () => 'om_reply'),
+      lastRepoScan: new Map(),
+    } as any, 'cli_alert');
+
+    expect(result?.toast?.type).toBe('error');
+    expect(result?.toast?.content).toBe('仅 owner 可操作');
+    expect(fetchDaemonIpcMock).not.toHaveBeenCalled();
+  });
 });

--- a/test/daemon-codex-app-workflow-wiring.test.ts
+++ b/test/daemon-codex-app-workflow-wiring.test.ts
@@ -58,4 +58,13 @@ describe('daemon Codex App workflow prompt lanes', () => {
     expect(block).toContain('if (ds?.pendingRepo || initialStartPending) {');
     expect(block).not.toContain('if (ds?.pendingRepo || ds?.pendingRepoCommitInFlight || initialStartPending)');
   });
+
+  it('does not use the raw owner DM fallback for notifier card authorization', () => {
+    const block = region(
+      'const handleCodexNotifierCardAction',
+      'const cardDeps',
+    );
+    expect(block).toContain('getExpectedOwnerOpenId: getOwnerOpenId,');
+    expect(block).not.toContain('resolvePrimaryOwnerOpenId');
+  });
 });

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -808,6 +808,7 @@ function setupBotState(opts?: {
   /** 整群 talk 授权（owner 在群里裸 `/grant` 写入的 chat_id 列表）。 */
   allowedChatGroups?: string[];
   allowedUsers?: string[];
+  ownerOpenId?: string;
   /** 原始配置里的 allowedUsers（默认镜像 allowedUsers）。用于构造「配了 owner 但解析为空」的场景。 */
   configAllowedUsers?: string[];
   restrictGrantCommands?: boolean;
@@ -843,6 +844,7 @@ function setupBotState(opts?: {
       // 生产里 config.allowedUsers 是原始配置（启动后 resolvedAllowedUsers 才是解析结果）。
       // 默认镜像, 单测可用 configAllowedUsers 单独构造「配了但解析为空」的 fail-closed 场景。
       allowedUsers: opts?.configAllowedUsers ?? opts?.allowedUsers,
+      ownerOpenId: opts?.ownerOpenId,
       chatGrants: opts?.chatGrants,
       globalGrants: opts?.globalGrants,
       allowedChatGroups: opts?.allowedChatGroups,
@@ -5666,6 +5668,18 @@ describe('configured-but-unresolved allowlist stays fail-closed (not fail-open)'
   it('canTalk: configured owner that resolves to empty blocks ordinary talk (not open)', () => {
     setupBotState({ configAllowedUsers: ['owner@corp.com'], allowedUsers: [] });
     expect(canTalk(MY_APP_ID, 'chat-A', 'ou_random_stranger')).toBe(false);
+  });
+
+  it('revoking explicit owner from resolved allowlist revokes both talk and operate', () => {
+    setupBotState({
+      ownerOpenId: 'ou_old_owner',
+      configAllowedUsers: ['ou_old_owner', 'ou_new_owner'],
+      allowedUsers: ['ou_new_owner'],
+    });
+    expect(canOperate(MY_APP_ID, 'chat-A', 'ou_old_owner')).toBe(false);
+    expect(canTalk(MY_APP_ID, 'chat-A', 'ou_old_owner')).toBe(false);
+    expect(canOperate(MY_APP_ID, 'chat-A', 'ou_new_owner')).toBe(true);
+    expect(canTalk(MY_APP_ID, 'chat-A', 'ou_new_owner')).toBe(true);
   });
 
   it('truly empty config (no allowlist at all) remains open mode', () => {

--- a/test/grant-command.test.ts
+++ b/test/grant-command.test.ts
@@ -268,6 +268,17 @@ describe('tryHandleGrantCommand (@bot /grant @user)', () => {
     expect(content).toContain('owner');                 // owner_only message text
   });
 
+  it('co-owner: can also execute /grant and card reflects co-owner', async () => {
+    const bot = getBot('b1');
+    bot.resolvedAllowedUsers = ['ou_owner', 'ou_coowner'];
+    const handled = await tryHandleGrantCommand('b1', grantMessage(), 'ou_coowner');
+    expect(handled).toBe(true);
+    const [, , cardStr, msgType] = replyMock.mock.calls.at(-1)!;
+    expect(msgType).toBe('interactive');
+    const card = JSON.parse(cardStr);
+    expect(card.body.elements[0].content).toContain('ou_coowner');
+  });
+
   it('unrelated message is not intercepted', async () => {
     const msg = { message_id: 'om_y', chat_id: 'oc_1', content: JSON.stringify({ text: '@_user_1 帮我看下代码' }), mentions: [{ key: '@_user_1', id: { open_id: 'ou_bot' }, name: 'Claude' }] };
     expect(await tryHandleGrantCommand('b1', msg, 'ou_owner')).toBe(false);

--- a/test/grant-command.test.ts
+++ b/test/grant-command.test.ts
@@ -260,12 +260,12 @@ describe('tryHandleGrantCommand (@bot /grant @user)', () => {
     expect(pending.checkNonce('b1', 'oc_1', 'ou_z', grantChat.nonce)).toBe(true);
   });
 
-  it('non-owner: replies owner_only, no card', async () => {
+  it('non-admin: replies owner_only, no card', async () => {
     const handled = await tryHandleGrantCommand('b1', grantMessage(), 'ou_intruder');
     expect(handled).toBe(true);
     const [, , content, msgType] = replyMock.mock.calls.at(-1)!;
     expect(msgType ?? 'text').not.toBe('interactive');  // text reply, not a card
-    expect(content).toContain('owner');                 // owner_only message text
+    expect(content).toContain('管理员');                // owner_only message text
   });
 
   it('co-owner: can also execute /grant and card reflects co-owner', async () => {

--- a/test/grant-owner.test.ts
+++ b/test/grant-owner.test.ts
@@ -38,17 +38,30 @@ describe('grant-owner', () => {
         larkAppSecret: 's',
         cliId: 'claude-code',
         ownerOpenId: 'ou_owner_explicit',
-        allowedUsers: ['user@example.com', 'ou_admin_raw', 'ou_owner_explicit'],
+        allowedUsers: ['user@example.com', 'ou_owner_explicit'],
       });
       bot.resolvedAllowedUsers = ['ou_owner_explicit', 'ou_admin_resolved', 'ou_admin_2'];
 
       const admins = getBotAdminOpenIds('b_multi');
-      expect(admins).toEqual(['ou_owner_explicit', 'ou_admin_resolved', 'ou_admin_2', 'ou_admin_raw']);
+      expect(admins).toEqual(['ou_owner_explicit', 'ou_admin_resolved', 'ou_admin_2']);
 
       expect(isBotAdmin('b_multi', 'ou_owner_explicit')).toBe(true);
       expect(isBotAdmin('b_multi', 'ou_admin_resolved')).toBe(true);
-      expect(isBotAdmin('b_multi', 'ou_admin_raw')).toBe(true);
       expect(isBotAdmin('b_multi', 'ou_stranger')).toBe(false);
+    });
+
+    it('fails closed when raw allowedUsers failed contact resolution', () => {
+      const bot = registerBot({
+        larkAppId: 'b_fail_closed',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_unresolved_cross_app'],
+      });
+      // applyAllowedUsersResolve drops unresolved/invalid ou_ from runtime resolvedAllowedUsers
+      bot.resolvedAllowedUsers = [];
+
+      expect(getBotAdminOpenIds('b_fail_closed')).toEqual([]);
+      expect(isBotAdmin('b_fail_closed', 'ou_unresolved_cross_app')).toBe(false);
     });
 
     it('handles bot without ownerOpenId (legacy config style)', () => {

--- a/test/grant-owner.test.ts
+++ b/test/grant-owner.test.ts
@@ -50,14 +50,16 @@ describe('grant-owner', () => {
       expect(isBotAdmin('b_multi', 'ou_stranger')).toBe(false);
     });
 
-    it('fails closed when raw allowedUsers failed contact resolution', () => {
+    it('fails closed when raw owner and allowedUsers failed contact resolution', () => {
       const bot = registerBot({
         larkAppId: 'b_fail_closed',
         larkAppSecret: 's',
         cliId: 'claude-code',
+        ownerOpenId: 'ou_unresolved_cross_app',
         allowedUsers: ['ou_unresolved_cross_app'],
       });
-      // applyAllowedUsersResolve drops unresolved/invalid ou_ from runtime resolvedAllowedUsers
+      // applyAllowedUsersResolve drops unresolved/invalid identities from runtime resolvedAllowedUsers.
+      // The raw owner must not reopen the permission gate.
       bot.resolvedAllowedUsers = [];
 
       expect(getBotAdminOpenIds('b_fail_closed')).toEqual([]);
@@ -124,6 +126,12 @@ describe('grant-owner', () => {
         listChatMemberOpenIds: listMembers,
       });
       expect(approverNoChat).toBe('ou_owner_1');
+      expect(listMembers).not.toHaveBeenCalled();
+
+      const approverNonChat = await resolveGrantApprover('b_dual', 'not-a-chat-id', undefined, {
+        listChatMemberOpenIds: listMembers,
+      });
+      expect(approverNonChat).toBe('ou_owner_1');
       expect(listMembers).not.toHaveBeenCalled();
     });
 

--- a/test/grant-owner.test.ts
+++ b/test/grant-owner.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getBotAdminOpenIds,
+  isBotAdmin,
+  resolveGrantApprover,
+  clearChatMemberCache,
+} from '../src/im/lark/grant-owner.js';
+import { registerBot, loadBotConfigs } from '../src/bot-registry.js';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('grant-owner', () => {
+  let configPath: string;
+
+  beforeEach(() => {
+    clearChatMemberCache();
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-grant-owner-'));
+    configPath = join(dir, 'bots.json');
+    process.env.BOTS_CONFIG = configPath;
+  });
+
+  afterEach(() => {
+    delete process.env.BOTS_CONFIG;
+    vi.restoreAllMocks();
+  });
+
+  describe('getBotAdminOpenIds & isBotAdmin', () => {
+    it('returns empty array when bot is unregistered', () => {
+      expect(getBotAdminOpenIds('non-existent')).toEqual([]);
+      expect(isBotAdmin('non-existent', 'ou_test')).toBe(false);
+      expect(isBotAdmin('non-existent', undefined)).toBe(false);
+    });
+
+    it('collects ownerOpenId and resolvedAllowedUsers with deduplication', () => {
+      const bot = registerBot({
+        larkAppId: 'b_multi',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        ownerOpenId: 'ou_owner_explicit',
+        allowedUsers: ['user@example.com', 'ou_admin_raw', 'ou_owner_explicit'],
+      });
+      bot.resolvedAllowedUsers = ['ou_owner_explicit', 'ou_admin_resolved', 'ou_admin_2'];
+
+      const admins = getBotAdminOpenIds('b_multi');
+      expect(admins).toEqual(['ou_owner_explicit', 'ou_admin_resolved', 'ou_admin_2', 'ou_admin_raw']);
+
+      expect(isBotAdmin('b_multi', 'ou_owner_explicit')).toBe(true);
+      expect(isBotAdmin('b_multi', 'ou_admin_resolved')).toBe(true);
+      expect(isBotAdmin('b_multi', 'ou_admin_raw')).toBe(true);
+      expect(isBotAdmin('b_multi', 'ou_stranger')).toBe(false);
+    });
+
+    it('handles bot without ownerOpenId (legacy config style)', () => {
+      const bot = registerBot({
+        larkAppId: 'b_legacy',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_first', 'tengdianjiang@bytedance.com'],
+      });
+      bot.resolvedAllowedUsers = ['ou_first', 'ou_second'];
+
+      const admins = getBotAdminOpenIds('b_legacy');
+      expect(admins).toEqual(['ou_first', 'ou_second']);
+      expect(isBotAdmin('b_legacy', 'ou_first')).toBe(true);
+      expect(isBotAdmin('b_legacy', 'ou_second')).toBe(true);
+      expect(isBotAdmin('b_legacy', 'ou_other')).toBe(false);
+    });
+  });
+
+  describe('resolveGrantApprover', () => {
+    it('returns undefined if no admins exist', async () => {
+      registerBot({
+        larkAppId: 'b_empty',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+      });
+      const approver = await resolveGrantApprover('b_empty', 'oc_chat_1');
+      expect(approver).toBeUndefined();
+    });
+
+    it('returns the single admin immediately without calling listMembers', async () => {
+      const bot = registerBot({
+        larkAppId: 'b_single',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_sole_owner'],
+      });
+      bot.resolvedAllowedUsers = ['ou_sole_owner'];
+
+      const listMembers = vi.fn(async () => ['ou_other']);
+      const approver = await resolveGrantApprover('b_single', 'oc_chat_1', undefined, {
+        listChatMemberOpenIds: listMembers,
+      });
+
+      expect(approver).toBe('ou_sole_owner');
+      expect(listMembers).not.toHaveBeenCalled();
+    });
+
+    it('returns first candidate if chatId is missing or not a Lark chat', async () => {
+      const bot = registerBot({
+        larkAppId: 'b_dual',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_owner_1', 'ou_owner_2'],
+      });
+      bot.resolvedAllowedUsers = ['ou_owner_1', 'ou_owner_2'];
+
+      const listMembers = vi.fn(async () => ['ou_owner_2']);
+      const approverNoChat = await resolveGrantApprover('b_dual', undefined, undefined, {
+        listChatMemberOpenIds: listMembers,
+      });
+      expect(approverNoChat).toBe('ou_owner_1');
+      expect(listMembers).not.toHaveBeenCalled();
+    });
+
+    it('prefers admin explicitly mentioned in the message', async () => {
+      const bot = registerBot({
+        larkAppId: 'b_mention',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_owner_1', 'ou_owner_2'],
+      });
+      bot.resolvedAllowedUsers = ['ou_owner_1', 'ou_owner_2'];
+
+      const listMembers = vi.fn(async () => ['ou_owner_1', 'ou_owner_2']);
+      const messageWithMention = {
+        mentions: [
+          { id: { open_id: 'ou_bot' }, name: 'Bot' },
+          { id: { open_id: 'ou_owner_2' }, name: 'Dianjiang' },
+        ],
+      };
+
+      const approver = await resolveGrantApprover('b_mention', 'oc_chat_1', messageWithMention, {
+        listChatMemberOpenIds: listMembers,
+      });
+
+      // Directly picks ou_owner_2 without calling listMembers API
+      expect(approver).toBe('ou_owner_2');
+      expect(listMembers).not.toHaveBeenCalled();
+    });
+
+    it('picks the in-chat admin when global owner is not in chat', async () => {
+      // Yuanhong is allowedUsers[0], but Teng Dianjiang (allowedUsers[1]) is the one in this chat
+      const bot = registerBot({
+        larkAppId: 'b_inchat',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_yuanhong', 'ou_dianjiang'],
+      });
+      bot.resolvedAllowedUsers = ['ou_yuanhong', 'ou_dianjiang'];
+
+      const listMembers = vi.fn(async () => ['ou_dianjiang', 'ou_stranger_user']);
+
+      const approver = await resolveGrantApprover('b_inchat', 'oc_chat_1', {}, {
+        listChatMemberOpenIds: listMembers,
+      });
+
+      expect(approver).toBe('ou_dianjiang');
+      expect(listMembers).toHaveBeenCalledWith('b_inchat', 'oc_chat_1');
+    });
+
+    it('picks the first admin in priority order when multiple admins are in chat', async () => {
+      const bot = registerBot({
+        larkAppId: 'b_both_inchat',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_yuanhong', 'ou_dianjiang'],
+      });
+      bot.resolvedAllowedUsers = ['ou_yuanhong', 'ou_dianjiang'];
+
+      const listMembers = vi.fn(async () => ['ou_dianjiang', 'ou_yuanhong']);
+
+      const approver = await resolveGrantApprover('b_both_inchat', 'oc_chat_1', {}, {
+        listChatMemberOpenIds: listMembers,
+      });
+
+      // Both are in chat, but ou_yuanhong has higher priority in allowedUsers
+      expect(approver).toBe('ou_yuanhong');
+    });
+
+    it('falls back to global owner if NO admin is in chat', async () => {
+      const bot = registerBot({
+        larkAppId: 'b_none_inchat',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_yuanhong', 'ou_dianjiang'],
+      });
+      bot.resolvedAllowedUsers = ['ou_yuanhong', 'ou_dianjiang'];
+
+      const listMembers = vi.fn(async () => ['ou_stranger_1', 'ou_stranger_2']);
+
+      const approver = await resolveGrantApprover('b_none_inchat', 'oc_chat_1', {}, {
+        listChatMemberOpenIds: listMembers,
+      });
+
+      expect(approver).toBe('ou_yuanhong');
+    });
+
+    it('falls back to global owner if listChatMemberOpenIds throws', async () => {
+      const bot = registerBot({
+        larkAppId: 'b_error',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_yuanhong', 'ou_dianjiang'],
+      });
+      bot.resolvedAllowedUsers = ['ou_yuanhong', 'ou_dianjiang'];
+
+      const listMembers = vi.fn(async () => {
+        throw new Error('API network failure');
+      });
+
+      const approver = await resolveGrantApprover('b_error', 'oc_chat_1', {}, {
+        listChatMemberOpenIds: listMembers,
+      });
+
+      expect(approver).toBe('ou_yuanhong');
+    });
+
+    it('caches member list and deduplicates in-flight calls', async () => {
+      const bot = registerBot({
+        larkAppId: 'b_cache',
+        larkAppSecret: 's',
+        cliId: 'claude-code',
+        allowedUsers: ['ou_yuanhong', 'ou_dianjiang'],
+      });
+      bot.resolvedAllowedUsers = ['ou_yuanhong', 'ou_dianjiang'];
+
+      const listMembers = vi.fn(async () => {
+        return ['ou_dianjiang'];
+      });
+
+      // Call concurrently
+      const [res1, res2] = await Promise.all([
+        resolveGrantApprover('b_cache', 'oc_chat_cache', {}, { listChatMemberOpenIds: listMembers }),
+        resolveGrantApprover('b_cache', 'oc_chat_cache', {}, { listChatMemberOpenIds: listMembers }),
+      ]);
+
+      expect(res1).toBe('ou_dianjiang');
+      expect(res2).toBe('ou_dianjiang');
+      expect(listMembers).toHaveBeenCalledTimes(1);
+
+      // Subsequent call uses cache
+      const res3 = await resolveGrantApprover('b_cache', 'oc_chat_cache', {}, { listChatMemberOpenIds: listMembers });
+      expect(res3).toBe('ou_dianjiang');
+      expect(listMembers).toHaveBeenCalledTimes(1);
+
+      // Clear cache and call again
+      clearChatMemberCache();
+      const res4 = await resolveGrantApprover('b_cache', 'oc_chat_cache', {}, { listChatMemberOpenIds: listMembers });
+      expect(res4).toBe('ou_dianjiang');
+      expect(listMembers).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/test/invite-command.test.ts
+++ b/test/invite-command.test.ts
@@ -134,12 +134,12 @@ describe('tryHandleInviteCommand — 拦截与闸门', () => {
     expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(false);
   });
 
-  it('non-owner: replies owner_only, never calls addBotToChat', async () => {
+  it('non-admin: replies owner_only, never calls addBotToChat', async () => {
     writeBotsInfo([{ larkAppId: 'cli_codex', botName: 'Codex' }]);
     expect(await tryHandleInviteCommand('b1', inviteMessage(), 'ou_intruder')).toBe(true);
     expect(addBotMock).not.toHaveBeenCalled();
     expect(replyMock).toHaveBeenCalled();
-    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('owner');
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('管理员');
   });
 
   it('another bot addressed (I am not mentioned): intercepted but fully silent', async () => {


### PR DESCRIPTION
## 问题背景

在群聊场景下，未授权用户或外部 bot 触发授权流程时，`maybeSendGrantRequestCard` 和 `requestGrantForAskClicker` 之前硬编码使用 `getOwnerOpenId(larkAppId)` 获取主管理员（即 `resolvedAllowedUsers` 中的首个 `ou_xxx` 用户）。

当 Bot 配置了多位管理员（例如主管理员和协作者/第二管理员）时，若主管理员根本不在当前群聊中，授权申请卡仍会盲目 `@` 圈出主管理员，导致群外人员被误打扰，而真正身处该群内的管理员却收不到提醒，也无法便捷地点击卡片进行审批。

## 改动内容

1. **审批人解析优先级 (`resolveGrantApprover`)**：
   - 支持 Bot 配置显式声明 `ownerOpenId`。
   - 在群聊且存在多个管理员候选人时：
     - 若消息显式 `@` 了某位管理员，优先选取被 `@` 的管理员。
     - 否则调用 `listChatMemberOpenIds` 查询当前群成员，按配置优先级挑出第一个当前身在群内的管理员作为卡片 `@` 审批对象。
     - 若无任何管理员在群内或查询异常，安全回退至全局主 owner。
   - 对群成员查询增加了 60 秒 TTL 内存缓存与并发请求收敛，避免频繁 API 往返与频控风险。

2. **多管理员审批与命令授权放宽 (`isBotAdmin`)**：
   - 将卡片点击动作（`grant_chat`、`grant_global`、`grant_deny`、`grant_set_duration`、`grant_set_quota`）的闸门由单人 `operatorOpenId === owner` 升级为 `isBotAdmin`，任何在配置中具备管理权限的群内协作者均可操作卡片完成授权。
   - `/grant`、`/revoke`、`/invite` 元命令同样对齐支持任意合法的 Bot 管理员执行。

3. **文档与测试**：
   - 补充 `ownerOpenId` 中英文配置文档。
   - 新增 `test/grant-owner.test.ts` 专项单测，覆盖群成员优先、回退、缓存与并发去重；并补充协作者卡片点击与 `/grant` 命令测试。