### PR TITLE
fix(bridge): Claude Code 的 <synthetic> 占位 assistant 行不再被当成正常完成，改判可重试失败

### DIFF
--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -36,6 +36,7 @@ import {
   extractTurnStartText,
   isClaudeTurnTerminalEvent,
   isTranscriptRateLimitEvent,
+  isSyntheticNoModelReplyEvent,
   classifyClaudeTerminalEvent,
   type ClaudeTerminalOutcome,
   type TranscriptEvent,
@@ -345,7 +346,12 @@ export class BridgeTurnQueue {
           continue;
         }
         const terminalOutcome = classifyClaudeTerminalEvent(ev);
-        if (ev.isApiErrorMessage === true) {
+        // The `<synthetic>` no-model-reply placeholder (see
+        // isSyntheticNoModelReplyEvent) takes the same exit as an API error:
+        // its "No response requested." text must not become the turn's reply,
+        // it must not synthesise a headless local turn, and the turn closes
+        // with the retryable failure the classifier produced.
+        if (ev.isApiErrorMessage === true || isSyntheticNoModelReplyEvent(ev)) {
           if (this.collecting && terminalOutcome?.status !== 'rate_limited') {
             this.collecting.terminalOutcome = terminalOutcome;
             this.collecting.terminalObserved = true;

--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -353,7 +353,15 @@ export class BridgeTurnQueue {
         // with the retryable failure the classifier produced.
         if (ev.isApiErrorMessage === true || isSyntheticNoModelReplyEvent(ev)) {
           if (this.collecting && terminalOutcome?.status !== 'rate_limited') {
-            this.collecting.terminalOutcome = terminalOutcome;
+            // `??=`, matching the normal terminal arm below: the FIRST terminal
+            // signal of a turn wins. A `<synthetic>` placeholder is the weakest
+            // possible one ("no model call happened"), and an execution-metadata
+            // error line is not stronger than a real reply either. Overwriting
+            // with `=` downgraded an already-`completed` turn to `failed`, and
+            // `emitReadyTurns` (`status !== 'completed' → continue`) then withheld
+            // the real answer text and let the daemon post a failure card for a
+            // turn that had in fact been answered. MEASURED both arms.
+            this.collecting.terminalOutcome ??= terminalOutcome;
             this.collecting.terminalObserved = true;
           }
           continue;

--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -350,18 +350,33 @@ export class BridgeTurnQueue {
         // isSyntheticNoModelReplyEvent) takes the same exit as an API error:
         // its "No response requested." text must not become the turn's reply,
         // it must not synthesise a headless local turn, and the turn closes
-        // with the retryable failure the classifier produced.
+        // with the retryable failure the classifier produced. The exit is
+        // shared; the assignment below is NOT - see the two branches.
         if (ev.isApiErrorMessage === true || isSyntheticNoModelReplyEvent(ev)) {
           if (this.collecting && terminalOutcome?.status !== 'rate_limited') {
-            // `??=`, matching the normal terminal arm below: the FIRST terminal
-            // signal of a turn wins. A `<synthetic>` placeholder is the weakest
-            // possible one ("no model call happened"), and an execution-metadata
-            // error line is not stronger than a real reply either. Overwriting
-            // with `=` downgraded an already-`completed` turn to `failed`, and
-            // `emitReadyTurns` (`status !== 'completed' → continue`) then withheld
-            // the real answer text and let the daemon post a failure card for a
-            // turn that had in fact been answered. MEASURED both arms.
-            this.collecting.terminalOutcome ??= terminalOutcome;
+            // The two signals that share this exit are NOT of equal authority,
+            // so they do not share an assignment operator (maintainer ruling on
+            // PR #1330):
+            if (ev.isApiErrorMessage === true) {
+              // An API-error line is authoritative execution metadata. When the
+              // connection drops mid-response, Claude force-closes the stream
+              // with an `end_turn` record whose text is a half-finished
+              // sentence, and that record has already written `completed` here.
+              // Letting the error win is what keeps the turn `failed` +
+              // retryable, which is the only thing ordinary-turn-recovery acts
+              // on (`status !== 'failed' || retryable !== true` → no
+              // continuation). Unconditional assignment, therefore.
+              this.collecting.terminalOutcome = terminalOutcome;
+            } else {
+              // The `<synthetic>` placeholder is the WEAKEST terminal signal
+              // there is - no model call happened at all (no requestId, usage
+              // all zero). It must not downgrade an already-`completed` turn:
+              // `emitReadyTurns` (`status !== 'completed' → continue`) would
+              // then withhold the real answer text AND let the daemon post a
+              // failure card for a turn that had in fact been answered. With no
+              // earlier terminal outcome it still records the failure.
+              this.collecting.terminalOutcome ??= terminalOutcome;
+            }
             this.collecting.terminalObserved = true;
           }
           continue;

--- a/src/services/claude-transcript.ts
+++ b/src/services/claude-transcript.ts
@@ -30,7 +30,10 @@ export interface TranscriptEvent {
      * reasons such as `end_turn` / `stop_sequence` close the logical turn. */
     stop_reason?: string | null;
     /** Model that actually served this reply (e.g. `claude-opus-4-8`). Claude
-     *  Code writes the placeholder `<synthetic>` on API-error records. */
+     *  Code writes the placeholder `<synthetic>` on records no model produced:
+     *  API-error records (`isApiErrorMessage:true`) and the bridge-resume
+     *  placeholder (`isApiErrorMessage:false`, text "No response requested.",
+     *  usage all zero, no `requestId`) — see {@link isSyntheticNoModelReplyEvent}. */
     model?: string;
   };
   /** API-error records. When the model call fails, Claude Code writes a
@@ -504,6 +507,37 @@ function hasApiErrorSignature(ev: TranscriptEvent, pattern: RegExp): boolean {
   return pattern.test(apiErrorMessageText(ev));
 }
 
+/** Model placeholder Claude Code writes on assistant records no model produced. */
+export const SYNTHETIC_MODEL_PLACEHOLDER = '<synthetic>';
+
+/**
+ * A `type:"assistant"` record that Claude Code wrote WITHOUT calling the model
+ * and WITHOUT flagging it as an API error. Observed shape (Claude Code 2.1.263,
+ * bridge resume of a turn that was cut mid-flight):
+ *
+ *     {"type":"assistant","isApiErrorMessage":false,
+ *      "message":{"model":"<synthetic>","stop_reason":"stop_sequence",
+ *                 "content":[{"type":"text","text":"No response requested."}],
+ *                 "usage":{"input_tokens":0,"output_tokens":0,...}}}
+ *
+ * It is always preceded (same timestamp) by an `isMeta` user record
+ * "Continue from where you left off.", and it carries no `requestId`.
+ *
+ * Such a record has every attribute the queue reads as "the model's final
+ * answer" — visible text block, terminal `stop_reason`, not an API error — but
+ * the user's message was never answered. Treating it as `completed` closes the
+ * Lark turn silently (measured: 53 such records across 26 local sessions, 39 of
+ * them directly after a Lark-delivered user message, none surfaced anywhere).
+ * Only `message.model` distinguishes it from a real reply.
+ */
+export function isSyntheticNoModelReplyEvent(ev: TranscriptEvent | null | undefined): boolean {
+  if (!ev || typeof ev !== 'object') return false;
+  if (ev.isApiErrorMessage === true) return false;
+  const role = ev.message?.role ?? ev.type;
+  if (role !== 'assistant') return false;
+  return ev.message?.model === SYNTHETIC_MODEL_PLACEHOLDER;
+}
+
 export function classifyClaudeTerminalEvent(
   ev: TranscriptEvent,
 ): ClaudeTerminalOutcome | undefined {
@@ -542,6 +576,14 @@ export function classifyClaudeTerminalEvent(
     return { status: 'ambiguous', errorCode: 'provider_unknown_error', retryable: false };
   }
   if (ev.type === 'system' && ev.subtype === 'turn_duration') return undefined;
+  // No model call happened, so nothing was answered; the input is still intact
+  // in the transcript, so a continuation can pick it up. `provider_` prefix on
+  // purpose: the daemon routes Claude execution failures (Wait-Mode settle,
+  // async sink, failure card) on that prefix, and the retry offer stays
+  // `caveated` — the cut turn may have run tools before it was resumed.
+  if (isSyntheticNoModelReplyEvent(ev)) {
+    return { status: 'failed', errorCode: 'provider_no_model_reply', retryable: true };
+  }
   const role = ev.message?.role ?? ev.type;
   if (role !== 'assistant') return undefined;
   const reason = ev.message?.stop_reason;

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -689,14 +689,22 @@ describe('BridgeTurnQueue', () => {
       expect(ready[0].terminalOutcome).toEqual({ status: 'completed' });
     });
 
-    it('same first-signal-wins rule for the API-error arm it shares', () => {
+    // The API-error arm does NOT share that rule: an error line is authoritative
+    // execution metadata, and the `end_turn` before it is, in the connection-lost
+    // case, a force-closed half sentence. The error must win so the turn stays
+    // `failed` + retryable - the only shape ordinary-turn-recovery acts on
+    // (ordinary-turn-recovery.ts: `status !== 'failed' || retryable !== true`
+    // → no continuation). Maintainer ruling on PR #1330.
+    it('lets an API-error line override an earlier completed outcome (recovery must still fire)', () => {
       const q = new BridgeTurnQueue();
       q.mark('t1');
       q.ingest([user('u1'), realReply('a1', 'the real answer'), apiErrorLine('e1')]);
       const ready = q.drainEmittable();
       expect(ready.length).toBe(1);
       expect(ready[0].assistantUuids).toEqual(['a1']);
-      expect(ready[0].terminalOutcome).toEqual({ status: 'completed' });
+      expect(ready[0].terminalOutcome).toEqual({
+        status: 'failed', errorCode: 'provider_server_error', retryable: true,
+      });
     });
 
     it('still records the failure when the turn has no earlier terminal', () => {

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -608,6 +608,60 @@ describe('BridgeTurnQueue', () => {
     });
   });
 
+  describe('synthetic no-model-reply assistant records', () => {
+    // Claude Code bridge-resume placeholder (see isSyntheticNoModelReplyEvent):
+    // visible text, terminal stop_reason, isApiErrorMessage:false — every
+    // attribute the queue used to read as "the model's final answer", but no
+    // model call happened and the Lark message was never answered.
+    function metaContinue(uuid: string): TranscriptEvent {
+      return {
+        type: 'user', uuid, isMeta: true,
+        message: { role: 'user', content: [{ type: 'text', text: 'Continue from where you left off.' }] },
+      } as TranscriptEvent;
+    }
+    function syntheticNoReply(uuid: string, model = '<synthetic>'): TranscriptEvent {
+      return {
+        type: 'assistant', uuid, isApiErrorMessage: false,
+        message: { role: 'assistant', model, stop_reason: 'stop_sequence', content: [{ type: 'text', text: 'No response requested.' }] },
+      } as TranscriptEvent;
+    }
+
+    it('closes the pending Lark turn as a retryable failure instead of attributing the placeholder text', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('t1');
+      q.ingest([user('u1'), metaContinue('m1'), syntheticNoReply('s1')]);
+      const ready = q.drainEmittable();
+      expect(ready.length).toBe(1);
+      expect(ready[0].turnId).toBe('t1');
+      expect(ready[0].assistantUuids).toEqual([]);
+      expect(ready[0].terminalObserved).toBe(true);
+      expect(ready[0].terminalOutcome).toEqual({
+        status: 'failed', errorCode: 'provider_no_model_reply', retryable: true,
+      });
+    });
+
+    it('control: the same record served by a real model is the completed reply', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('t1');
+      q.ingest([user('u1'), metaContinue('m1'), syntheticNoReply('s1', 'claude-opus-4-8')]);
+      const ready = q.drainEmittable();
+      expect(ready.length).toBe(1);
+      expect(ready[0].assistantUuids).toEqual(['s1']);
+      expect(ready[0].terminalOutcome).toEqual({ status: 'completed' });
+    });
+
+    it('does not synthesise a headless local turn out of the placeholder', () => {
+      const q = new BridgeTurnQueue();
+      q.ingest([metaContinue('m1'), syntheticNoReply('s1')]);
+      expect(q.size()).toBe(0);
+      // control: a real headless reply still gets its local turn
+      const q2 = new BridgeTurnQueue();
+      q2.ingest([metaContinue('m1'), syntheticNoReply('s1', 'claude-opus-4-8')]);
+      expect(q2.size()).toBe(1);
+      expect(q2.peek()[0].isLocal).toBe(true);
+    });
+  });
+
   describe('synthetic / non-meaningful user events', () => {
     function syntheticUser(content: string, extra: Record<string, unknown> = {}): TranscriptEvent {
       return { type: 'user', uuid: `sx-${content.slice(0, 10)}`, message: { role: 'user', content }, ...extra } as TranscriptEvent;

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -660,6 +660,55 @@ describe('BridgeTurnQueue', () => {
       expect(q2.size()).toBe(1);
       expect(q2.peek()[0].isLocal).toBe(true);
     });
+
+    // The placeholder is the WEAKEST terminal signal there is: it says "no model
+    // call happened". It must never overwrite a stronger outcome the same turn
+    // already carries, because worker.ts (`terminalOutcome.status !== 'completed'
+    // → continue`) would then withhold the real answer text AND let the daemon
+    // post a failure card for a turn that was in fact answered.
+    function realReply(uuid: string, text: string): TranscriptEvent {
+      return {
+        type: 'assistant', uuid, isApiErrorMessage: false,
+        message: { role: 'assistant', model: 'claude-opus-4-8', stop_reason: 'end_turn', content: [{ type: 'text', text }] },
+      } as TranscriptEvent;
+    }
+    function apiErrorLine(uuid: string): TranscriptEvent {
+      return {
+        type: 'assistant', uuid, isApiErrorMessage: true, error: 'server_error', apiErrorStatus: 500,
+        message: { role: 'assistant', model: '<synthetic>', stop_reason: 'stop_sequence', content: [{ type: 'text', text: 'API Error: 500' }] },
+      } as TranscriptEvent;
+    }
+
+    it('does not downgrade a turn that already completed with a real reply', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('t1');
+      q.ingest([user('u1'), realReply('a1', 'the real answer'), syntheticNoReply('s1')]);
+      const ready = q.drainEmittable();
+      expect(ready.length).toBe(1);
+      expect(ready[0].assistantUuids).toEqual(['a1']);
+      expect(ready[0].terminalOutcome).toEqual({ status: 'completed' });
+    });
+
+    it('same first-signal-wins rule for the API-error arm it shares', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('t1');
+      q.ingest([user('u1'), realReply('a1', 'the real answer'), apiErrorLine('e1')]);
+      const ready = q.drainEmittable();
+      expect(ready.length).toBe(1);
+      expect(ready[0].assistantUuids).toEqual(['a1']);
+      expect(ready[0].terminalOutcome).toEqual({ status: 'completed' });
+    });
+
+    it('still records the failure when the turn has no earlier terminal', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('t1');
+      q.ingest([user('u1'), syntheticNoReply('s1')]);
+      const ready = q.drainEmittable();
+      expect(ready[0].terminalOutcome).toEqual({
+        status: 'failed', errorCode: 'provider_no_model_reply', retryable: true,
+      });
+      expect(ready[0].terminalObserved).toBe(true);
+    });
   });
 
   describe('synthetic / non-meaningful user events', () => {

--- a/test/claude-transcript.test.ts
+++ b/test/claude-transcript.test.ts
@@ -27,6 +27,7 @@ import {
   splitTranscriptEventsByCutoff,
   isTranscriptRateLimitEvent,
   classifyClaudeTerminalEvent,
+  isSyntheticNoModelReplyEvent,
   apiErrorMessageText,
   type TranscriptEvent,
 } from '../src/services/claude-transcript.js';
@@ -182,6 +183,64 @@ describe('isTranscriptRateLimitEvent', () => {
   it('apiErrorMessageText recovers the human retry clock from the record text', () => {
     const ev: TranscriptEvent = { type: 'assistant', uuid: 'r', error: 'rate_limit', message: { role: 'assistant', content: [{ type: 'text', text: "You've hit your session limit · resets 10:40pm (America/Los_Angeles)" }] } };
     expect(apiErrorMessageText(ev)).toContain('resets 10:40pm');
+  });
+});
+
+describe('synthetic no-model-reply records', () => {
+  // Byte-shape of a record observed in a live Claude Code 2.1.263 transcript:
+  // the bridge resumed a turn that had been cut mid-flight, wrote an `isMeta`
+  // user "Continue from where you left off." and this assistant placeholder
+  // with the same timestamp, and never called the model (no `requestId`,
+  // usage all zero). The Lark message that started the turn got no answer.
+  function syntheticNoReply(extra: Record<string, unknown> = {}): TranscriptEvent {
+    return {
+      type: 'assistant',
+      uuid: 'a6e59f9c-8ca4-4907-bc62-b9ae78206e37',
+      timestamp: '2026-09-08T10:56:21.981Z',
+      isApiErrorMessage: false,
+      message: {
+        role: 'assistant',
+        model: '<synthetic>',
+        stop_reason: 'stop_sequence',
+        content: [{ type: 'text', text: 'No response requested.' }],
+      },
+      ...extra,
+    } as TranscriptEvent;
+  }
+
+  it('recognises the placeholder by model, not by text', () => {
+    expect(isSyntheticNoModelReplyEvent(syntheticNoReply())).toBe(true);
+    expect(isSyntheticNoModelReplyEvent(syntheticNoReply({
+      message: { role: 'assistant', model: '<synthetic>', stop_reason: 'stop_sequence', content: [{ type: 'text', text: 'anything' }] },
+    }))).toBe(true);
+  });
+
+  it('leaves API-error records to the API-error classifier', () => {
+    const apiErr = syntheticNoReply({ isApiErrorMessage: true, error: 'unknown' });
+    expect(isSyntheticNoModelReplyEvent(apiErr)).toBe(false);
+    expect(classifyClaudeTerminalEvent(apiErr)).toEqual({
+      status: 'ambiguous', errorCode: 'provider_unknown_error', retryable: false,
+    });
+  });
+
+  it('a real model reply of the same shape is still a completed turn', () => {
+    const real = syntheticNoReply({
+      requestId: 'req_011CN',
+      message: { role: 'assistant', model: 'claude-opus-4-8', stop_reason: 'end_turn', content: [{ type: 'text', text: 'done' }] },
+    });
+    expect(isSyntheticNoModelReplyEvent(real)).toBe(false);
+    expect(classifyClaudeTerminalEvent(real)).toEqual({ status: 'completed' });
+  });
+
+  it('classifies the placeholder as a retryable failure, never as completed', () => {
+    expect(classifyClaudeTerminalEvent(syntheticNoReply())).toEqual({
+      status: 'failed', errorCode: 'provider_no_model_reply', retryable: true,
+    });
+  });
+
+  it('ignores sidechain and non-assistant records', () => {
+    expect(isSyntheticNoModelReplyEvent(syntheticNoReply({ type: 'user', message: { role: 'user', model: '<synthetic>', content: 'x' } }))).toBe(false);
+    expect(classifyClaudeTerminalEvent(syntheticNoReply({ isSidechain: true }))).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## 现象

Claude Code（本机 2.1.263）在 bridge 恢复会话（`Continue from where you left off.` 的 isMeta 用户行）之后，会往转录里写一条**没有任何模型调用**的 assistant 行：

```json
{"type":"assistant","message":{"role":"assistant","model":"<synthetic>","stop_reason":"stop_sequence","usage":{"input_tokens":0,"output_tokens":0,…},"content":[{"type":"text","text":"No response requested."}]},"isApiErrorMessage":false}
```

无 `requestId`、usage 全 0。它和 API 错误行共用 `<synthetic>` 这个 model 占位，但 `isApiErrorMessage` 是 `false`。

现在的处理：`BridgeTurnQueue.ingest` 的 assistant 分支只排除 rate-limit 与 `isApiErrorMessage === true`；`classifyClaudeTerminalEvent` 对任何带终止 `stop_reason` 的 assistant 行返回 `completed`。于是这条占位行被当成一次正常完成：uuid 被归属给挂起的 Lark 轮，轮关闭，**用户那条消息被静默吞掉**——不走 ordinary-turn-recovery、不出失败卡片、不出重试卡片。

本机基率：26 个 Claude Code 会话转录里 53 行同形，其中 39 行紧跟 Lark `<user_message>` 用户行（另 4 行跟其他 botmux 标签、10 行来自本地会话）。三次现场都发生在一个约 1 分钟的 Bash 工具调用进行中，之前 5–24 秒 daemon 日志有 `Ignored unbound stale managed turn origin revoke`。**谁切断了进行中的那轮，本 PR 不下结论**；本 PR 只修「切断之后 botmux 把占位行读成正常完成」这一层。

## 修法

- `src/services/claude-transcript.ts`
  - 新增 `isSyntheticNoModelReplyEvent(ev)`：assistant 行、`message.model === '<synthetic>'`、且 `isApiErrorMessage !== true`（API 错误行仍交给原有分类）。
  - `classifyClaudeTerminalEvent` 对它返回 `{ status: 'failed', errorCode: 'provider_no_model_reply', retryable: true }`。选 `provider_` 前缀是为了让 daemon 现有的 `errorCode.startsWith('provider_')` 路由生效（ordinary-turn-recovery 的 continuation / 失败卡片），`turnRetryOffer` 保持 `caveated`。
- `src/services/bridge-turn-queue.ts`
  - ingest 的 assistant 分支把它和 `isApiErrorMessage === true` 走同一条退出：不做文本归属、不合成 headless 本地轮，用分类器的可重试失败关闭挂起轮。

真实模型同形（`model` 为真实模型 id、同样 stop_sequence）不受影响，测试里有对照。

## 验证

- `test/claude-transcript.test.ts` 新增 5 个用例，`test/bridge-turn-queue.test.ts` 新增 3 个（含真实模型对照、API 错误行对照、headless 对照）。
- 相关 10 个测试文件：`bridge-turn-journal / bridge-turn-queue / claude-model-fallback-transcript / claude-transcript / claude-turn-terminal-contract / model-fallback-daemon-state / model-fallback-wiring / ordinary-turn-recovery / thinking-transcript / turn-failure-card` ⇒ 396/396 通过。
- 去掉 src 改动只留测试 ⇒ 7 个用例红（变异对照）。
- `tsc --noEmit -p tsconfig.json` 通过。
- 用真实转录（脱敏成三行）喂生产 `BridgeTurnQueue`：修前 `completed` 且占位 uuid 被归属；修后 `failed / provider_no_model_reply / retryable:true`，API 错误行与真实模型行读数不变。
- 全量 `bun run test` 我这台机没跑完（1261 个文件，tmux 相关集成用例在无 tmux server 环境下超时），交给 CI。

## 未定 / 请维护者裁

1. `errorCode` 命名：`provider_no_model_reply` 是为了复用 `provider_` 路由；若你们更想把它单列（例如不进 provider 失败统计），改名即可，测试只断言这个字符串。
2. 53 行里有 7 行前面不是 isMeta 的 continue 行；本 PR 只按 `model === '<synthetic>'` 判，不依赖前一行，所以同样覆盖，但那 7 行的成因我没查。
3. 是否要在 journal / 去重侧再做点什么（例如同一原消息重试时的去重键），我没动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HHfZWeW2Q2W476zbAXVQp
