### PR TITLE
fix(terminal): make overflowing fixed grids fully scrollable

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17614,6 +17614,13 @@ body{display:flex;flex-direction:column;height:100vh;height:100dvh}
 @media(prefers-reduced-motion:reduce){#toolbar,#toolbar.collapsed{transition:opacity .12s linear}}
 #terminal{flex:1;min-width:0;min-height:0;width:100%;height:100%}
 #terminal .xterm{height:100%}
+/* Fixed remote grids need canvas scrolling in addition to xterm history.
+   Reserve the same 15px scrollbar allowance as FitAddon beside the last column. */
+#terminal.fixed-grid{overflow:auto}
+#terminal.fixed-grid .xterm{height:auto;width:max-content;padding-right:15px}
+/* Hidden input helpers can retain old cursor coordinates after a font resize.
+   They must not extend the outer scroll range past the rendered final row. */
+#terminal.fixed-grid .xterm-screen{overflow:clip}
 /* Real scroll container is xterm's own viewport — kill iOS rubber-band bounce
    and momentum here (not just on body), and reserve gestures for pinch-zoom so
    single-finger drag is driven manually by the touch handler below. */
@@ -17923,8 +17930,8 @@ window.addEventListener('message',function(_ev){
     // 1.3 对中文密集的 TUI 内容还是偏松：汉字撑满 em 框，行间空隙观感接近隔行，于是
     // 再收一档到 1.15（单元格高约 18.2px），比经典松一成半，读起来才连成一段。
     term.options.lineHeight=_d.termStyle==='reader'?1.15:1;
-    // 行距变了可视行数就变，必须复算一次。几何契约不动：只有画布内重绘。
-    fit.fit();
+    // Refit only an owned grid; followers must preserve the remote row/column count.
+    if(!fixedSize)fit.fit();
   }catch(_e){}
 });
 // xterm parses writes asynchronously.  On a brand-new page the first tmux /
@@ -17940,11 +17947,11 @@ function _cancelInitialFollow(){
 }
 function _settleInitialBottom(){
   if(!_initialFollow)return;
-  try{term.scrollToBottom()}catch(_e){}
+  try{term.scrollToBottom();_followFixedGridBottom()}catch(_e){}
   clearTimeout(_initialFollowT);
   _initialFollowT=setTimeout(function(){
     if(!_initialFollow)return;
-    try{term.scrollToBottom()}catch(_e){}
+    try{term.scrollToBottom();_followFixedGridBottom()}catch(_e){}
     _initialFollow=false;
   },500);
 }
@@ -18136,6 +18143,46 @@ term.onData(function(d){
   _sendInput(d);
 });
 var fixedSize=false,_lastC=0,_lastR=0,_rzT=0;
+function _setFixedGrid(enabled){
+  fixedSize=enabled;
+  var host=document.getElementById('terminal');
+  host.classList.toggle('fixed-grid',enabled);
+  if(!enabled){host.scrollTop=0;host.scrollLeft=0;}
+}
+function _followFixedGridBottom(){
+  if(fixedSize){var host=document.getElementById('terminal');host.scrollTop=host.scrollHeight;}
+}
+function _scrollFixedGrid(dx,dy){
+  if(!fixedSize)return false;
+  var host=document.getElementById('terminal'),x=host.scrollLeft,y=host.scrollTop;
+  host.scrollLeft+=dx;host.scrollTop+=dy;
+  return host.scrollLeft!==x||host.scrollTop!==y;
+}
+// Reveal the canvas before xterm or the remote-wheel handler consumes gestures.
+// At the canvas edge, normal terminal history scrolling resumes.
+var _fixedHost=document.getElementById('terminal'),_fixedTouch=null;
+_fixedHost.addEventListener('wheel',function(e){
+  if(e.ctrlKey)return;
+  var unit=e.deltaMode===1?16:e.deltaMode===2?_fixedHost.clientHeight:1;
+  if(_scrollFixedGrid(e.deltaX*unit,e.deltaY*unit)){
+    e.preventDefault();e.stopImmediatePropagation();
+  }
+},{capture:true,passive:false});
+_fixedHost.addEventListener('touchstart',function(e){
+  _fixedTouch=e.touches.length===1?{x:e.touches[0].clientX,y:e.touches[0].clientY}:null;
+},{capture:true,passive:true});
+_fixedHost.addEventListener('touchmove',function(e){
+  if(!_fixedTouch||e.touches.length!==1){_fixedTouch=null;return;}
+  var touch=e.touches[0],dx=_fixedTouch.x-touch.clientX,dy=_fixedTouch.y-touch.clientY;
+  _fixedTouch={x:touch.clientX,y:touch.clientY};
+  if(_scrollFixedGrid(dx,dy)){
+    // Keep the downstream touch handler's anchor current when it resumes.
+    _tLastY=touch.clientY;
+    e.preventDefault();e.stopImmediatePropagation();
+  }
+},{capture:true,passive:false});
+_fixedHost.addEventListener('touchend',function(){_fixedTouch=null;},{passive:true});
+_fixedHost.addEventListener('touchcancel',function(){_fixedTouch=null;},{passive:true});
 function sendResize(){
   if(!ws_||ws_.readyState!==1)return;
   // Dedup: a fit that lands on the same grid must NOT re-emit a resize — for a
@@ -18225,20 +18272,20 @@ if(typeof ResizeObserver!=='undefined'){
     // own viewport and reports the new size back to the worker.
     var _hf=data.match(/\\x1b\\]1989;follower;(\\d+);(\\d+)\\x07/);
     if(_hf){
-      fixedSize=true;var _hc=+_hf[1],_hr=+_hf[2];
+      _setFixedGrid(true);var _hc=+_hf[1],_hr=+_hf[2];
       if(_hc>0&&_hr>0){try{term.resize(_hc,_hr)}catch(ex){}_lastC=_hc;_lastR=_hr}
       data=data.replace(_hf[0],'');
     }
     var _ho=data.match(/\\x1b\\]1989;owner\\x07/);
     if(_ho){
-      fixedSize=false;data=data.replace(_ho[0],'');
+      _setFixedGrid(false);data=data.replace(_ho[0],'');
       try{fit.fit()}catch(ex){}
       _lastC=_lastR=0;sendResize();
     }
     // botmux OSC 1989: pin the xterm to the adopted pane's fixed size (the pane
     // can't be resized, so FitAddon-to-browser would wrap the snapshot lines).
     var _fs=data.match(/\\x1b\\]1989;(\\d+);(\\d+)\\x07/);
-    if(_fs){fixedSize=true;var _c=+_fs[1],_r=+_fs[2];if(_c>0&&_r>0){try{term.resize(_c,_r)}catch(ex){}}data=data.replace(_fs[0],'')}
+    if(_fs){_setFixedGrid(true);var _c=+_fs[1],_r=+_fs[2];if(_c>0&&_r>0){try{term.resize(_c,_r)}catch(ex){}}data=data.replace(_fs[0],'')}
     // Intercept OSC 52 clipboard sequence from tmux (set-clipboard on)
     var m=data.match(/\\x1b\\]52;[^;]*;([A-Za-z0-9+/=]+)(?:\\x07|\\x1b\\\\)/);
     if(m){try{_clipBuf=new TextDecoder().decode(Uint8Array.from(atob(m[1]),function(c){return c.charCodeAt(0)}));_doCopy(_clipBuf);_showCopied()}catch(ex){}}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -18155,8 +18155,14 @@ function _followFixedGridBottom(){
 function _scrollFixedGrid(dx,dy){
   if(!fixedSize)return false;
   var host=document.getElementById('terminal'),x=host.scrollLeft,y=host.scrollTop;
-  host.scrollLeft+=dx;host.scrollTop+=dy;
-  return host.scrollLeft!==x||host.scrollTop!==y;
+  // Consume only the dominant axis: minor cross-axis drift must not swallow
+  // a gesture that should reach terminal history at the canvas boundary.
+  if(Math.abs(dy)>=Math.abs(dx)){
+    host.scrollTop+=dy;
+    return host.scrollTop!==y;
+  }
+  host.scrollLeft+=dx;
+  return host.scrollLeft!==x;
 }
 // Reveal the canvas before xterm or the remote-wheel handler consumes gestures.
 // At the canvas edge, normal terminal history scrolling resumes.

--- a/test/agent-workbench-term-appearance-bridge.test.ts
+++ b/test/agent-workbench-term-appearance-bridge.test.ts
@@ -86,7 +86,7 @@ interface Harness {
   fire: (data: unknown, source?: unknown) => void;
 }
 
-function bootTerminalPage(): Harness {
+function bootTerminalPage(fixedSize = false): Harness {
   const term: TermStub = { options: {} };
   let fits = 0;
   const fit = { fit: () => { fits += 1; } };
@@ -98,8 +98,8 @@ function bootTerminalPage(): Harness {
       if (type === 'message') handlers.push(handler);
     },
   };
-  // 子页那段是浏览器端 ES5 脚本，用 Function 注入它依赖的三个外部符号。
-  new Function('term', 'fit', 'window', extractTerminalPageListener())(term, fit, win);
+  // Inject the browser listener dependencies, including remote grid ownership.
+  new Function('term', 'fit', 'window', 'fixedSize', extractTerminalPageListener())(term, fit, win, fixedSize);
   expect(handlers.length, '监听器没挂上').toBe(1);
   return {
     term,
@@ -112,6 +112,13 @@ function bootTerminalPage(): Harness {
 }
 
 describe('工作台 → 终端 iframe 的外观下发接缝', () => {
+  it('preserves a fixed remote grid when changing terminal appearance', () => {
+    const page = bootTerminalPage(true);
+    page.fire(workbenchTermAppearanceMessage('reader', 'ink'));
+    expect(page.term.options.lineHeight).toBe(WORKBENCH_TERM_LINE_HEIGHTS.reader);
+    expect(page.fitCount()).toBe(0);
+  });
+
   it('父页构造的 8 种载荷（4 皮肤 × 2 风格）子页全部收下，主题逐色落到 xterm', () => {
     for (const skin of WORKBENCH_SKIN_IDS) {
       for (const termStyle of WORKBENCH_TERM_STYLES) {

--- a/test/web-terminal-fixed-grid-scroll.test.ts
+++ b/test/web-terminal-fixed-grid-scroll.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+const start = source.indexOf('function _scrollFixedGrid(dx,dy){');
+const end = source.indexOf('function sendResize(){', start);
+if (start < 0 || end < 0) throw new Error('Fixed-grid event handlers not found');
+const script = source.slice(start, end);
+
+type Input = 'wheel' | 'touch';
+interface Gesture {
+  ctrlKey: boolean;
+  deltaMode: number;
+  deltaX: number;
+  deltaY: number;
+  touches: { clientX: number; clientY: number }[];
+  preventDefault(): void;
+  stopImmediatePropagation(): void;
+}
+
+function boot(input: Input, left = 100, top = 100, fixedSize = true) {
+  const listeners = new Map<string, (event: Gesture) => void>();
+  // Model browser scroll clamping: both axes have a 200px scroll range.
+  const host = {
+    clientHeight: 100,
+    get scrollLeft() { return left; },
+    set scrollLeft(value: number) { left = Math.max(0, Math.min(200, value)); },
+    get scrollTop() { return top; },
+    set scrollTop(value: number) { top = Math.max(0, Math.min(200, value)); },
+    addEventListener(name: string, handler: (event: Gesture) => void) {
+      listeners.set(name, handler);
+    },
+  };
+  const context = { fixedSize, _tLastY: 300, document: { getElementById: () => host } };
+  runInNewContext(script, context);
+  let touchX = 300;
+  let touchY = 300;
+  function fire(name: string, dx = 0, dy = 0, ctrlKey = false, deltaMode = 0) {
+    let prevented = false;
+    let stopped = false;
+    const handler = listeners.get(name);
+    if (!handler) throw new Error(`Missing ${name} handler`);
+    handler({
+      ctrlKey, deltaMode, deltaX: dx, deltaY: dy,
+      touches: [{ clientX: touchX, clientY: touchY }],
+      preventDefault() { prevented = true; },
+      stopImmediatePropagation() { stopped = true; },
+    });
+    return { prevented, stopped };
+  }
+  if (input === 'touch') fire('touchstart');
+  return {
+    host, context,
+    move(dx: number, dy: number, ctrlKey = false, deltaMode = 0) {
+      touchX -= dx;
+      touchY -= dy;
+      return fire(input === 'touch' ? 'touchmove' : 'wheel', dx, dy, ctrlKey, deltaMode);
+    },
+  };
+}
+
+describe.each<Input>(['wheel', 'touch'])('fixed-grid %s gestures', (input) => {
+  it.each([0, 200])('passes vertical intent downstream at boundary %i despite horizontal jitter', (top) => {
+    const page = boot(input, 100, top);
+    const result = page.move(1, top === 0 ? -100 : 100);
+    expect(result).toEqual({ prevented: false, stopped: false });
+    expect(page.host.scrollLeft).toBe(100);
+    expect(page.host.scrollTop).toBe(top);
+  });
+
+  it('scrolls only vertically for predominantly vertical input inside the canvas', () => {
+    const page = boot(input);
+    expect(page.move(1, 30)).toEqual({ prevented: true, stopped: true });
+    expect(page.host.scrollTop).toBe(130);
+    expect(page.host.scrollLeft).toBe(100);
+  });
+
+  it('scrolls only horizontally for predominantly horizontal input', () => {
+    const page = boot(input);
+    expect(page.move(30, 1)).toEqual({ prevented: true, stopped: true });
+    expect(page.host.scrollLeft).toBe(130);
+    expect(page.host.scrollTop).toBe(100);
+  });
+
+  it('passes a horizontal edge gesture downstream without consuming vertical jitter', () => {
+    const page = boot(input, 200, 100);
+    expect(page.move(30, 1)).toEqual({ prevented: false, stopped: false });
+    expect(page.host.scrollTop).toBe(100);
+  });
+
+  it('reaches the canvas edge before yielding subsequent gestures to terminal history', () => {
+    const page = boot(input, 100, 190);
+    expect(page.move(1, 30).stopped).toBe(true);
+    expect(page.host.scrollTop).toBe(200);
+    expect(page.move(1, 30).stopped).toBe(false);
+    expect(page.host.scrollLeft).toBe(100);
+    if (input === 'touch') expect(page.context._tLastY).toBe(270);
+  });
+
+  it('leaves owned viewport gestures to the normal terminal handlers', () => {
+    const page = boot(input, 100, 100, false);
+    expect(page.move(1, 30)).toEqual({ prevented: false, stopped: false });
+    expect(page.host.scrollTop).toBe(100);
+    expect(page.host.scrollLeft).toBe(100);
+  });
+});
+
+it('preserves Ctrl-wheel zoom gestures', () => {
+  const page = boot('wheel');
+  expect(page.move(1, 30, true)).toEqual({ prevented: false, stopped: false });
+  expect(page.host.scrollTop).toBe(100);
+});
+
+it.each([1, 2])('passes diagonal wheel input at the bottom in delta mode %i', (mode) => {
+  const page = boot('wheel', 100, 200);
+  expect(page.move(0.1, 1, false, mode)).toEqual({ prevented: false, stopped: false });
+  expect(page.host.scrollLeft).toBe(100);
+});


### PR DESCRIPTION
Adopted sessions and follower terminals preserve the remote pane's fixed grid. When that grid is larger than the browser viewport, the page clips the bottom rows and rightmost columns even with xterm's history scrollbar at the bottom. In the reported case, a 1376px canvas was clipped by a 1145px viewport.

This change makes the fixed canvas independently scrollable while preserving remote row and column counts. Wheel and single-finger gestures reveal the canvas before falling through to terminal history at its edges. Initial loading follows the canvas bottom, promotion to owner restores viewport fitting, and appearance updates keep fixed grids intact. Hidden input helpers are clipped so stale cursor coordinates cannot extend the outer scroll range after font resizing.

Validation:
- 70 tests passed across the terminal script parsing, initial follow, touch scrolling, mobile input, mouse modes, appearance bridge, and Herdr binding suites. Includes a regression test for appearance updates preserving fixed grids.
- TypeScript check (`tsc --noEmit`) and `git diff --check` passed.
- Isolated Chrome validation with the actual generated terminal page and xterm: bottom/right reachability, narrow viewport, adopt/follower modes, and promotion back to owner.
- The reporter verified the isolated page in both desktop and mobile Feishu and confirmed that the final row is fully visible and scrolling works.

The browser fixture uses simulated output; the change has not been deployed to the reporter's live Botmux service. Existing adopted sessions were left running throughout validation.
