### PR TITLE
fix(dashboard): trigger-user-auth IPC 落盘字符串导致所有 bot 启动崩溃循环

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -6819,9 +6819,13 @@ ipcRoute('PUT', '/api/bot-codex-auth-sync', async (req, res) => {
 });
 
 // PUT /api/bot-trigger-user-auth — 按触发人身份调用 CLI 的开关。Body
-// `{ triggerUserAuth: object | null }`：null / 空对象 → 清除（关闭）。
-// 与 /botconfig set 共用 applyConfigField，因此两个门的校验完全一致：拒绝原因
-// （比如「fallback 不能是 device」）原样透出，不在这里另写一套判断。
+// `{ triggerUserAuth: object | null }`：null / undefined → 清除（关闭）。
+// 与 /botconfig set 共用 coerceConfigValue + applyConfigField，因此两个门的校验
+// 完全一致：拒绝原因（比如「fallback 不能是 device」）原样透出，不在这里另写一套
+// 判断。applyConfigField 只接受「已解析」的值——跳过 coerce 直接喂字符串会把
+// stringified JSON / 空串原样写进 bots.json，daemon 下次启动在
+// parseTriggerUserAuthConfig 处 fatal（triggerUserAuth must be an object），
+// 所有 bot 进程崩溃循环（见 test/dashboard-ipc.test.ts 回归用例）。
 ipcRoute('PUT', '/api/bot-trigger-user-auth', async (req, res) => {
   if (!cachedLarkAppId) return jsonRes(res, 503, { error: 'larkAppId_not_set' });
   let body: { triggerUserAuth?: unknown };
@@ -6829,13 +6833,16 @@ ipcRoute('PUT', '/api/bot-trigger-user-auth', async (req, res) => {
   catch { return jsonRes(res, 400, { error: 'invalid_json' }); }
   const spec = findConfigField('triggerUserAuth');
   if (!spec) return jsonRes(res, 500, { ok: false, error: 'field_unavailable' });
-  // '' is the store's "clear" sentinel; anything else goes through the shared
-  // JSON coercion so a malformed policy is rejected the same way here as it is
-  // from chat.
-  const raw = body.triggerUserAuth === null || body.triggerUserAuth === undefined
-    ? ''
-    : JSON.stringify(body.triggerUserAuth);
-  const r = await applyConfigField(cachedLarkAppId, spec, raw);
+  // null/undefined → null（applyConfigField 的清除哨兵）；其余先 JSON.stringify
+  // 成文本，再走共享 coerceConfigValue 解析校验（kind: 'json'），与 /botconfig
+  // set、/api/bot-riff、/api/bot-env 同一条路。
+  let value: unknown = null;
+  if (body.triggerUserAuth !== null && body.triggerUserAuth !== undefined) {
+    const coerced = coerceConfigValue(spec, JSON.stringify(body.triggerUserAuth));
+    if (!coerced.ok) return jsonRes(res, 400, { ok: false, error: coerced.reason });
+    value = coerced.value;
+  }
+  const r = await applyConfigField(cachedLarkAppId, spec, value);
   if (!r.ok) return jsonRes(res, 400, r);
   jsonRes(res, 200, { ok: true });
 });

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -7034,6 +7034,97 @@ describe('PUT /api/bot-riff config safety (finding H)', () => {
   });
 });
 
+describe('PUT /api/bot-trigger-user-auth persisted shape', () => {
+  async function withTriggerUserAuthBot(
+    fn: (base: string, configPath: string) => Promise<void>,
+  ): Promise<void> {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-tua-ipc-'));
+    const configPath = join(dir, 'bots.json');
+    const appId = 'test-tua-cfg-app';
+    const prevBotsConfig = process.env.BOTS_CONFIG;
+    try {
+      process.env.BOTS_CONFIG = configPath;
+      writeFileSync(configPath, JSON.stringify([{
+        larkAppId: appId,
+        larkAppSecret: 'secret',
+        cliId: 'opencode',
+      }], null, 2));
+      loadBotConfigs().forEach((c: any) => registerBot(c));
+      setLarkAppId(appId);
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      await fn(`http://127.0.0.1:${handle.port}`, configPath);
+    } finally {
+      if (prevBotsConfig === undefined) delete process.env.BOTS_CONFIG;
+      else process.env.BOTS_CONFIG = prevBotsConfig;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('persists the policy as an object, not a stringified JSON scalar', async () => {
+    await withTriggerUserAuthBot(async (base, configPath) => {
+      const res = await fetch(`${base}/api/bot-trigger-user-auth`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          triggerUserAuth: { enabled: true, tools: ['lark-cli', 'bytedcli'], fallback: 'bot-identity' },
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true });
+
+      // 回归断言：applyConfigField 只接受「已解析」的值。这里若是字符串，daemon
+      // 下次启动会在 parseTriggerUserAuthConfig 处 fatal（must be an object），
+      // 所有 bot 进程进入崩溃循环——正是线上踩过的坑。
+      const stored = JSON.parse(readFileSync(configPath, 'utf8'))[0].triggerUserAuth;
+      expect(stored).toEqual({
+        enabled: true,
+        tools: ['lark-cli', 'bytedcli'],
+        fallback: 'bot-identity',
+      });
+    });
+  });
+
+  it('rejects an invalid policy with the shared parser reason and leaves disk untouched', async () => {
+    await withTriggerUserAuthBot(async (base, configPath) => {
+      const before = readFileSync(configPath, 'utf8');
+      const res = await fetch(`${base}/api/bot-trigger-user-auth`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          triggerUserAuth: { enabled: true, fallback: 'device' },
+        }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(String(body.error)).toContain('invalid_trigger_user_auth');
+      expect(readFileSync(configPath, 'utf8')).toBe(before);
+    });
+  });
+
+  it('null clears the key instead of persisting an empty string', async () => {
+    await withTriggerUserAuthBot(async (base, configPath) => {
+      const saved = await fetch(`${base}/api/bot-trigger-user-auth`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          triggerUserAuth: { enabled: true, tools: ['lark-cli'], fallback: 'bot-identity' },
+        }),
+      });
+      expect(saved.status).toBe(200);
+
+      const cleared = await fetch(`${base}/api/bot-trigger-user-auth`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ triggerUserAuth: null }),
+      });
+      expect(cleared.status).toBe(200);
+      const entry = JSON.parse(readFileSync(configPath, 'utf8'))[0];
+      expect('triggerUserAuth' in entry).toBe(false);
+    });
+  });
+});
+
 describe('PUT /api/bot-agent riff backend pairing', () => {
   it('reports a mismatch close that left a REMOTE session behind', async () => {
     // mojo / riff sessions live off-box: the local row can close while the remote


### PR DESCRIPTION
## 问题
Dashboard「按触发人身份调用 CLI」开关（PUT /api/bots/:id/trigger-user-auth → daemon IPC `PUT /api/bot-trigger-user-auth`）保存后，`bots.json` 里的 `triggerUserAuth` 变成**字符串标量**而非对象。daemon（重）启动时严格校验在 `parseTriggerUserAuthConfig` 处 fatal：

```
Fatal error: Error: Bot config [0]: triggerUserAuth must be an object (file: ~/.botmux/bots.json)
```

每个 bot 进程启动即崩，重启 10 次耗尽后卡在 errored。线上实测：通过 dashboard 配置该开关后，新加的 3 个 bot 全部崩溃循环起不来（本机 v3.21.0 复盘）。

## 根因
`src/core/dashboard-ipc-server.ts` 的该 IPC 路由把 `JSON.stringify(policy)` 得到的字符串直接传给 `applyConfigField`，而后者契约只接受「已解析」的值——`kind: 'json'` 原样落盘。路由注释声称“与 /botconfig set 共用校验”，但 `/botconfig set` 实际先走 `coerceConfigValue`，此路由跳过了这一步。附带两个次生问题：
- 非法 policy（如 `fallback: 'device'`）不被 400 拒绝，直接写盘（写完照样炸 daemon）
- 清除路径把 `null` 转成 `''` 原样写入空串，同样 fatal

## 修复
对齐 `/api/bot-riff`、`/api/bot-env` 的既有模式：非空值先 `coerceConfigValue` 共享解析校验（非法原因原样 400 透出），`null` 走 `applyConfigField` 清除哨兵删除 key。

## 测试
`test/dashboard-ipc.test.ts` 新增 3 个回归用例（在 master 上先复现失败，修复后通过）：
1. 落盘为对象而非字符串标量
2. 非法 policy 400 且磁盘不动
3. null 清除 key 而非写空串

相关测试面全绿（dashboard-ipc 254 用例 / bot-config-store / trigger-user-auth），`tsc --noEmit` 通过；全量 unit 套件其余失败经 stash 对照验证为 master 上预存的环境相关失败，与本次改动无关。