### PR TITLE
test(types): 收敛子进程 mock 返回类型

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun run audit:domains && node scripts/generate-app-icon-data.mjs && node scripts/clean-dist.mjs && tsc && bun run typecheck:scripts && node scripts/generate-runtime-build-id.mjs && cp src/setup/lark-scopes.json dist/setup/ && bun run dashboard:bundle && chmod +x dist/cli.js && node scripts/audit-dist.mjs && node scripts/audit-embedded-assets.mjs --require-dist",
+    "build": "bun run audit:domains && node scripts/generate-app-icon-data.mjs && node scripts/clean-dist.mjs && tsc && bun run typecheck:scripts && bun run typecheck:test-mocks && node scripts/generate-runtime-build-id.mjs && cp src/setup/lark-scopes.json dist/setup/ && bun run dashboard:bundle && chmod +x dist/cli.js && node scripts/audit-dist.mjs && node scripts/audit-embedded-assets.mjs --require-dist",
     "verify:binary": "bun scripts/verify-binary.mjs",
     "typecheck:scripts": "tsc -p tsconfig.scripts.json",
+    "typecheck:test-mocks": "tsc -p tsconfig.test-mocks.json",
     "workflow-core:build": "node scripts/build-workflow-core-package.mjs",
     "workflow-core:test": "bun run workflow-core:build && node scripts/test-workflow-core-package.mjs",
     "workflow-core:pack": "bun run workflow-core:build && node scripts/pack-workflow-core-package.mjs",

--- a/test/ensure-herdr-integrations.test.ts
+++ b/test/ensure-herdr-integrations.test.ts
@@ -2,10 +2,18 @@ import { EventEmitter } from 'node:events';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import type { SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { textSpawnResult } from './helpers/spawn-result.js';
+
+type TextSpawnSync = (
+  command: string,
+  args?: readonly string[],
+  options?: SpawnSyncOptionsWithStringEncoding,
+) => SpawnSyncReturns<string>;
 
 const spawn = vi.fn();
-const spawnSync = vi.fn();
+const spawnSync = vi.fn<TextSpawnSync>();
 const execSync = vi.fn();
 
 vi.mock('node:child_process', () => ({ spawn, spawnSync, execSync }));
@@ -82,7 +90,7 @@ describe('TraeX herdr plugin installation', () => {
     spawn.mockReset();
     spawnSync.mockReset();
     execSync.mockReset();
-    spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    spawnSync.mockReturnValue(textSpawnResult({ status: 0 }));
     execSync.mockReturnValue('herdr 0.7.3');
   });
 
@@ -116,7 +124,7 @@ describe('TraeX herdr plugin installation', () => {
   it('gates herdr versions without the plugin capability and reports the version', async () => {
     vi.stubEnv('BOTMUX_HERDR_TRAEX_PLUGIN_ENABLED', 'true');
     vi.stubEnv('BOTMUX_HERDR_TRAEX_PLUGIN_SOURCE', 'trusted/repo');
-    spawnSync.mockReturnValue({ status: 1, stdout: '', stderr: 'unknown command' });
+    spawnSync.mockReturnValue(textSpawnResult({ status: 1, stderr: 'unknown command' }));
     execSync.mockReturnValue('herdr 0.6.6');
     const { ensureHerdrIntegrations } = await loadSubject();
     const result = await ensureHerdrIntegrations(['traex']);

--- a/test/helpers/spawn-result.ts
+++ b/test/helpers/spawn-result.ts
@@ -1,0 +1,36 @@
+import type { SpawnSyncReturns } from 'node:child_process';
+import type { NonSharedBuffer } from 'node:buffer';
+
+type SpawnResultInput<T> =
+  Partial<SpawnSyncReturns<T>>
+  & Pick<SpawnSyncReturns<T>, 'status'>;
+
+export function textSpawnResult(
+  partial: SpawnResultInput<string>,
+): SpawnSyncReturns<string> {
+  const stdout = partial.stdout ?? '';
+  const stderr = partial.stderr ?? '';
+  return {
+    pid: 4242,
+    output: [null, stdout, stderr],
+    stdout,
+    stderr,
+    signal: null,
+    ...partial,
+  };
+}
+
+export function bufferSpawnResult(
+  partial: SpawnResultInput<NonSharedBuffer>,
+): SpawnSyncReturns<NonSharedBuffer> {
+  const stdout = partial.stdout ?? Buffer.alloc(0) as NonSharedBuffer;
+  const stderr = partial.stderr ?? Buffer.alloc(0) as NonSharedBuffer;
+  return {
+    pid: 4242,
+    output: [null, stdout, stderr],
+    stdout,
+    stderr,
+    signal: null,
+    ...partial,
+  };
+}

--- a/test/hermes-transcript.test.ts
+++ b/test/hermes-transcript.test.ts
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { textSpawnResult } from './helpers/spawn-result.js';
 
 // A synchronous `require` inside the factory, not `await vi.importActual(...)`:
 // bun's `vi` shim has no `importActual`, and a fill that resolved without actually
@@ -65,7 +66,7 @@ describe('hermes transcript reader', () => {
 
   it('converts Hermes rows into bridge events and advances by row id', async () => {
     existsSyncMock.mockReturnValue(true);
-    spawnSyncMock.mockReturnValue({
+    spawnSyncMock.mockReturnValue(textSpawnResult({
       status: 0,
       stdout: JSON.stringify([
         { id: 2, session_id: ' h1 ', role: 'user', content: 'hello', timestamp: 100 },
@@ -74,7 +75,7 @@ describe('hermes transcript reader', () => {
         { id: 5, session_id: 'h1', role: 'assistant', content: '', timestamp: 103, finish_reason: 'stop' },
       ]),
       stderr: '',
-    } as any);
+    }));
     const { drainHermesStateDb } = await import('../src/services/hermes-transcript.js');
 
     expect(drainHermesStateDb(1, '/tmp/state.db')).toEqual({
@@ -88,7 +89,7 @@ describe('hermes transcript reader', () => {
 
   it('reads the current max row id as offset', async () => {
     existsSyncMock.mockReturnValue(true);
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: '42\n', stderr: '' } as any);
+    spawnSyncMock.mockReturnValue(textSpawnResult({ status: 0, stdout: '42\n' }));
     const { currentHermesStateOffset } = await import('../src/services/hermes-transcript.js');
 
     expect(currentHermesStateOffset('/tmp/state.db')).toBe(42);
@@ -96,7 +97,7 @@ describe('hermes transcript reader', () => {
 
   it('checks whether a Hermes native session exists', async () => {
     existsSyncMock.mockReturnValue(true);
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: '1\n', stderr: '' } as any);
+    spawnSyncMock.mockReturnValue(textSpawnResult({ status: 0, stdout: '1\n' }));
     const { hermesSessionExists } = await import('../src/services/hermes-transcript.js');
 
     expect(hermesSessionExists('20260716_163643_7782fd', '/tmp/state.db')).toBe(true);
@@ -105,7 +106,7 @@ describe('hermes transcript reader', () => {
 
   it('returns false when Hermes session is provably absent', async () => {
     existsSyncMock.mockReturnValue(true);
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: '0\n', stderr: '' } as any);
+    spawnSyncMock.mockReturnValue(textSpawnResult({ status: 0, stdout: '0\n' }));
     const { hermesSessionExists } = await import('../src/services/hermes-transcript.js');
 
     expect(hermesSessionExists('missing-session', '/tmp/state.db')).toBe(false);
@@ -119,7 +120,7 @@ describe('hermes transcript reader', () => {
     expect(spawnSyncMock).not.toHaveBeenCalled();
 
     existsSyncMock.mockReturnValue(true);
-    spawnSyncMock.mockReturnValue({ status: 1, stdout: '', stderr: 'broken' } as any);
+    spawnSyncMock.mockReturnValue(textSpawnResult({ status: 1, stderr: 'broken' }));
     expect(hermesSessionExists('20260716_163643_7782fd', '/tmp/state.db')).toBeUndefined();
   });
 });

--- a/test/mtr-transcript.test.ts
+++ b/test/mtr-transcript.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { textSpawnResult } from './helpers/spawn-result.js';
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
@@ -46,9 +47,8 @@ describe('mtr transcript reader', () => {
 
   it('converts completed MTR messages into bridge events', async () => {
     existsSyncMock.mockReturnValue(true);
-    spawnSyncMock.mockReturnValue({
+    spawnSyncMock.mockReturnValue(textSpawnResult({
       status: 0,
-      stderr: '',
       stdout: JSON.stringify([
         {
           message_id: 'msg_user',
@@ -91,7 +91,7 @@ describe('mtr transcript reader', () => {
           part_data: JSON.stringify({ type: 'text', text: 'hi there' }),
         },
       ]),
-    } as any);
+    }));
     const { drainMtrSession } = await import('../src/services/mtr-transcript.js');
 
     expect(drainMtrSession({ dbPath: '/tmp/mtr-alpha.db', sessionId: 'ses_1' }, 999)).toEqual({
@@ -117,7 +117,7 @@ describe('mtr transcript reader', () => {
 
   it('re-reads a small timestamp overlap to avoid same-ms cursor misses', async () => {
     existsSyncMock.mockReturnValue(true);
-    spawnSyncMock.mockReturnValue({ status: 0, stderr: '', stdout: '[]' } as any);
+    spawnSyncMock.mockReturnValue(textSpawnResult({ status: 0, stdout: '[]' }));
     const { drainMtrSession } = await import('../src/services/mtr-transcript.js');
 
     expect(drainMtrSession({ dbPath: '/tmp/mtr-alpha.db', sessionId: 'ses_1' }, 10_000)).toEqual({
@@ -134,8 +134,14 @@ describe('mtr transcript reader', () => {
     readdirSyncMock.mockReturnValue(['mtr.db', 'mtr-alpha.db', 'mtr-alpha.db-wal'] as any);
     statSyncMock.mockReturnValue({ isFile: () => true } as any);
     spawnSyncMock
-      .mockReturnValueOnce({ status: 0, stdout: JSON.stringify({ id: 'ses_old', time_updated: 10 }), stderr: '' } as any)
-      .mockReturnValueOnce({ status: 0, stdout: JSON.stringify({ id: 'ses_new', time_updated: 20 }), stderr: '' } as any);
+      .mockReturnValueOnce(textSpawnResult({
+        status: 0,
+        stdout: JSON.stringify({ id: 'ses_old', time_updated: 10 }),
+      }))
+      .mockReturnValueOnce(textSpawnResult({
+        status: 0,
+        stdout: JSON.stringify({ id: 'ses_new', time_updated: 20 }),
+      }));
     const { findLatestMtrSessionByDirectory } = await import('../src/services/mtr-transcript.js');
 
     expect(findLatestMtrSessionByDirectory('/repo', ['/tmp/mtr.db', '/tmp/mtr-alpha.db'])).toEqual({

--- a/test/plugin-pm2-env.test.ts
+++ b/test/plugin-pm2-env.test.ts
@@ -2,9 +2,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from 'node:child_process';
+import { textSpawnResult } from './helpers/spawn-result.js';
+
+type TextSpawnSync = (
+  command: string,
+  args?: readonly string[],
+  options?: SpawnSyncOptionsWithStringEncoding,
+) => SpawnSyncReturns<string>;
 
 const childProcess = vi.hoisted(() => ({
-  spawnSync: vi.fn(),
+  spawnSync: vi.fn<TextSpawnSync>(),
   ownershipProcesses: [
     { pid: 123, cgroup: '/user.slice/botmux.service', startIdentity: 'fixture-birth' },
   ] as Array<{ pid: number; cgroup: string; startIdentity: string }>,
@@ -43,7 +51,7 @@ describe('plugin PM2 environment', () => {
     childProcess.ownershipProcesses = [
       { pid: 123, cgroup: '/user.slice/botmux.service', startIdentity: 'fixture-birth' },
     ];
-    childProcess.spawnSync.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    childProcess.spawnSync.mockReturnValue(textSpawnResult({ status: 0 }));
   });
 
   afterEach(() => {

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -62,6 +62,7 @@ import {
   tmuxLifecycleInitialDelayMs,
   setStartupTmuxRetrySleepForTests,
 } from '../src/adapters/backend/tmux-pipe-backend.js';
+import { bufferSpawnResult } from './helpers/spawn-result.js';
 
 // Startup retries sleep synchronously (Atomics.wait — immune to fake timers);
 // stub the sleep for the whole suite so retry tests don't add real seconds.
@@ -123,7 +124,7 @@ beforeEach(() => {
   mockedSpawnSync.mockReset();
   mockedUnlinkSync.mockReset();
   mockedExecSync.mockReturnValue(Buffer.from('') as any);
-  mockedSpawnSync.mockReturnValue({ status: 0 } as any);
+  mockedSpawnSync.mockReturnValue(bufferSpawnResult({ status: 0 }));
 });
 
 describe('TmuxPipeBackend.spawn', () => {
@@ -424,10 +425,10 @@ describe('TmuxPipeBackend input addressing', () => {
     const be = new TmuxPipeBackend('0:5.0');
     be.spawn('', [], spawnOpts());
     mockedExecFileSync.mockClear();
-    mockedExecFileSync.mockImplementation(((_cmd: string, args?: string[]) => {
+    mockedExecFileSync.mockImplementation((_cmd, args) => {
       if (Array.isArray(args) && args.includes('paste-buffer')) throw new Error('no server running');
       return Buffer.from('');
-    }));
+    });
 
     expect(be.pasteText('boom')).toBe(false);
   });

--- a/test/transient-snapshot.test.ts
+++ b/test/transient-snapshot.test.ts
@@ -56,6 +56,7 @@ import { execSync, spawnSync } from 'node:child_process';
 import { TmuxPipeBackend } from '../src/adapters/backend/tmux-pipe-backend.js';
 import { snapshotToPng, snapshotToText, tryCapturePipeSnapshot } from '../src/utils/transient-snapshot.js';
 import { captureToPng } from '../src/utils/screenshot-renderer.js';
+import { bufferSpawnResult } from './helpers/spawn-result.js';
 
 const mockedExecSync = vi.mocked(execSync);
 const mockedSpawnSync = vi.mocked(spawnSync);
@@ -70,7 +71,7 @@ function spawnedBackend() {
 beforeEach(() => {
   mockedExecSync.mockReset();
   mockedSpawnSync.mockReset();
-  mockedSpawnSync.mockReturnValue({ status: 0 } as any);
+  mockedSpawnSync.mockReturnValue(bufferSpawnResult({ status: 0 }));
   mockedExecSync.mockReturnValue(Buffer.from('') as any);
   mockedCaptureToPng.mockClear();
 });

--- a/test/vc-agent-polling-source.test.ts
+++ b/test/vc-agent-polling-source.test.ts
@@ -20,35 +20,10 @@ vi.mock('node:child_process', () => {
   return { ...actual, spawnSync: vi.fn() };
 });
 
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import { textSpawnResult } from './helpers/spawn-result.js';
 
 const spawnSyncMock = vi.mocked(spawnSync);
-
-/**
- * A complete `SpawnSyncReturns` from just the fields a test cares about.
- *
- * `vi.mocked(spawnSync)` carries the REAL signature, so `mockReturnValue` demands
- * every field — `pid`, `output` and `signal` included. The previous mock was a bare
- * `vi.fn()` with no signature, which accepted these partial literals silently; the
- * literals were always incomplete, the looseness just hid it. Neither runner checks
- * types at runtime, and `tsc --noEmit -p tsconfig.json` only includes `src`, so this
- * shows up nowhere but the editor. Filling the fields here keeps each call site
- * stating only what it is actually asserting on.
- */
-function spawnResult(
-  partial: Partial<SpawnSyncReturns<string>> & Pick<SpawnSyncReturns<string>, 'status'>,
-): SpawnSyncReturns<string> {
-  const stdout = partial.stdout ?? '';
-  const stderr = partial.stderr ?? '';
-  return {
-    pid: 4242,
-    output: [null, stdout, stderr],
-    stdout,
-    stderr,
-    signal: null,
-    ...partial,
-  };
-}
 
 import {
   fetchMeetingEventsAsBot,
@@ -61,7 +36,7 @@ describe('vc agent polling source process bounds', () => {
   });
 
   it('passes an explicit timeout to synchronous lark-cli execution', () => {
-    spawnSyncMock.mockReturnValue(spawnResult({ status: 0, stdout: '{}' }));
+    spawnSyncMock.mockReturnValue(textSpawnResult({ status: 0, stdout: '{}' }));
 
     expect(runLarkCliJson(['vc', '+meeting-events'], { timeoutMs: 12_345 })).toEqual({});
     expect(spawnSyncMock).toHaveBeenCalledWith('lark-cli', ['vc', '+meeting-events'], expect.objectContaining({
@@ -72,14 +47,14 @@ describe('vc agent polling source process bounds', () => {
 
   it('reports a bounded timeout instead of treating it as an ordinary exit', () => {
     const error = Object.assign(new Error('spawnSync lark-cli ETIMEDOUT'), { code: 'ETIMEDOUT' });
-    spawnSyncMock.mockReturnValue(spawnResult({ status: null, error }));
+    spawnSyncMock.mockReturnValue(textSpawnResult({ status: null, error }));
 
     expect(() => runLarkCliJson(['vc', '+meeting-events'], { timeoutMs: 500 }))
       .toThrow('timed out after 500ms');
   });
 
   it('forwards the restore timeout through meeting event polling', () => {
-    spawnSyncMock.mockReturnValue(spawnResult({
+    spawnSyncMock.mockReturnValue(textSpawnResult({
       status: 0,
       stdout: JSON.stringify({ meeting: { id: 'm1' }, events: [] }),
     }));

--- a/tsconfig.test-mocks.json
+++ b/tsconfig.test-mocks.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src/**/*",
+    "test/helpers/spawn-result.ts",
+    "test/ensure-herdr-integrations.test.ts",
+    "test/hermes-transcript.test.ts",
+    "test/mtr-transcript.test.ts",
+    "test/plugin-pm2-env.test.ts",
+    "test/tmux-pipe-backend.test.ts",
+    "test/transient-snapshot.test.ts",
+    "test/vc-agent-polling-source.test.ts"
+  ]
+}


### PR DESCRIPTION
## 问题

`test/` 不在主 `tsconfig.json` 的 include 范围内，多个 `spawnSync` / `execFileSync` mock 的类型缺陷会被两个测试 runner 的转译过程隐藏。对目标测试文件启用 TypeScript 检查时，`tmux-pipe-backend.test.ts` 稳定报出 `execFileSync` mock 参数签名不兼容；其余文件则依赖 `as any` 或裸 `vi.fn()` 接受不完整返回值。

Fixes #1160

## 修复

- 新增共享 `textSpawnResult()` / `bufferSpawnResult()` 测试 helper，补齐 `SpawnSyncReturns` 的 `pid`、`output`、`signal`、`stdout`、`stderr`。
- 将 Issue 列出的 7 个测试文件统一改用完整返回结构。
- 给两处裸 `spawnSync` mock 增加文本编码签名，避免继续静默接受不完整对象。
- 修正 `execFileSync` mock 的参数签名，兼容真实 API 的只读 argv。
- 新增 `tsconfig.test-mocks.json`，并把窄范围测试类型检查接入标准 build，防止同类问题静默回归而不引爆全仓历史测试类型债。

## 影响面

- 生产代码与运行时行为不变。
- 测试用例原本模拟的退出码、stdout、stderr 和错误行为不变。
- 标准 build 多执行一个只覆盖这 7 个目标测试文件的 TypeScript 门禁。
- 同时兼容 Node/Vitest 与 Bun 1.4.1/Vitest。

## 验证

- 修复前，测试级 TypeScript 探针稳定报 `test/tmux-pipe-backend.test.ts:427 TS2345`。
- `npm exec --yes bun@1.4.1 -- run typecheck:test-mocks`：通过。
- `npx vitest run --project unit ...`：7 files、98 tests passed。
- `npm exec --yes bun@1.4.1 -- run vitest run --project unit ...`：7 files、98 tests passed。
- `npm exec --yes bun@1.4.1 -- run build`：通过，包含新增测试类型门禁。
- `git diff --check`：通过。
