### PR TITLE
fix(send): 返回附件消息 ID 以支持送达核验

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9943,6 +9943,15 @@ async function cmdSend(rest: string[]): Promise<void> {
     let feedbackBaseCard: Record<string, unknown> | undefined;
     let failedAttachments: { path: string; error: string }[] = [];
     let failedVideoAttachments: { path: string; coverPath: string; error: string }[] = [];
+    // Message ids of the attachment messages themselves. Attachments go out as
+    // SEPARATE messages, so the primary `messageId` below can never carry them:
+    // a caller that verifies delivery by inspecting the primary message finds
+    // `msgType=interactive` with an empty `resources[]` whether the upload
+    // succeeded or failed, reads that as a silent failure, and resends. Both
+    // dispatch helpers already return these ids; surfacing them lets a caller
+    // assert "one id per requested attachment" instead of guessing.
+    let attachmentMessageIds: string[] = [];
+    let videoMessageIds: string[] = [];
     const pureVideoSend = customCard
       ? false
       : shouldSendAsPureVideo({
@@ -9996,6 +10005,7 @@ async function cmdSend(rest: string[]): Promise<void> {
         videoAttachments,
       );
       failedVideoAttachments = videoResult.failed;
+      videoMessageIds = videoResult.sent;
       if (videoResult.sent.length === 0) {
         const first = failedVideoAttachments[0]?.error ?? 'unknown error';
         throw new Error(`视频发送失败: ${first}`);
@@ -10174,13 +10184,14 @@ async function cmdSend(rest: string[]): Promise<void> {
     // message above is the primary and failures before any media is sent still
     // surface as command failure.
     if (!pureVideoSend && !vcMeetingListenerReplyReplay) {
-      ({ failed: failedAttachments } = await sendFileAttachments(
+      ({ sent: attachmentMessageIds, failed: failedAttachments } = await sendFileAttachments(
         { uploadFile, dispatch: dispatchAfterOriginGate, beforeEffect: fenceIsolatedOriginBeforeEffect }, appId, files,
       ));
       const videoResult = await sendVideoAttachments(
         { uploadFile, uploadImage, dispatch: dispatchAfterOriginGate, beforeEffect: fenceIsolatedOriginBeforeEffect }, appId, videoAttachments,
       );
       failedVideoAttachments = videoResult.failed;
+      videoMessageIds = videoResult.sent;
     }
     for (const f of failedAttachments) {
       console.error(`⚠️ 附件未发送（主消息已送达 ${messageId}，请勿重发）: ${f.path} — ${f.error}`);
@@ -10195,6 +10206,12 @@ async function cmdSend(rest: string[]): Promise<void> {
     // --mention 的 open_id 解析（在上方 mentions 数组里完成）仍然必要，它让
     // Lark 在消息里渲染真正的 @at 元素，从而触发对方 bot 的 WS 事件投递。
 
+    if (attachmentMessageIds.length > 0 || videoMessageIds.length > 0) {
+      console.error(
+        `   附件消息: ${[...attachmentMessageIds, ...videoMessageIds].join(', ')}`
+        + `（附件是独立消息，主消息 ${messageId} 上查不到它们）`,
+      );
+    }
     const atSummary = mentions.length > 0
       ? `@${mentions.map(m => m.name || m.open_id).join(',')}`
       : '未@任何人';
@@ -10278,6 +10295,8 @@ async function cmdSend(rest: string[]): Promise<void> {
         ? { deferredTopicRootMessageId: deferredTopicRootMessageIdForOutput, turnId: currentTurnId }
         : {}),
       ...(attention.requested ? { attentionRaised, attentionError } : {}),
+      ...(attachmentMessageIds.length > 0 ? { attachmentMessageIds } : {}),
+      ...(videoMessageIds.length > 0 ? { videoMessageIds } : {}),
       ...(failedAttachments.length > 0
         ? { failedAttachments: failedAttachments.map(f => f.path) }
         : {}),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10206,9 +10206,17 @@ async function cmdSend(rest: string[]): Promise<void> {
     // --mention 的 open_id 解析（在上方 mentions 数组里完成）仍然必要，它让
     // Lark 在消息里渲染真正的 @at 元素，从而触发对方 bot 的 WS 事件投递。
 
-    if (attachmentMessageIds.length > 0 || videoMessageIds.length > 0) {
+    // On the pure-video path the first video IS the primary message
+    // (`messageId = videoResult.sent[0]` above), so listing it here would print
+    // the primary id while claiming the primary message cannot carry it.
+    // Filtering by id keeps one wording correct on every path instead of
+    // branching on `pureVideoSend`; the JSON fields stay unfiltered so the
+    // caller's "one id per requested attachment" check is unaffected.
+    const separateAttachmentMessageIds = [...attachmentMessageIds, ...videoMessageIds]
+      .filter(id => id !== messageId);
+    if (separateAttachmentMessageIds.length > 0) {
       console.error(
-        `   附件消息: ${[...attachmentMessageIds, ...videoMessageIds].join(', ')}`
+        `   附件消息: ${separateAttachmentMessageIds.join(', ')}`
         + `（附件是独立消息，主消息 ${messageId} 上查不到它们）`,
       );
     }

--- a/test/send-attachment-message-ids-wiring.test.ts
+++ b/test/send-attachment-message-ids-wiring.test.ts
@@ -103,4 +103,22 @@ describe('send 附件消息 id 的接线（helper 返回 ≠ cmdSend 输出）',
     expect(block).toMatch(/attachmentMessageIds\.length > 0 \? \{ attachmentMessageIds \}/);
     expect(block).toMatch(/videoMessageIds\.length > 0 \? \{ videoMessageIds \}/);
   });
+
+  it('stderr 提示排除掉「就是主消息」的那一条，JSON 侧不受影响', () => {
+    // 纯视频路径下 `messageId = videoResult.sent[0]`，于是 videoMessageIds[0] === messageId。
+    // 提示行若不过滤就会打印「附件消息: om_X（附件是独立消息，主消息 om_X 上查不到它们）」——
+    // 列出的那个 id 就是主消息自己。单视频无正文是该路径最常见的用法，会稳定触发。
+    const code = cliSource.split('\n').filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+    // ① 过滤集合确实是「两个 id 数组减去主消息 id」
+    expect(code).toMatch(
+      /const separateAttachmentMessageIds = \[\.\.\.attachmentMessageIds, \.\.\.videoMessageIds\]\s*\.filter\(id => id !== messageId\);/,
+    );
+    // ② 提示行用的是过滤后的集合，不是原始拼接（回到原形态即红）
+    const hint = blockFrom('separateAttachmentMessageIds.length > 0');
+    expect(hint).toContain('separateAttachmentMessageIds.join');
+    expect(hint).not.toContain('...attachmentMessageIds, ...videoMessageIds');
+    // ③ JSON 侧必须仍输出**未过滤**的完整数组，否则调用方「要几个附件就该有几个 id」
+    //    这条核验判据会在纯视频路径下少一个而误判成上传失败。
+    expect(successJsonBlock()).not.toContain('separateAttachmentMessageIds');
+  });
 });

--- a/test/send-attachment-message-ids-wiring.test.ts
+++ b/test/send-attachment-message-ids-wiring.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `botmux send` 把**附件消息 id** 交给调用方的**接线**回归。
+ *
+ * 为什么需要这个文件：`sendFileAttachments` / `sendVideoAttachments` 返回的 `sent`
+ * 在 `test/cli-send-dispatch.test.ts` 里已经有覆盖（全成功/部分失败/全失败三种），
+ * 但 helper 全绿**不能**证明 `cmdSend` 没有再次把它丢掉 —— 本次缺陷恰好就发生在这一层：
+ * 调用处长期只解构 `failed`，`sent` 从未进入任何输出，于是「核验刚发出的消息带不带附件」
+ * 这个判据永远不成立，调用方把成功判成静默失败并重发（实测一份文件被重发 3 次）。
+ *
+ * 所以这里按源码钉住整条接线：两个 dispatch 的 `sent` 都被接住、都进入最终 JSON、
+ * 且失败字段不被顶掉、字段是按非空条件输出（全失败时不冒充成功）。
+ *
+ * Run: bunx vitest run test/send-attachment-message-ids-wiring.test.ts
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliSource = readFileSync(join(__dirname, '..', 'src', 'cli.ts'), 'utf8');
+
+/** 按真实大括号配对取块，不用固定行宽：窄了会被新增几行推出窗口（干净代码变红），
+ *  宽了会越过闭合括号（把块外的内容也算进来，断言失去意义）。同时剔除注释行，
+ *  避免把代码注释掉之后、注释里残留的同样字符仍然满足断言。 */
+function blockFrom(anchor: string): string {
+  const lines = cliSource.split('\n');
+  const hits = lines.filter(l => l.includes(anchor)).length;
+  if (hits === 0) throw new Error(`anchor not found: ${anchor}`);
+  // 锚点必须唯一：`console.log(JSON.stringify({` 这类在本文件里有 30+ 处，
+  // 取第一处会安静地断言到别的代码块上（本测试第一版就踩了这个）。
+  if (hits > 1) throw new Error(`anchor is ambiguous (${hits} hits): ${anchor}`);
+  const start = lines.findIndex(l => l.includes(anchor));
+  let depth = 0;
+  const out: string[] = [];
+  for (let i = start; i < lines.length; i++) {
+    out.push(lines[i]);
+    for (const ch of lines[i]) {
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+    }
+    if (i > start && depth <= 0) break;
+  }
+  return out.filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+}
+
+/** 成功 JSON 那个对象字面量：`console.log(JSON.stringify({` 在本文件有 30+ 处，
+ *  所以先用块内的唯一行定位，再回溯到它所属的那个 `JSON.stringify({`，
+ *  然后按括号配对取整块。这样锚点唯一，且块边界仍由括号决定。 */
+function successJsonBlock(): string {
+  const lines = cliSource.split('\n');
+  const uniq = 'quotedMessageId: primaryQuotedId,';
+  const hits = lines.filter(l => l.includes(uniq)).length;
+  if (hits !== 1) throw new Error(`inner anchor must be unique, got ${hits}`);
+  const inner = lines.findIndex(l => l.includes(uniq));
+  let open = -1;
+  for (let i = inner; i >= 0; i--) {
+    if (lines[i].includes('JSON.stringify({')) { open = i; break; }
+  }
+  if (open < 0) throw new Error('enclosing JSON.stringify({ not found');
+  let depth = 0;
+  const out: string[] = [];
+  for (let i = open; i < lines.length; i++) {
+    out.push(lines[i]);
+    for (const ch of lines[i]) {
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+    }
+    if (i > open && depth <= 0) break;
+  }
+  return out.filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+}
+
+describe('send 附件消息 id 的接线（helper 返回 ≠ cmdSend 输出）', () => {
+  it('文件附件的 sent 被接住，不是只解构 failed', () => {
+    const block = blockFrom('await sendFileAttachments(');
+    expect(block).toContain('sent: attachmentMessageIds');
+    expect(block).toContain('failed: failedAttachments');
+  });
+
+  it('视频附件的 sent 在每一个消费 failed 的调用点都被接住', () => {
+    // 只数**赋值语句本身**，不要数"提到 videoResult.sent"的行：
+    // 纯视频路径里有一处 `if (videoResult.sent.length === 0)` 的失败判断也含这个串，
+    // 把它算进来会让计数凑够、于是删掉一处真正的赋值仍然全绿（本测试第一版就是这样漏的）。
+    const code = cliSource.split('\n').filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l));
+    const failedAssign = code.filter(l => l.includes('failedVideoAttachments = videoResult.failed;')).length;
+    const sentAssign = code.filter(l => l.includes('videoMessageIds = videoResult.sent;')).length;
+    expect(failedAssign).toBeGreaterThan(0);
+    expect(sentAssign).toBe(failedAssign);
+  });
+
+  it('两个 id 数组都进入最终成功 JSON，且失败字段仍在', () => {
+    const block = successJsonBlock();
+    expect(block).toContain('attachmentMessageIds');
+    expect(block).toContain('videoMessageIds');
+    // 回归护栏：新字段不得把既有失败字段顶掉
+    expect(block).toContain('failedAttachments');
+    expect(block).toContain('failedVideoAttachments');
+  });
+
+  it('id 字段按非空条件输出：全失败时不冒充成功', () => {
+    const block = successJsonBlock();
+    expect(block).toMatch(/attachmentMessageIds\.length > 0 \? \{ attachmentMessageIds \}/);
+    expect(block).toMatch(/videoMessageIds\.length > 0 \? \{ videoMessageIds \}/);
+  });
+});


### PR DESCRIPTION
## 问题

`--files` 与 `--videos` 的附件是**作为独立消息**发出的，但 `cmdSend` 只回报**主消息**的 id。（`--images` 不同：它经 `buildImageCardElements` **内嵌进主卡片**，是唯一在主消息上查得到的附件类型——所以本 PR 只补 files / videos 两个字段。）于是任何"发完核验刚拿到的那条消息带不带附件"的调用方，看到的永远是 `msgType=interactive` + 空的 `resources[]` —— **上传成功还是失败都一样** —— 它据此判定静默失败，然后重发。

我们在生产上撞到了：一份业务文件**第一次就送到了**，却被核验成"没送到"，接着**重发了三次**（外加两条诊断消息）才找到原因。这不是调用方写错了：它执行的正是自己那份技能说明要求的动作（"确认已发消息带附件资源，确认后删除本地源文件"），而以 `send` 目前返回的信息，**这个核验永远不可能成立**。

两个连带影响：

- "确认送达后删除本地文件"这一步**永远不会执行**（确认永远不成立），导出文件因此持续堆积；
- 与"未知 flag 被静默接受"（`botmux send --definitely-not-a-real-flag` 仍打印 `✓ 已发送`）叠加后会得到反方向的故障：`--files` 拼错时命令报成功、附件从未尝试上传、也没有任何提示。

## 需要的数据早就算出来了，只是被丢掉

`sendFileAttachments` 与 `sendVideoAttachments` 都返回 `{ sent, failed }`，而 `sent` 在 `src/cli/send-dispatch.ts` 的类型定义里就注释为 *"message ids of delivered attachments"*。调用处只解构了 `failed`：

```js
({ failed: failedAttachments } = await sendFileAttachments(…));   // src/cli.ts
failedVideoAttachments = videoResult.failed;                       // 视频同样只取了 failed
```

所以 `sent` 从未进入任何输出路径。

有点讽刺的是 `src/cli/send-dispatch.ts` 里那段注释解释的正是"附件失败不能往上抛，否则 *drives resends and duplicates*"—— 那条路径守住了，而被丢掉的 `sent` 让重复从**核验**这条路径回来了。

## 改了什么

只是接线，4 行代码 + 注释：

- 接住两个 dispatch helper 返回的 `sent`（文件路径，以及视频的两个调用点）；
- 在成功 JSON 里以 `attachmentMessageIds` / `videoMessageIds` 输出（为空时省略，与既有的 `failedAttachments` 一致）；
- 增加一行 stderr 提示，说明附件是独立消息、主消息 id 上查不到它们。

调用方从此可以断言**"要发几个附件就应有几个 id"**，这一条同时挡住两个方向：真正上传失败（id 数量不足）、以及 flag 拼错导致压根没进上传流程（字段缺失）。

**影响面**：不删除、不修改任何既有字段与退出码，**仅新增兼容输出**（成功 JSON 多两个可选字段 + 一行 stderr）。忽略新字段的调用方不受影响。

## 测试

新增 `test/send-attachment-message-ids-wiring.test.ts`（4 条断言）。这里刻意采用本仓已有的**源码级接线回归**范式（参见 `test/send-after-the-fact-topic-quote-wiring.test.ts`，那个文件的注释写的正是"纯函数全绿不能证明 `cmdSend` 真的用了它"）：helper 层的 `sent` 在 `test/cli-send-dispatch.test.ts` 已有覆盖，但那证明不了 `cmdSend` 没有再次把它丢掉，而本次缺陷恰好就发生在这一层。

变异验证（先确认基线全绿，再逐条改坏）：

| 变异 | 新测试 |
| --- | --- |
| 基线 | 4 passed |
| 撤掉 `sent` 解构（回到缺陷原形态） | 1 failed ✅ |
| 删掉成功 JSON 里的 `attachmentMessageIds` | 2 failed ✅ |
| 删掉主路径的 `videoMessageIds = videoResult.sent` | 1 failed ✅ |
| 删掉纯视频路径的同一赋值 | 1 failed ✅ |
| 复原 | 4 passed |

**关键对照**：在第一个变异下**只跑既有的 `test/cli-send-dispatch.test.ts` → 44 passed**，即旧测试确实抓不到这个回归。

另：`tsc --noEmit` 干净；依赖用独立 clone 内的 `bun install --frozen-lockfile`（`node_modules` 是真实目录，非软链）。

## 有意留在本 PR 之外

- `send` 静默接受未知 flag（上面提到的放大器）；
- `--files` **没有**出现在 `cli.ts:8903` 那条「没有内容可发送」的报错提示里（它只列了 `--content-file` / `--images` / `--videos`）。（`botmux send --help` 的用法块里 `--files` 是有的。）

需要一起改的话我可以补进来。


---

**更新（复审后）**：已按评审意见推一个 commit（`c3f43a9`）。纯视频路径下第一条视频本身就是主消息，提示行未区分会打印「`附件消息: om_X（附件是独立消息，主消息 om_X 上查不到它们）`」，列出的就是主消息自己。改法是按 id 过滤掉等于 `messageId` 的那条，一句措辞在三条路径上都成立，不需要引入 `pureVideoSend` 分支；成功 JSON 里的两个数组保持**不过滤**，否则调用方「几个附件几个 id」的核验会在纯视频路径下少一个。新增测试第 5 条附变异验证（无过滤 → 1 failed；去掉 `.filter` → 1 failed；把过滤后的数组泄进 JSON → 2 failed；复原 → 5 passed）。上面描述里关于 `--images` 和 `--help` 的两处不准确也一并更正了。
