### PR TITLE
fix(mcp): 保留网关标记间的 Codex 信任配置

### DIFF
--- a/src/core/plugins/mcp/gateway-installer.ts
+++ b/src/core/plugins/mcp/gateway-installer.ts
@@ -43,18 +43,12 @@ export function defaultGatewayEntry(): GatewayEntry {
 }
 
 function stripCommentBlock(text: string, start: string, end: string): string {
-  let next = text;
-  while (true) {
-    const startIdx = next.indexOf(start);
-    if (startIdx < 0) break;
-    const endIdx = next.indexOf(end, startIdx);
-    if (endIdx < 0) break;
-    let after = endIdx + end.length;
-    if (next.slice(after, after + 2) === '\r\n') after += 2;
-    else if (next[after] === '\n') after += 1;
-    next = `${next.slice(0, startIdx)}${next.slice(after)}`;
-  }
-  return next;
+  // TOML editors can insert unrelated tables (e.g. hooks.state) before the
+  // trailing end comment. Markers are not ownership boundaries: remove only
+  // the marker lines, then let stripCodexBotmuxSections remove our MCP tables.
+  return text.split(/\r?\n/)
+    .filter(line => line.trim() !== start && line.trim() !== end)
+    .join('\n');
 }
 
 function stripLegacyPluginBlocks(text: string): string {

--- a/test/plugin-mcp-gateway-installer.test.ts
+++ b/test/plugin-mcp-gateway-installer.test.ts
@@ -83,6 +83,53 @@ describe('plugin MCP Gateway installer', () => {
     expect(readFileSync(path, 'utf8')).not.toContain('mcp_servers.botmux');
   });
 
+  it.each(['\n', '\r\n'])('preserves tables inserted before the gateway end marker (%j)', (newline) => {
+    const path = join(home, '.codex', 'config.toml');
+    mkdirSync(dirname(path), { recursive: true });
+    const adapter = { id: 'codex', mcpGateway: { format: 'codex-toml' as const, configPath: path } };
+    const userTables = [
+      '[hooks.state]',
+      '[hooks.state."/tmp/hooks.json:session_start:0:0"]',
+      'trusted_hash = "sha256:first"',
+      '[hooks.state."/tmp/hooks.json:stop:0:0"]',
+      'trusted_hash = "sha256:second"',
+      '[projects."/tmp/work"]',
+      'trust_level = "trusted"',
+      '[mcp_servers.keep]',
+      'command = "keep"',
+    ].join('\n');
+    const initial = [
+      'model = "test-model"',
+      '# >>> botmux mcp gateway',
+      '[mcp_servers.botmux]',
+      'command = "old-gateway"',
+      '[mcp_servers.botmux.env]',
+      'OWNED = "old"',
+      userTables,
+      '# <<< botmux mcp gateway',
+      '',
+    ].join('\n').replace(/\n/g, newline);
+
+    writeFileSync(path, initial);
+    expect(ensureGatewayEntry(adapter).state).toBe('installed');
+    const updated = readFileSync(path, 'utf8');
+    expect(updated).toContain(userTables);
+    expect(updated).toContain('model = "test-model"');
+    expect(updated).not.toContain('old-gateway');
+    expect(updated).not.toContain('OWNED = "old"');
+    expect(updated.indexOf('[hooks.state]')).toBeLessThan(updated.indexOf('# >>> botmux mcp gateway'));
+    expect(ensureGatewayEntry(adapter).state).toBe('unchanged');
+
+    // Removal must also preserve a file that has not gone through repair yet.
+    writeFileSync(path, initial);
+    expect(removeGatewayEntry(adapter).state).toBe('removed');
+    const removed = readFileSync(path, 'utf8');
+    expect(removed).toContain(userTables);
+    expect(removed).not.toContain('mcp_servers.botmux');
+    expect(removed).not.toContain('botmux mcp gateway');
+    expect(removeGatewayEntry(adapter).state).toBe('absent');
+  });
+
   it('merges and removes only the owned Claude gateway entry', () => {
     const path = join(home, '.claude.json');
     writeFileSync(path, JSON.stringify({ mcpServers: { keep: { command: 'keep' } }, theme: 'dark' }));


### PR DESCRIPTION
## 背景

Codex CLI 审批 Hook 后，会将 `hooks.state` 写入用户级 TOML。实测新表可能插入 BotMux MCP Gateway 结束注释之前。旧逻辑更新 Gateway 时按注释起止位置删除整个块，误删信任记录，导致 `botmux start` 后原生 Codex 和 Bot 会话再次要求审批。

Closes #1375

## 改动

- 将 Gateway 标记清理改为仅过滤起止标记行，不删除标记之间的全部文本。
- 继续使用现有 `stripCodexBotmuxSections` 删除 BotMux 自己的 MCP 表和子表。
- 安装与移除路径共用这一修复。
- 新增 LF/CRLF 回归用例，覆盖两条 Hook 信任记录、用户 MCP、项目配置、旧 Gateway 子表清理，以及重复安装/移除的幂等性。

## 影响范围

- 仅改变 Codex TOML Gateway 标记处理；Claude JSON 路径不变，现有 Claude 回归用例通过。
- 不修改沙箱策略、Hook 审批机制、CLI 启动目录或用户凭据。
- PTY/Tmux、不同会话类型使用这条共享配置更新路径时均受益；没有修改后端特有逻辑。
- LF/CRLF 已覆盖；实际构建和部署平台为 Linux x64，未执行 macOS 运行验证。
- 本次不改写 legacy plugin block 清理器，也不宣称实现了完整 TOML 解析器。

## 实际验证

构建工具 Bun 1.4.2，依赖通过 `bun install --frozen-lockfile` 安装。

```sh
bun run test -- test/plugin-mcp-gateway-installer.test.ts test/plugin-manifest-store.test.ts test/plugin-mcp-sandbox.test.ts test/bypass-codex-hook-trust-config.test.ts
bun run build
BOTMUX_VERIFY_BAKED_VERSION=3.21.0-hooktrust.89eb378c bun run build:bun --target bun-linux-x64
node scripts/smoke-bun-binary.mjs dist-bin/botmux-linux-x64
git diff --check
```

- 相关测试：37 passed、3 skipped；3 项真实沙箱集成测试因宿主条件不满足而跳过。未执行全量测试。
- 完整构建、类型检查、构建资产审计通过。
- 二进制隔离 smoke 全部通过，包括 CLI 图加载、版本、配置资源、插件服务、supervisor、Dashboard HTTP/前端和二进制完整性。
- 实机部署：用构建产物替换本地单文件安装，并以安装路径执行 `botmux restart`；确认新安装的 SHA-256 与构建产物一致，daemon 和 Dashboard 均 online。
- 重启后 `hooks.state` 的原有信任哈希保留，且位于 Gateway 标记块外。此检查没有关闭 Hook 审批，也没有重新授予信任。
- 尚未声称验证了重启后所有飞书业务流程，或用户再次新开 Codex 的最终 UI 结果。

## 效果

当 Codex 在 Gateway 注释块中插入其他表时，下一次 Gateway 更新或移除不再把这些表一并删除。已丢失的信任记录不会凭空恢复，需要用户正常审批；仍存在的记录会被保留。
