### PR TITLE
fix(traex): 透传触发人鉴权所需的 shell 环境变量

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -227,7 +227,7 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
     sandboxReadonlyPaths: () => [...TRAE_MIGRATION_DONE_MARKERS],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
-    buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, reasoningEffort, modelBackendVariant, disableCliBypass, bypassHookTrust, remoteWsUrl, remoteThreadId, nativeSubagentRuntimeHookCommand }) {
+    buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, reasoningEffort, modelBackendVariant, disableCliBypass, bypassHookTrust, remoteWsUrl, remoteThreadId, shellSubprocessEnv, nativeSubagentRuntimeHookCommand }) {
       // Hybrid RPC input mode (codex-family): attach the TUI to the botmux-owned
       // app-server thread; input flows via JSON-RPC (see codex-rpc-engine + worker)
       // instead of a drop-prone paste. TRAE CLI shares codex's --remote/resume
@@ -254,6 +254,11 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
         '--no-alt-screen',
         ...goalEnvConfigArgs(),
       ];
+      // Keep trigger-user identity wrappers available in tool shells. Set only
+      // the requested keys, without inheriting the entire worker environment.
+      for (const [key, value] of Object.entries(shellSubprocessEnv ?? {})) {
+        baseArgs.push('-c', `shell_environment_policy.set.${key}=${JSON.stringify(value)}`);
+      }
       if (model && model.trim()) baseArgs.push('--model', model.trim());
       if (reasoningEffort) baseArgs.push('-c', `model_reasoning_effort=${JSON.stringify(reasoningEffort)}`);
       if (modelBackendVariant) baseArgs.push('-c', `model_backend_variant=${JSON.stringify(modelBackendVariant)}`);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14297,12 +14297,14 @@ async function spawnCli(
   // buildArgs runs first; these are pure path derivations, so naming them early
   // is safe, and the block below is still what actually writes the files.
   //
-  // Only the shim vars: the wrapper reads the identity file itself, keyed by
-  // SESSION_DATA_DIR + BOTMUX_SESSION_ID, which the pane already carries. No
-  // credential is passed through this channel.
+  // Shim paths and the identity-file locator must reach the tool shell together.
+  // Use cfg.sessionId, not the native CLI resume id: the daemon publishes the
+  // identity under the Botmux session id. No credential is passed here.
   const identityShellEnv: Record<string, string> = {};
   if (cfg.triggerUserAuth?.enabled && process.env.SESSION_DATA_DIR) {
     const dir = sessionIdentityBinDir(process.env.SESSION_DATA_DIR, cfg.sessionId);
+    identityShellEnv.BOTMUX_SESSION_ID = cfg.sessionId;
+    identityShellEnv.SESSION_DATA_DIR = process.env.SESSION_DATA_DIR;
     identityShellEnv.BOTMUX_IDENTITY_BIN = dir;
     identityShellEnv.ZDOTDIR = join(dir, 'shell');
     identityShellEnv.BASH_ENV = join(dir, 'shell', 'bash_env.sh');
@@ -14341,8 +14343,8 @@ async function spawnCli(
     // agent from reading another person's token file today, and the likeliest
     // way that happens is an agent grepping the data dir to debug an auth error.
     triggerUserAuth: cfg.triggerUserAuth?.enabled === true,
-    // Adapters whose CLI filters the environment of the shell commands it runs
-    // (codex) re-declare these; the rest ignore them and inherit normally.
+    // Codex and TraeX explicitly set these in tool shells instead of depending
+    // on the CLI's default inheritance policy; other adapters inherit normally.
     ...(Object.keys(identityShellEnv).length ? { shellSubprocessEnv: identityShellEnv } : {}),
     locale: cfg.locale,
     model: ttadkGateway ? undefined : cfg.model,

--- a/test/traex-shell-env.test.ts
+++ b/test/traex-shell-env.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { createTraexAdapter } from '../src/adapters/cli/traex.js';
+
+const shellEnv = {
+  BOTMUX_IDENTITY_BIN: '/tmp/session "quoted"/bin',
+  ZDOTDIR: '/tmp/session/shell',
+  BASH_ENV: '/tmp/session/shell/bash_env.sh',
+  GIT_ASKPASS: '/tmp/session/bin/git-askpass',
+};
+
+function shellOverrides(args: string[]): Record<string, string> {
+  const prefix = 'shell_environment_policy.set.';
+  return Object.fromEntries(args.flatMap((arg, index) => {
+    if (!arg.startsWith(prefix)) return [];
+    expect(args[index - 1]).toBe('-c');
+    const separator = arg.indexOf('=');
+    return [[arg.slice(prefix.length, separator), JSON.parse(arg.slice(separator + 1))]];
+  }));
+}
+
+describe('TraeX trigger-user shell environment', () => {
+  it.each([false, true])('forwards the identity wrapper paths for resume=%s', (resume) => {
+    const args = createTraexAdapter('/bin/traex').buildArgs({
+      sessionId: 'botmux-session',
+      resume,
+      resumeSessionId: resume ? 'native-session' : undefined,
+      workingDir: '/tmp/project',
+      shellSubprocessEnv: shellEnv,
+    });
+
+    expect(shellOverrides(args)).toMatchObject(shellEnv);
+    expect(args).not.toContain('shell_environment_policy.inherit="all"');
+    expect(args).not.toContain('shell_environment_policy.ignore_default_excludes=true');
+    expect(args[args.indexOf('-C') + 1]).toBe('/tmp/project');
+    if (resume) {
+      expect(args[0]).toBe('resume');
+      expect(args.at(-1)).toBe('native-session');
+    }
+  });
+
+  it.each([undefined, {}])('keeps the launch unchanged without requested variables: %j', (env) => {
+    const adapter = createTraexAdapter('/bin/traex');
+    const request = { sessionId: 'botmux-session', resume: false };
+    expect(adapter.buildArgs({ ...request, shellSubprocessEnv: env }))
+      .toEqual(adapter.buildArgs(request));
+  });
+
+  it('forwards identity paths for a restricted CLI without granting bypass flags', () => {
+    const args = createTraexAdapter('/bin/traex').buildArgs({
+      sessionId: 'botmux-session',
+      resume: false,
+      disableCliBypass: true,
+      bypassHookTrust: true,
+      shellSubprocessEnv: shellEnv,
+    });
+
+    expect(shellOverrides(args)).toMatchObject(shellEnv);
+    expect(args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+    expect(args).not.toContain('--dangerously-bypass-hook-trust');
+  });
+
+  it('does not attach execution settings to the remote viewer', () => {
+    const adapter = createTraexAdapter('/bin/traex');
+    const request = {
+      sessionId: 'botmux-session',
+      resume: true,
+      remoteWsUrl: 'ws://127.0.0.1:9876',
+      remoteThreadId: 'remote-thread',
+    };
+
+    expect(adapter.buildArgs({ ...request, shellSubprocessEnv: shellEnv }))
+      .toEqual(adapter.buildArgs(request));
+  });
+});

--- a/test/trigger-user-shell-env.test.ts
+++ b/test/trigger-user-shell-env.test.ts
@@ -1,0 +1,115 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { createCodexAdapter } from '../src/adapters/cli/codex.js';
+import { createTraexAdapter } from '../src/adapters/cli/traex.js';
+import {
+  GIT_ASKPASS_BASENAME,
+  IDENTITY_DENIED_EXIT_CODE,
+  installIdentityWrapper,
+  publishActiveTurn,
+  sessionIdentityBinDir,
+  writeSessionIdentity,
+} from '../src/core/cli-identity.js';
+
+// worker.ts is a process entrypoint: execute its actual environment-assembly
+// block without starting a worker, rather than recreating that block in a fixture.
+const worker = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+const start = worker.indexOf('const identityShellEnv: Record<string, string> = {};');
+const end = worker.indexOf('const args = cliAdapter.buildArgs({', start);
+if (start < 0 || end <= start) throw new Error('Cannot locate worker identity environment assembly');
+const assembly = ts.transpileModule(worker.slice(start, end), {
+  compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.None },
+}).outputText;
+const assemble = new Function('cfg', 'process', 'sessionIdentityBinDir', 'join', 'GIT_ASKPASS_BASENAME',
+  'effectiveAdapterSessionId', `${assembly}\nreturn identityShellEnv;`);
+
+function workerShellEnv(sessionDataDir: string | undefined, enabled = true, tools = ['bytedcli']): Record<string, string> {
+  return assemble(
+    { sessionId: 'botmux-session', triggerUserAuth: { enabled, tools } },
+    { env: sessionDataDir === undefined ? {} : { SESSION_DATA_DIR: sessionDataDir } },
+    sessionIdentityBinDir, join, GIT_ASKPASS_BASENAME, 'native-session',
+  );
+}
+
+function shellOverrides(args: string[]): Record<string, string> {
+  const prefix = 'shell_environment_policy.set.';
+  return Object.fromEntries(args.flatMap((arg, index) => {
+    if (!arg.startsWith(prefix)) return [];
+    expect(args[index - 1]).toBe('-c');
+    const separator = arg.indexOf('=');
+    return [[arg.slice(prefix.length, separator), JSON.parse(arg.slice(separator + 1))]];
+  }));
+}
+
+describe('worker trigger-user shell contract', () => {
+  it('uses the credential file identity, not the native CLI resume identity', () => {
+    const dataDir = '/tmp/data "quoted"';
+    expect(workerShellEnv(dataDir)).toEqual({
+      BOTMUX_SESSION_ID: 'botmux-session',
+      SESSION_DATA_DIR: dataDir,
+      BOTMUX_IDENTITY_BIN: sessionIdentityBinDir(dataDir, 'botmux-session'),
+      ZDOTDIR: join(sessionIdentityBinDir(dataDir, 'botmux-session'), 'shell'),
+      BASH_ENV: join(sessionIdentityBinDir(dataDir, 'botmux-session'), 'shell', 'bash_env.sh'),
+      GIT_ASKPASS: join(sessionIdentityBinDir(dataDir, 'botmux-session'), GIT_ASKPASS_BASENAME),
+    });
+  });
+
+  it('does not request an environment when trigger-user auth is off or has no data root', () => {
+    expect(workerShellEnv('/tmp/data', false)).toEqual({});
+    expect(workerShellEnv(undefined)).toEqual({});
+  });
+
+  it('does not request git askpass for lark-only authentication', () => {
+    expect(workerShellEnv('/tmp/data', true, ['lark-cli'])).not.toHaveProperty('GIT_ASKPASS');
+  });
+});
+
+describe.each([
+  ['traex', createTraexAdapter],
+  ['codex', createCodexAdapter],
+] as const)('%s explicit identity environment', (_name, createAdapter) => {
+  it.each([false, true])('runs the real wrapper without inherited identity variables, resume=%s', (resume) => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-shell-env-'));
+    try {
+      const shellEnv = workerShellEnv(dataDir);
+      const realTool = join(dataDir, 'real-tool');
+      writeFileSync(realTool, '#!/bin/sh\nprintf "%s" "$BYTEDCLI_USER_CLOUD_JWT"\n', { mode: 0o755 });
+      const wrapper = installIdentityWrapper(shellEnv.BOTMUX_IDENTITY_BIN, 'bytedcli', realTool)!;
+      const args = createAdapter('/bin/cli').buildArgs({
+        sessionId: 'native-session',
+        resume,
+        resumeSessionId: resume ? 'native-session' : undefined,
+        shellSubprocessEnv: shellEnv,
+      });
+      // Model a shell receiving ONLY the adapter's explicit .set entries. This
+      // tests our contract, not any particular TRAE version's inheritance policy.
+      const toolEnv = { PATH: '/usr/bin:/bin', ...shellOverrides(args) };
+      expect(toolEnv).not.toHaveProperty('BYTEDCLI_USER_CLOUD_JWT');
+      const run = (env: Record<string, string> = toolEnv) => spawnSync('/bin/sh', [wrapper], {
+        env, encoding: 'utf8', timeout: 5_000,
+      });
+      const publish = (token: string, turnId: string) => {
+        writeSessionIdentity(dataDir, 'botmux-session', { tool: 'bytedcli', cloudJwt: token, turnId });
+        publishActiveTurn(dataDir, 'botmux-session', turnId);
+      };
+      publish('test-alice', 'turn-a');
+      expect(run()).toMatchObject({ status: 0, stdout: 'test-alice' });
+      publish('test-bob', 'turn-b');
+      expect(run()).toMatchObject({ status: 0, stdout: 'test-bob' });
+
+      for (const key of ['BOTMUX_SESSION_ID', 'SESSION_DATA_DIR']) {
+        const missing: Record<string, string> = { ...toolEnv };
+        delete missing[key];
+        expect(run(missing)).toMatchObject({ status: IDENTITY_DENIED_EXIT_CODE, stdout: '' });
+      }
+      publishActiveTurn(dataDir, 'botmux-session', 'turn-a');
+      expect(run()).toMatchObject({ status: IDENTITY_DENIED_EXIT_CODE, stdout: '' });
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
TraeX 的 `buildArgs` 原先忽略了 worker 提供的 `shellSubprocessEnv`。本变更让 TraeX 遵循已有适配器契约，显式配置触发人身份包装器所需的 shell 环境，避免依赖 CLI 的默认环境继承策略。

这里不将 TRAE 描述为已证实会过滤这些变量：评审者在 Linux TRAE 0.202.2 / 0.202.3 的 TUI 和 exec 模式下验证了默认继承可用。本 PR 解决的是显式环境配置契约不完整，未复现这些版本的实际鉴权故障。

具体变更：

- TraeX 将调用方请求的变量逐项编码为 `-c shell_environment_policy.set.<key>=<JSON string>`，覆盖新建和恢复会话。空参数和远端 TUI 查看器保持原行为。
- worker 在启用 `triggerUserAuth` 时，将 `BOTMUX_SESSION_ID` 和 `SESSION_DATA_DIR` 与已有的包装器路径一并放入 `shellSubprocessEnv`。会话 ID 使用写入身份文件的 `cfg.sessionId`，避免恢复会话时误用原生 CLI 的 session ID。
- 这两个定位变量同时由现有 Codex 和 TraeX 适配器显式传递。仅配置所需的会话 ID 和路径，不内联凭据、不使用 `inherit="all"`，不改变审批、沙箱或鉴权策略。

相关功能：#1266。

验证（macOS arm64，Bun 1.4.2 / Node 22.22.0）：

- 新增 worker 与真实 shell 包装器的回归测试：修复前 5 failed / 2 passed，修复后 7 passed。覆盖 canonical Botmux session ID、鉴权关闭、缺少数据根、按需 GIT_ASKPASS，以及 Codex / TraeX 的新建和恢复会话。
- 测试仅向真实 `/bin/sh` 提供适配器生成的显式环境配置，验证身份文件读取、下一轮切换用户、缺少任一定位变量时拒绝执行，以及轮次不匹配时拒绝执行。
- `bun run test test/trigger-user-shell-env.test.ts test/traex-shell-env.test.ts test/cli-adapters.test.ts test/cli-identity.test.ts test/trigger-user-auth.test.ts test/turn-cli-identity.test.ts`：6 个文件，552 passed。
- `bun run build`：通过，包含 TypeScript、脚本和测试 mock 类型检查及构建审计。
- `git diff --check`：通过。
- 已逐字节核对远端 PR 的四个文件与本地验证版本一致。

上述测试验证适配器配置与身份包装器之间的契约，不代表真实 TRAE 二进制的环境继承测试或多人登录端到端验收。