### PR TITLE
fix(runtime): 修复容器内存准入指标边界

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6309,9 +6309,10 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   autostart enable     注册开机自启（macOS launchd / Linux user systemd / Windows Task Scheduler，无需 sudo）
   autostart disable    注销开机自启
   autostart status     查看自启状态
-  worker-budget status 查看主机内存准入阈值与 session scope 能力
-       set             设置 --min-available-mib / --max-memory-full-avg10 / --session-memory-max-mib
-       unset           清除主机 worker 内存策略覆盖
+  worker-budget status 查看 worker 内存准入来源、阈值与 session scope 能力
+       set             设置 --memory-admission-enabled true|false / --min-available-mib /
+                       --max-memory-full-avg10 / --session-memory-max-mib
+       unset           清除 worker 内存策略覆盖
   lang [zh|en]         切换 UI 语言（无参 = 查看当前设置）
        --bot N         仅改 bots.json 中第 N 个 bot 的 lang
        --unset         清除（global 或 --bot N 配合）
@@ -6546,14 +6547,51 @@ function positiveNumber(value: string | undefined, label: string): number {
   return parsed;
 }
 
+function positiveMibBytes(value: string | undefined, label: string): number {
+  const bytes = Math.round(positiveNumber(value, label) * 1024 ** 2);
+  if (!Number.isSafeInteger(bytes) || bytes <= 0) throw new Error(`${label} must resolve to a positive safe byte count`);
+  return bytes;
+}
+
+function strictBoolean(value: string | undefined, label: string): boolean {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new Error(`${label} must be true or false`);
+}
+
+function validateWorkerBudgetSetArgs(args: string[]): void {
+  const flags = new Set([
+    '--memory-admission-enabled',
+    '--min-available-mib',
+    '--max-memory-full-avg10',
+    '--session-memory-max-mib',
+  ]);
+  const seen = new Set<string>();
+  for (let i = 0; i < args.length; i++) {
+    const token = args[i];
+    const flag = token.includes('=') ? token.slice(0, token.indexOf('=')) : token;
+    if (!flags.has(flag)) throw new Error(`unknown worker-budget flag: ${token}`);
+    if (seen.has(flag)) throw new Error(`duplicate worker-budget flag: ${flag}`);
+    seen.add(flag);
+    if (token === flag) {
+      const value = args[++i];
+      if (value === undefined || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+    } else if (token.slice(token.indexOf('=') + 1) === '') {
+      throw new Error(`${flag} requires a value`);
+    }
+  }
+}
+
 function cmdWorkerBudget(args: string[]): void {
   const sub = (args[0] ?? 'status').toLowerCase();
   if (sub === 'status') {
-    const pressure = readHostMemoryPressure();
-    const decision = evaluateWorkerAdmission(pressure, readGlobalConfig().worker);
+    if (args.length > 1) throw new Error('worker-budget status does not accept arguments');
+    const sampledPressure = readHostMemoryPressure();
+    const decision = evaluateWorkerAdmission(sampledPressure, readGlobalConfig().worker);
+    const pressure = decision.pressure;
     const scope = sessionScopeCapabilities();
     const bots = loadBotsJson();
-    console.log('Worker host protection');
+    console.log('Worker memory protection');
     console.log(`  resident ceiling policy: unchanged (per-bot maxLiveWorkers; default ${DEFAULT_MAX_LIVE_WORKERS})`);
     if (bots.length === 0) {
       console.log(`  effective resident ceiling: ${DEFAULT_MAX_LIVE_WORKERS} (default; no configured bots)`);
@@ -6575,11 +6613,13 @@ function cmdWorkerBudget(args: string[]): void {
         );
       });
     }
-    console.log(`  MemAvailable: ${pressure.availableMemoryBytes === undefined ? 'unavailable' : formatMemoryBytes(pressure.availableMemoryBytes)}`);
+    console.log(`  memory admission: ${decision.policy.memoryAdmissionEnabled ? 'enabled' : 'disabled'} (${decision.policy.memoryAdmissionEnabledSource})`);
+    console.log(`  effective total memory: ${formatMemoryBytes(pressure.totalMemoryBytes)} (${pressure.totalMemorySource})`);
+    console.log(`  available memory: ${pressure.availableMemoryBytes === undefined ? 'unavailable' : formatMemoryBytes(pressure.availableMemoryBytes)} (${pressure.availableMemorySource})`);
     console.log(`  reserve: ${formatMemoryBytes(decision.policy.minAvailableMemoryBytes)} (${decision.policy.minAvailableMemorySource})`);
-    console.log(`  memory full PSI avg10: ${pressure.memoryFullAvg10 === undefined ? 'unavailable' : `${pressure.memoryFullAvg10.toFixed(2)}%`}`);
+    console.log(`  memory full PSI avg10: ${pressure.memoryFullAvg10 === undefined ? 'unavailable' : `${pressure.memoryFullAvg10.toFixed(2)}%`} (${pressure.memoryFullAvg10Source})`);
     console.log(`  PSI limit: ${decision.policy.maxMemoryFullAvg10.toFixed(2)}% (${decision.policy.maxMemoryFullAvg10Source})`);
-    console.log(`  admission: ${decision.allowed ? 'allowed' : `blocked — ${decision.reasons.join('; ')}`}`);
+    console.log(`  admission: ${decision.policy.memoryAdmissionEnabled ? (decision.allowed ? 'allowed' : `blocked — ${decision.reasons.join('; ')}`) : 'disabled'}`);
     console.log(`  session scope cleanup: ${scope.cleanupSupported ? 'supported' : 'unsupported'}`);
     console.log(`  MemoryMax enforceable: ${scope.memoryControllerSupported ? 'yes' : 'no'}`);
     console.log(`  configured session MemoryMax: ${decision.policy.sessionMemoryMaxBytes === undefined ? 'unset' : formatMemoryBytes(decision.policy.sessionMemoryMaxBytes)}`);
@@ -6590,29 +6630,33 @@ function cmdWorkerBudget(args: string[]): void {
   }
   if (sub === 'set') {
     const rest = args.slice(1);
+    validateWorkerBudgetSetArgs(rest);
+    const enabled = argValue(rest, '--memory-admission-enabled');
     const minMib = argValue(rest, '--min-available-mib');
     const psi = argValue(rest, '--max-memory-full-avg10');
     const memoryMaxMib = argValue(rest, '--session-memory-max-mib');
-    if (minMib === undefined && psi === undefined && memoryMaxMib === undefined) {
+    if (enabled === undefined && minMib === undefined && psi === undefined && memoryMaxMib === undefined) {
       throw new Error('worker-budget set requires at least one policy flag');
     }
     const patch: WorkerConfig = {};
-    if (minMib !== undefined) patch.minAvailableMemoryBytes = Math.round(positiveNumber(minMib, '--min-available-mib') * 1024 ** 2);
+    if (enabled !== undefined) patch.memoryAdmissionEnabled = strictBoolean(enabled, '--memory-admission-enabled');
+    if (minMib !== undefined) patch.minAvailableMemoryBytes = positiveMibBytes(minMib, '--min-available-mib');
     if (psi !== undefined) {
       const value = positiveNumber(psi, '--max-memory-full-avg10');
       if (value > 100) throw new Error('--max-memory-full-avg10 must be <= 100');
       patch.maxMemoryFullAvg10 = value;
     }
-    if (memoryMaxMib !== undefined) patch.sessionMemoryMaxBytes = Math.round(positiveNumber(memoryMaxMib, '--session-memory-max-mib') * 1024 ** 2);
+    if (memoryMaxMib !== undefined) patch.sessionMemoryMaxBytes = positiveMibBytes(memoryMaxMib, '--session-memory-max-mib');
     const resolved = mergeWorkerConfig(patch);
-    console.log('Updated worker host protection policy.');
+    console.log('Updated worker memory protection policy.');
     console.log(JSON.stringify(resolved, null, 2));
     console.log('New worker admissions use this policy without changing resident-session ceilings.');
     return;
   }
   if (sub === 'unset' || sub === 'clear') {
+    if (args.length > 1) throw new Error(`worker-budget ${sub} does not accept arguments`);
     clearWorkerConfig();
-    console.log('Cleared worker host protection overrides; defaults apply.');
+    console.log('Cleared worker memory protection overrides; defaults apply.');
     return;
   }
   console.error('Usage: botmux worker-budget [status|set|unset]');

--- a/src/core/worker-budget.ts
+++ b/src/core/worker-budget.ts
@@ -1,22 +1,39 @@
 import { readFileSync } from 'node:fs';
 import { totalmem } from 'node:os';
+import { posix } from 'node:path';
 import type { WorkerConfig } from '../global-config.js';
 
 export const DEFAULT_MIN_AVAILABLE_MEMORY_BYTES = 4 * 1024 ** 3;
 export const DEFAULT_MIN_AVAILABLE_MEMORY_FRACTION = 0.25;
 export const DEFAULT_MAX_MEMORY_FULL_AVG10 = 20;
 
+export type MemoryMetricSource = 'host' | 'cgroup-v2' | 'unavailable';
+
+export interface CgroupMemoryBoundary {
+  totalMemoryBytes: number;
+  availableMemoryBytes?: number;
+  memoryFullAvg10?: number;
+  cgroupPath: string;
+}
+
 export interface HostMemoryPressure {
   totalMemoryBytes: number;
   availableMemoryBytes?: number;
   memoryFullAvg10?: number;
+  totalMemorySource: Exclude<MemoryMetricSource, 'unavailable'>;
+  availableMemorySource: MemoryMetricSource;
+  memoryFullAvg10Source: MemoryMetricSource;
+  cgroupPath?: string;
+  cgroupBoundaries?: CgroupMemoryBoundary[];
   warnings: string[];
 }
 
 export interface ResolvedWorkerPressurePolicy {
+  memoryAdmissionEnabled: boolean;
   minAvailableMemoryBytes: number;
   maxMemoryFullAvg10: number;
   sessionMemoryMaxBytes?: number;
+  memoryAdmissionEnabledSource: 'default' | 'config';
   minAvailableMemorySource: 'default' | 'config';
   maxMemoryFullAvg10Source: 'default' | 'config';
 }
@@ -28,11 +45,29 @@ export interface WorkerAdmissionDecision {
   policy: ResolvedWorkerPressurePolicy;
 }
 
+interface MemoryPressureReadOptions {
+  platform?: NodeJS.Platform;
+  totalMemoryBytes?: number;
+  readFile?: (path: string) => string;
+  procRoot?: string;
+  cgroupRoot?: string;
+}
+
+interface CgroupMount {
+  root: string;
+  mountPoint: string;
+}
+
+type CgroupMemoryResult =
+  | { kind: 'none' | 'unlimited' }
+  | { kind: 'unavailable'; warnings: string[] }
+  | { kind: 'finite'; boundaries: CgroupMemoryBoundary[]; warnings: string[] };
+
 function parseMemAvailable(raw: string): number | undefined {
   const match = /^MemAvailable:\s+(\d+)\s+kB$/m.exec(raw);
   if (!match) return undefined;
   const kib = Number(match[1]);
-  return Number.isFinite(kib) ? kib * 1024 : undefined;
+  return Number.isSafeInteger(kib) ? kib * 1024 : undefined;
 }
 
 function parseMemoryFullAvg10(raw: string): number | undefined {
@@ -43,46 +78,283 @@ function parseMemoryFullAvg10(raw: string): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
 
-export function readHostMemoryPressure(options: {
-  platform?: NodeJS.Platform;
-  totalMemoryBytes?: number;
-  readFile?: (path: string) => string;
-} = {}): HostMemoryPressure {
-  const totalMemoryBytes = options.totalMemoryBytes ?? totalmem();
-  const warnings: string[] = [];
-  const readFile = options.readFile ?? (path => readFileSync(path, 'utf8'));
-  if ((options.platform ?? process.platform) !== 'linux') {
-    return { totalMemoryBytes, warnings: ['memory pressure inspection is unavailable on this platform'] };
+function parseCgroupValue(raw: string): number | 'max' | undefined {
+  const value = raw.trim();
+  if (value === 'max') return 'max';
+  if (!/^\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function parseInactiveFile(raw: string): number | undefined {
+  const match = /^inactive_file\s+(\d+)$/m.exec(raw);
+  if (!match) return undefined;
+  const parsed = Number(match[1]);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function parseUnifiedCgroupPath(raw: string): string | undefined {
+  for (const line of raw.split('\n')) {
+    const match = /^0::(\/.*)$/.exec(line.trim());
+    if (!match) continue;
+    return posix.normalize(match[1]);
+  }
+  return undefined;
+}
+
+function decodeMountInfoPath(value: string): string {
+  return value.replace(/\\(040|011|012|134)/g, (_, code: string) => {
+    if (code === '040') return ' ';
+    if (code === '011') return '\t';
+    if (code === '012') return '\n';
+    return '\\';
+  });
+}
+
+function parseCgroupMounts(raw: string): CgroupMount[] {
+  const mounts: CgroupMount[] = [];
+  for (const line of raw.split('\n')) {
+    const separator = line.indexOf(' - ');
+    if (separator < 0) continue;
+    const before = line.slice(0, separator).split(' ');
+    const after = line.slice(separator + 3).split(' ');
+    if (before.length < 5 || after[0] !== 'cgroup2') continue;
+    mounts.push({
+      root: posix.normalize(decodeMountInfoPath(before[3])),
+      mountPoint: posix.normalize(decodeMountInfoPath(before[4])),
+    });
+  }
+  return mounts;
+}
+
+function cgroupCandidates(
+  membershipPath: string,
+  mounts: CgroupMount[],
+  fallbackRoot: string,
+): Array<{ directory: string; mountPoint: string; hierarchyComplete: boolean }> {
+  if (mounts.length === 0) {
+    return [{
+      directory: posix.join(fallbackRoot, membershipPath),
+      mountPoint: fallbackRoot,
+      hierarchyComplete: false,
+    }];
+  }
+  return mounts.map(mount => {
+    const membershipWithinRoot = membershipPath === mount.root || membershipPath.startsWith(`${mount.root}/`);
+    const relative = membershipWithinRoot
+      ? posix.relative(mount.root, membershipPath)
+      : membershipPath.slice(1);
+    return {
+      directory: posix.join(mount.mountPoint, relative),
+      mountPoint: mount.mountPoint,
+      hierarchyComplete: mount.root === '/',
+    };
+  }).sort((a, b) => Number(b.hierarchyComplete) - Number(a.hierarchyComplete));
+}
+
+function readBoundary(
+  directory: string,
+  memoryMax: number,
+  hostTotalMemoryBytes: number,
+  readFile: (path: string) => string,
+  warnings: string[],
+): CgroupMemoryBoundary | undefined {
+  if (memoryMax > hostTotalMemoryBytes) return undefined;
+  let availableMemoryBytes: number | undefined;
+  try {
+    const current = parseCgroupValue(readFile(posix.join(directory, 'memory.current')));
+    if (typeof current === 'number') {
+      let inactiveFile = 0;
+      try {
+        inactiveFile = parseInactiveFile(readFile(posix.join(directory, 'memory.stat'))) ?? 0;
+      } catch {}
+      const workingSet = Math.max(0, current - Math.min(inactiveFile, current));
+      availableMemoryBytes = Math.max(0, Math.min(memoryMax, memoryMax - workingSet));
+    } else {
+      warnings.push(`${directory}/memory.current has no valid byte value`);
+    }
+  } catch (error) {
+    warnings.push(`cannot read ${directory}/memory.current: ${error instanceof Error ? error.message : String(error)}`);
   }
 
-  let availableMemoryBytes: number | undefined;
   let memoryFullAvg10: number | undefined;
   try {
-    availableMemoryBytes = parseMemAvailable(readFile('/proc/meminfo'));
-    if (availableMemoryBytes === undefined) warnings.push('/proc/meminfo has no valid MemAvailable value');
+    memoryFullAvg10 = parseMemoryFullAvg10(readFile(posix.join(directory, 'memory.pressure')));
+    if (memoryFullAvg10 === undefined) warnings.push(`${directory}/memory.pressure has no valid full avg10 value`);
   } catch (error) {
-    warnings.push(`cannot read /proc/meminfo: ${error instanceof Error ? error.message : String(error)}`);
+    warnings.push(`cannot read ${directory}/memory.pressure: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return {
+    totalMemoryBytes: memoryMax,
+    ...(availableMemoryBytes !== undefined ? { availableMemoryBytes } : {}),
+    ...(memoryFullAvg10 !== undefined ? { memoryFullAvg10 } : {}),
+    cgroupPath: directory,
+  };
+}
+
+function readCgroupMemoryPressure(
+  hostTotalMemoryBytes: number,
+  readFile: (path: string) => string,
+  procRoot: string,
+  cgroupRoot: string,
+): CgroupMemoryResult {
+  let membershipRaw: string;
+  try {
+    membershipRaw = readFile(posix.join(procRoot, 'self/cgroup'));
+  } catch (error) {
+    return {
+      kind: 'unavailable',
+      warnings: [`cannot read ${posix.join(procRoot, 'self/cgroup')}: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+  const membershipPath = parseUnifiedCgroupPath(membershipRaw);
+  if (!membershipPath) return { kind: 'none' };
+
+  let mounts: CgroupMount[] = [];
+  try {
+    mounts = parseCgroupMounts(readFile(posix.join(procRoot, 'self/mountinfo')));
+  } catch {}
+
+  const unavailableWarnings: string[] = [];
+  for (const candidate of cgroupCandidates(membershipPath, mounts, cgroupRoot)) {
+    const boundaries: CgroupMemoryBoundary[] = [];
+    const warnings: string[] = [];
+    let directory = candidate.directory;
+    let complete = true;
+    while (directory === candidate.mountPoint || directory.startsWith(`${candidate.mountPoint}/`)) {
+      let memoryMax: number | 'max' | undefined;
+      try {
+        memoryMax = parseCgroupValue(readFile(posix.join(directory, 'memory.max')));
+      } catch (error) {
+        complete = false;
+        warnings.push(`cannot read ${directory}/memory.max: ${error instanceof Error ? error.message : String(error)}`);
+        if (directory === candidate.mountPoint) break;
+        directory = posix.dirname(directory);
+        continue;
+      }
+      if (memoryMax === undefined) {
+        complete = false;
+        warnings.push(`${directory}/memory.max has no valid byte value or max token`);
+      } else if (typeof memoryMax === 'number') {
+        const boundary = readBoundary(directory, memoryMax, hostTotalMemoryBytes, readFile, warnings);
+        if (boundary) boundaries.push(boundary);
+      }
+      if (directory === candidate.mountPoint) break;
+      directory = posix.dirname(directory);
+    }
+    if (boundaries.length > 0 && candidate.hierarchyComplete) return { kind: 'finite', boundaries, warnings };
+    if (boundaries.length > 0) warnings.push(`${candidate.mountPoint} does not expose finite ancestor limits`);
+    if (complete && candidate.hierarchyComplete) return { kind: 'unlimited' };
+    if (complete) warnings.push(`${candidate.mountPoint} does not expose the full cgroup-v2 hierarchy`);
+    unavailableWarnings.push(...warnings);
+  }
+  return {
+    kind: 'unavailable',
+    warnings: unavailableWarnings.length > 0
+      ? unavailableWarnings
+      : ['cgroup-v2 memory hierarchy could not be resolved'],
+  };
+}
+
+function pressureFromBoundary(
+  boundary: CgroupMemoryBoundary,
+  boundaries: CgroupMemoryBoundary[],
+  warnings: string[],
+): HostMemoryPressure {
+  return {
+    totalMemoryBytes: boundary.totalMemoryBytes,
+    ...(boundary.availableMemoryBytes !== undefined ? { availableMemoryBytes: boundary.availableMemoryBytes } : {}),
+    ...(boundary.memoryFullAvg10 !== undefined ? { memoryFullAvg10: boundary.memoryFullAvg10 } : {}),
+    totalMemorySource: 'cgroup-v2',
+    availableMemorySource: boundary.availableMemoryBytes === undefined ? 'unavailable' : 'cgroup-v2',
+    memoryFullAvg10Source: boundary.memoryFullAvg10 === undefined ? 'unavailable' : 'cgroup-v2',
+    cgroupPath: boundary.cgroupPath,
+    cgroupBoundaries: boundaries,
+    warnings,
+  };
+}
+
+export function readHostMemoryPressure(options: MemoryPressureReadOptions = {}): HostMemoryPressure {
+  const totalMemoryBytes = options.totalMemoryBytes ?? totalmem();
+  const readFile = options.readFile ?? (path => readFileSync(path, 'utf8'));
+  if ((options.platform ?? process.platform) !== 'linux') {
+    return {
+      totalMemoryBytes,
+      totalMemorySource: 'host',
+      availableMemorySource: 'unavailable',
+      memoryFullAvg10Source: 'unavailable',
+      warnings: ['memory pressure inspection is unavailable on this platform'],
+    };
+  }
+
+  const procRoot = options.procRoot ?? '/proc';
+  const cgroup = readCgroupMemoryPressure(
+    totalMemoryBytes,
+    readFile,
+    procRoot,
+    options.cgroupRoot ?? '/sys/fs/cgroup',
+  );
+  if (cgroup.kind === 'finite') {
+    const initial = cgroup.boundaries.reduce((selected, boundary) => (
+      boundary.totalMemoryBytes < selected.totalMemoryBytes ? boundary : selected
+    ));
+    return pressureFromBoundary(initial, cgroup.boundaries, cgroup.warnings);
+  }
+  if (cgroup.kind === 'unavailable') {
+    return {
+      totalMemoryBytes,
+      totalMemorySource: 'host',
+      availableMemorySource: 'unavailable',
+      memoryFullAvg10Source: 'unavailable',
+      warnings: cgroup.warnings,
+    };
+  }
+
+  const warnings: string[] = [];
+  let availableMemoryBytes: number | undefined;
+  let memoryFullAvg10: number | undefined;
+  const meminfoPath = posix.join(procRoot, 'meminfo');
+  const pressurePath = posix.join(procRoot, 'pressure/memory');
+  try {
+    availableMemoryBytes = parseMemAvailable(readFile(meminfoPath));
+    if (availableMemoryBytes === undefined) warnings.push(`${meminfoPath} has no valid MemAvailable value`);
+  } catch (error) {
+    warnings.push(`cannot read ${meminfoPath}: ${error instanceof Error ? error.message : String(error)}`);
   }
   try {
-    memoryFullAvg10 = parseMemoryFullAvg10(readFile('/proc/pressure/memory'));
-    if (memoryFullAvg10 === undefined) warnings.push('/proc/pressure/memory has no valid full avg10 value');
+    memoryFullAvg10 = parseMemoryFullAvg10(readFile(pressurePath));
+    if (memoryFullAvg10 === undefined) warnings.push(`${pressurePath} has no valid full avg10 value`);
   } catch (error) {
-    warnings.push(`cannot read /proc/pressure/memory: ${error instanceof Error ? error.message : String(error)}`);
+    warnings.push(`cannot read ${pressurePath}: ${error instanceof Error ? error.message : String(error)}`);
   }
-  return { totalMemoryBytes, availableMemoryBytes, memoryFullAvg10, warnings };
+  return {
+    totalMemoryBytes,
+    ...(availableMemoryBytes !== undefined ? { availableMemoryBytes } : {}),
+    ...(memoryFullAvg10 !== undefined ? { memoryFullAvg10 } : {}),
+    totalMemorySource: 'host',
+    availableMemorySource: availableMemoryBytes === undefined ? 'unavailable' : 'host',
+    memoryFullAvg10Source: memoryFullAvg10 === undefined ? 'unavailable' : 'host',
+    warnings,
+  };
 }
 
 export function resolveWorkerPressurePolicy(
   config: WorkerConfig | undefined,
   totalMemoryBytes: number,
+  totalMemorySource: HostMemoryPressure['totalMemorySource'] = 'host',
 ): ResolvedWorkerPressurePolicy {
+  const defaultReserve = totalMemorySource === 'cgroup-v2'
+    ? Math.max(1, Math.ceil(totalMemoryBytes * DEFAULT_MIN_AVAILABLE_MEMORY_FRACTION))
+    : Math.max(DEFAULT_MIN_AVAILABLE_MEMORY_BYTES, Math.ceil(totalMemoryBytes * DEFAULT_MIN_AVAILABLE_MEMORY_FRACTION));
   return {
-    minAvailableMemoryBytes: config?.minAvailableMemoryBytes
-      ?? Math.max(DEFAULT_MIN_AVAILABLE_MEMORY_BYTES, Math.ceil(totalMemoryBytes * DEFAULT_MIN_AVAILABLE_MEMORY_FRACTION)),
+    memoryAdmissionEnabled: config?.memoryAdmissionEnabled !== false,
+    minAvailableMemoryBytes: config?.minAvailableMemoryBytes ?? defaultReserve,
     maxMemoryFullAvg10: config?.maxMemoryFullAvg10 ?? DEFAULT_MAX_MEMORY_FULL_AVG10,
     ...(config?.sessionMemoryMaxBytes !== undefined
       ? { sessionMemoryMaxBytes: config.sessionMemoryMaxBytes }
       : {}),
+    memoryAdmissionEnabledSource: config?.memoryAdmissionEnabled === undefined ? 'default' : 'config',
     minAvailableMemorySource: config?.minAvailableMemoryBytes === undefined ? 'default' : 'config',
     maxMemoryFullAvg10Source: config?.maxMemoryFullAvg10 === undefined ? 'default' : 'config',
   };
@@ -92,27 +364,97 @@ export function evaluateWorkerAdmission(
   pressure: HostMemoryPressure,
   config?: WorkerConfig,
 ): WorkerAdmissionDecision {
-  const policy = resolveWorkerPressurePolicy(config, pressure.totalMemoryBytes);
-  const reasons: string[] = [];
-  if (pressure.availableMemoryBytes !== undefined
-    && pressure.availableMemoryBytes < policy.minAvailableMemoryBytes) {
-    reasons.push(
-      `MemAvailable ${formatMemoryBytes(pressure.availableMemoryBytes)} is below the reserved `
-      + `${formatMemoryBytes(policy.minAvailableMemoryBytes)}`,
-    );
+  const boundaries = pressure.cgroupBoundaries;
+  if (!boundaries || boundaries.length === 0) {
+    const policy = resolveWorkerPressurePolicy(config, pressure.totalMemoryBytes, pressure.totalMemorySource);
+    const reasons = evaluatePressureReasons(pressure, policy);
+    return { allowed: reasons.length === 0, reasons, pressure, policy };
   }
-  if (pressure.memoryFullAvg10 !== undefined
-    && pressure.memoryFullAvg10 >= policy.maxMemoryFullAvg10) {
-    reasons.push(
-      `memory full PSI avg10 ${pressure.memoryFullAvg10.toFixed(2)}% reached `
-      + `${policy.maxMemoryFullAvg10.toFixed(2)}%`,
-    );
-  }
-  return { allowed: reasons.length === 0, reasons, pressure, policy };
+
+  const evaluated = boundaries.map(boundary => {
+    const candidate = pressureFromBoundary(boundary, boundaries, pressure.warnings);
+    const policy = resolveWorkerPressurePolicy(config, boundary.totalMemoryBytes, 'cgroup-v2');
+    const availableScore = boundary.availableMemoryBytes === undefined
+      ? Number.POSITIVE_INFINITY
+      : (boundary.availableMemoryBytes - policy.minAvailableMemoryBytes) / Math.max(1, policy.minAvailableMemoryBytes);
+    const psiScore = boundary.memoryFullAvg10 === undefined
+      ? Number.NEGATIVE_INFINITY
+      : boundary.memoryFullAvg10 - policy.maxMemoryFullAvg10;
+    return { candidate, policy, availableScore, psiScore };
+  });
+  const available = evaluated.reduce((selected, value) => (
+    value.availableScore < selected.availableScore ? value : selected
+  ));
+  const psi = evaluated.reduce((selected, value) => value.psiScore > selected.psiScore ? value : selected);
+  const reasons = [
+    ...evaluateAvailableReason(available.candidate, available.policy),
+    ...evaluatePsiReason(psi.candidate, psi.policy),
+  ];
+  const selected = available;
+  const effectivePressure: HostMemoryPressure = {
+    ...selected.candidate,
+    ...(available.candidate.availableMemoryBytes !== undefined
+      ? { availableMemoryBytes: available.candidate.availableMemoryBytes, availableMemorySource: 'cgroup-v2' as const }
+      : { availableMemoryBytes: undefined, availableMemorySource: 'unavailable' as const }),
+    ...(psi.candidate.memoryFullAvg10 !== undefined
+      ? { memoryFullAvg10: psi.candidate.memoryFullAvg10, memoryFullAvg10Source: 'cgroup-v2' as const }
+      : { memoryFullAvg10: undefined, memoryFullAvg10Source: 'unavailable' as const }),
+  };
+  return {
+    allowed: reasons.length === 0,
+    reasons,
+    pressure: effectivePressure,
+    policy: selected.policy,
+  };
 }
 
-export function checkWorkerAdmission(config?: WorkerConfig): WorkerAdmissionDecision {
-  return evaluateWorkerAdmission(readHostMemoryPressure(), config);
+function evaluateAvailableReason(
+  pressure: HostMemoryPressure,
+  policy: ResolvedWorkerPressurePolicy,
+): string[] {
+  if (!policy.memoryAdmissionEnabled
+    || pressure.availableMemoryBytes === undefined
+    || pressure.availableMemoryBytes >= policy.minAvailableMemoryBytes) return [];
+  return [
+    `available memory ${formatMemoryBytes(pressure.availableMemoryBytes)} is below the reserved `
+    + `${formatMemoryBytes(policy.minAvailableMemoryBytes)}`,
+  ];
+}
+
+function evaluatePsiReason(
+  pressure: HostMemoryPressure,
+  policy: ResolvedWorkerPressurePolicy,
+): string[] {
+  if (!policy.memoryAdmissionEnabled
+    || pressure.memoryFullAvg10 === undefined
+    || pressure.memoryFullAvg10 < policy.maxMemoryFullAvg10) return [];
+  return [
+    `memory full PSI avg10 ${pressure.memoryFullAvg10.toFixed(2)}% reached `
+    + `${policy.maxMemoryFullAvg10.toFixed(2)}%`,
+  ];
+}
+
+function evaluatePressureReasons(
+  pressure: HostMemoryPressure,
+  policy: ResolvedWorkerPressurePolicy,
+): string[] {
+  return [...evaluateAvailableReason(pressure, policy), ...evaluatePsiReason(pressure, policy)];
+}
+
+export function checkWorkerAdmission(
+  config?: WorkerConfig,
+  options: MemoryPressureReadOptions = {},
+): WorkerAdmissionDecision {
+  if (config?.memoryAdmissionEnabled === false) {
+    return evaluateWorkerAdmission({
+      totalMemoryBytes: options.totalMemoryBytes ?? totalmem(),
+      totalMemorySource: 'host',
+      availableMemorySource: 'unavailable',
+      memoryFullAvg10Source: 'unavailable',
+      warnings: [],
+    }, config);
+  }
+  return evaluateWorkerAdmission(readHostMemoryPressure(options), config);
 }
 
 export function formatMemoryBytes(bytes: number): string {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -10266,12 +10266,12 @@ export function forkWorker(
   for (const warning of admission.pressure.warnings) {
     if (hostPressureWarningsLogged.has(warning)) continue;
     hostPressureWarningsLogged.add(warning);
-    logger.warn(`[${tag(ds)}] Host memory pressure check degraded (fail-open): ${warning}`);
+    logger.warn(`[${tag(ds)}] Memory pressure check degraded (fail-open): ${warning}`);
   }
   if (!admission.allowed) {
     const reason = admission.reasons.join('; ');
-    logger.warn(`[${tag(ds)}] Worker admission blocked by host memory pressure: ${reason}`);
-    const retry = `Host memory pressure is critical: ${reason}. `
+    logger.warn(`[${tag(ds)}] Worker admission blocked by memory pressure: ${reason}`);
+    const retry = `Memory pressure is critical: ${reason}. `
       + `No worker was started. Free memory or wait for pressure to recover, then retry your message `
       + `(reserve ${formatMemoryBytes(admission.policy.minAvailableMemoryBytes)}, `
       + `PSI limit ${admission.policy.maxMemoryFullAvg10.toFixed(2)}%).`;

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -132,7 +132,9 @@ export interface WorkflowFeatureGlobalConfig {
 }
 
 export interface WorkerConfig {
-  /** Refuse a fresh/resumed worker while MemAvailable is below this value. */
+  /** Default-on switch for fresh/resumed worker memory admission. */
+  memoryAdmissionEnabled?: boolean;
+  /** Refuse a fresh/resumed worker while available memory is below this value. */
   minAvailableMemoryBytes?: number;
   /** Refuse a fresh/resumed worker while memory full PSI avg10 reaches this percentage. */
   maxMemoryFullAvg10?: number;
@@ -468,6 +470,7 @@ function readWorker(raw: unknown): WorkerConfig | undefined {
   const out: WorkerConfig = {};
   const minAvailableMemoryBytes = readPositiveInteger(value.minAvailableMemoryBytes);
   const sessionMemoryMaxBytes = readPositiveInteger(value.sessionMemoryMaxBytes);
+  if (typeof value.memoryAdmissionEnabled === 'boolean') out.memoryAdmissionEnabled = value.memoryAdmissionEnabled;
   if (minAvailableMemoryBytes !== undefined) out.minAvailableMemoryBytes = minAvailableMemoryBytes;
   if (sessionMemoryMaxBytes !== undefined) out.sessionMemoryMaxBytes = sessionMemoryMaxBytes;
   if (typeof value.maxMemoryFullAvg10 === 'number'
@@ -887,6 +890,7 @@ export function clearWorkerConfig(): WorkerConfig {
     return {};
   }
   const remaining = { ...raw.worker as Record<string, unknown> };
+  delete remaining.memoryAdmissionEnabled;
   delete remaining.minAvailableMemoryBytes;
   delete remaining.maxMemoryFullAvg10;
   delete remaining.sessionMemoryMaxBytes;

--- a/test/global-config.test.ts
+++ b/test/global-config.test.ts
@@ -166,6 +166,7 @@ describe('global dashboard config', () => {
   it('validates worker memory policy and preserves future sibling keys on update', () => {
     writeFileSync(globalConfigPath(), JSON.stringify({
       worker: {
+        memoryAdmissionEnabled: false,
         minAvailableMemoryBytes: 4 * 1024 ** 3,
         maxMemoryFullAvg10: 15.5,
         sessionMemoryMaxBytes: 8 * 1024 ** 3,
@@ -173,6 +174,7 @@ describe('global dashboard config', () => {
       },
     }));
     expect(readGlobalConfig().worker).toEqual({
+      memoryAdmissionEnabled: false,
       minAvailableMemoryBytes: 4 * 1024 ** 3,
       maxMemoryFullAvg10: 15.5,
       sessionMemoryMaxBytes: 8 * 1024 ** 3,
@@ -181,6 +183,7 @@ describe('global dashboard config', () => {
     const raw = JSON.parse(readFileSync(globalConfigPath(), 'utf8'));
     expect(raw.worker.futurePolicy).toEqual({ version: 2 });
     expect(readGlobalConfig().worker?.maxMemoryFullAvg10).toBe(25);
+    expect(readGlobalConfig().worker?.memoryAdmissionEnabled).toBe(false);
 
     clearWorkerConfig();
     const cleared = JSON.parse(readFileSync(globalConfigPath(), 'utf8'));

--- a/test/worker-budget-cli.test.ts
+++ b/test/worker-budget-cli.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawnSyncTsScript } from './helpers/ts-runner.js';
+
+const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
+const PROJECT_ROOT = join(__dirname, '..');
+
+let home: string;
+
+function runCli(args: string[]) {
+  return spawnSyncTsScript(CLI_PATH, args, {
+    cwd: PROJECT_ROOT,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      SESSION_DATA_DIR: join(home, '.botmux', 'data'),
+      BOTS_CONFIG: join(home, '.botmux', 'bots.json'),
+    },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+describe('worker-budget CLI', () => {
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'botmux-worker-budget-cli-'));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('sets, reports, and clears explicit memory admission disablement', () => {
+    const set = runCli(['worker-budget', 'set', '--memory-admission-enabled', 'false']);
+    expect(set.status).toBe(0);
+    expect(set.stdout).toContain('"memoryAdmissionEnabled": false');
+    expect(JSON.parse(readFileSync(join(home, '.botmux', 'config.json'), 'utf8')).worker).toEqual({
+      memoryAdmissionEnabled: false,
+    });
+
+    const status = runCli(['worker-budget', 'status']);
+    expect(status.status).toBe(0);
+    expect(status.stdout).toContain('memory admission: disabled (config)');
+    expect(status.stdout).toContain('effective total memory:');
+    expect(status.stdout).toMatch(/available memory: .*\((host|cgroup-v2|unavailable)\)/);
+    expect(status.stdout).toMatch(/memory full PSI avg10: .*\((host|cgroup-v2|unavailable)\)/);
+    expect(status.stdout).toContain('admission: disabled');
+
+    const unset = runCli(['worker-budget', 'unset']);
+    expect(unset.status).toBe(0);
+    expect(JSON.parse(readFileSync(join(home, '.botmux', 'config.json'), 'utf8'))).not.toHaveProperty('worker');
+  });
+
+  it('rejects invalid boolean values without writing config', () => {
+    const result = runCli(['worker-budget', 'set', '--memory-admission-enabled', 'no']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--memory-admission-enabled must be true or false');
+  });
+
+  it('rejects unknown, duplicate, missing-value, and trailing unset arguments', () => {
+    for (const args of [
+      ['worker-budget', 'set', '--memory-admission-enabled', 'false', '--unknown', '1'],
+      ['worker-budget', 'set', '--min-available-mib', '1', '--min-available-mib', '2'],
+      ['worker-budget', 'set', '--memory-admission-enabled'],
+      ['worker-budget', 'set', '--min-available-mib', '1e300'],
+      ['worker-budget', 'set', '--session-memory-max-mib', '0.0000001'],
+      ['worker-budget', 'status', '--unknown'],
+      ['worker-budget', 'unset', '--unknown'],
+    ]) {
+      expect(runCli(args).status).toBe(1);
+    }
+  });
+});

--- a/test/worker-budget.test.ts
+++ b/test/worker-budget.test.ts
@@ -1,64 +1,234 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  checkWorkerAdmission,
   DEFAULT_MAX_MEMORY_FULL_AVG10,
   evaluateWorkerAdmission,
   readHostMemoryPressure,
   resolveWorkerPressurePolicy,
+  type HostMemoryPressure,
 } from '../src/core/worker-budget.js';
 
 const GIB = 1024 ** 3;
 
-describe('worker host-memory admission', () => {
-  it('parses MemAvailable and memory full PSI fixtures', () => {
+function hostPressure(overrides: Partial<HostMemoryPressure> = {}): HostMemoryPressure {
+  return {
+    totalMemoryBytes: 32 * GIB,
+    totalMemorySource: 'host',
+    availableMemorySource: 'unavailable',
+    memoryFullAvg10Source: 'unavailable',
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function fixtureReader(files: Record<string, string>): (path: string) => string {
+  return path => {
+    if (path in files) return files[path];
+    throw new Error(`missing fixture: ${path}`);
+  };
+}
+
+describe('worker memory admission', () => {
+  it('parses host MemAvailable and memory full PSI fixtures', () => {
     const pressure = readHostMemoryPressure({
       platform: 'linux',
       totalMemoryBytes: 32 * GIB,
-      readFile: path => path.endsWith('meminfo')
-        ? 'MemTotal:       33554432 kB\nMemAvailable:    6291456 kB\n'
-        : 'some avg10=1.00 avg60=2.00 avg300=3.00 total=1\nfull avg10=7.25 avg60=2.00 avg300=1.00 total=2\n',
+      readFile: fixtureReader({
+        '/proc/self/cgroup': '1:name=systemd:/\n',
+        '/proc/meminfo': 'MemTotal:       33554432 kB\nMemAvailable:    6291456 kB\n',
+        '/proc/pressure/memory': 'some avg10=1.00 avg60=2.00 avg300=3.00 total=1\nfull avg10=7.25 avg60=2.00 avg300=1.00 total=2\n',
+      }),
     });
     expect(pressure.availableMemoryBytes).toBe(6 * GIB);
     expect(pressure.memoryFullAvg10).toBe(7.25);
+    expect(pressure.totalMemorySource).toBe('host');
+    expect(pressure.availableMemorySource).toBe('host');
+    expect(pressure.memoryFullAvg10Source).toBe('host');
     expect(pressure.warnings).toEqual([]);
   });
 
-  it('blocks low MemAvailable or critical full PSI and permits normal pressure', () => {
-    const normal = evaluateWorkerAdmission({
-      totalMemoryBytes: 32 * GIB,
-      availableMemoryBytes: 12 * GIB,
-      memoryFullAvg10: 1,
+  it('uses finite cgroup-v2 memory and pressure from the same boundary', () => {
+    const pressure = readHostMemoryPressure({
+      platform: 'linux',
+      totalMemoryBytes: 64 * GIB,
+      readFile: fixtureReader({
+        '/proc/self/cgroup': '0::/docker/demo\n',
+        '/proc/self/mountinfo': '29 23 0:26 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n',
+        '/sys/fs/cgroup/docker/demo/memory.max': String(8 * GIB),
+        '/sys/fs/cgroup/docker/demo/memory.current': String(3 * GIB),
+        '/sys/fs/cgroup/docker/demo/memory.stat': `anon ${2 * GIB}\ninactive_file ${GIB}\n`,
+        '/sys/fs/cgroup/docker/demo/memory.pressure': 'some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=2.50 avg60=0.00 avg300=0.00 total=0\n',
+        '/sys/fs/cgroup/docker/memory.max': 'max\n',
+        '/sys/fs/cgroup/memory.max': 'max\n',
+        '/proc/meminfo': 'MemAvailable: 1 kB\n',
+        '/proc/pressure/memory': 'full avg10=99.00 avg60=0.00 avg300=0.00 total=0\n',
+      }),
+    });
+    expect(pressure).toMatchObject({
+      totalMemoryBytes: 8 * GIB,
+      availableMemoryBytes: 6 * GIB,
+      memoryFullAvg10: 2.5,
+      totalMemorySource: 'cgroup-v2',
+      availableMemorySource: 'cgroup-v2',
+      memoryFullAvg10Source: 'cgroup-v2',
+      cgroupPath: '/sys/fs/cgroup/docker/demo',
       warnings: [],
     });
+    expect(resolveWorkerPressurePolicy(undefined, pressure.totalMemoryBytes, pressure.totalMemorySource).minAvailableMemoryBytes).toBe(2 * GIB);
+  });
+
+  it('uses a finite cgroup ancestor when the leaf is unlimited', () => {
+    const pressure = readHostMemoryPressure({
+      platform: 'linux',
+      totalMemoryBytes: 64 * GIB,
+      readFile: fixtureReader({
+        '/proc/self/cgroup': '0::/tenant/session\n',
+        '/proc/self/mountinfo': '29 23 0:26 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n',
+        '/sys/fs/cgroup/tenant/session/memory.max': 'max\n',
+        '/sys/fs/cgroup/tenant/memory.max': String(10 * GIB),
+        '/sys/fs/cgroup/tenant/memory.current': String(4 * GIB),
+        '/sys/fs/cgroup/tenant/memory.stat': 'inactive_file 0\n',
+        '/sys/fs/cgroup/tenant/memory.pressure': 'full avg10=1.00 avg60=0.00 avg300=0.00 total=0\n',
+      }),
+    });
+    expect(pressure.totalMemoryBytes).toBe(10 * GIB);
+    expect(pressure.availableMemoryBytes).toBe(6 * GIB);
+    expect(pressure.totalMemorySource).toBe('cgroup-v2');
+  });
+
+  it('blocks on a tighter finite ancestor even when the leaf has ample headroom', () => {
+    const pressure = readHostMemoryPressure({
+      platform: 'linux',
+      totalMemoryBytes: 64 * GIB,
+      readFile: fixtureReader({
+        '/proc/self/cgroup': '0::/tenant/session\n',
+        '/proc/self/mountinfo': '29 23 0:26 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n',
+        '/sys/fs/cgroup/tenant/session/memory.max': String(16 * GIB),
+        '/sys/fs/cgroup/tenant/session/memory.current': String(2 * GIB),
+        '/sys/fs/cgroup/tenant/session/memory.stat': 'inactive_file 0\n',
+        '/sys/fs/cgroup/tenant/session/memory.pressure': 'full avg10=1.00 avg60=0.00 avg300=0.00 total=0\n',
+        '/sys/fs/cgroup/tenant/memory.max': String(8 * GIB),
+        '/sys/fs/cgroup/tenant/memory.current': String(7 * GIB),
+        '/sys/fs/cgroup/tenant/memory.stat': 'inactive_file 0\n',
+        '/sys/fs/cgroup/tenant/memory.pressure': 'full avg10=1.00 avg60=0.00 avg300=0.00 total=0\n',
+        '/sys/fs/cgroup/memory.max': 'max\n',
+      }),
+    });
+    expect(pressure.cgroupBoundaries).toHaveLength(2);
+    const decision = evaluateWorkerAdmission(pressure);
+    expect(decision.allowed).toBe(false);
+    expect(decision.pressure.totalMemoryBytes).toBe(8 * GIB);
+    expect(decision.reasons).toEqual(['available memory 1.0 GiB is below the reserved 2.0 GiB']);
+  });
+
+  it('fails open instead of trusting a partial hierarchy when mountinfo is unavailable', () => {
+    const pressure = readHostMemoryPressure({
+      platform: 'linux',
+      totalMemoryBytes: 32 * GIB,
+      readFile: fixtureReader({
+        '/proc/self/cgroup': '0::/docker/demo\n',
+        '/sys/fs/cgroup/docker/demo/memory.max': 'max\n',
+        '/sys/fs/cgroup/docker/memory.max': 'max\n',
+        '/sys/fs/cgroup/memory.max': 'max\n',
+        '/proc/meminfo': 'MemAvailable: 1 kB\n',
+      }),
+    });
+    expect(pressure.availableMemoryBytes).toBeUndefined();
+    expect(pressure.availableMemorySource).toBe('unavailable');
+    expect(pressure.warnings.join('\n')).toContain('does not expose the full cgroup-v2 hierarchy');
+  });
+
+  it('falls back to host metrics when the cgroup hierarchy is unlimited', () => {
+    const pressure = readHostMemoryPressure({
+      platform: 'linux',
+      totalMemoryBytes: 32 * GIB,
+      readFile: fixtureReader({
+        '/proc/self/cgroup': '0::/docker/demo\n',
+        '/proc/self/mountinfo': '29 23 0:26 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n',
+        '/sys/fs/cgroup/docker/demo/memory.max': 'max\n',
+        '/sys/fs/cgroup/docker/memory.max': 'max\n',
+        '/sys/fs/cgroup/memory.max': 'max\n',
+        '/proc/meminfo': 'MemAvailable: 12582912 kB\n',
+        '/proc/pressure/memory': 'full avg10=3.00 avg60=0.00 avg300=0.00 total=0\n',
+      }),
+    });
+    expect(pressure.totalMemoryBytes).toBe(32 * GIB);
+    expect(pressure.availableMemoryBytes).toBe(12 * GIB);
+    expect(pressure.memoryFullAvg10).toBe(3);
+    expect(pressure.totalMemorySource).toBe('host');
+  });
+
+  it('does not mix host availability into a finite cgroup with missing current usage', () => {
+    const pressure = readHostMemoryPressure({
+      platform: 'linux',
+      totalMemoryBytes: 32 * GIB,
+      readFile: fixtureReader({
+        '/proc/self/cgroup': '0::/docker/demo\n',
+        '/proc/self/mountinfo': '29 23 0:26 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n',
+        '/sys/fs/cgroup/docker/demo/memory.max': String(8 * GIB),
+        '/sys/fs/cgroup/docker/demo/memory.pressure': 'full avg10=1.00 avg60=0.00 avg300=0.00 total=0\n',
+        '/proc/meminfo': 'MemAvailable: 1 kB\n',
+      }),
+    });
+    expect(pressure.totalMemorySource).toBe('cgroup-v2');
+    expect(pressure.availableMemoryBytes).toBeUndefined();
+    expect(pressure.availableMemorySource).toBe('unavailable');
+    expect(pressure.memoryFullAvg10).toBe(1);
+    expect(evaluateWorkerAdmission(pressure).allowed).toBe(true);
+  });
+
+  it('blocks low available memory or critical full PSI and permits normal pressure', () => {
+    const normal = evaluateWorkerAdmission(hostPressure({
+      availableMemoryBytes: 12 * GIB,
+      availableMemorySource: 'host',
+      memoryFullAvg10: 1,
+      memoryFullAvg10Source: 'host',
+    }));
     expect(normal.allowed).toBe(true);
     expect(normal.policy.minAvailableMemoryBytes).toBe(8 * GIB);
     expect(normal.policy.maxMemoryFullAvg10).toBe(DEFAULT_MAX_MEMORY_FULL_AVG10);
 
-    expect(evaluateWorkerAdmission({
-      totalMemoryBytes: 32 * GIB,
+    expect(evaluateWorkerAdmission(hostPressure({
       availableMemoryBytes: 2 * GIB,
+      availableMemorySource: 'host',
       memoryFullAvg10: 1,
-      warnings: [],
-    }).allowed).toBe(false);
-    expect(evaluateWorkerAdmission({
-      totalMemoryBytes: 32 * GIB,
+      memoryFullAvg10Source: 'host',
+    })).allowed).toBe(false);
+    expect(evaluateWorkerAdmission(hostPressure({
       availableMemoryBytes: 12 * GIB,
+      availableMemorySource: 'host',
       memoryFullAvg10: 35,
-      warnings: [],
-    }).allowed).toBe(false);
+      memoryFullAvg10Source: 'host',
+    })).allowed).toBe(false);
   });
 
   it('honours policy overrides without changing any resident-worker ceiling', () => {
     expect(resolveWorkerPressurePolicy({
+      memoryAdmissionEnabled: false,
       minAvailableMemoryBytes: 2 * GIB,
       maxMemoryFullAvg10: 40,
       sessionMemoryMaxBytes: 6 * GIB,
     }, 32 * GIB)).toEqual({
+      memoryAdmissionEnabled: false,
       minAvailableMemoryBytes: 2 * GIB,
       maxMemoryFullAvg10: 40,
       sessionMemoryMaxBytes: 6 * GIB,
+      memoryAdmissionEnabledSource: 'config',
       minAvailableMemorySource: 'config',
       maxMemoryFullAvg10Source: 'config',
     });
+  });
+
+  it('explicitly disables admission without reading pressure files', () => {
+    const readFile = vi.fn(() => { throw new Error('must not read'); });
+    const decision = checkWorkerAdmission({ memoryAdmissionEnabled: false }, {
+      platform: 'linux',
+      totalMemoryBytes: 8 * GIB,
+      readFile,
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.policy.memoryAdmissionEnabled).toBe(false);
+    expect(readFile).not.toHaveBeenCalled();
   });
 
   it('fails open when proc pressure files are unavailable', () => {
@@ -69,7 +239,8 @@ describe('worker host-memory admission', () => {
     });
     const decision = evaluateWorkerAdmission(pressure);
     expect(decision.allowed).toBe(true);
-    expect(pressure.warnings).toHaveLength(2);
+    expect(pressure.warnings).toHaveLength(1);
+    expect(pressure.availableMemorySource).toBe('unavailable');
   });
 
   it('fails open when proc pressure files are present but malformed', () => {
@@ -86,5 +257,12 @@ describe('worker host-memory admission', () => {
       '/proc/meminfo has no valid MemAvailable value',
       '/proc/pressure/memory has no valid full avg10 value',
     ]);
+  });
+
+  it('keeps non-Linux admission fail-open', () => {
+    const pressure = readHostMemoryPressure({ platform: 'darwin', totalMemoryBytes: 16 * GIB });
+    expect(evaluateWorkerAdmission(pressure).allowed).toBe(true);
+    expect(pressure.totalMemorySource).toBe('host');
+    expect(pressure.availableMemorySource).toBe('unavailable');
   });
 });


### PR DESCRIPTION
## 改动

- 在 Linux 下解析当前进程的 cgroup v2 membership 与 mountinfo，读取有限层级及其祖先的 `memory.max`、`memory.current`、`memory.stat`、`memory.pressure`
- 按同一 cgroup 边界估算可用内存，避免混用宿主机总量、MemAvailable 与 PSI；仅在确认无有限 cgroup 约束时回退宿主机指标，读取不完整时保持 fail-open
- 容器默认 reserve 改为有效上限的 25%，避免小内存容器被 4 GiB 主机保底永久拦截
- 新增 `worker.memoryAdmissionEnabled` 与 `worker-budget set --memory-admission-enabled true|false`，显式关闭准入且不影响 session MemoryMax
- `worker-budget status` 展示启用状态、有效总量、可用量、PSI 及指标来源，并收紧参数校验

Closes #1343

## 影响面

- 影响所有经共享 `forkWorker` 路径创建或恢复的普通 worker，覆盖全部 CLI 与本地/远端 backend；不扩展到 adopt worker 和 v3 ephemeral worker
- Linux cgroup v2 有限约束优先使用容器/服务层级指标；无约束时保持原宿主机逻辑
- 非 Linux、cgroup 信息不可读或指标缺失时保持 fail-open
- `sessionMemoryMaxBytes` 的 systemd scope 行为不变

## 验证

- `bun run vitest run --project unit test/worker-budget.test.ts test/global-config.test.ts test/worker-budget-cli.test.ts`：3 个文件、52 个测试通过
- `bun run build`：通过（含 tsc、scripts/test-mocks typecheck、dashboard bundle 与 dist audit）
- `bun src/cli.ts worker-budget status`：本机 macOS 正确显示 enabled/default、host/unavailable 来源并 fail-open
- `bun run test`：运行 120 秒后超时；期间出现多组与本改动无关的现有 mock/import/环境失败，相关 changed-file suites 均通过
- `bun run daemon:restart`：未执行成功，本 checkout 无 Botmux 配置，命令在任何 daemon 变更前以“请先运行 botmux setup”退出