### PR TITLE
fix(codex): 进程级关闭低额度切 luna 的模型 nudge 弹窗

### DIFF
--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -188,7 +188,16 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
         // enter to continue" dialog would block the resume forever and freeze the
         // Web terminal. Disable the check at the PROCESS level (never the user's
         // global config). The bounded startup-dialog watcher is only a fail-safe.
-        return ['--remote', remoteWsUrl, 'resume', '--no-alt-screen', '-c', 'check_for_update_on_startup=false', remoteThreadId];
+        //
+        // -c notice.hide_rate_limit_model_nudge=true: the viewer is itself a TUI
+        // and renders the low-usage luna switch popup. botmux never injects keys
+        // here, so it cannot be confirmed by accident, but the modal still covers
+        // the pane and confuses screen-state detection / manual inspection; keep
+        // it suppressed like the startup update picker.
+        return ['--remote', remoteWsUrl, 'resume', '--no-alt-screen',
+          '-c', 'check_for_update_on_startup=false',
+          '-c', 'notice.hide_rate_limit_model_nudge=true',
+          remoteThreadId];
       }
       // Read isolation for Codex is enforced by the worker's Seatbelt wrapper,
       // NOT by codex's own profile (codex 0.137 can't express a read blocklist).
@@ -220,6 +229,19 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
         // not); the host-side daily monitor reports newer versions to the owner.
         '-c',
         'check_for_update_on_startup=false',
+        // Codex 0.151+ opens a "Switch to <luna-tier model> for lower credit
+        // usage?" selection view once the primary usage limit is >=90% used
+        // (upstream RATE_LIMIT_SWITCH_PROMPT_THRESHOLD). Its first item is the
+        // default selection and performs the switch, so this paste path's
+        // trailing submit Enter confirms the popup instead of sending the Lark
+        // message — the session silently downgrades model AND reasoning effort,
+        // or the Enter is swallowed and the message never runs (see #1281).
+        // Process-level opt-out, equivalent to the popup's "Keep current model
+        // (never show again)"; never written to the user's global config. Added
+        // on BOTH TUI launch shapes (this plain pane and the --remote viewer
+        // above); app-server/runner CLIs render no TUI popup and need no flag.
+        '-c',
+        'notice.hide_rate_limit_model_nudge=true',
       ];
       // Under read isolation the worker denies bots.json, so `botmux send` (a shell
       // subprocess) registers this bot from the worker-written cred FILE, keyed by

--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -317,7 +317,8 @@ export function stripSettingsArgs(args: ReadonlyArray<string>): string[] {
 /**
  * 剥掉 aiden `aiden x <cli>` 网关拒收的、**botmux 注入的**底层 CLI config 覆盖参数：
  *   - `--settings <v>` / `--settings=<v>`（claude 携带 hook/bypass，aiden x claude 历来就剥）
- *   - botmux 自己注入的 Codex `-c`（session 环境，以及关闭启动更新选择器）；
+ *   - botmux 自己注入的 Codex `-c`（session 环境、关闭启动更新选择器，以及关闭低额度
+ *     切 luna 的模型 nudge 弹窗）；
  *     aiden 1.8.38+ 会直接报错拒收 `aiden x codex` 透传的 `-c`/`--config`。
  *   - `--dangerously-bypass-hook-trust`（codex 家族的 hook-trust 绕过 flag）：aiden 网关
  *     自身已管理底层 codex 的 hook-trust，botmux 再透传一份会让 codex 收到两次 →

--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -292,6 +292,10 @@ function isBotmuxCodexConfigValue(value: string | undefined): boolean {
   return !!value && (
     value.startsWith('shell_environment_policy.set.BOTMUX_')
     || value === 'check_for_update_on_startup=false'
+    // 关闭 codex 低额度切 luna 的模型 nudge 弹窗（见 codex 适配器 buildArgs），
+    // 同属 botmux 注入的进程级 config 覆盖，须与上面的更新检查一并被 wrapper 识别，
+    // 否则 aiden 网关会拒收裸 `-c` 直接启动失败。
+    || value === 'notice.hide_rate_limit_model_nudge=true'
   );
 }
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -502,7 +502,9 @@ describe('codex buildArgs', () => {
     // pure --remote viewer: no paste-mode bypass flag, no stale resume path
     expect(args).toEqual([
       '--remote', 'ws://127.0.0.1:9931', 'resume', '--no-alt-screen',
-      '-c', 'check_for_update_on_startup=false', 'thread-abc',
+      '-c', 'check_for_update_on_startup=false',
+      '-c', 'notice.hide_rate_limit_model_nudge=true',
+      'thread-abc',
     ]);
     // the -c disable must land BEFORE the thread id (a resume-subcommand config)
     const cIdx = args.indexOf('-c');
@@ -568,6 +570,8 @@ describe('codex buildArgs', () => {
       'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
       '-c',
       'check_for_update_on_startup=false',
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
       '-C',
       '/repo/root',
     ]);
@@ -581,6 +585,8 @@ describe('codex buildArgs', () => {
       'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
       '-c',
       'check_for_update_on_startup=false',
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
       '-C',
       '/repo/root',
     ]);
@@ -593,6 +599,40 @@ describe('codex buildArgs', () => {
     const idx = args.indexOf('check_for_update_on_startup=false');
     expect(idx).toBeGreaterThan(0);
     expect(args[idx - 1]).toBe('-c');
+  });
+
+  it('suppresses the low-usage luna model nudge for plain TUI launches', () => {
+    // Codex 0.151+ shows a "Switch to <luna> for lower credit usage?" popup at
+    // >=90% primary usage; its default item switches models, and the paste
+    // path's submit Enter would confirm it (#1281). Process-level -c only.
+    const fresh = adapter.buildArgs({ sessionId: 'sess-4', resume: false });
+    const idx = fresh.indexOf('notice.hide_rate_limit_model_nudge=true');
+    expect(idx).toBeGreaterThan(0);
+    expect(fresh[idx - 1]).toBe('-c');
+
+    // Must survive resume as well, placed before the resumed session id.
+    const resumed = adapter.buildArgs({
+      sessionId: 'sess-4',
+      resume: true,
+      resumeSessionId: 'codex-session-id',
+    });
+    const resumeIdx = resumed.indexOf('notice.hide_rate_limit_model_nudge=true');
+    expect(resumeIdx).toBeGreaterThan(0);
+    expect(resumeIdx).toBeLessThan(resumed.indexOf('codex-session-id'));
+  });
+
+  it('also suppresses the luna nudge popup on the pure --remote RPC viewer', () => {
+    // The viewer injects no keys (turns go through app-server JSON-RPC), but it
+    // is itself a TUI that renders the modal; keep the pane free of it like the
+    // startup update picker, before the resumed thread id.
+    const args = adapter.buildArgs({
+      sessionId: 'sess-rpc', resume: true,
+      remoteWsUrl: 'ws://127.0.0.1:9931', remoteThreadId: 'thread-abc',
+    });
+    const idx = args.indexOf('notice.hide_rate_limit_model_nudge=true');
+    expect(idx).toBeGreaterThan(0);
+    expect(args[idx - 1]).toBe('-c');
+    expect(idx).toBeLessThan(args.indexOf('thread-abc'));
   });
 
   it('keeps the startup update override on resume before the Codex session id', () => {

--- a/test/cli-selection.test.ts
+++ b/test/cli-selection.test.ts
@@ -344,6 +344,19 @@ describe('buildWrappedLaunch', () => {
     expect(out.args).toEqual(['x', 'codex', '--no-alt-screen']);
   });
 
+  it('strips the luna-nudge override alongside the startup-update one (aiden x codex)', () => {
+    // aiden 1.8.38+ rejects passthrough -c outright; without whitelisting this
+    // botmux-injected value the launch would abort instead of merely losing it.
+    const out = buildWrappedLaunch('aiden x codex', [
+      '-c',
+      'check_for_update_on_startup=false',
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
+      '--no-alt-screen',
+    ]);
+    expect(out.args).toEqual(['x', 'codex', '--no-alt-screen']);
+  });
+
   it('does not strip a user-supplied -c that is not a botmux override (aiden x codex)', () => {
     const out = buildWrappedLaunch('aiden x codex', ['-c', 'model_reasoning_effort="high"', '--model', 'm']);
     expect(out.args).toEqual(['x', 'codex', '-c', 'model_reasoning_effort="high"', '--model', 'm']);
@@ -407,6 +420,16 @@ describe('buildWrappedLaunch', () => {
       'check_for_update_on_startup=false',
     ]);
     expect(out.args).toEqual(['codex', '--config', 'check_for_update_on_startup=false']);
+  });
+
+  it('rewrites the luna-nudge override to --config for cjadk codex', () => {
+    // Same -c → --config passthrough requirement as the startup-update override;
+    // cjadk's code subcommand claims -c as --command otherwise.
+    const out = buildWrappedLaunch('cjadk codex', [
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
+    ]);
+    expect(out.args).toEqual(['codex', '--config', 'notice.hide_rate_limit_model_nudge=true']);
   });
 
   it('keeps the codex -c override for the bare-passthrough ttadk codex gateway', () => {

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -1359,6 +1359,8 @@ describe('codex writeInput submission confirmation', () => {
       'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       '-c',
       'check_for_update_on_startup=false',
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
       '019dd3e2-f2da-7592-86b5-a43d4cd0772f',
     ]);
   });
@@ -1380,6 +1382,8 @@ describe('codex writeInput submission confirmation', () => {
       'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       '-c',
       'check_for_update_on_startup=false',
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
       '019dd3e2-f2da-7592-86b5-a43d4cd0772f',
     ]);
   });
@@ -1399,6 +1403,8 @@ describe('codex writeInput submission confirmation', () => {
       'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       '-c',
       'check_for_update_on_startup=false',
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
       'new-codex-session',
     ]);
   });
@@ -1419,6 +1425,8 @@ describe('codex writeInput submission confirmation', () => {
         'shell_environment_policy.set.BOTMUX_SESSION_ID="custom-botmux-session"',
         '-c',
         'check_for_update_on_startup=false',
+        '-c',
+        'notice.hide_rate_limit_model_nudge=true',
         'custom-codex-session',
       ]);
 
@@ -1444,6 +1452,8 @@ describe('codex writeInput submission confirmation', () => {
       'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       '-c',
       'check_for_update_on_startup=false',
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
     ]);
   });
 
@@ -1462,6 +1472,8 @@ describe('codex writeInput submission confirmation', () => {
       'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       '-c',
       'check_for_update_on_startup=false',
+      '-c',
+      'notice.hide_rate_limit_model_nudge=true',
       '-C',
       '/repo/root',
     ]);


### PR DESCRIPTION
## 改了什么

Codex CLI 0.151+ 在主额度用量 ≥90%（剩余 <10%，上游常量 `RATE_LIMIT_SWITCH_PROMPT_THRESHOLD = 90.0`，见 `codex-rs/tui/src/chatwidget/rate_limits.rs`）时，TUI 会弹出 "Approaching rate limits：Switch to gpt-5.6-luna for lower credit usage?" 选择框，三个选项中第一项 **"Switch to gpt-5.6-luna" 是默认选中项**，裸回车即确认（同时把模型与 reasoning effort 切到 luna 预设）。

botmux 传统粘贴链路是「bracketed paste 正文 + ~200ms 后补 Enter」。弹窗存在时该 Enter 被弹窗消费，线上观测到两种表现：

1. **模型被静默切换**：Enter 确认了默认项，会话在 luna + 被覆盖的 effort 上继续执行；
2. **`submit_unconfirmed`**：Enter 被模态框吞掉，正文留在 composer 未提交，消息实际未执行。

属于 #1281 记录的「抢 Enter 的弹窗家族」之一（该 issue 已明确列出额度 <10% 切 luna 确认框）。

修复：codex 适配器的**两条 TUI 启动形态**均在启动参数注入进程级 config 覆盖：

```
-c notice.hide_rate_limit_model_nudge=true
```

- 该键是上游官方配置（`config.schema.json` 顶层 `[notice]` 表；等价于在弹窗选一次 "Keep current model (never show again)"，上游 `edit.rs` 持久化到同一键路径），只作用于本次进程，**不写用户全局 config.toml**；
- 普通 TUI 分支：消除弹窗本身，粘贴 Enter 不再有模态框可消费；
- `--remote` RPC viewer 分支：viewer 自身仍是 TUI、会渲染该弹窗。botmux 虽不向 viewer 注入按键（不可能误确认），但模态框会盖住 pane、干扰屏幕状态检测与 Web 终端人工查看，故与既有的 `check_for_update_on_startup=false` 同样在 viewer 上关闭；
- app-server / runner（codex-app 等）是 headless 链路，TUI notice 不会渲染，不加；
- traex 适配器不动：其传统分支本就没有同类注入，且该 nudge 是 openai codex TUI 的功能。

## wrapper 兼容（影响面重点）

`src/setup/cli-selection.ts` 的 botmux 注入参数白名单 `isBotmuxCodexConfigValue` 同步加入新值：

- **aiden** 网关 1.8.38+ 直接拒收透传的裸 `-c`，新值若不进白名单会导致经 aiden 的 codex 启动失败（白名单命中后按既有策略剥离，该路径本就无法传递此类覆盖）；
- **cjadk** 依赖同一白名单把 `-c` 改写成 `--config` 透传；
- ttadk 等裸透传网关原样转发，直接生效。

## 影响面评估

- 跨 CLI：仅改动 codex 适配器与 codex wrapper 白名单；白名单是「botmux 注入特征」精确匹配，用户自带的 `-c key=val` 不受影响；traex 及其余 20+ CLI 不涉及。
- 跨会话类型：新建会话生效；已存在的旧会话 resume 时也带新参数（参数在每次 buildArgs 时构造）。
- 行为变化：botmux 管理的 codex 不再弹出低额度切模型提示。额度状态用户仍可在 codex 内 `/status`、以及 botmux 自身的额度/限流结构化通知中看到；不影响 codex 真正耗尽额度后的报错与 botmux 的额度耗尽交接（quota fallback）链路。
- 对旧版 codex（不含该配置键的版本）：codex 对未知 `-c` 配置键宽松忽略（与既有注入项同一机制），不会启动失败。

## 测试验证

- `node_modules/.bin/tsc --noEmit` 通过；
- `vitest run test/cli-adapters.test.ts test/cli-selection.test.ts test/write-input.test.ts`：669 passed；
- `vitest run` codex 相关其余 7 个测试文件（rpc-lifecycle / hook-trust / startup-readiness / read-isolation / effort-wiring / trigger-user-shell-env / cli-usage-limit）：143 passed；
- 实测 codex 0.151.0：`[notice] hide_rate_limit_model_nudge=true` 配置可被完整加载（正常进入运行阶段），配置路径与官方 `config.schema.json` 及上游持久化代码一致；
- 新增测试覆盖：普通 TUI 与 resume 参数位置、`--remote` viewer 参数位置（位于 thread id 之前）、aiden 剥离、cjadk `-c→--config` 改写，并更新全部既有 buildArgs 快照。

Refs #1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)