### PR TITLE
fix(cli): 阻止 autostart 帮助参数触发系统变更

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14576,13 +14576,26 @@ switch (command) {
     break;
   }
   case 'autostart': {
+    const args = process.argv.slice(3);
+    if (args.some(arg => arg === '--help' || arg === '-h')) {
+      console.log('用法: botmux autostart <enable|disable|status>');
+      break;
+    }
+    const sub = args[0] ?? 'status';
+    const extra = args.slice(1);
+    const knownSubcommands = new Set(['enable', 'install', 'disable', 'uninstall', 'status']);
+    if (!knownSubcommands.has(sub) || extra.length > 0) {
+      const unknown = [...(!knownSubcommands.has(sub) ? [sub] : []), ...extra];
+      console.error(`未知参数: ${unknown.join(' ')}`);
+      console.error('  `botmux autostart` 只接受一个子命令: enable、disable、status（兼容别名: install、uninstall）。');
+      process.exitCode = 2;
+      break;
+    }
     ensureConfigDir();
-    const sub = process.argv[3] ?? 'status';
     const opts = { pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR };
     if (sub === 'enable' || sub === 'install') enableAutostart(opts);
     else if (sub === 'disable' || sub === 'uninstall') disableAutostart(opts);
-    else if (sub === 'status') autostartStatus(opts);
-    else { console.error(`用法: botmux autostart <enable|disable|status>`); process.exit(1); }
+    else autostartStatus(opts);
     break;
   }
   default:

--- a/test/cli-unknown-args.test.ts
+++ b/test/cli-unknown-args.test.ts
@@ -216,3 +216,38 @@ describe('botmux history：未知参数一律中止', () => {
     expect(r.stderr).not.toContain('未知参数');
   });
 });
+
+describe('botmux autostart：帮助与额外参数不得产生副作用', () => {
+  it.each([
+    ['enable', '--help'],
+    ['enable', '-h'],
+    ['disable', '--help'],
+    ['status', '--help'],
+    ['install', '--help'],
+    ['uninstall', '--help'],
+  ])('botmux autostart %s %s → rc=0，只打印帮助', (subcommand, flag) => {
+    const r = runCli(['autostart', subcommand, flag]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('用法: botmux autostart <enable|disable|status>');
+    expect(r.homeUnchanged).toBe(true);
+  });
+
+  it.each([
+    ['enable', '--dry-run'],
+    ['disable', '--force'],
+    ['status', 'extra'],
+  ])('botmux autostart %s %s → rc=2，不执行', (subcommand, extra) => {
+    const r = runCli(['autostart', subcommand, extra]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('未知参数');
+    expect(r.stderr).toContain(extra);
+    expect(r.homeUnchanged).toBe(true);
+  });
+
+  it('未知子命令同样在创建配置目录前中止', () => {
+    const r = runCli(['autostart', 'typo']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('未知参数: typo');
+    expect(r.homeUnchanged).toBe(true);
+  });
+});


### PR DESCRIPTION
## 问题

`botmux autostart enable --help` 会把 `--help` 静默忽略并直接调用 `enableAutostart()`，导致只想查看帮助的用户意外写入并启用系统自启动配置。其它 autostart 子命令也会吞掉额外参数；未知子命令则会在报错前先创建配置目录。

Fixes #1268

## 修复

- 在执行任何 autostart 状态变更或创建配置目录前识别 `--help` / `-h`，输出专用 usage 并成功退出。
- 对未知子命令和额外参数 fail closed，返回退出码 2，不执行任何文件或系统服务变更。
- 保留 `install` / `uninstall` 兼容别名。
- 增加 HOME 递归快照回归测试，覆盖 enable、disable、status 及兼容别名的帮助路径，以及未知参数/未知子命令。

## 影响面

- 只影响 `botmux autostart` 的 CLI 参数分发。
- 不改变 Linux systemd、macOS launchd 或 Windows Task Scheduler 的实际 enable/disable 实现。
- Dashboard autostart API 仍使用不带额外参数的合法命令，不受影响。

## 验证

- `npx vitest run --project unit test/cli-unknown-args.test.ts`：28 passed。
- `bun run vitest run --project unit test/cli-unknown-args.test.ts`：28 passed。
- `bun run build`：通过。
- `bun run test`：21373 passed、31 skipped；13 个失败均为当前主机上的既有环境/时序问题（tmux locale/socket、npm allow-scripts、mojo/native-subagent 时序），与本次修改文件无关。
