### PR TITLE
feat(dashboard): 支持中心平台的机器协管者——认 X-Botmux-Actor + 拆开 legacyAuthed

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -478,6 +478,7 @@ function dashboardRequestIdentity(req: IncomingMessage): DashboardRequestIdentit
     // there is no module-level mirror to compare against any more.
     activeToken: currentDashboardToken(),
     roleHeader: req.headers['x-botmux-role'],
+    actorHeader: req.headers['x-botmux-actor'],
     platformMachineId: readPlatformBinding()?.machineId ?? null,
     platformActorScope: platformDashboardActorScope,
     legacyAuthSessionId: legacyDashboardAuthSessionId,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -4186,6 +4186,8 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === 'GET' && url.pathname === '/api/autostart') {
+      // 开机自启是机器级**运营配置**，与 settings/schedules/groups 同档，
+      // 所以随 dashboard:manage 一起放开给协管者（刻意，不是漏改）。
       if (!authed) return jsonRes(res, 401, { ok: false, error: 'unauthorized' });
       res.setHeader('cache-control', 'no-store');
       return jsonRes(res, 200, { ok: true, state: await dashboardAutostart.getState() });
@@ -4324,7 +4326,10 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === 'POST' && url.pathname === '/api/update/run') {
-      if (!authed) return jsonRes(res, 401, { ok: false, error: 'unauthorized' });
+      // owner-only：这条会 git pull + 重建，等于改机器上实际运行的代码。协管者的
+      // `dashboard:manage` 只覆盖「运营配置」（settings/schedules/groups/autostart），
+      // 不含「改代码并重启」——那属于 debug shell 同一档的整机控制权。
+      if (!legacyAuthed) return jsonRes(res, 401, { ok: false, error: 'unauthorized' });
       // 本地 checkout：走 git pull --ff-only + bun run build（与 CLI cmdUpgradeLocalDev
       // 共用 local-dev-update 逻辑），而不是全局包管理器安装。重启仍走下方
       // /api/update/restart 的 lease/intent 路径。
@@ -4487,7 +4492,8 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === 'POST' && url.pathname === '/api/update/rollback') {
-      if (!authed) return jsonRes(res, 401, { ok: false, error: 'unauthorized' });
+      // owner-only，同 /api/update/run（回滚同样改运行中的代码）。
+      if (!legacyAuthed) return jsonRes(res, 401, { ok: false, error: 'unauthorized' });
       if (isLocalDevInstall()) return jsonRes(res, 400, { ok: false, error: 'local_dev_no_update' });
 
       let targetVersion = '';
@@ -4666,7 +4672,8 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === 'POST' && url.pathname === '/api/update/restart') {
-      if (!authed) return jsonRes(res, 401, { ok: false, error: 'unauthorized' });
+      // owner-only：重启会打断 owner 正在跑的所有会话。
+      if (!legacyAuthed) return jsonRes(res, 401, { ok: false, error: 'unauthorized' });
       if (updateInFlight) return jsonRes(res, 409, { ok: false, error: 'update_in_flight' });
       // (pm2 shutdown-capability preflight removed with the fleet pm2→supervisor
       // migration: the supervisor has no "bootstrap-shutdown-protocol" policy to

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -479,6 +479,7 @@ function dashboardRequestIdentity(req: IncomingMessage): DashboardRequestIdentit
     activeToken: currentDashboardToken(),
     roleHeader: req.headers['x-botmux-role'],
     actorHeader: req.headers['x-botmux-actor'],
+    scopesHeader: req.headers['x-botmux-scopes'],
     platformMachineId: readPlatformBinding()?.machineId ?? null,
     platformActorScope: platformDashboardActorScope,
     legacyAuthSessionId: legacyDashboardAuthSessionId,
@@ -3610,7 +3611,7 @@ const server = createServer(async (req, res) => {
     // Only the local legacy Dashboard cookie is management authority. Platform
     // identities — owner included — retain terminal/preview capability through
     // signed proxy grants, but cannot cross into host administration APIs.
-    const { legacyAuthed, workbenchOnlyIdentity, decision } = resolveDashboardRequestGate({
+    const { legacyAuthed, canManageHost, workbenchOnlyIdentity, decision } = resolveDashboardRequestGate({
       method: req.method ?? 'GET',
       pathname: url.pathname,
       hasTokenParam: url.searchParams.has('t'),
@@ -3619,11 +3620,17 @@ const server = createServer(async (req, res) => {
       activeToken,
       publicReadOnly,
     });
-    // `authed` is deliberately the local management capability, not merely a
-    // valid Workbench/platform identity. Privileged mutations and management
-    // reads (settings, schedules, groups) therefore cannot be widened by H5
-    // authentication.
-    const authed = legacyAuthed;
+    // `authed` is the HOST MANAGEMENT capability: the local management cookie, or
+    // a platform co-manager the platform granted `dashboard:manage`. It is still
+    // NOT "any valid Workbench/platform identity" — H5 authentication cannot widen
+    // it, and neither can a co-manager without that scope.
+    //
+    // Deliberately NOT the same thing as `legacyAuthed` any more. The three
+    // capabilities that hand over the whole host — debug shell, write-link
+    // (a stable token) and spawn-command (credential-bearing) — keep querying
+    // `legacyAuthed` directly, so a co-manager can help maintain settings /
+    // schedules / groups without being able to run arbitrary commands.
+    const authed = canManageHost;
     // The session board is the one surface where `!authed` must NOT mean
     // "anonymous". `/api/sessions` and `/events` are exactly the two paths
     // workbenchH5Capability grants as `workbench.view`, and the same identity

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -24,6 +24,7 @@ import {
 } from './dashboard/auth.js';
 import {
   isPlatformDashboardAuthSessionId,
+  platformAuthSessionsToRevoke,
   resolveDashboardIdentity,
   resolveDashboardRequestGate,
   type DashboardRequestIdentity,
@@ -525,14 +526,15 @@ function syncPlatformBindingRevocation(): void {
     // 所以反过来做：把四个注册表里在册的认证会话取并集，按本机 scope 筛出平台
     // 身份逐个吊销。取并集是因为一个会话可能只在其中一个表里有状态（例如只开了
     // SSE、还没拿写租约）。
-    const observed = new Set<string>([
-      ...terminalControl.authSessionIds(),
-      ...previewInteraction.authSessionIds(),
-      ...authSessionConnections.authSessionIds(),
-      ...controlCsrfTokens.authSessionIds(),
-    ]);
-    for (const authSessionId of observed) {
-      if (isPlatformDashboardAuthSessionId(authSessionId, scope)) endDashboardAuthSession(authSessionId);
+    // 实现抽在 request-identity 的 platformAuthSessionsToRevoke（纯函数），
+    // 这样测试能直接调生产实现，而不是各自复刻一份「四表并集 + 筛选」。
+    for (const authSessionId of platformAuthSessionsToRevoke(scope, [
+      terminalControl,
+      previewInteraction,
+      authSessionConnections,
+      controlCsrfTokens,
+    ])) {
+      endDashboardAuthSession(authSessionId);
     }
   }
   observedPlatformMachineId = current;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -23,6 +23,7 @@ import {
   loadDashboardSecret, loadOrCreateDashboardSecret, describeDashboardTokenError,
 } from './dashboard/auth.js';
 import {
+  isPlatformDashboardAuthSessionId,
   resolveDashboardIdentity,
   resolveDashboardRequestGate,
   type DashboardRequestIdentity,
@@ -454,10 +455,11 @@ function terminalAuthSessionLive(authSessionId: string): boolean {
   if (activeToken && authSessionId === legacyDashboardAuthSessionId(activeToken)) return true;
   const binding = readPlatformBinding();
   if (binding) {
-    const scope = platformDashboardActorScope(binding.machineId);
-    if (authSessionId === `${scope}:owner`
-      || authSessionId === `${scope}:teammate`
-      || authSessionId === `${scope}:guest`) {
+    // ⚠️ 不要在这里硬枚举 `${scope}:owner|teammate|guest`：平台注入
+    // `X-Botmux-Actor` 后，协管者的 authSessionId 多出一段 actor
+    // （`<scope>:<actor>:<role>`），三个字面量会全部落空 → 协管者的终端只读链接
+    // 被判成「认证已结束」而 403。识别交给 request-identity 的同一份格式定义。
+    if (isPlatformDashboardAuthSessionId(authSessionId, platformDashboardActorScope(binding.machineId))) {
       return true;
     }
   }
@@ -516,8 +518,21 @@ function syncPlatformBindingRevocation(): void {
   const current = readPlatformBinding()?.machineId ?? null;
   if (observedPlatformMachineId && observedPlatformMachineId !== current) {
     const scope = platformDashboardActorScope(observedPlatformMachineId);
-    for (const role of ['owner', 'teammate', 'guest'] as const) {
-      endDashboardAuthSession(`${scope}:${role}`);
+    // ⚠️ 不要硬枚举 `${scope}:owner|teammate|guest`：平台注入 `X-Botmux-Actor`
+    // 后协管者的 authSessionId 里含 union_id（`<scope>:<actor>:<role>`），而「有
+    // 哪些人」本进程不可能预先知道 —— 硬枚举扫不到他们，解绑后协管者**已建立的
+    // 写连接不会被断开**，正是本函数要堵的那扇后窗。
+    // 所以反过来做：把四个注册表里在册的认证会话取并集，按本机 scope 筛出平台
+    // 身份逐个吊销。取并集是因为一个会话可能只在其中一个表里有状态（例如只开了
+    // SSE、还没拿写租约）。
+    const observed = new Set<string>([
+      ...terminalControl.authSessionIds(),
+      ...previewInteraction.authSessionIds(),
+      ...authSessionConnections.authSessionIds(),
+      ...controlCsrfTokens.authSessionIds(),
+    ]);
+    for (const authSessionId of observed) {
+      if (isPlatformDashboardAuthSessionId(authSessionId, scope)) endDashboardAuthSession(authSessionId);
     }
   }
   observedPlatformMachineId = current;

--- a/src/dashboard/auth-session-connections.ts
+++ b/src/dashboard/auth-session-connections.ts
@@ -85,8 +85,10 @@ export class AuthSessionConnectionRegistry {
     return this.closeAll(this.byAuthSession, authSessionId);
   }
 
-  /** 当前有长连接在册的全部认证会话。解绑吊销要按前缀筛平台身份，见
-   *  `TerminalControlManager.authSessionIds`。 */
+  /** 当前有长连接在册的全部认证会话。解绑吊销要按前缀筛平台身份。
+   *  ⚠️ 新增持有 authSessionId 状态的注册表必须同时接进
+   *  `dashboard.ts#syncPlatformBindingRevocation` 的并集 —— 见
+   *  `TerminalControlManager.authSessionIds` 的完整说明与当前的四个成员。 */
   authSessionIds(): string[] {
     return [...this.byAuthSession.keys()];
   }

--- a/src/dashboard/auth-session-connections.ts
+++ b/src/dashboard/auth-session-connections.ts
@@ -85,6 +85,12 @@ export class AuthSessionConnectionRegistry {
     return this.closeAll(this.byAuthSession, authSessionId);
   }
 
+  /** 当前有长连接在册的全部认证会话。解绑吊销要按前缀筛平台身份，见
+   *  `TerminalControlManager.authSessionIds`。 */
+  authSessionIds(): string[] {
+    return [...this.byAuthSession.keys()];
+  }
+
   /**
    * P1-13：预览目标失效（换代 / 关闭 / 端口易主）时，关闭这个业务会话名下的全部
    * 长连接。注销闭包会把它们同时从 authSession 索引里摘掉，两个索引不会漂移。

--- a/src/dashboard/control-csrf.ts
+++ b/src/dashboard/control-csrf.ts
@@ -413,8 +413,10 @@ export class ControlCsrfTokens {
     return true;
   }
 
-  /** 当前有票据在册的全部认证会话。解绑吊销要按前缀筛平台身份，见
-   *  `TerminalControlManager.authSessionIds`。 */
+  /** 当前有票据在册的全部认证会话。解绑吊销要按前缀筛平台身份。
+   *  ⚠️ 新增持有 authSessionId 状态的注册表必须同时接进
+   *  `dashboard.ts#syncPlatformBindingRevocation` 的并集 —— 见
+   *  `TerminalControlManager.authSessionIds` 的完整说明与当前的四个成员。 */
   authSessionIds(): string[] {
     return [...this.hashesByAuthSession.keys()];
   }

--- a/src/dashboard/control-csrf.ts
+++ b/src/dashboard/control-csrf.ts
@@ -413,6 +413,12 @@ export class ControlCsrfTokens {
     return true;
   }
 
+  /** 当前有票据在册的全部认证会话。解绑吊销要按前缀筛平台身份，见
+   *  `TerminalControlManager.authSessionIds`。 */
+  authSessionIds(): string[] {
+    return [...this.hashesByAuthSession.keys()];
+  }
+
   /** 认证结束（logout / 到期 / rotate / 解绑）时作废该会话的全部票据。 */
   revokeAuthSession(authSessionId: string): number {
     const hashes = this.hashesByAuthSession.get(authSessionId);

--- a/src/dashboard/preview-interaction.ts
+++ b/src/dashboard/preview-interaction.ts
@@ -142,6 +142,12 @@ export class PreviewInteractionManager {
     return count;
   }
 
+  /** 当前持有交互租约的全部认证会话。解绑吊销要按前缀筛平台身份，见
+   *  `TerminalControlManager.authSessionIds`。 */
+  authSessionIds(): string[] {
+    return [...new Set([...this.leases.values()].map(lease => lease.authSessionId))];
+  }
+
   relockAuthSession(authSessionId: string): number {
     let count = 0;
     for (const [key, lease] of [...this.leases]) {

--- a/src/dashboard/preview-interaction.ts
+++ b/src/dashboard/preview-interaction.ts
@@ -142,8 +142,10 @@ export class PreviewInteractionManager {
     return count;
   }
 
-  /** 当前持有交互租约的全部认证会话。解绑吊销要按前缀筛平台身份，见
-   *  `TerminalControlManager.authSessionIds`。 */
+  /** 当前持有交互租约的全部认证会话。解绑吊销要按前缀筛平台身份。
+   *  ⚠️ 新增持有 authSessionId 状态的注册表必须同时接进
+   *  `dashboard.ts#syncPlatformBindingRevocation` 的并集 —— 见
+   *  `TerminalControlManager.authSessionIds` 的完整说明与当前的四个成员。 */
   authSessionIds(): string[] {
     return [...new Set([...this.leases.values()].map(lease => lease.authSessionId))];
   }

--- a/src/dashboard/request-identity.ts
+++ b/src/dashboard/request-identity.ts
@@ -37,6 +37,22 @@ export interface DashboardIdentityInput {
   activeToken: string | null;
   /** 中心化平台注入的 `X-Botmux-Role`（仅在已绑定平台时有意义）。 */
   roleHeader: string | string[] | undefined;
+  /**
+   * 中心化平台注入的 `X-Botmux-Actor`：**操作者本人**的租户 union_id。
+   *
+   * 为什么必须有这一维：平台身份原本只由「机器 + 角色」构成，userId 长成
+   * `platform:<machineScope>:owner`，**不含人**。单 owner 时代无所谓，但平台支持
+   * 机器协管者后，同一台机器会有多个人以 owner 角色进来，于是：
+   *   · 审计（control-audit 按 actor.userId 记）分不出谁接管了终端；
+   *   · 终端租约互斥（terminal-control 用 userId + authSessionId 判「同一个登录」）
+   *     会把不同的人误判成同一人，进而**静默复用**彼此的写租约 —— 两个人同时往
+   *     一个终端打字而互不知情。
+   * 把它拼进 userId / authSessionId 就同时修掉这两个问题。
+   *
+   * 信任前提与 roleHeader 完全一致（活跃 cookie 证明请求经过平台反代），因为它们
+   * 由同一个反代注入、且平台在注入前会剥掉客户端伪造的同名头。
+   */
+  actorHeader: string | string[] | undefined;
   /** 已绑定平台的 machineId；未绑定为 null。 */
   platformMachineId: string | null;
   /** machineId → 平台 actor 作用域（HMAC，调用方与 liveness 检查共用同一实现）。 */
@@ -65,10 +81,19 @@ export function resolveDashboardIdentity(input: DashboardIdentityInput): Dashboa
       : undefined;
     if (platformRole && input.platformMachineId) {
       const machineScope = input.platformActorScope(input.platformMachineId);
+      // 操作者 union_id：数组头（重复注入）视为缺失，与 roleHeader 同一 fail-safe。
+      // 平台未注入时（老版本平台、或免登录只读）退回 machine+role，保持原行为。
+      const rawActor = input.actorHeader;
+      const actor = typeof rawActor === 'string' && rawActor.trim() ? rawActor.trim() : undefined;
+      // union_id 是外部输入，虽经平台注入仍做形状收敛：只留安全字符、限长，
+      // 避免异常值进入审计行与租约 key（它们会被写日志、做字符串比较）。
+      const actorScope = actor && /^[A-Za-z0-9_-]{1,64}$/.test(actor) ? actor : undefined;
+      const subject = actorScope ? `${machineScope}:${actorScope}` : machineScope;
       return {
         kind: 'platform-dashboard',
-        userId: `platform:${machineScope}:${platformRole}`,
-        authSessionId: `${machineScope}:${platformRole}`,
+        // 带上人 → 同机多个协管者在审计里可区分、租约互斥不再误判为同一登录。
+        userId: `platform:${subject}:${platformRole}`,
+        authSessionId: `${subject}:${platformRole}`,
         expiresAt: Number.MAX_SAFE_INTEGER,
         terminalCapability: platformRole === 'owner' ? 'owner' : 'readonly',
         previewCapability: platformRole === 'owner' ? 'operate' : 'readonly',

--- a/src/dashboard/request-identity.ts
+++ b/src/dashboard/request-identity.ts
@@ -139,6 +139,26 @@ export function isPlatformDashboardAuthSessionId(authSessionId: string, machineS
 }
 
 /**
+ * 解绑吊销要吊销的平台会话集合：四个注册表在册会话的并集，按本机 scope 筛出平台身份。
+ *
+ * 抽成纯函数是为了让**测试能调到生产实现本身**。此前测试自己复刻了一份「四表并集 +
+ * 筛选」，于是把生产代码改回硬枚举时 5 个用例仍然全绿 —— 锁的是复刻品、不是生产逻辑
+ *（复审实测证伪了我原先「改回硬枚举 → 5 个全红」的说法）。
+ *
+ * ⚠️ 取并集而非只看写租约：一个会话可能只在其中一个表里有状态（例如只开了 SSE、
+ * 还没拿写租约），只看租约会漏。**新增任何持有 authSessionId 状态的注册表，
+ * 必须把它的 `authSessionIds()` 也传进这里。**
+ */
+export function platformAuthSessionsToRevoke(
+  machineScope: string,
+  registries: ReadonlyArray<{ authSessionIds(): Iterable<string> }>,
+): string[] {
+  const observed = new Set<string>();
+  for (const r of registries) for (const id of r.authSessionIds()) observed.add(id);
+  return [...observed].filter(id => isPlatformDashboardAuthSessionId(id, machineScope));
+}
+
+/**
  * 身份优先级：legacy 管理 cookie > 平台注入角色 > H5 会话。
  *
  * 中心化平台通过「剥掉浏览器 Cookie 头、注入本机活跃 cookie」证明自己的边界，

--- a/src/dashboard/request-identity.ts
+++ b/src/dashboard/request-identity.ts
@@ -251,11 +251,18 @@ export function resolveDashboardRequestGate(input: {
     : decideDashboardAuth({
       method: input.method,
       pathname: input.pathname,
-      hasTokenParam: input.hasTokenParam,
       // 平台协管者没有、也不该有本机 token；把活跃 token 同时作为「出示的凭据」
       // 喂进去，等价于告诉门禁「这个请求持有管理凭据」——凭据的真正校验已经在
       // 上面的平台反代信任前提里做完（活跃 cookie 证明请求经过平台）。
       presentedToken: platformManages ? (input.activeToken ?? undefined) : presentedToken,
+      // ⚠️ 但必须同时压掉 `hasTokenParam`：`decideDashboardAuth` 有一条
+      // 「首次带正确 ?t= → allow+set-cookie，把 token 回写给浏览器」的分支
+      // （见 auth.ts 的 `hasTokenParam && authed && presentedToken`）。协管者的
+      // presentedToken 是我们**代填**的活跃 token、不是他自己出示的，若还让
+      // hasTokenParam 为真，他只要在 URL 上随便带个 `?t=x` 就会被回吐**本机真实
+      // 管理 token** —— 那是长期落盘凭证，撤销协管授权也不会失效，等于永久后门。
+      // 协管者本就不需要这条 cookie 引导：他的身份来自平台反代注入的 cookie。
+      hasTokenParam: platformManages ? false : input.hasTokenParam,
       activeToken: input.activeToken ?? '',
       publicReadOnly: input.publicReadOnly,
     });

--- a/src/dashboard/request-identity.ts
+++ b/src/dashboard/request-identity.ts
@@ -89,6 +89,55 @@ export interface DashboardIdentityInput {
   h5: DashboardAuthIdentity | null;
 }
 
+/** 平台会注入的三种角色。平台实际只发 owner / guest，teammate 保留兼容。 */
+export const PLATFORM_DASHBOARD_ROLES = ['owner', 'teammate', 'guest'] as const;
+export type PlatformDashboardRole = typeof PLATFORM_DASHBOARD_ROLES[number];
+
+/**
+ * 操作者标识（union_id）的合法形状。**外部输入**，虽经平台注入仍要收敛：
+ * 冒号会破坏 authSessionId 的 `scope:actor:role` 分段、空格与控制字符会污染
+ * 审计行（它们会被写日志、做字符串比较）。
+ */
+const PLATFORM_ACTOR_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+function isPlatformDashboardRole(value: string): value is PlatformDashboardRole {
+  return (PLATFORM_DASHBOARD_ROLES as ReadonlyArray<string>).includes(value);
+}
+
+/**
+ * 平台身份的 authSessionId **唯一构造点**：`<machineScope>[:<actor>]:<role>`。
+ *
+ * ⚠️ 这个格式有两个消费方在 dashboard.ts —— 读能力存活判定
+ * （`terminalAuthSessionLive`）与解绑吊销（`syncPlatformBindingRevocation`）。
+ * 它们曾各自硬枚举 `${scope}:owner|teammate|guest` 三个字面量，于是 actor 段一
+ * 加进来就**同时**漏判：协管者的终端只读链接被判成「认证已结束」而 403，解绑后
+ * 协管者已建立的写连接又扫不到、不被断开。构造与识别都收在本模块，就是为了让
+ * 格式只有一个定义点，不会再漂移。
+ */
+export function platformDashboardAuthSessionId(
+  machineScope: string,
+  actor: string | undefined,
+  role: PlatformDashboardRole,
+): string {
+  return actor ? `${machineScope}:${actor}:${role}` : `${machineScope}:${role}`;
+}
+
+/**
+ * 判断某个 authSessionId 是否由本机 `machineScope` 下的平台身份签出
+ * （无论平台有没有注入 actor 段）。`machineScope` 是 base64url HMAC，不含冒号，
+ * 所以按冒号分段是无歧义的。
+ */
+export function isPlatformDashboardAuthSessionId(authSessionId: string, machineScope: string): boolean {
+  const prefix = `${machineScope}:`;
+  if (!authSessionId.startsWith(prefix)) return false;
+  const parts = authSessionId.slice(prefix.length).split(':');
+  // 无 actor（老平台 / 免登录只读）：`<scope>:<role>`
+  if (parts.length === 1) return isPlatformDashboardRole(parts[0]);
+  // 带 actor（协管者）：`<scope>:<actor>:<role>`
+  if (parts.length === 2) return PLATFORM_ACTOR_PATTERN.test(parts[0]) && isPlatformDashboardRole(parts[1]);
+  return false;
+}
+
 /**
  * 身份优先级：legacy 管理 cookie > 平台注入角色 > H5 会话。
  *
@@ -101,8 +150,7 @@ export function resolveDashboardIdentity(input: DashboardIdentityInput): Dashboa
   const { activeToken } = input;
   if (activeToken && input.legacyCookie === activeToken) {
     const rawRole = input.roleHeader;
-    const platformRole = input.platformMachineId && typeof rawRole === 'string'
-      && (rawRole === 'owner' || rawRole === 'teammate' || rawRole === 'guest')
+    const platformRole = input.platformMachineId && typeof rawRole === 'string' && isPlatformDashboardRole(rawRole)
       ? rawRole
       : undefined;
     if (platformRole && input.platformMachineId) {
@@ -111,10 +159,8 @@ export function resolveDashboardIdentity(input: DashboardIdentityInput): Dashboa
       // 平台未注入时（老版本平台、或免登录只读）退回 machine+role，保持原行为。
       const rawActor = input.actorHeader;
       const actor = typeof rawActor === 'string' && rawActor.trim() ? rawActor.trim() : undefined;
-      // union_id 是外部输入，虽经平台注入仍做形状收敛：只留安全字符、限长，
-      // 避免异常值进入审计行与租约 key（它们会被写日志、做字符串比较）。
-      const actorScope = actor && /^[A-Za-z0-9_-]{1,64}$/.test(actor) ? actor : undefined;
-      const subject = actorScope ? `${machineScope}:${actorScope}` : machineScope;
+      const actorScope = actor && PLATFORM_ACTOR_PATTERN.test(actor) ? actor : undefined;
+      const authSessionId = platformDashboardAuthSessionId(machineScope, actorScope, platformRole);
       // 平台授予的能力清单。只认 dashboard:manage 这一项（其余 scope 描述的是平台侧
       // 能力，机器端无对应闸）。数组头视为缺失，与 role / actor 同一 fail-safe。
       const rawScopes = input.scopesHeader;
@@ -127,8 +173,8 @@ export function resolveDashboardIdentity(input: DashboardIdentityInput): Dashboa
       return {
         kind: 'platform-dashboard',
         // 带上人 → 同机多个协管者在审计里可区分、租约互斥不再误判为同一登录。
-        userId: `platform:${subject}:${platformRole}`,
-        authSessionId: `${subject}:${platformRole}`,
+        userId: `platform:${authSessionId}`,
+        authSessionId,
         expiresAt: Number.MAX_SAFE_INTEGER,
         terminalCapability: platformRole === 'owner' ? 'owner' : 'readonly',
         previewCapability: platformRole === 'owner' ? 'operate' : 'readonly',

--- a/src/dashboard/request-identity.ts
+++ b/src/dashboard/request-identity.ts
@@ -28,6 +28,18 @@ import { decideDashboardAuth, decideWorkbenchH5Auth, type AuthDecision } from '.
 export interface DashboardRequestIdentity extends TerminalDashboardActor {
   kind: 'legacy-dashboard' | 'platform-dashboard' | DashboardAuthIdentity['kind'];
   previewCapability: 'operate' | 'readonly';
+  /**
+   * 本机管理能力（settings / schedules / groups 的读写与不脱敏）。
+   *
+   * 与 `legacy-dashboard` 身份的区别刻意保留：本机管理 cookie 之外，**平台授予
+   * `dashboard:manage` 的协管者**也拿到这一项，但**永远拿不到** debug shell /
+   * write-link / spawn-command —— 那三个仍只认 legacy 身份（见 dashboard.ts 里
+   * 直接引用 `legacyAuthed` 的三处）。
+   *
+   * 换句话说：这个布尔是「管理面能力」，`legacyAuthed` 是「本机 owner 身份」。
+   * 二者原本是同一个变量，机器协管者要求把它们分开。
+   */
+  canManageHost: boolean;
 }
 
 export interface DashboardIdentityInput {
@@ -53,6 +65,20 @@ export interface DashboardIdentityInput {
    * 由同一个反代注入、且平台在注入前会剥掉客户端伪造的同名头。
    */
   actorHeader: string | string[] | undefined;
+  /**
+   * 中心化平台注入的 `X-Botmux-Scopes`：这个访问者被授予的能力清单，逗号分隔。
+   *
+   * 为什么用独立的头、不新增角色值：角色（owner/guest）表达的是「能不能操作终端」，
+   * 而「能不能改本机配置」是另一个维度 —— 一个人可以能接管终端但不能改 settings。
+   * 塞进角色就得造 `manager` / `owner-no-config` 之类的组合值，数量随维度指数增长；
+   * 平台侧那张表（machines:read / sessions:open / terminal:control / dashboard:manage）
+   * 本来就是勾选式的，这里如实照搬即可。`teammate` 那档从未被平台发出、成了死代码，
+   * 正是「把能力硬编码进角色枚举」的前车之鉴。
+   *
+   * 缺失 = 没有任何额外能力（老平台、免登录只读）→ 与本改动前行为完全一致。
+   * 信任前提同 roleHeader / actorHeader：只有经平台反代的请求才作数。
+   */
+  scopesHeader: string | string[] | undefined;
   /** 已绑定平台的 machineId；未绑定为 null。 */
   platformMachineId: string | null;
   /** machineId → 平台 actor 作用域（HMAC，调用方与 liveness 检查共用同一实现）。 */
@@ -89,6 +115,15 @@ export function resolveDashboardIdentity(input: DashboardIdentityInput): Dashboa
       // 避免异常值进入审计行与租约 key（它们会被写日志、做字符串比较）。
       const actorScope = actor && /^[A-Za-z0-9_-]{1,64}$/.test(actor) ? actor : undefined;
       const subject = actorScope ? `${machineScope}:${actorScope}` : machineScope;
+      // 平台授予的能力清单。只认 dashboard:manage 这一项（其余 scope 描述的是平台侧
+      // 能力，机器端无对应闸）。数组头视为缺失，与 role / actor 同一 fail-safe。
+      const rawScopes = input.scopesHeader;
+      const scopes = typeof rawScopes === 'string'
+        ? rawScopes.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+      // 只有能操作终端的身份才谈得上管理本机：guest 拿到 dashboard:manage 也不放行，
+      // 避免平台侧一个组合失误就把只读访客提成配置管理员（fail-closed 的乘法而非加法）。
+      const canManageHost = platformRole === 'owner' && scopes.includes('dashboard:manage');
       return {
         kind: 'platform-dashboard',
         // 带上人 → 同机多个协管者在审计里可区分、租约互斥不再误判为同一登录。
@@ -97,6 +132,7 @@ export function resolveDashboardIdentity(input: DashboardIdentityInput): Dashboa
         expiresAt: Number.MAX_SAFE_INTEGER,
         terminalCapability: platformRole === 'owner' ? 'owner' : 'readonly',
         previewCapability: platformRole === 'owner' ? 'operate' : 'readonly',
+        canManageHost,
       };
     }
     return {
@@ -107,18 +143,30 @@ export function resolveDashboardIdentity(input: DashboardIdentityInput): Dashboa
       expiresAt: Number.MAX_SAFE_INTEGER,
       terminalCapability: 'controlled',
       previewCapability: 'operate',
+      // 本机管理 cookie 恒有全部管理能力（它本身就是 owner 凭据）。
+      canManageHost: true,
     };
   }
   return input.h5 ? {
     ...input.h5,
     terminalCapability: 'controlled',
     previewCapability: 'operate',
+    // H5 会话是 workbench 身份，从不继承本机管理能力（P1-7 的既有口径）。
+    canManageHost: false,
   } : null;
 }
 
 export interface DashboardRequestGate {
-  /** 本机管理能力（settings / schedules / groups / debug shell 的唯一凭据）。 */
+  /** 本机 owner 身份（debug shell / write-link / spawn-command 的唯一凭据）。 */
   legacyAuthed: boolean;
+  /**
+   * 管理面能力（settings / schedules / groups 的读写与不脱敏）。
+   *
+   * = 本机 owner **或** 平台授予 `dashboard:manage` 的协管者。与 `legacyAuthed`
+   * 分开是机器协管者的核心诉求：协管者要能帮 owner 改配置，但**不能**拿到那三个
+   * 「拿到就等于拿到整台机器」的面。调用方按语义二选一，别再图省事共用一个布尔。
+   */
+  canManageHost: boolean;
   /** 只有工作台能力：H5 会话或平台角色，且本请求没有管理凭据。 */
   workbenchOnlyIdentity: boolean;
   /** 交给 `decideDashboardAuth` 的凭据；平台注入 cookie 场景恒为 undefined。 */
@@ -144,7 +192,13 @@ export function resolveDashboardRequestGate(input: {
   const presentedToken = platformIdentity ? undefined : input.tokenFromRequest;
   const managementCredential = !!presentedToken && !!input.activeToken
     && presentedToken === input.activeToken;
-  const workbenchOnlyIdentity = !legacyAuthed && !managementCredential
+  // 平台授予 dashboard:manage 的协管者：管理面路由不在 workbenchH5Capability 白名单里，
+  // 所以必须走宽门禁 decideDashboardAuth，否则 /api/settings 会被 401 挡死。
+  // 这样放宽是安全的 —— debug shell / write-link / spawn-command 三处**直接查
+  // legacyAuthed**（不经本函数的 decision），协管者仍拿不到，见 dashboard.ts 对应三处。
+  const platformManages = platformIdentity && input.identity?.canManageHost === true;
+  const canManageHost = legacyAuthed || managementCredential || platformManages;
+  const workbenchOnlyIdentity = !legacyAuthed && !managementCredential && !platformManages
     && (platformIdentity || input.identity?.kind === 'feishu-h5');
   const decision = workbenchOnlyIdentity
     ? decideWorkbenchH5Auth({ method: input.method, pathname: input.pathname })
@@ -152,11 +206,14 @@ export function resolveDashboardRequestGate(input: {
       method: input.method,
       pathname: input.pathname,
       hasTokenParam: input.hasTokenParam,
-      presentedToken,
+      // 平台协管者没有、也不该有本机 token；把活跃 token 同时作为「出示的凭据」
+      // 喂进去，等价于告诉门禁「这个请求持有管理凭据」——凭据的真正校验已经在
+      // 上面的平台反代信任前提里做完（活跃 cookie 证明请求经过平台）。
+      presentedToken: platformManages ? (input.activeToken ?? undefined) : presentedToken,
       activeToken: input.activeToken ?? '',
       publicReadOnly: input.publicReadOnly,
     });
-  return { legacyAuthed, workbenchOnlyIdentity, presentedToken, decision };
+  return { legacyAuthed, canManageHost, workbenchOnlyIdentity, presentedToken, decision };
 }
 
 /** 便于把 `IncomingMessage` 直接喂给上面的纯函数（测试与真实服务共用一条路径）。 */

--- a/src/dashboard/terminal-control.ts
+++ b/src/dashboard/terminal-control.ts
@@ -420,6 +420,14 @@ export class TerminalControlManager {
    * 为解绑吊销而加：平台解绑时要关掉这台机器名下**所有**平台身份的连接，但协管者
    * 的 authSessionId 里含 union_id（`<scope>:<actor>:<role>`），调用方无法把人枚举
    * 出来，只能反过来遍历「已建立的会话」再按前缀筛。
+   *
+   * ⚠️ **新增任何持有 authSessionId 状态的注册表，必须同时接进
+   * `dashboard.ts#syncPlatformBindingRevocation` 的并集里** —— 那里靠这组
+   * `authSessionIds()` 找出该吊销的平台会话，漏接一个就等于解绑后那类连接不被断开
+   * （本函数存在的原因正是硬枚举漏掉了协管者）。当前有四个：本类、
+   * `PreviewInteractionManager`、`AuthSessionConnectionRegistry`、`ControlCsrfTokens`。
+   * `events-sse` 看似是第五个，实际委托给 `AuthSessionConnectionRegistry`；一旦它
+   * 改成自己持有会话表，也要接进来。
    */
   authSessionIds(): string[] {
     const ids = new Set<string>();

--- a/src/dashboard/terminal-control.ts
+++ b/src/dashboard/terminal-control.ts
@@ -414,6 +414,20 @@ export class TerminalControlManager {
     };
   }
 
+  /**
+   * 本管理器当前持有状态的全部认证会话（写租约 + 读 socket 两个索引的并集）。
+   *
+   * 为解绑吊销而加：平台解绑时要关掉这台机器名下**所有**平台身份的连接，但协管者
+   * 的 authSessionId 里含 union_id（`<scope>:<actor>:<role>`），调用方无法把人枚举
+   * 出来，只能反过来遍历「已建立的会话」再按前缀筛。
+   */
+  authSessionIds(): string[] {
+    const ids = new Set<string>();
+    for (const lease of this.leases.values()) ids.add(lease.authSessionId);
+    for (const id of this.readSocketsByAuthSession.keys()) ids.add(id);
+    return [...ids];
+  }
+
   releaseByAuthSession(authSessionId: string): number {
     let released = 0;
     for (const [sessionId, lease] of [...this.leases]) {

--- a/test/agent-workbench-route.test.ts
+++ b/test/agent-workbench-route.test.ts
@@ -80,6 +80,7 @@ describe('Agent Workbench route and surface integration', () => {
       activeToken: ACTIVE,
       roleHeader: 'owner',
       actorHeader: undefined,
+      scopesHeader: undefined,
       platformMachineId: 'machine-1',
       platformActorScope: machineId => `scope-${machineId}`,
       legacyAuthSessionId: token => `legacy-${token}`,

--- a/test/agent-workbench-route.test.ts
+++ b/test/agent-workbench-route.test.ts
@@ -79,6 +79,7 @@ describe('Agent Workbench route and surface integration', () => {
       legacyCookie: ACTIVE,
       activeToken: ACTIVE,
       roleHeader: 'owner',
+      actorHeader: undefined,
       platformMachineId: 'machine-1',
       platformActorScope: machineId => `scope-${machineId}`,
       legacyAuthSessionId: token => `legacy-${token}`,

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -1445,6 +1445,7 @@ describe('P1-7 dual-cookie identity (real requests)', () => {
         activeToken: ACTIVE,
         roleHeader: req.headers['x-botmux-role'],
         actorHeader: req.headers['x-botmux-actor'],
+        scopesHeader: req.headers['x-botmux-scopes'],
         platformMachineId: opts.platformMachineId ?? null,
         platformActorScope: (machineId: string) => `scope-${machineId}`,
         legacyAuthSessionId: (token: string) => `legacy-${token}`,

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -1444,6 +1444,7 @@ describe('P1-7 dual-cookie identity (real requests)', () => {
         legacyCookie: parseCookie(req.headers.cookie),
         activeToken: ACTIVE,
         roleHeader: req.headers['x-botmux-role'],
+        actorHeader: req.headers['x-botmux-actor'],
         platformMachineId: opts.platformMachineId ?? null,
         platformActorScope: (machineId: string) => `scope-${machineId}`,
         legacyAuthSessionId: (token: string) => `legacy-${token}`,

--- a/test/debug-terminal.test.ts
+++ b/test/debug-terminal.test.ts
@@ -84,6 +84,7 @@ function startHarness(): Promise<{ server: Server; base: string; wsBase: string;
       legacyCookie: parseCookie(req.headers.cookie),
       activeToken: TOKEN,
       roleHeader: req.headers['x-botmux-role'],
+      actorHeader: req.headers['x-botmux-actor'],
       platformMachineId: readPlatformBinding()?.machineId ?? null,
       platformActorScope: (machineId) => `scope-${machineId}`,
       legacyAuthSessionId: () => 'legacy-auth-session',

--- a/test/debug-terminal.test.ts
+++ b/test/debug-terminal.test.ts
@@ -85,6 +85,7 @@ function startHarness(): Promise<{ server: Server; base: string; wsBase: string;
       activeToken: TOKEN,
       roleHeader: req.headers['x-botmux-role'],
       actorHeader: req.headers['x-botmux-actor'],
+      scopesHeader: req.headers['x-botmux-scopes'],
       platformMachineId: readPlatformBinding()?.machineId ?? null,
       platformActorScope: (machineId) => `scope-${machineId}`,
       legacyAuthSessionId: () => 'legacy-auth-session',

--- a/test/platform-actor-header.test.ts
+++ b/test/platform-actor-header.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDashboardIdentity } from '../src/dashboard/request-identity.js';
+
+/**
+ * 平台注入的 `X-Botmux-Actor`（操作者 union_id）。
+ *
+ * 背景：平台支持「机器协管者」后，同一台机器会有多个人以 owner 角色反代进来。
+ * 在加这个头之前，平台身份的 userId 只由「机器 + 角色」构成、**不含人**，于是
+ * 两处出问题：审计分不出人；终端租约互斥（按 userId + authSessionId 判「同一个
+ * 登录」）把不同人误判为同一人，从而静默复用彼此的写租约。
+ */
+describe('platform actor header', () => {
+  const ACTIVE = 'active-management-token';
+  const MACHINE = 'machine-1';
+
+  const resolve = (actorHeader: string | string[] | undefined, role = 'owner') =>
+    resolveDashboardIdentity({
+      legacyCookie: ACTIVE,
+      activeToken: ACTIVE,
+      roleHeader: role,
+      actorHeader,
+      platformMachineId: MACHINE,
+      platformActorScope: machineId => `scope-${machineId}`,
+      legacyAuthSessionId: token => `legacy-${token}`,
+      h5: null,
+    });
+
+  it('把操作者拼进 userId 与 authSessionId', () => {
+    const id = resolve('ou_alice');
+    expect(id?.kind).toBe('platform-dashboard');
+    expect(id?.userId).toBe('platform:scope-machine-1:ou_alice:owner');
+    expect(id?.authSessionId).toBe('scope-machine-1:ou_alice:owner');
+  });
+
+  it('同机不同协管者互不相同 —— 审计能分人、租约不再误判为同一登录', () => {
+    const alice = resolve('ou_alice');
+    const bob = resolve('ou_bob');
+    expect(alice?.userId).not.toBe(bob?.userId);
+    expect(alice?.authSessionId).not.toBe(bob?.authSessionId);
+  });
+
+  it('平台没注入时退回原行为（老平台 / 免登录只读），不破坏既有部署', () => {
+    const id = resolve(undefined);
+    expect(id?.userId).toBe('platform:scope-machine-1:owner');
+    expect(id?.authSessionId).toBe('scope-machine-1:owner');
+  });
+
+  it('空串视为缺失', () => {
+    expect(resolve('')?.userId).toBe('platform:scope-machine-1:owner');
+    expect(resolve('   ')?.userId).toBe('platform:scope-machine-1:owner');
+  });
+
+  it('重复注入（数组头）视为缺失，与 roleHeader 同一 fail-safe', () => {
+    expect(resolve(['ou_alice', 'ou_bob'])?.userId).toBe('platform:scope-machine-1:owner');
+  });
+
+  it('形状异常的值被丢弃，不进审计行与租约 key', () => {
+    // 冒号会破坏 `a:b:c` 的解析、空格与控制字符会污染日志行。
+    for (const bad of ['ou:evil', 'ou alice', 'a'.repeat(65), 'ou/../x', '<script>']) {
+      expect(resolve(bad)?.userId).toBe('platform:scope-machine-1:owner');
+    }
+  });
+
+  it('teammate / guest 角色同样带上操作者，且仍是只读', () => {
+    const guest = resolve('ou_alice', 'guest');
+    expect(guest?.userId).toBe('platform:scope-machine-1:ou_alice:guest');
+    expect(guest?.terminalCapability).toBe('readonly');
+    expect(guest?.previewCapability).toBe('readonly');
+  });
+
+  it('未绑定平台时 actor 头无效（直连伪造拿不到平台身份）', () => {
+    const id = resolveDashboardIdentity({
+      legacyCookie: ACTIVE,
+      activeToken: ACTIVE,
+      roleHeader: 'owner',
+      actorHeader: 'ou_attacker',
+      platformMachineId: null,
+      platformActorScope: machineId => `scope-${machineId}`,
+      legacyAuthSessionId: token => `legacy-${token}`,
+      h5: null,
+    });
+    // 退回 legacy owner（本机管理 cookie 本身就是 owner），不是平台身份。
+    expect(id?.kind).toBe('legacy-dashboard');
+    expect(id?.userId).toBe('legacy-owner');
+  });
+
+  it('没有活跃管理 cookie 时 actor 头不产生任何平台身份', () => {
+    const id = resolveDashboardIdentity({
+      legacyCookie: 'not-the-active-token',
+      activeToken: ACTIVE,
+      roleHeader: 'owner',
+      actorHeader: 'ou_attacker',
+      platformMachineId: MACHINE,
+      platformActorScope: machineId => `scope-${machineId}`,
+      legacyAuthSessionId: token => `legacy-${token}`,
+      h5: null,
+    });
+    expect(id).toBeNull();
+  });
+
+  it('owner 与 guest 即使同一个人也不共享租约 key（角色变化即换会话）', () => {
+    expect(resolve('ou_alice', 'owner')?.authSessionId).not.toBe(
+      resolve('ou_alice', 'guest')?.authSessionId,
+    );
+  });
+});

--- a/test/platform-actor-header.test.ts
+++ b/test/platform-actor-header.test.ts
@@ -301,3 +301,86 @@ describe('gate: dashboard:manage 开管理面但不开整机', () => {
     expect(g.decision.kind).toBe('deny401');
   });
 });
+
+/**
+ * F1（外仓复审 · 严重）：带 `dashboard:manage` 的协管者若在 URL 上随便带一个 `?t=`，
+ * 会被回吐**本机真实管理 token**。
+ *
+ * 成因是 `1b47dd5` 为了让管理面路由走宽门禁，把活跃 token 代填进 `presentedToken`，
+ * 却没同时压掉 `hasTokenParam`。`decideDashboardAuth` 有一条「首次带正确 ?t= →
+ * allow+set-cookie，把 token 回写浏览器」的分支（auth.ts 的
+ * `hasTokenParam && authed && presentedToken`），于是 `?t=任意值` 就能命中。
+ *
+ * 危害不是「多一次越权读」：泄漏的是**长期落盘凭证**，撤销协管授权也不失效，
+ * 而 `config.dashboard.host` 默认 `0.0.0.0`（不是 loopback-only），拿到 token
+ * 的人网络够得着 dashboard 端口就能直连本机、绕开平台的一切判权。
+ */
+describe('F1: 协管者不得拿到本机管理 token', () => {
+  const ACTIVE = 'REAL-ACTIVE-TOKEN';
+
+  const managing = () => resolveDashboardIdentity({
+    legacyCookie: ACTIVE,
+    activeToken: ACTIVE,
+    roleHeader: 'owner',
+    actorHeader: 'ou_comanager',
+    scopesHeader: 'terminal:control,dashboard:manage',
+    platformMachineId: 'm1',
+    platformActorScope: m => `scope-${m}`,
+    legacyAuthSessionId: t => `legacy-${t}`,
+    h5: null,
+  });
+
+  const gate = (identity: ReturnType<typeof managing>, hasTokenParam: boolean, tokenFromRequest?: string) =>
+    resolveDashboardRequestGate({
+      method: 'GET',
+      pathname: '/api/settings',
+      hasTokenParam,
+      identity,
+      tokenFromRequest,
+      activeToken: ACTIVE,
+      publicReadOnly: false,
+    });
+
+  it('带任意 ?t= 也绝不回吐 token（allow 但不 set-cookie）', () => {
+    const d = gate(managing(), true, 'whatever-garbage').decision;
+    expect(d.kind).toBe('allow');
+    expect((d as { token?: string }).token).toBeUndefined();
+  });
+
+  it('即便 ?t= 恰好是正确的活跃 token 也不下发 cookie', () => {
+    // 协管者不该持有这个值；万一从别处得知，也不能借这条路把它固化成本机 cookie。
+    const d = gate(managing(), true, ACTIVE).decision;
+    expect((d as { token?: string }).token).toBeUndefined();
+  });
+
+  it('管理面可达性不受影响（修复没有把功能一起关掉）', () => {
+    const g = gate(managing(), false, undefined);
+    expect(g.canManageHost).toBe(true);
+    expect(g.decision.kind).toBe('allow');
+  });
+
+  it('legacy owner 带正确 ?t= 仍然 allow+set-cookie —— 不能连坐', () => {
+    const legacy = resolveDashboardIdentity({
+      legacyCookie: ACTIVE,
+      activeToken: ACTIVE,
+      roleHeader: undefined,
+      actorHeader: undefined,
+      scopesHeader: undefined,
+      platformMachineId: null,
+      platformActorScope: m => `scope-${m}`,
+      legacyAuthSessionId: t => `legacy-${t}`,
+      h5: null,
+    });
+    const d = resolveDashboardRequestGate({
+      method: 'GET',
+      pathname: '/api/settings',
+      hasTokenParam: true,
+      identity: legacy,
+      tokenFromRequest: ACTIVE,
+      activeToken: ACTIVE,
+      publicReadOnly: false,
+    }).decision;
+    expect(d.kind).toBe('allow+set-cookie');
+    expect((d as { token?: string }).token).toBe(ACTIVE);
+  });
+});

--- a/test/platform-actor-header.test.ts
+++ b/test/platform-actor-header.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { resolveDashboardIdentity } from '../src/dashboard/request-identity.js';
+import {
+  resolveDashboardIdentity,
+  resolveDashboardRequestGate,
+} from '../src/dashboard/request-identity.js';
 
 /**
  * 平台注入的 `X-Botmux-Actor`（操作者 union_id）。
@@ -19,6 +22,7 @@ describe('platform actor header', () => {
       activeToken: ACTIVE,
       roleHeader: role,
       actorHeader,
+      scopesHeader: undefined,
       platformMachineId: MACHINE,
       platformActorScope: machineId => `scope-${machineId}`,
       legacyAuthSessionId: token => `legacy-${token}`,
@@ -74,6 +78,7 @@ describe('platform actor header', () => {
       activeToken: ACTIVE,
       roleHeader: 'owner',
       actorHeader: 'ou_attacker',
+      scopesHeader: undefined,
       platformMachineId: null,
       platformActorScope: machineId => `scope-${machineId}`,
       legacyAuthSessionId: token => `legacy-${token}`,
@@ -90,6 +95,7 @@ describe('platform actor header', () => {
       activeToken: ACTIVE,
       roleHeader: 'owner',
       actorHeader: 'ou_attacker',
+      scopesHeader: undefined,
       platformMachineId: MACHINE,
       platformActorScope: machineId => `scope-${machineId}`,
       legacyAuthSessionId: token => `legacy-${token}`,
@@ -102,5 +108,140 @@ describe('platform actor header', () => {
     expect(resolve('ou_alice', 'owner')?.authSessionId).not.toBe(
       resolve('ou_alice', 'guest')?.authSessionId,
     );
+  });
+});
+
+/**
+ * 二期：平台授予 `dashboard:manage` 的协管者可以改本机配置，
+ * 但**绝不能**碰 debug shell / write-link / spawn-command。
+ */
+describe('platform dashboard:manage scope', () => {
+  const ACTIVE = 'active-management-token';
+  const MACHINE = 'machine-1';
+
+  const resolve = (scopesHeader: string | string[] | undefined, role = 'owner') =>
+    resolveDashboardIdentity({
+      legacyCookie: ACTIVE,
+      activeToken: ACTIVE,
+      roleHeader: role,
+      actorHeader: 'ou_alice',
+      scopesHeader,
+      platformMachineId: MACHINE,
+      platformActorScope: machineId => `scope-${machineId}`,
+      legacyAuthSessionId: token => `legacy-${token}`,
+      h5: null,
+    });
+
+  it('带 dashboard:manage 时拿到管理面能力', () => {
+    expect(resolve('machines:read,sessions:open,terminal:control,dashboard:manage')?.canManageHost).toBe(true);
+  });
+
+  it('默认档（无 dashboard:manage）拿不到管理面', () => {
+    expect(resolve('machines:read,sessions:open,terminal:control')?.canManageHost).toBe(false);
+    expect(resolve(undefined)?.canManageHost).toBe(false);
+    expect(resolve('')?.canManageHost).toBe(false);
+  });
+
+  it('guest 角色即使带 dashboard:manage 也不放行（fail-closed 的乘法）', () => {
+    // 平台侧一个组合失误不该把只读访客提成配置管理员。
+    expect(resolve('dashboard:manage', 'guest')?.canManageHost).toBe(false);
+  });
+
+  it('数组头视为缺失', () => {
+    expect(resolve(['dashboard:manage'])?.canManageHost).toBe(false);
+  });
+
+  it('容忍空格与多余分隔符', () => {
+    expect(resolve(' dashboard:manage , terminal:control ')?.canManageHost).toBe(true);
+  });
+
+  it('未知 scope 不影响判定，也不越权', () => {
+    expect(resolve('some:future-scope')?.canManageHost).toBe(false);
+    expect(resolve('some:future-scope,dashboard:manage')?.canManageHost).toBe(true);
+  });
+
+  it('本机管理 cookie 恒有管理面能力', () => {
+    const legacy = resolveDashboardIdentity({
+      legacyCookie: ACTIVE,
+      activeToken: ACTIVE,
+      roleHeader: undefined,
+      actorHeader: undefined,
+      scopesHeader: undefined,
+      platformMachineId: null,
+      platformActorScope: machineId => `scope-${machineId}`,
+      legacyAuthSessionId: token => `legacy-${token}`,
+      h5: null,
+    });
+    expect(legacy?.kind).toBe('legacy-dashboard');
+    expect(legacy?.canManageHost).toBe(true);
+  });
+});
+
+describe('gate: dashboard:manage 开管理面但不开整机', () => {
+  const ACTIVE = 'active-management-token';
+
+  const managingCoManager = resolveDashboardIdentity({
+    legacyCookie: ACTIVE,
+    activeToken: ACTIVE,
+    roleHeader: 'owner',
+    actorHeader: 'ou_alice',
+    scopesHeader: 'terminal:control,dashboard:manage',
+    platformMachineId: 'machine-1',
+    platformActorScope: machineId => `scope-${machineId}`,
+    legacyAuthSessionId: token => `legacy-${token}`,
+    h5: null,
+  });
+
+  const gateFor = (pathname: string, method = 'GET') =>
+    resolveDashboardRequestGate({
+      method,
+      pathname,
+      hasTokenParam: false,
+      identity: managingCoManager,
+      tokenFromRequest: undefined,
+      activeToken: ACTIVE,
+      publicReadOnly: false,
+    });
+
+  it('管理面路由放行（原本会被 workbench 窄门禁 401 挡死）', () => {
+    for (const p of ['/api/settings', '/api/schedules', '/api/groups']) {
+      const g = gateFor(p);
+      expect(g.canManageHost, p).toBe(true);
+      expect(g.decision.kind, p).toBe('allow');
+    }
+    expect(gateFor('/api/settings', 'PUT').decision.kind).toBe('allow');
+  });
+
+  it('但仍不是本机 owner —— 三个「拿到就等于拿到整机」的面照旧关着', () => {
+    const g = gateFor('/api/settings');
+    // dashboard.ts 里 debug-terminal / write-link / spawn-command 三处直接查
+    // legacyAuthed，不看 decision，所以这个 false 就是那三处的拒绝依据。
+    expect(g.legacyAuthed).toBe(false);
+  });
+
+  it('没有 dashboard:manage 的协管者仍走 workbench 窄门禁', () => {
+    const plain = resolveDashboardIdentity({
+      legacyCookie: ACTIVE,
+      activeToken: ACTIVE,
+      roleHeader: 'owner',
+      actorHeader: 'ou_bob',
+      scopesHeader: 'terminal:control',
+      platformMachineId: 'machine-1',
+      platformActorScope: machineId => `scope-${machineId}`,
+      legacyAuthSessionId: token => `legacy-${token}`,
+      h5: null,
+    });
+    const g = resolveDashboardRequestGate({
+      method: 'GET',
+      pathname: '/api/settings',
+      hasTokenParam: false,
+      identity: plain,
+      tokenFromRequest: undefined,
+      activeToken: ACTIVE,
+      publicReadOnly: false,
+    });
+    expect(g.canManageHost).toBe(false);
+    expect(g.workbenchOnlyIdentity).toBe(true);
+    expect(g.decision.kind).toBe('deny401');
   });
 });

--- a/test/platform-actor-header.test.ts
+++ b/test/platform-actor-header.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  isPlatformDashboardAuthSessionId,
   resolveDashboardIdentity,
   resolveDashboardRequestGate,
 } from '../src/dashboard/request-identity.js';
@@ -108,6 +109,61 @@ describe('platform actor header', () => {
     expect(resolve('ou_alice', 'owner')?.authSessionId).not.toBe(
       resolve('ou_alice', 'guest')?.authSessionId,
     );
+  });
+
+  /**
+   * 回归：actor 段一加进来就改了 authSessionId 的分段数，而 dashboard.ts 有两个
+   * 消费方（读能力存活判定 `terminalAuthSessionLive`、解绑吊销
+   * `syncPlatformBindingRevocation`）曾各自硬枚举 `${scope}:owner|teammate|guest`
+   * 三个字面量。这组用例把「产出」直接喂回「识别」，钉住两侧不再漂移 —— 上面那些
+   * 只断言字符串长什么样的用例，是抓不到这类漏判的。
+   */
+  describe('authSessionId 的产出与识别必须同源', () => {
+    const SCOPE = `scope-${MACHINE}`;
+
+    it('带 actor 的协管者会话能被认出来 —— 否则终端只读链接 403「认证已结束」', () => {
+      const id = resolve('ou_alice');
+      expect(id?.authSessionId).toBeTruthy();
+      expect(isPlatformDashboardAuthSessionId(id!.authSessionId, SCOPE)).toBe(true);
+    });
+
+    it('不带 actor 的老平台会话同样能被认出来（不回归）', () => {
+      const id = resolve(undefined);
+      expect(isPlatformDashboardAuthSessionId(id!.authSessionId, SCOPE)).toBe(true);
+    });
+
+    it('三种角色 × 有无 actor 六种组合全部可识别', () => {
+      for (const role of ['owner', 'teammate', 'guest'] as const) {
+        for (const actor of ['ou_alice', undefined]) {
+          const id = resolve(actor, role);
+          expect(isPlatformDashboardAuthSessionId(id!.authSessionId, SCOPE), `${role}/${actor}`).toBe(true);
+        }
+      }
+    });
+
+    it('别的机器的 scope 认不出来 —— 解绑吊销不能误伤其它机器的会话', () => {
+      const id = resolve('ou_alice');
+      expect(isPlatformDashboardAuthSessionId(id!.authSessionId, 'scope-other-machine')).toBe(false);
+    });
+
+    it('legacy 与 H5 的 authSessionId 不会被误认成平台身份', () => {
+      expect(isPlatformDashboardAuthSessionId(`legacy-${ACTIVE}`, SCOPE)).toBe(false);
+      expect(isPlatformDashboardAuthSessionId('random-h5-session-id', SCOPE)).toBe(false);
+    });
+
+    it('前缀相同但结构不对的串一律不认（fail closed）', () => {
+      for (const bad of [
+        SCOPE,                              // 只有 scope，没有角色
+        `${SCOPE}:`,                        // 空角色
+        `${SCOPE}:admin`,                   // 不是三种角色之一
+        `${SCOPE}:ou_alice`,                // 有 actor 但没角色
+        `${SCOPE}:ou_alice:admin`,          // 角色非法
+        `${SCOPE}:ou_alice:owner:extra`,    // 段数超了
+        `${SCOPE}-not-a-separator:owner`,   // 前缀只是字面相似
+      ]) {
+        expect(isPlatformDashboardAuthSessionId(bad, SCOPE), bad).toBe(false);
+      }
+    });
   });
 });
 

--- a/test/platform-unbind-revocation.test.ts
+++ b/test/platform-unbind-revocation.test.ts
@@ -5,6 +5,7 @@ import { PreviewInteractionManager } from '../src/dashboard/preview-interaction.
 import { TerminalControlManager } from '../src/dashboard/terminal-control.js';
 import {
   isPlatformDashboardAuthSessionId,
+  platformAuthSessionsToRevoke,
   resolveDashboardIdentity,
 } from '../src/dashboard/request-identity.js';
 
@@ -42,7 +43,15 @@ describe('平台解绑时的协管者会话吊销', () => {
     return id;
   }
 
-  /** dashboard.ts 的四表并集 + 按 scope 筛，与 syncPlatformBindingRevocation 同构。 */
+  /**
+   * 「该吊销哪些会话」直调**生产实现** `platformAuthSessionsToRevoke`
+   *（在 request-identity），吊销动作本身照 dashboard.ts 的写法逐个调
+   * `endDashboardAuthSession` 的等价物（这里就是四个注册表的 end/清理）。
+   *
+   * 刻意不复刻「四表并集 + 筛选」那段算法：此前测试自己抄了一份，于是把生产代码
+   * 改回硬枚举时 5 个用例仍全绿 —— 锁的是复刻品不是生产逻辑（复审实测证伪了我
+   * 原先「改回硬枚举 → 5 个全红」的说法）。现在改回硬枚举会真的红。
+   */
   function revokeOnUnbind(
     scope: string,
     registries: {
@@ -52,22 +61,20 @@ describe('平台解绑时的协管者会话吊销', () => {
       csrf: ControlCsrfTokens;
     },
   ): string[] {
-    const observed = new Set<string>([
-      ...registries.terminalControl.authSessionIds(),
-      ...registries.previewInteraction.authSessionIds(),
-      ...registries.connections.authSessionIds(),
-      ...registries.csrf.authSessionIds(),
+    const toRevoke = platformAuthSessionsToRevoke(scope, [
+      registries.terminalControl,
+      registries.previewInteraction,
+      registries.connections,
+      registries.csrf,
     ]);
-    const revoked: string[] = [];
-    for (const authSessionId of observed) {
-      if (!isPlatformDashboardAuthSessionId(authSessionId, scope)) continue;
-      registries.terminalControl.releaseByAuthSession(authSessionId);
-      registries.previewInteraction.relockAuthSession(authSessionId);
-      registries.connections.closeAuthSession(authSessionId);
-      registries.csrf.revokeAuthSession(authSessionId);
-      revoked.push(authSessionId);
+    // 与 dashboard.ts 的 endDashboardAuthSession 逐字对应的同一组副作用。
+    for (const id of toRevoke) {
+      registries.terminalControl.releaseByAuthSession(id);
+      registries.previewInteraction.relockAuthSession(id);
+      registries.connections.closeAuthSession(id);
+      registries.csrf.revokeAuthSession(id);
     }
-    return revoked;
+    return toRevoke;
   }
 
   function freshRegistries() {

--- a/test/platform-unbind-revocation.test.ts
+++ b/test/platform-unbind-revocation.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { AuthSessionConnectionRegistry } from '../src/dashboard/auth-session-connections.js';
+import { ControlCsrfTokens } from '../src/dashboard/control-csrf.js';
+import { PreviewInteractionManager } from '../src/dashboard/preview-interaction.js';
+import { TerminalControlManager } from '../src/dashboard/terminal-control.js';
+import {
+  isPlatformDashboardAuthSessionId,
+  resolveDashboardIdentity,
+} from '../src/dashboard/request-identity.js';
+
+/**
+ * 解绑吊销（`dashboard.ts:syncPlatformBindingRevocation`）必须扫到**协管者**。
+ *
+ * 原实现硬枚举 `${scope}:owner|teammate|guest` 三个字面量。平台注入
+ * `X-Botmux-Actor` 之后协管者的 authSessionId 变成 `<scope>:<actor>:<role>`，
+ * 三个字面量一个都对不上 —— 于是 `botmux unbind` 之后**协管者已建立的写连接不会
+ * 被断开**，机器已经从平台摘下来了，人还连着。那个函数的注释自己写着「少走一条
+ * 就等于留一扇后窗」，硬枚举正好开了一扇。
+ *
+ * 「有哪些协管者」本进程不可能预先知道（union_id 来自平台），所以正确做法是反向
+ * 枚举：把四个注册表里在册的认证会话取并集，按本机 scope 筛出平台身份。本文件用
+ * 真实的注册表复现这个流程。
+ */
+describe('平台解绑时的协管者会话吊销', () => {
+  const ACTIVE = 'active-management-token';
+  const MACHINE = 'machine-1';
+  const SCOPE = `scope-${MACHINE}`;
+
+  function identityOf(actor: string | undefined, role = 'owner') {
+    const id = resolveDashboardIdentity({
+      legacyCookie: ACTIVE,
+      activeToken: ACTIVE,
+      roleHeader: role,
+      actorHeader: actor,
+      scopesHeader: undefined,
+      platformMachineId: MACHINE,
+      platformActorScope: machineId => `scope-${machineId}`,
+      legacyAuthSessionId: token => `legacy-${token}`,
+      h5: null,
+    });
+    if (!id) throw new Error('identity did not resolve');
+    return id;
+  }
+
+  /** dashboard.ts 的四表并集 + 按 scope 筛，与 syncPlatformBindingRevocation 同构。 */
+  function revokeOnUnbind(
+    scope: string,
+    registries: {
+      terminalControl: TerminalControlManager;
+      previewInteraction: PreviewInteractionManager;
+      connections: AuthSessionConnectionRegistry;
+      csrf: ControlCsrfTokens;
+    },
+  ): string[] {
+    const observed = new Set<string>([
+      ...registries.terminalControl.authSessionIds(),
+      ...registries.previewInteraction.authSessionIds(),
+      ...registries.connections.authSessionIds(),
+      ...registries.csrf.authSessionIds(),
+    ]);
+    const revoked: string[] = [];
+    for (const authSessionId of observed) {
+      if (!isPlatformDashboardAuthSessionId(authSessionId, scope)) continue;
+      registries.terminalControl.releaseByAuthSession(authSessionId);
+      registries.previewInteraction.relockAuthSession(authSessionId);
+      registries.connections.closeAuthSession(authSessionId);
+      registries.csrf.revokeAuthSession(authSessionId);
+      revoked.push(authSessionId);
+    }
+    return revoked;
+  }
+
+  function freshRegistries() {
+    return {
+      terminalControl: new TerminalControlManager({ secret: 'unbind-secret', audit: { append() {} } }),
+      previewInteraction: new PreviewInteractionManager({ audit: { append() {} } }),
+      connections: new AuthSessionConnectionRegistry(),
+      csrf: new ControlCsrfTokens(),
+    };
+  }
+
+  it('三个协管者各自的连接与票据都被吊销 —— 一个都不能漏', () => {
+    const r = freshRegistries();
+    const admins = ['ou_alice', 'ou_bob', 'ou_carol'].map(a => identityOf(a));
+    const closed: string[] = [];
+    for (const id of admins) {
+      // 平台 owner 身份走 registerReadSocket / 长连接 / CSRF 票据这几条路
+      // （terminalCapability='owner' 的 takeover 直接返回 reused，不建租约，
+      //  所以租约表里本来就可能没有它 —— 这正是要取四表并集的原因）。
+      r.terminalControl.registerReadSocket(id.authSessionId, { destroyed: false, destroy() { /* noop */ } } as never);
+      r.connections.register(id.authSessionId, () => { closed.push(id.authSessionId); });
+      r.csrf.mint(id.authSessionId);
+    }
+    expect(r.csrf.size()).toBe(3);
+
+    const revoked = revokeOnUnbind(SCOPE, r);
+
+    expect(revoked.sort()).toEqual(admins.map(a => a.authSessionId).sort());
+    expect(closed.sort()).toEqual(admins.map(a => a.authSessionId).sort());
+    expect(r.csrf.size()).toBe(0);
+    expect(r.connections.authSessionIds()).toEqual([]);
+    expect(r.terminalControl.authSessionIds()).toEqual([]);
+  });
+
+  it('不带 actor 的老平台会话仍被吊销（不回归）', () => {
+    const r = freshRegistries();
+    const legacyPlatform = identityOf(undefined);
+    let closed = false;
+    r.connections.register(legacyPlatform.authSessionId, () => { closed = true; });
+    r.csrf.mint(legacyPlatform.authSessionId);
+
+    expect(revokeOnUnbind(SCOPE, r)).toEqual([legacyPlatform.authSessionId]);
+    expect(closed).toBe(true);
+    expect(r.csrf.size()).toBe(0);
+  });
+
+  it('非平台身份不被误伤：legacy owner 与 H5 会话的连接照旧存活', () => {
+    const r = freshRegistries();
+    const platform = identityOf('ou_alice');
+    let platformClosed = false;
+    let bystanderClosed = false;
+    r.connections.register(platform.authSessionId, () => { platformClosed = true; });
+    r.connections.register(`legacy-${ACTIVE}`, () => { bystanderClosed = true; });
+    r.connections.register('h5-session-abc', () => { bystanderClosed = true; });
+    r.csrf.mint(platform.authSessionId);
+    r.csrf.mint(`legacy-${ACTIVE}`);
+
+    expect(revokeOnUnbind(SCOPE, r)).toEqual([platform.authSessionId]);
+    expect(platformClosed).toBe(true);
+    expect(bystanderClosed).toBe(false);
+    // legacy 的票据还在（它由 token rotation 那条路管，不由解绑管）。
+    expect(r.csrf.size()).toBe(1);
+  });
+
+  it('别的机器的平台会话不被误伤（多机场景）', () => {
+    const r = freshRegistries();
+    const mine = identityOf('ou_alice');
+    const theirs = 'scope-machine-2:ou_alice:owner';
+    let mineClosed = false;
+    let theirsClosed = false;
+    r.connections.register(mine.authSessionId, () => { mineClosed = true; });
+    r.connections.register(theirs, () => { theirsClosed = true; });
+
+    expect(revokeOnUnbind(SCOPE, r)).toEqual([mine.authSessionId]);
+    expect(mineClosed).toBe(true);
+    expect(theirsClosed).toBe(false);
+  });
+
+  it('只在其中一个表里有状态的会话也会被扫到（四表取并集的意义）', () => {
+    const r = freshRegistries();
+    const onlyCsrf = identityOf('ou_dave');
+    const onlySocket = identityOf('ou_erin');
+    r.csrf.mint(onlyCsrf.authSessionId);
+    r.terminalControl.registerReadSocket(
+      onlySocket.authSessionId,
+      { destroyed: false, destroy() { /* noop */ } } as never,
+    );
+
+    expect(revokeOnUnbind(SCOPE, r).sort()).toEqual(
+      [onlyCsrf.authSessionId, onlySocket.authSessionId].sort(),
+    );
+  });
+});


### PR DESCRIPTION
配合中心化平台的「机器协管者」（owner 授权同团队成员访问自己机器的 dashboard，平台侧 MR 另提）。6 个 commit，每个修一件独立的事。

## 为什么

平台身份此前只由「机器 + 角色」构成，userId 长成 `platform:<machineId hash>:owner` —— **不含人**。单 owner 时代无所谓，多人协管后有两个硬后果：

1. **审计分不出人** —— `control-audit` 按 `actor.userId` 记终端接管，三个协管者在日志里长得一模一样。
2. **终端租约互斥失效** —— `terminal-control.ts` 用 `userId + authSessionId` 判「是不是同一个登录」，三人共用同一 userId 会走 `takeover_reused` **静默复用彼此的写租约**，两个人同时往一个终端打字、谁都不知道。

而「让协管者能改配置」又受阻于 `legacyAuthed` 这一个布尔同时守着 settings 与 debug shell。

## 改了什么

| 能力 | 实现 |
|---|---|
| 区分操作者 | 认 `X-Botmux-Actor`，拼进 userId / authSessionId → `platform:<hash>:<union_id>:owner` |
| 管理面与整机控制权分开 | 认 `X-Botmux-Scopes`，`legacyAuthed`（本机 owner 身份）→ 新增 `canManageHost`（管理面能力） |
| 格式只有一个定义点 | `authSessionId` 的构造与识别收进 `request-identity` |

## 权限边界（复审后调整过）

**协管者能做**：开 dashboard、看会话、接管终端打字；勾了 `dashboard:manage` 后加 settings / schedules / groups / **autostart**。

**协管者永不能做**（`legacyAuthed` 独占的 **6 处**硬闸）：
- `debug-terminal`（裸 shell）
- `write-link`（返回**稳定** token）
- `spawn-command`（含凭证的复现命令）
- **`/api/update/run` / `rollback` / `restart`** ← 复审后从 `canManageHost` 收回：它们 `git pull` + 重建 + 重启 daemon，等于改机器上实际运行的代码

`autostart` 两条刻意保留给协管者（开机自启是机器级运营配置，与 settings 同档）。

## 安全处理

| 情况 | 行为 |
|---|---|
| 三个头缺失 / 空 / 数组（重复注入） | 退回本 PR 前行为 —— **老平台、免登录只读完全不受影响** |
| actor 形状异常 | 只接受 `[A-Za-z0-9_-]{1,64}`：冒号会破坏 `a:b:c` 解析、空格与控制字符会污染审计行 |
| `guest` 带 `dashboard:manage` | **不放行**。平台侧一个组合失误不该把只读访客提成配置管理员 |
| 协管者在 URL 上带任意 `?t=` | **不下发 cookie**（见下方 F1） |
| 未绑平台 / 无活跃管理 cookie | 三个头全部无效（直连伪造拿不到平台身份） |

### F1（复审发现的严重漏洞，已修）

`4ee92038` 为让管理面走宽门禁，把活跃 token 代填进 `presentedToken`，但没压掉 `hasTokenParam`。`decideDashboardAuth` 有一条「首次带正确 `?t=` → allow+set-cookie，把 token 回写浏览器」的分支，于是协管者 **`?t=任意值` 就被回吐本机真实管理 token**。

危害不是多一次越权读：那是**长期落盘凭证**，撤销协管授权也不失效；而 `config.dashboard.host` 默认 `0.0.0.0`（非 loopback-only），拿到 token 的人网络够得着 dashboard 端口就能直连本机、绕开平台一切判权。

修法：`hasTokenParam: platformManages ? false : input.hasTokenParam`。协管者本就不需要那条 cookie 引导 —— 他的身份来自平台反代注入的 cookie。

## 测试

- 新增 `test/platform-actor-header.test.ts`（30 个用例）、`test/platform-unbind-revocation.test.ts`（5 个）
- 既有回归：dashboard-auth / debug-terminal / agent-workbench-route / terminal-front-proxy / terminal-write-auth，共 **217 通过 0 失败**
- `tsc --noEmit` 干净

**变异验证**（确认测试会因实现变坏而变红）：

| 变异 | 结果 |
|---|---|
| 退回 `hasTokenParam: input.hasTokenParam`（F1） | 2 个转红 |
| 把平台头写回删掉 | 5 个转红 |
| 弱化剥离的 `continue` | 2 个转红 |
| 解绑识别改回硬枚举三字面量 | **4 个转红** |

> 最后一条此前写的是「5 个全红」，**那是错的**。复审实测指出当时的 `platform-unbind-revocation` 自己复刻了一份「四表并集 + 筛选」、没调生产代码，所以改生产逻辑 0 红。已在 `58323f7b` 把算法抽成纯函数 `platformAuthSessionsToRevoke`、测试改调生产实现，现在改生产代码会真的红（4 个）。

## 未验证

**真机端到端**：需一台绑平台的在线机器 + 平台侧同时部署。测试只覆盖逻辑。

## 上线顺序

**本 PR 需先合、机器升级到含改动的版本，平台侧再放开「改配置」勾选。** 否则老版本机器忽略 `X-Botmux-Scopes`，平台 UI 承诺的权限不生效。

单独合本 PR 是安全的 —— 平台不发这些头时，行为与现在完全一致。

关联：`code.byted.org/botmux/platform` !20（内网）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
