### PR TITLE
fix(opencode): 补齐 PTY 长消息的粘贴协议

### DIFF
--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -398,11 +398,12 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
       // 提交验证基线先于写入采样（traex 同款）。斜杠命令是 TUI 命令面板输入，
       // 不产生 user message 行，跳过验证（重试 Enter 还可能误触面板项）。
       const isSlashCommand = content.startsWith('/');
+      const needsPaste = !isSlashCommand && (content.length > OPENCODE_PASTE_THRESHOLD || content.includes('\n'));
       const baseline = isSlashCommand ? null : snapPartBaseline();
 
       try {
         if (pty.sendText && pty.sendSpecialKeys) {
-          if (!isSlashCommand && pty.pasteText && (content.length > OPENCODE_PASTE_THRESHOLD || content.includes('\n'))) {
+          if (needsPaste && pty.pasteText) {
             pty.pasteText(content);
           } else {
             pty.sendText(content);
@@ -410,7 +411,10 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
           await delay(200);
           pty.sendSpecialKeys('Enter');
         } else {
-          pty.write(content);
+          // Raw PTY has no tmux paste-buffer to add these markers. Without
+          // them, long/deferred or multiline prompts are parsed as individual
+          // key events and can be dropped instead of submitted as one message.
+          pty.write(needsPaste ? `\x1b[200~${content}\x1b[201~` : content);
           await delay(1000);
           pty.write('\r');
         }

--- a/test/opencode-resume.test.ts
+++ b/test/opencode-resume.test.ts
@@ -281,6 +281,38 @@ describe('opencode writeInput DB verification', () => {
     expect(events).toEqual([`paste:${content.length}`, 'key:Enter']);
   });
 
+  it.each([
+    ['long deferred first prompt', `FIRST\n${'中文多行 0123456789\n'.repeat(700)}LAST`],
+    ['short multiline follow-up', 'first line\nsecond line'],
+    ['long single line', '内容'.repeat(100)],
+  ])('uses bracketed paste on raw PTY for a %s', async (_label, content) => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_target' });
+    const writes: string[] = [];
+    const pty: PtyHandle = {
+      write(data) {
+        writes.push(data);
+        if (data === '\r' && writes[0] === `\x1b[200~${content}\x1b[201~`) {
+          seedUserPart(db, 'ses_target', content, Date.now());
+        }
+      },
+    };
+
+    try {
+      const result = await createOpenCodeAdapter().writeInput(pty, content);
+      expect(result).toMatchObject({ submitted: true, cliSessionId: 'ses_target' });
+      expect(writes).toEqual([`\x1b[200~${content}\x1b[201~`, '\r']);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each(['short follow-up', '/session'])('keeps raw PTY typing for %s', async (content) => {
+    const writes: string[] = [];
+    await createOpenCodeAdapter().writeInput({ write(data) { writes.push(data); } }, content);
+    expect(writes).toEqual([content, '\r']);
+  });
+
   it('recognizes the submission when OpenCode prepends a Directory Context block to the stored user part', async () => {
     const db = openDb();
     seedSession(db, { id: 'ses_target' });

--- a/test/opencode-resume.test.ts
+++ b/test/opencode-resume.test.ts
@@ -307,7 +307,12 @@ describe('opencode writeInput DB verification', () => {
     }
   });
 
-  it.each(['short follow-up', '/session'])('keeps raw PTY typing for %s', async (content) => {
+  it.each([
+    ['short follow-up', 'short follow-up'],
+    ['short slash command', '/session'],
+    ['long slash command', `/compact ${'a'.repeat(300)}`],
+    ['multiline slash command', '/ask first line\nsecond line'],
+  ])('keeps raw PTY typing for %s', async (_label, content) => {
     const writes: string[] = [];
     await createOpenCodeAdapter().writeInput({ write(data) { writes.push(data); } }, content);
     expect(writes).toEqual([content, '\r']);


### PR DESCRIPTION
## 问题与改动

#1251 已将超过 8192 UTF-8 字节的 OpenCode 首条消息转入启动后的输入队列。使用 `PtyBackend` 时，`writeInput` 的回退分支仍直接写入全文；长文本与换行会被 TUI 当作按键解析，可能未能提交。

本地用 OpenCode 兼容 CLI 1.16.2 复现：22443 字节的中文多行首条消息经原 PTY 分支投递后，没有 user part 落库，`submitted=false`；相同输入添加 bracketed-paste 标记后完整落库。

本次沿用现有的粘贴判定条件，为 OpenCode 的 raw PTY 分支补充 `ESC[200~` / `ESC[201~`，随后按原有等待间隔发送 Enter。短单行文本和斜杠命令仍使用原来的输入方式。补充长首条、多行后续、长单行、短单行及短/长/多行斜杠命令的回归覆盖。

## 影响范围

- 修改仅涉及 `src/adapters/cli/opencode.ts` 的输入投递及对应测试；覆盖走 PTY 的延迟首条、后续消息和恢复后的输入。
- tmux 继续使用 `pasteText` / `sendText`，仅复用同一粘贴判定条件；已做真实 tmux 回归。
- 没有修改 worker、公共后端实现、Codex、Claude Code 或 OpenCode2 的适配逻辑；相关适配器单测一并通过。
- Linux 已实测；macOS、sandbox on、完整飞书话题/群会话及 v3 编排未实测。本次按本地验证范围执行，未切换或重启线上 daemon。

## 实际验证

```bash
bun run build
bun run test test/initial-prompt-arg-limit.test.ts test/opencode-resume.test.ts test/opencode-raw-passthrough.test.ts test/opencode-busy-state.test.ts test/opencode2-resume.test.ts test/cli-adapters.test.ts
git diff --check
```

使用 Bun 1.4.1、Node 22.22.0：构建通过，6 个文件共 522 项测试通过，diff 检查通过。新增的 3 个粘贴用例在修改生产代码前失败，修复后通过。另补充长斜杠命令与多行斜杠命令用例：临时删除 `!isSlashCommand` 守卫时，两条均失败；恢复原实现后全部通过。

另以真实 CLI、本地 HTTP 模型 fixture、独立 HOME/XDG/工作目录/tmux socket 验证 adapter 与后端的输入链路；使用 BotMux `IdleDetector` 等待首次就绪：

| 场景 | PTY 修复后 | tmux 回归 |
| --- | --- | --- |
| 22443 字节中文多行首条 | 完整落库 1 次 | 完整落库 1 次 |
| 55 字节多行后续消息 | 同一 session 完整落库 1 次 | 同一 session 完整落库 1 次 |
| 停止 CLI，再以 `--session` 恢复并发送 24035 字节消息 | 同一 session 完整落库 1 次 | 同一 session 完整落库 1 次 |

逐字比对独立数据库中的 user part，完整内容一致；该 CLI 的原生 paste-summary 会额外追加一个 ASCII 空格。每组恰好 3 条 user part，均属于同一个 session。模型 fixture 仅返回固定文本，不执行工具；这些结果验证 CLI 输入链路，不代表飞书端到端或真实模型服务已验证。
