### PR TITLE
fix(tmux-pipe-backend): fifo 拆除时不再重复关闭 ReadStream 已拥有的 fd

### DIFF
--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -988,6 +988,7 @@ export class TmuxPipeBackend implements SessionBackend {
   private teardownFifoReader(): void {
     liveFifoReaders.delete(this);
     this.fifoTornDown = true;
+    const hadStream = this.readStream !== null;
     if (this.readStream) {
       const stream = this.readStream as fs.ReadStream & { close?: () => void; unref?: () => void };
       this.readStream = null;
@@ -1017,7 +1018,12 @@ export class TmuxPipeBackend implements SessionBackend {
       // then the number could name a freshly-opened unrelated file).
       const fd = this.fifoFd;
       this.fifoFd = null;
-      try { fs.closeSync(fd); } catch { /* stream already closed it */ }
+      // Only close the fd ourselves when no ReadStream owned it. Under bun a
+      // destroy()ed stream leaves a threadpool thread parked in read(2) on this
+      // fd; closing it here makes that thread unjoinable and the next
+      // execFileSync() in the same process never returns (MEASURED: bun 1.4.0
+      // deterministic, 1.4.2 ~2/3). destroy() already closes the fd itself.
+      if (!hadStream) { try { fs.closeSync(fd); } catch { /* already closed */ } }
     }
     try { fs.unlinkSync(this.fifoPath); } catch { /* already gone */ }
   }

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -50,12 +50,18 @@ vi.mock('node:fs', () => {
       };
     }),
     unlinkSync: vi.fn(),
+    // closeSync/writeSync are mocked so the fd-ownership guard below can observe
+    // them. They must also NOT hit the real syscall: openSync above is stubbed to
+    // return 7 for both the read fd and the wake fd, and 7 is a live fd in the test
+    // process itself — the unmocked versions were closing/writing it for real.
+    closeSync: vi.fn(),
+    writeSync: vi.fn(),
     constants: actual.constants,
   };
 });
 
 import { execSync, execFileSync, spawnSync } from 'node:child_process';
-import { unlinkSync, createReadStream } from 'node:fs';
+import { unlinkSync, createReadStream, closeSync, writeSync } from 'node:fs';
 import {
   TmuxPipeBackend,
   normaliseCaptureLineEndings,
@@ -72,6 +78,8 @@ const mockedExecSync = vi.mocked(execSync);
 const mockedExecFileSync = vi.mocked(execFileSync);
 const mockedSpawnSync = vi.mocked(spawnSync);
 const mockedUnlinkSync = vi.mocked(unlinkSync);
+const mockedCloseSync = vi.mocked(closeSync);
+const mockedWriteSync = vi.mocked(writeSync);
 
 type FakeShell = {
   readonly dir: string;
@@ -123,6 +131,8 @@ beforeEach(() => {
   mockedExecFileSync.mockReset();
   mockedSpawnSync.mockReset();
   mockedUnlinkSync.mockReset();
+  mockedCloseSync.mockReset();
+  mockedWriteSync.mockReset();
   mockedExecSync.mockReturnValue(Buffer.from('') as any);
   mockedSpawnSync.mockReturnValue(bufferSpawnResult({ status: 0 }));
 });
@@ -1256,5 +1266,56 @@ describe('TmuxPipeBackend.onData', () => {
     const joined = received.join('');
     expect(joined).toBe('┌─┐');
     expect(joined).not.toContain('�');
+  });
+});
+
+describe('TmuxPipeBackend fifo fd ownership on teardown', () => {
+  // Guards the fix for a process-level wedge that the storm-recovery suite can
+  // also catch, but only by hanging until the 720s per-file wall — and only for
+  // as long as bun keeps parking a threadpool thread on the fifo read. This
+  // asserts the behaviour DIRECTLY instead: once a ReadStream has owned the fifo
+  // fd, teardown must not close that fd itself.
+  //
+  // The bug: spawn() holds the fifo O_RDWR and hands the fd to
+  // createReadStream(fd, {autoClose:false}). Under bun that read is serviced by a
+  // threadpool thread parked in read(2); destroy() detaches the JS stream but
+  // leaves the thread parked AND has already closed the fd. Closing it a second
+  // time here makes the thread unjoinable, and the next execFileSync() in the
+  // process never returns — not even on its own timeout. Measured: bun 1.4.0
+  // wedges deterministically, 1.4.2 about two runs in three, node is immune.
+  it('does not close the fifo fd that the ReadStream owns', () => {
+    const be = new TmuxPipeBackend('0:2.0');
+    be.spawn('', [], spawnOpts());
+
+    // spawn() opens two fds through the stubbed openSync, both reported as 7:
+    // the O_RDWR read fd (handed to the stream) and the O_WRONLY wake fd. Only
+    // the wake fd may be closed here, so record the count before teardown.
+    mockedCloseSync.mockClear();
+    be.kill();
+
+    // The wake fd is closed exactly once; the stream-owned read fd is not.
+    // Before the fix this was 2 — the second call is the one that wedges.
+    expect(mockedCloseSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaks no fd on the spawn fail-closed path', () => {
+    // The other way a fifo fd can be opened without a stream: the wake-fd open
+    // throws, so spawn() bails after opening the read fd. spawn() closes that fd
+    // ITSELF here (see the catch block around the wake-fd open) and never reaches
+    // teardown — which is why teardown's own `!hadStream` close has no reachable
+    // caller today and is a defensive backstop, not a tested branch. Asserting
+    // that would be asserting nothing: with the close removed from teardown this
+    // test still passes, because the close it observes belongs to spawn().
+    const be = new TmuxPipeBackend('0:2.0');
+    process.env.BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL = '1';
+    try {
+      expect(() => be.spawn('', [], spawnOpts())).toThrow(/EMFILE/);
+    } finally {
+      delete process.env.BOTMUX_TEST_FORCE_WAKE_OPEN_FAIL;
+    }
+    // The read fd is closed and the fifo unlinked, so the failed spawn leaves
+    // nothing behind.
+    expect(mockedCloseSync).toHaveBeenCalledTimes(1);
+    expect(mockedUnlinkSync).toHaveBeenCalledWith(expect.stringMatching(/botmux-pipe-.*\.fifo/));
   });
 });


### PR DESCRIPTION
## 问题

`teardownFifoReader()` 在 `stream.destroy()` 之后，又对同一个 fd 调了一次 `fs.closeSync()`。

在 bun 下这会楔死整个进程：被 destroy 的 ReadStream 会留下一个**线程池线程仍然阻塞在这个 fd 的 `read(2)` 上**（fifo 是我们自己以 O_RDWR 持有的，永远不会 EOF）。此时把 fd 关掉，那个线程就再也无法被 join —— **同进程内下一次 `execFileSync()` 永不返回，连它自己的 `timeout` 都不会触发**。

楔死瞬间的进程形状（实测）：

- 主线程停在 `epoll_pwait2`
- 持有 **0 个 pipe fd**
- 挂着一个 `[tmux: client] <defunct>` 僵尸子进程

即**子进程早已退出，同步调用却收不回来**——这也是为什么表面上看不出是谁在阻塞。

## 改法

只在**没有 ReadStream 拥有该 fd** 时才自己关闭。`destroy()` 本来就会关它 —— 这一点原注释里已经写明「EBADF here is the normal, expected outcome」，那行 `closeSync` 原本只是 in-flight 情况的兜底，而恰恰是 in-flight 时它会踩中上面的楔死。

## 影响面

`teardownFifoReader()` 是 `TmuxPipeBackend` **唯一**的 fifo 拆除路径，`kill()` / `destroySession()` / `handlePaneExit()` / 进程退出钩子都汇到这里，所以**所有 tmux 会话的收尾都会走到**。

- **生产**：同一进程在拆掉一个 backend 之后继续跑同步子进程（`pipe-pane`、`kill-session`、下一个会话的 `new-session`）时会命中同样的楔死。worker 主线程被冻住，心跳/取消/新消息都处理不了。
- **其它后端**：`PtyBackend` / `TmuxBackend` / `zmx` / `zellij` 不走 fifo 这条路径，不受影响。
- **Node 运行时**：node 下 `destroy()` 后 fd 已是 EBADF、线程池不留驻留线程，行为不变（该文件在 vitest/node 下一直是 2/2 通过）。

## 验证

**目标用例 `test/tmux-startup-storm-recovery.test.ts`**（就是 #1369 里记录的「第 4 个 flake」，其 PR 描述把真因列为 open question）：

| 运行时 | 修复前 | 修复后 |
|---|---|---|
| bun 1.4.0 | **3/3 楔死**（>90s 无结果行） | **3/3 通过**（6s） |
| bun 1.4.2（CI 钉的版本） | **2/3 楔死** | **5/5 通过**（6s） |
| vitest / node | 2/2 通过（7s） | 2/2 通过 |

1.4.0 是确定性楔死、1.4.2 是间歇 —— 与 CI 上这个文件「时红时绿」的 flake 形状一致。

**反变异**：把那一行还原成无条件 `closeSync`，1.4.2 立刻复现楔死（70s 外部超时，无结果行）⟹ 改动是「武装」的，不是惰性编辑。

**定位过程（最小 A/B）**：单独 `destroy()` 绿、单独 `closeSync(fd)` 绿、**两者相邻则楔死**；不带 backend 的同形用例 190ms 通过。

**回归**：逐文件（one-file-per-process，按 `scripts/run-bun-tests.mjs` 的要求）跑 33 个 tmux/backend 相关用例文件 —— 4 个文件有失败，但在**干净 master 上同样失败**（各 `0 pass`，属既有基础设施问题），**本改动零回归**。`test/tmux-pipe-backend.test.ts` 54/54 通过。

**fd 泄漏核查**（这是本改法唯一的真实风险——少关一次 fd）：N=25 与 N=100 两档 `delta` **恒为 2 且无 fifo fd 残留**，不随次数增长 ⟹ 是 bun 运行时基线开销，不是本改动漏关；node 下 delta=0。

`bun run build` 通过，`tsc --noEmit` 通过。

## 备注

这解答了 #1369 留下的 open question。之前我一度判成 `Atomics.wait` 挡住了 per-test timeout，**那个结论是错的**（实测楔死 >290s，38s 的算术产生不了；且按那个思路做的测试侧修法 3/3 仍楔死），已作废。

🤖 Generated with [Claude Code](https://claude.com/claude-code)