### PR TITLE
fix(plugin): 修复 standalone 插件 PM2 helper 启动

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ import {
 } from './core/session-marker.js';
 import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { ENTRY_SUBCOMMANDS, entryForSubcommand, resolveEntrySpawn } from './core/self-spawn.js';
+import { PM2_EXISTING_CLIENT_SUBCOMMAND, PM2_READONLY_CLIENT_SUBCOMMAND } from './cli/pm2-helper-spawn.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { acceptedDispatchBotAppIds, activeConversationBotOpenIds, buildDispatchCompletionBrief, parseDispatchBotSpec, buildDispatchMessages, buildRepoPrimeText, buildReportContent, eligibleAutoMentionAliases, foldableChatSessionAppIds, offTopicSubBotTopic, resolveReportPlacement, resolveReportRecipient, resolveSendTarget, threadRootForReachability } from './core/dispatch.js';
 import {
@@ -12772,6 +12773,18 @@ if (__entrySubcommand) {
   // loop alive for the daemon; the worker's IPC listener does the same; a
   // core-only bind failure exits from within). Park here so the normal dispatch
   // below never runs. This awaits forever; the imported module owns exit().
+  await new Promise<never>(() => {});
+}
+
+if (command === PM2_READONLY_CLIENT_SUBCOMMAND) {
+  process.argv.splice(2, 1);
+  await import('./cli/pm2-readonly-client.js');
+  await new Promise<never>(() => {});
+}
+
+if (command === PM2_EXISTING_CLIENT_SUBCOMMAND) {
+  process.argv.splice(2, 1);
+  await import('./cli/pm2-existing-client.js');
   await new Promise<never>(() => {});
 }
 

--- a/src/cli/pm2-existing.ts
+++ b/src/cli/pm2-existing.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
 import type { LinuxPm2GodProcess } from '../core/pm2-lifecycle-owner.js';
+import { buildPm2HelperSpawn, PM2_EXISTING_CLIENT_SUBCOMMAND } from './pm2-helper-spawn.js';
 
 const ABSENT_EXIT_CODE = 4;
 
@@ -44,16 +43,19 @@ function mutationFromArgs(args: string[]): ExistingPm2Mutation {
   };
 }
 
-function helperArgs(pkgRoot: string, request: ExistingPm2Request): string[] {
-  const built = join(pkgRoot, 'dist', 'cli', 'pm2-existing-client.js');
+function helperSpawn(pkgRoot: string, request: ExistingPm2Request, nodePath?: string) {
   const payload = JSON.stringify(request);
-  // Source/test execution must not silently select a stale dist helper with an
-  // older request contract. Installed production code runs from dist and uses
-  // the sibling built helper.
-  if (import.meta.url.includes('/dist/cli/pm2-existing.js') && existsSync(built)) {
-    return [built, payload];
-  }
-  return ['--import', 'tsx', join(pkgRoot, 'src', 'cli', 'pm2-existing-client.ts'), payload];
+  return buildPm2HelperSpawn({
+    pkgRoot,
+    nodePath,
+    clientName: 'pm2-existing-client',
+    clientSubcommand: PM2_EXISTING_CLIENT_SUBCOMMAND,
+    clientArgs: [payload],
+    // Source/test execution must not silently select a stale dist helper with an
+    // older request contract. Installed production code runs from dist and uses
+    // the sibling built helper.
+    runningFromDist: import.meta.url.includes('/dist/cli/pm2-existing.js'),
+  });
 }
 
 /** Mutate an attested existing God without PM2's public connect/daemonize path. */
@@ -71,9 +73,10 @@ export function runExistingPm2Command(input: {
     throw new Error(`PM2 God pid ${input.expectedGod.pid} has no process-birth identity`);
   }
   const request = { ...mutationFromArgs(input.args), expectedGod: input.expectedGod };
+  const helper = helperSpawn(input.pkgRoot, request, input.nodePath);
   const result = spawnSync(
-    input.nodePath ?? process.execPath,
-    helperArgs(input.pkgRoot, request),
+    helper.command,
+    helper.args,
     {
       stdio: input.inherit === false ? 'pipe' : 'inherit',
       env: {

--- a/src/cli/pm2-helper-spawn.ts
+++ b/src/cli/pm2-helper-spawn.ts
@@ -1,0 +1,49 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { isStandaloneBinary } from '../core/self-spawn.js';
+
+export const PM2_READONLY_CLIENT_SUBCOMMAND = '__pm2-readonly-client';
+export const PM2_EXISTING_CLIENT_SUBCOMMAND = '__pm2-existing-client';
+
+interface HelperSpawnInput {
+  pkgRoot: string;
+  nodePath?: string;
+  clientName: 'pm2-readonly-client' | 'pm2-existing-client';
+  clientSubcommand: typeof PM2_READONLY_CLIENT_SUBCOMMAND | typeof PM2_EXISTING_CLIENT_SUBCOMMAND;
+  clientArgs: readonly string[];
+  runningFromDist: boolean;
+  standalone?: boolean;
+  bunRuntime?: boolean;
+}
+
+export interface HelperSpawn {
+  command: string;
+  args: string[];
+}
+
+function isBunRuntime(): boolean {
+  // @ts-ignore -- Bun global is absent under Node/tsc; guard at runtime.
+  return typeof Bun !== 'undefined';
+}
+
+export function buildPm2HelperSpawn(input: HelperSpawnInput): HelperSpawn {
+  const standalone = input.standalone ?? isStandaloneBinary();
+  if (standalone) {
+    return {
+      command: process.execPath,
+      args: [input.clientSubcommand, ...input.clientArgs],
+    };
+  }
+
+  const command = input.nodePath ?? process.execPath;
+  const sourceRunsTypescriptNatively = input.bunRuntime ?? (!input.nodePath && isBunRuntime());
+  const built = join(input.pkgRoot, 'dist', 'cli', `${input.clientName}.js`);
+  if (input.runningFromDist && existsSync(built)) {
+    return { command, args: [built, ...input.clientArgs] };
+  }
+
+  const source = join(input.pkgRoot, 'src', 'cli', `${input.clientName}.ts`);
+  return sourceRunsTypescriptNatively
+    ? { command, args: [source, ...input.clientArgs] }
+    : { command, args: ['--import', 'tsx', source, ...input.clientArgs] };
+}

--- a/src/cli/pm2-readonly.ts
+++ b/src/cli/pm2-readonly.ts
@@ -1,16 +1,18 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
 import type { LinuxPm2GodProcess } from '../core/pm2-lifecycle-owner.js';
+import { buildPm2HelperSpawn, PM2_READONLY_CLIENT_SUBCOMMAND } from './pm2-helper-spawn.js';
 
 const ABSENT_EXIT_CODE = 3;
 
-function helperArgs(pkgRoot: string, modeArgs: string[]): string[] {
-  const built = join(pkgRoot, 'dist', 'cli', 'pm2-readonly-client.js');
-  if (import.meta.url.includes('/dist/cli/pm2-readonly.js') && existsSync(built)) {
-    return [built, ...modeArgs];
-  }
-  return ['--import', 'tsx', join(pkgRoot, 'src', 'cli', 'pm2-readonly-client.ts'), ...modeArgs];
+function helperSpawn(pkgRoot: string, modeArgs: string[], nodePath?: string) {
+  return buildPm2HelperSpawn({
+    pkgRoot,
+    nodePath,
+    clientName: 'pm2-readonly-client',
+    clientSubcommand: PM2_READONLY_CLIENT_SUBCOMMAND,
+    clientArgs: modeArgs,
+    runningFromDist: import.meta.url.includes('/dist/cli/pm2-readonly.js'),
+  });
 }
 
 function readonlyEnv(
@@ -37,7 +39,8 @@ export function captureReadonlyPm2Jlist(input: {
   env?: NodeJS.ProcessEnv;
   expectedGod?: LinuxPm2GodProcess;
 }): string {
-  const result = spawnSync(input.nodePath ?? process.execPath, helperArgs(input.pkgRoot, ['jlist']), {
+  const helper = helperSpawn(input.pkgRoot, ['jlist'], input.nodePath);
+  const result = spawnSync(helper.command, helper.args, {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     env: readonlyEnv(input.home, input.expectedGod, { ...process.env, ...(input.env ?? {}) }),
@@ -59,7 +62,8 @@ export function printReadonlyPm2Status(input: {
   nodePath?: string;
   expectedGod?: LinuxPm2GodProcess;
 }): void {
-  const result = spawnSync(input.nodePath ?? process.execPath, helperArgs(input.pkgRoot, ['status']), {
+  const helper = helperSpawn(input.pkgRoot, ['status'], input.nodePath);
+  const result = spawnSync(helper.command, helper.args, {
     stdio: 'inherit',
     env: readonlyEnv(input.home, input.expectedGod),
     timeout: 15_000,
@@ -77,9 +81,10 @@ export function spawnReadonlyPm2Logs(input: {
   nodePath?: string;
   expectedGod?: LinuxPm2GodProcess;
 }): ChildProcess {
+  const helper = helperSpawn(input.pkgRoot, ['logs', input.target, input.lines], input.nodePath);
   return spawn(
-    input.nodePath ?? process.execPath,
-    helperArgs(input.pkgRoot, ['logs', input.target, input.lines]),
+    helper.command,
+    helper.args,
     { stdio: 'inherit', env: readonlyEnv(input.home, input.expectedGod) },
   );
 }

--- a/test/pm2-helper-spawn.test.ts
+++ b/test/pm2-helper-spawn.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildPm2HelperSpawn,
+  PM2_EXISTING_CLIENT_SUBCOMMAND,
+  PM2_READONLY_CLIENT_SUBCOMMAND,
+} from '../src/cli/pm2-helper-spawn.js';
+
+describe('PM2 helper spawn resolution', () => {
+  let root = '';
+
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = '';
+  });
+
+  function tmpRoot(): string {
+    root = mkdtempSync(join(tmpdir(), 'botmux-pm2-helper-'));
+    return root;
+  }
+
+  it('re-enters the current executable for readonly helpers in standalone builds', () => {
+    const spawn = buildPm2HelperSpawn({
+      pkgRoot: '/',
+      clientName: 'pm2-readonly-client',
+      clientSubcommand: PM2_READONLY_CLIENT_SUBCOMMAND,
+      clientArgs: ['jlist'],
+      runningFromDist: false,
+      standalone: true,
+    });
+
+    expect(spawn).toEqual({
+      command: process.execPath,
+      args: [PM2_READONLY_CLIENT_SUBCOMMAND, 'jlist'],
+    });
+    expect(spawn.args.join(' ')).not.toContain('/src/cli/pm2-readonly-client.ts');
+  });
+
+  it('re-enters the current executable for existing-daemon helpers in standalone builds', () => {
+    const spawn = buildPm2HelperSpawn({
+      pkgRoot: '/',
+      clientName: 'pm2-existing-client',
+      clientSubcommand: PM2_EXISTING_CLIENT_SUBCOMMAND,
+      clientArgs: ['{"operation":"kill"}'],
+      runningFromDist: false,
+      standalone: true,
+    });
+
+    expect(spawn).toEqual({
+      command: process.execPath,
+      args: [PM2_EXISTING_CLIENT_SUBCOMMAND, '{"operation":"kill"}'],
+    });
+    expect(spawn.args.join(' ')).not.toContain('/src/cli/pm2-existing-client.ts');
+  });
+
+  it('keeps using the built helper for Node dist installs', () => {
+    const pkgRoot = tmpRoot();
+    const distCli = join(pkgRoot, 'dist', 'cli');
+    mkdirSync(distCli, { recursive: true });
+    writeFileSync(join(distCli, 'pm2-readonly-client.js'), '');
+
+    const spawn = buildPm2HelperSpawn({
+      pkgRoot,
+      nodePath: '/usr/bin/node',
+      clientName: 'pm2-readonly-client',
+      clientSubcommand: PM2_READONLY_CLIENT_SUBCOMMAND,
+      clientArgs: ['status'],
+      runningFromDist: true,
+      standalone: false,
+    });
+
+    expect(spawn).toEqual({
+      command: '/usr/bin/node',
+      args: [join(distCli, 'pm2-readonly-client.js'), 'status'],
+    });
+  });
+
+  it('keeps source/test execution on the TypeScript helper', () => {
+    const pkgRoot = tmpRoot();
+    const spawn = buildPm2HelperSpawn({
+      pkgRoot,
+      nodePath: '/usr/bin/node',
+      clientName: 'pm2-existing-client',
+      clientSubcommand: PM2_EXISTING_CLIENT_SUBCOMMAND,
+      clientArgs: ['{"operation":"kill"}'],
+      runningFromDist: false,
+      standalone: false,
+      bunRuntime: false,
+    });
+
+    expect(spawn).toEqual({
+      command: '/usr/bin/node',
+      args: [
+        '--import',
+        'tsx',
+        join(pkgRoot, 'src', 'cli', 'pm2-existing-client.ts'),
+        '{"operation":"kill"}',
+      ],
+    });
+  });
+});

--- a/test/pm2-helper-spawn.test.ts
+++ b/test/pm2-helper-spawn.test.ts
@@ -100,4 +100,24 @@ describe('PM2 helper spawn resolution', () => {
       ],
     });
   });
+
+  it('runs TypeScript helpers directly under Bun source execution', () => {
+    const pkgRoot = tmpRoot();
+    const spawn = buildPm2HelperSpawn({
+      pkgRoot,
+      clientName: 'pm2-readonly-client',
+      clientSubcommand: PM2_READONLY_CLIENT_SUBCOMMAND,
+      clientArgs: ['jlist'],
+      runningFromDist: false,
+      standalone: false,
+      bunRuntime: true,
+    });
+
+    expect(spawn).toEqual({
+      command: process.execPath,
+      args: [join(pkgRoot, 'src', 'cli', 'pm2-readonly-client.ts'), 'jlist'],
+    });
+    expect(spawn.args).not.toContain('--import');
+    expect(spawn.args).not.toContain('tsx');
+  });
 });


### PR DESCRIPTION
## 改动说明

- 修复 standalone 二进制场景下插件 PM2 helper 的启动入口解析。
- 抽出 PM2 helper spawn 逻辑，复用到 existing / readonly 相关路径。
- 增加 PM2 helper spawn 行为测试，覆盖源码态与 standalone 态入口差异。

## 影响面

- 影响 CLI 插件启动与 PM2 helper 相关路径。
- 涉及 standalone binary 与源码运行态的入口解析，不改动 daemon 主流程和其他 CLI adapter 行为。

## 验证

- bun --version：1.4.0
- bun test test/pm2-helper-spawn.test.ts：4 pass
- bun run build：通过
- node -e "console.log(require('electron'))"：可解析到 node_modules/electron/dist/electron
- node-pty native 模块存在：node_modules/node-pty/build/Release/pty.node