### PR TITLE
fix(feedback): 空 reviewer 名单仍展示反馈按钮

### DIFF
--- a/docs/feedback-capability-current-implementation.md
+++ b/docs/feedback-capability-current-implementation.md
@@ -73,7 +73,7 @@ Core 只接受三种语义：
 - 总开关默认关闭。
 - `apiOnly` bot 不展示反馈。
 - `audience` 默认 `requester`：鉴权主体固定为 delivery 中保存的 requester subject。正常 final 路径优先使用精确 turn sender；当该身份不可得时，当前实现会退化到已确认的 session owner/footer recipient，因此不是所有路径都能保证等同于“本次消息发送者”。
-- `audience: "reviewers"` 用于 bot 触发的自动分析场景（如 Oncall/告警监听，本次 turn 的发送者是另一个 bot、没有单一真人 owner）：改由发送时冻结的 `reviewers` 名单鉴权，名单里任一可信真人身份点击即放行，与是否存在真人 requester 无关。名单可填写 `ou_`、`on_` 或完整邮箱；邮箱会在发卡时解析为当前应用的 `open_id`，回调仍保持零网络鉴权。
+- `audience: "reviewers"` 用于 bot 触发的自动分析场景（如 Oncall/告警监听，本次 turn 的发送者是另一个 bot、没有单一真人 owner）：改由发送时冻结的 `reviewers` 名单鉴权，名单里任一可信真人身份点击即放行，与是否存在真人 requester 无关。名单可填写 `ou_`、`on_` 或完整邮箱；邮箱会在发卡时解析为当前应用的 `open_id`，回调仍保持零网络鉴权。名单为空时仍展示反馈按钮，但所有点击都会被拒绝。
 - `audience: "everyone"` 允许任意具有平台核验 operator 身份的点击者反馈，不要求 requester，也不需要 `reviewers` 名单。该模式会扩大反馈写入范围，应只用于群成员都可信的场景。
 - `allowReselect` 默认 `false`；只有显式设置 `true` 才允许改选。
 - 说明框默认开启、非必填，默认最大 1000 字。
@@ -86,8 +86,8 @@ Core 只接受三种语义：
 - 按钮 2–4 个，key 唯一，只允许 `[a-z0-9_-]+`。
 - 负向原因最多 6 个。
 - 说明最大长度 1–2000。
-- `audience` 仅接受 `requester` / `reviewers` / `everyone`。`reviewers` 名单每项必须是 `ou_`（app 内 open_id）、`on_`（跨 app union_id）或完整邮箱，最多 50 项且不重复。邮箱在发送时用当前 bot 凭证解析为 `ou_` 后才写入策略快照；解析不到时丢弃该项，全部无法解析则 fail closed、不展示反馈。跨 app 场景应优先使用 `on_`（`ou_` 是 app-scoped、不可跨 app 复制）。
-- `audience: "reviewers"` 与 `reviewers` 名单必须同时成立：`reviewers` audience 缺名单，或 `requester` / `everyone` audience 却带名单，都会 fail closed（分层配置合并后仍按整体校验，任一层非法即不展示反馈）。
+- `audience` 仅接受 `requester` / `reviewers` / `everyone`。`reviewers` 名单每项必须是 `ou_`（app 内 open_id）、`on_`（跨 app union_id）或完整邮箱，最多 50 项且不重复。邮箱在发送时用当前 bot 凭证解析为 `ou_` 后才写入策略快照；解析不到时丢弃该项，全部无法解析时保留空名单和反馈按钮，但点击鉴权仍 fail closed。跨 app 场景应优先使用 `on_`（`ou_` 是 app-scoped、不可跨 app 复制）。
+- `audience: "reviewers"` 允许缺省或清空 `reviewers`，此时按钮可见但没有任何用户能提交反馈；`requester` / `everyone` audience 带非空名单仍会被判为无效策略。
 - 不允许配置任意 Lark card JSON；配置仅包含受约束的领域字段。
 
 ## 4. 分层配置模型
@@ -166,7 +166,7 @@ built-in defaults
 
 - 名单项为 `ou_`（app 内 open_id）、`on_`（跨 app union_id）或完整邮箱；跨 app 优先用 `on_`。邮箱在发卡时解析为当前应用的 `ou_`，未解析成功的项不会写入快照。
 - 名单随 delivery 快照冻结：后续改名单只影响新卡，旧卡仍按发送时名单鉴权。
-- `audience` 与 `reviewers` 可分散在不同层（team/bot/chat）提供，合并后按整体校验；`reviewers` audience 缺名单会 fail closed。
+- `audience` 与 `reviewers` 可分散在不同层（team/bot/chat）提供，合并后按整体校验；`reviewers` audience 缺名单时仍展示按钮，但所有点击都会 fail closed。
 
 ### 4.5 everyone audience 示例
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9081,8 +9081,8 @@ async function cmdSend(rest: string[]): Promise<void> {
   // Freeze email reviewers into this bot's app-scoped open_id NOW, with
   // the bot's own credentials, so the card callback can match network-free
   // against the delivery snapshot. Pure ou_/on_ lists (and requester/everyone)
-  // skip the lookup. If resolution empties a reviewers list, fail closed (no
-  // feedback control) rather than ship a card nobody can click.
+  // skip the lookup. An empty materialized list still renders the control; the
+  // callback then rejects every operator without widening access.
   if (feedbackPolicy && effectiveResponseKind === 'final' && feedbackPolicy.audience === 'reviewers') {
     try {
       const { materializeFeedbackReviewers } = await import('./services/feedback-policy.js');
@@ -9099,7 +9099,6 @@ async function cmdSend(rest: string[]): Promise<void> {
     } catch {
       feedbackPolicy = undefined;
     }
-    if (feedbackPolicy && feedbackPolicy.reviewers.length === 0) feedbackPolicy = undefined;
   }
   const feedbackRequesterSubjectId = replyTargetSenderOpenId ?? s.ownerOpenId;
   // `reviewers`/`everyone` audiences gate clicks without a human requester —

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -14624,8 +14624,9 @@ function deliverFinalOutput(
       let feedbackPolicy = managedReceiver ? undefined : ds.feedbackPolicy;
       // Freeze email reviewers into this bot's app-scoped open_id so the
       // card callback can match network-free against the delivery snapshot. Pure
-      // ou_/on_ lists (and requester/everyone) skip the lookup. If resolution
-      // empties the list, fail closed (drop the feedback control).
+      // ou_/on_ lists (and requester/everyone) skip the lookup. An empty
+      // materialized list keeps the control visible while the callback rejects
+      // every operator.
       if (feedbackPolicy && feedbackPolicy.audience === 'reviewers') {
         try {
           const { materializeFeedbackReviewers } = await import('../services/feedback-policy.js');
@@ -14642,7 +14643,6 @@ function deliverFinalOutput(
         } catch {
           feedbackPolicy = undefined;
         }
-        if (feedbackPolicy && feedbackPolicy.reviewers.length === 0) feedbackPolicy = undefined;
       }
       const feedbackRequesterSubjectId = recipientOpenId;
       // `reviewers`/`everyone` audiences gate clicks without a human requester,

--- a/src/services/feedback-policy-resolver.ts
+++ b/src/services/feedback-policy-resolver.ts
@@ -120,10 +120,10 @@ export function resolveEffectiveFeedbackPolicy(input: {
   mergeLayer(merged, input.bot);
   mergeLayer(merged, input.chat);
   if (merged.enabled !== true) return undefined;
-  // Individually-valid layers can still merge into an invalid whole — most
-  // notably `audience: 'reviewers'` with an empty reviewers allowlist once the
-  // layers are combined. Fail closed (feedback simply not shown) rather than
-  // letting the throw propagate to the unguarded worker-spawn delivery path.
+  // Individually-valid layers can still merge into an invalid whole (for
+  // example, a reviewers allowlist paired with another audience). Fail closed
+  // rather than letting the throw propagate to worker-spawn delivery. An empty
+  // reviewers allowlist is valid and remains visible but unclickable.
   try {
     return structuredClone(normalizeFeedbackPolicy(merged));
   } catch {

--- a/src/services/feedback-policy.ts
+++ b/src/services/feedback-policy.ts
@@ -145,12 +145,10 @@ export function normalizeFeedbackPolicy(raw: unknown): FeedbackPolicy {
   if (input.reviewers !== undefined) {
     reviewers = validateReviewerEntries(input.reviewers);
   }
-  // `reviewers` audience is meaningless without at least one reviewer, and a
-  // silently-empty allowlist would render an un-clickable control. Fail closed
-  // at config time instead of shipping a dead button.
-  if (audience === 'reviewers' && reviewers.length === 0) {
-    throw new Error('feedback.audience "reviewers" requires a non-empty feedback.reviewers allowlist');
-  }
+  // An empty reviewers allowlist is intentional: keep the feedback control
+  // visible, but let the callback identity gate reject every operator. This
+  // surfaces the configured feedback affordance without widening access when
+  // the trusted reviewer list has not been filled in yet.
   // A reviewers allowlist only has meaning under the reviewers audience; reject
   // the combination rather than silently ignoring it (a requester-only or
   // everyone card must never appear to have carried an allowlist).
@@ -238,8 +236,9 @@ function isResolvableReviewerEntry(entry: string): boolean {
  *  - a resolver that maps an email to an `ou_` replaces that entry;
  *  - an unresolved email is DROPPED (never shipped as a dead entry that
  *    silently gates nothing, and never left as raw text the callback can't
- *    match). If every entry drops, the caller sees an empty allowlist and must
- *    fail closed (no clickable control) rather than emitting an open card.
+ *    match). If every entry drops, the caller sees an empty allowlist and the
+ *    callback remains fail closed: the control stays visible, but nobody can
+ *    submit feedback until a reviewer can be verified.
  *
  * `resolve` receives the raw email entries and returns a map from the
  * raw entry to a resolved `ou_` (missing key = unresolved). It is only called
@@ -259,8 +258,8 @@ export async function materializeFeedbackReviewers(
   } catch {
     // A transient resolver failure must not silently widen or dead-gate the
     // card. Drop the unresolved entries; keep any literal ids that need no
-    // lookup. An all-dropped result yields an empty allowlist (caller fails
-    // closed), never an open one.
+    // lookup. An all-dropped result yields an empty allowlist (the callback
+    // rejects every operator), never an open one.
     map = new Map();
   }
   const seen = new Set<string>();

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -482,7 +482,7 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(JSON.stringify(delivery?.policy)).not.toContain('reviewer@example.com');
   });
 
-  it('does not render a reviewers card when every email is unresolved', async () => {
+  it('renders a fail-closed reviewers card when every email is unresolved', async () => {
     resolveAllowedUsersWithMapMock.mockResolvedValue({
       resolved: [],
       map: new Map(),
@@ -501,7 +501,24 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
     await vi.advanceTimersByTimeAsync(10);
 
-    expect(String(sessionReply.mock.calls[0][1])).not.toContain('botmux_feedback');
+    expect(String(sessionReply.mock.calls[0][1])).toContain('botmux_feedback');
+  });
+
+  it('renders a fail-closed reviewers card when no reviewers are configured', async () => {
+    const sessionReply = vi.fn(async () => 'om_empty_reviewers_feedback');
+    initWorkerPool({ sessionReply, getSessionWorkingDir: () => '/tmp', getActiveCount: () => 1, closeSession: vi.fn() });
+    const ds = makeDs();
+    ds.feedbackPolicy = normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers' });
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    const { getSkillFeedbackStore } = await import('../src/services/skill-feedback-store.js');
+
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(String(sessionReply.mock.calls[0][1])).toContain('botmux_feedback');
+    expect((await getSkillFeedbackStore('/tmp/test-sessions'))
+      .findDeliveryByPlatformMessage('lark', ds.larkAppId, 'om_empty_reviewers_feedback'))
+      .toMatchObject({ policy: { audience: 'reviewers', reviewers: [] } });
   });
 
   it('keeps feedback disabled by default and does not open the store', async () => {

--- a/test/feedback-policy-resolution.test.ts
+++ b/test/feedback-policy-resolution.test.ts
@@ -120,7 +120,7 @@ describe('feedback policy layered resolution', () => {
     expect(resolveFeedbackPolicyForDelivery({ dataDir, larkAppId: 'appB', chatId: 'sameChat', bot: botB })).toMatchObject({ allowReselect: true });
   });
 
-  it('merges a reviewers allowlist across layers and fails closed on an invalid merged whole', () => {
+  it('merges a reviewers allowlist across layers and keeps an empty reviewers audience', () => {
     // audience and reviewers may legitimately arrive from different layers.
     expect(resolveEffectiveFeedbackPolicy({
       team: { enabled: true },
@@ -134,10 +134,11 @@ describe('feedback policy layered resolution', () => {
       chat: { reviewers: ['ou_carol'] },
     })).toMatchObject({ audience: 'reviewers', reviewers: ['ou_carol'] });
 
-    // Individually-valid layers can merge into an invalid whole (reviewers
-    // audience with an empty allowlist, or an allowlist without the audience) —
-    // fail closed instead of shipping a dead or mis-gated button.
-    expect(resolveEffectiveFeedbackPolicy({ team: { enabled: true, audience: 'reviewers' } })).toBeUndefined();
+    // An empty reviewers audience deliberately keeps the controls visible; its
+    // callback allowlist is empty, so every click is still rejected. An
+    // allowlist paired with another audience remains invalid.
+    expect(resolveEffectiveFeedbackPolicy({ team: { enabled: true, audience: 'reviewers' } }))
+      .toMatchObject({ audience: 'reviewers', reviewers: [] });
     expect(resolveEffectiveFeedbackPolicy({ team: { enabled: true, reviewers: ['ou_alice'] } })).toBeUndefined();
   });
 

--- a/test/feedback-policy.test.ts
+++ b/test/feedback-policy.test.ts
@@ -132,9 +132,9 @@ describe('feedback policy', () => {
       expect(policy.reviewers).toEqual(['alice@example.com', 'on_bob']);
     });
 
-    it('fails closed when the reviewers audience has an empty allowlist', () => {
-      expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers' })).toThrow(/non-empty/);
-      expect(() => normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers', reviewers: [] })).toThrow(/non-empty/);
+    it('keeps an empty reviewers allowlist visible but fail-closed at callback time', () => {
+      expect(normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers' }).reviewers).toEqual([]);
+      expect(normalizeFeedbackPolicy({ enabled: true, audience: 'reviewers', reviewers: [] }).reviewers).toEqual([]);
     });
 
     it('rejects a reviewers allowlist paired with a non-reviewers audience', () => {

--- a/test/skill-feedback-callback.test.ts
+++ b/test/skill-feedback-callback.test.ts
@@ -180,6 +180,14 @@ describe('feedback callback reviewers audience', () => {
     expect(store.listFeedbackRevisions(delivery.deliveryId, 'ou_reviewer')).toHaveLength(0);
     store.close();
   });
+
+  it('rejects every operator when the reviewers allowlist is empty', async () => {
+    const { store, delivery } = await reviewersSetup([]);
+    const result = await handleSkillFeedbackCardAction(event({ action: 'feedback_submit', result: 'conclusive_usable' }, 'ou_anyone'), 'app', { store });
+    expect(result.toast).toMatchObject({ type: 'error', content: '仅指定的反馈人可反馈' });
+    expect(store.listFeedbackRevisions(delivery.deliveryId, 'ou_anyone')).toHaveLength(0);
+    store.close();
+  });
 });
 
 describe('feedback callback everyone audience', () => {


### PR DESCRIPTION
## 改了什么

- 允许 `audience: "reviewers"` 在未配置或清空 `reviewers` 时生成有效反馈策略。
- 最终回答仍展示反馈按钮；空名单下回调鉴权拒绝所有点击者，并提示“仅指定的反馈人可反馈”。
- reviewer 邮箱全部解析失败时保留空名单反馈控件，不再静默移除按钮。
- 保持 `requester`、`everyone` 和非空 reviewer 名单的原有行为，并同步实现文档。

## 为什么

此前 `reviewers` audience 缺少有效名单时会在策略解析或发卡阶段移除反馈控件，导致用户看不到已开启的反馈功能。现在将“控件是否展示”与“谁有权限提交”分离：控件保持可见，权限仍严格 fail closed，不会因漏配名单而扩大到群内所有人。

## 影响面

- 影响飞书最终回答反馈卡的策略解析、CLI 主动发送和 daemon 兜底投递路径。
- 回调鉴权仍使用 delivery 中冻结的 reviewer 名单；空名单不允许任何人写入反馈。
- 与具体 CLI、PtyBackend/TmuxBackend 无关；其它 IM 和 `apiOnly` bot 不受影响。
- 未配置 `audience` 时仍默认 `requester`，旧配置与非空 reviewer 配置行为不变。

## 测试验证

- `bunx vitest run test/feedback-analytics-api.test.ts test/skill-feedback-card.test.ts test/feedback-live-regression.test.ts test/skill-feedback-store.test.ts test/feedback-webhook-dispatcher.test.ts test/feedback-outbox.test.ts test/feedback-policy-resolution.test.ts test/cli-send-hook-context.test.ts test/feedback-analytics.test.ts test/dashboard-feedback-settings.test.ts test/skill-feedback-callback.test.ts test/dashboard-feedback-page.test.ts test/bridge-final-output-retry.test.ts test/feedback-policy.test.ts test/feedback-store-v3-migration.test.ts`
  - 15 个测试文件通过，230 tests passed。
- `bun run build`
  - 构建、脚本类型检查、Dashboard bundle 和产物审计均通过。
- `git diff --check`
  - 通过。

## Live 验证

- 执行 `bun run switch:here && bun run daemon:restart`，daemon 与 Dashboard 均正常在线。
- 将测试 Bot 配置为 `audience: "reviewers"`、`reviewers: []`，向真实飞书会话发送 final 回答卡。
- 实际卡片正常展示“结论可用 / 有效推进 / 结论有误”三个反馈按钮。
- 点击任意按钮后提示“仅指定的反馈人可反馈”。
- 点击后核对 SQLite delivery 快照仍为 `audience: reviewers`、`reviewers: []`，对应 feedback revision 数为 0，确认未越权写入。
