### PR TITLE
fix(doc-comment): 补全被飞书分页截断的评论回复串，长 thread 不再永久失联

### DIFF
--- a/src/core/doc-comment-poller.ts
+++ b/src/core/doc-comment-poller.ts
@@ -1,3 +1,6 @@
+// ⚠️ 必须保持 **type-only**：doc-comment.ts 反过来从本模块值导入
+// `compareReplyIds`（补全后自排序要用）。type-only import 编译后被擦除，所以
+// 现在不构成运行时循环；一旦这行改成值导入，两个模块就成真循环了。
 import type { DocComment } from '../im/lark/doc-comment.js';
 
 export interface DocCommentPollCursor {
@@ -17,7 +20,9 @@ export interface PolledDocReply extends DocCommentPollCursor {
 
 /**
  * reply_id 按数值比大小（飞书 id 是雪花数，字符串序会把长度不同的排错）。
- * 非数字 id 退化成字典序。
+ * 无法解析成数字的 id 退化成字典序 —— 但注意空串不走这条路：`BigInt('')` 返回
+ * `0n` 而不抛，所以空 id 会当 0 参与比较。实际无影响（空 id 的回复在
+ * `flattenDocCommentReplies` 里已被过滤，事件链路也匹配不上）。
  */
 export function compareReplyIds(a: string, b: string): number {
   try {

--- a/src/core/doc-comment-poller.ts
+++ b/src/core/doc-comment-poller.ts
@@ -15,7 +15,11 @@ export interface PolledDocReply extends DocCommentPollCursor {
   priorReplies: Array<{ authorOpenId?: string; text: string }>;
 }
 
-function compareReplyIds(a: string, b: string): number {
+/**
+ * reply_id 按数值比大小（飞书 id 是雪花数，字符串序会把长度不同的排错）。
+ * 非数字 id 退化成字典序。
+ */
+export function compareReplyIds(a: string, b: string): number {
   try {
     const aa = BigInt(a);
     const bb = BigInt(b);

--- a/src/im/lark/doc-comment.ts
+++ b/src/im/lark/doc-comment.ts
@@ -19,6 +19,7 @@ import { logger } from '../../utils/logger.js';
 import { UserTokenMissingError, assertLarkTransport } from './client.js';
 import { type Brand, larkHosts, normalizeBrand } from './lark-hosts.js';
 import type { CommentTriggerMode } from '../../services/doc-subs-store.js';
+import { compareReplyIds } from '../../core/doc-comment-poller.js';
 
 /**
  * bot 回复的隐形哨兵：追加在 bot 发表的评论末尾（零宽字符，用户不可见）。
@@ -591,7 +592,8 @@ async function hydrateTruncatedReplies(
         : undefined;
       // 服务端若返回恒定 page_token 会把这里变成死循环，而且是嵌在
       // 「每条评论 × 每个订阅」的两层循环里，足以把整个 poller 卡死。
-      if (pages++ >= MAX_REPLY_PAGES) {
+      // ⚠️ 只在「确认还有下一页」时计数，否则正常拉完的第 51 页也会被判成异常。
+      if (pageToken && ++pages >= MAX_REPLY_PAGES) {
         throw new Error(`回复分页超过 ${MAX_REPLY_PAGES} 页上限（comment=${comment.commentId.slice(0, 12)}），疑似游标未推进`);
       }
     } while (pageToken);
@@ -601,6 +603,15 @@ async function hydrateTruncatedReplies(
       logger.warn(`[doc-comment] hydrate returned 0 replies for ${comment.commentId.slice(0, 12)} (截断结果有 ${comment.replies.length} 条)；保留截断结果`);
       return comment;
     }
+    // 按 createdAt 升序稳定排一次。实测 `/replies` 与 `reply_list.replies` 同序
+    // （均为 create_time 升序，跨页拼接后仍升序），但飞书**既没声明排序也没给
+    // 排序参数** —— 这是未承诺行为。上层 `priorReplies`
+    // （event-dispatcher 的 `replies.slice(0, triggerIndex)`）直接吃这个顺序且
+    // 不自己排，一旦飞书改成降序，症状是模型把「后面的回复」当历史上下文喂进去，
+    // 且没有任何日志会报。与其把这个假设只写在注释里，不如让代码自己守住。
+    // create_time 是秒级、同秒并列真实存在，故用 replyId 做次级比较（复用
+    // poller 的 compareReplyIds，别重写一套）。
+    replies.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0) || compareReplyIds(a.replyId, b.replyId));
     logger.info(`[doc-comment] hydrated truncated thread comment=${comment.commentId.slice(0, 12)} ${comment.replies.length} → ${replies.length} replies`);
     return { ...comment, replies, hasMoreReplies: false };
   } catch (err) {

--- a/src/im/lark/doc-comment.ts
+++ b/src/im/lark/doc-comment.ts
@@ -91,6 +91,11 @@ export interface DocComment {
   quote?: string;
   /** 是否为整篇文档的全文评论。 */
   isWhole?: boolean;
+  /**
+   * `replies` 是否被飞书分页截断（评论对象顶层 `has_more`）。
+   * true 表示这里拿到的只是**前几条**回复，不能当作完整 thread 用。
+   */
+  hasMoreReplies?: boolean;
   /** 该评论 thread 下所有回复（飞书把评论建模成 reply_list）。 */
   replies: Array<{
     replyId: string;
@@ -508,11 +513,73 @@ export async function getDocComment(
     const data = ensureOk(res, '获取评论');
     const raw = Array.isArray(data?.items) ? data.items[0] : undefined;
     if (!raw) return null;
-    return normalizeComment(raw);
+    return await hydrateTruncatedReplies(larkAppId, file, normalizeComment(raw));
   } catch (err) {
     logger.warn(`[doc-comment] getDocComment ${commentId.slice(0, 12)} failed: ${err instanceof Error ? err.message : err}`);
     return null;
   }
+}
+
+/**
+ * 补全被截断的回复串。
+ *
+ * ⚠️ 飞书的 `batch_query` / `GET /comments` **对每条评论的 `reply_list.replies`
+ * 分页**，实测一页只给 5 条，并在评论对象顶层（不是 reply_list 里）挂
+ * `has_more: true`。这层分页没有任何参数可以调大，也不能靠 page_size 绕过。
+ *
+ * 吃下这个截断的后果是**长评论串会永久静默失联**：事件带着第 6 条以后的
+ * reply_id 打进来，在只有 5 条的 replies 里 find 不到，触发回复解析出错的那条
+ * → @ 判定、自触发过滤、turnId 去重全部基于错误的回复，最终每一条新评论都被
+ * 当成重复回合丢弃。
+ *
+ * 因此 `has_more` 为真时改用专用端点 `GET /comments/{id}/replies` 翻全量（该
+ * 端点分页正常、局部评论也支持）。拉失败就退回截断结果——半个 thread 好过没有。
+ */
+async function hydrateTruncatedReplies(
+  larkAppId: string,
+  file: ResolvedDocFile,
+  comment: DocComment,
+): Promise<DocComment> {
+  if (!comment.hasMoreReplies || !comment.commentId) return comment;
+  try {
+    const replies: DocComment['replies'] = [];
+    let pageToken: string | undefined;
+    do {
+      const res = await driveApiCall(larkAppId, {
+        method: 'GET',
+        path: `/open-apis/drive/v1/files/${encodeURIComponent(file.fileToken)}/comments/${encodeURIComponent(comment.commentId)}/replies`,
+        params: {
+          file_type: file.fileType,
+          user_id_type: 'open_id',
+          page_size: 50,
+          page_token: pageToken,
+        },
+        preferTenant: true,
+      });
+      const data = ensureOk(res, '拉取评论回复');
+      if (Array.isArray(data?.items)) replies.push(...data.items.map(normalizeReply));
+      pageToken = data?.has_more === true && typeof data?.page_token === 'string' && data.page_token
+        ? data.page_token
+        : undefined;
+    } while (pageToken);
+    if (replies.length === 0) return comment;
+    logger.info(`[doc-comment] hydrated truncated thread comment=${comment.commentId.slice(0, 12)} ${comment.replies.length} → ${replies.length} replies`);
+    return { ...comment, replies, hasMoreReplies: false };
+  } catch (err) {
+    // 补全失败不致命：返回截断结果，调用方的「找不到触发回复」告警会暴露问题。
+    logger.warn(`[doc-comment] hydrate replies for ${comment.commentId.slice(0, 12)} failed: ${err instanceof Error ? err.message : err}`);
+    return comment;
+  }
+}
+
+function normalizeReply(r: any): DocComment['replies'][number] {
+  return {
+    replyId: r?.reply_id ?? '',
+    userId: r?.user_id,
+    text: elementsToText(r?.content?.elements),
+    mentions: elementsMentions(r?.content?.elements),
+    createdAt: Number.isFinite(Number(r?.create_time)) ? Number(r.create_time) : undefined,
+  };
 }
 
 function normalizeComment(raw: any): DocComment {
@@ -525,13 +592,9 @@ function normalizeComment(raw: any): DocComment {
     isSolved: raw?.is_solved === true,
     quote: quote || undefined,
     isWhole: raw?.is_whole === true,
-    replies: replies.map((r: any) => ({
-      replyId: r?.reply_id ?? '',
-      userId: r?.user_id,
-      text: elementsToText(r?.content?.elements),
-      mentions: elementsMentions(r?.content?.elements),
-      createdAt: Number.isFinite(Number(r?.create_time)) ? Number(r.create_time) : undefined,
-    })),
+    // 顶层 has_more 表示**回复串**还有下一页（不是评论列表还有下一页）。
+    hasMoreReplies: raw?.has_more === true,
+    replies: replies.map(normalizeReply),
   };
 }
 
@@ -539,6 +602,10 @@ function normalizeComment(raw: any): DocComment {
  * 列出文档当前可见的全部评论。`/watch-comment --all` 用它做增量轮询：
  * 评论读取优先应用身份，因此不需要 User Token；只有应用身份无权访问文档时才
  * 回退已有的用户授权。
+ *
+ * ⚠️ 两层分页别混淆：外层 `data.has_more` 是**评论列表**还有下一页，每个 item
+ * 自己的 `has_more` 是**该评论的回复串**被截断（见 hydrateTruncatedReplies）。
+ * 只翻外层会让轮询永远看不到长 thread 第 6 条以后的回复。
  */
 export async function listDocComments(
   larkAppId: string,
@@ -564,7 +631,13 @@ export async function listDocComments(
       ? data.page_token
       : undefined;
   } while (pageToken);
-  return comments;
+  // 串行补全：一篇文档可能有几十条评论，Promise.all 会把补全请求一次性打出去撞
+  // 飞书限流。补全只在 has_more 的评论上真正发请求，串行开销可接受。
+  const hydrated: DocComment[] = [];
+  for (const comment of comments) {
+    hydrated.push(await hydrateTruncatedReplies(larkAppId, file, comment));
+  }
+  return hydrated;
 }
 
 // ─── 回评论 ─────────────────────────────────────────────────────────────────────

--- a/src/im/lark/doc-comment.ts
+++ b/src/im/lark/doc-comment.ts
@@ -513,7 +513,12 @@ export async function getDocComment(
     const data = ensureOk(res, '获取评论');
     const raw = Array.isArray(data?.items) ? data.items[0] : undefined;
     if (!raw) return null;
-    return await hydrateTruncatedReplies(larkAppId, file, normalizeComment(raw));
+    // 事件链路：与本函数的 batch_query 主请求保持同一身份优先级（user-first），
+    // 不要一半 user-first 一半 tenant-first。补全失败降级，下游有 `!trigger` 兜底。
+    return await hydrateTruncatedReplies(larkAppId, file, normalizeComment(raw), {
+      onTruncated: 'degrade',
+      preferTenant: false,
+    });
   } catch (err) {
     logger.warn(`[doc-comment] getDocComment ${commentId.slice(0, 12)} failed: ${err instanceof Error ? err.message : err}`);
     return null;
@@ -523,27 +528,50 @@ export async function getDocComment(
 /**
  * 补全被截断的回复串。
  *
- * ⚠️ 飞书的 `batch_query` / `GET /comments` **对每条评论的 `reply_list.replies`
- * 分页**，实测一页只给 5 条，并在评论对象顶层（不是 reply_list 里）挂
- * `has_more: true`。这层分页没有任何参数可以调大，也不能靠 page_size 绕过。
+ * ⚠️ 飞书**对每条评论的 `reply_list.replies` 分页**，`has_more` 挂在评论对象
+ * 顶层（不是 reply_list 里），没有参数可以调大，也不能靠 page_size 绕过。
+ *
+ * 实测（33 条评论、单串最长 11 条回复的真实文档）两个端点表现**并不一样**：
+ *   • `POST .../comments/batch_query` —— 截断，一页只给 5 条并置 has_more=true
+ *   • `GET  .../comments`            —— 未见截断，11 条的串也完整返回
+ * 事件链路走 batch_query，所以是它踩了这个坑。`listDocComments` 走 GET，目前
+ * 观察不到截断，但 `has_more` 是文档化字段、飞书随时可能对它也生效，故两条
+ * 链路都接上补全（GET 那条实际是防御性的，正常不会真的发请求）。
  *
  * 吃下这个截断的后果是**长评论串会永久静默失联**：事件带着第 6 条以后的
  * reply_id 打进来，在只有 5 条的 replies 里 find 不到，触发回复解析出错的那条
  * → @ 判定、自触发过滤、turnId 去重全部基于错误的回复，最终每一条新评论都被
  * 当成重复回合丢弃。
  *
- * 因此 `has_more` 为真时改用专用端点 `GET /comments/{id}/replies` 翻全量（该
- * 端点分页正常、局部评论也支持）。拉失败就退回截断结果——半个 thread 好过没有。
+ * 因此 `has_more` 为真时改用专用端点 `GET /comments/{id}/replies` 翻全量。
+ * 实测确认该端点与 `reply_list.replies` **同序（create_time 升序）**、跨页拼接
+ * 后仍升序、前 N 条与截断结果逐字节一致 —— 上层 priorReplies / trigger 依赖
+ * 这个顺序，换端点不能破坏它。
+ *
+ * `onTruncated` 决定补全失败时的行为，**两条链路语义不同，必须由调用方选**：
+ * - 事件链路（getDocComment）传 'degrade'：退回截断结果。下游 `!trigger` 有
+ *   兜底告警，且事件链路本来就没有游标可污染。
+ * - 轮询链路（listDocComments）传 'throw'：**绝不能**降级。游标是按拿到的
+ *   回复算的，降级会让 `latestDocCommentPollCursor` 用截断的 5 条推游标；一旦
+ *   某轮补全成功把游标推到第 11 条、下一轮补全失败只看到 5 条，
+ *   `docCommentRepliesAfterCursor` 返回空，这轮新来的第 12 条就永久不投了
+ *   （游标已在 11，而截断响应里永远看不到 12）。抛错让 daemon 的 per-sub
+ *   try/catch 跳过这一轮、游标不动、下轮重试，才是正确语义。
  */
+/** 单条评论回复串的翻页上限。纯粹是死循环保险，正常 thread 远够用。 */
+const MAX_REPLY_PAGES = 50;
+
 async function hydrateTruncatedReplies(
   larkAppId: string,
   file: ResolvedDocFile,
   comment: DocComment,
+  opts: { onTruncated: 'degrade' | 'throw'; preferTenant: boolean },
 ): Promise<DocComment> {
   if (!comment.hasMoreReplies || !comment.commentId) return comment;
   try {
     const replies: DocComment['replies'] = [];
     let pageToken: string | undefined;
+    let pages = 0;
     do {
       const res = await driveApiCall(larkAppId, {
         method: 'GET',
@@ -554,19 +582,30 @@ async function hydrateTruncatedReplies(
           page_size: 50,
           page_token: pageToken,
         },
-        preferTenant: true,
+        preferTenant: opts.preferTenant,
       });
       const data = ensureOk(res, '拉取评论回复');
       if (Array.isArray(data?.items)) replies.push(...data.items.map(normalizeReply));
       pageToken = data?.has_more === true && typeof data?.page_token === 'string' && data.page_token
         ? data.page_token
         : undefined;
+      // 服务端若返回恒定 page_token 会把这里变成死循环，而且是嵌在
+      // 「每条评论 × 每个订阅」的两层循环里，足以把整个 poller 卡死。
+      if (pages++ >= MAX_REPLY_PAGES) {
+        throw new Error(`回复分页超过 ${MAX_REPLY_PAGES} 页上限（comment=${comment.commentId.slice(0, 12)}），疑似游标未推进`);
+      }
     } while (pageToken);
-    if (replies.length === 0) return comment;
+    // 空数组是**合法应答**（整串回复都被删了），不能和「没拉到」混为一谈。
+    // 但也不敢直接拿它覆盖已有的 5 条，故保留旧值并留痕，让线上能分辨。
+    if (replies.length === 0) {
+      logger.warn(`[doc-comment] hydrate returned 0 replies for ${comment.commentId.slice(0, 12)} (截断结果有 ${comment.replies.length} 条)；保留截断结果`);
+      return comment;
+    }
     logger.info(`[doc-comment] hydrated truncated thread comment=${comment.commentId.slice(0, 12)} ${comment.replies.length} → ${replies.length} replies`);
     return { ...comment, replies, hasMoreReplies: false };
   } catch (err) {
-    // 补全失败不致命：返回截断结果，调用方的「找不到触发回复」告警会暴露问题。
+    if (opts.onTruncated === 'throw') throw err;
+    // 事件链路降级：返回截断结果，下游 `!trigger` 的告警会暴露问题。
     logger.warn(`[doc-comment] hydrate replies for ${comment.commentId.slice(0, 12)} failed: ${err instanceof Error ? err.message : err}`);
     return comment;
   }
@@ -631,11 +670,20 @@ export async function listDocComments(
       ? data.page_token
       : undefined;
   } while (pageToken);
-  // 串行补全：一篇文档可能有几十条评论，Promise.all 会把补全请求一次性打出去撞
-  // 飞书限流。补全只在 has_more 的评论上真正发请求，串行开销可接受。
+  // 串行补全，且只在 has_more 的评论上真正发请求。GET /comments 实测不截断，
+  // 所以这里通常一个补全请求都不会发；Promise.all 只会在真出现批量截断时把
+  // 请求一次性打出去撞限流（/replies 限 100 次/分，poll 每 5s 一轮），得不偿失。
+  // 注：真出现「一篇文档几十条串都被截断」时，本轮 poll 会明显变慢（有
+  // docCommentPollRunning 互斥，不会重入，但会拖慢游标推进）。届时应改成只补全
+  // 游标之后可能有新回复的评论 —— 留待后续 PR。
   const hydrated: DocComment[] = [];
   for (const comment of comments) {
-    hydrated.push(await hydrateTruncatedReplies(larkAppId, file, comment));
+    // 轮询链路：与本函数的列表主请求同为 tenant-first；补全失败必须抛错，
+    // 降级会让游标按截断的回复数推进并永久漏投后续回复（见 hydrateTruncatedReplies）。
+    hydrated.push(await hydrateTruncatedReplies(larkAppId, file, comment, {
+      onTruncated: 'throw',
+      preferTenant: true,
+    }));
   }
   return hydrated;
 }

--- a/src/im/lark/doc-comment.ts
+++ b/src/im/lark/doc-comment.ts
@@ -549,7 +549,9 @@ export async function getDocComment(
  * 后仍升序、前 N 条与截断结果逐字节一致 —— 上层 priorReplies / trigger 依赖
  * 这个顺序，换端点不能破坏它。
  *
- * `onTruncated` 决定补全失败时的行为，**两条链路语义不同，必须由调用方选**：
+ * `onTruncated` 决定**补全没能拿到完整回复串**时的行为（包括请求失败、分页
+ * 超上限，以及 `/replies` 返回空数组这种「合法但用不了」的应答 —— 三者对调用
+ * 方是同一件事：手上仍是截断结果）。**两条链路语义不同，必须由调用方选**：
  * - 事件链路（getDocComment）传 'degrade'：退回截断结果。下游 `!trigger` 有
  *   兜底告警，且事件链路本来就没有游标可污染。
  * - 轮询链路（listDocComments）传 'throw'：**绝不能**降级。游标是按拿到的
@@ -597,11 +599,17 @@ async function hydrateTruncatedReplies(
         throw new Error(`回复分页超过 ${MAX_REPLY_PAGES} 页上限（comment=${comment.commentId.slice(0, 12)}），疑似游标未推进`);
       }
     } while (pageToken);
-    // 空数组是**合法应答**（整串回复都被删了），不能和「没拉到」混为一谈。
-    // 但也不敢直接拿它覆盖已有的 5 条，故保留旧值并留痕，让线上能分辨。
+    // 空数组是**合法应答**（整串回复都被删了），不能和「没拉到」混为一谈；
+    // 但也不敢直接拿它覆盖已有的 N 条，只能保留截断结果。
+    //
+    // ⚠️ 保留截断结果 == 补全没成功，所以**必须和补全失败走同一条路**。这里曾经
+    // 无条件 `return comment`，绕过了下面的 catch，等于给 'throw' 契约开了条边路：
+    // 轮询链路拿到截断的回复 + hasMoreReplies:true，游标照样按截断的条数推进，
+    // 正是 onTruncated:'throw' 要堵的永久漏投。
+    // 故这里只管抛，由 catch 里那**唯一一处** onTruncated 分派决定抛还是降级 ——
+    // 别在这儿再判一次 opts.onTruncated，两处分派迟早会走岔。
     if (replies.length === 0) {
-      logger.warn(`[doc-comment] hydrate returned 0 replies for ${comment.commentId.slice(0, 12)} (截断结果有 ${comment.replies.length} 条)；保留截断结果`);
-      return comment;
+      throw new Error(`hydrate returned 0 replies for ${comment.commentId.slice(0, 12)}（截断结果有 ${comment.replies.length} 条）`);
     }
     // 按 createdAt 升序稳定排一次。实测 `/replies` 与 `reply_list.replies` 同序
     // （均为 create_time 升序，跨页拼接后仍升序），但飞书**既没声明排序也没给
@@ -683,7 +691,8 @@ export async function listDocComments(
   } while (pageToken);
   // 串行补全，且只在 has_more 的评论上真正发请求。GET /comments 实测不截断，
   // 所以这里通常一个补全请求都不会发；Promise.all 只会在真出现批量截断时把
-  // 请求一次性打出去撞限流（/replies 限 100 次/分，poll 每 5s 一轮），得不偿失。
+  // 补全请求一次性打出去撞飞书限流（具体额度未核实，别在别处引用一个拍脑袋的
+  // 数字当依据），得不偿失。
   // 注：真出现「一篇文档几十条串都被截断」时，本轮 poll 会明显变慢（有
   // docCommentPollRunning 互斥，不会重入，但会拖慢游标推进）。届时应改成只补全
   // 游标之后可能有新回复的评论 —— 留待后续 PR。

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -3112,8 +3112,17 @@ async function processCommentEvent(
     return;
   }
   const trigger = parsed.replyId
-    ? comment.replies.find(r => r.replyId === parsed.replyId) ?? comment.replies[comment.replies.length - 1]
+    ? comment.replies.find(r => r.replyId === parsed.replyId)
     : comment.replies[comment.replies.length - 1];
+  // ⚠️ 事件给了 reply_id 却在 thread 里找不到 → 只能是**我们拿到的 replies 不完整**
+  // （飞书对回复串分页，见 doc-comment.ts:hydrateTruncatedReplies）。这里曾经
+  // `?? replies[last]` 静默回退到最后一条已知回复，后果是长 thread 从第 6 条起
+  // 永久失联：turnId 恒等于那条老回复 → 每条新评论都被 dedup 当成重复回合丢掉，
+  // @ 判定和自触发过滤也全基于错误的回复。宁可丢这一条并告警，也不能拿错的顶上。
+  if (!trigger) {
+    logger.warn(`[doc-comment] event dropped: 触发回复 ${parsed.replyId?.slice(0, 12)} 不在拉到的 ${comment.replies.length} 条回复里 (comment=${commentId.slice(0, 12)} truncated=${comment.hasMoreReplies === true}) — 回复串可能未补全`);
+    return;
+  }
   const triggerIndex = Math.max(0, comment.replies.indexOf(trigger));
 
   // 3) 自触发过滤（防死循环）：bot 的回复可能以应用身份（作者=bot open_id）或回退

--- a/test/doc-comment-reply-pagination.test.ts
+++ b/test/doc-comment-reply-pagination.test.ts
@@ -283,3 +283,70 @@ describe('listDocComments: 轮询链路补全失败必须抛错', () => {
     expect(calls).toBeLessThan(200); // 有界，不是死循环
   });
 });
+
+/**
+ * 排序保险：`/replies` 的顺序是飞书**未承诺**的行为（文档既没声明排序也没给
+ * 排序参数）。事件链路的 priorReplies 直接吃这个顺序且不自己排，所以补全后
+ * 必须由我们自己排一次，不能只把「实测同序」写在注释里。
+ */
+describe('hydrate 后按 createdAt 升序排序（不信任 API 顺序）', () => {
+  beforeEach(() => {
+    mocks.tenantRequest.mockReset();
+    mocks.resolveUserToken.mockReset().mockResolvedValue(null);
+    mocks.warn.mockReset();
+    mocks.info.mockReset();
+  });
+
+  function hydrateWith(items: unknown[]) {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments/batch_query')) return truncatedBatchQuery(first5);
+      if (opts.url.includes('/replies')) return { code: 0, data: { items, has_more: false } };
+      throw new Error(`unexpected ${opts.url}`);
+    });
+    return getDocComment('app-test', FILE, COMMENT_ID);
+  }
+
+  it('端点若返回降序，补全结果仍是升序', async () => {
+    const descending = [5, 4, 3, 2, 1].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    const comment = await hydrateWith(descending);
+    expect(comment!.replies.map(r => r.replyId)).toEqual(['reply-1', 'reply-2', 'reply-3', 'reply-4', 'reply-5']);
+  });
+
+  it('create_time 同秒并列时按 replyId 数值序（非字典序）稳定排', async () => {
+    // 同一秒内的三条回复，reply_id 长度不同 —— 字典序会把 '710' 排到 '99' 前面。
+    const sameSecond = [
+      { ...reply('7681633934731430857', 'c', 1788500001) },
+      { ...reply('999', 'a', 1788500001) },
+      { ...reply('7681622822946343898', 'b', 1788500001) },
+    ];
+    const comment = await hydrateWith(sameSecond);
+    expect(comment!.replies.map(r => r.replyId)).toEqual([
+      '999',
+      '7681622822946343898',
+      '7681633934731430857',
+    ]);
+  });
+
+  it('正常拉完最后一页不会被误判成分页死循环', async () => {
+    // 每页 1 条、共 3 页正常结束：不能因为翻了页就抛错。
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    let page = 0;
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments/batch_query')) return truncatedBatchQuery(first5);
+      page++;
+      const last = page >= 3;
+      return {
+        code: 0,
+        data: {
+          items: [reply(`reply-${page}`, `msg ${page}`, 1788500000 + page)],
+          has_more: !last,
+          page_token: last ? undefined : `cursor-${page}`,
+        },
+      };
+    });
+    const comment = await getDocComment('app-test', FILE, COMMENT_ID);
+    expect(comment!.replies).toHaveLength(3);
+    expect(comment!.hasMoreReplies).toBe(false);
+  });
+});

--- a/test/doc-comment-reply-pagination.test.ts
+++ b/test/doc-comment-reply-pagination.test.ts
@@ -282,6 +282,38 @@ describe('listDocComments: 轮询链路补全失败必须抛错', () => {
     await expect(listDocComments('app-test', FILE)).rejects.toThrow(/页上限|游标未推进/);
     expect(calls).toBeLessThan(200); // 有界，不是死循环
   });
+
+  /**
+   * 回归：`/replies` 返回**空数组**是合法应答（整串回复被删），但对调用方而言
+   * 和补全失败是同一件事 —— 手上仍是截断结果。这里曾经无条件 `return comment`，
+   * 绕过了 onTruncated:'throw'，等于给上面那条游标漏投的契约开了条边路。
+   */
+  it('回归：/replies 返回空数组时轮询链路同样抛错，不走边路降级', async () => {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments')) {
+        return listResponse([{ comment_id: COMMENT_ID, has_more: true, reply_list: { replies: first5 } }]);
+      }
+      if (opts.url.includes('/replies')) return { code: 0, data: { items: [], has_more: false } };
+      throw new Error(`unexpected ${opts.url}`);
+    });
+
+    await expect(listDocComments('app-test', FILE)).rejects.toThrow(/0 replies/);
+  });
+
+  it('事件链路对同样的空数组仍降级（两条链路语义不同，别一起改）', async () => {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments/batch_query')) return truncatedBatchQuery(first5);
+      if (opts.url.includes('/replies')) return { code: 0, data: { items: [], has_more: false } };
+      throw new Error(`unexpected ${opts.url}`);
+    });
+
+    const comment = await getDocComment('app-test', FILE, COMMENT_ID);
+    expect(comment!.replies).toHaveLength(5);
+    // 截断标记必须留着 —— 下游 `!trigger` 的告警靠它区分「分页没补全」和别的原因。
+    expect(comment!.hasMoreReplies).toBe(true);
+  });
 });
 
 /**

--- a/test/doc-comment-reply-pagination.test.ts
+++ b/test/doc-comment-reply-pagination.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from 'node:fs';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 回归：飞书对**单条评论的回复串**分页（实测一页 5 条），并把 `has_more` 挂在
+ * 评论对象顶层。吃下这个截断会让长 thread 从第 6 条回复起永久失联 —— 事件带
+ * 着新 reply_id 打进来，在只有 5 条的 replies 里找不到，旧代码 `?? replies[last]`
+ * 静默回退到最后一条已知回复，turnId 因此恒定不变，每条新评论都被去重逻辑
+ * 当成重复回合丢弃。
+ */
+
+const mocks = vi.hoisted(() => ({
+  tenantRequest: vi.fn(),
+  resolveUserToken: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  formatLarkError: vi.fn(),
+  getAllBots: vi.fn(() => []),
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app-test', larkAppSecret: 'secret-test', brand: 'feishu' },
+  })),
+  getBotClient: vi.fn(() => ({ request: mocks.tenantRequest })),
+  loadBotConfigs: vi.fn(() => []),
+}));
+
+vi.mock('../src/utils/user-token.js', () => ({
+  resolveUserToken: mocks.resolveUserToken,
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: mocks.info, warn: mocks.warn },
+}));
+
+import { getDocComment } from '../src/im/lark/doc-comment.js';
+
+const FILE = { fileToken: 'DocToken1234567890123456', fileType: 'docx' };
+const COMMENT_ID = '7681622822925421500';
+
+function reply(id: string, text: string, createTime: number) {
+  return {
+    reply_id: id,
+    user_id: 'ou_author',
+    create_time: String(createTime),
+    content: { elements: [{ text_run: { text } }] },
+  };
+}
+
+/** batch_query 的应答：只给前 5 条，顶层 has_more=true。 */
+function truncatedBatchQuery(replies: unknown[]) {
+  return {
+    code: 0,
+    data: {
+      items: [{
+        comment_id: COMMENT_ID,
+        is_whole: false,
+        is_solved: false,
+        quote: '  "grain": "product_id",',
+        has_more: true,
+        page_token: '7681631714111704022',
+        reply_list: { replies },
+      }],
+    },
+  };
+}
+
+describe('getDocComment: 补全被分页截断的回复串', () => {
+  beforeEach(() => {
+    mocks.tenantRequest.mockReset();
+    mocks.resolveUserToken.mockReset().mockResolvedValue(null);
+    mocks.warn.mockReset();
+    mocks.info.mockReset();
+  });
+
+  it('has_more=true 时改用 /replies 端点拉全量，返回完整 thread', async () => {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    const all11 = Array.from({ length: 11 }, (_, i) => reply(`reply-${i + 1}`, `msg ${i + 1}`, 1788500000 + i + 1));
+
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments/batch_query')) return truncatedBatchQuery(first5);
+      if (opts.url.includes(`/comments/${COMMENT_ID}/replies`)) {
+        return { code: 0, data: { items: all11, has_more: false } };
+      }
+      throw new Error(`unexpected call ${opts.url}`);
+    });
+
+    const comment = await getDocComment('app-test', FILE, COMMENT_ID);
+
+    expect(comment).not.toBeNull();
+    expect(comment!.replies).toHaveLength(11);
+    expect(comment!.replies.at(-1)!.replyId).toBe('reply-11');
+    expect(comment!.hasMoreReplies).toBe(false);
+    // 评论自身的元数据（quote / is_whole）不能被补全流程弄丢。
+    expect(comment!.quote).toBe('"grain": "product_id",');
+    expect(comment!.isWhole).toBe(false);
+  });
+
+  it('/replies 自身分页时继续翻页直到 has_more=false', async () => {
+    const page1 = [1, 2].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    const page2 = [3, 4].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments/batch_query')) return truncatedBatchQuery(page1);
+      if (opts.url.includes('/replies')) {
+        return opts.params?.page_token
+          ? { code: 0, data: { items: page2, has_more: false } }
+          : { code: 0, data: { items: page1, has_more: true, page_token: 'cursor-2' } };
+      }
+      throw new Error(`unexpected call ${opts.url}`);
+    });
+
+    const comment = await getDocComment('app-test', FILE, COMMENT_ID);
+    expect(comment!.replies.map(r => r.replyId)).toEqual(['reply-1', 'reply-2', 'reply-3', 'reply-4']);
+  });
+
+  it('has_more=false 时不额外打 /replies', async () => {
+    const replies = [reply('reply-1', 'only one', 1788500001)];
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments/batch_query')) {
+        return {
+          code: 0,
+          data: {
+            items: [{ comment_id: COMMENT_ID, has_more: false, reply_list: { replies } }],
+          },
+        };
+      }
+      throw new Error(`should not fetch replies: ${opts.url}`);
+    });
+
+    const comment = await getDocComment('app-test', FILE, COMMENT_ID);
+    expect(comment!.replies).toHaveLength(1);
+    expect(mocks.tenantRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('补全失败时退回截断结果并保留 hasMoreReplies 标记（不静默假装完整）', async () => {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments/batch_query')) return truncatedBatchQuery(first5);
+      throw new Error('replies endpoint down');
+    });
+    // 补全走 preferTenant，tenant 失败会回退 user 身份 —— 让 user 也失败。
+    mocks.resolveUserToken.mockResolvedValue(null);
+
+    const comment = await getDocComment('app-test', FILE, COMMENT_ID);
+    expect(comment!.replies).toHaveLength(5);
+    expect(comment!.hasMoreReplies).toBe(true);
+  });
+});
+
+/**
+ * 事件派发里的触发回复解析：源码形状钉死。
+ * 这段逻辑深埋在 handleDocCommentEvent 中间（前面有订阅解析、open_id 探针、
+ * 网络拉评论），单测起来要 mock 整条链路；这里按仓库已有做法直接钉源码形状，
+ * 保证那个会导致长 thread 永久失联的静默回退不会被改回来。
+ */
+describe('handleDocCommentEvent 触发回复解析（源码形状）', () => {
+  const dispatcherSrc = readFileSync(new URL('../src/im/lark/event-dispatcher.ts', import.meta.url), 'utf-8');
+  const region = (() => {
+    const start = dispatcherSrc.indexOf('const trigger = parsed.replyId');
+    expect(start).toBeGreaterThan(-1);
+    return dispatcherSrc.slice(start, dispatcherSrc.indexOf('const triggerIndex', start));
+  })();
+
+  it('事件带 reply_id 时不再回退到 replies 的最后一条', () => {
+    expect(region).toContain('comment.replies.find(r => r.replyId === parsed.replyId)');
+    // 这个 `??` 回退正是 bug 本体：找不到就拿老回复顶上。
+    expect(region).not.toContain('?? comment.replies[comment.replies.length - 1]');
+  });
+
+  it('找不到触发回复时告警并丢弃本条，而不是静默用错的回复继续', () => {
+    expect(region).toContain('if (!trigger) {');
+    expect(region).toContain('logger.warn(');
+    expect(region).toContain('return;');
+    // 告警要带上「回复串是否被截断」，否则线上无法区分是分页截断还是别的原因。
+    expect(region).toContain('comment.hasMoreReplies');
+  });
+});

--- a/test/doc-comment-reply-pagination.test.ts
+++ b/test/doc-comment-reply-pagination.test.ts
@@ -35,7 +35,8 @@ vi.mock('../src/utils/logger.js', () => ({
   logger: { debug: vi.fn(), error: vi.fn(), info: mocks.info, warn: mocks.warn },
 }));
 
-import { getDocComment } from '../src/im/lark/doc-comment.js';
+import { getDocComment, listDocComments } from '../src/im/lark/doc-comment.js';
+import { docCommentRepliesAfterCursor, latestDocCommentPollCursor } from '../src/core/doc-comment-poller.js';
 
 const FILE = { fileToken: 'DocToken1234567890123456', fileType: 'docx' };
 const COMMENT_ID = '7681622822925421500';
@@ -176,5 +177,109 @@ describe('handleDocCommentEvent 触发回复解析（源码形状）', () => {
     expect(region).toContain('return;');
     // 告警要带上「回复串是否被截断」，否则线上无法区分是分页截断还是别的原因。
     expect(region).toContain('comment.hasMoreReplies');
+  });
+});
+
+/**
+ * 轮询链路（listDocComments）的补全语义，与事件链路**故意不同**：这里补全失败
+ * 必须抛错，绝不能降级返回截断结果。
+ */
+describe('listDocComments: 轮询链路补全失败必须抛错', () => {
+  beforeEach(() => {
+    mocks.tenantRequest.mockReset();
+    mocks.resolveUserToken.mockReset().mockResolvedValue(null);
+    mocks.warn.mockReset();
+    mocks.info.mockReset();
+  });
+
+  function listResponse(items: unknown[]) {
+    return { code: 0, data: { items, has_more: false } };
+  }
+
+  it('补全成功时把截断的评论补齐（轮询链路也接上了，不只事件链路）', async () => {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    const all11 = Array.from({ length: 11 }, (_, i) => reply(`reply-${i + 1}`, `msg ${i + 1}`, 1788500000 + i + 1));
+
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments')) {
+        return listResponse([{ comment_id: COMMENT_ID, has_more: true, reply_list: { replies: first5 } }]);
+      }
+      if (opts.url.includes('/replies')) return { code: 0, data: { items: all11, has_more: false } };
+      throw new Error(`unexpected ${opts.url}`);
+    });
+
+    const comments = await listDocComments('app-test', FILE);
+    expect(comments).toHaveLength(1);
+    expect(comments[0].replies).toHaveLength(11);
+    expect(comments[0].hasMoreReplies).toBe(false);
+  });
+
+  it('补全失败时抛错，不返回截断结果', async () => {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments')) {
+        return listResponse([{ comment_id: COMMENT_ID, has_more: true, reply_list: { replies: first5 } }]);
+      }
+      throw new Error('replies endpoint down');
+    });
+
+    await expect(listDocComments('app-test', FILE)).rejects.toThrow();
+  });
+
+  /**
+   * 回归：补全失败若降级返回截断结果，游标会按截断的回复数推进，后续回复永久漏投。
+   *
+   * 复现序列（游标是**全文档所有回复拉平后**的单一游标，见 flattenDocCommentReplies）：
+   *   轮 1：补全成功 → 看到 11 条 → 游标推到 reply-11
+   *   轮 2：补全失败 →（若降级）只看到 5 条 → 全部 ≤ 游标 → fresh 为空
+   *          此时新到的 reply-12 在截断响应里根本不存在，且游标已在 11 不会回退
+   *          → reply-12 永久不投
+   * 抛错则 daemon 的 per-sub try/catch 跳过本轮、游标不动、下轮重试。
+   */
+  it('回归：补全失败必须让整轮 poll 失败，而不是让游标基于 5 条回复推进', async () => {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    const all11 = Array.from({ length: 11 }, (_, i) => reply(`reply-${i + 1}`, `msg ${i + 1}`, 1788500000 + i + 1));
+
+    // 轮 1：补全成功，游标推到最后一条。
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments')) {
+        return listResponse([{ comment_id: COMMENT_ID, has_more: true, reply_list: { replies: first5 } }]);
+      }
+      if (opts.url.includes('/replies')) return { code: 0, data: { items: all11, has_more: false } };
+      throw new Error(`unexpected ${opts.url}`);
+    });
+    const round1 = await listDocComments('app-test', FILE);
+    const cursor = latestDocCommentPollCursor(round1)!;
+    expect(cursor.replyId).toBe('reply-11');
+
+    // 轮 2：补全失败。抛错 ⇒ 调用方拿不到任何 comments，游标不动。
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments')) {
+        return listResponse([{ comment_id: COMMENT_ID, has_more: true, reply_list: { replies: first5 } }]);
+      }
+      throw new Error('replies endpoint down');
+    });
+    await expect(listDocComments('app-test', FILE)).rejects.toThrow();
+
+    // 反证：若当初降级返回了截断的 5 条，游标之后就什么都看不到了 ——
+    // 而真实新回复 reply-12 恰恰在那个看不见的区间里，于是永久漏投。
+    const degraded = [{ ...round1[0], replies: round1[0].replies.slice(0, 5) }];
+    expect(docCommentRepliesAfterCursor(degraded, cursor)).toHaveLength(0);
+  });
+
+  it('分页游标不推进时不会死循环，超过页数上限抛错', async () => {
+    const first5 = [1, 2, 3, 4, 5].map(i => reply(`reply-${i}`, `msg ${i}`, 1788500000 + i));
+    let calls = 0;
+    mocks.tenantRequest.mockImplementation(async (opts: any) => {
+      if (opts.url.endsWith('/comments')) {
+        return listResponse([{ comment_id: COMMENT_ID, has_more: true, reply_list: { replies: first5 } }]);
+      }
+      calls++;
+      // 恒定 page_token：服务端 bug 的典型形态。
+      return { code: 0, data: { items: [reply('reply-x', 'x', 1788500099)], has_more: true, page_token: 'stuck' } };
+    });
+
+    await expect(listDocComments('app-test', FILE)).rejects.toThrow(/页上限|游标未推进/);
+    expect(calls).toBeLessThan(200); // 有界，不是死循环
   });
 });


### PR DESCRIPTION
## 现象

文档评论里 @ bot，前几轮正常，聊到一定长度后 **bot 突然彻底不回了** —— 没有报错、没有失败卡片，就是静默消失。再怎么 @ 都不会醒。

daemon 日志里是刷屏的：

```
[doc-comment] dispatch file=JWoidiGzSo36 comment=768162282292 mode=mention-only → session anchor=doc:JWoidiGz
[doc-comment] duplicate turn skipped file=JWoidiGzSo36 turn=768163171411
```

注意 `turn=` 每次都一样，但用户明明在发新评论。

## 根因

飞书对**单条评论的回复串**分页，`has_more` 挂在**评论对象顶层**（不是 `reply_list` 里），没有参数可以调大。

用触发这个 bug 的真实 thread 实测（同一条评论，11 条回复）：

| 端点 | 返回回复数 | 截断 |
|---|---|---|
| `POST /comments/batch_query` | **5** | 是，`has_more: true` |
| `GET /comments` | 11 | 否 |
| `GET /comments/{id}/replies` | 11 | 否（补全用的端点） |

> ⚠️ 更正：本 PR 第一版的描述和注释称 `batch_query` 和 `GET /comments` **都**截断，这是错的。全文档扫描（33 条评论、单串最长 11 条）确认 `GET /comments` 没有任何一条 `has_more=true`。**踩坑的只有事件链路走的 `batch_query`。** `listDocComments`（`--all` 轮询链路）的补全因此是**防御性**的——`has_more` 是文档化字段，飞书随时可能对它生效——正常情况下一个补全请求都不会发。第二个 commit 已修正代码注释。

`processCommentEvent` 里这行是引爆点：

```ts
const trigger = parsed.replyId
  ? comment.replies.find(r => r.replyId === parsed.replyId) ?? comment.replies[comment.replies.length - 1]
  : comment.replies[comment.replies.length - 1];
```

第 6 条回复起，事件带的新 `reply_id` 在只有 5 条的 `replies` 里 `find` 不到 → `??` 静默回退到**最后一条已知回复**。于是：

1. `turnId` 恒等于那条老回复 → `handleDocComment` 的 dedup 每次都判重复 → 新评论全部丢弃
2. mention-only 闸用错误回复的 `mentions` 判定
3. 自触发过滤用错误回复的作者/哨兵判定

三重污染，且完全静默。**任何超过 5 条回复的评论串都会必然中断**，不是偶发。

## 改动

**`src/im/lark/doc-comment.ts`** — 新增 `hydrateTruncatedReplies()`

顶层 `has_more` 为真时改用 `GET /comments/{id}/replies` 翻全量补齐。`getDocComment`（事件链路，实际踩坑方）和 `listDocComments`（`--all` 轮询链路，防御性）都接上。

补全失败的语义**由调用方选**，因为两条链路后果完全不同：

| 链路 | `onTruncated` | 理由 |
|---|---|---|
| `getDocComment`（事件） | `degrade` | 没有游标可污染，下游 `!trigger` 有兜底告警 |
| `listDocComments`（轮询） | **`throw`** | 降级会让游标按截断的回复数推进，**永久漏投**（下详） |

轮询链路为什么绝不能降级 —— `hasMoreReplies` 在整条轮询链路无人消费，游标是按拿到的回复算的：

1. 某轮补全成功 → 看到 11 条 → 游标推到第 11 条
2. 下一轮补全失败 →（若降级）只看到 5 条 → `docCommentRepliesAfterCursor` 返回空
3. 本轮新到的第 12 条**永久不投**：游标已在 11，而截断响应里永远看不到 12

抛错则 daemon 的 per-sub `try/catch` 跳过本轮、游标不动、下轮重试，才是正确语义。

其余：
- `preferTenant` 改为形参，两条链路各自与自己的主请求身份优先级对齐（原先一律 tenant-first，在 user-only 有权的文档上每轮都会先打一次注定失败的 tenant 请求）
- 加 `MAX_REPLY_PAGES = 50`：服务端返回恒定 `page_token` 会把补全卡死在「每条评论 × 每个订阅」两层循环里，连带 `docCommentPollRunning` 永不释放
- `replies.length === 0` 补 warn，不再与「没调用」混淆
- `DocComment` 新增 `hasMoreReplies` 字段暴露截断状态

**排序保险**：补全成功后按 `createdAt` 升序稳定排一次（同秒并列用 `replyId` 数值序，复用 poller 的 `compareReplyIds`）。实测 `/replies` 与 `reply_list.replies` 同序，但飞书**既未声明排序也未提供排序参数**——这是未承诺行为。轮询链路有 `flattenDocCommentReplies` 的 sort 兜底，**事件链路没有**：`priorReplies` 直接吃 API 顺序，一旦飞书改成降序，症状是模型把「后面的回复」当历史上下文，且无任何日志。与其把假设写在注释里，不如让代码守住。

**`src/im/lark/event-dispatcher.ts`** — 删掉静默回退

`?? comment.replies[...]` 去掉。事件明确给了 `reply_id` 却找不到，是「数据不完整」的错误信号，不是「用最后一条凑合」的场景。改为 warn + 丢弃本条，日志带 `truncated=` 便于区分是分页截断还是别的原因。

宁可丢一条并留下告警，也不能拿错误的回复去驱动 @ 判定、自触发过滤和 turnId 去重。

## 测试

新增 `test/doc-comment-reply-pagination.test.ts`（10 passed）：

事件链路（`getDocComment`）：
- `has_more=true` 走 `/replies` 拉全量（5 → 11 条），`quote` / `is_whole` 元数据不丢
- `/replies` 自身分页时继续翻页直到 `has_more=false`
- `has_more=false` 时不多打一次请求
- 补全失败降级并保留 `hasMoreReplies` 标记

轮询链路（`listDocComments`）：
- 补全成功时补齐（证明这条链路真的接上了，不只事件链路）
- **补全失败抛错，不返回截断结果**
- **回归：补全失败必须让整轮 poll 失败，而不是让游标基于 5 条回复推进** —— 用真实的 `latestDocCommentPollCursor` / `docCommentRepliesAfterCursor` 复现上面那个漏投序列
- 分页游标不推进时不死循环，超上限抛错

两个源码形状用例钉住 dispatcher 的回退删除（沿用仓库已有风格）。

**变异验证**（两轮，确认断言不是摆设）：
- 把 `??` 回退改回 `event-dispatcher.ts` → 形状用例转红（1 failed）
- 把轮询链路的 `'throw'` 改回 `'degrade'` → 3 个用例转红
- 删掉补全后的 `sort` → 2 个用例转红

**真实 API 端到端复核**（触发本 bug 的那条 thread，bot tenant token）：

```
[before] replies = 5  | hasMoreReplies = true
[after ] replies = 11
  reply 7681633934731430857: before=MISSING | after=FOUND ✓
  reply 7681638981947149295: before=MISSING | after=FOUND ✓
  reply 7681645968344747278: before=MISSING | after=FOUND ✓
```

三条原本被 dedup 丢弃的评论，补全后均可正确命中。

**另外两项经实测确认、而非推测的事实**（评审时被质疑，已验证）：

- **`/replies` 与 `reply_list.replies` 同序**：都是 `create_time` 升序，跨页拼接（`page_size=2` 强制多页）后仍升序，前 5 条与截断结果逐字节一致。这点很关键——上层的 `priorReplies`（`replies.slice(0, triggerIndex)`）和无 `reply_id` 时的 trigger 选取都依赖升序，换端点若破坏顺序会让模型把「未来的回复」当成历史上下文。飞书文档对该端点**未声明排序也没有排序参数**，所以只能实测。
- **两端点的 reply 对象同构**：`normalizeReply` 的提取是纯重构，无行为变化。

**已跑过**：

| 范围 | 结果 |
|---|---|
| `tsc --noEmit` | 干净 |
| 新增用例 | 13 passed |
| doc-comment 全部 6 个文件 | 68 passed |
| `event-dispatcher.test.ts` | 330 passed |
| 全量 `vitest run --project unit` | **70 failed / 21003 passed / 95 skipped**（1226 个文件中 16 个失败） |

全量的 70 个失败**与本 PR 无关，是仓库既有失败**。已在未修改的 `upstream/master`（86e99a3c）新建 worktree 复跑同一组文件复核：**同样是 16 files / 70 tests 失败，集合完全一致**。失败集中在 `git-worktree` / `default-worktree` / `cli-adapters` / `workflow-cli` / `session-store-sqlite-*` 等，与文档评论链路无交集。

## 未验证

| 剩余检查 | 需要的环境或原因 | 影响范围 |
|---|---|---|
| 真实 daemon live 回归 | 需重启 daemon 才能加载新代码 | 阻塞发布，不阻塞 PR |
| `--all` 轮询模式端到端 | 需要一篇真实的 `has_more=true` 文档；实测 `GET /comments` 不截断，构造不出 | 不阻塞（该路径为防御性） |
| e2e 项目（`--project e2e`） | 需要 CLI 后端环境 | 不阻塞 PR |

另记一次**未复现**的观察：某轮全量出现过 71 failed（比基线多 `test/session-lifecycle-start.test.ts` 的 `keeps daemon routing identity…`，报 `expected null to match object`）。该文件单独跑 170 passed（连跑 4 次）、带我的改动跑子集也不失败、与本 PR 三个文件无代码交集；后续**两次**全量复跑均为 70 failed / 21003 passed、失败文件集合与基线逐行一致，均未再出现；该文件单独跑累计 4 次 170 passed。判定为全量并发下的串扰，非本 PR 引入——但如果它再次出现且仍是唯一新增失败，应往 SQLite session store 的测试隔离查一层。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
