### PR TITLE
fix(feedback): 持久化原生回合执行耗时，并解耦投递记录与反馈卡片

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10276,7 +10276,18 @@ async function cmdSend(rest: string[]): Promise<void> {
       }
     }
 
-    if (feedbackPolicy && effectiveResponseKind === 'final' && !customCard && !pureVideoSend && !vcMeetingManagedSendOrigin && messageId) {
+    // Turn-completion bookkeeping is INDEPENDENT of the feedback card. A
+    // delivery row is what a later `turn_terminal` correlates against to emit
+    // `turn.completed` (with the real completion time and native duration), so
+    // gating it on `feedbackPolicy` used to mean "feedback off → no completion
+    // record at all". Record every canonical in-session final answer; the
+    // feedback policy/card only decides whether a *control* rides along.
+    // The excluded shapes (custom card, pure video, managed VC send) are not
+    // canonical final-answer cards — and they are exactly the shapes the
+    // feedback gate above rejects outright, so the recorded set stays identical
+    // whether feedback is on or off.
+    if (effectiveResponseKind === 'final' && !customCard && !pureVideoSend && !vcMeetingManagedSendOrigin && messageId) {
+      const carriesFeedbackControl = !!feedbackPolicy;
       const deliveryTurnId = currentTurnId ?? `send:${messageId}`;
       const correlationDiscriminator = currentTurnId ? messageId : undefined;
       try {
@@ -10296,17 +10307,23 @@ async function cmdSend(rest: string[]): Promise<void> {
           dispatchAttempt: originDispatchAttempt,
           content: text,
           cliId: s.cliId,
-          cardMode: 'feedback',
+          // 'card' records a canonical final answer that carries no feedback
+          // control, so analytics can tell the two apart.
+          cardMode: carriesFeedbackControl ? 'feedback' : 'card',
           status: 'delivered',
-          policy: feedbackPolicy,
-          baseCard: feedbackBaseCard,
-          requesterSubjectId: feedbackRequesterSubjectId,
+          // Only a card that actually shows the control persists a policy and a
+          // replayable base card; without them the callback path fails closed.
+          ...(carriesFeedbackControl ? { policy: feedbackPolicy } : {}),
+          ...(carriesFeedbackControl && feedbackBaseCard ? { baseCard: feedbackBaseCard } : {}),
+          ...(carriesFeedbackControl ? { requesterSubjectId: feedbackRequesterSubjectId } : {}),
+          // turn.completed webhooks are a completion concern, not a feedback
+          // one: they must keep firing with the card turned off.
           webhookDestinations: feedbackWebhookDestinations,
           context: { ...(resolveFeedbackTeamId({ dataDir: resolveDataDir(), chatId: targetChatId }) ? { teamId: resolveFeedbackTeamId({ dataDir: resolveDataDir(), chatId: targetChatId }) } : {}) },
         });
       } catch (error) {
         console.error(
-          `botmux send: feedback indexing failed after delivery: ${error instanceof Error ? error.message : String(error)}`,
+          `botmux send: turn delivery indexing failed after delivery: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -14210,6 +14210,16 @@ function setupWorkerHandlers(
                     turnId: msg.turnId,
                     dispatchAttempt: msg.dispatchAttempt,
                     status: 'completed',
+                    // The worker measured this turn; carry its numbers onto the
+                    // synthesized terminal. This row is written FIRST and the
+                    // store's INSERT OR IGNORE keeps it, so omitting the timing
+                    // here would permanently shadow the worker's real terminal.
+                    ...(settlement.completedAtMs !== undefined
+                      ? { completedAtMs: settlement.completedAtMs }
+                      : {}),
+                    ...(settlement.durationMs !== undefined
+                      ? { durationMs: settlement.durationMs }
+                      : {}),
                   }, { workerGeneration });
                 } catch (err) {
                   logger.error(`[${t}] Failed to persist Codex App settlement terminal: ${err instanceof Error ? err.message : String(err)}`);
@@ -14617,18 +14627,32 @@ async function finishTurnReactions(ds: DaemonSession): Promise<void> {
  *  same provider key; the daemon owns bounded transient retries. After 3 attempts we log
  *  and give up — the user's answer is lost; better than leaking memory
  *  via an unbounded retry loop. */
-async function persistFinalOutputFeedback(
+/** Record the canonical final-answer delivery for this turn.
+ *
+ * This is turn-completion bookkeeping, NOT a feedback side effect: the row is
+ * what a later `turn_terminal` correlates against to emit `turn.completed` with
+ * the real completion time and native duration. It is therefore written whether
+ * or not a feedback control rides on the card — `policy`/`baseCard` are the only
+ * parts that depend on the feedback policy, and their absence simply means the
+ * card has no clickable control.
+ *
+ * Best-effort: the answer is already delivered, so a persistence failure is
+ * logged, never thrown. */
+async function persistFinalOutputDelivery(
   ds: DaemonSession,
   msg: Extract<WorkerToDaemon, { type: 'final_output' }>,
   content: string,
   effectiveCliId: string,
   messageId: string,
-  policy: import('../services/feedback-policy.js').FeedbackPolicy,
-  baseCard: Record<string, unknown>,
+  policy: import('../services/feedback-policy.js').FeedbackPolicy | undefined,
+  baseCard: Record<string, unknown> | undefined,
   requesterSubjectId: string | undefined,
   webhookDestinations: import('../services/feedback-outbox.js').FeedbackWebhookDestination[] | undefined,
   logTag: string,
 ): Promise<void> {
+  // A control needs BOTH the policy and the card snapshot to stay clickable
+  // after a restart; either one missing means "record the delivery, no control".
+  const carriesFeedbackControl = !!policy && !!baseCard;
   try {
     const { getSkillFeedbackStore } = await import('../services/skill-feedback-store.js');
     const feedbackStore = await getSkillFeedbackStore(config.session.dataDir);
@@ -14648,18 +14672,18 @@ async function persistFinalOutputFeedback(
       cliVersion: ds.cliVersion,
       model: ds.session.model,
       reasoningEffort: ds.session.reasoningEffort,
-      cardMode: 'feedback',
+      cardMode: carriesFeedbackControl ? 'feedback' : 'card',
       status: 'delivered',
       usage: msg.usage,
-      policy,
-      baseCard,
-      requesterSubjectId,
+      ...(carriesFeedbackControl ? { policy, baseCard, requesterSubjectId } : {}),
+      // turn.completed webhooks are a completion concern, not a feedback one:
+      // they must keep firing with the feedback card turned off.
       webhookDestinations,
       context: { ...(resolveFeedbackTeamId({ dataDir: config.session.dataDir, chatId: ds.chatId }) ? { teamId: resolveFeedbackTeamId({ dataDir: config.session.dataDir, chatId: ds.chatId }) } : {}) },
     });
   } catch (error) {
     logger.warn(
-      `[${logTag}] Failed to persist final-output feedback delivery: ${error instanceof Error ? error.message : String(error)}`,
+      `[${logTag}] Failed to persist final-output turn delivery: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }
@@ -15093,8 +15117,11 @@ function deliverFinalOutput(
       };
       if (preparedListenerReply?.kind === 'succeeded' && preparedListenerReply.messageId) {
         recordPrimaryOutput(preparedListenerReply.messageId);
-        if (feedbackPolicy && baseFeedbackCard) {
-          await persistFinalOutputFeedback(ds, msg, safeAssistantText, effectiveCliId, preparedListenerReply.messageId, feedbackPolicy!, baseFeedbackCard, feedbackRequesterSubjectId, getBot(ds.larkAppId).config.feedbackWebhooks?.destinations, t);
+        // Managed VC receivers are accounted in their own delivery store and
+        // never correlate to a feedback turn_terminal; skip them. Every other
+        // fallback final is recorded regardless of the feedback policy.
+        if (!managedReceiver) {
+          await persistFinalOutputDelivery(ds, msg, safeAssistantText, effectiveCliId, preparedListenerReply.messageId, feedbackPolicy, baseFeedbackCard, feedbackRequesterSubjectId, getBot(ds.larkAppId).config.feedbackWebhooks?.destinations, t);
         }
         ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
         logger.info(
@@ -15151,8 +15178,10 @@ function deliverFinalOutput(
       }
       ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
       logger.info(`[${t}] Bridge final_output forwarded (turn ${msg.turnId.substring(0, 8)}, ${msg.content.length} chars, kind=${msg.kind ?? 'bridge'}, attempt ${attempt + 1})`);
-      if (feedbackPolicy && baseFeedbackCard && messageId) {
-        await persistFinalOutputFeedback(ds, msg, safeAssistantText, effectiveCliId, messageId, feedbackPolicy!, baseFeedbackCard, feedbackRequesterSubjectId, getBot(ds.larkAppId).config.feedbackWebhooks?.destinations, t);
+      if (messageId && !managedReceiver) {
+        // Normal fallback final only; managed VC receivers have their own
+        // delivery accounting and no feedback turn_terminal to correlate to.
+        await persistFinalOutputDelivery(ds, msg, safeAssistantText, effectiveCliId, messageId, feedbackPolicy, baseFeedbackCard, feedbackRequesterSubjectId, getBot(ds.larkAppId).config.feedbackWebhooks?.destinations, t);
       }
       onComplete?.(true);
     } catch (err: any) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22528,7 +22528,17 @@ export async function startDaemon(botIndex?: number): Promise<void> {
           dataDir: config.session.dataDir,
           botAppId: ds.larkAppId,
           sessionId: ds.session.sessionId,
-          terminal: { turnId: terminal.turnId, dispatchAttempt: terminal.dispatchAttempt, status: terminal.status },
+          terminal: {
+            turnId: terminal.turnId,
+            dispatchAttempt: terminal.dispatchAttempt,
+            status: terminal.status,
+            // Carry the worker's real completion instant and native execution
+            // span. Without these the store can only stamp its own write time
+            // and leave duration NULL, which is what made recorded "completion
+            // time" unusable for measuring how long a turn actually took.
+            ...(terminal.completedAtMs !== undefined ? { completedAtMs: terminal.completedAtMs } : {}),
+            ...(terminal.durationMs !== undefined ? { durationMs: terminal.durationMs } : {}),
+          },
           onError: error => logger.error(
             `[turn-completion] persistence failed turn=${terminal.turnId.slice(0, 12)}: `
             + `${error instanceof Error ? error.message : String(error)}`,

--- a/src/services/skill-feedback-store.ts
+++ b/src/services/skill-feedback-store.ts
@@ -100,6 +100,10 @@ export interface RecordTurnTerminalInput {
 
 export interface TurnCompletionEventPayload {
   type: 'turn.completed'; version: 1; eventId: string; time: string;
+  /** True when `time` is the store's write time rather than a measured
+   *  completion instant (the emitter could not vouch for one). Absent means
+   *  `time` is the real native completion instant. */
+  completedAtEstimated?: true;
   status: Exclude<TurnDeliveryStatus, 'delivered'>; deliveryId: string;
   contentHash: string; contentRef?: string;
   platform: string; platformMessageId: string; platformAppId: string;
@@ -196,7 +200,17 @@ function feedbackCardTemplate(baseCard: Record<string, unknown> | undefined): Re
   return card as Record<string, unknown>;
 }
 
-const SCHEMA_VERSION = 7;
+const SCHEMA_VERSION = 8;
+
+/** v8: mark rows whose completed_at is the store's write time rather than a
+ *  measured completion instant. Pre-v8 rows are all estimates (nothing upstream
+ *  sent a real instant before this version), so the backfill defaults to 1 and
+ *  new rows carry the emitter's actual answer. Keeps existing readers working —
+ *  completed_at itself is unchanged — while letting a consumer that cares about
+ *  accuracy tell measured from approximated. */
+const TERMINAL_V8_SCHEMA = `
+  ALTER TABLE turn_terminals ADD COLUMN completed_at_estimated INTEGER NOT NULL DEFAULT 1;
+`;
 
 const DELIVERY_V7_SCHEMA = `
   ALTER TABLE deliveries ADD COLUMN correlation_discriminator TEXT NOT NULL DEFAULT '';
@@ -288,12 +302,12 @@ const DELIVERY_V3_COLUMNS = `
     WHERE bot_app_id IS NOT NULL AND session_id IS NOT NULL AND turn_id IS NOT NULL;
 `;
 
-/** Fresh-build DDL for a brand-new DB (version 0 → 7). No BEGIN/COMMIT/PRAGMA:
+/** Fresh-build DDL for a brand-new DB (version 0 → 8). No BEGIN/COMMIT/PRAGMA:
  *  migrateStep() owns the transaction and the user_version bump. Base tables use
  *  IF NOT EXISTS so a loser that somehow re-enters is a no-op on them; the later
  *  ${...} fragments (bare ALTER/CREATE) are guarded by migrateStep re-reading
  *  user_version under the write lock, so the loser never reaches this SQL. */
-const FRESH_V7_SCHEMA = `
+const FRESH_V8_SCHEMA = `
   CREATE TABLE IF NOT EXISTS interactions (
     interaction_id TEXT PRIMARY KEY,
     context_json TEXT,
@@ -349,6 +363,7 @@ const FRESH_V7_SCHEMA = `
   ${OUTBOX_V5_SCHEMA}
   ${ANALYTICS_V6_SCHEMA}
   ${DELIVERY_V7_SCHEMA}
+  ${TERMINAL_V8_SCHEMA}
 `;
 
 /** Legacy v1→v2 columns (no BEGIN/COMMIT/PRAGMA — migrateStep owns those). */
@@ -415,13 +430,14 @@ export class SkillFeedbackStore {
     // still within [from,to]; the fresh-build step (from 0) creates the full v7
     // schema, later steps are incremental ALTER/CREATE for legacy DBs.
     const steps: Array<{ from: number; to: number; target: number; sql: string }> = [
-      { from: 0, to: 0, target: 7, sql: FRESH_V7_SCHEMA },
+      { from: 0, to: 0, target: 8, sql: FRESH_V8_SCHEMA },
       { from: 1, to: 1, target: 2, sql: MIGRATE_V1_TO_V2 },
       { from: 1, to: 2, target: 3, sql: DELIVERY_V3_COLUMNS },
       { from: 1, to: 3, target: 4, sql: COMPLETION_V4_SCHEMA },
       { from: 1, to: 4, target: 5, sql: MIGRATE_V4_TO_V5 },
       { from: 1, to: 5, target: 6, sql: ANALYTICS_V6_SCHEMA },
       { from: 1, to: 6, target: 7, sql: DELIVERY_V7_SCHEMA },
+      { from: 1, to: 7, target: 8, sql: TERMINAL_V8_SCHEMA },
     ];
     for (const step of steps) {
       // Stop as soon as the DB is fully migrated: a loser that lost every race
@@ -660,6 +676,13 @@ export class SkillFeedbackStore {
   /** Shared turn-terminal transaction body (caller owns BEGIN/COMMIT/ROLLBACK). */
   private applyTurnTerminal(input: RecordTurnTerminalInput): TurnCompletionEventPayload | undefined {
     const attempt = input.dispatchAttempt ?? 0;
+    // completed_at is NOT NULL, so an emitter that could not vouch for a real
+    // completion instant still needs a value here. Write time is the closest
+    // available approximation — but it is an approximation (it includes however
+    // long this row waited behind the write lock), so flag it rather than let a
+    // consumer read it as a measured instant. Emitters that DO know the real
+    // instant send completedAt and land in the authoritative branch.
+    const completedAtEstimated = input.completedAt === undefined;
     const completedAt = input.completedAt ?? new Date().toISOString();
     const prior = this.db.prepare(`SELECT status FROM turn_terminals WHERE bot_app_id=? AND session_id=? AND turn_id=?
       AND dispatch_attempt=?`).get(
@@ -667,9 +690,10 @@ export class SkillFeedbackStore {
     ) as { status: string } | undefined;
     if (prior && prior.status !== input.status) throw new Error('turn_terminal_status_conflict');
     this.db.prepare(`INSERT OR IGNORE INTO turn_terminals(
-      bot_app_id,session_id,turn_id,dispatch_attempt,status,completed_at,duration_ms,usage_json
-    ) VALUES(?,?,?,?,?,?,?,?)`).run(
+      bot_app_id,session_id,turn_id,dispatch_attempt,status,completed_at,completed_at_estimated,duration_ms,usage_json
+    ) VALUES(?,?,?,?,?,?,?,?,?)`).run(
       input.botAppId, input.sessionId, input.turnId, attempt, input.status, completedAt,
+      completedAtEstimated ? 1 : 0,
       input.durationMs ?? null, input.usage ? JSON.stringify(input.usage) : null,
     );
     const deliveries = this.db.prepare(`SELECT delivery_id FROM deliveries WHERE bot_app_id=? AND session_id=? AND turn_id=?
@@ -736,7 +760,8 @@ export class SkillFeedbackStore {
 
   private reconcileTurnCompletion(deliveryId: string): TurnCompletionEventPayload | undefined {
     const row = this.db.prepare(`SELECT d.*,r.content_hash,r.content_ref,t.status AS terminal_status,
-      t.completed_at AS terminal_completed_at,t.duration_ms AS terminal_duration_ms,t.usage_json AS terminal_usage_json
+      t.completed_at AS terminal_completed_at,t.completed_at_estimated AS terminal_completed_at_estimated,
+      t.duration_ms AS terminal_duration_ms,t.usage_json AS terminal_usage_json
       FROM deliveries d JOIN responses r ON r.response_id=d.response_id
       JOIN turn_terminals t ON t.bot_app_id=d.bot_app_id AND t.session_id=d.session_id AND t.turn_id=d.turn_id
        AND t.dispatch_attempt=IFNULL(d.dispatch_attempt,0)
@@ -750,6 +775,9 @@ export class SkillFeedbackStore {
       status: row.terminal_status, deliveryId, contentHash: row.content_hash,
       platform: row.platform, platformMessageId: row.platform_message_id, platformAppId: row.platform_app_id,
       botAppId: row.bot_app_id, sessionId: row.session_id, turnId: row.turn_id,
+      // Only stated when true, so a consumer reading `time` as a measured
+      // instant is explicitly warned when it is really the store's write time.
+      ...(row.terminal_completed_at_estimated ? { completedAtEstimated: true as const } : {}),
       ...(row.content_ref ? { contentRef: row.content_ref } : {}),
       ...(row.native_session_id ? { nativeSessionId: row.native_session_id } : {}),
       ...(row.dispatch_attempt !== null ? { dispatchAttempt: row.dispatch_attempt } : {}),
@@ -762,10 +790,11 @@ export class SkillFeedbackStore {
       ...(row.workflow_id ? { workflowId: row.workflow_id } : {}), ...(row.task_id ? { taskId: row.task_id } : {}),
       ...(row.parent_task_id ? { parentTaskId: row.parent_task_id } : {}),
     };
-    // COALESCE so a terminal that carries no usage/duration (the turn-terminal
-    // path only records status) does not clobber the usage/duration_ms the
-    // delivery captured at send time. status/completed_at are authoritative from
-    // the terminal and intentionally overwrite.
+    // COALESCE so a terminal that carries no usage/duration (an emitter that
+    // could not measure the turn, or a legacy worker predating the timing
+    // fields) does not clobber the usage/duration_ms the delivery captured at
+    // send time. status/completed_at are authoritative from the terminal and
+    // intentionally overwrite.
     this.db.prepare('UPDATE deliveries SET status=?,duration_ms=COALESCE(?,duration_ms),usage_json=COALESCE(?,usage_json),completed_at=? WHERE delivery_id=?').run(
       row.terminal_status, row.terminal_duration_ms, row.terminal_usage_json, row.terminal_completed_at, deliveryId,
     );

--- a/src/services/turn-completion-events.ts
+++ b/src/services/turn-completion-events.ts
@@ -6,11 +6,39 @@ import {
   type TurnCompletionEventPayload,
 } from './skill-feedback-store.js';
 
+/** The terminal facts the persistence layer needs. Timing is carried end-to-end
+ *  (worker → daemon → queue → store) so `completed_at` is the turn's REAL
+ *  completion instant rather than the row's write time, and `duration_ms` is the
+ *  CLI's own execution span. Both stay optional: an emitter that cannot vouch
+ *  for a real instant sends neither, and the store falls back honestly. */
+export type PersistedTurnTerminal = Pick<
+  Extract<WorkerToDaemon, { type: 'turn_terminal' }>,
+  'turnId' | 'dispatchAttempt' | 'status' | 'completedAtMs' | 'durationMs'
+>;
+
+/** Normalize the wire's epoch-ms timing into the store's column shape. Rejects
+ *  non-finite / negative values instead of writing a nonsense timestamp. */
+export function turnTerminalTiming(terminal: PersistedTurnTerminal): {
+  completedAt?: string;
+  durationMs?: number;
+} {
+  const completedAtMs = terminal.completedAtMs;
+  const durationMs = terminal.durationMs;
+  return {
+    ...(typeof completedAtMs === 'number' && Number.isFinite(completedAtMs) && completedAtMs > 0
+      ? { completedAt: new Date(completedAtMs).toISOString() }
+      : {}),
+    ...(typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs >= 0
+      ? { durationMs: Math.round(durationMs) }
+      : {}),
+  };
+}
+
 export async function persistTurnTerminal(input: {
   dataDir: string;
   botAppId: string;
   session: Pick<Session, 'sessionId'>;
-  terminal: Pick<Extract<WorkerToDaemon, { type: 'turn_terminal' }>, 'turnId' | 'dispatchAttempt' | 'status'>;
+  terminal: PersistedTurnTerminal;
   store?: SkillFeedbackStore;
 }): Promise<TurnCompletionEventPayload | undefined> {
   const store = input.store ?? await getSkillFeedbackStore(input.dataDir);
@@ -20,6 +48,7 @@ export async function persistTurnTerminal(input: {
     turnId: input.terminal.turnId,
     dispatchAttempt: input.terminal.dispatchAttempt,
     status: input.terminal.status,
+    ...turnTerminalTiming(input.terminal),
   });
 }
 
@@ -40,7 +69,7 @@ export interface EnqueueTurnTerminalInput {
   dataDir: string;
   botAppId: string;
   sessionId: string;
-  terminal: Pick<Extract<WorkerToDaemon, { type: 'turn_terminal' }>, 'turnId' | 'dispatchAttempt' | 'status'>;
+  terminal: PersistedTurnTerminal;
   onError?: (error: unknown) => void;
   /** Test/tuning knobs. */
   retryBaseMs?: number;
@@ -136,6 +165,7 @@ async function attempt(key: string): Promise<void> {
       turnId: input.terminal.turnId,
       dispatchAttempt: input.terminal.dispatchAttempt,
       status: input.terminal.status,
+      ...turnTerminalTiming(input.terminal),
     });
     if (result.done) { finish(key); return; }
     // Write lock busy: reschedule with capped backoff, yielding the loop.

--- a/src/services/turn-execution-clock.ts
+++ b/src/services/turn-execution-clock.ts
@@ -1,0 +1,130 @@
+/**
+ * Worker-local clock for a turn's REAL native execution window.
+ *
+ * The window opens at the literal CLI write (the moment this turn's input is
+ * actually handed to the backend), not when the daemon queued it — a turn that
+ * waited 40s behind a busy CLI must not report 40s of "execution". It closes at
+ * the turn's native terminal.
+ *
+ * Everything here is deliberately fail-quiet: an unknown start yields NO
+ * duration rather than a guessed one, because a fabricated number is worse than
+ * an absent one for the analytics this feeds.
+ */
+
+/** Bound the map so a turn that never reaches a terminal cannot leak forever
+ *  (cancelled mid-flight, CLI killed, worker replaced). Insertion-ordered
+ *  eviction drops the oldest unsettled start, which is exactly the one whose
+ *  duration is least trustworthy by then. */
+const MAX_TRACKED_TURNS = 512;
+
+export interface TurnExecutionTiming {
+  /** Epoch ms of the native terminal. Always present. */
+  completedAtMs: number;
+  /** Native execution time in ms. Absent when the start instant is unknown. */
+  durationMs?: number;
+}
+
+function key(turnId: string, dispatchAttempt?: number): string {
+  return `${turnId}:${dispatchAttempt ?? 'generic'}`;
+}
+
+export class TurnExecutionClock {
+  private readonly startedAtMs = new Map<string, number>();
+
+  constructor(private readonly maxTracked = MAX_TRACKED_TURNS) {
+    if (!Number.isInteger(maxTracked) || maxTracked < 1) {
+      throw new Error('maxTracked must be a positive integer');
+    }
+  }
+
+  /**
+   * Open the window for one `(turn, dispatch attempt)` at its literal write.
+   * Re-arming the same key overwrites: a resubmit/replay genuinely restarts the
+   * CLI-side work, so the later write is the honest start.
+   */
+  start(turnId: string | undefined, dispatchAttempt?: number, atMs: number = Date.now()): void {
+    if (!turnId || !Number.isFinite(atMs)) return;
+    const id = key(turnId, dispatchAttempt);
+    // Delete first so a re-armed key moves to the end of the insertion order and
+    // is not evicted ahead of genuinely older starts.
+    this.startedAtMs.delete(id);
+    this.startedAtMs.set(id, atMs);
+    while (this.startedAtMs.size > this.maxTracked) {
+      const oldest = this.startedAtMs.keys().next().value;
+      if (oldest === undefined) break;
+      this.startedAtMs.delete(oldest);
+    }
+  }
+
+  /**
+   * Close the window and return the timing to publish. The entry is consumed, so
+   * a duplicate terminal for the same key reports the completion instant without
+   * a second duration — the first (real) terminal already owns it.
+   *
+   * `completedAtMs` may be supplied by a backend that timestamps its own
+   * completion (codex-app's runner does); it is trusted only when it is a finite
+   * instant that is not in the future, so a skewed/forged runner clock cannot
+   * mint a completion later than this worker's own observation.
+   */
+  settle(
+    turnId: string | undefined,
+    dispatchAttempt?: number,
+    completedAtMs?: number,
+    nowMs: number = Date.now(),
+  ): TurnExecutionTiming | undefined {
+    const timing = this.read(turnId, dispatchAttempt, completedAtMs, nowMs);
+    if (turnId) this.startedAtMs.delete(key(turnId, dispatchAttempt));
+    return timing;
+  }
+
+  /**
+   * Same computation as `settle` but WITHOUT consuming the entry. Used by the
+   * codex-app two-phase settlement, which must stamp the daemon-synthesized
+   * terminal before the worker's own terminal fires; both then report identical
+   * numbers, and the store's INSERT OR IGNORE makes whichever lands first the
+   * one that counts.
+   */
+  peek(
+    turnId: string | undefined,
+    dispatchAttempt?: number,
+    completedAtMs?: number,
+    nowMs: number = Date.now(),
+  ): TurnExecutionTiming | undefined {
+    return this.read(turnId, dispatchAttempt, completedAtMs, nowMs);
+  }
+
+  private read(
+    turnId: string | undefined,
+    dispatchAttempt: number | undefined,
+    completedAtMs: number | undefined,
+    nowMs: number,
+  ): TurnExecutionTiming | undefined {
+    if (!turnId) return undefined;
+    const startedAt = this.startedAtMs.get(key(turnId, dispatchAttempt));
+    const completed = typeof completedAtMs === 'number' && Number.isFinite(completedAtMs)
+      ? Math.min(completedAtMs, nowMs)
+      : nowMs;
+    if (startedAt === undefined) return { completedAtMs: completed };
+    const durationMs = completed - startedAt;
+    // A negative span means the clocks disagree (backend-supplied completion
+    // predating our own write observation). Report the completion instant and
+    // withhold the duration rather than publish a nonsense number.
+    if (!Number.isFinite(durationMs) || durationMs < 0) return { completedAtMs: completed };
+    return { completedAtMs: completed, durationMs: Math.round(durationMs) };
+  }
+
+  /** Drop a tracked start without producing timing (turn abandoned pre-terminal). */
+  forget(turnId: string | undefined, dispatchAttempt?: number): void {
+    if (!turnId) return;
+    this.startedAtMs.delete(key(turnId, dispatchAttempt));
+  }
+
+  /** Drop every tracked start (CLI replaced / session reset). */
+  clear(): void {
+    this.startedAtMs.clear();
+  }
+
+  size(): number {
+    return this.startedAtMs.size;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1579,6 +1579,15 @@ export type WorkerToDaemon =
         generation: string;
         seq: number;
         dispatchId: string;
+        /** Real completion instant / native execution span for the terminal the
+         *  daemon synthesizes from this settlement. The daemon persists that
+         *  terminal BEFORE the worker's own ordered `turn_terminal` arrives, and
+         *  the store's INSERT OR IGNORE keeps whichever lands first — so without
+         *  these the durable path would durably win with a timing-less row and
+         *  permanently mask the worker's real numbers. Same optional-means-
+         *  unknown contract as `turn_terminal`. */
+        completedAtMs?: number;
+        durationMs?: number;
       };
       /** The model already delivered through botmux send; settle without fallback output. */
       suppressDelivery?: boolean;
@@ -1624,6 +1633,18 @@ export type WorkerToDaemon =
        *  emits `completed` with no final_output after fs-lag and must NOT be
        *  read as silence (that would mask a real, still-arriving answer). */
       outputDisposition?: 'nothing_to_send';
+      /** Wall-clock epoch ms at which the CLI turn actually reached its native
+       *  terminal. Absent when the emitter cannot vouch for a real instant, in
+       *  which case the recorder falls back to its own write time (which is NOT
+       *  the completion time — that fallback is exactly why this field exists). */
+      completedAtMs?: number;
+      /** True native execution time: from the moment this turn's input was
+       *  literally written to the CLI, to `completedAtMs`. Deliberately excludes
+       *  daemon/worker queueing before the write, so it measures the CLI, not the
+       *  backlog. Omitted (never guessed, never zero-filled) whenever the start
+       *  instant is unknown — an absent duration is honest, a fabricated one is
+       *  not. Always a non-negative integer when present. */
+      durationMs?: number;
     }
   | { type: 'adopt_preamble'; userText: string; assistantText: string; turnId?: string }
   | { type: 'deferred_topic_materialized'; sessionId: string; turnId: string; rootMessageId: string }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11615,10 +11615,6 @@ async function flushPending(): Promise<void> {
         currentBotmuxDispatchAttempt = item.dispatchAttempt;
         currentGatewayTrustedCaller = item.trustedCaller;
         currentVcMeetingImTurnOrigin = item.vcMeetingImTurnOrigin;
-        // Native execution starts HERE — at the literal write that hands this
-        // turn to the CLI — so its reported duration excludes the time it spent
-        // queued behind an earlier turn.
-        markTurnExecutionStart(item.turnId, item.dispatchAttempt);
         // Acquire durable HOL ownership only after this turn owns the backend
         // submission mutex. If an older ZMX recovery debt rejects capture,
         // this input is known not to have started and must not leave a latch
@@ -11665,6 +11661,14 @@ async function flushPending(): Promise<void> {
           log('Refused durable Claude submit: transcript terminal bridge is unavailable');
           throw new Error('terminal bridge unavailable before submission');
         }
+        // All pre-write guards have passed and the fenced write (the next
+        // operation) is about to hand this turn's input to the CLI. Arm the
+        // execution window HERE, not at the top of the hook: the guard above can
+        // refuse the submission before a single byte is written, and a turn that
+        // never executed must not report a (near-zero) duration — it still gets a
+        // real completedAtMs (the failure instant), just no durationMs. Arming
+        // here also keeps queueing time out of the span.
+        markTurnExecutionStart(item.turnId, item.dispatchAttempt);
         if (lastInitConfig?.cliId === 'codex-app') {
           log(
             `Writing Codex App input to PTY (flush): `

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -122,6 +122,7 @@ import {
   evaluateVcMeetingManagedSend,
 } from './services/vc-meeting-send-policy.js';
 import { TurnTerminalDeduper } from './services/turn-terminal-deduper.js';
+import { TurnExecutionClock } from './services/turn-execution-clock.js';
 import {
   appendBridgeTurnJournalEntry,
   BridgeRestoreGate,
@@ -2763,6 +2764,9 @@ async function deliverRawInput(msg: Extract<DaemonToWorker, { type: 'raw_input' 
         currentBotmuxDispatchAttempt = undefined;
         currentGatewayTrustedCaller = undefined;
         currentVcMeetingImTurnOrigin = undefined;
+        // A passthrough is a real CLI turn and can settle with a terminal, so it
+        // gets the same write-anchored execution window as a queued message.
+        markTurnExecutionStart(msg.turnId, undefined);
         stampMojoTurnMark(msg.turnId, undefined); // a passthrough IS a mojo turn
         writeCliPidMarker();
         publishSandboxRelayCapability();
@@ -8266,6 +8270,10 @@ async function writeAdoptMessage(
   const prepareAdoptWrite = (): void => {
     if (adoptWritePrepared) return;
     adoptWritePrepared = true;
+    // Same anchor rule as flushPending: the execution window opens at the
+    // literal adopt write, inside the submission transaction, so a refused
+    // write never leaves a start armed for work that never began.
+    markTurnExecutionStart(turnId, dispatchAttempt);
     beginCliWriteCycle();
     if (bridgeJsonlPath) {
       try { bridgeIngest(); } catch { /* best effort */ }
@@ -9838,6 +9846,10 @@ async function handleTrustedCodexAppMarker(
     if (codexAppDispatchId) {
       if (!control || codexAppDispatchHandle === undefined) return false;
       const requestId = randomBytes(16).toString('hex');
+      // Read (do NOT consume) this turn's execution window: the daemon persists a
+      // synthesized terminal from this settlement before our own emitTurnTerminal
+      // below runs, so both must report the same numbers.
+      const settlementTiming = turnExecutionClock.peek(turnId, dispatchAttempt, completedAtMs);
       // A superseded member is durably settled but NEVER delivered: force empty
       // content + suppressDelivery so the daemon persists the FIFO advance without
       // deliverFinalOutput, and tag the disposition so the sink is explicit.
@@ -9856,6 +9868,8 @@ async function handleTrustedCodexAppMarker(
           generation: control.generation,
           seq: control.seq,
           dispatchId: codexAppDispatchId!,
+          ...(settlementTiming ? { completedAtMs: settlementTiming.completedAtMs } : {}),
+          ...(settlementTiming?.durationMs !== undefined ? { durationMs: settlementTiming.durationMs } : {}),
         },
       }));
       if (!persisted || !codexAppTurnDispatchQueue.commitExactHead(codexAppDispatchHandle)) {
@@ -9934,7 +9948,10 @@ async function handleTrustedCodexAppMarker(
         codexAppCompletionAwaitingFinal = false;
       }
     }
-    emitTurnTerminal(turnId, 'completed', undefined, dispatchAttempt);
+    // The app-server runner timestamps its own completion; prefer that instant
+    // over "whenever this worker got around to handling the marker". The clock
+    // clamps it to now, so a skewed runner cannot mint a future completion.
+    emitTurnTerminal(turnId, 'completed', undefined, dispatchAttempt, undefined, undefined, completedAtMs);
     return true;
   }
   rejectCodexAppControlMarker(`unsupported signed ${kind}`);
@@ -11598,6 +11615,10 @@ async function flushPending(): Promise<void> {
         currentBotmuxDispatchAttempt = item.dispatchAttempt;
         currentGatewayTrustedCaller = item.trustedCaller;
         currentVcMeetingImTurnOrigin = item.vcMeetingImTurnOrigin;
+        // Native execution starts HERE — at the literal write that hands this
+        // turn to the CLI — so its reported duration excludes the time it spent
+        // queued behind an earlier turn.
+        markTurnExecutionStart(item.turnId, item.dispatchAttempt);
         // Acquire durable HOL ownership only after this turn owns the backend
         // submission mutex. If an older ZMX recovery debt rejects capture,
         // this input is known not to have started and must not leave a latch
@@ -19091,6 +19112,16 @@ if(isTouch&&hasToken){(function(){
 
 type TurnTerminalStatus = Extract<WorkerToDaemon, { type: 'turn_terminal' }>['status'];
 const emittedTurnTerminals = new TurnTerminalDeduper();
+/** Opens at each turn's literal CLI write, closes at its terminal. See
+ *  turn-execution-clock.ts for why queueing time is deliberately excluded. */
+const turnExecutionClock = new TurnExecutionClock();
+
+/** Arm the execution window for the turn whose input is being written right
+ *  now. Called from every literal-write site (flush, adopt, passthrough, init)
+ *  so `durationMs` measures the CLI, not the daemon's backlog. */
+function markTurnExecutionStart(turnId: string | undefined, dispatchAttempt?: number): void {
+  turnExecutionClock.start(turnId, dispatchAttempt);
+}
 
 /** Report CLI processing completion independently from user-visible output.
  *  Keep a bounded worker-local dedup set because transcript watchers and app
@@ -19102,6 +19133,9 @@ function emitTurnTerminal(
   dispatchAttempt?: number,
   outputDisposition?: 'nothing_to_send',
   retryable?: boolean,
+  /** Backend-supplied completion instant (codex-app's runner timestamps its own
+   *  finals). Clamped to now by the clock; absent means "use this instant". */
+  completedAtMs?: number,
 ): void {
   if (!sessionId || !turnId) return;
   cancelSubmitFailureChainForTerminal(
@@ -19109,7 +19143,14 @@ function emitTurnTerminal(
     { turnId, dispatchAttempt },
     cliSpawnGeneration,
   );
-  if (!emittedTurnTerminals.claim(sessionId, turnId, dispatchAttempt)) return;
+  if (!emittedTurnTerminals.claim(sessionId, turnId, dispatchAttempt)) {
+    // A duplicate terminal must not leave the start armed: the first emission
+    // already published this turn's timing and consumed the entry, but a
+    // *replay* whose first emission never ran through this path could.
+    turnExecutionClock.forget(turnId, dispatchAttempt);
+    return;
+  }
+  const timing = turnExecutionClock.settle(turnId, dispatchAttempt, completedAtMs);
   if (status !== 'completed') {
     const dropped = codexBridgeQueue.dropPendingTurn(turnId, dispatchAttempt, true);
     if (dropped) {
@@ -19128,6 +19169,8 @@ function emitTurnTerminal(
     ...(errorCode ? { errorCode } : {}),
     ...(outputDisposition ? { outputDisposition } : {}),
     ...(retryable !== undefined ? { retryable } : {}),
+    ...(timing ? { completedAtMs: timing.completedAtMs } : {}),
+    ...(timing?.durationMs !== undefined ? { durationMs: timing.durationMs } : {}),
   });
   if (terminalReleasesDurableTurn(
     { turnId: currentBotmuxTurnId, dispatchAttempt: currentBotmuxDispatchAttempt },
@@ -19430,6 +19473,11 @@ process.on('message', async (raw: unknown) => {
           currentBotmuxDispatchAttempt = msg.dispatchAttempt;
           currentGatewayTrustedCaller = msg.trustedCaller;
           currentVcMeetingImTurnOrigin = msg.vcMeetingImTurnOrigin;
+          // Opening/argv turns start with the session (their prompt rides the
+          // spawn). Arm the window at init; a later literal write re-arms with
+          // the true write instant, so argv-only turns measure spawn→terminal
+          // and written turns measure write→terminal.
+          markTurnExecutionStart(msg.turnId, msg.dispatchAttempt);
           writeCliPidMarker();
           publishSandboxRelayCapability();
         }

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -504,15 +504,23 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(String(sessionReply.mock.calls[0][1])).not.toContain('botmux_feedback');
   });
 
-  it('keeps feedback disabled by default and does not open the store', async () => {
+  it('keeps feedback disabled by default but still records the turn-completion delivery', async () => {
     const sessionReply = vi.fn(async () => 'om_plain_answer');
     initWorkerPool({ sessionReply, getSessionWorkingDir: () => '/tmp', getActiveCount: () => 1, closeSession: vi.fn() });
     const ds = makeDs();
     const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
     __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
     await vi.advanceTimersByTimeAsync(10);
+    // No feedback control on the card itself.
     expect(String(sessionReply.mock.calls[0][1])).not.toContain('botmux_feedback');
-    expect(existsSync(join('/tmp/test-sessions', 'botmux-feedback.sqlite'))).toBe(false);
+    // But the delivery is still recorded so a later turn_terminal correlates to
+    // a turn.completed event — feedback is independent of completion bookkeeping.
+    const { getSkillFeedbackStore } = await import('../src/services/skill-feedback-store.js');
+    const delivery = (await getSkillFeedbackStore('/tmp/test-sessions'))
+      .findDeliveryByPlatformMessage('lark', ds.larkAppId, 'om_plain_answer');
+    expect(delivery).toMatchObject({ cardMode: 'card' });
+    expect(delivery?.policy).toBeUndefined();
+    expect(delivery?.baseCard).toBeUndefined();
   });
 
   it('keeps feedback controls on ordinary local-turn output', async () => {

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -697,12 +697,20 @@ describe('cmdSend hook context wiring', () => {
     expect(cmdSend).not.toContain('const deliveryTurnId = `send:${messageId}`');
     expect(cmdSend).not.toContain('--feedback-level');
     const primarySend = cmdSend.indexOf('messageId = await dispatchPrimary');
-    const feedbackIndex = cmdSend.indexOf('feedback indexing failed after delivery');
+    const deliveryIndex = cmdSend.indexOf('turn delivery indexing failed after delivery');
     expect(primarySend).toBeGreaterThanOrEqual(0);
-    expect(feedbackIndex).toBeGreaterThan(primarySend);
-    expect(cmdSend.slice(cmdSend.lastIndexOf('try {', feedbackIndex), feedbackIndex)).toContain('getSkillFeedbackStore');
-    expect(cmdSend).toContain('policy: feedbackPolicy');
-    expect(cmdSend).toContain('baseCard: feedbackBaseCard');
+    // The delivery record is written AFTER the message is actually sent.
+    expect(deliveryIndex).toBeGreaterThan(primarySend);
+    expect(cmdSend.slice(cmdSend.lastIndexOf('try {', deliveryIndex), deliveryIndex)).toContain('getSkillFeedbackStore');
+    // Turn-completion recording is gated on the response KIND, not on the
+    // feedback policy — feedback off must still produce a correlatable record.
+    expect(cmdSend).toContain("if (effectiveResponseKind === 'final' && !customCard && !pureVideoSend && !vcMeetingManagedSendOrigin && messageId)");
+    // The feedback control (policy + card snapshot) rides along only when a
+    // policy actually applies; the record itself is unconditional.
+    expect(cmdSend).toContain('const carriesFeedbackControl = !!feedbackPolicy;');
+    expect(cmdSend).toContain("cardMode: carriesFeedbackControl ? 'feedback' : 'card'");
+    expect(cmdSend).toContain('...(carriesFeedbackControl ? { policy: feedbackPolicy } : {})');
+    expect(cmdSend).toContain('...(carriesFeedbackControl && feedbackBaseCard ? { baseCard: feedbackBaseCard } : {})');
     expect(cmdSend).toContain('buildFeedbackElement(feedbackPolicy)');
   });
 });

--- a/test/feedback-outbox.test.ts
+++ b/test/feedback-outbox.test.ts
@@ -32,7 +32,7 @@ describe('feedback schema v5 durable event outbox', () => {
     db.recordTurnTerminal({ botAppId: 'app', sessionId: 'session', turnId: 'turn', status: 'completed', completedAt: '2026-08-11T00:00:00.000Z' });
     db.recordTurnDelivery(deliveryInput([destination('one'), destination('disabled'), { ...destination('off'), enabled: false }]));
 
-    expect(db.schemaVersion()).toBe(7);
+    expect(db.schemaVersion()).toBe(8);
     const events = db.listFeedbackEvents();
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe('turn.completed');

--- a/test/feedback-store-v3-migration.test.ts
+++ b/test/feedback-store-v3-migration.test.ts
@@ -34,7 +34,7 @@ describe('SkillFeedbackStore v3 migration', () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'botmux-feedback-v6-'));
     dirs.push(dataDir);
     const store = await SkillFeedbackStore.open(dataDir);
-    expect(store.schemaVersion()).toBe(7);
+    expect(store.schemaVersion()).toBe(8);
     store.close();
     const { DatabaseSync } = await import('node:sqlite');
     const db = new DatabaseSync(join(dataDir, 'botmux-feedback.sqlite'));
@@ -60,7 +60,7 @@ describe('SkillFeedbackStore v3 migration', () => {
     copyFileSync(join(fixtureDir, 'botmux-feedback.sqlite'), join(migratedDir, 'botmux-feedback.sqlite'));
 
     const store = await SkillFeedbackStore.open(migratedDir);
-    expect(store.schemaVersion()).toBe(7);
+    expect(store.schemaVersion()).toBe(8);
     const old = store.findDeliveryByPlatformMessage('lark', 'app_old', 'om_old');
     expect(old).toMatchObject({
       deliveryId: 'del_old', responseId: 'resp_old', requesterSubjectId: 'on_old',

--- a/test/skill-feedback-store.test.ts
+++ b/test/skill-feedback-store.test.ts
@@ -43,7 +43,7 @@ describe('SkillFeedbackStore', () => {
     });
     expect(JSON.stringify(reopened.getResponse(response.responseId))).not.toContain('secret answer');
     expect(reopened.pragmas()).toMatchObject({ journalMode: 'wal', foreignKeys: 1, busyTimeout: 5000 });
-    expect(reopened.schemaVersion()).toBe(7);
+    expect(reopened.schemaVersion()).toBe(8);
     reopened.close();
   });
 
@@ -72,9 +72,9 @@ describe('SkillFeedbackStore', () => {
     dirs.push(dataDir);
     const { DatabaseSync } = await import('node:sqlite');
     const db = new DatabaseSync(join(dataDir, 'botmux-feedback.sqlite'));
-    db.exec('CREATE TABLE sentinel(value TEXT); INSERT INTO sentinel VALUES (\'keep\'); PRAGMA user_version=8;');
+    db.exec('CREATE TABLE sentinel(value TEXT); INSERT INTO sentinel VALUES (\'keep\'); PRAGMA user_version=9;');
     db.close();
-    await expect(SkillFeedbackStore.open(dataDir)).rejects.toThrow('skill_feedback_schema_newer:8');
+    await expect(SkillFeedbackStore.open(dataDir)).rejects.toThrow('skill_feedback_schema_newer:9');
     const verify = new DatabaseSync(join(dataDir, 'botmux-feedback.sqlite'));
     expect((verify.prepare('SELECT value FROM sentinel').get() as any).value).toBe('keep');
     verify.close();
@@ -126,7 +126,7 @@ describe('SkillFeedbackStore', () => {
     `);
     db.close();
     const store = await SkillFeedbackStore.open(dataDir);
-    expect(store.schemaVersion()).toBe(7);
+    expect(store.schemaVersion()).toBe(8);
     expect(store.findDeliveryByPlatformMessage('lark', 'app', 'om_old')).toMatchObject({ policy: undefined, baseCard: undefined, requesterSubjectId: undefined });
     store.close();
   });

--- a/test/turn-completion-events.test.ts
+++ b/test/turn-completion-events.test.ts
@@ -179,4 +179,103 @@ describe('durable turn.completed events', () => {
     expect(() => store.recordTurnTerminal(terminal({ status: 'completed' }))).toThrow('turn_terminal_status_conflict');
     store.close();
   });
+
+  it('records a measured completion instant and native duration, not write time', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-turn-event-')); dirs.push(dir);
+    const store = await SkillFeedbackStore.open(dir);
+    store.recordTurnDelivery(delivery());
+    // Epoch ms → ISO; 2026-08-11T12:00:00.000Z is exactly what `terminal()` uses.
+    const measuredAt = Date.parse('2026-08-11T12:00:00.000Z');
+    store.recordTurnTerminal(terminal({
+      completedAt: new Date(measuredAt).toISOString(),
+      durationMs: 321,
+    }));
+    const event = store.listTurnCompletionEvents()[0].payload;
+    expect(event.time).toBe('2026-08-11T12:00:00.000Z');
+    expect(event.durationMs).toBe(321);
+    // A measured instant carries no estimate flag.
+    expect(event).not.toHaveProperty('completedAtEstimated');
+    store.close();
+  });
+
+  it('flags an estimated completion time when the emitter sent no instant', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-turn-event-')); dirs.push(dir);
+    const store = await SkillFeedbackStore.open(dir);
+    store.recordTurnDelivery(delivery());
+    // No completedAt / durationMs: the store stamps its own write time and
+    // must flag it so a consumer does not read it as a measured instant.
+    store.recordTurnTerminal({
+      botAppId: 'app_a', sessionId: 'session_a', turnId: 'turn_a',
+      dispatchAttempt: 2, status: 'completed',
+    });
+    const event = store.listTurnCompletionEvents()[0].payload;
+    expect(event.completedAtEstimated).toBe(true);
+    expect(event).not.toHaveProperty('durationMs');
+    expect(Date.parse(event.time)).toBeGreaterThan(Date.parse('2026-08-11T12:00:00.000Z'));
+    store.close();
+  });
+
+  it('persists real timing end-to-end through the nonblocking queue', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-turn-event-')); dirs.push(dir);
+    const store = await SkillFeedbackStore.open(dir);
+    store.recordTurnDelivery(delivery());
+    const measuredAt = Date.parse('2026-08-11T12:00:00.000Z');
+    await persistTurnTerminal({
+      dataDir: dir,
+      botAppId: 'app_a',
+      session: { sessionId: 'session_a' },
+      terminal: {
+        turnId: 'turn_a', dispatchAttempt: 2, status: 'completed',
+        completedAtMs: measuredAt, durationMs: 321,
+      },
+      store,
+    });
+    const event = store.listTurnCompletionEvents()[0].payload;
+    expect(event).toMatchObject({ time: '2026-08-11T12:00:00.000Z', durationMs: 321 });
+    expect(event).not.toHaveProperty('completedAtEstimated');
+    store.close();
+  });
+
+  it('ignores malformed timing instead of writing a nonsense timestamp', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-turn-event-')); dirs.push(dir);
+    const store = await SkillFeedbackStore.open(dir);
+    store.recordTurnDelivery(delivery());
+    await persistTurnTerminal({
+      dataDir: dir,
+      botAppId: 'app_a',
+      session: { sessionId: 'session_a' },
+      terminal: {
+        turnId: 'turn_a', dispatchAttempt: 2, status: 'completed',
+        completedAtMs: Number.NaN, durationMs: -5,
+      } as any,
+      store,
+    });
+    const event = store.listTurnCompletionEvents()[0].payload;
+    // Bad input falls back to an honest estimated time, never an Invalid Date.
+    expect(event.completedAtEstimated).toBe(true);
+    expect(Number.isFinite(Date.parse(event.time))).toBe(true);
+    expect(event).not.toHaveProperty('durationMs');
+    store.close();
+  });
+
+  it('records a canonical final answer without a feedback control and still emits turn.completed', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-turn-event-')); dirs.push(dir);
+    const store = await SkillFeedbackStore.open(dir);
+    // A delivery with NO policy/baseCard — feedback turned off. It must still be
+    // recorded (cardMode 'card') and still correlate to a turn.completed event.
+    const saved = store.recordTurnDelivery(delivery({
+      platformMessageId: 'om_no_feedback',
+      cardMode: 'card' as const,
+      policy: undefined, baseCard: undefined, requesterSubjectId: undefined,
+    }));
+    expect(saved.cardMode).toBe('card');
+    expect(saved.policy).toBeUndefined();
+    store.recordTurnTerminal(terminal({}));
+    const events = store.listTurnCompletionEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].payload).toMatchObject({
+      deliveryId: saved.deliveryId, status: 'completed',
+    });
+    store.close();
+  });
 });

--- a/test/turn-execution-clock.test.ts
+++ b/test/turn-execution-clock.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { TurnExecutionClock } from '../src/services/turn-execution-clock.js';
+
+describe('TurnExecutionClock', () => {
+  it('measures from the literal write, not from when the turn was queued', () => {
+    const clock = new TurnExecutionClock();
+    // Queued at t=1000 (not observed by the clock), written at t=5000.
+    clock.start('turn_a', 1, 5_000);
+    expect(clock.settle('turn_a', 1, undefined, 7_400)).toEqual({
+      completedAtMs: 7_400,
+      durationMs: 2_400,
+    });
+  });
+
+  it('reports the completion instant but no duration when the start is unknown', () => {
+    const clock = new TurnExecutionClock();
+    // A terminal for a turn this worker never wrote (recovered/replayed attempt):
+    // an absent duration is honest; a zero or a guess would not be.
+    expect(clock.settle('turn_never_written', 0, undefined, 9_000)).toEqual({ completedAtMs: 9_000 });
+  });
+
+  it('prefers a backend-supplied completion instant but never lets it exceed now', () => {
+    const clock = new TurnExecutionClock();
+    clock.start('turn_b', undefined, 1_000);
+    // Runner's own timestamp, earlier than our handling of the marker: trusted.
+    expect(clock.settle('turn_b', undefined, 3_000, 4_500)).toEqual({
+      completedAtMs: 3_000,
+      durationMs: 2_000,
+    });
+
+    clock.start('turn_c', undefined, 1_000);
+    // A future-dated (skewed or forged) runner clock is clamped to now.
+    expect(clock.settle('turn_c', undefined, 99_000, 4_000)).toEqual({
+      completedAtMs: 4_000,
+      durationMs: 3_000,
+    });
+  });
+
+  it('withholds the duration when the completion instant predates the write', () => {
+    const clock = new TurnExecutionClock();
+    clock.start('turn_skew', undefined, 8_000);
+    // Backend clock disagrees with ours; publish the instant, not a negative span.
+    expect(clock.settle('turn_skew', undefined, 5_000, 9_000)).toEqual({ completedAtMs: 5_000 });
+  });
+
+  it('consumes the entry so a duplicate terminal cannot report a second duration', () => {
+    const clock = new TurnExecutionClock();
+    clock.start('turn_d', 2, 1_000);
+    expect(clock.settle('turn_d', 2, undefined, 2_000)).toEqual({ completedAtMs: 2_000, durationMs: 1_000 });
+    expect(clock.settle('turn_d', 2, undefined, 3_000)).toEqual({ completedAtMs: 3_000 });
+    expect(clock.size()).toBe(0);
+  });
+
+  it('peek reports the same numbers without consuming, so both settlement phases agree', () => {
+    const clock = new TurnExecutionClock();
+    clock.start('turn_e', 3, 1_000);
+    // codex-app: the daemon-synthesized terminal peeks, the worker's own
+    // terminal then settles. Both must publish identical numbers.
+    const peeked = clock.peek('turn_e', 3, 4_000, 5_000);
+    const settled = clock.settle('turn_e', 3, 4_000, 5_000);
+    expect(peeked).toEqual({ completedAtMs: 4_000, durationMs: 3_000 });
+    expect(settled).toEqual(peeked);
+    expect(clock.size()).toBe(0);
+  });
+
+  it('scopes the window per dispatch attempt', () => {
+    const clock = new TurnExecutionClock();
+    clock.start('turn_f', 1, 1_000);
+    clock.start('turn_f', 2, 4_000);
+    expect(clock.settle('turn_f', 2, undefined, 5_000)).toEqual({ completedAtMs: 5_000, durationMs: 1_000 });
+    expect(clock.settle('turn_f', 1, undefined, 5_000)).toEqual({ completedAtMs: 5_000, durationMs: 4_000 });
+  });
+
+  it('re-arming a key restarts the measurement (a resubmit really does restart the work)', () => {
+    const clock = new TurnExecutionClock();
+    clock.start('turn_g', 0, 1_000);
+    clock.start('turn_g', 0, 6_000);
+    expect(clock.settle('turn_g', 0, undefined, 6_500)).toEqual({ completedAtMs: 6_500, durationMs: 500 });
+  });
+
+  it('bounds retained starts so abandoned turns cannot leak', () => {
+    const clock = new TurnExecutionClock(3);
+    for (let i = 0; i < 10; i++) clock.start(`turn_${i}`, undefined, 1_000 + i);
+    expect(clock.size()).toBe(3);
+    // The oldest unsettled starts were evicted; the newest survive with timing.
+    expect(clock.settle('turn_0', undefined, undefined, 2_000)).toEqual({ completedAtMs: 2_000 });
+    expect(clock.settle('turn_9', undefined, undefined, 2_000)).toEqual({ completedAtMs: 2_000, durationMs: 991 });
+  });
+
+  it('forget and clear drop tracked starts without emitting timing', () => {
+    const clock = new TurnExecutionClock();
+    clock.start('turn_h', undefined, 1_000);
+    clock.forget('turn_h', undefined);
+    expect(clock.settle('turn_h', undefined, undefined, 2_000)).toEqual({ completedAtMs: 2_000 });
+
+    clock.start('turn_i', undefined, 1_000);
+    clock.start('turn_j', undefined, 1_000);
+    clock.clear();
+    expect(clock.size()).toBe(0);
+  });
+
+  it('ignores empty turn ids on every entry point', () => {
+    const clock = new TurnExecutionClock();
+    clock.start(undefined, 1, 1_000);
+    clock.start('', 1, 1_000);
+    expect(clock.size()).toBe(0);
+    expect(clock.settle(undefined, 1, undefined, 2_000)).toBeUndefined();
+    expect(clock.peek(undefined, 1, undefined, 2_000)).toBeUndefined();
+  });
+});

--- a/test/turn-execution-clock.test.ts
+++ b/test/turn-execution-clock.test.ts
@@ -19,6 +19,20 @@ describe('TurnExecutionClock', () => {
     expect(clock.settle('turn_never_written', 0, undefined, 9_000)).toEqual({ completedAtMs: 9_000 });
   });
 
+  it('a submission refused before the write reports a failure instant but no execution span', () => {
+    // Regression: a durable submit can be refused by a pre-write guard (e.g. the
+    // reliable-terminal bridge unavailable check) BEFORE a single byte is handed
+    // to the CLI. Such a turn never executed, so it must not be armed and its
+    // `failed` terminal carries completedAtMs (the failure instant) but no
+    // durationMs — otherwise near-zero fake durations pollute failure/p95 stats.
+    const clock = new TurnExecutionClock();
+    // Pre-write guard refuses the submission: start() is deliberately never called.
+    expect(clock.settle('turn_refused_preflight', 1, undefined, 12_000)).toEqual({
+      completedAtMs: 12_000,
+    });
+    expect(clock.size()).toBe(0);
+  });
+
   it('prefers a backend-supplied completion instant but never lets it exceed now', () => {
     const clock = new TurnExecutionClock();
     clock.start('turn_b', undefined, 1_000);


### PR DESCRIPTION
## 背景 / 问题

数据库存储层本来就有 `completed_at` / `duration_ms` 列，但链路上多处把时间字段截断了：

- `turn_terminal` IPC（`types.ts`）不带 `completedAt` / `durationMs`；
- worker 的 `emitTurnTerminal()` 只发状态；codex-app 路径其实已拿到 `startedAtMs`/`completedAtMs`，发终态时却丢了；
- daemon 写队列、非阻塞 terminal queue、最终 `recordTurnTerminal()` 一路只挑 `turnId / dispatchAttempt / status`；
- 于是 store 只能把 `completed_at` 默认成**行写入时间**、`duration_ms` 写成 `NULL`；
- 并且投递记录与反馈卡片**强耦合**：`recordTurnDelivery` 只在挂反馈卡片时调用——反馈功能关掉就不建 delivery，也就没有可按 `turnId` 关联的 `turn.completed` 数据。

结果：webhook / 数据库里的「完成时间」不是真实原生完成时刻，执行耗时基本拿不到；关掉反馈后连完整的 turn completion 记录都没有。

## 改动

1. **IPC 带时间**：`turn_terminal` 增加可选 `completedAtMs` / `durationMs`，语义写进类型注释（durationMs 只算 CLI turn 真正开始到原生 terminal，不含排队；拿不到就不填、不伪造）。

2. **worker 真实计时**：新增 `TurnExecutionClock`（`services/turn-execution-clock.ts`）。执行窗口在「输入**真正写入 CLI**」那一刻打开——flush、adopt、passthrough、init 四个写入点都打点——在原生 terminal 关闭，因此排队等待不计入执行耗时。codex-app 用 runner 自带的完成时间（钳到 `now`，防时钟偏斜造出未来时刻）。缺起点 → 只发完成时刻、不发 duration（诚实缺席，不编造）。

3. **codex-app 两阶段 settlement 对齐**：worker 把同一组时间经 `final_output.codexAppSettlement` 带给 daemon；daemon 在 worker 终态之前先持久化的那条**合成 terminal** 也带时间，避免「无耗时」记录被 `INSERT OR IGNORE` 抢先落库、永久遮蔽 worker 的真实数字。worker 侧用 `peek`（不消费窗口）保证两次上报数字一致。

4. **全链路透传**：daemon `onTurnTerminal` → 非阻塞 queue（`turn-completion-events.ts`）→ SQLite store 都带上时间；`turnTerminalTiming()` 把 epoch ms 归一化成 ISO、拒绝非有限/负值。

5. **投递记录与反馈卡片解耦**：`cli.ts` 的 `botmux send --response-kind final` 与 worker-pool 的兜底投递路径，现在只要是**规范的会话内最终回答**都会落 delivery 行——反馈卡片在时 `cardMode='feedback'`，反馈控件关掉时 `cardMode='card'`，但两者都能被后续 `turn_terminal` 关联出完整 `turn.completed`（含真实耗时）。`policy`/`baseCard` 仅在确有可点击控件时写入（回调路径 fail-closed 行为不变）。托管 VC（meeting receiver）投递走独立账务，仍跳过。`turn.completed` webhook 也随投递记录触发，而非随反馈控件。

6. **store 诚实标记**：新增 `completed_at_estimated` 列（schema v7→v8）。拿不到真实完成时刻时 `completed_at` 仍用写入时间兜底（列是 NOT NULL），但显式标记为估算、`turn.completed` 事件带 `completedAtEstimated: true`，不再被当成测量时刻；旧库迁移默认估算。

## 影响面

- **跨 CLI**：计时打点在 worker 共用写入路径（flush/adopt/passthrough/init），非 codex 系 CLI（claude-code transcript、codex RPC 等）经各自 terminal 自动受益；codex-app 额外走 runner 时间戳。
- **跨会话类型**：普通话题 / 群会话的最终回答投递都会落 completion 记录；托管 VC 投递刻意排除（它有独立 store、不与 feedback turn_terminal 关联）。
- **反馈开关**：反馈开/关两态都产出可关联的 `turn.completed`；反馈 UI、卡片回调、打分统计的既有行为保持不变（无 policy/baseCard 的行回调 fail-closed）。
- **数据迁移**：`botmux-feedback.sqlite` v7→v8 增量加列，多进程迁移沿用既有 `migrateStep` 写锁守卫；旧 `completed_at` 数据不改动。
- **平台隧道协议**：不涉及 daemon↔平台控制连接消息，无需 platform 侧同步。

## 测试

- `npx tsc --noEmit`：通过。
- 新增 `test/turn-execution-clock.test.ts`（11 例）：写入锚点不含排队、缺起点不伪造 duration、runner 时间戳优先但不超过 now、完成早于写入时不给负时长、重复 terminal 不二次计时、`peek` 不消费且两阶段数字一致、按 dispatchAttempt 隔离、re-arm 重新计时、容量上限防泄漏、forget/clear、空 turnId 忽略。
- 扩展 `test/turn-completion-events.test.ts`：真实耗时透传（时间戳+ durationMs、无估算标记）、无时间时标记 `completedAtEstimated` 且不给 duration、经非阻塞 queue 端到端、畸形时间（NaN/负值）拒绝而非写坏时间戳、反馈关闭仍落 `cardMode='card'` 并产出 `turn.completed`。
- 更新受影响既有测试：schema 版本钉 v8（skill-feedback-store / feedback-outbox / feedback-store-v3-migration）、`bridge-final-output-retry`（反馈关闭仍记录投递；托管 VC 仍不记录）、`cli-send-hook-context`（源码断言改为新的解耦条件）。
- 相关单测与集成测试全部通过：反馈/耗时/投递/callback/analytics（163 例）、`worker-codex-app-turn-routing.integration`（8 例，含 settlement 持久化）、`worker-ordinary-im-init-concurrency.integration`（5 例）。
- 全量 `vitest run --project unit`：剩余失败均为本机环境问题（bun 不在 PATH、bwrap 文件沙箱不可用），与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
