### PR TITLE
chore(test): 更正 scope manifest 数量注释 171→169

### DIFF
--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -3295,7 +3295,7 @@ describe('automateOpenPlatformSetup', () => {
 
     // 锁生产链路：走**真实默认 manifest**（不注入 scopeManifest）+ 已授权集合。
     // 这是维护者复审揪出的空白——之前 3 例都注入空 manifest，恰好绕开了唯一有意义
-    // 的那条路径（默认 171+130 项、importedScopeCount 恒 >0 → mutated 恒真 → 短路
+    // 的那条路径（默认 169+130 项、importedScopeCount 恒 >0 → mutated 恒真 → 短路
     // 永不触发）。这里用「manifest 全部已授权」模拟「配置本就齐全」的重启自检。
     const defaultManifest = JSON.parse(
       readFileSync(join(fileURLToPath(new URL('../src/setup/lark-scopes.json', import.meta.url))), 'utf-8'),


### PR DESCRIPTION
## 改了什么

一行注释：`test/setup-open-platform-automation.test.ts:3298` 的「默认 171+130 项」改成「169+130」。

## 为什么

#1233 删掉飞书未开放的 `im:tag:write` / `im:biz_entity_tag_relation:write` 后，tenant 桶 171→169，但这句描述「默认 manifest 有多少项」的注释没跟着改，读的人会以为清单里还有那两条。

纯注释，零行为变更。

## 验证

- `test/setup-open-platform-automation.test.ts` **154/154** 通过
- 实测当前 manifest = tenant **169** + user **130**，与更正后的注释一致

## 来源

#1233 复审提出的非阻断 nit。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
