### PR TITLE
fix(worker): 视口忙碌探针先剥 ANSI，修复 claude-code 翻绿守卫永不命中

### DIFF
--- a/src/utils/busy-probe.ts
+++ b/src/utils/busy-probe.ts
@@ -1,0 +1,14 @@
+import { stripAnsiScreenText } from './idle-detector.js';
+
+/** Tail region of a screen snapshot scanned for a CLI busyPattern.
+ *  Strips ANSI FIRST: captureViewport()/captureCurrentScreen() return tmux
+ *  `capture-pane -e` output with SGR/control codes at line starts (e.g.
+ *  `\x1b[39m  \x1b[38;5;211m⏵⏵ …`). Line-anchored busyPatterns (claude-code's
+ *  `^\s*[⏵⏸]…`) never match through that lead-in, so the pre-idle veto
+ *  silently never fires. Uses the SAME stripping as the IdleDetector PTY
+ *  stream path so both probes see identical text. */
+export function busyProbeRegion(content: string): string {
+  const lines = stripAnsiScreenText(content).split(/\r?\n/);
+  const tailLineCount = Math.max(12, Math.ceil(lines.length / 3));
+  return lines.slice(-tailLineCount).join('\n');
+}

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -12,6 +12,19 @@ const QUIESCENCE_MS = 2_000;
 /** Spinner guard — don't declare idle if spinner seen within this window */
 const SPINNER_GUARD_MS = 3_000;
 
+/** Strip ANSI escape sequences from a screen/PTY text before running
+ *  line-anchored adapter patterns. Shared by the IdleDetector PTY stream path
+ *  and the worker's viewport busy probes: both must see IDENTICAL text, since
+ *  patterns (e.g. claude-code's footer regex) anchor on `^` and tmux
+ *  `capture-pane -e` emits SGR color codes at line starts that break the
+ *  anchor unless stripped first. Cursor-forward sequences (`ESC[nC`) are
+ *  expanded to spaces because they represent real horizontal gaps. */
+export function stripAnsiScreenText(str: string): string {
+  return str
+    .replace(/\x1b\[(\d*)C/g, (_m, n) => ' '.repeat(Number(n) || 1))
+    .replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][0-9A-B]|\x1b\[[\?]?[0-9;]*[hlmsuJ]/g, '');
+}
+
 export class IdleDetector {
   private outputTail = '';
   private lastSpinnerAt = 0;
@@ -315,9 +328,7 @@ export class IdleDetector {
   }
 
   private stripAnsi(str: string): string {
-    return str
-      .replace(/\x1b\[(\d*)C/g, (_m, n) => ' '.repeat(Number(n) || 1))
-      .replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][0-9A-B]|\x1b\[[\?]?[0-9;]*[hlmsuJ]/g, '');
+    return stripAnsiScreenText(str);
   }
 }
 

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -18,11 +18,28 @@ const SPINNER_GUARD_MS = 3_000;
  *  patterns (e.g. claude-code's footer regex) anchor on `^` and tmux
  *  `capture-pane -e` emits SGR color codes at line starts that break the
  *  anchor unless stripped first. Cursor-forward sequences (`ESC[nC`) are
- *  expanded to spaces because they represent real horizontal gaps. */
+ *  expanded to spaces because they represent real horizontal gaps.
+ *
+ *  Covers what tmux capture-pane actually emits (verified against tmux 3.5a
+ *  grid output): CSI with `:` subparameters (e.g. `ESC[4:3m`), OSC hyperlinks
+ *  terminated by ST (`ESC \`) as well as BEL, charset designation (`ESC( B`),
+ *  and bare SO/SI charset-shift bytes (0x0e/0x0f). Leaving any of these at a
+ *  line start keeps a `^`-anchored pattern from binding. */
 export function stripAnsiScreenText(str: string): string {
   return str
+    // Cursor-forward: ESC[nC moves the cursor right n columns, which renders
+    // as real horizontal whitespace on screen — preserve it as spaces.
     .replace(/\x1b\[(\d*)C/g, (_m, n) => ' '.repeat(Number(n) || 1))
-    .replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][0-9A-B]|\x1b\[[\?]?[0-9;]*[hlmsuJ]/g, '');
+    // CSI: ESC[ params(0x30–0x3F, includes ':' ';' '?') intermediates final.
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    // OSC: ESC] ... terminated by BEL (0x07) or ST (ESC \).
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g, '')
+    // Charset designation: ESC ( B / ESC ) 0 etc.
+    .replace(/\x1b[()][0-9A-B]/g, '')
+    // Remaining two-byte escape sequences.
+    .replace(/\x1b[ -/]*[@-~]/g, '')
+    // Bare SO/SI (G0/G1 charset shift) control bytes.
+    .replace(/[\x0e\x0f]/g, '');
 }
 
 export class IdleDetector {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -358,7 +358,7 @@ import type {
 import { tmuxEnv, probeTmuxFunctionalWithRetry } from './setup/ensure-tmux.js';
 import { probeZmxVersion } from './setup/ensure-zmx.js';
 import { tmuxRestartJitterMs } from './core/tmux-recovery.js';
-import { IdleDetector } from './utils/idle-detector.js';
+import { IdleDetector, stripAnsiScreenText } from './utils/idle-detector.js';
 import {
   StuckDetector,
   matchHookReviewScreen,
@@ -12653,7 +12653,13 @@ function canCaptureBusyPatternScreen(be: Pick<SessionBackend, 'captureCurrentScr
 }
 
 function busyProbeRegion(content: string): string {
-  const lines = content.split(/\r?\n/);
+  // Strip ANSI FIRST: captureViewport()/captureCurrentScreen() return
+  // tmux `capture-pane -e` output with SGR color codes at line starts
+  // (e.g. `\x1b[39m  \x1b[38;5;211m⏵⏵ …`). Line-anchored busyPatterns
+  // (claude-code's `^\s*[⏵⏸]…`) never match through that lead-in, so the
+  // pre-idle veto silently never fires. Use the SAME stripping as the
+  // IdleDetector PTY stream path so both probes see identical text.
+  const lines = stripAnsiScreenText(content).split(/\r?\n/);
   const tailLineCount = Math.max(12, Math.ceil(lines.length / 3));
   return lines.slice(-tailLineCount).join('\n');
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -358,7 +358,8 @@ import type {
 import { tmuxEnv, probeTmuxFunctionalWithRetry } from './setup/ensure-tmux.js';
 import { probeZmxVersion } from './setup/ensure-zmx.js';
 import { tmuxRestartJitterMs } from './core/tmux-recovery.js';
-import { IdleDetector, stripAnsiScreenText } from './utils/idle-detector.js';
+import { IdleDetector } from './utils/idle-detector.js';
+import { busyProbeRegion } from './utils/busy-probe.js';
 import {
   StuckDetector,
   matchHookReviewScreen,
@@ -12650,18 +12651,6 @@ function captureBackendScreen(be: Pick<SessionBackend, 'captureCurrentScreen' | 
 
 function canCaptureBusyPatternScreen(be: Pick<SessionBackend, 'captureCurrentScreen' | 'captureViewport'>): boolean {
   return !!(be.captureCurrentScreen || be.captureViewport || renderer);
-}
-
-function busyProbeRegion(content: string): string {
-  // Strip ANSI FIRST: captureViewport()/captureCurrentScreen() return
-  // tmux `capture-pane -e` output with SGR color codes at line starts
-  // (e.g. `\x1b[39m  \x1b[38;5;211m⏵⏵ …`). Line-anchored busyPatterns
-  // (claude-code's `^\s*[⏵⏸]…`) never match through that lead-in, so the
-  // pre-idle veto silently never fires. Use the SAME stripping as the
-  // IdleDetector PTY stream path so both probes see identical text.
-  const lines = stripAnsiScreenText(content).split(/\r?\n/);
-  const tailLineCount = Math.max(12, Math.ceil(lines.length / 3));
-  return lines.slice(-tailLineCount).join('\n');
 }
 
 function deferPromptReadyWhileBusy(source: string, be: SessionBackend): boolean {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -25,6 +25,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { createCliAdapterSync } from '../src/adapters/cli/registry.js';
+import { stripAnsiScreenText } from '../src/utils/idle-detector.js';
 import { TERMINAL_CANCEL_COOLDOWN_MS } from '../src/adapters/backend/critical-control-key.js';
 import { createClaudeCodeAdapter } from '../src/adapters/cli/claude-code.js';
 import { createAidenAdapter } from '../src/adapters/cli/aiden.js';
@@ -2353,6 +2354,40 @@ describe('busyPattern', () => {
     // Shared def: seed/relay render the same Claude Code footer.
     expect(createCliAdapterSync('seed').busyPattern!.source).toBe(busy!.source);
     expect(createCliAdapterSync('relay').busyPattern!.source).toBe(busy!.source);
+  });
+
+  it('claude-code busy footer matches through the SGR color codes tmux capture-pane -e emits at line starts', () => {
+    // Regression: the worker's viewport busy probe reads captureViewport() =
+    // `tmux capture-pane -e -p`, whose rows carry SGR color codes. A live busy
+    // footer is literally (verbatim bytes from a busy pane):
+    //   \x1b[39m  \x1b[38;5;211m⏵⏵ bypass permissions on\x1b[38;5;246m (shift+tab to cycle) · esc to interrupt · ← for agents\x1b[39m
+    // The pattern anchors on `^\s*[⏵⏸]`, but the line STARTS with an ESC
+    // sequence, so the anchor never binds and the pre-idle veto never fires —
+    // the card flips green while Claude works. busyProbeRegion() must strip
+    // ANSI (via stripAnsiScreenText, the same pass the IdleDetector PTY stream
+    // uses) before running the pattern.
+    const busy = createCliAdapterSync('claude-code').busyPattern!;
+    const ansiBusyFooter =
+      '\x1b[39m  \x1b[38;5;211m⏵⏵ bypass permissions on\x1b[38;5;246m (shift+tab to cycle) · esc to interrupt · ← for agents\x1b[39m';
+    // The raw ANSI row does NOT match — this is the production bug.
+    expect(busy.test(ansiBusyFooter)).toBe(false);
+    // After the same strip busyProbeRegion applies, it matches.
+    expect(busy.test(stripAnsiScreenText(ansiBusyFooter))).toBe(true);
+    // Idle composer with the same SGR lead-in stays idle after stripping.
+    const ansiIdleFooter =
+      '\x1b[39m  \x1b[38;5;211m⏵⏵ bypass permissions on\x1b[38;5;246m (shift+tab to cycle) · ← for agents\x1b[39m';
+    expect(busy.test(stripAnsiScreenText(ansiIdleFooter))).toBe(false);
+    // Multi-line probe region: ANSI-colored prose above + ANSI busy footer at
+    // the bottom must still resolve to busy (and the idle variant must not).
+    const ansiRegion = [
+      '\x1b[36m● docs say esc to interrupt works\x1b[39m',
+      '\x1b[2m────────────────────────────────\x1b[22m',
+      '\x1b[1m❯\x1b[22m',
+      '\x1b[2m────────────────────────────────\x1b[22m',
+      ansiBusyFooter,
+    ].join('\n');
+    expect(busy.test(stripAnsiScreenText(ansiRegion))).toBe(true);
+    expect(busy.test(stripAnsiScreenText(ansiRegion.replace('· esc to interrupt · ', '')))).toBe(false);
   });
 
   it('traex matches spinner-anchored working labels and standalone queue strings but not prose or idle composer', () => {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -25,7 +25,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { createCliAdapterSync } from '../src/adapters/cli/registry.js';
-import { stripAnsiScreenText } from '../src/utils/idle-detector.js';
+import { busyProbeRegion } from '../src/utils/busy-probe.js';
 import { TERMINAL_CANCEL_COOLDOWN_MS } from '../src/adapters/backend/critical-control-key.js';
 import { createClaudeCodeAdapter } from '../src/adapters/cli/claude-code.js';
 import { createAidenAdapter } from '../src/adapters/cli/aiden.js';
@@ -2358,36 +2358,48 @@ describe('busyPattern', () => {
 
   it('claude-code busy footer matches through the SGR color codes tmux capture-pane -e emits at line starts', () => {
     // Regression: the worker's viewport busy probe reads captureViewport() =
-    // `tmux capture-pane -e -p`, whose rows carry SGR color codes. A live busy
-    // footer is literally (verbatim bytes from a busy pane):
+    // `tmux capture-pane -e -p`, whose rows carry SGR/control codes. A live
+    // busy footer is literally (verbatim bytes from a busy pane):
     //   \x1b[39m  \x1b[38;5;211m⏵⏵ bypass permissions on\x1b[38;5;246m (shift+tab to cycle) · esc to interrupt · ← for agents\x1b[39m
     // The pattern anchors on `^\s*[⏵⏸]`, but the line STARTS with an ESC
     // sequence, so the anchor never binds and the pre-idle veto never fires —
-    // the card flips green while Claude works. busyProbeRegion() must strip
-    // ANSI (via stripAnsiScreenText, the same pass the IdleDetector PTY stream
-    // uses) before running the pattern.
+    // the card flips green while Claude works. Assertions go through the REAL
+    // worker entry (busyProbeRegion, which strips ANSI before region/slice),
+    // so reverting the worker fix makes these fail.
     const busy = createCliAdapterSync('claude-code').busyPattern!;
     const ansiBusyFooter =
       '\x1b[39m  \x1b[38;5;211m⏵⏵ bypass permissions on\x1b[38;5;246m (shift+tab to cycle) · esc to interrupt · ← for agents\x1b[39m';
-    // The raw ANSI row does NOT match — this is the production bug.
-    expect(busy.test(ansiBusyFooter)).toBe(false);
-    // After the same strip busyProbeRegion applies, it matches.
-    expect(busy.test(stripAnsiScreenText(ansiBusyFooter))).toBe(true);
-    // Idle composer with the same SGR lead-in stays idle after stripping.
     const ansiIdleFooter =
       '\x1b[39m  \x1b[38;5;211m⏵⏵ bypass permissions on\x1b[38;5;246m (shift+tab to cycle) · ← for agents\x1b[39m';
-    expect(busy.test(stripAnsiScreenText(ansiIdleFooter))).toBe(false);
-    // Multi-line probe region: ANSI-colored prose above + ANSI busy footer at
-    // the bottom must still resolve to busy (and the idle variant must not).
-    const ansiRegion = [
+    // Raw ANSI rows do NOT match the bare pattern — that is the production
+    // bug; busyProbeRegion must repair them.
+    expect(busy.test(ansiBusyFooter)).toBe(false);
+    expect(busy.test(ansiIdleFooter)).toBe(false);
+    // Through the real viewport entry: busy resolves busy, idle stays idle.
+    expect(busy.test(busyProbeRegion(ansiBusyFooter))).toBe(true);
+    expect(busy.test(busyProbeRegion(ansiIdleFooter))).toBe(false);
+    // Multi-line region (tail slice + strip): colored prose above + colored
+    // busy footer at the bottom resolves busy; the same with the interrupt
+    // segment removed stays idle.
+    const region = (footer: string) => [
       '\x1b[36m● docs say esc to interrupt works\x1b[39m',
       '\x1b[2m────────────────────────────────\x1b[22m',
       '\x1b[1m❯\x1b[22m',
       '\x1b[2m────────────────────────────────\x1b[22m',
-      ansiBusyFooter,
+      footer,
     ].join('\n');
-    expect(busy.test(stripAnsiScreenText(ansiRegion))).toBe(true);
-    expect(busy.test(stripAnsiScreenText(ansiRegion.replace('· esc to interrupt · ', '')))).toBe(false);
+    expect(busy.test(busyProbeRegion(region(ansiBusyFooter)))).toBe(true);
+    expect(busy.test(busyProbeRegion(region(ansiIdleFooter)))).toBe(false);
+    // Control sequences tmux capture-pane can emit that a narrower stripper
+    // misses (Codex review): CSI with ':' subparameter, ST-terminated OSC 8
+    // hyperlink, and bare SO/SI charset-shift bytes at the line start. Each
+    // must be removed so the `^` anchor still binds; all must resolve busy.
+    const plainBusy = '⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt · ← for agents';
+    expect(busy.test(busyProbeRegion('\x1b[4:3m' + plainBusy))).toBe(true);
+    expect(busy.test(busyProbeRegion('\x1b]8;;http://x\x1b\\' + plainBusy + '\x1b]8;;\x1b\\'))).toBe(true);
+    expect(busy.test(busyProbeRegion('\x0f' + plainBusy))).toBe(true);
+    // Cursor-forward (ESC[nC) renders as real gaps and is preserved as spaces.
+    expect(busy.test(busyProbeRegion('\x1b[5C' + plainBusy))).toBe(true);
   });
 
   it('traex matches spinner-anchored working labels and standalone queue strings but not prose or idle composer', () => {

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -630,15 +630,20 @@ describe('worker pipe initial screen ordering', () => {
   });
 
   it('limits busy-pattern idle probes to the active status region', () => {
-    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
-    const helperStart = source.indexOf('function busyProbeRegion(content: string): string');
-    const probeStart = source.indexOf('function probeBusyPatternIdle');
-    const probeEnd = source.indexOf('function scheduleReattachIdleProbe');
-    const helper = source.slice(helperStart, probeEnd);
-    const probe = source.slice(probeStart, probeEnd);
+    // The region helper lives in src/utils/busy-probe.ts (it must strip ANSI
+    // before slicing — tmux capture-pane -e emits SGR codes at line starts
+    // that break the claude busyPattern's ^ anchor); the probe that calls it
+    // stays in worker.ts.
+    const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    const helperSource = readFileSync(join(process.cwd(), 'src/utils/busy-probe.ts'), 'utf8');
+    const probeStart = workerSource.indexOf('function probeBusyPatternIdle');
+    const probeEnd = workerSource.indexOf('function scheduleReattachIdleProbe');
+    const probe = workerSource.slice(probeStart, probeEnd);
 
-    expect(helperStart).toBeGreaterThan(-1);
-    expect(helper).toContain('const tailLineCount = Math.max(12, Math.ceil(lines.length / 3));');
+    expect(helperSource).toContain('export function busyProbeRegion(content: string): string');
+    expect(helperSource).toContain('stripAnsiScreenText(content).split(/\\r?\\n/)');
+    expect(helperSource).toContain('const tailLineCount = Math.max(12, Math.ceil(lines.length / 3));');
+    expect(probeStart).toBeGreaterThan(-1);
     expect(probe).toContain('cliAdapter.busyPattern.test(busyProbeRegion(content))');
     expect(probe).not.toContain('cliAdapter.busyPattern.test(content)');
   });


### PR DESCRIPTION
## 背景
#1317 给 claude-code adapter 补了 `busyPattern`/`idleToBusyPattern`（锚工作态页脚多出的「· esc to interrupt ·」段），以修复「Claude 还在工作、卡片却提前翻绿且钉死」。但 #1317 上线后用户仍复现同一现象。

## 根因（已实证）
翻绿前的视口否决 `deferPromptReadyWhileBusy` / `probeBusyPatternIdle` 读的是 `captureViewport()` = `tmux capture-pane -e -p`，**行内带 SGR 颜色码**。真实忙碌页脚字节形如：

```
\x1b[39m  \x1b[38;5;211m⏵⏵ bypass permissions on\x1b[38;5;246m (shift+tab to cycle) · esc to interrupt · ← for agents\x1b[39m
```

正则 `CLAUDE_BUSY_FOOTER_RE = /^\s*(?:[⏵⏸]+\s.*\bon\b|.*next try).*·\s*esc to interrupt\b/m` 用 `^\s*` 锚行首，但行首其实是 `ESC[39m` 而非空白 → 锚点失效 → **翻绿守卫永不命中**。空闲判定只剩 2s 静默一条负证据，长思考/网关停顿即错翻；错翻后的回拉（idleToBusy）只在下一帧重绘触发，也极易错过。

- 同一直方屏实测：`capture-pane -p`（纯文本）✅ 匹配；`capture-pane -e -p`（ANSI，探针实际读的）❌ 不匹配；strip 后 ✅。
- 生产日志（上线后全天）：claude 视口否决 **0 次**、回拉仅 **1 次**；同期 Pi（`/Working…/` 无行首锚）否决 458 次、Codex（`[^\r\n]{0,160}` 吃掉 ANSI 字节）8 次——机制活着，只有 claude 这条锚点被颜色码顶掉。
- #1317 单测与 242-pane 实测喂的都是**不带 `-e` 的纯文本**，测试格式与生产探针读到的格式不一致，故测试全绿、线上全瞎。

## 修法
- `busyProbeRegion()` 切行前先 `stripAnsiScreenText()`。
- 把 `IdleDetector` 私有的 `stripAnsi` 导出为共享 `stripAnsiScreenText`，让**视口探针与 PTY 流探针看到完全一致的文本**（含 `ESC[nC` 光标前移还原为空格；不做日志用的折叠空行/trim）。
- 三条视口 busyPattern 调用点（OMP quiet-final、deferPromptReadyWhileBusy、probeBusyPatternIdle）全部经 `busyProbeRegion`，一处修改全覆盖。

## 测试
- 新增回归用例：喂真实 SGR 前导的忙碌页脚 —— 裸 ANSI 不匹配（复现 bug）、`stripAnsiScreenText` 后匹配；带色空闲页脚/散文仍不误报；多行带色 region 忙碌命中、空闲不命中。
- 本机对在线 tmux pane 端到端验证修复后的 `busyProbeRegion`：忙碌 claude pane 命中、空闲 pane 0 误报。
- `vitest run --project unit test/cli-adapters.test.ts` 447 通过；`test/idle-detector.test.ts` 78 通过；`tsc --noEmit` 无错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)