### PR TITLE
fix(lark): 仓库选择卡加字节预算，发送失败时降级开工而非挂死会话

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -17868,6 +17868,7 @@ async function startInitialPassthroughSession(args: {
   if (await replyInvalidWorkingDirs(anchor, larkAppId, ds)) return;
   const scanDirs = getProjectScanDirs(ds).filter(d => existsSync(d));
   const projects = scanDirs.length > 0 ? scanMultipleProjects(scanDirs, 3, repoPickerScanOptions()) : [];
+  let repoCardDegraded = false;
   if (projects.length > 0) {
     ds.initialStartPending = false; // pendingRepo/card now owns buffering
     lastRepoScan.set(chatId, projects);
@@ -17875,11 +17876,26 @@ async function startInitialPassthroughSession(args: {
     //（重发会在 pendingRepo 缓冲里再入一份）。
     onDurablyAdmitted?.();
     const cardJson = buildRepoSelectCard(projects, getSessionWorkingDir(ds), anchor, localeForBot(larkAppId), getBot(larkAppId).config.worktreeMultiPicker);
-    ds.repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
-    persistPendingRepoCardMessageId(ds, ds.repoCardMessageId);
-    announcePendingRepoSession(ds);
-    logger.info(`[${tag(ds)}] Waiting for repo selection before initial raw passthrough (${projects.length} projects)`);
-    return;
+    let repoCardMessageId: string | undefined;
+    try {
+      repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
+    } catch (err) {
+      // 卡片没发出去 ⟹ 没有任何 picker 可点，保持 pendingRepo 会把这条已 durable
+      // 接纳的开场永久挂死在一张不存在的卡片上（重启也只是重发同一张）。降级成
+      // 「无可选项目」那条路：清掉 pendingRepo 后 forkWorker 会清空 activation
+      // journal，用默认 cwd 直接开工，与 createSession 的降级语义一致。
+      repoCardDegraded = true;
+      logger.warn(`[${tag(ds)}] repo card publish failed (${err instanceof Error ? err.message : String(err)}); falling back to default cwd`);
+    }
+    if (repoCardMessageId) {
+      ds.repoCardMessageId = repoCardMessageId;
+      persistPendingRepoCardMessageId(ds, ds.repoCardMessageId);
+      announcePendingRepoSession(ds);
+      logger.info(`[${tag(ds)}] Waiting for repo selection before initial raw passthrough (${projects.length} projects)`);
+      return;
+    }
+    ds.repoCardMessageId = undefined;
+    // fall through to the no-card opening below
   }
 
   // 已 durable staging（picker，含 rawInput）且通过放弃闸：fork 失败后本条 raw
@@ -17894,7 +17910,7 @@ async function startInitialPassthroughSession(args: {
   });
   const availableBots = await getAvailableBots(larkAppId, chatId);
   forkReservedInitialRawSession(ds, availableBots);
-  logger.info(`[${tag(ds)}] No projects to select, queued initial raw passthrough ${commandContent.substring(0, 40)}`);
+  logger.info(`[${tag(ds)}] ${repoCardDegraded ? 'Repo card unavailable' : 'No projects to select'}, queued initial raw passthrough ${commandContent.substring(0, 40)}`);
 }
 
 
@@ -19067,6 +19083,7 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
       projects = scanMultipleProjects(scanDirs, 3, repoPickerScanOptions());
     }
   }
+  let repoCardPublished = false;
   if (projects.length > 0) {
     ds.initialStartPending = false; // pendingRepo/card now owns buffering
     lastRepoScan.set(chatId, projects);
@@ -19075,12 +19092,27 @@ async function handleNewTopicAdmitted(data: any, ctx: RoutingContext): Promise<v
     markIngressAdmitted(ctx);
     const currentCwd = getSessionWorkingDir(ds);
     const cardJson = buildRepoSelectCard(projects, currentCwd, anchor, localeForBot(larkAppId), getBot(larkAppId).config.worktreeMultiPicker);
-    ds.repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
-    persistPendingRepoCardMessageId(ds, ds.repoCardMessageId);
-    announcePendingRepoSession(ds);
-    logger.info(`[${tag(ds)}] Waiting for repo selection (${projects.length} projects)`);
-  } else {
-    // No projects found — skip repo selection, spawn directly.
+    let repoCardMessageId: string | undefined;
+    try {
+      repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
+    } catch (err) {
+      // 没有可点的卡片就不能保持 pendingRepo（详见 startInitialPassthroughSession
+      // 同款降级）：走下面的 no-card 分支，用默认 cwd 直接开工。
+      logger.warn(`[${tag(ds)}] repo card publish failed (${err instanceof Error ? err.message : String(err)}); falling back to default cwd`);
+    }
+    if (repoCardMessageId) {
+      repoCardPublished = true;
+      ds.repoCardMessageId = repoCardMessageId;
+      persistPendingRepoCardMessageId(ds, ds.repoCardMessageId);
+      announcePendingRepoSession(ds);
+      logger.info(`[${tag(ds)}] Waiting for repo selection (${projects.length} projects)`);
+    } else {
+      ds.repoCardMessageId = undefined;
+    }
+  }
+  if (!repoCardPublished) {
+    // No projects found (or the picker could not be published) — skip repo
+    // selection, spawn directly.
     // 已 durable staging（picker）且通过放弃闸：即使下面 fork 失败，opening 仍由
     // 会话 durable 持有（pre-init 回滚恢复 queued journal，重启复活），重发会
     // 重复执行——先打接纳标。
@@ -19605,6 +19637,7 @@ async function handleBotAdded(
     }
     const scanDirs = getProjectScanDirs(ds).filter(d => existsSync(d));
     const projects = scanDirs.length > 0 ? scanMultipleProjects(scanDirs, 3, repoPickerScanOptions()) : [];
+    let repoCardPublished = false;
     if (projects.length > 0) {
       ds.initialStartPending = false; // pendingRepo/card now owns buffering
       lastRepoScan.set(chatId, projects);
@@ -19613,8 +19646,16 @@ async function handleBotAdded(
       // immediately before its single network await; pendingRepo already makes
       // this a stable buffered state for normal inbound/scheduler paths.
       armSharedReplyTarget();
-      const repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
-      if (joinBootstrapWasTakenOver()) {
+      let repoCardMessageId: string | undefined;
+      try {
+        repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
+      } catch (err) {
+        // 卡片没发出去就没有 picker 可点，保持 pendingRepo 会把这个入群会话挂死。
+        // 落到下面「无可选项目」那条路直接开工——它自己会重跑 takeover 检查并
+        // 重新 armSharedReplyTarget，所以这里既不撤 seed 也不动 reply target。
+        logger.warn(`[auto-start:入群] ${chatId.substring(0, 12)} repo 卡发送失败（${err instanceof Error ? err.message : String(err)}），改用默认目录直接开工`);
+      }
+      if (repoCardMessageId && joinBootstrapWasTakenOver()) {
         void deleteMessage(larkAppId, repoCardMessageId);
         // If another entry actually started this same ds, its output still owns
         // the shared seed we just armed. Preserve that root; closed/replaced
@@ -19622,11 +19663,17 @@ async function handleBotAdded(
         if (!ds.worker || ds.worker.killed) withdrawSharedReplySeed();
         return;
       }
-      ds.repoCardMessageId = repoCardMessageId;
-      persistPendingRepoCardMessageId(ds, ds.repoCardMessageId);
-      announcePendingRepoSession(ds);
-      logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 无默认目录，弹 repo 选择卡（${projects.length} 个项目）`);
-    } else {
+      if (repoCardMessageId) {
+        repoCardPublished = true;
+        ds.repoCardMessageId = repoCardMessageId;
+        persistPendingRepoCardMessageId(ds, ds.repoCardMessageId);
+        announcePendingRepoSession(ds);
+        logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 无默认目录，弹 repo 选择卡（${projects.length} 个项目）`);
+      } else {
+        ds.repoCardMessageId = undefined;
+      }
+    }
+    if (!repoCardPublished) {
       ds.pendingRepo = false;
       ensureSessionWhiteboard(ds);
       const availableBots = await getAvailableBots(larkAppId, chatId);
@@ -19643,7 +19690,7 @@ async function handleBotAdded(
       forkReservedInitialSession(ds, availableBots);
       ds.pendingTurnId = undefined;
       ds.pendingChatContext = undefined;
-      logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 无默认目录且无可选项目，直接开工`);
+      logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 无默认目录${projects.length > 0 ? '且 repo 卡不可用' : '且无可选项目'}，直接开工`);
     }
   } finally {
     joinReady?.settle();
@@ -20974,6 +21021,7 @@ async function handleThreadReplyAdmitted(
     if (scanDirs2.length > 0) {
       projects = scanMultipleProjects(scanDirs2, 3, repoPickerScanOptions());
     }
+    let repoCardPublished = false;
     if (projects.length > 0) {
       newDs.initialStartPending = false; // pendingRepo/card now owns buffering
       lastRepoScan.set(autoCreateChatId, projects);
@@ -20981,12 +21029,27 @@ async function handleThreadReplyAdmitted(
       markIngressAdmitted(ctx);
       const currentCwd = getSessionWorkingDir(newDs);
       const cardJson = buildRepoSelectCard(projects, currentCwd, anchor, localeForBot(larkAppId), getBot(larkAppId).config.worktreeMultiPicker);
-      newDs.repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
-      persistPendingRepoCardMessageId(newDs, newDs.repoCardMessageId);
-      announcePendingRepoSession(newDs);
-      logger.info(`[${tag(newDs)}] Waiting for repo selection (${projects.length} projects)`);
-    } else {
-      // No projects found — skip repo selection, spawn directly.
+      let repoCardMessageId: string | undefined;
+      try {
+        repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
+      } catch (err) {
+        // 没有可点的卡片就不能保持 pendingRepo（详见 handleNewTopicAdmitted 同款
+        // 降级）：走下面的 no-card 分支，用默认 cwd 直接开工。
+        logger.warn(`[${tag(newDs)}] repo card publish failed (${err instanceof Error ? err.message : String(err)}); falling back to default cwd`);
+      }
+      if (repoCardMessageId) {
+        repoCardPublished = true;
+        newDs.repoCardMessageId = repoCardMessageId;
+        persistPendingRepoCardMessageId(newDs, newDs.repoCardMessageId);
+        announcePendingRepoSession(newDs);
+        logger.info(`[${tag(newDs)}] Waiting for repo selection (${projects.length} projects)`);
+      } else {
+        newDs.repoCardMessageId = undefined;
+      }
+    }
+    if (!repoCardPublished) {
+      // No projects found (or the picker could not be published) — skip repo
+      // selection, spawn directly.
       // 已 durable staging（picker）：fork 失败后 opening 仍由会话 durable 持有，
       // 先打接纳标（同 handleNewTopicAdmitted 的 no-projects 分支）。
       markIngressAdmitted(ctx);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -90,6 +90,7 @@ export const messages: Record<string, string> = {
   'card.repo.current_active': 'Current working directory:',
   'card.repo.current_marker': ' ← current',
   'card.repo.note': 'You can also reply `/repo <N>` (e.g. `/repo 1`), or `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`) to skip this card. `/repo wt <N|name> [branch]` opens a fresh worktree off the remote default branch.',
+  'card.repo.truncated_hint': '⚠️ Too many projects — the dropdown lists only the first {shown} of {total}. For one that is not listed, use `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`).',
   'card.repo.placeholder_worktree': '🌿 Open a repo as a new worktree',
   'card.repo.placeholder_worktree_multi': '🌿 Select one or more repos for new worktrees',
   'card.repo.worktree_now_multi': 'Multi-repo picker on (default for this bot’s future sessions)',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -93,6 +93,7 @@ export const messages: Record<string, string> = {
   'card.repo.current_active': '当前工作目录：',
   'card.repo.current_marker': ' ← 当前',
   'card.repo.note': '也可以回复 `/repo <编号>` 切换（如 `/repo 1`），或直接 `/repo <路径|项目名>`（如 `/repo botmux`、`/repo ~/projects/foo`）跳过本卡片；`/repo wt <编号|项目名> [分支名]` 基于远端默认分支新建 worktree 打开',
+  'card.repo.truncated_hint': '⚠️ 项目过多，下拉框仅显示前 {shown} 个（共 {total} 个）。未列出的用 `/repo <路径|项目名>` 直接指定（如 `/repo botmux`、`/repo ~/projects/foo`）。',
   'card.repo.placeholder_worktree': '🌿 选仓库新建 worktree 打开',
   'card.repo.placeholder_worktree_multi': '🌿 选择一个或多个仓库新建 worktree',
   'card.repo.worktree_now_multi': '多仓库选择器已开启（本 bot 后续会话默认）',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1353,10 +1353,13 @@ function worktreeMultiForm(worktreeOptions: Array<{ text: { tag: 'plain_text'; c
   };
 }
 
-/** Repo selection card. `multiPicker` (persisted per-bot via worktreeMultiPicker)
- *  flips the worktree control between an instant single-select dropdown (false)
- *  and the inline multi-select form (true). */
-export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: string, rootMessageId?: string, locale?: Locale, multiPicker?: boolean): string {
+/** Render the repo selection card for an already-budgeted slice of the scan.
+ *  `multiPicker` (persisted per-bot via worktreeMultiPicker) flips the worktree
+ *  control between an instant single-select dropdown (false) and the inline
+ *  multi-select form (true). `hiddenCount` > 0 means the caller dropped that
+ *  many trailing projects to fit the card byte budget; the card then says so.
+ *  Callers go through buildRepoSelectCard, which owns the budget. */
+function renderRepoSelectCard(projects: ProjectInfo[], currentPath: string | undefined, rootMessageId: string | undefined, locale: Locale | undefined, multiPicker: boolean | undefined, hiddenCount: number): string {
   const currentMarker = t('card.repo.current_marker', undefined, locale);
   const options = projects.map((p, i) => {
     const currentTag = p.path === currentPath ? currentMarker : '';
@@ -1551,6 +1554,18 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
           },
         ],
       },
+      // Over-budget scans lose their tail (see buildRepoSelectCard). Say so, and
+      // point at `/repo <path|name>` — that resolves against a fresh scan, so it
+      // reaches a dropped project regardless of what this dropdown lists.
+      ...(hiddenCount > 0 ? [{
+        tag: 'note',
+        elements: [
+          {
+            tag: 'lark_md',
+            content: t('card.repo.truncated_hint', { shown: projects.length, total: projects.length + hiddenCount }, locale),
+          },
+        ],
+      }] : []),
       {
         tag: 'note',
         elements: [
@@ -1564,6 +1579,53 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
   };
 
   return JSON.stringify(card);
+}
+
+/** Byte budget for the repo picker card.
+ *
+ *  The Feishu card API rejects a payload past ~109 KB with error 230025 ("The
+ *  length of the message content reaches its limit."). Unlike the streaming
+ *  card there is no user-authored content to shorten here: the card carries one
+ *  select_static option per scanned project, so a broad scan root sets the size
+ *  on its own. A live 1174-project root (47 repos + 1127 worktrees) serialized
+ *  to 186 KB and the send threw — and because the picker is published after the
+ *  turn is durably admitted, the session was left waiting on a card that never
+ *  existed, with a restart rebuilding the same oversized card. Budgeting here is
+ *  what keeps that from being reachable at all.
+ *
+ *  Set below the observed cliff (~115 KB of card) rather than at it: the egress
+ *  stamp (stampBotmuxCallbackMarkers) grows the wire payload after this measures
+ *  it, the API envelope adds its own overhead, and non-ASCII project names cost
+ *  more bytes than characters. 80 KB still lists several hundred projects — far
+ *  past what anyone scrolls — and the overflow stays reachable by name. */
+export const REPO_SELECT_CARD_MAX_BYTES = 80_000;
+
+/** Repo selection card, capped at REPO_SELECT_CARD_MAX_BYTES.
+ *
+ *  Truncation takes the head of `projects` and never reorders or renumbers it:
+ *  option labels stay 1-based over the caller's own list, which is the same list
+ *  `/repo <N>` indexes through lastRepoScan, so a visible option means the same
+ *  thing before and after a truncation. The scanner sorts repos ahead of
+ *  worktrees, so in practice the tail that goes is worktrees. */
+export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: string, rootMessageId?: string, locale?: Locale, multiPicker?: boolean): string {
+  const render = (visible: number): string =>
+    renderRepoSelectCard(projects.slice(0, visible), currentPath, rootMessageId, locale, multiPicker, projects.length - visible);
+  const fits = (json: string): boolean => Buffer.byteLength(json, 'utf-8') <= REPO_SELECT_CARD_MAX_BYTES;
+
+  const full = render(projects.length);
+  if (fits(full)) return full;
+
+  // Largest head slice that fits. Option size varies (name, branch, path), so
+  // search rather than divide by an assumed per-option cost. Floor at 1: an
+  // empty dropdown would be a worse card than an over-budget one, and the
+  // publish sites degrade gracefully when a send is rejected anyway.
+  let lo = 1;
+  let hi = projects.length - 1;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (fits(render(mid))) lo = mid; else hi = mid - 1;
+  }
+  return render(lo);
 }
 
 // ─── 群内授权卡片 ─────────────────────────────────────────────────────────────

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -14,6 +14,7 @@ import {
   buildSessionCard,
   buildStreamingCard,
   buildRepoSelectCard,
+  REPO_SELECT_CARD_MAX_BYTES,
   buildSessionClosedCard,
   buildRelayPickerCard,
   buildAdoptSelectCard,
@@ -1750,6 +1751,99 @@ describe('buildRepoSelectCard', () => {
       const actionEl = card.elements.find((e: any) => e.tag === 'action');
       const selectStatic = actionEl.actions.find((a: any) => a.tag === 'select_static');
       expect(selectStatic.options).toHaveLength(0);
+    });
+  });
+
+  // ── Byte budget ────────────────────────────────────────────────────────
+
+  describe('byte budget', () => {
+    // A broad scan root (observed live: 1174 projects) serialized past Feishu's
+    // ~109 KB card limit, the send threw 230025, and the session was left
+    // waiting on a card that was never published.
+    function manyProjects(n: number): ProjectInfo[] {
+      const out: ProjectInfo[] = [];
+      for (let i = 0; i < n; i++) {
+        // Repos first, then worktrees — the scanner's own compareProjects order.
+        const isRepo = i < 40;
+        out.push({
+          name: `project-with-a-fairly-long-name-${i}`,
+          path: `/root/iserver/some/deep/path/project-with-a-fairly-long-name-${i}`,
+          type: isRepo ? 'repo' : 'worktree',
+          branch: isRepo ? 'main' : `botmux-wt-feature-branch-${i}`,
+        });
+      }
+      return out;
+    }
+
+    function switchOptions(card: any): any[] {
+      const actionEl = card.elements.find((e: any) => e.tag === 'action');
+      return actionEl.actions.find((a: any) => a.tag === 'select_static').options;
+    }
+
+    function noteContents(card: any): string[] {
+      return card.elements.filter((e: any) => e.tag === 'note').map((e: any) => e.elements[0].content);
+    }
+
+    it('keeps an oversized scan under the byte budget', () => {
+      const json = buildRepoSelectCard(manyProjects(3000), '/root/iserver', 'om_root');
+      expect(Buffer.byteLength(json, 'utf-8')).toBeLessThanOrEqual(REPO_SELECT_CARD_MAX_BYTES);
+    });
+
+    it('stays under budget in multi-picker mode too', () => {
+      const json = buildRepoSelectCard(manyProjects(3000), '/root/iserver', 'om_root', 'zh', true);
+      expect(Buffer.byteLength(json, 'utf-8')).toBeLessThanOrEqual(REPO_SELECT_CARD_MAX_BYTES);
+    });
+
+    it('truncates the tail rather than the head, so 1-based numbering still matches lastRepoScan', () => {
+      const all = manyProjects(3000);
+      const options = switchOptions(parse(buildRepoSelectCard(all, '/root/iserver', 'om_root')));
+      expect(options.length).toBeGreaterThan(0);
+      expect(options.length).toBeLessThan(all.length);
+      // Every visible option keeps its index in the FULL list: `/repo <N>`
+      // indexes lastRepoScan, which the caller stores unsliced.
+      options.forEach((opt: any, i: number) => {
+        expect(opt.text.content).toMatch(new RegExp(`^${i + 1}\\.`));
+        expect(opt.value).toBe(all[i].path);
+      });
+    });
+
+    it('drops worktrees before repos (scanner sorts repos first)', () => {
+      const options = switchOptions(parse(buildRepoSelectCard(manyProjects(3000), '/root/iserver', 'om_root')));
+      const repoLabels = options.filter((o: any) => !o.text.content.includes('[worktree]'));
+      expect(repoLabels).toHaveLength(40);
+    });
+
+    it('adds a truncation note naming shown/total and the /repo escape hatch', () => {
+      const notes = noteContents(parse(buildRepoSelectCard(manyProjects(3000), '/root/iserver', 'om_root')));
+      const hint = notes.find(n => n.includes('仅显示前'));
+      expect(hint).toBeDefined();
+      expect(hint).toContain('共 3000 个');
+      expect(hint).toContain('/repo <路径|项目名>');
+      // The ordinary usage note survives alongside it.
+      expect(notes.some(n => n.includes('/repo <编号>'))).toBe(true);
+    });
+
+    it('localizes the truncation note', () => {
+      const notes = noteContents(parse(buildRepoSelectCard(manyProjects(3000), '/root/iserver', 'om_root', 'en')));
+      expect(notes.some(n => n.includes('lists only the first') && n.includes('of 3000'))).toBe(true);
+    });
+
+    it('leaves a normally-sized scan untouched: every project shown, no truncation note', () => {
+      const few = manyProjects(30);
+      const card = parse(buildRepoSelectCard(few, '/root/iserver', 'om_root'));
+      expect(switchOptions(card)).toHaveLength(30);
+      expect(noteContents(card).some(n => n.includes('仅显示前'))).toBe(false);
+    });
+
+    it('still shows one option when even a single project would exceed the budget', () => {
+      const huge: ProjectInfo[] = Array.from({ length: 3 }, (_, i) => ({
+        name: 'x'.repeat(REPO_SELECT_CARD_MAX_BYTES),
+        path: `/p/${i}`,
+        type: 'repo',
+        branch: 'main',
+      }));
+      const options = switchOptions(parse(buildRepoSelectCard(huge, '/root/iserver', 'om_root')));
+      expect(options).toHaveLength(1);
     });
   });
 });

--- a/test/daemon-ordinary-ingress-failure-notice.test.ts
+++ b/test/daemon-ordinary-ingress-failure-notice.test.ts
@@ -357,7 +357,15 @@ describe('durable admission then failing status reply → no resend advice (PR #
     expect(ds.session.pendingRepoSetup?.turnId).toBe('om_msg_pr2');
   });
 
-  it('new topic staged + queued durably: failing repo card keeps exactly one queue item and never advises a resend', async () => {
+  // A failing repo card used to escape this handler and land here as an
+  // "admitted, do not resend" notice. That was the least-bad reading of a wedge:
+  // the turn was durably staged behind a picker that did not exist, so every
+  // follow-up hit 「请先在上方卡片中选择仓库」 and a restart re-published the same
+  // card. The publish sites now degrade instead — no picker means fork with the
+  // default cwd — so the turn actually runs. The invariant this case was written
+  // for still holds and is what it now pins: a failed card never advises a
+  // resend and never duplicates the queue item.
+  it('new topic staged + queued durably: a failing repo card degrades to a working session instead of wedging', async () => {
     const anchor = 'om_msg_nt_admitted';
     mocks.scanMultipleProjects.mockReturnValue([
       { name: 'demo', path: '/tmp/botmux-demo', type: 'repo', branch: 'main' },
@@ -372,13 +380,72 @@ describe('durable admission then failing status reply → no resend advice (PR #
       return 'om_top';
     });
 
-    await expect(
-      handleNewTopic(makeEventData(anchor, 'start a durable task'), makeCtx(anchor, anchor)),
-    ).rejects.toThrow('lark card send failure');
+    await handleNewTopic(makeEventData(anchor, 'start a durable task'), makeCtx(anchor, anchor));
 
+    const ds: any = activeSessions.get(sessionKey(anchor, APP));
+    expect(ds?.pendingRepo).toBe(false);
+    expect(ds?.repoCardMessageId).toBeUndefined();
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
     expect(repliedText()).not.toContain(resendNotice());
-    expect(repliedText()).toContain(admittedNotice());
+    expect(repliedText()).not.toContain(chooseRepoNotice());
     expect(messageQueue.readUnread(anchor).length).toBe(1);
+  });
+
+  // 同一降级的另外两个发卡点。三处的 fallback 各自不同（raw passthrough 走
+  // forkReservedInitialRawSession，auto-create 走 noteTurnReceived +
+  // forkReservedInitialSession），所以分别钉住，避免只在一处补了兜底。
+  it('initial raw passthrough: a failing repo card runs the command on the default cwd', async () => {
+    const anchor = 'om_msg_raw_passthrough';
+    mocks.scanMultipleProjects.mockReturnValue([
+      { name: 'demo', path: '/tmp/botmux-demo', type: 'repo', branch: 'main' },
+    ] as any);
+    mocks.replyMessage.mockImplementation(async (...args: any[]) => {
+      if (args[3] === 'interactive') throw new Error('lark card send failure');
+      return 'om_reply';
+    });
+    mocks.sendMessage.mockImplementation(async (...args: any[]) => {
+      if (args[3] === 'interactive') throw new Error('lark card send failure');
+      return 'om_top';
+    });
+
+    // /goal is claude-code's adapter default passthrough → initial raw passthrough route.
+    await handleNewTopic(makeEventData(anchor, '/goal ship the fix'), makeCtx(anchor, anchor));
+
+    const ds: any = activeSessions.get(sessionKey(anchor, APP));
+    expect(ds?.pendingRepo).toBe(false);
+    expect(ds?.repoCardMessageId).toBeUndefined();
+    // The raw command survives the degradation — it is what gets executed.
+    expect(ds?.pendingRawInput).toBe('/goal ship the fix');
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(repliedText()).not.toContain(resendNotice());
+  });
+
+  it('thread auto-create: a failing repo card forks the new session on the default cwd', async () => {
+    const anchor = 'om_autocreate_root';
+    mocks.scanMultipleProjects.mockReturnValue([
+      { name: 'demo', path: '/tmp/botmux-demo', type: 'repo', branch: 'main' },
+    ] as any);
+    mocks.replyMessage.mockImplementation(async (...args: any[]) => {
+      if (args[3] === 'interactive') throw new Error('lark card send failure');
+      return 'om_reply';
+    });
+    mocks.sendMessage.mockImplementation(async (...args: any[]) => {
+      if (args[3] === 'interactive') throw new Error('lark card send failure');
+      return 'om_top';
+    });
+
+    // A reply under a root with no session → auto-create takes the picker route.
+    await handleThreadReply(
+      makeEventData('om_autocreate_msg', 'auto create me', anchor),
+      makeCtx(anchor, 'om_autocreate_msg'),
+    );
+
+    const ds: any = activeSessions.get(sessionKey(anchor, APP));
+    expect(ds?.pendingRepo).toBe(false);
+    expect(ds?.repoCardMessageId).toBeUndefined();
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(repliedText()).not.toContain(resendNotice());
+    expect(repliedText()).not.toContain(chooseRepoNotice());
   });
 
   it('a failing admitted-notice never masks the original status-reply error', async () => {

--- a/test/group-join-shared-routing.test.ts
+++ b/test/group-join-shared-routing.test.ts
@@ -423,6 +423,45 @@ describe('handleBotAdded — 普通群 shared 路由', () => {
     );
   });
 
+  // 卡片发不出去（飞书 230025 等）时不能停在 pendingRepo：入群自动开工没有任何
+  // 用户输入可再触发，会话会永久挂在一张不存在的卡片上。降级 = 走同一个「无可选
+  // 项目」分支，用默认目录直接开工，且共享 seed 仍归本轮所有。
+  it('repo 卡发送失败时改用默认目录直接开工，而不是挂在不存在的卡片上', async () => {
+    const { daemon, registry, types } = modules;
+    const appId = 'app_join_pending_repo_card_fail';
+    const chatId = 'oc_join_pending_repo_card_fail';
+    const scanDir = tempDir('scan-pending-repo-card-fail');
+    mocks.getProjectScanDirs.mockReturnValue([scanDir]);
+    mocks.scanMultipleProjects.mockReturnValue([{
+      name: 'botmux',
+      path: scanDir,
+      type: 'repo',
+      branch: 'master',
+    }]);
+    mocks.replyMessage.mockImplementation(async (...args: any[]) => {
+      if (args[3] === 'interactive') throw new Error('lark card send failure');
+      return 'om_reply';
+    });
+    registry.registerBot({
+      larkAppId: appId,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      autoStartOnGroupJoin: true,
+      autoStartOnGroupJoinPrompt: '开始排查',
+      regularGroupReplyMode: 'shared',
+    });
+
+    await daemon.__testOnly_handleBotAdded(chatId, 'ou_owner', appId);
+
+    const ds = daemon.__testOnly_activeSessions.get(types.sessionKey(chatId, appId));
+    expect(ds?.pendingRepo).toBe(false);
+    expect(ds?.repoCardMessageId).toBeUndefined();
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    // 卡片没发出去就没有可删的消息，别拿 undefined 去调删除接口。
+    expect(mocks.deleteMessage).not.toHaveBeenCalled();
+  });
+
   it('losing registration leaves no shared seed message or orphaned first turn', async () => {
     const { daemon, registry, types } = modules;
     const appId = 'app_join_shared_race';


### PR DESCRIPTION
## 问题

扫描根目录下项目过多时（实测 1020 个项目 = 16 repo + 1004 worktree），`buildRepoSelectCard` 会拼出 **186KB** 的卡片，超过飞书约 109KB 的消息上限，API 返回 `230025 The length of the message content reaches its limit.`。

四个发卡点当时都是裸 `await sessionReply(...)`，异常直接掀翻整条投递链，于是同一个 bug 表现成两个症状：

1. **卡片没弹出来**；
2. **会话永久挂死** —— `onDurablyAdmitted?.()` 在发送之前就已触发，`pendingRepoSetup` 已落库但 `repoCardMessageId` 从未写入。用户看到「已接收勿重发」，之后每条跟进都被「请先在上方卡片中选择仓库」挡回，重启也只是重发同一张超限卡片。

## 改动

### 卡片侧（根因）

`buildRepoSelectCard` 加 80KB 预算（`REPO_SELECT_CARD_MAX_BYTES`）。留出的余量是给 egress 处 `stampBotmuxCallbackMarkers` 追加的 `__bm_cb` 标记——实测线上真卡片的膨胀量 36–48 字节，80KB 到 109KB 硬上限之间有充分冗余。

超预算时**二分搜索**最大可容纳的头部切片，而不是按固定单价估算：选项体积随名字/分支/路径长度差异很大。

截断取头部是有意的：`compareProjects` 把 `type === 'repo'` 排在 `'worktree'` 之前，所以**先丢的一定是 worktree，真实仓库全部保留**。

截断时在下拉框上方加一条提示，告知总数并引导 `/repo <路径|项目名>`（该路径走 `resolveRepoSelection` 重新扫描，不依赖卡片里的编号）。原有 `/repo <编号>` 提示保留，且**编号严格保持 1-based 不重排**，与 `lastRepoScan` 里的完整列表对齐。

### daemon 侧（兜底）

四个发卡点补 try/catch，语义对齐 `session-manager.ts` 的 `createSession`：卡片发不出去就没有 picker 可点，保持 `pendingRepo` 只会把已 durable 接纳的开场挂死在一张不存在的卡片上。改为落到各自「无可选项目」那条**既有**分支——清 `pendingRepo` 后 `forkWorker` 会清空 activation journal，用默认 cwd 直接开工。

各站点复用自己的 fallback，不共享一套：保留 `topicHeaderIdleStart` 判断、入群的 shared-seed / takeover 交接、以及线程自建会话的 `newDs` 身份。

**未加 catch 的两处已确认无需处理**：`command-handler.ts` 的 `/repo` 从不置 `pendingRepo`，发送失败只是普通命令报错；`resumeRestoredPendingRepoSetup` 的调用方本就有 try/catch + `restorePendingRepoRuntime`，且预算落地后它也不可能再构造出超限卡片。

## 影响面

跨公共层改动：`im/lark/card-builder.ts`（卡片构造，所有 CLI/后端共用）、`i18n/`（中英双语）、`daemon.ts`（四条会话诞生路径）。

| 维度 | 评估 | 怎么验的 |
|---|---|---|
| 会话类型 | 话题首轮、raw passthrough 首轮、入群自动开工、线程回复自建 —— 四条发卡路径 | 逐条补了降级测试；已有默认目录 / auto-worktree 路径不经过发卡点 |
| 跨 CLI / 后端 | 无关：卡片构造不碰适配器，也不碰 PtyBackend/TmuxBackend | 仅按 `worktreeMultiPicker` 分两种形态，两种都验了预算 |
| 跨平台 | 无关：纯字符串字节计算 + 已有飞书调用，无路径/shell/PTY 语义 | — |
| 正常规模 | 项目数未超预算时输出与改动前**逐字节一致** | 30 项目用例钉住「无提示、选项数不变」 |

## 验证

```
npx tsc --noEmit -p tsconfig.json          → EXIT=0
bun run build                              → EXIT=0
                                             [audit-embed] 13 dist asset(s) accounted for
```

相关套件（card-builder / card-handler-repo-select / repo-selection / pending-repo-journal / command-handler / group-join-shared-routing / session-group-birth ×3 / session-manager-scan / daemon-ordinary-ingress-failure-notice）：

```
Test Files  11 passed (11)
     Tests  673 passed (673)
```

另 8 个触及面套件（close-consumer-matrix / dashboard-create-session / issue-claim-flow / command-retry / session-resume / initial-passthrough-ownership / transfer-input-gate-wiring / topic-directive-header）：

```
Test Files  8 passed (8)
     Tests  188 passed (188)
```

**全量 `vitest run --project unit`**：`1297 passed | 14 failed`。把这 14 个文件单独跑 → 7 个失败；在**同一 worktree 的干净基线**（`git reset` 到 base `56f2c2fd1`，`git status` 报干净）跑同一组 → **同样 7 个文件、同样 33 个用例失败**，逐文件一致：

```
本分支：      Test Files  7 failed | 7 passed (14)   Tests  33 failed | 201 passed (234)
干净基线：    Test Files  7 failed | 7 passed (14)   Tests  33 failed | 201 passed (234)
             linux-isolation / mojo-launcher-env-quarantine / plugin-mcp-sandbox /
             plugin-registry-sandbox-read / sandbox-session-data-dir /
             session-store-sqlite-bun-import / session-store-sqlite-poisoned-recovery
```

均为 root+bwrap 与 sqlite 引擎版本类环境噪声，**零回归**。（全量里多出的 7 个是并发下的超时，单独跑即通过。）

**反变异 7 条全部转红**：

| # | 变异 | 结果 |
|---|---|---|
| M1 | 去掉字节预算（永远整张渲染） | 6 红 |
| M2 | 去掉截断提示 note | 2 红 |
| M3 | 头部截断改尾部截断（会丢真实仓库） | 2 红 |
| M4 | 发卡点 1（raw passthrough）catch 改回 rethrow | 1 红 |
| M5 | 发卡点 2（话题首轮）catch 改回 rethrow | 1 红 |
| M6 | 发卡点 4（线程自建）catch 改回 rethrow | 1 红 |
| M7 | 发卡点 3（入群自动开工）catch 改回 rethrow | 1 红 |

**真实扫描实测**（`/root/iserver`，1020 个项目 = 16 repo + 1004 worktree）：

```
budget = 80000
multiPicker=false: 79973 bytes, 521/1020 options, withinBudget=true
multiPicker=true:  79934 bytes, 515/1020 options, withinBudget=true
  16 个真实仓库全部保留（截断只吃 worktree）
```

## UI 效果

超量时下拉框上方新增一条提示，与原有 `/repo` 用法提示并存（900 个项目，单选形态）：

**中文**
```
⚠️ 项目过多，下拉框仅显示前 376 个（共 900 个）。未列出的用 `/repo <路径|项目名>`
   直接指定（如 `/repo botmux`、`/repo ~/projects/foo`）。

也可以回复 `/repo <编号>` 切换（如 `/repo 1`），或直接 `/repo <路径|项目名>`
（如 `/repo botmux`、`/repo ~/projects/foo`）跳过本卡片；`/repo wt <编号|项目名>
[分支名]` 基于远端默认分支新建 worktree 打开
```

**English**
```
⚠️ Too many projects — the dropdown lists only the first 376 of 900. For one that is
   not listed, use `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`).
```

项目数在预算内时**不出现**这条提示（12 个项目的实测输出里只有原有那条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
