### PR TITLE
fix(pm2): 修复编译态只读客户端入口

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13383,6 +13383,9 @@ if (__entrySubcommand) {
   else if (__entrySubcommand === 'dsh-runner') await import('./dsh-runner.js');
   else if (__entrySubcommand === 'mira-runner') await import('./mira-runner.js');
   else if (__entrySubcommand === 'mir-runner') await import('./mir-runner.js');
+  // Internal helper: importing the top-level script executes its read-only PM2
+  // observer. Keep this static so Bun includes it in the compiled module graph.
+  else if (__entrySubcommand === 'pm2-readonly-client') await import('./cli/pm2-readonly-client.js');
   // The entry module now drives the process (top-level main() keeps the event
   // loop alive for the daemon; the worker's IPC listener does the same; a
   // core-only bind failure exits from within). Park here so the normal dispatch

--- a/src/cli/pm2-readonly.ts
+++ b/src/cli/pm2-readonly.ts
@@ -2,10 +2,14 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { LinuxPm2GodProcess } from '../core/pm2-lifecycle-owner.js';
+import { isStandaloneBinary, subcommandForEntry } from '../core/self-spawn.js';
 
 const ABSENT_EXIT_CODE = 3;
 
-function helperArgs(pkgRoot: string, modeArgs: string[]): string[] {
+export function helperArgs(pkgRoot: string, modeArgs: string[]): string[] {
+  if (isStandaloneBinary()) {
+    return [subcommandForEntry('pm2-readonly-client'), ...modeArgs];
+  }
   const built = join(pkgRoot, 'dist', 'cli', 'pm2-readonly-client.js');
   if (import.meta.url.includes('/dist/cli/pm2-readonly.js') && existsSync(built)) {
     return [built, ...modeArgs];

--- a/src/core/self-spawn.ts
+++ b/src/core/self-spawn.ts
@@ -33,7 +33,10 @@ export type BotmuxEntry =
   // an adapter spawns one as the CLI session itself (`resolvedBin` is
   // process.execPath and the runner is argv[0]). They need the same treatment for
   // the same reason — see RUNNER_ENTRIES below.
-  | 'codex-app-runner' | 'dsh-runner' | 'mira-runner' | 'mir-runner';
+  | 'codex-app-runner' | 'dsh-runner' | 'mira-runner' | 'mir-runner'
+  // Internal helpers are neither fleet processes nor CLI session runners, but
+  // still need a hidden self-spawn entry in the standalone binary.
+  | 'pm2-readonly-client';
 
 /** Hidden CLI subcommand that runs a given entry inline (see cli.ts dispatch). */
 const ENTRY_SUBCOMMAND: Record<BotmuxEntry, string> = {
@@ -46,6 +49,7 @@ const ENTRY_SUBCOMMAND: Record<BotmuxEntry, string> = {
   'dsh-runner': '__dsh-runner',
   'mira-runner': '__mira-runner',
   'mir-runner': '__mir-runner',
+  'pm2-readonly-client': '__pm2-readonly-client',
 };
 
 /** dist/<entry>.js filename for the Node path. */
@@ -59,6 +63,7 @@ const ENTRY_SCRIPT: Record<BotmuxEntry, string> = {
   'dsh-runner': 'dsh-runner.js',
   'mira-runner': 'mira-runner.js',
   'mir-runner': 'mir-runner.js',
+  'pm2-readonly-client': 'cli/pm2-readonly-client.js',
 };
 
 /**
@@ -80,6 +85,11 @@ const ENTRY_SCRIPT: Record<BotmuxEntry, string> = {
  */
 export const RUNNER_ENTRIES: readonly BotmuxEntry[] = [
   'codex-app-runner', 'dsh-runner', 'mira-runner', 'mir-runner',
+] as const;
+
+/** Internal subprocess helpers that are not user-facing CLI session runners. */
+export const INTERNAL_HELPER_ENTRIES: readonly BotmuxEntry[] = [
+  'pm2-readonly-client',
 ] as const;
 
 /**
@@ -170,6 +180,11 @@ export function resolveCliSpawn(
 
 /** The set of hidden subcommand tokens, so the CLI dispatcher can recognize them. */
 export const ENTRY_SUBCOMMANDS: ReadonlySet<string> = new Set(Object.values(ENTRY_SUBCOMMAND));
+
+/** Map an entry to the hidden subcommand used for standalone self-spawn. */
+export function subcommandForEntry(entry: BotmuxEntry): string {
+  return ENTRY_SUBCOMMAND[entry];
+}
 
 /**
  * The hidden token a compiled binary is launched with to become a worker, i.e.

--- a/test/pm2-readonly-compiled-entry.test.ts
+++ b/test/pm2-readonly-compiled-entry.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The read-only PM2 observer must be launchable from both Botmux shapes.
+ *
+ * Under Node, the child receives the existing on-disk helper path. A Bun
+ * standalone binary has no usable dist/ path outside /$bunfs/, so it must
+ * re-exec itself with a hidden token that cli.ts dispatches via static import.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { helperArgs } from '../src/cli/pm2-readonly.js';
+import {
+  ENTRY_SUBCOMMANDS,
+  INTERNAL_HELPER_ENTRIES,
+  RUNNER_ENTRIES,
+  entryForSubcommand,
+  resolveEntrySpawn,
+  subcommandForEntry,
+} from '../src/core/self-spawn.js';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const REAL_ARGV1 = process.argv[1];
+
+function asCompiledBinary(): void {
+  process.argv[1] = '/$bunfs/root/cli.js';
+}
+
+afterEach(() => {
+  process.argv[1] = REAL_ARGV1;
+});
+
+describe('PM2 read-only helper entry', () => {
+  it('uses the mapped hidden token in the compiled form and emits no file path', () => {
+    asCompiledBinary();
+    const modeArgs = ['logs', 'data-mcp', '50'];
+    const args = helperArgs('/ignored/pkg-root', modeArgs);
+
+    // This assertion pins the call site to the mapping as its source of truth;
+    // the mapping's literal token value is pinned separately below.
+    expect(args).toEqual([subcommandForEntry('pm2-readonly-client'), ...modeArgs]);
+    expect(args.every(arg => !String(arg).includes('/'))).toBe(true);
+  });
+
+  it('preserves the existing Node tsx fallback argv, including the helper path', () => {
+    const pkgRoot = '/opt/botmux checkout';
+    const modeArgs = ['status'];
+    const args = helperArgs(pkgRoot, modeArgs);
+
+    // Vitest imports the source module, so import.meta.url cannot select the
+    // built-dist branch. That branch remains for build/artifact-level validation.
+    expect(args).toEqual([
+      '--import',
+      'tsx',
+      join(pkgRoot, 'src', 'cli', 'pm2-readonly-client.ts'),
+      ...modeArgs,
+    ]);
+    expect(args[2]).toContain('/src/cli/pm2-readonly-client.ts');
+  });
+
+  it('resolves the helper under the cli subdirectory in the Node dist form', () => {
+    const distDir = '/opt/botmux/dist';
+
+    expect(resolveEntrySpawn('pm2-readonly-client', distDir)).toEqual({
+      command: process.execPath,
+      args: [join(distDir, 'cli', 'pm2-readonly-client.js')],
+    });
+  });
+
+  it('wires the helper token through the inverse map and a static CLI import', () => {
+    const entry = INTERNAL_HELPER_ENTRIES[0];
+    const token = subcommandForEntry(entry);
+    const cliSource = readFileSync(resolve(REPO_ROOT, 'src', 'cli.ts'), 'utf8');
+
+    expect([...INTERNAL_HELPER_ENTRIES]).toEqual(['pm2-readonly-client']);
+    expect(token).toBe('__pm2-readonly-client');
+    expect(ENTRY_SUBCOMMANDS.has(token)).toBe(true);
+    expect(entryForSubcommand(token)).toBe(entry);
+    expect(cliSource).toContain("__entrySubcommand === 'pm2-readonly-client'");
+    expect(cliSource).toContain("await import('./cli/pm2-readonly-client.js')");
+  });
+
+  it('does not expand the session-runner collection', () => {
+    expect(RUNNER_ENTRIES.length).toBe(4);
+    expect([...RUNNER_ENTRIES]).toEqual([
+      'codex-app-runner',
+      'dsh-runner',
+      'mira-runner',
+      'mir-runner',
+    ]);
+  });
+});


### PR DESCRIPTION
## 改动内容

- 为 `pm2-readonly-client` 增加独立的内部 helper self-spawn entry，并保持 `RUNNER_ENTRIES` 仍只包含四个会话 runner。
- 编译态下让只读 PM2 helper 通过隐藏子命令 re-exec 当前二进制；Node 形态继续沿用现有 built/tsx 路径。
- 在 CLI 隐藏入口分发中使用静态字面量 import，确保 Bun 编译时包含 helper 模块。
- 增加回归测试，覆盖编译态 token、Node tsx fallback、Node dist 子目录、双向映射、CLI 分发与 runner 集合边界。

## 为什么改

源码层检查确认，`v3.18.14@851ddd5f` 与 `deploy/all@d711dd2c` 中的 `pm2-readonly-client` 均未接入编译态安全的 hidden self-spawn 机制。编译态继续使用模块相对路径与 `process.execPath` re-exec 时，存在进入普通 CLI 分发而得到 help 输出、没有可解析 PM2 JSON 的风险；这与已观测到的 `pm2_jlist_json_not_found` 现象一致。

本次没有在真实编译产物上做执行级复现，因此不将现场根因表述为已定位，也不宣称修复了某次线上故障。

## 影响范围

- 影响使用受影响编译态版本、且执行到 plugin-service 只读 PM2 helper 路径的场景。
- Node 形态的现有 built/tsx 选择逻辑及显式 `nodePath` 调用方式保持不变。
- `RUNNER_ENTRIES` 有精确四项断言和 “must not quietly grow” 护栏，语义只承载会话 runner；因此内部 PM2 helper 使用单独集合，不扩大会话 runner 范围。
- 不涉及依赖、锁文件、安装入口、运行中进程或配置变更。

## 验证

- `PATH="$HOME/.bun/bin:$PATH" ./node_modules/.bin/tsc --noEmit`：通过。
- 新增测试：`1 file / 5 tests passed`。
- 定向改前基线：`2 failed / 347 passed / 10 skipped`；改后同集合：`2 failed / 352 passed / 10 skipped`。程序化逐用例比对只新增本 PR 的 5 条通过状态；两条既有失败同名同数量保持。
- 四次变异验证分别删除 standalone 分支、写死错误 token、删除 subcommand 映射、删除 dist 路径的 `cli/` 前缀；每次均只新增对应的一条测试失败。
- `git diff --check` 与 staged diff check：通过。

## 覆盖限制

`test/pm2-existing-client.test.ts` 是现有直接运行 PM2 helper 调用面的 Linux-only 测试，在本次 macOS 自测中整文件跳过。因此本机对改动点的直接运行覆盖全部来自新增测试；既有 PM2 客户端路径需由 PR 的 Linux CI job 验证。

本次也未构建或运行真实 standalone 产物，产物级回归以 CI/后续专门验证结果为准。
