### PR TITLE
fix(unicode): 避免标题截断拆开代理对

### DIFF
--- a/src/core/session-board.ts
+++ b/src/core/session-board.ts
@@ -1,6 +1,7 @@
 // 会话看板（kanban）的列定义与输入校验 — daemon 写端点与 dashboard 前端共用，
 // 保证两侧对「合法列 / 合法排序值 / 合法标题」的口径一致。保持零依赖：
 // 该模块会被 esbuild 打进浏览器 bundle。
+import { truncateUtf16WellFormed } from '../utils/unicode.js';
 
 export const KANBAN_COLUMN_IDS = ['backlog', 'todo', 'in_progress', 'in_review', 'done'] as const;
 export type SessionKanbanColumn = (typeof KANBAN_COLUMN_IDS)[number];
@@ -27,5 +28,5 @@ export function normalizeSessionTitle(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const title = value.replace(/[\u0000-\u001f\u007f-\u009f]+/g, ' ').replace(/\s+/g, ' ').trim();
   if (!title) return null;
-  return title.slice(0, SESSION_TITLE_MAX);
+  return truncateUtf16WellFormed(title, SESSION_TITLE_MAX);
 }

--- a/src/core/session-create.ts
+++ b/src/core/session-create.ts
@@ -3,6 +3,7 @@
 // 单测。daemon 侧 /api/sessions/spawn 与 session-manager 的 spawn/activate 复用。
 import { t, type Locale } from '../i18n/index.js';
 import type { CliTurnPayload } from '../types.js';
+import { truncateUtf16WellFormed } from '../utils/unicode.js';
 import { parseDashboardImageUploads, type DashboardImageUpload } from './dashboard-images.js';
 
 /** 协作模式：
@@ -54,15 +55,16 @@ function normalizeSpawnRole(value: unknown): SpawnRole | null {
 export function deriveSessionTitleFromContent(content: string): string {
   const firstLine = content.split(/\r?\n/).map(s => s.trim()).find(Boolean) ?? '';
   if (!firstLine) return t('cmd.createSession.untitled');
-  return firstLine.length > TITLE_MAX ? firstLine.slice(0, TITLE_MAX) + '…' : firstLine;
+  const title = truncateUtf16WellFormed(firstLine, TITLE_MAX);
+  return firstLine.length > TITLE_MAX ? title + '…' : title;
 }
 
 /** Dashboard group name follows the same visible first-line rule as the
  * session title. Keeping it here prevents the browser placeholder and the
  * actual Lark chat name from drifting apart. */
 export function deriveCreateGroupName(explicitName: unknown, content: string): string {
-  if (typeof explicitName === 'string' && explicitName.trim()) return explicitName.trim().slice(0, 60);
-  return deriveSessionTitleFromContent(content).slice(0, 60);
+  if (typeof explicitName === 'string' && explicitName.trim()) return truncateUtf16WellFormed(explicitName.trim(), 60);
+  return truncateUtf16WellFormed(deriveSessionTitleFromContent(content), 60);
 }
 
 /** Decide which already-joined bots receive the opening turn. The content is
@@ -214,7 +216,9 @@ export function parseSpawnRequest(body: unknown): ParseResult<SpawnRequest> {
   if (!column) return { ok: false, error: 'bad_column' };
   const role = normalizeSpawnRole(b.role);
   if (!role) return { ok: false, error: 'bad_role' };
-  const title = typeof b.title === 'string' && b.title.trim() ? b.title.trim().slice(0, 200) : undefined;
+  const title = typeof b.title === 'string' && b.title.trim()
+    ? truncateUtf16WellFormed(b.title.trim(), 200)
+    : undefined;
   const parsedImages = parseDashboardImageUploads(b.images);
   if (!parsedImages.ok) return { ok: false, error: parsedImages.error };
   return {

--- a/src/utils/unicode.ts
+++ b/src/utils/unicode.ts
@@ -1,0 +1,16 @@
+/** Truncate to a UTF-16 code-unit budget without splitting a surrogate pair. */
+export function truncateUtf16WellFormed(value: string, maxCodeUnits: number): string {
+  let used = 0;
+  let result = '';
+  for (const codePoint of value) {
+    const normalized = codePoint.length === 1
+      && codePoint.charCodeAt(0) >= 0xd800
+      && codePoint.charCodeAt(0) <= 0xdfff
+      ? '\ufffd'
+      : codePoint;
+    if (used + normalized.length > maxCodeUnits) break;
+    result += normalized;
+    used += normalized.length;
+  }
+  return result;
+}

--- a/test/session-create.test.ts
+++ b/test/session-create.test.ts
@@ -37,6 +37,16 @@ describe('deriveSessionTitleFromContent', () => {
     expect(title.length).toBe(51); // 50 chars + …
     expect(title.endsWith('…')).toBe(true);
   });
+  it('does not split an emoji at the title boundary', () => {
+    const title = deriveSessionTitleFromContent('a'.repeat(49) + '😀x');
+    expect(title.isWellFormed()).toBe(true);
+    expect(title).toBe('a'.repeat(49) + '…');
+  });
+  it('repairs an isolated surrogate in a short title', () => {
+    const title = deriveSessionTitleFromContent('短标题\ud83d');
+    expect(title.isWellFormed()).toBe(true);
+    expect(title).toBe('短标题\ufffd');
+  });
   it('falls back to a placeholder for blank content', () => {
     expect(deriveSessionTitleFromContent('   \n  ')).toBeTruthy();
   });
@@ -48,6 +58,11 @@ describe('deriveCreateGroupName', () => {
   });
   it('falls back to the first non-empty content line when blank', () => {
     expect(deriveCreateGroupName('   ', '\n  修复创建会话  \n详情')).toBe('修复创建会话');
+  });
+  it('does not split an emoji at the explicit-name boundary', () => {
+    const name = deriveCreateGroupName('a'.repeat(59) + '😀x', '内容首行');
+    expect(name.isWellFormed()).toBe(true);
+    expect(name).toBe('a'.repeat(59));
   });
 });
 
@@ -95,6 +110,15 @@ describe('parseSpawnRequest', () => {
     const r = parseSpawnRequest({ ...base, content: huge });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.value.content.length).toBe(50000);
+  });
+
+  it('does not split an emoji in the explicit title', () => {
+    const r = parseSpawnRequest({ ...base, title: 'a'.repeat(199) + '😀x' });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.title?.isWellFormed()).toBe(true);
+      expect(r.value.title).toBe('a'.repeat(199));
+    }
   });
 
   it('rejects bad column / role', () => {

--- a/test/session-kanban.test.ts
+++ b/test/session-kanban.test.ts
@@ -48,6 +48,9 @@ describe('session-board normalizers', () => {
     expect(normalizeSessionTitle('安全\r\n标题\t\u001b[31m\u0000\u009b')).toBe('安全 标题 [31m');
     expect(normalizeSessionTitle('\x1b]52;c;payload\x07安全\t标题\u009b2J')).toBe(']52;c;payload 安全 标题 2J');
     expect(normalizeSessionTitle('a'.repeat(300))).toHaveLength(200);
+    const emojiBoundary = normalizeSessionTitle('a'.repeat(199) + '😀x');
+    expect(emojiBoundary?.isWellFormed()).toBe(true);
+    expect(emojiBoundary).toBe('a'.repeat(199));
     expect(normalizeSessionTitle('   ')).toBeNull();
     expect(normalizeSessionTitle('')).toBeNull();
     expect(normalizeSessionTitle(42)).toBeNull();

--- a/test/unicode.test.ts
+++ b/test/unicode.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { truncateUtf16WellFormed } from '../src/utils/unicode.js';
+
+describe('truncateUtf16WellFormed', () => {
+  it('keeps the UTF-16 budget without splitting a surrogate pair', () => {
+    const value = truncateUtf16WellFormed('a'.repeat(4) + '😀x', 5);
+    expect(value).toBe('a'.repeat(4));
+    expect(value.isWellFormed()).toBe(true);
+    expect(value.length).toBeLessThanOrEqual(5);
+  });
+
+  it('preserves a complete astral code point when it fits', () => {
+    expect(truncateUtf16WellFormed('a'.repeat(3) + '😀x', 5))
+      .toBe('a'.repeat(3) + '😀');
+  });
+
+  it('repairs an isolated surrogate in truncated input', () => {
+    const value = truncateUtf16WellFormed(`a\ud83db`, 2);
+    expect(value).toBe('a\ufffd');
+    expect(value.isWellFormed()).toBe(true);
+  });
+
+  it('repairs an isolated surrogate even when no truncation is needed', () => {
+    expect(truncateUtf16WellFormed('a\ud83d', 10)).toBe('a\ufffd');
+  });
+});


### PR DESCRIPTION
## 问题

多条标题生成路径直接用 `String.slice(0, N)` 截断。JavaScript 按 UTF-16 code unit 索引，当 emoji 恰好跨越边界时会留下孤立 surrogate，并在 UTF-8 编码时变成替换字符 `�`。

Fixes #1253

## 修复

- 新增 `truncateUtf16WellFormed()`：按 Unicode code point 遍历，同时以 UTF-16 code unit 计入原有长度预算。
- 替换以下四条路径的直接切片：
  - 内容首行生成会话标题（50）
  - 显式群名（60）
  - 会话重命名标题（200）
  - Dashboard spawn 显式标题（200）
- 对输入中的孤立 surrogate 使用 `U+FFFD` 归一化，保证返回字符串 well-formed。
- 保持原有长度上限及会话标题省略号语义。

## 影响面

- 只影响用户可见标题/群名的边界截断。
- BMP 字符和未超长的正常 Unicode 输入行为不变。
- 不改变 session id、消息正文或其它协议字段。

## 验证

- Issue 中最小复现在修复前稳定得到 `wellFormed: false`。
- `npx vitest run --project unit test/unicode.test.ts test/session-create.test.ts test/session-kanban.test.ts`：53 passed。
- `bun run vitest run --project unit test/unicode.test.ts test/session-create.test.ts test/session-kanban.test.ts`：53 passed。
- `bun run build`：通过。

