### PR TITLE
fix(npm): 加回 bin 指向 sh 启动器，修 pnpm/bun 全局安装后没有 botmux 命令

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "0.0.0",
   "description": "Bridge between IM platforms and AI coding CLIs \u2014 one topic, one CLI session with live streaming",
   "type": "module",
+  "bin": {
+    "botmux": "scripts/botmux-launcher.sh"
+  },
   "files": [
+    "scripts/botmux-launcher.sh",
     "scripts/postinstall-bin.mjs",
     "scripts/install-path-entry.mjs",
     "README.md",

--- a/scripts/botmux-launcher.sh
+++ b/scripts/botmux-launcher.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# botmux launcher — the `bin` entry npm/pnpm/bun link onto PATH.
+#
+# ── WHY THIS FILE EXISTS ───────────────────────────────────────────────────────
+# The main package ships NO binary (0.1MB, 6 files): the compiled single-file
+# executable lives in a platform subpackage (`botmux-linux-x64`, …) pulled in as
+# an optional dependency. `bin` can only point INSIDE the main package, so it
+# cannot name that binary directly — hence this dispatcher, which resolves the
+# subpackage at RUN time and `exec`s it.
+#
+# Until now the only thing that produced a runnable `botmux` was
+# `scripts/postinstall-bin.mjs`, which writes ~/.botmux/bin/botmux. That still
+# runs and is still what gives multi-Node-version boxes ONE unambiguous global
+# botmux. But postinstall is not guaranteed to run:
+#
+#   MEASURED on v3.18.13, isolated HOME, each manager's own global install:
+#     npm i -g botmux    → postinstall runs   → launcher written → `botmux` works
+#     bun add -g botmux  → "Blocked 2 postinstalls" → NO launcher → no command
+#     pnpm add -g botmux → script not run at all    → NO launcher → no command
+#
+#   Both failures exit 0 and print "installed botmux@3.18.13" / "+ botmux 3.18.13",
+#   so the user believes it worked and only finds out at `botmux: command not found`.
+#   bun can be rescued with `bun pm -g trust botmux`; pnpm could NOT be rescued —
+#   `onlyBuiltDependencies: [botmux]` still produced no launcher (measured).
+#
+# With a `bin` entry the package manager links this script itself, so all three
+# get a working command with no lifecycle script at all. postinstall then becomes
+# an OPTIMISATION (the single canonical launcher) rather than a prerequisite.
+#
+# ── WHY sh AND NOT node ────────────────────────────────────────────────────────
+# A Node dispatcher would reintroduce a Node dependency for a package whose whole
+# point is a self-contained binary, and would add interpreter startup to every
+# invocation. `bin` pointing at a shell script works on npm, pnpm and bun alike
+# (measured, all three link it and run it). `exec` replaces this process, so the
+# binary receives the original argv and signals with no shell left in between.
+#
+# Windows is not handled here: there are no win32 platform subpackages at all
+# (only darwin/linux × x64/arm64 ± musl), so there is nothing for a .cmd shim to
+# dispatch to. WSL2 reports as linux and is the supported route.
+
+set -e
+
+# Resolve this script through symlinks, then take the PACKAGE root.
+#
+# Two things make this fiddly, both MEASURED:
+#  · `bin` entries are linked into the manager's bin dir, so $0 is often a
+#    symlink — but pnpm instead generates a wrapper that runs `/bin/sh <path>`,
+#    where <path> goes through a symlinked package dir. Either way the honest
+#    answer comes from resolving the path and then `cd -P`.
+#  · This file lives in `<pkg>/scripts/`, so the package root is the PARENT of
+#    this script's directory. Using the script's own dir made every sibling
+#    lookup miss by one level.
+target=$0
+# Bounded: a symlink cycle would otherwise spin here forever.
+i=0
+while [ -L "$target" ] && [ "$i" -lt 40 ]; do
+  link=$(readlink "$target")
+  case $link in
+    /*) target=$link ;;
+    *)  target=$(dirname "$target")/$link ;;
+  esac
+  i=$((i + 1))
+done
+# `cd -P` resolves any symlinked parent directory (pnpm's store links).
+pkg=$(cd "$(dirname "$target")/.." && pwd -P)
+
+# musl (Alpine and most slim images): npm/pnpm/bun select the -musl subpackage via
+# each subpackage's `libc` field, so we must look for that same name. Positive
+# evidence only — never claim musl on a glibc box.
+libc=''
+if [ "$(uname -s)" = Linux ]; then
+  if ls /lib/ld-musl-* /usr/lib/ld-musl-* >/dev/null 2>&1 || [ -f /etc/alpine-release ]; then
+    libc='-musl'
+  fi
+fi
+
+case $(uname -s) in
+  Linux)  os=linux ;;
+  Darwin) os=darwin ;;
+  *)      os='' ;;
+esac
+case $(uname -m) in
+  x86_64|amd64)  arch=x64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *)             arch='' ;;
+esac
+
+if [ -z "$os" ] || [ -z "$arch" ]; then
+  echo "botmux: unsupported platform $(uname -s)/$(uname -m)." >&2
+  echo "Supported: linux-x64, linux-arm64, darwin-x64, darwin-arm64. On Windows use WSL2." >&2
+  exit 1
+fi
+
+sub="botmux-$os-$arch$libc"
+
+# Two layouts, both MEASURED against real global installs of v3.18.13:
+#   npm       → <main>/node_modules/botmux-linux-x64/botmux   (nested)
+#   pnpm, bun → <main>/../botmux-linux-x64/botmux             (sibling / hoisted)
+# Try the exact-libc name first, then the other libc as a fallback: a mirrored or
+# repacked registry can drop the `libc` field, leaving the "wrong" one installed.
+for name in "$sub" "botmux-$os-$arch"; do
+  for candidate in "$pkg/node_modules/$name/botmux" "$pkg/../$name/botmux"; do
+    if [ -x "$candidate" ]; then
+      exec "$candidate" "$@"
+    fi
+  done
+done
+
+echo "botmux: no platform binary found for $sub." >&2
+echo "The optional platform package did not install. Reinstall with:" >&2
+echo "  npm i -g botmux --force    (or: pnpm add -g botmux / bun add -g botmux)" >&2
+exit 1

--- a/test/botmux-launcher.test.ts
+++ b/test/botmux-launcher.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * `scripts/botmux-launcher.sh` is the package's `bin` entry: the ONLY thing that
+ * gives pnpm and bun users a working `botmux` command, because neither runs the
+ * postinstall that writes ~/.botmux/bin/botmux.
+ *
+ * MEASURED on v3.18.13 before this launcher existed (isolated HOME each):
+ *   npm i -g botmux    → postinstall ran      → command works
+ *   bun add -g botmux  → "Blocked 2 postinstalls" → NO command
+ *   pnpm add -g botmux → script not run          → NO command
+ * Both failures exit 0 and print "installed", so the user only finds out at
+ * `botmux: command not found`.
+ *
+ * These tests drive the real script with a fake platform binary, so they cover
+ * the layout resolution rather than restating it. The layouts are the ones real
+ * global installs produce (verified against actual npm/pnpm/bun installs).
+ */
+const LAUNCHER = resolve(import.meta.dirname, '../scripts/botmux-launcher.sh');
+
+/** A stand-in for the compiled binary: prints a marker plus the argv it got. */
+function writeFakeBinary(path: string): void {
+  writeFileSync(path, '#!/bin/sh\necho "FAKE-BINARY $*"\n', { mode: 0o755 });
+}
+
+/**
+ * Build `<root>/node_modules/botmux` with the launcher in place, and drop a fake
+ * platform binary into the requested layout.
+ *
+ * `nested`  → <main>/node_modules/botmux-<plat>/botmux   (npm)
+ * `sibling` → <main>/../botmux-<plat>/botmux             (pnpm, bun)
+ * `none`    → no platform package at all
+ */
+function makeInstall(layout: 'nested' | 'sibling' | 'none'): { dir: string; main: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'botmux-launcher-'));
+  const nm = join(dir, 'node_modules');
+  const main = join(nm, 'botmux');
+  mkdirSync(join(main, 'scripts'), { recursive: true });
+  // Copy rather than symlink: the launcher must work as a plain file too.
+  const body = spawnSync('cat', [LAUNCHER], { encoding: 'utf-8' }).stdout;
+  const shipped = join(main, 'scripts', 'botmux-launcher.sh');
+  writeFileSync(shipped, body, { mode: 0o755 });
+
+  const plat = `botmux-${process.platform}-${process.arch === 'x64' ? 'x64' : process.arch}`;
+  if (layout === 'nested') {
+    const d = join(main, 'node_modules', plat);
+    mkdirSync(d, { recursive: true });
+    writeFakeBinary(join(d, 'botmux'));
+  } else if (layout === 'sibling') {
+    const d = join(nm, plat);
+    mkdirSync(d, { recursive: true });
+    writeFakeBinary(join(d, 'botmux'));
+  }
+  return { dir, main };
+}
+
+function runLauncher(entry: string, args: string[] = ['--version']) {
+  return spawnSync(entry, args, { encoding: 'utf-8', timeout: 20_000 });
+}
+
+const onPosix = process.platform === 'win32' ? describe.skip : describe;
+
+onPosix('botmux-launcher.sh', () => {
+  it.each(['nested', 'sibling'] as const)(
+    'resolves the platform binary in the %s layout (npm vs pnpm/bun)',
+    (layout) => {
+      const { dir, main } = makeInstall(layout);
+      try {
+        const r = runLauncher(join(main, 'scripts', 'botmux-launcher.sh'));
+        expect(r.stdout.trim(), `stderr=${r.stderr}`).toBe('FAKE-BINARY --version');
+        expect(r.status).toBe(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('resolves through a symlinked bin entry (how managers put it on PATH)', () => {
+    const { dir, main } = makeInstall('sibling');
+    try {
+      const binDir = join(dir, 'bin');
+      mkdirSync(binDir, { recursive: true });
+      const link = join(binDir, 'botmux');
+      symlinkSync(join(main, 'scripts', 'botmux-launcher.sh'), link);
+      const r = runLauncher(link);
+      expect(r.stdout.trim(), `stderr=${r.stderr}`).toBe('FAKE-BINARY --version');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes argv through verbatim, including flags and spaces', () => {
+    const { dir, main } = makeInstall('nested');
+    try {
+      const r = runLauncher(join(main, 'scripts', 'botmux-launcher.sh'), ['send', '--no-mention', 'a b']);
+      expect(r.stdout.trim()).toBe('FAKE-BINARY send --no-mention a b');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails loudly (exit 1 + actionable stderr) when no platform package installed', () => {
+    const { dir, main } = makeInstall('none');
+    try {
+      const r = runLauncher(join(main, 'scripts', 'botmux-launcher.sh'));
+      // Exit code matters: a silent 0 would make wrapper scripts think it worked.
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain('no platform binary found');
+      expect(r.stderr).toContain('Reinstall');
+      expect(r.stdout).toBe('');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not pick a non-executable candidate (a bad unpack must not be exec-ed)', () => {
+    const { dir, main } = makeInstall('nested');
+    try {
+      const plat = `botmux-${process.platform}-${process.arch === 'x64' ? 'x64' : process.arch}`;
+      chmodSync(join(main, 'node_modules', plat, 'botmux'), 0o644);
+      const r = runLauncher(join(main, 'scripts', 'botmux-launcher.sh'));
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain('no platform binary found');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is POSIX sh (no bashisms) — pnpm and npm shims both exec it with /bin/sh', () => {
+    expect(spawnSync('sh', ['-n', LAUNCHER], { encoding: 'utf-8' }).status).toBe(0);
+  });
+});

--- a/test/npm-binary-distribution.test.ts
+++ b/test/npm-binary-distribution.test.ts
@@ -152,8 +152,24 @@ describe('package.json — lockfile safety and packaging', () => {
     // that lies about itself: `require('botmux')` would resolve and then fail on a
     // missing file. The package is a CLI delivered as a compiled binary, so it has
     // no library entry point at all.
-    expect(manifest.bin).toBeUndefined();
+    //
+    // `bin` IS set again (it was undefined between #1047 and the sh-launcher
+    // change), but only to a launcher this package actually ships. That is exactly
+    // the invariant this test is named after, so assert the invariant rather than
+    // the absence: every `bin` target must be a file inside `files`, and must not
+    // point into `dist/`. See the node-pty pin below for the shape that must NOT
+    // come back (`bin` → dist/cli.js, which needed a Node runtime + node-pty).
     expect(manifest.main).toBeUndefined();
+    const binTargets = Object.values((manifest.bin ?? {}) as Record<string, string>);
+    expect(binTargets).toEqual(['scripts/botmux-launcher.sh']);
+    for (const target of binTargets) {
+      expect(target.startsWith('dist/'), `${target} must not point into dist/`).toBe(false);
+      expect(
+        manifest.files.some((f: string) => f === target || f === 'scripts/' || f === 'scripts'),
+        `${target} is declared in bin but not shipped in files`,
+      ).toBe(true);
+      expect(existsSync(resolve(import.meta.dirname, '..', target)), `${target} missing on disk`).toBe(true);
+    }
   });
 
   it('ships the postinstall script in `files` (otherwise npm i -g fails hard)', () => {
@@ -576,13 +592,20 @@ describe('postinstall-bin — writes the launcher ONLY for a real global install
     // pre-#1047 install reached the same unrunnable CLI with no `bin` involved —
     // that is the crash users hit on 3.18.7/3.18.8. `dist/` is out of `files` now
     // (asserted against real `npm pack` output above); keep BOTH pins.
+    //
+    // `bin` itself is back (sh launcher), so the pin can no longer be "bin is
+    // undefined". What must never come back is a `bin` that needs a NODE RUNTIME:
+    // the sh launcher `exec`s the platform binary directly and imports nothing.
     const manifest = JSON.parse(readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf-8')) as {
-      bin?: unknown;
+      bin?: Record<string, string>;
       dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
       optionalDependencies?: Record<string, string>;
     };
-    expect(manifest.bin).toBeUndefined();
+    for (const target of Object.values(manifest.bin ?? {})) {
+      expect(target.endsWith('.sh'), `bin ${target} must be the sh launcher, not a Node entry point`).toBe(true);
+      expect(target.startsWith('dist/'), `bin ${target} must not resolve into dist/`).toBe(false);
+    }
     // node-pty must be a devDependency and NOTHING else. It has an `install` script
     // and ships no linux prebuild, so ANY placement an end user's install would honor
     // (`dependencies` OR `optionalDependencies`) makes npm run node-gyp — measured:


### PR DESCRIPTION
## 背景

主包自 #1047 起没有 `bin` 字段，可用的 `botmux` 命令完全依赖 postinstall（`scripts/postinstall-bin.mjs`）写 `~/.botmux/bin/botmux`。但 **pnpm 10/11 与 bun 默认都不执行依赖的 postinstall**，于是这两种装法装完**没有任何 botmux 命令**。

实测 v3.18.13（各用隔离 HOME，同一台机器）：

| 装法 | exit | 提示 | 装完有 `botmux` 命令 |
|---|---|---|---|
| `npm i -g botmux` | 0 | 正常 | ✅ 有 |
| `bun add -g botmux` | 0 | `installed botmux@3.18.13` + `Blocked 2 postinstalls` | ❌ 无 |
| `pnpm add -g botmux` | 0 | `+ botmux 3.18.13` | ❌ 无 |

最坑的是**两种失败都 exit 0 并打印「installed」**，用户以为装好了，直到敲 `botmux` 才发现 command not found——报错也不是「找不到包」（包确实下下来了），而是没人给它写启动器。

补救手段只有一半有效：`bun pm -g trust botmux` 可以救 bun；**pnpm 救不了**——改用非交互的 `onlyBuiltDependencies: [botmux]` 重装，exit 0 但仍无 launcher（实测）。

## 改动

主包加回 `bin`，指向随包发布的 `scripts/botmux-launcher.sh`。包管理器自己会把这个脚本链到 PATH，**三种装法都不再依赖生命周期脚本**。postinstall 保持不变，从「必需」降级为「优化」——它仍然负责在多 Node 版本的机器上给出唯一一个全局 botmux。

**为什么用 sh 而不是 Node 启动器**：主包的意义就是不依赖 Node 运行时；且 sh 启动器 `exec` 掉自身，二进制直接拿到原始 argv 与信号，中间不留进程。

**为什么要运行时解析**：`bin` 只能指向主包内的路径，而二进制在平台子包里（主包本身只有 0.1MB / 6 个文件）。所以脚本在运行时找子包——**实测两种布局都必须覆盖**：

- npm → `<主包>/node_modules/<平台包>/botmux`（嵌套）
- pnpm、bun → `<主包>/../<平台包>/botmux`（同级）

musl 沿用与 postinstall 相同的判据（positive evidence only），并在找不到精确 libc 名时回退另一个名字，兼容丢掉 `libc` 字段的镜像源。

**Windows 不在此处处理**：仓库没有 win32 平台子包（只有 darwin/linux × x64/arm64 ± musl），cmd shim 没有可分发的目标；WSL2 报告为 linux 且已支持。

## 影响面

- **跨包管理器**：npm / pnpm / bun 三种全局安装形态都实测过（见下）；npm 侧既有的 postinstall launcher 行为未改变
- **跨平台**：linux 与 darwin 走同一条解析路径；musl 判据与 postinstall 一致。Windows 无平台包，无回归面
- **不碰**：daemon / worker / 适配器 / IM 层均未涉及；`dist/` 仍不在 `files` 里
- **发版链路**：`scripts/inject-optional-binaries.mjs` 注入 optionalDependencies 的方式不变，本改动只多发一个 4.7KB 的脚本文件

## 验证

**真实安装（不是模拟）**：用改动后的包真实打 tarball（版本与 optionalDependencies 按发版形态注入 3.18.13），分别用三种包管理器全局安装：

```
pnpm add -g <tarball>  →  botmux --version  →  3.18.13   ← 修复前无命令
bun  add -g <tarball>  →  botmux --version  →  3.18.13   ← 修复前无命令（仍显示 Blocked 2 postinstalls，但命令可用）
npm  i   -g <tarball>  →  botmux --version  →  3.18.13   ← 阳性对照，且 ~/.botmux/bin/botmux 仍照常写入
```

**阴性对照**：移走平台子包后 `exit 1` 并打印可操作的错误（`no platform binary found` + 重装命令），复原后恢复 `3.18.13`。

**新增 `test/botmux-launcher.test.ts` 7 例**：两种布局、symlink 入口、argv 透传（含空格与 flag）、缺子包时 exit 1 + stderr、非可执行文件不被选中、`sh -n` 无 bashism。**变异测试 5 例全部转红**：去掉 sibling 候选（2 红）、去掉 nested 候选（2 红）、找不到时 exit 0（2 红）、忘记向上一级取包根（4 红，这是我写这个脚本时真犯过的 bug）、`-x` 改 `-e`（1 红）。

**既有测试的处理**：`test/npm-binary-distribution.test.ts` 原本钉 `manifest.bin` 必须 `undefined`。该断言的立意是「不要声明 tarball 里没有的入口」，而本改动的 `bin` 确实随包发布，所以**改为钉真正的不变量**而非删除：`bin` 目标必须在 `files` 里、必须存在于磁盘、不得指向 `dist/`、且必须是 sh 启动器（不能退回需要 Node 运行时的形态——那正是 3.18.7/3.18.8 的事故形态）。三个变异全部转红：指向 `dist/cli.js`（3 红）、指向未发布文件（1 红）、从 `files` 删掉 launcher（1 红）。

**其它**：`bun run build` 与 `tsc --noEmit` 通过；相关 5 个测试文件 138/138；`sh -n` 与 `dash -n` 均通过。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
