### PR TITLE
test(dashboard): 限定 CSS 断言到目标规则

### DIFF
--- a/test/css-rule.test.ts
+++ b/test/css-rule.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { cssRuleBody } from './helpers/css-rule.js';
+
+describe('cssRuleBody', () => {
+  it('returns only the requested flat rule body', () => {
+    const css = '.target { color: red; }\n.other { color: blue; }';
+    expect(cssRuleBody(css, '.target')).toBe(' color: red; ');
+  });
+
+  it('fails closed when the requested rule contains a nested block', () => {
+    const css = '.target { color: red; & > span { color: blue; } }';
+    expect(() => cssRuleBody(css, '.target')).toThrow('nested CSS rule is unsupported');
+  });
+
+  it('fails closed for missing and unterminated rules', () => {
+    expect(() => cssRuleBody('.other { color: blue; }', '.target')).toThrow('selector not found');
+    expect(() => cssRuleBody('.target { color: red;', '.target')).toThrow('unterminated CSS rule');
+  });
+});

--- a/test/dashboard-bot-defaults-layout.test.ts
+++ b/test/dashboard-bot-defaults-layout.test.ts
@@ -1,50 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { cssRuleBody } from './helpers/css-rule.js';
 
 const page = readFileSync(new URL('../src/dashboard/web/bot-defaults-page.tsx', import.meta.url), 'utf8');
 const css = readFileSync(new URL('../src/dashboard/web/style.css', import.meta.url), 'utf8');
 const i18n = readFileSync(new URL('../src/dashboard/web/i18n.ts', import.meta.url), 'utf8');
-
-// Slice out ONE rule body, ending at its own closing brace.
-//
-// Bounding the slice on the *next* landmark instead (`@media`, the following
-// selector) makes the window wider than the rule: any declaration in a rule
-// that later gets inserted into that gap satisfies the assertions, while the
-// property they are meant to pin has already been deleted. Verified: dropping
-// `align-content: start` from .bd-roster-list and adding an unrelated rule
-// carrying it before the @media kept all assertions green.
-//
-// `.bd-roster-list` is declared TWICE — once at top level for desktop, once
-// inside @media (max-width: 980px). Every caller here wants the desktop rule,
-// which is the first match, so this takes the first and does not offer a
-// choice.
-//
-// This is NOT a safety net for a rename, and the gap is only partial: rename
-// the desktop rule and the mobile copy becomes the first match. Only the
-// `align-content: start` assertion then fails, because the mobile body has no
-// such declaration; `min-height: 0`, `overflow-y: auto` and
-// `overscroll-behavior: contain` all happen to be present in the mobile body
-// too, so those three keep passing against the wrong rule. Measured, not
-// assumed. Pinning a declaration that both copies share needs a check the
-// slice cannot give you.
-//
-// These rule bodies contain no nested blocks, so the first `}` after the
-// selector is the closing brace. Throw rather than slice from -1.
-//
-// Every rule assertion in this file goes through here. Leaving even one
-// landmark-bounded slice behind is what let the pattern spread in the first
-// place: the fill-height shell block used to be sliced as one 800-char window
-// spanning five rules, and deleting `overflow: hidden` from `main:has(...)`
-// alone kept every assertion green, because the very next rule carries the
-// same declaration and `[\s\S]*?` walked into it. That window needed no
-// planted decoy at all — the duplicates were already there.
-function ruleBody(selector: string): string {
-  const start = css.indexOf(selector);
-  if (start === -1) throw new Error(`selector not found in style.css: ${selector}`);
-  const end = css.indexOf('}', start);
-  if (end === -1) throw new Error(`unterminated rule in style.css: ${selector}`);
-  return css.slice(start, end);
-}
 
 describe('bot defaults focused layout', () => {
   it('keeps every task panel mounted while hiding inactive categories', () => {
@@ -75,7 +35,7 @@ describe('bot defaults focused layout', () => {
     // CSS: single column + auto rows by default, 2 cols + 1px row track in the container query
     expect(css).toMatch(/\.bot-defaults-page \.bd-tab-grid\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\);[\s\S]*?grid-auto-rows:\s*auto;/);
     expect(css).toMatch(/@container \(min-width: 1024px\)\s*\{[\s\S]*?\.bot-defaults-page \.bd-tab-grid\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);[\s\S]*?grid-auto-rows:\s*1px;/);
-    expect(css).toMatch(/\.bot-defaults-page \.bd-tab-grid > \.bd-tile-wide\s*\{[\s\S]*?grid-column:\s*1 \/ -1;/);
+    expect(cssRuleBody(css, '.bot-defaults-page .bd-tab-grid > .bd-tile-wide')).toMatch(/grid-column:\s*1 \/ -1;/);
   });
 
   it('fills the desktop main so the roster cannot be shoved under the search box', () => {
@@ -84,21 +44,21 @@ describe('bot defaults focused layout', () => {
     // sliding it up and clips #bd-filters. Desktop therefore uses the same
     // fill-height shell as roles-page: main does not scroll, both columns
     // stretch, the list and the detail pane are the scrollports.
-    const desktop = ruleBody('main:has(.bot-defaults-page) {');
+    const desktop = cssRuleBody(css, 'main:has(.bot-defaults-page)');
     expect(desktop).toMatch(/overflow:\s*hidden;/);
-    expect(ruleBody('main:has(.bot-defaults-page) .bot-defaults-page {')).toMatch(/grid-template-rows:\s*auto minmax\(0,\s*1fr\);/);
-    expect(ruleBody('main:has(.bot-defaults-page) .bd-layout {')).toMatch(/align-items:\s*stretch;/);
-    const shellRoster = ruleBody('main:has(.bot-defaults-page) .bd-roster {');
+    expect(cssRuleBody(css, 'main:has(.bot-defaults-page) .bot-defaults-page')).toMatch(/grid-template-rows:\s*auto minmax\(0,\s*1fr\);/);
+    expect(cssRuleBody(css, 'main:has(.bot-defaults-page) .bd-layout')).toMatch(/align-items:\s*stretch;/);
+    const shellRoster = cssRuleBody(css, 'main:has(.bot-defaults-page) .bd-roster');
     expect(shellRoster).toMatch(/position:\s*static;/);
     expect(shellRoster).toMatch(/height:\s*100%;/);
-    expect(ruleBody('main:has(.bot-defaults-page) .bd-detail {')).toMatch(/overflow-y:\s*auto;/);
+    expect(cssRuleBody(css, 'main:has(.bot-defaults-page) .bd-detail')).toMatch(/overflow-y:\s*auto;/);
 
-    const roster = ruleBody('.bot-defaults-page .bd-roster {');
+    const roster = cssRuleBody(css, '.bot-defaults-page .bd-roster');
     expect(roster).toMatch(/grid-template-rows:\s*auto auto minmax\(0,\s*1fr\);/);
     expect(roster).toMatch(/overflow:\s*hidden;/);
     expect(roster).not.toMatch(/max-height:\s*calc\(100dvh/);
 
-    const list = ruleBody('.bot-defaults-page .bd-roster-list {');
+    const list = cssRuleBody(css, '.bot-defaults-page .bd-roster-list');
     expect(list).toMatch(/min-height:\s*0;/);
     expect(list).toMatch(/overflow-y:\s*auto;/);
     expect(list).toMatch(/overscroll-behavior:\s*contain;/);
@@ -111,7 +71,7 @@ describe('bot defaults focused layout', () => {
     // per row instead of 54.4px, so the selected row rendered as a tall block
     // and the last row sank to the panel floor. align-content:start makes the
     // rows keep their content height and leaves the slack as empty space.
-    const list = ruleBody('.bot-defaults-page .bd-roster-list {');
+    const list = cssRuleBody(css, '.bot-defaults-page .bd-roster-list');
     expect(list).toMatch(/align-content:\s*start;/);
   });
 
@@ -189,7 +149,7 @@ describe('bot defaults focused layout', () => {
     const profileHead = page.slice(profileStart, tabsStart);
 
     expect(profileHead).toContain('<BotDescriptionControl bot={bot} />');
-    expect(css).toMatch(/\.bot-defaults-page \.bd-description-preview\s*\{[\s\S]*?-webkit-line-clamp:\s*2;/);
+    expect(cssRuleBody(css, '.bot-defaults-page .bd-description-preview')).toMatch(/-webkit-line-clamp:\s*2;/);
     expect(css).toMatch(/\.bot-defaults-page \.bd-description-modal\s*\{[\s\S]*?max-height:\s*min\(720px,\s*calc\(100vh - 32px\)\);/);
   });
 
@@ -222,7 +182,7 @@ describe('bot defaults focused layout', () => {
     expect(i18n).not.toContain('产品默认 3 条');
     expect(i18n).not.toContain('product default of 3');
     expect(css).not.toContain('.bot-defaults-page .bd-grant-default-grid');
-    expect(css).toMatch(/\.bot-defaults-page \.bd-grant-defaults > \.actions\s*\{[\s\S]*?justify-content:\s*flex-end;/);
+    expect(cssRuleBody(css, '.bot-defaults-page .bd-grant-defaults > .actions')).toMatch(/justify-content:\s*flex-end;/);
   });
 
   it('offers granular Session owner reminder controls in advanced settings', () => {

--- a/test/dashboard-mobile-layout.test.ts
+++ b/test/dashboard-mobile-layout.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { cssRuleBody } from './helpers/css-rule.js';
 
 const css = readFileSync(new URL('../src/dashboard/web/style.css', import.meta.url), 'utf8');
 
@@ -23,11 +24,13 @@ describe('dashboard mobile layout', () => {
     expect(css).toMatch(/\.bulk-bar\s*\{[\s\S]*?--bulk-bar-bg:\s*color-mix\(in srgb,\s*var\(--warning\) 10%,\s*var\(--bg\)\);[\s\S]*?background:\s*var\(--bulk-bar-bg\);/);
     expect(css).toMatch(/main:has\(\.sessions-page\) \.bulk-bar\s*\{[\s\S]*?box-shadow:\s*0 0 0 16px var\(--bulk-bar-bg\),\s*var\(--shadow\);/);
     expect(css).toMatch(/main:has\(\.sessions-page\) \.bulk-bar\[hidden\]\s*\{\s*display:\s*none;/);
-    expect(css).toMatch(/main:has\(\.sessions-page\) \.bulk-bar button\s*\{[\s\S]*?white-space:\s*nowrap;/);
+    expect(cssRuleBody(css, 'main:has(.sessions-page) .bulk-bar button')).toMatch(/white-space:\s*nowrap;/);
   });
 
   it('stacks topic aggregation cards on mobile', () => {
-    expect(css).toMatch(/main:has\(\.sessions-page\) \.sessions-topic-view\s*\{[\s\S]*?height:\s*auto;[\s\S]*?overflow:\s*visible;/);
+    const topicView = cssRuleBody(css, 'main:has(.sessions-page) .sessions-topic-view');
+    expect(topicView).toMatch(/height:\s*auto;/);
+    expect(topicView).toMatch(/overflow:\s*visible;/);
     expect(css).toMatch(/main:has\(\.sessions-page\) \.session-topic-members\s*\{\s*grid-template-columns:\s*1fr;/);
   });
 });

--- a/test/dashboard-rebase-ui-regressions.test.ts
+++ b/test/dashboard-rebase-ui-regressions.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { cssRuleBody } from './helpers/css-rule.js';
 
 function dashboardSource(file: string): string {
   return readFileSync(new URL(`../src/dashboard/web/${file}`, import.meta.url), 'utf8');
@@ -88,7 +89,9 @@ describe('dashboard master feature integration', () => {
     // DropdownMenu is shared by Bots, Roles, Settings, and Sessions. Its disabled
     // appearance belongs to the shared selector rather than a page-specific override.
     expect(css).toContain('.sect-sort-menu.is-disabled > summary,');
-    expect(css).toMatch(/\.sect-sort-menu\.is-disabled > summary:hover \{[\s\S]*?cursor: not-allowed;[\s\S]*?opacity: 0\.62;/);
+    const disabledSummary = cssRuleBody(css, '.sect-sort-menu.is-disabled > summary:hover');
+    expect(disabledSummary).toMatch(/cursor:\s*not-allowed;/);
+    expect(disabledSummary).toMatch(/opacity:\s*0\.62;/);
     expect(css).not.toContain('.kanban-team-menu.is-disabled > summary');
   });
 

--- a/test/dashboard-schedules-ui.test.ts
+++ b/test/dashboard-schedules-ui.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { createDashboardTranslator } from '../src/dashboard/web/i18n.js';
 import { store } from '../src/dashboard/web/store.js';
+import { cssRuleBody } from './helpers/css-rule.js';
 import {
   buildSchedulePreconditionFormFields,
   canSubmitSchedule,
@@ -880,6 +881,6 @@ describe('dashboard schedules React page helpers', () => {
     expect(css).not.toContain('.schedule-error-chip');
     expect(css).toContain('.schedule-row-head .schedule-state {');
     expect(css).toMatch(/\.schedules-list \{[\s\S]*?grid-auto-rows:\s*max-content/);
-    expect(css).toMatch(/\.schedule-list-row \.schedule-actions \{[\s\S]*?flex-wrap:\s*nowrap/);
+    expect(cssRuleBody(css, '.schedule-list-row .schedule-actions')).toMatch(/flex-wrap:\s*nowrap/);
   });
 });

--- a/test/dashboard-version-popover.test.ts
+++ b/test/dashboard-version-popover.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { cssRuleBody } from './helpers/css-rule.js';
 
 function dashboardSource(file: string): string {
   return readFileSync(new URL(`../src/dashboard/web/${file}`, import.meta.url), 'utf8');
@@ -18,7 +19,7 @@ describe('dashboard version popover layering regression', () => {
     expect(app).toContain('firstFocusable?.focus()');
     expect(app).toContain('window.requestAnimationFrame');
     expect(css).toMatch(/\.dashboard-version-popover\s*\{[\s\S]*?position:\s*fixed;[\s\S]*?z-index:\s*1601;/);
-    expect(css).toMatch(/\.dashboard-version-control\s*\{[\s\S]*?z-index:\s*2;/);
+    expect(cssRuleBody(css, '.dashboard-version-control')).toMatch(/z-index:\s*2;/);
   });
 
   it('clamps the portal horizontally instead of relying on the old topbar offset', () => {

--- a/test/helpers/css-rule.ts
+++ b/test/helpers/css-rule.ts
@@ -1,0 +1,14 @@
+/** Return one flat CSS rule body without allowing assertions to cross `}`. */
+export function cssRuleBody(source: string, selector: string, from = 0): string {
+  const marker = `${selector} {`;
+  const start = source.indexOf(marker, from);
+  if (start === -1) throw new Error(`selector not found in CSS: ${selector}`);
+  const bodyStart = start + marker.length;
+  const end = source.indexOf('}', bodyStart);
+  if (end === -1) throw new Error(`unterminated CSS rule: ${selector}`);
+  const nestedStart = source.indexOf('{', bodyStart);
+  if (nestedStart !== -1 && nestedStart < end) {
+    throw new Error(`nested CSS rule is unsupported: ${selector}`);
+  }
+  return source.slice(bodyStart, end);
+}


### PR DESCRIPTION
## 问题

部分 Dashboard CSS 测试使用 `selector { [\s\S]*? property` 形式的正则。该模式不会在目标规则的 `}` 停止；删除真实声明后，后续任意规则里的同名属性仍可让断言通过。

Fixes #1243
Fixes #1159

## 修复

- 新增共享 `cssRuleBody()` 测试 helper，只返回一个无嵌套 CSS 规则自己的声明块，并在发现嵌套块时 fail closed。
- 将 Issue 列出的 8 条弱断言改为规则体内匹配：
  - version control 层级
  - mobile bulk action 按钮
  - mobile topic view
  - bot defaults wide tile
  - description preview
  - grant actions
  - disabled sort menu
  - schedule actions
- 将 bot defaults 文件中已有的局部 `ruleBody()` 收敛到共享 helper，避免继续复制脆弱写法。

## 影响面

- 只修改测试，不改变生产 CSS 或运行时代码。
- helper 适用于无嵌套块的普通规则；需要指定 at-rule 范围的测试仍应先定位对应上下文。

## 验证

- Issue 已记录逐条删除真实属性时旧断言仍通过的反变异证据。
- `npx vitest run --project unit test/dashboard-version-popover.test.ts test/dashboard-mobile-layout.test.ts test/dashboard-bot-defaults-layout.test.ts test/dashboard-rebase-ui-regressions.test.ts test/dashboard-schedules-ui.test.ts`：53 passed。
- `bun run vitest run --project unit test/dashboard-version-popover.test.ts test/dashboard-mobile-layout.test.ts test/dashboard-bot-defaults-layout.test.ts test/dashboard-rebase-ui-regressions.test.ts test/dashboard-schedules-ui.test.ts`：53 passed。
- `bun run build`：通过。

