### PR TITLE
fix(test): 按根因修掉 bun-test 三个 flake，并定位第四个的真实失败形状

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,29 @@ jobs:
   # paths. Bun is what ships the single-file executable, so those paths need a
   # leg that actually runs on it.
   #
-  # Non-blocking on purpose (for now): the shim in test/bun-test-shim.ts
-  # deliberately does not fake `vi.doMock`/`resetModules`/`importOriginal`, and
-  # scripts/run-bun-tests.mjs excludes the files needing them, but the remaining
-  # population has not yet had a full green baseline established across a CI
-  # runner's environment. Flip `continue-on-error` off once it holds green — a
-  # gate that is red for environmental reasons trains people to ignore it.
+  # STILL ADVISORY, but the reason has narrowed. Three of the four flakes that
+  # kept this leg off a green baseline are now fixed at their cause rather than
+  # retried:
+  #   • a port-pair assumption (`base+1` was presumed free) → reserve both,
+  #   • a torn read of a marker file → write tmp + `renameSync`, plus a poll
+  #     predicate that THREW on a partial read, aborting the loop and reporting a
+  #     parse error instead of the timeout → fail soft,
+  #   • an env-leak guard whose transport was node-pty, which cannot fork/exec
+  #     reliably under Bun (see that file's comment for the measurements) → the
+  #     guard now runs over `child_process.spawn` on both legs, with the pty form
+  #     kept for Node only.
+  #
+  # The fourth is NOT fixed: test/tmux-startup-storm-recovery.test.ts wedged in
+  # run 34570428914 — one `(pass)` line, then 180s of silence and a SIGKILL, i.e.
+  # the second case never completed. Observed once in 28 completed master runs
+  # (~4%); not reproduced locally across ~50 attempts spanning core starvation,
+  # piped stdio, the runner's exact spawn shape and args, and its 4-way file
+  # concurrency. Since the test times out per-case at 15s and the file still went
+  # quiet for 180s, whatever blocks it is synchronous.
+  #
+  # A gate that is red for environmental reasons trains people to ignore it, so
+  # this flips to blocking when that cause is named and reproduced — not on a
+  # rerun, and not on the other three being green.
   #
   # The generous timeout is inherent to the design: the runner spawns ONE bun
   # process PER FILE, because `bun test` otherwise runs every file in a single

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
 import {
   applySessionOwnerEnv,
   scrubExternalMemberEnv,
@@ -207,12 +208,37 @@ describe('redactChildEnv()', () => {
     expect(REDACTED_CHILD_ENV_KEYS).toContain(PM2_GRACEFUL_EXIT_CODE_ENV);
   });
 
-  it('real node-pty child does NOT inherit a redacted var (not the string "undefined")', async () => {
-    // End-to-end guard for the actual leak vector Codex found: a spawned child
-    // must see the redacted var as genuinely UNSET. `${VAR+x}` expands to empty
-    // only when VAR is unset, distinguishing "unset" from "set to the string
-    // 'undefined'". Run against the real bundled node-pty + /bin/sh.
-    const pty = await import('node-pty');
+  // Two REAL-CHILD guards for the same leak vector, split by transport.
+  //
+  // The plain-spawn one runs everywhere. The node-pty one is Node-only, because
+  // node-pty's fork/exec is broken under Bun when cores are scarce — MEASURED
+  // here with `taskset` (node-pty 1.1.0, bun 1.4.2, `/bin/sh -c`):
+  //
+  //     node, 1 core .......... 25/25 child ran
+  //     bun,  1 core ..........  1/25
+  //     bun,  2 cores .........  24/25   <- the ~4% red on the 2-core CI runner
+  //
+  // It is NOT a lost read, which is what this test used to claim. Point the child
+  // at a file instead of the pty stream and it still fails 1/25 under bun; have
+  // the shell announce itself first (`exec >>log; echo ENTERED`) and a failing run
+  // leaves exitCode 1 with no log file at all — /bin/sh never starts. So no
+  // amount of draining, waiting or retrying on the JS side can fix it: retrying
+  // four times inside one process recovered 0/20 on one core, because the failure
+  // is per-process, not per-attempt. A retry loop would look like a fix and only
+  // be one on a fast runner.
+  //
+  // Skipping under Bun keeps the pty leg honest on Node instead of trading a real
+  // guard for a flaky one. `redactChildEnv` is transport-agnostic, and the
+  // plain-spawn case below exercises the same env marshalling on BOTH runtimes,
+  // so nothing about the leak vector goes unguarded here.
+  const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+
+  const leakProbeScript = (sentinel: string) =>
+    'if [ -z "${LARK_APP_ID+x}" ]; then echo "R=UNSET"; else echo "R=SET[$LARK_APP_ID]"; fi; '
+    + `if [ -z "\${${sentinel}+x}" ]; then echo "S=UNSET"; else echo "S=SET[\$${sentinel}]"; fi`;
+
+  /** Set the two vars, hand `redactChildEnv`'s output to `run`, always restore. */
+  const withLeakyParentEnv = async (run: (env: NodeJS.ProcessEnv) => Promise<string>) => {
     const prev = process.env.LARK_APP_ID;
     const prevSentinel = process.env[PM2_GRACEFUL_EXIT_CODE_ENV];
     process.env.LARK_APP_ID = 'cli_parent_must_not_leak';
@@ -220,67 +246,81 @@ describe('redactChildEnv()', () => {
     // which must not survive into the forked CLI child.
     process.env[PM2_GRACEFUL_EXIT_CODE_ENV] = '90';
     try {
-      const env = redactChildEnv(process.env) as { [k: string]: string };
-      const script =
-        'if [ -z "${LARK_APP_ID+x}" ]; then echo "R=UNSET"; else echo "R=SET[$LARK_APP_ID]"; fi; ' +
-        `if [ -z "\${${PM2_GRACEFUL_EXIT_CODE_ENV}+x}" ]; then echo "S=UNSET"; else echo "S=SET[\$${PM2_GRACEFUL_EXIT_CODE_ENV}]"; fi`;
-      const out: string = await new Promise((resolve, reject) => {
-        const p = pty.spawn('/bin/sh', ['-c', script], {
-          name: 'xterm-256color', cols: 80, rows: 24, cwd: '/tmp', env,
-        });
-        let buf = '';
-        let settled = false;
-        // node-pty delivers onData and onExit on independent paths: the child can
-        // be reaped before the pty's pending output has been drained, so
-        // resolving straight from onExit can hand back an empty string. That
-        // surfaces as `Expected to contain "R=UNSET" / Received: ""` under CI
-        // load, which reads like a real leak but is only a lost read.
-        //
-        // So settle on having BOTH answers, and let exit only START a short grace
-        // period rather than decide. If the grace period expires with the output
-        // still incomplete, REJECT with the raw buffer instead of resolving it:
-        // the whole point is that a lost read must never again be reported as a
-        // leak-shaped assertion failure. Resolving '' here would rebuild the very
-        // trap this guard exists to remove.
-        const hasBothAnswers = () => /\bR=(UNSET|SET)/.test(buf) && /\bS=(UNSET|SET)/.test(buf);
-        const finish = (settle: () => void) => {
-          if (settled) return;
-          settled = true;
-          settle();
-        };
-        const fail = () => finish(() => reject(new Error(
-          'pty output incomplete — a lost read, not an env leak. '
-          + `Expected both R= and S= answers, got ${JSON.stringify(buf)}`,
-        )));
-        const guard = setTimeout(fail, 10_000);
-        guard.unref?.();
-        p.onData((d) => {
-          buf += d;
-          if (hasBothAnswers()) {
-            clearTimeout(guard);
-            finish(() => resolve(buf));
-          }
-        });
-        p.onExit(() => {
-          // Exit is a deadline, not the signal: give already-queued reads a
-          // moment to land, then decide — complete output resolves, incomplete
-          // output fails loudly as a fixture problem.
-          setTimeout(() => {
-            clearTimeout(guard);
-            if (hasBothAnswers()) finish(() => resolve(buf));
-            else fail();
-          }, 250);
-        });
-      });
-      expect(out).toContain('R=UNSET');
-      expect(out).toContain('S=UNSET');
-      expect(out).not.toContain('undefined');
+      return await run(redactChildEnv(process.env) as { [k: string]: string });
     } finally {
       if (prev === undefined) delete process.env.LARK_APP_ID;
       else process.env.LARK_APP_ID = prev;
       if (prevSentinel === undefined) delete process.env[PM2_GRACEFUL_EXIT_CODE_ENV];
       else process.env[PM2_GRACEFUL_EXIT_CODE_ENV] = prevSentinel;
     }
+  };
+
+  /** Both answers present — the only shape that proves the child actually ran. */
+  const expectNoLeak = (out: string) => {
+    expect(out).toContain('R=UNSET');
+    expect(out).toContain('S=UNSET');
+    expect(out).not.toContain('undefined');
+  };
+
+  it('real spawned child does NOT inherit a redacted var (not the string "undefined")', async () => {
+    // End-to-end guard for the actual leak vector: a spawned child must see the
+    // redacted var as genuinely UNSET. `${VAR+x}` expands to empty only when VAR
+    // is unset, distinguishing "unset" from "set to the string 'undefined'".
+    // Plain spawn, so this leg runs on Node AND Bun (measured 25/25 on both at
+    // one core).
+    const out = await withLeakyParentEnv((env) => new Promise<string>((resolve, reject) => {
+      const child = spawn('/bin/sh', ['-c', leakProbeScript(PM2_GRACEFUL_EXIT_CODE_ENV)], {
+        cwd: '/tmp', env, stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let buf = '';
+      child.stdout.on('data', (d) => { buf += String(d); });
+      child.on('error', reject);
+      // `close` (not `exit`) fires only after both stdio streams are drained, so
+      // the buffer is complete by definition — no grace period to tune.
+      child.on('close', () => resolve(buf));
+    }));
+    expectNoLeak(out);
+  });
+
+  it.skipIf(isBun)('real node-pty child does NOT inherit a redacted var (not the string "undefined")', async () => {
+    // Same guard across the PTY transport, which marshals env into raw K=V pairs
+    // in native code rather than reusing libuv's spawn path — a distinct code
+    // path worth covering. Node-only for the reason documented above.
+    const pty = await import('node-pty');
+    const out = await withLeakyParentEnv((env) => new Promise<string>((resolve, reject) => {
+      const p = pty.spawn('/bin/sh', ['-c', leakProbeScript(PM2_GRACEFUL_EXIT_CODE_ENV)], {
+        name: 'xterm-256color', cols: 80, rows: 24, cwd: '/tmp', env: env as { [k: string]: string },
+      });
+      let buf = '';
+      let settled = false;
+      // node-pty delivers onData and onExit on independent paths: the child can be
+      // reaped before the pty's pending output has been drained, so resolving
+      // straight from onExit can hand back an empty string. Settle on having BOTH
+      // answers, and let exit only START a short grace period rather than decide.
+      // If the grace period expires with the output still incomplete, REJECT with
+      // the raw buffer: a lost read must never be reported as a leak-shaped
+      // assertion failure ("Expected to contain R=UNSET / Received: ''").
+      const hasBothAnswers = () => /\bR=(UNSET|SET)/.test(buf) && /\bS=(UNSET|SET)/.test(buf);
+      const finish = (settle: () => void) => { if (settled) return; settled = true; settle(); };
+      const fail = () => finish(() => reject(new Error(
+        'pty output incomplete — a lost read, not an env leak. '
+        + `Expected both R= and S= answers, got ${JSON.stringify(buf)}`,
+      )));
+      const guard = setTimeout(fail, 10_000);
+      guard.unref?.();
+      p.onData((d) => {
+        buf += d;
+        if (hasBothAnswers()) { clearTimeout(guard); finish(() => resolve(buf)); }
+      });
+      p.onExit(() => {
+        setTimeout(() => {
+          clearTimeout(guard);
+          if (hasBothAnswers()) finish(() => resolve(buf));
+          else fail();
+        }, 250);
+      });
+    }));
+    expectNoLeak(out);
   });
 });
 

--- a/test/listen-with-probe.test.ts
+++ b/test/listen-with-probe.test.ts
@@ -23,6 +23,45 @@ function rawListen(s: Server, port: number, host = '127.0.0.1'): Promise<number>
 }
 afterEach(async () => { for (const s of open.splice(0)) await new Promise<void>(r => s.close(() => r())); });
 
+/**
+ * Reserve a port `p` such that `p + 1` is ALSO free right now, and return `p`
+ * with nothing bound.
+ *
+ * WHY: every case here exercises "requested port busy → step to port+1", so it
+ * needs a base port whose successor is available. Asking the OS for an ephemeral
+ * port (`listen(0)`) only guarantees the port itself — on a shared runner the
+ * neighbour can already be held by an unrelated process, and then
+ * `rawListen(mk(), busy + 1)` rejects with EADDRINUSE and the case fails on its
+ * own fixture. MEASURED on CI: `Failed to start server. Is port 33638 in use?`
+ * raised from rawListen, reported as "rejects once maxProbe is exhausted"
+ * failing — a fixture collision wearing the assertion's name.
+ *
+ * Probing both and retrying removes the assumption instead of widening a
+ * tolerance: we only proceed once the OS has told us both are bindable.
+ */
+async function reserveAdjacentPair(attempts = 40): Promise<number> {
+  for (let i = 0; i < attempts; i++) {
+    const probe = createServer();
+    const base = await new Promise<number>((resolve, reject) => {
+      probe.once('error', reject);
+      probe.listen(0, '127.0.0.1', () => {
+        const a = probe.address();
+        resolve(typeof a === 'object' && a ? a.port : 0);
+      });
+    });
+    // Hold `base` while testing the neighbour, so nothing can slip into `base`
+    // between the two checks.
+    const neighbourFree = await new Promise<boolean>((resolve) => {
+      const nb = createServer();
+      nb.once('error', () => resolve(false));
+      nb.listen(base + 1, '127.0.0.1', () => nb.close(() => resolve(true)));
+    });
+    await new Promise<void>(r => probe.close(() => r()));
+    if (neighbourFree) return base;
+  }
+  throw new Error('could not reserve a free adjacent port pair');
+}
+
 describe('listenWithProbe', () => {
   it('binds the requested port when it is free', async () => {
     const port = await listenWithProbe({ server: mk(), port: 0, host: '127.0.0.1' });
@@ -30,10 +69,7 @@ describe('listenWithProbe', () => {
   });
 
   it('skips ports rejected by caller-specific availability checks', async () => {
-    const tmp = mk();
-    const start = await rawListen(tmp, 0);
-    await new Promise<void>(r => tmp.close(() => r()));
-    open.splice(open.indexOf(tmp), 1);
+    const start = await reserveAdjacentPair();
     const logs: string[] = [];
     const bound = await listenWithProbe({
       server: mk(),
@@ -47,7 +83,7 @@ describe('listenWithProbe', () => {
   });
 
   it('probes to the next port without crashing when the requested port is busy', async () => {
-    const busy = await rawListen(mk(), 0);
+    const busy = await rawListen(mk(), await reserveAdjacentPair());
     const logs: string[] = [];
     const bound = await listenWithProbe({ server: mk(), port: busy, host: '127.0.0.1', log: m => logs.push(m) });
     expect(bound).toBe(busy + 1);
@@ -55,7 +91,7 @@ describe('listenWithProbe', () => {
   });
 
   it('rejects (does not loop forever) once maxProbe is exhausted', async () => {
-    const busy = await rawListen(mk(), 0);
+    const busy = await rawListen(mk(), await reserveAdjacentPair());
     await rawListen(mk(), busy + 1);            // occupy the single probe target too
     let err: NodeJS.ErrnoException | null = null;
     await listenWithProbe({ server: mk(), port: busy, host: '127.0.0.1', maxProbe: 1 })
@@ -68,10 +104,7 @@ describe('listenWithProbe', () => {
     // A wildcard bind can succeed at the OS level yet be shadowed on loopback
     // (someone else holds 127.0.0.1:port and wins loopback routing). verifyBound
     // runs AFTER listen; returning false must close that binding and re-probe.
-    const tmp = mk();
-    const start = await rawListen(tmp, 0);
-    await new Promise<void>(r => tmp.close(() => r()));
-    open.splice(open.indexOf(tmp), 1);
+    const start = await reserveAdjacentPair();
 
     const verified: number[] = [];
     const logs: string[] = [];

--- a/test/plugin-supervisor.integration.test.ts
+++ b/test/plugin-supervisor.integration.test.ts
@@ -58,14 +58,34 @@ describe('plugin services on the built-in supervisor', () => {
     writeFileSync(join(root, 'dist', 'service', 'server.cjs'), options.body ?? `
       const fs = require('node:fs');
       process.on('SIGTERM', () => process.exit(0));
-      fs.writeFileSync(process.env.MARKER, JSON.stringify({pid: process.pid, args: process.argv.slice(2), env: process.env, cwd: process.cwd()}));
+      // Write the marker ATOMICALLY (tmp + rename). The reader below polls every
+      // 40ms while this child writes a multi-KB JSON blob (it embeds the whole
+      // env), so a plain writeFileSync lets the poller read a half-written file
+      // and blow up with \`SyntaxError: JSON Parse error: Unterminated string\`
+      // — MEASURED on CI, and it reads like a supervisor defect when it is only
+      // a torn read. rename(2) is atomic within a filesystem, so the reader sees
+      // either the old absence or the complete file, never a prefix.
+      const marker = process.env.MARKER;
+      const tmp = marker + '.' + process.pid + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify({pid: process.pid, args: process.argv.slice(2), env: process.env, cwd: process.cwd()}));
+      fs.renameSync(tmp, marker);
       setInterval(() => {}, 1000);
     `);
     return { ...installLocalPlugin(root, { link: options.linked }), root };
   }
   const proc = (id: string) => readPluginProcesses().find(p => p.name === `botmux-plugin-${id}`);
-  const ready = (id: string) => until(() => existsSync(join(home, id + '.ready'))
-    && JSON.parse(readFileSync(join(home, id + '.ready'), 'utf8')).pid === proc(id)?.pid, `${id} ready`);
+  // A predicate that THROWS aborts the poll loop and reports the parse error as
+  // the test's failure, hiding what was actually being waited for. The marker is
+  // written atomically (see the fixture), so a malformed read should no longer
+  // happen — but if one ever does, the honest outcome is "timed out: <id> ready",
+  // not a SyntaxError masquerading as a supervisor defect.
+  const readyPid = (id: string): number | undefined => {
+    const marker = join(home, id + '.ready');
+    if (!existsSync(marker)) return undefined;
+    try { return JSON.parse(readFileSync(marker, 'utf8')).pid as number; }
+    catch { return undefined; }
+  };
+  const ready = (id: string) => until(() => readyPid(id) !== undefined && readyPid(id) === proc(id)?.pid, `${id} ready`);
 
   it('installs and queries without creating a supervisor; update/uninstall guard checks actual liveness', async () => {
     const { root, runtimeDir } = fixture('demo');
@@ -147,7 +167,9 @@ describe('plugin services on the built-in supervisor', () => {
     await delay(600);
     expect(proc('once')!.pid).toBeUndefined();
     fixture('stubborn', { body: `process.on('SIGTERM',()=>{});
-      require('fs').writeFileSync(process.env.MARKER, JSON.stringify({pid:process.pid})); setInterval(()=>{},1000);` });
+      const fs = require('fs'); const tmp = process.env.MARKER + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify({pid:process.pid})); fs.renameSync(tmp, process.env.MARKER);
+      setInterval(()=>{},1000);` });
     await startPluginServices(['stubborn']);
     await ready('stubborn');
     const pid = proc('stubborn')!.pid!;

--- a/test/tmux-startup-storm-recovery.test.ts
+++ b/test/tmux-startup-storm-recovery.test.ts
@@ -102,9 +102,28 @@ describe.skipIf(!REAL_TMUX)('tmux startup storm recovery (real tmux, shimmed dea
       '  if [ ! -e "$MARKER" ]; then',
       '    : > "$MARKER"',
       '    "$REAL" "$@"',
-      '    trap "exit 0" TERM',
-      '    sleep 30 &',
-      '    wait $!',
+      // The holder MUST NOT inherit the caller's stderr pipe. `spawnSync` kills
+      // this shim at its 5s deadline, but the backgrounded child survives that
+      // (the TERM trap fires in the SHELL, not in the child), reparents to init
+      // and keeps the inherited fd open. MEASURED: without the redirect the
+      // orphan holds `fd 2 -> socket:[...]`; with it, `fd 2 -> /dev/null`.
+      //
+      // This is HYGIENE, not a fix for CI run 34570428914. That run was
+      // originally read here as "both cases passed, then an orphan fd held the
+      // process open" — the log says otherwise: exactly ONE `(pass)` line, so
+      // the SECOND case never completed. A `sleep 30` also cannot hold a 180s
+      // idle timer open. Measured under the runner's own spawn shape
+      // (`stdio: ['ignore','pipe','pipe']`, waiting on 'close'), with and
+      // without the redirect: exit→close delta is 1ms either way. So the
+      // orphan is real and worth not leaking, but the wedge's cause is still
+      // open — see that run's log before blaming this shim.
+      '    sleep 30 >/dev/null 2>&1 &',
+      '    SLEEP_PID=$!',
+      // Reap the holder on the deadline kill so no stray `sleep` outlives the
+      // run at all. The redirect above still covers the window before this trap
+      // is installed (and a SIGKILL, which runs no trap).
+      '    trap "kill $SLEEP_PID 2>/dev/null; exit 0" TERM',
+      '    wait $SLEEP_PID',
       '    exit 0',
       '  fi',
       'fi',


### PR DESCRIPTION
## 改了什么

bun-test leg 带 `continue-on-error: true`，是「跑但不拦」的顾问态。它在拦不住的
位置发现了真问题，但也因此无人修 —— master 最近 28 次跑完的 job 里 4 次真红（14%）。

⚠️ 注意 workflow 层的结论看不出这一点：`continue-on-error` 会把整条 workflow 染绿，
必须按 job 粒度查（`actions/runs/<id>/jobs` 里筛 `.name=="bun-test"`）。这也是这批
flake 长期没人处理的直接原因。

本 PR 修好其中三个，第四个只定位不假修，**因此不摘 `continue-on-error`**。

### 已按根因修好（3）

| 文件 | 根因 | 修法 |
|---|---|---|
| `test/listen-with-probe.test.ts` | 假设「`port+1` 一定空闲」 | `reserveAdjacentPair()`：占住 `base` 的同时验 `base+1`，两个端口一起预留 |
| `test/plugin-supervisor.integration.test.ts` | marker 文件被轮询方读到写了一半的内容；且轮询谓词解析失败时**抛错**，中断轮询并把 JSON 解析错误报成测试失败，掩盖了「在等什么」 | 先写 tmp 再 `renameSync`（同文件系统内 `rename(2)` 原子）；谓词改 fail-soft，超时信息才诚实 |
| `test/child-env.test.ts` | 用 node-pty 作为验证 env 泄漏的传输层，而 node-pty 在 Bun 下 fork/exec 本身不可靠 | 按传输层拆分：`child_process.spawn` 的守卫两条腿都跑，pty 形态保留但仅在 Node 下跑 |

关于第三条，原注释判定为「丢了一次读」，实测证否：子进程根本没起来（`exitCode=1`、
写文件的 sink 也无输出）。限核实测 node 1 核 25/25、bun 1 核 0/25、bun 2 核 24/25，
是**每进程**特性而非每次尝试的抖动 —— 重试修不好。

### 未修好，只收敛噪声（1）

`test/tmux-startup-storm-recovery.test.ts` 在 run 34570428914 被 180s post-result
idle SIGKILL。**日志形状是「一条 `(pass)` 之后静默 180 秒」，即第二个用例没跑完**，
不是「两个用例都过了之后进程不退」。

本次只做了一件确定有价值的事：shim 里 `sleep 30 &` 会继承调用方的 stderr 管道，
shim 被 5s deadline 杀掉后它反哺给 init 并继续持有该 fd（实测 `fd 2 -> socket:[...]`、
ppid=1），加重定向 + 按 pid 回收，孤儿不再泄漏。

但这**不是**那次红的原因，两条独立判据：
1. 按 runner 完全相同的 spawn 形态（`stdio: ['ignore','pipe','pipe']`、等 `'close'`）实测，改前改后 exit→close 都只差 1ms；
2. `sleep 30` 三十秒就自己死了，撑不起一个 180 秒的 idle 计时器。

真正的原因仍未定位，已在测试注释里写清楚，免得下一个人误以为已修。

## 为什么不一起「扶正」

转阻断的前提是四个都按因修好。现在第四个根因未明，拿它去转阻断，等于把一个
已知会随机红的 gate 变成必过项 —— 而「因环境原因常红的 gate 会训练所有人忽略它」
正是它当初被设成顾问态的理由。等那条查清楚再单独摘。

另外提醒一个次序问题：`sandbox-shim-compiled-form.test.ts` 在 Linux runner 上是
真跑的（其 `describe.skipIf` 只跳非 Linux），而 bwrap 安装步骤目前只在 `test` job
里、`bun-test` job 没有。也就是说即使四个 flake 全修好，摘 `continue-on-error`
之前仍需先补上 bun-test 侧的 bwrap，否则转阻断当天就红。

## 影响面

只动 CI 注释与 4 个测试文件，**`src/` 零改动**，不涉及任何运行时代码路径，
因此不存在跨 CLI / 跨后端 / 跨会话类型的回归面。

## 验证

```
bun run build            → rc=0
npx tsc --noEmit         → rc=0，0 行输出
```

rebase 到最新 master（`ba70056fa`）后逐个复跑：

```
listen-with-probe.test.ts              rc=0   6 pass  0 fail
plugin-supervisor.integration.test.ts  rc=0  12 pass  0 fail
child-env.test.ts                      rc=0  52 pass  0 fail
tmux-startup-storm-recovery.test.ts    rc=0   2 pass  0 fail
```

本地全量 bun leg（bun 1.4.2，与 CI 钉的版本一致）1133 个文件，上述文件全绿；
余下 7 个失败是本机 root+bwrap 环境噪声（同 base 的 CI 跑 1133/1133 全绿，
run 34576765446）。

**限核 A/B**（`taskset` 限核，不额外加负载）：child-env 旧形态 bun 1 核 12/12 红
→ 新形态 12/12 绿。

**反变异**：让 `redactChildEnv` 漏掉 `LARK_APP_ID`，新的 spawn 守卫在两条腿上都转红，
证明是真覆盖而非哑弹。

**tmux 一项的复现尝试**（均未复现，故不声称修好）：1 核 / 2 核限核、`| cat` 管道、
runner 的真实 spawn 形态、runner 的真实参数（`--timeout=180000`）、以及 runner 的
4 路文件并发，累计约 50 次全绿。该 flake 在 28 次 CI 里只出现 1 次（约 4%），
本机复现不出属预期。

## 后续

tmux 那条的下一步是查「第二个用例为什么会同步阻塞」—— 每个用例有 15s 超时却整整
静默 180s，说明卡在同步调用里（事件循环没转，超时定时器压根没机会跑）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
