### PR TITLE
test(flake): 修两条时序型 bun-test 间歇失败

### DIFF
--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -197,13 +197,53 @@ describe('redactChildEnv()', () => {
       const script =
         'if [ -z "${LARK_APP_ID+x}" ]; then echo "R=UNSET"; else echo "R=SET[$LARK_APP_ID]"; fi; ' +
         `if [ -z "\${${PM2_GRACEFUL_EXIT_CODE_ENV}+x}" ]; then echo "S=UNSET"; else echo "S=SET[\$${PM2_GRACEFUL_EXIT_CODE_ENV}]"; fi`;
-      const out: string = await new Promise((resolve) => {
+      const out: string = await new Promise((resolve, reject) => {
         const p = pty.spawn('/bin/sh', ['-c', script], {
           name: 'xterm-256color', cols: 80, rows: 24, cwd: '/tmp', env,
         });
         let buf = '';
-        p.onData((d) => { buf += d; });
-        p.onExit(() => resolve(buf));
+        let settled = false;
+        // node-pty delivers onData and onExit on independent paths: the child can
+        // be reaped before the pty's pending output has been drained, so
+        // resolving straight from onExit can hand back an empty string. That
+        // surfaces as `Expected to contain "R=UNSET" / Received: ""` under CI
+        // load, which reads like a real leak but is only a lost read.
+        //
+        // So settle on having BOTH answers, and let exit only START a short grace
+        // period rather than decide. If the grace period expires with the output
+        // still incomplete, REJECT with the raw buffer instead of resolving it:
+        // the whole point is that a lost read must never again be reported as a
+        // leak-shaped assertion failure. Resolving '' here would rebuild the very
+        // trap this guard exists to remove.
+        const hasBothAnswers = () => /\bR=(UNSET|SET)/.test(buf) && /\bS=(UNSET|SET)/.test(buf);
+        const finish = (settle: () => void) => {
+          if (settled) return;
+          settled = true;
+          settle();
+        };
+        const fail = () => finish(() => reject(new Error(
+          'pty output incomplete — a lost read, not an env leak. '
+          + `Expected both R= and S= answers, got ${JSON.stringify(buf)}`,
+        )));
+        const guard = setTimeout(fail, 10_000);
+        guard.unref?.();
+        p.onData((d) => {
+          buf += d;
+          if (hasBothAnswers()) {
+            clearTimeout(guard);
+            finish(() => resolve(buf));
+          }
+        });
+        p.onExit(() => {
+          // Exit is a deadline, not the signal: give already-queued reads a
+          // moment to land, then decide — complete output resolves, incomplete
+          // output fails loudly as a fixture problem.
+          setTimeout(() => {
+            clearTimeout(guard);
+            if (hasBothAnswers()) finish(() => resolve(buf));
+            else fail();
+          }, 250);
+        });
       });
       expect(out).toContain('R=UNSET');
       expect(out).toContain('S=UNSET');

--- a/test/plugin-card-action-gateway.integration.test.ts
+++ b/test/plugin-card-action-gateway.integration.test.ts
@@ -100,6 +100,36 @@ const requestsFrom = (logPath: string): Array<Record<string, any>> => {
   return readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
 };
 
+/**
+ * Wait until the fixture has logged `count` requests, then return them.
+ *
+ * The fixture appends its log line from `request.on('end')` — i.e. only after it
+ * has read the whole request body. When the gateway aborts on a short
+ * `timeoutMs`, the abort races that read: the request genuinely arrived and the
+ * assertion below is about arrival, but on a loaded CI runner the log line has
+ * not landed yet and `requestsFrom()` returns []. Polling for arrival keeps the
+ * assertion (the request WAS delivered despite the client giving up) while
+ * removing the dependency on which side of the race won.
+ *
+ * Throws on timeout so a genuinely undelivered request still fails the test
+ * rather than silently asserting on a short array.
+ */
+const waitForRequests = async (
+  logPath: string,
+  count: number,
+  timeoutMs = 5_000,
+): Promise<Array<Record<string, any>>> => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const requests = requestsFrom(logPath);
+    if (requests.length >= count) return requests;
+    if (Date.now() >= deadline) {
+      throw new Error(`fixture logged ${requests.length} request(s), expected ${count} within ${timeoutMs}ms`);
+    }
+    await new Promise(resolveWait => setTimeout(resolveWait, 20));
+  }
+};
+
 afterEach(async () => {
   await Promise.all([...children].map(stopFixture));
   for (const root of tempRoots) rmSync(root, { recursive: true, force: true });
@@ -180,7 +210,7 @@ describe('plugin card action gateway loopback integration', () => {
       await expect(gateway.dispatch({
         action: { value: { action: 'example.review.submit' } },
       }, 'cli_current')).resolves.toBeUndefined();
-      expect(requestsFrom(fixture.logPath)).toHaveLength(1);
+      expect(await waitForRequests(fixture.logPath, 1)).toHaveLength(1);
       await stopFixture(fixture.child);
     }
   });


### PR DESCRIPTION
## 改了什么

只改测试，`src/` 一行未动。修掉 `bun-test` 腿上两条长期间歇失败的用例，两条的根因同类：**断言依赖了一场竞态谁先赢**，不是产品缺陷。

### 1. `test/plugin-card-action-gateway.integration.test.ts`

`隔离不可用服务和非法插件响应` 的最后一格是 `{ mode: 'success', timeoutMs: 25, delayMs: 200 }`：网关侧 `AbortController` 在 25ms 就 abort，而 fixture（`test/fixtures/plugin-card-action-service.ts`）是在 `request.on('end')`——**读完整个 body 之后**——才 `appendFileSync` 写请求日志。

两件事在抢跑。CI 负载下 abort 赢，日志一行都没落 ⟹ `expect(requestsFrom(...)).toHaveLength(1)` 拿到 0。

这条断言真正想验的是「**请求确实送达了服务端，尽管客户端已经放弃**」。所以修法不是放宽 25ms（那会把被测的隔离行为一起改掉），而是**轮询等日志落盘**：新增 `waitForRequests(logPath, count, timeoutMs = 5000)`，每 20ms 重读一次，**超时抛错**——所以「真的没送达」依然会失败，不是把红改成绿。

### 2. `test/child-env.test.ts`

`real node-pty child does NOT inherit a redacted var` 原来从 `p.onExit(() => resolve(buf))` 直接结算。node-pty 的 `onData` 与 `onExit` 是**两条独立投递路径**，子进程可以在 pty 待读输出排空之前就被回收 ⟹ `resolve('')`，表现为：

```
AssertionError: expected '' to contain 'R=UNSET'
```

**这个报错形状本身就是坑**：它读起来像「redact 失效、环境变量真漏了」，而实际只是一次丢读。

修法：以「**两个答案（`R=` 和 `S=`）都到了**」为结算条件，`onExit` 只当**兜底期限**（250ms 宽限）而不是信号；宽限期满仍不完整就**带原始 buffer 抛错**，错误文案直接写明这是丢读不是泄漏。10s 硬超时兜底。

⚠️ 这一条我第一版写错了：`onExit` 里无条件 `resolve(buf)`，空串照样当成功返回——**代码与它自己的注释矛盾**（注释写「exit with no output is a fixture failure」）。是下面探针 3 打出来的，已修。

## 为什么

该腿 `continue-on-error: true`、不挡合并，且 `gh run list` 的 run 级 conclusion 会把它吃成 success，所以长期没人处理。实际读数是**两个方向都会翻**，同一 40 分钟窗口内连着三跑（都真跑到 `test:bun` 这一步，不是 install 层挂掉的假绿）：

| commit | 结果 | 红在哪 |
|---|---|---|
| `97233b1f2` | 红 | `test/child-env.test.ts` — `"R=UNSET"` 拿到空串 |
| `8f00f280e` | 红 | `plugin-card-action-gateway` — `Expected length 1` |
| `ba431e179` | 绿 | 1091/1091 files, 0 failing |

一条负载敏感、两个方向都翻的用例，会让「基线也红/也绿」这类归属判据每次都得重核；顺手把两条根因都掐掉，这条腿以后才可能建立全绿基线。

## 影响面

- **只改 `test/`，不动 `src/`**，产品行为零变化
- **断言语义未变**：泄漏守卫仍在验 `R=UNSET` / `S=UNSET`（探针 5 证明真泄漏照样红），网关用例仍在验隔离后请求已送达
- 不涉及跨 CLI / 跨后端（`PtyBackend` vs `TmuxBackend`）/ 跨 IM 的共用代码路径；`waitForRequests` 是该测试文件内的局部 helper，未进 `test/helpers/`
- 修法**沿用仓库既有写法**：`test/helpers/proc-ready.ts` 头注释已经记录了同一类「CI `bun-test` 负载下」的竞态，并且用的就是「带期限轮询 + 超时抛错」（`waitForPidCmdline`）。两处修法与它同构，不是新造一套惯例

## 验证

```
npx tsc --noEmit                                          → exit 0
npx vitest run <两个文件>                                  → Test Files 2 passed, Tests 53 passed
bun test（1.4.0，与 CI 同 runner，fence 掉 HOME/TMPDIR）
  child-env.test.ts                                       → 50 pass 0 fail
  plugin-card-action-gateway.integration.test.ts           → 3 pass 0 fail
```

网关那条在 bun 下的日志里能看到 `status=isolated error=plugin_card_action_timeout` —— **abort 确实发生了**，用例仍然通过，正是这次要建立的「送达」与「放弃」分离。

### 反变异（每一枪都做双向对照：新守卫吸收 + 旧断言转红）

| # | 变异 | 新代码 | 旧代码 |
|---|---|---|---|
| 1b | fixture 仅在 `delayMs > 0` 时把写日志延后 400ms（精确命中被 abort 的那一格） | 3 passed | `隔离不可用服务和非法插件响应` FAILED |
| 2 | fixture 读 body **之前**先 busy-loop 300ms（abort 落地时 body 还没读） | 3 passed | 同一条 FAILED |
| 3 | 丢弃**全部** pty 输出（`void d; buf += ''`） | `Error: pty output incomplete — a lost read, not an env leak … got ""` | `AssertionError: expected '' to contain 'R=UNSET'` |
| 4 | 只丢 `S=` 那半个答案 | 同上，`got "R=UNSET\r\n\r\n"` | — |
| 5 | **绕过 `redactChildEnv`（模拟真泄漏）** | `AssertionError: expected 'R=SET[cli_parent_must_not_leak]…' to contain 'R=UNSET'` | — |

- 探针 2 顺带证明了 `end` **仍会触发**，所以轮询是对的解法，而不是「把一个快的红拖成一个慢的红」
- 探针 3 是**第一版修复的照妖镜**：它打出的是旧的、误导性的泄漏形报错，说明我的守卫没兑现自己注释里的承诺 —— 据此修正后重打，报错变成明确的 fixture 错误
- 探针 5 是**最要紧的一枪**：证明这次改动**没有把用例本来要抓的东西一起吸收掉**，真泄漏仍然按泄漏的形状报错

⚠️ 另跑了「24 路 CPU 负载 × 5 轮」的复现尝试，**修前修后都 5×53 全绿** —— 本机（64 核）复现不出该竞态，所以**这组读数不构成支持证据**（只说明本机压不出来），一并写在这里以免被当成额外证明。真正的承重证据是上面的双向变异。
