### PR TITLE
feat(browser): 扩展 Chrome 操作桥接并接入认证运行时

### DIFF
--- a/docs-site/docs/en/bots-json.md
+++ b/docs-site/docs/en/bots-json.md
@@ -136,6 +136,8 @@ You can also add it to the corresponding bot entry directly (manual `bots.json` 
 
 ### Codex App browser bridge (experimental)
 
+Install the browser runtime bundled with the Codex desktop app. The bridge prefers `mcp_servers.node_repl`, but locates the installed runtime when the desktop removes that MCP registration; set `BOTMUX_CODEX_NODE_REPL_PATH` for a custom installation. Identity, site safety status, and feature configuration use the official authenticated request channel. The bridge does not read or store login tokens, and fails closed when the runtime or authentication is unavailable.
+
 This option addresses one narrow gap: Codex running through Botmux's app-server path does not otherwise inherit the Chrome tool built into Codex App. The bridge belongs entirely to Botmux and has no dependency on a project repository, Harness, or local-proxy setup.
 
 ```json
@@ -146,8 +148,10 @@ This option addresses one narrow gap: Codex running through Botmux's app-server 
 ```
 
 - Install and enable the Codex browser extension in Chrome / Edge under the same OS user first. Botmux selects the newest complete official plugin under `CODEX_HOME` (or `~/.codex`) automatically; use an absolute `pluginRoot` only for a maintained custom location.
-- The setting registers one `botmux_browser` dynamic tool only on newly created Codex App threads. Existing threads are not rewritten; open a new Lark topic / session to verify it.
-- The tool exposes only high-level tab, accessibility-tree interaction, navigation, and screenshot operations. It does not expose arbitrary JavaScript, raw CDP, cookies, local storage, browser history, clipboard, or file transfer.
+- The setting registers the `botmux_browser` dynamic tool when starting or resuming a Codex App thread. Restart or resume an already-running runner to load the updated tool definition.
+- The bridge probes capabilities per tab. It prefers the accessibility tree, falls back automatically to visible-DOM / Playwright-DOM snapshots when AX is unavailable, and exposes typed Playwright locator, DOM, and coordinate operations. A backend without `tab.ax` no longer breaks the entire Chrome connection.
+- Browser Use safety requests for origin access, uploads, downloads, and similar actions block the operation and appear as Lark authorization cards. Only users accepted by Botmux's `canTalk` check can choose session approval, persistent approval, or denial; Botmux ask records the answer and reviewer. A plain approval is also scoped to the current runner session and is reused for the same origin, operation type, and risk context; a different origin, operation type, risk context, or new session requires confirmation again. Denial, timeout, or daemon unavailability fails closed.
+- The tool does not expose arbitrary JavaScript, raw CDP, cookies, local storage, browser history, or clipboard. Uploads/downloads run only through Browser Use's controlled file chooser and safety checks. Secure browser-auth flows involving credentials never downgrade to an ordinary Lark card and require a client with a secure credential broker.
 - Each Botmux runner owns isolated browser-session state. The feature is off by default, so unconfigured bots retain their existing launch arguments and behavior.
 - It currently cannot be combined with `existingAppServer`, `sandbox`, or `readIsolation`; conflicting configuration fails at startup instead of running with an incomplete isolation boundary.
 

--- a/docs-site/docs/en/env.md
+++ b/docs-site/docs/en/env.md
@@ -8,6 +8,7 @@ Most configuration goes through `bots.json` / the dashboard — you **usually do
 
 | Variable | Default | Description |
 |------|------|------|
+| `BOTMUX_CODEX_NODE_REPL_PATH` | — | Absolute path to the installed Codex `node_repl` executable when no valid MCP runtime is configured; used only by opt-in browser support. |
 | `BOTS_CONFIG` | _(unset)_ | Path to bots.json (overrides the default location) |
 | `WEB_HOST` | `0.0.0.0` | HTTP service bind address |
 | `WEB_EXTERNAL_HOST` | _(auto-detect LAN IP)_ | External hostname/IP used in terminal links (for public/intranet-domain access, see [Web Terminal](/en/web-terminal)) |

--- a/docs-site/docs/zh/bots-json.md
+++ b/docs-site/docs/zh/bots-json.md
@@ -146,8 +146,11 @@
 ```
 
 - 需要先在同一 OS 用户的 Chrome / Edge 中安装并启用 Codex 浏览器扩展；Botmux 默认从 `CODEX_HOME`（或 `~/.codex`）的官方插件缓存中选择最新完整版本。只有维护自定义插件目录时才填写绝对路径 `pluginRoot`。
-- 开启后仅给新建的 Codex App thread 注册一个 `botmux_browser` 动态工具。旧 thread 不会被原地改写，请新开一个飞书话题 / 会话验证。
-- 工具只暴露标签页、可访问性树交互、导航和截图等高层操作，不暴露任意 JavaScript、raw CDP、cookie、local storage、浏览历史、剪贴板或文件传输。
+- 需要安装 Codex 桌面端附带的浏览器运行时。桥接优先使用 `mcp_servers.node_repl` 配置；桌面端移除该 MCP 注册项时，会从已安装的桌面端定位运行时，自定义安装位置可设置 `BOTMUX_CODEX_NODE_REPL_PATH`。身份、站点安全状态和功能配置均走官方认证请求通道，不自行读取或保存登录令牌；运行时缺失或登录失败时会中止操作，不降级为匿名请求。
+- 开启后会在新建和恢复 Codex App thread 时注册 `botmux_browser` 动态工具。已运行的 runner 需重启或重新恢复会话，才能加载更新后的工具定义。
+- 工具先按标签页探测能力：优先使用可访问性树；AX 不可用时自动回退到可见 DOM / Playwright DOM，并提供受类型约束的 Playwright locator、DOM 和坐标交互。不会因为某个后端缺少 `tab.ax` 而中断整个 Chrome 连接。
+- Browser Use 发出的站点访问、上传、下载等安全确认会阻塞当前操作并投射为飞书授权卡；只有通过 Botmux `canTalk` 校验的用户可以选择“本会话允许 / 始终允许 / 拒绝”，回答和回答人由 Botmux ask 记录。普通“允许”也只授予当前 runner 会话，后续同一站点、操作类型和风险上下文自动复用；不同站点、操作类型、风险上下文或新会话仍会重新确认。拒绝、超时、daemon 不可达均 fail closed。
+- 工具不暴露任意 JavaScript、raw CDP、cookie、local storage、浏览历史或剪贴板。上传/下载只通过 Browser Use 的受控文件选择器和安全确认执行；需要密码等秘密输入的 secure browser-auth 流程不会降级到普通飞书卡片，必须由支持安全凭证 broker 的客户端处理。
 - 每个 Botmux runner 独立持有浏览器会话状态；默认关闭，未配置的 bot 启动参数和行为完全不变。
 - 当前不支持与 `existingAppServer`、`sandbox` 或 `readIsolation` 组合，配置冲突会在启动时直接报错，避免以不完整隔离边界运行。
 

--- a/docs-site/docs/zh/env.md
+++ b/docs-site/docs/zh/env.md
@@ -8,6 +8,7 @@
 
 | 变量 | 默认 | 说明 |
 |------|------|------|
+| `BOTMUX_CODEX_NODE_REPL_PATH` | — | 未配置有效 MCP 运行时时，指定已安装的 Codex `node_repl` 可执行文件绝对路径；仅供显式启用的浏览器功能使用。 |
 | `BOTS_CONFIG` | _(未设置)_ | 指定 bots.json 路径（覆盖默认位置） |
 | `WEB_HOST` | `0.0.0.0` | HTTP 服务绑定地址 |
 | `WEB_EXTERNAL_HOST` | _(自动探测局域网 IP)_ | 终端链接中的外部主机名/IP（公网/内网域名访问见 [Web 终端](/web-terminal)） |

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -742,7 +742,14 @@ const browserBroker = args.browserFamily
   ? new CodexBrowserBroker({
       sessionId: args.sessionId,
       family: args.browserFamily,
+      codexBin: args.codexBin,
       ...(args.browserPluginRoot ? { pluginRoot: args.browserPluginRoot } : {}),
+      readConfig: params => client.request('config/read', params, { timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS }),
+      readConfigRequirements: () => client.request(
+        'configRequirements/read',
+        {},
+        { timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS },
+      ),
     })
   : undefined;
 let threadReady = false;
@@ -1494,6 +1501,7 @@ async function ensureThread(startupDeadlineAtMs?: number): Promise<string> {
         // Keep Codex App's rich history in sync with turns created by this
         // external runner so the desktop UI can render follow-up messages.
         persistExtendedHistory: true,
+        ...(browserBroker ? { dynamicTools: [CODEX_BROWSER_DYNAMIC_TOOL] } : {}),
       }, { timeoutMs: startupRequestTimeout(startupDeadlineAtMs, 'thread/resume') });
       const resumedThreadId = String(resumed.thread.id);
       threadId = resumedThreadId;
@@ -2454,20 +2462,20 @@ async function main(): Promise<void> {
   prompt();
 }
 
-process.on('SIGTERM', () => {
+process.on('SIGTERM', async () => {
   cancelRunnerIdleSettle();
   if (controlReconnectTimer) clearTimeout(controlReconnectTimer);
   controlSocket?.destroy();
-  browserBroker?.close();
+  await browserBroker?.close().catch(() => {});
   client?.close();
   process.exit(0);
 });
 
-process.on('SIGINT', () => {
+process.on('SIGINT', async () => {
   cancelRunnerIdleSettle();
   if (controlReconnectTimer) clearTimeout(controlReconnectTimer);
   controlSocket?.destroy();
-  browserBroker?.close();
+  await browserBroker?.close().catch(() => {});
   client?.close();
   process.exit(130);
 });

--- a/src/services/codex-browser-authenticated-fetch.ts
+++ b/src/services/codex-browser-authenticated-fetch.ts
@@ -1,0 +1,170 @@
+import { existsSync } from 'node:fs';
+import { delimiter, dirname, isAbsolute, join } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+type Json = Record<string, any>;
+interface Options {
+  readConfig: () => Promise<Json>;
+  requestMeta: () => Record<string, string>;
+  codexBin?: string;
+}
+
+interface RuntimeConfig { command: string; args?: string[]; env?: Record<string, string> }
+
+/** The desktop app rewrites its MCP configuration as tool availability changes.
+ * Absence of an MCP registration does not mean the bundled runtime is absent. */
+export function resolveBrowserFetchRuntime(config: Json, candidates?: string[]): RuntimeConfig {
+  const configured = config.mcp_servers?.node_repl;
+  if (configured && typeof configured.command === 'string' && isAbsolute(configured.command)
+    && existsSync(configured.command)) return configured;
+
+  const override = process.env.BOTMUX_CODEX_NODE_REPL_PATH?.trim();
+  const paths = candidates ?? (override ? [override] : [
+    '/usr/lib/chatgpt/resources/cua_node/bin/node_repl',
+    '/opt/ChatGPT/resources/cua_node/bin/node_repl',
+    '/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node_repl',
+    '/Applications/Codex.app/Contents/Resources/cua_node/bin/node_repl',
+    join(homedir(), 'Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node_repl'),
+    join(homedir(), 'Applications/Codex.app/Contents/Resources/cua_node/bin/node_repl'),
+  ]);
+  for (const command of paths) {
+    if (!isAbsolute(command) || !existsSync(command)) continue;
+    const node = join(dirname(command), process.platform === 'win32' ? 'node.exe' : 'node');
+    if (!existsSync(node)) continue;
+    return { command, args: [], env: { NODE_REPL_NODE_PATH: node } };
+  }
+  throw new Error('Codex browser authenticated runtime was not found; install the Codex desktop runtime or set BOTMUX_CODEX_NODE_REPL_PATH to its node_repl executable');
+}
+
+/** Use the same authenticated fetch implementation as the installed browser
+ * plugin. Plain Node fetch cannot substitute for the Codex trusted runtime:
+ * identity, site-status and rollout requests need its authentication policy. */
+export class CodexBrowserAuthenticatedFetch {
+  private client?: Client;
+  private transport?: StdioClientTransport;
+  private starting?: Promise<Client>;
+  private closed = false;
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(private readonly options: Options) {}
+
+  readonly fetch: typeof fetch = async (input, init) => {
+    const request = new Request(input, init);
+    request.signal.throwIfAborted();
+    const body = Buffer.from(await request.arrayBuffer());
+    const payload = {
+      method: 'fetch',
+      params: {
+        url: request.url,
+        method: request.method,
+        headers: [...request.headers.entries()],
+        ...(body.length ? { body: body.toString('base64') } : {}),
+      },
+    };
+    const client = await this.getClient();
+    request.signal.throwIfAborted();
+    const run = async () => {
+      request.signal.throwIfAborted();
+      if (this.closed) throw new Error('Codex browser authenticated runtime is closed');
+      return client.callTool({
+        name: 'js',
+        arguments: {
+          code: `nodeRepl.write(JSON.stringify(await nodeRepl.rpc("botmux_browser_fetch", ${JSON.stringify(payload)})));`,
+          title: 'Botmux browser authenticated request',
+          timeout_ms: 35_000,
+        },
+        _meta: this.options.requestMeta(),
+      }, undefined, { timeout: 40_000, signal: request.signal });
+    };
+    // A single runtime owns one JS execution at a time. Browser initialization
+    // starts identity and rollout fetches concurrently, so serialize only this
+    // transport while preserving the callers' individual abort signals.
+    const pending = this.queue.then(run, run);
+    this.queue = pending.catch(() => {});
+    const result = await pending;
+    const text = Array.isArray(result.content)
+      ? result.content.filter(item => item.type === 'text').map(item => item.text).join('\n')
+      : '';
+    // Never fall back to an unauthenticated request or include a response body
+    // in a model-visible error; identity responses can contain private data.
+    if (result.isError) throw new Error('Codex browser authenticated request failed; check the Codex login and runtime connection');
+    let response: Json;
+    try { response = JSON.parse(text); }
+    catch { throw new Error('Codex browser authenticated runtime returned an invalid response'); }
+    if (!Number.isInteger(response.status) || response.status < 200 || response.status > 599
+      || !Array.isArray(response.headers) || typeof response.body !== 'string') {
+      throw new Error('Codex browser authenticated runtime returned an invalid response');
+    }
+    return new Response([204, 205, 304].includes(response.status) ? null : Buffer.from(response.body, 'base64'), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  private async getClient(): Promise<Client> {
+    if (this.closed) throw new Error('Codex browser authenticated runtime is closed');
+    if (this.client) return this.client;
+    const starting = this.starting ??= this.start();
+    try { return await starting; }
+    catch (error) {
+      if (this.starting === starting) this.starting = undefined;
+      throw error;
+    }
+  }
+
+  private async start(): Promise<Client> {
+    const result = await this.options.readConfig();
+    const runtime = resolveBrowserFetchRuntime(result.config ?? {});
+    if (this.closed) throw new Error('Codex browser authenticated runtime is closed');
+    const service = fileURLToPath(new URL('./codex-browser-fetch-service.js', import.meta.url));
+    const env = { ...getDefaultEnvironment() };
+    for (const [key, value] of Object.entries(runtime.env ?? {})) {
+      if (typeof value === 'string') env[key] = value;
+    }
+    env.CODEX_HOME = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex');
+    if (this.options.codexBin) env.CODEX_CLI_PATH = this.options.codexBin;
+    // Scope the extra trusted code entry to this single transport module. Do
+    // not grant trust to the checkout, working directory, or model input.
+    env.NODE_REPL_TRUSTED_CODE_PATHS = [env.NODE_REPL_TRUSTED_CODE_PATHS, service].filter(Boolean).join(delimiter);
+    env.NODE_REPL_TRUSTED_SERVICES = JSON.stringify({ botmux_browser_fetch: service });
+    const transport = new StdioClientTransport({
+      command: runtime.command,
+      args: Array.isArray(runtime.args) ? runtime.args : [],
+      env,
+      stderr: 'pipe',
+    });
+    // Drain diagnostics without forwarding credentials or server bodies into
+    // a Lark transcript. Errors are reported via the structured MCP response.
+    transport.stderr?.on('data', () => {});
+    const client = new Client({ name: 'botmux-browser-fetch', version: '1.0.0' }, { capabilities: {} });
+    client.onclose = () => {
+      if (this.client === client) {
+        this.client = undefined;
+        this.starting = undefined;
+        this.transport = undefined;
+      }
+    };
+    this.transport = transport;
+    try {
+      await client.connect(transport, { timeout: 10_000 });
+      if (this.closed) throw new Error('Codex browser authenticated runtime is closed');
+      this.client = client;
+      return client;
+    } catch (error) {
+      await client.close().catch(() => {});
+      if (this.transport === transport) this.transport = undefined;
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    await this.transport?.close();
+    this.client = undefined;
+    this.transport = undefined;
+  }
+}

--- a/src/services/codex-browser-authenticated-fetch.ts
+++ b/src/services/codex-browser-authenticated-fetch.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { delimiter, dirname, isAbsolute, join } from 'node:path';
 import { homedir } from 'node:os';
-import { fileURLToPath } from 'node:url';
+import { materializeBrowserFetchService } from './codex-browser-fetch-service.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
@@ -47,6 +47,7 @@ export class CodexBrowserAuthenticatedFetch {
   private transport?: StdioClientTransport;
   private starting?: Promise<Client>;
   private closed = false;
+  private disposeService?: () => void;
   private queue: Promise<unknown> = Promise.resolve();
 
   constructor(private readonly options: Options) {}
@@ -120,42 +121,49 @@ export class CodexBrowserAuthenticatedFetch {
     const result = await this.options.readConfig();
     const runtime = resolveBrowserFetchRuntime(result.config ?? {});
     if (this.closed) throw new Error('Codex browser authenticated runtime is closed');
-    const service = fileURLToPath(new URL('./codex-browser-fetch-service.js', import.meta.url));
-    const env = { ...getDefaultEnvironment() };
-    for (const [key, value] of Object.entries(runtime.env ?? {})) {
-      if (typeof value === 'string') env[key] = value;
-    }
-    env.CODEX_HOME = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex');
-    if (this.options.codexBin) env.CODEX_CLI_PATH = this.options.codexBin;
-    // Scope the extra trusted code entry to this single transport module. Do
-    // not grant trust to the checkout, working directory, or model input.
-    env.NODE_REPL_TRUSTED_CODE_PATHS = [env.NODE_REPL_TRUSTED_CODE_PATHS, service].filter(Boolean).join(delimiter);
-    env.NODE_REPL_TRUSTED_SERVICES = JSON.stringify({ botmux_browser_fetch: service });
-    const transport = new StdioClientTransport({
-      command: runtime.command,
-      args: Array.isArray(runtime.args) ? runtime.args : [],
-      env,
-      stderr: 'pipe',
-    });
-    // Drain diagnostics without forwarding credentials or server bodies into
-    // a Lark transcript. Errors are reported via the structured MCP response.
-    transport.stderr?.on('data', () => {});
-    const client = new Client({ name: 'botmux-browser-fetch', version: '1.0.0' }, { capabilities: {} });
-    client.onclose = () => {
-      if (this.client === client) {
-        this.client = undefined;
-        this.starting = undefined;
-        this.transport = undefined;
-      }
-    };
-    this.transport = transport;
+    const serviceModule = materializeBrowserFetchService();
+    const service = serviceModule.path;
+    this.disposeService = serviceModule.dispose;
+    let transport: StdioClientTransport | undefined;
+    let client: Client | undefined;
     try {
+      const env = { ...getDefaultEnvironment() };
+      for (const [key, value] of Object.entries(runtime.env ?? {})) {
+        if (typeof value === 'string') env[key] = value;
+      }
+      env.CODEX_HOME = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex');
+      if (this.options.codexBin) env.CODEX_CLI_PATH = this.options.codexBin;
+      // Scope the extra trusted code entry to this single transport module. Do
+      // not grant trust to the checkout, working directory, or model input.
+      env.NODE_REPL_TRUSTED_CODE_PATHS = [env.NODE_REPL_TRUSTED_CODE_PATHS, service].filter(Boolean).join(delimiter);
+      env.NODE_REPL_TRUSTED_SERVICES = JSON.stringify({ botmux_browser_fetch: service });
+      transport = new StdioClientTransport({
+        command: runtime.command,
+        args: Array.isArray(runtime.args) ? runtime.args : [],
+        env,
+        stderr: 'pipe',
+      });
+      // Drain diagnostics without forwarding credentials or server bodies into
+      // a Lark transcript. Errors are reported via the structured MCP response.
+      transport.stderr?.on('data', () => {});
+      client = new Client({ name: 'botmux-browser-fetch', version: '1.0.0' }, { capabilities: {} });
+      const connectedClient = client;
+      client.onclose = () => {
+        serviceModule.dispose();
+        if (this.client === connectedClient) {
+          this.client = undefined;
+          this.starting = undefined;
+          this.transport = undefined;
+        }
+      };
+      this.transport = transport;
       await client.connect(transport, { timeout: 10_000 });
       if (this.closed) throw new Error('Codex browser authenticated runtime is closed');
       this.client = client;
       return client;
     } catch (error) {
-      await client.close().catch(() => {});
+      await client?.close().catch(() => {});
+      serviceModule.dispose();
       if (this.transport === transport) this.transport = undefined;
       throw error;
     }
@@ -163,8 +171,12 @@ export class CodexBrowserAuthenticatedFetch {
 
   async close(): Promise<void> {
     this.closed = true;
-    await this.transport?.close();
-    this.client = undefined;
-    this.transport = undefined;
+    try { await this.transport?.close(); }
+    finally {
+      this.disposeService?.();
+      this.disposeService = undefined;
+      this.client = undefined;
+      this.transport = undefined;
+    }
   }
 }

--- a/src/services/codex-browser-broker.ts
+++ b/src/services/codex-browser-broker.ts
@@ -1,9 +1,12 @@
 import { existsSync, readdirSync, realpathSync } from 'node:fs';
+import { execFile } from 'node:child_process';
 import { createConnection, type Socket } from 'node:net';
 import { homedir, platform, tmpdir } from 'node:os';
 import { basename, isAbsolute, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 import type { CodexBrowserFamily } from '../core/codex-browser-config.js';
+import { CodexBrowserAuthenticatedFetch } from './codex-browser-authenticated-fetch.js';
 
 type Json = Record<string, any>;
 
@@ -15,9 +18,11 @@ export const CODEX_BROWSER_DYNAMIC_TOOL = {
   description: [
     'Control the user\'s explicitly configured Chrome or Edge browser through the installed Codex browser extension.',
     'Start with operation=list_tabs, then claim_tab before interacting with an existing user tab.',
-    'Use snapshot to get fresh accessibility element indexes; never reuse indexes after an action.',
-    'Supported operations: list_tabs, claim_tab, new_tab, selected_tab, tab_info, goto, snapshot, click, set_value, type_text, press_key, scroll, screenshot, reload, back, forward, mark_handoff, mark_deliverable, close_tab.',
-    'This tool does not expose cookies, local storage, browsing history, arbitrary JavaScript, raw CDP, clipboard, or file transfer.',
+    'Call capabilities after claiming a tab. Prefer snapshot and accessibility actions; snapshot automatically falls back to DOM when AX is unavailable.',
+    'For stable selectors or frontend testing, use locator_* operations. Use DOM or coordinate operations only when AX and locators are unsuitable.',
+    'For locator_upload, target the visible upload button or label that opens the chooser; use locator_count and locator_is_visible to disambiguate, and do not pick an arbitrary hidden input[type=file].',
+    'Browser security prompts are projected to a blocking Lark confirmation card and require an authorized human decision.',
+    'This tool does not expose cookies, local storage, browsing history, arbitrary JavaScript, raw CDP, or clipboard.',
   ].join(' '),
   inputSchema: {
     type: 'object',
@@ -27,9 +32,20 @@ export const CODEX_BROWSER_DYNAMIC_TOOL = {
       operation: {
         type: 'string',
         enum: [
-          'list_tabs', 'claim_tab', 'new_tab', 'selected_tab', 'tab_info',
+          'capabilities', 'list_tabs', 'claim_tab', 'new_tab', 'selected_tab', 'tab_info',
           'goto', 'snapshot', 'click', 'set_value', 'type_text', 'press_key',
-          'scroll', 'screenshot', 'reload', 'back', 'forward',
+          'scroll', 'select_text', 'secondary_action', 'drag',
+          'dom_snapshot', 'dom_click', 'dom_double_click', 'dom_type', 'dom_keypress', 'dom_scroll',
+          'coordinate_click', 'coordinate_double_click', 'coordinate_move', 'coordinate_drag',
+          'coordinate_type', 'coordinate_keypress', 'coordinate_scroll',
+          'locator_count', 'locator_text', 'locator_all_text', 'locator_click',
+          'locator_double_click', 'locator_fill', 'locator_type', 'locator_press',
+          'locator_check', 'locator_uncheck', 'locator_set_checked', 'locator_select_option',
+          'locator_wait', 'locator_is_visible', 'locator_is_enabled', 'locator_attribute',
+          'locator_download', 'locator_upload',
+          'wait_for_load_state', 'wait_for_url', 'wait',
+          'dialog_info', 'dialog_accept', 'dialog_dismiss',
+          'screenshot', 'reload', 'back', 'forward',
           'mark_handoff', 'mark_deliverable', 'close_tab',
         ],
       },
@@ -37,16 +53,138 @@ export const CODEX_BROWSER_DYNAMIC_TOOL = {
       url: { type: 'string', minLength: 1, maxLength: 16_384 },
       elementIndex: { type: 'integer', minimum: 0 },
       value: { type: 'string', maxLength: 100_000 },
+      text: { type: 'string', maxLength: 100_000 },
       key: { type: 'string', minLength: 1, maxLength: 256 },
       direction: { type: 'string', enum: ['up', 'down', 'left', 'right'] },
       pages: { type: 'number', exclusiveMinimum: 0, maximum: 20 },
       x: { type: 'number' },
       y: { type: 'number' },
+      x2: { type: 'number' },
+      y2: { type: 'number' },
+      deltaX: { type: 'number' },
+      deltaY: { type: 'number' },
+      nodeId: { type: 'string', minLength: 1, maxLength: 256 },
+      locatorType: { type: 'string', enum: ['selector', 'role', 'text', 'label', 'placeholder', 'test_id'] },
+      selector: { type: 'string', minLength: 1, maxLength: 16_384 },
+      frameSelector: { type: 'string', minLength: 1, maxLength: 16_384 },
+      role: { type: 'string', minLength: 1, maxLength: 256 },
+      name: { type: 'string', maxLength: 10_000 },
+      exact: { type: 'boolean' },
+      pick: { type: 'string', enum: ['first', 'last', 'nth'] },
+      nth: { type: 'integer', minimum: 0, maximum: 100_000 },
+      timeoutMs: { type: 'integer', minimum: 1, maximum: 60_000 },
+      attribute: { type: 'string', minLength: 1, maxLength: 512 },
+      checked: { type: 'boolean' },
+      values: { type: 'array', minItems: 1, maxItems: 100, items: { type: 'string', maxLength: 10_000 } },
+      files: { type: 'array', minItems: 1, maxItems: 20, items: { type: 'string', minLength: 1, maxLength: 16_384 } },
+      state: { type: 'string', enum: ['attached', 'detached', 'visible', 'hidden', 'load', 'domcontentloaded', 'networkidle'] },
+      waitUntil: { type: 'string', enum: ['load', 'domcontentloaded', 'networkidle', 'commit'] },
+      button: { type: 'string', enum: ['left', 'right', 'middle'] },
+      modifiers: { type: 'array', maxItems: 4, items: { type: 'string', enum: ['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift'] } },
+      prefix: { type: 'string', maxLength: 10_000 },
+      suffix: { type: 'string', maxLength: 10_000 },
+      selectionType: { type: 'string', enum: ['text', 'cursor_before', 'cursor_after'] },
+      secondaryAction: { type: 'string', minLength: 1, maxLength: 256 },
       disableDiffing: { type: 'boolean' },
       fullPage: { type: 'boolean' },
     },
   },
 } as const;
+
+interface BrowserAX {
+  click(target: number | [number, number], opts?: { mouseButton?: 'left' | 'right' }): Promise<void>;
+  drag(from: [number, number], to: [number, number]): Promise<void>;
+  get(mode?: 'state', opts?: { disableDiffing?: boolean }): Promise<string>;
+  performSecondaryAction(elementIndex: number, action: string): Promise<void>;
+  pressKey(key: string): Promise<void>;
+  scroll(target: number | [number, number], direction: 'up' | 'down' | 'left' | 'right', pages?: number): Promise<void>;
+  selectText(
+    elementIndex: number,
+    text: string,
+    opts?: { prefix?: string; selectionType?: 'text' | 'cursor_before' | 'cursor_after'; suffix?: string },
+  ): Promise<void>;
+  setValue(index: number, value: string): Promise<void>;
+  typeText(value: string): Promise<void>;
+}
+
+interface BrowserLocator {
+  allTextContents(opts: { timeoutMs?: number }): Promise<string[]>;
+  check(opts: { timeoutMs?: number }): Promise<void>;
+  click(opts: { button?: 'left' | 'right' | 'middle'; modifiers?: string[]; timeoutMs?: number }): Promise<void>;
+  count(): Promise<number>;
+  dblclick(opts: { button?: 'left' | 'right' | 'middle'; modifiers?: string[]; timeoutMs?: number }): Promise<void>;
+  fill(value: string, opts: { timeoutMs?: number }): Promise<void>;
+  first(): BrowserLocator;
+  getAttribute(name: string, opts: { timeoutMs?: number }): Promise<string | null>;
+  innerText(opts: { timeoutMs?: number }): Promise<string>;
+  isEnabled(): Promise<boolean>;
+  isVisible(): Promise<boolean>;
+  last(): BrowserLocator;
+  nth(index: number): BrowserLocator;
+  press(value: string, opts: { timeoutMs?: number }): Promise<void>;
+  selectOption(value: string | string[], opts: { timeoutMs?: number }): Promise<void>;
+  setChecked(checked: boolean, opts: { timeoutMs?: number }): Promise<void>;
+  textContent(opts: { timeoutMs?: number }): Promise<string | null>;
+  type(value: string, opts: { timeoutMs?: number }): Promise<void>;
+  uncheck(opts: { timeoutMs?: number }): Promise<void>;
+  waitFor(opts: { state: 'attached' | 'detached' | 'visible' | 'hidden'; timeoutMs?: number }): Promise<void>;
+}
+
+interface BrowserLocatorFactory {
+  getByLabel(text: string, opts: { exact?: boolean }): BrowserLocator;
+  getByPlaceholder(text: string, opts: { exact?: boolean }): BrowserLocator;
+  getByRole(role: string, opts: { exact?: boolean; name?: string }): BrowserLocator;
+  getByTestId(testId: string): BrowserLocator;
+  getByText(text: string, opts: { exact?: boolean }): BrowserLocator;
+  locator(selector: string): BrowserLocator;
+}
+
+interface BrowserPlaywright extends BrowserLocatorFactory {
+  domSnapshot(): Promise<string>;
+  frameLocator(frameSelector: string): BrowserLocatorFactory;
+  waitForEvent(event: 'download', opts?: { timeoutMs?: number }): Promise<{
+    path(opts: { timeoutMs?: number }): Promise<string | null>;
+  }>;
+  waitForEvent(event: 'filechooser', opts?: { timeoutMs?: number }): Promise<{
+    isMultiple(): boolean;
+    setFiles(files: string | string[], opts: { timeoutMs?: number }): Promise<void>;
+  }>;
+  waitForLoadState(opts: { state?: 'load' | 'domcontentloaded' | 'networkidle'; timeoutMs?: number }): Promise<void>;
+  waitForTimeout(timeoutMs: number): Promise<void>;
+  waitForURL(url: string, opts: {
+    timeoutMs?: number;
+    waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+  }): Promise<void>;
+}
+
+interface BrowserDomCua {
+  click(opts: { node_id: string }): Promise<void>;
+  double_click(opts: { node_id: string }): Promise<void>;
+  get_visible_dom(): Promise<unknown>;
+  keypress(opts: { keys: string[] }): Promise<void>;
+  scroll(opts: { node_id?: string; x: number; y: number }): Promise<void>;
+  type(opts: { text: string }): Promise<void>;
+}
+
+interface BrowserCua {
+  click(opts: { button?: number; keypress?: string[]; x: number; y: number }): Promise<void>;
+  double_click(opts: { keypress?: string[]; x: number; y: number }): Promise<void>;
+  drag(opts: { keys?: string[]; path: Array<{ x: number; y: number }> }): Promise<void>;
+  keypress(opts: { keys: string[] }): Promise<void>;
+  move(opts: { keys?: string[]; x: number; y: number }): Promise<void>;
+  scroll(opts: { keypress?: string[]; scrollX: number; scrollY: number; x: number; y: number }): Promise<void>;
+  type(opts: { text: string }): Promise<void>;
+}
+
+interface BrowserDialog {
+  type: 'alert' | 'beforeunload' | 'confirm' | 'prompt';
+  accept?: (text?: string) => Promise<void>;
+  dismiss(): Promise<void>;
+}
+
+interface BrowserCapabilityCollection {
+  list(): Promise<unknown[]>;
+}
 
 interface BrowserTab {
   id: string;
@@ -60,18 +198,17 @@ interface BrowserTab {
   screenshot(opts?: { fullPage?: boolean }): Promise<Uint8Array>;
   title(): Promise<string | undefined>;
   url(): Promise<string | undefined>;
-  ax: {
-    click(index: number): Promise<void>;
-    get(mode?: 'state', opts?: { disableDiffing?: boolean }): Promise<string>;
-    pressKey(key: string): Promise<void>;
-    scroll(target: number | [number, number], direction: 'up' | 'down' | 'left' | 'right', pages?: number): Promise<void>;
-    setValue(index: number, value: string): Promise<void>;
-    typeText(value: string): Promise<void>;
-  };
+  getJsDialog?(): Promise<BrowserDialog | undefined>;
+  capabilities?: BrowserCapabilityCollection;
+  ax?: BrowserAX;
+  playwright?: BrowserPlaywright;
+  dom_cua?: BrowserDomCua;
+  cua?: BrowserCua;
 }
 
 interface BrowserBinding {
   browserId: string;
+  capabilities?: BrowserCapabilityCollection;
   nameSession(name: string): Promise<void>;
   tabs: {
     get(id: string): Promise<BrowserTab>;
@@ -96,11 +233,33 @@ interface BrowserPluginModules {
 
 export interface CodexBrowserBrokerOptions {
   sessionId: string;
+  codexBin?: string;
   family: CodexBrowserFamily;
   pluginRoot?: string;
   /** Unit-test seam. Production always loads the installed Codex plugin. */
   modules?: BrowserPluginModules;
+  /** Unit-test seam. Production projects browser safety decisions into Lark. */
+  requestApproval?: BrowserApprovalHandler;
+  /** Security inputs from the same Codex app-server that owns this runner. */
+  readConfig?: (params: { cwd: string; includeLayers: boolean }) => Promise<Json>;
+  readConfigRequirements?: () => Promise<Json>;
 }
+
+export interface BrowserElicitationRequest {
+  message?: unknown;
+  meta?: Json;
+  _meta?: Json;
+  requestedSchema?: unknown;
+}
+
+export interface BrowserElicitationResponse {
+  action: 'accept' | 'decline' | 'cancel';
+  meta?: Json;
+}
+
+export type BrowserApprovalHandler = (
+  request: BrowserElicitationRequest,
+) => Promise<BrowserElicitationResponse>;
 
 export interface DynamicToolCallParams {
   arguments: unknown;
@@ -119,9 +278,12 @@ export interface DynamicToolCallResponse {
   success: boolean;
 }
 
-const TOOL_TIMEOUT_MS = 45_000;
+const TOOL_TIMEOUT_MS = 660_000;
 const MAX_TEXT_RESULT_BYTES = 512 * 1024;
 const MAX_SCREENSHOT_BYTES = 16 * 1024 * 1024;
+const MAX_OPERATION_TIMEOUT_MS = 60_000;
+const DEFAULT_FILE_CHOOSER_TIMEOUT_MS = 10_000;
+const execFileAsync = promisify(execFile);
 
 function requiredString(value: unknown, field: string, max = 100_000): string {
   if (typeof value !== 'string' || !value || Buffer.byteLength(value, 'utf8') > max) {
@@ -149,6 +311,153 @@ function requiredFinite(value: unknown, field: string): number {
     throw new Error(`${field} must be a finite number`);
   }
   return value;
+}
+
+function optionalString(value: unknown, field: string, max = 100_000): string | undefined {
+  if (value === undefined) return undefined;
+  return requiredText(value, field, max);
+}
+
+function requiredStringArray(value: unknown, field: string, maxItems = 100): string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > maxItems) {
+    throw new Error(`${field} must be a non-empty string array with at most ${maxItems} items`);
+  }
+  return value.map((item, index) => requiredString(item, `${field}[${index}]`, 16_384));
+}
+
+function optionalStringArray(value: unknown, field: string, maxItems = 100): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length > maxItems) {
+    throw new Error(`${field} must be a string array with at most ${maxItems} items`);
+  }
+  return value.map((item, index) => requiredString(item, `${field}[${index}]`, 16_384));
+}
+
+function operationTimeout(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const timeoutMs = requiredInteger(value, 'timeoutMs');
+  if (timeoutMs < 1 || timeoutMs > MAX_OPERATION_TIMEOUT_MS) {
+    throw new Error(`timeoutMs must be between 1 and ${MAX_OPERATION_TIMEOUT_MS}`);
+  }
+  return timeoutMs;
+}
+
+function requireCapability<T>(value: T | undefined, name: string): T {
+  if (!value) {
+    throw new Error(
+      `${name} is unavailable for this browser/tab; call capabilities and use an advertised fallback`,
+    );
+  }
+  return value;
+}
+
+function asMeta(request: BrowserElicitationRequest): Json {
+  return request.meta && typeof request.meta === 'object'
+    ? request.meta
+    : request._meta && typeof request._meta === 'object'
+      ? request._meta
+      : {};
+}
+
+function displayApprovalRequest(request: BrowserElicitationRequest): string {
+  const meta = asMeta(request);
+  const message = typeof request.message === 'string' ? request.message : '浏览器请求执行受保护操作';
+  const tool = typeof meta.tool_title === 'string'
+    ? meta.tool_title
+    : typeof meta.tool_name === 'string' ? meta.tool_name : undefined;
+  const origin = typeof meta.origin === 'string' ? meta.origin : undefined;
+  const risk = typeof meta.risk_level === 'string'
+    ? meta.risk_level
+    : typeof meta.riskLevel === 'string' ? meta.riskLevel : undefined;
+  return [
+    'BotMux 浏览器安全确认',
+    message,
+    tool ? `操作：${tool}` : undefined,
+    origin ? `站点：${origin}` : undefined,
+    risk ? `风险级别：${risk}` : undefined,
+    '请选择授权范围；拒绝或超时将取消操作。授权记录由 Browser Use 安全策略管理。',
+  ].filter(Boolean).join('\n').slice(0, 4_000);
+}
+
+function approvalOptions(meta: Json): string {
+  const persist = Array.isArray(meta.persist) ? meta.persist : [meta.persist];
+  if (persist.includes('session') || persist.includes('always')) {
+    return 'session=本会话允许,always=始终允许,decline=拒绝';
+  }
+  return 'approve=允许,decline=拒绝';
+}
+
+function sessionApprovalKey(request: BrowserElicitationRequest): string | undefined {
+  const meta = asMeta(request);
+  if (meta.codex_approval_kind === 'browser_auth') return undefined;
+
+  const persist = Array.isArray(meta.persist) ? meta.persist : [meta.persist];
+  if (!persist.includes('session') && !persist.includes('always')) return undefined;
+
+  const origin = typeof meta.origin === 'string' ? meta.origin.trim() : undefined;
+  const tool = typeof meta.tool_name === 'string'
+    ? meta.tool_name.trim()
+    : typeof meta.file_transfer === 'string' ? meta.file_transfer.trim() : undefined;
+  if (!origin || !tool) return undefined;
+
+  return JSON.stringify({
+    kind: typeof meta.codex_approval_kind === 'string' ? meta.codex_approval_kind : 'browser',
+    origin,
+    risk: typeof meta.riskLevel === 'string'
+      ? meta.riskLevel
+      : typeof meta.risk_level === 'string' ? meta.risk_level : undefined,
+    tool,
+  });
+}
+
+async function requestLarkBrowserApproval(
+  request: BrowserElicitationRequest,
+): Promise<BrowserElicitationResponse> {
+  const meta = asMeta(request);
+  if (meta.codex_approval_kind === 'browser_auth') {
+    // Authentication elicitations may contain secrets and require the Codex
+    // secure challenge broker. An ordinary Lark card must never impersonate it.
+    return { action: 'cancel' };
+  }
+  if (!process.env.BOTMUX_SESSION_ID || !process.env.BOTMUX_CHAT_ID || !process.env.BOTMUX_LARK_APP_ID) {
+    return { action: 'cancel' };
+  }
+  try {
+    const { stdout } = await execFileAsync('botmux', [
+      'ask',
+      'buttons',
+      '--json',
+      '--timeout',
+      '600',
+      '--options',
+      approvalOptions(meta),
+      displayApprovalRequest(request),
+    ], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024,
+      timeout: 610_000,
+      windowsHide: true,
+    });
+    const answer = JSON.parse(stdout) as { selected?: unknown; by?: unknown; timedOut?: unknown };
+    if (answer.selected === 'approve' || answer.selected === 'session' || answer.selected === 'always') {
+      return {
+        action: 'accept',
+        meta: {
+          approval_channel: 'lark',
+          approved_by: typeof answer.by === 'string' ? answer.by : 'authorized_user',
+          // A plain "允许" is intentionally a session grant. This keeps the
+          // common one-click flow useful without turning it into a persistent
+          // browser permission. The explicit "始终允许" option remains the
+          // only path that asks the browser plugin for durable permission.
+          persist: answer.selected === 'always' ? 'always' : 'session',
+        },
+      };
+    }
+    if (answer.selected === 'decline') return { action: 'decline' };
+    return { action: 'cancel' };
+  } catch {
+    return { action: 'cancel' };
+  }
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs = TOOL_TIMEOUT_MS): Promise<T> {
@@ -265,8 +574,11 @@ export class CodexBrowserBroker {
   private init?: Promise<BrowserBinding>;
   private readonly claimedTabs = new Map<string, BrowserTab>();
   private readonly configStore = new Map<string, Json>();
+  private readonly sessionApprovals = new Set<string>();
+  private readonly pendingApprovals = new Map<string, Promise<BrowserElicitationResponse>>();
   private previousNodeRepl: unknown;
   private runtimeShim?: Json;
+  private authenticatedFetch?: CodexBrowserAuthenticatedFetch;
 
   constructor(private readonly opts: CodexBrowserBrokerOptions) {}
 
@@ -314,27 +626,29 @@ export class CodexBrowserBroker {
 
     const tab = await this.getTab(requiredString(input.tabId, 'tabId', 256));
     switch (operation) {
+      case 'capabilities':
+        return textResult(await this.describeCapabilities(browser, tab));
       case 'tab_info':
         return textResult(await this.describeTab(tab));
       case 'goto':
         await tab.goto(requiredString(input.url, 'url', 16_384));
         return textResult(await this.describeTab(tab));
       case 'snapshot':
-        return textResult(await tab.ax.get('state', { disableDiffing: input.disableDiffing === true }));
+        return this.snapshot(tab, input.disableDiffing === true);
       case 'click':
-        await tab.ax.click(requiredInteger(input.elementIndex, 'elementIndex'));
+        await requireCapability(tab.ax, 'accessibility').click(requiredInteger(input.elementIndex, 'elementIndex'));
         return textResult({ ok: true });
       case 'set_value':
-        await tab.ax.setValue(
+        await requireCapability(tab.ax, 'accessibility').setValue(
           requiredInteger(input.elementIndex, 'elementIndex'),
           requiredText(input.value, 'value'),
         );
         return textResult({ ok: true });
       case 'type_text':
-        await tab.ax.typeText(requiredText(input.value, 'value'));
+        await requireCapability(tab.ax, 'accessibility').typeText(requiredText(input.value, 'value'));
         return textResult({ ok: true });
       case 'press_key':
-        await tab.ax.pressKey(requiredString(input.key, 'key', 256));
+        await requireCapability(tab.ax, 'accessibility').pressKey(requiredString(input.key, 'key', 256));
         return textResult({ ok: true });
       case 'scroll': {
         const direction = input.direction;
@@ -346,21 +660,228 @@ export class CodexBrowserBroker {
           : [requiredFinite(input.x, 'x'), requiredFinite(input.y, 'y')] as [number, number];
         const pages = input.pages === undefined ? undefined : requiredFinite(input.pages, 'pages');
         if (pages !== undefined && (pages <= 0 || pages > 20)) throw new Error('pages must be > 0 and <= 20');
-        await tab.ax.scroll(target, direction, pages);
+        await requireCapability(tab.ax, 'accessibility').scroll(target, direction, pages);
+        return textResult({ ok: true });
+      }
+      case 'select_text':
+        await requireCapability(tab.ax, 'accessibility').selectText(
+          requiredInteger(input.elementIndex, 'elementIndex'),
+          requiredText(input.value, 'value'),
+          {
+            prefix: optionalString(input.prefix, 'prefix', 10_000),
+            suffix: optionalString(input.suffix, 'suffix', 10_000),
+            selectionType: input.selectionType,
+          },
+        );
+        return textResult({ ok: true });
+      case 'secondary_action':
+        await requireCapability(tab.ax, 'accessibility').performSecondaryAction(
+          requiredInteger(input.elementIndex, 'elementIndex'),
+          requiredString(input.secondaryAction, 'secondaryAction', 256),
+        );
+        return textResult({ ok: true });
+      case 'drag':
+        await requireCapability(tab.ax, 'accessibility').drag(
+          [requiredFinite(input.x, 'x'), requiredFinite(input.y, 'y')],
+          [requiredFinite(input.x2, 'x2'), requiredFinite(input.y2, 'y2')],
+        );
+        return textResult({ ok: true });
+      case 'dom_snapshot':
+        return textResult(await requireCapability(tab.dom_cua, 'DOM CUA').get_visible_dom());
+      case 'dom_click':
+        await requireCapability(tab.dom_cua, 'DOM CUA').click({
+          node_id: requiredString(input.nodeId, 'nodeId', 256),
+        });
+        return textResult({ ok: true });
+      case 'dom_double_click':
+        await requireCapability(tab.dom_cua, 'DOM CUA').double_click({
+          node_id: requiredString(input.nodeId, 'nodeId', 256),
+        });
+        return textResult({ ok: true });
+      case 'dom_type':
+        await requireCapability(tab.dom_cua, 'DOM CUA').type({ text: requiredText(input.value, 'value') });
+        return textResult({ ok: true });
+      case 'dom_keypress':
+        await requireCapability(tab.dom_cua, 'DOM CUA').keypress({ keys: this.keys(input) });
+        return textResult({ ok: true });
+      case 'dom_scroll':
+        await requireCapability(tab.dom_cua, 'DOM CUA').scroll({
+          ...(input.nodeId === undefined ? {} : { node_id: requiredString(input.nodeId, 'nodeId', 256) }),
+          x: requiredFinite(input.deltaX, 'deltaX'),
+          y: requiredFinite(input.deltaY, 'deltaY'),
+        });
+        return textResult({ ok: true });
+      case 'coordinate_click':
+        await requireCapability(tab.cua, 'coordinate CUA').click({
+          x: requiredFinite(input.x, 'x'),
+          y: requiredFinite(input.y, 'y'),
+          button: this.coordinateButton(input.button),
+          keypress: optionalStringArray(input.modifiers, 'modifiers', 4),
+        });
+        return textResult({ ok: true });
+      case 'coordinate_double_click':
+        await requireCapability(tab.cua, 'coordinate CUA').double_click({
+          x: requiredFinite(input.x, 'x'),
+          y: requiredFinite(input.y, 'y'),
+          keypress: optionalStringArray(input.modifiers, 'modifiers', 4),
+        });
+        return textResult({ ok: true });
+      case 'coordinate_move':
+        await requireCapability(tab.cua, 'coordinate CUA').move({
+          x: requiredFinite(input.x, 'x'),
+          y: requiredFinite(input.y, 'y'),
+          keys: optionalStringArray(input.modifiers, 'modifiers', 4),
+        });
+        return textResult({ ok: true });
+      case 'coordinate_drag':
+        await requireCapability(tab.cua, 'coordinate CUA').drag({
+          path: [
+            { x: requiredFinite(input.x, 'x'), y: requiredFinite(input.y, 'y') },
+            { x: requiredFinite(input.x2, 'x2'), y: requiredFinite(input.y2, 'y2') },
+          ],
+          keys: optionalStringArray(input.modifiers, 'modifiers', 4),
+        });
+        return textResult({ ok: true });
+      case 'coordinate_type':
+        await requireCapability(tab.cua, 'coordinate CUA').type({ text: requiredText(input.value, 'value') });
+        return textResult({ ok: true });
+      case 'coordinate_keypress':
+        await requireCapability(tab.cua, 'coordinate CUA').keypress({ keys: this.keys(input) });
+        return textResult({ ok: true });
+      case 'coordinate_scroll':
+        await requireCapability(tab.cua, 'coordinate CUA').scroll({
+          x: requiredFinite(input.x, 'x'),
+          y: requiredFinite(input.y, 'y'),
+          scrollX: requiredFinite(input.deltaX, 'deltaX'),
+          scrollY: requiredFinite(input.deltaY, 'deltaY'),
+          keypress: optionalStringArray(input.modifiers, 'modifiers', 4),
+        });
+        return textResult({ ok: true });
+      case 'locator_count':
+        return textResult({ count: await this.locator(tab, input).count() });
+      case 'locator_text': {
+        const timeoutMs = operationTimeout(input.timeoutMs);
+        const locator = this.locator(tab, input);
+        return textResult({
+          innerText: await locator.innerText({ timeoutMs }),
+          textContent: await locator.textContent({ timeoutMs }),
+        });
+      }
+      case 'locator_all_text':
+        return textResult(await this.locator(tab, input).allTextContents({
+          timeoutMs: operationTimeout(input.timeoutMs),
+        }));
+      case 'locator_click':
+        await this.locator(tab, input).click(this.locatorClickOptions(input));
+        return textResult({ ok: true });
+      case 'locator_double_click':
+        await this.locator(tab, input).dblclick(this.locatorClickOptions(input));
+        return textResult({ ok: true });
+      case 'locator_fill':
+        await this.locator(tab, input).fill(requiredText(input.value, 'value'), {
+          timeoutMs: operationTimeout(input.timeoutMs),
+        });
+        return textResult({ ok: true });
+      case 'locator_type':
+        await this.locator(tab, input).type(requiredText(input.value, 'value'), {
+          timeoutMs: operationTimeout(input.timeoutMs),
+        });
+        return textResult({ ok: true });
+      case 'locator_press':
+        await this.locator(tab, input).press(requiredString(input.key, 'key', 256), {
+          timeoutMs: operationTimeout(input.timeoutMs),
+        });
+        return textResult({ ok: true });
+      case 'locator_check':
+        await this.locator(tab, input).check({ timeoutMs: operationTimeout(input.timeoutMs) });
+        return textResult({ ok: true });
+      case 'locator_uncheck':
+        await this.locator(tab, input).uncheck({ timeoutMs: operationTimeout(input.timeoutMs) });
+        return textResult({ ok: true });
+      case 'locator_set_checked':
+        if (typeof input.checked !== 'boolean') throw new Error('checked must be a boolean');
+        await this.locator(tab, input).setChecked(input.checked, {
+          timeoutMs: operationTimeout(input.timeoutMs),
+        });
+        return textResult({ ok: true });
+      case 'locator_select_option': {
+        const values = requiredStringArray(input.values, 'values');
+        await this.locator(tab, input).selectOption(values.length === 1 ? values[0]! : values, {
+          timeoutMs: operationTimeout(input.timeoutMs),
+        });
+        return textResult({ ok: true });
+      }
+      case 'locator_wait': {
+        const state = input.state;
+        if (!['attached', 'detached', 'visible', 'hidden'].includes(state)) {
+          throw new Error('state must be attached, detached, visible, or hidden');
+        }
+        await this.locator(tab, input).waitFor({ state, timeoutMs: operationTimeout(input.timeoutMs) });
+        return textResult({ ok: true });
+      }
+      case 'locator_is_visible':
+        return textResult({ visible: await this.locator(tab, input).isVisible() });
+      case 'locator_is_enabled':
+        return textResult({ enabled: await this.locator(tab, input).isEnabled() });
+      case 'locator_attribute':
+        return textResult({
+          value: await this.locator(tab, input).getAttribute(
+            requiredString(input.attribute, 'attribute', 512),
+            { timeoutMs: operationTimeout(input.timeoutMs) },
+          ),
+        });
+      case 'locator_download':
+        return textResult({ path: await this.locatorDownload(tab, input) });
+      case 'locator_upload':
+        await this.locatorUpload(tab, input);
+        return textResult({ ok: true });
+      case 'wait_for_load_state': {
+        const state = input.state;
+        if (state !== undefined && !['load', 'domcontentloaded', 'networkidle'].includes(state)) {
+          throw new Error('state must be load, domcontentloaded, or networkidle');
+        }
+        await requireCapability(tab.playwright, 'Playwright').waitForLoadState({
+          state,
+          timeoutMs: operationTimeout(input.timeoutMs),
+        });
+        return textResult({ ok: true });
+      }
+      case 'wait_for_url': {
+        const waitUntil = input.waitUntil;
+        if (waitUntil !== undefined && !['load', 'domcontentloaded', 'networkidle', 'commit'].includes(waitUntil)) {
+          throw new Error('waitUntil must be load, domcontentloaded, networkidle, or commit');
+        }
+        await requireCapability(tab.playwright, 'Playwright').waitForURL(
+          requiredString(input.url, 'url', 16_384),
+          { waitUntil, timeoutMs: operationTimeout(input.timeoutMs) },
+        );
+        return textResult({ ok: true });
+      }
+      case 'wait': {
+        const timeoutMs = operationTimeout(input.timeoutMs);
+        if (timeoutMs === undefined) throw new Error('timeoutMs is required');
+        await requireCapability(tab.playwright, 'Playwright').waitForTimeout(timeoutMs);
+        return textResult({ ok: true });
+      }
+      case 'dialog_info': {
+        const dialog = await requireCapability(tab.getJsDialog, 'JavaScript dialog').call(tab);
+        return textResult(dialog ? { type: dialog.type } : { dialog: null });
+      }
+      case 'dialog_accept': {
+        const dialog = await requireCapability(tab.getJsDialog, 'JavaScript dialog').call(tab);
+        if (!dialog) throw new Error('there is no active JavaScript dialog');
+        if (!dialog.accept) throw new Error(`${dialog.type} dialog cannot be accepted`);
+        await dialog.accept(dialog.type === 'prompt' ? requiredText(input.value, 'value') : undefined);
+        return textResult({ ok: true });
+      }
+      case 'dialog_dismiss': {
+        const dialog = await requireCapability(tab.getJsDialog, 'JavaScript dialog').call(tab);
+        if (!dialog) throw new Error('there is no active JavaScript dialog');
+        await dialog.dismiss();
         return textResult({ ok: true });
       }
       case 'screenshot': {
-        const bytes = await tab.screenshot({ fullPage: input.fullPage === true });
-        if (bytes.byteLength > MAX_SCREENSHOT_BYTES) {
-          throw new Error(`screenshot exceeds ${MAX_SCREENSHOT_BYTES} bytes`);
-        }
-        return {
-          contentItems: [{
-            type: 'inputImage',
-            imageUrl: `data:image/jpeg;base64,${Buffer.from(bytes).toString('base64')}`,
-          }],
-          success: true,
-        };
+        return this.screenshot(tab, input.fullPage === true);
       }
       case 'reload': await tab.reload(); return textResult({ ok: true });
       case 'back': await tab.back(); return textResult({ ok: true });
@@ -376,11 +897,206 @@ export class CodexBrowserBroker {
     }
   }
 
+  private async snapshot(tab: BrowserTab, disableDiffing: boolean): Promise<DynamicToolCallResponse> {
+    if (tab.ax?.get) {
+      return textResult(await tab.ax.get('state', { disableDiffing }));
+    }
+    if (tab.dom_cua?.get_visible_dom) {
+      return textResult({ representation: 'visible_dom', snapshot: await tab.dom_cua.get_visible_dom() });
+    }
+    if (tab.playwright?.domSnapshot) {
+      return textResult({ representation: 'playwright_dom', snapshot: await tab.playwright.domSnapshot() });
+    }
+    return this.screenshot(tab, false);
+  }
+
+  private async screenshot(tab: BrowserTab, fullPage: boolean): Promise<DynamicToolCallResponse> {
+    const bytes = await tab.screenshot({ fullPage });
+    if (bytes.byteLength > MAX_SCREENSHOT_BYTES) {
+      throw new Error(`screenshot exceeds ${MAX_SCREENSHOT_BYTES} bytes`);
+    }
+    return {
+      contentItems: [{
+        type: 'inputImage',
+        imageUrl: `data:image/jpeg;base64,${Buffer.from(bytes).toString('base64')}`,
+      }],
+      success: true,
+    };
+  }
+
+  private async describeCapabilities(browser: BrowserBinding, tab: BrowserTab): Promise<Json> {
+    return {
+      browserFamily: this.opts.family,
+      browserId: browser.browserId,
+      tabId: tab.id,
+      core: {
+        navigation: typeof tab.goto === 'function',
+        screenshot: typeof tab.screenshot === 'function',
+        dialogs: typeof tab.getJsDialog === 'function',
+        markHandoff: typeof tab.markHandoff === 'function',
+        markDeliverable: typeof tab.markDeliverable === 'function',
+      },
+      interaction: {
+        accessibility: !!tab.ax,
+        playwright: !!tab.playwright,
+        domCua: !!tab.dom_cua,
+        coordinateCua: !!tab.cua,
+      },
+      advertised: {
+        browser: await this.capabilityIds(browser.capabilities),
+        tab: await this.capabilityIds(tab.capabilities),
+      },
+      restrictedByBotmux: [
+        'arbitrary JavaScript',
+        'raw CDP',
+        'cookies and local storage',
+        'browser history',
+        'clipboard',
+        'secure credential collection',
+      ],
+    };
+  }
+
+  private async capabilityIds(collection: BrowserCapabilityCollection | undefined): Promise<Json> {
+    if (!collection?.list) return { available: false, ids: [] };
+    try {
+      return { available: true, ids: await collection.list() };
+    } catch (error) {
+      return { available: true, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  private locator(tab: BrowserTab, input: Json): BrowserLocator {
+    const playwright = requireCapability(tab.playwright, 'Playwright');
+    const factory = input.frameSelector === undefined
+      ? playwright
+      : playwright.frameLocator(requiredString(input.frameSelector, 'frameSelector', 16_384));
+    const exact = input.exact === true;
+    let locator: BrowserLocator;
+    switch (input.locatorType ?? 'selector') {
+      case 'selector':
+        locator = factory.locator(requiredString(input.selector, 'selector', 16_384));
+        break;
+      case 'role':
+        locator = factory.getByRole(requiredString(input.role, 'role', 256), {
+          exact,
+          name: optionalString(input.name, 'name', 10_000),
+        });
+        break;
+      case 'text':
+        locator = factory.getByText(this.locatorText(input), { exact });
+        break;
+      case 'label':
+        locator = factory.getByLabel(this.locatorText(input), { exact });
+        break;
+      case 'placeholder':
+        locator = factory.getByPlaceholder(this.locatorText(input), { exact });
+        break;
+      case 'test_id':
+        locator = factory.getByTestId(this.locatorText(input));
+        break;
+      default:
+        throw new Error('locatorType must be selector, role, text, label, placeholder, or test_id');
+    }
+    if (input.pick === 'first') return locator.first();
+    if (input.pick === 'last') return locator.last();
+    if (input.pick === 'nth') return locator.nth(requiredInteger(input.nth, 'nth'));
+    if (input.pick !== undefined) throw new Error('pick must be first, last, or nth');
+    return locator;
+  }
+
+  private locatorText(input: Json): string {
+    return requiredString(input.text ?? input.value, 'text', 100_000);
+  }
+
+  private locatorClickOptions(input: Json): {
+    button?: 'left' | 'right' | 'middle';
+    modifiers?: string[];
+    timeoutMs?: number;
+  } {
+    const button = input.button;
+    if (button !== undefined && !['left', 'right', 'middle'].includes(button)) {
+      throw new Error('button must be left, right, or middle');
+    }
+    return {
+      button,
+      modifiers: optionalStringArray(input.modifiers, 'modifiers', 4),
+      timeoutMs: operationTimeout(input.timeoutMs),
+    };
+  }
+
+  private keys(input: Json): string[] {
+    const key = requiredString(input.key, 'key', 256);
+    return [...(optionalStringArray(input.modifiers, 'modifiers', 4) ?? []), key];
+  }
+
+  private coordinateButton(value: unknown): number | undefined {
+    if (value === undefined) return undefined;
+    switch (value) {
+      case 'left': return 1;
+      case 'middle': return 2;
+      case 'right': return 3;
+      default: throw new Error('button must be left, right, or middle');
+    }
+  }
+
+  private async locatorDownload(tab: BrowserTab, input: Json): Promise<string | null> {
+    const playwright = requireCapability(tab.playwright, 'Playwright');
+    const timeoutMs = operationTimeout(input.timeoutMs);
+    const downloadPromise = playwright.waitForEvent('download', { timeoutMs });
+    await this.locator(tab, input).click(this.locatorClickOptions(input));
+    return (await downloadPromise).path({ timeoutMs });
+  }
+
+  private async locatorUpload(tab: BrowserTab, input: Json): Promise<void> {
+    const playwright = requireCapability(tab.playwright, 'Playwright');
+    // The browser plugin's implicit filechooser timeout is only a few seconds
+    // in some installed versions. Uploads commonly need longer for a custom
+    // input/label click to dispatch, so keep a safe explicit default while
+    // still allowing callers to provide a bounded override.
+    const timeoutMs = operationTimeout(input.timeoutMs) ?? DEFAULT_FILE_CHOOSER_TIMEOUT_MS;
+    const files = requiredStringArray(input.files, 'files', 20);
+    const locator = this.locator(tab, input);
+    if (!await locator.isVisible()) {
+      throw new Error(
+        'upload locator is hidden; target the visible upload button or label that opens the file chooser instead of a hidden input[type=file]',
+      );
+    }
+    const chooserPromise = playwright.waitForEvent('filechooser', { timeoutMs });
+    try {
+      await locator.click({
+        ...this.locatorClickOptions(input),
+        timeoutMs,
+      });
+    } catch (error) {
+      // A failed click leaves the plugin's waiter alive. Older browser plugin
+      // builds reject that waiter later, which otherwise becomes an unhandled
+      // rejection and can terminate the Codex App runner after the original
+      // (useful) click error has already been returned.
+      void chooserPromise.catch(() => {});
+      throw error;
+    }
+    const chooser = await chooserPromise;
+    if (!chooser.isMultiple() && files.length > 1) {
+      throw new Error('the selected file input does not accept multiple files');
+    }
+    await chooser.setFiles(files.length === 1 ? files[0]! : files, { timeoutMs });
+  }
+
   private async getBrowser(): Promise<BrowserBinding> {
     if (this.browser) return this.browser;
-    this.init ??= this.initialize();
-    this.browser = await this.init;
-    return this.browser;
+    const init = this.init ??= this.initialize();
+    try {
+      this.browser = await init;
+      return this.browser;
+    } catch (error) {
+      // Extension/native-host availability can change after the first tool
+      // call (for example when the user enables or reconnects the extension).
+      // Do not permanently cache that transient discovery failure: the next
+      // browser operation must perform a fresh discovery attempt.
+      if (this.init === init) this.init = undefined;
+      throw error;
+    }
   }
 
   private async initialize(): Promise<BrowserBinding> {
@@ -400,7 +1116,59 @@ export class CodexBrowserBroker {
     return browser;
   }
 
+  private async requestBrowserApproval(
+    request: BrowserElicitationRequest,
+  ): Promise<BrowserElicitationResponse> {
+    const key = sessionApprovalKey(request);
+    if (key && this.sessionApprovals.has(key)) {
+      return {
+        action: 'accept',
+        meta: {
+          approval_channel: 'lark',
+          approval_scope: 'session-cache',
+          approved_by: 'authorized_user_session',
+          persist: 'session',
+        },
+      };
+    }
+
+    const pending = key ? this.pendingApprovals.get(key) : undefined;
+    if (pending) return pending;
+
+    const handler = this.opts.requestApproval ?? requestLarkBrowserApproval;
+    const approval = handler(request).then(response => {
+      if (response.action !== 'accept' || !key) return response;
+      this.sessionApprovals.add(key);
+      return {
+        ...response,
+        meta: {
+          ...(response.meta ?? {}),
+          approval_scope: 'session-cache',
+          // Preserve an explicit durable choice, otherwise make a normal
+          // approval session-scoped for the browser plugin as well.
+          persist: response.meta?.persist ?? 'session',
+        },
+      };
+    });
+    if (!key) return approval;
+
+    this.pendingApprovals.set(key, approval);
+    try {
+      return await approval;
+    } finally {
+      if (this.pendingApprovals.get(key) === approval) this.pendingApprovals.delete(key);
+    }
+  }
+
   private createRuntimeShim(): Json {
+    this.authenticatedFetch ??= new CodexBrowserAuthenticatedFetch({
+      codexBin: this.opts.codexBin,
+      readConfig: async () => {
+        if (!this.opts.readConfig) throw new Error('Codex config reader is unavailable');
+        return this.opts.readConfig({ cwd: process.cwd(), includeLayers: false });
+      },
+      requestMeta: () => this.runtimeShim?.requestMeta ?? {},
+    });
     const requestMeta: Record<string, string> = {};
     const shim: Json = {
       env: { ...process.env },
@@ -411,18 +1179,27 @@ export class CodexBrowserBroker {
       requestMeta,
       nativePipe: { createConnection: connectNativePipe },
       config: {
-        read: async () => ({}),
-        readRequirements: async () => ({}),
+        read: async (params?: { cwd?: unknown; includeLayers?: unknown }) => {
+          if (!this.opts.readConfig) throw new Error('Codex config reader is unavailable');
+          return this.opts.readConfig({
+            cwd: typeof params?.cwd === 'string' ? params.cwd : process.cwd(),
+            includeLayers: params?.includeLayers === true,
+          });
+        },
+        readRequirements: async () => {
+          if (!this.opts.readConfigRequirements) {
+            throw new Error('Codex config requirements reader is unavailable');
+          }
+          return this.opts.readConfigRequirements();
+        },
         readToml: async (path: string) => this.configStore.get(path) ?? {},
         writeToml: async (path: string, value: Json) => { this.configStore.set(path, value); },
       },
-      // Botmux does not yet project Codex browser approval forms into Lark.
-      // Cancel instead of guessing or bypassing the plugin's safety policy.
-      createElicitation: async () => ({ action: 'cancel' }),
+      createElicitation: (request: BrowserElicitationRequest) => this.requestBrowserApproval(request),
       setResponseMeta: () => {},
       addAfterSubmittedCodeHook: () => {},
       emitContentItem: () => {},
-      fetch: globalThis.fetch,
+      fetch: this.authenticatedFetch.fetch,
       emitImage: () => {},
       write: () => {},
       rpc: undefined,
@@ -459,10 +1236,11 @@ export class CodexBrowserBroker {
   }
 
   /** Test/process cleanup; production runner teardown exits the process. */
-  close(): void {
+  close(): Promise<void> {
     if ((globalThis as Json).nodeRepl === this.runtimeShim) {
       if (this.previousNodeRepl === undefined) delete (globalThis as Json).nodeRepl;
       else (globalThis as Json).nodeRepl = this.previousNodeRepl;
     }
+    return this.authenticatedFetch?.close() ?? Promise.resolve();
   }
 }

--- a/src/services/codex-browser-broker.ts
+++ b/src/services/codex-browser-broker.ts
@@ -5,6 +5,7 @@ import { homedir, platform, tmpdir } from 'node:os';
 import { basename, isAbsolute, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
+import { findMissingAskEnv } from '../core/ask-args.js';
 import type { CodexBrowserFamily } from '../core/codex-browser-config.js';
 import { CodexBrowserAuthenticatedFetch } from './codex-browser-authenticated-fetch.js';
 
@@ -403,9 +404,9 @@ function sessionApprovalKey(request: BrowserElicitationRequest): string | undefi
   return JSON.stringify({
     kind: typeof meta.codex_approval_kind === 'string' ? meta.codex_approval_kind : 'browser',
     origin,
-    risk: typeof meta.riskLevel === 'string'
-      ? meta.riskLevel
-      : typeof meta.risk_level === 'string' ? meta.risk_level : undefined,
+    risk: typeof meta.risk_level === 'string'
+      ? meta.risk_level
+      : typeof meta.riskLevel === 'string' ? meta.riskLevel : undefined,
     tool,
   });
 }
@@ -419,7 +420,7 @@ async function requestLarkBrowserApproval(
     // secure challenge broker. An ordinary Lark card must never impersonate it.
     return { action: 'cancel' };
   }
-  if (!process.env.BOTMUX_SESSION_ID || !process.env.BOTMUX_CHAT_ID || !process.env.BOTMUX_LARK_APP_ID) {
+  if (findMissingAskEnv(process.env) !== null) {
     return { action: 'cancel' };
   }
   try {
@@ -1044,6 +1045,8 @@ export class CodexBrowserBroker {
     const playwright = requireCapability(tab.playwright, 'Playwright');
     const timeoutMs = operationTimeout(input.timeoutMs);
     const downloadPromise = playwright.waitForEvent('download', { timeoutMs });
+    // Attach immediately: the waiter may reject before the click settles.
+    void downloadPromise.catch(() => {});
     await this.locator(tab, input).click(this.locatorClickOptions(input));
     return (await downloadPromise).path({ timeoutMs });
   }
@@ -1063,6 +1066,7 @@ export class CodexBrowserBroker {
       );
     }
     const chooserPromise = playwright.waitForEvent('filechooser', { timeoutMs });
+    void chooserPromise.catch(() => {});
     try {
       await locator.click({
         ...this.locatorClickOptions(input),

--- a/src/services/codex-browser-fetch-service.ts
+++ b/src/services/codex-browser-fetch-service.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 /** Runs only in the installed Codex runtime's trusted process. Authentication,
  * destination restrictions and token refresh remain owned by that runtime. */
 interface FetchMessage {
@@ -24,4 +28,22 @@ export async function handleRpc(request: { method: string; params: FetchMessage 
     headers: [...response.headers.entries()],
     body: Buffer.from(await response.arrayBuffer()).toString('base64'),
   };
+}
+
+/** Keep handleRpc self-contained: its compiled function body is embedded by
+ * static import, then materialized for the separate trusted runtime process.
+ * Never pass a checkout or Bun virtual filesystem path to that process. */
+export function materializeBrowserFetchService(): { path: string; dispose: () => void } {
+  const directory = mkdtempSync(join(tmpdir(), 'botmux-browser-fetch-'));
+  const path = join(directory, 'codex-browser-fetch-service.mjs');
+  const dispose = () => rmSync(directory, { recursive: true, force: true });
+  try {
+    writeFileSync(path, `export const handleRpc = ${handleRpc.toString()};\n`, {
+      encoding: 'utf8', mode: 0o600, flag: 'wx',
+    });
+    return { path, dispose };
+  } catch (error) {
+    dispose();
+    throw error;
+  }
 }

--- a/src/services/codex-browser-fetch-service.ts
+++ b/src/services/codex-browser-fetch-service.ts
@@ -1,0 +1,27 @@
+/** Runs only in the installed Codex runtime's trusted process. Authentication,
+ * destination restrictions and token refresh remain owned by that runtime. */
+interface FetchMessage {
+  url: string;
+  method: string;
+  headers: [string, string][];
+  body?: string;
+}
+
+export async function handleRpc(request: { method: string; params: FetchMessage }): Promise<unknown> {
+  if (request.method !== 'fetch') throw new Error('Unsupported browser fetch operation');
+  const runtime = (globalThis as unknown as { nodeRepl: { fetch: typeof fetch } }).nodeRepl;
+  const { url, method, headers, body } = request.params;
+  const response = await runtime.fetch(url, {
+    method,
+    headers,
+    ...(body === undefined ? {} : { body: Buffer.from(body, 'base64') }),
+    signal: AbortSignal.timeout(30_000),
+    redirect: 'error',
+  });
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: [...response.headers.entries()],
+    body: Buffer.from(await response.arrayBuffer()).toString('base64'),
+  };
+}

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -2564,7 +2564,12 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
     const control = new ControlCollector(dir);
     await control.listen();
     const harness = startRunner(fakeCodex, dir, logPath, '0.144.6', 'success', control.bootstrap.path, {
-      extraArgs: ['--thread-id', 'thread-existing-1', '--model', 'gpt-5.6-terra', '--reasoning-effort', 'xhigh'],
+      extraArgs: [
+        '--thread-id', 'thread-existing-1',
+        '--model', 'gpt-5.6-terra',
+        '--reasoning-effort', 'xhigh',
+        '--browser-family', 'chrome',
+      ],
     });
     try {
       await waitFor(harness, () => harness.stdout.includes('Codex App connected.'));
@@ -2577,6 +2582,12 @@ describe('codex-app-runner app-server protocol integration', { timeout: 120_000,
       expect(start).toBeFalsy();            // a warm resume must not fresh-start
       expect(resume.params.model).toBeUndefined();                          // no top-level model
       expect(resume.params.config?.model_reasoning_effort).toBeUndefined(); // no effort
+      expect(resume.params.dynamicTools).toEqual([
+        expect.objectContaining({
+          type: 'function',
+          name: 'botmux_browser',
+        }),
+      ]);
     } finally {
       await stopChild(harness.child);
       await control.close();

--- a/test/codex-browser-authenticated-fetch.test.ts
+++ b/test/codex-browser-authenticated-fetch.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CodexBrowserAuthenticatedFetch, resolveBrowserFetchRuntime } from '../src/services/codex-browser-authenticated-fetch.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { handleRpc } from '../src/services/codex-browser-fetch-service.js';
+
+const mock = vi.hoisted(() => ({
+  callTool: vi.fn(), connect: vi.fn(), close: vi.fn(), transport: vi.fn(),
+}));
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    callTool = mock.callTool;
+    connect = mock.connect;
+    close = mock.close;
+  },
+}));
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  getDefaultEnvironment: () => ({ PATH: '/usr/bin' }),
+  StdioClientTransport: class {
+    constructor(options: unknown) { mock.transport(options); }
+    close = mock.close;
+  },
+}));
+
+function result(body = 'ok', status = 200) {
+  return { content: [{ type: 'text', text: JSON.stringify({
+    status, statusText: '', headers: [['content-type', 'text/plain']],
+    body: Buffer.from(body).toString('base64'),
+  }) }] };
+}
+function config() {
+  return { config: { mcp_servers: { node_repl: {
+    command: process.execPath, args: [], env: { NODE_REPL_TRUSTED_CODE_PATHS: '/trusted' },
+  } } } };
+}
+
+describe('CodexBrowserAuthenticatedFetch', () => {
+  let fetcher: CodexBrowserAuthenticatedFetch;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mock.connect.mockResolvedValue(undefined);
+    mock.close.mockResolvedValue(undefined);
+    mock.callTool.mockResolvedValue(result());
+    fetcher = new CodexBrowserAuthenticatedFetch({
+      readConfig: async () => config(), requestMeta: () => ({ 'x-codex-turn-metadata': 'turn-meta' }),
+    });
+  });
+  afterEach(async () => { await fetcher.close(); vi.unstubAllEnvs(); });
+
+  it('uses the installed authenticated runtime and preserves HTTP request/response data', async () => {
+    const response = await fetcher.fetch('https://chatgpt.com/backend-api/aura/identity', {
+      method: 'POST', headers: { 'x-test': 'value' }, body: 'hello',
+    });
+    expect(await response.text()).toBe('ok');
+    const call = mock.callTool.mock.calls[0]![0];
+    expect(call._meta).toEqual({ 'x-codex-turn-metadata': 'turn-meta' });
+    expect(call.arguments.code).toContain('"body":"aGVsbG8="');
+    expect(call.arguments.code).toContain('"x-test","value"');
+    const env = mock.transport.mock.calls[0]![0].env;
+    expect(JSON.parse(env.NODE_REPL_TRUSTED_SERVICES).botmux_browser_fetch).toMatch(/codex-browser-fetch-service\.js$/);
+    expect(env.NODE_REPL_TRUSTED_CODE_PATHS).toMatch(/codex-browser-fetch-service\.js$/);
+    expect(env.LARK_APP_SECRET).toBeUndefined();
+  });
+
+  it('serializes concurrent requests and reuses one authenticated process', async () => {
+    let release!: (value: unknown) => void;
+    mock.callTool.mockImplementationOnce(() => new Promise(resolve => { release = resolve; }));
+    const first = fetcher.fetch('https://chatgpt.com/first');
+    const second = fetcher.fetch('https://chatgpt.com/second');
+    await vi.waitFor(() => expect(mock.callTool).toHaveBeenCalledTimes(1));
+    release(result());
+    await Promise.all([first, second]);
+    expect(mock.callTool).toHaveBeenCalledTimes(2);
+    expect(mock.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed without leaking runtime errors or falling back to plain fetch', async () => {
+    mock.callTool.mockResolvedValueOnce({ isError: true, content: [{ type: 'text', text: 'secret-token' }] });
+    await expect(fetcher.fetch('https://chatgpt.com/')).rejects.toThrow('authenticated request failed');
+    await expect(fetcher.fetch('https://chatgpt.com/')).resolves.toBeInstanceOf(Response);
+  });
+
+  it('retries a failed runtime startup', async () => {
+    mock.connect.mockRejectedValueOnce(new Error('offline'));
+    await expect(fetcher.fetch('https://chatgpt.com/')).rejects.toThrow('offline');
+    await expect(fetcher.fetch('https://chatgpt.com/')).resolves.toBeInstanceOf(Response);
+    expect(mock.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not start a runtime for an already aborted request', async () => {
+    await expect(fetcher.fetch('https://chatgpt.com/', { signal: AbortSignal.abort() })).rejects.toThrow();
+    expect(mock.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests after shutdown', async () => {
+    await fetcher.close();
+    await expect(fetcher.fetch('https://chatgpt.com/')).rejects.toThrow('closed');
+  });
+
+  it('preserves bodyless HTTP responses', async () => {
+    mock.callTool.mockResolvedValueOnce(result('', 204));
+    const response = await fetcher.fetch('https://chatgpt.com/');
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+  });
+
+  it('reports missing runtime configuration instead of sending an anonymous request', async () => {
+    vi.stubEnv('BOTMUX_CODEX_NODE_REPL_PATH', '/definitely-missing-botmux-runtime/node_repl');
+    const missing = new CodexBrowserAuthenticatedFetch({ readConfig: async () => ({}), requestMeta: () => ({}) });
+    await expect(missing.fetch('https://chatgpt.com/')).rejects.toThrow('authenticated runtime was not found');
+    expect(mock.callTool).not.toHaveBeenCalled();
+    await missing.close();
+  });
+
+  it('works after the desktop removes the node_repl MCP registration', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-browser-runtime-'));
+    try {
+      const command = join(root, 'node_repl');
+      writeFileSync(command, 'fixture');
+      writeFileSync(join(root, process.platform === 'win32' ? 'node.exe' : 'node'), 'fixture');
+      vi.stubEnv('BOTMUX_CODEX_NODE_REPL_PATH', command);
+      const fallback = new CodexBrowserAuthenticatedFetch({
+        readConfig: async () => ({ config: { mcp_servers: { botmux: {} } } }),
+        requestMeta: () => ({}), codexBin: '/installed/codex',
+      });
+      await expect(fallback.fetch('https://chatgpt.com/')).resolves.toBeInstanceOf(Response);
+      expect(mock.transport.mock.calls.at(-1)![0]).toMatchObject({
+        command, env: { CODEX_CLI_PATH: '/installed/codex', NODE_REPL_NODE_PATH: join(root, process.platform === 'win32' ? 'node.exe' : 'node') },
+      });
+      await fallback.close();
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it('prefers a valid registered runtime and fails when no installed runtime exists', () => {
+    expect(resolveBrowserFetchRuntime(config().config, [])).toEqual(config().config.mcp_servers.node_repl);
+    expect(() => resolveBrowserFetchRuntime({}, [])).toThrow('runtime was not found');
+  });
+});
+
+describe('trusted fetch service', () => {
+  it('delegates authentication to the official runtime and preserves non-200 status', async () => {
+    const globals = globalThis as unknown as { nodeRepl?: unknown };
+    const previous = globals.nodeRepl;
+    const fetch = vi.fn(async () => new Response('denied', { status: 403 }));
+    globals.nodeRepl = { fetch };
+    try {
+      const response = await handleRpc({ method: 'fetch', params: {
+        url: 'https://chatgpt.com/backend-api/aura/identity', method: 'POST',
+        headers: [], body: Buffer.from('body').toString('base64'),
+      } });
+      expect(response).toMatchObject({ status: 403, body: Buffer.from('denied').toString('base64') });
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(fetch.mock.calls[0]).toEqual([
+        'https://chatgpt.com/backend-api/aura/identity',
+        expect.objectContaining({ body: Buffer.from('body'), redirect: 'error' }),
+      ]);
+    } finally { globals.nodeRepl = previous; }
+  });
+});

--- a/test/codex-browser-authenticated-fetch.test.ts
+++ b/test/codex-browser-authenticated-fetch.test.ts
@@ -1,6 +1,9 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { resolveBunExecutable, resolveNodeExecutable, spawnSyncBunTsEvalWithRepoImports } from './helpers/ts-runner.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CodexBrowserAuthenticatedFetch, resolveBrowserFetchRuntime } from '../src/services/codex-browser-authenticated-fetch.js';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { handleRpc } from '../src/services/codex-browser-fetch-service.js';
@@ -58,9 +61,14 @@ describe('CodexBrowserAuthenticatedFetch', () => {
     expect(call.arguments.code).toContain('"body":"aGVsbG8="');
     expect(call.arguments.code).toContain('"x-test","value"');
     const env = mock.transport.mock.calls[0]![0].env;
-    expect(JSON.parse(env.NODE_REPL_TRUSTED_SERVICES).botmux_browser_fetch).toMatch(/codex-browser-fetch-service\.js$/);
-    expect(env.NODE_REPL_TRUSTED_CODE_PATHS).toMatch(/codex-browser-fetch-service\.js$/);
+    expect(JSON.parse(env.NODE_REPL_TRUSTED_SERVICES).botmux_browser_fetch).toMatch(/codex-browser-fetch-service\.mjs$/);
+    expect(env.NODE_REPL_TRUSTED_CODE_PATHS).toMatch(/codex-browser-fetch-service\.mjs$/);
     expect(env.LARK_APP_SECRET).toBeUndefined();
+    const service = JSON.parse(env.NODE_REPL_TRUSTED_SERVICES).botmux_browser_fetch;
+    expect(readFileSync(service, 'utf8')).toContain('export const handleRpc');
+    if (process.platform !== 'win32') expect(statSync(service).mode & 0o777).toBe(0o600);
+    await fetcher.close();
+    expect(existsSync(service)).toBe(false);
   });
 
   it('serializes concurrent requests and reuses one authenticated process', async () => {
@@ -84,6 +92,8 @@ describe('CodexBrowserAuthenticatedFetch', () => {
   it('retries a failed runtime startup', async () => {
     mock.connect.mockRejectedValueOnce(new Error('offline'));
     await expect(fetcher.fetch('https://chatgpt.com/')).rejects.toThrow('offline');
+    const service = JSON.parse(mock.transport.mock.calls[0]![0].env.NODE_REPL_TRUSTED_SERVICES).botmux_browser_fetch;
+    expect(existsSync(service)).toBe(false);
     await expect(fetcher.fetch('https://chatgpt.com/')).resolves.toBeInstanceOf(Response);
     expect(mock.connect).toHaveBeenCalledTimes(2);
   });
@@ -158,3 +168,38 @@ describe('trusted fetch service', () => {
     } finally { globals.nodeRepl = previous; }
   });
 });
+
+// This must cross a real process boundary: Bun's virtual filesystem is only
+// visible inside the compiled executable. Minification matches release builds.
+it.skipIf(!resolveBunExecutable())('materializes an executable trusted service from a minified Bun binary', () => {
+  const root = mkdtempSync(join(tmpdir(), 'botmux-browser-compiled-'));
+  try {
+    const entry = join(root, 'entry.ts');
+    const binary = join(root, process.platform === 'win32' ? 'probe.exe' : 'probe');
+    writeFileSync(entry, `
+      import { materializeBrowserFetchService } from ${JSON.stringify(resolve('src/services/codex-browser-fetch-service.ts'))};
+      import { spawnSync } from 'node:child_process';
+      import { existsSync } from 'node:fs';
+      import { pathToFileURL } from 'node:url';
+      const service = materializeBrowserFetchService();
+      try {
+        const code = 'globalThis.nodeRepl = { fetch: async () => new Response("compiled-ok", {status: 201}) };' +
+          'const {handleRpc} = await import(' + JSON.stringify(pathToFileURL(service.path).href) + ');' +
+          'const result = await handleRpc({method:"fetch",params:{url:"https://example.test",method:"GET",headers:[]}});' +
+          'if(result.status !== 201 || Buffer.from(result.body,"base64").toString() !== "compiled-ok") throw Error("bad response");';
+        const child = spawnSync(process.argv[2], ['--input-type=module', '-e', code], {encoding:'utf8'});
+        if(child.status !== 0) throw Error(child.stderr || String(child.error));
+      } finally { service.dispose(); }
+      if(existsSync(service.path)) throw Error('service was not cleaned up');
+      console.log('compiled service passed');
+    `);
+    const build = spawnSyncBunTsEvalWithRepoImports(`
+      const result = await Bun.build({entrypoints:[${JSON.stringify(entry)}], compile:{outfile:${JSON.stringify(binary)}}, minify:true});
+      if(!result.success) throw Error(String(result.logs));
+    `, { encoding: 'utf8', timeout: 60_000 });
+    expect(build.status, String(build.stderr)).toBe(0);
+    const run = spawnSync(binary, [resolveNodeExecutable()!], { encoding: 'utf8', timeout: 20_000 });
+    expect(run.status, String(run.stderr)).toBe(0);
+    expect(run.stdout).toContain('compiled service passed');
+  } finally { rmSync(root, {recursive:true, force:true}); }
+}, 90_000);

--- a/test/codex-browser-broker.test.ts
+++ b/test/codex-browser-broker.test.ts
@@ -64,6 +64,7 @@ function fakeModules() {
   return {
     actions,
     browser,
+    tab,
     modules: {
       handleRpc: vi.fn(async () => ({})),
       setupBrowserRuntime: vi.fn(async () => ({
@@ -97,6 +98,28 @@ describe.sequential('CodexBrowserBroker', () => {
     const claimed = await broker.handleToolCall(call({ operation: 'claim_tab', tabId: 'user-7' }));
     expect(claimed.success).toBe(true);
     expect(fake.browser.user.claimTab).toHaveBeenCalledOnce();
+  });
+
+  it('retries browser discovery after a transient extension connection failure', async () => {
+    const fake = fakeModules();
+    const get = vi.fn()
+      .mockRejectedValueOnce(new Error('Browser is not available: chrome'))
+      .mockResolvedValue(fake.browser);
+    fake.modules.setupBrowserRuntime = vi.fn(async () => ({ browsers: { get } }));
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-reconnect',
+      family: 'chrome',
+      modules: fake.modules,
+    });
+
+    const disconnected = await broker.handleToolCall(call({ operation: 'list_tabs' }));
+    expect(disconnected.success).toBe(false);
+    expect((disconnected.contentItems[0] as { text: string }).text).toContain('Browser is not available: chrome');
+
+    const reconnected = await broker.handleToolCall(call({ operation: 'list_tabs' }));
+    expect(reconnected.success).toBe(true);
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(fake.modules.setupBrowserRuntime).toHaveBeenCalledTimes(2);
   });
 
   it('supports bounded accessibility actions without arbitrary JavaScript', async () => {
@@ -148,6 +171,282 @@ describe.sequential('CodexBrowserBroker', () => {
       contentItems: [{ type: 'inputImage', imageUrl: 'data:image/jpeg;base64,/9j/2Q==' }],
       success: true,
     });
+  });
+
+  it('detects optional capabilities and falls back from AX to the visible DOM', async () => {
+    const fake = fakeModules();
+    delete (fake.tab as { ax?: unknown }).ax;
+    Object.assign(fake.tab, {
+      capabilities: { list: vi.fn(async () => ['tab.example']) },
+      dom_cua: {
+        get_visible_dom: vi.fn(async () => ({ node_id: 'dom-1', role: 'button', text: 'Continue' })),
+      },
+    });
+    Object.assign(fake.browser, {
+      capabilities: { list: vi.fn(async () => ['browser.example']) },
+    });
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-dom',
+      family: 'chrome',
+      modules: fake.modules,
+    });
+
+    const snapshot = await broker.handleToolCall(call({ operation: 'snapshot', tabId: 'claimed-7' }));
+    expect(snapshot.success).toBe(true);
+    expect((snapshot.contentItems[0] as { text: string }).text).toContain('visible_dom');
+    expect((snapshot.contentItems[0] as { text: string }).text).toContain('Continue');
+
+    const capabilities = await broker.handleToolCall(call({ operation: 'capabilities', tabId: 'claimed-7' }));
+    expect(capabilities.success).toBe(true);
+    expect(JSON.parse((capabilities.contentItems[0] as { text: string }).text)).toMatchObject({
+      interaction: { accessibility: false, domCua: true, playwright: false },
+      advertised: {
+        browser: { available: true, ids: ['browser.example'] },
+        tab: { available: true, ids: ['tab.example'] },
+      },
+    });
+  });
+
+  it('uses typed Playwright locators without exposing JavaScript evaluation', async () => {
+    const fake = fakeModules();
+    const locator = {
+      click: vi.fn(async () => {}),
+      first: vi.fn(),
+    };
+    locator.first.mockReturnValue(locator);
+    Object.assign(fake.tab, {
+      playwright: {
+        getByRole: vi.fn(() => locator),
+      },
+    });
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-locator',
+      family: 'chrome',
+      modules: fake.modules,
+    });
+
+    const result = await broker.handleToolCall(call({
+      operation: 'locator_click',
+      tabId: 'claimed-7',
+      locatorType: 'role',
+      role: 'button',
+      name: 'Continue',
+      exact: true,
+      pick: 'first',
+      timeoutMs: 5000,
+    }));
+    expect(result.success).toBe(true);
+    expect((fake.tab as any).playwright.getByRole).toHaveBeenCalledWith('button', {
+      exact: true,
+      name: 'Continue',
+    });
+    expect(locator.click).toHaveBeenCalledWith({
+      button: undefined,
+      modifiers: undefined,
+      timeoutMs: 5000,
+    });
+  });
+
+  it('uses an explicit 10-second default for file chooser uploads', async () => {
+    const fake = fakeModules();
+    const setFiles = vi.fn(async () => {});
+    const chooser = {
+      isMultiple: vi.fn(() => false),
+      setFiles,
+    };
+    const waitForEvent = vi.fn(async () => chooser);
+    const locator = {
+      click: vi.fn(async () => {}),
+      isVisible: vi.fn(async () => true),
+    };
+    Object.assign(fake.tab, {
+      playwright: {
+        locator: vi.fn(() => locator),
+        waitForEvent,
+      },
+    });
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-upload',
+      family: 'chrome',
+      modules: fake.modules,
+    });
+
+    const result = await broker.handleToolCall(call({
+      operation: 'locator_upload',
+      tabId: 'claimed-7',
+      selector: 'input[type="file"]',
+      files: ['/tmp/example.mp4'],
+    }));
+
+    expect(result.success).toBe(true);
+    expect(waitForEvent).toHaveBeenCalledWith('filechooser', { timeoutMs: 10_000 });
+    expect(locator.click).toHaveBeenCalledWith({
+      button: undefined,
+      modifiers: undefined,
+      timeoutMs: 10_000,
+    });
+    expect(setFiles).toHaveBeenCalledWith('/tmp/example.mp4', { timeoutMs: 10_000 });
+  });
+
+  it('consumes a late file chooser rejection when the upload click fails first', async () => {
+    const fake = fakeModules();
+    let rejectChooser!: (reason: Error) => void;
+    const chooserPromise = new Promise<never>((_resolve, reject) => {
+      rejectChooser = reject;
+    });
+    const locator = {
+      click: vi.fn(async () => { throw new Error('upload input is not clickable'); }),
+      isVisible: vi.fn(async () => true),
+    };
+    Object.assign(fake.tab, {
+      playwright: {
+        locator: vi.fn(() => locator),
+        waitForEvent: vi.fn(() => chooserPromise),
+      },
+    });
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-upload-click-failure',
+      family: 'chrome',
+      modules: fake.modules,
+    });
+
+    const result = await broker.handleToolCall(call({
+      operation: 'locator_upload',
+      tabId: 'claimed-7',
+      selector: 'input[type="file"]',
+      files: ['/tmp/example.mp4'],
+    }));
+
+    expect(result.success).toBe(false);
+    expect((result.contentItems[0] as { text: string }).text).toContain('upload input is not clickable');
+    rejectChooser(new Error('late file chooser timeout'));
+    await new Promise(resolve => setImmediate(resolve));
+  });
+
+  it('rejects a hidden upload input before starting a file chooser waiter', async () => {
+    const fake = fakeModules();
+    const waitForEvent = vi.fn();
+    const locator = {
+      click: vi.fn(),
+      isVisible: vi.fn(async () => false),
+    };
+    Object.assign(fake.tab, {
+      playwright: {
+        locator: vi.fn(() => locator),
+        waitForEvent,
+      },
+    });
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-upload-hidden-input',
+      family: 'chrome',
+      modules: fake.modules,
+    });
+
+    const result = await broker.handleToolCall(call({
+      operation: 'locator_upload',
+      tabId: 'claimed-7',
+      selector: 'input[type="file"]',
+      files: ['/tmp/example.mp4'],
+    }));
+
+    expect(result.success).toBe(false);
+    expect((result.contentItems[0] as { text: string }).text).toContain('upload locator is hidden');
+    expect(waitForEvent).not.toHaveBeenCalled();
+    expect(locator.click).not.toHaveBeenCalled();
+  });
+
+  it('forwards browser safety elicitations to the injected approval handler', async () => {
+    const fake = fakeModules();
+    const requestApproval = vi.fn(async () => ({ action: 'accept' as const, meta: { reviewer: 'user-1' } }));
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-approval',
+      family: 'chrome',
+      modules: fake.modules,
+      requestApproval,
+    });
+    await broker.handleToolCall(call({ operation: 'list_tabs' }));
+
+    const request = {
+      message: 'Allow upload?',
+      meta: { codex_approval_kind: 'mcp_tool_call', origin: 'https://example.test' },
+    };
+    const response = await (globalThis as any).nodeRepl.createElicitation(request);
+    expect(requestApproval).toHaveBeenCalledWith(request);
+    expect(response).toEqual({ action: 'accept', meta: { reviewer: 'user-1' } });
+  });
+
+  it('caches accepted session-scoped approvals per origin and tool', async () => {
+    const fake = fakeModules();
+    const requestApproval = vi.fn(async () => ({ action: 'accept' as const }));
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-approval-cache',
+      family: 'chrome',
+      modules: fake.modules,
+      requestApproval,
+    });
+    await broker.handleToolCall(call({ operation: 'list_tabs' }));
+
+    const request = {
+      message: 'Allow upload?',
+      meta: {
+        codex_approval_kind: 'mcp_tool_call',
+        persist: ['session', 'always'],
+        origin: 'https://example.test',
+        tool_name: 'upload_browser_files',
+      },
+    };
+    const createElicitation = (globalThis as any).nodeRepl.createElicitation;
+    await expect(createElicitation(request)).resolves.toMatchObject({
+      action: 'accept',
+      meta: { approval_scope: 'session-cache', persist: 'session' },
+    });
+    await expect(createElicitation(request)).resolves.toMatchObject({
+      action: 'accept',
+      meta: { approval_scope: 'session-cache', approved_by: 'authorized_user_session' },
+    });
+    await expect(createElicitation({
+      ...request,
+      meta: { ...request.meta, origin: 'https://other.example' },
+    })).resolves.toMatchObject({ action: 'accept' });
+
+    expect(requestApproval).toHaveBeenCalledTimes(2);
+  });
+
+  it('reads browser security policy from the owning Codex app-server', async () => {
+    const fake = fakeModules();
+    const readConfig = vi.fn(async () => ({ config: { browser_use: {} }, origins: {} }));
+    const readConfigRequirements = vi.fn(async () => ({ requirements: null }));
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-policy',
+      family: 'chrome',
+      modules: fake.modules,
+      readConfig,
+      readConfigRequirements,
+    });
+    await broker.handleToolCall(call({ operation: 'list_tabs' }));
+
+    await expect((globalThis as any).nodeRepl.config.read({
+      cwd: '/tmp/example',
+      includeLayers: false,
+    })).resolves.toEqual({ config: { browser_use: {} }, origins: {} });
+    await expect((globalThis as any).nodeRepl.config.readRequirements())
+      .resolves.toEqual({ requirements: null });
+    expect(readConfig).toHaveBeenCalledWith({ cwd: '/tmp/example', includeLayers: false });
+    expect(readConfigRequirements).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed for secure browser authentication elicitations', async () => {
+    const fake = fakeModules();
+    broker = new CodexBrowserBroker({
+      sessionId: 'session-auth',
+      family: 'chrome',
+      modules: fake.modules,
+    });
+    await broker.handleToolCall(call({ operation: 'list_tabs' }));
+    await expect((globalThis as any).nodeRepl.createElicitation({
+      message: 'Enter credentials',
+      meta: { codex_approval_kind: 'browser_auth' },
+    })).resolves.toEqual({ action: 'cancel' });
   });
 
   it('fails closed for a different tool or namespace', async () => {

--- a/test/codex-browser-broker.test.ts
+++ b/test/codex-browser-broker.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+const approvalExec = vi.hoisted(() => vi.fn((...args: any[]) => {
+  args.at(-1)(null, JSON.stringify({ answer: 'approve' }), '');
+}));
+vi.mock('node:child_process', async importOriginal => ({
+  ...await importOriginal<typeof import('node:child_process')>(), execFile: approvalExec,
+}));
 import {
   CODEX_BROWSER_TOOL_NAME,
   CodexBrowserBroker,
@@ -80,6 +86,7 @@ describe.sequential('CodexBrowserBroker', () => {
   afterEach(() => {
     broker?.close();
     broker = undefined;
+    vi.unstubAllEnvs();
   });
 
   it('lists and claims only explicitly requested user tabs', async () => {
@@ -323,6 +330,43 @@ describe.sequential('CodexBrowserBroker', () => {
     await new Promise(resolve => setImmediate(resolve));
   });
 
+  it('downloads through the locator and returns the downloaded path', async () => {
+    const fake = fakeModules();
+    const path = vi.fn(async () => '/tmp/report.csv');
+    const click = vi.fn(async () => {});
+    const waitForEvent = vi.fn(async () => ({ path }));
+    Object.assign(fake.tab, { playwright: { locator: () => ({ click }), waitForEvent } });
+    broker = new CodexBrowserBroker({ sessionId: 'download', family: 'chrome', modules: fake.modules });
+    const result = await broker.handleToolCall(call({ operation: 'locator_download', tabId: 'claimed-7', selector: 'button', timeoutMs: 5000 }));
+    expect(result.success).toBe(true);
+    expect(waitForEvent).toHaveBeenCalledWith('download', { timeoutMs: 5000 });
+    expect(path).toHaveBeenCalledWith({ timeoutMs: 5000 });
+  });
+
+  it('attaches a download rejection handler before clicking, including when the click fails', async () => {
+    const fake = fakeModules();
+    let rejectDownload!: (reason: Error) => void;
+    const waiter = new Promise<never>((_, reject) => { rejectDownload = reject; });
+    // Inspect registration directly: vi.fn returning a promise can otherwise
+    // mask an unhandled rejection in Vitest's bookkeeping.
+    const consume = vi.spyOn(waiter, 'catch');
+    let attachedBeforeClick = false;
+    Object.assign(fake.tab, { playwright: {
+      locator: () => ({ click: async () => {
+        attachedBeforeClick = consume.mock.calls.length > 0;
+        throw new Error('download click failed');
+      } }),
+      waitForEvent: () => waiter,
+    } });
+    broker = new CodexBrowserBroker({ sessionId: 'download-failure', family: 'chrome', modules: fake.modules });
+    const result = await broker.handleToolCall(call({ operation: 'locator_download', tabId: 'claimed-7', selector: 'button' }));
+    expect(result.success).toBe(false);
+    expect((result.contentItems[0] as { text: string }).text).toContain('download click failed');
+    expect(attachedBeforeClick).toBe(true);
+    rejectDownload(new Error('late download timeout'));
+    await new Promise(resolve => setImmediate(resolve));
+  });
+
   it('rejects a hidden upload input before starting a file chooser waiter', async () => {
     const fake = fakeModules();
     const waitForEvent = vi.fn();
@@ -436,6 +480,10 @@ describe.sequential('CodexBrowserBroker', () => {
   });
 
   it('fails closed for secure browser authentication elicitations', async () => {
+    for (const key of ['BOTMUX_SESSION_ID', 'BOTMUX_CHAT_ID', 'BOTMUX_LARK_APP_ID', 'BOTMUX_ROOT_MESSAGE_ID']) {
+      vi.stubEnv(key, 'browser-auth-test');
+    }
+    approvalExec.mockClear();
     const fake = fakeModules();
     broker = new CodexBrowserBroker({
       sessionId: 'session-auth',
@@ -447,6 +495,7 @@ describe.sequential('CodexBrowserBroker', () => {
       message: 'Enter credentials',
       meta: { codex_approval_kind: 'browser_auth' },
     })).resolves.toEqual({ action: 'cancel' });
+    expect(approvalExec).not.toHaveBeenCalled();
   });
 
   it('fails closed for a different tool or namespace', async () => {


### PR DESCRIPTION
Chrome 会话在已发现浏览器后，仍可能因缺少 AX 能力、认证运行时未注册或恢复线程未注册工具而无法继续操作。本 PR 扩展显式启用的 `codexBrowser` 桥接，使用已安装的 Codex 插件和认证运行时完成浏览器操作。

## 改动

- 探测页面能力，AX 不可用时回退至可见 DOM；提供 locator、DOM、坐标、弹窗及受控文件上传下载操作。
- HTTP 请求通过 Codex 官方认证运行时执行；支持运行时发现、串行请求、取消与连接清理，认证失败时关闭操作。
- 认证服务通过静态引用进入编译模块图，在独立临时目录写入仅当前用户可读写的 `.mjs` 文件，再交给运行时子进程加载；连接关闭或启动失败时清理，避免传递 `/$bunfs/` 虚拟路径。
- 上传和下载均在点击前接管 waiter 的拒绝，防止点击失败或等待事件先超时后产生未处理异常。
- 恢复线程时重新注册浏览器工具；沿用既有飞书授权流程，凭证类请求不会降级成普通飞书卡片。会话授权缓存仍按站点、操作与风险区分。
- 复用完整的 ask 环境检查，统一风险字段优先级，更新中英文配置和环境变量文档。

## 影响范围

改动集中在浏览器服务，runner 仅涉及浏览器接线、恢复注册与关闭清理。未修改其他 CLI 适配器、公共后端、业务工程或 Harness；没有业务 URL、工程路径、业务 selector 或配置依赖。浏览器功能未配置即关闭，运行时仍依赖 Codex 浏览器插件及官方认证组件。

未添加任意 JavaScript、原始 CDP、Cookie、历史或剪贴板接口，也未添加全局自动批准逻辑。

## 验证

- `bun run build`：构建、类型检查、发行资产审计通过。
- `node node_modules/vitest/vitest.mjs run --project unit test/codex-browser-authenticated-fetch.test.ts test/codex-browser-broker.test.ts test/codex-app-runner.integration.test.ts`：82 项通过。启动异常清理最后调整后，再跑两个浏览器测试文件，30 项通过。
- 编译回归使用本机 Bun 1.4.0，生成开启 minify 的真实单文件可执行程序，再由独立 Node 子进程加载落盘服务、执行模拟认证请求、验证响应并检查清理。CI 固定 Bun 1.4.1；本地尚未验证该版本。
- 下载回归覆盖成功路径及点击失败后晚到的 waiter 拒绝，并直接断言点击前已注册拒绝处理，避免 mock 掩盖未处理异常。凭证类授权测试补齐四项环境变量并断言没有调用普通飞书授权命令。
- 此前在 Linux + Chrome 源码运行环境验证过认证 identity 请求、列出和认领真实标签页，以及正常站点授权检查。本轮为 PR 修复验证，未替换正在运行的本地服务。
- 尚未验证 macOS、Windows、Edge，以及完整发行二进制连接真实 Chrome 的端到端流程；编译回归使用真实二进制与模拟认证传输。
