### PR TITLE
fix(groups): 隐藏已解散的飞书群

### DIFF
--- a/src/services/groups-store.ts
+++ b/src/services/groups-store.ts
@@ -18,6 +18,7 @@ export interface ChatBrief {
   name?: string;
   description?: string;
   chatMode?: string;
+  chatStatus?: string;
   ownerId?: string;
   /** 群头像 URL（/open-apis/im/v1/chats 的 avatar 字段）。 */
   avatar?: string;
@@ -41,11 +42,19 @@ export async function listChats(larkAppId: string): Promise<ChatBrief[]> {
       throw new Error(`Failed to list chats: ${res.msg} (code: ${res.code})`);
     }
     for (const c of res.data?.items ?? []) {
+      const chatStatus = typeof c.chat_status === 'string' ? c.chat_status : undefined;
+      // Feishu keeps dissolved_save chats in /im/v1/chats so users can retain
+      // their history. They are no longer manageable groups, though: member
+      // APIs reject them with 232009 even while is_in_chat may still say true.
+      // Fail closed for missing/future states as well: the groups board offers
+      // mutating controls, so only an explicit normal status is manageable.
+      if (chatStatus !== 'normal') continue;
       out.push({
         chatId: c.chat_id,
         name: c.name,
         description: c.description,
         chatMode: c.chat_mode,
+        chatStatus,
         ownerId: c.owner_id,
         avatar: c.avatar,
       });

--- a/test/groups-store.test.ts
+++ b/test/groups-store.test.ts
@@ -12,6 +12,7 @@ const chatCreateStub = vi.fn();
 const chatUpdateStub = vi.fn();
 // chat.link mocks the share-link fetch.
 const chatLinkStub = vi.fn();
+let chatListItems: Array<Record<string, unknown>>;
 
 // Mock bot-registry's getBotClient — that's where groups-store imports from.
 // Read-only GETs (listChats / isInChat / getChatOwner) now go through
@@ -27,16 +28,7 @@ vi.mock('../src/bot-registry.js', () => ({
         return {
           code: 0,
           data: {
-            items: [
-              {
-                chat_id: 'c1',
-                name: 'one',
-                description: 'first chat',
-                chat_mode: 'group',
-                owner_id: 'ou_owner',
-                avatar: 'https://avatar.example/c1.png',
-              },
-            ],
+            items: chatListItems,
             has_more: false,
           },
         };
@@ -76,7 +68,20 @@ import {
 } from '../src/services/groups-store.js';
 
 describe('groups-store wrappers', () => {
-  beforeEach(() => { chatCreateStub.mockClear(); chatUpdateStub.mockClear(); chatLinkStub.mockReset(); });
+  beforeEach(() => {
+    chatCreateStub.mockClear();
+    chatUpdateStub.mockClear();
+    chatLinkStub.mockReset();
+    chatListItems = [{
+      chat_id: 'c1',
+      name: 'one',
+      description: 'first chat',
+      chat_mode: 'group',
+      chat_status: 'normal',
+      owner_id: 'ou_owner',
+      avatar: 'https://avatar.example/c1.png',
+    }];
+  });
 
   it('listChats returns ChatBrief array', async () => {
     const out = await listChats('appA');
@@ -85,8 +90,21 @@ describe('groups-store wrappers', () => {
     expect(out[0].name).toBe('one');
     expect(out[0].description).toBe('first chat');
     expect(out[0].chatMode).toBe('group');
+    expect(out[0].chatStatus).toBe('normal');
     expect(out[0].ownerId).toBe('ou_owner');
     expect(out[0].avatar).toBe('https://avatar.example/c1.png');
+  });
+
+  it('listChats only returns chats that Feishu explicitly reports as normal', async () => {
+    chatListItems.push(
+      { chat_id: 'c2', name: 'dissolved', chat_status: 'dissolved' },
+      { chat_id: 'c3', name: 'retained history', chat_status: 'dissolved_save' },
+      { chat_id: 'c4', name: 'unknown legacy state' },
+    );
+
+    await expect(listChats('appA')).resolves.toEqual([
+      expect.objectContaining({ chatId: 'c1', chatStatus: 'normal' }),
+    ]);
   });
 
   it('isInChat returns boolean', async () => {


### PR DESCRIPTION
## 问题

飞书 `/im/v1/chats` 会继续返回 `chat_status=dissolved_save` 的已解散保留群。Botmux 的群组数据源此前无条件映射所有条目，并丢弃 `chat_status`，导致群组管理页继续展示无法管理的已解散群；这类群的成员接口会返回 `232009`，但 `is_in_chat` 仍可能返回 `true`。

## 修改

- 在 `groups-store.listChats()` 中读取并保留 `chat_status`。
- 群组管理数据源仅接纳明确为 `normal` 的群；`dissolved`、`dissolved_save`、缺失或未来未知状态均 fail closed，不进入管理矩阵。
- 增加回归测试，覆盖正常、已解散、已解散保留和缺失状态。

## 影响面

- 只影响 Dashboard/群组卡片共用的群组管理矩阵及其名称投影。
- 不修改消息路由、群授权、历史会话和飞书群本身。
- 已解散群的 closed session 仍保留，可继续用于历史审计。
- 改动与平台、CLI、后端类型无关；所有 Bot 的群组管理列表统一采用相同状态过滤。

## 验证

- `bun run build`：通过。
- `bun run test -- test/groups-store.test.ts test/dashboard-ipc.test.ts`：276 passed，1 skipped。
- `bun run test -- test/groups-store.test.ts test/groups-card-model.test.ts test/dashboard-groups-matrix-snapshot.test.ts test/dashboard-groups-names-view.test.ts`：59 passed。
- `tsc --noEmit`、`tsc -p tsconfig.scripts.json --noEmit`、`tsc -p tsconfig.test-mocks.json --noEmit`：通过。
- GitHub CI：build、3 个 Node test shard、3 个跨平台 binary job 均通过；`bun-test` 仅 `tmux-startup-storm-recovery.test.ts` 被 runner 的 180 秒 post-result idle watchdog SIGKILL，单独以 Bun 1.4.2 复跑该文件为 2 passed。
