### PR TITLE
fix(build): darwin 二进制编译后补 ad-hoc 重签

### DIFF
--- a/scripts/build-bun-binary.mjs
+++ b/scripts/build-bun-binary.mjs
@@ -133,6 +133,73 @@ function resolveNodePtyNative(platform, arch) {
   return { ptyNode, spawnHelper: spawnHelper && existsSync(spawnHelper) ? spawnHelper : null };
 }
 
+/** Run a tool, returning exit code + stderr instead of throwing on ENOENT. */
+function runTool(argv) {
+  try {
+    const p = Bun.spawnSync(argv, { stdout: 'pipe', stderr: 'pipe' });
+    return { code: p.exitCode, err: p.stderr.toString().trim() };
+  } catch (e) {
+    return { code: -1, err: `could not run \`${argv[0]}\`: ${e?.message ?? e}` };
+  }
+}
+
+/**
+ * Ad-hoc re-sign a compiled darwin binary, then verify it.
+ *
+ * WHY: `bun build --compile` ad-hoc-signs its own darwin output, but the signer
+ * only gets the HOST arch right. On the macos-14 (arm64) release runner,
+ * `--target=bun-darwin-x64` therefore lands an INVALID signature. Measured on
+ * the v3.19.0 release run, where `codesign --verify --strict` reported:
+ *
+ *     botmux-darwin-arm64: valid on disk                                  ← native, fine
+ *     botmux-darwin-x64: invalid signature (code or signature have been modified)
+ *     In architecture: x86_64
+ *
+ * ...with bun 1.4.1 on the runner — i.e. AFTER the version bump this was
+ * supposed to be fixed by. oven-sh/bun#39837 is titled "compile: fix invalid
+ * ad-hoc code signature on darwin-arm64" and its test only compiles
+ * `--target=bun-darwin-arm64`; nothing upstream covers x86_64. So bumping bun
+ * again does NOT close this — don't read "we're on 1.4.1" as "already fixed".
+ * `codesign --force --sign -` is the re-signing fix confirmed in
+ * oven-sh/bun#39764 (`BUN_NO_CODESIGN_MACHO_BINARY=1` and `--remove-signature`
+ * were both reported there as NOT working).
+ *
+ * WHY IT MATTERS: recent macOS SIGKILLs a bad-signature binary before `main()`,
+ * so 3.18.14 shipped a darwin-x64 build that could not start at all — all
+ * `botmux upgrade` saw was a dead process. Nothing caught it, because
+ * release.yml's `Smoke-test the host-arch binary` runs only the host arch
+ * (arm64), and the arm64 binary was always fine.
+ *
+ * Idempotent, so this runs for BOTH darwin targets rather than special-casing
+ * x64: re-signing the already-valid native output just rewrites an equivalent
+ * signature, and not depending on "which arch is currently broken upstream"
+ * keeps this correct if the arch-conditional bug moves.
+ *
+ * Signing needs macOS (`codesign` is an Apple tool), so a darwin binary
+ * cross-built from Linux stays unsigned — warn loudly rather than fail, since
+ * release.yml builds darwin only on macOS (so the shipped path is always
+ * signed) while `--all` on a Linux dev box is a legitimate workflow.
+ */
+function adhocResignDarwin(outfile) {
+  if (process.platform !== 'darwin') {
+    console.warn(
+      `⚠️  ${outfile}: darwin target cross-built on ${process.platform} — cannot ad-hoc sign, ` +
+      `codesign is macOS-only. Recent macOS will SIGKILL this binary before main(). ` +
+      `Release builds compile darwin on macOS (release.yml \`bun-binaries\`) and are signed there.`,
+    );
+    return;
+  }
+  const signed = runTool(['codesign', '--force', '--sign', '-', outfile]);
+  if (signed.code !== 0) throw new Error(`ad-hoc codesign failed for ${outfile}: ${signed.err}`);
+  // Verify with the strictness newer macOS applies at exec time, so a bad
+  // signature fails the build here instead of on a user's machine. release.yml
+  // re-checks this independently after the compile loop; that gate is the
+  // fail-closed backstop for the release lane, this one covers every caller.
+  const ok = runTool(['codesign', '--verify', '--strict', '--verbose=2', outfile]);
+  if (ok.code !== 0) throw new Error(`codesign --verify --strict failed for ${outfile}: ${ok.err}`);
+  console.log(`🔐 ad-hoc signed ${outfile}`);
+}
+
 async function buildOne({ target, out }) {
   const { platform, arch } = targetToPlatformArch(target);
   const { ptyNode, spawnHelper } = resolveNodePtyNative(platform, arch);
@@ -162,6 +229,7 @@ async function buildOne({ target, out }) {
     for (const log of result.logs) console.error(log);
     throw new Error(`bun build failed for ${target ?? 'host'}`);
   }
+  if (platform === 'darwin') adhocResignDarwin(outfile);
   console.log(`✅ built ${outfile} (${target ?? 'host'}; version=${baked}; pty.node=${ptyNode}${spawnHelper ? `, spawn-helper=${spawnHelper}` : ''})`);
   return outfile;
 }

--- a/test/release-darwin-codesign-gate.test.ts
+++ b/test/release-darwin-codesign-gate.test.ts
@@ -41,6 +41,7 @@ const RELEASE = stripHashComments(read('.github/workflows/release.yml'));
 const CI = stripHashComments(read('.github/workflows/ci.yml'));
 const GLIBC_SH = stripHashComments(read('scripts/build-linux-glibc-baseline.sh'));
 const SMOKE = stripJsComments(read('scripts/smoke-bun-binary.mjs'));
+const BUILD = stripJsComments(read('scripts/build-bun-binary.mjs'));
 const PKG = JSON.parse(read('package.json')) as { packageManager?: string };
 
 /** The step body from its `- name:` line up to the next step. */
@@ -59,7 +60,10 @@ const gte = (a: string, b: string) => {
   return true;
 };
 
-/** First Bun version known to write a valid darwin ad-hoc signature (#39837). */
+/** First Bun version known to write a valid darwin ad-hoc signature (#39837).
+ *  ⚠️ ONLY for the HOST arch — see the build-bun-binary.mjs suite below: 1.4.1
+ *  still writes an invalid signature when cross-compiling darwin-x64, so this
+ *  pin is necessary but NOT sufficient. */
 const FIRST_GOOD_BUN = '1.4.1';
 
 describe('release.yml — every darwin binary is codesign-verified before it ships', () => {
@@ -121,6 +125,62 @@ describe('smoke-bun-binary.mjs — the shared smoke checks the signature first o
     expect(SMOKE).toMatch(/startsWith\('BOTMUX_'\)/);
     expect(SMOKE).toMatch(/'BOTS_CONFIG'/);
     expect(SMOKE).toMatch(/'SESSION_DATA_DIR'/);
+  });
+});
+
+describe('build-bun-binary.mjs — re-signs darwin output, because the bun pin is not enough', () => {
+  /**
+   * MEASURED on the v3.19.0 release run (bun 1.4.1 on the macos-14 runner):
+   *   botmux-darwin-arm64: valid on disk                                   ← native
+   *   botmux-darwin-x64: invalid signature (code or signature have been modified)
+   *   In architecture: x86_64
+   *
+   * Reproduced locally with bun 1.4.1 by parsing the CodeDirectory and recomputing
+   * the page hashes (no macOS required). A bare `bun build --compile` of a two-line
+   * hello-world — no repo plugin, no dist/cli.js — shows the same split, so the
+   * defect is upstream, not something this repo's native-embed plugin causes:
+   *   plain hello → bun-darwin-arm64: VALID   (15095/15095 page hashes)
+   *   plain hello → bun-darwin-x64:   INVALID (2/16792 mismatch, incl. slot 0)
+   * The x64 CodeDirectory also stops early — codeLimit 68776432 vs signature start
+   * 94548464 — leaving ~25 MB outside the signed range.
+   *
+   * oven-sh/bun#39837 is titled "fix invalid ad-hoc code signature on
+   * darwin-arm64" and its test only compiles --target=bun-darwin-arm64; nothing
+   * upstream covers x86_64. So bumping the pin again does NOT close this, and
+   * these assertions exist so nobody deletes the re-sign after reading
+   * "we're already on 1.4.1".
+   */
+  it('ad-hoc re-signs with codesign --force --sign -', () => {
+    // #39764 reports --remove-signature and BUN_NO_CODESIGN_MACHO_BINARY=1 as NOT
+    // working; --force re-signing is the fix confirmed there.
+    expect(BUILD).toMatch(/codesign', '--force', '--sign', '-'/);
+  });
+
+  it('verifies its own output with --strict, so a bad signature fails the build', () => {
+    expect(BUILD).toMatch(/codesign', '--verify', '--strict'/);
+  });
+
+  it('throws when signing or verification fails (never warns and continues)', () => {
+    expect(BUILD).toMatch(/throw new Error\(`ad-hoc codesign failed/);
+    expect(BUILD).toMatch(/throw new Error\(`codesign --verify --strict failed/);
+  });
+
+  it('signs on the darwin TARGET, not merely when the host happens to be macOS', () => {
+    // The bug is arch-specific and cross-compiled, so keying off the target is
+    // what makes darwin-x64 (built on an arm64 runner) get re-signed at all.
+    expect(BUILD).toMatch(/if \(platform === 'darwin'\) adhocResignDarwin\(outfile\)/);
+  });
+
+  it('degrades to a warning when a darwin target is cross-built off macOS', () => {
+    // codesign is macOS-only. release.yml builds darwin on macos-14, so the
+    // shipped path always signs; `--all` on a Linux dev box must still work.
+    expect(BUILD).toMatch(/process\.platform !== 'darwin'/);
+    expect(BUILD).toMatch(/cannot ad-hoc sign/);
+  });
+
+  it('re-signs both darwin arches rather than special-casing x64', () => {
+    // Idempotent, and keeps working if the arch-conditional upstream bug moves.
+    expect(BUILD).not.toMatch(/=== 'x64'[\s\S]{0,80}codesign/);
   });
 });
 


### PR DESCRIPTION
## 问题

v3.19.0 的 Release run 在 `bun-binaries (macos-14, darwin)` 的 `Verify Mach-O signatures on every darwin binary` 步骤失败：

```
verifying signature: dist-bin/botmux-darwin-arm64
dist-bin/botmux-darwin-arm64: valid on disk
dist-bin/botmux-darwin-arm64: satisfies its Designated Requirement
verifying signature: dist-bin/botmux-darwin-x64
dist-bin/botmux-darwin-x64: invalid signature (code or signature have been modified)
In architecture: x86_64
```

分界线很干净：**原生 arm64 有效，同一个 runner 上交叉编译出的 darwin-x64 无效**。该 runner 用的已经是 bun 1.4.1，所以 #1263 把 pin 升到 1.4.1 **并没有覆盖交叉编译这条路径**。

fail-closed 生效，没有任何东西发出去（`release` / `binary-subpackages` / `attach-bun-binaries` / `publish-github-release` 全部 skipped，npm `latest` 仍是 3.18.14，`botmux@3.19.0` 为 E404）。

## 根因：上游 bun，且升版本修不掉

本地复现（解析 Mach-O 的 `LC_CODE_SIGNATURE` → SuperBlob → CodeDirectory 重算分页哈希，不需要 macOS）。关键是**阴性对照**——用 bun 1.4.1 编一个两行 hello world，不经过本仓库的构建脚本、不挂 native-embed 插件：

| 构建 | bun 1.4.1 结果 |
|---|---|
| 裸 `bun build --compile` → darwin-**arm64** | ✅ VALID（15095/15095 分页哈希匹配） |
| 裸 `bun build --compile` → darwin-**x64** | 🔴 INVALID（2/16792 不匹配，含 slot 0） |
| 本仓库脚本 → darwin-arm64 | ✅ VALID（21403/21403） |

⟹ 与本仓库的插件、`dist/cli.js` 均无关。x64 的形态比 arm64 当初那个更严重：CodeDirectory 的 `codeLimit` 只到 `68776432`，而签名本体从 `94548464` 开始 —— **约 25MB 内容落在签名范围之外**。

上游 oven-sh/bun#39837 标题即为 "compile: fix invalid ad-hoc code signature on **darwin-arm64**"，其测试只编 `--target=bun-darwin-arm64`，x86_64 未被覆盖。**因此再升 bun 版本不能关闭此问题**，不要把「已经在 1.4.1 了」读成「已修」。

## 改动

`scripts/build-bun-binary.mjs`：

- darwin 目标编译成功后走 `codesign --force --sign -` 重签，再以 `--verify --strict` 自校验；两步任一失败即 `throw`，不降级为警告。（`--remove-signature` 与 `BUN_NO_CODESIGN_MACHO_BINARY=1` 在 oven-sh/bun#39764 中被报告为无效，`--force` 重签是那里确认可行的修法。）
- **两个 arch 都签，不特判 x64**：重签幂等，且上游那个按 arch 分支的 bug 换个位置也不会漏掉。
- 非 macOS 主机上交叉编 darwin 目标时**打警告而非失败**：`codesign` 是 macOS 独有工具，而 release.yml 的 darwin 腿固定在 macos-14（发布路径必定签名），Linux 开发机上跑 `--all` 属正常用法，不应因此编不出来。

`test/release-darwin-codesign-gate.test.ts`：新增 6 条断言钉住「重签 / 自校验 / 失败即抛 / 按 target 触发 / 两 arch 都签」，并把该文件里「1.4.1 已修好」这个**已被证伪的前提**在注释与 `FIRST_GOOD_BUN` 说明中更正为「仅 host arch，必要但不充分」。

## 影响面

该脚本同时服务：release.yml 的 darwin 腿与 glibc baseline 腿、ci.yml 的 musl 腿、`bun run build:bun`、`scripts/verify-binary.mjs`、`scripts/build-linux-glibc-baseline.sh`。

签名分支以 `platform === 'darwin'` 为闸 ⟹ **linux / musl 的全部目标都不进该分支**，行为逐字不变（已实测 bun-linux-x64 输出中无 `⚠️`/`🔐` 行）。唯一进入警告分支的场景是「在非 macOS 主机上编 darwin 目标」，即本地 `--all`；该场景此前也拿不到有效签名，现在会明确告知而非静默产出坏签名。

## 验证

- **反变异 6 枪全红**（去掉 `--force`、去掉 `--strict`、两处 `throw` 改 `console.warn`、改成按 host 触发、只特判 x64）⟹ 无哑弹断言
- `test/release-darwin-codesign-gate.test.ts` **20/20** 通过
- `npm-binary-distribution` + `ci-glibc-baseline-gate` + `claim-botmux-bin-binary` **54/54** 通过（`Test Files 3 passed (3)`）
- `bun run build` 通过
- **linux-x64 实编产物跑完整 smoke 全绿**：version / lark-scopes selfcheck / self-spawn（PTY，supervisor 拉起 dashboard）/ dashboard 无重启 / HTTP 200 / 前端内嵌资源 / 自毁守卫
- darwin 目标在 Linux 本机实编：走警告分支、**不 throw**，产物为 `Mach-O 64-bit x86_64 executable`
- 守卫为承重代码：把 `process.platform !== 'darwin'` 短路成 `false` 后，Linux 上编 darwin 立即抛错

### 🔴 本地无法终判的部分

签名有效性**只能在 macOS 上判**：本机是 Linux 无 `codesign`，且 `ci.yml` 里 `darwin|macos` 出现 **0 次**（正是这道缺陷能溜到发版阶段才被抓到的原因）。

合并后的判据是 Release 日志里**这两行都在**：

```
dist-bin/botmux-darwin-x64: valid on disk
dist-bin/botmux-darwin-x64: satisfies its Designated Requirement
```

只看 arm64 转绿**不能**判定修好了。

### 后续（不在本 PR）

给 `ci.yml` 补一条 darwin 编译 + 签名校验腿，使这类缺陷在 PR 阶段即被拦下，而不是等到 tag 已经打出去。
