### PR TITLE
fix(sandbox): 用内核判据阻止 Linux 隔离身份降级

### DIFF
--- a/docs/file-sandbox.md
+++ b/docs/file-sandbox.md
@@ -89,6 +89,32 @@ worker spawnCli
 
 → **所有飞书密钥全程不进沙盒**。
 
+### Linux 隔离判据
+
+环境变量只是路由提示，不是安全边界。完整 bwrap 和仅凭据隔离 bwrap 在启动 CLI
+前都会安装一个很窄的 seccomp 规则：拒绝 `getpriority(PRIO_PROCESS, 1)`，其它
+已支持 ABI 的系统调用保持原策略。内核会把规则传给 fork / exec 的后代；清空环境、
+替换 HOME / 数据目录或再创建 namespace 都不能移除它。
+
+CLI 通过 `os.getPriority(1)` 查询这个判据，只把成功且位于合法 nice 范围
+`[-20, 19]` 的结果视为普通宿主。不能只匹配 EPERM：后代可以叠加 seccomp 规则
+替换 errno，但不能恢复真实调用；即使伪造 errno 0，libc 返回的 nice 20 仍会被拒绝。
+规则通过匿名管道传给 bwrap，不落可修改的配置文件，也不占用交互终端的 stdin。
+
+确认处于隔离中的 `send` 不能因缺失 capability 或伪造进程标记降级为宿主直发；
+daemon 不可达时，`delete` 等命令也不能退回离线写会话库。正常宿主 relay 不安装此
+规则，普通宿主命令不依赖 HOME 中是否存在探针文件。
+
+兼容边界：支持 Linux x64 / arm64 及其 i386 / ARM EABI / x32 调用约定；未知 ABI
+或无法安装 seccomp 时拒绝启动，不静默关闭保护。查询 PID 1 的 nice 值会被拒绝，
+查询当前进程优先级、调整优先级不受此规则影响。如果外层容器策略本来就禁止这个
+查询，宿主命令也会按隔离处理，需要先核对外层策略，不能靠环境变量绕过。
+隔离 pane 标记版本升至 15，旧 pane 必须冷启动一次才能获得新规则。
+
+这是受信 CLI 的隔离分类防线，不代替文件和凭据隔离，也不承诺阻止修改 CLI 代码、
+持有真实凭据后自行调用 API 或内核逃逸。规则继承与叠加语义见
+[Linux seccomp 文档](https://docs.kernel.org/userspace-api/seccomp_filter.html)。
+
 ## no-transport 会话（apiOnly / HTTP virtual）跟随本地配置
 
 no-transport 会话（core-only `apiOnly` bot、或 `http_async_*`/`http_wait_*` HTTP virtual 会话）**不被自动强制文件隔离**。它们的磁盘可读写范围和普通聊天会话一样，只由 bot 自己的 `sandbox`/`readIsolation` 配置决定：没配 → 不隔离（以同一 OS 用户身份对宿主文件有完整**读写**权，能读宿主 `bots.json`、也能改写宿主配置）；配了 → 照常隔离。

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -27,6 +27,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { compileToBwrap, type FsPolicy } from '../cli/fs-policy.js';
 import { CA_BUNDLE_ENV_KEYS, PROXY_ENV_KEYS } from '../../utils/child-env.js';
 import { isStandaloneBinary } from '../../core/self-spawn.js';
+import { linuxIsolationLaunch } from '../../core/linux-isolation.js';
 import {
   MCP_GATEWAY_REQUIRED_ENV,
   MCP_GATEWAY_SOCKET_ENV,
@@ -159,7 +160,7 @@ function probeBubblewrapCredentialMasks(): HostCredentialIsolationMechanismProbe
   if (probe.status !== 0) {
     return { supported: false, mechanism: null, reason: 'bubblewrap is unavailable' };
   }
-  const runtime = spawnSync(executable, [
+  const launch = linuxIsolationLaunch(executable, [
     '--bind', '/', '/',
     '--proc', '/proc',
     '--tmpfs', '/tmp',
@@ -171,7 +172,8 @@ function probeBubblewrapCredentialMasks(): HostCredentialIsolationMechanismProbe
     '--die-with-parent',
     '--new-session',
     '--', '/bin/true',
-  ], { stdio: 'ignore', timeout: 5_000 });
+  ]);
+  const runtime = spawnSync(launch.bin, launch.args, { stdio: 'ignore', timeout: 5_000 });
   if (runtime.status === 0) return { supported: true, mechanism: 'bwrap', executable };
   return {
     supported: false,
@@ -221,10 +223,7 @@ export function prepareCredentialOnlySandbox(input: {
   if (process.platform !== 'linux' || !ensureSandboxDeps()) return null;
   const probe = probeBubblewrapCredentialMasks();
   if (!probe.supported || probe.mechanism !== 'bwrap') return null;
-  return {
-    bin: probe.executable,
-    args: buildCredentialOnlySandboxArgs(input),
-  };
+  return linuxIsolationLaunch(probe.executable, buildCredentialOnlySandboxArgs(input));
 }
 
 /** Re-expose trusted executable directories hidden below the fresh /run tmpfs. */
@@ -631,9 +630,9 @@ export const __testOnly_maskMounts = {
 };
 
 export interface DirectSandboxSpawn {
-  /** Replace the CLI binary with this (always 'bwrap'). */
+  /** Replace the CLI binary with this (the bwrap isolation launcher). */
   bin: string;
-  /** bwrap args + '--' + original (bin, ...args). */
+  /** Isolation launcher + bwrap args + '--' + original (bin, ...args). */
   args: string[];
   /** Env overrides to merge into childEnv (HOME, PATH, BOTMUX_SEND_RELAY, proxies). */
   env: Record<string, string>;
@@ -680,6 +679,9 @@ export function prepareDirectSandbox(opts: {
 }): DirectSandboxSpawn | null {
   if (process.platform !== 'linux') return null;
   if (!ensureSandboxDeps()) return null;
+
+  // Validate marker support before creating any session files or deny masks.
+  const launch = linuxIsolationLaunch('bwrap', []);
 
   const dataDir = canonical(opts.dataDir);
   const sessionRoot = join(dataDir, 'sandboxes', opts.sessionId);
@@ -892,8 +894,8 @@ export function prepareDirectSandbox(opts: {
   args.push('--', execBin, ...opts.cliArgs);
 
   return {
-    bin: 'bwrap',
-    args,
+    bin: launch.bin,
+    args: [...launch.args, ...args],
     env,
     outbox,
     cleanup: () => {

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -363,7 +363,9 @@ export function buildSeatbeltProfile(
 // would keep failing TLS on UnknownIssuer with no output at all.
 // 14 pins canonical SESSION_DATA_DIR and matching managed-origin mounts on
 // Linux. Warm reattach would retain the old lexical env/mount namespace split.
-export const ISOLATION_PANE_MARKER_VERSION = 14;
+// 15 adds an inherited Linux seccomp isolation probe. Existing processes cannot
+// acquire it on warm reattach and must cold-spawn under the new contract.
+export const ISOLATION_PANE_MARKER_VERSION = 15;
 
 export type IsolationCapability = 'credential' | 'read' | 'write';
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -217,6 +217,7 @@ import { fetchDaemonIpc, loadDaemonIpcSecret } from './core/daemon-ipc-auth.js';
 import { REPORT_SESSION_RELAY_ROUTE } from './core/report-session-relay.js';
 import { DISPATCH_REPORT_REGISTER_ROUTE } from './core/dispatch-report-binding.js';
 import { isRetryableAskHttpStatus } from './core/ask-types.js';
+import { linuxIsolationDetected } from './core/linux-isolation.js';
 import {
   hasManagedOriginIsolationMarker,
   isIsolatedCliProcess,
@@ -8152,8 +8153,9 @@ async function cmdSend(rest: string[]): Promise<void> {
   const replyLayoutRequest = parseReplyLayoutRequest(rest);
   if (replyLayoutRequest.warning) console.error(replyLayoutRequest.warning);
   let replyLayout = replyLayoutRequest.layout;
-  // Resolve isolation marker-first. A visible host marker always wins over a
-  // leftover capability. Linux bwrap keeps its host-execution outbox; macOS
+  // A kernel isolation stamp wins over process markers in a child-selected
+  // data root. Otherwise a visible host marker wins over a leftover capability.
+  // Linux bwrap keeps its host-execution outbox; macOS
   // read isolation instead challenges the owning daemon and trusts only the
   // matching host-written read-only proof sidecar. The capability file itself
   // may survive worker SIGKILL and is never direct-send authority.
@@ -8185,7 +8187,9 @@ async function cmdSend(rest: string[]): Promise<void> {
     console.error('botmux send refused: OS account home unavailable for isolation classification');
     process.exit(2);
   }
-  const kernelReadIsolationDetected = managedOriginLegacyIsolationProbeAccess(osUserHomeDir)
+  const linuxKernelIsolationDetected = linuxIsolationDetected();
+  const kernelReadIsolationDetected = linuxKernelIsolationDetected
+    || managedOriginLegacyIsolationProbeAccess(osUserHomeDir)
     === 'sandbox_denied'
     || managedOriginIsolationSentinelAccess(osUserHomeDir) === 'sandbox_denied';
   const isolatedSendRequired = !relayDir
@@ -8228,7 +8232,7 @@ async function cmdSend(rest: string[]): Promise<void> {
     process.env.SESSION_DATA_DIR = sendDataDir;
     liveMarkerCtx = findLiveAncestorSessionContext(sendDataDir);
   }
-  const isolatedCapabilityCtx = !isolatedSendRequired && liveMarkerCtx?.sessionId
+  const isolatedCapabilityCtx = !isolatedSendRequired && !linuxKernelIsolationDetected && liveMarkerCtx?.sessionId
     ? null
     : readWorkflowSessionRelayContext({
         env: process.env,
@@ -8236,7 +8240,7 @@ async function cmdSend(rest: string[]): Promise<void> {
         // Keep one marker snapshot for the whole decision. In particular, do
         // not let resolveSessionContext's protected-capability fallback get
         // mislabeled as a live process marker.
-        findMarker: () => isolatedSendRequired ? null : liveMarkerCtx,
+        findMarker: () => isolatedSendRequired || linuxKernelIsolationDetected ? null : liveMarkerCtx,
       });
   if (isolatedSendRequired
     && (isolatedCapabilityCtx?.sessionId !== isolatedBoundSessionId
@@ -8272,7 +8276,7 @@ async function cmdSend(rest: string[]): Promise<void> {
     await relaySend(rest, relayDir, replyLayout);
     return;
   }
-  if (relayDir && !liveMarkerCtx?.sessionId) {
+  if (relayDir && (linuxKernelIsolationDetected || !liveMarkerCtx?.sessionId)) {
     // The child may delete or replace its writable outbox capability, while
     // the immutable default snapshot remains visible. That snapshot is only a
     // routing hint and can survive worker death; never fall through to direct

--- a/src/core/linux-isolation.ts
+++ b/src/core/linux-isolation.ts
@@ -89,3 +89,18 @@ export function linuxIsolationLaunch(bin: string, args: string[]): { bin: string
     ],
   };
 }
+
+/** Lifecycle hint only, never isolation authority. The pipe adapter remains
+ * as a noninteractive shell while bwrap runs. Its fixed script never evaluates
+ * terminal input, so the worker must not mistake it for a failed interactive
+ * launch. Match the entire script, not just a forgeable argv[0] label; an rcfile
+ * trampoline or an unrelated shell must still hit the bare-shell input guard.
+ */
+export function isLinuxIsolationLauncher(commandLine: readonly string[]): boolean {
+  const launch = linuxIsolationLaunch('bwrap', []);
+  return commandLine[0] === launch.bin
+    && launch.args.slice(0, 3).every((arg, index) => commandLine[index + 1] === arg)
+    && !!commandLine[4]
+    && commandLine[5] === '--seccomp'
+    && commandLine[6] === '3';
+}

--- a/src/core/linux-isolation.ts
+++ b/src/core/linux-isolation.ts
@@ -1,0 +1,91 @@
+import { getPriority } from 'node:os';
+
+/**
+ * A Linux isolation stamp that survives env -i, exec and nested namespaces.
+ * Reserve getpriority(PRIO_PROCESS, 1) as a read-only kernel probe: bwrap's
+ * inherited seccomp filter denies only this query, not priority changes or
+ * queries for the current process. PID 1 exists in every live PID namespace.
+ *
+ * Do NOT match a particular errno. A child can stack another RET_ERRNO filter
+ * and replace EPERM with ESRCH or even errno 0. Linux returns raw priorities
+ * in [1, 40]; libc maps raw 0 to nice 20, outside the valid [-20, 19] range.
+ * Only a successful, in-range answer establishes the ordinary host path.
+ * Additional seccomp filters cannot turn our denial into a real syscall.
+ *
+ * This is a trusted-CLI confused-deputy guard, not a replacement for the
+ * filesystem/credential boundary or protection against modified CLI code.
+ * A host policy that independently denies this query also fails closed.
+ */
+export function linuxIsolationDetected(): boolean {
+  if (process.platform !== 'linux') return false;
+  try {
+    const priority = getPriority(1);
+    return !Number.isInteger(priority) || priority < -20 || priority > 19;
+  } catch {
+    return true;
+  }
+}
+
+/** Classic BPF, using Linux's seccomp_data offsets and audit architecture IDs.
+ * Cover both native and compat ABIs on the supported little-endian hosts.
+ * Unknown ABIs fail closed instead of interpreting a foreign syscall number.
+ */
+function isolationFilter(): Buffer {
+  if (!['x64', 'arm64', 'ia32', 'arm'].includes(process.arch)) {
+    throw new Error(`Linux isolation marker unsupported on ${process.arch}`);
+  }
+  const LD = 0x20; // BPF_LD | BPF_W | BPF_ABS
+  const JEQ = 0x15; // BPF_JMP | BPF_JEQ | BPF_K
+  const RET = 0x06; // BPF_RET | BPF_K
+  const ALLOW = 0x7fff0000;
+  const instructions: Array<[number, number, number, number]> = [[LD, 0, 0, 4]];
+  const probeJumps: number[] = [];
+  for (const [arch, syscall, x32] of [
+    [0xc000003e, 140, true], // x86-64 / x32
+    [0xc00000b7, 141, false], // AArch64
+    [0x40000003, 96, false], // i386
+    [0x40000028, 96, false], // ARM EABI
+  ] as const) {
+    instructions.push([JEQ, 0, x32 ? 4 : 3, arch], [LD, 0, 0, 0]);
+    if (x32) instructions.push([0x54, 0, 0, 0xbfffffff]); // clear __X32_SYSCALL_BIT
+    probeJumps.push(instructions.length);
+    instructions.push([JEQ, 0, 0, syscall], [RET, 0, 0, ALLOW]);
+  }
+  instructions.push([RET, 0, 0, 0x80000000]); // SECCOMP_RET_KILL_PROCESS
+  for (const index of probeJumps) instructions[index]![1] = instructions.length - index - 1;
+  // The kernel takes int / id_t arguments: compare the low 32 bits, including
+  // compat calls and calls with arbitrary unused upper argument bits.
+  instructions.push(
+    [LD, 0, 0, 16], [JEQ, 0, 3, 0], // which == PRIO_PROCESS
+    [LD, 0, 0, 24], [JEQ, 0, 1, 1], // who == 1
+    [RET, 0, 0, 0x00050001], // SECCOMP_RET_ERRNO | EPERM
+    [RET, 0, 0, ALLOW],
+  );
+  const bytes = Buffer.alloc(instructions.length * 8);
+  instructions.forEach(([code, jt, jf, k], index) => {
+    const offset = index * 8;
+    bytes.writeUInt16LE(code, offset);
+    bytes[offset + 2] = jt;
+    bytes[offset + 3] = jf;
+    bytes.writeUInt32LE(k, offset + 4);
+  });
+  return bytes;
+}
+
+/** Feed bwrap a private anonymous filter pipe without consuming PTY stdin.
+ * No mutable profile file, inherited descriptor requirement, native addon or
+ * installed helper is needed (including in the standalone binary). The tiny
+ * POSIX shell adapter works with both PTY and persistent terminal backends.
+ * bwrap must install the filter before exec; failure never runs the CLI bare.
+ */
+export function linuxIsolationLaunch(bin: string, args: string[]): { bin: string; args: string[] } {
+  const octal = [...isolationFilter()].map(byte => `\\${byte.toString(8).padStart(3, '0')}`).join('');
+  return {
+    bin: '/bin/sh',
+    args: [
+      '-c',
+      `exec 4<&0 || exit; printf '${octal}' | { exec "$@" 3<&0 0<&4 4<&-; }`,
+      'botmux-isolation', bin, '--seccomp', '3', ...args,
+    ],
+  };
+}

--- a/src/core/managed-origin-capability.ts
+++ b/src/core/managed-origin-capability.ts
@@ -5,6 +5,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
+import { linuxIsolationDetected } from './linux-isolation.js';
 
 export const RELAY_ORIGIN_CAPABILITY_BASENAME = '.botmux-origin-capability.json';
 export const MANAGED_ORIGIN_ISOLATION_MARKER_BASENAME = '.botmux-read-isolated-v1';
@@ -354,7 +355,8 @@ export function managedOriginLegacyIsolationProbeAccess(
  * therefore cannot act as a session store host (it may only SEND commands to
  * the owning daemon). Positive signals only: the sandbox outbox marker, the
  * host-stamped read-isolation env, the host-stamped origin channel, or a
- * kernel denial (EACCES/EPERM) on a probe inode. `missing_or_unsafe` — an
+ * kernel denial on a probe inode or the inherited Linux seccomp probe.
+ * `missing_or_unsafe` — an
  * absent `~/.botmux`, a secret never created because no daemon ran here, a
  * foreign HOME — is NEVER isolation: a genuine host shell must keep its
  * offline close / abandon / prune.
@@ -380,7 +382,8 @@ export function isIsolatedCliProcess(
   if (env.BOTMUX_SEND_RELAY) return true;
   if (env.BOTMUX_READ_ISOLATED === '1') return true;
   if (env.BOTMUX_ORIGIN_CHANNEL_ID?.trim()) return true;
-  return managedOriginLegacyIsolationProbeAccess(osUserHomeDir) === 'sandbox_denied'
+  return linuxIsolationDetected()
+    || managedOriginLegacyIsolationProbeAccess(osUserHomeDir) === 'sandbox_denied'
     || managedOriginIsolationSentinelAccess(osUserHomeDir) === 'sandbox_denied';
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2071,35 +2071,6 @@ let viewToken = randomBytes(32).toString('base64url');
 const DASHBOARD_TOKEN_PATH = join(homedir(), '.botmux', '.dashboard-token');
 const DASHBOARD_SECRET_PATH = join(homedir(), '.botmux', '.dashboard-secret');
 
-// Test-only seam (inert in production): widen the SYNCHRONOUS `.dashboard-secret`
-// read that happens twice inside the terminal WS handshake — once at
-// `verifyClient`, once at the post-upgrade `connection` re-check — so the
-// integration test can land a capability's expiry inside that gap and prove the
-// second check still fail-closes it (see worker-terminal-read-auth P1-3). A real
-// slow HOME (NFS/slow disk) produces the same window in production. The old test
-// bloated the secret file with 32MB of whitespace to force this delay, which is
-// incompatible with #920's strict 0600 host-authority reader (its 256-byte cap
-// rejects a padded file); this env-gated busy-wait reproduces the timing without
-// an oversized or otherwise unsafe credential file. Only ever set by that test.
-const HANDSHAKE_SECRET_READ_DELAY_MS = Number.isFinite(
-  Number(process.env.BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS),
-)
-  ? Math.max(0, Number(process.env.BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS))
-  : 0;
-
-/** Read the dashboard secret on the terminal WS-handshake path. Identical to
- *  {@link loadDashboardSecret} in production; adds a bounded synchronous delay
- *  ONLY when the test seam env var is set, to make the handshake read window
- *  observable without an oversized secret file. */
-function loadHandshakeSecret(): string | null {
-  const secret = loadDashboardSecret(DASHBOARD_SECRET_PATH);
-  if (HANDSHAKE_SECRET_READ_DELAY_MS > 0) {
-    const until = Date.now() + HANDSHAKE_SECRET_READ_DELAY_MS;
-    while (Date.now() < until) { /* busy-wait: mimic a slow synchronous fs read */ }
-  }
-  return secret;
-}
-
 /** Re-derive the stable write (operate) token from the host-only dashboard
  *  secret so a restarted worker mints the SAME token — keeping already-issued
  *  「操作链接」/write links valid across restarts. Falls back to the random
@@ -2182,7 +2153,7 @@ function resolveTerminalAccessForReq(req: IncomingMessage, url: URL): WorkerTerm
   let viewGrantUser: string | undefined;
   let viewGrantExpiresAt: number | undefined;
   if (!viewTokenMatches && looksLikeTerminalControlGrant(viewParam) && sessionId) {
-    const secret = loadHandshakeSecret();
+    const secret = loadDashboardSecret(DASHBOARD_SECRET_PATH);
     if (secret && verifyTerminalViewForward(secret, viewParam, req.headers[TERMINAL_VIEW_FORWARD_HEADER])) {
       const viewGrant = verifyTerminalControlGrant(secret, viewParam, sessionId);
       if (viewGrant.ok
@@ -2210,7 +2181,7 @@ function resolveTerminalAccessForReq(req: IncomingMessage, url: URL): WorkerTerm
   // second synchronous secret-file read on that hot path; only the central
   // front proxy supplies this internal header.
   if (req.headers['x-botmux-terminal-control'] === undefined) return legacy;
-  const secret = loadHandshakeSecret();
+  const secret = loadDashboardSecret(DASHBOARD_SECRET_PATH);
   if (!secret || !sessionId) return legacy;
   const grant = verifyTerminalControlGrant(
     secret,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -438,6 +438,7 @@ import {
   replaceManagedOriginCapabilityFile,
   sweepManagedOriginAttestationProofs,
 } from './core/managed-origin-capability.js';
+import { isLinuxIsolationLauncher } from './core/linux-isolation.js';
 import {
   CodexRpcEngine,
   type CodexRpcTurnIdentity,
@@ -10426,7 +10427,15 @@ function releaseRawInputRestartGate(): void {
 
 function readPaneLeafComm(observedBackend: SessionBackend | null = backend): string | undefined {
   const pid = observedBackend?.getChildPid?.();
-  return pid ? readComm(pid) : undefined;
+  if (!pid) return undefined;
+  const comm = readComm(pid);
+  if (lastSpawnOuterBwrapActive && process.platform === 'linux' && isBareShellComm(comm)) {
+    try {
+      const commandLine = readFileSync(`/proc/${pid}/cmdline`, 'utf8').split('\0');
+      if (isLinuxIsolationLauncher(commandLine)) return 'bwrap';
+    } catch { /* Unverified shells retain the normal input hold. */ }
+  }
+  return comm;
 }
 
 /** A slow rcfile can outlive the launch detector's settle window, then finish

--- a/test/fixtures/worker-terminal-recheck-clock.ts
+++ b/test/fixtures/worker-terminal-recheck-clock.ts
@@ -1,0 +1,24 @@
+import type { IncomingMessage } from 'node:http';
+import { WebSocketServer } from 'ws';
+
+// Test entry point only. Keep the real handshake, signature checks and worker
+// connection handler; advance time only while the post-upgrade handler runs.
+// Unlike estimating a TTL from HTTP latency, this always crosses the intended
+// boundary, regardless of CI load. Unmarked requests retain the real clock.
+const emit = WebSocketServer.prototype.emit;
+WebSocketServer.prototype.emit = function (event: string | symbol, ...args: unknown[]): boolean {
+  const req = event === 'connection' ? args[1] as IncomingMessage : undefined;
+  const rawNow = req?.headers['x-botmux-test-recheck-now'];
+  if (typeof rawNow !== 'string') return Reflect.apply(emit, this, [event, ...args]);
+  const now = Number(rawNow);
+  if (!Number.isSafeInteger(now)) throw new Error('Invalid re-check clock');
+  const realNow = Date.now;
+  Date.now = () => now;
+  try {
+    return Reflect.apply(emit, this, [event, ...args]);
+  } finally {
+    Date.now = realNow;
+  }
+};
+
+await import('../../src/worker.js');

--- a/test/linux-isolation.test.ts
+++ b/test/linux-isolation.test.ts
@@ -1,0 +1,200 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { linuxIsolationDetected, linuxIsolationLaunch } from '../src/core/linux-isolation.js';
+import { prepareCredentialOnlySandbox } from '../src/adapters/backend/sandbox.js';
+import { tsEvalArgs, tsRunnerPrefix } from './helpers/ts-runner.js';
+import { readPersistedSessionRows, seedPersistedSessionRows } from './helpers/session-store-disk.js';
+
+const supported = ['x64', 'arm64', 'ia32', 'arm'].includes(process.arch);
+const linux = process.platform === 'linux';
+const canRunBwrap = linux && spawnSync('bwrap', [
+  '--ro-bind', '/', '/', '--unshare-user', '--unshare-pid', '--proc', '/proc',
+  '--', '/bin/true',
+], { stdio: 'ignore', timeout: 5_000 }).status === 0;
+const repoRoot = realpathSync(fileURLToPath(new URL('..', import.meta.url)));
+const bwrapArgs = ['--ro-bind', '/', '/', '--unshare-user', '--unshare-pid',
+  '--unshare-net', '--proc', '/proc', '--dev', '/dev', '--'];
+
+type Launch = ReturnType<typeof linuxIsolationLaunch>;
+
+// Inspect the exact bytes supplied to bwrap, not a second filter generator.
+function filterBytes(launch: Launch): Buffer {
+  const encoded = launch.args[1]!.match(/printf '((?:\\[0-7]{3})+)'/)![1]!;
+  return Buffer.from(encoded.match(/\\[0-7]{3}/g)!.map(byte => parseInt(byte.slice(1), 8)));
+}
+
+function replaceFilter(launch: Launch, bytes: Buffer): Launch {
+  const octal = [...bytes].map(byte => `\\${byte.toString(8).padStart(3, '0')}`).join('');
+  const args = [...launch.args];
+  args[1] = args[1]!.replace(/printf '(?:\\[0-7]{3})+'/, () => `printf '${octal}'`);
+  return { bin: launch.bin, args };
+}
+
+function evaluate(bytes: Buffer, arch: number, nr: number, which = 0, who = 1): number {
+  const data = Buffer.alloc(64);
+  data.writeUInt32LE(nr >>> 0, 0);
+  data.writeUInt32LE(arch, 4);
+  data.writeUInt32LE(which >>> 0, 16);
+  data.writeUInt32LE(who >>> 0, 24);
+  // Linux ignores these upper argument bits even in the 64-bit ABI.
+  data.writeUInt32LE(0xffffffff, 20);
+  data.writeUInt32LE(0xffffffff, 28);
+  let accumulator = 0;
+  for (let pc = 0; pc < bytes.length / 8; pc++) {
+    const offset = pc * 8;
+    const code = bytes.readUInt16LE(offset);
+    const k = bytes.readUInt32LE(offset + 4);
+    if (code === 0x20) accumulator = data.readUInt32LE(k);
+    else if (code === 0x54) accumulator = (accumulator & k) >>> 0;
+    else if (code === 0x15) pc += bytes[offset + (accumulator === k ? 2 : 3)]!;
+    else if (code === 0x06) return k;
+    else throw new Error(`unexpected BPF instruction ${code}`);
+  }
+  throw new Error('filter did not return');
+}
+
+describe.skipIf(!supported)('Linux isolation filter', () => {
+  it.each([
+    [0xc000003e, 140, 0], [0xc000003e, 140, 0x40000000],
+    [0xc00000b7, 141, 0], [0x40000003, 96, 0], [0x40000028, 96, 0],
+  ])('denies only the probe in ABI %s (syscall %s, bit %s)', (arch, syscall, bit) => {
+    const bytes = filterBytes(linuxIsolationLaunch('bwrap', []));
+    for (let nr = 0; nr < 600; nr++) {
+      expect(evaluate(bytes, arch!, nr | bit!)).toBe(nr === syscall ? 0x00050001 : 0x7fff0000);
+    }
+    for (const [which, who] of [[0, 0], [0, 2], [0, -1], [1, 1], [2, 1]]) {
+      expect(evaluate(bytes, arch!, syscall! | bit!, which, who)).toBe(0x7fff0000);
+    }
+  });
+
+  it('fails closed for unknown or opposite-endian ABIs', () => {
+    const bytes = filterBytes(linuxIsolationLaunch('bwrap', []));
+    for (const arch of [0, 0x800000b7, 0xdeadbeef]) {
+      expect(evaluate(bytes, arch, 141)).toBe(0x80000000);
+    }
+  });
+});
+
+describe.skipIf(!canRunBwrap || !supported)('Linux isolation kernel probe', () => {
+  const snippet = tsEvalArgs(`
+    import { getPriority } from 'node:os';
+    import { readFileSync } from 'node:fs';
+    import { linuxIsolationDetected } from './src/core/linux-isolation.js';
+    import { isIsolatedCliProcess } from './src/core/managed-origin-capability.js';
+    console.log(JSON.stringify({
+      isolated: linuxIsolationDetected(), offline: isIsolatedCliProcess({}, ''),
+      ownPriority: getPriority(), input: readFileSync(0, 'utf8'),
+    }));
+  `);
+  const { command, prefixArgs } = tsRunnerPrefix();
+  const cli = [command, ...prefixArgs, ...snippet.args];
+  const cleanCli = ['/usr/bin/env', '-i', ...cli];
+
+  function run(launch: Launch) {
+    const result = spawnSync(launch.bin, launch.args, {
+      cwd: repoRoot, encoding: 'utf8', input: 'interactive stdin', timeout: 15_000,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    return JSON.parse(result.stdout);
+  }
+
+  it('keeps an ordinary host unmarked, including a bare HOME', () => {
+    expect(linuxIsolationDetected()).toBe(false);
+    expect(run({ bin: cleanCli[0]!, args: cleanCli.slice(1) })).toMatchObject({
+      isolated: false, offline: false, input: 'interactive stdin',
+    });
+  });
+
+  it('survives a cleared environment and preserves stdin/current priority', () => {
+    expect(run(linuxIsolationLaunch('bwrap', [...bwrapArgs, ...cleanCli]))).toEqual({
+      isolated: true, offline: true, input: 'interactive stdin', ownPriority: expect.any(Number),
+    });
+  }, 20_000);
+
+  it('survives another user/PID/mount namespace with no environment markers', () => {
+    expect(run(linuxIsolationLaunch('bwrap', [
+      ...bwrapArgs, 'bwrap', ...bwrapArgs, ...cleanCli,
+    ]))).toMatchObject({ isolated: true, offline: true });
+  });
+
+  it.each([0, 3, 38])('does not trust an overlaid seccomp errno %s', errno => {
+    const inner = linuxIsolationLaunch('bwrap', [...bwrapArgs, ...cleanCli]);
+    const bytes = filterBytes(inner);
+    let replaced = 0;
+    for (let offset = 0; offset < bytes.length; offset += 8) {
+      if (bytes.readUInt16LE(offset) === 0x06 && bytes.readUInt32LE(offset + 4) === 0x00050001) {
+        bytes.writeUInt32LE(0x00050000 | errno, offset + 4);
+        replaced++;
+      }
+    }
+    expect(replaced).toBe(1);
+    const stacked = replaceFilter(inner, bytes);
+    expect(run(linuxIsolationLaunch('bwrap', [
+      ...bwrapArgs, stacked.bin, ...stacked.args,
+    ]))).toMatchObject({ isolated: true, offline: true });
+  });
+
+  it('never executes the CLI if bwrap cannot install the filter', () => {
+    const launch = replaceFilter(linuxIsolationLaunch('bwrap', [
+      ...bwrapArgs, '/bin/sh', '-c', 'printf should-not-run',
+    ]), Buffer.from([0]));
+    const result = spawnSync(launch.bin, launch.args, { encoding: 'utf8', timeout: 5_000 });
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).not.toContain('should-not-run');
+    expect(result.stderr).toContain('seccomp');
+  });
+
+  it('marks credential-only bwrap as isolated even after all BOTMUX env is removed', () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'botmux-kernel-marker-')));
+    const hidden = join(root, 'authority');
+    mkdirSync(hidden);
+    try {
+      const launch = prepareCredentialOnlySandbox({
+        hideDirectories: [hidden], hideFiles: [], workingDir: repoRoot,
+        cliBin: cleanCli[0]!, cliArgs: cleanCli.slice(1),
+      });
+      expect(launch).not.toBeNull();
+      // A private /dev makes the runtime fixture independent of the host's
+      // container device mounts (Bun can abort on those even without seccomp).
+      launch!.args.splice(launch!.args.indexOf('--'), 0, '--dev', '/dev');
+      expect(run(launch!)).toMatchObject({ isolated: true, offline: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses offline session mutation in credential-only mode with a writable store', () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'botmux-kernel-offline-')));
+    const hidden = join(root, 'authority');
+    const dataDir = join(root, 'data');
+    mkdirSync(hidden);
+    mkdirSync(dataDir);
+    const row = { sessionId: 'session', chatId: 'oc_test', rootMessageId: 'om_test',
+      title: 'fixture', status: 'active', createdAt: new Date(0).toISOString(), larkAppId: 'app-test' };
+    seedPersistedSessionRows(dataDir, 'app-test', { session: row });
+    try {
+      const launch = prepareCredentialOnlySandbox({
+        hideDirectories: [hidden], hideFiles: [], workingDir: repoRoot,
+        cliBin: '/usr/bin/env', cliArgs: ['-i', `HOME=${root}`, `SESSION_DATA_DIR=${dataDir}`,
+          `BOTS_CONFIG=${join(root, 'bots.json')}`, command, ...prefixArgs,
+          join(repoRoot, 'src/cli.ts'), 'delete', 'session'],
+      });
+      expect(launch).not.toBeNull();
+      launch!.args.splice(launch!.args.indexOf('--'), 0, '--dev', '/dev', '--unshare-net');
+      const result = spawnSync(launch!.bin, launch!.args, {
+        cwd: repoRoot, encoding: 'utf8', timeout: 15_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain('隔离会话内不能离线修改会话');
+      expect(readPersistedSessionRows(dataDir, 'app-test').session).toEqual(row);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 20_000);
+});

--- a/test/linux-isolation.test.ts
+++ b/test/linux-isolation.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { linuxIsolationDetected, linuxIsolationLaunch } from '../src/core/linux-isolation.js';
+import { isLinuxIsolationLauncher, linuxIsolationDetected, linuxIsolationLaunch } from '../src/core/linux-isolation.js';
 import { prepareCredentialOnlySandbox } from '../src/adapters/backend/sandbox.js';
 import { tsEvalArgs, tsRunnerPrefix } from './helpers/ts-runner.js';
 import { readPersistedSessionRows, seedPersistedSessionRows } from './helpers/session-store-disk.js';
@@ -58,6 +58,20 @@ function evaluate(bytes: Buffer, arch: number, nr: number, which = 0, who = 1): 
 }
 
 describe.skipIf(!supported)('Linux isolation filter', () => {
+  it('recognizes only the fixed noninteractive launcher, never a bare shell or copied label', () => {
+    const launch = linuxIsolationLaunch('/usr/bin/bwrap', ['--', '/bin/true']);
+    const commandLine = [launch.bin, ...launch.args];
+    expect(isLinuxIsolationLauncher(commandLine)).toBe(true);
+    expect(isLinuxIsolationLauncher(['/bin/sh', '-i'])).toBe(false);
+    expect(isLinuxIsolationLauncher(['/bin/sh', '-c', 'exec /bin/sh -i', 'botmux-isolation'])).toBe(false);
+    const replacedScript = [...commandLine];
+    replacedScript[2] = 'read input; eval "$input"';
+    expect(isLinuxIsolationLauncher(replacedScript)).toBe(false);
+    const missingFilter = [...commandLine];
+    missingFilter[5] = '--ro-bind';
+    expect(isLinuxIsolationLauncher(missingFilter)).toBe(false);
+  });
+
   it.each([
     [0xc000003e, 140, 0], [0xc000003e, 140, 0x40000000],
     [0xc00000b7, 141, 0], [0x40000003, 96, 0], [0x40000028, 96, 0],

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -922,6 +922,16 @@ describe('isolatedPaneReattachSafe — start-time contract bump forces cold resp
     }), ['credential', 'read', 'write'])).toBe(false);
   });
 
+  it('cold-spawns v14 panes that lack the Linux kernel isolation stamp', () => {
+    expect(ISOLATION_PANE_MARKER_VERSION).toBeGreaterThan(14);
+    expect(isolatedPaneReattachSafe(JSON.stringify({
+      version: 14,
+      bootId: 'before-kernel-marker',
+      state: 'committed',
+      capabilities: ['credential', 'read', 'write'],
+    }), ['credential', 'read', 'write'])).toBe(false);
+  });
+
   it('has moved the version past 12 — the release before the sandboxed-Codex CA env contract', () => {
     // A pane spawned before this change keeps its ORIGINAL process environment, so
     // it would never see the host CA bundle (SSL_CERT_FILE) and its Codex would keep

--- a/test/sandbox-session-data-dir.test.ts
+++ b/test/sandbox-session-data-dir.test.ts
@@ -8,7 +8,7 @@ import { prepareDirectSandbox } from '../src/adapters/backend/sandbox.js';
 import type { FsPolicy } from '../src/adapters/cli/fs-policy.js';
 import { seedPersistedSessionRows } from './helpers/session-store-disk.js';
 import { tsRunnerPrefix } from './helpers/ts-runner.js';
-import { ensureManagedOriginAttestationDirectory } from '../src/core/managed-origin-capability.js';
+import { ensureManagedOriginAttestationDirectory, RELAY_ORIGIN_CAPABILITY_BASENAME } from '../src/core/managed-origin-capability.js';
 
 const linux = process.platform === 'linux';
 const hasBwrap = linux && spawnSync('bwrap', ['--version']).status === 0;
@@ -219,7 +219,9 @@ describe.skipIf(!hasBwrap)('sandbox session-data root', () => {
         'send', 'must not send', '--session-id', 'session', '--no-mention'],
       });
       expect(plan).not.toBeNull();
-      const result = spawnSync(plan!.bin, ['--uid', '0', '--gid', '0', ...plan!.args], {
+      const args = [...plan!.args];
+      args.splice(args.indexOf('--'), 0, '--uid', '0', '--gid', '0');
+      const result = spawnSync(plan!.bin, args, {
         cwd: repoRoot,
         env: {
           ...process.env,
@@ -237,6 +239,108 @@ describe.skipIf(!hasBwrap)('sandbox session-data root', () => {
       expect(result.status, result.stderr).toBe(2);
       expect(result.stderr).toContain('read-isolated owning data-root locator is missing or ambiguous');
       expect(result.stderr).not.toContain('authorized Codex App origin');
+    } finally {
+      cleanup(f, plan);
+    }
+  });
+
+  it.each([0, 65534])('rejects env-cleared direct sends inside a real sandbox (UID %s)', uid => {
+    if (!canRunBwrap) return;
+    const f = fixture('canonical');
+    f.policy.net = false;
+    let plan: ReturnType<typeof prepareDirectSandbox> = null;
+    try {
+      rmSync(join(f.dataDir, 'session-stores/app-a/sessions.db'));
+      seedPersistedSessionRows(f.dataDir, 'app-a', {
+        session: {
+          sessionId: 'session', chatId: 'oc_own', rootMessageId: 'om_own',
+          title: 'fixture', status: 'active', createdAt: new Date(0).toISOString(),
+          larkAppId: 'app-a', cliId: 'codex',
+        },
+      });
+      const { repoRoot, command, prefixArgs } = allowTestRuntime(f.policy);
+      plan = prepareDirectSandbox({
+        sessionId: 'session', dataDir: f.dataDir, policy: f.policy,
+        chdir: repoRoot, home: f.home, cliBin: '/usr/bin/env',
+        cliArgs: ['-i', `HOME=${f.home}`, `SESSION_DATA_DIR=${f.dataDir}`,
+          'BOTMUX_SESSION_ID=session', 'BOTMUX_LARK_APP_ID=app-a',
+          'BOTMUX_HOST_RELAY_AUTHORIZED=1', command, ...prefixArgs,
+          // If classification ever regresses, stop at the later argument
+          // validation gate. No credentials, provider request or network.
+          join(repoRoot, 'src/cli.ts'), 'send', 'fixture', '--video'],
+      });
+      expect(plan).not.toBeNull();
+      const args = [...plan!.args];
+      args.splice(args.indexOf('--'), 0, '--uid', String(uid), '--gid', String(uid));
+      const result = spawnSync(plan!.bin, args, {
+        cwd: repoRoot, encoding: 'utf8', timeout: 15_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(2);
+      expect(result.stderr).toContain('read-isolated pane authority channel is missing or invalid');
+      expect(result.stderr).not.toContain('--video 需要路径参数');
+    } finally {
+      cleanup(f, plan);
+    }
+  });
+
+  it.skipIf(!canRunBwrap)('does not let a forged relay and process marker authorize direct send', () => {
+    const f = fixture('canonical');
+    f.policy.net = false;
+    let plan: ReturnType<typeof prepareDirectSandbox> = null;
+    try {
+      const { repoRoot, command, prefixArgs } = allowTestRuntime(f.policy);
+      const fakeDataDir = join(f.ownBotHome, 'fake-data');
+      plan = prepareDirectSandbox({
+        sessionId: 'session', dataDir: f.dataDir, policy: f.policy,
+        chdir: repoRoot, home: f.home, cliBin: '/usr/bin/env',
+        cliArgs: ['-i', `HOME=${f.home}`, `SESSION_DATA_DIR=${fakeDataDir}`,
+          `BOTMUX_SEND_RELAY=${join(f.ownBotHome, 'fake-relay')}`, 'BOTMUX_SESSION_ID=session',
+          '/bin/sh', '-c', `
+            mkdir -p "$SESSION_DATA_DIR/.botmux-cli-pids"
+            printf session > "$SESSION_DATA_DIR/.botmux-cli-pids/$$"
+            "$@"
+          `, 'marker-fixture', command, ...prefixArgs, join(repoRoot, 'src/cli.ts'),
+          'send', 'fixture', '--video'],
+      });
+      expect(plan).not.toBeNull();
+      const result = spawnSync(plan!.bin, plan!.args, {
+        cwd: repoRoot, encoding: 'utf8', timeout: 15_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(2);
+      expect(result.stderr).toContain('managed host relay capability is stale or missing');
+      expect(result.stderr).not.toContain('--video 需要路径参数');
+    } finally {
+      cleanup(f, plan);
+    }
+  });
+
+  it.skipIf(!canRunBwrap)('keeps a valid sandbox capability on the relay path', () => {
+    const f = fixture('canonical');
+    f.policy.net = false;
+    f.policy.rules.push({ path: join(f.dataDir, 'sandboxes/session/outbox'), access: 'readWrite', source: 'internal' });
+    let plan: ReturnType<typeof prepareDirectSandbox> = null;
+    try {
+      const { repoRoot, command, prefixArgs } = allowTestRuntime(f.policy);
+      plan = prepareDirectSandbox({
+        sessionId: 'session', dataDir: f.dataDir, policy: f.policy,
+        chdir: repoRoot, home: f.home, cliBin: command,
+        // This flag is rejected at the start of relaySend, proving that the
+        // normal relay path was reached without issuing any real request.
+        cliArgs: [...prefixArgs, join(repoRoot, 'src/cli.ts'), 'send', 'fixture', '--top-level'],
+      });
+      expect(plan).not.toBeNull();
+      writeFileSync(join(plan!.outbox, RELAY_ORIGIN_CAPABILITY_BASENAME), JSON.stringify({
+        token: 'ab'.repeat(32), turnId: 'turn', dispatchAttempt: 1,
+      }), { mode: 0o600 });
+      const result = spawnSync(plan!.bin, plan!.args, {
+        cwd: repoRoot, env: { ...process.env, BOTMUX_SESSION_ID: 'session' },
+        encoding: 'utf8', timeout: 15_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(2);
+      expect(result.stderr).toContain('ROUTING_NOT_SUPPORTED');
     } finally {
       cleanup(f, plan);
     }

--- a/test/worker-terminal-read-auth.integration.test.ts
+++ b/test/worker-terminal-read-auth.integration.test.ts
@@ -617,13 +617,9 @@ setInterval(() => {}, 1_000);
   // 解析已经拿不到 controlExpiresAt，于是这条只读连接连到期 timer 都没有——一条永不
   // 过期的窥屏通道，中央前门再怎么撤销也够不着它。
   //
-  // 这条缝的宽度就等于那次同步文件读：本地 SSD 上 ~0.1ms，$HOME 挂在慢盘/NFS 上就是
-  // 几十上百毫秒（backlog P1-10 记的正是这种 HOME）。以前靠把 secret 文件用 32MB 空白
-  // 撑大来复现慢 HOME 的时序，但 #920 给宿主凭证读取加了严格 0600 + 256 字节上限，撑大的
-  // 文件会被直接判「大小异常」拒读——于是改用 worker 侧的测试专用 env
-  // （BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS）在握手路径的那次 secret 读后加一段有界
-  // 忙等：secret 值一个字节没变、凭证文件仍是合法的小文件，只是把这条本来就存在的缝
-  // 稳定拉宽到可观测（生产不设该 env，行为不变）。
+  // 不能用一次 HTTP 往返耗时估计两次校验之间的窗口：连接建立、调度和页面渲染都
+  // 会混进测量，扫描 TTL 可能全部落在窗口之外。测试入口只在真实 connection 回调
+  // 同步执行期间推进 Date.now，精确覆盖到期边界；生产 worker 不包含测试时钟或忙等。
   it('P1-3: a view capability that dies inside the WS handshake is refused at the connection re-check', async () => {
     const root = mkdtempSync(join(tmpdir(), 'botmux-ws-handshake-race-'));
     tempDirs.add(root);
@@ -632,16 +628,12 @@ setInterval(() => {}, 1_000);
     const secret = 'integration-ws-handshake-race-secret';
     const botmuxDir = join(root, '.botmux');
     mkdirSync(botmuxDir, { recursive: true });
-    // 合法的小凭证文件（0600），满足 #920 的严格宿主凭证读取；握手读窗口由下面的
-    // 测试专用 env 拉宽，而不是靠撑大文件。
+    // 合法的小凭证文件（0600），满足 #920 的严格宿主凭证读取。
     writeFileSync(
       join(botmuxDir, '.dashboard-secret'),
       secret,
       { mode: 0o600 },
     );
-    // 握手路径每次读 secret 后忙等这么久，复现慢 HOME 的读窗口（> P1-3 需要的 20ms 下限）。
-    const handshakeReadDelayMs = 40;
-
     // 让 scrollback 非空。socket 一旦被登记，worker 会立刻把这段历史种子推过去，于是
     // 「有没有被登记」在客户端侧是直接可观测的事实，不用去断言 worker 的内部集合。
     const seedMarker = 'BOTMUX_SCROLLBACK_SEED_MARKER';
@@ -656,7 +648,7 @@ setInterval(() => {}, 1_000);
 
     const logs: string[] = [];
     const sessionId = 'ws-handshake-race-session';
-    const child = spawnNodeTsScript(resolve('src/worker.ts'), [], {
+    const child = spawnNodeTsScript(resolve('test/fixtures/worker-terminal-recheck-clock.ts'), [], {
       cwd: resolve('.'),
       env: {
         ...process.env,
@@ -665,7 +657,6 @@ setInterval(() => {}, 1_000);
         BOTMUX_SESSION_ID: sessionId,
         LARK_APP_ID: 'app_ws_race',
         LARK_APP_SECRET: 'secret',
-        BOTMUX_TEST_TERMINAL_SECRET_READ_DELAY_MS: String(handshakeReadDelayMs),
       },
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     });
@@ -686,7 +677,6 @@ setInterval(() => {}, 1_000);
       larkAppSecret: 'secret',
     } satisfies DaemonToWorker);
     const ready = await waitForReady(child, logs);
-    const base = `http://127.0.0.1:${ready.port}`;
     const boot = ready.viewToken!;
 
     interface ViewSocketAttempt {
@@ -698,11 +688,14 @@ setInterval(() => {}, 1_000);
     }
 
     /** 走真实握手开一条 view WS，看它最终是被拒、被关，还是活过了自己的有效期。 */
-    const openViewSocket = (capability: string, waitMs: number): Promise<ViewSocketAttempt> => (
+    const openViewSocket = (capability: string, waitMs: number, recheckNow?: number): Promise<ViewSocketAttempt> => (
       new Promise(resolveAttempt => {
         const socket = new WebSocket(
           `ws://127.0.0.1:${ready.port}/?viewToken=${encodeURIComponent(capability)}`,
-          { headers: centralForwardHeaders(secret, capability) },
+          { headers: {
+            ...centralForwardHeaders(secret, capability),
+            ...(recheckNow === undefined ? {} : { 'x-botmux-test-recheck-now': String(recheckNow) }),
+          } },
         );
         const chunks: string[] = [];
         let opened = false;
@@ -726,8 +719,8 @@ setInterval(() => {}, 1_000);
       })
     );
 
-    // 对照组，同时也是页缓存预热：一条两次校验都过的正常能力照常放行、照常拿到历史
-    // 种子，并且由第二次解析算出的 expiresAt timer 到点关掉（4003 / view expired）。
+    // 真实时钟对照组：一条两次校验都过的正常能力照常登记，并且由第二次解析算出的
+    // expiresAt timer 到点关掉（4003 / view expired）。
     const liveTtlMs = 1_500;
     const liveCapability = centralViewCapability(secret, sessionId, boot, {
       issuedAt: Date.now(), expiresAt: Date.now() + liveTtlMs,
@@ -745,43 +738,18 @@ setInterval(() => {}, 1_000);
     expect(live.received).toContain('{"botmux":"terminal.write","write":false}');
     expect(Date.now() - liveStart).toBeGreaterThanOrEqual(liveTtlMs - 300);
 
-    // 量一次 access 解析在这台机器上到底多贵——这个数值就是那条缝的宽度：
-    // 握手前那次校验发生在「一次解析之后」，connection 里那次发生在「两次解析之后」。
-    const probeCapability = centralViewCapability(secret, sessionId, boot, {
-      issuedAt: Date.now(), expiresAt: Date.now() + 60_000,
-    });
-    const probeStart = Date.now();
-    const probe = await fetch(`${base}/?viewToken=${encodeURIComponent(probeCapability)}`, {
-      headers: centralForwardHeaders(secret, probeCapability),
-    });
-    const oneResolveMs = Date.now() - probeStart;
-    expect(probe.status).toBe(200);
-    // 慢 HOME 复现必须真的生效，否则这条缝窄到根本量不出来，后面的扫描就成了空跑。
-    expect(oneResolveMs).toBeGreaterThan(20);
-
-    // 把到期时刻扫过 (第一次校验, 第二次校验] 这段区间。
-    const attempts: ViewSocketAttempt[] = [];
-    for (const factor of [1.15, 1.3, 1.45, 1.6, 1.75, 1.9, 1.45, 1.6]) {
-      const ttlMs = Math.max(2, Math.round(oneResolveMs * factor));
+    // 第一次校验使用真实时钟且能力仍有效；只有 connection 回调使用精确的到期时刻。
+    // 每个边界都必须被二次校验拒绝，不能靠“多试几次至少撞中一次”来证明覆盖。
+    for (const expiryOffsetMs of [0, 1]) {
+      const expiresAt = Date.now() + 60_000;
       const capability = centralViewCapability(secret, sessionId, boot, {
-        issuedAt: Date.now(), expiresAt: Date.now() + ttlMs,
+        issuedAt: Date.now(), expiresAt,
       });
-      attempts.push(await openViewSocket(capability, ttlMs + 900));
+      const attempt = await openViewSocket(capability, 5_000, expiresAt + expiryOffsetMs);
+      expect(attempt).toEqual({
+        kind: 'closed', code: 4003, reason: 'authorization expired', received: '',
+      });
     }
-
-    // 1) 没有任何一条 socket 活过自己能力的有效期。旧实现里跨缝那条既没被拒也没有
-    //    timer，会一直活着——这一条就是本项的红线。
-    expect(attempts.filter(attempt => attempt.kind === 'alive')).toEqual([]);
-    // 2) 这一轮确实撞进了缝：至少有一条是被 connection 二次校验 fail closed 掉的，
-    //    而不是被握手前那次拦掉（refused）、也不是靠到期 timer 兜底（view expired）。
-    //    没撞进去就说明这个测试根本没测到东西，所以它必须响，不能默默变绿。
-    const refusedAtRecheck = attempts.filter(attempt => (
-      attempt.kind === 'closed' && attempt.reason === 'authorization expired'
-    ));
-    expect(refusedAtRecheck.length).toBeGreaterThan(0);
-    expect(refusedAtRecheck.every(attempt => attempt.code === 4003)).toBe(true);
-    // 3) 被二次校验拒掉的 socket 压根没进 wsClients，所以一个字节的终端历史都没拿到。
-    for (const attempt of refusedAtRecheck) expect(attempt.received).toBe('');
 
     // worker 重启语义：钉在上一代 worker 上的能力连握手都过不去，压根到不了
     // connection——二次校验是补上的那道闸，不是把前一道闸放松的借口。


### PR DESCRIPTION
## 关联问题

Closes #1339

## 改动

Linux 沙箱子进程可以清除 relay / origin 环境标识；fresh-root 中缺失的文件探针又只返回 ENOENT，导致受管 CLI 退回普通宿主路径。此问题在 #1315 合并后仍可复现，并非该 PR 引入。

- 在 full bwrap 和 credential-only bwrap 的启动入口安装同一个窄 seccomp 判据，供 `send` 和离线会话变更分类复用。
- 使用 `getpriority(PRIO_PROCESS, 1)` 的内核行为，不依赖 HOME、环境标识、可修改的标记文件或 PID 数值相等。规则跨 fork / exec / 嵌套 namespace 继承。
- 只接受成功且位于合法 nice 范围的探针结果；不按特定 errno 匹配，防止追加过滤器替换 errno（包括 errno 0）后伪装成宿主。
- 使用匿名管道将过滤器交给 bwrap，保留交互 stdin；不增加 native addon、外部辅助程序或可被替换的 profile 文件。
- 内核隔离判据优先于可伪造的进程标记；缺失 relay capability 不能降级为直发。真正的宿主 relay 保留现有路径。
- pane 标记版本升至 15，避免旧进程 warm reattach 后仍缺少新规则。

## 影响面与边界

改动位于共用 Linux 启动层，覆盖完整沙箱和仅凭据隔离、PTY 与持久终端后端，不改变各 CLI 的文件白名单。macOS 保留原 Seatbelt 探针逻辑；未启动真实业务机器人，也未修改全局安装或部署配置。

支持 x64 / arm64 及 i386 / ARM EABI / x32 调用约定；未知 ABI、seccomp 无法安装时 fail closed。该规则仅拒绝查询 PID 1 的 nice 值，不影响当前进程优先级查询或优先级设置。外层策略若已禁止此探针，普通宿主命令也会按隔离处理。详细取舍见 `docs/file-sandbox.md`。

这是受信 CLI 的隔离分类加固，不宣称能够阻止修改 CLI 代码、持有真实凭据后自行调用 API 或内核逃逸。受控复现未使用真实凭据，未请求真实消息 API。

## 验证

原基线 `7d83eabd`：UID 0 / 65534 保留来源标识时拒绝；清除后均到达隔离检查之后的普通参数校验。
修复后：源码及编译后的单文件程序均在隔离分类阶段拒绝，无外部请求。

已运行：

```sh
node node_modules/vitest/vitest.mjs run --project unit --maxWorkers 4 \
  test/linux-isolation.test.ts test/sandbox-session-data-dir.test.ts \
  test/sandbox-relay-watcher.test.ts test/managed-origin-capability.test.ts \
  test/managed-origin-attestation.test.ts test/read-isolation.test.ts \
  test/session-delete-cli.test.ts test/cli-send-dispatch.test.ts \
  test/cli-send-hook-context.test.ts test/sandbox.test.ts \
  test/sandbox-mask-manifest.test.ts test/sandbox-shim-compiled-form.test.ts \
  test/plugin-mcp-sandbox.test.ts test/traex-worker-bridge-wiring.test.ts
# 14 个文件，297 项通过

node node_modules/vitest/vitest.mjs run --project unit --maxWorkers 4 \
  test/read-isolation.test.ts test/session-marker-resolve.test.ts \
  test/pty-backend-launch-shell.test.ts test/tmux-backend-env.test.ts \
  test/tmux-backend-input.test.ts test/herdr-backend.test.ts \
  test/zellij-backend-helpers.test.ts
# 7 个文件，273 项通过，5 项平台相关跳过

bun test test/linux-isolation.test.ts test/sandbox-session-data-dir.test.ts \
  test/read-isolation.test.ts test/managed-origin-capability.test.ts \
  test/sandbox-relay-watcher.test.ts
# Bun 1.4.2，136 项通过；启动前及仓库 preload 均隔离测试 HOME

bun run build
bun run verify:binary --keep
# 构建与全部单文件冒烟检查通过；额外验证后已删除临时二进制
```

另用真实 node-pty 和独立 socket 的 tmux 服务验证交互输入及内核判据，均通过。新增内核测试覆盖清空环境、嵌套 namespace、叠加 errno 0 / ESRCH / ENOSYS、过滤器安装失败、伪造 relay/进程标记、合法 relay 路由、credential-only 可写会话库的离线变更拒绝，以及 v14 pane 冷启动。

测试夹具使用私有 `/dev`，避免 Bun 在部分宿主容器设备挂载上启动崩溃；无本次 seccomp 改动的对照组同样出现该崩溃，因此未扩大生产设备挂载策略。ARM / compat ABI 在本轮验证的是过滤器逐指令行为，不冒充跨架构硬件实测。

临时复现 worktree、测试数据、独立 tmux 服务与编译测试产物均已清理。
