### PR TITLE
fix(sandbox): 对齐 Linux 会话路径并修正宿主转发判定

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -681,7 +681,8 @@ export function prepareDirectSandbox(opts: {
   if (process.platform !== 'linux') return null;
   if (!ensureSandboxDeps()) return null;
 
-  const sessionRoot = join(canonical(opts.dataDir), 'sandboxes', opts.sessionId);
+  const dataDir = canonical(opts.dataDir);
+  const sessionRoot = join(dataDir, 'sandboxes', opts.sessionId);
   const outbox = join(sessionRoot, 'outbox');
   const shimBin = join(sessionRoot, 'shimbin');
   const empties = join(sessionRoot, 'empties');
@@ -836,6 +837,10 @@ export function prepareDirectSandbox(opts: {
   pushExecDir(opts.cliBin);      // the CLI binary
   const env: Record<string, string> = {
     HOME: opts.home,
+    // The worker mounts canonical paths. A symlinked host HOME/data root is
+    // not recreated in bwrap's fresh root, so inherited lexical paths cannot
+    // locate the owning session store or its per-bot schedule directory.
+    SESSION_DATA_DIR: dataDir,
     BOTMUX_SEND_RELAY: outbox,
     PATH: ['/run/sbxbin', ...canonicalExecDirs, process.env.PATH ?? ''].filter(Boolean).join(':'),
   };

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -1225,6 +1225,11 @@ export function buildRelayHostEnv(
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   delete env.BOTMUX_SEND_RELAY;
+  // This channel locates the pane's read-isolation proof, not the host
+  // watcher's origin. Carrying it across re-exec misclassifies the host child
+  // as isolated. Durable origin still comes from authorize below; do not add
+  // a cmdSend exemption based on child-mutable env or namespace-local PIDs.
+  delete env.BOTMUX_ORIGIN_CHANNEL_ID;
   delete env.BOTMUX_CARD_PREPARED_CONTENT_FILE;
   delete env.BOTMUX_HOST_RELAY_REQUIRES_CODEX_APP_LEDGER;
   if (preparedContentFile) {

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -361,7 +361,9 @@ export function buildSeatbeltProfile(
 // adds the host CA bundle startup env a sandboxed Codex pane needs — a pane spawned
 // before it keeps its ORIGINAL environment, so it would never see SSL_CERT_FILE and
 // would keep failing TLS on UnknownIssuer with no output at all.
-export const ISOLATION_PANE_MARKER_VERSION = 13;
+// 14 pins canonical SESSION_DATA_DIR and matching managed-origin mounts on
+// Linux. Warm reattach would retain the old lexical env/mount namespace split.
+export const ISOLATION_PANE_MARKER_VERSION = 14;
 
 export type IsolationCapability = 'credential' | 'read' | 'write';
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8122,10 +8122,22 @@ async function cmdSend(rest: string[]): Promise<void> {
   const kernelReadIsolationDetected = managedOriginLegacyIsolationProbeAccess(osUserHomeDir)
     === 'sandbox_denied'
     || managedOriginIsolationSentinelAccess(osUserHomeDir) === 'sandbox_denied';
+  const trustedHostRelay = process.env.BOTMUX_HOST_RELAY_AUTHORIZED === '1';
+  // The Linux outbox watcher re-execs on the host with the pane's origin
+  // channel intact. Verify its recorded worker parent before treating that
+  // inherited channel as evidence of read isolation; the env flag alone is
+  // never authority, and kernel/explicit isolation still takes precedence.
+  const parentBoundHostRelay = !relayDir && !kernelReadIsolationDetected
+    && trustedHostRelay && !!inheritedSessionId
+    && isTrustedVcMeetingHostRelayParent(
+      trustedHostRelay,
+      loadSessions().get(inheritedSessionId)?.pid,
+      process.ppid,
+    );
   const isolatedSendRequired = !relayDir
     && (kernelReadIsolationDetected
       || process.env.BOTMUX_READ_ISOLATED === '1'
-      || (!liveMarkerCtx?.sessionId && isolationMarkerPresent));
+      || (!liveMarkerCtx?.sessionId && isolationMarkerPresent && !parentBoundHostRelay));
   let isolatedBoundSessionId: string | undefined;
   if (isolatedSendRequired) {
     if (!inheritedOriginChannelId || !/^[a-f0-9]{64}$/.test(inheritedOriginChannelId)) {
@@ -8162,7 +8174,7 @@ async function cmdSend(rest: string[]): Promise<void> {
     process.env.SESSION_DATA_DIR = sendDataDir;
     liveMarkerCtx = findLiveAncestorSessionContext(sendDataDir);
   }
-  const isolatedCapabilityCtx = !isolatedSendRequired && liveMarkerCtx?.sessionId
+  const isolatedCapabilityCtx = !isolatedSendRequired && (liveMarkerCtx?.sessionId || parentBoundHostRelay)
     ? null
     : readWorkflowSessionRelayContext({
         env: process.env,
@@ -8180,7 +8192,6 @@ async function cmdSend(rest: string[]): Promise<void> {
   }
   let isolatedAttestationContext: ManagedOriginAttestationContext | undefined;
   let isolatedManagedOriginCtx: ManagedOriginAttestation | undefined;
-  const trustedHostRelay = process.env.BOTMUX_HOST_RELAY_AUTHORIZED === '1';
   const trustedRelayAttemptRaw = Number(process.env.BOTMUX_DISPATCH_ATTEMPT);
   const trustedRelayCandidate = trustedHostRelay && process.env.BOTMUX_SESSION_ID
     ? {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8122,22 +8122,10 @@ async function cmdSend(rest: string[]): Promise<void> {
   const kernelReadIsolationDetected = managedOriginLegacyIsolationProbeAccess(osUserHomeDir)
     === 'sandbox_denied'
     || managedOriginIsolationSentinelAccess(osUserHomeDir) === 'sandbox_denied';
-  const trustedHostRelay = process.env.BOTMUX_HOST_RELAY_AUTHORIZED === '1';
-  // The Linux outbox watcher re-execs on the host with the pane's origin
-  // channel intact. Verify its recorded worker parent before treating that
-  // inherited channel as evidence of read isolation; the env flag alone is
-  // never authority, and kernel/explicit isolation still takes precedence.
-  const parentBoundHostRelay = !relayDir && !kernelReadIsolationDetected
-    && trustedHostRelay && !!inheritedSessionId
-    && isTrustedVcMeetingHostRelayParent(
-      trustedHostRelay,
-      loadSessions().get(inheritedSessionId)?.pid,
-      process.ppid,
-    );
   const isolatedSendRequired = !relayDir
     && (kernelReadIsolationDetected
       || process.env.BOTMUX_READ_ISOLATED === '1'
-      || (!liveMarkerCtx?.sessionId && isolationMarkerPresent && !parentBoundHostRelay));
+      || (!liveMarkerCtx?.sessionId && isolationMarkerPresent));
   let isolatedBoundSessionId: string | undefined;
   if (isolatedSendRequired) {
     if (!inheritedOriginChannelId || !/^[a-f0-9]{64}$/.test(inheritedOriginChannelId)) {
@@ -8174,7 +8162,7 @@ async function cmdSend(rest: string[]): Promise<void> {
     process.env.SESSION_DATA_DIR = sendDataDir;
     liveMarkerCtx = findLiveAncestorSessionContext(sendDataDir);
   }
-  const isolatedCapabilityCtx = !isolatedSendRequired && (liveMarkerCtx?.sessionId || parentBoundHostRelay)
+  const isolatedCapabilityCtx = !isolatedSendRequired && liveMarkerCtx?.sessionId
     ? null
     : readWorkflowSessionRelayContext({
         env: process.env,
@@ -8192,6 +8180,7 @@ async function cmdSend(rest: string[]): Promise<void> {
   }
   let isolatedAttestationContext: ManagedOriginAttestationContext | undefined;
   let isolatedManagedOriginCtx: ManagedOriginAttestation | undefined;
+  const trustedHostRelay = process.env.BOTMUX_HOST_RELAY_AUTHORIZED === '1';
   const trustedRelayAttemptRaw = Number(process.env.BOTMUX_DISPATCH_ATTEMPT);
   const trustedRelayCandidate = trustedHostRelay && process.env.BOTMUX_SESSION_ID
     ? {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14919,13 +14919,15 @@ async function spawnCli(
       }
     }
     if (process.platform === 'linux' && readIsolationOriginChannelId) {
+      // Match the canonical SESSION_DATA_DIR pinned by prepareDirectSandbox;
+      // the host's lexical symlink aliases do not exist in the fresh root.
       mandatoryReadOnlyPaths.push(managedOriginCapabilityDirectory(
-        isolationRuntimeDataDir,
+        canonical(isolationRuntimeDataDir),
         cfg.sessionId,
         readIsolationOriginChannelId,
       ));
       mandatoryReadOnlyPaths.push(managedOriginAttestationDirectory(
-        isolationRuntimeDataDir,
+        canonical(isolationRuntimeDataDir),
         cfg.sessionId,
         readIsolationOriginChannelId,
       ));

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -7,6 +7,7 @@ import { spawnSyncTsScript, spawnTsScript } from './helpers/ts-runner.js';
 import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 import { startOutboxWatcher } from '../src/adapters/backend/sandbox.js';
 import {
+  ensureManagedOriginAttestationDirectory,
   managedOriginCapabilityPath,
   RELAY_ORIGIN_CAPABILITY_BASENAME,
   replaceManagedOriginCapabilityFile,
@@ -482,6 +483,12 @@ describe('cmdSend hook context wiring', () => {
 
   it('rejects a trusted host re-exec when its authorized Codex App ledger was already settled', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'botmux-send-host-ledger-gone-'));
+    const channelId = 'ef'.repeat(32);
+    ensureManagedOriginAttestationDirectory(dataDir, 'session', channelId);
+    replaceManagedOriginCapabilityFile(
+      managedOriginCapabilityPath(dataDir, 'session', channelId),
+      JSON.stringify({ sessionId: 'session', channelId, capability: 'cd'.repeat(32) }),
+    );
     seedPersistedSessionRows(dataDir, 'app-a', {
       session: {
         sessionId: 'session', chatId: 'oc_chat', rootMessageId: 'om_root',
@@ -497,6 +504,7 @@ describe('cmdSend hook context wiring', () => {
           SESSION_DATA_DIR: dataDir,
           BOTMUX_SESSION_ID: 'session',
           BOTMUX_TURN_ID: 'turn-settled',
+          BOTMUX_ORIGIN_CHANNEL_ID: channelId,
           BOTMUX_DISPATCH_ATTEMPT: '4',
           BOTMUX_HOST_RELAY_AUTHORIZED: '1',
           BOTMUX_HOST_RELAY_REQUIRES_CODEX_APP_LEDGER: '1',
@@ -508,6 +516,42 @@ describe('cmdSend hook context wiring', () => {
       expect(result.code).toBe(2);
       expect(result.stderr).toContain('authorized Codex App origin session/turn-settled is no longer unsettled');
       expect(result.stderr).not.toContain('must not downgrade');
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { name: 'a different worker parent', workerPid: process.pid + 1, readIsolated: '' },
+    { name: 'an explicitly isolated child', workerPid: process.pid, readIsolated: '1' },
+  ])('does not accept a host relay flag from $name', async ({ workerPid, readIsolated }) => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-send-host-parent-'));
+    try {
+      const channelId = 'fe'.repeat(32);
+      ensureManagedOriginAttestationDirectory(dataDir, 'session', channelId);
+      seedPersistedSessionRows(dataDir, 'app-a', {
+        session: {
+          sessionId: 'session', chatId: 'oc_chat', rootMessageId: 'om_root',
+          title: 'isolated', status: 'active', createdAt: new Date(0).toISOString(),
+          larkAppId: 'app-a', cliId: 'codex', pid: workerPid,
+        },
+      });
+      const result = await runCli(
+        ['send', 'must not send', '--session-id', 'session', '--no-mention'],
+        {
+          ...process.env,
+          SESSION_DATA_DIR: dataDir,
+          BOTMUX_SESSION_ID: 'session',
+          BOTMUX_ORIGIN_CHANNEL_ID: channelId,
+          BOTMUX_HOST_RELAY_AUTHORIZED: '1',
+          BOTMUX_SEND_RELAY: '',
+          BOTMUX_READ_ISOLATED: readIsolated,
+          BOTMUX_WORKFLOW: '',
+          BOTMUX_LARK_APP_ID: '', BOTMUX_LARK_APP_SECRET: '',
+        },
+      );
+      expect(result.code).toBe(2);
+      expect(result.stderr).toContain('read-isolated owning data-root locator is missing or ambiguous');
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { spawnSyncTsScript, spawnTsScript } from './helpers/ts-runner.js';
 import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
-import { startOutboxWatcher } from '../src/adapters/backend/sandbox.js';
+import { buildRelayHostEnv, startOutboxWatcher } from '../src/adapters/backend/sandbox.js';
 import {
   ensureManagedOriginAttestationDirectory,
   managedOriginCapabilityPath,
@@ -500,17 +500,20 @@ describe('cmdSend hook context wiring', () => {
       const result = await runCli(
         ['send', 'must not downgrade', '--session-id', 'session', '--no-mention'],
         {
-          ...process.env,
-          SESSION_DATA_DIR: dataDir,
-          BOTMUX_SESSION_ID: 'session',
-          BOTMUX_TURN_ID: 'turn-settled',
-          BOTMUX_ORIGIN_CHANNEL_ID: channelId,
-          BOTMUX_DISPATCH_ATTEMPT: '4',
-          BOTMUX_HOST_RELAY_AUTHORIZED: '1',
+          ...buildRelayHostEnv({
+            ...process.env,
+            SESSION_DATA_DIR: dataDir,
+            BOTMUX_SESSION_ID: 'session',
+            BOTMUX_TURN_ID: 'turn-settled',
+            BOTMUX_ORIGIN_CHANNEL_ID: channelId,
+            BOTMUX_DISPATCH_ATTEMPT: '4',
+            BOTMUX_HOST_RELAY_AUTHORIZED: '1',
+            BOTMUX_SEND_RELAY: '',
+            BOTMUX_WORKFLOW: '',
+            BOTMUX_LARK_APP_ID: '', BOTMUX_LARK_APP_SECRET: '',
+          }),
+          // startOutboxWatcher applies this only after authorize succeeds.
           BOTMUX_HOST_RELAY_REQUIRES_CODEX_APP_LEDGER: '1',
-          BOTMUX_SEND_RELAY: '',
-          BOTMUX_WORKFLOW: '',
-          BOTMUX_LARK_APP_ID: '', BOTMUX_LARK_APP_SECRET: '',
         },
       );
       expect(result.code).toBe(2);
@@ -522,6 +525,7 @@ describe('cmdSend hook context wiring', () => {
   });
 
   it.each([
+    { name: 'a matching numeric parent with a pane origin channel', workerPid: process.pid, readIsolated: '' },
     { name: 'a different worker parent', workerPid: process.pid + 1, readIsolated: '' },
     { name: 'an explicitly isolated child', workerPid: process.pid, readIsolated: '1' },
   ])('does not accept a host relay flag from $name', async ({ workerPid, readIsolated }) => {

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -912,6 +912,16 @@ describe('isolatedPaneReattachSafe — start-time contract bump forces cold resp
     expect(ISOLATION_PANE_MARKER_VERSION).toBeGreaterThanOrEqual(12);
   });
 
+  it('cold-spawns panes predating the canonical session-data root contract', () => {
+    expect(ISOLATION_PANE_MARKER_VERSION).toBeGreaterThan(13);
+    expect(isolatedPaneReattachSafe(JSON.stringify({
+      version: 13,
+      bootId: 'lexical-data-root',
+      state: 'committed',
+      capabilities: ['credential', 'read', 'write'],
+    }), ['credential', 'read', 'write'])).toBe(false);
+  });
+
   it('has moved the version past 12 — the release before the sandboxed-Codex CA env contract', () => {
     // A pane spawned before this change keeps its ORIGINAL process environment, so
     // it would never see the host CA bundle (SSL_CERT_FILE) and its Codex would keep
@@ -958,6 +968,16 @@ describe('isolatedPaneReattachSafe — #714 mount contract forces cold respawn o
 describe('worker capability carve-out ordering', () => {
   const source = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
   const strippedSource = stripComments(source);
+
+  it('aligns Linux managed-origin grants with the canonical sandbox data root', () => {
+    const linuxAt = strippedSource.indexOf("if (process.platform === 'linux' && readIsolationOriginChannelId)");
+    expect(linuxAt).toBeGreaterThanOrEqual(0);
+    const grants = strippedSource.slice(linuxAt, strippedSource.indexOf('if (mcpRuntimeManifest)', linuxAt));
+    // The real-bwrap tests feed a compile-ready policy; guard the worker's
+    // production call site too, so lexical grants cannot silently return.
+    expect(grants).toMatch(/managedOriginCapabilityDirectory\(\s*canonical\(isolationRuntimeDataDir\)/);
+    expect(grants).toMatch(/managedOriginAttestationDirectory\(\s*canonical\(isolationRuntimeDataDir\)/);
+  });
 
   it('publishes each child-visible capability before the sandbox starts', () => {
     const macPathAt = strippedSource.indexOf("readIsolationOriginCapabilityFile = process.platform === 'darwin'");

--- a/test/sandbox-relay-watcher.test.ts
+++ b/test/sandbox-relay-watcher.test.ts
@@ -134,6 +134,7 @@ describe('sandbox relay watcher host handoff', () => {
         preparedPath,
         localLinkMode: process.env.BOTMUX_CARD_LOCAL_LINK_MODE,
         relayEnv: process.env.BOTMUX_SEND_RELAY ?? null,
+        originChannel: process.env.BOTMUX_ORIGIN_CHANNEL_ID ?? null,
         sessionId: value('--session-id'),
       }));
     `);
@@ -153,6 +154,7 @@ describe('sandbox relay watcher host handoff', () => {
     const stop = startOutboxWatcher(outbox, {
       ...process.env,
       BOTMUX_SEND_RELAY: outbox,
+      BOTMUX_ORIGIN_CHANNEL_ID: 'ab'.repeat(32),
       BOTMUX_CARD_PREPARED_CONTENT_FILE: '/untrusted/stale-prepared.md',
     }, 'forced-session', { cliPath: fixture });
 
@@ -176,6 +178,7 @@ describe('sandbox relay watcher host handoff', () => {
         preparedPath: string;
         localLinkMode: string;
         relayEnv: string | null;
+        originChannel: string | null;
         sessionId: string;
       };
 
@@ -186,6 +189,7 @@ describe('sandbox relay watcher host handoff', () => {
         selected: 'PREPARED',
         localLinkMode: 'disabled',
         relayEnv: null,
+        originChannel: null,
         sessionId: 'forced-session',
       });
       expect(dirname(child.rawPath)).toBe(join(root, 'relay-staging'));

--- a/test/sandbox-session-data-dir.test.ts
+++ b/test/sandbox-session-data-dir.test.ts
@@ -1,0 +1,167 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { prepareDirectSandbox } from '../src/adapters/backend/sandbox.js';
+import type { FsPolicy } from '../src/adapters/cli/fs-policy.js';
+import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
+import { tsRunnerPrefix } from './helpers/ts-runner.js';
+
+const linux = process.platform === 'linux';
+const hasBwrap = linux && spawnSync('bwrap', ['--version']).status === 0;
+const canRunBwrap = hasBwrap && spawnSync('bwrap', [
+  '--ro-bind', '/', '/', '--unshare-user', '--unshare-pid', '--proc', '/proc',
+  '--', '/bin/true',
+], { stdio: 'ignore', timeout: 5_000 }).status === 0;
+
+function fixture(layout: 'home-link' | 'data-link' | 'canonical') {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'botmux-sandbox-data-')));
+  const home = join(root, 'home');
+  const dataDir = join(home, '.botmux/data');
+  const ownStore = join(dataDir, 'session-stores/app-a');
+  const ownBotHome = join(home, '.botmux/bots/app-a');
+  const workspace = join(root, 'workspace');
+  const origin = join(dataDir, 'read-isolation/origin-own');
+  const attestation = join(dataDir, 'read-isolation/attest-own');
+  for (const path of [ownStore, ownBotHome, workspace, origin, attestation]) {
+    mkdirSync(path, { recursive: true });
+  }
+  writeFileSync(join(ownStore, 'sessions.db'), 'own-session');
+  writeFileSync(join(origin, 'capability.json'), 'own-capability');
+  writeFileSync(join(attestation, 'proof.json'), 'own-proof');
+  const siblingStore = join(dataDir, 'session-stores/app-b');
+  const siblingOrigin = join(dataDir, 'read-isolation/origin-other');
+  for (const path of [siblingStore, siblingOrigin]) mkdirSync(path, { recursive: true });
+  writeFileSync(join(siblingStore, 'sessions.db'), 'private-sibling');
+  writeFileSync(join(siblingOrigin, 'capability.json'), 'private-sibling');
+  const alias = join(root, 'alias');
+  symlinkSync(layout === 'home-link' ? home : dataDir, alias);
+  const configuredDataDir = layout === 'home-link'
+    ? join(alias, '.botmux/data')
+    : layout === 'data-link' ? alias : dataDir;
+  const policy: FsPolicy = {
+    rules: [
+      ...['/usr', '/etc', ownStore, origin, attestation].map(path => ({
+        path, access: 'readOnly' as const, source: 'internal' as const,
+      })),
+      ...[workspace, ownBotHome].map(path => ({
+        path, access: 'readWrite' as const, source: 'internal' as const,
+      })),
+    ],
+    net: true,
+    writeRegexes: [],
+  };
+  return { root, home, dataDir, configuredDataDir, ownBotHome, workspace, policy };
+}
+
+function cleanup(f: ReturnType<typeof fixture>, plan: ReturnType<typeof prepareDirectSandbox>) {
+  // Bun's recursive rm does not repair mode-000 directories like Node does.
+  // Restore only this fixture's empty mask, after the sandbox child has exited.
+  const empty = join(f.dataDir, 'sandboxes/session/empty');
+  if (existsSync(empty)) chmodSync(empty, 0o700);
+  plan?.cleanup();
+  rmSync(f.root, { recursive: true, force: true });
+}
+
+describe.skipIf(!hasBwrap)('sandbox session-data root', () => {
+  it.each(['home-link', 'data-link', 'canonical'] as const)(
+    'pins the mounted root in both the child env and bwrap argv (%s)', layout => {
+      const f = fixture(layout);
+      let plan: ReturnType<typeof prepareDirectSandbox> = null;
+      try {
+        plan = prepareDirectSandbox({
+          sessionId: 'session', dataDir: f.configuredDataDir, policy: f.policy,
+          chdir: f.workspace, home: f.home, cliBin: '/bin/true', cliArgs: [],
+        });
+        expect(plan).not.toBeNull();
+        expect(plan!.env.SESSION_DATA_DIR).toBe(f.dataDir);
+        const keyAt = plan!.args.indexOf('SESSION_DATA_DIR');
+        expect(plan!.args.slice(keyAt - 1, keyAt + 2)).toEqual([
+          '--setenv', 'SESSION_DATA_DIR', f.dataDir,
+        ]);
+      } finally {
+        cleanup(f, plan);
+      }
+    },
+  );
+
+  it.skipIf(!canRunBwrap)('resolves session state through a symlinked home without exposing siblings', () => {
+    const f = fixture('home-link');
+    let plan: ReturnType<typeof prepareDirectSandbox> = null;
+    try {
+      plan = prepareDirectSandbox({
+        sessionId: 'session', dataDir: f.configuredDataDir, policy: f.policy,
+        chdir: f.workspace, home: f.home, cliBin: '/bin/sh', cliArgs: ['-ec', `
+          cat "$SESSION_DATA_DIR/session-stores/app-a/sessions.db"
+          cat "$SESSION_DATA_DIR/read-isolation/origin-own/capability.json"
+          cat "$SESSION_DATA_DIR/read-isolation/attest-own/proof.json"
+          test ! -r "$SESSION_DATA_DIR/session-stores/app-b/sessions.db"
+          test ! -r "$SESSION_DATA_DIR/read-isolation/origin-other/capability.json"
+          printf schedule > "$SESSION_DATA_DIR/../bots/app-a/schedule-probe"
+        `],
+      });
+      expect(plan).not.toBeNull();
+      const result = spawnSync(plan!.bin, plan!.args, {
+        env: { ...process.env, SESSION_DATA_DIR: f.configuredDataDir },
+        encoding: 'utf8', timeout: 10_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toBe('own-sessionown-capabilityown-proof');
+      expect(readFileSync(join(f.ownBotHome, 'schedule-probe'), 'utf8')).toBe('schedule');
+    } finally {
+      cleanup(f, plan);
+    }
+  });
+
+  it.skipIf(!canRunBwrap)('creates a schedule for the inferred session inside the real sandbox', () => {
+    const f = fixture('home-link');
+    let plan: ReturnType<typeof prepareDirectSandbox> = null;
+    try {
+      rmSync(join(f.dataDir, 'session-stores/app-a/sessions.db'));
+      seedPersistedSessionRows(f.dataDir, 'app-a', {
+        session: {
+          sessionId: 'session', chatId: 'oc_own', rootMessageId: 'om_own',
+          title: 'own session', status: 'active', createdAt: new Date(0).toISOString(),
+          larkAppId: 'app-a', cliId: 'codex', workingDir: f.workspace,
+          ownerOpenId: 'ou_owner', chatType: 'p2p', scope: 'chat',
+        },
+      });
+      const repoRoot = realpathSync(fileURLToPath(new URL('..', import.meta.url)));
+      const { command, prefixArgs } = tsRunnerPrefix();
+      f.policy.rules.push(...[repoRoot, dirname(realpathSync(command))].map(path => ({
+        path, access: 'readOnly' as const, source: 'internal' as const,
+      })));
+      plan = prepareDirectSandbox({
+        sessionId: 'session', dataDir: f.configuredDataDir, policy: f.policy,
+        chdir: repoRoot, home: f.home, cliBin: command,
+        cliArgs: [...prefixArgs, join(repoRoot, 'src/cli.ts'),
+          'schedule', 'add', '0 12 * * *', 'fixture reminder'],
+      });
+      expect(plan).not.toBeNull();
+      const result = spawnSync(plan!.bin, plan!.args, {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          SESSION_DATA_DIR: f.configuredDataDir,
+          BOTMUX_SESSION_ID: 'session', BOTMUX_LARK_APP_ID: 'app-a',
+          BOTMUX_API_ONLY: '0', BOTMUX_READ_ISOLATION: '1',
+          BOTMUX_WORKFLOW: '',
+        },
+        encoding: 'utf8', timeout: 15_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('已创建定时任务');
+      const store = JSON.parse(readFileSync(join(f.ownBotHome, 'schedules.json'), 'utf8'));
+      expect(Object.values(store)).toEqual([expect.objectContaining({
+        chatId: 'oc_own', larkAppId: 'app-a', ownerOpenId: 'ou_owner',
+        workingDir: f.workspace, prompt: 'fixture reminder',
+      })]);
+    } finally {
+      cleanup(f, plan);
+    }
+  });
+});

--- a/test/sandbox-session-data-dir.test.ts
+++ b/test/sandbox-session-data-dir.test.ts
@@ -8,6 +8,7 @@ import { prepareDirectSandbox } from '../src/adapters/backend/sandbox.js';
 import type { FsPolicy } from '../src/adapters/cli/fs-policy.js';
 import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 import { tsRunnerPrefix } from './helpers/ts-runner.js';
+import { ensureManagedOriginAttestationDirectory } from '../src/core/managed-origin-capability.js';
 
 const linux = process.platform === 'linux';
 const hasBwrap = linux && spawnSync('bwrap', ['--version']).status === 0;
@@ -15,6 +16,20 @@ const canRunBwrap = hasBwrap && spawnSync('bwrap', [
   '--ro-bind', '/', '/', '--unshare-user', '--unshare-pid', '--proc', '/proc',
   '--', '/bin/true',
 ], { stdio: 'ignore', timeout: 5_000 }).status === 0;
+const canRunRootBwrap = canRunBwrap && spawnSync('bwrap', [
+  '--ro-bind', '/', '/', '--unshare-user', '--uid', '0', '--gid', '0',
+  '--unshare-pid', '--proc', '/proc', '--', '/bin/bash', '-c', 'test "$EUID" = 0',
+], { stdio: 'ignore', timeout: 5_000 }).status === 0;
+
+function allowTestRuntime(policy: FsPolicy) {
+  const repoRoot = realpathSync(fileURLToPath(new URL('..', import.meta.url)));
+  const runtime = tsRunnerPrefix();
+  // Review worktrees can share dependencies outside the mounted checkout.
+  for (const path of [repoRoot, realpathSync(join(repoRoot, 'node_modules')), dirname(realpathSync(runtime.command))]) {
+    policy.rules.push({ path, access: 'readOnly', source: 'internal' });
+  }
+  return { repoRoot, ...runtime };
+}
 
 function fixture(layout: 'home-link' | 'data-link' | 'canonical') {
   const root = realpathSync(mkdtempSync(join(tmpdir(), 'botmux-sandbox-data-')));
@@ -129,11 +144,7 @@ describe.skipIf(!hasBwrap)('sandbox session-data root', () => {
           ownerOpenId: 'ou_owner', chatType: 'p2p', scope: 'chat',
         },
       });
-      const repoRoot = realpathSync(fileURLToPath(new URL('..', import.meta.url)));
-      const { command, prefixArgs } = tsRunnerPrefix();
-      f.policy.rules.push(...[repoRoot, dirname(realpathSync(command))].map(path => ({
-        path, access: 'readOnly' as const, source: 'internal' as const,
-      })));
+      const { repoRoot, command, prefixArgs } = allowTestRuntime(f.policy);
       plan = prepareDirectSandbox({
         sessionId: 'session', dataDir: f.configuredDataDir, policy: f.policy,
         chdir: repoRoot, home: f.home, cliBin: command,
@@ -160,6 +171,72 @@ describe.skipIf(!hasBwrap)('sandbox session-data root', () => {
         chatId: 'oc_own', larkAppId: 'app-a', ownerOpenId: 'ou_owner',
         workingDir: f.workspace, prompt: 'fixture reminder',
       })]);
+    } finally {
+      cleanup(f, plan);
+    }
+  });
+
+  it.skipIf(!canRunRootBwrap)('rejects a root sandbox forging the host relay flag and worker PID', () => {
+    const f = fixture('canonical');
+    let plan: ReturnType<typeof prepareDirectSandbox> = null;
+    try {
+      rmSync(join(f.dataDir, 'session-stores/app-a/sessions.db'));
+      const workerPid = 64;
+      const channelId = 'ac'.repeat(32);
+      const attestationDir = ensureManagedOriginAttestationDirectory(f.dataDir, 'session', channelId);
+      f.policy.rules.push({ path: attestationDir, access: 'readOnly', source: 'internal' });
+      seedPersistedSessionRows(f.dataDir, 'app-a', {
+        session: {
+          sessionId: 'session', chatId: 'oc_own', rootMessageId: 'om_own',
+          title: 'settled', status: 'active', createdAt: new Date(0).toISOString(),
+          larkAppId: 'app-a', cliId: 'codex-app', pid: workerPid,
+        },
+      });
+      const { repoRoot, command, prefixArgs } = allowTestRuntime(f.policy);
+      // No external effects even if the regression returns: the later ledger
+      // gate rejects this settled turn, and the sandbox has no network.
+      f.policy.net = false;
+      plan = prepareDirectSandbox({
+        sessionId: 'session', dataDir: f.dataDir, policy: f.policy,
+        chdir: repoRoot, home: f.home, cliBin: '/bin/bash',
+        cliArgs: ['-c', `
+          unset BOTMUX_SEND_RELAY BOTMUX_READ_ISOLATED
+          export BOTMUX_HOST_RELAY_AUTHORIZED=1
+          while :; do
+            (
+              if (( BASHPID == ${workerPid} )); then
+                printf 'fixture uid=%s parent=%s\\n' "$EUID" "$BASHPID"
+                "$@"
+                exit $?
+              fi
+              if (( BASHPID > ${workerPid} )); then exit 99; fi
+              exit 77
+            )
+            result=$?
+            if (( result != 77 )); then exit "$result"; fi
+          done
+        `, 'pid-collision', command, ...prefixArgs, join(repoRoot, 'src/cli.ts'),
+        'send', 'must not send', '--session-id', 'session', '--no-mention'],
+      });
+      expect(plan).not.toBeNull();
+      const result = spawnSync(plan!.bin, ['--uid', '0', '--gid', '0', ...plan!.args], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          SESSION_DATA_DIR: f.dataDir,
+          BOTMUX_SESSION_ID: 'session', BOTMUX_ORIGIN_CHANNEL_ID: channelId,
+          BOTMUX_TURN_ID: 'turn-settled', BOTMUX_DISPATCH_ATTEMPT: '4',
+          BOTMUX_HOST_RELAY_REQUIRES_CODEX_APP_LEDGER: '1',
+          BOTMUX_API_ONLY: '0', BOTMUX_WORKFLOW: '',
+          BOTMUX_LARK_APP_ID: '', BOTMUX_LARK_APP_SECRET: '',
+        },
+        encoding: 'utf8', timeout: 15_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.stdout).toBe(`fixture uid=0 parent=${workerPid}\n`);
+      expect(result.status, result.stderr).toBe(2);
+      expect(result.stderr).toContain('read-isolated owning data-root locator is missing or ambiguous');
+      expect(result.stderr).not.toContain('authorized Codex App origin');
     } finally {
       cleanup(f, plan);
     }


### PR DESCRIPTION
Closes #1313

## 问题

Linux bwrap 挂载使用 canonical 路径，但沙箱内继承的 `SESSION_DATA_DIR` 仍可能包含宿主 HOME 的软链接别名。新根目录没有该别名，因此会话数据库虽已挂载，`history` / `schedule add` 仍无法定位。

另一处独立问题是 outbox 的宿主重执行：它继承了属于 pane 的 origin channel，导致宿主 CLI 被误分类为读隔离调用，提前报缺少 data-root locator。

## 修改

- 在 `prepareDirectSandbox` 的返回环境和 bwrap `--setenv` 中固定 canonical `SESSION_DATA_DIR`。
- 对齐 Linux managed-origin capability / attestation 的只读挂载路径。
- 隔离启动约定版本从 13 升到 14，避免重连继续使用旧环境和挂载。
- 在 `buildRelayHostEnv` 中清理 pane 专属的 `BOTMUX_ORIGIN_CHANNEL_ID`，与清理 `BOTMUX_SEND_RELAY` 处于同一宿主重执行边界。只修改宿主子进程的环境副本，不修改沙箱 pane 的环境或授权文件。
- 为真实 bwrap 测试补充共享 `node_modules` 的实际路径挂载。

根据 review，已完整撤销初版 `parentBoundHostRelay` 隔离豁免：**当前 PR 的 `src/cli.ts` 相对基线没有改动**。PID 数值不再被新增用于跨 namespace 识别宿主。宿主 watcher 仍走原有 capability 授权，后续精确轮次、VC 输出策略和 ledger 检查保持不变。

没有增加生产目录授权、配置字段或持久化 token 协议，也没有修改发布版本号。

## 影响面

生产改动涉及 Linux 完整文件沙箱的数据目录、managed-origin 挂载以及 outbox 的宿主重执行（send / dispatch）。新建与恢复会话共用相同 watcher 环境清理逻辑；其他平台的直接发送和隔离鉴权实现不变。测试覆盖 Codex、Claude 的共用隔离逻辑及持久 pane 版本检查。

## 验证

最新修订的实际结果：

- Node / Vitest：17 个相关测试文件，267 项通过；6 项 macOS Seatbelt 真实运行测试在 Linux 按平台跳过。
- Bun 1.4.2：4 个相关文件逐进程运行，130 项通过；每个进程在启动前隔离 HOME 和临时目录。
- 共享依赖的临时 worktree：`node_modules` 软链接指向外部实际依赖目录，真实 bwrap 文件中的 6 项全部通过。
- `bun run build`：通过。
- `bun run verify:binary`：Linux x64 独立可执行文件的全部冒烟检查通过。
- 真实 outbox watcher → 构建后的 CLI，以及独立可执行文件的宿主重执行：均到达预期的精确已结束轮次拒绝门，未误报缺少 locator。

关键回归用例：

- 软链接 HOME、数据路径别名、普通路径的环境与 argv 一致性。
- 真实 bwrap 内当前会话及自身授权目录可读，兄弟 bot 的会话和授权目录不可读。
- 真实 CLI 在沙箱内不指定 chat-id 创建定时任务，校验目标聊天、bot、所有者、工作目录及落盘位置。
- root 用户命名空间中，通过 fork 命中夹具 worker PID 后伪造宿主 relay 标志：初版越过隔离校验，修订后在 locator 校验处拒绝。测试同时断言实际 UID/PID，且使用禁网沙箱和已结束轮次避免外部副作用。
- 合法宿主环境清理后仍执行精确 ledger 校验；匹配数值 PID 的 pane、错误父进程和显式隔离调用均不能借宿主标志取得新增豁免。
- 旧 pane 版本不能直接重连，worker 的授权目录生成点使用 canonical 路径。

测试均使用临时数据，不依赖真实飞书凭据，不发送真实消息；未部署或重启运行中的机器人。