### PR TITLE
perf(traex): 避免重启恢复时递归扫描 sidecar 大目录

### DIFF
--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -39,10 +39,11 @@ import {
   readdirSync,
   readlinkSync,
   statSync,
+  type Dirent,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { platform } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join, relative, sep } from 'node:path';
 import {
   splitCodexEventsByCutoff,
   extractLastCodexTurn,
@@ -93,6 +94,22 @@ export interface TraexRuntimeSnapshot {
 
 const IS_LINUX = platform() === 'linux';
 const TRAEX_SESSION_META_SCAN_MAX_BYTES = 4 * 1024 * 1024;
+const TRAEX_ROLLOUT_LOOKUP_INITIAL_BACKOFF_MS = 2_000;
+const TRAEX_ROLLOUT_LOOKUP_MAX_BACKOFF_MS = 8_000;
+const TRAEX_ROLLOUT_LOOKUP_MISS_CACHE_MAX = 256;
+const TRAEX_YEAR_DIR_RE = /^\d{4}$/;
+const TRAEX_MONTH_DIR_RE = /^(?:0[1-9]|1[0-2])$/;
+const TRAEX_DAY_DIR_RE = /^(?:0[1-9]|[12]\d|3[01])$/;
+
+interface TraexRolloutLookupMiss {
+  nextFilesystemScanAtMs: number;
+  backoffMs: number;
+}
+
+/** Per-process fallback throttle. The authoritative SQLite lookup still runs
+ *  on every call, so a newly indexed rollout attaches immediately; only the
+ *  compatibility filesystem scan is delayed after repeated misses. */
+const traexRolloutLookupMisses = new Map<string, TraexRolloutLookupMiss>();
 
 type DatabaseSyncLike = {
   prepare(sql: string): StatementSyncLike;
@@ -117,7 +134,7 @@ function withTraeDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
   // logic had moved here from the traex adapter — where the Bun fix lived. A
   // clean merge is not a correct merge; re-check this call whenever the file
   // moves again.
-  const db = openDatabaseSyncNow(dbPath) as DatabaseSyncLike | null;
+  const db = openDatabaseSyncNow(dbPath, { readOnly: true }) as DatabaseSyncLike | null;
   if (!db) return null;
   try {
     return fn(db);
@@ -951,29 +968,125 @@ export function traexHistorySidIsOwned(
 }
 
 
-/** Locate the rollout file for a given TRAE session UUID. Filename shape is
- *  identical to Codex: `rollout-<ts>-<sid>.jsonl`, so a suffix match over the
- *  TRAE sessions tree is unambiguous. */
-export function findTraexRolloutBySessionId(cliSessionId: string): string | undefined {
-  const sessionsRoot = traeSessionsRoot();
-  if (!cliSessionId || !existsSync(sessionsRoot)) return undefined;
-  const suffix = `-${cliSessionId}.jsonl`;
-  const stack: string[] = [sessionsRoot];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    let entries: string[];
-    try { entries = readdirSync(dir); } catch { continue; }
-    for (const name of entries) {
-      const full = join(dir, name);
-      let st: ReturnType<typeof statSync>;
-      try { st = statSync(full); } catch { continue; }
-      if (st.isDirectory()) {
-        stack.push(full);
-      } else if (st.isFile() && name.endsWith(suffix)) {
-        return full;
+function readTraexDirectory(path: string): Dirent[] {
+  try {
+    return readdirSync(path, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function isCanonicalTraexRolloutPath(
+  path: string,
+  sessionsRoot: string,
+  suffix: string,
+): boolean {
+  if (!path.endsWith(suffix)) return false;
+  const rel = relative(sessionsRoot, path);
+  if (!rel || isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) return false;
+  const parts = rel.split(sep);
+  return parts.length === 4
+    && TRAEX_YEAR_DIR_RE.test(parts[0]!)
+    && TRAEX_MONTH_DIR_RE.test(parts[1]!)
+    && TRAEX_DAY_DIR_RE.test(parts[2]!)
+    && parts[3]!.startsWith('rollout-');
+}
+
+function findIndexedTraexRollout(
+  cliSessionId: string,
+  sessionsRoot: string,
+  suffix: string,
+): string | undefined {
+  const rows = withTraeDb((db) => db.prepare(
+    'SELECT rollout_path AS rolloutPath FROM threads WHERE id = ? LIMIT 1',
+  ).all(cliSessionId) as { rolloutPath?: string }[]) ?? [];
+  const path = rows[0]?.rolloutPath;
+  if (typeof path !== 'string' || !isCanonicalTraexRolloutPath(path, sessionsRoot, suffix)) {
+    return undefined;
+  }
+  try {
+    return statSync(path).isFile() ? path : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findTraexRolloutInDateTree(sessionsRoot: string, suffix: string): string | undefined {
+  const years = readTraexDirectory(sessionsRoot)
+    .filter((entry) => entry.isDirectory() && TRAEX_YEAR_DIR_RE.test(entry.name))
+    .sort((a, b) => b.name.localeCompare(a.name));
+  for (const year of years) {
+    const yearPath = join(sessionsRoot, year.name);
+    const months = readTraexDirectory(yearPath)
+      .filter((entry) => entry.isDirectory() && TRAEX_MONTH_DIR_RE.test(entry.name))
+      .sort((a, b) => b.name.localeCompare(a.name));
+    for (const month of months) {
+      const monthPath = join(yearPath, month.name);
+      const days = readTraexDirectory(monthPath)
+        .filter((entry) => entry.isDirectory() && TRAEX_DAY_DIR_RE.test(entry.name))
+        .sort((a, b) => b.name.localeCompare(a.name));
+      for (const day of days) {
+        const dayPath = join(monthPath, day.name);
+        const rollout = readTraexDirectory(dayPath)
+          .find((entry) => entry.isFile()
+            && entry.name.startsWith('rollout-')
+            && entry.name.endsWith(suffix));
+        if (rollout) return join(dayPath, rollout.name);
       }
     }
   }
+  return undefined;
+}
+
+function recordTraexRolloutLookupMiss(key: string, nowMs: number): void {
+  const previous = traexRolloutLookupMisses.get(key);
+  const backoffMs = previous
+    ? Math.min(previous.backoffMs * 2, TRAEX_ROLLOUT_LOOKUP_MAX_BACKOFF_MS)
+    : TRAEX_ROLLOUT_LOOKUP_INITIAL_BACKOFF_MS;
+  // Refresh insertion order so the bounded map evicts the least-recent miss.
+  traexRolloutLookupMisses.delete(key);
+  traexRolloutLookupMisses.set(key, {
+    nextFilesystemScanAtMs: nowMs + backoffMs,
+    backoffMs,
+  });
+  if (traexRolloutLookupMisses.size > TRAEX_ROLLOUT_LOOKUP_MISS_CACHE_MAX) {
+    const oldest = traexRolloutLookupMisses.keys().next().value as string | undefined;
+    if (oldest !== undefined) traexRolloutLookupMisses.delete(oldest);
+  }
+}
+
+/** Locate the rollout file for a given TRAE session UUID.
+ *
+ * TRAE's `threads` table is the authoritative session→path index. Older TRAE
+ * versions may not expose `rollout_path`, so lookup degrades to the documented
+ * `sessions/YYYY/MM/DD/rollout-<ts>-<sid>.jsonl` tree. The fallback never
+ * descends into rollout sidecars (`*.artifacts`, `tool-results`,
+ * `rollout-blobs`), whose contents cannot be top-level sessions and may span
+ * gigabytes. Repeated fallback misses are backed off, while the cheap indexed
+ * lookup remains live on every late-attach tick. */
+export function findTraexRolloutBySessionId(cliSessionId: string): string | undefined {
+  if (!cliSessionId) return undefined;
+  const sessionsRoot = traeSessionsRoot();
+  const suffix = `-${cliSessionId}.jsonl`;
+  const missKey = `${sessionsRoot}\0${cliSessionId.toLowerCase()}`;
+
+  const indexed = findIndexedTraexRollout(cliSessionId, sessionsRoot, suffix);
+  if (indexed) {
+    traexRolloutLookupMisses.delete(missKey);
+    return indexed;
+  }
+  if (!existsSync(sessionsRoot)) return undefined;
+
+  const nowMs = Date.now();
+  const miss = traexRolloutLookupMisses.get(missKey);
+  if (miss && nowMs < miss.nextFilesystemScanAtMs) return undefined;
+
+  const scanned = findTraexRolloutInDateTree(sessionsRoot, suffix);
+  if (scanned) {
+    traexRolloutLookupMisses.delete(missKey);
+    return scanned;
+  }
+  recordTraexRolloutLookupMiss(missKey, nowMs);
   return undefined;
 }
 

--- a/test/traex-rollout-lookup-perf.test.ts
+++ b/test/traex-rollout-lookup-perf.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findTraexRolloutBySessionId } from '../src/services/traex-transcript.js';
+import { openDatabaseSyncNow } from '../src/services/sqlite-compat.js';
+
+const fsProbe = vi.hoisted(() => ({
+  readdirPaths: [] as string[],
+  statPaths: [] as string[],
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => {
+      fsProbe.readdirPaths.push(String(args[0]));
+      return actual.readdirSync(...args);
+    },
+    statSync: (...args: Parameters<typeof actual.statSync>) => {
+      fsProbe.statPaths.push(String(args[0]));
+      return actual.statSync(...args);
+    },
+  };
+});
+
+const SID = '00000000-0000-7000-8000-000000000001';
+let dir: string;
+let previousTraeHome: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'traex-rollout-lookup-'));
+  previousTraeHome = process.env.TRAE_HOME;
+  process.env.TRAE_HOME = join(dir, 'trae-home');
+  fsProbe.readdirPaths.length = 0;
+  fsProbe.statPaths.length = 0;
+});
+
+afterEach(() => {
+  if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
+  else process.env.TRAE_HOME = previousTraeHome;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('TRAE rollout lookup filesystem budget', () => {
+  it('uses the threads index without scanning the sessions tree', () => {
+    const traeHome = process.env.TRAE_HOME!;
+    const dayDir = join(traeHome, 'cli', 'sessions', '2026', '06', '04');
+    const rollout = join(dayDir, `rollout-2026-06-04T12-00-00-${SID}.jsonl`);
+    const dbPath = join(traeHome, 'cli', 'state_5.sqlite');
+    mkdirSync(dayDir, { recursive: true });
+    writeFileSync(rollout, '{}\n');
+    const db = openDatabaseSyncNow(dbPath);
+    expect(db).not.toBeNull();
+    db!.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL)');
+    db!.prepare('INSERT INTO threads (id, rollout_path) VALUES (?, ?)').run(SID, rollout);
+    db!.close();
+    fsProbe.readdirPaths.length = 0;
+
+    expect(findTraexRolloutBySessionId(SID)).toBe(rollout);
+    expect(fsProbe.readdirPaths).toEqual([]);
+  });
+
+  it('keeps fallback work independent of sidecar contents', () => {
+    const dayDir = join(process.env.TRAE_HOME!, 'cli', 'sessions', '2026', '06', '04');
+    const sidecarDir = join(dayDir, 'rollout-blobs');
+    mkdirSync(sidecarDir, { recursive: true });
+    for (let i = 0; i < 200; i += 1) {
+      writeFileSync(join(sidecarDir, `blob-${i}.json`), '{}');
+    }
+    fsProbe.readdirPaths.length = 0;
+    fsProbe.statPaths.length = 0;
+
+    expect(findTraexRolloutBySessionId('00000000-0000-7000-8000-000000000099')).toBeUndefined();
+    expect(fsProbe.statPaths.length).toBe(0);
+    expect(fsProbe.readdirPaths).not.toContain(sidecarDir);
+    expect(fsProbe.readdirPaths.length).toBeLessThanOrEqual(4);
+  });
+});

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
@@ -10,12 +10,14 @@ import {
 } from '../src/services/bridge-fallback-gate.js';
 import {
   drainTraexRollout,
+  findTraexRolloutBySessionId,
   readLatestTraexRuntime,
   traexRolloutHasUserInputSince,
   traexHistoryMatchDelta,
   traexHistorySize,
   traexHistorySidIsOwned,
 } from '../src/services/traex-transcript.js';
+import { openDatabaseSyncNow } from '../src/services/sqlite-compat.js';
 
 const SID = '00000000-0000-7000-8000-000000000001';
 let dir: string;
@@ -160,6 +162,133 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
+});
+
+describe('findTraexRolloutBySessionId', () => {
+  it('does not resolve rollout-shaped files inside TRAE sidecar directories', () => {
+    const previousTraeHome = process.env.TRAE_HOME;
+    const traeHome = join(dir, 'trae-home');
+    const sidecarDir = join(traeHome, 'cli', 'sessions', '2026', '06', '04', 'rollout-blobs');
+    const internalRollout = join(sidecarDir, `rollout-internal-${SID}.jsonl`);
+    const dbPath = join(traeHome, 'cli', 'state_5.sqlite');
+    mkdirSync(sidecarDir, { recursive: true });
+    writeFileSync(internalRollout, line(user('internal sidecar record')));
+    const db = openDatabaseSyncNow(dbPath);
+    expect(db).not.toBeNull();
+    db!.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL)');
+    db!.prepare('INSERT INTO threads (id, rollout_path) VALUES (?, ?)').run(SID, internalRollout);
+    db!.close();
+    process.env.TRAE_HOME = traeHome;
+
+    try {
+      expect(findTraexRolloutBySessionId(SID)).toBeUndefined();
+    } finally {
+      if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
+      else process.env.TRAE_HOME = previousTraeHome;
+    }
+  });
+
+  it('resolves a rollout recorded in the TRAE threads index', () => {
+    const previousTraeHome = process.env.TRAE_HOME;
+    const traeHome = join(dir, 'trae-home');
+    const dayDir = join(traeHome, 'cli', 'sessions', '2026', '06', '04');
+    const rollout = join(dayDir, `rollout-2026-06-04T12-00-00-${SID}.jsonl`);
+    const dbPath = join(traeHome, 'cli', 'state_5.sqlite');
+    mkdirSync(dayDir, { recursive: true });
+    writeFileSync(rollout, line(user('indexed rollout')));
+    const db = openDatabaseSyncNow(dbPath);
+    expect(db).not.toBeNull();
+    db!.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL)');
+    db!.prepare('INSERT INTO threads (id, rollout_path) VALUES (?, ?)').run(SID, rollout);
+    db!.close();
+    process.env.TRAE_HOME = traeHome;
+
+    try {
+      expect(findTraexRolloutBySessionId(SID)).toBe(rollout);
+    } finally {
+      if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
+      else process.env.TRAE_HOME = previousTraeHome;
+    }
+  });
+
+  it('falls back to the canonical date tree when an older threads schema has no rollout_path', () => {
+    const previousTraeHome = process.env.TRAE_HOME;
+    const traeHome = join(dir, 'trae-home');
+    const dayDir = join(traeHome, 'cli', 'sessions', '2026', '06', '04');
+    const rollout = join(dayDir, `rollout-2026-06-04T12-00-00-${SID}.jsonl`);
+    const dbPath = join(traeHome, 'cli', 'state_5.sqlite');
+    mkdirSync(dayDir, { recursive: true });
+    writeFileSync(rollout, line(user('fallback rollout')));
+    const db = openDatabaseSyncNow(dbPath);
+    expect(db).not.toBeNull();
+    db!.exec('CREATE TABLE threads (id TEXT PRIMARY KEY)');
+    db!.close();
+    process.env.TRAE_HOME = traeHome;
+
+    try {
+      expect(findTraexRolloutBySessionId(SID)).toBe(rollout);
+    } finally {
+      if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
+      else process.env.TRAE_HOME = previousTraeHome;
+    }
+  });
+
+  it('backs off repeated filesystem misses while keeping discovery bounded', () => {
+    const previousTraeHome = process.env.TRAE_HOME;
+    const traeHome = join(dir, 'trae-home');
+    const dayDir = join(traeHome, 'cli', 'sessions', '2026', '06', '04');
+    const rollout = join(dayDir, `rollout-2026-06-04T12-00-00-${SID}.jsonl`);
+    mkdirSync(dayDir, { recursive: true });
+    process.env.TRAE_HOME = traeHome;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-04T12:00:00.000Z'));
+
+    try {
+      expect(findTraexRolloutBySessionId(SID)).toBeUndefined();
+      writeFileSync(rollout, line(user('appeared after miss')));
+
+      vi.advanceTimersByTime(1_000);
+      expect(findTraexRolloutBySessionId(SID)).toBeUndefined();
+      vi.advanceTimersByTime(999);
+      expect(findTraexRolloutBySessionId(SID)).toBeUndefined();
+      vi.advanceTimersByTime(1);
+      expect(findTraexRolloutBySessionId(SID)).toBe(rollout);
+    } finally {
+      vi.useRealTimers();
+      if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
+      else process.env.TRAE_HOME = previousTraeHome;
+    }
+  });
+
+  it('observes a newly indexed rollout during filesystem backoff', () => {
+    const previousTraeHome = process.env.TRAE_HOME;
+    const traeHome = join(dir, 'trae-home');
+    const dayDir = join(traeHome, 'cli', 'sessions', '2026', '06', '04');
+    const rollout = join(dayDir, `rollout-2026-06-04T12-00-00-${SID}.jsonl`);
+    const dbPath = join(traeHome, 'cli', 'state_5.sqlite');
+    mkdirSync(dayDir, { recursive: true });
+    process.env.TRAE_HOME = traeHome;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-04T12:00:00.000Z'));
+
+    try {
+      expect(findTraexRolloutBySessionId(SID)).toBeUndefined();
+
+      writeFileSync(rollout, line(user('indexed during backoff')));
+      const db = openDatabaseSyncNow(dbPath);
+      expect(db).not.toBeNull();
+      db!.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL)');
+      db!.prepare('INSERT INTO threads (id, rollout_path) VALUES (?, ?)').run(SID, rollout);
+      db!.close();
+      vi.advanceTimersByTime(1_000);
+
+      expect(findTraexRolloutBySessionId(SID)).toBe(rollout);
+    } finally {
+      vi.useRealTimers();
+      if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
+      else process.env.TRAE_HOME = previousTraeHome;
+    }
+  });
 });
 
 describe('drainTraexRollout', () => {


### PR DESCRIPTION
## 问题

Closes #1027

daemon 重启后的 TRAE late-attach 会按 session、每秒调用一次 rollout 查找。原实现递归遍历整个 sessions 树，并进入 rollout-blobs、tool-results、*.artifacts 等 sidecar 目录；大历史目录和多个待恢复 session 会把这段扫描成倍放大。

## 修复

- 优先查询 TRAE threads 表中以主键 id 索引的 rollout_path，并校验路径确实是规范日期目录下的顶层 rollout 文件。
- 旧 TRAE schema、数据库暂不可用或索引路径失效时，回退到 sessions/YYYY/MM/DD 三层有界遍历；使用 Dirent，完全不进入 sidecar 目录。
- 对文件系统 miss 增加 2s → 4s → 8s 的有界退避，最多保留 256 个进程内 miss；SQLite 索引仍在每个 tick 查询，因此新记录写入后可以立即 attach。
- TRAE 状态库统一按只读方式打开。

## 性能证据

- 确定性测试夹具包含 200 个 sidecar 文件：旧实现产生 204 次 stat 并读取 sidecar；新实现为 0 次 stat、最多 4 次目录读取，且不进入 sidecar。
- 一次性 5,000 sidecar 条目合成基准：旧递归 21.273ms，新有界查找 0.742ms（macOS 单次样本，仅用于验证复杂度变化，不作为固定倍数承诺）。
- 本机真实 TRAE 索引 smoke：100 次查找平均 0.416ms，均命中规范 rollout 路径。

## 验证

- 相关 TRAE / transcript resolver 测试：10 files, 141 tests passed
- 新增/修改的定向测试：2 files, 62 tests passed
- TypeScript 主工程、scripts、test mocks typecheck 通过
- domain audit 与 git diff --check 通过

GitHub CI 将继续覆盖 Linux + Bun 1.4.2 build、三分片 unit suite、Bun runtime 与发布二进制 smoke。
