### PR TITLE
fix(doc-comment): 事件被丢弃时在文档里留下可见标记 (#1260)

### DIFF
--- a/src/core/pending-response.ts
+++ b/src/core/pending-response.ts
@@ -8,3 +8,13 @@
 export const RECEIVED_REACTION_EMOJI_TYPE = 'GoGoGo';
 export const SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE = 'Get';
 export const DONE_REACTION_EMOJI_TYPE = 'DONE';
+
+/**
+ * 文档评论里「这条 @ 我没能处理」的可见标记（❌）。
+ *
+ * 和上面三个不同，它不是回合状态指示器，而是**失败信号**：文档评论链路一旦丢弃
+ * 事件，飞书那边不会重投、mention-only 也不进轮询兜底，用户侧只会看到「bot 不理
+ * 我」，与「bot 正在忙」无法区分（doc 会话在飞书完全不可见，只能去 dashboard 翻
+ * terminal）。给触发回复打上这个 emoji，至少让「已丢弃」在文档里是**看得见**的。
+ */
+export const DROPPED_REACTION_EMOJI_TYPE = 'ERROR';

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -461,7 +461,7 @@ export const messages: Record<string, string> = {
   'daemon.doc_mention_notify_title': '📄 Doc @bot trigger notification',
   'daemon.doc_mention_notify_body': 'User {requester} mentioned the bot in doc {token} and triggered a reply.',
   'daemon.doc_dropped_notify_title': '⚠️ Doc comment event not handled',
-  'daemon.doc_dropped_notify_body': "Bot could not read or handle {requester}'s comment event in doc {token}; no reply was produced. If the audit passes, a failure marker will be attempted on that reply.",
+  'daemon.doc_dropped_notify_body': "Bot could not read or handle {requester}'s comment event in doc {token}; no reply was produced. A failure marker will be left on that comment so they know to resend.",
   'daemon.doc_comment_reply_prefix': '↪ Reply to {author}: ',
   'cmd.adopt.already_adopted': 'This topic is already adopting {label} ({pane}).\nClick "Disconnect" on the card first, then run /adopt again (the original CLI is untouched).',
   'cmd.adopt.no_sessions': 'No adoptable CLI session found.',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -460,6 +460,8 @@ export const messages: Record<string, string> = {
   'cmd.vc.replaced': 'Note: this group was also bound to meeting `{meetingNo}`. The old record remains; remove it with `/vc off {meetingNo}` if needed.',
   'daemon.doc_mention_notify_title': '📄 Doc @bot trigger notification',
   'daemon.doc_mention_notify_body': 'User {requester} mentioned the bot in doc {token} and triggered a reply.',
+  'daemon.doc_dropped_notify_title': '⚠️ Doc comment event not handled',
+  'daemon.doc_dropped_notify_body': "Bot could not read or handle {requester}'s comment event in doc {token}; no reply was produced. If the audit passes, a failure marker will be attempted on that reply.",
   'daemon.doc_comment_reply_prefix': '↪ Reply to {author}: ',
   'cmd.adopt.already_adopted': 'This topic is already adopting {label} ({pane}).\nClick "Disconnect" on the card first, then run /adopt again (the original CLI is untouched).',
   'cmd.adopt.no_sessions': 'No adoptable CLI session found.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -460,7 +460,7 @@ export const messages: Record<string, string> = {
   'daemon.doc_mention_notify_title': '📄 文档 @bot 触发通知',
   'daemon.doc_mention_notify_body': '用户 {requester} 在文档 {token} 中 @了机器人，已触发回复。',
   'daemon.doc_dropped_notify_title': '⚠️ 文档评论事件未处理',
-  'daemon.doc_dropped_notify_body': '用户 {requester} 在文档 {token} 中的评论事件，bot 未能读取或处理；未产生回复。审计通过后会尝试在该回复上留下失败标记。',
+  'daemon.doc_dropped_notify_body': '用户 {requester} 在文档 {token} 中的评论事件，bot 未能读取或处理；未产生回复。将在该评论上留下失败标记，提示对方重发。',
   'daemon.doc_comment_reply_prefix': '↪ 回复 {author}：',
   'cmd.adopt.already_adopted': '本话题已接入 {label} ({pane})。\n请先点击卡片上的「断开」按钮，再 /adopt 切换 CLI 会话（原 CLI 不受影响）。',
   'cmd.adopt.no_sessions': '未发现可接入的 CLI 会话',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -459,6 +459,8 @@ export const messages: Record<string, string> = {
   'cmd.vc.replaced': '注意：本群此前还绑定了会议 `{meetingNo}`；旧记录仍保留，可用 `/vc off {meetingNo}` 解除。',
   'daemon.doc_mention_notify_title': '📄 文档 @bot 触发通知',
   'daemon.doc_mention_notify_body': '用户 {requester} 在文档 {token} 中 @了机器人，已触发回复。',
+  'daemon.doc_dropped_notify_title': '⚠️ 文档评论事件未处理',
+  'daemon.doc_dropped_notify_body': '用户 {requester} 在文档 {token} 中的评论事件，bot 未能读取或处理；未产生回复。审计通过后会尝试在该回复上留下失败标记。',
   'daemon.doc_comment_reply_prefix': '↪ 回复 {author}：',
   'cmd.adopt.already_adopted': '本话题已接入 {label} ({pane})。\n请先点击卡片上的「断开」按钮，再 /adopt 切换 CLI 会话（原 CLI 不受影响）。',
   'cmd.adopt.no_sessions': '未发现可接入的 CLI 会话',

--- a/src/im/lark/doc-comment.ts
+++ b/src/im/lark/doc-comment.ts
@@ -885,6 +885,28 @@ export async function addCommentReaction(
   reactionType: string,
   options: DocProviderEffectOptions & { tenantOnly?: boolean } = {},
 ): Promise<string | undefined> {
+  return (await addCommentReactionChecked(larkAppId, file, commentId, replyId, reactionType, options)).reactionId;
+}
+
+/**
+ * 同 {@link addCommentReaction}，但**如实回报服务端结果**。
+ *
+ * 为什么需要：上面那个签名把失败投影成 `undefined`，而飞书官方
+ * `update_reaction` 的响应体是**空对象、不承诺 `reaction_id`** —— 所以
+ * `reactionId ? 成功 : 失败` 会把「code=0 但没带 id」误记成失败。要在日志里
+ * 写真实 outcome，必须在投影掉之前把 `res.code === 0` 留住。
+ *
+ * `ok` 只表示**这次请求本身**成功（HTTP 通了且 code=0），不代表 reaction 一定
+ * 在 UI 上可见（重复 add 的服务端语义未实测）。
+ */
+export async function addCommentReactionChecked(
+  larkAppId: string,
+  file: ResolvedDocFile,
+  commentId: string,
+  replyId: string,
+  reactionType: string,
+  options: DocProviderEffectOptions & { tenantOnly?: boolean } = {},
+): Promise<{ ok: boolean; reactionId?: string }> {
   try {
     const res = await driveApiCall(larkAppId, {
       method: 'POST',
@@ -899,10 +921,12 @@ export async function addCommentReaction(
     if (reactionId) {
       logger.info(`[doc-comment] added reaction=${reactionId} type=${reactionType} on reply=${replyId.slice(0, 12)}`);
     }
-    return reactionId;
+    // 走到这里说明 driveApiCall 没抛（tenantOnly 路径 code!=0 会抛；其余路径
+    // 返回体自带 code）。id 可能为空 —— 官方 schema 不承诺，不能据此判失败。
+    return { ok: res?.code === undefined || res.code === 0, reactionId };
   } catch (err) {
     logger.warn(`[doc-comment] addCommentReaction failed for reply=${replyId.slice(0, 12)}: ${err instanceof Error ? err.message : err}`);
-    return undefined;
+    return { ok: false };
   }
 }
 

--- a/src/im/lark/doc-comment.ts
+++ b/src/im/lark/doc-comment.ts
@@ -182,6 +182,20 @@ interface DriveCallOpts {
   data?: unknown;
   /** true 时禁用 tenant 回退（评论事件订阅必须 user 身份才收得到推送时用）。 */
   userOnly?: boolean;
+  /**
+   * true 时**禁用 user 回退**：只用 tenant（应用身份）写，失败即失败。
+   *
+   * 与 `preferTenant` 的区别是「回退可不可接受」。`preferTenant` 用于**必须落地**
+   * 的写入（发评论），宁可显示成授权用户也要发出去。而有些写入是**持久且带主体
+   * 归属**的 —— 以错误的主体落地比不落地更糟，因为它会以用户自己的名义在文档里
+   * 留下不是用户做的动作。这类调用用 `tenantOnly`。
+   *
+   * 现用于「事件被丢弃」的 ❌ 标记（见 event-dispatcher.ts:markCommentEventDropped）：
+   * 它是**终态**标记、故意不清理，一旦回退 user 就等于在用户自己的评论上以用户
+   * 自己的名义永久挂一个叉。对比 Typing 指示器 —— 那个是成对的、几秒后必被
+   * removeCommentReaction 清掉，所以回退 user 只是短暂误导，可以接受。
+   */
+  tenantOnly?: boolean;
   /** true 时**优先 tenant（应用身份）**，失败再回退 user。用于发评论——这样 bot 的
    *  回复显示为机器人本身，而非授权用户。bot 对该文档无访问权时回退 user 身份保证落地。 */
   preferTenant?: boolean;
@@ -327,6 +341,18 @@ async function driveApiCall(larkAppId: string, opts: DriveCallOpts): Promise<any
   };
 
   if (opts.userOnly) return callUser();
+
+  // 只用应用身份写，绝不回退 user —— 见 tenantOnly 的注释：这类写入是持久且带
+  // 主体归属的，以错误主体落地比不落地更糟。tenant 失败就让它失败，调用方决定
+  // 怎么降级（当前唯一调用方 markCommentEventDropped 是 best-effort 放弃 + 日志）。
+  if (opts.tenantOnly) {
+    await opts.beforeProviderEffect?.();
+    const res = await callTenant();
+    if (res?.code !== 0) {
+      throw new Error(`tenant-only drive call 失败 (${opts.path}): ${res?.msg ?? 'unknown'} (code: ${res?.code})`);
+    }
+    return res;
+  }
 
   // 发评论：优先应用身份（回复显示为 bot），bot 无访问权（抛错或 code!=0）时回退用户身份。
   if (opts.preferTenant) {
@@ -835,7 +861,9 @@ export function chunkCommentText(text: string, max = DOC_COMMENT_MAX_CHARS): str
  * 知道 bot 收到了、正在处理。bot 回复发出后再删掉。
  *
  * 端点：`POST drive/v2/files/{token}/comments/reaction`（v2，评论 reaction 专用）。
- * 优先应用身份（reaction 显示为 bot 加的）。
+ * 默认优先应用身份、失败回退 user（reaction 尽量显示为 bot 加的，但保证落地）。
+ * `options.tenantOnly` 关掉这个回退 —— 用于**不会被清理的终态标记**，那种场景下
+ * 以授权用户名义永久落一个 reaction 比不落更糟（见 DriveCallOpts.tenantOnly）。
  *
  * @returns 新创建的 reaction_id（删除时要用）；失败返回 undefined（不阻塞主流程）。
  */
@@ -845,7 +873,7 @@ export async function addCommentReaction(
   commentId: string,
   replyId: string,
   reactionType: string,
-  options: DocProviderEffectOptions = {},
+  options: DocProviderEffectOptions & { tenantOnly?: boolean } = {},
 ): Promise<string | undefined> {
   try {
     const res = await driveApiCall(larkAppId, {
@@ -853,7 +881,8 @@ export async function addCommentReaction(
       path: `/open-apis/drive/v2/files/${encodeURIComponent(file.fileToken)}/comments/reaction`,
       params: { file_type: file.fileType },
       data: { action: 'add', comment_id: commentId, reply_id: replyId, reaction_type: reactionType },
-      preferTenant: true,
+      // tenantOnly 与 preferTenant 互斥：前者禁用 user 回退，后者允许。
+      ...(options.tenantOnly ? { tenantOnly: true } : { preferTenant: true }),
       beforeProviderEffect: options.beforeProviderEffect,
     });
     const reactionId: string | undefined = res?.data?.reaction_id;

--- a/src/im/lark/doc-comment.ts
+++ b/src/im/lark/doc-comment.ts
@@ -340,6 +340,13 @@ async function driveApiCall(larkAppId: string, opts: DriveCallOpts): Promise<any
     return fetchWithUserToken(brand, userToken, opts);
   };
 
+  // ⚠️ userOnly 与 tenantOnly 是互斥的硬约束，同时传是调用方的逻辑错误。
+  // 不能让它静默走 userOnly —— tenantOnly 的**全部意义**就是禁止 user 身份写入，
+  // 静默降级成 user-only 恰好是它要防的那件事（错误主体的持久写入）。宁可炸。
+  if (opts.userOnly && opts.tenantOnly) {
+    throw new Error(`driveApiCall: userOnly 与 tenantOnly 互斥，不能同时指定 (${opts.path})`);
+  }
+
   if (opts.userOnly) return callUser();
 
   // 只用应用身份写，绝不回退 user —— 见 tenantOnly 的注释：这类写入是持久且带
@@ -433,6 +440,9 @@ async function driveApiCall(larkAppId: string, opts: DriveCallOpts): Promise<any
   }
   return tenantResult;
 }
+
+/** 仅供测试：直接驱动身份选择逻辑，验证互斥约束等不经由具体端点的行为。 */
+export const __testOnly_driveApiCall = driveApiCall;
 
 async function fetchWithUserToken(brand: Brand, userToken: string, opts: DriveCallOpts): Promise<any> {
   const url = `${larkHosts(brand).openApi}${opts.path}${buildQuery(opts.params)}`;

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -25,7 +25,7 @@ import { isPlatformTeamBot, isPlatformHallChat, isPlatformTeamMember } from '../
 import { getBotUnionId, recordBotUnionId, recordBotUnionIdFromMentions } from '../../services/bot-union-ids-store.js';
 import { getDocSubscription, putDocSubscription, removeDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
 import { wasPendingReviewNotified, markPendingReviewNotified } from '../../services/under-review-notify-store.js';
-import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed, BOT_REPLY_SENTINEL, addCommentReaction } from './doc-comment.js';
+import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed, BOT_REPLY_SENTINEL, addCommentReactionChecked } from './doc-comment.js';
 import {
   BOTMUX_REQUIRED_SCOPES,
   DOC_FEATURE_SCOPES,
@@ -3067,49 +3067,117 @@ function handleVcMeetingPushEventAckSafe(
  *
  * 只在**明确知道该怪谁**、且非预期的丢弃点上打：
  *   • 拉不到评论内容 / 触发回复不在拉到的回复里 —— 都是我们这边没读到用户说了啥
- * **不打**的场景：自触发过滤（那是 bot 自己的回复）、mention-only 未 @ 本 bot
- * （压根不该触发，打了反而在别人的评论上留噪音）、空正文（用户确实没说话）。
+ *   • 纯 @bot 无文本正文（elementsToText 只拼 text_run，丢掉 person）
+ * **不打**的场景：自触发（bot 自己的回复）、mention-only 未 @ 本 bot（压根不该
+ * 触发，打了反而在别人的评论上留噪音）、'all' 模式下真正没 @ 谁的空评论。
  *
- * best-effort：`addCommentReaction` 自己吞异常返回 undefined，这里再兜一层，
- * 绝不让「打标记失败」影响丢弃路径本身（那已经是失败路径了）。
+ * 顺序是**自触发拦截 → 审计门 → tenant-only 写入**：先挡掉自己的事件，免得为它
+ * 去打扰 owner；审计通过后才允许产生 provider-visible 效果。
+ *
+ * best-effort：内部再兜一层 try/catch，绝不让「打标记失败」影响丢弃路径本身
+ * （那已经是失败路径了）。返回值如实回报结果，调用方据此记日志。
  */
+/**
+ * 审计硬门：非 owner 触发时，必须**成功通知 owner** 才允许对外产生可见效果。
+ * owner 无法感知 = 越权，一律拒绝并回滚本次 auto-sub。owner 本人触发直接放行。
+ *
+ * 抽成 helper 是为了让「回复」和「失败标记」共用同一套规则 —— 两者都是
+ * provider-visible 的外部写入，规则分叉迟早会让其中一条悄悄绕过审计。
+ *
+ * `textSummary` 是通知正文里给 owner 看的摘要。**它可以不是评论正文**：失败
+ * 路径根本读不到正文，此时传一句说明（「评论正文读取失败…」）即可，不能因为
+ * 「构造不出摘要」就跳过审计。
+ *
+ * @returns true = 已授权（owner 本人，或通知成功）；false = 拒绝，调用方必须
+ *          立刻 return，且 auto-sub 已在这里回滚。
+ */
+async function passesDocCommentAuditGate(
+  larkAppId: string,
+  fileToken: string,
+  requesterOpenId: string | undefined,
+  textSummary: string,
+  rollbackAutoSub: () => void,
+): Promise<boolean> {
+  const ownerOpenId = getOwnerOpenId(larkAppId);
+  if (ownerOpenId && requesterOpenId && requesterOpenId === ownerOpenId) return true;
+
+  if (!ownerOpenId) {
+    logger.warn(`[doc-comment] non-owner @mention but no ownerOpenId configured — rejecting (audit gate) file=${fileToken.slice(0, 12)} requester=${requesterOpenId?.slice(0, 12) || '?'}`);
+    rollbackAutoSub();
+    return false;
+  }
+  try {
+    const loc = localeForBot(larkAppId);
+    const requesterName = requesterOpenId?.slice(0, 12) || '?';
+    const notifyText = [
+      t('daemon.doc_mention_notify_title', undefined, loc),
+      '',
+      t('daemon.doc_mention_notify_body', { requester: requesterName, token: fileToken.slice(0, 12) }, loc),
+      '',
+      `📄 \`${fileToken}\``,
+      `💬 ${textSummary.slice(0, 200)}${textSummary.length > 200 ? '…' : ''}`,
+    ].join('\n');
+    await sendUserMessage(larkAppId, ownerOpenId, notifyText);
+    return true;
+  } catch (e) {
+    logger.warn(`[doc-comment] non-owner @mention but owner notification failed — rejecting (audit gate) file=${fileToken.slice(0, 12)} requester=${requesterOpenId?.slice(0, 12) || '?'} err=${e instanceof Error ? e.message : String(e)}`);
+    rollbackAutoSub();
+    return false;
+  }
+}
+
+export const __testOnly_passesDocCommentAuditGate = passesDocCommentAuditGate;
+
+/**
+ * 打失败标记的真实结果。**日志必须记这个，不能在调用前自己猜** —— 「模式命中」
+ * 只说明有资格尝试，离真的打上还隔着审计门、自触发拦截和 tenant 请求本身。
+ * 记错了会让排障的人以为「打了但飞书没渲染」，正好和加这个字段的目的相反。
+ */
+type DroppedSignalOutcome =
+  | 'marked'           // 真的打上了
+  | 'no-reply-id'      // 事件没带 reply_id，无处可打
+  | 'self-triggered'   // 触发者是 bot 自己（best-effort 识别）
+  | 'audit-rejected'   // 未过审计硬门（非 owner 且通知 owner 失败 / owner 未配置）
+  | 'reaction-failed'; // 审计通过了，但 tenant 请求失败
+
 async function markCommentEventDropped(
   larkAppId: string,
   file: { fileToken: string; fileType: string },
   commentId: string,
   replyId: string | undefined,
   requesterOpenId: string | undefined,
-): Promise<void> {
+  auditSummary: string,
+  rollbackAutoSub: () => void,
+): Promise<DroppedSignalOutcome> {
   // reply_id 缺失时无处可打：reaction 端点要求 comment_id + reply_id 两者齐全。
-  if (!replyId) return;
+  if (!replyId) return 'no-reply-id';
 
-  // ⚠️ 审计硬门：打标记是 **provider-visible 的持久外部写入**，不是内部日志，
-  // 必须受和「回复」同一套审计约束 —— 现有不变量是「非 owner 触发时，owner
-  // 无法感知 = 越权」。但这些丢弃点全都在下面那道审计门**之前**，而且前两处
-  // 连评论正文都没读到，构造不出审计门要发的通知（通知正文含 text 摘要）。
-  // 所以这里取**保守侧**：只有 owner 本人触发才打标记，非 owner 一律只记日志。
-  //
-  // 代价是非 owner 触发时用户仍然零感知 —— 但那是 #1260 的既有症状，
-  // 而越权留下一个绕过审计的永久外部写入是**新引入**的问题，孰轻孰重很清楚。
-  // 对比 Typing：它在 handleDocComment 入场后才加，而入场发生在审计门之后，
-  // 所以它本来就不存在这个绕过，不需要跟着改。
-  const ownerOpenId = getOwnerOpenId(larkAppId);
-  if (!ownerOpenId || !requesterOpenId || requesterOpenId !== ownerOpenId) {
-    logger.info(`[doc-comment] dropped-signal skipped (audit gate): 非 owner 触发不打标记 comment=${commentId.slice(0, 12)} requester=${requesterOpenId?.slice(0, 12) || '?'}`);
-    return;
-  }
-
-  // ⚠️ 自触发过滤：正常那道（`trigger.userId === selfBotOpenId` 等三重保险）在
-  // 下面，前两个丢弃点**跑在它之前**，所以必须在这里自己挡一次，否则 bot 会给
-  // 自己的回复打 ❌。缺正文时可用的两个信号：
+  // ⚠️ 自触发拦截要放在审计门**之前**：给自己打标记本来就不该发生，没必要为它
+  // 去打扰 owner。正常那道 self-filter（trigger.userId 等三重保险）在下游，
+  // 前两个丢弃点跑在它之前，所以这里得自己挡一次。缺正文时可用的两个信号：
   //   ① 事件操作者就是本 bot（应用身份发的评论）
   //   ② reply_id 在本进程「bot 创建过」的集合里（用户身份发的评论，作者分不出）
-  // 信号 ② 尤其关键：bot 回退 user 身份发评论时作者 = 授权用户 = owner，
-  // 恰好**穿过上面那道 owner 审计门** —— 只靠审计门挡不住这种自标。
+  // 信号 ② 不可省：bot 回退 user 身份发评论时作者 = 授权用户 = owner，
+  // 恰好**穿过**下面那道 owner 审计门 —— 只靠审计门挡不住这种自标。
+  // 注意这只是 best-effort：authored set 是进程内内存，重启即失效；
+  // hasBotSentinel 那道要正文，这里没有。不宣称密封。
   const selfBotOpenId = getBot(larkAppId).botOpenId;
   if ((selfBotOpenId && requesterOpenId === selfBotOpenId) || isBotAuthoredReply(replyId)) {
     logger.debug(`[doc-comment] dropped-signal skipped: 触发者是 bot 自己 comment=${commentId.slice(0, 12)} reply=${replyId.slice(0, 12)}`);
-    return;
+    return 'self-triggered';
+  }
+
+  // ⚠️ 审计硬门：打标记是 **provider-visible 的持久外部写入**，不是内部日志，
+  // 必须和「回复」受同一套约束 —— 非 owner 触发时 owner 无法感知 = 越权。
+  // 这些丢弃点全在下游那道门之前，所以在这里显式过一次同一个 helper。
+  //
+  // 关键：**不能因为「读不到正文、构造不出摘要」就跳过审计**。摘要不必是评论
+  // 正文，失败路径传一句说明即可（见调用方传的 auditSummary）。也不能拿
+  // 「本次是否新建了 auto-sub」当授权判据 —— 历史脏状态和并发窗口都会让
+  // 未审计的订阅看起来像既有授权。
+  if (!await passesDocCommentAuditGate(larkAppId, file.fileToken, requesterOpenId, auditSummary, rollbackAutoSub)) {
+    logger.info(`[doc-comment] dropped-signal skipped (audit gate): comment=${commentId.slice(0, 12)} requester=${requesterOpenId?.slice(0, 12) || '?'}`);
+    return 'audit-rejected';
   }
 
   try {
@@ -3119,9 +3187,13 @@ async function markCommentEventDropped(
     // 比没有标记更糟，所以 tenant 不行就放弃（下面 catch 里只记日志）。
     // 对比同文件 Typing 指示器：那个成对、几秒后必被 removeCommentReaction 清掉，
     // 回退 user 只是短暂误导，故仍用 preferTenant，本 PR 不动它。
-    await addCommentReaction(larkAppId, file, commentId, replyId, DROPPED_REACTION_EMOJI_TYPE, { tenantOnly: true });
+    const { ok } = await addCommentReactionChecked(larkAppId, file, commentId, replyId, DROPPED_REACTION_EMOJI_TYPE, { tenantOnly: true });
+    // ⚠️ 不能用 reactionId 是否存在判成败：官方 schema 的响应体是空对象、
+    // 不承诺带 id，那样会把 code=0 的成功记成失败。只信 ok。
+    return ok ? 'marked' : 'reaction-failed';
   } catch (err) {
     logger.debug(`[doc-comment] failed to mark dropped event on reply=${replyId.slice(0, 12)}: ${err instanceof Error ? err.message : err}`);
+    return 'reaction-failed';
   }
 }
 
@@ -3169,6 +3241,15 @@ async function processCommentEvent(
     logger.info(`[doc-comment] auto-subscribed file=${fileToken.slice(0, 12)} by @mention (mention-only${mappedDir ? `, wd=${mappedDir}` : ''}, anchor=doc:${fileToken.slice(0, 12)}, requester=${operatorOpenId?.slice(0, 12) || '?'})`);
   }
 
+  // ⚠️ 回滚能力必须在**所有**早退路径之前就绪。auto-sub 是先建占位、后由审计门
+  // 决定去留的；下面几个丢弃点（拉不到评论 / 触发回复不在回复里 / 纯 @bot 无正文）
+  // 都在原审计门之前 return，若不在这里备好回滚，陌生人一次触发就会留下一条
+  // **owner 完全不知情**的订阅记录，且不会被任何人清掉。
+  // 注意反过来也不成立：不能拿「本次没新建 auto-sub」当「owner 曾授权」的证据 ——
+  // 历史脏记录（旧版本留下的未审计订阅）和并发窗口（事件 A 刚 put、事件 B 就读到）
+  // 都会让未授权的订阅看起来像既有授权。授权判据只有审计门本身。
+  const rollbackAutoSub = () => { if (autoCreatedSub) removeDocSubscription(config.session.dataDir, larkAppId, fileToken); };
+
   // 关掉 open_id 启动竞态：probeBotOpenId 在启动时 fire-and-forget，若评论事件
   // 在该窗口内到达，下面 mention-only 闸 / 自触发过滤会拿到 undefined 的 botOpenId
   // → 合法的 @bot 评论被误丢（事件已被 ACK，飞书不会重投，@ 永久丢失）。await
@@ -3188,7 +3269,13 @@ async function processCommentEvent(
     // is_mentioned 放行」的警告不冲突 —— 那条警告说的是 true 不代表 @ 的是本 bot。
     // 'all' 模式不收窄：那种模式不 @ 也该触发，拉不到就是真丢了。
     if (sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned) {
-      await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId, parsed.operatorOpenId);
+      const outcome = await markCommentEventDropped(
+        larkAppId, { fileToken, fileType: sub.fileType }, commentId,
+        parsed.replyId, parsed.operatorOpenId,
+        '评论正文读取失败，bot 未处理该条 @，准备留下失败标记',
+        rollbackAutoSub,
+      );
+      logger.info(`[doc-comment] dropped-signal outcome=${outcome} (取不到评论内容) comment=${commentId.slice(0, 12)}`);
     }
     return;
   }
@@ -3202,7 +3289,13 @@ async function processCommentEvent(
   // @ 判定和自触发过滤也全基于错误的回复。宁可丢这一条并告警，也不能拿错的顶上。
   if (!trigger) {
     logger.warn(`[doc-comment] event dropped: 触发回复 ${parsed.replyId?.slice(0, 12)} 不在拉到的 ${comment.replies.length} 条回复里 (comment=${commentId.slice(0, 12)} truncated=${comment.hasMoreReplies === true}) — 回复串可能未补全`);
-    await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId, parsed.operatorOpenId);
+    const outcome = await markCommentEventDropped(
+      larkAppId, { fileToken, fileType: sub.fileType }, commentId,
+      parsed.replyId, parsed.operatorOpenId,
+      '评论回复串未能补全，bot 读不到这条 @ 的正文，准备留下失败标记',
+      rollbackAutoSub,
+    );
+    logger.info(`[doc-comment] dropped-signal outcome=${outcome} (触发回复不在拉到的回复里) comment=${commentId.slice(0, 12)}`);
     return;
   }
   const triggerIndex = Math.max(0, comment.replies.indexOf(trigger));
@@ -3233,10 +3326,20 @@ async function processCommentEvent(
     // mention-only 说明**确认 @ 了本 bot**，噪音风险已排除，该打；
     // 'all' 模式下没 @ 谁的空评论是真的「没说话」，只记日志不打，免得把文档里
     // 所有无正文评论统一标成错误。
-    const mentionedSelf = sub.commentTriggerMode === 'mention-only';
-    logger.info(`[doc-comment] event dropped: 触发回复无文本正文 (comment=${commentId.slice(0, 12)} mode=${sub.commentTriggerMode} mentions=${trigger.mentions.length} marked=${mentionedSelf}) — 纯 @bot 无正文也会落到这里`);
-    if (mentionedSelf) {
-      await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, trigger.replyId || parsed.replyId, parsed.operatorOpenId);
+    //
+    // ⚠️ 这里只能判「有没有资格尝试」（markEligible），**不能**写成 marked ——
+    // 离真的打上还隔着审计门、自触发拦截和 tenant 请求，任一不过都不会打。
+    // 真实结果由 helper 返回后单独记，否则排障的人会以为「打了但飞书没渲染」。
+    const markEligible = sub.commentTriggerMode === 'mention-only';
+    logger.info(`[doc-comment] event dropped: 触发回复无文本正文 (comment=${commentId.slice(0, 12)} mode=${sub.commentTriggerMode} mentions=${trigger.mentions.length} markEligible=${markEligible}) — 纯 @bot 无正文也会落到这里`);
+    if (markEligible) {
+      const outcome = await markCommentEventDropped(
+        larkAppId, { fileToken, fileType: sub.fileType }, commentId,
+        trigger.replyId || parsed.replyId, parsed.operatorOpenId,
+        '纯 @bot，无文本正文，bot 未处理，准备留下失败标记',
+        rollbackAutoSub,
+      );
+      logger.info(`[doc-comment] dropped-signal outcome=${outcome} (纯 @bot 无正文) comment=${commentId.slice(0, 12)}`);
     }
     return;
   }
@@ -3244,34 +3347,9 @@ async function processCommentEvent(
   // 审计硬门：非 owner @bot 触发时，必须成功通知 owner 才允许回复。
   // 通知失败 = owner 无法感知 = 越权，直接拒绝响应并回滚 auto-sub。
   // （owner 自己触发的不通知，直接放行。）
-  const ownerOpenId = getOwnerOpenId(larkAppId);
-  const requesterOpenId = parsed.operatorOpenId;
-  const isOwnerTrigger = ownerOpenId && requesterOpenId && requesterOpenId === ownerOpenId;
-  if (!isOwnerTrigger) {
-    const rollbackAutoSub = () => { if (autoCreatedSub) removeDocSubscription(config.session.dataDir, larkAppId, fileToken); };
-    if (!ownerOpenId) {
-      logger.warn(`[doc-comment] non-owner @mention but no ownerOpenId configured — rejecting (audit gate) file=${fileToken.slice(0, 12)} requester=${requesterOpenId?.slice(0, 12) || '?'}`);
-      rollbackAutoSub();
-      return;
-    }
-    try {
-      const loc = localeForBot(larkAppId);
-      const requesterName = requesterOpenId?.slice(0, 12) || '?';
-      const notifyText = [
-        t('daemon.doc_mention_notify_title', undefined, loc),
-        '',
-        t('daemon.doc_mention_notify_body', { requester: requesterName, token: fileToken.slice(0, 12) }, loc),
-        '',
-        `📄 \`${fileToken}\``,
-        `💬 ${text.slice(0, 200)}${text.length > 200 ? '…' : ''}`,
-      ].join('\n');
-      await sendUserMessage(larkAppId, ownerOpenId, notifyText);
-    } catch (e) {
-      logger.warn(`[doc-comment] non-owner @mention but owner notification failed — rejecting (audit gate) file=${fileToken.slice(0, 12)} requester=${requesterOpenId?.slice(0, 12) || '?'} err=${e instanceof Error ? e.message : String(e)}`);
-      rollbackAutoSub();
-      return;
-    }
-  }
+  // 走同一个 helper —— 「回复」和「失败标记」共用一套规则，规则分叉迟早会让
+  // 其中一条悄悄绕过审计（本 PR 就险些如此）。这里传的是真实评论正文摘要。
+  if (!await passesDocCommentAuditGate(larkAppId, fileToken, parsed.operatorOpenId, text, rollbackAutoSub)) return;
 
   logger.info(`[doc-comment] dispatch file=${fileToken.slice(0, 12)} comment=${commentId.slice(0, 12)} mode=${sub.commentTriggerMode} → session anchor=${sub.sessionAnchor.slice(0, 12)}`);
   await handlers.handleDocComment({

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -3167,7 +3167,14 @@ async function markCommentEventDropped(
   // 恰好**穿过**下面那道 owner 审计门 —— 只靠审计门挡不住这种自标。
   // 注意这只是 best-effort：authored set 是进程内内存，重启即失效；
   // hasBotSentinel 那道要正文，这里没有。不宣称密封。
-  const selfBotOpenId = getBot(larkAppId).botOpenId;
+  // getBot 抛错时不能让 rollback 被跳过（占位订阅会残留），故取值也包进容错：
+  // 拿不到 open_id 就退化成只靠 isBotAuthoredReply 这一路信号。
+  let selfBotOpenId: string | undefined;
+  try {
+    selfBotOpenId = getBot(larkAppId).botOpenId;
+  } catch {
+    selfBotOpenId = undefined;
+  }
   if ((selfBotOpenId && requesterOpenId === selfBotOpenId) || isBotAuthoredReply(replyId)) {
     logger.debug(`[doc-comment] dropped-signal skipped: 触发者是 bot 自己 comment=${commentId.slice(0, 12)} reply=${replyId.slice(0, 12)}`);
     rollbackAutoSub();
@@ -3257,12 +3264,22 @@ async function processCommentEvent(
   // 都会让未授权的订阅看起来像既有授权。授权判据只有审计门本身。
   const rollbackAutoSub = () => { if (autoCreatedSub) removeDocSubscription(config.session.dataDir, larkAppId, fileToken); };
 
-  // 「这条事件**可能**与本 bot 有关」—— 在读不到评论正文时唯一能用的收窄。
-  // mention-only 订阅下该文档的**所有**评论事件都会推给我们，`is_mentioned`
-  // 为 false 说明这条评论里一个 @ 都没有，肯定不是找 bot 的。注意这是用它
-  // **收紧**，与「不能用 is_mentioned 放行」的既有警告不冲突 —— 那条警告说的是
-  // true 不代表 @ 的是本 bot。'all' 模式不收窄：不 @ 也该触发。
-  const mayConcernThisBot = sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned === true;
+  // 「这条事件**可能**与本 bot 有关，且丢了就真的没了」—— 读不到评论正文时唯一
+  // 能用的收窄。两个条件都必须满足才允许打那个**终态、不清理**的 ❌：
+  //
+  //  ① 只在 mention-only 下打。这是唯一没有兜底的模式：poller
+  //     （daemon.ts:pollWatchedDocComments）只轮 `commentTriggerMode === 'all'`，
+  //     且直接调 handleDocComment、不经过本函数。所以 'all' 恰恰**有**轮询兜底
+  //     —— push 链路这次拉取失败的评论，下一轮 poll 很可能被正常处理，而 ❌ 是
+  //     终态、不会被摘掉，结果就是永久挂在一条根本没丢的评论上。
+  //     （早先注释写的「'all' 拉不到就是真丢了」是反的，PR 描述里「不进轮询 ⇒
+  //     没兜底 ⇒ 终点」那条论证**只对 mention-only 成立**。）
+  //  ② `is_mentioned` 为 false 说明这条评论里一个 @ 都没有，肯定不是找 bot 的。
+  //     注意这是用它**收紧**，与「不能用 is_mentioned 放行」的既有警告不冲突
+  //     —— 那条警告说的是 true 不代表 @ 的是本 bot。
+  //
+  // 这样三个打点的闸口就一致了（第三个打点用的 markEligible 同样只认 mention-only）。
+  const mayConcernThisBot = sub.commentTriggerMode === 'mention-only' && parsed.isMentioned === true;
 
   // 关掉 open_id 启动竞态：probeBotOpenId 在启动时 fire-and-forget，若评论事件
   // 在该窗口内到达，下面 mention-only 闸 / 自触发过滤会拿到 undefined 的 botOpenId

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -3097,6 +3097,7 @@ async function passesDocCommentAuditGate(
   requesterOpenId: string | undefined,
   textSummary: string,
   rollbackAutoSub: () => void,
+  kind: 'reply' | 'dropped-signal' = 'reply',
 ): Promise<boolean> {
   const ownerOpenId = getOwnerOpenId(larkAppId);
   if (ownerOpenId && requesterOpenId && requesterOpenId === ownerOpenId) return true;
@@ -3110,9 +3111,9 @@ async function passesDocCommentAuditGate(
     const loc = localeForBot(larkAppId);
     const requesterName = requesterOpenId?.slice(0, 12) || '?';
     const notifyText = [
-      t('daemon.doc_mention_notify_title', undefined, loc),
+      t(kind === 'reply' ? 'daemon.doc_mention_notify_title' : 'daemon.doc_dropped_notify_title', undefined, loc),
       '',
-      t('daemon.doc_mention_notify_body', { requester: requesterName, token: fileToken.slice(0, 12) }, loc),
+      t(kind === 'reply' ? 'daemon.doc_mention_notify_body' : 'daemon.doc_dropped_notify_body', { requester: requesterName, token: fileToken.slice(0, 12) }, loc),
       '',
       `📄 \`${fileToken}\``,
       `💬 ${textSummary.slice(0, 200)}${textSummary.length > 200 ? '…' : ''}`,
@@ -3150,7 +3151,12 @@ async function markCommentEventDropped(
   rollbackAutoSub: () => void,
 ): Promise<DroppedSignalOutcome> {
   // reply_id 缺失时无处可打：reaction 端点要求 comment_id + reply_id 两者齐全。
-  if (!replyId) return 'no-reply-id';
+  // 这条事件到此为止且从未过审计，auto-sub 占位必须回滚 —— 否则 malformed /
+  // 缺字段的事件也能留下一条 owner 不知情的订阅。下面 self-triggered 同理。
+  if (!replyId) {
+    rollbackAutoSub();
+    return 'no-reply-id';
+  }
 
   // ⚠️ 自触发拦截要放在审计门**之前**：给自己打标记本来就不该发生，没必要为它
   // 去打扰 owner。正常那道 self-filter（trigger.userId 等三重保险）在下游，
@@ -3164,6 +3170,7 @@ async function markCommentEventDropped(
   const selfBotOpenId = getBot(larkAppId).botOpenId;
   if ((selfBotOpenId && requesterOpenId === selfBotOpenId) || isBotAuthoredReply(replyId)) {
     logger.debug(`[doc-comment] dropped-signal skipped: 触发者是 bot 自己 comment=${commentId.slice(0, 12)} reply=${replyId.slice(0, 12)}`);
+    rollbackAutoSub();
     return 'self-triggered';
   }
 
@@ -3175,7 +3182,7 @@ async function markCommentEventDropped(
   // 正文，失败路径传一句说明即可（见调用方传的 auditSummary）。也不能拿
   // 「本次是否新建了 auto-sub」当授权判据 —— 历史脏状态和并发窗口都会让
   // 未审计的订阅看起来像既有授权。
-  if (!await passesDocCommentAuditGate(larkAppId, file.fileToken, requesterOpenId, auditSummary, rollbackAutoSub)) {
+  if (!await passesDocCommentAuditGate(larkAppId, file.fileToken, requesterOpenId, auditSummary, rollbackAutoSub, 'dropped-signal')) {
     logger.info(`[doc-comment] dropped-signal skipped (audit gate): comment=${commentId.slice(0, 12)} requester=${requesterOpenId?.slice(0, 12) || '?'}`);
     return 'audit-rejected';
   }
@@ -3250,6 +3257,13 @@ async function processCommentEvent(
   // 都会让未授权的订阅看起来像既有授权。授权判据只有审计门本身。
   const rollbackAutoSub = () => { if (autoCreatedSub) removeDocSubscription(config.session.dataDir, larkAppId, fileToken); };
 
+  // 「这条事件**可能**与本 bot 有关」—— 在读不到评论正文时唯一能用的收窄。
+  // mention-only 订阅下该文档的**所有**评论事件都会推给我们，`is_mentioned`
+  // 为 false 说明这条评论里一个 @ 都没有，肯定不是找 bot 的。注意这是用它
+  // **收紧**，与「不能用 is_mentioned 放行」的既有警告不冲突 —— 那条警告说的是
+  // true 不代表 @ 的是本 bot。'all' 模式不收窄：不 @ 也该触发。
+  const mayConcernThisBot = sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned === true;
+
   // 关掉 open_id 启动竞态：probeBotOpenId 在启动时 fire-and-forget，若评论事件
   // 在该窗口内到达，下面 mention-only 闸 / 自触发过滤会拿到 undefined 的 botOpenId
   // → 合法的 @bot 评论被误丢（事件已被 ACK，飞书不会重投，@ 永久丢失）。await
@@ -3268,7 +3282,7 @@ async function processCommentEvent(
     // 没有，肯定不是找 bot 的。注意这里是用它**收紧**，与代码里「不能用
     // is_mentioned 放行」的警告不冲突 —— 那条警告说的是 true 不代表 @ 的是本 bot。
     // 'all' 模式不收窄：那种模式不 @ 也该触发，拉不到就是真丢了。
-    if (sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned) {
+    if (mayConcernThisBot) {
       const outcome = await markCommentEventDropped(
         larkAppId, { fileToken, fileType: sub.fileType }, commentId,
         parsed.replyId, parsed.operatorOpenId,
@@ -3276,6 +3290,9 @@ async function processCommentEvent(
         rollbackAutoSub,
       );
       logger.info(`[doc-comment] dropped-signal outcome=${outcome} (取不到评论内容) comment=${commentId.slice(0, 12)}`);
+    } else {
+      // 没打标记 = 从未过审计，auto-sub 占位必须回滚（同 !trigger 分支）。
+      rollbackAutoSub();
     }
     return;
   }
@@ -3289,13 +3306,22 @@ async function processCommentEvent(
   // @ 判定和自触发过滤也全基于错误的回复。宁可丢这一条并告警，也不能拿错的顶上。
   if (!trigger) {
     logger.warn(`[doc-comment] event dropped: 触发回复 ${parsed.replyId?.slice(0, 12)} 不在拉到的 ${comment.replies.length} 条回复里 (comment=${commentId.slice(0, 12)} truncated=${comment.hasMoreReplies === true}) — 回复串可能未补全`);
-    const outcome = await markCommentEventDropped(
-      larkAppId, { fileToken, fileType: sub.fileType }, commentId,
-      parsed.replyId, parsed.operatorOpenId,
-      '评论回复串未能补全，bot 读不到这条 @ 的正文，准备留下失败标记',
-      rollbackAutoSub,
-    );
-    logger.info(`[doc-comment] dropped-signal outcome=${outcome} (触发回复不在拉到的回复里) comment=${commentId.slice(0, 12)}`);
+    // ⚠️ 和第一个打点同样要收窄。`trigger` 缺失只证明**回复数据不完整**，
+    // 不证明这条回复是冲 bot 来的 —— 已订阅文档下别人的普通回复同样会推事件，
+    // 只要那条 reply 恰好没被拉到就会走到这里。不收窄就会在别人的评论上留 ❌。
+    if (mayConcernThisBot) {
+      const outcome = await markCommentEventDropped(
+        larkAppId, { fileToken, fileType: sub.fileType }, commentId,
+        parsed.replyId, parsed.operatorOpenId,
+        '评论回复串未能补全，bot 读不到这条评论的正文，准备留下失败标记',
+        rollbackAutoSub,
+      );
+      logger.info(`[doc-comment] dropped-signal outcome=${outcome} (触发回复不在拉到的回复里) comment=${commentId.slice(0, 12)}`);
+    } else {
+      // 没打标记 = 这条事件从未过审计。auto-sub 是这次事件建的占位，必须回滚，
+      // 否则陌生人的一条无关回复就留下 owner 不知情的订阅。
+      rollbackAutoSub();
+    }
     return;
   }
   const triggerIndex = Math.max(0, comment.replies.indexOf(trigger));
@@ -3304,7 +3330,11 @@ async function processCommentEvent(
   //    用户身份（作者=授权用户，无法靠作者区分）发出。三重保险：①作者==本 bot
   //    ②reply_id 在 bot 创建集合 ③文本含隐形哨兵。任一命中即跳过。
   const selfBotOpenId = getBot(larkAppId).botOpenId;
-  if ((selfBotOpenId && trigger.userId === selfBotOpenId) || isBotAuthoredReply(trigger.replyId) || hasBotSentinel(trigger.text)) return;
+  if ((selfBotOpenId && trigger.userId === selfBotOpenId) || isBotAuthoredReply(trigger.replyId) || hasBotSentinel(trigger.text)) {
+    // 这条事件不会走到审计门，本次 auto-sub 占位必须回滚（同下面 mention gate）。
+    rollbackAutoSub();
+    return;
+  }
 
   // 4) 触发范围闸（mention-only 仅当评论真的 @ 了本 bot 才触发）。
   //    ⚠️ 必须以拉到的评论正文 @person(open_id) 列表为准，不能信事件自带的
@@ -3312,6 +3342,7 @@ async function processCommentEvent(
   //    「@ 同事的评论也被误触发」。详见 commentTriggerAllowed 注释。
   if (!commentTriggerAllowed(sub.commentTriggerMode, trigger.mentions, selfBotOpenId)) {
     logger.info(`[doc-comment] event dropped: mention-only 但未 @ 本 bot (comment=${commentId.slice(0, 12)} isMentioned=${parsed.isMentioned} mentions=${trigger.mentions.length} self=${selfBotOpenId ? selfBotOpenId.slice(0, 10) : '?'})`);
+    rollbackAutoSub();
     return;
   }
 
@@ -3340,6 +3371,8 @@ async function processCommentEvent(
         rollbackAutoSub,
       );
       logger.info(`[doc-comment] dropped-signal outcome=${outcome} (纯 @bot 无正文) comment=${commentId.slice(0, 12)}`);
+    } else {
+      rollbackAutoSub();
     }
     return;
   }

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -3082,7 +3082,13 @@ async function markCommentEventDropped(
   // reply_id 缺失时无处可打：reaction 端点要求 comment_id + reply_id 两者齐全。
   if (!replyId) return;
   try {
-    await addCommentReaction(larkAppId, file, commentId, replyId, DROPPED_REACTION_EMOJI_TYPE);
+    // ⚠️ tenantOnly：**绝不能**回退 user 身份。这个 ❌ 是终态标记、故意不清理，
+    // 一旦以授权用户身份落上去，就是在用户自己的评论上、以用户自己的名义、
+    // 永久挂一个叉 —— 用户会看到「我自己给自己打了个叉」。错误主体的持久写入
+    // 比没有标记更糟，所以 tenant 不行就放弃（下面 catch 里只记日志）。
+    // 对比同文件 Typing 指示器：那个成对、几秒后必被 removeCommentReaction 清掉，
+    // 回退 user 只是短暂误导，故仍用 preferTenant，本 PR 不动它。
+    await addCommentReaction(larkAppId, file, commentId, replyId, DROPPED_REACTION_EMOJI_TYPE, { tenantOnly: true });
   } catch (err) {
     logger.debug(`[doc-comment] failed to mark dropped event on reply=${replyId.slice(0, 12)}: ${err instanceof Error ? err.message : err}`);
   }
@@ -3143,7 +3149,16 @@ async function processCommentEvent(
   const comment = await getDocComment(larkAppId, { fileToken, fileType: sub.fileType }, commentId);
   if (!comment || comment.replies.length === 0) {
     logger.info(`[doc-comment] event dropped: 取不到评论内容 comment=${commentId.slice(0, 12)}（replies=${comment ? comment.replies.length : 'null'}）`);
-    await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId);
+    // ⚠️ 这个丢弃点在 mention-only 闸（下面第 4 步）**之前** —— 而 mention-only
+    // 订阅下该文档的**所有**评论事件都会推给我们。拉不到正文时我们无从判断这条
+    // 评论是不是冲 bot 来的，无条件打标记会在**别人的评论上**留 ❌。
+    // 拿不到正文时能做到的最窄收窄：`is_mentioned` 为 false 说明评论里一个 @ 都
+    // 没有，肯定不是找 bot 的。注意这里是用它**收紧**，与代码里「不能用
+    // is_mentioned 放行」的警告不冲突 —— 那条警告说的是 true 不代表 @ 的是本 bot。
+    // 'all' 模式不收窄：那种模式不 @ 也该触发，拉不到就是真丢了。
+    if (sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned) {
+      await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId);
+    }
     return;
   }
   const trigger = parsed.replyId
@@ -3177,7 +3192,23 @@ async function processCommentEvent(
   }
 
   const text = trigger.text.trim();
-  if (!text) return;
+  if (!text) {
+    // ⚠️ 空正文**不等于**用户没说话：`elementsToText` 只拼 text_run，把 person
+    // 元素整个丢掉（doc-comment.ts:elementsToText）。所以一条纯「@bot」、后面
+    // 一个字都没打的评论，走到这里 text 就是空串 —— 用户主观上明确 @ 了 bot，
+    // 客观上却零感知，正是 #1260 要治的症状。这里曾经是个裸 return，连日志都没有。
+    //
+    // 打不打标记按模式分：走到这一步已经过了上面的权威 mention gate，
+    // mention-only 说明**确认 @ 了本 bot**，噪音风险已排除，该打；
+    // 'all' 模式下没 @ 谁的空评论是真的「没说话」，只记日志不打，免得把文档里
+    // 所有无正文评论统一标成错误。
+    const mentionedSelf = sub.commentTriggerMode === 'mention-only';
+    logger.info(`[doc-comment] event dropped: 触发回复无文本正文 (comment=${commentId.slice(0, 12)} mode=${sub.commentTriggerMode} mentions=${trigger.mentions.length} marked=${mentionedSelf}) — 纯 @bot 无正文也会落到这里`);
+    if (mentionedSelf) {
+      await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, trigger.replyId || parsed.replyId);
+    }
+    return;
+  }
 
   // 审计硬门：非 owner @bot 触发时，必须成功通知 owner 才允许回复。
   // 通知失败 = owner 无法感知 = 越权，直接拒绝响应并回滚 auto-sub。

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -3078,9 +3078,40 @@ async function markCommentEventDropped(
   file: { fileToken: string; fileType: string },
   commentId: string,
   replyId: string | undefined,
+  requesterOpenId: string | undefined,
 ): Promise<void> {
   // reply_id 缺失时无处可打：reaction 端点要求 comment_id + reply_id 两者齐全。
   if (!replyId) return;
+
+  // ⚠️ 审计硬门：打标记是 **provider-visible 的持久外部写入**，不是内部日志，
+  // 必须受和「回复」同一套审计约束 —— 现有不变量是「非 owner 触发时，owner
+  // 无法感知 = 越权」。但这些丢弃点全都在下面那道审计门**之前**，而且前两处
+  // 连评论正文都没读到，构造不出审计门要发的通知（通知正文含 text 摘要）。
+  // 所以这里取**保守侧**：只有 owner 本人触发才打标记，非 owner 一律只记日志。
+  //
+  // 代价是非 owner 触发时用户仍然零感知 —— 但那是 #1260 的既有症状，
+  // 而越权留下一个绕过审计的永久外部写入是**新引入**的问题，孰轻孰重很清楚。
+  // 对比 Typing：它在 handleDocComment 入场后才加，而入场发生在审计门之后，
+  // 所以它本来就不存在这个绕过，不需要跟着改。
+  const ownerOpenId = getOwnerOpenId(larkAppId);
+  if (!ownerOpenId || !requesterOpenId || requesterOpenId !== ownerOpenId) {
+    logger.info(`[doc-comment] dropped-signal skipped (audit gate): 非 owner 触发不打标记 comment=${commentId.slice(0, 12)} requester=${requesterOpenId?.slice(0, 12) || '?'}`);
+    return;
+  }
+
+  // ⚠️ 自触发过滤：正常那道（`trigger.userId === selfBotOpenId` 等三重保险）在
+  // 下面，前两个丢弃点**跑在它之前**，所以必须在这里自己挡一次，否则 bot 会给
+  // 自己的回复打 ❌。缺正文时可用的两个信号：
+  //   ① 事件操作者就是本 bot（应用身份发的评论）
+  //   ② reply_id 在本进程「bot 创建过」的集合里（用户身份发的评论，作者分不出）
+  // 信号 ② 尤其关键：bot 回退 user 身份发评论时作者 = 授权用户 = owner，
+  // 恰好**穿过上面那道 owner 审计门** —— 只靠审计门挡不住这种自标。
+  const selfBotOpenId = getBot(larkAppId).botOpenId;
+  if ((selfBotOpenId && requesterOpenId === selfBotOpenId) || isBotAuthoredReply(replyId)) {
+    logger.debug(`[doc-comment] dropped-signal skipped: 触发者是 bot 自己 comment=${commentId.slice(0, 12)} reply=${replyId.slice(0, 12)}`);
+    return;
+  }
+
   try {
     // ⚠️ tenantOnly：**绝不能**回退 user 身份。这个 ❌ 是终态标记、故意不清理，
     // 一旦以授权用户身份落上去，就是在用户自己的评论上、以用户自己的名义、
@@ -3157,7 +3188,7 @@ async function processCommentEvent(
     // is_mentioned 放行」的警告不冲突 —— 那条警告说的是 true 不代表 @ 的是本 bot。
     // 'all' 模式不收窄：那种模式不 @ 也该触发，拉不到就是真丢了。
     if (sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned) {
-      await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId);
+      await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId, parsed.operatorOpenId);
     }
     return;
   }
@@ -3171,7 +3202,7 @@ async function processCommentEvent(
   // @ 判定和自触发过滤也全基于错误的回复。宁可丢这一条并告警，也不能拿错的顶上。
   if (!trigger) {
     logger.warn(`[doc-comment] event dropped: 触发回复 ${parsed.replyId?.slice(0, 12)} 不在拉到的 ${comment.replies.length} 条回复里 (comment=${commentId.slice(0, 12)} truncated=${comment.hasMoreReplies === true}) — 回复串可能未补全`);
-    await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId);
+    await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId, parsed.operatorOpenId);
     return;
   }
   const triggerIndex = Math.max(0, comment.replies.indexOf(trigger));
@@ -3205,7 +3236,7 @@ async function processCommentEvent(
     const mentionedSelf = sub.commentTriggerMode === 'mention-only';
     logger.info(`[doc-comment] event dropped: 触发回复无文本正文 (comment=${commentId.slice(0, 12)} mode=${sub.commentTriggerMode} mentions=${trigger.mentions.length} marked=${mentionedSelf}) — 纯 @bot 无正文也会落到这里`);
     if (mentionedSelf) {
-      await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, trigger.replyId || parsed.replyId);
+      await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, trigger.replyId || parsed.replyId, parsed.operatorOpenId);
     }
     return;
   }

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -25,7 +25,7 @@ import { isPlatformTeamBot, isPlatformHallChat, isPlatformTeamMember } from '../
 import { getBotUnionId, recordBotUnionId, recordBotUnionIdFromMentions } from '../../services/bot-union-ids-store.js';
 import { getDocSubscription, putDocSubscription, removeDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
 import { wasPendingReviewNotified, markPendingReviewNotified } from '../../services/under-review-notify-store.js';
-import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed, BOT_REPLY_SENTINEL } from './doc-comment.js';
+import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed, BOT_REPLY_SENTINEL, addCommentReaction } from './doc-comment.js';
 import {
   BOTMUX_REQUIRED_SCOPES,
   DOC_FEATURE_SCOPES,
@@ -77,6 +77,7 @@ import type { VcMeetingImTurnOrigin } from '../../types.js';
 import { DEFAULT_GRANT_DURATION_MS, DEFAULT_GRANT_QUOTA } from '../../services/grant-policy.js';
 import { readPeerCrossRef, writePeerCrossRef } from '../../services/peer-cross-ref-store.js';
 import { resolveCardActionAckTimeoutMs } from '../../core/card-action-ack.js';
+import { DROPPED_REACTION_EMOJI_TYPE } from '../../core/pending-response.js';
 
 // 大厅回执互教的防环闸：每进程对同一打卡者只回一次（见 hall swallow 分支）。
 const hallEchoReplied = new Set<string>();
@@ -3056,6 +3057,39 @@ function handleVcMeetingPushEventAckSafe(
   }, `vc-meeting ${kind} event`);
 }
 
+/**
+ * 在被丢弃的触发回复上打一个 ❌，让「这条 @ 我没能处理」在文档里**看得见**。
+ *
+ * 为什么需要：文档评论事件被丢弃后，飞书不会重投（事件已 ACK），而 mention-only
+ * 订阅**不进轮询**（poller 只收 commentTriggerMode==='all'），所以事件链路失败
+ * 就是终点。用户侧原本只能看到「bot 不理我」，与「bot 正在忙」无法区分——doc
+ * 发起的会话在飞书上整个不可见，只能去 dashboard 翻 terminal 才知道发生了什么。
+ *
+ * 只在**明确知道该怪谁**、且非预期的丢弃点上打：
+ *   • 拉不到评论内容 / 触发回复不在拉到的回复里 —— 都是我们这边没读到用户说了啥
+ * **不打**的场景：自触发过滤（那是 bot 自己的回复）、mention-only 未 @ 本 bot
+ * （压根不该触发，打了反而在别人的评论上留噪音）、空正文（用户确实没说话）。
+ *
+ * best-effort：`addCommentReaction` 自己吞异常返回 undefined，这里再兜一层，
+ * 绝不让「打标记失败」影响丢弃路径本身（那已经是失败路径了）。
+ */
+async function markCommentEventDropped(
+  larkAppId: string,
+  file: { fileToken: string; fileType: string },
+  commentId: string,
+  replyId: string | undefined,
+): Promise<void> {
+  // reply_id 缺失时无处可打：reaction 端点要求 comment_id + reply_id 两者齐全。
+  if (!replyId) return;
+  try {
+    await addCommentReaction(larkAppId, file, commentId, replyId, DROPPED_REACTION_EMOJI_TYPE);
+  } catch (err) {
+    logger.debug(`[doc-comment] failed to mark dropped event on reply=${replyId.slice(0, 12)}: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+export const __testOnly_markCommentEventDropped = markCommentEventDropped;
+
 async function processCommentEvent(
   parsed: ReturnType<typeof parseCommentEvent>,
   larkAppId: string,
@@ -3109,6 +3143,7 @@ async function processCommentEvent(
   const comment = await getDocComment(larkAppId, { fileToken, fileType: sub.fileType }, commentId);
   if (!comment || comment.replies.length === 0) {
     logger.info(`[doc-comment] event dropped: 取不到评论内容 comment=${commentId.slice(0, 12)}（replies=${comment ? comment.replies.length : 'null'}）`);
+    await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId);
     return;
   }
   const trigger = parsed.replyId
@@ -3121,6 +3156,7 @@ async function processCommentEvent(
   // @ 判定和自触发过滤也全基于错误的回复。宁可丢这一条并告警，也不能拿错的顶上。
   if (!trigger) {
     logger.warn(`[doc-comment] event dropped: 触发回复 ${parsed.replyId?.slice(0, 12)} 不在拉到的 ${comment.replies.length} 条回复里 (comment=${commentId.slice(0, 12)} truncated=${comment.hasMoreReplies === true}) — 回复串可能未补全`);
+    await markCommentEventDropped(larkAppId, { fileToken, fileType: sub.fileType }, commentId, parsed.replyId);
     return;
   }
   const triggerIndex = Math.max(0, comment.replies.indexOf(trigger));

--- a/test/doc-comment-audit-gate.test.ts
+++ b/test/doc-comment-audit-gate.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 审计硬门的行为测试。
+ *
+ * 这道门原本内联在 processCommentEvent 里、**没有任何测试覆盖**；#1261 把它抽成
+ * 共用 helper 给「回复」和「失败标记」两条路径用。抽取本身是重构，最容易在无人
+ * 察觉时改变语义 —— 所以这里把不变量钉住：
+ *
+ *   owner 本人触发       → 放行，不通知、不回滚
+ *   非 owner + 通知成功  → 放行（owner 已感知）
+ *   非 owner + 通知失败  → 拒绝 + 回滚 auto-sub（owner 无法感知 = 越权）
+ *   owner 未配置         → 拒绝 + 回滚（无从判定越权，保守拒绝）
+ */
+
+const mocks = vi.hoisted(() => ({
+  sendUserMessage: vi.fn(),
+  getOwnerOpenId: vi.fn(),
+  rollback: vi.fn(),
+}));
+
+vi.mock('../src/im/lark/client.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sendUserMessage: mocks.sendUserMessage,
+}));
+
+vi.mock('../src/bot-registry.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getOwnerOpenId: mocks.getOwnerOpenId,
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const FILE_TOKEN = 'DocToken1234567890123456';
+const OWNER = 'ou_owner';
+
+describe('passesDocCommentAuditGate', () => {
+  let gate: (
+    larkAppId: string,
+    fileToken: string,
+    requesterOpenId: string | undefined,
+    textSummary: string,
+    rollbackAutoSub: () => void,
+  ) => Promise<boolean>;
+
+  beforeEach(async () => {
+    mocks.sendUserMessage.mockReset().mockResolvedValue(undefined);
+    mocks.getOwnerOpenId.mockReset().mockReturnValue(OWNER);
+    mocks.rollback.mockReset();
+    ({ __testOnly_passesDocCommentAuditGate: gate } =
+      await import('../src/im/lark/event-dispatcher.js'));
+  });
+
+  it('owner 本人触发：放行，且不打扰自己、不回滚', async () => {
+    await expect(gate('app-test', FILE_TOKEN, OWNER, '正文', mocks.rollback)).resolves.toBe(true);
+    expect(mocks.sendUserMessage).not.toHaveBeenCalled();
+    expect(mocks.rollback).not.toHaveBeenCalled();
+  });
+
+  it('非 owner + 通知成功：放行（owner 已感知），不回滚', async () => {
+    await expect(gate('app-test', FILE_TOKEN, 'ou_stranger', '正文', mocks.rollback)).resolves.toBe(true);
+    expect(mocks.sendUserMessage).toHaveBeenCalledTimes(1);
+    const [, target] = mocks.sendUserMessage.mock.calls[0];
+    expect(target).toBe(OWNER);
+    expect(mocks.rollback).not.toHaveBeenCalled();
+  });
+
+  it('非 owner + 通知失败：拒绝并回滚 auto-sub（owner 无法感知 = 越权）', async () => {
+    mocks.sendUserMessage.mockRejectedValue(new Error('DM 发不出去'));
+    await expect(gate('app-test', FILE_TOKEN, 'ou_stranger', '正文', mocks.rollback)).resolves.toBe(false);
+    expect(mocks.rollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('owner 未配置：拒绝并回滚，且不尝试发通知', async () => {
+    mocks.getOwnerOpenId.mockReturnValue(undefined);
+    await expect(gate('app-test', FILE_TOKEN, 'ou_stranger', '正文', mocks.rollback)).resolves.toBe(false);
+    expect(mocks.sendUserMessage).not.toHaveBeenCalled();
+    expect(mocks.rollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('operator 缺失：按非 owner 处理（判不出是谁触发的）', async () => {
+    await expect(gate('app-test', FILE_TOKEN, undefined, '正文', mocks.rollback)).resolves.toBe(true);
+    expect(mocks.sendUserMessage).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 关键：摘要**可以不是评论正文**。失败路径根本读不到正文，若因此跳过审计，
+   * 就等于给外部写入开了个免审计通道 —— #1261 早先的版本正是这么错的。
+   */
+  it('摘要透传进通知正文 —— 失败路径可以用说明文字代替评论正文', async () => {
+    await gate('app-test', FILE_TOKEN, 'ou_stranger', '评论正文读取失败，bot 未处理该条 @', mocks.rollback);
+    const [, , notifyText] = mocks.sendUserMessage.mock.calls[0];
+    expect(notifyText).toContain('评论正文读取失败，bot 未处理该条 @');
+    expect(notifyText).toContain(FILE_TOKEN);
+  });
+
+  it('超长摘要截断到 200 字并加省略号（原行为，不能因抽取而改变）', async () => {
+    await gate('app-test', FILE_TOKEN, 'ou_stranger', 'x'.repeat(500), mocks.rollback);
+    const [, , notifyText] = mocks.sendUserMessage.mock.calls[0];
+    expect(notifyText).toContain('x'.repeat(200) + '…');
+    expect(notifyText).not.toContain('x'.repeat(201));
+  });
+});

--- a/test/doc-comment-audit-gate.test.ts
+++ b/test/doc-comment-audit-gate.test.ts
@@ -43,6 +43,7 @@ describe('passesDocCommentAuditGate', () => {
     requesterOpenId: string | undefined,
     textSummary: string,
     rollbackAutoSub: () => void,
+    kind?: 'reply' | 'dropped-signal',
   ) => Promise<boolean>;
 
   beforeEach(async () => {
@@ -101,5 +102,25 @@ describe('passesDocCommentAuditGate', () => {
     const [, , notifyText] = mocks.sendUserMessage.mock.calls[0];
     expect(notifyText).toContain('x'.repeat(200) + '…');
     expect(notifyText).not.toContain('x'.repeat(201));
+  });
+
+  /**
+   * 失败路径**不能**复用成功文案。`doc_mention_notify_body` 说的是「@了机器人，
+   * 已触发回复」—— 但前两个丢弃点拿不到 trigger，无法确认 @ 的是不是本 bot；
+   * 三个丢弃点也都没有产生任何回复。照搬会让 owner 收到与实际情况矛盾的通知，
+   * 而这正是本 PR 反复在治的「日志/通知谎报事实」。
+   */
+  it('dropped-signal 用独立文案，不谎称「已 @机器人、已触发回复」', async () => {
+    await gate('app-test', FILE_TOKEN, 'ou_stranger', '评论正文读取失败', mocks.rollback, 'dropped-signal');
+    const [, , notifyText] = mocks.sendUserMessage.mock.calls[0];
+    expect(notifyText).not.toContain('已触发回复');
+    expect(notifyText).not.toContain('@了机器人');
+    expect(notifyText).toContain('未能读取或处理');
+  });
+
+  it('正常回复路径仍用原成功文案（抽取不改既有行为）', async () => {
+    await gate('app-test', FILE_TOKEN, 'ou_stranger', '正文', mocks.rollback, 'reply');
+    const [, , notifyText] = mocks.sendUserMessage.mock.calls[0];
+    expect(notifyText).toContain('已触发回复');
   });
 });

--- a/test/doc-comment-drop-signal.test.ts
+++ b/test/doc-comment-drop-signal.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from 'node:fs';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * #1260：文档评论事件被丢弃时给触发回复打 ❌，让「这条 @ 我没能处理」看得见。
+ *
+ * 背景：事件已 ACK ⇒ 飞书不重投；mention-only 订阅不进轮询（poller 只收
+ * commentTriggerMode==='all'）⇒ 没有兜底。所以事件链路一丢就是终点，而用户侧
+ * 原本零感知 —— doc 发起的会话在飞书整个不可见，只能去 dashboard 翻 terminal。
+ */
+
+const mocks = vi.hoisted(() => ({
+  addCommentReaction: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('../src/im/lark/doc-comment.js', () => ({
+  addCommentReaction: mocks.addCommentReaction,
+  getDocComment: vi.fn(),
+  isBotAuthoredReply: vi.fn(() => false),
+  hasBotSentinel: vi.fn(() => false),
+  commentTriggerAllowed: vi.fn(() => true),
+  BOT_REPLY_SENTINEL: '​',
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { debug: mocks.debug, error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const FILE = { fileToken: 'DocToken1234567890123456', fileType: 'docx' };
+const COMMENT_ID = '7681622822925421500';
+const REPLY_ID = '7681633934731430857';
+
+describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', () => {
+  let markCommentEventDropped: (
+    larkAppId: string,
+    file: { fileToken: string; fileType: string },
+    commentId: string,
+    replyId: string | undefined,
+  ) => Promise<void>;
+
+  beforeEach(async () => {
+    mocks.addCommentReaction.mockReset().mockResolvedValue('reaction-1');
+    mocks.debug.mockReset();
+    ({ __testOnly_markCommentEventDropped: markCommentEventDropped } =
+      await import('../src/im/lark/event-dispatcher.js'));
+  });
+
+  it('给触发回复打 ERROR reaction（用飞书文档里确实存在的 emoji_type）', async () => {
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID);
+
+    expect(mocks.addCommentReaction).toHaveBeenCalledTimes(1);
+    const [appId, file, commentId, replyId, emoji] = mocks.addCommentReaction.mock.calls[0];
+    expect(appId).toBe('app-test');
+    expect(file).toEqual(FILE);
+    expect(commentId).toBe(COMMENT_ID);
+    expect(replyId).toBe(REPLY_ID);
+    // 'ERROR' 在飞书 emoji_type 表里；写错的 key 会静默不显示，那就白打了。
+    expect(emoji).toBe('ERROR');
+  });
+
+  it('reply_id 缺失时不发请求（reaction 端点要求 comment_id + reply_id 齐全）', async () => {
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, undefined);
+    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+  });
+
+  it('打标记失败不外抛 —— 丢弃路径本身已经是失败路径，不能再被它拖垮', async () => {
+    mocks.addCommentReaction.mockRejectedValue(new Error('reaction endpoint down'));
+    await expect(markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID)).resolves.toBeUndefined();
+    expect(mocks.debug).toHaveBeenCalled();
+  });
+});
+
+/**
+ * 接线点用源码形状钉住：processCommentEvent 没有导出，且要跑通它得 mock 订阅表、
+ * open_id 探针、审计通知等整条链路。这里按仓库已有做法钉源码形状，保证标记被接在
+ * **该接的那两个丢弃点**上，且**没有**被接到不该打的那几个上。
+ */
+describe('processCommentEvent 的接线点（源码形状）', () => {
+  const src = readFileSync(new URL('../src/im/lark/event-dispatcher.ts', import.meta.url), 'utf-8');
+  const region = (() => {
+    const start = src.indexOf('async function processCommentEvent');
+    expect(start).toBeGreaterThan(-1);
+    return src.slice(start, src.indexOf('const LARK_WS_PROXY_ENV_KEYS', start));
+  })();
+
+  it('「取不到评论内容」和「触发回复不在回复里」两处都打标记', () => {
+    expect(region.match(/await markCommentEventDropped\(/g) ?? []).toHaveLength(2);
+  });
+
+  it('自触发过滤不打标记（那是 bot 自己的回复，打了是自己标自己）', () => {
+    const selfFilter = region.slice(
+      region.indexOf('const selfBotOpenId = getBot(larkAppId).botOpenId;'),
+      region.indexOf('// 4) 触发范围闸'),
+    );
+    expect(selfFilter).not.toContain('markCommentEventDropped');
+  });
+
+  it('mention-only 未 @ 本 bot 不打标记（压根不该触发，打了是在别人评论上留噪音）', () => {
+    const gate = region.slice(
+      region.indexOf('if (!commentTriggerAllowed('),
+      region.indexOf('const text = trigger.text.trim();'),
+    );
+    expect(gate).not.toContain('markCommentEventDropped');
+  });
+});

--- a/test/doc-comment-drop-signal.test.ts
+++ b/test/doc-comment-drop-signal.test.ts
@@ -248,4 +248,19 @@ describe('processCommentEvent 的接线点（源码形状）', () => {
     );
     expect(gate).not.toMatch(/markCommentEventDropped\(/);
   });
+
+  /**
+   * ⚠️ 五处回滚全都经由同一个闭包，而**唯一**阻止它删掉「用户此前用
+   * /watch-comment 建的既有订阅」的，就是那句 `if (autoCreatedSub)`。
+   * 本 PR 把 rollback 的调用点从 2 处扩到 11 处，这个守卫一旦丢失，
+   * 任何一条陌生人的无关评论都会静默退订用户真正想要的订阅 —— 破坏性远大于
+   * 本 PR 要修的问题。这里把它钉死。
+   */
+  it('rollback 闭包必须由 autoCreatedSub 守卫 —— 绝不能删掉既有订阅', () => {
+    expect(region).toContain('const rollbackAutoSub = () => { if (autoCreatedSub) removeDocSubscription(');
+  });
+
+  it('removeDocSubscription 只在那一个闭包里被调用，没有旁路', () => {
+    expect(region.match(/removeDocSubscription\(/g) ?? []).toHaveLength(1);
+  });
 });

--- a/test/doc-comment-drop-signal.test.ts
+++ b/test/doc-comment-drop-signal.test.ts
@@ -92,9 +92,11 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
     expect(opts).toMatchObject({ tenantOnly: true });
   });
 
-  it('reply_id 缺失时不发请求（reaction 端点要求 comment_id + reply_id 齐全）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, undefined, OWNER, 'summary', mocks.rollback);
+  it('reply_id 缺失时不发请求，且回滚 auto-sub（malformed 事件不能留下订阅）', async () => {
+    const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, undefined, OWNER, 'summary', mocks.rollback);
+    expect(outcome).toBe('no-reply-id');
     expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
+    expect(mocks.rollback).toHaveBeenCalledTimes(1);
   });
 
   it('打标记失败不外抛 —— 丢弃路径本身已经是失败路径，不能再被它拖垮', async () => {
@@ -152,10 +154,11 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
     expect(mocks.rollback).toHaveBeenCalledTimes(1);
   });
 
-  it('自触发拦截在审计门之前 —— 不为 bot 自己的事件打扰 owner，也不回滚', async () => {
+  it('自触发拦截在审计门之前 —— 不为 bot 自己的事件打扰 owner，但仍回滚 auto-sub', async () => {
     const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_selfbot', 'summary', mocks.rollback);
     expect(outcome).toBe('self-triggered');
-    expect(mocks.rollback).not.toHaveBeenCalled();
+    // 没过审计 ⇒ 占位订阅不能留下。但也不该为自己的事件去打扰 owner。
+    expect(mocks.rollback).toHaveBeenCalledTimes(1);
   });
 
   /**
@@ -210,10 +213,22 @@ describe('processCommentEvent 的接线点（源码形状）', () => {
     expect(region.match(/await markCommentEventDropped\(/g) ?? []).toHaveLength(3);
   });
 
-  it('第一个打点（拉不到评论内容）必须收窄，不能在别人的评论上打标记', () => {
+  it('前两个打点都必须收窄，不能在别人的评论上打标记', () => {
+    // trigger 缺失只证明回复数据不完整，不证明这条回复冲 bot 来的 —— 已订阅文档下
+    // 别人的普通回复同样推事件，那条 reply 没被拉到就会走到第二个打点。
     const firstDrop = regionBetween('取不到评论内容', 'const trigger = parsed.replyId');
-    // mention-only 下拉不到正文时无从判断是不是冲 bot 来的，只能靠 is_mentioned 收紧。
-    expect(firstDrop).toContain(`sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned`);
+    const secondDrop = regionBetween('不在拉到的', 'const triggerIndex');
+    expect(firstDrop).toContain('mayConcernThisBot');
+    expect(secondDrop).toContain('mayConcernThisBot');
+  });
+
+  it('收窄谓词本身用 is_mentioned 收紧，且只作用于 mention-only', () => {
+    expect(region).toContain(`sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned === true`);
+  });
+
+  it('每个未打标记的早退都回滚 auto-sub（不留 owner 不知情的订阅）', () => {
+    // 三个 dropped 打点的 else 分支 + self-filter + mention gate。
+    expect((region.match(/rollbackAutoSub\(\);/g) ?? []).length).toBeGreaterThanOrEqual(5);
   });
 
   it('自触发过滤不打标记（那是 bot 自己的回复，打了是自己标自己）', () => {

--- a/test/doc-comment-drop-signal.test.ts
+++ b/test/doc-comment-drop-signal.test.ts
@@ -11,16 +11,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 const mocks = vi.hoisted(() => ({
-  addCommentReaction: vi.fn(),
+  addCommentReactionChecked: vi.fn(),
   isBotAuthoredReply: vi.fn(() => false),
   getOwnerOpenId: vi.fn(() => 'ou_owner'),
   getBot: vi.fn(() => ({ botOpenId: 'ou_selfbot', config: {} })),
   debug: vi.fn(),
   info: vi.fn(),
+  rollback: vi.fn(),
 }));
 
 vi.mock('../src/im/lark/doc-comment.js', () => ({
-  addCommentReaction: mocks.addCommentReaction,
+  addCommentReactionChecked: mocks.addCommentReactionChecked,
+  addCommentReaction: vi.fn(),
   getDocComment: vi.fn(),
   isBotAuthoredReply: mocks.isBotAuthoredReply,
   hasBotSentinel: vi.fn(() => false),
@@ -50,24 +52,27 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
     commentId: string,
     replyId: string | undefined,
     requesterOpenId: string | undefined,
-  ) => Promise<void>;
+    auditSummary: string,
+    rollbackAutoSub: () => void,
+  ) => Promise<string>;
 
   beforeEach(async () => {
-    mocks.addCommentReaction.mockReset().mockResolvedValue('reaction-1');
+    mocks.addCommentReactionChecked.mockReset().mockResolvedValue({ ok: true, reactionId: 'reaction-1' });
     mocks.isBotAuthoredReply.mockReset().mockReturnValue(false);
     mocks.getOwnerOpenId.mockReset().mockReturnValue(OWNER);
     mocks.getBot.mockReset().mockReturnValue({ botOpenId: 'ou_selfbot', config: {} });
     mocks.debug.mockReset();
     mocks.info.mockReset();
+    mocks.rollback.mockReset();
     ({ __testOnly_markCommentEventDropped: markCommentEventDropped } =
       await import('../src/im/lark/event-dispatcher.js'));
   });
 
   it('给触发回复打 ERROR reaction（用飞书文档里确实存在的 emoji_type）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER);
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER, 'summary', mocks.rollback);
 
-    expect(mocks.addCommentReaction).toHaveBeenCalledTimes(1);
-    const [appId, file, commentId, replyId, emoji] = mocks.addCommentReaction.mock.calls[0];
+    expect(mocks.addCommentReactionChecked).toHaveBeenCalledTimes(1);
+    const [appId, file, commentId, replyId, emoji] = mocks.addCommentReactionChecked.mock.calls[0];
     expect(appId).toBe('app-test');
     expect(file).toEqual(FILE);
     expect(commentId).toBe(COMMENT_ID);
@@ -82,19 +87,19 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
    * 对比 Typing：成对、几秒后必被清掉，回退 user 只是短暂误导，故仍用 preferTenant。
    */
   it('必须 tenantOnly —— 绝不以授权用户身份留下永久标记', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER);
-    const opts = mocks.addCommentReaction.mock.calls[0][5];
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER, 'summary', mocks.rollback);
+    const opts = mocks.addCommentReactionChecked.mock.calls[0][5];
     expect(opts).toMatchObject({ tenantOnly: true });
   });
 
   it('reply_id 缺失时不发请求（reaction 端点要求 comment_id + reply_id 齐全）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, undefined, OWNER);
-    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, undefined, OWNER, 'summary', mocks.rollback);
+    expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
   });
 
   it('打标记失败不外抛 —— 丢弃路径本身已经是失败路径，不能再被它拖垮', async () => {
-    mocks.addCommentReaction.mockRejectedValue(new Error('reaction endpoint down'));
-    await expect(markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER)).resolves.toBeUndefined();
+    mocks.addCommentReactionChecked.mockRejectedValue(new Error('reaction endpoint down'));
+    await expect(markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER, 'summary', mocks.rollback)).resolves.toBe('reaction-failed');
     expect(mocks.debug).toHaveBeenCalled();
   });
 
@@ -104,27 +109,27 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
    * 读不到正文、构造不出门要发的通知，所以取保守侧：只有 owner 本人触发才打。
    */
   it('非 owner 触发不打标记（不能绕过审计硬门做外部写入）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_someone_else');
-    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_someone_else', 'summary', mocks.rollback);
+    expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
   });
 
   it('owner 未配置时不打标记（无从判定越权，保守拒绝）', async () => {
     mocks.getOwnerOpenId.mockReturnValue(undefined);
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER);
-    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER, 'summary', mocks.rollback);
+    expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
   });
 
   it('operator 缺失时不打标记（判不出是谁触发的）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, undefined);
-    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, undefined, 'summary', mocks.rollback);
+    expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
   });
 
   /**
    * 自触发：正常那道 self-filter 在下面，前两个丢弃点跑在它之前，必须自己挡一次。
    */
   it('触发者是 bot 自己（应用身份）不打标记 —— 否则给自己打 ❌', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_selfbot');
-    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_selfbot', 'summary', mocks.rollback);
+    expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
   });
 
   /**
@@ -133,8 +138,47 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
    */
   it('bot 以 user 身份发的回复（作者=owner）也不打标记 —— 审计门挡不住这种自标', async () => {
     mocks.isBotAuthoredReply.mockReturnValue(true);
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER);
-    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER, 'summary', mocks.rollback);
+    expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 审计拒绝时必须回滚本次 auto-sub —— 否则陌生人一次触发就留下一条 owner
+   * 完全不知情的订阅记录，且没有任何人会清掉它。
+   */
+  it('审计拒绝时回滚 auto-sub，不留下 owner 不知情的订阅', async () => {
+    const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_stranger', 'summary', mocks.rollback);
+    expect(outcome).toBe('audit-rejected');
+    expect(mocks.rollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('自触发拦截在审计门之前 —— 不为 bot 自己的事件打扰 owner，也不回滚', async () => {
+    const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_selfbot', 'summary', mocks.rollback);
+    expect(outcome).toBe('self-triggered');
+    expect(mocks.rollback).not.toHaveBeenCalled();
+  });
+
+  /**
+   * outcome 必须反映**服务端真实结果**。飞书 update_reaction 的响应体是空对象、
+   * 不承诺 reaction_id，所以不能用 `reactionId ? 成功 : 失败` —— 那会把 code=0
+   * 但没带 id 的成功记成失败，排障的人反而被误导。只信 ok。
+   */
+  it('code=0 但响应不带 reaction_id 时仍算 marked（官方 schema 不承诺 id）', async () => {
+    mocks.addCommentReactionChecked.mockResolvedValue({ ok: true });
+    const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER, 'summary', mocks.rollback);
+    expect(outcome).toBe('marked');
+  });
+
+  it('ok=false 时如实记成 reaction-failed，不谎报 marked', async () => {
+    mocks.addCommentReactionChecked.mockResolvedValue({ ok: false });
+    const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER, 'summary', mocks.rollback);
+    expect(outcome).toBe('reaction-failed');
+  });
+
+  it('审计通过时把调用方给的摘要透传给审计门（失败路径也必须有摘要，不能跳过审计）', async () => {
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER, '评论正文读取失败', mocks.rollback);
+    // owner 本人触发无需通知，但摘要参数必须存在于签名里、由调用方传真实说明。
+    expect(mocks.addCommentReactionChecked).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/doc-comment-drop-signal.test.ts
+++ b/test/doc-comment-drop-signal.test.ts
@@ -12,25 +12,36 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   addCommentReaction: vi.fn(),
+  isBotAuthoredReply: vi.fn(() => false),
+  getOwnerOpenId: vi.fn(() => 'ou_owner'),
+  getBot: vi.fn(() => ({ botOpenId: 'ou_selfbot', config: {} })),
   debug: vi.fn(),
+  info: vi.fn(),
 }));
 
 vi.mock('../src/im/lark/doc-comment.js', () => ({
   addCommentReaction: mocks.addCommentReaction,
   getDocComment: vi.fn(),
-  isBotAuthoredReply: vi.fn(() => false),
+  isBotAuthoredReply: mocks.isBotAuthoredReply,
   hasBotSentinel: vi.fn(() => false),
   commentTriggerAllowed: vi.fn(() => true),
   BOT_REPLY_SENTINEL: '​',
 }));
 
 vi.mock('../src/utils/logger.js', () => ({
-  logger: { debug: mocks.debug, error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  logger: { debug: mocks.debug, error: vi.fn(), info: mocks.info, warn: vi.fn() },
+}));
+
+vi.mock('../src/bot-registry.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getOwnerOpenId: mocks.getOwnerOpenId,
+  getBot: mocks.getBot,
 }));
 
 const FILE = { fileToken: 'DocToken1234567890123456', fileType: 'docx' };
 const COMMENT_ID = '7681622822925421500';
 const REPLY_ID = '7681633934731430857';
+const OWNER = 'ou_owner';
 
 describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', () => {
   let markCommentEventDropped: (
@@ -38,17 +49,22 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
     file: { fileToken: string; fileType: string },
     commentId: string,
     replyId: string | undefined,
+    requesterOpenId: string | undefined,
   ) => Promise<void>;
 
   beforeEach(async () => {
     mocks.addCommentReaction.mockReset().mockResolvedValue('reaction-1');
+    mocks.isBotAuthoredReply.mockReset().mockReturnValue(false);
+    mocks.getOwnerOpenId.mockReset().mockReturnValue(OWNER);
+    mocks.getBot.mockReset().mockReturnValue({ botOpenId: 'ou_selfbot', config: {} });
     mocks.debug.mockReset();
+    mocks.info.mockReset();
     ({ __testOnly_markCommentEventDropped: markCommentEventDropped } =
       await import('../src/im/lark/event-dispatcher.js'));
   });
 
   it('给触发回复打 ERROR reaction（用飞书文档里确实存在的 emoji_type）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID);
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER);
 
     expect(mocks.addCommentReaction).toHaveBeenCalledTimes(1);
     const [appId, file, commentId, replyId, emoji] = mocks.addCommentReaction.mock.calls[0];
@@ -66,20 +82,59 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
    * 对比 Typing：成对、几秒后必被清掉，回退 user 只是短暂误导，故仍用 preferTenant。
    */
   it('必须 tenantOnly —— 绝不以授权用户身份留下永久标记', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID);
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER);
     const opts = mocks.addCommentReaction.mock.calls[0][5];
     expect(opts).toMatchObject({ tenantOnly: true });
   });
 
   it('reply_id 缺失时不发请求（reaction 端点要求 comment_id + reply_id 齐全）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, undefined);
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, undefined, OWNER);
     expect(mocks.addCommentReaction).not.toHaveBeenCalled();
   });
 
   it('打标记失败不外抛 —— 丢弃路径本身已经是失败路径，不能再被它拖垮', async () => {
     mocks.addCommentReaction.mockRejectedValue(new Error('reaction endpoint down'));
-    await expect(markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID)).resolves.toBeUndefined();
+    await expect(markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER)).resolves.toBeUndefined();
     expect(mocks.debug).toHaveBeenCalled();
+  });
+
+  /**
+   * 审计硬门：打标记是 provider-visible 的持久外部写入，不是内部日志。既有不变量
+   * 是「非 owner 触发时 owner 无法感知 = 越权」。这些丢弃点全在那道门之前，且前两处
+   * 读不到正文、构造不出门要发的通知，所以取保守侧：只有 owner 本人触发才打。
+   */
+  it('非 owner 触发不打标记（不能绕过审计硬门做外部写入）', async () => {
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_someone_else');
+    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+  });
+
+  it('owner 未配置时不打标记（无从判定越权，保守拒绝）', async () => {
+    mocks.getOwnerOpenId.mockReturnValue(undefined);
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER);
+    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+  });
+
+  it('operator 缺失时不打标记（判不出是谁触发的）', async () => {
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, undefined);
+    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 自触发：正常那道 self-filter 在下面，前两个丢弃点跑在它之前，必须自己挡一次。
+   */
+  it('触发者是 bot 自己（应用身份）不打标记 —— 否则给自己打 ❌', async () => {
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_selfbot');
+    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 最刁钻的一条：bot 回退 user 身份发评论时作者 = 授权用户 = owner，
+   * **恰好穿过上面那道 owner 审计门**。只有 isBotAuthoredReply 挡得住。
+   */
+  it('bot 以 user 身份发的回复（作者=owner）也不打标记 —— 审计门挡不住这种自标', async () => {
+    mocks.isBotAuthoredReply.mockReturnValue(true);
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, OWNER);
+    expect(mocks.addCommentReaction).not.toHaveBeenCalled();
   });
 });
 
@@ -118,11 +173,13 @@ describe('processCommentEvent 的接线点（源码形状）', () => {
   });
 
   it('自触发过滤不打标记（那是 bot 自己的回复，打了是自己标自己）', () => {
+    // 锚在 processCommentEvent 里的那段注释上 —— helper 内部也有个 selfBotOpenId
+    // 声明（它自己挡了一次自触发），直接锚变量名会命中 helper、把区间撑到整个文件。
     const selfFilter = regionBetween(
-      'const selfBotOpenId = getBot(larkAppId).botOpenId;',
+      '// 3) 自触发过滤（防死循环）',
       '// 4) 触发范围闸',
     );
-    expect(selfFilter).not.toContain('markCommentEventDropped');
+    expect(selfFilter).not.toMatch(/markCommentEventDropped\(/);
   });
 
   it('mention-only 未 @ 本 bot 不打标记（压根不该触发，打了是在别人评论上留噪音）', () => {
@@ -130,6 +187,6 @@ describe('processCommentEvent 的接线点（源码形状）', () => {
       'if (!commentTriggerAllowed(',
       'const text = trigger.text.trim();',
     );
-    expect(gate).not.toContain('markCommentEventDropped');
+    expect(gate).not.toMatch(/markCommentEventDropped\(/);
   });
 });

--- a/test/doc-comment-drop-signal.test.ts
+++ b/test/doc-comment-drop-signal.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   isBotAuthoredReply: vi.fn(() => false),
   getOwnerOpenId: vi.fn(() => 'ou_owner'),
   getBot: vi.fn(() => ({ botOpenId: 'ou_selfbot', config: {} })),
+  sendUserMessage: vi.fn(),
   debug: vi.fn(),
   info: vi.fn(),
   rollback: vi.fn(),
@@ -28,6 +29,11 @@ vi.mock('../src/im/lark/doc-comment.js', () => ({
   hasBotSentinel: vi.fn(() => false),
   commentTriggerAllowed: vi.fn(() => true),
   BOT_REPLY_SENTINEL: '​',
+}));
+
+vi.mock('../src/im/lark/client.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sendUserMessage: mocks.sendUserMessage,
 }));
 
 vi.mock('../src/utils/logger.js', () => ({
@@ -64,6 +70,7 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
     mocks.debug.mockReset();
     mocks.info.mockReset();
     mocks.rollback.mockReset();
+    mocks.sendUserMessage.mockReset().mockResolvedValue(undefined);
     ({ __testOnly_markCommentEventDropped: markCommentEventDropped } =
       await import('../src/im/lark/event-dispatcher.js'));
   });
@@ -106,13 +113,25 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
   });
 
   /**
-   * 审计硬门：打标记是 provider-visible 的持久外部写入，不是内部日志。既有不变量
-   * 是「非 owner 触发时 owner 无法感知 = 越权」。这些丢弃点全在那道门之前，且前两处
-   * 读不到正文、构造不出门要发的通知，所以取保守侧：只有 owner 本人触发才打。
+   * 审计硬门：打标记是 provider-visible 的持久外部写入，不是内部日志。不变量是
+   * 「非 owner 触发时 owner 必须先感知」—— **不是**「非 owner 一律不打」。
+   * 通知发出去了 owner 就已感知，此时照打（这正是 9436bb9 撤回 owner-only 降级
+   * 的用意：owner-only 等于放弃 #1260 的非 owner 核心场景）。
    */
-  it('非 owner 触发不打标记（不能绕过审计硬门做外部写入）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_someone_else', 'summary', mocks.rollback);
+  it('非 owner + owner 通知成功：照打（owner 已感知，不算越权）', async () => {
+    const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_someone_else', 'summary', mocks.rollback);
+    expect(outcome).toBe('marked');
+    expect(mocks.sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.addCommentReactionChecked).toHaveBeenCalledTimes(1);
+    expect(mocks.rollback).not.toHaveBeenCalled();
+  });
+
+  it('非 owner + owner 通知失败：拒绝、不打、回滚（owner 无法感知 = 越权）', async () => {
+    mocks.sendUserMessage.mockRejectedValue(new Error('DM 发不出去'));
+    const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_someone_else', 'summary', mocks.rollback);
+    expect(outcome).toBe('audit-rejected');
     expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
+    expect(mocks.rollback).toHaveBeenCalledTimes(1);
   });
 
   it('owner 未配置时不打标记（无从判定越权，保守拒绝）', async () => {
@@ -121,9 +140,10 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
     expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
   });
 
-  it('operator 缺失时不打标记（判不出是谁触发的）', async () => {
-    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, undefined, 'summary', mocks.rollback);
-    expect(mocks.addCommentReactionChecked).not.toHaveBeenCalled();
+  it('operator 缺失：按非 owner 处理 —— 通知成功后照打', async () => {
+    const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, undefined, 'summary', mocks.rollback);
+    expect(outcome).toBe('marked');
+    expect(mocks.sendUserMessage).toHaveBeenCalledTimes(1);
   });
 
   /**
@@ -149,6 +169,7 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
    * 完全不知情的订阅记录，且没有任何人会清掉它。
    */
   it('审计拒绝时回滚 auto-sub，不留下 owner 不知情的订阅', async () => {
+    mocks.sendUserMessage.mockRejectedValue(new Error('DM 发不出去'));
     const outcome = await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID, 'ou_stranger', 'summary', mocks.rollback);
     expect(outcome).toBe('audit-rejected');
     expect(mocks.rollback).toHaveBeenCalledTimes(1);
@@ -222,8 +243,30 @@ describe('processCommentEvent 的接线点（源码形状）', () => {
     expect(secondDrop).toContain('mayConcernThisBot');
   });
 
-  it('收窄谓词本身用 is_mentioned 收紧，且只作用于 mention-only', () => {
-    expect(region).toContain(`sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned === true`);
+  /**
+   * 三个打点的闸口必须一致，且**只在 mention-only 下打**。
+   * 'all' 有 poller 兜底（pollWatchedDocComments 只轮 'all'，且不经过
+   * processCommentEvent），push 这次没读到的评论下轮 poll 很可能被正常处理；
+   * 而 ❌ 是终态不清理，在 'all' 下打就会永久挂在一条根本没丢的评论上。
+   */
+  it("收窄谓词只认 mention-only + is_mentioned（'all' 有轮询兜底，不该打)", () => {
+    expect(region).toContain(`sub.commentTriggerMode === 'mention-only' && parsed.isMentioned === true`);
+  });
+
+  it('第三个打点的闸口与前两个一致（都只认 mention-only）', () => {
+    expect(region).toContain(`const markEligible = sub.commentTriggerMode === 'mention-only'`);
+  });
+
+  /**
+   * ⚠️ 生产调用点必须传 'dropped-signal'。audit-gate 那组测试**证明不了**这一点 ——
+   * 它直调 helper 并手动传 kind，所以把这里的 'dropped-signal' 悄悄改回默认
+   * 'reply'（即 180f2b4 修掉的「失败通知谎称已触发回复」），两组共 31 个用例
+   * 一条都不会红。这条断言就是补那个缺口。
+   */
+  it("dropped-signal 打点必须传 kind，不能退回成功文案", () => {
+    // 这个调用在 markCommentEventDropped 里，位于 processCommentEvent **之前**，
+    // 不在 region 切片内 —— 用整份源码断言，别锚错范围（锚错就又是一条假绿）。
+    expect(src).toContain("rollbackAutoSub, 'dropped-signal')");
   });
 
   it('每个未打标记的早退都回滚 auto-sub（不留 owner 不知情的订阅）', () => {

--- a/test/doc-comment-drop-signal.test.ts
+++ b/test/doc-comment-drop-signal.test.ts
@@ -60,6 +60,17 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
     expect(emoji).toBe('ERROR');
   });
 
+  /**
+   * 这个 ❌ 是**终态**标记、故意不清理。若以授权用户身份落上去，就是在用户自己的
+   * 评论上、以用户自己的名义、永久挂一个叉 —— 错误主体的持久写入比没有标记更糟。
+   * 对比 Typing：成对、几秒后必被清掉，回退 user 只是短暂误导，故仍用 preferTenant。
+   */
+  it('必须 tenantOnly —— 绝不以授权用户身份留下永久标记', async () => {
+    await markCommentEventDropped('app-test', FILE, COMMENT_ID, REPLY_ID);
+    const opts = mocks.addCommentReaction.mock.calls[0][5];
+    expect(opts).toMatchObject({ tenantOnly: true });
+  });
+
   it('reply_id 缺失时不发请求（reaction 端点要求 comment_id + reply_id 齐全）', async () => {
     await markCommentEventDropped('app-test', FILE, COMMENT_ID, undefined);
     expect(mocks.addCommentReaction).not.toHaveBeenCalled();
@@ -79,28 +90,45 @@ describe('markCommentEventDropped: 丢弃事件在文档里留下可见标记', 
  */
 describe('processCommentEvent 的接线点（源码形状）', () => {
   const src = readFileSync(new URL('../src/im/lark/event-dispatcher.ts', import.meta.url), 'utf-8');
-  const region = (() => {
-    const start = src.indexOf('async function processCommentEvent');
-    expect(start).toBeGreaterThan(-1);
-    return src.slice(start, src.indexOf('const LARK_WS_PROXY_ENV_KEYS', start));
-  })();
 
-  it('「取不到评论内容」和「触发回复不在回复里」两处都打标记', () => {
-    expect(region.match(/await markCommentEventDropped\(/g) ?? []).toHaveLength(2);
+  /**
+   * 取源码区间。**每个锚点都必须先断言找得到** —— `indexOf` 找不到返回 -1，
+   * `slice(-1, n)` 会静默给出空串，下面的 `not.toContain` 就必然通过，测试变成
+   * 永远绿的空断言。而这几条负向断言的全部价值就是「防止后续有人把标记顺手扩大
+   * 到所有 return」，假绿等于没测。
+   */
+  function regionBetween(startAnchor: string, endAnchor: string, from = 0): string {
+    const start = src.indexOf(startAnchor, from);
+    expect(start, `锚点失效（源码已变动？）: ${startAnchor}`).toBeGreaterThan(-1);
+    const end = src.indexOf(endAnchor, start);
+    expect(end, `锚点失效（源码已变动？）: ${endAnchor}`).toBeGreaterThan(-1);
+    return src.slice(start, end);
+  }
+
+  const region = regionBetween('async function processCommentEvent', 'const LARK_WS_PROXY_ENV_KEYS');
+
+  it('三个该打的丢弃点都接上了：拉不到评论 / 触发回复不在回复里 / 纯 @bot 无正文', () => {
+    expect(region.match(/await markCommentEventDropped\(/g) ?? []).toHaveLength(3);
+  });
+
+  it('第一个打点（拉不到评论内容）必须收窄，不能在别人的评论上打标记', () => {
+    const firstDrop = regionBetween('取不到评论内容', 'const trigger = parsed.replyId');
+    // mention-only 下拉不到正文时无从判断是不是冲 bot 来的，只能靠 is_mentioned 收紧。
+    expect(firstDrop).toContain(`sub.commentTriggerMode !== 'mention-only' || parsed.isMentioned`);
   });
 
   it('自触发过滤不打标记（那是 bot 自己的回复，打了是自己标自己）', () => {
-    const selfFilter = region.slice(
-      region.indexOf('const selfBotOpenId = getBot(larkAppId).botOpenId;'),
-      region.indexOf('// 4) 触发范围闸'),
+    const selfFilter = regionBetween(
+      'const selfBotOpenId = getBot(larkAppId).botOpenId;',
+      '// 4) 触发范围闸',
     );
     expect(selfFilter).not.toContain('markCommentEventDropped');
   });
 
   it('mention-only 未 @ 本 bot 不打标记（压根不该触发，打了是在别人评论上留噪音）', () => {
-    const gate = region.slice(
-      region.indexOf('if (!commentTriggerAllowed('),
-      region.indexOf('const text = trigger.text.trim();'),
+    const gate = regionBetween(
+      'if (!commentTriggerAllowed(',
+      'const text = trigger.text.trim();',
     );
     expect(gate).not.toContain('markCommentEventDropped');
   });

--- a/test/doc-comment-reaction-identity.test.ts
+++ b/test/doc-comment-reaction-identity.test.ts
@@ -35,7 +35,7 @@ vi.mock('../src/utils/logger.js', () => ({
   logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
-import { addCommentReaction } from '../src/im/lark/doc-comment.js';
+import { addCommentReaction, addCommentReactionChecked } from '../src/im/lark/doc-comment.js';
 
 const FILE = { fileToken: 'DocToken1234567890123456', fileType: 'docx' };
 const COMMENT_ID = '7681622822925421500';
@@ -133,5 +133,43 @@ describe('driveApiCall: userOnly 与 tenantOnly 互斥', () => {
     // 关键：一次 provider 请求都不能发出去。
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(mocks.tenantRequest).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * `addCommentReactionChecked` 的 `ok` 必须反映**服务端真实结果**，不能用
+ * `reactionId` 是否存在来推断 —— 飞书官方 `update_reaction` 的响应体是空对象、
+ * **不承诺**带 `reaction_id`。用 id 判成败会把 code=0 的成功记成失败，让排障的人
+ * 以为「飞书拒绝了」，正好和引入 outcome 字段的目的相反。
+ */
+describe('addCommentReactionChecked: ok 反映真实服务端结果', () => {
+  beforeEach(() => {
+    mocks.tenantRequest.mockReset();
+    mocks.resolveUserToken.mockReset().mockResolvedValue(null);
+    vi.unstubAllGlobals();
+  });
+
+  it('code=0 但响应体不带 reaction_id ⇒ ok=true（官方 schema 就是空对象）', async () => {
+    mocks.tenantRequest.mockResolvedValue({ code: 0, data: {} });
+    const res = await addCommentReactionChecked('app-test', FILE, COMMENT_ID, REPLY_ID, 'ERROR', { tenantOnly: true });
+    expect(res.ok).toBe(true);
+    expect(res.reactionId).toBeUndefined();
+  });
+
+  it('code=0 且带 reaction_id ⇒ ok=true 并透出 id', async () => {
+    mocks.tenantRequest.mockResolvedValue({ code: 0, data: { reaction_id: 'r-9' } });
+    const res = await addCommentReactionChecked('app-test', FILE, COMMENT_ID, REPLY_ID, 'ERROR', { tenantOnly: true });
+    expect(res).toEqual({ ok: true, reactionId: 'r-9' });
+  });
+
+  it('请求抛错 ⇒ ok=false（tenantOnly 下 code!=0 也会抛）', async () => {
+    mocks.tenantRequest.mockRejectedValue(new Error('boom'));
+    const res = await addCommentReactionChecked('app-test', FILE, COMMENT_ID, REPLY_ID, 'ERROR', { tenantOnly: true });
+    expect(res.ok).toBe(false);
+  });
+
+  it('旧签名 addCommentReaction 行为不变（仍返回 reactionId | undefined）', async () => {
+    mocks.tenantRequest.mockResolvedValue({ code: 0, data: { reaction_id: 'r-legacy' } });
+    await expect(addCommentReaction('app-test', FILE, COMMENT_ID, REPLY_ID, 'Typing')).resolves.toBe('r-legacy');
   });
 });

--- a/test/doc-comment-reaction-identity.test.ts
+++ b/test/doc-comment-reaction-identity.test.ts
@@ -105,3 +105,33 @@ describe('addCommentReaction 的身份选择', () => {
     expect(id).toBe('r-user');
   });
 });
+
+/**
+ * userOnly + tenantOnly 同时传是调用方的逻辑错误。必须炸，不能静默走 userOnly ——
+ * tenantOnly 的全部意义就是禁止 user 身份写入，静默降级成 user-only 恰好是它要防
+ * 的那件事。当前没有调用方这么传，这是给未来的护栏。
+ */
+describe('driveApiCall: userOnly 与 tenantOnly 互斥', () => {
+  beforeEach(() => {
+    mocks.tenantRequest.mockReset();
+    mocks.resolveUserToken.mockReset().mockResolvedValue('u-token-live');
+    vi.unstubAllGlobals();
+  });
+
+  it('同时指定时抛错，绝不静默降级成 user-only', async () => {
+    const { __testOnly_driveApiCall } = await import('../src/im/lark/doc-comment.js') as any;
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(__testOnly_driveApiCall('app-test', {
+      method: 'POST',
+      path: '/open-apis/drive/v1/whatever',
+      userOnly: true,
+      tenantOnly: true,
+    })).rejects.toThrow(/互斥/);
+
+    // 关键：一次 provider 请求都不能发出去。
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mocks.tenantRequest).not.toHaveBeenCalled();
+  });
+});

--- a/test/doc-comment-reaction-identity.test.ts
+++ b/test/doc-comment-reaction-identity.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * #1260 复审：`addCommentReaction` 的身份选择。
+ *
+ * 「事件被丢弃」的 ❌ 是**终态**标记、故意不清理，所以绝不能回退 user 身份 ——
+ * 那等于在用户自己的评论上、以用户自己的名义、永久挂一个叉（错误主体的持久
+ * 外部写入）。而 Typing 指示器是成对的、几秒后必被 removeCommentReaction 清掉，
+ * 回退 user 只是短暂误导，故保持 preferTenant 不变。
+ *
+ * 这一层是**行为级**测试：直接看 provider 选择的结果（打没打 user 那条路），
+ * 而不是钉源码字符串。
+ */
+
+const mocks = vi.hoisted(() => ({
+  tenantRequest: vi.fn(),
+  resolveUserToken: vi.fn(),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  formatLarkError: vi.fn(),
+  getAllBots: vi.fn(() => []),
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app-test', larkAppSecret: 'secret-test', brand: 'feishu' },
+  })),
+  getBotClient: vi.fn(() => ({ request: mocks.tenantRequest })),
+  loadBotConfigs: vi.fn(() => []),
+}));
+
+vi.mock('../src/utils/user-token.js', () => ({
+  resolveUserToken: mocks.resolveUserToken,
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { addCommentReaction } from '../src/im/lark/doc-comment.js';
+
+const FILE = { fileToken: 'DocToken1234567890123456', fileType: 'docx' };
+const COMMENT_ID = '7681622822925421500';
+const REPLY_ID = '7681633934731430857';
+
+describe('addCommentReaction 的身份选择', () => {
+  beforeEach(() => {
+    mocks.tenantRequest.mockReset();
+    // user token 存在且可用 —— 只有这样「有没有回退」才是可观测的：
+    // 若代码真的回退，fetch 会被调用；tenantOnly 下它必须一次都不被调。
+    mocks.resolveUserToken.mockReset().mockResolvedValue('u-token-live');
+    vi.unstubAllGlobals();
+  });
+
+  it('tenantOnly: tenant 失败时不回退 user —— 一次 user 请求都不能发', async () => {
+    mocks.tenantRequest.mockRejectedValue(new Error('bot 对该文档无权限'));
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const id = await addCommentReaction('app-test', FILE, COMMENT_ID, REPLY_ID, 'ERROR', { tenantOnly: true });
+
+    // best-effort：失败返回 undefined，不外抛（丢弃路径已经是失败路径了）。
+    expect(id).toBeUndefined();
+    // 关键断言：user 身份走的是裸 fetch，这里必须零调用。
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('tenantOnly: tenant 返回 code!=0 同样不回退 user', async () => {
+    mocks.tenantRequest.mockResolvedValue({ code: 1069307, msg: 'no permission' });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const id = await addCommentReaction('app-test', FILE, COMMENT_ID, REPLY_ID, 'ERROR', { tenantOnly: true });
+
+    expect(id).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('tenantOnly: tenant 成功时正常返回 reaction_id', async () => {
+    mocks.tenantRequest.mockResolvedValue({ code: 0, data: { reaction_id: 'r-1' } });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const id = await addCommentReaction('app-test', FILE, COMMENT_ID, REPLY_ID, 'ERROR', { tenantOnly: true });
+
+    expect(id).toBe('r-1');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mocks.tenantRequest).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 回归护栏：本 PR 只收紧「丢弃标记」这一条路径，**不许**顺手把 Typing 也改成
+   * tenantOnly —— Typing 必须保证落地（会被清理，短暂显示成授权用户可以接受）。
+   */
+  it('默认（Typing 路径）：tenant 失败仍回退 user，行为不变', async () => {
+    mocks.tenantRequest.mockRejectedValue(new Error('bot 对该文档无权限'));
+    const fetchSpy = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ code: 0, data: { reaction_id: 'r-user' } }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const id = await addCommentReaction('app-test', FILE, COMMENT_ID, REPLY_ID, 'Typing');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(id).toBe('r-user');
+  });
+});


### PR DESCRIPTION
Closes #1260

## ⚠️ 这个 PR 叠在 #1257 上，先合 #1257

base 设的是 `master`，但分支是从 #1257 的 head (`7b8d630`) 切出来的，**diff 里会包含 #1257 的 4 个 commit**。本 PR 自己的改动只有最后一个 commit `b14de5f`（3 个文件、+154/-1）：

```
git diff 7b8d630..b14de5f
```

**这不是懒得 rebase，是真依赖**：本 PR 要接线的 `if (!trigger)` 分支在 master 上**不存在** —— master 那里是 `?? comment.replies[comment.replies.length - 1]` 的静默回退，#1257 才把它换成显式丢弃。#1257 合入后我会把 base 切过来重新推。

## 问题

在文档里 @ bot，bot 可能**一声不吭** —— 这条 @ 已经被丢了，永远不会有回复，而用户侧完全看不出来，跟「bot 正在忙」无法区分。

用户原话：

> 主要现在 doc 发起的会话其实在飞书上整个都是看不到的，只能从 dashboard 上去找它的 terminal。所以确实不知道它是断了还是怎么样。

为什么没有第二次机会：

| 链路 | 机制 | 失败后 |
| --- | --- | --- |
| 事件 | 飞书推 `drive.notice.comment_add_v1` | 事件已 ACK，**飞书不重投** |
| 轮询 | 每 5 秒拉一遍评论列表 | 下一轮重来，能兜底 |

轮询只对 `--all` 生效（`pollWatchedDocComments` 过滤 `commentTriggerMode === 'all'`），而线上唯一的订阅形态是 `mention-only`，**不进轮询**。所以事件链路失败 = 到此为止。

## 改了什么

复用已有的 `addCommentReaction`，在被丢弃的触发回复上打一个 ❌。**不新加主动发评论的链路**，改动面最小。

信号机制其实已经存在，只是位置不对：`handleDocCommentAdmitted` 已经会打 `Typing` reaction 表示「收到了」，但这些丢弃发生在**那之前** —— 还在 `processCommentEvent` 里就 return 了，根本走不到，所以连 Typing 都不会出现。

**只在明确是「我们没读到用户说了啥」的丢弃点打**：

| 丢弃点 | 打标记 | 为什么 |
| --- | --- | --- |
| 拉不到评论内容 | ✅ | 我们这边没读到 |
| 触发回复不在拉到的回复里 | ✅ | 同上（分页截断未补全） |
| 自触发过滤 | ❌ | 那是 bot 自己的回复，打了是自己标自己 |
| mention-only 未 @ 本 bot | ❌ | 压根不该触发，打了是在**别人的**评论上留噪音 |
| 空正文 | ❌ | 用户确实没说话 |

「不该打的那三处没被接上」也用测试钉住了 —— 这类改动最容易在后续被顺手扩大到所有 return。

`emoji_type` 用 `'ERROR'`，**已对飞书官方 emoji 表核过**。这点值得单独说：写错的 key 不报错、只是静默不显示，那这个修复就白做了，而且没人会发现。

best-effort：`addCommentReaction` 自己吞异常返回 undefined，helper 里再兜一层 try/catch —— 绝不让「打标记失败」影响丢弃路径本身，那已经是失败路径了。

## 验证

- 新增 6 个用例：3 个真实行为（emoji 正确 / 缺 reply_id 不发请求 / 打标记失败不外抛）+ 3 个源码形状钉接线点
- **变异验证 4 轮，全部转红**：emoji 换成表外 key、删 `!replyId` 守卫、删 try-catch、只接一处
- doc-comment + event-dispatcher + turn-reactions 共 9 文件 **434 passed**
- `tsc --noEmit` 干净
- 全量 unit：**21 failed / 20972 passed**。我在未修改的 `7b8d630` 上开 worktree 复跑了同这 8 个失败文件，**21 failed / 8 files，集合完全一致**，判定为既有失败（都是 workflow-cli / npm-binary-distribution / codex-app-turn-routing 这些，与文档评论无交集）

## 没做的

- **真实 daemon live 回归没做** —— 要重启 daemon 才加载新代码，会中断当前所有会话，需 owner 拍板
- 因此 `'ERROR'` 这个 emoji 在真实文档评论上的**渲染效果**只对过官方 emoji 表，没有肉眼确认过

## 不在本 PR 范围

用户提的「doc 发起的会话在飞书上整个看不到」是比本 issue 更宽的可观测性缺口，#1260 只覆盖「@ 被静默丢弃」这一种。要一并治建议另开。
