### PR TITLE
fix(claude-hook): 结构化识别 session-ready hook

### DIFF
--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -284,19 +284,13 @@ export function hasInstalledSessionReadyHook(hookInstall: HookInstallConfig): bo
   }
   const settings = readJsonFile<ClaudeSettings>(expandHome(hookInstall.configPath));
   const groups = settings?.hooks?.SessionStart;
-  return Array.isArray(groups) && groups.some(group =>
-    Array.isArray(group?.hooks) && group.hooks.some(entry =>
-      entry?.type === 'command'
-      && entry.command === hookInstall.sessionStartCommand,
-    ),
-  );
+  return Array.isArray(groups) && groups.some(group => isBotmuxReadyHookGroup(group));
 }
 
 /**
  * Read-only preflight: is the botmux UserPromptSubmit hook present in the
- * settings file the CLI actually reads? 结构化匹配（不像
- * hasInstalledSessionReadyHook 那样按完整字符串相等——dev checkout 与 npm global
- * 的 cli.js 路径不同，精确匹配会把已安装的 hook 误判为未安装）。
+ * settings file the CLI actually reads? 与 SessionStart preflight 一样结构化匹配，
+ * 避免 dev checkout 与 npm global 的 cli.js 绝对路径差异造成误判。
  */
 export function hasInstalledPromptHook(hookInstall: HookInstallConfig): boolean {
   if (!hookInstall.userPromptSubmitCommand) return false;

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -284,7 +284,17 @@ export function hasInstalledSessionReadyHook(hookInstall: HookInstallConfig): bo
   }
   const settings = readJsonFile<ClaudeSettings>(expandHome(hookInstall.configPath));
   const groups = settings?.hooks?.SessionStart;
-  return Array.isArray(groups) && groups.some(group => isBotmuxReadyHookGroup(group));
+  return Array.isArray(groups) && groups.some(group =>
+    isBotmuxReadyHookGroup(group)
+    // Preserve the old exact-match fallback for a current command whose
+    // executable basename is newer than the structural whitelist. This keeps
+    // path-switch recognition broad without regressing the simplest case:
+    // the configured command is exactly the one installed in settings.
+    || (Array.isArray(group?.hooks) && group.hooks.some(entry =>
+      entry?.type === 'command'
+      && entry.command === hookInstall.sessionStartCommand,
+    )),
+  );
 }
 
 /**

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -147,6 +147,26 @@ describe('installHook — claude-settings', () => {
     })).toBe(true);
   });
 
+  it.each([
+    '/repo/dist-bin/botmux-linux-x64 session-ready',
+    '/repo/dist-bin/botmux-future-riscv64 session-ready',
+  ])('ready preflight preserves an exact command match: %s', (installedCommand) => {
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: installedCommand }] },
+        ],
+      },
+    }));
+
+    expect(hasInstalledSessionReadyHook({
+      configPath,
+      format: 'claude-settings',
+      sessionStartCommand: installedCommand,
+    })).toBe(true);
+  });
+
   it('ready preflight fails closed for malformed or unrelated SessionStart config', () => {
     mkdirSync(join(tmpDir, '.claude'), { recursive: true });
     writeFileSync(configPath, JSON.stringify({
@@ -213,7 +233,7 @@ describe('installHook — claude-settings', () => {
     const botmuxUps = ups.filter((g) => g.hooks?.some((e: any) => e.command.includes('cli.js') && e.command.trimEnd().endsWith('user-prompt-hook')));
     expect(botmuxUps.length).toBe(1);
     expect(botmuxUps[0].hooks[0].command).toBe(promptCmd2);
-    // 结构化识别：换路径后 preflight 仍为 true（与 hasInstalledSessionReadyHook 的精确字符串匹配不同）
+    // 结构化识别：换路径后 preflight 仍为 true。
     expect(hasInstalledPromptHook({ configPath, format: 'claude-settings', userPromptSubmitCommand: promptCmd2 })).toBe(true);
   });
 

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -126,8 +126,25 @@ describe('installHook — claude-settings', () => {
     const botmuxReady = ss.filter((g) => g.hooks?.some((e: any) => e.command.includes('cli.js') && e.command.trimEnd().endsWith('session-ready')));
     expect(botmuxReady.length).toBe(1);
     expect(botmuxReady[0].hooks[0].command).toBe(readyCmd2);
-    expect(hasInstalledSessionReadyHook(hookInstall)).toBe(false);
+    expect(hasInstalledSessionReadyHook(hookInstall)).toBe(true);
     expect(hasInstalledSessionReadyHook({ ...hookInstall, sessionStartCommand: readyCmd2 })).toBe(true);
+  });
+
+  it('ready preflight recognizes a standalone hook after switching to a Node launch path', () => {
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: '/home/u/.botmux/bin/botmux session-ready' }] },
+        ],
+      },
+    }));
+
+    expect(hasInstalledSessionReadyHook({
+      configPath,
+      format: 'claude-settings',
+      sessionStartCommand: '/usr/bin/node /opt/botmux/dist/cli.js session-ready',
+    })).toBe(true);
   });
 
   it('ready preflight fails closed for malformed or unrelated SessionStart config', () => {
@@ -137,6 +154,22 @@ describe('installHook — claude-settings', () => {
         SessionStart: [
           { matcher: 'malformed-without-hooks' },
           { hooks: [{ type: 'command', command: '/usr/bin/unrelated-ready-hook' }] },
+        ],
+      },
+    }));
+    expect(hasInstalledSessionReadyHook({
+      configPath,
+      format: 'claude-settings',
+      sessionStartCommand: '/usr/bin/node /path/to/cli.js session-ready',
+    })).toBe(false);
+  });
+
+  it('ready preflight does not accept a third-party command with the same suffix', () => {
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: '/usr/bin/botmux-helper session-ready' }] },
         ],
       },
     }));


### PR DESCRIPTION
## 问题

SessionStart hook 的安装/去重已经使用结构化命令匹配，但 worker 启动前的 `hasInstalledSessionReadyHook()` 仍要求命令完整字符串相等。只要 BotMux 从 dev checkout、npm global 或 standalone 之间切换安装路径，已安装 hook 就会被误判为缺失，worker 退回启发式 ready 检测。

Fixes #1211

## 修复

- 让 SessionStart preflight 复用现有 `isBotmuxReadyHookGroup()`。
- 按 BotMux 调用目标 basename 与 `session-ready` 子命令签名识别，不再依赖绝对路径完全一致。
- 增加第三方 `botmux-helper session-ready` 不得被误认的反例。
- 更新过期注释，使 SessionStart 与 UserPromptSubmit 的匹配策略说明一致。

## 影响面

- 仅影响 Claude/Grok SessionStart hook 的只读 preflight。
- 不修改 hook 安装内容、配置写入或 CLI 启动参数。
- 保持 malformed/无关 hook fail closed。

## 验证

- `npx vitest run --project unit test/hook-installer.test.ts`：29 passed。
- `bun run vitest run --project unit test/hook-installer.test.ts`：29 passed。
- `bun run build`：通过。

