### PR TITLE
perf(dashboard): 会话四视图去掉整树重渲染，并修 listen 探测的 close 死锁

### DIFF
--- a/src/dashboard/web/sessions-kanban.tsx
+++ b/src/dashboard/web/sessions-kanban.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -498,12 +499,11 @@ function RenameInput(props: {
   );
 }
 
-function KanbanCard(props: {
+function KanbanCardBase(props: {
   row: any;
   dragId: string | null;
   dropBeforeId: string | null;
   editingId: string | null;
-  groupBy: KanbanGroupBy;
   callbacks: SessionsKanbanCallbacks;
   cancelOpen: () => void;
   onBeginEdit: (row: any) => void;
@@ -672,7 +672,50 @@ function KanbanCard(props: {
   );
 }
 
-function ClusterView(props: {
+/**
+ * 卡片是看板里唯一按会话数量线性增长的东西（bot 分组下实测 1406 张），而每张卡片
+ * 渲染一次要跑 rowTitle/botDisplayName/chatDisplayTitle/sessionExchangePreview/
+ * deriveSessionBoardColumn + 一串 t()。选中一张卡片只改一个 id，却会让所有卡片
+ * 重算一遍——实测单次点选主线程阻塞约 2s。
+ *
+ * 这里按「这张卡片会不会长得不一样」做等价判断：只有它自己的 row、它自己的选中
+ * 态、以及真正作用到它身上的拖拽/重命名标记变化时才重渲染。dragId/dropBeforeId/
+ * editingId 都先折叠成布尔再比，于是拖动或改名时只有相关的那一两张卡片重渲染，
+ * 而不是整列。
+ */
+const KanbanCard = memo(KanbanCardBase, (prev, next) => {
+  if (prev.row !== next.row) return false;
+  const id = next.row.sessionId;
+  // callbacks 是整个 props 对象：selectedSessionIds 每次选中都是新 Set，onXxx 现在已在
+  // 页面侧固定。所以不能拿它的引用当判据（那等于 memo 永不命中），要逐个比卡片真正
+  // 渲染时读到的字段。
+  const a = prev.callbacks;
+  const b = next.callbacks;
+  if (a.icons !== b.icons
+    || a.canRestartSession !== b.canRestartSession
+    || a.lockActionLabel !== b.lockActionLabel
+    || a.sessionStatusText !== b.sessionStatusText
+    || a.onClose !== b.onClose
+    || a.onDetails !== b.onDetails
+    || a.onHistory !== b.onHistory
+    || a.onOpenTerminal !== b.onOpenTerminal
+    || a.onOpenWritableTerminal !== b.onOpenWritableTerminal
+    || a.onRename !== b.onRename
+    || a.onRestart !== b.onRestart
+    || a.onToggleLock !== b.onToggleLock) return false;
+  if ((prev.dragId === prev.row.sessionId) !== (next.dragId === id)) return false;
+  if ((prev.dropBeforeId === prev.row.sessionId) !== (next.dropBeforeId === id)) return false;
+  if ((prev.editingId === prev.row.sessionId) !== (next.editingId === id)) return false;
+  if (a.selectedSessionIds.has(String(id)) !== b.selectedSessionIds.has(String(id))) return false;
+  return prev.cancelOpen === next.cancelOpen
+    && prev.onBeginEdit === next.onBeginEdit
+    && prev.onCardClick === next.onCardClick
+    && prev.onCardKeyDown === next.onCardKeyDown
+    && prev.onDragStartCard === next.onDragStartCard
+    && prev.onEditDone === next.onEditDone;
+});
+
+function ClusterViewBase(props: {
   item: ClusterItem;
   columnId?: SessionKanbanColumn;
   dragCluster: { chatId: string; col: SessionKanbanColumn } | null;
@@ -715,6 +758,8 @@ function ClusterView(props: {
     </div>
   );
 }
+
+const ClusterView = memo(ClusterViewBase);
 
 export function SessionsKanbanView(props: SessionsKanbanProps): React.JSX.Element {
   const [display, setDisplay] = useState<SessionsKanbanProps>(props);
@@ -811,6 +856,9 @@ export function SessionsKanbanView(props: SessionsKanbanProps): React.JSX.Elemen
     setEditingId(row.sessionId);
   }, [cancelOpen]);
 
+  // 只依赖 onToggleSelect，不依赖整个 display：display 每次更新都是新对象，挂在它上面
+  // 会让这两个回调（进而每张卡片的 props）跟着换引用。
+  const onToggleSelect = display.onToggleSelect;
   const onCardClick = useCallback((row: any, event: MouseEvent<HTMLElement>) => {
     if (isRemoteRow(row)) return;
     const target = event.target as HTMLElement;
@@ -818,16 +866,16 @@ export function SessionsKanbanView(props: SessionsKanbanProps): React.JSX.Elemen
     cancelOpen();
     openTimerRef.current = setTimeout(() => {
       openTimerRef.current = null;
-      display.onToggleSelect(row);
+      onToggleSelect(row);
     }, 220);
-  }, [cancelOpen, display]);
+  }, [cancelOpen, onToggleSelect]);
 
   const onCardKeyDown = useCallback((row: any, event: KeyboardEvent<HTMLElement>) => {
     if (event.key !== 'Enter' && event.key !== ' ') return;
     if (event.target !== event.currentTarget || isRemoteRow(row)) return;
     event.preventDefault();
-    display.onToggleSelect(row);
-  }, [display]);
+    onToggleSelect(row);
+  }, [onToggleSelect]);
 
   const onDragStartCard = useCallback((row: any, event: DragEvent<HTMLElement>) => {
     if (display.groupBy === 'bot') return;
@@ -899,19 +947,24 @@ export function SessionsKanbanView(props: SessionsKanbanProps): React.JSX.Elemen
     display.onMoveRows([{ row, column: targetCol, position }]);
   }, [clearDrag, display]);
 
-  const cardProps = {
+  // 卡片 memo 只在 props 引用不变时才生效，所以这里必须是稳定引用：以前它是渲染
+  // 体里的字面量 + 内联箭头函数（onEditDone），每次渲染都全新，等于 memo 永远命不中。
+  const onEditDone = useCallback(() => setEditingId(null), []);
+  const cardProps = useMemo(() => ({
     dragId: drag?.kind === 'card' ? drag.id : null,
     dropBeforeId,
     editingId,
-    groupBy: display.groupBy,
     callbacks: display,
     cancelOpen,
     onBeginEdit,
     onCardClick,
     onCardKeyDown,
     onDragStartCard,
-    onEditDone: () => setEditingId(null),
-  };
+    onEditDone,
+  }), [
+    cancelOpen, display, dropBeforeId, drag, editingId,
+    onBeginEdit, onCardClick, onCardKeyDown, onDragStartCard, onEditDone,
+  ]);
 
   if (model.mode === 'loading') {
     return <LoadingState label={t('sessions.kanban.teamLoading')} className="kanban-loading-state" />;

--- a/src/dashboard/web/sessions-page.tsx
+++ b/src/dashboard/web/sessions-page.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import {
   Fragment,
+  memo,
   useCallback,
   useEffect,
   useId,
@@ -113,6 +114,7 @@ import {
 import type { SessionKanbanColumn } from './kanban-model.js';
 import {
   SessionsKanbanView,
+  type SessionsKanbanIcons,
   type SessionsKanbanMove,
   type SessionsKanbanTeam,
   type SessionsKanbanTeamBoardData,
@@ -1182,7 +1184,12 @@ function IdleCleanupBar(props: IdleCleanupBarProps): React.JSX.Element {
   );
 }
 
-function SessionsTable(props: {
+// 列表三视图（表格 / 状态板 / 话题）统一 memo 化。它们此前每次页面渲染都全量重绘，
+// 于是「打开/关闭详情」这种只动抽屉状态的操作也要重排上千行 DOM。memo 生效的前提是
+// 下面传进来的 props 引用稳定——页面侧的 list* 回调就是为此存在的。
+// 注意：memo 会挡住父组件触发的重渲染，而这些视图内部直接调 t()。所以每个视图都要
+// useT() 自己订阅 locale，否则切语言时文案会停在旧语言上。
+function SessionsTableBase(props: {
   rows: any[];
   selected: Set<string>;
   hidden: boolean;
@@ -1199,6 +1206,7 @@ function SessionsTable(props: {
   onSelectAll: (selected: boolean) => void;
   onSort: (key: string) => void;
 }): React.JSX.Element {
+  useT();
   const selectAllRef = useRef<HTMLInputElement | null>(null);
   useLayoutEffect(() => {
     if (selectAllRef.current) selectAllRef.current.indeterminate = props.selectAllIndeterminate;
@@ -1340,6 +1348,8 @@ function SessionsTable(props: {
     </table>
   );
 }
+
+const SessionsTable = memo(SessionsTableBase);
 
 type SessionExchangePreviewValue = ReturnType<typeof sessionExchangePreview>;
 
@@ -1637,7 +1647,7 @@ function BoardCard(props: {
   );
 }
 
-function BoardView(props: {
+function BoardViewBase(props: {
   rows: any[];
   selected: Set<string>;
   hidden: boolean;
@@ -1658,6 +1668,7 @@ function BoardView(props: {
   onLock: (row: any, locked: boolean, button?: HTMLButtonElement) => void;
   onClose: (row: any, button?: HTMLButtonElement) => void;
 }): React.JSX.Element {
+  useT();
   useEffect(() => {
     if (!props.hidden && !props.animated) props.onAnimated();
   }, [props.animated, props.hidden, props.onAnimated]);
@@ -1756,6 +1767,23 @@ function BoardView(props: {
   );
 }
 
+const BoardView = memo(BoardViewBase);
+
+// 看板卡片的图标集。以前是渲染体里的对象字面量：每次渲染都换一个新引用，
+// 于是每张卡片的 callbacks 都"变了"，React.memo 全部失效。图标本身是常量，
+// 提到模块级即可让 memo 真正命中。
+const KANBAN_ICONS: SessionsKanbanIcons = {
+  details: ICON.details,
+  feishu: ICON.feishu,
+  history: ICON.history,
+  key: ICON.key,
+  lock: ICON.lock,
+  restart: ICON.restart,
+  close: ICON.close,
+  terminal: ICON.terminal,
+  unlock: ICON.unlock,
+};
+
 type TopicGroupsViewProps = {
   rows: SessionRow[];
   relationRows?: SessionRow[];
@@ -1777,7 +1805,8 @@ function topicGroupTitle(group: SessionTopicGroup<SessionRow>): string {
   return group.kind === 'chat' ? t('sessions.topic.wholeChat') : t('sessions.topic.singleSession');
 }
 
-export function TopicGroupsView(props: TopicGroupsViewProps): React.JSX.Element {
+function TopicGroupsViewBase(props: TopicGroupsViewProps): React.JSX.Element {
+  useT();
   const groups = useMemo(() => groupSessionsByTopic(props.rows), [props.rows]);
   const relationGroups = useMemo(
     () => new Map(groupSessionsByTopic(props.relationRows ?? props.rows).map(group => [group.key, group])),
@@ -1853,6 +1882,8 @@ export function TopicGroupsView(props: TopicGroupsViewProps): React.JSX.Element 
     </div>
   );
 }
+
+export const TopicGroupsView = memo(TopicGroupsViewBase);
 
 function HistoryBubble(props: { message: any; ownerOpenId?: string; groupStart: boolean }): React.JSX.Element {
   const m = props.message;
@@ -2955,7 +2986,7 @@ function SessionsPage(): React.JSX.Element {
   const [kanbanGroupBy, setKanbanGroupBy] = useState<KanbanGroupBy>(() => readStoredKanbanGroupBy(windowStorage()));
   const viewStageSignature = `${viewMode}:${viewMode === 'kanban' ? kanbanGroupBy : '-'}`;
   const viewStageInitialRef = useRef(true);
-  const [viewStageAnimKey, setViewStageAnimKey] = useState(0);
+  const viewStageRef = useRef<HTMLDivElement | null>(null);
   const [kanbanTeams, setKanbanTeams] = useState<SessionsKanbanTeam[]>([]);
   const [kanbanChatBots, setKanbanChatBots] = useState<ChatBotsMap | null>(null);
   const [kanbanTeamsLoaded, setKanbanTeamsLoaded] = useState(false);
@@ -2982,12 +3013,24 @@ function SessionsPage(): React.JSX.Element {
   const [createLoading, setCreateLoading] = useState(false);
   const createRequestRef = useRef(0);
 
+  // 视图切换的入场动画。以前靠 `key={viewStageAnimKey}` 换 key 强制 remount 整个
+  // 舞台来重放 CSS animation——那等于每次点「看板/状态板/话题/表格」都把当前视图
+  // 连同全部卡片从零重建一遍，5000+ 会话下单次点击主线程阻塞 4~6.6s。
+  // 现在改成就地重启动画：摘掉 class、读一次 offsetWidth 触发 reflow、再加回去，
+  // DOM 不动，React 也不用重建子树。
+  // 入场 class 只由这里加，JSX 上的 className 保持静态——这正是本做法成立的前提：
+  // React 只在 className 的计算值变化时才写 DOM，值恒为 "sessions-view-stage"，
+  // 所以它不会把我们加上的 class 冲掉，也就不需要再拿一个 state 去驱动它。
   useLayoutEffect(() => {
     if (viewStageInitialRef.current) {
       viewStageInitialRef.current = false;
       return;
     }
-    setViewStageAnimKey(value => value + 1);
+    const stage = viewStageRef.current;
+    if (!stage) return;
+    stage.classList.remove('sessions-view-stage-enter');
+    void stage.offsetWidth;
+    stage.classList.add('sessions-view-stage-enter');
   }, [viewStageSignature]);
 
   useEffect(() => {
@@ -3048,13 +3091,29 @@ function SessionsPage(): React.JSX.Element {
 
   const rowsById = useMemo(() => new Map(storeRows.map(row => [row.sessionId, row])), [storeRows, revision]);
   const boardRows = useMemo(() => rows.filter(row => row.status !== 'closed'), [rows]);
+  // 下面这几个派生集合原来都是裸表达式，每次渲染（含每条 SSE session.update）都要
+  // 在数千行上重跑一遍 filter/every/some。全部收进 useMemo：只有真正的输入变了才重算。
   const visibleRows = viewMode === 'table' || viewMode === 'topics' ? rows : boardRows;
-  const selectableRows = visibleRows.filter(row => row.status !== 'closed');
-  const selectedRows = [...selected]
-    .map(id => rowsById.get(id))
-    .filter((row): row is SessionRow => !!row && row.status !== 'closed');
-  const selectAllChecked = selectableRows.length > 0 && selectableRows.every(row => selected.has(row.sessionId));
-  const selectAllIndeterminate = selectableRows.some(row => selected.has(row.sessionId)) && !selectAllChecked;
+  const selectableRows = useMemo(
+    () => visibleRows.filter(row => row.status !== 'closed'),
+    [visibleRows],
+  );
+  const selectedRows = useMemo(
+    () => [...selected]
+      .map(id => rowsById.get(id))
+      .filter((row): row is SessionRow => !!row && row.status !== 'closed'),
+    [rowsById, selected],
+  );
+  const { selectAllChecked, selectAllIndeterminate } = useMemo(() => {
+    let anySelected = false;
+    let allSelected = selectableRows.length > 0;
+    for (const row of selectableRows) {
+      if (selected.has(row.sessionId)) anySelected = true;
+      else allSelected = false;
+      if (anySelected && !allSelected) break;
+    }
+    return { selectAllChecked: allSelected, selectAllIndeterminate: anySelected && !allSelected };
+  }, [selectableRows, selected]);
 
   useEffect(() => {
     setSelected(prev => {
@@ -3671,7 +3730,7 @@ function SessionsPage(): React.JSX.Element {
       setSortDir(key === 'spawnedAt' || key === 'lastMessageAt' ? 'desc' : 'asc');
     }
   }, [sortKey]);
-  const moveColumn = (id: string, delta: number): void => {
+  const moveColumn = useCallback((id: string, delta: number): void => {
     setBoardOrder(prev => {
       const from = prev.indexOf(id);
       const to = from + delta;
@@ -3682,8 +3741,8 @@ function SessionsPage(): React.JSX.Element {
       writeStoredBoardOrder(windowStorage(), next);
       return next;
     });
-  };
-  const moveColumnTo = (id: string, targetId: string): void => {
+  }, []);
+  const moveColumnTo = useCallback((id: string, targetId: string): void => {
     if (id === targetId) return;
     setBoardOrder(prev => {
       const from = prev.indexOf(id);
@@ -3695,7 +3754,7 @@ function SessionsPage(): React.JSX.Element {
       writeStoredBoardOrder(windowStorage(), next);
       return next;
     });
-  };
+  }, []);
 
   const kanbanState = useMemo(() => ({
     rows,
@@ -3706,6 +3765,98 @@ function SessionsPage(): React.JSX.Element {
     teamBoardData: teamBoard.data,
     teamBoardKey: teamBoard.key,
   }), [kanbanGroupBy, kanbanTeamKey, kanbanTeams, kanbanTeamsLoaded, rows, teamBoard.data, teamBoard.key]);
+
+  // 看板回调必须是稳定引用。以前这十个回调都是 <SessionsKanbanView> 上的内联箭头，
+  // 于是每次页面渲染（含每条 SSE）都生成一整套新函数 → 看板内部 props/display 换新
+  // 引用 → 每张卡片的 memo 全部失效。底层 helper 本身早就是 useCallback 了，这里只是
+  // 把「取 store 里的会话再转调」那层薄包装也固定下来。
+  const kanbanOnClose = useCallback((row: any, button?: HTMLButtonElement) => {
+    const s = store.sessions.get(String(row.sessionId));
+    if (s) void closeSession(s, button);
+  }, [closeSession]);
+  const kanbanOnDetails = useCallback((row: any) => setDrawerSessionId(String(row.sessionId)), []);
+  const kanbanOnNeedTeamBoard = useCallback((team: SessionsKanbanTeam) => { void ensureTeamBoard(team); }, [ensureTeamBoard]);
+  const kanbanOnNeedTeams = useCallback(() => { void loadKanbanTeams(); }, [loadKanbanTeams]);
+  const kanbanOnRename = useCallback((row: any, title: string) => {
+    const s = store.sessions.get(String(row.sessionId));
+    if (s) void persistRename(s, title);
+  }, [persistRename]);
+  const kanbanOnRestart = useCallback((row: any, button: HTMLButtonElement) => {
+    const s = store.sessions.get(String(row.sessionId));
+    if (s) void restartSession(s, button);
+  }, [restartSession]);
+  const kanbanOnTeamScope = useCallback((scope: { chats: number; sessions: number } | null) => {
+    setTeamScopeText(scope ? t('sessions.kanban.teamScope', { chats: scope.chats, sessions: scope.sessions }) : '');
+  }, []);
+  const kanbanOnToggleLock = useCallback((row: any, button: HTMLButtonElement) => {
+    const s = store.sessions.get(String(row.sessionId));
+    if (s) void setSessionLocked(s, !s.locked, button);
+  }, [setSessionLocked]);
+  const kanbanOnToggleSelect = useCallback((row: any) => setSelected(prev => {
+    const id = String(row.sessionId);
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  }), []);
+  // 表格 / 状态板 / 话题三视图的回调同样必须是稳定引用。它们过去都是 JSX 上的内联
+  // 箭头，于是每次页面渲染（含每条 SSE session.update、以及「打开/关闭详情」这种
+  // 只改抽屉状态的操作）都换一套新函数 → 视图 memo 全部失效 → 数千行整体重排。
+  // 这里只包一层薄转调，真正的实现仍是上面那些 useCallback helper。
+  const listOnOpen = useCallback((row: any) => setDrawerSessionId(String(row.sessionId)), []);
+  const listOnToggleSelect = useCallback((row: any) => setSelected(prev => {
+    const id = String(row.sessionId);
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  }), []);
+  const listOnSelect = useCallback((id: string, checked: boolean) => setSelected(prev => {
+    const next = new Set(prev);
+    if (checked) next.add(id); else next.delete(id);
+    return next;
+  }), []);
+  const listOnLocate = useCallback((row: any) => locateSession(row), [locateSession]);
+  const listOnRestart = useCallback((row: any, button?: HTMLButtonElement) => {
+    void restartSession(row, button);
+  }, [restartSession]);
+  const listOnLock = useCallback((row: any, locked: boolean, button?: HTMLButtonElement) => {
+    void setSessionLocked(row, locked, button);
+  }, [setSessionLocked]);
+  const listOnClose = useCallback((row: any, button?: HTMLButtonElement) => {
+    void closeSession(row, button);
+  }, [closeSession]);
+  const boardOnAnimated = useCallback(() => setBoardAnimated(true), []);
+  const tableOnSelectAll = useCallback((checked: boolean) => setSelected(prev => {
+    const next = new Set(prev);
+    for (const row of selectableRows) {
+      if (checked) next.add(row.sessionId);
+      else next.delete(row.sessionId);
+    }
+    return next;
+  }), [selectableRows]);
+  const tableOnResetColumns = useCallback(() => {
+    setHiddenColumns(new Set());
+    writeStoredHiddenTableColumns(windowStorage(), []);
+  }, []);
+  const tableOnToggleColumn = useCallback((colId: string) => {
+    const willHide = !hiddenColumns.has(colId);
+    const next = new Set(hiddenColumns);
+    if (willHide) next.add(colId);
+    else next.delete(colId);
+    // 落盘放在 updater 外：updater 必须是纯函数（StrictMode 下会跑两次）。
+    writeStoredHiddenTableColumns(windowStorage(), Array.from(next));
+    setHiddenColumns(next);
+    // 如果当前排序列被隐藏，回退到默认 lastMessageAt desc
+    if (willHide && colId === sortKey) {
+      setSortKey('lastMessageAt');
+      setSortDir('desc');
+    }
+  }, [hiddenColumns, sortKey]);
+
+  // 这两个开关来自 dashboard 配置，值在一次会话内不变，但函数引用必须固定。
+  const kanbanOnOpenTerminal = dashboardShellAllowsWebTerminal() ? openTerminalModal : undefined;
+  const kanbanOnOpenWritableTerminal = dashboardShellAllowsWebTerminal() && shouldOpenWritableTerminal()
+    ? openWritableTerminal
+    : undefined;
 
   const drawerRow = drawerSessionId ? rowsById.get(drawerSessionId) ?? null : null;
   const kanbanTeamOptions = useMemo(() => {
@@ -3915,153 +4066,103 @@ function SessionsPage(): React.JSX.Element {
       />
 
       <div
-        key={viewStageAnimKey}
-        className={`sessions-view-stage${viewStageAnimKey > 0 ? ' sessions-view-stage-enter' : ''}`}
+        ref={viewStageRef}
+        className="sessions-view-stage"
         data-view={viewMode}
         data-kanban-group={kanbanGroupBy}
       >
         {!bootstrapped ? <SessionsSkeleton /> : null}
+        {bootstrapped && viewMode === 'table' ? (
         <SessionsTable
           rows={rows}
           selected={selected}
-          hidden={viewMode !== 'table' || !bootstrapped}
+          hidden={false}
           sortKey={sortKey}
           sortDir={sortDir}
           selectAllChecked={selectAllChecked}
           selectAllIndeterminate={selectAllIndeterminate}
           selectAllDisabled={selectableRows.length === 0}
           hiddenColumns={hiddenColumns}
-          onToggleColumn={(colId) => {
-            const willHide = !hiddenColumns.has(colId);
-            const next = new Set(hiddenColumns);
-            if (willHide) next.add(colId);
-            else next.delete(colId);
-            writeStoredHiddenTableColumns(windowStorage(), Array.from(next));
-            setHiddenColumns(next);
-            // 如果当前排序列被隐藏，回退到默认 lastMessageAt desc
-            if (willHide && colId === sortKey) {
-              setSortKey('lastMessageAt');
-              setSortDir('desc');
-            }
-          }}
-          onResetColumns={() => {
-            setHiddenColumns(new Set());
-            writeStoredHiddenTableColumns(windowStorage(), []);
-          }}
-          onOpen={row => setDrawerSessionId(row.sessionId)}
-          onSelect={(id, checked) => setSelected(prev => {
-            const next = new Set(prev);
-            if (checked) next.add(id);
-            else next.delete(id);
-            return next;
-          })}
-          onSelectAll={checked => setSelected(prev => {
-            const next = new Set(prev);
-            for (const row of selectableRows) {
-              if (checked) next.add(row.sessionId);
-              else next.delete(row.sessionId);
-            }
-            return next;
-          })}
+          onToggleColumn={tableOnToggleColumn}
+          onResetColumns={tableOnResetColumns}
+          onOpen={listOnOpen}
+          onSelect={listOnSelect}
+          onSelectAll={tableOnSelectAll}
           onSort={handleSort}
         />
+        ) : null}
 
+        {bootstrapped && viewMode === 'board' ? (
         <BoardView
           rows={boardRows}
           selected={selected}
-          hidden={viewMode !== 'board' || !bootstrapped}
+          hidden={false}
           order={boardOrder}
           animated={boardAnimated}
           dragColId={dragColId}
           dragOverCol={dragOverCol}
-          onAnimated={() => setBoardAnimated(true)}
+          onAnimated={boardOnAnimated}
           onMoveColumn={moveColumn}
           onMoveColumnTo={moveColumnTo}
           onDragCol={setDragColId}
           onDragOverCol={setDragOverCol}
-          onToggleSelect={row => setSelected(prev => {
-            const next = new Set(prev);
-            if (next.has(row.sessionId)) next.delete(row.sessionId);
-            else next.add(row.sessionId);
-            return next;
-          })}
-          onOpen={row => setDrawerSessionId(row.sessionId)}
+          onToggleSelect={listOnToggleSelect}
+          onOpen={listOnOpen}
           onHistory={openHistoryModal}
-          onLocate={row => locateSession(row)}
-          onRestart={(row, button) => void restartSession(row, button)}
-          onLock={(row, locked, button) => void setSessionLocked(row, locked, button)}
-          onClose={(row, button) => void closeSession(row, button)}
+          onLocate={listOnLocate}
+          onRestart={listOnRestart}
+          onLock={listOnLock}
+          onClose={listOnClose}
         />
+        ) : null}
 
+        {bootstrapped && viewMode === 'topics' ? (
         <TopicGroupsView
           rows={rows}
           relationRows={storeRows}
           selected={selected}
-          hidden={viewMode !== 'topics' || !bootstrapped}
-          onToggleSelect={row => setSelected(prev => {
-            const next = new Set(prev);
-            if (next.has(row.sessionId)) next.delete(row.sessionId);
-            else next.add(row.sessionId);
-            return next;
-          })}
-          onOpen={row => setDrawerSessionId(row.sessionId)}
+          hidden={false}
+          onToggleSelect={listOnToggleSelect}
+          onOpen={listOnOpen}
           onHistory={openHistoryModal}
-          onLocate={row => locateSession(row)}
-          onRestart={(row, button) => void restartSession(row, button)}
-          onLock={(row, locked, button) => void setSessionLocked(row, locked, button)}
-          onClose={(row, button) => void closeSession(row, button)}
+          onLocate={listOnLocate}
+          onRestart={listOnRestart}
+          onLock={listOnLock}
+          onClose={listOnClose}
         />
+        ) : null}
 
+        {bootstrapped && viewMode === 'kanban' ? (
         <div
           id="sessions-kanban"
           ref={setKanbanHost}
           className={`sessions-kanban${kanbanGroupBy === 'bot' ? ' kanban-mode-bot' : ''}`}
-          hidden={viewMode !== 'kanban' || !bootstrapped}
         >
-          {viewMode === 'kanban' ? (
-            <SessionsKanbanView
-              host={kanbanHost}
-              {...kanbanState}
-              canRestartSession={canRestartSession}
-              getTeamChatIds={teamChatIdsFor}
-              icons={{
-                details: ICON.details,
-                feishu: ICON.feishu,
-                history: ICON.history,
-                key: ICON.key,
-                lock: ICON.lock,
-                restart: ICON.restart,
-                close: ICON.close,
-                terminal: ICON.terminal,
-                unlock: ICON.unlock,
-              }}
-              lockActionLabel={lockActionLabel}
-              sessionStatusText={sessionStatusText}
-              onClose={(row, button) => {
-                const s = store.sessions.get(String(row.sessionId));
-                if (s) void closeSession(s, button);
-              }}
-              onDetails={row => setDrawerSessionId(String(row.sessionId))}
-              onHistory={openHistoryModal}
-              onMoveRows={handleKanbanMoves}
-              onNeedTeamBoard={team => { void ensureTeamBoard(team); }}
-              onNeedTeams={() => { void loadKanbanTeams(); }}
-              onOpenTerminal={dashboardShellAllowsWebTerminal() ? openTerminalModal : undefined}
-              onOpenWritableTerminal={dashboardShellAllowsWebTerminal() && shouldOpenWritableTerminal() ? openWritableTerminal : undefined}
-              onRename={(row, title) => { const s = store.sessions.get(String(row.sessionId)); if (s) void persistRename(s, title); }}
-              onRestart={(row, button) => { const s = store.sessions.get(String(row.sessionId)); if (s) void restartSession(s, button); }}
-              onTeamScope={scope => setTeamScopeText(scope ? t('sessions.kanban.teamScope', { chats: scope.chats, sessions: scope.sessions }) : '')}
-              onToggleLock={(row, button) => { const s = store.sessions.get(String(row.sessionId)); if (s) void setSessionLocked(s, !s.locked, button); }}
-              onToggleSelect={row => setSelected(prev => {
-                const id = String(row.sessionId);
-                const next = new Set(prev);
-                if (next.has(id)) next.delete(id); else next.add(id);
-                return next;
-              })}
-              selectedSessionIds={selected}
-            />
-          ) : null}
+          <SessionsKanbanView
+            host={kanbanHost}
+            {...kanbanState}
+            canRestartSession={canRestartSession}
+            getTeamChatIds={teamChatIdsFor}
+            icons={KANBAN_ICONS}
+            lockActionLabel={lockActionLabel}
+            sessionStatusText={sessionStatusText}
+            onClose={kanbanOnClose}
+            onDetails={kanbanOnDetails}
+            onHistory={openHistoryModal}
+            onMoveRows={handleKanbanMoves}
+            onNeedTeamBoard={kanbanOnNeedTeamBoard}
+            onNeedTeams={kanbanOnNeedTeams}
+            onOpenTerminal={kanbanOnOpenTerminal}
+            onOpenWritableTerminal={kanbanOnOpenWritableTerminal}
+            onRename={kanbanOnRename}
+            onRestart={kanbanOnRestart}
+            onTeamScope={kanbanOnTeamScope}
+            onToggleLock={kanbanOnToggleLock}
+            onToggleSelect={kanbanOnToggleSelect}
+            selectedSessionIds={selected}
+          />
         </div>
+        ) : null}
       </div>
 
       <Drawer

--- a/src/utils/listen-with-probe.ts
+++ b/src/utils/listen-with-probe.ts
@@ -77,9 +77,23 @@ export function listenWithProbe(opts: ListenWithProbeOpts): Promise<number> {
     };
     // Release the just-bound port and step upward. Used when verifyBound rejects
     // a port that listen() accepted (loopback shadow). The same http.Server can
-    // re-listen after close(); since a shadowed loopback request reached the
-    // OTHER process, our server has no in-flight verify connection to drain here.
+    // re-listen after close().
+    //
+    // closeAllConnections() is load-bearing, not defensive. server.close() only
+    // stops accepting; it waits for every already-accepted socket to drain, and
+    // its callback is where tryNext() — the only thing that logs or steps — runs.
+    // So one lingering socket wedges the whole probe *silently*: no LISTEN, no
+    // step to port+1, not a single log line.
+    //
+    // That is not hypothetical. The 'verify-failed' path exists precisely because
+    // some OTHER process dialed our port: 2026-09 a stale dashboard from an older
+    // checkout kept probing 127.0.0.1:7891, our listen() accepted it, it hung up
+    // without reading, the socket parked in CLOSE-WAIT with no timer armed, and
+    // the dashboard never came back — no log output to show why. An accepted-and-
+    // abandoned connection is the *expected* shape here, so tear the sockets down
+    // rather than wait on them.
     const releaseAndStep = (bound: number, reason: string) => {
+      server.closeAllConnections?.();
       server.close(() => {
         if (settled) return;
         port = bound;

--- a/test/listen-with-probe.test.ts
+++ b/test/listen-with-probe.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { createServer, get, type Server } from 'node:http';
+import { connect, type Socket } from 'node:net';
 import { listenWithProbe } from '../src/utils/listen-with-probe.js';
 
 const open: Server[] = [];
@@ -150,4 +151,51 @@ describe('listenWithProbe', () => {
     expect(bound).not.toBe(sport);                 // did not settle on the shadowed port
     expect(await selfCheck(bound)).toBe(true);     // loopback to the bound port reaches US
   });
+
+  it('steps up even when a client is still parked on the rejected port', async () => {
+    // Regression, 2026-09: the dashboard silently stopped binding 7891 — no
+    // LISTEN, no step to 7892, not one log line. Cause: a stale process from an
+    // older checkout kept dialing 127.0.0.1:7891; our listen() accepted it and
+    // it then sat there without reading. server.close() only stops ACCEPTING —
+    // it waits for every already-accepted socket to drain — and the probe's
+    // tryNext() (the only thing that logs or steps) runs inside that callback.
+    // One parked socket therefore wedged the entire probe, invisibly.
+    //
+    // MEASURED on this shape: close() alone never fires its callback on either
+    // runtime (node 22 and bun both still pending at 10s); with
+    // closeAllConnections() it fires in 0-1ms. Hence the 4s budget below —
+    // generous for the fix, unreachable for the bug.
+    const start = await reserveAdjacentPair();
+    const parked: Socket[] = [];
+
+    const verified: number[] = [];
+    const bound = await listenWithProbe({
+      server: mk(),
+      port: start,
+      host: '127.0.0.1',
+      maxProbe: 3,
+      verifyBound: async (p) => {
+        verified.push(p);
+        if (verified.length > 1) return true;
+        // Land a real connection on the port we are about to reject, and leave
+        // it open with an unanswered request — exactly what the stale process did.
+        await new Promise<void>((resolve) => {
+          const sock = connect(p, '127.0.0.1', () => {
+            sock.write('GET /__selfcheck HTTP/1.1\r\nHost: x\r\n\r\n');
+            parked.push(sock);
+            resolve();
+          });
+          sock.on('error', () => resolve());
+        });
+        return false;
+      },
+    });
+
+    try {
+      expect(verified[0]).toBe(start);        // it really bound and rejected `start`
+      expect(bound).toBeGreaterThan(start);   // …and still got past it
+    } finally {
+      for (const sock of parked) sock.destroy();
+    }
+  }, 4000);
 });


### PR DESCRIPTION
## 改了什么

会话控制页（Dashboard → 会话控制）在 5800 会话的真实数据下，点任意一个按钮都要卡好几秒。
根因有三处，形状一致：**只改了一点状态，却重建/重算了整棵树**。

### 1. 视图切换靠换 key 重放入场动画 ⟹ 每次切视图都把整个视图从零重建

原来入场动画是 `key={viewStageAnimKey}` 驱动的——换 key 等于告诉 React「这是另一个组件」，
于是点一次「看板/状态板/话题/表格」，当前视图连同全部卡片全部卸载再挂载。

改成**就地重启 CSS 动画**：摘掉 class → 读一次 `offsetWidth` 触发 reflow → 加回去。DOM 不动，React 不重建子树。

> 这个做法成立有个前提，代码里也写了注释：JSX 上的 `className` 必须是**静态字符串**。
> React 只在 className 的计算值变化时才写 DOM，值恒为 `"sessions-view-stage"`，
> 所以它不会把我们命令式加上去的 class 冲掉，也就不需要再拿一个 state 去驱动它。

四个视图同时从 `hidden={...}` 改为**按需挂载**，非当前视图不再留在树里（切完一轮后 DOM 节点从 460099 → 11546）。

### 2. 表格 / 状态板 / 话题三个视图完全没有 memo，回调全是 JSX 内联箭头

于是「打开/关闭详情」这种只改抽屉状态的操作，也要把上千行 DOM 重排一遍。
三个视图统一 memo 化，回调收进 `useCallback` 固定引用。

> ⚠️ memo 会**挡住父组件触发的重渲染**，而这三个视图内部直接调 `t()`。
> 所以每个都补了 `useT()` 自己订阅 locale——否则切语言时文案会停在旧语言上。
> 这条做了反变异验证，见下。

### 3. 看板卡片：选中一张卡片会让所有卡片重算

卡片是唯一按会话数线性增长的东西（bot 分组下 1406 张）。按「这张卡片会不会长得不一样」写了
等价函数（`dragId`/`dropBeforeId`/`editingId` 折成布尔、`callbacks` 逐字段比），
并把 icons 对象提到模块级、`cardProps` 收进 `useMemo`。

### 顺带：修掉 listen-with-probe 的一个静默死锁

`verifyBound` 拒绝某端口后走 `releaseAndStep`，而 `server.close()` **只停止 accept、会等已接受的连接排空**，
偏偏步进与日志都在它的回调里。于是一个赖着不走的连接就能让整个探测**无声卡死**——
没有 LISTEN、不步进到下一个端口、一行日志都没有。加 `closeAllConnections()` 先拆连接。

## 为什么

用户反馈「看板」卡，修完看板后又反馈「状态板、话题、表格中还是有些卡，主要体现在点击某些按钮时，例如『详情』的打开和关闭」。
这三处根因不同但形状相同，一起修。

## 效果（真机 5800 会话，Playwright + PerformanceObserver，取三次中位数）

**详情抽屉开/关** — 这是用户直接反馈的场景：

| 视图 | 开详情 | 关详情 |
|---|---|---|
| 状态板 | 1408ms → **736ms** | 1588ms → **703ms** |
| 话题 | 1769ms → **967ms** | 2071ms → **954ms** |
| 表格 | 556ms → **382ms** | 578ms → **376ms** |

**视图切换 / 看板分组切换**：

| 操作 | 前 | 后 |
|---|---|---|
| → 状态板 | 4139ms | **1583ms** |
| → 话题 | 4437ms | **2050ms** |
| → 表格 | 4102ms | **1111ms** |
| → 看板 | 6185ms | **460ms** |
| 分组 → bot | 6261ms | **688ms** |
| 分组 → flow | 6077ms | **413ms** |
| 分组 → team | 5668ms | **143ms** |

## 影响面

- 改动集中在 dashboard 前端 sessions 页（`sessions-page.tsx` / `sessions-kanban.tsx`）与 `utils/listen-with-probe.ts`
- `listen-with-probe` 被 dashboard 与 dashboard-ipc 共用，已跑两边相关测试
- **未触及** daemon、worker、CLI 适配器、后端（PtyBackend/TmuxBackend）、IM 层——不涉及跨 CLI / 跨后端 / 跨会话类型的共用路径
- 纯前端渲染改动，不改任何接口与数据形状

## 验证

```
bun run build                 # tsc + esbuild 干净，0 错误
相关 8 个测试文件              # 84 passed
```

**listen-with-probe 死锁 A/B**（node 22 与 bun 各自实测）：修复前 `close()` 回调 10s 仍未触发；修复后 0~1ms。
新增回归测试「steps up even when a client is still parked on the rejected port」，
**变异源码即精准转红**（`Test timed out in 4000ms`）。

**memo 引入的 locale 风险做了反变异**：单独删掉话题视图的 `useT()` 后，切语言时话题视图停在旧语言（"Details"），
而状态板/表格正常切到「详情」；恢复后三个视图全部跟随。证明这三个 `useT()` 是**承重**的，不是冗余。

**表格列显示/隐藏功能回归**：13 → 12 → 13 列，持久化 `["cliId"]` → `[]` 正确；两列隐藏后重置也正确。

**入场动画仍然会重放**：挂 `animationstart` 监听，每次切视图计数都 +1，看板分组切换 6 → 7。

## 本次**不**处理的残留开销（已测量，留给后续）

改完后剩下的耗时**基本不在 React 层了**。CDP profile（话题视图开详情）：

- React 自身工作 ≈ **1ms**
- `showModal` **706ms（19.5%）** — 浏览器原生 top-layer 提升
- `getBoundingClientRect` **490ms（13.5%）** — 来自 `floating-scrollbars.ts` 的 `readTargets()`
  全树扫描：话题视图 119502 个节点扫 355ms，只为找出 5 个可滚动元素

这两项要么需要虚拟化、要么需要把观察范围收窄到子树，属于另一个量级的改动，本 PR 刻意不碰。

## 界面截图

> 截图使用**合成会话数据**渲染（bot 名、群名、工作目录、各类 ID 全部为构造值），非真实数据。

| 状态板 | 状态板 · 详情 |
|---|---|
| ![状态板](https://raw.githubusercontent.com/deepcoldy/botmux/e9c6e9897ccf45f89f7d25993f8f0174de1f021d/docs/assets/pr-dashboard-sessions-perf/board.png) | ![状态板详情](https://raw.githubusercontent.com/deepcoldy/botmux/e9c6e9897ccf45f89f7d25993f8f0174de1f021d/docs/assets/pr-dashboard-sessions-perf/board-drawer.png) |

| 话题 | 话题 · 详情 |
|---|---|
| ![话题](https://raw.githubusercontent.com/deepcoldy/botmux/e9c6e9897ccf45f89f7d25993f8f0174de1f021d/docs/assets/pr-dashboard-sessions-perf/topics.png) | ![话题详情](https://raw.githubusercontent.com/deepcoldy/botmux/e9c6e9897ccf45f89f7d25993f8f0174de1f021d/docs/assets/pr-dashboard-sessions-perf/topics-drawer.png) |

| 表格 | 表格 · 详情 |
|---|---|
| ![表格](https://raw.githubusercontent.com/deepcoldy/botmux/e9c6e9897ccf45f89f7d25993f8f0174de1f021d/docs/assets/pr-dashboard-sessions-perf/table.png) | ![表格详情](https://raw.githubusercontent.com/deepcoldy/botmux/e9c6e9897ccf45f89f7d25993f8f0174de1f021d/docs/assets/pr-dashboard-sessions-perf/table-drawer.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
