### PR TITLE
fix(web-terminal): 手机底栏改「上屏」文案并支持长按连续删除

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17304,10 +17304,15 @@ body.touch.has-token #terminal .xterm{
   padding-bottom:calc(var(--mobile-bar-h,0px) + var(--keyboard-inset,0px))}
 #mobile-bar-keys{display:flex;gap:6px;margin-bottom:5px;overflow-x:auto;scrollbar-width:none;-webkit-overflow-scrolling:touch}
 #mobile-bar-keys::-webkit-scrollbar{display:none}
+/* A long press on a bar key must repeat that key (see the repeat handler below),
+   never raise the iOS selection handles / callout menu. user-select alone is not
+   enough in a WKWebView — the -webkit- pair is what suppresses both, same as the
+   xterm content area above. */
 #mobile-bar-keys button{
   flex:none;min-width:44px;height:34px;padding:0 12px;border:1px solid #2a2b3d;border-radius:8px;
   background:#1c1c24;color:#9d9fb0;font:500 13px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
-  touch-action:manipulation;-webkit-tap-highlight-color:transparent;user-select:none;white-space:nowrap}
+  touch-action:manipulation;-webkit-tap-highlight-color:transparent;
+  -webkit-user-select:none;user-select:none;-webkit-touch-callout:none;white-space:nowrap}
 #mobile-bar-keys button:active{background:#3a3b4d;color:#e4e6f0}
 #mobile-bar-row{display:flex;align-items:flex-end;gap:8px}
 #mobile-input-wrap{flex:1;position:relative;min-width:0;display:flex}
@@ -17320,7 +17325,8 @@ body.touch.has-token #terminal .xterm{
 #mobile-bar-row button{
   flex:none;width:42px;min-height:42px;height:42px;padding:0;border:1px solid #2a2b3d;border-radius:8px;
   background:#1c1c24;color:#9d9fb0;font:500 15px/1 -apple-system,BlinkMacSystemFont,sans-serif;
-  touch-action:manipulation;-webkit-tap-highlight-color:transparent;user-select:none}
+  touch-action:manipulation;-webkit-tap-highlight-color:transparent;
+  -webkit-user-select:none;user-select:none;-webkit-touch-callout:none}
 #mobile-bar-row button:active{background:#3a3b4d;color:#e4e6f0}
 #mobile-input-bar button:disabled,#mobile-input-bar textarea:disabled{opacity:.45;cursor:not-allowed}
 #mobile-send{min-width:52px;border-radius:8px;font:600 13px/1 -apple-system,BlinkMacSystemFont,sans-serif;background:#7aa2f7;color:#1a1b26;border-color:#7aa2f7}
@@ -17381,7 +17387,7 @@ ${loginUrl ? `<a id="login-banner" href="${loginUrl}" target="_top" rel="noopene
       <textarea id="mobile-input" rows="1" inputmode="text" enterkeyhint="send" placeholder="输入命令…" autocomplete="off" autocapitalize="off" spellcheck="false" aria-label="终端输入"></textarea>
       <span id="mobile-live-hint" aria-hidden="true">实时输入 · 点击显示键盘</span>
     </div>
-    <button id="mobile-send" type="submit">发送</button>
+    <button id="mobile-send" type="submit">上屏</button>
   </div>
 </form>
 <div id="status" class="err">connecting...</div>
@@ -18385,9 +18391,17 @@ if(isTouch&&hasToken){(function(){
     if(payload&&!sendInput(payload))return false;
     mirror.sent=mirror.held='';ta.value='';resizeTa();return true;}
 
+  // Buffer mode types the text into the CLI's own input box WITHOUT submitting
+  // (the payload ends in a newline, which a TUI treats as "insert", not "run"),
+  // so the button is labelled 上屏 there and the user presses the Enter key once
+  // the text looks right. Live mode's button really does submit (it appends a
+  // carriage return), so it keeps 发送 — same reason the mode button spells out
+  // the extra Enter step.
   function setMode(m){mode=m;bar.setAttribute('data-mode',m);
     modeBtn.textContent=m===LIVE?'实时':'缓冲';
-    modeBtn.setAttribute('aria-label',m===LIVE?'当前为实时输入，点击切换为缓冲':'当前为缓冲输入，点击切换为实时');}
+    sendBtn.textContent=m===LIVE?'发送':'上屏';
+    sendBtn.setAttribute('aria-label',m===LIVE?'发送并执行':'把文本送上终端，随后按 Enter 执行');
+    modeBtn.setAttribute('aria-label',m===LIVE?'当前为实时输入，点击切换为缓冲':'当前为缓冲输入（上屏后需按 Enter 提交），点击切换为实时');}
   var measuredBarHeight=-1;
   function measureBar(){
     var rect=bar.getBoundingClientRect?bar.getBoundingClientRect():null;
@@ -18415,6 +18429,9 @@ if(isTouch&&hasToken){(function(){
 
   // shortcut keys row
   var sk={ctrlc:'\\x03',esc:'\\x1b',tab:'\\t',left:'\\x1b[D',right:'\\x1b[C',up:'\\x1b[A',down:'\\x1b[B',bs:'\\x7f',enter:'\\r',stab:'\\x1b[Z'};
+  // Keys whose effect is safe to apply repeatedly while the finger stays down.
+  var REPEATABLE={bs:1,left:1,right:1,up:1,down:1};
+  var REPEAT_DELAY=450,REPEAT_EVERY=60;
   var keyBtns=document.querySelectorAll('#mobile-bar-keys button');
   for(var i=0;i<keyBtns.length;i++){(function(btn){
     btn.addEventListener('click',function(){btn.blur();
@@ -18428,7 +18445,37 @@ if(isTouch&&hasToken){(function(){
           navigator.clipboard.readText().then(function(t){if(t)sendInput(t);}).catch(function(){showKeyboard();});
         }else{showKeyboard();}
         return;}
-      if(mode===LIVE)sendLiveKey(sk[act]);else sendInput(sk[act]);});})(keyBtns[i]);}
+      if(mode===LIVE)sendLiveKey(sk[act]);else sendInput(sk[act]);});
+    // Hold-to-repeat, but ONLY for keys that are safe to apply N times: cursor
+    // moves and backspace. Enter/Ctrl-C/Esc/Tab/Shift-Tab/Paste are one-shot —
+    // repeating Enter would fire the command several times, repeating Ctrl-C
+    // would spray interrupts. The first hit still comes from the click handler
+    // above (so a plain tap keeps working, mouse included); this only adds the
+    // follow-up ticks after the finger has stayed down past REPEAT_DELAY.
+    if(REPEATABLE[btn.getAttribute('data-sk')]){
+      var holdT=null,holdIv=null;
+      var stopHold=function(){if(holdT)clearTimeout(holdT);if(holdIv)clearInterval(holdIv);holdT=holdIv=null;};
+      btn.addEventListener('pointerdown',function(){
+        stopHold();
+        holdT=setTimeout(function(){
+          holdIv=setInterval(function(){
+            // Stop as soon as this key can no longer be pressed — either the bar
+            // was disabled (write permission lost / socket dropped mid-hold) or
+            // the send itself was refused — instead of spinning until release.
+            if(btn.disabled){stopHold();return;}
+            var seq=sk[btn.getAttribute('data-sk')];
+            var ok=mode===LIVE?sendLiveKey(seq):sendInput(seq);
+            if(!ok)stopHold();
+          },REPEAT_EVERY);
+        },REPEAT_DELAY);
+      });
+      // pointerup fires on release, pointercancel when the gesture is stolen
+      // (scroll/system), pointerleave when the finger slides off the button.
+      ['pointerup','pointercancel','pointerleave'].forEach(function(ev){
+        btn.addEventListener(ev,stopHold);
+      });
+    }
+  })(keyBtns[i]);}
 
   modeBtn.addEventListener('click',function(){modeBtn.blur();
     // switching away from live flushes pending held text

--- a/test/web-terminal-mobile-input.test.ts
+++ b/test/web-terminal-mobile-input.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 const workerSource = (): string => readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
 
@@ -19,6 +19,7 @@ type Listener = (event: Record<string, unknown>) => void;
 
 class FakeElement {
   value = '';
+  textContent = '';
   disabled = false;
   scrollHeight = 38;
   offsetHeight = 91;
@@ -268,5 +269,107 @@ describe('手机 Web 终端输入栏', () => {
     backspace?.dispatch('click');
     down?.dispatch('click');
     expect(page.sentInputs()).toEqual(['\x1b[A', '\x7f', '\x1b[B']);
+  });
+
+  it('缓冲模式的按钮叫「上屏」并说明还要按 Enter，实时模式才叫「发送」', () => {
+    const source = workerSource();
+    // The static markup must already say 上屏 so there is no flash of the wrong
+    // word before setMode() runs on boot.
+    expect(source).toMatch(/<button id="mobile-send" type="submit">上屏<\/button>/);
+
+    const page = bootMobileInput({ wsHasWrite: true });
+    const send = page.controls.find(control => control.id === 'mobile-send');
+    expect(send?.textContent).toBe('上屏');
+    expect(send?.getAttribute('aria-label')).toContain('Enter');
+    const mode = page.controls.find(control => control.id === 'mobile-mode');
+    expect(mode?.getAttribute('aria-label')).toContain('Enter');
+
+    // Switching to live mode makes the button a real submit again.
+    mode?.dispatch('click');
+    expect(send?.textContent).toBe('发送');
+    expect(mode?.textContent).toBe('实时');
+    mode?.dispatch('click');
+    expect(send?.textContent).toBe('上屏');
+  });
+
+  it('长按 ⌫ 连续删除，松手即停，且 Enter/Ctrl+C 这类一次性键从不重复', () => {
+    vi.useFakeTimers();
+    try {
+      const page = bootMobileInput({ wsHasWrite: true });
+      const backspace = page.shortcut('bs');
+      expect(backspace).toBeDefined();
+
+      // A press shorter than the repeat delay must not add any repeat tick.
+      backspace?.dispatch('pointerdown');
+      vi.advanceTimersByTime(200);
+      backspace?.dispatch('pointerup');
+      vi.advanceTimersByTime(600);
+      expect(page.sentInputs()).toEqual([]);
+
+      // Holding past the delay repeats at a steady cadence…
+      backspace?.dispatch('pointerdown');
+      vi.advanceTimersByTime(450 + 60 * 5);
+      const whileHeld = page.sentInputs().length;
+      expect(whileHeld).toBe(5);
+      expect(page.sentInputs().every(sequence => sequence === '\x7f')).toBe(true);
+
+      // …and releasing stops it immediately (no ticks after pointerup).
+      backspace?.dispatch('pointerup');
+      vi.advanceTimersByTime(600);
+      expect(page.sentInputs().length).toBe(whileHeld);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('一次性键长按不重复，手指移开或断线都会停下重复', () => {
+    vi.useFakeTimers();
+    try {
+      // Repeating Enter would run the command several times; Ctrl+C would spray
+      // interrupts. Neither may gain a repeat handler.
+      const oneShot = bootMobileInput({ wsHasWrite: true });
+      for (const action of ['enter', 'ctrlc', 'esc', 'tab', 'stab', 'paste']) {
+        oneShot.shortcut(action)?.dispatch('pointerdown');
+        vi.advanceTimersByTime(450 + 60 * 10);
+        oneShot.shortcut(action)?.dispatch('pointerup');
+      }
+      expect(oneShot.sentInputs()).toEqual([]);
+
+      // Sliding the finger off the key stops the repeat too.
+      const slide = bootMobileInput({ wsHasWrite: true });
+      slide.shortcut('left')?.dispatch('pointerdown');
+      vi.advanceTimersByTime(450 + 60 * 3);
+      const beforeLeave = slide.sentInputs().length;
+      expect(beforeLeave).toBe(3);
+      slide.shortcut('left')?.dispatch('pointerleave');
+      vi.advanceTimersByTime(600);
+      expect(slide.sentInputs().length).toBe(beforeLeave);
+
+      // A socket that stops accepting input mid-hold must not spin forever.
+      const dropped = bootMobileInput({ wsHasWrite: true });
+      dropped.shortcut('bs')?.dispatch('pointerdown');
+      vi.advanceTimersByTime(450 + 60 * 2);
+      const beforeDrop = dropped.sentInputs().length;
+      expect(beforeDrop).toBe(2);
+      dropped.setWriteState?.(null);
+      vi.advanceTimersByTime(600);
+      expect(dropped.sentInputs().length).toBe(beforeDrop);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('底栏按钮抑制 iOS 长按选中与 callout，避免长按删除时弹出选择气泡', () => {
+    const source = workerSource();
+    // `user-select` alone leaves the WKWebView selection handles / callout menu
+    // on a long press — the `-webkit-` pair is what suppresses both.
+    for (const selector of ['#mobile-bar-keys button', '#mobile-bar-row button']) {
+      const start = source.indexOf(`${selector}{`);
+      expect(start, `${selector} 规则缺失`).toBeGreaterThan(-1);
+      const rule = source.slice(start, source.indexOf('}', start));
+      expect(rule, selector).toContain('-webkit-user-select:none');
+      expect(rule, selector).toContain('user-select:none');
+      expect(rule, selector).toContain('-webkit-touch-callout:none');
+    }
   });
 });


### PR DESCRIPTION
## 背景

`#884` 合入后在手机飞书里实测发现底栏三处体验问题：

1. **缓冲模式的「发送」按钮名不副实**。它发出的 payload 以换行结尾，而 TUI 把换行当「插入」不当「执行」，所以文本只是**上屏进 CLI 的输入框、并不提交**。屏幕上看不出变化，用户会以为「还在缓冲，不知道要等多久才上屏」。
2. **长按 ⌫ 不能连续删除**，只能一次一下，手机上删长命令很痛苦。
3. **长按底栏按钮会弹出 iOS 的选中手柄／callout 菜单**，长按删除因此被打断。

关于第 1 条：经确认这个两步语义（先上屏 → 检查一眼 → 再按 Enter 执行）**本身是想要的**——手机上打长命令，能先看一眼再回车是优点。所以不改行为，只把文案改准。

## 改动

### 1. 文案：缓冲模式叫「上屏」，实时模式仍叫「发送」

`setMode()` 里让按钮文案随模式切换，并在两个按钮的 `aria-label` 中写明「上屏后需按 Enter 提交」。静态 HTML 也一并改成「上屏」，避免启动瞬间闪现错误文案。实时模式的按钮确实会追加回车提交，所以保留「发送」。

### 2. 长按连续删除

按住超过 450ms 后以 60ms 的节奏重复，**只对幂等键开放**：⌫ / ← / → / ↑ / ↓。

`Enter`、`Ctrl+C`、`Esc`、`Tab`、`Shift+Tab`、`Paste` **一律不重复** —— 重复回车会把命令连发多次，重复 Ctrl+C 会连发中断信号。

停止条件覆盖：松手（`pointerup`）、手指滑出按钮（`pointerleave`）、手势被系统接走（`pointercancel`），以及**按住期间掉线或失去写权限**（按钮被置灰或 `sendInput` 被拒时立刻停，不空转）。首次触发仍走原来的 `click` 处理，所以普通点按（含桌面鼠标）行为完全不变。

### 3. 抑制 iOS 长按选中／callout

底栏按钮原先只写了 `user-select:none`，缺 `-webkit-user-select` 与 `-webkit-touch-callout`。同一文件里 xterm 内容区**早已用这一对属性解决过同样的问题**（那里的注释也写明长按会触发 native selection + callout），这里补齐。

## 影响范围

只改 `worker.ts` 中 `getTerminalHtml` 生成的手机底栏（CSS + 该段浏览器脚本），**仅在触屏且可写的会话下渲染**。不涉及 v3 / dashboard / projection；桌面端、只读会话均不受影响（只读会话本就没有这条底栏）。

## 验证

- `bun run build` 通过
- 相关 8 个测试文件 **181/181 通过**（含新增 4 条用例）
- **变异测试确认新断言有牙**——以下四种改动分别都会让对应用例失败：
  - 把 `Enter`/`Ctrl+C` 加进可重复集合 → 断言收到 20 次 `\r`，失败
  - 去掉 `pointerleave`/`pointercancel` 的停止逻辑 → 失败
  - 把按钮文案写死成「发送」 → 失败
  - 删掉 `-webkit-touch-callout` → 失败
- **真实渲染验证**（用真实 `getTerminalHtml` 生成的页面 + Chromium 390×844 触屏上下文）：
  - 页面无 JS 错误；按钮显示「上屏」，切到实时后显示「发送」
  - 按住 ⌫ 1.2s 发出 **12 次**退格，实测间隔稳定 60ms；松手立即停止
  - 单击每个键仍只发 **1 次**（新增 pointer 处理没有造成重复触发）
  - `#884` 的输入条让位几何未受影响：rows 53、xterm 渲染区底边比底栏顶边**高 8px**、底行命中终端而非底栏

开发过程中新增的用例还抓到了我自己的一个缺陷：按住期间失去写权限时重复没有停下，已在本 PR 内修掉（改为同时检查按钮的 `disabled` 状态）。

## ⚠️ 需要真机确认的一项

第 3 条依赖 `-webkit-touch-callout`，这是 **Safari / iOS WKWebView 专有属性**，本机 Chromium 不支持（`CSS.supports('-webkit-touch-callout','none')` 返回 `false`，加不加补丁 computed 值完全一样）。因此**这一条无法在 headless 环境验证**，需要在 iOS 飞书 webview 里实机确认长按 ⌫ 不再弹出选择气泡。另两条已在上面的真实渲染验证中覆盖。

## 截图

底栏 UI 与 `#884` 一致，仅右侧按钮文案在缓冲模式下由「发送」变为「上屏」；长按与选中抑制属交互行为，需真机录屏体现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
