### PR TITLE
feat(send): 支持设置飞书单图渲染尺寸

### DIFF
--- a/docs/assets/send-image-mode.svg
+++ b/docs/assets/send-image-mode.svg
@@ -15,14 +15,16 @@
       <text x="18" y="33" font-size="18">small</text>
       <rect x="18" y="55" width="88" height="58.667" rx="5" fill="#e8efff"/>
       <path d="M25 64h57m-57 7h73m-73 7h48m-48 7h62" stroke="#688aca" stroke-width="2.33"/>
-      <text x="18" y="262" font-size="14">Column width: 1/3; fit_horizontal</text>
+      <path d="M106 50v175m88-175v175" stroke="#d9e1ee" stroke-dasharray="4 4"/>
+      <text x="18" y="262" font-size="14">3 equal columns; image in column 1</text>
     </g>
     <g transform="translate(690 95)">
       <rect width="300" height="285" rx="12" fill="white" stroke="#d9e1ee"/>
       <text x="18" y="33" font-size="18">tiny</text>
       <rect x="18" y="55" width="66" height="44" rx="4" fill="#e8efff"/>
       <path d="M23 62h42m-42 5.5h55m-55 5.5h36m-36 5.5h46" stroke="#688aca" stroke-width="2"/>
-      <text x="18" y="262" font-size="14">Column width: 1/4; fit_horizontal</text>
+      <path d="M84 50v175m66-175v175m66-175v175" stroke="#d9e1ee" stroke-dasharray="4 4"/>
+      <text x="18" y="262" font-size="14">4 equal columns; image in column 1</text>
     </g>
     <text x="30" y="412" font-size="14" fill="#526070">Standalone images only. Inline Markdown images and multi-image rows keep their existing layout.</text>
   </g>

--- a/docs/assets/send-image-mode.svg
+++ b/docs/assets/send-image-mode.svg
@@ -13,16 +13,16 @@
     <g transform="translate(360 95)">
       <rect width="300" height="285" rx="12" fill="white" stroke="#d9e1ee"/>
       <text x="18" y="33" font-size="18">small</text>
-      <rect x="18" y="55" width="150" height="100" rx="5" fill="#e8efff"/>
-      <path d="M30 72h95m-95 13h124m-124 13h82m-82 13h104" stroke="#688aca" stroke-width="4"/>
-      <text x="18" y="262" font-size="14">Native img element: mode = small</text>
+      <rect x="18" y="55" width="88" height="58.667" rx="5" fill="#e8efff"/>
+      <path d="M25 64h57m-57 7h73m-73 7h48m-48 7h62" stroke="#688aca" stroke-width="2.33"/>
+      <text x="18" y="262" font-size="14">Column width: 1/3; fit_horizontal</text>
     </g>
     <g transform="translate(690 95)">
       <rect width="300" height="285" rx="12" fill="white" stroke="#d9e1ee"/>
       <text x="18" y="33" font-size="18">tiny</text>
-      <rect x="18" y="55" width="75" height="50" rx="4" fill="#e8efff"/>
-      <path d="M24 64h47m-47 7h62m-62 7h41m-41 7h52" stroke="#688aca" stroke-width="2"/>
-      <text x="18" y="262" font-size="14">Native img element: mode = tiny</text>
+      <rect x="18" y="55" width="66" height="44" rx="4" fill="#e8efff"/>
+      <path d="M23 62h42m-42 5.5h55m-55 5.5h36m-36 5.5h46" stroke="#688aca" stroke-width="2"/>
+      <text x="18" y="262" font-size="14">Column width: 1/4; fit_horizontal</text>
     </g>
     <text x="30" y="412" font-size="14" fill="#526070">Standalone images only. Inline Markdown images and multi-image rows keep their existing layout.</text>
   </g>

--- a/docs/assets/send-image-mode.svg
+++ b/docs/assets/send-image-mode.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1020" height="430" viewBox="0 0 1020 430">
+  <rect width="1020" height="430" fill="#f4f6fa"/>
+  <g font-family="Arial, sans-serif" fill="#172b4d">
+    <text x="30" y="38" font-size="22" font-weight="bold">botmux send --images screenshot.png --image-mode &lt;mode&gt;</text>
+    <text x="30" y="67" font-size="14" fill="#526070">Layout illustration only — actual sizes are determined by the Feishu client.</text>
+    <g transform="translate(30 95)">
+      <rect width="300" height="285" rx="12" fill="white" stroke="#d9e1ee"/>
+      <text x="18" y="33" font-size="18">fit_horizontal (default)</text>
+      <rect x="18" y="55" width="264" height="176" rx="5" fill="#e8efff"/>
+      <path d="M38 82h170m-170 22h220m-220 22h145m-145 22h185" stroke="#688aca" stroke-width="7"/>
+      <text x="18" y="262" font-size="14">Existing Markdown output preserved</text>
+    </g>
+    <g transform="translate(360 95)">
+      <rect width="300" height="285" rx="12" fill="white" stroke="#d9e1ee"/>
+      <text x="18" y="33" font-size="18">small</text>
+      <rect x="18" y="55" width="150" height="100" rx="5" fill="#e8efff"/>
+      <path d="M30 72h95m-95 13h124m-124 13h82m-82 13h104" stroke="#688aca" stroke-width="4"/>
+      <text x="18" y="262" font-size="14">Native img element: mode = small</text>
+    </g>
+    <g transform="translate(690 95)">
+      <rect width="300" height="285" rx="12" fill="white" stroke="#d9e1ee"/>
+      <text x="18" y="33" font-size="18">tiny</text>
+      <rect x="18" y="55" width="75" height="50" rx="4" fill="#e8efff"/>
+      <path d="M24 64h47m-47 7h62m-62 7h41m-41 7h52" stroke="#688aca" stroke-width="2"/>
+      <text x="18" y="262" font-size="14">Native img element: mode = tiny</text>
+    </g>
+    <text x="30" y="412" font-size="14" fill="#526070">Standalone images only. Inline Markdown images and multi-image rows keep their existing layout.</text>
+  </g>
+</svg>

--- a/docs/send-image-mode.md
+++ b/docs/send-image-mode.md
@@ -1,0 +1,29 @@
+# 发送完整截图的缩小预览
+
+```sh
+botmux send --images /tmp/screenshot.png --image-mode small "截图"
+botmux send --images /tmp/screenshot.png --image-mode tiny "截图"
+```
+
+`--image-mode` 控制独立单图的布局。缩小档位保留完整图片和原始宽高比，仍可点击预览。
+
+| 参数 | 行为 |
+| --- | --- |
+| 不传 / `fit_horizontal` | 保持现有全宽 Markdown 图片输出 |
+| `large` | 占可用宽度的 3/4，完整显示 |
+| `medium` | 占可用宽度的 1/2，完整显示 |
+| `small` | 占可用宽度的 1/3，完整显示 |
+| `tiny` | 占可用宽度的 1/4，完整显示 |
+| `crop_center` | 显式选择居中裁剪，不适用于保留完整截图 |
+
+这里的 large/medium/small/tiny 是 **botmux 的分栏宽度档位**，不是飞书 `size` 字段的方形尺寸档位。缩小比例相对卡片可用宽度，窄屏仍按比例收缩，不表示固定像素宽度，也不是原始文件像素的缩放比例。
+
+末尾追加的 `--images` 图片、独占一行的 `![说明](img:0)`、以及不带 `--images` 而在正文独占一行的 `![说明](img_v3_...)` 均支持此参数。正文行内图片、并排多图、代码块维持原有行为。非法值或缺值以退出码 2 拒绝。
+
+![布局示意](assets/send-image-mode.svg)
+
+以上为布局示意，不是飞书客户端截图。实际客户端视觉效果仍需实测。
+
+实现采用 schema 2.0 原生 `img.scale_type: fit_horizontal`，置于带空白分栏的 `column_set`，以加权分栏控制占宽；`flex_mode: none` 保持窄屏比例。图片不设置 `size`、`custom_width` 或旧版 `mode`。默认路径和原有多图并排路径保持原样。
+
+依据：[飞书 2.0 图片组件](https://open.feishu.cn/document/feishu-cards/card-json-v2-components/content-components/image) 将 `fit_horizontal` 定义为完整展示、不裁剪，并说明 `size` 仅在裁剪模式下生效；[分栏组件](https://open.feishu.cn/document/feishu-cards/card-json-v2-components/containers/column-set) 支持 `weighted` 宽度与 `none` 窄屏比例压缩。

--- a/docs/send-image-mode.md
+++ b/docs/send-image-mode.md
@@ -10,20 +10,20 @@ botmux send --images /tmp/screenshot.png --image-mode tiny "截图"
 | 参数 | 行为 |
 | --- | --- |
 | 不传 / `fit_horizontal` | 保持现有全宽 Markdown 图片输出 |
-| `large` | 占可用宽度的 3/4，完整显示 |
 | `medium` | 占可用宽度的 1/2，完整显示 |
 | `small` | 占可用宽度的 1/3，完整显示 |
 | `tiny` | 占可用宽度的 1/4，完整显示 |
-| `crop_center` | 显式选择居中裁剪，不适用于保留完整截图 |
 
-这里的 large/medium/small/tiny 是 **botmux 的分栏宽度档位**，不是飞书 `size` 字段的方形尺寸档位。缩小比例相对卡片可用宽度，窄屏仍按比例收缩，不表示固定像素宽度，也不是原始文件像素的缩放比例。
+这里的 medium/small/tiny 是 **botmux 的分栏宽度档位**，不是飞书 `size` 字段的方形尺寸档位。缩小比例相对卡片可用宽度，窄屏仍按比例收缩，不表示固定像素宽度，也不是原始文件像素的缩放比例。
 
-末尾追加的 `--images` 图片、独占一行的 `![说明](img:0)`、以及不带 `--images` 而在正文独占一行的 `![说明](img_v3_...)` 均支持此参数。正文行内图片、并排多图、代码块维持原有行为。非法值或缺值以退出码 2 拒绝。
+末尾追加的 `--images` 图片、独占一行的 `![说明](img:0)`、以及不带 `--images` 而在正文独占一行的 `![说明](img_v3_...)` 均支持此参数。正文行内图片、并排多图、代码块维持原有行为。非法值或缺值以退出码 2 拒绝。早期 PR 版本的 `large` 和 `crop_center` 已移除，同样报错退出。
 
 ![布局示意](assets/send-image-mode.svg)
 
 以上为布局示意，不是飞书客户端截图。实际客户端视觉效果仍需实测。
 
-实现采用 schema 2.0 原生 `img.scale_type: fit_horizontal`，置于带空白分栏的 `column_set`，以加权分栏控制占宽；`flex_mode: none` 保持窄屏比例。图片不设置 `size`、`custom_width` 或旧版 `mode`。默认路径和原有多图并排路径保持原样。
+实现采用 schema 2.0 原生 `img.scale_type: fit_horizontal`，置于 `column_set` 的 2、3 或 4 个等权分栏中，第一列放图片，其余列为空白；所有列的 `weight` 均为 1；`flex_mode: none` 保持窄屏比例。图片不设置 `size`、`custom_width` 或旧版 `mode`。默认路径和原有多图并排路径保持原样。
 
 依据：[飞书 2.0 图片组件](https://open.feishu.cn/document/feishu-cards/card-json-v2-components/content-components/image) 将 `fit_horizontal` 定义为完整展示、不裁剪，并说明 `size` 仅在裁剪模式下生效；[分栏组件](https://open.feishu.cn/document/feishu-cards/card-json-v2-components/containers/column-set) 支持 `weighted` 宽度与 `none` 窄屏比例压缩。
+
+不使用非等权比例：PR 实际服务端回读发现非等权会被压平为 1:1，而多个等权列能保留。该回读证据来自维护者，当前分支的本地测试验证最终出站 JSON，尚未独立执行真实服务端回读和客户端视觉验收。

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6250,7 +6250,8 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
        --proactive                    标记为 AI 主动改名（应用 10 分钟防抖）
   send [content]                       发消息到当前话题（支持 stdin / --content-file）
        --images <path>                 内联图片（可重复）
-       --image-mode <mode>             独立单图尺寸：fit_horizontal（默认）|crop_center|large|medium|small|tiny
+       --image-mode <mode>             独立单图：fit_horizontal（默认）|crop_center|large|medium|small|tiny
+                                      large/medium/small/tiny 等比占宽 3/4、1/2、1/3、1/4；crop_center 居中裁剪
        --files <path>                  附件（可重复）
        --videos <path>                 视频预览 MP4（可重复，需配套 --video-covers）
        --video-covers <path>           视频封面图片（可重复，按顺序对应 --videos）

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6250,6 +6250,7 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
        --proactive                    标记为 AI 主动改名（应用 10 分钟防抖）
   send [content]                       发消息到当前话题（支持 stdin / --content-file）
        --images <path>                 内联图片（可重复）
+       --image-mode <mode>             独立单图尺寸：fit_horizontal（默认）|crop_center|large|medium|small|tiny
        --files <path>                  附件（可重复）
        --videos <path>                 视频预览 MP4（可重复，需配套 --video-covers）
        --video-covers <path>           视频封面图片（可重复，按顺序对应 --videos）
@@ -8439,6 +8440,12 @@ async function cmdSend(rest: string[]): Promise<void> {
     console.error('botmux send: --card-json 与 --card-file 不能同时使用');
     process.exit(2);
   }
+  const imageMode = argValue(rest, '--image-mode') ?? 'fit_horizontal';
+  if (flagPresentButValueMissing(rest, '--image-mode')
+    || !['fit_horizontal', 'crop_center', 'large', 'medium', 'small', 'tiny'].includes(imageMode)) {
+    console.error('botmux send: --image-mode 仅支持 fit_horizontal|crop_center|large|medium|small|tiny');
+    process.exit(2);
+  }
   const images = argValues(rest, '--image', '--images');
   const files = argValues(rest, '--file', '--files');
   const videos = argValues(rest, '--video', '--videos');
@@ -10033,7 +10040,7 @@ async function cmdSend(rest: string[]): Promise<void> {
           ? 'lexical'
           : 'filesystem';
       const elements = (md || imageKeys.length > 0)
-        ? buildImageCardElements(md, imageKeys, process.cwd(), localHomeLinkMode)
+        ? buildImageCardElements(md, imageKeys, process.cwd(), localHomeLinkMode, imageMode)
         : [];
 
       // Footer: de-emphasized markdown (v2 dropped the `note` tag). Use small

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6250,8 +6250,8 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
        --proactive                    标记为 AI 主动改名（应用 10 分钟防抖）
   send [content]                       发消息到当前话题（支持 stdin / --content-file）
        --images <path>                 内联图片（可重复）
-       --image-mode <mode>             独立单图：fit_horizontal（默认）|crop_center|large|medium|small|tiny
-                                      large/medium/small/tiny 等比占宽 3/4、1/2、1/3、1/4；crop_center 居中裁剪
+       --image-mode <mode>             独立单图：fit_horizontal（默认）|medium|small|tiny
+                                      medium/small/tiny 等比占宽 1/2、1/3、1/4，完整显示不裁剪
        --files <path>                  附件（可重复）
        --videos <path>                 视频预览 MP4（可重复，需配套 --video-covers）
        --video-covers <path>           视频封面图片（可重复，按顺序对应 --videos）
@@ -8443,8 +8443,8 @@ async function cmdSend(rest: string[]): Promise<void> {
   }
   const imageMode = argValue(rest, '--image-mode') ?? 'fit_horizontal';
   if (flagPresentButValueMissing(rest, '--image-mode')
-    || !['fit_horizontal', 'crop_center', 'large', 'medium', 'small', 'tiny'].includes(imageMode)) {
-    console.error('botmux send: --image-mode 仅支持 fit_horizontal|crop_center|large|medium|small|tiny');
+    || !['fit_horizontal', 'medium', 'small', 'tiny'].includes(imageMode)) {
+    console.error('botmux send: --image-mode 仅支持 fit_horizontal|medium|small|tiny');
     process.exit(2);
   }
   const images = argValues(rest, '--image', '--images');

--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -895,7 +895,7 @@ export function buildCardBodyElements(
   const layoutBudget = { promotedHeadings: 0 };
   for (const seg of splitImageRowSegments(input, imageMode)) {
     if (seg.type === 'imgrow') elements.push(imageRowElement(seg.keys));
-    else if (seg.type === 'img') elements.push(singleImgElement(seg.key, imageMode, seg.alt));
+    else if (seg.type === 'img') elements.push(singleImageLayout(seg.key, imageMode, seg.alt));
     else elements.push(...buildMarkdownElements(seg.content, layoutBudget));
   }
   return elements;
@@ -1005,9 +1005,34 @@ function buildMarkdownElements(
   return elements;
 }
 
-/** A single uploaded image; full-width by default for compatibility. */
-function singleImgElement(imgKey: string, mode = 'fit_horizontal', alt = ''): any {
-  return { tag: 'img', img_key: imgKey, alt: { tag: 'plain_text', content: alt }, mode, preview: true };
+// Existing multi-image rows retain their legacy payload for compatibility.
+function singleImgElement(imgKey: string): any {
+  return { tag: 'img', img_key: imgKey, alt: { tag: 'plain_text', content: '' }, mode: 'fit_horizontal', preview: true };
+}
+
+/** Botmux width presets, not Feishu's square/cropping `size` presets. */
+function singleImageLayout(imgKey: string, mode: string, alt: string): any {
+  const img = {
+    tag: 'img', img_key: imgKey, alt: { tag: 'plain_text', content: alt },
+    scale_type: mode === 'crop_center' ? 'crop_center' : 'fit_horizontal',
+    ...(mode === 'crop_center' ? { size: 'stretch' } : {}),
+    preview: true,
+  };
+  const weights: Record<string, [number, number]> = {
+    large: [3, 1], medium: [1, 1], small: [1, 2], tiny: [1, 3],
+  };
+  const ratio = weights[mode];
+  if (!ratio) return img;
+  // `none` preserves the ratio on narrow screens too. The second column is
+  // intentionally empty; the image fits its column without cropping or a
+  // fixed height. `size` only applies to crop modes in card schema 2.0.
+  return {
+    tag: 'column_set', flex_mode: 'none', horizontal_spacing: '0px',
+    columns: [
+      { tag: 'column', width: 'weighted', weight: ratio[0], elements: [img] },
+      { tag: 'column', width: 'weighted', weight: ratio[1], elements: [] },
+    ],
+  };
 }
 
 /**
@@ -1134,7 +1159,7 @@ export function buildImageCardElements(
   localHomeLinkMode: LocalHomeLinkMode = 'filesystem',
   imageMode?: string,
 ): any[] {
-  if (imageKeys.length === 0) return md ? buildCardBodyElements(md, cwd, localHomeLinkMode) : [];
+  if (imageKeys.length === 0) return md ? buildCardBodyElements(md, cwd, localHomeLinkMode, imageMode) : [];
 
   const used = new Set<number>();
   const keyAt = (idx: number): string | null =>

--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -1014,24 +1014,20 @@ function singleImgElement(imgKey: string): any {
 function singleImageLayout(imgKey: string, mode: string, alt: string): any {
   const img = {
     tag: 'img', img_key: imgKey, alt: { tag: 'plain_text', content: alt },
-    scale_type: mode === 'crop_center' ? 'crop_center' : 'fit_horizontal',
-    ...(mode === 'crop_center' ? { size: 'stretch' } : {}),
-    preview: true,
+    scale_type: 'fit_horizontal', preview: true,
   };
-  const weights: Record<string, [number, number]> = {
-    large: [3, 1], medium: [1, 1], small: [1, 2], tiny: [1, 3],
-  };
-  const ratio = weights[mode];
-  if (!ratio) return img;
-  // `none` preserves the ratio on narrow screens too. The second column is
-  // intentionally empty; the image fits its column without cropping or a
-  // fixed height. `size` only applies to crop modes in card schema 2.0.
+  const columnCounts: Record<string, number> = { medium: 2, small: 3, tiny: 4 };
+  const count = columnCounts[mode];
+  if (!count) return img;
+  // Feishu normalizes unequal weights to 1. Use N equal columns instead:
+  // one image and N-1 empty columns. `none` preserves the fraction on narrow
+  // screens; fit_horizontal keeps the entire image without a fixed height.
   return {
     tag: 'column_set', flex_mode: 'none', horizontal_spacing: '0px',
-    columns: [
-      { tag: 'column', width: 'weighted', weight: ratio[0], elements: [img] },
-      { tag: 'column', width: 'weighted', weight: ratio[1], elements: [] },
-    ],
+    columns: Array.from({ length: count }, (_, index) => ({
+      tag: 'column', width: 'weighted', weight: 1,
+      elements: index === 0 ? [img] : [],
+    })),
   };
 }
 

--- a/src/im/lark/md-card.ts
+++ b/src/im/lark/md-card.ts
@@ -881,6 +881,7 @@ export function buildCardBodyElements(
   input: string,
   cwd = process.cwd(),
   localHomeLinkMode: LocalHomeLinkMode = 'filesystem',
+  imageMode = 'fit_horizontal',
 ): any[] {
   if (!input) return [];
   // Recover model-escaped fences first so markdown-it can classify their
@@ -892,8 +893,9 @@ export function buildCardBodyElements(
   // image-looking lines inside ``` code blocks are left intact.
   const elements: any[] = [];
   const layoutBudget = { promotedHeadings: 0 };
-  for (const seg of splitImageRowSegments(input)) {
+  for (const seg of splitImageRowSegments(input, imageMode)) {
     if (seg.type === 'imgrow') elements.push(imageRowElement(seg.keys));
+    else if (seg.type === 'img') elements.push(singleImgElement(seg.key, imageMode, seg.alt));
     else elements.push(...buildMarkdownElements(seg.content, layoutBudget));
   }
   return elements;
@@ -1003,9 +1005,9 @@ function buildMarkdownElements(
   return elements;
 }
 
-/** A single uploaded image rendered full-width (legacy single-image look). */
-function singleImgElement(imgKey: string): any {
-  return { tag: 'img', img_key: imgKey, alt: { tag: 'plain_text', content: '' }, mode: 'fit_horizontal', preview: true };
+/** A single uploaded image; full-width by default for compatibility. */
+function singleImgElement(imgKey: string, mode = 'fit_horizontal', alt = ''): any {
+  return { tag: 'img', img_key: imgKey, alt: { tag: 'plain_text', content: alt }, mode, preview: true };
 }
 
 /**
@@ -1050,14 +1052,14 @@ const IMG_ROW_LINE = /^ {0,3}(?:!\[[^\]]*\]\([^)\s]+\)\s*){2,}$/;
  */
 const FEISHU_IMG_KEY = /^img_v\d+_[A-Za-z0-9_-]+$/i;
 
-type BodySegment = { type: 'text'; content: string } | { type: 'imgrow'; keys: string[] };
+type BodySegment = { type: 'text'; content: string } | { type: 'imgrow'; keys: string[] } | { type: 'img'; key: string; alt: string };
 
 /**
  * Split a markdown body into segments, pulling out lines that consist solely of
  * 2+ image tokens as `imgrow` segments (→ side-by-side row). Fence-aware: lines
  * inside ``` / ~~~ code blocks are never treated as image rows.
  */
-function splitImageRowSegments(input: string): BodySegment[] {
+function splitImageRowSegments(input: string, imageMode = 'fit_horizontal'): BodySegment[] {
   const segs: BodySegment[] = [];
   let buf: string[] = [];
   const flush = () => { if (buf.length) { segs.push({ type: 'text', content: buf.join('\n') }); buf = []; } };
@@ -1081,6 +1083,16 @@ function splitImageRowSegments(input: string): BodySegment[] {
       }
       buf.push(line);
       continue;
+    }
+    // Only promote standalone images for an explicit size override. Keep the
+    // legacy Markdown output, inline prose, code blocks, and image grids intact.
+    if (!fenceChar && imageMode !== 'fit_horizontal') {
+      const single = line.match(/^ {0,3}!\[([^\]]*)\]\(([^)\s]+)\)\s*$/);
+      if (single && FEISHU_IMG_KEY.test(single[2])) {
+        flush();
+        segs.push({ type: 'img', key: single[2], alt: single[1] });
+        continue;
+      }
     }
     if (!fenceChar && IMG_ROW_LINE.test(line)) {
       const keys = Array.from(line.matchAll(IMG_TOKEN_SRC), m => m[1]);
@@ -1112,12 +1124,15 @@ function splitImageRowSegments(input: string): BodySegment[] {
  * pre-pass turns multi-image lines into the actual `column_set` rows. This keeps
  * one rendering path: a caller that embeds `![](img_key)` directly and puts two
  * on a line (e.g. the menu poster) gets the same grid without using `--images`.
+ * `imageMode` overrides standalone single images only; inline Markdown images
+ * and side-by-side rows retain their existing layout.
  */
 export function buildImageCardElements(
   md: string,
   imageKeys: string[],
   cwd = process.cwd(),
   localHomeLinkMode: LocalHomeLinkMode = 'filesystem',
+  imageMode?: string,
 ): any[] {
   if (imageKeys.length === 0) return md ? buildCardBodyElements(md, cwd, localHomeLinkMode) : [];
 
@@ -1150,7 +1165,7 @@ export function buildImageCardElements(
   const trailing = imageKeys.map((k, i) => (used.has(i) ? '' : `![](${k})`)).filter(Boolean).join('\n\n');
   if (trailing) resolved = resolved ? `${resolved}\n\n${trailing}` : trailing;
 
-  return buildCardBodyElements(resolved, cwd, localHomeLinkMode);
+  return buildCardBodyElements(resolved, cwd, localHomeLinkMode, imageMode);
 }
 
 /**

--- a/test/cli-send-image-mode.test.ts
+++ b/test/cli-send-image-mode.test.ts
@@ -21,14 +21,14 @@ function run(args: string[]) {
 describe('send --image-mode', () => {
   it.each([
     ['--image-mode', 'invalid'], ['--image-mode=SMALL'], ['--image-mode'],
-    ['--image-mode='], ['--image-mode', '--images', '/tmp/screenshot.png'],
+    ['--image-mode='], ['--image-mode', 'large'], ['--image-mode=crop_center'], ['--image-mode', '--images', '/tmp/screenshot.png'],
   ])('rejects invalid or missing mode: %j', (...args) => {
     const result = run(['send', ...args]);
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('--image-mode 仅支持');
   });
 
-  it.each(['fit_horizontal', 'crop_center', 'large', 'medium', 'small', 'tiny'])('accepts %s before attachment validation', mode => {
+  it.each(['fit_horizontal', 'medium', 'small', 'tiny'])('accepts %s before attachment validation', mode => {
     // Reject stdin-as-attachment after parsing, without uploading or sending.
     const result = run(['send', `--image-mode=${mode}`, '--images', '-']);
     expect(result.status).toBe(1);
@@ -39,16 +39,16 @@ describe('send --image-mode', () => {
     const result = run(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('--image-mode <mode>');
-    expect(result.stdout).toContain('fit_horizontal（默认）|crop_center|large|medium|small|tiny');
-    expect(result.stdout).toContain('large/medium/small/tiny 等比占宽 3/4、1/2、1/3、1/4');
+    expect(result.stdout).toContain('fit_horizontal（默认）|medium|small|tiny');
+    expect(result.stdout).toContain('medium/small/tiny 等比占宽 1/2、1/3、1/4');
   });
 });
 
 
 describe('cmdSend outbound card JSON', () => {
   it.each([
-    ['small', 2], ['tiny', 3], ['fit_horizontal', 0],
-  ])('delivers the width preset through the real CLI: %s', (mode, spacerWeight) => {
+    ['medium', 2], ['small', 3], ['tiny', 4], ['fit_horizontal', 0],
+  ])('delivers the width preset through the real CLI: %s', (mode, columnCount) => {
     for (const upload of [false, true]) {
       const dir = mkdtempSync(join(tmpdir(), 'botmux-image-card-'));
       try {
@@ -71,11 +71,12 @@ describe('cmdSend outbound card JSON', () => {
         const card = JSON.parse(captured!.slice('CAPTURE_CARD='.length));
         expect(card.schema).toBe('2.0');
         const row = card.body.elements.find((e: any) => e.tag === 'column_set');
-        if (spacerWeight) {
-          expect(row).toMatchObject({ flex_mode: 'none', columns: [
-            { width: 'weighted', weight: 1, elements: [{ tag: 'img', img_key: 'img_v3_test_upload', scale_type: 'fit_horizontal', preview: true }] },
-            { width: 'weighted', weight: spacerWeight, elements: [] },
-          ] });
+        if (columnCount) {
+          expect(row).toMatchObject({ flex_mode: 'none', horizontal_spacing: '0px' });
+          expect(row.columns).toHaveLength(columnCount as number);
+          for (const column of row.columns) expect(column).toMatchObject({ width: 'weighted', weight: 1 });
+          for (const column of row.columns.slice(1)) expect(column.elements).toEqual([]);
+          expect(row.columns[0].elements).toEqual([{ tag: 'img', img_key: 'img_v3_test_upload', alt: { tag: 'plain_text', content: upload ? '' : '截图' }, scale_type: 'fit_horizontal', preview: true }]);
           expect(row.columns[0].elements[0]).not.toHaveProperty('mode');
           expect(row.columns[0].elements[0]).not.toHaveProperty('size');
         } else {

--- a/test/cli-send-image-mode.test.ts
+++ b/test/cli-send-image-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -40,5 +40,51 @@ describe('send --image-mode', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('--image-mode <mode>');
     expect(result.stdout).toContain('fit_horizontal（默认）|crop_center|large|medium|small|tiny');
+    expect(result.stdout).toContain('large/medium/small/tiny 等比占宽 3/4、1/2、1/3、1/4');
+  });
+});
+
+
+describe('cmdSend outbound card JSON', () => {
+  it.each([
+    ['small', 2], ['tiny', 3], ['fit_horizontal', 0],
+  ])('delivers the width preset through the real CLI: %s', (mode, spacerWeight) => {
+    for (const upload of [false, true]) {
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-image-card-'));
+      try {
+        const path = join(dir, 'screenshot.png');
+        writeFileSync(path, Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aX1sAAAAASUVORK5CYII=', 'base64'));
+        const result = spawnSyncTsScript(fileURLToPath(new URL('./fixtures/send-image-mode-capture.ts', import.meta.url)), [
+          'send', '--image-mode', mode, '--no-mention', '--top-level',
+          ...(upload ? ['--images', path, '截图'] : ['![截图](img_v3_test_upload)']),
+        ], {
+          env: {
+            PATH: process.env.PATH, HOME: dir, SESSION_DATA_DIR: join(dir, 'data'), BOTS_CONFIG: join(dir, 'bots.json'),
+            BOTMUX_LARK_APP_ID: 'cli_test', BOTMUX_LARK_APP_SECRET: 'test',
+            BOTMUX_SESSION_ID: 'test-image-mode', BOTMUX_CHAT_ID: 'oc_test', BOTMUX_SESSION_SCOPE: 'chat',
+          },
+          encoding: 'utf8', timeout: 30_000,
+        });
+        expect(result.status, String(result.stderr)).toBe(0);
+        const captured = String(result.stdout).split('\n').find(line => line.startsWith('CAPTURE_CARD='));
+        expect(captured, String(result.stdout)).toBeTruthy();
+        const card = JSON.parse(captured!.slice('CAPTURE_CARD='.length));
+        expect(card.schema).toBe('2.0');
+        const row = card.body.elements.find((e: any) => e.tag === 'column_set');
+        if (spacerWeight) {
+          expect(row).toMatchObject({ flex_mode: 'none', columns: [
+            { width: 'weighted', weight: 1, elements: [{ tag: 'img', img_key: 'img_v3_test_upload', scale_type: 'fit_horizontal', preview: true }] },
+            { width: 'weighted', weight: spacerWeight, elements: [] },
+          ] });
+          expect(row.columns[0].elements[0]).not.toHaveProperty('mode');
+          expect(row.columns[0].elements[0]).not.toHaveProperty('size');
+        } else {
+          expect(row).toBeUndefined();
+          expect(card.body.elements.some((e: any) => e.tag === 'markdown' && e.content.includes('(img_v3_test_upload)'))).toBe(true);
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
   });
 });

--- a/test/cli-send-image-mode.test.ts
+++ b/test/cli-send-image-mode.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSyncTsScript } from './helpers/ts-runner.js';
+
+const cli = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+function run(args: string[]) {
+  const dir = mkdtempSync(join(tmpdir(), 'botmux-image-mode-'));
+  try {
+    return spawnSyncTsScript(cli, args, {
+      env: { PATH: process.env.PATH, HOME: dir, SESSION_DATA_DIR: join(dir, 'data'), BOTS_CONFIG: join(dir, 'bots.json') },
+      encoding: 'utf8', timeout: 30_000,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('send --image-mode', () => {
+  it.each([
+    ['--image-mode', 'invalid'], ['--image-mode=SMALL'], ['--image-mode'],
+    ['--image-mode='], ['--image-mode', '--images', '/tmp/screenshot.png'],
+  ])('rejects invalid or missing mode: %j', (...args) => {
+    const result = run(['send', ...args]);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('--image-mode 仅支持');
+  });
+
+  it.each(['fit_horizontal', 'crop_center', 'large', 'medium', 'small', 'tiny'])('accepts %s before attachment validation', mode => {
+    // Reject stdin-as-attachment after parsing, without uploading or sending.
+    const result = run(['send', `--image-mode=${mode}`, '--images', '-']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('不能把 stdin');
+  });
+
+  it('documents the allowed modes and default in help', () => {
+    const result = run(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--image-mode <mode>');
+    expect(result.stdout).toContain('fit_horizontal（默认）|crop_center|large|medium|small|tiny');
+  });
+});

--- a/test/fixtures/send-image-mode-capture.ts
+++ b/test/fixtures/send-image-mode-capture.ts
@@ -1,0 +1,16 @@
+import { defaultHttpInstance } from '@larksuiteoapi/node-sdk';
+(defaultHttpInstance as any).defaults.adapter = async (config: any) => {
+  const url = config.url;
+  let data;
+  if (url.includes('/auth/')) data = { code: 0, tenant_access_token: 'test-token', expire: 7200 };
+  else if (url.endsWith('/im/v1/messages')) {
+    const body = JSON.parse(config.data);
+    console.log('CAPTURE_CARD=' + body.content);
+    data = { code: 0, data: { message_id: 'om_test_sent' } };
+  } else if (url.includes('/im/v1/chats/')) data = { code: 0, data: { chat_mode: 'group', chat_type: 'private' } };
+  else if (url.endsWith('/im/v1/images')) data = { code: 0, data: { image_key: 'img_v3_test_upload' } };
+  else throw new Error('Unexpected HTTP request: ' + url);
+  return { data, status: 200, statusText: 'OK', headers: {}, config };
+};
+process.argv = [process.execPath, './src/cli.ts', ...process.argv.slice(2)];
+await import('../../src/cli.js');

--- a/test/md-card.test.ts
+++ b/test/md-card.test.ts
@@ -1361,10 +1361,27 @@ describe('buildCardBodyElements image rows', () => {
 describe('buildImageCardElements', () => {
   const K = ['img_v2_a', 'img_v2_b', 'img_v2_c', 'img_v2_d'];
 
-  it.each(['crop_center', 'large', 'medium', 'small', 'tiny'])('renders standalone uploads with mode %s', mode => {
-    const out = buildImageCardElements('截图', [K[0]], undefined, undefined, mode);
-    expect(out.find(e => e.tag === 'img')).toMatchObject({ img_key: K[0], mode, preview: true });
-    expect(mdElements(out).map(e => e.content).join('')).toBe('截图');
+  it.each([
+    ['large', 3, 1], ['medium', 1, 1], ['small', 1, 2], ['tiny', 1, 3],
+  ])('fits the whole image in a proportional column: %s', (mode, imageWeight, spacerWeight) => {
+    for (const [markdown, keys] of [['截图', [K[0]]], ['![截图](img:0)', [K[0]]], ['![截图](img_v2_a)', []]] as const) {
+      const out = buildImageCardElements(markdown, [...keys], undefined, undefined, mode as string);
+      const row = out.find(e => e.tag === 'column_set');
+      expect(row).toMatchObject({ flex_mode: 'none', horizontal_spacing: '0px', columns: [
+        { width: 'weighted', weight: imageWeight }, { width: 'weighted', weight: spacerWeight, elements: [] },
+      ] });
+      const img = row.columns[0].elements[0];
+      expect(img).toMatchObject({ tag: 'img', img_key: K[0], scale_type: 'fit_horizontal', preview: true });
+      expect(img).not.toHaveProperty('mode');
+      expect(img).not.toHaveProperty('size');
+      expect(img).not.toHaveProperty('custom_width');
+    }
+  });
+
+  it('keeps explicit cropping separate from proportional width presets', () => {
+    expect(buildImageCardElements('', [K[0]], undefined, undefined, 'crop_center')).toEqual([
+      { tag: 'img', img_key: K[0], alt: { tag: 'plain_text', content: '' }, scale_type: 'crop_center', size: 'stretch', preview: true },
+    ]);
   });
 
   it('keeps the default output identical, including explicit fit_horizontal', () => {
@@ -1375,11 +1392,10 @@ describe('buildImageCardElements', () => {
 
   it('sizes standalone placeholders and trailing images without resizing a grid', () => {
     const out = buildImageCardElements('![预览](img:0)\n\n![](img:1,2)', K, undefined, undefined, 'tiny');
-    expect(out.filter(e => e.tag === 'img')).toMatchObject([
-      { img_key: K[0], mode: 'tiny', alt: { content: '预览' } },
-      { img_key: K[3], mode: 'tiny' },
-    ]);
-    expect(out.find(e => e.tag === 'column_set').columns.every((c: any) => c.elements[0].mode === 'fit_horizontal')).toBe(true);
+    const rows = out.filter(e => e.tag === 'column_set');
+    expect(rows[0].columns[0].elements[0]).toMatchObject({ img_key: K[0], scale_type: 'fit_horizontal', alt: { content: '预览' } });
+    expect(rows[2].columns[0].elements[0]).toMatchObject({ img_key: K[3], scale_type: 'fit_horizontal' });
+    expect(rows[1]).toEqual(buildImageCardElements('![](img:0,1)', [K[1], K[2]])[0]);
   });
 
   it('keeps fenced code, indented code, inline prose and remote images as Markdown', () => {

--- a/test/md-card.test.ts
+++ b/test/md-card.test.ts
@@ -1361,6 +1361,34 @@ describe('buildCardBodyElements image rows', () => {
 describe('buildImageCardElements', () => {
   const K = ['img_v2_a', 'img_v2_b', 'img_v2_c', 'img_v2_d'];
 
+  it.each(['crop_center', 'large', 'medium', 'small', 'tiny'])('renders standalone uploads with mode %s', mode => {
+    const out = buildImageCardElements('截图', [K[0]], undefined, undefined, mode);
+    expect(out.find(e => e.tag === 'img')).toMatchObject({ img_key: K[0], mode, preview: true });
+    expect(mdElements(out).map(e => e.content).join('')).toBe('截图');
+  });
+
+  it('keeps the default output identical, including explicit fit_horizontal', () => {
+    const legacy = buildCardBodyElements('截图\n\n![](img_v2_a)');
+    expect(buildImageCardElements('截图', [K[0]])).toEqual(legacy);
+    expect(buildImageCardElements('截图', [K[0]], undefined, undefined, 'fit_horizontal')).toEqual(legacy);
+  });
+
+  it('sizes standalone placeholders and trailing images without resizing a grid', () => {
+    const out = buildImageCardElements('![预览](img:0)\n\n![](img:1,2)', K, undefined, undefined, 'tiny');
+    expect(out.filter(e => e.tag === 'img')).toMatchObject([
+      { img_key: K[0], mode: 'tiny', alt: { content: '预览' } },
+      { img_key: K[3], mode: 'tiny' },
+    ]);
+    expect(out.find(e => e.tag === 'column_set').columns.every((c: any) => c.elements[0].mode === 'fit_horizontal')).toBe(true);
+  });
+
+  it('keeps fenced code, indented code, inline prose and remote images as Markdown', () => {
+    for (const markdown of ['```\n![](img_v2_a)\n```', '    ![](img_v2_a)', 'see ![](img_v2_a) here', '![](https://example.com/a.png)']) {
+      expect(buildCardBodyElements(markdown, undefined, undefined, 'small')).toEqual(buildCardBodyElements(markdown));
+    }
+  });
+
+
   it('no images → identical to buildCardBodyElements', () => {
     expect(buildImageCardElements('hello **world**', [])).toEqual(
       buildCardBodyElements('hello **world**'),

--- a/test/md-card.test.ts
+++ b/test/md-card.test.ts
@@ -1362,26 +1362,21 @@ describe('buildImageCardElements', () => {
   const K = ['img_v2_a', 'img_v2_b', 'img_v2_c', 'img_v2_d'];
 
   it.each([
-    ['large', 3, 1], ['medium', 1, 1], ['small', 1, 2], ['tiny', 1, 3],
-  ])('fits the whole image in a proportional column: %s', (mode, imageWeight, spacerWeight) => {
+    ['medium', 2], ['small', 3], ['tiny', 4],
+  ])('fits the whole image in a proportional column: %s', (mode, columnCount) => {
     for (const [markdown, keys] of [['截图', [K[0]]], ['![截图](img:0)', [K[0]]], ['![截图](img_v2_a)', []]] as const) {
       const out = buildImageCardElements(markdown, [...keys], undefined, undefined, mode as string);
       const row = out.find(e => e.tag === 'column_set');
-      expect(row).toMatchObject({ flex_mode: 'none', horizontal_spacing: '0px', columns: [
-        { width: 'weighted', weight: imageWeight }, { width: 'weighted', weight: spacerWeight, elements: [] },
-      ] });
+      expect(row).toMatchObject({ flex_mode: 'none', horizontal_spacing: '0px' });
+      expect(row.columns).toHaveLength(columnCount as number);
+      for (const column of row.columns) expect(column).toMatchObject({ width: 'weighted', weight: 1 });
+      for (const column of row.columns.slice(1)) expect(column.elements).toEqual([]);
       const img = row.columns[0].elements[0];
       expect(img).toMatchObject({ tag: 'img', img_key: K[0], scale_type: 'fit_horizontal', preview: true });
       expect(img).not.toHaveProperty('mode');
       expect(img).not.toHaveProperty('size');
       expect(img).not.toHaveProperty('custom_width');
     }
-  });
-
-  it('keeps explicit cropping separate from proportional width presets', () => {
-    expect(buildImageCardElements('', [K[0]], undefined, undefined, 'crop_center')).toEqual([
-      { tag: 'img', img_key: K[0], alt: { tag: 'plain_text', content: '' }, scale_type: 'crop_center', size: 'stretch', preview: true },
-    ]);
   });
 
   it('keeps the default output identical, including explicit fit_horizontal', () => {


### PR DESCRIPTION
`botmux send --images /tmp/screenshot.png --image-mode small "截图"` 现在可将独立单图渲染为原生飞书 `img` 元素，并设置 `mode: small`，避免截图默认全宽显示过大。支持 `fit_horizontal`、`crop_center`、`large`、`medium`、`small`、`tiny`；非法值或缺少值均以 exit code 2 退出，帮助文本列出模式和默认值。

当前 master 的单图实际通过 Markdown 渲染，`singleImgElement` 用于并排图片。为保持向后兼容，未传参数或显式指定 `fit_horizontal` 时保留原有 Markdown 输出；非默认模式才提升独立单图为原生图片元素。独占一行的 `![alt](img:N)` 占位符和末尾追加的图片均支持尺寸覆盖，保留 alt 和图片预览。正文行内图片、多图并排、代码块保持原有布局。

影响面：修改 `src/cli.ts` 的 send 参数解析和飞书图片卡片构建，以及 `src/im/lark/md-card.ts` 的公共卡片预处理。新参数默认保持旧行为，其余调用方不受影响；不修改 CLI 适配器、PTY/Tmux 后端、会话路由、adopt/restore、sandbox 或 workflow 权限逻辑。纯参数和卡片 JSON 处理不引入平台相关代码；本次在 macOS 验证，未运行 Linux 或各 CLI 的 live 会话验证。

验证：

- Bun 1.4.1，`bun install --frozen-lockfile` 补齐 canonical checkout 缺少的 yaml 依赖，package.json 与 bun.lock 无改动。
- `bun run build`：通过，包括 TypeScript、脚本和 mock 类型检查、Dashboard 打包及资源审计。
- `bun run test test/md-card.test.ts test/cli-send-image-mode.test.ts test/cli-send-dispatch.test.ts test/cli-arg-utils.test.ts`：4 个文件、217 项测试全部通过。覆盖六种合法模式解析、非法值与缺值的退出码、help、small/tiny 等原生 img 输出、默认输出一致性、多图与代码块回归。
- `git diff --check`：通过。
- live 部署未执行：本地自动审批拒绝了全局 checkout 认领和 daemon 重启；尚未在真实飞书客户端验证尺寸。手动验证前需授权执行 `bun run switch:here && bun run daemon:restart`，再分别发送默认、small 和 tiny 图片确认显示效果。

尺寸示意（非飞书客户端截图，实际尺寸由飞书客户端决定）：

![单图模式布局示意](https://raw.githubusercontent.com/zhangke0117cursor/botmux/codex/send-image-mode/docs/assets/send-image-mode.svg)