### PR TITLE
fix(card): 拒绝 runtime session-id 缺值

### DIFF
--- a/src/cli/arg-utils.ts
+++ b/src/cli/arg-utils.ts
@@ -27,6 +27,26 @@ export function hasFlagOrEq(args: string[], flag: string): boolean {
   return args.some(a => a === flag || a.startsWith(flag + '='));
 }
 
+/** True when a value-taking flag is present without a usable value.
+ *
+ * Rejects the bare flag at argv end, an empty `--flag=` form, and a following
+ * flag token. A lone `-` remains a valid value for stdin-taking flags.
+ */
+export function flagPresentButValueMissing(
+  args: readonly string[],
+  flag: string,
+  allowDash = true,
+): boolean {
+  const i = args.findIndex(a => a === flag || a.startsWith(`${flag}=`));
+  if (i < 0) return false;
+  if (args[i].startsWith(`${flag}=`)) {
+    const value = args[i].slice(flag.length + 1);
+    return value === '' || (!allowDash && value === '-');
+  }
+  const next = args[i + 1];
+  return next === undefined || (next.startsWith('-') && !(allowDash && next === '-'));
+}
+
 /** The flag-looking tokens in `args` that this subcommand does not know.
  *
  *  Motivation: every parser in this file (and `argValue` / `argFlag` in cli.ts)

--- a/src/cli/arg-utils.ts
+++ b/src/cli/arg-utils.ts
@@ -31,6 +31,21 @@ export function hasFlagOrEq(args: string[], flag: string): boolean {
  *
  * Rejects the bare flag at argv end, an empty `--flag=` form, and a following
  * flag token. A lone `-` remains a valid value for stdin-taking flags.
+ *
+ * ⚠️ `allowDash` defaults to **true** here, which is the OPPOSITE of the
+ * same-named private copy in `cli.ts` (it defaults to `false`) and of the one
+ * in `card-dispatch.ts` (which has no such parameter and always rejects `-`).
+ * The default is load-bearing, not cosmetic: callers that omit the argument —
+ * `--content`, `--summary`, `--message-id`, `--stream-id`, `--element-id` in
+ * `card-stream-dispatch.ts` — accept a lone `-`, while `--session-id` opts out
+ * with an explicit `false` because a session id is a UUID, never a dash.
+ *
+ * So when folding the remaining private copies into this one, do NOT assume
+ * the call sites are drop-in: `cli.ts` has six that rely on its `false`
+ * default (`--plugin-card-action` ×2, `--response-kind`, `--into`,
+ * `--dispatch-root`, `--from-chat`), and pointing them here would silently
+ * start accepting `-` as their value. Re-check each site and pass the flag
+ * explicitly rather than inheriting whichever default happens to be in scope.
  */
 export function flagPresentButValueMissing(
   args: readonly string[],

--- a/src/cli/card-runtime-status-dispatch.ts
+++ b/src/cli/card-runtime-status-dispatch.ts
@@ -1,4 +1,5 @@
 import type { ScreenStatus } from '../types.js';
+import { flagPresentButValueMissing } from './arg-utils.js';
 
 const STREAM_ID_RE = /^cs_[0-9a-f]{32}$/;
 const ELEMENT_ID_RE = /^[A-Za-z][A-Za-z0-9_-]{0,19}$/;
@@ -42,6 +43,9 @@ export function parseCardRuntimeStatusArgs(args: string[]): CardRuntimeStatusPar
   const stream = required(args, '--stream-id');
   if (!stream.ok) return stream;
   if (!STREAM_ID_RE.test(stream.value)) return { ok: false, error: `streamId 格式无效: ${stream.value}` };
+  if (flagPresentButValueMissing(args, '--session-id', false)) {
+    return { ok: false, error: '--session-id 需要会话 id 参数' };
+  }
   const sessionId = flagValue(args, '--session-id');
   if (operation === 'unbind-runtime') {
     return { ok: true, operation, streamId: stream.value, ...(sessionId ? { sessionId } : {}) };

--- a/src/cli/card-stream-dispatch.ts
+++ b/src/cli/card-stream-dispatch.ts
@@ -7,6 +7,7 @@ import type {
   CardStreamRecord,
   CardStreamSequenceLease,
 } from '../services/card-stream-store.js';
+import { flagPresentButValueMissing } from './arg-utils.js';
 
 const STREAM_ID_RE = /^cs_[0-9a-f]{32}$/;
 const ELEMENT_ID_RE = /^[A-Za-z][A-Za-z0-9_-]{0,19}$/;
@@ -43,14 +44,6 @@ export function cardStreamArgsWantHelp(args: string[]): boolean {
   return args.includes('--help') || args.includes('-h');
 }
 
-function flagPresentButValueMissing(args: string[], flag: string): boolean {
-  const i = args.findIndex(a => a === flag || a.startsWith(`${flag}=`));
-  if (i < 0) return false;
-  if (args[i].startsWith(`${flag}=`)) return args[i].slice(flag.length + 1) === '';
-  const next = args[i + 1];
-  return next === undefined || (next.startsWith('-') && next !== '-');
-}
-
 function flagValue(args: string[], flag: string): string | undefined {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -61,7 +54,7 @@ function flagValue(args: string[], flag: string): string | undefined {
 }
 
 function optionalSessionId(args: string[]): { ok: true; sessionId?: string } | { ok: false; error: string } {
-  if (flagPresentButValueMissing(args, '--session-id')) {
+  if (flagPresentButValueMissing(args, '--session-id', false)) {
     return { ok: false, error: '--session-id 需要会话 id 参数' };
   }
   const sessionId = flagValue(args, '--session-id');
@@ -181,7 +174,7 @@ export function parseCardStreamArgs(args: string[]): CardStreamParsedArgs {
   if (flagPresentButValueMissing(flags, '--content')) {
     return { ok: false, error: '--content 需要文本参数' };
   }
-  if (flagPresentButValueMissing(flags, '--content-file')) {
+  if (flagPresentButValueMissing(flags, '--content-file', true)) {
     return { ok: false, error: '--content-file 需要路径或 -' };
   }
   const content = flagValue(flags, '--content');

--- a/test/cli-arg-utils.test.ts
+++ b/test/cli-arg-utils.test.ts
@@ -6,7 +6,12 @@
  * Run:  pnpm vitest run test/cli-arg-utils.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { firstPositional, hasFlagOrEq, unknownFlags } from '../src/cli/arg-utils.js';
+import {
+  firstPositional,
+  flagPresentButValueMissing,
+  hasFlagOrEq,
+  unknownFlags,
+} from '../src/cli/arg-utils.js';
 
 describe('firstPositional', () => {
   it('returns the first non-flag token in a plain positional list', () => {
@@ -59,6 +64,28 @@ describe('hasFlagOrEq', () => {
     // `--teammate` must not satisfy a `--team` check.
     expect(hasFlagOrEq(['--teammate', 'x'], '--team')).toBe(false);
     expect(hasFlagOrEq(['--teammate=x'], '--team')).toBe(false);
+  });
+});
+
+describe('flagPresentButValueMissing', () => {
+  it('rejects absent bare and empty equals values', () => {
+    expect(flagPresentButValueMissing(['--session-id'], '--session-id')).toBe(true);
+    expect(flagPresentButValueMissing(['--session-id='], '--session-id')).toBe(true);
+  });
+
+  it('rejects a following flag but can allow the stdin dash sentinel', () => {
+    expect(flagPresentButValueMissing(
+      ['--session-id', '--stream-id', 'cs_1'],
+      '--session-id',
+    )).toBe(true);
+    expect(flagPresentButValueMissing(['--content-file', '-'], '--content-file', true)).toBe(false);
+    expect(flagPresentButValueMissing(['--session-id', '-'], '--session-id', false)).toBe(true);
+    expect(flagPresentButValueMissing(['--session-id=-'], '--session-id', false)).toBe(true);
+  });
+
+  it('accepts ordinary values and absent flags', () => {
+    expect(flagPresentButValueMissing(['--session-id', 'sid_1'], '--session-id')).toBe(false);
+    expect(flagPresentButValueMissing([], '--session-id')).toBe(false);
   });
 });
 

--- a/test/cli-card-stream-dispatch.test.ts
+++ b/test/cli-card-stream-dispatch.test.ts
@@ -153,6 +153,30 @@ describe('parseCardRuntimeStatusArgs', () => {
     ])).toEqual({ ok: true, operation: 'unbind-runtime', streamId: STREAM_ID });
   });
 
+  it.each([
+    ['--session-id'],
+    ['--session-id='],
+    ['--session-id', '--stream-id', STREAM_ID],
+    ['--session-id', '-'],
+    ['--session-id=-'],
+  ])('rejects a missing --session-id value: %j', (...sessionArgs) => {
+    for (const args of [
+      ['unbind-runtime', '--stream-id', STREAM_ID, ...sessionArgs],
+      [
+        'bind-runtime',
+        '--stream-id', STREAM_ID,
+        '--status-element-id', 'status_badge',
+        '--image-element-id', 'loader_img',
+        '--active-image-key', 'img_active_12345678',
+        '--inactive-image-key', 'img_inactive_12345678',
+        ...sessionArgs,
+      ],
+    ]) {
+      expect(parseCardRuntimeStatusArgs(args))
+        .toEqual({ ok: false, error: '--session-id 需要会话 id 参数' });
+    }
+  });
+
   it('rejects unsafe element/image ids and malformed labels', () => {
     expect(parseCardRuntimeStatusArgs([
       'bind-runtime', '--stream-id', STREAM_ID,


### PR DESCRIPTION
## 问题

`card stream bind-runtime` / `unbind-runtime` 直接读取可选 `--session-id`，没有区分“未提供该参数”和“明确提供但缺值”。结果是命令可能回退到当前会话，或把下一个 flag 名误当成 session id。

Fixes #1256

## 修复

- 将 value flag 缺值检测抽到无副作用的共享 argv helper。
- `bind-runtime` / `unbind-runtime` 拒绝以下形式：
  - `--session-id`
  - `--session-id=`
  - `--session-id --stream-id ...`
  - `--session-id -`
- 让现有 card stream parser 复用同一 helper，同时保留 `--content-file -` 的 stdin 语义。
- 补充 helper 与 runtime parser 回归测试，覆盖 bind/unbind 两条路径。

## 影响面

- 仅影响 card stream CLI 参数解析。
- 合法的 `--session-id <id>` 与 `--session-id=<id>` 行为不变。
- 不改变 runtime binding、daemon IPC 或卡片流状态机。

## 验证

- `npx vitest run --project unit test/cli-arg-utils.test.ts test/cli-card-stream-dispatch.test.ts`：47 passed。
- `bun run vitest run --project unit test/cli-arg-utils.test.ts test/cli-card-stream-dispatch.test.ts`：47 passed。
- `bun run build`：通过。

