### PR TITLE
fix(runtime): 修复 Codex 启动投递与 Claude 故障续跑

### DIFF
--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -412,6 +412,14 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
     // but reject numbered menu choices. This remains necessary for wrappers
     // such as Aiden that cannot forward the startup-update config override.
     readyPattern: /›(?!\s*\d+\.)|\d+% left/,
+    // 0.153.x paints a skeleton composer before thread initialization. The
+    // `›` and two seconds of silence do not prove it can submit yet; history
+    // can remain empty throughout bootstrap even when a TUI input is queued.
+    // Release only on complete initialized banner cells, including custom
+    // models/paths. The footer can already show a model during loading. Match
+    // cell boundaries, not literal newlines: PTY redraws also move the cursor.
+    startupPendingPattern: /│[ \t]+(?:model|directory):[ \t]+loading\b/,
+    startupReadyPattern: /│[ \t]+model:[ \t]+(?!loading\b)[^│\s][^│\r\n]*│[ \t\r\n]*│[ \t]+directory:[ \t]+(?!loading\b)[^│\s][^│\r\n]*│/,
     // Codex cold starts can exceed the worker's 15s soft first-prompt timeout.
     // Wait for the real composer marker so the bare-shell guard does not treat
     // a still-loading zsh wrapper as a failed launch.

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -462,6 +462,13 @@ export interface CliAdapter {
    *  Examples: CoCo `⏵⏵` status bar, Codex `›` prompt indicator. */
   readonly readyPattern?: RegExp;
 
+  /** Optional first-start screen gate. Some CLIs draw their composer before
+   * initialization finishes. A pending marker holds screen idle and queued
+   * input until startupReadyPattern or an authoritative transcript idle.
+   * It survives per-turn resets and is retired once per IdleDetector/spawn. */
+  readonly startupPendingPattern?: RegExp;
+  readonly startupReadyPattern?: RegExp;
+
   /** When true, the adapter injects a `SessionStart` hook that calls
    *  `botmux session-ready` once the CLI's input box is genuinely rendered —
    *  Claude-family via its effective settings.json, Grok via its global

--- a/src/core/scheduled-turn-provenance.ts
+++ b/src/core/scheduled-turn-provenance.ts
@@ -27,10 +27,11 @@
  *      in that configuration. This is a known limitation, not a regression:
  *      scheduled tasks themselves (prompt execution) never checked owner.
  */
+import { randomUUID } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { botHomePath } from '../adapters/cli/read-isolation.js';
-import type { ScheduledTask } from '../types.js';
+import type { ScheduledTask, TrustedCaller } from '../types.js';
 
 /** Scheduled turn ids: `schedule:<8-hex-taskId>:<uuid>`. Task ids are minted
  *  by schedule-store as `randomUUID().substring(0, 8)`; the strict shape keeps
@@ -42,6 +43,50 @@ const SCHEDULED_TURN_RE = /^schedule:([0-9a-f]{8}):[0-9a-f]{8}-[0-9a-f]{4}-[0-9a
 export function parseScheduledTurnId(turnId: string): string | null {
   const match = SCHEDULED_TURN_RE.exec(turnId);
   return match ? match[1]! : null;
+}
+
+/** Mint the turn id for a semantic-recovery continuation of a scheduled turn.
+ *  A scheduled turn authenticates by its `schedule:<taskId>:<uuid>` id (task
+ *  binding + owner gate, see authorizeScheduledTurn — the uuid is per fire and
+ *  never checked), so its `[BOTMUX_RECOVERY]` continuation must keep the same
+ *  task prefix: a `bmx-recovery-*` id would strip the schedule provenance and
+ *  every `botmux` command in the continuation would lose the creator identity.
+ *  Returns undefined for a non-scheduled logical turn (ordinary IM turns keep
+ *  the coordinator's default id). */
+export function mintScheduledContinuationTurnId(
+  logicalTurnId: string,
+  uuid: () => string = randomUUID,
+): string | undefined {
+  const taskId = parseScheduledTurnId(logicalTurnId);
+  return taskId ? `schedule:${taskId}:${uuid()}` : undefined;
+}
+
+/**
+ * Identity a scheduled turn runs as: the task's creator, as captured at
+ * creation time. The turn itself is authenticated by the daemon-minted
+ * `schedule:<taskId>:<uuid>` turn id (authorizeScheduledTurn above) — this
+ * only decides WHICH identity that authenticated turn carries. Shared by the
+ * scheduler fire path and the ordinary-turn recovery continuation so a
+ * continuation runs as exactly the identity its original fire ran as.
+ *
+ * Returns undefined when the task has no creator union_id (legacy tasks,
+ * CLI-created tasks, bot-created tasks). That is deliberate and is the whole
+ * fail-closed story: with no identity on the turn, identity-bound tools refuse
+ * to run instead of falling back to the bot's own access, while everything that
+ * does not need a user identity keeps working.
+ */
+export function trustedCallerForScheduledTask(
+  task: ScheduledTask,
+  larkAppId: string,
+): TrustedCaller | undefined {
+  if (!task.ownerUnionId) return undefined;
+  return {
+    ...(task.ownerOpenId ? { requestUserOpenId: task.ownerOpenId } : {}),
+    requestUserUnionId: task.ownerUnionId,
+    requestLarkAppId: task.creatorLarkAppId ?? task.larkAppId ?? larkAppId,
+    source: 'schedule_creator',
+    taskId: task.id,
+  };
 }
 
 /**

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -56,6 +56,7 @@ import { validateZellijAdoptTarget } from './zellij-adopt-discovery.js';
 import type { BackendType, SessionProbe } from '../adapters/backend/types.js';
 import { backendSupportsWebTerminal } from '../adapters/backend/capabilities.js';
 import type { ChatContext, CliTurnPayload, CodexAppAdditionalContextEntry, CodexAppTurnInput, LarkAttachment, LarkMention, ScheduledTask, Session, SubstituteTrigger } from '../types.js';
+import { trustedCallerForScheduledTask } from './scheduled-turn-provenance.js';
 import { addCodexAppContext } from '../utils/codex-app-context.js';
 import { hasUnsettledCodexAppDispatch } from '../utils/codex-app-dispatch-ledger.js';
 import { hasProtectedSessionMutationOwnership } from './session-mutation-guard.js';
@@ -3356,32 +3357,6 @@ export function resolveScheduledTaskExecutionPosition(
   if (task.executionPosition === 'top-level') return 'top-level';
   if (task.deliver === 'new-topic') return 'new-topic';
   return task.scope !== 'chat' && task.rootMessageId ? 'topic' : 'top-level';
-}
-
-/**
- * Identity a scheduled turn runs as: the task's creator, as captured at
- * creation time. The turn itself is authenticated by the daemon-minted
- * `schedule:<taskId>:<uuid>` turn id (see scheduled-turn-provenance) — this
- * only decides WHICH identity that authenticated turn carries.
- *
- * Returns undefined when the task has no creator union_id (legacy tasks,
- * CLI-created tasks, bot-created tasks). That is deliberate and is the whole
- * fail-closed story: with no identity on the turn, identity-bound tools refuse
- * to run instead of falling back to the bot's own access, while everything that
- * does not need a user identity keeps working.
- */
-function trustedCallerForScheduledTask(
-  task: ScheduledTask,
-  larkAppId: string,
-): CliTurnPayload['trustedCaller'] | undefined {
-  if (!task.ownerUnionId) return undefined;
-  return {
-    ...(task.ownerOpenId ? { requestUserOpenId: task.ownerOpenId } : {}),
-    requestUserUnionId: task.ownerUnionId,
-    requestLarkAppId: task.creatorLarkAppId ?? task.larkAppId ?? larkAppId,
-    source: 'schedule_creator',
-    taskId: task.id,
-  };
 }
 
 async function buildScheduledTargetNotice(params: {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -556,7 +556,13 @@ import {
 import { parseVcMeetingListenerOutput } from '../services/vc-meeting-listener-output-protocol.js';
 import { isLocalCliOpenEnabled, isLocalCliOpenReady } from '../services/local-cli-opener.js';
 import { sessionConfiguredRuntimeDisplayName } from './cli-runtime-display.js';
-import { isSilentScheduledTurn } from './silent-schedule-turns.js';
+import { armSilentScheduledTurn, disarmSilentScheduledTurn, isSilentScheduledTurn } from './silent-schedule-turns.js';
+import {
+  mintScheduledContinuationTurnId,
+  parseScheduledTurnId,
+  readScheduledTaskForProvenance,
+  trustedCallerForScheduledTask,
+} from './scheduled-turn-provenance.js';
 import { isTriggerFinalSuppressed } from './trigger-final-suppression.js';
 import { writeDeferredTopicBinding } from './deferred-topic-binding.js';
 import {
@@ -1370,6 +1376,29 @@ function ordinaryTurnRecoveryEligible(
     && larkTransportEnabled({ chatId: ds.chatId, apiOnly: botCfg.apiOnly });
 }
 
+/** Turns the semantic (ordinary-turn) recovery owns: a Lark inbound message
+ *  turn (`om_*`) or a daemon-fired scheduled turn (`schedule:<taskId>:<uuid>`).
+ *  Scheduled turns used to be excluded by an `om_` prefix check, so a transient
+ *  provider failure inside an hourly task never auto-continued and only raised
+ *  the「未启动自动续跑」card — the most frequent shape of that card on a box that
+ *  runs recurring tasks. Everything else (durable replays, HTTP triggers,
+ *  meeting deliveries, `bmx-recovery-*` continuations themselves) stays out. */
+function isOrdinaryRecoveryTurnId(turnId: string | undefined): turnId is string {
+  return !!turnId && (turnId.startsWith('om_') || parseScheduledTurnId(turnId) !== null);
+}
+
+/** The identity a scheduled continuation runs as — the task creator, exactly as
+ *  the original fire resolved it (see trustedCallerForScheduledTask). Reads the
+ *  task back from the bot's schedules store; a deleted task yields no identity,
+ *  which is the same fail-closed outcome the fire path has. */
+function scheduledContinuationTrustedCaller(
+  ds: DaemonSession,
+  taskId: string,
+): TrustedCaller | undefined {
+  const task = readScheduledTaskForProvenance(config.session.dataDir, ds.larkAppId, taskId);
+  return task ? trustedCallerForScheduledTask(task, ds.larkAppId) : undefined;
+}
+
 function ordinaryTurnRecoveryStillOwnsSession(ds: DaemonSession): boolean {
   if (ds.session.status !== 'active') return false;
   if (!activeSessionsRegistry) return true;
@@ -1461,23 +1490,45 @@ export function ensureOrdinaryTurnRecoveryAttached(
     },
     cancel: timer => clearTimeout(timer),
     persist: () => sessionStore.updateSession(ds.session),
+    mintContinuationTurnId: logicalTurnId => mintScheduledContinuationTurnId(logicalTurnId),
     enqueue: (dispatch: OrdinaryTurnRecoveryDispatch) => {
       if (!ordinaryTurnRecoveryEligible(ds) || !ordinaryTurnRecoveryStillOwnsSession(ds)) return false;
+      // A scheduled logical turn continues as the same scheduled turn: same
+      // task prefix on the id (minted above), the task creator as trustedCaller,
+      // and the fire's silent flag carried over so a silent task's continuation
+      // stays silent. Ordinary IM turns take none of this and keep their
+      // inherited reply context alone.
+      const scheduledTaskId = parseScheduledTurnId(dispatch.logicalTurnId);
+      const trustedCaller = scheduledTaskId
+        ? scheduledContinuationTrustedCaller(ds, scheduledTaskId)
+        : undefined;
+      const silent = scheduledTaskId !== null && isSilentScheduledTurn(ds, dispatch.logicalTurnId);
+      if (silent) armSilentScheduledTurn(ds, dispatch.turnId);
+      let enqueued = false;
       try {
         if (!ds.worker || ds.worker.killed || ds.worker.connected === false) {
-          return forkWorker(ds, dispatch.prompt, {
-            resume: true,
-            turnId: dispatch.turnId,
-          });
+          enqueued = forkWorker(
+            ds,
+            trustedCaller ? { content: dispatch.prompt, trustedCaller } : dispatch.prompt,
+            { resume: true, turnId: dispatch.turnId },
+          );
+        } else {
+          enqueued = sendWorkerInput(
+            ds,
+            dispatch.prompt,
+            dispatch.turnId,
+            trustedCaller ? { trustedCaller } : {},
+          );
         }
-        return sendWorkerInput(ds, dispatch.prompt, dispatch.turnId);
       } catch (err) {
         logger.error(
           `[${tag(ds)}] Failed to enqueue ordinary-turn recovery `
           + `${dispatch.continuation}: ${err instanceof Error ? err.message : String(err)}`,
         );
-        return false;
+        enqueued = false;
       }
+      if (!enqueued && silent) disarmSilentScheduledTurn(ds, dispatch.turnId);
+      return enqueued;
     },
     warn: state => {
       const warning = ordinaryTurnRecoveryWarning(state, localeForBot(ds.larkAppId));
@@ -9413,7 +9464,7 @@ export function sendWorkerInput(
       logger.info(
         `[${tag(ds)}] Staged turn ${queuedTurnId} behind queued activation ACK`,
       );
-      if (turnId?.startsWith('om_')) {
+      if (isOrdinaryRecoveryTurnId(turnId)) {
         recordAdmittedOrdinaryUserTurn(ds, turnId, { beginRecovery: false });
       }
       return true;
@@ -9510,7 +9561,7 @@ export function sendWorkerInput(
     );
     return false;
   }
-  if (turnId?.startsWith('om_')) {
+  if (isOrdinaryRecoveryTurnId(turnId)) {
     recordAdmittedOrdinaryUserTurn(ds, turnId, { beginRecovery: true });
   }
   return true;
@@ -9866,7 +9917,7 @@ export function promoteQueuedActivationTail(
       queuedActivationToken: token,
       ...(vcMeetingImTurnOrigin ? { vcMeetingImTurnOrigin } : {}),
     } as DaemonToWorker);
-    if (head.turnId.startsWith('om_')) {
+    if (isOrdinaryRecoveryTurnId(head.turnId)) {
       recordAdmittedOrdinaryUserTurn(ds, head.turnId, { beginRecovery: true });
     }
   } catch (err) {
@@ -11022,7 +11073,7 @@ export function forkWorker(
   } else {
     worker.send(initMsg);
   }
-  if (prompt.length > 0 && initAttributionTurnId?.startsWith('om_')) {
+  if (prompt.length > 0 && isOrdinaryRecoveryTurnId(initAttributionTurnId)) {
     recordAdmittedOrdinaryUserTurn(ds, initAttributionTurnId, { beginRecovery: true });
   }
   ds.spawnedAt = Date.now();

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -473,6 +473,7 @@ import { publishAttentionPatch, publishClosedSessionPatch } from './session-acti
 import {
   attachOrdinaryTurnRecovery,
   beginOrdinaryTurnRecovery,
+  ordinaryTurnRecoverySilentTurnIds,
   cancelOrdinaryTurnRecoveryForUserInput as cancelOrdinaryRecoveryForUserInput,
   disposeOrdinaryTurnRecovery,
   handleOrdinaryTurnRecoveryTerminal,
@@ -1482,6 +1483,13 @@ export function ensureOrdinaryTurnRecoveryAttached(
     disposeOrdinaryTurnRecovery(ds.session);
     return false;
   }
+  // Re-arm the runtime silent registry from the persisted recovery state BEFORE
+  // the timer is re-armed: an overdue backoff fires on the next tick, and the
+  // enqueue below (plus every terminal-time suppression gate) reads that
+  // registry by exact turn id. Idempotent, so repeated attach calls are fine.
+  for (const turnId of ordinaryTurnRecoverySilentTurnIds(ds.session.ordinaryTurnRecovery)) {
+    if (!isSilentScheduledTurn(ds, turnId)) armSilentScheduledTurn(ds, turnId);
+  }
   attachOrdinaryTurnRecovery(ds.session, {
     schedule: (delayMs, run) => {
       const timer = setTimeout(run, delayMs);
@@ -1502,7 +1510,9 @@ export function ensureOrdinaryTurnRecoveryAttached(
       const trustedCaller = scheduledTaskId
         ? scheduledContinuationTrustedCaller(ds, scheduledTaskId)
         : undefined;
-      const silent = scheduledTaskId !== null && isSilentScheduledTurn(ds, dispatch.logicalTurnId);
+      // Silence comes from the frozen per-turn attribute in the persisted
+      // state, not from the runtime registry (which a daemon restart empties).
+      const silent = dispatch.silent;
       if (silent) armSilentScheduledTurn(ds, dispatch.turnId);
       let enqueued = false;
       try {
@@ -9339,7 +9349,12 @@ function recordAdmittedOrdinaryUserTurn(
   let recoveryBookkeepingSucceeded = false;
   try {
     if (opts.beginRecovery) {
-      const state = beginOrdinaryTurnRecovery(ds.session, turnId);
+      // Freeze the fire's silent attribute onto the logical turn now: the
+      // scheduler arms the runtime registry before dispatch, so it is readable
+      // here, and only the persisted copy survives a restart.
+      const state = beginOrdinaryTurnRecovery(ds.session, turnId, {
+        silent: isSilentScheduledTurn(ds, turnId),
+      });
       recoveryBookkeepingSucceeded = state?.logicalTurnId === turnId
         && state.currentTurnId === turnId;
     } else {

--- a/src/services/ordinary-turn-recovery.ts
+++ b/src/services/ordinary-turn-recovery.ts
@@ -30,6 +30,15 @@ export interface OrdinaryTurnRecoveryState {
    *  while the owner is still `running` means the owner's terminal was lost and
    *  the successor is adopted on the spot. Absent when empty. */
   queuedLogicalTurnIds?: string[];
+  /** Logical turns (owner or queued successor) whose fire was a silent
+   *  scheduled run. Frozen at admission from the daemon's runtime silent
+   *  registry and persisted here, because that registry does not survive a
+   *  daemon restart while a backoff timer or a delivered continuation does:
+   *  every continuation of such a turn must stay silent, and restore re-arms
+   *  the registry from this list before re-arming the timer. Pruned to the live
+   *  owner + queue on every commit; absent when empty (pre-upgrade archives have
+   *  no field and are read as loud, the pre-existing semantics). */
+  silentLogicalTurnIds?: string[];
 }
 
 /** The slot is held by the original logical turn itself, still running — no
@@ -62,6 +71,48 @@ export interface OrdinaryTurnRecoveryDispatch {
   turnId: string;
   prompt: string;
   continuation: number;
+  /** The logical turn was a silent scheduled fire: the continuation must be
+   *  armed silent too. Read from the persisted state, never from runtime. */
+  silent: boolean;
+}
+
+export interface OrdinaryTurnBeginOptions {
+  /** Freeze "this fire is silent" onto the logical turn at admission. */
+  silent?: boolean;
+}
+
+function isSilentLogicalTurn(state: OrdinaryTurnRecoveryState, logicalTurnId: string): boolean {
+  return (state.silentLogicalTurnIds ?? []).includes(logicalTurnId);
+}
+
+/** Keep silent marks only for turns the state still tracks (owner + queue).
+ *  Applied at commit time, i.e. after a promotion/adoption has already chosen
+ *  the new owner, so the promoted turn's own mark is never dropped early. */
+function pruneSilentLogicalTurnIds(state: OrdinaryTurnRecoveryState): OrdinaryTurnRecoveryState {
+  const { silentLogicalTurnIds, ...rest } = state;
+  if (!silentLogicalTurnIds) return rest;
+  const live = new Set([state.logicalTurnId, ...(state.queuedLogicalTurnIds ?? [])]);
+  const kept = silentLogicalTurnIds.filter((id, index, all) => live.has(id) && all.indexOf(id) === index);
+  return kept.length > 0 ? { ...rest, silentLogicalTurnIds: kept } : rest;
+}
+
+/** Turn ids a daemon restore must re-arm in its runtime silent registry before
+ *  re-arming the recovery timer: every silent logical turn still tracked, plus
+ *  the delivered continuation of a silent owner (its id differs from the
+ *  logical id). Settled states are included on purpose: the registry keeps a
+ *  mark past turn_terminal so late idle/final events stay hushed, and a restart
+ *  right after a silent continuation settled must not turn those late events
+ *  loud. Marks are turn-exact and TTL/size bounded, so re-arming a finished id
+ *  can never hush another turn. */
+export function ordinaryTurnRecoverySilentTurnIds(
+  state: OrdinaryTurnRecoveryState | undefined,
+): string[] {
+  if (!state) return [];
+  const ids = [...(state.silentLogicalTurnIds ?? [])];
+  if (isSilentLogicalTurn(state, state.logicalTurnId) && state.currentTurnId !== state.logicalTurnId) {
+    ids.push(state.currentTurnId);
+  }
+  return ids;
 }
 
 export interface OrdinaryTurnRecoveryDeps<TTimer = unknown> {
@@ -116,7 +167,7 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
     if (this.state.status === 'backoff') this.armBackoff();
   }
 
-  begin(logicalTurnId: string): OrdinaryTurnRecoveryState {
+  begin(logicalTurnId: string, opts: OrdinaryTurnBeginOptions = {}): OrdinaryTurnRecoveryState {
     // Claude can accept type-ahead while the preceding turn is still running.
     // A session-level slot must keep owning that earlier terminal instead of
     // being overwritten by the queued successor; otherwise the earlier failed
@@ -131,10 +182,13 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
       if (logicalTurnId === live.currentTurnId || logicalTurnId === live.logicalTurnId
         || queued.includes(logicalTurnId)) return live;
       try {
-        return this.commit(withQueuedLogicalTurnIds(
+        const withQueue = withQueuedLogicalTurnIds(
           live,
           [...queued, logicalTurnId].slice(-MAX_QUEUED_LOGICAL_TURNS),
-        ));
+        );
+        return this.commit(opts.silent
+          ? { ...withQueue, silentLogicalTurnIds: [...(withQueue.silentLogicalTurnIds ?? []), logicalTurnId] }
+          : withQueue);
       } catch {
         return live;
       }
@@ -147,6 +201,7 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
         currentTurnId: logicalTurnId,
         continuationsStarted: 0,
         status: 'running',
+        ...(opts.silent ? { silentLogicalTurnIds: [logicalTurnId] } : {}),
       });
     } catch (err) {
       if (wasBackoff) this.armBackoff();
@@ -189,11 +244,13 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
       if (next === undefined) return this.commit({ ...current, status: 'completed' });
       // Hand the slot to the type-ahead successor Claude is about to run, so
       // its failure has a recovery consumer instead of only the fallback card.
+      // The silent marks ride along; commit prunes them to the new owner + queue.
       return this.commit(withQueuedLogicalTurnIds({
         logicalTurnId: next,
         currentTurnId: next,
         continuationsStarted: 0,
         status: 'running',
+        ...(current.silentLogicalTurnIds ? { silentLogicalTurnIds: current.silentLogicalTurnIds } : {}),
       }, rest));
     }
     if (terminal.errorCode === 'provider_rate_limited') return current;
@@ -304,6 +361,7 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
           turnId,
           prompt: ORDINARY_TURN_RECOVERY_PROMPT,
           continuation,
+          silent: isSilentLogicalTurn(dispatching, dispatching.logicalTurnId),
         });
       } catch {
         enqueued = false;
@@ -338,7 +396,7 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
 
   private commit(state: OrdinaryTurnRecoveryState): OrdinaryTurnRecoveryState {
     const prior = this.state;
-    const next = { ...state };
+    const next = pruneSilentLogicalTurnIds({ ...state });
     this.state = next;
     try {
       this.deps.persist(next);
@@ -472,6 +530,7 @@ export function ordinaryTurnRecoveryHandlesTerminal(
 export function beginOrdinaryTurnRecovery(
   session: OrdinaryTurnRecoverySession,
   logicalTurnId: string,
+  opts: OrdinaryTurnBeginOptions = {},
 ): OrdinaryTurnRecoveryState | undefined {
   const attached = attachedRecoveries.get(session.sessionId);
   if (!attached) return session.ordinaryTurnRecovery;
@@ -481,7 +540,7 @@ export function beginOrdinaryTurnRecovery(
   if (session.ordinaryTurnRecovery) {
     attached.coordinator.restore(session.ordinaryTurnRecovery);
   }
-  return attached.coordinator.begin(logicalTurnId);
+  return attached.coordinator.begin(logicalTurnId, opts);
 }
 
 export function cancelOrdinaryTurnRecoveryForUserInput(

--- a/src/services/ordinary-turn-recovery.ts
+++ b/src/services/ordinary-turn-recovery.ts
@@ -24,6 +24,30 @@ export interface OrdinaryTurnRecoveryState {
   /** True once the one user-visible warning has been scheduled. */
   warningDispatched?: boolean;
   cancelledByTurnId?: string;
+  /** Type-ahead successors admitted while the owner was still running, in
+   *  admission order. Claude runs them after the owner, so ownership moves to
+   *  the head of this list when the owner completes; a terminal for one of them
+   *  while the owner is still `running` means the owner's terminal was lost and
+   *  the successor is adopted on the spot. Absent when empty. */
+  queuedLogicalTurnIds?: string[];
+}
+
+/** The slot is held by the original logical turn itself, still running — no
+ *  continuation has been dispatched for it. Only then may a queued successor's
+ *  terminal mean "the owner's terminal was lost" and be adopted. */
+function ownerAwaitingOwnTerminal(state: OrdinaryTurnRecoveryState): boolean {
+  return state.status === 'running' && state.currentTurnId === state.logicalTurnId;
+}
+
+/** Bound on remembered type-ahead successors; older ones are forgotten first. */
+const MAX_QUEUED_LOGICAL_TURNS = 32;
+
+function withQueuedLogicalTurnIds(
+  state: OrdinaryTurnRecoveryState,
+  queued: readonly string[],
+): OrdinaryTurnRecoveryState {
+  const { queuedLogicalTurnIds: _dropped, ...rest } = state;
+  return queued.length > 0 ? { ...rest, queuedLogicalTurnIds: [...queued] } : rest;
 }
 
 export interface OrdinaryTurnRecoveryTerminal {
@@ -100,7 +124,20 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
     // entered backoff (or reached a terminal state), a fresh admitted user turn
     // may replace it as before.
     if (this.state?.status === 'running' || this.state?.status === 'dispatching') {
-      return this.state;
+      // Remember the successor without disturbing the live owner. A persist
+      // failure here degrades to the old behaviour (successor not tracked).
+      const live = this.state;
+      const queued = live.queuedLogicalTurnIds ?? [];
+      if (logicalTurnId === live.currentTurnId || logicalTurnId === live.logicalTurnId
+        || queued.includes(logicalTurnId)) return live;
+      try {
+        return this.commit(withQueuedLogicalTurnIds(
+          live,
+          [...queued, logicalTurnId].slice(-MAX_QUEUED_LOGICAL_TURNS),
+        ));
+      } catch {
+        return live;
+      }
     }
     const wasBackoff = this.state?.status === 'backoff';
     this.cancelTimer();
@@ -121,9 +158,44 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
     current: OrdinaryTurnRecoveryState,
     terminal: OrdinaryTurnRecoveryTerminal,
   ): OrdinaryTurnRecoveryState {
-    if (terminal.turnId !== current.currentTurnId
-      || current.status !== 'running') return current;
-    if (terminal.status === 'completed') return this.commit({ ...current, status: 'completed' });
+    if (terminal.turnId !== current.currentTurnId) {
+      const queued = current.queuedLogicalTurnIds ?? [];
+      if (!queued.includes(terminal.turnId)) return current;
+      const remaining = withQueuedLogicalTurnIds(current, queued.filter(id => id !== terminal.turnId));
+      // The owner's own recovery is in flight (backoff timer, dispatching, or
+      // an already-delivered continuation that is still running) or the owner
+      // already settled: the successor ran on its own and is simply forgotten
+      // here — the delivered continuation keeps the slot.
+      if (!ownerAwaitingOwnTerminal(current)) return this.commit(remaining);
+      // The owner never reported a terminal (lost/missed) yet its successor
+      // did: the successor is the live turn now, and its terminal is handled
+      // exactly as an owner terminal would be.
+      const adopted = this.commit({
+        ...remaining,
+        logicalTurnId: terminal.turnId,
+        currentTurnId: terminal.turnId,
+        continuationsStarted: 0,
+        status: 'running',
+        nextAttemptAt: undefined,
+        lastErrorCode: undefined,
+        alertSentAt: undefined,
+        warningDispatched: undefined,
+      });
+      return this.onTerminal(adopted, terminal);
+    }
+    if (current.status !== 'running') return current;
+    if (terminal.status === 'completed') {
+      const [next, ...rest] = current.queuedLogicalTurnIds ?? [];
+      if (next === undefined) return this.commit({ ...current, status: 'completed' });
+      // Hand the slot to the type-ahead successor Claude is about to run, so
+      // its failure has a recovery consumer instead of only the fallback card.
+      return this.commit(withQueuedLogicalTurnIds({
+        logicalTurnId: next,
+        currentTurnId: next,
+        continuationsStarted: 0,
+        status: 'running',
+      }, rest));
+    }
     if (terminal.errorCode === 'provider_rate_limited') return current;
     if (terminal.status !== 'failed' || terminal.retryable !== true) {
       const next = {
@@ -387,8 +459,14 @@ export function ordinaryTurnRecoveryHandlesTerminal(
   terminal: OrdinaryTurnRecoveryTerminal,
 ): boolean {
   const current = session.ordinaryTurnRecovery;
-  return attachedRecoveries.get(session.sessionId)?.session === session
-    && current?.currentTurnId === terminal.turnId;
+  if (attachedRecoveries.get(session.sessionId)?.session !== session || !current) return false;
+  if (current.currentTurnId === terminal.turnId) return true;
+  // A queued type-ahead successor is adopted by onTerminal only while the
+  // original owner itself is still running (no continuation dispatched); in any
+  // other state its terminal is merely forgotten and the fallback notice must
+  // stay in charge.
+  return ownerAwaitingOwnTerminal(current)
+    && (current.queuedLogicalTurnIds ?? []).includes(terminal.turnId);
 }
 
 export function beginOrdinaryTurnRecovery(

--- a/src/services/ordinary-turn-recovery.ts
+++ b/src/services/ordinary-turn-recovery.ts
@@ -46,6 +46,11 @@ export interface OrdinaryTurnRecoveryDeps<TTimer = unknown> {
   persist: (state: OrdinaryTurnRecoveryState) => void;
   enqueue: (dispatch: OrdinaryTurnRecoveryDispatch) => boolean;
   warn: (state: OrdinaryTurnRecoveryState) => void;
+  /** Identity for the next continuation of `logicalTurnId`. Return undefined
+   *  to keep the default `bmx-recovery-<random>` id. The daemon uses this to
+   *  keep a scheduled turn's `schedule:<taskId>:<uuid>` provenance on its
+   *  continuation, so the continuation authenticates exactly like the fire. */
+  mintContinuationTurnId?: (logicalTurnId: string, continuation: number) => string | undefined;
   now?: () => number;
   randomId?: () => string;
   backoffMs?: readonly number[];
@@ -207,7 +212,8 @@ export class OrdinaryTurnRecoveryCoordinator<TTimer = unknown> {
       const live = this.state;
       if (!live || live.status !== 'backoff') return;
       const continuation = live.continuationsStarted + 1;
-      const turnId = `bmx-recovery-${this.randomId()}`;
+      const turnId = this.deps.mintContinuationTurnId?.(live.logicalTurnId, continuation)
+        ?? `bmx-recovery-${this.randomId()}`;
       // Persist the exact synthetic turn before handing it to IPC. If the
       // daemon crashes after this write, restore fails closed instead of
       // replaying a continuation whose external effects may already have

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -26,6 +26,11 @@ export class IdleDetector {
   private busyTransitionArmed = false;
   private readyPattern: RegExp | undefined;
   private readySeen = false;
+  private startupPendingPattern: RegExp | undefined;
+  private startupReadyPattern: RegExp | undefined;
+  private startupTail = '';
+  private startupPending = false;
+  private startupComplete = false;
   /** Pre-idle latch for static busy screens (capacity queue). Set from PTY
    *  chunks carrying explicit static-busy evidence (scanned across chunks
    *  via the rolling tail); suppresses screen-derived idle until a chunk
@@ -43,6 +48,8 @@ export class IdleDetector {
     this.staticBusyPattern = cli.staticBusyPattern;
     this.staticBusyClearPattern = cli.staticBusyClearPattern;
     this.readyPattern = cli.readyPattern;
+    this.startupPendingPattern = cli.startupPendingPattern;
+    this.startupReadyPattern = cli.startupReadyPattern;
   }
 
   onIdle(cb: (source: IdleEvidenceSource) => void): void {
@@ -86,6 +93,31 @@ export class IdleDetector {
     }
 
     const stripped = this.stripAnsi(data);
+    if (!this.startupComplete && this.startupPendingPattern) {
+      // Preserve raw chunks until decoding: an ANSI style sequence can be
+      // split between reads right before `loading`. Per-chunk stripping would
+      // leave escape fragments inside the word and miss the startup hold.
+      const rawStartup = this.startupTail + data;
+      const startup = this.stripAnsi(rawStartup);
+      const pendingAt = lastMatchIndex(this.startupPendingPattern, startup);
+      const readyAt = this.startupReadyPattern
+        ? lastMatchIndex(this.startupReadyPattern, startup)
+        : -1;
+      // Initialization is monotonic for this CLI process. A restored pane may
+      // seed its entire history in one chunk, including a quoted loading
+      // banner after the actual loaded banner. Treat that exactly like two
+      // feeds: once fully initialized, later text cannot re-arm startup.
+      if (readyAt >= 0) {
+        this.startupComplete = true;
+        this.startupPending = false;
+        this.startupTail = '';
+      } else {
+        if (pendingAt >= 0) this.startupPending = true;
+        // Keep split banner evidence without retaining startup output
+        // indefinitely. Unlike outputTail this survives a per-turn reset.
+        this.startupTail = rawStartup.slice(-8_192);
+      }
+    }
     // Shift the clear position left when the tail window drops characters
     // from the head, so it stays relative to the current window.
     const combined = this.outputTail + stripped;
@@ -175,7 +207,7 @@ export class IdleDetector {
         this.quiescenceTimer = null;
         // A static-busy latch outranks a completion marker: the queue screen
         // can carry both, and the latch only clears on a composer redraw.
-        if (!this.isIdle && !this.staticBusyLatch) this.markIdle('screen');
+        if (!this.isIdle && !this.staticBusyLatch && !this.isStartupPending()) this.markIdle('screen');
       }, 500);
       return;
     }
@@ -223,7 +255,17 @@ export class IdleDetector {
    *  for the next turn — same lifecycle as the internal markIdle path. */
   fireIdle(): void {
     if (this.isIdle) return;
+    // Actual transcript completion proves the session initialized, even if
+    // its loaded banner was omitted or the operator customized the footer.
+    this.startupComplete = true;
+    this.startupPending = false;
+    this.startupTail = '';
     this.markIdle('external');
+  }
+
+  /** Shared by the worker's screen-ready and hard-timeout write paths. */
+  isStartupPending(): boolean {
+    return this.startupPending && !this.startupComplete;
   }
 
   dispose(): void {
@@ -238,6 +280,7 @@ export class IdleDetector {
   private quiescenceCheck(): void {
     this.quiescenceTimer = null;
     if (this.isIdle) return;
+    if (this.isStartupPending()) return;
     // Explicit static-busy evidence (capacity queue): the screen is not
     // quiescing into a prompt — it is parked on a queue notice. Do not mark
     // idle and do not re-arm: the latch clears on the composer redraw, whose

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8991,6 +8991,7 @@ let injectionFlushing = false;
 
 /** 排队注入一行 TUI 命令：idle（isPromptReady）时经串行恢复事务敲入。 */
 async function flushPendingInjections(): Promise<void> {
+  if (idleDetector?.isStartupPending()) return;
   // 不跨 restart 边界写入（与 flushPending 同款守卫）：destroySession 异步期间
   // backend 可能仍指向旧 CLI。
   if (cliRestartInProgress) return;
@@ -10647,6 +10648,9 @@ function scheduleSpawnArgvTurnStartFailOpen(): void {
 }
 
 function markPromptReady(): void {
+  // Screen probes and timeout fallbacks must honor the same startup evidence
+  // as quiescence; a skeleton composer is not a ready CLI.
+  if (idleDetector?.isStartupPending()) return;
   if (bareShellLaunchBlocked) {
     log('Ignoring non-PTY prompt-ready while bare-shell launch block is active');
     return;
@@ -11316,6 +11320,7 @@ function codexAppRuntimeTypeAheadReady(): boolean {
 }
 
 async function flushPending(): Promise<void> {
+  if (idleDetector?.isStartupPending()) return;
   // destroySession() may be asynchronous while `backend` still references the
   // old CLI. Never let a new flush (including one triggered by the old
   // backend's idle/task-done callback) write across that restart boundary.
@@ -16759,6 +16764,13 @@ async function spawnCli(
   const firstPromptBackend = backend;
   const releaseFirstPromptTimeout = (elapsedMs: number, forced: boolean): void => {
     if (!awaitingFirstPrompt || backend !== firstPromptBackend) return;
+    // A timeout can recover missing prompt evidence, never contradict explicit
+    // loading evidence. Keep the queue/startup flag; the loaded frame re-drives
+    // normal idle detection and flushes it without replaying a pasted draft.
+    if (idleDetector?.isStartupPending()) {
+      log(`First prompt timeout — ${cliName()} still initializing; keeping input queued`);
+      return;
+    }
     if (!shouldReleaseFirstPromptTimeout({
       deferFirstPromptTimeoutUntilReady: cliAdapter?.deferFirstPromptTimeoutUntilReady === true,
       hasReadyPattern: !!cliAdapter?.readyPattern,

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -2724,6 +2724,43 @@ describe('Worker turn_terminal routing', () => {
     expect(sessionReply).toHaveBeenCalledTimes(1);
   });
 
+  it.each(['running', 'completed'] as const)('restores a %s silent recovery before handling trailing output', async (status) => {
+    const ds = makeDs();
+    ds.adoptedFrom = undefined;
+    const logicalTurnId = 'schedule:abcdef12:11111111-2222-3333-4444-555555555555';
+    const turnId = 'schedule:abcdef12:22222222-2222-3333-4444-555555555555';
+    ds.session.ordinaryTurnRecovery = {
+      logicalTurnId, currentTurnId: turnId, continuationsStarted: 1,
+      status, silentLogicalTurnIds: [logicalTurnId],
+    };
+    vi.mocked(getBot).mockReturnValue({
+      config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code' },
+      resolvedAllowedUsers: [], botOpenId: 'ou_bot', botName: 'TestBot',
+    } as any);
+    const sessionReply = vi.fn(async () => 'om_reply');
+    initWorkerPool({ sessionReply, getSessionWorkingDir: () => '/tmp', getActiveCount: () => 1, closeSession: vi.fn() });
+    expect(ds.silentScheduledTurns).toBeUndefined();
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    // A terminal can be persisted before the trailing bridge output arrives.
+    (ds.worker as any).emit('message', {
+      type: 'final_output', sessionId: ds.session.sessionId, turnId,
+      content: 'late silent answer', lastUuid: `silent-restored-${status}`,
+    } satisfies Extract<WorkerToDaemon, { type: 'final_output' }>);
+    (ds.worker as any).emit('message', {
+      type: 'user_notify', message: 'late silent notice', turnId,
+    } satisfies Extract<WorkerToDaemon, { type: 'user_notify' }>);
+    await Promise.resolve();
+    expect(sessionReply).not.toHaveBeenCalled();
+
+    (ds.worker as any).emit('message', {
+      type: 'user_notify', message: 'ordinary notice', turnId: 'om_normal_after_restart',
+    } satisfies Extract<WorkerToDaemon, { type: 'user_notify' }>);
+    await Promise.resolve();
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    expect(sessionReply.mock.calls[0][1]).toBe('ordinary notice');
+  });
+
   it('drops only the final_output of a suppressed trigger turn while other turns and its aux UI stay loud', async () => {
     const ds = makeDs();
     // A loud connector opted into suppressFinalOutput; trigger-session armed this

--- a/test/codex-startup-readiness.test.ts
+++ b/test/codex-startup-readiness.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCodexAdapter } from '../src/adapters/cli/codex.js';
+import { IdleDetector } from '../src/utils/idle-detector.js';
+
+const LOADING = `╭───────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.153.3)            │
+│ model:     loading   /model to change │
+│ directory: loading                    │
+╰───────────────────────────────────────╯
+› Ask Codex to do anything
+  ? for shortcuts`;
+const LOADED = `╭───────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.153.3)                        │
+│ model:       gpt-6-astra xhigh   /model to change │
+│ directory:   ~                                    │
+│ permissions: YOLO mode                            │
+╰───────────────────────────────────────────────────╯
+› Ask Codex to do anything
+  gpt-6-astra xhigh · ~`;
+
+let detector: IdleDetector;
+let idle: ReturnType<typeof vi.fn>;
+beforeEach(() => {
+  vi.useFakeTimers();
+  detector = new IdleDetector(createCodexAdapter());
+  idle = vi.fn();
+  detector.onIdle(idle);
+});
+afterEach(() => { detector.dispose(); vi.useRealTimers(); });
+
+function quiet() { vi.advanceTimersByTime(95_000); }
+
+describe('Codex startup readiness', () => {
+  it('does not release input during a silent loading skeleton, even beyond the first-prompt hard timeout', () => {
+    detector.feed(LOADING);
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+  });
+
+  it('holds split loading evidence and releases exactly once after the initialized screen', () => {
+    const split = LOADING.indexOf('loading') + 3;
+    detector.feed(LOADING.slice(0, split));
+    detector.feed(LOADING.slice(split));
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+    detector.feed(LOADED);
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let prompt-only redraws or a reset erase known startup loading', () => {
+    detector.feed(LOADING);
+    detector.reset();
+    detector.feed('› Ask Codex to do anything\n  ? for shortcuts');
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+    detector.feed(LOADED);
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a warm initialized session and its later ordinary prompt', () => {
+    detector.feed(LOADED);
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(1);
+    detector.reset();
+    detector.feed('› Continue\n  gpt-6-astra xhigh · ~');
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets authoritative transcript completion release a startup hold', () => {
+    detector.feed(LOADING);
+    detector.fireIdle();
+    expect(idle).toHaveBeenCalledTimes(1);
+    detector.reset();
+    detector.feed('› Continue');
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not release on the model footer, which can precede initialization', () => {
+    detector.feed(LOADING);
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+    detector.feed('› Ask Codex to do anything\n  custom-model high ·');
+    detector.feed(' /tmp/work');
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+    detector.feed(LOADED);
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not classify a partial directory value as initialized', () => {
+    detector.feed(LOADING);
+    detector.feed('│ model: gpt-6-astra xhigh /model to change │\n│ directory: l');
+    detector.feed('oading │\n› Ask Codex');
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+  });
+
+  it('recognizes loading styles split inside an ANSI escape sequence', () => {
+    detector.feed('│ model: \x1b[');
+    detector.feed('0mloading /model to change │\n› Ask Codex');
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+  });
+
+  it('recognizes complete initialized cells drawn with cursor movement and no newline', () => {
+    detector.feed(LOADING);
+    detector.feed('\x1b[3;1H│ model: custom-model /model to change │\x1b[4;1H│ directory: /tmp/work │');
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts an initialized banner when the user hides the status footer', () => {
+    detector.feed(LOADING);
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+    detector.feed(LOADED.replace('  gpt-6-astra xhigh · ~', ''));
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps holding when only the model resolves and the directory is still loading', () => {
+    detector.feed(LOADING);
+    detector.feed('│ model: gpt-6-astra xhigh /model to change │\n│ directory: loading │\n› Ask Codex');
+    quiet();
+    expect(idle).not.toHaveBeenCalled();
+    expect(detector.isStartupPending()).toBe(true);
+  });
+
+  it('does not mistake an old loading banner quoted after startup for a new startup', () => {
+    detector.feed(LOADED);
+    quiet();
+    detector.reset();
+    detector.feed(`The earlier screen was:\n${LOADING}\n› Continue`);
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(2);
+    expect(detector.isStartupPending()).toBe(false);
+  });
+
+  it('keeps initialized evidence when reattach seeds history and quoted loading in one chunk', () => {
+    detector.feed(`${LOADED}\nEarlier failure:\n${LOADING}\n› Continue`);
+    quiet();
+    expect(idle).toHaveBeenCalledTimes(1);
+    expect(detector.isStartupPending()).toBe(false);
+  });
+});

--- a/test/ordinary-turn-recovery.test.ts
+++ b/test/ordinary-turn-recovery.test.ts
@@ -468,3 +468,55 @@ describe('ordinary recovery session registry', () => {
     });
   });
 });
+
+describe('continuation identity', () => {
+  function drive(mint: ((logicalTurnId: string, continuation: number) => string | undefined) | undefined, logicalTurnId: string) {
+    const scheduled: Array<() => void> = [];
+    const enqueue = vi.fn(() => true);
+    const persist = vi.fn();
+    const coordinator = new OrdinaryTurnRecoveryCoordinator({
+      schedule: (_delayMs, run) => { scheduled.push(run); return run; },
+      cancel: vi.fn(),
+      persist,
+      enqueue,
+      warn: vi.fn(),
+      randomId: () => 'rand',
+      ...(mint ? { mintContinuationTurnId: mint } : {}),
+    });
+    coordinator.onTerminal(state({ logicalTurnId, currentTurnId: logicalTurnId }), {
+      turnId: logicalTurnId,
+      status: 'failed',
+      errorCode: 'provider_server_error',
+      retryable: true,
+    });
+    scheduled[0]!();
+    return { enqueue, persist };
+  }
+
+  it('lets the daemon mint the continuation turn id and persists that exact identity before enqueue', () => {
+    const mint = vi.fn((logicalTurnId: string, continuation: number) => `schedule:abcdef12:cont-${continuation}`);
+    const { enqueue, persist } = drive(mint, 'schedule:abcdef12:11111111-1111-1111-1111-111111111111');
+
+    expect(mint).toHaveBeenCalledWith('schedule:abcdef12:11111111-1111-1111-1111-111111111111', 1);
+    expect(enqueue).toHaveBeenCalledWith(expect.objectContaining({
+      logicalTurnId: 'schedule:abcdef12:11111111-1111-1111-1111-111111111111',
+      turnId: 'schedule:abcdef12:cont-1',
+      continuation: 1,
+    }));
+    const dispatching = persist.mock.calls.map(([value]) => value).find(value => value.status === 'dispatching');
+    expect(dispatching).toEqual(expect.objectContaining({ currentTurnId: 'schedule:abcdef12:cont-1' }));
+    expect(persist).toHaveBeenLastCalledWith(expect.objectContaining({
+      currentTurnId: 'schedule:abcdef12:cont-1',
+      status: 'running',
+    }));
+  });
+
+  it('keeps the default bmx-recovery id when the minter declines or is absent', () => {
+    expect(drive(() => undefined, 'om_original').enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ turnId: 'bmx-recovery-rand' }),
+    );
+    expect(drive(undefined, 'om_original').enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ turnId: 'bmx-recovery-rand' }),
+    );
+  });
+});

--- a/test/ordinary-turn-recovery.test.ts
+++ b/test/ordinary-turn-recovery.test.ts
@@ -5,6 +5,7 @@ import {
   cancelOrdinaryTurnRecoveryForUserInput,
   disposeOrdinaryTurnRecovery,
   handleOrdinaryTurnRecoveryTerminal,
+  ordinaryTurnRecoveryHandlesTerminal,
   requireOrdinaryTurnRecoveryAttention,
   ORDINARY_TURN_RECOVERY_PROMPT,
   OrdinaryTurnRecoveryCoordinator,
@@ -196,8 +197,177 @@ describe('OrdinaryTurnRecoveryCoordinator', () => {
 
     const current = coordinator.begin('om_type_ahead');
 
-    expect(current).toEqual(running);
-    expect(persist).not.toHaveBeenCalled();
+    // The running owner keeps the terminal; the successor is only remembered.
+    expect(current).toEqual({ ...running, queuedLogicalTurnIds: ['om_type_ahead'] });
+    expect(persist).toHaveBeenCalledWith({ ...running, queuedLogicalTurnIds: ['om_type_ahead'] });
+    expect(coordinator.begin('om_type_ahead')).toEqual(current);
+  });
+
+  it('hands ownership to the queued type-ahead turn once the running turn completes', () => {
+    const scheduled: Array<() => void> = [];
+    const enqueue = vi.fn(() => true);
+    const coordinator = new OrdinaryTurnRecoveryCoordinator({
+      schedule: (_delayMs, run) => { scheduled.push(run); return run; },
+      cancel: vi.fn(),
+      persist: vi.fn(),
+      enqueue,
+      warn: vi.fn(),
+      now: () => 1_000,
+      randomId: () => 'one',
+      backoffMs: [2_000, 8_000],
+    });
+    coordinator.restore(state());
+    const queued = coordinator.begin('om_type_ahead');
+
+    const promoted = coordinator.onTerminal(queued, { turnId: 'om_original', status: 'completed' });
+    expect(promoted).toEqual({
+      logicalTurnId: 'om_type_ahead',
+      currentTurnId: 'om_type_ahead',
+      continuationsStarted: 0,
+      status: 'running',
+    });
+
+    // Before this, the successor's failure had no recovery consumer at all and
+    // fell through to the「未启动自动续跑」card.
+    const failed = coordinator.onTerminal(promoted, {
+      turnId: 'om_type_ahead', status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    expect(failed.status).toBe('backoff');
+    scheduled[0]!();
+    expect(enqueue).toHaveBeenCalledWith(expect.objectContaining({
+      logicalTurnId: 'om_type_ahead',
+      turnId: 'bmx-recovery-one',
+      continuation: 1,
+    }));
+  });
+
+  it('adopts a queued successor whose terminal arrives while the owner terminal was lost', () => {
+    const schedule = vi.fn((_delayMs: number, run: () => void) => run);
+    const coordinator = new OrdinaryTurnRecoveryCoordinator({
+      schedule,
+      cancel: vi.fn(),
+      persist: vi.fn(),
+      enqueue: vi.fn(() => true),
+      warn: vi.fn(),
+      now: () => 1_000,
+      randomId: () => 'one',
+      backoffMs: [2_000, 8_000],
+    });
+    coordinator.restore(state());
+    const queued = coordinator.begin('om_type_ahead');
+
+    const next = coordinator.onTerminal(queued, {
+      turnId: 'om_type_ahead', status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    expect(next).toEqual(expect.objectContaining({
+      logicalTurnId: 'om_type_ahead',
+      currentTurnId: 'om_type_ahead',
+      status: 'backoff',
+    }));
+    expect(next.queuedLogicalTurnIds).toBeUndefined();
+    expect(schedule).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a delivered continuation as owner when the earlier-queued successor terminates first', () => {
+    const scheduled: Array<() => void> = [];
+    const enqueue = vi.fn(() => true);
+    const persist = vi.fn();
+    const coordinator = new OrdinaryTurnRecoveryCoordinator({
+      schedule: (_delayMs, run) => { scheduled.push(run); return run; },
+      cancel: vi.fn(),
+      persist,
+      enqueue,
+      warn: vi.fn(),
+      now: () => 1_000,
+      randomId: () => 'one',
+      backoffMs: [2_000, 8_000],
+    });
+    coordinator.restore(state());
+    const queued = coordinator.begin('om_type_ahead');
+    // A fails → backoff → A's continuation delivered and running.
+    coordinator.onTerminal(queued, {
+      turnId: 'om_original', status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    scheduled[0]!();
+    const inFlight = persist.mock.calls.at(-1)![0] as OrdinaryTurnRecoveryState;
+    expect(inFlight).toEqual(expect.objectContaining({
+      currentTurnId: 'bmx-recovery-one', continuationsStarted: 1, status: 'running',
+      queuedLogicalTurnIds: ['om_type_ahead'],
+    }));
+
+    // B was queued in Claude before the continuation, so it terminates first:
+    // it must not steal the slot from the delivered continuation, and its
+    // failure must not dispatch a second recovery.
+    const afterB = coordinator.onTerminal(inFlight, {
+      turnId: 'om_type_ahead', status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    expect(afterB).toEqual(expect.objectContaining({
+      logicalTurnId: 'om_original', currentTurnId: 'bmx-recovery-one', continuationsStarted: 1, status: 'running',
+    }));
+    expect(afterB.queuedLogicalTurnIds).toBeUndefined();
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(scheduled).toHaveLength(1);
+
+    // The continuation's own terminal still settles the original logical turn.
+    expect(coordinator.onTerminal(afterB, { turnId: 'bmx-recovery-one', status: 'completed' }))
+      .toEqual(expect.objectContaining({ logicalTurnId: 'om_original', status: 'completed' }));
+  });
+
+  it('does not let a queued successor completing first overwrite a running continuation', () => {
+    const scheduled: Array<() => void> = [];
+    const enqueue = vi.fn(() => true);
+    const persist = vi.fn();
+    const coordinator = new OrdinaryTurnRecoveryCoordinator({
+      schedule: (_delayMs, run) => { scheduled.push(run); return run; },
+      cancel: vi.fn(),
+      persist,
+      enqueue,
+      warn: vi.fn(),
+      now: () => 1_000,
+      randomId: () => 'one',
+      backoffMs: [2_000, 8_000],
+    });
+    coordinator.restore(state());
+    const queued = coordinator.begin('om_type_ahead');
+    coordinator.onTerminal(queued, {
+      turnId: 'om_original', status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    scheduled[0]!();
+    const inFlight = persist.mock.calls.at(-1)![0] as OrdinaryTurnRecoveryState;
+
+    // B completes before A_recovery: A_recovery must stay the running owner ...
+    const afterB = coordinator.onTerminal(inFlight, { turnId: 'om_type_ahead', status: 'completed' });
+    expect(afterB).toEqual(expect.objectContaining({
+      logicalTurnId: 'om_original', currentTurnId: 'bmx-recovery-one', continuationsStarted: 1, status: 'running',
+    }));
+    expect(afterB.queuedLogicalTurnIds).toBeUndefined();
+    // ... so its later retryable failure still drives the second (bounded) continuation.
+    const afterRecoveryFailed = coordinator.onTerminal(afterB, {
+      turnId: 'bmx-recovery-one', status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    expect(afterRecoveryFailed.status).toBe('backoff');
+    expect(scheduled).toHaveLength(2);
+  });
+
+  it('only forgets a queued successor that terminates while a recovery is already in flight', () => {
+    const schedule = vi.fn((_delayMs: number, run: () => void) => run);
+    const coordinator = new OrdinaryTurnRecoveryCoordinator({
+      schedule,
+      cancel: vi.fn(),
+      persist: vi.fn(),
+      enqueue: vi.fn(() => true),
+      warn: vi.fn(),
+      now: () => 1_000,
+      randomId: () => 'one',
+      backoffMs: [2_000, 8_000],
+    });
+    const backoff = state({ status: 'backoff', nextAttemptAt: 3_000, queuedLogicalTurnIds: ['om_type_ahead'] });
+    coordinator.restore(backoff);
+
+    const after = coordinator.onTerminal(backoff, { turnId: 'om_type_ahead', status: 'completed' });
+    expect(after).toEqual(expect.objectContaining({ currentTurnId: 'om_original', status: 'backoff' }));
+    expect(after.queuedLogicalTurnIds).toBeUndefined();
+    expect(coordinator.onTerminal(after, { turnId: 'om_unknown', status: 'completed' })).toEqual(after);
   });
 
   it('ignores stale, duplicate, non-retryable, and rate-limited terminals', () => {
@@ -229,6 +399,29 @@ describe('OrdinaryTurnRecoveryCoordinator', () => {
 });
 
 describe('ordinary recovery session registry', () => {
+  it('claims a terminal for a queued type-ahead successor so the fallback card stays quiet', () => {
+    const session = { sessionId: 'session-queued', ordinaryTurnRecovery: state() } as any;
+    attachOrdinaryTurnRecovery(session, {
+      schedule: (_delay, run) => run,
+      cancel: vi.fn(),
+      persist: vi.fn(),
+      enqueue: vi.fn(() => true),
+      warn: vi.fn(),
+    });
+    beginOrdinaryTurnRecovery(session, 'om_type_ahead');
+
+    expect(ordinaryTurnRecoveryHandlesTerminal(session, { turnId: 'om_original', status: 'completed' })).toBe(true);
+    expect(ordinaryTurnRecoveryHandlesTerminal(session, { turnId: 'om_type_ahead', status: 'failed' })).toBe(true);
+    expect(ordinaryTurnRecoveryHandlesTerminal(session, { turnId: 'om_unknown', status: 'failed' })).toBe(false);
+
+    // Once a continuation holds the slot, the queued successor is no longer claimed.
+    session.ordinaryTurnRecovery = state({
+      currentTurnId: 'bmx-recovery-live', continuationsStarted: 1, queuedLogicalTurnIds: ['om_type_ahead'],
+    });
+    expect(ordinaryTurnRecoveryHandlesTerminal(session, { turnId: 'bmx-recovery-live', status: 'failed' })).toBe(true);
+    expect(ordinaryTurnRecoveryHandlesTerminal(session, { turnId: 'om_type_ahead', status: 'failed' })).toBe(false);
+  });
+
   it('begins a fresh logical turn only after its daemon admission succeeds', () => {
     const session = { sessionId: 'session-begin' } as any;
     attachOrdinaryTurnRecovery(session, {

--- a/test/ordinary-turn-recovery.test.ts
+++ b/test/ordinary-turn-recovery.test.ts
@@ -6,6 +6,7 @@ import {
   disposeOrdinaryTurnRecovery,
   handleOrdinaryTurnRecoveryTerminal,
   ordinaryTurnRecoveryHandlesTerminal,
+  ordinaryTurnRecoverySilentTurnIds,
   requireOrdinaryTurnRecoveryAttention,
   ORDINARY_TURN_RECOVERY_PROMPT,
   OrdinaryTurnRecoveryCoordinator,
@@ -711,5 +712,123 @@ describe('continuation identity', () => {
     expect(drive(undefined, 'om_original').enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ turnId: 'bmx-recovery-rand' }),
     );
+  });
+});
+
+describe('silent scheduled turns keep their silence across continuations', () => {
+  const SILENT = 'schedule:abcdef12:11111111-1111-1111-1111-111111111111';
+
+  function coordinatorWith(enqueue = vi.fn(() => true)) {
+    const scheduled: Array<() => void> = [];
+    let seq = 0;
+    const coordinator = new OrdinaryTurnRecoveryCoordinator({
+      schedule: (_delayMs, run) => { scheduled.push(run); return run; },
+      cancel: vi.fn(),
+      persist: vi.fn(),
+      enqueue,
+      warn: vi.fn(),
+      now: () => 1_000,
+      randomId: () => `r${++seq}`,
+      backoffMs: [2_000, 8_000],
+    });
+    const fail = (current: OrdinaryTurnRecoveryState, turnId: string) => coordinator.onTerminal(current, {
+      turnId, status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    const fire = () => { scheduled.shift()!(); };
+    return { coordinator, enqueue, fail, fire };
+  }
+
+  it('freezes the silent attribute at admission and carries it onto every continuation', () => {
+    const { coordinator, enqueue, fail, fire } = coordinatorWith();
+    const running = coordinator.begin(SILENT, { silent: true });
+    expect(running.silentLogicalTurnIds).toEqual([SILENT]);
+
+    fail(running, SILENT); fire();
+    expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({ logicalTurnId: SILENT, continuation: 1, silent: true }));
+    const first = enqueue.mock.calls[0]![0] as any;
+    fail({ ...running, currentTurnId: first.turnId, continuationsStarted: 1, status: 'running', silentLogicalTurnIds: [SILENT] }, first.turnId); fire();
+    expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({ continuation: 2, silent: true }));
+  });
+
+  it('keeps silence per logical turn: a queued silent successor is silent after promotion, an ordinary successor is not', () => {
+    const { coordinator, enqueue, fail, fire } = coordinatorWith();
+    const owner = coordinator.begin('om_first');
+    const withSilent = coordinator.begin(SILENT, { silent: true });
+    expect(withSilent.queuedLogicalTurnIds).toEqual([SILENT]);
+    expect(withSilent.silentLogicalTurnIds).toEqual([SILENT]);
+    const withOm = coordinator.begin('om_second');
+    expect(withOm.queuedLogicalTurnIds).toEqual([SILENT, 'om_second']);
+
+    // The loud owner's own continuation stays loud.
+    const backoff = fail(withOm, 'om_first'); fire();
+    expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({ logicalTurnId: 'om_first', silent: false }));
+    const cont = (enqueue.mock.calls.at(-1)![0] as any).turnId;
+    const promotedSilent = coordinator.onTerminal(
+      { ...backoff, currentTurnId: cont, continuationsStarted: 1, status: 'running' },
+      { turnId: cont, status: 'completed' },
+    );
+    expect(promotedSilent).toEqual(expect.objectContaining({ logicalTurnId: SILENT, currentTurnId: SILENT, status: 'running' }));
+    expect(promotedSilent.silentLogicalTurnIds).toEqual([SILENT]);
+    expect(promotedSilent.queuedLogicalTurnIds).toEqual(['om_second']);
+
+    fail(promotedSilent, SILENT); fire();
+    expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({ logicalTurnId: SILENT, silent: true }));
+    const silentCont = (enqueue.mock.calls.at(-1)![0] as any).turnId;
+    const promotedOm = coordinator.onTerminal(
+      { ...promotedSilent, currentTurnId: silentCont, continuationsStarted: 1, status: 'running' },
+      { turnId: silentCont, status: 'completed' },
+    );
+    expect(promotedOm).toEqual(expect.objectContaining({ logicalTurnId: 'om_second', status: 'running' }));
+    expect(promotedOm.silentLogicalTurnIds).toBeUndefined();
+    fail(promotedOm, 'om_second'); fire();
+    expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({ logicalTurnId: 'om_second', silent: false }));
+    expect(owner.silentLogicalTurnIds).toBeUndefined();
+  });
+
+  it('keeps silence when a queued silent successor is adopted after the owner terminal was lost', () => {
+    const { coordinator, enqueue, fail, fire } = coordinatorWith();
+    coordinator.begin('om_first');
+    const queued = coordinator.begin(SILENT, { silent: true });
+    const adopted = fail(queued, SILENT);
+    expect(adopted).toEqual(expect.objectContaining({ logicalTurnId: SILENT, status: 'backoff', silentLogicalTurnIds: [SILENT] }));
+    fire();
+    expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({ logicalTurnId: SILENT, silent: true }));
+  });
+
+  it('does not inherit silence into a fresh turn after cancellation, and tolerates archives without the field', () => {
+    const { coordinator, enqueue, fail, fire } = coordinatorWith();
+    const silent = coordinator.begin(SILENT, { silent: true });
+    fail(silent, SILENT);
+    coordinator.cancelForUserInput('om_next');
+    const fresh = coordinator.begin('om_next');
+    expect(fresh.silentLogicalTurnIds).toBeUndefined();
+    fail(fresh, 'om_next'); fire();
+    expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({ logicalTurnId: 'om_next', silent: false }));
+
+    const legacy = coordinatorWith();
+    legacy.coordinator.restore({ logicalTurnId: SILENT, currentTurnId: SILENT, continuationsStarted: 0, status: 'backoff', nextAttemptAt: 0 });
+    legacy.fire();
+    expect(legacy.enqueue).toHaveBeenLastCalledWith(expect.objectContaining({ logicalTurnId: SILENT, silent: false }));
+  });
+
+  it('lists the turn ids a restore must re-arm as silent', () => {
+    expect(ordinaryTurnRecoverySilentTurnIds(undefined)).toEqual([]);
+    expect(ordinaryTurnRecoverySilentTurnIds(state())).toEqual([]);
+    // Owner silent, its delivered continuation running: both ids.
+    expect(ordinaryTurnRecoverySilentTurnIds(state({
+      logicalTurnId: SILENT, currentTurnId: 'schedule:abcdef12:22222222-2222-2222-2222-222222222222',
+      continuationsStarted: 1, silentLogicalTurnIds: [SILENT],
+    }))).toEqual([SILENT, 'schedule:abcdef12:22222222-2222-2222-2222-222222222222']);
+    // Loud owner with a silent queued successor: only the successor.
+    expect(ordinaryTurnRecoverySilentTurnIds(state({
+      queuedLogicalTurnIds: [SILENT], silentLogicalTurnIds: [SILENT],
+    }))).toEqual([SILENT]);
+    // Settled states still re-arm: late idle/final events after a restart must
+    // stay hushed, and marks are turn-exact so this cannot leak onto other turns.
+    expect(ordinaryTurnRecoverySilentTurnIds(state({
+      logicalTurnId: SILENT, currentTurnId: 'schedule:abcdef12:22222222-2222-2222-2222-222222222222',
+      continuationsStarted: 1, status: 'completed', silentLogicalTurnIds: [SILENT],
+    }))).toEqual([SILENT, 'schedule:abcdef12:22222222-2222-2222-2222-222222222222']);
+    expect(ordinaryTurnRecoverySilentTurnIds(state({ status: 'cancelled' }))).toEqual([]);
   });
 });

--- a/test/scheduled-turn-provenance.test.ts
+++ b/test/scheduled-turn-provenance.test.ts
@@ -12,8 +12,10 @@ import { dirname, join } from 'node:path';
 
 import {
   authorizeScheduledTurn,
+  mintScheduledContinuationTurnId,
   parseScheduledTurnId,
   readScheduledTaskForProvenance,
+  trustedCallerForScheduledTask,
 } from '../src/core/scheduled-turn-provenance.js';
 import { botHomePath } from '../src/adapters/cli/read-isolation.js';
 
@@ -153,5 +155,66 @@ describe('authorizeScheduledTurn', () => {
       isOwnerAllowed: (app, openId) => { seen.push([app, openId]); return true; },
     });
     expect(seen).toEqual([[appId, owner]]);
+  });
+});
+
+describe('mintScheduledContinuationTurnId', () => {
+  it('keeps the task prefix so the continuation authenticates like the fire', () => {
+    const minted = mintScheduledContinuationTurnId(TURN_ID, () => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    expect(minted).toBe(`schedule:${TASK_ID}:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`);
+    expect(parseScheduledTurnId(minted!)).toBe(TASK_ID);
+    expect(minted).not.toBe(TURN_ID);
+  });
+
+  it('mints a fresh uuid per continuation by default', () => {
+    const first = mintScheduledContinuationTurnId(TURN_ID)!;
+    const second = mintScheduledContinuationTurnId(TURN_ID)!;
+    expect(parseScheduledTurnId(first)).toBe(TASK_ID);
+    expect(parseScheduledTurnId(second)).toBe(TASK_ID);
+    expect(first).not.toBe(second);
+  });
+
+  it('declines for ordinary IM turns and malformed ids', () => {
+    expect(mintScheduledContinuationTurnId('om_x100')).toBeUndefined();
+    expect(mintScheduledContinuationTurnId('bmx-recovery-abc')).toBeUndefined();
+    expect(mintScheduledContinuationTurnId('schedule:abc:def')).toBeUndefined();
+  });
+});
+
+describe('trustedCallerForScheduledTask', () => {
+  const base = {
+    id: TASK_ID,
+    name: 'hourly',
+    prompt: 'do it',
+    chatId: 'oc_chat',
+    enabled: true,
+  } as any;
+
+  it('runs the turn as the task creator, binding the task id', () => {
+    expect(trustedCallerForScheduledTask({
+      ...base,
+      ownerOpenId: 'ou_owner',
+      ownerUnionId: 'on_owner',
+      creatorLarkAppId: 'cli_creator',
+      larkAppId: 'cli_target',
+    }, 'cli_session')).toEqual({
+      requestUserOpenId: 'ou_owner',
+      requestUserUnionId: 'on_owner',
+      requestLarkAppId: 'cli_creator',
+      source: 'schedule_creator',
+      taskId: TASK_ID,
+    });
+  });
+
+  it('falls back to the task app, then the session app, for the requesting app id', () => {
+    expect(trustedCallerForScheduledTask({ ...base, ownerUnionId: 'on_owner', larkAppId: 'cli_target' }, 'cli_session'))
+      .toEqual(expect.objectContaining({ requestLarkAppId: 'cli_target' }));
+    const sessionFallback = trustedCallerForScheduledTask({ ...base, ownerUnionId: 'on_owner' }, 'cli_session');
+    expect(sessionFallback).toEqual(expect.objectContaining({ requestLarkAppId: 'cli_session' }));
+    expect(sessionFallback).not.toHaveProperty('requestUserOpenId');
+  });
+
+  it('fails closed without a creator union id (legacy / bot-created task)', () => {
+    expect(trustedCallerForScheduledTask({ ...base, ownerOpenId: 'ou_owner' }, 'cli_session')).toBeUndefined();
   });
 });

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -177,7 +177,9 @@ vi.mock('../src/core/scheduled-turn-provenance.js', async (importOriginal) => {
 import { armSilentScheduledTurn, isSilentScheduledTurn } from '../src/core/silent-schedule-turns.js';
 import {
   __testOnly_resetOrdinaryImDeliveries,
+  auxUiSuppressedFor,
   detachWorkerForTransfer,
+  ensureOrdinaryTurnRecoveryAttached,
   forkAdoptWorker,
   forkWorker,
   getDaemonBootId,
@@ -5053,6 +5055,7 @@ describe('ordinary-turn recovery admission (scheduled turns, type-ahead)', () =>
       currentTurnId: SCHEDULED_TURN,
       continuationsStarted: 0,
       status: 'running',
+      silentLogicalTurnIds: [SCHEDULED_TURN],
     });
 
     worker.emit('message', {
@@ -5200,6 +5203,100 @@ describe('ordinary-turn recovery admission (scheduled turns, type-ahead)', () =>
       continuationsStarted: 1,
       status: 'running',
     }));
+  });
+
+  it('freezes the silent attribute into the persisted recovery state at admission', async () => {
+    const { ds, worker } = await bootClaudeSession();
+    armSilentScheduledTurn(ds, SCHEDULED_TURN);
+    expect(sendWorkerInput(ds, 'hourly task prompt', SCHEDULED_TURN)).toBe(true);
+    ackInput(worker, SCHEDULED_TURN);
+    expect(ds.session.ordinaryTurnRecovery?.silentLogicalTurnIds).toEqual([SCHEDULED_TURN]);
+    // A type-ahead ordinary turn is remembered but never marked silent.
+    expect(sendWorkerInput(ds, 'follow-up', 'om_follow')).toBe(true);
+    ackInput(worker, 'om_follow');
+    expect(ds.session.ordinaryTurnRecovery?.queuedLogicalTurnIds).toEqual(['om_follow']);
+    expect(ds.session.ordinaryTurnRecovery?.silentLogicalTurnIds).toEqual([SCHEDULED_TURN]);
+  });
+
+  it('keeps a silent continuation silent across a daemon restart during backoff (zero-delay re-arm)', async () => {
+    const { ds, worker } = await bootClaudeSession();
+    armSilentScheduledTurn(ds, SCHEDULED_TURN);
+    expect(sendWorkerInput(ds, 'hourly task prompt', SCHEDULED_TURN)).toBe(true);
+    ackInput(worker, SCHEDULED_TURN);
+    worker.emit('message', {
+      type: 'turn_terminal', sessionId: ds.session.sessionId, turnId: SCHEDULED_TURN,
+      status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    await Promise.resolve();
+    const persisted = structuredClone(ds.session.ordinaryTurnRecovery)!;
+    expect(persisted.status).toBe('backoff');
+
+    // Restart: a fresh DaemonSession rebuilt from the persisted row only — the
+    // runtime silent registry is gone and the backoff deadline already passed.
+    const restored = makeDs({
+      session: { ...structuredClone(ds.session), ordinaryTurnRecovery: { ...persisted, nextAttemptAt: Date.now() - 1 } },
+    });
+    expect(restored.silentScheduledTurns).toBeUndefined();
+    const silentAtSend: Array<[string, boolean]> = [];
+    forkMock.mockImplementation(() => {
+      const w = makeFakeWorker();
+      w.send = vi.fn((message: any) => {
+        if (message?.turnId) silentAtSend.push([message.turnId, isSilentScheduledTurn(restored, message.turnId)]);
+        return true;
+      });
+      return w;
+    });
+    ensureOrdinaryTurnRecoveryAttached(restored);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const [continuationId, silentWhenSent] = silentAtSend.find(([id]) => id !== SCHEDULED_TURN)!;
+    expect(continuationId).toMatch(/^schedule:abcdef12:/);
+    expect(silentWhenSent).toBe(true);
+    expect(isSilentScheduledTurn(restored, continuationId)).toBe(true);
+    expect(auxUiSuppressedFor(restored, continuationId)).toBe(true);
+    const initMsg = vi.mocked(forkMock.mock.results.at(-1)!.value.send).mock.calls
+      .map((c: any[]) => c[0]).find((m: any) => m?.type === 'init');
+    expect(initMsg.trustedCaller).toEqual(CREATOR_IDENTITY);
+  });
+
+  it('re-arms silence for a delivered continuation that was running when the daemon restarted', async () => {
+    await bootClaudeSession();
+    const continuationId = 'schedule:abcdef12:22222222-2222-2222-2222-222222222222';
+    const restored = makeDs({
+      session: {
+        ...makeDs().session,
+        ordinaryTurnRecovery: {
+          logicalTurnId: SCHEDULED_TURN, currentTurnId: continuationId, continuationsStarted: 1,
+          status: 'running', silentLogicalTurnIds: [SCHEDULED_TURN],
+        },
+      },
+    });
+    ensureOrdinaryTurnRecoveryAttached(restored);
+    expect(isSilentScheduledTurn(restored, continuationId)).toBe(true);
+    expect(isSilentScheduledTurn(restored, SCHEDULED_TURN)).toBe(true);
+    expect(auxUiSuppressedFor(restored, continuationId)).toBe(true);
+    // Unrelated turns stay loud.
+    expect(auxUiSuppressedFor(restored, 'om_other')).toBe(false);
+  });
+
+  it('treats a pre-upgrade archive without the silent field as loud and still recovers', async () => {
+    await bootClaudeSession();
+    const restored = makeDs({
+      session: {
+        ...makeDs().session,
+        ordinaryTurnRecovery: {
+          logicalTurnId: SCHEDULED_TURN, currentTurnId: SCHEDULED_TURN, continuationsStarted: 0,
+          status: 'backoff', nextAttemptAt: Date.now() - 1, lastErrorCode: 'provider_server_error',
+        },
+      },
+    });
+    ensureOrdinaryTurnRecoveryAttached(restored);
+    await vi.advanceTimersByTimeAsync(0);
+    const initMsg = vi.mocked(forkMock.mock.results.at(-1)!.value.send).mock.calls
+      .map((c: any[]) => c[0]).find((m: any) => m?.type === 'init');
+    expect(initMsg.turnId).toMatch(/^schedule:abcdef12:/);
+    expect(isSilentScheduledTurn(restored, initMsg.turnId)).toBe(false);
+    expect(restored.session.ordinaryTurnRecovery).toEqual(expect.objectContaining({ continuationsStarted: 1, status: 'running' }));
   });
 
   it('still raises the failure card when a scheduled turn fails non-retryably', async () => {

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -160,6 +160,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 }));
 
 import { __testOnly_resetSessionLifecycleHooks } from '../src/services/session-lifecycle-hooks.js';
+import { armSilentScheduledTurn, isSilentScheduledTurn } from '../src/core/silent-schedule-turns.js';
 import {
   __testOnly_resetOrdinaryImDeliveries,
   detachWorkerForTransfer,
@@ -4956,5 +4957,120 @@ describe('forkWorker session.workingDir back-fill (cross-bot inherit enabler)', 
     ds.session.workingDir = undefined;
     forkWorker(ds, 'hi', false);
     expect(ds.session.workingDir).toBeFalsy();   // realpath(homeLink) === realpath($HOME) → excluded
+  });
+});
+
+describe('ordinary-turn recovery for scheduled turns', () => {
+  const SCHEDULED_TURN = 'schedule:abcdef12:11111111-2222-3333-4444-555555555555';
+
+  async function bootClaudeSession() {
+    vi.useFakeTimers();
+    vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId: 'claude-code' }));
+    const sessionReply = vi.fn(async () => 'om_card');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+    forkWorker(ds, 'warm up', 'om_original');
+    const worker = forkMock.mock.results.at(-1)!.value;
+    worker.emit('message', { type: 'ready', port: 3456, token: 'token' });
+    worker.emit('message', { type: 'turn_input_received', turnId: 'om_original' });
+    worker.emit('message', { type: 'turn_input_committed', turnId: 'om_original' });
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'om_original',
+      status: 'completed',
+    });
+    // The terminal handler is async; let it settle before the next admission.
+    await vi.advanceTimersByTimeAsync(0);
+    vi.mocked(worker.send).mockImplementation((_message: any, callback?: (err?: Error | null) => void) => {
+      callback?.(null);
+      return true;
+    });
+    sessionReply.mockClear();
+    return { ds, worker, sessionReply };
+  }
+
+  function sentMessages(worker: any) {
+    return vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'message');
+  }
+
+  it('admits a scheduled fire into semantic recovery and continues it as the same scheduled turn', async () => {
+    const { ds, worker, sessionReply } = await bootClaudeSession();
+    armSilentScheduledTurn(ds, SCHEDULED_TURN);
+
+    expect(sendWorkerInput(ds, 'hourly task prompt', SCHEDULED_TURN)).toBe(true);
+    expect(ds.session.ordinaryTurnRecovery).toEqual({
+      logicalTurnId: SCHEDULED_TURN,
+      currentTurnId: SCHEDULED_TURN,
+      continuationsStarted: 0,
+      status: 'running',
+    });
+
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: SCHEDULED_TURN,
+      status: 'failed',
+      errorCode: 'provider_server_error',
+      retryable: true,
+    });
+    await Promise.resolve();
+    // Recovery owns the terminal: no「未启动自动续跑」card for a retryable failure.
+    expect(sessionReply).not.toHaveBeenCalled();
+    expect(ds.session.ordinaryTurnRecovery?.status).toBe('backoff');
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    const continuation = sentMessages(worker).find(message => message.turnId !== SCHEDULED_TURN);
+    expect(continuation).toBeDefined();
+    expect(continuation.turnId).toMatch(/^schedule:abcdef12:[0-9a-f-]{36}$/);
+    expect(continuation.turnId).not.toBe(SCHEDULED_TURN);
+    expect(continuation.content).toContain('[BOTMUX_RECOVERY]');
+    expect(continuation.content).not.toContain('hourly task prompt');
+    // The fire was silent, so its continuation stays silent.
+    expect(isSilentScheduledTurn(ds, continuation.turnId)).toBe(true);
+    expect(ds.session.ordinaryTurnRecovery).toEqual(expect.objectContaining({
+      logicalTurnId: SCHEDULED_TURN,
+      currentTurnId: continuation.turnId,
+      continuationsStarted: 1,
+      status: 'running',
+    }));
+
+    worker.emit('message', { type: 'turn_input_received', turnId: continuation.turnId });
+    worker.emit('message', { type: 'turn_input_committed', turnId: continuation.turnId });
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: continuation.turnId,
+      status: 'completed',
+    });
+    await Promise.resolve();
+    expect(ds.session.ordinaryTurnRecovery?.status).toBe('completed');
+    expect(sessionReply).not.toHaveBeenCalled();
+  });
+
+  it('still raises the failure card when a scheduled turn fails non-retryably', async () => {
+    const { ds, worker, sessionReply } = await bootClaudeSession();
+    expect(sendWorkerInput(ds, 'hourly task prompt', SCHEDULED_TURN)).toBe(true);
+
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: SCHEDULED_TURN,
+      status: 'failed',
+      errorCode: 'provider_authentication_failed',
+      retryable: false,
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    expect(sentMessages(worker).filter(message => message.turnId !== SCHEDULED_TURN)).toHaveLength(0);
+    expect(ds.session.ordinaryTurnRecovery?.status).toBe('attention_required');
   });
 });

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -160,6 +160,20 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 }));
 
 import { __testOnly_resetSessionLifecycleHooks } from '../src/services/session-lifecycle-hooks.js';
+
+// Scheduled-task store seen by the recovery continuation's identity lookup.
+// Keyed by task id; empty means "task deleted" (no identity, fail-closed).
+const { scheduledTasksForProvenance } = vi.hoisted(() => ({
+  scheduledTasksForProvenance: new Map<string, any>(),
+}));
+vi.mock('../src/core/scheduled-turn-provenance.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/core/scheduled-turn-provenance.js')>();
+  return {
+    ...actual,
+    readScheduledTaskForProvenance: (_dataDir: string, _larkAppId: string, taskId: string) =>
+      scheduledTasksForProvenance.get(taskId),
+  };
+});
 import { armSilentScheduledTurn, isSilentScheduledTurn } from '../src/core/silent-schedule-turns.js';
 import {
   __testOnly_resetOrdinaryImDeliveries,
@@ -4960,7 +4974,7 @@ describe('forkWorker session.workingDir back-fill (cross-bot inherit enabler)', 
   });
 });
 
-describe('ordinary-turn recovery for scheduled turns', () => {
+describe('ordinary-turn recovery admission (scheduled turns, type-ahead)', () => {
   const SCHEDULED_TURN = 'schedule:abcdef12:11111111-2222-3333-4444-555555555555';
 
   async function bootClaudeSession() {
@@ -4995,17 +5009,45 @@ describe('ordinary-turn recovery for scheduled turns', () => {
     return { ds, worker, sessionReply };
   }
 
+  function ackInput(worker: any, turnId: string) {
+    worker.emit('message', { type: 'turn_input_received', turnId });
+    worker.emit('message', { type: 'turn_input_committed', turnId });
+  }
+
   function sentMessages(worker: any) {
     return vi.mocked(worker.send).mock.calls
       .map(call => call[0])
       .filter(message => message?.type === 'message');
   }
 
+  const CREATOR_IDENTITY = {
+    requestUserOpenId: 'ou_owner',
+    requestUserUnionId: 'on_owner',
+    requestLarkAppId: 'cli_creator',
+    source: 'schedule_creator',
+    taskId: 'abcdef12',
+  };
+
+  beforeEach(() => {
+    scheduledTasksForProvenance.clear();
+    scheduledTasksForProvenance.set('abcdef12', {
+      id: 'abcdef12',
+      name: 'hourly',
+      prompt: 'hourly task prompt',
+      chatId: 'oc_chat',
+      enabled: true,
+      ownerOpenId: 'ou_owner',
+      ownerUnionId: 'on_owner',
+      creatorLarkAppId: 'cli_creator',
+    });
+  });
+
   it('admits a scheduled fire into semantic recovery and continues it as the same scheduled turn', async () => {
     const { ds, worker, sessionReply } = await bootClaudeSession();
     armSilentScheduledTurn(ds, SCHEDULED_TURN);
 
     expect(sendWorkerInput(ds, 'hourly task prompt', SCHEDULED_TURN)).toBe(true);
+    ackInput(worker, SCHEDULED_TURN);
     expect(ds.session.ordinaryTurnRecovery).toEqual({
       logicalTurnId: SCHEDULED_TURN,
       currentTurnId: SCHEDULED_TURN,
@@ -5033,6 +5075,8 @@ describe('ordinary-turn recovery for scheduled turns', () => {
     expect(continuation.turnId).not.toBe(SCHEDULED_TURN);
     expect(continuation.content).toContain('[BOTMUX_RECOVERY]');
     expect(continuation.content).not.toContain('hourly task prompt');
+    // The continuation IPC runs as the task creator, exactly like the fire.
+    expect(continuation.trustedCaller).toEqual(CREATOR_IDENTITY);
     // The fire was silent, so its continuation stays silent.
     expect(isSilentScheduledTurn(ds, continuation.turnId)).toBe(true);
     expect(ds.session.ordinaryTurnRecovery).toEqual(expect.objectContaining({
@@ -5042,8 +5086,7 @@ describe('ordinary-turn recovery for scheduled turns', () => {
       status: 'running',
     }));
 
-    worker.emit('message', { type: 'turn_input_received', turnId: continuation.turnId });
-    worker.emit('message', { type: 'turn_input_committed', turnId: continuation.turnId });
+    ackInput(worker, continuation.turnId);
     worker.emit('message', {
       type: 'turn_terminal',
       sessionId: ds.session.sessionId,
@@ -5055,9 +5098,114 @@ describe('ordinary-turn recovery for scheduled turns', () => {
     expect(sessionReply).not.toHaveBeenCalled();
   });
 
+  it('bounds a scheduled turn to two continuations and then raises exactly one card', async () => {
+    const { ds, worker, sessionReply } = await bootClaudeSession();
+    expect(sendWorkerInput(ds, 'hourly task prompt', SCHEDULED_TURN)).toBe(true);
+    ackInput(worker, SCHEDULED_TURN);
+
+    const fail = async (turnId: string, advanceMs: number) => {
+      worker.emit('message', {
+        type: 'turn_terminal',
+        sessionId: ds.session.sessionId,
+        turnId,
+        status: 'failed',
+        errorCode: 'provider_server_error',
+        retryable: true,
+      });
+      await vi.advanceTimersByTimeAsync(advanceMs);
+    };
+    const continuations = () => sentMessages(worker).filter(message => message.turnId !== SCHEDULED_TURN);
+
+    await fail(SCHEDULED_TURN, 2_000);
+    expect(continuations()).toHaveLength(1);
+    ackInput(worker, continuations()[0].turnId);
+    await fail(continuations()[0].turnId, 8_000);
+    expect(continuations()).toHaveLength(2);
+    expect(continuations()[1].turnId).not.toBe(continuations()[0].turnId);
+    for (const message of continuations()) {
+      expect(message.turnId).toMatch(/^schedule:abcdef12:[0-9a-f-]{36}$/);
+      expect(message.trustedCaller).toEqual(CREATOR_IDENTITY);
+    }
+    expect(sessionReply).not.toHaveBeenCalled();
+
+    ackInput(worker, continuations()[1].turnId);
+    await fail(continuations()[1].turnId, 60_000);
+    expect(continuations()).toHaveLength(2);
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    expect(ds.session.ordinaryTurnRecovery).toEqual(expect.objectContaining({
+      status: 'exhausted',
+      continuationsStarted: 2,
+    }));
+  });
+
+  it('continues without an identity when the scheduled task was deleted meanwhile', async () => {
+    const { ds, worker } = await bootClaudeSession();
+    expect(sendWorkerInput(ds, 'hourly task prompt', SCHEDULED_TURN)).toBe(true);
+    ackInput(worker, SCHEDULED_TURN);
+    scheduledTasksForProvenance.clear();
+
+    worker.emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: SCHEDULED_TURN,
+      status: 'failed',
+      errorCode: 'provider_server_error',
+      retryable: true,
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    const continuation = sentMessages(worker).find(message => message.turnId !== SCHEDULED_TURN);
+    expect(continuation.turnId).toMatch(/^schedule:abcdef12:/);
+    expect(continuation.trustedCaller).toBeUndefined();
+  });
+
+  it('recovers a type-ahead turn that fails after the running turn completed', async () => {
+    const { ds, worker, sessionReply } = await bootClaudeSession();
+    expect(sendWorkerInput(ds, 'first question', 'om_first')).toBe(true);
+    ackInput(worker, 'om_first');
+    // Type-ahead: admitted while om_first is still running.
+    expect(sendWorkerInput(ds, 'second question', 'om_second')).toBe(true);
+    ackInput(worker, 'om_second');
+    expect(ds.session.ordinaryTurnRecovery).toEqual({
+      logicalTurnId: 'om_first',
+      currentTurnId: 'om_first',
+      continuationsStarted: 0,
+      status: 'running',
+      queuedLogicalTurnIds: ['om_second'],
+    });
+
+    worker.emit('message', {
+      type: 'turn_terminal', sessionId: ds.session.sessionId, turnId: 'om_first', status: 'completed',
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ds.session.ordinaryTurnRecovery).toEqual({
+      logicalTurnId: 'om_second',
+      currentTurnId: 'om_second',
+      continuationsStarted: 0,
+      status: 'running',
+    });
+
+    worker.emit('message', {
+      type: 'turn_terminal', sessionId: ds.session.sessionId, turnId: 'om_second',
+      status: 'failed', errorCode: 'provider_server_error', retryable: true,
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    // Before: om_second had no recovery consumer → only the「未启动自动续跑」card.
+    expect(sessionReply).not.toHaveBeenCalled();
+    const continuation = sentMessages(worker).find(message => message.turnId?.startsWith('bmx-recovery-'));
+    expect(continuation).toBeDefined();
+    expect(continuation.content).toContain('[BOTMUX_RECOVERY]');
+    expect(ds.session.ordinaryTurnRecovery).toEqual(expect.objectContaining({
+      logicalTurnId: 'om_second',
+      currentTurnId: continuation.turnId,
+      continuationsStarted: 1,
+      status: 'running',
+    }));
+  });
+
   it('still raises the failure card when a scheduled turn fails non-retryably', async () => {
     const { ds, worker, sessionReply } = await bootClaudeSession();
     expect(sendWorkerInput(ds, 'hourly task prompt', SCHEDULED_TURN)).toBe(true);
+    ackInput(worker, SCHEDULED_TURN);
 
     worker.emit('message', {
       type: 'turn_terminal',

--- a/test/worker-codex-startup-readiness.integration.test.ts
+++ b/test/worker-codex-startup-readiness.integration.test.ts
@@ -1,0 +1,78 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { ChildProcess } from 'node:child_process';
+import { expect, it } from 'vitest';
+import { spawnNodeTsScript } from './helpers/ts-runner.js';
+import type { DaemonToWorker, WorkerToDaemon } from '../src/types.js';
+
+it('keeps the worker input queue untouched during Codex loading, then pastes the first message once', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'botmux-worker-codex-startup-'));
+  const dataDir = join(root, 'data');
+  mkdirSync(dataDir);
+  const loadingFile = join(root, 'loading');
+  const releaseFile = join(root, 'release');
+  const inputFile = join(root, 'input');
+  const cliPidFile = join(root, 'cli-pid');
+  const fakeCli = join(root, 'fake-codex');
+  writeFileSync(fakeCli, `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.writeFileSync(${JSON.stringify(cliPidFile)}, String(process.pid));
+process.stdin.setRawMode(true);
+process.stdin.on('data', b => fs.appendFileSync(${JSON.stringify(inputFile)}, b));
+process.stdout.write('│ model: loading /model to change │\\n│ directory: loading │\\n› Ask Codex to do anything\\n  ? for shortcuts');
+fs.writeFileSync(${JSON.stringify(loadingFile)}, 'ready');
+const poll = setInterval(() => {
+  if (!fs.existsSync(${JSON.stringify(releaseFile)})) return;
+  clearInterval(poll);
+  process.stdout.write('\\n│ model: custom-model /model to change │\\n│ directory: /tmp │\\n› Ask Codex to do anything\\n  custom-model · /tmp');
+}, 50);
+setInterval(() => {}, 1000);
+`);
+  chmodSync(fakeCli, 0o755);
+  const messages: WorkerToDaemon[] = [];
+  const logs: string[] = [];
+  let child: ChildProcess | undefined;
+  const waitFor = async (condition: () => boolean) => {
+    const deadline = Date.now() + 12_000;
+    while (!condition()) {
+      if (Date.now() >= deadline || child?.exitCode != null) throw new Error(logs.join(''));
+      await new Promise(r => setTimeout(r, 25));
+    }
+  };
+  try {
+    child = spawnNodeTsScript(resolve('src/worker.ts'), [], {
+      cwd: resolve('.'),
+      env: { ...process.env, HOME: root, SESSION_DATA_DIR: dataDir, BOTMUX_SESSION_ID: 'sid-startup-test', LARK_APP_ID: 'app_test', LARK_APP_SECRET: 'secret' },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    child.on('message', m => messages.push(m as WorkerToDaemon));
+    child.stdout?.on('data', b => logs.push(b.toString()));
+    child.stderr?.on('data', b => logs.push(b.toString()));
+    child.send({
+      type: 'init', sessionId: 'sid-startup-test', chatId: 'oc_test', rootMessageId: 'om_root',
+      workingDir: dataDir, cliId: 'codex', cliPathOverride: fakeCli, backendType: 'pty',
+      prompt: 'only-this-startup-prompt', turnId: 'om_test', larkAppId: 'app_test', larkAppSecret: 'secret',
+    } satisfies DaemonToWorker);
+    await waitFor(() => existsSync(loadingFile));
+    // Cross the real 2s screen-idle threshold while startup remains blocked.
+    await new Promise(r => setTimeout(r, 3_200));
+    expect(existsSync(inputFile), logs.join('')).toBe(false);
+    expect(messages.some(m => m.type === 'prompt_ready')).toBe(false);
+    writeFileSync(releaseFile, 'loaded');
+    await waitFor(() => existsSync(inputFile));
+    const text = readFileSync(inputFile, 'utf8');
+    expect(text.match(/only-this-startup-prompt/g)).toHaveLength(1);
+    expect(text).toContain('\x1b[200~');
+  } finally {
+    if (child && child.exitCode === null && child.signalCode === null) {
+      const exited = new Promise<void>(r => child!.once('exit', () => r()));
+      child.kill('SIGKILL');
+      await Promise.race([exited, new Promise(r => setTimeout(r, 2_000))]);
+    }
+    if (existsSync(cliPidFile)) {
+      try { process.kill(Number(readFileSync(cliPidFile, 'utf8')), 'SIGKILL'); } catch { /* exited */ }
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 25_000);

--- a/test/worker-ordinary-im-init-concurrency.integration.test.ts
+++ b/test/worker-ordinary-im-init-concurrency.integration.test.ts
@@ -242,7 +242,10 @@ setInterval(() => {}, 1_000);
         OPENCODE_DB_PATH: join(dbDir, 'opencode.db'),
         SESSION_DATA_DIR: dataDir,
         BOTMUX_SESSION_ID: 'sid-opencode-activation',
-        BOTMUX_TIME_SCALE: '0.05',
+        // This starts a real Node process: shrinking the 2.4s confirmation
+        // window to 120ms races its SQLite write, then the 20s deferred
+        // recheck falls outside this test's 8s acknowledgement deadline.
+        BOTMUX_TIME_SCALE: '1',
         LARK_APP_ID: 'app_test',
         LARK_APP_SECRET: 'secret',
       },


### PR DESCRIPTION
Codex 冷启动会先画出带 `›` 的 loading 骨架屏，原有静默判定会提前投递首条消息；Claude 的定时任务和运行中排队的后继消息又未完整登记到故障恢复状态，遇到可重试的服务错误时只显示「未启动自动续跑」。

本改动让 Codex 等模型与目录 banner 完整加载后再投递，并让屏幕就绪、普通输入、命令注入及首次超时共用启动门控。门控保留分块 ANSI 和 reset 前的证据，初始化完成后不会被历史中引用的 loading 再次锁住。Claude 恢复新增定时轮与排队后继的登记，保持定时任务创建者身份、静默设置和最多两次续跑；已投递的恢复不会被后继终态抢占。

静默属性现在按逻辑轮次持久化，并在恢复定时器及 worker 事件处理前重建静默标记。覆盖排队后继接管、两次续跑、运行中重启和已结束轮次的迟到输出；普通消息不会继承静默。旧存档没有静默属性时保留原有行为，不根据后来修改或删除的任务配置反推本轮属性。

现场可证明输入留在草稿，不能证明 loading 总会吞 Enter：隔离真机中也观察到输入在 bootstrap 后自动排队提交。本改动消除已验证的过早投递条件，没有新增重贴原始任务或盲目补 Enter。模型服务端错误本身仍可能发生。

影响面：启动门控是可选 adapter 能力，目前仅 Codex 启用；其它 CLI 继续原有路径。Claude 恢复仅针对原有 eligible 的 active Lark 会话，shared adopt、会议接收、无 Lark 传输路径保持排除。PTY 与持久终端共用 worker 门控，恢复旧会话的历史播种有回归覆盖；本机实测平台为 macOS arm64，未实测 Linux/Windows。

验证：

- 静默恢复补修 `bf8e5adf`：10 个相关文件 439 项测试通过，完整 build 与编译态烟测通过。新增用例先验证失败；worker 事件层实际复现了 completed 轮次重启后漏发通知，修订后保持静默，随后普通消息仍可显示。此提交的 [CI #34265758347](https://github.com/deepcoldy/botmux/actions/runs/34265758347) 中 build、三项二进制检查、bun-test 和两组 Node 测试通过；第一组有一个既有 OpenCode 集成用例确认超时，汇总检查因此失败。该用例在本机复现后，用单独的测试提交修正时间加速配置（见下），最新提交 `583d8523` 的 [CI #34266897206](https://github.com/deepcoldy/botmux/actions/runs/34266897206) 已完成，9 项检查全部通过：build、三组 Node 测试及汇总、bun-test、Linux/macOS/musl 二进制检查。

- 测试补修 `583d8523`：OpenCode 真实进程集成用例改为正常时间比例，避免把提交确认窗口从 2.4 秒压缩到 120ms，却仍需等待真实 Node 启动和 SQLite 写入；20 秒延后复查无法落在测试的 8 秒等待范围内。同一失败也在干净基线 `7d83eabd` 与另一测试文件并跑时复现，属于负载敏感的既有测试竞争。保留原有提交确认断言，未修改运行时代码。失败用例修改前 8 秒超时，修改后 2.13 秒通过，执行 `node node_modules/vitest/vitest.mjs run --project unit test/worker-ordinary-im-init-concurrency.integration.test.ts`，整个文件 5 项通过；再次执行 `bun run build` 通过。
- GitHub [CI #34246201618](https://github.com/deepcoldy/botmux/actions/runs/34246201618) 在 commit `a5e682e3` 上的 9 项检查全部通过：build、三组测试及汇总、bun-test、Linux/macOS/musl 二进制检查。
- 最终合并分支 12 个相关测试文件、943 项全部通过，覆盖启动/恢复/输入确认/其它 CLI adapter；新增回归均先验证失败后修复。
- 最终 `bun run build` 通过，包含 TypeScript、scripts/mock typecheck、资源审计。
- 两次隔离 Codex 0.153.3 真机慢启动探针：约 42 秒 loading 期间未投递，加载后约 0.4 秒确认 4516 字符消息，history 精确匹配均只有一条。
- 最终编译态 `bun run verify:binary --keep` 的签名、PTY、supervisor、Dashboard 和内嵌资源烟测通过。
- 本机已更新到补修 commit `bf8e5adf` 的独立二进制（版本 `3.20.0-18-gbf8e5adf`），核对进程路径后确认两个 bot daemon 与 Dashboard 均运行此版本、online、零重启。补修版本已完成既有飞书话题收发复验：原 Claude 会话在重启后正常接收普通消息并回复，CLI 版本同步确认。原安装保留供回退，未发布 npm/tag。
- 另一个工作目录的全量 unit 运行报告 22151 通过、52 失败，涉及构建产物和本机环境；两个抽样失败已在原始基线复现。其余未逐一排除，未把这次全量运行作为全绿证据。

