### PR TITLE
fix(doc-comment): 按评论线程隔离文档会话

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -57,7 +57,7 @@ import { parseDocWatchCommand } from './doc-watch-command.js';
 import { parseVcMeetingPrepareCommand } from './vc-meeting-prepare-command.js';
 import { latestDocCommentPollCursor } from './doc-comment-poller.js';
 import {
-  putDocSubscription, removeDocSubscription, listDocSubscriptionsForSession, listAllDocSubscriptions, getDocSubscription,
+  docWatchAnchor, putDocSubscription, removeDocSubscription, listDocSubscriptionsForSession, listAllDocSubscriptions, getDocSubscription,
   type CommentTriggerMode, type DocSubscription,
 } from '../services/doc-subs-store.js';
 import {
@@ -3217,7 +3217,7 @@ export async function handleCommand(
           const existing = getDocSubscription(dataDir, larkAppId, file.fileToken);
           const mode: CommentTriggerMode = request.requestedMode
             ?? (botCfg.docSubscribeDefaultMode === 'all' ? 'all' : 'mention-only');
-          const anchor = ds ? sessionAnchorId(ds) : `doc:${file.fileToken}`;
+          const anchor = ds ? sessionAnchorId(ds) : docWatchAnchor(file.fileToken);
           // Existing chat/thread sessions own their project binding. A watch
           // without an explicit --dir inherits that binding; session-less
           // document watches keep their own stored/mapped directory fallback.
@@ -3254,7 +3254,7 @@ export async function handleCommand(
             sessionAnchor: anchor,
             sessionId: ds?.session.sessionId,
             scope: ds?.scope ?? 'chat',
-            chatId: ds?.chatId ?? `doc:${file.fileToken}`,
+            chatId: ds?.chatId ?? anchor,
             commentTriggerMode: mode,
             managedBy: 'watch-comment',
             ownerOpenId: message.senderId,

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -10045,6 +10045,12 @@ export type ForkResumeOrTurnId = boolean | string | {
   trustedCaller?: TrustedCaller;
 };
 
+export type WorkerForkAdmission = 'accepted' | 'deferred' | 'rejected';
+export type ForkWorkerOptions = {
+  onAdmission?: (admission: WorkerForkAdmission) => void;
+  deferDuringDeviceIsolation?: boolean;
+};
+
 /** Central quarantine decision for one fork boundary — the SINGLE authority that
  * keeps a restore-time "tail-only quarantine" from being forked incorrectly.
  *
@@ -10125,7 +10131,14 @@ export function forkWorker(
   ds: DaemonSession,
   promptInput: string | CliTurnPayload,
   resumeOrTurnId: ForkResumeOrTurnId = false,
+  opts: ForkWorkerOptions = {},
 ): boolean {
+  let admissionReported = false;
+  const reportAdmission = (admission: WorkerForkAdmission): void => {
+    if (admissionReported) return;
+    admissionReported = true;
+    opts.onAdmission?.(admission);
+  };
   const gatedPrompt = typeof promptInput === 'string' ? { content: promptInput } : promptInput;
   const remoteRetirementPhase = remoteRetirementAdmissionPhase(ds);
   if (remoteRetirementPhase) {
@@ -10156,6 +10169,7 @@ export function forkWorker(
     );
     // The request was handled by the retirement fence; false is reserved for
     // tail-only quarantine promotion failures by this function's contract.
+    reportAdmission('rejected');
     return true;
   }
   const transferGate = transferInputGates.get(ds);
@@ -10209,6 +10223,7 @@ export function forkWorker(
     // Buffered/deferred behind the routing transfer: no live worker started
     // now, but the turn is durably staged, so this is not the quarantine
     // refusal that boolean-false signals to callers.
+    reportAdmission('deferred');
     return true;
   }
 
@@ -10217,12 +10232,18 @@ export function forkWorker(
   // ANY session mutation or child fork. One deferred spawn per logical session
   // is replayed after the exact freeze lease is released; a session closed by
   // the activation transaction is deliberately not revived.
+  if (opts.deferDuringDeviceIsolation === false && currentDeviceIsolationFreezeLease()) {
+    logger.info(`[${tag(ds)}] worker spawn left retryable during device credential activation`);
+    reportAdmission('rejected');
+    return true;
+  }
   if (deferWorkerSpawnDuringDeviceIsolation(ds.session.sessionId, () => {
     if (findActiveBySessionId(ds.session.sessionId) === ds) {
       forkWorker(ds, promptInput, resumeOrTurnId);
     }
   })) {
     logger.info(`[${tag(ds)}] worker spawn deferred during device credential activation`);
+    reportAdmission('deferred');
     return true;
   }
 
@@ -10231,12 +10252,18 @@ export function forkWorker(
   // before ANY prompt derivation or session mutation so a refusal is side-effect
   // free, and so a recovered plan rewrites the prompt/resume args used below.
   const quarantinePlan = resolveQuarantinedForkPlan(ds, promptInput, resumeOrTurnId);
-  if (!quarantinePlan.fork) return false;
+  if (!quarantinePlan.fork) {
+    reportAdmission('rejected');
+    return false;
+  }
   promptInput = quarantinePlan.promptInput;
   resumeOrTurnId = quarantinePlan.resumeOrTurnId;
 
   // Refuse a closed or superseded session before any mutation (master guard).
-  if (!canForkRegisteredSession(ds)) return false;
+  if (!canForkRegisteredSession(ds)) {
+    reportAdmission('rejected');
+    return false;
+  }
 
   const promptPayload = typeof promptInput === 'string' ? { content: promptInput } : promptInput;
   const prompt = promptPayload.content;
@@ -10280,6 +10307,7 @@ export function forkWorker(
     && hasProtectedSessionMutationOwnership(ds)) {
     if (prompt.length === 0) {
       logger.warn(`[${tag(ds)}] Refused empty worker refork while durable activation ownership is non-empty`);
+      reportAdmission('rejected');
       return true;
     }
     if (hasQueuedActivationAdmissionGate(ds)) {
@@ -10307,6 +10335,7 @@ export function forkWorker(
         `[${tag(ds)}] Staged double-fork prompt behind queued activation ACK `
         + `(turn=${turnId})`,
       );
+      reportAdmission('deferred');
       return true;
     }
     const routed = sendWorkerInput(ds, promptPayload, initTurnId, {
@@ -10322,6 +10351,7 @@ export function forkWorker(
     logger[routed ? 'info' : 'warn'](
       `[${tag(ds)}] ${routed ? 'Routed' : 'Failed to route'} double-fork prompt through existing durable owner`,
     );
+    reportAdmission(routed ? 'accepted' : 'rejected');
     return true;
   }
 
@@ -10352,6 +10382,7 @@ export function forkWorker(
       `[${tag(ds)}] Failed to report blocked worker admission: `
       + `${error instanceof Error ? error.message : String(error)}`,
     ));
+    reportAdmission('rejected');
     return true;
   }
   if (
@@ -11181,6 +11212,7 @@ export function forkWorker(
   } catch (err) {
     logger.error(`[${t}] Failed to record attached worker ownership: ${err instanceof Error ? err.message : String(err)}`);
   }
+  reportAdmission('accepted');
   return true;
 }
 
@@ -15339,12 +15371,15 @@ export function adoptSandboxBlocked(
     || sandboxEnabled();
 }
 
-export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata?: boolean; prompt?: string; turnId?: string }): void {
+export function forkAdoptWorker(
+  ds: DaemonSession,
+  opts?: { restoredFromMetadata?: boolean; prompt?: string; turnId?: string },
+): 'accepted' | 'rejected' {
   if (isSessionTransferring(ds)) {
     logger.warn(`[${tag(ds)}] Adopt worker fork refused during routing transfer`);
-    return;
+    return 'rejected';
   }
-  if (!canForkRegisteredSession(ds)) return;
+  if (!canForkRegisteredSession(ds)) return 'rejected';
   ds.workerReady = false;
   const cb = requireCallbacks();
   const t = tag(ds);
@@ -15376,7 +15411,7 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
       ds.session.adoptedFrom = undefined;
       try { sessionStore.updateSession(ds.session); } catch { /* best-effort */ }
     }
-    return;
+    return 'rejected';
   }
 
   // Reserve before replacing an existing bridge worker for the same reason as
@@ -15424,7 +15459,10 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
     } as NodeJS.ProcessEnv,
   });
   const startupState: WorkerStartupState = { ready: false, failureNotified: false };
+  const adoptedCliId = adopted.cliId ?? 'claude-code';
+  let initMsg!: DaemonToWorker;
 
+  try {
   // A fork-level failure emits 'error'; without a handler it crashes the daemon.
   // Adopt has no worker IPC in this case either, so reply from the daemon just
   // like the normal-session fork guard.
@@ -15482,7 +15520,6 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   //     the append-only agent-transcript JSONL, then harvests final replies
   //     from there (cursor-agent never calls `botmux send`).
   // Other CLIs fall back to legacy screen-capture only.
-  const adoptedCliId = adopted.cliId ?? 'claude-code';
   // Claude adopt needs a sessionId to compute bridgeJsonlPath (the worker's
   // claude branch starts its transcript bridge ONLY from bridgeJsonlPath — it
   // has no by-pid fallback like codex/traex/cursor). Discovery resolves the
@@ -15517,7 +15554,7 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   const isStructuredBridge = isStructuredBridgeAdoptCli(adoptedCliId);
   const adoptBackendType = adopted.source === 'herdr' ? 'herdr' : adopted.zellijPaneId ? 'zellij' : 'tmux';
 
-  const initMsg: DaemonToWorker = {
+  initMsg = {
     type: 'init',
     sessionId: ds.session.sessionId,
     chatId: ds.chatId,
@@ -15595,52 +15632,75 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
     // way out of date if the user has /clear'd since).
     adoptRestoredFromMetadata: opts?.restoredFromMetadata === true ? true : undefined,
   };
+  setupWorkerHandlers(ds, worker, startupState, workerGeneration);
+  ds.worker = worker;
   worker.send(initMsg);
+  } catch (err) {
+    if (ds.worker === worker) ds.worker = null;
+    try { worker.kill(); } catch { /* best-effort pre-init child fence */ }
+    throw err;
+  }
+
+  // init is now accepted by the child. Everything below is projection only and
+  // must not turn this prompt back into a retryable delivery.
   ds.initConfig = initMsg;
-  // New generation ledger. NOT a plain reset: the previous generation's keys are
-  // parked until its worker is observed to exit, because the double-fork guard
-  // kills asynchronously and spawns the replacement synchronously.
-  startNewGenerationEnvLedger(ds, initMsg.env);
-  // Stamp cliId on the persisted session so the dashboard can show a CLI badge
-  // even after the session is closed. Adopt sessions inherit the adopted CLI's id.
-  // Do this before installing worker handlers: a fast worker can emit `ready`
-  // immediately after init, and card rendering must use the adopted CLI identity.
+  try {
+    startNewGenerationEnvLedger(ds, initMsg.env);
+  } catch (err) {
+    logger.error(`[${t}] Failed to initialize adopt worker env ledger: ${err instanceof Error ? err.message : String(err)}`);
+  }
   const adoptedCliIdTyped = adoptedCliId as CliId;
   if (ds.session.cliId !== adoptedCliIdTyped) {
     ds.session.cliId = adoptedCliIdTyped;
-    sessionStore.updateSession(ds.session);
+    try {
+      sessionStore.updateSession(ds.session);
+    } catch (err) {
+      logger.error(`[${t}] Failed to persist adopted CLI identity: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
-
-  // Use shared handler
-  setupWorkerHandlers(ds, worker, startupState, workerGeneration);
-
-  ds.worker = worker;
   ds.spawnedAt = Date.now();
   ds.cliVersion = '';
-  // Persist the bridge worker's pid, exactly like forkWorker. Without it the
-  // session row keeps pid=null, so `botmux list` (and killStalePids) judge an
-  // adopt session by "process dead AND no bmx-<id> tmux" — but adopt attaches to
-  // the user's OWN tmux/zellij pane, never a bmx-* session, so the heuristic
-  // always reported it unrecoverable and auto-pruned it to "closed" right after
-  // /adopt. Storing the worker pid (botmux's bridge, NOT the user's CLI) makes
-  // liveness consistent with normal sessions and leaves the user's CLI alone.
-  sessionStore.updateSessionPid(ds.session.sessionId, worker.pid ?? null);
+  try {
+    sessionStore.updateSessionPid(ds.session.sessionId, worker.pid ?? null);
+  } catch (err) {
+    logger.error(`[${t}] Failed to persist adopt worker pid: ${err instanceof Error ? err.message : String(err)}`);
+  }
   logger.info(`[${t}] Adopt worker forked (pid: ${worker.pid}, target: ${adopted.tmuxTarget ?? `${adopted.zellijSession}/${adopted.zellijPaneId}`})`);
 
   ds.exitEventEmitted = false;
-  dashboardEventBus.publish({
-    type: 'session.spawned',
-    body: { session: composeRowFromActive(ds) },
-  });
-  cb.enforceLiveSessionCap?.();
-  emitSessionLifecycleHook(ds, 'session.start', {
-    reason: opts?.restoredFromMetadata ? 'adopt_restore' : 'adopt',
-    pid: worker.pid ?? null,
-    adoptedFrom: adopted.tmuxTarget,
-  });
-  // Adopted CLIs come with pre-botmux history — anchor it out of the ledger.
-  anchorUsageForDaemonSession(ds);
-  recordOwnershipForDaemonSession(ds);
+  try {
+    dashboardEventBus.publish({
+      type: 'session.spawned',
+      body: { session: composeRowFromActive(ds) },
+    });
+  } catch (err) {
+    logger.error(`[${t}] Failed to publish adopt worker state: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  try {
+    cb.enforceLiveSessionCap?.();
+  } catch (err) {
+    logger.error(`[${t}] Failed to enforce live-session cap after adopt: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  try {
+    emitSessionLifecycleHook(ds, 'session.start', {
+      reason: opts?.restoredFromMetadata ? 'adopt_restore' : 'adopt',
+      pid: worker.pid ?? null,
+      adoptedFrom: adopted.tmuxTarget,
+    });
+  } catch (err) {
+    logger.error(`[${t}] Failed to emit adopt worker lifecycle hook: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  try {
+    anchorUsageForDaemonSession(ds);
+  } catch (err) {
+    logger.error(`[${t}] Failed to initialize adopt worker usage state: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  try {
+    recordOwnershipForDaemonSession(ds);
+  } catch (err) {
+    logger.error(`[${t}] Failed to record adopt worker ownership: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return 'accepted';
 }
 
 // ─── Reap orphan workers ────────────────────────────────────────────────────

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -231,6 +231,7 @@ import {
   admitQueuedActivationTail,
   reserveQueuedActivationTailAdmission,
   type QueuedActivationTailReservation,
+  type WorkerForkAdmission,
   codexAppCleanInputAcceptedForSession,
   hasQueuedActivationAdmissionGate,
   sendWorkerSessionInput,
@@ -511,7 +512,7 @@ function republishResolvedAllowedUsers(larkAppId: string, resolved: string[]): v
 }
 let vcMeetingTerminalReconciler: VcMeetingTerminalReconciler | undefined;
 import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, markForwardFollowupsSessionsReady, writeBotInfoFile, canOperate, canRunDaemonCommand, evaluateTalk, evaluateBotTalk, evaluateAskAnswerTalk, askCustomReplyCandidate, grantCommandRestriction, isKnownPeerBot, resolveSiblingBotNameByUnionId, checkRequiredScopes, ensureVcMeetingEventsSubscribed, type RoutingContext, type TalkEvaluation, type DocCommentContext, type EventHandlers } from './im/lark/event-dispatcher.js';
-import { getDocSubscription, listAllDocSubscriptions, listDocSubscriptionsForSession, putDocSubscription, removeDocSubscription, setDocCommentPollCursor, type DocSubscription } from './services/doc-subs-store.js';
+import { commitDocCommentPollCursor, docCommentThreadAnchor, getDocSubscription, isDocNativeWatchSubscription, listAllDocSubscriptions, listDocSubscriptionsForSession, normalizeDocNativeWatchSubscription, putDocSubscription, removeDocSubscription, settleDocCommentWsDelivery, type DocSubscription } from './services/doc-subs-store.js';
 import { BOT_REPLY_SENTINEL, subscribeDocFile, unsubscribeDocFile, addCommentReaction, removeCommentReaction, hasBotSentinel, isBotAuthoredReply, listDocComments } from './im/lark/doc-comment.js';
 import { learnFromMentions, resolveSender, flushIdentityCacheSync, type ResolvedSender } from './im/lark/identity-cache.js';
 import { normalizeBrand } from './im/lark/lark-hosts.js';
@@ -21261,7 +21262,8 @@ async function handleThreadReplyAdmitted(
 /**
  * 为文档评论自动创建 session（无活跃 IM session 时调用）。
  *
- * 用虚拟 anchor = `doc:{fileToken}` 作为 session key，workingDir 取自：
+ * 文档原生监听用 `doc:{fileToken}:{commentId}` 作为 session key；显式绑定会话
+ * 失效后的兼容回退仍使用 `doc:{fileToken}`。workingDir 取自：
  *   1) sub.workingDir（如果订阅时指定了）
  *   2) bot 的 defaultWorkingDir / workingDir 配置
  *   3) fallback 到 ~
@@ -21271,14 +21273,62 @@ async function handleThreadReplyAdmitted(
  * handleDocComment delivery owner 统一完成这些动作。
  * 返回胜出的 DaemonSession（已加入 activeSessions），失败返回 null。
  */
-async function autoCreateDocSession(sub: DocSubscription, larkAppId: string, ctx: DocCommentContext): Promise<DaemonSession | null> {
+const ephemeralDocCommentSessions = new WeakSet<DaemonSession>();
+const docCommentSessionReservations = new WeakMap<DaemonSession, Set<string>>();
+
+function reserveDocCommentSession(ds: DaemonSession, turnId: string): () => void {
+  const reservations = docCommentSessionReservations.get(ds) ?? new Set<string>();
+  reservations.add(turnId);
+  docCommentSessionReservations.set(ds, reservations);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    reservations.delete(turnId);
+    if (reservations.size === 0) docCommentSessionReservations.delete(ds);
+  };
+}
+
+function claimUnacceptedDocCommentSessionRetirement(ds: DaemonSession): boolean {
+  if (!ephemeralDocCommentSessions.has(ds)) return false;
+  if ((docCommentSessionReservations.get(ds)?.size ?? 0) > 0) return false;
+  if (ds.worker && !ds.worker.killed) return false;
+  if ((ds.docCommentTurns?.size ?? 0) > 0) return false;
+  if (Object.keys(ds.session.docCommentTargets ?? {}).length > 0) return false;
+  if (ds.pendingRepo || ds.worktreeCreating || hasProtectedSessionMutationOwnership(ds)) return false;
+  const key = sessionKey(sessionAnchorId(ds), ds.larkAppId);
+  if (activeSessions.get(key) !== ds) return false;
+  activeSessions.delete(key);
+  ephemeralDocCommentSessions.delete(ds);
+  return true;
+}
+
+function acceptDocCommentSession(ds: DaemonSession): void {
+  ephemeralDocCommentSessions.delete(ds);
+}
+
+export const __testOnly_markEphemeralDocCommentSession = (ds: DaemonSession): void => {
+  ephemeralDocCommentSessions.add(ds);
+};
+export const __testOnly_reserveDocCommentSession = reserveDocCommentSession;
+export const __testOnly_claimUnacceptedDocCommentSessionRetirement = claimUnacceptedDocCommentSessionRetirement;
+export const __testOnly_acceptDocCommentSession = acceptDocCommentSession;
+
+async function autoCreateDocSession(
+  sub: DocSubscription,
+  larkAppId: string,
+  ctx: DocCommentContext,
+): Promise<DaemonSession | null> {
   const botCfg = getBot(larkAppId).config;
-  const virtualChatId = `doc:${sub.fileToken}`;
-  const virtualAnchor = virtualChatId;
+  const docNative = isDocNativeWatchSubscription(sub);
+  const virtualAnchor = docNative
+    ? docCommentThreadAnchor(sub.fileToken, ctx.commentId)
+    : `doc:${sub.fileToken}`;
+  const virtualChatId = virtualAnchor;
   const routingKey = sessionKey(virtualAnchor, larkAppId);
   const existing = activeSessions.get(routingKey);
   if (existing?.session.status === 'active' && ownsCurrentRoute(existing, larkAppId)) {
-    persistDocBindingToSession(sub, larkAppId, existing);
+    if (!docNative) persistDocBindingToSession(sub, larkAppId, existing);
     return existing;
   }
 
@@ -21324,7 +21374,9 @@ async function autoCreateDocSession(sub: DocSubscription, larkAppId: string, ctx
     logger.warn(`[doc-comment] auto-create registration lost without an active winner file=${sub.fileToken.slice(0, 12)}`);
     return null;
   }
-  await persistSelectedDocBinding(routingKey, sub, larkAppId, selected, ds);
+  if (!docNative) {
+    await persistSelectedDocBinding(routingKey, sub, larkAppId, selected, ds);
+  }
   if (selected !== ds) {
     logger.info(
       `[doc-comment] auto-create ${session.sessionId.slice(0, 8)} lost to ` +
@@ -21335,7 +21387,8 @@ async function autoCreateDocSession(sub: DocSubscription, larkAppId: string, ctx
 
   // 不在这里 forkWorker —— handleDocComment 会统一处理 reaction、per-turn
   // 回复落点及 fork/send。这里只建好 session skeleton。
-  logger.info(`[doc-comment] auto-created session for file=${sub.fileToken.slice(0, 12)} (wd=${workingDir}, cli=${botCfg.cliId})`);
+  if (docNative) ephemeralDocCommentSessions.add(selected);
+  logger.info(`[doc-comment] auto-created session for file=${sub.fileToken.slice(0, 12)} comment=${ctx.commentId.slice(0, 12)} (wd=${workingDir}, cli=${botCfg.cliId})`);
   return selected;
 }
 
@@ -21360,6 +21413,25 @@ class DocCommentDeferredError extends Error {
     super(reason);
     this.name = 'DocCommentDeferredError';
   }
+}
+
+class DocCommentSubscriptionChangedError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'DocCommentSubscriptionChangedError';
+  }
+}
+
+function currentDocSubscriptionForDelivery(
+  larkAppId: string,
+  expected: DocSubscription,
+): DocSubscription {
+  const current = getDocSubscription(config.session.dataDir, larkAppId, expected.fileToken);
+  if (!current) throw new DocCommentSubscriptionChangedError('subscription removed');
+  if (!sameDocBindingRoute(current, expected) || current.managedBy !== expected.managedBy) {
+    throw new DocCommentSubscriptionChangedError('subscription rebound');
+  }
+  return current;
 }
 
 async function runClaimedDocCommentTurn(
@@ -21404,8 +21476,8 @@ export function __testOnly_resetDocCommentClaims(): void {
  * ds.docCommentTurns —— deliverFinalOutput 据此把正文发表为文档评论。状态卡 /
  * 占位卡仍走会话起点（飞书），天然实现「卡片留飞书、正文进评论」的分流。
  *
- * MVP 边界：仅投递给 activeSessions 里仍在的会话（含 idle 挂起、worker=null —
- * 走 resume 重 fork）；已 /close 的会话其订阅在关闭时已退订，这里查不到 ds 即跳过。
+ * 显式绑定模式沿用绑定会话；文档原生 watch 按 commentId 创建可独立关闭的会话，
+ * 关闭单个评论会话不会停止整篇文档监听。
  */
 async function handleDocComment(ctx: DocCommentContext): Promise<boolean> {
   return withBotTurnAdmission(
@@ -21414,14 +21486,16 @@ async function handleDocComment(ctx: DocCommentContext): Promise<boolean> {
   );
 }
 
-async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean> {
-  const { larkAppId, sub, commentId, text } = ctx;
+async function handleDocCommentAdmitted(ctx: DocCommentContext, routeRetry = 0): Promise<boolean> {
+  const { larkAppId, commentId, text } = ctx;
+  let sub = ctx.sub;
   const turnId = ctx.replyId || commentId;
   const claimKey = `${larkAppId}:${sub.fileToken}:${turnId}`;
   const userReplyId = ctx.replyId;
   let reactionId: string | undefined;
   let deliveryDs: DaemonSession | undefined;
   let deliverySession: Session | undefined;
+  let releaseDeliveryReservation: (() => void) | undefined;
 
   const targetMatchesThisTurn = (target: {
     fileToken: string;
@@ -21434,7 +21508,7 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
     && target.commentId === commentId
     && target.replyId === userReplyId;
 
-  const cleanupFailedDelivery = async (): Promise<void> => {
+  const cleanupFailedDelivery = async (error: unknown): Promise<void> => {
     if (deliveryDs) {
       const runtimeTarget = deliveryDs.docCommentTurns?.get(turnId);
       if (targetMatchesThisTurn(runtimeTarget)) {
@@ -21483,6 +21557,14 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
         );
       }
     }
+
+    releaseDeliveryReservation?.();
+    if (deliveryDs && claimUnacceptedDocCommentSessionRetirement(deliveryDs)) {
+      await closeSessionForBackgroundCleanup(
+        deliveryDs.session.sessionId,
+        'document comment admission cleanup',
+      );
+    }
   };
 
   try {
@@ -21492,16 +21574,29 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
     }
     return await runClaimedDocCommentTurn(claimKey, async () => {
       const loc = localeForBot(larkAppId);
-      let ds: DaemonSession | undefined | null = resolveBoundDocSession(sub, larkAppId);
+      const currentSub = getDocSubscription(config.session.dataDir, larkAppId, sub.fileToken);
+      if (!currentSub) {
+        logger.info(`[doc-comment] ignored stale delivery after subscription removal file=${sub.fileToken.slice(0, 12)} turn=${turnId.slice(0, 12)}`);
+        return;
+      }
+      sub = currentSub;
+      const docNative = isDocNativeWatchSubscription(sub);
+      const docThreadAnchor = docNative
+        ? docCommentThreadAnchor(sub.fileToken, commentId)
+        : undefined;
+      let ds: DaemonSession | undefined | null = docThreadAnchor
+        ? activeSessions.get(sessionKey(docThreadAnchor, larkAppId))
+        : resolveBoundDocSession(sub, larkAppId);
+      if (ds && !ownsCurrentRoute(ds, larkAppId)) ds = undefined;
       if (!ds) {
-        // 无活跃 session → 自动为该文档创建一个（用虚拟 anchor = doc:{fileToken}）
-        logger.info(`[doc-comment] no active session for anchor=${sub.sessionAnchor.slice(0, 12)}; auto-creating for file=${sub.fileToken.slice(0, 12)}`);
+        logger.info(`[doc-comment] no active session for anchor=${(docThreadAnchor ?? sub.sessionAnchor).slice(0, 12)}; auto-creating for file=${sub.fileToken.slice(0, 12)}`);
         ds = await autoCreateDocSession(sub, larkAppId, ctx);
         if (!ds) {
           throw new Error(`auto-create session failed for ${sub.fileToken.slice(0, 12)}`);
         }
       }
       deliveryDs = ds;
+      releaseDeliveryReservation = reserveDocCommentSession(ds, turnId);
       const generation = captureRoutingGeneration(ds);
       deliverySession = generation.session;
       ensureCurrentRoutingGeneration(generation, 'comment:start');
@@ -21522,6 +21617,8 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
         );
       }
 
+      sub = currentDocSubscriptionForDelivery(larkAppId, sub);
+
       // 给用户的回复加 "Typing" reaction，让评论者知道 bot 正在处理。
       if (userReplyId) {
         reactionId = await addCommentReaction(larkAppId,
@@ -21532,6 +21629,7 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
 
       const sender = ctx.authorOpenId ? await resolveSender(larkAppId, ctx.authorOpenId, 'user') : undefined;
       ensureCurrentRoutingGeneration(generation, 'comment:sender');
+      sub = currentDocSubscriptionForDelivery(larkAppId, sub);
       const authorName = sender?.name || ctx.authorOpenId?.slice(0, 8) || '?';
       const dsBotCfg = getBot(ds.larkAppId).config;
       const promptInput = {
@@ -21586,13 +21684,22 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
         rememberLastCliInput(ds, promptContent, cliInput);
         await noteTurnReceived(ds, commentId, text, sender, turnId);
         ensureCurrentRoutingGeneration(generation, 'comment:live-note');
+        sub = currentDocSubscriptionForDelivery(larkAppId, sub);
         if (ds.worker !== targetWorker || targetWorker.killed) {
           throw new Error('worker generation changed during comment:live-note');
         }
         if (!sendWorkerInput(ds, cliInput, turnId)) {
           throw new Error('worker became unavailable during comment:live-send');
         }
-        beginNewTurn(ds, text, turnId);
+        acceptDocCommentSession(ds);
+        try {
+          beginNewTurn(ds, text, turnId);
+        } catch (err) {
+          // Worker IPC already accepted this turn. Presentation/session
+          // projection failure must not make the provider retry the comment and
+          // execute it twice.
+          logger.error(`[${tag(ds)}] doc-comment post-admission projection failed (turn ${turnId.slice(0, 8)}): ${err instanceof Error ? err.message : String(err)}`);
+        }
         logger.info(`[${tag(ds)}] doc-comment turn injected (turn ${turnId.slice(0, 8)})`);
         return;
       }
@@ -21632,17 +21739,47 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
       rememberLastCliInput(ds, promptContent, wrappedInput);
       await noteTurnReceived(ds, commentId, text, sender, turnId);
       ensureCurrentRoutingGeneration(generation, 'comment:refork-note');
+      sub = currentDocSubscriptionForDelivery(larkAppId, sub);
       if (ds.worker && !ds.worker.killed) {
         throw new Error('worker became active during comment:refork-note');
       }
       sessionStore.updateSession(ds.session);
       if (ds.adoptedFrom) {
-        forkAdoptWorker(ds, { prompt: wrappedInput.content, turnId });
+        if (forkAdoptWorker(ds, { prompt: wrappedInput.content, turnId }) !== 'accepted') {
+          throw new Error('adopt worker fork did not accept document comment input');
+        }
+        acceptDocCommentSession(ds);
       } else {
-        forkWorker(ds, wrappedInput, { resume: ds.hasHistory, turnId });
+        let forkAdmission: WorkerForkAdmission | undefined;
+        const forked = forkWorker(
+          ds,
+          wrappedInput,
+          { resume: ds.hasHistory, turnId },
+          {
+            onAdmission: admission => { forkAdmission = admission; },
+            deferDuringDeviceIsolation: false,
+          },
+        );
+        if (!forked || forkAdmission === undefined || forkAdmission === 'rejected') {
+          throw new Error('worker fork did not accept document comment input');
+        }
+        acceptDocCommentSession(ds);
       }
     }, cleanupFailedDelivery);
   } catch (err) {
+    if (err instanceof DocCommentSubscriptionChangedError) {
+      const current = getDocSubscription(config.session.dataDir, larkAppId, sub.fileToken);
+      if (!current) {
+        logger.info(`[doc-comment] stopped watch consumed stale turn file=${sub.fileToken.slice(0, 12)} turn=${turnId.slice(0, 12)}`);
+        return true;
+      }
+      if (routeRetry < 1) {
+        logger.info(`[doc-comment] retrying turn on rebound route file=${sub.fileToken.slice(0, 12)} turn=${turnId.slice(0, 12)}`);
+        return await handleDocCommentAdmitted({ ...ctx, sub: current }, routeRetry + 1);
+      }
+      logger.warn(`[doc-comment] route changed repeatedly; retry deferred file=${sub.fileToken.slice(0, 12)} turn=${turnId.slice(0, 12)}`);
+      return false;
+    }
     if (err instanceof DocCommentDeferredError) {
       // Retryable defer (durable opening ownership): claim was released above so
       // the provider cursor re-attempts this exact comment later. Not a failure.
@@ -21654,6 +21791,8 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
     }
     logger.warn(`[doc-comment] delivery failed, claim released for retry file=${sub.fileToken.slice(0, 12)} turn=${turnId.slice(0, 12)} err=${err instanceof Error ? err.message : String(err)}`);
     return false;
+  } finally {
+    releaseDeliveryReservation?.();
   }
 }
 
@@ -21691,6 +21830,66 @@ export const __testOnly_handleChatModeConverted = handleChatModeConverted;
 
 let docCommentPollRunning = false;
 
+async function retryPendingDocCommentDeliveries(
+  larkAppId: string,
+  deliver: (ctx: DocCommentContext) => Promise<boolean> = handleDocComment,
+): Promise<{ acceptedKeys: Set<string>; blockedFiles: Set<string> }> {
+  const acceptedKeys = new Set<string>();
+  const blockedFiles = new Set<string>();
+  const snapshots = listAllDocSubscriptions(config.session.dataDir, larkAppId)
+    .filter(sub => (sub.pendingDocCommentDeliveries?.length ?? 0) > 0);
+  for (const snapshot of snapshots) {
+    for (const pending of snapshot.pendingDocCommentDeliveries ?? []) {
+      const current = getDocSubscription(config.session.dataDir, larkAppId, snapshot.fileToken);
+      if (!current) break;
+      const key = pending.replyId || pending.commentId;
+      const currentPending = current.pendingDocCommentDeliveries?.find(candidate =>
+        (candidate.replyId || candidate.commentId) === key);
+      if (!currentPending) continue;
+      if (currentPending.acceptedAt !== undefined) {
+        acceptedKeys.add(`${snapshot.fileToken}:${key}`);
+        continue;
+      }
+      try {
+        const accepted = await deliver({
+          larkAppId,
+          sub: current,
+          commentId: pending.commentId,
+          replyId: pending.replyId,
+          text: pending.text,
+          selectedText: pending.selectedText,
+          priorReplies: pending.priorReplies,
+          isWhole: pending.isWhole,
+          authorOpenId: pending.authorOpenId,
+        });
+        if (!accepted) {
+          blockedFiles.add(snapshot.fileToken);
+          logger.warn(`[doc-comment-retry] still pending file=${snapshot.fileToken.slice(0, 12)} reply=${key.slice(0, 12)}`);
+          break;
+        }
+        settleDocCommentWsDelivery(
+          config.session.dataDir,
+          larkAppId,
+          snapshot.fileToken,
+          pending,
+          true,
+        );
+        const latest = getDocSubscription(config.session.dataDir, larkAppId, snapshot.fileToken);
+        const retained = latest?.pendingDocCommentDeliveries?.some(candidate =>
+          (candidate.replyId || candidate.commentId) === key);
+        if (retained) acceptedKeys.add(`${snapshot.fileToken}:${key}`);
+        logger.info(`[doc-comment-retry] accepted file=${snapshot.fileToken.slice(0, 12)} reply=${key.slice(0, 12)}`);
+      } catch (err) {
+        blockedFiles.add(snapshot.fileToken);
+        logger.warn(`[doc-comment-retry] failed file=${snapshot.fileToken.slice(0, 12)} reply=${key.slice(0, 12)}: ${err instanceof Error ? err.message : String(err)}`);
+        break;
+      }
+    }
+  }
+  return { acceptedKeys, blockedFiles };
+}
+export const __testOnly_retryPendingDocCommentDeliveries = retryPendingDocCommentDeliveries;
+
 /**
  * `/watch-comment --all` 的应用身份增量轮询。
  *
@@ -21702,10 +21901,12 @@ async function pollWatchedDocComments(larkAppId: string): Promise<void> {
   if (docCommentPollRunning) return;
   docCommentPollRunning = true;
   try {
+    const pendingRetry = await retryPendingDocCommentDeliveries(larkAppId);
     const subs = listAllDocSubscriptions(config.session.dataDir, larkAppId)
       .filter(sub => sub.managedBy === 'watch-comment' && sub.commentTriggerMode === 'all');
     for (const snapshot of subs) {
       try {
+        if (pendingRetry.blockedFiles.has(snapshot.fileToken)) continue;
         const comments = await listDocComments(larkAppId, {
           fileToken: snapshot.fileToken,
           fileType: snapshot.fileType,
@@ -21713,13 +21914,20 @@ async function pollWatchedDocComments(larkAppId: string): Promise<void> {
         const latest = latestDocCommentPollCursor(comments);
         const current = getDocSubscription(config.session.dataDir, larkAppId, snapshot.fileToken);
         if (!current || current.managedBy !== 'watch-comment' || current.commentTriggerMode !== 'all') continue;
+        const acceptedPending = current.pendingDocCommentDeliveries?.filter(item => item.acceptedAt !== undefined) ?? [];
+        const visibleReplyIds = new Set(comments.flatMap(comment => comment.replies.map(reply => reply.replyId)));
+        if (acceptedPending.some(item => !visibleReplyIds.has(item.replyId || item.commentId))) {
+          logger.info(`[doc-comment-poll] waiting for accepted reply visibility file=${current.fileToken.slice(0, 12)}`);
+          continue;
+        }
 
         if (!current.pollBaselineReady || current.pollCursorAt === undefined || current.pollCursorReplyId === undefined) {
-          setDocCommentPollCursor(
+          commitDocCommentPollCursor(
             config.session.dataDir,
             larkAppId,
             current.fileToken,
             latest ?? { createdAt: Math.floor(Date.now() / 1000), replyId: '' },
+            { clearAcceptedBaseline: true },
           );
           logger.info(`[doc-comment-poll] baseline file=${current.fileToken.slice(0, 12)} comments=${comments.length}`);
           continue;
@@ -21739,6 +21947,8 @@ async function pollWatchedDocComments(larkAppId: string): Promise<void> {
             if (!stillWatching || stillWatching.managedBy !== 'watch-comment' || stillWatching.commentTriggerMode !== 'all') {
               return false; // watch removed mid-loop → stop without advancing
             }
+            const pendingKey = `${current.fileToken}:${reply.replyId}`;
+            if (pendingRetry.acceptedKeys.has(pendingKey)) return true;
             const selfBotOpenId = getBot(larkAppId).botOpenId;
             const isSelfReply = (selfBotOpenId && reply.authorOpenId === selfBotOpenId)
               || isBotAuthoredReply(reply.replyId)
@@ -21762,10 +21972,27 @@ async function pollWatchedDocComments(larkAppId: string): Promise<void> {
             });
             if (!ok) {
               logger.warn(`[doc-comment-poll] cursor NOT advanced for reply=${reply.replyId.slice(0, 12)} (handleDocComment returned false; stopping this round, will retry next poll)`);
+              return false;
             }
-            return ok;
+            settleDocCommentWsDelivery(
+              config.session.dataDir,
+              larkAppId,
+              current.fileToken,
+              {
+                commentId: reply.commentId,
+                replyId: reply.replyId,
+                text: reply.text,
+                selectedText: reply.selectedText,
+                priorReplies: reply.priorReplies,
+                isWhole: reply.isWhole,
+                authorOpenId: reply.authorOpenId,
+                queuedAt: Date.now(),
+              },
+              true,
+            );
+            return true;
           },
-          (reply) => { setDocCommentPollCursor(config.session.dataDir, larkAppId, current.fileToken, reply); },
+          (reply) => { commitDocCommentPollCursor(config.session.dataDir, larkAppId, current.fileToken, reply); },
         );
       } catch (err) {
         logger.warn(`[doc-comment-poll] file=${snapshot.fileToken.slice(0, 12)} failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -21773,6 +22000,17 @@ async function pollWatchedDocComments(larkAppId: string): Promise<void> {
     }
   } finally {
     docCommentPollRunning = false;
+  }
+}
+
+function normalizeDocNativeSubscriptionsBeforeSessionRestore(larkAppId: string): void {
+  let subs: DocSubscription[];
+  try { subs = listAllDocSubscriptions(config.session.dataDir, larkAppId); } catch { return; }
+  for (const sub of subs) {
+    const normalized = normalizeDocNativeWatchSubscription(sub);
+    if (normalized === sub) continue;
+    putDocSubscription(config.session.dataDir, larkAppId, normalized);
+    logger.info(`[doc-comment] migrated thread-scoped watch ${sub.fileToken.slice(0, 12)} before session restore`);
   }
 }
 
@@ -21787,6 +22025,10 @@ async function restoreDocSubscriptions(_sessions: Map<string, DaemonSession>): P
     try { subs = listAllDocSubscriptions(config.session.dataDir, appId); } catch { continue; }
     for (const sub of subs) {
       const file = { fileToken: sub.fileToken, fileType: sub.fileType };
+      if (isDocNativeWatchSubscription(sub)) {
+        logger.info(`[doc-comment] restore: kept thread-scoped event watch ${sub.fileToken.slice(0, 12)}`);
+        continue;
+      }
       // 判定保留/退订以**持久化的会话状态**为准（不看内存 activeSessions，避免恢复
       // 时序 / keying 差异误删活跃会话的订阅）。只有「明确已关闭」才退订清表：
       //   • 有 sessionId 且其会话 status==='closed' → 真的关了 → 退订 + 删表
@@ -23108,7 +23350,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // See reapOrphanWorkers() in worker-pool.ts.
   reapOrphanWorkers();
 
-  // Restore active sessions from previous run
+  // Normalize legacy document-native watches before restore can close their old sessions.
+  if (!cfg.apiOnly) normalizeDocNativeSubscriptionsBeforeSessionRestore(cfg.larkAppId);
+
   // Restore active sessions from previous run
   await restoreSessionsAndScheduleStartupRecovery({
     larkAppId: cfg.larkAppId,

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -24,7 +24,7 @@ import { isTeamBot, recordTeamBot } from '../../services/team-bots-store.js';
 import { isTeamGroupChat } from '../../services/team-groups-store.js';
 import { isPlatformTeamBot, isPlatformHallChat, isPlatformTeamMember } from '../../services/platform-team-store.js';
 import { getBotUnionId, recordBotUnionId, recordBotUnionIdFromMentions } from '../../services/bot-union-ids-store.js';
-import { getDocSubscription, putDocSubscription, removeDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
+import { docWatchAnchor, getDocSubscription, putDocSubscription, removeDocSubscription, listAllDocSubscriptions, settleDocCommentWsDelivery, type DocSubscription } from '../../services/doc-subs-store.js';
 import { wasPendingReviewNotified, markPendingReviewNotified } from '../../services/under-review-notify-store.js';
 import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed, BOT_REPLY_SENTINEL, addCommentReactionChecked } from './doc-comment.js';
 import {
@@ -3069,9 +3069,10 @@ function handleVcMeetingPushEventAckSafe(
 /**
  * 在被丢弃的触发回复上打一个 ❌，让「这条 @ 我没能处理」在文档里**看得见**。
  *
- * 为什么需要：文档评论事件被丢弃后，飞书不会重投（事件已 ACK），而 mention-only
- * 订阅**不进轮询**（poller 只收 commentTriggerMode==='all'），所以事件链路失败
- * 就是终点。用户侧原本只能看到「bot 不理我」，与「bot 正在忙」无法区分——doc
+ * 为什么需要：文档评论事件被丢弃后，飞书不会重投（事件已 ACK）。已经读到正文、
+ * 通过 @ 与审计门的投递会进入持久 pending 重试；但本 helper 处理的是更早的失败
+ * （正文/回复都没读全，无法构造安全投递上下文），所以仍是终点。用户侧原本只能
+ * 看到「bot 不理我」，与「bot 正在忙」无法区分——doc
  * 发起的会话在飞书上整个不可见，只能去 dashboard 翻 terminal 才知道发生了什么。
  *
  * 只在**明确知道该怪谁**、且非预期的丢弃点上打：
@@ -3245,13 +3246,14 @@ async function processCommentEvent(
     const operatorOpenId = parsed.operatorOpenId;
     const botCfg = getBot(larkAppId).config;
     const mappedDir = botCfg.docRepoMap?.[fileToken];
+    const watchAnchor = docWatchAnchor(fileToken);
     const autoSub: DocSubscription = {
       fileToken,
       fileType: parsed.fileType || 'docx',
-      sessionAnchor: `doc:${fileToken}`,
+      sessionAnchor: watchAnchor,
       sessionId: undefined,
       scope: 'chat',
-      chatId: `doc:${fileToken}`,
+      chatId: watchAnchor,
       commentTriggerMode: 'mention-only',
       managedBy: 'watch-comment',
       ownerOpenId: operatorOpenId || getOwnerOpenId(larkAppId),
@@ -3276,10 +3278,10 @@ async function processCommentEvent(
   // 「这条事件**可能**与本 bot 有关，且丢了就真的没了」—— 读不到评论正文时唯一
   // 能用的收窄。两个条件都必须满足才允许打那个**终态、不清理**的 ❌：
   //
-  //  ① 只在 mention-only 下打。这是唯一没有兜底的模式：poller
-  //     （daemon.ts:pollWatchedDocComments）只轮 `commentTriggerMode === 'all'`，
-  //     且直接调 handleDocComment、不经过本函数。所以 'all' 恰恰**有**轮询兜底
-  //     —— push 链路这次拉取失败的评论，下一轮 poll 很可能被正常处理，而 ❌ 是
+  //  ① 只在 mention-only 下打。它没有评论列表轮询；持久 pending 又只在正文、
+  //     @ 与审计门都已通过后才建立，所以这里这种「正文尚不可读」的失败没有恢复
+  //     上下文。'all' 则有列表轮询兜底 —— push 链路这次拉取失败的评论，下一轮
+  //     poll 很可能被正常处理，而 ❌ 是
   //     终态、不会被摘掉，结果就是永久挂在一条根本没丢的评论上。
   //     （早先注释写的「'all' 拉不到就是真丢了」是反的，PR 描述里「不进轮询 ⇒
   //     没兜底 ⇒ 终点」那条论证**只对 mention-only 成立**。）
@@ -3410,8 +3412,7 @@ async function processCommentEvent(
   // 其中一条悄悄绕过审计（本 PR 就险些如此）。这里传的是真实评论正文摘要。
   if (!await passesDocCommentAuditGate(larkAppId, fileToken, parsed.operatorOpenId, text, rollbackAutoSub)) return;
 
-  logger.info(`[doc-comment] dispatch file=${fileToken.slice(0, 12)} comment=${commentId.slice(0, 12)} mode=${sub.commentTriggerMode} → session anchor=${sub.sessionAnchor.slice(0, 12)}`);
-  await handlers.handleDocComment({
+  const delivery: DocCommentContext = {
     larkAppId,
     sub,
     commentId,
@@ -3424,7 +3425,38 @@ async function processCommentEvent(
     })).filter(reply => reply.text.length > 0),
     isWhole: comment.isWhole,
     authorOpenId: trigger.userId,
-  });
+  };
+  logger.info(`[doc-comment] dispatch file=${fileToken.slice(0, 12)} comment=${commentId.slice(0, 12)} mode=${sub.commentTriggerMode} → session anchor=${sub.sessionAnchor.slice(0, 12)}`);
+  let accepted = false;
+  let deliveryError: unknown;
+  try {
+    accepted = await handlers.handleDocComment(delivery);
+  } catch (err) {
+    deliveryError = err;
+  }
+  const retryOutcome = settleDocCommentWsDelivery(
+    config.session.dataDir,
+    larkAppId,
+    fileToken,
+    {
+      commentId: delivery.commentId,
+      replyId: delivery.replyId,
+      text: delivery.text,
+      selectedText: delivery.selectedText,
+      priorReplies: delivery.priorReplies,
+      isWhole: delivery.isWhole,
+      authorOpenId: delivery.authorOpenId,
+      queuedAt: Date.now(),
+    },
+    accepted,
+  );
+  if (!accepted) {
+    logger.warn(
+      `[doc-comment] WS delivery not accepted; retry outcome=${retryOutcome} `
+      + `file=${fileToken.slice(0, 12)} reply=${(delivery.replyId ?? delivery.commentId).slice(0, 12)}`,
+    );
+  }
+  if (deliveryError) throw deliveryError;
 }
 
 const LARK_WS_PROXY_ENV_KEYS = [

--- a/src/services/doc-subs-store.ts
+++ b/src/services/doc-subs-store.ts
@@ -1,10 +1,10 @@
 /**
- * 飞书文档订阅注册表 —— 把「一个被订阅的文档」绑到「一条会话」。
+ * 飞书文档订阅注册表 —— 保存「一个被订阅的文档」的监听配置和可选会话绑定。
  *
  * 设计约束（设计拍板）：
- *   • 一条会话可订阅多个文档（N 行同 sessionAnchor）。
- *   • **一个文档只绑一条活跃会话**：本表以 fileToken 为主键，重复订阅直接覆盖，
- *     天然保证「一条评论事件只命中一条会话」。
+ *   • 显式绑定的监听仍指向一条既有会话，一条会话可订阅多个文档。
+ *   • 无群聊绑定的 watch-comment 只保存文档级监听配置；运行时按 commentId
+ *     创建独立文档原生会话，避免同一文档的并发评论互相合并。
  *
  * 文件按观察者 app 隔离（`doc-subscriptions-<larkAppId>.json`）：飞书 open_id /
  * 文档可见性都是 per-app 的，且生产是「一 bot 一 daemon」，per-app 文件让每个
@@ -20,19 +20,32 @@ import { atomicWriteFileSync } from '../utils/atomic-write.js';
 /** 评论触发范围：仅 @bot 的评论触发 / 该文档所有新评论都触发。 */
 export type CommentTriggerMode = 'mention-only' | 'all';
 
+/** 已通过 WS 的 @/审计门、但 daemon 尚未接纳的评论投递。 */
+export interface PendingDocCommentDelivery {
+  commentId: string;
+  replyId?: string;
+  text: string;
+  selectedText?: string;
+  priorReplies?: Array<{ authorOpenId?: string; text: string }>;
+  isWhole?: boolean;
+  authorOpenId?: string;
+  queuedAt: number;
+  /** Delivery crossed the daemon admission boundary; --all keeps this marker until cursor commit. */
+  acceptedAt?: number;
+}
+
 export interface DocSubscription {
   /** 解析后的底层文档 token（wiki 已换成 obj_token）。主键。 */
   fileToken: string;
   /** 飞书 file_type（docx 等）—— 调评论 / 订阅 API 都要带。 */
   fileType: string;
-  /** 绑定会话的路由锚点：thread-scope=rootMessageId / chat-scope=chatId。 */
+  /** 显式绑定的会话锚点；文档原生 watch 使用独立的 `doc:{fileToken}:watch`。 */
   sessionAnchor: string;
-  /** 绑定会话的 sessionId。daemon 重启恢复时据此查持久化会话状态判定保留/退订
-   *  （不依赖内存 activeSessions，避免误删活跃会话的订阅）。旧订阅可能缺此字段。 */
+  /** 显式绑定会话的 sessionId。文档原生 watch 不绑定 session；旧记录会迁移清除。 */
   sessionId?: string;
   /** 会话 scope —— 重订阅 / 落点路由时要知道。 */
   scope: 'thread' | 'chat';
-  /** 会话所在群（回飞书侧卡片、dashboard 展示用）。 */
+  /** 显式绑定的群；文档原生 watch 与 sessionAnchor 同为内部 watch 地址。 */
   chatId: string;
   /** 评论触发范围。dashboard 可改。 */
   commentTriggerMode: CommentTriggerMode;
@@ -55,7 +68,40 @@ export interface DocSubscription {
   pollCursorReplyId?: string;
   /** 首次成功读取已建立历史基线；false 时只建基线、不触发历史评论。 */
   pollBaselineReady?: boolean;
+  /** WS 已 ACK 但 worker 尚未接纳的评论；daemon 轮询周期负责持久重试。 */
+  pendingDocCommentDeliveries?: PendingDocCommentDelivery[];
   createdAt: number;
+}
+
+export function docWatchAnchor(fileToken: string): string {
+  return `doc:${fileToken}:watch`;
+}
+
+export function docCommentThreadAnchor(fileToken: string, commentId: string): string {
+  return `doc:${fileToken}:${commentId}`;
+}
+
+export function isDocNativeWatchSubscription(sub: DocSubscription): boolean {
+  const legacyAnchor = `doc:${sub.fileToken}`;
+  const watchAnchor = docWatchAnchor(sub.fileToken);
+  return sub.managedBy === 'watch-comment'
+    && sub.scope === 'chat'
+    && (sub.sessionAnchor === legacyAnchor || sub.sessionAnchor === watchAnchor)
+    && (sub.chatId === legacyAnchor || sub.chatId === watchAnchor);
+}
+
+/** Separate the document watch from both legacy and per-comment sessions. */
+export function normalizeDocNativeWatchSubscription(sub: DocSubscription): DocSubscription {
+  if (!isDocNativeWatchSubscription(sub)) return sub;
+  const watchAnchor = docWatchAnchor(sub.fileToken);
+  if (!sub.sessionId && sub.sessionAnchor === watchAnchor && sub.chatId === watchAnchor) return sub;
+  return {
+    ...sub,
+    sessionAnchor: watchAnchor,
+    sessionId: undefined,
+    scope: 'chat',
+    chatId: watchAnchor,
+  };
 }
 
 type FileShape = Record<string, DocSubscription>;
@@ -80,9 +126,8 @@ function writeFile(dataDir: string, larkAppId: string, data: FileShape): void {
 }
 
 /**
- * 新增 / 覆盖一条订阅（fileToken 主键 → 重订阅覆盖旧绑定 = 1 文档:1 会话）。
- * 返回被覆盖掉的旧订阅（如果该文档此前绑在别的会话上），调用方据此退订旧的 /
- * 提示用户。
+ * 新增 / 覆盖一条订阅（fileToken 主键）。显式绑定模式下会覆盖旧会话绑定；
+ * 文档原生 watch 模式下只覆盖文档级监听配置。返回旧订阅供调用方提示。
  */
 export function putDocSubscription(
   dataDir: string,
@@ -91,7 +136,10 @@ export function putDocSubscription(
 ): { previous?: DocSubscription } {
   const data = readFile(dataDir, larkAppId);
   const previous = data[sub.fileToken];
-  data[sub.fileToken] = sub;
+  data[sub.fileToken] = previous?.pendingDocCommentDeliveries
+    && sub.pendingDocCommentDeliveries === undefined
+    ? { ...sub, pendingDocCommentDeliveries: previous.pendingDocCommentDeliveries }
+    : sub;
   writeFile(dataDir, larkAppId, data);
   return { previous };
 }
@@ -162,6 +210,104 @@ export function setDocCommentPollCursor(
   sub.pollCursorAt = cursor?.createdAt;
   sub.pollCursorReplyId = cursor?.replyId;
   sub.pollBaselineReady = baselineReady;
+  writeFile(dataDir, larkAppId, data);
+  return true;
+}
+
+function pendingDeliveryKey(delivery: Pick<PendingDocCommentDelivery, 'commentId' | 'replyId'>): string {
+  return delivery.replyId || delivery.commentId;
+}
+
+/** Persist one WS delivery that must survive daemon restart until accepted. */
+export function upsertPendingDocCommentDelivery(
+  dataDir: string,
+  larkAppId: string,
+  fileToken: string,
+  delivery: PendingDocCommentDelivery,
+): boolean {
+  const data = readFile(dataDir, larkAppId);
+  const sub = data[fileToken];
+  if (!sub) return false;
+  const pending = sub.pendingDocCommentDeliveries ?? [];
+  const key = pendingDeliveryKey(delivery);
+  const index = pending.findIndex(candidate => pendingDeliveryKey(candidate) === key);
+  if (index >= 0) {
+    const existing = pending[index]!;
+    pending[index] = existing.acceptedAt !== undefined && delivery.acceptedAt === undefined
+      ? { ...delivery, acceptedAt: existing.acceptedAt }
+      : delivery;
+  } else pending.push(delivery);
+  sub.pendingDocCommentDeliveries = pending;
+  writeFile(dataDir, larkAppId, data);
+  return true;
+}
+
+/** Record or clear one WS delivery according to its final daemon admission. */
+export function settleDocCommentWsDelivery(
+  dataDir: string,
+  larkAppId: string,
+  fileToken: string,
+  delivery: PendingDocCommentDelivery,
+  accepted: boolean,
+): 'accepted' | 'queued' | 'stopped' {
+  const sub = getDocSubscription(dataDir, larkAppId, fileToken);
+  if (!sub) return 'stopped';
+  if (accepted) {
+    if (sub.managedBy === 'watch-comment' && sub.commentTriggerMode === 'all') {
+      upsertPendingDocCommentDelivery(dataDir, larkAppId, fileToken, {
+        ...delivery,
+        acceptedAt: Date.now(),
+      });
+    } else {
+      removePendingDocCommentDelivery(dataDir, larkAppId, fileToken, delivery);
+    }
+    return 'accepted';
+  }
+  return upsertPendingDocCommentDelivery(dataDir, larkAppId, fileToken, delivery)
+    ? 'queued'
+    : 'stopped';
+}
+
+/** Atomically advance the --all cursor and retire the exact accepted pending marker. */
+export function commitDocCommentPollCursor(
+  dataDir: string,
+  larkAppId: string,
+  fileToken: string,
+  cursor: { createdAt: number; replyId: string },
+  opts: { clearAcceptedBaseline?: boolean } = {},
+): boolean {
+  const data = readFile(dataDir, larkAppId);
+  const sub = data[fileToken];
+  if (!sub) return false;
+  sub.pollCursorAt = cursor.createdAt;
+  sub.pollCursorReplyId = cursor.replyId;
+  sub.pollBaselineReady = true;
+  const pending = sub.pendingDocCommentDeliveries ?? [];
+  const next = opts.clearAcceptedBaseline
+    ? pending.filter(candidate => candidate.acceptedAt === undefined)
+    : pending.filter(candidate => pendingDeliveryKey(candidate) !== cursor.replyId);
+  if (next.length > 0) sub.pendingDocCommentDeliveries = next;
+  else delete sub.pendingDocCommentDeliveries;
+  writeFile(dataDir, larkAppId, data);
+  return true;
+}
+
+/** Remove one accepted/stopped WS delivery. */
+export function removePendingDocCommentDelivery(
+  dataDir: string,
+  larkAppId: string,
+  fileToken: string,
+  delivery: Pick<PendingDocCommentDelivery, 'commentId' | 'replyId'>,
+): boolean {
+  const data = readFile(dataDir, larkAppId);
+  const sub = data[fileToken];
+  if (!sub) return false;
+  const key = pendingDeliveryKey(delivery);
+  const pending = (sub.pendingDocCommentDeliveries ?? [])
+    .filter(candidate => pendingDeliveryKey(candidate) !== key);
+  if (pending.length === (sub.pendingDocCommentDeliveries?.length ?? 0)) return false;
+  if (pending.length > 0) sub.pendingDocCommentDeliveries = pending;
+  else delete sub.pendingDocCommentDeliveries;
   writeFile(dataDir, larkAppId, data);
   return true;
 }

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -119,6 +119,14 @@ describe('API-only bot mode — runtime Feishu transport gates (source lock)', (
     expect(block).toContain('.filter(notApiOnly)');
   });
 
+  it('normalizes legacy document watches before restoring sessions can close them', () => {
+    const block = region(daemonSource, 'reapOrphanWorkers();', '// Close CoT thinking bubbles');
+    expect(block).toContain('normalizeDocNativeSubscriptionsBeforeSessionRestore(cfg.larkAppId)');
+    expect(block).toContain('restoreSessionsAndScheduleStartupRecovery({');
+    expect(block.indexOf('normalizeDocNativeSubscriptionsBeforeSessionRestore(cfg.larkAppId)'))
+      .toBeLessThan(block.indexOf('restoreSessionsAndScheduleStartupRecovery({'));
+  });
+
   it('gates doc-subscription restore + comment poller behind !cfg.apiOnly', () => {
     const block = region(daemonSource, '文档订阅恢复 + 评论轮询', 'Sweep orphan sandbox trees');
     expect(block).toContain('if (!cfg.apiOnly) {');

--- a/test/close-consumer-matrix.test.ts
+++ b/test/close-consumer-matrix.test.ts
@@ -162,6 +162,11 @@ const CONSUMERS: Record<string, Rule> = {
     why: 'Deferred-schedule settlement injection: settlement returns close_refused '
       + 'rather than closed.',
   },
+  'daemon.ts::cleanupFailedDelivery::closeSessionForBackgroundCleanup': {
+    category: 'background',
+    why: 'Document-comment admission rollback has no direct user surface; the '
+      + 'background wrapper logs refused cleanup and any remote residual.',
+  },
   'daemon.ts::failCloseIdempotentTurnIfConvergenceWriteFailed::runIdempotencyFailClose': {
     category: 'background',
     why: 'Typed consumer: refusal never claims fail-closed, residual uses the '

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -434,6 +434,7 @@ vi.mock('../src/im/lark/doc-comment.js', () => {
 });
 
 vi.mock('../src/services/doc-subs-store.js', () => ({
+  docWatchAnchor: (fileToken: string) => `doc:${fileToken}:watch`,
   putDocSubscription: vi.fn(() => ({})),
   removeDocSubscription: vi.fn(),
   listDocSubscriptionsForSession: vi.fn(() => []),
@@ -2070,10 +2071,10 @@ describe('handleCommand', () => {
         LARK_APP_ID,
         expect.objectContaining({
           fileToken: 'doc_token_12345678901234567890',
-          sessionAnchor: 'doc:doc_token_12345678901234567890',
+          sessionAnchor: 'doc:doc_token_12345678901234567890:watch',
           sessionId: undefined,
           scope: 'chat',
-          chatId: 'doc:doc_token_12345678901234567890',
+          chatId: 'doc:doc_token_12345678901234567890:watch',
           workingDir: '/work/repo',
           managedBy: 'watch-comment',
         }),

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -73,8 +73,14 @@ const mocks = vi.hoisted(() => {
       const session = sessions.get(sessionId);
       if (session) session.status = 'closed';
     }),
-    forkWorker: vi.fn((ds: any) => {
+    forkWorker: vi.fn((ds: any, _input?: any, _resume?: any, opts?: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      opts?.onAdmission?.('accepted');
+      return true;
+    }),
+    forkAdoptWorker: vi.fn((ds: any) => {
+      ds.worker = { killed: false, send: vi.fn() };
+      return 'accepted' as const;
     }),
     // Must mirror the real contract: closeSession() always resolves a
     // CloseSessionResult. Returning undefined made the remote-close guard
@@ -90,6 +96,7 @@ const mocks = vi.hoisted(() => {
     scanMultipleProjects: vi.fn(() => [] as any[]),
     getAvailableBots: vi.fn(async () => [] as any[]),
     downloadResources: vi.fn(async () => ({ attachments: [], needLogin: false })),
+    persistStreamCardState: vi.fn((impl: (...args: any[]) => any, ...args: any[]) => impl(...args)),
   };
 });
 
@@ -143,7 +150,10 @@ vi.mock('../src/core/worker-pool.js', async () => {
   return {
     ...actual,
     forkWorker: mocks.forkWorker,
+    forkAdoptWorker: mocks.forkAdoptWorker,
     closeSession: mocks.closeWorkerPoolSession,
+    closeSessionForBackgroundCleanup: (sessionId: string) =>
+      mocks.closeWorkerPoolSession(sessionId),
   };
 });
 
@@ -173,6 +183,8 @@ vi.mock('../src/core/session-manager.js', async () => {
     ...actual,
     getAvailableBots: mocks.getAvailableBots,
     downloadResources: mocks.downloadResources,
+    persistStreamCardState: (...args: any[]) =>
+      mocks.persistStreamCardState(actual.persistStreamCardState, ...args),
   };
 });
 
@@ -201,6 +213,7 @@ import {
   __testOnly_prewarmDocCommentSession as prewarmDocCommentSession,
   __testOnly_releaseQueuedActivationReservation as releaseQueuedActivationReservation,
   __testOnly_resetDocCommentClaims as resetDocCommentClaims,
+  __testOnly_retryPendingDocCommentDeliveries as retryPendingDocCommentDeliveries,
 } from '../src/daemon.js';
 import {
   admitQueuedActivationTail,
@@ -550,9 +563,16 @@ describe('/rename production routing — must not pre-create a session (review P
     mocks.getChatMode.mockResolvedValue('group');
     mocks.getChatNameAndMode.mockResolvedValue({ name: null, mode: 'group' });
     mocks.sessions.clear();
-    mocks.forkWorker.mockImplementation((ds: any) => {
+    mocks.forkWorker.mockImplementation((ds: any, _input?: any, _resume?: any, opts?: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      opts?.onAdmission?.('accepted');
+      return true;
     });
+    mocks.forkAdoptWorker.mockImplementation((ds: any) => {
+      ds.worker = { killed: false, send: vi.fn() };
+      return 'accepted';
+    });
+    mocks.persistStreamCardState.mockImplementation((impl: (...args: any[]) => any, ...args: any[]) => impl(...args));
     mocks.closeWorkerPoolSession.mockImplementation(async (sessionId: string) => {
       for (const [key, candidate] of activeSessions) {
         if (candidate.session.sessionId !== sessionId) continue;
@@ -2842,8 +2862,10 @@ describe('document comment canonical ownership and single-flight delivery', () =
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.sessions.clear();
-    mocks.forkWorker.mockImplementation((ds: any) => {
+    mocks.forkWorker.mockImplementation((ds: any, _input?: any, _resume?: any, opts?: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      opts?.onAdmission?.('accepted');
+      return true;
     });
     mocks.getAvailableBots.mockResolvedValue([]);
     activeSessions.clear();
@@ -2867,6 +2889,21 @@ describe('document comment canonical ownership and single-flight delivery', () =
     return sub;
   }
 
+  function docNativeSub(fileToken: string): any {
+    const anchor = `doc:${fileToken}:watch`;
+    const sub = {
+      fileToken,
+      fileType: 'docx',
+      sessionAnchor: anchor,
+      scope: 'chat' as const,
+      chatId: anchor,
+      commentTriggerMode: 'all' as const,
+      managedBy: 'watch-comment' as const,
+      createdAt: Date.now(),
+    };
+    putDocSubscription(config.session.dataDir, APP, sub);
+    return sub;
+  }
   function docCtx(sub: any, suffix: string): any {
     return {
       larkAppId: APP,
@@ -2971,50 +3008,243 @@ describe('document comment canonical ownership and single-flight delivery', () =
     removeDocSubscription(config.session.dataDir, APP, sub.fileToken);
   });
 
-  it('serializes concurrent get-or-create, merges targets, and reuses canonical state after restart', async () => {
+  it('isolates concurrent document comment threads and reuses one thread after restart', async () => {
     const fileToken = `doc-concurrent-${Date.now()}`;
-    const sub = docSub(fileToken);
+    const sub = docNativeSub(fileToken);
 
     await expect(Promise.all([
       handleDocComment(docCtx(sub, 'one')),
       handleDocComment(docCtx(sub, 'two')),
     ])).resolves.toEqual([true, true]);
 
-    const key = sessionKey(`doc:${fileToken}`, APP);
-    const owner = activeSessions.get(key)!;
-    expect(owner).toBeDefined();
-    expect(mocks.createSession).toHaveBeenCalledTimes(1);
-    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
-    expect(Object.keys(owner.session.docCommentTargets ?? {}).sort()).toEqual(['reply-one', 'reply-two']);
+    const keyOne = sessionKey(`doc:${fileToken}:comment-one`, APP);
+    const keyTwo = sessionKey(`doc:${fileToken}:comment-two`, APP);
+    const ownerOne = activeSessions.get(keyOne)!;
+    const ownerTwo = activeSessions.get(keyTwo)!;
+    expect(ownerOne).toBeDefined();
+    expect(ownerTwo).toBeDefined();
+    expect(ownerOne).not.toBe(ownerTwo);
+    expect(mocks.createSession).toHaveBeenCalledTimes(2);
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(2);
+    expect(Object.keys(ownerOne.session.docCommentTargets ?? {})).toEqual(['reply-one']);
+    expect(Object.keys(ownerTwo.session.docCommentTargets ?? {})).toEqual(['reply-two']);
 
     const persisted = getDocSubscription(config.session.dataDir, APP, fileToken)!;
     expect(persisted).toMatchObject({
-      sessionAnchor: `doc:${fileToken}`,
-      sessionId: owner.session.sessionId,
+      sessionAnchor: `doc:${fileToken}:watch`,
       scope: 'chat',
-      chatId: `doc:${fileToken}`,
+      chatId: `doc:${fileToken}:watch`,
     });
-    // This is the exact anchor closeSession uses to find subscriptions.
-    expect(sessionAnchorId(owner)).toBe(persisted.sessionAnchor);
+    expect(persisted.sessionId).toBeUndefined();
 
-    // Simulate a daemon memory restart restoring the same persisted session at
-    // activeSessionKey(ds), then deliver another comment from a stale snapshot.
     activeSessions.clear();
-    owner.worker = null;
-    activeSessions.set(key, owner);
+    ownerOne.worker = null;
+    activeSessions.set(keyOne, ownerOne);
     const staleSnapshot = { ...sub };
-    await expect(handleDocComment(docCtx(staleSnapshot, 'three'))).resolves.toBe(true);
-    expect(mocks.createSession).toHaveBeenCalledTimes(1);
-    expect(activeSessions.get(key)).toBe(owner);
-    expect(Object.keys(owner.session.docCommentTargets ?? {}).sort()).toEqual([
+    await expect(handleDocComment({
+      ...docCtx(staleSnapshot, 'one-followup'),
+      commentId: 'comment-one',
+    })).resolves.toBe(true);
+    expect(mocks.createSession).toHaveBeenCalledTimes(2);
+    expect(activeSessions.get(keyOne)).toBe(ownerOne);
+    expect(Object.keys(ownerOne.session.docCommentTargets ?? {}).sort()).toEqual([
       'reply-one',
-      'reply-three',
-      'reply-two',
+      'reply-one-followup',
     ]);
 
     removeDocSubscription(config.session.dataDir, APP, fileToken);
   });
+  it('consumes a stale comment after its document watch is stopped during sender lookup', async () => {
+    const fileToken = `doc-stopped-${Date.now()}`;
+    const sub = docNativeSub(fileToken);
+    const gate = deferred();
+    mocks.resolveSender.mockImplementationOnce(async () => {
+      await gate.promise;
+      return { openId: OWNER, type: 'user' as const };
+    });
+    mocks.closeWorkerPoolSession.mockImplementationOnce(async (sessionId: string) => {
+      for (const [key, candidate] of activeSessions) {
+        if (candidate.session.sessionId !== sessionId) continue;
+        activeSessions.delete(key);
+        candidate.session.status = 'closed';
+      }
+      return { ok: true as const, outcome: 'closed' as const, alreadyClosed: false, known: true };
+    });
 
+    const delivery = handleDocComment(docCtx(sub, 'stopped'));
+    await vi.waitFor(() => expect(mocks.createSession).toHaveBeenCalledTimes(1));
+    removeDocSubscription(config.session.dataDir, APP, fileToken);
+    gate.resolve();
+
+    await expect(delivery).resolves.toBe(true);
+    expect(mocks.closeWorkerPoolSession).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+    expect(activeSessions.has(sessionKey(`doc:${fileToken}:comment-stopped`, APP))).toBe(false);
+  });
+
+  it('retries a stale document comment on the latest explicit session binding', async () => {
+    const fileToken = `doc-rebound-${Date.now()}`;
+    const sub = docNativeSub(fileToken);
+    const gate = deferred();
+    mocks.resolveSender.mockImplementationOnce(async () => {
+      await gate.promise;
+      return { openId: OWNER, type: 'user' as const };
+    });
+    mocks.closeWorkerPoolSession.mockImplementationOnce(async (sessionId: string) => {
+      for (const [key, candidate] of activeSessions) {
+        if (candidate.session.sessionId !== sessionId) continue;
+        activeSessions.delete(key);
+        candidate.session.status = 'closed';
+      }
+      return { ok: true as const, outcome: 'closed' as const, alreadyClosed: false, known: true };
+    });
+
+    const delivery = handleDocComment(docCtx(sub, 'rebound'));
+    await vi.waitFor(() => expect(mocks.createSession).toHaveBeenCalledTimes(1));
+    const rebound = seedThreadSession(`om_rebound_${fileToken}`, 'rebound doc owner');
+    putDocSubscription(config.session.dataDir, APP, {
+      ...sub,
+      sessionAnchor: sessionAnchorId(rebound),
+      sessionId: rebound.session.sessionId,
+      scope: rebound.scope,
+      chatId: rebound.chatId,
+    });
+    gate.resolve();
+
+    await expect(delivery).resolves.toBe(true);
+    expect(mocks.closeWorkerPoolSession).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(rebound.session.docCommentTargets).toHaveProperty('reply-rebound');
+    expect(activeSessions.has(sessionKey(`doc:${fileToken}:comment-rebound`, APP))).toBe(false);
+    removeDocSubscription(config.session.dataDir, APP, fileToken);
+  });
+
+  it('keeps a live-worker comment accepted when post-send projection fails', async () => {
+    const fileToken = `doc-live-projection-${Date.now()}`;
+    const sub = docSub(fileToken);
+    sub.commentTriggerMode = 'mention-only';
+    const ds = seedThreadSession(sub.sessionAnchor, 'live projection');
+    const send = vi.fn();
+    ds.worker = { killed: false, send } as any;
+    bindSubToSession(sub, ds);
+    mocks.persistStreamCardState.mockImplementationOnce(() => {
+      throw new Error('projection persistence failed');
+    });
+
+    await expect(handleDocComment(docCtx(sub, 'projection'))).resolves.toBe(true);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(ds.session.docCommentTargets).toHaveProperty('reply-projection');
+    expect(getDocSubscription(config.session.dataDir, APP, fileToken)?.pendingDocCommentDeliveries).toBeUndefined();
+    removeDocSubscription(config.session.dataDir, APP, fileToken);
+  });
+
+  it('keeps the comment retryable when worker admission rejects the fork', async () => {
+    const fileToken = `doc-admission-rejected-${Date.now()}`;
+    const sub = docNativeSub(fileToken);
+    mocks.forkWorker.mockImplementationOnce((_ds: any, _input: any, _resume: any, opts?: any) => {
+      opts?.onAdmission?.('rejected');
+      return true;
+    });
+
+    await expect(handleDocComment(docCtx(sub, 'rejected'))).resolves.toBe(false);
+
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker.mock.calls[0]?.[3]).toEqual(expect.objectContaining({
+      deferDuringDeviceIsolation: false,
+    }));
+    expect(mocks.closeWorkerPoolSession).toHaveBeenCalledTimes(1);
+    expect(activeSessions.has(sessionKey(`doc:${fileToken}:comment-rejected`, APP))).toBe(false);
+    expect(getDocSubscription(config.session.dataDir, APP, fileToken)).not.toBeNull();
+    removeDocSubscription(config.session.dataDir, APP, fileToken);
+  });
+
+  it('keeps an explicitly bound adopted comment retryable when the adopt fork rejects', async () => {
+    const fileToken = `doc-adopt-rejected-${Date.now()}`;
+    const sub = docSub(fileToken);
+    const ds = seedThreadSession(sub.sessionAnchor, 'adopted doc owner');
+    ds.adoptedFrom = {
+      source: 'tmux',
+      tmuxTarget: 'work:0.0',
+      originalCliPid: 4242,
+      sessionId: 'sess-adopt-live',
+      cliId: 'claude-code',
+      cwd: '/repo',
+    };
+    ds.session.adoptedFrom = { ...ds.adoptedFrom };
+    bindSubToSession(sub, ds);
+    mocks.forkAdoptWorker.mockReturnValueOnce('rejected');
+
+    await expect(handleDocComment(docCtx(sub, 'adopt-rejected'))).resolves.toBe(false);
+
+    expect(mocks.forkAdoptWorker).toHaveBeenCalledTimes(1);
+    expect(ds.session.docCommentTargets).not.toHaveProperty('reply-adopt-rejected');
+    expect(getDocSubscription(config.session.dataDir, APP, fileToken)).not.toBeNull();
+    removeDocSubscription(config.session.dataDir, APP, fileToken);
+  });
+
+  it('retries persisted WS delivery across rounds using the latest explicit binding', async () => {
+    const fileToken = `doc-pending-ws-${Date.now()}`;
+    const sub = docSub(fileToken);
+    sub.commentTriggerMode = 'mention-only';
+    putDocSubscription(config.session.dataDir, APP, {
+      ...sub,
+      pendingDocCommentDeliveries: [{
+        commentId: 'comment-pending',
+        replyId: 'reply-pending',
+        text: 'retry me',
+        queuedAt: 1,
+      }],
+    });
+    const attempts: string[] = [];
+    const reject = vi.fn(async (ctx: any) => {
+      attempts.push(ctx.sub.sessionAnchor);
+      return false;
+    });
+
+    const blocked = await retryPendingDocCommentDeliveries(APP, reject);
+    expect(blocked).toEqual({ acceptedKeys: new Set(), blockedFiles: new Set([fileToken]) });
+    expect(getDocSubscription(config.session.dataDir, APP, fileToken)?.pendingDocCommentDeliveries).toHaveLength(1);
+
+    const rebound = seedThreadSession(`om_pending_rebound_${fileToken}`, 'pending rebound');
+    bindSubToSession(getDocSubscription(config.session.dataDir, APP, fileToken)!, rebound);
+    const accept = vi.fn(async (ctx: any) => {
+      attempts.push(ctx.sub.sessionAnchor);
+      return true;
+    });
+    const accepted = await retryPendingDocCommentDeliveries(APP, accept);
+
+    expect(accepted).toEqual({ acceptedKeys: new Set(), blockedFiles: new Set() });
+    expect(attempts).toEqual([sub.sessionAnchor, sessionAnchorId(rebound)]);
+    expect(getDocSubscription(config.session.dataDir, APP, fileToken)?.pendingDocCommentDeliveries).toBeUndefined();
+    removeDocSubscription(config.session.dataDir, APP, fileToken);
+  });
+  it('does not re-execute an accepted --all pending marker after restart', async () => {
+    const fileToken = `doc-accepted-marker-${Date.now()}`;
+    const sub = docSub(fileToken);
+    sub.commentTriggerMode = 'all';
+    putDocSubscription(config.session.dataDir, APP, {
+      ...sub,
+      pendingDocCommentDeliveries: [{
+        commentId: 'comment-accepted',
+        replyId: 'reply-accepted',
+        text: 'already delivered',
+        queuedAt: 1,
+        acceptedAt: 2,
+      }],
+    });
+    const deliver = vi.fn(async () => true);
+
+    await expect(retryPendingDocCommentDeliveries(APP, deliver)).resolves.toEqual({
+      acceptedKeys: new Set([`${fileToken}:reply-accepted`]),
+      blockedFiles: new Set(),
+    });
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(getDocSubscription(config.session.dataDir, APP, fileToken)?.pendingDocCommentDeliveries?.[0])
+      .toMatchObject({ replyId: 'reply-accepted', acceptedAt: 2 });
+    removeDocSubscription(config.session.dataDir, APP, fileToken);
+  });
   it('makes duplicate WS/poll deliveries share failure so neither advances its cursor', async () => {
     const fileToken = `doc-failure-${Date.now()}`;
     const sub = docSub(fileToken);
@@ -3030,8 +3260,10 @@ describe('document comment canonical ownership and single-flight delivery', () =
     expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
 
     // Failure was not recorded as completed: a later poll retry can deliver.
-    mocks.forkWorker.mockImplementation((ds: any) => {
+    mocks.forkWorker.mockImplementation((ds: any, _input?: any, _resume?: any, opts?: any) => {
       ds.worker = { killed: false, send: vi.fn() };
+      opts?.onAdmission?.('accepted');
+      return true;
     });
     await expect(handleDocComment(ctx)).resolves.toBe(true);
     expect(mocks.forkWorker).toHaveBeenCalledTimes(2);

--- a/test/doc-comment-daemon-concurrency.test.ts
+++ b/test/doc-comment-daemon-concurrency.test.ts
@@ -362,6 +362,39 @@ describe('document-comment routing generation primitives', () => {
     expect(winner.session.status).toBe('active');
   });
 
+  it('does not retire an ephemeral session while another turn reserves it or after acceptance', async () => {
+    const daemon = await import('../src/daemon.js');
+    const candidate = makeDocDs('candidate');
+    const key = 'doc:doccnFILE::app-doc';
+    daemon.__testOnly_activeSessions.set(key, candidate);
+    daemon.__testOnly_markEphemeralDocCommentSession(candidate);
+    const releaseOld = daemon.__testOnly_reserveDocCommentSession(candidate, 'turn-old');
+    const releaseNew = daemon.__testOnly_reserveDocCommentSession(candidate, 'turn-new');
+
+    releaseOld();
+    expect(daemon.__testOnly_claimUnacceptedDocCommentSessionRetirement(candidate)).toBe(false);
+    expect(daemon.__testOnly_activeSessions.get(key)).toBe(candidate);
+
+    daemon.__testOnly_acceptDocCommentSession(candidate);
+    releaseNew();
+    expect(daemon.__testOnly_claimUnacceptedDocCommentSessionRetirement(candidate)).toBe(false);
+    expect(daemon.__testOnly_activeSessions.get(key)).toBe(candidate);
+  });
+
+  it('retires an unaccepted ephemeral session only after its final reservation releases', async () => {
+    const daemon = await import('../src/daemon.js');
+    const candidate = makeDocDs('candidate');
+    const key = 'doc:doccnFILE::app-doc';
+    daemon.__testOnly_activeSessions.set(key, candidate);
+    daemon.__testOnly_markEphemeralDocCommentSession(candidate);
+    const release = daemon.__testOnly_reserveDocCommentSession(candidate, 'turn-only');
+
+    expect(daemon.__testOnly_claimUnacceptedDocCommentSessionRetirement(candidate)).toBe(false);
+    release();
+    expect(daemon.__testOnly_claimUnacceptedDocCommentSessionRetirement(candidate)).toBe(true);
+    expect(daemon.__testOnly_activeSessions.has(key)).toBe(false);
+  });
+
   it('makes a concurrent follower await the owner failure instead of reporting success', async () => {
     const daemon = await import('../src/daemon.js');
     let failOwner!: () => void;
@@ -402,10 +435,24 @@ describe('document-comment routing integration', () => {
     expect(region).not.toContain('resolveSender(');
     expect(region).not.toContain('docCommentTurns');
     expect(region).not.toContain('docCommentTargets');
-    expect(region).toContain('const virtualAnchor = virtualChatId;');
+    expect(region).toContain('docCommentThreadAnchor(sub.fileToken, ctx.commentId)');
     expect(region).toContain('registerDocSessionCandidate(routingKey, ds)');
     expect(region).toContain('persistSelectedDocBinding(routingKey, sub, larkAppId, selected, ds)');
     expect(region).toContain('return selected;');
+  });
+
+  it('coordinates persisted WS retries with the --all cursor without double delivery', () => {
+    const start = src.indexOf('async function pollWatchedDocComments');
+    const end = src.indexOf('function normalizeDocNativeSubscriptionsBeforeSessionRestore', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const region = src.slice(start, end);
+    expect(region).toContain('if (pendingRetry.acceptedKeys.has(pendingKey)) return true;');
+    expect(region).toContain('commitDocCommentPollCursor(');
+    expect(region).toContain('if (pendingRetry.blockedFiles.has(snapshot.fileToken)) continue;');
+    expect(region.indexOf('retryPendingDocCommentDeliveries(larkAppId)')).toBeLessThan(
+      region.indexOf('listDocComments(larkAppId'),
+    );
   });
 
   it('revalidates prewarm after sender resolution before mutating or dispatching', () => {

--- a/test/doc-comment-drop-signal.test.ts
+++ b/test/doc-comment-drop-signal.test.ts
@@ -5,8 +5,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 /**
  * #1260：文档评论事件被丢弃时给触发回复打 ❌，让「这条 @ 我没能处理」看得见。
  *
- * 背景：事件已 ACK ⇒ 飞书不重投；mention-only 订阅不进轮询（poller 只收
- * commentTriggerMode==='all'）⇒ 没有兜底。所以事件链路一丢就是终点，而用户侧
+ * 背景：事件已 ACK ⇒ 飞书不重投。通过 @/审计门的投递现在有持久 pending；
+ * 但本文件覆盖的是更早、连安全投递上下文都构造不出的失败，所以仍是终点。用户侧
  * 原本零感知 —— doc 发起的会话在飞书整个不可见，只能去 dashboard 翻 terminal。
  */
 
@@ -245,8 +245,8 @@ describe('processCommentEvent 的接线点（源码形状）', () => {
 
   /**
    * 三个打点的闸口必须一致，且**只在 mention-only 下打**。
-   * 'all' 有 poller 兜底（pollWatchedDocComments 只轮 'all'，且不经过
-   * processCommentEvent），push 这次没读到的评论下轮 poll 很可能被正常处理；
+   * 'all' 有列表 poller 兜底；mention-only 的 pending 要到正文/@/审计均通过后
+   * 才建立，所以本文件覆盖的 pre-dispatch 读失败仍不能靠 pending 恢复；
    * 而 ❌ 是终态不清理，在 'all' 下打就会永久挂在一条根本没丢的评论上。
    */
   it("收窄谓词只认 mention-only + is_mentioned（'all' 有轮询兜底，不该打)", () => {
@@ -267,6 +267,14 @@ describe('processCommentEvent 的接线点（源码形状）', () => {
     // 这个调用在 markCommentEventDropped 里，位于 processCommentEvent **之前**，
     // 不在 region 切片内 —— 用整份源码断言，别锚错范围（锚错就又是一条假绿）。
     expect(src).toContain("rollbackAutoSub, 'dropped-signal')");
+  });
+
+  it('WS 未接纳或抛错都先交给持久重试，再结束 ACK-safe 任务', () => {
+    expect(region).toContain('accepted = await handlers.handleDocComment(delivery)');
+    expect(region.indexOf('const retryOutcome = settleDocCommentWsDelivery(')).toBeGreaterThan(
+      region.indexOf('accepted = await handlers.handleDocComment(delivery)'),
+    );
+    expect(region).toContain('if (deliveryError) throw deliveryError');
   });
 
   it('每个未打标记的早退都回滚 auto-sub（不留 owner 不知情的订阅）', () => {

--- a/test/doc-subs-store.test.ts
+++ b/test/doc-subs-store.test.ts
@@ -10,6 +10,11 @@ import {
   listDocSubscriptionsForSession,
   listAllDocSubscriptions,
   setCommentTriggerMode,
+  docCommentThreadAnchor,
+  isDocNativeWatchSubscription,
+  commitDocCommentPollCursor,
+  normalizeDocNativeWatchSubscription,
+  settleDocCommentWsDelivery,
   type DocSubscription,
 } from '../src/services/doc-subs-store.js';
 
@@ -81,5 +86,104 @@ describe('doc-subs-store', () => {
     putDocSubscription(dataDir, APP_A, sub());
     expect(getDocSubscription(dataDir, APP_B, 'doccnFILE1')).toBeNull();
     expect(listAllDocSubscriptions(dataDir, APP_B)).toEqual([]);
+  });
+
+  it('derives one virtual session anchor per document comment thread', () => {
+    expect(docCommentThreadAnchor('doccnFILE1', 'comment-1')).toBe('doc:doccnFILE1:comment-1');
+    expect(docCommentThreadAnchor('doccnFILE1', 'comment-2')).toBe('doc:doccnFILE1:comment-2');
+  });
+
+  it('persists rejected mention-only WS delivery and clears it after acceptance', () => {
+    putDocSubscription(dataDir, APP_A, sub({
+      managedBy: 'watch-comment',
+      commentTriggerMode: 'mention-only',
+    }));
+    const delivery = {
+      commentId: 'comment-1',
+      replyId: 'reply-1',
+      text: 'question',
+      authorOpenId: 'ou_author',
+      queuedAt: 1,
+    };
+
+    expect(settleDocCommentWsDelivery(dataDir, APP_A, 'doccnFILE1', delivery, false)).toBe('queued');
+    expect(getDocSubscription(dataDir, APP_A, 'doccnFILE1')?.pendingDocCommentDeliveries).toEqual([delivery]);
+
+    // A later explicit rebind must not erase the unaccepted WS turn.
+    putDocSubscription(dataDir, APP_A, sub({ sessionAnchor: 'om_rebound' }));
+    expect(getDocSubscription(dataDir, APP_A, 'doccnFILE1')?.pendingDocCommentDeliveries).toEqual([delivery]);
+
+    expect(settleDocCommentWsDelivery(dataDir, APP_A, 'doccnFILE1', delivery, true)).toBe('accepted');
+    expect(getDocSubscription(dataDir, APP_A, 'doccnFILE1')?.pendingDocCommentDeliveries).toBeUndefined();
+  });
+
+  it('preserves pending retry ownership when mode switches to all', () => {
+    const delivery = {
+      commentId: 'comment-1', replyId: 'reply-1', text: 'question', queuedAt: 1,
+    };
+    putDocSubscription(dataDir, APP_A, sub({
+      managedBy: 'watch-comment',
+      commentTriggerMode: 'mention-only',
+      pendingDocCommentDeliveries: [delivery],
+    }));
+
+    expect(setCommentTriggerMode(dataDir, APP_A, 'doccnFILE1', 'all')).toBe(true);
+    expect(getDocSubscription(dataDir, APP_A, 'doccnFILE1')?.pendingDocCommentDeliveries).toEqual([delivery]);
+  });
+
+  it('persists rejected --all WS delivery until the retry loop or list cursor accepts it', () => {
+    putDocSubscription(dataDir, APP_A, sub({
+      managedBy: 'watch-comment',
+      commentTriggerMode: 'all',
+    }));
+    const delivery = { commentId: 'comment-1', replyId: 'reply-1', text: 'question', queuedAt: 1 };
+
+    expect(settleDocCommentWsDelivery(dataDir, APP_A, 'doccnFILE1', delivery, false)).toBe('queued');
+    expect(getDocSubscription(dataDir, APP_A, 'doccnFILE1')?.pendingDocCommentDeliveries).toEqual([delivery]);
+  });
+
+  it('keeps an accepted --all marker across restart until cursor commit retires it atomically', () => {
+    putDocSubscription(dataDir, APP_A, sub({
+      managedBy: 'watch-comment',
+      commentTriggerMode: 'all',
+      pollBaselineReady: true,
+      pollCursorAt: 10,
+      pollCursorReplyId: '100',
+    }));
+    const delivery = { commentId: 'comment-1', replyId: '101', text: 'question', queuedAt: 1 };
+    // First-attempt success has no pre-existing pending row; it must still
+    // create a durable accepted marker until the cursor commits.
+    expect(settleDocCommentWsDelivery(dataDir, APP_A, 'doccnFILE1', delivery, true)).toBe('accepted');
+
+    const accepted = getDocSubscription(dataDir, APP_A, 'doccnFILE1')?.pendingDocCommentDeliveries?.[0];
+    expect(accepted).toMatchObject({ replyId: '101', acceptedAt: expect.any(Number) });
+
+    expect(commitDocCommentPollCursor(
+      dataDir, APP_A, 'doccnFILE1', { createdAt: 11, replyId: '101' },
+    )).toBe(true);
+    expect(getDocSubscription(dataDir, APP_A, 'doccnFILE1')).toMatchObject({
+      pollCursorAt: 11,
+      pollCursorReplyId: '101',
+      pollBaselineReady: true,
+    });
+    expect(getDocSubscription(dataDir, APP_A, 'doccnFILE1')?.pendingDocCommentDeliveries).toBeUndefined();
+  });
+
+  it('normalizes legacy document-native watches without retaining one session binding', () => {
+    const legacy = sub({
+      sessionAnchor: 'doc:doccnFILE1',
+      sessionId: 'legacy-session',
+      scope: 'chat',
+      chatId: 'doc:doccnFILE1',
+      managedBy: 'watch-comment',
+    });
+
+    expect(isDocNativeWatchSubscription(legacy)).toBe(true);
+    expect(normalizeDocNativeWatchSubscription(legacy)).toEqual({
+      ...legacy,
+      sessionAnchor: 'doc:doccnFILE1:watch',
+      sessionId: undefined,
+      chatId: 'doc:doccnFILE1:watch',
+    });
   });
 });

--- a/test/session-delete-close-barrier.test.ts
+++ b/test/session-delete-close-barrier.test.ts
@@ -120,6 +120,61 @@ describe('daemon close barrier used by botmux delete', () => {
     }
   });
 
+  it('keeps a document watch when one comment-thread session closes', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-doc-thread-close-'));
+    tempDirs.push(dataDir);
+    const previousDataDir = config.session.dataDir;
+    config.session.dataDir = dataDir;
+    sessionStore.init('app-doc-thread-close');
+    const fileToken = 'doc-thread-close';
+    const watchAnchor = docSubsStore.docWatchAnchor(fileToken);
+    docSubsStore.putDocSubscription(dataDir, 'app-doc-thread-close', {
+      fileToken,
+      fileType: 'docx',
+      sessionAnchor: watchAnchor,
+      scope: 'chat',
+      chatId: watchAnchor,
+      commentTriggerMode: 'mention-only',
+      managedBy: 'watch-comment',
+      createdAt: Date.now(),
+    });
+    const unsubscribe = vi.spyOn(docComment, 'unsubscribeDocFile');
+
+    try {
+      const commentAnchor = docSubsStore.docCommentThreadAnchor(fileToken, 'comment-1');
+      const session = sessionStore.createSession(commentAnchor, commentAnchor, 'doc comment thread', 'group');
+      session.larkAppId = 'app-doc-thread-close';
+      session.scope = 'chat';
+      sessionStore.updateSession(session);
+      const ds = {
+        session,
+        worker: null,
+        workerPort: null,
+        workerToken: null,
+        workerViewToken: null,
+        larkAppId: 'app-doc-thread-close',
+        chatId: commentAnchor,
+        chatType: 'group',
+        scope: 'chat',
+        spawnedAt: Date.now(),
+        cliVersion: 'test',
+        lastMessageAt: Date.now(),
+        hasHistory: true,
+      } as any;
+      workerPool.setActiveSessionsRegistry(new Map([[activeSessionKey(ds), ds]]));
+
+      await expect(workerPool.closeSession(session.sessionId)).resolves.toMatchObject({ ok: true });
+
+      expect(docSubsStore.getDocSubscription(dataDir, 'app-doc-thread-close', fileToken)).toMatchObject({
+        sessionAnchor: watchAnchor,
+        managedBy: 'watch-comment',
+      });
+      expect(unsubscribe).not.toHaveBeenCalled();
+    } finally {
+      config.session.dataDir = previousDataDir;
+    }
+  });
+
   it('keeps bridge send markers until the live worker acknowledges close', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'botmux-close-fence-'));
     tempDirs.push(dataDir);

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -186,9 +186,15 @@ import {
   initWorkerPool,
   promoteQueuedActivationTail,
   restartCounts,
+  setActiveSessionsRegistry,
   sendWorkerInput,
   suspendWorker,
 } from '../src/core/worker-pool.js';
+import {
+  acquireDeviceIsolationFreeze,
+  releaseDeviceIsolationFreeze,
+  resetDeviceIsolationActivationForTest,
+} from '../src/core/device-isolation-activation.js';
 import {
   managedOriginCapabilityDirectory,
   readManagedOriginCapability,
@@ -263,6 +269,7 @@ beforeEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
   vi.mocked(sessionStore.updateSession).mockImplementation(() => undefined);
+  vi.mocked(sessionStore.updateSessionPid).mockImplementation(() => undefined);
   __testOnly_resetOrdinaryImDeliveries();
   vi.mocked(getBot).mockImplementation(() => defaultBot());
   __testOnly_resetSessionLifecycleHooks();
@@ -314,11 +321,15 @@ describe('host memory pressure worker admission', () => {
     });
     const ds = makeDs({ hasHistory: true });
 
-    expect(forkWorker(ds, 'resume me', { resume: true, turnId: 'om_retry' })).toBe(true);
+    const admissions: string[] = [];
+    expect(forkWorker(ds, 'resume me', { resume: true, turnId: 'om_retry' }, {
+      onAdmission: admission => admissions.push(admission),
+    })).toBe(true);
     await Promise.resolve();
 
     expect(forkMock).not.toHaveBeenCalled();
     expect(ds.worker).toBeNull();
+    expect(admissions).toEqual(['rejected']);
     expect(sessionReply).toHaveBeenCalledWith(
       'om_root',
       expect.stringMatching(/memory pressure.*retry/i),
@@ -327,6 +338,45 @@ describe('host memory pressure worker admission', () => {
       'om_retry',
       undefined,
     );
+  });
+
+  it('reports accepted after a worker receives its init message', () => {
+    const ds = makeDs();
+    const admissions: string[] = [];
+
+    expect(forkWorker(ds, 'hello', false, {
+      onAdmission: admission => admissions.push(admission),
+    })).toBe(true);
+
+    expect(forkMock).toHaveBeenCalledTimes(1);
+    expect(admissions).toEqual(['accepted']);
+  });
+
+  it('leaves explicit retry ownership with the caller during device isolation', async () => {
+    const ds = makeDs({ hasHistory: true });
+    setActiveSessionsRegistry(new Map([['active', ds]]));
+    acquireDeviceIsolationFreeze({
+      nonce: 'n'.repeat(32),
+      inventoryGeneration: 'g1',
+      leaseIdFactory: () => 'lease-1',
+    });
+    const admissions: string[] = [];
+
+    try {
+      expect(forkWorker(ds, 'resume me', { resume: true, turnId: 'om_deferred' }, {
+        onAdmission: admission => admissions.push(admission),
+        deferDuringDeviceIsolation: false,
+      })).toBe(true);
+      expect(admissions).toEqual(['rejected']);
+      releaseDeviceIsolationFreeze({ nonce: 'n'.repeat(32), leaseId: 'lease-1' });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(forkMock).not.toHaveBeenCalled();
+      expect(admissions).toEqual(['rejected']);
+    } finally {
+      setActiveSessionsRegistry(undefined);
+      resetDeviceIsolationActivationForTest();
+    }
   });
 });
 
@@ -3328,6 +3378,44 @@ describe('adopt worker re-fork forwards the incoming turn (PR#293 issue #3)', ()
     }));
     expect(init.turnId).toBeUndefined();
   });
+
+  it('keeps an adopted turn accepted when post-init pid persistence fails', () => {
+    const ds = makeAdoptDs();
+    vi.mocked(sessionStore.updateSessionPid).mockImplementationOnce(() => {
+      throw new Error('pid persistence failed');
+    });
+
+    expect(forkAdoptWorker(ds, {
+      prompt: '<bridge>accepted once</bridge>',
+      turnId: 'om_adopt_pid_failure',
+    })).toBe('accepted');
+
+    const worker = ds.worker as any;
+    expect(worker.send).toHaveBeenCalledTimes(1);
+    expect(worker.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'init',
+      prompt: '<bridge>accepted once</bridge>',
+      turnId: 'om_adopt_pid_failure',
+    }));
+  });
+
+  it('cleans up and reports a synchronous adopt init send failure', () => {
+    const ds = makeAdoptDs();
+    const worker = makeFakeWorker();
+    worker.send.mockImplementationOnce(() => {
+      throw new Error('init send failed');
+    });
+    forkMock.mockReturnValueOnce(worker);
+
+    expect(() => forkAdoptWorker(ds, {
+      prompt: '<bridge>not accepted</bridge>',
+      turnId: 'om_adopt_send_failure',
+    })).toThrow('init send failed');
+
+    expect(ds.worker).toBeNull();
+    expect(ds.initConfig).toBeUndefined();
+    expect(worker.kill).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('session.start lifecycle integration', () => {
@@ -3909,7 +3997,7 @@ describe('blocker #3: forkAdoptWorker refuses sandbox-enabled bots', () => {
     vi.mocked(getBot).mockImplementation(() => defaultBot({ sandbox: true }));
     const ds = adopt();
     ds.session.adoptedFrom = { ...ds.adoptedFrom } as any;
-    forkAdoptWorker(ds);
+    expect(forkAdoptWorker(ds)).toBe('rejected');
     expect(forkMock).not.toHaveBeenCalled();
     expect(emitHookEventMock).not.toHaveBeenCalledWith('session.start', expect.anything());
     expect(ds.adoptedFrom).toBeUndefined();
@@ -3927,7 +4015,7 @@ describe('blocker #3: forkAdoptWorker refuses sandbox-enabled bots', () => {
 
   it('no sandbox anywhere → adopt proceeds (fork + session.start)', () => {
     vi.mocked(getBot).mockImplementation(() => defaultBot());
-    forkAdoptWorker(adopt());
+    expect(forkAdoptWorker(adopt())).toBe('accepted');
     expect(forkMock).toHaveBeenCalled();
     expect(emitHookEventMock).toHaveBeenCalledWith('session.start', expect.objectContaining({
       reason: 'adopt',


### PR DESCRIPTION
## 问题

飞书文档原生评论监听当前按整篇文档复用 `doc:{fileToken}` 会话。同一文档短时间出现多条独立评论时，它们会进入同一个 CLI 会话，后续评论可能被合并到正在执行的 turn，表现为部分评论长期没有正式回复。

预期行为应与飞书话题会话一致：不同评论线程互相独立、可以并行；同一评论线程的后续回复继续复用原会话。

## 修复

- 文档原生监听不再让整篇文档共用一个 CLI 会话，改为按 `fileToken + commentId` 创建或复用会话；不同评论线程可并行，同一评论线程继续复用。
- 文档监听使用独立的 `doc:{fileToken}:watch` 锚点。关闭单个评论会话不会停止整篇文档监听；旧绑定会在会话恢复前迁移。
- 评论处理期间重读最新订阅，正确处理停止监听和显式重绑竞态。
- worker、adopt、device isolation 未最终接纳输入时不推进评论；WS 事件已 ACK 的未接纳评论会持久化重试，重启后继续投递。
- `--all` 模式用 accepted marker 衔接 WS 重试与列表游标：评论已执行但游标尚未提交时不会重复执行，游标推进与 marker 清理使用同一次原子写。
- 文档评论候选会话增加 reservation，失败清理不会误杀已被并发评论复用的会话。

## 影响面

- 影响：`watch-comment` 文档原生会话、评论 WS/轮询投递、会话恢复和关闭流程，以及 worker/adopt 的接纳结果上报。
- 不改变：普通飞书话题/群会话、显式绑定到既有会话的评论路由、各 CLI/后端的启动参数。
- 公共 worker fork 路径新增可选 admission 回调；现有布尔返回契约保持不变。

## 验证

- 针对性单元测试：`9` 个测试文件，`733 passed`。
- TypeScript：`tsconfig.json`、`tsconfig.test-mocks.json`、`tsconfig.scripts.json` 均通过。
- Bun 1.4.2：`bun run build` 通过，dist 与嵌入资源审计通过。
- 完整 unit suite此前运行到 `22506 passed`，其中 3 项基线失败（2 个 MCP sandbox、1 个 Dashboard loopback timeout）；在精确基线 `60b460c1` 上可同样复现。
- 开发机已部署并重启：3 个 Bot 和 Dashboard 均在线。