### PR TITLE
feat(dashboard): 支持宿主按机器人身份更新群名

### DIFF
--- a/docs-site/docs/en/dashboard.md
+++ b/docs-site/docs/en/dashboard.md
@@ -31,6 +31,25 @@ Authenticated administrators can manage botmux background-service auto-start und
 
 The toggle reuses the existing `botmux autostart` behavior. It only manages the entry used at the next boot/login and does not start, stop, or restart the current daemon.
 
+## Authenticated integration actions
+
+An authenticated host integration can rename a Lark group through one explicit
+bot identity:
+
+```http
+PUT /api/groups/{chatId}/name/{larkAppId}
+Content-Type: application/json
+
+{"name":"New group name"}
+```
+
+Both path segments must be URL-encoded. The selected bot must currently be in
+the group; botmux never falls back to another configured bot. The name follows
+Lark's 100-code-point limit and rejects control or invisible formatting
+characters. The request body is limited to 4 KiB and accepts only `name`.
+Authentication uses the existing Dashboard management boundary described
+below; `publicReadOnly` never makes this mutation anonymous.
+
 ## External read-only queries
 
 The primary external observation surfaces documented here are:
@@ -110,7 +129,7 @@ The following fields belong only to the richer `/api/sessions` rows and `/events
 
 `publicReadOnly` is on by default. While it is enabled, allow-listed reads including `GET /api/dashboard/v1/summary`, `GET /api/sessions`, and `GET /events` are reachable **without a token** on the Dashboard listener. The summary contains only the strongly redacted aggregate above; session names, titles, backends, and the other session/event row metadata must be treated as public to that network.
 
-- Every POST / PATCH / DELETE mutation, every GET outside the read-only allow-list, and every raw PTY / diagnostic log still requires the current token issued by `botmux dashboard`. The allow-list is fail-closed: a newly added GET endpoint does not become public merely because public read-only mode is enabled.
+- Every POST / PUT / PATCH / DELETE mutation, every GET outside the read-only allow-list, and every raw PTY / diagnostic log still requires the current token issued by `botmux dashboard`. The allow-list is fail-closed: a newly added GET endpoint does not become public merely because public read-only mode is enabled.
 - When `publicReadOnly` is off, a tokenless summary request returns 401. A request carrying the current token remains available and is exempt from the anonymous rate limit. In public read-only mode, an incorrect or rotated old token is treated as anonymous.
 - `botmux dashboard` and `botmux dashboard current` reuse the current token (creating the first one when absent); `botmux dashboard rotate` explicitly replaces it and invalidates the previous link. The token is application-layer Dashboard access, not a replacement for host firewall, VPN, or reverse-proxy authentication.
 - If tokenless observation is unnecessary, turn off **Public read-only** under Dashboard Settings. You can also start with `BOTMUX_DASHBOARD_PUBLIC_READONLY=false`; once the setting has been saved in the UI, the persisted value in `~/.botmux/config.json` takes precedence over the environment variable.

--- a/docs-site/docs/zh/dashboard.md
+++ b/docs-site/docs/zh/dashboard.md
@@ -48,6 +48,23 @@ botmux dashboard rotate   # 轮换 token 并输出新 URL
 
 该开关复用现有 `botmux autostart` 能力，只管理下次开机/登录时使用的启动项，不会启动、停止或重启当前 daemon。
 
+## 需认证的集成操作
+
+已认证的宿主集成可以指定一个明确的机器人身份更新飞书群名：
+
+```http
+PUT /api/groups/{chatId}/name/{larkAppId}
+Content-Type: application/json
+
+{"name":"新的群名称"}
+```
+
+两个路径参数都必须做 URL 编码。指定机器人必须当前就在该群内；botmux
+不会失败后改用其它已配置机器人。群名遵循飞书的 100 个 Unicode 码点上限，
+并拒绝控制字符与不可见格式字符。请求体上限为 4 KiB，且只接受 `name`
+字段。鉴权沿用下文所述的 Dashboard 管理权限边界；`publicReadOnly` 不会让该
+写操作变成匿名可用。
+
 ## 对外只读查询
 
 这里重点说明三个对外观测接口：
@@ -127,7 +144,7 @@ botmux dashboard rotate   # 轮换 token 并输出新 URL
 
 `publicReadOnly` 默认开启。开启时，`GET /api/dashboard/v1/summary`、`GET /api/sessions` 和 `GET /events` 等只读白名单接口在 Dashboard 监听地址上可以**无 token** 访问。summary 只含上述强脱敏聚合；会话名称、标题、后端和 session / event row 中的其它元数据都应按可公开信息对待。
 
-- 全部 POST / PATCH / DELETE 写操作、不在只读白名单中的 GET，以及原始 PTY / 诊断日志，始终需要 `botmux dashboard` 生成的当前 token。白名单是 fail-closed 的：新增 GET 不会因公开只读开启就自动暴露。
+- 全部 POST / PUT / PATCH / DELETE 写操作、不在只读白名单中的 GET，以及原始 PTY / 诊断日志，始终需要 `botmux dashboard` 生成的当前 token。白名单是 fail-closed 的：新增 GET 不会因公开只读开启就自动暴露。
 - 关闭 `publicReadOnly` 后，无 token 的 summary 请求会返回 401；持当前 token 的请求仍可访问，且不受上面的匿名限流。错误或已轮换的旧 token 在公开只读开启时按匿名请求处理。
 - `botmux dashboard` 和 `botmux dashboard current` 会复用当前 token（尚无时创建第一个）；`botmux dashboard rotate` 才会显式替换 token、让之前的链接失效。token 只提供 Dashboard 应用层访问权，不代替主机防火墙、VPN 或反向代理鉴权。
 - 不需要无 token 观测时，在 Dashboard 「设置」中关闭「公开只读」。也可先设 `BOTMUX_DASHBOARD_PUBLIC_READONLY=false`；但设置页一旦保存过该开关，`~/.botmux/config.json` 的持久值会优先于环境变量。

--- a/src/core/chat-rename-operation.ts
+++ b/src/core/chat-rename-operation.ts
@@ -1,0 +1,110 @@
+import type { RenameChatResult } from '../services/groups-store.js';
+import type { Session } from '../types.js';
+
+export interface ActiveChatSession {
+  chatId: string;
+  session: Session;
+}
+
+export interface ChatRenameOperationDeps {
+  renameChat: (
+    larkAppId: string,
+    chatId: string,
+    newName: string,
+    opts?: {
+      beforeUpdate?: () =>
+        | { ok: true }
+        | { ok: false; error: 'rate_limited'; retryAfterSeconds: number };
+    },
+  ) => Promise<RenameChatResult>;
+  activeSessions: () => Iterable<ActiveChatSession>;
+  persistSession: (session: Session) => void;
+  logger: {
+    info: (message: string) => void;
+    warn: (message: string) => void;
+  };
+}
+
+export interface ChatRenameOperationInput {
+  larkAppId: string;
+  chatId: string;
+  name: string;
+  trigger: 'ai_proactive' | 'user_explicit' | 'host_api';
+  sessionId?: string;
+  botOpenId?: string;
+  beforeUpdate?: () =>
+    | { ok: true }
+    | { ok: false; error: 'rate_limited'; retryAfterSeconds: number };
+}
+
+export interface ChatRenameOperationResponse {
+  status: number;
+  body:
+    | (Extract<RenameChatResult, { ok: true }> & { chatId: string })
+    | Extract<RenameChatResult, { ok: false }>;
+}
+
+function failureStatus(result: Extract<RenameChatResult, { ok: false }>): number {
+  if (result.error === 'bot_not_in_chat' || result.error === 'permission_denied') return 403;
+  if (result.error === 'rate_limited') return 429;
+  return 502;
+}
+
+function auditContext(input: ChatRenameOperationInput): string {
+  return [
+    input.sessionId ? `session=${JSON.stringify(input.sessionId)}` : undefined,
+    `chat=${JSON.stringify(input.chatId)}`,
+    `app=${JSON.stringify(input.larkAppId)}`,
+    `botOpenId=${JSON.stringify(input.botOpenId ?? '-')}`,
+    `trigger=${input.trigger}`,
+  ].filter(Boolean).join(' ');
+}
+
+/**
+ * Execute one exact-bot chat rename and keep every active session projection in
+ * sync. Both the session-scoped Skill route and host integrations use this
+ * application seam so Lark errors, audit records, and cache behavior cannot
+ * drift apart.
+ */
+export async function executeChatRename(
+  input: ChatRenameOperationInput,
+  deps: ChatRenameOperationDeps,
+): Promise<ChatRenameOperationResponse> {
+  const result = await deps.renameChat(input.larkAppId, input.chatId, input.name, {
+    beforeUpdate: input.beforeUpdate,
+  });
+  const context = auditContext(input);
+
+  if (!result.ok) {
+    deps.logger.warn(
+      `[chat-rename:audit] result=failed ${context} `
+      + `old=${JSON.stringify(result.oldName ?? null)} new=${JSON.stringify(result.newName ?? input.name)} `
+      + `error=${result.error} larkCode=${result.larkCode ?? '-'} detail=${JSON.stringify(result.detail ?? '-')}`,
+    );
+    // Preserve the existing session-route error contract. A failed mutation
+    // does not gain response fields merely because it used the shared seam.
+    return { status: failureStatus(result), body: result };
+  }
+
+  if (result.changed) {
+    for (const active of deps.activeSessions()) {
+      if (active.chatId !== input.chatId) continue;
+      active.session.chatDisplayName = result.newName;
+      try {
+        deps.persistSession(active.session);
+      } catch (error) {
+        deps.logger.warn(
+          `[chat-rename:audit] cache_refresh_failed session=${JSON.stringify(active.session.sessionId)} `
+          + `chat=${JSON.stringify(input.chatId)} app=${JSON.stringify(input.larkAppId)} `
+          + `detail=${JSON.stringify(error instanceof Error ? error.message : String(error))}`,
+        );
+      }
+    }
+    deps.logger.info(
+      `[chat-rename:audit] result=success ${context} `
+      + `old=${JSON.stringify(result.oldName)} new=${JSON.stringify(result.newName)} larkCode=0`,
+    );
+  }
+
+  return { status: 200, body: { ...result, chatId: input.chatId } };
+}

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -296,6 +296,7 @@ import {
 } from './session-preview.js';
 import { clearSessionPreviewTarget } from './session-preview-registry.js';
 import { ChatRenameCooldown, ChatRenameSerialQueue, normalizeLarkChatName } from './chat-rename.js';
+import { executeChatRename } from './chat-rename-operation.js';
 import type { DaemonToWorker, ScheduledTask, ParsedSchedule, ScheduleExecutionPosition, Session } from '../types.js';
 import { sessionAnchorId, larkTransportEnabled, type DaemonSession } from './types.js';
 import { isRemoteBackendSession } from './persistent-backend.js';
@@ -2070,7 +2071,13 @@ ipcRoute('POST', '/api/sessions/:sessionId/chat-rename', async (req, res, params
   const trigger = proactive ? 'ai_proactive' : 'user_explicit';
   const cooldownKey = `${ds.larkAppId}:${ds.chatId}`;
   await chatRenameSerialQueue.run(cooldownKey, async () => {
-    const result = await groupsStore.renameChat(ds.larkAppId, ds.chatId, normalized.name, {
+    const response = await executeChatRename({
+      larkAppId: ds.larkAppId,
+      chatId: ds.chatId,
+      name: normalized.name,
+      trigger,
+      sessionId: ds.session.sessionId,
+      botOpenId: getBotOpenId(ds.larkAppId),
       beforeUpdate: proactive
         ? () => {
             const cooldown = proactiveChatRenameCooldown.check(cooldownKey);
@@ -2079,43 +2086,16 @@ ipcRoute('POST', '/api/sessions/:sessionId/chat-rename', async (req, res, params
               : { ...cooldown, error: 'rate_limited' as const };
           }
         : undefined,
+    }, {
+      renameChat: groupsStore.renameChat,
+      activeSessions: () => getActiveSessionsRegistry()?.values() ?? [],
+      persistSession: sessionStore.updateSession,
+      logger,
     });
-    const botOpenId = getBotOpenId(ds.larkAppId) ?? '-';
-    if (!result.ok) {
-      const status = result.error === 'bot_not_in_chat' ? 403
-        : result.error === 'permission_denied' ? 403
-          : result.error === 'rate_limited' ? 429
-            : 502;
-      logger.warn(
-        `[chat-rename:audit] result=failed session=${ds.session.sessionId} chat=${ds.chatId} `
-        + `app=${ds.larkAppId} botOpenId=${botOpenId} trigger=${trigger} `
-        + `old=${JSON.stringify(result.oldName ?? null)} new=${JSON.stringify(result.newName ?? normalized.name)} `
-        + `error=${result.error} larkCode=${result.larkCode ?? '-'} detail=${result.detail ?? '-'}`,
-      );
-      return jsonRes(res, status, result);
+    if (proactive && response.body.ok && response.body.changed) {
+      proactiveChatRenameCooldown.record(cooldownKey);
     }
-    if (result.changed) {
-      if (proactive) proactiveChatRenameCooldown.record(cooldownKey);
-      // FR-7: the Lark write already succeeded, so a local cache-refresh
-      // failure (ENOSPC/EACCES on the session store) must NOT reverse the
-      // outcome into an HTTP 500 — best-effort per session, warn and keep the
-      // rename a success. Catch per-session so one bad write can't skip the rest.
-      for (const active of getActiveSessionsRegistry()?.values() ?? []) {
-        if (active.chatId !== ds.chatId) continue;
-        active.session.chatDisplayName = result.newName;
-        try {
-          sessionStore.updateSession(active.session);
-        } catch (e) {
-          logger.warn(`[chat-rename:audit] cache_refresh_failed session=${active.session.sessionId} chat=${ds.chatId} app=${ds.larkAppId} detail=${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-      logger.info(
-        `[chat-rename:audit] result=success session=${ds.session.sessionId} chat=${ds.chatId} `
-        + `app=${ds.larkAppId} botOpenId=${botOpenId} trigger=${trigger} `
-        + `old=${JSON.stringify(result.oldName)} new=${JSON.stringify(result.newName)} larkCode=0`,
-      );
-    }
-    return jsonRes(res, 200, { ...result, chatId: ds.chatId });
+    return jsonRes(res, response.status, response.body);
   });
 });
 
@@ -4090,6 +4070,40 @@ ipcRoute('GET', '/api/groups/:chatId/membership', async (_req, res, p) => {
   } catch (e) {
     jsonRes(res, 502, { error: String(e) });
   }
+});
+
+/** Host-only rename through this daemon's exact bot identity. */
+ipcRoute('PUT', '/api/groups/:chatId/name', async (req, res, p) => {
+  if (!cachedLarkAppId) return jsonRes(res, 503, { ok: false, error: 'larkAppId_not_set' });
+  let body: Record<string, unknown>;
+  try {
+    body = await readJsonBody<Record<string, unknown>>(req);
+  } catch {
+    return jsonRes(res, 400, { ok: false, error: 'bad_json' });
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)
+    || Object.keys(body).some(key => key !== 'name')) {
+    return jsonRes(res, 400, { ok: false, error: 'invalid_request' });
+  }
+  const normalized = normalizeLarkChatName(body.name);
+  if (!normalized.ok) return jsonRes(res, 400, normalized);
+
+  const larkAppId = cachedLarkAppId;
+  await chatRenameSerialQueue.run(`${larkAppId}:${p.chatId}`, async () => {
+    const response = await executeChatRename({
+      larkAppId,
+      chatId: p.chatId,
+      name: normalized.name,
+      trigger: 'host_api',
+      botOpenId: getBotOpenId(larkAppId),
+    }, {
+      renameChat: groupsStore.renameChat,
+      activeSessions: () => getActiveSessionsRegistry()?.values() ?? [],
+      persistSession: sessionStore.updateSession,
+      logger,
+    });
+    return jsonRes(res, response.status, response.body);
+  });
 });
 
 ipcRoute('POST', '/api/groups/:chatId/add-bots', async (req, res, p) => {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -232,6 +232,7 @@ import {
   bindOncall,
   disbandGroup,
   leaveGroup,
+  renameGroup,
   setPinStreamingCardForGroup,
   unbindOncall,
   type GroupsActionDeps,
@@ -6281,6 +6282,26 @@ const server = createServer(async (req, res) => {
         return jsonRes(res, 400, { ok: false, error: 'bad_json' });
       }
       const result = await leaveGroup(chatId, parsed, groupsActionDeps);
+      return writeHandlerResult(res, result);
+    }
+
+    // Host integrations can select one exact configured bot for the write;
+    // the daemon still enforces membership before calling Lark.
+    let mRename: RegExpMatchArray | null;
+    if (req.method === 'PUT' && (mRename = url.pathname.match(/^\/api\/groups\/([^/]+)\/name\/([^/]+)$/))) {
+      const chatId = decodeURIComponent(mRename[1]);
+      const appId = decodeURIComponent(mRename[2]);
+      let parsed: unknown;
+      try {
+        parsed = await readJsonBody(req, 4_096);
+      } catch (error) {
+        const tooLarge = error instanceof DashboardJsonBodyTooLargeError;
+        return jsonRes(res, tooLarge ? 413 : 400, {
+          ok: false,
+          error: tooLarge ? 'body_too_large' : 'bad_json',
+        });
+      }
+      const result = await renameGroup(chatId, appId, JSON.stringify(parsed) || '{}', groupsActionDeps);
       return writeHandlerResult(res, result);
     }
 

--- a/src/dashboard/groups-action-helpers.ts
+++ b/src/dashboard/groups-action-helpers.ts
@@ -196,6 +196,30 @@ export async function bindOncall(
 }
 
 /**
+ * PUT /api/groups/:chatId/name/:appId — rename a group through one explicit
+ * bot identity. The selected daemon validates membership and the Lark name.
+ */
+export async function renameGroup(
+  chatId: string,
+  appId: string,
+  bodyRaw: string,
+  deps: GroupsActionDeps,
+): Promise<HandlerResult> {
+  const upstream = await deps.proxyToDaemon(
+    appId,
+    `/api/groups/${encodeURIComponent(chatId)}/name`,
+    {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: bodyRaw || '{}',
+    },
+  );
+  const { text, json } = await parseUpstream(upstream);
+  if (upstream.ok && json?.ok !== false) deps.invalidateGroups?.();
+  return { status: upstream.status, body: json ?? text };
+}
+
+/**
  * DELETE /api/groups/:chatId/oncall/:appId — unbind the per-(chat × bot)
  * oncall. Internal proxy path is `/api/oncall/:chatId` DELETE.
  */

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -366,7 +366,7 @@ describe('API-only bot mode — bot-level primitive boundary (source lock)', () 
     // Region-scoped per route (NOT file-wide count): each write route's body
     // must call the gate, so deleting one seam fails.
     const routes: Array<[string, string, string]> = [
-      ['chat-rename', "ipcRoute('POST', '/api/sessions/:sessionId/chat-rename'", 'groupsStore.renameChat('],
+      ['chat-rename', "ipcRoute('POST', '/api/sessions/:sessionId/chat-rename'", 'executeChatRename('],
       ['write-link-card', "ipcRoute('POST', '/api/sessions/:sessionId/write-link-card'", 'deliverWriteLinkCardToOwners(ds)'],
       ['locate', "ipcRoute('POST', '/api/sessions/:sessionId/locate'", 'sendSessionOwnerThreadNotification('],
     ];

--- a/test/chat-rename-operation.test.ts
+++ b/test/chat-rename-operation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { executeChatRename } from '../src/core/chat-rename-operation.js';
+import type { RenameChatResult } from '../src/services/groups-store.js';
+import type { Session } from '../src/types.js';
+
+function session(sessionId: string, chatId: string, name: string): Session {
+  return {
+    sessionId,
+    chatId,
+    rootMessageId: 'om_root',
+    title: 'test',
+    status: 'active',
+    cliId: 'codex',
+    workingDir: '/tmp',
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    chatDisplayName: name,
+  } as Session;
+}
+
+function deps(result: RenameChatResult, sessions: Session[] = []) {
+  return {
+    renameChat: vi.fn(async () => result),
+    activeSessions: () => sessions.map(item => ({ chatId: item.chatId, session: item })),
+    persistSession: vi.fn(),
+    logger: { info: vi.fn(), warn: vi.fn() },
+  };
+}
+
+describe('executeChatRename', () => {
+  it('updates and persists every active projection for the renamed chat only', async () => {
+    const matching = session('s-one', 'oc_target', 'Old');
+    const unrelated = session('s-two', 'oc_other', 'Other');
+    const operationDeps = deps(
+      { ok: true, oldName: 'Old', newName: 'New', changed: true },
+      [matching, unrelated],
+    );
+
+    const response = await executeChatRename({
+      larkAppId: 'cli_app',
+      chatId: 'oc_target',
+      name: 'New',
+      trigger: 'host_api',
+    }, operationDeps);
+
+    expect(response).toEqual({
+      status: 200,
+      body: { ok: true, oldName: 'Old', newName: 'New', changed: true, chatId: 'oc_target' },
+    });
+    expect(matching.chatDisplayName).toBe('New');
+    expect(unrelated.chatDisplayName).toBe('Other');
+    expect(operationDeps.persistSession).toHaveBeenCalledExactlyOnceWith(matching);
+  });
+
+  it.each([
+    ['bot_not_in_chat', 403],
+    ['permission_denied', 403],
+    ['rate_limited', 429],
+    ['lark_api_error', 502],
+  ] as const)('maps %s to HTTP %i without mutating projections', async (error, status) => {
+    const active = session('s-one', 'oc_target', 'Old');
+    const operationDeps = deps({ ok: false, error }, [active]);
+
+    const response = await executeChatRename({
+      larkAppId: 'cli_app',
+      chatId: 'oc_target',
+      name: 'New',
+      trigger: 'host_api',
+    }, operationDeps);
+
+    expect(response.status).toBe(status);
+    expect(response.body).toEqual({ ok: false, error });
+    expect(active.chatDisplayName).toBe('Old');
+    expect(operationDeps.persistSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps a successful Lark write successful when one projection cannot persist', async () => {
+    const active = session('s-one', 'oc_target', 'Old');
+    const operationDeps = deps(
+      { ok: true, oldName: 'Old', newName: 'New', changed: true },
+      [active],
+    );
+    operationDeps.persistSession.mockImplementation(() => {
+      throw new Error('ENOSPC');
+    });
+
+    const response = await executeChatRename({
+      larkAppId: 'cli_app',
+      chatId: 'oc_target',
+      name: 'New',
+      trigger: 'host_api',
+    }, operationDeps);
+
+    expect(response.status).toBe(200);
+    expect(active.chatDisplayName).toBe('New');
+    expect(operationDeps.logger.warn).toHaveBeenCalledWith(expect.stringContaining('cache_refresh_failed'));
+  });
+});

--- a/test/dashboard-chat-pin-route-auth.integration.test.ts
+++ b/test/dashboard-chat-pin-route-auth.integration.test.ts
@@ -90,7 +90,7 @@ async function stopChild(child: ChildProcess | undefined): Promise<void> {
   }
 }
 
-describe('dashboard pin-streaming-card route auth', () => {
+describe('dashboard group mutation route auth', () => {
   let rootDir = '';
   let fakeDaemon: Server | undefined;
   let dashboardChild: ChildProcess | undefined;
@@ -122,13 +122,19 @@ describe('dashboard pin-streaming-card route auth', () => {
     }], null, 2));
     const dashboardToken = loadOrCreatePersistedToken(join(botmuxDir, '.dashboard-token'));
 
-    const pinWrites: Array<{ method: string; url: string }> = [];
-    fakeDaemon = createServer((req, res) => {
+    const daemonWrites: Array<{ method: string; url: string; body: string }> = [];
+    fakeDaemon = createServer(async (req, res) => {
       const url = req.url ?? '/';
-      if (req.method === 'PUT' && url === '/api/chat-pin-streaming-card/oc%20auth%2Ftopic') {
-        pinWrites.push({ method: req.method, url });
+      const bodyChunks: Buffer[] = [];
+      for await (const chunk of req) bodyChunks.push(chunk as Buffer);
+      const body = Buffer.concat(bodyChunks).toString('utf8');
+      if (req.method === 'PUT' && (
+        url === '/api/chat-pin-streaming-card/oc%20auth%2Ftopic'
+        || url === '/api/groups/oc%20auth%2Ftopic/name'
+      )) {
+        daemonWrites.push({ method: req.method, url, body });
         res.writeHead(202, { 'content-type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, enabled: false }));
+        res.end(JSON.stringify({ ok: true, changed: true }));
         return;
       }
       res.writeHead(404, { 'content-type': 'application/json' });
@@ -176,6 +182,8 @@ describe('dashboard pin-streaming-card route auth', () => {
     const base = `http://127.0.0.1:${dashboardPort}`;
     const pinRoute = `${base}/api/groups/${encodeURIComponent('oc auth/topic')}`
       + `/pin-streaming-card/${encodeURIComponent('cli auth-test-app')}`;
+    const renameRoute = `${base}/api/groups/${encodeURIComponent('oc auth/topic')}`
+      + `/name/${encodeURIComponent('cli auth-test-app')}`;
     const anonymousPin = () => requestLoopback(pinRoute, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
@@ -189,20 +197,56 @@ describe('dashboard pin-streaming-card route auth', () => {
       },
       body: JSON.stringify({ enabled: false }),
     });
-    expect({ status: authenticatedPin.status, pinWrites }, stderr).toEqual({
+    expect({ status: authenticatedPin.status, daemonWrites }, stderr).toEqual({
       status: 202,
-      pinWrites: [{
+      daemonWrites: [{
         method: 'PUT',
         url: '/api/chat-pin-streaming-card/oc%20auth%2Ftopic',
+        body: '{"enabled":false}',
       }],
     });
-    pinWrites.length = 0;
+    daemonWrites.length = 0;
+
+    const authenticatedRename = await requestLoopback(renameRoute, {
+      method: 'PUT',
+      headers: {
+        cookie: `botmux_dashboard_token=${dashboardToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'New name' }),
+    });
+    expect({ status: authenticatedRename.status, daemonWrites }, stderr).toEqual({
+      status: 202,
+      daemonWrites: [{
+        method: 'PUT',
+        url: '/api/groups/oc%20auth%2Ftopic/name',
+        body: '{"name":"New name"}',
+      }],
+    });
+    daemonWrites.length = 0;
+
+    const oversizedRename = await requestLoopback(renameRoute, {
+      method: 'PUT',
+      headers: {
+        cookie: `botmux_dashboard_token=${dashboardToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'x'.repeat(4_096) }),
+    });
+    expect(JSON.parse(oversizedRename.bodyText)).toEqual({ ok: false, error: 'body_too_large' });
+    expect({ status: oversizedRename.status, daemonWrites }, stderr).toEqual({ status: 413, daemonWrites: [] });
 
     const privateModeDenied = await anonymousPin();
-    expect({ status: privateModeDenied.status, pinWrites }, stderr).toEqual({
+    expect({ status: privateModeDenied.status, daemonWrites }, stderr).toEqual({
       status: 401,
-      pinWrites: [],
+      daemonWrites: [],
     });
+    const privateRenameDenied = await requestLoopback(renameRoute, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Denied' }),
+    });
+    expect({ status: privateRenameDenied.status, daemonWrites }, stderr).toEqual({ status: 401, daemonWrites: [] });
 
     const enablePublicReadOnly = await requestLoopback(`${base}/api/settings`, {
       method: 'PUT',
@@ -222,9 +266,15 @@ describe('dashboard pin-streaming-card route auth', () => {
     });
 
     const publicModeDenied = await anonymousPin();
-    expect({ status: publicModeDenied.status, pinWrites }, stderr).toEqual({
+    expect({ status: publicModeDenied.status, daemonWrites }, stderr).toEqual({
       status: 401,
-      pinWrites: [],
+      daemonWrites: [],
     });
+    const publicRenameDenied = await requestLoopback(renameRoute, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Denied' }),
+    });
+    expect({ status: publicRenameDenied.status, daemonWrites }, stderr).toEqual({ status: 401, daemonWrites: [] });
   }, 20_000);
 });

--- a/test/groups-action-helpers.test.ts
+++ b/test/groups-action-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   bindOncall,
   disbandGroup,
   leaveGroup,
+  renameGroup,
   setPinStreamingCardForGroup,
   unbindOncall,
   type DaemonHandle,
@@ -245,6 +246,51 @@ describe('bindOncall', () => {
     const deps = makeDeps({ proxyToDaemon: proxySpy });
     await bindOncall('oc_demo', 'cli_owner', '', deps);
     expect((proxySpy.mock.calls[0]![2] as RequestInit).body).toBe('{}');
+  });
+});
+
+describe('renameGroup', () => {
+  it('routes through the exact bot identity and invalidates snapshots on success', async () => {
+    const proxySpy = vi.fn(async () => makeRes(200, {
+      ok: true,
+      changed: true,
+      oldName: 'Old',
+      newName: 'New',
+    }));
+    const operationDeps = makeDeps({ proxyToDaemon: proxySpy });
+
+    const result = await renameGroup(
+      'oc topic/one',
+      'cli/app one',
+      '{"name":"New"}',
+      operationDeps,
+    );
+
+    expect(result).toEqual({
+      status: 200,
+      body: { ok: true, changed: true, oldName: 'Old', newName: 'New' },
+    });
+    expect(proxySpy).toHaveBeenCalledWith(
+      'cli/app one',
+      '/api/groups/oc%20topic%2Fone/name',
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: '{"name":"New"}',
+      },
+    );
+    expect(operationDeps.invalidateGroups).toHaveBeenCalledOnce();
+  });
+
+  it('preserves upstream failures without invalidating snapshots', async () => {
+    const operationDeps = makeDeps({
+      proxyToDaemon: vi.fn(async () => makeRes(403, { ok: false, error: 'bot_not_in_chat' })),
+    });
+
+    const result = await renameGroup('oc_demo', 'cli_owner', '{}', operationDeps);
+
+    expect(result).toEqual({ status: 403, body: { ok: false, error: 'bot_not_in_chat' } });
+    expect(operationDeps.invalidateGroups).not.toHaveBeenCalled();
   });
 });
 

--- a/test/ipc-chat-rename-route.test.ts
+++ b/test/ipc-chat-rename-route.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   setIpcAuthSecret,
+  setLarkAppId,
   startIpcServer,
   type IpcServerHandle,
 } from '../src/core/dashboard-ipc-server.js';
+import { daemonIpcAuthHeaders } from '../src/core/daemon-ipc-auth.js';
 import * as workerPool from '../src/core/worker-pool.js';
 import * as groupsStore from '../src/services/groups-store.js';
 import * as sessionStore from '../src/services/session-store.js';
@@ -17,6 +19,7 @@ afterEach(async () => {
   if (handle) await handle.close();
   handle = null;
   setIpcAuthSecret(null);
+  setLarkAppId('');
   vi.restoreAllMocks();
 });
 
@@ -106,5 +109,99 @@ describe('POST /api/sessions/:sessionId/chat-rename', () => {
     expect(updateSpy).toHaveBeenCalledOnce();
     // FR-7 requires a cache-refresh warning be recorded on failure.
     expect(warnSpy.mock.calls.some(([msg]) => String(msg).includes('cache_refresh_failed'))).toBe(true);
+  });
+});
+
+describe('PUT /api/groups/:chatId/name', () => {
+  async function put(body: string): Promise<Response> {
+    if (!handle) handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+    return fetch(`http://127.0.0.1:${handle.port}/api/groups/oc-target/name`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+  }
+
+  it('renames through the daemon bot identity and validates the exact body', async () => {
+    setLarkAppId('cli_exact_bot');
+    const renameSpy = vi.spyOn(groupsStore, 'renameChat').mockResolvedValue({
+      ok: true,
+      oldName: 'Old',
+      newName: 'New',
+      changed: true,
+    });
+
+    const response = await put(JSON.stringify({ name: 'New' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      oldName: 'Old',
+      newName: 'New',
+      changed: true,
+      chatId: 'oc-target',
+    });
+    expect(renameSpy).toHaveBeenCalledWith('cli_exact_bot', 'oc-target', 'New', {
+      beforeUpdate: undefined,
+    });
+
+    const invalid = await put(JSON.stringify({ name: 'New', unexpected: true }));
+    expect(invalid.status).toBe(400);
+    expect(await invalid.json()).toEqual({ ok: false, error: 'invalid_request' });
+    expect(renameSpy).toHaveBeenCalledOnce();
+  });
+
+  it('maps membership denial and never falls back to another bot', async () => {
+    setLarkAppId('cli_exact_bot');
+    const renameSpy = vi.spyOn(groupsStore, 'renameChat').mockResolvedValue({
+      ok: false,
+      error: 'bot_not_in_chat',
+    });
+
+    const response = await put(JSON.stringify({ name: 'New' }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: 'bot_not_in_chat',
+    });
+    expect(renameSpy).toHaveBeenCalledOnce();
+  });
+
+  it('requires trusted-host authentication in the production IPC mode', async () => {
+    const secret = 'test-chat-rename-host-secret';
+    setIpcAuthSecret(secret);
+    setLarkAppId('cli_exact_bot');
+    const renameSpy = vi.spyOn(groupsStore, 'renameChat').mockResolvedValue({
+      ok: true,
+      oldName: 'Old',
+      newName: 'New',
+      changed: true,
+    });
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const path = '/api/groups/oc-target/name';
+    const body = JSON.stringify({ name: 'New' });
+
+    const denied = await fetch(`http://127.0.0.1:${handle.port}${path}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+    expect(denied.status).toBe(401);
+    expect(renameSpy).not.toHaveBeenCalled();
+
+    const allowed = await fetch(`http://127.0.0.1:${handle.port}${path}`, {
+      method: 'PUT',
+      headers: daemonIpcAuthHeaders({
+        secret,
+        port: handle.port,
+        method: 'PUT',
+        path,
+        headers: { 'content-type': 'application/json' },
+      }),
+      body,
+    });
+    expect(allowed.status).toBe(200);
+    expect(renameSpy).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## 变更内容

- 新增需管理权限的 `PUT /api/groups/:chatId/name/:larkAppId`，按明确机器人身份修改飞书群名
- daemon 继续校验机器人在群内，不做凭证或机器人回退；请求体严格校验并限制为 4 KiB
- 抽取共享改名执行层，统一会话 Skill 与宿主集成的错误映射、审计和活跃会话投影同步
- 补充中英文 Dashboard API 文档

## 影响面

- 仅影响 Dashboard/daemon 的飞书群改名链路
- 不涉及 CLI 适配器、PTY/Tmux、远程后端或非飞书会话
- 复用现有 Dashboard 管理权限、daemon HMAC、群成员校验和每 bot/chat 串行队列

## 验证

- `bun run build`
- `bun run build:bun`
- `bun run verify:binary`
- 定向测试：5 个文件、83 个用例全部通过
- 全仓测试：21,740 个用例通过；1 个计时用例独立重跑通过，2 个 `plugin-mcp-sandbox` 用例在同环境最新 `origin/master` 基线上同样失败
