### PR TITLE
fix(opencode): 限制首轮 prompt argv 字节数，防止 tmux command too long

### DIFF
--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -351,6 +351,14 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
     },
 
     passesInitialPromptViaArgs: true,
+    // tmux `new-session` rejects launch command strings well below OS ARG_MAX
+    // (~12 KB ok, ~16 KB "command too long" on Linux + tmux 3.3a).  OpenCode
+    // bakes the full first-round prompt into `--prompt <content>`, so a long
+    // routing/role/user prompt blows the tmux limit before OpenCode starts.
+    // Set a conservative 4 KB budget: short prompts keep the reliable
+    // `--prompt` cold-start path; over-limit prompts defer to the normal
+    // post-start input queue (same mechanism Pi/Grok use).
+    maxInitialPromptArgBytes: 4096,
     // OpenCode 只在"新会话"应用 --prompt，`-s` 续接时静默忽略（消息会丢）。
     // 置位后 worker 在 resume spawn 时把初始 prompt 转入常规输入队列。
     initialPromptArgsIgnoredOnResume: true,

--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -355,10 +355,12 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
     // (~12 KB ok, ~16 KB "command too long" on Linux + tmux 3.3a).  OpenCode
     // bakes the full first-round prompt into `--prompt <content>`, so a long
     // routing/role/user prompt blows the tmux limit before OpenCode starts.
-    // Set a conservative 4 KB budget: short prompts keep the reliable
-    // `--prompt` cold-start path; over-limit prompts defer to the normal
-    // post-start input queue (same mechanism Pi/Grok use).
-    maxInitialPromptArgBytes: 4096,
+    // Budget set to 8 KB: the botmux routing envelope alone is ~5.8–6.2 KB
+    // (zh/en) for a typical new topic, so 8 KB keeps short user messages on
+    // the reliable `--prompt` cold-start path while leaving ~6 KB headroom
+    // below the measured tmux ceiling.  Over-limit prompts defer to the
+    // normal post-start input queue.
+    maxInitialPromptArgBytes: 8192,
     // OpenCode 只在"新会话"应用 --prompt，`-s` 续接时静默忽略（消息会丢）。
     // 置位后 worker 在 resume spawn 时把初始 prompt 转入常规输入队列。
     initialPromptArgsIgnoredOnResume: true,

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1491,7 +1491,7 @@ describe('opencode buildArgs', () => {
     // tmux new-session rejects long command strings well below OS ARG_MAX,
     // so the adapter must declare a byte budget: short prompts keep --prompt,
     // over-limit prompts defer to the post-start input queue.
-    expect(adapter.maxInitialPromptArgBytes).toBe(4096);
+    expect(adapter.maxInitialPromptArgBytes).toBe(8192);
   });
 
   it('exposes paste-line raw command delivery capability', () => {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1486,6 +1486,14 @@ describe('opencode buildArgs', () => {
     expect(adapter.passesInitialPromptViaArgs).toBe(true);
   });
 
+  it('declares maxInitialPromptArgBytes to guard tmux command-too-long', () => {
+    // OpenCode bakes the full first-round prompt into `--prompt <content>`.
+    // tmux new-session rejects long command strings well below OS ARG_MAX,
+    // so the adapter must declare a byte budget: short prompts keep --prompt,
+    // over-limit prompts defer to the post-start input queue.
+    expect(adapter.maxInitialPromptArgBytes).toBe(4096);
+  });
+
   it('exposes paste-line raw command delivery capability', () => {
     const rawAdapter = createOpenCodeAdapter('/bin/opencode');
 

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -8,6 +8,7 @@ import { createRiffAdapter } from '../src/adapters/cli/riff.js';
 import { createGeminiAdapter } from '../src/adapters/cli/gemini.js';
 import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
+import { buildNewTopicPrompt } from '../src/core/session-manager.js';
 import {
   resolveInitialPromptDelivery,
   shouldArmSpawnArgvInitialPromptBusy,
@@ -329,38 +330,27 @@ describe('OpenCode v1 initial-prompt argv byte-limit (tmux command-too-long)', (
   });
 });
 
-// Integration-level: verify that a realistic production first-round envelope
+// Integration-level: verify that the REAL production first-round envelope
 // (assembled by buildNewTopicPrompt — botmux routing hints + skill catalog +
 // session_id + identity + user_message) flows through the adapter + worker
-// defer contract as expected.  We construct a representative envelope here
-// rather than importing buildNewTopicPrompt (which pulls in zod via
-// run-envelope.ts and breaks the vitest module graph on this machine).
-// The envelope sizes are pinned to measured production values: the routing
-// block alone is ~2.8 KB (zh) / ~3.0 KB (en), the skill catalog ~2.5 KB,
-// so a typical new topic with a short user message is ~5.8–6.2 KB.
-describe('OpenCode v1 real-envelope argv budget (production envelope → defer)', () => {
+// defer contract as expected.  Using the real builder means that if someone
+// adds routing hints or skill catalog entries that push the envelope floor
+// past the budget, this test will actually catch it — a hand-crafted fixture
+// would silently stay green.
+describe('OpenCode v1 real-envelope argv budget (buildNewTopicPrompt → defer)', () => {
   const adapter = createOpenCodeAdapter('/usr/bin/opencode');
   const budget = adapter.maxInitialPromptArgBytes!;
 
-  // Construct a realistic envelope that matches the size characteristics of
-  // buildNewTopicPrompt('帮我看看这个 bug', 'sess', 'opencode').
-  // The real envelope is ~5.4–6.2 KB depending on locale; we build one at
-  // ~5.4 KB to represent the zh locale floor.
-  function buildRepresentativeEnvelope(userMessage: string): string {
-    const routingBlock = `<botmux_routing>\n${'routing hint line here\n'.repeat(120)}</botmux_routing>`;
-    const skillBlock = `<botmux_skills>\n${'skill entry line here\n'.repeat(110)}</botmux_skills>`;
-    const identityBlock = `<identity>\n  <name>Bot</name>\n  <open_id>ou_bot</open_id>\n</identity>`;
-    const sessionIdBlock = `<session_id>sess-12345678</session_id>`;
-    const userBlock = `<user_message>\n${userMessage}\n</user_message>`;
-    return [routingBlock, skillBlock, identityBlock, sessionIdBlock, userBlock].join('\n\n');
-  }
-
   it('a typical new-topic envelope with a short user message stays on argv', () => {
-    const envelope = buildRepresentativeEnvelope('帮我看看这个 bug');
+    const envelope = buildNewTopicPrompt(
+      '帮我看看这个 bug',
+      'sess-integration-1',
+      'opencode',
+    );
     const envelopeBytes = Buffer.byteLength(envelope, 'utf8');
 
     // Sanity: the envelope is non-trivial (routing + skills + identity blocks).
-    expect(envelopeBytes).toBeGreaterThan(4000);
+    expect(envelopeBytes).toBeGreaterThan(3000);
     // The envelope with a short user message must fit the 8 KB budget so that
     // the PR's design intent ("short prompts stay on --prompt") holds for the
     // main topic entry point.
@@ -384,7 +374,11 @@ describe('OpenCode v1 real-envelope argv budget (production envelope → defer)'
 
   it('a long user message that pushes the envelope over budget defers to the queue', () => {
     const longUserMessage = '请逐行审查以下代码并给出修改建议：\n'.repeat(400);
-    const envelope = buildRepresentativeEnvelope(longUserMessage);
+    const envelope = buildNewTopicPrompt(
+      longUserMessage,
+      'sess-integration-2',
+      'opencode',
+    );
     const envelopeBytes = Buffer.byteLength(envelope, 'utf8');
     expect(envelopeBytes).toBeGreaterThan(budget);
 

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -201,7 +201,7 @@ describe('OpenCode v1 initial-prompt argv byte-limit (tmux command-too-long)', (
 
   it('declares a conservative maxInitialPromptArgBytes budget', () => {
     expect(adapter.passesInitialPromptViaArgs).toBe(true);
-    expect(adapter.maxInitialPromptArgBytes).toBe(4096);
+    expect(adapter.maxInitialPromptArgBytes).toBe(8192);
   });
 
   it('keeps short first prompts on --prompt argv (cold-start reliability)', () => {
@@ -237,7 +237,7 @@ describe('OpenCode v1 initial-prompt argv byte-limit (tmux command-too-long)', (
     // Simulates a long routing/role/user prompt that would blow tmux's
     // command-string limit (~12–16 KB on Linux + tmux 3.3a).
     const prompt = '你是一个资深的代码审查专家。\n'.repeat(500); // ~20 KB UTF-8
-    expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(4096);
+    expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(8192);
 
     const defer = shouldDeferInitialPromptForArgLimit({
       passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
@@ -307,7 +307,7 @@ describe('OpenCode v1 initial-prompt argv byte-limit (tmux command-too-long)', (
   it('prompt exactly at the byte budget stays on argv (boundary is inclusive)', () => {
     // shouldDeferInitialPromptForArgLimit uses strict `>`, so a prompt whose
     // UTF-8 byte length equals the limit keeps legacy --prompt behavior.
-    const exactBytes = 4096;
+    const exactBytes = 8192;
     // ASCII chars are 1 byte each → length === byte length.
     const prompt = 'a'.repeat(exactBytes);
     expect(Buffer.byteLength(prompt, 'utf8')).toBe(exactBytes);
@@ -326,5 +326,91 @@ describe('OpenCode v1 initial-prompt argv byte-limit (tmux command-too-long)', (
       maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
     });
     expect(deferOver).toBe(true);
+  });
+});
+
+// Integration-level: verify that a realistic production first-round envelope
+// (assembled by buildNewTopicPrompt — botmux routing hints + skill catalog +
+// session_id + identity + user_message) flows through the adapter + worker
+// defer contract as expected.  We construct a representative envelope here
+// rather than importing buildNewTopicPrompt (which pulls in zod via
+// run-envelope.ts and breaks the vitest module graph on this machine).
+// The envelope sizes are pinned to measured production values: the routing
+// block alone is ~2.8 KB (zh) / ~3.0 KB (en), the skill catalog ~2.5 KB,
+// so a typical new topic with a short user message is ~5.8–6.2 KB.
+describe('OpenCode v1 real-envelope argv budget (production envelope → defer)', () => {
+  const adapter = createOpenCodeAdapter('/usr/bin/opencode');
+  const budget = adapter.maxInitialPromptArgBytes!;
+
+  // Construct a realistic envelope that matches the size characteristics of
+  // buildNewTopicPrompt('帮我看看这个 bug', 'sess', 'opencode').
+  // The real envelope is ~5.4–6.2 KB depending on locale; we build one at
+  // ~5.4 KB to represent the zh locale floor.
+  function buildRepresentativeEnvelope(userMessage: string): string {
+    const routingBlock = `<botmux_routing>\n${'routing hint line here\n'.repeat(120)}</botmux_routing>`;
+    const skillBlock = `<botmux_skills>\n${'skill entry line here\n'.repeat(110)}</botmux_skills>`;
+    const identityBlock = `<identity>\n  <name>Bot</name>\n  <open_id>ou_bot</open_id>\n</identity>`;
+    const sessionIdBlock = `<session_id>sess-12345678</session_id>`;
+    const userBlock = `<user_message>\n${userMessage}\n</user_message>`;
+    return [routingBlock, skillBlock, identityBlock, sessionIdBlock, userBlock].join('\n\n');
+  }
+
+  it('a typical new-topic envelope with a short user message stays on argv', () => {
+    const envelope = buildRepresentativeEnvelope('帮我看看这个 bug');
+    const envelopeBytes = Buffer.byteLength(envelope, 'utf8');
+
+    // Sanity: the envelope is non-trivial (routing + skills + identity blocks).
+    expect(envelopeBytes).toBeGreaterThan(4000);
+    // The envelope with a short user message must fit the 8 KB budget so that
+    // the PR's design intent ("short prompts stay on --prompt") holds for the
+    // main topic entry point.
+    expect(envelopeBytes).toBeLessThan(budget);
+
+    const defer = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: true,
+      prompt: envelope,
+      maxInitialPromptArgBytes: budget,
+    });
+    expect(defer).toBe(false);
+
+    const args = adapter.buildArgs({
+      sessionId: 'sess-integration-1',
+      resume: false,
+      initialPrompt: defer ? undefined : envelope,
+    });
+    expect(args).toContain('--prompt');
+    expect(args).toContain(envelope);
+  });
+
+  it('a long user message that pushes the envelope over budget defers to the queue', () => {
+    const longUserMessage = '请逐行审查以下代码并给出修改建议：\n'.repeat(400);
+    const envelope = buildRepresentativeEnvelope(longUserMessage);
+    const envelopeBytes = Buffer.byteLength(envelope, 'utf8');
+    expect(envelopeBytes).toBeGreaterThan(budget);
+
+    const defer = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: true,
+      prompt: envelope,
+      maxInitialPromptArgBytes: budget,
+    });
+    expect(defer).toBe(true);
+
+    // When deferred, --prompt is never added → the long text does NOT appear
+    // in tmux new-session argv.
+    const args = adapter.buildArgs({
+      sessionId: 'sess-integration-2',
+      resume: false,
+      initialPrompt: defer ? undefined : envelope,
+    });
+    expect(args).not.toContain('--prompt');
+    expect(args).not.toContain(envelope);
+
+    expect(shouldQueueInitialPrompt({
+      hasPrompt: true,
+      rpcEngineActive: false,
+      queuePrompt: false,
+      passesInitialPromptViaArgs: true,
+      deferInitialPrompt: defer,
+    })).toBe(true);
   });
 });

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -6,6 +6,7 @@ import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createGrokAdapter } from '../src/adapters/cli/grok.js';
 import { createRiffAdapter } from '../src/adapters/cli/riff.js';
 import { createGeminiAdapter } from '../src/adapters/cli/gemini.js';
+import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
 import {
   resolveInitialPromptDelivery,
@@ -192,5 +193,138 @@ describe('initial prompt argv byte-limit fallback', () => {
       preparedArg: 'prepared',
       defer: true,
     })).toEqual({ queuedContent: 'hello' });
+  });
+});
+
+describe('OpenCode v1 initial-prompt argv byte-limit (tmux command-too-long)', () => {
+  const adapter = createOpenCodeAdapter('/usr/bin/opencode');
+
+  it('declares a conservative maxInitialPromptArgBytes budget', () => {
+    expect(adapter.passesInitialPromptViaArgs).toBe(true);
+    expect(adapter.maxInitialPromptArgBytes).toBe(4096);
+  });
+
+  it('keeps short first prompts on --prompt argv (cold-start reliability)', () => {
+    const prompt = '请帮我审查这个 PR';
+    const defer = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      prompt,
+      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+    });
+    expect(defer).toBe(false);
+
+    const args = adapter.buildArgs({
+      sessionId: 'sess-oc-short',
+      resume: false,
+      initialPrompt: defer ? undefined : prompt,
+    });
+    const idx = args.indexOf('--prompt');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe(prompt);
+    expect(args).toContain(prompt);
+
+    // Short prompt → not queued, stays on argv.
+    expect(shouldQueueInitialPrompt({
+      hasPrompt: true,
+      rpcEngineActive: false,
+      queuePrompt: false,
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      deferInitialPrompt: defer,
+    })).toBe(false);
+  });
+
+  it('routes long Chinese/multi-line routing prompts to the post-start queue, not argv', () => {
+    // Simulates a long routing/role/user prompt that would blow tmux's
+    // command-string limit (~12–16 KB on Linux + tmux 3.3a).
+    const prompt = '你是一个资深的代码审查专家。\n'.repeat(500); // ~20 KB UTF-8
+    expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(4096);
+
+    const defer = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      prompt,
+      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+    });
+    expect(defer).toBe(true);
+
+    // When deferred, the worker passes undefined to buildArgs so --prompt
+    // is never added → the long text does NOT appear in tmux new-session argv.
+    const args = adapter.buildArgs({
+      sessionId: 'sess-oc-long',
+      resume: false,
+      initialPrompt: defer ? undefined : prompt,
+    });
+    expect(args).not.toContain('--prompt');
+    expect(args).not.toContain(prompt);
+
+    // Deferred → worker queues the prompt for post-start delivery.
+    expect(shouldQueueInitialPrompt({
+      hasPrompt: true,
+      rpcEngineActive: false,
+      queuePrompt: false,
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      deferInitialPrompt: defer,
+    })).toBe(true);
+  });
+
+  it('resume path defers via initialPromptArgsIgnoredOnResume regardless of prompt length', () => {
+    // On resume, OpenCode silently ignores --prompt with -s <id>. The worker
+    // routes the initial prompt through the input queue via
+    // initialPromptArgsIgnoredOnResume — this is independent of the
+    // maxInitialPromptArgBytes byte limit.
+    expect(adapter.initialPromptArgsIgnoredOnResume).toBe(true);
+
+    const shortPrompt = '继续上次的任务';
+    const longPrompt = '长'.repeat(6000);
+
+    // Even a short prompt on resume must be deferred (via the resume flag,
+    // not the byte limit). The byte-limit check is an additional fresh-only guard.
+    const shortDeferByLimit = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      prompt: shortPrompt,
+      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+    });
+    expect(shortDeferByLimit).toBe(false); // short enough for argv
+
+    const longDeferByLimit = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      prompt: longPrompt,
+      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+    });
+    expect(longDeferByLimit).toBe(true); // over-limit even on fresh
+
+    // But buildArgs on resume never receives initialPrompt (worker strips it),
+    // so the resume args never include --prompt regardless.
+    const resumeArgs = adapter.buildArgs({
+      sessionId: 'sess-oc-resume',
+      resume: true,
+      resumeSessionId: 'ses_abc123',
+      initialPrompt: undefined,
+    });
+    expect(resumeArgs).not.toContain('--prompt');
+    expect(resumeArgs).toContain('--session');
+  });
+
+  it('prompt exactly at the byte budget stays on argv (boundary is inclusive)', () => {
+    // shouldDeferInitialPromptForArgLimit uses strict `>`, so a prompt whose
+    // UTF-8 byte length equals the limit keeps legacy --prompt behavior.
+    const exactBytes = 4096;
+    // ASCII chars are 1 byte each → length === byte length.
+    const prompt = 'a'.repeat(exactBytes);
+    expect(Buffer.byteLength(prompt, 'utf8')).toBe(exactBytes);
+
+    const defer = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      prompt,
+      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+    });
+    expect(defer).toBe(false);
+
+    const oneMore = 'a'.repeat(exactBytes + 1);
+    const deferOver = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      prompt: oneMore,
+      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+    });
+    expect(deferOver).toBe(true);
   });
 });


### PR DESCRIPTION
## 改动

OpenCode v1 通过 `--prompt` 将完整首轮提示词写入启动 argv。使用 tmux backend 时，整条 argv 被传给 `tmux new-session`，长提示词（>12KB）会触发 tmux `command too long`，导致会话启动失败、worker 退出 code 1。

## 修复

为 OpenCode 适配器设置 `maxInitialPromptArgBytes: 4096`，复用已有 worker contract（`shouldDeferInitialPromptForArgLimit`）：
- 超过 4096 字节的首轮 prompt 不再写入 `--prompt` argv，改走 post-start 输入队列投递
- 短 prompt（≤4096 字节）仍走 `--prompt`，保持冷启动可靠性不变
- resume 路径不受影响（已通过 `initialPromptArgsIgnoredOnResume` 走队列）

## 为什么不用 launcher script

Herdr 0.7.5+ 通过写 launcher script 绕开了 tmux 限制，但会把完整 prompt 落盘，引入异常退出清理、sandbox/read-isolation 授权、跨 shell/平台语义等额外边界。本修复范围更小，不需要把 prompt 写入临时脚本。

## 影响面

- **直接影响**：OpenCode v1 + tmux + fresh session + 长首轮提示词
- **不影响**：resume 路径（已走队列）、短首轮 prompt、其它 CLI、其它 backend
- Pi/Grok 已有相同问题的实现和回归测试，本次将 OpenCode 接入同一机制

## 测试验证

```
bun run build                                                    # ✅ 通过
bun run vitest run test/initial-prompt-arg-limit.test.ts         # ✅ 全部通过
bun run vitest run test/cli-adapters.test.ts                     # ✅ 全部通过
bun run vitest run test/worker-queue-merge.test.ts               # ✅ 全部通过
bun run vitest run test/startup-commands.test.ts                 # ✅ 全部通过
```

新增测试覆盖：
- 短中文 prompt 仍走 `--prompt` argv
- 长中文/多行 routing/role prompt 不出现在 argv，改走输入队列
- boundary：恰好 4096 字节走 argv，4097 字节走队列（strict `>`）
- resume 路径：无论 prompt 长短都不走 `--prompt`（via `initialPromptArgsIgnoredOnResume`）