### PR TITLE
fix(schedule): 修复任务变更后 Dashboard 状态不同步

### DIFF
--- a/src/services/schedule-store.ts
+++ b/src/services/schedule-store.ts
@@ -829,15 +829,14 @@ export function appendOutputLog(taskId: string, content: string): string {
 }
 
 /**
- * Watch schedules.json for changes from external processes (e.g. `botmux
- * schedule add` running outside the daemon) and emit dashboard events for
- * the diff. Idempotent — calling twice is a no-op.
+ * Reconcile committed schedules.json changes into dashboard events, including
+ * writes made by this daemon. Idempotent — calling twice is a no-op.
  *
- * The existing `load()` already reloads when the on-disk file identity differs
- * from `cachedFileVersion`, so this watcher snapshots the in-memory map, calls
- * `load()` to refresh, then diffs and publishes. fs.watch can fire multiple
- * events for one logical write — the identity guard inside `load()` makes
- * redundant fires no-ops, and an unchanged diff produces no events anyway.
+ * Keep the publication baseline separate from the business cache: mutations
+ * and ordinary reads can refresh that cache before fs.watch runs. Comparing
+ * against it would consume changes without notifying dashboard subscribers.
+ * Reconcile on the watcher turn so synchronous compound writes/rollbacks have
+ * finished; repeated filesystem notifications produce no additional diff.
  */
 let watcherStarted = false;
 export function startExternalWriteWatcher(): void {
@@ -854,9 +853,15 @@ export function startExternalWriteWatcher(): void {
       mutateTasks(working => ({ result: undefined, changed: !existsSync(fp) && working.size === 0 }));
     } catch { /* best effort */ }
   }
-  // Prime the cached file identity so the first watcher fire is comparable.
   load();
-  const state = stateFor(fp);
+  // Serialized public rows are immutable even if a caller retains a task
+  // object, and never retain protected precondition references in events.
+  const snapshot = (): Map<string, string> => new Map(
+    [...stateFor(fp).tasks].map(([id, { preconditionRef, ...task }]) => [
+      id, JSON.stringify({ ...task, hasPrecondition: !!preconditionRef }),
+    ]),
+  );
+  let published = snapshot();
 
   try {
     // Watch the directory, not the file inode: every commit atomically replaces
@@ -866,33 +871,29 @@ export function startExternalWriteWatcher(): void {
       try {
         if (filename && filename.toString() !== basename(fp)) return;
         if (!existsSync(fp)) return;
-        if (fileVersion(fp) === state.version) return;
-
-        // Snapshot in-memory state, then let load() refresh from disk.
-        // load() compares file identity internally and updates the cache.
-        const before = new Map<string, ScheduledTask>();
-        for (const [k, v] of state.tasks) before.set(k, v);
         load();
+        const current = snapshot();
+        const before = published;
+        published = current;
 
-        // Diff and publish.
-        for (const [id, t] of state.tasks) {
-          const prev = before.get(id);
-          if (!prev) {
-            const { preconditionRef: _preconditionRef, ...schedule } = t;
-            dashboardEventBus.publish({
-              type: 'schedule.created',
-              body: { schedule: { ...schedule, hasPrecondition: !!t.preconditionRef } },
-            });
-          } else if (JSON.stringify(prev) !== JSON.stringify(t)) {
-            const { preconditionRef: _preconditionRef, ...patch } = t;
-            dashboardEventBus.publish({
-              type: 'schedule.updated',
-              body: { id, patch: { ...patch, hasPrecondition: !!t.preconditionRef } },
-            });
+        for (const [id, serialized] of current) {
+          const previous = before.get(id);
+          if (previous === serialized) continue;
+          const row = JSON.parse(serialized) as Record<string, unknown>;
+          if (previous === undefined) {
+            dashboardEventBus.publish({ type: 'schedule.created', body: { schedule: row } });
+          } else {
+            // JSON omits undefined. Explicit nulls clear fields such as an old
+            // error or thread bookmark in the dashboard's merge-based cache.
+            const patch = { ...row };
+            for (const key of Object.keys(JSON.parse(previous))) {
+              if (!(key in row)) patch[key] = null;
+            }
+            dashboardEventBus.publish({ type: 'schedule.updated', body: { id, patch } });
           }
         }
         for (const id of before.keys()) {
-          if (!state.tasks.has(id)) {
+          if (!current.has(id)) {
             dashboardEventBus.publish({ type: 'schedule.deleted', body: { id } });
           }
         }

--- a/src/services/schedule-store.ts
+++ b/src/services/schedule-store.ts
@@ -862,6 +862,7 @@ export function startExternalWriteWatcher(): void {
     ]),
   );
   let published = snapshot();
+  const announced = new Set(published.keys());
 
   try {
     // Watch the directory, not the file inode: every commit atomically replaces
@@ -880,13 +881,13 @@ export function startExternalWriteWatcher(): void {
           const previous = before.get(id);
           if (previous === serialized) continue;
           const row = JSON.parse(serialized) as Record<string, unknown>;
-          if (previous === undefined) {
+          if (!announced.has(id)) {
             dashboardEventBus.publish({ type: 'schedule.created', body: { schedule: row } });
           } else {
             // JSON omits undefined. Explicit nulls clear fields such as an old
             // error or thread bookmark in the dashboard's merge-based cache.
             const patch = { ...row };
-            for (const key of Object.keys(JSON.parse(previous))) {
+            for (const key of Object.keys(JSON.parse(previous ?? '{}'))) {
               if (!(key in row)) patch[key] = null;
             }
             dashboardEventBus.publish({ type: 'schedule.updated', body: { id, patch } });
@@ -899,6 +900,17 @@ export function startExternalWriteWatcher(): void {
         }
       } catch (err) {
         logger.debug(`[schedule-store] watch handler error: ${err}`);
+      }
+    });
+    // Dashboard mutations can announce a richer row before fs.watch runs.
+    // Reconcile it with an update, not another create that would replace its
+    // presentation metadata. Track lifecycle only: a partial eager update
+    // must not consume other committed fields still awaiting publication.
+    dashboardEventBus.subscribe(event => {
+      if (event.type === 'schedule.created' && stateFor(fp).tasks.has(event.body.schedule.id)) {
+        announced.add(event.body.schedule.id);
+      } else if (event.type === 'schedule.deleted') {
+        announced.delete(event.body.id);
       }
     });
     logger.info(`[schedule-store] Watching ${fp} for external writes`);

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   applySessionOwnerEnv,
   scrubExternalMemberEnv,
@@ -213,6 +215,7 @@ describe('redactChildEnv()', () => {
     // only when VAR is unset, distinguishing "unset" from "set to the string
     // 'undefined'". Run against the real bundled node-pty + /bin/sh.
     const pty = await import('node-pty');
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-child-env-'));
     const prev = process.env.LARK_APP_ID;
     const prevSentinel = process.env[PM2_GRACEFUL_EXIT_CODE_ENV];
     process.env.LARK_APP_ID = 'cli_parent_must_not_leak';
@@ -221,57 +224,30 @@ describe('redactChildEnv()', () => {
     process.env[PM2_GRACEFUL_EXIT_CODE_ENV] = '90';
     try {
       const env = redactChildEnv(process.env) as { [k: string]: string };
+      // This guard tests environment inheritance through a real PTY spawn.
+      // Read the child's report from a private file: terminal data and exit
+      // events can race, but the report is complete before the shell exits.
+      const reportPath = join(dir, 'env-report');
       const script =
-        'if [ -z "${LARK_APP_ID+x}" ]; then echo "R=UNSET"; else echo "R=SET[$LARK_APP_ID]"; fi; ' +
-        `if [ -z "\${${PM2_GRACEFUL_EXIT_CODE_ENV}+x}" ]; then echo "S=UNSET"; else echo "S=SET[\$${PM2_GRACEFUL_EXIT_CODE_ENV}]"; fi`;
-      const out: string = await new Promise((resolve, reject) => {
-        const p = pty.spawn('/bin/sh', ['-c', script], {
-          name: 'xterm-256color', cols: 80, rows: 24, cwd: '/tmp', env,
+        '{ if [ -z "${LARK_APP_ID+x}" ]; then echo "R=UNSET"; else echo "R=SET[$LARK_APP_ID]"; fi; ' +
+        `if [ -z "\${${PM2_GRACEFUL_EXIT_CODE_ENV}+x}" ]; then echo "S=UNSET"; else echo "S=SET[\$${PM2_GRACEFUL_EXIT_CODE_ENV}]"; fi; } > "$1"`;
+      const exitCode = await new Promise<number>((resolve, reject) => {
+        const p = pty.spawn('/bin/sh', ['-c', script, 'env-probe', reportPath], {
+          name: 'xterm-256color', cols: 80, rows: 24, cwd: dir, env,
         });
-        let buf = '';
-        let settled = false;
-        // node-pty delivers onData and onExit on independent paths: the child can
-        // be reaped before the pty's pending output has been drained, so
-        // resolving straight from onExit can hand back an empty string. That
-        // surfaces as `Expected to contain "R=UNSET" / Received: ""` under CI
-        // load, which reads like a real leak but is only a lost read.
-        //
-        // So settle on having BOTH answers, and let exit only START a short grace
-        // period rather than decide. If the grace period expires with the output
-        // still incomplete, REJECT with the raw buffer instead of resolving it:
-        // the whole point is that a lost read must never again be reported as a
-        // leak-shaped assertion failure. Resolving '' here would rebuild the very
-        // trap this guard exists to remove.
-        const hasBothAnswers = () => /\bR=(UNSET|SET)/.test(buf) && /\bS=(UNSET|SET)/.test(buf);
-        const finish = (settle: () => void) => {
-          if (settled) return;
-          settled = true;
-          settle();
-        };
-        const fail = () => finish(() => reject(new Error(
-          'pty output incomplete — a lost read, not an env leak. '
-          + `Expected both R= and S= answers, got ${JSON.stringify(buf)}`,
-        )));
-        const guard = setTimeout(fail, 10_000);
-        guard.unref?.();
-        p.onData((d) => {
-          buf += d;
-          if (hasBothAnswers()) {
-            clearTimeout(guard);
-            finish(() => resolve(buf));
-          }
-        });
-        p.onExit(() => {
-          // Exit is a deadline, not the signal: give already-queued reads a
-          // moment to land, then decide — complete output resolves, incomplete
-          // output fails loudly as a fixture problem.
-          setTimeout(() => {
-            clearTimeout(guard);
-            if (hasBothAnswers()) finish(() => resolve(buf));
-            else fail();
-          }, 250);
+        const guard = setTimeout(() => {
+          exit.dispose();
+          try { p.kill(); } catch { /* already exited */ }
+          reject(new Error('pty environment probe timed out'));
+        }, 10_000);
+        const exit = p.onExit(({ exitCode }) => {
+          clearTimeout(guard);
+          exit.dispose();
+          resolve(exitCode);
         });
       });
+      expect(exitCode).toBe(0);
+      const out = readFileSync(reportPath, 'utf8');
       expect(out).toContain('R=UNSET');
       expect(out).toContain('S=UNSET');
       expect(out).not.toContain('undefined');
@@ -280,8 +256,9 @@ describe('redactChildEnv()', () => {
       else process.env.LARK_APP_ID = prev;
       if (prevSentinel === undefined) delete process.env[PM2_GRACEFUL_EXIT_CODE_ENV];
       else process.env[PM2_GRACEFUL_EXIT_CODE_ENV] = prevSentinel;
+      rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 });
 
 describe('stripDashboardH5Env()', () => {

--- a/test/codex-app-threads.test.ts
+++ b/test/codex-app-threads.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   generateCodexAppThreadTitle,
   setCodexAppThreadName,
@@ -159,7 +159,13 @@ describe('generateCodexAppThreadTitle', () => {
     const logPath = join(dir, 'requests.jsonl');
     const pidPath = join(dir, 'pid');
 
-    const title = await generateCodexAppThreadTitle({
+    // Keep the deadline still while the real subprocess starts. Its response to
+    // the fixture's tool request proves turn/started has reached the client;
+    // only then expire the title deadline, independently of machine load.
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+    let forceClose: (() => void) | undefined;
+    let completed = false;
+    const pendingTitle = generateCodexAppThreadTitle({
       sourceText: '这个标题生成永远不会完成',
       codexBin: FAKE_CODEX,
       env: fakeCodexEnv(dir, {
@@ -169,12 +175,32 @@ describe('generateCodexAppThreadTitle', () => {
       }),
       timeoutMs: 100,
       detached: true,
+      registerForceClose: close => {
+        forceClose = close;
+        return () => { forceClose = undefined; };
+      },
     });
-
-    expect(title).toBeUndefined();
-    if (!existsSync(logPath)) {
-      expect(existsSync(pidPath)).toBe(false);
-      return;
+    try {
+      const readyDeadline = performance.now() + 5000;
+      let ready = false;
+      while (performance.now() < readyDeadline) {
+        if (existsSync(logPath)) {
+          ready = readFileSync(logPath, 'utf8').trim().split('\n')
+            .some(line => JSON.parse(line).id === 9001);
+          if (ready) break;
+        }
+        await new Promise<void>(resolve => setImmediate(resolve));
+      }
+      expect(ready, 'fake app-server must reach the active title turn').toBe(true);
+      vi.advanceTimersByTime(100);
+      // Cleanup still exercises real RPC and process reaping with real timers.
+      vi.useRealTimers();
+      expect(await pendingTitle).toBeUndefined();
+      completed = true;
+    } finally {
+      vi.useRealTimers();
+      if (!completed) forceClose?.();
+      await pendingTitle;
     }
     const requests = readFileSync(logPath, 'utf8')
       .trim()
@@ -185,7 +211,7 @@ describe('generateCodexAppThreadTitle', () => {
       'thread/unsubscribe',
     ]));
 
-    if (!existsSync(pidPath)) return;
+    expect(existsSync(pidPath)).toBe(true);
     const pid = Number(readFileSync(pidPath, 'utf8'));
     const reapDeadline = Date.now() + 2000;
     while (Date.now() < reapDeadline) {
@@ -197,7 +223,7 @@ describe('generateCodexAppThreadTitle', () => {
       }
     }
     throw new Error(`title generator fake Codex app-server ${pid} was not reaped`);
-  });
+  }, 15_000);
 });
 
 describe('setCodexAppThreadName', () => {

--- a/test/schedule-store-dashboard-sync.test.ts
+++ b/test/schedule-store-dashboard-sync.test.ts
@@ -125,6 +125,22 @@ describe('schedule store → dashboard notifications', () => {
     expect(agg.getSchedules()).toEqual([]);
   });
 
+  it('preserves enriched rows already announced by the dashboard create endpoint', async () => {
+    const { store, agg, events, flush } = await setup();
+    const { dashboardEventBus } = await import('../src/core/dashboard-events.js');
+    const task = store.createTask({ ...params, id: 'dashboard-created' });
+    dashboardEventBus.publish({
+      type: 'schedule.created',
+      body: { schedule: { ...task, botName: 'Reporter', preconditionSource: 'inline' } },
+    });
+    store.updateTask(task.id, { enabled: false });
+    flush();
+    expect(agg.getSchedules().find(t => t.id === task.id)).toMatchObject({
+      botName: 'Reporter', preconditionSource: 'inline', enabled: false,
+    });
+    expect(events.filter(e => e.type === 'schedule.created')).toHaveLength(1);
+  });
+
   it('does not publish sibling bot changes', async () => {
     const { store, agg, events, flush } = await setup();
     store.createTask({ ...params, id: 'sibling', larkAppId: 'cli_schedule_sync_other' });

--- a/test/schedule-store-dashboard-sync.test.ts
+++ b/test/schedule-store-dashboard-sync.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { DashboardEvent } from '../src/core/dashboard-events.js';
+
+let tempDir: string;
+const watcher = vi.hoisted(() => ({ callback: undefined as undefined | ((event: string, filename: string | null) => void) }));
+vi.mock('node:fs', async importOriginal => ({
+  ...await importOriginal<typeof import('node:fs')>(),
+  watch: vi.fn((_path, _options, callback) => { watcher.callback = callback; }),
+}));
+vi.mock('../src/config.js', () => ({ config: { session: { get dataDir() { return join(tempDir, 'data'); } } } }));
+vi.mock('../src/utils/logger.js', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+const app = 'cli_schedule_sync_test';
+const params = {
+  id: 'task', name: 'Daily report', schedule: '0 12 * * *',
+  parsed: { kind: 'cron' as const, expr: '0 12 * * *', display: 'daily' },
+  prompt: 'Report public news', workingDir: '/workspace', chatId: 'oc_test', larkAppId: app,
+};
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'schedule-dashboard-sync-'));
+  watcher.callback = undefined;
+  vi.resetModules();
+});
+afterEach(() => { rmSync(tempDir, { recursive: true, force: true }); });
+
+async function setup() {
+  const store = await import('../src/services/schedule-store.js');
+  const { dashboardEventBus } = await import('../src/core/dashboard-events.js');
+  const { Aggregator } = await import('../src/dashboard/aggregator.js');
+  store.setScheduleScope(app);
+  store.createTask(params);
+  const agg = new Aggregator();
+  agg.hydrateSchedules(app, store.listTasks());
+  store.startExternalWriteWatcher();
+  const events: DashboardEvent[] = [];
+  dashboardEventBus.subscribe(event => {
+    events.push(event);
+    // Use the actual wire representation: undefined fields disappear in SSE.
+    agg.applyEvent(app, JSON.parse(JSON.stringify(event)));
+  });
+  const flush = () => watcher.callback!('rename', 'schedules.json');
+  const replace = (rows: unknown) => {
+    const file = store.scheduleFilePathFor(app);
+    writeFileSync(file + '.test', JSON.stringify(rows));
+    renameSync(file + '.test', file);
+  };
+  return { store, agg, events, flush, replace };
+}
+
+describe('schedule store → dashboard notifications', () => {
+  it('publishes an in-process deletion even after the store cache advances', async () => {
+    const { store, agg, events, flush } = await setup();
+    store.removeTask('task');
+    expect(store.listTasks()).toEqual([]);
+    flush();
+    expect(agg.getSchedules()).toEqual([]);
+    expect(events.map(e => e.type)).toEqual(['schedule.deleted']);
+  });
+
+  it('publishes create, pause, resume and dispatch status from in-process writes', async () => {
+    const { store, agg, flush } = await setup();
+    store.createTask({ ...params, id: 'second' });
+    flush();
+    expect(agg.getSchedules()).toHaveLength(2);
+    store.updateTask('task', { enabled: false });
+    flush();
+    expect(agg.getSchedules().find(t => t.id === 'task')?.enabled).toBe(false);
+    store.updateTask('task', { enabled: true, nextRunAt: '2030-01-01T04:00:00.000Z' });
+    store.markRun('task', true);
+    flush();
+    expect(agg.getSchedules().find(t => t.id === 'task')).toMatchObject({
+      enabled: true, nextRunAt: '2030-01-01T04:00:00.000Z', lastStatus: 'ok', lastRunAt: expect.any(String),
+    });
+  });
+
+  it('does not lose an external deletion when a read refreshes the cache first', async () => {
+    const { store, agg, events, flush, replace } = await setup();
+    replace({});
+    expect(store.listTasks()).toEqual([]);
+    flush();
+    expect(agg.getSchedules()).toEqual([]);
+    expect(events.map(e => e.type)).toEqual(['schedule.deleted']);
+  });
+
+  it('publishes external changes without a prior read and ignores repeated watcher callbacks', async () => {
+    const { agg, events, flush, replace } = await setup();
+    replace({});
+    flush();
+    flush();
+    expect(agg.getSchedules()).toEqual([]);
+    expect(events.map(e => e.type)).toEqual(['schedule.deleted']);
+  });
+
+  it('clears removed fields across JSON transport and keeps precondition references private', async () => {
+    const { store, agg, events, flush } = await setup();
+    store.updateTask('task', { lastError: 'previous failure', preconditionRef: 'private-reference' });
+    flush();
+    expect(agg.getSchedules()[0]).toMatchObject({ lastError: 'previous failure', hasPrecondition: true });
+    store.updateTask('task', { lastError: undefined, preconditionRef: undefined });
+    flush();
+    expect(agg.getSchedules()[0]).toMatchObject({ lastError: null, hasPrecondition: false });
+    expect(JSON.stringify(events)).not.toContain('private-reference');
+    expect(JSON.stringify(events)).not.toContain('preconditionRef');
+  });
+
+  it('publishes only the final state of a synchronous rollback', async () => {
+    const { store, agg, events, flush } = await setup();
+    store.updateTask('task', { chatId: 'oc_temporary' });
+    store.updateTask('task', { chatId: params.chatId });
+    flush();
+    expect(events).toEqual([]);
+    expect(agg.getSchedules()[0].chatId).toBe(params.chatId);
+  });
+
+  it('notifies automatic removal after the last scheduled repetition', async () => {
+    const { store, agg, flush } = await setup();
+    store.updateTask('task', { repeat: { times: 1, completed: 0 } });
+    flush();
+    store.markRun('task', true);
+    flush();
+    expect(agg.getSchedules()).toEqual([]);
+  });
+
+  it('does not publish sibling bot changes', async () => {
+    const { store, agg, events, flush } = await setup();
+    store.createTask({ ...params, id: 'sibling', larkAppId: 'cli_schedule_sync_other' });
+    flush();
+    expect(events).toEqual([]);
+    expect(agg.getSchedules().map(t => t.id)).toEqual(['task']);
+  });
+});

--- a/test/schedule-store-dashboard-watch.test.ts
+++ b/test/schedule-store-dashboard-watch.test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnTsEvalWithRepoImports } from './helpers/ts-runner.js';
+
+it('reconciles real filesystem notifications after local writes and early reads', async () => {
+  const scratch = mkdtempSync(join(tmpdir(), 'schedule-watch-'));
+  const source = `
+    import assert from 'node:assert/strict';
+    import { writeFileSync, renameSync } from 'node:fs';
+    import * as store from './src/services/schedule-store.ts';
+    import { dashboardEventBus } from './src/core/dashboard-events.ts';
+    import { Aggregator } from './src/dashboard/aggregator.ts';
+    const app = 'cli_schedule_watch_test';
+    store.setScheduleScope(app);
+    const task = store.createTask({
+      id: 'task', name: 'Report', schedule: '0 12 * * *',
+      parsed: { kind: 'cron', expr: '0 12 * * *', display: 'daily' },
+      prompt: 'Public news', workingDir: process.env.SESSION_DATA_DIR,
+      chatId: 'oc_test', larkAppId: app,
+    });
+    const agg = new Aggregator();
+    agg.hydrateSchedules(app, store.listTasks());
+    store.startExternalWriteWatcher();
+    dashboardEventBus.subscribe(event => agg.applyEvent(app, JSON.parse(JSON.stringify(event))));
+    async function until(predicate) {
+      const deadline = Date.now() + 5000;
+      while (!predicate()) {
+        assert.ok(Date.now() < deadline, 'dashboard did not converge');
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+    }
+    store.removeTask(task.id);
+    await until(() => agg.getSchedules().length === 0);
+    store.createTask({ ...task, id: 'next' });
+    await until(() => agg.getSchedules().length === 1);
+    const file = store.scheduleFilePathFor(app);
+    writeFileSync(file + '.test', '{}');
+    renameSync(file + '.test', file);
+    assert.equal(store.listTasks().length, 0);
+    await until(() => agg.getSchedules().length === 0);
+    console.log('WATCHER_OK');
+  `;
+  try {
+    const result = await new Promise<{ code: number | null; output: string }>((resolve, reject) => {
+      const child = spawnTsEvalWithRepoImports(source, {
+        env: { ...process.env, SESSION_DATA_DIR: join(scratch, 'data') },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 15_000,
+      });
+      let output = '';
+      child.stdout?.on('data', chunk => { output += chunk; });
+      child.stderr?.on('data', chunk => { output += chunk; });
+      child.on('error', reject);
+      child.on('close', code => resolve({ code, output }));
+    });
+    expect(result.output).toContain('WATCHER_OK');
+    expect(result.code).toBe(0);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
飞书或 CLI 删除、暂停定时任务后，daemon 已使用新状态，Dashboard 却可能继续显示旧任务或旧状态；手动触发后的执行时间也会滞留。文件监听器使用业务缓存作为比较基准，而本进程写入或抢先发生的读取已经刷新了该缓存，导致变更事件被跳过。

生产代码仅调整任务存储的通知逻辑：使用独立、不可变的公开任务快照比较已提交状态，统一覆盖本进程写入与外部文件变更。移除的可选字段通过显式 null 清除，避免 JSON/SSE 丢弃 undefined 后残留旧错误信息。重复文件通知不重复发布差异，同步复合操作及回滚只发布最终状态，前置条件引用不进入事件。已被 Dashboard 创建入口提前发布的任务按更新合并，保留机器人名称等展示信息。

影响范围：所有 CLI、会话后端及 IM 共用的定时任务状态展示；不改变任务执行位置、排期、权限或存储格式。现有启动及重连快照同步保留。

同时修复标题超时测试的时序竞争：先通过协议往返确认已进入生成阶段，再推进测试时钟，严格验证中断、取消订阅及进程回收。此部分仅涉及测试，不改变运行时行为。

验证：
- 9 项确定性定时任务同步回归全部通过，覆盖删除、创建、启停、执行状态、自动删除、跨机器人隔离、回滚、重复事件、清空可选字段及提前发布的展示信息。
- Node 下存储、Dashboard、执行上下文、前置条件、文件监听、标题、环境隔离及 tmux 相关的 9 个测试文件，共 155 项通过。
- `bun test test/schedule-store-dashboard-watch.test.ts test/codex-app-threads.test.ts test/child-env.test.ts test/tmux-startup-storm-recovery.test.ts`：Bun 1.4.2 下 66 项通过，1 项按主干设计跳过；跳过的真实 PTY 环境隔离用例在 Node 下通过。
- 真实 fs.watch 回归在 Node 和 Bun 下均通过，覆盖本进程删除、再次创建及外部删除后抢先读取。
- 标题超时用例增加 300 毫秒模拟服务启动延迟后，旧测试失败、修复后通过。
- `bun run build`、`git diff --check` 通过。

实验使用隔离的临时任务数据，未部署到运行中的服务。
