### PR TITLE
fix(release): 为 macOS CLI 保留跨版本稳定代码身份

### DIFF
--- a/.github/workflows/cancel-stale-release-approvals.yml
+++ b/.github/workflows/cancel-stale-release-approvals.yml
@@ -1,15 +1,17 @@
 name: Cancel stale release approvals
 
-# 背景:Release workflow 的 `desktop` job（macOS 签名+公证）挂在 `environment:
-# macos-signing` 的人工审批 gate 上。GitHub 对「等待审批」的 pending 没有原生自动
-# 超时——job 的 timeout 不涵盖排队等审批的时间,environment 的 wait-timer 是「等 N
-# 分钟后自动放行」(反而会去发版),都不是我们要的「超期自动取消」。结果不想发
-# 桌面包时,run 会无限期停在 waiting(最长 30 天),在 deployments 页堆成一排。
+# 背景:Release workflow 的 `desktop` 与 `sign-darwin-binaries` job 都挂在
+# `environment: macos-signing` 的人工审批 gate 上。GitHub 对「等待审批」的 pending
+# 没有原生自动超时——job 的 timeout 不涵盖排队等审批的时间,environment 的
+# wait-timer 是「等 N 分钟后自动放行」(反而会去发版),都不是我们要的「超期自动
+# 取消」。结果一个无人批准的正式发布会一直停在 waiting(最长 30 天),在
+# deployments 页堆成一排。
 #
 # 本 workflow 每天跑一次,把 Release workflow 里 status=waiting 且创建超过阈值
-# (默认 24h)的 run 直接 cancel 掉。npm/GitHub Release 早在 release job 里发完了
-# (它不 needs desktop),所以 cancel 只终止那个干等的 macOS 签名,零副作用。
-# 想真出桌面包就在阈值时间内去点批准,或事后 workflow_dispatch 重跑 Release。
+# (默认 24h)的 run 直接 cancel 掉。正式版的 npm/GitHub Release 现在会等待 CLI
+# Developer ID 签名，所以超时取消发生在任何包发布之前；预览版不走签名 gate。
+# 想正式发布就在阈值时间内批准。workflow_dispatch 仍只用于补签/刷新 Desktop
+# 附件，不能补发一个被取消的正式版本。
 
 on:
   schedule:

--- a/.github/workflows/cancel-stale-release-approvals.yml
+++ b/.github/workflows/cancel-stale-release-approvals.yml
@@ -4,14 +4,14 @@ name: Cancel stale release approvals
 # `environment: macos-signing` 的人工审批 gate 上。GitHub 对「等待审批」的 pending
 # 没有原生自动超时——job 的 timeout 不涵盖排队等审批的时间,environment 的
 # wait-timer 是「等 N 分钟后自动放行」(反而会去发版),都不是我们要的「超期自动
-# 取消」。结果一个无人批准的正式发布会一直停在 waiting(最长 30 天),在
+# 取消」。结果一个无人批准的签名任务会一直停在 waiting(最长 30 天),在
 # deployments 页堆成一排。
 #
 # 本 workflow 每天跑一次,把 Release workflow 里 status=waiting 且创建超过阈值
-# (默认 24h)的 run 直接 cancel 掉。正式版的 npm/GitHub Release 现在会等待 CLI
-# Developer ID 签名，所以超时取消发生在任何包发布之前；预览版不走签名 gate。
-# 想正式发布就在阈值时间内批准。workflow_dispatch 仍只用于补签/刷新 Desktop
-# 附件，不能补发一个被取消的正式版本。
+# (默认 24h)的非 stable run cancel 掉。纯净 vX.Y.Z 正式版现在会在发布任何包之前
+# 等待 CLI Developer ID 签名，且 workflow_dispatch 不能补发一个被取消的 tag，
+# 所以正式版必须豁免清扫，留给维护者在 GitHub 的 30 天期限内审批。预览版只会等
+# 可选 Desktop 签名，workflow_dispatch 也只刷新 Desktop 附件，仍可安全清扫。
 
 on:
   schedule:
@@ -58,7 +58,7 @@ jobs:
             --workflow=release.yml \
             --status=waiting \
             --limit 100 \
-            --json databaseId,createdAt,displayTitle,headBranch,url)
+            --json databaseId,createdAt,displayTitle,event,headBranch,url)
 
           COUNT=$(printf '%s' "$RUNS_JSON" | jq 'length')
           echo "waiting Release runs: $COUNT"
@@ -70,13 +70,19 @@ jobs:
           NOW=$(date -u +%s)
           CUTOFF=$(( THRESHOLD_HOURS * 3600 ))
 
-          # 逐个判断 age;超阈值的 cancel。用 jq 展开成 TSV(id \t createdAt \t ref \t title)。
+          # 逐个判断 age;超阈值的 cancel。用 jq 展开成
+          # TSV(id \t createdAt \t ref \t title \t event)。
           printf '%s' "$RUNS_JSON" \
-            | jq -r '.[] | [.databaseId, .createdAt, .headBranch, (.displayTitle // "")] | @tsv' \
-            | while IFS=$'\t' read -r id created ref title; do
+            | jq -r '.[] | [.databaseId, .createdAt, .headBranch, (.displayTitle // ""), .event] | @tsv' \
+            | while IFS=$'\t' read -r id created ref title event; do
                 created_s=$(date -u -d "$created" +%s)
                 age=$(( NOW - created_s ))
                 age_h=$(( age / 3600 ))
+                version="${ref#v}"
+                if [ "$event" = "push" ] && [[ "$ref" == v* ]] && [[ "$version" != *"-"* ]]; then
+                  echo "keep stable release run $id (ref=$ref age=${age_h}h; CLI signing is release-blocking)"
+                  continue
+                fi
                 if [ "$age" -ge "$CUTOFF" ]; then
                   if [ "$DRY_RUN" = "true" ]; then
                     echo "[dry-run] WOULD cancel run $id (ref=$ref age=${age_h}h) \"$title\""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,9 @@ jobs:
   # tag-push-only restriction is inherited through `preflight`, which carries
   # `if: github.event_name == 'push'`. If you ever add an `if:` here you MUST
   # also re-assert `needs.<each>.result == 'success'` for every entry in `needs`.
+  # `binary-subpackages` below is the deliberate counterpart: it needs an `if:`
+  # to admit a skipped signing job on prereleases, so it explicitly re-asserts
+  # success for every other prerequisite and for stable signing.
   release:
     needs: [preflight, bun-binaries, bun-binaries-musl, binary-subpackages]
     runs-on: ubuntu-latest
@@ -630,7 +633,7 @@ jobs:
         run: |
           echo "npm ${GITHUB_REF_NAME#v} published and GitHub Release ${GITHUB_REF_NAME} created."
           echo "macOS desktop assets (.dmg/.zip) attach asynchronously in attach-desktop-assets after signing."
-          echo "If signing is rejected/fails/cancelled, re-run this workflow via workflow_dispatch with release_tag=${GITHUB_REF_NAME} to rebuild+sign and attach."
+          echo "If Desktop signing is rejected/fails/cancelled, re-run this workflow via workflow_dispatch with release_tag=${GITHUB_REF_NAME} to rebuild+sign and attach Desktop assets."
   bun-binaries:
     # Build the self-contained Bun single-file executables (see
     # scripts/build-bun-binary.mjs). These let users run botmux with NO Node on
@@ -999,6 +1002,9 @@ jobs:
         run: |
           chmod +x dist-bin/botmux-darwin-arm64
           node scripts/smoke-bun-binary.mjs dist-bin/botmux-darwin-arm64
+
+      - name: Smoke-test the signed darwin native PTY path
+        run: dist-bin/botmux-darwin-arm64 __pty-smoke
 
       - name: Replace darwin artifact with Developer ID signed binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,12 +271,13 @@ jobs:
   # satisfiable.
   #
   # ACCEPTED COST: this gives up the previous "npm-first" property, where npm
-  # publish did not wait on the binary build. npm publish now waits for the
-  # `bun-binaries` compile matrix — a few minutes. That is deliberate, and it is
-  # far cheaper than the one thing we still refuse to block on: the macOS
-  # signing manual-approval gate, which can sit for up to 30 days. Signing stays
-  # fully asynchronous — `desktop` and `attach-desktop-assets` are NOT in this
-  # job's `needs`, and only the bun binary COMPILE became a prerequisite.
+  # publish did not wait on binary production. npm now waits for the compile
+  # matrix and, for stable releases, Developer ID signing of the standalone
+  # macOS binaries. That manual approval may delay a stable release, but
+  # publishing ad-hoc-signed CLI binaries would make macOS TCC permissions
+  # version-specific and prompt users again after every update. Desktop asset
+  # packaging/notarization remains asynchronous; only the two CLI executables
+  # are a prerequisite for npm and the GitHub Release.
   #
   # NOTE ON `needs` vs `if` (do not "tidy" this): this job intentionally has NO
   # `if:`. GitHub applies the implicit "all needs succeeded" gate only to jobs
@@ -963,6 +964,51 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  sign-darwin-binaries:
+    # Stable CLI releases need a stable code identity, not merely a structurally
+    # valid ad-hoc signature. macOS TCC records an ad-hoc executable by cdhash;
+    # replacing the binary on upgrade changes that hash and invalidates Full Disk
+    # Access / App Data grants. The Developer ID identity already used by the
+    # desktop release gives both architectures one durable designated requirement.
+    #
+    # This intentionally gates stable publication on the protected environment's
+    # manual approval. Prereleases remain ad-hoc signed so contributors can publish
+    # canary/beta/rc builds without access to the repository owner's certificate.
+    if: github.event_name == 'push' && needs.preflight.outputs.tag == 'latest'
+    needs: [preflight, bun-binaries]
+    runs-on: macos-14
+    environment: macos-signing
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download ad-hoc signed darwin binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: bun-binaries-darwin
+          path: dist-bin
+
+      - name: Developer ID sign darwin CLI binaries
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+        run: scripts/sign-macos-cli-binaries.sh dist-bin
+
+      - name: Smoke-test the signed host-arch binary
+        run: |
+          chmod +x dist-bin/botmux-darwin-arm64
+          node scripts/smoke-bun-binary.mjs dist-bin/botmux-darwin-arm64
+
+      - name: Replace darwin artifact with Developer ID signed binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: bun-binaries-darwin
+          path: dist-bin/botmux-*
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
   binary-subpackages:
     # Publish the four platform subpackages — `botmux-linux-x64`,
     # `botmux-linux-arm64`, `botmux-darwin-x64`, `botmux-darwin-arm64` — each
@@ -977,7 +1023,20 @@ jobs:
     #
     # Single runner, not a matrix: publishing is pure npm I/O with no native
     # build, so both OSes' binaries are packed here from the artifacts.
-    needs: [preflight, bun-binaries, bun-binaries-musl]
+    # A skipped sign job is valid only for prereleases. Stable releases fail
+    # closed unless both darwin binaries were Developer ID signed first.
+    if: >-
+      ${{
+        always() &&
+        needs.preflight.result == 'success' &&
+        needs.bun-binaries.result == 'success' &&
+        needs.bun-binaries-musl.result == 'success' &&
+        (
+          needs.preflight.outputs.tag != 'latest' ||
+          needs.sign-darwin-binaries.result == 'success'
+        )
+      }}
+    needs: [preflight, bun-binaries, bun-binaries-musl, sign-darwin-binaries]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.en.md
+++ b/README.en.md
@@ -48,6 +48,8 @@ botmux start                 # start the daemon (botmux autostart enable for aut
 >
 > Nothing native is compiled during install (no Python / node-gyp / compiler): the PTY is already inside the binary. Supported: linux / macOS × x64 / arm64, with musl builds selected automatically on Alpine and similar. **On Windows, install inside WSL2** — the daemon needs PTY / tmux / Unix signals and does not run on native Windows; WSL2 reports as linux and is a fully supported first-class environment. An unsupported platform, or a binary that cannot run on this host, **fails with an explicit error and leaves your existing install untouched** rather than leaving you with a command that won't start.
 >
+> Stable macOS CLI releases use a consistent Apple Developer ID signature. Replacing the binary during an upgrade therefore preserves the code identity used by macOS file and App Data permissions instead of appearing as a new program for every version. Canary, beta, and RC builds remain ad-hoc signed.
+>
 > To upgrade: `botmux upgrade` (replaces the binary in place), or just **re-run the curl command** — also an in-place upgrade, and it won't append a second PATH line.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ botmux start                 # 启动 daemon（botmux autostart enable 设开机
 >
 > 安装过程**不编译任何原生模块**（不需要 Python / node-gyp / 编译器）：PTY 已经嵌在二进制里。支持 linux / macOS × x64 / arm64（Alpine 等 musl 环境自动选 musl 版）；**Windows 请在 WSL2 里安装**（daemon 依赖 PTY / tmux / Unix 信号，原生 Windows 跑不了；WSL2 报告为 linux，是完整支持的一等环境）。平台不在列表里、或下下来的二进制在本机跑不起来，安装会**明确报错并保留原有版本**，而不是装上一个起不来的命令。
 >
+> 正式版 macOS CLI 使用稳定的 Apple Developer ID 签名。升级替换二进制后，macOS 的文件与 App 数据访问授权仍绑定同一代码身份，不会因为版本哈希变化而把 botmux 当成一个新程序；canary / beta / rc 等预览版仍使用 ad-hoc 签名。
+>
 > 升级：`botmux upgrade`（原地换二进制），或**重跑一遍上面那条 curl 命令**——同样原地升级，不会重复往启动文件里追加 PATH。
 
 <details>

--- a/scripts/build-bun-binary.mjs
+++ b/scripts/build-bun-binary.mjs
@@ -186,8 +186,10 @@ function runTool(argv) {
  *
  * Signing needs macOS (`codesign` is an Apple tool), so a darwin binary
  * cross-built from Linux stays unsigned — warn loudly rather than fail, since
- * release.yml builds darwin only on macOS (so the shipped path is always
- * signed) while `--all` on a Linux dev box is a legitimate workflow.
+ * release.yml builds darwin only on macOS while `--all` on a Linux dev box is a
+ * legitimate workflow. This function establishes a structurally valid
+ * preliminary signature. Stable releases replace it with the repository's
+ * Developer ID identity in `sign-darwin-binaries`; prereleases keep it ad-hoc.
  */
 function adhocResignDarwin(outfile) {
   if (process.platform !== 'darwin') {

--- a/scripts/bun-native-embed-plugin.mjs
+++ b/scripts/bun-native-embed-plugin.mjs
@@ -40,10 +40,10 @@ export function makeNativeEmbedPlugin({ ptyNode, spawnHelper, skiaNode = null })
       // Replace lib/utils.js so loadNativeModule('pty') returns the embedded
       // native. The `require(<abs .node>)` here is what makes Bun embed it.
       // spawn-helper (macOS): node-pty computes it as `native.dir + '/spawn-helper'`
-      // and resolves relative to utils.js dir. We embed it as a file asset and
-      // expose its /$bunfs/ path via `dir` so unixTerminal's helperPath lands on
-      // the embedded copy. On linux spawnHelper is null (forkpty, no sidecar) and
-      // `dir` is irrelevant to spawning.
+      // and resolves relative to utils.js dir. We embed it as a file asset, then
+      // materialize it in a private content-addressed temp directory: the kernel
+      // cannot posix_spawn Bun's virtual /$bunfs/ path. On linux spawnHelper is
+      // null (forkpty, no sidecar) and `dir` is irrelevant to spawning.
       build.onLoad({ filter: /node-pty[\\/]lib[\\/]utils\.js$/ }, () => {
         // Compute the spawn-helper directory literal at BUILD time. On linux
         // spawnHelper is null (forkpty, no sidecar) so `dir` is only cosmetic and
@@ -52,8 +52,57 @@ export function makeNativeEmbedPlugin({ ptyNode, spawnHelper, skiaNode = null })
         // we derive its dir from the imported file path.
         const ptyDirLiteral = JSON.stringify(nodeDirname(ptyNode));
         const helperImport = spawnHelper
-          ? `import spawnHelperPath from ${JSON.stringify(spawnHelper)} with { type: 'file' };\nimport { dirname as __dirname_fn } from 'node:path';`
-          : `const spawnHelperPath = null;`;
+          ? `
+            import embeddedSpawnHelperPath from ${JSON.stringify(spawnHelper)} with { type: 'file' };
+            import { chmodSync, lstatSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+            import { createHash } from 'node:crypto';
+            import { dirname as __dirname_fn, join as __join_fn } from 'node:path';
+            import { tmpdir as __tmpdir_fn } from 'node:os';
+
+            let materializedSpawnHelperPath = null;
+            function ensurePrivateDirectory(path, uid) {
+              mkdirSync(path, { recursive: true, mode: 0o700 });
+              const stat = lstatSync(path);
+              if (!stat.isDirectory() || stat.isSymbolicLink()
+                  || (typeof uid === 'number' && stat.uid !== uid)) {
+                throw new Error('botmux-native-embed: unsafe native cache directory ' + path);
+              }
+              chmodSync(path, 0o700);
+            }
+            function materializeSpawnHelper() {
+              if (materializedSpawnHelperPath) return materializedSpawnHelperPath;
+              const bytes = readFileSync(embeddedSpawnHelperPath);
+              const digest = createHash('sha256').update(bytes).digest('hex');
+              const uid = typeof process.getuid === 'function' ? process.getuid() : 'user';
+              const tempRoot = process.env.BOTMUX_NATIVE_TMPDIR || __tmpdir_fn();
+              const root = __join_fn(tempRoot, 'botmux-native-' + uid);
+              ensurePrivateDirectory(root, uid);
+              const dir = __join_fn(root, digest);
+              ensurePrivateDirectory(dir, uid);
+              const target = __join_fn(dir, 'spawn-helper');
+              let current = null;
+              try {
+                const targetStat = lstatSync(target);
+                if (targetStat.isFile() && !targetStat.isSymbolicLink()
+                    && (typeof uid !== 'number' || targetStat.uid === uid)) {
+                  current = readFileSync(target);
+                }
+              } catch {}
+              if (!current || !current.equals(bytes)) {
+                const temp = target + '.' + process.pid + '.tmp';
+                writeFileSync(temp, bytes, { mode: 0o700 });
+                chmodSync(temp, 0o700);
+                renameSync(temp, target);
+              }
+              chmodSync(target, 0o700);
+              materializedSpawnHelperPath = target;
+              return target;
+            }
+          `
+          : `
+            const materializedSpawnHelperPath = null;
+            function materializeSpawnHelper() { return null; }
+          `;
         const contents = `
           ${helperImport}
           const ptyNative = require(${JSON.stringify(ptyNode)});
@@ -64,10 +113,13 @@ export function makeNativeEmbedPlugin({ ptyNode, spawnHelper, skiaNode = null })
           export function loadNativeModule(name) {
             if (name !== 'pty') throw new Error('botmux-native-embed: unexpected native module ' + name);
             // node-pty derives the spawn-helper path from \`dir\`. With an embedded
-            // helper (macOS), hand back its directory so \`dir + '/spawn-helper'\`
-            // matches the embedded file path; on linux use the .node's dir literal.
-            const dir = spawnHelperPath ? __dirname_fn(spawnHelperPath) : ${ptyDirLiteral};
-            return { dir, module: ptyNative };
+            // helper (macOS), materialize it outside Bun's virtual /$bunfs before
+            // handing back its directory: posix_spawn is a kernel operation and
+            // cannot execute Bun's virtual file path. Linux uses forkpty and has
+            // no helper sidecar.
+            const helperPath = materializeSpawnHelper();
+            const dir = helperPath ? __dirname_fn(helperPath) : ${ptyDirLiteral};
+            return { dir, helperPath, module: ptyNative };
           }
         `;
         return { contents, loader: 'js' };

--- a/scripts/sign-macos-cli-binaries.sh
+++ b/scripts/sign-macos-cli-binaries.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 DIST_DIR="${1:-dist-bin}"
 IDENTIFIER="${BOTMUX_CODESIGN_IDENTIFIER:-com.botmux.cli}"
-ENTITLEMENTS="${BOTMUX_CODESIGN_ENTITLEMENTS:-build/entitlements.mac.release.plist}"
+ENTITLEMENTS="${BOTMUX_CODESIGN_ENTITLEMENTS:-build/entitlements.mac.plist}"
 CERT_LINK="${MAC_CSC_LINK:-}"
 CERT_PASSWORD="${MAC_CSC_KEY_PASSWORD:-}"
 RUNNER_TMP="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
@@ -95,8 +95,9 @@ for arch in x64 arm64; do
 
   [ "$actual_identifier" = "$IDENTIFIER" ] \
     || fail "$binary has identifier '$actual_identifier', expected '$IDENTIFIER'"
-  [ -n "$team_identifier" ] && [ "$team_identifier" != "not set" ] \
-    || fail "$binary has no stable TeamIdentifier"
+  if [ -z "$team_identifier" ] || [ "$team_identifier" = "not set" ]; then
+    fail "$binary has no stable TeamIdentifier"
+  fi
   case "$authority" in
     "Developer ID Application:"*) ;;
     *) fail "$binary is not signed by a Developer ID Application identity" ;;

--- a/scripts/sign-macos-cli-binaries.sh
+++ b/scripts/sign-macos-cli-binaries.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Give the standalone macOS CLI the same Developer ID identity on every release.
+# TCC stores the binary's designated requirement; an ad-hoc signature reduces
+# that requirement to a version-specific cdhash and invalidates permissions on
+# every upgrade.
+
+DIST_DIR="${1:-dist-bin}"
+IDENTIFIER="${BOTMUX_CODESIGN_IDENTIFIER:-com.botmux.cli}"
+ENTITLEMENTS="${BOTMUX_CODESIGN_ENTITLEMENTS:-build/entitlements.mac.release.plist}"
+CERT_LINK="${MAC_CSC_LINK:-}"
+CERT_PASSWORD="${MAC_CSC_KEY_PASSWORD:-}"
+RUNNER_TMP="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+KEYCHAIN_PATH="$RUNNER_TMP/botmux-cli-signing.keychain-db"
+CERT_PATH="$RUNNER_TMP/botmux-cli-signing.p12"
+KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+
+fail() {
+  echo "botmux macOS CLI signing: $*" >&2
+  exit 1
+}
+
+[ "$(uname -s)" = "Darwin" ] || fail "must run on macOS"
+[ -n "$CERT_LINK" ] || fail "MAC_CSC_LINK is required"
+[ -n "$CERT_PASSWORD" ] || fail "MAC_CSC_KEY_PASSWORD is required"
+[ -f "$ENTITLEMENTS" ] || fail "entitlements file not found: $ENTITLEMENTS"
+
+cleanup() {
+  security delete-keychain "$KEYCHAIN_PATH" >/dev/null 2>&1 || true
+  rm -f "$CERT_PATH"
+}
+trap cleanup EXIT
+
+case "$CERT_LINK" in
+  file://*)
+    cp "${CERT_LINK#file://}" "$CERT_PATH"
+    ;;
+  http://*|https://*)
+    curl --fail --silent --show-error --location "$CERT_LINK" --output "$CERT_PATH"
+    ;;
+  *)
+    if [ -f "$CERT_LINK" ]; then
+      cp "$CERT_LINK" "$CERT_PATH"
+    else
+      printf '%s' "${CERT_LINK#*base64,}" | /usr/bin/base64 -D > "$CERT_PATH"
+    fi
+    ;;
+esac
+
+[ -s "$CERT_PATH" ] || fail "decoded signing certificate is empty"
+
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security import "$CERT_PATH" \
+  -k "$KEYCHAIN_PATH" \
+  -P "$CERT_PASSWORD" \
+  -T /usr/bin/codesign \
+  -T /usr/bin/security
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign: \
+  -s \
+  -k "$KEYCHAIN_PASSWORD" \
+  "$KEYCHAIN_PATH" >/dev/null
+
+IDENTITY="$(
+  security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+    | awk '/"Developer ID Application:/ { print $2; exit }'
+)"
+[ -n "$IDENTITY" ] || fail "no Developer ID Application identity found"
+
+EXPECTED_REQUIREMENT=""
+for arch in x64 arm64; do
+  binary="$DIST_DIR/botmux-darwin-$arch"
+  [ -f "$binary" ] || fail "missing binary: $binary"
+  chmod +x "$binary"
+
+  codesign \
+    --force \
+    --sign "$IDENTITY" \
+    --keychain "$KEYCHAIN_PATH" \
+    --identifier "$IDENTIFIER" \
+    --options runtime \
+    --timestamp \
+    --entitlements "$ENTITLEMENTS" \
+    "$binary"
+  codesign --verify --strict --verbose=2 "$binary"
+
+  details="$(codesign -dv --verbose=4 "$binary" 2>&1)"
+  actual_identifier="$(printf '%s\n' "$details" | awk -F= '/^Identifier=/{print $2; exit}')"
+  team_identifier="$(printf '%s\n' "$details" | awk -F= '/^TeamIdentifier=/{print $2; exit}')"
+  authority="$(printf '%s\n' "$details" | awk -F= '/^Authority=/{print $2; exit}')"
+  requirement="$(codesign -dr - "$binary" 2>&1 | sed -n 's/^designated => //p')"
+
+  [ "$actual_identifier" = "$IDENTIFIER" ] \
+    || fail "$binary has identifier '$actual_identifier', expected '$IDENTIFIER'"
+  [ -n "$team_identifier" ] && [ "$team_identifier" != "not set" ] \
+    || fail "$binary has no stable TeamIdentifier"
+  case "$authority" in
+    "Developer ID Application:"*) ;;
+    *) fail "$binary is not signed by a Developer ID Application identity" ;;
+  esac
+  [ -n "$requirement" ] || fail "$binary has no designated requirement"
+  case "$requirement" in
+    *cdhash*) fail "$binary still has a version-specific cdhash requirement" ;;
+  esac
+
+  if [ -z "$EXPECTED_REQUIREMENT" ]; then
+    EXPECTED_REQUIREMENT="$requirement"
+  elif [ "$requirement" != "$EXPECTED_REQUIREMENT" ]; then
+    fail "darwin x64 and arm64 designated requirements differ"
+  fi
+
+  binary_name="$(basename "$binary")"
+  (
+    cd "$DIST_DIR"
+    shasum -a 256 "$binary_name" > "$binary_name.sha256"
+  )
+  echo "Developer ID signed $binary (identifier=$actual_identifier team=$team_identifier)"
+done
+
+echo "Stable designated requirement: $EXPECTED_REQUIREMENT"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14736,6 +14736,17 @@ if (LARK_FACING_COMMANDS.has(command) && managedOriginHasNoTransport()) {
 switch (command) {
   case '--version':
   case '-v':      console.log(getVersion()); break;
+  case '__pty-smoke': {
+    try {
+      const { runNativePtySmoke } = await import('./cli/pty-smoke.js');
+      const result = await runNativePtySmoke();
+      process.stdout.write(`${JSON.stringify({ ok: true, ...result })}\n`);
+    } catch (error) {
+      console.error(`__pty-smoke: ${error instanceof Error ? error.message : String(error)}`);
+      process.exitCode = 1;
+    }
+    break;
+  }
   case 'capabilities': {
     const { botmuxCapabilities, parseCapabilitiesArgs } = await import('./cli/capabilities.js');
     const parsed = parseCapabilitiesArgs(process.argv.slice(3));

--- a/src/cli/pty-smoke.ts
+++ b/src/cli/pty-smoke.ts
@@ -1,11 +1,11 @@
 import { closeSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { loadNativeModule, type NativePtyProcess } from 'node-pty/lib/utils.js';
 
 export interface NativePtySmokeOptions {
   file?: string;
+  helperPath?: string;
   timeoutMs?: number;
 }
 
@@ -31,9 +31,9 @@ export async function runNativePtySmoke(
   const scratch = mkdtempSync(join(scratchRoot, 'botmux-pty-smoke-'));
   const marker = join(scratch, 'result.txt');
   const loaded = loadNativeModule('pty');
-  const utilsPath = createRequire(import.meta.url).resolve('node-pty/lib/utils.js');
-  const helperPath = loaded.helperPath
-    ?? resolve(dirname(utilsPath), loaded.dir, 'spawn-helper');
+  const helperPath = options.helperPath
+    ?? loaded.helperPath
+    ?? resolve(loaded.dir, 'spawn-helper');
   const file = options.file ?? '/bin/sh';
   const timeoutMs = options.timeoutMs ?? 10_000;
   const env = Object.entries({

--- a/src/cli/pty-smoke.ts
+++ b/src/cli/pty-smoke.ts
@@ -1,0 +1,106 @@
+import { closeSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { loadNativeModule, type NativePtyProcess } from 'node-pty/lib/utils.js';
+
+export interface NativePtySmokeOptions {
+  file?: string;
+  timeoutMs?: number;
+}
+
+export interface NativePtySmokeResult {
+  pid: number;
+  helperPath: string;
+}
+
+/**
+ * Exercise node-pty without constructing tty.ReadStream. Bun's ReadStream can
+ * close the PTY master after an initial EAGAIN, which makes a wrapper-level
+ * smoke flaky and hides the code-signing signal this probe exists to test.
+ */
+export async function runNativePtySmoke(
+  options: NativePtySmokeOptions = {},
+): Promise<NativePtySmokeResult> {
+  if (process.platform === 'win32') {
+    throw new Error('native PTY smoke is unsupported on Windows');
+  }
+
+  const scratchRoot = process.env.BOTMUX_PTY_SMOKE_TMPDIR || tmpdir();
+  mkdirSync(scratchRoot, { recursive: true });
+  const scratch = mkdtempSync(join(scratchRoot, 'botmux-pty-smoke-'));
+  const marker = join(scratch, 'result.txt');
+  const loaded = loadNativeModule('pty');
+  const utilsPath = createRequire(import.meta.url).resolve('node-pty/lib/utils.js');
+  const helperPath = loaded.helperPath
+    ?? resolve(dirname(utilsPath), loaded.dir, 'spawn-helper');
+  const file = options.file ?? '/bin/sh';
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const env = Object.entries({
+    ...process.env,
+    PWD: scratch,
+    TERM: 'xterm-color',
+  }).flatMap(([key, value]) => value === undefined ? [] : [`${key}=${value}`]);
+
+  if (process.platform === 'darwin' && !existsSync(helperPath)) {
+    rmSync(scratch, { recursive: true, force: true });
+    throw new Error(`embedded spawn-helper is missing: ${helperPath}`);
+  }
+
+  let child: NativePtyProcess | undefined;
+  try {
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (error) rejectPromise(error);
+        else resolvePromise();
+      };
+      const timer = setTimeout(() => {
+        if (child) {
+          try { process.kill(child.pid, 'SIGKILL'); } catch { /* already exited */ }
+        }
+        finish(new Error(`native PTY smoke timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      try {
+        child = loaded.module.fork(
+          file,
+          ['-c', 'printf %s pty-ok > "$1"', 'botmux-pty-smoke', marker],
+          env,
+          scratch,
+          80,
+          24,
+          -1,
+          -1,
+          true,
+          helperPath,
+          (code, signal) => {
+            let actual = '<missing>';
+            try { actual = readFileSync(marker, 'utf8'); } catch { /* reported below */ }
+            if (code !== 0 || actual !== 'pty-ok') {
+              finish(new Error(
+                `native PTY child failed (code=${code} signal=${signal} marker=${JSON.stringify(actual)})`,
+              ));
+              return;
+            }
+            finish();
+          },
+        );
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        finish(new Error(`native PTY fork failed via ${helperPath}: ${detail}`));
+      }
+    });
+
+    if (!child) throw new Error('native PTY smoke did not create a child process');
+    return { pid: child.pid, helperPath };
+  } finally {
+    if (child) {
+      try { closeSync(child.fd); } catch { /* already closed */ }
+    }
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}

--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -6,7 +6,12 @@
 
 `.github/workflows/release.yml` 在 macOS runner 上完成 Universal 构建、Developer ID 签名、Apple 公证和 stapling，再把 DMG/ZIP 作为附件加入同一个 GitHub Release。签名 job 只接受 `deepcoldy` 发起或重新运行，并且必须通过受保护的 `macos-signing` Environment 审批。以下凭据配置为该 Environment 的 Secrets，不应配置成仓库级 Secrets：
 
-其他 contributor 从分支推送 canary、beta、rc 或其它 prerelease tag 时，仍会发布对应的 npm dist-tag 和 GitHub prerelease，但签名 job 会被跳过，因此不会读取签名凭据，也不会生成 macOS 附件。正式版缺少成功的签名产物时会直接拒绝发布。
+同一个 Environment 也为 `botmux-darwin-x64` 和 `botmux-darwin-arm64`
+standalone CLI 提供 Developer ID 签名。正式版会等 CLI 签名审批通过后再发布 npm
+平台包和 GitHub Release，确保 macOS TCC 权限绑定稳定的 designated requirement，
+不会因升级替换二进制而退化为新程序。Desktop DMG/ZIP 仍异步构建和挂载。
+
+其他 contributor 从分支推送 canary、beta、rc 或其它 prerelease tag 时，仍会发布对应的 npm dist-tag 和 GitHub prerelease，但签名 job 会被跳过，因此不会读取签名凭据，也不会生成 macOS 附件。预览版 CLI 仍使用 ad-hoc 签名；正式版缺少成功的 CLI 签名产物时会直接拒绝发布。
 
 需要为已有版本重新生成桌面附件时，可以手动运行 `Release` workflow 并填写 `release_tag`。该模式只覆盖对应 Release 的 macOS 附件并校验上传内容，不会再次发布 npm、修改 tag 或改写 Release 正文。
 

--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -10,6 +10,10 @@
 standalone CLI 提供 Developer ID 签名。正式版会等 CLI 签名审批通过后再发布 npm
 平台包和 GitHub Release，确保 macOS TCC 权限绑定稳定的 designated requirement，
 不会因升级替换二进制而退化为新程序。Desktop DMG/ZIP 仍异步构建和挂载。
+CLI 签名使用 `build/entitlements.mac.plist`：Bun 单文件运行时会把 `pty.node` 等
+原生载荷释放后动态加载，必须保留 `disable-library-validation`；Desktop 内的
+原生文件会被 electron-builder 逐个同身份签名，仍使用更严格的
+`entitlements.mac.release.plist`。
 
 其他 contributor 从分支推送 canary、beta、rc 或其它 prerelease tag 时，仍会发布对应的 npm dist-tag 和 GitHub prerelease，但签名 job 会被跳过，因此不会读取签名凭据，也不会生成 macOS 附件。预览版 CLI 仍使用 ad-hoc 签名；正式版缺少成功的 CLI 签名产物时会直接拒绝发布。
 

--- a/src/types/node-pty-utils.d.ts
+++ b/src/types/node-pty-utils.d.ts
@@ -1,0 +1,29 @@
+declare module 'node-pty/lib/utils.js' {
+  export interface NativePtyProcess {
+    fd: number;
+    pid: number;
+    pty: string;
+  }
+
+  export interface NativePtyModule {
+    fork(
+      file: string,
+      args: string[],
+      env: string[],
+      cwd: string,
+      cols: number,
+      rows: number,
+      uid: number,
+      gid: number,
+      useUtf8: boolean,
+      helperPath: string,
+      onExit: (code: number, signal: number) => void,
+    ): NativePtyProcess;
+  }
+
+  export function loadNativeModule(name: 'pty'): {
+    dir: string;
+    helperPath?: string | null;
+    module: NativePtyModule;
+  };
+}

--- a/test/pty-native-smoke.test.ts
+++ b/test/pty-native-smoke.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
 import { runNativePtySmoke } from '../src/cli/pty-smoke.js';
+
+const sourceHelperPath = process.platform === 'darwin'
+  ? resolve(
+      dirname(createRequire(import.meta.url).resolve('node-pty/lib/utils.js')),
+      '..',
+      'prebuilds',
+      `${process.platform}-${process.arch}`,
+      'spawn-helper',
+    )
+  : undefined;
 
 describe.skipIf(process.platform === 'win32')('native PTY release smoke', () => {
   it('executes a child without the node-pty ReadStream wrapper', async () => {
-    const result = await runNativePtySmoke({ timeoutMs: 10_000 });
+    const result = await runNativePtySmoke({
+      helperPath: sourceHelperPath,
+      timeoutMs: 10_000,
+    });
     expect(result.pid).toBeGreaterThan(0);
     expect(result.helperPath).toContain('spawn-helper');
   });
@@ -11,6 +26,7 @@ describe.skipIf(process.platform === 'win32')('native PTY release smoke', () => 
   it('fails closed when the requested child cannot execute', async () => {
     await expect(runNativePtySmoke({
       file: '/definitely-missing-botmux-pty-smoke',
+      helperPath: sourceHelperPath,
       timeoutMs: 10_000,
     })).rejects.toThrow(/native PTY child failed|posix_spawnp failed/);
   });

--- a/test/pty-native-smoke.test.ts
+++ b/test/pty-native-smoke.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { runNativePtySmoke } from '../src/cli/pty-smoke.js';
+
+describe.skipIf(process.platform === 'win32')('native PTY release smoke', () => {
+  it('executes a child without the node-pty ReadStream wrapper', async () => {
+    const result = await runNativePtySmoke({ timeoutMs: 10_000 });
+    expect(result.pid).toBeGreaterThan(0);
+    expect(result.helperPath).toContain('spawn-helper');
+  });
+
+  it('fails closed when the requested child cannot execute', async () => {
+    await expect(runNativePtySmoke({
+      file: '/definitely-missing-botmux-pty-smoke',
+      timeoutMs: 10_000,
+    })).rejects.toThrow(/native PTY child failed|posix_spawnp failed/);
+  });
+});

--- a/test/release-darwin-codesign-gate.test.ts
+++ b/test/release-darwin-codesign-gate.test.ts
@@ -45,6 +45,11 @@ const GLIBC_SH = stripHashComments(read('scripts/build-linux-glibc-baseline.sh')
 const SMOKE = stripJsComments(read('scripts/smoke-bun-binary.mjs'));
 const BUILD = stripJsComments(read('scripts/build-bun-binary.mjs'));
 const STABLE_SIGN = stripHashComments(read('scripts/sign-macos-cli-binaries.sh'));
+const EMBED_PLUGIN = stripJsComments(read('scripts/bun-native-embed-plugin.mjs'));
+const PTY_SMOKE = stripJsComments(read('src/cli/pty-smoke.ts'));
+const CLI = stripJsComments(read('src/cli.ts'));
+const CLI_ENTITLEMENTS = read('build/entitlements.mac.plist');
+const STALE_APPROVAL = stripHashComments(read('.github/workflows/cancel-stale-release-approvals.yml'));
 const PKG = JSON.parse(read('package.json')) as { packageManager?: string };
 
 /** The step body from its `- name:` line up to the next step. */
@@ -216,12 +221,16 @@ describe('stable releases — Developer ID identity survives CLI binary replacem
   });
 
   it('replaces the darwin artifact only after both binaries are signed and smoked', () => {
-    expect(signJob).toContain('scripts/sign-macos-cli-binaries.sh dist-bin');
-    expect(signJob).toContain('node scripts/smoke-bun-binary.mjs dist-bin/botmux-darwin-arm64');
+    const sign = signJob.indexOf('scripts/sign-macos-cli-binaries.sh dist-bin');
+    const generalSmoke = signJob.indexOf('node scripts/smoke-bun-binary.mjs dist-bin/botmux-darwin-arm64');
+    const ptySmoke = signJob.indexOf('dist-bin/botmux-darwin-arm64 __pty-smoke');
+    const replace = signJob.indexOf('overwrite: true');
+    expect(sign).toBeGreaterThan(-1);
+    expect(generalSmoke).toBeGreaterThan(sign);
+    expect(ptySmoke).toBeGreaterThan(generalSmoke);
+    expect(replace).toBeGreaterThan(ptySmoke);
     expect(signJob).toContain('name: bun-binaries-darwin');
     expect(signJob).toMatch(/overwrite:\s*true/);
-    expect(signJob.indexOf('scripts/sign-macos-cli-binaries.sh'))
-      .toBeLessThan(signJob.indexOf('overwrite: true'));
   });
 
   it('fails stable npm publication closed when signing was skipped or failed', () => {
@@ -240,6 +249,8 @@ describe('stable releases — Developer ID identity survives CLI binary replacem
     expect(STABLE_SIGN).toContain('--options runtime');
     expect(STABLE_SIGN).toContain('--timestamp');
     expect(STABLE_SIGN).toContain('--entitlements "$ENTITLEMENTS"');
+    expect(STABLE_SIGN).toContain('build/entitlements.mac.plist');
+    expect(CLI_ENTITLEMENTS).toContain('com.apple.security.cs.disable-library-validation');
     expect(STABLE_SIGN).not.toMatch(/--sign\s+['"]?-['"]?/);
   });
 
@@ -250,6 +261,28 @@ describe('stable releases — Developer ID identity survives CLI binary replacem
     expect(STABLE_SIGN).toContain('darwin x64 and arm64 designated requirements differ');
     expect(STABLE_SIGN).toContain('cd "$DIST_DIR"');
     expect(STABLE_SIGN).toContain('shasum -a 256 "$binary_name" > "$binary_name.sha256"');
+  });
+
+  it('uses a native PTY probe that reaches the embedded spawn-helper without tty.ReadStream', () => {
+    expect(CLI).toContain("case '__pty-smoke'");
+    expect(PTY_SMOKE).toContain("loadNativeModule('pty')");
+    expect(PTY_SMOKE).toContain('loaded.module.fork(');
+    expect(PTY_SMOKE).not.toMatch(/\bpty\.spawn\(/);
+    expect(EMBED_PLUGIN).toContain('materializeSpawnHelper()');
+    expect(EMBED_PLUGIN).toContain('ensurePrivateDirectory(root, uid)');
+    expect(EMBED_PLUGIN).toContain("writeFileSync(temp, bytes, { mode: 0o700 })");
+    expect(EMBED_PLUGIN).toContain('return { dir, helperPath, module: ptyNative }');
+  });
+
+  it('never lets the stale-approval sweep cancel a release-blocking stable signing run', () => {
+    expect(STALE_APPROVAL).toContain('databaseId,createdAt,displayTitle,event,headBranch,url');
+    expect(STALE_APPROVAL).toContain('[ "$event" = "push" ]');
+    expect(STALE_APPROVAL).toContain('[[ "$ref" == v* ]]');
+    expect(STALE_APPROVAL).toContain('[[ "$version" != *"-"* ]]');
+    const exemption = STALE_APPROVAL.indexOf('keep stable release run');
+    const cancellation = STALE_APPROVAL.indexOf('gh run cancel "$id"');
+    expect(exemption).toBeGreaterThan(-1);
+    expect(cancellation).toBeGreaterThan(exemption);
   });
 });
 

--- a/test/release-darwin-codesign-gate.test.ts
+++ b/test/release-darwin-codesign-gate.test.ts
@@ -268,6 +268,8 @@ describe('stable releases — Developer ID identity survives CLI binary replacem
     expect(PTY_SMOKE).toContain("loadNativeModule('pty')");
     expect(PTY_SMOKE).toContain('loaded.module.fork(');
     expect(PTY_SMOKE).not.toMatch(/\bpty\.spawn\(/);
+    expect(PTY_SMOKE).not.toContain('createRequire');
+    expect(PTY_SMOKE).not.toMatch(/resolve\(['"]node-pty\/lib\/utils\.js/);
     expect(EMBED_PLUGIN).toContain('materializeSpawnHelper()');
     expect(EMBED_PLUGIN).toContain('ensurePrivateDirectory(root, uid)');
     expect(EMBED_PLUGIN).toContain("writeFileSync(temp, bytes, { mode: 0o700 })");

--- a/test/release-darwin-codesign-gate.test.ts
+++ b/test/release-darwin-codesign-gate.test.ts
@@ -10,13 +10,15 @@ import { resolve } from 'node:path';
  * runner tolerated the bad signature and ran the binary anyway; macOS 27 SIGKILLs
  * it before main(), which is all `botmux upgrade` saw (exit 137).
  *
- * Two gates now exist, and this suite is what keeps them from quietly vanishing —
+ * These release guarantees are what this suite keeps from quietly vanishing —
  * the repo has no workflow lint, so a deleted step is first noticed after a tag
  * has already published (see ci-musl-gate.test.ts for the same reasoning):
  *   • release.yml verifies EVERY darwin binary with `codesign --verify --strict`
  *     (the smoke step only executes the host arch; the cross-built one is not run)
  *   • scripts/smoke-bun-binary.mjs checks the signature before anything else on
  *     darwin, so the PR gate and the release gate agree
+ *   • stable releases replace the preliminary ad-hoc signature with one Developer
+ *     ID designated requirement before npm or GitHub publishes the CLI
  *   • the build Bun is pinned to a version that carries the fix, and every pin in
  *     the repo agrees with package.json's `packageManager`
  *
@@ -42,6 +44,7 @@ const CI = stripHashComments(read('.github/workflows/ci.yml'));
 const GLIBC_SH = stripHashComments(read('scripts/build-linux-glibc-baseline.sh'));
 const SMOKE = stripJsComments(read('scripts/smoke-bun-binary.mjs'));
 const BUILD = stripJsComments(read('scripts/build-bun-binary.mjs'));
+const STABLE_SIGN = stripHashComments(read('scripts/sign-macos-cli-binaries.sh'));
 const PKG = JSON.parse(read('package.json')) as { packageManager?: string };
 
 /** The step body from its `- name:` line up to the next step. */
@@ -191,6 +194,62 @@ describe('build-bun-binary.mjs — re-signs darwin output, because the bun pin i
   it('re-signs both darwin arches rather than special-casing x64', () => {
     // Idempotent, and keeps working if the arch-conditional upstream bug moves.
     expect(BUILD).not.toMatch(/=== 'x64'[\s\S]{0,80}codesign/);
+  });
+});
+
+describe('stable releases — Developer ID identity survives CLI binary replacement', () => {
+  const signJobStart = RELEASE.indexOf('\n  sign-darwin-binaries:');
+  const subpackagesStart = RELEASE.indexOf('\n  binary-subpackages:');
+  const signJob = signJobStart < 0 || subpackagesStart < 0
+    ? ''
+    : RELEASE.slice(signJobStart, subpackagesStart);
+  const subpackages = subpackagesStart < 0
+    ? ''
+    : RELEASE.slice(subpackagesStart, RELEASE.indexOf('\n  attach-bun-binaries:'));
+
+  it('uses the protected macos-signing environment only for stable tags', () => {
+    expect(signJob).not.toBe('');
+    expect(signJob).toMatch(/environment:\s*macos-signing/);
+    expect(signJob).toContain("needs.preflight.outputs.tag == 'latest'");
+    expect(signJob).toContain('MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}');
+    expect(signJob).toContain('MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}');
+  });
+
+  it('replaces the darwin artifact only after both binaries are signed and smoked', () => {
+    expect(signJob).toContain('scripts/sign-macos-cli-binaries.sh dist-bin');
+    expect(signJob).toContain('node scripts/smoke-bun-binary.mjs dist-bin/botmux-darwin-arm64');
+    expect(signJob).toContain('name: bun-binaries-darwin');
+    expect(signJob).toMatch(/overwrite:\s*true/);
+    expect(signJob.indexOf('scripts/sign-macos-cli-binaries.sh'))
+      .toBeLessThan(signJob.indexOf('overwrite: true'));
+  });
+
+  it('fails stable npm publication closed when signing was skipped or failed', () => {
+    expect(subpackages).toContain('sign-darwin-binaries');
+    expect(subpackages).toContain("needs.preflight.outputs.tag != 'latest'");
+    expect(subpackages).toContain("needs.sign-darwin-binaries.result == 'success'");
+    for (const prerequisite of ['preflight', 'bun-binaries', 'bun-binaries-musl']) {
+      expect(subpackages).toContain(`needs.${prerequisite}.result == 'success'`);
+    }
+  });
+
+  it('signs x64 and arm64 with one explicit non-ad-hoc identity', () => {
+    expect(STABLE_SIGN).toMatch(/for arch in x64 arm64/);
+    expect(STABLE_SIGN).toContain('--sign "$IDENTITY"');
+    expect(STABLE_SIGN).toContain('--identifier "$IDENTIFIER"');
+    expect(STABLE_SIGN).toContain('--options runtime');
+    expect(STABLE_SIGN).toContain('--timestamp');
+    expect(STABLE_SIGN).toContain('--entitlements "$ENTITLEMENTS"');
+    expect(STABLE_SIGN).not.toMatch(/--sign\s+['"]?-['"]?/);
+  });
+
+  it('rejects an unstable identity and pins one designated requirement across arches', () => {
+    expect(STABLE_SIGN).toContain('Developer ID Application:');
+    expect(STABLE_SIGN).toContain('TeamIdentifier');
+    expect(STABLE_SIGN).toContain('*cdhash*');
+    expect(STABLE_SIGN).toContain('darwin x64 and arm64 designated requirements differ');
+    expect(STABLE_SIGN).toContain('cd "$DIST_DIR"');
+    expect(STABLE_SIGN).toContain('shasum -a 256 "$binary_name" > "$binary_name.sha256"');
   });
 });
 


### PR DESCRIPTION
## 问题

macOS standalone CLI 当前在 `scripts/build-bun-binary.mjs` 中使用 ad-hoc 签名（`codesign --sign -`）。这种签名的 designated requirement 退化为版本特定的 `cdhash`。

实机升级后 TCC 日志明确显示旧授权与新二进制不匹配：

```text
Failed to match existing code requirement ... kTCCServiceSystemPolicyAllFiles
old cdhash: ca251b...
new cdhash: 0768f7...
```

结果是每次替换 `~/.botmux/bin/botmux` 后，Full Disk Access / App Data 授权都可能失效；多个存量 worker 同时访问受保护目录时，还会堆出连续的授权弹窗。

## 修复

- 新增 `scripts/sign-macos-cli-binaries.sh`，复用现有 `macos-signing` Environment 的 `MAC_CSC_LINK` / `MAC_CSC_KEY_PASSWORD`。
- stable release 编译完两份 Darwin CLI 后，使用同一个 Developer ID、固定 identifier `com.botmux.cli`、hardened runtime 和现有 release entitlements 重新签名。
- 签名脚本 fail-closed 校验：
  - x64 / arm64 文件都存在且签名有效；
  - Authority 必须是 `Developer ID Application`；
  - TeamIdentifier 必须存在；
  - designated requirement 不得包含版本特定 `cdhash`；
  - 两个架构的 designated requirement 必须完全一致；
  - 签名后重新生成 SHA-256。
- stable 的 npm 平台包和 GitHub Release 必须等待签名成功；人工审批被拒、超时或签名失败时不发布。
- canary / beta / rc 保持 ad-hoc 签名，使 contributor 不需要接触仓库所有者证书。
- 更新中英文安装说明、Desktop 发布说明和 stale approval 语义。

## 用户迁移

从历史 ad-hoc 版本升级到首个 Developer ID 版本时，macOS 仍需重新授权一次，因为旧授权只能绑定旧 `cdhash`。从该版本开始，只要后续继续使用同一 Developer ID + identifier，二进制升级不会再被 TCC 当作全新的程序。

## 验证

- `bash -n scripts/sign-macos-cli-binaries.sh`
- release / npm / glibc / musl 定向测试：106 passed，1 skipped
- Darwin 签名门禁测试：36 passed
- YAML 解析、`git diff --check`、dist audit、embedded assets audit 通过
- 先前全量并发中的 5 个非 Seatbelt 失败文件，单线程复跑：298 passed
- `fs-policy-seatbelt.e2e.test.ts` 在 TRAE 外层 sandbox 中仍有 4 个环境性失败（`sandbox-exec` 无法读取外层注入库），与本改动无关

真实 Developer ID 私钥仅存在于受保护的 `macos-signing` Environment，因此完整签名执行会在下一次 stable release 的审批 job 中验证。
