### PR TITLE
feat(dashboard,worker): 直达入口恢复无边框工作台，并修 Web 终端滚动条样式

### DIFF
--- a/docs/agent-workbench.md
+++ b/docs/agent-workbench.md
@@ -84,10 +84,12 @@ botmux dashboard
 工作台: http://<lan-ip>:7891/workbench?t=<token>
 
 # 已绑定中心平台 —— 不带 token，身份由平台注入 + SSO 认
-工作台: https://m-<machineId>.<平台域名>/#/agent-workbench
+工作台: https://m-<machineId>.<平台域名>/#/agent-workbench?botmuxWorkbenchShell=immersive
 ```
 
-两种形态浏览器打开都直达工作台（带 token 的 `/workbench` 会 302 到 `/#/agent-workbench`；不带 token 的直接就是 hash 路由，因为 `/workbench` 在无凭证时会被门禁 401）。
+两种形态浏览器打开都直达工作台（带 token 的 `/workbench` 会 302 到 `/#/agent-workbench?botmuxWorkbenchShell=immersive`；不带 token 的直接就是 hash 路由，因为 `/workbench` 在无凭证时会被门禁 401）。
+
+hash 里的 `botmuxWorkbenchShell=immersive` 是**沉浸式标记**：带着它进来的工作台是一整屏的无边框壳（没有 Dashboard 的顶栏和侧栏），`/dashboard` 卡片的「打开工作台」按钮、`botmux dashboard` 打印的链接、常驻链接和短票兑换这些直达入口都落在这种形态；从 Dashboard 侧边栏「驾驶舱」点进去的 `#/agent-workbench` 不带标记，保持正常壳，方便继续在侧栏间切换。页面加载后标记会被提升进查询串（`/?botmuxWorkbenchShell=immersive#/agent-workbench`），之后选中会话切换 hash 也不会丢。
 
 绑定平台后链接不再带 token 是有意的：走平台子域时 `?t=` 会被服务端压制成无效，token 对访问毫无贡献、只剩被转发截图的泄漏风险。注意判据是「**是否由中心平台托管**」而非「有没有远程基址」——自建反代与 Devbox 短链没有人注入身份，token 仍是唯一凭证，对它们摘 token 会摘成死链。那条带 token 的本地直连兜底链接默认不打印，需要时按命令输出里提示的参数取回（该参数不进 `--help`，避免 AI 顺手带上）。怀疑链接泄露时可用 `botmux dashboard rotate` 轮换 token，旧链接与已发出的卡片按钮立即作废。
 
@@ -97,10 +99,11 @@ botmux dashboard
 
 | 地址 | 打开什么 |
 |---|---|
-| `https://<dashboard>/#/agent-workbench` | 完整工作台 |
+| `https://<dashboard>/#/agent-workbench` | 完整工作台（带 Dashboard 侧栏，与侧边栏「驾驶舱」一致） |
+| `https://<dashboard>/#/agent-workbench?botmuxWorkbenchShell=immersive` | 完整工作台，沉浸式无边框壳 |
 | `https://<dashboard>/#/agent-workbench/<会话id>` | 完整工作台并定位到某个会话 |
 | `https://<dashboard>/#/agent-workbench-dock` | 会话坞（侧边栏形态） |
-| `https://<dashboard>/workbench`、`/workbench/dock` | 同上两个入口的无 `#` 跳板（自动 302） |
+| `https://<dashboard>/workbench`、`/workbench/dock` | 同上两个入口的无 `#` 跳板（自动 302 到沉浸式形态） |
 
 ### 3.4 手机加桌（PWA）
 

--- a/src/core/dashboard-url.ts
+++ b/src/core/dashboard-url.ts
@@ -5,6 +5,7 @@ import {
 } from '../platform/binding.js';
 import { isRemoteAccessEnabled } from '../global-config.js';
 import { devboxDashboardBaseUrl } from '../platform/devbox-dashboard-export.js';
+import { immersiveWorkbenchHash } from './workbench-shell.js';
 
 export interface DashboardUrls {
   /**
@@ -142,25 +143,28 @@ export const WORKBENCH_HASH_ROUTE = '#/agent-workbench';
 
 /**
  * 把一条 Dashboard 登录 URL（`<base>/?t=<token>`，见 {@link buildDashboardUrls}）
- * 改写成**工作台直达** URL：`<base>/?t=<token>#/agent-workbench`。
+ * 改写成**工作台直达** URL：`<base>/?t=<token>#/agent-workbench?botmuxWorkbenchShell=immersive`。
  *
- * 用于飞书卡片的「打开工作台」按钮：token 留在查询串里（Dashboard 的鉴权只认
- * `?t=`），hash 只负责选路由，所以两者可以共存。非 http/https 或不可解析的
- * 输入返回 null，调用方据此不渲染按钮，绝不拼出半截链接。
+ * 用于飞书卡片的「打开工作台」按钮与平台托管时 CLI 打印的工作台链接：token 留在
+ * 查询串里（Dashboard 的鉴权只认 `?t=`），hash 只负责选路由，所以两者可以共存。
+ * hash 里的沉浸式标记让直达入口落成无边框壳（不带 Dashboard 侧栏），登录跳转剥
+ * 查询串时它跟着 fragment 一起活下来（见 core/workbench-shell.ts）。非 http/https
+ * 或不可解析的输入返回 null，调用方据此不渲染按钮，绝不拼出半截链接。
  */
 export function workbenchSpaUrl(dashboardUrl: string): string | null {
   const u = parseHttpUrl(dashboardUrl);
   if (!u) return null;
-  u.hash = WORKBENCH_HASH_ROUTE;
+  u.hash = immersiveWorkbenchHash(WORKBENCH_HASH_ROUTE);
   return u.toString();
 }
 
 /**
  * 无 fragment 的工作台入口：`<base>/workbench?t=<token>`。
  *
- * Dashboard 自己 302 到 `/?t=…#/agent-workbench`（见 dashboard.ts 的 `/workbench`
- * 分支）。终端/脚本里复制粘贴一条不带 `#` 的 URL 更不容易被截断或被 shell 当注释，
- * 所以 CLI 打印这一形态。同样在无法解析时返回 null。
+ * Dashboard 自己 302 到 `/?t=…#/agent-workbench?botmuxWorkbenchShell=immersive`
+ * （见 dashboard.ts 的 `/workbench` 分支；直达入口落沉浸式无边框壳，标记的来龙去脉
+ * 见 core/workbench-shell.ts）。终端/脚本里复制粘贴一条不带 `#` 的 URL 更不容易被
+ * 截断或被 shell 当注释，所以 CLI 打印这一形态。同样在无法解析时返回 null。
  *
  * ⚠️ 这是**唯一**保留「长期 token 直拼进 URL」的形态，只出现在两个**私人上下文**：
  *   1. `botmux dashboard` 的终端输出（cli/dashboard-command.ts，终端是私人环境）；

--- a/src/core/workbench-shell.ts
+++ b/src/core/workbench-shell.ts
@@ -1,0 +1,34 @@
+/**
+ * 工作台「沉浸式」壳标记——从直达入口进工作台时不带 Dashboard 的 topbar / 侧栏。
+ *
+ * 背景：#948 之后 `#/agent-workbench` 从侧边栏「驾驶舱」进入时套普通 Dashboard 壳，
+ * 无边框只留给桌面 / 移动客户端（`botmuxClientShell`）。但 `/dashboard` 卡片的
+ * 「打开工作台」按钮、`botmux dashboard` 打印的工作台链接、常驻链接、短票兑换这些
+ * **直达入口**，语义上就是「一整屏工作台」，不该落进带侧栏的壳。它们统一在目标 hash
+ * 里带上本标记，前端认到就渲染无边框壳；侧栏导航不带标记，仍是正常壳。
+ *
+ * 标记放在 **hash 查询串**而不是 `?` 查询串：`?t=<token>` 登录跳转会把查询串整个
+ * 剥掉（auth.ts 的 `allow+set-cookie`），而浏览器跟随无 fragment 的 302 时会保留
+ * 原 fragment；前端启动时再把它提升进查询串（client-shell.ts），之后的 hash 导航
+ * （选中会话改成 `#/agent-workbench/<id>`）才不会把标记冲掉。与 `botmuxClientShell`
+ * 同一套机制，但**不**复用它——客户端壳还会过滤导航、拦 Workflow / Web 终端路由，
+ * 网页直达入口不该被连带限制。
+ *
+ * 本模块保持零依赖：Dashboard 服务端（auth / 路由 / 票据）与 web bundle 都从这里
+ * 取常量，避免两边手写字符串漂移。
+ */
+
+export const WORKBENCH_SHELL_PARAM = 'botmuxWorkbenchShell';
+export const WORKBENCH_SHELL_IMMERSIVE = 'immersive';
+export type DashboardWorkbenchShell = typeof WORKBENCH_SHELL_IMMERSIVE;
+
+/** `#/agent-workbench` → `#/agent-workbench?botmuxWorkbenchShell=immersive`。 */
+export function immersiveWorkbenchHash(hashRoute: string): string {
+  return `${hashRoute}?${WORKBENCH_SHELL_PARAM}=${WORKBENCH_SHELL_IMMERSIVE}`;
+}
+
+/** 完整工作台 / 会话坞的沉浸式 hash，以及服务端 302 用的入口（以 `/` 开头）。 */
+export const WORKBENCH_IMMERSIVE_HASH = immersiveWorkbenchHash('#/agent-workbench');
+export const WORKBENCH_DOCK_IMMERSIVE_HASH = immersiveWorkbenchHash('#/agent-workbench-dock');
+export const WORKBENCH_IMMERSIVE_ENTRY = `/${WORKBENCH_IMMERSIVE_HASH}`;
+export const WORKBENCH_DOCK_IMMERSIVE_ENTRY = `/${WORKBENCH_DOCK_IMMERSIVE_HASH}`;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -163,6 +163,7 @@ import {
   workbenchEntryUrl,
   type DashboardUrls,
 } from './core/dashboard-url.js';
+import { WORKBENCH_DOCK_IMMERSIVE_HASH, WORKBENCH_IMMERSIVE_HASH } from './core/workbench-shell.js';
 import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { parseCloseResidual, type ParsedCloseResidual } from './core/close-residual.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
@@ -3890,10 +3891,12 @@ const server = createServer(async (req, res) => {
     // `/s/<id>?token=` URL; ours carried `#/agent-workbench`, and a fragment is
     // the one structural difference between the two. Clients that re-encode or
     // truncate an AppLink's `url` lose it and land on the Dashboard home, so
-    // offer a path that survives regardless.
+    // offer a path that survives regardless. These are direct entries, so the
+    // target hash carries the immersive (chrome-less) marker — the sidebar's
+    // own `#/agent-workbench` keeps the normal shell (core/workbench-shell.ts).
     if ((req.method === 'GET' || req.method === 'HEAD')
       && (url.pathname === '/workbench' || url.pathname === '/workbench/dock')) {
-      const target = url.pathname === '/workbench/dock' ? '#/agent-workbench-dock' : '#/agent-workbench';
+      const target = url.pathname === '/workbench/dock' ? WORKBENCH_DOCK_IMMERSIVE_HASH : WORKBENCH_IMMERSIVE_HASH;
       const token = url.searchParams.get('t');
       const query = token ? `?t=${encodeURIComponent(token)}` : '';
       res.writeHead(302, { location: `/${query}${target}`, 'cache-control': 'no-store' });

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -1,5 +1,7 @@
 import { randomBytes, createHmac, timingSafeEqual } from 'node:crypto';
 import { dirname } from 'node:path';
+
+import { WORKBENCH_DOCK_IMMERSIVE_ENTRY, WORKBENCH_IMMERSIVE_ENTRY } from '../core/workbench-shell.js';
 import {
   readSecureHostFileSync,
   UnsafeHostAuthorityFileError,
@@ -495,11 +497,12 @@ export function decideDashboardAuth(opts: {
       // The fragment-free Workbench entries are redirects themselves. Sending
       // the cleaned URL back to the same path would bounce between "strip the
       // token" and "redirect again", so resolve them to their real destination
-      // in this one hop.
+      // in this one hop. They are direct entries, so the destination carries the
+      // immersive (chrome-less) marker — see core/workbench-shell.ts.
       redirectTo: pathname === '/workbench'
-        ? '/#/agent-workbench'
+        ? WORKBENCH_IMMERSIVE_ENTRY
         : pathname === '/workbench/dock'
-          ? '/#/agent-workbench-dock'
+          ? WORKBENCH_DOCK_IMMERSIVE_ENTRY
           : pathname || '/',
     };
   }

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -36,6 +36,7 @@ import {
   canonicalDashboardClientShellUrl,
   dashboardClientShellRedirect,
   readDashboardClientShell,
+  readDashboardWorkbenchShell,
 } from './client-shell.js';
 import { dashboardLoginHref } from './auth-login.js';
 import { ToastStack } from './toast.js';
@@ -117,8 +118,8 @@ const NAV_ITEMS: NavItem[] = [
   },
   { id: 'sessions', href: '#/sessions', labelKey: 'nav.sessions', icon: <path d="M2 3.5h12v7H6l-3 3v-3H2z" /> },
   {
-    // 驾驶舱（Agent Workbench）：桌面/移动壳内仍是无边框壳（见 workbenchSurface），
-    // 从侧边栏进入时走正常壳。不属于 manage 项。
+    // 驾驶舱（Agent Workbench）：桌面/移动壳内与带沉浸式标记的直达入口是无边框壳
+    // （见 workbenchSurface），从侧边栏进入时走正常壳。不属于 manage 项。
     id: 'agent-workbench',
     href: '#/agent-workbench',
     labelKey: 'nav.workbench',
@@ -1231,11 +1232,13 @@ function DashboardShell(): React.JSX.Element {
     expiredShown = false;
     setAuthExpiredOpen(false);
   };
-  // 工作台默认是无边框壳（没有 topbar / 侧栏），但无边框只留给桌面 / 移动客户端
-  // （botmuxClientShell）：从侧边栏等网页入口点进 #/agent-workbench 时必须保持正常
-  // 壳，否则导航一去不回。client-shell 参数可能挂在 search 也可能挂在 hash（桌面端
-  // 为过登录重定向把壳标记放在 hash 里），readDashboardClientShell 两种都认。
-  const workbenchSurface = readDashboardClientShell()
+  // 工作台默认是无边框壳（没有 topbar / 侧栏），但无边框只留给两类入口：桌面 / 移动
+  // 客户端（botmuxClientShell），以及带沉浸式标记的直达入口（botmuxWorkbenchShell，
+  // `/workbench`、短票兑换、卡片按钮与 CLI 打印的链接都 302 到这种 hash，见
+  // core/workbench-shell.ts）。从侧边栏等网页入口点进 #/agent-workbench 时必须保持
+  // 正常壳，否则导航一去不回。两种标记都可能挂在 search 或 hash（为过登录重定向把
+  // 标记放在 hash 里，启动时再提升进 search），reader 两种都认。
+  const workbenchSurface = (readDashboardClientShell() || readDashboardWorkbenchShell())
     ? activeHash.startsWith('#/agent-workbench-dock')
       ? 'dock'
       : activeHash.startsWith('#/agent-workbench')

--- a/src/dashboard/web/client-shell.ts
+++ b/src/dashboard/web/client-shell.ts
@@ -1,3 +1,9 @@
+import {
+  WORKBENCH_SHELL_IMMERSIVE,
+  WORKBENCH_SHELL_PARAM,
+  type DashboardWorkbenchShell,
+} from '../../core/workbench-shell.js';
+
 export type DashboardClientShell = 'desktop' | 'mobile';
 
 const CLIENT_SHELL_PARAM = 'botmuxClientShell';
@@ -9,30 +15,71 @@ function normalizeClientShell(value: string | null): DashboardClientShell | null
     : null;
 }
 
+function normalizeWorkbenchShell(value: string | null): DashboardWorkbenchShell | null {
+  return value === WORKBENCH_SHELL_IMMERSIVE ? value : null;
+}
+
 /**
- * Upgrade a legacy hash-scoped shell marker into the durable URL query.
- * Returns the replacement URL, or null when no rewrite is needed/possible.
+ * Markers that must survive hash navigation. Both ride the hash on entry
+ * (login redirects strip the query, browsers keep the fragment) and get
+ * promoted into the durable URL query on boot by
+ * {@link canonicalDashboardClientShellUrl}.
+ */
+const DURABLE_SHELL_MARKERS: ReadonlyArray<{
+  param: string;
+  normalize: (value: string | null) => string | null;
+}> = [
+  { param: CLIENT_SHELL_PARAM, normalize: normalizeClientShell },
+  { param: WORKBENCH_SHELL_PARAM, normalize: normalizeWorkbenchShell },
+];
+
+/**
+ * Upgrade hash-scoped shell markers (client shell, immersive workbench) into
+ * the durable URL query. Returns the replacement URL, or null when no rewrite
+ * is needed/possible. A marker already present in the query is left alone.
  */
 export function canonicalDashboardClientShellUrl(href: string): string | null {
   try {
     const url = new URL(href);
-    if (normalizeClientShell(url.searchParams.get(CLIENT_SHELL_PARAM))) return null;
-
     const queryIndex = url.hash.indexOf('?');
     if (queryIndex < 0) return null;
-    const hashParams = new URLSearchParams(url.hash.slice(queryIndex + 1));
-    const shell = normalizeClientShell(hashParams.get(CLIENT_SHELL_PARAM));
-    if (!shell) return null;
-
     const hashPath = url.hash.slice(0, queryIndex) || '#/';
-    hashParams.delete(CLIENT_SHELL_PARAM);
+    const hashParams = new URLSearchParams(url.hash.slice(queryIndex + 1));
+
+    let moved = false;
+    for (const { param, normalize } of DURABLE_SHELL_MARKERS) {
+      if (normalize(url.searchParams.get(param))) continue;
+      const value = normalize(hashParams.get(param));
+      if (!value) continue;
+      hashParams.delete(param);
+      url.searchParams.set(param, value);
+      moved = true;
+    }
+    if (!moved) return null;
+
     const remainingHashQuery = hashParams.toString();
-    url.searchParams.set(CLIENT_SHELL_PARAM, shell);
     url.hash = remainingHashQuery ? `${hashPath}?${remainingHashQuery}` : hashPath;
     return url.toString();
   } catch {
     return null;
   }
+}
+
+/** Query-string form first (durable), hash form as the entry-time fallback. */
+function readDurableShellMarker<T extends string>(
+  param: string,
+  normalize: (value: string | null) => T | null,
+  search: string,
+  hash: string,
+): T | null {
+  const fromSearch = normalize(
+    new URLSearchParams(search.startsWith('?') ? search.slice(1) : search).get(param),
+  );
+  if (fromSearch) return fromSearch;
+
+  const queryIndex = hash.indexOf('?');
+  if (queryIndex < 0) return null;
+  return normalize(new URLSearchParams(hash.slice(queryIndex + 1)).get(param));
 }
 
 /**
@@ -46,17 +93,20 @@ export function readDashboardClientShell(
   search = typeof location === 'undefined' ? '' : location.search,
   hash = typeof location === 'undefined' ? '' : location.hash,
 ): DashboardClientShell | null {
-  const fromSearch = normalizeClientShell(
-    new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
-      .get(CLIENT_SHELL_PARAM),
-  );
-  if (fromSearch) return fromSearch;
+  return readDurableShellMarker(CLIENT_SHELL_PARAM, normalizeClientShell, search, hash);
+}
 
-  const queryIndex = hash.indexOf('?');
-  if (queryIndex < 0) return null;
-  return normalizeClientShell(
-    new URLSearchParams(hash.slice(queryIndex + 1)).get(CLIENT_SHELL_PARAM),
-  );
+/**
+ * Detect the immersive (chrome-less) Workbench entry — `/workbench`,
+ * `/workbench-ticket/<ticket>` and the CLI / card links land here. Unlike the
+ * client shell it only decides the Workbench surface: navigation filtering and
+ * route redirects stay client-shell-only (see `core/workbench-shell.ts`).
+ */
+export function readDashboardWorkbenchShell(
+  search = typeof location === 'undefined' ? '' : location.search,
+  hash = typeof location === 'undefined' ? '' : location.hash,
+): DashboardWorkbenchShell | null {
+  return readDurableShellMarker(WORKBENCH_SHELL_PARAM, normalizeWorkbenchShell, search, hash);
 }
 
 /** Workflow is deliberately outside the Botmux Desktop/Mobile integration. */

--- a/src/dashboard/workbench-ticket.ts
+++ b/src/dashboard/workbench-ticket.ts
@@ -8,6 +8,8 @@ import {
   withSecureHostParentSync,
 } from '../platform/secure-host-file.js';
 
+import { WORKBENCH_IMMERSIVE_ENTRY } from '../core/workbench-shell.js';
+
 import { buildSetCookie } from './auth.js';
 import { DashboardH5ExchangeGate, dashboardH5ClientIp } from './h5-auth.js';
 
@@ -498,7 +500,9 @@ export interface WorkbenchTicketRedemptionDeps {
  *  - 触发限流：429 + Retry-After + 无凭据提示页（在读任何盘之前就返回，见文件
  *    顶部 P1-10）。名额按尝试消耗，与 LocateRateLimiter 一致。
  *  - 票据有效（含 generation 命中）且有活跃 token：
- *    `Set-Cookie: botmux_dashboard_token=<active>` + 302 `/#/agent-workbench`。
+ *    `Set-Cookie: botmux_dashboard_token=<active>` + 302 进沉浸式工作台
+ *    （`/#/agent-workbench?botmuxWorkbenchShell=immersive`，卡片按钮是直达入口，
+ *    不带 Dashboard 侧栏，见 core/workbench-shell.ts）。
  *  - 票据有效但当前没有活跃 token（dashboard 从未发号）：302 进工作台但不种
  *    cookie，用户面对正常登录墙。这是旧「读不到 token 就发裸链接」行为的对位，
  *    绝不在匿名请求侧顺手铸造新 token。
@@ -534,7 +538,7 @@ export function handleWorkbenchTicketRedemption(
   // 兑不出新 cookie，也不会退化成「无 cookie 但仍然 302」的半通过。
   if (verifyWorkbenchTicket(ticket, Date.now(), workbenchTicketGeneration(token))) {
     res.writeHead(302, {
-      location: '/#/agent-workbench',
+      location: WORKBENCH_IMMERSIVE_ENTRY,
       'cache-control': 'no-store',
       ...(token ? { 'set-cookie': buildSetCookie(token) } : {}),
     });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17379,6 +17379,20 @@ body{display:flex;flex-direction:column;height:100vh;height:100dvh}
    and momentum here (not just on body), and reserve gestures for pinch-zoom so
    single-finger drag is driven manually by the touch handler below. */
 #terminal .xterm-viewport{overscroll-behavior:none;-webkit-overflow-scrolling:auto;touch-action:pinch-zoom}
+/* Scrollbar: Feishu's embedded webview (and any desktop with classic, non-overlay
+   scrollbars) paints the viewport's native bar as a wide light track that glares
+   against the dark terminal. Thin translucent thumb on a transparent track instead,
+   darker on hover. Standard scrollbar-* covers Firefox and Chromium 121+ (where
+   they take precedence); ::-webkit-scrollbar covers older Chromium and WebKit. The
+   viewport is xterm's real scroll container, so this is the only bar to style.
+   Neutral gray so it reads on both dark and light terminal themes. */
+#terminal .xterm-viewport{scrollbar-width:thin;scrollbar-color:rgba(140,148,170,.38) transparent}
+#terminal .xterm-viewport::-webkit-scrollbar{width:8px;height:8px}
+#terminal .xterm-viewport::-webkit-scrollbar-track{background:transparent}
+#terminal .xterm-viewport::-webkit-scrollbar-thumb{min-height:36px;border:2px solid transparent;border-radius:8px;
+  background:rgba(140,148,170,.38);background-clip:padding-box}
+#terminal .xterm-viewport::-webkit-scrollbar-thumb:hover{background:rgba(140,148,170,.6);background-clip:padding-box}
+#terminal .xterm-viewport::-webkit-scrollbar-corner{background:transparent}
 /* On touch, glyph cells are selectable text — a finger-drag over text starts
    native text selection (and the long-press callout) instead of scrolling,
    which is why blank areas scroll fine but text areas stall/won't move.

--- a/test/agent-workbench-route.test.ts
+++ b/test/agent-workbench-route.test.ts
@@ -29,6 +29,24 @@ describe('Agent Workbench route and surface integration', () => {
     expect(app).toContain('data-workbench-surface');
   });
 
+  // 直达入口（/workbench 跳板、?t= 登录跳转、短票兑换、CLI / 卡片链接）落沉浸式
+  // 无边框壳，靠 hash 里的 botmuxWorkbenchShell=immersive 标记；侧栏进入不带标记、
+  // 保持正常壳。钉死三处服务端目标都取自同一份常量，前端壳判定认这个标记。
+  it('direct entries land on the immersive surface; the sidebar keeps the shell', () => {
+    const app = readFileSync(join(process.cwd(), 'src/dashboard/web/app.tsx'), 'utf8');
+    expect(app).toContain('(readDashboardClientShell() || readDashboardWorkbenchShell())');
+
+    const dashboard = readFileSync(join(process.cwd(), 'src/dashboard.ts'), 'utf8');
+    expect(dashboard).toContain(
+      "url.pathname === '/workbench/dock' ? WORKBENCH_DOCK_IMMERSIVE_HASH : WORKBENCH_IMMERSIVE_HASH",
+    );
+    const auth = readFileSync(join(process.cwd(), 'src/dashboard/auth.ts'), 'utf8');
+    expect(auth).toContain('? WORKBENCH_IMMERSIVE_ENTRY');
+    expect(auth).toContain('? WORKBENCH_DOCK_IMMERSIVE_ENTRY');
+    const ticket = readFileSync(join(process.cwd(), 'src/dashboard/workbench-ticket.ts'), 'utf8');
+    expect(ticket).toContain('location: WORKBENCH_IMMERSIVE_ENTRY');
+  });
+
   // 工作台是无边框壳（没有 topbar/侧栏），登录态失效时 AuthExpiredOverlay 是它
   // **唯一**的自救出口。普通壳一直传着 loginUrl，工作台壳漏传 → 浮层退化成
   // 「访问链接已失效，知道了」的死胡同，一键登录按钮根本不渲染。两处必须一致。

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -961,6 +961,33 @@ describe('decideDashboardAuth — ?t=<token> cookie set redirect', () => {
     });
   });
 
+  it('?t=<correct> on the fragment-free Workbench entries → set-cookie + one-hop redirect into the immersive workbench', () => {
+    // `/workbench` 与 `/workbench/dock` 自己就是跳板，登录跳转直接落到真实目的地；
+    // 直达入口落沉浸式壳（hash 带 botmuxWorkbenchShell=immersive），不带侧栏。
+    expect(decideDashboardAuth({
+      method: 'GET',
+      pathname: '/workbench',
+      hasTokenParam: true,
+      presentedToken: TOK,
+      activeToken: TOK,
+    })).toEqual({
+      kind: 'allow+set-cookie',
+      token: TOK,
+      redirectTo: '/#/agent-workbench?botmuxWorkbenchShell=immersive',
+    });
+    expect(decideDashboardAuth({
+      method: 'GET',
+      pathname: '/workbench/dock',
+      hasTokenParam: true,
+      presentedToken: TOK,
+      activeToken: TOK,
+    })).toEqual({
+      kind: 'allow+set-cookie',
+      token: TOK,
+      redirectTo: '/#/agent-workbench-dock?botmuxWorkbenchShell=immersive',
+    });
+  });
+
   it('?t=<wrong> on protected route → deny401 (no cookie minted)', () => {
     const d = decideDashboardAuth({
       method: 'GET',

--- a/test/dashboard-command.test.ts
+++ b/test/dashboard-command.test.ts
@@ -361,7 +361,8 @@ describe('formatDashboardSuccessLines', () => {
     expect(lines[0]).toBe('https://m-abc.platform.test/');
     // 无凭证形态必须走 hash 路由：`/workbench` 不在静态壳白名单里，token-free
     // 访问是 401 死链（实测平台身份下同样 401）。
-    expect(lines[1]).toBe('工作台: https://m-abc.platform.test/#/agent-workbench');
+    // 直达入口带沉浸式标记（无边框壳），见 core/workbench-shell.ts。
+    expect(lines[1]).toBe('工作台: https://m-abc.platform.test/#/agent-workbench?botmuxWorkbenchShell=immersive');
     // 整段输出里不得再出现 token —— 这是本次改动的核心断言。
     expect(lines.join('\n')).not.toContain('tok-abc');
   });

--- a/test/dashboard-url.test.ts
+++ b/test/dashboard-url.test.ts
@@ -396,7 +396,7 @@ describe('workbench entry URL shapes', () => {
   });
 
   it('workbenchSpaUrl keeps the ?t= token and adds the SPA hash route', () => {
-    expect(workbenchSpaUrl(dashboardUrl)).toBe('http://1.2.3.4:7891/?t=abc#/agent-workbench');
+    expect(workbenchSpaUrl(dashboardUrl)).toBe('http://1.2.3.4:7891/?t=abc#/agent-workbench?botmuxWorkbenchShell=immersive');
   });
 
   it('workbenchEntryUrl swaps the path and drops the fragment', () => {
@@ -410,12 +410,12 @@ describe('workbench entry URL shapes', () => {
     setRemote(true);
     setPlatform('https://m-deadbeef.botmux.example');
     const { url } = buildDashboardUrls({ host: '1.2.3.4', port: 7891, token: 'abc' });
-    expect(workbenchSpaUrl(url)).toBe('https://m-deadbeef.botmux.example/?t=abc#/agent-workbench');
+    expect(workbenchSpaUrl(url)).toBe('https://m-deadbeef.botmux.example/?t=abc#/agent-workbench?botmuxWorkbenchShell=immersive');
     expect(workbenchEntryUrl(url)).toBe('https://m-deadbeef.botmux.example/workbench?t=abc');
   });
 
   it('tolerates a token-less dashboard URL (user logs in on arrival)', () => {
-    expect(workbenchSpaUrl('http://1.2.3.4:7891/')).toBe('http://1.2.3.4:7891/#/agent-workbench');
+    expect(workbenchSpaUrl('http://1.2.3.4:7891/')).toBe('http://1.2.3.4:7891/#/agent-workbench?botmuxWorkbenchShell=immersive');
     expect(workbenchEntryUrl('http://1.2.3.4:7891/')).toBe('http://1.2.3.4:7891/workbench');
   });
 

--- a/test/desktop/dashboard-client-shell.test.ts
+++ b/test/desktop/dashboard-client-shell.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  WORKBENCH_DOCK_IMMERSIVE_ENTRY,
+  WORKBENCH_IMMERSIVE_ENTRY,
+  WORKBENCH_IMMERSIVE_HASH,
+  immersiveWorkbenchHash,
+} from '../../src/core/workbench-shell.js';
+import {
   canonicalDashboardClientShellUrl,
   dashboardClientShellRedirect,
   dashboardShellAllowsWebTerminal,
   isWebTerminalDashboardHash,
   isWorkflowDashboardHash,
   readDashboardClientShell,
+  readDashboardWorkbenchShell,
 } from '../../src/dashboard/web/client-shell.js';
 
 describe('dashboard client shell', () => {
@@ -86,5 +93,50 @@ describe('dashboard client shell', () => {
       '?botmuxClientShell=desktop',
     )).toBeNull();
     expect(dashboardClientShellRedirect('#/monitor-room', '')).toBeNull();
+  });
+});
+
+describe('immersive workbench shell marker', () => {
+  it('pins the shared entry constants the server redirects to', () => {
+    expect(WORKBENCH_IMMERSIVE_HASH).toBe('#/agent-workbench?botmuxWorkbenchShell=immersive');
+    expect(WORKBENCH_IMMERSIVE_ENTRY).toBe('/#/agent-workbench?botmuxWorkbenchShell=immersive');
+    expect(WORKBENCH_DOCK_IMMERSIVE_ENTRY).toBe('/#/agent-workbench-dock?botmuxWorkbenchShell=immersive');
+    expect(immersiveWorkbenchHash('#/agent-workbench/s%2F1'))
+      .toBe('#/agent-workbench/s%2F1?botmuxWorkbenchShell=immersive');
+  });
+
+  it('reads the marker from the durable query and from the entry-time hash', () => {
+    expect(readDashboardWorkbenchShell('?botmuxWorkbenchShell=immersive', '#/agent-workbench'))
+      .toBe('immersive');
+    expect(readDashboardWorkbenchShell('', '#/agent-workbench?botmuxWorkbenchShell=immersive'))
+      .toBe('immersive');
+    expect(readDashboardWorkbenchShell('', '#/agent-workbench')).toBeNull();
+    expect(readDashboardWorkbenchShell('?botmuxWorkbenchShell=full', '#/agent-workbench')).toBeNull();
+  });
+
+  it('is not a client shell: navigation, terminals and redirects stay unrestricted', () => {
+    expect(readDashboardClientShell('?botmuxWorkbenchShell=immersive', '#/agent-workbench')).toBeNull();
+    expect(dashboardShellAllowsWebTerminal('?botmuxWorkbenchShell=immersive', '#/sessions')).toBe(true);
+    expect(dashboardClientShellRedirect('#/workflows/run-1', '?botmuxWorkbenchShell=immersive')).toBeNull();
+  });
+
+  it('canonicalizes the hash marker into the durable query, alone or beside the client shell', () => {
+    expect(canonicalDashboardClientShellUrl(
+      'https://botmux.example.test/#/agent-workbench?botmuxWorkbenchShell=immersive',
+    )).toBe(
+      'https://botmux.example.test/?botmuxWorkbenchShell=immersive#/agent-workbench',
+    );
+    expect(canonicalDashboardClientShellUrl(
+      'https://botmux.example.test/#/agent-workbench-dock?botmuxClientShell=desktop&botmuxWorkbenchShell=immersive',
+    )).toBe(
+      'https://botmux.example.test/?botmuxClientShell=desktop&botmuxWorkbenchShell=immersive#/agent-workbench-dock',
+    );
+    // 已经在查询串里的标记不重复搬运；hash 里没有任何可搬的标记时不改写。
+    expect(canonicalDashboardClientShellUrl(
+      'https://botmux.example.test/?botmuxWorkbenchShell=immersive#/agent-workbench/s%2F1',
+    )).toBeNull();
+    expect(canonicalDashboardClientShellUrl(
+      'https://botmux.example.test/#/agent-workbench?botmuxWorkbenchShell=full',
+    )).toBeNull();
   });
 });

--- a/test/workbench-ticket.test.ts
+++ b/test/workbench-ticket.test.ts
@@ -223,13 +223,13 @@ async function startRedemptionServer(
 }
 
 describe('GET /workbench-ticket/<ticket>', () => {
-  it('valid ticket → same legacy cookie as the ?t= flow + 302 into the workbench, no-store', async () => {
+  it('valid ticket → same legacy cookie as the ?t= flow + 302 into the immersive workbench, no-store', async () => {
     const ticket = mintWorkbenchTicket();
     const base = await startRedemptionServer(ACTIVE_TOKEN);
     const res = await fetch(`${base}/workbench-ticket/${ticket}`, { redirect: 'manual' });
 
     expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toBe('/#/agent-workbench');
+    expect(res.headers.get('location')).toBe('/#/agent-workbench?botmuxWorkbenchShell=immersive');
     // 与 ?t= 流程逐字同款的 cookie（HttpOnly / SameSite=Lax / Path=/）。
     expect(res.headers.get('set-cookie')).toBe(buildSetCookie(ACTIVE_TOKEN));
     expect(res.headers.get('cache-control')).toBe('no-store');
@@ -270,7 +270,7 @@ describe('GET /workbench-ticket/<ticket>', () => {
     const base = await startRedemptionServer(null);
     const res = await fetch(`${base}/workbench-ticket/${ticket}`, { redirect: 'manual' });
     expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toBe('/#/agent-workbench');
+    expect(res.headers.get('location')).toBe('/#/agent-workbench?botmuxWorkbenchShell=immersive');
     expect(res.headers.get('set-cookie')).toBeNull();
   });
 


### PR DESCRIPTION
## 改了什么

**1. 直达入口进沉浸式工作台（`feat(dashboard)`）**

- 新增 `src/core/workbench-shell.ts`：定义工作台沉浸式标记 `botmuxWorkbenchShell=immersive`，以及服务端三处共用的 302 目标常量（零依赖，服务端与 web bundle 共用一份）。
- 三个直达入口改为 302 到带标记的 hash：`/workbench`、`/workbench/dock` 跳板（`dashboard.ts`）、`?t=` 登录一跳（`dashboard/auth.ts`）、`/workbench-ticket/<ticket>` 兑换（`dashboard/workbench-ticket.ts`）。
- `workbenchSpaUrl`（无凭证兜底链接、平台托管时 CLI 打印的工作台链接）同样带标记。
- 前端 `client-shell.ts` 新增 `readDashboardWorkbenchShell`，启动时把标记与 `botmuxClientShell` 一样从 hash 提升进查询串（之后 hash 导航不丢）；`app.tsx` 壳判定认到标记即渲染无边框壳。
- `docs/agent-workbench.md` 补充入口形态说明。

**2. Web 终端滚动条改细（`fix(worker)`）**

- 给 `#terminal .xterm-viewport` 补滚动条样式：轨道透明、拇指细且半透明、悬停加深。标准 `scrollbar-*` 覆盖 Firefox 与 Chromium 121+，`::-webkit-scrollbar` 覆盖旧 Chromium / WebKit。

## 为什么

- #948 之后 `#/agent-workbench` 只在桌面/移动客户端壳里无边框，浏览器一律套 Dashboard 外壳。于是 `/dashboard` 卡片「打开工作台」按钮、`botmux dashboard` 打印的工作台链接、常驻链接、短票兑换这些**直达入口**全部落进了带侧栏的壳，与「一整屏工作台」的定位相悖。改后直达入口恢复无边框；侧边栏「驾驶舱」进入不带标记，保持正常壳（保留 #948「从侧栏进来要能回去」的意图）。标记不复用 `botmuxClientShell`：客户端壳还会过滤导航、拦 Workflow / Web 终端路由，网页直达入口不该被连带限制。
- 飞书内嵌 webview（以及任何用经典非悬浮滚动条的桌面环境）会把 xterm viewport 的原生滚动条画成白底粗条，压在暗色终端上非常扎眼。

## 影响面

- 模块：dashboard 服务端（auth 一跳、`/workbench` 跳板、短票兑换）、`core/dashboard-url`（`workbenchSpaUrl`）、dashboard web（client-shell、app 壳判定）、worker 提供的 Web 终端页样式。daemon 消息链路 / adapters / 卡片内容不涉及。
- 会话类型：与会话类型无关，只影响工作台入口 URL 的落点形态与终端页样式。
- 平台：飞书卡片按钮（PC AppLink / 移动端裸 URL）、CLI 输出、常驻链接、浏览器书签都会落沉浸式壳；桌面 / 移动客户端壳行为不变（仍由 `botmuxClientShell` 决定）。飞书 H5 免登的 returnTo 清洗器会丢 hash 查询串，这条路径与之前一致（未改）。终端页样式对桌面浏览器、工作台 iframe、飞书内嵌页是同一份 HTML，Reader / Classic 两种终端风格共用同一 viewport，均生效。

## 实际测试验证

- `tsc --noEmit` 通过；`bun run build`（含 audit:domains / audit-dist / audit-embedded）通过。
- `vitest run --project unit`：相关 15 个测试文件 471 项全绿，含新增用例：client-shell 标记读取 / 提升 / 不是客户端壳；auth `/workbench`、`/workbench/dock` 一跳目标；票据 302 目标；`workbenchSpaUrl` 带标记；源码钉死三处服务端目标取同一常量。全量 unit 套件失败项与同机 master 基线一致（均为 spawn / 环境类既有失败，本分支同条件下反而更少）。
- 隔离 HOME 起补丁版 dashboard（`node dist/index-dashboard.js`，端口 7999），Playwright 冷登录实测：`/workbench?t=`、`/workbench/dock?t=`、`/workbench-ticket/<ticket>` 三条都落到 `/?botmuxWorkbenchShell=immersive#/agent-workbench(-dock)`，无侧栏、有会话列表；改 hash 到 `#/agent-workbench/<id>` 后仍保持无边框；`/?t=#/agent-workbench`（侧栏形态）仍是正常壳。curl 核对三处 302 的 Location 与 set-cookie 与预期一致。
- 本机 fleet 已 `switch:here` + `restart` 跑本分支 live 验证：真实会话下 `/workbench?t=` 打开为无边框、打开终端面板与切换会话后保持；终端 iframe 内 `getComputedStyle(viewport)` 为 `scrollbar-width: thin` + 自定义 `scrollbar-color`，截图确认拇指细且半透明。
