### PR TITLE
fix(open-platform): 飞书登录态失效归类为 session_expired，触发重新扫码

### DIFF
--- a/src/services/open-platform-rename.ts
+++ b/src/services/open-platform-rename.ts
@@ -28,6 +28,7 @@ import {
   extractVersionId,
   nextAppVersion,
   OpenPlatformApiError,
+  openPlatformWebSessionExpired,
   readStoredCookiesFromSessionFile,
   safeErrorMessage,
   type OpenPlatformApiClient,
@@ -78,6 +79,17 @@ function failureFromError(err: unknown, fallbackReason: OpenPlatformRenameFailur
     if (code === 10003) {
       return { reason: 'no_access', message: '当前缓存的飞书账号不是该应用的协作者，开放平台拒绝访问（code=10003）' };
     }
+  }
+  // 飞书 console Web 登录态失效（cookie 过期后调 /developers/v1/* 会返回 passport
+  // 登出信号）——复用 open-platform-automation 的统一判定器：它综合 HTTP 401、
+  // Code/code=4101、code=99991641 且 LogoutReason=40、「请重新登录」文案和 cause
+  // 链，且刻意不把顶层通用 code=99991641 单独当登录失效（避免一般 console 故障
+  // 误弹扫码，见 automation.ts 注释与 redirect-repair 反例测试）。命中后归类
+  // session_expired，dashboard 引导重新扫码而不是把裸的 HTTP 400 甩给用户。
+  if (openPlatformWebSessionExpired(err)) {
+    return { reason: 'session_expired', message: '飞书开放平台登录态已失效，请重新扫码登录后重试' };
+  }
+  if (err instanceof OpenPlatformApiError) {
     return { reason: fallbackReason, message: err.message };
   }
   // 网络类错误（undici "fetch failed"）的真实原因在 cause 链里，safeErrorMessage 会带上。

--- a/test/open-platform-description.test.ts
+++ b/test/open-platform-description.test.ts
@@ -127,6 +127,22 @@ describe('readBotDescriptionsOnOpenPlatform', () => {
     });
     expect(result).toMatchObject({ ok: false, reason: 'no_access' });
   });
+
+  // console cookie 过期后读描述会在第一笔 app/:id 就撞上 passport 登出信号，必须
+  // 归类 session_expired（dashboard 才弹重新扫码），而不是把裸的 HTTP 400 甩出去。
+  it('maps an expired web session (real HTTP 400 passport payload) to session_expired', async () => {
+    const result = await readBotDescriptionsOnOpenPlatform('cli_x', 'feishu', {
+      loadCookies: () => COOKIES,
+      clientFactory: fakeClient([], {
+        '/developers/v1/app/cli_x': new OpenPlatformApiError(
+          'HTTP 400 /developers/v1/app/cli_x',
+          { code: 99991641, msg: 'Something went wrong, please log in again.', error: { Code: 4101, LogoutReason: 15 } },
+          400,
+        ),
+      }),
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'session_expired' });
+  });
 });
 
 describe('updateBotDescriptionsOnOpenPlatform', () => {
@@ -235,5 +251,30 @@ describe('updateBotDescriptionsOnOpenPlatform', () => {
     );
     expect(result).toMatchObject({ ok: false, reason: 'api_error' });
     expect(calls.every(call => !call.path.includes('/base_info/'))).toBe(true);
+  });
+
+  // 登录态可能在链路“中途”才失效：前面读取都成功，直到 base_info 写那笔才撞上
+  // passport 登出。必须仍归 session_expired（引导重新扫码），且没有建版/发布。
+  it('maps a mid-chain expired session (base_info write) to session_expired without publishing', async () => {
+    const calls: Call[] = [];
+    const result = await updateBotDescriptionsOnOpenPlatform(
+      'cli_x', { zh_cn: '中文新版', en_us: 'English new' }, 'feishu', {
+        loadCookies: () => COOKIES,
+        clientFactory: fakeClient(calls, {
+          '/developers/v1/app/cli_x': BASE_INFO,
+          '/developers/v1/visible/online/cli_x': ONLINE_VISIBLE,
+          '/developers/v1/app_version/list/cli_x': VERSION_LIST,
+          '/developers/v1/base_info/cli_x': new OpenPlatformApiError(
+            'HTTP 400 /developers/v1/base_info/cli_x',
+            { code: 99991641, msg: 'Something went wrong, please log in again.', error: { Code: 4101, LogoutReason: 40 } },
+            400,
+          ),
+        }),
+      },
+    );
+    expect(result).toMatchObject({ ok: false, reason: 'session_expired' });
+    // 写 base_info 已尝试并失败，但绝不能继续建版/发布。
+    expect(calls.some(call => call.path === '/developers/v1/base_info/cli_x')).toBe(true);
+    expect(calls.every(call => !call.path.includes('/app_version/create/') && !call.path.includes('/publish/commit/'))).toBe(true);
   });
 });

--- a/test/open-platform-rename.test.ts
+++ b/test/open-platform-rename.test.ts
@@ -231,6 +231,82 @@ describe('renameBotOnOpenPlatform', () => {
     expect(r).toMatchObject({ ok: false, reason: 'no_access' });
   });
 
+  // 飞书 console cookie 过期后再调 /developers/v1/* 返回 passport 登出信号，必须
+  // 归类为 session_expired（而非兜底 api_error），dashboard 才会弹重新扫码，而不
+  // 是把裸的 HTTP 400 甩给用户。判定复用 open-platform-automation 的统一 helper
+  // openPlatformWebSessionExpired（强信号：HTTP 401 / Code=4101 / 99991641+
+  // LogoutReason=40 / 「请重新登录」文案 / cause 链），本组用例锚定这些形态。
+  it('maps the real expired payload (code=99991641 + Code=4101 + "please log in again") to session_expired', async () => {
+    const calls: Call[] = [];
+    const r = await renameBotOnOpenPlatform('cli_x', '新名字', undefined, {
+      loadCookies: () => COOKIES,
+      clientFactory: fakeClient(calls, {
+        '/developers/v1/app/cli_x': new OpenPlatformApiError(
+          'HTTP 400 /developers/v1/app/cli_x',
+          { code: 99991641, msg: 'Something went wrong, please log in again.', error: { Code: 4101, LogoutReason: 15 } },
+          400,
+        ),
+      }),
+    });
+    expect(r).toMatchObject({ ok: false, reason: 'session_expired' });
+    // 登录态失效在第一笔读（app/:id）就暴露：没有任何写发生。
+    expect(calls.every(c => !c.path.includes('/base_info/') && !c.path.includes('/app_version/create/'))).toBe(true);
+  });
+
+  it('maps HTTP 401 to session_expired', async () => {
+    const calls: Call[] = [];
+    const r = await renameBotOnOpenPlatform('cli_x', '新名字', undefined, {
+      loadCookies: () => COOKIES,
+      clientFactory: fakeClient(calls, {
+        '/developers/v1/app/cli_x': new OpenPlatformApiError('HTTP 401', { msg: 'unauthorized' }, 401),
+      }),
+    });
+    expect(r).toMatchObject({ ok: false, reason: 'session_expired' });
+  });
+
+  it('maps a login-expired error wrapped in a cause chain (undici-style) to session_expired', async () => {
+    const calls: Call[] = [];
+    const inner = new OpenPlatformApiError('HTTP 400', { code: 99991641, error: { Code: 4101, LogoutReason: 40 } }, 400);
+    const wrapper = new Error('base_info write failed');
+    (wrapper as Error & { cause?: unknown }).cause = inner;
+    const r = await renameBotOnOpenPlatform('cli_x', '新名字', undefined, {
+      loadCookies: () => COOKIES,
+      clientFactory: fakeClient(calls, {
+        '/developers/v1/app/cli_x': wrapper,
+      }),
+    });
+    expect(r).toMatchObject({ ok: false, reason: 'session_expired' });
+  });
+
+  // 顶层通用 code=99991641、没有任何登录失效强信号时，不应误判为过期弹扫码——
+  // 与 master 统一 helper 的反例语义（open-platform-redirect-repair.test.ts）一致，
+  // 避免一般 console 故障也把用户踢去重新扫码。
+  it('does NOT over-match: generic code=99991641 without a strong login-expired signal stays api_error', async () => {
+    const calls: Call[] = [];
+    const r = await renameBotOnOpenPlatform('cli_x', '新名字', undefined, {
+      loadCookies: () => COOKIES,
+      clientFactory: fakeClient(calls, {
+        '/developers/v1/app/cli_x': new OpenPlatformApiError(
+          'HTTP 400 /developers/v1/app/cli_x: code=99991641 msg=Something went wrong.',
+          { code: 99991641, msg: 'Something went wrong.' },
+          400,
+        ),
+      }),
+    });
+    expect(r).toMatchObject({ ok: false, reason: 'api_error' });
+  });
+
+  it('still surfaces ordinary business errors as api_error', async () => {
+    const calls: Call[] = [];
+    const r = await renameBotOnOpenPlatform('cli_x', '新名字', undefined, {
+      loadCookies: () => COOKIES,
+      clientFactory: fakeClient(calls, {
+        '/developers/v1/app/cli_x': new OpenPlatformApiError('code=1 msg=服务器开小差', { code: 1, msg: '服务器开小差' }, 500),
+      }),
+    });
+    expect(r).toMatchObject({ ok: false, reason: 'api_error' });
+  });
+
   it('surfaces mid-chain API failures as api_error (e.g. version create rejected)', async () => {
     const calls: Call[] = [];
     const r = await renameBotOnOpenPlatform('cli_x', '新名字', undefined, {


### PR DESCRIPTION
## 问题

Dashboard 的「机器人改名 / 改头像 / 改描述」复用缓存的开放平台 console 登录态（`~/.botmux/feishu-session.json` 里的飞书 Web cookie）去调 `/developers/v1/*` 内部接口。cookie 过期后，接口返回 passport 登出信号：

```
HTTP 400 /developers/v1/app/cli_xxx: {"code":99991641,"msg":"Something went wrong, please log in again.","error":{"Code":4101,"LogoutReason":15}}
```

但 `failureFromError` 只识别 `code=10003`（非协作者 → `no_access`），其余一律兜底成 `api_error`。而前端只在 `reason==='session_expired'`（或 `no_session`）时才弹 `FeishuLoginModal` 二维码引导重新扫码。于是登录态失效被错分成 `api_error`，`session_expired` 分支永不进 —— 用户只看到裸的 `✗ 读取描述失败：HTTP 400 ...`，**扫码按钮永远不出现**。

## 修复

在 `failureFromError` 里**复用 `open-platform-automation` 已导出的统一判定器 `openPlatformWebSessionExpired`**，命中后归类为 `session_expired`。该 helper 综合判断：

- HTTP `401`
- `Code` / `code` = `4101`（强信号）
- `code=99991641` **且** `LogoutReason=40`
- 「please log in again」/「请重新登录」文案
- cause 链（undici 包裹的内层错误）

**不自造本地判据**：统一 helper 刻意**不把顶层通用 `code=99991641` 单独当登录失效**（避免一般 console 故障也误弹扫码，已有 `test/open-platform-redirect-repair.test.ts` 反例测试钉死该语义）。若在 profile 链路单独放宽会形成两套矛盾判据。实测过期 payload 带 `Code=4101` + "please log in again"，统一 helper 能命中，复用不丢修复。

`OpenPlatformRenameFailureReason` 类型**早已声明 `session_expired`**，本次补全的是产出侧，前端与 IPC 层无需任何改动。

## 影响面

- `failureFromError` 为**改名 / 改描述 / 改头像**三条链路共用：描述读取走 `loadBaseInfoContext`，描述写入与改名/头像共用 `applyBaseInfoChangeAndRepublish`。一处修复三条都受益。
- 改名 / 改头像 / 改描述（描述功能来自 #999，已在 master）当前都受此 bug 影响，本 PR 一并修复。
- 纯 dashboard→开放平台 console 的错误分类逻辑，**不碰** PTY / 会话 / 适配器共用路径，不涉及跨平台 / 跨 CLI / 跨后端。
- 不涉及飞书 owner 身份边界（这是 console Web 登录态，非 `ou_` app-scoped owner）。

## 验证

- `test/open-platform-rename.test.ts`：新增真实过期 payload / HTTP 401 / cause 链包裹 / 顶层通用 `99991641` 不过度匹配 / 普通业务错误仍 `api_error` 等用例
- `test/open-platform-description.test.ts`：新增**描述读取入口**过期 + **描述写入中途**（`base_info` 那笔才过期、不建版发布）两个 `session_expired` 用例
- `open-platform-{rename,description,avatar,redirect-repair}` 4 文件 **69 tests 全绿**（含 master 反例测试，证明无语义冲突）
- `tsc --noEmit` 通过

> 说明：本 PR 已 rebase 到最新 master（早先版本 base 陈旧、且自造了与统一 helper 冲突的本地判据，已按评审意见改为复用统一 helper 并订正影响面）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)