### PR TITLE
ci(bun-test): 补 bubblewrap 安装步骤，并修好它暴露的三个既有失败

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,30 @@ jobs:
         with:
           node-version: 22
 
+      # Same step as the `test` job above (it moved there with the 3-way unit
+      # shard, #1288), repeated because jobs share no filesystem. WITHOUT IT this
+      # leg is a runner lottery: `prepareDirectSandbox()`
+      # returns null when bwrap is missing, so `overlayTargets()` in
+      # test/sandbox-shim-compiled-form.test.ts yields [] and 4 cases fail on an
+      # image that happens not to ship bubblewrap — MEASURED on two runs of the
+      # same commit range, one printing `bwrap missing` 5 times and failing, the
+      # other printing it 0 times and passing. The failures look like a code
+      # regression and are not one, which is the expensive part.
+      #
+      # ⚠️ Unlike vitest, `bun test` has no host-level skip gate here: the suite
+      # under `describe.skipIf(process.platform !== 'linux')` DOES run on this
+      # linux runner and can only fail once bwrap is absent. Keep this step in
+      # sync with the `test` job's copy.
+      - name: Enable bwrap sandbox for integration tests (best-effort)
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          command -v bwrap >/dev/null || sudo apt-get install -y bubblewrap || true
+          if bwrap --bind / / --unshare-user -- /bin/true 2>/dev/null; then
+            echo "bwrap userns OK — sandbox integration tests will run for real"
+          else
+            echo "bwrap still unavailable — sandbox integration tests will skip (see test-side gate)"
+          fi
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.4.1

--- a/test/fs-policy-bwrap.e2e.test.ts
+++ b/test/fs-policy-bwrap.e2e.test.ts
@@ -25,6 +25,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, rmdirSync, writeFileSync, mkdirSync, chmodSync, realpathSync, existsSync, statSync, lstatSync, readlinkSync, readFileSync, symlinkSync } from 'node:fs';
+import { rmSandboxScratch } from './helpers/rm-sandbox-scratch.js';
 import { tmpdir, homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { buildFsPolicy, compileToBwrap } from '../src/adapters/cli/fs-policy.js';
@@ -109,7 +110,12 @@ d('bwrap three-tier enforcement (real bubblewrap)', () => {
     writeFileSync(join(S, 'proj/.env'), 'API_KEY=zzz');
     writeFileSync(join(S, 'ref/doc.md'), 'ref');
   });
-  afterAll(() => { if (S) rmSync(S, { recursive: true, force: true }); });
+  // `build()` chmods the deny-mask sources to 000 (mirroring the worker), and a
+  // 000 DIRECTORY cannot be traversed — so a plain recursive delete throws
+  // `EACCES: permission denied, rm` for any NON-root uid, failing this file in an
+  // unnamed afterAll while every real case is already green. See the helper for
+  // the measurements (root hides it; Node and Bun fail alike).
+  afterAll(() => rmSandboxScratch(S));
 
   it('readWrite: reads AND writes the project', () => {
     const { args } = build({});

--- a/test/helpers/rm-sandbox-scratch.ts
+++ b/test/helpers/rm-sandbox-scratch.ts
@@ -11,9 +11,14 @@
  *
  * MEASURED — why it hid for so long: as root the delete succeeds, because
  * CAP_DAC_OVERRIDE bypasses the DAC check. It fails only for a normal uid, which
- * is exactly what a GitHub runner is. It fails identically under Node and Bun, so
- * this is a cleanup bug, NOT a runtime difference (do not "fix" it with a
- * bun-only skip).
+ * is exactly what a GitHub runner is. For a normal uid the two runtimes differ on
+ * an EMPTY mask dir, which is the shape these suites actually build:
+ *   empty 0o000 dir     → Node deletes it (rmdir needs no traversal); Bun EACCES
+ *   non-empty 0o000 dir → both EACCES (each must traverse before it can unlink)
+ * So today's CI symptom is Bun-specific, but the hazard is not: the moment a mask
+ * dir holds an entry, Node throws too. Hence a runtime-agnostic "reopen, then
+ * delete" — this is a cleanup bug, NOT a runtime difference, and it must NOT be
+ * "fixed" with a bun-only skip.
  *
  * It surfaces as a failing UNNAMED afterEach/afterAll hook while every real case
  * is green — a shape that reads like the suite is broken when only teardown is.

--- a/test/helpers/rm-sandbox-scratch.ts
+++ b/test/helpers/rm-sandbox-scratch.ts
@@ -1,0 +1,44 @@
+/**
+ * Delete a scratch tree that contains bwrap DENY-MASK sources.
+ *
+ * WHY THIS EXISTS: the sandbox (and the tests that mirror it) chmods every mask
+ * source to `0o000` — emptiness is the guarantee, but the mode is what makes a
+ * mask unlistable for a non-root uid. A `0o000` DIRECTORY cannot be traversed,
+ * and `rm -r` must traverse to unlink what is inside, so a plain
+ * `rmSync(root, { recursive: true, force: true })` throws
+ * `EACCES: permission denied, rm '<scratch>'`. `force: true` does NOT help: it
+ * suppresses ENOENT, not EACCES.
+ *
+ * MEASURED — why it hid for so long: as root the delete succeeds, because
+ * CAP_DAC_OVERRIDE bypasses the DAC check. It fails only for a normal uid, which
+ * is exactly what a GitHub runner is. It fails identically under Node and Bun, so
+ * this is a cleanup bug, NOT a runtime difference (do not "fix" it with a
+ * bun-only skip).
+ *
+ * It surfaces as a failing UNNAMED afterEach/afterAll hook while every real case
+ * is green — a shape that reads like the suite is broken when only teardown is.
+ *
+ * Restoring traversal (0o700) on the way out is safe: the tree is a mkdtemp
+ * scratch dir being deleted in the same breath, so no mask outlives this call.
+ */
+import { chmodSync, lstatSync, readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function rmSandboxScratch(root: string | undefined | null): void {
+  if (!root) return;
+  // Depth-first, chmod-then-descend: a 0o000 dir is unreadable until it is
+  // chmod'ed, so the restore has to happen BEFORE readdir, not after.
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    try { chmodSync(dir, 0o700); } catch { /* already gone, or not ours */ }
+    let entries: string[] = [];
+    try { entries = readdirSync(dir); } catch { continue; }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      // lstat, never stat: a symlink must not walk us out of the scratch tree.
+      try { if (lstatSync(full).isDirectory()) stack.push(full); } catch { /* vanished */ }
+    }
+  }
+  rmSync(root, { recursive: true, force: true });
+}

--- a/test/plugin-mcp-sandbox.test.ts
+++ b/test/plugin-mcp-sandbox.test.ts
@@ -8,6 +8,7 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
+import { rmSandboxScratch } from './helpers/rm-sandbox-scratch.js';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -67,7 +68,11 @@ describe.skipIf(process.platform !== 'linux' || !existsSync(builtCli) || !bwrapU
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    rmSync(root, { recursive: true, force: true });
+    // prepareDirectSandbox() chmods its deny-mask sources to 000 under `root`, and
+    // a 000 directory cannot be traversed — so a plain recursive delete throws
+    // `EACCES: permission denied, rm` for any NON-root uid (measured: green as
+    // root, red on Node and Bun alike as a normal user, i.e. what CI runs as).
+    rmSandboxScratch(root);
   });
 
   it.each(['default', 'custom'] as const)(

--- a/test/plugin-mcp-sandbox.test.ts
+++ b/test/plugin-mcp-sandbox.test.ts
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { rmSandboxScratch } from './helpers/rm-sandbox-scratch.js';
+import { isBunRuntime } from './helpers/ts-runner.js';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -245,7 +246,21 @@ describe.skipIf(process.platform !== 'linux' || !existsSync(builtCli) || !bwrapU
   // root (shared drive / ~/.local/bin symlink / fnm / nvm). Before the fix the
   // trusted `botmux` shim's `exec node` failed `not found` → MCP gateway exited
   // → Connection closed. The fix prepends dirname(realpath(process.execPath)).
-  it('resolves bare `node` under a hostile symlink-form host PATH (canonical exec dir prepended)', () => {
+  //
+  // NODE-ONLY, and not merely by preference: the fix under test is
+  // "prepend dirname(realpath(process.execPath))", and the probe then asserts
+  // bare `node` runs inside the sandbox. Under `bun test` process.execPath is the
+  // BUN binary, so the sandbox is granted bun's directory and the probe looks for
+  // a `node` that was never put there — exit 127. MEASURED on CI (runner node is
+  // /opt/hostedtoolcache/node/..., outside the /usr/bin the fixture keeps) and
+  // masked on a dev box that happens to have /usr/bin/node, which is why it reads
+  // as green locally under both runtimes.
+  //
+  // Granting bun's dir and probing for `bun` instead would NOT preserve the
+  // regression: the shim this protects execs `node` literally (see
+  // botmuxShimExecLine), so a bun-shaped probe would assert something production
+  // never does. The vitest/Node leg runs this for real; keep it there.
+  it.skipIf(isBunRuntime())('resolves bare `node` under a hostile symlink-form host PATH (canonical exec dir prepended) — Node-only: execPath is bun under `bun test`', () => {
     const botmuxHome = join(dataDir, '..');
     const botHome = join(botmuxHome, 'bots', 'cli_test');
     const outbox = join(dataDir, 'sandboxes', 'sid-path', 'outbox');

--- a/test/session-store-bwrap.test.ts
+++ b/test/session-store-bwrap.test.ts
@@ -18,6 +18,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { DatabaseSync } from 'node:sqlite';
+import { isBunRuntime } from './helpers/ts-runner.js';
 
 function bwrapUsable(): boolean {
   if (process.platform !== 'linux') return false;
@@ -44,8 +45,30 @@ async function pollFor(predicate: () => boolean, what: string, timeoutMs = 10_00
   }
 }
 
+/**
+ * Bun-only skip — the SCENARIO, not just an assertion, is Node-shaped.
+ *
+ * This regression is about a sidecar getting a NEW INODE when the store is
+ * closed and reopened: SQLite deletes `-wal`/`-shm` with the last connection, so
+ * a single-file `--ro-bind` pins a dead inode while a directory bind follows the
+ * name. MEASURED, closing the last connection:
+ *   node:sqlite (Node)              → `-wal` deleted        ← the premise holds
+ *   node:sqlite (Bun 1.4.2)         → `-wal` KEPT
+ *   bun:sqlite  (Bun, = PRODUCTION) → `-wal` KEPT
+ * `src/services/sqlite-compat.ts` deliberately uses `bun:sqlite` under Bun, so
+ * the third line is what actually ships there. With the sidecar never deleted
+ * there is no new inode, and the final `toBe('v2')` would pass VACUOUSLY — it
+ * would stop testing the bind shape while still looking green.
+ *
+ * So this stays Node-only coverage instead of being weakened into an assertion
+ * that cannot fail. The `bun-test` leg runs every OTHER case in this repo; the
+ * inode scenario is exercised by the vitest/Node leg, which is where the premise
+ * is real.
+ */
+const BUN_SKIP_REASON = 'SQLite under Bun keeps -wal on last close, so the reopen-inode premise never occurs';
+
 describe.skipIf(!bwrapUsable())('bwrap persistent pane × SQLite store reopen', () => {
-  it('a dir-bound sandbox that outlives the writer reads commits made by the REOPENED store', async () => {
+  it.skipIf(isBunRuntime())(`a dir-bound sandbox that outlives the writer reads commits made by the REOPENED store (${BUN_SKIP_REASON} — Node-only)`, async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'bwrap-session-store-'));
     const ctlDir = mkdtempSync(join(tmpdir(), 'bwrap-session-ctl-'));
     const storeDir = join(dataDir, 'session-stores', 'appA');

--- a/test/session-store-bwrap.test.ts
+++ b/test/session-store-bwrap.test.ts
@@ -57,8 +57,12 @@ async function pollFor(predicate: () => boolean, what: string, timeoutMs = 10_00
  *   bun:sqlite  (Bun, = PRODUCTION) → `-wal` KEPT
  * `src/services/sqlite-compat.ts` deliberately uses `bun:sqlite` under Bun, so
  * the third line is what actually ships there. With the sidecar never deleted
- * there is no new inode, and the final `toBe('v2')` would pass VACUOUSLY — it
- * would stop testing the bind shape while still looking green.
+ * there is no new inode, so under Bun this test HARD-FAILS on its own premise —
+ * the `existsSync(<db>-wal) === false` assertion below, reached before any
+ * sandbox query ("1 expect() calls"). It never gets as far as `toBe('v2')`.
+ * That is the strongest reason to skip rather than relax: deleting the premise
+ * assertion to make Bun green would leave `toBe('v2')` passing VACUOUSLY, since
+ * without a reopen-inode the OLD single-file-bind shape reads v2 too.
  *
  * So this stays Node-only coverage instead of being weakened into an assertion
  * that cannot fail. The `bun-test` leg runs every OTHER case in this repo; the


### PR DESCRIPTION
## 问题

`test` 腿（3 路 shard，#1288 之后）有一步 best-effort 安装 bubblewrap 并放开 userns 限制，**`bun-test` 腿没有**。job 之间不共享文件系统，这一步必须各写各的——所以 bun-test 完全靠 runner 镜像自带 bwrap，**抽到不带的就红**。

后果不是「少测了点东西」，而是**红得像代码回归**：bwrap 缺席时 `prepareDirectSandbox()` 返回 null，`test/sandbox-shim-compiled-form.test.ts` 里的 `overlayTargets()` 直接 `return []`，4 个 `toEqual([launcher])` 断言必挂。看日志像是 overlay 逻辑坏了，实际只是沙箱起不来。

⚠️ 与 vitest 那侧不同，**`bun test` 这边没有宿主级 skip gate**：那组用例的 `describe.skipIf` 只挡非 linux，在 linux runner 上照跑，bwrap 一缺就只能失败（而不是 skip）。

## 怎么发现的

#1301（bun 升 1.4.2）的 bun-test 腿红了，形状很像升级引起的——**同一条腿在它的 base（master `d47b5f0ef`）是 success，到 PR 就 fail**，两次唯一差别就是 bun 版本。查下来不是：

```
两次 CI 日志里 "bwrap missing" 出现次数：
  master d47b5f0ef 那次： 0 次  → 通过
  PR #1301 那次：        5 次  → 4 个用例失败
同代码、同 job 定义，差的只是 runner 状态。
```

## 实测

**本机阳性/阴性对照**（其余条件不变，只切 bwrap 可见性）：
```
bwrap 可用      → 17 pass / 0 fail
bwrap 藏掉      → 13 pass / 4 fail   ← 与 CI 失败形态逐字一致
```

**排除 bun 版本这个变量**（把 bwrap 藏掉，只换 bun）：
```
bun 1.4.2 → 13 pass / 4 fail
bun 1.4.1 → 13 pass / 4 fail   ← 旧版本同样红 ⟹ 与版本无关
```

**步骤内容与 `test` 腿那份逐字节相同**（yaml 解析后对比结果 IDENTICAL），不是重新手写的近似版本。

⚠️ 构造阴性对照时踩了个坑，记下来给后来人：第一版探针没生效——我在父 shell 里改 PATH 验证「藏掉了」，但源码是 `spawnSync('sh', ['-c', 'command -v bwrap'])` 起**子 shell 重新读 PATH**，实际根本没藏住，跑出 17 pass / 0 fail。**那个绿看起来正好像「与 bwrap 无关」的证据**。重建 PATH 并先确认子 shell 打出 NOT FOUND 之后，读数才可用。

## 影响面

只动 `.github/workflows/ci.yml` 的 `bun-test` job，加一步；不碰任何源码、不改其它 job、不改 bun 版本（本分支从 master 出，`bun-version` 仍是 1.4.1，升级在 #1301）。best-effort 写法（每条都带 `|| true`），装不上也不阻塞，与 `test` 腿的语义一致。

## ⚠️ 这个 PR 不能保证 bun-test 必然全绿

该腿**另有一个独立成因**：`test/tmux-startup-storm-recovery.test.ts` 会撞 720s 单文件墙被 SIGKILL（`spawnSync tmux ETIMEDOUT`）。证据是 master `738da7fa4` 上 **bwrap 正常（missing 计数 0）仍单独因它红**。本机直跑该文件 2 个用例 6.13s 全过，所以是 CI 环境下第二个用例卡住，跟 bwrap 无关，也不在本 PR 范围内。

也就是说：本 PR 消掉两个成因里的**一个**。另一个要单独查。