### PR TITLE
test(codex): 消除 history ownership 用例的时序竞态

### DIFF
--- a/test/codex-adapter-history-ownership.test.ts
+++ b/test/codex-adapter-history-ownership.test.ts
@@ -30,11 +30,6 @@ let prevCodexHome: string | undefined;
 let prevScale: string | undefined;
 let ownerChild: ChildProcessWithoutNullStreams;
 let rolloutB: string;
-/** Deferred timers scheduled by a test's onEnter. writeInput retries Enter, so
- *  onEnter can fire several times; track every timer and clear them in afterEach
- *  so none survives to append to an already-removed home dir (→ uncaught ENOENT
- *  that poisons later tests / fails CI). */
-let pendingTimers: ReturnType<typeof setTimeout>[] = [];
 
 /** A rollout file under `<CODEX_HOME>/sessions/YYYY/MM/DD/rollout-<ts>-<sid>.jsonl`. */
 function rolloutPath(root: string, sid: string): string {
@@ -87,8 +82,6 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-  for (const t of pendingTimers) clearTimeout(t);
-  pendingTimers = [];
   if (ownerChild && !ownerChild.killed) ownerChild.kill('SIGKILL');
   if (home) rmSync(home, { recursive: true, force: true });
   if (prevScale === undefined) delete process.env.BOTMUX_TIME_SCALE; else process.env.BOTMUX_TIME_SCALE = prevScale;
@@ -146,22 +139,24 @@ describe('codex writeInput history ownership filter', () => {
   it('does not wedge when ONLY the foreign line exists yet — waits, then binds B once B lands', async () => {
     const historyPath = join(home, 'history.jsonl');
     const adapter = createCodexAdapter();
-    // On submit only A appears; B's line arrives shortly after (separate tick).
-    // writeInput retries Enter, so guard the deferred B-append one-shot and track
-    // the timer so afterEach can clear it (no append into a removed home dir).
-    let scheduledB = false;
+    // The first Enter only exposes A. Once writeInput has rejected that foreign
+    // match and exhausted its first bounded wait, its retry is the observable
+    // happens-before boundary that publishes B. This preserves the intended
+    // "foreign first, owned later" ordering without racing a wall-clock timer.
+    let enterCount = 0;
     const onEnter = () => {
-      appendFileSync(historyPath, historyLine(SID_A, 'ping'));
-      if (scheduledB) return;
-      scheduledB = true;
-      pendingTimers.push(setTimeout(() => {
-        try { appendFileSync(historyPath, historyLine(SID_B, 'ping')); } catch { /* home may be gone if test already resolved */ }
-      }, 20));
+      enterCount += 1;
+      if (enterCount === 1) {
+        appendFileSync(historyPath, historyLine(SID_A, 'ping'));
+      } else if (enterCount === 2) {
+        appendFileSync(historyPath, historyLine(SID_B, 'ping'));
+      }
     };
 
     const result = await adapter.writeInput!(fakePty(ownerChild.pid!, onEnter), 'ping');
     // Must NOT have taken A; must eventually bind B (not a permanent no-match).
     expect((result as any)?.cliSessionId).toBe(SID_B);
+    expect(enterCount).toBe(2);
   });
 
   it('with NO pid, preserves accept-first semantics (single-pane / pid-less callers unchanged)', async () => {


### PR DESCRIPTION
## 背景

`codex-adapter-history-ownership` 的相关用例通过固定 20ms 定时器写入 owned history 行。在 CI 负载较高时，定时器可能落到 adapter 的缩短等待窗口之外，导致同一代码出现 `Received: undefined` 的间歇失败。

Fixes #1291

## 修改

- 第一次 Enter 只写入 foreign session A，保留拒绝非 owner history 行的场景。
- 以 adapter 首轮等待结束后的第二次 Enter 作为可观察的 happens-before 边界，再同步写入 owned session B。
- 移除全局定时器及清理状态，并断言总计发生两次 Enter，确保 A 未被提前接纳且 B 能稳定绑定。

## 影响范围

仅修改 `test/codex-adapter-history-ownership.test.ts`，不改变生产代码或运行时行为。

## 验证

- `node_modules/.bin/vitest run --project unit test/codex-adapter-history-ownership.test.ts`：5/5 通过。
- 上述目标测试连续运行 10 次：10/10 通过。
- `node_modules/.bin/tsc --noEmit --pretty false`：通过。
- `git diff --check`：通过。

> 当前本地环境未安装 Bun，因此未执行 `bun run build`；仓库 CI 将覆盖 Bun 相关验证。