### PR TITLE
fix(dashboard): 修复触发人鉴权策略保存为字符串

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -6524,8 +6524,8 @@ ipcRoute('PUT', '/api/bot-codex-auth-sync', async (req, res) => {
 });
 
 // PUT /api/bot-trigger-user-auth — 按触发人身份调用 CLI 的开关。Body
-// `{ triggerUserAuth: object | null }`：null / 空对象 → 清除（关闭）。
-// 与 /botconfig set 共用 applyConfigField，因此两个门的校验完全一致：拒绝原因
+// `{ triggerUserAuth?: object | null }`：省略 / null / 空对象 → 清除（关闭）。
+// 与 /botconfig set 共用 coerceConfigValue → applyConfigField：拒绝原因
 // （比如「fallback 不能是 device」）原样透出，不在这里另写一套判断。
 ipcRoute('PUT', '/api/bot-trigger-user-auth', async (req, res) => {
   if (!cachedLarkAppId) return jsonRes(res, 503, { error: 'larkAppId_not_set' });
@@ -6534,13 +6534,17 @@ ipcRoute('PUT', '/api/bot-trigger-user-auth', async (req, res) => {
   catch { return jsonRes(res, 400, { error: 'invalid_json' }); }
   const spec = findConfigField('triggerUserAuth');
   if (!spec) return jsonRes(res, 500, { ok: false, error: 'field_unavailable' });
-  // '' is the store's "clear" sentinel; anything else goes through the shared
-  // JSON coercion so a malformed policy is rejected the same way here as it is
-  // from chat.
-  const raw = body.triggerUserAuth === null || body.triggerUserAuth === undefined
-    ? ''
-    : JSON.stringify(body.triggerUserAuth);
-  const r = await applyConfigField(cachedLarkAppId, spec, raw);
+  const policy = body.triggerUserAuth;
+  const clear = policy === null || policy === undefined
+    || (typeof policy === 'object' && !Array.isArray(policy) && Object.keys(policy).length === 0);
+  // The store accepts parsed values and null for clearing, never JSON text.
+  let value: unknown = null;
+  if (!clear) {
+    const coerced = coerceConfigValue(spec, JSON.stringify(policy));
+    if (!coerced.ok) return jsonRes(res, 400, { ok: false, error: coerced.reason });
+    value = coerced.value;
+  }
+  const r = await applyConfigField(cachedLarkAppId, spec, value);
   if (!r.ok) return jsonRes(res, 400, r);
   jsonRes(res, 200, { ok: true });
 });

--- a/test/dashboard-trigger-user-auth.test.ts
+++ b/test/dashboard-trigger-user-auth.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __testOnly_resetBotRegistry, getBot, loadBotConfigs, registerBot,
+} from '../src/bot-registry.js';
+import {
+  setIpcAuthSecret, setLarkAppId, startIpcServer, type IpcServerHandle,
+} from '../src/core/dashboard-ipc-server.js';
+
+const APP = 'cli_trigger_user_auth_test';
+const previousPolicy = { enabled: true, tools: ['lark-cli'], fallback: 'none' };
+let dir: string;
+let configPath: string;
+let handle: IpcServerHandle | undefined;
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'dashboard-trigger-user-auth-'));
+  configPath = join(dir, 'bots.json');
+  vi.stubEnv('BOTS_CONFIG', configPath);
+  writeFileSync(configPath, JSON.stringify([{
+    larkAppId: APP,
+    larkAppSecret: 'test-secret',
+    cliId: 'codex',
+    triggerUserAuth: previousPolicy,
+  }], null, 2));
+  loadBotConfigs().forEach(registerBot);
+  setLarkAppId(APP);
+  handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+});
+
+afterEach(async () => {
+  await handle?.close();
+  handle = undefined;
+  setLarkAppId('');
+  setIpcAuthSecret(null);
+  __testOnly_resetBotRegistry();
+  vi.unstubAllEnvs();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function put(triggerUserAuth: unknown) {
+  const res = await fetch(`http://127.0.0.1:${handle!.port}/api/bot-trigger-user-auth`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ triggerUserAuth }),
+  });
+  return { status: res.status, json: await res.json() };
+}
+
+function readEntry() {
+  return JSON.parse(readFileSync(configPath, 'utf8'))[0];
+}
+
+// Exercise the real HTTP -> coercion -> locked atomic write -> live registry
+// chain. Neither the parser nor either config store is mocked.
+describe('PUT /api/bot-trigger-user-auth', () => {
+  it.each([
+    {
+      input: { enabled: true },
+      expected: { enabled: true, tools: ['lark-cli', 'bytedcli'], fallback: 'bot-identity' },
+    },
+    {
+      input: {
+        enabled: true, tools: ['bytedcli', 'lark-cli', 'bytedcli'], fallback: 'none',
+        gitHost: 'code.example.com', gitTokenExchangeUrl: 'https://auth.example.com/exchange',
+      },
+      expected: {
+        enabled: true, tools: ['bytedcli', 'lark-cli'], fallback: 'none',
+        gitHost: 'code.example.com', gitTokenExchangeUrl: 'https://auth.example.com/exchange',
+      },
+    },
+    {
+      input: { enabled: false },
+      expected: { enabled: false, tools: ['lark-cli', 'bytedcli'], fallback: 'bot-identity' },
+    },
+  ])('persists a normalized object and reloads after success: $input', async ({ input, expected }) => {
+    expect(await put(input)).toEqual({ status: 200, json: { ok: true } });
+    expect(typeof readEntry().triggerUserAuth).toBe('object');
+    expect(readEntry().triggerUserAuth).toEqual(expected);
+    const live = getBot(APP).config.triggerUserAuth;
+    expect(typeof live).toBe('object');
+    expect(live).toEqual(expected);
+    // Re-run the production file loader after the success response. A JSON
+    // string would throw "triggerUserAuth must be an object" here.
+    expect(loadBotConfigs()[0].triggerUserAuth).toEqual(expected);
+  });
+
+  it.each([null, {}])('clears disk and live config for %j', async input => {
+    expect(await put(input)).toEqual({ status: 200, json: { ok: true } });
+    expect(readEntry()).not.toHaveProperty('triggerUserAuth');
+    expect(getBot(APP).config.triggerUserAuth).toBeUndefined();
+    expect(loadBotConfigs()[0].triggerUserAuth).toBeUndefined();
+  });
+
+  it.each([
+    ['JSON string', JSON.stringify({ enabled: true }), 'must be an object'],
+    ['empty string', '', 'must be an object'],
+    ['number', 42, 'must be an object'],
+    ['boolean', false, 'must be an object'],
+    ['array', [], 'must be an object'],
+    ['invalid enabled', { enabled: 'true' }, 'enabled must be a boolean'],
+    ['unknown tool', { enabled: true, tools: ['unknown-cli'] }, 'tools has unknown entries'],
+    ['invalid tools type', { enabled: true, tools: 'lark-cli' }, 'tools must be an array'],
+    ['invalid fallback', { enabled: true, fallback: 'device' }, 'fallback must be one of'],
+  ])('rejects %s without changing disk or memory', async (_label, input, reason) => {
+    const diskBefore = readFileSync(configPath, 'utf8');
+    const liveBefore = structuredClone(getBot(APP).config);
+    const result = await put(input);
+    expect(result.status).toBe(400);
+    expect(result.json).toEqual({ ok: false, error: expect.stringContaining(reason as string) });
+    expect(readFileSync(configPath, 'utf8')).toBe(diskBefore);
+    expect(getBot(APP).config).toEqual(liveBefore);
+    expect(loadBotConfigs()[0].triggerUserAuth).toEqual(previousPolicy);
+  });
+});


### PR DESCRIPTION
Dashboard 的 `PUT /api/bot-trigger-user-auth` 原先将 `JSON.stringify(body.triggerUserAuth)` 直接传给只接收已解析字段值的 `applyConfigField`，因此接口返回成功后，磁盘和内存中的策略仍是字符串；再次加载 `bots.json` 会报 `triggerUserAuth must be an object`。

本变更让非空策略经过 `coerceConfigValue → parseTriggerUserAuthConfig`，仅将 `coerced.value` 交给存储层。省略字段、`null` 和空对象统一传 `null` 清除，并同步修正路由注释；非法输入返回 400，磁盘与内存配置均保持原值。Handler 不复制策略字段校验。

新增 14 个真实 HTTP 回归用例，不 mock parser 或配置存储，覆盖默认值补齐、tools 去重、显式关闭、object 类型及规范化内容落盘、内存热更新、成功响应后重新加载、清除，以及非 object / 非法 enabled、tools、fallback 的拒绝与原配置保留。

影响范围：仅该 Dashboard 路由和回归测试。未修改共享 parser、持久化实现、CLI 适配器或 PTY/Tmux、话题/群/adopt/restore、sandbox、workflow 路径；macOS/Linux 共用同一 JSON 处理逻辑。本次在 macOS arm64、Bun 1.4.2 / Node 22.22.0 下验证，未进行 Linux 实测。没有 UI 结构或样式变更。

验证：

- 新增 14 个用例在原始 `60b460c1` 实现上全部失败，复现字符串持久化、清除失败和非法输入返回 200；修复后全部通过。
- `bun run test test/dashboard-trigger-user-auth.test.ts test/trigger-user-auth.test.ts test/bot-config-store.test.ts test/dashboard-ipc.test.ts`：4 个文件、338 个测试通过。
- `bun run build`：通过，包含 TypeScript、脚本及测试 mock 类型检查、Dashboard bundle 和资源审计；新增测试文件单独 TypeScript 检查通过。
- `bun run daemon:restart`：本地重启成功，通过 fleet 健康门槛；未声明远端部署或飞书人工端到端验收。
- `git diff --check`：通过。
- 远端分支与本地已验证版本的 Git tree 完全一致，diff 仅包含上述两个文件。

文档更新限于路由旁的接口约定；恢复既定 object 存储契约，不引入新的架构决策。