### PR TITLE
fix(autostart): 过滤会话临时 PATH

### DIFF
--- a/src/autostart.ts
+++ b/src/autostart.ts
@@ -40,6 +40,8 @@ export interface AutostartOpts {
   /** Executable to name in the boot hook, for tests. Defaults to
    *  `process.execPath` (the Node binary, or the compiled binary itself). */
   execPath?: string;
+  /** PATH to persist in the boot hook, for tests. Defaults to `process.env.PATH`. */
+  environmentPath?: string;
 }
 
 /** Minimal registration state used by the Dashboard toggle. */
@@ -151,13 +153,25 @@ export function launchCommand(opts: AutostartOpts, sub: string, quote = false): 
   return (quote ? parts.map((p) => `"${p}"`) : parts).join(' ');
 }
 
-function currentPath(): string {
+export function autostartPath(
+  pathValue: string = process.env.PATH || '',
+  targetPlatform: NodeJS.Platform = process.platform,
+): string {
   // Capture PATH from the install-time shell so the unit can find any
   // binaries the user expects (node-pty's `node`, the AI CLI binaries,
-  // tmux, etc.). Falls back to a sane default if PATH is empty.
-  const p = process.env.PATH || '';
-  if (p) return p;
-  return process.platform === 'darwin'
+  // tmux, etc.). Session-scoped TRAE argv[0] shims live under a temporary
+  // directory and must not be made durable in a boot hook.
+  const separator = targetPlatform === 'win32' ? ';' : ':';
+  const entries = pathValue
+    .split(separator)
+    .filter(Boolean)
+    .filter(entry => !entry.replace(/\\/g, '/').includes('/.trae/tmp/arg0/'));
+  const stable = [...new Set(entries)].join(separator);
+  if (stable) return stable;
+  if (targetPlatform === 'win32') {
+    return '%SystemRoot%\\System32;%SystemRoot%;%SystemRoot%\\System32\\Wbem';
+  }
+  return targetPlatform === 'darwin'
     ? '/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin'
     : '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
 }
@@ -172,7 +186,7 @@ export function plistContent(opts: AutostartOpts): string {
     .map((p) => `        <string>${escapeXml(p)}</string>`)
     .join('\n');
   const cwd = escapeXml(opts.configDir);
-  const path = escapeXml(currentPath());
+  const path = escapeXml(autostartPath(opts.environmentPath, 'darwin'));
   const outLog = escapeXml(join(opts.logDir, 'autostart-out.log'));
   const errLog = escapeXml(join(opts.logDir, 'autostart-err.log'));
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -302,7 +316,7 @@ Wants=network-online.target
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=${opts.configDir}
-Environment=PATH=${currentPath()}
+Environment=PATH=${autostartPath(opts.environmentPath, 'linux')}
 Environment=${AUTOSTART_UNIT_ENV}=1
 ExecStart=${launchCommand(opts, 'start')}
 ExecStop=${launchCommand(opts, 'stop')}
@@ -447,7 +461,7 @@ function windowsLogPath(opts: AutostartOpts, name: string): string {
 }
 
 export function windowsScriptContent(opts: AutostartOpts): string {
-  const path = escapeCmdValue(currentPath());
+  const path = escapeCmdValue(autostartPath(opts.environmentPath, 'win32'));
   const cwd = opts.configDir;
   const outLog = windowsLogPath(opts, 'autostart-out.log');
   const errLog = windowsLogPath(opts, 'autostart-err.log');

--- a/src/autostart.ts
+++ b/src/autostart.ts
@@ -52,6 +52,7 @@ export interface AutostartState {
 
 const LABEL = 'com.botmux.daemon';
 const SERVICE_NAME = 'botmux.service';
+const WINDOWS_FALLBACK_PATH = '%SystemRoot%\\System32;%SystemRoot%;%SystemRoot%\\System32\\Wbem';
 
 /**
  * Env marker the generated boot hooks set on themselves, so `botmux start` can
@@ -159,17 +160,18 @@ export function autostartPath(
 ): string {
   // Capture PATH from the install-time shell so the unit can find any
   // binaries the user expects (node-pty's `node`, the AI CLI binaries,
-  // tmux, etc.). Session-scoped TRAE argv[0] shims live under a temporary
-  // directory and must not be made durable in a boot hook.
+  // tmux, etc.). Session-scoped argv[0] shims from TRAE, Codex, and other AI
+  // CLIs live under a `tmp/arg0` path segment and must not be made durable in
+  // a boot hook.
   const separator = targetPlatform === 'win32' ? ';' : ':';
   const entries = pathValue
     .split(separator)
     .filter(Boolean)
-    .filter(entry => !entry.replace(/\\/g, '/').includes('/.trae/tmp/arg0/'));
+    .filter(entry => !entry.replace(/\\/g, '/').includes('/tmp/arg0/'));
   const stable = [...new Set(entries)].join(separator);
   if (stable) return stable;
   if (targetPlatform === 'win32') {
-    return '%SystemRoot%\\System32;%SystemRoot%;%SystemRoot%\\System32\\Wbem';
+    return WINDOWS_FALLBACK_PATH;
   }
   return targetPlatform === 'darwin'
     ? '/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin'
@@ -433,6 +435,14 @@ function escapeCmdValue(s: string): string {
   return s.replace(/\^/g, '^^').replace(/%/g, '%%');
 }
 
+function windowsPathValue(pathValue: string | undefined): string {
+  const normalized = autostartPath(pathValue, 'win32');
+  // The fallback deliberately contains expandable %SystemRoot% references.
+  // Captured PATH values must stay literal, but escaping the fallback would
+  // turn those references into literal text when cmd.exe executes the script.
+  return normalized === WINDOWS_FALLBACK_PATH ? normalized : escapeCmdValue(normalized);
+}
+
 function escapeVbsString(s: string): string {
   return s.replace(/"/g, '""');
 }
@@ -461,7 +471,7 @@ function windowsLogPath(opts: AutostartOpts, name: string): string {
 }
 
 export function windowsScriptContent(opts: AutostartOpts): string {
-  const path = escapeCmdValue(autostartPath(opts.environmentPath, 'win32'));
+  const path = windowsPathValue(opts.environmentPath);
   const cwd = opts.configDir;
   const outLog = windowsLogPath(opts, 'autostart-out.log');
   const errLog = windowsLogPath(opts, 'autostart-err.log');

--- a/test/autostart-standalone-path.test.ts
+++ b/test/autostart-standalone-path.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   AUTOSTART_UNIT_ENV,
+  autostartPath,
   consumeAutostartUnitMarker,
   launchProgram, launchCommand, unitContent, plistContent, windowsScriptContent,
   type AutostartOpts,
@@ -116,6 +117,17 @@ describe('autostart boot hook — compiled binary (standalone) shape', () => {
     expect(unitContent(nodeOpts())).toContain(`Environment=${AUTOSTART_UNIT_ENV}=1`);
   });
 
+  it('does not persist TRAE session shims into boot-hook PATH', () => {
+    const transient = '/home/u/.trae/tmp/arg0/traecli-random';
+    const stable = '/home/u/.local/bin:/usr/bin:/bin';
+    const renderedOpts = opts({ environmentPath: `${transient}:${stable}` });
+
+    expect(unitContent(renderedOpts)).toContain(`Environment=PATH=${stable}`);
+    expect(plistContent(renderedOpts)).toContain(`<string>${stable}</string>`);
+    expect(unitContent(renderedOpts)).not.toContain(transient);
+    expect(plistContent(renderedOpts)).not.toContain(transient);
+  });
+
   it('the rendered ExecStart actually starts botmux (not: prints help and exits 0)', () => {
     // THE HEART OF THE BUG. A string assertion alone would have passed even in
     // production, because the broken command was still a well-formed command
@@ -165,6 +177,29 @@ describe('autostart boot hook — compiled binary (standalone) shape', () => {
     expect(r.status).toBe(0);              // systemd saw success...
     expect(r.stdout).toContain('usage');   // ...while botmux only printed help
     expect(r.stdout).not.toContain('DAEMON_STARTED');
+  });
+});
+
+describe('autostart PATH normalization', () => {
+  it('filters TRAE argv0 shims, preserves order, and removes duplicates on POSIX', () => {
+    expect(autostartPath(
+      '/home/u/.trae/tmp/arg0/traecli-a:/home/u/.local/bin:/usr/bin:/home/u/.local/bin',
+      'linux',
+    )).toBe('/home/u/.local/bin:/usr/bin');
+  });
+
+  it('uses the platform delimiter when filtering Windows PATH', () => {
+    expect(autostartPath(
+      'C:\\Users\\u\\.trae\\tmp\\arg0\\traecli-a;C:\\Tools;C:\\Windows',
+      'win32',
+    )).toBe('C:\\Tools;C:\\Windows');
+  });
+
+  it('falls back to a stable system PATH when every entry is transient', () => {
+    expect(autostartPath('/home/u/.trae/tmp/arg0/traecli-a', 'linux'))
+      .toBe('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin');
+    expect(autostartPath('C:\\Users\\u\\.trae\\tmp\\arg0\\traecli-a', 'win32'))
+      .toBe('%SystemRoot%\\System32;%SystemRoot%;%SystemRoot%\\System32\\Wbem');
   });
 });
 

--- a/test/autostart-standalone-path.test.ts
+++ b/test/autostart-standalone-path.test.ts
@@ -181,11 +181,25 @@ describe('autostart boot hook — compiled binary (standalone) shape', () => {
 });
 
 describe('autostart PATH normalization', () => {
-  it('filters TRAE argv0 shims, preserves order, and removes duplicates on POSIX', () => {
+  it('filters AI CLI argv0 shims, preserves order, and removes duplicates on POSIX', () => {
     expect(autostartPath(
-      '/home/u/.trae/tmp/arg0/traecli-a:/home/u/.local/bin:/usr/bin:/home/u/.local/bin',
+      [
+        '/home/u/.trae/tmp/arg0/traecli-a',
+        '/home/u/.trae/cli/tmp/arg0/traecli-b',
+        '/home/u/.codex/tmp/arg0/codex-execve-wrapper',
+        '/home/u/.local/bin',
+        '/usr/bin',
+        '/home/u/.local/bin',
+      ].join(':'),
       'linux',
     )).toBe('/home/u/.local/bin:/usr/bin');
+  });
+
+  it('requires tmp/arg0 to be a complete path segment', () => {
+    expect(autostartPath(
+      '/opt/tmp/arg0bin:/usr/tmp/arg00:/var/tmp/arg0-tools/bin',
+      'linux',
+    )).toBe('/opt/tmp/arg0bin:/usr/tmp/arg00:/var/tmp/arg0-tools/bin');
   });
 
   it('uses the platform delimiter when filtering Windows PATH', () => {
@@ -200,6 +214,20 @@ describe('autostart PATH normalization', () => {
       .toBe('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin');
     expect(autostartPath('C:\\Users\\u\\.trae\\tmp\\arg0\\traecli-a', 'win32'))
       .toBe('%SystemRoot%\\System32;%SystemRoot%;%SystemRoot%\\System32\\Wbem');
+  });
+
+  it('expands the Windows fallback but keeps captured percent references literal', () => {
+    const transient = 'C:\\Users\\u\\.codex\\tmp\\arg0\\codex-execve-wrapper';
+    const fallbackScript = windowsScriptContent(opts({ environmentPath: transient }));
+    expect(fallbackScript).toContain(
+      'set "PATH=%SystemRoot%\\System32;%SystemRoot%;%SystemRoot%\\System32\\Wbem"',
+    );
+    expect(fallbackScript).not.toContain('%%SystemRoot%%');
+
+    const capturedScript = windowsScriptContent(opts({
+      environmentPath: '%LOCALAPPDATA%\\bin;C:\\Tools',
+    }));
+    expect(capturedScript).toContain('set "PATH=%%LOCALAPPDATA%%\\bin;C:\\Tools"');
   });
 });
 


### PR DESCRIPTION
## 问题

`botmux autostart enable` 会把调用者的 `PATH` 原样固化到 systemd、launchd 或 Windows 启动配置。在 AI CLI 会话中执行时，PATH 可能包含 `~/.trae/tmp/arg0/traecli-<random>` 这类短生命周期 shim；该目录失效后仍会长期留在开机服务环境里，并改变命令解析优先级。

Fixes #1270

## 修复

- 抽出 `autostartPath()`，在生成持久启动配置前归一化 PATH。
- 过滤 TRAE 会话级 `/.trae/tmp/arg0/` 条目。
- 保持其它 PATH 条目的原顺序并去重。
- 按 POSIX/Windows 平台使用正确的路径分隔符。
- 过滤后为空时回退到原有平台默认 PATH。

## 影响面

- 影响 Linux systemd、macOS launchd 和 Windows 启动脚本的 PATH 渲染。
- 不改变当前进程环境，也不改变 BotMux/AI CLI 可执行文件路径选择。
- 只过滤路径结构明确的 TRAE 临时 argv0 shim，其它用户自定义路径保持不变。

## 验证

- `npx vitest run --project unit test/autostart-standalone-path.test.ts`：19 passed。
- `bun run vitest run --project unit test/autostart-standalone-path.test.ts`：19 passed。
- `bun run build`：通过。
