### PR TITLE
fix(claude-hook): 识别开发版平台二进制

### DIFF
--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -126,12 +126,10 @@ function botmuxHookSuffix(hookCommand: string): string {
  * `botmux`（`botmux-linux-x64/botmux` 的 basename 同为 `botmux`；Windows 上为 `botmux.exe`）。
  * 两者取其一即视为同一条 botmux hook，无论它指向哪个安装路径、由 node 还是打包二进制执行。
  *
- * ⚠️ basename 白名单**故意只认这三个字面量**，不要放宽成 `botmux-*` 前缀匹配：那会把
+ * ⚠️ basename 白名单**故意枚举正式产物名**，不要放宽成 `botmux-*` 前缀匹配：那会把
  * 第三方同前缀程序（`botmux-helper` / `botmux-wrapper` 等）也当成自己的 hook 删掉。
- * 已知未覆盖形态：本地 `bun run use:here --binary` 指向的 `dist-bin/botmux-<plat>-<arch>`
- * （basename 带平台后缀）。生产两条安装路径都落在 `botmux` 上（npm 平台子包
- * `…/node_modules/botmux-<plat>-<arch>/botmux`、install.sh 的 `~/.botmux/bin/botmux`），
- * 故仅影响开发机；真要覆盖须**枚举死平台后缀**而非放宽为任意后缀。
+ * 生产安装入口通常叫 `botmux`；本地 `bun run use:here --binary` 会指向
+ * `dist-bin/botmux-<plat>-<arch>[-musl]`，因此也需精确覆盖这些构建产物名。
  */
 function isBotmuxHookCommand(command: string, suffix: string): boolean {
   const trimmed = command.trimEnd();
@@ -141,7 +139,11 @@ function isBotmuxHookCommand(command: string, suffix: string): boolean {
   if (!target) return false;
   const slash = Math.max(target.lastIndexOf('/'), target.lastIndexOf('\\'));
   const basename = target.slice(slash + 1);
-  return basename === 'cli.js' || basename === 'botmux' || basename === 'botmux.exe';
+  return basename === 'cli.js'
+    || basename === 'botmux'
+    || basename === 'botmux.exe'
+    || /^botmux-(?:linux|darwin)-(?:x64|arm64)(?:-musl)?$/.test(basename)
+    || /^botmux-windows-(?:x64|arm64)(?:\.exe)?$/.test(basename);
 }
 
 /**

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -142,7 +142,8 @@ function isBotmuxHookCommand(command: string, suffix: string): boolean {
   return basename === 'cli.js'
     || basename === 'botmux'
     || basename === 'botmux.exe'
-    || /^botmux-(?:linux|darwin)-(?:x64|arm64)(?:-musl)?$/.test(basename)
+    || /^botmux-linux-(?:x64|arm64)(?:-musl)?$/.test(basename)
+    || /^botmux-darwin-(?:x64|arm64)$/.test(basename)
     || /^botmux-windows-(?:x64|arm64)(?:\.exe)?$/.test(basename);
 }
 

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -167,9 +167,19 @@ describe('installHook — claude-settings', () => {
     })).toBe(true);
   });
 
-  it('识别 dev dist-bin 的平台二进制并保持三类 hook 幂等', () => {
-    const first = '/repo/dist-bin/botmux-linux-x64';
-    const second = '/repo/dist-bin/botmux-darwin-arm64';
+  it.each([
+    '/repo/dist-bin/botmux-linux-x64',
+    '/repo/dist-bin/botmux-linux-arm64',
+    '/repo/dist-bin/botmux-linux-x64-musl',
+    '/repo/dist-bin/botmux-linux-arm64-musl',
+    '/repo/dist-bin/botmux-darwin-x64',
+    '/repo/dist-bin/botmux-darwin-arm64',
+    'C:\\repo\\dist-bin\\botmux-windows-x64',
+    'C:\\repo\\dist-bin\\botmux-windows-x64.exe',
+    'C:\\repo\\dist-bin\\botmux-windows-arm64',
+    'C:\\repo\\dist-bin\\botmux-windows-arm64.exe',
+  ])('识别 dev dist-bin 产物并保持三类 hook 幂等: %s', (first) => {
+    const second = '/opt/botmux/bin/botmux';
     const firstInstall = {
       configPath,
       format: 'claude-settings' as const,
@@ -191,25 +201,6 @@ describe('installHook — claude-settings', () => {
     }
   });
 
-  it('识别 Windows dev binary 的可选 exe 后缀', () => {
-    for (const basename of ['botmux-windows-x64', 'botmux-windows-arm64.exe']) {
-      const installed = {
-        configPath,
-        format: 'claude-settings' as const,
-        sessionStartCommand: `C:\repo\dist-bin\${basename} session-ready`,
-      };
-      installHook('claude-code', installed, `C:\repo\dist-bin\${basename} hook claude-code`);
-      installHook('claude-code', {
-        ...installed,
-        sessionStartCommand: '/repo/dist-bin/botmux-linux-x64 session-ready',
-      }, '/repo/dist-bin/botmux-linux-x64 hook claude-code');
-
-      const groups = JSON.parse(readFileSync(configPath, 'utf-8')).hooks.SessionStart;
-      expect(groups).toHaveLength(1);
-      expect(groups[0].hooks).toHaveLength(1);
-    }
-  });
-
   it.each([
     'botmux-helper',
     'botmux-wrapper',
@@ -217,7 +208,11 @@ describe('installHook — claude-settings', () => {
     'botmux-x64',
     'botmux-linux-x64-extra',
     'botmux-linux-x64.exe',
+    'botmux-linux-arm64-musl.exe',
     'botmux-darwin-arm64.exe',
+    'botmux-darwin-arm64-musl',
+    'botmux-windows-x64-musl',
+    'botmux-windows-arm64-musl.exe',
   ])('不把第三方同前缀程序 %s 当成 botmux hook', (basename) => {
     const thirdPartyCommand = `/usr/local/bin/${basename} session-ready`;
     mkdirSync(join(tmpDir, '.claude'), { recursive: true });
@@ -225,11 +220,16 @@ describe('installHook — claude-settings', () => {
       hooks: { SessionStart: [{ hooks: [{ type: 'command', command: thirdPartyCommand }] }] },
     }));
 
-    expect(hasInstalledSessionReadyHook({
+    const currentBinary = '/repo/dist-bin/botmux-linux-x64';
+    installHook('claude-code', {
       configPath,
       format: 'claude-settings',
-      sessionStartCommand: '/repo/dist-bin/botmux-linux-x64 session-ready',
-    })).toBe(false);
+      sessionStartCommand: `${currentBinary} session-ready`,
+    }, `${currentBinary} hook claude-code`);
+
+    const commands = JSON.parse(readFileSync(configPath, 'utf-8'))
+      .hooks.SessionStart.flatMap((group: any) => group.hooks.map((entry: any) => entry.command));
+    expect(commands).toContain(thirdPartyCommand);
   });
 
   it('ready preflight fails closed for malformed or unrelated SessionStart config', () => {

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -167,6 +167,71 @@ describe('installHook — claude-settings', () => {
     })).toBe(true);
   });
 
+  it('识别 dev dist-bin 的平台二进制并保持三类 hook 幂等', () => {
+    const first = '/repo/dist-bin/botmux-linux-x64';
+    const second = '/repo/dist-bin/botmux-darwin-arm64';
+    const firstInstall = {
+      configPath,
+      format: 'claude-settings' as const,
+      sessionStartCommand: `${first} session-ready`,
+      userPromptSubmitCommand: `${first} user-prompt-hook`,
+    };
+    installHook('claude-code', firstInstall, `${first} hook claude-code`);
+    installHook('claude-code', {
+      ...firstInstall,
+      sessionStartCommand: `${second} session-ready`,
+      userPromptSubmitCommand: `${second} user-prompt-hook`,
+    }, `${second} hook claude-code`);
+
+    const hooks = JSON.parse(readFileSync(configPath, 'utf-8')).hooks;
+    for (const event of ['PreToolUse', 'SessionStart', 'UserPromptSubmit']) {
+      expect(hooks[event]).toHaveLength(1);
+      expect(hooks[event][0].hooks).toHaveLength(1);
+      expect(hooks[event][0].hooks[0].command).toContain(second);
+    }
+  });
+
+  it('识别 Windows dev binary 的可选 exe 后缀', () => {
+    for (const basename of ['botmux-windows-x64', 'botmux-windows-arm64.exe']) {
+      const installed = {
+        configPath,
+        format: 'claude-settings' as const,
+        sessionStartCommand: `C:\repo\dist-bin\${basename} session-ready`,
+      };
+      installHook('claude-code', installed, `C:\repo\dist-bin\${basename} hook claude-code`);
+      installHook('claude-code', {
+        ...installed,
+        sessionStartCommand: '/repo/dist-bin/botmux-linux-x64 session-ready',
+      }, '/repo/dist-bin/botmux-linux-x64 hook claude-code');
+
+      const groups = JSON.parse(readFileSync(configPath, 'utf-8')).hooks.SessionStart;
+      expect(groups).toHaveLength(1);
+      expect(groups[0].hooks).toHaveLength(1);
+    }
+  });
+
+  it.each([
+    'botmux-helper',
+    'botmux-wrapper',
+    'botmux-linux',
+    'botmux-x64',
+    'botmux-linux-x64-extra',
+    'botmux-linux-x64.exe',
+    'botmux-darwin-arm64.exe',
+  ])('不把第三方同前缀程序 %s 当成 botmux hook', (basename) => {
+    const thirdPartyCommand = `/usr/local/bin/${basename} session-ready`;
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: thirdPartyCommand }] }] },
+    }));
+
+    expect(hasInstalledSessionReadyHook({
+      configPath,
+      format: 'claude-settings',
+      sessionStartCommand: '/repo/dist-bin/botmux-linux-x64 session-ready',
+    })).toBe(false);
+  });
+
   it('ready preflight fails closed for malformed or unrelated SessionStart config', () => {
     mkdirSync(join(tmpDir, '.claude'), { recursive: true });
     writeFileSync(configPath, JSON.stringify({


### PR DESCRIPTION
## 问题

Hook 去重只识别 `cli.js`、`botmux` 和 `botmux.exe`。本地 `bun run use:here --binary` 使用 `dist-bin/botmux-<platform>-<arch>[-musl]`，因此路径切换或重复安装时，SessionStart/UserPromptSubmit hook 会持续累积。

Fixes #1210

## 修复

- 将 BotMux 可执行文件 basename 判据扩展为受限的平台产物枚举：Linux、Darwin × x64/arm64（可选 `-musl`），以及 Windows × x64/arm64（可选 `.exe`）。
- 不使用宽泛 `botmux-*` 匹配，继续拒绝 `botmux-helper`、`botmux-wrapper`、缺平台/架构和额外后缀等第三方名字。
- 回归测试覆盖 Ask、SessionStart、UserPromptSubmit 三类 hook 在不同 dist-bin 路径间重复安装后仍各保留一条。

## 影响面

- 只影响 Claude 家族 hook 的幂等识别与清理。
- 生产 npm/install.sh 的 `botmux` 名称和 Node `cli.js` 路径行为不变。
- 不扩大到任意同前缀程序，避免误删第三方 hook。

## 验证

- `npx vitest run --project unit test/hook-installer.test.ts`：36 passed。
- `bun run vitest run --project unit test/hook-installer.test.ts`：36 passed。
- `bun run build`：通过。

