### PR TITLE
fix(bridge): 确保结构化失败对用户可见

### DIFF
--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -370,7 +370,7 @@ export function shouldEmitEmptyCompletedBridgeFallback(
   return !shouldSuppressBridgeEmit(turn, nextBoundaryMs, markers, adoptMode);
 }
 
-/** 结构化失败回合补发可见错误；部分回答不能替代失败原因。 */
+/** 结构化失败回合补发可见错误；进度回复不能替代失败原因。 */
 export function shouldEmitFailedBridgeFallback(
   turn: BridgeGateInput,
   nextBoundaryMs: number | undefined,
@@ -380,7 +380,48 @@ export function shouldEmitFailedBridgeFallback(
   if (adoptMode) return false;
   if (turn.isLocal) return false;
   if (turn.terminalStatus !== 'failed') return false;
-  return !shouldSuppressBridgeEmit(turn, nextBoundaryMs, markers, adoptMode);
+  // A bare sentinel is an explicit request for silence, even when the provider
+  // also reports a failed terminal. Never turn that internal token into visible
+  // failure content.
+  if (isBridgeNothingToSendFinal(turn.finalText)) return false;
+  // A progress/final send only proves that some user-facing content was already
+  // delivered; it cannot replace the structured terminal failure reason. The
+  // existing delivery path uses the current turn's stable key for deduplication.
+  return true;
+}
+
+/** Failure fallbacks are terminal diagnostics, not another model answer. Only
+ * bypass marker-based suppression; preserve deliberate silence and the existing
+ * local/adopt ownership gates. Non-failure output keeps the ordinary gate. */
+export function shouldSuppressStructuredFallback(
+  fallbackKind: StructuredFallbackKind,
+  turn: BridgeGateInput,
+  nextBoundaryMs: number | undefined,
+  markers: readonly BridgeSendMarker[],
+  adoptMode: boolean,
+): boolean {
+  if (fallbackKind !== 'failed') {
+    return shouldSuppressBridgeEmit(turn, nextBoundaryMs, markers, adoptMode);
+  }
+  return adoptMode || Boolean(turn.isLocal) || isBridgeNothingToSendFinal(turn.finalText);
+}
+
+/** Compose a failed-turn diagnostic without replaying partial text that the
+ * ordinary marker gate already classifies as delivered or deliberately kept
+ * out of chat. Any retained partial text is sentinel-cleaned before the
+ * diagnostic is appended, so the protocol token can never become body text. */
+export function composeFailedBridgeFallbackContent(
+  failureText: string,
+  turn: BridgeGateInput,
+  nextBoundaryMs: number | undefined,
+  markers: readonly BridgeSendMarker[],
+  adoptMode: boolean,
+): string {
+  if (shouldSuppressBridgeEmit(turn, nextBoundaryMs, markers, adoptMode)) {
+    return failureText;
+  }
+  const visiblePartialText = bridgePostText(turn.finalText ?? '', adoptMode).trim();
+  return visiblePartialText ? `${visiblePartialText}\n\n${failureText}` : failureText;
 }
 
 /** Which fallback content the worker should post for a ready structured turn.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -66,7 +66,7 @@ import { roleLibraryRoot, roleLibrarySubtree } from './core/role-library.js';
 import { larkTransportEnabled as sessionLarkTransportEnabled } from './core/types.js';
 import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, extractCotEntries, ClaudeModelFallbackTracker, type ModelFallbackObservation, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint, type BridgePendingTurn } from './services/bridge-turn-queue.js';
-import { bridgePostText, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, structuredFallbackKind, stripTrailingOaiMemoryCitation, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
+import { bridgePostText, composeFailedBridgeFallbackContent, isBridgeNothingToSendFinal, shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, shouldSuppressStructuredFallback, structuredFallbackKind, stripTrailingOaiMemoryCitation, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { buildSubmitMessagePreview } from './services/submit-notification.js';
 import {
   decideHardTimeoutAction,
@@ -4597,7 +4597,7 @@ function emptyCompletedBridgeFallbackContent(): string {
   return t('worker.empty_final_completed', { cliName: cliName() });
 }
 
-function failedBridgeFallbackContent(errorCode?: string, summary?: string, partialText?: string): string {
+function failedBridgeFailureText(errorCode?: string, summary?: string): string {
   const reason = summary || t('worker.failed_reason_unavailable');
   const key = errorCode === CODEX_INVALID_REQUEST_ERROR_CODE
     ? 'worker.empty_final_failed_invalid_request'
@@ -4609,8 +4609,7 @@ function failedBridgeFallbackContent(errorCode?: string, summary?: string, parti
           ? 'worker.empty_final_failed_upstream'
           : 'worker.empty_final_failed';
   const failure = t(key, { cliName: cliName(), reason });
-  const visiblePartialText = stripTrailingOaiMemoryCitation(partialText ?? '').trim();
-  return visiblePartialText ? `${visiblePartialText}\n\n${failure}` : failure;
+  return failure;
 }
 
 // ─── Bridge fallback marker (non-adopt) ────────────────────────────────────
@@ -7711,7 +7710,13 @@ function emitReadyCodexTurns(): void {
       gateInput, nextBoundaryMs, markers, adoptMode, structuredBridgeIsCodex(),
     );
     const content = fallbackKind === 'failed'
-      ? failedBridgeFallbackContent(turn.terminalErrorCode, turn.terminalErrorSummary, turn.finalText)
+      ? composeFailedBridgeFallbackContent(
+          failedBridgeFailureText(turn.terminalErrorCode, turn.terminalErrorSummary),
+          gateInput,
+          nextBoundaryMs,
+          markers,
+          adoptMode,
+        )
       : fallbackKind === 'final'
         ? turn.finalText ?? ''
         : fallbackKind === 'empty_completed'
@@ -7728,11 +7733,11 @@ function emitReadyCodexTurns(): void {
     // the most common success path of all. failed/ambiguous stay a no-op via
     // bridgeTurnOutcome, so a limit refusal never reads as success.
     const turnOutcome = bridgeTurnOutcome(turn);
-    if (!content || shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
+    if (!content || shouldSuppressStructuredFallback(fallbackKind, gateInput, nextBoundaryMs, markers, adoptMode)) {
       usageLimitTracker.noteTurnCompleted(turnOutcome);
     }
     if (!content) continue;
-    if (shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {
+    if (shouldSuppressStructuredFallback(fallbackKind, gateInput, nextBoundaryMs, markers, adoptMode)) {
       log(`Codex bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (gate)`);
       // Distinguish DELIBERATE SILENCE (bare nothing-to-send sentinel, no prose,
       // no send) from other suppression reasons (already `botmux send`-ed this

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -7,9 +7,11 @@ import {
   buildBridgeSendMarkerContent,
   buildBridgeSendPreviewText,
   bridgePostText,
+  composeFailedBridgeFallbackContent,
   isBridgeNothingToSendFinal,
   shouldEmitEmptyCompletedBridgeFallback,
   shouldEmitFailedBridgeFallback,
+  shouldSuppressStructuredFallback,
   shouldSuppressBridgeEmit,
   structuredFallbackKind,
   stripTrailingBridgeSentinelLine,
@@ -714,13 +716,16 @@ describe('shouldEmitFailedBridgeFallback', () => {
     )).toBe(true);
   });
 
-  it('does not duplicate a send or affect completed, local, and adopt turns', () => {
+  it('keeps the failure visible after an explicit progress send', () => {
     expect(shouldEmitFailedBridgeFallback(
       { ...turn(100), finalText: '', terminalStatus: 'failed' },
       200,
       [markerForContent(150, 'already reported')],
       false,
-    )).toBe(false);
+    )).toBe(true);
+  });
+
+  it('does not affect completed, local, and adopt turns', () => {
     expect(shouldEmitFailedBridgeFallback(
       { ...turn(100), finalText: '', terminalStatus: 'completed' },
       undefined,
@@ -748,6 +753,83 @@ describe('shouldEmitFailedBridgeFallback', () => {
       [],
       false,
     )).toBe(true);
+  });
+
+  it('preserves deliberate silence for a failed turn with only the sentinel', () => {
+    expect(shouldEmitFailedBridgeFallback(
+      { ...turn(100), finalText: 'BOTMUX_NOTHING_TO_SEND', terminalStatus: 'failed' },
+      undefined,
+      [],
+      false,
+    )).toBe(false);
+  });
+});
+
+describe('shouldSuppressStructuredFallback', () => {
+  const progress = [markerForContent(150, 'still working')];
+  const failed = { ...turn(100), finalText: '', terminalStatus: 'failed' as const };
+
+  it('never lets a progress marker suppress a terminal failure fallback', () => {
+    expect(shouldSuppressStructuredFallback('failed', failed, 200, progress, false)).toBe(false);
+  });
+
+  it('still suppresses a failed turn whose final is only the silence sentinel', () => {
+    const sentinelFailure = {
+      ...turn(100),
+      finalText: 'BOTMUX_NOTHING_TO_SEND',
+      terminalStatus: 'failed' as const,
+    };
+    expect(shouldSuppressStructuredFallback('failed', sentinelFailure, undefined, [], false)).toBe(true);
+    expect(shouldSuppressStructuredFallback('failed', sentinelFailure, 200, progress, false)).toBe(true);
+  });
+
+  it('retains local and adopt ownership gates for failure fallbacks', () => {
+    expect(shouldSuppressStructuredFallback('failed', { ...failed, isLocal: true }, undefined, [], false)).toBe(true);
+    expect(shouldSuppressStructuredFallback('failed', failed, undefined, [], true)).toBe(true);
+  });
+
+  it('preserves ordinary marker dedup for non-failure output', () => {
+    expect(shouldSuppressStructuredFallback('final', turn(100), 200, progress, false)).toBe(true);
+    expect(shouldSuppressStructuredFallback('empty_completed', turn(100), 200, progress, false)).toBe(true);
+  });
+});
+
+describe('composeFailedBridgeFallbackContent', () => {
+  it('shows the failure but drops marker-suppressed narration and its trailing sentinel', () => {
+    const narration = 'Internal narration that was deliberately kept out of chat.';
+    const failed = {
+      ...turn(100),
+      finalText: `${narration}\n\nBOTMUX_NOTHING_TO_SEND`,
+      terminalStatus: 'failed' as const,
+    };
+
+    const content = composeFailedBridgeFallbackContent(
+      'FAILURE',
+      failed,
+      200,
+      [markerForContent(150, 'still working')],
+      false,
+    );
+
+    expect(content).toBe('FAILURE');
+    expect(content).not.toContain(narration);
+    expect(content).not.toContain('BOTMUX_NOTHING_TO_SEND');
+  });
+
+  it('keeps an unsent partial answer but strips its trailing sentinel before the failure', () => {
+    const failed = {
+      ...turn(100),
+      finalText: 'Partial answer\n\nBOTMUX_NOTHING_TO_SEND',
+      terminalStatus: 'failed' as const,
+    };
+
+    expect(composeFailedBridgeFallbackContent(
+      'FAILURE',
+      failed,
+      undefined,
+      [],
+      false,
+    )).toBe('Partial answer\n\nFAILURE');
   });
 });
 
@@ -787,6 +869,39 @@ describe('structuredFallbackKind', () => {
         hasChain,
       )).toBe('failed');
     }
+  });
+
+  it('a progress marker cannot suppress an empty structured failure', () => {
+    expect(structuredFallbackKind(
+      { ...turn(100), finalText: '', terminalStatus: 'failed', terminalErrorCode: CODEX_CONNECTION_ERROR_CODE },
+      200,
+      [markerForContent(150, 'still working')],
+      false,
+      false,
+    )).toBe('failed');
+  });
+
+  it('a pure sentinel never becomes a failure fallback, with or without a progress marker', () => {
+    const sentinelFailure = {
+      ...turn(100),
+      finalText: 'BOTMUX_NOTHING_TO_SEND',
+      terminalStatus: 'failed' as const,
+      terminalErrorCode: CODEX_CONNECTION_ERROR_CODE,
+    };
+    expect(structuredFallbackKind(
+      sentinelFailure,
+      undefined,
+      [],
+      false,
+      false,
+    )).toBe('final');
+    expect(structuredFallbackKind(
+      sentinelFailure,
+      200,
+      [markerForContent(150, 'still working')],
+      false,
+      false,
+    )).toBe('final');
   });
 
   it('a non-empty final maps to final', () => {


### PR DESCRIPTION
## 背景

结构化 turn 失败在已有进度输出或协议 sentinel 的情况下，可能被 fallback suppression 吞掉，用户侧只能看到任务停止，无法看到失败原因。

## 改动

- 仅允许结构化 `failed` turn 绕过基于已发送 marker 的 suppression。
- 保留纯 sentinel、本地 turn、shared adopt 等现有门禁。
- 组合失败消息前清理协议 sentinel；已有安全进度 marker 时仅发送失败诊断，避免重复正文。
- 补充 failed、普通 final、empty completed、本地 turn、shared adopt 和去重场景测试。

## 影响面

改动位于 bridge fallback 公共路径，但仅改变带结构化 `turn_terminal.status=failed` 的失败兜底。普通成功回答、刻意静默、本地 turn、shared adopt 及已有回答去重语义保持不变。未修改运行中实例，也未触发发布。

## 验证

- `bun run test -- ...`：相关 7 个测试文件 326 项全部通过。
- 扩展回归：409 项全部通过。
- `bun run build` 通过。
- `git diff --check` 通过。