### PR TITLE
feat(worker,card): Claude 自动降级模型时在会话卡片上提示

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1788,6 +1788,7 @@ export function persistStreamCardState(ds: DaemonSession): void {
     s.currentTurnTitle === ds.currentTurnTitle &&
     sameUsageLimit(s.usageLimit, ds.usageLimit) &&
     s.modelFallback?.uuid === ds.modelFallback?.uuid &&
+    s.modelFallback?.claudeSessionId === ds.modelFallback?.claudeSessionId &&
     s.lastUserPrompt === ds.lastUserPrompt &&
     s.lastCliInput === ds.lastCliInput &&
     JSON.stringify(s.lastCodexAppInput ?? null) === JSON.stringify(ds.lastCodexAppInput ?? null) &&

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1787,6 +1787,7 @@ export function persistStreamCardState(ds: DaemonSession): void {
     s.currentImageKey === ds.currentImageKey &&
     s.currentTurnTitle === ds.currentTurnTitle &&
     sameUsageLimit(s.usageLimit, ds.usageLimit) &&
+    s.modelFallback?.uuid === ds.modelFallback?.uuid &&
     s.lastUserPrompt === ds.lastUserPrompt &&
     s.lastCliInput === ds.lastCliInput &&
     JSON.stringify(s.lastCodexAppInput ?? null) === JSON.stringify(ds.lastCodexAppInput ?? null) &&
@@ -1800,6 +1801,7 @@ export function persistStreamCardState(ds: DaemonSession): void {
   s.currentImageKey = ds.currentImageKey;
   s.currentTurnTitle = ds.currentTurnTitle;
   s.usageLimit = ds.usageLimit;
+  s.modelFallback = ds.modelFallback;
   s.lastUserPrompt = ds.lastUserPrompt;
   s.lastCliInput = ds.lastCliInput;
   if (ds.lastCodexAppInput) s.lastCodexAppInput = ds.lastCodexAppInput;
@@ -2212,6 +2214,7 @@ export async function restoreActiveSessions(
           currentImageKey: session.currentImageKey,
           currentTurnTitle: session.currentTurnTitle,
           usageLimit: session.usageLimit,
+          modelFallback: session.modelFallback,
           lastUserPrompt: session.lastUserPrompt,
           lastCliInput: session.lastCliInput,
           lastCodexAppInput: session.lastCodexAppInput,
@@ -2417,6 +2420,7 @@ export async function restoreActiveSessions(
       currentImageKey: session.currentImageKey,
       currentTurnTitle: session.currentTurnTitle,
       usageLimit: session.usageLimit,
+      modelFallback: session.modelFallback,
       lastUserPrompt: session.lastUserPrompt,
       lastCliInput: session.lastCliInput,
       lastCodexAppInput: session.lastCodexAppInput,
@@ -3119,6 +3123,7 @@ export async function resumeSession(
     currentImageKey: session.currentImageKey,
     currentTurnTitle: session.currentTurnTitle,
     usageLimit: session.usageLimit,
+    modelFallback: session.modelFallback,
     lastUserPrompt: session.lastUserPrompt,
     lastCliInput: session.lastCliInput,
     lastCodexAppInput: session.lastCodexAppInput,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -390,9 +390,11 @@ export interface DaemonSession {
   activeReasoningEffort?: string;
   /** Claude model fallback still in effect, reported by the worker from the
    *  session transcript. Mirrored to Session.modelFallback so a card rebuilt
-   *  without a live worker keeps the notice; cleared with the other
-   *  worker-generation runtime facts on respawn and re-seeded by the new
-   *  worker's bridge start. */
+   *  without a live worker keeps the notice. Unlike the other runtime facts it
+   *  is NOT owned by a worker generation and survives every respawn: it is
+   *  bound to a Claude session id instead, and only positive evidence moves it
+   *  — a reply served by a different model, a newer switch record, a message
+   *  from another Claude session, or a role switch away from claude-code. */
   modelFallback?: ModelFallbackState;
   /** Runtime change arrived while a streaming-card POST was in flight. */
   pendingActiveRuntimeCardRefresh?: boolean;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -8,6 +8,7 @@ import type {
   DaemonToWorker,
   LarkAttachment,
   LarkMention,
+  ModelFallbackState,
   DisplayMode,
   StreamStatus,
   VcMeetingImTurnOrigin,
@@ -387,6 +388,12 @@ export interface DaemonSession {
   activeModel?: string;
   /** Latest reasoning effort reported by the live executor. */
   activeReasoningEffort?: string;
+  /** Claude model fallback still in effect, reported by the worker from the
+   *  session transcript. Mirrored to Session.modelFallback so a card rebuilt
+   *  without a live worker keeps the notice; cleared with the other
+   *  worker-generation runtime facts on respawn and re-seeded by the new
+   *  worker's bridge start. */
+  modelFallback?: ModelFallbackState;
   /** Runtime change arrived while a streaming-card POST was in flight. */
   pendingActiveRuntimeCardRefresh?: boolean;
   /** Queued suspend: the request arrived while the session was producing

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -32,7 +32,7 @@ import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, pickTurnRe
 import { updateMessage, deleteMessage, pinMessage, unpinMessage, listChatPins, sendEphemeralCard, sendUserMessage, addReaction, removeReaction, getMessageChatId, MessageWithdrawnError, type LarkPinRecord } from '../im/lark/client.js';
 import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildTuiPromptFailedCard, buildRelayedFrozenCard, buildTurnFailedCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { codexServiceTierBadge } from '../services/codex-service-tier.js';
-import { normalizeClaudeModelId } from '../services/claude-transcript.js';
+import { isFableModelId, normalizeClaudeModelId } from '../services/claude-transcript.js';
 import { cliModelSupportsReasoningEffort, isConfigurableReasoningCliId } from '../services/codex-reasoning-effort.js';
 import { RPC_CAPABLE_CLIS } from '../codex-rpc-lifecycle.js';
 import { loadFrozenCards, saveFrozenCards } from '../services/frozen-card-store.js';
@@ -398,10 +398,14 @@ export function getDaemonStreamingCardUsageSnapshot(
  *   b) a switch record with a NEW uuid replaces whatever we held (and is
  *      stamped with the message's Claude session); `fallback: null` — the
  *      newest session-scoped record is NOT a live Fable fallback — clears.
- *   c) a serving model that disagrees with the held `fallbackModel` clears it —
- *      that "Claude answered on a different model" is the ONLY evidence of a
- *      switch back. Ordering matters: a `servingModel` arriving in the same
- *      message as a `fallback` was observed AFTER it, so (c) runs after (b).
+ *   c) a serving model that is a FABLE model clears it — the notice is "this
+ *      session fell OFF Fable", and the only evidence it is over is Claude
+ *      being observed back on a Fable model. A drift onto a THIRD non-Fable
+ *      model (opus-5 → opus-4-8 across a resume, with no new switch record) is
+ *      still "not on Fable": clearing there would hide the very condition the
+ *      notice exists for. Ordering matters: a `servingModel` arriving in the
+ *      same message as a `fallback` was observed AFTER it, so (c) runs after
+ *      (b).
  *   d) `changed` compares the resulting STATE with the one we came in with, so
  *      a message that runs both rules and lands back where it started costs no
  *      write and no card patch.
@@ -430,7 +434,13 @@ export function mergeModelFallbackObservation(
   }
   if (msg.servingModel && next) {
     const serving = normalizeClaudeModelId(msg.servingModel);
-    if (serving && serving !== normalizeClaudeModelId(next.fallbackModel)) {
+    // Back ON a Fable model is the only switch-back evidence. Answering on a
+    // model that merely differs from the fallback one is not: a silent drift
+    // onto a third non-Fable model (observed in a real transcript — opus-5 →
+    // opus-4-8 across a resume, no new switch record) also "differs", and
+    // clearing on it retires the notice while the session is still off Fable.
+    // Same Fable predicate the parse layer uses to scope the notice.
+    if (serving && isFableModelId(serving)) {
       next = undefined;
     }
   }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -32,6 +32,7 @@ import { fallbackTurnId, frozenReplyContextForTurn, isSubstituteTurn, pickTurnRe
 import { updateMessage, deleteMessage, pinMessage, unpinMessage, listChatPins, sendEphemeralCard, sendUserMessage, addReaction, removeReaction, getMessageChatId, MessageWithdrawnError, type LarkPinRecord } from '../im/lark/client.js';
 import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildTuiPromptFailedCard, buildRelayedFrozenCard, buildTurnFailedCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { codexServiceTierBadge } from '../services/codex-service-tier.js';
+import { normalizeClaudeModelId } from '../services/claude-transcript.js';
 import { cliModelSupportsReasoningEffort, isConfigurableReasoningCliId } from '../services/codex-reasoning-effort.js';
 import { RPC_CAPABLE_CLIS } from '../codex-rpc-lifecycle.js';
 import { loadFrozenCards, saveFrozenCards } from '../services/frozen-card-store.js';
@@ -378,6 +379,43 @@ export function getDaemonStreamingCardUsageSnapshot(
   };
 }
 
+/**
+ * Merge one worker `model_fallback` observation into the fallback the daemon
+ * holds. The daemon is the authority here, not the worker: the persisted state
+ * outlives every worker generation, while a worker only ever sees a bounded
+ * tail of the transcript.
+ *
+ * The rules, in order:
+ *   b) a switch record with a NEW uuid replaces whatever we held;
+ *   c) a serving model that disagrees with the held `fallbackModel` clears it —
+ *      that "Claude answered on a different model" is the ONLY evidence of a
+ *      switch back. Ordering matters: a `servingModel` arriving in the same
+ *      message as a `fallback` was observed AFTER it, so (c) runs after (b).
+ *
+ * Everything else — a missing record, a restarted worker, a transcript window
+ * too short to reach the switch — leaves the state exactly as it was. Absence
+ * of evidence is never evidence of a switch back.
+ */
+export function mergeModelFallbackObservation(
+  current: ModelFallbackState | undefined,
+  msg: { fallback?: ModelFallbackState; servingModel?: string },
+): { next: ModelFallbackState | undefined; changed: boolean } {
+  let next = current;
+  let changed = false;
+  if (msg.fallback && next?.uuid !== msg.fallback.uuid) {
+    next = msg.fallback;
+    changed = true;
+  }
+  if (msg.servingModel && next) {
+    const serving = normalizeClaudeModelId(msg.servingModel);
+    if (serving && serving !== normalizeClaudeModelId(next.fallbackModel)) {
+      next = undefined;
+      changed = true;
+    }
+  }
+  return { next, changed };
+}
+
 import { normalizeBrand } from '../im/lark/lark-hosts.js';
 import { dashboardEventBus } from './dashboard-events.js';
 import {
@@ -413,6 +451,7 @@ import type {
   CodexAppTurnInput,
   FrozenSessionReplyTarget,
   DaemonToWorker,
+  ModelFallbackState,
   TrustedCaller,
   WorkerToDaemon,
   Session,
@@ -11159,11 +11198,16 @@ function setupWorkerHandlers(
   // cannot leave a stale model/effort tail on the card.
   ds.activeModel = undefined;
   ds.activeReasoningEffort = undefined;
-  // Same authority rule for the model-fallback notice, and it additionally
-  // guards a role switch to a non-Claude CLI, which would never send a
-  // clearing model_fallback of its own. A Claude worker re-seeds it from the
-  // transcript when its bridge starts.
-  ds.modelFallback = undefined;
+  // The model-fallback notice is the ONE runtime fact a worker generation does
+  // NOT own: it must survive every respawn and stay visible each round until
+  // Claude is observed answering on a different model. Clearing it here and
+  // waiting for the new worker to re-seed loses it whenever the switch record
+  // has scrolled out of the bounded tail scan (a long session), and nothing
+  // ever brings it back. So only a role switch AWAY from claude-code clears it
+  // — that worker would never send a correcting observation of its own.
+  if (sessionCliId(ds, getBot(ds.larkAppId).config) !== 'claude-code') {
+    ds.modelFallback = undefined;
+  }
   ds.pendingActiveRuntimeCardRefresh = undefined;
   const handlerSession = ds.session;
   const handlerAnchor = sessionAnchorId(ds);
@@ -12108,9 +12152,12 @@ function setupWorkerHandlers(
           logger.warn(`[${t}] Ignored model_fallback from stale worker generation`);
           break;
         }
-        const next = msg.state ?? undefined;
-        if (ds.modelFallback?.uuid === next?.uuid) break;
-        ds.modelFallback = next;
+        // Claude-Code-only affordance (product decision). A worker for any
+        // other CLI has no business moving this state.
+        if (effectiveCliId !== 'claude-code') break;
+        const merged = mergeModelFallbackObservation(ds.modelFallback, msg);
+        if (!merged.changed) break;
+        ds.modelFallback = merged.next;
         persistStreamCardState(ds);
         scheduleActiveRuntimePatch(ds);
         break;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -386,7 +386,18 @@ export function getDaemonStreamingCardUsageSnapshot(
  * tail of the transcript.
  *
  * The rules, in order:
- *   b) a switch record with a NEW uuid replaces whatever we held;
+ *   a) a message from a DIFFERENT Claude session drops what we held first. The
+ *      notice belongs to one Claude conversation; `/repo`, `/adopt` and a
+ *      resume onto another native session all replace it, and carrying the old
+ *      record across shows a warning about a conversation the user has left —
+ *      or, when the new session's real model happens to equal the old
+ *      `fallbackModel`, a warning nothing can ever clear. State persisted
+ *      before the binding existed carries no session id and is likewise
+ *      dropped: it cannot be shown to belong here, and the same message's seed
+ *      re-establishes it when it does.
+ *   b) a switch record with a NEW uuid replaces whatever we held (and is
+ *      stamped with the message's Claude session); `fallback: null` — the
+ *      newest session-scoped record is NOT a live Fable fallback — clears.
  *   c) a serving model that disagrees with the held `fallbackModel` clears it —
  *      that "Claude answered on a different model" is the ONLY evidence of a
  *      switch back. Ordering matters: a `servingModel` arriving in the same
@@ -395,16 +406,28 @@ export function getDaemonStreamingCardUsageSnapshot(
  *      a message that runs both rules and lands back where it started costs no
  *      write and no card patch.
  *
- * Everything else — a missing record, a restarted worker, a transcript window
- * too short to reach the switch — leaves the state exactly as it was. Absence
- * of evidence is never evidence of a switch back.
+ * Everything else — a missing record, a restarted worker on the SAME Claude
+ * session, a transcript window too short to reach the switch — leaves the state
+ * exactly as it was. Absence of evidence is never evidence of a switch back.
  */
 export function mergeModelFallbackObservation(
   current: ModelFallbackState | undefined,
-  msg: { fallback?: ModelFallbackState; servingModel?: string },
+  msg: { claudeSessionId?: string; fallback?: ModelFallbackState | null; servingModel?: string },
 ): { next: ModelFallbackState | undefined; changed: boolean } {
   let next = current;
-  if (msg.fallback && next?.uuid !== msg.fallback.uuid) next = msg.fallback;
+  if (next && msg.claudeSessionId && next.claudeSessionId !== msg.claudeSessionId) {
+    next = undefined;
+  }
+  if (msg.fallback === null) {
+    next = undefined;
+  } else if (msg.fallback) {
+    const incoming = msg.claudeSessionId
+      ? { ...msg.fallback, claudeSessionId: msg.claudeSessionId }
+      : msg.fallback;
+    if (next?.uuid !== incoming.uuid || next?.claudeSessionId !== incoming.claudeSessionId) {
+      next = incoming;
+    }
+  }
   if (msg.servingModel && next) {
     const serving = normalizeClaudeModelId(msg.servingModel);
     if (serving && serving !== normalizeClaudeModelId(next.fallbackModel)) {
@@ -416,8 +439,14 @@ export function mergeModelFallbackObservation(
   // disagrees with it runs both rules and lands back on "no notice" — where we
   // started — so persisting and patching the card for it would be a wasted
   // Feishu edit on every worker start of an already-switched-back session.
-  // Same uuid identity the persist dirty-check uses.
-  return { next, changed: current?.uuid !== next?.uuid };
+  // Same identity the persist dirty-check uses: uuid AND Claude session, so an
+  // upgrade that only stamps the session id onto pre-existing state still
+  // persists it once.
+  return {
+    next,
+    changed: current?.uuid !== next?.uuid
+      || current?.claudeSessionId !== next?.claudeSessionId,
+  };
 }
 
 import { normalizeBrand } from '../im/lark/lark-hosts.js';
@@ -11208,9 +11237,13 @@ function setupWorkerHandlers(
   // waiting for the new worker to re-seed loses it whenever the switch record
   // has scrolled out of the bounded tail scan (a long session), and nothing
   // ever brings it back. So only a role switch AWAY from claude-code clears it
-  // — that worker would never send a correcting observation of its own.
+  // — that worker would never send a correcting observation of its own. And it
+  // must be cleared on DISK as well: leaving the mirror on Session.modelFallback
+  // means a daemon restart (or any card rebuilt without a live worker) revives
+  // the notice on a session that is no longer running Claude at all.
   if (sessionCliId(ds, getBot(ds.larkAppId).config) !== 'claude-code') {
     ds.modelFallback = undefined;
+    persistStreamCardState(ds);
   }
   ds.pendingActiveRuntimeCardRefresh = undefined;
   const handlerSession = ds.session;
@@ -12160,10 +12193,25 @@ function setupWorkerHandlers(
         // other CLI has no business moving this state.
         if (effectiveCliId !== 'claude-code') break;
         const merged = mergeModelFallbackObservation(ds.modelFallback, msg);
-        if (!merged.changed) break;
-        ds.modelFallback = merged.next;
-        persistStreamCardState(ds);
-        scheduleActiveRuntimePatch(ds);
+        if (merged.changed) {
+          ds.modelFallback = merged.next;
+          persistStreamCardState(ds);
+        }
+        // The card's usage line shows ds.activeModel, and Claude Code never
+        // emits `active_runtime` — so without this the line renders the LAUNCH
+        // model (ds.session.model) forever, even while an automatic fallback
+        // has the session answering on something else. The serving model is a
+        // per-reply observation of the real thing, so it is the runtime model:
+        // same "only write when it changed, then patch" semantics as the
+        // active_runtime handler. Effort is untouched — Claude reports none,
+        // and a blank one would erase what another channel wrote.
+        let runtimeChanged = false;
+        const servingModel = normalizeClaudeModelId(msg.servingModel);
+        if (servingModel && ds.activeModel !== servingModel) {
+          ds.activeModel = servingModel;
+          runtimeChanged = true;
+        }
+        if (merged.changed || runtimeChanged) scheduleActiveRuntimePatch(ds);
         break;
       }
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -339,6 +339,10 @@ export function getDaemonStreamingCardUsageSnapshot(
   const reasoningEffort = ds.activeReasoningEffort?.trim()
     || ds.session.reasoningEffort?.trim();
   const modelBackendVariant = ds.session.modelBackendVariant;
+  // The fallback notice is a warning about which model is answering, not a
+  // usage metric — it rides the snapshot (every buildStreamingCard call site
+  // already forwards one) but must survive the 'off'/'footer' early return.
+  const modelFallback = ds.modelFallback;
   try {
     if (resolveUsageDisplay(ds.larkAppId) !== 'streaming') {
       return {
@@ -347,6 +351,7 @@ export function getDaemonStreamingCardUsageSnapshot(
         ...(runtimeModel ? { model: runtimeModel } : {}),
         ...(reasoningEffort ? { reasoningEffort } : {}),
         ...(modelBackendVariant ? { modelBackendVariant } : {}),
+        ...(modelFallback ? { modelFallback } : {}),
       };
     }
   } catch {
@@ -369,6 +374,7 @@ export function getDaemonStreamingCardUsageSnapshot(
     ...(runtimeModel ? { model: runtimeModel } : grokModel ? { model: grokModel } : {}),
     ...(reasoningEffort ? { reasoningEffort } : grokReasoningEffort ? { reasoningEffort: grokReasoningEffort } : {}),
     ...(modelBackendVariant ? { modelBackendVariant } : {}),
+    ...(modelFallback ? { modelFallback } : {}),
   };
 }
 
@@ -11153,6 +11159,11 @@ function setupWorkerHandlers(
   // cannot leave a stale model/effort tail on the card.
   ds.activeModel = undefined;
   ds.activeReasoningEffort = undefined;
+  // Same authority rule for the model-fallback notice, and it additionally
+  // guards a role switch to a non-Claude CLI, which would never send a
+  // clearing model_fallback of its own. A Claude worker re-seeds it from the
+  // transcript when its bridge starts.
+  ds.modelFallback = undefined;
   ds.pendingActiveRuntimeCardRefresh = undefined;
   const handlerSession = ds.session;
   const handlerAnchor = sessionAnchorId(ds);
@@ -12084,6 +12095,23 @@ function setupWorkerHandlers(
         }
         ds.activeModel = model;
         ds.activeReasoningEffort = reasoningEffort;
+        scheduleActiveRuntimePatch(ds);
+        break;
+      }
+
+      case 'model_fallback': {
+        if (
+          ds.worker !== worker
+          || ds.workerGeneration !== workerGeneration
+          || ds.session.workerGeneration !== workerGeneration
+        ) {
+          logger.warn(`[${t}] Ignored model_fallback from stale worker generation`);
+          break;
+        }
+        const next = msg.state ?? undefined;
+        if (ds.modelFallback?.uuid === next?.uuid) break;
+        ds.modelFallback = next;
+        persistStreamCardState(ds);
         scheduleActiveRuntimePatch(ds);
         break;
       }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -391,6 +391,9 @@ export function getDaemonStreamingCardUsageSnapshot(
  *      that "Claude answered on a different model" is the ONLY evidence of a
  *      switch back. Ordering matters: a `servingModel` arriving in the same
  *      message as a `fallback` was observed AFTER it, so (c) runs after (b).
+ *   d) `changed` compares the resulting STATE with the one we came in with, so
+ *      a message that runs both rules and lands back where it started costs no
+ *      write and no card patch.
  *
  * Everything else — a missing record, a restarted worker, a transcript window
  * too short to reach the switch — leaves the state exactly as it was. Absence
@@ -401,19 +404,20 @@ export function mergeModelFallbackObservation(
   msg: { fallback?: ModelFallbackState; servingModel?: string },
 ): { next: ModelFallbackState | undefined; changed: boolean } {
   let next = current;
-  let changed = false;
-  if (msg.fallback && next?.uuid !== msg.fallback.uuid) {
-    next = msg.fallback;
-    changed = true;
-  }
+  if (msg.fallback && next?.uuid !== msg.fallback.uuid) next = msg.fallback;
   if (msg.servingModel && next) {
     const serving = normalizeClaudeModelId(msg.servingModel);
     if (serving && serving !== normalizeClaudeModelId(next.fallbackModel)) {
       next = undefined;
-      changed = true;
     }
   }
-  return { next, changed };
+  // `changed` is about the STATE, not about which rules fired. A cold-start
+  // message carrying a record together with a serving model that already
+  // disagrees with it runs both rules and lands back on "no notice" — where we
+  // started — so persisting and patching the card for it would be a wasted
+  // Feishu edit on every worker start of an already-switched-back session.
+  // Same uuid identity the persist dirty-check uses.
+  return { next, changed: current?.uuid !== next?.uuid };
 }
 
 import { normalizeBrand } from '../im/lark/lark-hosts.js';

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -65,6 +65,13 @@ export const messages: Record<string, string> = {
   'card.body.choose_label': 'Choice:',
   'card.usage_limit.retry_at': '⚠️ {cliName} usage limit has been reached. Try again after {retryLabel}.',
   'card.usage_limit.retry_ready': '✅ {cliName} usage limit should have reset. Retry the last task, or send a new message.',
+  'card.model_fallback.refusal': '⚠️ Safety guardrails tripped — auto-downgraded: {originalModel} → {fallbackModel}{reason}this session keeps running on {fallbackModel}; reply /model {alias} to switch back',
+  'card.model_fallback.unavailable': '⚠️ Model unavailable — auto-switched: {originalModel} → {fallbackModel}{reason}reply /model {alias} to switch back',
+  'card.model_fallback.consent': '⚠️ Usage quota limit — auto-switched: {originalModel} → {fallbackModel}{reason}reply /model {alias} to switch back',
+  // {reason} carries the separator that follows it, so the no-reason variant
+  // does not leave a doubled space.
+  'card.model_fallback.reason': ' ({reason}) · ',
+  'card.model_fallback.no_reason': ' · ',
   'worker.rate_limit_notify.rate': '⚠️ {cliName} hit a rate limit — this turn is paused. Resend the last task after {retryLabel}, or send a new message to continue.',
   'worker.rate_limit_notify.usage': '⚠️ {cliName} hit its usage limit — this turn is paused. Once the quota resets ({retryLabel}), resend the last task or send a new message to continue.',
   'card.private.snapshot_note': '🔒 Private static snapshot (visible only to you, not live-updating). Tap Open Web Terminal for the live view.',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -65,9 +65,9 @@ export const messages: Record<string, string> = {
   'card.body.choose_label': 'Choice:',
   'card.usage_limit.retry_at': '⚠️ {cliName} usage limit has been reached. Try again after {retryLabel}.',
   'card.usage_limit.retry_ready': '✅ {cliName} usage limit should have reset. Retry the last task, or send a new message.',
-  'card.model_fallback.refusal': '⚠️ Safety guardrails tripped — auto-downgraded: {originalModel} → {fallbackModel}{reason}this session keeps running on {fallbackModel}; reply /model {alias} to switch back',
-  'card.model_fallback.unavailable': '⚠️ Model unavailable — auto-switched: {originalModel} → {fallbackModel}{reason}reply /model {alias} to switch back',
-  'card.model_fallback.consent': '⚠️ Usage quota limit — auto-switched: {originalModel} → {fallbackModel}{reason}reply /model {alias} to switch back',
+  'card.model_fallback.refusal': '⚠️ Safety fallback: {originalModel} → {fallbackModel}{reason}/model {alias} to switch back',
+  'card.model_fallback.unavailable': '⚠️ Model unavailable: {originalModel} → {fallbackModel}{reason}/model {alias} to switch back',
+  'card.model_fallback.consent': '⚠️ Quota fallback: {originalModel} → {fallbackModel}{reason}/model {alias} to switch back',
   // {reason} carries the separator that follows it, so the no-reason variant
   // does not leave a doubled space.
   'card.model_fallback.reason': ' ({reason}) · ',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -65,13 +65,12 @@ export const messages: Record<string, string> = {
   'card.body.choose_label': 'Choice:',
   'card.usage_limit.retry_at': '⚠️ {cliName} usage limit has been reached. Try again after {retryLabel}.',
   'card.usage_limit.retry_ready': '✅ {cliName} usage limit should have reset. Retry the last task, or send a new message.',
-  'card.model_fallback.refusal': '⚠️ Safety fallback: {originalModel} → {fallbackModel}{reason}/model {alias} to switch back',
-  'card.model_fallback.unavailable': '⚠️ Model unavailable: {originalModel} → {fallbackModel}{reason}/model {alias} to switch back',
-  'card.model_fallback.consent': '⚠️ Quota fallback: {originalModel} → {fallbackModel}{reason}/model {alias} to switch back',
-  // {reason} carries the separator that follows it, so the no-reason variant
-  // does not leave a doubled space.
-  'card.model_fallback.reason': ' ({reason}) · ',
-  'card.model_fallback.no_reason': ' · ',
+  'card.model_fallback.refusal': '⚠️ Safety fallback: {originalModel} → {fallbackModel}{reason}',
+  'card.model_fallback.unavailable': '⚠️ Model unavailable, switched for this turn: {originalModel} → {fallbackModel}{reason}',
+  'card.model_fallback.consent': '⚠️ Quota fallback: {originalModel} → {fallbackModel}{reason}',
+  // {reason} ends the line; the no-reason variant adds nothing.
+  'card.model_fallback.reason': ' ({reason})',
+  'card.model_fallback.no_reason': '',
   'worker.rate_limit_notify.rate': '⚠️ {cliName} hit a rate limit — this turn is paused. Resend the last task after {retryLabel}, or send a new message to continue.',
   'worker.rate_limit_notify.usage': '⚠️ {cliName} hit its usage limit — this turn is paused. Once the quota resets ({retryLabel}), resend the last task or send a new message to continue.',
   'card.private.snapshot_note': '🔒 Private static snapshot (visible only to you, not live-updating). Tap Open Web Terminal for the live view.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -68,12 +68,12 @@ export const messages: Record<string, string> = {
   'card.body.choose_label': '选择:',
   'card.usage_limit.retry_at': '⚠️ 当前已达到 {cliName} 使用限额。请在 {retryLabel} 后再试。',
   'card.usage_limit.retry_ready': '✅ {cliName} 限额预计已刷新。你可以重发上一条任务，或直接发送新消息。',
-  'card.model_fallback.refusal': '⚠️ 安全管控降级：{originalModel} → {fallbackModel}{reason}/model {alias} 切回',
-  'card.model_fallback.unavailable': '⚠️ 模型不可用已切换：{originalModel} → {fallbackModel}{reason}/model {alias} 切回',
-  'card.model_fallback.consent': '⚠️ 额度限制已切换：{originalModel} → {fallbackModel}{reason}/model {alias} 切回',
-  // {reason} 连同后面的分隔点一起替换：全角括号自带视觉间距，前面不再补空格。
-  'card.model_fallback.reason': '（{reason}）· ',
-  'card.model_fallback.no_reason': ' · ',
+  'card.model_fallback.refusal': '⚠️ 安全管控降级：{originalModel} → {fallbackModel}{reason}',
+  'card.model_fallback.unavailable': '⚠️ 模型不可用，本轮切换：{originalModel} → {fallbackModel}{reason}',
+  'card.model_fallback.consent': '⚠️ 额度限制已切换：{originalModel} → {fallbackModel}{reason}',
+  // {reason} 是行尾：全角括号自带视觉间距，前面不补空格；没有原因就什么都不加。
+  'card.model_fallback.reason': '（{reason}）',
+  'card.model_fallback.no_reason': '',
   'worker.rate_limit_notify.rate': '⚠️ {cliName} 触发限流，本轮任务已暂停。请在 {retryLabel} 后重发上一条任务，或直接发送新消息继续。',
   'worker.rate_limit_notify.usage': '⚠️ {cliName} 已达使用限额，本轮任务已暂停。额度刷新后（{retryLabel}）请重发上一条任务，或直接发送新消息继续。',
   'card.private.snapshot_note': '🔒 仅你可见的静态快照（不会实时刷新）。点「打开 Web 终端」查看实时画面。',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -68,6 +68,12 @@ export const messages: Record<string, string> = {
   'card.body.choose_label': '选择:',
   'card.usage_limit.retry_at': '⚠️ 当前已达到 {cliName} 使用限额。请在 {retryLabel} 后再试。',
   'card.usage_limit.retry_ready': '✅ {cliName} 限额预计已刷新。你可以重发上一条任务，或直接发送新消息。',
+  'card.model_fallback.refusal': '⚠️ 安全管控触发，已自动降级：{originalModel} → {fallbackModel}{reason}后续都在 {fallbackModel} 上跑，回复 /model {alias} 可切回',
+  'card.model_fallback.unavailable': '⚠️ 模型不可用，已自动切换：{originalModel} → {fallbackModel}{reason}回复 /model {alias} 可切回',
+  'card.model_fallback.consent': '⚠️ 因用量额度限制，已自动切换：{originalModel} → {fallbackModel}{reason}回复 /model {alias} 可切回',
+  // {reason} 连同后面的分隔点一起替换：全角括号自带视觉间距，前面不再补空格。
+  'card.model_fallback.reason': '（{reason}）· ',
+  'card.model_fallback.no_reason': ' · ',
   'worker.rate_limit_notify.rate': '⚠️ {cliName} 触发限流，本轮任务已暂停。请在 {retryLabel} 后重发上一条任务，或直接发送新消息继续。',
   'worker.rate_limit_notify.usage': '⚠️ {cliName} 已达使用限额，本轮任务已暂停。额度刷新后（{retryLabel}）请重发上一条任务，或直接发送新消息继续。',
   'card.private.snapshot_note': '🔒 仅你可见的静态快照（不会实时刷新）。点「打开 Web 终端」查看实时画面。',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -68,9 +68,9 @@ export const messages: Record<string, string> = {
   'card.body.choose_label': '选择:',
   'card.usage_limit.retry_at': '⚠️ 当前已达到 {cliName} 使用限额。请在 {retryLabel} 后再试。',
   'card.usage_limit.retry_ready': '✅ {cliName} 限额预计已刷新。你可以重发上一条任务，或直接发送新消息。',
-  'card.model_fallback.refusal': '⚠️ 安全管控触发，已自动降级：{originalModel} → {fallbackModel}{reason}后续都在 {fallbackModel} 上跑，回复 /model {alias} 可切回',
-  'card.model_fallback.unavailable': '⚠️ 模型不可用，已自动切换：{originalModel} → {fallbackModel}{reason}回复 /model {alias} 可切回',
-  'card.model_fallback.consent': '⚠️ 因用量额度限制，已自动切换：{originalModel} → {fallbackModel}{reason}回复 /model {alias} 可切回',
+  'card.model_fallback.refusal': '⚠️ 安全管控降级：{originalModel} → {fallbackModel}{reason}/model {alias} 切回',
+  'card.model_fallback.unavailable': '⚠️ 模型不可用已切换：{originalModel} → {fallbackModel}{reason}/model {alias} 切回',
+  'card.model_fallback.consent': '⚠️ 额度限制已切换：{originalModel} → {fallbackModel}{reason}/model {alias} 切回',
   // {reason} 连同后面的分隔点一起替换：全角括号自带视觉间距，前面不再补空格。
   'card.model_fallback.reason': '（{reason}）· ',
   'card.model_fallback.no_reason': ' · ',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -9,7 +9,7 @@ import type { DisplayMode, StreamStatus } from '../../types.js';
 import type { CliUsageLimitState } from '../../utils/cli-usage-limit.js';
 import type { TurnRetryOffer } from '../../services/turn-failure-notice.js';
 import { t, type Locale } from '../../i18n/index.js';
-import { cardUsageFooterSegment, cardUsageRuntimeSegment, contextOverCompactThreshold, type CardUsageSnapshot } from './md-card.js';
+import { cardModelFallbackNotice, cardUsageFooterSegment, cardUsageRuntimeSegment, contextOverCompactThreshold, type CardUsageSnapshot } from './md-card.js';
 import { readGlobalConfig } from '../../global-config.js';
 import type { ConfigCardData } from '../../services/bot-config-store.js';
 import { isLocalCliOpenEnabled } from '../../services/local-cli-opener.js';
@@ -885,6 +885,14 @@ function pushStreamBody(
         ? t('card.usage_limit.retry_ready', { cliName: escapeMd(cliName) }, locale)
         : t('card.usage_limit.retry_at', { cliName: escapeMd(cliName), retryLabel: usageLimit.retryLabel }, locale),
     });
+    elements.push({ tag: 'hr' });
+  }
+  // Model auto-fallback notice — deliberately pinned to the card rather than
+  // sent as its own message, right after the usage-limit line: both answer
+  // "why does this turn look off".
+  const modelFallbackNotice = cardModelFallbackNotice(usage?.modelFallback, locale);
+  if (modelFallbackNotice) {
+    elements.push({ tag: 'markdown', content: modelFallbackNotice });
     elements.push({ tag: 'hr' });
   }
   if (displayMode === 'screenshot') {

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1168,7 +1168,7 @@ export function buildStreamingCard(
     });
   }
 
-  // Model auto-fallback notice — pinned as small grey text at the very bottom of
+  // Model auto-fallback notice — pinned as small yellow text at the very bottom of
   // the session card (never a separate message) for as long as the session
   // keeps running on the fallback model.
   const modelFallbackNotice = cardModelFallbackNotice(usage?.modelFallback, locale);
@@ -1176,7 +1176,7 @@ export function buildStreamingCard(
     elements.push({
       tag: 'markdown',
       text_size: MODEL_FALLBACK_NOTICE_TEXT_SIZE,
-      content: `<font color='grey'>${modelFallbackNotice}</font>`,
+      content: `<font color='yellow'>${modelFallbackNotice}</font>`,
     });
   }
 

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -873,6 +873,10 @@ function streamStatusLabel(status: StreamStatus, usageLimit: CliUsageLimitState 
 
 /** Push the shared "output body" elements (usage-limit notice + screenshot) used
  *  by both {@link buildStreamingCard} and {@link buildPrivateSnapshotCard}. */
+/** Smallest built-in Feishu card font (10px): the fallback notice is a
+ *  footnote, one step below the 12px usage line. */
+const MODEL_FALLBACK_NOTICE_TEXT_SIZE = 'x-small';
+
 function pushStreamBody(
   elements: any[],
   opts: { status: StreamStatus; usageLimit?: CliUsageLimitState; displayMode: DisplayMode; imageKey?: string; cliName: string; locale?: Locale; usage?: CardUsageSnapshot },
@@ -1171,7 +1175,7 @@ export function buildStreamingCard(
   if (modelFallbackNotice) {
     elements.push({
       tag: 'markdown',
-      text_size: 'notation_small_v2',
+      text_size: MODEL_FALLBACK_NOTICE_TEXT_SIZE,
       content: `<font color='grey'>${modelFallbackNotice}</font>`,
     });
   }

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -887,14 +887,6 @@ function pushStreamBody(
     });
     elements.push({ tag: 'hr' });
   }
-  // Model auto-fallback notice — deliberately pinned to the card rather than
-  // sent as its own message, right after the usage-limit line: both answer
-  // "why does this turn look off".
-  const modelFallbackNotice = cardModelFallbackNotice(usage?.modelFallback, locale);
-  if (modelFallbackNotice) {
-    elements.push({ tag: 'markdown', content: modelFallbackNotice });
-    elements.push({ tag: 'hr' });
-  }
   if (displayMode === 'screenshot') {
     if (imageKey) {
       elements.push({ tag: 'img', img_key: imageKey, alt: { tag: 'plain_text', content: '' }, mode: 'fit_horizontal', preview: true });
@@ -1169,6 +1161,18 @@ export function buildStreamingCard(
         mkKey(t('card.btn.half_page_up', undefined, locale), 'half_page_up'),
         mkKey(t('card.btn.half_page_down', undefined, locale), 'half_page_down'),
       ],
+    });
+  }
+
+  // Model auto-fallback notice — pinned as small grey text at the very bottom of
+  // the session card (never a separate message) for as long as the session
+  // keeps running on the fallback model.
+  const modelFallbackNotice = cardModelFallbackNotice(usage?.modelFallback, locale);
+  if (modelFallbackNotice) {
+    elements.push({
+      tag: 'markdown',
+      text_size: 'notation_small_v2',
+      content: `<font color='grey'>${modelFallbackNotice}</font>`,
     });
   }
 

--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -514,11 +514,18 @@ export function cardUsageRuntimeSegment(
 }
 
 /** Friendly Claude model name for card copy: `claude-fable-5-1[1m]` → `Fable 5.1`,
- *  `claude-opus-5` → `Opus 5`. Anything that is not a recognised
- *  `claude-<family>-<major>[-<minor>][-<date>]` id keeps its raw form. */
+ *  `claude-opus-5` → `Opus 5`, `claude-haiku-4-5-20251001` → `Haiku 4.5`.
+ *  Anything that is not a recognised `claude-<family>-<major>[-<minor>][-<date>]`
+ *  id keeps its raw form.
+ *
+ *  The minor is capped at TWO digits on purpose. Date-suffixed ids without a
+ *  minor (`claude-opus-4-20250514`) otherwise let the minor group swallow the
+ *  date and render "Opus 4.20250514"; with the cap the regex backtracks into
+ *  the date branch and the id reads as plain "Opus 4". No real Claude minor has
+ *  ever been longer than two digits. */
 function claudeModelLabel(id: string): string {
   const bare = id.trim().replace(/\[[^\]]*\]$/, '').trim();
-  const m = /^claude-(fable|opus|sonnet|haiku)-(\d+)(?:-(\d+))?(?:-\d{6,})?$/i.exec(bare);
+  const m = /^claude-(fable|opus|sonnet|haiku)-(\d+)(?:-(\d{1,2}))?(?:-\d{6,})?$/i.exec(bare);
   if (!m) return id.trim();
   const family = m[1].toLowerCase();
   return `${family.charAt(0).toUpperCase()}${family.slice(1)} ${m[2]}${m[3] ? `.${m[3]}` : ''}`;
@@ -531,21 +538,33 @@ function escapeCardPlainText(value: string): string {
 }
 
 const MODEL_FALLBACK_LABEL_MAX = 32;
+/** Tighter than the model cap: `trigger` / `apiRefusalCategory` are raw
+ *  provider strings that ride in parentheses at the end of an already-full
+ *  line, and unlike a model id nothing about them is worth more than a glance.
+ *  Real values (`overloaded`, `model_not_found`, `cyber`) fit easily. */
+const MODEL_FALLBACK_REASON_MAX = 24;
 
-/** Bound one model-derived token of the notice. Every one of them comes from the
- *  transcript, so the `/model` argument needs the same cap as the display
- *  labels — an unbounded alias would blow up exactly the line those labels are
- *  trimmed to keep short. Real Claude ids are well under the cap (the longest,
- *  `claude-haiku-4-5-20251001`, is 25 chars), so this only ever bites a
- *  pathological id whose `/model` hint could not have worked anyway. */
-function truncateModelToken(value: string): string {
-  return value.length > MODEL_FALLBACK_LABEL_MAX
-    ? `${value.slice(0, MODEL_FALLBACK_LABEL_MAX - 1)}…`
-    : value;
+/** Bound one transcript-derived token of the notice and force it onto ONE line.
+ *  Every token here comes from Claude's own record, so it can carry newlines,
+ *  control characters or an arbitrarily long `/model` alias — any of which
+ *  would break the single-line footnote the notice is. Real values are well
+ *  under the caps (the longest Claude id, `claude-haiku-4-5-20251001`, is 25
+ *  chars), so this only ever bites a pathological value. */
+function compactNoticeToken(value: string, maxLength: number): string {
+  const normalized = value
+    // C0/C1 controls (newlines included) plus the Unicode line/paragraph
+    // separators, flattened to a space before whitespace is collapsed.
+    .replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const compact = normalized.length > maxLength
+    ? `${normalized.slice(0, Math.max(1, maxLength - 1))}\u2026`
+    : normalized;
+  return escapeCardPlainText(compact);
 }
 
 function fallbackModelText(id: string): string {
-  return escapeCardPlainText(truncateModelToken(claudeModelLabel(id)));
+  return compactNoticeToken(claudeModelLabel(id), MODEL_FALLBACK_LABEL_MAX);
 }
 
 /** One-line notice for a model fallback still in effect, or null when there is
@@ -559,8 +578,14 @@ export function cardModelFallbackNotice(
   const rawReason = fallback.kind === 'refusal'
     ? fallback.apiRefusalCategory
     : fallback.kind === 'unavailable' ? fallback.trigger : undefined;
-  const reason = rawReason
-    ? t('card.model_fallback.reason', { reason: escapeCardPlainText(rawReason) }, locale)
+  // The reason is a raw provider string straight out of the transcript, so it
+  // gets the same one-line + bounded + escaped treatment as the model labels;
+  // a multi-line or novel-length trigger would otherwise wreck the footnote.
+  const compactReason = rawReason
+    ? compactNoticeToken(rawReason, MODEL_FALLBACK_REASON_MAX)
+    : '';
+  const reason = compactReason
+    ? t('card.model_fallback.reason', { reason: compactReason }, locale)
     : t('card.model_fallback.no_reason', undefined, locale);
   return t(`card.model_fallback.${fallback.kind}`, {
     originalModel: fallbackModelText(fallback.originalModel),

--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -26,6 +26,7 @@ import { resolve } from 'node:path';
 import MarkdownIt from 'markdown-it';
 import type Token from 'markdown-it/lib/token.mjs';
 import { t, type Locale } from '../../i18n/index.js';
+import type { ModelFallbackState } from '../../types.js';
 import {
   REPLY_CARD_FOOTER_ELEMENT_ID,
   REPLY_CARD_FOOTER_MARKER,
@@ -101,6 +102,12 @@ export interface CardUsageSnapshot {
   reasoningEffort?: string;
   /** Frozen TraeX backend variant selected for this session. */
   modelBackendVariant?: string;
+  /** Claude model fallback in effect, rendered as its own notice line on the
+   *  live card. It rides this snapshot rather than a 23rd positional arg on
+   *  buildStreamingCard: every call site already forwards the snapshot (locked
+   *  by test/streaming-card-usage-arg.test.ts), so no call site can forget it.
+   *  Not a usage metric, but the same class of runtime identity as `model`. */
+  modelFallback?: ModelFallbackState;
 }
 
 export interface ReplyCardFooter {
@@ -504,6 +511,66 @@ export function cardUsageRuntimeSegment(
   const reasoningEffort = compactRuntimeLabel(usage.reasoningEffort, 10);
   const tail = [variant, reasoningEffort].filter(Boolean);
   return `**${model}**${tail.length > 0 ? `\u00a0${tail.join(' · ')}` : ''}`;
+}
+
+/** Friendly Claude model name for card copy: `claude-fable-5-1[1m]` → `Fable 5.1`,
+ *  `claude-opus-5` → `Opus 5`. Anything that is not a recognised
+ *  `claude-<family>-<major>[-<minor>][-<date>]` id keeps its raw form. */
+function claudeModelLabel(id: string): string {
+  const bare = id.trim().replace(/\[[^\]]*\]$/, '').trim();
+  const m = /^claude-(fable|opus|sonnet|haiku)-(\d+)(?:-(\d+))?(?:-\d{6,})?$/i.exec(bare);
+  if (!m) return id.trim();
+  const family = m[1].toLowerCase();
+  return `${family.charAt(0).toUpperCase()}${family.slice(1)} ${m[2]}${m[3] ? `.${m[3]}` : ''}`;
+}
+
+/** The `/model <alias>` argument that puts the session back on `id`. Claude Code
+ *  resolves the family aliases (fable/opus/sonnet/haiku) to the current
+ *  recommended build; an unrecognised id is echoed verbatim so the hint stays
+ *  actionable. */
+function claudeModelAlias(id: string): string {
+  const bare = id.trim().replace(/\[[^\]]*\]$/, '').trim();
+  const m = /^claude-(fable|opus|sonnet|haiku)-/i.exec(bare);
+  return m ? m[1].toLowerCase() : id.trim();
+}
+
+/** Escape markdown control characters without the non-breaking-space rewrite
+ *  compactRuntimeLabel applies — this notice is prose, not a compact tail. */
+function escapeCardPlainText(value: string): string {
+  return value.replace(/[*_~`\[\]\\<>]/g, char => `\\${char}`);
+}
+
+const MODEL_FALLBACK_LABEL_MAX = 32;
+
+function fallbackModelText(id: string): string {
+  const label = claudeModelLabel(id);
+  return escapeCardPlainText(
+    label.length > MODEL_FALLBACK_LABEL_MAX
+      ? `${label.slice(0, MODEL_FALLBACK_LABEL_MAX - 1)}…`
+      : label,
+  );
+}
+
+/** One-line notice for a model fallback still in effect, or null when there is
+ *  none. Only the model ids and the reason are rendered — Claude's own record
+ *  carries a full paragraph of prose, which would swamp a status line. */
+export function cardModelFallbackNotice(
+  fallback: ModelFallbackState | undefined,
+  locale?: Locale,
+): string | null {
+  if (!fallback?.originalModel || !fallback.fallbackModel) return null;
+  const rawReason = fallback.kind === 'refusal'
+    ? fallback.apiRefusalCategory
+    : fallback.kind === 'unavailable' ? fallback.trigger : undefined;
+  const reason = rawReason
+    ? t('card.model_fallback.reason', { reason: escapeCardPlainText(rawReason) }, locale)
+    : t('card.model_fallback.no_reason', undefined, locale);
+  return t(`card.model_fallback.${fallback.kind}`, {
+    originalModel: fallbackModelText(fallback.originalModel),
+    fallbackModel: fallbackModelText(fallback.fallbackModel),
+    alias: escapeCardPlainText(claudeModelAlias(fallback.originalModel)),
+    reason,
+  }, locale);
 }
 
 /** Build the one canonical footer shared by all Bot Session reply cards.

--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -542,13 +542,20 @@ function escapeCardPlainText(value: string): string {
 
 const MODEL_FALLBACK_LABEL_MAX = 32;
 
+/** Bound one model-derived token of the notice. Every one of them comes from the
+ *  transcript, so the `/model` argument needs the same cap as the display
+ *  labels — an unbounded alias would blow up exactly the line those labels are
+ *  trimmed to keep short. Real Claude ids are well under the cap (the longest,
+ *  `claude-haiku-4-5-20251001`, is 25 chars), so this only ever bites a
+ *  pathological id whose `/model` hint could not have worked anyway. */
+function truncateModelToken(value: string): string {
+  return value.length > MODEL_FALLBACK_LABEL_MAX
+    ? `${value.slice(0, MODEL_FALLBACK_LABEL_MAX - 1)}…`
+    : value;
+}
+
 function fallbackModelText(id: string): string {
-  const label = claudeModelLabel(id);
-  return escapeCardPlainText(
-    label.length > MODEL_FALLBACK_LABEL_MAX
-      ? `${label.slice(0, MODEL_FALLBACK_LABEL_MAX - 1)}…`
-      : label,
-  );
+  return escapeCardPlainText(truncateModelToken(claudeModelLabel(id)));
 }
 
 /** One-line notice for a model fallback still in effect, or null when there is
@@ -568,7 +575,7 @@ export function cardModelFallbackNotice(
   return t(`card.model_fallback.${fallback.kind}`, {
     originalModel: fallbackModelText(fallback.originalModel),
     fallbackModel: fallbackModelText(fallback.fallbackModel),
-    alias: escapeCardPlainText(claudeModelAlias(fallback.originalModel)),
+    alias: escapeCardPlainText(truncateModelToken(claudeModelAlias(fallback.originalModel))),
     reason,
   }, locale);
 }

--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -524,16 +524,6 @@ function claudeModelLabel(id: string): string {
   return `${family.charAt(0).toUpperCase()}${family.slice(1)} ${m[2]}${m[3] ? `.${m[3]}` : ''}`;
 }
 
-/** The `/model <alias>` argument that puts the session back on `id`. Claude Code
- *  resolves the family aliases (fable/opus/sonnet/haiku) to the current
- *  recommended build; an unrecognised id is echoed verbatim so the hint stays
- *  actionable. */
-function claudeModelAlias(id: string): string {
-  const bare = id.trim().replace(/\[[^\]]*\]$/, '').trim();
-  const m = /^claude-(fable|opus|sonnet|haiku)-/i.exec(bare);
-  return m ? m[1].toLowerCase() : id.trim();
-}
-
 /** Escape markdown control characters without the non-breaking-space rewrite
  *  compactRuntimeLabel applies — this notice is prose, not a compact tail. */
 function escapeCardPlainText(value: string): string {
@@ -575,7 +565,6 @@ export function cardModelFallbackNotice(
   return t(`card.model_fallback.${fallback.kind}`, {
     originalModel: fallbackModelText(fallback.originalModel),
     fallbackModel: fallbackModelText(fallback.fallbackModel),
-    alias: escapeCardPlainText(truncateModelToken(claudeModelAlias(fallback.originalModel))),
     reason,
   }, locale);
 }

--- a/src/services/claude-transcript.ts
+++ b/src/services/claude-transcript.ts
@@ -382,7 +382,10 @@ export class ClaudeModelFallbackTracker {
    *  records are skipped outright: a sub-agent fell back on its own and the
    *  main session model is untouched. A session-scoped record that is NOT a
    *  live Fable fallback still counts — it reports `fallback: null`, the
-   *  positive "no notice here" the daemon clears on. */
+   *  positive "no notice here" the daemon clears on.
+   *
+   *  Whatever the batch holds, the NEWEST session-scoped record in it decides:
+   *  an older one is only reported when no newer record follows it here. */
   observe(events: readonly TranscriptEvent[]): ModelFallbackObservation | null {
     let fallback: ClaudeModelFallbackRecord | null | undefined;
     let servingModel: string | undefined;
@@ -399,7 +402,16 @@ export class ClaudeModelFallbackTracker {
         // reset would let one of those older replies reach the daemon as
         // "Claude answered on a different model".
         servingModel = undefined;
-        if (this.seenUuids.has(rec.uuid)) continue;
+        if (this.seenUuids.has(rec.uuid)) {
+          // Already reported — but it is still the record that DECIDES, so an
+          // OLDER one earlier in the same batch must not outlive it. A drain
+          // from offset 0 (a jsonl switch, a truncation re-read) replays the
+          // whole file, and the older record is unseen whenever it predates
+          // this worker's baseline: without this reset the batch would report
+          // it and resurrect a notice the newest record already retired.
+          fallback = undefined;
+          continue;
+        }
         this.acceptSwitch(rec.uuid);
         fallback = noticeFromSessionRecord(rec);
         continue;

--- a/src/services/claude-transcript.ts
+++ b/src/services/claude-transcript.ts
@@ -307,13 +307,19 @@ export class ClaudeModelFallbackTracker {
     for (const ev of events) {
       const rec = parseClaudeModelFallbackEvent(ev);
       if (rec) {
-        if (rec.scope === 'local' || this.seenUuids.has(rec.uuid)) continue;
-        this.rememberUuid(rec.uuid);
-        fallback = rec;
+        if (rec.scope === 'local') continue;
         // Replies written BEFORE the switch say nothing about what serves now;
         // shipping one alongside the switch would make the daemon clear the
-        // notice the instant it appeared.
+        // notice the instant it appeared. That holds whether or not the record
+        // is new to us, so the reset comes BEFORE the uuid dedupe: a re-drain
+        // from offset 0 (a jsonl switch, a baseline self-heal) replays the
+        // switch together with every reply that preceded it, and skipping the
+        // reset would let one of those older replies reach the daemon as
+        // "Claude answered on a different model".
         servingModel = undefined;
+        if (this.seenUuids.has(rec.uuid)) continue;
+        this.rememberUuid(rec.uuid);
+        fallback = rec;
         continue;
       }
       const serving = servingModelFromAssistantEvent(ev);

--- a/src/services/claude-transcript.ts
+++ b/src/services/claude-transcript.ts
@@ -120,6 +120,13 @@ export function normalizeClaudeModelId(value: string | undefined): string | unde
   return normalized || undefined;
 }
 
+/** True when a model id names a Fable model, whatever its case or context
+ *  suffix (`claude-fable-5-1[1m]`, `Claude-Fable-5[1M]`, …). The single place
+ *  the product's "Fable only" scope is expressed. */
+export function isFableModelId(value: string | undefined): boolean {
+  return normalizeClaudeModelId(value)?.startsWith('claude-fable') === true;
+}
+
 /** Parse a `type:"system"` model-switch record. Returns undefined for anything
  *  else, and fail-closed for a record missing the uuid or either model id —
  *  a half-written switch must not produce a notice we can never clear. */
@@ -135,6 +142,12 @@ export function parseClaudeModelFallbackEvent(
   const originalModel = typeof ev.originalModel === 'string' ? ev.originalModel.trim() : '';
   const fallbackModel = typeof ev.fallbackModel === 'string' ? ev.fallbackModel.trim() : '';
   if (!uuid || !originalModel || !fallbackModel) return undefined;
+  // PRODUCT DECISION: only a fall *off Fable* is surfaced. Claude Code also
+  // records ordinary safety downgrades between non-Fable models (Opus 5 →
+  // Opus 4.8), which are routine and must stay invisible. Gating here rather
+  // than at each call site means observe() / the tail scan / every future
+  // consumer inherits the scope for free.
+  if (!isFableModelId(originalModel)) return undefined;
   const trigger = typeof ev.trigger === 'string' ? ev.trigger.trim() : '';
   const apiRefusalCategory = typeof ev.apiRefusalCategory === 'string'
     ? ev.apiRefusalCategory.trim()
@@ -165,28 +178,11 @@ export function servingModelFromAssistantEvent(ev: TranscriptEvent): string | un
   return model;
 }
 
-/** Resolve the model fallback still in effect from the newest session-scoped
- *  switch record plus the model serving replies AFTER it. A serving model that
- *  no longer matches means the user ran `/model` to switch back, so the notice
- *  clears. An unknown serving model (no assistant reply since the switch) keeps
- *  the notice — Claude stays on the fallback until told otherwise. */
-export function resolveActiveModelFallback(opts: {
-  fallback?: ClaudeModelFallbackRecord;
-  servingModel?: string;
-}): ModelFallbackState | null {
-  const rec = opts.fallback;
-  if (!rec || rec.scope === 'local') return null;
-  const serving = normalizeClaudeModelId(opts.servingModel);
-  if (serving && serving !== normalizeClaudeModelId(rec.fallbackModel)) return null;
-  return {
-    uuid: rec.uuid,
-    kind: rec.kind,
-    originalModel: rec.originalModel,
-    fallbackModel: rec.fallbackModel,
-    ...(rec.trigger ? { trigger: rec.trigger } : {}),
-    ...(rec.apiRefusalCategory ? { apiRefusalCategory: rec.apiRefusalCategory } : {}),
-    ...(rec.observedAt ? { observedAt: rec.observedAt } : {}),
-  };
+/** Drop the transcript-only `scope` field: what ships to the daemon and gets
+ *  persisted is the product state, not our parse bookkeeping. */
+export function modelFallbackStateOf(rec: ClaudeModelFallbackRecord): ModelFallbackState {
+  const { scope: _scope, ...state } = rec;
+  return state;
 }
 
 /** Upper bound on the backward scan below. Same guard rationale as
@@ -199,10 +195,12 @@ const CLAUDE_MODEL_FALLBACK_SCAN_MAX_BYTES = 4 * 1024 * 1024;
  *  before `--resume` / a daemon restart is never drained again.
  *
  *  Scans BACKWARD and stops at the newest session-scoped switch record; the
- *  serving model is therefore only collected from records NEWER than it, which
- *  is exactly what {@link resolveActiveModelFallback} needs (an assistant reply
- *  written before the switch says nothing about what serves now). A
- *  non-newline-terminated tail is excluded via baselineJsonlCursor. */
+ *  serving model is therefore only collected from records NEWER than it (an
+ *  assistant reply written before the switch says nothing about what serves
+ *  now). With no switch record in the window the serving model is simply the
+ *  window's newest one — still useful, because the daemon compares it against
+ *  the fallback IT persisted. A non-newline-terminated tail is excluded via
+ *  baselineJsonlCursor. */
 export function readLatestClaudeModelFallback(path: string): {
   fallback?: ClaudeModelFallbackRecord;
   servingModel?: string;
@@ -273,60 +271,91 @@ export function readLatestClaudeModelFallback(path: string): {
  *  times, so an unbounded set would leak slowly. */
 const MODEL_FALLBACK_SEEN_UUIDS_MAX = 256;
 
-/** Running model-fallback state for one Claude bridge. Owns the record-uuid
+/** One report from the worker to the daemon: OBSERVED FACTS ONLY, never a
+ *  decision. The worker cannot decide whether the notice should still show —
+ *  its transcript window is bounded and it is younger than the session — so it
+ *  says what it saw and the daemon, which holds the persisted state, merges:
+ *
+ *   - `fallback` — a switch record it had not reported before;
+ *   - `servingModel` — the model serving the MAIN thread, whenever that value
+ *     changed since its last report.
+ *
+ *  Absence of a field means "nothing new observed", never "cleared". */
+export interface ModelFallbackObservation {
+  fallback?: ModelFallbackState;
+  servingModel?: string;
+}
+
+/** Running model-fallback observer for one Claude bridge. Owns the record-uuid
  *  dedupe (the same record is re-drained after a truncation or a jsonl switch)
- *  and the "serving model since the switch" rule, leaving the worker with only
- *  the decision of when to publish. */
+ *  and the "only report the serving model when it changed" rule, so the worker
+ *  is left with nothing but "did I see anything worth sending". */
 export class ClaudeModelFallbackTracker {
   private readonly seenUuids = new Set<string>();
-  private fallback: ClaudeModelFallbackRecord | undefined;
-  private servingModel: string | undefined;
+  /** Last serving model reported to the daemon, normalised. `undefined` = none
+   *  reported yet in this worker's lifetime, so the first one always ships. */
+  private reportedServingModel: string | undefined;
 
-  /** Fold newly-drained events in, newest last. Returns the records newly
-   *  accepted, for the caller to log. `scope:"local"` records are skipped
-   *  outright: a sub-agent fell back on its own and the main session model is
-   *  untouched. */
-  observe(events: readonly TranscriptEvent[]): ClaudeModelFallbackRecord[] {
-    const accepted: ClaudeModelFallbackRecord[] = [];
+  /** Fold newly-drained events in, newest last, and return what the daemon has
+   *  not been told yet (or null when there is nothing new). `scope:"local"`
+   *  records are skipped outright: a sub-agent fell back on its own and the
+   *  main session model is untouched. Non-Fable switches never even parse (see
+   *  {@link parseClaudeModelFallbackEvent}). */
+  observe(events: readonly TranscriptEvent[]): ModelFallbackObservation | null {
+    let fallback: ClaudeModelFallbackRecord | undefined;
+    let servingModel: string | undefined;
     for (const ev of events) {
       const rec = parseClaudeModelFallbackEvent(ev);
       if (rec) {
         if (rec.scope === 'local' || this.seenUuids.has(rec.uuid)) continue;
-        this.seenUuids.add(rec.uuid);
-        if (this.seenUuids.size > MODEL_FALLBACK_SEEN_UUIDS_MAX) {
-          const oldest = this.seenUuids.values().next().value;
-          if (oldest !== undefined) this.seenUuids.delete(oldest);
-        }
-        this.fallback = rec;
-        // Replies written before the switch say nothing about what serves now;
-        // keeping the old value would clear the notice the instant it appeared.
-        this.servingModel = undefined;
-        accepted.push(rec);
+        this.rememberUuid(rec.uuid);
+        fallback = rec;
+        // Replies written BEFORE the switch say nothing about what serves now;
+        // shipping one alongside the switch would make the daemon clear the
+        // notice the instant it appeared.
+        servingModel = undefined;
         continue;
       }
       const serving = servingModelFromAssistantEvent(ev);
-      if (serving) this.servingModel = serving;
+      if (serving) servingModel = serving;
     }
-    return accepted;
+    return this.report(fallback, servingModel);
   }
 
-  /** Recover the state from a transcript tail at bridge start (see
-   *  {@link readLatestClaudeModelFallback}). */
-  seed(path: string): void {
+  /** Recover what the transcript tail can show at bridge start (see
+   *  {@link readLatestClaudeModelFallback}) and report it verbatim. A scan that
+   *  finds nothing reports nothing — a short window is not evidence that the
+   *  daemon's persisted notice is stale. */
+  seed(path: string): ModelFallbackObservation | null {
     const seeded = readLatestClaudeModelFallback(path);
-    if (seeded.fallback) {
-      this.fallback = seeded.fallback;
-      this.seenUuids.add(seeded.fallback.uuid);
+    let fallback: ClaudeModelFallbackRecord | undefined;
+    if (seeded.fallback && !this.seenUuids.has(seeded.fallback.uuid)) {
+      this.rememberUuid(seeded.fallback.uuid);
+      fallback = seeded.fallback;
     }
-    this.servingModel = seeded.servingModel;
+    return this.report(fallback, seeded.servingModel);
   }
 
-  /** The fallback still in effect, or null. */
-  current(): ModelFallbackState | null {
-    return resolveActiveModelFallback({
-      fallback: this.fallback,
-      servingModel: this.servingModel,
-    });
+  private report(
+    fallback: ClaudeModelFallbackRecord | undefined,
+    servingModel: string | undefined,
+  ): ModelFallbackObservation | null {
+    const normalized = normalizeClaudeModelId(servingModel);
+    const servingChanged = normalized !== undefined && normalized !== this.reportedServingModel;
+    if (servingChanged) this.reportedServingModel = normalized;
+    if (!fallback && !servingChanged) return null;
+    return {
+      ...(fallback ? { fallback: modelFallbackStateOf(fallback) } : {}),
+      ...(servingChanged && servingModel ? { servingModel } : {}),
+    };
+  }
+
+  private rememberUuid(uuid: string): void {
+    this.seenUuids.add(uuid);
+    if (this.seenUuids.size > MODEL_FALLBACK_SEEN_UUIDS_MAX) {
+      const oldest = this.seenUuids.values().next().value;
+      if (oldest !== undefined) this.seenUuids.delete(oldest);
+    }
   }
 }
 

--- a/src/services/claude-transcript.ts
+++ b/src/services/claude-transcript.ts
@@ -64,6 +64,11 @@ export interface TranscriptEvent {
   originalModel?: string;
   fallbackModel?: string;
   apiRefusalCategory?: string;
+  /** Claude Code ≥2.1.259 stamps this on a `model_refusal_fallback` copied into
+   *  a FORKED session: the record is history the fork inherited, and the switch
+   *  it describes does NOT apply to this conversation. Treated as positive
+   *  evidence of "no notice here", exactly like a non-Fable switch. */
+  neutralizedByFork?: boolean;
 }
 
 /**
@@ -106,9 +111,32 @@ const MODEL_FALLBACK_KIND_BY_SUBTYPE: Record<string, ClaudeModelFallbackKind> = 
 /** One parsed model-switch record. `scope: 'local'` is a sub-agent /
  *  side-question fallback: the main session model did NOT change, so surfacing
  *  it would mislead. Builds that predate the field omit it and read as
- *  'session'. */
+ *  'session'.
+ *
+ *  EVERY session-scoped switch parses, including the ones that must NOT raise a
+ *  notice — `fable: false` (a routine Opus 5 → Opus 4.8 downgrade) and
+ *  `neutralizedByFork` (a record a fork inherited). Dropping those at parse time
+ *  was a bug: the backward tail scan would step straight over the newest record
+ *  and resurrect an OLDER Fable one, so a notice the user had already left
+ *  behind came back. They are positive evidence of "no notice", which only the
+ *  newest record can express — see {@link noticeFromSessionRecord}. */
 export interface ClaudeModelFallbackRecord extends ModelFallbackState {
   scope: 'session' | 'local';
+  /** The configured model this switch fell OFF was a Fable one. Only a fall off
+   *  Fable is a product-visible notice. */
+  fable: boolean;
+  /** The record was copied into a fork and does not apply here. */
+  neutralizedByFork: boolean;
+}
+
+/** Product state the NEWEST session-scoped record implies: the record itself
+ *  when it is a live Fable fallback, or `null` when it says positively that no
+ *  notice applies here (fell off a non-Fable model, or a fork neutralised it).
+ *  `null` is evidence, not absence — the daemon clears on it. */
+function noticeFromSessionRecord(
+  rec: ClaudeModelFallbackRecord,
+): ClaudeModelFallbackRecord | null {
+  return rec.fable && !rec.neutralizedByFork ? rec : null;
 }
 
 /** Normalise a model id for comparison: drop a trailing context-window suffix
@@ -121,8 +149,10 @@ export function normalizeClaudeModelId(value: string | undefined): string | unde
 }
 
 /** True when a model id names a Fable model, whatever its case or context
- *  suffix (`claude-fable-5-1[1m]`, `Claude-Fable-5[1M]`, …). The single place
- *  the product's "Fable only" scope is expressed. */
+ *  suffix (`claude-fable-5-1[1m]`, `Claude-Fable-5[1M]`, …). The single
+ *  PREDICATE behind the product's "Fable only" scope: the parse records its
+ *  verdict on each switch as `fable`, and noticeFromSessionRecord is the only
+ *  place that turns it into "show / do not show". */
 export function isFableModelId(value: string | undefined): boolean {
   return normalizeClaudeModelId(value)?.startsWith('claude-fable') === true;
 }
@@ -142,12 +172,6 @@ export function parseClaudeModelFallbackEvent(
   const originalModel = typeof ev.originalModel === 'string' ? ev.originalModel.trim() : '';
   const fallbackModel = typeof ev.fallbackModel === 'string' ? ev.fallbackModel.trim() : '';
   if (!uuid || !originalModel || !fallbackModel) return undefined;
-  // PRODUCT DECISION: only a fall *off Fable* is surfaced. Claude Code also
-  // records ordinary safety downgrades between non-Fable models (Opus 5 →
-  // Opus 4.8), which are routine and must stay invisible. Gating here rather
-  // than at each call site means observe() / the tail scan / every future
-  // consumer inherits the scope for free.
-  if (!isFableModelId(originalModel)) return undefined;
   const trigger = typeof ev.trigger === 'string' ? ev.trigger.trim() : '';
   const apiRefusalCategory = typeof ev.apiRefusalCategory === 'string'
     ? ev.apiRefusalCategory.trim()
@@ -159,6 +183,13 @@ export function parseClaudeModelFallbackEvent(
     originalModel,
     fallbackModel,
     scope: ev.scope === 'local' ? 'local' : 'session',
+    // PRODUCT DECISION: only a fall *off Fable* is surfaced. Claude Code also
+    // records ordinary safety downgrades between non-Fable models (Opus 5 →
+    // Opus 4.8), which are routine and must stay invisible. Recorded as a flag
+    // rather than a parse rejection so the newest record still terminates the
+    // tail scan — see {@link ClaudeModelFallbackRecord}.
+    fable: isFableModelId(originalModel),
+    neutralizedByFork: ev.neutralizedByFork === true,
     ...(trigger ? { trigger } : {}),
     ...(apiRefusalCategory ? { apiRefusalCategory } : {}),
     ...(observedAt ? { observedAt } : {}),
@@ -178,10 +209,11 @@ export function servingModelFromAssistantEvent(ev: TranscriptEvent): string | un
   return model;
 }
 
-/** Drop the transcript-only `scope` field: what ships to the daemon and gets
- *  persisted is the product state, not our parse bookkeeping. */
+/** Drop the transcript-only parse bookkeeping (`scope`, `fable`,
+ *  `neutralizedByFork`): what ships to the daemon and gets persisted is the
+ *  product state. */
 export function modelFallbackStateOf(rec: ClaudeModelFallbackRecord): ModelFallbackState {
-  const { scope: _scope, ...state } = rec;
+  const { scope: _scope, fable: _fable, neutralizedByFork: _neutralized, ...state } = rec;
   return state;
 }
 
@@ -194,15 +226,23 @@ const CLAUDE_MODEL_FALLBACK_SCAN_MAX_BYTES = 4 * 1024 * 1024;
  *  worker's cold start: baseline cursors straight to EOF, so a switch recorded
  *  before `--resume` / a daemon restart is never drained again.
  *
- *  Scans BACKWARD and stops at the newest session-scoped switch record; the
- *  serving model is therefore only collected from records NEWER than it (an
- *  assistant reply written before the switch says nothing about what serves
+ *  Scans BACKWARD and stops at the newest session-scoped switch record — the
+ *  newest one DECIDES, whatever it says. When it is a live Fable fallback it is
+ *  returned; when it fell off a non-Fable model or a fork neutralised it, the
+ *  scan returns `fallback: null`, which is positive evidence that no notice
+ *  applies. Stepping over such a record to keep hunting for an older Fable one
+ *  (the previous behaviour) resurrects a notice the session already left
+ *  behind. `fallback` absent means the window simply held no session-scoped
+ *  record — no evidence either way.
+ *
+ *  The serving model is only collected from records NEWER than that stop point
+ *  (an assistant reply written before the switch says nothing about what serves
  *  now). With no switch record in the window the serving model is simply the
  *  window's newest one — still useful, because the daemon compares it against
  *  the fallback IT persisted. A non-newline-terminated tail is excluded via
  *  baselineJsonlCursor. */
 export function readLatestClaudeModelFallback(path: string): {
-  fallback?: ClaudeModelFallbackRecord;
+  fallback?: ClaudeModelFallbackRecord | null;
   servingModel?: string;
 } {
   if (!path || !existsSync(path)) return {};
@@ -210,10 +250,10 @@ export function readLatestClaudeModelFallback(path: string): {
   try { completeEnd = baselineJsonlCursor(path).newOffset; } catch { return {}; }
   if (completeEnd <= 0) return {};
 
-  let fallback: ClaudeModelFallbackRecord | undefined;
+  let fallback: ClaudeModelFallbackRecord | null | undefined;
   let servingModel: string | undefined;
   const emit = () => ({
-    ...(fallback ? { fallback } : {}),
+    ...(fallback !== undefined ? { fallback } : {}),
     ...(servingModel ? { servingModel } : {}),
   });
   const consider = (line: string): boolean => {
@@ -224,7 +264,7 @@ export function readLatestClaudeModelFallback(path: string): {
     const rec = parseClaudeModelFallbackEvent(ev);
     if (rec) {
       if (rec.scope === 'local') return false;
-      fallback = rec;
+      fallback = noticeFromSessionRecord(rec);
       return true;
     }
     if (!servingModel) servingModel = servingModelFromAssistantEvent(ev);
@@ -276,33 +316,75 @@ const MODEL_FALLBACK_SEEN_UUIDS_MAX = 256;
  *  its transcript window is bounded and it is younger than the session — so it
  *  says what it saw and the daemon, which holds the persisted state, merges:
  *
- *   - `fallback` — a switch record it had not reported before;
+ *   - `claudeSessionId` — WHICH Claude conversation these facts are about. The
+ *     state is per Claude session: `/repo`, `/adopt` and a resume onto another
+ *     native session all replace it, and state carried over from the previous
+ *     one is either a notice for a conversation this session is no longer
+ *     having or (worse) one that can never be cleared. Always present.
+ *   - `fallback` — a switch record it had not reported before, or `null` when
+ *     the newest session-scoped record is positive evidence that NO notice
+ *     applies (fell off a non-Fable model, or neutralised by a fork).
  *   - `servingModel` — the model serving the MAIN thread, whenever that value
- *     changed since its last report.
+ *     changed since its last report. Not gated on Fable: it also drives the
+ *     card's usage line, since Claude never emits `active_runtime`.
  *
- *  Absence of a field means "nothing new observed", never "cleared". */
+ *  An ABSENT `fallback` / `servingModel` means "nothing new observed", never
+ *  "cleared" — only `fallback: null`, or a `claudeSessionId` that disagrees
+ *  with the held state, clears. */
 export interface ModelFallbackObservation {
-  fallback?: ModelFallbackState;
+  claudeSessionId: string;
+  fallback?: ModelFallbackState | null;
   servingModel?: string;
 }
 
-/** Running model-fallback observer for one Claude bridge. Owns the record-uuid
- *  dedupe (the same record is re-drained after a truncation or a jsonl switch)
- *  and the "only report the serving model when it changed" rule, so the worker
- *  is left with nothing but "did I see anything worth sending". */
+/** Running model-fallback observer for ONE Claude session. Owns the record-uuid
+ *  dedupe (the same record is re-drained after a truncation or a jsonl switch),
+ *  the "only report the serving model when it changed" rule, and the binding to
+ *  the Claude session id all of that describes — so the worker is left with
+ *  nothing but "did I see anything worth sending". */
 export class ClaudeModelFallbackTracker {
+  /** Claude session (jsonl basename) every remembered fact belongs to. Empty
+   *  until the first {@link bind}. */
+  private claudeSessionId = '';
   private readonly seenUuids = new Set<string>();
   /** Last serving model reported to the daemon, normalised. `undefined` = none
-   *  reported yet in this worker's lifetime, so the first one always ships. */
+   *  reported yet for the bound session, so the first one always ships. */
   private reportedServingModel: string | undefined;
+
+  get boundClaudeSessionId(): string {
+    return this.claudeSessionId;
+  }
+
+  /** Bind to `claudeSessionId`, returning true when that was a SWITCH. A
+   *  different id means the bridge moved to another Claude conversation
+   *  (`/repo`, `/adopt`, a resume onto another native session, an in-pane
+   *  `/clear`): every uuid we deduped and every serving model we reported
+   *  describes the old one, so all of it is dropped. Without this the new
+   *  session inherits the old one's notice, and — when its real model happens
+   *  to equal the old fallback — the serving-model dedupe swallows the very
+   *  observation that would have cleared it, leaving a false notice that
+   *  survives restarts. */
+  bind(claudeSessionId: string): boolean {
+    if (claudeSessionId === this.claudeSessionId) return false;
+    this.claudeSessionId = claudeSessionId;
+    this.reset();
+    return true;
+  }
+
+  /** Forget everything remembered about the bound session. */
+  reset(): void {
+    this.seenUuids.clear();
+    this.reportedServingModel = undefined;
+  }
 
   /** Fold newly-drained events in, newest last, and return what the daemon has
    *  not been told yet (or null when there is nothing new). `scope:"local"`
    *  records are skipped outright: a sub-agent fell back on its own and the
-   *  main session model is untouched. Non-Fable switches never even parse (see
-   *  {@link parseClaudeModelFallbackEvent}). */
+   *  main session model is untouched. A session-scoped record that is NOT a
+   *  live Fable fallback still counts — it reports `fallback: null`, the
+   *  positive "no notice here" the daemon clears on. */
   observe(events: readonly TranscriptEvent[]): ModelFallbackObservation | null {
-    let fallback: ClaudeModelFallbackRecord | undefined;
+    let fallback: ClaudeModelFallbackRecord | null | undefined;
     let servingModel: string | undefined;
     for (const ev of events) {
       const rec = parseClaudeModelFallbackEvent(ev);
@@ -318,8 +400,8 @@ export class ClaudeModelFallbackTracker {
         // "Claude answered on a different model".
         servingModel = undefined;
         if (this.seenUuids.has(rec.uuid)) continue;
-        this.rememberUuid(rec.uuid);
-        fallback = rec;
+        this.acceptSwitch(rec.uuid);
+        fallback = noticeFromSessionRecord(rec);
         continue;
       }
       const serving = servingModelFromAssistantEvent(ev);
@@ -328,30 +410,58 @@ export class ClaudeModelFallbackTracker {
     return this.report(fallback, servingModel);
   }
 
-  /** Recover what the transcript tail can show at bridge start (see
-   *  {@link readLatestClaudeModelFallback}) and report it verbatim. A scan that
-   *  finds nothing reports nothing — a short window is not evidence that the
-   *  daemon's persisted notice is stale. */
-  seed(path: string): ModelFallbackObservation | null {
+  /** Bind to `claudeSessionId` and report what the transcript tail can show
+   *  (see {@link readLatestClaudeModelFallback}).
+   *
+   *  ALWAYS returns an observation, even when the scan found nothing at all.
+   *  The empty one is not a claim that the daemon's notice is stale — it is the
+   *  worker declaring WHICH Claude session it is now bridging, which is the
+   *  only way state left over from a different one can be dropped. The daemon
+   *  ignores an empty message whose `claudeSessionId` matches what it holds, so
+   *  a plain worker restart still costs nothing. */
+  seed(path: string, claudeSessionId: string): ModelFallbackObservation {
+    this.bind(claudeSessionId);
     const seeded = readLatestClaudeModelFallback(path);
-    let fallback: ClaudeModelFallbackRecord | undefined;
-    if (seeded.fallback && !this.seenUuids.has(seeded.fallback.uuid)) {
-      this.rememberUuid(seeded.fallback.uuid);
+    let fallback: ClaudeModelFallbackRecord | null | undefined;
+    if (seeded.fallback === null) {
+      // No uuid to dedupe on, and none needed: re-sending the same "no notice"
+      // is a no-op at the daemon (it lands on the state it already holds).
+      fallback = null;
+    } else if (seeded.fallback && !this.seenUuids.has(seeded.fallback.uuid)) {
+      this.acceptSwitch(seeded.fallback.uuid);
       fallback = seeded.fallback;
     }
-    return this.report(fallback, seeded.servingModel);
+    return this.report(fallback, seeded.servingModel)
+      ?? { claudeSessionId: this.claudeSessionId };
+  }
+
+  /** Take a session-scoped switch record we had not seen before.
+   *
+   *  Resetting `reportedServingModel` here is what keeps a switch BACK visible:
+   *  one drain can carry the whole story (fall off Fable → an Opus reply → the
+   *  user switches back → a Fable reply). Without the reset the batch's closing
+   *  Fable equals the model reported before the fall, gets deduped as
+   *  "unchanged", and the daemon receives the fallback with no clearing
+   *  evidence — a notice that hangs forever. The first serving model observed
+   *  after a switch must always ship, even when its value is old news. */
+  private acceptSwitch(uuid: string): void {
+    this.rememberUuid(uuid);
+    this.reportedServingModel = undefined;
   }
 
   private report(
-    fallback: ClaudeModelFallbackRecord | undefined,
+    fallback: ClaudeModelFallbackRecord | null | undefined,
     servingModel: string | undefined,
   ): ModelFallbackObservation | null {
     const normalized = normalizeClaudeModelId(servingModel);
     const servingChanged = normalized !== undefined && normalized !== this.reportedServingModel;
     if (servingChanged) this.reportedServingModel = normalized;
-    if (!fallback && !servingChanged) return null;
+    if (fallback === undefined && !servingChanged) return null;
     return {
-      ...(fallback ? { fallback: modelFallbackStateOf(fallback) } : {}),
+      claudeSessionId: this.claudeSessionId,
+      ...(fallback !== undefined
+        ? { fallback: fallback === null ? null : modelFallbackStateOf(fallback) }
+        : {}),
       ...(servingChanged && servingModel ? { servingModel } : {}),
     };
   }

--- a/src/services/claude-transcript.ts
+++ b/src/services/claude-transcript.ts
@@ -13,6 +13,8 @@
  */
 import { existsSync, openSync, readSync, closeSync, statSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { baselineJsonlCursor } from './jsonl-cursor.js';
+import type { ModelFallbackState } from '../types.js';
 
 /** Subset of Claude Code's JSONL event shape we care about. */
 export interface TranscriptEvent {
@@ -27,6 +29,9 @@ export interface TranscriptEvent {
     /** Claude's API stop reason. `tool_use` is an intra-turn pause; terminal
      * reasons such as `end_turn` / `stop_sequence` close the logical turn. */
     stop_reason?: string | null;
+    /** Model that actually served this reply (e.g. `claude-opus-4-8`). Claude
+     *  Code writes the placeholder `<synthetic>` on API-error records. */
+    model?: string;
   };
   /** API-error records. When the model call fails, Claude Code writes a
    *  `type:"assistant"` line with `isApiErrorMessage:true` and a machine
@@ -51,6 +56,14 @@ export interface TranscriptEvent {
     prompt?: unknown;
     commandMode?: string;
   };
+  /** Present on `type:"system"` model-switch records (see
+   *  {@link parseClaudeModelFallbackEvent}). `scope:"local"` marks a sub-agent /
+   *  side-question fallback that leaves the main session model untouched. */
+  scope?: string;
+  trigger?: string;
+  originalModel?: string;
+  fallbackModel?: string;
+  apiRefusalCategory?: string;
 }
 
 /**
@@ -78,6 +91,243 @@ export function apiErrorMessageText(ev: TranscriptEvent): string {
       .join(' ');
   }
   return '';
+}
+
+/** Kind of automatic model switch Claude Code recorded, mapped from the raw
+ *  `type:"system"` subtype so the card copy can branch on one stable value. */
+export type ClaudeModelFallbackKind = 'refusal' | 'unavailable' | 'consent';
+
+const MODEL_FALLBACK_KIND_BY_SUBTYPE: Record<string, ClaudeModelFallbackKind> = {
+  model_refusal_fallback: 'refusal',
+  model_fallback: 'unavailable',
+  model_consent_fallback: 'consent',
+};
+
+/** One parsed model-switch record. `scope: 'local'` is a sub-agent /
+ *  side-question fallback: the main session model did NOT change, so surfacing
+ *  it would mislead. Builds that predate the field omit it and read as
+ *  'session'. */
+export interface ClaudeModelFallbackRecord extends ModelFallbackState {
+  scope: 'session' | 'local';
+}
+
+/** Normalise a model id for comparison: drop a trailing context-window suffix
+ *  and lower-case. `originalModel` is written as `claude-fable-5-1[1m]` while an
+ *  assistant record's `message.model` is the bare `claude-fable-5-1`; without
+ *  this the "user switched back" check can never fire. */
+export function normalizeClaudeModelId(value: string | undefined): string | undefined {
+  const normalized = value?.trim().replace(/\[[^\]]*\]$/, '').trim().toLowerCase();
+  return normalized || undefined;
+}
+
+/** Parse a `type:"system"` model-switch record. Returns undefined for anything
+ *  else, and fail-closed for a record missing the uuid or either model id —
+ *  a half-written switch must not produce a notice we can never clear. */
+export function parseClaudeModelFallbackEvent(
+  ev: TranscriptEvent,
+): ClaudeModelFallbackRecord | undefined {
+  if (!ev || typeof ev !== 'object' || ev.type !== 'system') return undefined;
+  const kind = typeof ev.subtype === 'string'
+    ? MODEL_FALLBACK_KIND_BY_SUBTYPE[ev.subtype]
+    : undefined;
+  if (!kind) return undefined;
+  const uuid = typeof ev.uuid === 'string' ? ev.uuid.trim() : '';
+  const originalModel = typeof ev.originalModel === 'string' ? ev.originalModel.trim() : '';
+  const fallbackModel = typeof ev.fallbackModel === 'string' ? ev.fallbackModel.trim() : '';
+  if (!uuid || !originalModel || !fallbackModel) return undefined;
+  const trigger = typeof ev.trigger === 'string' ? ev.trigger.trim() : '';
+  const apiRefusalCategory = typeof ev.apiRefusalCategory === 'string'
+    ? ev.apiRefusalCategory.trim()
+    : '';
+  const observedAt = typeof ev.timestamp === 'string' ? ev.timestamp.trim() : '';
+  return {
+    uuid,
+    kind,
+    originalModel,
+    fallbackModel,
+    scope: ev.scope === 'local' ? 'local' : 'session',
+    ...(trigger ? { trigger } : {}),
+    ...(apiRefusalCategory ? { apiRefusalCategory } : {}),
+    ...(observedAt ? { observedAt } : {}),
+  };
+}
+
+/** Model that actually served an assistant record. Sub-agent output, API-error
+ *  placeholders and Claude's `<synthetic>` sentinel are not the main session's
+ *  model, so they yield undefined rather than a false "model changed". */
+export function servingModelFromAssistantEvent(ev: TranscriptEvent): string | undefined {
+  if (!ev || typeof ev !== 'object') return undefined;
+  if ((ev as any).isSidechain === true) return undefined;
+  if (ev.isApiErrorMessage === true || isTranscriptRateLimitEvent(ev)) return undefined;
+  if ((ev.message?.role ?? ev.type) !== 'assistant') return undefined;
+  const model = ev.message?.model?.trim();
+  if (!model || model === '<synthetic>') return undefined;
+  return model;
+}
+
+/** Resolve the model fallback still in effect from the newest session-scoped
+ *  switch record plus the model serving replies AFTER it. A serving model that
+ *  no longer matches means the user ran `/model` to switch back, so the notice
+ *  clears. An unknown serving model (no assistant reply since the switch) keeps
+ *  the notice — Claude stays on the fallback until told otherwise. */
+export function resolveActiveModelFallback(opts: {
+  fallback?: ClaudeModelFallbackRecord;
+  servingModel?: string;
+}): ModelFallbackState | null {
+  const rec = opts.fallback;
+  if (!rec || rec.scope === 'local') return null;
+  const serving = normalizeClaudeModelId(opts.servingModel);
+  if (serving && serving !== normalizeClaudeModelId(rec.fallbackModel)) return null;
+  return {
+    uuid: rec.uuid,
+    kind: rec.kind,
+    originalModel: rec.originalModel,
+    fallbackModel: rec.fallbackModel,
+    ...(rec.trigger ? { trigger: rec.trigger } : {}),
+    ...(rec.apiRefusalCategory ? { apiRefusalCategory: rec.apiRefusalCategory } : {}),
+    ...(rec.observedAt ? { observedAt: rec.observedAt } : {}),
+  };
+}
+
+/** Upper bound on the backward scan below. Same guard rationale as
+ *  TRAEX_RUNTIME_SCAN_MAX_BYTES: the fallback notice is advisory and must never
+ *  synchronously parse a multi-GB transcript at bridge start. */
+const CLAUDE_MODEL_FALLBACK_SCAN_MAX_BYTES = 4 * 1024 * 1024;
+
+/** Recover the current model-fallback state from a transcript's tail, for the
+ *  worker's cold start: baseline cursors straight to EOF, so a switch recorded
+ *  before `--resume` / a daemon restart is never drained again.
+ *
+ *  Scans BACKWARD and stops at the newest session-scoped switch record; the
+ *  serving model is therefore only collected from records NEWER than it, which
+ *  is exactly what {@link resolveActiveModelFallback} needs (an assistant reply
+ *  written before the switch says nothing about what serves now). A
+ *  non-newline-terminated tail is excluded via baselineJsonlCursor. */
+export function readLatestClaudeModelFallback(path: string): {
+  fallback?: ClaudeModelFallbackRecord;
+  servingModel?: string;
+} {
+  if (!path || !existsSync(path)) return {};
+  let completeEnd: number;
+  try { completeEnd = baselineJsonlCursor(path).newOffset; } catch { return {}; }
+  if (completeEnd <= 0) return {};
+
+  let fallback: ClaudeModelFallbackRecord | undefined;
+  let servingModel: string | undefined;
+  const emit = () => ({
+    ...(fallback ? { fallback } : {}),
+    ...(servingModel ? { servingModel } : {}),
+  });
+  const consider = (line: string): boolean => {
+    if (!line.trim()) return false;
+    let ev: TranscriptEvent;
+    try { ev = JSON.parse(line) as TranscriptEvent; } catch { return false; }
+    if (!ev || typeof ev !== 'object') return false;
+    const rec = parseClaudeModelFallbackEvent(ev);
+    if (rec) {
+      if (rec.scope === 'local') return false;
+      fallback = rec;
+      return true;
+    }
+    if (!servingModel) servingModel = servingModelFromAssistantEvent(ev);
+    return false;
+  };
+
+  const floor = Math.max(0, completeEnd - CLAUDE_MODEL_FALLBACK_SCAN_MAX_BYTES);
+  const chunkBytes = 64 * 1024;
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, 'r');
+    let end = completeEnd;
+    let carry = Buffer.alloc(0);
+    while (end > floor) {
+      const start = Math.max(floor, end - chunkBytes);
+      const chunk = Buffer.alloc(end - start);
+      readSync(fd, chunk, 0, chunk.length, start);
+      const block = carry.length > 0 ? Buffer.concat([chunk, carry]) : chunk;
+      let lineEnd = block.length;
+      if (lineEnd > 0 && block[lineEnd - 1] === 0x0a) lineEnd--;
+      let carryEnd = lineEnd;
+      for (let i = lineEnd - 1; i >= 0; i--) {
+        if (block[i] !== 0x0a) continue;
+        const line = block.subarray(i + 1, lineEnd).toString('utf8');
+        lineEnd = i;
+        carryEnd = i;
+        if (consider(line)) return emit();
+      }
+      // Drop the leading fragment only at the byte-cap floor (a truncated
+      // historical partial); at true file start it is a complete record.
+      carry = start === floor && floor > 0 ? Buffer.alloc(0) : block.subarray(0, carryEnd);
+      end = start;
+    }
+    if (carry.length > 0) consider(carry.toString('utf8'));
+  } catch {
+    return emit();
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+  return emit();
+}
+
+/** Bound on the tracker's dedupe set. A long session can switch models many
+ *  times, so an unbounded set would leak slowly. */
+const MODEL_FALLBACK_SEEN_UUIDS_MAX = 256;
+
+/** Running model-fallback state for one Claude bridge. Owns the record-uuid
+ *  dedupe (the same record is re-drained after a truncation or a jsonl switch)
+ *  and the "serving model since the switch" rule, leaving the worker with only
+ *  the decision of when to publish. */
+export class ClaudeModelFallbackTracker {
+  private readonly seenUuids = new Set<string>();
+  private fallback: ClaudeModelFallbackRecord | undefined;
+  private servingModel: string | undefined;
+
+  /** Fold newly-drained events in, newest last. Returns the records newly
+   *  accepted, for the caller to log. `scope:"local"` records are skipped
+   *  outright: a sub-agent fell back on its own and the main session model is
+   *  untouched. */
+  observe(events: readonly TranscriptEvent[]): ClaudeModelFallbackRecord[] {
+    const accepted: ClaudeModelFallbackRecord[] = [];
+    for (const ev of events) {
+      const rec = parseClaudeModelFallbackEvent(ev);
+      if (rec) {
+        if (rec.scope === 'local' || this.seenUuids.has(rec.uuid)) continue;
+        this.seenUuids.add(rec.uuid);
+        if (this.seenUuids.size > MODEL_FALLBACK_SEEN_UUIDS_MAX) {
+          const oldest = this.seenUuids.values().next().value;
+          if (oldest !== undefined) this.seenUuids.delete(oldest);
+        }
+        this.fallback = rec;
+        // Replies written before the switch say nothing about what serves now;
+        // keeping the old value would clear the notice the instant it appeared.
+        this.servingModel = undefined;
+        accepted.push(rec);
+        continue;
+      }
+      const serving = servingModelFromAssistantEvent(ev);
+      if (serving) this.servingModel = serving;
+    }
+    return accepted;
+  }
+
+  /** Recover the state from a transcript tail at bridge start (see
+   *  {@link readLatestClaudeModelFallback}). */
+  seed(path: string): void {
+    const seeded = readLatestClaudeModelFallback(path);
+    if (seeded.fallback) {
+      this.fallback = seeded.fallback;
+      this.seenUuids.add(seeded.fallback.uuid);
+    }
+    this.servingModel = seeded.servingModel;
+  }
+
+  /** The fallback still in effect, or null. */
+  current(): ModelFallbackState | null {
+    return resolveActiveModelFallback({
+      fallback: this.fallback,
+      servingModel: this.servingModel,
+    });
+  }
 }
 
 /** Provider-neutral terminal semantics derived from one Claude transcript

--- a/src/types.ts
+++ b/src/types.ts
@@ -1367,11 +1367,16 @@ export type WorkerToDaemon =
       model: string | null;
       reasoningEffort: string | null;
     }
-  /** Claude Code auto-switched the main session model, or the user switched
-   * back (`state: null`). The worker has already filtered `scope:"local"`
-   * sub-agent fallbacks, deduped by record uuid, and compared the serving model,
-   * so the daemon only stores and renders what arrives. */
-  | { type: 'model_fallback'; state: ModelFallbackState | null }
+  /** OBSERVED FACTS about Claude Code's automatic model switching — never a
+   * decision. `fallback` is a switch record this worker had not reported yet
+   * (already filtered to `scope:"session"` and to Fable originals);
+   * `servingModel` is the model serving the MAIN thread, sent whenever it
+   * changed since the worker's last report. The daemon holds the state and
+   * merges: a new record replaces, and ONLY a serving model different from the
+   * held `fallbackModel` clears. An absent field means "nothing new observed" —
+   * a worker restart or a too-short transcript window must never read as
+   * "cleared". */
+  | { type: 'model_fallback'; fallback?: ModelFallbackState; servingModel?: string }
   | { type: 'native_session_title_generated'; title: string }
   | {
     type: 'claude_exit';

--- a/src/types.ts
+++ b/src/types.ts
@@ -596,6 +596,10 @@ export interface Session {
   currentImageKey?: string;
   currentTurnTitle?: string;
   usageLimit?: CliUsageLimitState;
+  /** Model fallback in effect. Persisted alongside usageLimit because the
+   *  worker's baseline cursors to EOF after a restart — the switch record is
+   *  already history by then and would never be drained again. */
+  modelFallback?: ModelFallbackState;
   lastUserPrompt?: string;
   lastCliInput?: string;
   /** Structured companion for lastCliInput so retry_last_task can preserve a
@@ -1284,6 +1288,29 @@ export type CotEntry =
   | { kind: 'tool_call'; id: string; name: string; args: string }
   | { kind: 'tool_result'; id: string; result: string };
 
+/** A Claude model switch that is still in effect: Claude Code fell back off the
+ *  configured model and every later reply is served by `fallbackModel` until the
+ *  user runs `/model` to switch back. Observed by the worker from the session
+ *  transcript, persisted on the Session, and rendered as one notice line on the
+ *  live card. */
+export interface ModelFallbackState {
+  /** uuid of the transcript record that caused the switch — the stable key for
+   *  dedupe and for "is this still the same switch". */
+  uuid: string;
+  /** 'refusal' = safety guardrails, 'unavailable' = model not usable,
+   *  'consent' = quota/billing confirmation. */
+  kind: 'refusal' | 'unavailable' | 'consent';
+  /** Configured model, as written in the transcript (e.g. `claude-fable-5-1[1m]`). */
+  originalModel: string;
+  /** Model now serving the session (e.g. `claude-opus-4-8[1m]`). */
+  fallbackModel: string;
+  /** Raw reason for a non-refusal switch: `overloaded`, `model_not_found`, … */
+  trigger?: string;
+  /** Refusal category (`cyber`, `bio`, …). */
+  apiRefusalCategory?: string;
+  observedAt?: string;
+}
+
 /** Messages sent from Worker to Daemon */
 export type WorkerToDaemon =
   | {
@@ -1340,6 +1367,11 @@ export type WorkerToDaemon =
       model: string | null;
       reasoningEffort: string | null;
     }
+  /** Claude Code auto-switched the main session model, or the user switched
+   * back (`state: null`). The worker has already filtered `scope:"local"`
+   * sub-agent fallbacks, deduped by record uuid, and compared the serving model,
+   * so the daemon only stores and renders what arrives. */
+  | { type: 'model_fallback'; state: ModelFallbackState | null }
   | { type: 'native_session_title_generated'; title: string }
   | {
     type: 'claude_exit';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1309,6 +1309,14 @@ export interface ModelFallbackState {
   /** Refusal category (`cyber`, `bio`, …). */
   apiRefusalCategory?: string;
   observedAt?: string;
+  /** Claude session (transcript jsonl basename) this switch happened in. The
+   *  notice is per Claude conversation, not per botmux session: `/repo`,
+   *  `/adopt` and a resume onto another native session all replace it, and a
+   *  record carried across that boundary is either a warning about a
+   *  conversation the user is no longer having or one nothing can ever clear.
+   *  Absent on state persisted by builds that predate the binding; the next
+   *  worker's mandatory seed re-establishes it. */
+  claudeSessionId?: string;
 }
 
 /** Messages sent from Worker to Daemon */
@@ -1368,15 +1376,24 @@ export type WorkerToDaemon =
       reasoningEffort: string | null;
     }
   /** OBSERVED FACTS about Claude Code's automatic model switching — never a
-   * decision. `fallback` is a switch record this worker had not reported yet
-   * (already filtered to `scope:"session"` and to Fable originals);
-   * `servingModel` is the model serving the MAIN thread, sent whenever it
-   * changed since the worker's last report. The daemon holds the state and
-   * merges: a new record replaces, and ONLY a serving model different from the
-   * held `fallbackModel` clears. An absent field means "nothing new observed" —
-   * a worker restart or a too-short transcript window must never read as
-   * "cleared". */
-  | { type: 'model_fallback'; fallback?: ModelFallbackState; servingModel?: string }
+   * decision. `claudeSessionId` (always present) says WHICH Claude conversation
+   * they are about; `fallback` is a `scope:"session"` switch record this worker
+   * had not reported yet, or `null` when the newest such record is positive
+   * evidence that no notice applies (a non-Fable original, or one a fork
+   * neutralised); `servingModel` is the model serving the MAIN thread, sent
+   * whenever it changed since the worker's last report — it also drives the
+   * card's usage line, because Claude never emits `active_runtime`. The daemon
+   * holds the state and merges: a message from a different Claude session drops
+   * what it held first, a new record replaces, `fallback: null` clears, and a
+   * serving model different from the held `fallbackModel` clears. An ABSENT
+   * field means "nothing new observed" — a worker restart or a too-short
+   * transcript window must never read as "cleared". */
+  | {
+      type: 'model_fallback';
+      claudeSessionId: string;
+      fallback?: ModelFallbackState | null;
+      servingModel?: string;
+    }
   | { type: 'native_session_title_generated'; title: string }
   | {
     type: 'claude_exit';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5534,6 +5534,13 @@ function bridgeIngest(): void {
     // Lazy baseline: file didn't exist at attach, baseline the moment it does.
     if (!existsSyncSafe(bridgeJsonlPath)) return;
     bridgeAbsorbBaseline();
+    // Seed for the same reason startBridgeWatcher seeds after ITS baseline:
+    // this one also skips the file's existing records — to EOF in the non-adopt
+    // branch, and in the adopt branch straight into bridgeQueue.absorb() rather
+    // than through observeModelFallback. Either way a switch already written to
+    // the file would never be seen. The tail scan is idempotent: re-seeding the
+    // same record is deduped by uuid and publishes nothing.
+    seedModelFallbackFromTranscript();
     return;
   }
   const result = drainTranscript(bridgeJsonlPath, bridgeOffset);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -61,7 +61,7 @@ import { roleLibraryRoot, roleLibrarySubtree } from './core/role-library.js';
 // Central no-transport predicate. Aliased because a local `const larkTransportEnabled`
 // (the role-library gate) already binds that name in one function scope.
 import { larkTransportEnabled as sessionLarkTransportEnabled } from './core/types.js';
-import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, extractCotEntries, type TranscriptEvent } from './services/claude-transcript.js';
+import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, extractCotEntries, ClaudeModelFallbackTracker, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint, type BridgePendingTurn } from './services/bridge-turn-queue.js';
 import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, structuredFallbackKind, stripTrailingOaiMemoryCitation, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { buildSubmitMessagePreview } from './services/submit-notification.js';
@@ -244,6 +244,7 @@ import type {
   DaemonToWorker,
   WorkerToDaemon,
   DisplayMode,
+  ModelFallbackState,
   TermActionKey,
   ScreenStatus,
   TrustedCaller,
@@ -4252,6 +4253,13 @@ const bridgeRestoreGate = new BridgeRestoreGate();
  *  `limited` emit. Readers may re-read from offset 0 after rotation, so the
  *  stable record uuid keeps the notification idempotent. */
 const emittedRateLimitUuids = new Set<string>();
+/** Claude Code's automatic model switches for this bridge (uuid dedupe +
+ *  serving-model tracking live in the tracker). */
+const modelFallbackTracker = new ClaudeModelFallbackTracker();
+/** Last state pushed to the daemon (`null` = "no fallback"). `undefined` means
+ *  nothing pushed yet, so the first resolve always publishes — that initial
+ *  `null` is what clears a stale persisted notice. */
+let publishedModelFallback: ModelFallbackState | null | undefined;
 let bridgeWatcher: FSWatcher | null = null;
 let bridgeFallbackTimer: NodeJS.Timeout | null = null;
 let herdrAdoptBridgeQuietTimer: NodeJS.Timeout | null = null;
@@ -5538,6 +5546,7 @@ function bridgeIngest(): void {
   // signal — read it here (event-driven, once per record) instead of scraping
   // the TUI. The queue already skips it as an assistant reply.
   maybeEmitStructuredRateLimit(result.events);
+  observeModelFallback(result.events);
   // Transcript terminal markers are authoritative and may settle a durable
   // turn immediately. Do not wait for the screen prompt: permission/AskUser
   // surfaces can resemble idle, while an explicit JSONL boundary cannot.
@@ -5571,6 +5580,40 @@ function maybeEmitStructuredRateLimit(events: readonly TranscriptEvent[]): void 
     log(`Structured rate-limit detected in Claude transcript (uuid=${ev.uuid.substring(0, 8)}, retryLabel=${usageLimit.retryLabel}) → emitted limited state.`);
     return; // one limited emit per ingest is enough; state key is stable
   }
+}
+
+/** Fold newly-drained events into the model-fallback tracker and push the
+ *  resulting state to the daemon whenever it changes. Claude-only by
+ *  construction: bridgeIngest is the Claude bridge. */
+function observeModelFallback(events: readonly TranscriptEvent[]): void {
+  for (const rec of modelFallbackTracker.observe(events)) {
+    log(`Claude model fallback observed (kind=${rec.kind}, ${rec.originalModel} → ${rec.fallbackModel}, trigger=${rec.trigger ?? 'n/a'})`);
+  }
+  publishModelFallbackIfChanged();
+}
+
+/** Emit the resolved state only when it actually changed — bridgeIngest runs on
+ *  every fs.watch wakeup and once a second besides. Idempotent, so the baseline
+ *  seed and the incremental path can both call it. */
+function publishModelFallbackIfChanged(): void {
+  const state = modelFallbackTracker.current();
+  if (publishedModelFallback !== undefined && publishedModelFallback?.uuid === state?.uuid) return;
+  publishedModelFallback = state;
+  send({ type: 'model_fallback', state });
+}
+
+/** Seed the fallback state at bridge start. Baseline cursors to EOF, so a
+ *  switch recorded before `--resume` or a daemon restart is never drained;
+ *  a bounded backward scan recovers it (same shape as Codex/TRAE runtime
+ *  seeding). Always publishes, including `null` — the user may have switched
+ *  back while the daemon was down, and that has to overwrite the persisted
+ *  notice. */
+function seedModelFallbackFromTranscript(): void {
+  if (bridgeJsonlPath) {
+    try { modelFallbackTracker.seed(bridgeJsonlPath); }
+    catch (err: any) { log(`Model fallback seed skipped: ${err?.message ?? err}`); }
+  }
+  publishModelFallbackIfChanged();
 }
 
 function performBridgeIngestAndScheduleQuietEmit(): void {
@@ -5662,6 +5705,7 @@ function startBridgeWatcher(jsonlPath: string, opts?: { cliPid?: number; cliCwd?
   } else {
     log(`Bridge transcript not yet present at ${bridgeJsonlPath}; will baseline on first appearance`);
   }
+  seedModelFallbackFromTranscript();
   // fs.watch is best-effort wakeup — actual data source is the byte offset.
   // The fallback poller covers fs.watch's gaps (NFS, rename-rotation, etc.)
   // and also drives lazy baseline when the file shows up after attach.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4252,9 +4252,11 @@ const bridgeRestoreGate = new BridgeRestoreGate();
  *  `limited` emit. Readers may re-read from offset 0 after rotation, so the
  *  stable record uuid keeps the notification idempotent. */
 const emittedRateLimitUuids = new Set<string>();
-/** Claude Code's automatic model switches for this bridge (uuid dedupe +
- *  "only report the serving model when it changed" live in the tracker). The
- *  worker reports observations only; the daemon owns the state and decides. */
+/** Claude Code's automatic model switches for this bridge. The tracker owns the
+ *  binding to the CURRENT Claude session id, the record-uuid dedupe and the
+ *  "only report the serving model when it changed" rule; every transcript drain
+ *  reaches it through observeModelFallbackEvents. The worker reports
+ *  observations only — the daemon owns the state and decides. */
 const modelFallbackTracker = new ClaudeModelFallbackTracker();
 let bridgeWatcher: FSWatcher | null = null;
 let bridgeFallbackTimer: NodeJS.Timeout | null = null;
@@ -4860,6 +4862,7 @@ function bridgeAbsorbBaseline(): void {
   bridgeOffset = result.newOffset;
   bridgePendingTail = result.pendingTail;
   bridgeQueue.absorb(result.events);
+  observeModelFallbackEvents(bridgeJsonlPath, result.events);
   bridgeBaselineDone = true;
   // After absorb (uuids registered as seen so they won't re-emit as a Lark
   // turn), surface the last completed user/assistant exchange to Lark as a
@@ -4930,6 +4933,7 @@ function tryRestoreInterruptedBridgeTurns(): boolean {
   const { history, live } = splitTranscriptEventsByCutoff(drained.events, cutoffMs);
   bridgeQueue.absorb(history);
   if (live.length > 0) bridgeQueue.ingest(live, bridgeJsonlPath);
+  observeModelFallbackEvents(bridgeJsonlPath, drained.events);
   bridgeBaselineDone = true;
   log(`Bridge restored ${restorable.length} interrupted turn(s) from journal (drain ${fromOffset}→${bridgeOffset}, absorbed=${history.length}, live=${live.length})`);
   return true;
@@ -5002,6 +5006,11 @@ function bridgeApplyFingerprintSwitch(matched: string, reason: string, cutoffMs:
   const { history, live } = splitTranscriptEventsByCutoff(drained.events, cutoffMs);
   bridgeQueue.absorb(history);
   if (live.length > 0) bridgeQueue.ingest(live, matched);
+  // The switch moved us onto another Claude session: rebind the fallback
+  // tracker to it (seed always publishes, so the daemon drops whatever the
+  // previous session left behind) before folding this file's own events in.
+  seedModelFallbackFromTranscript();
+  observeModelFallbackEvents(matched, drained.events);
   bridgeBaselineDone = true;
   log(`Bridge fingerprint switch split: ${history.length} historical events absorbed, ${live.length} live events ingested (cutoff=${cutoffMs})`);
   bridgeRememberSessionIdForPath(matched);
@@ -5271,6 +5280,10 @@ function performRotationSwitch(newPath: string, cutoffMs: number, reason: string
   const { history, live } = splitTranscriptEventsByCutoff(result.events, cutoffMs);
   bridgeQueue.absorb(history);
   if (live.length > 0) bridgeQueue.ingest(live, newPath);
+  // Same as the fingerprint switch: rebind the fallback tracker to the Claude
+  // session we just rotated onto, then fold this file's own events in.
+  seedModelFallbackFromTranscript();
+  observeModelFallbackEvents(newPath, result.events);
   bridgeBaselineDone = true;
   log(`Bridge rotation split: ${history.length} historical events absorbed, ${live.length} live events ingested`);
 
@@ -5531,11 +5544,10 @@ function bridgeIngest(): void {
     if (!existsSyncSafe(bridgeJsonlPath)) return;
     bridgeAbsorbBaseline();
     // Seed for the same reason startBridgeWatcher seeds after ITS baseline:
-    // this one also skips the file's existing records — to EOF in the non-adopt
-    // branch, and in the adopt branch straight into bridgeQueue.absorb() rather
-    // than through observeModelFallback. Either way a switch already written to
-    // the file would never be seen. The tail scan is idempotent: re-seeding the
-    // same record is deduped by uuid and publishes nothing.
+    // the non-adopt branch cursors straight to EOF, so a switch already written
+    // to the file is never drained and only the tail scan can recover it. It
+    // also binds the tracker to this file's Claude session. Idempotent with the
+    // adopt branch's own observe: the same record is deduped by uuid.
     seedModelFallbackFromTranscript();
     return;
   }
@@ -5549,7 +5561,7 @@ function bridgeIngest(): void {
   // signal — read it here (event-driven, once per record) instead of scraping
   // the TUI. The queue already skips it as an assistant reply.
   maybeEmitStructuredRateLimit(result.events);
-  observeModelFallback(result.events);
+  observeModelFallbackEvents(bridgeJsonlPath, result.events);
   // Transcript terminal markers are authoritative and may settle a durable
   // turn immediately. Do not wait for the screen prompt: permission/AskUser
   // surfaces can resemble idle, while an explicit JSONL boundary cannot.
@@ -5585,36 +5597,75 @@ function maybeEmitStructuredRateLimit(events: readonly TranscriptEvent[]): void 
   }
 }
 
-/** Fold newly-drained events into the model-fallback tracker and report what
- *  the daemon has not been told yet. bridgeIngest is the Claude bridge, but the
- *  notice is a claude-code-only product affordance, so the cliId gate is
- *  explicit rather than implied by the call site. */
-function observeModelFallback(events: readonly TranscriptEvent[]): void {
+/** THE single entry every Claude transcript drain feeds — history and live
+ *  alike. bridgeIngest is only ONE of the drains that reach the bridge queue:
+ *  the adopt baseline, the journal restore, the fingerprint switch, the
+ *  fd-rotation switch, drainPathInto and the secondary-path sweep all pull
+ *  transcript events too, and a switch record that arrives through any of them
+ *  is just as real. Routing them all through here is what stops a `/clear` or a
+ *  rotation from silently swallowing one.
+ *
+ *  Routing is by the PATH's Claude session id, never by which drain called:
+ *    - the bound session → observe;
+ *    - a different session that IS the current primary path → the bridge moved
+ *      to another Claude conversation, so rebind (dropping the previous
+ *      session's dedupe state) and observe;
+ *    - a different session on a secondary / already-retired path → ignore.
+ *      Those are trailing bytes of a conversation this session no longer runs
+ *      on; folding them in would resurrect its notice or its serving model.
+ *
+ *  The notice is a claude-code-only product affordance, so the cliId gate is
+ *  explicit rather than implied by the call sites. */
+function observeModelFallbackEvents(
+  path: string | null | undefined,
+  events: readonly TranscriptEvent[],
+): void {
   if (lastInitConfig?.cliId !== 'claude-code') return;
+  if (!path || events.length === 0) return;
+  const claudeSessionId = sessionIdFromJsonlPath(path);
+  if (!claudeSessionId) return;
+  if (claudeSessionId !== modelFallbackTracker.boundClaudeSessionId) {
+    if (path !== bridgeJsonlPath) return;
+    modelFallbackTracker.bind(claudeSessionId);
+  }
   reportModelFallbackObservation(modelFallbackTracker.observe(events));
 }
 
-/** Seed from the transcript tail at bridge start. Baseline cursors to EOF, so a
- *  switch recorded before `--resume` or a daemon restart is never drained; a
- *  bounded backward scan recovers what it can (same shape as Codex/TRAE runtime
- *  seeding). A scan that finds NOTHING reports nothing: the daemon's persisted
- *  notice outlives this worker, and a short window is not evidence against it. */
+/** Bind the tracker to the CURRENT primary path's Claude session and publish
+ *  one observation from its tail. Called at every bind/switch of
+ *  bridgeJsonlPath (watcher start, lazy baseline, fingerprint switch, rotation
+ *  switch): baseline cursors to EOF, so a switch recorded before `--resume`, a
+ *  daemon restart or the switch itself is never drained, and a bounded backward
+ *  scan is the only way to recover it (same shape as Codex/TRAE runtime
+ *  seeding).
+ *
+ *  This ALWAYS sends, including when the scan found nothing. The empty message
+ *  is not a claim that the daemon's notice is stale — it names the Claude
+ *  session the bridge is now on, which is how the daemon drops a notice that
+ *  belonged to a different conversation. An empty message for the SAME session
+ *  changes nothing there, so a plain worker restart still costs nothing. */
 function seedModelFallbackFromTranscript(): void {
   if (lastInitConfig?.cliId !== 'claude-code' || !bridgeJsonlPath) return;
-  let seeded: ModelFallbackObservation | null = null;
-  try { seeded = modelFallbackTracker.seed(bridgeJsonlPath); }
+  const claudeSessionId = sessionIdFromJsonlPath(bridgeJsonlPath);
+  if (!claudeSessionId) return;
+  let seeded: ModelFallbackObservation;
+  try { seeded = modelFallbackTracker.seed(bridgeJsonlPath, claudeSessionId); }
   catch (err: any) { log(`Model fallback seed skipped: ${err?.message ?? err}`); return; }
   reportModelFallbackObservation(seeded);
 }
 
-/** Ship one observation. Facts only — there is deliberately no shape here that
- *  says "no fallback": clearing is the daemon's call, made from a serving model
- *  that disagrees with the record it holds. */
+/** Ship one observation. Facts only: the worker never decides that a notice is
+ *  over. The two shapes that CAN clear are both positive evidence — a
+ *  `claudeSessionId` naming a different Claude conversation, and `fallback:
+ *  null` from a newest session-scoped record that is not a live Fable
+ *  fallback — and the daemon applies them, not us. */
 function reportModelFallbackObservation(observed: ModelFallbackObservation | null): void {
   if (!observed) return;
   const rec = observed.fallback;
   if (rec) {
     log(`Claude model fallback observed (kind=${rec.kind}, ${rec.originalModel} → ${rec.fallbackModel}, trigger=${rec.trigger ?? 'n/a'})`);
+  } else if (rec === null) {
+    log(`Claude model fallback cleared by the newest session switch record (session=${observed.claudeSessionId})`);
   }
   send({ type: 'model_fallback', ...observed });
 }
@@ -6087,6 +6138,10 @@ function emitReadyTurns(opts: { explicitTerminalOnly?: boolean } = {}): void {
 function drainPathInto(path: string, fromOffset: number): { offset: number; tail: string } {
   const result = drainTranscript(path, fromOffset);
   bridgeQueue.ingest(result.events, path);
+  // Drain-before-switch runs while `path` is still the primary, so these are
+  // the bound session's own trailing bytes — a switch record Claude wrote just
+  // before the rotation lands here and nowhere else.
+  observeModelFallbackEvents(path, result.events);
   return { offset: result.newOffset, tail: result.pendingTail };
 }
 
@@ -7726,6 +7781,10 @@ function drainSecondaryPaths(): void {
     try {
       const result = drainTranscript(path, offset);
       if (result.events.length > 0) bridgeQueue.ingest(result.events, path);
+      // Retired paths belong to a Claude session we already left, so the router
+      // drops them; routed anyway so the "every queue-feeding drain goes
+      // through one entry" rule has no exception to reason about.
+      observeModelFallbackEvents(path, result.events);
       bridgeSecondaryPaths.set(path, result.newOffset);
     } catch (err: any) {
       log(`Bridge secondary-path drain failed (${path}): ${err.message}`);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -61,7 +61,7 @@ import { roleLibraryRoot, roleLibrarySubtree } from './core/role-library.js';
 // Central no-transport predicate. Aliased because a local `const larkTransportEnabled`
 // (the role-library gate) already binds that name in one function scope.
 import { larkTransportEnabled as sessionLarkTransportEnabled } from './core/types.js';
-import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, extractCotEntries, ClaudeModelFallbackTracker, type TranscriptEvent } from './services/claude-transcript.js';
+import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, extractCotEntries, ClaudeModelFallbackTracker, type ModelFallbackObservation, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint, type BridgePendingTurn } from './services/bridge-turn-queue.js';
 import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, structuredFallbackKind, stripTrailingOaiMemoryCitation, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { buildSubmitMessagePreview } from './services/submit-notification.js';
@@ -244,7 +244,6 @@ import type {
   DaemonToWorker,
   WorkerToDaemon,
   DisplayMode,
-  ModelFallbackState,
   TermActionKey,
   ScreenStatus,
   TrustedCaller,
@@ -4254,12 +4253,9 @@ const bridgeRestoreGate = new BridgeRestoreGate();
  *  stable record uuid keeps the notification idempotent. */
 const emittedRateLimitUuids = new Set<string>();
 /** Claude Code's automatic model switches for this bridge (uuid dedupe +
- *  serving-model tracking live in the tracker). */
+ *  "only report the serving model when it changed" live in the tracker). The
+ *  worker reports observations only; the daemon owns the state and decides. */
 const modelFallbackTracker = new ClaudeModelFallbackTracker();
-/** Last state pushed to the daemon (`null` = "no fallback"). `undefined` means
- *  nothing pushed yet, so the first resolve always publishes — that initial
- *  `null` is what clears a stale persisted notice. */
-let publishedModelFallback: ModelFallbackState | null | undefined;
 let bridgeWatcher: FSWatcher | null = null;
 let bridgeFallbackTimer: NodeJS.Timeout | null = null;
 let herdrAdoptBridgeQuietTimer: NodeJS.Timeout | null = null;
@@ -5589,38 +5585,38 @@ function maybeEmitStructuredRateLimit(events: readonly TranscriptEvent[]): void 
   }
 }
 
-/** Fold newly-drained events into the model-fallback tracker and push the
- *  resulting state to the daemon whenever it changes. Claude-only by
- *  construction: bridgeIngest is the Claude bridge. */
+/** Fold newly-drained events into the model-fallback tracker and report what
+ *  the daemon has not been told yet. bridgeIngest is the Claude bridge, but the
+ *  notice is a claude-code-only product affordance, so the cliId gate is
+ *  explicit rather than implied by the call site. */
 function observeModelFallback(events: readonly TranscriptEvent[]): void {
-  for (const rec of modelFallbackTracker.observe(events)) {
+  if (lastInitConfig?.cliId !== 'claude-code') return;
+  reportModelFallbackObservation(modelFallbackTracker.observe(events));
+}
+
+/** Seed from the transcript tail at bridge start. Baseline cursors to EOF, so a
+ *  switch recorded before `--resume` or a daemon restart is never drained; a
+ *  bounded backward scan recovers what it can (same shape as Codex/TRAE runtime
+ *  seeding). A scan that finds NOTHING reports nothing: the daemon's persisted
+ *  notice outlives this worker, and a short window is not evidence against it. */
+function seedModelFallbackFromTranscript(): void {
+  if (lastInitConfig?.cliId !== 'claude-code' || !bridgeJsonlPath) return;
+  let seeded: ModelFallbackObservation | null = null;
+  try { seeded = modelFallbackTracker.seed(bridgeJsonlPath); }
+  catch (err: any) { log(`Model fallback seed skipped: ${err?.message ?? err}`); return; }
+  reportModelFallbackObservation(seeded);
+}
+
+/** Ship one observation. Facts only — there is deliberately no shape here that
+ *  says "no fallback": clearing is the daemon's call, made from a serving model
+ *  that disagrees with the record it holds. */
+function reportModelFallbackObservation(observed: ModelFallbackObservation | null): void {
+  if (!observed) return;
+  const rec = observed.fallback;
+  if (rec) {
     log(`Claude model fallback observed (kind=${rec.kind}, ${rec.originalModel} → ${rec.fallbackModel}, trigger=${rec.trigger ?? 'n/a'})`);
   }
-  publishModelFallbackIfChanged();
-}
-
-/** Emit the resolved state only when it actually changed — bridgeIngest runs on
- *  every fs.watch wakeup and once a second besides. Idempotent, so the baseline
- *  seed and the incremental path can both call it. */
-function publishModelFallbackIfChanged(): void {
-  const state = modelFallbackTracker.current();
-  if (publishedModelFallback !== undefined && publishedModelFallback?.uuid === state?.uuid) return;
-  publishedModelFallback = state;
-  send({ type: 'model_fallback', state });
-}
-
-/** Seed the fallback state at bridge start. Baseline cursors to EOF, so a
- *  switch recorded before `--resume` or a daemon restart is never drained;
- *  a bounded backward scan recovers it (same shape as Codex/TRAE runtime
- *  seeding). Always publishes, including `null` — the user may have switched
- *  back while the daemon was down, and that has to overwrite the persisted
- *  notice. */
-function seedModelFallbackFromTranscript(): void {
-  if (bridgeJsonlPath) {
-    try { modelFallbackTracker.seed(bridgeJsonlPath); }
-    catch (err: any) { log(`Model fallback seed skipped: ${err?.message ?? err}`); }
-  }
-  publishModelFallbackIfChanged();
+  send({ type: 'model_fallback', ...observed });
 }
 
 function performBridgeIngestAndScheduleQuietEmit(): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5456,6 +5456,14 @@ function maybeFollowSessionRotationViaPid(): PidFollowResult {
   bridgeOffset = 0;
   bridgePendingTail = '';
   bridgeBaselineDone = true;
+  // Same as the fingerprint and fd-rotation switches: the bridge is now on
+  // another Claude conversation, so re-declare which one before any of its
+  // bytes are folded in. Waiting for the next ingest to rebind would leave the
+  // daemon showing the PREVIOUS session's notice for as long as the new
+  // transcript holds nothing observable (a rotation onto a file with no
+  // assistant reply yet), and would let the secondary-path sweep fold the old
+  // session's trailing bytes in as if they were the bound session's.
+  seedModelFallbackFromTranscript();
   try {
     bridgeWatcher = fsWatch(resolved.path, { persistent: false }, () => {
       try { performBridgeIngestAndScheduleQuietEmit(); } catch (err: any) { log(`Bridge ingest error: ${err.message}`); }

--- a/test/card-model-fallback-notice.test.ts
+++ b/test/card-model-fallback-notice.test.ts
@@ -77,13 +77,13 @@ function markdownContents(card: any): string[] {
 }
 
 function noticeIn(card: any): string | undefined {
-  return markdownContents(card).find(c => c.includes('/model'));
+  return markdownContents(card).find(c => c.includes('⚠️'));
 }
 
 describe('cardModelFallbackNotice: copy', () => {
   it('renders the refusal notice with friendly names, category and switch-back hint (zh)', () => {
     expect(cardModelFallbackNotice(REFUSAL, 'zh')).toBe(
-      '⚠️ 安全管控降级：Fable 5.1 → Opus 4.8（cyber）· /model fable 切回',
+      '⚠️ 安全管控降级：Fable 5.1 → Opus 4.8（cyber）',
     );
   });
 
@@ -95,7 +95,7 @@ describe('cardModelFallbackNotice: copy', () => {
       fallbackModel: 'claude-opus-4-8[1m]',
       trigger: 'overloaded',
     }, 'zh')).toBe(
-      '⚠️ 模型不可用已切换：Fable 5.1 → Opus 4.8（overloaded）· /model fable 切回',
+      '⚠️ 模型不可用，本轮切换：Fable 5.1 → Opus 4.8（overloaded）',
     );
   });
 
@@ -106,7 +106,7 @@ describe('cardModelFallbackNotice: copy', () => {
       originalModel: 'claude-fable-5-1[1m]',
       fallbackModel: 'claude-opus-4-8[1m]',
     }, 'zh')).toBe(
-      '⚠️ 额度限制已切换：Fable 5.1 → Opus 4.8 · /model fable 切回',
+      '⚠️ 额度限制已切换：Fable 5.1 → Opus 4.8',
     );
   });
 
@@ -114,20 +114,20 @@ describe('cardModelFallbackNotice: copy', () => {
     const en = (['refusal', 'unavailable', 'consent'] as const)
       .map(kind => cardModelFallbackNotice({ ...REFUSAL, kind }, 'en')!);
     expect(en[0]).toBe(
-      '⚠️ Safety fallback: Fable 5.1 → Opus 4.8 (cyber) · /model fable to switch back',
+      '⚠️ Safety fallback: Fable 5.1 → Opus 4.8 (cyber)',
     );
     expect(en[1]).toBe(
-      '⚠️ Model unavailable: Fable 5.1 → Opus 4.8 (refusal) · /model fable to switch back',
+      '⚠️ Model unavailable, switched for this turn: Fable 5.1 → Opus 4.8 (refusal)',
     );
     expect(en[2]).toBe(
-      '⚠️ Quota fallback: Fable 5.1 → Opus 4.8 · /model fable to switch back',
+      '⚠️ Quota fallback: Fable 5.1 → Opus 4.8',
     );
     for (const line of en) expect(line).not.toMatch(/[一-鿿]/);
   });
 
   it('drops the reason when the record carries none', () => {
     expect(cardModelFallbackNotice({ ...REFUSAL, apiRefusalCategory: undefined }, 'zh'))
-      .toBe('⚠️ 安全管控降级：Fable 5.1 → Opus 4.8 · /model fable 切回');
+      .toBe('⚠️ 安全管控降级：Fable 5.1 → Opus 4.8');
   });
 
   it('names known Claude models and keeps an unknown id verbatim', () => {
@@ -135,11 +135,9 @@ describe('cardModelFallbackNotice: copy', () => {
       cardModelFallbackNotice({ ...REFUSAL, kind: 'consent', originalModel, fallbackModel }, 'zh')!;
     expect(label('claude-opus-5', 'claude-haiku-4-5-20251001')).toContain('Opus 5 → Haiku 4.5');
     expect(label('claude-sonnet-5', 'claude-opus-4-8[1m]')).toContain('Sonnet 5 → Opus 4.8');
-    expect(label('claude-opus-5', 'claude-opus-5')).toContain('/model opus 切回');
-    // Unrecognised id: raw form is kept and the alias falls back to it.
+    // Unrecognised id: raw form is kept.
     const custom = label('internal-model-x', 'claude-opus-5');
     expect(custom).toContain('internal-model-x → Opus 5');
-    expect(custom).toContain('/model internal-model-x');
   });
 
   it('truncates an absurdly long model id and escapes markdown control chars', () => {
@@ -152,27 +150,6 @@ describe('cardModelFallbackNotice: copy', () => {
     expect(line).toContain('…');
     expect(line).toContain('x\\*\\_\\`');
     expect(line.length).toBeLessThan(200);
-  });
-
-  it('bounds the /model argument of an unrecognised id, like the labels', () => {
-    // The alias is transcript-derived too, so leaving it unbounded would blow
-    // up the very line the labels are truncated to keep short.
-    const line = cardModelFallbackNotice({
-      ...REFUSAL,
-      kind: 'consent',
-      originalModel: 'internal-model-'.repeat(20),
-      fallbackModel: 'claude-opus-5',
-    }, 'zh')!;
-    expect(line.length).toBeLessThan(200);
-    expect(line).toContain('…');
-    expect(line).not.toContain('internal-model-internal-model-internal-model-');
-    // A real-length unrecognised id is still echoed whole and stays actionable.
-    expect(cardModelFallbackNotice({
-      ...REFUSAL,
-      kind: 'consent',
-      originalModel: 'claude-3-7-sonnet-20250219',
-      fallbackModel: 'claude-opus-5',
-    }, 'zh')).toContain('/model claude-3-7-sonnet-20250219');
   });
 
   it('returns null with no fallback or an incomplete one', () => {
@@ -204,7 +181,7 @@ describe('buildStreamingCard: model-fallback notice placement', () => {
     const last = elements[elements.length - 1];
     expect(last.tag).toBe('markdown');
     expect(last.text_size).toBe('x-small');
-    expect(last.content).toMatch(/^<font color='grey'>⚠️ 安全管控降级：.*<\/font>$/);
+    expect(last.content).toMatch(/^<font color='yellow'>⚠️ 安全管控降级：.*<\/font>$/);
     // Below the button rows and below the usage line, never above them.
     expect(elements.findIndex(e => e.tag === 'action')).toBeGreaterThanOrEqual(0);
     expect(elements.findIndex(e => e.tag === 'action')).toBeLessThan(elements.length - 1);

--- a/test/card-model-fallback-notice.test.ts
+++ b/test/card-model-fallback-notice.test.ts
@@ -83,7 +83,7 @@ function noticeIn(card: any): string | undefined {
 describe('cardModelFallbackNotice: copy', () => {
   it('renders the refusal notice with friendly names, category and switch-back hint (zh)', () => {
     expect(cardModelFallbackNotice(REFUSAL, 'zh')).toBe(
-      '⚠️ 安全管控触发，已自动降级：Fable 5.1 → Opus 4.8（cyber）· 后续都在 Opus 4.8 上跑，回复 /model fable 可切回',
+      '⚠️ 安全管控降级：Fable 5.1 → Opus 4.8（cyber）· /model fable 切回',
     );
   });
 
@@ -95,7 +95,7 @@ describe('cardModelFallbackNotice: copy', () => {
       fallbackModel: 'claude-opus-4-8[1m]',
       trigger: 'overloaded',
     }, 'zh')).toBe(
-      '⚠️ 模型不可用，已自动切换：Fable 5.1 → Opus 4.8（overloaded）· 回复 /model fable 可切回',
+      '⚠️ 模型不可用已切换：Fable 5.1 → Opus 4.8（overloaded）· /model fable 切回',
     );
   });
 
@@ -106,7 +106,7 @@ describe('cardModelFallbackNotice: copy', () => {
       originalModel: 'claude-fable-5-1[1m]',
       fallbackModel: 'claude-opus-4-8[1m]',
     }, 'zh')).toBe(
-      '⚠️ 因用量额度限制，已自动切换：Fable 5.1 → Opus 4.8 · 回复 /model fable 可切回',
+      '⚠️ 额度限制已切换：Fable 5.1 → Opus 4.8 · /model fable 切回',
     );
   });
 
@@ -114,23 +114,20 @@ describe('cardModelFallbackNotice: copy', () => {
     const en = (['refusal', 'unavailable', 'consent'] as const)
       .map(kind => cardModelFallbackNotice({ ...REFUSAL, kind }, 'en')!);
     expect(en[0]).toBe(
-      '⚠️ Safety guardrails tripped — auto-downgraded: Fable 5.1 → Opus 4.8 (cyber) · '
-      + 'this session keeps running on Opus 4.8; reply /model fable to switch back',
+      '⚠️ Safety fallback: Fable 5.1 → Opus 4.8 (cyber) · /model fable to switch back',
     );
     expect(en[1]).toBe(
-      '⚠️ Model unavailable — auto-switched: Fable 5.1 → Opus 4.8 (refusal) · '
-      + 'reply /model fable to switch back',
+      '⚠️ Model unavailable: Fable 5.1 → Opus 4.8 (refusal) · /model fable to switch back',
     );
     expect(en[2]).toBe(
-      '⚠️ Usage quota limit — auto-switched: Fable 5.1 → Opus 4.8 · '
-      + 'reply /model fable to switch back',
+      '⚠️ Quota fallback: Fable 5.1 → Opus 4.8 · /model fable to switch back',
     );
     for (const line of en) expect(line).not.toMatch(/[一-鿿]/);
   });
 
   it('drops the reason when the record carries none', () => {
     expect(cardModelFallbackNotice({ ...REFUSAL, apiRefusalCategory: undefined }, 'zh'))
-      .toBe('⚠️ 安全管控触发，已自动降级：Fable 5.1 → Opus 4.8 · 后续都在 Opus 4.8 上跑，回复 /model fable 可切回');
+      .toBe('⚠️ 安全管控降级：Fable 5.1 → Opus 4.8 · /model fable 切回');
   });
 
   it('names known Claude models and keeps an unknown id verbatim', () => {
@@ -138,7 +135,7 @@ describe('cardModelFallbackNotice: copy', () => {
       cardModelFallbackNotice({ ...REFUSAL, kind: 'consent', originalModel, fallbackModel }, 'zh')!;
     expect(label('claude-opus-5', 'claude-haiku-4-5-20251001')).toContain('Opus 5 → Haiku 4.5');
     expect(label('claude-sonnet-5', 'claude-opus-4-8[1m]')).toContain('Sonnet 5 → Opus 4.8');
-    expect(label('claude-opus-5', 'claude-opus-5')).toContain('回复 /model opus 可切回');
+    expect(label('claude-opus-5', 'claude-opus-5')).toContain('/model opus 切回');
     // Unrecognised id: raw form is kept and the alias falls back to it.
     const custom = label('internal-model-x', 'claude-opus-5');
     expect(custom).toContain('internal-model-x → Opus 5');
@@ -187,7 +184,7 @@ describe('cardModelFallbackNotice: copy', () => {
 describe('buildStreamingCard: model-fallback notice placement', () => {
   it('adds the notice when the usage snapshot carries a fallback', () => {
     const card = build({ usage: { context: null, tokens: null, modelFallback: REFUSAL }, locale: 'zh' });
-    expect(noticeIn(card)).toContain('安全管控触发，已自动降级');
+    expect(noticeIn(card)).toContain('安全管控降级');
   });
 
   it('renders nothing once the fallback is cleared', () => {
@@ -206,8 +203,8 @@ describe('buildStreamingCard: model-fallback notice placement', () => {
     const elements = card.elements as any[];
     const last = elements[elements.length - 1];
     expect(last.tag).toBe('markdown');
-    expect(last.text_size).toBe('notation_small_v2');
-    expect(last.content).toMatch(/^<font color='grey'>⚠️ 安全管控触发，已自动降级：.*<\/font>$/);
+    expect(last.text_size).toBe('x-small');
+    expect(last.content).toMatch(/^<font color='grey'>⚠️ 安全管控降级：.*<\/font>$/);
     // Below the button rows and below the usage line, never above them.
     expect(elements.findIndex(e => e.tag === 'action')).toBeGreaterThanOrEqual(0);
     expect(elements.findIndex(e => e.tag === 'action')).toBeLessThan(elements.length - 1);
@@ -229,13 +226,13 @@ describe('buildStreamingCard: model-fallback notice placement', () => {
     });
     const contents = markdownContents(card);
     const limitIdx = contents.findIndex(c => c.includes('使用限额'));
-    const fallbackIdx = contents.findIndex(c => c.includes('已自动降级'));
+    const fallbackIdx = contents.findIndex(c => c.includes('安全管控降级'));
     expect(limitIdx).toBeGreaterThanOrEqual(0);
     expect(fallbackIdx).toBeGreaterThan(limitIdx);
   });
 
   it('follows the card locale', () => {
     const card = build({ usage: { context: null, tokens: null, modelFallback: REFUSAL }, locale: 'en' });
-    expect(noticeIn(card)).toContain('Safety guardrails tripped');
+    expect(noticeIn(card)).toContain('Safety fallback');
   });
 });

--- a/test/card-model-fallback-notice.test.ts
+++ b/test/card-model-fallback-notice.test.ts
@@ -194,15 +194,33 @@ describe('buildStreamingCard: model-fallback notice placement', () => {
     const withNotice = build({ usage: { context: null, tokens: null, modelFallback: REFUSAL } });
     const cleared = build({ usage: { context: null, tokens: null } });
     expect(noticeIn(cleared)).toBeUndefined();
-    // The cleared card also drops the notice's separator, not just its text.
-    expect(cleared.elements.length).toBe(withNotice.elements.length - 2);
+    // The notice is a single trailing element; nothing else changes.
+    expect(cleared.elements.length).toBe(withNotice.elements.length - 1);
+  });
+
+  it('is pinned as the last element, in small grey text, below the action rows', () => {
+    const card = build({
+      usage: { context: { usedTokens: 1000, windowTokens: 1_000_000, percentUsed: 0.1 }, tokens: { in: 1000, out: 50 }, modelFallback: REFUSAL },
+      locale: 'zh',
+    });
+    const elements = card.elements as any[];
+    const last = elements[elements.length - 1];
+    expect(last.tag).toBe('markdown');
+    expect(last.text_size).toBe('notation_small_v2');
+    expect(last.content).toMatch(/^<font color='grey'>⚠️ 安全管控触发，已自动降级：.*<\/font>$/);
+    // Below the button rows and below the usage line, never above them.
+    expect(elements.findIndex(e => e.tag === 'action')).toBeGreaterThanOrEqual(0);
+    expect(elements.findIndex(e => e.tag === 'action')).toBeLessThan(elements.length - 1);
+    const usageIdx = elements.findIndex(e => typeof e.content === 'string' && e.content.includes('上下文'));
+    expect(usageIdx).toBeGreaterThanOrEqual(0);
+    expect(usageIdx).toBeLessThan(elements.length - 1);
   });
 
   it('renders nothing when no usage snapshot is supplied at all', () => {
     expect(noticeIn(build({}))).toBeUndefined();
   });
 
-  it('coexists with the usage-limit notice and renders after it', () => {
+  it('coexists with the usage-limit notice and stays below it', () => {
     const card = build({
       status: 'limited',
       usageLimit: { retryReady: false, retryLabel: '10:40pm' },

--- a/test/card-model-fallback-notice.test.ts
+++ b/test/card-model-fallback-notice.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The model-fallback notice is pinned to the live streaming card (deliberately
+ * not sent as its own message). These tests cover the copy for all three kinds
+ * in both locales, the friendly model naming, coexistence with the usage-limit
+ * line, and disappearance once the fallback is cleared.
+ *
+ * Run: npx vitest run --project unit test/card-model-fallback-notice.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { buildStreamingCard } from '../src/im/lark/card-builder.js';
+import { cardModelFallbackNotice } from '../src/im/lark/md-card.js';
+import { globalConfigPath, invalidateGlobalConfigCache } from '../src/global-config.js';
+import type { ModelFallbackState } from '../src/types.js';
+
+let cardTestHome: string;
+beforeEach(() => {
+  cardTestHome = mkdtempSync(join(tmpdir(), 'botmux-card-mfb-'));
+  vi.stubEnv('HOME', cardTestHome);
+  mkdirSync(dirname(globalConfigPath()), { recursive: true });
+  invalidateGlobalConfigCache();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  invalidateGlobalConfigCache();
+  rmSync(cardTestHome, { recursive: true, force: true });
+});
+
+const REFUSAL: ModelFallbackState = {
+  uuid: 'u-refusal',
+  kind: 'refusal',
+  originalModel: 'claude-fable-5-1[1m]',
+  fallbackModel: 'claude-opus-4-8[1m]',
+  trigger: 'refusal',
+  apiRefusalCategory: 'cyber',
+};
+
+/** Same 22 positional args as card-builder-stop-compact.test.ts; usage is 17th. */
+function build(opts: {
+  status?: string;
+  usage?: any;
+  locale?: string;
+  usageLimit?: any;
+} = {}): any {
+  return JSON.parse(buildStreamingCard(
+    'sess-mfb',
+    'om_root_mfb',
+    'https://example.com/term',
+    'Fallback Task',
+    '',
+    (opts.status ?? 'working') as any,
+    'claude-code' as any,
+    'hidden' as any,
+    undefined,
+    undefined,
+    false,
+    false,
+    opts.locale as any,
+    opts.usageLimit,
+    undefined,
+    false,
+    opts.usage,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ));
+}
+
+function markdownContents(card: any): string[] {
+  return (card.elements as any[])
+    .filter(e => e.tag === 'markdown' && typeof e.content === 'string')
+    .map(e => e.content);
+}
+
+function noticeIn(card: any): string | undefined {
+  return markdownContents(card).find(c => c.includes('/model'));
+}
+
+describe('cardModelFallbackNotice: copy', () => {
+  it('renders the refusal notice with friendly names, category and switch-back hint (zh)', () => {
+    expect(cardModelFallbackNotice(REFUSAL, 'zh')).toBe(
+      '⚠️ 安全管控触发，已自动降级：Fable 5.1 → Opus 4.8（cyber）· 后续都在 Opus 4.8 上跑，回复 /model fable 可切回',
+    );
+  });
+
+  it('renders the unavailable notice with the raw trigger as the reason (zh)', () => {
+    expect(cardModelFallbackNotice({
+      uuid: 'u-unavailable',
+      kind: 'unavailable',
+      originalModel: 'claude-fable-5-1[1m]',
+      fallbackModel: 'claude-opus-4-8[1m]',
+      trigger: 'overloaded',
+    }, 'zh')).toBe(
+      '⚠️ 模型不可用，已自动切换：Fable 5.1 → Opus 4.8（overloaded）· 回复 /model fable 可切回',
+    );
+  });
+
+  it('renders the consent notice without a reason (zh)', () => {
+    expect(cardModelFallbackNotice({
+      uuid: 'u-consent',
+      kind: 'consent',
+      originalModel: 'claude-fable-5-1[1m]',
+      fallbackModel: 'claude-opus-4-8[1m]',
+    }, 'zh')).toBe(
+      '⚠️ 因用量额度限制，已自动切换：Fable 5.1 → Opus 4.8 · 回复 /model fable 可切回',
+    );
+  });
+
+  it('renders English copy for all three kinds', () => {
+    const en = (['refusal', 'unavailable', 'consent'] as const)
+      .map(kind => cardModelFallbackNotice({ ...REFUSAL, kind }, 'en')!);
+    expect(en[0]).toBe(
+      '⚠️ Safety guardrails tripped — auto-downgraded: Fable 5.1 → Opus 4.8 (cyber) · '
+      + 'this session keeps running on Opus 4.8; reply /model fable to switch back',
+    );
+    expect(en[1]).toBe(
+      '⚠️ Model unavailable — auto-switched: Fable 5.1 → Opus 4.8 (refusal) · '
+      + 'reply /model fable to switch back',
+    );
+    expect(en[2]).toBe(
+      '⚠️ Usage quota limit — auto-switched: Fable 5.1 → Opus 4.8 · '
+      + 'reply /model fable to switch back',
+    );
+    for (const line of en) expect(line).not.toMatch(/[一-鿿]/);
+  });
+
+  it('drops the reason when the record carries none', () => {
+    expect(cardModelFallbackNotice({ ...REFUSAL, apiRefusalCategory: undefined }, 'zh'))
+      .toBe('⚠️ 安全管控触发，已自动降级：Fable 5.1 → Opus 4.8 · 后续都在 Opus 4.8 上跑，回复 /model fable 可切回');
+  });
+
+  it('names known Claude models and keeps an unknown id verbatim', () => {
+    const label = (originalModel: string, fallbackModel: string) =>
+      cardModelFallbackNotice({ ...REFUSAL, kind: 'consent', originalModel, fallbackModel }, 'zh')!;
+    expect(label('claude-opus-5', 'claude-haiku-4-5-20251001')).toContain('Opus 5 → Haiku 4.5');
+    expect(label('claude-sonnet-5', 'claude-opus-4-8[1m]')).toContain('Sonnet 5 → Opus 4.8');
+    expect(label('claude-opus-5', 'claude-opus-5')).toContain('回复 /model opus 可切回');
+    // Unrecognised id: raw form is kept and the alias falls back to it.
+    const custom = label('internal-model-x', 'claude-opus-5');
+    expect(custom).toContain('internal-model-x → Opus 5');
+    expect(custom).toContain('/model internal-model-x');
+  });
+
+  it('truncates an absurdly long model id and escapes markdown control chars', () => {
+    const line = cardModelFallbackNotice({
+      ...REFUSAL,
+      kind: 'consent',
+      originalModel: `x*_\`${'y'.repeat(80)}`,
+      fallbackModel: 'claude-opus-5',
+    }, 'zh')!;
+    expect(line).toContain('…');
+    expect(line).toContain('x\\*\\_\\`');
+    expect(line.length).toBeLessThan(200);
+  });
+
+  it('returns null with no fallback or an incomplete one', () => {
+    expect(cardModelFallbackNotice(undefined, 'zh')).toBeNull();
+    expect(cardModelFallbackNotice({ ...REFUSAL, fallbackModel: '' }, 'zh')).toBeNull();
+  });
+});
+
+describe('buildStreamingCard: model-fallback notice placement', () => {
+  it('adds the notice when the usage snapshot carries a fallback', () => {
+    const card = build({ usage: { context: null, tokens: null, modelFallback: REFUSAL }, locale: 'zh' });
+    expect(noticeIn(card)).toContain('安全管控触发，已自动降级');
+  });
+
+  it('renders nothing once the fallback is cleared', () => {
+    const withNotice = build({ usage: { context: null, tokens: null, modelFallback: REFUSAL } });
+    const cleared = build({ usage: { context: null, tokens: null } });
+    expect(noticeIn(cleared)).toBeUndefined();
+    // The cleared card also drops the notice's separator, not just its text.
+    expect(cleared.elements.length).toBe(withNotice.elements.length - 2);
+  });
+
+  it('renders nothing when no usage snapshot is supplied at all', () => {
+    expect(noticeIn(build({}))).toBeUndefined();
+  });
+
+  it('coexists with the usage-limit notice and renders after it', () => {
+    const card = build({
+      status: 'limited',
+      usageLimit: { retryReady: false, retryLabel: '10:40pm' },
+      usage: { context: null, tokens: null, modelFallback: REFUSAL },
+      locale: 'zh',
+    });
+    const contents = markdownContents(card);
+    const limitIdx = contents.findIndex(c => c.includes('使用限额'));
+    const fallbackIdx = contents.findIndex(c => c.includes('已自动降级'));
+    expect(limitIdx).toBeGreaterThanOrEqual(0);
+    expect(fallbackIdx).toBeGreaterThan(limitIdx);
+  });
+
+  it('follows the card locale', () => {
+    const card = build({ usage: { context: null, tokens: null, modelFallback: REFUSAL }, locale: 'en' });
+    expect(noticeIn(card)).toContain('Safety guardrails tripped');
+  });
+});

--- a/test/card-model-fallback-notice.test.ts
+++ b/test/card-model-fallback-notice.test.ts
@@ -157,6 +157,27 @@ describe('cardModelFallbackNotice: copy', () => {
     expect(line.length).toBeLessThan(200);
   });
 
+  it('bounds the /model argument of an unrecognised id, like the labels', () => {
+    // The alias is transcript-derived too, so leaving it unbounded would blow
+    // up the very line the labels are truncated to keep short.
+    const line = cardModelFallbackNotice({
+      ...REFUSAL,
+      kind: 'consent',
+      originalModel: 'internal-model-'.repeat(20),
+      fallbackModel: 'claude-opus-5',
+    }, 'zh')!;
+    expect(line.length).toBeLessThan(200);
+    expect(line).toContain('…');
+    expect(line).not.toContain('internal-model-internal-model-internal-model-');
+    // A real-length unrecognised id is still echoed whole and stays actionable.
+    expect(cardModelFallbackNotice({
+      ...REFUSAL,
+      kind: 'consent',
+      originalModel: 'claude-3-7-sonnet-20250219',
+      fallbackModel: 'claude-opus-5',
+    }, 'zh')).toContain('/model claude-3-7-sonnet-20250219');
+  });
+
   it('returns null with no fallback or an incomplete one', () => {
     expect(cardModelFallbackNotice(undefined, 'zh')).toBeNull();
     expect(cardModelFallbackNotice({ ...REFUSAL, fallbackModel: '' }, 'zh')).toBeNull();

--- a/test/card-model-fallback-notice.test.ts
+++ b/test/card-model-fallback-notice.test.ts
@@ -81,7 +81,7 @@ function noticeIn(card: any): string | undefined {
 }
 
 describe('cardModelFallbackNotice: copy', () => {
-  it('renders the refusal notice with friendly names, category and switch-back hint (zh)', () => {
+  it('renders the refusal notice with friendly names and the refusal category (zh)', () => {
     expect(cardModelFallbackNotice(REFUSAL, 'zh')).toBe(
       '⚠️ 安全管控降级：Fable 5.1 → Opus 4.8（cyber）',
     );
@@ -152,6 +152,55 @@ describe('cardModelFallbackNotice: copy', () => {
     expect(line.length).toBeLessThan(200);
   });
 
+  it('P3-1: keeps a date-suffixed id from reading as a minor version', () => {
+    // `claude-opus-4-20250514` has no minor at all — the date must not be
+    // spliced in as one ("Opus 4.20250514").
+    const label = (id: string) =>
+      cardModelFallbackNotice({ ...REFUSAL, kind: 'consent', fallbackModel: id }, 'zh')!;
+    expect(label('claude-opus-4-20250514')).toContain('→ Opus 4');
+    expect(label('claude-opus-4-20250514')).not.toContain('20250514');
+    expect(label('claude-sonnet-4-20250219')).toContain('→ Sonnet 4');
+    // …while a real one- or two-digit minor still joins, date suffix or not.
+    expect(label('claude-opus-4-8')).toContain('→ Opus 4.8');
+    expect(label('claude-haiku-4-5-20251001')).toContain('→ Haiku 4.5');
+    expect(label('claude-fable-5-1[1m]')).toContain('→ Fable 5.1');
+  });
+
+  describe('P2-4: the reason is single-lined and bounded', () => {
+    const withReason = (reason: string) =>
+      cardModelFallbackNotice({ ...REFUSAL, kind: 'unavailable', trigger: reason }, 'zh')!;
+
+    it('collapses newlines and control characters into one line', () => {
+      const line = withReason('over\nloaded\r\n\tnow');
+      expect(line).toBe('⚠️ 模型不可用，本轮切换：Fable 5.1 → Opus 4.8（over loaded now）');
+      expect(line).not.toMatch(/[\r\n\t]/);
+    });
+
+    it('truncates a long reason to 24 chars with an ellipsis', () => {
+      const line = withReason('z'.repeat(200));
+      expect(line).toContain(`${'z'.repeat(23)}…`);
+      expect(line).not.toContain('z'.repeat(24));
+      expect(line.length).toBeLessThan(80);
+    });
+
+    it('escapes markdown control characters in the reason', () => {
+      expect(withReason('a*b_c`d')).toContain('a\\*b\\_c\\`d');
+    });
+
+    it('drops a reason that is nothing but whitespace', () => {
+      expect(withReason(' \n\t ')).toBe('⚠️ 模型不可用，本轮切换：Fable 5.1 → Opus 4.8');
+    });
+
+    it('applies the same treatment to a multi-line model id', () => {
+      const line = cardModelFallbackNotice({
+        ...REFUSAL,
+        kind: 'consent',
+        originalModel: 'weird\nalias',
+      }, 'zh')!;
+      expect(line).toBe('⚠️ 额度限制已切换：weird alias → Opus 4.8');
+    });
+  });
+
   it('returns null with no fallback or an incomplete one', () => {
     expect(cardModelFallbackNotice(undefined, 'zh')).toBeNull();
     expect(cardModelFallbackNotice({ ...REFUSAL, fallbackModel: '' }, 'zh')).toBeNull();
@@ -172,7 +221,7 @@ describe('buildStreamingCard: model-fallback notice placement', () => {
     expect(cleared.elements.length).toBe(withNotice.elements.length - 1);
   });
 
-  it('is pinned as the last element, in small grey text, below the action rows', () => {
+  it('is pinned as the last element, in small yellow text, below the action rows', () => {
     const card = build({
       usage: { context: { usedTokens: 1000, windowTokens: 1_000_000, percentUsed: 0.1 }, tokens: { in: 1000, out: 50 }, modelFallback: REFUSAL },
       locale: 'zh',

--- a/test/claude-model-fallback-transcript.test.ts
+++ b/test/claude-model-fallback-transcript.test.ts
@@ -1,8 +1,9 @@
 /**
  * Claude Code writes a `type:"system"` record whenever it automatically
- * switches the session model. These tests cover the parse (including the
- * product's "Fable originals only" scope), the bridge tracker's dedupe /
- * local-scope / serving-model reporting, and the cold-start tail scan.
+ * switches the session model. These tests cover the parse (every session-scoped
+ * record, with the product's "Fable originals only" scope carried as a flag),
+ * the bridge tracker's Claude-session binding / dedupe / local-scope /
+ * serving-model reporting, and the cold-start tail scan.
  *
  * The tracker reports OBSERVED FACTS only — it never decides whether the
  * notice should still show. That decision lives in the daemon
@@ -58,6 +59,11 @@ const REFUSAL_RECORD = {
   sessionId: 'a9bc732e-0000-0000-0000-000000000000',
 };
 
+/** The Claude session id the tracker binds to in these tests (the jsonl's
+ *  basename in production; any stable string here). */
+const SID = 'a9bc732e-0000-0000-0000-000000000000';
+const OTHER_SID = 'b0000000-1111-1111-1111-111111111111';
+
 function assistant(model: string, extra: Record<string, unknown> = {}): TranscriptEvent {
   return {
     type: 'assistant',
@@ -104,6 +110,8 @@ describe('parseClaudeModelFallbackEvent', () => {
       originalModel: 'claude-fable-5-1[1m]',
       fallbackModel: 'claude-opus-4-8[1m]',
       scope: 'session',
+      fable: true,
+      neutralizedByFork: false,
       trigger: 'refusal',
       apiRefusalCategory: 'cyber',
       observedAt: REFUSAL_RECORD.timestamp,
@@ -163,33 +171,58 @@ describe('parseClaudeModelFallbackEvent', () => {
   });
 
   describe('Fable gate (product scope)', () => {
-    it('ignores a switch whose original model is not Fable', () => {
-      // Opus 5 → Opus 4.8 is a routine safety downgrade; surfacing it would
-      // put a warning on sessions that never asked for Fable.
+    it('P2-2: parses a non-Fable switch, flagged fable:false rather than dropped', () => {
+      // Opus 5 → Opus 4.8 is a routine safety downgrade; surfacing it would put
+      // a warning on sessions that never asked for Fable. But DROPPING it at
+      // parse time let the backward tail scan walk straight past it and
+      // resurrect an older Fable record — a notice the session had already left
+      // behind. The record must survive the parse so it can stop the scan.
       for (const originalModel of ['claude-opus-5', 'claude-opus-5[1m]', 'claude-sonnet-4-5']) {
         expect(parseClaudeModelFallbackEvent({
           ...REFUSAL_RECORD,
           originalModel,
-        } as TranscriptEvent), originalModel).toBeUndefined();
+        } as TranscriptEvent), originalModel).toMatchObject({
+          uuid: REFUSAL_RECORD.uuid,
+          scope: 'session',
+          fable: false,
+        });
       }
     });
 
     it('accepts every Fable spelling', () => {
       for (const originalModel of ['claude-fable-5[1m]', 'claude-fable-5-1', 'Claude-Fable-5-1[1M]']) {
-        expect(parseClaudeModelFallbackEvent({
+        const rec = parseClaudeModelFallbackEvent({
           ...REFUSAL_RECORD,
           originalModel,
-        } as TranscriptEvent)?.originalModel, originalModel).toBe(originalModel);
+        } as TranscriptEvent);
+        expect(rec?.originalModel, originalModel).toBe(originalModel);
+        expect(rec?.fable, originalModel).toBe(true);
       }
+    });
+  });
+
+  describe('P2-2: neutralizedByFork', () => {
+    it('flags a record a fork copied over', () => {
+      expect(parseClaudeModelFallbackEvent({
+        ...REFUSAL_RECORD,
+        neutralizedByFork: true,
+      } as TranscriptEvent)).toMatchObject({ fable: true, neutralizedByFork: true });
+    });
+
+    it('reads a missing flag as not neutralised', () => {
+      expect(parseClaudeModelFallbackEvent(REFUSAL_RECORD as TranscriptEvent)?.neutralizedByFork)
+        .toBe(false);
     });
   });
 });
 
 describe('modelFallbackStateOf', () => {
-  it('drops the transcript-only scope field', () => {
+  it('drops the transcript-only parse bookkeeping', () => {
     const rec = parseClaudeModelFallbackEvent(REFUSAL_RECORD as TranscriptEvent)!;
     const state = modelFallbackStateOf(rec);
     expect(state).not.toHaveProperty('scope');
+    expect(state).not.toHaveProperty('fable');
+    expect(state).not.toHaveProperty('neutralizedByFork');
     expect(state).toMatchObject({ uuid: REFUSAL_RECORD.uuid, kind: 'refusal' });
   });
 });
@@ -224,16 +257,32 @@ describe('normalizeClaudeModelId', () => {
 });
 
 describe('ClaudeModelFallbackTracker', () => {
-  it('reports a new switch record once, without a serving model', () => {
+  /** A tracker already bound to a Claude session — every observe() below
+   *  reports against it, exactly as the worker's router leaves it. */
+  function bound(claudeSessionId = SID): ClaudeModelFallbackTracker {
     const tracker = new ClaudeModelFallbackTracker();
+    tracker.bind(claudeSessionId);
+    return tracker;
+  }
+
+  it('reports a new switch record once, without a serving model', () => {
+    const tracker = bound();
     const observed = tracker.observe([REFUSAL_RECORD as TranscriptEvent]);
     expect(observed?.fallback).toMatchObject({ uuid: REFUSAL_RECORD.uuid, kind: 'refusal' });
     expect(observed?.fallback).not.toHaveProperty('scope');
+    expect(observed?.fallback).not.toHaveProperty('fable');
     expect(observed).not.toHaveProperty('servingModel');
   });
 
+  it('stamps every observation with the bound Claude session', () => {
+    const tracker = bound();
+    expect(tracker.boundClaudeSessionId).toBe(SID);
+    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])?.claudeSessionId).toBe(SID);
+    expect(tracker.observe([assistant('claude-opus-4-8')])?.claudeSessionId).toBe(SID);
+  });
+
   it('says nothing on a re-drain of the same record (uuid dedupe)', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     tracker.observe([REFUSAL_RECORD as TranscriptEvent]);
     expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toBeNull();
   });
@@ -244,7 +293,7 @@ describe('ClaudeModelFallbackTracker', () => {
     // but the replies preceding it are still stale: without a reset on the dup
     // the worker would report the pre-switch model and the daemon would read it
     // as a switch back and clear a notice that is still current.
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     tracker.observe([assistant('claude-fable-5-1'), REFUSAL_RECORD as TranscriptEvent]);
     expect(tracker.observe([
       assistant('claude-fable-5-1'),
@@ -255,33 +304,58 @@ describe('ClaudeModelFallbackTracker', () => {
       assistant('claude-fable-5-1'),
       REFUSAL_RECORD as TranscriptEvent,
       assistant('claude-opus-4-8'),
-    ])).toEqual({ servingModel: 'claude-opus-4-8' });
+    ])).toEqual({ claudeSessionId: SID, servingModel: 'claude-opus-4-8' });
   });
 
   it('ignores a sub-agent (scope local) fallback entirely', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     expect(tracker.observe([{ ...REFUSAL_RECORD, scope: 'local' } as TranscriptEvent])).toBeNull();
   });
 
-  it('ignores a non-Fable switch entirely (Fable gate)', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+  it('P2-2: reports a non-Fable switch as fallback:null, not silence', () => {
+    // "The newest session-scoped record is not a Fable fallback" is POSITIVE
+    // evidence that no notice applies — the shape that lets the daemon drop an
+    // older Fable notice the user has already moved past.
+    const tracker = bound();
+    expect(tracker.observe([
+      { ...REFUSAL_RECORD, originalModel: 'claude-opus-5' } as TranscriptEvent,
+    ])).toEqual({ claudeSessionId: SID, fallback: null });
+    // Deduped like any other record: the same one re-drained says nothing.
     expect(tracker.observe([
       { ...REFUSAL_RECORD, originalModel: 'claude-opus-5' } as TranscriptEvent,
     ])).toBeNull();
   });
 
+  it('P2-2: reports a fork-neutralised record as fallback:null', () => {
+    const tracker = bound();
+    expect(tracker.observe([
+      { ...REFUSAL_RECORD, neutralizedByFork: true } as TranscriptEvent,
+    ])).toEqual({ claudeSessionId: SID, fallback: null });
+  });
+
+  it('P2-2: a newer non-Fable switch supersedes a live Fable notice', () => {
+    const tracker = bound();
+    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])?.fallback)
+      .toMatchObject({ uuid: REFUSAL_RECORD.uuid });
+    expect(tracker.observe([{
+      ...REFUSAL_RECORD,
+      uuid: 'opus-downgrade',
+      originalModel: 'claude-opus-5',
+    } as TranscriptEvent])).toEqual({ claudeSessionId: SID, fallback: null });
+  });
+
   it('reports the first serving model it sees, then only on change', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     expect(tracker.observe([assistant('claude-fable-5-1')]))
-      .toEqual({ servingModel: 'claude-fable-5-1' });
+      .toEqual({ claudeSessionId: SID, servingModel: 'claude-fable-5-1' });
     expect(tracker.observe([assistant('claude-fable-5-1')])).toBeNull();
     expect(tracker.observe([assistant('claude-opus-4-8')]))
-      .toEqual({ servingModel: 'claude-opus-4-8' });
+      .toEqual({ claudeSessionId: SID, servingModel: 'claude-opus-4-8' });
     expect(tracker.observe([assistant('claude-opus-4-8')])).toBeNull();
   });
 
   it('treats a context-suffix difference as the same serving model', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     tracker.observe([assistant('claude-opus-4-8')]);
     expect(tracker.observe([assistant('claude-opus-4-8[1m]')])).toBeNull();
   });
@@ -289,7 +363,7 @@ describe('ClaudeModelFallbackTracker', () => {
   it('drops a reply written BEFORE the switch in the same batch', () => {
     // Otherwise the daemon would see "fallback to opus" + "serving fable" in one
     // message and clear the notice the instant it appeared.
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     const observed = tracker.observe([
       assistant('claude-fable-5-1'),
       REFUSAL_RECORD as TranscriptEvent,
@@ -299,25 +373,124 @@ describe('ClaudeModelFallbackTracker', () => {
   });
 
   it('reports a reply written AFTER the switch in the same batch', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     expect(tracker.observe([
       REFUSAL_RECORD as TranscriptEvent,
       assistant('claude-opus-4-8'),
     ])).toEqual({
+      claudeSessionId: SID,
       fallback: expect.objectContaining({ uuid: REFUSAL_RECORD.uuid }),
       servingModel: 'claude-opus-4-8',
     });
   });
 
   it('reports the switch-back reply that lets the daemon clear', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-opus-4-8')]);
     expect(tracker.observe([assistant('claude-fable-5-1')]))
-      .toEqual({ servingModel: 'claude-fable-5-1' });
+      .toEqual({ claudeSessionId: SID, servingModel: 'claude-fable-5-1' });
+  });
+
+  describe('P1-1: a switch resets the serving-model dedupe', () => {
+    it('reports the switch-back reply even when one drain carries the whole story', () => {
+      // The bug: Fable was already the reported serving model, so when a single
+      // drain carried "fell off Fable → Opus answered → user switched back →
+      // Fable answered", the batch's closing Fable read as "unchanged" and was
+      // swallowed. The daemon then got the fallback with NO clearing evidence
+      // and the notice hung forever.
+      const tracker = bound();
+      expect(tracker.observe([assistant('claude-fable-5-1')]))
+        .toEqual({ claudeSessionId: SID, servingModel: 'claude-fable-5-1' });
+      expect(tracker.observe([
+        REFUSAL_RECORD as TranscriptEvent,
+        assistant('claude-opus-4-8'),
+        assistant('claude-fable-5-1'),
+      ])).toEqual({
+        claudeSessionId: SID,
+        fallback: expect.objectContaining({ uuid: REFUSAL_RECORD.uuid }),
+        servingModel: 'claude-fable-5-1',
+      });
+    });
+
+    it('re-reports an unchanged serving model right after a switch', () => {
+      // Narrower form of the same rule: the first serving model observed AFTER
+      // a switch always ships, even when its value is old news.
+      const tracker = bound();
+      tracker.observe([assistant('claude-opus-4-8')]);
+      expect(tracker.observe([
+        { ...REFUSAL_RECORD, fallbackModel: 'claude-opus-4-8[1m]' } as TranscriptEvent,
+        assistant('claude-opus-4-8'),
+      ])).toMatchObject({ servingModel: 'claude-opus-4-8' });
+    });
+
+    it('resets the dedupe for a fallback:null record too', () => {
+      const tracker = bound();
+      tracker.observe([assistant('claude-fable-5-1')]);
+      expect(tracker.observe([
+        { ...REFUSAL_RECORD, uuid: 'opus-downgrade', originalModel: 'claude-opus-5' } as TranscriptEvent,
+        assistant('claude-fable-5-1'),
+      ])).toEqual({
+        claudeSessionId: SID,
+        fallback: null,
+        servingModel: 'claude-fable-5-1',
+      });
+    });
+  });
+
+  describe('P1-3: binding to a Claude session', () => {
+    it('drops uuid dedupe and serving-model memory when the session changes', () => {
+      const tracker = bound();
+      tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-opus-4-8')]);
+      expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toBeNull();
+
+      expect(tracker.bind(OTHER_SID)).toBe(true);
+      expect(tracker.boundClaudeSessionId).toBe(OTHER_SID);
+      // Same record, new conversation: reported again, under the new session.
+      expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toEqual({
+        claudeSessionId: OTHER_SID,
+        fallback: expect.objectContaining({ uuid: REFUSAL_RECORD.uuid }),
+      });
+      // …and so is a serving model identical to the one the old session had.
+      expect(tracker.observe([assistant('claude-opus-4-8')]))
+        .toEqual({ claudeSessionId: OTHER_SID, servingModel: 'claude-opus-4-8' });
+    });
+
+    it('is a no-op when the same session is re-bound', () => {
+      const tracker = bound();
+      tracker.observe([REFUSAL_RECORD as TranscriptEvent]);
+      expect(tracker.bind(SID)).toBe(false);
+      expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toBeNull();
+    });
+
+    it('seed binds and ALWAYS publishes, even on an empty scan', () => {
+      // The empty message is how the daemon learns which Claude session the
+      // worker moved to — the only way state belonging to a different one can
+      // be dropped. It is never a claim that a notice is stale.
+      writeFileSync(path, '', 'utf8');
+      const tracker = bound();
+      expect(tracker.seed(path, OTHER_SID)).toEqual({ claudeSessionId: OTHER_SID });
+      expect(tracker.boundClaudeSessionId).toBe(OTHER_SID);
+      expect(tracker.seed(join(dir, 'nope.jsonl'), OTHER_SID))
+        .toEqual({ claudeSessionId: OTHER_SID });
+    });
+
+    it('seed re-finds a record already deduped under another session', () => {
+      // A → B → resume A: the tail scan is what restores A's notice, and it can
+      // only do that because binding back to A cleared B's dedupe state.
+      appendLine(REFUSAL_RECORD);
+      const tracker = bound();
+      expect(tracker.seed(path, SID)?.fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
+      expect(tracker.seed(path, SID)).toEqual({ claudeSessionId: SID }); // deduped
+      tracker.bind(OTHER_SID);
+      expect(tracker.seed(path, SID)).toEqual({
+        claudeSessionId: SID,
+        fallback: expect.objectContaining({ uuid: REFUSAL_RECORD.uuid }),
+      });
+    });
   });
 
   it('ignores <synthetic>, sidechain and API-error replies', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-opus-4-8')]);
     expect(tracker.observe([
       assistant('<synthetic>'),
@@ -327,7 +500,7 @@ describe('ClaudeModelFallbackTracker', () => {
   });
 
   it('reports a second, different switch', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     tracker.observe([REFUSAL_RECORD as TranscriptEvent]);
     expect(tracker.observe([{
       ...REFUSAL_RECORD,
@@ -338,7 +511,7 @@ describe('ClaudeModelFallbackTracker', () => {
   });
 
   it('reports nothing for an events batch with nothing in it', () => {
-    const tracker = new ClaudeModelFallbackTracker();
+    const tracker = bound();
     expect(tracker.observe([])).toBeNull();
     expect(tracker.observe([{ type: 'user', uuid: 'u1' } as TranscriptEvent])).toBeNull();
   });
@@ -347,30 +520,41 @@ describe('ClaudeModelFallbackTracker', () => {
     appendLine({ type: 'user', uuid: 'u1' });
     appendLine(REFUSAL_RECORD);
     appendLine(assistant('claude-opus-4-8'));
-    const tracker = new ClaudeModelFallbackTracker();
-    expect(tracker.seed(path)).toEqual({
+    const tracker = bound();
+    expect(tracker.seed(path, SID)).toEqual({
+      claudeSessionId: SID,
       fallback: expect.objectContaining({ uuid: REFUSAL_RECORD.uuid }),
       servingModel: 'claude-opus-4-8',
     });
     // Idempotent: a second seed (lazy baseline) and a re-drain of the same
-    // line both report nothing new.
-    expect(tracker.seed(path)).toBeNull();
+    // line both report nothing new beyond the session id.
+    expect(tracker.seed(path, SID)).toEqual({ claudeSessionId: SID });
     expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toBeNull();
   });
 
-  it('reports NOTHING when the tail scan finds nothing', () => {
-    // The critical invariant: a short window / fresh transcript must never be
-    // turned into a message, because any message the daemon receives could only
-    // make it drop a notice it is rightly holding.
+  it('carries no fallback / servingModel when the tail scan finds nothing', () => {
+    // The critical invariant is unchanged: a short window / fresh transcript
+    // must never produce a shape the daemon can read as "cleared". It publishes
+    // the session id and NOTHING else, and the daemon leaves same-session state
+    // alone.
     writeFileSync(path, '', 'utf8');
-    expect(new ClaudeModelFallbackTracker().seed(path)).toBeNull();
-    expect(new ClaudeModelFallbackTracker().seed(join(dir, 'nope.jsonl'))).toBeNull();
+    for (const p of [path, join(dir, 'nope.jsonl')]) {
+      const seeded = bound().seed(p, SID);
+      expect(seeded, p).toEqual({ claudeSessionId: SID });
+      expect(seeded, p).not.toHaveProperty('fallback');
+    }
   });
 
   it('seeds a bare serving model when the window holds no switch record', () => {
     appendLine(assistant('claude-fable-5-1'));
-    expect(new ClaudeModelFallbackTracker().seed(path))
-      .toEqual({ servingModel: 'claude-fable-5-1' });
+    expect(bound().seed(path, SID))
+      .toEqual({ claudeSessionId: SID, servingModel: 'claude-fable-5-1' });
+  });
+
+  it('P2-2: seeds fallback:null when the newest record is not a Fable fallback', () => {
+    appendLine(REFUSAL_RECORD);
+    appendLine({ ...REFUSAL_RECORD, uuid: 'opus-downgrade', originalModel: 'claude-opus-5' });
+    expect(bound().seed(path, SID)).toEqual({ claudeSessionId: SID, fallback: null });
   });
 });
 
@@ -415,10 +599,34 @@ describe('readLatestClaudeModelFallback', () => {
     expect(readLatestClaudeModelFallback(path).fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
   });
 
-  it('skips a non-Fable switch and keeps looking for a Fable one', () => {
+  it('P2-2: stops at a newer non-Fable switch and reports null, not the older Fable one', () => {
+    // Walking past it (the old behaviour) resurrected a notice the session had
+    // already left behind: the user switched off Fable, Claude recorded a
+    // routine Opus 5 → Opus 4.8 downgrade, and the scan reached back over it to
+    // the stale Fable record.
     appendLine(REFUSAL_RECORD);
     appendLine({ ...REFUSAL_RECORD, originalModel: 'claude-opus-5', uuid: 'opus-downgrade' });
+    expect(readLatestClaudeModelFallback(path)).toEqual({ fallback: null });
+  });
+
+  it('P2-2: stops at a fork-neutralised record and reports null', () => {
+    // 2.1.259+ copies the parent's refusal record into the fork with
+    // neutralizedByFork:true. It applies to the parent, never here.
+    appendLine({ ...REFUSAL_RECORD, neutralizedByFork: true });
+    expect(readLatestClaudeModelFallback(path)).toEqual({ fallback: null });
+  });
+
+  it('P2-2: still reports the record when it is the newest and genuinely live', () => {
+    appendLine({ ...REFUSAL_RECORD, originalModel: 'claude-opus-5', uuid: 'opus-downgrade' });
+    appendLine(REFUSAL_RECORD);
     expect(readLatestClaudeModelFallback(path).fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
+  });
+
+  it('P2-2: distinguishes "no evidence" from "positive no-notice"', () => {
+    // Absent vs null is the whole point: absent leaves the daemon's state
+    // alone, null clears it.
+    appendLine({ type: 'user', uuid: 'u1' });
+    expect(readLatestClaudeModelFallback(path)).not.toHaveProperty('fallback');
   });
 
   it('returns nothing for a missing, empty, or fallback-free transcript', () => {

--- a/test/claude-model-fallback-transcript.test.ts
+++ b/test/claude-model-fallback-transcript.test.ts
@@ -344,6 +344,58 @@ describe('ClaudeModelFallbackTracker', () => {
     } as TranscriptEvent])).toEqual({ claudeSessionId: SID, fallback: null });
   });
 
+  describe('P2-2: the NEWEST record in the batch decides, even when deduped', () => {
+    // A drain from offset 0 (a fingerprint/rotation switch onto this file, or
+    // drainTranscript's truncation re-read) replays the WHOLE file. The newest
+    // switch record in it is routinely one we already reported, while an older
+    // one that predates this worker's baseline has never been seen. Letting the
+    // unseen older record win would resurrect exactly the notice the newest one
+    // retired — the P2-2 bug, back through the P1-2 drains.
+    const DOWNGRADE = {
+      ...REFUSAL_RECORD,
+      uuid: 'opus-downgrade',
+      originalModel: 'claude-opus-5',
+      fallbackModel: 'claude-opus-4-8',
+    } as TranscriptEvent;
+
+    it('an already-reported non-Fable record still buries an older unseen Fable one', () => {
+      const tracker = bound();
+      expect(tracker.observe([DOWNGRADE])).toEqual({ claudeSessionId: SID, fallback: null });
+      // The replay: older Fable record first, the deduped newest one last.
+      expect(tracker.observe([
+        REFUSAL_RECORD as TranscriptEvent,
+        assistant('claude-opus-4-8'),
+        DOWNGRADE,
+      ])?.fallback ?? undefined).toBeUndefined();
+    });
+
+    it('an already-reported Fable record is not replaced by an older one', () => {
+      const older = { ...REFUSAL_RECORD, uuid: 'older-fable' } as TranscriptEvent;
+      const tracker = bound();
+      expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])?.fallback)
+        .toMatchObject({ uuid: REFUSAL_RECORD.uuid });
+      expect(tracker.observe([older, REFUSAL_RECORD as TranscriptEvent])?.fallback ?? undefined)
+        .toBeUndefined();
+    });
+
+    it('a switch-path replay after the seed reports no stale record', () => {
+      // Exactly what bridgeApplyFingerprintSwitch / performRotationSwitch do:
+      // seed the new path's tail first, then fold the same file's events in
+      // from offset 0.
+      appendLine(REFUSAL_RECORD);
+      appendLine(assistant('claude-opus-4-8'));
+      appendLine({ ...REFUSAL_RECORD, uuid: 'newer-fable' });
+      const tracker = new ClaudeModelFallbackTracker();
+      expect(tracker.seed(path, SID).fallback).toMatchObject({ uuid: 'newer-fable' });
+      const replay = tracker.observe([
+        REFUSAL_RECORD as TranscriptEvent,
+        assistant('claude-opus-4-8'),
+        { ...REFUSAL_RECORD, uuid: 'newer-fable' } as TranscriptEvent,
+      ]);
+      expect(replay?.fallback ?? undefined).toBeUndefined();
+    });
+  });
+
   it('reports the first serving model it sees, then only on change', () => {
     const tracker = bound();
     expect(tracker.observe([assistant('claude-fable-5-1')]))

--- a/test/claude-model-fallback-transcript.test.ts
+++ b/test/claude-model-fallback-transcript.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Claude Code writes a `type:"system"` record whenever it automatically
+ * switches the session model. These tests cover the parse, the "is it still in
+ * effect" rule (serving model vs. fallback model), the bridge tracker's dedupe /
+ * local-scope / clearing behaviour, and the cold-start tail scan.
+ *
+ * Run: npx vitest run --project unit test/claude-model-fallback-transcript.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, appendFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ClaudeModelFallbackTracker,
+  normalizeClaudeModelId,
+  parseClaudeModelFallbackEvent,
+  readLatestClaudeModelFallback,
+  resolveActiveModelFallback,
+  servingModelFromAssistantEvent,
+  type ClaudeModelFallbackRecord,
+  type TranscriptEvent,
+} from '../src/services/claude-transcript.js';
+
+let dir: string;
+let path: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'bmx-mfb-'));
+  path = join(dir, 'session.jsonl');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function appendLine(obj: unknown): void {
+  appendFileSync(path, JSON.stringify(obj) + '\n', 'utf8');
+}
+
+/** Verbatim shape of a real Claude Code refusal-fallback record. */
+const REFUSAL_RECORD = {
+  type: 'system',
+  subtype: 'model_refusal_fallback',
+  content: "Fable 5.1's safeguards flagged this message. Switched to Opus 4.8 (1M context).",
+  level: 'warning',
+  trigger: 'refusal',
+  direction: 'retry',
+  scope: 'session',
+  originalModel: 'claude-fable-5-1[1m]',
+  fallbackModel: 'claude-opus-4-8[1m]',
+  apiRefusalCategory: 'cyber',
+  uuid: '0b5864a0-1111-2222-3333-444444444444',
+  timestamp: '2026-09-02T09:23:37.007Z',
+  sessionId: 'a9bc732e-0000-0000-0000-000000000000',
+};
+
+function assistant(model: string, extra: Record<string, unknown> = {}): TranscriptEvent {
+  return {
+    type: 'assistant',
+    uuid: `a-${model}-${Math.random().toString(36).slice(2)}`,
+    message: { role: 'assistant', model, content: [{ type: 'text', text: 'hi' }] },
+    ...extra,
+  } as TranscriptEvent;
+}
+
+describe('parseClaudeModelFallbackEvent', () => {
+  it('parses a real refusal-fallback record', () => {
+    expect(parseClaudeModelFallbackEvent(REFUSAL_RECORD as TranscriptEvent)).toEqual({
+      uuid: REFUSAL_RECORD.uuid,
+      kind: 'refusal',
+      originalModel: 'claude-fable-5-1[1m]',
+      fallbackModel: 'claude-opus-4-8[1m]',
+      scope: 'session',
+      trigger: 'refusal',
+      apiRefusalCategory: 'cyber',
+      observedAt: REFUSAL_RECORD.timestamp,
+    });
+  });
+
+  it('maps all three subtypes to a kind', () => {
+    const kinds = (['model_refusal_fallback', 'model_fallback', 'model_consent_fallback'] as const)
+      .map(subtype => parseClaudeModelFallbackEvent({
+        ...REFUSAL_RECORD,
+        subtype,
+      } as TranscriptEvent)?.kind);
+    expect(kinds).toEqual(['refusal', 'unavailable', 'consent']);
+  });
+
+  it('keeps the raw trigger of a model_fallback record', () => {
+    const rec = parseClaudeModelFallbackEvent({
+      type: 'system',
+      subtype: 'model_fallback',
+      trigger: 'overloaded',
+      originalModel: 'claude-fable-5-1[1m]',
+      fallbackModel: 'claude-opus-4-8[1m]',
+      uuid: 'u-overloaded',
+    } as TranscriptEvent);
+    expect(rec).toMatchObject({ kind: 'unavailable', trigger: 'overloaded', scope: 'session' });
+  });
+
+  it('reads a record with no scope field (older Claude Code) as session scope', () => {
+    const { scope, ...withoutScope } = REFUSAL_RECORD;
+    expect(scope).toBe('session');
+    expect(parseClaudeModelFallbackEvent(withoutScope as TranscriptEvent)?.scope).toBe('session');
+  });
+
+  it('marks a sub-agent fallback as local scope', () => {
+    expect(parseClaudeModelFallbackEvent({
+      ...REFUSAL_RECORD,
+      scope: 'local',
+    } as TranscriptEvent)?.scope).toBe('local');
+  });
+
+  it('rejects a record missing the uuid or either model id (fail-closed)', () => {
+    for (const missing of ['uuid', 'originalModel', 'fallbackModel'] as const) {
+      const partial: any = { ...REFUSAL_RECORD };
+      delete partial[missing];
+      expect(parseClaudeModelFallbackEvent(partial as TranscriptEvent)).toBeUndefined();
+    }
+  });
+
+  it('ignores non-fallback events', () => {
+    expect(parseClaudeModelFallbackEvent(assistant('claude-opus-5'))).toBeUndefined();
+    expect(parseClaudeModelFallbackEvent({ type: 'user', uuid: 'u1' } as TranscriptEvent)).toBeUndefined();
+    expect(parseClaudeModelFallbackEvent({
+      type: 'system',
+      subtype: 'turn_duration',
+      uuid: 'u2',
+    } as TranscriptEvent)).toBeUndefined();
+  });
+});
+
+describe('servingModelFromAssistantEvent', () => {
+  it('returns the model of a normal assistant record', () => {
+    expect(servingModelFromAssistantEvent(assistant('claude-opus-4-8'))).toBe('claude-opus-4-8');
+  });
+
+  it('ignores the <synthetic> API-error placeholder', () => {
+    expect(servingModelFromAssistantEvent(assistant('<synthetic>'))).toBeUndefined();
+  });
+
+  it('ignores sub-agent (sidechain) and API-error records', () => {
+    expect(servingModelFromAssistantEvent(assistant('claude-opus-5', { isSidechain: true }))).toBeUndefined();
+    expect(servingModelFromAssistantEvent(assistant('claude-opus-5', { isApiErrorMessage: true }))).toBeUndefined();
+  });
+
+  it('ignores non-assistant records', () => {
+    expect(servingModelFromAssistantEvent(REFUSAL_RECORD as TranscriptEvent)).toBeUndefined();
+  });
+});
+
+describe('normalizeClaudeModelId', () => {
+  it('makes a context-suffixed id comparable with a bare one', () => {
+    expect(normalizeClaudeModelId('claude-fable-5-1[1m]'))
+      .toBe(normalizeClaudeModelId('claude-fable-5-1'));
+    expect(normalizeClaudeModelId('CLAUDE-Opus-4-8')).toBe('claude-opus-4-8');
+    expect(normalizeClaudeModelId('  ')).toBeUndefined();
+    expect(normalizeClaudeModelId(undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveActiveModelFallback', () => {
+  const fallback = parseClaudeModelFallbackEvent(REFUSAL_RECORD as TranscriptEvent)!;
+
+  it('keeps the state while the fallback model is still serving', () => {
+    const state = resolveActiveModelFallback({ fallback, servingModel: 'claude-opus-4-8' });
+    expect(state).toMatchObject({ kind: 'refusal', fallbackModel: 'claude-opus-4-8[1m]' });
+    expect(state).not.toHaveProperty('scope');
+  });
+
+  it('clears once the user switched back to the original model', () => {
+    expect(resolveActiveModelFallback({ fallback, servingModel: 'claude-fable-5-1' })).toBeNull();
+  });
+
+  it('keeps the state when no reply has been served since the switch', () => {
+    expect(resolveActiveModelFallback({ fallback, servingModel: undefined })).not.toBeNull();
+  });
+
+  it('returns null with no record, or a local-scope one', () => {
+    expect(resolveActiveModelFallback({})).toBeNull();
+    expect(resolveActiveModelFallback({
+      fallback: { ...fallback, scope: 'local' } as ClaudeModelFallbackRecord,
+    })).toBeNull();
+  });
+});
+
+describe('ClaudeModelFallbackTracker', () => {
+  it('accepts a switch once and reports it as active', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toHaveLength(1);
+    expect(tracker.current()).toMatchObject({ uuid: REFUSAL_RECORD.uuid, kind: 'refusal' });
+  });
+
+  it('ignores the same record on a re-drain (uuid dedupe)', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.observe([REFUSAL_RECORD as TranscriptEvent]);
+    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toEqual([]);
+    expect(tracker.current()).not.toBeNull();
+  });
+
+  it('ignores a sub-agent (scope local) fallback entirely', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    expect(tracker.observe([{ ...REFUSAL_RECORD, scope: 'local' } as TranscriptEvent])).toEqual([]);
+    expect(tracker.current()).toBeNull();
+  });
+
+  it('does not clear on a reply written before the switch', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.observe([assistant('claude-fable-5-1'), REFUSAL_RECORD as TranscriptEvent]);
+    expect(tracker.current()).not.toBeNull();
+  });
+
+  it('clears after the user switches back with /model', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-opus-4-8')]);
+    expect(tracker.current()).not.toBeNull();
+    tracker.observe([assistant('claude-fable-5-1')]);
+    expect(tracker.current()).toBeNull();
+  });
+
+  it('ignores <synthetic> and sidechain replies when deciding to clear', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-opus-4-8')]);
+    tracker.observe([
+      assistant('<synthetic>'),
+      assistant('claude-fable-5-1', { isSidechain: true }),
+      assistant('claude-fable-5-1', { isApiErrorMessage: true }),
+    ]);
+    expect(tracker.current()).not.toBeNull();
+  });
+
+  it('re-arms on a second, different switch', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-fable-5-1')]);
+    expect(tracker.current()).toBeNull();
+    tracker.observe([{
+      ...REFUSAL_RECORD,
+      subtype: 'model_fallback',
+      trigger: 'overloaded',
+      uuid: 'second-switch',
+    } as TranscriptEvent]);
+    expect(tracker.current()).toMatchObject({ uuid: 'second-switch', kind: 'unavailable' });
+  });
+
+  it('seeds from a transcript tail (cold start after --resume)', () => {
+    appendLine({ type: 'user', uuid: 'u1' });
+    appendLine(REFUSAL_RECORD);
+    appendLine(assistant('claude-opus-4-8'));
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.seed(path);
+    expect(tracker.current()).toMatchObject({ uuid: REFUSAL_RECORD.uuid });
+    // A seeded record must not be re-accepted when the same line is drained.
+    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toEqual([]);
+  });
+});
+
+describe('readLatestClaudeModelFallback', () => {
+  it('returns the newest switch plus the model serving since it', () => {
+    appendLine(REFUSAL_RECORD);
+    appendLine(assistant('claude-opus-4-8'));
+    const r = readLatestClaudeModelFallback(path);
+    expect(r.fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
+    expect(r.servingModel).toBe('claude-opus-4-8');
+    expect(resolveActiveModelFallback(r)).not.toBeNull();
+  });
+
+  it('reports the original model once the user switched back', () => {
+    appendLine(REFUSAL_RECORD);
+    appendLine(assistant('claude-opus-4-8'));
+    appendLine(assistant('claude-fable-5-1'));
+    const r = readLatestClaudeModelFallback(path);
+    expect(r.servingModel).toBe('claude-fable-5-1');
+    expect(resolveActiveModelFallback(r)).toBeNull();
+  });
+
+  it('does not read a reply from before the switch as the serving model', () => {
+    appendLine(assistant('claude-fable-5-1'));
+    appendLine(REFUSAL_RECORD);
+    const r = readLatestClaudeModelFallback(path);
+    expect(r.fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
+    expect(r.servingModel).toBeUndefined();
+    expect(resolveActiveModelFallback(r)).not.toBeNull();
+  });
+
+  it('skips a local-scope record and keeps looking for a session one', () => {
+    appendLine(REFUSAL_RECORD);
+    appendLine({ ...REFUSAL_RECORD, scope: 'local', uuid: 'sub-agent-uuid' });
+    expect(readLatestClaudeModelFallback(path).fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
+  });
+
+  it('returns nothing for a missing, empty, or fallback-free transcript', () => {
+    expect(readLatestClaudeModelFallback(join(dir, 'nope.jsonl'))).toEqual({});
+    writeFileSync(path, '', 'utf8');
+    expect(readLatestClaudeModelFallback(path)).toEqual({});
+    appendLine({ type: 'user', uuid: 'u1' });
+    expect(readLatestClaudeModelFallback(path).fallback).toBeUndefined();
+  });
+
+  it('ignores a half-written trailing line', () => {
+    appendLine({ type: 'user', uuid: 'u1' });
+    appendFileSync(path, JSON.stringify(REFUSAL_RECORD), 'utf8'); // no trailing newline
+    expect(readLatestClaudeModelFallback(path).fallback).toBeUndefined();
+  });
+
+  it('finds a switch that is further back than one 64KiB chunk', () => {
+    appendLine(REFUSAL_RECORD);
+    for (let i = 0; i < 200; i++) {
+      appendLine({ type: 'user', uuid: `pad-${i}`, message: { role: 'user', content: 'x'.repeat(1000) } });
+    }
+    expect(readLatestClaudeModelFallback(path).fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
+  });
+});

--- a/test/claude-model-fallback-transcript.test.ts
+++ b/test/claude-model-fallback-transcript.test.ts
@@ -1,8 +1,12 @@
 /**
  * Claude Code writes a `type:"system"` record whenever it automatically
- * switches the session model. These tests cover the parse, the "is it still in
- * effect" rule (serving model vs. fallback model), the bridge tracker's dedupe /
- * local-scope / clearing behaviour, and the cold-start tail scan.
+ * switches the session model. These tests cover the parse (including the
+ * product's "Fable originals only" scope), the bridge tracker's dedupe /
+ * local-scope / serving-model reporting, and the cold-start tail scan.
+ *
+ * The tracker reports OBSERVED FACTS only — it never decides whether the
+ * notice should still show. That decision lives in the daemon
+ * (mergeModelFallbackObservation, covered in model-fallback-daemon-state).
  *
  * Run: npx vitest run --project unit test/claude-model-fallback-transcript.test.ts
  */
@@ -12,12 +16,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   ClaudeModelFallbackTracker,
+  isFableModelId,
+  modelFallbackStateOf,
   normalizeClaudeModelId,
   parseClaudeModelFallbackEvent,
   readLatestClaudeModelFallback,
-  resolveActiveModelFallback,
   servingModelFromAssistantEvent,
-  type ClaudeModelFallbackRecord,
   type TranscriptEvent,
 } from '../src/services/claude-transcript.js';
 
@@ -62,6 +66,35 @@ function assistant(model: string, extra: Record<string, unknown> = {}): Transcri
     ...extra,
   } as TranscriptEvent;
 }
+
+describe('isFableModelId', () => {
+  it('accepts Fable ids whatever the case or context suffix', () => {
+    for (const id of [
+      'claude-fable-5-1',
+      'claude-fable-5-1[1m]',
+      'claude-fable-5[1m]',
+      'CLAUDE-Fable-5-1[1M]',
+      '  claude-fable-5-1  ',
+    ]) {
+      expect(isFableModelId(id), id).toBe(true);
+    }
+  });
+
+  it('rejects every non-Fable id, including the empty ones', () => {
+    for (const id of [
+      'claude-opus-5',
+      'claude-opus-5[1m]',
+      'claude-opus-4-8',
+      'claude-sonnet-4-5',
+      'fable-5-1',
+      '',
+      '   ',
+      undefined,
+    ]) {
+      expect(isFableModelId(id), String(id)).toBe(false);
+    }
+  });
+});
 
 describe('parseClaudeModelFallbackEvent', () => {
   it('parses a real refusal-fallback record', () => {
@@ -128,6 +161,37 @@ describe('parseClaudeModelFallbackEvent', () => {
       uuid: 'u2',
     } as TranscriptEvent)).toBeUndefined();
   });
+
+  describe('Fable gate (product scope)', () => {
+    it('ignores a switch whose original model is not Fable', () => {
+      // Opus 5 → Opus 4.8 is a routine safety downgrade; surfacing it would
+      // put a warning on sessions that never asked for Fable.
+      for (const originalModel of ['claude-opus-5', 'claude-opus-5[1m]', 'claude-sonnet-4-5']) {
+        expect(parseClaudeModelFallbackEvent({
+          ...REFUSAL_RECORD,
+          originalModel,
+        } as TranscriptEvent), originalModel).toBeUndefined();
+      }
+    });
+
+    it('accepts every Fable spelling', () => {
+      for (const originalModel of ['claude-fable-5[1m]', 'claude-fable-5-1', 'Claude-Fable-5-1[1M]']) {
+        expect(parseClaudeModelFallbackEvent({
+          ...REFUSAL_RECORD,
+          originalModel,
+        } as TranscriptEvent)?.originalModel, originalModel).toBe(originalModel);
+      }
+    });
+  });
+});
+
+describe('modelFallbackStateOf', () => {
+  it('drops the transcript-only scope field', () => {
+    const rec = parseClaudeModelFallbackEvent(REFUSAL_RECORD as TranscriptEvent)!;
+    const state = modelFallbackStateOf(rec);
+    expect(state).not.toHaveProperty('scope');
+    expect(state).toMatchObject({ uuid: REFUSAL_RECORD.uuid, kind: 'refusal' });
+  });
 });
 
 describe('servingModelFromAssistantEvent', () => {
@@ -159,87 +223,104 @@ describe('normalizeClaudeModelId', () => {
   });
 });
 
-describe('resolveActiveModelFallback', () => {
-  const fallback = parseClaudeModelFallbackEvent(REFUSAL_RECORD as TranscriptEvent)!;
-
-  it('keeps the state while the fallback model is still serving', () => {
-    const state = resolveActiveModelFallback({ fallback, servingModel: 'claude-opus-4-8' });
-    expect(state).toMatchObject({ kind: 'refusal', fallbackModel: 'claude-opus-4-8[1m]' });
-    expect(state).not.toHaveProperty('scope');
-  });
-
-  it('clears once the user switched back to the original model', () => {
-    expect(resolveActiveModelFallback({ fallback, servingModel: 'claude-fable-5-1' })).toBeNull();
-  });
-
-  it('keeps the state when no reply has been served since the switch', () => {
-    expect(resolveActiveModelFallback({ fallback, servingModel: undefined })).not.toBeNull();
-  });
-
-  it('returns null with no record, or a local-scope one', () => {
-    expect(resolveActiveModelFallback({})).toBeNull();
-    expect(resolveActiveModelFallback({
-      fallback: { ...fallback, scope: 'local' } as ClaudeModelFallbackRecord,
-    })).toBeNull();
-  });
-});
-
 describe('ClaudeModelFallbackTracker', () => {
-  it('accepts a switch once and reports it as active', () => {
+  it('reports a new switch record once, without a serving model', () => {
     const tracker = new ClaudeModelFallbackTracker();
-    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toHaveLength(1);
-    expect(tracker.current()).toMatchObject({ uuid: REFUSAL_RECORD.uuid, kind: 'refusal' });
+    const observed = tracker.observe([REFUSAL_RECORD as TranscriptEvent]);
+    expect(observed?.fallback).toMatchObject({ uuid: REFUSAL_RECORD.uuid, kind: 'refusal' });
+    expect(observed?.fallback).not.toHaveProperty('scope');
+    expect(observed).not.toHaveProperty('servingModel');
   });
 
-  it('ignores the same record on a re-drain (uuid dedupe)', () => {
+  it('says nothing on a re-drain of the same record (uuid dedupe)', () => {
     const tracker = new ClaudeModelFallbackTracker();
     tracker.observe([REFUSAL_RECORD as TranscriptEvent]);
-    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toEqual([]);
-    expect(tracker.current()).not.toBeNull();
+    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toBeNull();
   });
 
   it('ignores a sub-agent (scope local) fallback entirely', () => {
     const tracker = new ClaudeModelFallbackTracker();
-    expect(tracker.observe([{ ...REFUSAL_RECORD, scope: 'local' } as TranscriptEvent])).toEqual([]);
-    expect(tracker.current()).toBeNull();
+    expect(tracker.observe([{ ...REFUSAL_RECORD, scope: 'local' } as TranscriptEvent])).toBeNull();
   });
 
-  it('does not clear on a reply written before the switch', () => {
+  it('ignores a non-Fable switch entirely (Fable gate)', () => {
     const tracker = new ClaudeModelFallbackTracker();
-    tracker.observe([assistant('claude-fable-5-1'), REFUSAL_RECORD as TranscriptEvent]);
-    expect(tracker.current()).not.toBeNull();
+    expect(tracker.observe([
+      { ...REFUSAL_RECORD, originalModel: 'claude-opus-5' } as TranscriptEvent,
+    ])).toBeNull();
   });
 
-  it('clears after the user switches back with /model', () => {
+  it('reports the first serving model it sees, then only on change', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    expect(tracker.observe([assistant('claude-fable-5-1')]))
+      .toEqual({ servingModel: 'claude-fable-5-1' });
+    expect(tracker.observe([assistant('claude-fable-5-1')])).toBeNull();
+    expect(tracker.observe([assistant('claude-opus-4-8')]))
+      .toEqual({ servingModel: 'claude-opus-4-8' });
+    expect(tracker.observe([assistant('claude-opus-4-8')])).toBeNull();
+  });
+
+  it('treats a context-suffix difference as the same serving model', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.observe([assistant('claude-opus-4-8')]);
+    expect(tracker.observe([assistant('claude-opus-4-8[1m]')])).toBeNull();
+  });
+
+  it('drops a reply written BEFORE the switch in the same batch', () => {
+    // Otherwise the daemon would see "fallback to opus" + "serving fable" in one
+    // message and clear the notice the instant it appeared.
+    const tracker = new ClaudeModelFallbackTracker();
+    const observed = tracker.observe([
+      assistant('claude-fable-5-1'),
+      REFUSAL_RECORD as TranscriptEvent,
+    ]);
+    expect(observed?.fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
+    expect(observed).not.toHaveProperty('servingModel');
+  });
+
+  it('reports a reply written AFTER the switch in the same batch', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    expect(tracker.observe([
+      REFUSAL_RECORD as TranscriptEvent,
+      assistant('claude-opus-4-8'),
+    ])).toEqual({
+      fallback: expect.objectContaining({ uuid: REFUSAL_RECORD.uuid }),
+      servingModel: 'claude-opus-4-8',
+    });
+  });
+
+  it('reports the switch-back reply that lets the daemon clear', () => {
     const tracker = new ClaudeModelFallbackTracker();
     tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-opus-4-8')]);
-    expect(tracker.current()).not.toBeNull();
-    tracker.observe([assistant('claude-fable-5-1')]);
-    expect(tracker.current()).toBeNull();
+    expect(tracker.observe([assistant('claude-fable-5-1')]))
+      .toEqual({ servingModel: 'claude-fable-5-1' });
   });
 
-  it('ignores <synthetic> and sidechain replies when deciding to clear', () => {
+  it('ignores <synthetic>, sidechain and API-error replies', () => {
     const tracker = new ClaudeModelFallbackTracker();
     tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-opus-4-8')]);
-    tracker.observe([
+    expect(tracker.observe([
       assistant('<synthetic>'),
       assistant('claude-fable-5-1', { isSidechain: true }),
       assistant('claude-fable-5-1', { isApiErrorMessage: true }),
-    ]);
-    expect(tracker.current()).not.toBeNull();
+    ])).toBeNull();
   });
 
-  it('re-arms on a second, different switch', () => {
+  it('reports a second, different switch', () => {
     const tracker = new ClaudeModelFallbackTracker();
-    tracker.observe([REFUSAL_RECORD as TranscriptEvent, assistant('claude-fable-5-1')]);
-    expect(tracker.current()).toBeNull();
-    tracker.observe([{
+    tracker.observe([REFUSAL_RECORD as TranscriptEvent]);
+    expect(tracker.observe([{
       ...REFUSAL_RECORD,
       subtype: 'model_fallback',
       trigger: 'overloaded',
       uuid: 'second-switch',
-    } as TranscriptEvent]);
-    expect(tracker.current()).toMatchObject({ uuid: 'second-switch', kind: 'unavailable' });
+    } as TranscriptEvent])?.fallback).toMatchObject({ uuid: 'second-switch', kind: 'unavailable' });
+  });
+
+  it('reports nothing for an events batch with nothing in it', () => {
+    const tracker = new ClaudeModelFallbackTracker();
+    expect(tracker.observe([])).toBeNull();
+    expect(tracker.observe([{ type: 'user', uuid: 'u1' } as TranscriptEvent])).toBeNull();
   });
 
   it('seeds from a transcript tail (cold start after --resume)', () => {
@@ -247,10 +328,29 @@ describe('ClaudeModelFallbackTracker', () => {
     appendLine(REFUSAL_RECORD);
     appendLine(assistant('claude-opus-4-8'));
     const tracker = new ClaudeModelFallbackTracker();
-    tracker.seed(path);
-    expect(tracker.current()).toMatchObject({ uuid: REFUSAL_RECORD.uuid });
-    // A seeded record must not be re-accepted when the same line is drained.
-    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toEqual([]);
+    expect(tracker.seed(path)).toEqual({
+      fallback: expect.objectContaining({ uuid: REFUSAL_RECORD.uuid }),
+      servingModel: 'claude-opus-4-8',
+    });
+    // Idempotent: a second seed (lazy baseline) and a re-drain of the same
+    // line both report nothing new.
+    expect(tracker.seed(path)).toBeNull();
+    expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toBeNull();
+  });
+
+  it('reports NOTHING when the tail scan finds nothing', () => {
+    // The critical invariant: a short window / fresh transcript must never be
+    // turned into a message, because any message the daemon receives could only
+    // make it drop a notice it is rightly holding.
+    writeFileSync(path, '', 'utf8');
+    expect(new ClaudeModelFallbackTracker().seed(path)).toBeNull();
+    expect(new ClaudeModelFallbackTracker().seed(join(dir, 'nope.jsonl'))).toBeNull();
+  });
+
+  it('seeds a bare serving model when the window holds no switch record', () => {
+    appendLine(assistant('claude-fable-5-1'));
+    expect(new ClaudeModelFallbackTracker().seed(path))
+      .toEqual({ servingModel: 'claude-fable-5-1' });
   });
 });
 
@@ -261,7 +361,6 @@ describe('readLatestClaudeModelFallback', () => {
     const r = readLatestClaudeModelFallback(path);
     expect(r.fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
     expect(r.servingModel).toBe('claude-opus-4-8');
-    expect(resolveActiveModelFallback(r)).not.toBeNull();
   });
 
   it('reports the original model once the user switched back', () => {
@@ -269,8 +368,8 @@ describe('readLatestClaudeModelFallback', () => {
     appendLine(assistant('claude-opus-4-8'));
     appendLine(assistant('claude-fable-5-1'));
     const r = readLatestClaudeModelFallback(path);
+    expect(r.fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
     expect(r.servingModel).toBe('claude-fable-5-1');
-    expect(resolveActiveModelFallback(r)).toBeNull();
   });
 
   it('does not read a reply from before the switch as the serving model', () => {
@@ -279,12 +378,26 @@ describe('readLatestClaudeModelFallback', () => {
     const r = readLatestClaudeModelFallback(path);
     expect(r.fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
     expect(r.servingModel).toBeUndefined();
-    expect(resolveActiveModelFallback(r)).not.toBeNull();
+  });
+
+  it('returns the serving model alone when the window holds no switch record', () => {
+    // The long-session case: the switch scrolled past the scan cap. The serving
+    // model is still worth reporting — the daemon compares it with the record
+    // IT persisted, which is the only copy that survived.
+    appendLine({ type: 'user', uuid: 'u1' });
+    appendLine(assistant('claude-opus-4-8'));
+    expect(readLatestClaudeModelFallback(path)).toEqual({ servingModel: 'claude-opus-4-8' });
   });
 
   it('skips a local-scope record and keeps looking for a session one', () => {
     appendLine(REFUSAL_RECORD);
     appendLine({ ...REFUSAL_RECORD, scope: 'local', uuid: 'sub-agent-uuid' });
+    expect(readLatestClaudeModelFallback(path).fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
+  });
+
+  it('skips a non-Fable switch and keeps looking for a Fable one', () => {
+    appendLine(REFUSAL_RECORD);
+    appendLine({ ...REFUSAL_RECORD, originalModel: 'claude-opus-5', uuid: 'opus-downgrade' });
     expect(readLatestClaudeModelFallback(path).fallback?.uuid).toBe(REFUSAL_RECORD.uuid);
   });
 

--- a/test/claude-model-fallback-transcript.test.ts
+++ b/test/claude-model-fallback-transcript.test.ts
@@ -238,6 +238,26 @@ describe('ClaudeModelFallbackTracker', () => {
     expect(tracker.observe([REFUSAL_RECORD as TranscriptEvent])).toBeNull();
   });
 
+  it('a re-drained record still drops the replies written before it', () => {
+    // A jsonl switch / baseline self-heal rewinds the bridge to offset 0 and
+    // replays the WHOLE file in one batch. The switch record is a dup by then,
+    // but the replies preceding it are still stale: without a reset on the dup
+    // the worker would report the pre-switch model and the daemon would read it
+    // as a switch back and clear a notice that is still current.
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.observe([assistant('claude-fable-5-1'), REFUSAL_RECORD as TranscriptEvent]);
+    expect(tracker.observe([
+      assistant('claude-fable-5-1'),
+      REFUSAL_RECORD as TranscriptEvent,
+    ])).toBeNull();
+    // …and the post-switch reply in the same replay is still reported.
+    expect(tracker.observe([
+      assistant('claude-fable-5-1'),
+      REFUSAL_RECORD as TranscriptEvent,
+      assistant('claude-opus-4-8'),
+    ])).toEqual({ servingModel: 'claude-opus-4-8' });
+  });
+
   it('ignores a sub-agent (scope local) fallback entirely', () => {
     const tracker = new ClaudeModelFallbackTracker();
     expect(tracker.observe([{ ...REFUSAL_RECORD, scope: 'local' } as TranscriptEvent])).toBeNull();

--- a/test/model-fallback-daemon-state.test.ts
+++ b/test/model-fallback-daemon-state.test.ts
@@ -1,8 +1,13 @@
 /**
- * Daemon-side plumbing for the model-fallback notice: the state has to reach
- * the card through the usage snapshot (including for bots that hide usage —
- * this is a warning, not a metric), and it has to survive a daemon restart via
- * the same persisted-stream-card path as usageLimit.
+ * Daemon-side ownership of the model-fallback notice. The daemon — not the
+ * worker — holds this state: it outlives every worker generation, while a
+ * worker only ever sees a bounded tail of the transcript. Covered here:
+ *
+ *   - the merge rules that turn a worker's observation into state;
+ *   - the state reaching the card through the usage snapshot (including for
+ *     bots that hide usage — this is a warning, not a metric);
+ *   - surviving a daemon restart via the same persisted-stream-card path as
+ *     usageLimit.
  *
  * Run: npx vitest run --project unit test/model-fallback-daemon-state.test.ts
  */
@@ -22,7 +27,7 @@ vi.mock('../src/services/session-store.js', async importOriginal => ({
   updateSession,
 }));
 
-const { getDaemonStreamingCardUsageSnapshot } = await import('../src/core/worker-pool.js');
+const { getDaemonStreamingCardUsageSnapshot, mergeModelFallbackObservation } = await import('../src/core/worker-pool.js');
 const { persistStreamCardState } = await import('../src/core/session-manager.js');
 
 const FALLBACK: ModelFallbackState = {
@@ -104,5 +109,86 @@ describe('persistStreamCardState: model fallback', () => {
     persistStreamCardState(ds);
     expect(updateSession).toHaveBeenCalledTimes(1);
     expect(ds.session.modelFallback?.uuid).toBe('u-second');
+  });
+});
+
+describe('mergeModelFallbackObservation', () => {
+  it('(b) takes a switch record with a new uuid', () => {
+    expect(mergeModelFallbackObservation(undefined, { fallback: FALLBACK }))
+      .toEqual({ next: FALLBACK, changed: true });
+    const second = { ...FALLBACK, uuid: 'u-second', fallbackModel: 'claude-sonnet-4-5' };
+    expect(mergeModelFallbackObservation(FALLBACK, { fallback: second }))
+      .toEqual({ next: second, changed: true });
+  });
+
+  it('(c) clears once a reply is served by a different model', () => {
+    expect(mergeModelFallbackObservation(FALLBACK, { servingModel: 'claude-fable-5-1' }))
+      .toEqual({ next: undefined, changed: true });
+  });
+
+  it('(d) reports no change when the same record arrives again', () => {
+    expect(mergeModelFallbackObservation(FALLBACK, { fallback: { ...FALLBACK } }))
+      .toEqual({ next: FALLBACK, changed: false });
+  });
+
+  it('(e) reports no change for an observation carrying nothing', () => {
+    expect(mergeModelFallbackObservation(FALLBACK, {}))
+      .toEqual({ next: FALLBACK, changed: false });
+    expect(mergeModelFallbackObservation(undefined, {}))
+      .toEqual({ next: undefined, changed: false });
+  });
+
+  it('keeps the notice while the fallback model is still serving', () => {
+    expect(mergeModelFallbackObservation(FALLBACK, { servingModel: 'claude-opus-4-8' }))
+      .toEqual({ next: FALLBACK, changed: false });
+  });
+
+  it('compares serving models across the [1m] context suffix', () => {
+    // FALLBACK.fallbackModel is `claude-opus-4-8[1m]`; the assistant record
+    // writes the bare id. Without normalisation every reply would look like a
+    // switch back and the notice would vanish after one round.
+    for (const servingModel of ['claude-opus-4-8', 'claude-opus-4-8[1m]', 'CLAUDE-OPUS-4-8']) {
+      expect(mergeModelFallbackObservation(FALLBACK, { servingModel }), servingModel)
+        .toEqual({ next: FALLBACK, changed: false });
+    }
+  });
+
+  it('applies the new record before judging the serving model in one message', () => {
+    // The worker only ever attaches a servingModel it observed AFTER the record
+    // in the same batch, so (b) then (c) is the correct order.
+    const same = mergeModelFallbackObservation(undefined, {
+      fallback: FALLBACK,
+      servingModel: 'claude-opus-4-8',
+    });
+    expect(same).toEqual({ next: FALLBACK, changed: true });
+    const switchedBack = mergeModelFallbackObservation(undefined, {
+      fallback: FALLBACK,
+      servingModel: 'claude-fable-5-1',
+    });
+    expect(switchedBack).toEqual({ next: undefined, changed: true });
+  });
+
+  it('never clears on a serving model when no record is held', () => {
+    expect(mergeModelFallbackObservation(undefined, { servingModel: 'claude-fable-5-1' }))
+      .toEqual({ next: undefined, changed: false });
+  });
+
+  it('holds the notice through anything short of a different serving model', () => {
+    // The requirement in one test: the notice stays across rounds, and NOTHING
+    // — an empty observation, a re-report of the same record, an unreadable
+    // serving model — is allowed to drop it.
+    let state = mergeModelFallbackObservation(undefined, { fallback: FALLBACK }).next;
+    for (const msg of [
+      {},
+      { fallback: { ...FALLBACK } },
+      { servingModel: 'claude-opus-4-8' },
+      { servingModel: '   ' },
+      {},
+    ]) {
+      state = mergeModelFallbackObservation(state, msg).next;
+      expect(state).toEqual(FALLBACK);
+    }
+    expect(mergeModelFallbackObservation(state, { servingModel: 'claude-fable-5-1' }).next)
+      .toBeUndefined();
   });
 });

--- a/test/model-fallback-daemon-state.test.ts
+++ b/test/model-fallback-daemon-state.test.ts
@@ -30,6 +30,9 @@ vi.mock('../src/services/session-store.js', async importOriginal => ({
 const { getDaemonStreamingCardUsageSnapshot, mergeModelFallbackObservation } = await import('../src/core/worker-pool.js');
 const { persistStreamCardState } = await import('../src/core/session-manager.js');
 
+const SID = 'a9bc732e-0000-0000-0000-000000000000';
+const OTHER_SID = 'b0000000-1111-1111-1111-111111111111';
+
 const FALLBACK: ModelFallbackState = {
   uuid: 'u-refusal',
   kind: 'refusal',
@@ -37,6 +40,9 @@ const FALLBACK: ModelFallbackState = {
   fallbackModel: 'claude-opus-4-8[1m]',
   apiRefusalCategory: 'cyber',
 };
+
+/** The same record as it looks once bound to a Claude session. */
+const BOUND: ModelFallbackState = { ...FALLBACK, claudeSessionId: SID };
 
 function makeSession(modelFallback?: ModelFallbackState): DaemonSession {
   return {
@@ -72,6 +78,17 @@ describe('getDaemonStreamingCardUsageSnapshot: model fallback', () => {
       expect(getDaemonStreamingCardUsageSnapshot(makeSession()), mode)
         .not.toHaveProperty('modelFallback');
     }
+  });
+
+  it('P1-4: the usage line shows the serving model, not the launch config', () => {
+    // Claude never emits `active_runtime`, so ds.activeModel used to stay empty
+    // and the usage line rendered ds.session.model (`claude-fable-5-1`) even
+    // while a fallback was answering. The model_fallback handler now writes the
+    // observed serving model there; this is the half the user actually sees.
+    const ds = makeSession(BOUND);
+    expect(getDaemonStreamingCardUsageSnapshot(ds).model).toBe('claude-fable-5-1');
+    ds.activeModel = 'claude-opus-4-8';
+    expect(getDaemonStreamingCardUsageSnapshot(ds).model).toBe('claude-opus-4-8');
   });
 });
 
@@ -109,6 +126,25 @@ describe('persistStreamCardState: model fallback', () => {
     persistStreamCardState(ds);
     expect(updateSession).toHaveBeenCalledTimes(1);
     expect(ds.session.modelFallback?.uuid).toBe('u-second');
+  });
+
+  it('P1-3: rewrites the store when only the Claude session changed', () => {
+    // Same record, different conversation (and the pre-binding upgrade path,
+    // where the id is stamped onto state that had none). Comparing uuids alone
+    // would leave the persisted mirror unbound forever.
+    const ds = makeSession(FALLBACK);
+    persistStreamCardState(ds);
+    updateSession.mockClear();
+    ds.modelFallback = BOUND;
+    persistStreamCardState(ds);
+    expect(updateSession).toHaveBeenCalledTimes(1);
+    expect(ds.session.modelFallback?.claudeSessionId).toBe(SID);
+  });
+
+  it('P1-3: persists the Claude session id so it survives a daemon restart', () => {
+    const ds = makeSession(BOUND);
+    persistStreamCardState(ds);
+    expect(ds.session.modelFallback).toEqual(BOUND);
   });
 });
 
@@ -182,6 +218,85 @@ describe('mergeModelFallbackObservation', () => {
   it('never clears on a serving model when no record is held', () => {
     expect(mergeModelFallbackObservation(undefined, { servingModel: 'claude-fable-5-1' }))
       .toEqual({ next: undefined, changed: false });
+  });
+
+  describe('P1-3: state is bound to one Claude session', () => {
+    it('stamps the incoming record with the message Claude session', () => {
+      expect(mergeModelFallbackObservation(undefined, {
+        claudeSessionId: SID,
+        fallback: FALLBACK,
+      })).toEqual({ next: BOUND, changed: true });
+    });
+
+    it('drops state from another Claude session before anything else', () => {
+      // /repo, /adopt and a resume onto another native session all replace the
+      // Claude conversation. Carrying the old record across shows a warning
+      // about a conversation the user has left.
+      expect(mergeModelFallbackObservation(BOUND, { claudeSessionId: OTHER_SID }))
+        .toEqual({ next: undefined, changed: true });
+    });
+
+    it('drops it even when the empty message carries no evidence at all', () => {
+      // The mandatory seed after a rebind is usually empty — that IS the
+      // evidence: "the bridge is on a different conversation now".
+      const merged = mergeModelFallbackObservation(BOUND, { claudeSessionId: OTHER_SID });
+      expect(merged.next).toBeUndefined();
+      expect(merged.changed).toBe(true);
+    });
+
+    it('leaves the state alone for an empty message on the SAME session', () => {
+      // A plain worker restart re-seeds and finds nothing; that must not clear.
+      expect(mergeModelFallbackObservation(BOUND, { claudeSessionId: SID }))
+        .toEqual({ next: BOUND, changed: false });
+    });
+
+    it('replaces old-session state with the record in the same message', () => {
+      // A→B→resume A: the seed for A carries both the session id and the record
+      // its tail scan recovered.
+      const other = { ...FALLBACK, uuid: 'u-other', claudeSessionId: OTHER_SID };
+      expect(mergeModelFallbackObservation(other, {
+        claudeSessionId: SID,
+        fallback: FALLBACK,
+      })).toEqual({ next: BOUND, changed: true });
+    });
+
+    it('does not clear on a serving model from a different session', () => {
+      // Rule (a) runs first, so the stale record is gone before rule (c) could
+      // read a foreign session reply as a switch back.
+      expect(mergeModelFallbackObservation(BOUND, {
+        claudeSessionId: OTHER_SID,
+        servingModel: 'claude-opus-4-8',
+      })).toEqual({ next: undefined, changed: true });
+    });
+
+    it('stamps the session onto pre-binding state and persists that once', () => {
+      // Upgrade path: state persisted before the binding existed carries no
+      // session id, so it cannot be shown to belong here — but the same
+      // message's own record re-establishes it, and `changed` must report the
+      // stamping so the mirror on disk is rewritten.
+      const merged = mergeModelFallbackObservation(FALLBACK, {
+        claudeSessionId: SID,
+        fallback: FALLBACK,
+      });
+      expect(merged).toEqual({ next: BOUND, changed: true });
+    });
+  });
+
+  describe('P2-2: fallback:null is positive "no notice" evidence', () => {
+    it('clears the held record', () => {
+      expect(mergeModelFallbackObservation(BOUND, { claudeSessionId: SID, fallback: null }))
+        .toEqual({ next: undefined, changed: true });
+    });
+
+    it('costs nothing when there is no notice to clear', () => {
+      expect(mergeModelFallbackObservation(undefined, { claudeSessionId: SID, fallback: null }))
+        .toEqual({ next: undefined, changed: false });
+    });
+
+    it('is not the same as an absent fallback, which changes nothing', () => {
+      expect(mergeModelFallbackObservation(BOUND, { claudeSessionId: SID, fallback: undefined }))
+        .toEqual({ next: BOUND, changed: false });
+    });
   });
 
   it('holds the notice through anything short of a different serving model', () => {

--- a/test/model-fallback-daemon-state.test.ts
+++ b/test/model-fallback-daemon-state.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { DaemonSession } from '../src/core/types.js';
 import type { ModelFallbackState } from '../src/types.js';
+import { ClaudeModelFallbackTracker, type TranscriptEvent } from '../src/services/claude-transcript.js';
 
 const usageDisplay = vi.hoisted(() => ({ mode: 'streaming' as string }));
 const updateSession = vi.hoisted(() => vi.fn());
@@ -177,6 +178,55 @@ describe('mergeModelFallbackObservation', () => {
   it('keeps the notice while the fallback model is still serving', () => {
     expect(mergeModelFallbackObservation(FALLBACK, { servingModel: 'claude-opus-4-8' }))
       .toEqual({ next: FALLBACK, changed: false });
+  });
+
+  it('F1: keeps the notice when the serving model drifts to a THIRD non-Fable model', () => {
+    // Real transcript (be6da26c): fable-5 → opus-5 fallback, then across a
+    // resume the session silently drifted opus-5 → opus-4-8 with NO new switch
+    // record. The session is still off Fable, so "serving differs from the
+    // fallback model" must NOT clear — only a Fable serving model does.
+    expect(mergeModelFallbackObservation(FALLBACK, { servingModel: 'claude-opus-5' }))
+      .toEqual({ next: FALLBACK, changed: false });
+    expect(mergeModelFallbackObservation(FALLBACK, { servingModel: 'claude-sonnet-4-5' }))
+      .toEqual({ next: FALLBACK, changed: false });
+    expect(mergeModelFallbackObservation(FALLBACK, { servingModel: 'claude-haiku-4-5' }))
+      .toEqual({ next: FALLBACK, changed: false });
+  });
+
+  it('F1: clears once the serving model is back on a (different) Fable variant', () => {
+    // A manual /model onto another Fable variant still ends the fall-off-Fable
+    // condition, so the notice clears — not only on the exact original model.
+    expect(mergeModelFallbackObservation(FALLBACK, { servingModel: 'claude-fable-5' }))
+      .toEqual({ next: undefined, changed: true });
+  });
+
+  it('F1: the full tracker→merge pipeline keeps the notice through a third-model drift', () => {
+    // Mirrors the real be6da26c transcript: one fable→opus switch, then the
+    // session silently drifts onto another non-Fable model with no new record.
+    const tracker = new ClaudeModelFallbackTracker();
+    tracker.bind(SID);
+    const switchEvent: TranscriptEvent = {
+      type: 'system', subtype: 'model_consent_fallback', uuid: 'u-drift',
+      sessionId: SID, originalModel: 'claude-fable-5[1m]', fallbackModel: 'claude-opus-5[1m]',
+      timestamp: '2026-08-16T10:44:00.126Z',
+    };
+    const reply = (model: string, uuid: string): TranscriptEvent => ({
+      type: 'assistant', uuid,
+      message: { role: 'assistant', model, content: [{ type: 'text', text: 'x' }], stop_reason: 'end_turn' },
+    });
+    let state: ModelFallbackState | undefined;
+    // Batch 1: the switch plus the first fallback-model reply.
+    const obs1 = tracker.observe([switchEvent, reply('claude-opus-5', 'a1')]);
+    if (obs1) state = mergeModelFallbackObservation(state, { ...obs1, claudeSessionId: SID }).next;
+    expect(state?.uuid).toBe('u-drift');
+    // Batch 2: the silent drift onto a THIRD non-Fable model.
+    const obs2 = tracker.observe([reply('claude-opus-4-8', 'a2')]);
+    if (obs2) state = mergeModelFallbackObservation(state, { ...obs2, claudeSessionId: SID }).next;
+    expect(state?.uuid, 'notice survives the third-model drift').toBe('u-drift');
+    // Batch 3: the user switches back to Fable — only now does it clear.
+    const obs3 = tracker.observe([reply('claude-fable-5', 'a3')]);
+    if (obs3) state = mergeModelFallbackObservation(state, { ...obs3, claudeSessionId: SID }).next;
+    expect(state).toBeUndefined();
   });
 
   it('compares serving models across the [1m] context suffix', () => {

--- a/test/model-fallback-daemon-state.test.ts
+++ b/test/model-fallback-daemon-state.test.ts
@@ -161,11 +161,22 @@ describe('mergeModelFallbackObservation', () => {
       servingModel: 'claude-opus-4-8',
     });
     expect(same).toEqual({ next: FALLBACK, changed: true });
-    const switchedBack = mergeModelFallbackObservation(undefined, {
-      fallback: FALLBACK,
+    const switchedBack = mergeModelFallbackObservation(FALLBACK, {
+      fallback: { ...FALLBACK, uuid: 'u-second', fallbackModel: 'claude-sonnet-4-5' },
       servingModel: 'claude-fable-5-1',
     });
     expect(switchedBack).toEqual({ next: undefined, changed: true });
+  });
+
+  it('reports no change when both rules fire but the state lands where it began', () => {
+    // Cold start on a session the user already switched back: the tail scan
+    // finds the record AND a newer reply on another model, so (b) then (c) run
+    // and we end on "no notice" — exactly what we held. Reporting `changed`
+    // here would cost a wasted card patch on every worker start.
+    expect(mergeModelFallbackObservation(undefined, {
+      fallback: FALLBACK,
+      servingModel: 'claude-fable-5-1',
+    })).toEqual({ next: undefined, changed: false });
   });
 
   it('never clears on a serving model when no record is held', () => {

--- a/test/model-fallback-daemon-state.test.ts
+++ b/test/model-fallback-daemon-state.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Daemon-side plumbing for the model-fallback notice: the state has to reach
+ * the card through the usage snapshot (including for bots that hide usage —
+ * this is a warning, not a metric), and it has to survive a daemon restart via
+ * the same persisted-stream-card path as usageLimit.
+ *
+ * Run: npx vitest run --project unit test/model-fallback-daemon-state.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DaemonSession } from '../src/core/types.js';
+import type { ModelFallbackState } from '../src/types.js';
+
+const usageDisplay = vi.hoisted(() => ({ mode: 'streaming' as string }));
+const updateSession = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/bot-registry.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/bot-registry.js')>()),
+  resolveUsageDisplay: () => usageDisplay.mode,
+}));
+vi.mock('../src/services/session-store.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/services/session-store.js')>()),
+  updateSession,
+}));
+
+const { getDaemonStreamingCardUsageSnapshot } = await import('../src/core/worker-pool.js');
+const { persistStreamCardState } = await import('../src/core/session-manager.js');
+
+const FALLBACK: ModelFallbackState = {
+  uuid: 'u-refusal',
+  kind: 'refusal',
+  originalModel: 'claude-fable-5-1[1m]',
+  fallbackModel: 'claude-opus-4-8[1m]',
+  apiRefusalCategory: 'cyber',
+};
+
+function makeSession(modelFallback?: ModelFallbackState): DaemonSession {
+  return {
+    larkAppId: 'cli_test',
+    modelFallback,
+    session: { sessionId: 'sess-mfb', model: 'claude-fable-5-1' },
+  } as unknown as DaemonSession;
+}
+
+beforeEach(() => {
+  usageDisplay.mode = 'streaming';
+  updateSession.mockClear();
+});
+
+describe('getDaemonStreamingCardUsageSnapshot: model fallback', () => {
+  it('carries the fallback into the streaming snapshot', () => {
+    expect(getDaemonStreamingCardUsageSnapshot(makeSession(FALLBACK)).modelFallback)
+      .toEqual(FALLBACK);
+  });
+
+  it('still carries it for bots that do not display usage on the card', () => {
+    for (const mode of ['off', 'footer']) {
+      usageDisplay.mode = mode;
+      const snapshot = getDaemonStreamingCardUsageSnapshot(makeSession(FALLBACK));
+      expect(snapshot.context, mode).toBeNull();
+      expect(snapshot.modelFallback, mode).toEqual(FALLBACK);
+    }
+  });
+
+  it('omits the key entirely when there is no fallback', () => {
+    for (const mode of ['streaming', 'off']) {
+      usageDisplay.mode = mode;
+      expect(getDaemonStreamingCardUsageSnapshot(makeSession()), mode)
+        .not.toHaveProperty('modelFallback');
+    }
+  });
+});
+
+describe('persistStreamCardState: model fallback', () => {
+  it('mirrors the fallback onto the persisted Session', () => {
+    const ds = makeSession(FALLBACK);
+    persistStreamCardState(ds);
+    expect(ds.session.modelFallback).toEqual(FALLBACK);
+    expect(updateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not rewrite the store when the same fallback is re-persisted', () => {
+    const ds = makeSession(FALLBACK);
+    persistStreamCardState(ds);
+    updateSession.mockClear();
+    persistStreamCardState(ds);
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it('clears the persisted fallback once the user switched back', () => {
+    const ds = makeSession(FALLBACK);
+    persistStreamCardState(ds);
+    ds.modelFallback = undefined;
+    updateSession.mockClear();
+    persistStreamCardState(ds);
+    expect(updateSession).toHaveBeenCalledTimes(1);
+    expect(ds.session.modelFallback).toBeUndefined();
+  });
+
+  it('rewrites the store when a different fallback replaces the current one', () => {
+    const ds = makeSession(FALLBACK);
+    persistStreamCardState(ds);
+    updateSession.mockClear();
+    ds.modelFallback = { ...FALLBACK, uuid: 'u-second' };
+    persistStreamCardState(ds);
+    expect(updateSession).toHaveBeenCalledTimes(1);
+    expect(ds.session.modelFallback?.uuid).toBe('u-second');
+  });
+});

--- a/test/model-fallback-wiring.test.ts
+++ b/test/model-fallback-wiring.test.ts
@@ -188,7 +188,7 @@ describe('model-fallback wiring (source lock)', () => {
 
   describe('P1-3: the state is bound to a Claude session', () => {
     it('re-seeds at every bind/switch of the primary path', () => {
-      // Four places move bridgeJsonlPath. Each must re-declare which Claude
+      // Five places move bridgeJsonlPath. Each must re-declare which Claude
       // conversation the worker is now on, or the daemon keeps showing (or can
       // never clear) a notice that belongs to the previous one.
       const SEED = 'seedModelFallbackFromTranscript();';
@@ -197,10 +197,19 @@ describe('model-fallback wiring (source lock)', () => {
         ['lazy baseline', sliceBetween(worker, 'if (!bridgeBaselineDone) {', '\n  }\n')],
         ['fingerprint switch', sliceBetween(worker, 'function bridgeApplyFingerprintSwitch(', '\n}\n')],
         ['rotation switch', sliceBetween(worker, 'function performRotationSwitch(', '\n}\n')],
+        // The pid resolver is the fifth: it swaps the path and cursors to 0
+        // WITHOUT draining, so nothing else here would rebind the tracker until
+        // the new transcript happens to hold something observable.
+        ['pid-resolver switch', sliceBetween(worker, 'function maybeFollowSessionRotationViaPid(', '\nfunction bridgeIngest(')],
       ] as const) {
         expect(slice, `${name} does not re-seed the fallback tracker`).toContain(SEED);
       }
-      expect(worker.match(/seedModelFallbackFromTranscript\(\);/g)).toHaveLength(4);
+      expect(worker.match(/seedModelFallbackFromTranscript\(\);/g)).toHaveLength(5);
+      // Guard against a SIXTH switch site appearing unnoticed: three of the six
+      // assignments are startBridgeWatcher's own (initial bind + the pid-file
+      // and fd-probe adjustments it makes before its single seed); the other
+      // three are the fingerprint, fd-rotation and pid-resolver switches above.
+      expect(worker.match(/\bbridgeJsonlPath = /g)).toHaveLength(6);
     });
 
     it('the seed ALWAYS publishes, even when the scan found nothing', () => {

--- a/test/model-fallback-wiring.test.ts
+++ b/test/model-fallback-wiring.test.ts
@@ -5,11 +5,18 @@ import { describe, expect, it } from 'vitest';
 /**
  * Source-lock for the model-fallback wiring — the seams a behavioural unit test
  * cannot reach (IPC hook-up, worker-generation authority, cold-start seed, the
- * cliId gates). Same idiom as codex-active-runtime-wiring.test.ts.
+ * cliId gates, and the fan-out of transcript drains). Same idiom as
+ * codex-active-runtime-wiring.test.ts.
  *
- * The invariant these locks defend: the notice is claude-code + Fable only, and
- * once shown it stays shown every round until Claude is OBSERVED answering on a
- * different model. No "not found" path may ever clear it.
+ * The invariants these locks defend:
+ *   - the notice is claude-code + Fable only, and once shown it stays shown
+ *     every round until POSITIVE evidence retires it (a different serving
+ *     model, a newer non-Fable switch, another Claude session). No "not found"
+ *     path may ever clear it;
+ *   - EVERY transcript drain that feeds the bridge queue also feeds the
+ *     fallback observer — bridgeIngest is only one of seven (P1-2);
+ *   - the state is bound to a Claude session id, re-declared at every
+ *     bind/switch of the primary path (P1-3).
  */
 const worker = readFileSync(resolve(__dirname, '../src/worker.ts'), 'utf8');
 const workerPool = readFileSync(resolve(__dirname, '../src/core/worker-pool.ts'), 'utf8');
@@ -27,22 +34,77 @@ describe('model-fallback wiring (source lock)', () => {
     // bridgeIngest IS the Claude bridge (Codex/TRAE have their own drains), so
     // hooking it here is what keeps the notice Claude-only.
     const ingest = sliceBetween(worker, 'function bridgeIngest(', 'function maybeEmitStructuredRateLimit');
-    expect(ingest).toContain('observeModelFallback(result.events);');
-    expect(worker).not.toContain('observeModelFallback(codex');
+    expect(ingest).toContain('observeModelFallbackEvents(bridgeJsonlPath, result.events);');
+    expect(worker).not.toContain('observeModelFallbackEvents(codex');
+  });
+
+  describe('P1-2: every queue-feeding drain reaches the observer', () => {
+    // The bug: bridgeIngest was the ONLY drain wired to the observer, while the
+    // adopt baseline, the journal restore, the fingerprint switch, the
+    // fd-rotation switch, drainPathInto and the secondary-path sweep all pull
+    // transcript events into the same queue. A switch record that arrived
+    // through any of those was silently dropped.
+    //
+    // Slice the file at each `drainTranscript(` call site: whichever slice
+    // hands events to bridgeQueue must also hand them to the one observer
+    // entry. That way a NEW drain added later fails this test by construction.
+    const CALL = 'drainTranscript(';
+    const sites: number[] = [];
+    for (let i = worker.indexOf(CALL); i >= 0; i = worker.indexOf(CALL, i + CALL.length)) {
+      // Skip the import statement and prose mentions.
+      if (/[A-Za-z0-9_$.]/.test(worker[i - 1] ?? '')) continue;
+      sites.push(i);
+    }
+    const slices = sites.map((start, i) => ({
+      line: worker.slice(0, start).split('\n').length,
+      text: worker.slice(start, sites[i + 1] ?? worker.length),
+    }));
+    const feedsQueue = slices.filter(s =>
+      s.text.includes('bridgeQueue.ingest(') || s.text.includes('bridgeQueue.absorb('));
+
+    it('finds every call site (guard against the slicer silently matching none)', () => {
+      expect(sites.length).toBeGreaterThanOrEqual(8);
+      expect(feedsQueue.length).toBeGreaterThanOrEqual(7);
+    });
+
+    it('routes each of them through observeModelFallbackEvents', () => {
+      for (const slice of feedsQueue) {
+        expect(slice.text, `drainTranscript( at worker.ts:${slice.line} feeds bridgeQueue `
+          + 'but never reaches observeModelFallbackEvents')
+          .toContain('observeModelFallbackEvents(');
+      }
+    });
+
+    it('keeps one observer entry, which owns the cliId gate and the routing', () => {
+      const entry = sliceBetween(worker, 'function observeModelFallbackEvents(', '\n}\n');
+      expect(entry).toContain("lastInitConfig?.cliId !== 'claude-code'");
+      expect(entry).toContain('sessionIdFromJsonlPath(path)');
+      // Bound session → observe; a different session on the CURRENT primary
+      // path → rebind; a different session on a secondary/retired path → drop.
+      expect(entry).toContain('modelFallbackTracker.boundClaudeSessionId');
+      expect(entry).toContain('if (path !== bridgeJsonlPath) return;');
+      expect(entry).toContain('modelFallbackTracker.bind(claudeSessionId);');
+      expect(entry).toContain('modelFallbackTracker.observe(events)');
+      // …and it is the only observe() caller.
+      expect(worker.match(/modelFallbackTracker\.observe\(/g)).toHaveLength(1);
+    });
   });
 
   it('gates both the observe and the seed path on cliId claude-code', () => {
     // Belt and braces over the call site: the notice is a claude-code product
     // affordance, so a future non-Claude caller of these helpers stays inert.
-    expect(sliceBetween(worker, 'function observeModelFallback(', '\n}\n'))
+    expect(sliceBetween(worker, 'function observeModelFallbackEvents(', '\n}\n'))
       .toContain("lastInitConfig?.cliId !== 'claude-code'");
     expect(sliceBetween(worker, 'function seedModelFallbackFromTranscript(', '\n}\n'))
       .toContain("lastInitConfig?.cliId !== 'claude-code'");
   });
 
-  it('never sends a "cleared" shape — the worker reports facts only', () => {
-    // The old bug: the seed published `null` whenever its bounded tail scan
-    // found nothing, wiping the daemon's persisted notice on every long session.
+  it('reports facts only — an empty tail scan is never turned into a clear', () => {
+    // The old bug: the seed published a "no fallback" decision whenever its
+    // bounded tail scan found nothing, wiping the daemon's persisted notice on
+    // every long session. Absence still says nothing; the two shapes that DO
+    // clear are positive evidence the daemon applies (a foreign
+    // claudeSessionId, and fallback: null from the newest switch record).
     const report = sliceBetween(worker, 'function reportModelFallbackObservation(', '\n}\n');
     expect(report).toContain('if (!observed) return;');
     expect(report).toContain("send({ type: 'model_fallback', ...observed });");
@@ -65,9 +127,9 @@ describe('model-fallback wiring (source lock)', () => {
   });
 
   it('also seeds on the lazy baseline, when the transcript appears after attach', () => {
-    // bridgeAbsorbBaseline skips whatever is already in the file (EOF cursor in
-    // the non-adopt branch; bridgeQueue.absorb — not observeModelFallback — in
-    // the adopt one), so this second baseline site needs the tail scan too.
+    // bridgeAbsorbBaseline cursors the non-adopt branch straight to EOF, so a
+    // switch already written to the file is never drained and only the tail
+    // scan can recover it — this second baseline site needs it too.
     const ingest = sliceBetween(worker, 'function bridgeIngest(', 'function maybeEmitStructuredRateLimit');
     const lazy = sliceBetween(ingest, 'if (!bridgeBaselineDone) {', '\n  }\n');
     expect(lazy).toContain('bridgeAbsorbBaseline();');
@@ -82,8 +144,10 @@ describe('model-fallback wiring (source lock)', () => {
     expect(handler).toContain('ds.session.workerGeneration !== workerGeneration');
     expect(handler).toContain("if (effectiveCliId !== 'claude-code') break;");
     expect(handler).toContain('mergeModelFallbackObservation(ds.modelFallback, msg)');
-    expect(handler).toContain('if (!merged.changed) break;');
-    expect(handler).toContain('persistStreamCardState(ds);');
+    // State is written and persisted only when the merge actually moved it.
+    expect(handler).toMatch(
+      /if \(merged\.changed\) \{\s*ds\.modelFallback = merged\.next;\s*persistStreamCardState\(ds\);\s*\}/,
+    );
     expect(handler).toContain('scheduleActiveRuntimePatch(ds);');
     // The daemon must never take a "no fallback" claim from the worker.
     expect(handler).not.toContain('msg.state');
@@ -97,7 +161,7 @@ describe('model-fallback wiring (source lock)', () => {
     const generationReset = sliceBetween(workerPool, 'ds.codexServiceTier = undefined;', 'const handlerSession');
     expect(generationReset).toContain("!== 'claude-code'");
     expect(generationReset).toMatch(
-      /if \(sessionCliId\(ds, getBot\(ds\.larkAppId\)\.config\) !== 'claude-code'\) \{\s*ds\.modelFallback = undefined;\s*\}/,
+      /if \(sessionCliId\(ds, getBot\(ds\.larkAppId\)\.config\) !== 'claude-code'\) \{\s*ds\.modelFallback = undefined;\s*persistStreamCardState\(ds\);\s*\}/,
     );
     // …and there is no second, statement-level (2-space indent) clear next to
     // the other unconditional runtime resets.
@@ -122,9 +186,87 @@ describe('model-fallback wiring (source lock)', () => {
     )).not.toContain('modelFallback');
   });
 
-  it('gates the parse on Fable originals, so every consumer inherits it', () => {
+  describe('P1-3: the state is bound to a Claude session', () => {
+    it('re-seeds at every bind/switch of the primary path', () => {
+      // Four places move bridgeJsonlPath. Each must re-declare which Claude
+      // conversation the worker is now on, or the daemon keeps showing (or can
+      // never clear) a notice that belongs to the previous one.
+      const SEED = 'seedModelFallbackFromTranscript();';
+      for (const [name, slice] of [
+        ['startBridgeWatcher', sliceBetween(worker, 'function startBridgeWatcher(', 'function stopBridgeWatcher(')],
+        ['lazy baseline', sliceBetween(worker, 'if (!bridgeBaselineDone) {', '\n  }\n')],
+        ['fingerprint switch', sliceBetween(worker, 'function bridgeApplyFingerprintSwitch(', '\n}\n')],
+        ['rotation switch', sliceBetween(worker, 'function performRotationSwitch(', '\n}\n')],
+      ] as const) {
+        expect(slice, `${name} does not re-seed the fallback tracker`).toContain(SEED);
+      }
+      expect(worker.match(/seedModelFallbackFromTranscript\(\);/g)).toHaveLength(4);
+    });
+
+    it('the seed ALWAYS publishes, even when the scan found nothing', () => {
+      // The empty message is what tells the daemon to drop another session's
+      // state. `seed` therefore returns a value, not a nullable one, and the
+      // helper has no "found nothing → return" arm.
+      const seed = sliceBetween(worker, 'function seedModelFallbackFromTranscript(', '\n}\n');
+      expect(seed).toContain('let seeded: ModelFallbackObservation;');
+      expect(seed).toContain('modelFallbackTracker.seed(bridgeJsonlPath, claudeSessionId)');
+      expect(seed).toContain('reportModelFallbackObservation(seeded);');
+      expect(seed).not.toContain('if (!seeded) return;');
+      const tracker = readFileSync(resolve(__dirname, '../src/services/claude-transcript.ts'), 'utf8');
+      expect(sliceBetween(tracker, '  seed(path: string, claudeSessionId: string)', '\n  }\n'))
+        .toContain('?? { claudeSessionId: this.claudeSessionId }');
+    });
+
+    it('the daemon drops state belonging to another Claude session first', () => {
+      const merge = sliceBetween(workerPool, 'export function mergeModelFallbackObservation(', '\n}\n');
+      const dropIdx = merge.indexOf('next.claudeSessionId !== msg.claudeSessionId');
+      const recordIdx = merge.indexOf('msg.fallback === null');
+      expect(dropIdx).toBeGreaterThanOrEqual(0);
+      // Rule (a) runs BEFORE the record and serving-model rules.
+      expect(recordIdx).toBeGreaterThan(dropIdx);
+      // The record is stamped with the message's session, and `changed` is
+      // identity over uuid AND session so the stamping is persisted.
+      expect(merge).toContain('claudeSessionId: msg.claudeSessionId');
+      expect(merge).toContain("current?.claudeSessionId !== next?.claudeSessionId");
+    });
+  });
+
+  it('P1-4: the serving model becomes the card usage line\'s runtime model', () => {
+    // Claude Code never emits `active_runtime`, so without this the usage line
+    // shows the LAUNCH model forever while a fallback answers. Same
+    // "changed-only + patch" semantics as the active_runtime handler; effort is
+    // untouched because Claude reports none.
+    const handler = sliceBetween(workerPool, "case 'model_fallback': {", "case 'codex_service_tier':");
+    expect(handler).toContain('normalizeClaudeModelId(msg.servingModel)');
+    expect(handler).toContain('ds.activeModel !== servingModel');
+    expect(handler).toContain('ds.activeModel = servingModel;');
+    expect(handler).toContain('if (merged.changed || runtimeChanged) scheduleActiveRuntimePatch(ds);');
+    expect(handler).not.toContain('ds.activeReasoningEffort');
+    // A card patch requires a real change on one of the two axes; nothing is
+    // patched for a message that moved neither.
+    expect(handler).not.toMatch(/\n\s*scheduleActiveRuntimePatch\(ds\);\n\s*break;/);
+  });
+
+  it('P2-3: a role switch away from claude-code clears the notice on disk too', () => {
+    // Memory-only clearing left the mirror on Session.modelFallback, so a
+    // daemon restart revived the notice on a session no longer running Claude.
+    const generationReset = sliceBetween(workerPool, 'ds.codexServiceTier = undefined;', 'const handlerSession');
+    expect(generationReset).toMatch(
+      /ds\.modelFallback = undefined;\s*persistStreamCardState\(ds\);/,
+    );
+  });
+
+  it('P2-2: the parse keeps every session switch, flagged rather than dropped', () => {
+    // Dropping non-Fable records at parse time let the backward tail scan walk
+    // past the newest one and resurrect an older Fable notice.
     const transcript = readFileSync(resolve(__dirname, '../src/services/claude-transcript.ts'), 'utf8');
-    expect(sliceBetween(transcript, 'export function parseClaudeModelFallbackEvent(', '\n}\n'))
-      .toContain('if (!isFableModelId(originalModel)) return undefined;');
+    const parse = sliceBetween(transcript, 'export function parseClaudeModelFallbackEvent(', '\n}\n');
+    expect(parse).not.toContain('if (!isFableModelId(originalModel)) return undefined;');
+    expect(parse).toContain('fable: isFableModelId(originalModel),');
+    expect(parse).toContain('neutralizedByFork: ev.neutralizedByFork === true,');
+    // The Fable scope now lives in ONE mapper both the scan and the tracker use.
+    expect(sliceBetween(transcript, 'function noticeFromSessionRecord(', '\n}\n'))
+      .toContain('rec.fable && !rec.neutralizedByFork ? rec : null');
+    expect(transcript.match(/noticeFromSessionRecord\(/g)).toHaveLength(3);
   });
 });

--- a/test/model-fallback-wiring.test.ts
+++ b/test/model-fallback-wiring.test.ts
@@ -144,6 +144,14 @@ describe('model-fallback wiring (source lock)', () => {
     expect(handler).toContain('ds.session.workerGeneration !== workerGeneration');
     expect(handler).toContain("if (effectiveCliId !== 'claude-code') break;");
     expect(handler).toContain('mergeModelFallbackObservation(ds.modelFallback, msg)');
+    // F2: the gate must fire BEFORE the merge and the state write. A toContain
+    // shape lock is blind to the gate being moved below them, which would let
+    // a non-Claude worker move the state (the worker-side gates make that
+    // unlikely, but this is the daemon's defense-in-depth — keep it load-bearing).
+    expect(handler.indexOf("if (effectiveCliId !== 'claude-code') break;"))
+      .toBeLessThan(handler.indexOf('mergeModelFallbackObservation(ds.modelFallback, msg)'));
+    expect(handler.indexOf('mergeModelFallbackObservation(ds.modelFallback, msg)'))
+      .toBeLessThan(handler.indexOf('ds.modelFallback = merged.next'));
     // State is written and persisted only when the merge actually moved it.
     expect(handler).toMatch(
       /if \(merged\.changed\) \{\s*ds\.modelFallback = merged\.next;\s*persistStreamCardState\(ds\);\s*\}/,
@@ -169,10 +177,14 @@ describe('model-fallback wiring (source lock)', () => {
     expect(generationReset.match(/ds\.modelFallback = undefined;/g)).toHaveLength(1);
   });
 
-  it('clears only on a serving model that disagrees with the held record', () => {
+  it('clears only on a serving model back on a Fable model', () => {
     const merge = sliceBetween(workerPool, 'export function mergeModelFallbackObservation(', '\n}\n');
     expect(merge).toContain('normalizeClaudeModelId(msg.servingModel)');
-    expect(merge).toContain('normalizeClaudeModelId(next.fallbackModel)');
+    // The clear predicate is "back on a Fable model", NOT "differs from the
+    // fallback model": a drift onto a third non-Fable model must keep the
+    // notice (see model-fallback-daemon-state F1 regression).
+    expect(merge).toContain('isFableModelId(serving)');
+    expect(merge).not.toContain('normalizeClaudeModelId(next.fallbackModel)');
     expect(merge).toContain('next = undefined;');
   });
 

--- a/test/model-fallback-wiring.test.ts
+++ b/test/model-fallback-wiring.test.ts
@@ -45,6 +45,18 @@ describe('model-fallback wiring (source lock)', () => {
       .toContain('publishModelFallbackIfChanged();');
   });
 
+  it('also seeds on the lazy baseline, when the transcript appears after attach', () => {
+    // bridgeAbsorbBaseline skips whatever is already in the file (EOF cursor in
+    // the non-adopt branch; bridgeQueue.absorb — not observeModelFallback — in
+    // the adopt one), so this second baseline site needs the tail scan too.
+    const ingest = sliceBetween(worker, 'function bridgeIngest(', 'function maybeEmitStructuredRateLimit');
+    const lazy = sliceBetween(ingest, 'if (!bridgeBaselineDone) {', '\n  }\n');
+    expect(lazy).toContain('bridgeAbsorbBaseline();');
+    expect(lazy).toContain('seedModelFallbackFromTranscript();');
+    expect(lazy.indexOf('seedModelFallbackFromTranscript();'))
+      .toBeGreaterThan(lazy.indexOf('bridgeAbsorbBaseline();'));
+  });
+
   it('rejects a stale worker generation and persists what it accepts', () => {
     const handler = sliceBetween(workerPool, "case 'model_fallback': {", "case 'codex_service_tier':");
     expect(handler).toContain('ds.workerGeneration !== workerGeneration');

--- a/test/model-fallback-wiring.test.ts
+++ b/test/model-fallback-wiring.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Source-lock for the model-fallback wiring — the seams a behavioural unit test
+ * cannot reach (IPC hook-up, worker-generation authority, cold-start seed).
+ * Same idiom as codex-active-runtime-wiring.test.ts.
+ */
+const worker = readFileSync(resolve(__dirname, '../src/worker.ts'), 'utf8');
+const workerPool = readFileSync(resolve(__dirname, '../src/core/worker-pool.ts'), 'utf8');
+
+function sliceBetween(source: string, startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  expect(start, `missing marker: ${startMarker}`).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  expect(end, `missing marker: ${endMarker}`).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('model-fallback wiring (source lock)', () => {
+  it('observes fallbacks from the Claude bridge drain only', () => {
+    // bridgeIngest IS the Claude bridge (Codex/TRAE have their own drains), so
+    // hooking it here is what keeps the notice Claude-only.
+    const ingest = sliceBetween(worker, 'function bridgeIngest(', 'function maybeEmitStructuredRateLimit');
+    expect(ingest).toContain('observeModelFallback(result.events);');
+    expect(worker).not.toContain('observeModelFallback(codex');
+  });
+
+  it('publishes only when the resolved state changes', () => {
+    const publish = sliceBetween(worker, 'function publishModelFallbackIfChanged(', '\n}\n');
+    expect(publish).toContain('publishedModelFallback?.uuid === state?.uuid) return;');
+    expect(publish).toContain("send({ type: 'model_fallback', state });");
+  });
+
+  it('seeds from the transcript tail at bridge start, after baseline', () => {
+    // Baseline cursors to EOF, so a switch recorded before --resume / a daemon
+    // restart is never drained; the bounded backward scan recovers it.
+    const start = sliceBetween(worker, 'function startBridgeWatcher(', 'function stopBridgeWatcher(');
+    const baselineIdx = start.indexOf('bridgeAbsorbBaseline();');
+    const seedIdx = start.indexOf('seedModelFallbackFromTranscript();');
+    expect(baselineIdx).toBeGreaterThanOrEqual(0);
+    expect(seedIdx).toBeGreaterThan(baselineIdx);
+    expect(sliceBetween(worker, 'function seedModelFallbackFromTranscript(', '\n}\n'))
+      .toContain('publishModelFallbackIfChanged();');
+  });
+
+  it('rejects a stale worker generation and persists what it accepts', () => {
+    const handler = sliceBetween(workerPool, "case 'model_fallback': {", "case 'codex_service_tier':");
+    expect(handler).toContain('ds.workerGeneration !== workerGeneration');
+    expect(handler).toContain('ds.session.workerGeneration !== workerGeneration');
+    expect(handler).toContain('if (ds.modelFallback?.uuid === next?.uuid) break;');
+    expect(handler).toContain('persistStreamCardState(ds);');
+    expect(handler).toContain('scheduleActiveRuntimePatch(ds);');
+  });
+
+  it('clears the state with the other worker-generation runtime facts', () => {
+    // Without this a role switch to a non-Claude CLI would strand the notice:
+    // that worker never sends a clearing model_fallback of its own.
+    expect(sliceBetween(workerPool, 'ds.codexServiceTier = undefined;', 'const handlerSession'))
+      .toContain('ds.modelFallback = undefined;');
+  });
+
+  it('keeps the notice out of the reply-card footer snapshot', () => {
+    // The final reply card is the answer; the fallback notice belongs on the
+    // live status card only.
+    expect(sliceBetween(
+      workerPool,
+      'export function getDaemonReplyCardUsageSnapshot(',
+      'export function getDaemonStreamingCardUsageSnapshot(',
+    )).not.toContain('modelFallback');
+  });
+});

--- a/test/model-fallback-wiring.test.ts
+++ b/test/model-fallback-wiring.test.ts
@@ -4,8 +4,12 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * Source-lock for the model-fallback wiring — the seams a behavioural unit test
- * cannot reach (IPC hook-up, worker-generation authority, cold-start seed).
- * Same idiom as codex-active-runtime-wiring.test.ts.
+ * cannot reach (IPC hook-up, worker-generation authority, cold-start seed, the
+ * cliId gates). Same idiom as codex-active-runtime-wiring.test.ts.
+ *
+ * The invariant these locks defend: the notice is claude-code + Fable only, and
+ * once shown it stays shown every round until Claude is OBSERVED answering on a
+ * different model. No "not found" path may ever clear it.
  */
 const worker = readFileSync(resolve(__dirname, '../src/worker.ts'), 'utf8');
 const workerPool = readFileSync(resolve(__dirname, '../src/core/worker-pool.ts'), 'utf8');
@@ -27,10 +31,25 @@ describe('model-fallback wiring (source lock)', () => {
     expect(worker).not.toContain('observeModelFallback(codex');
   });
 
-  it('publishes only when the resolved state changes', () => {
-    const publish = sliceBetween(worker, 'function publishModelFallbackIfChanged(', '\n}\n');
-    expect(publish).toContain('publishedModelFallback?.uuid === state?.uuid) return;');
-    expect(publish).toContain("send({ type: 'model_fallback', state });");
+  it('gates both the observe and the seed path on cliId claude-code', () => {
+    // Belt and braces over the call site: the notice is a claude-code product
+    // affordance, so a future non-Claude caller of these helpers stays inert.
+    expect(sliceBetween(worker, 'function observeModelFallback(', '\n}\n'))
+      .toContain("lastInitConfig?.cliId !== 'claude-code'");
+    expect(sliceBetween(worker, 'function seedModelFallbackFromTranscript(', '\n}\n'))
+      .toContain("lastInitConfig?.cliId !== 'claude-code'");
+  });
+
+  it('never sends a "cleared" shape — the worker reports facts only', () => {
+    // The old bug: the seed published `null` whenever its bounded tail scan
+    // found nothing, wiping the daemon's persisted notice on every long session.
+    const report = sliceBetween(worker, 'function reportModelFallbackObservation(', '\n}\n');
+    expect(report).toContain('if (!observed) return;');
+    expect(report).toContain("send({ type: 'model_fallback', ...observed });");
+    expect(worker).not.toContain('publishModelFallbackIfChanged');
+    expect(worker).not.toContain("type: 'model_fallback', state");
+    // Every model_fallback send in the worker goes through that one helper.
+    expect(worker.match(/type: 'model_fallback'/g)).toHaveLength(1);
   });
 
   it('seeds from the transcript tail at bridge start, after baseline', () => {
@@ -42,7 +61,7 @@ describe('model-fallback wiring (source lock)', () => {
     expect(baselineIdx).toBeGreaterThanOrEqual(0);
     expect(seedIdx).toBeGreaterThan(baselineIdx);
     expect(sliceBetween(worker, 'function seedModelFallbackFromTranscript(', '\n}\n'))
-      .toContain('publishModelFallbackIfChanged();');
+      .toContain('reportModelFallbackObservation(seeded);');
   });
 
   it('also seeds on the lazy baseline, when the transcript appears after attach', () => {
@@ -57,20 +76,40 @@ describe('model-fallback wiring (source lock)', () => {
       .toBeGreaterThan(lazy.indexOf('bridgeAbsorbBaseline();'));
   });
 
-  it('rejects a stale worker generation and persists what it accepts', () => {
+  it('rejects a stale worker generation, gates on claude-code, and merges', () => {
     const handler = sliceBetween(workerPool, "case 'model_fallback': {", "case 'codex_service_tier':");
     expect(handler).toContain('ds.workerGeneration !== workerGeneration');
     expect(handler).toContain('ds.session.workerGeneration !== workerGeneration');
-    expect(handler).toContain('if (ds.modelFallback?.uuid === next?.uuid) break;');
+    expect(handler).toContain("if (effectiveCliId !== 'claude-code') break;");
+    expect(handler).toContain('mergeModelFallbackObservation(ds.modelFallback, msg)');
+    expect(handler).toContain('if (!merged.changed) break;');
     expect(handler).toContain('persistStreamCardState(ds);');
     expect(handler).toContain('scheduleActiveRuntimePatch(ds);');
+    // The daemon must never take a "no fallback" claim from the worker.
+    expect(handler).not.toContain('msg.state');
   });
 
-  it('clears the state with the other worker-generation runtime facts', () => {
-    // Without this a role switch to a non-Claude CLI would strand the notice:
-    // that worker never sends a clearing model_fallback of its own.
-    expect(sliceBetween(workerPool, 'ds.codexServiceTier = undefined;', 'const handlerSession'))
-      .toContain('ds.modelFallback = undefined;');
+  it('keeps the notice across worker generations for claude-code sessions', () => {
+    // The persisted state is the authority: a new worker only moves it with
+    // positive evidence. Clearing on respawn (and hoping the re-seed finds the
+    // record again) loses the notice for good once the switch scrolls out of
+    // the bounded tail scan. Only a role switch AWAY from claude-code clears.
+    const generationReset = sliceBetween(workerPool, 'ds.codexServiceTier = undefined;', 'const handlerSession');
+    expect(generationReset).toContain("!== 'claude-code'");
+    expect(generationReset).toMatch(
+      /if \(sessionCliId\(ds, getBot\(ds\.larkAppId\)\.config\) !== 'claude-code'\) \{\s*ds\.modelFallback = undefined;\s*\}/,
+    );
+    // …and there is no second, statement-level (2-space indent) clear next to
+    // the other unconditional runtime resets.
+    expect(generationReset).not.toMatch(/\n {2}ds\.modelFallback = undefined;/);
+    expect(generationReset.match(/ds\.modelFallback = undefined;/g)).toHaveLength(1);
+  });
+
+  it('clears only on a serving model that disagrees with the held record', () => {
+    const merge = sliceBetween(workerPool, 'export function mergeModelFallbackObservation(', '\n}\n');
+    expect(merge).toContain('normalizeClaudeModelId(msg.servingModel)');
+    expect(merge).toContain('normalizeClaudeModelId(next.fallbackModel)');
+    expect(merge).toContain('next = undefined;');
   });
 
   it('keeps the notice out of the reply-card footer snapshot', () => {
@@ -81,5 +120,11 @@ describe('model-fallback wiring (source lock)', () => {
       'export function getDaemonReplyCardUsageSnapshot(',
       'export function getDaemonStreamingCardUsageSnapshot(',
     )).not.toContain('modelFallback');
+  });
+
+  it('gates the parse on Fable originals, so every consumer inherits it', () => {
+    const transcript = readFileSync(resolve(__dirname, '../src/services/claude-transcript.ts'), 'utf8');
+    expect(sliceBetween(transcript, 'export function parseClaudeModelFallbackEvent(', '\n}\n'))
+      .toContain('if (!isFableModelId(originalModel)) return undefined;');
   });
 });


### PR DESCRIPTION
## 改了什么

Claude Code 在会话中自动切换模型（Fable 安全管控触发的降级、模型不可用兜底、额度确认切换）时，botmux 现在会在**本会话那张流式卡片的最底部**贴一行黄色小字提示，例如：

- `⚠️ 安全管控降级：Fable 5.1 → Opus 4.8（cyber）`
- `⚠️ 模型不可用，本轮切换：Fable 5.1 → Opus 4.8（overloaded）`
- `⚠️ 额度限制已切换：Fable 5.1 → Opus 4.8`

提示随每一轮卡片刷新持续显示，只有识别到会话已切回（降级之后的主线程回复来自其它模型）、或出现更新的切换记录、或换到了另一条 Claude 会话时才消失。不发单独消息，不自动切回。

同时修了一个旧问题：Claude 会话的卡片用量行里模型名一直取启动配置，降级后显示的是错的；现在改为取回复记录里的实际服务模型（`ds.activeModel`）。

## 为什么

Fable 的安全分类器命中后，Claude Code 会把整个会话切到 Opus 4.8 并停留在那里直到手动 `/model`，飞书侧此前完全看不出来。本机会话记录里 7 月以来有 16 次这样的静默降级，用户在飞书上并不知道后续的活是别的模型干的。

## 实现方式

- **信号源**：Claude 会话 JSONL 里的结构化记录（`type=system`，`subtype` 为 `model_refusal_fallback` / `model_fallback` / `model_consent_fallback`），以及 `type=assistant` 记录的 `message.model`。
- **worker 只上报事实**（`src/worker.ts` + `src/services/claude-transcript.ts`）：新的 session 级切换记录、当前回复的服务模型、绑定的 Claude 会话 id。所有喂 `bridgeQueue` 的 transcript drain 路径（主路径、fingerprint/rotation 切换、pid 跟随切换、secondary 补读）都经过同一个观测入口，按路径的会话 id 分流；冷启动/换会话时从文件尾部有界回扫（4MB）补种。
- **daemon 持有状态并做判断**（`src/core/worker-pool.ts` `mergeModelFallbackObservation`）：只在三种正面证据下清除——会话 id 不符、更新的记录不是 Fable 降级（含 fork 复制过来的 `neutralizedByFork` 记录）、切换之后的回复模型 ≠ 降级模型。空回扫、worker 换代、daemon 重启都不会清除。状态随 `persistStreamCardState` 持久化到 `Session.modelFallback`。
- **门控**：只对 `cliId = claude-code` 的会话生效；只有原模型是 Fable 的记录才产生提示；`scope=local`（子 agent 局部回退）忽略。
- **渲染**（`src/im/lark/card-builder.ts`、`md-card.ts`）：卡片最后一个元素，`text_size: x-small`，`<font color='yellow'>`；模型名转友好名（`claude-fable-5-1[1m]` → `Fable 5.1`，日期后缀不会被当成次版本号）；原因去控制字符、单行、限长 24。

## 影响面评估

- **公共层改动**：`src/types.ts`（`ModelFallbackState`、`WorkerToDaemon` 新增 `model_fallback` 消息）、`src/core/types.ts`（`DaemonSession.modelFallback`）、`src/core/worker-pool.ts`（新 IPC case、换代清理、用量快照）、`src/core/session-manager.ts`（持久化脏检查与 restore 回填）、`src/im/lark/card-builder.ts` / `md-card.ts`（流式卡片）、`src/i18n/zh.ts` / `en.ts`。
- **跨 CLI**：观测只挂在 Claude bridge（`bridgeIngest` 及其同族 drain）上，worker 与 daemon 两侧都加了 `claude-code` 门；Codex / TRAE / 其它 CLI 的 bridge 代码未动，跑了 codex / traex / hermes / existing-app-server 的 bridge wiring 与 codex-active-runtime-wiring 测试确认无回归。
- **跨会话类型**：话题会话、adopt、resume、/clear 与 pid 跟随的会话轮转都在观测入口的分流规则里覆盖，并有对应测试；非 Claude 会话的换代会清掉并落盘旧状态。
- **卡片**：无降级时卡片逐字不变（测试锁定元素数量差恰为 1）；最终回复卡与私有快照卡不显示该提示。
- **平台**：纯 Node/TS 逻辑，无平台相关路径。

## 实际测试验证

在本分支（基于 `origin/master` e7c8cf80）上：

```
npx tsc --noEmit -p .                      # 0 errors
bun run build                              # 通过（含 audit:domains / dashboard:bundle / audit-dist）
npx vitest run --project unit \
  test/claude-model-fallback-transcript.test.ts test/model-fallback-daemon-state.test.ts \
  test/model-fallback-wiring.test.ts test/card-model-fallback-notice.test.ts \
  test/card-builder.test.ts test/card-builder-stop-compact.test.ts \
  test/streaming-card-usage-arg.test.ts test/card-integration.test.ts \
  test/claude-transcript.test.ts test/session-card-model.test.ts \
  test/codex-active-runtime-wiring.test.ts test/bridge-rotation-policy.test.ts \
  test/adopt-route.test.ts test/jsonl-cursor.test.ts
# 14 files passed, 568 passed / 0 failed
npx vitest run --project unit              # 全量：23 failed / 21066 passed，失败集合与 origin/master 同机基线逐条一致
                                           #（session-store-sqlite-* 缺 bun、cli-runtime-update、cli-adapters 缺二进制，另 1 条随机端口 flake）
```

新增 4 个测试文件覆盖：记录解析与 Fable 门、tracker 的去重/切回/会话绑定、尾部回扫、daemon 合并规则（保留/清除/会话切换/activeModel）、卡片渲染（三种文案 zh/en、位置、字号颜色、清除后元素数）、以及 worker 各 drain 路径接入观测入口的源码锁。

## 卡片示意

卡片底部（用量行与按钮行之后）新增一行：

```
上下文 58.2K/1M (6%) · 本轮 ↑4.2K ↓310 · 累计 ↑58.2K ↓3.1K · claude-opus-4-8 max     ← 用量行（现在显示实际模型）
[ 📖 显示输出 | 🖥️ 打开 Web 终端 | 🔑 获取操作链接 | 🗜️ 压缩 | ⏹ 停止 | ❌ 关闭会话 ]
⚠️ 安全管控降级：Fable 5.1 → Opus 4.8（cyber）                                        ← 新增，x-small 黄色
```

用真实降级状态渲染出的卡片已在飞书里预览确认过样式；生产链路上的端到端（真实 Fable 安全管控触发）尚未在线上 daemon 验证，建议合并后第一次真触发时看一眼。

## 已知限制

- 用户 `/model` 切回后，要等下一条回复出来提示才消失（Claude 只在回复记录里留模型信息，`/model` 本身只有一行人类可读的 local_command 记录）。
- 冷启动回扫只看文件最后 4MB；记录更早时不会从文件恢复，但持久化状态仍在，且只会被正面证据清除。
- daemon 恢复期（`suppressRecoveryCard`）沿用所有运行时补丁共用的抑制，状态已落盘，下一次活动刷新卡片。
