### PR TITLE
fix(traex): 使用未截断首轮内容生成标题

### DIFF
--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -45,6 +45,7 @@ export function piTurnBoundaryExtensionPath(): string | undefined {
 export function buildPiArgs(opts: {
   sessionId: string;
   initialPrompt?: string;
+  nativeSessionTitle?: string;
   model?: string;
   turnBoundaryExtension: string | undefined;
 }): string[] {
@@ -57,6 +58,7 @@ export function buildPiArgs(opts: {
   // only in the argv we build). See pi-turn-boundary-extension.ts.
   if (opts.turnBoundaryExtension) args.push('--extension', opts.turnBoundaryExtension);
   args.push('--session-id', opts.sessionId);
+  if (opts.nativeSessionTitle?.trim()) args.push('--name', opts.nativeSessionTitle.trim());
   if (opts.model?.trim()) args.push('--model', opts.model.trim());
   // Pi's interactive mode processes positional initial messages after TUI
   // startup, avoiding stdin races while keeping the native TUI visible.
@@ -140,10 +142,11 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
     authPaths: ['~/.pi/agent/auth.json'],
     resolvedBin: bin,
 
-    buildArgs({ sessionId, initialPrompt, model }) {
+    buildArgs({ sessionId, initialPrompt, nativeSessionTitle, model }) {
       return buildPiArgs({
         sessionId,
         initialPrompt,
+        nativeSessionTitle,
         model,
         turnBoundaryExtension: piTurnBoundaryExtensionPath(),
       });
@@ -168,6 +171,7 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
       };
     },
 
+    buildSessionRenameCommand: (title) => `/name ${title}`,
     passesInitialPromptViaArgs: true,
 
     async writeInput(pty: PtyHandle, content: string) {

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -138,6 +138,9 @@ export interface CliAdapter {
      *  and a resumeSessionId; adapters whose CLI lacks the primitive ignore it. */
     forkSession?: boolean;
     initialPrompt?: string;
+    /** CLI-native display/session title prepared by botmux. Adapters with a
+     *  launch-time title flag may consume it; others should ignore it. */
+    nativeSessionTitle?: string;
     botName?: string;
     botOpenId?: string;
     /** This bot's larkAppId. Lets injectsSessionContext adapters (genius) resolve

--- a/src/core/session-title.ts
+++ b/src/core/session-title.ts
@@ -10,7 +10,7 @@ export type SessionTitleUpdateResult =
   | { ok: false; error: 'bad_title' };
 
 const BOTMUX_LARK_TITLE_PREFIX = '[BotMux·Lark]';
-const BOTMUX_LARK_TITLE_MAX = 100;
+const BOTMUX_LARK_TITLE_MAX = 200;
 const BOTMUX_LARK_TITLE_PROMPT_MAX = 2_000;
 
 function stripLeadingKnownMentions(

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -10356,7 +10356,7 @@ export function forkWorker(
     );
     if (isFreshNativeSession && !ds.session.nativeSessionTitleUserDefined) {
       ds.session.nativeSessionTitle = buildBotmuxLarkNativeSessionTitle(
-        titlePrompt ? ds.session.title : undefined,
+        titlePrompt,
         bot.botName ? [{ name: bot.botName }] : undefined,
         ds.chatType === 'group' ? ds.session.chatDisplayName : undefined,
       );

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14059,6 +14059,7 @@ async function spawnCli(
     // fork from, so a fresh session is spawned instead.
     forkSession: cfg.forkSession === true && effectiveResume,
     initialPrompt: preparedInitialPrompt,
+    nativeSessionTitle: cfg.nativeSessionTitle,
     botName: cfg.botName,
     botOpenId: cfg.botOpenId,
     larkAppId: cfg.larkAppId,

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1259,6 +1259,21 @@ describe('pi buildArgs', () => {
     expect(adapter.altScreen).toBe(true);
   });
 
+  it('passes botmux native titles through Pi launch-time --name', () => {
+    const args = adapter.buildArgs({
+      sessionId: 'sess-pi',
+      resume: false,
+      nativeSessionTitle: '  [BotMux·Lark] Fix login flow  ',
+      initialPrompt: 'hello pi',
+    });
+    expect(args.slice(2)).toEqual([
+      '--session-id', 'sess-pi',
+      '--name', '[BotMux·Lark] Fix login flow',
+      'hello pi',
+    ]);
+    expect(adapter.buildSessionRenameCommand?.('Renamed in Botmux')).toBe('/name Renamed in Botmux');
+  });
+
   it('loads the turn-boundary extension on every spawn so mid-turn retries are not read as failures', () => {
     // Pi's `stopReason:"error"` is per-REQUEST and its loop retries inside the
     // same turn, so the transcript alone cannot say when a turn ended. The
@@ -2550,7 +2565,7 @@ describe('buildResumeCommand', () => {
 });
 
 describe('native session rename capability', () => {
-  it('is declared only by the verified Codex-family, Claude Code, and Grok adapters', () => {
+  it('is declared only by verified adapters', () => {
     expect(createCodexAdapter('/bin/codex').buildSessionRenameCommand?.('新的标题'))
       .toBe('/rename 新的标题');
     expect(createTraexAdapter('/bin/traex').buildSessionRenameCommand?.('TraeX 标题'))
@@ -2559,6 +2574,8 @@ describe('native session rename capability', () => {
       .toBe('/rename new title');
     expect(createGrokAdapter('/usr/bin/grok').buildSessionRenameCommand?.('新标题'))
       .toBe('/rename 新标题');
+    expect(createPiAdapter('/bin/pi').buildSessionRenameCommand?.('Pi 标题'))
+      .toBe('/name Pi 标题');
 
     expect(createCliAdapterSync('seed', '/bin/true').buildSessionRenameCommand).toBeUndefined();
     expect(createCodexAppAdapter('/bin/codex').buildSessionRenameCommand).toBeUndefined();

--- a/test/codex-hook-trust-worker-wiring.test.ts
+++ b/test/codex-hook-trust-worker-wiring.test.ts
@@ -49,6 +49,10 @@ describe('worker → codex buildArgs wiring (source lock)', () => {
     expect(call).toContain('remoteThreadId,');
   });
 
+  it('passes the prepared native session title into launch args consumers', () => {
+    expect(call).toContain('nativeSessionTitle: cfg.nativeSessionTitle,');
+  });
+
   it('engages RPC (which sets remoteWsUrl/remoteThreadId) BEFORE the spawn that reads them', () => {
     // The module vars are populated inside engageCodexRpc; spawnCli (→ buildArgs)
     // must run after, or the fields would always be undefined at the call site.

--- a/test/pi-initial-prompt.test.ts
+++ b/test/pi-initial-prompt.test.ts
@@ -106,11 +106,16 @@ describe('Pi initial prompt @file delivery', () => {
       const args = createPiAdapter('pi').buildArgs({
         sessionId: 'sess-long-adapter',
         initialPrompt: adapterPrepared.initialPrompt,
+        nativeSessionTitle: '[BotMux·Lark] Long Pi prompt',
       });
       // The turn-boundary extension leads every Pi launch line (asserted in
       // `pi buildArgs`); the @file prompt still lands last.
       expect(args[0]).toBe('--extension');
-      expect(args.slice(2)).toEqual(['--session-id', 'sess-long-adapter', adapterPrepared.initialPrompt]);
+      expect(args.slice(2)).toEqual([
+        '--session-id', 'sess-long-adapter',
+        '--name', '[BotMux·Lark] Long Pi prompt',
+        adapterPrepared.initialPrompt,
+      ]);
 
       expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(PI_INITIAL_PROMPT_ARG_BYTE_LIMIT);
       expect(Buffer.byteLength(adapterPrepared.initialPrompt, 'utf8')).toBeLessThan(prompt.length);

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -3511,20 +3511,21 @@ describe('session.start lifecycle integration', () => {
   it.each([
     ['codex'],
     ['traex'],
-  ] as const)('passes the persisted Lark topic title to a fresh %s worker before its first prompt', (cliId) => {
+  ] as const)('derives a fresh %s native title from the untruncated first prompt', (cliId) => {
     vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId, wrapperCli: undefined }));
+    const titlePrompt = '帮我看下https://example.com/product/alpha/content/videoTag 这个页面的接口你能打开吗？我这访问一直报错，看起来访问到sample.api.service这，像是权限服务报错。';
     const ds = makeDs({
       session: {
         ...makeDs().session,
         cliId,
-        title: '@TestBot 排查这个 TTP logid',
-        nativeSessionTitle: '[BotMux·Lark] 排查这个 TTP logid',
+        title: '@TestBot 帮我看下https://example.com/product/alp',
+        nativeSessionTitle: '[BotMux·Lark] @TestBot 帮我看下https://example.com/product/alp',
       },
     });
     forkWorker(ds, `
 <botmux_routing>routing instructions</botmux_routing>
 <user_message>
-@TestBot 排查这个 TTP logid 的失败原因
+@TestBot ${titlePrompt}
 </user_message>
 `, false);
     const worker = forkMock.mock.results.at(-1)!.value;
@@ -3532,9 +3533,10 @@ describe('session.start lifecycle integration', () => {
 
     expect(init).toEqual(expect.objectContaining({
       type: 'init',
-      nativeSessionTitle: '[BotMux·Lark] 排查这个 TTP logid',
-      nativeSessionTitlePrompt: '排查这个 TTP logid 的失败原因',
+      nativeSessionTitle: `[BotMux·Lark] ${titlePrompt}`,
+      nativeSessionTitlePrompt: titlePrompt,
     }));
+    expect(init.nativeSessionTitle).toContain('/product/alpha/content/videoTag');
   });
 
   it.each([

--- a/test/session-title.test.ts
+++ b/test/session-title.test.ts
@@ -65,10 +65,10 @@ describe('buildBotmuxLarkNativeSessionTitle', () => {
     )).toBe('[BotMux·Lark] 排查这个 logid');
   });
 
-  it('limits the complete title to 100 characters with an ellipsis', () => {
-    const title = buildBotmuxLarkNativeSessionTitle('话'.repeat(200));
+  it('limits the complete title to 200 characters with an ellipsis', () => {
+    const title = buildBotmuxLarkNativeSessionTitle('话'.repeat(300));
 
-    expect(Array.from(title)).toHaveLength(100);
+    expect(Array.from(title)).toHaveLength(200);
     expect(title.startsWith('[BotMux·Lark] ')).toBe(true);
     expect(title.endsWith('…')).toBe(true);
   });


### PR DESCRIPTION
本次 follow-up 修复 TraeX 原生会话标题过早截断的问题。

fresh native title 生成时，不再使用 Botmux session title 作为来源，因为 session title 在创建时会先被截到 50 字符（`src/core/session-create.ts` 的 `TITLE_MAX = 50`）。改为直接使用从首轮 `<user_message>` 提取出的 `titlePrompt` 生成 native title，避免 URL / 关键问题描述在写入 TraeX `/rename` 前已经被截断。

将 Botmux Lark native title 的最终标题上限从 100 字符放宽到 200 字符，保留可读性边界，同时让较长 URL 和关键上下文能完整进入 resume picker。

补充回归测试：模拟 session.title 已被 50 字符截断、首轮 prompt 仍包含完整 URL 的场景，断言 native title 使用未截断 prompt，并覆盖 200 字符上限。

## 同时新增：pi 适配器的原生会话改名能力

除标题来源修复外，本 PR 还给 **pi 适配器**补齐了原生会话名支持——这是**用户可见的行为变化**，单独说明：

- `buildPiArgs` 新增 `--name`（启动期传入 botmux 准备好的 native title）；
- 新增 `buildSessionRenameCommand: (title) => '/name ' + title`（TUI 期）。

两者都对照 pi 真实二进制（v0.84.4）核实过：`--help` 中有 `--name, -n <name>  Set session display name`，TUI 命令表中有 `{name:"name", description:"Set session display name"}`，符合 `buildSessionRenameCommand` 契约要求的「已验证、不得使用猜测的 slash 命令」。

**效果**：pi 会话的 `/rename` 从此前返回 `unsupported`（no-op）变为可用。

**行为边界**（供 reviewer 判断影响面）：

- pi 未被纳入自动标题闸（`supportsBotmuxLarkNativeSessionTitle` 仅 codex/traex，`supportsPostSubmitRenameSessionTitle` 仅 traex），因此**全新 pi 会话启动时不会带 `--name`**；
- `--name` 的唯一供给路径是：botmux 侧 `/rename` → `rename_session` 写入 `lastInitConfig.nativeSessionTitle` → worker 内重启时 `restartCfg` 透传 → `buildArgs`；
- 已知低危项：由于 botmux 不监听 pi 的 `session_info_changed`，若用户先经 botmux `/rename`、随后在 pi TUI 内手动 `/name` 改名，再发生 worker 内重启，启动期 `--name` 会把 botmux 侧标题重新写回。触发窗口较窄，仅影响 pi 原生会话名，不影响 botmux 侧标题。

## Impact

- 影响范围：Botmux 生成的 CLI-native session title，主要改善 TraeX resume picker 展示；另新增 pi 原生改名能力（见上节）。
- Codex / TraeX 共享 `buildBotmuxLarkNativeSessionTitle` 的最终长度上限会从 100 提升到 200。该值恰好等于 `normalizeSessionTitle` 的 `SESSION_TITLE_MAX = 200`，不会被二次裁剪。
- 仍会做单行化、控制字符清理和最大长度限制，不会无限制写入完整首轮消息。
- 不改变 Botmux canonical session title 的 50 字符展示逻辑，只改变写入原生 `/rename` 的 native title 来源和长度上限。
- `nativeSessionTitle` 不参与飞书卡片与 dashboard 渲染，仅在 worker / adapter 侧使用。
