### PR TITLE
fix(release): 构建 Bun 升到 1.4.1 并对 darwin 二进制加 codesign 校验门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
             echo "bwrap still unavailable — sandbox integration tests will skip (see test-side gate)"
           fi
 
-      # Bun is the package manager (packageManager: bun@1.4.0). node-pty's native
+      # Bun is the package manager (packageManager: bun@1.4.1). node-pty's native
       # build runs only because it is in `trustedDependencies` — bun skips
       # dependency lifecycle scripts otherwise, and the sandbox/PTY tests below
       # need a real build/Release/pty.node.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.1
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: bun run test
@@ -89,7 +89,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.1
       - run: bun install --frozen-lockfile
       - run: bun run build
       # Exercise the runner itself before the 20-minute suite. `node --check` cannot
@@ -183,7 +183,7 @@ jobs:
               # prebuild and must compile here. binutils supplies readelf.
               apk add --no-cache python3 make g++ libstdc++ binutils >/dev/null
 
-              npm i -g bun@1.4.0 --loglevel=error
+              npm i -g bun@1.4.1 --loglevel=error
               echo "bun $(bun --version) on $(uname -m)"
 
               # Compiles node-pty against MUSL — the entire point of this job.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.1
       - run: bun install --frozen-lockfile
 
       - name: Sync version from git tag to package.json
@@ -314,7 +314,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.1
       - run: bun install --frozen-lockfile
 
       - name: Upgrade npm for Trusted Publishing
@@ -707,7 +707,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: matrix.glibc_baseline == ''
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.1
       # --frozen-lockfile + the platform's own install compiles node-pty's
       # build/Release/pty.node for THIS OS/arch, which the embed plugin bundles.
       - if: matrix.glibc_baseline == ''
@@ -738,6 +738,27 @@ jobs:
           for t in ${{ matrix.targets }}; do
             bun scripts/build-bun-binary.mjs --target "$t" --out "dist-bin/botmux-${t#bun-}"
           done
+
+      - name: Verify Mach-O signatures on every darwin binary
+        if: matrix.glibc_baseline == '' && runner.os == 'macOS'
+        # `bun build --compile` ad-hoc-signs darwin binaries, and Bun 1.4.0 wrote
+        # an INVALID signature (oven-sh/bun#39764, fixed in #39837 → 1.4.1). The
+        # macos-14 runner tolerated it, so 3.18.14 built, smoke-passed and shipped
+        # — and macOS 27 SIGKILLed it before main(), which is all `botmux upgrade`
+        # saw. The smoke step below only runs the HOST arch; this verifies BOTH
+        # darwin outputs (the cross-built one included) with the same strictness
+        # newer macOS applies, so a bad signature fails the release here instead
+        # of on a user machine.
+        run: |
+          shopt -s nullglob
+          found=0
+          for f in dist-bin/botmux-darwin-*; do
+            case "$f" in *.map|*.sha256) continue;; esac
+            found=1
+            echo "codesign --verify --strict $f"
+            codesign --verify --strict --verbose=2 "$f"
+          done
+          if [ "$found" = 0 ]; then echo "no darwin binaries in dist-bin"; exit 1; fi
 
       - name: Smoke-test the host-arch binary
         if: matrix.glibc_baseline == ''
@@ -866,7 +887,7 @@ jobs:
 
               # setup-bun does not support musl, and npm ships musl builds of bun
               # (@oven/bun-linux-{x64,aarch64}-musl), so npm is the way in.
-              npm i -g bun@1.4.0 --loglevel=error
+              npm i -g bun@1.4.1 --loglevel=error
               echo "bun $(bun --version) on $(uname -m)"
 
               # Compiles node-pty against MUSL — the whole point of this job.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -755,7 +755,7 @@ jobs:
           for f in dist-bin/botmux-darwin-*; do
             case "$f" in *.map|*.sha256) continue;; esac
             found=1
-            echo "codesign --verify --strict $f"
+            echo "verifying signature: $f"
             codesign --verify --strict --verbose=2 "$f"
           done
           if [ "$found" = 0 ]; then echo "no darwin binaries in dist-bin"; exit 1; fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ bun run daemon:logs          # 查看日志
 
 - 每次修改后需要 `bun run build` 然后 `bun run daemon:restart`
 
-**包管理器是 bun**（`packageManager: bun@1.4.0`，锁文件 `bun.lock`）。装依赖用 `bun install --frozen-lockfile`。
+**包管理器是 bun**（`packageManager: bun@1.4.1`，锁文件 `bun.lock`）。装依赖用 `bun install --frozen-lockfile`。
 
 ⚠️ `trustedDependencies: ["electron","node-pty"]` **不能删**：bun 默认**不跑依赖的生命周期脚本**，而 `node-pty` 要靠它 `node-gyp` 编出 `build/Release/pty.node` —— 少了这个，PTY 全废、编译版二进制也打不出来（`pty.node` 是被嵌进去的）。electron 的 postinstall 负责下载对应平台的二进制。
 
@@ -31,7 +31,7 @@ bun run dashboard:bun        # bun src/index-dashboard.ts
 bun run build:bun            # 打自包含单文件二进制（scripts/build-bun-binary.mjs）
 ```
 
-发版编译用的 Bun 版本**钉在 1.4.0**（见 `.github/workflows/`）。本地 bun 与它差太多时，编译产物的行为可能和 CI 不一致——排查编译态问题前先核对 `bun --version`。
+发版编译用的 Bun 版本**钉在 1.4.1**（见 `.github/workflows/`）。本地 bun 与它差太多时，编译产物的行为可能和 CI 不一致——排查编译态问题前先核对 `bun --version`。
 
 **测试里 spawn 子进程必须走 `test/helpers/ts-runner.ts`**，不要写 `spawn(process.execPath, ['--import','tsx', …])`：那是 Node-only 形态，Bun 下 `process.execPath` 是 bun 二进制、`bun --import tsx` 不合法，子进程会全部起不来。helper 按运行时解析（Node 加 tsx loader、Bun 原生跑 TS）。片段里 import 仓库模块（`.js` specifier 实际是 `.ts`）时用 `spawnTsEvalWithRepoImports`，普通 `spawnTsEval` 在 Node 下会 ERR_MODULE_NOT_FOUND。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ bun run daemon:logs
 
 > Every code change requires `bun run build` then `bun run daemon:restart`.
 
-> **Package manager is [bun](https://bun.sh)** (`packageManager: bun@1.4.0`,
+> **Package manager is [bun](https://bun.sh)** (`packageManager: bun@1.4.1`,
 > lockfile `bun.lock`). `trustedDependencies` in `package.json` must keep
 > `node-pty`: bun does not run dependency lifecycle scripts by default, and
 > `node-pty` needs its install hook to build `build/Release/pty.node` — without

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "bun@1.4.0",
+  "packageManager": "bun@1.4.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/deepcoldy/botmux.git"

--- a/scripts/build-linux-glibc-baseline.sh
+++ b/scripts/build-linux-glibc-baseline.sh
@@ -81,7 +81,7 @@ docker run --rm \
     tar -xJf /tmp/node.tar.xz -C /opt/node --strip-components=1
     export PATH="/opt/node/bin:$PATH"
     node --version
-    npm install -g bun@1.4.0 --loglevel=error
+    npm install -g bun@1.4.1 --loglevel=error
     bun --version
 
     # Compiles node-pty on glibc 2.28; trustedDependencies makes this lifecycle

--- a/scripts/smoke-bun-binary.mjs
+++ b/scripts/smoke-bun-binary.mjs
@@ -71,8 +71,18 @@ mkdirSync(join(home, '.botmux'), { recursive: true });
 // dashboard to add their first bot" state — and it needs no credentials.
 writeFileSync(join(home, '.botmux', 'bots.json'), '[]');
 
+// Drop every inherited BOTMUX_* variable before layering the scratch config on
+// top. When this script runs INSIDE a botmux-managed CLI session (a bot doing a
+// local repro), the shell carries the live fleet's BOTMUX_DAEMON_IPC_PORT,
+// BOTMUX_LARK_APP_ID, BOTMUX_SESSION_ID, … — and the smoke supervisor inherits
+// them, so a scratch-HOME test fleet can end up addressing the REAL daemon's IPC
+// port. Measured: a leftover smoke supervisor carried BOTMUX_DAEMON_IPC_PORT=7950
+// (the live daemon) while its own base port had been set to 19950.
+const inheritedEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith('BOTMUX_') && k !== 'BOTMUX' && k !== 'BOTS_CONFIG' && k !== 'SESSION_DATA_DIR'),
+);
 const childEnv = {
-  ...process.env,
+  ...inheritedEnv,
   HOME: home,
   BOTMUX_DAEMON_IPC_BASE_PORT: String(PORTS.ipc),
   BOTMUX_WEB_PROXY_BASE_PORT: String(PORTS.proxy),
@@ -149,6 +159,32 @@ const fail = (step, detail) => {
   process.exit(1);
 };
 const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── 0. darwin: the Mach-O ad-hoc signature is valid ──────────────────────────
+// `bun build --compile` writes an ad-hoc code signature into every darwin
+// binary. Bun 1.4.0 wrote an INVALID one (last page hashed zero-padded, stale
+// signature bytes left past the new one — oven-sh/bun#39764, fixed in #39837 /
+// 1.4.1). Older macOS tolerated it, so the binary still ran here on the
+// macos-14 runner and every check below passed, while macOS 27 SIGKILLs the
+// process before main() — `botmux upgrade` to 3.18.14 died with `exit SIGKILL`
+// and nothing else. Verify the signature explicitly so a release gate never
+// again depends on the runner's macOS being lenient. `--strict` is what Apple's
+// newer loaders effectively enforce.
+if (process.platform === 'darwin') {
+  try {
+    // codesign reports on stderr even on success; a zero exit is the verdict.
+    execFileSync('codesign', ['--verify', '--strict', '--verbose=2', binary], {
+      encoding: 'utf-8', timeout: 60_000, stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    console.log('smoke: ✅ codesign — ad-hoc Mach-O signature valid (--strict)');
+  } catch (err) {
+    const detail = err && typeof err === 'object' && 'stderr' in err && err.stderr
+      ? String(err.stderr).trim()
+      : (err instanceof Error ? err.message : String(err));
+    fail('codesign', `invalid Mach-O signature — newer macOS will SIGKILL this binary before it runs. ` +
+      `Check the Bun that compiled it (1.4.0 is known-bad, need >= 1.4.1). codesign said: ${detail}`);
+  }
+}
 
 // ── 1. capabilities: the CLI graph loads ─────────────────────────────────────
 // Run from a scratch cwd with NO node_modules so a missing native/embedded

--- a/src/utils/local-dev-update.ts
+++ b/src/utils/local-dev-update.ts
@@ -183,9 +183,10 @@ export function gitHeadSha(dir: string): string {
  *   2. bun run build       (dist/ is gitignored: a pull alone leaves stale code)
  *
  * MUST stay `bun run build`, and MUST NOT go back to pnpm. Since the repo
- * declares `packageManager: bun@1.4.0`, a corepack-shimmed `pnpm` REFUSES to run
- * here at all — even `pnpm --version` exits 1 with `Unsupported package manager
- * specification (bun@1.4.0)`, so the whole update aborted before building.
+ * declares `packageManager: bun@<pinned>` (1.4.1 at the time of writing; the
+ * pin lives in package.json), a corepack-shimmed `pnpm` REFUSES to run here at
+ * all — even `pnpm --version` exits 1 with `Unsupported package manager
+ * specification (bun@<pinned>)`, so the whole update aborted before building.
  *
  * `run` is not optional either: bare `bun build` is Bun's BUNDLER subcommand,
  * which exits 1 with "Missing entrypoints" instead of running the `build`

--- a/test/local-dev-update.test.ts
+++ b/test/local-dev-update.test.ts
@@ -111,7 +111,7 @@ describe('localDevUpdateSteps', () => {
   });
 
   // Regression guard for the real breakage: the repo declares
-  // `packageManager: bun@1.4.0`, so a corepack-shimmed `pnpm` refuses to run in
+  // `packageManager: bun@<pinned>` (see package.json), so a corepack-shimmed `pnpm` refuses to run in
   // this repo AT ALL (`pnpm --version` itself exits 1 with "Unsupported package
   // manager specification"). `botmux upgrade` therefore died right after
   // `git pull` with `pnpm build 退出码 1`. A per-token check rather than only the

--- a/test/release-darwin-codesign-gate.test.ts
+++ b/test/release-darwin-codesign-gate.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * botmux 3.18.14's darwin-arm64 binary shipped with an INVALID ad-hoc Mach-O
+ * signature. Bun 1.4.0's `bun build --compile` hashed the last partial page
+ * zero-padded and left stale signature bytes past the new one (oven-sh/bun#39764,
+ * fixed in #39837 → 1.4.1). Every release gate stayed green because the macos-14
+ * runner tolerated the bad signature and ran the binary anyway; macOS 27 SIGKILLs
+ * it before main(), which is all `botmux upgrade` saw (exit 137).
+ *
+ * Two gates now exist, and this suite is what keeps them from quietly vanishing —
+ * the repo has no workflow lint, so a deleted step is first noticed after a tag
+ * has already published (see ci-musl-gate.test.ts for the same reasoning):
+ *   • release.yml verifies EVERY darwin binary with `codesign --verify --strict`
+ *     (the smoke step only executes the host arch; the cross-built one is not run)
+ *   • scripts/smoke-bun-binary.mjs checks the signature before anything else on
+ *     darwin, so the PR gate and the release gate agree
+ *   • the build Bun is pinned to a version that carries the fix, and every pin in
+ *     the repo agrees with package.json's `packageManager`
+ *
+ * Parsed as text, comments stripped, so prose ABOUT the gate can never satisfy an
+ * assertion that the gate exists.
+ */
+
+const root = resolve(import.meta.dirname, '..');
+const read = (p: string) => readFileSync(resolve(root, p), 'utf-8');
+
+const stripHashComments = (src: string) => src
+  .split('\n')
+  .map((line) => line.replace(/(^|\s)#.*$/, '$1'))
+  .join('\n');
+const stripJsComments = (src: string) => src
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .split('\n')
+  .map((line) => line.replace(/(^|\s)\/\/.*$/, '$1'))
+  .join('\n');
+
+const RELEASE = stripHashComments(read('.github/workflows/release.yml'));
+const CI = stripHashComments(read('.github/workflows/ci.yml'));
+const GLIBC_SH = stripHashComments(read('scripts/build-linux-glibc-baseline.sh'));
+const SMOKE = stripJsComments(read('scripts/smoke-bun-binary.mjs'));
+const PKG = JSON.parse(read('package.json')) as { packageManager?: string };
+
+/** The step body from its `- name:` line up to the next step. */
+function step(yaml: string, name: string): string {
+  const start = yaml.indexOf(`- name: ${name}`);
+  if (start < 0) return '';
+  const rest = yaml.slice(start + 1);
+  const next = rest.search(/\n\s*- name: /);
+  return rest.slice(0, next < 0 ? undefined : next);
+}
+
+const semver = (v: string) => v.split('.').map(Number) as [number, number, number];
+const gte = (a: string, b: string) => {
+  const [x, y] = [semver(a), semver(b)];
+  for (let i = 0; i < 3; i++) if (x[i] !== y[i]) return x[i] > y[i];
+  return true;
+};
+
+/** First Bun version known to write a valid darwin ad-hoc signature (#39837). */
+const FIRST_GOOD_BUN = '1.4.1';
+
+describe('release.yml — every darwin binary is codesign-verified before it ships', () => {
+  const verify = step(RELEASE, 'Verify Mach-O signatures on every darwin binary');
+
+  it('has the verification step', () => {
+    expect(verify).not.toBe('');
+  });
+
+  it('runs codesign --verify --strict (strict is what newer macOS enforces)', () => {
+    expect(verify).toMatch(/codesign --verify --strict/);
+  });
+
+  it('iterates ALL darwin outputs, not just the host arch the smoke step runs', () => {
+    expect(verify).toMatch(/for f in dist-bin\/botmux-darwin-\*/);
+  });
+
+  it('fails closed when no darwin binary is present (found=0 → exit 1)', () => {
+    // A glob that matches nothing must not turn into a silent pass.
+    expect(verify).toMatch(/found=0/);
+    expect(verify).toMatch(/\[ "\$found" = 0 \][\s\S]*exit 1/);
+  });
+
+  it('skips sourcemap/checksum siblings so a .map file cannot fail (or pass for) the binary', () => {
+    // `sourcemap: 'linked'` emits botmux-darwin-<arch>.map next to the binary.
+    expect(verify).toMatch(/\*\.map/);
+  });
+
+  it('is scoped to the macOS leg (codesign does not exist on Linux runners)', () => {
+    expect(verify).toMatch(/runner\.os == 'macOS'/);
+  });
+
+  it('runs BEFORE the smoke step in the same job', () => {
+    const smokeIdx = RELEASE.indexOf('- name: Smoke-test the host-arch binary');
+    const verifyIdx = RELEASE.indexOf('- name: Verify Mach-O signatures on every darwin binary');
+    expect(verifyIdx).toBeGreaterThan(-1);
+    expect(smokeIdx).toBeGreaterThan(verifyIdx);
+  });
+});
+
+describe('smoke-bun-binary.mjs — the shared smoke checks the signature first on darwin', () => {
+  it('verifies with codesign --strict when running on darwin', () => {
+    expect(SMOKE).toMatch(/process\.platform === 'darwin'/);
+    expect(SMOKE).toMatch(/execFileSync\('codesign', \['--verify', '--strict'/);
+  });
+
+  it('treats a bad signature as a hard failure', () => {
+    expect(SMOKE).toMatch(/fail\('codesign'/);
+  });
+
+  it('does not let a live fleet leak into the scratch fleet through inherited env', () => {
+    // Measured: run from inside a botmux session, the smoke supervisor inherited
+    // BOTMUX_DAEMON_IPC_PORT (the real daemon) and BOTS_CONFIG (the real registry).
+    expect(SMOKE).toMatch(/startsWith\('BOTMUX_'\)/);
+    expect(SMOKE).toMatch(/'BOTS_CONFIG'/);
+    expect(SMOKE).toMatch(/'SESSION_DATA_DIR'/);
+  });
+});
+
+describe('Bun pin — carries the darwin codesign fix and is consistent everywhere', () => {
+  const pinned = PKG.packageManager?.match(/^bun@(\d+\.\d+\.\d+)$/)?.[1];
+
+  it('package.json pins a bun version', () => {
+    expect(pinned).toBeDefined();
+  });
+
+  it(`is at least ${FIRST_GOOD_BUN} (1.4.0 writes an invalid darwin signature)`, () => {
+    expect(gte(pinned!, FIRST_GOOD_BUN)).toBe(true);
+  });
+
+  it('every setup-bun and npm-installed bun in the workflows uses the same version', () => {
+    const versions = new Set<string>();
+    for (const src of [RELEASE, CI, GLIBC_SH]) {
+      for (const m of src.matchAll(/bun-version:\s*(\d+\.\d+\.\d+)/g)) versions.add(m[1]);
+      for (const m of src.matchAll(/bun@(\d+\.\d+\.\d+)/g)) versions.add(m[1]);
+    }
+    expect(versions.size).toBeGreaterThan(0);
+    expect([...versions]).toEqual([pinned]);
+  });
+
+  it('the release compile matrix actually installs the pinned bun', () => {
+    // Belt and braces for the line that matters most: the job that emits the
+    // darwin binaries. A pin drifting only here is exactly the 3.18.14 shape.
+    const compileJob = RELEASE.slice(RELEASE.indexOf('bun-binaries:'));
+    expect(compileJob).toMatch(new RegExp(`bun-version:\\s*${pinned!.replace(/\./g, '\\.')}`));
+  });
+});

--- a/test/release-darwin-codesign-gate.test.ts
+++ b/test/release-darwin-codesign-gate.test.ts
@@ -70,7 +70,12 @@ describe('release.yml — every darwin binary is codesign-verified before it shi
   });
 
   it('runs codesign --verify --strict (strict is what newer macOS enforces)', () => {
-    expect(verify).toMatch(/codesign --verify --strict/);
+    // Anchored to the start of a line so the EXECUTED command must carry --strict.
+    // An `echo "codesign --verify --strict $f"` progress line is not a comment and
+    // survives stripHashComments; without the anchor it satisfied this assertion
+    // while the real invocation had dropped --strict — the exact parameter that
+    // separates "rejects 3.18.14's bad signature" from "lets it through".
+    expect(verify).toMatch(/^\s*codesign --verify --strict/m);
   });
 
   it('iterates ALL darwin outputs, not just the host arch the smoke step runs', () => {


### PR DESCRIPTION
## 问题

botmux 3.18.14 的 `botmux-darwin-arm64` 在 macOS 27 上无法运行：`botmux upgrade` 的 postinstall 探测阶段进程被 SIGKILL（exit 137），安装器 fail-closed 保住了旧版本，但用户无法升级。

根因不在 botmux 代码，而在编译工具链：Bun 1.4.0 的 `bun build --compile` 写入 darwin 二进制的 ad-hoc 签名无效（末页补零后计算哈希、写入新签名后未截断残留旧签名字节），见 oven-sh/bun#39764，已在 oven-sh/bun#39837 修复并随 Bun 1.4.1（2026-09-04）发布。旧 macOS 校验宽松，`macos-14` runner 上 smoke 照常通过，所以发版 CI 没拦住。

本机复现（macOS 27.0 arm64）：从 npm 下载 `botmux-darwin-arm64@3.18.14`

```
$ codesign --verify --strict --verbose=2 package/botmux
package/botmux: invalid signature (code or signature have been modified)
$ package/botmux --version; echo $?
137
```

## 改动

1. **构建 Bun 1.4.0 → 1.4.1**：`release.yml`（4 处）、`ci.yml`（3 处）、`package.json` `packageManager`、`scripts/build-linux-glibc-baseline.sh`、`CLAUDE.md`、`CONTRIBUTING.md`。取最小且已确认含修复的版本，未直接跳到 9-5 刚发布的 1.4.2。
2. **release.yml bun-binaries macOS 腿新增 `Verify Mach-O signatures on every darwin binary`**：对 `dist-bin/botmux-darwin-*`（包括交叉编出的 x64）逐个 `codesign --verify --strict`，签名无效即发版失败。此前只靠「在 runner 的 macOS 上能启动」放行，这次正是被它漏过。
3. **`scripts/smoke-bun-binary.mjs` 新增第 0 步**：darwin 上先 codesign 校验再跑后续检查，PR 门禁与发版门禁共用；失败信息指明「Bun 1.4.0 已知坏、需 ≥ 1.4.1」。同时剥掉继承的 `BOTMUX_*` / `BOTS_CONFIG` / `SESSION_DATA_DIR` 环境变量——在 botmux 会话内运行该脚本时，测试 fleet 会继承真实 daemon 的 `BOTMUX_DAEMON_IPC_PORT` 等并连过去（实测过一次）。

## 影响面

- 只涉及构建/发版工具链与 smoke 脚本，不改运行时代码；所有平台的二进制都会改用 Bun 1.4.1 编译。
- `bun install --frozen-lockfile` 在现有 `bun.lock`（1.4.0 生成）下用 1.4.1 直接可用，无需重新生成锁文件。
- 新增的 codesign 步骤仅在 `runner.os == 'macOS'` 执行，Linux/musl 腿不受影响。
- 源码中若干「Measured on Bun 1.4.0」的历史实测注释保持原样，它们记录的是当时的测量结果。

## 评审后追加（27614cc）

- **本地开发者注意**：`test/session-store-sqlite-bun-import.test.ts` 与 `session-store-sqlite-poisoned-recovery.test.ts` 断言运行时 Bun 必须等于 `package.json` 的 pin。合入后本地 Bun 仍是 1.4.0 的机器会看到 19 个测试失败，`bun upgrade`（或 `npm i -g bun@1.4.1`）到 1.4.1 即可。CI 不受影响。
- **新增 `test/release-darwin-codesign-gate.test.ts`（14 项）**，照 `ci-musl-gate.test.ts` 的文本解析做法锁住新门禁：release.yml 的 codesign 步骤存在、带 `--strict`、遍历所有 darwin 二进制、`found=0` 时 exit 1、跳过 `.map`、限定 macOS、位于 smoke 之前；smoke 脚本在 darwin 先校验签名并剥离继承的 `BOTMUX_*` 环境；`packageManager` 钉点 ≥ 1.4.1 且与 release.yml / ci.yml / glibc 基线脚本中的所有 bun 版本一致。变异验证：删掉 codesign step → 7 红，一处 pin 改回 1.4.0 → 2 红，还原 → 14 绿。
- `src/utils/local-dev-update.ts` 与 `test/local-dev-update.test.ts` 两处「declares `packageManager: bun@1.4.0`」的现在时陈述改为版本无关写法。
- **行为变化备忘（评审实测）**：npm `ws` 的 `bufferedAmount` 在 Bun 1.4.0 下恒为 0，1.4.1 下恢复正常读数。`src/vc-agent/realtime/pacer.ts` 的背压闸在编译版二进制里因此从死代码变为真正生效；Node 运行时的 daemon 不受影响，方向安全。

## 验证

macOS 27.0 arm64，Bun 1.4.1（本机 `npm i bun@1.4.1` 安装）：

- `bun install --frozen-lockfile` 通过（695 packages），`bun run build` 通过
- `bun scripts/build-bun-binary.mjs --target bun-darwin-arm64`：
  ```
  $ codesign --verify --strict --verbose=2 dist-bin/botmux-darwin-arm64
  dist-bin/botmux-darwin-arm64: valid on disk
  dist-bin/botmux-darwin-arm64: satisfies its Designated Requirement
  $ dist-bin/botmux-darwin-arm64 --version
  3.18.15-local
  ```
- `node scripts/smoke-bun-binary.mjs dist-bin/botmux-darwin-arm64`：codesign / capabilities / version / selfcheck / self-spawn / dashboard / http / frontend / self-destruct guard 9 项全绿，退出后无残留进程
- 同一脚本对 npm 上的 3.18.14 坏二进制：第 0 步 `FAIL [codesign] invalid Mach-O signature …`，门禁有效
- `vitest run test/ci-musl-gate.test.ts test/release-ancestry-pin.test.ts test/ci-glibc-baseline-gate.test.ts test/release-draft-until-assets.test.ts test/local-dev-update.test.ts`：5 files / 61 tests passed
- 两份 workflow YAML 解析正常

合入后需从 master 打新 tag 发版，3.18.14 的 darwin 用户才能恢复 `botmux upgrade`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMWgh6B45AQS1SZozVviR6

