### PR TITLE
fix(dashboard): 下拉弹层限高改按裁剪祖先计算，长列表不再被面板裁掉

### DIFF
--- a/src/dashboard/web/dashboard-components.tsx
+++ b/src/dashboard/web/dashboard-components.tsx
@@ -489,23 +489,38 @@ export function dropdownPlacement(input: {
  * the popup. Should a popup ever be re-parented out of the menu, or the menu
  * be made `position: static`, this walk would need the containing block
  * checked per ancestor rather than assumed.
+ *
+ * Two distinct things happen at a `position: fixed` ancestor, and conflating
+ * them drops a real clipper: boxes *above* it stop applying, but the fixed box
+ * *itself* still crops its own descendants — a `<dialog>` opened with
+ * `showModal()` is exactly that (the UA stylesheet makes it fixed, and the
+ * dashboard's modals add their own `overflow`). So record it, then stop.
  */
 function clippingAncestorBoxes(el: HTMLElement): { top: number; bottom: number }[] {
   const boxes: { top: number; bottom: number }[] = [];
   for (let node = el.parentElement; node && node !== document.documentElement; node = node.parentElement) {
     const style = window.getComputedStyle(node);
-    // A `fixed` box is positioned against the viewport, so overflow boxes above
-    // it in the tree do not crop it (verified in Chromium: a popup inside a
-    // `position: fixed` panel stays visible and hit-testable well outside an
-    // `overflow: hidden` grandparent). Stop here or a modal/panel would be
-    // budgeted against a container it visibly escapes.
-    if (style.position === 'fixed') break;
     // `clip`/`hidden`/`auto`/`scroll` all crop; only `visible` lets the popup out.
     // A single axis is enough: `overflow-x: hidden` forces the other axis to a
     // scrolling value too, so reading both keeps mixed pairs from slipping past.
-    if (style.overflowY === 'visible' && style.overflowX === 'visible') continue;
-    const box = node.getBoundingClientRect();
-    boxes.push({ top: box.top, bottom: box.bottom });
+    const crops = !(style.overflowY === 'visible' && style.overflowX === 'visible');
+    if (crops) {
+      const box = node.getBoundingClientRect();
+      boxes.push({ top: box.top, bottom: box.bottom });
+    }
+    // A `fixed` box is positioned against the viewport, so overflow boxes above
+    // it in the tree do not crop it (verified in Chromium: a popup inside a
+    // `position: fixed` panel stays visible and hit-testable well outside an
+    // `overflow: hidden` grandparent). Stop, or a modal would be budgeted
+    // against a container it visibly escapes.
+    //
+    // Its own box is already recorded above but rarely changes the outcome:
+    // popupClipFrame starts from the viewport and a fixed box cannot leave it,
+    // so the viewport clamp usually supplies the same bound (measured on the
+    // dashboard's four modal dropdowns: at most 6px tighter, well under the
+    // 140px floor). Recorded anyway so the frame stays correct if a modal ever
+    // drops the inner scroll container that currently does the cropping.
+    if (style.position === 'fixed') break;
   }
   return boxes;
 }

--- a/src/dashboard/web/dashboard-components.tsx
+++ b/src/dashboard/web/dashboard-components.tsx
@@ -396,14 +396,49 @@ type DropdownMenuProps<T extends string> = {
 };
 
 /**
+ * The band a popup has to stay inside, in viewport coordinates.
+ *
+ * The screen edge is not the only thing that crops a popup: every ancestor with
+ * a non-`visible` overflow crops it too, and such a box is often far smaller
+ * than the viewport. `.roles-profile-apply` (角色管理 → Profiles → 应用到群组)
+ * is one — `max-height: 34%; overflow: auto` — so a popup budgeted against
+ * `window.innerHeight` believed it had ~635px above the trigger when the panel
+ * only showed ~290px, flipped up, and left a single group row reachable.
+ *
+ * Overshooting the TOP edge of such a box is unrecoverable: an overflow
+ * container scrolls towards its content, never above it, so those options can
+ * be neither seen nor clicked. Intersecting the ancestors' boxes with the
+ * viewport gives the placement maths a frame that reflects what is really on
+ * screen.
+ *
+ * Pure function of the geometry so it can be unit-tested without a DOM.
+ */
+export function popupClipFrame(input: {
+  viewportHeight: number;
+  /** Border boxes of the clipping ancestors; order does not matter. */
+  clippers: { top: number; bottom: number }[];
+}): { top: number; bottom: number } {
+  let top = 0;
+  let bottom = input.viewportHeight;
+  for (const box of input.clippers) {
+    top = Math.max(top, box.top);
+    bottom = Math.min(bottom, box.bottom);
+  }
+  // An ancestor scrolled entirely off screen inverts the band; collapse it
+  // instead of handing negative geometry to the caller (the height floor in
+  // dropdownPlacement then keeps the popup usable).
+  return { top, bottom: Math.max(top, bottom) };
+}
+
+/**
  * Where a dropdown popup should go, and how tall it may be.
  *
  * A dropdown's ancestors are mostly `overflow: hidden` (main / .chrome-body /
- * .app-shell), so a popup hanging past the viewport edge is clipped away: those
- * options cannot be seen, and pointer/wheel events never reach them either
- * (the popup is not under the cursor down there). Plain CSS cannot know how
- * much room is left below the trigger, so the component measures it and hands
- * the budget to style.css as a custom property.
+ * .app-shell), so a popup hanging past the edge of the frame is clipped away:
+ * those options cannot be seen, and pointer/wheel events never reach them
+ * either (the popup is not under the cursor down there). Plain CSS cannot know
+ * how much room is left below the trigger, so the component measures it and
+ * hands the budget to style.css as a custom property.
  *
  * Pure function of the geometry so it can be unit-tested without a DOM.
  */
@@ -415,6 +450,13 @@ export function dropdownPlacement(input: {
   naturalHeight: number;
   viewportHeight: number;
   /**
+   * Visible band from popupClipFrame. Defaults to the whole viewport, which is
+   * the right frame only when nothing between the trigger and the screen edge
+   * clips — pass the measured band whenever a DOM is available.
+   */
+  frameTop?: number;
+  frameBottom?: number;
+  /**
    * Size for this direction instead of deciding one. Used when a per-page rule
    * pins the direction with higher specificity than the `.is-drop-up` class, so
    * the budget must match what actually rendered rather than what we asked for.
@@ -423,8 +465,10 @@ export function dropdownPlacement(input: {
 }): { dropUp: boolean; maxHeight: number } {
   const margin = 12;
   const gap = 8;
-  const roomBelow = input.viewportHeight - input.triggerBottom - gap - margin;
-  const roomAbove = input.triggerTop - gap - margin;
+  const frameTop = input.frameTop ?? 0;
+  const frameBottom = input.frameBottom ?? input.viewportHeight;
+  const roomBelow = frameBottom - input.triggerBottom - gap - margin;
+  const roomAbove = input.triggerTop - frameTop - gap - margin;
   // Flip up only when below genuinely cannot fit AND above is roomier;
   // otherwise stay below (predictable) and just cap the height.
   const dropUp = input.forceDropUp ?? (input.naturalHeight > roomBelow && roomAbove > roomBelow);
@@ -432,6 +476,38 @@ export function dropdownPlacement(input: {
   // worse than a popup that slightly overhangs but is still scrollable.
   const maxHeight = Math.max(140, Math.floor(dropUp ? roomAbove : roomBelow));
   return { dropUp, maxHeight };
+}
+
+/**
+ * Border boxes of the ancestors that crop `el`, nearest first.
+ *
+ * An `overflow` box does not clip an absolutely positioned descendant whose
+ * containing block sits *above* that box — which is how a popup sometimes
+ * escapes one. Here it never does: the popup's containing block is its own
+ * `.sect-sort-menu` (`position: relative`, style.css), so every non-`visible`
+ * overflow box further up encloses that containing block and genuinely crops
+ * the popup. Should a popup ever be re-parented out of the menu, or the menu
+ * be made `position: static`, this walk would need the containing block
+ * checked per ancestor rather than assumed.
+ */
+function clippingAncestorBoxes(el: HTMLElement): { top: number; bottom: number }[] {
+  const boxes: { top: number; bottom: number }[] = [];
+  for (let node = el.parentElement; node && node !== document.documentElement; node = node.parentElement) {
+    const style = window.getComputedStyle(node);
+    // A `fixed` box is positioned against the viewport, so overflow boxes above
+    // it in the tree do not crop it (verified in Chromium: a popup inside a
+    // `position: fixed` panel stays visible and hit-testable well outside an
+    // `overflow: hidden` grandparent). Stop here or a modal/panel would be
+    // budgeted against a container it visibly escapes.
+    if (style.position === 'fixed') break;
+    // `clip`/`hidden`/`auto`/`scroll` all crop; only `visible` lets the popup out.
+    // A single axis is enough: `overflow-x: hidden` forces the other axis to a
+    // scrolling value too, so reading both keeps mixed pairs from slipping past.
+    if (style.overflowY === 'visible' && style.overflowX === 'visible') continue;
+    const box = node.getBoundingClientRect();
+    boxes.push({ top: box.top, bottom: box.bottom });
+  }
+  return boxes;
 }
 
 export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): React.JSX.Element {
@@ -470,12 +546,22 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
       const pop = popRef.current;
       if (!details || !pop) return;
       const trigger = details.getBoundingClientRect();
-      const { dropUp, maxHeight } = dropdownPlacement({
+      // Walk from the popup, so the <details> that wraps it is itself checked:
+      // nothing sets overflow on `.sect-sort-menu` today, but a page-level rule
+      // that did would clip the popup, and starting at the trigger would miss it.
+      const frame = popupClipFrame({
+        viewportHeight: window.innerHeight,
+        clippers: clippingAncestorBoxes(pop),
+      });
+      const geometry = {
         triggerTop: trigger.top,
         triggerBottom: trigger.bottom,
         naturalHeight: pop.scrollHeight,
         viewportHeight: window.innerHeight,
-      });
+        frameTop: frame.top,
+        frameBottom: frame.bottom,
+      };
+      const { dropUp, maxHeight } = dropdownPlacement(geometry);
       details.classList.toggle('is-drop-up', dropUp);
       // A per-page rule may pin the direction regardless of the class — e.g.
       // `.connector-create-modal #cn-verify .sect-sort-pop` sets `bottom` with
@@ -490,13 +576,7 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): Rea
       const renderedUp = popBox.height > 0 && popBox.bottom <= trigger.top + 1;
       const effective = renderedUp === dropUp
         ? maxHeight
-        : dropdownPlacement({
-          triggerTop: trigger.top,
-          triggerBottom: trigger.bottom,
-          naturalHeight: pop.scrollHeight,
-          viewportHeight: window.innerHeight,
-          forceDropUp: renderedUp,
-        }).maxHeight;
+        : dropdownPlacement({ ...geometry, forceDropUp: renderedUp }).maxHeight;
       pop.style.setProperty('--dropdown-popover-space', `${effective}px`);
     };
     const frame = window.requestAnimationFrame(place);

--- a/src/dashboard/web/dashboard-components.tsx
+++ b/src/dashboard/web/dashboard-components.tsx
@@ -514,12 +514,15 @@ function clippingAncestorBoxes(el: HTMLElement): { top: number; bottom: number }
     // `overflow: hidden` grandparent). Stop, or a modal would be budgeted
     // against a container it visibly escapes.
     //
-    // Its own box is already recorded above but rarely changes the outcome:
-    // popupClipFrame starts from the viewport and a fixed box cannot leave it,
-    // so the viewport clamp usually supplies the same bound (measured on the
-    // dashboard's four modal dropdowns: at most 6px tighter, well under the
-    // 140px floor). Recorded anyway so the frame stays correct if a modal ever
-    // drops the inner scroll container that currently does the cropping.
+    // Its own box is already recorded above. On today's four modal dropdowns
+    // that changes the frame by at most a few pixels — but only because each of
+    // them also has an inner scroll container, clamped to roughly the same
+    // height, that was recorded before we got here. The viewport does not
+    // supply that bound: a fixed box centred in a taller viewport sits strictly
+    // inside it (measured: a 219-380 dialog against a 0-599 viewport), so the
+    // clamp contributes nothing. Drop the inner container from such a modal and
+    // skipping this box would over-budget the popup by ~200px, straight back to
+    // the overshoot this whole walk exists to prevent.
     if (style.position === 'fixed') break;
   }
   return boxes;

--- a/test/dashboard-dropdown-viewport.test.ts
+++ b/test/dashboard-dropdown-viewport.test.ts
@@ -219,4 +219,27 @@ describe('dropdown popup respects clipping ancestors, not just the viewport', ()
     expect(source).toMatch(/frameTop: frame\.top/);
     expect(source).toMatch(/frameBottom: frame\.bottom/);
   });
+
+  it('records a fixed ancestor own box before stopping at it', () => {
+    // `showModal()` makes a <dialog> `position: fixed` via the UA stylesheet, and
+    // the dashboard's modals add their own overflow, so the stopping node is
+    // itself a clipper. Breaking before the push would drop it: today the
+    // viewport clamp hides that (a fixed box cannot leave the viewport), but a
+    // modal that dropped its inner scroll container would silently regress.
+    const source = readFileSync(new URL('../src/dashboard/web/dashboard-components.tsx', import.meta.url), 'utf8');
+    const walk = source.slice(
+      source.indexOf('function clippingAncestorBoxes'),
+      source.indexOf('export function DropdownMenu'));
+    expect(walk).not.toBe('');
+    const pushAt = walk.indexOf('boxes.push(');
+    const breakAt = walk.indexOf("if (style.position === 'fixed') break;");
+    expect(pushAt).toBeGreaterThan(-1);
+    expect(breakAt).toBeGreaterThan(-1);
+    // Order is the whole point: record, then stop.
+    expect(pushAt).toBeLessThan(breakAt);
+    // And the push must not be nested under the fixed check (which would make
+    // the ordering vacuous) — it is gated on cropping only.
+    expect(walk).toMatch(/const crops = !\(style\.overflowY === 'visible' && style\.overflowX === 'visible'\);/);
+    expect(walk).toMatch(/if \(crops\) \{/);
+  });
 });

--- a/test/dashboard-dropdown-viewport.test.ts
+++ b/test/dashboard-dropdown-viewport.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-import { dropdownPlacement } from '../src/dashboard/web/dashboard-components.js';
+import { dropdownPlacement, popupClipFrame } from '../src/dashboard/web/dashboard-components.js';
 
 function style(): string {
   return readFileSync(new URL('../src/dashboard/web/style.css', import.meta.url), 'utf8');
@@ -131,5 +131,92 @@ describe('dropdown popup stays inside the viewport', () => {
 
   it('has a drop-up rule for the flipped state', () => {
     expect(style()).toMatch(/\.sect-sort-menu\.is-drop-up\s*>\s*\.sect-sort-pop\s*\{[^}]*bottom:\s*calc\(100% \+ 8px\)/);
+  });
+});
+
+/**
+ * Regression cover for「角色管理 Profiles 页看不到别的群」: the 应用到群组 dropdown
+ * sits inside `.roles-profile-apply`, a `max-height: 34%; overflow: auto` panel.
+ * Budgeting against `window.innerHeight` measured ~635px of room above a trigger
+ * whose panel only showed ~290px, so the popup flipped up and out of the panel:
+ * in a 1400x900 Chromium repro only 1 of 24 groups was hit-testable, and
+ * scrolling the popup reached just 17 — an overflow container scrolls towards
+ * its content, never above it, so the rest could not be brought back.
+ */
+describe('dropdown popup respects clipping ancestors, not just the viewport', () => {
+  it('intersects every clipping ancestor into the visible band', () => {
+    const frame = popupClipFrame({
+      viewportHeight: 900,
+      clippers: [
+        { top: 615, bottom: 907 }, // .roles-profile-apply — the short panel
+        { top: 28, bottom: 928 },  // .roles-page
+        { top: 0, bottom: 900 },   // .app-shell
+      ],
+    });
+    // Tightest top and tightest bottom win, so the band is the panel clamped
+    // to the viewport — not the panel's own 907 bottom, nor the full 0-900.
+    expect(frame).toEqual({ top: 615, bottom: 900 });
+  });
+
+  it('falls back to the whole viewport when nothing clips', () => {
+    expect(popupClipFrame({ viewportHeight: 720, clippers: [] })).toEqual({ top: 0, bottom: 720 });
+  });
+
+  it('collapses rather than inverting when an ancestor is scrolled off screen', () => {
+    // bottom above top would otherwise hand negative room to the placement maths.
+    const frame = popupClipFrame({ viewportHeight: 900, clippers: [{ top: 700, bottom: 200 }] });
+    expect(frame.bottom).toBeGreaterThanOrEqual(frame.top);
+  });
+
+  it('stops flipping up into a panel that cannot show the popup', () => {
+    // The reported geometry: trigger inside .roles-profile-apply (615..907),
+    // 24 groups wanting 920px. Viewport-only maths saw 635px "above" and flipped.
+    const geometry = { triggerTop: 671, triggerBottom: 707, naturalHeight: 920, viewportHeight: 900 };
+    const viewportOnly = dropdownPlacement(geometry);
+    expect(viewportOnly.dropUp).toBe(true);
+    expect(viewportOnly.maxHeight).toBe(651);
+
+    const clipped = dropdownPlacement({ ...geometry, frameTop: 615, frameBottom: 900 });
+    // Only ~36px usable above the trigger inside the panel, ~173px below, so
+    // staying below is the reachable side.
+    expect(clipped.dropUp).toBe(false);
+    // And the budget must fit the panel, not the viewport.
+    expect(clipped.maxHeight).toBeLessThan(viewportOnly.maxHeight);
+    expect(clipped.maxHeight).toBeLessThanOrEqual(900 - 707);
+  });
+
+  it('measures room above from the frame top, not the screen top', () => {
+    // Trigger low in the viewport but near the top of its scroll panel: the
+    // space above belongs to the panel's ancestors, not to this popup.
+    const geometry = { triggerTop: 600, triggerBottom: 640, naturalHeight: 800, viewportHeight: 900 };
+    const unclipped = dropdownPlacement(geometry);
+    const clipped = dropdownPlacement({ ...geometry, frameTop: 560, frameBottom: 900 });
+    expect(unclipped.dropUp).toBe(true);       // 580 above vs 240 below
+    expect(clipped.dropUp).toBe(false);        // only 20 above once the panel is honoured
+    expect(clipped.maxHeight).toBe(240);
+  });
+
+  it('keeps the sliver floor when a panel is smaller than the floor', () => {
+    const placement = dropdownPlacement({
+      triggerTop: 300, triggerBottom: 340, naturalHeight: 600,
+      viewportHeight: 900, frameTop: 290, frameBottom: 400,
+    });
+    // 400-340-20 = 40px of real room; the floor keeps it scrollable instead of
+    // rendering a few unusable pixels.
+    expect(placement.maxHeight).toBe(140);
+  });
+
+  it('walks the popup ancestry from the popup and stops at a fixed ancestor', () => {
+    const source = readFileSync(new URL('../src/dashboard/web/dashboard-components.tsx', import.meta.url), 'utf8');
+    // Starting the walk at the <details> would skip the menu itself, which a
+    // per-page overflow rule could turn into a clipper.
+    expect(source).toMatch(/clippingAncestorBoxes\(pop\)/);
+    // A `position: fixed` panel is laid out against the viewport, so overflow
+    // boxes above it do not crop it; treating them as clippers would shrink
+    // every modal dropdown to a container it visibly escapes.
+    expect(source).toMatch(/style\.position === 'fixed'/);
+    // The measured band must actually reach the placement maths.
+    expect(source).toMatch(/frameTop: frame\.top/);
+    expect(source).toMatch(/frameBottom: frame\.bottom/);
   });
 });


### PR DESCRIPTION
## 问题

角色管理 → Profiles → 右侧「应用到群组」的群下拉，展开后只露出**一行**，其余群既看不到也点不到（用户截图里红框那块就是被裁断的弹层）。

## 根因

弹层限高只按 `window.innerHeight` 算，**不知道头上还压着一个矮得多的滚动容器**：

```css
.roles-profile-apply { max-height: 34%; overflow: auto; }
```

`overflow: auto` 会连带裁剪绝对定位的子弹层。真机测下来触发器上方"看似"有 650px 空间、于是判定向上弹，但该面板自身只有 232px 高，弹层整个落在面板可视区之外，**只剩 39px（1.4 行）**露出来 —— 正是截图里那一行。

而且这种越界**不可恢复**：overflow 容器只会朝内容方向滚，不会滚到内容上方，所以被顶出去的选项没法再找回来。

## 改法

新增 `popupClipFrame`：把 viewport 与各级裁剪祖先的盒子**取交集**，得出弹层真正可见的带；`dropdownPlacement` 改按这个带算上下可用空间，不再拿整屏高度当分母。

两个边界处理：

- **走查从弹层自身起步**（而不是从 `<details>`），这样将来有人给 `.sect-sort-menu` 加 overflow 也能算进去；
- **遇到 `position: fixed` 祖先即停** —— 它按 viewport 定位，上方的 overflow 盒并不裁剪它（已实测确认）。不停的话，模态框里的下拉会被一个它明显逃逸的容器白白压缩。

## 影响面

`DropdownMenu` 是全 Dashboard 共用组件（**13 个页面、30 处使用**），所以同类问题一并修好，不只是角色管理这一处。

**兼容性**：无裁剪祖先时交集退化为整个 viewport，行为与改动前逐字相同；只有当祖先确实比 viewport 更窄时才收紧，而那正是"原本就会被裁掉"的场景。

不涉及飞书卡片 / Web 终端 / CLI 适配器，与后端（PtyBackend / TmuxBackend）、会话类型无关；纯前端渲染层，跨平台无差异。

## 验证

**真机**（`switch:here` + `daemon:restart` 后的 live dashboard，**1577 个真实群**）。为避免滚动触发组件自身的 `scroll` 监听而污染读数，采用纯几何测量、全程不滚动：

| | 弹向 | 预算 | 面板内可见带 | 可见行数 |
|---|---|---|---|---|
| 旧算法（按 viewport） | 向上 | 650px | **39px** | **1.4 行** |
| 本 PR | 向下 | 140px | **140px** | **5 行**，且弹层内可滚动 → 1577 项全可达 |

两张对照截图（同一页面、同一份真实数据，只切换限高算法）已贴在飞书话题里；
上表的数字即取自这两次测量。修复前那张能逐像素复现用户反馈的现象：弹层被
顶到面板上方，面板顶边只剩一行被切掉一半的群名。

**反变异 7 枪，逐枪转红**（证明新增测试真的承重）：退回 `frameTop` / 退回 `frameBottom` / 去掉交集计算 / 去掉倒挂折叠 / 走查起点改回 `details` / 去掉 `fixed` 判断 / 组件不把 frame 传下去。

**其它**：
- `bun run build` → rc=0
- 103 个 dashboard 测试文件：**2066 passed**
- 本文件测试 16 passed（新增 7 个用例）
- 全量 `vitest run --project unit` 有 21 个红文件，与本改动无关：同一跑法下 master 基线与本分支**均为同样 5 文件 28 条失败，差集为空**（其余为全量并发下的负载 flake）
