### PR TITLE
fix(opencode): 修复 durable 首轮提示词丢失

### DIFF
--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -140,6 +140,7 @@ export async function detectOpenCodeSubmit(
   content: string,
   delayFn: (ms: number) => Promise<void> = delay,
   kind: OpenCodeDbKind = 'v1',
+  retryEnter = true,
 ): Promise<{ submitted: boolean; cliSessionId?: string; recheck?: () => { submitted: boolean; cliSessionId?: string } | false }> {
   const trySendEnter = (): boolean => {
     try {
@@ -169,7 +170,7 @@ export async function detectOpenCodeSubmit(
         ? { submitted: true, cliSessionId: afterWait.cliSessionId }
         : { submitted: true };
     }
-    if (!trySendEnter()) return { submitted: false };
+    if (retryEnter && !trySendEnter()) return { submitted: false };
   }
   const finalMatch = detectNewSubmit(baseline, content, kind);
   if (finalMatch.found) {
@@ -223,6 +224,32 @@ export const OPENCODE_BUSY_FRESHNESS_MS = 120_000;
  *  1. 存在属于该 session、状态为 `status: "running"` 的 tool part；
  *  2. 该 session 最新的一条 assistant message 处于未完成状态（没有 completed 时间戳）。
  */
+export function isOpenCodeInitialPromptComplete(
+  baseline: number,
+  cliSessionId: string,
+  kind: OpenCodeDbKind = 'v1',
+): boolean {
+  const table = kind === 'v2' ? 'session_message' : 'message';
+  const role = kind === 'v2' ? "type = 'assistant'" : "json_extract(data, '$.role') = 'assistant'";
+  const completed = kind === 'v2'
+    ? "json_extract(data, '$.time.completed')"
+    : "json_extract(data, '$.time.completed')";
+  return withDb((db) => {
+    const assistant = db.prepare(
+      `SELECT ${completed} AS completed FROM ${table} WHERE session_id = ? AND ${role} AND time_created > ? ORDER BY time_created DESC LIMIT 1`,
+    ).get(cliSessionId, baseline) as { completed?: number | null } | undefined;
+    if (assistant?.completed === undefined || assistant.completed === null) return false;
+    const runningTool = kind === 'v2'
+      ? db.prepare(
+        "SELECT 1 AS busy FROM session_message WHERE session_id = ? AND time_created > ? AND json_extract(data, '$.state.status') = 'running' LIMIT 1",
+      ).get(cliSessionId, baseline)
+      : db.prepare(
+        "SELECT 1 AS busy FROM part WHERE session_id = ? AND time_created > ? AND json_extract(data, '$.type') = 'tool' AND json_extract(data, '$.state.status') = 'running' LIMIT 1",
+      ).get(cliSessionId, baseline);
+    return !(runningTool as { busy?: number } | undefined)?.busy;
+  }) ?? false;
+}
+
 export function isOpenCodeSessionBusy(
   cliSessionId: string,
   kind: OpenCodeDbKind = 'v1',
@@ -364,6 +391,23 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
     // OpenCode 只在"新会话"应用 --prompt，`-s` 续接时静默忽略（消息会丢）。
     // 置位后 worker 在 resume spawn 时把初始 prompt 转入常规输入队列。
     initialPromptArgsIgnoredOnResume: true,
+    durableInitialPromptViaArgs: true,
+    captureInitialPromptArgSubmission() {
+      return snapPartBaseline();
+    },
+    async confirmInitialPromptArgSubmission(baseline, content) {
+      return detectOpenCodeSubmit({ write() {} }, baseline, content, delay, 'v1', false);
+    },
+    findInitialPromptArgSubmission(baseline, content) {
+      if (baseline === null) return { submitted: false };
+      const result = detectNewSubmit(baseline, content, 'v1');
+      return result.cliSessionId
+        ? { submitted: result.found, cliSessionId: result.cliSessionId }
+        : { submitted: result.found };
+    },
+    isInitialPromptComplete(baseline, cliSessionId) {
+      return baseline !== null && isOpenCodeInitialPromptComplete(baseline, cliSessionId);
+    },
     rawCommandInputMode: 'paste-line',
     rawCommandSettleMs: 300,
 

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -250,6 +250,22 @@ export interface CliAdapter {
    *  triggered the resume would be lost. */
   readonly initialPromptArgsIgnoredOnResume?: boolean;
 
+  readonly durableInitialPromptViaArgs?: boolean;
+  captureInitialPromptArgSubmission?(): number | null;
+  confirmInitialPromptArgSubmission?(
+    baseline: number | null,
+    content: string,
+  ): Promise<{
+    submitted: boolean;
+    cliSessionId?: string;
+    recheck?: () => SubmitRecheckResult | Promise<SubmitRecheckResult>;
+  }>;
+  findInitialPromptArgSubmission?(baseline: number, content: string): {
+    submitted: boolean;
+    cliSessionId?: string;
+  };
+  isInitialPromptComplete?(baseline: number, cliSessionId: string): boolean;
+
   readonly rawCommandInputMode?: 'paste-line';
   readonly rawCommandSettleMs?: number;
 

--- a/src/utils/pending-input-queue.ts
+++ b/src/utils/pending-input-queue.ts
@@ -131,11 +131,13 @@ export function pendingInputAllowsTypeAhead(
  * launch-argument path; adopt observes an already-running process. */
 export function shouldDeferArgsBakedDurablePrompt(opts: {
   passesInitialPromptViaArgs: boolean;
+  durableInitialPromptViaArgs?: boolean;
   adoptMode: boolean;
   dispatchAttempt?: number;
   queuedActivationToken?: string;
 }): boolean {
   return opts.passesInitialPromptViaArgs
+    && !opts.durableInitialPromptViaArgs
     && !opts.adoptMode
     && (opts.dispatchAttempt !== undefined || !!opts.queuedActivationToken);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -16465,10 +16465,10 @@ async function spawnCli(
         // Race-safe with transcript final / submit-failure: the worker-local
         // terminal deduper lets exactly one status win for this attempt.
         emitTurnTerminal(
-          exitedTurnId,
+          currentBotmuxTurnId!,
           'ambiguous',
-          'cli_exit',
-          exitedDispatchAttempt,
+        'cli_exit',
+          currentBotmuxDispatchAttempt,
         );
       }
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19395,9 +19395,16 @@ process.on('message', async (raw: unknown) => {
             const argvGeneration = cliSpawnGeneration;
             const argvBackend = backend;
             const finalizeArgvSubmission = (cliSessionId?: string) => {
+              if (!cliSessionId) return;
+              if (msg.queuedActivationToken) {
+                send({
+                  type: 'queued_activation_submitted',
+                  sessionId,
+                  activationToken: msg.queuedActivationToken,
+                });
+              }
               if (!submission
                 || submission.baseline === null
-                || !cliSessionId
                 || !msg.turnId
                 || msg.dispatchAttempt === undefined
                 || !cliAdapter?.isInitialPromptComplete
@@ -19416,13 +19423,6 @@ process.on('message', async (raw: unknown) => {
                 backend: argvBackend,
                 generation: argvGeneration,
               });
-              if (msg.queuedActivationToken) {
-                send({
-                  type: 'queued_activation_submitted',
-                  sessionId,
-                  activationToken: msg.queuedActivationToken,
-                });
-              }
             };
             if (submission && confirm && argvBackend) {
               try {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1882,8 +1882,76 @@ let lastSpawnEffectiveResume = false;
 let lastSpawnEffectiveCliSessionId: string | undefined;
 let lastSpawnEffectiveAdapterSessionId: string | undefined;
 let lastSpawnDeferInitialPrompt = false;
+let lastSpawnArgvDurableInitialPrompt = false;
+let lastSpawnArgvDurableInitialPromptSubmission: { baseline: number | null; content: string } | undefined;
+let argvDurableInitialPromptCompletionTimer: ReturnType<typeof setInterval> | null = null;
+let argvDurableInitialPromptCompletion: {
+  baseline: number;
+  content: string;
+  cliSessionId?: string;
+  turnId: string;
+  dispatchAttempt: number;
+  adapter: CliAdapter;
+} | undefined;
 let lastSpawnQueuedInitialPrompt: string | undefined;
 let lastSpawnQueuedInitialPromptLogicalContent: string | undefined;
+
+function watchArgvDurableInitialPromptCompletion(opts: {
+  baseline: number;
+  cliSessionId: string;
+  turnId: string;
+  dispatchAttempt: number;
+  adapter: CliAdapter;
+  backend: SessionBackend;
+  generation: number;
+}): void {
+  if (argvDurableInitialPromptCompletionTimer) {
+    clearInterval(argvDurableInitialPromptCompletionTimer);
+    argvDurableInitialPromptCompletionTimer = null;
+  }
+  const check = () => {
+    if (cliSpawnGeneration !== opts.generation || backend !== opts.backend) {
+      if (argvDurableInitialPromptCompletionTimer) {
+        clearInterval(argvDurableInitialPromptCompletionTimer);
+        argvDurableInitialPromptCompletionTimer = null;
+      }
+      return;
+    }
+    if (!opts.adapter.isInitialPromptComplete?.(opts.baseline, opts.cliSessionId)) return;
+    if (argvDurableInitialPromptCompletionTimer) {
+      clearInterval(argvDurableInitialPromptCompletionTimer);
+      argvDurableInitialPromptCompletionTimer = null;
+    }
+    argvDurableInitialPromptCompletion = undefined;
+    emitTurnTerminal(opts.turnId, 'completed', undefined, opts.dispatchAttempt);
+  };
+  check();
+  if (argvDurableInitialPromptCompletionTimer) return;
+  argvDurableInitialPromptCompletionTimer = setInterval(check, 1_000);
+  argvDurableInitialPromptCompletionTimer.unref?.();
+}
+
+function drainArgvDurableInitialPromptCompletion(): boolean {
+  const completion = argvDurableInitialPromptCompletion;
+  if (!completion
+    || completion.turnId !== currentBotmuxTurnId
+    || completion.dispatchAttempt !== currentBotmuxDispatchAttempt) return false;
+  const submission = completion.cliSessionId
+    ? { submitted: true, cliSessionId: completion.cliSessionId }
+    : completion.adapter.findInitialPromptArgSubmission?.(
+      completion.baseline,
+      completion.content,
+    );
+  if (!submission?.submitted
+    || !submission.cliSessionId
+    || !completion.adapter.isInitialPromptComplete?.(
+      completion.baseline,
+      submission.cliSessionId,
+    )) return false;
+  argvDurableInitialPromptCompletion = undefined;
+  emitTurnTerminal(completion.turnId, 'completed', undefined, completion.dispatchAttempt);
+  return true;
+}
 // True when this session runs under an outer bwrap supervisor (file sandbox OR
 // Linux credential-only bwrap) — both make getChildPid() the supervisor, not the
 // CLI leaf. credentialOnlyBwrap needs host probes so it can't be recomputed from
@@ -10955,6 +11023,7 @@ function scheduleSubmitFailureNotify(
   turnIdentity?: Pick<PendingCliInput, 'turnId' | 'dispatchAttempt' | 'nativeSessionTitle'>,
   durableTerminalStatus: 'failed' | 'ambiguous' = 'failed',
   structuredTarget = false,
+  onConfirmed?: (cliSessionId?: string) => void,
 ): void {
   const preview = buildSubmitMessagePreview(msg);
   const emitDurableTerminal = (errorCode: string): void => {
@@ -11040,6 +11109,7 @@ function scheduleSubmitFailureNotify(
           if (codexBridgeFallbackActive()) codexBridgeNotifyCliSessionId(cliSessionId);
           void syncFreshCodexNativeSessionTitle(cliSessionId, codexRpcEngine);
         }
+        onConfirmed?.(cliSessionId);
         log(`Deferred recheck found submit in ${transcriptLabel} — suppressing warning. preview="${preview}"`);
         redriveRejectedStructuredReady();
         return;
@@ -14195,12 +14265,18 @@ async function spawnCli(
     preparedInitialPrompt = prepared?.initialPrompt ?? cfg.prompt;
     promptArgPreparationChanged = preparedInitialPrompt !== cfg.prompt;
   }
+  const hasDurableInitialPrompt = cfg.dispatchAttempt !== undefined || !!cfg.queuedActivationToken;
+  const durableInitialPromptArgBaseline = hasDurableInitialPrompt
+    ? cliAdapter.captureInitialPromptArgSubmission?.() ?? null
+    : undefined;
   const deferInitialPrompt = shouldDeferInitialPromptForStartup({
     hasStartupCommands: !!cfg.startupCommands?.length,
     adoptMode: cfg.adoptMode === true,
     passesInitialPromptViaArgs: cliAdapter.passesInitialPromptViaArgs === true,
   }) || shouldDeferArgsBakedDurablePrompt({
     passesInitialPromptViaArgs: cliAdapter.passesInitialPromptViaArgs === true,
+    durableInitialPromptViaArgs: cliAdapter.durableInitialPromptViaArgs === true
+      && durableInitialPromptArgBaseline !== null,
     adoptMode: cfg.adoptMode === true,
     dispatchAttempt: cfg.dispatchAttempt,
     queuedActivationToken: cfg.queuedActivationToken,
@@ -14247,6 +14323,17 @@ async function spawnCli(
     piInitialPromptEnv = { ...(preparedDeferredInput.env ?? {}) };
   }
   lastSpawnDeferInitialPrompt = deferInitialPrompt;
+  lastSpawnArgvDurableInitialPrompt = !deferInitialPrompt
+    && !effectiveResume
+    && !willReattachPersistent
+    && !!preparedInitialPrompt
+    && cliAdapter.durableInitialPromptViaArgs === true
+    && !!cliAdapter.confirmInitialPromptArgSubmission
+    && durableInitialPromptArgBaseline !== null
+    && hasDurableInitialPrompt;
+  lastSpawnArgvDurableInitialPromptSubmission = lastSpawnArgvDurableInitialPrompt
+    ? { baseline: durableInitialPromptArgBaseline!, content: preparedInitialPrompt! }
+    : undefined;
   kiroSessionIdCaptureArmed = cfg.cliId === 'kiro-cli' && !effectiveCliSessionId && !willReattachPersistent;
   kiroSessionIdCaptureBuffer = '';
   // Sandboxed sessions: write this bot's OWN send-credential into its BOT_HOME.
@@ -15665,6 +15752,7 @@ async function spawnCli(
   }
   const actuallyReattachedPersistent = 'isReattach' in backend
     && backend.isReattach === true;
+  if (actuallyReattachedPersistent) lastSpawnArgvDurableInitialPrompt = false;
   // ── Generational-race commit/teardown for the read-isolation provenance proof ──
   // We wrote a PENDING proof before spawn (pendingProvenanceCommit). Now that spawn
   // has returned we know whether a FRESH generation was actually established.
@@ -16364,7 +16452,7 @@ async function spawnCli(
       );
       return;
     }
-    if (cliAdapter?.reliableTurnTerminal === true
+    if ((cliAdapter?.reliableTurnTerminal === true || lastSpawnArgvDurableInitialPrompt)
       && exitedTurnId
       && exitedDispatchAttempt !== undefined) {
       // The CLI may have durably appended its terminal record immediately
@@ -16372,14 +16460,17 @@ async function spawnCli(
       // synchronously before claiming `cli_exit`; otherwise ambiguous wins the
       // deduper and needlessly replays a turn that actually completed.
       drainReliableTerminalBeforeInterrupt();
-      // Race-safe with transcript final / submit-failure: the worker-local
-      // terminal deduper lets exactly one status win for this attempt.
-      emitTurnTerminal(
-        exitedTurnId,
-        'ambiguous',
-        'cli_exit',
-        exitedDispatchAttempt,
-      );
+      if (drainArgvDurableInitialPromptCompletion()) {
+      } else {
+        // Race-safe with transcript final / submit-failure: the worker-local
+        // terminal deduper lets exactly one status win for this attempt.
+        emitTurnTerminal(
+          exitedTurnId,
+          'ambiguous',
+          'cli_exit',
+          exitedDispatchAttempt,
+        );
+      }
     }
     durableTurnInFlight = false;
     // Hybrid RPC mode: the `codex --remote` viewer just died — tear down the
@@ -19284,6 +19375,93 @@ process.on('message', async (raw: unknown) => {
           // A successful spawn with a non-queued prompt means the adapter baked
           // it into argv or the RPC engine already accepted it.
           initialInputCommitted = true;
+          if (lastSpawnArgvDurableInitialPrompt) {
+            if (msg.dispatchAttempt !== undefined) durableTurnInFlight = true;
+            const submission = lastSpawnArgvDurableInitialPromptSubmission;
+            const confirm = cliAdapter?.confirmInitialPromptArgSubmission;
+            if (submission
+              && submission.baseline !== null
+              && msg.turnId
+              && msg.dispatchAttempt !== undefined
+              && cliAdapter) {
+              argvDurableInitialPromptCompletion = {
+                baseline: submission.baseline,
+                content: submission.content,
+                turnId: msg.turnId,
+                dispatchAttempt: msg.dispatchAttempt,
+                adapter: cliAdapter,
+              };
+            }
+            const argvGeneration = cliSpawnGeneration;
+            const argvBackend = backend;
+            const finalizeArgvSubmission = (cliSessionId?: string) => {
+              if (!submission
+                || submission.baseline === null
+                || !cliSessionId
+                || !msg.turnId
+                || msg.dispatchAttempt === undefined
+                || !cliAdapter?.isInitialPromptComplete
+                || !argvBackend) return;
+              const completion = {
+                baseline: submission.baseline,
+                content: submission.content,
+                cliSessionId,
+                turnId: msg.turnId,
+                dispatchAttempt: msg.dispatchAttempt,
+                adapter: cliAdapter,
+              };
+              argvDurableInitialPromptCompletion = completion;
+              watchArgvDurableInitialPromptCompletion({
+                ...completion,
+                backend: argvBackend,
+                generation: argvGeneration,
+              });
+              if (msg.queuedActivationToken) {
+                send({
+                  type: 'queued_activation_submitted',
+                  sessionId,
+                  activationToken: msg.queuedActivationToken,
+                });
+              }
+            };
+            if (submission && confirm && argvBackend) {
+              try {
+                const result = await confirm(submission.baseline, submission.content);
+                if (cliSpawnGeneration === argvGeneration && backend === argvBackend) {
+                  if (result.cliSessionId) persistCliSessionId(result.cliSessionId);
+                  if (result.submitted) {
+                    finalizeArgvSubmission(result.cliSessionId);
+                  } else {
+                    scheduleSubmitFailureNotify(
+                      submission.content,
+                      result.recheck,
+                      t('worker.transcriptLabel'),
+                      undefined,
+                      undefined,
+                      usageLimitTracker.currentTurn(),
+                      { turnId: msg.turnId, dispatchAttempt: msg.dispatchAttempt },
+                      'failed',
+                      false,
+                      cliSessionId => finalizeArgvSubmission(cliSessionId),
+                    );
+                  }
+                }
+              } catch {
+                if (cliSpawnGeneration === argvGeneration && backend === argvBackend) {
+                  scheduleSubmitFailureNotify(
+                    submission.content,
+                    undefined,
+                    t('worker.transcriptLabel'),
+                    undefined,
+                    undefined,
+                    usageLimitTracker.currentTurn(),
+                    { turnId: msg.turnId, dispatchAttempt: msg.dispatchAttempt },
+                    'failed',
+                  );
+                }
+              }
+            }
+          }
         }
         // The first turn is now either at queue head or already owned by the
         // argv/RPC startup path. Only now may an early idle edge drain
@@ -19629,7 +19807,10 @@ process.on('message', async (raw: unknown) => {
       settleDurableTurnForRestart({
         hasInFlightTurn: durableTurnInFlight,
         hasCurrentTurnId: !!currentBotmuxTurnId,
-        drain: () => drainReliableTerminalBeforeInterrupt(),
+        drain: () => {
+          drainReliableTerminalBeforeInterrupt();
+          drainArgvDurableInitialPromptCompletion();
+        },
         isStillInFlight: () => durableTurnInFlight,
         emitAmbiguous: () => emitTurnTerminal(currentBotmuxTurnId!, 'ambiguous', undefined, currentBotmuxDispatchAttempt),
         release: () => { durableTurnInFlight = false; inflightInputs.onTurnComplete(); },

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -12,6 +12,7 @@ import { buildNewTopicPrompt } from '../src/core/session-manager.js';
 import {
   resolveInitialPromptDelivery,
   shouldArmSpawnArgvInitialPromptBusy,
+  shouldDeferArgsBakedDurablePrompt,
   shouldTrackArgvBakedFirstPrompt,
   shouldDeferInitialPromptForArgLimit,
 } from '../src/utils/pending-input-queue.js';
@@ -367,6 +368,32 @@ describe('OpenCode v1 real-envelope argv budget (buildNewTopicPrompt → defer)'
       sessionId: 'sess-integration-1',
       resume: false,
       initialPrompt: defer ? undefined : envelope,
+    });
+    expect(args).toContain('--prompt');
+    expect(args).toContain(envelope);
+  });
+
+  it.each([
+    ['dispatch attempt', { dispatchAttempt: 1 }],
+    ['queued activation', { queuedActivationToken: 'activation-token' }],
+  ])('keeps a short fresh durable %s envelope on OpenCode --prompt', (_label, durable) => {
+    const envelope = buildNewTopicPrompt(
+      '帮我看看这个 bug',
+      'sess-durable-opencode',
+      'opencode',
+    );
+    expect(Buffer.byteLength(envelope, 'utf8')).toBeLessThan(budget);
+    expect(shouldDeferArgsBakedDurablePrompt({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      durableInitialPromptViaArgs: adapter.durableInitialPromptViaArgs === true,
+      adoptMode: false,
+      ...durable,
+    })).toBe(false);
+
+    const args = adapter.buildArgs({
+      sessionId: 'sess-durable-opencode',
+      resume: false,
+      initialPrompt: envelope,
     });
     expect(args).toContain('--prompt');
     expect(args).toContain(envelope);

--- a/test/opencode-resume.test.ts
+++ b/test/opencode-resume.test.ts
@@ -12,7 +12,12 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { DatabaseSync } from 'node:sqlite';
 
-import { createOpenCodeAdapter, detectOpenCodeSubmit, snapPartBaseline } from '../src/adapters/cli/opencode.js';
+import {
+  createOpenCodeAdapter,
+  detectOpenCodeSubmit,
+  isOpenCodeInitialPromptComplete,
+  snapPartBaseline,
+} from '../src/adapters/cli/opencode.js';
 import { opencodeDbPath } from '../src/services/opencode-paths.js';
 import type { PtyHandle } from '../src/adapters/cli/types.js';
 
@@ -68,6 +73,20 @@ function seedUserPart(db: DatabaseSync, sessionId: string, text: string, timeCre
     .run(mid, sessionId, timeCreated, JSON.stringify({ role: 'user' }));
   db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
     .run(`prt_${++idSeq}`, mid, sessionId, timeCreated, JSON.stringify({ type: 'text', text }));
+}
+
+function seedCompletedAssistantMessage(db: DatabaseSync, sessionId: string, timeCreated: number): void {
+  db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+    .run(`msg_${++idSeq}`, sessionId, timeCreated, JSON.stringify({
+      role: 'assistant', time: { completed: timeCreated },
+    }));
+}
+
+function seedRunningToolPart(db: DatabaseSync, sessionId: string, timeCreated: number): void {
+  db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
+    .run(`prt_${++idSeq}`, `msg_${++idSeq}`, sessionId, timeCreated, JSON.stringify({
+      type: 'tool', state: { status: 'running' },
+    }));
 }
 
 beforeEach(() => {
@@ -185,6 +204,24 @@ describe('opencode listResumableSessions', () => {
   });
 });
 
+describe('opencode initial prompt completion', () => {
+  it('requires a completed assistant row after the argv submission baseline', () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_target' });
+    seedCompletedAssistantMessage(db, 'ses_target', 1_000);
+    expect(isOpenCodeInitialPromptComplete(1_000, 'ses_target')).toBe(false);
+
+    seedCompletedAssistantMessage(db, 'ses_target', 2_000);
+    expect(isOpenCodeInitialPromptComplete(1_000, 'ses_target')).toBe(true);
+
+    const current = Date.now();
+    seedCompletedAssistantMessage(db, 'ses_target', current);
+    seedRunningToolPart(db, 'ses_target', current);
+    expect(isOpenCodeInitialPromptComplete(1_000, 'ses_target')).toBe(false);
+    db.close();
+  });
+});
+
 describe('opencode writeInput DB verification', () => {
   function stubPty(onEnter?: () => void): PtyHandle & { enters: number } {
     const handle = {
@@ -212,6 +249,20 @@ describe('opencode writeInput DB verification', () => {
     const adapter = createOpenCodeAdapter();
     const result = await adapter.writeInput(pty, content);
     db.close();
+    expect(result).toMatchObject({ submitted: true, cliSessionId: 'ses_target' });
+  });
+
+  it('confirms a fresh --prompt submission against the pre-spawn baseline', async () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_target' });
+    const adapter = createOpenCodeAdapter();
+    const baseline = adapter.captureInitialPromptArgSubmission!();
+    const content = `<session_id>${BOTMUX_SESSION_ID}</session_id>\n\nargv opening`;
+    seedUserPart(db, 'ses_target', content, Date.now());
+
+    const result = await adapter.confirmInitialPromptArgSubmission!(baseline, content);
+    db.close();
+
     expect(result).toMatchObject({ submitted: true, cliSessionId: 'ses_target' });
   });
 

--- a/test/worker-ordinary-im-init-concurrency.integration.test.ts
+++ b/test/worker-ordinary-im-init-concurrency.integration.test.ts
@@ -2,6 +2,7 @@ import { type ChildProcess } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { afterEach, describe, expect, it } from 'vitest';
 import { spawnNodeTsScript } from './helpers/ts-runner.js';
 import type { DaemonToWorker, WorkerToDaemon } from '../src/types.js';
@@ -191,6 +192,96 @@ if (process.argv.includes('app-server')) {
       turnId: 'om_followup_order',
     }));
   }, 20_000);
+
+  it('acknowledges an OpenCode argv activation token without a dispatch attempt', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-opencode-argv-activation-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    const xdgDataDir = join(root, 'xdg');
+    const dbDir = join(xdgDataDir, 'opencode');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(dbDir, { recursive: true });
+    const prompt = '<session_id>sid-opencode-activation</session_id>\n<user_message>OPEN_CODE_TOKEN_ONLY</user_message>';
+    const db = new DatabaseSync(join(dbDir, 'opencode.db'));
+    db.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT, title TEXT, time_created INTEGER, time_updated INTEGER, time_archived INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    db.prepare('INSERT INTO session VALUES (?,?,?,?,?,?,?)')
+      .run('ses_activation', null, dataDir, '', 1, 1, null);
+    const initialBaseline = Date.now();
+    db.prepare('INSERT INTO message VALUES (?,?,?,?)')
+      .run('msg_before', 'ses_activation', initialBaseline, JSON.stringify({ role: 'user' }));
+    db.prepare('INSERT INTO part VALUES (?,?,?,?,?)')
+      .run('part_before', 'msg_before', 'ses_activation', initialBaseline, JSON.stringify({ type: 'text', text: 'before' }));
+    db.close();
+
+    const fakeOpenCode = join(root, 'fake-opencode');
+    writeFileSync(fakeOpenCode, `#!/usr/bin/env node
+const fs = require('node:fs');
+const { DatabaseSync } = require('node:sqlite');
+const args = process.argv.slice(2);
+const prompt = args[args.indexOf('--prompt') + 1];
+const db = new DatabaseSync(process.env.OPENCODE_DB_PATH);
+const now = Date.now();
+db.prepare('INSERT INTO message VALUES (?,?,?,?)').run('msg_user', 'ses_activation', now, JSON.stringify({ role: 'user' }));
+db.prepare('INSERT INTO part VALUES (?,?,?,?,?)').run('part_user', 'msg_user', 'ses_activation', now, JSON.stringify({ type: 'text', text: prompt }));
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakeOpenCode, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawnNodeTsScript(resolve('src/worker.ts'), [], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        XDG_DATA_HOME: xdgDataDir,
+        OPENCODE_DB_PATH: join(dbDir, 'opencode.db'),
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-opencode-activation',
+        BOTMUX_TIME_SCALE: '0.05',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => {
+      messages.push(raw as WorkerToDaemon);
+      logs.push(`[ipc] ${JSON.stringify(raw)}\n`);
+    });
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-opencode-activation',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'opencode',
+      cliPathOverride: fakeOpenCode,
+      backendType: 'pty',
+      prompt,
+      queuedActivationToken: 'opencode-token-only',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_opencode_initial',
+    } satisfies DaemonToWorker);
+
+    await waitFor(() => messages.some(message =>
+      message.type === 'queued_activation_submitted'
+      && message.activationToken === 'opencode-token-only'), logs, 8_000);
+
+    expect(messages).toContainEqual({
+      type: 'queued_activation_submitted',
+      sessionId: 'sid-opencode-activation',
+      activationToken: 'opencode-token-only',
+    });
+  }, 12_000);
 
   it('renames a TraeX native session only after the first Lark prompt is submitted', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-traex-native-title-'));

--- a/test/worker-queue-merge.test.ts
+++ b/test/worker-queue-merge.test.ts
@@ -165,11 +165,16 @@ describe('initial prompt args deferral', () => {
 });
 
 describe('durable turn queue boundary', () => {
-  it('routes an args-baked cold durable prompt through the owned queue', () => {
+  it('routes an args-baked cold durable prompt through the owned queue by default', () => {
     expect(shouldDeferArgsBakedDurablePrompt({
       passesInitialPromptViaArgs: true,
       adoptMode: false,
       dispatchAttempt: 1,
+    })).toBe(true);
+    expect(shouldDeferArgsBakedDurablePrompt({
+      passesInitialPromptViaArgs: true,
+      adoptMode: false,
+      queuedActivationToken: 'activation',
     })).toBe(true);
     expect(shouldDeferArgsBakedDurablePrompt({
       passesInitialPromptViaArgs: true,
@@ -184,6 +189,21 @@ describe('durable turn queue boundary', () => {
       passesInitialPromptViaArgs: true,
       adoptMode: true,
       dispatchAttempt: 1,
+    })).toBe(false);
+  });
+
+  it('keeps a fresh durable prompt on argv only for an adapter that guarantees it', () => {
+    expect(shouldDeferArgsBakedDurablePrompt({
+      passesInitialPromptViaArgs: true,
+      durableInitialPromptViaArgs: true,
+      adoptMode: false,
+      dispatchAttempt: 1,
+    })).toBe(false);
+    expect(shouldDeferArgsBakedDurablePrompt({
+      passesInitialPromptViaArgs: true,
+      durableInitialPromptViaArgs: true,
+      adoptMode: false,
+      queuedActivationToken: 'activation',
     })).toBe(false);
   });
 

--- a/test/worker-restart-race.test.ts
+++ b/test/worker-restart-race.test.ts
@@ -49,7 +49,7 @@ describe('worker restart P1 — drain reliable terminal before ambiguous emit', 
   it('onExit reuses the same shared drain helper (no divergent duplicate)', () => {
     // Both the CLI onExit path and the restart IPC path must drain identically;
     // the shared helper is the single source, so onExit calls it too.
-    const onExitAmbiguous = workerSource.indexOf("'ambiguous',\n        'cli_exit'");
+    const onExitAmbiguous = workerSource.search(/'ambiguous',\n\s+'cli_exit'/);
     expect(onExitAmbiguous).toBeGreaterThan(0);
     const before = workerSource.slice(onExitAmbiguous - 400, onExitAmbiguous);
     expect(before).toContain('drainReliableTerminalBeforeInterrupt()');


### PR DESCRIPTION
## 改动

- OpenCode fresh 短首轮携带 dispatchAttempt 或 queuedActivationToken 时继续走可靠的 --prompt，不再因 durable 标识改走启动期 PTY 输入队列。
- 以 OpenCode SQLite 的提交记录确认 argv 首轮已接收，捕获原生 session id，并在同一会话的首轮 assistant/tool 生命周期结束后结算 durable turn。
- DB 不可用、resume、超长提示词、startup commands 与 reattach 继续使用原有队列路径；提交确认延迟、进程退出和显式重启均保留精确的完成/ambiguous 结算。

## 原因

OpenCode Bubble Tea 的 composer 在启动早期尚未挂载时会静默丢弃 PTY paste。此前 durable 首轮为建立 HOL ownership 被强制改走该路径，导致空 composer 和 submit_unconfirmed。

## 影响范围

仅影响 OpenCode v1 的 fresh、短 prompt、durable opening 路径；普通 OpenCode 首轮、resume、超长 prompt 及其它 CLI 保持既有传输策略。tmux 与 PTY 均受益于恢复 OpenCode 自身的 --prompt 启动交付。

## 验证

- bunx vitest run --project unit test/worker-queue-merge.test.ts test/initial-prompt-arg-limit.test.ts test/opencode-resume.test.ts：72 passed
- bunx vitest run --project e2e test/opencode-input.e2e.ts：10 passed（OpenCode 1.18.29）
- bun run build：通过
- tmux 3.3a + OpenCode 1.18.29 direct smoke：fresh opencode --prompt 在独立 tmux server 中返回预期响应

Closes #1297