### PR TITLE
fix(actor): 兼容共享 tmux 的陈旧祖先环境

### DIFF
--- a/src/cli/current-actor.ts
+++ b/src/cli/current-actor.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readlinkSync } from 'node:fs';
+import { basename } from 'node:path';
 import { loopbackFetchImpl } from '../core/loopback-fetch.js';
 
 export const CURRENT_ACTOR_SCHEMA = 'botmux.current-actor.v2' as const;
@@ -81,6 +82,31 @@ function processEnvironment(pid: number, procRoot: string): Record<string, strin
   } catch { return undefined; }
 }
 
+/**
+ * A pane process is parented by the long-lived tmux server, not by the tmux
+ * client that created the session. The server's kernel-held environment is a
+ * launch-time snapshot: `tmux set-environment -gu` can scrub tmux's global
+ * table, but cannot rewrite `/proc/<server>/environ`. Treat the real server as
+ * a lineage boundary so stale routing from an older BotMux session is neither
+ * trusted nor compared with the current pane's fresh routing.
+ *
+ * Require both the kernel process name and executable basename. A process that
+ * merely changes argv/comm to look like tmux must not truncate attestation.
+ */
+function isTmuxServerProcess(pid: number, procRoot: string): boolean {
+  try {
+    const raw = readFileSync(`${procRoot}/${pid}/stat`, 'utf8');
+    const openParen = raw.indexOf('(');
+    const closeParen = raw.lastIndexOf(')');
+    if (openParen < 0 || closeParen <= openParen
+      || raw.slice(openParen + 1, closeParen) !== 'tmux: server') return false;
+    const executable = basename(readlinkSync(`${procRoot}/${pid}/exe`)).replace(/ \(deleted\)$/, '');
+    return executable === 'tmux';
+  } catch {
+    return false;
+  }
+}
+
 /** Read routing only from an already-running BotMux CLI ancestor. A child can
  * mutate its own env but cannot rewrite its parent's kernel-held environment. */
 export function resolveBotmuxAncestorContext(
@@ -93,6 +119,7 @@ export function resolveBotmuxAncestorContext(
   const contexts: BotmuxAncestorContext[] = [];
   let pid = startPid;
   for (let depth = 0; depth < 32 && pid > 1; depth++) {
+    if (isTmuxServerProcess(pid, procRoot)) break;
     const env = processEnvironment(pid, procRoot);
     if (!env) throw new CurrentActorError('current actor ancestor attestation failed');
     if (env.BOTMUX === '1') {

--- a/test/current-actor.test.ts
+++ b/test/current-actor.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -13,11 +13,18 @@ import {
   resolveCurrentActor,
 } from '../src/cli/current-actor.js';
 
-function writeProcEnv(root: string, pid: number, parent: number, env: Record<string, string>): void {
+function writeProcEnv(
+  root: string,
+  pid: number,
+  parent: number,
+  env: Record<string, string>,
+  options: { comm?: string; exe?: string } = {},
+): void {
   const dir = join(root, String(pid));
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, 'stat'), `${pid} (proc) S ${parent} 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 100\n`);
+  writeFileSync(join(dir, 'stat'), `${pid} (${options.comm ?? 'proc'}) S ${parent} 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 100\n`);
   writeFileSync(join(dir, 'environ'), Object.entries(env).map(([key, value]) => `${key}=${value}`).join('\0'));
+  if (options.exe) symlinkSync(options.exe, join(dir, 'exe'));
 }
 
 describe('current actor client contract', () => {
@@ -42,6 +49,38 @@ describe('current actor client contract', () => {
     writeProcEnv(root, 10, 1, {
       BOTMUX: '1', BOTMUX_SESSION_ID: 's2', BOTMUX_LARK_APP_ID: 'cli_app', BOTMUX_DAEMON_IPC_PORT: '7951',
     });
+    expect(() => resolveBotmuxAncestorContext(20, root)).toThrow(CurrentActorError);
+  });
+
+  it.skipIf(process.platform !== 'linux')('stops before a shared tmux server with stale BotMux routing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'actor-env-'));
+    const current = {
+      BOTMUX: '1', BOTMUX_SESSION_ID: 's-current', BOTMUX_LARK_APP_ID: 'cli_current',
+      BOTMUX_DAEMON_IPC_PORT: '7951',
+    };
+    const stale = {
+      BOTMUX: '1', BOTMUX_SESSION_ID: 's-stale', BOTMUX_LARK_APP_ID: 'cli_stale',
+      BOTMUX_DAEMON_IPC_PORT: '7952',
+    };
+    writeProcEnv(root, 30, 20, current);
+    writeProcEnv(root, 20, 10, current);
+    writeProcEnv(root, 10, 5, stale, { comm: 'tmux: server', exe: '/usr/bin/tmux' });
+    writeProcEnv(root, 5, 1, stale);
+
+    expect(resolveBotmuxAncestorContext(30, root)).toEqual({
+      sessionId: 's-current', larkAppId: 'cli_current', ipcPort: 7951,
+    });
+  });
+
+  it.skipIf(process.platform !== 'linux')('does not trust a process merely named like a tmux server', () => {
+    const root = mkdtempSync(join(tmpdir(), 'actor-env-'));
+    writeProcEnv(root, 20, 10, {
+      BOTMUX: '1', BOTMUX_SESSION_ID: 's1', BOTMUX_LARK_APP_ID: 'cli_app', BOTMUX_DAEMON_IPC_PORT: '7951',
+    });
+    writeProcEnv(root, 10, 1, {
+      BOTMUX: '1', BOTMUX_SESSION_ID: 's2', BOTMUX_LARK_APP_ID: 'cli_app', BOTMUX_DAEMON_IPC_PORT: '7951',
+    }, { comm: 'tmux: server', exe: '/tmp/not-tmux' });
+
     expect(() => resolveBotmuxAncestorContext(20, root)).toThrow(CurrentActorError);
   });
 


### PR DESCRIPTION
## 改了什么

- 将真实 tmux server 进程视为 `actor current` 祖先路由遍历边界
- 通过 `/proc/<pid>/stat` 进程名与 `/proc/<pid>/exe` 可执行文件双重确认，避免只伪装进程名就截断校验
- 新增共享 tmux 陈旧路由和伪装进程名的回归测试

## 为什么

共享 tmux server 的内核环境是启动时快照。即使 BotMux 清理了 tmux global environment table，也无法改写 `/proc/<server>/environ`。旧的 `BOTMUX_*` 与当前 pane 的新路由发生冲突时，`actor current` 会在联系 daemon 前 fail closed。

## 影响面

- 修复 Linux + tmux backend 下的祖先路由解析
- PTY、zellij、zmx 等其他后端行为不变
- daemon 侧 socket、进程谱系、CLI generation、当前 turn 与 sender 校验不变
- 无法读取或无法双重确认 tmux server 时保持 fail closed
- 通讯录 scope/可见范围问题属于独立链路，本改动不改变其行为

## 验证

- `bun test test/current-actor.test.ts`：18 passed，0 failed
- `bun run test -- test/current-actor.test.ts test/current-actor-attestation.test.ts test/ipc-current-actor-route.test.ts`：3 files / 28 tests passed
- `bun run build`：通过
- 完整单测：22,442 passed；当前执行环境有 41 个无关失败，主要为子进程找不到隔离安装的 Bun，以及 tmux/bridge 超时
