### PR TITLE
fix(terminal-proxy): 等待响应发送完成后关闭连接

### DIFF
--- a/src/core/terminal-proxy.ts
+++ b/src/core/terminal-proxy.ts
@@ -199,7 +199,11 @@ export function startTerminalProxy(opts: TerminalProxyOptions): Promise<Terminal
           upstream.destroy();
         });
         client.on('error', cleanup);
-        upstream.on('close', () => client.destroy());
+        upstream.on('close', () => {
+          // pipe() ends the client after a clean EOF. Let pending writes drain
+          // before closing it, or the HTTP response tail can be truncated.
+          if (!upstream.readableEnded) client.destroy();
+        });
         client.on('close', () => upstream.destroy());
       }).catch(() => {
         if (!client.destroyed) writeHttpError(client, 502, 'Bad Gateway', 'proxy error');

--- a/test/terminal-proxy-drain.test.ts
+++ b/test/terminal-proxy-drain.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { connect, createServer, Server, type Socket } from 'node:net';
+import { startTerminalProxy, type TerminalProxyHandle } from '../src/core/terminal-proxy.js';
+
+describe('terminal proxy response drain', () => {
+  it('delivers the complete chunked response before closing a slow client', async () => {
+    const body = '<html>' + 'x'.repeat(90_000) + '<script>ready()</script></html>';
+    const response = Buffer.from(
+      'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n'
+      + 'Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n'
+      + Buffer.byteLength(body).toString(16) + '\r\n' + body + '\r\n0\r\n\r\n',
+    );
+    const sockets = new Set<Socket>();
+    const timers = new Set<ReturnType<typeof setTimeout>>();
+    let proxy: TerminalProxyHandle | undefined;
+    const worker = createServer(socket => {
+      sockets.add(socket);
+      socket.on('error', () => {});
+      socket.once('data', () => socket.end(response));
+    });
+
+    // Delay only the proxy's downstream writes. The real upstream can finish
+    // while the browser still has response bytes queued, as on a slow link.
+    const emit = Server.prototype.emit;
+    const emitSpy = vi.spyOn(Server.prototype, 'emit').mockImplementation(function (
+      this: Server, event: string | symbol, ...args: unknown[]
+    ) {
+      if (event === 'connection') {
+        const socket = args[0] as Socket;
+        if (socket.localPort === proxy?.port) {
+          sockets.add(socket);
+          const write = socket._write;
+          const writev = socket._writev!;
+          const later = (run: () => void) => {
+            const timer = setTimeout(() => { timers.delete(timer); run(); }, 30);
+            timers.add(timer);
+          };
+          socket._write = (chunk, encoding, callback) => later(() => write.call(socket, chunk, encoding, callback));
+          socket._writev = (chunks, callback) => later(() => writev.call(socket, chunks, callback));
+        }
+      }
+      return emit.call(this, event, ...args);
+    });
+
+    try {
+      await new Promise<void>(resolve => worker.listen(0, '127.0.0.1', resolve));
+      const workerPort = (worker.address() as { port: number }).port;
+      proxy = await startTerminalProxy({ port: 0, host: '127.0.0.1', resolvePort: () => workerPort });
+      const received = await new Promise<Buffer>((resolve, reject) => {
+        const client = connect(proxy!.port, '127.0.0.1', () => {
+          client.write('GET /s/session/?viewToken=view HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n');
+        });
+        sockets.add(client);
+        const chunks: Buffer[] = [];
+        const timeout = setTimeout(() => {
+          client.destroy();
+          reject(new Error('proxy did not finish and close the response'));
+        }, 3_000);
+        client.on('data', chunk => chunks.push(chunk));
+        client.on('error', reject);
+        client.on('close', () => {
+          clearTimeout(timeout);
+          resolve(Buffer.concat(chunks));
+        });
+      });
+      // Includes both the final inline script and the chunked end marker.
+      expect(received.equals(response)).toBe(true);
+    } finally {
+      emitSpy.mockRestore();
+      for (const timer of timers) clearTimeout(timer);
+      for (const socket of sockets) socket.destroy();
+      await proxy?.close();
+      await new Promise<void>(resolve => worker.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
远端浏览器打开会话 Web 终端时，如果 worker 已结束响应而代理仍有待发送字节，代理会提前销毁浏览器连接，导致 HTML 尾部和分块结束标记丢失，页面报 `ERR_INCOMPLETE_CHUNKED_ENCODING` 并停在 `connecting...`。

本次仅调整 `terminal-proxy` 的连接收尾：正常 EOF 交给 `pipe()` 完成发送并关闭；异常关闭继续销毁连接。新增使用真实 TCP 连接的回归测试，延迟下游发送并断言整个 chunked 响应完整到达。

影响范围为经过每个 daemon `/s/{sessionId}` 代理的 Web 终端，覆盖不同 CLI、读写链接和会话类型；改动不依赖操作系统或 CLI 适配器。

验证：

- 回归测试在旧代码的 Node 22.22.0 和 Bun 1.4.1 上均失败，修复后通过。
- `node node_modules/vitest/vitest.mjs run --project unit test/terminal-proxy.test.ts test/terminal-proxy-drain.test.ts`：26/26 通过（Node / Vitest）。
- Bun 1.4.1 分别执行以上两个测试文件：26/26 通过，含 HTTP 路由、keep-alive 隔离、读写凭据转发、WebSocket 和按需唤醒。
- `bun run build`：通过。
- 使用 Bun 1.4.1 编译 Linux x64 独立二进制，`node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64`：全部通过。
- 已部署基于 v3.19.1 的本机修复构建。服务器浏览器的 OpenCode、Codex 终端均显示 `connected` 并收到数据；Mac 端已人工确认原终端链接恢复访问。
