### PR TITLE
feat(config): 支持受控启动密钥文件配置

### DIFF
--- a/docs-site/docs/en/cli-commands.md
+++ b/docs-site/docs/en/cli-commands.md
@@ -5,9 +5,9 @@ Manage the daemon and sessions from the terminal.
 | Command | Description |
 |------|------|
 | `botmux setup` | Interactive configuration (first run / add / edit / delete a bot) |
-| `botmux start` | Start the daemon (managed by PM2) |
+| `botmux start [--companion-secret-file <path> --companion-bot <appId>]` | Start the daemon. Supplying both companion options enables the closed local API for exactly one isolated test Bot; see [Local Companion API](/en/companion-api) |
 | `botmux stop` | Stop the daemon |
-| `botmux restart [--include-pm2]` | Restart the daemon (automatically restores active sessions); `--include-pm2` additionally retires botmux's PM2 God daemon after the fleet is safely shut down, so the whole process tree restarts from the invoking shell's clean environment (plugin services are gracefully stopped first; auto ones come back after the restart) |
+| `botmux restart [--companion-secret-file <path> --companion-bot <appId>]` | Restart the daemon and restore active sessions; accepts the same closed Companion API options as `start` |
 | `botmux logs [--lines N]` | View logs |
 | `botmux status` | View daemon status |
 | `botmux upgrade` | Upgrade to the latest version |

--- a/docs-site/docs/en/companion-api.md
+++ b/docs-site/docs/en/companion-api.md
@@ -1,0 +1,39 @@
+# Local Companion API
+
+Botmux can expose a closed local management protocol for one explicitly bound isolated test Bot. It neither reuses Dashboard tokens or Dashboard/daemon HMAC keys nor proxies arbitrary Dashboard routes.
+
+## Startup
+
+```bash
+botmux start \
+  --companion-secret-file /run/secrets/botmux/companion \
+  --companion-bot local_test_bot
+```
+
+`restart` accepts the same options. Both options are required together. The target must match exactly one `bots.json` entry with `sandbox` enabled and `cliId` set to `codex` or `traex`. The secret must be a nonempty, non-symlink `0600` regular file owned by the current user at a canonical absolute path. Invalid configuration fails closed without including the path or contents in the error.
+
+## Authentication
+
+The surface uses the Dashboard's local listening port but authenticates independently before ordinary Dashboard auth/routing; it grants no Dashboard administrator identity. Requests must originate from loopback and carry:
+
+- `X-Botmux-Companion-Timestamp`: epoch milliseconds, within 60 seconds;
+- `X-Botmux-Companion-Nonce`: a one-time random value;
+- `X-Botmux-Companion-Signature`: base64url HMAC-SHA256.
+
+Signing material:
+
+```text
+timestamp\nnonce\nMETHOD\nexact-pathname\nsha256(raw-body)
+```
+
+Bodies are capped at 64 KiB. Replay, stale timestamps, and signature/method/path/body mismatches are rejected before the operation runs.
+
+## Fixed routes
+
+- `GET /__companion/v1/health`: protocol version and capabilities only;
+- `GET /__companion/v1/role`: `{role, injectMode, revision:null}`, with role text capped at 32 KiB;
+- `PUT /__companion/v1/role`: only `{requestId, role, injectMode}`; `injectMode` is `every|once`, and `role:""` clears it; returns the sanitized readback;
+- `GET /__companion/v1/runtime`: `{provider, model?, reasoning?}`;
+- `PUT /__companion/v1/runtime`: only `{requestId, provider, model?, reasoning?}`. `provider` is `codex|traecli` (mapped to Botmux `codex|traex`), model is at most 200 characters, and reasoning uses the existing provider/model-specific closed allowlist.
+
+Writes are idempotent by `requestId` for the process lifetime. The API accepts no Bot ID, chat ID, arbitrary settings/env/URL/header/command and exposes no trigger/result surface; every operation targets the startup-bound Bot. Role text is returned only on this companion-HMAC route and is not added to Dashboard/public DTOs. Responses and errors contain no secret, file path, or native identifier.

--- a/docs-site/docs/en/env.md
+++ b/docs-site/docs/en/env.md
@@ -34,7 +34,8 @@ Most configuration goes through `bots.json` / the dashboard — you **usually do
 | `BOTMUX_DAEMON_IPC_BASE_PORT` | `7892` | Each daemon's IPC port = base + botIndex |
 | `BOTMUX_WORKFLOW_RUNS_DIR` | `~/.botmux/workflow-runs` | Workflow run storage directory |
 | `BOTMUX_DASHBOARD_PUBLIC_READONLY` | `true` | Allow tokenless access to the Dashboard's allow-listed read-only APIs / SSE. Once this switch has been saved in Dashboard Settings, the value persisted in `~/.botmux/config.json` takes precedence over this environment variable |
-| `BOTMUX_COMPANION_SECRET_FILE` | _(unset)_ | Path to a local companion process's private secret file. At startup, Botmux stores only the trimmed non-empty path in `config.companion.secretFile`; it does not read, validate, or log file contents, and does not pass the path to session CLIs. Unset or blank resolves to `undefined`; there is no fallback to or reuse of `~/.botmux/.dashboard-secret`. Use an absolute `0600` regular file owned by the Botmux account; the companion process is responsible for secure reading and validation. |
+| `BOTMUX_COMPANION_SECRET_FILE` | _(unset)_ | Dedicated HMAC secret-file path for the closed [Local Companion API](/en/companion-api), normally set by `start/restart --companion-secret-file`. Botmux strictly requires a canonical absolute path, current-user ownership, non-symlink regular file, `0600`, and nonempty content. It is not passed to session CLIs and never falls back to `.dashboard-secret`. |
+| `BOTMUX_COMPANION_BOT_APP_ID` | _(unset)_ | The single isolated test Bot bound to the Companion API, normally set by `start/restart --companion-bot`. Callers cannot select a Bot. |
 
 ## File locations
 

--- a/docs-site/docs/en/env.md
+++ b/docs-site/docs/en/env.md
@@ -34,6 +34,7 @@ Most configuration goes through `bots.json` / the dashboard — you **usually do
 | `BOTMUX_DAEMON_IPC_BASE_PORT` | `7892` | Each daemon's IPC port = base + botIndex |
 | `BOTMUX_WORKFLOW_RUNS_DIR` | `~/.botmux/workflow-runs` | Workflow run storage directory |
 | `BOTMUX_DASHBOARD_PUBLIC_READONLY` | `true` | Allow tokenless access to the Dashboard's allow-listed read-only APIs / SSE. Once this switch has been saved in Dashboard Settings, the value persisted in `~/.botmux/config.json` takes precedence over this environment variable |
+| `BOTMUX_COMPANION_SECRET_FILE` | _(unset)_ | Path to a local companion process's private secret file. At startup, Botmux stores only the trimmed non-empty path in `config.companion.secretFile`; it does not read, validate, or log file contents, and does not pass the path to session CLIs. Unset or blank resolves to `undefined`; there is no fallback to or reuse of `~/.botmux/.dashboard-secret`. Use an absolute `0600` regular file owned by the Botmux account; the companion process is responsible for secure reading and validation. |
 
 ## File locations
 

--- a/docs-site/docs/zh/cli-commands.md
+++ b/docs-site/docs/zh/cli-commands.md
@@ -5,9 +5,9 @@
 | 命令 | 说明 |
 |------|------|
 | `botmux setup` | 交互式配置（首次 / 添加 / 编辑 / 删除机器人） |
-| `botmux start` | 启动 daemon（PM2 管理） |
+| `botmux start [--companion-secret-file <path> --companion-bot <appId>]` | 启动 daemon；两个 companion 参数同时提供时，为唯一绑定的隔离测试 Bot 开启封闭本机 API（见[本地 Companion API](/companion-api)） |
 | `botmux stop` | 停止 daemon |
-| `botmux restart [--include-pm2]` | 重启 daemon（自动恢复活跃会话）；`--include-pm2` 会在 fleet 安全关停并验证后同时退役 botmux 专用 PM2 God daemon，让整棵进程树以当前 shell 的干净环境全新启动（插件 service 会先优雅停止，auto 的重启后自动恢复） |
+| `botmux restart [--companion-secret-file <path> --companion-bot <appId>]` | 重启 daemon（自动恢复活跃会话）；接受与 `start` 相同的封闭 Companion API 参数 |
 | `botmux logs [--lines N]` | 查看日志 |
 | `botmux status` | 查看 daemon 状态 |
 | `botmux upgrade` | 升级到最新版本 |

--- a/docs-site/docs/zh/companion-api.md
+++ b/docs-site/docs/zh/companion-api.md
@@ -1,0 +1,39 @@
+# 本地 Companion API
+
+Botmux 可为一个显式绑定的隔离测试 Bot 开启封闭的本机管理协议。它不复用 Dashboard token、Dashboard/daemon HMAC 密钥，也不代理任意 Dashboard 路由。
+
+## 启动
+
+```bash
+botmux start \
+  --companion-secret-file /run/secrets/botmux/companion \
+  --companion-bot local_test_bot
+```
+
+`restart` 接受相同选项。两个选项必须同时提供；目标必须精确匹配 `bots.json` 中一个启用 `sandbox`、且 `cliId` 为 `codex` 或 `traex` 的 Bot。密钥必须是 canonical 绝对路径上的当前用户所有、非符号链接、非空 `0600` 普通文件。校验失败时拒绝启动该配置，且错误不会包含路径或内容。
+
+## 鉴权
+
+接口复用 Dashboard 的本机监听端口，但在普通 Dashboard 鉴权与路由之外独立验签；它不会授予 Dashboard 管理身份。请求只能来自 loopback。每个请求携带：
+
+- `X-Botmux-Companion-Timestamp`：epoch 毫秒；允许偏差 60 秒；
+- `X-Botmux-Companion-Nonce`：一次性随机值；
+- `X-Botmux-Companion-Signature`：base64url HMAC-SHA256。
+
+签名材料为：
+
+```text
+timestamp\nnonce\nMETHOD\nexact-pathname\nsha256(raw-body)
+```
+
+body 上限 64 KiB。重放、过期、签名/方法/路径/body 不匹配均在执行操作前拒绝。
+
+## 固定路由
+
+- `GET /__companion/v1/health`：只返回协议版本和 capability；
+- `GET /__companion/v1/role`：返回 `{role, injectMode, revision:null}`；role 最大 32 KiB；
+- `PUT /__companion/v1/role`：仅接受 `{requestId, role, injectMode}`；`injectMode` 为 `every|once`，`role:""` 清除；返回 sanitize 后 readback；
+- `GET /__companion/v1/runtime`：返回 `{provider, model?, reasoning?}`；
+- `PUT /__companion/v1/runtime`：仅接受 `{requestId, provider, model?, reasoning?}`。`provider` 为 `codex|traecli`（分别映射 Botmux `codex|traex`），model 最长 200 字符，reasoning 使用对应 provider/model 的现有闭集。
+
+写操作按 `requestId` 在进程生命周期内幂等。接口不接受 Bot ID、chat ID、任意 settings/env/URL/header/命令，也不提供 trigger/result；所有操作固定作用于启动绑定 Bot。角色文本只在通过 companion HMAC 的该路由返回，不加入 Dashboard/public DTO。响应和错误不包含密钥、文件路径或原生 ID。

--- a/docs-site/docs/zh/env.md
+++ b/docs-site/docs/zh/env.md
@@ -34,6 +34,7 @@
 | `BOTMUX_DAEMON_IPC_BASE_PORT` | `7892` | 每个 daemon 的 IPC 端口 = base + botIndex |
 | `BOTMUX_WORKFLOW_RUNS_DIR` | `~/.botmux/workflow-runs` | workflow run 存储目录 |
 | `BOTMUX_DASHBOARD_PUBLIC_READONLY` | `true` | 是否允许无 token 访问 Dashboard 白名单只读 API / SSE；一旦在 Dashboard 设置页保存过该开关，`~/.botmux/config.json` 中的值优先于本环境变量 |
+| `BOTMUX_COMPANION_SECRET_FILE` | _(未设置)_ | 本地 companion 进程的私有密钥文件**路径**。Botmux 启动时仅保存经 trim 的非空路径到 `config.companion.secretFile`；不读取、校验、记录文件内容，不下发给会话 CLI，且未设置/空白时为 `undefined`，绝不回退或复用 `~/.botmux/.dashboard-secret`。建议配置为运行 Botmux 账号持有的绝对 `0600` 普通文件；companion 进程负责安全读取与校验。 |
 
 ## 文件位置
 

--- a/docs-site/docs/zh/env.md
+++ b/docs-site/docs/zh/env.md
@@ -34,7 +34,8 @@
 | `BOTMUX_DAEMON_IPC_BASE_PORT` | `7892` | 每个 daemon 的 IPC 端口 = base + botIndex |
 | `BOTMUX_WORKFLOW_RUNS_DIR` | `~/.botmux/workflow-runs` | workflow run 存储目录 |
 | `BOTMUX_DASHBOARD_PUBLIC_READONLY` | `true` | 是否允许无 token 访问 Dashboard 白名单只读 API / SSE；一旦在 Dashboard 设置页保存过该开关，`~/.botmux/config.json` 中的值优先于本环境变量 |
-| `BOTMUX_COMPANION_SECRET_FILE` | _(未设置)_ | 本地 companion 进程的私有密钥文件**路径**。Botmux 启动时仅保存经 trim 的非空路径到 `config.companion.secretFile`；不读取、校验、记录文件内容，不下发给会话 CLI，且未设置/空白时为 `undefined`，绝不回退或复用 `~/.botmux/.dashboard-secret`。建议配置为运行 Botmux 账号持有的绝对 `0600` 普通文件；companion 进程负责安全读取与校验。 |
+| `BOTMUX_COMPANION_SECRET_FILE` | _(未设置)_ | 封闭[本地 Companion API](/companion-api) 的专用 HMAC 密钥文件路径；通常由 `start/restart --companion-secret-file` 设置。严格校验 canonical 绝对路径、当前用户 owner、非软链、普通文件、`0600`、非空；不下发给会话 CLI，绝不回退或复用 `.dashboard-secret`。 |
+| `BOTMUX_COMPANION_BOT_APP_ID` | _(未设置)_ | Companion API 唯一绑定的隔离测试 Bot；通常由 `start/restart --companion-bot` 设置。不接受请求方选择 Bot。 |
 
 ## 文件位置
 

--- a/docs-site/rspress.config.ts
+++ b/docs-site/rspress.config.ts
@@ -77,6 +77,7 @@ const zhSidebar = [
     items: [
       { text: 'bots.json 配置', link: '/bots-json' },
       { text: '环境变量与文件位置', link: '/env' },
+      { text: '本地 Companion API', link: '/companion-api' },
       { text: '多 CLI 适配器', link: '/adapters' },
     ],
   },
@@ -160,6 +161,7 @@ const enSidebar = [
     items: [
       { text: 'bots.json', link: '/en/bots-json' },
       { text: 'Environment & File Locations', link: '/en/env' },
+      { text: 'Local Companion API', link: '/en/companion-api' },
       { text: 'CLI Adapters', link: '/en/adapters' },
     ],
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,9 +7,11 @@
  *   botmux setup --no-open-platform-auto — skip Feishu Open Platform automation
  *   botmux setup list|add|configure|edit|remove — scripted (non-TUI) bot management, see `botmux setup help`
  *   botmux clone <bot> [--name <name>] — create a new app, then copy an existing bot's configuration
- *   botmux start          — start daemon and auto plugin services
+ *   botmux start [--companion-secret-file <path> --companion-bot <appId>]
+ *                         — start daemon and optionally its closed local companion API
  *   botmux stop [--with-plugin] — stop daemon (optionally stop auto plugin services)
- *   botmux restart [--with-plugin] — restart daemon, then ensure auto plugin services
+ *   botmux restart [--with-plugin] [--companion-secret-file <path> --companion-bot <appId>]
+ *                         — restart daemon, then ensure auto plugin services
  *   botmux logs [--lines] [--bot <i>] [--no-follow] — view/stream per-bot daemon logs
  *   botmux status         — show daemon status
  *   botmux upgrade|update — upgrade to latest version (本地 checkout 则 git pull --ff-only + rebuild + restart)
@@ -2430,10 +2432,22 @@ function preflightNodeSanity(): void {
   }
 }
 
-async function cmdStart(): Promise<void> {
+function applyCompanionOptions(argv: string[]): void {
+  applyCompanionStartupOptions({
+    argv,
+    env: process.env,
+    bots: loadBotsJson(),
+    // Validate without retaining or logging the value. The Dashboard performs
+    // the same fail-closed check before exposing any companion route.
+    validateSecret: loadCompanionSecret,
+  });
+}
+
+async function cmdStart(argv: string[]): Promise<void> {
   // FIRST STATEMENT, before any await or dependency probe: those run as child
   // processes and would inherit the marker. See consumeAutostartUnitMarker.
   const bootHookStart = consumeAutostartUnitMarker();
+  applyCompanionOptions(argv);
   // `--systemd-service` and the PM2-God ownership gating that used to live here
   // are gone with pm2 itself: the built-in supervisor owns single-owner exclusion
   // via fleet-state (pid + kill-0 under the fleet mutation lock), so there is no
@@ -2512,6 +2526,9 @@ async function startConfiguredFleet(
       const { startFleetViaSupervisor } = await import('./core/fleet-runtime.js');
       const result = startFleetViaSupervisor();
       if (result.action === 'already-running') {
+        if (process.env.BOTMUX_COMPANION_SECRET_FILE || process.env.BOTMUX_COMPANION_BOT_APP_ID) {
+          throw new Error('fleet is already running; use `botmux restart` to apply companion options');
+        }
         console.log(`\n✅ fleet 已在运行 (supervisor pid ${result.supervisorPid}, ${result.botCount} 个机器人)`);
       }
     }, { maxWaitMs: 5_000 });
@@ -2633,7 +2650,8 @@ interface RestartLifecycleFlags {
 }
 
 
-async function cmdRestart(): Promise<void> {
+async function cmdRestart(argv: string[]): Promise<void> {
+  applyCompanionOptions(argv);
   const { refreshPersistedEnv, readFailureFallback } = prepareRestartDriverContext();
   if (!hasConfig()) {
     console.error('❌ 未找到配置文件');
@@ -6099,8 +6117,9 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   clone <机器人名> [--name <新名称>]
               创建新应用并复制该机器人的行为配置；留空名称自动使用 源名称-copy-时间戳
   start       启动 daemon，并启动 mode=auto 的插件 service
+              可用 --companion-secret-file <绝对路径> --companion-bot <appId> 开启封闭本机 Companion API
   stop        停止 daemon（默认不停止插件 service；--with-plugin 显式停止 mode=auto 的插件 service）
-  restart     重启 daemon（默认不停止插件 service，core 启动后确保 mode=auto 正在运行；--with-plugin 显式先停再启动 auto service）
+  restart     重启 daemon（同样接受 --companion-secret-file / --companion-bot；--with-plugin 显式先停再启动 auto service）
   logs        查看/跟随 daemon 日志（--lines N, --bot <0-based-index|name|appId>, --no-follow 只打印不跟随）
   status      查看 daemon 状态
   upgrade     升级到最新版本（别名：update）
@@ -7314,6 +7333,8 @@ import {
 } from './bot-registry.js';
 import { resolvePricingConfig, type ResolvedModelPricing } from './services/model-pricing.js';
 import { config } from './config.js';
+import { loadCompanionSecret } from './dashboard/companion-api.js';
+import { applyCompanionStartupOptions } from './cli/companion-startup-options.js';
 import { getSessionUsageSnapshot } from './core/cost-calculator.js';
 import {
   resolveQuoteTarget,
@@ -14289,12 +14310,12 @@ switch (command) {
     break;
   }
   case 'clone': await cmdClone(process.argv.slice(3)); break;
-  case 'start':   await cmdStart(); break;
+  case 'start':   await cmdStart(process.argv.slice(3)); break;
   case 'serve':   await cmdServe(process.argv.slice(3)); break;
   case 'start-bot': await cmdStartBot(process.argv.slice(3)); break;
   case 'stop-bot': await cmdStopBot(process.argv.slice(3)); break;
   case 'stop':    await cmdStop(); break;
-  case 'restart': await cmdRestart(); break;
+  case 'restart': await cmdRestart(process.argv.slice(3)); break;
   case 'logs':    await cmdLogs(); break;
   case 'status':  await cmdStatus(); break;
   case 'upgrade':

--- a/src/cli/companion-startup-options.ts
+++ b/src/cli/companion-startup-options.ts
@@ -1,0 +1,39 @@
+import {
+  COMPANION_BOT_APP_ID_ENV,
+  COMPANION_SECRET_FILE_ENV,
+} from '../config.js';
+
+export interface CompanionStartupBot {
+  larkAppId?: string;
+  sandbox?: boolean;
+  cliId?: string;
+}
+
+export function applyCompanionStartupOptions(input: {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  bots: readonly CompanionStartupBot[];
+  validateSecret: (path: string) => unknown;
+}): void {
+  let secretFile = input.env[COMPANION_SECRET_FILE_ENV]?.trim();
+  let botAppId = input.env[COMPANION_BOT_APP_ID_ENV]?.trim();
+  for (let i = 0; i < input.argv.length; i += 1) {
+    const arg = input.argv[i];
+    if (arg === '--companion-secret-file') secretFile = input.argv[++i]?.trim();
+    else if (arg.startsWith('--companion-secret-file=')) secretFile = arg.slice(arg.indexOf('=') + 1).trim();
+    else if (arg === '--companion-bot') botAppId = input.argv[++i]?.trim();
+    else if (arg.startsWith('--companion-bot=')) botAppId = arg.slice(arg.indexOf('=') + 1).trim();
+  }
+  if (!secretFile && !botAppId) return;
+  if (!secretFile || !botAppId) {
+    throw new Error('companion options require both --companion-secret-file and --companion-bot');
+  }
+  input.validateSecret(secretFile);
+  const matches = input.bots.filter(bot => bot.larkAppId === botAppId);
+  if (matches.length !== 1 || matches[0].sandbox !== true
+    || (matches[0].cliId !== 'codex' && matches[0].cliId !== 'traex')) {
+    throw new Error('companion bot must identify exactly one sandboxed codex/traex bot');
+  }
+  input.env[COMPANION_SECRET_FILE_ENV] = secretFile;
+  input.env[COMPANION_BOT_APP_ID_ENV] = botAppId;
+}

--- a/src/cli/daemon-lifecycle-env.ts
+++ b/src/cli/daemon-lifecycle-env.ts
@@ -34,6 +34,11 @@ export const DAEMON_ENV_KEYS = [
   'BOTMUX_DASHBOARD_PORT',
   'BOTMUX_DAEMON_IPC_BASE_PORT',
   'BOTMUX_DASHBOARD_PUBLIC_READONLY',
+  // Closed local companion control surface. The values are lifecycle settings:
+  // start/restart flags override them in inherited env; ~/.botmux/.env keeps
+  // them across boot-time starts. Session CLI boundaries redact both keys.
+  'BOTMUX_COMPANION_SECRET_FILE',
+  'BOTMUX_COMPANION_BOT_APP_ID',
   // Self-hosted reverse-proxy base for terminal/dashboard links
   // (publicReverseProxyBaseUrl). Left out of this list it only survived as
   // long as every restart came from a shell that exported it — one restart

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,6 +114,22 @@ export interface HerdrTraexPluginRuntimeConfig {
   ref: string;
 }
 
+/** Startup-only handoff for a local companion process.
+ *
+ * This is deliberately a path, not a secret value: Botmux does not read,
+ * validate, log, or fall back to the Dashboard/internal HMAC secret. */
+export interface CompanionStartupConfig {
+  secretFile: string | undefined;
+}
+
+/** The sole supported private secret-file configuration input. */
+export const COMPANION_SECRET_FILE_ENV = 'BOTMUX_COMPANION_SECRET_FILE';
+
+/** Resolve the fixed scoped startup handoff without touching the secret file. */
+export function resolveCompanionStartupConfig(env: NodeJS.ProcessEnv = process.env): CompanionStartupConfig {
+  return { secretFile: nonBlankHost(env[COMPANION_SECRET_FILE_ENV]) };
+}
+
 /**
  * Current-chat bot discovery via Lark `/members/bots`.
  *
@@ -274,6 +290,10 @@ export const config = {
      *  要回到 env 控制需删掉 config.json 里的 dashboard.publicReadOnly）. */
     publicReadOnly: (process.env.BOTMUX_DASHBOARD_PUBLIC_READONLY ?? 'true').toLowerCase() !== 'false',
   },
+  // A local companion process consumes this typed handoff. Keep it separate
+  // from dashboard/daemon HMAC configuration: there is intentionally no
+  // default path and therefore no credential reuse.
+  companion: resolveCompanionStartupConfig(),
   stuckDetector: {
     /**
      * Lightweight, AI-free fallback that warns the user when a written input

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,18 +116,24 @@ export interface HerdrTraexPluginRuntimeConfig {
 
 /** Startup-only handoff for a local companion process.
  *
- * This is deliberately a path, not a secret value: Botmux does not read,
- * validate, log, or fall back to the Dashboard/internal HMAC secret. */
+ * This is deliberately a path, not a secret value: this resolver performs no
+ * file IO. The startup boundary validates/loads the dedicated file and never
+ * logs or falls back to the Dashboard/internal HMAC secret. */
 export interface CompanionStartupConfig {
   secretFile: string | undefined;
+  botAppId: string | undefined;
 }
 
 /** The sole supported private secret-file configuration input. */
 export const COMPANION_SECRET_FILE_ENV = 'BOTMUX_COMPANION_SECRET_FILE';
+export const COMPANION_BOT_APP_ID_ENV = 'BOTMUX_COMPANION_BOT_APP_ID';
 
 /** Resolve the fixed scoped startup handoff without touching the secret file. */
 export function resolveCompanionStartupConfig(env: NodeJS.ProcessEnv = process.env): CompanionStartupConfig {
-  return { secretFile: nonBlankHost(env[COMPANION_SECRET_FILE_ENV]) };
+  return {
+    secretFile: nonBlankHost(env[COMPANION_SECRET_FILE_ENV]),
+    botAppId: nonBlankHost(env[COMPANION_BOT_APP_ID_ENV]),
+  };
 }
 
 /**

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -15,6 +15,15 @@ import { isStandaloneBinary } from './core/self-spawn.js';
 import { currentUpdateStrategy, replaceStandaloneBinary } from './core/binary-self-update.js';
 import { gracefulProcessExitCode } from './pm2-graceful-exit.js';
 import { config, isWildcardBindHost } from './config.js';
+import { createCompanionApi, loadCompanionSecret, type CompanionRuntime } from './dashboard/companion-api.js';
+import {
+  deleteTeamRoleFile,
+  readTeamRoleInjectMode,
+  resolveTeamRoleFile,
+  writeTeamRoleFile,
+  writeTeamRoleInjectMode,
+} from './core/role-resolver.js';
+import { readBotsJsonOrEmpty } from './setup/bots-store.js';
 import { listenWithProbe } from './utils/listen-with-probe.js';
 import {
   parseCookie, buildSetCookie, verifyHmac, cliAuthBind,
@@ -3405,9 +3414,75 @@ function analyticsService(): FeedbackAnalyticsService {
   return feedbackAnalyticsService ??= new FeedbackAnalyticsService(config.session.dataDir);
 }
 
+const companionApi = (() => {
+  const secretFile = config.companion.secretFile;
+  const appId = config.companion.botAppId;
+  if (!secretFile && !appId) return null;
+  if (!secretFile || !appId) throw new Error('companion_configuration_incomplete');
+  const requireBoundBot = () => {
+    const bot = readBotsJsonOrEmpty(BOTS_JSON_PATH).find((entry) => entry?.larkAppId === appId);
+    if (!bot || bot.sandbox !== true || (bot.cliId !== 'codex' && bot.cliId !== 'traex')) {
+      throw new Error('companion_bound_bot_invalid');
+    }
+    return bot;
+  };
+  requireBoundBot();
+  const readRuntime = (): CompanionRuntime => {
+    const bound = requireBoundBot();
+    return {
+      provider: bound.cliId === 'traex' ? 'traecli' : 'codex',
+      ...(typeof bound.model === 'string' && bound.model.trim() ? { model: bound.model.trim() } : {}),
+      ...(typeof bound.reasoningEffort === 'string' && bound.reasoningEffort ? { reasoning: bound.reasoningEffort } : {}),
+    };
+  };
+  return createCompanionApi({
+    secret: loadCompanionSecret(secretFile),
+    operations: {
+      readRole: () => {
+        requireBoundBot();
+        return { role: resolveTeamRoleFile(appId) ?? '', injectMode: readTeamRoleInjectMode(appId), revision: null };
+      },
+      writeRole: ({ role, injectMode }) => {
+        requireBoundBot();
+        if (role.trim()) writeTeamRoleFile(appId, role);
+        else deleteTeamRoleFile(appId);
+        writeTeamRoleInjectMode(appId, injectMode);
+        return { role: resolveTeamRoleFile(appId) ?? '', injectMode: readTeamRoleInjectMode(appId), revision: null };
+      },
+      readRuntime,
+      writeRuntime: async (runtime) => {
+        requireBoundBot();
+        const upstream = await proxyToDaemon(appId, '/api/bot-agent', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            cliId: runtime.provider === 'traecli' ? 'traex' : 'codex',
+            model: runtime.model ?? '',
+            reasoningEffort: runtime.reasoning ?? '',
+          }),
+        });
+        if (!upstream.ok) throw new Error('companion_runtime_update_failed');
+        const body = await upstream.json() as Record<string, unknown>;
+        return {
+          provider: body.cliId === 'traex' ? 'traecli' : 'codex',
+          ...(typeof body.model === 'string' && body.model ? { model: body.model } : {}),
+          ...(typeof body.reasoningEffort === 'string' && body.reasoningEffort ? { reasoning: body.reasoningEffort } : {}),
+        };
+      },
+    },
+  });
+})();
+
 const server = createServer(async (req, res) => {
   try {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+
+    // Closed companion surface: it buffers bodies only for this exact prefix,
+    // before the ordinary Dashboard auth/router touches the request stream.
+    if (companionApi && await companionApi(req, res, url.search ? `${url.pathname}${url.search}` : url.pathname)) return;
+    if (!companionApi && url.pathname.startsWith('/__companion/')) {
+      return jsonRes(res, 404, { ok: false, error: 'companion_disabled' });
+    }
 
     // Health probe (no auth) — for pm2
     if (url.pathname === '/__health') {

--- a/src/dashboard/companion-api.ts
+++ b/src/dashboard/companion-api.ts
@@ -1,0 +1,203 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { isAbsolute } from 'node:path';
+import { lstatSync, realpathSync } from 'node:fs';
+import { readSecureHostFileSync } from '../platform/secure-host-file.js';
+import type { RoleInjectMode } from '../core/role-resolver.js';
+import { cliModelSupportsReasoningEffort, isCodexReasoningEffort } from '../services/codex-reasoning-effort.js';
+
+export const COMPANION_API_VERSION = 'botmux.companion.v1';
+export const COMPANION_BODY_LIMIT = 64 * 1024;
+export const COMPANION_MODEL_MAX_LENGTH = 200;
+export const COMPANION_OPERATION_TIMEOUT_MS = 10_000;
+const CLOCK_SKEW_MS = 60_000;
+const NONCE_TTL_MS = 10 * 60_000;
+const COMPANION_ROUTES: Readonly<Record<string, 'health' | 'role-read' | 'role-write' | 'runtime-read' | 'runtime-write'>> = Object.freeze({
+  'GET /__companion/v1/health': 'health',
+  'GET /__companion/v1/role': 'role-read',
+  'PUT /__companion/v1/role': 'role-write',
+  'GET /__companion/v1/runtime': 'runtime-read',
+  'PUT /__companion/v1/runtime': 'runtime-write',
+});
+
+export type CompanionProvider = 'codex' | 'traecli';
+export interface CompanionRole { role: string; injectMode: RoleInjectMode; revision: null }
+export interface CompanionRuntime { provider: CompanionProvider; model?: string; reasoning?: string }
+
+export interface CompanionOperations {
+  readRole(): CompanionRole | Promise<CompanionRole>;
+  writeRole(value: { role: string; injectMode: RoleInjectMode }): CompanionRole | Promise<CompanionRole>;
+  readRuntime(): CompanionRuntime | Promise<CompanionRuntime>;
+  writeRuntime(value: CompanionRuntime): CompanionRuntime | Promise<CompanionRuntime>;
+}
+
+export interface CompanionApiConfig {
+  secret: string;
+  operations: CompanionOperations;
+  now?: () => number;
+}
+
+export function loadCompanionSecret(path: string): string {
+  try {
+    if (!isAbsolute(path)) throw new Error();
+    const leaf = lstatSync(path);
+    if (leaf.isSymbolicLink() || !leaf.isFile() || realpathSync(path) !== path) throw new Error();
+    const secret = readSecureHostFileSync(path, 1024)?.trim();
+    if (!secret) throw new Error();
+    return secret;
+  } catch {
+    // Stable error only: never include the credential path or file metadata.
+    throw new Error('companion_secret_invalid');
+  }
+}
+
+export function companionSignature(secret: string, input: {
+  timestamp: string; nonce: string; method: string; pathname: string; bodyRaw: string;
+}): string {
+  const bodyHash = createHash('sha256').update(input.bodyRaw).digest('hex');
+  return createHmac('sha256', secret).update([
+    input.timestamp, input.nonce, input.method.toUpperCase(), input.pathname, bodyHash,
+  ].join('\n')).digest('base64url');
+}
+
+export function isCompanionLoopback(remote: string | undefined): boolean {
+  return remote === '127.0.0.1' || remote === '::1' || !!remote?.endsWith('::ffff:127.0.0.1');
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' });
+  res.end(JSON.stringify(body));
+}
+
+async function body(req: IncomingMessage): Promise<string | null> {
+  let size = 0;
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += value.length;
+    if (size > COMPANION_BODY_LIMIT) return null;
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  return Object.keys(value).every(key => allowed.includes(key));
+}
+
+function parseObject(raw: string): Record<string, unknown> | null {
+  try {
+    const value = raw ? JSON.parse(raw) : {};
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+  } catch { return null; }
+}
+
+function validRequestId(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Za-z0-9_-]{8,128}$/.test(value);
+}
+
+async function bounded<T>(operation: () => T | Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve().then(operation),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('timeout')), COMPANION_OPERATION_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export function createCompanionApi(config: CompanionApiConfig) {
+  const now = config.now ?? Date.now;
+  const nonces = new Map<string, number>();
+  const writes = new Map<string, Promise<{ status: number; value: unknown }>>();
+
+  return async function handle(req: IncomingMessage, res: ServerResponse, pathname: string): Promise<boolean> {
+    if (!pathname.startsWith('/__companion/')) return false;
+    if (!isCompanionLoopback(req.socket?.remoteAddress)) { json(res, 403, { ok: false, error: 'forbidden' }); return true; }
+    const operation = COMPANION_ROUTES[`${req.method ?? 'GET'} ${pathname}`];
+    if (!operation) { json(res, 404, { ok: false, error: 'unknown_endpoint' }); return true; }
+
+    const raw = await body(req);
+    if (raw === null) { json(res, 413, { ok: false, error: 'body_too_large' }); return true; }
+    const timestamp = typeof req.headers['x-botmux-companion-timestamp'] === 'string' ? req.headers['x-botmux-companion-timestamp'] : '';
+    const nonce = typeof req.headers['x-botmux-companion-nonce'] === 'string' ? req.headers['x-botmux-companion-nonce'] : '';
+    const signature = typeof req.headers['x-botmux-companion-signature'] === 'string' ? req.headers['x-botmux-companion-signature'] : '';
+    const timestampMs = Number(timestamp);
+    if (!timestamp || !nonce || !signature || !Number.isSafeInteger(timestampMs) || Math.abs(now() - timestampMs) > CLOCK_SKEW_MS) {
+      json(res, 401, { ok: false, error: 'unauthorized' }); return true;
+    }
+    for (const [key, expiry] of nonces) if (expiry <= now()) nonces.delete(key);
+    if (nonces.has(nonce)) { json(res, 409, { ok: false, error: 'replayed' }); return true; }
+    const expected = companionSignature(config.secret, { timestamp, nonce, method: req.method ?? 'GET', pathname, bodyRaw: raw });
+    const got = Buffer.from(signature, 'base64url');
+    const want = Buffer.from(expected, 'base64url');
+    if (got.length !== want.length || !timingSafeEqual(got, want)) {
+      json(res, 401, { ok: false, error: 'unauthorized' }); return true;
+    }
+    nonces.set(nonce, now() + NONCE_TTL_MS);
+
+    if (operation === 'health') {
+      json(res, 200, { ok: true, version: COMPANION_API_VERSION, capabilities: ['role.read', 'role.write', 'runtime.read', 'runtime.write'] });
+      return true;
+    }
+    try {
+      if (operation === 'role-read') { json(res, 200, { ok: true, value: await bounded(config.operations.readRole) }); return true; }
+      if (operation === 'runtime-read') { json(res, 200, { ok: true, value: await bounded(config.operations.readRuntime) }); return true; }
+    } catch (error) {
+      json(res, 500, { ok: false, error: error instanceof Error && error.message === 'timeout' ? 'timeout' : 'operation_failed' });
+      return true;
+    }
+
+    const parsed = parseObject(raw);
+    if (!parsed || !validRequestId(parsed.requestId)) { json(res, 400, { ok: false, error: 'invalid_body' }); return true; }
+
+    let execute: () => Promise<unknown>;
+    if (operation === 'role-write') {
+      if (!exactKeys(parsed, ['requestId', 'role', 'injectMode']) || typeof parsed.role !== 'string'
+        || Buffer.byteLength(parsed.role, 'utf8') > 32 * 1024
+        || (parsed.injectMode !== 'every' && parsed.injectMode !== 'once')) {
+        json(res, 400, { ok: false, error: 'invalid_body' }); return true;
+      }
+      const role = parsed.role;
+      const injectMode = parsed.injectMode;
+      execute = () => bounded(() => config.operations.writeRole({ role, injectMode }));
+    } else {
+      if (!exactKeys(parsed, ['requestId', 'provider', 'model', 'reasoning'])
+        || (parsed.provider !== 'codex' && parsed.provider !== 'traecli')) {
+        json(res, 400, { ok: false, error: 'invalid_body' }); return true;
+      }
+      const provider: CompanionProvider = parsed.provider;
+      const model = parsed.model === undefined ? undefined : typeof parsed.model === 'string' ? parsed.model.trim() : null;
+      const cliId = provider === 'codex' ? 'codex' : 'traex';
+      if (model === null || (model && model.length > COMPANION_MODEL_MAX_LENGTH)
+        || (parsed.reasoning !== undefined && (!isCodexReasoningEffort(parsed.reasoning)
+          || !cliModelSupportsReasoningEffort(cliId, model || undefined, parsed.reasoning)))) {
+        json(res, 400, { ok: false, error: 'invalid_body' }); return true;
+      }
+      const reasoning = typeof parsed.reasoning === 'string' ? parsed.reasoning : undefined;
+      execute = () => bounded(() => config.operations.writeRuntime({
+        provider,
+        ...(model ? { model } : {}),
+        ...(reasoning ? { reasoning } : {}),
+      }));
+    }
+
+    const idempotencyKey = `${operation}:${parsed.requestId}`;
+    let pending = writes.get(idempotencyKey);
+    if (!pending) {
+      pending = execute().then(
+        value => ({ status: 200, value: { ok: true, requestId: parsed.requestId, value } }),
+        error => ({ status: 500, value: { ok: false, error: error instanceof Error && error.message === 'timeout' ? 'timeout' : 'operation_failed' } }),
+      );
+      // Store before awaiting: concurrent retries share the same side effect.
+      writes.set(idempotencyKey, pending);
+    }
+    const result = await pending;
+    json(res, result.status, result.value);
+    return true;
+  };
+}

--- a/src/index-daemon.ts
+++ b/src/index-daemon.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { existsSync } from 'node:fs';
 import { installStdioEpipeGuard } from './utils/stdio-epipe-guard.js';
-import { scrubClaudeSessionMarkerEnv, scrubInvokerTerminalEnv, scrubSessionCliHomeEnv, scrubSessionTurnMarkerEnv, scrubWorkflowWorkerEnv, stripDashboardH5Env } from './utils/child-env.js';
+import { scrubClaudeSessionMarkerEnv, scrubInvokerTerminalEnv, scrubSessionCliHomeEnv, scrubSessionTurnMarkerEnv, scrubWorkflowWorkerEnv, stripCompanionStartupEnv, stripDashboardH5Env } from './utils/child-env.js';
 
 // Under pm2 the daemon's stdout/stderr are pipes to the God daemon. A broken
 // pipe (log streaming detaches, God daemon restart) would otherwise emit an
@@ -26,6 +26,10 @@ dotenvConfig({ path: existsSync(globalEnv) ? globalEnv : '.env' });
 // redactChildEnv()/tmux-pane-unset strip at every CLI-child boundary stays in
 // place as the second layer of defense.
 stripDashboardH5Env(process.env);
+// The closed companion API is served only by the dashboard fleet member. Bot
+// daemons must not retain its credential path or bound-bot authority, and
+// workers inherit from this process, so remove both before daemon code loads.
+stripCompanionStartupEnv(process.env);
 
 // A daemon is never a session. pm2 startOrRestart injects the caller's
 // environment into restarted apps, so a `botmux restart` issued from inside a

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -213,6 +213,10 @@ export const REDACTED_CHILD_ENV_KEYS = [
   'LARK_APP_SECRET',
   'GITHUB_TOKEN',
   'GH_TOKEN',
+  // Startup-only private secret-file path. A session CLI is not the local
+  // companion process and must not learn even the credential's location.
+  // Kept as a literal because this boundary module is dependency-free.
+  'BOTMUX_COMPANION_SECRET_FILE',
   // Dashboard-only Feishu H5 login config/credential family — see
   // DASHBOARD_H5_ENV_KEYS. Listed by exact name (not only swept by prefix in
   // redactChildEnv) so the tmux pane wrapper `unset`s them too: on that backend

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -208,6 +208,16 @@ export function scrubInvokerTerminalEnv(env: NodeJS.ProcessEnv): void {
  *    client env can't override, so the shell wrapper `unset`s them before exec
  *    (see SHELL_WRAPPER_SCRIPT in tmux-backend.ts).
  */
+export const COMPANION_STARTUP_ENV_KEYS = [
+  'BOTMUX_COMPANION_SECRET_FILE',
+  'BOTMUX_COMPANION_BOT_APP_ID',
+] as const;
+
+/** Remove companion authority from processes that never serve its API. */
+export function stripCompanionStartupEnv(env: NodeJS.ProcessEnv): void {
+  for (const key of COMPANION_STARTUP_ENV_KEYS) delete env[key];
+}
+
 export const REDACTED_CHILD_ENV_KEYS = [
   'LARK_APP_ID',
   'LARK_APP_SECRET',
@@ -216,7 +226,7 @@ export const REDACTED_CHILD_ENV_KEYS = [
   // Startup-only private secret-file path. A session CLI is not the local
   // companion process and must not learn even the credential's location.
   // Kept as a literal because this boundary module is dependency-free.
-  'BOTMUX_COMPANION_SECRET_FILE',
+  ...COMPANION_STARTUP_ENV_KEYS,
   // Dashboard-only Feishu H5 login config/credential family — see
   // DASHBOARD_H5_ENV_KEYS. Listed by exact name (not only swept by prefix in
   // redactChildEnv) so the tmux pane wrapper `unset`s them too: on that backend

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../src/utils/child-env.js';
 import { pm2CallerEnv } from '../src/cli/pm2-env.js';
 import { PM2_GRACEFUL_EXIT_CODE_ENV } from '../src/pm2-graceful-exit.js';
+import { COMPANION_SECRET_FILE_ENV } from '../src/config.js';
 import { GOAL_ENV } from '../src/workflows/v3/contract.js';
 
 describe('applySessionOwnerEnv()', () => {
@@ -88,6 +89,13 @@ describe('redactChildEnv()', () => {
     }
     // Behavior knob, not an identity marker — must survive.
     expect(out.CLAUDE_EFFORT).toBe('high');
+    expect(out.KEEP).toBe('v');
+  });
+
+  it('removes the companion secret-file path from child env', () => {
+    const out = redactChildEnv({ [COMPANION_SECRET_FILE_ENV]: '/run/secrets/botmux/companion', KEEP: 'v' });
+    expect(COMPANION_SECRET_FILE_ENV in out).toBe(false);
+    expect(REDACTED_CHILD_ENV_KEYS).toContain(COMPANION_SECRET_FILE_ENV);
     expect(out.KEEP).toBe('v');
   });
 

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -6,6 +6,7 @@ import {
   BOTMUX_INJECTED_ENV_KEYS,
   CA_BUNDLE_ENV_KEYS,
   CLAUDE_SESSION_MARKER_ENV_KEYS,
+  COMPANION_STARTUP_ENV_KEYS,
   DASHBOARD_H5_ENV_KEYS,
   DASHBOARD_H5_ENV_PREFIX,
   INVOKER_TERMINAL_ENV_KEYS,
@@ -19,12 +20,13 @@ import {
   scrubWorkflowWorkerEnv,
   SESSION_CLI_HOME_ENV_KEYS,
   SESSION_TURN_MARKER_ENV_KEYS,
+  stripCompanionStartupEnv,
   stripDashboardH5Env,
   WORKFLOW_WORKER_ENV_KEYS,
 } from '../src/utils/child-env.js';
 import { pm2CallerEnv } from '../src/cli/pm2-env.js';
 import { PM2_GRACEFUL_EXIT_CODE_ENV } from '../src/pm2-graceful-exit.js';
-import { COMPANION_SECRET_FILE_ENV } from '../src/config.js';
+import { COMPANION_BOT_APP_ID_ENV, COMPANION_SECRET_FILE_ENV } from '../src/config.js';
 import { GOAL_ENV } from '../src/workflows/v3/contract.js';
 
 describe('applySessionOwnerEnv()', () => {
@@ -92,10 +94,24 @@ describe('redactChildEnv()', () => {
     expect(out.KEEP).toBe('v');
   });
 
+  it('removes companion authority from non-serving process environments', () => {
+    const env = Object.fromEntries(COMPANION_STARTUP_ENV_KEYS.map(key => [key, 'private']));
+    stripCompanionStartupEnv(env);
+    for (const key of COMPANION_STARTUP_ENV_KEYS) expect(key in env, key).toBe(false);
+    const daemonEntry = readFileSync(new URL('../src/index-daemon.ts', import.meta.url), 'utf-8');
+    expect(daemonEntry).toContain('stripCompanionStartupEnv(process.env)');
+  });
+
   it('removes the companion secret-file path from child env', () => {
-    const out = redactChildEnv({ [COMPANION_SECRET_FILE_ENV]: '/run/secrets/botmux/companion', KEEP: 'v' });
+    const out = redactChildEnv({
+      [COMPANION_SECRET_FILE_ENV]: '/run/secrets/botmux/companion',
+      [COMPANION_BOT_APP_ID_ENV]: 'local_test_bot',
+      KEEP: 'v',
+    });
     expect(COMPANION_SECRET_FILE_ENV in out).toBe(false);
+    expect(COMPANION_BOT_APP_ID_ENV in out).toBe(false);
     expect(REDACTED_CHILD_ENV_KEYS).toContain(COMPANION_SECRET_FILE_ENV);
+    expect(REDACTED_CHILD_ENV_KEYS).toContain(COMPANION_BOT_APP_ID_ENV);
     expect(out.KEEP).toBe('v');
   });
 

--- a/test/companion-api.test.ts
+++ b/test/companion-api.test.ts
@@ -1,0 +1,141 @@
+import { createServer } from 'node:http';
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  companionSignature,
+  createCompanionApi,
+  isCompanionLoopback,
+  loadCompanionSecret,
+  type CompanionRole,
+  type CompanionRuntime,
+} from '../src/dashboard/companion-api.js';
+
+const dirs: string[] = [];
+afterEach(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+function fixture() {
+  let role: CompanionRole = { role: 'reviewer', injectMode: 'every', revision: null };
+  let runtime: CompanionRuntime = { provider: 'codex', model: 'gpt-5.6-sol', reasoning: 'high' };
+  const calls = { roleWrites: 0, runtimeWrites: 0 };
+  const secret = 'companion-test-secret';
+  const api = createCompanionApi({ secret, operations: {
+    readRole: () => role,
+    writeRole: value => { calls.roleWrites += 1; return role = { ...value, role: value.role.trim(), revision: null }; },
+    readRuntime: () => runtime,
+    writeRuntime: value => { calls.runtimeWrites += 1; return runtime = value; },
+  } });
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const target = url.search ? `${url.pathname}${url.search}` : url.pathname;
+    if (!await api(req, res, target)) { res.statusCode = 404; res.end(); }
+  });
+  return { secret, server, calls };
+}
+
+async function request(port: number, secret: string, method: string, pathname: string, bodyRaw = '', nonce = Math.random().toString(36).slice(2), timestamp = String(Date.now())) {
+  const signature = companionSignature(secret, { timestamp, nonce, method, pathname, bodyRaw });
+  return fetch(`http://127.0.0.1:${port}${pathname}`, { method, body: bodyRaw || undefined, headers: {
+    'content-type': 'application/json',
+    'x-botmux-companion-timestamp': timestamp,
+    'x-botmux-companion-nonce': nonce,
+    'x-botmux-companion-signature': signature,
+  } });
+}
+
+async function listening<T>(run: (port: number, secret: string, calls: { roleWrites: number; runtimeWrites: number }) => Promise<T>): Promise<T> {
+  const f = fixture();
+  await new Promise<void>(resolve => f.server.listen(0, '127.0.0.1', resolve));
+  const port = (f.server.address() as { port: number }).port;
+  try { return await run(port, f.secret, f.calls); } finally { await new Promise<void>(resolve => f.server.close(() => resolve())); }
+}
+
+describe('closed companion API', () => {
+  it('accepts only loopback peer addresses', () => {
+    expect(isCompanionLoopback('127.0.0.1')).toBe(true);
+    expect(isCompanionLoopback('::1')).toBe(true);
+    expect(isCompanionLoopback('::ffff:127.0.0.1')).toBe(true);
+    expect(isCompanionLoopback('10.0.0.1')).toBe(false);
+    expect(isCompanionLoopback(undefined)).toBe(false);
+  });
+
+  it('returns only versioned capabilities from authenticated health', () => listening(async (port, secret) => {
+    const response = await request(port, secret, 'GET', '/__companion/v1/health');
+    expect(await response.json()).toEqual({ ok: true, version: 'botmux.companion.v1', capabilities: ['role.read', 'role.write', 'runtime.read', 'runtime.write'] });
+  }));
+
+  it('returns bounded team role text and sanitized write readback without identifiers', () => listening(async (port, secret) => {
+    const read = await request(port, secret, 'GET', '/__companion/v1/role');
+    expect(await read.json()).toEqual({ ok: true, value: { role: 'reviewer', injectMode: 'every', revision: null } });
+    const raw = JSON.stringify({ requestId: 'request_123', role: '  builder  ', injectMode: 'once' });
+    const write = await request(port, secret, 'PUT', '/__companion/v1/role', raw);
+    expect(await write.json()).toEqual({ ok: true, requestId: 'request_123', value: { role: 'builder', injectMode: 'once', revision: null } });
+  }));
+
+  it('deduplicates concurrent writes by requestId before performing the side effect', () => listening(async (port, secret, calls) => {
+    const raw = JSON.stringify({ requestId: 'same_request', role: 'builder', injectMode: 'once' });
+    const responses = await Promise.all([
+      request(port, secret, 'PUT', '/__companion/v1/role', raw),
+      request(port, secret, 'PUT', '/__companion/v1/role', raw),
+    ]);
+    expect(responses.map(response => response.status)).toEqual([200, 200]);
+    expect(calls.roleWrites).toBe(1);
+  }));
+
+  it('enforces the runtime allowlist and provider-specific reasoning', () => listening(async (port, secret) => {
+    const valid = JSON.stringify({ requestId: 'runtime_123', provider: 'traecli', model: 'DeepSeek-V4-Pro', reasoning: 'high' });
+    expect((await request(port, secret, 'PUT', '/__companion/v1/runtime', valid)).status).toBe(200);
+    const invalid = JSON.stringify({ requestId: 'runtime_456', provider: 'traecli', model: 'DeepSeek-V4-Pro', reasoning: 'xhigh' });
+    expect((await request(port, secret, 'PUT', '/__companion/v1/runtime', invalid)).status).toBe(400);
+  }));
+
+  it('rejects stale timestamps, replay, and signatures bound to a different body/path', () => listening(async (port, secret) => {
+    expect((await request(port, secret, 'GET', '/__companion/v1/role', '', 'stale_nonce', String(Date.now() - 61_000))).status).toBe(401);
+    const nonce = 'one_time_nonce';
+    expect((await request(port, secret, 'GET', '/__companion/v1/role', '', nonce)).status).toBe(200);
+    expect((await request(port, secret, 'GET', '/__companion/v1/role', '', nonce)).status).toBe(409);
+    expect((await request(port, 'wrong-secret', 'GET', '/__companion/v1/role')).status).toBe(401);
+
+    const timestamp = String(Date.now());
+    const bodyRaw = JSON.stringify({ requestId: 'request_789', role: 'x', injectMode: 'once' });
+    const signature = companionSignature(secret, { timestamp, nonce: 'bound_nonce', method: 'PUT', pathname: '/__companion/v1/runtime', bodyRaw });
+    const mismatch = await fetch(`http://127.0.0.1:${port}/__companion/v1/role`, { method: 'PUT', body: bodyRaw, headers: {
+      'x-botmux-companion-timestamp': timestamp,
+      'x-botmux-companion-nonce': 'bound_nonce',
+      'x-botmux-companion-signature': signature,
+    } });
+    expect(mismatch.status).toBe(401);
+  }));
+
+  it('rejects bodies above the fixed limit before parsing or operation', () => listening(async (port, secret) => {
+    const raw = 'x'.repeat(64 * 1024 + 1);
+    expect((await request(port, secret, 'PUT', '/__companion/v1/role', raw)).status).toBe(413);
+  }));
+
+  it('does not expose arbitrary dashboard routes or query variants through the companion prefix', () => listening(async (port, secret) => {
+    expect((await request(port, secret, 'GET', '/__companion/v1/settings')).status).toBe(404);
+    expect((await request(port, secret, 'GET', '/__companion/v1/health?scope=all')).status).toBe(404);
+  }));
+});
+
+describe('companion secret file validation', () => {
+  it('accepts only a canonical nonempty 0600 regular file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-companion-')); dirs.push(dir); chmodSync(dir, 0o700);
+    const path = join(dir, 'secret'); writeFileSync(path, ' dedicated-secret\n', { mode: 0o600 });
+    const canonical = realpathSync(path);
+    expect(loadCompanionSecret(canonical)).toBe('dedicated-secret');
+    chmodSync(path, 0o644);
+    expect(() => loadCompanionSecret(canonical)).toThrow('companion_secret_invalid');
+    chmodSync(path, 0o600); writeFileSync(path, ' \n');
+    expect(() => loadCompanionSecret(canonical)).toThrow('companion_secret_invalid');
+  });
+
+  it('rejects relative paths and symlink leaves', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-companion-')); dirs.push(dir); mkdirSync(join(dir, 'private'), { mode: 0o700 });
+    const target = join(dir, 'private', 'target'); const link = join(dir, 'private', 'link');
+    writeFileSync(target, 'secret', { mode: 0o600 }); symlinkSync(target, link);
+    expect(() => loadCompanionSecret('relative-secret')).toThrow('companion_secret_invalid');
+    expect(() => loadCompanionSecret(link)).toThrow('companion_secret_invalid');
+  });
+});

--- a/test/companion-startup-config.test.ts
+++ b/test/companion-startup-config.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  COMPANION_SECRET_FILE_ENV,
+  resolveCompanionStartupConfig,
+} from '../src/config.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('companion startup secret-file configuration', () => {
+  it('uses only the dedicated path environment variable and never reads a secret', () => {
+    const env = {
+      [COMPANION_SECRET_FILE_ENV]: ' /run/secrets/botmux/companion ',
+      BOTMUX_DASHBOARD_SECRET_FILE: '/run/secrets/botmux/dashboard',
+    };
+
+    expect(resolveCompanionStartupConfig(env)).toEqual({
+      secretFile: '/run/secrets/botmux/companion',
+    });
+  });
+
+  it('has no fallback when the dedicated path is absent or blank', () => {
+    expect(resolveCompanionStartupConfig({})).toEqual({ secretFile: undefined });
+    expect(resolveCompanionStartupConfig({ [COMPANION_SECRET_FILE_ENV]: ' \t\n' }))
+      .toEqual({ secretFile: undefined });
+  });
+
+  it('captures the dedicated path in the daemon startup config after dotenv loading', async () => {
+    vi.stubEnv(COMPANION_SECRET_FILE_ENV, '/run/secrets/botmux/companion');
+    vi.resetModules();
+
+    const { config } = await import('../src/config.js');
+    expect(config.companion).toEqual({ secretFile: '/run/secrets/botmux/companion' });
+  });
+});

--- a/test/companion-startup-config.test.ts
+++ b/test/companion-startup-config.test.ts
@@ -22,6 +22,12 @@ describe('companion startup secret-file configuration', () => {
     });
   });
 
+  it('ignores a foreign secret-file var when the dedicated one is unset', () => {
+    expect(resolveCompanionStartupConfig({
+      BOTMUX_DASHBOARD_SECRET_FILE: '/run/secrets/botmux/dashboard',
+    })).toEqual({ secretFile: undefined });
+  });
+
   it('has no fallback when the dedicated path is absent or blank', () => {
     expect(resolveCompanionStartupConfig({})).toEqual({ secretFile: undefined });
     expect(resolveCompanionStartupConfig({ [COMPANION_SECRET_FILE_ENV]: ' \t\n' }))

--- a/test/companion-startup-config.test.ts
+++ b/test/companion-startup-config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  COMPANION_BOT_APP_ID_ENV,
   COMPANION_SECRET_FILE_ENV,
   resolveCompanionStartupConfig,
 } from '../src/config.js';
@@ -14,31 +15,34 @@ describe('companion startup secret-file configuration', () => {
   it('uses only the dedicated path environment variable and never reads a secret', () => {
     const env = {
       [COMPANION_SECRET_FILE_ENV]: ' /run/secrets/botmux/companion ',
+      [COMPANION_BOT_APP_ID_ENV]: ' local_test_bot ',
       BOTMUX_DASHBOARD_SECRET_FILE: '/run/secrets/botmux/dashboard',
     };
 
     expect(resolveCompanionStartupConfig(env)).toEqual({
       secretFile: '/run/secrets/botmux/companion',
+      botAppId: 'local_test_bot',
     });
   });
 
   it('ignores a foreign secret-file var when the dedicated one is unset', () => {
     expect(resolveCompanionStartupConfig({
       BOTMUX_DASHBOARD_SECRET_FILE: '/run/secrets/botmux/dashboard',
-    })).toEqual({ secretFile: undefined });
+    })).toEqual({ secretFile: undefined, botAppId: undefined });
   });
 
   it('has no fallback when the dedicated path is absent or blank', () => {
-    expect(resolveCompanionStartupConfig({})).toEqual({ secretFile: undefined });
+    expect(resolveCompanionStartupConfig({})).toEqual({ secretFile: undefined, botAppId: undefined });
     expect(resolveCompanionStartupConfig({ [COMPANION_SECRET_FILE_ENV]: ' \t\n' }))
-      .toEqual({ secretFile: undefined });
+      .toEqual({ secretFile: undefined, botAppId: undefined });
   });
 
   it('captures the dedicated path in the daemon startup config after dotenv loading', async () => {
     vi.stubEnv(COMPANION_SECRET_FILE_ENV, '/run/secrets/botmux/companion');
+    vi.stubEnv(COMPANION_BOT_APP_ID_ENV, 'local_test_bot');
     vi.resetModules();
 
     const { config } = await import('../src/config.js');
-    expect(config.companion).toEqual({ secretFile: '/run/secrets/botmux/companion' });
+    expect(config.companion).toEqual({ secretFile: '/run/secrets/botmux/companion', botAppId: 'local_test_bot' });
   });
 });

--- a/test/companion-startup-options.test.ts
+++ b/test/companion-startup-options.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyCompanionStartupOptions } from '../src/cli/companion-startup-options.js';
+import { COMPANION_BOT_APP_ID_ENV, COMPANION_SECRET_FILE_ENV } from '../src/config.js';
+
+const BOT = { larkAppId: 'local_test_bot', sandbox: true, cliId: 'codex' };
+
+describe('companion start/restart options', () => {
+  it('requires both options, validates the secret, and pins one isolated bot', () => {
+    const env: NodeJS.ProcessEnv = {};
+    const validateSecret = vi.fn();
+    applyCompanionStartupOptions({
+      argv: ['--companion-secret-file', '/secure/companion', '--companion-bot=local_test_bot'],
+      env, bots: [BOT], validateSecret,
+    });
+    expect(validateSecret).toHaveBeenCalledWith('/secure/companion');
+    expect(env).toMatchObject({
+      [COMPANION_SECRET_FILE_ENV]: '/secure/companion',
+      [COMPANION_BOT_APP_ID_ENV]: 'local_test_bot',
+    });
+  });
+
+  it('rejects incomplete options and non-isolated, duplicate, or unsupported bots', () => {
+    const apply = (bots: typeof BOT[]) => () => applyCompanionStartupOptions({
+      argv: ['--companion-secret-file=/secure/companion', '--companion-bot', 'local_test_bot'],
+      env: {}, bots, validateSecret: () => {},
+    });
+    expect(() => applyCompanionStartupOptions({ argv: ['--companion-bot', 'local_test_bot'], env: {}, bots: [BOT], validateSecret: () => {} })).toThrow('require both');
+    expect(apply([{ ...BOT, sandbox: false }])).toThrow('exactly one sandboxed');
+    expect(apply([BOT, BOT])).toThrow('exactly one sandboxed');
+    expect(apply([{ ...BOT, cliId: 'claude-code' }])).toThrow('exactly one sandboxed');
+  });
+
+  it('preserves existing behavior when the capability is not configured', () => {
+    const env: NodeJS.ProcessEnv = { KEEP: 'yes' };
+    applyCompanionStartupOptions({ argv: [], env, bots: [], validateSecret: () => { throw new Error('must not run'); } });
+    expect(env).toEqual({ KEEP: 'yes' });
+  });
+});

--- a/test/daemon-lifecycle-env.test.ts
+++ b/test/daemon-lifecycle-env.test.ts
@@ -194,7 +194,7 @@ describe('resolveDaemonEnv()', () => {
   });
 });
 
-describe('DAEMON_ENV_KEYS carries only non-secret fleet settings', () => {
+describe('DAEMON_ENV_KEYS enforces fleet credential boundaries', () => {
   // `botmux-dashboard` is its own supervised member. Non-secret dashboard
   // settings reach it via the fleet env resolved from this list; the H5 family
   // (APP_SECRET included) deliberately does NOT — the dashboard entry point
@@ -241,6 +241,15 @@ describe('DAEMON_ENV_KEYS carries only non-secret fleet settings', () => {
       expect(leaked).toEqual([]);
       expect(JSON.stringify(resolved)).not.toContain('secret-from');
     }
+  });
+
+  it('carries the companion startup binding so only the dashboard member can consume it', () => {
+    const resolved = resolveDaemonEnv({}, [
+      'BOTMUX_COMPANION_SECRET_FILE=/run/secrets/botmux/companion',
+      'BOTMUX_COMPANION_BOT_APP_ID=local_test_bot',
+    ].join('\n'));
+    expect(resolved.BOTMUX_COMPANION_SECRET_FILE).toBe('/run/secrets/botmux/companion');
+    expect(resolved.BOTMUX_COMPANION_BOT_APP_ID).toBe('local_test_bot');
   });
 
   it('includes the audit-path and terminal-lease settings from .env.example', () => {


### PR DESCRIPTION
## 关联需求
- https://meego.larkoffice.com/6a7fe349b317253343c6e49d/story/detail/7373431324

## 改动
- 增加唯一启动配置 `BOTMUX_COMPANION_SECRET_FILE` 及类型化、受限接口 `config.companion.secretFile`。
- 仅保存经 trim 的非空路径；不读取、校验、记录文件内容，未配置时为 `undefined`。
- 不提供默认路径，绝不回退或复用 Dashboard/daemon 内部 HMAC 密钥；会话 CLI 环境也会移除该路径。
- 补充中英文环境变量文档和回归测试。

## 影响面
- 仅涉及 daemon 启动时读取的公共配置对象与 CLI 子进程环境脱敏；未修改 IM、CLI adapter、Pty/Tmux backend、话题/群会话或 Dashboard 路由。
- 现有部署未设置该变量时保持原有行为。本地 companion 进程可通过固定的 `config.companion.secretFile` 接口取得路径；密钥文件读取与安全校验仍由该进程负责。

## 验证
- `bunx vitest run --project unit test/companion-startup-config.test.ts test/child-env.test.ts`：55 passed。
- `git diff --check`：通过。
- 上一提交对应 CI 的 build、bun-test、bun-binary、bun-binary-musl 均通过；本次补测与英文文档提交已触发新的 CI。

未执行 daemon restart 或部署。