### PR TITLE
chore(build): bun 统一升级到 1.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
         with:
           node-version: 22
 
-      # Bun is the package manager (packageManager: bun@1.4.1). node-pty's native
+      # Bun is the package manager (packageManager: bun@1.4.2). node-pty's native
       # build runs only because it is in `trustedDependencies` — bun skips
       # dependency lifecycle scripts otherwise, and the sandbox/PTY tests below
       # need a real build/Release/pty.node.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: bun run workflow-core:test
@@ -84,7 +84,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       - run: bun install --frozen-lockfile
       - run: bun run build
       # Wrapper retries once only when every file already passed and vitest's
@@ -146,7 +146,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       - run: bun install --frozen-lockfile
       - run: bun run build
       # Exercise the runner itself before the 20-minute suite. `node --check` cannot
@@ -240,7 +240,7 @@ jobs:
               # prebuild and must compile here. binutils supplies readelf.
               apk add --no-cache python3 make g++ libstdc++ binutils >/dev/null
 
-              npm i -g bun@1.4.1 --loglevel=error
+              npm i -g bun@1.4.2 --loglevel=error
               echo "bun $(bun --version) on $(uname -m)"
 
               # Compiles node-pty against MUSL — the entire point of this job.
@@ -363,7 +363,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
 
       # node-pty SHIPS darwin prebuilds (prebuilds/darwin-{x64,arm64}/pty.node
       # plus the spawn-helper sidecar), which is why ONE macOS runner can emit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       - run: bun install --frozen-lockfile
 
       - name: Sync version from git tag to package.json
@@ -314,7 +314,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       - run: bun install --frozen-lockfile
 
       - name: Upgrade npm for Trusted Publishing
@@ -707,7 +707,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: matrix.glibc_baseline == ''
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       # --frozen-lockfile + the platform's own install compiles node-pty's
       # build/Release/pty.node for THIS OS/arch, which the embed plugin bundles.
       - if: matrix.glibc_baseline == ''
@@ -887,7 +887,7 @@ jobs:
 
               # setup-bun does not support musl, and npm ships musl builds of bun
               # (@oven/bun-linux-{x64,aarch64}-musl), so npm is the way in.
-              npm i -g bun@1.4.1 --loglevel=error
+              npm i -g bun@1.4.2 --loglevel=error
               echo "bun $(bun --version) on $(uname -m)"
 
               # Compiles node-pty against MUSL — the whole point of this job.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ bun run daemon:logs          # 查看日志
 
 - 每次修改后需要 `bun run build` 然后 `bun run daemon:restart`
 
-**包管理器是 bun**（`packageManager: bun@1.4.1`，锁文件 `bun.lock`）。装依赖用 `bun install --frozen-lockfile`。
+**包管理器是 bun**（`packageManager: bun@1.4.2`，锁文件 `bun.lock`）。装依赖用 `bun install --frozen-lockfile`。
 
 ⚠️ `trustedDependencies: ["electron","node-pty"]` **不能删**：bun 默认**不跑依赖的生命周期脚本**，而 `node-pty` 要靠它 `node-gyp` 编出 `build/Release/pty.node` —— 少了这个，PTY 全废、编译版二进制也打不出来（`pty.node` 是被嵌进去的）。electron 的 postinstall 负责下载对应平台的二进制。
 
@@ -31,7 +31,7 @@ bun run dashboard:bun        # bun src/index-dashboard.ts
 bun run build:bun            # 打自包含单文件二进制（scripts/build-bun-binary.mjs）
 ```
 
-发版编译用的 Bun 版本**钉在 1.4.1**（见 `.github/workflows/`）。本地 bun 与它差太多时，编译产物的行为可能和 CI 不一致——排查编译态问题前先核对 `bun --version`。
+发版编译用的 Bun 版本**钉在 1.4.2**（见 `.github/workflows/`）。本地 bun 与它差太多时，编译产物的行为可能和 CI 不一致——排查编译态问题前先核对 `bun --version`。
 
 **测试里 spawn 子进程必须走 `test/helpers/ts-runner.ts`**，不要写 `spawn(process.execPath, ['--import','tsx', …])`：那是 Node-only 形态，Bun 下 `process.execPath` 是 bun 二进制、`bun --import tsx` 不合法，子进程会全部起不来。helper 按运行时解析（Node 加 tsx loader、Bun 原生跑 TS）。片段里 import 仓库模块（`.js` specifier 实际是 `.ts`）时用 `spawnTsEvalWithRepoImports`，普通 `spawnTsEval` 在 Node 下会 ERR_MODULE_NOT_FOUND。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ bun run daemon:logs
 
 > Every code change requires `bun run build` then `bun run daemon:restart`.
 
-> **Package manager is [bun](https://bun.sh)** (`packageManager: bun@1.4.1`,
+> **Package manager is [bun](https://bun.sh)** (`packageManager: bun@1.4.2`,
 > lockfile `bun.lock`). `trustedDependencies` in `package.json` must keep
 > `node-pty`: bun does not run dependency lifecycle scripts by default, and
 > `node-pty` needs its install hook to build `build/Release/pty.node` — without

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "bun@1.4.1",
+  "packageManager": "bun@1.4.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/deepcoldy/botmux.git"

--- a/scripts/build-bun-binary.mjs
+++ b/scripts/build-bun-binary.mjs
@@ -159,7 +159,16 @@ function runTool(argv) {
  * supposed to be fixed by. oven-sh/bun#39837 is titled "compile: fix invalid
  * ad-hoc code signature on darwin-arm64" and its test only compiles
  * `--target=bun-darwin-arm64`; nothing upstream covers x86_64. So bumping bun
- * again does NOT close this — don't read "we're on 1.4.1" as "already fixed".
+ * again does NOT close this — don't read "we're on 1.4.2" as "already fixed".
+ *
+ * RE-MEASURED when the pin moved 1.4.1 → 1.4.2, by cross-compiling a two-line
+ * hello-world from linux and recomputing the CodeDirectory page hashes (no
+ * macOS required), with 1.4.0 as a control so the check is known to discriminate:
+ *   1.4.0 → darwin-arm64: INVALID (1/15483)   darwin-x64: INVALID (2/17124)
+ *   1.4.2 → darwin-arm64: VALID   (15075/15075)  darwin-x64: INVALID (2/16792, incl. slot 0)
+ * So 1.4.2 changes nothing for the cross-compiled x64 cell: the arch-specific
+ * defect is still there and this re-sign is still what makes the shipped
+ * darwin-x64 binary runnable.
  * `codesign --force --sign -` is the re-signing fix confirmed in
  * oven-sh/bun#39764 (`BUN_NO_CODESIGN_MACHO_BINARY=1` and `--remove-signature`
  * were both reported there as NOT working).

--- a/scripts/build-linux-glibc-baseline.sh
+++ b/scripts/build-linux-glibc-baseline.sh
@@ -81,7 +81,7 @@ docker run --rm \
     tar -xJf /tmp/node.tar.xz -C /opt/node --strip-components=1
     export PATH="/opt/node/bin:$PATH"
     node --version
-    npm install -g bun@1.4.1 --loglevel=error
+    npm install -g bun@1.4.2 --loglevel=error
     bun --version
 
     # Compiles node-pty on glibc 2.28; trustedDependencies makes this lifecycle

--- a/src/utils/local-dev-update.ts
+++ b/src/utils/local-dev-update.ts
@@ -183,7 +183,7 @@ export function gitHeadSha(dir: string): string {
  *   2. bun run build       (dist/ is gitignored: a pull alone leaves stale code)
  *
  * MUST stay `bun run build`, and MUST NOT go back to pnpm. Since the repo
- * declares `packageManager: bun@<pinned>` (1.4.1 at the time of writing; the
+ * declares `packageManager: bun@<pinned>` (1.4.2 at the time of writing; the
  * pin lives in package.json), a corepack-shimmed `pnpm` REFUSES to run here at
  * all — even `pnpm --version` exits 1 with `Unsupported package manager
  * specification (bun@<pinned>)`, so the whole update aborted before building.

--- a/test/release-darwin-codesign-gate.test.ts
+++ b/test/release-darwin-codesign-gate.test.ts
@@ -61,9 +61,13 @@ const gte = (a: string, b: string) => {
 };
 
 /** First Bun version known to write a valid darwin ad-hoc signature (#39837).
+ *  A FLOOR, not the pin: package.json may be ahead (it is — 1.4.2), and this
+ *  only has to stay at or below it. Deliberately NOT bumped in lockstep, so the
+ *  assertion below keeps testing "the pin carries the fix" instead of restating
+ *  whatever the pin currently happens to be.
  *  ⚠️ ONLY for the HOST arch — see the build-bun-binary.mjs suite below: 1.4.1
- *  still writes an invalid signature when cross-compiling darwin-x64, so this
- *  pin is necessary but NOT sufficient. */
+ *  still writes an invalid signature when cross-compiling darwin-x64, and 1.4.2
+ *  re-measured identically, so this pin is necessary but NOT sufficient. */
 const FIRST_GOOD_BUN = '1.4.1';
 
 describe('release.yml — every darwin binary is codesign-verified before it ships', () => {
@@ -148,7 +152,13 @@ describe('build-bun-binary.mjs — re-signs darwin output, because the bun pin i
    * darwin-arm64" and its test only compiles --target=bun-darwin-arm64; nothing
    * upstream covers x86_64. So bumping the pin again does NOT close this, and
    * these assertions exist so nobody deletes the re-sign after reading
-   * "we're already on 1.4.1".
+   * "we're already on 1.4.2".
+   *
+   * RE-MEASURED the same way when the pin moved 1.4.1 → 1.4.2 (1.4.0 as a
+   * control, so the check is known to discriminate between versions):
+   *   1.4.0 → arm64 INVALID (1/15483)      x64 INVALID (2/17124)
+   *   1.4.2 → arm64 VALID   (15075/15075)  x64 INVALID (2/16792, incl. slot 0)
+   * Identical split to 1.4.1: the x64 cross-compile cell is still broken.
    */
   it('ad-hoc re-signs with codesign --force --sign -', () => {
     // #39764 reports --remove-signature and BUN_NO_CODESIGN_MACHO_BINARY=1 as NOT


### PR DESCRIPTION
## 改了什么

把仓库里所有「当前使用的 bun 版本」从 1.4.1 提到 1.4.2，共 10 处可执行 pin：

| 载体 | 处数 |
|---|---|
| `package.json` 的 `packageManager` | 1 |
| `ci.yml` / `release.yml` 的 `setup-bun` `bun-version` | 6 |
| 两条 musl 腿的 `npm i -g bun@`（setup-bun 不支持 musl，只能走 npm） | 2 |
| `scripts/build-linux-glibc-baseline.sh` 的 `npm install -g bun@` | 1 |

外加描述「当前 pin」的文档/注释：`CLAUDE.md`、`CONTRIBUTING.md`、`src/utils/local-dev-update.ts`。

## 为什么这么改

**历史实测记录一律不动。** darwin 签名那几段（1.4.0 写坏签名、1.4.1 只修了 host arch）记的是历史事实，不是当前状态，改了就是伪造实测。

但有两处例外必须跟着走：`build-bun-binary.mjs` 和 gate 测试里那句「别把『我们已经在 1.4.1 了』读成『已经修好了』」——升完版读者眼前就是 1.4.2，警告指着一个没人会读到的版本号就失效了。所以这两处改成 1.4.2，并补上本次复测数据。

**`FIRST_GOOD_BUN` 故意保持 1.4.1**：它是「首个带 darwin 签名修复的版本」这个下限，不是 pin。跟着一起改会让断言退化成「pin == pin」的同义反复，就再也测不出「pin 是否带着修复」了。已在注释里写明这是有意为之。

## 影响面

改的是**构建工具链版本**，不是运行时代码，也不改任何依赖版本。受影响的是 CI 全部 job（build / bun-test / 三条 binary 腿 / release 全流程）与本地开发链路；不涉及具体 CLI 适配器、后端或会话类型。

`bun.lock` 未重新生成——1.4.2 完全接受现有 lockfileVersion 2（下面有实测）。

## 实测验证

均在本机 bun 1.4.2 下跑。**worktree 内没有跑过 install**，隔离验证都在 `/tmp` 副本里做。

**锁文件兼容性**（这项不过关的话 CI 每个 job 都会红）
```
干净副本 bun install --frozen-lockfile --dry-run   rc=0
  bun.lock sha256 前后一致 1a7ce58a…（未被要求改写）
真实 install（公共 registry，镜像主机名 0 次泄漏）  rc=0
  698 packages installed，node-pty 的 pty.node 正常编出（生命周期脚本跑到了）
```

**升级前 → 升级后（同一批断言）**
```
升级前：19 failed —— AssertionError: expected '1.4.2' to be '1.4.1'
升级后：3 files / 50 tests passed
```
（这批断言把 `Bun.version` 和 `packageManager` 对齐，所以本次改动是可观测的，不是空改。）

**版本一致性闸 + 反变异**
```
test/release-darwin-codesign-gate.test.ts   31/31 passed
三枪变异，每次只让一个载体漂回 1.4.1：
  ① workflow 的 bun-version  → 1 failed  expected ['1.4.2','1.4.1'] to equal ['1.4.2']
  ② musl 腿的 npm i -g bun@  → 1 failed  同上
  ③ glibc 脚本的 npm install → 1 failed  同上
三个载体各自都被真的守住，不是只守住了其中一个。
```

**构建 / 运行时 / 编译态**
```
bun run build            rc=0
bun test（直跑，非 vitest）  50 pass / 0 fail    bun test v1.4.2 (744846f84)
bun run test:bun:self-check  rc=0，且所有 bun spawn 都留在 home fence 内
bun run verify:binary    rc=0，编译态 8 项 smoke 全绿
  capabilities / version / selfcheck / self-spawn / dashboard / http / frontend / self-destruct guard
```

**全量 unit（含红项归因）**
```
vitest run --project unit   11 failed | 21899 passed (21923)
```
11 条红全部与本改动无关，逐条对照过：

- 其中 **9 条**：把同样 5 个文件在**干净 master**（同一台机、同一 bun、同样先 build 过）上跑，得到**逐个用例完全相同**的失败集合（`diff` 判定 IDENTICAL），是本机 bwrap 沙箱相关的既有失败。
- 另 **2 条**：满载下的时序抖动（`stops reading slow partial stdin` 3000ms 预算实测跑了 3066ms），单独跑即绿。
- 结构佐证：这 5 个红文件与 `origin/master` **逐字节相同**，且**都不读这个 pin**。

⚠️ 归因过程中踩到一个坑，记下来避免复现：baseline 第一次跑出来是 7 red（比我这边少），差异其实来自 `plugin-mcp-sandbox` 的 skip 条件是 `existsSync('dist/cli.js')`——`/tmp` 里的 baseline 是 `git archive` 导出的，没有 `dist/` 所以整个文件被跳过了。给 baseline 补跑 `bun run build` 之后两边才对得上。

## ⚠️ 一个必须留档的结论：1.4.2 仍然没修 darwin-x64 交叉编译的签名缺陷

仓库里原本就写着「别以为升级 bun 就能删掉重签步骤」。既然这次真的升了版，我把它重测了一遍，而不是照抄旧结论：从 linux 交叉编译一个两行 hello-world，解析 CodeDirectory 重算 page hash（不需要 macOS），并**用 1.4.0 做对照**确认这个判据能区分版本：

```
1.4.0 → darwin-arm64: INVALID (1/15483)        darwin-x64: INVALID (2/17124)
1.4.2 → darwin-arm64: VALID   (15075/15075)    darwin-x64: INVALID (2/16792，含 slot 0)
```

arm64 那格从 INVALID 变 VALID，说明判据确实在区分版本、不是恒定输出；**x64 交叉编译那格和 1.4.1 时代记录的形态一模一样，依旧是坏的**。

结论：`build-bun-binary.mjs` 里的 `codesign --force --sign -` 重签步骤**仍然是承重的**，谁都别因为「我们已经升到 1.4.2 了」把它删掉。这个结论已写进代码注释。

（旧注释里还提到 x64 有 ~25MB 落在签名范围外，我这两次构建都没复现出来（gap 均为 0）。我新增的文字只陈述自己直接测到的 page-hash 判定，没有沿用那个 gap 数字。）