### PR TITLE
fix(dashboard): 消息监听预览透传 contentPolicy 关键词过滤

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -146,7 +146,7 @@ import {
   protectedSessionMutationReasons,
 } from './session-mutation-guard.js';
 import { listPendingAsks, submitAskFromDesktop } from './ask-broker.js';
-import { getMessageListenerConfig, sanitizeMessageListenerUpdate, updateMessageListenerConfig, validateMessageListenerUpdate } from '../services/message-listener-store.js';
+import { getMessageListenerConfig, messageListenerConfigFromUpdate, sanitizeMessageListenerUpdate, updateMessageListenerConfig, validateMessageListenerUpdate } from '../services/message-listener-store.js';
 import { getCommandTriggerConfig, setCommandTriggerChatEnabled, updateCommandTriggerConfig } from '../services/command-trigger-store.js';
 import { reservedCommandKind } from '../services/command-trigger.js';
 import { resolvePassthroughCommands } from './command-handler.js';
@@ -3843,16 +3843,19 @@ async function collectMessageListenerPreviewMatches(
   limit: number,
 ): Promise<MessageListenerPreviewMatch[]> {
   const bot = getBot(larkAppId);
-  const previewListener: MessageListenerConfig = {
-    enabled: true,
-    ...(listener.name ? { name: listener.name } : {}),
-    ...(listener.replyCardTitle ? { replyCardTitle: listener.replyCardTitle } : {}),
-    ...(listener.workingDir ? { workingDir: listener.workingDir } : {}),
-    prompt: listener.prompt,
-    ...(listener.senderPolicy && Object.keys(listener.senderPolicy).length > 0 ? { senderPolicy: listener.senderPolicy } : {}),
-    ...(listener.messagePolicy ? { messagePolicy: { ...listener.messagePolicy, scope: 'top_level' } } : { messagePolicy: { scope: 'top_level' } }),
-    replyPolicy: { mode: 'thread', sessionMode: 'per_message' },
-  };
+  // Build the preview listener with the SAME builder the save path uses, so
+  // preview can never drift from what the saved listener actually does. This
+  // used to be a hand-copied object literal that silently omitted
+  // contentPolicy: preview then ran with "no content filter" and reported
+  // every message as a match (and run-preview forked real sessions for
+  // messages the live listener would never wake on). Reusing the builder makes
+  // the preview leg structurally immune to the next field added to the config.
+  // Only `enabled` is overridden: an off draft is still previewable.
+  const configured = messageListenerConfigFromUpdate(listener);
+  // Blank prompt => nothing worth previewing (findMessageListenerForChat would
+  // reject it anyway); mirrors the save path treating it as a clear.
+  if (!configured) return [];
+  const previewListener: MessageListenerConfig = { ...configured, enabled: true };
   const previewBot = {
     ...bot,
     config: {

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -6856,6 +6856,111 @@ describe('role profile IPC routes', () => {
     }
   });
 
+  // Regression: the preview builder used to hand-copy the submitted listener
+  // field by field and silently omitted contentPolicy, so preview ran with "no
+  // content filter" and reported EVERY message as a match — a false positive
+  // that contradicts what the saved listener actually does at runtime.
+  it('applies the submitted contentPolicy keyword filter in preview', async () => {
+    setLarkAppId('cli_listener');
+    registerBot({
+      larkAppId: 'cli_listener',
+      larkAppSecret: 'secret',
+      cliId: 'codex',
+    });
+    const now = Date.now();
+    const historySpy = vi.spyOn(larkClient, 'listChatMessagesUntil').mockResolvedValue([
+      {
+        message_id: 'om_no_keyword',
+        create_time: String(now - 10_000),
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: '今天天气不错' }) },
+        sender: { id: 'ou_allowed', sender_type: 'user', sender_name: '张三' },
+      },
+      {
+        message_id: 'om_keyword',
+        create_time: String(now - 5_000),
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: 'CPU 告警 500' }) },
+        sender: { id: 'ou_allowed', sender_type: 'user', sender_name: '张三' },
+      },
+    ]);
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const base = `http://127.0.0.1:${handle.port}`;
+      const res = await fetch(`${base}/api/message-listeners/oc_alerts/preview`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          limit: 50,
+          listener: {
+            enabled: true,
+            prompt: '分析告警',
+            senderPolicy: { mode: 'all_except_excluded' },
+            messagePolicy: { includeMsgTypes: ['text'], scope: 'top_level' },
+            contentPolicy: { includeKeywords: ['告警'] },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Only the keyword message matches; the other one must be filtered out.
+      expect(body.matches.map((match: any) => match.messageId)).toEqual(['om_keyword']);
+    } finally {
+      historySpy.mockRestore();
+    }
+  });
+
+  it('honours matchMode all in preview', async () => {
+    setLarkAppId('cli_listener');
+    registerBot({
+      larkAppId: 'cli_listener',
+      larkAppSecret: 'secret',
+      cliId: 'codex',
+    });
+    const now = Date.now();
+    const historySpy = vi.spyOn(larkClient, 'listChatMessagesUntil').mockResolvedValue([
+      {
+        message_id: 'om_partial',
+        create_time: String(now - 10_000),
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: 'CPU 告警' }) },
+        sender: { id: 'ou_allowed', sender_type: 'user', sender_name: '张三' },
+      },
+      {
+        message_id: 'om_both',
+        create_time: String(now - 5_000),
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: 'CPU 告警 500' }) },
+        sender: { id: 'ou_allowed', sender_type: 'user', sender_name: '张三' },
+      },
+    ]);
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const base = `http://127.0.0.1:${handle.port}`;
+      const res = await fetch(`${base}/api/message-listeners/oc_alerts/preview`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          limit: 50,
+          listener: {
+            enabled: true,
+            prompt: '分析告警',
+            senderPolicy: { mode: 'all_except_excluded' },
+            messagePolicy: { includeMsgTypes: ['text'], scope: 'top_level' },
+            contentPolicy: { includeKeywords: ['告警', '500'], matchMode: 'all' },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.matches.map((match: any) => match.messageId)).toEqual(['om_both']);
+    } finally {
+      historySpy.mockRestore();
+    }
+  });
+
   it('runs message listener preview through the visible listener reply path', async () => {
     setLarkAppId('cli_listener_run');
     registerBot({
@@ -6989,6 +7094,66 @@ describe('role profile IPC routes', () => {
       expect(body.matches).toEqual([]);
       expect(body.results).toEqual([]);
       // The explicit @mention hands off to normal routing → no session spawned.
+      expect(forkSpy).not.toHaveBeenCalled();
+    } finally {
+      workerPool.setActiveSessionsRegistry(new Map());
+      forkSpy.mockRestore();
+      messageChatSpy.mockRestore();
+      chatModeSpy.mockRestore();
+      inChatSpy.mockRestore();
+      historySpy.mockRestore();
+    }
+  });
+
+  // Regression: run-preview spawns REAL turns off the matches, so dropping
+  // contentPolicy did not merely misreport — it forked sessions (and burned
+  // model calls) for messages the saved listener would never wake on.
+  it('does not fork a run-preview session for a message the contentPolicy filters out', async () => {
+    setLarkAppId('cli_listener_run');
+    registerBot({
+      larkAppId: 'cli_listener_run',
+      larkAppSecret: 'secret',
+      cliId: 'codex',
+      workingDir: process.cwd(),
+    });
+    const activeSessions = new Map<string, any>();
+    const now = Date.now();
+    const historySpy = vi.spyOn(larkClient, 'listChatMessagesUntil').mockResolvedValue([
+      {
+        message_id: 'om_off_topic',
+        create_time: String(now - 5_000),
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: '中午吃什么' }) },
+        sender: { id: 'ou_allowed', sender_type: 'user', sender_name: '张三' },
+      },
+    ]);
+    const inChatSpy = vi.spyOn(groupsStore, 'isInChat').mockResolvedValue(true);
+    const chatModeSpy = vi.spyOn(larkClient, 'getChatMode').mockResolvedValue('topic');
+    const messageChatSpy = vi.spyOn(larkClient, 'getMessageChatId').mockResolvedValue('oc_alerts');
+    const forkSpy = vi.spyOn(workerPool, 'forkWorker').mockImplementation(() => {});
+    try {
+      workerPool.setActiveSessionsRegistry(activeSessions);
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const base = `http://127.0.0.1:${handle.port}`;
+      const res = await fetch(`${base}/api/message-listeners/oc_alerts/run-preview`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          limit: 5,
+          listener: {
+            enabled: true,
+            prompt: '分析告警',
+            senderPolicy: { mode: 'all_except_excluded' },
+            messagePolicy: { includeMsgTypes: ['text'], scope: 'top_level' },
+            contentPolicy: { includeKeywords: ['告警'] },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.matches).toEqual([]);
+      expect(body.results).toEqual([]);
       expect(forkSpy).not.toHaveBeenCalled();
     } finally {
       workerPool.setActiveSessionsRegistry(new Map());

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -6961,6 +6961,67 @@ describe('role profile IPC routes', () => {
     }
   });
 
+  // Regression: preview must work on an OFF draft. The preview builder reuses
+  // the save path's messageListenerConfigFromUpdate, which faithfully carries
+  // `enabled:false` through — but findMessageListenerForChat requires
+  // `enabled===true`, so without the explicit `enabled:true` override the whole
+  // preview would silently collapse to zero matches. The dashboard always posts
+  // enabled:true (validateListenerForPreview forces it), so only a direct HTTP
+  // caller previewing a disabled draft exercises this path — which is exactly
+  // why it needs a test rather than being left to the UI's good behaviour.
+  it('previews a disabled draft listener (enabled:false is overridden for preview)', async () => {
+    setLarkAppId('cli_listener');
+    registerBot({
+      larkAppId: 'cli_listener',
+      larkAppSecret: 'secret',
+      cliId: 'codex',
+    });
+    const now = Date.now();
+    const historySpy = vi.spyOn(larkClient, 'listChatMessagesUntil').mockResolvedValue([
+      {
+        message_id: 'om_draft_skip',
+        create_time: String(now - 10_000),
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: '今天天气不错' }) },
+        sender: { id: 'ou_allowed', sender_type: 'user', sender_name: '张三' },
+      },
+      {
+        message_id: 'om_draft_hit',
+        create_time: String(now - 5_000),
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: 'CPU 告警 500' }) },
+        sender: { id: 'ou_allowed', sender_type: 'user', sender_name: '张三' },
+      },
+    ]);
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const base = `http://127.0.0.1:${handle.port}`;
+      const res = await fetch(`${base}/api/message-listeners/oc_alerts/preview`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          limit: 50,
+          listener: {
+            // An off draft: the operator is still tuning it and has not enabled
+            // it yet, but must still be able to preview what it would match.
+            enabled: false,
+            prompt: '分析告警',
+            senderPolicy: { mode: 'all_except_excluded' },
+            messagePolicy: { includeMsgTypes: ['text'], scope: 'top_level' },
+            contentPolicy: { includeKeywords: ['告警'] },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // The draft still previews, and still honours its own contentPolicy.
+      expect(body.matches.map((match: any) => match.messageId)).toEqual(['om_draft_hit']);
+    } finally {
+      historySpy.mockRestore();
+    }
+  });
+
   it('runs message listener preview through the visible listener reply path', async () => {
     setLarkAppId('cli_listener_run');
     registerBot({


### PR DESCRIPTION
## 问题

Dashboard 群消息监听配置了「内容关键词过滤」后，点击**预览**仍然命中全部消息，关键词过滤看起来完全没生效。

## 根因

`collectMessageListenerPreviewMatches()` 构造 `previewListener` 时，是**手工逐字段拷贝**提交上来的表单配置，而这份手抄名单里漏了 `contentPolicy`。于是预览链路拿到的是一个「没有内容过滤配置」的 listener，`matchesContentPolicy()` 按兼容语义（无策略 = 匹配一切）放行了全部消息。

链路两端其实都是好的，唯独中间这段丢字段：

| 环节 | 是否携带 `contentPolicy` |
|---|---|
| 前端 `listenerSavePayload()` | ✅ 有传 |
| `sanitizeMessageListenerUpdate()` | ✅ 有解析并保留 |
| **`collectMessageListenerPreviewMatches()`** | ❌ **手抄时漏了** |
| 真实监听 `evaluateMessageListener()` | ✅ 过滤正常 |

引入自 #1008（`9c19530f4`）新增关键词过滤时未同步更新预览构造。

## 影响面

- **预览**：假阳性，展示的命中数与保存后的真实行为不一致（用户实际遇到的现象）
- **试运行**：同一个函数，危害更实——它会按 matches **真的 fork 会话发起模型调用**，等于对「真实监听永远不会唤醒」的消息也跑了一轮，白烧 token 并可能在群里产生回复
- **真实监听不受影响**：保存与运行时链路独立，关键词过滤一直是生效的（用户也确认「功能是可用的，只是预览会失败」）

跨 CLI / 跨后端 / 跨 IM 评估：改动仅限 Dashboard 预览/试运行这一条路径，未触碰 CLI 适配器、`PtyBackend`/`TmuxBackend` 或其它 IM 链路；`matchesContentPolicy()` 本身未改动，realtime 与轮询补投两条腿共用它，行为不变。

## 修法

不只是补一个字段，而是**消除重复构造**：改为复用保存链路同款的 `messageListenerConfigFromUpdate()`，仅覆盖 `enabled: true`（关闭态草稿也能预览）。

这样预览与保存在结构上不可能再分叉——**以后 config 新增字段也不会重演本次「手抄名单漏字段」**。空 prompt 返回空结果，与保存链路视其为清除、`findMessageListenerForChat` 拒绝空 prompt 的语义一致。

```diff
-  const previewListener: MessageListenerConfig = {
-    enabled: true,
-    ...(listener.name ? { name: listener.name } : {}),
-    ...  // 逐字段手抄，漏了 contentPolicy
-  };
+  const configured = messageListenerConfigFromUpdate(listener);
+  if (!configured) return [];
+  const previewListener: MessageListenerConfig = { ...configured, enabled: true };
```

## 测试验证

新增 3 条回归测试，全部**先证红、修完转绿**（不是「加完就绿」的空测试）：

| 用例 | 改前（红） | 改后（绿） |
|---|---|---|
| `applies the submitted contentPolicy keyword filter in preview` | `['om_no_keyword','om_keyword']` | `['om_keyword']` |
| `honours matchMode all in preview` | `['om_partial','om_both']` | `['om_both']` |
| `does not fork a run-preview session for a message the contentPolicy filters out` | matches 非空且**真的 fork** | `matches=[] results=[]`，`forkWorker` 未被调用 |

三条都从**生产 HTTP 入口**（`POST /api/message-listeners/:chatId/preview` 与 `/run-preview`）进入，不直调内部 helper。

```
bun run build                                   ✅ 通过
npx vitest run test/dashboard-ipc.test.ts       ✅ 218 passed | 1 skipped

# 监听相关全量
message-listener / -content-policy / -store /
dashboard-listener-filters /
listener-foreign-bot-owner(-behavior)           ✅ 6 files, 66 passed

# IPC 邻近面
dashboard-ipc-probe / dashboard-ipc /
ipc-slash-route / ipc-close-route /
api-only-mode-wiring                            ✅ 5 files, 289 passed | 1 skipped
```

改前红的原始报错（节选，证明用例确实打在这个缺陷上）：

```
FAIL  role profile IPC routes > does not fork a run-preview session for a message the contentPolicy filters out
AssertionError: expected [ { messageId: 'om_off_topic', …(6) } ] to deeply equal []
```

## UI 说明

本 PR 不改任何界面元素，仅修正「预览/试运行」返回的命中结果，因此无截图：同一个预览面板，改前列出全部消息，改后只列出命中关键词的消息。

## 遗留（未在本 PR 处理）

用户同时提到希望支持 `excludeKeywords`（内容级排除关键词，建议 deny-wins 语义），属独立 feature，另行提 issue/PR，不混在这个 bugfix 里。
