### PR TITLE
refactor(session): 开场激活的分散串行化 fence 收进按 session 的命令队列（Stage 3）

### DIFF
--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -2,16 +2,17 @@
 title: Session 终态：非分布式 virtual actor（持久化仅 SQLite）
 type: design
 date: 2026-08-12
-updated: 2026-09-06（Stage 2 单一 apply 落地：close / prune / 白板绑定只有一份行级变换，宿主离线写改为命令）
+updated: 2026-09-07（Stage 3 per-session turn 落地：开场激活窗口内的命令走按 sessionId 的队列，分散的计数 / 延迟交接 / 回放删除；Stage 4 降为低优先级；Stage 0 / Stage 1 收尾按升级窗口已关闭排期）
 topic: session-virtual-actor
 status: active
-baseline: origin/master@8d2986c71（含已合入的 #852、#1073、#1093、#1051、#1202）
+baseline: origin/master@cfc425a00（含已合入的 #852、#1073、#1093、#1051、#1202、#1280）
 references:
   - PR #846（会话行唯一写入入口）
   - PR #852（per-bot SQLite + JSON 导入 + 混合窗口；已合入 master）
   - PR #1051（删除 daemon 侧 JSON 写路径 + 行级持久化；已合入 master）
   - PR #1202（Stage 1 occupancy：库内 `occupancy` 租约；已合入 master）
-  - Stage 2 单一 apply（`services/session-commands.ts`；本轮落地）
+  - PR #1280（Stage 2 单一 apply：`services/session-commands.ts`；已合入 master）
+  - Stage 3 per-session turn（`core/session-turn-queue.ts`；本轮落地）
   - #831 / feat/virtual_actor_stage2（不合入；SessionRuntime 只覆盖部分写点的失败记录）
 ---
 
@@ -93,8 +94,8 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 
 - **occupancy 已在同库 `occupancy` 表。** 租约在 `BEGIN IMMEDIATE` 内判定，有效租约一票否决离线写；`findOnlineDaemon` 不再是唯一所有权来源。没有有效租约（缺行 / 过期 / 不可读）时心跳仍参与判定——这是升级窗口（只写会话行、不写 occupancy 的 daemon，含回滚后的旧构建）。删除该回落的条件与 Stage 0 JSON 读路径相同。
 - **apply 已收成一份**（Stage 2）。行级变换只在 `services/session-commands.ts`：daemon 的 `closeSession` / `/whiteboard` 路由与宿主的 `services/session-command-host.ts`（`applySessionCommandAsHost` / `readSessionRowAsHost`）都调用它。仍分开的是**运行时拆除**（daemon 的 killWorker / remote cancel prepare vs 宿主 CLI 的 SIGTERM + backing 销毁）与 close 后的旁路清理（宿主只做 dashboard 图片目录清理；turn-sends / prompt-ctx / frozen-card 仍由 daemon 清）。
-- **没有 per-session turn。** 进程内仍依赖多处独立的 fence。
-- **跨进程仍可能读 JSON**（#1051 保留）：当 CLI 已升级、daemon 仍在写 JSON 时，快照、点读、身份扫描、worker、`owner: false` 走 db-else-json。这是迁移兼容，不是终态。删除这些分支的条件见 Stage 0（fleet 自动重启落地，或 2026-11-26 的兜底复核点）。磁盘上的冻结 JSON 文件可以保留。
+- **per-session turn 已有（Stage 3）。** `core/session-turn-queue.ts#runSessionTurn` 是按 `sessionId` 的 Promise 链；开场激活窗口内的命令（后到消息的 prompt 构造 + durable tail 落盘、开场 ACK 对路由的释放）都走它。仍在队列外的是 fork 边界的所有权 `initialStartClaimToken`（跨越整段资源准备，见 Stage 3「有意保留」）与 pendingRepo 等待期的缓冲（等人，不是等 `await`）。
+- **跨进程仍可能读 JSON**（#1051 保留）：当 CLI 已升级、daemon 仍在写 JSON 时，快照、点读、身份扫描、worker、`owner: false` 走 db-else-json。这是迁移兼容，不是终态。升级窗口已按关闭处理（见 Stage 0 的状态记录），这些分支在收尾 PR 里删除。磁盘上的冻结 JSON 文件可以保留。
 
 #831 / `SessionRuntime` **不合入**。失败原因是只把约 32% 的写点迁入新层、旧 API 完整保留、约 17k 行适配层按设计要整段删除，并在 build 上挂审计脚本。这不能证明会话桥不该用 virtual actor。写点地图和 receipts/lane 只作线索，立项前在现行代码上复核。
 
@@ -123,6 +124,8 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 2. 兜底复核点 **2026-11-26**（本文 2026-08-28 定稿起 90 天）。届时若 fleet 自动重启仍未落地，就按当时 latest 与「`sessions.db` 首次进入 latest 的版本」之间的跨度，决定直接删除还是再延一期，并把结论写回本节。
 
 第 2 条是必需的：fleet 自动重启不在本文范围，也没有承诺时间点。只写第 1 条，等于把跨进程 JSON 读做成 §不做 明令禁止的「长期不变量」。
+
+**状态（2026-09-07）**：SQLite 引擎首次进入 latest 是 v3.18.0（2026-08-28），daemon 不再写 JSON 的版本是 v3.18.12（2026-09-02），occupancy 租约的版本是 v3.19.0（2026-09-06）。维护者已决定不再等 fleet 自动重启，按升级窗口已关闭处理；收尾 PR（本节的 JSON 读路径删除 + Stage 1 的心跳回落删除）排在 Stage 3 之后统一做，范围见 §5。
 
 条件满足后，再开一个仍属 Stage 0 的 PR，从代码中删除 JSON 读路径（不必等 occupancy）：
 
@@ -165,21 +168,32 @@ Mailbox 在本仓库里要解决的问题：飞书、dashboard、CLI、worker �
 
 未纳入本 stage：daemon 与宿主各自的运行时拆除（worker / backing 的杀法）本来就分属两种进程形态，不是行级 apply；IPC 传输层（`postSessionCliIpc` 的 capability 鉴权 vs `fetchDaemonIpc` 的 host HMAC）承载不同的鉴权语义，不合并。
 
-### Stage 3 — Per-session turn
+### Stage 3 — Per-session turn【已落地：开场激活窗口】
 
 **目标**：同一 `sessionId` 上的命令在跨 `await` 后仍串行。按 session 排队，不引入 `SessionRuntime`。
 
-- 按 `sessionId` 将命令闭包入队（或等价的 Promise 链）。host 仍是 bot 进程。
-- 用队列替换已有测试或线上证据的分散 fence（async tail-admission、worker generation / exit 路径上无保护的 `updateSession`、队首激活 FIFO 等）。没有复现的路径不要为了「更像 actor」而改。
-- stage2 的 receipts / lane 只作线索，立项前在现行代码复核。
+已落地：
 
-daemon 进程内部可以先于 Stage 2 排队；**对外保证**要等所有外部入口都走同一 apply，否则队列覆盖不到 CLI / dashboard。
+1. `core/session-turn-queue.ts#runSessionTurn(sessionId, command)`：按 `sessionId` 的 Promise 链，命令按入队顺序执行、跨自身 `await` 不交错，前一条失败不阻塞后一条；链空即回收。没有 mailbox 类型、没有 actor 对象。`hasPendingSessionTurns(sessionId)` 供入口判定「这条 session 上还有命令没跑完」。
+2. 收进队列的命令，全部在**开场激活窗口**——到达 → 构造 prompt（`await` 发送者查询）→ 落 durable tail：
+   - 同 anchor 后到消息的两处入口（`initialStartPending` 下的 follower；worker 已死、带 retained journal 的 refork 前置 staging）统一走 `admitFollowerBehindOpening`：到达时同步取 FIFO 序号，构造 + 落盘作为一条命令入队。若开场的释放在它之前跑完（tail 为空、路由已放开），同一条命令内联 promote，不再排队。pendingRepo 分支从到达到落盘没有 `await`，不需入队。
+   - 开场的路由释放 `releaseQueuedActivationReservation`（worker `queued_activation_submitted` ACK、普通冷 fork 后的交接、失败重试）入队，因此必然在先到的 follower 落盘之后执行。
+   - `hasQueuedActivationAdmissionGate` 用 `hasPendingSessionTurns` 代替计数：队列上有命令时，live worker 的普通 turn 也进 durable tail，不得插队。
+3. 删除的分散 fence：`queuedActivationTailAdmissionsOutstanding` 计数、`queuedActivationTailReleasePending` 延迟交接、`reserveAsync… / settleAsync…` 回放；`forkReservedInitialSession` 与原始命令冷启动对计数的判定改为查队列。保留的 100ms 重试定时器只负责「promote 落盘 / IPC 失败后重试」，不再承担排序。
+4. 顺手删除的死代码：`pendingQueuedActivationFollowUps` 与 `reparkQueuedActivationFollowUpTail`——#597 的 durable tail 落地后没有任何写入方，repark 恒返回 false。
 
-`admitQueuedActivationTail` 一类在 store 外做字段备份再回滚的逻辑：在「按命令更新且不替换 `ds.session` 引用」的 apply 入口出现后删除。不要为少写几行回滚代码单独增加一个公共 patch API。
+有意保留、不入队的：
 
-### Stage 4 — （可选）按 session 隔离激活
+- `initialStartClaimToken` / `initialStartPending`：fork 边界的所有权，跨越 `handleNewTopic` 从资源准备到 fork 的整段异步（秒级）。期间到达的 follower 必须**立刻**落 durable tail 才扛得住 daemon 崩溃；把整段准备做成队列命令会让 follower 在内存里等待、失去这层持久化。它是状态，不是 `await` 间隙。
+- `pendingRepo` 等待期的 `pendingFollowUps*` 缓冲：等人点卡片，队列不能被人拿着。
+- `admitQueuedActivationTail` / `promoteQueuedActivationTail` 里「store 外备份再回滚」的写法：删除条件不变——daemon 侧出现「按命令更新且不替换 `ds.session` 引用」的 apply 入口（`closeSession` 已是该形态）。让 admit 走它需要新的 store 导出，并改动多个 stub 了 `updateSession` 的测试夹具；本轮未做，与 promote 的四份备份一起处理。
+- worker generation / exit 路径上的 `updateSession`：没有复现证据（相关回归测试覆盖的是重启协调器）。按本节「没有复现的路径不改」不动。
 
-仅当「同一 bot 进程内容纳全部会话」导致事件循环或崩溃域不可接受时立项。Stage 1–3 不依赖本 stage。调度仍在本机，不引入跨机器放置。
+后续再有证据的交错路径，用 `runSessionTurn` 包住那一段即可，不再新增计数或标志。
+
+### Stage 4 — （低优先级）按 session 隔离激活
+
+**暂不立项。** 触发条件是「同一 bot 进程容纳全部会话导致事件循环或崩溃域不可接受」，目前没有证据：2026-08-23 的恢复风暴发生在共享 tmux server 层（见 `test/tmux-startup-storm-recovery.test.ts`），按 session 拆进程解决不了它。Stage 0–3 不依赖本 stage；调度仍在本机，不引入跨机器放置。只有出现上述证据时再评估。
 
 ### 不做
 
@@ -222,11 +236,18 @@ daemon 进程内部可以先于 Stage 2 排队；**对外保证**要等所有外
 
 - **#1051**：删除 daemon JSON 写路径；含白板解绑的 compare-and-set、离线写打开前拒绝缺文件、离线写与 daemon 发现各收敛成一份实现。
 - **Stage 1**：occupancy 写入 SQLite；有效租约一票否决，`findOnlineDaemon` 降为无有效租约时的回落。回落的删除条件见上。
-- **删除 JSON 读路径**：条件见 Stage 0（fleet 自动重启落地，或 2026-11-26 的兜底复核点）。fleet 实现不在本文范围。
+- **删除 JSON 读路径**：升级窗口已按关闭处理（见 Stage 0 的状态记录），与 Stage 1 心跳回落一起进下面的收尾 PR。
 - **Stage 2（已落地）**：daemon 未运行时宿主在同一事务内执行同一 apply，删除第二套对外写协议（任意闭包改行）。这一阶段减少的概念最多。
-- **下一个架构主 PR：Stage 3**：按已有证据把分散 fence 收进 per-session 队列。不设「迁完全部写点」的完成门。
+- **Stage 3（已落地）**：开场激活窗口内的命令收进按 `sessionId` 的队列；计数 / 延迟交接 / 回放删除。不设「迁完全部写点」的完成门。
+- **下一个 PR：Stage 0 / Stage 1 收尾（净删除）**，升级窗口已按关闭处理（见 Stage 0 状态）：
+  - `session-store`：删 db-else-json 分流（`StoreFileRef.kind`、`resolveStoreFile` / `listStoreRefs` 的 JSON 分支、`readStoreEntries` / `readStoreRowByKey` / `readStoreActiveRows` / `countActiveSessionsOnDisk` 的 JSON 分支）、`getSessionFresh` 的 JSON 文件锁读、非 owner 进程无库时的 `loadFromFrozenJson`、宿主命令的 JSON 文件锁写路径。无 `.db` 且尚未导入时非 owner 进程明确报「会话库尚未迁移，请重启 daemon」。
+  - 删 `abortIf` 心跳回落：`session-command-host` 的 `legacyHeartbeatHeld` / `hostOptions`，`isOccupancyHeld` 只看租约；`sqliteOccupancyBlocksWrite` 去掉 `abortIf`。
+  - 沙盒 `fs-policy`：不再授权 `sessions-<self>.json` 只读（两处）。
+  - `core/mojo-containment-command.ts#defaultIsSessionActive` 仍直接扫 `sessions*.json`：SQLite 后它对所有会话都答「不活跃」，revoke 的安全闸静默失效。改为读 store（严格跨 store 点读，保留「有库读不了 → 未知」的三态）。
+  - 保留：owner daemon 首次 load 的一次性导入及其文件锁、中毒库恢复。它不是跨进程协议；删掉会让从 3.17.x 直接升到新版的用户静默丢会话。其删除条件是「升级来源不可能低于 3.18.0」，晚于本次。
+  - 测试：`session-store` / `session-store-sqlite` / `session-occupancy` / `session-delete-cli` / `whiteboard-unbind-session` / `fs-policy` / `mojo-containment` 里的 JSON 窗口与心跳回落用例改为 fail-closed 断言。
 
-`closeSession` 的字段级回滚已在 #1051 替换。`admitQueuedActivationTail`、async tail-admission、generation / exit 上无保护的写入归 Stage 3。`initial-user-turn` 在落盘失败时仅更新内存：有复现再进入 Stage 2 或 3，不单独开事务修复轨道。
+`closeSession` 的字段级回滚已在 #1051 替换；async tail-admission 已在 Stage 3 收进队列。`admitQueuedActivationTail` / `promoteQueuedActivationTail` 的回滚写法与 generation / exit 上无保护的写入仍归 Stage 3 的后续（见其「有意保留」）。`initial-user-turn` 在落盘失败时仅更新内存：有复现再进入 Stage 2 或 3，不单独开事务修复轨道。
 
 ## 6. 历史
 

--- a/docs/design/2026-08-12-session-restage-store-first.md
+++ b/docs/design/2026-08-12-session-restage-store-first.md
@@ -5,7 +5,7 @@ date: 2026-08-12
 updated: 2026-09-07（Stage 3 per-session turn 落地：开场激活窗口内的命令走按 sessionId 的队列，分散的计数 / 延迟交接 / 回放删除；Stage 4 降为低优先级；Stage 0 / Stage 1 收尾按升级窗口已关闭排期）
 topic: session-virtual-actor
 status: active
-baseline: origin/master@cfc425a00（含已合入的 #852、#1073、#1093、#1051、#1202、#1280）
+baseline: origin/master@61dadb04c（含已合入的 #852、#1073、#1093、#1051、#1202、#1280）
 references:
   - PR #846（会话行唯一写入入口）
   - PR #852（per-bot SQLite + JSON 导入 + 混合窗口；已合入 master）

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -162,6 +162,13 @@ const TEST_TIMEOUT_MS = 180_000;
 // the real failure count. The wall's job is to stop a wedged file from holding the leg
 // open, not to truncate a file that is legitimately reporting many slow failures.
 const FILE_WALL_MS = TEST_TIMEOUT_MS * 4;
+// bun test does not force-exit. A file that printed `(pass)` / `(fail)` and
+// then goes silent is almost always waiting on a leftover handle (fifo, child)
+// after the last case — test/tmux-startup-storm-recovery.test.ts sat in that
+// state until FILE_WALL (720s) on CI after both cases had already passed.
+// Idle is one per-test timeout so a quiet-but-still-running next case is not
+// cut short; it only fires when NOTHING has been printed for that long.
+const POST_RESULT_IDLE_MS = TEST_TIMEOUT_MS;
 
 const all = collectTestFiles(TEST_DIR).sort();
 
@@ -383,20 +390,38 @@ function runOne(file) {
     });
     liveChildren.set(child, scratch);
     let out = '';
-    const cap = chunk => { if (out.length < 200_000) out += chunk; };
+    let lastOutputAt = Date.now();
+    let sawResult = false;
+    const cap = chunk => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString();
+      if (out.length < 200_000) out += text;
+      lastOutputAt = Date.now();
+      if (!sawResult && /^\s*\((?:pass|fail)\)/m.test(text)) sawResult = true;
+    };
     child.stdout.on('data', cap);
     child.stderr.on('data', cap);
     // Recorded so the close handler can say the output was CUT rather than complete.
     let wallKilled = false;
+    let idleKilled = false;
     const wall = setTimeout(() => { wallKilled = true; killTree(child, 'SIGKILL'); }, FILE_WALL_MS);
+    const idle = setInterval(() => {
+      if (sawResult && Date.now() - lastOutputAt >= POST_RESULT_IDLE_MS) {
+        idleKilled = true;
+        wallKilled = true;
+        killTree(child, 'SIGKILL');
+      }
+    }, 5_000);
+    idle.unref?.();
     child.on('error', err => {
       clearTimeout(wall);
+      clearInterval(idle);
       liveChildren.delete(child);
       removeScratch(scratch);
       resolve({ file, ok: false, out: `failed to launch bun: ${err.message}` });
     });
     child.on('close', (code, signal) => {
       clearTimeout(wall);
+      clearInterval(idle);
       liveChildren.delete(child);
       // Sweep whatever is LEFT in the child's process group. A test that spawns a
       // grandchild and only kills the intermediate process leaves the grandchild
@@ -415,7 +440,9 @@ function runOne(file) {
         // output itself: a reader (or a future me) counting `FAIL` lines from a killed
         // file would otherwise report a number that is silently too small.
         const truncated = wallKilled
-          ? `\n[runner] OUTPUT TRUNCATED: killed by the ${FILE_WALL_MS}ms per-file wall. `
+          ? `\n[runner] OUTPUT TRUNCATED: killed by the ${idleKilled
+            ? `${POST_RESULT_IDLE_MS}ms post-result idle`
+            : `${FILE_WALL_MS}ms per-file wall`}. `
             + 'Any failure count from this file is a LOWER BOUND — the run did not finish. '
             + `Re-run this file alone (optionally with a smaller --timeout than ${TEST_TIMEOUT_MS}ms) `
             + 'to see the complete set.\n'

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -935,7 +935,10 @@ export class TmuxPipeBackend implements SessionBackend {
 
   private stopLifecycleWatcher(): void {
     if (this.lifecycleTimer) {
-      clearInterval(this.lifecycleTimer);
+      // Watcher is a chained setTimeout (backoff), not setInterval. Node
+      // aliases the two clears; still call the matching one so a future
+      // runtime that does not cannot leave a probe timer on the loop.
+      clearTimeout(this.lifecycleTimer);
       this.lifecycleTimer = null;
     }
   }
@@ -986,13 +989,15 @@ export class TmuxPipeBackend implements SessionBackend {
     liveFifoReaders.delete(this);
     this.fifoTornDown = true;
     if (this.readStream) {
-      try { this.readStream.destroy(); } catch { /* already closed */ }
-      // After destroy the stream must not keep the event loop alive. Bun's test
-      // runner waits for open handles between cases; a destroyed-but-still-ref'd
-      // fifo reader is what wedged test/tmux-startup-storm-recovery.test.ts
-      // after its first case passed (CI FILE_WALL, 720s).
-      try { (this.readStream as { unref?: () => void }).unref?.(); } catch { /* not a handle anymore */ }
+      const stream = this.readStream as fs.ReadStream & { close?: () => void; unref?: () => void };
       this.readStream = null;
+      // Bun's ReadStream has close() and no unref() (verified bun 1.4.0).
+      // bun test waits for open handles after the last case; destroy()+unref
+      // is a no-op there and left test/tmux-startup-storm-recovery.test.ts
+      // wedged until the 720s FILE_WALL after both cases had already passed.
+      try { stream.close?.(); } catch { /* already closed */ }
+      try { stream.destroy(); } catch { /* already closed */ }
+      try { stream.unref?.(); } catch { /* not a handle anymore */ }
     }
     if (this.fifoWakeFd !== null) {
       // EAGAIN (pipe full) is fine: a full pipe means the read already has data

--- a/src/core/session-turn-queue.ts
+++ b/src/core/session-turn-queue.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-session turn serialization — the "turn" leg of the session terminal
+ * state (docs/design/2026-08-12-session-restage-store-first.md §1, §3 Stage 3).
+ *
+ * JavaScript's single thread does not serialize a command that `await`s:
+ * between a turn's arrival and its durable admission, another arrival or the
+ * worker's ACK for the opening it is queued behind can run and observe a
+ * half-applied session. `runSessionTurn` runs the commands aimed at one
+ * `sessionId` one at a time, in the order they were enqueued, across their own
+ * awaits. It is a Promise chain per session and nothing more: no mailbox type,
+ * no actor object, and the chain is dropped as soon as it drains.
+ *
+ * What belongs on the queue is the section that must not interleave with other
+ * commands on the same session — a follower's prompt build + tail admission,
+ * the opening ACK's release of the route. A human-paced wait (a repo picker)
+ * is session STATE, never a queued command: nothing may hold the queue while
+ * waiting for a person.
+ *
+ * A command must not call `runSessionTurn` for its own session from inside
+ * itself — it would wait on itself. Run the nested step inline instead.
+ */
+
+type Chain = { tail: Promise<void>; pending: number };
+
+const chains = new Map<string, Chain>();
+
+/** Run `command` once every command enqueued earlier for `sessionId` has
+ *  settled. Resolves/rejects with the command's own outcome; a rejected
+ *  predecessor never blocks later commands. */
+export function runSessionTurn<T>(sessionId: string, command: () => T | Promise<T>): Promise<T> {
+  const chain = chains.get(sessionId) ?? { tail: Promise.resolve(), pending: 0 };
+  chain.pending += 1;
+  chains.set(sessionId, chain);
+  const run = chain.tail.then(command);
+  const settle = (): void => {
+    chain.pending -= 1;
+    if (chain.pending === 0 && chains.get(sessionId) === chain) chains.delete(sessionId);
+  };
+  chain.tail = run.then(settle, settle);
+  return run;
+}
+
+/** True while a command for `sessionId` is running or waiting to run. Ingress
+ *  that must not overtake such a command (an ordinary live-worker turn arriving
+ *  behind a follower still being built) checks this instead of keeping its own
+ *  outstanding counter. */
+export function hasPendingSessionTurns(sessionId: string): boolean {
+  return (chains.get(sessionId)?.pending ?? 0) > 0;
+}
+
+export function __testOnly_resetSessionTurnQueues(): void {
+  chains.clear();
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -187,16 +187,10 @@ export interface DaemonSession {
    * refork. Later same-anchor handlers may prepare concurrently, but only this
    * owner may cross the fork boundary; followers buffer behind its gate. */
   initialStartClaimToken?: string;
-  /** Number of activation-tail arrivals that reserved FIFO order before an
-   * asynchronous prompt/sender build and have not yet durably admitted or
-   * failed. An opening ACK must not clear the route while this is non-zero. */
-  queuedActivationTailAdmissionsOutstanding?: number;
-  /** An opening ACK (or ordinary cold-start handoff) observed while an
-   * asynchronous tail admission was outstanding. The final settler replays
-   * this release so a late durable successor cannot be stranded. */
-  queuedActivationTailReleasePending?: { acknowledgedToken?: string };
-  /** Retry timer for an ordinary cold-start handoff whose durable promotion
-   * failed after all asynchronous admissions had settled. */
+  /** Retry timer for a route release whose durable promotion failed while the
+   * route was still held. Ordering between a follower still being built and
+   * the opening's release is the session turn queue's job
+   * (core/session-turn-queue.ts), not a field here. */
   queuedActivationTailReleaseRetryTimer?: ReturnType<typeof setTimeout>;
   repoCardMessageId?: string;    // message_id of the repo selection card — for withdrawal
   /**
@@ -273,18 +267,6 @@ export interface DaemonSession {
    * Used only when a literal raw cold start must fold followers onto the same
    * text→Enter IPC boundary. */
   pendingCodexAppFollowUpGateAccepted?: boolean[];
-  /** Exact turns that arrived while a previously attempted queued activation
-   * was re-parked. They remain separate FIFO items behind the retained opening
-   * payload and advance only after worker acceptance. In-memory only. */
-  pendingQueuedActivationFollowUps?: Array<{
-    userPrompt: string;
-    cliInput: CliTurnPayload;
-    turnId: string;
-    dispatchAttempt?: number;
-    /** Legacy volatile entries already crossed the clean-input gate when they
-     * were staged. Migration must preserve that exact sidecar decision. */
-    codexAppInputGateFrozen?: true;
-  }>;
   /** Daemon-selected, app-scoped session owner. Frozen for the worker lifetime;
    *  not the current-turn sender. Absent for ownerless/foreign-bot sessions. */
   ownerOpenId?: string;          // receives owner-only links and controls write-enabled access

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -526,6 +526,7 @@ import {
   type DaemonSession,
 } from './types.js';
 import { hasProtectedSessionMutationOwnership } from './session-mutation-guard.js';
+import { hasPendingSessionTurns } from './session-turn-queue.js';
 import { DONE_REACTION_EMOJI_TYPE } from './pending-response.js';
 import { buildTerminalUrl } from './terminal-url.js';
 import { prependBotmuxBin, resolveBotmuxWrapperBinDir } from './botmux-wrapper.js';
@@ -9163,71 +9164,6 @@ function reparkUnsubmittedQueuedActivation(ds: DaemonSession, reason: string): b
   return true;
 }
 
-/** The opening activation was ACKed, but one of the turns held behind its
- * runtime reservation was not accepted before that worker exited. Promote the
- * exact FIFO head into a new durable queued activation so the next inbound or
- * Dashboard activation reforks it before every remaining tail item. */
-function reparkQueuedActivationFollowUpTail(ds: DaemonSession, reason: string): boolean {
-  if (!ds.initialStartPending || ds.session.queuedActivationPending) return false;
-  const next = ds.pendingQueuedActivationFollowUps?.[0];
-  if (!next) return false;
-  const matchingCodexEntries = ds.session.cliId === 'codex-app'
-    ? (ds.session.codexAppDispatchLedger ?? []).filter(entry =>
-      (entry.state === 'accepted' || entry.state === 'prepared')
-      && entry.turnId === next.turnId
-      && entry.dispatchAttempt === next.dispatchAttempt)
-    : [];
-  if (matchingCodexEntries.length > 1) {
-    logger.error(
-      `[${tag(ds)}] Cannot re-park queued follow-up after ${reason}: `
-      + `${matchingCodexEntries.length} Codex entries match turn ${next.turnId}`,
-    );
-    return false;
-  }
-  const retainedCodexEntry = matchingCodexEntries[0];
-  const retainedCodexToken = retainedCodexEntry
-    ? (retainedCodexEntry.queuedActivationToken ?? randomUUID())
-    : undefined;
-  // A failed daemon→worker IPC normally rolls its newly accepted Codex entry
-  // back. If that rollback persistence itself failed, the durable FIFO remains
-  // authoritative: recover it through a tokened ACK journal instead of
-  // creating an invalid queued+unsettled hybrid.
-  ds.session.queued = !retainedCodexEntry;
-  ds.session.queuedPrompt = next.cliInput.content;
-  ds.session.queuedCodexAppText = next.cliInput.codexAppInput?.text;
-  ds.session.queuedCodexAppMessageContext = undefined;
-  ds.session.queuedActivationInput = next.cliInput;
-  ds.session.queuedActivationTurnId = next.turnId;
-  ds.session.queuedActivationDispatchAttempt = next.dispatchAttempt;
-  ds.session.queuedActivationPending = retainedCodexEntry ? true : undefined;
-  ds.session.queuedActivationToken = retainedCodexToken;
-  if (retainedCodexEntry && retainedCodexToken) {
-    retainedCodexEntry.queuedActivationToken = retainedCodexToken;
-  }
-  ds.pendingQueuedActivationFollowUps!.shift();
-  if (ds.pendingQueuedActivationFollowUps!.length === 0) {
-    ds.pendingQueuedActivationFollowUps = undefined;
-  }
-  ds.pendingPrompt = next.cliInput.content;
-  ds.initialStartPending = false;
-  ds.initialStartClaimToken = undefined;
-  try {
-    sessionStore.updateSession(ds.session);
-  } catch (err) {
-    // Keep the exact head parked in memory. The caller has already fenced the
-    // dead worker, so a later inbound can safely retry this owner even if the
-    // durable projection is temporarily unavailable.
-    logger.error(
-      `[${tag(ds)}] Failed to persist queued follow-up re-park after ${reason}: `
-      + `${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-  logger.warn(`[${tag(ds)}] Re-parked unaccepted queued activation follow-up after ${reason}`);
-  return true;
-}
-
-export const __testOnly_reparkQueuedActivationFollowUpTail = reparkQueuedActivationFollowUpTail;
-
 type AcceptedWorkerForkDispatch = {
   dispatchId: string;
   turnId: string;
@@ -9953,12 +9889,13 @@ export function admitQueuedActivationTail(
 
 /** True while a live worker's opening activation still owns submission order.
  * Every ingress that sees this state must use admitQueuedActivationTail rather
- * than ordinary worker IPC. */
+ * than ordinary worker IPC. A command still queued for the session (a follower
+ * whose prompt is being built, the opening's own release) holds the gate too:
+ * an ordinary turn arriving now must land behind it, not overtake it. */
 export function hasQueuedActivationAdmissionGate(ds: DaemonSession): boolean {
   return ds.session.queuedActivationPending === true
     || (ds.session.queuedActivationTail?.length ?? 0) > 0
-    || (ds.queuedActivationTailAdmissionsOutstanding ?? 0) > 0
-    || ds.queuedActivationTailReleasePending !== undefined
+    || hasPendingSessionTurns(ds.session.sessionId)
     || (ds.initialStartPending === true
       && ds.session.queuedActivationInput !== undefined);
 }
@@ -10723,8 +10660,6 @@ export function forkWorker(
         // claim so the next generation can replay that exact head.
         ds.initialStartPending = false;
         ds.initialStartClaimToken = undefined;
-      } else {
-        reparkQueuedActivationFollowUpTail(ds, 'worker error during activation follow-up handoff');
       }
       const retainExactRetirementGeneration = ds.remoteShutdownState !== undefined
         || ds.remoteCloseState !== undefined;
@@ -14298,8 +14233,6 @@ function setupWorkerHandlers(
         // this exact head with queuedActivationResume before durable tail N+1.
         ds.initialStartPending = false;
         ds.initialStartClaimToken = undefined;
-      } else {
-        reparkQueuedActivationFollowUpTail(ds, 'worker exit during activation follow-up handoff');
       }
       ds.worker = null;
       ds.workerReady = false;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -17038,6 +17038,16 @@ function clearInitialStartClaim(ds: DaemonSession, token?: string): boolean {
   return true;
 }
 
+/** True while a failed release still has work: the route is held, or a
+ * durable tail entry is waiting for promotion. Do not key this only on
+ * `initialStartPending` — inline promote can fail after the opening already
+ * cleared that flag, and `promoteQueuedActivationTail` setting it again
+ * before a store throw is not a contract. */
+function queuedActivationReleaseDue(ds: DaemonSession): boolean {
+  return ds.initialStartPending === true
+    || (ds.session.queuedActivationTail?.length ?? 0) > 0;
+}
+
 /** Retry a route release whose durable promotion failed (a store write or the
  * worker IPC) while the route is still held. The retry is one more command on
  * the session's turn queue, so it cannot overtake an admission that arrived in
@@ -17046,11 +17056,11 @@ function scheduleQueuedActivationTailReleaseRetry(
   ds: DaemonSession,
   acknowledgedToken?: string,
 ): void {
-  if (!ds.initialStartPending || ds.queuedActivationTailReleaseRetryTimer) return;
+  if (!queuedActivationReleaseDue(ds) || ds.queuedActivationTailReleaseRetryTimer) return;
   const timer = setTimeout(() => {
     if (ds.queuedActivationTailReleaseRetryTimer !== timer) return;
     ds.queuedActivationTailReleaseRetryTimer = undefined;
-    if (!ds.initialStartPending) return;
+    if (!queuedActivationReleaseDue(ds)) return;
     void releaseQueuedActivationReservation(ds, acknowledgedToken).then(released => {
       if (!released) scheduleQueuedActivationTailReleaseRetry(ds, acknowledgedToken);
     }, err => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -205,6 +205,7 @@ import {
   larkTransportEnabled,
 } from './core/types.js';
 import { stagePendingRepoSetup, persistPendingRepoCardMessageId } from './core/pending-repo-journal.js';
+import { hasPendingSessionTurns, runSessionTurn } from './core/session-turn-queue.js';
 import { buildTerminalUrl, setTerminalProxyPort, setTerminalExternalPort } from './core/terminal-url.js';
 import { startTerminalProxy, type TerminalProxyHandle } from './core/terminal-proxy.js';
 import type { CliId } from './adapters/cli/types.js';
@@ -17030,28 +17031,17 @@ function clearInitialStartClaim(ds: DaemonSession, token?: string): boolean {
   if (token !== undefined && ds.initialStartClaimToken !== token) return false;
   ds.initialStartClaimToken = undefined;
   ds.initialStartPending = false;
-  if ((ds.queuedActivationTailAdmissionsOutstanding ?? 0) === 0) {
-    ds.queuedActivationTailReleasePending = undefined;
-    if (ds.queuedActivationTailReleaseRetryTimer) {
-      clearTimeout(ds.queuedActivationTailReleaseRetryTimer);
-      ds.queuedActivationTailReleaseRetryTimer = undefined;
-    }
+  if (ds.queuedActivationTailReleaseRetryTimer) {
+    clearTimeout(ds.queuedActivationTailReleaseRetryTimer);
+    ds.queuedActivationTailReleaseRetryTimer = undefined;
   }
   return true;
 }
 
-/** Fence an arrival before any sender/prompt await. Besides reserving durable
- * FIFO order, keep the opening route owned until this reservation either lands
- * in the durable tail or fails. */
-function reserveAsyncQueuedActivationTailAdmission(
-  ds: DaemonSession,
-): QueuedActivationTailReservation {
-  const reservation = reserveQueuedActivationTailAdmission(ds);
-  ds.queuedActivationTailAdmissionsOutstanding =
-    (ds.queuedActivationTailAdmissionsOutstanding ?? 0) + 1;
-  return reservation;
-}
-
+/** Retry a route release whose durable promotion failed (a store write or the
+ * worker IPC) while the route is still held. The retry is one more command on
+ * the session's turn queue, so it cannot overtake an admission that arrived in
+ * the meantime. */
 function scheduleQueuedActivationTailReleaseRetry(
   ds: DaemonSession,
   acknowledgedToken?: string,
@@ -17061,49 +17051,62 @@ function scheduleQueuedActivationTailReleaseRetry(
     if (ds.queuedActivationTailReleaseRetryTimer !== timer) return;
     ds.queuedActivationTailReleaseRetryTimer = undefined;
     if (!ds.initialStartPending) return;
-    if (!releaseQueuedActivationReservation(ds, acknowledgedToken)) {
-      scheduleQueuedActivationTailReleaseRetry(ds, acknowledgedToken);
-    }
+    void releaseQueuedActivationReservation(ds, acknowledgedToken).then(released => {
+      if (!released) scheduleQueuedActivationTailReleaseRetry(ds, acknowledgedToken);
+    }, err => {
+      logger.error(
+        `[${ds.session.sessionId.slice(0, 8)}] Queued activation release retry failed: `
+        + `${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
   }, 100);
   timer.unref?.();
   ds.queuedActivationTailReleaseRetryTimer = timer;
 }
 
-/** Complete one async reservation. If the predecessor ACK arrived during its
- * await, the final settler performs the deferred handoff immediately. */
-function settleAsyncQueuedActivationTailAdmission(ds: DaemonSession): void {
-  const outstanding = Math.max(
-    0,
-    (ds.queuedActivationTailAdmissionsOutstanding ?? 0) - 1,
-  );
-  ds.queuedActivationTailAdmissionsOutstanding = outstanding || undefined;
-  if (outstanding > 0 || !ds.queuedActivationTailReleasePending) return;
-  const pending = ds.queuedActivationTailReleasePending;
-  ds.queuedActivationTailReleasePending = undefined;
-  if (!releaseQueuedActivationReservation(ds, pending.acknowledgedToken)) {
-    scheduleQueuedActivationTailReleaseRetry(ds, pending.acknowledgedToken);
-  }
+/** Admit one same-anchor follower behind the opening it arrived after.
+ *
+ * Its FIFO order was stamped at arrival (`reservation`); the prompt build
+ * awaits (sender lookup), so build + durable admission run as ONE command on
+ * the session's turn queue — neither a later arrival nor the opening's ACK can
+ * act on the session in between. If the opening released its route while this
+ * follower was still queued (its ACK or ordinary fork ran ahead on the same
+ * queue and found an empty tail), nothing else will promote the entry, so the
+ * same command promotes it inline — never through the queue again. */
+async function admitFollowerBehindOpening(
+  ds: DaemonSession,
+  reservation: QueuedActivationTailReservation,
+  follower: { userPrompt: string; turnId: string; build: () => Promise<CliTurnPayload> },
+): Promise<void> {
+  await runSessionTurn(ds.session.sessionId, async () => {
+    const cliInput = await follower.build();
+    admitQueuedActivationTail(ds, {
+      userPrompt: follower.userPrompt,
+      cliInput,
+      turnId: follower.turnId,
+    }, reservation);
+    if (!ds.initialStartPending && !releaseQueuedActivationReservationNow(ds)) {
+      scheduleQueuedActivationTailReleaseRetry(ds);
+    }
+  });
 }
-
-export const __testOnly_reserveAsyncQueuedActivationTailAdmission =
-  reserveAsyncQueuedActivationTailAdmission;
-export const __testOnly_settleAsyncQueuedActivationTailAdmission =
-  settleAsyncQueuedActivationTailAdmission;
 
 /** Release a queued activation's runtime route reservation only after the
  * worker ACKs actual adapter submission. Turns that arrived meanwhile are sent
- * as one ordered follow-up, never allowed to overtake the opening item. */
-function releaseQueuedActivationReservation(ds: DaemonSession, acknowledgedToken?: string): boolean {
-  if ((ds.queuedActivationTailAdmissionsOutstanding ?? 0) > 0) {
-    // The worker may ACK while N+1 is still awaiting sender/resource prompt
-    // construction. Keep the route gate and replay this release when the last
-    // reserved arrival either persists or fails.
-    ds.queuedActivationTailReleasePending = acknowledgedToken === undefined
-      ? {}
-      : { acknowledgedToken };
-    return false;
-  }
-  ds.queuedActivationTailReleasePending = undefined;
+ * as one ordered follow-up, never allowed to overtake the opening item.
+ *
+ * One command on the session's turn queue: a follower whose build + admission
+ * is still in flight was enqueued before this release, so the release runs
+ * after its durable tail entry exists — no outstanding counter, no deferred
+ * replay. */
+function releaseQueuedActivationReservation(ds: DaemonSession, acknowledgedToken?: string): Promise<boolean> {
+  return runSessionTurn(ds.session.sessionId, () => releaseQueuedActivationReservationNow(ds, acknowledgedToken));
+}
+
+/** The release itself. Only for a caller already running on the session's turn
+ * queue (a follower admission that found the route released); every other
+ * caller goes through {@link releaseQueuedActivationReservation}. */
+function releaseQueuedActivationReservationNow(ds: DaemonSession, acknowledgedToken?: string): boolean {
   // A prior callback retry may observe the successor already promoted. That is
   // success for the acknowledged predecessor; never append/send the same tail
   // head a second time while its fresh token owns the journal.
@@ -17178,27 +17181,6 @@ function releaseQueuedActivationReservation(ds: DaemonSession, acknowledgedToken
     ds.pendingCodexAppApplicationContext = undefined;
   }
 
-  // Migrate pre-durable runtime tails (and tests/rolling-upgrade state) before
-  // advancing. Persistence happens before the volatile cursor is cleared.
-  for (const staged of ds.pendingQueuedActivationFollowUps ?? []) {
-    const reservation = reserveQueuedActivationTailAdmission(ds);
-    try {
-      admitQueuedActivationTail(ds, {
-        userPrompt: staged.userPrompt,
-        cliInput: staged.cliInput,
-        turnId: staged.turnId,
-        dispatchAttempt: staged.dispatchAttempt,
-      }, reservation, { codexAppInputGateFrozen: true });
-    } catch (err) {
-      logger.error(
-        `[${ds.session.sessionId.slice(0, 8)}] Failed to migrate activation successor: `
-        + `${err instanceof Error ? err.message : String(err)}`,
-      );
-      return false;
-    }
-  }
-  ds.pendingQueuedActivationFollowUps = undefined;
-
   if ((ds.session.queuedActivationTail?.length ?? 0) === 0) {
     clearInitialStartBuffers(ds);
     clearInitialStartClaim(ds);
@@ -17230,11 +17212,12 @@ function releaseQueuedActivationReservation(ds: DaemonSession, acknowledgedToken
 }
 
 export const __testOnly_releaseQueuedActivationReservation = releaseQueuedActivationReservation;
+export const __testOnly_admitFollowerBehindOpening = admitFollowerBehindOpening;
 
 /** Exact production callback passed to initWorkerPool. Keep the boolean return:
  * false means the worker did not accept the staged FIFO head and the pool must
  * retry instead of silently dropping the activation reservation. */
-function onQueuedActivationSubmitted(ds: DaemonSession, activationToken?: string): boolean {
+function onQueuedActivationSubmitted(ds: DaemonSession, activationToken?: string): Promise<boolean> {
   return releaseQueuedActivationReservation(ds, activationToken);
 }
 
@@ -17259,12 +17242,19 @@ function forkReservedInitialSession(ds: DaemonSession, availableBots: AvailableB
   const waitsForQueuedAck = ds.session.queuedActivationPending === true;
   ds.initialStartPending = waitsForQueuedAck
     || (ds.session.queuedActivationTail?.length ?? 0) > 0
-    || (ds.queuedActivationTailAdmissionsOutstanding ?? 0) > 0;
+    || hasPendingSessionTurns(ds.session.sessionId);
   clearInitialStartBuffers(ds);
   if (!waitsForQueuedAck && ds.initialStartPending) {
-    // A follower may have reserved FIFO order while the opening prompt was
-    // still being built. Hand off now, or defer until its reservation settles.
-    void releaseQueuedActivationReservation(ds);
+    // A follower may still be building its prompt behind this opening. The
+    // release is queued behind it, so the handoff sees every admitted entry.
+    void releaseQueuedActivationReservation(ds).then(released => {
+      if (!released) scheduleQueuedActivationTailReleaseRetry(ds);
+    }, err => {
+      logger.error(
+        `[${ds.session.sessionId.slice(0, 8)}] Failed to release the opening route after fork: `
+        + `${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
   }
 }
 
@@ -17306,7 +17296,7 @@ function forkReservedInitialRawSession(ds: DaemonSession, availableBots: Availab
   // both the raw text and Enter have crossed the adapter boundary.
   const armRawActivationAck = !ds.session.queuedActivationPending
     && ((ds.session.queuedActivationTail?.length ?? 0) > 0
-      || (ds.queuedActivationTailAdmissionsOutstanding ?? 0) > 0);
+      || hasPendingSessionTurns(ds.session.sessionId));
   if (armRawActivationAck) ds.session.queued = true;
   try {
     forkWorker(ds, '', false);
@@ -20166,39 +20156,41 @@ async function handleThreadReplyAdmitted(
     && !ownsInitialStartClaim()
     && !liveTakeoverReady;
   if (ds && initialStartPending && !ds.pendingRepo) {
-    const tailReservation = reserveAsyncQueuedActivationTailAdmission(ds);
-    try {
-      const botCfg = getBot(ds.larkAppId).config;
-      const followUp = buildFollowUpCliInput(promptContent, ds.session.sessionId, {
-        attachments,
-        mentions: parsed.mentions,
-        isAdoptMode: false,
-        cliId: ds.session.cliLaunchSnapshot?.cliId ?? ds.session.cliId ?? botCfg.cliId,
-        cliPathOverride: ds.session.cliLaunchSnapshot?.cliPathOverride ?? ds.session.cliPathOverride ?? botCfg.cliPathOverride,
-        sender: await getThreadSender(),
-        larkAppId,
-        chatId: ds.session.chatId,
-        whiteboardId: ds.session.whiteboardId,
-        substituteTrigger,
-        codexAppText: parsed.content,
-        codexAppApplicationContext,
-        codexAppMessageContext,
-      sessionBackendType: ds.session.backendType,
+    // FIFO order is stamped now, at arrival; the prompt build (sender lookup)
+    // and the durable admission then run as one command on the session's turn
+    // queue, so neither a later arrival nor the opening's ACK can act on the
+    // session in between.
+    const tailReservation = reserveQueuedActivationTailAdmission(ds);
+    await admitFollowerBehindOpening(ds, tailReservation, {
+      userPrompt: promptContent,
       turnId: parsed.messageId,
-      });
-      // R5-B1-1: freeze the admission-time steer authorization onto this earliest
-      // (initialStartPending follower) tail entry — the strip-proof admit rebuild
-      // then preserves it through promote/repark. Only a plain-human turn is true.
-      if (codexAppSteerable) followUp.codexAppSteerable = true;
-      admitQueuedActivationTail(ds, {
-        userPrompt: promptContent,
-        cliInput: followUp,
-        turnId: parsed.messageId,
-      }, tailReservation);
-      markIngressAdmitted(ctx);
-    } finally {
-      settleAsyncQueuedActivationTailAdmission(ds);
-    }
+      build: async () => {
+        const botCfg = getBot(ds.larkAppId).config;
+        const followUp = buildFollowUpCliInput(promptContent, ds.session.sessionId, {
+          attachments,
+          mentions: parsed.mentions,
+          isAdoptMode: false,
+          cliId: ds.session.cliLaunchSnapshot?.cliId ?? ds.session.cliId ?? botCfg.cliId,
+          cliPathOverride: ds.session.cliLaunchSnapshot?.cliPathOverride ?? ds.session.cliPathOverride ?? botCfg.cliPathOverride,
+          sender: await getThreadSender(),
+          larkAppId,
+          chatId: ds.session.chatId,
+          whiteboardId: ds.session.whiteboardId,
+          substituteTrigger,
+          codexAppText: parsed.content,
+          codexAppApplicationContext,
+          codexAppMessageContext,
+          sessionBackendType: ds.session.backendType,
+          turnId: parsed.messageId,
+        });
+        // R5-B1-1: freeze the admission-time steer authorization onto this earliest
+        // (initialStartPending follower) tail entry — the strip-proof admit rebuild
+        // then preserves it through promote/repark. Only a plain-human turn is true.
+        if (codexAppSteerable) followUp.codexAppSteerable = true;
+        return followUp;
+      },
+    });
+    markIngressAdmitted(ctx);
     logger.info(
       `[${tag(ds)}] buffered same-anchor turn ${parsed.messageId.substring(0, 12)} `
       + 'behind queued activation submission ACK',
@@ -20227,13 +20219,9 @@ async function handleThreadReplyAdmitted(
     return;
   }
   if (ds?.pendingRepo || initialStartPending) {
-    const durableTailReservation = ds.pendingRepo
-      ? reserveAsyncQueuedActivationTailAdmission(ds)
-      : undefined;
     const bufferedCodexAppInputAccepted = initialStartPending && !ds.pendingRepo
       ? codexAppCleanInputAcceptedForSession(ds)
       : undefined;
-    try {
     // Enrich content with attachment hints and mention metadata (same as normal send)
     const codexAppFollowUpContextParts: string[] = [];
     if (codexAppMessageContext) codexAppFollowUpContextParts.push(codexAppMessageContext);
@@ -20331,11 +20319,13 @@ async function handleThreadReplyAdmitted(
         ds.session.queuedCodexAppMessageContext ??= ds.pendingCodexAppMessageContext;
         // R5-B1-1: freeze steer authorization onto the pending-repo follower tail.
         if (codexAppSteerable) exactFollowUp.codexAppSteerable = true;
+        // No await separates this arrival from its admission, so the FIFO
+        // order is stamped by the admit itself.
         admitQueuedActivationTail(ds, {
           userPrompt: promptContent,
           cliInput: exactFollowUp,
           turnId: parsed.messageId,
-        }, durableTailReservation!);
+        });
       }
       // 本轮已持久化接纳（durable opening 或 durable tail）；下面的状态回复再
       // 失败也不得诱导重发（PR #846 review）。
@@ -20411,9 +20401,6 @@ async function handleThreadReplyAdmitted(
       : 'daemon.choose_repo_first';
     await sessionReply(anchor, tr(pendingReplyKey, undefined, localeForBot(larkAppId)), 'text', larkAppId);
     return;
-    } finally {
-      if (durableTailReservation) settleAsyncQueuedActivationTailAdmission(ds);
-    }
   }
 
   if (!ds) {
@@ -20826,42 +20813,40 @@ async function handleThreadReplyAdmitted(
     // <whiteboard> block in its refork prompt) that its live turns never had.
     if (!ds.adoptedFrom) ensureSessionWhiteboard(ds);
     const stageCurrentBehindQueuedActivation = async (): Promise<void> => {
-      const tailReservation = reserveAsyncQueuedActivationTailAdmission(ds);
-      try {
-        const currentFollowUp = buildFollowUpCliInput(promptContent, ds.session.sessionId, {
-          attachments,
-          mentions: parsed.mentions,
-          isAdoptMode: false,
-          cliId: ds.session.cliLaunchSnapshot?.cliId ?? ds.session.cliId ?? dsBotCfgForFork.cliId,
-          cliPathOverride: ds.session.cliLaunchSnapshot?.cliPathOverride ?? ds.session.cliPathOverride ?? dsBotCfgForFork.cliPathOverride,
-          sender: await getThreadSender(),
-          larkAppId,
-          chatId: ds.session.chatId,
-          whiteboardId: ds.session.whiteboardId,
-          substituteTrigger,
-          codexAppText: parsed.content,
-          codexAppApplicationContext,
-          codexAppMessageContext,
-        sessionBackendType: ds.session.backendType,
+      const tailReservation = reserveQueuedActivationTailAdmission(ds);
+      await admitFollowerBehindOpening(ds, tailReservation, {
+        userPrompt: promptContent,
         turnId: parsed.messageId,
-        });
-        // R4-B1: freeze the admission-time steer authorization onto the queued
-        // opening payload so the worker-null re-fork path carries it exactly like
-        // the live-worker path (admission computed once at line ~18431; COPIED
-        // here, never re-inferred). System/recovery openings keep it absent.
-        if (codexAppSteerable) currentFollowUp.codexAppSteerable = true;
-        if (threadTrustedCaller) currentFollowUp.trustedCaller = threadTrustedCaller;
-        admitQueuedActivationTail(ds, {
-          userPrompt: promptContent,
-          cliInput: currentFollowUp,
-          turnId: parsed.messageId,
-        }, tailReservation);
-        // 本轮已进 durable tail——之后 fork/回执失败可由重启或下一条 inbound 恢复，
-        // 不得再诱导重发。
-        markIngressAdmitted(ctx);
-      } finally {
-        settleAsyncQueuedActivationTailAdmission(ds);
-      }
+        build: async () => {
+          const currentFollowUp = buildFollowUpCliInput(promptContent, ds.session.sessionId, {
+            attachments,
+            mentions: parsed.mentions,
+            isAdoptMode: false,
+            cliId: ds.session.cliLaunchSnapshot?.cliId ?? ds.session.cliId ?? dsBotCfgForFork.cliId,
+            cliPathOverride: ds.session.cliLaunchSnapshot?.cliPathOverride ?? ds.session.cliPathOverride ?? dsBotCfgForFork.cliPathOverride,
+            sender: await getThreadSender(),
+            larkAppId,
+            chatId: ds.session.chatId,
+            whiteboardId: ds.session.whiteboardId,
+            substituteTrigger,
+            codexAppText: parsed.content,
+            codexAppApplicationContext,
+            codexAppMessageContext,
+            sessionBackendType: ds.session.backendType,
+            turnId: parsed.messageId,
+          });
+          // R4-B1: freeze the admission-time steer authorization onto the queued
+          // opening payload so the worker-null re-fork path carries it exactly like
+          // the live-worker path (admission computed once at line ~18431; COPIED
+          // here, never re-inferred). System/recovery openings keep it absent.
+          if (codexAppSteerable) currentFollowUp.codexAppSteerable = true;
+          if (threadTrustedCaller) currentFollowUp.trustedCaller = threadTrustedCaller;
+          return currentFollowUp;
+        },
+      });
+      // 本轮已进 durable tail——之后 fork/回执失败可由重启或下一条 inbound 恢复，
+      // 不得再诱导重发。
+      markIngressAdmitted(ctx);
       ds.initialStartPending = true;
       await noteTurnReceived(
         ds,
@@ -21085,7 +21070,7 @@ async function handleThreadReplyAdmitted(
         // Ordinary cold reforks have no adapter-submission ACK. The child owns
         // the opening init after forkWorker returns, so hand any concurrently
         // buffered followers to its IPC queue now in exact arrival order.
-        retainInitialStartClaim = !releaseQueuedActivationReservation(ds);
+        retainInitialStartClaim = !(await releaseQueuedActivationReservation(ds));
       }
     }
   }

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -207,7 +207,7 @@ import {
   hasQueuedActivationAdmissionGate,
   reserveQueuedActivationTailAdmission,
 } from '../src/core/worker-pool.js';
-import { runSessionTurn } from '../src/core/session-turn-queue.js';
+import { __testOnly_resetSessionTurnQueues, runSessionTurn } from '../src/core/session-turn-queue.js';
 import type { DaemonSession } from '../src/core/types.js';
 import { getDocSubscription, putDocSubscription, removeDocSubscription } from '../src/services/doc-subs-store.js';
 import { config } from '../src/config.js';
@@ -525,6 +525,7 @@ function resetRouteTestState(): void {
   mocks.getChatMode.mockResolvedValue('group');
   mocks.getChatNameAndMode.mockResolvedValue({ name: null, mode: 'group' });
   activeSessions.clear();
+  __testOnly_resetSessionTurnQueues();
   rmSync(crossRefPath(), { force: true });
   rmSync(botsConfigPath(), { force: true });
   rmSync(botsInfoPath(), { force: true });
@@ -571,6 +572,7 @@ describe('/rename production routing — must not pre-create a session (review P
     mocks.getAvailableBots.mockResolvedValue([]);
     mocks.downloadResources.mockResolvedValue({ attachments: [], needLogin: false });
     activeSessions.clear();
+    __testOnly_resetSessionTurnQueues();
     resetDocCommentClaims();
     // master: clear per-bot store files so a seeded cross-ref / bots config from
     // one test can't leak into the next (see the known-peer + /fast tests).
@@ -2566,6 +2568,46 @@ describe('/rename production routing — must not pre-create a session (review P
     }));
     expect(ds.session.queuedActivationPending).toBe(true);
     expect(ds.session.queuedActivationTail).toBeUndefined();
+  });
+
+  it('retries inline promote when the opening already released and the store write fails', async () => {
+    const ds = seedThreadSession('om_inline_promote_retry', 'inline promote retry');
+    ds.session.cliId = 'claude-code';
+    ds.initialStartPending = true;
+    ds.hasHistory = true;
+    const send = vi.fn();
+    ds.worker = { killed: false, send } as any;
+
+    const ack = onQueuedActivationSubmitted(ds, 'opening-token');
+    const reservation = reserveQueuedActivationTailAdmission(ds);
+    mocks.updateSession
+      .mockImplementationOnce((session: any) => { mocks.sessions.set(session.sessionId, session); })
+      .mockImplementationOnce(() => { throw new Error('promote persist unavailable'); });
+    const admission = admitFollowerBehindOpening(ds, reservation, {
+      userPrompt: 'AFTER_RELEASE_RETRY',
+      turnId: 'turn-after-release-retry',
+      build: async () => ({ content: 'AFTER_RELEASE_RETRY' }),
+    });
+    await expect(ack).resolves.toBe(true);
+    await admission;
+    expect(ds.session.queuedActivationTail).toEqual([
+      expect.objectContaining({ turnId: 'turn-after-release-retry' }),
+    ]);
+    expect(ds.queuedActivationTailReleaseRetryTimer).toBeDefined();
+
+    const deadline = Date.now() + 1_000;
+    while (!ds.session.queuedActivationPending && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 20));
+    }
+    expect(ds.session.queuedActivationPending).toBe(true);
+    expect(ds.session.queuedActivationTurnId).toBe('turn-after-release-retry');
+    expect(ds.session.queuedActivationTail).toBeUndefined();
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'message',
+      turnId: 'turn-after-release-retry',
+      content: 'AFTER_RELEASE_RETRY',
+    }));
+    expect(ds.queuedActivationTailReleaseRetryTimer).toBeUndefined();
   });
 
   it('holds the admission gate while a follower is still being built, so a live-worker turn cannot overtake it', async () => {

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -191,6 +191,7 @@ import { sessionAnchorId, sessionKey } from '../src/core/types.js';
 import { recordBotUnionId } from '../src/services/bot-union-ids-store.js';
 import {
   __testOnly_activeSessions as activeSessions,
+  __testOnly_admitFollowerBehindOpening as admitFollowerBehindOpening,
   __testOnly_claimNewDaemonSession as claimNewDaemonSession,
   __testOnly_handleChatModeConverted as handleChatModeConverted,
   __testOnly_handleDocComment as handleDocComment,
@@ -199,11 +200,14 @@ import {
   __testOnly_onQueuedActivationSubmitted as onQueuedActivationSubmitted,
   __testOnly_prewarmDocCommentSession as prewarmDocCommentSession,
   __testOnly_releaseQueuedActivationReservation as releaseQueuedActivationReservation,
-  __testOnly_reserveAsyncQueuedActivationTailAdmission as reserveAsyncQueuedActivationTailAdmission,
   __testOnly_resetDocCommentClaims as resetDocCommentClaims,
-  __testOnly_settleAsyncQueuedActivationTailAdmission as settleAsyncQueuedActivationTailAdmission,
 } from '../src/daemon.js';
-import { admitQueuedActivationTail } from '../src/core/worker-pool.js';
+import {
+  admitQueuedActivationTail,
+  hasQueuedActivationAdmissionGate,
+  reserveQueuedActivationTailAdmission,
+} from '../src/core/worker-pool.js';
+import { runSessionTurn } from '../src/core/session-turn-queue.js';
 import type { DaemonSession } from '../src/core/types.js';
 import { getDocSubscription, putDocSubscription, removeDocSubscription } from '../src/services/doc-subs-store.js';
 import { config } from '../src/config.js';
@@ -341,6 +345,14 @@ function makeCtx(anchor: string, messageId: string): any {
     anchor,
     larkAppId: APP,
   };
+}
+
+/** A hand-released promise: parks a queued follower's prompt build so an
+ *  opening ACK can be modelled as landing while that build is still awaiting. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(res => { resolve = res; });
+  return { promise, resolve };
 }
 
 function seedThreadSession(anchor: string, title: string): DaemonSession {
@@ -1783,7 +1795,7 @@ describe('/rename production routing — must not pre-create a session (review P
       queuedActivationResume: undefined,
       pendingRepoSetup: undefined,
     });
-    expect(onQueuedActivationSubmitted(owner, openingToken)).toBe(true);
+    await expect(onQueuedActivationSubmitted(owner, openingToken)).resolves.toBe(true);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'message',
@@ -1849,7 +1861,7 @@ describe('/rename production routing — must not pre-create a session (review P
       queuedActivationResume: undefined,
       pendingRepoSetup: undefined,
     });
-    expect(onQueuedActivationSubmitted(owner, openingToken)).toBe(true);
+    await expect(onQueuedActivationSubmitted(owner, openingToken)).resolves.toBe(true);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'message',
@@ -1924,7 +1936,7 @@ describe('/rename production routing — must not pre-create a session (review P
     ]);
 
     const send = vi.mocked(ds.worker!.send);
-    expect(releaseQueuedActivationReservation(ds)).toBe(true);
+    await expect(releaseQueuedActivationReservation(ds)).resolves.toBe(true);
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'message',
       turnId: 'om_later_n_plus_1',
@@ -1948,7 +1960,7 @@ describe('/rename production routing — must not pre-create a session (review P
       queuedActivationDispatchAttempt: undefined,
       queuedActivationResume: undefined,
     });
-    expect(onQueuedActivationSubmitted(ds, successorToken)).toBe(true);
+    await expect(onQueuedActivationSubmitted(ds, successorToken)).resolves.toBe(true);
     expect(ds.initialStartPending).toBe(false);
   });
 
@@ -1977,7 +1989,7 @@ describe('/rename production routing — must not pre-create a session (review P
     // into a steer authorization at any layer.
     ds.pendingCodexAppFollowUpGateAccepted = [...gates];
 
-    expect(releaseQueuedActivationReservation(ds)).toBe(true);
+    await expect(releaseQueuedActivationReservation(ds)).resolves.toBe(true);
 
     // release admits the coalesced tail then promotes+sends it. After that, the
     // three durable/live surfaces all persist on ds — assert steerable is absent
@@ -2338,7 +2350,7 @@ describe('/rename production routing — must not pre-create a session (review P
     expect(ds.initialStartClaimToken).toBe(ownerToken);
 
     const send = vi.mocked(ds.worker!.send);
-    expect(onQueuedActivationSubmitted(ds)).toBe(true);
+    await expect(onQueuedActivationSubmitted(ds)).resolves.toBe(true);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(expect.objectContaining({
       type: 'message',
@@ -2357,7 +2369,7 @@ describe('/rename production routing — must not pre-create a session (review P
       queuedActivationDispatchAttempt: undefined,
       queuedActivationResume: undefined,
     });
-    expect(onQueuedActivationSubmitted(ds, successorToken)).toBe(true);
+    await expect(onQueuedActivationSubmitted(ds, successorToken)).resolves.toBe(true);
     expect(ds.initialStartPending).toBe(false);
     expect(ds.initialStartClaimToken).toBeUndefined();
   });
@@ -2366,8 +2378,8 @@ describe('/rename production routing — must not pre-create a session (review P
     { arrivalGate: true, laterGate: false, expectsSidecar: true, label: 'ON→OFF' },
     { arrivalGate: false, laterGate: true, expectsSidecar: false, label: 'OFF→ON' },
   ])(
-    'freezes a queued follower clean-input decision at reservation time ($label)',
-    ({ arrivalGate, laterGate, expectsSidecar }) => {
+    'freezes a queued follower clean-input decision at arrival, even when N\'s ACK lands mid-build ($label)',
+    async ({ arrivalGate, laterGate, expectsSidecar }) => {
       const bot = registerBot({
         larkAppId: APP,
         larkAppSecret: 's',
@@ -2383,34 +2395,43 @@ describe('/rename production routing — must not pre-create a session (review P
       ds.hasHistory = true;
       ds.session.cliId = 'codex-app';
 
-      const reservation = reserveAsyncQueuedActivationTailAdmission(ds);
-      expect(ds.queuedActivationTailAdmissionsOutstanding).toBe(1);
+      // Arrival: FIFO order and the clean-input decision are stamped synchronously.
+      const reservation = reserveQueuedActivationTailAdmission(ds);
       bot.config.codexAppCleanInput = laterGate;
 
-      // Model N's ACK landing while N+1 is still awaiting prompt materialization.
-      expect(releaseQueuedActivationReservation(ds, 'opening-token')).toBe(false);
+      // N+1's prompt build is still awaiting when N's ACK lands. Both are
+      // commands on the session's turn queue, in arrival order: the release
+      // must not run until the follower's admission has landed.
+      const build = deferred();
       const sidecar = {
         text: 'FOLLOWER_CLEAN_N1',
         additionalContext: {
           hidden: { kind: 'application' as const, value: '<hidden>arrival</hidden>' },
         },
       };
-      admitQueuedActivationTail(ds, {
-        userPrompt: 'FOLLOWER_CLEAN_N1',
-        cliInput: {
-          content: '<user_message>FOLLOWER_LEGACY_N1</user_message>',
-          codexAppInput: sidecar,
-        },
-        turnId: 'turn-clean-follower',
-        dispatchAttempt: 2,
-      }, reservation);
-      settleAsyncQueuedActivationTailAdmission(ds);
+      const admission = runSessionTurn(ds.session.sessionId, async () => {
+        await build.promise;
+        admitQueuedActivationTail(ds, {
+          userPrompt: 'FOLLOWER_CLEAN_N1',
+          cliInput: {
+            content: '<user_message>FOLLOWER_LEGACY_N1</user_message>',
+            codexAppInput: sidecar,
+          },
+          turnId: 'turn-clean-follower',
+          dispatchAttempt: 2,
+        }, reservation);
+      });
+      const ack = onQueuedActivationSubmitted(ds, 'opening-token');
+      await Promise.resolve();
+      expect(send).not.toHaveBeenCalled();
+      expect(ds.session.queuedActivationTail).toBeUndefined();
+      build.resolve();
+      await admission;
+      await expect(ack).resolves.toBe(true);
 
       const expectedSidecar = expectsSidecar
         ? { ...sidecar, clientUserMessageId: 'turn-clean-follower' }
         : undefined;
-      expect(ds.queuedActivationTailAdmissionsOutstanding).toBeUndefined();
-      expect(ds.queuedActivationTailReleasePending).toBeUndefined();
       expect(ds.session.queuedActivationTail).toBeUndefined();
       expect(ds.session.queuedActivationInput?.codexAppInput).toEqual(expectedSidecar);
       expect(ds.session.codexAppDispatchLedger?.at(-1)?.codexAppInput)
@@ -2437,16 +2458,22 @@ describe('/rename production routing — must not pre-create a session (review P
     ds.initialStartPending = true;
     ds.worker = { killed: false, send: vi.fn() } as any;
 
-    const reservation = reserveAsyncQueuedActivationTailAdmission(ds);
-    expect(releaseQueuedActivationReservation(ds, 'opening-token')).toBe(false);
+    const reservation = reserveQueuedActivationTailAdmission(ds);
+    const build = deferred();
+    const admission = runSessionTurn(ds.session.sessionId, async () => {
+      await build.promise;
+      admitQueuedActivationTail(ds, {
+        userPrompt: 'LATE_N_PLUS_1',
+        cliInput: { content: 'LATE_N_PLUS_1' },
+        turnId: 'turn-late-n1',
+      }, reservation);
+    });
+    const ack = onQueuedActivationSubmitted(ds, 'opening-token');
     // N's worker exits after its ACK but before the reserved N+1 finishes.
     ds.worker = null;
-    admitQueuedActivationTail(ds, {
-      userPrompt: 'LATE_N_PLUS_1',
-      cliInput: { content: 'LATE_N_PLUS_1' },
-      turnId: 'turn-late-n1',
-    }, reservation);
-    settleAsyncQueuedActivationTailAdmission(ds);
+    build.resolve();
+    await admission;
+    await expect(ack).resolves.toBe(true);
 
     expect(ds.session).toMatchObject({
       queuedActivationPending: true,
@@ -2477,35 +2504,82 @@ describe('/rename production routing — must not pre-create a session (review P
     ]);
   });
 
-  it('releases the route when a post-ACK async follower admission fails', () => {
+  it('releases the route when a follower admission queued ahead of the ACK fails', async () => {
     const ds = seedThreadSession('om_failed_late_admission', 'failed late admission');
     ds.session.cliId = 'claude-code';
     ds.initialStartPending = true;
     ds.worker = { killed: false, send: vi.fn() } as any;
-    const reservation = reserveAsyncQueuedActivationTailAdmission(ds);
-    expect(releaseQueuedActivationReservation(ds, 'opening-token')).toBe(false);
+    const reservation = reserveQueuedActivationTailAdmission(ds);
     mocks.updateSession.mockImplementationOnce(() => {
       throw new Error('tail persistence unavailable');
     });
 
-    expect(() => {
-      try {
-        admitQueuedActivationTail(ds, {
-          userPrompt: 'FAILED_N_PLUS_1',
-          cliInput: { content: 'FAILED_N_PLUS_1' },
-          turnId: 'turn-failed-n1',
-        }, reservation);
-      } finally {
-        settleAsyncQueuedActivationTailAdmission(ds);
-      }
-    }).toThrow('tail persistence unavailable');
+    const admission = runSessionTurn(ds.session.sessionId, () => admitQueuedActivationTail(ds, {
+      userPrompt: 'FAILED_N_PLUS_1',
+      cliInput: { content: 'FAILED_N_PLUS_1' },
+      turnId: 'turn-failed-n1',
+    }, reservation));
+    const ack = onQueuedActivationSubmitted(ds, 'opening-token');
+    await expect(admission).rejects.toThrow('tail persistence unavailable');
+    // The failed command never blocks the release queued behind it.
+    await expect(ack).resolves.toBe(true);
 
     expect(ds.session.queuedActivationTail).toBeUndefined();
-    expect(ds.queuedActivationTailAdmissionsOutstanding).toBeUndefined();
-    expect(ds.queuedActivationTailReleasePending).toBeUndefined();
     expect(ds.initialStartPending).toBe(false);
     expect(ds.initialStartClaimToken).toBeUndefined();
     expect(ds.queuedActivationTailReleaseRetryTimer).toBeUndefined();
+  });
+
+  it('promotes a follower whose admission ran after the opening ACK had already released the route', async () => {
+    const ds = seedThreadSession('om_ack_before_follower', 'ACK before follower admission');
+    ds.session.cliId = 'claude-code';
+    ds.initialStartPending = true;
+    ds.hasHistory = true;
+    const send = vi.fn();
+    ds.worker = { killed: false, send } as any;
+
+    // N's ACK is enqueued first; the follower arrived in the same tick — its
+    // order is stamped now, its build + admission queued behind the release.
+    const ack = onQueuedActivationSubmitted(ds, 'opening-token');
+    const reservation = reserveQueuedActivationTailAdmission(ds);
+    let routeHeldAtAdmission: boolean | undefined;
+    const admission = admitFollowerBehindOpening(ds, reservation, {
+      userPrompt: 'AFTER_RELEASE_N_PLUS_1',
+      turnId: 'turn-after-release-n1',
+      build: async () => {
+        // The release ran ahead and found an empty tail: the route is gone by
+        // the time this follower is built, so nothing else will promote it.
+        routeHeldAtAdmission = ds.initialStartPending;
+        return { content: 'AFTER_RELEASE_N_PLUS_1' };
+      },
+    });
+    await expect(ack).resolves.toBe(true);
+    await admission;
+    expect(routeHeldAtAdmission).toBe(false);
+    // …so the same command promoted it inline, with no separate release call.
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'message',
+      turnId: 'turn-after-release-n1',
+      content: 'AFTER_RELEASE_N_PLUS_1',
+      queuedActivationToken: expect.any(String),
+    }));
+    expect(ds.session.queuedActivationPending).toBe(true);
+    expect(ds.session.queuedActivationTail).toBeUndefined();
+  });
+
+  it('holds the admission gate while a follower is still being built, so a live-worker turn cannot overtake it', async () => {
+    const ds = seedThreadSession('om_gate_follows_queue', 'gate follows the turn queue');
+    ds.session.cliId = 'claude-code';
+    ds.worker = { killed: false, send: vi.fn() } as any;
+    expect(hasQueuedActivationAdmissionGate(ds)).toBe(false);
+
+    const build = deferred();
+    const admission = runSessionTurn(ds.session.sessionId, async () => { await build.promise; });
+    expect(hasQueuedActivationAdmissionGate(ds)).toBe(true);
+    build.resolve();
+    await admission;
+    expect(hasQueuedActivationAdmissionGate(ds)).toBe(false);
   });
 
   it('releases a failed queued-refork claim so a later inbound can become the owner', async () => {
@@ -2564,7 +2638,7 @@ describe('/rename production routing — must not pre-create a session (review P
 
     // Promotion is already a durable acceptance boundary: an IPC throw fences
     // this child but keeps one tokened journal owner for exact recovery.
-    expect(onQueuedActivationSubmitted(ds)).toBe(true);
+    await expect(onQueuedActivationSubmitted(ds)).resolves.toBe(true);
     expect(failedSend).toHaveBeenCalledTimes(1);
     expect(kill).toHaveBeenCalledTimes(1);
     expect(ds.pendingFollowUps).toBeUndefined();
@@ -2610,7 +2684,7 @@ describe('/rename production routing — must not pre-create a session (review P
       queuedActivationDispatchAttempt: undefined,
       queuedActivationResume: undefined,
     });
-    expect(onQueuedActivationSubmitted(ds, retainedToken)).toBe(true);
+    await expect(onQueuedActivationSubmitted(ds, retainedToken)).resolves.toBe(true);
     expect(resumedSend).toHaveBeenCalledTimes(1);
     expect(resumedSend).toHaveBeenCalledWith(expect.objectContaining({
       type: 'message',

--- a/test/fixtures/tmux-pipe-exit-fixture.ts
+++ b/test/fixtures/tmux-pipe-exit-fixture.ts
@@ -37,6 +37,8 @@
  *              BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL drives the injection.
  *   nowake   — reproduces the pre-fix teardown (destroy + unlink, no wake-up
  *              byte) and MUST hang, proving the harness has teeth
+ *   drain    — kill() then return, no process.exit(). bun test waits for the
+ *              event loop to empty; process.exit() would hide a leftover handle
  */
 import fs from 'node:fs';
 import { TmuxPipeBackend, __testOnly_liveFifoReaderCount as readerRegistrySize } from '../../src/adapters/backend/tmux-pipe-backend.js';
@@ -184,7 +186,9 @@ setTimeout(() => {
   process.stdout.write(
     `LEAKED_READERS=${readerRegistrySize()} FIFO_LEFT=${fs.existsSync(fifoPath)}\n`,
   );
-  process.exit(0);
+  // bun test does not force-exit: a leftover fifo handle keeps the process
+  // alive after every assertion has passed. process.exit() would hide that.
+  if (mode !== 'drain') process.exit(0);
 }, 250);
 
 }

--- a/test/session-turn-queue.test.ts
+++ b/test/session-turn-queue.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Stage 3 per-session turn：同一 sessionId 上的命令跨 await 仍按入队顺序串行。
+ *
+ * Run:  bunx vitest run test/session-turn-queue.test.ts
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  __testOnly_resetSessionTurnQueues,
+  hasPendingSessionTurns,
+  runSessionTurn,
+} from '../src/core/session-turn-queue.js';
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  __testOnly_resetSessionTurnQueues();
+});
+
+describe('runSessionTurn', () => {
+  it('runs commands for one session in enqueue order, even when an earlier one awaits', async () => {
+    const order: string[] = [];
+    const gate = deferred();
+    const first = runSessionTurn('s1', async () => {
+      order.push('first:start');
+      await gate.promise;
+      order.push('first:end');
+      return 1;
+    });
+    const second = runSessionTurn('s1', () => {
+      order.push('second');
+      return 2;
+    });
+    // The second command must not start while the first is parked on its await.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['first:start']);
+    gate.resolve();
+    await expect(first).resolves.toBe(1);
+    await expect(second).resolves.toBe(2);
+    expect(order).toEqual(['first:start', 'first:end', 'second']);
+  });
+
+  it('does not serialize different sessions against each other', async () => {
+    const order: string[] = [];
+    const gate = deferred();
+    const blocked = runSessionTurn('s1', async () => { await gate.promise; order.push('s1'); });
+    await runSessionTurn('s2', () => { order.push('s2'); });
+    expect(order).toEqual(['s2']);
+    gate.resolve();
+    await blocked;
+    expect(order).toEqual(['s2', 's1']);
+  });
+
+  it('a rejected command surfaces to its caller and never blocks the next one', async () => {
+    const failing = runSessionTurn('s1', () => { throw new Error('boom'); });
+    const next = runSessionTurn('s1', () => 'ran');
+    await expect(failing).rejects.toThrow('boom');
+    await expect(next).resolves.toBe('ran');
+  });
+
+  it('reports pending turns only while a command is queued or running, then drops the chain', async () => {
+    expect(hasPendingSessionTurns('s1')).toBe(false);
+    const gate = deferred();
+    const running = runSessionTurn('s1', async () => { await gate.promise; });
+    const waiting = runSessionTurn('s1', () => undefined);
+    expect(hasPendingSessionTurns('s1')).toBe(true);
+    gate.resolve();
+    await running;
+    // The second command is still on the chain until it settles.
+    expect(hasPendingSessionTurns('s1')).toBe(true);
+    await waiting;
+    expect(hasPendingSessionTurns('s1')).toBe(false);
+  });
+
+  it('a command enqueued after the chain drained starts a fresh chain in order', async () => {
+    const order: number[] = [];
+    await runSessionTurn('s1', () => { order.push(1); });
+    expect(hasPendingSessionTurns('s1')).toBe(false);
+    const gate = deferred();
+    const a = runSessionTurn('s1', async () => { await gate.promise; order.push(2); });
+    const b = runSessionTurn('s1', () => { order.push(3); });
+    gate.resolve();
+    await Promise.all([a, b]);
+    expect(order).toEqual([1, 2, 3]);
+  });
+});

--- a/test/tmux-pipe-backend-exit.test.ts
+++ b/test/tmux-pipe-backend-exit.test.ts
@@ -40,7 +40,7 @@ let fdLimitWrapper: string;
 let wrapperDir: string;
 
 /** Run the fixture; resolve with how it ended. `timedOut` means it wedged. */
-type FixtureMode = 'real' | 'nowake' | 'paneexit' | 'full' | 'spawnfail' | 'unlinked' | 'emfile' | 'directexit' | 'wakefail';
+type FixtureMode = 'real' | 'nowake' | 'paneexit' | 'full' | 'spawnfail' | 'unlinked' | 'emfile' | 'directexit' | 'wakefail' | 'drain';
 
 async function runFixture(mode: FixtureMode): Promise<{
   timedOut: boolean;
@@ -123,6 +123,17 @@ afterAll(() => {
 });
 
 describe('TmuxPipeBackend fifo teardown', () => {
+  it('lets the event loop drain after kill() without process.exit()', async () => {
+    const r = await runFixture('drain');
+
+    expect(r.stdout).toContain('TEARDOWN');
+    expect(r.stdout).not.toContain('FIXTURE_NO_FIFO');
+    expect(r.stdout).toContain('EXITING');
+    expect(r.stdout).toContain('LEAKED_READERS=0 FIFO_LEFT=false');
+    expect(r.timedOut).toBe(false);
+    expect(r.code).toBe(0);
+  }, EXIT_TIMEOUT_MS + 15_000);
+
   it('lets the process exit after kill() (does not wedge in uv_thread_join)', async () => {
     const r = await runFixture('real');
 

--- a/test/tmux-startup-storm-recovery.test.ts
+++ b/test/tmux-startup-storm-recovery.test.ts
@@ -62,6 +62,25 @@ describe.skipIf(!REAL_TMUX)('tmux startup storm recovery (real tmux, shimmed dea
     return env;
   };
 
+  // bun's execFileSync timeout defaults to SIGTERM. A wedged `tmux kill-server`
+  // (or kill-session) that ignores TERM is the same shape as the storm itself
+  // and held this file until the 720s per-file wall after both cases passed.
+  const forceKillTmux = (args: string[], env: NodeJS.ProcessEnv, timeout = 2_000): void => {
+    try {
+      execFileSync(REAL_TMUX!, args, {
+        stdio: 'ignore',
+        env,
+        timeout,
+        killSignal: 'SIGKILL',
+      });
+    } catch { /* already gone or deadline */ }
+  };
+
+  const disposeBackend = (backend: TmuxPipeBackend, sessionName: string): void => {
+    try { backend.destroySession(); } catch { try { backend.kill(); } catch { /* already torn down */ } }
+    forceKillTmux(['kill-session', '-t', sessionName], realTmuxEnv());
+  };
+
   beforeAll(() => {
     workDir = mkdtempSync(join(tmpdir(), 'bmx-storm-'));
     shimDir = join(workDir, 'shim');
@@ -112,13 +131,7 @@ describe.skipIf(!REAL_TMUX)('tmux startup storm recovery (real tmux, shimmed dea
     // is being torn down and PATH is already restored) — strip before killing.
     delete killEnv.TMUX;
     delete killEnv.TMUX_PANE;
-    try {
-      execFileSync(REAL_TMUX!, ['kill-server'], {
-        stdio: 'ignore',
-        env: killEnv,
-        timeout: 5000,
-      });
-    } catch { /* server already gone */ }
+    forceKillTmux(['kill-server'], killEnv);
     rmSync(workDir, { recursive: true, force: true });
   });
 
@@ -155,14 +168,7 @@ describe.skipIf(!REAL_TMUX)('tmux startup storm recovery (real tmux, shimmed dea
       // otherwise keep the private server busy. destroySession also drops the
       // session. Under bun test a leftover fifo handle after the first case
       // wedged the whole file until the 720s per-file wall.
-      try { backend.destroySession(); } catch { backend.kill(); }
-      try {
-        execFileSync(REAL_TMUX!, ['kill-session', '-t', SESSION_NAME], {
-          stdio: 'ignore',
-          env: realTmuxEnv(),
-          timeout: 5000,
-        });
-      } catch { /* already gone */ }
+      disposeBackend(backend, SESSION_NAME);
     }
   }, 25_000);
 
@@ -178,12 +184,7 @@ describe.skipIf(!REAL_TMUX)('tmux startup storm recovery (real tmux, shimmed dea
     try {
       expect(Date.now() - startedAt).toBeLessThan(4000);
     } finally {
-      backend.kill();
-      try {
-        execFileSync(REAL_TMUX!, ['kill-session', '-t', 'bmx-stormrep2'], {
-          stdio: 'ignore', env: realTmuxEnv(), timeout: 5000,
-        });
-      } catch { /* already gone */ }
+      disposeBackend(backend, 'bmx-stormrep2');
     }
   }, 15_000);
 });


### PR DESCRIPTION
## 改了什么

设计文档 `docs/design/2026-08-12-session-restage-store-first.md` §3 Stage 3：同一 `sessionId` 上的命令跨 `await` 后仍要串行。此前这个保证由开场激活窗口里一组互相配合的机制拼出来：到达时预留 FIFO 序号、`queuedActivationTailAdmissionsOutstanding` 计数、`queuedActivationTailReleasePending` 延迟交接、settle 时回放释放、100ms 重试定时器。它们存在的唯一原因是「到达 → 构造 prompt（`await` 发送者查询）→ 落 durable tail」中间可能被后到的消息或 worker 的开场 ACK 插队。

本 PR 用一条按 session 的命令队列取代这组机制：

- 新增 `src/core/session-turn-queue.ts`：`runSessionTurn(sessionId, command)` 是按 `sessionId` 的 Promise 链，命令按入队顺序执行、跨自身 `await` 不交错，前一条失败不阻塞后一条，链空即回收；`hasPendingSessionTurns(sessionId)` 供入口判定。不引入 mailbox / actor 类型。
- daemon 两处 follower 入口（`initialStartPending` 下的同 anchor 后到消息；worker 已死、带 retained journal 的 refork 前置 staging）统一走 `admitFollowerBehindOpening`：到达时同步取序号，构造 + 落盘作为一条命令入队。若开场的释放已先跑完（tail 空、路由已放开），同一条命令内联 promote，不再排队。pendingRepo 分支从到达到落盘没有 `await`，直接同步落盘。
- 开场路由释放 `releaseQueuedActivationReservation`（worker `queued_activation_submitted` ACK、普通冷 fork 后的交接、失败重试）入队，因此必然在先到的 follower 落盘之后执行；worker-pool 的 `onQueuedActivationSubmitted` 回调相应变为异步（回调类型本来就允许 Promise）。
- `hasQueuedActivationAdmissionGate` 改查队列：队列上有命令时，live worker 的普通 turn 也进 durable tail，不得插队；`forkReservedInitialSession` 与原始命令冷启动对计数的判定同样改为查队列。
- 删除 `queuedActivationTailAdmissionsOutstanding`、`queuedActivationTailReleasePending`、`reserveAsync… / settleAsync…` 及其回放和测试钩子。保留的重试定时器只负责 promote 落盘 / IPC 失败后的重试，不再承担排序。
- 删除从未被写入的 `pendingQueuedActivationFollowUps` 与 `reparkQueuedActivationFollowUpTail`：#597 落地 durable tail 之后没有任何写入方，repark 恒返回 false，worker exit / error 里对它的调用也一并删除。

## 有意保留、没有入队的

- `initialStartClaimToken` / `initialStartPending`：fork 边界的所有权，跨越整段资源准备（秒级）。期间到达的 follower 必须立刻落 durable tail 才扛得住 daemon 崩溃，把整段准备做成队列命令会让 follower 在内存里等待。它是状态，不是 `await` 间隙。
- pendingRepo 等待期的 `pendingFollowUps*` 缓冲：等人点卡片，队列不能被人拿着。
- `admitQueuedActivationTail` / `promoteQueuedActivationTail` 里「store 外备份再回滚」的写法：删除条件不变（daemon 侧出现按命令更新且不替换 `ds.session` 引用的 apply 入口）；让 admit 走它需要新的 store 导出并改多个 stub 了 `updateSession` 的测试夹具，本轮未做。
- worker generation / exit 路径上的 `updateSession`：没有复现证据，按文档「没有复现的路径不改」不动。

## 设计文档

- Stage 3 标为已落地并写明范围与保留项。
- Stage 4 降为低优先级、暂不立项：触发条件是单 bot 进程的事件循环或崩溃域不可接受，目前没有证据（08-23 的恢复风暴在 tmux server 层）。
- Stage 0 / Stage 1 收尾按升级窗口已关闭排期，范围清单写入 §5（含 `mojo-containment` 的 revoke 安全闸仍直接扫 JSON、SQLite 后静默失效这一条），作为下一个 PR。

## 影响面

- 只动 daemon 进程内的开场激活路径（`daemon.ts` 的 `handleThreadReplyAdmitted` / `handleNewTopic` 两处 follower 入口、`forkReservedInitialSession`、`forkReservedInitialRawSession`、release 回调）与 `worker-pool.ts` 的 admission gate 和 worker exit / error 处理；不动 session-store、CLI、dashboard、沙盒。
- 所有 CLI 共用这条路径：codex-app 的 clean-input 决策仍在到达时冻结（序号预留未变），steer 授权的 COPY 点未变；PTY / tmux 后端与话题 / 群 / adopt / restore 会话类型无差别。
- 时序上的行为差异只有一处：以前 `forkReservedInitialSession` 立即释放且失败不重试、延迟释放才重试；现在两种情况统一走队列并在失败时重试。

## 验证

- `bun run build` 绿，`tsc --noEmit` 绿。
- 新增 `test/session-turn-queue.test.ts`（5 条：入队顺序、跨 session 不互斥、失败不阻塞、pending 判定、链回收）。
- `test/daemon-rename-route.test.ts` 里三条原本对计数/延迟交接断言的用例改为对队列顺序断言（ACK 落在 follower 构造中、ACK 后 worker 退出、follower 落盘失败），新增两条：开场释放先于 follower 跑完时 follower 内联 promote；follower 构造期间 admission gate 保持关闭。
- 受影响的 21 个测试文件（含 `session-lifecycle-start`、`worker-ready-display-mode`、`trigger-session-*`、`session-resume`、`dashboard-create-session` 等）1029 条全过。
- 全量 `vitest run --project unit`：1266 个文件通过、7 个跳过；21902 条通过、108 条跳过，0 失败。

## 真机验证

- 已 `bun run switch:here && bun run daemon:restart`：四个 bot 由新进程持有 occupancy 租约，活跃会话正常恢复，日志无 ERROR。
- 普通新话题连发两条：第二条在 worker fork 完成后到达，走原有的 worker 侧排队，顺序正确（本 PR 不改这条路径）。
- 从 Dashboard 待办池把会话拖到「进行中」启动，在开场被 CLI 确认接收之前发出第二条：daemon 日志出现「buffered same-anchor turn … behind queued activation submission ACK」（第二条经队列命令落入 durable tail），开场被 CLI 接收并回 ACK 后，第二条被提升并送入 worker；两条回复顺序正确，会话行的激活 journal 与 tail 均已清空，序号预留计数为 1。
