### PR TITLE
fix(adapter): claude-code 补忙碌标志防止静默误判空闲

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -584,6 +584,14 @@ function findJsonlAcrossProjectsRoot(
 }
 
 const COMPLETION_RE = /\u2733\s*(?:Worked|Crunched|Cogitated|Cooked|Churned|Saut[eé]ed|Baked|Brewed) for \d+[smh]/;
+/** Busy footer for idle detection: the working-state status bar carries an
+ *  extra 「· esc to interrupt ·」 segment the idle composer lacks. Anchored to
+ *  the footer's STRUCTURE — a leading mode glyph (⏵⏵/⏸, mode name NOT
+ *  enumerated: manual/bypass strings are runtime-assembled, absent from the
+ *  binary) or a retry segment, joined by mid-dots — because the bare phrase
+ *  also appears in transcript prose on the same screen (busyProbeRegion scans
+ *  the bottom third), which would pin an idle session busy forever. */
+const CLAUDE_BUSY_FOOTER_RE = /^\s*(?:[⏵⏸]+\s.*\bon\b|.*next try).*·\s*esc to interrupt\b/m;
 /** Escape hatch: force a specific chat:submit key regardless of
  *  keybindings.json. Accepts the same spellings as the config (e.g.
  *  `meta+enter`, `alt+enter`, `enter`). A value that can't be sent through the
@@ -1186,6 +1194,24 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
 
     completionPattern: COMPLETION_RE,
     readyPattern: /❯/,
+    // 忙碌正证据：Claude Code 工作时输入框 ❯ 常驻（readyPattern 在忙时也命中），
+    // idle 判定只剩 2s 静默这一条负证据——长思考/网关延迟造成的一次 ≥2s 停顿
+    // 就会把工作中的会话错翻成 idle，且没有拉回手段。工作时 footer 比空闲态
+    // （⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents）多出
+    // 「· esc to interrupt ·」一段：busyPattern 让 deferPromptReadyWhileBusy
+    // 在翻绿前先查一次屏幕（否决错翻），idleToBusyPattern 让已错翻的绿卡在
+    // 下一帧拉回工作中。
+    //
+    // ⚠️ 必须锚 footer 的结构而不是裸短语：transcript 与 footer 同屏，busyProbeRegion
+    // 扫的是末 max(12, ⌈行数/3⌉) 行——正文只要出现裸短语（讨论中断快捷键、贴 diff、
+    // grep 源码）就会命中，把已空闲的会话钉死在「工作中」（probe 重试无上限）。
+    // 行首模式字形（⏵⏵/⏸，不枚举 mode 名——binary 里 manual/bypass 是运行时拼的）
+    // 或重试段「next try」+ `·` 分隔联合锚定：真 footer 7/7 命中（5 种模式 + 重试
+    // footer + ctrl+t 变体），散文 8/8 不误报（reviewer 与本机双向实测）。
+    // 窄视口（<80 列）footer 截断时拿不到中断段——安全降级回 2s 静默裸奔，
+    // 不产生误报。本机 242 个 tmux pane 扫末行实测 0 误报。
+    busyPattern: CLAUDE_BUSY_FOOTER_RE,
+    idleToBusyPattern: CLAUDE_BUSY_FOOTER_RE,
     // Claude 家族在 spawn 时注入 SessionStart hook，回调
     // `botmux session-ready` 给出启动 selector 边界。worker 收到后清掉旧
     // readyPattern 证据，并等待新 prompt 再投首条消息。

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -2298,6 +2298,63 @@ describe('busyPattern', () => {
     expect(busy!.test('press esc to interrupt')).toBe(false);
   });
 
+  it('claude-code matches the working footer structure and self-heals a false idle, but not prose or the idle composer', () => {
+    // Regression: claude-code only had a readyPattern (❯ is resident while
+    // Claude works), so a single ≥2s PTY stall flipped a busy session to idle
+    // with no path back. The working footer carries an extra
+    // 「· esc to interrupt ·」 segment the idle composer lacks.
+    const claude = createCliAdapterSync('claude-code');
+    const busy = claude.busyPattern;
+    expect(busy).toBeDefined();
+    expect(claude.idleToBusyPattern).toBeDefined();
+    expect(claude.idleToBusyPattern!.source).toBe(busy!.source);
+    // Real footer lines (5 permission modes — mode names are runtime-assembled,
+    // do NOT enumerate them in the anchor — plus the ctrl+t variant and the
+    // retry footer), extracted from live panes.
+    expect(busy!.test('⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt · ← for agents')).toBe(true);
+    expect(busy!.test('⏸  manual mode on · esc to interrupt · ← for agents')).toBe(true);
+    expect(busy!.test('⏵⏵ accept edits on (shift+tab to cycle) · esc to interrupt · ← for agents')).toBe(true);
+    expect(busy!.test('⏸  plan mode on (shift+tab to cycle) · esc to interrupt · ← for agents')).toBe(true);
+    expect(busy!.test('⏵⏵ auto mode on (shift+tab to cycle) · esc to interrupt · ← for agents')).toBe(true);
+    expect(busy!.test('⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt · ctrl+t to hide tasks · ← for agents')).toBe(true);
+    expect(busy!.test(' · next try in 3s · attempt 2 · esc to interrupt')).toBe(true);
+    // Idle composer: no interrupt segment.
+    expect(busy!.test('⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents')).toBe(false);
+    expect(busy!.test('❯')).toBe(false);
+    // Prose quoting the hint must not flip an idle card back to busy. The
+    // transcript shares the screen with the footer and busyProbeRegion scans
+    // the bottom third, so the BARE phrase in prose (prompt echo, assistant
+    // reply, mid-dot decoration, "on" + hint shape, prompt-then-help form)
+    // must all stay inert — a loose /esc to interrupt/ anchor pinned idle
+    // sessions busy forever (probe retries have no deadline).
+    expect(busy!.test('press esc to interrupt')).toBe(false);
+    expect(busy!.test('❯ Reply with exactly this one line and nothing else: docs say esc to interrupt works')).toBe(false);
+    expect(busy!.test('● docs say esc to interrupt works')).toBe(false);
+    expect(busy!.test('· esc to interrupt ·')).toBe(false);
+    expect(busy!.test('the mode is on · esc to interrupt is documented in the docs')).toBe(false);
+    expect(busy!.test('next try: please esc to interrupt yourself')).toBe(false);
+    // Multi-line probe region: prose above must not rescue a busy verdict,
+    // and a busy footer must be found mid-region.
+    const region = [
+      '❯ docs say esc to interrupt works',
+      '● docs say esc to interrupt works',
+      '✻ Cogitated for 19s · done 10:36 PM',
+      '────────────────────────────────',
+      '❯',
+      '────────────────────────────────',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
+    ].join('\n');
+    expect(busy!.test(region)).toBe(false);
+    const busyRegion = region.replace(
+      '· ← for agents',
+      '· esc to interrupt · ← for agents',
+    );
+    expect(busy!.test(busyRegion)).toBe(true);
+    // Shared def: seed/relay render the same Claude Code footer.
+    expect(createCliAdapterSync('seed').busyPattern!.source).toBe(busy!.source);
+    expect(createCliAdapterSync('relay').busyPattern!.source).toBe(busy!.source);
+  });
+
   it('traex matches spinner-anchored working labels and standalone queue strings but not prose or idle composer', () => {
     // Regression: a static capacity-queue screen matches readyPattern's
     // `\d+% left` status-bar arm and survives the 2s quiescence window,


### PR DESCRIPTION
## 改了什么

claude-code 适配器此前只有 `readyPattern: /❯/`，而 Claude Code 工作时输入框 ❯ 常驻——idle 判定只剩「2s 静默」这一条负证据。长思考或三方网关延迟造成的一次 ≥2s PTY 停顿就会把工作中的会话错翻成 idle，且没有任何拉回手段（无 `busyPattern` ⇒ `deferPromptReadyWhileBusy()` 直接 return false；无 `idleToBusyPattern` ⇒ `onBusy` 永不触发），卡片钉死在绿色。

本 PR 给 claude-code 补上忙碌正证据双保险：

- `busyPattern: /(?<!press )esc to interrupt/`：工作态 footer 比空闲态多出「· esc to interrupt ·」一段，翻绿前先查屏幕，忙碌标志否决错翻
- `idleToBusyPattern`（同源）：已错翻的绿卡在下一帧被拉回工作中

## 为什么

- Claude Code 工作时 ❯ 常驻，正证据缺失导致只靠负证据判 idle
- 实测健康 turn 很难撞上（本机 60s 采样 435 次重绘最大间隔 0.43s），但走三方网关的长思考会话（秒级空窗）正好踩中
- 判别力实测：本机 242 个 tmux pane 扫末 3 行，命中 1 个（确实在工作），0 误报；空闲 footer 是「⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents」，不含该段

## 影响面

- def 由 claude-code / seed / relay 三个同源 fork 共享（渲染同一套 Claude Code TUI footer），对三者效果一致
- 不影响其它 CLI 适配器；未动 `adapters/cli/` 共用工具
- 负向后行断言排除「press esc to interrupt」散文形态（codex/traex 既有教训），防止正文引用提示语把闲卡翻忙
- ⚠️ `COMPLETION_RE` 的字形问题（✳U+2733 vs 屏幕 ✻U+273B）刻意未动：该分支无 spinner 守卫，单独修会新造提前翻绿 bug

## 测试验证

- `bunx vitest run test/cli-adapters.test.ts` — 441 passed（含新增回归用例：工作态 footer 命中、空闲态不命中、散文不命中、seed/relay 共享 def）
- `bun run build` — 通过，audit 无异常
- `bun run daemon:restart` — 已在 live daemon 验证加载