### PR TITLE
fix(opencode2): 为裸 PTY 补齐粘贴协议

### DIFF
--- a/src/adapters/cli/opencode2.ts
+++ b/src/adapters/cli/opencode2.ts
@@ -100,11 +100,12 @@ export function createOpenCode2Adapter(pathOverride?: string): CliAdapter {
 
     async writeInput(pty: PtyHandle, content: string) {
       const isSlashCommand = content.startsWith('/');
+      const needsPaste = !isSlashCommand && (content.length > OPENCODE_PASTE_THRESHOLD || content.includes('\n'));
       const baseline = isSlashCommand ? null : snapPartBaseline('v2');
 
       try {
         if (pty.sendText && pty.sendSpecialKeys) {
-          if (!isSlashCommand && pty.pasteText && (content.length > OPENCODE_PASTE_THRESHOLD || content.includes('\n'))) {
+          if (needsPaste && pty.pasteText) {
             pty.pasteText(content);
           } else {
             pty.sendText(content);
@@ -112,7 +113,9 @@ export function createOpenCode2Adapter(pathOverride?: string): CliAdapter {
           await delay(200);
           pty.sendSpecialKeys('Enter');
         } else {
-          pty.write(content);
+          // Raw PTY has no tmux paste-buffer to add these markers. Without
+          // them, long or multiline prompts may be split into key events.
+          pty.write(needsPaste ? `\x1b[200~${content}\x1b[201~` : content);
           await delay(1000);
           pty.write('\r');
         }

--- a/test/opencode2-resume.test.ts
+++ b/test/opencode2-resume.test.ts
@@ -314,6 +314,43 @@ describe('opencode2 writeInput DB verification', () => {
     expect(result).toBeUndefined();
   });
 
+  it.each([
+    ['long deferred first prompt', `FIRST\n${'中文多行 0123456789\n'.repeat(700)}LAST`],
+    ['short multiline follow-up', 'first line\nsecond line'],
+    ['long single line', '内容'.repeat(100)],
+  ])('uses bracketed paste on raw PTY for a %s', async (_label, content) => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_target' });
+    const writes: string[] = [];
+    const pty: PtyHandle = {
+      write(data) {
+        writes.push(data);
+        if (data === '\r' && writes[0] === `\x1b[200~${content}\x1b[201~`) {
+          seedUserPart(db, 'ses_target', content, Date.now());
+        }
+      },
+    };
+
+    try {
+      const result = await createOpenCode2Adapter().writeInput(pty, content);
+      expect(result).toMatchObject({ submitted: true, cliSessionId: 'ses_target' });
+      expect(writes).toEqual([`\x1b[200~${content}\x1b[201~`, '\r']);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each([
+    ['short follow-up', 'short follow-up'],
+    ['short slash command', '/session'],
+    ['long slash command', `/compact ${'a'.repeat(300)}`],
+    ['multiline slash command', '/ask first line\nsecond line'],
+  ])('keeps raw PTY typing for %s', async (_label, content) => {
+    const writes: string[] = [];
+    await createOpenCode2Adapter().writeInput({ write(data) { writes.push(data); } }, content);
+    expect(writes).toEqual([content, '\r']);
+  });
+
   it('recognizes the submission when OpenCode2 prepends a Directory Context block to the stored user part', async () => {
     const db = openDb();
     seedSession(db, { id: 'ses_target' });


### PR DESCRIPTION
## 问题

`opencode2.writeInput` 的裸 PTY 分支直接写入原始内容，没有 bracketed-paste 标记。长文本或多行文本中的换行会被 TUI 当作独立按键处理，可能造成消息碎裂、提前提交或丢失。

OpenCode V2 不通过参数提交首条消息，因此 fresh 与 resume 的首条消息都会经过这条路径，暴露面比 V1 更大。

Fixes #1303

## 修改

- 提取 `needsPaste` 判定：仅普通长文本或多行文本使用粘贴协议。
- 裸 PTY 分支使用 `ESC[200~ ... ESC[201~` 包裹内容。
- tmux 分支复用同一判定，行为保持不变。
- 增加长首条、多行后续、长单行的正向覆盖，并验证短文本、短斜杠、长斜杠和多行斜杠仍按原始 typing 路径发送。

## 影响范围

仅影响 `opencode2` 的裸 PTY 长文本和多行普通消息。短单行、斜杠命令、tmux 后端以及其他 CLI 均保持原有行为。

## 验证

- 修复前新增正向用例 3/3 失败，均返回 `submitted: false`。
- `node_modules/.bin/vitest run --project unit test/opencode2-resume.test.ts`：29/29 通过。
- OpenCode 相关 5 个测试文件：512/512 通过。
- `node_modules/.bin/tsc --noEmit --pretty false`：通过。
- 反变异去掉 `!isSlashCommand` 后，长斜杠和多行斜杠两项按预期转红；恢复后全绿。
- `git diff --check`：通过。

> 当前环境未安装 Bun，因此未执行 `bun run build`；仓库 CI 将覆盖 Bun 构建与测试。