### PR TITLE
fix(web-terminal): 手机底栏「上屏」不多送换行、iOS 不放大、长按不多删、空输入框收发得了终端按键、点按钮不收键盘

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18444,7 +18444,11 @@ if(isTouch&&hasToken){(function(){
   var REPEAT_DELAY=450,REPEAT_EVERY=60;
   var keyBtns=document.querySelectorAll('#mobile-bar-keys button');
   for(var i=0;i<keyBtns.length;i++){(function(btn){
+    // Set once a repeat tick has actually fired, so the click the browser sends
+    // when the finger lifts can be swallowed instead of adding one more hit.
+    var suppressTrailingClick=false;
     btn.addEventListener('click',function(){btn.blur();
+      if(suppressTrailingClick){suppressTrailingClick=false;return;}
       var act=btn.getAttribute('data-sk');
       if(act==='paste'){
         // Commit pending live text before the async clipboard result lands.
@@ -18459,13 +18463,16 @@ if(isTouch&&hasToken){(function(){
     // Hold-to-repeat, but ONLY for keys that are safe to apply N times: cursor
     // moves and backspace. Enter/Ctrl-C/Esc/Tab/Shift-Tab/Paste are one-shot —
     // repeating Enter would fire the command several times, repeating Ctrl-C
-    // would spray interrupts. The first hit still comes from the click handler
-    // above (so a plain tap keeps working, mouse included); this only adds the
-    // follow-up ticks after the finger has stayed down past REPEAT_DELAY.
+    // would spray interrupts. A plain tap is still served by the click handler
+    // above (mouse included); this adds the follow-up ticks once the finger has
+    // stayed down past REPEAT_DELAY. Note a click event fires when the finger
+    // LIFTS, so on a long press it lands AFTER the ticks — it is swallowed above
+    // so a 1.2s hold deletes exactly as many characters as it showed ticks.
     if(REPEATABLE[btn.getAttribute('data-sk')]){
       var holdT=null,holdIv=null;
       var stopHold=function(){if(holdT)clearTimeout(holdT);if(holdIv)clearInterval(holdIv);holdT=holdIv=null;};
       btn.addEventListener('pointerdown',function(){
+        suppressTrailingClick=false;
         stopHold();
         holdT=setTimeout(function(){
           holdIv=setInterval(function(){
@@ -18475,7 +18482,8 @@ if(isTouch&&hasToken){(function(){
             if(btn.disabled){stopHold();return;}
             var seq=sk[btn.getAttribute('data-sk')];
             var ok=mode===LIVE?sendLiveKey(seq):sendInput(seq);
-            if(!ok)stopHold();
+            if(!ok){stopHold();return;}
+            suppressTrailingClick=true;
           },REPEAT_EVERY);
         },REPEAT_DELAY);
       });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18498,6 +18498,16 @@ if(isTouch&&hasToken){(function(){
   modeBtn.addEventListener('click',function(){modeBtn.blur();
     // switching away from live flushes pending held text
     if(mode===LIVE&&!sendLiveKey(''))return;
+    // Entering live must flush the staged buffer text too, for the same reason:
+    // live means "what the box holds is already in the terminal", and the mirror
+    // is reset to empty just below. Leaving text in the textarea breaks that
+    // invariant AND is invisible (live renders the textarea transparent), so the
+    // next keystroke would diff '' → 'hello…' and INSERT the stale text into the
+    // terminal instead of editing it. Flush it the way 上屏 does — insert without
+    // submitting — rather than silently discarding what the user typed.
+    if(mode!==LIVE&&ta.value){
+      if(!sendInput(ta.value.replace(/\\x1b/g,'')))return;
+      ta.value='';resizeTa();}
     setMode(mode===LIVE?BUFFER:LIVE);
     if(mode===LIVE){mirror.sent=mirror.held='';hint.textContent='实时输入 · 点击显示键盘';}
     showKeyboard();});
@@ -18515,6 +18525,17 @@ if(isTouch&&hasToken){(function(){
     if(mode===LIVE&&!mirror.composing&&!e.isComposing&&['Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].indexOf(e.key)>=0){
       e.preventDefault();
       sendLiveKey({Tab:'\\t',Escape:'\\x1b',ArrowUp:'\\x1b[A',ArrowDown:'\\x1b[B',ArrowLeft:'\\x1b[D',ArrowRight:'\\x1b[C'}[e.key]);return;}
+    // Backspace on an EMPTY textarea has to be forwarded by hand. Live mode
+    // otherwise only ever sends what the 'input' listener diffs — and deleting
+    // from an empty box changes nothing, so the browser fires beforeinput but
+    // NO input event at all (verified in a real browser). The result was that
+    // text already on the terminal — typed in buffer mode and 上屏'd, or typed
+    // live and mirrored away — could not be erased with the system keyboard:
+    // every Backspace was silently dropped. Non-empty is left to the diff so a
+    // pending IME draft still edits locally instead of eating terminal chars.
+    if(mode===LIVE&&!mirror.composing&&!e.isComposing&&e.key==='Backspace'&&!ta.value){
+      e.preventDefault();
+      sendInput('\\x7f');return;}
     if(e.key==='Enter'&&!e.shiftKey&&!mirror.composing&&!e.isComposing){e.preventDefault();submit();}});
 
   setMode(BUFFER);resizeTa();setWriteState(wsHasWrite);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17317,10 +17317,15 @@ body.touch.has-token #terminal .xterm{
 #mobile-bar-keys button:active{background:#3a3b4d;color:#e4e6f0}
 #mobile-bar-row{display:flex;align-items:flex-end;gap:8px}
 #mobile-input-wrap{flex:1;position:relative;min-width:0;display:flex}
+/* 16px is a hard floor, not a taste call: iOS Safari / WKWebView auto-zooms the
+   page whenever a focused form control renders below 16px, and it never zooms
+   back out — the terminal is left scaled up with its right-hand columns off
+   screen. -webkit-text-size-adjust does NOT prevent that (it only stops the
+   text-inflation algorithm), so the size itself has to be 16px. */
 #mobile-input{
   flex:1;min-width:0;min-height:42px;max-height:120px;resize:none;overflow-y:auto;
   padding:10px 12px;border:1px solid #2a2b3d;border-radius:10px;background:#1c1c24;color:#e4e6f0;
-  font:14px/1.3 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+  font:16px/1.3 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
   -webkit-text-size-adjust:100%;text-size-adjust:100%}
 #mobile-input::placeholder{color:#565f89}
 #mobile-bar-row button{
@@ -18416,17 +18421,21 @@ if(isTouch&&hasToken){(function(){
     measureBar();}
   function showKeyboard(){try{ta.focus({preventScroll:true})}catch(e){ta.focus();}}
 
-  function sendBuffered(appendEnter){
+  // 上屏 puts the text into the CLI's own input box and stops there — the user
+  // eyeballs it and presses Enter themselves. It must append NOTHING: a newline
+  // lands inside that box as a literal line break (a TUI reads it as "insert"),
+  // so the text showed up with a stray empty line after it. Only the Enter key
+  // (or live mode's own commit) sends the \\r that actually runs the command.
+  function sendBuffered(){
     var text=ta.value;
-    var payload=appendEnter?text+'\\n':text;
-    if(!payload)return;
-    if(!sendInput(payload.replace(/\\x1b/g,'')))return;
+    if(!text)return;
+    if(!sendInput(text.replace(/\\x1b/g,'')))return;
     ta.value='';resizeTa();
     if(mode===LIVE){mirror.sent=mirror.held='';}
     showKeyboard();}
   function sendLiveCommit(appendEnter){
     if(sendLiveKey(appendEnter?'\\r':''))showKeyboard();}
-  function submit(){if(mode===LIVE)sendLiveCommit(true);else sendBuffered(true);}
+  function submit(){if(mode===LIVE)sendLiveCommit(true);else sendBuffered();}
 
   // shortcut keys row
   var sk={ctrlc:'\\x03',esc:'\\x1b',tab:'\\t',left:'\\x1b[D',right:'\\x1b[C',up:'\\x1b[A',down:'\\x1b[B',bs:'\\x7f',enter:'\\r',stab:'\\x1b[Z'};

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18525,15 +18525,20 @@ if(isTouch&&hasToken){(function(){
     if(mode===LIVE&&!mirror.composing&&!e.isComposing&&['Tab','Escape','ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].indexOf(e.key)>=0){
       e.preventDefault();
       sendLiveKey({Tab:'\\t',Escape:'\\x1b',ArrowUp:'\\x1b[A',ArrowDown:'\\x1b[B',ArrowLeft:'\\x1b[D',ArrowRight:'\\x1b[C'}[e.key]);return;}
-    // Backspace on an EMPTY textarea has to be forwarded by hand. Live mode
-    // otherwise only ever sends what the 'input' listener diffs — and deleting
-    // from an empty box changes nothing, so the browser fires beforeinput but
-    // NO input event at all (verified in a real browser). The result was that
-    // text already on the terminal — typed in buffer mode and 上屏'd, or typed
-    // live and mirrored away — could not be erased with the system keyboard:
-    // every Backspace was silently dropped. Non-empty is left to the diff so a
-    // pending IME draft still edits locally instead of eating terminal chars.
-    if(mode===LIVE&&!mirror.composing&&!e.isComposing&&e.key==='Backspace'&&!ta.value){
+    // Backspace on an EMPTY textarea has to be forwarded by hand, in BOTH modes.
+    // Live mode otherwise only ever sends what the 'input' listener diffs, and
+    // buffer mode does not send keystrokes at all — but deleting from an empty
+    // box changes nothing, so the browser fires beforeinput and NO input event
+    // (verified in a real browser). Either way the keystroke evaporates.
+    // An empty box has no draft to edit, so the only thing Backspace can
+    // sensibly mean there is "delete on the terminal" — which is exactly what
+    // the bottom bar's ⌫ (aria-label 删除终端字符) already does in both modes.
+    // Leaving it mode-gated made the two disagree in the same visible state:
+    // after 上屏 the box is empty and the text is on the terminal, yet the
+    // system keyboard could not erase it while ⌫ could.
+    // Non-empty is still left alone so a pending IME draft edits locally
+    // instead of eating terminal characters.
+    if(!mirror.composing&&!e.isComposing&&e.key==='Backspace'&&!ta.value){
       e.preventDefault();
       sendInput('\\x7f');return;}
     if(e.key==='Enter'&&!e.shiftKey&&!mirror.composing&&!e.isComposing){e.preventDefault();submit();}});

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18439,7 +18439,7 @@ if(isTouch&&hasToken){(function(){
   // terminal and the box was cleared, and pressing Enter is literally step 3 of
   // the 上屏 → 检查 → Enter flow this bar is built around. sendBuffered() bails on
   // empty text, and the keydown handler has already called preventDefault(), so
-  // routing there would make the key vanish entirely. Send the \r the key-row ⏎
+  // routing there would make the key vanish entirely. Send the \\r the key-row ⏎
   // button already sends in this exact state — same reasoning as the empty-box
   // Backspace below: an empty box has no draft, so the key belongs to the terminal.
   function submit(){if(mode===LIVE)sendLiveCommit(true);else if(ta.value)sendBuffered();else sendInput('\\r');}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18398,11 +18398,11 @@ if(isTouch&&hasToken){(function(){
     mirror.sent=mirror.held='';ta.value='';resizeTa();return true;}
 
   // Buffer mode types the text into the CLI's own input box WITHOUT submitting
-  // (the payload ends in a newline, which a TUI treats as "insert", not "run"),
-  // so the button is labelled 上屏 there and the user presses the Enter key once
-  // the text looks right. Live mode's button really does submit (it appends a
-  // carriage return), so it keeps 发送 — same reason the mode button spells out
-  // the extra Enter step.
+  // (it sends the text and nothing else — no trailing newline, which a TUI would
+  // insert as a literal line break rather than run), so the button is labelled
+  // 上屏 there and the user presses the Enter key once the text looks right. Live
+  // mode's button really does submit (it appends a carriage return), so it keeps
+  // 发送 — same reason the mode button spells out the extra Enter step.
   function setMode(m){mode=m;bar.setAttribute('data-mode',m);
     modeBtn.textContent=m===LIVE?'实时':'缓冲';
     sendBtn.textContent=m===LIVE?'发送':'上屏';
@@ -18435,7 +18435,14 @@ if(isTouch&&hasToken){(function(){
     showKeyboard();}
   function sendLiveCommit(appendEnter){
     if(sendLiveKey(appendEnter?'\\r':''))showKeyboard();}
-  function submit(){if(mode===LIVE)sendLiveCommit(true);else sendBuffered();}
+  // An EMPTY box in buffer mode still has to submit: after 上屏 the text is on the
+  // terminal and the box was cleared, and pressing Enter is literally step 3 of
+  // the 上屏 → 检查 → Enter flow this bar is built around. sendBuffered() bails on
+  // empty text, and the keydown handler has already called preventDefault(), so
+  // routing there would make the key vanish entirely. Send the \r the key-row ⏎
+  // button already sends in this exact state — same reasoning as the empty-box
+  // Backspace below: an empty box has no draft, so the key belongs to the terminal.
+  function submit(){if(mode===LIVE)sendLiveCommit(true);else if(ta.value)sendBuffered();else sendInput('\\r');}
 
   // shortcut keys row
   var sk={ctrlc:'\\x03',esc:'\\x1b',tab:'\\t',left:'\\x1b[D',right:'\\x1b[C',up:'\\x1b[A',down:'\\x1b[B',bs:'\\x7f',enter:'\\r',stab:'\\x1b[Z'};

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18502,6 +18502,22 @@ if(isTouch&&hasToken){(function(){
     }
   })(keyBtns[i]);}
 
+  // Tapping ANY bar button must not blur the textarea. iOS retracts the
+  // software keyboard the moment the focused element loses focus, and this bar
+  // rides above the keyboard (transform: -var(--keyboard-inset)) — so the
+  // keyboard closing yanks the whole bar down by ~300px while the finger is
+  // still on the glass. The button the user aims at next has moved, which is
+  // exactly the mis-tap being reported. Cancelling pointerdown suppresses the
+  // pointer-initiated focus transfer; click, form submit, :active feedback and
+  // the key row's horizontal scroll all still work (verified in a real
+  // browser — Backspace/Ctrl-C/mode/上屏 all kept focus on #mobile-input).
+  // Buttons only: the textarea itself must keep focusing and placing its caret,
+  // and Tab focus is unaffected because only pointer-driven focus is cancelled.
+  var barBtns=bar.querySelectorAll('button');
+  for(var bbi=0;bbi<barBtns.length;bbi++){
+    barBtns[bbi].addEventListener('pointerdown',function(e){e.preventDefault();});
+  }
+
   modeBtn.addEventListener('click',function(){modeBtn.blur();
     // switching away from live flushes pending held text
     if(mode===LIVE&&!sendLiveKey(''))return;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18513,6 +18513,9 @@ if(isTouch&&hasToken){(function(){
   // browser — Backspace/Ctrl-C/mode/上屏 all kept focus on #mobile-input).
   // Buttons only: the textarea itself must keep focusing and placing its caret,
   // and Tab focus is unaffected because only pointer-driven focus is cancelled.
+  // Static NodeList, captured once: the bar's buttons must stay in the initial
+  // markup. A button added later would miss this handler AND the disable pass
+  // over 'controls' below, so both regress together rather than silently apart.
   var barBtns=bar.querySelectorAll('button');
   for(var bbi=0;bbi<barBtns.length;bbi++){
     barBtns[bbi].addEventListener('pointerdown',function(e){e.preventDefault();});

--- a/test/web-terminal-mobile-input.test.ts
+++ b/test/web-terminal-mobile-input.test.ts
@@ -431,6 +431,59 @@ describe('手机 Web 终端输入栏', () => {
     expect(Number.parseFloat(fontSize![1])).toBeGreaterThanOrEqual(16);
   });
 
+  it('实时模式下输入框已空时，系统键盘的删除键仍然删得掉终端里的字符', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+    page.controls.find(control => control.id === 'mobile-mode')?.dispatch('click');
+    expect(page.bar.getAttribute('data-mode')).toBe('live');
+
+    // The regression this pins: live mode only ever sends what the textarea's
+    // `input` event diffs, and deleting from an EMPTY box changes nothing — so a
+    // real browser fires beforeinput but NO input event at all (verified with
+    // Playwright + a real worker). Every Backspace was silently dropped, which
+    // is exactly what "上屏 的字用系统键盘删不掉" looks like: the text is on the
+    // terminal, the box is empty, and the key does nothing.
+    page.textarea.value = '';
+    page.textarea.dispatch('keydown', { key: 'Backspace' });
+    expect(page.sentInputs()).toEqual(['\x7f']);
+
+    // A pending IME draft must still edit locally instead of eating terminal
+    // characters, so a non-empty box is left to the diff path (which the browser
+    // does drive with a real input event).
+    page.textarea.value = 'ab';
+    page.textarea.dispatch('keydown', { key: 'Backspace' });
+    expect(page.sentInputs()).toEqual(['\x7f']);
+  });
+
+  it('缓冲模式下删除键不被接管，仍然只编辑输入框', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+    expect(page.bar.getAttribute('data-mode')).toBe('buffer');
+    page.textarea.value = '';
+    page.textarea.dispatch('keydown', { key: 'Backspace' });
+    // Buffer mode's box is a staging area — an empty-box Backspace there means
+    // "nothing to delete", not "delete a terminal character".
+    expect(page.sentInputs()).toEqual([]);
+  });
+
+  it('切进实时模式时，输入框里没上屏的文字要送上终端而不是隐形留着', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+    page.textarea.value = 'hello';
+    page.controls.find(control => control.id === 'mobile-mode')?.dispatch('click');
+
+    // Live mode renders the textarea transparent, so leftover text is invisible
+    // to the user while still being the mirror's baseline mismatch: the next
+    // keystroke diffed '' → 'hell' and INSERTED the stale text into the terminal
+    // instead of deleting anything. Flush it the way 上屏 does.
+    expect(page.sentInputs()).toEqual(['hello']);
+    expect(page.textarea.value).toBe('');
+
+    // …and it must stay an insert, not a submit — the two-step semantics hold.
+    expect(page.sentInputs().some(sequence => sequence.endsWith('\r'))).toBe(false);
+
+    // With the box actually empty, the very next Backspace reaches the terminal.
+    page.textarea.dispatch('keydown', { key: 'Backspace' });
+    expect(page.sentInputs()).toEqual(['hello', '\x7f']);
+  });
+
   it('底栏按钮抑制 iOS 长按选中与 callout，避免长按删除时弹出选择气泡', () => {
     const source = workerSource();
     // `user-select` alone leaves the WKWebView selection handles / callout menu

--- a/test/web-terminal-mobile-input.test.ts
+++ b/test/web-terminal-mobile-input.test.ts
@@ -317,6 +317,10 @@ describe('手机 Web 终端输入栏', () => {
 
       // …and releasing stops it immediately (no ticks after pointerup).
       backspace?.dispatch('pointerup');
+      // The browser always sends a click when the finger lifts — it arrives
+      // AFTER the repeat ticks, so it must be swallowed rather than delete one
+      // more character than the user watched tick by.
+      backspace?.dispatch('click');
       vi.advanceTimersByTime(600);
       expect(page.sentInputs().length).toBe(whileHeld);
     } finally {
@@ -356,6 +360,31 @@ describe('手机 Web 终端输入栏', () => {
       dropped.setWriteState?.(null);
       vi.advanceTimersByTime(600);
       expect(dropped.sentInputs().length).toBe(beforeDrop);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('长按后手指滑开(无 click)，下一次单击仍然生效——吞掉尾随 click 的标志必须每次按下重置', () => {
+    vi.useFakeTimers();
+    try {
+      const page = bootMobileInput({ wsHasWrite: true });
+
+      // Slide off after the repeat has started: pointerleave stops the ticks and
+      // the browser sends NO click, so the swallow flag is left armed.
+      page.shortcut('bs')?.dispatch('pointerdown');
+      vi.advanceTimersByTime(450 + 60 * 3);
+      page.shortcut('bs')?.dispatch('pointerleave');
+      const afterSlide = page.sentInputs().length;
+      expect(afterSlide).toBe(3);
+
+      // The next plain tap must still delete one character. Without the reset on
+      // pointerdown the stale flag eats it and the key silently does nothing.
+      page.shortcut('bs')?.dispatch('pointerdown');
+      vi.advanceTimersByTime(100);
+      page.shortcut('bs')?.dispatch('pointerup');
+      page.shortcut('bs')?.dispatch('click');
+      expect(page.sentInputs().length).toBe(afterSlide + 1);
     } finally {
       vi.useRealTimers();
     }

--- a/test/web-terminal-mobile-input.test.ts
+++ b/test/web-terminal-mobile-input.test.ts
@@ -227,7 +227,9 @@ describe('手机 Web 终端输入栏', () => {
     const connected = bootMobileInput({ wsHasWrite: true });
     connected.textarea.value = 'ship it';
     connected.bar.dispatch('submit');
-    expect(connected.sentInputs()).toEqual(['ship it\n']);
+    // 上屏 types the text into the CLI's input box and stops — no trailing
+    // newline, which would land there as a literal blank line.
+    expect(connected.sentInputs()).toEqual(['ship it']);
     expect(connected.textarea.value).toBe('');
   });
 
@@ -357,6 +359,47 @@ describe('手机 Web 终端输入栏', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('「上屏」只把正文送上终端，不追加换行——追加的换行会在 CLI 输入框里留下一个空行', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+    page.textarea.value = '继续';
+    page.bar.dispatch('submit');
+
+    const sent = page.sentInputs();
+    expect(sent).toEqual(['继续']);
+    // The regression this pins: a trailing \n is NOT a submit in a TUI, it is an
+    // inserted line break, so the text showed up with a stray empty line after it.
+    expect(sent.some(sequence => sequence.endsWith('\n'))).toBe(false);
+    // …and it must not silently become a real submit either — that would throw
+    // away the deliberate two-step 上屏 → 检查 → Enter semantics.
+    expect(sent.some(sequence => sequence.endsWith('\r'))).toBe(false);
+
+    // The Enter key is what actually runs it, and it still does.
+    page.shortcut('enter')?.dispatch('click');
+    expect(page.sentInputs()).toEqual(['继续', '\r']);
+  });
+
+  it('实时模式的「发送」仍然真提交，两步语义只属于缓冲模式', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+    page.controls.find(control => control.id === 'mobile-mode')?.dispatch('click');
+    page.textarea.value = 'ls';
+    page.bar.dispatch('submit');
+    // live mode diffs the mirror and appends a carriage return: a real submit.
+    expect(page.sentInputs().join('').endsWith('\r')).toBe(true);
+  });
+
+  it('输入框字号不低于 16px，否则 iOS 聚焦时会自动放大页面且不再缩回', () => {
+    const source = workerSource();
+    const start = source.indexOf('#mobile-input{');
+    expect(start, '#mobile-input 规则缺失').toBeGreaterThan(-1);
+    const rule = source.slice(start, source.indexOf('}', start));
+    const fontSize = rule.match(/font:\s*(\d+(?:\.\d+)?)px/);
+    expect(fontSize, '#mobile-input 未声明 px 字号').not.toBeNull();
+    // Hard floor, not a taste call: below 16px, iOS Safari / WKWebView zooms the
+    // page on focus and never zooms back, pushing the terminal's right-hand
+    // columns off screen. -webkit-text-size-adjust does not prevent this.
+    expect(Number.parseFloat(fontSize![1])).toBeGreaterThanOrEqual(16);
   });
 
   it('底栏按钮抑制 iOS 长按选中与 callout，避免长按删除时弹出选择气泡', () => {

--- a/test/web-terminal-mobile-input.test.ts
+++ b/test/web-terminal-mobile-input.test.ts
@@ -454,13 +454,31 @@ describe('手机 Web 终端输入栏', () => {
     expect(page.sentInputs()).toEqual(['\x7f']);
   });
 
-  it('缓冲模式下删除键不被接管，仍然只编辑输入框', () => {
+  it('缓冲模式下「上屏」后输入框已空，系统键盘的删除键同样删得掉终端里的字符', () => {
     const page = bootMobileInput({ wsHasWrite: true });
     expect(page.bar.getAttribute('data-mode')).toBe('buffer');
-    page.textarea.value = '';
+
+    // 上屏 puts the text on the terminal and empties the box.
+    page.textarea.value = 'hello';
+    page.bar.dispatch('submit');
+    expect(page.sentInputs()).toEqual(['hello']);
+    expect(page.textarea.value).toBe('');
+
+    // An empty box has no draft to edit, so Backspace can only sensibly mean
+    // "delete on the terminal" — the same thing the bottom bar's ⌫ (aria-label
+    // 删除终端字符) already does in this exact state. Gating the forwarding on
+    // live mode made the two disagree while looking identical to the user: the
+    // text sits on the terminal, the box is empty, ⌫ erases it and the system
+    // keyboard's delete key does nothing.
     page.textarea.dispatch('keydown', { key: 'Backspace' });
-    // Buffer mode's box is a staging area — an empty-box Backspace there means
-    // "nothing to delete", not "delete a terminal character".
+    expect(page.sentInputs()).toEqual(['hello', '\x7f']);
+  });
+
+  it('缓冲模式下输入框非空时，删除键仍然只编辑草稿，不碰终端', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+    expect(page.bar.getAttribute('data-mode')).toBe('buffer');
+    page.textarea.value = 'ab';
+    page.textarea.dispatch('keydown', { key: 'Backspace' });
     expect(page.sentInputs()).toEqual([]);
   });
 

--- a/test/web-terminal-mobile-input.test.ts
+++ b/test/web-terminal-mobile-input.test.ts
@@ -62,7 +62,11 @@ class FakeElement {
   }
 
   querySelectorAll(selector: string): FakeElement[] {
-    return selector === 'button,textarea' ? this.descendants : [];
+    if (selector === 'button,textarea') return this.descendants;
+    // The bar cancels pointerdown on its buttons only — the textarea must keep
+    // taking focus, so this selector deliberately excludes it.
+    if (selector === 'button') return this.descendants.filter(node => node.id !== 'mobile-input');
+    return [];
   }
 }
 
@@ -565,6 +569,45 @@ describe('手机 Web 终端输入栏', () => {
     // With the box actually empty, the very next Backspace reaches the terminal.
     page.textarea.dispatch('keydown', { key: 'Backspace' });
     expect(page.sentInputs()).toEqual(['hello', '\x7f']);
+  });
+
+  it('点底栏按钮不会让输入框失焦——失焦会收起系统键盘、底栏整体下移导致点错', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+
+    // The regression this pins: a button tap moved focus mobile-input → BODY
+    // (measured in a real browser). iOS retracts the software keyboard the
+    // instant the focused element blurs, and this bar rides above the keyboard
+    // (transform: -var(--keyboard-inset)), so the whole bar drops ~300px while
+    // the finger is still down — the next button is no longer where the user
+    // aimed. Cancelling pointerdown suppresses the pointer-driven focus
+    // transfer without touching click / submit / :active / row scrolling.
+    const prevented: Array<string | null> = [];
+    for (const control of page.controls) {
+      control.dispatch('pointerdown', { preventDefault: () => prevented.push(control.id) });
+    }
+
+    // Every button cancels it…
+    expect(prevented).toEqual(
+      page.controls.filter(control => control.id !== 'mobile-input').map(control => control.id),
+    );
+    // …and the textarea deliberately does NOT: it has to keep taking focus and
+    // placing the caret where the finger landed.
+    expect(prevented).not.toContain('mobile-input');
+  });
+
+  it('抑制失焦不能顺带吃掉按钮本身的功能：click、上屏提交、长按重复都照旧', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+
+    // preventDefault on pointerdown does not cancel the click that follows, so
+    // every key still sends its sequence.
+    page.shortcut('bs')?.dispatch('pointerdown');
+    page.shortcut('bs')?.dispatch('click');
+    expect(page.sentInputs()).toEqual(['\x7f']);
+
+    // 上屏 is type="submit"; the form submit still fires.
+    page.textarea.value = 'hi';
+    page.bar.dispatch('submit');
+    expect(page.sentInputs()).toEqual(['\x7f', 'hi']);
   });
 
   it('底栏按钮抑制 iOS 长按选中与 callout，避免长按删除时弹出选择气泡', () => {

--- a/test/web-terminal-mobile-input.test.ts
+++ b/test/web-terminal-mobile-input.test.ts
@@ -482,6 +482,71 @@ describe('手机 Web 终端输入栏', () => {
     expect(page.sentInputs()).toEqual([]);
   });
 
+  it('「上屏」之后输入框已空，系统键盘按 Enter 仍然要提交——两步语义的第 3 步不能蒸发', () => {
+    const page = bootMobileInput({ wsHasWrite: true });
+    page.textarea.value = '继续';
+    page.bar.dispatch('submit');
+    expect(page.sentInputs()).toEqual(['继续']);
+    expect(page.textarea.value).toBe('');
+
+    // 上屏 → 检查 → Enter is the whole point of buffer mode, and after 上屏 the
+    // box is empty by design. sendBuffered() bails on empty text while the
+    // keydown handler has already called preventDefault(), so without the empty
+    // box branch this key vanishes with no fallback — the user watches 上屏 put
+    // the text on the terminal and then cannot run it from the system keyboard.
+    page.textarea.dispatch('keydown', { key: 'Enter' });
+    expect(page.sentInputs()).toEqual(['继续', '\r']);
+  });
+
+  it('同一状态下系统键盘 Enter 与底栏 ⏎ 必须发出同一个字节，两种模式都一致', () => {
+    // The defect this pins is an inconsistency between two entry points in one
+    // visible state, which is the same shape as the Backspace gap above: the
+    // key-row ⏎ worked after 上屏 while the system keyboard did nothing.
+    const viaKeyboard = (live: boolean): string[] => {
+      const page = bootMobileInput({ wsHasWrite: true });
+      if (live) page.controls.find(control => control.id === 'mobile-mode')?.dispatch('click');
+      page.textarea.value = '';
+      page.textarea.dispatch('keydown', { key: 'Enter' });
+      return page.sentInputs();
+    };
+    const viaButton = (live: boolean): string[] => {
+      const page = bootMobileInput({ wsHasWrite: true });
+      if (live) page.controls.find(control => control.id === 'mobile-mode')?.dispatch('click');
+      page.textarea.value = '';
+      page.shortcut('enter')?.dispatch('click');
+      return page.sentInputs();
+    };
+    expect(viaKeyboard(false)).toEqual(['\r']);
+    expect(viaButton(false)).toEqual(['\r']);
+    expect(viaKeyboard(true)).toEqual(['\r']);
+    expect(viaButton(true)).toEqual(['\r']);
+  });
+
+  it('输入法组合中按删除键不转发给终端，待选草稿的退格只能编辑草稿', () => {
+    // Load-bearing guard with no coverage before this: dropping
+    // `!mirror.composing && !e.isComposing` still left every other case green,
+    // but a Chinese/Japanese IME candidate-editing backspace would then eat a
+    // terminal character instead of editing the pending draft.
+    for (const live of [false, true]) {
+      // composition tracked through compositionstart (mirror.composing)
+      const viaEvent = bootMobileInput({ wsHasWrite: true });
+      if (live) viaEvent.controls.find(control => control.id === 'mobile-mode')?.dispatch('click');
+      const baseline = viaEvent.sentInputs().length;
+      viaEvent.textarea.dispatch('compositionstart');
+      viaEvent.textarea.value = '';
+      viaEvent.textarea.dispatch('keydown', { key: 'Backspace' });
+      expect(viaEvent.sentInputs().length, `composing backspace leaked (live=${live})`).toBe(baseline);
+
+      // …and through the event's own isComposing flag
+      const viaFlag = bootMobileInput({ wsHasWrite: true });
+      if (live) viaFlag.controls.find(control => control.id === 'mobile-mode')?.dispatch('click');
+      const flagBaseline = viaFlag.sentInputs().length;
+      viaFlag.textarea.value = '';
+      viaFlag.textarea.dispatch('keydown', { key: 'Backspace', isComposing: true });
+      expect(viaFlag.sentInputs().length, `isComposing backspace leaked (live=${live})`).toBe(flagBaseline);
+    }
+  });
+
   it('切进实时模式时，输入框里没上屏的文字要送上终端而不是隐形留着', () => {
     const page = bootMobileInput({ wsHasWrite: true });
     page.textarea.value = 'hello';

--- a/test/web-terminal-served-script-parses.test.ts
+++ b/test/web-terminal-served-script-parses.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// The whole web terminal ships as ONE TypeScript template literal inside
+// getTerminalHtml(). That means every backslash escape in the source gets one
+// round of processing on the way out: `\\r` in worker.ts reaches the browser as
+// the two characters `\r`, but a bare `\r` reaches it as an actual carriage
+// return. Inside a `//` comment a real CR terminates the comment, and whatever
+// followed it on that line is suddenly parsed as code — which throws a
+// SyntaxError that kills the ENTIRE inline script, not just that line. The
+// terminal then never boots: no xterm, no input bar handlers, nothing.
+//
+// This is invisible to the other web-terminal tests. They all read worker.ts as
+// TEXT and either grep it or slice out a fragment and `replaceAll('\\\\','\\')`
+// it — an approximation of template-literal processing applied to the source,
+// which leaves a lone `\r` as the harmless two-character sequence it is in the
+// source. Only the emitted HTML has the real control character, so only a test
+// that looks at the emitted HTML can catch this.
+//
+// Rather than execute the page (it needs a DOM, a WebSocket and a live worker),
+// this parses it: a SyntaxError anywhere in the script is exactly the failure
+// mode, and `new Function` reports it without running a line.
+
+const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+
+/**
+ * Recover the served text of the getTerminalHtml template literal by applying
+ * the one escape-processing pass the TypeScript compiler applies to it.
+ * Deliberately does NOT interpolate `${...}` — those are runtime values, and
+ * the parse check below tolerates them by blanking them out.
+ */
+function servedHtml(): string {
+  const start = workerSource.indexOf('function getTerminalHtml(');
+  expect(start, 'worker.ts 里找不到 getTerminalHtml').toBeGreaterThan(-1);
+  const open = workerSource.indexOf('return `', start);
+  expect(open, 'getTerminalHtml 里找不到模板字符串起点').toBeGreaterThan(-1);
+  const bodyStart = open + 'return `'.length;
+
+  // Walk to the closing backtick, honouring escapes and nested ${...} spans so
+  // a backtick inside an interpolation does not read as the end of the literal.
+  let i = bodyStart;
+  let depth = 0;
+  for (; i < workerSource.length; i++) {
+    const ch = workerSource[i];
+    if (ch === '\\') { i++; continue; }
+    if (ch === '$' && workerSource[i + 1] === '{') { depth++; i++; continue; }
+    if (ch === '}' && depth > 0) { depth--; continue; }
+    if (ch === '`' && depth === 0) break;
+  }
+  expect(i, 'getTerminalHtml 的模板字符串没有闭合').toBeLessThan(workerSource.length);
+  const raw = workerSource.slice(bodyStart, i);
+
+  // One pass of escape processing, the same one the compiler performs.
+  return raw.replace(/\\(u\{[0-9a-fA-F]+\}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2}|[\s\S])/g, (_m, esc: string) => {
+    switch (esc[0]) {
+      case 'n': return '\n';
+      case 'r': return '\r';
+      case 't': return '\t';
+      case 'b': return '\b';
+      case 'f': return '\f';
+      case 'v': return '\v';
+      case '0': return esc === '0' ? '\0' : esc;
+      case 'x': return String.fromCharCode(parseInt(esc.slice(1), 16));
+      case 'u': return esc[1] === '{'
+        ? String.fromCodePoint(parseInt(esc.slice(2, -1), 16))
+        : String.fromCharCode(parseInt(esc.slice(1), 16));
+      default: return esc;
+    }
+  });
+}
+
+function inlineScripts(html: string): string[] {
+  const out: string[] = [];
+  const re = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    if (m[1].trim()) out.push(m[1]);
+  }
+  return out;
+}
+
+describe('getTerminalHtml 发出的内联脚本必须是合法 JS', () => {
+  it('模板字符串里的转义不会在注释中变成真实控制字符', () => {
+    const html = servedHtml();
+    const scripts = inlineScripts(html);
+    // If this drops to zero the test would pass vacuously — the exact failure
+    // shape this file exists to prevent.
+    expect(scripts.length, '没有解出任何内联脚本，说明提取逻辑坏了').toBeGreaterThan(0);
+
+    for (const script of scripts) {
+      // `${...}` spans are runtime interpolations; blank them to a literal so
+      // the remainder parses as the shape it will have in the browser.
+      const parseable = script.replace(/\$\{[\s\S]*?\}/g, '0');
+      expect(() => new Function(parseable)).not.toThrow();
+    }
+  });
+
+  it('任何 // 注释里都不含真实换行/回车（会截断注释并让整段脚本 SyntaxError）', () => {
+    const html = servedHtml();
+    for (const script of inlineScripts(html)) {
+      // A CR that is not part of a CRLF pair, anywhere in the emitted script,
+      // is the fingerprint: worker.ts writes the whole document with \n.
+      const strayCr = /\r(?!\n)/.exec(script);
+      expect(
+        strayCr,
+        strayCr
+          ? `发出的脚本里出现真实回车（源码里应写 \\\\r 而不是 \\r）：`
+            + JSON.stringify(script.slice(Math.max(0, strayCr.index - 90), strayCr.index + 30))
+          : '',
+      ).toBeNull();
+    }
+  });
+});

--- a/test/web-terminal-served-script-parses.test.ts
+++ b/test/web-terminal-served-script-parses.test.ts
@@ -21,6 +21,14 @@ import { describe, expect, it } from 'vitest';
 // Rather than execute the page (it needs a DOM, a WebSocket and a live worker),
 // this parses it: a SyntaxError anywhere in the script is exactly the failure
 // mode, and `new Function` reports it without running a line.
+//
+// Known gap, deliberately not closed here: a bare `\n` (or the U+2028 / U+2029
+// line separators, named here rather than written literally because they would
+// terminate this very comment) in a `//` comment also becomes a real line break
+// and truncates the comment. If what follows happens to be valid JS there is no
+// SyntaxError, so the parse check passes -- and the CR fingerprint below cannot
+// see it either, because real LFs are everywhere in the emitted document. The
+// bug this file was written for was a `\r`, which both checks do catch.
 
 const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
 
@@ -98,7 +106,11 @@ describe('getTerminalHtml 发出的内联脚本必须是合法 JS', () => {
 
   it('任何 // 注释里都不含真实换行/回车（会截断注释并让整段脚本 SyntaxError）', () => {
     const html = servedHtml();
-    for (const script of inlineScripts(html)) {
+    const scripts = inlineScripts(html);
+    // Same vacuous-pass guard as above: with zero scripts the loop below runs
+    // zero assertions and this test goes green on a broken extractor.
+    expect(scripts.length, '没有解出任何内联脚本，说明提取逻辑坏了').toBeGreaterThan(0);
+    for (const script of scripts) {
       // A CR that is not part of a CRLF pair, anywhere in the emitted script,
       // is the fingerprint: worker.ts writes the whole document with \n.
       const strayCr = /\r(?!\n)/.exec(script);


### PR DESCRIPTION
## 背景

`#1248` 上线后在 iOS 飞书真机测出两个问题（均由 owner 实测反馈），另外补上 `#1248` review 时发现、当时未修的第三条：

1. **点「上屏」后 CLI 输入框里多出一个换行。**
2. **点输入框时 iOS 会放大整个页面**，导致 web 终端右侧文字看不全，而且不会自动缩回。
3. **长按 ⌫ 松手时会多删一个字符**（`#1248` review 的遗留项 F1）。
4. **缓冲模式打的字，切到实时模式后用系统自带键盘删不掉**（owner 后续实测反馈）。
5. **缓冲模式下「上屏」之后，用系统键盘也删不掉上屏的文字**（owner 再次实测反馈；第 4 条修完只覆盖了实时模式，缓冲模式仍不通）。
6. **上屏之后输入框已空时，系统键盘按 Enter 不提交**（评审发现，由第 1 条引入的回归）。
7. **点底栏按钮会收起系统键盘，底栏整体下移导致点错**（owner 再次实测反馈）。
8. **注释里的裸 `\r` 让整段手机终端脚本 SyntaxError**（评审发现，由第 6 条引入的回归；页面级白屏）。

## 根因与改动

### 1. 「上屏」不再追加换行

`sendBuffered` 原本发的是 `text + '\n'`。而 TUI 把换行当**「插入」**不当「执行」——所以那个 `\n` 既没有提交，又在 CLI 的输入框里留下一个**字面换行**，正是用户看到的多余空行。

真 PTY 实测（raw-mode TUI，逐字节上报）：

| 载荷 | 缓冲区最终内容 | 是否提交 |
| --- | --- | --- |
| `"继续\n"`（改前） | `"继续\n"` | ❌ 否 |
| `"继续"`（改后） | `"继续"` | ❌ 否 |

两者都不提交，但前者污染了输入框。改为**不追加任何字符**，「上屏」名副其实。真正的提交仍由 Enter 键（发 `\r`）完成——**两步语义（上屏 → 检查 → Enter）保持不变**，这正是 `#1248` 刻意保留的设计。实时模式的「发送」走 `sendLiveCommit`，不受影响。

> 一个容易踩的反向修法：把 `'\n'` 换成 `'\r'`。那样「多余空行」确实不见了，但 `\r` 会**真正提交**，等于把上面这条两步语义直接拆掉——用户还没检查就执行了。所以正解是「不追加」，不是「换一个字符」。

### 2. 输入框字号 14px → 16px

iOS Safari / WKWebView 对**字号低于 16px 的表单控件**会在聚焦时自动放大页面，并且不会缩回。`#mobile-input` 原为 14px。

注意 `-webkit-text-size-adjust:100%` **拦不住这个行为**——它只影响文本膨胀算法，不影响聚焦缩放，所以必须把字号本身提到 16px。也没有采用 `user-scalable=no` / `maximum-scale=1` 那类做法：本页面**刻意支持双指缩放**（`touch-action:pinch-zoom`），禁用缩放会伤可访问性。

### 3. 长按松手不再多删一个字符

`click` 事件在手指**松开**时才触发，所以它排在所有重复 tick **之后**，而不是之前。用户长按 1.2 秒眼看着删了 12 次，实际被删掉 13 个字符——松手这个「停」的动作本身又下了一条删除指令。原注释写的「第一次由 click 处理器发出」方向正好反了，一并改正。

修法是**标志位**而非时间窗：重复真的跑过至少一次后置位，`click` 处理器看到它就吞掉这一次并复位。时间窗（「刚 tick 过 N 毫秒内忽略 click」）会误伤「松手后立刻再点一下」的快速连点。

标志位**在每次 `pointerdown` 复位是承重的**，不是防御性冗余：滑出按键时 `pointerleave` 停掉重复，但浏览器**不会**补发 `click`，标志位就会一直举着，下一次真实单击被静默吃掉、按键看起来失灵。这条已用真浏览器打出来（见下表）。

### 4 / 5. 输入框为空时，系统键盘的删除键不再被吞（两种模式都是）

实时模式**唯一的发送路径**是 textarea 的 `input` 事件 → `syncMirror` 逐字符 diff。而**从空输入框删除不会改变任何内容**，所以浏览器只发 `keydown` + `beforeinput[deleteContentBackward]`，**根本不发 `input`** —— 这条路径在结构上不可达，每一次 Backspace 都被静默丢弃。

真浏览器事件流实测（这是定性的决定性证据，不是看代码推的）：

```
keydown(Backspace) → beforeinput[deleteContentBackward] → keyup(Backspace)
                                   ↑ 没有 input 事件
```

这正好解释了用户的现象：缓冲模式打的字「上屏」后已经在终端里、输入框是空的，此时切到实时模式想用系统键盘删掉它们，一个都删不动。而**同一状态下点底栏的 ⌫ 按钮却正常** —— 它直接发 `\x7f`，不走 diff 路径。范围因此收敛为「系统键盘」，与反馈一致。

修法是在 keydown 里手工补发：不在输入法组合中、且 **textarea 为空**时，`preventDefault` 并直接发 `\x7f`。**非空时仍然交给原有路径** —— 否则输入法待选草稿里的删除会变成吃掉终端字符，而不是编辑草稿。

**第 5 条是同一个机制在缓冲模式下的另一半。** 第 4 条的修复一开始把这个分支限定在 `mode===LIVE`，缓冲模式不接管。但缓冲模式点「上屏」之后，文字已经在终端上、输入框被清空 —— 从空框删除同样不产生 `input` 事件，而缓冲模式本来就不逐键发送，两条路都不通。结果是**同一个可见状态下，底栏 ⌫ 删得掉、系统键盘删不掉**。

判据因此收敛为「**输入框为空**」而不是「处于实时模式」：空输入框里没有草稿可编辑，删除键在那里只可能是「删终端里的字符」，这正是底栏 ⌫（`aria-label="删除终端字符"`）在两种模式下一贯的语义。桌面端 xterm 隐藏 textarea 的 IME 接管逻辑早就是同一条边界 —— `attachCustomKeyEventHandler` 里空 textarea 交给终端发标准 `\x7f`、非空才认作待编辑草稿。这条修正让手机底栏与仓库里既有的判据一致。

### 4b. 切进实时模式时，残留文本要上屏而不是隐形留着

排查途中发现的**第二个独立缺陷**：缓冲模式打了字、**不点「上屏」直接切实时**，这段文字会留在 textarea 里 —— 而实时模式的 CSS 把输入框渲染成透明（`color:transparent;caret-color:transparent`），**它是看不见的**。

更糟的是它污染了 mirror 基线：`mirror.sent=''` 但 `ta.value='hello'`，于是下一次按删除键，diff 算出的是 `'' → 'hell'`，**往终端里插入了一段陈旧文本**，而不是删掉任何东西。

修法是切进实时模式时，像「上屏」那样把残留文本**送上终端后清空**（而不是静默丢弃用户打的字）。同样**不追加任何字符** —— 与第 1 条一致，不能把两步语义拆掉。

### 6. 上屏之后，输入框已空时系统键盘按 Enter 仍然要提交

**评审发现的回归，由上面第 1 条引入。**

`submit()` 在缓冲模式走 `sendBuffered()`，而它开头是 `if(!text)return`。上屏之后输入框已被清空，这一句**直接 return**；而 keydown 的 Enter 分支在此之前已经 `e.preventDefault()`，连浏览器默认行为都不剩——**这一键彻底蒸发**。

改前不是这样：payload 是 `text+'\n'`，空文本时仍是 `'\n'` 非空，过得了同一句 guard（会发出一个 `\n`）。改成「不追加任何字符」后空文本的 payload 为空，被同一句 guard 挡死，**从「发个不提交的 `\n`」退化成「什么都不发」**。而「上屏 → 检查 → 按 Enter」正是缓冲模式的核心流程，最典型的路径上这一步不工作。

判据与本 PR 对 Backspace 的处理**同源**：输入框为空 ⟹ 没有草稿可编辑 ⟹ 这一键只可能是给终端的。底栏 ⏎ 按钮在同一状态下本来就发 `\r`，本次只是让系统键盘与它一致。发 `\r` 而不是 `\n`：raw-mode TUI 通常只认 `\r`，canonical 模式经 ICRNL 同样成立。

同一状态（上屏后空框）四个入口实测：

| | 系统键盘 Enter | 底栏 ⏎ 按钮 |
| --- | --- | --- |
| 缓冲 | 修前 **什么都不发** / 修后 `\r` | `\r` |
| 实时 | `\r` | `\r` |

修前「缓冲 + 系统键盘」是唯一发不出东西的一格，修后四格一致。

顺带修正 `setMode` 上方那段注释：它仍写着 payload 以换行结尾，而那个换行正是本 PR 删掉的。另补一条**输入法组合态**用例——此前删掉 `!mirror.composing && !e.isComposing` 守卫，整套用例仍全绿（守卫承重却零覆盖），补上后该变异转红。

### 7. 点底栏按钮不再收起系统键盘（导致底栏整体下移、点错）

底栏骑在键盘上方：`transform: translateY(calc(0px - var(--keyboard-inset,0px)))`。点任一按钮会把焦点从 textarea 移走，iOS 在**失焦瞬间**收起软键盘，`--keyboard-inset` 归零，于是整条底栏在手指还没离开屏幕时下移约 300px——用户瞄准的下一个按钮已经不在原位。

真实浏览器实测（390×844 hasTouch，真 worker + 真 PTY），修复前：

| 操作 | 焦点变化 |
| --- | --- |
| 点 ⌫ | `mobile-input` → **`BODY`** |
| 点 Ctrl+C | `mobile-input` → **`BODY`** |
| 长按 ⌫ 1.2s | `mobile-input` → **`BODY`** |
| 点「模式」/「上屏」 | `mobile-input` → `mobile-input` |

后两个**看起来**正常，只是因为它们的处理器事后补调了 `showKeyboard()`——底层的失焦对所有按钮一视同仁。量化用户所说的「布局一变化」：注入 300px 键盘 inset 后底栏 top 由 **750 变 450（差 300px）**。

改法是在底栏按钮上 `preventDefault()` 掉 `pointerdown`，抑制**指针触发的焦点转移**。这与仓库既有做法一致——顶部悬浮工具栏早就这么做，手机底栏才是不合群的那个；原先的 `btn.blur()` 与发送/切模式后补调 `showKeyboard()` 都是焦点已经丢掉之后的补救。

**只作用于按钮**：textarea 本身刻意排除在外，它必须继续取得焦点并把光标落在手指处；Tab 键焦点也不受影响（只取消指针驱动的焦点转移）。

### 8. 注释里的裸 `\r` 让整段手机终端脚本 SyntaxError 起不来

这是第 6 条引入的回归，**页面级**：`getTerminalHtml()` 把整个网页终端放在一个 TypeScript 模板字符串里，源码里的转义会被消耗一层——写 `\\r` 浏览器收到的是 `\r` 两个字符，写 `\r` 收到的就是**一个真实回车**。真实回车出现在 `//` 注释里会当场截断注释，后面残留的 `the key-row ⏎` 被当代码解析，抛 SyntaxError，**整段内联脚本全废**：xterm 和底栏事件一个都不会初始化，手机端终端页面直接白屏。

改成 `\\r`（与同段落上方那行写法一致），并补上这一类的守卫用例。

**为什么既有用例挡不住**：所有网页终端用例都把 `worker.ts` 当**文本**读——要么 grep 源码，要么切片后 `replaceAll('\\\\','\\')` 近似还原再执行。而在源码里裸 `\r` 本就是无害的两个字符，只有**发出去的 HTML** 里才是控制字符。实测：带着这个 bug，手机输入栏那 23 条用例**全绿**。新用例改为还原模板字符串真正发出的文本，再解析其中的内联脚本。

## 影响范围

只改 `worker.ts` 中 `getTerminalHtml` 生成的手机底栏（1 处 CSS + 底栏脚本），**仅在触屏且可写的会话下渲染**。不涉及 v3 / dashboard / projection；桌面端、只读会话均不受影响。

第 3 条只在 `REPEATABLE`（⌫ / ← / → / ↑ / ↓）这几个键上挂重复监听，Enter / Ctrl-C / Esc / Tab / Shift-Tab / Paste 不进这个分支（已实测长按它们仍只发 1 次）；桌面鼠标单击仍只走 `click` 处理器。不涉及 PTY / tmux 后端、其它 CLI 适配器与飞书侧代码。

字号变化会让底栏高度从 91px 变 94px，终端让位逻辑按实测高度自适应，已验证未破坏 `#884` 的几何保证。

第 4 / 5 条同样只在手机底栏脚本内：新增的 keydown 分支**以「输入框为空」为唯一前提**，两种模式一致；非空一律走各自的原有路径（实时走 diff、缓冲留在草稿里），输入法组合态（`mirror.composing` / `e.isComposing`）直接跳过，不影响中文/日文等输入法。发出的 `\x7f` 与既有底栏 ⌫ 按钮（`bs:'\x7f'`）、实时 diff 的 `BS` 常量**逐字同形**，是这条路径上已在使用的写法。桌面端不渲染底栏，其 xterm IME 接管是另一段独立代码，未改动。

## 验证

- `bun run build` 通过，且 `dist/worker.js` 内确认含本次改动
- 相关 **8 个测试文件 127/127 通过**（含新增 4 条用例）；第 4 条另加 3 条用例，`web-terminal-mobile-input.test.ts` **17/17 通过**
- 第 5 条：web 终端相关 **15 个文件 104/104 通过**（`web-terminal-mobile-input.test.ts` 改写 1 条 + 新增 1 条，18/18）；另把仓库里所有断言 `keydown` / `\x7f` 的测试一并跑过（`cli-adapters`、`fs-policy`、`zellij-backend-helpers`、`role-library`、`critical-control-key`、`terminal-write-frame` 等 7 文件 **624/624 通过**）。其中 `web-terminal-ime.test.ts` 守的正是桌面端 xterm 的同一条「空 textarea 交给终端」边界，未受影响
- **全量单测回归对照**：改前 / 改后各跑一遍 `--project unit`（1228 个文件），红名单**逐项一致**，均为 sandbox / 只读前置类（root 造不出只读目录）与 `native-subagent-runtime-hook`、`tmux-pipe-backend-exit` 两个时序 flake —— 后两者隔离复跑 **28/28 全绿**。与 web 终端零交集
- **变异测试确认新断言有牙**（合成 harness）：
  - 把 `'\n'` 加回去 → **2 红**；字号改回 14px → **1 红**
  - 撤掉 click 吞抑 → `expected 6 to be 5`；撤掉 `pointerdown` 复位 → `expected 3 to be 4`；只置位不吞 → `expected 6 to be 5`
  - 第 4 条：撤掉空框补发 → **2 红**；撤掉切换时的 flush → **1 红**
  - 第 5 条：删掉整条补发分支 → **3 红**；把 `mode===LIVE` 前提加回去 → **1 红**（且正好只打中缓冲模式那条用例，说明新断言精确钉住的是这次的改动）；去掉「输入框为空」前提 → **2 红**（实时与缓冲两侧的草稿编辑边界各 1）
  - 另做了一次源码级对照：把 `src/worker.ts` 回退到本次修改之前跑全量，新增的 3 条用例**自己转红**，修复回来后转绿
- **真实渲染验证**（真实 worker 起的页面 + Chromium 390×844 触屏上下文，在 `WebSocket.send` 处记账，CDP 真触摸事件）：

  长按 ⌫ 的实发删除次数，与撤掉修复的对照：

  | 长按时长 | tick 数 | 修后实测 | 撤掉修复 |
  | --- | --- | --- | --- |
  | 150 / 300 / 500ms | 0 | 1 / 1 / 1 | 1 / 1 / 1 |
  | 800ms | 5 | **5** | 6 |
  | 1200ms | 12 | **12** | 13 |
  | 2000ms | 25 | **25** | 26 |

  - 单击恒为 1；长按后再单击 +1（没误吞真实点击）
  - **滑出按键后再单击仍为 1**；撤掉 `pointerdown` 复位则为 **0**（被静默吃掉）
  - 长按 Enter / Ctrl-C 各仍只发 1 次
  - 「上屏」发出的字节**恰为 `"继续"`**，不以 `\n` 也不以 `\r` 结尾
  - 输入框 computed `font-size` = **16px**
  - `#884` 的让位几何未受影响：rows 53、xterm 渲染区底边比底栏顶边**高 8px**
  - 页面无 JS 错误

  第 4 条的端到端（同一套真实 worker + Chromium 触屏上下文，PTY 侧逐字节回显）：

  | 场景 | 页面发出 | PTY 实收 |
  | --- | --- | --- |
  | 缓冲打字 → 上屏 → 切实时 → 系统键盘删 5 次 | 5 × `\x7f` | 5 × `\x7f` |
  | 缓冲打字 → **不上屏**直接切实时 | `world`（不含 `\r`） | 同左 |
  | ↑ 紧接着按一次 Backspace | `\x7f` | `\x7f` |

  - 切换后 textarea 恒为空（不再有隐形残留）
  - 撤掉修复的对照：删 5 次 → **0 帧、PTY 0 字节**；不上屏切实时 → `world` 隐形留在框里，下一次删除发出的是 **`worl`**（插入陈旧文本）—— 与反馈的现象逐字吻合
  - 页面无 JS 错误

  第 5 条的端到端 A/B（同一套真实 worker + 真 PTY + Chromium 触屏，`WebSocket.send` 处记账）：

  | 场景（缓冲模式，打字 → 上屏 → 输入框已空） | 修后 | 撤掉修复 |
  | --- | --- | --- |
  | 系统键盘按 3 次删除：页面发出 | 3 × `\x7f` | **0 帧** |
  | 同上：PTY 实收 | `7f 7f 7f` | **0 字节** |
  | 同上：textarea 事件流 | `keydown → keyup`（已 preventDefault） | `keydown → beforeinput[deleteContentBackward] → keyup`，**中间没有 `input`** |
  | 对照：非空草稿 `abc` 按删除 | 0 帧、框内变 `ab` | 0 帧、框内变 `ab` |
  | 对照：同一状态下点底栏 ⌫ | `\x7f` | `\x7f` |
  | 对照：实时模式空框按删除 | `\x7f` | `\x7f` |

  最后三行是关键：修复前**在同一个可见状态下，底栏 ⌫ 删得掉而系统键盘删不掉**，这就是这个缺陷的本质；修复后两者一致，同时非空草稿与实时模式的既有行为都没变。页面无 JS 错误

- **第 6 条**：tsc 0 error；`web-terminal-mobile-input.test.ts` **21/21**（新增 3 条）；web 终端与 terminal 相关 **23 文件 291/291**；断言 `keydown` / `\x7f` 的相邻用例（`web-terminal-ime`、`terminal-write-frame`、`critical-control-key`）**41/41**。变异四枪全红：撤掉本次修复 → 2 红；空框改发 `\n` → 2 红；删掉输入法守卫 → 1 红（**补用例前为全绿**）；只删 `mirror.composing` 一半 → 1 红。边界实测：Shift+Enter 仍交给浏览器插换行不转发；非空框 Enter 仍只上屏不提交；组合态空框 Enter 不发；只读会话与断线时不发
- **真 PTY 补充实测（canonical 模式）**：对**普通 bash** 这类行缓冲程序，改前的 `echo X\n` 载荷会**立刻执行**——也就是说在这类会话里「上屏」等于直接跑命令，两步语义根本不成立；改后 `echo X` 只上屏、再发 `\r` 才执行。这让第 1 条的价值比原先描述的更大（不只是「污染输入框」，还消除了「上屏即执行」）
- **基线**：已在最新 `origin/master`（含 #1249 对 `worker.ts` 的改动）上验证，两处改动区段不重叠
- 已部署供真机验证：daemon 跑本分支 checkout 的 `dist/index-daemon.js`（`/proc/<pid>/cmdline` 实读），进程启动时间晚于 `dist/worker.js` 的 mtime，56 个 bot 全部 online，且核对该 `dist/worker.js` **同时**含第 7 条的 `pointerdown` 抑制与第 8 条的 `\\r` 修正

- **第 7 条**：真实浏览器 A/B（390×844 hasTouch，真 worker + 真 PTY，两侧各自重新 build 并以 dist 内命中数为判据）。修复前 ⌫ / Ctrl+C / 长按后焦点均落到 `BODY`，修复后全部保持 `mobile-input`；两侧**其余读数逐字相同**：长按 1.2s 连发 12 次、按键行触摸拖动 `scrollLeft` 257、上屏提交后输入框清空、几何 `overlap -8`（要求 ≤ 0.5）、页面零报错。`web-terminal-mobile-input.test.ts` 新增 2 条。三枪变异全红：删掉整段循环 → 1 红；**过度接管到 textarea（`'button'` 改 `'button,textarea'`）→ 1 红**；监听器留空壳 → 1 红（证明用例钉的是效果不是接线）
- **第 8 条**：修复前真实浏览器 pageerror `SyntaxError: Unexpected identifier 'key'`、`.xterm-screen` 始终不出现、`--mobile-bar-h` 为空；修复后页面正常起来，发出的脚本**零真实回车**、`node --check` 通过。新用例三枪变异全红：还原真实缺陷 → 2 红（**同一轮既有 23 条仍全绿**，正是这条用例存在的理由）；在模板里另一处注释插入裸 `\r` → 1 红（守的是这一类而不是某一行）；把脚本提取正则改成永不匹配 → 1 红（挡住「解不出脚本因而空过」的假绿）
- **组合树复测**（第 7 条 rebase 到第 6 条之上后重跑）：`bun run build` 通过并核对 `dist/worker.js` **同时**含两处改动；「上屏 → 按 Enter」焦点仍在输入框、输入框已空、Enter 照常发出 `\r`——即第 6 条的修复正因为焦点被保住才够得着
- **回归面**：涉及 `getTerminalHtml` / `pointerdown` / `activeElement` / `showKeyboard` 的 6 个文件 **77/77**；全量单测 `1223 passed`，5 个红全部核过——3 个是 root 下 `chmod 0o500` 拦不住写入的既有环境类（**在未改动的基线上逐条复现同样 9 红**），2 个隔离重跑即绿的负载 flake，均不碰本 PR 载体

## ⚠️ 需要真机确认

- 第 2 条的实际效果（聚焦输入框不再放大页面）依赖 iOS WKWebView 的行为，**本机 WebKit 缺约 35 个系统库跑不起来**，无法 headless 验证；16px 阈值是 WebKit 的既有行为，但仍建议在 iOS 飞书里实机确认一次。
- 第 3 条的差一在 Chromium 上是确定性复现并已修掉；iOS WKWebView 在长按 >450ms 后是否仍补发 `click` 同样无法本地验证。若 iOS 本就不发，则那里原先没有差一，修复也不会引入回归（标志位只在重复真的跑过后才置位）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)




