### PR TITLE
fix(grok): 忙态消息改为中断并立即发送

### DIFF
--- a/src/adapters/cli/grok.ts
+++ b/src/adapters/cli/grok.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { resolveCommand } from './registry.js';
 import { buildBotmuxSystemPromptText } from './shared-hints.js';
-import type { CliAdapter, PtyHandle } from './types.js';
+import type { CliAdapter, PtyHandle, WriteInputContext } from './types.js';
 import { sessionReadyHookCommand } from '../hook-command.js';
 import { delay, scaleMs } from '../../utils/timing.js';
 import {
@@ -47,14 +47,14 @@ import { whiteboardEnabled } from '../../services/whiteboard-store.js';
  *    `initialPromptArgsIgnoredOnResume`.
  *
  *  ## Type-ahead
- *  Grok's interactive TUI accepts mid-turn Enter as a follow-up. Although its
- *  UI describes this as queued, 0.2.99 transcripts can contain multiple
- *  `user_message_chunk`s before one `turn_completed` (active-turn merge).
- *  `supportsTypeAhead: true` remains useful for ordinary IM turns and
- *  CodexBridgeQueue's HOL-block-drop attributes the one merged final to the
- *  newest matching turn. Durable deliveries are explicitly excluded from
- *  type-ahead on both sides by the worker's queue policy, so an exact receipt
- *  can never be merged away.
+ *  Grok's default mid-turn Enter queues a follow-up until the active turn ends.
+ *  Botmux human follow-ups instead use Grok's explicit send-now action:
+ *  Ctrl+I, the documented terminal-stable alias of Ctrl+Enter. The worker
+ *  captures readiness before resetting the write cycle and passes
+ *  `submissionMode=interrupt` only for a genuinely busy submit. Idle submits
+ *  keep Enter. Durable deliveries remain excluded from type-ahead, and the
+ *  worker drains at most one item per flush for this interrupting adapter so a
+ *  pre-existing backlog cannot cascade-cancel each newly started turn.
  *
  *  ## Input delivery: bracketed paste
  *  The body is delivered via BRACKETED PASTE (tmux load-buffer +
@@ -133,6 +133,7 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     supportsTypeAhead: true,
+    busyInputBehavior: 'interrupt',
     // updates.jsonl provides a session-scoped, explicit `turn_completed`
     // boundary. The bridge preserves empty finals and maps error/cancelled
     // stop reasons, so meeting delivery never relies on prompt-looking screen
@@ -248,7 +249,7 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
       return discoverGrokSessions(limit, exclude);
     },
 
-    async writeInput(pty: PtyHandle, content: string) {
+    async writeInput(pty: PtyHandle, content: string, context?: WriteInputContext) {
       // Submit verify against the bucket-level prompt_history.jsonl (one
       // {timestamp, session_id, prompt} line per submit; idle-composer
       // submits append at submit time, mid-turn queued submits only at
@@ -264,12 +265,13 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
       //
       // TmuxPipeBackend (adopt) returns false on failed writes instead of
       // throwing — treat false as definite failure.
-      const trySendEnter = (): boolean => {
+      const submissionKey = context?.submissionMode === 'interrupt' ? 'C-i' : 'Enter';
+      const trySubmit = (): boolean => {
         try {
           if (pty.sendSpecialKeys) {
-            return pty.sendSpecialKeys('Enter') !== false;
+            return pty.sendSpecialKeys(submissionKey) !== false;
           }
-          pty.write('\r');
+          pty.write(submissionKey === 'C-i' ? '\t' : '\r');
           return true;
         } catch {
           // tmux session gone mid-write — bail cleanly.
@@ -300,7 +302,7 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
       if (!cwd) {
         if (!deliverBody()) return { submitted: false };
         await delay(scaleMs(200));
-        trySendEnter();
+        trySubmit();
         return { submitted: false };
       }
 
@@ -309,14 +311,12 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
 
       if (!deliverBody()) return { submitted: false };
       await delay(scaleMs(200));
-      // One paste + one Enter per call, and NEVER an Enter without a paste
-      // in the same call: `submitted:false` is not proof the body is parked
-      // in the composer (every mid-turn submit verifies late — see header),
-      // and a bare Enter on an empty composer with a queued follow-up is
-      // send-now (cancels the running turn). An unconfirmed submit is
-      // recovered by the worker's flush retry (full re-paste) and the
-      // deferred recheck, never by extra in-band Enters.
-      if (!trySendEnter()) return { submitted: false };
+      // Exactly one semantic submit per call, always paired with this paste.
+      // Idle uses Enter. A worker-proven busy human follow-up uses Ctrl+I,
+      // Grok's terminal-stable Ctrl+Enter alias, to cancel-and-send directly.
+      // We still never emit a bare retry key: `submitted:false` does not prove
+      // where the body landed, which is the #865 send-now regression boundary.
+      if (!trySubmit()) return { submitted: false };
 
       // First submit in a fresh bucket creates the file after our snapshot —
       // re-stat base as 0 when the path appears mid-poll. Re-resolve prefer

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -59,12 +59,24 @@ export type RunnerSubmissionDisposition =
   | 'flushed_invalid'
   | 'dirty_unknown';
 
+/** Semantic result of submitting text while the CLI already has an active
+ * turn. This is deliberately separate from supportsTypeAhead: accepting PTY
+ * bytes says nothing about whether the CLI queues, steers, or interrupts. */
+export type BusyInputBehavior = 'queue' | 'steer' | 'interrupt';
+
+/** Per-write submission action selected by the worker from prompt readiness
+ * and the adapter's busy-input contract. */
+export type InputSubmissionMode = 'default' | 'interrupt';
+
 /** Optional per-input correlation metadata. Adapters that do not need it may
  * ignore it; runner-based adapters use the immutable botmux/Lark turn id to
  * keep protocol ids separate from reply-routing ids. */
 export interface WriteInputContext {
   turnId?: string;
   trustedCaller?: TrustedCaller;
+  /** Use the CLI's explicit cancel-and-send action for a busy human follow-up.
+   * Missing/default preserves every adapter's legacy submit key. */
+  submissionMode?: InputSubmissionMode;
   /** codex-app only: this turn is authorized to steer into an active turn. */
   codexAppSteerable?: true;
 }
@@ -464,6 +476,12 @@ export interface CliAdapter {
    *  assistant_final). CodexBridgeQueue's HOL-block-drop keeps attribution
    *  correct for both shapes. */
   readonly supportsTypeAhead?: boolean;
+
+  /** What a submit must do when supportsTypeAhead admits input during an
+   * active turn. Undefined preserves the adapter's existing submit behavior.
+   * `interrupt` also makes the worker stop after one queued item per flush, so
+   * an already-buffered backlog cannot repeatedly cancel the replacement turn. */
+  readonly busyInputBehavior?: BusyInputBehavior;
 
   /** True when this CLI supports a UserPromptSubmit hook whose additionalContext
    *  is injected as an INVISIBLE system-reminder (not rendered into the visible

--- a/src/utils/input-gate.ts
+++ b/src/utils/input-gate.ts
@@ -1,3 +1,5 @@
+import type { BusyInputBehavior, InputSubmissionMode } from '../adapters/cli/types.js';
+
 /**
  * Worker input-gate — decide whether an incoming Lark message is written to the
  * CLI's PTY now, or queued until the CLI is ready.
@@ -34,6 +36,18 @@ export function shouldWriteNow(state: {
   if (state.isPromptReady || state.isFlushing) return true;
   // Type-ahead is only safe after the TUI has booted at least once.
   return state.supportsTypeAhead && !state.awaitingFirstPrompt;
+}
+
+/** Select the semantic submit action before beginCliWriteCycle clears the
+ * worker's readiness bit. Only adapters that explicitly declare interrupt
+ * behavior receive the interrupt action; every legacy adapter stays default. */
+export function resolveWriteInputSubmissionMode(state: {
+  isPromptReady: boolean;
+  busyInputBehavior?: BusyInputBehavior;
+}): InputSubmissionMode {
+  return !state.isPromptReady && state.busyInputBehavior === 'interrupt'
+    ? 'interrupt'
+    : 'default';
 }
 
 /**

--- a/src/utils/pending-input-queue.ts
+++ b/src/utils/pending-input-queue.ts
@@ -1,4 +1,5 @@
 import type { CodexAppTurnInput, TrustedCaller, VcMeetingImTurnOrigin } from '../types.js';
+import type { BusyInputBehavior } from '../adapters/cli/types.js';
 
 export interface PendingCliInput {
   content: string;
@@ -240,8 +241,10 @@ export function shouldArmSpawnArgvInitialPromptBusy(opts: {
 export function shouldStopPendingBatch(
   written: PendingCliInput,
   next: PendingCliInput | undefined,
+  busyInputBehavior?: BusyInputBehavior,
 ): boolean {
-  return written.dispatchAttempt !== undefined
+  return busyInputBehavior === 'interrupt'
+    || written.dispatchAttempt !== undefined
     || next?.dispatchAttempt !== undefined
     || !!written.queuedActivationToken
     || !!next?.queuedActivationToken

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -69,6 +69,7 @@ import {
   decideHardTimeoutAction,
   decidePostHookPromptEvidence,
   decideSettleMarkReady,
+  resolveWriteInputSubmissionMode,
   shouldArmPostHookPromptEvidenceFallback,
   shouldReleaseFirstPromptTimeout,
   shouldWaitForPostSessionStartPromptEvidence,
@@ -11328,6 +11329,10 @@ async function flushPending(): Promise<void> {
   if (!isPromptReady && pendingMessages.length === 0) return;
   if (!isPromptReady && !typeAheadAllowed) return;
 
+  // Capture the real prompt state before beginCliWriteCycle re-arms it to
+  // false. Interrupt-capable adapters need to distinguish an idle submit from
+  // a human follow-up that arrived during an active turn.
+  const inputWasPromptReady = isPromptReady;
   isFlushing = true;
   const codexAppPromptReplay = new CodexAppFlushPromptReplay();
   // Raw input and native rename own their explicit command-line/session gates;
@@ -11468,6 +11473,10 @@ async function flushPending(): Promise<void> {
       const writeGeneration = cliSpawnGeneration;
       const writeBackend = backend;
       const writeAdapter = cliAdapter;
+      const submissionMode = resolveWriteInputSubmissionMode({
+        isPromptReady: inputWasPromptReady,
+        busyInputBehavior: writeAdapter.busyInputBehavior,
+      });
       const writeRpcEngine = codexRpcEngine;
       const writeContinuationIsCurrent = (): boolean => (
         cliSpawnGeneration === writeGeneration
@@ -11689,6 +11698,7 @@ async function flushPending(): Promise<void> {
               item.codexAppInput!,
               {
                 turnId: item.turnId,
+                submissionMode,
                 ...(item.trustedCaller ? { trustedCaller: item.trustedCaller } : {}),
                 ...(item.codexAppSteerable ? { codexAppSteerable: true } : {}),
               },
@@ -11707,6 +11717,7 @@ async function flushPending(): Promise<void> {
               msg,
               {
                 turnId: item.turnId,
+                submissionMode,
                 ...(item.trustedCaller ? { trustedCaller: item.trustedCaller } : {}),
                 ...(item.codexAppSteerable ? { codexAppSteerable: true } : {}),
               },
@@ -12033,7 +12044,11 @@ async function flushPending(): Promise<void> {
       // HOL-dropped or steered into the other.
       if (rpcLifecycleFailClosedOwners.size > 0) break;
       if (item.trustedCaller && lastInitConfig?.cliId === 'codex') break;
-      if (shouldStopPendingBatch(item, pendingMessages[0])) break;
+      if (shouldStopPendingBatch(
+        item,
+        pendingMessages[0],
+        writeAdapter.busyInputBehavior,
+      )) break;
     }
   } finally {
     isFlushing = false;

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -3077,6 +3077,7 @@ describe('grok buildArgs', () => {
 
   it('enables type-ahead, ready-hook gate, and grok-hooks SessionStart install', () => {
     expect(adapter.supportsTypeAhead).toBe(true);
+    expect(adapter.busyInputBehavior).toBe('interrupt');
     expect(adapter.injectsReadyHook).toBe(true);
     expect(adapter.deferFirstPromptTimeoutUntilReady).toBe(true);
     expect(adapter.readyPattern?.test('│ ❯')).toBe(true);

--- a/test/grok-adapter-submit.test.ts
+++ b/test/grok-adapter-submit.test.ts
@@ -24,9 +24,9 @@ import type { PtyHandle } from '../src/adapters/cli/types.js';
 // 1.0.5 a bare Enter with a queued follow-up is send-now (cancels the
 // running turn), and an Enter-only "retry" for an identical resend would
 // swallow the new message entirely. The mock composer below is honest about
-// both: mid-turn submits queue and append only on flushQueue(), and a bare
-// Enter on an empty composer with a non-empty queue counts a send-now
-// cancellation instead of pretending to be a no-op.
+// both: mid-turn Enter submits queue and append only on flushQueue(), while
+// Ctrl+I models Grok's documented Ctrl+Enter "send now" fallback and commits
+// the pasted body as the next turn immediately.
 
 const SID = '00000000-0000-7000-8000-00000000aaaa';
 const CWD = '/fake/grok-project';
@@ -78,6 +78,16 @@ function makePty(opts: { cwd?: string; sid?: string; swallowEnters?: number; mid
     pasteText: vi.fn((text: string) => { composer += text; }),
     sendText: vi.fn(),
     sendSpecialKeys: vi.fn((key: string) => {
+      if (key === 'C-i') {
+        // Grok's send-now chord is deliberately idle-no-op; the worker must
+        // select it only from a captured busy state.
+        if (!opts.midTurn) return;
+        if (!composer) return;
+        sendNowCancels += 1;
+        appendPrompt(opts.sid ?? SID, composer);
+        composer = '';
+        return;
+      }
       if (key !== 'Enter') return;
       if (swallowLeft > 0) {
         swallowLeft -= 1;
@@ -128,6 +138,46 @@ describe.sequential('grok adapter submit delivery (prompt_history.jsonl)', () =>
     expect(pty.pasteText).toHaveBeenCalledTimes(1);
     expect(pty.pasteText).toHaveBeenCalledWith('第一条多行消息\n第二行');
     expect(pty.sendText).not.toHaveBeenCalled();
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+    expect(pty.sendSpecialKeys).not.toHaveBeenCalledWith('C-i');
+  });
+
+  it('interrupts a busy turn with Ctrl+I send-now instead of queueing with Enter', async () => {
+    const adapter = createGrokAdapter('/bin/grok');
+    const pty = makePty({ midTurn: true });
+
+    const result = await adapter.writeInput(
+      pty,
+      '停下当前任务，先回答这个问题',
+      { submissionMode: 'interrupt' },
+    );
+
+    expect(result).toEqual({ submitted: true, cliSessionId: SID });
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('C-i');
+    expect(pty.sendSpecialKeys).not.toHaveBeenCalledWith('Enter');
+    expect(pty.sendNowCancels()).toBe(1);
+  });
+
+  it('uses the Ctrl+I byte on raw PTY backends too', async () => {
+    const adapter = createGrokAdapter('/bin/grok');
+    const writes: string[] = [];
+    const pty = {
+      write(data: string) { writes.push(data); },
+    } satisfies PtyHandle;
+
+    const result = await adapter.writeInput(
+      pty,
+      'raw backend interrupt',
+      { submissionMode: 'interrupt' },
+    );
+
+    expect(result).toEqual({ submitted: false });
+    expect(writes).toEqual([
+      '\x1b[200~raw backend interrupt\x1b[201~',
+      '\t',
+    ]);
   });
 
   it('confirms the very first submit of a lazy-created bucket (history file did not exist yet)', async () => {

--- a/test/input-gate.test.ts
+++ b/test/input-gate.test.ts
@@ -17,6 +17,7 @@ import {
   decideHardTimeoutAction,
   decidePostHookPromptEvidence,
   decideSettleMarkReady,
+  resolveWriteInputSubmissionMode,
   shouldArmPostHookPromptEvidenceFallback,
   shouldReleaseFirstPromptTimeout,
   shouldWaitForPostSessionStartPromptEvidence,
@@ -64,6 +65,28 @@ describe('shouldWriteNow', () => {
 
   it('queues when the CLI is busy and does not support type-ahead', () => {
     expect(shouldWriteNow({ ...base, supportsTypeAhead: false, awaitingFirstPrompt: false })).toBe(false);
+  });
+});
+
+describe('resolveWriteInputSubmissionMode', () => {
+  it('interrupts only when an interrupting adapter is actually busy', () => {
+    expect(resolveWriteInputSubmissionMode({
+      isPromptReady: false,
+      busyInputBehavior: 'interrupt',
+    })).toBe('interrupt');
+    expect(resolveWriteInputSubmissionMode({
+      isPromptReady: true,
+      busyInputBehavior: 'interrupt',
+    })).toBe('default');
+  });
+
+  it('preserves legacy queue and steer submit keys while busy', () => {
+    for (const busyInputBehavior of [undefined, 'queue', 'steer'] as const) {
+      expect(resolveWriteInputSubmissionMode({
+        isPromptReady: false,
+        busyInputBehavior,
+      })).toBe('default');
+    }
   });
 });
 

--- a/test/worker-queue-merge.test.ts
+++ b/test/worker-queue-merge.test.ts
@@ -205,6 +205,15 @@ describe('durable turn queue boundary', () => {
     expect(shouldStopPendingBatch({ content: 'user 1' }, { content: 'user 2' })).toBe(false);
   });
 
+  it('stops after one input for interrupting adapters so a backlog cannot cascade-cancel', () => {
+    const written = { content: 'interrupt current turn', turnId: 'user-1' };
+    const next = { content: 'must wait for another edge', turnId: 'user-2' };
+
+    expect(shouldStopPendingBatch(written, next, 'interrupt')).toBe(true);
+    expect(shouldStopPendingBatch(written, next, 'queue')).toBe(false);
+    expect(shouldStopPendingBatch(written, next, 'steer')).toBe(false);
+  });
+
   it('does not cross an unresolved durable boundary on a screen-idle edge', () => {
     expect(pendingInputMayFlush(true)).toBe(false);
     expect(pendingInputMayFlush(false)).toBe(true);

--- a/test/worker-structured-lifecycle-status.test.ts
+++ b/test/worker-structured-lifecycle-status.test.ts
@@ -84,6 +84,23 @@ describe('worker structured-turn status wiring', () => {
     expect(adopt.slice(adoptWrite)).not.toContain('idleDetector?.reset();');
   });
 
+  it('captures busy state before re-arming and gives interrupt adapters one write per flush', () => {
+    const flush = functionSlice('flushPending', 'sendToPty');
+    const capture = flush.indexOf('const inputWasPromptReady = isPromptReady');
+    const outerCycle = flush.indexOf('beginCliWriteCycle()', capture);
+    const mode = flush.indexOf('resolveWriteInputSubmissionMode(', outerCycle);
+    const write = flush.indexOf('writeAdapter.writeInput(', mode);
+    const batchStop = flush.indexOf('shouldStopPendingBatch(', write);
+
+    expect(capture).toBeGreaterThanOrEqual(0);
+    expect(outerCycle).toBeGreaterThan(capture);
+    expect(mode).toBeGreaterThan(outerCycle);
+    expect(write).toBeGreaterThan(mode);
+    expect(flush.slice(mode, write)).toContain('inputWasPromptReady');
+    expect(flush.slice(write, batchStop)).toContain('submissionMode');
+    expect(flush.slice(batchStop, batchStop + 180)).toContain('writeAdapter.busyInputBehavior');
+  });
+
   it('uses the same lifecycle-aware projection for periodic and screenshot updates', () => {
     const screenshot = functionSlice('captureAndUpload', 'applyDisplayMode');
     const periodic = functionSlice('startScreenUpdates', 'stopScreenUpdates');


### PR DESCRIPTION
## 问题

Grok 忙态下，普通 `Enter` 的语义是 queue。Botmux 过去只声明 `supportsTypeAhead`，没有区分“PTY 能接收字节”和“忙态提交后究竟 queue / steer / interrupt”，所以用户的新消息会一直等到旧 turn 完成，看起来像无法打断、卡在 Grok queue。

## 改动

- 给 CLI adapter 增加显式的 busy-input 语义，默认不改变任何现有 adapter。
- worker 在重置 ready 状态前保留真实 prompt 状态；仅 Grok 忙态输入选择 `interrupt` submission mode。
- Grok 空闲提交仍用 `Enter`；忙态用官方 `Ctrl+Enter` 的终端稳定别名 `Ctrl+I`（字节 `0x09`）执行 cancel-and-send。
- interrupt adapter 每次 flush 只写一条，避免积压消息连续取消刚启动的新 turn。
- 保留 #865 / #1052 的边界：每次只做“一次 paste + 一次 submit”，绝不恢复裸 Enter 重试。

## 验证

- `vitest` 定向回归：6 files / 564 tests passed。
- `bun run build`：通过（Node 22.23.2、Bun 1.4.1）。
- tmux 实测 `send-keys C-i` 到 PTY 为十进制字节 `9`。
- 全量 unit：21719 passed / 31 failed / 19 skipped。31 个失败均在未修改的环境敏感文件：26 个来自本机 git 2.20 不支持 `git init -b`；其余为本机 PID namespace / Mojo residual / keep-shell 行为。受影响 Grok/worker suite 全绿。
- 隔离 Grok 1.0.13 实机探测未计为通过：当时 Grok 卡在网络 retry / 数据共享提示，没形成稳定的普通 model-active 窗口；没有把这个无效窗口包装成 E2E 成功。

## 历史兼容

- #865：不能把未确认的 queued submit 用裸 Enter 重试成 send-now。
- #1052：正文继续使用 bracketed paste，保持一次 paste + 一次提交键。

## Wiki impact

- **Status: no-impact**
- **Reason:** 不涉及仓库内 domain pack / 对外配置格式；本机 Grok/botmux 运维知识单独记录。

## Risk reflection

- **Reserved-path / shared-state collision**: 不新增文件写路径、命名空间或持久化状态；只扩展 adapter 输入上下文和 worker 的提交选择。
- **Bookkeeping consistency**: pending queue 与 transcript attribution 仍由原有 owner 管理；新增的一条边界只是 interrupt adapter 每次 flush 最多消费一项，不涉及 Write/Edit/Delete/Rename 多视图对象。
- **Blast radius**: 用 `rg 'supportsTypeAhead|writeInput|shouldStopPendingBatch' src test` 枚举调用方；新增字段均为 optional，非 Grok adapter 走 `default`，并由 `cli-adapters`、`input-gate`、`worker-queue-merge`、`worker-structured-lifecycle-status` 覆盖。
- **Reversibility**: 无 schema、迁移或用户数据写入；回滚本 PR 即恢复旧行为。
- **Follow-ups identified**: Web 终端目前只做原始 xterm 字节转发，后续可单独补 Grok “send now” 的显式入口/提示；本 PR 不改 Web UI。
