### PR TITLE
fix(feedback): 避免 SQLite 争锁阻塞 daemon

### DIFF
--- a/src/services/feedback-webhook-dispatcher.ts
+++ b/src/services/feedback-webhook-dispatcher.ts
@@ -152,19 +152,21 @@ export function startFeedbackWebhookDispatcher(options: {
     if (stopped || running) return;
     running = (async () => {
       const now = Date.now(), claimToken = randomUUID();
-      const rows = options.store.claimFeedbackOutbox({ now, limit: options.batchSize ?? 10, claimToken });
+      const claim = options.store.tryClaimFeedbackOutbox({ now, limit: options.batchSize ?? 10, claimToken });
+      if (!claim.done) return;
+      const rows = claim.rows;
       await Promise.all(rows.map(async row => {
         try {
           const secret = options.readSecret(row.destination.secretRef);
-          if (!secret) { options.store.rescheduleFeedbackOutbox(row.outboxId, claimToken, { now, nextAttemptAt: now, error: 'webhook_secret_missing', permanent: true }); return; }
+          if (!secret) { options.store.tryRescheduleFeedbackOutbox(row.outboxId, claimToken, { now, nextAttemptAt: now, error: 'webhook_secret_missing', permanent: true }); return; }
           const result = await dispatch({ destination: row.destination, event: row.event, secret, allowPrivateNetworks: options.allowPrivateNetworks, signal: controller.signal });
-          if (result.kind === 'delivered') { options.store.settleFeedbackOutboxDelivered(row.outboxId, claimToken, result.status ?? 200, new Date().toISOString()); return; }
+          if (result.kind === 'delivered') { options.store.trySettleFeedbackOutboxDelivered(row.outboxId, claimToken, result.status ?? 200, new Date().toISOString()); return; }
           const delay = result.kind === 'retry' ? computeRetryDelay({ attempts: row.attempts, retryAfter: result.retryAfter }) : 0;
-          options.store.rescheduleFeedbackOutbox(row.outboxId, claimToken, { now, nextAttemptAt: now + delay, error: result.error ?? `webhook_http_${result.status ?? 0}`, httpStatus: result.status, permanent: result.kind === 'failed' });
+          options.store.tryRescheduleFeedbackOutbox(row.outboxId, claimToken, { now, nextAttemptAt: now + delay, error: result.error ?? `webhook_http_${result.status ?? 0}`, httpStatus: result.status, permanent: result.kind === 'failed' });
         } catch (error) {
           options.onError?.(error);
           const delay = computeRetryDelay({ attempts: row.attempts });
-          options.store.rescheduleFeedbackOutbox(row.outboxId, claimToken, { now, nextAttemptAt: now + delay, error: String((error as Error)?.message ?? error).slice(0, 500), permanent: false });
+          options.store.tryRescheduleFeedbackOutbox(row.outboxId, claimToken, { now, nextAttemptAt: now + delay, error: String((error as Error)?.message ?? error).slice(0, 500), permanent: false });
         }
       }));
     })().finally(() => { running = undefined; });
@@ -173,7 +175,7 @@ export function startFeedbackWebhookDispatcher(options: {
   const installInterval = (): void => {
     if (stopped || timer) return;
     timer = setInterval(() => {
-      try { options.store.resetExpiredFeedbackOutboxClaims(Date.now(), options.staleClaimMs ?? 60_000); }
+      try { options.store.tryResetExpiredFeedbackOutboxClaims(Date.now(), options.staleClaimMs ?? 60_000); }
       catch (error) { options.onError?.(error); }
       void tick().catch(error => options.onError?.(error));
     }, options.intervalMs ?? 5_000);
@@ -186,7 +188,7 @@ export function startFeedbackWebhookDispatcher(options: {
     // webhooks never delivered until process restart). Report the bootstrap
     // failure but let the self-healing interval take over.
     try {
-      options.store.resetExpiredFeedbackOutboxClaims(Date.now(), options.staleClaimMs ?? 60_000);
+      options.store.tryResetExpiredFeedbackOutboxClaims(Date.now(), options.staleClaimMs ?? 60_000);
       await tick();
     } catch (error) {
       options.onError?.(error);

--- a/src/services/skill-feedback-store.ts
+++ b/src/services/skill-feedback-store.ts
@@ -719,19 +719,65 @@ export class SkillFeedbackStore {
       this.db.exec('COMMIT');
       const wanted = new Set(ids);
       return this.listFeedbackOutbox().filter(row => wanted.has(row.outboxId) && row.claimToken === input.claimToken);
-    } catch (error) { this.db.exec('ROLLBACK'); throw error; }
+    } catch (error) {
+      try { this.db.exec('ROLLBACK'); } catch { /* BEGIN may have failed before a transaction existed */ }
+      throw error;
+    }
+  }
+
+  /**
+   * Daemon-safe outbox claim. The shared feedback database is opened by every
+   * bot daemon, so a normal synchronous SQLite busy timeout can stall the whole
+   * event loop for seconds. Webhook polling is best-effort and recurring: fail
+   * fast on contention and let the next tick retry instead.
+   */
+  tryClaimFeedbackOutbox(input: { now: number; limit: number; claimToken: string }): { done: true; rows: Array<any> } | { done: false; busy: true } {
+    return this.withNonblockingBusy(() => this.claimFeedbackOutbox(input), rows => ({ done: true, rows }));
   }
 
   settleFeedbackOutboxDelivered(outboxId: string, claimToken: string, httpStatus: number, deliveredAt: string): boolean {
     return this.db.prepare(`UPDATE feedback_outbox SET status='delivered',last_http_status=?,delivered_at=?,claim_token=NULL,claimed_at=NULL WHERE outbox_id=? AND status='inflight' AND claim_token=?`).run(httpStatus, deliveredAt, outboxId, claimToken).changes === 1;
   }
+  trySettleFeedbackOutboxDelivered(outboxId: string, claimToken: string, httpStatus: number, deliveredAt: string): { done: true; changed: boolean } | { done: false; busy: true } {
+    return this.withNonblockingBusy(
+      () => this.settleFeedbackOutboxDelivered(outboxId, claimToken, httpStatus, deliveredAt),
+      changed => ({ done: true, changed }),
+    );
+  }
 
   rescheduleFeedbackOutbox(outboxId: string, claimToken: string, input: { now: number; nextAttemptAt: number; error: string; httpStatus?: number; permanent?: boolean }): boolean {
     return this.db.prepare(`UPDATE feedback_outbox SET status=?,next_attempt_at=?,last_error=?,last_http_status=?,claim_token=NULL,claimed_at=NULL WHERE outbox_id=? AND status='inflight' AND claim_token=?`).run(input.permanent ? 'failed' : 'pending', input.nextAttemptAt, input.error.slice(0, 500), input.httpStatus ?? null, outboxId, claimToken).changes === 1;
   }
+  tryRescheduleFeedbackOutbox(outboxId: string, claimToken: string, input: { now: number; nextAttemptAt: number; error: string; httpStatus?: number; permanent?: boolean }): { done: true; changed: boolean } | { done: false; busy: true } {
+    return this.withNonblockingBusy(
+      () => this.rescheduleFeedbackOutbox(outboxId, claimToken, input),
+      changed => ({ done: true, changed }),
+    );
+  }
 
   resetExpiredFeedbackOutboxClaims(now: number, staleAfterMs: number): number {
     return Number(this.db.prepare(`UPDATE feedback_outbox SET status='pending',claim_token=NULL,claimed_at=NULL WHERE status='inflight' AND claimed_at<=?`).run(now - staleAfterMs).changes);
+  }
+  tryResetExpiredFeedbackOutboxClaims(now: number, staleAfterMs: number): { done: true; changed: number } | { done: false; busy: true } {
+    return this.withNonblockingBusy(
+      () => this.resetExpiredFeedbackOutboxClaims(now, staleAfterMs),
+      changed => ({ done: true, changed }),
+    );
+  }
+
+  /** Borrow busy_timeout=0 for one fully synchronous operation. */
+  private withNonblockingBusy<T, R>(operation: () => T, success: (value: T) => R): R | { done: false; busy: true } {
+    this.db.exec('PRAGMA busy_timeout=0;');
+    try {
+      try {
+        return success(operation());
+      } catch (error) {
+        if (isSqliteBusyError(error)) return { done: false, busy: true };
+        throw error;
+      }
+    } finally {
+      this.db.exec('PRAGMA busy_timeout=5000;');
+    }
   }
 
   private reconcileTurnCompletion(deliveryId: string): TurnCompletionEventPayload | undefined {

--- a/test/feedback-webhook-dispatcher.test.ts
+++ b/test/feedback-webhook-dispatcher.test.ts
@@ -92,6 +92,27 @@ describe('feedback webhook attempt contract', () => {
     await dispatcher.stop(); db.close();
   });
 
+  it('does not block the daemon event loop when another process holds the feedback DB write lock', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-webhook-busy-')); dirs.push(dir);
+    const db = await SkillFeedbackStore.open(dir);
+    const blocker = await SkillFeedbackStore.open(dir);
+    (blocker as any).db.exec('BEGIN IMMEDIATE;');
+
+    const started = Date.now();
+    const dispatcher = startFeedbackWebhookDispatcher({
+      store: db,
+      readSecret: () => 'secret',
+      intervalMs: 100_000,
+    });
+    await dispatcher.ready;
+    expect(Date.now() - started).toBeLessThan(500);
+
+    (blocker as any).db.exec('COMMIT;');
+    await dispatcher.stop();
+    blocker.close();
+    db.close();
+  });
+
   it('stop(0) returns immediately without waiting the internal default window', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-webhook-stop0-')); dirs.push(dir);
     const db = await SkillFeedbackStore.open(dir);


### PR DESCRIPTION
## 问题

多个 bot daemon 共用 `botmux-feedback.sqlite`。Webhook dispatcher 使用同步 SQLite 写操作，并继承 5 秒 `busy_timeout`。数据库争锁时，单个 daemon 的 Node event loop 可能被同步阻塞；这会影响同进程里的 Worker 回执处理。

## 修改

- 为 webhook outbox 的 claim、settle、reschedule 和 stale-claim reset 增加非阻塞写入口。
- daemon 侧争锁时把 `busy_timeout` 临时设为 0，快速返回，交给后续轮询重试。
- 修正 `claimFeedbackOutbox` 在 `BEGIN IMMEDIATE` 失败后仍执行 `ROLLBACK`、可能覆盖原始错误的问题。
- 保留原有同步 API，避免影响 CLI 和其它调用方。

## 影响面

- 影响共享 feedback webhook dispatcher 的数据库写路径。
- 不修改 Worker、CLI adapter、会话路由和消息内容。
- SQLite 无争锁时行为保持不变；争锁时 webhook 继续采用已有的至少一次投递与 stale claim 恢复机制。

## 验证

- `tsc --noEmit`
- `vitest run --project unit test/feedback-webhook-dispatcher.test.ts test/feedback-outbox.test.ts test/feedback-store-v3-migration.test.ts test/turn-completion-events.test.ts test/turn-terminal-queue.test.ts`
- 结果：5 个测试文件、51 个测试全部通过。
- 新增争锁回归：另一个连接持有 SQLite 写锁时，dispatcher 在 500ms 内完成启动轮询，不等待 5 秒 `busy_timeout`。