### PR TITLE
fix(cli-adapters): gemini/mtr 首轮 argv 加长度预算，防止 tmux command too long

### DIFF
--- a/src/adapters/cli/gemini.ts
+++ b/src/adapters/cli/gemini.ts
@@ -34,6 +34,15 @@ export function createGeminiAdapter(pathOverride?: string): CliAdapter {
     },
 
     passesInitialPromptViaArgs: true,
+    // tmux `new-session` rejects launch command strings well below OS ARG_MAX
+    // (measured on Linux + tmux 3.3a: 12 KB ok, ceiling between 16256 and
+    // 16384 bytes). Gemini bakes the whole first round into `-i <content>`,
+    // and botmux's new-topic envelope alone is ~5.8 KB, so a pasted log or
+    // stack trace can cross the tmux limit before Gemini ever starts — the
+    // same failure #1250 hit on OpenCode. Same 8 KB budget as OpenCode
+    // (#1251): short messages keep the reliable argv cold-start path,
+    // over-limit ones defer to the post-start input queue.
+    maxInitialPromptArgBytes: 8192,
 
     async writeInput(pty: PtyHandle, content: string) {
       if (pty.sendText && pty.sendSpecialKeys) {

--- a/src/adapters/cli/mtr.ts
+++ b/src/adapters/cli/mtr.ts
@@ -57,6 +57,11 @@ export function createMtrAdapter(pathOverride?: string): CliAdapter {
     },
 
     passesInitialPromptViaArgs: true,
+    // See the Gemini adapter for the measured tmux ceiling. MTR bakes the
+    // first round into `--prompt <content>` and declares no budget, so the
+    // same `command too long` launch failure applies. 8 KB matches OpenCode
+    // (#1251); over-limit prompts defer to the post-start input queue.
+    maxInitialPromptArgBytes: 8192,
 
     async writeInput(pty: PtyHandle, content: string) {
       if (pty.sendText && pty.sendSpecialKeys) {

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -6,6 +6,8 @@ import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createGrokAdapter } from '../src/adapters/cli/grok.js';
 import { createRiffAdapter } from '../src/adapters/cli/riff.js';
 import { createGeminiAdapter } from '../src/adapters/cli/gemini.js';
+import { createMtrAdapter } from '../src/adapters/cli/mtr.js';
+import { createCursorAdapter } from '../src/adapters/cli/cursor.js';
 import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
 import { buildNewTopicPrompt } from '../src/core/session-manager.js';
@@ -406,5 +408,72 @@ describe('OpenCode v1 real-envelope argv budget (buildNewTopicPrompt → defer)'
       passesInitialPromptViaArgs: true,
       deferInitialPrompt: defer,
     })).toBe(true);
+  });
+});
+
+// #1251 closed the OpenCode half of #1250, but gemini/mtr bake the first round
+// into argv the same way with no budget at all. These pin the fix AND the
+// deliberate exclusion of cursor, whose argv path is load-bearing (deferring
+// its opening turn can feed it into a still-active browser-login flow).
+describe('argv budget coverage for the remaining argv-baking adapters (#1264)', () => {
+  const cases = [
+    { id: 'gemini', adapter: createGeminiAdapter('/usr/bin/gemini'), flag: '-i' },
+    { id: 'mtr', adapter: createMtrAdapter('/usr/bin/mtr'), flag: '--prompt' },
+  ] as const;
+
+  it.each(cases.map(c => [c.id, c] as const))(
+    '%s declares a budget and keeps a short real envelope on argv',
+    (_id, c) => {
+      const budget = c.adapter.maxInitialPromptArgBytes;
+      expect(budget).toBe(8192);
+
+      const envelope = buildNewTopicPrompt('帮我看看这个 bug', 'sess-argv-short', _id);
+      // The envelope floor is ~5.8 KB; if a future change pushes it past the
+      // budget, short messages would silently stop using the argv cold-start
+      // path — this assertion is the tripwire for that.
+      expect(Buffer.byteLength(envelope, 'utf8')).toBeLessThan(budget!);
+      expect(shouldDeferInitialPromptForArgLimit({
+        passesInitialPromptViaArgs: true,
+        prompt: envelope,
+        maxInitialPromptArgBytes: budget,
+      })).toBe(false);
+    },
+  );
+
+  it.each(cases.map(c => [c.id, c] as const))(
+    '%s defers an oversized real envelope so it never reaches tmux argv',
+    (_id, c) => {
+      const budget = c.adapter.maxInitialPromptArgBytes!;
+      const envelope = buildNewTopicPrompt(
+        '请逐行审查以下代码并给出修改建议：\n'.repeat(400),
+        'sess-argv-long',
+        _id,
+      );
+      expect(Buffer.byteLength(envelope, 'utf8')).toBeGreaterThan(budget);
+
+      const defer = shouldDeferInitialPromptForArgLimit({
+        passesInitialPromptViaArgs: true,
+        prompt: envelope,
+        maxInitialPromptArgBytes: budget,
+      });
+      expect(defer).toBe(true);
+
+      const args = c.adapter.buildArgs({
+        sessionId: 'sess-argv-long',
+        resume: false,
+        initialPrompt: defer ? undefined : envelope,
+      });
+      expect(args).not.toContain(c.flag);
+      expect(args).not.toContain(envelope);
+    },
+  );
+
+  it('cursor is deliberately left without a budget (browser-login hazard)', () => {
+    // Not an oversight: cursor's positional prompt is only handed to the TUI
+    // after auth/startup settle. Deferring it to the post-start queue can write
+    // into a live browser-login flow — a worse failure than the tmux ceiling.
+    // Pinned so a future "complete the coverage" sweep has to read this first.
+    expect(createCursorAdapter('/usr/bin/cursor').maxInitialPromptArgBytes).toBeUndefined();
+    expect(createCursorAdapter('/usr/bin/cursor').passesInitialPromptViaArgs).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #1264

> [!WARNING]
> **自动评审：下面的自述有三条已被实测推翻**（本 PR 并未完整"防止 command too long"；「余量约 10.4 KB」用的是不含 wrapper 开销的裸上限、真实约 8 KB；「超预算首轮不再写入 argv」对 gemini/mtr 不成立）。**详情见本描述末尾的警示块与 PR 评论。最终以维护者审阅为准。**

## 改了什么

#1251（`7fd6fdcc9`）给 OpenCode 加了 `maxInitialPromptArgBytes` 修好 #1250，但**同一个成因在 gemini / mtr 上依然成立**：两者同样把完整首轮内容烘进启动 argv（`-i <content>` / `--prompt <content>`），却都没有声明预算。本 PR 给这两个补上，每个一行。

## 为什么（实测，非推断）

在 master `fd7c588ce` + Linux / tmux 3.3a 上：

- **tmux 启动命令上限**二分到 **16256 ~ 16384 字节**之间（8 KB / 12 KB 通过，16 KB 起 `command too long`）——与 #1250 现场描述一致。
- **botmux 新话题信封地板约 5.8 KB**（`buildNewTopicPrompt`），用户消息是**净增**在这之上：

| 适配器 | 预算 | 兜底 | 典型新话题 argv |
|---|---|---|---|
| `opencode` | 8192（#1251） | — | 5414 B |
| `pi` | 未声明 | ✅ 自带 `PI_INITIAL_PROMPT_ARG_BYTE_LIMIT=4096`，超限转 `@file` | 5921 B |
| **`gemini`** | ❌ → **本 PR 8192** | ❌ | 5789 B |
| **`mtr`** | ❌ → **本 PR 8192** | ❌ | 5833 B |
| `cursor` | ❌ **刻意不加**（见下） | ❌ | 5795 B |
| `grok` | ❌ 不在本 PR 范围（见下） | ❌ | 5106 B |

- tmux backend **不按 cliId 限制**，这两个适配器都能跑在上面；启动命令整条交给 `tmux new-session`。
- 用户消息余量约 **10.4 KB**：不是日常打字能达到的，但**贴一段日志、堆栈或代码就够**——正是 #1250 的现场形态。**潜在但可达。**

## 修法

复用 #1251 已经跑通的既有 worker contract（`shouldDeferInitialPromptForArgLimit`）：超预算的首轮不再写入 argv，改走 post-start 输入队列；短消息保留原有 argv 冷启动路径。预算 8192 与 OpenCode 对齐。**没有新增机制。**

## 两个刻意的排除

**`cursor` 不加预算，并加守卫用例钉住**——它的位置参数路径是**承重**的：源码注释写明 Cursor 直到认证/启动完成才把 prompt 交给 TUI，改走启动后队列可能把首轮**写进仍活跃的浏览器登录流程**，比撞 tmux 上限更糟。守卫用例的作用是让日后「顺手补全覆盖」的改动**必须先读到这段理由**。

**`grok` 单独立项**（见 #1264）：它声明 `injectsSessionContext`，路由负载走 `--rules`——实测 argv 5106 B 里 **4990 B 是 `--rules`**，**把首轮 prompt 整个拿掉后 argv 仍有 5019 B**。而 `maxInitialPromptArgBytes` 的语义只覆盖被 defer 的那个 prompt，**管不到 `--rules`**，给它加预算几乎没用，需要单独讨论。

## 测试

沿用 #1251 的做法：用**真实 `buildNewTopicPrompt`** 构造信封而非手搓 fixture，这样信封地板日后若被顶过预算，用例会**真的红**。

- gemini / mtr 各两条：短信封留在 argv；超长信封 defer 且长文本**不出现在 argv**；
- cursor 排除守卫一条。

**变异验证**（每个都确认命中）：删 gemini 预算 → **2 红**；删 mtr 预算 → **4 红**；给 cursor 加预算 → **守卫红**。

`bun run build` 通过；`initial-prompt-arg-limit` + `cli-adapters` **462 例全绿**。

## 影响面

- 只动两个适配器各一行常量 + 测试；**无共用代码路径改动**，其余 20+ CLI 不受影响。
- 平台：预算是纯字节判断，macOS / Linux 行为一致；tmux 上限本身依环境而异，8192 取的是保守值。
- 后端：只影响「argv 传首轮」这条路径；PTY / tmux / riff / mojo 的其它行为不变。resume 路径本来就不走 argv 首轮，不受影响。

---
本 PR 由自动评审在 review #1244 时顺带发现（#1244 往 pi argv 里加了 `--name`，因此顺手核了一遍 argv 预算面；#1244 自身实测最坏 4809 B，安全）。最终以维护者审阅为准。


---

> [!WARNING]
> **自动评审补充（写在描述里，因为下面几条结论已被实测推翻；详细证据见本 PR 评论）**
>
> 1. **本 PR 并没有完整"防止 tmux command too long"**。`maxInitialPromptArgBytes` 的 defer 出口落到 `writeInput`，而 gemini/mtr 的 `writeInput` 用 `pty.sendText` = `tmux send-keys -l -- <text>` —— **文本仍是 tmux 的命令行参数**，实测同样在 **16342 B** 触顶。对照：opencode(#1251) 与 pi 用 `pasteText`（`load-buffer` 走 stdin，实测 500 KB 无碍）才真正绕开 argv。
> 2. **上文「用户消息余量约 10.4 KB」偏乐观**。`16256~16384` 是**不含 botmux wrapper + env 开销**的裸 `new-session` 上限；按真实启动形态（~1.2 KB 脚本 + 数十个 env 赋值）复测，prompt 上限只有 **~14.0 KB**（另一次独立复测 ~14.8 KB，随 env 长度浮动）。
> 3. **实际净收益只有一条窄带**：≤8192 走 argv（不变）；8193 ~ ~14 KB 虽 defer 但本来也不会炸；**~14 KB ~ 16342 B 才是真修好的区间（约 1.6–2.4 KB）**；**≥16343 B 仍然坏**，且失败形态从 `new-session` 启动失败（`spawn_failed`）搬到 post-start `writeInput threw`。
>
> 建议 **(a)** gemini/mtr 的 `writeInput` 改用 `pasteText`（已在真 gemini v0.58.0 与真 mtr 0.4.4/0.4.11 上验证：无 argv 墙、不误触提交、`mtr export` 内容逐字完整），或 **(b)** 保留本预算但在注释/字段文档写明"只覆盖到 ~16.3 KB"并另立 issue 跟 (a)。
> 以上为自动评审的初步意见，**最终以维护者审阅为准**。

